### PR TITLE
daemon: Fix invalid memory accesses in resource monitors.

### DIFF
--- a/src/daemon/cgroupmonitor.c
+++ b/src/daemon/cgroupmonitor.c
@@ -112,9 +112,6 @@ static void on_tick (GObject    *unused_source,
 static void
 cgroup_monitor_init (CGroupMonitor *monitor)
 {
-  g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (monitor),
-                                       G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
-
   monitor->samples_prev = -1;
   monitor->consumers = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
   monitor->timestamps = g_new0 (gint64, SAMPLES_MAX);
@@ -542,7 +539,7 @@ handle_get_samples (CockpitMultiResourceMonitor *_monitor,
       gint pos;
 
       pos = monitor->samples_next + n;
-      if (pos > SAMPLES_MAX)
+      if (pos >= SAMPLES_MAX)
         pos -= SAMPLES_MAX;
 
       if (monitor->timestamps[pos] == 0)

--- a/src/daemon/cpumonitor.c
+++ b/src/daemon/cpumonitor.c
@@ -97,9 +97,6 @@ cpu_monitor_init (CpuMonitor *monitor)
 {
   const gchar *legends[5] = {"Nice", "User", "Kernel", "I/O Wait", NULL}; /* TODO: i18n */
 
-  g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (monitor),
-                                       G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
-
   monitor->user_hz = sysconf (_SC_CLK_TCK);
   if (monitor->user_hz == -1 || monitor->user_hz == 0)
     {
@@ -394,7 +391,7 @@ handle_get_samples (CockpitResourceMonitor *_monitor,
       GVariantBuilder sample_builder;
 
       pos = monitor->samples_next + n;
-      if (pos > monitor->samples_max)
+      if (pos >= monitor->samples_max)
         pos -= monitor->samples_max;
 
       if (monitor->samples[pos].timestamp == 0)

--- a/src/daemon/diskiomonitor.c
+++ b/src/daemon/diskiomonitor.c
@@ -96,9 +96,6 @@ disk_io_monitor_init (DiskIOMonitor *monitor)
 {
   const gchar *legends[4] = {"Disk Reads", "Disk Writes", "I/O Operations", NULL}; /* TODO: i18n */
 
-  g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (monitor),
-                                       G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
-
   /* Assign legends */
   cockpit_resource_monitor_set_legends (COCKPIT_RESOURCE_MONITOR (monitor), legends);
 
@@ -428,7 +425,7 @@ handle_get_samples (CockpitResourceMonitor *_monitor,
       GVariantBuilder sample_builder;
 
       pos = monitor->samples_next + n;
-      if (pos > monitor->samples_max)
+      if (pos >= monitor->samples_max)
         pos -= monitor->samples_max;
 
       if (monitor->samples[pos].timestamp == 0)

--- a/src/daemon/memorymonitor.c
+++ b/src/daemon/memorymonitor.c
@@ -91,9 +91,6 @@ memory_monitor_init (MemoryMonitor *monitor)
 {
   const gchar *legends[5] = {"Free", "Used", "Cached", "Swap Used", NULL}; /* TODO: i18n */
 
-  g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (monitor),
-                                       G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
-
   /* Assign legends */
   cockpit_resource_monitor_set_legends (COCKPIT_RESOURCE_MONITOR (monitor), legends);
 
@@ -343,7 +340,7 @@ handle_get_samples (CockpitResourceMonitor *_monitor,
       GVariantBuilder sample_builder;
 
       pos = monitor->samples_next + n;
-      if (pos > monitor->samples_max)
+      if (pos >= monitor->samples_max)
         pos -= monitor->samples_max;
 
       if (monitor->samples[pos].timestamp == 0)

--- a/src/daemon/networkmonitor.c
+++ b/src/daemon/networkmonitor.c
@@ -94,9 +94,6 @@ network_monitor_init (NetworkMonitor *monitor)
 {
   const gchar *legends[3] = {"Incoming Traffic", "Outgoing Traffic", NULL}; /* TODO: i18n */
 
-  g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (monitor),
-                                       G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
-
   /* Assign legends */
   cockpit_resource_monitor_set_legends (COCKPIT_RESOURCE_MONITOR (monitor), legends);
 
@@ -388,7 +385,7 @@ handle_get_samples (CockpitResourceMonitor *_monitor,
       GVariantBuilder sample_builder;
 
       pos = monitor->samples_next + n;
-      if (pos > monitor->samples_max)
+      if (pos >= monitor->samples_max)
         pos -= monitor->samples_max;
 
       if (monitor->samples[pos].timestamp == 0)


### PR DESCRIPTION
Wrap the index correctly in GetSamples and don't run it in a thread.
The samples can not be read from multiple threads.
