### PR TITLE
shell: Fix and update cockpit-jobs.

### DIFF
--- a/modules/shell/cockpit-jobs.js
+++ b/modules/shell/cockpit-jobs.js
@@ -84,16 +84,16 @@ function cockpit_unwatch_jobs (client)
     }
 }
 
-function cockpit_job_box (client, box, domain, role, descriptions, target_describer)
+function cockpit_job_box (client, tbody, domain, role, descriptions, target_describer)
 {
     function update ()
     {
         var objs = client.getObjectsFrom("/com/redhat/Cockpit/Jobs/");
         var i, j, t, tdesc;
-        var tbody, target_desc, desc, progress, remaining, cancel;
+        var target_desc, desc, progress, remaining, cancel;
         var some_added = false;
 
-        tbody = $('<tbody>');
+        tbody.empty();
         for (i = 0; i < objs.length; i++) {
             j = objs[i].lookup("com.redhat.Cockpit.Job");
             if (j && j.Domain == domain) {
@@ -117,13 +117,13 @@ function cockpit_job_box (client, box, domain, role, descriptions, target_descri
                 else
                     remaining = '';
                 if (j.Cancellable) {
-                    cancel = $('<button data-mini="true" data-inline="true">Cancel</button>');
+                    cancel = $('<button class="btn btn-default">').text(_("Cancel"));
                     cancel.on('click', function (event) {
-                        if (!cockpit_check_role (role))
+                        if (!cockpit_check_role (role, client))
                             return;
                         j.call('Cancel', function (error) {
-                        if (error)
-                            cockpit_show_unexpected_error (error);
+                            if (error)
+                                cockpit_show_unexpected_error (error);
                         });
                     });
                 } else
@@ -141,11 +141,7 @@ function cockpit_job_box (client, box, domain, role, descriptions, target_descri
                 some_added = true;
             }
         }
-        box.empty();
-        if (!some_added)
-            box.text(_("(No current jobs)"));
-        else
-            box.append($('<table>', { 'class': 'table' }).append(tbody));
+        tbody.parents(".panel").toggle(some_added);
     }
 
     function update_props (event, obj, iface)

--- a/modules/shell/shell.html
+++ b/modules/shell/shell.html
@@ -246,7 +246,10 @@
 
         <div class="panel panel-default">
           <div class="panel-heading" translatable="yes">Storage Jobs</div>
-          <div class="panel-body" id="storage-jobs"></div>
+          <table class="table">
+            <tbody id="storage-jobs">
+            </tbody>
+          </table>
         </div>
 
         <div class="panel panel-default cockpit-log-panel">
@@ -418,7 +421,10 @@
 
         <div class="panel panel-default">
           <div class="panel-heading" translatable="yes">Storage Jobs</div>
-          <div class="panel-body" id="storage-detail-jobs"></div>
+          <table class="table">
+            <tbody id="storage-detail-jobs">
+            </tbody>
+          </table>
         </div>
 
         <div class="panel panel-default cockpit-log-panel">

--- a/test/check-storage
+++ b/test/check-storage
@@ -498,8 +498,9 @@ class TestStorage(MachineCase):
         b.wait_popdown("storage_format_dialog")
 
         with b.wait_timeout(120):
+            b.wait_visible("#storage-detail-jobs")
             b.wait_in_text("#storage-detail-jobs", "Erasing")
-            b.wait_in_text("#storage-detail-jobs", "No current jobs")
+            b.wait_not_visible("#storage-detail-jobs")
             b.wait_in_text("#storage_detail_partition_list", "FILESYSTEM")
 
     def testLvm(self):


### PR DESCRIPTION
The cockpit_check_role function was called wrong and it was still
using jQuery Mobile markup for the button.  The table needs to be a
direct child of the "div.panel" to look right.  Hide the whole panel
when it is empty.

Fixes #817.
