### PR TITLE
web: Hover over containers and images in overview page

### DIFF
--- a/src/web/cockpit.css
+++ b/src/web/cockpit.css
@@ -453,6 +453,21 @@ a {
 }
 
 /*
+ * Fix up table row hovering.
+ *
+ * When you hover over table rows it's because they're clickable.
+ * Make the table row hover color match the list-group-item.
+ */
+.table-hover > tbody > tr > td,
+.table-hover > tbody > tr > th {
+    cursor: pointer;
+}
+.table-hover > tbody > tr:hover > td,
+.table-hover > tbody > tr:hover > th {
+    background-color: #f5f9fc;
+}
+
+/*
  * Used to make a table cell that containts buttons have less padding
  * HACK: Because CSS has no parant selector.
  */

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -759,7 +759,7 @@
             <span style="float:right">
             </span>
           </div>
-          <table class="table">
+          <table class="table table-hover">
             <thead>
               <tr>
                 <th>Name</th>
@@ -778,7 +778,7 @@
           <div class="panel-heading">
             Images
           </div>
-          <table class="table">
+          <table class="table table-hover">
             <thead>
               <tr>
                 <th>Tags</th>


### PR DESCRIPTION
Make them look clickable with the right pointer as well.

Upstream patternfly now has .table-hover as of their commit:
456368a5595774340f133e2d35da518a4d5ca59a

Fixes #289
