### PR TITLE
ws: Implement CockpitWebServer without threads

### DIFF
--- a/src/websocket/test-websocket.c
+++ b/src/websocket/test-websocket.c
@@ -336,9 +336,6 @@ test_parse_headers_bad (void)
   gssize ret;
   gint i;
 
-  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
-                         "received invalid header line*");
-
   for (i = 0; i < G_N_ELEMENTS (input); i++)
     {
       ret = web_socket_util_parse_headers (input[i], strlen (input[i]), NULL);

--- a/src/websocket/websocket.c
+++ b/src/websocket/websocket.c
@@ -327,7 +327,6 @@ web_socket_util_parse_headers (const gchar *data,
           colon = memchr (data, ':', length);
           if (!colon || colon >= line)
             {
-              g_message ("received invalid header line: %.*s", (gint)line_len, data);
               consumed = -1;
               break;
             }

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -9,6 +9,8 @@ libcockpit_ws_a_SOURCES = \
 	src/ws/cockpithandlers.h	src/ws/cockpithandlers.c	\
 	src/ws/cockpitauth.h		src/ws/cockpitauth.c		\
 	src/ws/cockpitcreds.h src/ws/cockpitcreds.c \
+	src/ws/cockpitwebresponse.h \
+	src/ws/cockpitwebresponse.c \
 	src/ws/cockpitwebservice.h \
 	src/ws/cockpitwebservice.c \
 	src/ws/cockpitsshtransport.h \
@@ -91,6 +93,7 @@ test_server_LDADD = 					\
 WS_CHECKS = \
 	test-creds \
 	test-auth \
+	test-webresponse \
 	test-webserver \
 	test-sshtransport \
 	test-webservice \
@@ -150,6 +153,17 @@ test_webservice_SOURCES = \
 test_webservice_CFLAGS = $(cockpit_ws_CFLAGS)
 
 test_webservice_LDADD = \
+	libwebsocket.a \
+	libcockpit-ws.a \
+	$(cockpit_ws_LDADD) \
+	$(NULL)
+
+test_webresponse_SOURCES = \
+	src/ws/test-webresponse.c \
+	src/ws/mock-io-stream.c src/ws/mock-io-stream.h \
+	$(NULL)
+test_webresponse_CFLAGS = $(cockpit_ws_CFLAGS)
+test_webresponse_LDADD = \
 	libwebsocket.a \
 	libcockpit-ws.a \
 	$(cockpit_ws_LDADD) \

--- a/src/ws/cockpithandlers.h
+++ b/src/ws/cockpithandlers.h
@@ -22,6 +22,7 @@
 
 #include "cockpitauth.h"
 #include "cockpitwebserver.h"
+#include "cockpitwebresponse.h"
 
 typedef struct {
   CockpitAuth *auth;
@@ -29,47 +30,43 @@ typedef struct {
 
 gboolean       cockpit_handler_socket            (CockpitWebServer *server,
                                                   CockpitWebServerRequestType reqtype,
-                                                  const gchar *resource,
+                                                  const gchar *path,
                                                   GIOStream *io_stream,
                                                   GHashTable *headers,
-                                                  GDataInputStream *in,
-                                                  GDataOutputStream *out,
+                                                  GByteArray *input,
+                                                  guint in_length,
                                                   CockpitHandlerData *data);
 
 gboolean       cockpit_handler_login             (CockpitWebServer *server,
                                                   CockpitWebServerRequestType reqtype,
-                                                  const gchar *resource,
-                                                  GIOStream *io_stream,
+                                                  const gchar *path,
                                                   GHashTable *headers,
-                                                  GDataInputStream *in,
-                                                  GDataOutputStream *out,
+                                                  GBytes *input,
+                                                  CockpitWebResponse *response,
                                                   CockpitHandlerData *data);
 
 gboolean       cockpit_handler_logout            (CockpitWebServer *server,
                                                   CockpitWebServerRequestType reqtype,
-                                                  const gchar *resource,
-                                                  GIOStream *io_stream,
+                                                  const gchar *path,
                                                   GHashTable *headers,
-                                                  GDataInputStream *in,
-                                                  GDataOutputStream *out,
+                                                  GBytes *input,
+                                                  CockpitWebResponse *response,
                                                   CockpitHandlerData *data);
 
 gboolean       cockpit_handler_deauthorize       (CockpitWebServer *server,
                                                   CockpitWebServerRequestType reqtype,
                                                   const gchar *resource,
-                                                  GIOStream *io_stream,
                                                   GHashTable *headers,
-                                                  GDataInputStream *in,
-                                                  GDataOutputStream *out,
+                                                  GBytes *input,
+                                                  CockpitWebResponse *response,
                                                   CockpitHandlerData *data);
 
 gboolean       cockpit_handler_cockpitdyn        (CockpitWebServer *server,
                                                   CockpitWebServerRequestType reqtype,
-                                                  const gchar *resource,
-                                                  GIOStream *connection,
+                                                  const gchar *path,
                                                   GHashTable *headers,
-                                                  GDataInputStream *in,
-                                                  GDataOutputStream *out,
+                                                  GBytes *input,
+                                                  CockpitWebResponse *response,
                                                   CockpitHandlerData *data);
 
 #endif /* __COCKPIT_HANDLERS_H__ */

--- a/src/ws/cockpitwebresponse.c
+++ b/src/ws/cockpitwebresponse.c
@@ -1,0 +1,950 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitwebresponse.h"
+
+#include "cockpit/cockpiterror.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * CockpitWebResponse:
+ *
+ * A response sent back to an HTTP client. You can use the high level one
+ * shot APIs, like cockpit_web_response_content() and
+ * cockpit_web_response_error() * or low level builder APIs:
+ *
+ * cockpit_web_response_headers() send the headers
+ * cockpit_web_response_queue() send a block of data.
+ * cockpit_web_response_complete() finish.
+ */
+
+struct _CockpitWebResponse {
+  GObject parent;
+  GIOStream *io;
+  const gchar *logname;
+  gchar *path;
+
+  /* The output queue */
+  GPollableOutputStream *out;
+  GQueue *queue;
+  gsize partial_offset;
+  GSource *source;
+
+  /* Status flags */
+  guint count;
+  gboolean complete;
+  gboolean failed;
+  gboolean done;
+};
+
+typedef struct {
+  GObjectClass parent;
+} CockpitWebResponseClass;
+
+G_DEFINE_TYPE (CockpitWebResponse, cockpit_web_response, G_TYPE_OBJECT);
+
+static void
+cockpit_web_response_init (CockpitWebResponse *self)
+{
+  self->queue = g_queue_new ();
+}
+
+static void
+cockpit_web_response_done (CockpitWebResponse *self)
+{
+  g_assert (!self->done);
+  self->done = TRUE;
+
+  g_object_unref (self->io);
+  self->io = NULL;
+  self->out = NULL;
+
+  if (self->source)
+    {
+      g_source_destroy (self->source);
+      g_source_unref (self->source);
+      self->source = NULL;
+    }
+
+  if (self->complete)
+    {
+      g_object_unref (self);
+    }
+  else if (!self->failed)
+    {
+      g_critical ("A CockpitWebResponse was freed without being completed properly. "
+                  "This is a programming error.");
+    }
+}
+
+static void
+cockpit_web_response_dispose (GObject *object)
+{
+  CockpitWebResponse *self = COCKPIT_WEB_RESPONSE (object);
+
+  if (!self->done)
+    cockpit_web_response_done (self);
+
+  G_OBJECT_CLASS (cockpit_web_response_parent_class)->dispose (object);
+}
+
+static void
+cockpit_web_response_finalize (GObject *object)
+{
+  CockpitWebResponse *self = COCKPIT_WEB_RESPONSE (object);
+
+  g_free (self->path);
+  g_assert (self->io == NULL);
+  g_assert (self->out == NULL);
+  g_queue_free_full (self->queue, (GDestroyNotify)g_bytes_unref);
+
+  G_OBJECT_CLASS (cockpit_web_response_parent_class)->finalize (object);
+}
+
+static void
+cockpit_web_response_class_init (CockpitWebResponseClass *klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+  gobject_class->dispose = cockpit_web_response_dispose;
+  gobject_class->finalize = cockpit_web_response_finalize;
+}
+
+/**
+ * cockpit_web_response_new:
+ * @io: the stream to send on
+ * @path: the path resource or NULL
+ *
+ * Create a new web response.
+ *
+ * The returned refference belongs to the caller. Additionally
+ * once cockpit_web_response_complete() is called, an additional
+ * reference is held until the response is sent and flushed.
+ *
+ * Returns: (transfer full): the new response, unref when done with it
+ */
+CockpitWebResponse *
+cockpit_web_response_new (GIOStream *io,
+                          const gchar *path)
+{
+  CockpitWebResponse *self;
+  GOutputStream *out;
+
+  /* Trying to be a somewhat performant here, avoiding properties */
+  self = g_object_new (COCKPIT_TYPE_WEB_RESPONSE, NULL);
+  self->io = g_object_ref (io);
+
+  out = g_io_stream_get_output_stream (io);
+  if (G_IS_POLLABLE_OUTPUT_STREAM (out))
+    {
+      self->out = (GPollableOutputStream *)out;
+    }
+  else
+    {
+      g_critical ("Cannot send web response over non-pollable output stream: %s",
+                  G_OBJECT_TYPE_NAME (out));
+    }
+
+  self->path = g_strdup (path);
+  if (self->path)
+    self->logname = self->path;
+  else
+    self->logname = "response";
+
+  return self;
+}
+
+/**
+ * cockpit_web_response_get_path:
+ * @self: the response
+ *
+ * Returns: the resource path for response
+ */
+const gchar *
+cockpit_web_response_get_path (CockpitWebResponse *self)
+{
+  return self->path;
+}
+
+/**
+ * cockpit_web_response_get_stream:
+ * @self: the response
+ *
+ * Returns: the stream we're sending on
+ */
+GIOStream *
+cockpit_web_response_get_stream  (CockpitWebResponse *self)
+{
+  return self->io;
+}
+
+static gboolean
+should_suppress_output_error (CockpitWebResponse *self,
+                              GError *error)
+{
+  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE))
+    {
+      g_debug ("%s: output error: %s", self->logname, error->message);
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
+static void
+on_output_closed (GObject *stream,
+                  GAsyncResult *result,
+                  gpointer user_data)
+{
+  CockpitWebResponse *self = COCKPIT_WEB_RESPONSE (user_data);
+  GOutputStream *output = G_OUTPUT_STREAM (stream);
+  GError *error = NULL;
+
+  if (g_output_stream_close_finish (output, result, &error))
+    {
+      g_debug ("%s: closed output", self->logname);
+    }
+  else
+    {
+      if (!should_suppress_output_error (self, error))
+        g_warning ("%s: couldn't close web output: %s", self->logname, error->message);
+      g_error_free (error);
+    }
+
+  g_object_unref (self);
+  cockpit_web_response_done (self);
+}
+
+static void
+on_output_flushed (GObject *stream,
+                   GAsyncResult *result,
+                   gpointer user_data)
+{
+  CockpitWebResponse *self = COCKPIT_WEB_RESPONSE (user_data);
+  GOutputStream *output = G_OUTPUT_STREAM (stream);
+  GError *error = NULL;
+
+  if (g_output_stream_flush_finish (output, result, &error))
+    {
+      g_debug ("%s: flushed output", self->logname);
+
+      g_output_stream_close_async (output, G_PRIORITY_DEFAULT,
+                                   NULL, on_output_closed, g_object_ref (self));
+    }
+  else
+    {
+      if (!should_suppress_output_error (self, error))
+        g_warning ("%s: couldn't flush web output: %s", self->logname, error->message);
+      g_error_free (error);
+      cockpit_web_response_done (self);
+    }
+
+  g_object_unref (self);
+}
+
+static gboolean
+on_response_output (GObject *pollable,
+                    gpointer user_data)
+{
+  CockpitWebResponse *self = user_data;
+  GError *error = NULL;
+  const guint8 *data;
+  GBytes *block;
+  gssize count;
+  gsize len;
+
+  block = g_queue_peek_head (self->queue);
+  if (block)
+    {
+      data = g_bytes_get_data (block, &len);
+
+      if (len > 0)
+        {
+          g_assert (self->partial_offset < len);
+          data += self->partial_offset;
+          len -= self->partial_offset;
+          count = g_pollable_output_stream_write_nonblocking (self->out, data, len,
+                                                              NULL, &error);
+        }
+      else
+        {
+          count = 0;
+        }
+
+      if (count < 0)
+        {
+          if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK))
+            {
+              g_debug ("%s: write would block", self->logname);
+              g_error_free (error);
+              return TRUE;
+            }
+
+          if (!should_suppress_output_error (self, error))
+            g_warning ("%s: couldn't write web output: %s", self->logname, error->message);
+
+          self->failed = TRUE;
+          cockpit_web_response_done (self);
+
+          g_error_free (error);
+          return FALSE;
+        }
+
+      if (count == len)
+        {
+          g_debug ("%s: sent %d bytes", self->logname, (int)len);
+          self->partial_offset = 0;
+          g_queue_pop_head (self->queue);
+          g_bytes_unref (block);
+        }
+      else
+        {
+          g_debug ("%s: sent %d partial", self->logname, (int)count);
+          g_assert (count < len);
+          self->partial_offset += count;
+        }
+    }
+
+  if (!self->queue->head)
+    {
+      g_source_destroy (self->source);
+      g_source_unref (self->source);
+      self->source = NULL;
+
+      if (self->complete)
+        {
+          g_debug ("%s: complete flushing output", self->logname);
+          g_output_stream_flush_async (G_OUTPUT_STREAM (self->out), G_PRIORITY_DEFAULT,
+                                       NULL, on_output_flushed, g_object_ref (self));
+        }
+      else
+        {
+          g_debug ("%s: output queue is empty", self->logname);
+        }
+
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+/**
+ * cockpit_web_response_queue:
+ * @self: the response
+ * @block: the block of data to queue
+ *
+ * Queue a single block of data on the response. Will be sent
+ * during the main loop.
+ *
+ * See cockpit_web_response_content() for a simple way to
+ * avoid queing individual blocks.
+ *
+ * If this function returns %FALSE, then the respones has failed
+ * or has been completed elsewhere. The block was ignored and
+ * queuing more blocks doesn't makes sense.
+ *
+ * After done queuing all your blocks call
+ * cockpit_web_response_complete().
+*
+ * Returns: Whether queuing more blocks makes sense
+ */
+gboolean
+cockpit_web_response_queue (CockpitWebResponse *self,
+                            GBytes *block)
+{
+  g_return_val_if_fail (block != NULL, FALSE);
+  g_return_val_if_fail (self->complete == FALSE, FALSE);
+
+  if (self->failed)
+    {
+      g_debug ("%s: ignoring queued block after failure", self->logname);
+      return FALSE;
+    }
+
+  self->count++;
+  g_debug ("%s: queued %d bytes", self->logname, (int)g_bytes_get_size (block));
+  g_queue_push_tail (self->queue, g_bytes_ref (block));
+
+  if (!self->source)
+    {
+      self->source = g_pollable_output_stream_create_source (self->out, NULL);
+      g_source_set_callback (self->source, (GSourceFunc)on_response_output, self, NULL);
+      g_source_attach (self->source, NULL);
+    }
+
+  return TRUE;
+}
+
+/**
+ * cockpit_web_response_complete:
+ * @self: the response
+ *
+ * See cockpit_web_response_content() for easy to use stuff.
+ *
+ * Tell the response that all the data has been queued.
+ * The response will hold a reference to itself until the
+ * data is actually sent, so you can unref it.
+ */
+void
+cockpit_web_response_complete (CockpitWebResponse *self)
+{
+  g_return_if_fail (self->complete == FALSE);
+
+  if (self->failed)
+    return;
+
+  /* Hold a reference until cockpit_web_response_finish() */
+  g_object_ref (self);
+  self->complete = TRUE;
+
+  if (self->source)
+    {
+      g_debug ("%s: queueing complete", self->logname);
+    }
+  else
+    {
+      g_debug ("%s: complete closing io", self->logname);
+      g_output_stream_flush_async (G_OUTPUT_STREAM (self->out), G_PRIORITY_DEFAULT,
+                                   NULL, on_output_flushed, g_object_ref (self));
+    }
+}
+
+enum {
+    HEADER_CONTENT_TYPE = 1 << 0,
+};
+
+static GString *
+begin_headers (CockpitWebResponse *response,
+               guint status,
+               const gchar *reason)
+{
+  GString *string;
+
+  string = g_string_sized_new (1024);
+  g_string_printf (string, "HTTP/1.1 %d %s\r\n", status, reason);
+
+  return string;
+}
+
+static guint
+append_header (GString *string,
+               const gchar *name,
+               const gchar *value)
+{
+  if (value)
+    {
+      g_return_val_if_fail (strchr (name, '\n') == NULL, 0);
+      g_return_val_if_fail (strchr (value, '\n') == NULL, 0);
+      g_string_append_printf (string, "%s: %s\r\n", name, value);
+    }
+  if (g_ascii_strcasecmp ("Content-Type", name) == 0)
+    return HEADER_CONTENT_TYPE;
+  else if (g_ascii_strcasecmp ("Content-Length", name) == 0)
+    g_critical ("Don't set Content-Length manually. This is a programmer error.");
+  else if (g_ascii_strcasecmp ("Connection", name) == 0)
+    g_critical ("Don't set Content-Length manually. This is a programmer error.");
+  return 0;
+}
+
+static guint
+append_table (GString *string,
+              GHashTable *headers)
+{
+  GHashTableIter iter;
+  gpointer key;
+  gpointer value;
+  guint seen = 0;
+
+  if (headers)
+    {
+      g_hash_table_iter_init (&iter, headers);
+      while (g_hash_table_iter_next (&iter, &key, &value))
+        seen |= append_header (string, key, value);
+    }
+
+  return seen;
+}
+
+static guint
+append_va (GString *string,
+           va_list va)
+{
+  const gchar *name;
+  const gchar *value;
+  guint seen = 0;
+
+  for (;;)
+    {
+      name = va_arg (va, const gchar *);
+      if (!name)
+        break;
+      value = va_arg (va, const gchar *);
+      seen |= append_header (string, name, value);
+    }
+
+  return seen;
+}
+
+static GBytes *
+finish_headers (CockpitWebResponse *self,
+                GString *string,
+                gssize length,
+                guint seen)
+{
+  gint i;
+
+  static const struct {
+    const gchar *extension;
+    const gchar *content_type;
+  } content_types[] = {
+    { ".css", "text/css" },
+    { ".gif", "image/gif" },
+    { ".eot", "application/vnd.ms-fontobject" },
+    { ".html", "text/html" },
+    { ".ico", "image/vnd.microsoft.icon" },
+    { ".jpg", "image/jpg" },
+    { ".js", "application/javascript" },
+    { ".otf", "font/opentype" },
+    { ".png", "image/png" },
+    { ".svg", "image/svg+xml" },
+    { ".ttf", "application/octet-stream" }, /* unassigned */
+    { ".woff", "application/font-woff" },
+    { ".xml", "text/xml" },
+  };
+
+  /* Automatically figure out content type */
+  if ((seen & HEADER_CONTENT_TYPE) == 0 &&
+      self->path != NULL)
+    {
+      for (i = 0; i < G_N_ELEMENTS (content_types); i++)
+        {
+          if (g_str_has_suffix (self->path, content_types[i].extension))
+            {
+              g_string_append_printf (string, "Content-Type: %s\r\n", content_types[i].content_type);
+              break;
+            }
+        }
+    }
+
+  if (length >= 0)
+    g_string_append_printf (string, "Content-Length: %" G_GSSIZE_FORMAT "\r\n", length);
+  g_string_append (string, "Connection: close\r\n");
+  g_string_append (string, "\r\n");
+
+  return g_string_free_to_bytes (string);
+}
+
+/**
+ * cockpit_web_response_headers:
+ * @self: the response
+ * @status: the HTTP status code
+ * @reason: the HTTP reason
+ * @length: the combined length of data blocks to follow, or -1
+ *
+ * See cockpit_web_response_content() for an easy to use function.
+ *
+ * Queue the headers of the response. No data blocks must yet be
+ * queued on the response.
+ *
+ * Specify header name/value pairs in the var args, and end with
+ * a NULL name. If value is NULL, then that header won't be sent.
+ *
+ * Don't specify Content-Length or Connection headers.
+ *
+ * If @length is zero or greater, then it must represent the
+ * number of queued blocks to follow.
+ */
+void
+cockpit_web_response_headers (CockpitWebResponse *self,
+                              guint status,
+                              const gchar *reason,
+                              gssize length,
+                              ...)
+{
+  GString *string;
+  GBytes *block;
+  va_list va;
+
+  if (self->count > 0)
+    {
+      g_critical ("Headers should be sent first. This is a programmer error.");
+      return;
+    }
+
+  string = begin_headers (self, status, reason);
+
+  va_start (va, length);
+  block = finish_headers (self, string, length, append_va (string, va));
+  va_end (va);
+
+  cockpit_web_response_queue (self, block);
+  g_bytes_unref (block);
+}
+
+/**
+ * cockpit_web_response_headers:
+ * @self: the response
+ * @status: the HTTP status code
+ * @reason: the HTTP reason
+ * @length: the combined length of data blocks to follow, or -1
+ * @headers: headers to include or NULL
+ *
+ * See cockpit_web_response_content() for an easy to use function.
+ *
+ * Queue the headers of the response. No data blocks must yet be
+ * queued on the response.
+ *
+ * Don't put Content-Length or Connection in @headers.
+ *
+ * If @length is zero or greater, then it must represent the
+ * number of queued blocks to follow.
+ */
+void
+cockpit_web_response_headers_full  (CockpitWebResponse *self,
+                                    guint status,
+                                    const gchar *reason,
+                                    gssize length,
+                                    GHashTable *headers)
+{
+  GString *string;
+  GBytes *block;
+
+  if (self->count > 0)
+    {
+      g_critical ("Headers should be sent first. This is a programmer error.");
+      return;
+    }
+
+  string = begin_headers (self, status, reason);
+
+  block = finish_headers (self, string, length, append_table (string, headers));
+
+  cockpit_web_response_queue (self, block);
+  g_bytes_unref (block);
+}
+
+/**
+ * cockpit_web_response_content:
+ * @self: the response
+ * @headers: headers to include or NULL
+ * @block: first block to send
+ *
+ * This is a simple way to send an HTTP response as a single
+ * call. The response will be complete after this call, and will
+ * send in the main-loop.
+ *
+ * The var args are additional GBytes* blocks to send, followed by
+ * a trailing NULL.
+ *
+ * Don't include Content-Length or Connection in @headers.
+ *
+ * This calls cockpit_web_response_headers_full(),
+ * cockpit_web_response_queue() and cockpit_web_response_complete()
+ * internally.
+ */
+void
+cockpit_web_response_content (CockpitWebResponse *self,
+                              GHashTable *headers,
+                              GBytes *block,
+                              ...)
+{
+  GBytes *first;
+  gsize length = 0;
+  va_list va;
+  va_list va2;
+
+  first = block;
+  va_start (va, block);
+  va_copy (va2, va);
+
+  while (block)
+    {
+      length += g_bytes_get_size (block);
+      block = va_arg (va, GBytes *);
+    }
+  va_end (va);
+
+  cockpit_web_response_headers_full (self, 200, "OK", length, headers);
+
+  block = first;
+  for (;;)
+    {
+      if (!block)
+        {
+          cockpit_web_response_complete (self);
+          break;
+        }
+      if (!cockpit_web_response_queue (self, block))
+        break;
+      block = va_arg (va2, GBytes *);
+    }
+  va_end (va2);
+}
+
+/**
+ * cockpit_web_response_error:
+ * @self: the response
+ * @status: the HTTP status code
+ * @headers: headers to include or NULL
+ * @format: printf format of error message
+ *
+ * Send an error message with a basic HTML page containing
+ * the error.
+ */
+void
+cockpit_web_response_error (CockpitWebResponse *self,
+                            guint code,
+                            GHashTable *headers,
+                            const gchar *format,
+                            ...)
+{
+  gchar *body = NULL;
+  va_list var_args;
+  gchar *reason = NULL;
+  const gchar *message;
+  GBytes *content;
+  gsize length;
+
+  if (format)
+    {
+      va_start (var_args, format);
+      reason = g_strdup_vprintf (format, var_args);
+      va_end (var_args);
+      message = reason;
+    }
+  else
+    {
+      switch (code)
+        {
+        case 400:
+          message = "Bad request";
+          break;
+        case 401:
+          message = "Not Authorized";
+          break;
+        case 403:
+          message = "Forbidden";
+          break;
+        case 404:
+          message = "Not Found";
+          break;
+        case 405:
+          message = "Method Not Allowed";
+          break;
+        case 413:
+          message = "Request Entity Too Large";
+          break;
+        case 500:
+          message = "Internal Server Error";
+          break;
+        default:
+          if (code < 100)
+            message = "Continue";
+          else if (code < 200)
+            message = "OK";
+          else if (code < 300)
+            message = "Moved";
+          else
+            message = "Failed";
+          break;
+        }
+    }
+
+  body = g_strdup_printf ("<html><head><title>%u %s</title></head>"
+                          "<body>%s</body></html>",
+                          code, message, message);
+
+  g_debug ("%s: returning error: %u %s", self->logname, code, message);
+
+  length = strlen (body);
+  content = g_bytes_new_take (body, length);
+  cockpit_web_response_headers_full (self, code, message, length, headers);
+  if (cockpit_web_response_queue (self, content))
+    cockpit_web_response_complete (self);
+  g_bytes_unref (content);
+
+  g_free (reason);
+}
+
+/**
+ * cockpit_web_response_error:
+ * @self: the response
+ * @headers: headers to include or NULL
+ * @error: the error
+ *
+ * Send an error message with a basic HTML page containing
+ * the error.
+ */
+void
+cockpit_web_response_gerror (CockpitWebResponse *self,
+                             GHashTable *headers,
+                             GError *error)
+{
+  int code;
+
+  if (g_error_matches (error,
+                       COCKPIT_ERROR, COCKPIT_ERROR_AUTHENTICATION_FAILED))
+    code = 401;
+  else if (g_error_matches (error,
+                            G_IO_ERROR, G_IO_ERROR_INVALID_DATA))
+    code = 400;
+  else if (g_error_matches (error,
+                            G_IO_ERROR, G_IO_ERROR_NO_SPACE))
+    code = 413;
+  else
+    code = 500;
+
+  cockpit_web_response_error (self, code, headers, "%s", error->message);
+}
+
+static gboolean
+path_has_prefix (const gchar *path,
+                 const gchar *prefix)
+{
+  gsize len = strlen (prefix);
+  if (len == 0)
+    return FALSE;
+  if (!g_str_has_prefix (path, prefix))
+    return FALSE;
+  if (prefix[len - 1] == '/' ||
+      path[len] == '/')
+    return TRUE;
+  return FALSE;
+}
+
+/**
+ * cockpit_web_response_file:
+ * @response: the response
+ * @path: escaped path, or NULL to get from response
+ * @roots: directories to look for file in
+ *
+ * Serve a file from disk as an HTTP response.
+ */
+void
+cockpit_web_response_file (CockpitWebResponse *response,
+                           const gchar *escaped,
+                           const gchar **roots)
+{
+  GError *error = NULL;
+  gchar *query = NULL;
+  gchar *unescaped;
+  char *path = NULL;
+  gchar *built = NULL;
+  GMappedFile *file = NULL;
+  const gchar *root;
+  GBytes *body;
+
+  if (!escaped)
+    escaped = cockpit_web_response_get_path (response);
+
+  g_return_if_fail (escaped != NULL);
+
+  query = strchr (escaped, '?');
+  if (query != NULL)
+    *query++ = 0;
+
+  /* TODO: Remove this logic when we no longer use an index.html */
+  if (g_strcmp0 (escaped, "/") == 0)
+    escaped = "/index.html";
+
+again:
+  root = *(roots++);
+  if (root == NULL)
+    {
+      cockpit_web_response_error (response, 404, NULL, "Not Found");
+      goto out;
+    }
+
+  unescaped = g_uri_unescape_string (escaped, NULL);
+  built = g_build_filename (root, unescaped, NULL);
+  g_free (unescaped);
+
+  path = realpath (built, NULL);
+  g_free (built);
+
+  if (path == NULL)
+    {
+      if (errno == ENOENT || errno == ENOTDIR || errno == ELOOP || errno == ENAMETOOLONG)
+        goto again;
+      else if (errno == EACCES)
+        {
+          cockpit_web_response_error (response, 403, NULL, "Access Denied");
+          goto out;
+        }
+      else
+        {
+          g_warning ("%s: resolving path failed: %m", escaped);
+          cockpit_web_response_error (response, 500, NULL, "Internal Server Error");
+          goto out;
+        }
+    }
+
+  /* Double check that realpath() did the right thing */
+  g_return_if_fail (strstr (path, "../") == NULL);
+  g_return_if_fail (!g_str_has_suffix (path, "/.."));
+
+  /* Someone is trying to escape the root directory */
+  if (!path_has_prefix (path, root))
+    {
+      cockpit_web_response_error (response, 404, NULL, "Not Found");
+      goto out;
+    }
+
+  if (g_file_test (path, G_FILE_TEST_IS_DIR))
+    {
+      cockpit_web_response_error (response, 403, NULL, "Directory Listing Denied");
+      goto out;
+    }
+
+  file = g_mapped_file_new (path, FALSE, &error);
+  if (file == NULL)
+    {
+      if (g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_PERM) ||
+          g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_ACCES) ||
+          g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_ISDIR))
+        {
+          cockpit_web_response_error (response, 403, NULL, "Access denied");
+          g_clear_error (&error);
+          goto out;
+        }
+      else
+        {
+          g_warning ("%s: %s", path, error->message);
+          cockpit_web_response_error (response, 500, NULL, "Internal server error");
+          g_clear_error (&error);
+          goto out;
+        }
+    }
+
+  body = g_mapped_file_get_bytes (file);
+
+  cockpit_web_response_content (response, NULL, body, NULL);
+
+  g_bytes_unref (body);
+
+out:
+  free (path);
+  if (file)
+    g_mapped_file_unref (file);
+}

--- a/src/ws/cockpitwebresponse.h
+++ b/src/ws/cockpitwebresponse.h
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __COCKPIT_WEB_RESPONSE_H__
+#define __COCKPIT_WEB_RESPONSE_H__
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+#define COCKPIT_TYPE_WEB_RESPONSE         (cockpit_web_response_get_type ())
+#define COCKPIT_WEB_RESPONSE(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_WEB_RESPONSE, CockpitWebResponse))
+
+typedef struct _CockpitWebResponse        CockpitWebResponse;
+
+GType                 cockpit_web_response_get_type      (void) G_GNUC_CONST;
+
+CockpitWebResponse *  cockpit_web_response_new           (GIOStream *io,
+                                                          const gchar *path);
+
+const gchar *         cockpit_web_response_get_path      (CockpitWebResponse *self);
+
+GIOStream *           cockpit_web_response_get_stream    (CockpitWebResponse *self);
+
+void                  cockpit_web_response_headers       (CockpitWebResponse *self,
+                                                          guint status,
+                                                          const gchar *reason,
+                                                          gssize length,
+                                                          ...) G_GNUC_NULL_TERMINATED;
+
+void                  cockpit_web_response_headers_full  (CockpitWebResponse *self,
+                                                          guint status,
+                                                          const gchar *reason,
+                                                          gssize length,
+                                                          GHashTable *headers);
+
+gboolean              cockpit_web_response_queue         (CockpitWebResponse *self,
+                                                          GBytes *block);
+
+void                  cockpit_web_response_complete      (CockpitWebResponse *self);
+
+void                  cockpit_web_response_content       (CockpitWebResponse *self,
+                                                          GHashTable *headers,
+                                                          GBytes *block,
+                                                          ...) G_GNUC_NULL_TERMINATED;
+
+void                  cockpit_web_response_error         (CockpitWebResponse *self,
+                                                          guint status,
+                                                          GHashTable *headers,
+                                                          const char *format,
+                                                          ...) G_GNUC_PRINTF (4, 5);
+
+void                  cockpit_web_response_gerror        (CockpitWebResponse *self,
+                                                          GHashTable *headers,
+                                                          GError *error);
+
+void                  cockpit_web_response_file          (CockpitWebResponse *response,
+                                                          const gchar *escaped,
+                                                          const gchar **roots);
+
+G_END_DECLS
+
+#endif /* __COCKPIT_RESPONSE_H__ */

--- a/src/ws/cockpitwebserver.c
+++ b/src/ws/cockpitwebserver.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of Cockpit.
  *
- * Copyright (C) 2013 Red Hat, Inc.
+ * Copyright (C) 2013-2014 Red Hat, Inc.
  *
  * Cockpit is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by
@@ -27,10 +27,14 @@
 #include <cockpit/cockpit.h>
 
 #include "cockpitws.h"
+#include "cockpitwebresponse.h"
 
 #include "websocket/websocket.h"
 
 #include <gsystem-local-alloc.h>
+
+guint cockpit_ws_request_timeout = 30;
+gsize cockpit_ws_request_maximum = 4096;
 
 typedef struct _CockpitWebServerClass CockpitWebServerClass;
 
@@ -40,20 +44,31 @@ struct _CockpitWebServer {
   gint port;
   GTlsCertificate *certificate;
   gchar **document_roots;
+  gint request_timeout;
+  gint request_max;
 
   GSocketService *socket_service;
+  GMainContext *main_context;
+  GHashTable *requests;
 };
 
 struct _CockpitWebServerClass {
   GObjectClass parent_class;
 
-  gboolean (* handle_resource) (CockpitWebServer *server,
+  gboolean (* handle_stream)   (CockpitWebServer *server,
                                 CockpitWebServerRequestType reqtype,
-                                const gchar *escaped_resource,
+                                const gchar *path,
                                 GIOStream *io_stream,
                                 GHashTable *headers,
-                                GDataInputStream *in,
-                                GDataOutputStream *out);
+                                GByteArray *input,
+                                guint in_length);
+
+  gboolean (* handle_resource) (CockpitWebServer *server,
+                                CockpitWebServerRequestType reqtype,
+                                const gchar *path,
+                                GHashTable *headers,
+                                GBytes *input,
+                                CockpitWebResponse *response);
 };
 
 enum
@@ -61,19 +76,15 @@ enum
   PROP_0,
   PROP_PORT,
   PROP_CERTIFICATE,
-  PROP_DOCUMENT_ROOTS
+  PROP_DOCUMENT_ROOTS,
 };
 
