### PR TITLE
bridge: Fix use of 0 instead of NULL

### DIFF
--- a/src/bridge/cockpitchannel.c
+++ b/src/bridge/cockpitchannel.c
@@ -267,7 +267,7 @@ cockpit_channel_real_close (CockpitChannel *self,
       message = cockpit_json_write_bytes (object);
       json_object_unref (object);
 
-      cockpit_transport_send (self->priv->transport, 0, message);
+      cockpit_transport_send (self->priv->transport, NULL, message);
       g_bytes_unref (message);
     }
 

--- a/src/bridge/cockpitpolkitagent.c
+++ b/src/bridge/cockpitpolkitagent.c
@@ -245,7 +245,7 @@ on_helper_read (CockpitPipe *pipe,
   /* Consume from buffer, including null termination */
   cockpit_pipe_skip (buffer, lf - buffer->data);
 
-  cockpit_transport_send (caller->self->transport, 0, bytes);
+  cockpit_transport_send (caller->self->transport, NULL, bytes);
   g_bytes_unref (bytes);
 }
 


### PR DESCRIPTION
Although correct, this is confusing when reading code.
