### PR TITLE
removed socket dependency in cockpit.service

### DIFF
--- a/src/ws/cockpit.service.in
+++ b/src/ws/cockpit.service.in
@@ -1,7 +1,6 @@
 [Unit]
 Description=Cockpit Web Server
 Documentation=man:cockpit-ws(8)
-Requires=cockpit.socket
 
 [Service]
 ExecStartPre=@sbindir@/remotectl certificate --ensure --user=root --group=@group@


### PR DESCRIPTION
Hi,
I've found issue, that althought I've started cockpit, if I want to stop cockpit I have to also stop cockpit.socket, not only cockpit.service. because there was depencency. Withnout dependency, it should be more consistent.
