### PR TITLE
common, bridge: Support older JSON versions like 0.14.2

### DIFF
--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -324,7 +324,8 @@ parse_json_dictionary (JsonNode *node,
     {
       if (is_string)
         {
-          key_node = json_node_init_string (json_node_alloc (), l->data);
+          key_node = json_node_new (JSON_NODE_VALUE);
+          json_node_set_string (key_node, l->data);
         }
       else
         {
@@ -559,7 +560,8 @@ build_json_byte_array (GVariant *value)
 
   data = g_variant_get_fixed_array (value, &length, 1);
   string = g_base64_encode (data, length);
-  node = json_node_init_string (json_node_alloc (), string);
+  node = json_node_new (JSON_NODE_VALUE);
+  json_node_set_string (node, string);
   g_free (string); /* unfortunately :S */
 
   return node;
@@ -640,44 +642,66 @@ build_json (GVariant *value)
   switch (g_variant_classify (value))
     {
     case G_VARIANT_CLASS_BOOLEAN:
-      return json_node_init_boolean (json_node_alloc (), g_variant_get_boolean (value));
+      node = json_node_new (JSON_NODE_VALUE);
+      json_node_set_boolean (node, g_variant_get_boolean (value));
+      return node;
 
     case G_VARIANT_CLASS_BYTE:
-      return json_node_init_int (json_node_alloc (), g_variant_get_byte (value));
+      node = json_node_new (JSON_NODE_VALUE);
+      json_node_set_int (node, g_variant_get_byte (value));
+      return node;
 
     case G_VARIANT_CLASS_INT16:
-      return json_node_init_int (json_node_alloc (), g_variant_get_int16 (value));
+      node = json_node_new (JSON_NODE_VALUE);
+      json_node_set_int (node, g_variant_get_int16 (value));
+      return node;
 
     case G_VARIANT_CLASS_UINT16:
-      return json_node_init_int (json_node_alloc (), g_variant_get_uint16 (value));
+      node = json_node_new (JSON_NODE_VALUE);
+      json_node_set_int (node, g_variant_get_uint16 (value));
+      return node;
 
     case G_VARIANT_CLASS_INT32:
-      return json_node_init_int (json_node_alloc (), g_variant_get_int32 (value));
+      node = json_node_new (JSON_NODE_VALUE);
+      json_node_set_int (node, g_variant_get_int32 (value));
+      return node;
 
     case G_VARIANT_CLASS_UINT32:
-      return json_node_init_int (json_node_alloc (), g_variant_get_uint32 (value));
+      node = json_node_new (JSON_NODE_VALUE);
+      json_node_set_int (node, g_variant_get_uint32 (value));
+      return node;
 
     case G_VARIANT_CLASS_INT64:
-      return json_node_init_int (json_node_alloc (), g_variant_get_int64 (value));
+      node = json_node_new (JSON_NODE_VALUE);
+      json_node_set_int (node, g_variant_get_int64 (value));
+      return node;
 
     case G_VARIANT_CLASS_UINT64:
-      return json_node_init_int (json_node_alloc (), g_variant_get_uint64 (value));
+      node = json_node_new (JSON_NODE_VALUE);
+      json_node_set_int (node, g_variant_get_uint64 (value));
+      return node;
 
     case G_VARIANT_CLASS_HANDLE:
-      return json_node_init_int (json_node_alloc (), g_variant_get_handle (value));
+      node = json_node_new (JSON_NODE_VALUE);
+      json_node_set_int (node, g_variant_get_handle (value));
+      return node;
 
     case G_VARIANT_CLASS_DOUBLE:
-      return json_node_init_double (json_node_alloc (), g_variant_get_double (value));
+      node = json_node_new (JSON_NODE_VALUE);
+      json_node_set_double (node, g_variant_get_double (value));
+      return node;
 
     case G_VARIANT_CLASS_STRING:      /* explicit fall-through */
     case G_VARIANT_CLASS_OBJECT_PATH: /* explicit fall-through */
     case G_VARIANT_CLASS_SIGNATURE:
-      return json_node_init_string (json_node_alloc (), g_variant_get_string (value, NULL));
+      node = json_node_new (JSON_NODE_VALUE);
+      json_node_set_string (node, g_variant_get_string (value, NULL));
+      return node;
 
     case G_VARIANT_CLASS_VARIANT:
       object = build_json_variant (value);
-      node = json_node_init_object (json_node_alloc (), object);
-      json_object_unref (object);
+      node = json_node_new (JSON_NODE_OBJECT);
+      json_node_take_object (node, object);
       return node;
 
     case G_VARIANT_CLASS_ARRAY:
@@ -686,8 +710,8 @@ build_json (GVariant *value)
       if (g_variant_type_is_dict_entry (element_type))
         {
           object = build_json_dictionary (element_type, value);
-          node = json_node_init_object (json_node_alloc (), object);
-          json_object_unref (object);
+          node = json_node_new (JSON_NODE_OBJECT);
+          json_node_take_object (node, object);
         }
       else if (g_variant_type_equal (element_type, G_VARIANT_TYPE_BYTE))
         {
@@ -696,14 +720,16 @@ build_json (GVariant *value)
       else
         {
           array = build_json_array_or_tuple (value);
-          node = json_node_init_array (json_node_alloc (), array);
+          node = json_node_new (JSON_NODE_ARRAY);
+          json_node_set_array (node, array);
           json_array_unref (array);
         }
       return node;
 
     case G_VARIANT_CLASS_TUPLE:
       array = build_json_array_or_tuple (value);
-      node = json_node_init_array (json_node_alloc (), array);
+      node = json_node_new (JSON_NODE_ARRAY);
+      json_node_set_array (node, array);
       json_array_unref (array);
       return node;
 
@@ -783,7 +809,7 @@ build_json_body (GVariant *body,
     {
       if (type)
         *type = NULL;
-      return json_node_init_null (json_node_alloc ());
+      return json_node_new (JSON_NODE_NULL);
     }
 }
 

--- a/src/bridge/cockpitresource.c
+++ b/src/bridge/cockpitresource.c
@@ -131,7 +131,8 @@ respond_package_listing (CockpitChannel *channel)
   JsonNode *node;
 
   listing = load_package_listing (&root);
-  node = json_node_init_array (json_node_alloc (), root);
+  node = json_node_new (JSON_NODE_ARRAY);
+  json_node_set_array (node, root);
   cockpit_channel_close_json_option (channel, "packages", node);
   g_hash_table_unref (listing);
   json_node_free (node);

--- a/src/common/cockpitjson.c
+++ b/src/common/cockpitjson.c
@@ -510,7 +510,10 @@ cockpit_json_parse (const gchar *data,
            *
            * https://bugzilla.gnome.org/show_bug.cgi?id=728951
            */
-          json_node_init_null (root);
+          if (JSON_NODE_HOLDS_OBJECT (root))
+            json_node_take_object (root, json_object_new ());
+          else if (JSON_NODE_HOLDS_ARRAY (root))
+            json_node_take_array (root, json_array_new ());
         }
     }
   else
@@ -612,7 +615,8 @@ cockpit_json_write_object (JsonObject *object,
   JsonNode *node;
   gchar *ret;
 
-  node = json_node_init_object (json_node_alloc (), object);
+  node = json_node_new (JSON_NODE_OBJECT);
+  json_node_set_object (node, object);
   ret = cockpit_json_write (node, length);
   json_node_free (node);
 

--- a/src/common/cockpittest.c
+++ b/src/common/cockpittest.c
@@ -342,9 +342,15 @@ _cockpit_assert_json_eq_msg (const char *domain,
   gchar *msg;
 
   if (expect[0] == '[')
-    node = json_node_init_array (json_node_alloc (), object_or_array);
+    {
+      node = json_node_new (JSON_NODE_ARRAY);
+      json_node_set_array (node, object_or_array);
+    }
   else
-    node = json_node_init_object (json_node_alloc (), object_or_array);
+    {
+      node = json_node_new (JSON_NODE_OBJECT);
+      json_node_set_object (node, object_or_array);
+    }
 
   exnode = cockpit_json_parse (expect, -1, &error);
   if (error)


### PR DESCRIPTION
This is compatible on RHEL6 and other OS's. We just needed
a few minor changes to make this work.

We expect json-glib 0.14.0 or later, but I accidentally used
functions only available in later versions.
