### PR TITLE
Add dependency on libxslt

### DIFF
--- a/test/cockpit.spec.in
+++ b/test/cockpit.spec.in
@@ -42,6 +42,7 @@ BuildRequires: openssl-devel
 BuildRequires: zlib-devel
 BuildRequires: krb5-devel
 BuildRequires: libgsystem-devel
+BuildRequires: libxslt-devel
 
 # Used during make check
 BuildRequires: sshpass


### PR DESCRIPTION
There was a build regression due to the removal of
BuildRequires: gtk-doc
in bd902d3a5f5f503a8b343f8cb946754b081fc734 which was implicitly
pulling in libxslt.
