### PR TITLE
agent: Add CockpitTextStream with 'text-stream' payload type

### DIFF
--- a/src/agent/Makefile-agent.am
+++ b/src/agent/Makefile-agent.am
@@ -6,6 +6,8 @@ libcockpit_agent_a_SOURCES = \
 	src/agent/cockpitchannel.h \
 	src/agent/cockpitdbusjson.c \
 	src/agent/cockpitdbusjson.h \
+	src/agent/cockpittextstream.c \
+	src/agent/cockpittextstream.h \
 	$(NULL)
 
 libcockpit_agent_a_CFLAGS = \
@@ -51,6 +53,7 @@ test_agent_LDADD = $(libcockpit_agent_LIBS)
 AGENT_CHECKS = \
 	test-channel \
 	test-dbusjson \
+	test-textstream \
 	$(NULL)
 
 test_channel_SOURCES = src/agent/test-channel.c
@@ -64,5 +67,11 @@ test_dbusjson_SOURCES =  \
 test_dbusjson_CFLAGS = $(libcockpit_agent_a_CFLAGS)
 test_dbusjson_LDADD = $(libcockpit_agent_LIBS)
 
+test_textstream_SOURCES = src/agent/test-textstream.c
+test_textstream_CFLAGS = $(libcockpit_agent_a_CFLAGS)
+test_textstream_LDADD = $(libcockpit_agent_LIBS)
+
+noinst_PROGRAMS += $(AGENT_CHECKS)
+TESTS += $(AGENT_CHECKS)
 noinst_PROGRAMS += $(AGENT_CHECKS)
 TESTS += $(AGENT_CHECKS)

