### PR TITLE
ws: Hang onto query string in CockpitWebResponse

### DIFF
--- a/src/ws/cockpitwebresponse.c
+++ b/src/ws/cockpitwebresponse.c
@@ -50,6 +50,7 @@ struct _CockpitWebResponse {
   GIOStream *io;
   const gchar *logname;
   gchar *path;
+  gchar *query;
 
   /* The output queue */
   GPollableOutputStream *out;
@@ -134,6 +135,7 @@ cockpit_web_response_finalize (GObject *object)
   CockpitWebResponse *self = COCKPIT_WEB_RESPONSE (object);
 
   g_free (self->path);
+  g_free (self->query);
   g_assert (self->io == NULL);
   g_assert (self->out == NULL);
   g_queue_free_full (self->queue, (GDestroyNotify)g_bytes_unref);
@@ -159,6 +161,7 @@ cockpit_web_response_class_init (CockpitWebResponseClass *klass)
  * cockpit_web_response_new:
  * @io: the stream to send on
  * @path: the path resource or NULL
+ * @query: the query string or NULL
  * @in_headers: input headers or NULL
  *
  * Create a new web response.
@@ -172,6 +175,7 @@ cockpit_web_response_class_init (CockpitWebResponseClass *klass)
 CockpitWebResponse *
 cockpit_web_response_new (GIOStream *io,
                           const gchar *path,
+                          const gchar *query,
                           GHashTable *in_headers)
 {
   CockpitWebResponse *self;
@@ -194,6 +198,7 @@ cockpit_web_response_new (GIOStream *io,
     }
 
   self->path = g_strdup (path);
+  self->query = g_strdup (query);
   if (self->path)
     self->logname = self->path;
   else
@@ -220,6 +225,18 @@ const gchar *
 cockpit_web_response_get_path (CockpitWebResponse *self)
 {
   return self->path;
+}
+
+/**
+ * cockpit_web_response_get_query:
+ * @self: the response
+ *
+ * Returns: the resource path for response
+ */
+const gchar *
+cockpit_web_response_get_query (CockpitWebResponse *self)
+{
+  return self->query;
 }
 
 /**

--- a/src/ws/cockpitwebresponse.h
+++ b/src/ws/cockpitwebresponse.h
@@ -40,9 +40,12 @@ GType                 cockpit_web_response_get_type      (void) G_GNUC_CONST;
 
 CockpitWebResponse *  cockpit_web_response_new           (GIOStream *io,
                                                           const gchar *path,
+                                                          const gchar *query,
                                                           GHashTable *in_headers);
 
 const gchar *         cockpit_web_response_get_path      (CockpitWebResponse *self);
+
+const gchar *         cockpit_web_response_get_query     (CockpitWebResponse *self);
 
 GIOStream *           cockpit_web_response_get_stream    (CockpitWebResponse *self);
 

--- a/src/ws/cockpitwebserver.c
+++ b/src/ws/cockpitwebserver.c
@@ -311,16 +311,16 @@ cockpit_web_server_default_handle_stream (CockpitWebServer *self,
   gchar *pos;
   gchar bak;
 
-  /*
-   * We have no use for query string right now, and yes we happen to know
-   * that we can modify this string safely.
-   */
+  /* Yes, we happen to know that we can modify this string safely. */
   pos = strchr (path, '?');
   if (pos != NULL)
-    *pos = '\0';
+    {
+      *pos = '\0';
+      pos++;
+    }
 
   /* TODO: Correct HTTP version for response */
-  response = cockpit_web_response_new (io_stream, path, headers);
+  response = cockpit_web_response_new (io_stream, path, pos, headers);
   g_signal_connect_data (response, "done", G_CALLBACK (on_web_response_done),
                          g_object_ref (self), (GClosureNotify)g_object_unref, 0);
 
@@ -709,7 +709,7 @@ process_delayed_reply (CockpitRequest *request,
 
   g_assert (request->delayed_reply > 299);
 
-  response = cockpit_web_response_new (request->io, NULL, headers);
+  response = cockpit_web_response_new (request->io, NULL, NULL, headers);
   g_signal_connect_data (response, "done", G_CALLBACK (on_web_response_done),
                          g_object_ref (request->web_server), (GClosureNotify)g_object_unref, 0);
 

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -105,7 +105,7 @@ setup (Test *test,
   test->io = mock_io_stream_new (G_INPUT_STREAM (test->input),
                                  G_OUTPUT_STREAM (test->output));
 
-  test->response = cockpit_web_response_new (test->io, NULL, NULL);
+  test->response = cockpit_web_response_new (test->io, NULL, NULL, NULL);
   g_signal_connect (test->response, "done",
                     G_CALLBACK (on_web_response_done_set_flag),
                     &test->response_done);

--- a/src/ws/test-webresponse.c
+++ b/src/ws/test-webresponse.c
@@ -83,7 +83,7 @@ setup (TestCase *tc,
       g_hash_table_insert (headers, g_strdup (fixture->header), g_strdup (fixture->value));
     }
 
-  tc->response = cockpit_web_response_new (io, path, headers);
+  tc->response = cockpit_web_response_new (io, path, NULL, headers);
 
   if (headers)
     g_hash_table_unref (headers);

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -1373,7 +1373,7 @@ test_resource_simple (TestResourceCase *tc,
   GError *error = NULL;
   GBytes *bytes;
 
-  response = cockpit_web_response_new (tc->io, "/cockpit/another/test.html", NULL);
+  response = cockpit_web_response_new (tc->io, "/cockpit/another/test.html", NULL, NULL);
 
   cockpit_web_service_resource (tc->service, tc->headers, response);
 
@@ -1410,7 +1410,7 @@ test_resource_host (TestResourceCase *tc,
   GError *error = NULL;
   GBytes *bytes;
 
-  response = cockpit_web_response_new (tc->io, "/cockpit/another@localhost/test.html", NULL);
+  response = cockpit_web_response_new (tc->io, "/cockpit/another@localhost/test.html", NULL, NULL);
 
   cockpit_web_service_resource (tc->service, tc->headers, response);
 
@@ -1447,7 +1447,7 @@ test_resource_not_found (TestResourceCase *tc,
   GError *error = NULL;
   GBytes *bytes;
 
-  response = cockpit_web_response_new (tc->io, "/cockpit/another@localhost/not-exist", NULL);
+  response = cockpit_web_response_new (tc->io, "/cockpit/another@localhost/not-exist", NULL, NULL);
 
   cockpit_web_service_resource (tc->service, tc->headers, response);
 
@@ -1476,7 +1476,7 @@ test_resource_no_path (TestResourceCase *tc,
   GBytes *bytes;
 
   /* Missing path after package */
-  response = cockpit_web_response_new (tc->io, "/cockpit/another@localhost", NULL);
+  response = cockpit_web_response_new (tc->io, "/cockpit/another@localhost", NULL, NULL);
 
   cockpit_web_service_resource (tc->service, tc->headers, response);
 
@@ -1508,7 +1508,7 @@ test_resource_failure (TestResourceCase *tc,
 
   cockpit_expect_message ("*: failed to retrieve resource: terminated");
 
-  response = cockpit_web_response_new (tc->io, "/cockpit/another/test.html", NULL);
+  response = cockpit_web_response_new (tc->io, "/cockpit/another/test.html", NULL, NULL);
 
   /* Now kill the bridge */
   g_assert (cockpit_pipe_get_pid (tc->pipe, &pid));
@@ -1541,7 +1541,8 @@ test_resource_checksum (TestResourceCase *tc,
   GError *error = NULL;
   GBytes *bytes;
 
-  response = cockpit_web_response_new (tc->io, "/cockpit/$fec489a692ee808950f34f6c519803aed65e1849/sub/file.ext", NULL);
+  response = cockpit_web_response_new (tc->io, "/cockpit/$fec489a692ee808950f34f6c519803aed65e1849/sub/file.ext",
+                                       NULL, NULL);
   cockpit_web_service_resource (tc->service, tc->headers, response);
 
   while (cockpit_web_response_get_state (response) != COCKPIT_WEB_RESPONSE_SENT)
@@ -1573,7 +1574,7 @@ test_resource_no_checksum (TestResourceCase *tc,
   GBytes *bytes;
 
   /* Missing checksum */
-  response = cockpit_web_response_new (tc->io, "/cockpit/", NULL);
+  response = cockpit_web_response_new (tc->io, "/cockpit/", NULL, NULL);
 
   cockpit_web_service_resource (tc->service, tc->headers, response);
 
@@ -1602,7 +1603,7 @@ test_resource_bad_checksum (TestResourceCase *tc,
   GBytes *bytes;
 
   /* Missing checksum */
-  response = cockpit_web_response_new (tc->io, "/cockpit/09323094823029348/path", NULL);
+  response = cockpit_web_response_new (tc->io, "/cockpit/09323094823029348/path", NULL, NULL);
 
   cockpit_web_service_resource (tc->service, tc->headers, response);
 
@@ -1630,7 +1631,7 @@ test_resource_accept_language (TestResourceCase *tc,
   GError *error = NULL;
   GBytes *bytes;
 
-  response = cockpit_web_response_new (tc->io, "/cockpit/another/test.html", NULL);
+  response = cockpit_web_response_new (tc->io, "/cockpit/another/test.html", NULL, NULL);
 
   g_hash_table_insert (tc->headers, g_strdup ("Accept-Language"), g_strdup ("pig;q=0.1,de;q=0.9"));
   cockpit_web_service_resource (tc->service, tc->headers, response);
@@ -1669,7 +1670,7 @@ test_resource_override_language (TestResourceCase *tc,
   GError *error = NULL;
   GBytes *bytes;
 
-  response = cockpit_web_response_new (tc->io, "/cockpit/another/test.html", NULL);
+  response = cockpit_web_response_new (tc->io, "/cockpit/another/test.html", NULL, NULL);
 
   /* Language cookie overrides */
   g_hash_table_insert (tc->headers, g_strdup ("Accept-Language"), g_strdup ("de;q=0.9"));


### PR DESCRIPTION
So that we can use it in various handlers
