### PR TITLE
Don't link to libgsystem, just use the headers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,9 +55,6 @@ include tools/Makefile-tools.am
 
 libgsystem_srcpath := src/libgsystem
 libgsystem_cflags := -Isrc/libgsystem $(GIO_CFLAGS)
-libgsystem_libs := $(GIO_LIBS)
-include src/libgsystem/Makefile-libgsystem.am
-noinst_LTLIBRARIES += libgsystem.la
 
 include src/ws/Makefile-ws.am
 include src/daemon/Makefile-daemon.am

--- a/src/daemon/Makefile-daemon.am
+++ b/src/daemon/Makefile-daemon.am
@@ -102,7 +102,6 @@ cockpitd_CFLAGS = 					\
 cockpitd_LDADD = 					\
 	$(COCKPIT_DAEMON_LIBS)				\
 	liblvmdbus.la 					\
-	libgsystem.la					\
 	libcockpit-1.0.la				\
 	-lm 						\
 	$(NULL)

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -28,7 +28,6 @@ libcockpit_ws_la_CFLAGS = \
 libcockpit_ws_la_LIBADD =					\
 	$(COCKPIT_WS_LIBS)					\
         libcockpit-1.0.la					\
-	libgsystem.la		\
 	libwebsocket.la		\
 	$(NULL)
 
@@ -70,7 +69,6 @@ cockpit_ws_CFLAGS = 					\
 
 cockpit_ws_LDADD = 					\
 	$(COCKPIT_WS_LIBS)					\
-	libgsystem.la					\
         libcockpit-ws.la     				\
 	$(NULL)
 
@@ -104,7 +102,6 @@ cockpit_agent_CFLAGS = 					\
 
 cockpit_agent_LDADD = 					\
 	$(COCKPIT_AGENT_LIBS)				\
-	libgsystem.la					\
 	$(NULL)
 
 # ----------------------------------------------------------------------------------------------------
@@ -179,7 +176,6 @@ test_agent_CFLAGS = 					\
 
 test_agent_LDADD = 					\
 	$(COCKPIT_AGENT_LIBS)				\
-	libgsystem.la					\
 	$(NULL)
 
 CHECK_PROGS = \


### PR DESCRIPTION
This is necessary to get through packaging blockages in Fedora.
