### PR TITLE
bridge: Allow calls without arguments without introspection

### DIFF
--- a/pkg/base/cockpit.js
+++ b/pkg/base/cockpit.js
@@ -1259,7 +1259,7 @@ function full_scope(cockpit, $) {
                         options.type = msg.type;
                     if (msg.flags)
                         options.flags = msg.flags;
-                    dfd.resolve(msg.reply[0], options);
+                    dfd.resolve(msg.reply[0] || [], options);
                     delete calls[msg.id];
                 }
             } else if (msg.error) {
@@ -1328,7 +1328,7 @@ function full_scope(cockpit, $) {
             var id = String(last_cookie);
             last_cookie++;
             var call = {
-                "call": [ path, iface, method, args ],
+                "call": [ path, iface, method, args || [] ],
                 "id": id
             };
             if (options) {

--- a/pkg/base/test-dbus.html
+++ b/pkg/base/test-dbus.html
@@ -409,6 +409,21 @@ asyncTest("flags", function() {
         });
 });
 
+asyncTest("without introspection", function() {
+    expect(2);
+
+    var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", { "bus": "session" });
+    dbus.call("/bork", "borkety.Bork", "Echo").
+        done(function(reply) {
+            deepEqual(reply, [], "round trip");
+        }).
+        always(function() {
+            equal(this.state(), "resolved", "finished successfuly");
+            start();
+        });
+});
+
+
 asyncTest("watch path", function() {
     expect(2);
 


### PR DESCRIPTION
Calls without arguments can proceed without introspection data. In
addition default to zero arguments when a DBus call is made without
arguments.
