### PR TITLE
test: Don't use ifconfig, as it's less available on linux

### DIFF
--- a/test/testsuite-prepare
+++ b/test/testsuite-prepare
@@ -2,7 +2,7 @@
 
 set -e
 
-IFCONFIG=/sbin/ifconfig
+IP=/usr/sbin/ip
 
 silent()
 {
@@ -22,7 +22,7 @@ require_binary parallel
 require_binary js
 require_binary trickle
 
-if ! silent $IFCONFIG cockpit0; then
+if ! silent $IP address show dev cockpit0; then
   sudo ./vm-prep
 fi
 


### PR DESCRIPTION
Use the 'ip' command to test for the presence of an interface instead.

This was a complaint from a contributor to cockpit. Lets make life as easy as possible.
