### PR TITLE
selinux: session PAM stack wants to communicate with systemd via socket

### DIFF
--- a/src/selinux/cockpit.te
+++ b/src/selinux/cockpit.te
@@ -83,6 +83,9 @@ allow cockpit_session_t self:process { setexec setsched signal_perms };
 auth_login_pgm_domain(cockpit_session_t)
 auth_write_login_records(cockpit_session_t);
 
+# cockpit-session PAM stack wants to talk to systemd via a socket
+allow cockpit_session_t init_t:unix_stream_socket sendto;
+
 # cockpit-session can execute cockpit-agent as the user
 userdom_spec_domtrans_all_users(cockpit_session_t)
 


### PR DESCRIPTION
Symptom:

audit: type=1400 audit(1411115120.035:21): avc:  denied  { sendto } for  pid=1176
    comm="cockpit-session" path="socket:[18680]" dev="sockfs" ino=18680
    scontext=system_u:system_r:cockpit_session_t:s0
    tcontext=system_u:system_r:init_t:s0 tclass=unix_stream_socket
    permissive=0
