### PR TITLE
base: Fix null dereference when qualifying module path

### DIFF
--- a/pkg/base/cockpit.js
+++ b/pkg/base/cockpit.js
@@ -1614,7 +1614,10 @@ function full_scope(cockpit, $) {
         }
 
         /* Resolve dots and double dots */
-        return resolve_path_dots(path.split("/")).join("/");
+        path = resolve_path_dots(path.split("/"));
+        if (path)
+            path = path.join("/");
+        return path;
     }
 
     /* Qualify an array of possibly relative paths */


### PR DESCRIPTION
This happens because resolve_path_dots() can return null for
invalid paths.
