### PR TITLE
daemon: Don't hang if AccountsService cannot be reached

### DIFF
--- a/src/daemon/accounts.h
+++ b/src/daemon/accounts.h
@@ -32,6 +32,8 @@ GType             accounts_get_type          (void) G_GNUC_CONST;
 
 CockpitAccounts * accounts_new               (void);
 
+gboolean          accounts_is_valid          (Accounts *accounts);
+
 G_END_DECLS
 
 #endif /* COCKPIT_ACCOUNTS_H__ */

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -303,12 +303,16 @@ daemon_constructed (GObject *_object)
 
   /* /com/redhat/Cockpit/Accounts */
   accounts = accounts_new ();
-  object = cockpit_object_skeleton_new ("/com/redhat/Cockpit/Accounts");
-  cockpit_object_skeleton_set_accounts (object, accounts);
-  g_dbus_object_manager_server_export (daemon->object_manager, G_DBUS_OBJECT_SKELETON (object));
-  g_object_unref (accounts);
+  if (accounts_is_valid (ACCOUNTS (accounts)))
+    {
+      object = cockpit_object_skeleton_new ("/com/redhat/Cockpit/Accounts");
+      cockpit_object_skeleton_set_accounts (object, accounts);
+      g_dbus_object_manager_server_export (daemon->object_manager, G_DBUS_OBJECT_SKELETON (object));
+      g_object_unref (object);
 
-  g_object_unref (object);
+      g_debug ("exported accounts");
+    }
+  g_object_unref (accounts);
 
   /* /com/redhat/Cockpit/Storage/Manager */
   storage_manager = storage_manager_new (daemon);


### PR DESCRIPTION
And also don't export the accounts object when AccountsService
is not available.
