### PR TITLE
tools: Use package.json to identify which nodejs deps to install

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -37,7 +37,7 @@ cd $srcdir
 
 (
 	cd tools
-	npm install po2json jed
+	npm install # see tools/package.json
 )
 
 rm -rf autom4te.cache

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "CockpitDeps",
+  "description": "Cockpit is not a NPM or Node JS package, these are just deps",
+  "private": true,
+  "devDependencies": {
+    "po2json": "*",
+    "jed": "*"
+  }
+}
+


### PR DESCRIPTION
Use package.json to identify which nodejs packages to install during autogen.sh.

I hope this will fix #1498 but want confirmation from the reporter first.
