### PR TITLE
Tests: Include machine id in disk image name.

### DIFF
--- a/test/testvm.py
+++ b/test/testvm.py
@@ -614,7 +614,7 @@ class QemuMachine(Machine):
         if not serial:
             serial = "DISK%d" % index
 
-        path = os.path.join(self.run_dir, "disk-%d" % index)
+        path = os.path.join(self.run_dir, "disk-%s-%d" % (self.address, index))
         if os.path.exists(path):
             os.unlink(path)
 


### PR DESCRIPTION
So that we can run tests in parallel.
