### PR TITLE
test: Honor COCKPIT_DEPS_BASEURL if set

### DIFF
--- a/test/cockpit.setup
+++ b/test/cockpit.setup
@@ -15,9 +15,12 @@ echo 'SELINUX=disabled' > /etc/selinux/config
 
 rm -rf /etc/sysconfig/iptables
 
+COCKPIT_DEPS_BASEURL=${COCKPIT_DEPS_BASEURL:=http://cockpit-project.github.io/cockpit-deps}
+COCKPIT_DEPS_URL=${COCKPIT_DEPS_BASEURL}/$TEST_OS/$TEST_ARCH
+
 echo "[cockpit-deps]
 name=Unreleased Cockpit dependencies
-baseurl=http://cockpit-project.github.io/cockpit-deps/$TEST_OS/$TEST_ARCH
+baseurl=${COCKPIT_DEPS_URL}
 enabled=1
 gpgcheck=0" > /etc/yum.repos.d/cockpit-deps.repo
 

--- a/test/make-rpms
+++ b/test/make-rpms
@@ -75,6 +75,8 @@ EXTRA_FLAGS=${EXTRA_FLAGS:-}
 srpm=$("$make_srpm" "$@")
 rm -rf mock
 
+COCKPIT_DEPS_BASEURL=${COCKPIT_DEPS_BASEURL:=http://cockpit-project.github.io/cockpit-deps}
+
 # Create our custom config by adding the cockpit-deps repo
 mkdir mock
 cp --preserve=timestamps /etc/mock/site-defaults.cfg mock/
@@ -85,7 +87,7 @@ config_opts['root'] = "$os-$arch-cockpit"
 config_opts['yum.conf'] += """
 [cockpit-deps]
 name=Unreleased Cockpit dependencies
-baseurl=http://cockpit-project.github.io/cockpit-deps/$os/$arch
+baseurl=${COCKPIT_DEPS_BASEURL}/$os/$arch
 enabled=1
 gpgcheck=0
 """


### PR DESCRIPTION
This allows testing changes to the cockpit-deps repository locally, by
setting the above variable to point to local builds.
