### PR TITLE
web: Use correct client when getting max memory for docker

### DIFF
--- a/src/web/cockpit-docker.js
+++ b/src/web/cockpit-docker.js
@@ -830,15 +830,15 @@ PageContainerDetails.prototype = {
                     });
             });
 
-        PageRunImage.client.get_sys_memory().
-            done(function (max) {
-                self.memory_limit.max = max;
-            });
-
         this.address = cockpit_get_page_param('machine') || "localhost";
         this.client = get_docker_client(this.address);
         this.container_id = cockpit_get_page_param('id');
         this.name = this.container_id.slice(0,12);
+
+        this.client.get_sys_memory().
+            done(function(max) {
+                self.memory_limit.max = max;
+            });
 
         // Just for watching
         this.dbus_client = cockpit.dbus(this.address, { payload: "dbus-json1" });


### PR DESCRIPTION
Previously an error would occur if the run dialog wasn't shown before
the container details page.

Fixes #661
