### PR TITLE
daemon: Disable unreliable test of CPU usage

### DIFF
--- a/src/daemon/test-cgroupmonitor.c
+++ b/src/daemon/test-cgroupmonitor.c
@@ -366,7 +366,7 @@ test_new_samples (TestCase *tc,
   g_variant_get_child (values, 3, "d", &value);
   g_assert_cmpfloat (value, ==, -1.0);
   g_variant_get_child (values, 4, "d", &value);
-  g_assert_cmpfloat (value, >, 1.0);
+  /* Cannot reliably predict the CPU value */
   g_variant_unref (values);
 
   g_variant_unref (sample);


### PR DESCRIPTION
This is hard to predict currently, and leads to sporadic failures
when building in mock or elsewhere. Needs work, but lets disable
for now.
