### PR TITLE
test: Add extra restart allowed journal message

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -388,7 +388,8 @@ class MachineCase(unittest.TestCase):
                                     "g_dbus_connection_real_closed: Remote peer vanished with error: Underlying GIOStream returned 0 bytes on an async read \\(g-io-error-quark, 0\\). Exiting.",
                                     "g_dbus_connection_real_closed: Remote peer vanished with error: Error sending message: Broken pipe \\(g-io-error-quark, 44\\). Exiting.",
                                     # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1141137
-                                    "localhost: bridge program failed: Child process killed by signal 9")
+                                    "localhost: bridge program failed: Child process killed by signal 9",
+                                    "request timed out, closing")
 
     def check_journal_messages(self, machine=None):
         """Check for unexpected journal entries."""


### PR DESCRIPTION
The "request timed out, closing" happens intermittently during tests.
