### PR TITLE
test: Fix regression in ownership of /var/lib/cockpit dir

### DIFF
--- a/test/cockpit.spec.in
+++ b/test/cockpit.spec.in
@@ -119,7 +119,7 @@ install -p -m 644 cockpit.pp %{buildroot}%{_datadir}/selinux/targeted/
 %{_libdir}/security/pam_reauthorize.so
 %{_datadir}/%{name}
 %{_mandir}/*
-%attr(755, -, wheel) %{_sharedstatedir}/%{name}
+%attr(775, -, wheel) %{_sharedstatedir}/%{name}
 
 %package test-assets
 Summary: Additional stuff for testing Cockpit


### PR DESCRIPTION
This should be group writable by wheel so wheel users
can add/remove machines.

Fixes #853
