### PR TITLE
ws: Add a /ping REST request for checking if cockpit is running

### DIFF
--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -421,6 +421,44 @@ cockpit_handler_root (CockpitWebServer *server,
   return TRUE;
 }
 
+gboolean
+cockpit_handler_ping (CockpitWebServer *server,
+                      CockpitWebServerRequestType reqtype,
+                      const gchar *path,
+                      GHashTable *headers,
+                      GBytes *input,
+                      CockpitWebResponse *response,
+                      CockpitHandlerData *ws)
+{
+  GHashTable *out_headers;
+  const gchar *body;
+  GBytes *content;
+
+  out_headers = cockpit_web_server_new_table ();
+
+  /*
+   * The /ping request has unrestricted CORS enabled on it. This allows javascript
+   * in the browser on embedding websites to check if Cockpit is available. These
+   * websites could do this in another way (such as loading an image from Cockpit)
+   * but this does it in the correct manner.
+   *
+   * See: http://www.w3.org/TR/cors/
+   */
+  g_hash_table_insert (out_headers, g_strdup ("Access-Control-Allow-Origin"), g_strdup ("*"));
+
+  g_hash_table_insert (out_headers, g_strdup ("Content-Type"), g_strdup ("application/json"));
+  body ="{ \"service\": \"cockpit\" }";
+  content = g_bytes_new_static (body, strlen (body));
+
+  cockpit_web_response_content (response, out_headers, content, NULL);
+
+  g_bytes_unref (content);
+  g_hash_table_unref (out_headers);
+
+  return TRUE;
+}
+
+
 static void
 send_index_response (CockpitWebResponse *response,
                      CockpitWebService *service,

--- a/src/ws/cockpithandlers.h
+++ b/src/ws/cockpithandlers.h
@@ -94,4 +94,12 @@ gboolean       cockpit_handler_resource          (CockpitWebService *server,
                                                   CockpitWebResponse *response,
                                                   CockpitHandlerData *ws);
 
+gboolean       cockpit_handler_ping              (CockpitWebServer *server,
+                                                  CockpitWebServerRequestType reqtype,
+                                                  const gchar *path,
+                                                  GHashTable *headers,
+                                                  GBytes *input,
+                                                  CockpitWebResponse *response,
+                                                  CockpitHandlerData *ws);
+
 #endif /* __COCKPIT_HANDLERS_H__ */

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -375,6 +375,9 @@ main (int argc,
                     G_CALLBACK (cockpit_handler_deauthorize),
                     &data);
 
+  g_signal_connect (server, "handle-resource::/ping",
+                    G_CALLBACK (cockpit_handler_ping), &data);
+
   g_signal_connect (server,
                     "handle-resource::/",
                     G_CALLBACK (cockpit_handler_index),

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -372,6 +372,28 @@ test_favicon_ico (Test *test,
                            "*");
 }
 
+static void
+test_ping (Test *test,
+           gconstpointer data)
+{
+  const gchar *output;
+  gboolean ret;
+  GBytes *input;
+
+  input = g_bytes_new_static ("", 0);
+  ret = cockpit_handler_ping (test->server,
+                              COCKPIT_WEB_SERVER_REQUEST_GET, "/ping",
+                              test->headers, input, test->response, &test->data);
+
+  g_assert (ret == TRUE);
+
+  output = output_as_string (test);
+  cockpit_assert_strmatch (output,
+                           "HTTP/1.1 200 OK\r\n*"
+                           "Access-Control-Allow-Origin: *\r\n*"
+                           "\"cockpit\"*");
+}
+
 int
 main (int argc,
       char *argv[])
@@ -394,6 +416,9 @@ main (int argc,
 
   g_test_add ("/handlers/logout", Test, NULL,
               setup, test_logout, teardown);
+
+  g_test_add ("/handlers/ping", Test, NULL,
+              setup, test_ping, teardown);
 
   g_test_add ("/handlers/index", Test, NULL,
               setup, test_index, teardown);


### PR DESCRIPTION
We implement unrestricted CORS on `/ping` which allows callers
embedding Cockpit to check if it is running on a given server
before trying to embed it.

From a security perspective, there are _many_ other ways to check
if Cockpit is running on a particular server from a third-party
website such as loading an image or script from Cockpit. This
does not weaken security, simply enables the correct approach
for doing such a check.

http://www.w3.org/TR/cors/
