### PR TITLE
shell: Fix invalid HTML end tags

### DIFF
--- a/modules/shell/shell.html
+++ b/modules/shell/shell.html
@@ -1239,7 +1239,7 @@
                   <td style="width:0px">
                     <div id="realms-op-address-spinner"
                          class="waiting"
-                         style="margin-left:-40px;margin-top:4px"/>
+                         style="margin-left:-40px;margin-top:4px"></div>
                     <img id="realms-op-address-error"
                          src="@@module@@/images/dialog-error.png"
                          style="margin-left:-40px;margin-top:4px"/>
@@ -1317,7 +1317,7 @@
             </div>
           </div>
           <div class="modal-footer">
-            <div id="realms-op-spinner" class="waiting" style="float: left"/>
+            <div id="realms-op-spinner" class="waiting" style="float: left"></div>
             <span id="realms-op-wait-message">This may take a while</span>
             <button class="btn btn-default" id="realms-op-cancel">
               Cancel
@@ -2311,7 +2311,7 @@
             <div id="containers-search-image-waiting"></div>
             <div id="containers-search-image-results">
               <table class="table table-hover">
-                <tbody/>
+                <tbody></tbody>
               </table>
             </div>
             <div id="containers-search-image-no-results">
@@ -2343,7 +2343,7 @@
               <tr>
                 <td translatable="yes">Container Name</td>
                 <td colspan="3">
-                  <span class="container-name"/>
+                  <span class="container-name"></span>
                 </td>
               </tr>
               <tr class="memory-slider">


### PR DESCRIPTION
This isn't XML and tags must either have a full end tag or no end
tag to be valid. Fixed some missing HTML end tags.
