### PR TITLE
ws: Redo check for empty user name.

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -243,7 +243,7 @@ cockpit_auth_parse_input (GBytes *input,
     {
       post = g_bytes_get_data (input, &length);
       line = memchr (post, '\n', length);
-      if (line && line != post)
+      if (line)
         {
           user = g_strndup (post, line - post);
           offset = (line - post) + 1;
@@ -254,13 +254,7 @@ cockpit_auth_parse_input (GBytes *input,
         }
     }
 
-  if (!user)
-    {
-      g_set_error (error, COCKPIT_ERROR, COCKPIT_ERROR_AUTHENTICATION_FAILED,
-                   "Authentication failed");
-      ret = FALSE;
-    }
-  else if (user && password)
+  if (user && password)
     {
       if (ret_user)
         {

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -178,7 +178,7 @@ test_userpass_invalid (Test *test,
   g_object_unref (result);
 
   g_assert (service == NULL);
-  g_assert_error (error, COCKPIT_ERROR, COCKPIT_ERROR_AUTHENTICATION_FAILED);
+  g_assert_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
   g_clear_error (&error);
 
   g_hash_table_destroy (headers);

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -231,7 +231,7 @@ test_login_post_bad (Test *test,
   g_bytes_unref (input);
 
   g_assert (ret == TRUE);
-  cockpit_assert_strmatch (output_as_string (test), "HTTP/1.1 401 Authentication failed\r\n*");
+  cockpit_assert_strmatch (output_as_string (test), "HTTP/1.1 400 Malformed input\r\n*");
 }
 
 static void

--- a/test/check-login
+++ b/test/check-login
@@ -100,6 +100,8 @@ class TestLogin(MachineCase):
         self.assertEqual(self.curl_post_code ('/login', 'foo\nbar\n'), 400)
         self.assertEqual(self.curl_post_code ('/login', 'foo\nbar\nbaz'), 400)
         self.assertEqual(self.curl_post_code ('/login', '\n\n\n'), 400)
+        self.assertEqual(self.curl_post_code ('/login', '\n'), 401)
+        self.assertEqual(self.curl_post_code ('/login', '\nbar'), 401)
         self.assertEqual(self.curl_post_code ('/login', 'admin\nbar'), 401)
         self.assertEqual(self.curl_post_code ('/login', 'foo\nbar'), 401)
         self.assertEqual(self.curl_post_code ('/login', 'x' * 5000), 413)


### PR DESCRIPTION
Parsing the auth input now allows a empty user name.  Empty user names
will lead to authentication failures later on, which is what we want.

Previously, a empty user name was a syntax error.  Recently, all
syntax errors were reported as authentication failures.

This reverts the backend part of "3fd6344 shell: Fix bad response
when login with empty user name" and "a9e6943 ws: Update test cases
for previous commit".
