### PR TITLE
shell: matches text color to error input box

### DIFF
--- a/modules/shell/shell.html
+++ b/modules/shell/shell.html
@@ -1089,7 +1089,7 @@
                 <input type="checkbox" id="dashboard_setup_address_reuse_creds"/>
                 Login with my current credentials.
               </label>
-              <div id="dashboard_setup_address_error" colspan="2" style="color:red;visibility:hidden">Placeholder</div>
+              <div id="dashboard_setup_address_error" class="help-block" style="visibility:hidden">Placeholder</div>
               <ul class="list-group" id="dashboard_setup_address_discovered">
               </ul>
             </div>
@@ -1099,7 +1099,7 @@
               <p>Login to <span id="dashboard_setup_login_address"></span>.</p>
               <input type="text" class="form-control" id="dashboard_setup_login_user"/>
               <input type="password" class="form-control" id="dashboard_setup_login_password"/>
-              <div id="dashboard_setup_login_error" colspan="2" style="color:red;visibility:hidden">Placeholder</div>
+              <div id="dashboard_setup_login_error" class="help-block" style="visibility:hidden">Placeholder</div>
             </div>
 
             <div class="cockpit-setup-tab"


### PR DESCRIPTION
Adds help-block class to div to match patternfly's highlighted error box
color.

Fixes #992
