### PR TITLE
web: Explicitly use empty string for CPU column when stopped.

### DIFF
--- a/src/web/cockpit-docker.js
+++ b/src/web/cockpit-docker.js
@@ -167,7 +167,7 @@ PageContainers.prototype = {
             return;
         }
 
-        var cpuuse, cputext;
+        var cputext;
         var memuse, memlimit;
         var membar, memtext, memtextstyle;
 
@@ -196,6 +196,7 @@ PageContainers.prototype = {
             membar = true;
             memtextstyle = { 'color': 'inherit', 'text-align': 'inherit' };
         } else {
+            cputext = "";
             membar = false;
             memtext = _("Stopped");
             memtextstyle = { 'color': 'grey', 'text-align': 'right' };


### PR DESCRIPTION
Otherwise, it remains at "0%" when stopping a container, because
$(..).text(undefined) doesn't have any effect.
