### PR TITLE
tools: Make jslint print problems to stderr correctly

### DIFF
--- a/tools/rcompile
+++ b/tools/rcompile
@@ -140,7 +140,7 @@ jslint()
 {
     failed=no
     for f in "$@"; do
-        jsl -conf $base/jsl.conf -nologo -nofilelisting -nosummary -process "$f" || failed=yes
+        jsl -conf $base/jsl.conf -nologo -nofilelisting -nosummary -process "$f" >&2 || failed=yes
     done
     if is_yes $failed; then
         exit 1


### PR DESCRIPTION
Since stdout is being used for the output file, print problems
to stderr.
