### PR TITLE
SPEC: Do not attempt to build selinux in parallel

### DIFF
--- a/src/selinux/Makefile-selinux.am
+++ b/src/selinux/Makefile-selinux.am
@@ -7,7 +7,7 @@ SELINUX_FILES = \
 
 cockpit.pp: $(SELINUX_FILES)
 	cp $^ $(builddir)
-	$(MAKE) -f /usr/share/selinux/devel/Makefile cockpit.pp
+	$(MAKE) -j1 -f /usr/share/selinux/devel/Makefile cockpit.pp
 
 selinux: cockpit.pp
 


### PR DESCRIPTION
Coverity scans of Cockpit are failing regularly because parallelization sometimes results in the SELinux pieces being built out of order. Until this step is properly handling parallel build, we should explicitly build it without parallel execution.
