### PR TITLE
bridge, ws: Use "done" message instead of "eof"

### DIFF
--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -1967,7 +1967,7 @@ handle = file.watch(callback, error_callback);
       <para>Notify the channel to tune certain parameters on the fly. The <code>options</code>
         is a plain javascript object, and the contents depend on the <code>"payload"</code>
         of the channel.</para>
-      <para>One common operation is to set <code>"command"</code> to <code>"eof"</code> in the
+      <para>One common operation is to set <code>"command"</code> to <code>"done"</code> in the
         options field. To indicate that no further messages will be sent through the channel.</para>
     </refsection>
 
@@ -2007,7 +2007,7 @@ handle = file.watch(callback, error_callback);
 </programlisting>
       <para>An event triggered when the channel receives an control message in the
         middle of the flow. One particular use is when the <code>command</code> is set to
-        <code>"eof"</code> then no further messages will be received in the channel.
+        <code>"done"</code> then no further messages will be received in the channel.
         The exact form of these messages depend on the <code>"payload"</code> of the
         channel.</para>
     </refsection>

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -157,11 +157,12 @@ See below for a list of problem codes.
 
 Other fields may be present in a close message.
 
-Command: eof
-------------
 
-The "eof" command indicates that no more messages will be sent on the channel
-in the same direction as the "eof" was sent.
+Command: done
+-------------
+
+The "done" command indicates that no more messages will be sent on the channel
+in the same direction as the "done" was sent.
 
 The following fields are defined:
 
@@ -171,7 +172,7 @@ Either or both endpoints of a channel can send this message. It may only be
 sent once.
 
 After it is sent no more messages may be sent in that direction. It is an error
-to send further messages, or send another "eof" message.
+to send further messages, or send another "done" message.
 
 
 Command: options
@@ -262,7 +263,7 @@ Payload: echo
 -------------
 
 A channel opened with this payload type will send back all data that
-it receives. It sends an "eof" when it receives one.
+it receives. It sends an "done" when it receives one.
 
 
 Payload: dbus-json3
@@ -545,8 +546,8 @@ following options can be specified:
    then the environment is inherited from the cockpit-bridge.
  * "pty": Execute the command as a terminal pty.
 
-If an "eof" is sent to the bridge on this channel, then the socket and/or pipe
-input is shutdown. The channel will send an "eof" when the output of the socket
+If an "done" is sent to the bridge on this channel, then the socket and/or pipe
+input is shutdown. The channel will send an "done" when the output of the socket
 or pipe is done.
 
 Additionally, a "options" control message may be sent in this channel
@@ -636,7 +637,7 @@ fields:
    for a non-existing file is "-".
 
 It is not permitted to send data in an fsdir1 channel. This channel
-sends an "eof" when all file data was sent.
+sends an "done" when all file data was sent.
 
 Payload: fswrite1
 -----------------
@@ -653,9 +654,9 @@ The following options can be specified in the "open" control message:
    express that you expect the file to not exist, use "-" as the tag.
 
 You should write the new content to the channel as one or more
-messages.  To indicate the end of the content, send an "eof" message.
+messages.  To indicate the end of the content, send an "done" message.
 
-If you don't send any content messages before sending "eof", the file
+If you don't send any content messages before sending "done", the file
 will be removed.  To create an empty file, send at least one content
 message of length zero.
 

