### PR TITLE
SRPM: make sure submodules are initialized

### DIFF
--- a/test/make-srpm
+++ b/test/make-srpm
@@ -49,6 +49,14 @@ while [ $# -gt 0 ]; do
 	shift
 done
 
+# Fetch submodules if needed
+if test ! -f src/libgsystem/README;
+then
+  echo "+ Setting up submodules"
+  git submodule init
+  git submodule update
+fi
+
 git_archive_all=$(dirname "$0")/git-archive-all
 if [ ! -x "$git_archive_all" ]; then
   git_archive_all=git-archive-all


### PR DESCRIPTION
If we try to make an SRPM from a pristine checkout (as with
automation), it would be missing the necessary submodule to build
successfully. This patch just makes sure that the make-srpm tool
initializes the submodules.
