### PR TITLE
We don't and can't use fedora-deps.repo anymore

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -26,16 +26,15 @@ with pre-build binary packages of all needed dependencies.
 
 ### Fedora:
 
-Currently the 64-bit architectures of Fedora 18 and Fedora 20 are
-supported.  As root, copy or symlink `contrib/fedora/cockpit-deps.repo` into
-`/etc/yum.repos.d/cockpit-deps.repo`.
+Currently the 64-bit architectures of Fedora 20 and Rawhide are most
+often used for development.
 
 Check `test/cockpit.spec.in` for the concrete build dependencies.  The following
 should work in a fresh Git clone:
 
     $ cd ./test
     $ srpm=$(./make-srpm)
-    # yum-builddep --enablerepo=cockpit-deps $srpm
+    # yum-builddep $srpm
 
 ## Building and installing
 

--- a/contrib/fedora/cockpit-deps.repo
+++ b/contrib/fedora/cockpit-deps.repo
@@ -1,5 +1,0 @@
-[cockpit-deps]
-name=Unreleased Cockpit dependencies
-baseurl=http://cockpit-project.github.io/cockpit-deps/fedora-$releasever/$basearch
-enabled=0
-gpgcheck=0

--- a/test/cockpit.setup
+++ b/test/cockpit.setup
@@ -15,15 +15,6 @@ echo 'SELINUX=disabled' > /etc/selinux/config
 
 rm -rf /etc/sysconfig/iptables
 
-COCKPIT_DEPS_BASEURL=${COCKPIT_DEPS_BASEURL:=http://cockpit-project.github.io/cockpit-deps}
-COCKPIT_DEPS_URL=${COCKPIT_DEPS_BASEURL}/$TEST_OS/$TEST_ARCH
-
-echo "[cockpit-deps]
-name=Unreleased Cockpit dependencies
-baseurl=${COCKPIT_DEPS_URL}
-enabled=1
-gpgcheck=0" > /etc/yum.repos.d/cockpit-deps.repo
-
 maybe() { if type "$1" >/dev/null 2>&1; then "$@"; fi; }
 
 # For Cockpit

--- a/test/make-rpms
+++ b/test/make-rpms
@@ -75,22 +75,13 @@ EXTRA_FLAGS=${EXTRA_FLAGS:-}
 srpm=$("$make_srpm" "$@")
 rm -rf mock
 
-COCKPIT_DEPS_BASEURL=${COCKPIT_DEPS_BASEURL:=http://cockpit-project.github.io/cockpit-deps}
-
-# Create our custom config by adding the cockpit-deps repo
+# Create our custom config
 mkdir mock
 cp --preserve=timestamps /etc/mock/site-defaults.cfg mock/
 cp --preserve=timestamps /etc/mock/logging.ini mock/
 cp --preserve=timestamps /etc/mock/$os-$arch.cfg mock/$os-$arch-cockpit.cfg
 cat >>mock/$os-$arch-cockpit.cfg <<EOF
 config_opts['root'] = "$os-$arch-cockpit"
-config_opts['yum.conf'] += """
-[cockpit-deps]
-name=Unreleased Cockpit dependencies
-baseurl=${COCKPIT_DEPS_BASEURL}/$os/$arch
-enabled=1
-gpgcheck=0
-"""
 EOF
 touch -r /etc/mock/$os-$arch.cfg mock/$os-$arch-cockpit.cfg
 


### PR DESCRIPTION
With our use of Travis CI and inclusion in Atomic that horse
has left the barn. We're also buildable on other distros.

The upshot of this is that we have to be more careful with our
dependencies. This is expected as we mature.
