### PR TITLE
Wip/quiet close

### DIFF
--- a/src/websocket/websocketconnection.c
+++ b/src/websocket/websocketconnection.c
@@ -1080,7 +1080,15 @@ on_web_socket_input (GObject *pollable_stream,
       if (!pv->close_sent || !pv->close_received)
         {
           pv->dirty_close = TRUE;
-          g_message ("connection unexpectedly closed by peer");
+
+          /*
+           * Some versions of the hixie drafts don't have a close handshake,
+           * which is pretty wild. But what can you do. So don't raise a stink
+           * about it if we're talking hixie76
+           */
+
+          if (pv->flavor != WEB_SOCKET_FLAVOR_HIXIE76)
+            g_message ("connection unexpectedly closed by peer");
         }
       else
         {

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -293,9 +293,6 @@ class MachineCase(unittest.TestCase):
         # https://github.com/cockpit-project/cockpit/issues/48
         "Failed to load '.*': Key file does not have group 'Unit'",
 
-        # https://github.com/cockpit-project/cockpit/issues/114
-        "connection unexpectedly closed by peer",
-
         # https://github.com/cockpit-project/cockpit/issues/115
         "cockpit-testing\\.service: main process exited, code=exited, status=1/FAILURE",
         "Unit cockpit-testing\\.service entered failed state\\."


### PR DESCRIPTION
This should fix #114. Adds tests as well. Another commit fixes a related incorrect use of gssize vs. gsize in test.
