### PR TITLE
shell: Make Password field get focus automatically

### DIFF
--- a/modules/shell/cockpit-accounts.js
+++ b/modules/shell/cockpit-accounts.js
@@ -926,11 +926,11 @@ PageAccountSetPassword.prototype = {
             else
                 hide_error();
         } else if (behavior == "input") {
-              if ($('#account-set-password-pw2').val() !== "" &&
-                  !$('#account-set-password-pw1').val().startsWith($('#account-set-password-pw2').val()))
-                  highlight_error();
-              else
-                  hide_error();
+            if ($('#account-set-password-pw2').val() !== "" &&
+                !$('#account-set-password-pw1').val().startsWith($('#account-set-password-pw2').val()))
+                highlight_error();
+            else
+                hide_error();
 
             this.error_timeout = setTimeout(check_password_match, 2000);
             this.setTimeout = null;
@@ -949,8 +949,8 @@ PageAccountSetPassword.prototype = {
                                                  });
         } else if (PageAccountSetPassword.user_name) {
             cockpit.spawn([ "passwd", "--stdin", PageAccountSetPassword.user_name ]).
-                write($('#account-set-password-pw1').val()).
-                fail(cockpit_show_unexpected_error);
+                          write($('#account-set-password-pw1').val()).
+                          fail(cockpit_show_unexpected_error);
         }
     }
 };


### PR DESCRIPTION
Keep the behavior of primary input field consistently and make it more user-friendly.
