### PR TITLE
shell: Fix dashboard plot highlighting.

### DIFF
--- a/pkg/shell/cockpit-dashboard.js
+++ b/pkg/shell/cockpit-dashboard.js
@@ -248,10 +248,11 @@ PageDashboard.prototype = {
 
         function highlight(item, val) {
             item.toggleClass("highlight", val);
-            var series = item.data("plot-series");
-            if (series) {
-                series.options.lines.lineWidth = val? 3 : 2;
-                series.move_to_front();
+            var s = series[item.data("address")];
+            if (s) {
+                s.options.lines.lineWidth = val? 3 : 2;
+                if (val)
+                    s.move_to_front();
                 self.plot.refresh();
             }
         }


### PR DESCRIPTION
- There is no "series-plot" data attribute, so find the series
  belonging to an item via the address.
- Only move the plot to the front when turning the highlight on, not
  when turning it off.
