### PR TITLE
web: Align the server avatar image in the space provided

### DIFF
--- a/src/web/cockpit-server.js
+++ b/src/web/cockpit-server.js
@@ -128,7 +128,7 @@ PageServer.prototype = {
                                                  "com.redhat.Cockpit.Manager");
         manager.call('GetAvatarDataURL', function (error, result) {
             if (result)
-                $('#server-avatar').attr('src', result);
+                $('#server-avatar').css('background-image', 'url(' + result + ')');
         });
     },
 

--- a/src/web/cockpit.css
+++ b/src/web/cockpit.css
@@ -130,6 +130,14 @@ a {
     }
 }
 
+/* The server avatar */
+#server-avatar {
+    height: 250px;
+    background-image: url(images/server-large.png);
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
 /* Break up sidebar in columns in smaller sizes*/
 
 .cockpit-info-table td {

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -156,9 +156,8 @@
             <div class="list-group-item">
               <input data-role="none" type="file"
                      id="server-avatar-uploader" style="display:none"/>
-              <img id="server-avatar"
-                   src="images/server-large.png"/>
-            </div>
+              <div id="server-avatar"></div>
+           </div>
             <a class="list-group-item" onclick="cockpit_go_down('system_information')">
               <img class="cockpit-category-icon" src="images/category-system.png">
               System Information


### PR DESCRIPTION
Use a backgroud-image to do this, as it's the simplest. Note that
we now have a standard height of the area. But that makes sense anyway.

Fixes #339
