### PR TITLE
ws: cockpit.socket should be able to listen on reserved ports

### DIFF
--- a/src/ws/cockpitselinux.te
+++ b/src/ws/cockpitselinux.te
@@ -44,7 +44,7 @@ dev_read_urand(cockpit_ws_t) # for authkey
 dev_read_rand(cockpit_ws_t)  # for libssh
 
 # cockpit-ws can read from a reserved port
-corenet_tcp_bind_reserved_port(cockpit_ws_t)
+corenet_tcp_bind_all_reserved_ports(cockpit_ws_t)
 corenet_tcp_bind_all_unreserved_ports(cockpit_ws_t)
 
 # cockpit-ws can connect to other hosts via ssh


### PR DESCRIPTION
Update the SELinux policy.

This is the AVC that otherwise results:

```
type=AVC msg=audit(1400833955.781:264): avc:  denied  { name_bind } for  pid=1 comm="systemd" src=1001 scontext=system_u:system_r:cockpit_ws_t:s0 tcontext=system_u:object_r:hi_reserved_port_t:s0 tclass=tcp_socket
```
