### PR TITLE
FEDORA: Use the $basearch substitution in repo file

### DIFF
--- a/contrib/fedora/cockpit-deps.repo
+++ b/contrib/fedora/cockpit-deps.repo
@@ -1,5 +1,5 @@
 [cockpit-deps]
 name=Unreleased Cockpit dependencies
-baseurl=http://cockpit-project.github.io/cockpit-deps/fedora-$releasever/x86_64
+baseurl=http://cockpit-project.github.io/cockpit-deps/fedora-$releasever/$basearch
 enabled=0
 gpgcheck=0


### PR DESCRIPTION
This modifies the repo baseurl to use standard substitution
variables so it should work on all future versions and arches of
Fedora.
