### PR TITLE
common: Make sure to get all data out of CockpitPipe

### DIFF
--- a/src/common/cockpitpipe.c
+++ b/src/common/cockpitpipe.c
@@ -198,13 +198,19 @@ on_child_reap (GPid pid,
   self->priv->exited = TRUE;
   self->priv->watch_arg = NULL;
 
+  /* Release our reference on watch handler */
+  g_source_unref (self->priv->child);
+  self->priv->child = NULL;
+
   /*
-   * When a pid is present then this is the definitive way of
-   * determining when the process has closed.
+   * We need to wait until both the process has exited *and*
+   * the output has closed before we fire our close signal.
    */
 
-  g_debug ("%s: child process quit: closed: %d %d", self->priv->name, (int)pid, status);
-  g_signal_emit (self, cockpit_pipe_sig_close, 0, self->priv->problem);
+  g_debug ("%s: child process quit:%s  %d %d", self->priv->name,
+           self->priv->closed ? " closed:" : "", (int)pid, status);
+  if (self->priv->closed)
+    g_signal_emit (self, cockpit_pipe_sig_close, 0, self->priv->problem);
 }
 
 static gboolean
@@ -441,6 +447,8 @@ dispatch_output (gint fd,
 
   if (self->priv->closing)
     close_output (self);
+  else
+    close_maybe (self);
 
   return TRUE;
 }


### PR DESCRIPTION
When a process exited before all its data had been received,
we would accidentally lose the last bit of data. Wait until the output
has closed before closing the pipe.
