### PR TITLE
shell: changes hover-over of cells in tables

### DIFF
--- a/modules/shell/cockpit.css
+++ b/modules/shell/cockpit.css
@@ -549,7 +549,7 @@ a {
 }
 .table-hover > tbody > tr:hover > td,
 .table-hover > tbody > tr:hover > th {
-    background-color: #f5f9fc;
+    background-color: #d4edfa;
 }
 
 .container-col-name {


### PR DESCRIPTION
Changes hover-over of cells in tables to a more visible color that
matches the color of all our other cell hover-overs.

Fixes #995
