### PR TITLE
ws: Remove the warning when adding a server with a blank user name

### DIFF
--- a/src/ws/cockpitcreds.c
+++ b/src/ws/cockpitcreds.c
@@ -65,6 +65,9 @@ cockpit_creds_new (const gchar *user,
   const char *type;
   va_list va;
 
+  g_return_val_if_fail (user != NULL, NULL);
+  g_return_val_if_fail (!g_str_equal (user, ""), NULL);
+
   creds = g_new0 (CockpitCreds, 1);
   creds->user = g_strdup (user);
 

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -926,7 +926,7 @@ process_open (CockpitWebService *self,
    */
   private = FALSE;
 
-  if (cockpit_json_get_string (options, "user", NULL, &specific_user) && specific_user)
+  if (cockpit_json_get_string (options, "user", NULL, &specific_user) && specific_user && !g_str_equal (specific_user, ""))
     {
       if (!cockpit_json_get_string (options, "password", NULL, &password))
         password = NULL;


### PR DESCRIPTION
Fixes #941
