### PR TITLE
Forward "close" control messages properly to the bridge

### DIFF
--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -1332,10 +1332,11 @@ dispatch_inbound_command (CockpitWebService *self,
             cockpit_transport_send (session->transport, NULL, payload);
         }
     }
-
-  if (channel)
+  else if (channel)
     {
-      session = cockpit_session_by_channel (&self->sessions, channel);
+      if (!session)
+        session = cockpit_session_by_channel (&self->sessions, channel);
+
       if (session)
         {
           if (!session->sent_done)


### PR DESCRIPTION
These should be forwarded as the last message of that channel. Do
the session lookup before removing the channel from the table.
