### PR TITLE
shell: displays password error message

### DIFF
--- a/modules/shell/cockpit-accounts.js
+++ b/modules/shell/cockpit-accounts.js
@@ -248,6 +248,7 @@ cockpit_pages.push(new PageAccounts());
 
 PageAccountsCreate.prototype = {
     _init: function() {
+        this.error_timeout = null;
         this.id = "accounts-create-dialog";
     },
 
@@ -261,7 +262,9 @@ PageAccountsCreate.prototype = {
     setup: function() {
         $('#accounts-create-cancel').on('click', $.proxy(this, "cancel"));
         $('#accounts-create-create').on('click', $.proxy(this, "create"));
-        $('#accounts-create-dialog input').on('keyup change', $.proxy(this, "update"));
+        $('#accounts-create-dialog .check-passwords').on('keydown', $.proxy(this, "update", "keydown"));
+        $('#accounts-create-dialog .check-passwords').on('input', $.proxy(this, "update", "input"));
+        $('#accounts-create-dialog input').on('focusout change', $.proxy(this, "update", "changeFocus"));
     },
 
     enter: function() {
@@ -270,13 +273,14 @@ PageAccountsCreate.prototype = {
         $('#accounts-create-pw1').val("");
         $('#accounts-create-pw2').val("");
         $('#accounts-create-locked').prop('checked', false);
+        $('#accounts-create-message-password-mismatch').css("visibility", "hidden");
         this.update ();
     },
 
     leave: function() {
     },
 
-    update: function() {
+    update: function(behavior) {
         function check_params ()
         {
             return ($('#accounts-create-user-name').val() !== "" &&
@@ -285,12 +289,42 @@ PageAccountsCreate.prototype = {
                     $('#accounts-create-pw2').val() == $('#accounts-create-pw1').val());
         }
 
-	if($('#accounts-create-pw2').val() !== "" &&  $('#accounts-create-pw2').val() != $('#accounts-create-pw1').val()) {
-		$("#accounts-create-dialog .check-passwords").addClass("has-error");
-                $('#accounts-create-message-password-mismatch').css("visibility", "visible");
-        } else {
-		$("#accounts-create-dialog .check-passwords").removeClass("has-error");
-                $('#accounts-create-message-password-mismatch').css("visibility", "hidden");
+        function highlight_error() {
+            $("#accounts-create-dialog .check-passwords").addClass("has-error");
+            $('#accounts-create-message-password-mismatch').css("visibility", "visible");
+        }
+
+        function hide_error() {
+            $("#accounts-create-dialog .check-passwords").removeClass("has-error");
+            $('#accounts-create-message-password-mismatch').css("visibility", "hidden");
+        }
+
+        function check_password_match() {
+            if ($('#accounts-create-pw2').val() !== "" &&
+                $('#accounts-create-pw1').val() !==$('#accounts-create-pw2').val())
+                highlight_error();
+            else
+                hide_error();
+        }
+
+        clearTimeout(this.error_timeout);
+        this.error_timeout = null;
+
+        if (behavior == "changeFocus") {
+            if ($('#accounts-create-pw2').val() !== "" &&
+                $('#accounts-create-pw1').val() !== $('#accounts-create-pw2').val())
+                highlight_error();
+            else
+                hide_error();
+        } else if (behavior == "input") {
+            if ($('#accounts-create-pw2').val() !== "" &&
+                  !$('#accounts-create-pw1').val().startsWith($('#accounts-create-pw2').val()))
+                  highlight_error();
+            else
+                  hide_error();
+
+        this.error_timeout = setTimeout(check_password_match,2000);
+        this.setTimeout = null;
         }
 
         $('#accounts-create-create').prop('disabled', !check_params());
@@ -824,6 +858,7 @@ cockpit_pages.push(new PageAccountConfirmDelete());
 
 PageAccountSetPassword.prototype = {
     _init: function() {
+        this.error_timeout = null;
         this.id = "account-set-password-dialog";
     },
 
@@ -836,31 +871,64 @@ PageAccountSetPassword.prototype = {
 
     setup: function() {
         $('#account-set-password-apply').on('click', $.proxy(this, "apply"));
-        $('#account-set-password-dialog input').on('keyup change', $.proxy(this, "update"));
+        $('#account-set-password-dialog .check-passwords').on('keydown', $.proxy(this, "update", "keydown"));
+        $('#account-set-password-dialog .check-passwords').on('input', $.proxy(this, "update", "input"));
+        $('#account-set-password-dialog input').on('focusout change', $.proxy(this, "update", "changeFocus"));
     },
 
     enter: function() {
         $('#account-set-password-pw1').val("");
         $('#account-set-password-pw2').val("");
+        $('#account-set-password-message-password-mismatch').css("visibility", "hidden");
         this.update ();
     },
 
     leave: function() {
     },
 
-    update: function() {
+    update: function(behavior) {
         function check_params ()
         {
             return ($('#account-set-password-pw1').val() !== "" &&
                     $('#account-set-password-pw2').val() == $('#account-set-password-pw1').val());
         }
 
-	if(!check_params() && $('#account-set-password-pw2').val() !== "") {
-		$("#account-set-password-dialog .check-passwords").addClass("has-error");
-                $('#account-set-password-message-password-mismatch').css("visibility", "visible");
-        } else {
-		$("#account-set-password-dialog .check-passwords").removeClass("has-error");
-                $('#account-set-password-message-password-mismatch').css("visibility", "hidden");
+        function highlight_error() {
+            $("#account-set-password-dialog .check-passwords").addClass("has-error");
+            $('#account-set-password-message-password-mismatch').css("visibility", "visible");
+        }
+
+        function hide_error() {
+            $("#account-set-password-dialog .check-passwords").removeClass("has-error");
+            $('#account-set-password-message-password-mismatch').css("visibility", "hidden");
+        }
+
+        function check_password_match() {
+            if($('#account-set-password-pw2').val() !== "" &&
+               $('#account-set-password-pw1').val() !== $('#account-set-password-pw2').val())
+                highlight_error();
+            else
+                hide_error();
+        }
+
+        clearTimeout(this.error_timeout);
+        this.error_timeout = null;
+
+        if (behavior == "changeFocus") {
+            if ($('#account-set-password-pw2').val() !== "" &&
+                $('#account-set-password-pw1').val() !== $('#account-set-password-pw2').val())
+                highlight_error();
+            else
+                hide_error();
+        } else if (behavior == "input") {
+              if ($('#account-set-password-pw2').val() !== "" &&
+                 !$('#account-set-password-pw1').val().startsWith($('#account-set-password-pw2').val()))
+            highlight_error();
+        else
+            hide_error();
+
+            this.error_timeout = setTimeout(check_password_match, 2000);
+            this.setTimeout = null;
         }
 
         $('#account-set-password-apply').prop('disabled', !check_params());

--- a/modules/shell/shell.html
+++ b/modules/shell/shell.html
@@ -1297,8 +1297,12 @@
               </tr>
               <tr>
                 <td translatable="yes">Password</td>
-                <td><input class="form-control" type="password"
-                           id="accounts-create-pw1" value=""/></td>
+                <td>
+                  <div class="check-passwords">
+                    <input class="form-control" type="password"
+                           id="accounts-create-pw1" value=""/>
+                  </div>
+                </td>
               </tr>
               <tr>
                 <td translatable="yes">Confirm</td>
@@ -1354,12 +1358,16 @@
             <table class="cockpit-form-table">
               <tr>
                 <td translatable="yes">Password</td>
-                <td><input class="form-control" type="password" id="account-set-password-pw1"></td>
+                <td>
+                  <div class="check-passwords">
+                    <input class="form-control" type="password"
+                           id="account-set-password-pw1"/>
+                  </div>
+                </td>
               </tr>
               <tr>
                 <td translatable="yes">Confirm</td>
                 <td>
-<!-- add has-error class if incorrect-->
                 <div class="check-passwords">
                 <input class="form-control" type="password"
                            id="account-set-password-pw2" value=""/>


### PR DESCRIPTION
When a types in his password twice to confirm it is the desired password
an error message is now displayed under the text box. The text box
itself is now highlighted to further show this error.

Fixes: #739
