### PR TITLE
Use "name" instead of "interface" in bonds.

### DIFF
--- a/modules/shell/cockpit-networking.js
+++ b/modules/shell/cockpit-networking.js
@@ -1915,7 +1915,7 @@ PageNetworkBondSettings.prototype = {
         var body =
             $('<table class="cockpit-form-table">').append(
                 $('<tr>').append(
-                    $('<td>').text(_("Interface")),
+                    $('<td>').text(_("Name")),
                     $('<td>').append(
                         $('<input class="form-control">').
                             val(settings.bond["interface-name"]).


### PR DESCRIPTION
Fixes issue #1001
