### PR TITLE
shell: Hide the Format button for CD/DVD drive

### DIFF
--- a/modules/shell/cockpit-storage.js
+++ b/modules/shell/cockpit-storage.js
@@ -1046,7 +1046,8 @@ PageStorageDetail.prototype = {
             var is_lvol_pool          = (target.Type == "pool");
             var is_lvol_active        = (target._iface_name == "com.redhat.Cockpit.Storage.Block" ||
                                          target.Active);
-            var is_formattable        = (target._iface_name == "com.redhat.Cockpit.Storage.Block");
+            var is_formattable        = (target._iface_name == "com.redhat.Cockpit.Storage.Block" &&
+                                         !target.ReadOnly);
 
             var default_op = null;
             var action_spec = [ ];
@@ -1141,14 +1142,17 @@ PageStorageDetail.prototype = {
             if (block.IdUsage == 'crypto')
                 cleartext_device = find_cleartext_device(block);
 
+            btn = create_block_action_btn (block, !cleartext_device, !!part_desc);
+
             if (block.IdLabel.length > 0)
                 name = cockpit.esc(block.IdLabel);
+            else if (!btn)
+                name = null;
             else
                 name = "—";
             desc = block_get_desc(block, part_desc, cleartext_device);
 
-            id = append_entry (level, name, desc,
-                               create_block_action_btn (block, !cleartext_device, !!part_desc));
+            id = append_entry (level, name, desc, btn);
 
             mark_as_target('#entry-spinner-' + id, block.getObject().objectPath);
 
@@ -1419,6 +1423,11 @@ PageStorageDetail.prototype = {
             val += cockpit.esc(b.Device);
         }
         $("#disk_detail_device_file").html(val);
+
+        if (drive.Classification === "optical")
+            $('#drive_format').hide();
+        else
+            $('#drive_format').show();
     },
 
     _updateMDRaid: function() {

--- a/src/daemon/com.redhat.Cockpit.xml
+++ b/src/daemon/com.redhat.Cockpit.xml
@@ -462,6 +462,8 @@
 
     <property name="HintIgnore" type="b" access="read"/>
 
+    <property name="ReadOnly" type="b" access="read"/>
+
     <method name="Format">
       <arg name="type" direction="in" type="s"/>
       <arg name="erase" direction="in" type="s"/>

--- a/src/daemon/storageblock.c
+++ b/src/daemon/storageblock.c
@@ -183,6 +183,7 @@ storage_block_update (StorageBlock *block)
   cockpit_storage_block_set_id_uuid    (iface, udisks_block_get_id_uuid    (udisks_block));
 
   cockpit_storage_block_set_hint_ignore (iface, udisks_block_get_hint_ignore (udisks_block));
+  cockpit_storage_block_set_read_only  (iface, udisks_block_get_read_only  (udisks_block));
 
   if (udisks_partition == NULL)
     {


### PR DESCRIPTION
Hide the "Format" button both in Drive board and Content board and change "—" text to empty in the Content board if the device is a CD/DVD drive.

Fixes #919