-enum
-{
-  HANDLE_RESOURCE_SIGNAL,
-  LAST_SIGNAL
-};
+static gint sig_handle_stream = 0;
+static gint sig_handle_resource = 0;
+
+static void cockpit_request_free (gpointer data);
 
 static void initable_iface_init (GInitableIface *iface);
-
-
-static guint signals[LAST_SIGNAL] = { 0 };
 
 G_DEFINE_TYPE_WITH_CODE (CockpitWebServer, cockpit_web_server, G_TYPE_OBJECT,
                          G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, initable_iface_init));
@@ -83,6 +94,9 @@ G_DEFINE_TYPE_WITH_CODE (CockpitWebServer, cockpit_web_server, G_TYPE_OBJECT,
 static void
 cockpit_web_server_init (CockpitWebServer *server)
 {
+  server->requests = g_hash_table_new_full (g_direct_hash, g_direct_equal,
+                                            cockpit_request_free, NULL);
+  server->main_context = g_main_context_ref_thread_default ();
 }
 
 static void
@@ -98,13 +112,25 @@ cockpit_web_server_constructed (GObject *object)
 }
 
 static void
+cockpit_web_server_dispose (GObject *object)
+{
+  CockpitWebServer *self = COCKPIT_WEB_SERVER (object);
+
+  g_hash_table_remove_all (self->requests);
+
+  G_OBJECT_CLASS (cockpit_web_server_parent_class)->dispose (object);
+}
+
+static void
 cockpit_web_server_finalize (GObject *object)
 {
   CockpitWebServer *server = COCKPIT_WEB_SERVER (object);
 
   g_clear_object (&server->certificate);
   g_strfreev (server->document_roots);
-
+  g_hash_table_destroy (server->requests);
+  if (server->main_context)
+    g_main_context_unref (server->main_context);
   g_clear_object (&server->socket_service);
 
   G_OBJECT_CLASS (cockpit_web_server_parent_class)->finalize (object);
@@ -138,6 +164,26 @@ cockpit_web_server_get_property (GObject *object,
     }
 }
 
