### PR TITLE
shell: Avoid double border on #service page.

### DIFF
--- a/modules/shell/shell.html
+++ b/modules/shell/shell.html
@@ -536,7 +536,6 @@
         <br/>
         <div class="panel panel-default">
           <div class="panel-heading" id="service-name"></div>
-          <div id="service-unknown" translatable="yes">Unknown</div>
           <div id="service-known" class="list-group">
             <div class="list-group-item">
               <table style="width:100%">
@@ -595,6 +594,7 @@
               </table>
             </div>
           </div>
+          <div id="service-unknown" translatable="yes">Unknown</div>
         </div>
         <div class="panel panel-default">
           <div class="panel-heading" translatable="yes">Service Processes</div>


### PR DESCRIPTION
By making the list-group be the first sibling after the panel-heading
as expected by the CSS.

Fixes #700
