### PR TITLE
common: Log stderr output from spawned commands to journal

### DIFF
--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -91,3 +91,7 @@ test_unixsignal_LDADD = $(libcockpit_common_a_LIBS)
 
 noinst_PROGRAMS += $(COCKPIT_CHECKS)
 TESTS += $(COCKPIT_CHECKS)
+
+EXTRA_DIST += \
+	src/common/mock-stderr \
+	$(NULL)

--- a/src/common/mock-stderr
+++ b/src/common/mock-stderr
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+/usr/bin/printf 'line one\n' >&2
+/usr/bin/printf 'line ' >&2
+/usr/bin/printf 'two\nline ' >&2
+/usr/bin/printf 'three\nline four\nline five' >&2
+/usr/bin/printf '\nline six' >&2

--- a/src/common/test-pipe.c
+++ b/src/common/test-pipe.c
@@ -706,6 +706,60 @@ test_spawn_and_fail (void)
   g_object_unref (pipe);
 }
 
+static GPtrArray *printed = NULL;
+
+static void
+on_printerr_handler (const gchar *string)
+{
+  g_ptr_array_add (printed, g_strdup (string));
+}
+
+static void
+test_spawn_printerr (void)
+{
+  gboolean closed = FALSE;
+  const gchar **actual;
+  CockpitPipe *pipe;
+  GPrintFunc func;
+  gint i;
+
+  const gchar *argv[] = { SRCDIR "/src/common/mock-stderr", NULL };
+
+  const gchar *expected[] = {
+    "line one",
+    "line two",
+    "line three",
+    "line four",
+    "line five",
+    "line six",
+    NULL
+  };
+
+  func = g_set_printerr_handler (on_printerr_handler);
+  printed = g_ptr_array_new_with_free_func (g_free);
+
+  pipe = cockpit_pipe_spawn (argv, NULL, NULL);
+  g_assert (pipe != NULL);
+  g_signal_connect (pipe, "close", G_CALLBACK (on_close_get_flag), &closed);
+
+  while (!closed)
+    g_main_context_iteration (NULL, TRUE);
+
+  while (g_main_context_iteration (NULL, FALSE));
+
+  g_set_printerr_handler (func);
+
+  g_ptr_array_add (printed, NULL);
+  actual = (const gchar **)printed->pdata;
+
+  for (i = 0; expected[i] != NULL; i++)
+    g_assert_cmpstr (expected[i], ==, actual[i]);
+  g_assert_cmpint (printed->len, ==, i + 1);
+
+  g_ptr_array_free (printed, TRUE);
+  g_object_unref (pipe);
+}
+
 static void
 test_pty_shell (void)
 {
@@ -1048,6 +1102,7 @@ main (int argc,
   g_test_add_func ("/pipe/spawn/and-read", test_spawn_and_read);
   g_test_add_func ("/pipe/spawn/and-write", test_spawn_and_write);
   g_test_add_func ("/pipe/spawn/and-fail", test_spawn_and_fail);
+  g_test_add_func ("/pipe/spawn/printerr", test_spawn_printerr);
 
   g_test_add_func ("/pipe/pty/shell", test_pty_shell);
 


### PR DESCRIPTION
This lets us assign it to the right process name in the journal
rather than letting it fall through to stderr on its own.

This also fixes logging stderr of remote cockpit-agent invocations
(ie: via ssh)
