### PR TITLE
web: Handle task-less machine setup.

### DIFF
--- a/src/web/cockpit-setup.js
+++ b/src/web/cockpit-setup.js
@@ -437,12 +437,7 @@ PageSetupServer.prototype = {
 
         $('#dashboard_setup_action_address').text(this.address);
 
-        if (this.tasks.length > 0) {
-            this.show_tab ('action');
-        } else {
-            this.show_tab ('close');
-        }
-
+        this.show_tab ('action');
     },
 
     next_setup: function() {


### PR DESCRIPTION
We can't skip the 'action' tab anymore when there are no tasks since
actually adding the machine happens during that step now.
