### PR TITLE
ws: Fix use of Secure https only cookies

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -377,7 +377,7 @@ base64_decode_string (const char *enc)
 CockpitCreds *
 cockpit_auth_check_userpass (CockpitAuth *self,
                              const char *userpass,
-                             gboolean secure_req,
+                             gboolean force_secure,
                              GHashTable *out_headers,
                              GError **error)
 {
@@ -401,7 +401,7 @@ cockpit_auth_check_userpass (CockpitAuth *self,
     {
       cookie_b64 = g_base64_encode ((guint8 *)cookie, strlen (cookie));
       header = g_strdup_printf ("CockpitAuth=%s; Path=/; Expires=Wed, 13-Jan-2021 22:23:01 GMT;%s HttpOnly",
-                                cookie_b64, secure_req ? " Secure;" : "");
+                                cookie_b64, force_secure ? " Secure;" : "");
 
       g_hash_table_insert (out_headers, g_strdup ("Set-Cookie"), header);
     }

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -159,7 +159,7 @@ cockpit_handler_login (CockpitWebServer *server,
         goto out;
 
       creds = cockpit_auth_check_userpass (ws->auth, request_body,
-                                           ws->certificate != NULL,
+                                           !G_IS_SOCKET_CONNECTION (io_stream),
                                            out_headers, &error);
       if (creds == NULL)
         goto out;
@@ -226,7 +226,7 @@ cockpit_handler_logout (CockpitWebServer *server,
     "<body>Logged out</body></html>";
 
   cookie = g_strdup_printf ("CockpitAuth=blank; Path=/; Expires=Wed, 13-Jan-2021 22:23:01 GMT;%s HttpOnly\r\n",
-                            ws->certificate != NULL ? " Secure;" : "");
+                            !G_IS_SOCKET_CONNECTION (io_stream) ? " Secure;" : "");
 
   out_headers = cockpit_web_server_new_table ();
   g_hash_table_insert (out_headers, g_strdup ("Set-Cookie"), cookie);

--- a/src/ws/cockpithandlers.h
+++ b/src/ws/cockpithandlers.h
@@ -24,7 +24,6 @@
 #include "cockpitwebserver.h"
 
 typedef struct {
-  GTlsCertificate *certificate;
   CockpitAuth *auth;
 } CockpitHandlerData;
 

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -237,6 +237,7 @@ main (int argc,
   CockpitWebServer *server = NULL;
   GOptionContext *context;
   CockpitHandlerData data;
+  GTlsCertificate *certificate = NULL;
   GError *local_error = NULL;
   GError **error = &local_error;
   GMainLoop *loop;
@@ -270,7 +271,7 @@ main (int argc,
     }
   else
     {
-      if (!load_cert (&data.certificate, error))
+      if (!load_cert (&certificate, error))
         goto out;
     }
 
@@ -281,7 +282,7 @@ main (int argc,
     cockpit_ws_agent_program = opt_agent_program;
 
   server = cockpit_web_server_new (opt_port,
-                                   data.certificate,
+                                   certificate,
                                    (const gchar **)opt_http_roots,
                                    NULL,
                                    error);
@@ -329,7 +330,7 @@ out:
     }
   g_clear_object (&server);
   g_clear_object (&data.auth);
-  g_clear_object (&data.certificate);
+  g_clear_object (&certificate);
   return ret;
 }
 

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -253,6 +253,7 @@ test_login_post_accept (Test *test,
 
   output = output_as_string (test);
   cockpit_assert_strmatch (output, "HTTP/1.1 200 OK\r\n*");
+  cockpit_assert_strmatch (output, "*Secure; *");
 
   /* Check that returned cookie that works */
   headers = split_headers (output);
@@ -308,7 +309,7 @@ test_logout (Test *test,
   g_assert (ret == TRUE);
 
   output = output_as_string (test);
-  cockpit_assert_strmatch (output, "HTTP/1.1 200 OK\r\n*Set-Cookie: CockpitAuth=blank;*Logged out*");
+  cockpit_assert_strmatch (output, "HTTP/1.1 200 OK\r\n*Set-Cookie: CockpitAuth=blank;*Secure*Logged out*");
 }
 
 int


### PR DESCRIPTION
We now have various criteria on whether HTTPS is in use, not just
just whether a certificate is present or not. So make the 'Secure'
flag of cookies track those criteria, and just check if the
connection in use is a TLS connection or not.

In addition fail safe, so and don't use G_IS_TLS_CONNECTION() but
rather the inverse, and rename things, add tests, so if things
change in our TLS implementation this will be caught.
