### PR TITLE
VERIFY: Check for existence of some tools before doing work

### DIFF
--- a/VERIFY
+++ b/VERIFY
@@ -10,6 +10,19 @@ silent()
   return $?
 }
 
+# Prerequisites 
+require_binary() {
+  bin=$1
+  if ! which "$bin" >/dev/null 2>/dev/null; then
+    echo 1>&2 "Missing tool /usr/bin/$bin"
+    exit 1
+  fi
+}
+require_binary parallel
+require_binary js
+require_binary trickle
+
+# Start
 cd test
 
 if ! silent $IFCONFIG cockpit0; then


### PR DESCRIPTION
Since our VERIFY dependencies are separate from the RPM build
dependencies, let's maintain a list here.  Tthis duplicates the
README, but it's actually checked.
