### PR TITLE
Fix 'make distcheck' again

### DIFF
--- a/src/web/Makefile-web.am
+++ b/src/web/Makefile-web.am
@@ -147,6 +147,7 @@ contentdatalibfonts_DATA = 					\
 # -----------------------------------------------------------------------------
 
 CHECK_DEPS = \
+	dbus.js \
 	cockpit-journal-renderer.js \
 	$(NULL)
 

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -57,6 +57,10 @@ EXTRA_DIST += \
 	src/ws/mock_rsa_key \
 	src/ws/mock_dsa_key
 
+CLEANFILES += \
+	cockpitwsenumtypes.h \
+	$(NULL)
+
 # ----------------------------------------------------------------------------------------------------
 
 libexec_PROGRAMS += cockpit-ws cockpit-session cockpit-agent


### PR DESCRIPTION
- dbus.js is required by tests
- Cleanup cockpitwsenumtypes.h properly
