### PR TITLE
shell: Network Manager transfers Addresses in network byte order

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -327,7 +327,7 @@ and issues with these encodings and there is ongoing work to streamline.
 
         {
             "command": "seed",
-            "options": { "byteorder", "be" },
+            "options": { },
             "data": {
                 "/object/path": {
                     "objpath": "/object/path",

--- a/pkg/shell/cockpit-networking.js
+++ b/pkg/shell/cockpit-networking.js
@@ -364,44 +364,30 @@ function NetworkManagerModel(address) {
         return n.toString(10);
     }
 
-    function bytes_from_nm32(num) {
+    function bytes_from_network_long(num) {
         var bytes = [], i;
-        if (client.byteorder == "be") {
-            for (i = 3; i >= 0; i--) {
-                bytes[i] = num & 0xFF;
-                num = num >>> 8;
-            }
-        } else {
-            for (i = 0; i < 4; i++) {
-                bytes[i] = num & 0xFF;
-                num = num >>> 8;
-            }
+        for (i = 0; i < 4; i++) {
+            bytes[i] = num & 0xFF;
+            num = num >>> 8;
         }
         return bytes;
     }
 
-    function bytes_to_nm32(bytes) {
+    function bytes_to_network_long(bytes) {
         var num = 0, i;
-        if (client.byteorder == "be") {
-            for (i = 0; i < 4; i++) {
-                num = 256*num + bytes[i];
-            }
-        } else {
-            for (i = 3; i >= 0; i--) {
-                num = 256*num + bytes[i];
-            }
-        }
+        for (i = 3; i >= 0; i--)
+            num = 256 * num + bytes[i];
         return num;
     }
 
     function ip4_to_text(num) {
-        return bytes_from_nm32(num).map(toDec).join('.');
+        return bytes_from_network_long(num).map(toDec).join('.');
     }
 
     function ip4_from_text(text) {
         var parts = text.split('.');
         if (parts.length == 4)
-            return bytes_to_nm32(parts.map(function(s) { return parseInt(s, 10); }));
+            return bytes_to_network_long(parts.map(function(s) { return parseInt(s, 10); }));
         else // XXX - error
             return 0;
     }

--- a/pkg/shell/dbus.js
+++ b/pkg/shell/dbus.js
@@ -109,12 +109,6 @@
    only need to use this function for interfaces that don't support
    that signal.
 
-   - client.byteorder
-
-   Indicates the byte order of the machine that the service runs on.
-   The value is one of the strings "le" (for little endian) or "be"
-   (for big endian).
-
  */
 
 var phantom_checkpoint = phantom_checkpoint || function () { };
@@ -305,7 +299,6 @@ DBusClient.prototype = {
         this._last_error = null;
         this._proxies = !options || options.proxies || options.proxies === undefined;
         this.error_details = {};
-        this.byteorder = null;
         this.connect();
     },
 
@@ -393,9 +386,6 @@ DBusClient.prototype = {
     },
 
     _handle_seed : function(data, options) {
-        if (options && options.byteorder)
-            this.byteorder = options.byteorder;
-
         $(this).trigger("seed", data);
 
         if (!this._proxies)

--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -768,13 +768,6 @@ send_seed (CockpitDBusJson *self)
 
   json_builder_set_member_name (builder, "options");
   json_builder_begin_object (builder);
-  json_builder_set_member_name (builder, "byteorder");
-  if (G_BYTE_ORDER == G_LITTLE_ENDIAN)
-    json_builder_add_string_value (builder, "le");
-  else if (G_BYTE_ORDER == G_BIG_ENDIAN)
-    json_builder_add_string_value (builder, "be");
-  else
-    json_builder_add_string_value (builder, "");
   json_builder_end_object (builder);
 
   json_builder_set_member_name (builder, "data");

--- a/src/bridge/cockpitdbusjson1.c
+++ b/src/bridge/cockpitdbusjson1.c
@@ -434,13 +434,6 @@ send_seed (CockpitDBusJson1 *self)
 
   json_builder_set_member_name (builder, "options");
   json_builder_begin_object (builder);
-  json_builder_set_member_name (builder, "byteorder");
-  if (G_BYTE_ORDER == G_LITTLE_ENDIAN)
-    json_builder_add_string_value (builder, "le");
-  else if (G_BYTE_ORDER == G_BIG_ENDIAN)
-    json_builder_add_string_value (builder, "be");
-  else
-    json_builder_add_string_value (builder, "");
   json_builder_end_object (builder);
 
   json_builder_set_member_name (builder, "data");


### PR DESCRIPTION
See the documentation here:

https://developer.gnome.org/NetworkManager/unstable/spec.html

This is pretty standard way to represent addresses as evidenced
by the htonl() and ntohl() libc functions. Network byte order
is MSB.

We don't need to track the host's byte order. Any DBus interface
that makes us do this is broken, and needs some sorta work around,
perhaps a flag in the dbus interface, or in com.redhat.Cockpit.Manager.
But that's not the case here.
