### PR TITLE
ws: Remove the cockpit-ws --uninstalled option

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -222,22 +222,25 @@ You can run these processes as your own user, although you won't be able
 to debug all the authentication logic in those cases.
 
 First of all make sure Cockpit is installed correctly. Even though we
-will be running cockpit-ws and cockpit-bridge from the built sources
-this still relies on some of the right bits being installed in order
-for Cockpit to work (ie: PAM stack, UI files, etc.)
+will be running cockpit-ws from the built sources this still relies on
+some of the right bits being installed in order for Cockpit to work
+(ie: PAM stack, UI files, cockpit-bridge, etc.)
 
 This is how you would run cockpit-ws under gdb:
 
     $ export G_DEBUG=fatal-criticals
     $ export G_MESSAGES_DEBUG=cockpit-ws,cockpit-daemon,cockpit-bridge
-    $ gdb --args ./cockpit-ws --port 10000 --no-tls --uninstalled
+    $ gdb --args ./cockpit-ws --port 10000 --no-tls
 
 And you can run cockpit-ws and cockpit-bridge under valgrind like this:
 
     $ export G_DEBUG=fatal-criticals
     $ export G_MESSAGES_DEBUG=cockpit-ws,cockpit-daemon,cockpit-bridge
     $ valgrind --trace-children=yes --trace-children-skip='*unix_chkpwd*' \
-          ./cockpit-ws --port 10000 --no-tls --uninstalled
+          ./cockpit-ws --port 10000 --no-tls
+
+Note that cockpit-session and cockpit-bridge will run from the installed
+prefix, rather than your build tree.
 
 ## Setting up a domain server
 

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -41,14 +41,10 @@
 
 static gint      opt_port         = 9090;
 static gboolean  opt_no_tls       = FALSE;
-static gboolean  opt_uninstalled = FALSE;
 
 static GOptionEntry cmd_entries[] = {
   {"port", 'p', 0, G_OPTION_ARG_INT, &opt_port, "Local port to bind to (9090 if unset)", NULL},
   {"no-tls", 0, 0, G_OPTION_ARG_NONE, &opt_no_tls, "Don't use TLS", NULL},
-#ifdef WITH_DEBUG
-  {"uninstalled", 0, 0, G_OPTION_ARG_NONE, &opt_uninstalled, "Run from cockpit-ws from build directory", NULL},
-#endif
   {NULL}
 };
 
@@ -106,16 +102,7 @@ main (int argc,
       g_info ("Using certificate: %s", cert_path);
     }
 
-  if (opt_uninstalled)
-    {
-      roots = cockpit_web_server_resolve_roots (SRCDIR "/src/static", SRCDIR "/lib", NULL);
-      cockpit_ws_bridge_program = BUILDDIR "/cockpit-bridge";
-      cockpit_ws_session_program = BUILDDIR "/cockpit-session";
-    }
-  else
-    {
-      roots = cockpit_web_server_resolve_roots (DATADIR "/cockpit/static", NULL);
-    }
+  roots = cockpit_web_server_resolve_roots (DATADIR "/cockpit/static", NULL);
 
   data.auth = cockpit_auth_new ();
   data.static_roots = (const gchar **)roots;


### PR DESCRIPTION
While you can still run cockpit-ws from the build tree it will
spawn cockpit-session and cockpit-bridge from the $prefix.

This was already broken ... this commit just makes it official.
It was broken for two reasons:
- cockpit-session usually runs as privileged, and cockpit-ws does
  not. It is a security hole to have cockpit-ws tell cockpit-session
  which cockpit-bridge to launch.
- cockpit-bridge loads packages from directories based on the prefix
  and/or $XDG_DATA_DIRS, so --uninstalled didn't work here.

If someone wants to invest time in making Cockpit runnable from the
build tree, and can do so in a secure and clean way, then I wouldn't
be against it.
