### PR TITLE
doc: Upload latest guide to a separate directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -133,6 +133,8 @@ clean-local:
 uninstall-local:: uninstall-doc-local
 	@true
 
+LATEST = latest/
+
 if ENABLE_DOC
 
 include doc/Makefile-doc.am
@@ -156,7 +158,7 @@ distcheck-hook:
 	@true
 
 upload-doc: guide/index.html
-	rsync -Hvax guide/./ files.cockpit-project.org:/srv/guide/./
+	rsync -Hvax guide/./ files.cockpit-project.org:/srv/guide/$(LATEST)./
 
 else
 

--- a/doc/guide/cockpit-guide.xml
+++ b/doc/guide/cockpit-guide.xml
@@ -8,7 +8,9 @@
 <book id="index">
   <bookinfo>
     <title>Cockpit Guide</title>
-    <releaseinfo>for &version;</releaseinfo>
+    <releaseinfo>Documentation for Cockpit &version; --
+    latest version available at:
+      <ulink url="http://files.cockpit-project.org/guide/latest">http://files.cockpit-project.org/guide/latest/</ulink></releaseinfo>
   </bookinfo>
 
   <part id="guide">


### PR DESCRIPTION
Keep the stable guide at:

http://files.cockpit-project.org/guide/

And upload the latest guide to:

http://files.cockpit-project.org/guide/latest
