### PR TITLE
shell: Put network interface name in a more prominent place.

### DIFF
--- a/modules/shell/cockpit-networking.js
+++ b/modules/shell/cockpit-networking.js
@@ -1432,6 +1432,7 @@ PageNetworkInterface.prototype = {
         } else
             desc = _("Unknown");
 
+        $('#network-interface-name').text(self.dev_name);
         $hw.html(
             $('<div class="panel-body">').append(
                 $('<div>').append(

--- a/modules/shell/shell.html
+++ b/modules/shell/shell.html
@@ -473,7 +473,7 @@
         <br/>
         <div class="panel panel-default">
           <div class="panel-heading">
-            <span translatable="yes">Network hardware</span>
+            <span id="network-interface-name"></span>
             <div style="float:right">
               <button class="btn btn-danger" style="margin-right:20px"
                       id="network-interface-delete">

--- a/test/check-networking
+++ b/test/check-networking
@@ -89,7 +89,7 @@ class TestNetworking(MachineCase):
         b.set_val("#network-ip-settings-dialog table:contains('Address') td:first-child input", "1.2.3.4")
         b.click("#network-ip-settings-dialog button:contains('Apply')")
         b.wait_popdown("network-ip-settings-dialog")
-        b.wait_in_text("#network-interface .panel:contains('Network hardware')", "1.2.3.4/24")
+        b.wait_in_text("#network-interface .panel:contains('%s')" % iface, "1.2.3.4/24")
 
         # Disconnect
         #


### PR DESCRIPTION
Fixes #799
