### PR TITLE
Fix parsing of zero length base64

### DIFF
--- a/pkg/base/test-dbus.html
+++ b/pkg/base/test-dbus.html
@@ -329,6 +329,24 @@ asyncTest("with types", function() {
         });
 });
 
+asyncTest("empty base64", function() {
+    expect(3);
+
+    var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", { "bus": "session" });
+    dbus.call("/bork", "borkety.Bork", "Echo",
+              [ "" ],
+              { type: "ay" }).
+        done(function(reply, options) {
+            deepEqual(reply, [ "" ], "round trip");
+            equal(options.type, "ay", "got back type");
+        }).
+        always(function() {
+            equal(this.state(), "resolved", "finished successfuly");
+            start();
+        });
+});
+
+
 asyncTest("bad types", function() {
     expect(3);
 

--- a/pkg/base/test-echo.html
+++ b/pkg/base/test-echo.html
@@ -82,6 +82,26 @@ asyncTest("base64", function() {
     });
 });
 
+asyncTest("base64 empty", function() {
+    expect(1);
+
+    var channel = cockpit.channel({
+        "payload": "echo",
+        "binary": "base64"
+    });
+
+    var first = true;
+
+    $(channel).on("message", function(ev, payload) {
+        strictEqual(payload, "", "got the right payload");
+        $(channel).off();
+        start();
+    });
+
+    channel.send("");
+});
+
+
 asyncTest("binary", function() {
     expect(3);
 

--- a/src/bridge/cockpitchannel.c
+++ b/src/bridge/cockpitchannel.c
@@ -135,6 +135,9 @@ base64_decode (GBytes *bytes)
 
   data = g_bytes_get_data (bytes, &length);
 
+  if (length == 0)
+    return g_bytes_new_static ("", 0);
+
   /* We can use a smaller limit here, since we know the saved state is 0,
      +1 used to avoid calling g_malloc0(0), and hence returning NULL */
   decoded = g_malloc0 ((length / 4) * 3 + 3);
@@ -153,6 +156,9 @@ base64_encode (GBytes *bytes)
   gint save = 0;
 
   data = g_bytes_get_data (bytes, &length);
+
+  if (length == 0)
+    return g_bytes_new_static ("", 0);
 
   /* We can use a smaller limit here, since we know the saved state is 0,
      +1 is needed for trailing \0, also check for unlikely integer overflow */

--- a/src/websocket/websocketserver.c
+++ b/src/websocket/websocketserver.c
@@ -269,8 +269,9 @@ validate_rfc6455_websocket_key (const gchar *key)
 {
   /* The key must be 16 bytes base64 encoded */
   guchar *decoded;
-  gsize length;
-  if (strlen (key) > 1024)
+  gsize length, len;
+  len = strlen (key);
+  if (len == 0 || len > 1024)
     return FALSE;
   decoded = g_base64_decode (key, &length);
   if (!decoded)


### PR DESCRIPTION
GLib gives a warning about this, so we need to handle it before
calling the g_base64_decode_step() function.
