### PR TITLE
Don't complain loudly in logs ObjectManager access denied

### DIFF
--- a/src/bridge/cockpitdbuscache.c
+++ b/src/bridge/cockpitdbuscache.c
@@ -356,7 +356,8 @@ dbus_error_matches_unknown (GError *error)
 {
   gboolean ret = FALSE;
 
-  if (g_error_matches (error, G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_METHOD))
+  if (g_error_matches (error, G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_METHOD) ||
+      g_error_matches (error, G_DBUS_ERROR, G_DBUS_ERROR_ACCESS_DENIED))
     return TRUE;
 
 #if GLIB_CHECK_VERSION(2,42,0)


### PR DESCRIPTION
If access is denied when accessing a DBus service's ObjectManager
methods, or while trying to Introspect it, just treat it as if those
interfaces don't exist.

Otherwise we just fill up the log with useless stuff. When in fact
the service does not want to talk to us that way.  Debug level
message remains.
