### PR TITLE
base: Use the shell to determine default host if loaded into shell

### DIFF
--- a/pkg/base/cockpit.js
+++ b/pkg/base/cockpit.js
@@ -471,8 +471,16 @@ function Channel(options) {
             if (options.hasOwnProperty(i) && command[i] === undefined)
                 command[i] = options[i];
         }
-        if (command.host === undefined && default_host)
-            command.host = default_host;
+
+        if (command.host === undefined) {
+            var host = default_host;
+            /* HACK until we migrate all the pages from shell */
+            if ("shell" in window && typeof window['shell'].get_page_machine == "function")
+                host = window["shell"].get_page_machine();
+            if (host)
+                command.host = host;
+        }
+
         transport.send_control(command);
 
         /* Now drain the queue */

--- a/pkg/base/test-chan.html
+++ b/pkg/base/test-chan.html
@@ -670,6 +670,25 @@ asyncTest("transport options", function() {
     channel.send("blah");
 });
 
+var shell = shell || { };
+
+asyncTest("auto host shell hack", function() {
+    expect(1);
+
+    shell.get_page_machine = function() {
+        return "marmalade";
+    };
+
+    var channel = cockpit.channel({ });
+    $(mock_peer).on("recv", function(event, chan, payload) {
+        var command = JSON.parse(payload);
+        if (command.command == "open") {
+            strictEqual(command.host, "marmalade", "host automatically chosen");
+            delete shell.get_page_machine;
+            start();
+        }
+    });
+});
 
 window.location.hash = "";
 QUnit.start();

--- a/pkg/shell/cockpit-main.js
+++ b/pkg/shell/cockpit-main.js
@@ -430,7 +430,7 @@ function hosts_init() {
 
     local_account_proxies = null;
 
-    var cockpitd = cockpit.dbus("com.redhat.Cockpit");
+    var cockpitd = cockpit.dbus("com.redhat.Cockpit", { "host": "localhost" });
     local_account_proxies = cockpitd.proxies("com.redhat.Cockpit.Account",
                                              "/com/redhat/Cockpit/Accounts");
     host_proxies = cockpitd.proxies("com.redhat.Cockpit.Machine",


### PR DESCRIPTION
When cockpit.js code is loaded into the shell, use the shell to determine
the default host rather than requiring it to be passed in all over the
place.

This lets us write future proof code. Later on when everything is migrated
we can remove this hack.
