### PR TITLE
test-webservice: Null terminate GString correctly

### DIFF
--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -86,6 +86,7 @@ read_all_into_string (int fd)
       else
         {
           input->len = len + ret;
+          input->str[input->len] = '\0';
         }
     }
 }


### PR DESCRIPTION
Bug in previous work, limited to tests. Causes valgrind error.
