### PR TITLE
cockpit: Add cockpit_json_parse_object() method

### DIFF
--- a/src/agent/cockpitrestjson.c
+++ b/src/agent/cockpitrestjson.c
@@ -985,19 +985,13 @@ cockpit_rest_json_recv (CockpitChannel *channel,
                         GBytes *message)
 {
   CockpitRestJson *self = (CockpitRestJson *)channel;
+  JsonObject *object = NULL;
   GError *error = NULL;
-  JsonNode *node = NULL;
 
-  node = cockpit_json_parse_bytes (message, &error);
-  if (node)
-    {
-      if (json_node_get_node_type (node) != JSON_NODE_OBJECT)
-          g_set_error (&error, JSON_PARSER_ERROR, JSON_PARSER_ERROR_UNKNOWN, "Not an object");
-    }
-
+  object = cockpit_json_parse_bytes (message, &error);
   if (error == NULL)
     {
-      cockpit_rest_request_create (self, json_node_get_object (node));
+      cockpit_rest_request_create (self, object);
     }
   else
     {
@@ -1006,7 +1000,7 @@ cockpit_rest_json_recv (CockpitChannel *channel,
       g_error_free (error);
     }
 
-  json_node_free (node);
+  json_object_unref (object);
 }
 
 static void

--- a/src/agent/test-channel.c
+++ b/src/agent/test-channel.c
@@ -240,7 +240,8 @@ assert_bytes_eq_json_msg (const char *domain,
   gchar *escaped;
   gchar *msg;
 
-  node = cockpit_json_parse_bytes (bytes, &error);
+  node = cockpit_json_parse (g_bytes_get_data (bytes, NULL),
+                             g_bytes_get_size (bytes), &error);
   if (error)
     g_assertion_message_error (domain, file, line, func, "error", error, 0, 0);
   g_assert (node);

--- a/src/agent/test-restjson.c
+++ b/src/agent/test-restjson.c
@@ -124,7 +124,8 @@ mock_transport_send (CockpitTransport *transport,
 
   if (channel != 0)
     {
-      node = cockpit_json_parse_bytes (data, &error);
+      node = cockpit_json_parse (g_bytes_get_data (data, NULL),
+                                 g_bytes_get_size (data), &error);
       g_assert_no_error (error);
       g_assert (node);
       g_queue_push_tail (self->sent, node);

--- a/src/cockpit/cockpitjson.c
+++ b/src/cockpit/cockpitjson.c
@@ -457,7 +457,7 @@ cockpit_json_skip (const gchar *data,
  * Returns: (transfer full): the parsed node or %NULL
  */
 JsonNode *
-cockpit_json_parse (const char *data,
+cockpit_json_parse (const gchar *data,
                     gssize length,
                     GError **error)
 {
@@ -496,20 +496,62 @@ cockpit_json_parse (const char *data,
 }
 
 /**
+<<<<<<< HEAD
+=======
+ * cockpit_json_parse_object:
+ * @data: string data to parse
+ * @length: length of @data or -1
+ * @error: optional location to return an error
+ *
+ * Parses JSON GBytes into a JsonObject. This is a helper function
+ * combining cockpit_json_parse(), json_node_get_type() and
+ * json_node_get_object().
+ *
+ * Returns: (transfer full): the parsed object or %NULL
+ */
+JsonObject *
+cockpit_json_parse_object (const gchar *data,
+                           gssize length,
+                           GError **error)
+{
+  JsonNode *node;
+  JsonObject *object;
+
+  node = cockpit_json_parse (data, length, error);
+  if (!node)
+    return NULL;
+
+  if (json_node_get_node_type (node) != JSON_NODE_OBJECT)
+    {
+      object = NULL;
+      g_set_error (error, JSON_PARSER_ERROR, JSON_PARSER_ERROR_UNKNOWN, "Not a JSON object");
+    }
+  else
+    {
+      object = json_node_dup_object (node);
+    }
+
+  json_node_free (node);
+  return object;
+}
+
+/**
  * cockpit_json_parse_bytes:
  * @data: data to parse
  * @error: optional location to return an error
  *
- * Parses JSON GBytes into a JsonNode.
+ * Parses JSON GBytes into a JsonObject. This is a helper function
+ * combining cockpit_json_parse(), json_node_get_type() and
+ * json_node_get_object().
  *
- * Returns: (transfer full): the parsed node or %NULL
+ * Returns: (transfer full): the parsed object or %NULL
  */
-JsonNode *
+JsonObject *
 cockpit_json_parse_bytes (GBytes *data,
                           GError **error)
 {
   gsize length = g_bytes_get_size (data);
-  return cockpit_json_parse (g_bytes_get_data (data, NULL), length, error);
+  return cockpit_json_parse_object (g_bytes_get_data (data, NULL), length, error);
 }
 
 /**

--- a/src/cockpit/cockpitjson.h
+++ b/src/cockpit/cockpitjson.h
@@ -30,7 +30,11 @@ JsonNode *     cockpit_json_parse             (const char *data,
                                                gssize length,
                                                GError **error);
 
-JsonNode *     cockpit_json_parse_bytes       (GBytes *data,
+JsonObject *   cockpit_json_parse_object      (const gchar *data,
+                                               gssize length,
+                                               GError **error);
+
+JsonObject *   cockpit_json_parse_bytes       (GBytes *data,
                                                GError **error);
 
 gchar *        cockpit_json_write             (JsonNode *node,


### PR DESCRIPTION
And make cockpit_json_parse_bytes() return a JsonObject. It's by far
the most common situation that we're parsing and writing JsonObject
rather than individual JsonNode. So make those cases realy easy.

Related to #413
