### PR TITLE
daemon: Remove unused function in cgroup code

### DIFF
--- a/src/daemon/cgroup-show.c
+++ b/src/daemon/cgroup-show.c
@@ -399,9 +399,6 @@ static char *path_get_file_name(const char *p) {
         return (char*) p;
 }
 
-static inline const char *strna(const char *s) {
-        return s ? s : "n/a";
-}
 #define streq(a,b) (strcmp((a),(b)) == 0)
 
 


### PR DESCRIPTION
This seemed to start causing problems with Travis CI.
