### PR TITLE
shell: Use Browser 'localStorage' directly, and require it

### DIFF
--- a/modules/shell/cockpit-language.js
+++ b/modules/shell/cockpit-language.js
@@ -60,7 +60,7 @@ PageDisplayLanguageDialog.prototype = {
                     cockpit.language_po = data[code_to_select];
                     $('#display-language-dialog').modal('hide');
                     // Cool, that worked, update setting
-                    cockpit.settings_set("lang-code", code_to_select);
+                    localStorage.setItem("lang-code", code_to_select);
                     cockpit.localize_pages();
                 });
             } else {
@@ -68,7 +68,7 @@ PageDisplayLanguageDialog.prototype = {
                 cockpit.language_code = "";
                 cockpit.language_po = null;
                 // update setting
-                cockpit.settings_set("lang-code", null);
+                localStorage.removeItem("lang-code");
                 $('#display-language-dialog').modal('hide');
                 cockpit.localize_pages();
             }

--- a/modules/shell/cockpit-main.js
+++ b/modules/shell/cockpit-main.js
@@ -74,7 +74,7 @@ cockpit.init = function init() {
     var language, language_normalized, code, code_normalized;
 
     // First load translations, if any... first, check browser storage
-    lang_code = cockpit.settings_get("lang-code");
+    lang_code = localStorage.getItem("lang-code");
 
     // If that didn't work, try inferring from whatever language the
     // browser is using... this is a language code from RFC4646, see

--- a/modules/shell/cockpit-util.js
+++ b/modules/shell/cockpit-util.js
@@ -191,23 +191,6 @@ cockpit.format_delay = function format_delay(d) {
     return s;
 };
 
-cockpit.settings_get = function settings_get(key) {
-    var ret = null;
-    if (localStorage) {
-        ret = localStorage.getItem(key);
-    }
-    return ret;
-};
-
-cockpit.settings_set = function settings_set(key, value) {
-    if (localStorage) {
-        if (value)
-            localStorage.setItem(key, value);
-        else
-            localStorage.removeItem(key);
-    }
-};
-
 cockpit.find_in_array = function find_in_array(array, elt) {
     for (var i = 0; i < array.length; i++) {
         if (array[i] == elt)

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -57,7 +57,7 @@
 
             function requisites() {
                 return ("WebSocket" in window || "MozWebSocket" in window) &&
-                       ("XMLHttpRequest" in window);
+                       ("XMLHttpRequest" in window) && ("localStorage" in window);
             }
 
             function trim(s) {


### PR DESCRIPTION
Every browser that has WebSocket support has localStorage support.
In addition the API is quite sane, so we don't need to wrap this in
our own abstraction.
