### PR TITLE
shell: removes "options" text in join dialog

### DIFF
--- a/modules/shell/shell.html
+++ b/modules/shell/shell.html
@@ -1172,7 +1172,7 @@
                   </td>
                 </tr>
                 <tr class="realms-op-join-only-row">
-                  <td translatable="yes" class="header">Options</td>
+                  <td class="header"></td>
                 </tr>
                 <tr class="realms-op-join-only-row">
                   <td translatable="yes">Computer OU</td>


### PR DESCRIPTION
Fixes #952
