### PR TITLE
ws: Rearrange libssh logging during tests to diagnose travis

### DIFF
--- a/src/ws/test-sshtransport.c
+++ b/src/ws/test-sshtransport.c
@@ -401,12 +401,6 @@ test_close_problem (TestCase *tc,
 /* An ssh command that just kills itself with SIGTERM */
 static const TestFixture fixture_terminate_problem = {
   .ssh_command = "kill $$",
-
-  /*
-   * TODO: Trying to solve:
-   * https://travis-ci.org/cockpit-project/cockpit/jobs/25494752
-   */
-  .ssh_log_level = SSH_LOG_FUNCTIONS,
 };
 
 static void
@@ -616,12 +610,6 @@ test_expect_empty_key (TestCase *tc,
 
 static const TestFixture fixture_bad_command = {
   .ssh_command = "/nonexistant 2> /dev/null",
-
-  /*
-   * TODO: Trying to solve:
-   * https://travis-ci.org/cockpit-project/cockpit/jobs/25688198
-   */
-  .ssh_log_level = SSH_LOG_FUNCTIONS,
 };
 
 static void

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -33,6 +33,8 @@
 
 #include <glib.h>
 
+#include <libssh/libssh.h>
+
 #include <string.h>
 
 #include <sys/types.h>
@@ -871,9 +873,14 @@ test_fail_spawn (TestCase *test,
   WebSocketConnection *ws;
   GBytes *received = NULL;
   CockpitWebService *service;
+  int old_level;
 
   /* Fail to spawn this program */
   cockpit_ws_agent_program = "/nonexistant";
+
+  /* TODO: Trying to solve travis failures */
+  old_level = ssh_get_log_level ();
+  ssh_set_log_level (SSH_LOG_FUNCTIONS);
 
   start_web_service_and_connect_client (test, data, &ws, &service);
   g_signal_connect (ws, "message", G_CALLBACK (on_message_get_bytes), &received);
@@ -887,6 +894,8 @@ test_fail_spawn (TestCase *test,
   g_bytes_unref (received);
 
   close_client_and_stop_web_service (test, ws, service);
+
+  ssh_set_log_level (old_level);
 }
 
 static gboolean


### PR DESCRIPTION
Diagnose new test races by rearranging the SSH detailed logging.
