### PR TITLE
test-cgroupmonitor: Try to fix AddMatch() related critical in tests

### DIFF
--- a/src/daemon/test-cgroupmonitor.c
+++ b/src/daemon/test-cgroupmonitor.c
@@ -257,9 +257,14 @@ teardown (TestCase *tc,
   g_assert (tc->impl == NULL);
 
   g_test_dbus_down (tc->bus);
+  g_object_add_weak_pointer (G_OBJECT (tc->bus), (gpointer *)&tc->bus);
   g_object_unref (tc->bus);
+  g_assert (tc->bus == NULL);
 
   g_queue_free_full (tc->samples_received, (GDestroyNotify)g_variant_unref);
+
+  /* Wait for all updates to arrive asynchronously */
+  while (g_main_context_iteration (NULL, FALSE));
 }
 
 static void


### PR DESCRIPTION
Try to fix this:

```
==26704== 
==26704== Process terminating with default action of signal 5 (SIGTRAP)
==26704==    at 0x544AC13: g_logv (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0)
==26704==    by 0x544AD71: g_log (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0)
==26704==    by 0x4F01E55: g_dbus_connection_signal_subscribe (in /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.4000.0)
==26704==    by 0x4F0A9B2: ??? (in /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.4000.0)
==26704==    by 0x4F0B544: ??? (in /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.4000.0)
==26704==    by 0x4E6C5B0: g_async_initable_new_valist_async (in /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.4000.0)
==26704==    by 0x4E6C65A: g_async_initable_new_async (in /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.4000.0)
==26704==    by 0x40C45D: cockpit_multi_resource_monitor_proxy_new (cockpit-generated.c:8267)
==26704==    by 0x405A54: setup (test-cgroupmonitor.c:215)
==26704==    by 0x5467A86: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0)
==26704==    by 0x5467C55: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0)
==26704==    by 0x5467FAA: g_test_run_suite (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0)
==26704==    by 0x5467FE0: g_test_run (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0)
==26704==    by 0x4056DE: main (test-cgroupmonitor.c:457)
FAIL: test-cgroupmonitor 3 /cgroup-monitor/new-sample
```
