### PR TITLE
resource2 payload

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -241,7 +241,8 @@ Payload: echo
 A channel opened with this payload type will send back all data that
 it receives.
 
-Payload: resource1
+
+Payload: resource2
 ------------------
 
 These payloads contain resource data, such as javascript and html files that
@@ -253,7 +254,7 @@ type:
 
  * "package": the package to retrieve resource from
  * "path": path of the resource within the package.
- * "accept": various options for choosing the resource file
+ * "accept": array of various file extensions for content negotation
 
 The "package" may either be fully qualified (ie: package@host), although the
 host part is not used for routing, and the usual "open" command "host"
@@ -262,8 +263,13 @@ option should be used. The package may also be a package checksum.
 If "accept" includes "minified" then a minified form of the file will
 be selected, if it is available.
 
-The channel payload will be the raw (possibly binary) byte data of the
-resource being retrieved.
+The first channel payload will be a JSON object, containing the following
+options, related to headers.
+
+ * "accept": the content negotiation option accepted
+
+The remaining channel payloads will be the raw (possibly binary) byte data
+of the resource being retrieved.
 
 If "package" and "path" are missing, then the channel will be immediately
 closed without a "reason", and a combined manifest of all packages, including
@@ -272,7 +278,7 @@ the "packages" option:
 
     {
         "command": "close",
-        "channel": -5,
+        "channel": "5",
         "packages": [
             {
                 "id": ["app1", "$0d599f0ec05c3bda8c3b8a68c32a1b47"],
@@ -281,6 +287,9 @@ the "packages" option:
             ...
         ]
     }
+
+The resource1 payload is no longer supported.
+
 
 Payload: dbus-json3
 -------------------

--- a/doc/urls.md
+++ b/doc/urls.md
@@ -12,7 +12,7 @@ and their characteristics:
  * ```/cockpit/$xxxxxxxxxxxxxxx/path/to/file.ext``` are files which are
    cached by packages for as long as possible. The checksum changes when
    any of the contents of the given package change. Only available after
-   authentication and retrieving a resource1 listing.
+   authentication and retrieving a resource2 listing.
 
  * ```/cockpit/package/path/to/file.ext``` or ```/cockpit/package@host/path/to/file.ext```
    are files from packages (on specific hosts, or local machine if no host specified)

--- a/pkg/base/cockpit.js
+++ b/pkg/base/cockpit.js
@@ -566,7 +566,7 @@ function package_table(host, callback) {
         callback(table, null);
         return;
     }
-    var channel = new Channel({ "host": host, "payload": "resource1" });
+    var channel = new Channel({ "host": host, "payload": "resource2" });
     channel.onclose = function(event, options) {
         if (options.reason) {
             package_debug("package listing failed: " + options.reason);

--- a/pkg/base/test-echo.html
+++ b/pkg/base/test-echo.html
@@ -63,13 +63,19 @@ asyncTest("base64", function() {
     expect(1);
 
     var channel = cockpit.channel({
-        "payload": "resource1",
+        "payload": "resource2",
         "path": "test.html",
         "package": "another",
         "binary": "base64"
     });
 
+    var first = true;
+
     $(channel).on("message", function(ev, payload) {
+        if (first) {
+            first = false;
+            return;
+        }
         strictEqual(payload, "PGh0bWw+CjxoZWFkPgo8dGl0bGU+SW4gaG9tZSBkaXI8L3RpdGxlPgo8L2hlYWQ+Cjxib2R5PkluIGhvbWUgZGlyPC9ib2R5Pgo8L2h0bWw+Cg==", "got the right payload");
         $(channel).off();
         start();

--- a/pkg/base/test-framed.html
+++ b/pkg/base/test-framed.html
@@ -57,7 +57,7 @@
             }, false);
 
             /* This keeps coming up in tests ... how to open the transport */
-            var chan = cockpit.channel({ "payload": "resource1" });
+            var chan = cockpit.channel({ "payload": "resource2" });
             $(chan).on("close", function() {
                  $(document.body).append($("<iframe>").attr("name", "blah").
                          attr("src", window.location.href + "?sub"));

--- a/src/bridge/cockpitchannel.c
+++ b/src/bridge/cockpitchannel.c
@@ -480,7 +480,7 @@ cockpit_channel_open (CockpitTransport *transport,
     channel_type = COCKPIT_TYPE_REST_JSON;
   else if (g_strcmp0 (payload, "stream") == 0)
     channel_type = COCKPIT_TYPE_STREAM;
-  else if (g_strcmp0 (payload, "resource1") == 0)
+  else if (g_strcmp0 (payload, "resource2") == 0)
     channel_type = COCKPIT_TYPE_RESOURCE;
   else if (g_strcmp0 (payload, "null") == 0)
     channel_type = COCKPIT_TYPE_NULL_CHANNEL;

--- a/src/bridge/cockpitresource.h
+++ b/src/bridge/cockpitresource.h
@@ -34,6 +34,6 @@ CockpitChannel *   cockpit_resource_open         (CockpitTransport *transport,
                                                   const gchar *channel,
                                                   const gchar *package,
                                                   const gchar *path,
-                                                  const gchar *accept);
+                                                  const gchar **accept);
 
 #endif /* COCKPIT_RESOURCE_H__ */


### PR DESCRIPTION
bridge: New resource2 payload protocol

This is something that several future enhancements need. We need to send back a header payload before the actual data that can carry information that affects the HTTP Headers of the response.
