### PR TITLE
Add prefixes to header guards

### DIFF
--- a/src/daemon/account.h
+++ b/src/daemon/account.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __ACCOUNT_H__
-#define __ACCOUNT_H__
+#ifndef COCKPIT_ACCOUNT_H__
+#define COCKPIT_ACCOUNT_H__
 
 #include <act/act.h>
 
@@ -39,4 +39,4 @@ void               account_update            (Account *acc,
 
 G_END_DECLS
 
-#endif /* __ACCOUNTS_H__ */
+#endif /* COCKPIT_ACCOUNT_H__ */

--- a/src/daemon/accounts.h
+++ b/src/daemon/accounts.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __ACCOUNTS_H__
-#define __ACCOUNTS_H__
+#ifndef COCKPIT_ACCOUNTS_H__
+#define COCKPIT_ACCOUNTS_H__
 
 #include "types.h"
 
@@ -34,4 +34,4 @@ CockpitAccounts * accounts_new               (void);
 
 G_END_DECLS
 
-#endif /* __ACCOUNTS_H__ */
+#endif /* COCKPIT_ACCOUNTS_H__ */

--- a/src/daemon/auth.h
+++ b/src/daemon/auth.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __AUTH_H__
-#define __AUTH_H__
+#ifndef COCKPIT_AUTH_H__
+#define COCKPIT_AUTH_H__
 
 #include "types.h"
 
@@ -39,4 +39,4 @@ gboolean auth_check_sender_role  (GDBusMethodInvocation *invocation,
 
 G_END_DECLS
 
-#endif /* __DAEMON_H__ */
+#endif /* COCKPIT_AUTH_H__ */

--- a/src/daemon/cpumonitor.h
+++ b/src/daemon/cpumonitor.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __CPU_MONITOR_H__
-#define __CPU_MONITOR_H__
+#ifndef COCKPIT_CPU_MONITOR_H__
+#define COCKPIT_CPU_MONITOR_H__
 
 #include "types.h"
 
@@ -36,4 +36,4 @@ Daemon *                  cpu_monitor_get_daemon  (CpuMonitor *monitor);
 
 G_END_DECLS
 
-#endif /* __CPU_MONITOR_H__ */
+#endif /* COCKPIT_CPU_MONITOR_H__ */

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __DAEMON_H__
-#define __DAEMON_H__
+#ifndef COCKPIT_DAEMON_H__
+#define COCKPIT_DAEMON_H__
 
 #include "types.h"
 
@@ -49,4 +49,4 @@ Machines                  *daemon_get_machines         (Daemon *daemon);
 
 G_END_DECLS
 
-#endif /* __DAEMON_H__ */
+#endif /* COCKPIT_DAEMON_H__ */

--- a/src/daemon/diskiomonitor.h
+++ b/src/daemon/diskiomonitor.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __DISK_IO_MONITOR_H__
-#define __DISK_IO_MONITOR_H__
+#ifndef COCKPIT_DISK_IO_MONITOR_H__
+#define COCKPIT_DISK_IO_MONITOR_H__
 
 #include "types.h"
 
@@ -36,4 +36,4 @@ Daemon *                  disk_io_monitor_get_daemon (DiskIOMonitor *monitor);
 
 G_END_DECLS
 
-#endif /* __DISK_IO_MONITOR_H__ */
+#endif /* COCKPIT_DISK_IO_MONITOR_H__ */

--- a/src/daemon/journal.h
+++ b/src/daemon/journal.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __JOURNAL_H__
-#define __JOURNAL_H__
+#ifndef COCKPIT_JOURNAL_H__
+#define COCKPIT_JOURNAL_H__
 
 #include "types.h"
 
@@ -34,4 +34,4 @@ CockpitJournal *  journal_new         (void);
 
 G_END_DECLS
 
-#endif /* __JOURNAL_H__ */
+#endif /* COCKPIT_JOURNAL_H__ */

--- a/src/daemon/lvmutil.h
+++ b/src/daemon/lvmutil.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __LVM_UTIL_H__
-#define __LVM_UTIL_H__
+#ifndef COCKPIT_LVM_UTIL_H__
+#define COCKPIT_LVM_UTIL_H__
 
 #include "types.h"
 
@@ -36,4 +36,4 @@ UDisksBlock *lvm_util_peek_block_for_logical_volume (GDBusObjectManager *objman,
 
 G_END_DECLS
 
-#endif /* __STORAGE_BLOCK_H__ */
+#endif /* COCKPIT_LVM_UTIL_H__ */

--- a/src/daemon/machine.h
+++ b/src/daemon/machine.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __MACHINE_H__
-#define __MACHINE_H__
+#ifndef COCKPIT_MACHINE_H__
+#define COCKPIT_MACHINE_H__
 
 #include "types.h"
 
@@ -41,4 +41,4 @@ void              machine_unexport    (Machine *machine);
 
 G_END_DECLS
 
-#endif /* __MACHINE_H__ */
+#endif /* COCKPIT_MACHINE_H__ */

--- a/src/daemon/machines.h
+++ b/src/daemon/machines.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __MACHINES_H__
-#define __MACHINES_H__
+#ifndef COCKPIT_MACHINES_H__
+#define COCKPIT_MACHINES_H__
 
 #include "types.h"
 
@@ -38,4 +38,4 @@ gboolean          machines_write       (Machines *machines, GError **error);
 
 G_END_DECLS
 
-#endif /* __MACHINES_H__ */
+#endif /* COCKPIT_MACHINES_H__ */

--- a/src/daemon/manager.h
+++ b/src/daemon/manager.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __MANAGER_H__
-#define __MANAGER_H__
+#ifndef COCKPIT_MANAGER_H__
+#define COCKPIT_MANAGER_H__
 
 #include "types.h"
 
@@ -36,4 +36,4 @@ Daemon *          manager_get_daemon  (Manager *manager);
 
 G_END_DECLS
 
-#endif /* __MANAGER_H__ */
+#endif /* COCKPIT_MANAGER_H__ */

--- a/src/daemon/memorymonitor.h
+++ b/src/daemon/memorymonitor.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __MEMORY_MONITOR_H__
-#define __MEMORY_MONITOR_H__
+#ifndef COCKPIT_MEMORY_MONITOR_H__
+#define COCKPIT_MEMORY_MONITOR_H__
 
 #include "types.h"
 
@@ -36,4 +36,4 @@ Daemon *                  memory_monitor_get_daemon (MemoryMonitor *monitor);
 
 G_END_DECLS
 
-#endif /* __MEMORY_MONITOR_H__ */
+#endif /* COCKPIT_MEMORY_MONITOR_H__ */

--- a/src/daemon/netinterface.h
+++ b/src/daemon/netinterface.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __NETINTERFACE_H__
-#define __NETINTERFACE_H__
+#ifndef COCKPIT_NETINTERFACE_H__
+#define COCKPIT_NETINTERFACE_H__
 
 #include "types.h"
 
@@ -37,4 +37,4 @@ Network *                     netinterface_get_network (Netinterface *network);
 
 G_END_DECLS
 
-#endif /* __NETINTERFACE_H__ */
+#endif /* COCKPIT_NETINTERFACE_H__ */

--- a/src/daemon/network.h
+++ b/src/daemon/network.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __NETWORK_H__
-#define __NETWORK_H__
+#ifndef COCKPIT_NETWORK_H__
+#define COCKPIT_NETWORK_H__
 
 #include "types.h"
 
@@ -36,4 +36,4 @@ Daemon *          network_get_daemon  (Network *network);
 
 G_END_DECLS
 
-#endif /* __NETWORK_H__ */
+#endif /* COCKPIT_NETWORK_H__ */

--- a/src/daemon/networkmonitor.h
+++ b/src/daemon/networkmonitor.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __NETWORK_MONITOR_H__
-#define __NETWORK_MONITOR_H__
+#ifndef COCKPIT_NETWORK_MONITOR_H__
+#define COCKPIT_NETWORK_MONITOR_H__
 
 #include "types.h"
 
@@ -36,4 +36,4 @@ Daemon *                  network_monitor_get_daemon (NetworkMonitor *monitor);
 
 G_END_DECLS
 
-#endif /* __NETWORK_MONITOR_H__ */
+#endif /* COCKPIT_NETWORK_MONITOR_H__ */

--- a/src/daemon/realms.h
+++ b/src/daemon/realms.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __REALMS_H__
-#define __REALMS_H__
+#ifndef COCKPIT_REALMS_H__
+#define COCKPIT_REALMS_H__
 
 #include "types.h"
 
@@ -36,4 +36,4 @@ Daemon *         realms_get_daemon        (Realms *realms);
 
 G_END_DECLS
 
-#endif /* __REALMS_H__ */
+#endif /* COCKPIT_REALMS_H__ */

--- a/src/daemon/services.h
+++ b/src/daemon/services.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __SERVICES_H__
-#define __SERVICES_H__
+#ifndef COCKPIT_SERVICES_H__
+#define COCKPIT_SERVICES_H__
 
 #include "types.h"
 
@@ -36,4 +36,4 @@ Daemon *           services_get_daemon        (Services *realms);
 
 G_END_DECLS
 
-#endif /* __SERVICES_H__ */
+#endif /* COCKPIT_SERVICES_H__ */

--- a/src/daemon/storageblock.h
+++ b/src/daemon/storageblock.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __STORAGE_BLOCK_H__
-#define __STORAGE_BLOCK_H__
+#ifndef COCKPIT_STORAGE_BLOCK_H__
+#define COCKPIT_STORAGE_BLOCK_H__
 
 #include "types.h"
 
@@ -36,4 +36,4 @@ void                   storage_block_update      (StorageBlock *block);
 
 G_END_DECLS
 
-#endif /* __STORAGE_BLOCK_H__ */
+#endif /* COCKPIT_STORAGE_BLOCK_H__ */

--- a/src/daemon/storagedrive.h
+++ b/src/daemon/storagedrive.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __STORAGE_DRIVE_H__
-#define __STORAGE_DRIVE_H__
+#ifndef COCKPIT_STORAGE_DRIVE_H__
+#define COCKPIT_STORAGE_DRIVE_H__
 
 #include "types.h"
 
@@ -36,4 +36,4 @@ void                   storage_drive_update      (StorageDrive *drive);
 
 G_END_DECLS
 
-#endif /* __STORAGE_DRIVE_H__ */
+#endif /* COCKPIT_STORAGE_DRIVE_H__ */

--- a/src/daemon/storagejob.h
+++ b/src/daemon/storagejob.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __STORAGE_JOB_H__
-#define __STORAGE_JOB_H__
+#ifndef COCKPIT_STORAGE_JOB_H__
+#define COCKPIT_STORAGE_JOB_H__
 
 #include "types.h"
 
@@ -35,4 +35,4 @@ CockpitJob *    storage_job_new         (StorageProvider *provider,
 
 G_END_DECLS
 
-#endif /* __JOB_H__ */
+#endif /* COCKPIT_STORAGE_JOB_H__ */

--- a/src/daemon/storagelogicalvolume.h
+++ b/src/daemon/storagelogicalvolume.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __STORAGE_LOGICAL_VOLUME_H__
-#define __STORAGE_LOGICAL_VOLUME_H__
+#ifndef COCKPIT_STORAGE_LOGICAL_VOLUME_H__
+#define COCKPIT_STORAGE_LOGICAL_VOLUME_H__
 
 #include "types.h"
 
@@ -36,4 +36,4 @@ void                           storage_logical_volume_update    (StorageLogicalV
 
 G_END_DECLS
 
-#endif /* __STORAGE_LOGICAL_VOLUME_H__ */
+#endif /* COCKPIT_STORAGE_LOGICAL_VOLUME_H__ */

--- a/src/daemon/storagemanager.h
+++ b/src/daemon/storagemanager.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __STORAGE_MANAGER_H__
-#define __STORAGE_MANAGER_H__
+#ifndef COCKPIT_STORAGE_MANAGER_H__
+#define COCKPIT_STORAGE_MANAGER_H__
 
 #include "types.h"
 
@@ -84,4 +84,4 @@ void       storage_remember_block_configs   (StorageProvider *provider,
 
 G_END_DECLS
 
-#endif /* __STORAGE_MANAGER_H__ */
+#endif /* COCKPIT_STORAGE_MANAGER_H__ */

--- a/src/daemon/storagemdraid.h
+++ b/src/daemon/storagemdraid.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __STORAGE_MDRAID_H__
-#define __STORAGE_MDRAID_H__
+#ifndef COCKPIT_STORAGE_MDRAID_H__
+#define COCKPIT_STORAGE_MDRAID_H__
 
 #include "types.h"
 
@@ -36,4 +36,4 @@ void                    storage_mdraid_update      (StorageMDRaid  *mdraid);
 
 G_END_DECLS
 
-#endif /* __STORAGE_MDRAID_H__ */
+#endif /* COCKPIT_STORAGE_MDRAID_H__ */

--- a/src/daemon/storageobject.h
+++ b/src/daemon/storageobject.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __STORAGE_OBJECT_H__
-#define __STORAGE_OBJECT_H__
+#ifndef COCKPIT_STORAGE_OBJECT_H__
+#define COCKPIT_STORAGE_OBJECT_H__
 
 #include "types.h"
 
@@ -55,4 +55,4 @@ gchar *                storage_object_make_object_path          (StorageObject *
 
 G_END_DECLS
 
-#endif /* __STORAGE_OBJECT_H__ */
+#endif /* COCKPIT_STORAGE_OBJECT_H__ */

--- a/src/daemon/storageprovider.h
+++ b/src/daemon/storageprovider.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __STORAGE_PROVIDER_H__
-#define __STORAGE_PROVIDER_H__
+#ifndef COCKPIT_STORAGE_PROVIDER_H__
+#define COCKPIT_STORAGE_PROVIDER_H__
 
 #include "types.h"
 
@@ -69,4 +69,4 @@ GList *           storage_provider_get_and_forget_remembered_configs (StoragePro
 
 G_END_DECLS
 
-#endif /* __STORAGE_PROVIDER_H__ */
+#endif /* COCKPIT_STORAGE_PROVIDER_H__ */

--- a/src/daemon/storagevolumegroup.h
+++ b/src/daemon/storagevolumegroup.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __STORAGE_VOLUME_GROUP_H__
-#define __STORAGE_VOLUME_GROUP_H__
+#ifndef COCKPIT_STORAGE_VOLUME_GROUP_H__
+#define COCKPIT_STORAGE_VOLUME_GROUP_H__
 
 #include "types.h"
 
@@ -36,4 +36,4 @@ void                         storage_volume_group_update      (StorageVolumeGrou
 
 G_END_DECLS
 
-#endif /* __STORAGE_VOLUME_GROUP_H__ */
+#endif /* COCKPIT_STORAGE_VOLUME_GROUP_H__ */

--- a/src/daemon/types.h
+++ b/src/daemon/types.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __TYPES_H__
-#define __TYPES_H__
+#ifndef COCKPIT_TYPES_H__
+#define COCKPIT_TYPES_H__
 
 #include <glib-unix.h>
 #include <gio/gio.h>
@@ -101,4 +101,4 @@ typedef struct _Accounts Accounts;
 struct _Account;
 typedef struct _Account Account;
 
-#endif /* __TYPES_H__ */
+#endif /* COCKPIT_TYPES_H__ */

--- a/src/daemon/utils.h
+++ b/src/daemon/utils.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __UTILS_H__
-#define __UTILS_H__
+#ifndef COCKPIT_UTILS_H__
+#define COCKPIT_UTILS_H__
 
 #include "types.h"
 
@@ -29,4 +29,4 @@ gchar *    utils_generate_object_path     (const gchar  *base,
 
 G_END_DECLS
 
-#endif /* __UTILS_H__ */
+#endif /* COCKPIT_UTILS_H__ */

--- a/src/ws/dbus-server.h
+++ b/src/ws/dbus-server.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __DBUS_SERVER_H__
-#define __DBUS_SERVER_H__
+#ifndef COCKPIT_DBUS_SERVER_H__
+#define COCKPIT_DBUS_SERVER_H__
 
 void      dbus_server_serve_dbus       (const char *user,
                                         const char *dbus_service,


### PR DESCRIPTION
Certain header guards used defines like `__TYPE_H__` which are likely
to be shared by other projects or the standard library. Add a
`COCKPIT_` prefix to them.

Closes: #201
