### PR TITLE
cockpit: All processes and tests ignore SIGPIPE.

### DIFF
--- a/src/agent/cockpitpolkithelper.c
+++ b/src/agent/cockpitpolkithelper.c
@@ -93,6 +93,8 @@ main (int argc, char *argv[])
   uid_t uid;
   int res;
 
+  signal (SIGPIPE, SIG_IGN);
+
   if (clearenv () != 0)
     errx (1, "couldn't clear environment");
 

--- a/src/cockpit/cockpittest.c
+++ b/src/cockpit/cockpittest.c
@@ -173,6 +173,8 @@ cockpit_test_init (int *argc,
 {
   gchar *basename;
 
+  signal (SIGPIPE, SIG_IGN);
+
   g_type_init ();
 
   if (*argc > 0)

--- a/src/daemon/test-machines.c
+++ b/src/daemon/test-machines.c
@@ -21,6 +21,7 @@
 
 #include "machine.h"
 #include "machines.h"
+#include "cockpit/cockpittest.h"
 
 #include <glib/gstdio.h>
 
@@ -209,10 +210,7 @@ int
 main (int argc,
       char *argv[])
 {
-  g_type_init ();
-
-  g_set_prgname ("test-machines");
-  g_test_init (&argc, &argv, NULL);
+  cockpit_test_init (&argc, &argv);
 
   g_test_add ("/machines/add", TestCase, NULL,
               setup, test_add, teardown);

--- a/src/reauthorize/test-reauthorize.c
+++ b/src/reauthorize/test-reauthorize.c
@@ -341,6 +341,7 @@ main (int argc,
   int i;
 
   /* Some initial preparation */
+  signal (SIGPIPE, SIG_IGN);
   reauthorize_logger (test_logger, 0);
 
   re_fixture (setup, teardown);

--- a/src/websocket/frob-websocket.c
+++ b/src/websocket/frob-websocket.c
@@ -136,6 +136,7 @@ main (int argc,
     { NULL }
   };
 
+  signal (SIGPIPE, SIG_IGN);
   options = g_option_context_new ("URL");
   g_option_context_add_main_entries (options, entries, NULL);
   if (!g_option_context_parse (options, &argc, &argv, &error))

--- a/src/websocket/test-websocket.c
+++ b/src/websocket/test-websocket.c
@@ -1386,6 +1386,7 @@ main (int argc,
       { test_close_clean_server, "close-clean-server" },
   };
 
+  signal (SIGPIPE, SIG_IGN);
   g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
   g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
   g_setenv ("GIO_USE_VFS", "local", TRUE);

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -302,6 +302,7 @@ main (int argc,
   gchar **roots = NULL;
   GMainLoop *loop;
 
+  signal (SIGPIPE, SIG_IGN);
   g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
   g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
   g_setenv ("GIO_USE_VFS", "local", TRUE);

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -240,6 +240,7 @@ main (int argc,
     { NULL }
   };
 
+  signal (SIGPIPE, SIG_IGN);
   /* avoid gvfs (http://bugzilla.gnome.org/show_bug.cgi?id=526454) */
   g_setenv ("GIO_USE_VFS", "local", TRUE);
 

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -1360,8 +1360,6 @@ main (int argc,
 {
   cockpit_test_init (&argc, &argv);
 
-  signal (SIGPIPE, SIG_IGN);
-
   /*
    * HACK: Work around races in glib SIGCHLD handling.
    *


### PR DESCRIPTION
Make sure all processes and tests (except for some testing mock processes) ignore SIGPIPE.
Replace g_test_init() with cockpit_test_init() in the main of test-machines.

Fixes #716
