### PR TITLE
Add meta charset UTF-8 tags to all HTML files

### DIFF
--- a/examples/integrate-terminal/integrate-terminal.html
+++ b/examples/integrate-terminal/integrate-terminal.html
@@ -1,6 +1,7 @@
 <html>
 <head>
     <title>Example: Integrating Cockpit Terminal into a Web Application</title>
+    <meta charset="utf-8">
 </head>
 <body>
     <h2>Example: Integrating Cockpit Terminal into a Web Application</h2>

--- a/examples/ping-server/ping-server.html
+++ b/examples/ping-server/ping-server.html
@@ -1,6 +1,7 @@
 <html>
 <head>
     <title>Example: Ping Cockpit</title>
+    <meta charset="utf-8">
 </head>
 <body>
     <h2>Example: Ping Cockpit</h2>

--- a/pkg/base/test-chan.html
+++ b/pkg/base/test-chan.html
@@ -20,6 +20,7 @@
 <html>
   <head>
     <title>Channel Tests</title>
+    <meta charset="utf-8">
     <link rel="stylesheet" href="../../lib/qunit-1.14.0.css" type="text/css" media="screen" />
     <script type="text/javascript" src="../../lib/jquery.v2.1.0.js"></script>
     <script type="text/javascript" src="../../lib/qunit-1.14.0.js"></script>

--- a/pkg/base/test-spawn.html
+++ b/pkg/base/test-spawn.html
@@ -20,6 +20,7 @@
 <html>
   <head>
     <title>Spawn Tests</title>
+    <meta charset="utf-8">
     <link rel="stylesheet" href="../../lib/qunit-1.14.0.css" type="text/css" media="screen" />
     <script type="text/javascript" src="../../lib/jquery.v2.1.0.js"></script>
     <script type="text/javascript" src="../../lib/qunit-1.14.0.js"></script>

--- a/pkg/server/terminal.html
+++ b/pkg/server/terminal.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>Cockpit terminal</title>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="../@@latest@@/cockpit.css" type="text/css" rel="stylesheet">
     <script src="../@@latest@@/jquery.js"></script>

--- a/pkg/shell/STYLE.html
+++ b/pkg/shell/STYLE.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf8" />
   <head>
     <title>Cockpit Elements of Style</title>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <!-- Out of project dependencies -->

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>Cockpit</title>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <base href="/cockpit/@@shell@@/shell.html">
     <link href="shell.css" rel="stylesheet">

--- a/pkg/shell/test-dbus.html
+++ b/pkg/shell/test-dbus.html
@@ -21,6 +21,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   <meta http-equiv="Content-Type" content="text/html; charset=utf8" />
   <head>
     <title>D-Bus Tests</title>
+    <meta charset="utf-8">
     <link rel="stylesheet" href="../../lib/qunit-1.14.0.css" type="text/css" media="screen" />
     <script type="text/javascript" src="../../lib/jquery.v2.1.0.js"></script>
     <script type="text/javascript" src="../../lib/qunit-1.14.0.js"></script>

--- a/pkg/shell/test-dummy.html
+++ b/pkg/shell/test-dummy.html
@@ -20,6 +20,7 @@
 <html>
   <head>
     <title>Dummy Tests</title>
+    <meta charset="utf-8">
     <link rel="stylesheet" href="../../lib/qunit-1.14.0.css" type="text/css" media="screen" />
     <script type="text/javascript" src="../../lib/jquery.v2.1.0.js"></script>
     <script type="text/javascript" src="../../lib/qunit-1.14.0.js"></script>

--- a/pkg/shell/test-journal-renderer.html
+++ b/pkg/shell/test-journal-renderer.html
@@ -20,6 +20,7 @@
 <html>
   <head>
     <title>Journal Renderer Tests</title>
+    <meta charset="utf-8">
     <link rel="stylesheet" href="../../lib/qunit-1.14.0.css" type="text/css" media="screen" />
     <script type="text/javascript" src="../../lib/jquery.v2.1.0.js"></script>
     <script type="text/javascript" src="../../lib/qunit-1.14.0.js"></script>

--- a/pkg/shell/test-rest.html
+++ b/pkg/shell/test-rest.html
@@ -20,6 +20,7 @@
 <html>
   <head>
     <title>Rest Tests</title>
+    <meta charset="utf-8">
     <link rel="stylesheet" href="../../lib/qunit-1.14.0.css" type="text/css" media="screen" />
     <script type="text/javascript" src="../../lib/jquery.v2.1.0.js"></script>
     <script type="text/javascript" src="../../lib/qunit-1.14.0.js"></script>

--- a/pkg/shell/test-util.html
+++ b/pkg/shell/test-util.html
@@ -21,6 +21,7 @@
 <html>
   <head>
     <title>Util Tests</title>
+    <meta charset="utf-8">
     <link rel="stylesheet" href="../../lib/qunit-1.14.0.css" type="text/css" media="screen" />
     <script type="text/javascript" src="../../lib/jquery.v2.1.0.js"></script>
     <script type="text/javascript" src="../../lib/qunit-1.14.0.js"></script>

--- a/src/static/login.html
+++ b/src/static/login.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Cockpit starting...</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script>
 	/* Login page is standalone without external JS/CSS */


### PR DESCRIPTION
The server can't really know what kind of content a given
HTML file will have, so the HTML files need to declare that
themselves.
