### PR TITLE
shell: Use watchdog channel for disconnects, and reload on Reconnect

### DIFF
--- a/pkg/shell/cockpit-accounts.js
+++ b/pkg/shell/cockpit-accounts.js
@@ -181,14 +181,12 @@ PageAccounts.prototype = {
         this.address = shell.get_page_machine();
         /* TODO: This code needs to be migrated away from old dbus */
         this.client = shell.dbus(this.address, { "payload": "dbus-json1" });
-        shell.set_watched_client(this.client);
 
         on_account_changes(this.client, "accounts", $.proxy(this, "update"));
         this.update();
     },
 
     leave: function() {
-        shell.set_watched_client(null);
         off_account_changes(this.client, "accounts");
         this.client.release();
         this.client = null;
@@ -389,7 +387,6 @@ PageAccount.prototype = {
         this.address = shell.get_page_machine();
         /* TODO: This code needs to be migrated away from old dbus */
         this.client = shell.dbus(this.address, { payload: "dbus-json1" });
-        shell.set_watched_client(this.client);
 
         on_account_changes(this.client, "account", $.proxy(this, "update"));
         this.real_name_dirty = false;
@@ -397,7 +394,6 @@ PageAccount.prototype = {
     },
 
     leave: function() {
-        shell.set_watched_client(null);
         off_account_changes(this.client, "account");
         this.client.release();
         this.client = null;

--- a/pkg/shell/cockpit-cpu-status.js
+++ b/pkg/shell/cockpit-cpu-status.js
@@ -35,7 +35,6 @@ PageCpuStatus.prototype = {
         this.address = shell.get_page_param('machine', 'server') || "localhost";
         /* TODO: This code needs to be migrated away from old dbus */
         this.client = shell.dbus(this.address, { payload: "dbus-json1" });
-        shell.set_watched_client(this.client);
 
         var resmon = this.client.get("/com/redhat/Cockpit/CpuMonitor", "com.redhat.Cockpit.ResourceMonitor");
         var options = {
@@ -76,7 +75,6 @@ PageCpuStatus.prototype = {
     },
 
     leave: function() {
-        shell.set_watched_client(null);
         this.plot.destroy();
         this.client.release();
         this.client = null;

--- a/pkg/shell/cockpit-docker.js
+++ b/pkg/shell/cockpit-docker.js
@@ -291,7 +291,7 @@ function setup_for_failure(page, client, address) {
 
     /* High level failures about the overall functionality of docker */
     $(client).on('failure.failure', function(event, ex) {
-        /* This error is handled via shell.set_watched_client
+        /* This error is handled via the watchdog
          * and we don't need to show it here. */
         if (ex.problem != "disconnected")
             show_failure(ex, page);
@@ -453,7 +453,6 @@ PageContainers.prototype = {
 
         /* TODO: This code needs to be migrated away from old dbus */
         this.dbus_client = shell.dbus(this.address, { payload: "dbus-json1" });
-        shell.set_watched_client(this.dbus_client);
 
         var reds = [ "#250304",
                      "#5c080c",
@@ -526,7 +525,6 @@ PageContainers.prototype = {
     leave: function() {
         unsetup_for_failure(this.client);
 
-        shell.set_watched_client(null);
         this.dbus_client.release();
         this.dbus_client = null;
 
@@ -967,7 +965,6 @@ PageContainerDetails.prototype = {
     leave: function() {
         unsetup_for_failure(this.client);
 
-        shell.set_watched_client(null);
         this.dbus_client.release();
         this.dbus_client = null;
 
@@ -1074,7 +1071,6 @@ PageContainerDetails.prototype = {
 
         /* TODO: This code needs to be migrated away from old dbus */
         this.dbus_client = shell.dbus(this.address, { payload: "dbus-json1" });
-        shell.set_watched_client(this.dbus_client);
 
         $(this.client).on('container.container-details', function (event, id, container) {
             if (id == self.container_id)
@@ -1246,7 +1242,6 @@ PageImageDetails.prototype = {
     leave: function() {
         unsetup_for_failure(this.client);
 
-        shell.set_watched_client(null);
         this.dbus_client.release();
         this.dbus_client = null;
 
@@ -1270,7 +1265,6 @@ PageImageDetails.prototype = {
 
         /* TODO: migrate this code away from old dbus */
         this.dbus_client = shell.dbus(this.address, { payload: "dbus-json1" });
-        shell.set_watched_client(this.dbus_client);
 
         $('#image-details-containers table tbody tr').remove();
 

--- a/pkg/shell/cockpit-memory-status.js
+++ b/pkg/shell/cockpit-memory-status.js
@@ -33,7 +33,6 @@ PageMemoryStatus.prototype = {
         this.address = shell.get_page_machine();
         /* TODO: This code needs to be migrated away from old dbus */
         this.client = shell.dbus(this.address, { payload: "dbus-json1" });
-        shell.set_watched_client(this.client);
 
         var resmon = this.client.get("/com/redhat/Cockpit/MemoryMonitor", "com.redhat.Cockpit.ResourceMonitor");
         var options = {
@@ -70,7 +69,6 @@ PageMemoryStatus.prototype = {
     },
 
     leave: function() {
-        shell.set_watched_client(null);
         this.plot.destroy();
         this.client.release();
         this.client = null;

--- a/pkg/shell/cockpit-networking.js
+++ b/pkg/shell/cockpit-networking.js
@@ -1264,7 +1264,6 @@ PageNetworking.prototype = {
 
         this.address = shell.get_page_machine();
         this.model = get_nm_model(this.address);
-        shell.set_watched_client(this.model.client);
 
         this.ifaces = { };
 
@@ -1336,7 +1335,6 @@ PageNetworking.prototype = {
         this.tx_plot.destroy();
         this.log_box.stop();
 
-        shell.set_watched_client(null);
         $(this.model).off(".networking");
         this.model.release();
         this.model = null;
@@ -1589,7 +1587,6 @@ PageNetworkInterface.prototype = {
 
         self.address = shell.get_page_machine();
         self.model = get_nm_model(self.address);
-        shell.set_watched_client(self.model.client);
         $(self.model).on('changed.network-interface', $.proxy(self, "update"));
 
         self.dev_name = shell.get_page_param('dev');
@@ -1666,7 +1663,6 @@ PageNetworkInterface.prototype = {
         this.rx_plot.destroy();
         this.tx_plot.destroy();
 
-        shell.set_watched_client(null);
         $(this.model).off(".network-interface");
         this.model.release();
         this.model = null;

--- a/pkg/shell/cockpit-server.js
+++ b/pkg/shell/cockpit-server.js
@@ -64,7 +64,6 @@ PageServer.prototype = {
         self.address = shell.get_page_machine();
         /* TODO: Need to migrate away from old dbus */
         self.client = shell.dbus(self.address, { payload: 'dbus-json1' });
-        shell.set_watched_client(self.client);
 
         self.manager = self.client.get("/com/redhat/Cockpit/Manager",
                                        "com.redhat.Cockpit.Manager");
@@ -207,7 +206,6 @@ PageServer.prototype = {
         self.disk_io_plot.destroy();
         self.network_traffic_plot.destroy();
 
-        shell.set_watched_client(null);
         $(self.manager).off('.server');
         self.manager = null;
         $(self.realms).off('.server');

--- a/pkg/shell/cockpit-services.js
+++ b/pkg/shell/cockpit-services.js
@@ -268,7 +268,6 @@ PageServices.prototype = {
 
         /* TODO: This code needs to be migrated away from old dbus */
         me.client = shell.dbus(me.address, { payload: 'dbus-json1' });
-        shell.set_watched_client(me.client);
 
         me.manager = me.client.get("/com/redhat/Cockpit/Services",
                                    "com.redhat.Cockpit.Services");
@@ -335,7 +334,6 @@ PageServices.prototype = {
     leave: function() {
         var self = this;
 
-        shell.set_watched_client(null);
         this.cpu_plot.destroy();
         this.mem_plot.destroy();
         $(self.manager).off('.services');
@@ -616,7 +614,6 @@ PageService.prototype = {
         me.address = shell.get_page_machine();
         /* TODO: This code needs to be migrated away from old dbus */
         me.client = shell.dbus(me.address, { payload: 'dbus-json1' });
-        shell.set_watched_client(me.client);
 
         me.manager = me.client.get("/com/redhat/Cockpit/Services",
                                    "com.redhat.Cockpit.Services");
@@ -671,7 +668,6 @@ PageService.prototype = {
     leave: function() {
         this.cpu_plot.destroy();
         this.mem_plot.destroy();
-        shell.set_watched_client(null);
         this.journal_watcher.stop();
         this.client.release();
         this.client = null;

--- a/pkg/shell/cockpit-storage.js
+++ b/pkg/shell/cockpit-storage.js
@@ -346,7 +346,6 @@ PageStorage.prototype = {
         this.address = shell.get_page_machine();
         /* TODO: This code needs to be migrated away from the old dbus */
         this.client = shell.dbus(this.address, { payload: 'dbus-json1' });
-        shell.set_watched_client(this.client);
         watch_jobs(this.client);
 
         this._drives = $("#storage_drives");
@@ -445,7 +444,6 @@ PageStorage.prototype = {
         this.rx_plot.destroy();
         this.tx_plot.destroy();
 
-        shell.set_watched_client(null);
         $(this.client).off(".storage");
         $(this.monitor).off(".storage");
         $(this.mount_monitor).off(".storage");
@@ -1178,7 +1176,6 @@ PageStorageDetail.prototype = {
     },
 
     leave: function() {
-        shell.set_watched_client(null);
         this.unwatch_all_objects();
         this.job_box.stop();
         this.log_box.stop();
@@ -1247,7 +1244,6 @@ PageStorageDetail.prototype = {
         this.address = shell.get_page_machine();
         /* TODO: This code needs to be migrated away from old dbus */
         this.client = shell.dbus(this.address, { payload: 'dbus-json1' });
-        shell.set_watched_client(this.client);
         watch_jobs(this.client);
 
         this._drive = null;

--- a/test/check-connection
+++ b/test/check-connection
@@ -45,8 +45,6 @@ class TestConnection(MachineCase):
         b.wait_popup("disconnected-dialog")
         m.execute("systemctl start cockpit-testing.socket")
         b.click('#disconnected-reconnect')
-        b.wait_in_text('#disconnected-error', "Your session has expired.")
-        b.click('#disconnected-logout')
         b.expect_reload()
         b.wait_visible("#login")
         b.set_val("#login-user-input", "admin")
@@ -69,7 +67,8 @@ class TestConnection(MachineCase):
         b.wait_in_text('#disconnected-error', "Connection has timed out.")
         m.execute("iptables -D INPUT 1")
         b.click('#disconnected-reconnect')
-        b.wait_popdown("disconnected-dialog")
+        b.expect_reload()
+        b.wait_page("server")
 
         self.allow_restart_journal_messages()
 


### PR DESCRIPTION
Use a watchdog 'null' channel to watch for disconnects.

Given channels other than dbus, it's not possible to just reconnect
channels and try to patch things up on a disconnect. We really do
have to reload the current page.

We try to reestablish a connection as we're showing the Disconnected
dialog, which keeps our session alive until the user chooses whether
to Reconnect or Logout.
