### PR TITLE
include dirent.h to solve implicit declaration errors

### DIFF
--- a/src/common/cockpitunixfd.c
+++ b/src/common/cockpitunixfd.c
@@ -25,6 +25,8 @@
 
 #include <sys/resource.h>
 
+#include <dirent.h>
+
 typedef struct {
     GSource source;
     GPollFD pollfd;


### PR DESCRIPTION
```
modified:   src/common/cockpitunixfd.c
```

FWIW, this issue was seen on CentOS7, but not on fedora rawhide.