+static gchar **
+filter_document_roots (const gchar **input)
+{
+  GPtrArray *roots;
+  char *path;
+  gint i;
+
+  roots = g_ptr_array_new ();
+  for (i = 0; input && input[i]; i++)
+    {
+      path = realpath (input[i], NULL);
+      if (path == NULL)
+        g_warning ("couldn't resolve document root: %s: %m", input[i]);
+      else
+        g_ptr_array_add (roots, path);
+    }
+  g_ptr_array_add (roots, NULL);
+  return (gchar **)g_ptr_array_free (roots, FALSE);
+}
+
 static void
 cockpit_web_server_set_property (GObject *object,
                                  guint prop_id,
@@ -157,7 +203,7 @@ cockpit_web_server_set_property (GObject *object,
       break;
 
     case PROP_DOCUMENT_ROOTS:
-      server->document_roots = g_value_dup_boxed (value);
+      server->document_roots = filter_document_roots (g_value_get_boxed (value));
       break;
 
     default:
@@ -166,13 +212,81 @@ cockpit_web_server_set_property (GObject *object,
     }
 }
 
+static gboolean
+cockpit_web_server_default_handle_stream (CockpitWebServer *self,
+                                          CockpitWebServerRequestType reqtype,
+                                          const gchar *path,
+                                          GIOStream *io_stream,
+                                          GHashTable *headers,
+                                          GByteArray *input,
+                                          guint in_length)
+{
+  CockpitWebResponse *response;
+  gboolean claimed = FALSE;
+  GQuark detail;
+  GBytes *bytes;
+
+  if (in_length == input->len)
+    {
+      /* preserve the byte array wrapper */
+      g_byte_array_ref (input);
+      bytes = g_byte_array_free_to_bytes (input);
+    }
+  else
+    {
+      bytes = g_bytes_new (input->data, in_length);
+      g_byte_array_remove_range (input, 0, in_length);
+    }
+
+  /* TODO: Correct HTTP version for response */
+  response = cockpit_web_response_new (io_stream, path);
+
+  detail = g_quark_try_string (path);
+
+  /* See if we have any takers... */
+  g_signal_emit (self,
+                 sig_handle_resource, detail,
+                 reqtype,  /* args */
+                 path,
+                 headers,
+                 bytes,
+                 response,
+                 &claimed);
+
+  g_bytes_unref (bytes);
+
+  /* TODO: Here is where we would plug keep-alive into respnse */
+  g_object_unref (response);
+
+  return claimed;
+}
+
+static gboolean
+cockpit_web_server_default_handle_resource (CockpitWebServer *self,
+                                            CockpitWebServerRequestType reqtype,
+                                            const gchar *path,
+                                            GHashTable *headers,
+                                            GBytes *input,
+                                            CockpitWebResponse *response)
+{
+  if (reqtype == COCKPIT_WEB_SERVER_REQUEST_POST)
+    cockpit_web_response_error (response, 405, NULL, "POST not available for this path");
+  else
+    cockpit_web_response_file (response, path, (const gchar **)self->document_roots);
+  return TRUE;
+}
+
 static void
 cockpit_web_server_class_init (CockpitWebServerClass *klass)
 {
   GObjectClass *gobject_class;
 
+  klass->handle_stream = cockpit_web_server_default_handle_stream;
+  klass->handle_resource = cockpit_web_server_default_handle_resource;
+
   gobject_class = G_OBJECT_CLASS (klass);
   gobject_class->constructed = cockpit_web_server_constructed;
+  gobject_class->dispose = cockpit_web_server_dispose;
   gobject_class->finalize = cockpit_web_server_finalize;
   gobject_class->set_property = cockpit_web_server_set_property;
   gobject_class->get_property = cockpit_web_server_get_property;
@@ -204,21 +318,36 @@ cockpit_web_server_class_init (CockpitWebServerClass *klass)
                                                         G_PARAM_CONSTRUCT_ONLY |
                                                         G_PARAM_STATIC_STRINGS));
 
-  signals[HANDLE_RESOURCE_SIGNAL] = g_signal_new ("handle-resource",
-                                                  G_OBJECT_CLASS_TYPE (klass),
-                                                  G_SIGNAL_RUN_LAST | G_SIGNAL_DETAILED,
-                                                  G_STRUCT_OFFSET (CockpitWebServerClass, handle_resource),
-                                                  g_signal_accumulator_true_handled,
-                                                  NULL, /* accu_data */
-                                                  g_cclosure_marshal_generic,
-                                                  G_TYPE_BOOLEAN,
-                                                  6,
-                                                  G_TYPE_INT,
-                                                  G_TYPE_STRING,
-                                                  G_TYPE_IO_STREAM,
-                                                  G_TYPE_HASH_TABLE,
-                                                  G_TYPE_DATA_INPUT_STREAM,
-                                                  G_TYPE_DATA_OUTPUT_STREAM);
+  sig_handle_stream = g_signal_new ("handle-stream",
+                                    G_OBJECT_CLASS_TYPE (klass),
+                                    G_SIGNAL_RUN_LAST,
+                                    G_STRUCT_OFFSET (CockpitWebServerClass, handle_stream),
+                                    g_signal_accumulator_true_handled,
+                                    NULL, /* accu_data */
+                                    g_cclosure_marshal_generic,
+                                    G_TYPE_BOOLEAN,
+                                    6,
+                                    G_TYPE_INT,
+                                    G_TYPE_STRING,
+                                    G_TYPE_IO_STREAM,
+                                    G_TYPE_HASH_TABLE,
+                                    G_TYPE_BYTE_ARRAY,
+                                    G_TYPE_UINT);
+
+  sig_handle_resource = g_signal_new ("handle-resource",
+                                      G_OBJECT_CLASS_TYPE (klass),
+                                      G_SIGNAL_RUN_LAST | G_SIGNAL_DETAILED,
+                                      G_STRUCT_OFFSET (CockpitWebServerClass, handle_resource),
+                                      g_signal_accumulator_true_handled,
+                                      NULL, /* accu_data */
+                                      g_cclosure_marshal_generic,
+                                      G_TYPE_BOOLEAN,
+                                      5,
+                                      G_TYPE_INT,
+                                      G_TYPE_STRING,
+                                      G_TYPE_HASH_TABLE,
+                                      G_TYPE_BYTES,
+                                      COCKPIT_TYPE_WEB_RESPONSE);
 }
 
 CockpitWebServer *
@@ -381,536 +510,454 @@ out:
 
 /* ---------------------------------------------------------------------------------------------------- */
 
+typedef struct {
+  int state;
+  GIOStream *io;
+  GByteArray *buffer;
+  gint delayed_reply;
+  CockpitWebServer *web_server;
+  GSource *source;
+  GSource *timeout;
+} CockpitRequest;
+
 static void
