### PR TITLE
shell: jshint sometimes complains about this one

### DIFF
--- a/pkg/shell/cockpit-dashboard.js
+++ b/pkg/shell/cockpit-dashboard.js
@@ -297,6 +297,7 @@ PageDashboard.prototype = {
             var template = $("#dashboard-hosts-tmpl").html();
             Mustache.parse(template);
 
+            /* jshint validthis:true */
             function render_avatar() {
                 if (this.state == "failed")
                     return "images/server-error.png";


### PR DESCRIPTION
This is because we're using this in a case where it's not clear
that the functions are part of an object.
