### PR TITLE
Ws: No timeout for D-Bus calls.

### DIFF
--- a/src/ws/dbus-server.c
+++ b/src/ws/dbus-server.c
@@ -867,7 +867,7 @@ handle_dbus_call (DBusServerData *data,
                      method_name,
                      g_variant_builder_end (&arg_builder),
                      G_DBUS_CALL_FLAGS_NO_AUTO_START,
-                     -1, /* timeout */
+                     G_MAXINT, /* timeout */
                      data->cancellable,
                      (GAsyncReadyCallback)dbus_call_cb,
                      call_data); /* user_data*/


### PR DESCRIPTION
Some methods, such as com.redhat.Cockpit.Realms.Join, need longer
timeouts, and timeouts are bad anyway.  We let the user make the
decision when to cancel (or reload the browser).
