### PR TITLE
shell: Hide "Drop extra privileges" menu item for root.

### DIFF
--- a/modules/shell/cockpit-main.js
+++ b/modules/shell/cockpit-main.js
@@ -584,6 +584,7 @@ $(function() {
     var is_root = cockpit.connection_config.user == "root";
     $('#cockpit-go-account').toggle(!is_root);
     $('#cockpit-change-passwd').toggle(is_root);
+    $('.cockpit-deauthorize-item').toggle(!is_root);
 });
 
 cockpit.logout = function logout(reason) {


### PR DESCRIPTION
Because it has no effect.

Fixes #1219
