### PR TITLE
ws: Make favicon test work with other branding

### DIFF
--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -368,7 +368,7 @@ test_favicon_ico (Test *test,
   output = output_as_string (test);
   cockpit_assert_strmatch (output,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Length: 1150\r\n"
+                           "Content-Length: *\r\n"
                            "*");
 }
 


### PR DESCRIPTION
Other branding doesn't have the same exact content length for
favicon.
