### PR TITLE
shell, NM model: Don't pass DNS search domains through ip_to_text.

### DIFF
--- a/modules/shell/cockpit-networking.js
+++ b/modules/shell/cockpit-networking.js
@@ -474,7 +474,7 @@ function NetworkManagerModel(address) {
                 method:       meth,
                 addresses:    get(first, "addresses", []).map(addr_from_nm),
                 dns:          get(first, "dns", []).map(ip_to_text),
-                dns_search:   get(first, "dns-search", []).map(ip_to_text)
+                dns_search:   get(first, "dns-search", [])
             };
         }
 


### PR DESCRIPTION
They are just strings.  This was a copy/paste error.
