### PR TITLE
ws: Added the validation of HTTP Host header

### DIFF
--- a/src/ws/cockpitwebserver.c
+++ b/src/ws/cockpitwebserver.c
@@ -823,6 +823,13 @@ parse_and_process_request (CockpitRequest *request)
    *  * keep-alives
    */
 
+  str = g_hash_table_lookup (headers, "Host");
+  if (!str || g_str_equal (str, ""))
+    {
+      g_message ("received HTTP request without Host header");
+      request->delayed_reply = 400;
+    }
+
   g_byte_array_remove_range (request->buffer, 0, off1 + off2);
   process_request (request, reqtype, path, headers, length);
 


### PR DESCRIPTION
Added the check for presence of mandatory 'Host' header as expected by HTTP 1.1.
Together with a test case "test_webserver_host_header" in test-webserver.c

Fixes #663