-return_response (GOutputStream *out,
-                 gint status,
-                 gchar *reason,
+cockpit_request_free (gpointer data)
+{
+  CockpitRequest *request = data;
+  if (request->timeout)
+    {
+      g_source_destroy (request->timeout);
+      g_source_unref (request->timeout);
+    }
+  if (request->source)
+    {
+      g_source_destroy (request->source);
+      g_source_unref (request->source);
+    }
+
+  g_byte_array_unref (request->buffer);
+  g_object_unref (request->io);
+  g_free (request);
+}
+
+static void
+cockpit_request_finish (CockpitRequest *request)
+{
+  g_hash_table_remove (request->web_server->requests, request);
+}
+
+static void
+process_delayed_reply (CockpitRequest *request,
+                       const gchar *path,
+                       GHashTable *headers)
+{
+  CockpitWebResponse *response;
+  const gchar *host;
+  const gchar *body;
+  GBytes *bytes;
+  gsize length;
+  gchar *url;
+
+  g_assert (request->delayed_reply > 299);
+
+  response = cockpit_web_response_new (request->io, NULL);
+
+  if (request->delayed_reply == 301)
+    {
+      body = "<html><head><title>Moved</title></head>"
+        "<body>Please use TLS</body></html>";
+      host = g_hash_table_lookup (headers, "Host");
+      url = g_strdup_printf ("https://%s%s",
+                             host != NULL ? host : "", path);
+      length = strlen (body);
+      cockpit_web_response_headers (response, 301, "Moved Permanently", length,
+                                    "Content-Type", "text/html",
+                                    "Location", url,
+                                    NULL);
+      g_free (url);
+      bytes = g_bytes_new_static (body, length);
+      if (cockpit_web_response_queue (response, bytes))
+        cockpit_web_response_complete (response);
+      g_bytes_unref (bytes);
+      return;
+    }
+
+  cockpit_web_response_error (response, request->delayed_reply, NULL, NULL);
+  g_object_unref (response);
+}
+
+static void
+process_request (CockpitRequest *request,
+                 CockpitWebServerRequestType reqtype,
+                 const gchar *path,
                  GHashTable *headers,
-                 gconstpointer content,
-                 gsize length)
-{
-  GHashTableIter iter;
-  GError *error = NULL;
-  gpointer value;
-  gpointer key;
-  GString *resp;
-
-  resp = g_string_new (NULL);
-
-  g_string_printf (resp, "HTTP/1.1 %d %s\r\n"
-                         "Content-Length: %" G_GSIZE_FORMAT "\r\n"
-                         "Connection: close\r\n", status, reason, length);
-
-  if (headers)
-    {
-      g_hash_table_iter_init (&iter, headers);
-      while (g_hash_table_iter_next (&iter, &key, &value))
-        g_string_append_printf (resp, "%s: %s\r\n", (gchar *)key, (gchar *)value);
-    }
-
-  g_string_append (resp, "\r\n");
-
-  if (!g_output_stream_write_all (out, resp->str, resp->len, NULL, NULL, &error) ||
-      !g_output_stream_write_all (out, content, length, NULL, NULL, &error))
-    goto out;
-
-out:
-  g_string_free (resp, TRUE);
-  if (error)
-    {
-      if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE))
-        g_warning ("Failed to write response: %s", error->message);
-      g_error_free (error);
-    }
-}
-
-void
-cockpit_web_server_return_content (GOutputStream *out,
-                                   GHashTable *headers,
-                                   gconstpointer content,
-                                   gsize length)
-{
-  return_response (out, 200, "OK", headers, content, length);
-}
-
-void
-cockpit_web_server_return_error (GOutputStream *out,
-                                 guint code,
-                                 GHashTable *headers,
-                                 const gchar *format,
-                                 ...)
-{
-  gs_free gchar *body = NULL;
-  va_list var_args;
-  gs_free gchar *reason = NULL;
-
-  va_start (var_args, format);
-  reason = g_strdup_vprintf (format, var_args);
-  va_end (var_args);
-
-  g_message ("Returning error-response %d with reason `%s'", code, reason);
-
-  body = g_strdup_printf ("<html><head><title>%d %s</title></head>"
-                          "<body>%s</body></html>",
-                          code, reason,
-                          reason);
-
-  return_response (out, code, reason, headers, body, strlen (body));
-}
-
-void
-cockpit_web_server_return_gerror (GOutputStream *out,
-                                  GHashTable *headers,
-                                  GError *error)
-{
-  int code;
-
-  if (g_error_matches (error,
-                       COCKPIT_ERROR, COCKPIT_ERROR_AUTHENTICATION_FAILED))
-    code = 401;
-  else if (g_error_matches (error,
-                            G_IO_ERROR, G_IO_ERROR_INVALID_DATA))
-    code = 400;
-  else if (g_error_matches (error,
-                            G_IO_ERROR, G_IO_ERROR_NO_SPACE))
-    code = 413;
-  else
-    code = 500;
-
-  cockpit_web_server_return_error (out, code, headers, "%s", error->message);
-}
-
-/* ---------------------------------------------------------------------------------------------------- */
-
-static const struct {
-    const gchar *extension;
-    const gchar *content_type;
-} CONTENT_TYPES[] = {
-  { ".css", "text/css" },
-  { ".gif", "image/gif" },
-  { ".eot", "application/vnd.ms-fontobject" },
-  { ".html", "text/html" },
-  { ".ico", "image/vnd.microsoft.icon" },
-  { ".jpg", "image/jpg" },
-  { ".js", "application/javascript" },
-  { ".otf", "font/opentype" },
-  { ".png", "image/png" },
-  { ".svg", "image/svg+xml" },
-  { ".ttf", "application/octet-stream" }, /* unassigned */
-  { ".woff", "application/font-woff" },
-  { ".xml", "text/xml" },
-};
-
-static void
-serve_static_file (CockpitWebServer *server,
-                   GDataInputStream *input,
-                   GDataOutputStream *output,
-                   const gchar *escaped,
-                   GCancellable *cancellable)
-{
-  GString *str = NULL;
-  GError *local_error = NULL;
-  GError **error = &local_error;
-  gchar *query = NULL;
-  gs_free gchar *unescaped = NULL;
-  gs_free gchar *path = NULL;
-  gs_unref_object GFileInputStream *file_in = NULL;
-  gs_unref_object GFile *f = NULL;
-  gs_unref_object GFileInfo *info = NULL;
-  const gchar **roots;
-  const gchar *root;
-  gint i;
-
-  query = strchr (escaped, '?');
-  if (query != NULL)
-    *query++ = 0;
-
-  if (g_strcmp0 (escaped, "/") == 0)
-    escaped = "/index.html";
-
-  roots = (const gchar **)server->document_roots;
-
-again:
-  root = *(roots++);
-  if (root == NULL)
-    {
-      cockpit_web_server_return_error (G_OUTPUT_STREAM (output), 404, NULL, "Not found");
-      goto out;
-    }
-
-  unescaped = g_uri_unescape_string (escaped, NULL);
-  path = g_build_filename (root, unescaped, NULL);
-  f = g_file_new_for_path (path);
-
-  file_in = g_file_read (f, NULL, error);
-  if (file_in == NULL)
-    {
-      if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
-        {
-          g_clear_error (&local_error);
-          goto again;
-        }
-      else if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED) ||
-               g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_IS_DIRECTORY))
-        {
-          cockpit_web_server_return_error (G_OUTPUT_STREAM (output), 403, NULL, "Access denied");
-          g_clear_error (&local_error);
-          goto out;
-        }
-      else
-        {
-          cockpit_web_server_return_error (G_OUTPUT_STREAM (output), 500, NULL, "Internal server error");
-          goto out;
-        }
-    }
-
-  str = g_string_new ("HTTP/1.1 200 OK\r\n");
-  info = g_file_input_stream_query_info (file_in, G_FILE_ATTRIBUTE_STANDARD_SIZE,
-                                         cancellable, NULL);
-
-  g_string_append (str, "Connection: close\r\n");
-
-  if (info && g_file_info_has_attribute (info, G_FILE_ATTRIBUTE_STANDARD_SIZE))
-    {
-      g_string_append_printf (str,
-                              "Content-Length: %" G_GINT64_FORMAT "\r\n",
-                              g_file_info_get_size (info));
-    }
-
-  for (i = 0; i < G_N_ELEMENTS (CONTENT_TYPES); i++)
-    {
-      if (g_str_has_suffix (path, CONTENT_TYPES[i].extension))
-        {
-          g_string_append_printf (str,
-                                  "Content-Type: %s\r\n",
-                                  CONTENT_TYPES[i].content_type);
-          break;
-        }
-    }
-
-  g_string_append (str, "\r\n");
-
-  if (!g_output_stream_write_all (G_OUTPUT_STREAM (output),
-                                  str->str,
-                                  str->len,
-                                  NULL,
-                                  cancellable,
-                                  error))
-    {
-      g_prefix_error (error, "Error writing %d bytes to output stream: ", (gint) str->len);
-      goto out;
-    }
-
-  if (!g_output_stream_splice (G_OUTPUT_STREAM (output),
-                               G_INPUT_STREAM (file_in),
-                               0,
-                               cancellable,
-                               error))
-    {
-      g_prefix_error (error, "Error splicing to output stream: ");
-      goto out;
-    }
-
-  if (!g_input_stream_close (G_INPUT_STREAM (file_in), cancellable, error))
-    {
-      g_prefix_error (error, "Error closing input stream: ");
-      goto out;
-    }
-
-out:
-  if (local_error != NULL &&
-      !g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE))
-    {
-      g_warning ("Error serving static file: %s (%s, %d)",
-                 local_error->message, g_quark_to_string (local_error->domain), local_error->code);
-    }
-  g_clear_error (&local_error);
-  if (str)
-    g_string_free (str, TRUE);
-}
-
-static void
-process_request (CockpitWebServer *server,
-                 GIOStream *io_stream,
-                 GDataInputStream *input,
-                 GDataOutputStream *output,
-                 gboolean redirect_tls,
-                 GCancellable *cancellable)
+                 guint length)
 {
   gboolean claimed = FALSE;
-  GError *local_error = NULL;
-  GError **error = &local_error;
-  const gchar *escaped;
-  gchar *line = NULL;
-  gsize line_len;
-  gchar *tmp = NULL;
-  gs_unref_hashtable GHashTable *headers = NULL;
-  gs_free gchar *header_line = NULL;
-  CockpitWebServerRequestType reqtype;
-  gs_free gchar *buf = NULL;
 
-  headers = web_socket_util_new_headers ();
-
-  /* First read the request line */
-  line = g_data_input_stream_read_line (input, &line_len, cancellable, error);
-  if (line == NULL)
+  if (request->delayed_reply)
     {
-      if (error != NULL)
-        {
-          g_prefix_error (error, "Error reading request line: ");
-        }
-      else
-        {
-          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                       "Error reading request line (no data)");
-        }
-      goto out;
+      process_delayed_reply (request, path, headers);
+      return;
     }
 
-  /* Then each header */
-  do
-    {
-      gchar *key;
-      gchar *value;
+  /* See if we have any takers... */
+  g_signal_emit (request->web_server,
+                 sig_handle_stream, 0,
+                 reqtype,  /* args */
+                 path,
+                 request->io,
+                 headers,
+                 request->buffer,
+                 length,
+                 &claimed);
 
-      g_free (header_line);
-      header_line = g_data_input_stream_read_line (input, NULL, cancellable, error);
-      if (header_line == NULL)
-        {
-          g_prefix_error (error,
-                          "Error reading header line %d: ",
-                          g_hash_table_size (headers));
-          goto out;
-        }
-
-      if (strlen (header_line) == 0)
-        break;
-
-      tmp = strstr (header_line, ": ");
-      if (tmp == NULL)
-        {
-          g_prefix_error (error,
-                          "Header line %d with content `%s' is malformed: ",
-                          g_hash_table_size (headers),
-                          header_line);
-          goto out;
-        }
-      key = g_strndup (header_line, tmp - header_line);
-      value = g_strdup (tmp + 2);
-      g_strstrip (key);
-      /* transfer ownership of key and value */
-      g_hash_table_insert (headers, key, value);
-    }
-  while (TRUE);
-
-  if (g_str_has_prefix (line, "GET "))
-    {
-      reqtype = COCKPIT_WEB_SERVER_REQUEST_GET;
-      escaped = line + 4; /* Skip "GET " */
-    }
-  else if (g_str_has_prefix (line, "POST "))
-    {
-      reqtype = COCKPIT_WEB_SERVER_REQUEST_POST;
-      escaped = line + 5;
-    }
-  else
-    {
-      cockpit_web_server_return_error (G_OUTPUT_STREAM (output), 501, NULL,
-                                       "Only GET and POST is implemented");
-      goto out;
-    }
-
-  /* TODO: This is a bug, which causes all redirects to go to '/' */
-  tmp = strchr (escaped, ' ');
-  if (tmp != NULL)
-    {
-      *tmp = 0;
-      /* version = tmp + 1; */
-    }
-
-  /* Redirect plain HTTP if configured to use HTTPS */
-  if (redirect_tls)
-    {
-      const gchar *body =
-        "<html><head><title>Moved</title></head>"
-        "<body>Please use TLS</body></html>";
-      const gchar *host;
-      host = g_hash_table_lookup (headers, "Host");
-      g_free (buf);
-      buf = g_strdup_printf ("HTTP/1.1 301 Moved Permanently\r\n"
-                             "Location: https://%s/%s\r\n"
-                             "Content-Length: %d\r\n"
-                             "Connection: close\r\n"
-                             "\r\n"
-                             "%s",
-                             host != NULL ? host : "", tmp,
-                             (gint) strlen (body), body);
-      if (!g_output_stream_write_all (G_OUTPUT_STREAM (output), buf, strlen (buf), NULL, cancellable, error))
-        {
-          g_prefix_error (error, "Error writing 301 to redirect to https://%s/%s: ",
-                          host != NULL ? host : "", tmp);
-          goto out;
-        }
-      goto out;
-    }
-  else
-    {
-      /* See if we have any takers... */
-      g_signal_emit (server,
-                     signals[HANDLE_RESOURCE_SIGNAL],
-                     /* TODO: This is a resource leak */
-                     g_quark_from_string (escaped), /* detail */
-                     reqtype,  /* args */
-                     escaped,
-                     io_stream,
-                     headers,
-                     input,
-                     output,
-                     &claimed);
-      if (claimed)
-        {
-          goto out;
-        }
-      else
-        {
-          /* Don't look for filesystem resources for POST */
-          if (reqtype == COCKPIT_WEB_SERVER_REQUEST_POST)
-            {
-              cockpit_web_server_return_error (G_OUTPUT_STREAM (output), 404, NULL,
-                                               "Not found (use GET)");
-              goto out;
-            }
-
-          serve_static_file (server, input, output, escaped, cancellable);
-        }
-    }
-
-out:
-  if (local_error != NULL)
-    {
-      if (!g_error_matches (local_error, G_TLS_ERROR, G_TLS_ERROR_EOF))
-        g_warning ("Error processing request: %s (%s, %d)",
-                   local_error->message, g_quark_to_string (local_error->domain), local_error->code);
-      g_clear_error (&local_error);
-    }
-
-
-  local_error = NULL;
-  if (!g_io_stream_is_closed (io_stream) && !g_output_stream_is_closed (G_OUTPUT_STREAM (output)) &&
-      !g_output_stream_flush (G_OUTPUT_STREAM (output), NULL, &local_error))
-    {
-      if (!g_error_matches (local_error, G_TLS_ERROR, G_TLS_ERROR_EOF))
-        g_warning ("Error flusing output stream: %s (%s, %d)",
-                   local_error->message, g_quark_to_string (local_error->domain), local_error->code);
-      g_clear_error (&local_error);
-    }
+  if (!claimed)
+    g_critical ("no handler responded to request: %s", path);
 }
 
 static gboolean
