### PR TITLE
ws: Refactor cockpit_auth_login_finish() to add flags argument

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -652,7 +652,7 @@ on_web_service_destroy (CockpitWebService *service,
 CockpitWebService *
 cockpit_auth_login_finish (CockpitAuth *self,
                            GAsyncResult *result,
-                           gboolean force_secure,
+                           CockpitAuthFlags flags,
                            GHashTable *out_headers,
                            GError **error)
 {
@@ -705,6 +705,7 @@ cockpit_auth_login_finish (CockpitAuth *self,
 
   if (out_headers)
     {
+      gboolean force_secure = !(flags & COCKPIT_AUTH_COOKIE_INSECURE);
       cookie_b64 = g_base64_encode ((guint8 *)authenticated->cookie, strlen (authenticated->cookie));
       header = g_strdup_printf ("CockpitAuth=%s; Path=/; Expires=Wed, 13-Jan-2021 22:23:01 GMT;%s HttpOnly",
                                 cookie_b64, force_secure ? " Secure;" : "");

--- a/src/ws/cockpitauth.h
+++ b/src/ws/cockpitauth.h
@@ -35,6 +35,10 @@ G_BEGIN_DECLS
 #define COCKPIT_AUTH_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), COCKPIT_TYPE_AUTH, CockpitAuthClass))
 #define COCKPIT_IS_AUTH_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), COCKPIT_TYPE_AUTH))
 
+typedef enum {
+    COCKPIT_AUTH_COOKIE_INSECURE = 1 << 1
+} CockpitAuthFlags;
+
 typedef struct _CockpitAuth        CockpitAuth;
 typedef struct _CockpitAuthClass   CockpitAuthClass;
 
@@ -77,7 +81,7 @@ void            cockpit_auth_login_async     (CockpitAuth *self,
 
 CockpitWebService *  cockpit_auth_login_finish    (CockpitAuth *self,
                                                    GAsyncResult *result,
-                                                   gboolean secure_req,
+                                                   CockpitAuthFlags flags,
                                                    GHashTable *out_headers,
                                                    GError **error);
 

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -247,12 +247,14 @@ on_login_complete (GObject *object,
   LoginResponse *lr = user_data;
   GError *error = NULL;
   CockpitWebService *service;
+  CockpitAuthFlags flags = 0;
   GIOStream *io_stream;
 
   io_stream = cockpit_web_response_get_stream (lr->response);
-  service = cockpit_auth_login_finish (COCKPIT_AUTH (object), result,
-                                       !G_IS_SOCKET_CONNECTION (io_stream),
-                                       lr->headers, &error);
+  if (G_IS_SOCKET_CONNECTION (io_stream))
+    flags |= COCKPIT_AUTH_COOKIE_INSECURE;
+
+  service = cockpit_auth_login_finish (COCKPIT_AUTH (object), result, flags, lr->headers, &error);
 
   if (error)
     {

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -96,7 +96,7 @@ test_userpass_cookie_check (Test *test,
     g_main_context_iteration (NULL, TRUE);
 
   headers = web_socket_util_new_headers ();
-  service = cockpit_auth_login_finish (test->auth, result, TRUE, headers, &error);
+  service = cockpit_auth_login_finish (test->auth, result, 0, headers, &error);
   g_object_unref (result);
   g_assert_no_error (error);
   g_assert (service != NULL);
@@ -144,7 +144,7 @@ test_userpass_bad (Test *test,
     g_main_context_iteration (NULL, TRUE);
 
   headers = web_socket_util_new_headers ();
-  service = cockpit_auth_login_finish (test->auth, result, TRUE, headers, &error);
+  service = cockpit_auth_login_finish (test->auth, result, 0, headers, &error);
   g_object_unref (result);
 
   g_assert (service == NULL);
@@ -171,7 +171,7 @@ test_userpass_emptypass (Test *test,
     g_main_context_iteration (NULL, TRUE);
 
   headers = web_socket_util_new_headers ();
-  service = cockpit_auth_login_finish (test->auth, result, TRUE, headers, &error);
+  service = cockpit_auth_login_finish (test->auth, result, 0, headers, &error);
   g_object_unref (result);
 
   g_assert (service == NULL);
@@ -233,7 +233,7 @@ test_idle_timeout (Test *test,
     g_main_context_iteration (NULL, TRUE);
 
   headers = web_socket_util_new_headers ();
-  service = cockpit_auth_login_finish (test->auth, result, TRUE, headers, &error);
+  service = cockpit_auth_login_finish (test->auth, result, 0, headers, &error);
   g_object_unref (result);
   g_assert_no_error (error);
 

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -189,7 +189,7 @@ test_login_with_cookie (Test *test,
   g_hash_table_unref (headers);
   while (result == NULL)
     g_main_context_iteration (NULL, TRUE);
-  service = cockpit_auth_login_finish (test->auth, result, TRUE, test->headers, &error);
+  service = cockpit_auth_login_finish (test->auth, result, 0, test->headers, &error);
   g_object_unref (result);
 
   g_assert_no_error (error);


### PR DESCRIPTION
We want to pass more than one flag here in the future. Plus this
enhances code readability.
