### PR TITLE
Use strings as channel identifiers instead of numbers

### DIFF
--- a/src/agent/cockpitchannel.h
+++ b/src/agent/cockpitchannel.h
@@ -64,11 +64,13 @@ struct _CockpitChannelClass
 GType               cockpit_channel_get_type          (void) G_GNUC_CONST;
 
 CockpitChannel *    cockpit_channel_open              (CockpitTransport *transport,
-                                                       guint channel,
+                                                       const gchar *id,
                                                        JsonObject *options);
 
 void                cockpit_channel_close             (CockpitChannel *self,
                                                        const gchar *reason);
+
+const gchar *       cockpit_channel_get_id            (CockpitChannel *self);
 
 /* Used by implementations */
 

--- a/src/agent/cockpitdbusjson.c
+++ b/src/agent/cockpitdbusjson.c
@@ -1257,7 +1257,7 @@ cockpit_dbus_json_class_init (CockpitDBusJsonClass *klass)
 /**
  * cockpit_dbus_json_open:
  * @transport: transport to send messages on
- * @number: the channel number
+ * @channel_id: the channel id
  * @dbus_service: the DBus service name to talk to
  * @dbus_path: the o.f.D.ObjectManager path
  *
@@ -1270,12 +1270,14 @@ cockpit_dbus_json_class_init (CockpitDBusJsonClass *klass)
  */
 CockpitChannel *
 cockpit_dbus_json_open (CockpitTransport *transport,
-                        guint number,
+                        const gchar *channel_id,
                         const gchar *dbus_service,
                         const gchar *dbus_path)
 {
   CockpitChannel *channel;
   JsonObject *options;
+
+  g_return_val_if_fail (channel_id != NULL, NULL);
 
   options = json_object_new ();
   json_object_set_string_member (options, "service", dbus_service);
@@ -1284,7 +1286,7 @@ cockpit_dbus_json_open (CockpitTransport *transport,
 
   channel = g_object_new (COCKPIT_TYPE_DBUS_JSON,
                           "transport", transport,
-                          "channel", number,
+                          "id", channel_id,
                           "options", options,
                           NULL);
 

--- a/src/agent/cockpitdbusjson.h
+++ b/src/agent/cockpitdbusjson.h
@@ -31,7 +31,7 @@ G_BEGIN_DECLS
 GType              cockpit_dbus_json_get_type   (void) G_GNUC_CONST;
 
 CockpitChannel *   cockpit_dbus_json_open       (CockpitTransport *transport,
-                                                 guint channel,
+                                                 const gchar *channel_id,
                                                  const gchar *dbus_service,
                                                  const gchar *dbus_path);
 

--- a/src/agent/cockpitrestjson.c
+++ b/src/agent/cockpitrestjson.c
@@ -1183,7 +1183,7 @@ cockpit_rest_json_class_init (CockpitRestJsonClass *klass)
 /**
  * cockpit_rest_json_open:
  * @transport: the transport to send/receive messages on
- * @number: the channel number
+ * @channel_id: the channel id
  * @unix_path: the UNIX socket path to communicate with
  *
  * This function is mainly used by tests. The usual way
@@ -1193,7 +1193,7 @@ cockpit_rest_json_class_init (CockpitRestJsonClass *klass)
  */
 CockpitChannel *
 cockpit_rest_json_open (CockpitTransport *transport,
-                        guint number,
+                        const gchar *channel_id,
                         const gchar *unix_path)
 {
   CockpitChannel *channel;
@@ -1205,7 +1205,7 @@ cockpit_rest_json_open (CockpitTransport *transport,
 
   channel = g_object_new (COCKPIT_TYPE_REST_JSON,
                           "transport", transport,
-                          "channel", number,
+                          "id", channel_id,
                           "options", options,
                           NULL);
 

--- a/src/agent/cockpitrestjson.h
+++ b/src/agent/cockpitrestjson.h
@@ -31,7 +31,7 @@ G_BEGIN_DECLS
 GType              cockpit_rest_json_get_type       (void) G_GNUC_CONST;
 
 CockpitChannel *   cockpit_rest_json_open           (CockpitTransport *transport,
-                                                     guint channel,
+                                                     const gchar *channel_id,
                                                      const gchar *unix_path);
 
 #endif /* COCKPIT_REST_JSON_H__ */

--- a/src/agent/cockpittextstream.c
+++ b/src/agent/cockpittextstream.c
@@ -289,7 +289,7 @@ cockpit_text_stream_class_init (CockpitTextStreamClass *klass)
 /**
  * cockpit_text_stream_open:
  * @transport: the transport to send/receive messages on
- * @number: the channel number
+ * @channel_id: the channel id
  * @unix_path: the UNIX socket path to communicate with
  *
  * This function is mainly used by tests. The usual way
@@ -299,11 +299,13 @@ cockpit_text_stream_class_init (CockpitTextStreamClass *klass)
  */
 CockpitChannel *
 cockpit_text_stream_open (CockpitTransport *transport,
-                          guint number,
+                          const gchar *channel_id,
                           const gchar *unix_path)
 {
   CockpitChannel *channel;
   JsonObject *options;
+
+  g_return_val_if_fail (channel_id != NULL, NULL);
 
   options = json_object_new ();
   json_object_set_string_member (options, "unix", unix_path);
@@ -311,7 +313,7 @@ cockpit_text_stream_open (CockpitTransport *transport,
 
   channel = g_object_new (COCKPIT_TYPE_TEXT_STREAM,
                           "transport", transport,
-                          "channel", number,
+                          "id", channel_id,
                           "options", options,
                           NULL);
 

--- a/src/agent/cockpittextstream.h
+++ b/src/agent/cockpittextstream.h
@@ -31,7 +31,7 @@ G_BEGIN_DECLS
 GType              cockpit_text_stream_get_type     (void) G_GNUC_CONST;
 
 CockpitChannel *   cockpit_text_stream_open         (CockpitTransport *transport,
-                                                     guint channel,
+                                                     const gchar *channel_id,
                                                      const gchar *unix_path);
 
 #endif /* COCKPIT_TEXT_STREAM_H__ */

--- a/src/agent/test-dbusjson.c
+++ b/src/agent/test-dbusjson.c
@@ -60,7 +60,7 @@ dbus_server_thread (gpointer data)
 
   transport = cockpit_pipe_transport_new_fds ("mock", fd, fd);
 
-  channel = cockpit_dbus_json_open (transport, 444,
+  channel = cockpit_dbus_json_open (transport, "444",
                                     "com.redhat.Cockpit.DBusTests.Test", "/otree");
   g_signal_connect (channel, "closed", G_CALLBACK (on_closed_set_flag), &closed);
 

--- a/src/agent/test-restjson.c
+++ b/src/agent/test-restjson.c
@@ -101,14 +101,14 @@ mock_transport_finalize (GObject *object)
 
 static void
 mock_transport_send (CockpitTransport *transport,
-                     guint channel,
+                     const gchar *channel_id,
                      GBytes *data)
 {
   MockTransport *self = (MockTransport *)transport;
   GError *error = NULL;
   JsonNode *node;
 
-  if (channel != 0)
+  if (channel_id)
     {
       node = cockpit_json_parse (g_bytes_get_data (data, NULL),
                                  g_bytes_get_size (data), &error);
@@ -544,7 +544,7 @@ setup (TestCase *tc,
   tc->channel = g_object_new (COCKPIT_TYPE_REST_JSON,
                               "options", tc->options,
                               "transport", tc->transport,
-                              "channel", 888,
+                              "id", "888",
                               NULL);
   g_signal_connect (tc->channel, "closed", G_CALLBACK (on_closed_get_problem), &tc->channel_problem);
 }
@@ -575,7 +575,7 @@ send_request (TestCase *tc,
   GBytes *sent;
 
   sent = g_bytes_new (string, strlen (string));
-  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), 888, sent);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), "888", sent);
   g_bytes_unref (sent);
 }
 
@@ -590,7 +590,7 @@ simple_request (TestCase *tc,
 
   data = g_strdup_printf ("{\"method\":\"%s\",\"path\":\"%s\",\"cookie\":%d}", method, path, cookie);
   sent = g_bytes_new_take (data, strlen (data));
-  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), 888, sent);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), "888", sent);
   g_bytes_unref (sent);
 
   return cookie;
@@ -604,7 +604,7 @@ cancel_request (TestCase *tc, gint cookie)
 
   data = g_strdup_printf ("{\"cookie\":%d}", cookie);
   sent = g_bytes_new_take (data, strlen (data));
-  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), 888, sent);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), "888", sent);
   g_bytes_unref (sent);
 }
 
