### PR TITLE
test: Fixes to make tests set LANG=C before running

### DIFF
--- a/test/check-verify
+++ b/test/check-verify
@@ -18,6 +18,9 @@
 
 set -e
 
+LANG=C
+export LANG
+
 if which "parallel" >/dev/null 2>/dev/null; then
   RUNNER="parallel --gnu --progress -j ${TEST_JOBS:-1}"
 else

--- a/test/make-rpms
+++ b/test/make-rpms
@@ -91,7 +91,7 @@ EOF
 sed -i -e 's/gpgcheck=1/gpgcheck=0/' mock/$os-$arch-cockpit.cfg
 touch -r /etc/mock/$os-$arch.cfg mock/$os-$arch-cockpit.cfg
 
-if /usr/bin/mock $mock_opts $mock_clean_opts --configdir=mock/ \
+if LANG=C /usr/bin/mock $mock_opts $mock_clean_opts --configdir=mock/ \
 	--resultdir mock -r $os-$arch-cockpit $srpm \
 	--define="extra_flags $EXTRA_FLAGS"; then
     grep "^Wrote: .*\.\($arch\|noarch\)\.rpm$" mock/build.log | while read l; do


### PR DESCRIPTION
Lots of stuff requires parsing output from the host, including
log lines, and diagnostic messages from rpmbuild
