### PR TITLE
shell: Use correct address for Docker terminals.

### DIFF
--- a/pkg/shell/cockpit-docker.js
+++ b/pkg/shell/cockpit-docker.js
@@ -1103,7 +1103,7 @@ PageContainerDetails.prototype = {
 
         if (!this.terminal) {
             this.terminal = new DockerTerminal($("#container-terminal")[0],
-                                               this.client.machine,
+                                               this.address,
                                                this.container_id);
         }
 


### PR DESCRIPTION
Previously, this would use 'undefined' which means localhost and thus
mostly worked, by accident.
