### PR TITLE
ws: Clear login passwords from memory when freeing

### DIFF
--- a/src/cockpit/Makefile-libcockpit.am
+++ b/src/cockpit/Makefile-libcockpit.am
@@ -35,6 +35,8 @@ libcockpit_a_SOURCES = \
 	src/cockpit/cockpitjson.c \
 	src/cockpit/cockpitjson.h \
 	src/cockpit/cockpitlog.h src/cockpit/cockpitlog.c \
+	src/cockpit/cockpitmemory.c \
+	src/cockpit/cockpitmemory.h \
 	src/cockpit/cockpittypes.h \
 	src/cockpit/cockpitpipe.c \
 	src/cockpit/cockpitpipe.h \

--- a/src/cockpit/cockpitmemory.c
+++ b/src/cockpit/cockpitmemory.c
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitmemory.h"
+
+#include <string.h>
+
+int      cockpit_secmem_drain = 0;
+
+/* The cockpit_secclear function overwrites LEN bytes of memory
+ * pointed to by DATA with non-sensitive values.  When LEN is -1, DATA
+ * must be zero-terminated and all bytes until the zero are
+ * overwritten.
+ *
+ * This is very similar to memset but we take extra measures to
+ * prevent the compiler from optimizing it away.
+ *
+ * See http://www.dwheeler.com/secure-class/Secure-Programs-HOWTO/protect-secrets.html
+ */
+
+void
+cockpit_secclear (gpointer data,
+                  gssize len)
+{
+  volatile gchar *vp;
+
+  if (!data)
+    return;
+
+  if (len < 0)
+    len = strlen (data);
+
+  /* Defeats some optimizations */
+  memset (data, 0xAA, len);
+  memset (data, 0xBB, len);
+
+  /* Defeats others */
+  vp = (volatile gchar *)data;
+  while (len--)
+    {
+      cockpit_secmem_drain |= *vp;
+      *(vp++) = 0xAA;
+    }
+}

--- a/src/cockpit/cockpitmemory.h
+++ b/src/cockpit/cockpitmemory.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <glib.h>
+
+#ifndef __COCKPIT_MEMORY_H__
+#define __COCKPIT_MEMORY_H__
+
+G_BEGIN_DECLS
+
+void     cockpit_secclear                (gpointer data,
+                                          gssize length);
+
+G_END_DECLS
+
+#endif /* __COCKPIT_MEMORY_H__ */

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -31,6 +31,7 @@
 
 #include "cockpit/cockpitjson.h"
 #include "cockpit/cockpitpipe.h"
+#include "cockpit/cockpitmemory.h"
 
 #include <glib/gstdio.h>
 
@@ -381,6 +382,7 @@ verify_userpass (CockpitAuth *self,
 {
   gchar **lines = g_strsplit (content, "\n", 0);
   CockpitCreds *ret = NULL;
+  gint i;
 
   if (lines[0] == NULL
       || lines[1] == NULL
@@ -392,6 +394,8 @@ verify_userpass (CockpitAuth *self,
     }
 
   ret = cockpit_auth_verify_password (self, lines[0], lines[1], remote_peer, error);
+  for (i = 0; lines && lines[i]; i++)
+    cockpit_secclear (lines[i], -1);
   g_strfreev (lines);
   return ret;
 }

--- a/src/ws/cockpitcreds.c
+++ b/src/ws/cockpitcreds.c
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include "cockpitcreds.h"
+#include "cockpit/cockpitmemory.h"
 
 #include <string.h>
 
@@ -38,6 +39,7 @@ cockpit_creds_free (gpointer data)
 {
   CockpitCreds *creds = data;
   g_free (creds->user);
+  cockpit_secclear (creds->password, -1);
   g_free (creds->password);
   g_free (creds->rhost);
   g_free (creds);


### PR DESCRIPTION
Try to defeat compiler optimizations here too by having
side effects of our password clearing.
