### PR TITLE
base: Work around unreadable monospace fonts in PatternFly

### DIFF
--- a/pkg/base/cockpit.css
+++ b/pkg/base/cockpit.css
@@ -25,6 +25,11 @@ a {
     cursor: pointer;
 }
 
+/* HACK: https://github.com/patternfly/patternfly/issues/39 */
+code, kbd, pre, samp {
+  font-family: monospace, Menlo, Monaco, Consolas, "Courier New";
+}
+
 .dropdown-menu > .disabled > a:hover {
     cursor: default;
 }


### PR DESCRIPTION
https://github.com/patternfly/patternfly/issues/39
