### PR TITLE
bridge: Workaround temporary issue with UTF8 validation

### DIFF
--- a/src/bridge/cockpitresource.c
+++ b/src/bridge/cockpitresource.c
@@ -67,7 +67,11 @@ on_idle_send_block (gpointer data)
     }
   else
     {
-      cockpit_channel_send (channel, payload, FALSE);
+      /*
+       * TODO: These should be binary channels, change to FALSE
+       * when binary stuff is merged
+       */
+      cockpit_channel_send (channel, payload, TRUE);
       g_bytes_unref (payload);
       return TRUE;
     }


### PR DESCRIPTION
We're not properly indicating that the resource1 channels are
binary channels ... that work is on another branch.

So work around this for now by lying to cockpit_channel_send()
