### PR TITLE
test: Fix system info test.

### DIFF
--- a/pkg/shell/cockpit-system-information.js
+++ b/pkg/shell/cockpit-system-information.js
@@ -248,8 +248,8 @@ PageSystemInformationChangeHostname.prototype = {
     },
 
     setup: function() {
-        $("#sich-pretty-hostname").on("input", $.proxy(this._on_full_name_changed, this));
-        $("#sich-hostname").on("input", $.proxy(this._on_name_changed, this));
+        $("#sich-pretty-hostname").on("input change", $.proxy(this._on_full_name_changed, this));
+        $("#sich-hostname").on("input change", $.proxy(this._on_name_changed, this));
         $("#sich-apply-button").on("click", $.proxy(this._on_apply_button, this));
     },
 

--- a/test/check-system-info
+++ b/test/check-system-info
@@ -28,7 +28,7 @@ VERSION_ID="2.0"
 PRETTY_NAME="Foobar Adventure Linux Server 2.0 (Day of Doom)"
 """
 
-class TestRealms(MachineCase):
+class TestSystemInfo(MachineCase):
 
     def testBasic(self):
         m = self.machine


### PR DESCRIPTION
By making sure that the "Change" button gets enabled also when
changing the text fields from a program.  Clicking on disabled buttons
doesn't work anymore since 763b6bd.
