### PR TITLE
shell: removes errored input boxes on enter

### DIFF
--- a/modules/shell/cockpit-accounts.js
+++ b/modules/shell/cockpit-accounts.js
@@ -274,6 +274,7 @@ PageAccountsCreate.prototype = {
         $('#accounts-create-pw2').val("");
         $('#accounts-create-locked').prop('checked', false);
         $('#accounts-create-message-password-mismatch').css("visibility", "hidden");
+        $("#account-set-password-dialog .check-passwords").removeClass("has-error");
         this.update ();
     },
 
@@ -882,6 +883,7 @@ PageAccountSetPassword.prototype = {
         $('#account-set-password-pw1').val("");
         $('#account-set-password-pw2').val("");
         $('#account-set-password-message-password-mismatch').css("visibility", "hidden");
+        $("#account-set-password-dialog .check-passwords").removeClass("has-error");
         this.update ();
     },
 


### PR DESCRIPTION
Removes the has-error class on enter to hide any errors when first
entering the change password or create user dialogs.

Fixes #998
