### PR TITLE
ws: Don't complain when an HTTP keep alive times out

### DIFF
--- a/src/ws/cockpitwebserver.c
+++ b/src/ws/cockpitwebserver.c
@@ -1110,7 +1110,10 @@ static gboolean
 on_request_timeout (gpointer data)
 {
   CockpitRequest *request = data;
-  g_message ("request timed out, closing");
+  if (request->eof_okay)
+    g_debug ("request timed out, closing");
+  else
+    g_message ("request timed out, closing");
   cockpit_request_finish (request);
   return FALSE;
 }


### PR DESCRIPTION
Just disconnect quietly. Fixes spurious log lines like this
30 seconds after each cockpit login.

cockpit-ws[6184]: request timed out, closing
