### PR TITLE
web: Fix container images appearing multiple times

### DIFF
--- a/src/web/cockpit-docker.js
+++ b/src/web/cockpit-docker.js
@@ -326,7 +326,7 @@ PageContainers.prototype = {
                     PageRunImage.display(self.client, id);
                     return false;
                 });
-            tr = $('<tr>').append(
+            tr = $('<tr id="' + id + '">').append(
                     $('<td>'),
                     $('<td>'),
                     $('<td>').append($cockpit.BarRow("container-images")),


### PR DESCRIPTION
This happens when you come back to the overview page. Regression.
