### PR TITLE
bridge: Tweak DBus cache error message to be clearer

### DIFF
--- a/src/bridge/cockpitdbuscache.c
+++ b/src/bridge/cockpitdbuscache.c
@@ -1433,8 +1433,8 @@ on_get_all_reply (GObject *source,
     {
       if (!g_cancellable_is_cancelled (self->cancellable))
         {
-          g_message ("%s: couldn't get all properties of %s at %s", self->name,
-                     gad->iface->name, gad->path);
+          g_message ("%s: couldn't get all properties of %s at %s: %s", self->name,
+                     gad->iface->name, gad->path, error->message);
         }
       g_error_free (error);
     }


### PR DESCRIPTION
Include the underlying cause in the message