### PR TITLE
shell: Don't call legacy_page.setup when it is not defined.

### DIFF
--- a/pkg/shell/cockpit-main.js
+++ b/pkg/shell/cockpit-main.js
@@ -437,7 +437,8 @@ function go_params(params) {
         if (!legacy_page) {
             legacy_page = legacy_page_from_id(id);
             if (legacy_page) {
-                legacy_page.setup();
+                if (legacy_page.setup)
+                    legacy_page.setup();
                 visited_legacy_pages[id] = legacy_page;
             }
         }


### PR DESCRIPTION
Not all legacy pages have this, such as the big ugly graphs.
