### PR TITLE
test: Make /usr/bin/parallel optional.

### DIFF
--- a/test/README
+++ b/test/README
@@ -6,7 +6,7 @@ files for them.
 To run the tests, you need to install the following packages on
 Fedora:
 
-  # yum install trickle nbd-server npm python-libguestfs parallel
+  # yum install trickle nbd-server npm python-libguestfs
   # npm install phantomjs
 
 You also need a base tarball for the distribution you want to test
@@ -54,7 +54,8 @@ You can set these environment variables to configure the test suite:
              default is the same directory that this README file is in.
 
   TEST_JOBS  How many tests to run in parallel.  The default is 1.
-             (This only affects check-verify.)
+             (This only affects check-verify and you need to install
+             GNU parallel.)
 
 ## Quick start
 

--- a/test/check-verify
+++ b/test/check-verify
@@ -18,7 +18,13 @@
 
 set -e
 
-parallel --gnu --progress -j ${TEST_JOBS:-1} <<EOF
+if which "parallel" >/dev/null 2>/dev/null; then
+  RUNNER="parallel --gnu --progress -j ${TEST_JOBS:-1}"
+else
+  RUNNER="sh -e"
+fi
+
+$RUNNER <<EOF
 ./check-dbus
 ./check-login
 ./check-dashboard TestDashboard.testBasic

--- a/test/testsuite-prepare
+++ b/test/testsuite-prepare
@@ -18,7 +18,6 @@ require_binary() {
     exit 1
   fi
 }
-require_binary parallel
 require_binary js
 require_binary trickle
 


### PR DESCRIPTION
RHEL 6 doesn't seem to have it, for example.
