### PR TITLE
configure.ac: We don't need gobject introspection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,8 +54,6 @@ fi
 
 GTK_DOC_CHECK([1.3])
 
-GOBJECT_INTROSPECTION_CHECK([0.6.2])
-
 GIO_REQUIREMENT="gio-unix-2.0 >= 2.34"
 SYSTEMD_REQUIREMENT="libsystemd-journal >= 187 libsystemd-daemon"
 JSON_GLIB_REQUIREMENT="json-glib-1.0 >= 0.14.0"
@@ -216,7 +214,6 @@ echo "
         datadir:                    ${datadir}
         sysconfdir:                 ${sysconfdir}
         localstatedir:              ${localstatedir}
-        introspection:              ${found_introspection}
         systemdsystemunitdir:       ${systemdsystemunitdir}
 
         compiler:                   ${CC}

--- a/test/cockpit.spec.in
+++ b/test/cockpit.spec.in
@@ -27,7 +27,6 @@ Source0:	@TARBALLS_ARE_STUPID@
 BuildRequires: pkgconfig(gio-unix-2.0)
 BuildRequires: pkgconfig(gudev-1.0)
 BuildRequires: pkgconfig(json-glib-1.0)
-BuildRequires: pkgconfig(gobject-introspection-1.0)
 BuildRequires: pkgconfig(udisks2) >= 2.1.0
 BuildRequires: pkgconfig(libnm-glib)
 BuildRequires: pkgconfig(libsystemd-daemon)


### PR DESCRIPTION
We don't need gobject introspection in cockpit. Everything builds and functions fine without it.

Fixes #214
