### PR TITLE
shell: fixes alignment of storage buttons

### DIFF
--- a/modules/shell/cockpit-storage.js
+++ b/modules/shell/cockpit-storage.js
@@ -957,9 +957,9 @@ PageStorageDetail.prototype = {
             if (name)
                 tr.append($('<td>', { 'style': 'text-align:left' }).html(name));
             if (button)
-                tr.append($('<td>', { 'style': 'text-align:right' }).append(button));
+                tr.append($('<td>', { 'style': 'float:right' }).append(button));
             tr.append(
-                $('<td>', { 'style': 'width:28px' }).append(
+                $('<td>', { 'style': 'float:right' }).append(
                     $('<div>', { 'id': 'entry-spinner-' +id,
                                  'class': 'waiting'
                                })));


### PR DESCRIPTION
Puts waiting spinner to the left of button to remove awkward spacing to
the right of the buttons which caused alignment to be ruined.

Fixes #1011
