### PR TITLE
Tests: Fix qemu process leaks.

### DIFF
--- a/test/check-multi-machine
+++ b/test/check-multi-machine
@@ -59,20 +59,18 @@ def machine_error_selector(machine):
 class TestMultiMachine(MachineCase):
     def setUp(self):
         MachineCase.setUp(self)
-        self.machine2 = self.machine_class()
+        self.machine2 = self.new_machine()
         self.machine2.start()
         self.machine2.wait_boot()
 
-        self.machine3 = self.machine_class()
+        self.machine3 = self.new_machine()
         self.machine3.start()
         self.machine3.wait_boot()
 
     def tearDown(self):
-        MachineCase.tearDown(self)
         self.check_journal_messages(self.machine2)
-        self.machine2.kill()
         self.check_journal_messages(self.machine3)
-        self.machine3.kill()
+        MachineCase.tearDown(self)
 
     def testBasic(self):
         b = self.browser

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -234,14 +234,18 @@ class MachineCase(unittest.TestCase):
     machine = None
     do_check_journal_messages = True
 
+    def new_machine(self):
+        m = self.machine_class(verbose=arg_trace)
+        def cleanup():
+            if m.address:
+                m.kill()
+        self.addCleanup(cleanup)
+        return m
+
     def setUp(self):
-        self.machine = self.machine_class(verbose=arg_trace)
+        self.machine = self.new_machine()
         self.machine.start()
-        try:
-            self.machine.wait_boot()
-        except:
-            self.machine.stop()
-            raise
+        self.machine.wait_boot()
         self.browser = Browser(address=self.machine.address)
 
     def tearDown(self):
@@ -251,10 +255,7 @@ class MachineCase(unittest.TestCase):
                 print >> sys.stderr, "ADDRESS: %s" % self.machine.address
                 sit()
         if self.machine.address and self.do_check_journal_messages:
-            try:
-                self.check_journal_messages()
-            finally:
-                self.machine.kill()
+            self.check_journal_messages()
 
     def start_cockpit(self):
         """Start Cockpit.


### PR DESCRIPTION
The machine.kill() call was erroneously only done when checking
journal messages.  Also, a qemu process might leak when the
multi-machine tearDown throws in the middle.

To fix this, we add a "new_machine" function that registers a cleanup
for the new machine.  The explicit kills can then be removed.
