### PR TITLE
shell: Fix blank group list item when adding server.

### DIFF
--- a/modules/shell/cockpit-setup.js
+++ b/modules/shell/cockpit-setup.js
@@ -114,12 +114,14 @@ PageSetupServer.prototype = {
             if (!cockpit_find_in_array (machines[i].Tags, "dashboard")) {
                 var rendered_address = render_address (machines[i].Address);
                 if (rendered_address) {
-                    var item =
-                        $('<li>', { 'class': 'list-group-item',
-                                    'on': { 'click': $.proxy(this, 'discovered_clicked', machines[i])
-                                          }
-                                  }).html(rendered_address);
-                    discovered.append(item);
+                    if (machines[i].Address.trim() !== "") {
+                        var item =
+                            $('<li>', { 'class': 'list-group-item',
+                                        'on': { 'click': $.proxy(this, 'discovered_clicked', machines[i])
+                                              }
+                                      }).html(rendered_address);
+                        discovered.append(item);
+                    }
                 }
             }
         }

--- a/src/daemon/machines.c
+++ b/src/daemon/machines.c
@@ -387,6 +387,14 @@ handle_add (CockpitMachines *object,
   Machines *machines = MACHINES (object);
   Machine *machine;
 
+  if (g_strcmp0 (arg_address, "") == 0)
+    {
+      error = g_error_new (G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                           "IP address or host name cannot be empty.");
+      g_dbus_method_invocation_take_error (invocation, error);
+      return TRUE;
+    }
+
   machine = machines_add (machines, arg_address, arg_host_key, &error);
   if (machine)
     {


### PR DESCRIPTION
When adding a server, the group list item won't be generated
if the address or host name of the machine is empty (whitespaces).
