### PR TITLE
common: Add missing dirent.h header

### DIFF
--- a/src/cockpit/cockpitpipe.c
+++ b/src/cockpit/cockpitpipe.c
@@ -28,6 +28,7 @@
 #include <sys/uio.h>
 #include <sys/wait.h>
 
+#include <dirent.h>
 #include <errno.h>
 #include <pty.h>
 #include <stdio.h>


### PR DESCRIPTION
This caused build failures on some non-Fedora systems.
