### PR TITLE
cockpithandlers: Be defensive if PrettyHostname is not set

### DIFF
--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -323,10 +323,12 @@ cockpit_handler_cockpitdyn (CockpitWebServer *server,
   if (error == NULL)
     {
       g_variant_get (retval, "(@a{sv})", &props);
-      if (g_variant_lookup (props, "StaticHostname", "&s", &s))
-        g_string_append_printf (str, "cockpitdyn_hostname = \"%s\";\n", s);
-      if (g_variant_lookup (props, "PrettyHostname", "&s", &s))
-        g_string_append_printf (str, "cockpitdyn_pretty_hostname = \"%s\";\n", s);
+      if (!g_variant_lookup (props, "StaticHostname", "&s", &s))
+	s = "";
+      g_string_append_printf (str, "cockpitdyn_hostname = \"%s\";\n", s);
+      if (!g_variant_lookup (props, "PrettyHostname", "&s", &s))
+	s = "";
+      g_string_append_printf (str, "cockpitdyn_pretty_hostname = \"%s\";\n", s);
     }
   else
     {


### PR DESCRIPTION
The JS code will crash if the variables aren't defined; let's emit the
empty string in this case.

The real bug was that I had SELinux enforcing but with no policy for
Cockpit, so cockpitd couldn't talk to systemd-hostnamed.  But let's
still submit this defensive patch.
