### PR TITLE
common, ws: Add missing headers

### DIFF
--- a/src/common/cockpitlog.c
+++ b/src/common/cockpitlog.c
@@ -25,6 +25,8 @@
 #include "cockpitlog.h"
 
 #include <systemd/sd-journal.h>
+#include <syslog.h>
+#include <string.h>
 
 #include <errno.h>
 #include <unistd.h>

--- a/src/common/cockpitunixfd.c
+++ b/src/common/cockpitunixfd.c
@@ -26,6 +26,9 @@
 #include <sys/resource.h>
 
 #include <dirent.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 typedef struct {
     GSource source;

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -39,6 +39,7 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>

--- a/src/ws/cockpitwebserver.c
+++ b/src/ws/cockpitwebserver.c
@@ -26,6 +26,7 @@
 #include "config.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <systemd/sd-daemon.h>

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -43,6 +43,8 @@
 
 #include "reauthorize/reauthorize.h"
 
+#include <stdlib.h>
+
 /* Some tunables that can be set from tests */
 const gchar *cockpit_ws_session_program =
     PACKAGE_LIBEXEC_DIR "/cockpit-session";


### PR DESCRIPTION
Porting to RHEL6 highlighted these missing headers.
