### PR TITLE
web: Don't omit "dashboard" from URL.

### DIFF
--- a/doc/embed-example.html
+++ b/doc/embed-example.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <title>Embedded Cockpit</title>
+  </head>
+  <body>
+    This is Cockpit.
+    <br/>
+    <iframe width="800px" height="600px"
+            src="https://sunflower:21064/#server"/>
+  </body>
+</html>

--- a/doc/embed.md
+++ b/doc/embed.md
@@ -1,0 +1,18 @@
+Embedding Cockpit
+=================
+
+You can Cockpit into a larger web page as a frame.  You can control
+some aspects of Cockpit via the URL.
+
+See the file embed-example.html in this directory.
+
+No Dashboard
+------------
+
+If you want to confine Cockpit to a single machine, you can omit the
+"All" element in the breadcrumb trail.  The user then has no obvious
+way to navigate to a different machine.
+
+To achieve this, use a URL like this:
+
+  https://IP:21064/#server

--- a/src/web/cockpit-login.js
+++ b/src/web/cockpit-login.js
@@ -133,9 +133,8 @@ function cockpit_logout (reason)
 
 function cockpit_go_login_account ()
 {
-    cockpit_go ([ { page: "dashboard" },
-                  { page: "server", machine: "localhost" },
-                  { page: "accounts" },
-                  { page: "account", id: $cockpit.connection_config.user }
-                ]);
+    cockpit_go_server ("localhost",
+                       [ { page: "accounts" },
+                         { page: "account", id: $cockpit.connection_config.user }
+                       ]);
 }

--- a/src/web/cockpit-page.js
+++ b/src/web/cockpit-page.js
@@ -187,6 +187,23 @@ function cockpit_go_up ()
         cockpit_go (cockpit_loc_trail.slice(0, cockpit_loc_trail.length-1));
 }
 
+function cockpit_go_server (machine, extra)
+{
+    var loc = [ { page: "server",
+                  machine: machine
+                }
+              ];
+
+    if (extra)
+        loc = loc.concat(extra);
+
+    if (cockpit_loc_trail.length > 1 && cockpit_loc_trail[0].page == "dashboard")
+        loc =[ { page: "dashboard" } ].concat(loc);
+
+    cockpit_go(loc);
+}
+
+
 function cockpit_encode_trail (trail)
 {
     function encode (p)
@@ -200,16 +217,11 @@ function cockpit_encode_trail (trail)
         return res;
     }
 
-    var hash;
-    if (trail.length == 1 && trail[0].page == "dashboard")
-        hash = encode(trail[0]);
-    else {
-        hash = '';
-        for (var i = 1; i < trail.length; i++) {
-            hash += encode(trail[i]);
-            if (i < trail.length-1)
-                hash += '&';
-        }
+    var hash = '';
+    for (var i = 0; i < trail.length; i++) {
+        hash += encode(trail[i]);
+        if (i < trail.length-1)
+            hash += '&';
     }
 
     return '#' + hash;
@@ -238,8 +250,6 @@ function cockpit_decode_trail (hash)
         }
         trail.push(p);
     }
-    if (trail[0].page != "dashboard")
-        trail = [ { page: 'dashboard' } ].concat(trail);
 
     return trail;
 }

--- a/src/web/cockpit-search.js
+++ b/src/web/cockpit-search.js
@@ -39,8 +39,5 @@ function cockpit_search (string) {
     else
         loc = { page: "journal", prio: prio, start: start, search: string };
 
-    cockpit_go ([ { page: "dashboard" },
-                  { page: "server", machine: cockpit_get_page_param('machine', 'server') },
-                  loc
-                ]);
+    cockpit_go_server (cockpit_get_page_param('machine', 'server'), [ loc ]);
 }


### PR DESCRIPTION
This allows people to explicitly omit the dashboard ("All") from the
breadcrumb trail, such as when embedding Cockpit into a UI that
already takes care of multiple machines.

In addition, the "Account Settings" and "Search" widgets use te new
cockpit_go_server function to do their navigation.  That function
makes sure that the new breadcrumb only includes "All" when it was
there before.

Fixes #465.
