### PR TITLE
static: Don't wrap 'User name' string on login screen

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -25,6 +25,9 @@
         .login-fatal {
             font-size: 130%;
         }
+        .control-label {
+            white-space: nowrap;
+        }
     </style>
     <script>
         var cockpit = { };


### PR DESCRIPTION
Closes #768
