### PR TITLE
ws: Don't complain if resource web response is already closed

### DIFF
--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -1575,7 +1575,6 @@ resource_response_done (ResourceResponse *rr,
 
   /* The web response should not yet be complete */
   state = cockpit_web_response_get_state (rr->response);
-  g_return_if_fail (state < COCKPIT_WEB_RESPONSE_COMPLETE);
 
   if (problem == NULL)
     {


### PR DESCRIPTION
Sometimes a web response closes for a failure such as a send.
