### PR TITLE
web: Close other dialogs before opening "Disconnected".

### DIFF
--- a/src/web/cockpit-main.js
+++ b/src/web/cockpit-main.js
@@ -141,9 +141,10 @@ function set_watched_client(client) {
     $('#disconnected-dialog').modal('hide');
 
     function update() {
-        if (watched_client && watched_client.state == "closed")
+        if (watched_client && watched_client.state == "closed") {
+            $('.modal[role="dialog"]').modal('hide');
             $('#disconnected-dialog').modal('show');
-        else
+        } else
             $('#disconnected-dialog').modal('hide');
     }
 

--- a/src/web/cockpit-page.js
+++ b/src/web/cockpit-page.js
@@ -374,6 +374,7 @@ function cockpit_show_error_dialog(title, message)
         $("#error-popup-message").text(title);
     }
 
+    $('.modal[role="dialog"]').modal('hide');
     $('#error-popup').modal('show');
 }
 


### PR DESCRIPTION
We can't have two dialogs open at the same time, and "Disconnected" is
opened asynchronously.

For convenience and robustness, we also close other dialogs before
opening the #error-popup although the code is usually careful to close
any open dialog before showing errors.