@@ -1181,7 +1181,7 @@ test_bad_unix_socket (void)
   channel = g_object_new (COCKPIT_TYPE_REST_JSON,
                           "options", options,
                           "transport", transport,
-                          "channel", 888,
+                          "id", "888",
                           NULL);
   json_object_unref (options);
 
@@ -1192,7 +1192,7 @@ test_bad_unix_socket (void)
     {
       string = g_strdup_printf ("{ \"cookie\": %d, \"method\": \"GET\", \"path\": \"/bad-unix\" }", i);
       sent = g_bytes_new_take (string, strlen (string));
-      cockpit_transport_emit_recv (COCKPIT_TRANSPORT (transport), 888, sent);
+      cockpit_transport_emit_recv (COCKPIT_TRANSPORT (transport), "888", sent);
       g_bytes_unref (sent);
     }
 

--- a/src/cockpit/cockpitpipetransport.c
+++ b/src/cockpit/cockpitpipetransport.c
@@ -77,7 +77,7 @@ on_pipe_read (CockpitPipe *pipe,
   CockpitPipeTransport *self = COCKPIT_PIPE_TRANSPORT (user_data);
   GBytes *message;
   GBytes *payload;
-  guint channel;
+  gchar *channel;
   guint32 size;
 
   for (;;)
@@ -104,6 +104,7 @@ on_pipe_read (CockpitPipe *pipe,
           g_debug ("%s: received a %d byte payload", self->name, (int)size);
           cockpit_transport_emit_recv ((CockpitTransport *)self, channel, payload);
           g_bytes_unref (payload);
+          g_free (channel);
         }
       g_bytes_unref (message);
     }
