### PR TITLE
web: Switch overview display of memory back to MiB

### DIFF
--- a/src/web/cockpit-docker.js
+++ b/src/web/cockpit-docker.js
@@ -223,10 +223,10 @@ PageContainers.prototype = {
                 barvalue += "/" + memlimit.toString();
 
             if (memlimit) {
-                var parts = $cockpit.format_bytes(memlimit);
+                var parts = $cockpit.format_bytes(memlimit, 1024);
                 memtext = (memuse? $cockpit.format_bytes(memuse, parts[1])[0] : "?") + " / " + parts.join(" ");
             } else {
-                memtext = (memuse? $cockpit.format_bytes(memuse).join(" ") : "?");
+                memtext = (memuse? $cockpit.format_bytes(memuse, 1024).join(" ") : "?");
             }
 
 


### PR DESCRIPTION
Use base-2 suffixes for memory display on overview containers page.
This fixes a regression.
