### PR TITLE
Faster docker console

### DIFF
--- a/pkg/docker/docker.js
+++ b/pkg/docker/docker.js
@@ -100,18 +100,19 @@ define([
         var pre = $("<pre>").addClass("logs");
         parent.append(pre);
 
-        var scroll;
+        var wait;
+        var writing = [];
         function write(data) {
-            var at_bottom = pre[0].scrollHeight - pre.scrollTop() <= pre.outerHeight();
-            var span = $("<span>").text(data);
-            pre.append(span);
-            if (!at_bottom && scroll) {
-                window.clearInterval(scroll);
-                scroll = null;
-            } else if (at_bottom && !scroll) {
-                scroll = window.setTimeout(function() {
-                    scroll = null;
-                    pre.scrollTop(pre.prop("scrollHeight"));
+            writing.push(data);
+            if (!wait) {
+                wait = window.setTimeout(function() {
+                    wait = null;
+                    var at_bottom = pre[0].scrollHeight - pre.scrollTop() <= pre.outerHeight();
+                    var span = $("<span>").text(writing.join(""));
+                    writing.length = 0;
+                    pre.append(span);
+                    if (at_bottom)
+                        pre.scrollTop(pre.prop("scrollHeight"));
                 }, 50);
             }
         }


### PR DESCRIPTION
This fixes the problems with the docker console and implements on the fly changing of channel options. 

In order to transfer large amounts of data over the docker console stream we have to batch the data, otherwise the browser is overwhelmed (livelocked would be the technical term here). But with the docker console stream we don't know how to batch and treat the stream until we have read part of it.

Add a new channel control message called 'tell' which changes the channel on the fly. Fold 'eof' into this control message as well.
