### PR TITLE
ws: Add a firewalld service for cockpit-ws

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -84,8 +84,9 @@ To run Cockpit without systemd, start the cockpit-ws daemon manually:
 Then you can connect to port 1001 of the virtual machine.  You might
 need to open the firewall for it.  On Fedora:
 
-    # firewall-cmd --add-port 1001/tcp
-    # firewall-cmd --permanent --add-port 1001/tcp
+    # firewall-cmd --reload
+    # firewall-cmd --add-service=cockpit
+    # firewall-cmd --add-service=cockpit --permanent
 
 Point your browser to `https://IP-OR-NAME-OF-YOUR-VM:1001`
 

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -79,11 +79,15 @@ testassets_systemdunit_data += cockpit-testing.service
 cockpitconfdir = $(sysconfdir)/cockpit
 cockpitconf_DATA = src/ws/config
 
+firewalldir = $(prefix)/lib/firewalld/services
+firewall_DATA = src/ws/cockpit.xml
+
 EXTRA_DIST += \
 	src/ws/cockpit.service.in \
 	src/ws/cockpit-testing.service.in \
 	src/ws/test-server.service.in \
 	src/ws/config \
+	$(firewall_DATA) \
 	$(NULL)
 
 CLEANFILES += \

--- a/src/ws/cockpit.xml
+++ b/src/ws/cockpit.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <!-- This is a firewalld service definition for Cockpit -->
+  <short>Cockpit</short>
+  <description>Cockpit lets you access and configure your server remotely.</description>
+  <port protocol="tcp" port="1001"/>
+</service>

--- a/test/cockpit.setup
+++ b/test/cockpit.setup
@@ -15,9 +15,6 @@ rm -rf /etc/sysconfig/iptables
 
 maybe() { if type "$1" >/dev/null 2>&1; then "$@"; fi; }
 
-# For Cockpit
-maybe firewall-cmd --permanent --add-port 1001/tcp
-
 # For the D-Bus test server
 maybe firewall-cmd --permanent --add-port 8765/tcp
 

--- a/test/cockpit.spec.in
+++ b/test/cockpit.spec.in
@@ -76,6 +76,8 @@ chgrp wheel %{_sharedstatedir}/%{name}
 chmod 775 %{_sharedstatedir}/%{name}
 # Only for testing: in a distro we would ask sshd to ship the relevant lines
 cat %{_datadir}/%{name}/sshd-reauthorize.pam >> %{_sysconfdir}/pam.d/sshd
+# firewalld only partially picks up changes to its services files without this
+test -f %{_bindir}/firewall-cmd && firewall-cmd --reload --quiet || true
 
 %prep
 %setup -q
@@ -102,6 +104,7 @@ install -p -m 644 cockpit.pp %{buildroot}%{_datadir}/selinux/targeted/
 %{_sysconfdir}/pam.d/cockpit
 /usr/lib/systemd/system/cockpit.socket
 /usr/lib/systemd/system/cockpit.service
+/usr/lib/firewalld/services/cockpit.xml
 %{_datadir}/dbus-1/services/com.redhat.Cockpit.service
 %{_libexecdir}/cockpitd
 %{_libexecdir}/cockpit-ws

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -819,5 +819,7 @@ set -eu
 
 rpm -U --force $TEST_PACKAGES
 
+firewall-cmd --add-service=cockpit --permanent
+
 rm -rf /var/log/journal/*
 """


### PR DESCRIPTION
This allows people to easily open the cockpit port in their
zones with commands like:

```
 # firewall-cmd --add-service=cockpit --permanent
```

It also provides the basis for getting this enabled in Fedora Server
by default.
