### PR TITLE
tools: Use $PATH to determine location for phantomjs

### DIFF
--- a/tools/tap-phantom
+++ b/tools/tap-phantom
@@ -1,4 +1,4 @@
-#!/usr/bin/phantomjs
+#!/usr/bin/env phantomjs
 
 /*
  * Copyright (C) 2013 Red Hat, Inc.


### PR DESCRIPTION
Another place we want to use $PATH to determine the location of
phantomjs, in case it's installed to a home directory.
