### PR TITLE
Test webservice timeout

### DIFF
--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -54,6 +54,8 @@ const gchar *cockpit_ws_default_host_header =
 
 gint cockpit_ws_specific_ssh_port = 0;
 
+guint cockpit_ws_ping_interval = 5;
+
 /* ----------------------------------------------------------------------------
  * CockpitSession
  */
@@ -999,7 +1001,7 @@ cockpit_web_service_socket (GIOStream *io_stream,
   g_signal_connect (self->web_socket, "close", G_CALLBACK (on_web_socket_close), self);
   g_signal_connect (self->web_socket, "error", G_CALLBACK (on_web_socket_error), self);
 
-  self->ping_timeout = g_timeout_add_seconds (5, on_ping_time, self);
+  self->ping_timeout = g_timeout_add_seconds (cockpit_ws_ping_interval, on_ping_time, self);
 
   return self;
 }

--- a/src/ws/cockpitws.h
+++ b/src/ws/cockpitws.h
@@ -36,6 +36,7 @@ extern const gchar *cockpit_ws_agent_program;
 extern const gchar *cockpit_ws_known_hosts;
 extern const gchar *cockpit_ws_default_host_header;
 extern gint cockpit_ws_specific_ssh_port;
+extern guint cockpit_ws_ping_interval;
 
 /* From cockpitwebserver */
 extern guint cockpit_ws_request_timeout;

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -827,6 +827,9 @@ main (int argc,
 {
   cockpit_test_init (&argc, &argv);
 
+  /* We don't want to test the ping functionality in these tests */
+  cockpit_ws_ping_interval = G_MAXUINT;
+
   static const TestFixture fixture_rfc6455 = {
       .web_socket_flavor = WEB_SOCKET_FLAVOR_RFC6455,
   };


### PR DESCRIPTION
Trying to fix this issue:

```
PASS: test-reauthorize 18 /pamreauth/password-no-prepare
PASS: test-reauthorize 19 /pamreauth/password-bad-secret
PASS: test-transport 21 /transport/echo-large/child
**
cockpit-ws:ERROR:src/ws/test-webservice.c:361:expect_control_message: assertion failed (expected_command == message_command): ("open" == "ping")
PASS: test-cgroupmonitor 1 /cgroup-monitor/new
FAIL: test-webservice 1 /web-service/close-error
PASS: test-cgroupmonitor 2 /cgroup-monitor/get-samples
PASS: test-cgroupmonitor 3 /cgroup-monitor/new-sample
```

https://travis-ci.org/cockpit-project/cockpit/jobs/25492678
