### PR TITLE
cockpit: Make ECONNREFUSED also mean "not-found".

### DIFF
--- a/src/cockpit/cockpitpipe.c
+++ b/src/cockpit/cockpitpipe.c
@@ -310,7 +310,7 @@ set_problem_from_connect_errno (CockpitPipe *self,
 
   if (errn == EPERM || errn == EACCES)
     problem = "not-authorized";
-  else if (errn == ENOENT)
+  else if (errn == ENOENT || errn == ECONNREFUSED)
     problem = "not-found";
 
   g_free (self->priv->problem);


### PR DESCRIPTION
We get this error for example when docker is not running, and
previously we showed it as "internal-error".
