### PR TITLE
test: Fix make-rpms so it prints noarch packages as well

### DIFF
--- a/test/make-rpms
+++ b/test/make-rpms
@@ -88,7 +88,7 @@ touch -r /etc/mock/$os-$arch.cfg mock/$os-$arch-cockpit.cfg
 if /usr/bin/mock $mock_opts $mock_clean_opts --configdir=mock/ \
 	--resultdir mock -r $os-$arch-cockpit $srpm \
 	--define="extra_flags $EXTRA_FLAGS"; then
-    grep "^Wrote: .*\.$arch\.rpm$" mock/build.log | while read l; do
+    grep "^Wrote: .*\.\($arch\|noarch\)\.rpm$" mock/build.log | while read l; do
         p=$(basename "$l") # knocks off the "Wrote:" part as well...
         echo $p
         mv mock/$p .


### PR DESCRIPTION
This is causing the integration tests to fail on SELinux issues,
due to the cockpit-selinux-policy stuff now being noarch
