### PR TITLE
shell: Don't offer block devices for RAID or LVM that should be ignored.

### DIFF
--- a/modules/shell/cockpit-storage.js
+++ b/modules/shell/cockpit-storage.js
@@ -633,7 +633,7 @@ function cockpit_get_free_block_devices(client, filter)
         var o = objs[n];
         var b = o.lookup("com.redhat.Cockpit.Storage.Block");
 
-        if (b && b.Size > 0 && !has_fs_label(b) && !b.PartitionTableType && !is_extended_partition(b) &&
+        if (b && !b.HintIgnore && b.Size > 0 && !has_fs_label(b) && !b.PartitionTableType && !is_extended_partition(b) &&
             !(filter && filter(b)))
             result.push(b);
     }


### PR DESCRIPTION
Fixes #814.
