### PR TITLE
test: Remove *.pyc files when doing 'make clean'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,6 +96,10 @@ install-test-assets: $(testassets_programs) $(testassets_data) $(testassets_syst
 	for d in $(testassets_data); do $(INSTALL_DATA) $$d $(DESTDIR)$(testassetsdir); done
 	for d in $(testassets_systemdunit_data); do $(INSTALL_DATA) $$d $(DESTDIR)$(systemdunitdir); done
 
+clean-local:
+	find $(builddir) -name '*.gc??' -delete
+	find $(srcdir) -name '*.pyc' -delete
+
 include doc/Makefile-doc.am
 include doc/man/Makefile-man.am
 include data/Makefile-data.am

--- a/tools/Makefile-tools.am
+++ b/tools/Makefile-tools.am
@@ -14,9 +14,6 @@ EXTRA_DIST += \
 	$(NULL)
 
 if WITH_COVERAGE
-clean-local:
-	find $(builddir) -name '*.gc??' -delete
-
 coverage:
 	mkdir -p tools/coverage
 	$(MAKE)


### PR DESCRIPTION
git can confuse python, which checks the last modified date
of the pyc file.
