### PR TITLE
limit the displayed width of hostnames in sidebar

### DIFF
--- a/pkg/shell/shell.css
+++ b/pkg/shell/shell.css
@@ -75,6 +75,19 @@ html, body {
     border-radius: 3px;
 }
 
+#content-navbar-hostname {
+    width: 248px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap
+}
+
+#cockpit-sidebar .list-group .list-group-item {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 /* Style a button group */
 
 .navbar-primary .btn-group {


### PR DESCRIPTION
In order to maintain steady width and avoid jumping ui
