### PR TITLE
Fix setuid by setting %attr on cockpit-polkit

### DIFF
--- a/test/cockpit.spec.in
+++ b/test/cockpit.spec.in
@@ -107,7 +107,8 @@ install -p -m 644 cockpitselinux.pp %{buildroot}%{_datadir}/selinux/targeted/
 %{_libexecdir}/cockpit-ws
 %{_libexecdir}/cockpit-session
 %{_libexecdir}/cockpit-agent
-%{_libexecdir}/cockpit-polkit
+# We need to do attr because stripping debuginfo removes setuid
+%attr{4755, -, -} %{_libexecdir}/cockpit-polkit
 %{_libdir}/security/pam_reauthorize.so
 %{_datadir}/%{name}
 %{_mandir}/*


### PR DESCRIPTION
setuid gets stripped when rpmbuild extract the debug symbols, so let's put it back manually
