### PR TITLE
shell: No need to show "login" tab.

### DIFF
--- a/modules/shell/cockpit-setup.js
+++ b/modules/shell/cockpit-setup.js
@@ -158,7 +158,11 @@ PageSetupServer.prototype = {
             $('#dashboard_setup_action_tab').show();
             $('#dashboard_setup_next').text(_("Add server"));
             this.next_action = this.next_setup;
-            this.prev_tab = 'login';
+            var reuse = $('#dashboard_setup_address_reuse_creds').prop('checked');
+            if (reuse)
+                this.prev_tab = 'address';
+            else
+                this.prev_tab = 'login';
         } else if (tab == 'close') {
             $('#dashboard_setup_action_tab').show();
             $('#dashboard_setup_next').text(_("Close"));


### PR DESCRIPTION
No need to show "login" tab when clicking "previous" button in the 
"action" tab if the "reuse creds" label is checked in the "address" tab.
