### PR TITLE
Missing 'class=active' for Journal Page #1646

### DIFF
--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -72,7 +72,7 @@
             <a data-page-id="services">Services</a>
           </li>
           <li>
-            <a data-page-id="journal">Journal</a>
+            <a data-task-id="journal">Journal</a>
           </li>
           <li>
             <a data-page-id="networking">Networking</a>


### PR DESCRIPTION
Replace data-page-id to data-task-id for journal page in order to highlight "Journal Page" on dashboard