### PR TITLE
shell: more descriptive first title

### DIFF
--- a/modules/shell/cockpit-dashboard.js
+++ b/modules/shell/cockpit-dashboard.js
@@ -30,7 +30,7 @@ PageDashboard.prototype = {
     },
 
     getTitle: function() {
-        return C_("page-title", "All");
+        return C_("page-title", "Hosts");
     },
 
     setup: function() {


### PR DESCRIPTION
Changes the opening page after logging in from "All "to "Hosts" in order
to add clarity.

Fixes #860
