### PR TITLE
Internal DBus connections and cleanup

### DIFF
--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -537,6 +537,14 @@
             immediately be <link linkend="latest-dbus-onclose">closed</link> with a
             <code>"not-authorized"</code> problem code.</para></listitem>
         </varlistentry>
+        <varlistentry>
+          <term><code>"track"</code></term>
+          <listitem><para>It is valid for a DBus service to exit, and be restarted in such a
+            way that clients continue to talk to it across the restart. Some services are not
+            written with this in mind. If the <code>"track"</code> option is set to
+            <code>true</code> then the channel will close when the service exits and/or disconnects
+            from the DBus bus.</para></listitem>
+        </varlistentry>
       </variablelist>
     </refsection>
 

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -276,12 +276,15 @@ type:
  * "bus": The DBus bus to connect to either "session" or "system",
    defaults to "system" if not present.
  * "name": A service name of the DBus service to communicate with.
+ * "track": Only talk with the first name DBus owner of the service
+   name, and close the channel when it goes away.
 
 The DBus bus name is started on the bus if it is not already running. If it
 could not be started the channel is closed with a "not-found". If the DBus
-connection closes, the channel closes with "disconnected". The channel will
-also close, without a problem, if the bus name goes away (ie: the service
-exits).
+connection closes, the channel closes with "disconnected".
+
+If "track" is set to true, then the channel will also close without a
+problem, if the bus name goes away (ie: the service exits).
 
 DBus messages are encoded as JSON objects. If an unrecognized JSON object
 is received, then the channel is closed with a "protocol-error".

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -274,8 +274,10 @@ Additional "open" command options are needed to open a channel of this
 type:
 
  * "bus": The DBus bus to connect to either "session" or "system",
-   defaults to "system" if not present.
- * "name": A service name of the DBus service to communicate with.
+   defaults to "system" if not present. If set to "internal" then this
+   channel will communicate with the internal bridge DBus connection.
+ * "name": A service name of the DBus service to communicate with. Set to
+   null if "bus" is "internal".
  * "track": Only talk with the first name DBus owner of the service
    name, and close the channel when it goes away.
 

--- a/pkg/base/test-dbus.html
+++ b/pkg/base/test-dbus.html
@@ -949,6 +949,19 @@ asyncTest("no track name", function() {
         });
 });
 
+asyncTest("internal dbus", function() {
+    expect(2);
+
+    var dbus = cockpit.dbus(null, { "bus": "internal" });
+    dbus.call("/", "org.freedesktop.DBus.Introspectable", "Introspect")
+        .done(function(resp) {
+            ok(String(resp[0]).indexOf("<node") !== -1, "introspected internal");
+        })
+        .always(function() {
+            equal(this.state(), "resolved", "called internal");
+            start();
+        });
+});
 
 QUnit.start();
 </script>

--- a/pkg/base/test-dbus.html
+++ b/pkg/base/test-dbus.html
@@ -871,6 +871,84 @@ test("watch promise recursive", function() {
     equal(typeof promise3.remove, "function", "promise3.remove()");
 });
 
+asyncTest("track name", function() {
+    expect(4);
+
+    var name = "yo.x" + new Date().getTime();
+    var released = false;
+    var gone = false;
+
+    var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", { "bus": "session" });
+    dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
+              "ClaimOtherName", [ name ])
+        .always(function() {
+            equal(this.state(), "resolved", "name claimed");
+
+            var other = cockpit.dbus(name, { "bus": "session", "track": true });
+            $(other).on("close", function(event, data) {
+                strictEqual(data.problem, undefined, "no problem");
+                gone = true;
+                if (released && gone)
+                    start();
+            });
+
+            other.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
+                       "HelloWorld", [ "test" ])
+                .always(function() {
+                    equal(this.state(), "resolved", "called on other name");
+
+                    dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
+                              "ReleaseOtherName", [ name ])
+                        .always(function() {
+                            equal(this.state(), "resolved", "name released");
+                            released = true;
+                            if (released && gone)
+                                start();
+                        });
+                });
+        });
+});
+
+asyncTest("no track name", function() {
+    expect(5);
+
+    var name = "yo.y" + new Date().getTime();
+    var gone = false;
+
+    var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", { "bus": "session" });
+    dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
+              "ClaimOtherName", [ name ])
+        .always(function() {
+            equal(this.state(), "resolved", "name claimed");
+
+            var other = cockpit.dbus(name, { "bus": "session", "track": false });
+            $(other).on("close", function(event, data) {
+                console.log(data);
+                gone = true;
+            });
+
+            other.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
+                       "HelloWorld", [ "test" ])
+                .always(function() {
+                    equal(this.state(), "resolved", "called on other name");
+
+                    dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
+                              "ReleaseOtherName", [ name ])
+                        .always(function() {
+                            equal(this.state(), "resolved", "name released");
+
+                            other.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
+                                       "HelloWorld", [ "test" ])
+                                .always(function() {
+                                    equal(this.state(), "rejected", "call after release should fail");
+                                    equal(gone, false, "is not gone");
+                                    start();
+                                });
+                        });
+                });
+        });
+});
+
 
 QUnit.start();
 </script>

