### PR TITLE
Implement support for HTTP keep alives

### DIFF
--- a/src/ws/cockpitwebresponse.c
+++ b/src/ws/cockpitwebresponse.c
@@ -63,6 +63,7 @@ struct _CockpitWebResponse {
   gboolean failed;
   gboolean done;
   gboolean chunked;
+  gboolean keep_alive;
 };
 
 typedef struct {
@@ -89,10 +90,6 @@ cockpit_web_response_done (CockpitWebResponse *self)
   g_assert (!self->done);
   self->done = TRUE;
 
-  g_object_unref (self->io);
-  self->io = NULL;
-  self->out = NULL;
-
   if (self->source)
     {
       g_source_destroy (self->source);
@@ -102,8 +99,7 @@ cockpit_web_response_done (CockpitWebResponse *self)
 
   if (self->complete)
     {
-      /* TODO: This should depend on keep alive */
-      reusable = TRUE;
+      reusable = !self->failed && self->keep_alive;
       g_object_unref (self);
     }
   else if (!self->failed)
@@ -113,6 +109,11 @@ cockpit_web_response_done (CockpitWebResponse *self)
     }
 
   g_signal_emit (self, signal__done, 0, reusable);
+
+  g_object_unref (self->io);
+  self->io = NULL;
+  self->out = NULL;
+
   g_object_unref (self);
 }
 
@@ -158,6 +159,7 @@ cockpit_web_response_class_init (CockpitWebResponseClass *klass)
  * cockpit_web_response_new:
  * @io: the stream to send on
  * @path: the path resource or NULL
+ * @in_haeders: input headers or NULL
  *
  * Create a new web response.
  *
@@ -169,10 +171,12 @@ cockpit_web_response_class_init (CockpitWebResponseClass *klass)
  */
 CockpitWebResponse *
 cockpit_web_response_new (GIOStream *io,
-                          const gchar *path)
+                          const gchar *path,
+                          GHashTable *in_headers)
 {
   CockpitWebResponse *self;
   GOutputStream *out;
+  const gchar *connection;
 
   /* Trying to be a somewhat performant here, avoiding properties */
   self = g_object_new (COCKPIT_TYPE_WEB_RESPONSE, NULL);
@@ -194,6 +198,14 @@ cockpit_web_response_new (GIOStream *io,
     self->logname = self->path;
   else
     self->logname = "response";
+
+  self->keep_alive = TRUE;
+  if (in_headers)
+    {
+      connection = g_hash_table_lookup (in_headers, "Connection");
+      if (connection)
+        self->keep_alive = g_str_equal (connection, "keep-alive");
+    }
 
   return self;
 }
@@ -236,30 +248,6 @@ should_suppress_output_error (CockpitWebResponse *self,
 }
 
 static void
-on_output_closed (GObject *stream,
-                  GAsyncResult *result,
-                  gpointer user_data)
-{
-  CockpitWebResponse *self = COCKPIT_WEB_RESPONSE (user_data);
-  GOutputStream *output = G_OUTPUT_STREAM (stream);
-  GError *error = NULL;
-
-  if (g_output_stream_close_finish (output, result, &error))
-    {
-      g_debug ("%s: closed output", self->logname);
-    }
-  else
-    {
-      if (!should_suppress_output_error (self, error))
-        g_warning ("%s: couldn't close web output: %s", self->logname, error->message);
-      g_error_free (error);
-    }
-
-  g_object_unref (self);
-  cockpit_web_response_done (self);
-}
-
-static void
 on_output_flushed (GObject *stream,
                    GAsyncResult *result,
                    gpointer user_data)
@@ -271,18 +259,16 @@ on_output_flushed (GObject *stream,
   if (g_output_stream_flush_finish (output, result, &error))
     {
       g_debug ("%s: flushed output", self->logname);
-
-      g_output_stream_close_async (output, G_PRIORITY_DEFAULT,
-                                   NULL, on_output_closed, g_object_ref (self));
     }
   else
     {
       if (!should_suppress_output_error (self, error))
         g_warning ("%s: couldn't flush web output: %s", self->logname, error->message);
+      self->failed = TRUE;
       g_error_free (error);
-      cockpit_web_response_done (self);
     }
 
+  cockpit_web_response_done (self);
   g_object_unref (self);
 }
 
@@ -573,7 +559,7 @@ append_header (GString *string,
   else if (g_ascii_strcasecmp ("Content-Length", name) == 0)
     g_critical ("Don't set Content-Length manually. This is a programmer error.");
   else if (g_ascii_strcasecmp ("Connection", name) == 0)
-    g_critical ("Don't set Content-Length manually. This is a programmer error.");
+    g_critical ("Don't set Connection header manually. This is a programmer error.");
   return 0;
 }
 
@@ -668,7 +654,8 @@ finish_headers (CockpitWebResponse *self,
       self->chunked = TRUE;
       g_string_append_printf (string, "Transfer-Encoding: chunked\r\n");
     }
-  g_string_append (string, "Connection: close\r\n");
+  if (!self->keep_alive)
+    g_string_append (string, "Connection: close\r\n");
   g_string_append (string, "\r\n");
 
   return g_string_free_to_bytes (string);

--- a/src/ws/cockpitwebresponse.h
+++ b/src/ws/cockpitwebresponse.h
@@ -39,7 +39,8 @@ typedef struct _CockpitWebResponse        CockpitWebResponse;
 GType                 cockpit_web_response_get_type      (void) G_GNUC_CONST;
 
 CockpitWebResponse *  cockpit_web_response_new           (GIOStream *io,
-                                                          const gchar *path);
+                                                          const gchar *path,
+                                                          GHashTable *in_headers);
 
 const gchar *         cockpit_web_response_get_path      (CockpitWebResponse *self);
 

--- a/src/ws/test-webserver.c
+++ b/src/ws/test-webserver.c
@@ -188,6 +188,9 @@ perform_http_request (const gchar *hostport,
                              request, strlen (request), NULL, NULL, &error);
   g_assert_no_error (error);
 
+  g_socket_shutdown (g_socket_connection_get_socket (conn), FALSE, TRUE, &error);
+  g_assert_no_error (error);
+
   reply = g_string_new ("");
   input = g_io_stream_get_input_stream (G_IO_STREAM (conn));
   for (;;)


### PR DESCRIPTION
This makes us much faster, especially when loading over high latency links or using SSL.

We make it the responsibility of CockpitWebServer to close the connections, and we check for further requests on a connection.
