### PR TITLE
agent: Fix sporadic crash when test-dbusjson finishes

### DIFF
--- a/src/agent/test-dbusjson.c
+++ b/src/agent/test-dbusjson.c
@@ -96,6 +96,8 @@ teardown_dbus_server(TestCase *tc,
   shutdown (tc->fd, SHUT_WR);
   g_thread_join (tc->thread);
   close (tc->fd);
+
+  while (g_main_context_iteration (NULL, FALSE));
 }
 
 static void


### PR DESCRIPTION
Allow the DBus worker thread to properly cleanup all of its
own nastiness in the mainloop before bringing down the GTestDBus
bus.

GDBus is a can of worms with regard to cleanup. This is another
workaround.
