### PR TITLE
shell: Change default byte suffix to KB

### DIFF
--- a/modules/shell/cockpit-util.js
+++ b/modules/shell/cockpit-util.js
@@ -48,12 +48,12 @@ function cockpit_debug(str) {
  * @factor: optional, either 1000, 1024 or a string suffix
  *
  * Formats bytes into a displayable string and suffix, such as
- * 'kB' or 'MiB'. Returns an array of the formatted number and
+ * 'kB' or 'MB'. Returns an array of the formatted number and
  * the suffix.
  *
  * If specifying 1000 or 1024 these will be used as the factors
  * to choose an appropriate suffix. By default the factor is
- * 1000.
+ * 1024.
  *
  * You can pass the suffix into the second argument in which
  * case the number will be formatted with that specific suffix.
@@ -69,12 +69,16 @@ function cockpit_debug(str) {
  *    cockpit.format_bytes(1000000).join(" ");
  *    cockpit.format_bytes(1000000, 1024).join(" ");
  *    cockpit.format_bytes(1000000, "kB").join(" ");
+ *
+ * The current policy is to use KB, MB, GB, etc. for both factors
+ * of 1000 and 1024.
  */
 (function(cockpit) {
 
 var suffixes = {
-    1000: [ null, "kB", "MB", "GB", "TB", "PB", "EB", "ZB" ],
-    1024: [ null, "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB" ]
+    1024: [ null, "KB", "MB", "GB", "TB", "PB", "EB", "ZB" ],
+    1000: [ null, "kB", "MB", "GB", "TB", "PB", "EB", "ZB" ]
+    /* 1024: [ null, "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB" ] */
 };
 
 cockpit.format_bytes = function format_bytes(number, factor) {
@@ -82,7 +86,7 @@ cockpit.format_bytes = function format_bytes(number, factor) {
     var suffix = null;
 
     if (factor === undefined)
-        factor = 1000;
+        factor = 1024;
 
     /* Find that factor string */
     if (typeof (factor) === "string") {
@@ -119,6 +123,7 @@ cockpit.format_bytes = function format_bytes(number, factor) {
     if (number > 0 && number < 0.1)
         number = 0.1;
 
+    /* TODO: Make the decimal separator translatable */
     if (number === 0)
         return [number.toString(), suffix];
     else
@@ -167,11 +172,9 @@ function cockpit_add_thousands_separators(number)
 }
 
 function cockpit_format_bytes_long(num_bytes) {
-    var with_unit = cockpit_format_bytes(num_bytes);
-    var with_pow2_unit = cockpit_format_bytes_pow2(num_bytes);
-    var with_sep = cockpit_add_thousands_separators(num_bytes);
-    /* Translators: Used in "42.5 kB (42,399 bytes)" */
-    return with_unit + " (" + with_pow2_unit + ", " + with_sep + " " + C_("format-bytes", "bytes") + ")";
+    var with_unit = cockpit_format_bytes_pow2(num_bytes);
+    /* Translators: Used in "42.5 kB (42399 bytes)" */
+    return with_unit + " (" + num_bytes + " " + C_("format-bytes", "bytes") + ")";
 }
 
 function cockpit_format_bytes_per_sec(num_bytes) {

--- a/modules/shell/shell.html
+++ b/modules/shell/shell.html
@@ -1505,15 +1505,15 @@
                 <td translatable="yes">Chunk Size</td>
                 <td>
                   <select class="form-control selectpicker" id="create-raid-chunk">
-                    <option translatable="yes" value="4">4 KiB</option>
-                    <option translatable="yes" value="8">8 KiB</option>
-                    <option translatable="yes" value="16">16 KiB</option>
-                    <option translatable="yes" value="32">32 KiB</option>
-                    <option translatable="yes" value="64">64 KiB</option>
-                    <option translatable="yes" value="128">128 KiB</option>
-                    <option translatable="yes" value="512" selected="true">512 KiB</option>
-                    <option translatable="yes" value="1024">1 MiB</option>
-                    <option translatable="yes" value="2048">2 MiB</option>
+                    <option translatable="yes" value="4">4 KB</option>
+                    <option translatable="yes" value="8">8 KB</option>
+                    <option translatable="yes" value="16">16 KB</option>
+                    <option translatable="yes" value="32">32 KB</option>
+                    <option translatable="yes" value="64">64 KB</option>
+                    <option translatable="yes" value="128">128 KB</option>
+                    <option translatable="yes" value="512" selected="true">512 KB</option>
+                    <option translatable="yes" value="1024">1 MB</option>
+                    <option translatable="yes" value="2048">2 MB</option>
                   </select>
                 </td>
               </tr>
@@ -1643,7 +1643,7 @@
           <div class="modal-body">
             <table class="cockpit-form-table">
               <tr id="format-size-row">
-                <td translatable="yes">Size (MiB)</td>
+                <td translatable="yes">Size (MB)</td>
                 <td>
                   <input class="form-control" type="text" id="format-size">
                 </td>
@@ -1833,7 +1833,7 @@
                 </td>
               </tr>
               <tr>
-                <td translatable="yes">Size (MiB)</td>
+                <td translatable="yes">Size (MB)</td>
                 <td>
                   <input class="form-control" type="text" id="create-pvol-size"/>
                 </td>
@@ -1869,7 +1869,7 @@
                 </td>
               </tr>
               <tr>
-                <td translatable="yes">Size (MiB)</td>
+                <td translatable="yes">Size (MB)</td>
                 <td>
                   <input class="form-control" type="text" id="create-tpool-size"/>
                 </td>
@@ -1905,7 +1905,7 @@
                 </td>
               </tr>
               <tr>
-                <td translatable="yes">Size (MiB)</td>
+                <td translatable="yes">Size (MB)</td>
                 <td>
                   <input class="form-control" type="text" id="create-tvol-size"/>
                 </td>
@@ -1941,7 +1941,7 @@
                 </td>
               </tr>
               <tr id="create-svol-size-row">
-                <td translatable="yes">Size (MiB)</td>
+                <td translatable="yes">Size (MB)</td>
                 <td>
                   <input class="form-control" type="text" id="create-svol-size"/>
                 </td>
@@ -1971,7 +1971,7 @@
           <div class="modal-body">
             <table class="cockpit-form-table">
               <tr>
-                <td translatable="yes">New Size (MiB)</td>
+                <td translatable="yes">New Size (MB)</td>
                 <td>
                   <input class="form-control" type="text" id="resize-lvol-size"/>
                 </td>

--- a/modules/shell/test-util.html
+++ b/modules/shell/test-util.html
@@ -41,17 +41,16 @@
 test("format_bytes", function() {
     var checks = [
         [ 999, 1000, ["999"] ],
-        [ 1934, undefined, ["1.9", "kB"] ],
+        [ 1934, undefined, ["1.9", "KB"] ],
         [ 1934, 1000, ["1.9", "kB"] ],
-        [ 2000, 1024, ["2.0", "KiB"] ],
+        [ 2000, 1024, ["2.0", "KB"] ],
         [ 1999, 1000, ["2.0", "kB"] ],
-        [ 1999, 1024, ["2.0", "KiB"] ],
+        [ 1999, 1024, ["2.0", "KB"] ],
         [ 1000000, 1000, ["1.0", "MB"] ],
-        [ 1000000, 1024, ["976.6", "KiB"] ],
-        [ 2000000, 1024, ["1.9", "MiB"] ],
+        [ 1000000, 1024, ["976.6", "KB"] ],
+        [ 2000000, 1024, ["1.9", "MB"] ],
         [ 2000000, 1000, ["2.0", "MB"] ],
-        [ 2000000, "MiB", ["1.9", "MiB"] ],
-        [ 2000000, "MB", ["2.0", "MB"] ],
+        [ 2000000, "MB", ["1.9", "MB"] ],
         [ 2000000, "kB", ["2000.0", "kB"] ],
         [ 1, "kB", ["0.1", "kB"] ],
         [ 0, "kB", ["0", "kB"] ],
@@ -71,7 +70,7 @@ test("cockpit_format_bytes", function() {
 
 test("cockpit_format_bytes_pow2", function() {
     expect(1);
-    strictEqual(cockpit_format_bytes_pow2(5000), "4.9 KiB", "cockpit_format_bytes(5000) = 5.0 kB");
+    strictEqual(cockpit_format_bytes_pow2(5000), "4.9 KB", "cockpit_format_bytes(5000) = 4.9 KB");
 });
 
 test("quote_words", function() {

--- a/test/check-storage
+++ b/test/check-storage
@@ -755,7 +755,7 @@ class TestStorage(MachineCase):
         b.click("#format-disk-format")
         b.wait_popdown("storage_format_disk_dialog")
 
-        b.wait_in_text("#storage_detail_content", "50.0 MiB Free Space")
+        b.wait_in_text("#storage_detail_content", "50.0 MB Free Space")
 
     def testHidden(self):
         m = self.machine


### PR DESCRIPTION
Instead of using the more geeky KiB and such suffixes, use
KB consistently. Try to use 1024 factor as much as possible
for consistency.

Fixes #704
