### PR TITLE
web: Fix visibility on Docker images page

### DIFF
--- a/src/web/cockpit-docker.js
+++ b/src/web/cockpit-docker.js
@@ -1043,8 +1043,8 @@ PageImageDetails.prototype = {
         }
 
         var waiting = !!(this.client.waiting[this.image_id]);
-        $('#image-details div.waiting').toggle(waiting);
-        $('#image-details button').toggle(!waiting);
+        $('#image-details-buttons div.waiting').toggle(waiting);
+        $('#image-details-buttons button').toggle(!waiting);
 
         if (info.RepoTags && info.RepoTags.length > 0) {
             var name = info.RepoTags[0];

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -880,7 +880,7 @@
       <div id="image-details" class="container-fluid">
         <div class="row">
           <div class="col-sm-12">
-            <div class="pull-right" style="height:25px">
+            <div class="pull-right" style="height:25px" id="image-details-buttons">
               <button class="btn btn-default" id="image-details-run">Run</button>
               <button class="btn btn-danger" id="image-details-delete">Delete</button>
               <div class="waiting" style="display: none;"></div>


### PR DESCRIPTION
Previously all buttons on that page would be shown/hidden when the
image 'waiting' status changed not just the buttons for the image
itself.  That used to be OK, but now we also have buttons for
containers which should not be affected.
