### PR TITLE
test: Update user name expectation in check-realms

### DIFF
--- a/test/check-realms
+++ b/test/check-realms
@@ -193,6 +193,6 @@ class TestKerberos(MachineCase):
                                           '--resolve', 'x0.cockpit.lan:9090:%s' % self.machine.address,
                                           'http://x0.cockpit.lan:9090/login'])
         self.assertIn("HTTP/1.1 200 OK", output)
-        self.assertIn('"admin"', output)
+        self.assertIn('"admin@cockpit.lan"', output)
 
 test_main()


### PR DESCRIPTION
With a test image created today, check-realms fails like this

```
AssertionError: '"admin"' not found in 'HTTP/1.1 401 Authentication required\r\nWWW-Authenticate: Negotiate\r\nContent-Length: 104\r\n\r\nHTTP/1.1 200 OK\r\nWWW-Authenticate: Negotiate YIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRvhR9opiCj9fpxnVJaA98H9v/7dsjrALfj4l8NwCxgau7PhFhz2gEf2IaU5YdZOZJ/s+Xwqe7B+h4KhqU5JHM8yPbIQY+uIWZ5cjop90IWqlTEaB1Jl/duC5ST3R3r/N9JQzbCgsF5+zSt9q9vK49Y\r\nSet-Cookie: cockpit=dj0yO2s9MTAwMjM0ZGI1MjRiNDJmYjY5ZjYxZGYzZjE1MjY5N2JmYTU3NDkyYzhiOTMyYzA4NzQwMDU4OTFmZjM4YzMxZA==; Path=/;  HttpOnly\r\nContent-Type: application/json\r\nContent-Length: 28\r\n\r\n{"user":"admin@cockpit.lan"}'
```

The user name now seems to be `"admin@cockpit.lan"`.

I am not sure what the right thing to do here is.  Does the code need to strip away the "@cockpit.lan" part, maybe?