-on_run (GThreadedSocketService *service,
-        GSocketConnection *connection,
-        GSocketListener *listener,
-        gpointer user_data)
+parse_and_process_request (CockpitRequest *request)
 {
-  CockpitWebServer *server = COCKPIT_WEB_SERVER (user_data);
-  GError *local_error = NULL;
-  GError **error = &local_error;
-  gs_unref_object GIOStream *io_stream = NULL;
-  GIOStream *tls_stream = NULL;
-  GOutputStream *out = NULL;
-  GInputStream *in = NULL;
-  gs_unref_object GDataInputStream *data = NULL;
-  gs_unref_object GDataOutputStream *out_data = NULL;
-  GCancellable *cancellable = NULL;
-  gboolean redirect_tls = FALSE;
-  GSocketAddress *addr;
-  GInetAddress *inet;
+  CockpitWebServerRequestType reqtype = 0;
+  gboolean again = FALSE;
+  GHashTable *headers = NULL;
+  gchar *method = NULL;
+  gchar *path = NULL;
+  const gchar *str;
+  gchar *end = NULL;
+  gssize off1;
+  gssize off2;
+  guint64 length;
 
-  if (server->certificate != NULL)
+  /* The hard input limit, we just terminate the connection */
+  if (request->buffer->len > cockpit_ws_request_maximum * 2)
     {
-      guchar first_byte;
-      GInputVector vector[1] = {{&first_byte, 1}};
-      gint flags = G_SOCKET_MSG_PEEK;
-      gssize num_read;
+      g_message ("received HTTP request that was too large");
+      goto out;
+    }
 
-      num_read = g_socket_receive_message (g_socket_connection_get_socket (connection),
-                                           NULL, /* out GSocketAddress */
-                                           vector,
-                                           1,
-                                           NULL, /* out GSocketControlMessage */
-                                           NULL, /* out num_messages */
-                                           &flags,
-                                           NULL, /* GCancellable* */
-                                           error);
-      if (num_read == -1)
-        goto out;
+  off1 = web_socket_util_parse_req_line ((const gchar *)request->buffer->data,
+                                         request->buffer->len,
+                                         &method,
+                                         &path);
+  if (off1 == 0)
+    {
+      again = TRUE;
+      goto out;
+    }
+  if (off1 < 0)
+    {
+      g_message ("received invalid HTTP request line");
+      goto out;
+    }
 
-      /* TLS streams are guaranteed to start with octet 22.. this way we can distinguish them
-       * from regular HTTP requests
-       */
-      if (first_byte != 22 && first_byte != 0x80)
+  off2 = web_socket_util_parse_headers ((const gchar *)request->buffer->data + off1,
+                                        request->buffer->len - off1,
+                                        &headers);
+  if (off2 == 0)
+    {
+      again = TRUE;
+      goto out;
+    }
+  if (off2 < 0)
+    {
+      g_message ("received invalid HTTP request headers");
+      goto out;
+    }
+
+  /* If we get a Content-Length then we have to read that much data */
+  length = 0;
+  str = g_hash_table_lookup (headers, "Content-Length");
+  if (str != NULL)
+    {
+      end = NULL;
+      length = g_ascii_strtoull (str, &end, 10);
+      if (!end || end[0])
         {
-          redirect_tls = TRUE;
-          addr = g_socket_connection_get_remote_address (connection, NULL);
-          if (G_IS_INET_SOCKET_ADDRESS (addr))
-            {
-              inet = g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS (addr));
-              redirect_tls = !g_inet_address_get_is_loopback (inet);
-            }
-          g_clear_object (&addr);
-          goto not_tls;
+          g_message ("received invalid Content-Length");
+          request->delayed_reply = 400;
+          goto out;
         }
 
-      tls_stream = g_tls_server_connection_new (G_IO_STREAM (connection),
-                                                server->certificate,
-                                                error);
-      if (tls_stream == NULL)
-        goto out;
+      /* The soft limit, we return 413 */
+      if (length > cockpit_ws_request_maximum)
+        {
+          g_debug ("received too large Content-Length");
+          request->delayed_reply = 413;
+        }
+    }
 
-      io_stream = tls_stream;
-      in = g_io_stream_get_input_stream (G_IO_STREAM (tls_stream));
-      out = g_io_stream_get_output_stream (G_IO_STREAM (tls_stream));
-      redirect_tls = FALSE;
+  /* Not enough data yet */
+  if (request->buffer->len < off1 + off2 + length)
+    {
+      again = TRUE;
+      goto out;
+    }
+
+  if (g_str_equal (method, "GET"))
+    reqtype = COCKPIT_WEB_SERVER_REQUEST_GET;
+  else if (g_str_equal (method, "POST"))
+    reqtype = COCKPIT_WEB_SERVER_REQUEST_POST;
+  else
+    {
+      g_message ("received unsupported HTTP method");
+      request->delayed_reply = 405;
+    }
+
+  /*
+   * TODO: the following are not implemented and required by HTTP/1.1
+   *  * Transfer-Encoding: chunked (for requests)
+   *
+   * TODO: The following would help speed up cockpit:
+   *  * keep-alives
+   */
+
+  g_byte_array_remove_range (request->buffer, 0, off1 + off2);
+  process_request (request, reqtype, path, headers, length);
+
+out:
+  if (headers)
+    g_hash_table_unref (headers);
+  g_free (method);
+  g_free (path);
+  if (!again)
+    cockpit_request_finish (request);
+  return again;
+}
+
+static gboolean
+should_suppress_request_error (GError *error)
+{
+  if (g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_EOF))
+    {
+      g_debug ("request error: %s", error->message);
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
+static gboolean
+on_request_input (GObject *pollable_input,
+                  gpointer user_data)
+{
+  GPollableInputStream *input = (GPollableInputStream *)pollable_input;
+  CockpitRequest *request = user_data;
+  GError *error = NULL;
+  gsize length;
+  gssize count;
+
+  length = request->buffer->len;
+  g_byte_array_set_size (request->buffer, length + 4096);
+
+  count = g_pollable_input_stream_read_nonblocking (input, request->buffer->data + length,
+                                                    4096, NULL, &error);
+  if (count < 0)
+    {
+      g_byte_array_set_size (request->buffer, length);
+
+      /* Just wait and try again */
+      if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK))
+        {
+          g_error_free (error);
+          return TRUE;
+        }
+
+      if (!should_suppress_request_error (error))
+        g_warning ("couldn't read from connection: %s", error->message);
+
+      cockpit_request_finish (request);
+      g_error_free (error);
+      return FALSE;
+    }
+
+  g_byte_array_set_size (request->buffer, length + count);
+
+  if (count == 0)
+    {
+      g_debug ("caller closed connection early");
+      cockpit_request_finish (request);
+      return FALSE;
+    }
+
+  return parse_and_process_request (request);
+}
+
+static void
+start_request_input (CockpitRequest *request)
+{
+  GPollableInputStream *poll_in;
+  GInputStream *in;
+
+  g_debug ("starting web input");
+
+  /* Both GSocketConnection and GTlsServerConnection are pollable */
+  in = g_io_stream_get_input_stream (request->io);
+  poll_in = NULL;
+  if (G_IS_POLLABLE_INPUT_STREAM (in))
+    poll_in = (GPollableInputStream *)in;
+
+  if (!poll_in || !g_pollable_input_stream_can_poll (poll_in))
+    {
+      g_critical ("cannot use a non-pollable input stream: %s", G_OBJECT_TYPE_NAME (in));
+      cockpit_request_finish (request);
+      return;
+    }
+
+  /* Replace with a new source */
+  if (request->source)
+    {
+      g_source_destroy (request->source);
+      g_source_unref (request->source);
+    }
+
+  request->source = g_pollable_input_stream_create_source (poll_in, NULL);
+  g_source_set_callback (request->source, (GSourceFunc)on_request_input, request, NULL);
+  g_source_attach (request->source, request->web_server->main_context);
+}
+
+static gboolean
+on_socket_input (GSocket *socket,
+                 GIOCondition condition,
+                 gpointer user_data)
+{
+  CockpitRequest *request = user_data;
+  guchar first_byte;
+  GInputVector vector[1] = { { &first_byte, 1 } };
+  gint flags = G_SOCKET_MSG_PEEK;
+  gboolean redirect_tls;
+  gboolean is_tls;
+  GSocketAddress *addr;
+  GInetAddress *inet;
+  GError *error = NULL;
+  GIOStream *tls_stream;
+  gssize num_read;
+
+  g_debug ("peeking first incoming web byte");
+
+  num_read = g_socket_receive_message (socket,
+                                       NULL, /* out GSocketAddress */
+                                       vector,
+                                       1,
+                                       NULL, /* out GSocketControlMessage */
+                                       NULL, /* out num_messages */
+                                       &flags,
+                                       NULL, /* GCancellable* */
+                                       &error);
+  if (num_read < 0)
+    {
+      /* Just wait and try again */
+      if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK))
+        {
+          g_error_free (error);
+          return TRUE;
+        }
+
+      if (!should_suppress_request_error (error))
+        g_warning ("couldn't read from socket: %s", error->message);
+
+      cockpit_request_finish (request);
+      g_error_free (error);
+      return FALSE;
+    }
+
+  is_tls = TRUE;
+  redirect_tls = FALSE;
+
+  /*
+   * TLS streams are guaranteed to start with octet 22.. this way we can distinguish them
+   * from regular HTTP requests
+   */
+  if (first_byte != 22 && first_byte != 0x80)
+    {
+      is_tls = FALSE;
+      redirect_tls = TRUE;
+      addr = g_socket_connection_get_remote_address (G_SOCKET_CONNECTION (request->io), NULL);
+      if (G_IS_INET_SOCKET_ADDRESS (addr))
+        {
+          inet = g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS (addr));
+          redirect_tls = !g_inet_address_get_is_loopback (inet);
+        }
+      g_clear_object (&addr);
+    }
+
+  if (is_tls)
+    {
+      tls_stream = g_tls_server_connection_new (request->io,
+                                                request->web_server->certificate,
+                                                &error);
+      if (tls_stream == NULL)
+        {
+          g_warning ("couldn't create new TLS stream: %s", error->message);
+          cockpit_request_finish (request);
+          g_error_free (error);
+          return FALSE;
+        }
+
+      g_object_unref (request->io);
+      request->io = G_IO_STREAM (tls_stream);
+    }
+  else if (redirect_tls)
+    {
+      request->delayed_reply = 301;
+    }
+
+  start_request_input (request);
+
+  /* No longer run *this* source */
+  return FALSE;
+}
+
+static gboolean
+on_request_timeout (gpointer data)
+{
+  CockpitRequest *request = data;
+  g_message ("request timed out, closing");
+  cockpit_request_finish (request);
+  return FALSE;
+}
+
+static gboolean
+on_incoming (GSocketService *service,
+             GSocketConnection *connection,
+             GObject *source_object,
+             gpointer user_data)
+{
+  CockpitWebServer *self = COCKPIT_WEB_SERVER (user_data);
+  CockpitRequest *request;
+  GSocket *socket;
+
+  g_debug ("incoming connection");
+
+  request = g_new0 (CockpitRequest, 1);
+  request->web_server = self;
+  request->io = g_object_ref (connection);
+  request->buffer = g_byte_array_new ();
+
+  request->timeout = g_timeout_source_new_seconds (cockpit_ws_request_timeout);
+  g_source_set_callback (request->timeout, on_request_timeout, request, NULL);
+  g_source_attach (request->timeout, self->main_context);
+
+  socket = g_socket_connection_get_socket (connection);
+  g_socket_set_blocking (socket, FALSE);
+
+  /* Owns the request */
+  g_hash_table_add (self->requests, request);
+
+  if (self->certificate)
+    {
+      g_debug ("creating socket source");
+      request->source = g_socket_create_source (socket, G_IO_IN, NULL);
+      g_source_set_callback (request->source, (GSourceFunc)on_socket_input, request, NULL);
+      g_source_attach (request->source, self->main_context);
     }
   else
     {
-not_tls:
-      io_stream = g_object_ref (connection);
-      in = g_io_stream_get_input_stream (G_IO_STREAM (connection));
-      out = g_io_stream_get_output_stream (G_IO_STREAM (connection));
+      start_request_input (request);
     }
 
-  data = g_data_input_stream_new (in);
-  g_data_input_stream_set_byte_order (data, G_DATA_STREAM_BYTE_ORDER_BIG_ENDIAN);
-
-  out_data = g_data_output_stream_new (out);
-  g_data_output_stream_set_byte_order (out_data, G_DATA_STREAM_BYTE_ORDER_BIG_ENDIAN);
-
-  /* Be tolerant of input */
-  g_data_input_stream_set_newline_type (data, G_DATA_STREAM_NEWLINE_TYPE_ANY);
-
-  /* Keep serving until requested to not to anymore */
-  process_request (server, io_stream, data, out_data, redirect_tls, cancellable);
-
-  /* Forcibly close the connection when we're done */
-  (void) g_io_stream_close (G_IO_STREAM (connection), cancellable, NULL);
-  if (tls_stream != NULL)
-    {
-      (void) g_io_stream_close ((GIOStream*)tls_stream, cancellable, NULL);
-    }
-
-out:
-  if (local_error)
-    {
-      g_warning ("Serving the stream resulted in error: %s (%s, %d)",
-                 local_error->message, g_quark_to_string (local_error->domain), local_error->code);
-      g_clear_error (&local_error);
-    }
-
-  /* Prevent other GThreadedSocket::run handlers from being called (doesn't matter,
-   * we're the only one)
-   */
-
+  /* handled */
   return TRUE;
 }
 
