### PR TITLE
Shell: changes variable to more commonly used word

### DIFF
--- a/modules/shell/shell.html
+++ b/modules/shell/shell.html
@@ -222,7 +222,7 @@
         </div>
 
         <div class="panel panel-default">
-          <div class="panel-heading" translatable="yes">RAID Arrays</div>
+          <div class="panel-heading" translatable="yes">RAID Devices</div>
           <table class="table">
             <tbody id="storage_raids">
             </tbody>
@@ -255,7 +255,7 @@
           <div class="panel-body" id="storage-log"></div>
         </div>
 
-        <button id="storage_create_raid" class="btn btn-default" translatable="yes">Create RAID Array</button>
+        <button id="storage_create_raid" class="btn btn-default" translatable="yes">Create RAID Device</button>
         <button id="storage_create_volume_group" class="btn btn-default" translatable="yes">Create Volume Group</button>
       </div>
 
@@ -304,7 +304,7 @@
         <div id="raid_detail_list">
           <div class="panel panel-default">
             <div class="panel-heading">
-              <span translatable="yes">RAID Array</span>
+              <span translatable="yes">RAID Device</span>
               <span style="float:right" id="raid_action_btn"></span>
             </div>
             <table class="cockpit-info-table">
@@ -1438,7 +1438,7 @@
       <div class="modal-dialog">
         <div class="modal-content">
           <div class="modal-header">
-            <h4 class="modal-title">Create RAID Array</h4>
+            <h4 class="modal-title">Create RAID Device</h4>
           </div>
           <div class="modal-body">
             <table class="cockpit-form-table">


### PR DESCRIPTION
All instances of the "RAID Array" now changed to "RAID Device"

Fixes: #725
