### PR TITLE
Hide docker images without repotags.

### DIFF
--- a/src/web/cockpit-docker.js
+++ b/src/web/cockpit-docker.js
@@ -252,6 +252,10 @@ PageContainers.prototype = {
             this.delete_row(id);
             return;
         }
+        if (!image.RepoTags) {
+            this.delete_row(id);
+            return;
+        }
 
         var tr =
             $('<tr>').append(


### PR DESCRIPTION
This is for example the case when an image has been partially deleted
or if it is based on multiple layers.

Fixes #291
