### PR TITLE
web: Fix title of #server page

### DIFF
--- a/src/web/cockpit-server.js
+++ b/src/web/cockpit-server.js
@@ -23,7 +23,7 @@ PageServer.prototype = {
     },
 
     enter_breadcrumb: function() {
-        this.title_address = cockpit_get_page_param('machine') || "localhost";
+        this.title_address = cockpit_get_page_param('machine', 'server') || "localhost";
         /* TODO: This code needs to be migrated away from dbus-json1 */
         this.title_client = cockpit.dbus(this.title_address, { payload: 'dbus-json1' });
         this.title_manager = this.title_client.get("/com/redhat/Cockpit/Manager",


### PR DESCRIPTION
By getting the 'machine' parameters actually from the 'server' part of
the URL, and not the current page.
