### PR TITLE
tools: Fix rcompile to work under other LANG settings

### DIFF
--- a/tools/rcompile
+++ b/tools/rcompile
@@ -34,7 +34,7 @@ warning()
 
 is_function()
 {
-    case $(type $1 2> /dev/null) in
+    case $(LANG=C type $1 2> /dev/null) in
     *function*)
         return 0;
         ;;


### PR DESCRIPTION
This is because the only portable way to detect whether something
is a function is to use the output of 'type'. That output is
translated (the -t option is not portable).

Fixes #1380
