### PR TITLE
test: Don't polute user's known hosts file

### DIFF
--- a/test/testvm.py
+++ b/test/testvm.py
@@ -159,6 +159,7 @@ class Machine:
             "ssh",
             "-i", self._calc_identity(),
             "-o", "StrictHostKeyChecking=no",
+            "-o", "UserKnownHostsFile=/dev/null",
             "-l", "root",
             self.address
         ]
@@ -222,6 +223,7 @@ class Machine:
             "scp",
             "-i", self._calc_identity(),
             "-o", "StrictHostKeyChecking=no",
+            "-o", "UserKnownHostsFile=/dev/null",
             source, "root@%s:%s" % (self.address, dest),
         ]
 
@@ -239,6 +241,7 @@ class Machine:
             "scp",
             "-i", self._calc_identity(),
             "-o", "StrictHostKeyChecking=no",
+            "-o", "UserKnownHostsFile=/dev/null",
             "-r",
             "root@%s:%s" % (self.address, source), dest
         ]

--- a/test/vm-copy
+++ b/test/vm-copy
@@ -60,4 +60,4 @@ done
 dest=$1
 
 chmod 600 ./identity
-scp -i ./identity -o StrictHostKeyChecking=no -r "${srcs[@]}" "root@$M:$dest"
+scp -i ./identity -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -r "${srcs[@]}" "root@$M:$dest"

--- a/test/vm-sh
+++ b/test/vm-sh
@@ -46,4 +46,4 @@ case ${1:-} in
 esac
 
 chmod 600 ./identity
-ssh -i ./identity -p 22 -o StrictHostKeyChecking=no root@$M "$@"
+ssh -i ./identity -p 22 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$M "$@"


### PR DESCRIPTION
If you run ./VERIFY as a local user, it will use that known hosts
file and add all sorts of entries for 10.111.111.X to it.
