### PR TITLE
shell: gives user domain admininistrator hint text

### DIFF
--- a/modules/shell/cockpit-realms.js
+++ b/modules/shell/cockpit-realms.js
@@ -212,8 +212,8 @@ PageRealmsOp.prototype = {
             } else {
                 admin = me.given_details['suggested-administrator'];
             }
-            if (admin)
-                $("#realms-op-admin").val(admin);
+            if (admin && !$("#realms-op-admin").val())
+                $("#realms-op-admin")[0].placeholder = _("e.g. \""+admin+"\"");
         } else if (a == "user") {
             $("#realms-op-user-row").show();
             $("#realms-op-user-password-row").show();


### PR DESCRIPTION
After filling in a correct Domain Address, instead of overwriting
the Domain Administrator Name there will be suggested text put
there. This suggested text will put the same values in the text box but in
suggested text form. Furthermore, the text indicates to the user that
it is an example because it might not work for the user's domain.

Fixes #937
