### PR TITLE
static: displays Malformed input error message

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -96,8 +96,9 @@
                         phantom_checkpoint();
                     }).
                     fail(function(xhr, reason) {
-                        if (xhr.status == 401) {
-                            console.log(xhr.statusText);
+                        if(!user)
+                            $("#login-error-message").show().text(xhr.statusText);
+                        else if (xhr.status == 401) {
                             $("#login-error-message").show().text("Wrong username or password");
                         }else {
                             fatal(xhr.statusText);


### PR DESCRIPTION
When the user leaves the user name blank and tries to log in they will
not be brought to a new page any longer. Now the error message
"Malformed input" will be displayed.

Fixes: #940
