### PR TITLE
session: Clear environment when running cockpit-session setuid

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -171,7 +171,7 @@ enabled when trying to track down a problem. To turn it on add a file
 to your system like this:
 
     $ sudo mkdir -p /etc/systemd/system/cockpit.service.d
-    $ sudo printf "[Service]\nEnvironment=G_MESSAGES_DEBUG=cockpit-ws,cockpit-daemon,cockpit-agent\n" > /etc/systemd/system/cockpit.service.d/debug.conf
+    $ sudo printf "[Service]\nEnvironment=G_MESSAGES_DEBUG=cockpit-ws,cockpit-daemon,cockpit-agent\nUser=root\nGroup=\n" > /etc/systemd/system/cockpit.service.d/debug.conf
     $ sudo systemctl daemon-reload
     $ sudo systemctl restart cockpit
 

--- a/src/agent/session.c
+++ b/src/agent/session.c
@@ -497,6 +497,16 @@ main (int argc,
   /* When setuid root, make sure our group is also root */
   if (geteuid () == 0)
     {
+      /* Never trust the environment when running setuid() */
+      if (getuid() != 0)
+        {
+          if (clearenv () != 0)
+            err (1, "couldn't clear environment");
+
+          /* set a minimal environment */
+          setenv ("PATH", "/usr/sbin:/usr/bin:/sbin:/bin", 1);
+        }
+
       if (setgid (0) != 0 || setuid (0) != 0)
         err (1, "couldn't switch permissions correctly");
     }


### PR DESCRIPTION
Environment variables can affect all sorts of things like LD_PRELOAD,
PAM module behavior, and so on. When cockpit-session is running as
a setuid process, clear the environment completely.

This means that for debugging using G_DEBUG or G_MESSAGES_DEBUG
cockpit-ws must be running as root. Update HACKING.md to reflect this.
