### PR TITLE
ws: Use private kerberos ccaches

### DIFF
--- a/src/ws/cockpitcreds.h
+++ b/src/ws/cockpitcreds.h
@@ -52,12 +52,15 @@ const gchar *   cockpit_creds_get_password   (CockpitCreds *creds);
 
 const gchar *   cockpit_creds_get_rhost      (CockpitCreds *creds);
 
-gss_cred_id_t   cockpit_creds_dup_gssapi     (CockpitCreds *creds);
-
 gboolean        cockpit_creds_equal          (gconstpointer v1,
                                               gconstpointer v2);
 
 guint           cockpit_creds_hash           (gconstpointer v);
+
+gss_cred_id_t   cockpit_creds_push_thread_default_gssapi (CockpitCreds *creds);
+
+gboolean        cockpit_creds_pop_thread_default_gssapi  (CockpitCreds *creds,
+                                                          gss_cred_id_t gss_cred);
 
 G_END_DECLS
 

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -74,6 +74,9 @@ main (int argc,
   g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
   g_setenv ("GIO_USE_VFS", "local", TRUE);
 
+  /* Any interaction with a krb5 ccache should be explicit */
+  g_setenv ("KRB5CCNAME", "FILE:/dev/null", TRUE);
+
   g_type_init ();
   ssh_init ();
 

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -491,6 +491,9 @@ perform_gssapi (void)
   server = GSS_C_NO_CREDENTIAL;
   res = PAM_AUTH_ERR;
 
+  /* We shouldn't be writing to kerberos caches here */
+  setenv ("KRB5CCNAME", "FILE:/dev/null", 1);
+
   debug ("reading kerberos auth from cockpit-ws");
   input.value = read_auth_until_eof (&input.length);
 
@@ -614,6 +617,8 @@ out:
      gss_delete_sec_context (&minor, &context, GSS_C_NO_BUFFER);
   free (input.value);
   free (str);
+
+  unsetenv ("KRB5CCNAME");
 
   if (res != PAM_SUCCESS)
     exit (5);


### PR DESCRIPTION
We never want to share kerberos ticket caches with either the root
user (via the kernel keyring or default ccache) or between users
who are both authenticating via cockpit-ws.
- Prevent use of a default ccache in cockpit-ws
- Explicitly allocate memory ccache's in cockpit-ws for the
  threads that are authenticating users via libssh
- Prevent use of a default ccache in cockpit-session

Fixes #1311
