### PR TITLE
base: Fix use of Uint8Array with out the new operator

### DIFF
--- a/pkg/base/cockpit.js
+++ b/pkg/base/cockpit.js
@@ -340,7 +340,7 @@ function Transport() {
 
         /* A binary message, split out the channel */
         if (have_array_buffer && data instanceof window.ArrayBuffer) {
-            binary = window.Uint8Array(data);
+            binary = new window.Uint8Array(data);
             length = binary.length;
             for (pos = 0; pos < length; pos++) {
                 if (binary[pos] == 10) /* new line */


### PR DESCRIPTION
Get this error message:

  Uncaught TypeError: Constructor Uint8Array requires 'new'
