### PR TITLE
tools: Don't bail out of QUnit fails to start in a test

### DIFF
--- a/tools/qunit-config.js
+++ b/tools/qunit-config.js
@@ -75,7 +75,7 @@ QUnit.done(function() {
 });
 window.setTimeout(function() {
     if (!qunit_started) {
-        console.log("Bail out! QUnit not started by test");
-        console.log("qunit-tap-done");
+        console.log("QUnit not started by test");
+        console.log("qunit-tap-error");
     }
-}, 1000);
+}, 5000);

--- a/tools/tap-phantom
+++ b/tools/tap-phantom
@@ -59,6 +59,9 @@ page.onConsoleMessage = function(msg, lineNum, sourceId) {
     if (msg === "qunit-tap-done")
         setTimeout(function() { phantom.exit(0); }, 0);
 
+    else if (msg == "qunit-tap-error")
+        setTimeout(function() { phantom.exit(1); }, 0);
+
     /* TAP lines go to stdout */
     else if (msg.match(/^ok [0-9]+/i) ||
              msg.match(/^not ok [0-9]+/i) ||
@@ -95,8 +98,8 @@ page.open(url, function(status) {
 
     page.evaluate(function() {
         if (typeof qunit_included === "undefined") {
-            console.log("Bail out! QUnit not properly included in test case");
-            console.log("qunit-tap-done");
+            console.log("QUnit not properly included in test case");
+            phantom.exit(1);
         }
     });
 });


### PR DESCRIPTION
This is usually due to a top level failure loading the javascript
of the test or something like that.
