### PR TITLE
ws: Fix issue where remote channel is closed when sending data

### DIFF
--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -832,6 +832,8 @@ dispatch_queue (CockpitSshTransport *self)
 
   if (self->sent_eof)
     return FALSE;
+  if (self->received_close)
+    return FALSE;
 
   for (;;)
     {


### PR DESCRIPTION
Should fix errors like this:

```
couldn't write: Remote channel is closed
```
