### PR TITLE
test: Don't check for "js" in testsuite-prepare anymore.

### DIFF
--- a/test/testsuite-prepare
+++ b/test/testsuite-prepare
@@ -19,7 +19,6 @@ require_binary() {
   fi
 }
 require_binary parallel
-require_binary js
 require_binary trickle
 
 if ! silent $IP address show dev cockpit0; then


### PR DESCRIPTION
We don't need it.
