### PR TITLE
shell: Hide filesystem options when creating a extended partition.

### DIFF
--- a/modules/shell/cockpit-storage.js
+++ b/modules/shell/cockpit-storage.js
@@ -2959,14 +2959,14 @@ PageFormat.prototype = {
 
     update: function() {
         var type = $("#format-type").val();
-        var isEmpty = (type == "empty");
+        var isFS = (type != "empty" && type != "dos-extended");
         var isLuks = (type == "luks+xfs" || type == "luks+ext4");
-        var isDefaultMount = isEmpty || $("#format-mounting").val() == "default";
+        var isDefaultMount = !isFS || $("#format-mounting").val() == "default";
 
         $("#format-custom-row").toggle(type == "custom");
-        $("#format-name-row").toggle(!isEmpty);
+        $("#format-name-row").toggle(isFS);
         $("#format-passphrase-row, #format-passphrase-row-2, #format-store-passphrase-row, #format-crypto-options-row").toggle(isLuks);
-        $("#format-mounting-row").toggle(!isEmpty);
+        $("#format-mounting-row").toggle(isFS);
         $("#format-mount-point-row, #format-mount-options-row").toggle(!isDefaultMount);
         if ((type == "custom" && !$("#format-custom").val()) ||
             (isLuks &&
@@ -2992,8 +2992,8 @@ PageFormat.prototype = {
             type = $("#format-custom").val();
         var erase = $("#format-erase").val();
         var label = $("#format-name").val();
-        var isEmpty = (type == "empty");
-        var isDefaultMount = isEmpty || $("#format-mounting").val() == "default";
+        var isFS = (type != "empty" && type != "dos-extended");
+        var isDefaultMount = !isFS || $("#format-mounting").val() == "default";
         var passphrase = "";
         var stored_passphrase = "";
         if (isLuks) {

--- a/test/check-storage
+++ b/test/check-storage
@@ -233,7 +233,10 @@ class TestStorage(MachineCase):
         b.wait_popup("storage_format_dialog")
         b.set_val("#format-size", "");
         b.set_val("#format-type", "dos-extended")
-        b.set_val("#format-name", "")
+        b.wait_not_visible("#format-name")
+        b.wait_not_visible("#format-mounting")
+        b.wait_not_visible("#format-mount-point")
+        b.wait_not_visible("#format-mount-options")
         b.click("#format-format")
         b.wait_popdown("storage_format_dialog")
         b.wait_in_text("#storage_detail_partition_list", "Extended Partition")


### PR DESCRIPTION
Since it is not a filesystem.

Fixes #1306
