### PR TITLE
shell: empty realms-op-diagnostics box hidden

### DIFF
--- a/modules/shell/cockpit-realms.js
+++ b/modules/shell/cockpit-realms.js
@@ -461,6 +461,7 @@ PageRealmsOp.prototype = {
                     me.realm_manager.call("GetDiagnostics",
                                           function (error, result) {
                                               $("#realms-op-more-diagnostics").hide();
+                                              $("#realms-op-diagnostics").show();
                                               $("#realms-op-diagnostics").empty().append(result);
                                           });
                 });

--- a/modules/shell/shell.html
+++ b/modules/shell/shell.html
@@ -1231,7 +1231,7 @@
                     <div id="realms-op-error"
                          style="text-align:left;font-weight:bold"></div>
                     <pre id="realms-op-diagnostics"
-                         style="text-align:left">
+                         style="text-align:left; display: none">
                     </pre>
                   </td>
                 </tr>


### PR DESCRIPTION
realms-op-diagnostics box is hidden until the "more" button is clicked
to show the whole error in the "Join a Domain" dialog

Fixes: #778
