### PR TITLE
daemon: Fixed formatting string

### DIFF
--- a/src/daemon/diskiomonitor.c
+++ b/src/daemon/diskiomonitor.c
@@ -349,7 +349,7 @@ collect (DiskIOMonitor *monitor)
        */
 
       num_parsed = sscanf (line,
-                           "%d %d %s"
+                           "%d %d %64s"
                            " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT
                            " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT
                            " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT,


### PR DESCRIPTION
Limit the length of the sscanf field to prevent being attacked.

Fixes #665
