### PR TITLE
test: mvo.fedorapeople.org now uses https

### DIFF
--- a/test/vm-download
+++ b/test/vm-download
@@ -43,7 +43,7 @@ fi
 
 cd "$TEST_DATA/images"
 
-curl -s "http://mvo.fedorapeople.org/cockpit/images/$checksum_file" >"$checksum_file.remote"
+curl -s "https://mvo.fedorapeople.org/cockpit/images/$checksum_file" >"$checksum_file.remote"
 
 if [ -f "$checksum_file" ] && cmp "$checksum_file.remote" "$checksum_file"; then
     rm -f "$checksum_file.remote"
@@ -53,7 +53,7 @@ fi
 cat "$checksum_file.remote" | while read sum file; do
   if [ ! -f "$file" ] || ! echo $sum "$file" | sha256sum --status --check; then
       echo Downloading $file
-      curl "http://mvo.fedorapeople.org/cockpit/images/$file.xz" | xz -d >"$file.partial" && mv "$file.partial" "$file"
+      curl "https://mvo.fedorapeople.org/cockpit/images/$file.xz" | xz -d >"$file.partial" && mv "$file.partial" "$file"
   fi
 done
 


### PR DESCRIPTION
The redirects were causing ./vm-download (and thus ./VERIFY)
to fail.
