### PR TITLE
Fix a bunch of warnings that are raised by clang 3.3

### DIFF
--- a/src/agent/cockpitrestjson.c
+++ b/src/agent/cockpitrestjson.c
@@ -849,12 +849,12 @@ cockpit_rest_request_create (CockpitRestJson *self,
 {
   CockpitRestRequest *req = NULL;
   JsonObject *pollopts = NULL;
+  GString *string = NULL;
+  GBytes *body = NULL;
   gint64 cookie;
   const gchar *method;
   const gchar *path;
-  GString *string;
   gsize length;
-  GBytes *body;
   JsonNode *node;
   gint64 interval;
   gint64 watch;
@@ -899,7 +899,7 @@ cockpit_rest_request_create (CockpitRestJson *self,
         }
       pollopts = json_node_get_object (node);
       if (!cockpit_json_get_int (pollopts, "interval", 1000, &interval) ||
-          interval < 0 || interval > G_MAXUINT32)
+          interval < 0 || interval >= G_MAXINT32)
         {
           g_warning ("Invalid \"interval\" member in REST JSON request: should be non-negative integer");
           goto out;

--- a/src/daemon/machine.c
+++ b/src/daemon/machine.c
@@ -336,7 +336,6 @@ handle_remove_tag (CockpitMachine *object,
   GError *error = NULL;
   Machine *machine = MACHINE (object);
   Machines *machines = daemon_get_machines (machine->daemon);
-  gs_free const gchar **new_tags = NULL;
 
   const gchar *const *tags = cockpit_machine_get_tags (object);
 

--- a/src/daemon/realms.c
+++ b/src/daemon/realms.c
@@ -914,7 +914,7 @@ on_op_done (GObject *object,
   Realms *realms = REALMS (user_data);
 
   GError *error = NULL;
-  gs_unref_variant GVariant *join_result = g_dbus_proxy_call_finish (G_DBUS_PROXY (object), res, &error);
+  GVariant *join_result = g_dbus_proxy_call_finish (G_DBUS_PROXY (object), res, &error);
 
   if (error)
     end_invocation_take_gerror (realms, error);
@@ -925,6 +925,7 @@ on_op_done (GObject *object,
       else
         cockpit_realms_complete_leave (COCKPIT_REALMS (realms), realms->op_invocation);
       clear_invocation (realms);
+      g_variant_unref (join_result);
     }
 }
 
@@ -1095,11 +1096,15 @@ on_cancel_done (GObject *object,
 {
   GError *error = NULL;
 
-  gs_unref_variant GVariant *result = g_dbus_proxy_call_finish (G_DBUS_PROXY (object), res, &error);
+  GVariant *result = g_dbus_proxy_call_finish (G_DBUS_PROXY (object), res, &error);
   if (error)
     {
       g_warning ("Failed to cancel: %s", error->message);
       g_error_free (error);
+    }
+  else
+    {
+      g_variant_unref (result);
     }
 }
 

--- a/src/daemon/services.c
+++ b/src/daemon/services.c
@@ -233,11 +233,15 @@ on_subscribe_done (GObject *object,
                    gpointer user_data)
 {
   GError *error = NULL;
-  gs_unref_variant GVariant *result = g_dbus_proxy_call_finish (G_DBUS_PROXY (object), res, &error);
+  GVariant *result = g_dbus_proxy_call_finish (G_DBUS_PROXY (object), res, &error);
   if (error)
     {
       g_warning ("Can't subscribe to systemd signals: %s", error->message);
       g_error_free (error);
+    }
+  else
+    {
+      g_variant_unref (result);
     }
 }
 
@@ -977,7 +981,7 @@ on_reload_done (GObject *object,
   ServiceActionData *data = user_data;
   GError *error = NULL;
 
-  gs_unref_variant GVariant *result = g_dbus_proxy_call_finish (G_DBUS_PROXY (object), res, &error);
+  GVariant *result = g_dbus_proxy_call_finish (G_DBUS_PROXY (object), res, &error);
   if (error)
     {
       end_invocation_take_gerror (data->invocation, error);
@@ -985,6 +989,7 @@ on_reload_done (GObject *object,
       return;
     }
 
+  g_variant_unref (result);
   cockpit_services_complete_service_action (COCKPIT_SERVICES (data->services),
                                             data->invocation);
   g_free (data);

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -387,7 +387,6 @@ cockpit_auth_check_userpass (CockpitAuth *self,
   gchar *header;
   char *password;
   char *user;
-  gs_free char *id = NULL;
 
   if (!verify_userpass (self, userpass, &user, &password, error))
     {

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -138,7 +138,6 @@ cockpit_handler_login (CockpitWebServer *server,
 
   GHashTable *out_headers = NULL;
   gs_free gchar *response_body = NULL;
-  gs_free gchar *response = NULL;
   CockpitCreds *creds = NULL;
 
   out_headers = cockpit_web_server_new_table ();

--- a/src/ws/cockpitwebserver.c
+++ b/src/ws/cockpitwebserver.c
@@ -513,7 +513,6 @@ serve_static_file (CockpitWebServer *server,
   gchar *query = NULL;
   gs_free gchar *unescaped = NULL;
   gs_free gchar *path = NULL;
-  gs_free gchar *mime_type = NULL;
   gs_unref_object GFileInputStream *file_in = NULL;
   gs_unref_object GFile *f = NULL;
   gs_unref_object GFileInfo *info = NULL;

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -129,14 +129,11 @@ assert_matches_msg (const char *domain,
 static void
 skip_test (const gchar *reason)
 {
-#if GLIB_CHECK_VERSION(2, 40, 0)
-        g_test_skip (reason);
-#else
-        if (g_test_verbose ())
-                g_print ("GTest: skipping: %s\n", reason);
-        else
-                g_print ("SKIP: %s ", reason);
-#endif
+  /* Can't use g_test_skip() yet */
+  if (g_test_verbose ())
+    g_print ("GTest: skipping: %s\n", reason);
+  else
+    g_print ("SKIP: %s ", reason);
 }
 
 static void


### PR DESCRIPTION
Some of these are serious, such as the ones in CockpitRestJson
and others are innocuous, but seem worth fixing so we can rely
on the warnings.
