### PR TITLE
shell: Fix the debugging manifest.json for removed network js

### DIFF
--- a/modules/shell/manifest.json
+++ b/modules/shell/manifest.json
@@ -27,7 +27,6 @@
 		"cockpit-cpu-status.js",
 		"cockpit-memory-status.js",
 		"cockpit-disk-io-status.js",
-		"cockpit-network-traffic-status.js",
 		"cockpit-system-information.js",
 		"cockpit-networking.js",
 		"cockpit-storage.js",


### PR DESCRIPTION
Otherwise we get 404's when people link the shell module into
their home directory for quick development.
