### PR TITLE
Handle SSH_AUTH_AGAIN

### DIFF
--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -331,7 +331,7 @@ cockpit_ssh_authenticate (CockpitSshData *data)
                          data->logname);
               break;
             case SSH_AUTH_AGAIN:
-              g_message ("%s: server asked you to try logging in again",
+              g_message ("%s: password auth failed: server asked for retry",
                          data->logname);
               break;
             default:

--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -330,6 +330,10 @@ cockpit_ssh_authenticate (CockpitSshData *data)
               g_message ("%s: password auth worked, but server wants more authentication",
                          data->logname);
               break;
+            case SSH_AUTH_AGAIN:
+              g_message ("%s: server asked you to try logging in again",
+                         data->logname);
+              break;
             default:
               if (g_atomic_int_get (data->connecting))
                 g_message ("%s: couldn't authenticate: %s", data->logname,


### PR DESCRIPTION
Treats SSH_AUTH_AGAIN as an authentication failure
instead of an internal error. Fixes #1460