### PR TITLE
ws: Write size as big-endian always

### DIFF
--- a/src/ws/dbus-server.c
+++ b/src/ws/dbus-server.c
@@ -338,7 +338,9 @@ write_builder (DBusServerData *data,
 {
   json_builder_end_object (builder);
   gs_free gchar *s = _json_builder_to_str (builder);
-  uint32_t size = strlen (s);
+  guint32 size = strlen (s);
+  /* See cockpitwebsocket.c:copy_from_session_to_browser() */
+  size = GUINT32_TO_BE (size);
   write_all (data->out, &size, sizeof(size));
   write_all (data->out, s, size);
 }


### PR DESCRIPTION
I was just re-reviewing this code, and while I didn't actually hit
this problem, the way we write the size as host endianness would break
having the mgmt node be x86_64 and a target be ppc.

The simple fix (and this is the same as ext{2,3,4} do) is always use
big endian.
