### PR TITLE
ws: Don't run test-transport unit tests twice

### DIFF
--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -108,7 +108,6 @@ test_server_LDADD = 					\
 WS_CHECKS = \
 	test-creds \
 	test-auth \
-	test-transport \
 	test-webserver \
 	test-webservice \
 	test-handlers \


### PR DESCRIPTION
This was left behind when we moved test-transport.c to libcockpit.
