### PR TITLE
common: Fix JSON string encoding for control characters

### DIFF
--- a/src/cockpit/cockpitjson.c
+++ b/src/cockpit/cockpitjson.c
@@ -628,35 +628,56 @@ static gchar *dump_object (const gchar   *name,
                            JsonObject    *object,
                            gsize         *length);
 
-/* non-ASCII characters can't be escaped, otherwise UTF-8
- * chars will break, so we just pregenerate this table of
- * high characters and then we feed it to g_strescape()
- */
-static const char json_exceptions[] = {
-  0x7f,  0x80,  0x81,  0x82,  0x83,  0x84,  0x85,  0x86,
-  0x87,  0x88,  0x89,  0x8a,  0x8b,  0x8c,  0x8d,  0x8e,
-  0x8f,  0x90,  0x91,  0x92,  0x93,  0x94,  0x95,  0x96,
-  0x97,  0x98,  0x99,  0x9a,  0x9b,  0x9c,  0x9d,  0x9e,
-  0x9f,  0xa0,  0xa1,  0xa2,  0xa3,  0xa4,  0xa5,  0xa6,
-  0xa7,  0xa8,  0xa9,  0xaa,  0xab,  0xac,  0xad,  0xae,
-  0xaf,  0xb0,  0xb1,  0xb2,  0xb3,  0xb4,  0xb5,  0xb6,
-  0xb7,  0xb8,  0xb9,  0xba,  0xbb,  0xbc,  0xbd,  0xbe,
-  0xbf,  0xc0,  0xc1,  0xc2,  0xc3,  0xc4,  0xc5,  0xc6,
-  0xc7,  0xc8,  0xc9,  0xca,  0xcb,  0xcc,  0xcd,  0xce,
-  0xcf,  0xd0,  0xd1,  0xd2,  0xd3,  0xd4,  0xd5,  0xd6,
-  0xd7,  0xd8,  0xd9,  0xda,  0xdb,  0xdc,  0xdd,  0xde,
-  0xdf,  0xe0,  0xe1,  0xe2,  0xe3,  0xe4,  0xe5,  0xe6,
-  0xe7,  0xe8,  0xe9,  0xea,  0xeb,  0xec,  0xed,  0xee,
-  0xef,  0xf0,  0xf1,  0xf2,  0xf3,  0xf4,  0xf5,  0xf6,
-  0xf7,  0xf8,  0xf9,  0xfa,  0xfb,  0xfc,  0xfd,  0xfe,
-  0xff,
-  '\0'   /* g_strescape() expects a NUL-terminated string */
-};
-
 static gchar *
 json_strescape (const gchar *str)
 {
-  return g_strescape (str, json_exceptions);
+  const gchar *p;
+  const gchar *end;
+  GString *output;
+  gsize len;
+
+  len = strlen (str);
+  end = str + len;
+  output = g_string_sized_new (len);
+
+  for (p = str; p < end; p++)
+    {
+      if (*p == '\\' || *p == '"')
+        {
+          g_string_append_c (output, '\\');
+          g_string_append_c (output, *p);
+        }
+      else if ((*p > 0 && *p < 0x1f) || *p == 0x7f)
+        {
+          switch (*p)
+            {
+            case '\b':
+              g_string_append (output, "\\b");
+              break;
+            case '\f':
+              g_string_append (output, "\\f");
+              break;
+            case '\n':
+              g_string_append (output, "\\n");
+              break;
+            case '\r':
+              g_string_append (output, "\\r");
+              break;
+            case '\t':
+              g_string_append (output, "\\t");
+              break;
+            default:
+              g_string_append_printf (output, "\\u00%02x", (guint)*p);
+              break;
+            }
+        }
+      else
+        {
+          g_string_append_c (output, *p);
+        }
+    }
+
+  return g_string_free (output, FALSE);
 }
 
 static gchar *


### PR DESCRIPTION
The implementation we got from json-glib is totally broken here
and escapes using octal sequences which are invalid in JSON.
