### PR TITLE
Color the left side of Server list on dashboard rather than box

### DIFF
--- a/pkg/shell/shell.css
+++ b/pkg/shell/shell.css
@@ -69,6 +69,27 @@ html, body {
     width: 28px;
 }
 
+#dashboard-hosts .list-group-item {
+    border-left-width: 7px;
+    border-left-style: solid;
+    border-top: none;
+    position: relative;
+}
+
+#dashboard-hosts .list-group-item:before {
+    content: "";
+    position: absolute;
+    border-top: 1px solid #BABABA;
+    top: 0px;
+    left: 0px;
+    right: 0px;
+    height: 1px;
+}
+
+#dashboard-hosts .list-group-item:first-child:before {
+    border-top-color: transparent;
+}
+
 #dashboard-hosts button {
     height: 28px;
     width: 28px;
@@ -102,13 +123,7 @@ html, body {
 
 #dashboard-hosts .list-group-item .host-avatar {
     float: left;
-    border-width: 2px;
-    border-style: solid;
-}
-
-/* Failed items have no border around server icon */
-#dashboard-hosts .list-group-item.failed .host-avatar {
-    border: none;
+    border-style: none;
 }
 
 #dashboard-hosts .list-group-item span {

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -153,10 +153,10 @@
       <script id="dashboard-hosts-tmpl" type="x-template/mustache">
         {{#machines}}
           {{! state can be 'failed' or 'connected' }}
-          <a data-address="{{address}}" class="list-group-item {{state}}">
+          <a data-address="{{address}}" class="list-group-item {{state}}" style="border-left-color: {{ color }};">
             <button class="btn btn-danger edit-button pficon pficon-close"></button>
             <button class="btn btn-default edit-button pficon pficon-edit"></button>
-            <img style="border-color: {{color}};" class="host-avatar" src="{{render_avatar}}">
+            <img class="host-avatar" src="{{render_avatar}}">
             <span>{{display_name}}</span>
           </a>
         {{/machines}}


### PR DESCRIPTION
Put a color band on the left side of the servers instead of a box around the icon. This looks better.
