### PR TITLE
web: Hacky fix for no space at end of containers page

### DIFF
--- a/src/web/index.html
+++ b/src/web/index.html
@@ -791,6 +791,9 @@
             </tbody>
           </table>
         </div>
+
+        <!-- TODO: leave space at end of page for demo. need a real fix for this #342 -->
+        &nbsp;
       </div>
 
       <!-- Layout for container details page -->


### PR DESCRIPTION
Couldn't figure out how to do this with margins, so here's a hacky
fix for getting some space at the end of the containers page for now.

Issue #342
