### PR TITLE
shell: Remove cockit-search.js from debug manifest.json

### DIFF
--- a/modules/shell/manifest.json
+++ b/modules/shell/manifest.json
@@ -37,7 +37,6 @@
 		"cockpit-journal-renderer.js",
 		"cockpit-jobs.js",
 		"cockpit-terminal.js",
-		"cockpit-search.js",
 		"cockpit-accounts.js",
 		"cockpit-docker.js",
 		"cockpit-internal.js",


### PR DESCRIPTION
To avoid errors during development in the javascript console. The file was removed a while back.
