### PR TITLE
shell: makes delete buttons consistent

### DIFF
--- a/modules/shell/shell.html
+++ b/modules/shell/shell.html
@@ -832,7 +832,7 @@
                 <button class="btn btn-default" id="container-details-start">Start</button>
                 <button class="btn btn-default" id="container-details-stop">Stop</button>
                 <button class="btn btn-default" id="container-details-restart">Restart</button>
-                <button class="btn btn-default" id="container-details-delete">Delete</button>
+                <button class="btn btn-danger" id="container-details-delete">Delete</button>
                 <button class="btn btn-default" id="container-details-commit"
                     data-toggle="modal" data-target="#container-commit-dialog">
                     Commit
@@ -912,7 +912,7 @@
                Image: <span id="image-details-tags"></span>
               <div class="pull-right" style="height:25px" id="image-details-buttons">
                 <button class="btn btn-default" id="image-details-run">Run</button>
-                <button class="btn btn-default" id="image-details-delete">Delete</button>
+                <button class="btn btn-danger" id="image-details-delete">Delete</button>
                 <div class="waiting" style="display: none;"></div>
               </div>
             </div>


### PR DESCRIPTION
Changes delete buttons in the container page to use the same btn-danger
class as the ones used in the networking page.

Fixes #1261
