### PR TITLE
selinux: Allow accepting connections on sockets passed from systemd

### DIFF
--- a/src/selinux/cockpit.te
+++ b/src/selinux/cockpit.te
@@ -44,6 +44,7 @@ dev_read_rand(cockpit_ws_t)  # for libssh
 # cockpit-ws can read from the cockpit port
 # TODO: disable this until we have it in our f20 selinux-policy-targeted
 # corenet_tcp_bind_cockpit_port(cockpit_ws_t)
+allow cockpit_ws_t init_t:tcp_socket accept;
 corenet_tcp_bind_all_reserved_ports(cockpit_ws_t)
 
 # cockpit-ws can connect to other hosts via ssh


### PR DESCRIPTION
Otherwise we get AVC's that look like this:

```
type=AVC msg=audit(1402394341.625:70457): avc:  denied  { accept } for  pid=30536 comm="cockpit-ws" lport=1001 scontext=system_u:system_r:cockpit_ws_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=tcp_socket
type=SYSCALL msg=audit(1402394341.625:70457): arch=c000003e syscall=43 success=no exit=-13 a0=3 a1=0 a2=0 a3=1 items=0 ppid=1 pid=30536 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="cockpit-ws" exe="/usr/libexec/cockpit-ws" subj=system_u:system_r:cockpit_ws_t:s0 key=(null)
```
