### PR TITLE
tools: Define gitcommit for our work in progress srpms spec file

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -1,5 +1,6 @@
-# This global is defined by test builders like make-rpms
-# global gitcommit blah
+# Globals that might be defined elsewhere
+#  * gitcommit xxxx
+#  * selinux 1
 
 # Our SELinux policy gets built in tests and f21 and lower
 %if %{defined gitcommit}

--- a/tools/make-rpms
+++ b/tools/make-rpms
@@ -90,8 +90,7 @@ sed -i -e 's/gpgcheck=1/gpgcheck=0/' $base/mock/$os-$arch-cockpit.cfg
 touch -r /etc/mock/$os-$arch.cfg $base/mock/$os-$arch-cockpit.cfg
 
 if LANG=C /usr/bin/mock $mock_opts $mock_clean_opts --configdir=$base/mock/ \
-	--resultdir $base/mock -r $os-$arch-cockpit $srpm \
-    --define="gitcommit wip"; then
+	--resultdir $base/mock -r $os-$arch-cockpit $srpm; then
     grep "^Wrote: .*\.\($arch\|noarch\)\.rpm$" $base/mock/build.log | while read l; do
         p=$(basename "$l") # knocks off the "Wrote:" part as well...
         echo $p

--- a/tools/make-srpm
+++ b/tools/make-srpm
@@ -39,6 +39,8 @@ rpm_tmpdir=$(mktemp -d -t rpmbuild.XXXXXX)
     cd $base/..
     git archive HEAD --prefix cockpit-wip/ --output $rpm_tmpdir/cockpit-wip.tar.gz
     cp test/cockpit.pam $rpm_tmpdir
+    sed '1i\
+%define gitcommit wip' tools/cockpit.spec > $rpm_tmpdir/cockpit.spec
 )
 
 (
@@ -52,8 +54,7 @@ rpm_tmpdir=$(mktemp -d -t rpmbuild.XXXXXX)
         --define "_rpmdir `pwd`" \
         --define "_buildrootdir `pwd`/.build" \
         --define "optflags -ggdb3 -O0" \
-        --define "gitcommit wip" \
-        $base/cockpit.spec
+        cockpit.spec
 )
 
 for f in "${rpm_tmpdir}"/*.src.rpm; do


### PR DESCRIPTION
This way builders like Coverity and such can take the resulting
srpm and build it without special extra defines or flags.
