### PR TITLE
shell: Graph user interface restructure

### DIFF
--- a/modules/shell/cockpit.css
+++ b/modules/shell/cockpit.css
@@ -354,6 +354,7 @@ a {
 }
 
 .server-graph:hover {
+    cursor: pointer;
     background-color: #d4edfa;
 }
 

--- a/modules/shell/shell.html
+++ b/modules/shell/shell.html
@@ -112,27 +112,19 @@
 
         <div id="server-graph-columns">
           <div id="server-graph-column-1">
-            <a onclick="cockpit_go_down('cpu_status');">
               <div style="color:black">CPU<span style="float:right" id="server_cpu_text"></span></div>
-              <div style="height:120px" id="server_cpu_graph" class="server-graph"></div>
-            </a>
+              <div style="height:120px" id="server_cpu_graph" class="server-graph" onclick="cockpit_go_down('cpu_status');"></div>
             <br/>
-            <a onclick="cockpit_go_down('memory_status')">
               <div style="color:black">Memory<span style="float:right" id="server_memory_text"></span></div>
-              <div style="height:120px" id="server_memory_graph" class="server-graph"></div>
-            </a>
+              <div style="height:120px" id="server_memory_graph" class="server-graph" onclick="cockpit_go_down('memory_status')"></div>
             <br/>
           </div>
           <div id="server-graph-column-2">
-            <a onclick="cockpit_go_down('disk_io_status')">
               <div style="color:black">Disk I/O<span style="float:right" id="server_disk_io_text"></span></div>
-              <div style="height:120px" id="server_disk_io_graph" class="server-graph"></div>
-            </a>
+              <div style="height:120px" id="server_disk_io_graph" class="server-graph" onclick="cockpit_go_down('disk_io_status')"></div>
             <br/>
-            <a onclick="cockpit_go_down('networking')">
               <div style="color:black">Network Traffic<span style="float:right" id="server_network_traffic_text"></span></div>
-              <div style="height:120px" id="server_network_traffic_graph" class="server-graph"></div>
-            </a>
+              <div style="height:120px" id="server_network_traffic_graph" class="server-graph" onclick="cockpit_go_down('networking')"></div>
             <br/>
           </div>
         </div>


### PR DESCRIPTION
Removes link tag around text, whitespace, and graph. Now graphs can
only be highlighted and clicked when hovered over. This also removes the
problem with text being underlined and clickable.

Fixes #1018
