### PR TITLE
ws: Don't timeout the primary user session even when no channels

### DIFF
--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -179,7 +179,7 @@ cockpit_session_remove_channel (CockpitSessions *sessions,
   g_hash_table_remove (sessions->by_channel, channel);
   g_hash_table_remove (session->channels, channel);
 
-  if (g_hash_table_size (session->channels) == 0)
+  if (g_hash_table_size (session->channels) == 0 && !session->primary)
     {
       /*
        * Close sessions that are no longer in use after N seconds


### PR DESCRIPTION
Even when there are no channels open, we should never timeout
the primary user session which is tracking the user's login.

Sometimes this is a local session (via cockpit-session) and sometimes
this is via ssh (see --local-ssh).
