### PR TITLE
shell: Hide everything but top bar until ready

### DIFF
--- a/pkg/shell/cockpit-main.js
+++ b/pkg/shell/cockpit-main.js
@@ -72,6 +72,8 @@ function maybe_init() {
 }
 
 function init() {
+    $('.dropdown-toggle').dropdown();
+    setup_user_menu();
     content_init();
     content_show();
 }
@@ -191,14 +193,7 @@ function content_init() {
 }
 
 function content_show() {
-    function update_name() {
-        var str = cockpit.user["name"] || cockpit.user["user"] || "???";
-        $('#content-user-name').text(str);
-    }
-    $(cockpit.info).on("changed", update_name);
-    if (cockpit.user["name"])
-        update_name();
-
+    $("#content-navbar").show();
     display_location();
     phantom_checkpoint();
 }
@@ -883,15 +878,24 @@ shell.confirm = function confirm(title, body, action_text) {
     return deferred.promise();
 };
 
-function update_user_menu() {
-    var is_root = (cockpit.user["user"] == "root");
-    var is_not_root = (cockpit.user["user"] && !is_root);
-    $('#cockpit-go-account').toggle(is_not_root);
-    $('#cockpit-change-passwd').toggle(is_root);
-    $('.cockpit-deauthorize-item').toggle(is_not_root);
-}
+function setup_user_menu() {
+    function update_name() {
+        var str = cockpit.user["name"] || cockpit.user["user"] || "???";
+        $('#content-user-name').text(str);
+    }
 
-$(function() {
+    function update_user_menu() {
+        var is_root = (cockpit.user["user"] == "root");
+        var is_not_root = (cockpit.user["user"] && !is_root);
+        $('#cockpit-go-account').toggle(is_not_root);
+        $('#cockpit-change-passwd').toggle(is_root);
+        $('.cockpit-deauthorize-item').toggle(is_not_root);
+    }
+
+    $(cockpit.info).on("changed", update_name);
+    if (cockpit.user["name"])
+        update_name();
+
     $(".cockpit-deauthorize-item a").on("click", function(ev) {
         cockpit.drop_privileges(false);
         $(".cockpit-deauthorize-item").addClass("disabled");
@@ -904,7 +908,7 @@ $(function() {
 
     update_user_menu();
     $(cockpit.user).on("changed", update_user_menu);
-});
+}
 
 shell.go_login_account = function go_login_account() {
     cockpit.location.go([ "local", "account" ], { id: cockpit.user["user"] });

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -58,7 +58,7 @@
             </ul>
           </li>
         </ul>
-        <ul class="nav navbar-nav navbar-primary" id="content-navbar">
+        <ul class="nav navbar-nav navbar-primary" id="content-navbar" hidden>
           <li>
             <a id="hosts-button">
               <img height="10" src="images/switcher.png">
@@ -111,7 +111,7 @@
 
     <div id="content">
 
-      <div id="dashboard" class="container-fluid">
+      <div id="dashboard" class="container-fluid" hidden>
         <div class="row">
           <div class="col-md-12">
             <ul class="nav nav-tabs">
@@ -149,7 +149,7 @@
         </div>
       </div>
 
-      <div id="server" class="container-fluid">
+      <div id="server" class="container-fluid" hidden>
         <div class="col-md-3">
           <table class="cockpit-info-table">
             <tr>
@@ -200,15 +200,15 @@
         </div>
       </div>
 
-      <div id="cpu_status">
+      <div id="cpu_status" hidden>
         <div id="cpu_status_graph" style="height:400px;padding:20px"></div>
       </div>
 
-      <div id="memory_status">
+      <div id="memory_status" hidden>
         <div id="memory_status_graph" style="height:400px;padding:20px"></div>
       </div>
 
-      <div id="storage">
+      <div id="storage" hidden>
         <div class="col-sm-9">
 
           <div class="row">
@@ -298,7 +298,7 @@
         </div>
       </div>
 
-      <div id="storage-detail" class="container-fluid">
+      <div id="storage-detail" class="container-fluid" hidden>
         <ol class="breadcrumb">
           <li><a onclick="cockpit.location.go('storage')">Storage</a></li>
           <li class="active"></li>
@@ -471,7 +471,7 @@
 
       </div>
 
-      <div id="networking" class="container-fluid">
+      <div id="networking" class="container-fluid" hidden>
         <div class="row">
           <div class="col-sm-6">
             <div>Sending<span style="float:right" id="networking-tx-text"></span></div>
@@ -512,7 +512,7 @@
         </div>
       </div>
 
-      <div id="network-interface" class="container-fluid">
+      <div id="network-interface" class="container-fluid" hidden>
         <ol class="breadcrumb">
           <li><a onclick="cockpit.location.go('networking')">Networking</a></li>
           <li class="active"></li>
@@ -562,7 +562,7 @@
         </div>
       </div>
 
-      <div id="services" class="container-fluid">
+      <div id="services" class="container-fluid" hidden>
         <div class="row" id="services-graphs">
           <div class="col-sm-6">
             <div>Combined CPU usage<span style="float:right" id="services-cpu-text"></span></div>
@@ -598,7 +598,7 @@
         <button class="btn btn-default" id="services-add">Add Service</button>
       </div>
 
-      <div id="service" class="container-fluid">
+      <div id="service" class="container-fluid" hidden>
         <ol class="breadcrumb">
           <li><a onclick="cockpit.location.go('services')">Services</a></li>
           <li class="active"></li>
@@ -688,7 +688,7 @@
         <button class="btn btn-default" translatable="yes" id="service-refresh">Refresh</button>
       </div>
 
-      <div id="journal" class="container-fluid">
+      <div id="journal" class="container-fluid" hidden>
         <div>
           <div id="journal-end"></div>
           <div id="journal-box"></div>
@@ -696,7 +696,7 @@
         </div>
       </div>
 
-      <div id="journal-entry" class="container-fluid">
+      <div id="journal-entry" class="container-fluid" hidden>
         <ol class="breadcrumb">
           <li><a onclick="cockpit.location.go('journal')">Journal</a></li>
           <li class="active">Entry</li>
@@ -712,13 +712,13 @@
         </div>
       </div>
 
-      <div id="accounts" class="container-fluid">
+      <div id="accounts" class="container-fluid" hidden>
         <button class="btn btn-default" id="accounts-create" translatable="yes">Create New Account</button>
         <div id="accounts-list">
         </div>
       </div>
 
-      <div id="account" class="container-fluid">
+      <div id="account" class="container-fluid" hidden>
         <ol class="breadcrumb">
           <li><a onclick="cockpit.location.go('accounts')">Accounts</a></li>
           <li class="active"></li>
@@ -764,7 +764,7 @@
       </div>
 
       <!-- this will be moved into a page when it is shown. -->
-      <div id="containers-failure">
+      <div id="containers-failure" hidden>
         <center>
           <br/>
           <div id="containers-failure-message"></div>
@@ -774,7 +774,7 @@
         </center>
       </div>
 
-      <div id="containers" class="container-fluid">
+      <div id="containers" class="container-fluid" hidden>
         <div class="col-md-8 col-lg-9">
           <div class="row">
             <div class="col-sm-6">
@@ -841,7 +841,7 @@
       <div class="bar-row hidden" graph="containers-images" value="0/100000000"></div>
 
       <!-- Layout for container details page -->
-      <div id="container-details" class="container-fluid">
+      <div id="container-details" class="container-fluid" hidden>
         <ol class="breadcrumb">
           <li><a onclick="cockpit.location.go('containers')">Containers</a></li>
           <li class="active"></li>
@@ -929,7 +929,7 @@
       </div>
 
       <!-- Layout for image details page-->
-      <div id="image-details" class="container-fluid">
+      <div id="image-details" class="container-fluid" hidden>
         <ol class="breadcrumb">
           <li><a onclick="cockpit.location.go('containers')">Containers</a></li>
           <li class="active"></li>


### PR DESCRIPTION
The shell initializes asyncronously, it waits for package loading,
and soon it will wait for AMD modules as well.

Only show the very top bar until we're ready to start interacting
with the user.

Otherwise we see very ugly things like a half drawn dashboard before
jumping to another screen.
