### PR TITLE
Use cockpit_agent_strmatch() in tests for clarity

### DIFF
--- a/src/agent/test-textstream.c
+++ b/src/agent/test-textstream.c
@@ -594,7 +594,8 @@ test_spawn_pty (void)
         }
     }
 
-  g_assert (strstr (received->str, "booyah") != NULL);
+  cockpit_assert_strmatch (received->str, "*booyah*");
+  g_string_free (received, TRUE);
 
   g_assert_cmpstr (problem, ==, "");
   g_object_unref (channel);

--- a/src/cockpit/test-pipe.c
+++ b/src/cockpit/test-pipe.c
@@ -706,7 +706,7 @@ test_pty_shell (void)
   buffer = cockpit_pipe_get_buffer (pipe);
   g_byte_array_append (buffer, (const guint8 *)"\0", 1);
 
-  g_assert (strstr ((gchar *)buffer->data, "booyah") != NULL);
+  cockpit_assert_strmatch ((gchar *)buffer->data, "*booyah*");
   g_object_unref (pipe);
 }
 


### PR DESCRIPTION
CI seems to be failing in a racy way on of the test-restjson tests. Using cockpit_assert_strmatch() allows us to see a bit more about why it's failing like that when it does.
