### PR TITLE
Also add BuildRequires: docbook-style-xsl

### DIFF
--- a/test/cockpit.spec.in
+++ b/test/cockpit.spec.in
@@ -43,6 +43,7 @@ BuildRequires: zlib-devel
 BuildRequires: krb5-devel
 BuildRequires: libgsystem-devel
 BuildRequires: libxslt-devel
+BuildRequires: docbook-style-xsl
 
 # Used during make check
 BuildRequires: sshpass


### PR DESCRIPTION
The previous patch was incomplete. It got past the configure step but fails when actually generating the documentation without a network connection (such as in the Koji or Coverity build environments).
