### PR TITLE
ws: Fix race condition during ssh transport shutdown

### DIFF
--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -1019,7 +1019,9 @@ cockpit_ssh_source_dispatch (GSource *source,
        *
        * https://red.libssh.org/issues/158
        */
-      if (msg && (strstr (msg, "disconnected") || strstr (msg, "SSH_MSG_DISCONNECT")))
+      if (msg && (strstr (msg, "disconnected") ||
+                  strstr (msg, "SSH_MSG_DISCONNECT") ||
+                  strstr (msg, "Socket error: Success")))
         {
           g_debug ("%s: failed to process channel: %s", self->logname, msg);
           close_immediately (self, "terminated");


### PR DESCRIPTION
Without this change on certain machines, in certain environments
we would see messages like the following:

```
cockpit-protocol-Message: 127.0.0.1: failed to process channel: Socket error: Success
```
