### PR TITLE
ws: Make the HTTP parts of cockpit-ws log in cockpit-protocol domain

### DIFF
--- a/src/ws/cockpitwebresponse.c
+++ b/src/ws/cockpitwebresponse.c
@@ -17,6 +17,12 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+/* This gets logged as part of the (more verbose) protocol logging */
+#ifdef G_LOG_DOMAIN
+#undef G_LOG_DOMAIN
+#endif
+#define G_LOG_DOMAIN "cockpit-protocol"
+
 #include "config.h"
 
 #include "cockpitwebresponse.h"

--- a/src/ws/cockpitwebserver.c
+++ b/src/ws/cockpitwebserver.c
@@ -17,6 +17,12 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+/* This gets logged as part of the (more verbose) protocol logging */
+#ifdef G_LOG_DOMAIN
+#undef G_LOG_DOMAIN
+#endif
+#define G_LOG_DOMAIN "cockpit-protocol"
+
 #include "config.h"
 
 #include <stdio.h>


### PR DESCRIPTION
This lets us focus in on the semantic stuff, and leave the
mechanical shunting of bytes into the cockpit-protocol log domain.
