### PR TITLE
Use port 1001 by default to connect to cockpit-ws

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -72,7 +72,7 @@ systemd:
 
     # systemctl start cockpit.socket
 
-This will cause systemd to listen on port 21064 and start cockpit-ws
+This will cause systemd to listen on port 1001 and start cockpit-ws
 when someone connects to it.  Cockpit-ws will in turn activate
 cockpitd via D-Bus when someone logs in successfully.
 
@@ -80,13 +80,13 @@ To run Cockpit without systemd, start the cockpit-ws daemon manually:
 
     # /usr/libexec/cockpit-ws
 
-Then you can connect to port 21064 of the virtual machine.  You might
+Then you can connect to port 1001 of the virtual machine.  You might
 need to open the firewall for it.  On Fedora:
 
-    # firewall-cmd --add-port 21064/tcp
-    # firewall-cmd --permanent --add-port 21064/tcp
+    # firewall-cmd --add-port 1001/tcp
+    # firewall-cmd --permanent --add-port 1001/tcp
 
-Point your browser to `https://IP-OR-NAME-OF-YOUR-VM:21064`
+Point your browser to `https://IP-OR-NAME-OF-YOUR-VM:1001`
 
 and Cockpit should load after confirming the self-signed certificate.
 Log in as root with the normal root password (of the virtual machine).

--- a/data/cockpit-testing.socket
+++ b/data/cockpit-testing.socket
@@ -4,7 +4,7 @@ Documentation=man:cockpit-ws(8)
 Conflicts=cockpit.socket
 
 [Socket]
-ListenStream=21064
+ListenStream=1001
 
 [Install]
 WantedBy=sockets.target

--- a/data/cockpit.socket
+++ b/data/cockpit.socket
@@ -3,7 +3,7 @@ Description=Cockpit Web Server Socket
 Documentation=man:cockpit-ws(8)
 
 [Socket]
-ListenStream=21064
+ListenStream=1001
 
 [Install]
 WantedBy=sockets.target

--- a/doc/cockpit-transport.svg
+++ b/doc/cockpit-transport.svg
@@ -1405,7 +1405,7 @@
          x="58.464287"
          sodipodi:role="line"><tspan
    style="font-weight:bold"
-   id="tspan4113">WebSocket</tspan>: port 21064</tspan><tspan
+   id="tspan4113">WebSocket</tspan>: port 1001</tspan><tspan
          y="1017.4403"
          x="58.464287"
          sodipodi:role="line"

--- a/doc/embed-example.html
+++ b/doc/embed-example.html
@@ -6,6 +6,6 @@
     This is Cockpit.
     <br/>
     <iframe width="800px" height="600px"
-            src="https://sunflower:21064/#server"/>
+            src="https://sunflower:1001/#server"/>
   </body>
 </html>

--- a/doc/embed.md
+++ b/doc/embed.md
@@ -15,4 +15,4 @@ way to navigate to a different machine.
 
 To achieve this, use a URL like this:
 
-  https://IP:21064/#server
+  https://IP:1001/#server

--- a/doc/man/cockpit-ws.xml
+++ b/doc/man/cockpit-ws.xml
@@ -105,7 +105,7 @@
         <term><option>--port</option> <replaceable>PORT</replaceable></term>
         <listitem>
           <para>
-            Serve HTTP requests <replaceable>PORT</replaceable> instead of port 21064.
+            Serve HTTP requests <replaceable>PORT</replaceable> instead of port 1001.
           </para>
         </listitem>
       </varlistentry>

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -35,7 +35,7 @@
 
 /* ---------------------------------------------------------------------------------------------------- */
 
-static gint      opt_port         = 21064;
+static gint      opt_port         = 1001;
 static gchar   **opt_http_roots   = NULL;
 static gboolean  opt_no_tls       = FALSE;
 static gboolean  opt_disable_auth = FALSE;
@@ -43,7 +43,7 @@ static gboolean  opt_debug = FALSE;
 static gchar    *opt_agent_program;
 
 static GOptionEntry cmd_entries[] = {
-  {"port", 'p', 0, G_OPTION_ARG_INT, &opt_port, "Local port to bind to (21064 if unset)", NULL},
+  {"port", 'p', 0, G_OPTION_ARG_INT, &opt_port, "Local port to bind to (1001 if unset)", NULL},
   {"http-root", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_http_roots, "Path to serve HTTP GET requests from", NULL},
   {"no-tls", 0, 0, G_OPTION_ARG_NONE, &opt_no_tls, "Don't use TLS", NULL},
   {"debug", 'd', 0, G_OPTION_ARG_NONE, &opt_debug, "Debug mode: log messages to output", NULL},

--- a/test/check-connection
+++ b/test/check-connection
@@ -54,7 +54,7 @@ class TestConnection(MachineCase):
         b.set_val("#login-password-input", "foobar")
 
         # severe the connection on the login page
-        m.execute("iptables -I INPUT 1 -p tcp --dport 21064 -j REJECT")
+        m.execute("iptables -I INPUT 1 -p tcp --dport 1001 -j REJECT")
         b.click('#login-button')
         with b.wait_timeout(20):
             b.wait_text_not('#login-error-message', "")
@@ -63,7 +63,7 @@ class TestConnection(MachineCase):
         b.wait_page("server")
 
         # severe the connection on the server page
-        m.execute("iptables -I INPUT 1 -p tcp --dport 21064 -j REJECT")
+	m.execute("iptables -I INPUT 1 -p tcp --dport 1001 -j REJECT")
         with b.wait_timeout(60):
             b.wait_popup("disconnected")
         b.wait_in_text('#disconnected-error', "Connection has timed out.")

--- a/test/check-login
+++ b/test/check-login
@@ -83,7 +83,7 @@ class TestLogin(MachineCase):
 
     def curl_post(self, url, data):
         return subprocess.check_output(['/usr/bin/curl', '-s', '-k',  '-D', '-',
-                                    'http://%s:21064%s' % (self.machine.address, url),
+                                    'http://%s:1001%s' % (self.machine.address, url),
                                     '--data-binary', data ])
 
     def curl_post_code(self, url, data):

--- a/test/cockpit.setup
+++ b/test/cockpit.setup
@@ -18,7 +18,7 @@ rm -rf /etc/sysconfig/iptables
 maybe() { if type "$1" >/dev/null 2>&1; then "$@"; fi; }
 
 # For Cockpit
-maybe firewall-cmd --permanent --add-port 21064/tcp
+maybe firewall-cmd --permanent --add-port 1001/tcp
 
 # For the D-Bus test server
 maybe firewall-cmd --permanent --add-port 8765/tcp

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -77,7 +77,7 @@ class Browser:
     def title(self):
         return self.phantom.do('return document.title');
 
-    def open(self, page=None, url=None, port=21064):
+    def open(self, page=None, url=None, port=1001):
         """
         Load a page into the browser.
 


### PR DESCRIPTION
Port 1001 is so much easier to type and remember.  We still keep
listening on 21064 for now.
