### PR TITLE
base: Fix HttpError.toString() to not include 'undefined'

### DIFF
--- a/pkg/base/cockpit.js
+++ b/pkg/base/cockpit.js
@@ -2265,7 +2265,7 @@ function full_scope(cockpit, $) {
                 return this.status;
         };
         this.toString = function() {
-            if (this.status === 0)
+            if (!this.status)
                 return this.problem;
             else
                 return this.status + " " + this.message;


### PR DESCRIPTION
We should just include the status when it is set.