--- a/src/agent/cockpittextstream.c
+++ b/src/agent/cockpittextstream.c
@@ -1,0 +1,289 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpittextstream.h"
+
+#include "cockpit/cockpitpipe.h"
+
+#include <gio/gunixsocketaddress.h>
+
+/**
+ * CockpitTextStream:
+ *
+ * A #CockpitChannel that sends messages from a regular socket
+ * or file descriptor. Any data is read in whatever chunks it
+ * shows up in read().
+ *
+ * Only UTF8 text data may be transmitted.
+ *
+ * The payload type for this channel is 'text-stream'.
+ */
+
+#define COCKPIT_TEXT_STREAM(o)    (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_TEXT_STREAM, CockpitTextStream))
+
+typedef struct {
+  CockpitChannel parent;
+  CockpitPipe *pipe;
+  GSocket *sock;
+  const gchar *name;
+  gboolean open;
+  gboolean closing;
+  guint sig_read;
+  guint sig_closed;
+} CockpitTextStream;
+
+typedef struct {
+  CockpitChannelClass parent_class;
+} CockpitTextStreamClass;
+
+G_DEFINE_TYPE (CockpitTextStream, cockpit_text_stream, COCKPIT_TYPE_CHANNEL);
+
+static void
+cockpit_text_stream_recv (CockpitChannel *channel,
+                          GBytes *message)
+{
+  CockpitTextStream *self = COCKPIT_TEXT_STREAM (channel);
+  gconstpointer data;
+  gsize len;
+
+  data = g_bytes_get_data (message, &len);
+  if (g_utf8_validate (data, len, NULL))
+    {
+      cockpit_pipe_write (self->pipe, message);
+    }
+  else
+    {
+      g_warning ("received non-textual data from web");
+      if (self->open)
+        cockpit_pipe_close (self->pipe, "protocol-error");
+    }
+
+}
+
+static void
+cockpit_text_stream_close (CockpitChannel *channel,
+                           const gchar *problem)
+{
+  CockpitTextStream *self = COCKPIT_TEXT_STREAM (channel);
+
+  self->closing = TRUE;
+
+  /*
+   * If closed, call base class handler directly. Otherwise ask
+   * our pipe to close first, which will come back here.
+  */
+  if (self->open)
+    cockpit_pipe_close (self->pipe, problem);
+  else
+    COCKPIT_CHANNEL_CLASS (cockpit_text_stream_parent_class)->close (channel, problem);
+}
+
+static void
+on_pipe_read (CockpitPipe *pipe,
+              GByteArray *data,
+              gboolean end_of_data,
+              gpointer user_data)
+{
+  CockpitTextStream *self = user_data;
+  CockpitChannel *channel = user_data;
+  GBytes *message;
+
+  if (data->len || !end_of_data)
+    {
+      if (g_utf8_validate ((gchar *)data->data, data->len, NULL))
+        {
+          /* When array is reffed, this just clears byte array */
+          g_byte_array_ref (data);
+          message = g_byte_array_free_to_bytes (data);
+          cockpit_channel_send (channel, message);
+          g_bytes_unref (message);
+        } else {
+            g_warning ("received non-textual data from socket");
+            if (self->open)
+              cockpit_pipe_close (pipe, "protocol-error");
+        }
+    }
+
+  /* Close the pipe when writing is done */
+  if (end_of_data && self->open)
+    {
+      g_debug ("%s: end of data, closing pipe", self->name);
+      cockpit_pipe_close (pipe, NULL);
+    }
+}
+
+static void
+on_pipe_closed (CockpitPipe *buffer,
+                const gchar *problem,
+                gpointer user_data)
+{
+  CockpitTextStream *self = user_data;
+  CockpitChannel *channel = user_data;
+  self->open = FALSE;
+  cockpit_channel_close (channel, problem);
+}
+
+static void
+cockpit_text_stream_init (CockpitTextStream *self)
+{
+
+}
+
+static gboolean
+connect_in_idle (gpointer user_data)
+{
+  CockpitTextStream *self = COCKPIT_TEXT_STREAM (user_data);
+  CockpitChannel *channel = COCKPIT_CHANNEL (self);
+  GSocketAddress *address;
+  const gchar *unix_path;
+  GError *error = NULL;
+  gint fd;
+
+  if (self->closing)
+    return FALSE;
+
+  unix_path = cockpit_channel_get_option (channel, "unix");
+  if (unix_path == NULL)
+    {
+      g_warning ("did not receive a unix option");
+      cockpit_channel_close (channel, "protocol-error");
+      return FALSE;
+    }
+
+  self->name = unix_path;
+  address = g_unix_socket_address_new (unix_path);
+  self->sock = g_socket_new (G_SOCKET_FAMILY_UNIX, G_SOCKET_TYPE_STREAM,
+                             G_SOCKET_PROTOCOL_DEFAULT, &error);
+  if (self->sock)
+    {
+      /* TODO: This needs to be non-blocking */
+      if (g_socket_connect (self->sock, address, NULL, &error))
+        {
+          fd = g_socket_get_fd (self->sock);
+          self->pipe = g_object_new (COCKPIT_TYPE_PIPE,
+                                     "name", unix_path,
+                                     "in-fd", fd,
+                                     "out-fd", fd,
+                                     NULL);
+          self->sig_read = g_signal_connect (self->pipe, "read", G_CALLBACK (on_pipe_read), self);
+          self->sig_closed = g_signal_connect (self->pipe, "closed", G_CALLBACK (on_pipe_closed), self);
+          self->open = TRUE;
+          cockpit_channel_ready (channel);
+        }
+    }
+
+  if (error)
+    {
+      g_warning ("%s: %s", unix_path, error->message);
+      g_error_free (error);
+      cockpit_channel_close (channel, "internal-error");
+    }
+
+  g_object_unref (address);
+  return FALSE; /* don't run again */
+}
+
+static void
+cockpit_text_stream_constructed (GObject *object)
+{
+  G_OBJECT_CLASS (cockpit_text_stream_parent_class)->constructed (object);
+
+  /* Guarantee not to close immediately */
+  g_idle_add_full (G_PRIORITY_DEFAULT, connect_in_idle,
+                   g_object_ref (object), g_object_unref);
+}
+
+static void
+cockpit_text_stream_dispose (GObject *object)
+{
+  CockpitTextStream *self = COCKPIT_TEXT_STREAM (object);
+
+  if (self->pipe)
+    {
+      if (self->open)
+        cockpit_pipe_close (self->pipe, "terminated");
+      if (self->sig_read)
+        g_signal_handler_disconnect (self->pipe, self->sig_read);
+      if (self->sig_closed)
+        g_signal_handler_disconnect (self->pipe, self->sig_closed);
+      self->sig_read = self->sig_closed = 0;
+    }
+
+  G_OBJECT_CLASS (cockpit_text_stream_parent_class)->dispose (object);
+}
+
+static void
+cockpit_text_stream_finalize (GObject *object)
+{
+  CockpitTextStream *self = COCKPIT_TEXT_STREAM (object);
+
+  g_clear_object (&self->sock);
+  g_clear_object (&self->pipe);
+
+  G_OBJECT_CLASS (cockpit_text_stream_parent_class)->finalize (object);
+}
+
+static void
+cockpit_text_stream_class_init (CockpitTextStreamClass *klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  CockpitChannelClass *channel_class = COCKPIT_CHANNEL_CLASS (klass);
+
+  gobject_class->constructed = cockpit_text_stream_constructed;
+  gobject_class->dispose = cockpit_text_stream_dispose;
+  gobject_class->finalize = cockpit_text_stream_finalize;
+
+  channel_class->recv = cockpit_text_stream_recv;
+  channel_class->close = cockpit_text_stream_close;
+}
+
+/**
+ * cockpit_text_stream_open:
+ * @transport: the transport to send/receive messages on
+ * @number: the channel number
+ * @unix_path: the UNIX socket path to communicate with
+ *
+ * This function is mainly used by tests. The usual way
+ * to get a #CockpitTextStream is via cockpit_channel_open()
+ *
+ * Returns: (transfer full): the new channel
+ */
+CockpitChannel *
+cockpit_text_stream_open (CockpitTransport *transport,
+                          guint number,
+                          const gchar *unix_path)
+{
+  CockpitChannel *channel;
+  JsonObject *options;
+
+  options = json_object_new ();
+  json_object_set_string_member (options, "unix", unix_path);
+  json_object_set_string_member (options, "payload", "text-stream");
+
+  channel = g_object_new (COCKPIT_TYPE_TEXT_STREAM,
+                          "transport", transport,
+                          "channel", number,
+                          "options", options,
+                          NULL);
+
+  json_object_unref (options);
+  return channel;
+}

