### PR TITLE
pkg: Fix race with delayed loading of pages

### DIFF
--- a/pkg/playground/test.html
+++ b/pkg/playground/test.html
@@ -7,7 +7,7 @@
     <link href="../@@latest@@/cockpit.css" type="text/css" rel="stylesheet">
     <script src="../@@latest@@/cockpit.js"></script>
 </head>
-<body>
+<body style="display: none;">
     <div id="internal" class="container-fluid">
         <img src="hammer.gif" style="float: right;" onclick="$(this).hide();">
         <div id="nav"></div>
@@ -76,6 +76,7 @@ require([
         cockpit.location.go(cockpit.location.path.concat(len.toString()), { length: len.toString() });
     });
 
+    $("body").show();
 });
 </script>
 </body>

--- a/pkg/server-systemd/terminal.html
+++ b/pkg/server-systemd/terminal.html
@@ -56,13 +56,15 @@ require([
             if (channel && channel.valid)
                 channel.send(data);
         });
+
+        $("body").show();
     }
 
     $(show);
 });
 </script>
 </head>
-<body>
+<body style="display: none;">
     <div id="terminal" class="terminal-emulator"></div>
 </body>
 </html>

--- a/test/check-multi-machine
+++ b/test/check-multi-machine
@@ -172,8 +172,8 @@ class TestMultiMachine(MachineCase):
         m2 = self.machine2
 
         # Modify the terminals to be different on the two machines.
-        m1.execute("sed -i -e 's/<body>/<body>magic-m1-token/' /usr/share/cockpit/server-systemd/terminal.html")
-        m2.execute("sed -i -e 's/<body>/<body>magic-m2-token/' /usr/share/cockpit/server-systemd/terminal.html")
+        m1.execute("sed -i -e 's|</body>|magic-m1-token</body>|' /usr/share/cockpit/server-systemd/terminal.html")
+        m2.execute("sed -i -e 's|</body>|magic-m2-token</body>|' /usr/share/cockpit/server-systemd/terminal.html")
 
         self.login_and_go("dashboard")
         inject_extras(b)

--- a/test/check-terminal
+++ b/test/check-terminal
@@ -37,7 +37,6 @@ class TestTerminal(MachineCase):
         def wait_line(i,t):
             b.wait_text(line_sel(i), line_text(t))
 
-        b.wait_present('#terminal .terminal')
         b.focus('#terminal .terminal')
 
         # wait for prompt in first line and remember it

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -263,6 +263,8 @@ class Browser:
         if id.startswith("/"):
             self.wait_present("iframe.container-frame[name='%s'][data-loaded]" % id)
             self.switch_to_frame(id)
+            self.wait_present("body")
+            self.wait_visible("body")
         else:
             self.wait_visible('#' + id)
             self.wait_dbus_ready()


### PR DESCRIPTION
Because pages load via AMD they are not necessarily ready to use when
their onload event fires. We define a convention that a page shows its
<body> element when it is ready to use, or at least when it wants to
start interacting with the user.

In the future the shell could use this to determine when to display the
page and/or show a loading spinner.

For now we just use this from tests.
