### PR TITLE
remotectl: Fix issues when group is set to a blank string

### DIFF
--- a/src/remotectl/certificate.c
+++ b/src/remotectl/certificate.c
@@ -73,6 +73,8 @@ ensure_certificate (const gchar *user,
 
   if (!user)
     user = "root";
+  if (g_strcmp0 (group, "") == 0)
+    group = NULL;
 
   /* Resolve the user and group */
   pwd = getpwnam (user);


### PR DESCRIPTION
Treat it the same as NULL
