### PR TITLE
Websocket: Only send when the socket is open.

### DIFF
--- a/src/websocket/websocketconnection.c
+++ b/src/websocket/websocketconnection.c
@@ -1823,14 +1823,9 @@ web_socket_connection_send (WebSocketConnection *self,
   g_return_if_fail (WEB_SOCKET_IS_CONNECTION (self));
   g_return_if_fail (message != NULL);
 
-  if (!self->pv->handshake_done)
+  if (web_socket_connection_get_ready_state (self) != WEB_SOCKET_STATE_OPEN)
     {
-      g_critical ("Cannot send message before WebSocket is open");
-      return;
-    }
-  if (self->pv->close_sent)
-    {
-      g_critical ("Cannot send message after WebSocket close");
+      g_critical ("Can only send messages when WebSocket is open");
       return;
     }
 

--- a/src/ws/cockpitwebsocket.c
+++ b/src/ws/cockpitwebsocket.c
@@ -525,7 +525,8 @@ cockpit_web_socket_serve_dbus (CockpitWebServer *server,
           message = g_async_queue_try_pop (data->async_queue);
           if (message)
             {
-              web_socket_connection_send (data->web_socket, WEB_SOCKET_DATA_TEXT, message);
+              if (web_socket_connection_get_ready_state (data->web_socket) == WEB_SOCKET_STATE_OPEN)
+                web_socket_connection_send (data->web_socket, WEB_SOCKET_DATA_TEXT, message);
               g_bytes_unref (message);
             }
         }


### PR DESCRIPTION
Sending used to be allowed in state CLOSING, which could result in an
assertion failure during finalize.

Fixes #102.

We either need to make sending during CLOSING work, or refrain from doing it.  With the current state, cockpit-ws dumps core when we try to send during CLOSING.