--- a/src/agent/cockpittextstream.h
+++ b/src/agent/cockpittextstream.h
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COCKPIT_TEXT_STREAM_H__
+#define COCKPIT_TEXT_STREAM_H__
+
+#include <gio/gio.h>
+
+#include "cockpitchannel.h"
+
+G_BEGIN_DECLS
+
+#define COCKPIT_TYPE_TEXT_STREAM         (cockpit_text_stream_get_type ())
+
+GType              cockpit_text_stream_get_type     (void) G_GNUC_CONST;
+
+CockpitChannel *   cockpit_text_stream_open         (CockpitTransport *transport,
+                                                     guint channel,
+                                                     const gchar *unix_path);
+
+#endif /* COCKPIT_TEXT_STREAM_H__ */

--- a/src/agent/test-textstream.c
+++ b/src/agent/test-textstream.c
@@ -1,0 +1,550 @@
+
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpittextstream.h"
+
+#include <json-glib/json-glib.h>
+
+#include <glib/gstdio.h>
+#include <gio/gunixsocketaddress.h>
+
+#include <sys/socket.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+
+/* -----------------------------------------------------------------------------
+ * Mock
+ */
+
+static GType mock_transport_get_type (void) G_GNUC_CONST;
+
+typedef struct {
+  GObject parent;
+  gboolean closed;
+  gchar *problem;
+  guint channel_sent;
+  GBytes *payload_sent;
+  GBytes *control_sent;
+}MockTransport;
+
+typedef GObjectClass MockTransportClass;
+
+static void mock_transport_iface (CockpitTransportIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (MockTransport, mock_transport, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (COCKPIT_TYPE_TRANSPORT, mock_transport_iface);
+);
+
+static void
+mock_transport_init (MockTransport *self)
+{
+  self->channel_sent = G_MAXUINT;
+}
+
+static void
+mock_transport_get_property (GObject *object,
+                             guint prop_id,
+                             GValue *value,
+                             GParamSpec *pspec)
+{
+  switch (prop_id)
+    {
+    case 1:
+      g_value_set_string (value, "mock-name");
+      break;
+    default:
+      g_assert_not_reached ();
+      break;
+    }
+}
+
+static void
+mock_transport_set_property (GObject *object,
+                             guint prop_id,
+                             const GValue *value,
+                             GParamSpec *pspec)
+{
+  switch (prop_id)
+    {
+    case 1:
+      break;
+    default:
+      g_assert_not_reached ();
+      break;
+    }
+}
+
+static void
+mock_transport_finalize (GObject *object)
+{
+  MockTransport *self = (MockTransport *)object;
+
+  g_free (self->problem);
+  if (self->payload_sent)
+    g_bytes_unref (self->payload_sent);
+  if (self->control_sent)
+    g_bytes_unref (self->control_sent);
+
+  G_OBJECT_CLASS (mock_transport_parent_class)->finalize (object);
+}
+
+static void
+mock_transport_class_init (MockTransportClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  object_class->finalize = mock_transport_finalize;
+  object_class->get_property = mock_transport_get_property;
+  object_class->set_property = mock_transport_set_property;
+  g_object_class_override_property (object_class, 1, "name");
+}
+
+static void
+mock_transport_send (CockpitTransport *transport,
+                     guint channel,
+                     GBytes *data)
+{
+  MockTransport *self = (MockTransport *)transport;
+  if (channel == 0)
+    {
+      g_assert (self->control_sent == NULL);
+      self->control_sent = g_bytes_ref (data);
+    }
+  else
+    {
+      g_assert (self->channel_sent == G_MAXUINT);
+      g_assert (self->payload_sent == NULL);
+      self->channel_sent = channel;
+      self->payload_sent = g_bytes_ref (data);
+    }
+}
+
+static void
+mock_transport_close (CockpitTransport *transport,
+                      const gchar *problem)
+{
+  MockTransport *self = (MockTransport *)transport;
+  g_assert (!self->closed);
+  self->problem = g_strdup (problem);
+  self->closed = TRUE;
+  cockpit_transport_emit_closed (transport, problem);
+}
+
+static void
+mock_transport_iface (CockpitTransportIface *iface)
+{
+  iface->send = mock_transport_send;
+  iface->close = mock_transport_close;
+}
+
+/* -----------------------------------------------------------------------------
+ * Test
+ */
+
+typedef struct {
+  GSocket *listen_sock;
+  GSource *listen_source;
+  GSocket *conn_sock;
+  GSource *conn_source;
+  MockTransport *transport;
+  CockpitChannel *channel;
+  gchar *channel_problem;
+  const gchar *unix_path;
+  gchar *temp_file;
+} TestCase;
+
+static gboolean
+on_socket_input (GSocket *socket,
+                 GIOCondition cond,
+                 gpointer user_data)
+{
+  gchar buffer[1024];
+  GError *error = NULL;
+  gssize ret, wret;
+
+  ret = g_socket_receive (socket, buffer, sizeof (buffer), NULL, &error);
+  g_assert_no_error (error);
+
+  if (ret == 0)
+    {
+      g_socket_shutdown (socket, FALSE, TRUE, &error);
+      g_assert_no_error (error);
+      return FALSE;
+    }
+
+  g_assert (ret > 0);
+  wret = g_socket_send (socket, buffer, ret, NULL, &error);
+  g_assert_no_error (error);
+  g_assert (wret == ret);
+  return TRUE;
+}
+
+static gboolean
+on_socket_connection (GSocket *socket,
+                      GIOCondition cond,
+                      gpointer user_data)
+{
+  TestCase *tc = user_data;
+  GError *error = NULL;
+
+  g_assert (tc->conn_source == NULL);
+  tc->conn_sock = g_socket_accept (tc->listen_sock, NULL, &error);
+  g_assert_no_error (error);
+
+  tc->conn_source = g_socket_create_source (tc->conn_sock, G_IO_IN, NULL);
+  g_source_set_callback (tc->conn_source, (GSourceFunc)on_socket_input, tc, NULL);
+  g_source_attach (tc->conn_source, NULL);
+
+  /* Only one connection */
+  return FALSE;
+}
+
+static void
+setup (TestCase *tc,
+       gconstpointer data)
+{
+  GSocketAddress *address;
+  GError *error = NULL;
+
+  tc->unix_path = data;
+  if (tc->unix_path == NULL)
+    {
+      tc->unix_path = tc->temp_file = g_strdup ("/tmp/cockpit-test-XXXXXX.sock");
+      g_assert (close (g_mkstemp (tc->temp_file)) == 0);
+      g_assert (g_unlink (tc->temp_file) == 0);
+    }
+
+  address = g_unix_socket_address_new (tc->unix_path);
+
+  tc->listen_sock = g_socket_new (G_SOCKET_FAMILY_UNIX, G_SOCKET_TYPE_STREAM,
+                                  G_SOCKET_PROTOCOL_DEFAULT, &error);
+  g_assert_no_error (error);
+
+  g_socket_bind (tc->listen_sock, address, TRUE, &error);
+  g_assert_no_error (error);
+
+  g_socket_listen (tc->listen_sock, &error);
+  g_assert_no_error (error);
+
+  tc->listen_source = g_socket_create_source (tc->listen_sock, G_IO_IN, NULL);
+  g_source_set_callback (tc->listen_source, (GSourceFunc)on_socket_connection, tc, NULL);
+  g_source_attach (tc->listen_source, NULL);
+
+  g_object_unref (address);
+
+  tc->transport = g_object_new (mock_transport_get_type (), NULL);
+}
+
+static void
+on_closed_get_problem (CockpitChannel *channel,
+                       const gchar *problem,
+                       gpointer user_data)
+{
+  TestCase *tc = user_data;
+  g_assert (tc->channel_problem == NULL);
+  tc->channel_problem = g_strdup (problem ? problem : "");
+}
+
+static void
+setup_channel (TestCase *tc,
+               gconstpointer data)
+{
+  setup (tc, data);
+  tc->channel = cockpit_text_stream_open (COCKPIT_TRANSPORT (tc->transport), 548, tc->unix_path);
+  g_signal_connect (tc->channel, "closed", G_CALLBACK (on_closed_get_problem), tc);
+}
+
+static void
+teardown (TestCase *tc,
+          gconstpointer data)
+{
+  if (tc->conn_source)
+    {
+      g_source_destroy (tc->conn_source);
+      g_source_unref (tc->conn_source);
+    }
+  if (tc->listen_source)
+    {
+      g_source_destroy (tc->listen_source);
+      g_source_unref (tc->listen_source);
+    }
+  g_clear_object (&tc->listen_sock);
+  g_clear_object (&tc->conn_sock);
+
+  g_unlink (tc->unix_path);
+  g_free (tc->temp_file);
+
+  g_object_unref (tc->transport);
+
+  if (tc->channel)
+    {
+      g_object_add_weak_pointer (G_OBJECT (tc->channel), (gpointer *)&tc->channel);
+      g_object_unref (tc->channel);
+      g_assert (tc->channel == NULL);
+    }
+}
+static void
+expect_control_message (GBytes *payload,
+                        const gchar *command,
+                        guint channel,
+                        ...) G_GNUC_NULL_TERMINATED;
+
+static void
+expect_control_message (GBytes *payload,
+                        const gchar *expected_command,
+                        guint expected_channel,
+                        ...)
+{
+  const gchar *message_command;
+  guint message_channel;
+  JsonObject *options;
+  JsonParser *parser;
+  const gchar *expect_option;
+  const gchar *expect_value;
+  va_list va;
+
+  parser = json_parser_new ();
+  g_assert (cockpit_transport_parse_command (parser, payload, &message_command,
+                                             &message_channel, &options));
+
+  g_assert_cmpstr (expected_command, ==, message_command);
+  g_assert_cmpuint (expected_channel, ==, expected_channel);
+
+  va_start (va, expected_channel);
+  for (;;) {
+      expect_option = va_arg (va, const gchar *);
+      if (!expect_option)
+        break;
+      expect_value = va_arg (va, const gchar *);
+      g_assert (expect_value != NULL);
+      g_assert_cmpstr (json_object_get_string_member (options, expect_option), ==, expect_value);
+  }
+  va_end (va);
+
+  g_object_unref (parser);
+}
+
+
+static void
+test_echo (TestCase *tc,
+           gconstpointer unused)
+{
+  GBytes *sent;
+
+  sent = g_bytes_new ("Marmalaade!", 11);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), 548, sent);
+
+  while (!tc->transport->payload_sent)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_assert (g_bytes_equal (sent, tc->transport->payload_sent));
+  g_bytes_unref (sent);
+}
+
+static void
+test_shutdown (TestCase *tc,
+               gconstpointer unused)
+{
+  GError *error = NULL;
+
+  /* Wait until the socket has opened */
+  while (tc->conn_sock == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  /*
+   * Close down the write end of the socket (what
+   * CockpitTextStream is reading from)
+   */
+  g_socket_shutdown (tc->conn_sock, FALSE, TRUE, &error);
+  g_assert_no_error (error);
+
+  while (tc->channel_problem == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_assert_cmpstr (tc->channel_problem, ==, "");
+  expect_control_message (tc->transport->control_sent, "close", 548, "reason", "", NULL);
+}
+
+static void
+test_close_normal (TestCase *tc,
+                   gconstpointer unused)
+{
+  GBytes *sent;
+
+  /* Wait until the socket has opened */
+  while (tc->conn_sock == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  sent = g_bytes_new ("Marmalaade!", 11);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), 548, sent);
+  cockpit_channel_close (tc->channel, NULL);
+
+  /* Wait until channel closes */
+  while (tc->channel_problem == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  /* Should have sent payload and control */
+  g_assert_cmpstr (tc->channel_problem, ==, "");
+  g_assert (tc->transport->payload_sent != NULL);
+  g_assert (g_bytes_equal (sent, tc->transport->payload_sent));
+  g_bytes_unref (sent);
+  expect_control_message (tc->transport->control_sent, "close", 548, "reason", "", NULL);
+}
+
+static void
+test_close_problem (TestCase *tc,
+                    gconstpointer unused)
+{
+  GBytes *sent;
+
+  /* Wait until the socket has opened */
+  while (tc->conn_sock == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  sent = g_bytes_new ("Marmalaade!", 11);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), 548, sent);
+  g_bytes_unref (sent);
+  cockpit_channel_close (tc->channel, "boooyah");
+
+  /* Wait until channel closes */
+  while (tc->channel_problem == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  /* Should have sent payload and control */
+  g_assert_cmpstr (tc->channel_problem, ==, "boooyah");
+  g_assert (tc->transport->payload_sent == 0);
+  expect_control_message (tc->transport->control_sent, "close", 548, "reason", "boooyah", NULL);
+}
+
+static void
+test_close_before_open (TestCase *tc,
+                        gconstpointer unused)
+{
+  cockpit_channel_close (tc->channel, "boooyah");
+
+  /* Wait until channel closes */
+  while (tc->channel_problem == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  /* Should have sent payload and control */
+  g_assert_cmpstr (tc->channel_problem, ==, "boooyah");
+  g_assert (tc->transport->payload_sent == NULL);
+  expect_control_message (tc->transport->control_sent, "close", 548, "reason", "boooyah", NULL);
+
+  /* Should never have opened */
+  while (g_main_context_iteration (NULL, FALSE));
+  g_assert (tc->conn_sock == NULL);
+}
+
+static gboolean
+on_log_ignore_warnings (const gchar *log_domain,
+                        GLogLevelFlags log_level,
+                        const gchar *message,
+                        gpointer user_data)
+{
+  switch (log_level & G_LOG_LEVEL_MASK)
+    {
+    case G_LOG_LEVEL_WARNING:
+    case G_LOG_LEVEL_MESSAGE:
+    case G_LOG_LEVEL_INFO:
+    case G_LOG_LEVEL_DEBUG:
+      return FALSE;
+    default:
+      return TRUE;
+    }
+}
+
+static void
+test_send_invalid (TestCase *tc,
+                   gconstpointer unused)
+{
+  GBytes *sent;
+
+  /* Below we cause a warning, and g_test_expect_message() is broken */
+  g_test_log_set_fatal_handler (on_log_ignore_warnings, NULL);
+
+  sent = g_bytes_new ("\x00Marmalaade!", 12);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), 548, sent);
+  g_bytes_unref (sent);
+
+  /* Wait until channel closes */
+  while (tc->channel_problem == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  /* Should have sent payload and control */
+  g_assert_cmpstr (tc->channel_problem, ==, "protocol-error");
+  g_assert (tc->transport->payload_sent == 0);
+  expect_control_message (tc->transport->control_sent, "close", 548, "reason", "protocol-error", NULL);
+}
+
+static void
+test_recv_invalid (TestCase *tc,
+                   gconstpointer unused)
+{
+  GError *error = NULL;
+
+  /* Wait until the socket has opened */
+  while (tc->conn_sock == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  /* Below we cause a warning, and g_test_expect_message() is broken */
+  g_test_log_set_fatal_handler (on_log_ignore_warnings, NULL);
+
+  g_assert_cmpint (g_socket_send (tc->conn_sock, "\x00Marmalaade!", 12, NULL, &error), ==, 12);
+  g_assert_no_error (error);
+
+  /* Wait until channel closes */
+  while (tc->channel_problem == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  /* Should have sent payload and control */
+  g_assert_cmpstr (tc->channel_problem, ==, "protocol-error");
+  g_assert (tc->transport->payload_sent == 0);
+  expect_control_message (tc->transport->control_sent, "close", 548, "reason", "protocol-error", NULL);
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+  g_type_init ();
+
+  g_set_prgname ("test-textstream");
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add ("/text-stream/echo", TestCase, NULL,
+              setup_channel, test_echo, teardown);
+  g_test_add ("/text-stream/shutdown", TestCase, NULL,
+              setup_channel, test_shutdown, teardown);
+  g_test_add ("/text-stream/close-normal", TestCase, NULL,
+              setup_channel, test_close_normal, teardown);
+  g_test_add ("/text-stream/close-problem", TestCase, NULL,
+              setup_channel, test_close_problem, teardown);
+  g_test_add ("/text-stream/close-before-open", TestCase, NULL,
+              setup_channel, test_close_before_open, teardown);
+  g_test_add ("/text-stream/invalid-send", TestCase, NULL,
+              setup_channel, test_send_invalid, teardown);
+  g_test_add ("/text-stream/invalid-recv", TestCase, NULL,
+              setup_channel, test_recv_invalid, teardown);
+
+  return g_test_run ();
+}


### PR DESCRIPTION
CockpitTextStream is a channel of payload type 'text-stream'
that transfers raw textual data.
- Only UTF-8 data is supported. There may be another binary
  stream in the future, but that's not here.
- Only supports connecting to a unix socket for now, might
  get other connection types in the future implemented in
  the same class.

Fixes #257
