### PR TITLE
test: Increase timeouts on tests that regularly fall over

### DIFF
--- a/test/check-realms
+++ b/test/check-realms
@@ -46,14 +46,16 @@ class TestRealms(MachineCase):
         b.click("#realms-join-item")
         b.wait_popup("realms-op")
         b.wait_visible("#realms-op-form")
-        b.wait_val("#realms-op-address", "cockpit.lan")
-        b.wait_val("#realms-op-admin", "admin")
-        b.set_val("#realms-op-admin-password", "foobarfoo")
-        b.click("#realms-op-apply")
-        b.wait_popdown("realms-op")
 
-        # Check that this has worked
-        wait_number_domains(1)
+	with b.wait_timeout(120):
+	        b.wait_val("#realms-op-address", "cockpit.lan")
+	        b.wait_val("#realms-op-admin", "admin")
+	        b.set_val("#realms-op-admin-password", "foobarfoo")
+	        b.click("#realms-op-apply")
+	        b.wait_popdown("realms-op")
+
+	        # Check that this has worked
+	        wait_number_domains(1)
 
         # Leave the domain
         b.click("#realms-leave-0")

--- a/test/check-storage
+++ b/test/check-storage
@@ -454,8 +454,10 @@ class TestStorage(MachineCase):
         b.wait_popup("raid-actions-menu")
         b.click('#raid-actions-menu button[data-op="delete"]')
         b.wait_popdown("raid-actions-menu")
-        b.wait_page("storage")
-        b.wait_not_in_text ("#storage_raids", "ARR")
+
+	with b.wait_timeout(120):
+	        b.wait_page("storage")
+	       	b.wait_not_in_text ("#storage_raids", "ARR")
 
     def testJobs(self):
         m = self.machine


### PR DESCRIPTION
These tests regularly fall over for me. Lets increase reliability. It's a shame they're so slow :S