@@ -926,7 +973,7 @@ cockpit_web_server_initable_init (GInitable *initable,
   gboolean failed;
   int n, fd;
 
-  server->socket_service = g_threaded_socket_service_new (G_MAXINT);
+  server->socket_service = g_socket_service_new ();
 
   n = sd_listen_fds (0);
   if (n > 0)
@@ -978,8 +1025,8 @@ cockpit_web_server_initable_init (GInitable *initable,
     }
 
   g_signal_connect (server->socket_service,
-                    "run",
-                    G_CALLBACK (on_run),
+                    "incoming",
+                    G_CALLBACK (on_incoming),
                     server);
 
   ret = TRUE;

--- a/src/ws/cockpitwebserver.h
+++ b/src/ws/cockpitwebserver.h
@@ -54,21 +54,6 @@ gboolean           cockpit_web_server_parse_cookies (GHashTable *headers,
                                                      GHashTable **out_cookies,
                                                      GError **error);
 
-void              cockpit_web_server_return_content (GOutputStream *out,
-                                                     GHashTable *headers,
-                                                     gconstpointer content,
-                                                     gsize length);
-
-void               cockpit_web_server_return_error  (GOutputStream *out,
-                                                     guint code,
-                                                     GHashTable *headers,
-                                                     const char *format,
-                                                     ...) G_GNUC_PRINTF (4, 5);
-
-void               cockpit_web_server_return_gerror (GOutputStream *out,
-                                                     GHashTable *headers,
-                                                     GError *error);
-
 G_END_DECLS
 
 #endif /* __COCKPIT_WEB_SERVER_H__ */

--- a/src/ws/cockpitwebservice.h
+++ b/src/ws/cockpitwebservice.h
@@ -31,12 +31,13 @@ G_BEGIN_DECLS
 
 typedef struct _CockpitWebService   CockpitWebService;
 
-GType        cockpit_web_service_get_type    (void);
+GType                cockpit_web_service_get_type    (void);
 
-void         cockpit_web_service_socket      (GIOStream *io_stream,
-                                              GHashTable *headers,
-                                              GByteArray *input_buffer,
-                                              CockpitAuth *auth);
+CockpitWebService *  cockpit_web_service_socket      (GIOStream *io_stream,
+                                                      GHashTable *headers,
+                                                      GByteArray *input_buffer,
+                                                      CockpitAuth *auth,
+                                                      CockpitCreds *creds);
 
 G_END_DECLS
 

--- a/src/ws/cockpitws.h
+++ b/src/ws/cockpitws.h
@@ -28,11 +28,18 @@ G_BEGIN_DECLS
 #include <cockpitwebserver.h>
 #include <cockpitauth.h>
 
-/* Some tunables that can be set from tests. See cockpitwebsocket.c */
+/* Some tunables that can be set from tests. */
+
+/* From cockpitwebsocket.c */
 extern const gchar *cockpit_ws_session_program;
 extern const gchar *cockpit_ws_agent_program;
 extern const gchar *cockpit_ws_known_hosts;
+extern const gchar *cockpit_ws_default_host_header;
 extern gint cockpit_ws_specific_ssh_port;
+
+/* From cockpitwebserver */
+extern guint cockpit_ws_request_timeout;
+extern gsize cockpit_ws_request_maximum;
 
 G_END_DECLS
 

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -294,7 +294,7 @@ main (int argc,
 
   /* Ignores stuff it shouldn't handle */
   g_signal_connect (server,
-                    "handle-resource",
+                    "handle-stream",
                     G_CALLBACK (cockpit_handler_socket),
                     &data);
 

--- a/src/ws/mock-io-stream.c
+++ b/src/ws/mock-io-stream.c
@@ -99,3 +99,295 @@ mock_io_stream_new (GInputStream  *input_stream,
   stream->output_stream = g_object_ref (output_stream);
   return G_IO_STREAM (stream);
 }
+
+struct _MockOutputStream {
+  GOutputStream parent;
+  GString *buffer;
+  GError *write_error;
+  GError *flush_error;
+  GError *close_error;
+};
+
+typedef struct {
+  GOutputStreamClass parent;
+} MockOutputStreamClass;
+
+static void mock_output_stream_pollable_init (GPollableOutputStreamInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (MockOutputStream, mock_output_stream, G_TYPE_OUTPUT_STREAM,
+                         G_IMPLEMENT_INTERFACE (G_TYPE_POLLABLE_OUTPUT_STREAM, mock_output_stream_pollable_init);
+);
+
+static void
+mock_output_stream_init (MockOutputStream *self)
+{
+
+}
+
+static void
+mock_output_stream_finalize (GObject *object)
+{
+  MockOutputStream *self = (MockOutputStream *)object;
+
+  g_string_free (self->buffer, TRUE);
+  g_clear_error (&self->write_error);
+  g_clear_error (&self->flush_error);
+  g_clear_error (&self->close_error);
+
+  G_OBJECT_CLASS (mock_output_stream_parent_class)->finalize (object);
+}
+
+static gssize
+mock_output_stream_write (GOutputStream *stream,
+                          const void *buffer,
+                          gsize count,
+                          GCancellable *cancellable,
+                          GError **error)
+{
+  MockOutputStream *self = MOCK_OUTPUT_STREAM (stream);
+
+  if (self->write_error)
+    {
+      g_propagate_error (error, self->write_error);
+      self->write_error = NULL;
+      return -1;
+    }
+
+  if (g_cancellable_set_error_if_cancelled (cancellable, error))
+    return -1;
+
+  if (count == 0)
+    return 0;
+
+  if (count > 16)
+    {
+      g_string_append_len (self->buffer, buffer, 16);
+      return 16;
+    }
+  else
+    {
+      g_string_append_len (self->buffer, buffer, count);
+      return count;
+    }
+}
+
+static void
+mock_output_stream_write_async (GOutputStream *stream,
+                                const void *buffer,
+                                gsize count,
+                                int io_priority,
+                                GCancellable *cancellable,
+                                GAsyncReadyCallback callback,
+                                gpointer user_data)
+{
+  GSimpleAsyncResult *result;
+  GError *error = NULL;
+  gssize res;
+
+  result = g_simple_async_result_new (G_OBJECT (stream), callback, user_data,
+                                      mock_output_stream_write_async);
+
+  res = mock_output_stream_write (stream, buffer, count, cancellable, &error);
+  g_simple_async_result_set_op_res_gssize (result, res);
+  if (error)
+    g_simple_async_result_take_error (result, error);
+  g_simple_async_result_complete_in_idle (result);
+  g_object_unref (result);
+}
+
+static gssize
+mock_output_stream_write_finish (GOutputStream *stream,
+                                 GAsyncResult *result,
+                                 GError **error)
+{
+  g_return_val_if_fail (g_simple_async_result_is_valid (result, G_OBJECT (stream),
+                                                        mock_output_stream_write_async), FALSE);
+
+  if (g_simple_async_result_propagate_error (G_SIMPLE_ASYNC_RESULT (result), error))
+    return -1;
+
+  return g_simple_async_result_get_op_res_gssize (G_SIMPLE_ASYNC_RESULT (result));
+}
+
+static gboolean
+mock_output_stream_flush (GOutputStream *stream,
+                          GCancellable *cancellable,
+                          GError **error)
+{
+  MockOutputStream *self = MOCK_OUTPUT_STREAM (stream);
+
+  if (self->flush_error)
+    {
+      g_propagate_error (error, self->flush_error);
+      self->flush_error = NULL;
+      return FALSE;
+    }
+
+  if (g_cancellable_set_error_if_cancelled (cancellable, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static void
+mock_output_stream_flush_async (GOutputStream *stream,
+                                int io_priority,
+                                GCancellable *cancellable,
+                                GAsyncReadyCallback callback,
+                                gpointer data)
+{
+  GSimpleAsyncResult *result;
+
+  result = g_simple_async_result_new (G_OBJECT (stream), callback, data,
+                                      mock_output_stream_flush_async);
+
+  if (cancellable)
+    {
+      g_simple_async_result_set_op_res_gpointer (result,
+                                                 g_object_ref (cancellable),
+                                                 g_object_unref);
+    }
+
+  g_simple_async_result_complete_in_idle (result);
+  g_object_unref (result);
+}
+
+static gboolean
+mock_output_stream_flush_finish (GOutputStream *stream,
+                                 GAsyncResult *result,
+                                 GError **error)
+{
+  GCancellable *cancellable;
+
+  g_return_val_if_fail (g_simple_async_result_is_valid (result, G_OBJECT (stream),
+                                                        mock_output_stream_flush_async), FALSE);
+
+  cancellable = g_simple_async_result_get_op_res_gpointer (G_SIMPLE_ASYNC_RESULT (result));
+  return mock_output_stream_flush (stream, cancellable, error);
+}
+
+static gboolean
+mock_output_stream_close (GOutputStream *stream,
+                          GCancellable *cancellable,
+                          GError **error)
+{
+  MockOutputStream *self = MOCK_OUTPUT_STREAM (stream);
+
+  if (self->close_error)
+    {
+      g_propagate_error (error, self->close_error);
+      self->close_error = NULL;
+      return FALSE;
+    }
+
+  if (g_cancellable_set_error_if_cancelled (cancellable, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static void
+mock_output_stream_close_async (GOutputStream *stream,
+                                int io_priority,
+                                GCancellable *cancellable,
+                                GAsyncReadyCallback callback,
+                                gpointer data)
+{
+  GSimpleAsyncResult *result;
+
+  result = g_simple_async_result_new (G_OBJECT (stream), callback, data,
+                                      mock_output_stream_close_async);
+
+  if (cancellable)
+    {
+      g_simple_async_result_set_op_res_gpointer (result,
+                                                 g_object_ref (cancellable),
+                                                 g_object_unref);
+    }
+
+  g_simple_async_result_complete_in_idle (result);
+  g_object_unref (result);
+}
+
+static gboolean
+mock_output_stream_close_finish (GOutputStream *stream,
+                                 GAsyncResult *result,
+                                 GError **error)
+{
+  GCancellable *cancellable;
+
+  g_return_val_if_fail (g_simple_async_result_is_valid (result, G_OBJECT (stream),
+                                                        mock_output_stream_close_async), FALSE);
+
+  cancellable = g_simple_async_result_get_op_res_gpointer (G_SIMPLE_ASYNC_RESULT (result));
+  return mock_output_stream_close (stream, cancellable, error);
+}
+
+static void
+mock_output_stream_class_init (MockOutputStreamClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GOutputStreamClass *ostream_class = G_OUTPUT_STREAM_CLASS (klass);
+
+  object_class->finalize = mock_output_stream_finalize;
+
+  ostream_class->write_fn = mock_output_stream_write;
+  ostream_class->write_async  = mock_output_stream_write_async;
+  ostream_class->write_finish = mock_output_stream_write_finish;
+  ostream_class->close_fn = mock_output_stream_close;
+  ostream_class->close_async  = mock_output_stream_close_async;
+  ostream_class->close_finish = mock_output_stream_close_finish;
+  ostream_class->flush = mock_output_stream_flush;
+  ostream_class->flush_async  = mock_output_stream_flush_async;
+  ostream_class->flush_finish = mock_output_stream_flush_finish;
+}
+
+static gboolean
+mock_output_stream_is_writable (GPollableOutputStream *stream)
+{
+  return TRUE;
+}
+
+static GSource *
+mock_output_stream_create_source (GPollableOutputStream *stream,
+                                  GCancellable *cancellable)
+{
+  GSource *base_source, *pollable_source;
+
+  base_source = g_timeout_source_new (0);
+  pollable_source = g_pollable_source_new_full (stream, base_source, cancellable);
+  g_source_unref (base_source);
+
+  return pollable_source;
+}
+
+static void
+mock_output_stream_pollable_init (GPollableOutputStreamInterface *iface)
+{
+  iface->is_writable = mock_output_stream_is_writable;
+  iface->create_source = mock_output_stream_create_source;
+}
+
+GOutputStream *
+mock_output_stream_new (GString *buffer)
+{
+  MockOutputStream *self = g_object_new (MOCK_TYPE_OUTPUT_STREAM, NULL);
+  self->buffer = buffer;
+  return G_OUTPUT_STREAM (self);
+}
+
+void
+mock_output_stream_fail (MockOutputStream *self,
+                         GError *write_error,
+                         GError *flush_error,
+                         GError *close_error)
+{
+  g_clear_error (&self->write_error);
+  self->write_error = write_error;
+
+  g_clear_error (&self->flush_error);
+  self->flush_error = flush_error;
+
+  g_clear_error (&self->close_error);
+  self->close_error = close_error;
+}

--- a/src/ws/mock-io-stream.h
+++ b/src/ws/mock-io-stream.h
@@ -33,4 +33,20 @@ GType            mock_io_stream_get_type          (void);
 GIOStream *      mock_io_stream_new               (GInputStream *input,
                                                    GOutputStream *output);
 
+#define MOCK_TYPE_OUTPUT_STREAM    (mock_output_stream_get_type ())
+#define MOCK_OUTPUT_STREAM(o)      (G_TYPE_CHECK_INSTANCE_CAST ((o), MOCK_TYPE_OUTPUT_STREAM, MockOutputStream))
+#define MOCK_IS_OUTPUT_STREAM(o)   (G_TYPE_CHECK_INSTANCE_TYPE ((o), MOCK_TYPE_OUTPUT_STREAM))
+
+typedef struct _MockOutputStream MockOutputStream;
+
+GType            mock_output_stream_get_type      (void);
+
+GOutputStream *  mock_output_stream_new           (GString *buffer);
+
+void             mock_output_stream_fail          (MockOutputStream *self,
+                                                   GError *write_error,
+                                                   GError *flush_error,
+                                                   GError *close_error);
+
+
 #endif /* __MOCK_IO_STREAM_H__ */

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -41,85 +41,14 @@ typedef struct {
   CockpitWebServer *server;
   CockpitAuth *auth;
   GHashTable *headers;
+  GHashTable *auth_headers;
   GIOStream *io;
+  CockpitWebResponse *response;
   GMemoryOutputStream *output;
   GMemoryInputStream *input;
-  GDataOutputStream *dataout;
-  GDataInputStream *datain;
+  GByteArray *buffer;
+  gchar *scratch;
 } Test;
-
-static void
-setup (Test *test,
-       gconstpointer data)
-{
-  const gchar *roots[] = { SRCDIR "/src/ws", NULL };
-  GError *error = NULL;
-  const gchar *user;
-
-  test->server = cockpit_web_server_new (0, NULL, roots, NULL, &error);
-  g_assert_no_error (error);
-
-  /* Other test->data fields are fine NULL */
-  memset (&test->data, 0, sizeof (test->data));
-
-  user = g_get_user_name ();
-  test->auth = mock_auth_new (user, PASSWORD);
-
-  test->data.auth = test->auth;
-
-  test->headers = cockpit_web_server_new_table ();
-
-  test->output = G_MEMORY_OUTPUT_STREAM (g_memory_output_stream_new (NULL, 0, g_realloc, g_free));
-  test->dataout = g_data_output_stream_new (G_OUTPUT_STREAM (test->output));
-
-  test->input = G_MEMORY_INPUT_STREAM (g_memory_input_stream_new ());
-  test->datain = g_data_input_stream_new (G_INPUT_STREAM (test->input));
-
-  test->io = mock_io_stream_new (G_INPUT_STREAM (test->input),
-                                 G_OUTPUT_STREAM (test->output));
-}
-
-static void
-teardown (Test *test,
-          gconstpointer data)
-{
-  g_clear_object (&test->auth);
-  g_clear_object (&test->server);
-  g_clear_object (&test->output);
-  g_clear_object (&test->dataout);
-  g_clear_object (&test->input);
-  g_clear_object (&test->dataout);
-  g_clear_object (&test->io);
-  g_hash_table_destroy (test->headers);
-
-  cockpit_assert_expected ();
-}
-
-static const gchar *
-output_as_string (Test *test)
-{
-  g_assert (g_output_stream_flush (G_OUTPUT_STREAM (test->dataout), NULL, NULL));
-  g_assert (g_output_stream_write (G_OUTPUT_STREAM (test->output), "\0", 1, NULL, NULL) == 1);
-  return g_memory_output_stream_get_data (G_MEMORY_OUTPUT_STREAM (test->output));
-}
-
-static void
-test_login_no_cookie (Test *test,
-                      gconstpointer data)
-{
-  gboolean ret;
-
-  cockpit_expect_message ("*Returning error-response 401*");
-
-  ret = cockpit_handler_login (test->server,
-                               COCKPIT_WEB_SERVER_REQUEST_GET, "/login",
-                               test->io, test->headers,
-                               test->datain, test->dataout, &test->data);
-
-  g_assert (ret == TRUE);
-
-  cockpit_assert_strmatch (output_as_string (test), "HTTP/1.1 401 Sorry\r\n*");
-}
 
 static void
 include_cookie_as_if_client (GHashTable *resp_headers,
@@ -138,6 +67,94 @@ include_cookie_as_if_client (GHashTable *resp_headers,
 }
 
 static void
+setup (Test *test,
+       gconstpointer data)
+{
+  const gchar *roots[] = { SRCDIR "/src/ws", NULL };
+  CockpitCreds *creds;
+  GError *error = NULL;
+  const gchar *user;
+  gchar *userpass;
+
+  test->server = cockpit_web_server_new (0, NULL, roots, NULL, &error);
+  g_assert_no_error (error);
+
+  /* Other test->data fields are fine NULL */
+  memset (&test->data, 0, sizeof (test->data));
+
+  user = g_get_user_name ();
+  test->auth = mock_auth_new (user, PASSWORD);
+
+  test->data.auth = test->auth;
+
+  test->headers = cockpit_web_server_new_table ();
+
+  test->output = G_MEMORY_OUTPUT_STREAM (g_memory_output_stream_new (NULL, 0, g_realloc, g_free));
+  test->input = G_MEMORY_INPUT_STREAM (g_memory_input_stream_new ());
+
+  test->io = mock_io_stream_new (G_INPUT_STREAM (test->input),
+                                 G_OUTPUT_STREAM (test->output));
+
+  test->response = cockpit_web_response_new (test->io, NULL);
+
+  test->auth_headers = cockpit_web_server_new_table ();
+  userpass = g_strdup_printf ("%s\n%s", user, PASSWORD);
+  creds = cockpit_auth_check_userpass (test->auth, userpass, FALSE, NULL, test->auth_headers, &error);
+  g_assert_no_error (error);
+  g_assert (creds != NULL);
+  cockpit_creds_unref (creds);
+  include_cookie_as_if_client (test->auth_headers, test->auth_headers);
+  g_free (userpass);
+}
+
+static void
+teardown (Test *test,
+          gconstpointer data)
+{
+  g_clear_object (&test->auth);
+  g_clear_object (&test->server);
+  g_clear_object (&test->output);
+  g_clear_object (&test->input);
+  g_clear_object (&test->io);
+  g_hash_table_destroy (test->headers);
+  g_hash_table_destroy (test->auth_headers);
+  g_free (test->scratch);
+  g_object_unref (test->response);
+
+  cockpit_assert_expected ();
+}
+
+static const gchar *
+output_as_string (Test *test)
+{
+  while (!g_output_stream_is_closed (G_OUTPUT_STREAM (test->output)))
+    g_main_context_iteration (NULL, TRUE);
+
+  g_free (test->scratch);
+  test->scratch = g_strndup (g_memory_output_stream_get_data (test->output),
+                             g_memory_output_stream_get_data_size (test->output));
+  return test->scratch;
+}
+
+static void
+test_login_no_cookie (Test *test,
+                      gconstpointer data)
+{
+  GBytes *input;
+  gboolean ret;
+
+  input = g_bytes_new_static ("", 0);
+  ret = cockpit_handler_login (test->server,
+                               COCKPIT_WEB_SERVER_REQUEST_GET, "/login",
+                               test->headers, input, test->response, &test->data);
+  g_bytes_unref (input);
+
+  g_assert (ret == TRUE);
+
+  cockpit_assert_strmatch (output_as_string (test), "HTTP/1.1 401 Sorry\r\n*");
+}
+
+static void
 test_login_with_cookie (Test *test,
                         gconstpointer data)
 {
@@ -147,6 +164,7 @@ test_login_with_cookie (Test *test,
   gboolean ret;
   gchar *userpass;
   gchar *expect;
+  GBytes *input;
 
   user = g_get_user_name ();
   userpass = g_strdup_printf ("%s\n%s", user, PASSWORD);
@@ -157,10 +175,11 @@ test_login_with_cookie (Test *test,
   include_cookie_as_if_client (test->headers, test->headers);
   g_free (userpass);
 
+  input = g_bytes_new_static ("", 0);
   ret = cockpit_handler_login (test->server,
                                COCKPIT_WEB_SERVER_REQUEST_GET, "/login",
-                               test->io, test->headers,
-                               test->datain, test->dataout, &test->data);
+                               test->headers, input, test->response, &test->data);
+  g_bytes_unref (input);
 
   g_assert (ret == TRUE);
 
@@ -174,14 +193,13 @@ test_login_post_bad (Test *test,
                      gconstpointer data)
 {
   gboolean ret;
+  GBytes *input;
 
-  g_hash_table_insert (test->headers, g_strdup ("Content-Length"), g_strdup ("7"));
-  g_memory_input_stream_add_data (test->input, "boooyah", 7, NULL);
-
-  cockpit_expect_message ("*Returning error-response 400*");
+  input = g_bytes_new ("boooyah", 7);
 
   ret = cockpit_handler_login (test->server, COCKPIT_WEB_SERVER_REQUEST_POST, "/login",
-                               test->io, test->headers, test->datain, test->dataout, &test->data);
+                               test->headers, input, test->response, &test->data);
+  g_bytes_unref (input);
 
   g_assert (ret == TRUE);
   cockpit_assert_strmatch (output_as_string (test), "HTTP/1.1 400 Malformed input\r\n*");
@@ -192,14 +210,16 @@ test_login_post_fail (Test *test,
                       gconstpointer data)
 {
   gboolean ret;
+  GBytes *input;
 
-  g_hash_table_insert (test->headers, g_strdup ("Content-Length"), g_strdup ("8"));
-  g_memory_input_stream_add_data (test->input, "booo\nyah", 8, NULL);
-
-  cockpit_expect_message ("*Returning error-response 401*");
+  input = g_bytes_new_static ("booo\nyah", 8);
 
   ret = cockpit_handler_login (test->server, COCKPIT_WEB_SERVER_REQUEST_POST, "/login",
-                               test->io, test->headers, test->datain, test->dataout, &test->data);
+                               test->headers, input, test->response, &test->data);
+  g_bytes_unref (input);
+
+  while (!g_output_stream_is_closed (G_OUTPUT_STREAM (test->output)))
+    g_main_context_iteration (NULL, TRUE);
 
   g_assert (ret == TRUE);
   cockpit_assert_strmatch (output_as_string (test), "HTTP/1.1 401 Authentication failed\r\n*");
@@ -235,19 +255,17 @@ test_login_post_accept (Test *test,
   const gchar *user;
   const gchar *output;
   GHashTable *headers;
-  gint length;
   CockpitCreds *creds;
+  GBytes *input;
 
   user = g_get_user_name ();
   userpass = g_strdup_printf ("%s\n%s", user, PASSWORD);
-  length = strlen (userpass);
-  g_hash_table_insert (test->headers, g_strdup ("Content-Length"), g_strdup_printf ("%d", length));
-  g_memory_input_stream_add_data (test->input, userpass, length, g_free);
+  input = g_bytes_new_take (userpass, strlen (userpass));
 
   ret = cockpit_handler_login (test->server,
                                COCKPIT_WEB_SERVER_REQUEST_POST, "/login",
-                               test->io, test->headers,
-                               test->datain, test->dataout, &test->data);
+                               test->headers, input, test->response, &test->data);
+  g_bytes_unref (input);
 
   g_assert (ret == TRUE);
 
@@ -276,11 +294,13 @@ test_cockpitdyn (Test *test,
   gboolean ret;
   gchar hostname[256];
   gchar *expected;
+  GBytes *input;
 
+  input = g_bytes_new_static ("", 0);
   ret = cockpit_handler_cockpitdyn (test->server,
                                     COCKPIT_WEB_SERVER_REQUEST_GET, "/cockpitdyn.js",
-                                    test->io, test->headers,
-                                    test->datain, test->dataout, &test->data);
+                                    test->headers, input, test->response, &test->data);
+  g_bytes_unref (input);
 
   g_assert (ret == TRUE);
 
@@ -300,17 +320,64 @@ test_logout (Test *test,
 {
   const gchar *output;
   gboolean ret;
+  GBytes *input;
 
+  input = g_bytes_new_static ("", 0);
   ret = cockpit_handler_logout (test->server,
                                 COCKPIT_WEB_SERVER_REQUEST_GET, "/logout",
-                                test->io, test->headers,
-                                test->datain, test->dataout, &test->data);
+                                test->headers, input, test->response, &test->data);
+  g_bytes_unref (input);
 
   g_assert (ret == TRUE);
 
   output = output_as_string (test);
   cockpit_assert_strmatch (output, "HTTP/1.1 200 OK\r\n*Set-Cookie: CockpitAuth=blank;*Secure*Logged out*");
 }
+
+static void
+test_deauthorize (Test *test,
+                  gconstpointer data)
+{
+  const gchar *output;
+  gboolean ret;
+  GBytes *input;
+
+  input = g_bytes_new_static ("", 0);
+
+  /* Note we are requesting as authenticated user with cookie */
+  ret = cockpit_handler_deauthorize (test->server,
+                                     COCKPIT_WEB_SERVER_REQUEST_GET, "/deauthorize",
+                                     test->auth_headers, input, test->response, &test->data);
+  g_bytes_unref (input);
+
+  g_assert (ret == TRUE);
+
+  output = output_as_string (test);
+  cockpit_assert_strmatch (output, "HTTP/1.1 200 OK\r\n*Deauthorized*");
+}
+
+static void
+test_deauthorize_no_cookie (Test *test,
+                            gconstpointer data)
+{
+  const gchar *output;
+  gboolean ret;
+  GBytes *input;
+
+  input = g_bytes_new_static ("", 0);
+
+  /* Note we are requesting as unauthenticated without cookie */
+  ret = cockpit_handler_deauthorize (test->server,
+                                     COCKPIT_WEB_SERVER_REQUEST_GET, "/deauthorize",
+                                     test->headers, input, test->response, &test->data);
+  g_bytes_unref (input);
+
+  g_assert (ret == TRUE);
+
+  output = output_as_string (test);
+  cockpit_assert_strmatch (output, "HTTP/1.1 401 Unauthorized\r\n*");
+}
+
 
 int
 main (int argc,
@@ -331,6 +398,11 @@ main (int argc,
 
   g_test_add ("/handlers/logout", Test, NULL,
               setup, test_logout, teardown);
+
+  g_test_add ("/handlers/deauthorize/with-cookie", Test, NULL,
+              setup, test_deauthorize, teardown);
+  g_test_add ("/handlers/deauthorize/no-cookie", Test, NULL,
+              setup, test_deauthorize_no_cookie, teardown);
 
   g_test_add ("/handlers/cockpitdyn", Test, NULL,
               setup, test_cockpitdyn, teardown);

--- a/src/ws/test-webresponse.c
+++ b/src/ws/test-webresponse.c
@@ -1,0 +1,580 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitwebresponse.h"
+#include "cockpitwebserver.h"
+
+#include "mock-io-stream.h"
+
+#include "cockpit/cockpittest.h"
+
+#include "websocket/websocket.h"
+
+#include <glib/gstdio.h>
+
+#include <string.h>
+
+typedef struct {
+    CockpitWebResponse *response;
+    GString *scratch;
+    GOutputStream *output;
+} TestCase;
+
+typedef struct {
+    const gchar *path;
+} TestFixture;
+
+static void
+setup (TestCase *tc,
+       gconstpointer data)
+{
+  const TestFixture *fixture = data;
+  const gchar *path = NULL;
+  GInputStream *input;
+  GIOStream *io;
+
+  if (fixture)
+    path = fixture->path;
+
+  tc->scratch = g_string_new ("");
+  input = g_memory_input_stream_new ();
+  tc->output = mock_output_stream_new (tc->scratch);
+  io = mock_io_stream_new (input, tc->output);
+  g_object_unref (input);
+
+  tc->response = cockpit_web_response_new (io, path);
+  g_object_unref (io);
+}
+
+static void
+teardown (TestCase *tc,
+          gconstpointer data)
+{
+  cockpit_assert_expected ();
+
+  g_clear_object (&tc->output);
+  g_clear_object (&tc->response);
+}
+
+static const gchar *
+output_as_string (TestCase *tc)
+{
+  while (!g_output_stream_is_closed (tc->output))
+    g_main_context_iteration (NULL, TRUE);
+  return tc->scratch->str;
+}
+
+static void
+test_get_stream (TestCase *tc,
+                 gconstpointer data)
+{
+  g_assert (MOCK_IS_IO_STREAM (cockpit_web_response_get_stream (tc->response)));
+  cockpit_web_response_complete (tc->response);
+}
+
+static void
+test_return_content (TestCase *tc,
+                     gconstpointer data)
+{
+  const gchar *resp;
+  GBytes *content;
+
+  content = g_bytes_new_static ("the content", 11);
+  cockpit_web_response_content (tc->response, NULL, content, NULL);
+  g_bytes_unref (content);
+
+  resp = output_as_string (tc);
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Length: 11\r\nConnection: close\r\n\r\nthe content");
+}
+
+static void
+test_return_content_headers (TestCase *tc,
+                             gconstpointer data)
+{
+  const gchar *resp;
+  GHashTable *headers;
+  GBytes *content;
+
+  headers = cockpit_web_server_new_table ();
+  g_hash_table_insert (headers, g_strdup ("My-header"), g_strdup ("my-value"));
+
+  content = g_bytes_new_static ("the content", 11);
+  cockpit_web_response_content (tc->response, headers, content, NULL);
+  g_bytes_unref (content);
+  g_hash_table_destroy (headers);
+
+  resp = output_as_string (tc);
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nMy-header: my-value\r\nContent-Length: 11\r\nConnection: close\r\n\r\nthe content");
+}
+
+static void
+test_return_error (TestCase *tc,
+                   gconstpointer data)
+{
+  const gchar *resp;
+
+  cockpit_web_response_error (tc->response, 500, NULL, "Reason here: %s", "booyah");
+
+  resp = output_as_string (tc);
+  g_assert_cmpstr (resp, ==,
+    "HTTP/1.1 500 Reason here: booyah\r\nContent-Length: 96\r\nConnection: close\r\n\r\n<html><head><title>500 Reason here: booyah</title></head><body>Reason here: booyah</body></html>");
+}
+
+static void
+test_return_error_auto (TestCase *tc,
+                        gconstpointer data)
+{
+  const gchar *resp;
+
+  cockpit_web_response_error (tc->response, 500, NULL, NULL);
+
+  resp = output_as_string (tc);
+  g_assert_cmpstr (resp, ==,
+    "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 100\r\nConnection: close\r\n\r\n<html><head><title>500 Internal Server Error</title></head><body>Internal Server Error</body></html>");
+}
+
+static void
+test_return_error_unknown (TestCase *tc,
+                           gconstpointer data)
+{
+  const gchar *resp;
+
+  cockpit_web_response_error (tc->response, 501, NULL, NULL);
+
+  resp = output_as_string (tc);
+  g_assert_cmpstr (resp, ==,
+    "HTTP/1.1 501 Failed\r\nContent-Length: 70\r\nConnection: close\r\n\r\n<html><head><title>501 Failed</title></head><body>Failed</body></html>");
+}
+
+static void
+test_return_error_headers (TestCase *tc,
+                           gconstpointer data)
+{
+  const gchar *resp;
+  GHashTable *headers;
+
+  headers = g_hash_table_new (g_str_hash, g_str_equal);
+  g_hash_table_insert (headers, "Header1", "value1");
+
+  cockpit_web_response_error (tc->response, 500, headers, "Reason here: %s", "booyah");
+
+  g_hash_table_destroy (headers);
+
+  resp = output_as_string (tc);
+  g_assert_cmpstr (resp, ==,
+    "HTTP/1.1 500 Reason here: booyah\r\nHeader1: value1\r\nContent-Length: 96\r\nConnection: close\r\n\r\n<html><head><title>500 Reason here: booyah</title></head><body>Reason here: booyah</body></html>");
+}
+
+static void
+test_return_gerror_headers (TestCase *tc,
+                            gconstpointer data)
+{
+  const gchar *resp;
+  GHashTable *headers;
+  GError *error;
+
+  headers = g_hash_table_new (g_str_hash, g_str_equal);
+  g_hash_table_insert (headers, "Header1", "value1");
+
+  error = g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED, "Reason here: %s", "booyah");
+  cockpit_web_response_gerror (tc->response, headers, error);
+
+  g_error_free (error);
+  g_hash_table_destroy (headers);
+
+  resp = output_as_string (tc);
+  g_assert_cmpstr (resp, ==,
+    "HTTP/1.1 500 Reason here: booyah\r\nHeader1: value1\r\nContent-Length: 96\r\nConnection: close\r\n\r\n<html><head><title>500 Reason here: booyah</title></head><body>Reason here: booyah</body></html>");
+}
+
+static void
+test_file_not_found (TestCase *tc,
+                     gconstpointer user_data)
+{
+  const gchar *roots[] = { BUILDDIR, NULL };
+  cockpit_web_response_file (tc->response, "/non-existant", roots);
+  cockpit_assert_strmatch (output_as_string (tc), "HTTP/1.1 404 Not Found*");
+}
+
+static void
+test_file_directory_denied (TestCase *tc,
+                            gconstpointer user_data)
+{
+  const gchar *roots[] = { BUILDDIR, NULL };
+  cockpit_web_response_file (tc->response, "/src", roots);
+  cockpit_assert_strmatch (output_as_string (tc), "HTTP/1.1 403 Directory Listing Denied*");
+}
+
+static void
+test_file_access_denied (TestCase *tc,
+                         gconstpointer user_data)
+{
+  const gchar *roots[] = { "/tmp", NULL };
+  gchar templ[] = "/tmp/test-temp.XXXXXX";
+
+  if (!g_mkdtemp_full (templ, 0000))
+    g_assert_not_reached ();
+
+  cockpit_web_response_file (tc->response, templ + 4, roots);
+  cockpit_assert_strmatch (output_as_string (tc), "HTTP/1.1 403*");
+
+  g_unlink (templ);
+}
+
+static void
+test_file_breakout_denied (TestCase *tc,
+                           gconstpointer user_data)
+{
+  const gchar *roots[] = { BUILDDIR "/src", NULL };
+  const gchar *breakout = "/../dbus-test.html";
+  gchar *check = g_build_filename (roots[0], breakout, NULL);
+  g_assert (g_file_test (check, G_FILE_TEST_EXISTS));
+  g_free (check);
+  cockpit_web_response_file (tc->response, breakout, roots);
+  cockpit_assert_strmatch (output_as_string (tc), "HTTP/1.1 404*");
+}
+
+static void
+test_file_breakout_non_existant (TestCase *tc,
+                                 gconstpointer user_data)
+{
+  const gchar *roots[] = { BUILDDIR "/src", NULL };
+  const gchar *breakout = "/../non-existant";
+  gchar *check = g_build_filename (roots[0], breakout, NULL);
+  g_assert (!g_file_test (check, G_FILE_TEST_EXISTS));
+  g_free (check);
+  cockpit_web_response_file (tc->response, breakout, roots);
+  cockpit_assert_strmatch (output_as_string (tc), "HTTP/1.1 404*");
+}
+
+static const TestFixture content_type_fixture = {
+  .path = "/dbus-test.html"
+};
+
+static void
+test_content_type (TestCase *tc,
+                   gconstpointer user_data)
+{
+  GHashTable *headers;
+  const gchar *resp;
+  gsize length;
+  guint status;
+  gssize off;
+
+  g_assert (user_data == &content_type_fixture);
+
+  cockpit_web_response_headers (tc->response, 200, "OK", -1, NULL);
+  cockpit_web_response_complete (tc->response);
+
+  resp = output_as_string (tc);
+  length = strlen (resp);
+
+  off = web_socket_util_parse_status_line (resp, length, &status, NULL);
+  g_assert_cmpuint (off, >, 0);
+  g_assert_cmpint (status, ==, 200);
+
+  off = web_socket_util_parse_headers (resp + off, length - off, &headers);
+  g_assert_cmpuint (off, >, 0);
+
+  g_assert_cmpstr (g_hash_table_lookup (headers, "Content-Type"), ==, "text/html");
+
+  g_hash_table_unref (headers);
+}
+
+static void
+test_content_type_override (TestCase *tc,
+                            gconstpointer user_data)
+{
+  GHashTable *headers;
+  const gchar *resp;
+  gsize length;
+  guint status;
+  gssize off;
+
+  g_assert (user_data == &content_type_fixture);
+
+  cockpit_web_response_headers (tc->response, 200, "OK", -1,
+                                "Content-Type", "test/type",
+                                NULL);
+  cockpit_web_response_complete (tc->response);
+
+  resp = output_as_string (tc);
+  length = strlen (resp);
+
+  off = web_socket_util_parse_status_line (resp, length, &status, NULL);
+  g_assert_cmpuint (off, >, 0);
+  g_assert_cmpint (status, ==, 200);
+
+  off = web_socket_util_parse_headers (resp + off, length - off, &headers);
+  g_assert_cmpuint (off, >, 0);
+
+  g_assert_cmpstr (g_hash_table_lookup (headers, "Content-Type"), ==, "test/type");
+
+  g_hash_table_unref (headers);
+}
+
+static void
+test_dispose_early (TestCase *tc,
+                    gconstpointer data)
+{
+  GBytes *block;
+
+  block = g_bytes_new_static ("blah", 4);
+  cockpit_web_response_queue (tc->response, block);
+  g_bytes_unref (block);
+
+  cockpit_expect_critical ("*freed without being completed properly*");
+
+  g_object_unref (tc->response);
+  tc->response = NULL;
+}
+
+static void
+test_write_fail (TestCase *tc,
+                 gconstpointer data)
+{
+  GBytes *block;
+
+  mock_output_stream_fail (MOCK_OUTPUT_STREAM (tc->output),
+                           g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED, "Oh marmalade"),
+                           NULL, NULL);
+
+  block = g_bytes_new_static ("blah", 4);
+
+  /* Queing the first block should be okay */
+  if (!cockpit_web_response_queue (tc->response, block))
+    g_assert_not_reached ();
+
+  cockpit_expect_warning ("*Oh marmalade");
+
+  /* Wait for the error to happen */
+  while (!g_output_stream_is_closed (tc->output))
+    g_main_context_iteration (NULL, FALSE);
+
+  cockpit_assert_expected ();
+
+  /* Should return FALSE */
+  if (cockpit_web_response_queue (tc->response, block))
+    g_assert_not_reached ();
+
+  cockpit_web_response_complete (tc->response);
+
+  g_bytes_unref (block);
+}
+
+static void
+test_write_disconnect (TestCase *tc,
+                       gconstpointer data)
+{
+  GBytes *block;
+
+  /* An error that should be ignored */
+  mock_output_stream_fail (MOCK_OUTPUT_STREAM (tc->output),
+                           g_error_new (G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE, "Oh marmalade"),
+                           NULL, NULL);
+
+  block = g_bytes_new_static ("blah", 4);
+
+  /* Queing the first block should be okay */
+  if (!cockpit_web_response_queue (tc->response, block))
+    g_assert_not_reached ();
+
+  /* Wait for the error to happen */
+  while (!g_output_stream_is_closed (tc->output))
+    g_main_context_iteration (NULL, FALSE);
+
+  /* Should return FALSE */
+  if (cockpit_web_response_queue (tc->response, block))
+    g_assert_not_reached ();
+
+  g_bytes_unref (block);
+}
+
+static void
+test_write_again (TestCase *tc,
+                  gconstpointer data)
+{
+  GBytes *block;
+
+  /* An error that should be ignored */
+  mock_output_stream_fail (MOCK_OUTPUT_STREAM (tc->output),
+                           g_error_new (G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK, "Oh marmalade"),
+                           NULL, NULL);
+
+  block = g_bytes_new_static ("blah", 4);
+
+  /* Queing the first block should be okay */
+  if (!cockpit_web_response_queue (tc->response, block))
+    g_assert_not_reached ();
+
+  /* Lets just drain that */
+  while (g_main_context_iteration (NULL, FALSE));
+
+  /* Should not return FALSE */
+  if (!cockpit_web_response_queue (tc->response, block))
+    g_assert_not_reached ();
+
+  cockpit_web_response_complete (tc->response);
+  g_bytes_unref (block);
+
+  g_assert_cmpstr (output_as_string (tc), ==, "blahblah");
+}
+
+static void
+test_write_zero (TestCase *tc,
+                  gconstpointer data)
+{
+  GBytes *block;
+  GBytes *zero;
+
+  /* An error that should be ignored */
+  mock_output_stream_fail (MOCK_OUTPUT_STREAM (tc->output),
+                           g_error_new (G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK, "Oh marmalade"),
+                           NULL, NULL);
+
+  block = g_bytes_new_static ("blah", 4);
+  zero = g_bytes_new_static ("", 0);
+
+  /* Queing the first block should be okay */
+  if (!cockpit_web_response_queue (tc->response, block))
+    g_assert_not_reached ();
+
+  /* Lets just drain that */
+  while (g_main_context_iteration (NULL, FALSE));
+
+  if (!cockpit_web_response_queue (tc->response, zero) ||
+      !cockpit_web_response_queue (tc->response, block))
+    g_assert_not_reached ();
+
+  cockpit_web_response_complete (tc->response);
+  g_bytes_unref (block);
+
+  g_assert_cmpstr (output_as_string (tc), ==, "blahblah");
+}
+
+static void
+test_flush_fail (TestCase *tc,
+                 gconstpointer data)
+{
+  GBytes *block;
+
+  mock_output_stream_fail (MOCK_OUTPUT_STREAM (tc->output), NULL,
+                           g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED, "Oh marmalade"),
+                           NULL);
+
+  block = g_bytes_new_static ("blah", 4);
+
+  if (!cockpit_web_response_queue (tc->response, block))
+    g_assert_not_reached ();
+
+  g_bytes_unref (block);
+
+  cockpit_web_response_complete (tc->response);
+
+  cockpit_expect_warning ("*couldn't flush web output: Oh marmalade");
+
+  /* Wait for the error to happen */
+  while (!g_output_stream_is_closed (tc->output))
+    g_main_context_iteration (NULL, FALSE);
+
+  cockpit_assert_expected ();
+}
+
+static void
+test_close_fail (TestCase *tc,
+                 gconstpointer data)
+{
+  GBytes *block;
+
+  mock_output_stream_fail (MOCK_OUTPUT_STREAM (tc->output), NULL, NULL,
+                           g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED, "Oh marmalade"));
+
+  block = g_bytes_new_static ("blah", 4);
+
+  if (!cockpit_web_response_queue (tc->response, block))
+    g_assert_not_reached ();
+
+  g_bytes_unref (block);
+
+  cockpit_web_response_complete (tc->response);
+
+  cockpit_expect_warning ("*couldn't close web output: Oh marmalade");
+
+  /* Wait for the error to happen */
+  while (!g_output_stream_is_closed (tc->output))
+    g_main_context_iteration (NULL, FALSE);
+
+  cockpit_assert_expected ();
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+  cockpit_test_init (&argc, &argv);
+
+  g_test_add ("/web-response/get-stream", TestCase, NULL,
+              setup, test_get_stream, teardown);
+  g_test_add ("/web-response/return-content", TestCase, NULL,
+              setup, test_return_content, teardown);
+  g_test_add ("/web-response/return-content-headers", TestCase, NULL,
+              setup, test_return_content_headers, teardown);
+  g_test_add ("/web-response/return-error", TestCase, NULL,
+              setup, test_return_error, teardown);
+  g_test_add ("/web-response/return-error/auto", TestCase, NULL,
+              setup, test_return_error_auto, teardown);
+  g_test_add ("/web-response/return-error/unknown", TestCase, NULL,
+              setup, test_return_error_unknown, teardown);
+  g_test_add ("/web-response/return-error-headers", TestCase, NULL,
+              setup, test_return_error_headers, teardown);
+  g_test_add ("/web-response/return-gerror-headers", TestCase, NULL,
+              setup, test_return_gerror_headers, teardown);
+  g_test_add ("/web-response/file/not-found", TestCase, NULL,
+              setup, test_file_not_found, teardown);
+  g_test_add ("/web-response/file/directory-denied", TestCase, NULL,
+              setup, test_file_directory_denied, teardown);
+  g_test_add ("/web-response/file/access-denied", TestCase, NULL,
+              setup, test_file_access_denied, teardown);
+  g_test_add ("/web-response/file/breakout-denied", TestCase, NULL,
+              setup, test_file_breakout_denied, teardown);
+  g_test_add ("/web-response/file/breakout-non-existant", TestCase, NULL,
+              setup, test_file_breakout_non_existant, teardown);
+  g_test_add ("/web-response/content-type/auto", TestCase, &content_type_fixture,
+              setup, test_content_type, teardown);
+  g_test_add ("/web-response/content-type/override", TestCase, &content_type_fixture,
+              setup, test_content_type_override, teardown);
+  g_test_add ("/web-response/dispose-early", TestCase, NULL,
+              setup, test_dispose_early, teardown);
+  g_test_add ("/web-response/write-zero", TestCase, NULL,
+              setup, test_write_zero, teardown);
+  g_test_add ("/web-response/write-again", TestCase, NULL,
+              setup, test_write_again, teardown);
+  g_test_add ("/web-response/write-fail", TestCase, NULL,
+              setup, test_write_fail, teardown);
+  g_test_add ("/web-response/write-disconnect", TestCase, NULL,
+              setup, test_write_disconnect, teardown);
+  g_test_add ("/web-response/flush-fail", TestCase, NULL,
+              setup, test_flush_fail, teardown);
+  g_test_add ("/web-response/close-fail", TestCase, NULL,
+              setup, test_close_fail, teardown);
+
+  return g_test_run ();
+}


### PR DESCRIPTION
The main difference here is that things are no longer threaded
when serving HTTP requests.

This is necessary because we'll have some HTTP requests accessing
WebSocket channels in the future and locking everything will be
a major pain.

In addition the following fixes and benefits:
- Don't waste a whole thread on unauthenticated requests.
- Enforce a default 30 second timeout for reading HTTP requests.
- Hard 4096 byte size limit for HTTP request input.
- Don't leak so much internal state into error messages.
- Better setup for queuing and returning responses and guaranteeing
  that they're correct.
- Simpler to read POST input.
- Simpler handlers.
- No memory leak of per request signal detail (ie: the path).
- No expensive GIO for serving files, just use mmap.
- Use proper HTTP status codes for invalid requests
- Fix various races and multi-threading issues due to
  main context usage.
- Fix breaking out of the HTTP document root with double dots.

Although not implemented yet, set the ground work for:
- Chunked Encoding
- Correct HTTP version responses
- Persistent connections (with multiple requests)

Fixes #551
Fixes #550
