### PR TITLE
Add basic flags for address santizer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -223,7 +223,7 @@ AC_CHECK_FUNCS(fdwalk)
 AC_MSG_CHECKING([for asan flags])
 AC_ARG_ENABLE(asan,
               AC_HELP_STRING([--enable-asan=no/yes],
-                             [Turn on or off ASAN])
+                             [Turn the Address Sanitizer on or off])
              )
 
 if test "$enable_asan" = "yes"; then


### PR DESCRIPTION
This might be useful to detect memory errors during testing. I intend on using it in conjunction with various fuzz testing tools to see if it turns anything up. 

To use:
    ./autogen.sh --enable-asan=yes
