### PR TITLE
test: Allow phantomjs to be in $PATH

### DIFF
--- a/test/phantom-driver
+++ b/test/phantom-driver
@@ -1,4 +1,4 @@
-#! /usr/bin/phantomjs
+#!/usr/bin/env phantomjs
 
 /*
  * This file is part of Cockpit.


### PR DESCRIPTION
For example phantomjs may be installed in your homedir. It should
still be in the path, but not necessarily in /usr/bin
