### PR TITLE
Tests: Wait for disks to be free before using them for LVM.

### DIFF
--- a/test/check-storage
+++ b/test/check-storage
@@ -41,6 +41,10 @@ class TestStorage(MachineCase):
         self.browser.wait_dbus_prop("com.redhat.Cockpit.Storage.Block", "Drive", drive)
         return id
 
+    def get_block_object(self, serial):
+        drive = self.browser.wait_dbus_prop("com.redhat.Cockpit.Storage.Drive", "Serial", serial)
+        return self.browser.wait_dbus_prop("com.redhat.Cockpit.Storage.Block", "Drive", drive)
+
     def content_action_btn(self, index):
         return "#storage_detail_partition_list li:nth-child(%d) .btn-group" % index
 
@@ -535,6 +539,15 @@ class TestStorage(MachineCase):
         b.go("storage")
         m.execute("vgremove -f TEST1")
         b.wait_not_in_text("#storage_vgs", "TEST1")
+
+        # wait for the disks to be free
+        def wait_free(serial):
+            block = self.get_block_object(serial)
+            b.wait_dbus_object_prop (block, "com.redhat.Cockpit.Storage.Block", "PvGroup", "/")
+
+        wait_free("DISK1")
+        wait_free("DISK2")
+        wait_free("DISK3")
 
         # create volume group in the UI
         b.click('#storage_create_volume_group')

--- a/test/phantom-lib.js
+++ b/test/phantom-lib.js
@@ -93,3 +93,11 @@ function ph_dbus_prop (iface, prop, text)
     }
     return false;
 }
+
+function ph_dbus_object_prop (path, iface, prop, text)
+{
+    // check whether the given property has the given value
+
+    var proxy = cockpit_dbus_client.lookup(path, iface);
+    return proxy && proxy[prop] == text;
+}

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -202,6 +202,9 @@ class Browser:
     def wait_dbus_prop(self, iface, prop, text):
         return self.wait_js_func('ph_dbus_prop', iface, prop, text)
 
+    def wait_dbus_object_prop(self, path, iface, prop, text):
+        return self.wait_js_func('ph_dbus_object_prop', path, iface, prop, text)
+
     def wait_popup(self, id):
         """Wait for a popup to open.
 


### PR DESCRIPTION
There was a race between check-storage and storaged where we would try
to use a disk for a new volume group before storaged has noticed that
it is no longer used for the old volume group. In that case, that disk
would not be offered in the dialog, and the test would fail.
