### PR TITLE
test-webservice: Avoid leaking mock-sshd processes

### DIFF
--- a/src/ws/mock-sshd.c
+++ b/src/ws/mock-sshd.c
@@ -475,6 +475,11 @@ main (int argc,
     { NULL }
   };
 
+#ifdef __linux
+#include <sys/prctl.h>
+  prctl (PR_SET_PDEATHSIG, 15);
+#endif
+
   ssh_init ();
 
   context = g_option_context_new ("- mock ssh server");

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -108,7 +108,7 @@ setup_mock_sshd (Test *test,
       NULL
   };
 
-  g_spawn_async_with_pipes (BUILDDIR, (gchar **)argv, NULL, 0, NULL, NULL,
+  g_spawn_async_with_pipes (BUILDDIR, (gchar **)argv, NULL, G_SPAWN_DO_NOT_REAP_CHILD, NULL, NULL,
                             &test->mock_sshd, NULL, &out_fd, NULL, &error);
   g_assert_no_error (error);
 


### PR DESCRIPTION
With Linux PR_SET_PDEATHSIG, if the test program dies, that will
automatically terminate the child.  To make this work, we also need to
tell GLib not to double-fork, so it remains our child and not pid 1's.
