### PR TITLE
agent: Fix some issues reading DBus address from dbus-daemon

### DIFF
--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -181,7 +181,7 @@ start_dbus_daemon (void)
       if (ret < 0)
         {
           g_string_set_size (address, len);
-          if (errno != EAGAIN)
+          if (errno != EAGAIN && errno != EINTR)
             {
               g_warning ("couldn't read address from dbus-daemon: %s", g_strerror (errno));
               break;
@@ -189,6 +189,7 @@ start_dbus_daemon (void)
         }
       else if (ret == 0)
         {
+          g_string_set_size (address, len);
           break;
         }
       else


### PR DESCRIPTION
Trying to fix the isuse we see every once in a while:

cockpit-agent[20020]: The given address is empty
