### PR TITLE
daemon: Don't print warnings when systemd files are empty

### DIFF
--- a/src/daemon/services.c
+++ b/src/daemon/services.c
@@ -566,7 +566,8 @@ get_service_description (const gchar *file)
   return description;
 
 out:
-  g_warning ("Failed to load '%s': %s", file, error->message);
+  if (g_error_matches (error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_GROUP_NOT_FOUND))
+    g_warning ("Failed to load '%s': %s", file, error->message);
   g_error_free (error);
   g_key_file_free (kf);
   return g_strdup ("Unknown");


### PR DESCRIPTION
This fixes the warning:

```
Jul 17 17:18:49 stef.thewalter.lan cockpitd[29006]: Failed to load '/run/systemd/system/session-10.scope': Key file does not have group 'Unit'
Jul 17 17:18:49 stef.thewalter.lan systemd-coredump[29666]: Process 29006 (cockpitd) dumped core.
```
