### PR TITLE
Build: Keep test assets separate.

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -62,10 +62,6 @@ Then you can build the sources and install them, as usual:
 This will install Cockpit and all support files, and will install a
 simplistic PAM configuration.
 
-Currently, it will also install some files that are only useful during
-testing.  Their presence on the system might be a security risk, just
-like the simplistic PAM configuration.
-
 Cockpit has a single non-recursive Makefile.  You can only run "make"
 from the top-level and it will always rebuild the whole project.
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,6 +10,7 @@ noinst_LTLIBRARIES =
 privlibdir = $(pkglibdir)
 privlib_LTLIBRARIES =
 noinst_LIBRARIES=
+noinst_DATA =
 TESTS =
 
 ACLOCAL_AMFLAGS = -I tools ${ACLOCAL_FLAGS}
@@ -47,6 +48,21 @@ cockpit_cppflags_glib_version = \
 
 LOG_DRIVER = $(top_srcdir)/tools/tap-driver
 LOG_COMPILER = $(top_srcdir)/tools/tap-compiler
+
+testassetsdir = $(datadir)/cockpit-test-assets
+testassets_programs =
+testassets_data =
+testassets_systemdunit_data =
+
+install-test-assets: $(testassets_programs) $(testassets_data) $(testassets_systemdunit_data)
+	$(MKDIR_P) $(DESTDIR)$(testassetsdir)
+	$(MKDIR_P) $(DESTDIR)$(systemdunitdir)
+	for p in $(testassets_programs); do \
+          $(INSTALL_PROGRAM_ENV) $(LIBTOOL) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=install \
+            $(INSTALL_PROGRAM) $$p $(DESTDIR)$(testassetsdir); \
+        done
+	for d in $(testassets_data); do $(INSTALL_DATA) $$d $(DESTDIR)$(testassetsdir); done
+	for d in $(testassets_systemdunit_data); do $(INSTALL_DATA) $$d $(DESTDIR)$(systemdunitdir); done
 
 include doc/man/Makefile-man.am
 include data/Makefile-data.am

--- a/data/Makefile-data.am
+++ b/data/Makefile-data.am
@@ -12,8 +12,9 @@ com.redhat.Cockpit.conf: data/com.redhat.Cockpit.conf.in Makefile
 
 if HAVE_SYSTEMD
 systemdunitdir          = $(systemdsystemunitdir)
-dist_systemdunit_DATA   = data/cockpit-ws.socket data/cockpit-ws-testing.socket data/test-server.socket
+dist_systemdunit_DATA   = data/cockpit-ws.socket
 nodist_systemdunit_DATA =
+testassets_systemdunit_data += data/cockpit-ws-testing.socket data/test-server.socket
 
 cockpit.service : data/cockpit.service.in Makefile
 	@sed -e "s|\@libexecdir\@|$(libexecdir)|;s|\@datadir\@|$(datadir)|" $< > $@
@@ -21,7 +22,8 @@ nodist_systemdunit_DATA += cockpit.service
 
 cockpit-testing.service : data/cockpit-testing.service.in Makefile
 	@sed -e "s|\@libexecdir\@|$(libexecdir)|;s|\@datadir\@|$(datadir)|" $< > $@
-nodist_systemdunit_DATA += cockpit-testing.service
+noinst_DATA += cockpit-testing.service
+testassets_systemdunit_data += cockpit-testing.service
 
 cockpit-ws.service : data/cockpit-ws.service.in Makefile
 	@sed -e "s|\@libexecdir\@|$(libexecdir)|;s|\@datadir\@|$(datadir)|" $< > $@
@@ -29,11 +31,13 @@ nodist_systemdunit_DATA += cockpit-ws.service
 
 cockpit-ws-testing.service : data/cockpit-ws-testing.service.in Makefile
 	@sed -e "s|\@libexecdir\@|$(libexecdir)|;s|\@datadir\@|$(datadir)|" $< > $@
-nodist_systemdunit_DATA += cockpit-ws-testing.service
+noinst_DATA += cockpit-ws-testing.service
+testassets_systemdunit_data += cockpit-ws-testing.service
 
 test-server.service : data/test-server.service.in Makefile
 	@sed -e "s|\@libexecdir\@|$(libexecdir)|;s|\@datadir\@|$(datadir)|" $< > $@
-nodist_systemdunit_DATA += test-server.service
+noinst_DATA += test-server.service
+testassets_systemdunit_data += test-server.service
 
 endif
 EXTRA_DIST += 						\

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -113,8 +113,6 @@ cockpit_agent_LDADD = 					\
 
 # ----------------------------------------------------------------------------------------------------
 
-testassetsdir = $(datadir)/cockpit-test-assets
-
 $(test_server_built_sources) : Makefile.am $(top_srcdir)/src/ws/com.redhat.Cockpit.DBusTests.xml
 	gdbus-codegen							                \
 		--interface-prefix com.redhat.Cockpit.DBusTests                 	\
@@ -130,15 +128,16 @@ test_server_built_sources =								\
 
 BUILT_SOURCES += $(test_server_built_sources)
 
-testassets_PROGRAMS = test-server test-agent
+noinst_PROGRAMS += test-server test-agent
 
-testassets_DATA = dbus-test.html	\
-		  dbus.js  \
-		  dbus-test.js \
-		  jquery.min.js \
-		  qunit.css 	\
-		  qunit.js \
-		  $(NULL)
+testassets_programs += test-server test-agent
+testassets_data += dbus-test.html	\
+		   dbus.js  \
+		   dbus-test.js \
+		   jquery.min.js \
+		   qunit.css 	\
+		   qunit.js \
+		   $(NULL)
 
 # Place these into builddir so we can run tests against them
 dbus-test.js: src/ws/dbus-test.js

--- a/test/cockpit.spec.in
+++ b/test/cockpit.spec.in
@@ -78,7 +78,7 @@ make %{?_smp_mflags} %{?extra_flags}
 make check
 
 %install
-make install DESTDIR=%{buildroot}
+make install install-test-assets DESTDIR=%{buildroot}
 find %{buildroot} -name '*.la' -delete
 rm -f %{buildroot}/%{_libdir}/cockpit/*.so
 mkdir -p %{buildroot}/etc/pam.d/


### PR DESCRIPTION
Don't build or install them by default.

Fixes #226.
