### PR TITLE
PAM: Simplify to be distribution neutral.

### DIFF
--- a/data/cockpit
+++ b/data/cockpit
@@ -1,15 +1,7 @@
 #%PAM-1.0
-auth	   required	pam_sepermit.so
-auth       substack     password-auth
-auth       include      postlogin
-account    required     pam_nologin.so
-account    include      password-auth
-password   include      password-auth
-# pam_selinux.so close should be the first session rule
-session    required     pam_selinux.so close
-session    required     pam_loginuid.so
-# pam_selinux.so open should only be followed by sessions to be executed in the user context
-session    required     pam_selinux.so open env_params
-session    optional     pam_keyinit.so force revoke
-session    include      password-auth
-session    include      postlogin
+auth        required      pam_unix.so
+
+account     required      pam_unix.so
+
+-session     optional      pam_systemd.so
+session     required      pam_unix.so


### PR DESCRIPTION
The old content was highly Fedora specific.  Distributions need to
adapt this anyway, and it is better to start from something simple.
