### PR TITLE
web: Only show ethernet network devices

### DIFF
--- a/src/web/cockpit-networking.js
+++ b/src/web/cockpit-networking.js
@@ -222,8 +222,8 @@ PageNetworking.prototype = {
             if (!device)
                 continue;
 
-            // Skip loopback
-            if (device.DeviceType == 14)
+            // Skip everything that is not ethernet
+            if (device.DeviceType != 1)
                 continue;
 
             merge_props(device, "org.freedesktop.NetworkManager.Device.Wired",


### PR DESCRIPTION
We don't really know what to do with the rest.

Fixes #589
