### PR TITLE
Use a textual length when sending frames in stream

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -24,9 +24,8 @@ like cockpit-ws to know where to send messages.
 Framing
 -------
 
-The channel id is a string and ends with a newline.  It may not
-contain a newline, and must be utf8 valid. After this comes the
-channel dependent payload.
+The channel id is a UTF-8 valid string.  The channel id string comes first
+in the message, then a new line, then payload.
 
 For example if you had a payload of the string 'abc', and it was being
 sent through the channel 'a5', that might look like:
@@ -34,17 +33,15 @@ sent through the channel 'a5', that might look like:
     a5\nabc
 
 When a message is sent over a stream transport that does not have distinct
-messages (such as SSH or stdio), the message is also prefixed with a 32-bit MSB
-length in bytes of the message. The length does not include the 4 bytes
-of the length itself.
+messages (such as SSH or stdio), the message is also prefixed with a base 10
+integer and new line, which represents the length of the following message.
 
 An example. When going over a stream transport with a payload of the 3 byte
 string 'abc', and a channel of 'a5', would have a message length of 6: 3 bytes of
 payload, 2 bytes for the channel number, 1 for the new line. It would look like
-this on the wire:
+this in a stream:
 
-    |----msb length---| |----chan----| |---payload--|
-    0x00 0x00 0x00 0x06 0x61 0x35 0x0A 0x61 0x62 0x63
+    6\na5\nabc
 
 Control Messages
 ----------------

--- a/src/common/cockpitpipetransport.c
+++ b/src/common/cockpitpipetransport.c
@@ -78,26 +78,43 @@ on_pipe_read (CockpitPipe *pipe,
   GBytes *message;
   GBytes *payload;
   gchar *channel;
-  guint32 size;
+  guint32 i, size;
+  gchar *data;
 
   for (;;)
     {
-      if (input->len < sizeof (size))
+      size = 0;
+      data = (gchar *)input->data;
+      for (i = 0; i < input->len; i++)
+        {
+          /* Check invalid characters, prevent ineger overflow, limit max length */
+          if (i > 7 || data[i] < '0' || data[i] > '9')
+            break;
+          size *= 10;
+          size += data[i] - '0';
+        }
+
+      if (i == input->len)
         {
           if (!end_of_data)
             g_debug ("%s: want more data", self->name);
           break;
         }
 
-      memcpy (&size, input->data, sizeof (size));
-      size = GUINT32_FROM_BE (size);
-      if (input->len < size + sizeof (size))
+      if (data[i] != '\n')
         {
-          g_debug ("%s: want more data", self->name);
+          g_warning ("%s: incorrect protocol: received invalid length prefix", self->name);
+          cockpit_pipe_close (pipe, "protocol-error");
           break;
         }
 
-      message = cockpit_pipe_consume (input, sizeof (size), size, 0);
+      if (input->len < i + 1 + size)
+        {
+          g_debug ("%s: want more data 2", self->name);
+          break;
+        }
+
+      message = cockpit_pipe_consume (input, i + 1, size, 0);
       payload = cockpit_transport_parse_frame (message, &channel);
       if (payload)
         {
@@ -242,23 +259,22 @@ cockpit_pipe_transport_send (CockpitTransport *transport,
   CockpitPipeTransport *self = COCKPIT_PIPE_TRANSPORT (transport);
   GBytes *prefix;
   gchar *prefix_str;
-  gsize prefix_len;
-  guint32 size;
+  gsize payload_len;
+  gsize channel_len;
 
-  prefix_str = g_strdup_printf ("xxxx%s\n", channel_id ? channel_id : "");
-  prefix_len = strlen (prefix_str);
+  channel_len = channel_id ? strlen (channel_id) : 0;
+  payload_len = g_bytes_get_size (payload);
 
-  /* See doc/protocol.md */
-  size = GUINT32_TO_BE (g_bytes_get_size (payload) + prefix_len - 4);
-  memcpy (prefix_str, &size, 4);
-
-  prefix = g_bytes_new_take (prefix_str, prefix_len);
+  prefix_str = g_strdup_printf ("%" G_GSIZE_FORMAT "\n%s\n",
+                                channel_len + 1 + payload_len,
+                                channel_id ? channel_id : "");
+  prefix = g_bytes_new_take (prefix_str, strlen (prefix_str));
 
   cockpit_pipe_write (self->pipe, prefix);
   cockpit_pipe_write (self->pipe, payload);
   g_bytes_unref (prefix);
 
-  g_debug ("%s: queued %d byte payload", self->name, (int)g_bytes_get_size (payload));
+  g_debug ("%s: queued %" G_GSIZE_FORMAT " byte payload", self->name, payload_len);
 }
 
 static void

--- a/src/ws/mock-pid-cat
+++ b/src/ws/mock-pid-cat
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 # Here we send our PID as a message on channel '11x', which we happen to know will be
-# 31 bytes (or 0x1f) long. After that we echo anything sent
+# 31 bytes long. After that we echo anything sent
 
 /bin/sleep 1
-/usr/bin/printf '\x00\x00\x00\x1f11x\n{ "pid": % 16s }' $$
+/usr/bin/printf '31\n11x\n{ "pid": % 16s }' $$
 exec /bin/cat
 


### PR DESCRIPTION
When sending messages in a stream, use a textual length frame so that the result is more debuggable, loggable etc. 

Fixes #1589
