### PR TITLE
ws: Don't print out needless TLS EOF error

### DIFF
--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -1149,7 +1149,10 @@ on_web_socket_error (WebSocketConnection *connection,
                      GError *error,
                      gpointer unused)
 {
-  g_message ("%s", error->message);
+  if (g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_EOF))
+    g_debug ("web socket error: %s", error->message);
+  else
+    g_message ("%s", error->message);
 }
 
 static gboolean


### PR DESCRIPTION
When certain browsers disconnect a WebSocket, they just disconnect the connection. So don't make a big deal about this error message.
