### PR TITLE
ws: Handle 'Connection reset by peer' ssh message

### DIFF
--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -1017,7 +1017,8 @@ cockpit_ssh_source_dispatch (GSource *source,
        */
       if (msg && (strstr (msg, "disconnected") ||
                   strstr (msg, "SSH_MSG_DISCONNECT") ||
-                  strstr (msg, "Socket error: Success")))
+                  strstr (msg, "Socket error: Success") ||
+                  strstr (msg, "Socket error: Connection reset by peer")))
         {
           g_debug ("%s: failed to process channel: %s", self->logname, msg);
           close_immediately (self, "terminated");


### PR DESCRIPTION
Unfortunately we have to "screen scrape" to figure out the reason
for SSH errors. So add one more message here.
