### PR TITLE
websocket: Make sure headers parse without space

### DIFF
--- a/src/websocket/test-websocket.c
+++ b/src/websocket/test-websocket.c
@@ -274,6 +274,7 @@ test_parse_headers (void)
       "Header1: value3\r\n"
       "Header2:  field\r\n"
       "Head3:  Another \r\n"
+      "Host:http://cockpit-project.org\r\n"
       "\r\n"
       "BODY  ",
   };
@@ -289,6 +290,7 @@ test_parse_headers (void)
       g_assert_cmpstr (g_hash_table_lookup (headers, "header1"), ==, "value3");
       g_assert_cmpstr (g_hash_table_lookup (headers, "Header2"), ==, "field");
       g_assert_cmpstr (g_hash_table_lookup (headers, "hEAD3"), ==, "Another");
+      g_assert_cmpstr (g_hash_table_lookup (headers, "Host"), ==, "http://cockpit-project.org");
       g_assert (g_hash_table_lookup (headers, "Something else") == NULL);
       g_hash_table_unref (headers);
     }


### PR DESCRIPTION
Just an additional little tweak to the test case.
