### PR TITLE
shell: Use correct machine address for Docker Image Search.

### DIFF
--- a/modules/shell/cockpit-docker.js
+++ b/modules/shell/cockpit-docker.js
@@ -731,7 +731,8 @@ PageSearchImage.prototype = {
     },
 
     enter: function() {
-        this.client = get_docker_client();
+        this.address = cockpit_get_page_param('machine') || "localhost";
+        this.client = get_docker_client(this.address);
 
         // Clear the previous results and search string from previous time
         $('#containers-search-image-results tbody tr').remove();


### PR DESCRIPTION
Previously, this would always search on "localhost".