@@ -236,7 +237,7 @@ cockpit_pipe_transport_finalize (GObject *object)
 
 static void
 cockpit_pipe_transport_send (CockpitTransport *transport,
-                             guint channel,
+                             const gchar *channel_id,
                              GBytes *payload)
 {
   CockpitPipeTransport *self = COCKPIT_PIPE_TRANSPORT (transport);
@@ -245,7 +246,7 @@ cockpit_pipe_transport_send (CockpitTransport *transport,
   gsize prefix_len;
   guint32 size;
 
-  prefix_str = g_strdup_printf ("xxxx%u\n", channel);
+  prefix_str = g_strdup_printf ("xxxx%s\n", channel_id ? channel_id : "");
   prefix_len = strlen (prefix_str);
 
   /* See doc/protocol.md */

--- a/src/cockpit/cockpittransport.h
+++ b/src/cockpit/cockpittransport.h
@@ -49,12 +49,12 @@ struct _CockpitTransportClass
    * Fired when the transport recieves a new message.
    */
   gboolean    (* recv)        (CockpitTransport *transport,
-                               guint channel,
+                               const gchar *channel,
                                GBytes *data);
 
   gboolean    (* control)     (CockpitTransport *transport,
                                const char *command,
-                               guint channel,
+                               const gchar *channel,
                                JsonObject *options);
 
   void        (* closed)      (CockpitTransport *transport,
@@ -66,7 +66,7 @@ struct _CockpitTransportClass
    * Called when transport should queue a new message to send.
    */
   void        (* send)        (CockpitTransport *transport,
-                               guint channel,
+                               const gchar *channel,
                                GBytes *data);
 
   void        (* close)       (CockpitTransport *transport,
@@ -76,25 +76,25 @@ struct _CockpitTransportClass
 GType       cockpit_transport_get_type       (void) G_GNUC_CONST;
 
 void        cockpit_transport_send           (CockpitTransport *transport,
-                                              guint channel,
+                                              const gchar *channel,
                                               GBytes *data);
 
 void        cockpit_transport_close          (CockpitTransport *transport,
                                               const gchar *problem);
 
 void        cockpit_transport_emit_recv      (CockpitTransport *transport,
-                                              guint channel,
+                                              const gchar *channel,
                                               GBytes *data);
 
 void        cockpit_transport_emit_closed    (CockpitTransport *transport,
                                               const gchar *problem);
 
 GBytes *    cockpit_transport_parse_frame    (GBytes *message,
-                                              guint *channel);
+                                              gchar **channel);
 
 gboolean    cockpit_transport_parse_command  (GBytes *payload,
                                               const gchar **command,
-                                              guint *channel,
+                                              const gchar **channel,
                                               JsonObject **options);
 
 G_END_DECLS

--- a/src/web/test-chan.html
+++ b/src/web/test-chan.html
@@ -88,7 +88,7 @@ function MockWebSocket(url, protocol) {
         var pos = data.indexOf("\n");
         if (pos == -1)
             throw "Invalid frame sent to WebSocket: " + data;
-        var channel = parseInt(data.substring(0, pos), 10);
+        var channel = data.substring(0, pos);
         var payload = data.substring(pos + 1);
         window.setTimeout(function() { $(mock).triggerHandler("recv", [channel, payload]); }, 5);
     };
@@ -141,7 +141,7 @@ test("public api", function() {
     var channel = new Channel({ "host": "host.example.com" });
     equal(typeof channel, "object", "Channel() constructor");
     equal(channel.options.host, "host.example.com", "channel.options is dict");
-    equal(typeof channel.number, "number", "channel.number is valid");
+    equal(typeof channel.id, "string", "channel.id is valid");
     ok(channel.toString().indexOf("host.example.com") > 0, "channel.toString()");
     equal(typeof channel.send, "function", "channel.send() is a function");
     equal(typeof channel.close, "function", "channel.close() is a function");
@@ -158,11 +158,11 @@ asyncTest("open channel", function() {
         ok(true, "websocket connected");
     });
     $(mock_peer).on("recv", function(event, chan, payload) {
-        strictEqual(chan, 0, "open: sent with zero channel");
+        strictEqual(chan, "", "open: sent with empty channel");
         var command = JSON.parse(payload);
         equal(typeof command, "object", "open: valid json");
         equal(command.command, "open", "open: right command");
-        strictEqual(command.channel, channel.number, "open: contains right channel");
+        strictEqual(command.channel, channel.id, "open: contains right channel");
         equal(command.host, "scruffy", "open: host as expected");
         start();
     });
@@ -175,7 +175,7 @@ test("multiple", function() {
     var transport = Channel.transport;
 
     var channelb = new Channel({ "host": "amy" });
-    notStrictEqual(channel.number, channelb.number, "mulitple: channels have different numbers");
+    notStrictEqual(channel.id, channelb.id, "mulitple: channels have different ids");
     strictEqual(Channel.transport, transport, "multiple: channels share a transport");
 });
 
@@ -188,9 +188,9 @@ asyncTest("send message", function() {
     });
     $(mock_peer).on("recv", function(event, chan, payload) {
         /* Ignore the open message */
-        if (chan == 0)
+        if (!chan)
             return;
-        strictEqual(chan, channel.number, "send: sent with correct channel");
+        strictEqual(chan, channel.id, "send: sent with correct channel");
         equal(payload, "Scruffy gonna die the way he lived", "send: sent the right payload");
         start();
     });
@@ -225,7 +225,7 @@ asyncTest("receive message", function() {
         start();
     });
 
-    mock_peer.send(channel.number, "Oh, marrrrmalade!");
+    mock_peer.send(channel.id, "Oh, marrrrmalade!");
 });
 
 asyncTest("close channel", function() {
@@ -237,7 +237,7 @@ asyncTest("close channel", function() {
         if (cmd.command == "open")
             return; /* ignore the open command */
         equal(cmd.command, "close", "close: sent close command");
-        strictEqual(cmd.channel, channel.number, "close: correct channel");
+        strictEqual(cmd.channel, channel.id, "close: correct channel");
         start();
     });
     $(channel).on("close", function(event, options) {
@@ -286,11 +286,11 @@ asyncTest("close peer", function() {
 
     var cmd = {
         "command": "close",
-        "channel": channel.number,
+        "channel": channel.id,
         "reason" : "marmalade",
         "extra": 5
     };
-    mock_peer.send(0, JSON.stringify(cmd));
+    mock_peer.send("", JSON.stringify(cmd));
 });
 
 asyncTest("close broadcast", function() {
@@ -318,7 +318,7 @@ asyncTest("close broadcast", function() {
         /* no channel */
         "reason" : "pizzazz"
     };
-    mock_peer.send(0, JSON.stringify(cmd));
+    mock_peer.send("", JSON.stringify(cmd));
 });
 
 asyncTest("close socket", function() {

--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -716,7 +716,7 @@ drain_buffer (CockpitSshTransport *self)
 {
   GBytes *message;
   GBytes *payload;
-  guint channel;
+  gchar *channel;
   guint32 size;
 
   for (;;)
@@ -744,6 +744,7 @@ drain_buffer (CockpitSshTransport *self)
           g_debug ("%s: received a %d byte payload", self->logname, (int)g_bytes_get_size (payload));
           cockpit_transport_emit_recv ((CockpitTransport *)self, channel, payload);
           g_bytes_unref (payload);
+          g_free (channel);
         }
       g_bytes_unref (message);
     }
@@ -1183,7 +1184,7 @@ cockpit_ssh_transport_finalize (GObject *object)
 
 static void
 cockpit_ssh_transport_send (CockpitTransport *transport,
-                            guint channel,
+                            const gchar *channel,
                             GBytes *payload)
 {
   CockpitSshTransport *self = COCKPIT_SSH_TRANSPORT (transport);
@@ -1193,7 +1194,7 @@ cockpit_ssh_transport_send (CockpitTransport *transport,
 
   g_return_if_fail (!self->closing);
 
-  prefix = g_strdup_printf ("xxxx%u\n", channel);
+  prefix = g_strdup_printf ("xxxx%s\n", channel ? channel : "");
   length = strlen (prefix);
 
   /* See doc/protocol.md */

--- a/src/ws/test-sshtransport.c
+++ b/src/ws/test-sshtransport.c
@@ -201,12 +201,12 @@ teardown (TestCase *tc,
 
 static gboolean
 on_recv_get_payload (CockpitTransport *transport,
-                     guint channel,
+                     const gchar *channel,
                      GBytes *message,
                      gpointer user_data)
 {
   GBytes **received = user_data;
-  g_assert_cmpuint (channel, ==, 546);
+  g_assert_cmpstr (channel, ==, "546");
   g_assert (*received == NULL);
   *received = g_bytes_ref (message);
   return TRUE;
@@ -214,14 +214,14 @@ on_recv_get_payload (CockpitTransport *transport,
 
 static gboolean
 on_recv_multiple (CockpitTransport *transport,
-                  guint channel,
+                  const gchar *channel,
                   GBytes *message,
                   gpointer user_data)
 {
   gint *state = user_data;
   GBytes *check;
 
-  g_assert_cmpuint (channel, ==, 9);
+  g_assert_cmpstr (channel, ==, "9");
 
   if (*state == 0)
     check = g_bytes_new_static ("one", 3);
@@ -266,7 +266,7 @@ test_echo_and_close (TestCase *tc,
   sent = g_bytes_new_static ("the message", 11);
   g_signal_connect (tc->transport, "recv", G_CALLBACK (on_recv_get_payload), &received);
   g_signal_connect (tc->transport, "closed", G_CALLBACK (on_closed_set_flag), &closed);
-  cockpit_transport_send (tc->transport, 546, sent);
+  cockpit_transport_send (tc->transport, "546", sent);
 
   while (received == NULL && !closed)
     g_main_context_iteration (NULL, TRUE);
@@ -298,10 +298,10 @@ test_echo_queue (TestCase *tc,
   g_signal_connect (tc->transport, "closed", G_CALLBACK (on_closed_set_flag), &closed);
 
   sent = g_bytes_new_static ("one", 3);
-  cockpit_transport_send (tc->transport, 9, sent);
+  cockpit_transport_send (tc->transport, "9", sent);
   g_bytes_unref (sent);
   sent = g_bytes_new_static ("two", 3);
-  cockpit_transport_send (tc->transport, 9, sent);
+  cockpit_transport_send (tc->transport, "9", sent);
   g_bytes_unref (sent);
 
   /* Only closes after above are sent */
@@ -324,7 +324,7 @@ test_echo_large (TestCase *tc,
 
   /* Medium length */
   sent = g_bytes_new_take (g_strnfill (1020, '!'), 1020);
-  cockpit_transport_send (tc->transport, 546, sent);
+  cockpit_transport_send (tc->transport, "546", sent);
   while (received == NULL)
     g_main_context_iteration (NULL, TRUE);
   g_assert (g_bytes_equal (received, sent));
@@ -334,7 +334,7 @@ test_echo_large (TestCase *tc,
 
   /* Extra large */
   sent = g_bytes_new_take (g_strnfill (10 * 1000 * 1000, '?'), 10 * 1000 * 1000);
-  cockpit_transport_send (tc->transport, 546, sent);
+  cockpit_transport_send (tc->transport, "546", sent);
   while (received == NULL)
     g_main_context_iteration (NULL, TRUE);
   g_assert (g_bytes_equal (received, sent));
@@ -344,7 +344,7 @@ test_echo_large (TestCase *tc,
 
   /* Double check that didn't csrew things up */
   sent = g_bytes_new_static ("yello", 5);
-  cockpit_transport_send (tc->transport, 546, sent);
+  cockpit_transport_send (tc->transport, "546", sent);
   while (received == NULL)
     g_main_context_iteration (NULL, TRUE);
   g_assert (g_bytes_equal (received, sent));
@@ -502,7 +502,7 @@ test_get_host_key (TestCase *tc,
   sent = g_bytes_new_static ("the message", 11);
   g_signal_connect (tc->transport, "recv", G_CALLBACK (on_recv_get_payload), &received);
   g_signal_connect (tc->transport, "closed", G_CALLBACK (on_closed_set_flag), &closed);
-  cockpit_transport_send (tc->transport, 546, sent);
+  cockpit_transport_send (tc->transport, "546", sent);
   g_bytes_unref (sent);
 
   while (received == NULL && !closed)


### PR DESCRIPTION
This is done for three reasons:
- Much much more flexible going forward, since this is an integral
  part of our protocol, it can never be changed.
- We can allow routing multiple WebSockets to one agent, without
  trying to coordinate the channel number space of those WebSockets.
  This is not implemented in this patch.
- We can implement internal channels that don't get routed to a
  WebSocket (necessary for implementing resource loading).

This is an alternative to the signed channel number patch that was
floating around.
