### PR TITLE
ws: Make the core cockpitwebsocket code a real object

### DIFF
--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -6,10 +6,11 @@ libcockpit_ws_a_SOURCES = \
 	src/ws/cockpitws.h				\
 	src/ws/cockpitwstypes.h	\
 	src/ws/cockpitwebserver.h		src/ws/cockpitwebserver.c		\
-	src/ws/cockpitwebsocket.h 	src/ws/cockpitwebsocket.c		\
 	src/ws/cockpithandlers.h	src/ws/cockpithandlers.c	\
 	src/ws/cockpitauth.h		src/ws/cockpitauth.c		\
 	src/ws/cockpitcreds.h src/ws/cockpitcreds.c \
+	src/ws/cockpitwebservice.h \
+	src/ws/cockpitwebservice.c \
 	src/ws/cockpitsshtransport.h \
 	src/ws/cockpitsshtransport.c \
 	$(NULL)

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include "cockpithandlers.h"
+#include "cockpitwebservice.h"
 #include "cockpitws.h"
 
 #include "cockpit/cockpitjson.h"
@@ -67,7 +68,7 @@ cockpit_handler_socket (CockpitWebServer *server,
   g_filter_input_stream_set_close_base_stream (G_FILTER_INPUT_STREAM (in), FALSE);
   g_filter_output_stream_set_close_base_stream (G_FILTER_OUTPUT_STREAM (out), FALSE);
 
-  cockpit_web_socket_serve_dbus (server, io_stream, headers, buffer, ws->auth);
+  cockpit_web_service_socket (io_stream, headers, buffer, ws->auth);
 
   g_byte_array_unref (buffer);
   return TRUE;

--- a/src/ws/cockpitwebservice.h
+++ b/src/ws/cockpitwebservice.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of Cockpit.
  *
- * Copyright (C) 2013 Red Hat, Inc.
+ * Copyright (C) 2013-2014 Red Hat, Inc.
  *
  * Cockpit is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COCKPIT_WEB_SOCKET_H__
-#define __COCKPIT_WEB_SOCKET_H__
+#ifndef __COCKPIT_WEB_SERVICE_H__
+#define __COCKPIT_WEB_SERVICE_H__
 
 #include "cockpitwstypes.h"
 
@@ -26,12 +26,18 @@
 
 G_BEGIN_DECLS
 
-void         cockpit_web_socket_serve_dbus   (CockpitWebServer *server,
-                                              GIOStream *io_stream,
+#define COCKPIT_TYPE_WEB_SERVICE         (cockpit_web_service_get_type ())
+#define COCKPIT_WEB_SERVICE(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_WEB_SERVICE, CockpitWebService))
+
+typedef struct _CockpitWebService   CockpitWebService;
+
+GType        cockpit_web_service_get_type    (void);
+
+void         cockpit_web_service_socket      (GIOStream *io_stream,
                                               GHashTable *headers,
                                               GByteArray *input_buffer,
                                               CockpitAuth *auth);
 
 G_END_DECLS
 
-#endif /* __COCKPIT_WEB_SOCKET_H__ */
+#endif /* __COCKPIT_WEB_SERVICE_H__ */

--- a/src/ws/cockpitws.h
+++ b/src/ws/cockpitws.h
@@ -26,7 +26,6 @@ G_BEGIN_DECLS
 
 #include <cockpitwstypes.h>
 #include <cockpitwebserver.h>
-#include <cockpitwebsocket.h>
 #include <cockpitauth.h>
 
 /* Some tunables that can be set from tests. See cockpitwebsocket.c */

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -29,7 +29,7 @@
 
 #include "cockpitws.h"
 #include "cockpitwebserver.h"
-#include "cockpitwebsocket.h"
+#include "cockpitwebservice.h"
 
 static gboolean tap_mode = FALSE;
 static GMainLoop *loop = NULL;
@@ -83,7 +83,7 @@ on_handle_resource_socket (CockpitWebServer *server,
   g_filter_input_stream_set_close_base_stream (G_FILTER_INPUT_STREAM (in), FALSE);
   g_filter_output_stream_set_close_base_stream (G_FILTER_OUTPUT_STREAM (out), FALSE);
 
-  cockpit_web_socket_serve_dbus (server, io_stream, headers, buffer, auth);
+  cockpit_web_service_socket (io_stream, headers, buffer, auth);
 
   g_byte_array_unref (buffer);
   return TRUE;

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -21,7 +21,7 @@
 
 #include "mock-auth.h"
 #include "cockpitws.h"
-#include "cockpitwebsocket.h"
+#include "cockpitwebservice.h"
 #include "cockpitwebserver.h"
 #include "cockpit/cockpittransport.h"
 #include "cockpit/cockpitjson.h"
@@ -298,7 +298,7 @@ serve_thread_func (gpointer data)
   g_filter_input_stream_set_close_base_stream (G_FILTER_INPUT_STREAM (bis), FALSE);
 
   /*
-   * Parse the headers, as that's what cockpit_web_socket_serve_dbus()
+   * Parse the headers, as that's what cockpit_web_service_socket()
    * expects its caller to do.
    */
   g_buffered_input_stream_fill (bis, 1024, NULL, &error);
@@ -320,8 +320,7 @@ serve_thread_func (gpointer data)
   buffer = g_buffered_input_stream_peek_buffer (bis, &count);
   g_byte_array_append (consumed, (guchar *)buffer, count);
 
-  cockpit_web_socket_serve_dbus (test->web_server,
-                              test->io_b, headers,
+  cockpit_web_service_socket (test->io_b, headers,
                               consumed, test->auth);
 
   g_io_stream_close (test->io_b, NULL, &error);


### PR DESCRIPTION
This will allow us to do things like have it be reference counted
and so on.

Call it CockpitWebService since it's really the core of the
web service.
