### PR TITLE
daemon: Try and fix race unreferencing object in machines tests

### DIFF
--- a/src/daemon/test-machines.c
+++ b/src/daemon/test-machines.c
@@ -116,11 +116,11 @@ teardown (TestCase *tc,
   g_object_add_weak_pointer (G_OBJECT (tc->machines), (gpointer *)&tc->machines);
   g_object_unref (tc->machines);
 
-  while (g_main_context_iteration (NULL, FALSE));
-  g_assert (tc->machines == NULL);
-
   g_test_dbus_down (tc->bus);
   g_object_unref (tc->bus);
+
+  while (g_main_context_iteration (NULL, FALSE));
+  g_assert (tc->machines == NULL);
 
   g_assert_cmpint (g_unlink (tc->machines_file), ==, 0);
 }


### PR DESCRIPTION
Trying to fix this race here:

```
**
cockpit-daemon:ERROR:src/daemon/test-machines.c:120:teardown: assertion failed: (tc->machines == NULL)
FAIL: test-machines 3 /machines/append-known-hosts
ERROR: test-machines process failed: 247
```
