### PR TITLE
shell: Replaced "hostname" with "host name" in the UI.

### DIFF
--- a/modules/shell/STYLE.html
+++ b/modules/shell/STYLE.html
@@ -56,7 +56,7 @@
             <td>Fedora 20 (Heisenbug)</td>
           </tr>
           <tr>
-            <td>Hostname</td>
+            <td>Host Name</td>
             <td>sunflower</td>
             <td>
               <button class="btn btn-default">

--- a/modules/shell/cockpit-setup.js
+++ b/modules/shell/cockpit-setup.js
@@ -48,7 +48,7 @@ PageSetupServer.prototype = {
         self.address = null;
         self.options = { "host-key": "", "payload": "dbus-json1" };
 
-        $("#dashboard_setup_address")[0].placeholder = _("Enter IP address or hostname");
+        $("#dashboard_setup_address")[0].placeholder = _("Enter IP address or host name");
         $("#dashboard_setup_login_user")[0].placeholder = C_("login-screen", "Enter user name");
         $("#dashboard_setup_login_password")[0].placeholder = C_("login-screen", "Enter password");
         $('#dashboard_setup_address').on('keyup change', $.proxy (this, 'update_discovered'));

--- a/modules/shell/cockpit-system-information.js
+++ b/modules/shell/cockpit-system-information.js
@@ -126,7 +126,7 @@ PageSystemInformationChangeHostname.prototype = {
     },
 
     getTitle: function() {
-        return C_("page-title", "Change Hostname");
+        return C_("page-title", "Change Host Name");
     },
 
     setup: function() {
@@ -172,8 +172,8 @@ PageSystemInformationChangeHostname.prototype = {
     },
 
     _on_full_name_changed: function(event) {
-        /* Whenever the pretty hostname has changed (e.g. the user has edited it), we compute a new
-         * simple hostname (e.g. 7bit ASCII, no special chars/spaces, lower case) from it...
+        /* Whenever the pretty host name has changed (e.g. the user has edited it), we compute a new
+         * simple host name (e.g. 7bit ASCII, no special chars/spaces, lower case) from it...
          */
         var pretty_hostname = $("#sich-pretty-hostname").val();
         if (this._always_update_from_pretty || this._initial_pretty_hostname != pretty_hostname) {

--- a/modules/shell/shell.html
+++ b/modules/shell/shell.html
@@ -178,7 +178,7 @@
                 <td id="system_information_os_text"></td>
               </tr>
               <tr>
-                <td>Host name</td>
+                <td>Host Name</td>
                 <td id="system_information_hostname_text"></td>
                 <td>
                   <button class="btn btn-default" id="system_information_change_hostname_button">
@@ -679,7 +679,7 @@
           </table>
           <button class="btn btn-default" id="account-set-password">Set Password</button>
           <button class="btn btn-default" id="account-delete">Delete</button>
-          <button class="btn btn-default" id="account-logout">Terminate session</button>
+          <button class="btn btn-default" id="account-logout">Terminate Session</button>
           <button class="btn btn-default" id="account-change-roles">Change Roles</button>
         </center>
 

--- a/src/daemon/com.redhat.Cockpit.xml
+++ b/src/daemon/com.redhat.Cockpit.xml
@@ -91,8 +91,8 @@
 
     <!--
         SetHostname:
-        @pretty_hostname: Pretty Hostname to set or blank to not set the pretty hostname.
-        @hostname: Regular hostname to set or blank to not set the regular hostname.
+        @pretty_hostname: Pretty Host Name to set or blank to not set the pretty host name.
+        @hostname: Regular host name to set or blank to not set the regular host name.
         @options: Currently unused.
 
         Sets the host names.


### PR DESCRIPTION
Replaced all "hostname" with "host name".
To keep consistent, also changed "Terminate session" to "Terminate Session" in the User Accounts section.

Fixes #859
