### PR TITLE
agent: Call pam_acct_mgmt() when creating user session

### DIFF
--- a/src/agent/session.c
+++ b/src/agent/session.c
@@ -415,6 +415,9 @@ main (int argc,
 
   if (want_session)
     {
+      debug ("checking access for %s", user);
+      check (pam_acct_mgmt (pamh, 0));
+
       debug ("opening pam session for %s", user);
       check (pam_set_item (pamh, PAM_TTY, line));
       check (pam_setcred (pamh, PAM_ESTABLISH_CRED));


### PR DESCRIPTION
This allows PAM to deny access for the user, so we now
respect HBAC.

Fixes #493