--- a/pkg/shell/cockpit-main.js
+++ b/pkg/shell/cockpit-main.js
@@ -370,7 +370,7 @@ function hosts_init() {
     }
 
     function add_host(addr, proxy) {
-        var client = cockpit.dbus("com.redhat.Cockpit", { host: addr, bus: "session" });
+        var client = cockpit.dbus("com.redhat.Cockpit", { host: addr, bus: "session", track: true });
         var manager = client.proxy("com.redhat.Cockpit.Manager",
                                    "/com/redhat/Cockpit/Manager");
 
@@ -572,7 +572,7 @@ function hosts_init() {
 
     local_account_proxies = null;
 
-    var cockpitd = cockpit.dbus("com.redhat.Cockpit", { host: "localhost", bus: "session" });
+    var cockpitd = cockpit.dbus("com.redhat.Cockpit", { host: "localhost", bus: "session", track: true });
     local_account_proxies = cockpitd.proxies("com.redhat.Cockpit.Account",
                                              "/com/redhat/Cockpit/Accounts");
     host_proxies = cockpitd.proxies("com.redhat.Cockpit.Machine",

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -6,6 +6,8 @@ libcockpit_bridge_a_SOURCES = \
 	src/bridge/cockpitchannel.h \
 	src/bridge/cockpitdbuscache.c \
 	src/bridge/cockpitdbuscache.h \
+	src/bridge/cockpitdbusinternal.h \
+	src/bridge/cockpitdbusinternal.c \
 	src/bridge/cockpitdbusjson.c \
 	src/bridge/cockpitdbusjson.h \
 	src/bridge/cockpitdbusrules.c \

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -308,12 +308,10 @@ static int
 run_bridge (const gchar *interactive)
 {
   CockpitTransport *transport;
-  GDBusConnection *connection = NULL;
   gboolean terminated = FALSE;
   gboolean interupted = FALSE;
   gboolean closed = FALSE;
   CockpitSuperChannels *super = NULL;
-  GError *error = NULL;
   gpointer polkit_agent = NULL;
   GPid daemon_pid = 0;
   guint sig_term;
@@ -342,20 +340,8 @@ run_bridge (const gchar *interactive)
 
   /* Start a session daemon if necessary */
   if (!interactive)
-    {
-      daemon_pid = start_dbus_daemon ();
+    daemon_pid = start_dbus_daemon ();
 
-      connection = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &error);
-      if (connection == NULL)
-        {
-          g_message ("couldn't connect to session bus: %s", error->message);
-          g_clear_error (&error);
-        }
-      else
-        {
-          g_dbus_connection_set_exit_on_close (connection, FALSE);
-        }
-    }
 
   if (interactive)
     {
@@ -387,8 +373,6 @@ run_bridge (const gchar *interactive)
     cockpit_polkit_agent_unregister (polkit_agent);
   if (super)
     g_object_unref (super);
-  if (connection)
-    g_object_unref (connection);
   g_object_unref (transport);
   g_hash_table_destroy (channels);
 

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -19,6 +19,7 @@
 #include "config.h"
 
 #include "cockpitchannel.h"
+#include "cockpitdbusinternal.h"
 #include "cockpitinteracttransport.h"
 #include "cockpitpackage.h"
 #include "cockpitpolkitagent.h"
@@ -342,6 +343,7 @@ run_bridge (const gchar *interactive)
   if (!interactive)
     daemon_pid = start_dbus_daemon ();
 
+  cockpit_dbus_internal_startup ();
 
   if (interactive)
     {
@@ -375,6 +377,8 @@ run_bridge (const gchar *interactive)
     g_object_unref (super);
   g_object_unref (transport);
   g_hash_table_destroy (channels);
+
+  cockpit_dbus_internal_cleanup ();
 
   if (daemon_pid)
     kill (daemon_pid, SIGTERM);

--- a/src/bridge/cockpitdbuscache.c
+++ b/src/bridge/cockpitdbuscache.c
@@ -1080,10 +1080,11 @@ cockpit_dbus_cache_constructed (GObject *object)
 {
   CockpitDBusCache *self = COCKPIT_DBUS_CACHE (object);
 
-  g_return_if_fail (self->name != NULL);
   g_return_if_fail (self->connection != NULL);
 
   self->logname = self->name;
+  if (self->logname == NULL)
+    self->logname = "internal";
 
   self->subscribe_properties = g_dbus_connection_signal_subscribe (self->connection,
                                                                    self->name,

--- a/src/bridge/cockpitdbuscache.h
+++ b/src/bridge/cockpitdbuscache.h
@@ -52,8 +52,7 @@ typedef void       (* CockpitDBusBarrierFunc)              (CockpitDBusCache *ca
 GType                 cockpit_dbus_cache_get_type          (void) G_GNUC_CONST;
 
 CockpitDBusCache *    cockpit_dbus_cache_new               (GDBusConnection *connection,
-                                                            const gchar *name,
-                                                            const gchar *name_owner);
+                                                            const gchar *name);
 
 void                  cockpit_dbus_cache_barrier           (CockpitDBusCache *self,
                                                             CockpitDBusBarrierFunc callback,

--- a/src/bridge/cockpitdbusinternal.c
+++ b/src/bridge/cockpitdbusinternal.c
@@ -1,0 +1,234 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitdbusinternal.h"
+
+#include <gio/gunixinputstream.h>
+#include <gio/gunixoutputstream.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <errno.h>
+
+typedef struct {
+  GIOStream parent;
+  gint fd;
+  GInputStream *input_stream;
+  GOutputStream *output_stream;
+} UnixIOStream;
+
+typedef struct _GIOStreamClass UnixIOStreamClass;
+
+GType unix_io_stream_get_type (void);
+
+G_DEFINE_TYPE (UnixIOStream, unix_io_stream, G_TYPE_IO_STREAM)
+
+static void
+unix_io_stream_finalize (GObject *object)
+{
+  UnixIOStream *self = (UnixIOStream *)object;
+
+  /* strictly speaking we should unref these in dispose, but
+   * g_io_stream_dispose() wants them to still exist
+   */
+  g_clear_object (&self->input_stream);
+  g_clear_object (&self->output_stream);
+
+  G_OBJECT_CLASS (unix_io_stream_parent_class)->finalize (object);
+}
+
+static void
+unix_io_stream_init (UnixIOStream *stream)
+{
+}
+
+static GInputStream *
+unix_io_stream_get_input_stream (GIOStream *stream)
+{
+  UnixIOStream *self = (UnixIOStream *)stream;
+  return self->input_stream;
+}
+
+static GOutputStream *
+unix_io_stream_get_output_stream (GIOStream *stream)
+{
+  UnixIOStream *self = (UnixIOStream *)stream;
+  return self->output_stream;
+}
+
+static gboolean
+unix_io_stream_close (GIOStream *stream,
+                      GCancellable *cancellable,
+                      GError **error)
+{
+  UnixIOStream *self = (UnixIOStream *)stream;
+  gboolean ret;
+
+  ret = g_input_stream_close (self->input_stream, cancellable, error);
+  if (!g_output_stream_close (self->output_stream, cancellable, ret ? error : NULL))
+    ret = FALSE;
+
+  close (self->fd);
+  return ret;
+}
+
+static void
+unix_io_stream_close_async (GIOStream *stream,
+                            int io_priority,
+                            GCancellable *cancellable,
+                            GAsyncReadyCallback callback,
+                            gpointer user_data)
+{
+  GSimpleAsyncResult *res;
+  GError *error = NULL;
+
+  res = g_simple_async_result_new (G_OBJECT (stream), callback, user_data,
+                                   unix_io_stream_close_async);
+  if (!unix_io_stream_close (stream, cancellable, &error))
+    g_simple_async_result_take_error (res, error);
+
+  g_simple_async_result_complete_in_idle (res);
+  g_object_unref (res);
+}
+
+static gboolean
+unix_io_stream_close_finish (GIOStream *stream,
+                             GAsyncResult *result,
+                             GError **error)
+{
+  if (g_simple_async_result_propagate_error (G_SIMPLE_ASYNC_RESULT (result), error))
+    return FALSE;
+  return TRUE;
+}
+
+static void
+unix_io_stream_class_init (UnixIOStreamClass *klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  GIOStreamClass *stream_class = G_IO_STREAM_CLASS (klass);
+
+  gobject_class->finalize = unix_io_stream_finalize;
+
+  stream_class->get_input_stream  = unix_io_stream_get_input_stream;
+  stream_class->get_output_stream = unix_io_stream_get_output_stream;
+  stream_class->close_fn = unix_io_stream_close;
+  stream_class->close_async = unix_io_stream_close_async;
+  stream_class->close_finish = unix_io_stream_close_finish;
+}
+
+static GIOStream *
+unix_io_stream_new (gint fd)
+{
+  UnixIOStream *self;
+
+  self = g_object_new (unix_io_stream_get_type (), NULL);
+  self->input_stream = g_unix_input_stream_new (fd, FALSE);
+  self->output_stream = g_unix_output_stream_new (fd, FALSE);
+  self->fd = fd;
+  return G_IO_STREAM (self);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static GDBusConnection *the_server = NULL;
+static GDBusConnection *the_client = NULL;
+
+GDBusConnection *
+cockpit_dbus_internal_client (void)
+{
+  g_return_val_if_fail (the_client != NULL, NULL);
+  return g_object_ref (the_client);
+}
+
+GDBusConnection *
+cockpit_dbus_internal_server (void)
+{
+  g_return_val_if_fail (the_server != NULL, NULL);
+  return g_object_ref (the_server);
+}
+
+static void
+on_complete_get_result (GObject *source,
+                        GAsyncResult *result,
+                        gpointer user_data)
+{
+  GAsyncResult **ret = user_data;
+  g_assert (*ret == NULL);
+  *ret = g_object_ref (result);
+}
+
+void
+cockpit_dbus_internal_startup (void)
+{
+  GAsyncResult *rclient = NULL;
+  GAsyncResult *rserver = NULL;
+  GError *error = NULL;
+  GIOStream *io;
+  gchar *guid;
+  int fds[2];
+
+  if (socketpair (PF_LOCAL, SOCK_STREAM, 0, fds) < 0)
+    {
+      g_warning ("couldn't create loopback socket: %s", g_strerror (errno));
+      return;
+    }
+
+  io = unix_io_stream_new (fds[0]);
+  guid = g_dbus_generate_guid ();
+  g_dbus_connection_new (io, guid,
+                         G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_SERVER |
+                         G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_ALLOW_ANONYMOUS,
+                         NULL, NULL, on_complete_get_result, &rserver);
+  g_object_unref (io);
+
+  io = unix_io_stream_new (fds[1]);
+  g_dbus_connection_new (io, NULL, G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT,
+                         NULL, NULL, on_complete_get_result, &rclient);
+  g_object_unref (io);
+
+  while (!rserver || !rclient)
+    g_main_context_iteration (NULL, TRUE);
+
+  the_server = g_dbus_connection_new_finish (rserver, &error);
+  if (the_server == NULL)
+    {
+      g_warning ("couldn't create internal connection: %s", error->message);
+      g_clear_error (&error);
+    }
+
+  the_client = g_dbus_connection_new_finish (rclient, &error);
+  if (the_client == NULL)
+    {
+      g_warning ("couldn't create internal connection: %s", error->message);
+      g_clear_error (&error);
+    }
+
+  g_object_unref (rclient);
+  g_object_unref (rserver);
+  g_free (guid);
+}
+
+void
+cockpit_dbus_internal_cleanup (void)
+{
+  g_clear_object (&the_client);
+  g_clear_object (&the_server);
+}

--- a/src/bridge/cockpitdbusinternal.h
+++ b/src/bridge/cockpitdbusinternal.h
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __COCKPIT_DBUS_INTERNAL_H
+#define __COCKPIT_DBUS_INTERNAL_H
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+GDBusConnection *     cockpit_dbus_internal_client       (void);
+
+GDBusConnection *     cockpit_dbus_internal_server       (void);
+
+void                  cockpit_dbus_internal_startup      (void);
+
+void                  cockpit_dbus_internal_cleanup      (void);
+
+G_END_DECLS
+
+#endif /* __COCKPIT_DBUS_INTERNAL_H */

--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -1876,8 +1876,8 @@ on_bus_ready (GObject *source,
     }
   else
     {
+      /* Yup, we don't want this */
       g_dbus_connection_set_exit_on_close (self->connection, FALSE);
-
 
       flags = G_BUS_NAME_WATCHER_FLAGS_AUTO_START;
       self->name_watch = g_bus_watch_name_on_connection (self->connection,

--- a/src/common/cockpitjson.c
+++ b/src/common/cockpitjson.c
@@ -193,6 +193,32 @@ cockpit_json_get_strv (JsonObject *options,
   return valid;
 }
 
+gboolean
+cockpit_json_get_null (JsonObject *object,
+                       const gchar *member,
+                       gboolean *present)
+{
+  JsonNode *node;
+
+  node = json_object_get_member (object, member);
+  if (!node)
+    {
+      if (present)
+        *present = FALSE;
+      return TRUE;
+    }
+  else if (json_node_get_node_type (node) == JSON_NODE_NULL)
+    {
+      if (present)
+        *present = TRUE;
+      return TRUE;
+    }
+  else
+    {
+      return FALSE;
+    }
+}
+
 static gboolean
 cockpit_json_equal_object (JsonObject *previous,
                            JsonObject *current)

--- a/src/common/cockpitjson.h
+++ b/src/common/cockpitjson.h
@@ -78,6 +78,10 @@ gboolean       cockpit_json_get_array         (JsonObject *object,
                                                JsonArray *defawlt,
                                                JsonArray **value);
 
+gboolean       cockpit_json_get_null          (JsonObject *object,
+                                               const gchar *member,
+                                               gboolean *present);
+
 guint          cockpit_json_int_hash          (gconstpointer v);
 
 gboolean       cockpit_json_int_equal         (gconstpointer v1,

--- a/src/common/com.redhat.Cockpit.DBusTests.xml
+++ b/src/common/com.redhat.Cockpit.DBusTests.xml
@@ -118,6 +118,14 @@
       <arg direction="in" type="s" name="name" />
     </method>
 
+    <method name="ClaimOtherName">
+      <arg name="name" direction="in" type="s"/>
+    </method>
+
+    <method name="ReleaseOtherName">
+      <arg name="name" direction="in" type="s"/>
+    </method>
+
     <property name="y" type="y" access="readwrite"/>
     <property name="b" type="b" access="readwrite"/>
     <property name="n" type="n" access="readwrite"/>

--- a/src/common/test-json.c
+++ b/src/common/test-json.c
@@ -30,7 +30,8 @@ static const gchar *test_data =
   "   \"string\": \"value\","
   "   \"number\": 55,"
   "   \"array\": [ \"one\", \"two\", \"three\" ],"
-  "   \"bool\": true"
+  "   \"bool\": true,"
+  "   \"null\": null"
   "}";
 
 typedef struct {
@@ -121,6 +122,32 @@ test_get_bool (TestCase *tc,
   g_assert_cmpint (value, ==, FALSE);
 
   ret = cockpit_json_get_bool (tc->root, "string", FALSE, &value);
+  g_assert (ret == FALSE);
+}
+
+static void
+test_get_null (TestCase *tc,
+                 gconstpointer data)
+{
+  gboolean ret;
+  gboolean present;
+
+  ret = cockpit_json_get_null (tc->root, "null", NULL);
+  g_assert (ret == TRUE);
+
+  present = FALSE;
+  ret = cockpit_json_get_null (tc->root, "null", &present);
+  g_assert (ret == TRUE);
+  g_assert (present == TRUE);
+
+  ret = cockpit_json_get_null (tc->root, "unknown", NULL);
+  g_assert (ret == TRUE);
+
+  ret = cockpit_json_get_null (tc->root, "unknown", &present);
+  g_assert (ret == TRUE);
+  g_assert (present == FALSE);
+
+  ret = cockpit_json_get_null (tc->root, "number", NULL);
   g_assert (ret == FALSE);
 }
 
@@ -375,6 +402,8 @@ main (int argc,
               setup, test_get_int, teardown);
   g_test_add ("/json/get-bool", TestCase, NULL,
               setup, test_get_bool, teardown);
+  g_test_add ("/json/get-null", TestCase, NULL,
+              setup, test_get_null, teardown);
   g_test_add ("/json/get-strv", TestCase, NULL,
               setup, test_get_strv, teardown);
 


### PR DESCRIPTION
Allows connections directly to the cockpit-bridge without going through the session or system bus. This is essentially peer-to-peer communication.

 * Will be used for communicating with the bridge for one off tasks and system APIs without creating a whole
   new payload or control message each time. Usually read-only metadata. First use case is user information.
 * Some systems like RHEL 6 may not even have DBus installed, and we should be able to have some 
   rudimentary stone-age functionality without a session bus.

As part of this commit we also cleanup how we interact with system services and track them come and go. This is the result of discussion with Lennart and others about DBus.