### PR TITLE
agent: Remove use of PR_SET_PDEATHSIG when starting dbus-daemon

### DIFF
--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -133,7 +133,6 @@ on_closed_set_flag (CockpitTransport *transport,
 static void
 setup_dbus_daemon (gpointer addrfd)
 {
-  prctl (PR_SET_PDEATHSIG, SIGTERM);
   cockpit_unix_fd_close_all (3, GPOINTER_TO_INT (addrfd));
 }
 


### PR DESCRIPTION
It caused problems with g_spawn_async_with_pipes() double forking.

Lets just rely on logind to cleanup sessions after cockpit-agent
exits.
