### PR TITLE
test: Use a fixed mapping from MAC to IP

### DIFF
--- a/test/check-networking
+++ b/test/check-networking
@@ -57,7 +57,7 @@ class TestNetworking(MachineCase):
         # Add interface, wait for it to be recognized and activated by
         # Network Manager, and switch to its page
 
-        mac = "52:54:00:9e:00:ff"
+        mac = "52:54:00:9e:00:f1"
         label = "test"
         m.execute("echo -e 'TYPE=Ethernet\nHWADDR=%s\nBOOTPROTO=dhcp\n' >/etc/sysconfig/network-scripts/ifcfg-%s" % (mac, label))
         m.execute("nmcli c reload")

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -533,7 +533,7 @@ class QemuMachine(Machine):
                 return macaddr
             raise Failure("Mac address %s is in use" % macaddr)
         else:
-            for i in range(0, 0xFF):
+            for i in range(0, 0x0F):
                 macaddr = "%s:%02x" % (self.macaddr_prefix, i)
                 if self._lock_resource(macaddr):
                     return macaddr

--- a/test/vm-prep
+++ b/test/vm-prep
@@ -51,7 +51,23 @@ cat > $xml << EOF
 	<domain name='cockpit.lan'/>
 	<ip address='10.111.111.200' netmask='255.255.255.0'>
 		<dhcp>
-			<range start='10.111.111.1' end='10.111.111.99' />
+                        <host mac='52:54:00:9e:00:00' ip='10.111.111.10'   name='m10.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:01' ip='10.111.111.11'   name='m11.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:02' ip='10.111.111.12'   name='m12.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:03' ip='10.111.111.13'   name='m13.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:04' ip='10.111.111.14'   name='m14.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:05' ip='10.111.111.15'   name='m15.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:06' ip='10.111.111.16'   name='m16.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:07' ip='10.111.111.17'   name='m17.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:08' ip='10.111.111.18'   name='m18.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:09' ip='10.111.111.19'   name='m19.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:0a' ip='10.111.111.20'   name='m20.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:0b' ip='10.111.111.21'   name='m21.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:0c' ip='10.111.111.22'   name='m22.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:0d' ip='10.111.111.23'   name='m23.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:0e' ip='10.111.111.24'   name='m24.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:0f' ip='10.111.111.25'   name='m25.cockpit.lan'/>
+
                         <host mac='52:54:00:9e:00:F0' ip='10.111.111.100' name='f0.cockpit.lan'/>
                         <host mac='52:54:00:9e:00:F1' ip='10.111.111.101' name='f1.cockpit.lan'/>
                         <host mac='52:54:00:9e:00:F2' ip='10.111.111.102' name='f2.cockpit.lan'/>


### PR DESCRIPTION
This helps avoid DHCPNAK replies which some versions of
NetworkManager/dhclient don't seem to handle well.

Without this, this pattern can be observed when running tests in
parallel:

    DHCPDISCOVER(cockpit0)                 52:54:00:9e:00:02
    DHCPOFFER(cockpit0)    10.111.111.47   52:54:00:9e:00:02
    DHCPDISCOVER(cockpit0)                 52:54:00:9e:00:04
    DHCPOFFER(cockpit0)    10.111.111.47   52:54:00:9e:00:04
    DHCPDISCOVER(cockpit0)                 52:54:00:9e:00:01
    DHCPOFFER(cockpit0)    10.111.111.47   52:54:00:9e:00:01
    DHCPREQUEST(cockpit0)  10.111.111.47   52:54:00:9e:00:04
    DHCPACK(cockpit0)      10.111.111.47   52:54:00:9e:00:04
    DHCPREQUEST(cockpit0)  10.111.111.47   52:54:00:9e:00:02
    DHCPNAK(cockpit0)      10.111.111.47   52:54:00:9e:00:02 address in use
    DHCPREQUEST(cockpit0)  10.111.111.47   52:54:00:9e:00:01
    DHCPNAK(cockpit0)      10.111.111.47   52:54:00:9e:00:01 address in use
    DHCPREQUEST(cockpit0)  10.111.111.47   52:54:00:9e:00:01
    DHCPNAK(cockpit0)      10.111.111.47   52:54:00:9e:00:01 address in use
    DHCPDISCOVER(cockpit0)                 52:54:00:9e:00:03

That is, the dhcp server offers the same IP to multiple machines, but
only one succeeds when requesting it.