### PR TITLE
daemon: Use stock accountsservice without patches

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,11 +89,6 @@ old_LIBS=$LIBS
 CFLAGS=$COCKPIT_DAEMON_CFLAGS
 LIBS=$COCKPIT_DAEMON_LIBS
 
-AC_CHECK_FUNC(act_user_get_groups, [], AC_MSG_ERROR([
-The accountsservice package needs a patch.  See
-
-    https://bugs.freedesktop.org/attachment.cgi?id=81059&action=edit]))
-
 AC_CHECK_FUNC(udisks_volume_group_get_name, [], AC_MSG_ERROR([
 The udisks2 package needs a patch.  See
 


### PR DESCRIPTION
This is part of an effort to be buildable using standard dependencies.
Since no git or released version of accountsservice has groups support
at this time, don't depend on patches.

Reimplement the groups stuff in cockpitd.
