### PR TITLE
bridge: Allow both 'ready' and 'close' to be done later for a channel

### DIFF
--- a/src/bridge/cockpitchannel.c
+++ b/src/bridge/cockpitchannel.c
@@ -113,10 +113,10 @@ on_idle_later (gpointer data)
   if (later)
     {
       self->priv->later_data = NULL;
+      if (later->ready && !(later->close && later->problem != NULL))
+        cockpit_channel_ready (self);
       if (later->close)
         cockpit_channel_close (self, later->problem);
-      else if (later->ready)
-        cockpit_channel_ready (self);
       g_free (later->problem);
       g_slice_free (LaterData, later);
     }


### PR DESCRIPTION
We might have queued messages before the close comes and we should
process them first.
