### PR TITLE
websocket: Fix a return value for parse failures

### DIFF
--- a/src/websocket/websocket.c
+++ b/src/websocket/websocket.c
@@ -162,7 +162,7 @@ _web_socket_util_parse_url (const gchar *url,
  * Return value: zero if truncated, negative if fails, or number of
  *               characters parsed
  */
-gsize
+gssize
 web_socket_util_parse_req_line (const gchar *data,
                                 gsize length,
                                 gchar **method,

--- a/src/websocket/websocket.h
+++ b/src/websocket/websocket.h
@@ -34,7 +34,7 @@ gssize          web_socket_util_parse_headers  (const gchar *data,
                                                 gsize length,
                                                 GHashTable **headers);
 
-gsize           web_socket_util_parse_req_line (const gchar *data,
+gssize          web_socket_util_parse_req_line (const gchar *data,
                                                 gsize length,
                                                 gchar **method,
                                                 gchar **resource);


### PR DESCRIPTION
Fix return value for web_socket_util_parse_req_line() so that
it can return negative values on parse failures.
