### PR TITLE
test: Don't check journal after failure.

### DIFF
--- a/test/check-multi-machine
+++ b/test/check-multi-machine
@@ -68,8 +68,9 @@ class TestMultiMachine(MachineCase):
         self.machine3.wait_boot()
 
     def tearDown(self):
-        self.check_journal_messages(self.machine2)
-        self.check_journal_messages(self.machine3)
+        if self.runner and self.runner.wasSuccessful():
+            self.check_journal_messages(self.machine2)
+            self.check_journal_messages(self.machine3)
         MachineCase.tearDown(self)
 
     def testBasic(self):

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -322,7 +322,7 @@ class MachineCase(unittest.TestCase):
             if arg_sit_on_failure:
                 print >> sys.stderr, "ADDRESS: %s" % self.machine.address
                 sit()
-        if self.machine.address:
+        elif self.machine.address:
             self.check_journal_messages()
 
     def start_cockpit(self):


### PR DESCRIPTION
Not all 'allow_journal_messages' might have been seen and the check
might thus find false positives.  Also, throwing from tearDown in
check-multi-machine will cause the snapshotting to be skipped.
