### PR TITLE
daemon: Make dependency on storaged resolved at runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install automake autoconf intltool xsltproc libglib2.0-dev libgudev-1.0-dev libpolkit-gobject-1-dev libpolkit-agent-1-dev phantomjs gtk-doc-tools libjson-glib-dev libnm-glib-dev libaccountsservice-dev libpam0g-dev libssh-dev libsystemd-daemon-dev libsystemd-journal-dev libudisks2-dev libjson-perl liblocale-po-perl libjavascript-minifier-xs-perl pkg-config glib-networking valgrind libkeyutils-dev xmlto xsltproc
 
-  - sudo wget -O /usr/share/dbus-1/interfaces/com.redhat.lvm2.xml https://raw.githubusercontent.com/cockpit-project/storaged/master/data/com.redhat.lvm2.xml
   - wget http://www.javascriptlint.com/download/jsl-0.3.0-src.tar.gz
   - tar -xzvf jsl-0.3.0-src.tar.gz
   - ( cd jsl-0.3.0/src && make -f Makefile.ref )

--- a/configure.ac
+++ b/configure.ac
@@ -125,19 +125,6 @@ PKG_CHECK_MODULES(COCKPIT_DAEMON, [$GUDEV_REQUIREMENT
 COCKPIT_DAEMON_CFLAGS="$COCKPIT_CFLAGS $COCKPIT_DAEMON_CFLAGS $LIBGSYSTEM_CFLAGS"
 COCKPIT_DAEMON_LIBS="$COCKPIT_LIBS $COCKPIT_DAEMON_LIBS"
 
-# dbus interfaces dir
-
-# Can't use PKG_CHECK_VAR() as not all our target systems have it
-AC_CHECK_PROGS(PKG_CONFIG, pkg-config)
-AC_MSG_CHECKING(for dbus interfaces directory)
-interfacesdir=$($PKG_CONFIG dbus-1 --variable=interfaces_dir)
-if test "$interfacesdir" = ""; then
-    AC_MSG_ERROR(Couldn't find dbus interfaces directory. Try installing dbus-devel)
-else
-    AC_MSG_RESULT($interfacesdir)
-    AC_SUBST(interfacesdir)
-fi
-
 # dbus session dir
 AC_MSG_CHECKING(for dbus session services directory)
 if test "$enable_prefix_only" = "yes"; then
@@ -233,14 +220,6 @@ done
 
 AC_PATH_PROG([PHANTOMJS], [phantomjs])
 AM_CONDITIONAL([WITH_PHANTOMJS], [test -n "$PHANTOMJS"])
-
-# storaged
-
-LVM2_INTERFACE=$interfacesdir/com.redhat.lvm2.xml
-AC_CHECK_FILE($LVM2_INTERFACE, ,
-    [AC_MSG_ERROR(Need com.redhat.lvm2.xml. Try installing storaged)]
-)
-AC_SUBST(LVM2_INTERFACE)
 
 # usermod
 #

--- a/src/daemon/Makefile-daemon.am
+++ b/src/daemon/Makefile-daemon.am
@@ -18,13 +18,13 @@ CLEANFILES += cockpit-generated*
 lvm_dbus_built_sources = com.redhat.lvm2.h com.redhat.lvm2.c
 
 com.redhat.lvm2.h : com.redhat.lvm2.c
-com.redhat.lvm2.c : Makefile.am $(LVM2_INTERFACE)
+com.redhat.lvm2.c : Makefile.am src/daemon/com.redhat.lvm2.xml
 	$(AM_V_GEN) $(GDBUS_CODEGEN)  \
 		--interface-prefix com.redhat.lvm2 	\
 		--c-namespace Lvm 			\
 		--c-generate-object-manager 		\
 		--generate-c-code com.redhat.lvm2 	\
-		$(LVM2_INTERFACE) \
+		$(srcdir)/src/daemon/com.redhat.lvm2.xml \
 		$(NULL)
 
 BUILT_SOURCES += $(lvm_dbus_built_sources)
@@ -123,6 +123,7 @@ com.redhat.Cockpit.service: src/daemon/com.redhat.Cockpit.service.in Makefile.am
 EXTRA_DIST += \
 	src/daemon/com.redhat.Cockpit.xml \
 	src/daemon/com.redhat.Cockpit.service.in \
+	src/daemon/com.redhat.lvm2.xml \
 	$(NULL)
 
 CLEANFILES += \

--- a/src/daemon/com.redhat.lvm2.xml
+++ b/src/daemon/com.redhat.lvm2.xml
@@ -1,0 +1,516 @@
+<!DOCTYPE node PUBLIC
+"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+
+<!--
+ Copyright (C) 2013-2014 Red Hat, Inc.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General
+ Public License along with this library; if not, write to the
+ Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ Boston, MA 02110-1301, USA.
+-->
+
+  <!--
+      com.redhat.lvm2.Manager:
+      @short_description: Manager singleton
+
+      These are manager methods.
+  -->
+  <interface name="com.redhat.lvm2.Manager">
+
+    <!--
+        VolumeGroupCreate:
+        @name: The name for the volume group.
+        @blocks: The block devices to use as physical volumes, as UDisks2 object paths.
+        @options: Additional options.
+        @result: The object path of the new volume group object.
+
+        Creates a new volume group, using @blocks as the initial
+        physical volumes.  Each block device will be wiped and all
+        data on them will be lost.
+
+        You must specify at least one block device to be used as a
+        physical volume.
+
+        No additional options are currently defined.
+    -->
+    <method name="VolumeGroupCreate">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to delete a logical volume"/>
+      <arg name="name" direction="in" type="s"/>
+      <arg name="blocks" direction="in" type="ao"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+      <arg name="result" direction="out" type="o"/>
+    </method>
+
+  </interface>
+
+  <!--
+    com.redhat.lvm2.LogicalVolumeBlock:
+    @short_description: Block device that is a logical volume.
+
+    This interface shows up for blocks that are actually activated
+    logical volumes. It appears at the same object paths as the blocks
+    exposed by udisks via the org.freedesktop.UDisks2.Block interface.
+
+    Explanation: This is separate from the com.redhat.lvm2.LogicalVolume
+    interface because not all logical volumes are 'activated' and as such
+    are not all valid blocks.
+  -->
+  <interface name="com.redhat.lvm2.LogicalVolumeBlock">
+
+    <!-- LogicalVolume:
+         @since: x.x
+         The logical volume that this block corresponds to.
+      -->
+    <property name="LogicalVolume" type="o" access="read"/>
+
+  </interface>
+
+   <!--
+      com.redhat.lvm2.PhysicalVolumeBlock:
+      @short_description: Block device that is a physical volume.
+
+      This interface shows up for blocks that are actually physical
+      volumes in a volume group. It appears at the same object paths as the blocks
+      exposed by udisks via the org.freedesktop.UDisks2.Block interface.
+  -->
+  <interface name="com.redhat.lvm2.PhysicalVolumeBlock">
+    <property name="VolumeGroup" type="o" access="read"/>
+    <property name="Size" type="t" access="read"/>
+    <property name="FreeSize" type="t" access="read"/>
+  </interface>
+
+  <!--
+      com.redhat.lvm2.VolumeGroup:
+      @short_description: A volume group
+
+      Objects implementing this interface represent LVM2 volume groups.
+
+      The logical volume objects of a volume group are the children of
+      the volume group objects in the D-Bus object hierarchy.  See the
+      #com.redhat.lvm2.LogicalVolume interface.
+
+      The physical volume objects of a volume group can be found by
+      looking for block devices with a
+      #com.redhat.lvm2.PhysicalVolumeBlock.VolumeGroup property
+      that points to the volume group object.
+    -->
+  <interface name="com.redhat.lvm2.VolumeGroup">
+    <!-- Name:
+
+         The name of this volume group, as known to LVM2.
+    -->
+    <property name="Name" type="s" access="read"/>
+
+    <!-- UUID:
+
+         The UUID this volume group.  It is guaranteed to be unique,
+         but it might change over time.
+    -->
+    <property name="UUID" type="s" access="read"/>
+
+    <!-- Size:
+
+         The total capacity of this volume group, in bytes.
+    -->
+    <property name="Size" type="t" access="read"/>
+
+    <!-- FreeSize:
+
+         The unused capacity of this volume group, in bytes.
+    -->
+    <property name="FreeSize" type="t" access="read"/>
+
+    <!-- ExtentSize:
+
+         The size of extents.  When creating and resizing logical
+         volumes, sizes are rounded up to multiples of the extent
+         size.
+    -->
+    <property name="ExtentSize" type="t" access="read"/>
+
+    <!-- NeedsPolling:
+
+         Whether or not this volume group needs to be periodically
+         polled to guarantee updates.
+    -->
+    <property name="NeedsPolling" type="b" access="read"/>
+
+    <!-- Poll:
+
+         Make sure that all properties of this volume group and of all
+         their logical and physical volumes are up-to-date.
+
+         The properties are not guaranteed to be up-to-date yet when
+         this method returns.
+    -->
+    <method name="Poll">
+    </method>
+
+    <!-- Delete:
+         @wipe: Whether to wipe the physical volumes.
+         @options: Additional options.
+
+         Delete this volume group.  All its logical volumes will be
+         deleted, too.
+
+         No additional options are currently defined.
+    -->
+    <method name="Delete">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to delete a volume group"/>
+      <arg name="wipe" type="b" direction="in"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!-- Rename:
+         @new_name: The new name.
+         @options: Additional options.
+         @result: The new object path.
+
+         Rename this volume group.  This might cause the volume group
+         object to disappear from D-Bus and reappear with a different
+         path.
+
+         No additional options are currently defined.
+    -->
+    <method name="Rename">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to rename a volume group"/>
+      <arg name="new_name" type="s" direction="in"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+      <arg name="result" type="o" direction="out"/>
+    </method>
+
+    <!-- AddDevice:
+         @block: The block device to add, as a UDisks2 object path.
+         @options: Additional options.
+
+         Add a new physical volume to the volume group.  The block
+         device will be wiped and all data on it will be lost.
+    -->
+    <method name="AddDevice">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to add a device to a volume group"/>
+      <arg name="block" type="o" direction="in"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!-- EmptyDevice:
+         @block: The block device to empty, as a UDisks2 object path.
+         @options: Additional options.
+
+         Move all data on the given block device somewhere else so
+         that the block device might be removed.
+
+         No additional options are currently defined.
+    -->
+    <method name="EmptyDevice">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to empty a device in a volume group"/>
+      <arg name="block" type="o" direction="in"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!-- RemoveDevice:
+         @block: The block device to remove, as a UDisks2 object path.
+         @wipe: Whether to wipe the physical volume.
+         @options: Additional options.
+
+         Remove the indicated physical volume from the volume group.
+         The physical device must be unused.
+
+         No additional options are currently defined.
+    -->
+    <method name="RemoveDevice">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to remove a device from a volume group"/>
+      <arg name="block" type="o" direction="in"/>
+      <arg name="wipe" type="b" direction="in"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!-- CreatePlainVolume:
+         @name: The name of the new logical volume.
+         @size: The size.
+         @options: Additional options.
+         @result: The object path of the new logical volume.
+
+         Create a 'normal' new logical volume.
+
+         No additional options are currently defined.
+    -->
+    <method name="CreatePlainVolume">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to create a logical volume"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="size" type="t" direction="in"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+      <arg name="result" type="o" direction="out"/>
+    </method>
+
+    <!-- CreateThinPoolVolume:
+         @name: The name of the new logical volume.
+         @size: The size.
+         @options: Additional options.
+         @result: The object path of the new logical volume.
+
+         Create a new logical volume that can be used to back
+         thinly-provisioned logical volumes.
+
+         No additional options are currently defined.
+    -->
+    <method name="CreateThinPoolVolume">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to create a logical volume"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="size" type="t" direction="in"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+      <arg name="result" type="o" direction="out"/>
+    </method>
+
+    <!-- CreateThinVolume:
+         @name: The name of the new logical volume.
+         @size: The virtual size.
+         @pool: The thin pool to use.
+         @options: Additional options.
+         @result: The object path of the new logical volume.
+
+         Create a new thinly provisioned logical volume in the given
+         pool.
+
+         No additional options are currently defined.
+    -->
+    <method name="CreateThinVolume">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to create a logical volume"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="size" type="t" direction="in"/>
+      <arg name="pool" type="o" direction="in"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+      <arg name="result" type="o" direction="out"/>
+    </method>
+
+  </interface>
+
+  <!--
+      com.redhat.lvm2.LogicalVolume:
+      @short_description: A logical volume.
+      @since: x.x
+
+      Objects with this interface represent logical volumes in a
+      volume group.  Active logical volumes are associated with a
+      block device, which link back to the logical volume object via
+      their #com.redhat.lvm2.LogicalVolumeBlock.LogicalVolume property.
+
+      Logical volume objects have object paths that are children of their
+      volume group object, and also link to it via the #VolumeGroup property.
+  -->
+  <interface name="com.redhat.lvm2.LogicalVolume">
+
+    <!-- VolumeGroup:
+
+         The path of the volume group object that this logical volume
+         belongs to.
+    -->
+    <property name="VolumeGroup" type="o" access="read"/>
+
+    <!-- Name:
+
+         The name of this logical volume, as it is known to LVM2.
+    -->
+    <property name="Name" type="s" access="read"/>
+
+    <!-- Active:
+
+         Whether or not this volume is active.
+    -->
+    <property name="Active" type="b" access="read"/>
+
+    <!-- UUID:
+
+         The UUID of this logical volume.  It is guaranteed to be
+         unique within the group, but it might change over time.
+    -->
+    <property name="UUID" type="s" access="read"/>
+
+    <!-- Size:
+
+         The size of this logical volume in bytes.
+    -->
+    <property name="Size" type="t" access="read"/>
+
+    <!-- DataAllocatedRatio:
+
+         For a thin pool or a non-thin snapshot, indicates how full
+         the area for storing data is.  A value of 1.0 corresponds to
+         100%.
+    -->
+    <property name="DataAllocatedRatio" type="d" access="read"/>
+
+    <!-- MetadataAllocatedRatio:
+
+         For a thin pool or a non-thin snapshot, indicates how full
+         the area for storing meta data is.  A value of 1.0
+         corresponds to 100%.
+    -->
+    <property name="MetadataAllocatedRatio" type="d" access="read"/>
+
+    <!-- Type:
+
+         The general type of a logical volume.  One of "block" or
+         "pool".  More types might be defined in the future.
+
+         A volume of type "block" can be used as a block device.  A
+         volume of type "pool" can be used to create thin volumes.
+    -->
+    <property name="Type" type="s" access="read"/>
+
+    <!-- ThinPool:
+
+         For a thin volume, the object path of its pool.
+    -->
+    <property name="ThinPool" type="o" access="read"/>
+
+    <!-- Origin:
+
+         For a snapshot, the object path of its origin.
+    -->
+    <property name="Origin" type="o" access="read"/>
+
+    <!-- Activate:
+         @options: Additional options.
+         @result: The UDisks2 object path of the block device.
+
+         Activate this logical volume, which makes it appear as a
+         block device in the system.
+
+         Non-thin snapshots are always activated and deactivated
+         together with their origins.
+
+         No additional options are currently defined.
+    -->
+    <method name="Activate">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to activate a logical volume"/>
+      <arg name="result" type="o" direction="out"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!-- Deactivate:
+         @options: Additional options.
+
+         Deactivate this logical volume, which makes its block device
+         disappear.
+
+         Non-thin snapshots are always activated and deactivated
+         together with their origins.
+
+         No additional options are currently defined.
+    -->
+    <method name="Deactivate">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to deactivate a logical volume"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!-- Delete:
+         @options: Additional options.
+
+         Delete this logical volume.
+
+         If there are any non-thin snapshots of this logical volume,
+         they will be deleted as well.
+
+         If this is a thin pool, all its contained thin volumes will
+         be deleted as well.
+
+         No additional options are currently defined.
+    -->
+    <method name="Delete">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to delete a logical volume"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+    </method>
+
+    <!-- Rename:
+         @new_name: The new name.
+         @options: Additional options.
+         @result: The new object path.
+
+         Rename this logical volume.  This might cause the logical
+         volume object to disappear from D-Bus and reappear with a
+         different path.
+
+         No additional options are currently defined.
+    -->
+    <method name="Rename">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to rename a logical volume"/>
+      <arg name="new_name" type="s" direction="in"/>
+      <arg name="options" direction="in" type="a{sv}"/>
+      <arg name="result" type="o" direction="out"/>
+    </method>
+
+    <!-- Resize:
+         @new_size: The new size, in bytes.
+         @options: Additional options.
+
+         Resize this logical volume.
+
+         Additional options:
+
+         resize_fsys (b):   Whether to resize the filesystem on the
+                            logical volume as well.  Default to 'false'.
+    -->
+    <method name="Resize">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to resize a logical volume"/>
+      <arg name="new_size" type="t" direction="in"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+
+    <!-- CreateSnapshot:
+         @name: The name of the snapshot.
+         @size: The size of the backing store for the snapshot, in bytes.
+         @options: Additional options.
+
+         Create a snapshot of this logical volume.
+
+         When creating a snapshot of a non-thin volume, a non-zero
+         size must be specified.  A non-thin snapshot is created in
+         this case.
+
+         When creating a snapshot of a thin volume, specifying a @size
+         of zero will create a thin snapshot in the same pool.
+
+         When creating a snapshot of a thin volume, specifying a
+         non-zero @size will create a non-thin snapshot.
+
+         No additional options are currently defined.
+    -->
+    <method name="CreateSnapshot">
+      <annotation name="polkit.action_id" value="com.redhat.lvm2.manage-lvm"/>
+      <annotation name="polkit.message" value="Authentication is required to resize a logical volume"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="size" type="t" direction="in"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+      <arg name="result" type="o" direction="out"/>
+    </method>
+
+  </interface>
+
+</node>

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -37,7 +37,6 @@ BuildRequires: pkgconfig(libsystemd-daemon)
 BuildRequires: pkgconfig(polkit-agent-1) >= 0.105
 BuildRequires: pkgconfig(accountsservice) >= 0.6.35
 BuildRequires: pam-devel
-BuildRequires: storaged >= 0.3.1
 
 BuildRequires: autoconf automake
 BuildRequires: intltool


### PR DESCRIPTION
Soon we'll be calling storaged and udisks directly from javascript
code. The module that the javascript code lives in should be built
in a package that depends on storaged and udisks so it's appropriately
installed.

We won't be using the interface xml directly anymore anyway. So
this is an interim step, in the right direction, even though it looks
like a hack.
