### PR TITLE
test: Wait for container exit only after it has started.

### DIFF
--- a/test/check-docker
+++ b/test/check-docker
@@ -88,9 +88,9 @@ class TestDocker(MachineCase):
 
         # Make sure after restart we only have one
         b.click("#container-details-start")
-        b.wait_in_text("#container-details-state", "Exited")
         b.wait_in_text("#container-terminal", "Hello from container-probe.\nHello from container-probe.")
         b.call_js_func("ph_count_check", ".logs",  1)
+        b.wait_in_text("#container-details-state", "Exited")
 
         # Delete container
         b.click("#container-details-delete")


### PR DESCRIPTION
Otherwise we might find the exit status of the previous run and then
try to delete it too soon.

(Ideally, we should wait for the delete button to become sensitive...)