### PR TITLE
web: Rename $cockpit.xxx to cockpit.xxx

### DIFF
--- a/src/web/channel.js
+++ b/src/web/channel.js
@@ -71,7 +71,7 @@
  */
 
 var phantom_checkpoint = function () { };
-var $cockpit = $cockpit || { };
+var cockpit = cockpit || { };
 
 function Channel(options) {
     /* Choose a new channel number */
@@ -92,7 +92,7 @@ function Channel(options) {
         var transport = this;
 
         function transport_debug() {
-            if ($cockpit.debugging == "all" || $cockpit.debugging == "channel")
+            if (cockpit.debugging == "all" || cockpit.debugging == "channel")
                 console.debug.apply(console, arguments);
         }
 

--- a/src/web/cockpit-accounts.js
+++ b/src/web/cockpit-accounts.js
@@ -21,7 +21,7 @@ function cockpit_check_role (role, client)
 {
     var acc, i;
 
-    acc = cockpit_find_account ($cockpit.connection_config.user, client);
+    acc = cockpit_find_account (cockpit.connection_config.user, client);
     if (acc) {
         for (i = 0; i < acc.Groups.length; i++) {
             if (acc.Groups[i] == 'wheel' || acc.Groups[i] == role)
@@ -166,7 +166,7 @@ PageAccounts.prototype = {
 
     enter: function() {
         this.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        this.client = $cockpit.dbus(this.address);
+        this.client = cockpit.dbus(this.address);
 
         cockpit_on_account_changes(this.client, "accounts", $.proxy(this, "update"));
         this.update();
@@ -331,7 +331,7 @@ PageAccount.prototype = {
 
     enter: function() {
         this.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        this.client = $cockpit.dbus(this.address);
+        this.client = cockpit.dbus(this.address);
 
         cockpit_on_account_changes(this.client, "account", $.proxy(this, "update"));
         this.real_name_dirty = false;
@@ -414,7 +414,7 @@ PageAccount.prototype = {
     },
 
     check_role_for_self_mod: function () {
-        return (this.account.UserName == $cockpit.connection_config.user ||
+        return (this.account.UserName == cockpit.connection_config.user ||
                 cockpit_check_role ('cockpit-user-admin', this.client));
     },
 

--- a/src/web/cockpit-cpu-status.js
+++ b/src/web/cockpit-cpu-status.js
@@ -29,7 +29,7 @@ PageCpuStatus.prototype = {
     enter: function() {
 
         this.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        this.client = $cockpit.dbus(this.address);
+        this.client = cockpit.dbus(this.address);
 
         var resmon = this.client.get("/com/redhat/Cockpit/CpuMonitor", "com.redhat.Cockpit.ResourceMonitor");
         var options = {

--- a/src/web/cockpit-dashboard.js
+++ b/src/web/cockpit-dashboard.js
@@ -17,9 +17,9 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-var $cockpit = $cockpit || { };
+var cockpit = cockpit || { };
 
-(function($, $cockpit, cockpit_pages) {
+(function($, cockpit, cockpit_pages) {
 
 PageDashboard.prototype = {
     _init: function() {
@@ -45,7 +45,7 @@ PageDashboard.prototype = {
     enter: function() {
         var self = this;
 
-        self.local_client = $cockpit.dbus("localhost");
+        self.local_client = cockpit.dbus("localhost");
         $(self.local_client).on('state-change.dashboard-local', $.proxy(self, "local_client_state_change"));
         $(self.local_client).on('objectAdded.dashboard-local objectRemoved.dashboard-local', function (event, object) {
             if (object.lookup('com.redhat.Cockpit.Machine'))
@@ -76,7 +76,7 @@ PageDashboard.prototype = {
             $('#dashboard-local-disconnected').hide();
         } else {
             if (this.local_client.state == "closed")
-                $('#dashboard-local-error').text($cockpit.client_error_description(this.local_client.error));
+                $('#dashboard-local-error').text(cockpit.client_error_description(this.local_client.error));
             else
                 $('#dashboard-local-error').text("...");
             $('#dashboard-local-disconnected').show();
@@ -137,7 +137,7 @@ PageDashboard.prototype = {
         for (i = 0; i < configured_machines.length; i++) {
             var address = configured_machines[i].Address;
             var machine = { address: address,
-                            client: $cockpit.dbus(address, { }, false),
+                            client: cockpit.dbus(address, { }, false),
                             dbus_iface: configured_machines[i]
                           };
 
@@ -225,7 +225,7 @@ PageDashboard.prototype = {
                 cockpit_action_btn_enable (action_btn, 'connect', true);
                 cockpit_action_btn_enable (action_btn, 'disconnect', false);
                 cockpit_action_btn_select (action_btn, 'connect');
-                error_div.text($cockpit.client_error_description(client.error) || "Disconnected");
+                error_div.text(cockpit.client_error_description(client.error) || "Disconnected");
                 error_div.show();
                 spinner_div.hide();
                 plot_div.hide();
@@ -300,4 +300,4 @@ function PageDashboard() {
 
 cockpit_pages.push(new PageDashboard());
 
-})(jQuery, $cockpit, cockpit_pages);
+})(jQuery, cockpit, cockpit_pages);

--- a/src/web/cockpit-disk-io-status.js
+++ b/src/web/cockpit-disk-io-status.js
@@ -28,7 +28,7 @@ PageDiskIOStatus.prototype = {
 
     enter: function() {
         this.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        this.client = $cockpit.dbus(this.address);
+        this.client = cockpit.dbus(this.address);
 
         var resmon = this.client.get("/com/redhat/Cockpit/DiskIOMonitor", "com.redhat.Cockpit.ResourceMonitor");
         var options = {

--- a/src/web/cockpit-docker.js
+++ b/src/web/cockpit-docker.js
@@ -17,19 +17,19 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-var $cockpit = $cockpit || { };
+var cockpit = cockpit || { };
 
-(function($, $cockpit, cockpit_pages) {
+(function($, cockpit, cockpit_pages) {
 
 var docker_clients = { };
 
 function resource_debug() {
-    if ($cockpit.debugging == "all" || $cockpit.debugging == "resource")
+    if (cockpit.debugging == "all" || cockpit.debugging == "resource")
         console.debug.apply(console, arguments);
 }
 
 function docker_debug() {
-    if ($cockpit.debugging == "all" || $cockpit.debugging == "docker")
+    if (cockpit.debugging == "all" || cockpit.debugging == "docker")
         console.debug.apply(console, arguments);
 }
 
@@ -130,13 +130,13 @@ function format_memory_and_limit(usage, limit) {
     var units = 1024;
     var parts;
     if (limit) {
-        parts = $cockpit.format_bytes(limit, units);
+        parts = cockpit.format_bytes(limit, units);
         mtext = " / " + parts.join(" ");
         units = parts[1];
     }
 
     if (usage) {
-        parts = $cockpit.format_bytes(usage, units);
+        parts = cockpit.format_bytes(usage, units);
         if (mtext)
             return parts[0] + mtext;
         else
@@ -181,7 +181,7 @@ function MemorySlider(sel, min, max) {
         limit = Math.round(slider.value * max);
         if (limit < min)
             limit = min;
-        return $cockpit.format_bytes(limit, 1024).join(" ");
+        return cockpit.format_bytes(limit, 1024).join(" ");
     }
 
     /* Slider to limit amount of memory */
@@ -443,7 +443,7 @@ PageContainers.prototype = {
                 $('<td class="container-col-image">'),
                 $('<td class="container-col-command">'),
                 $('<td class="container-col-cpu">'),
-                $('<td class="container-col-memory-graph">').append($cockpit.BarRow("containers-containers")),
+                $('<td class="container-col-memory-graph">').append(cockpit.BarRow("containers-containers")),
                 $('<td class="container-col-memory-text">'),
                 $('<td class="cell-buttons">').append(btn_play, btn_stop, img_waiting));
             tr.on('click', function(event) {
@@ -498,7 +498,7 @@ PageContainers.prototype = {
             tr = $('<tr id="' + id + '">').append(
                     $('<td class="image-col-tags">'),
                     $('<td class="image-col-created">'),
-                    $('<td class="image-col-size-graph">').append($cockpit.BarRow("container-images")),
+                    $('<td class="image-col-size-graph">').append(cockpit.BarRow("container-images")),
                     $('<td class="image-col-size-text">'),
                     $('<td class="cell-buttons">').append(button));
             tr.on('click', function(event) {
@@ -514,7 +514,7 @@ PageContainers.prototype = {
         $(row[0]).html(multi_line(image.RepoTags));
         $(row[1]).text(new Date(image.Created * 1000).toLocaleString());
         $(row[2]).children("div").attr("value", image.VirtualSize);
-        $(row[3]).text($cockpit.format_bytes(image.VirtualSize, 1024).join(" "));
+        $(row[3]).text(cockpit.format_bytes(image.VirtualSize, 1024).join(" "));
 
         if (added)
             insert_table_sorted($('#containers-images table'), tr);
@@ -765,7 +765,7 @@ PageContainerDetails.prototype = {
 
                 $(commit).find(".container-tag").attr('value', "");
 
-                var author = $cockpit.connection_config.name || $cockpit.connection_config.user;
+                var author = cockpit.connection_config.name || cockpit.connection_config.user;
                 $(commit).find(".container-author").attr('value', author);
 
                 var command = "";
@@ -1055,7 +1055,7 @@ cockpit_pages.push(new PageImageDetails());
 
 function DockerClient(machine) {
     var me = this;
-    var rest = $cockpit.rest("unix:///var/run/docker.sock", machine);
+    var rest = cockpit.rest("unix:///var/run/docker.sock", machine);
 
     var events = rest.get("/events");
     var alive = true;
@@ -1224,7 +1224,7 @@ function DockerClient(machine) {
      * TODO: Call GetSamples for quicker initialization.
      */
 
-    var dbus_client = $cockpit.dbus(machine);
+    var dbus_client = cockpit.dbus(machine);
     var monitor = dbus_client.get ("/com/redhat/Cockpit/LxcMonitor",
                                    "com.redhat.Cockpit.MultiResourceMonitor");
 
@@ -1407,7 +1407,7 @@ function DockerClient(machine) {
         var options = {
             host: cockpit_get_page_param ("machine", "server")
         };
-        $cockpit.spawn(["/bin/sh", "-c", command], options).
+        cockpit.spawn(["/bin/sh", "-c", command], options).
             fail(function(ex) {
                 console.warn(ex);
             });
@@ -1657,4 +1657,4 @@ function DockerTerminal(parent, machine, id) {
     return this;
 }
 
-})(jQuery, $cockpit, cockpit_pages);
+})(jQuery, cockpit, cockpit_pages);

--- a/src/web/cockpit-i18n.js
+++ b/src/web/cockpit-i18n.js
@@ -23,8 +23,8 @@ function cockpit_i18n(string, context) {
         lookup_key = context + "\u0004" + string;
 
     var ret = string;
-    if ($cockpit.language_po) {
-        var translated = $cockpit.language_po[lookup_key];
+    if (cockpit.language_po) {
+        var translated = cockpit.language_po[lookup_key];
         if (translated && translated.length >= 1 && translated[1].length > 0) {
             ret = translated[1];
         }

--- a/src/web/cockpit-internal.js
+++ b/src/web/cockpit-internal.js
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function($cockpit, $){
+(function(cockpit, $){
 
 PageInternal.prototype = {
     _init: function() {
@@ -39,7 +39,7 @@ PageInternal.prototype = {
         $(".cockpit-internal-reauthorize .btn").on("click", function() {
             $(".cockpit-internal-reauthorize span").text("checking...");
             var cmd = "pkcheck --action-id org.freedesktop.policykit.exec --process $$ -u 2>&1";
-            $cockpit.spawn(["/bin/sh", "-c", cmd]).
+            cockpit.spawn(["/bin/sh", "-c", cmd]).
                 stream(function(data) {
                     console.debug(data);
                 }).
@@ -65,4 +65,4 @@ function PageInternal() {
 
 cockpit_pages.push(new PageInternal());
 
-})($cockpit, jQuery);
+})(cockpit, jQuery);

--- a/src/web/cockpit-journal.js
+++ b/src/web/cockpit-journal.js
@@ -455,7 +455,7 @@ PageJournal.prototype = {
         update_priority_buttons (this.query_prio);
 
         this.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        this.client = $cockpit.dbus(this.address);
+        this.client = cockpit.dbus(this.address);
 
         this.journal = this.client.get ("/com/redhat/Cockpit/Journal",
                                         "com.redhat.Cockpit.Journal");

--- a/src/web/cockpit-language.js
+++ b/src/web/cockpit-language.js
@@ -38,7 +38,7 @@ PageDisplayLanguageDialog.prototype = {
             var info = cockpitdyn_supported_languages[code];
             var name = info.name;
             var display_name = cockpit_i18n(name, "display-language");
-            if (code == $cockpit.language_code)
+            if (code == cockpit.language_code)
                 list.append("<option selected=\"true\" value=\"" + code + "\">" + display_name + "</option>");
             else
                 list.append("<option value=\"" + code + "\">" + display_name + "</option>");
@@ -54,8 +54,8 @@ PageDisplayLanguageDialog.prototype = {
                     cockpit_show_error_dialog("Error loading language \"" + code_to_select + "\"");
                 });
                 jqxhr.success(function(data) {
-                    $cockpit.language_code = code_to_select;
-                    $cockpit.language_po = data[code_to_select];
+                    cockpit.language_code = code_to_select;
+                    cockpit.language_po = data[code_to_select];
                     $('#display-language-dialog').modal('hide');
                     // Cool, that worked, update setting
                     cockpit_settings_set("lang-code", code_to_select);
@@ -63,8 +63,8 @@ PageDisplayLanguageDialog.prototype = {
                 });
             } else {
                 // English
-                $cockpit.language_code = "";
-                $cockpit.language_po = null;
+                cockpit.language_code = "";
+                cockpit.language_po = null;
                 // update setting
                 cockpit_settings_set("lang-code", null);
                 $('#display-language-dialog').modal('hide');

--- a/src/web/cockpit-login.js
+++ b/src/web/cockpit-login.js
@@ -17,9 +17,9 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-var $cockpit = $cockpit || { };
+var cockpit = cockpit || { };
 
-(function($cockpit, $) {
+(function(cockpit, $) {
 
 $(function() {
     $(".cockpit-deauthorize-item a").on("click", function(ev) {
@@ -40,7 +40,7 @@ $(function() {
     });
 });
 
-}($cockpit, jQuery));
+}(cockpit, jQuery));
 
 function cockpit_login_update ()
 {
@@ -71,7 +71,7 @@ function cockpit_login_init ()
 	    if (req.readyState == 4) {
                 clearTimeout(timeout_id);
                 if (req.status == 200) {
-                    $cockpit.connection_config = JSON.parse(req.responseText);
+                    cockpit.connection_config = JSON.parse(req.responseText);
                     cockpit_content_show();
                 } else {
                     $("#login-error-message").text(_("Sorry, that didn't work.") + " (" + req.status + ")");
@@ -128,7 +128,7 @@ function cockpit_login_try() {
     req.onreadystatechange = function (event) {
 	if (req.readyState == 4) {
             if (req.status == 200) {
-                $cockpit.connection_config = JSON.parse(req.responseText);
+                cockpit.connection_config = JSON.parse(req.responseText);
                 cockpit_content_show();
             } else {
                 cockpit_login_show();
@@ -149,7 +149,7 @@ function cockpit_logout (reason)
     req.open("POST", loc, true);
     req.onreadystatechange = function (event) {
 	if (req.readyState == 4) {
-            $cockpit._logged_out();
+            cockpit._logged_out();
             cockpit_login_show();
         }
     };
@@ -160,6 +160,6 @@ function cockpit_go_login_account ()
 {
     cockpit_go_server ("localhost",
                        [ { page: "accounts" },
-                         { page: "account", id: $cockpit.connection_config.user }
+                         { page: "account", id: cockpit.connection_config.user }
                        ]);
 }

--- a/src/web/cockpit-main.js
+++ b/src/web/cockpit-main.js
@@ -19,20 +19,20 @@
 
 /* MAIN
 
-   - $cockpit.connection_config
+   - cockpit.connection_config
 
    An object with information about the current connection to the
    interface server when we are logged in.  It has 'user' and 'name'
    fields describing the user account of the logged in user.
 
-   - $cockpit.language_code
-   - $cockpit.language_po
+   - cockpit.language_code
+   - cockpit.language_po
 
    Information about the selected display language.  'language_code'
    contains the symbol identifying the language, such as "de" or "fi".
    'language_po' is a dictionary with the actual translations.
 
-   - client = $cockpit.dbus(address, [options], [auto_reconnect])
+   - client = cockpit.dbus(address, [options], [auto_reconnect])
    - client.release()
 
    Manage the active D-Bus clients.  The 'dbus' function returns a
@@ -49,19 +49,19 @@
    last user.
 */
 
-var $cockpit = $cockpit || { };
+var cockpit = cockpit || { };
 
-(function($, $cockpit) {
+(function($, cockpit) {
 
-$cockpit.dbus = dbus;
+cockpit.dbus = dbus;
 
-$cockpit._logged_out = _logged_out;
+cockpit._logged_out = _logged_out;
 
 $(init);
 
 function init() {
-    $cockpit.language_code = "";
-    $cockpit.language_po = null;
+    cockpit.language_code = "";
+    cockpit.language_po = null;
     cockpit_visited_pages = {};
 
     var lang_code = null;
@@ -101,8 +101,8 @@ function init_load_lang(lang_code) {
         init_done();
     });
     jqxhr.success(function(data) {
-        $cockpit.language_code = lang_code;
-        $cockpit.language_po = data[lang_code];
+        cockpit.language_code = lang_code;
+        cockpit.language_po = data[lang_code];
         init_done();
     });
 }
@@ -167,4 +167,4 @@ function _logged_out() {
         Channel.transport.close('disconnecting');
 }
 
-})(jQuery, $cockpit);
+})(jQuery, cockpit);

--- a/src/web/cockpit-memory-status.js
+++ b/src/web/cockpit-memory-status.js
@@ -28,7 +28,7 @@ PageMemoryStatus.prototype = {
 
     enter: function() {
         this.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        this.client = $cockpit.dbus(this.address);
+        this.client = cockpit.dbus(this.address);
 
         var resmon = this.client.get("/com/redhat/Cockpit/MemoryMonitor", "com.redhat.Cockpit.ResourceMonitor");
         var options = {

--- a/src/web/cockpit-network-traffic-status.js
+++ b/src/web/cockpit-network-traffic-status.js
@@ -29,7 +29,7 @@ PageNetworkTrafficStatus.prototype =
 
     enter: function() {
         this.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        this.client = $cockpit.dbus(this.address);
+        this.client = cockpit.dbus(this.address);
 
         var resmon = this.client.get("/com/redhat/Cockpit/NetworkMonitor", "com.redhat.Cockpit.ResourceMonitor");
         var options = {

--- a/src/web/cockpit-networking.js
+++ b/src/web/cockpit-networking.js
@@ -28,7 +28,7 @@ PageNetworking.prototype = {
 
     enter: function () {
         this.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        this.client = $cockpit.dbus(this.address,
+        this.client = cockpit.dbus(this.address,
                                     { 'service': "org.freedesktop.NetworkManager",
                                       'object-paths': [ "/org/freedesktop/NetworkManager" ]
                                     });

--- a/src/web/cockpit-page.js
+++ b/src/web/cockpit-page.js
@@ -59,7 +59,7 @@ function cockpit_content_init ()
 
 function cockpit_content_show ()
 {
-    $('#content-user-name').text($cockpit.connection_config.name || $cockpit.connection_config.user || "???");
+    $('#content-user-name').text(cockpit.connection_config.name || cockpit.connection_config.user || "???");
 
     $('.page').hide();
     $('#content').show();

--- a/src/web/cockpit-realms.js
+++ b/src/web/cockpit-realms.js
@@ -41,7 +41,7 @@ PageRealms.prototype = {
         var self = this;
 
         self.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        self.client = $cockpit.dbus(self.address);
+        self.client = cockpit.dbus(self.address);
         self.realm_manager = self.client.get("/com/redhat/Cockpit/Realms",
                                              "com.redhat.Cockpit.Realms");
         $(self.realm_manager).on("notify:Joined.realms", $.proxy(self, "update"));

--- a/src/web/cockpit-server.js
+++ b/src/web/cockpit-server.js
@@ -24,7 +24,7 @@ PageServer.prototype = {
 
     enter_breadcrumb: function() {
         this.title_address = cockpit_get_page_param('machine') || "localhost";
-        this.title_client = $cockpit.dbus(this.title_address);
+        this.title_client = cockpit.dbus(this.title_address);
         this.title_manager = this.title_client.get("/com/redhat/Cockpit/Manager",
                                                    "com.redhat.Cockpit.Manager");
         $(this.title_manager).on('notify:PrettyHostname.server-title', cockpit_content_update_loc_trail);
@@ -53,7 +53,7 @@ PageServer.prototype = {
         var self = this;
 
         self.address = cockpit_get_page_param('machine') || "localhost";
-        self.client = $cockpit.dbus(self.address);
+        self.client = cockpit.dbus(self.address);
         $(self.client).on('state-change.server', $.proxy(self, "update"));
 
         self.manager = self.client.get("/com/redhat/Cockpit/Manager",

--- a/src/web/cockpit-services.js
+++ b/src/web/cockpit-services.js
@@ -153,7 +153,7 @@ PageServices.prototype = {
         });
 
         me.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        me.client = $cockpit.dbus(me.address);
+        me.client = cockpit.dbus(me.address);
 
         me.manager = me.client.get("/com/redhat/Cockpit/Services",
                                    "com.redhat.Cockpit.Services");
@@ -316,7 +316,7 @@ PageService.prototype = {
         var me = this;
 
         me.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        me.client = $cockpit.dbus(me.address);
+        me.client = cockpit.dbus(me.address);
 
         me.manager = me.client.get("/com/redhat/Cockpit/Services",
                                    "com.redhat.Cockpit.Services");

--- a/src/web/cockpit-setup.js
+++ b/src/web/cockpit-setup.js
@@ -53,7 +53,7 @@ PageSetupServer.prototype = {
         $("#dashboard_setup_login_password")[0].placeholder = C_("login-screen", "Enter password");
         $('#dashboard_setup_address').on('keyup change', $.proxy (this, 'update_discovered'));
 
-        self.local_client = $cockpit.dbus("localhost");
+        self.local_client = cockpit.dbus("localhost");
         $(self.local_client).on('objectAdded.setup objectRemoved.setup', function (event, object) {
             if (object.lookup('com.redhat.Cockpit.Machine'))
                 self.update_discovered ();
@@ -187,7 +187,7 @@ PageSetupServer.prototype = {
                     /* The given credentials didn't work.  Ask the
                      * user to try again.
                      */
-                    $('#dashboard_setup_login_error').text($cockpit.client_error_description(client.error));
+                    $('#dashboard_setup_login_error').text(cockpit.client_error_description(client.error));
                     self.show_tab('login');
                     return;
                 }
@@ -195,8 +195,8 @@ PageSetupServer.prototype = {
                 /* The connection has failed.  Show the error on every
                  * tab but stay on the current tab.
                  */
-                $('#dashboard_setup_address_error').text($cockpit.client_error_description(client.error));
-                $('#dashboard_setup_login_error').text($cockpit.client_error_description(client.error));
+                $('#dashboard_setup_address_error').text(cockpit.client_error_description(client.error));
+                $('#dashboard_setup_login_error').text(cockpit.client_error_description(client.error));
                 return;
 
             } else if (client.state == "ready") {

--- a/src/web/cockpit-shutdown.js
+++ b/src/web/cockpit-shutdown.js
@@ -56,7 +56,7 @@ PageShutdown.prototype = {
         var me = this;
 
         this.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        this.client = $cockpit.dbus(this.address);
+        this.client = cockpit.dbus(this.address);
 
         this.manager = this.client.get("/com/redhat/Cockpit/Manager",
                                        "com.redhat.Cockpit.Manager");

--- a/src/web/cockpit-storage.js
+++ b/src/web/cockpit-storage.js
@@ -143,7 +143,7 @@ PageStorage.prototype = {
         var self = this;
 
         this.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        this.client = $cockpit.dbus(this.address);
+        this.client = cockpit.dbus(this.address);
         cockpit_watch_jobs(this.client);
 
         this._drives = $("#storage_drives");
@@ -729,7 +729,7 @@ PageStorageDetail.prototype = {
         var id = cockpit_get_page_param("id");
 
         this.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        this.client = $cockpit.dbus(this.address);
+        this.client = cockpit.dbus(this.address);
         cockpit_watch_jobs(this.client);
 
         this._drive = null;

--- a/src/web/cockpit-system-information.js
+++ b/src/web/cockpit-system-information.js
@@ -41,7 +41,7 @@ PageSystemInformation.prototype = {
         var self = this;
 
         self.address = cockpit_get_page_param('machine', 'server') || "localhost";
-        self.client = $cockpit.dbus(self.address);
+        self.client = cockpit.dbus(self.address);
 
         self.manager = self.client.get("/com/redhat/Cockpit/Manager",
                                        "com.redhat.Cockpit.Manager");

--- a/src/web/cockpit-util.js
+++ b/src/web/cockpit-util.js
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-var $cockpit = $cockpit || { };
+var cockpit = cockpit || { };
 
 // Used for escaping things in HTML elements and attributes
 function cockpit_esc(str) {
@@ -43,7 +43,7 @@ function cockpit_debug(str) {
 /*
  * Byte formatting
  *
- * $cockpit.format_bytes(number, [factor])
+ * cockpit.format_bytes(number, [factor])
  * @number: a normal number
  * @factor: optional, either 1000, 1024 or a string suffix
  *
@@ -66,18 +66,18 @@ function cockpit_debug(str) {
  * suffix is returned.
  *
  * Examples:
- *    $cockpit.format_bytes(1000000).join(" ");
- *    $cockpit.format_bytes(1000000, 1024).join(" ");
- *    $cockpit.format_bytes(1000000, "kB").join(" ");
+ *    cockpit.format_bytes(1000000).join(" ");
+ *    cockpit.format_bytes(1000000, 1024).join(" ");
+ *    cockpit.format_bytes(1000000, "kB").join(" ");
  */
-(function($cockpit) {
+(function(cockpit) {
 
 var suffixes = {
     1000: [ null, "kB", "MB", "GB", "TB", "PB", "EB", "ZB" ],
     1024: [ null, "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB" ]
 };
 
-$cockpit.format_bytes = function format_bytes(number, factor) {
+cockpit.format_bytes = function format_bytes(number, factor) {
     var quotient;
     var suffix = null;
 
@@ -125,14 +125,14 @@ $cockpit.format_bytes = function format_bytes(number, factor) {
         return [number.toFixed(1), suffix];
 };
 
-})($cockpit);
+})(cockpit);
 
 function cockpit_format_bytes(num_bytes) {
-    return $cockpit.format_bytes(num_bytes, 1000).join(" ");
+    return cockpit.format_bytes(num_bytes, 1000).join(" ");
 }
 
 function cockpit_format_bytes_pow2(num_bytes) {
-    return $cockpit.format_bytes(num_bytes, 1024).join(" ");
+    return cockpit.format_bytes(num_bytes, 1024).join(" ");
 }
 
 
@@ -441,9 +441,9 @@ function cockpit_parse_bytes (str, def) {
     return NaN;
 }
 
-(function ($cockpit) {
+(function (cockpit) {
 
-$cockpit.client_error_description = client_error_description;
+cockpit.client_error_description = client_error_description;
 function client_error_description (error) {
     if (error == "terminated")
         return _("Your session has been terminated.");
@@ -465,4 +465,4 @@ function client_error_description (error) {
         return error;
 }
 
-})($cockpit);
+})(cockpit);

--- a/src/web/controls.js
+++ b/src/web/controls.js
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
-var $cockpit = $cockpit || { };
+var cockpit = cockpit || { };
 
 /* ----------------------------------------------------------------------------
  * Bar Graphs (in table rows)
@@ -41,13 +41,13 @@ var $cockpit = $cockpit || { };
  * graph should update a short while later.
  *
  * On document creation any div.bar-row are automatically turned into
- * Bar graphs. Or use $cockpit.BarRow('name') constructor.
+ * Bar graphs. Or use cockpit.BarRow('name') constructor.
  *
  * You can also use the el.reflow() function on the element to reflow
  * the corresponding graph.
  */
 
-(function($, $cockpit) {
+(function($, cockpit) {
 
 function reflow_bar_graph(graph, div) {
     var parts;
@@ -179,7 +179,7 @@ function setup_bar_graphs() {
 }
 
 /* Public API */
-$cockpit.BarRow = function BarRow(graph) {
+cockpit.BarRow = function BarRow(graph) {
     var div = $("<div>").addClass('bar-row').attr('graph', graph);
     setup_bar_graph(div);
     return div;
@@ -187,7 +187,7 @@ $cockpit.BarRow = function BarRow(graph) {
 
 $(document).ready(setup_bar_graphs);
 
-})(jQuery, $cockpit);
+})(jQuery, cockpit);
 
 /* ----------------------------------------------------------------------------
  * Sliders
@@ -213,7 +213,7 @@ $(document).ready(setup_bar_graphs);
  * it will get the .slider-warning class and go a bit red.
  *
  * On document creation any div.slider are automatically turned into
- * Bar graphs. Or use $cockpit.Slider() constructor.
+ * Bar graphs. Or use cockpit.Slider() constructor.
  *
  * Slider has the following extra read/write properties:
  *
@@ -225,7 +225,7 @@ $(document).ready(setup_bar_graphs);
  * on('change'): fired when the slider changes, passes value as additional arg.
  */
 
-(function($, $cockpit) {
+(function($, cockpit) {
 
 function resize_flex(slider, flex, total, part) {
     var value = 0;
@@ -333,7 +333,7 @@ function setup_sliders() {
 }
 
 /* Public API */
-$cockpit.Slider = function Slider() {
+cockpit.Slider = function Slider() {
     var div = $("<div class='slider'>").
         append($("<div class='slider-bar'>").
             append($("<div class='slider-thumb'>")));
@@ -343,4 +343,4 @@ $cockpit.Slider = function Slider() {
 
 $(document).ready(setup_sliders);
 
-})(jQuery, $cockpit);
+})(jQuery, cockpit);

--- a/src/web/dbus.js
+++ b/src/web/dbus.js
@@ -114,10 +114,10 @@
 
 var phantom_checkpoint = function () { };
 
-var $cockpit = $cockpit || { };
+var cockpit = cockpit || { };
 
 function dbus_debug() {
-    if ($cockpit.debugging == "all" || $cockpit.debugging == "dbus")
+    if (cockpit.debugging == "all" || cockpit.debugging == "dbus")
         console.debug.apply(console, arguments);
 }
 

--- a/src/web/debug.js
+++ b/src/web/debug.js
@@ -17,9 +17,9 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-var $cockpit = $cockpit || { };
+var cockpit = cockpit || { };
 
-(function($, $cockpit) {
+(function($, cockpit) {
 
 /*
  * HACK: Don't touch window.onerror in phantomjs, once it's non-null
@@ -65,6 +65,6 @@ function lookup_debugging_cookie() {
  * Set this from the javascript console to get debugging or use
  * document.cookie = "debugging=all; " + document.cookie;
  */
-$cockpit.debugging = lookup_debugging_cookie();
+cockpit.debugging = lookup_debugging_cookie();
 
-})(jQuery, $cockpit);
+})(jQuery, cockpit);

--- a/src/web/rest.js
+++ b/src/web/rest.js
@@ -18,9 +18,9 @@
  */
 
 /*
- * API: defined in $cockpit namespace
+ * API: defined in cockpit namespace
  *
- * $cockpit.rest(endpoint, [machine], [options])
+ * cockpit.rest(endpoint, [machine], [options])
  *   @endpoint: a unix socket that looks like 'unix:///path/to/sock'
  *   @machine: optional, a host name of the machine to connect to
  *   @options: optional, a plain object of additional channel options
@@ -34,7 +34,7 @@
  *   Makes a REST JSON GET request to the specified HTTP path.
  *   Returns: a jQuery deferred promise. See below.
  *
- *     $cockpit.rest("unix:///var/run/docker.sock")
+ *     cockpit.rest("unix:///var/run/docker.sock")
  *          .get("/containers/json")
  *              .done(function(resp) {
  *                  console.log(resp);
@@ -69,7 +69,7 @@
  *
  *   Example:
  *
- *      var rest = $cockpit.rest("unix:///var/run/docker.sock");
+ *      var rest = cockpit.rest("unix:///var/run/docker.sock");
  *      var events = rest.get("/events")
  *          .done(function on_done(resp) {
  *              setTimeout(function() {
@@ -114,9 +114,9 @@
  *             status where possible.
  */
 
-var $cockpit = $cockpit || { };
+var cockpit = cockpit || { };
 
-(function($cockpit, $) {
+(function(cockpit, $) {
     "use strict";
 
     /* Translates HTTP error codes to Cockpit codes */
@@ -152,7 +152,7 @@ var $cockpit = $cockpit || { };
     }
 
     function rest_debug() {
-        if ($cockpit.debugging == "all" || $cockpit.debugging == "rest")
+        if (cockpit.debugging == "all" || cockpit.debugging == "rest")
             console.debug.apply(console, arguments);
     }
 
@@ -329,8 +329,8 @@ var $cockpit = $cockpit || { };
     }
 
     /* public */
-    $cockpit.rest = function(endpoint, machine, options) {
+    cockpit.rest = function(endpoint, machine, options) {
         return new Rest(endpoint, machine, options);
     };
 
-}($cockpit, jQuery));
+}(cockpit, jQuery));

--- a/src/web/spawn.js
+++ b/src/web/spawn.js
@@ -18,9 +18,9 @@
  */
 
 /*
- * API: defined in $cockpit namespace
+ * API: defined in cockpit namespace
  *
- * $cockpit.spawn(args, [machine], [options])
+ * cockpit.spawn(args, [machine], [options])
  *   @args: an array of args including process path, or just process path as string
  *   @machine: optional, a host name of the machine to connect to
  *   @options: optional, a plain object of additional channel options
@@ -61,9 +61,9 @@
  *             status where possible.
  */
 
-var $cockpit = $cockpit || { };
+var cockpit = cockpit || { };
 
-(function($cockpit, $) {
+(function(cockpit, $) {
     "use strict";
 
     /* Translates HTTP error codes to Cockpit codes */
@@ -90,12 +90,12 @@ var $cockpit = $cockpit || { };
     }
 
     function spawn_debug() {
-        if ($cockpit.debugging == "all" || $cockpit.debugging == "spawn")
+        if (cockpit.debugging == "all" || cockpit.debugging == "spawn")
             console.debug.apply(console, arguments);
     }
 
     /* public */
-    $cockpit.spawn = function(command, machine, options) {
+    cockpit.spawn = function(command, machine, options) {
         var dfd = new $.Deferred();
 
         var args = { "payload": "text-stream" };
@@ -157,4 +157,4 @@ var $cockpit = $cockpit || { };
         return promise;
     };
 
-}($cockpit, jQuery));
+}(cockpit, jQuery));

--- a/src/web/test-rest.html
+++ b/src/web/test-rest.html
@@ -155,7 +155,7 @@ function MockPeer() {
 }
 
 test("public api", function() {
-    var rest = $cockpit.rest("unix://test");
+    var rest = cockpit.rest("unix://test");
     equal(typeof rest, "object", "rest is an object");
     equal(typeof rest.get, "function", "rest.get() is a function");
     equal(typeof rest.post, "function", "rest.post() is a function");
@@ -177,7 +177,7 @@ asyncTest("simple request", function() {
             "simple request looks correct");
     });
 
-    $cockpit.rest("unix:///test").get("/")
+    cockpit.rest("unix:///test").get("/")
         .done(function(resp) {
             deepEqual(resp, { key: "value" }, "simple request returned right json");
         })
@@ -203,7 +203,7 @@ asyncTest("channel options", function() {
 
     /* Don't care about the result ... */
     var options = { "extra-option": "zerogjuggs" };
-    $cockpit.rest("unix:///my/test/path", "the-other-host.example.com", options).get("/");
+    cockpit.rest("unix:///my/test/path", "the-other-host.example.com", options).get("/");
 });
 
 asyncTest("with params", function() {
@@ -217,7 +217,7 @@ asyncTest("with params", function() {
         this.reply(channel, request, [ "zerog", "juggs" ]);
     });
 
-    $cockpit.rest("unix:///test").get("/test/here", { "key": "value", "name": "Scruffy the Janitor" })
+    cockpit.rest("unix:///test").get("/test/here", { "key": "value", "name": "Scruffy the Janitor" })
         .done(function(resp) {
             deepEqual(resp, [ "zerog", "juggs"], "with params returned right json");
         })
@@ -242,7 +242,7 @@ asyncTest("not found", function() {
         return false;
     });
 
-    $cockpit.rest("unix:///test").get("/not/found")
+    cockpit.rest("unix:///test").get("/not/found")
         .fail(function(ex) {
             equal(ex.problem, "internal-error", "not found mapped to cockpit code");
             strictEqual(ex.status, 404, "not found has status code");
@@ -274,7 +274,7 @@ asyncTest("streaming", function() {
     });
 
     var at = 0;
-    $cockpit.rest("unix:///test").get("/split")
+    cockpit.rest("unix:///test").get("/split")
         .stream(function(resp) {
             var match = { };
             match[at.toString()] = at;
@@ -307,7 +307,7 @@ asyncTest("cancel", function() {
     });
 
     var at = 0;
-    var req = $cockpit.rest("unix:///test").get("/split")
+    var req = cockpit.rest("unix:///test").get("/split")
         .stream(function(resp) {
             var match = { };
             match[at.toString()] = at;
@@ -344,7 +344,7 @@ asyncTest("restart", function() {
         start();
     }
 
-    var req = $cockpit.rest("unix:///test").get("/restart")
+    var req = cockpit.rest("unix:///test").get("/restart")
         .done(function(resp) {
             strictEqual(resp, 1, "restart responded with right initial");
             var next = req.restart();
@@ -365,7 +365,7 @@ asyncTest("post json", function() {
         this.reply(channel, request, { "reply": "Marmallaaade!" });
     });
 
-    $cockpit.rest("unix:///test").post("/scruffy", { "param" : true }, { "request": "oh?" })
+    cockpit.rest("unix:///test").post("/scruffy", { "param" : true }, { "request": "oh?" })
         .done(function(resp) {
             deepEqual(resp, { "reply": "Marmallaaade!" }, "post json got reply");
         })
@@ -386,7 +386,7 @@ asyncTest("post nothing", function() {
         return false;
     });
 
-    $cockpit.rest("unix:///test").post("/nothing")
+    cockpit.rest("unix:///test").post("/nothing")
         .done(function(resp) {
             equal(resp, null, "post nothing got null back");
         })
@@ -405,7 +405,7 @@ asyncTest("delete method", function() {
         this.reply(channel, request, [ "one", "two", "three", "boom" ]);
     });
 
-    $cockpit.rest("unix:///test").del("/undead", { "param": 1 })
+    cockpit.rest("unix:///test").del("/undead", { "param": 1 })
         .done(function(resp) {
             deepEqual(resp, [ "one", "two", "three", "boom" ], "delete method right response");
         })
@@ -425,7 +425,7 @@ asyncTest("immediate close", function() {
         return false;
     });
 
-    $cockpit.rest("unix:///test").get("/")
+    cockpit.rest("unix:///test").get("/")
         .fail(function(ex) {
             equal(ex.problem, "disconnected", "immediate close got disconnected error");
         })
@@ -451,7 +451,7 @@ function failureTest(test_name, reason, response) {
             return false;
         });
 
-        $cockpit.rest("unix:///test").get("/")
+        cockpit.rest("unix:///test").get("/")
             .fail(function(ex) {
                 equal(ex.problem, reason, test_name + " should cause " + reason);
             })

--- a/src/web/test-spawn.html
+++ b/src/web/test-spawn.html
@@ -128,7 +128,7 @@ function MockPeer() {
 }
 
 test("public api", function() {
-    equal(typeof $cockpit.spawn, "function", "spawn is a function");
+    equal(typeof cockpit.spawn, "function", "spawn is a function");
 });
 
 asyncTest("simple request", function() {
@@ -145,7 +145,7 @@ asyncTest("simple request", function() {
         this.close(channel);
     });
 
-    $cockpit.spawn(["/the/path", "arg1", "arg2"]).
+    cockpit.spawn(["/the/path", "arg1", "arg2"]).
         write("input").
         done(function(resp) {
             deepEqual(resp, "output", "simple request returned right json");
@@ -172,7 +172,7 @@ asyncTest("channel options", function() {
 
     /* Don't care about the result ... */
     var options = { "extra-option": "zerogjuggs" };
-    $cockpit.spawn(["/the/path", "arg"], "the-other-host.example.com", options);
+    cockpit.spawn(["/the/path", "arg"], "the-other-host.example.com", options);
 });
 
 asyncTest("streaming", function() {
@@ -186,7 +186,7 @@ asyncTest("streaming", function() {
     });
 
     var at = 0;
-    $cockpit.spawn(["/unused"]).
+    cockpit.spawn(["/unused"]).
         stream(function(resp) {
             equal(String(at), resp, "stream got right data");
             at++;
@@ -208,7 +208,7 @@ asyncTest("with problem", function() {
         peer.close(channel, {"reason": "not-found"});
     });
 
-    $cockpit.spawn("/unused").
+    cockpit.spawn("/unused").
         fail(function(ex) {
             equal(ex.problem, "not-found", "with problem got problem");
             ok(isNaN(ex.exit_signal), "with problem got no signal");
@@ -228,7 +228,7 @@ asyncTest("with status", function() {
         peer.close(channel, {"exit-status": 5});
     });
 
-    $cockpit.spawn("/unused").
+    cockpit.spawn("/unused").
         fail(function(ex) {
             equal(ex.problem, "internal-error", "with status got problem");
             ok(isNaN(ex.exit_signal), "with status got no signal");
@@ -248,7 +248,7 @@ asyncTest("with signal", function() {
         peer.close(channel, {"exit-signal": 15});
     });
 
-    $cockpit.spawn("/unused").
+    cockpit.spawn("/unused").
         fail(function(ex) {
             equal(ex.problem, "internal-error", "with signal got problem");
             strictEqual(ex.exit_signal, 15, "with signal got signal");

--- a/src/web/test-util.html
+++ b/src/web/test-util.html
@@ -56,7 +56,7 @@ test("format_bytes", function() {
 
     expect(checks.length);
     for (var i = 0; i < checks.length; i++) {
-       deepEqual($cockpit.format_bytes(checks[i][0], checks[i][1]), checks[i][2],
+       deepEqual(cockpit.format_bytes(checks[i][0], checks[i][1]), checks[i][2],
                  "format_bytes(" + checks[i][0] + ", " + String(checks[i][1]) + ") = " + checks[i][2].join(" "));
     }
 });

--- a/test/phantom-lib.js
+++ b/test/phantom-lib.js
@@ -82,7 +82,7 @@ function ph_focus(sel)
 
 function ph_dbus_ready (client_address, client_options)
 {
-    var client = $cockpit.dbus(client_address, client_options);
+    var client = cockpit.dbus(client_address, client_options);
     var result = client && client.state == "ready";
     client.release();
     return result;
@@ -94,7 +94,7 @@ function ph_dbus_prop (client_address, client_options, iface, prop, text)
     // the value of the given property
 
     var result = false;
-    var client = $cockpit.dbus(client_address, client_options);
+    var client = cockpit.dbus(client_address, client_options);
     var objs = client.getObjectsFrom("/");
     for (var i = 0; i < objs.length; i++) {
         var obj_iface = objs[i].lookup(iface);
@@ -111,7 +111,7 @@ function ph_dbus_object_prop (client_address, client_options, path, iface, prop,
 {
     // check whether the given property has the given value
 
-    var client = $cockpit.dbus(client_address, client_options);
+    var client = cockpit.dbus(client_address, client_options);
     var proxy = client.lookup(path, iface);
     var result = proxy && proxy[prop] == text;
     client.release()

--- a/tools/js-lint
+++ b/tools/js-lint
@@ -56,7 +56,7 @@ cat <<EOF >$conf
 +define WebSocket
 +define MozWebSocket
 
-+define \$cockpit
++define cockpit
 +define dbus_debug
 
 +define _


### PR DESCRIPTION
Since $zzz is often used to indicate a jQuery selector, and
the usual convention is for global API like document.yyyy
or window.vvv is just in lower case.
