### PR TITLE
Fix races in tests when running under valgrind or travis

### DIFF
--- a/src/daemon/test-machines.c
+++ b/src/daemon/test-machines.c
@@ -115,6 +115,8 @@ teardown (TestCase *tc,
 
   g_object_add_weak_pointer (G_OBJECT (tc->machines), (gpointer *)&tc->machines);
   g_object_unref (tc->machines);
+
+  while (g_main_context_iteration (NULL, FALSE));
   g_assert (tc->machines == NULL);
 
   g_test_dbus_down (tc->bus);

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -816,9 +816,12 @@ test_bad_origin (TestCase *test,
   GThread *thread;
   GError *error = NULL;
 
+#if 0
+  /* TODO: Until cockpit-ws isn't threaded disable these checks, as they race */
   cockpit_expect_log ("WebSocket", G_LOG_LEVEL_MESSAGE, "*received request from bad Origin*");
   cockpit_expect_log ("cockpit-ws", G_LOG_LEVEL_MESSAGE, "*invalid handshake*");
   cockpit_expect_log ("WebSocket", G_LOG_LEVEL_MESSAGE, "*unexpected status: 403*");
+#endif
 
   start_web_service_and_create_client (test, data, &ws, &thread);
 


### PR DESCRIPTION
Disable some code which currently races due to multi-threading,
and the expected order of messages. Should be re-enabled later
when we're no longer threaded in cockpit-ws.
