### PR TITLE
daemon: Put Cockpit DBus .service file in system-services

### DIFF
--- a/src/daemon/Makefile-daemon.am
+++ b/src/daemon/Makefile-daemon.am
@@ -113,7 +113,7 @@ cockpitd_LDADD = 					\
 	-lm 						\
 	$(NULL)
 
-dbusservicedir = $(datadir)/dbus-1/services
+dbusservicedir = $(datadir)/dbus-1/system-services
 dbusservice_DATA = com.redhat.Cockpit.service
 
 com.redhat.Cockpit.service: src/daemon/com.redhat.Cockpit.service.in Makefile


### PR DESCRIPTION
Otherwise it's not elgible for activation on the system bus,
were we want it.

I hit this trying to use gdbus call -y --dest=com.redhat.Cockpit.

(Not tested though)
