### PR TITLE
web: Add checkbox for starting container with terminal or not

### DIFF
--- a/src/web/cockpit-docker.js
+++ b/src/web/cockpit-docker.js
@@ -544,14 +544,25 @@ PageRunImage.prototype = {
 
         $("#containers_run_image_dialog").modal('hide');
 
+        var tty = $("#containers-run-image-with-terminal").prop('checked');
         var options = {
             "Cmd": cockpit_unquote_cmdline(cmd),
             "Image": PageRunImage.image_info.id,
             "Memory": this.memory_limit || 0,
             "MemorySwap": (this.memory_limit * 2) || 0,
             "CpuShares": this.cpu_priority || 0,
-            "Tty": true
+            "Tty": tty
         };
+
+        if (tty) {
+            $.extend(options, {
+                "AttachStderr": true,
+                "AttachStdin": true,
+                "AttachStdout": true,
+                "OpenStdin": true,
+                "StdinOnce": true
+            });
+        }
 
         PageRunImage.client.create(name, options).
             fail(function(ex) {
@@ -562,8 +573,9 @@ PageRunImage.prototype = {
                     fail(function(ex) {
                         cockpit_show_unexpected_error(ex);
                     });
-                if (cockpit_get_page_param('page') == "image-details")
+                if (cockpit_get_page_param('page') == "image-details") {
                     cockpit_go_up();
+                }
             });
     }
 };

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -2124,6 +2124,12 @@
                     default
                 </td>
               </tr>
+              <tr>
+                <td translatable="yes">With terminal</td>
+                <td class="shrink">
+                  <input type="checkbox" id="containers-run-image-with-terminal" checked />
+                </td>
+              </tr>
             </table>
           </div>
           <div class="modal-footer">


### PR DESCRIPTION
Some commands won't run with a terminal, and not all images need
a terminal. So make this an optoin.

Fixes #357
