### PR TITLE
bridge: Move UTF8 validation to CockpitChannel

### DIFF
--- a/src/bridge/cockpitchannel.c
+++ b/src/bridge/cockpitchannel.c
@@ -464,10 +464,43 @@ cockpit_channel_ready (CockpitChannel *self)
   g_object_unref (self);
 }
 
+static GBytes *
+check_utf8_and_force_if_necessary (GBytes *input)
+{
+  const gchar *data;
+  const gchar *end;
+  gsize length;
+  GString *string;
+
+  data = g_bytes_get_data (input, &length);
+  if (g_utf8_validate (data, length, &end))
+    return g_bytes_ref (input);
+
+  string = g_string_sized_new (length + 16);
+  do
+    {
+      /* Valid part of the string */
+      g_string_append_len (string, data, end - data);
+
+      /* Replacement character */
+      g_string_append (string, "\xef\xbf\xbd");
+
+      length -= (end - data) + 1;
+      data = end + 1;
+    }
+  while (!g_utf8_validate (data, length, &end));
+
+  if (length)
+    g_string_append_len (string, data, length);
+
+  return g_string_free_to_bytes (string);
+}
+
 /**
  * cockpit_channel_send:
  * @self: a pipe
  * @payload: the message payload to send
+ * @trust_is_utf8: set to true if sure data is UTF8
  *
  * Called by implementations to send a message over the transport
  * on the right channel.
@@ -476,9 +509,18 @@ cockpit_channel_ready (CockpitChannel *self)
  */
 void
 cockpit_channel_send (CockpitChannel *self,
-                      GBytes *payload)
+                      GBytes *payload,
+                      gboolean trust_is_utf8)
 {
+  GBytes *validated = NULL;
+
+  if (!trust_is_utf8)
+    payload = validated = check_utf8_and_force_if_necessary (payload);
+
   cockpit_transport_send (self->priv->transport, self->priv->id, payload);
+
+  if (validated)
+    g_bytes_unref (validated);
 }
 
 /**

--- a/src/bridge/cockpitchannel.h
+++ b/src/bridge/cockpitchannel.h
@@ -77,7 +77,8 @@ const gchar *       cockpit_channel_get_id            (CockpitChannel *self);
 void                cockpit_channel_ready             (CockpitChannel *self);
 
 void                cockpit_channel_send              (CockpitChannel *self,
-                                                       GBytes *payload);
+                                                       GBytes *payload,
+                                                       gboolean valid_utf8);
 
 const gchar *       cockpit_channel_get_option        (CockpitChannel *self,
                                                        const gchar *name);

--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -722,7 +722,7 @@ send_json_object (CockpitDBusJson *self,
   GBytes *bytes;
 
   bytes = cockpit_json_write_bytes (object);
-  cockpit_channel_send (COCKPIT_CHANNEL (self), bytes);
+  cockpit_channel_send (COCKPIT_CHANNEL (self), bytes, TRUE);
   g_bytes_unref (bytes);
 }
 

--- a/src/bridge/cockpitresource.c
+++ b/src/bridge/cockpitresource.c
@@ -67,7 +67,7 @@ on_idle_send_block (gpointer data)
     }
   else
     {
-      cockpit_channel_send (channel, payload);
+      cockpit_channel_send (channel, payload, FALSE);
       g_bytes_unref (payload);
       return TRUE;
     }

--- a/src/bridge/cockpitrestjson.c
+++ b/src/bridge/cockpitrestjson.c
@@ -407,7 +407,7 @@ cockpit_rest_response_reply (CockpitRestJson *self,
   g_object_unref (builder);
 
   bytes = g_bytes_new_take (data, length);
-  cockpit_channel_send (COCKPIT_CHANNEL (self), bytes);
+  cockpit_channel_send (COCKPIT_CHANNEL (self), bytes, TRUE);
   g_bytes_unref (bytes);
 }
 

--- a/src/bridge/cockpittextstream.c
+++ b/src/bridge/cockpittextstream.c
@@ -63,48 +63,12 @@ typedef struct {
 
 G_DEFINE_TYPE (CockpitTextStream, cockpit_text_stream, COCKPIT_TYPE_CHANNEL);
 
-static GBytes *
-check_utf8_and_force_if_necessary (GBytes *input)
-{
-  const gchar *data;
-  const gchar *end;
-  gsize length;
-  GString *string;
-
-  data = g_bytes_get_data (input, &length);
-  if (g_utf8_validate (data, length, &end))
-    return g_bytes_ref (input);
-
-  string = g_string_sized_new (length + 16);
-  do
-    {
-      /* Valid part of the string */
-      g_string_append_len (string, data, end - data);
-
-      /* Replacement character */
-      g_string_append (string, "\xef\xbf\xbd");
-
-      length -= (end - data) + 1;
-      data = end + 1;
-    }
-  while (!g_utf8_validate (data, length, &end));
-
-  if (length)
-    g_string_append_len (string, data, length);
-
-  return g_string_free_to_bytes (string);
-}
-
 static void
 cockpit_text_stream_recv (CockpitChannel *channel,
                           GBytes *message)
 {
   CockpitTextStream *self = COCKPIT_TEXT_STREAM (channel);
-  GBytes *clean;
-
-  clean = check_utf8_and_force_if_necessary (message);
-  cockpit_pipe_write (self->pipe, clean);
-  g_bytes_unref (clean);
+  cockpit_pipe_write (self->pipe, message);
 }
 
 static void
