### PR TITLE
Don't free uninitialized local variables.

### DIFF
--- a/src/daemon/auth.c
+++ b/src/daemon/auth.c
@@ -159,19 +159,23 @@ auth_check_uid_role (GDBusMethodInvocation *invocation,
                      const gchar *role)
 {
   int err = 0;
+  gs_free struct passwd *pw = NULL;
+  gs_free struct group *wheel_gr = NULL;
+  gs_free struct group *role_gr = NULL;
+  gs_free gid_t *gids = NULL;
 
   if (uid == 0)
     return TRUE;
 
-  gs_free struct passwd *pw = getpwuid_a (uid, &err);
+  pw = getpwuid_a (uid, &err);
   if (pw == NULL)
     goto error;
 
-  gs_free struct group *wheel_gr = getgrnam_a ("wheel", NULL);
-  gs_free struct group *role_gr = role ? getgrnam_a (role, NULL) : NULL;
+  wheel_gr = getgrnam_a ("wheel", NULL);
+  role_gr = role ? getgrnam_a (role, NULL) : NULL;
 
   int n_groups;
-  gs_free gid_t *gids = getgrouplist_a (pw->pw_name, pw->pw_gid, &n_groups, &err);
+  gids = getgrouplist_a (pw->pw_name, pw->pw_gid, &n_groups, &err);
   if (gids == NULL)
     goto error;
 

--- a/src/daemon/manager.c
+++ b/src/daemon/manager.c
@@ -569,6 +569,8 @@ handle_set_avatar_data_url (CockpitManager *object,
                             const gchar *arg_data)
 {
   GError *error = NULL;
+  gsize raw_size;
+  gs_free gchar *raw_data = NULL;
 
   if (!auth_check_sender_role (invocation, COCKPIT_ROLE_ADMIN))
     return TRUE;
@@ -579,8 +581,7 @@ handle_set_avatar_data_url (CockpitManager *object,
 
   base64_data += strlen ("base64,");
 
-  gsize raw_size;
-  gs_free gchar *raw_data = (gchar *)g_base64_decode (base64_data, &raw_size);
+  raw_data = (gchar *)g_base64_decode (base64_data, &raw_size);
 
   const gchar *file = PACKAGE_SYSCONF_DIR "/cockpit/avatar.png";
   if (!g_file_set_contents (file, raw_data, raw_size, &error))

--- a/src/ws/dbus-server.c
+++ b/src/ws/dbus-server.c
@@ -692,7 +692,7 @@ dbus_call_cb (GDBusProxy *proxy,
   CallData *data = user_data;
   GVariant *result;
   GError *error;
-  gs_unref_object JsonBuilder *builder;
+  gs_unref_object JsonBuilder *builder = NULL;
 
   error = NULL;
   result = g_dbus_proxy_call_finish (proxy, res, &error);


### PR DESCRIPTION
Jumping over the declaration of a local variable that has a destructor
doesn't work since the variable will be uninitialized when the
destructor runs.
