### PR TITLE
daemon: Use G_SPAWN_STDOUT_TO_DEV_NULL as required.

### DIFF
--- a/src/daemon/manager.c
+++ b/src/daemon/manager.c
@@ -768,7 +768,8 @@ run_cmd_for_invocation (GDBusMethodInvocation *invocation,
   GError *error = NULL;
   gint code;
 
-  g_spawn_sync (NULL, (gchar **)argv, NULL, G_SPAWN_SEARCH_PATH,
+  g_spawn_sync (NULL, (gchar **)argv, NULL,
+                G_SPAWN_SEARCH_PATH | (output == NULL? G_SPAWN_STDOUT_TO_DEV_NULL : 0),
                 redirect_stderr_to_stdout, NULL, output, NULL, &code, &error);
   if (error)
     {


### PR DESCRIPTION
The g_spawn_sync documentation says:

```
Note that you must set the G_SPAWN_STDOUT_TO_DEV_NULL and
G_SPAWN_STDERR_TO_DEV_NULL flags when passing NULL for
standard_output and standard_error.
```

And indeed, without this, "shutdown" gets a EPIPE when writing to
stdout, which is a harmless but distracting error.
