### PR TITLE
Fix BuildRequires: sed

### DIFF
--- a/test/cockpit.spec.in
+++ b/test/cockpit.spec.in
@@ -57,7 +57,7 @@ BuildRequires: perl-JSON
 BuildRequires: selinux-policy-devel
 BuildRequires: checkpolicy
 BuildRequires: /usr/share/selinux/devel/policyhelp
-BuildRequires: /usr/bin/sed
+BuildRequires: sed
 
 # For documentation
 BuildRequires: /usr/bin/xmlto


### PR DESCRIPTION
At some point, 'sed' stopped installing to /usr/bin/sed and started
installing to /bin/sed. The easiest thing to do is to just require
the package instead of the path.
