### PR TITLE
ws: Drain the GMainContext when stopping the MockService

### DIFF
--- a/src/ws/mock-service.c
+++ b/src/ws/mock-service.c
@@ -480,6 +480,7 @@ mock_service_thread (gpointer unused)
   g_object_unref (exported);
   g_object_unref (conn);
 
+  while (g_main_context_iteration (main_ctx, FALSE));
   g_main_context_pop_thread_default (main_ctx);
   g_main_context_unref (main_ctx);
 


### PR DESCRIPTION
Otherwise references are held by outstanding sounces in the
GMainContext. If a GDBusConnection is leaked then g_test_dbus_down()
will hang for 30 seconds and fail waiting for it to go away.
