### PR TITLE
base: Make it easier to use proxies without CamelCase

### DIFF
--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -619,7 +619,7 @@
         function directly.</para>
 
       <para>Methods that do not start with an upper case letter can be invoked by using
-        the usual <link linkend="latest-dbus-call"><code>client.call()</code></link> directly.</para>
+        the usual <link linkend="latest-dbus-proxy-call"><code>proxy.call()</code></link> directly.</para>
 
 <programlisting>
   $(proxy).on("Signal", function(event, arg1, arg2) {
@@ -633,7 +633,7 @@
         argument.</para>
 
       <para>Signals that do not start with an upper case letter can be subscribed to by
-        using <link linkend="latest-dbus-subscribe"><code>client.subscribe()</code></link>
+        using <link linkend="latest-dbus-proxy-signal"><code>proxy.onsignal</code></link>
         directly.</para>
     </refsection>
 
@@ -677,6 +677,32 @@
         event will be emitted when it changes.</para>
     </refsection>
 
+    <refsection id="latest-dbus-proxy-call">
+      <title>proxy.call()</title>
+<programlisting>
+ invocation = proxy.call(method, args, [options])
+</programlisting>
+      <para>Make a DBus method call on this proxy.</para>
+
+      <para>For DBus methods that start with an upper case letter, is usually more convenient
+        <link linkend="latest-dbus-proxy">to call the method directly on the proxy</link>.
+        However if methods that do not follow the usual DBus convention,
+        or specify additional options, or the caller cannot be sure that the method actually
+        exists, you can use this method.</para>
+
+      <para>This function also works on proxies that have are still loading and have not
+        become valid yet.</para>
+
+      <para>The <code>method</code> should be a DBus method name, and the <code>args</code>
+        should be an array of arguments to pass to the method. The <code>options</code>
+        are <link linkend="latest-dbus-call">described elsewhere</link>.</para>
+
+      <para>The returned value is identical to the one returned from
+        <link linkend="latest-dbus-call">client.call()</link>. It is a
+        <ulink url="http://api.jquery.com/category/deferred-object/">jQuery promise</ulink>
+        that will complete sucessfully when the method returns, or fail if an error occurs.</para>
+    </refsection>
+
     <refsection id="latest-dbus-proxy-wait">
       <title>proxy.wait()</title>
 <programlisting>
@@ -708,6 +734,24 @@
     "Prop2": 5
   }
 </programlisting>
+    </refsection>
+
+    <refsection id="latest-dbus-proxy-signal">
+      <title>proxy.onsignal</title>
+<programlisting>
+ $(proxy).on("signal", function(event, name, args) {
+   ...
+ });
+</programlisting>
+      <para>This event is emitted when the proxy's emits an event.</para>
+
+      <para>For most events, that have names which start with an upper case letter, you can
+        just <link linkend="latest-dbus-proxy">connect to that event as a signal directly</link>.
+        However if you wish to be notified when any signal is emitted, or for signals that do not
+        follow the usual DBus convention, you can connect to this event.</para>
+
+      <para>The <code>name</code> is the DBus signal name, and the <code>args</code> is an array
+        of arguments that were emitted with the signal.</para>
     </refsection>
 
     <refsection id="latest-dbus-proxies">

--- a/pkg/base/cockpit.js
+++ b/pkg/base/cockpit.js
@@ -1062,6 +1062,8 @@ function full_scope(cockpit, $) {
             "valid": { get: function() { return valid; }, enumerable: false },
             "wait": { value: function(func) { waits.add(func); return this; },
                       enumerable: false, writable: false },
+            "call": { value: function(name, args) { return client.call(path, iface, name, args); },
+                      enumerable: false, writable: false },
             "data": { value: { }, enumerable: false }
         });
 
@@ -1138,6 +1140,7 @@ function full_scope(cockpit, $) {
         update(cache.lookup(path, iface));
 
         function signal(path, iface, name, args) {
+            $(self).triggerHandler("signal", [name, args]);
             if (name[0].toLowerCase() != name[0])
                 $(self).triggerHandler(name, args);
         }

--- a/pkg/base/test-dbus.html
+++ b/pkg/base/test-dbus.html
@@ -612,6 +612,50 @@ test("proxy no stutter", function() {
     equal(proxy.path, "/com/redhat/Cockpit/DBusTests/Test", "path auto chosen");
 });
 
+asyncTest("proxy call", function() {
+    expect(2);
+
+    var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", { "bus": "session" });
+    var proxy = dbus.proxy("com.redhat.Cockpit.DBusTests.Frobber", "/otree/frobber");
+
+    /* No wait */
+    proxy.call("HelloWorld", ["From a proxy"]).
+        done(function(args) {
+            equal(args[0], "Word! You said `From a proxy'. I'm Skeleton, btw!", "method args");
+        }).
+        always(function() {
+            equal(this.state(), "resolved", "method called");
+            $(dbus).off();
+            start();
+        });
+});
+
+asyncTest("proxy signal", function() {
+    expect(4);
+
+    var received = false;
+
+    var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", { "bus": "session" });
+    var proxy = dbus.proxy("com.redhat.Cockpit.DBusTests.Frobber", "/otree/frobber");
+
+    $(proxy).on("signal", function(event, name, args) {
+        equal(name, "TestSignal", "signals: got right name");
+        deepEqual(args, [
+                  43, [ "foo", "frobber" ], [ "/foo", "/foo/bar" ],
+                  { "first": [ 42, 42 ], "second": [ 43, 43 ] } ], "got right arguments");
+        received = true;
+    });
+
+    proxy.call("RequestSignalEmission", [ 0 ]).
+        always(function() {
+            equal(this.state(), "resolved", "emmision requested");
+            equal(received, true, "signal received");
+            $(dbus).off();
+            $(proxy).off();
+            start();
+        });
+});
+
 asyncTest("proxies", function() {
     expect(13);
 


### PR DESCRIPTION
- Support proxy.call(name, args)
- Support a "signal" event on proxies to catch any signal

Together with the 'data' field already on proxies, this makes it
possible to use proxies without CamelCase properties, methods, signals.
It's slightly less convenient but works well.

In addition this allows calling methods on proxies that are still loading.

Fixes #1500
