### PR TITLE
ws: Fix logout, disconnect, refresh logic

### DIFF
--- a/src/ws/cockpitwebservice.h
+++ b/src/ws/cockpitwebservice.h
@@ -30,6 +30,7 @@ G_BEGIN_DECLS
 
 #define COCKPIT_TYPE_WEB_SERVICE         (cockpit_web_service_get_type ())
 #define COCKPIT_WEB_SERVICE(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_WEB_SERVICE, CockpitWebService))
+#define COCKPIT_IS_WEB_SERVICE(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_WEB_SERVICE))
 
 typedef struct _CockpitWebService   CockpitWebService;
 
@@ -50,6 +51,8 @@ void                 cockpit_web_service_noauth      (GIOStream *io_stream,
                                                       GByteArray *input_buffer);
 
 CockpitCreds *       cockpit_web_service_get_creds   (CockpitWebService *self);
+
+gboolean             cockpit_web_service_get_idling  (CockpitWebService *self);
 
 G_END_DECLS
 

--- a/src/ws/cockpitws.h
+++ b/src/ws/cockpitws.h
@@ -43,6 +43,9 @@ extern gint cockpit_ws_agent_timeout;
 extern guint cockpit_ws_request_timeout;
 extern gsize cockpit_ws_request_maximum;
 
+/* From cockpitauth.c */
+extern guint cockpit_ws_idle_timeout;
+
 G_END_DECLS
 
 #endif /* __COCKPIT_WS_H__ */


### PR DESCRIPTION
First of all decouple the object references of CockpitWebService
from the logged in state. We don't want an erroneous ref leak to
become a security issue.

After the last WebSocket disconnects we wait for 15 seconds before
discarding the credentials. This allows refreshes to work, and is
exactly the same logic for holding the credentials between /login
and the first WebSocket connecting.

Using "Log out" (ie: /logout) still works as expected and discards
credentials and login state immediately, disconnecting all
WebSockets and so on.
