### PR TITLE
web: Show container memory limit and cpu priority in details

### DIFF
--- a/src/web/cockpit-docker.js
+++ b/src/web/cockpit-docker.js
@@ -672,7 +672,9 @@ PageContainerDetails.prototype = {
         $('#container-details-image').text("");
         $('#container-details-command').text("");
         $('#container-details-state').text("");
-        $('#container-details-ports').text("");
+        $('#container-details-ports-row').hide();
+        $('#container-detail-memory-row').hide();
+        $('#container-detail-cpu-row').hide();
 
         var info = this.client.containers[this.container_id];
         docker_debug("container-details", this.container_id, info);
@@ -718,7 +720,15 @@ PageContainerDetails.prototype = {
         $('#container-details-image').text(info.Image);
         $('#container-details-command').text(info.Command);
         $('#container-details-state').text(cockpit_render_container_state(info.State));
+
+        $('#container-details-ports-row').toggle(port_bindings.length > 0);
         $('#container-details-ports').html(port_bindings.map(cockpit_esc).join('<br/>'));
+
+        $('#container-details-memory-row').toggle(!!(info.Config.Memory));
+        $('#container-details-memory').text($cockpit.format_bytes(info.Config.Memory, 1024).join(" "));
+
+        $('#container-details-cpu-row').toggle(!!(info.Config.CpuShares));
+        $('#container-details-cpu').text(info.Config.CpuShares + _(" shares"));
 
         this.maybe_show_terminal(info);
     },

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -814,9 +814,17 @@
                 <td>State:</td>
                 <td id="container-details-state"></td>
               </tr>
-	      <tr>
+	      <tr id="container-details-ports-row" style="display: none;">
                 <td>Ports:</td>
                 <td id="container-details-ports"></td>
+              </tr>
+	      <tr id="container-details-memory-row" style="display: none;">
+                <td>Memory limit:</td>
+                <td id="container-details-memory"></td>
+              </tr>
+	      <tr id="container-details-cpu-row" style="display: none;">
+                <td>CPU priority:</td>
+                <td id="container-details-cpu"></td>
               </tr>
 	    </table>
             <div id="container-terminal" class="terminal-emulator" style="display: none;"></div>


### PR DESCRIPTION
If a CPU priority and memory limit have been assigned then
show them in the container details. In addition show the ports
row only when ports have been assigned.

Fixes #354
