### PR TITLE
web: Don't display 'null' everywhere on Services page

### DIFF
--- a/src/web/cockpit-util.js
+++ b/src/web/cockpit-util.js
@@ -21,6 +21,8 @@ var $cockpit = $cockpit || { };
 
 // Used for escaping things in HTML elements and attributes
 function cockpit_esc(str) {
+    if (str === null || str === undefined)
+        return "";
     var pre = document.createElement('pre');
     var text = document.createTextNode(str);
     pre.appendChild(text);

--- a/src/web/dbus.js
+++ b/src/web/dbus.js
@@ -246,6 +246,7 @@ DBusClient.prototype = {
         }
 
         $(client._channel).on("message", function(event, payload) {
+            console.warn(payload);
             var decoded = JSON.parse(payload);
             dbus_debug("got message command=" + decoded.command);
 


### PR DESCRIPTION
There's a lot of 'null' on the Services page. We should just display blank strings here.