--- a/pkg/base/test-echo.html
+++ b/pkg/base/test-echo.html
@@ -44,7 +44,7 @@ asyncTest("basic", function() {
     var channel = cockpit.channel({ "payload": "echo" });
 
     $(channel).on("control", function(ev, options) {
-        equal(options.command, "eof", "got eof");
+        equal(options.command, "done", "got done");
         channel.close();
         $(channel).off();
         start();
@@ -52,7 +52,7 @@ asyncTest("basic", function() {
 
     $(channel).on("message", function(ev, payload) {
         strictEqual(payload, "the payload", "got the right payload");
-        channel.control({ command: "eof" });
+        channel.control({ command: "done" });
     });
 
     strictEqual(channel.binary, false, "not binary");

--- a/src/bridge/cockpitchannel.h
+++ b/src/bridge/cockpitchannel.h
@@ -62,7 +62,7 @@ struct _CockpitChannelClass
   void        (* options)     (CockpitChannel *channel,
                                JsonObject *options);
 
-  void        (* eof)         (CockpitChannel *channel);
+  void        (* done)        (CockpitChannel *channel);
 
   void        (* close)       (CockpitChannel *channel,
                                const gchar *problem);
@@ -89,7 +89,7 @@ void                cockpit_channel_send              (CockpitChannel *self,
                                                        GBytes *payload,
                                                        gboolean valid_utf8);
 
-void                cockpit_channel_eof               (CockpitChannel *self);
+void                cockpit_channel_done              (CockpitChannel *self);
 
 JsonObject *        cockpit_channel_get_options       (CockpitChannel *self);
 

--- a/src/bridge/cockpitechochannel.c
+++ b/src/bridge/cockpitechochannel.c
@@ -51,10 +51,10 @@ cockpit_echo_channel_recv (CockpitChannel *channel,
 }
 
 static void
-cockpit_echo_channel_eof (CockpitChannel *channel)
+cockpit_echo_channel_done (CockpitChannel *channel)
 {
-  g_debug ("received echo channel eof");
-  cockpit_channel_eof (channel);
+  g_debug ("received echo channel done");
+  cockpit_channel_done (channel);
 }
 
 static void
@@ -77,5 +77,5 @@ cockpit_echo_channel_class_init (CockpitEchoChannelClass *klass)
 
   channel_class->prepare = cockpit_echo_channel_prepare;
   channel_class->recv = cockpit_echo_channel_recv;
-  channel_class->eof = cockpit_echo_channel_eof;
+  channel_class->done = cockpit_echo_channel_done;
 }

--- a/src/bridge/cockpitfsread.c
+++ b/src/bridge/cockpitfsread.c
@@ -69,7 +69,7 @@ on_idle_send_block (gpointer data)
   if (payload == NULL)
     {
       self->idler = 0;
-      cockpit_channel_eof (channel);
+      cockpit_channel_done (channel);
 
       problem = NULL;
       if (self->fd >= 0 && self->start_tag)

--- a/src/bridge/cockpitfswrite.c
+++ b/src/bridge/cockpitfswrite.c
@@ -143,7 +143,7 @@ xclose (int fd)
 }
 
 static void
-cockpit_fswrite_eof (CockpitChannel *channel)
+cockpit_fswrite_done (CockpitChannel *channel)
 {
   CockpitFswrite *self = COCKPIT_FSWRITE (channel);
   const gchar *problem = NULL;
@@ -294,7 +294,7 @@ cockpit_fswrite_class_init (CockpitFswriteClass *klass)
 
   channel_class->prepare = cockpit_fswrite_prepare;
   channel_class->recv = cockpit_fswrite_recv;
-  channel_class->eof = cockpit_fswrite_eof;
+  channel_class->done = cockpit_fswrite_done;
   channel_class->close = cockpit_fswrite_close;
 }
 

--- a/src/bridge/cockpithttpstream.c
+++ b/src/bridge/cockpithttpstream.c
@@ -791,7 +791,7 @@ cockpit_http_stream_recv (CockpitChannel *channel,
 }
 
 static void
-cockpit_http_stream_eof (CockpitChannel *channel)
+cockpit_http_stream_done (CockpitChannel *channel)
 {
   CockpitHttpStream *self = COCKPIT_HTTP_STREAM (channel);
 
@@ -817,7 +817,7 @@ cockpit_http_stream_close (CockpitChannel *channel,
     {
       g_debug ("%s: relayed response", self->name);
       self->state = FINISHED;
-      cockpit_channel_eof (channel);
+      cockpit_channel_done (channel);
 
       /* Save this for another round? */
       if (self->keep_alive)
@@ -930,7 +930,7 @@ cockpit_http_stream_class_init (CockpitHttpStreamClass *klass)
 
   channel_class->prepare = cockpit_http_stream_prepare;
   channel_class->recv = cockpit_http_stream_recv;
-  channel_class->eof = cockpit_http_stream_eof;
+  channel_class->done = cockpit_http_stream_done;
   channel_class->close = cockpit_http_stream_close;
 }
 

--- a/src/bridge/cockpitstream.c
+++ b/src/bridge/cockpitstream.c
@@ -103,7 +103,7 @@ process_pipe_buffer (CockpitStream *self,
 }
 
 static void
-cockpit_stream_eof (CockpitChannel *channel)
+cockpit_stream_done (CockpitChannel *channel)
 {
   CockpitStream *self = COCKPIT_STREAM (channel);
 
@@ -237,11 +237,11 @@ on_pipe_close (CockpitPipe *pipe,
     }
 
   /*
-   * In theory we should plumb eof handling all the way through to CockpitPipe.
+   * In theory we should plumb done handling all the way through to CockpitPipe.
    * But we can do that later in a compatible way.
    */
   if (problem == NULL)
-    cockpit_channel_eof (channel);
+    cockpit_channel_done (channel);
 
   cockpit_channel_close (channel, problem);
 }
@@ -380,7 +380,7 @@ cockpit_stream_class_init (CockpitStreamClass *klass)
 
   channel_class->prepare = cockpit_stream_prepare;
   channel_class->options = cockpit_stream_options;
-  channel_class->eof = cockpit_stream_eof;
+  channel_class->done = cockpit_stream_done;
   channel_class->recv = cockpit_stream_recv;
   channel_class->close = cockpit_stream_close;
 }

--- a/src/bridge/test-fs.c
+++ b/src/bridge/test-fs.c
@@ -128,9 +128,9 @@ send_string (TestCase *tc,
 }
 
 static void
-send_eof (TestCase *tc)
+send_done (TestCase *tc)
 {
-  const gchar *message = "{ \"command\": \"eof\", \"channel\": \"1234\" }";
+  const gchar *message = "{ \"command\": \"done\", \"channel\": \"1234\" }";
   GBytes *bytes = g_bytes_new_static (message, strlen (message));
   cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), NULL, bytes);
   g_bytes_unref (bytes);
@@ -262,7 +262,7 @@ test_read_simple (TestCase *tc,
   assert_received (tc, "Hello!");
 
   control = mock_transport_pop_control (tc->transport);
-  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "eof");
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "done");
 
   control = mock_transport_pop_control (tc->transport);
   g_assert (json_object_get_member (control, "problem") == NULL);
@@ -321,7 +321,7 @@ test_read_changed (TestCase *tc,
   wait_channel_closed (tc);
 
   control = mock_transport_pop_control (tc->transport);
-  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "eof");
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "done");
 
   control = mock_transport_pop_control (tc->transport);
   g_assert_cmpstr (json_object_get_string_member (control, "problem"), ==, "change-conflict");
@@ -352,7 +352,7 @@ test_read_replaced (TestCase *tc,
   assert_received (tc, "Hello!");
 
   control = mock_transport_pop_control (tc->transport);
-  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "eof");
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "done");
 
   control = mock_transport_pop_control (tc->transport);
   g_assert (json_object_get_member (control, "problem") == NULL);
@@ -381,7 +381,7 @@ test_read_removed (TestCase *tc,
   assert_received (tc, "Hello!");
 
   control = mock_transport_pop_control (tc->transport);
-  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "eof");
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "done");
 
   control = mock_transport_pop_control (tc->transport);
   g_assert (json_object_get_member (control, "problem") == NULL);
@@ -398,7 +398,7 @@ test_write_simple (TestCase *tc,
 
   setup_fswrite_channel (tc, tc->test_path, NULL);
   send_string (tc, "Hello!");
-  send_eof (tc);
+  send_done (tc);
   close_channel (tc, NULL);
 
   wait_channel_closed (tc);
@@ -422,7 +422,7 @@ test_write_multiple (TestCase *tc,
   setup_fswrite_channel (tc, tc->test_path, NULL);
   send_string (tc, "Hel");
   send_string (tc, "lo!");
-  send_eof (tc);
+  send_done (tc);
   close_channel (tc, NULL);
 
   wait_channel_closed (tc);
@@ -446,7 +446,7 @@ test_write_remove (TestCase *tc,
   set_contents (tc->test_path, "Goodbye!");
   tag = cockpit_get_file_tag (tc->test_path);
   setup_fswrite_channel (tc, tc->test_path, tag);
-  send_eof (tc);
+  send_done (tc);
   close_channel (tc, NULL);
   g_free (tag);
 
@@ -468,7 +468,7 @@ test_write_remove_nonexistent (TestCase *tc,
   g_assert (g_file_test (tc->test_path, G_FILE_TEST_EXISTS) == FALSE);
 
   setup_fswrite_channel (tc, tc->test_path, "-");
-  send_eof (tc);
+  send_done (tc);
   close_channel (tc, NULL);
 
   wait_channel_closed (tc);
@@ -491,7 +491,7 @@ test_write_empty (TestCase *tc,
   tag = cockpit_get_file_tag (tc->test_path);
   setup_fswrite_channel (tc, tc->test_path, tag);
   send_string (tc, "");
-  send_eof (tc);
+  send_done (tc);
   close_channel (tc, NULL);
   g_free (tag);
 
@@ -516,7 +516,7 @@ test_write_denied (TestCase *tc,
 
   setup_fswrite_channel (tc, tc->test_path, NULL);
   send_string (tc, "Hello!");
-  send_eof (tc);
+  send_done (tc);
   wait_channel_closed (tc);
 
   control = mock_transport_pop_control (tc->transport);
@@ -534,7 +534,7 @@ test_write_expect_non_existent (TestCase *tc,
 
   setup_fswrite_channel (tc, tc->test_path, "-");
   send_string (tc, "Hello!");
-  send_eof (tc);
+  send_done (tc);
   close_channel (tc, NULL);
 
   wait_channel_closed (tc);
@@ -558,7 +558,7 @@ test_write_expect_non_existent_fail (TestCase *tc,
 
   setup_fswrite_channel (tc, tc->test_path, "-");
   send_string (tc, "Hello!");
-  send_eof (tc);
+  send_done (tc);
   close_channel (tc, NULL);
 
   wait_channel_closed (tc);
@@ -580,7 +580,7 @@ test_write_expect_tag (TestCase *tc,
   tag = cockpit_get_file_tag (tc->test_path);
   setup_fswrite_channel (tc, tc->test_path, tag);
   send_string (tc, "Hello!");
-  send_eof (tc);
+  send_done (tc);
   close_channel (tc, NULL);
   g_free (tag);
 
@@ -607,7 +607,7 @@ test_write_expect_tag_fail (TestCase *tc,
   setup_fswrite_channel (tc, tc->test_path, tag);
   send_string (tc, "Hello!");
   set_contents (tc->test_path, "Tschüss!");
-  send_eof (tc);
+  send_done (tc);
   close_channel (tc, NULL);
   g_free (tag);
 

--- a/src/bridge/test-stream.c
+++ b/src/bridge/test-stream.c
@@ -269,7 +269,7 @@ test_shutdown (TestCase *tc,
 
   g_assert_cmpstr (tc->channel_problem, ==, "");
   sent = mock_transport_pop_control (tc->transport);
-  expect_control_message (sent, "eof", "548", NULL);
+  expect_control_message (sent, "done", "548", NULL);
 
   sent = mock_transport_pop_control (tc->transport);
   expect_control_message (sent, "close", "548", "problem", NULL, NULL);
@@ -303,7 +303,7 @@ test_close_normal (TestCase *tc,
   g_bytes_unref (payload);
 
   control = mock_transport_pop_control (tc->transport);
-  expect_control_message (control, "eof", "548", NULL);
+  expect_control_message (control, "done", "548", NULL);
 
   control = mock_transport_pop_control (tc->transport);
   expect_control_message (control, "close", "548", "problem", NULL, NULL);
@@ -474,7 +474,7 @@ test_spawn_status (void)
     g_main_context_iteration (NULL, TRUE);
 
   control = mock_transport_pop_control (transport);
-  expect_control_message (control, "eof", "548", NULL);
+  expect_control_message (control, "done", "548", NULL);
 
   control = mock_transport_pop_control (transport);
   expect_control_message (control, "close", "548", "problem", NULL, NULL);
@@ -520,7 +520,7 @@ test_spawn_signal (void)
     g_main_context_iteration (NULL, TRUE);
 
   control = mock_transport_pop_control (transport);
-  expect_control_message (control, "eof", "548", NULL);
+  expect_control_message (control, "done", "548", NULL);
 
   control = mock_transport_pop_control (transport);
   cockpit_assert_json_eq (control, "{ \"command\": \"close\", \"channel\": \"548\","


### PR DESCRIPTION
This is clearer and makes more sense for non-stream channels

Fixes #1590
