### PR TITLE
base: Closing channel without problem does not close immediately

### DIFF
--- a/pkg/base/test-chan.html
+++ b/pkg/base/test-chan.html
@@ -304,7 +304,7 @@ asyncTest("receive message", function() {
 });
 
 asyncTest("close channel", function() {
-    expect(5);
+    expect(4);
 
     $(mock_peer).on("recv", function(event, chan, payload) {
         var cmd = JSON.parse(payload);
@@ -312,17 +312,17 @@ asyncTest("close channel", function() {
             return;
         } else if (cmd.command == "open") {
             channel.close();
-            strictEqual(channel.valid, false, "no longer valid");
             return;
         }
         equal(cmd.command, "close", "sent close command");
         strictEqual(cmd.channel, channel.id, "correct channel");
-        start();
+        mock_peer.send("", payload);
     });
     var channel = cockpit.channel({ });
     $(channel).on("close", function(event, options) {
         ok(true, "triggered event");
         ok(!options.problem, "no problem");
+        start();
     });
 });
 
@@ -332,10 +332,10 @@ asyncTest("close early", function() {
     var channel = cockpit.channel({ });
     $(channel).on("close", function(event, options) {
         ok(true, "triggered event");
-        ok(!options.problem, "no problem");
+        equal(options.problem, "yo", "got problem");
         start();
     });
-    channel.close();
+    channel.close("yo");
     strictEqual(channel.valid, false, "no longer valid");
 });
 

--- a/pkg/base/test-spawn-proc.html
+++ b/pkg/base/test-spawn-proc.html
@@ -94,6 +94,26 @@ asyncTest("error output", function() {
         });
 });
 
+asyncTest("write close read", function() {
+    expect(2);
+
+    var proc = cockpit.spawn(["/usr/bin/sort"]);
+
+    proc.done(function(resp) {
+        equal(resp, "1\n2\n3\n", "output");
+    });
+
+    proc.always(function() {
+        equal(this.state(), "resolved", "didn't fail");
+        start();
+    });
+
+    proc.write("2\n");
+    proc.write("3\n1\n");
+    proc.close();
+});
+
+
 QUnit.start();
 
 </script>


### PR DESCRIPTION
When closing a channel we send a request to bridge to close the
channel. However we also short circuit the close, so that we aren't
waiting for an unresponsive bridge.

This short circuit shouldn't happen when the channel is closed without
a problem.

Closing a channel without a problem is used to indicate end-of-input
to channels like 'stream'.
