### PR TITLE
web: Use tighter regexp to find container cgroups.

### DIFF
--- a/src/web/cockpit-docker.js
+++ b/src/web/cockpit-docker.js
@@ -1238,7 +1238,7 @@ function DockerClient(machine) {
             $(me).trigger("failure", [ex]);
         });
 
-    var regex_docker_cgroup = /[A-Fa-f0-9]{64}/;
+    var regex_docker_cgroup = /docker-([A-Fa-f0-9]{64})\.scope/;
     var regex_geard_cgroup = /.*\/ctr-(.+).service/;
     function container_from_cgroup(cgroup) {
         /*
@@ -1250,7 +1250,7 @@ function DockerClient(machine) {
         /* Docker created cgroups */
         var match = regex_docker_cgroup.exec(cgroup);
         if (match)
-            return match[0];
+            return match[1];
 
         /* geard created cgroups */
         match = regex_geard_cgroup.exec(cgroup);


### PR DESCRIPTION
Otherwise we might pick up cgroups like
var-lib-docker-devicemapper-mnt-5cc43057ad4d45b2a1f01a7db64556c912526318eb365d3203535cc0fefc4c9c.mount.
This might cause handle_new_samples to store the wrong numbers in the
container data structure.

The sympton was that the resource graphs would work as expected but
the container rows would always show 0% CPU and "?" for the memory.

More tuning for the regexp might be needed, and ideally Docker should
tell us the cgroup of a container.