@@ -113,7 +77,6 @@ process_pipe_buffer (CockpitTextStream *self,
 {
   CockpitChannel *channel = (CockpitChannel *)self;
   GBytes *message;
-  GBytes *clean;
 
   if (self->batch_timeout)
     {
@@ -126,10 +89,8 @@ process_pipe_buffer (CockpitTextStream *self,
       /* When array is reffed, this just clears byte array */
       g_byte_array_ref (data);
       message = g_byte_array_free_to_bytes (data);
-      clean = check_utf8_and_force_if_necessary (message);
-      cockpit_channel_send (channel, clean);
+      cockpit_channel_send (channel, message, FALSE);
       g_bytes_unref (message);
-      g_bytes_unref (clean);
     }
 }
 

--- a/src/bridge/deprecated/cockpitdbusjson1.c
+++ b/src/bridge/deprecated/cockpitdbusjson1.c
@@ -335,7 +335,7 @@ write_builder (CockpitDBusJson1 *self,
 
   json_builder_end_object (builder);
   bytes = _json_builder_to_bytes (self, builder);
-  cockpit_channel_send (COCKPIT_CHANNEL (self), bytes);
+  cockpit_channel_send (COCKPIT_CHANNEL (self), bytes, TRUE);
   g_bytes_unref (bytes);
 }
 

--- a/src/bridge/deprecated/cockpitdbusjson2.c
+++ b/src/bridge/deprecated/cockpitdbusjson2.c
@@ -669,7 +669,7 @@ write_builder (CockpitDBusJson2 *self,
   json_node_free (root);
 
   bytes = g_bytes_new_take (ret, length);
-  cockpit_channel_send (COCKPIT_CHANNEL (self), bytes);
+  cockpit_channel_send (COCKPIT_CHANNEL (self), bytes, TRUE);
   g_bytes_unref (bytes);
 }
 

--- a/src/bridge/test-channel.c
+++ b/src/bridge/test-channel.c
@@ -48,7 +48,7 @@ static void
 mock_echo_channel_recv (CockpitChannel *channel,
                         GBytes *message)
 {
-  cockpit_channel_send (channel, message);
+  cockpit_channel_send (channel, message, FALSE);
 }
 
 static void


### PR DESCRIPTION
This allows multiple channels to take advantage of this. For
channels that are sure they're producing valid UTF8, there's a
flag so we don't have to recheck everything.
