### PR TITLE
Metrics Archives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ compiler:
 before_install:
   - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
   - sudo apt-get update -qq
-  - sudo apt-get install automake autoconf intltool xsltproc libglib2.0-dev libgudev-1.0-dev libpolkit-gobject-1-dev libpolkit-agent-1-dev phantomjs gtk-doc-tools libjson-glib-dev libnm-glib-dev libaccountsservice-dev libpam0g-dev libssh-dev libsystemd-daemon-dev libsystemd-journal-dev libudisks2-dev libjson-perl libjavascript-minifier-xs-perl pkg-config glib-networking valgrind libkeyutils-dev xmlto xsltproc libpcp3-dev libpcp-pmda3-dev pcp
+  - sudo apt-get install automake autoconf intltool xsltproc libglib2.0-dev libgudev-1.0-dev libpolkit-gobject-1-dev libpolkit-agent-1-dev phantomjs gtk-doc-tools libjson-glib-dev libnm-glib-dev libaccountsservice-dev libpam0g-dev libssh-dev libsystemd-daemon-dev libsystemd-journal-dev libudisks2-dev libjson-perl libjavascript-minifier-xs-perl pkg-config glib-networking valgrind libkeyutils-dev xmlto xsltproc libpcp3-dev libpcp-pmda3-dev libpcp-import1-dev pcp
 
 script:
   - ./autogen.sh --prefix=/usr --enable-strict && make V=1 all && sudo make enable-root-tests && make distcheck && make -j8 check-memory

--- a/Makefile.am
+++ b/Makefile.am
@@ -137,6 +137,7 @@ install-test-assets: $(testassets_programs) $(testassets_data) $(testassets_syst
 clean-local:
 	find $(builddir) -name '*.gc??' -delete
 	find $(srcdir) -name '*.pyc' -delete
+	rm -rf mock-archives
 
 uninstall-local:: uninstall-doc-local
 	@true

--- a/configure.ac
+++ b/configure.ac
@@ -248,7 +248,7 @@ if test "x$GCC" = "xyes"; then
           -Werror=implicit-function-declaration \
           -Werror=pointer-arith -Werror=init-self \
           -Werror=format-security \
-          -Werror=missing-include-dirs -Werror=aggregate-return $CFLAGS"
+          -Werror=missing-include-dirs $CFLAGS"
 fi
 changequote([,])dnl
 

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -689,14 +689,15 @@ In addition to monitoring live values of the metrics, you can also
 access archives of previously recorded values.
 
 You specify which metrics to monitor in the options of the "open"
-command for a new channel.  If some of the metrics are not available,
-or their attributes do not match what you have specified, the channel
-will close with an error.
+command for a new channel.
 
 One of the options is the "source" of the metrics.  Many details of
 how to specify metrics and how the channel will work in detail depend
 on the type of the source, and are explained in specific sections
 below.
+
+The channel guarantees that each sample returned by it contains values
+for all requested metrics.
 
 The general open options are:
 
@@ -706,6 +707,20 @@ The general open options are:
      Cockpit bridge directly.  Use this when in doubt.
 
    * "pcmd": PCP metrics from the local PCP daemon.
+
+   * A string starting with "/": PCP metrics from one or more
+     archives.
+
+     The string is either the name of an archive, or the name of a
+     directory.  When it refers to a directory, the bridge will find
+     all archives in that directory and merge them.  The archives must
+     not overlap in time.
+
+   * "pcp-archive": PCP metrics from the default pmlogger archive.
+
+     This is the same as using the name of the default pmlogger
+     archive directory directly, but you don't have to know where it
+     is.
 
  * "metrics" (array): Descriptions of the metrics to use.  The exact
    format and semantics depend on the source.  See the specific
@@ -720,6 +735,21 @@ The general open options are:
 
  * "interval" (number, optional): The sample interval in milliseconds.
    Defaults to 1000.
+
+ * "timestamp" (number, optional): The desired time of the first
+   sample.  This is only used when accessing archives of samples.
+
+   This is either the number of milliseconds since the epoch, or (when
+   negative) the number of milliseconds in the past.
+
+   The first sample will be from a time not earlier than this
+   timestamp, but it might be from a much later time.
+
+ * "limit" (number, optional): The number of samples to return.  This
+   is only used when accessing an archive.
+
+   When no "limit" is specified, all samples until the end of the
+   archive are delivered.
 
 Once the channel is open, it will send messages encoded as JSON.  It
 will send two types of message: 'meta' messages that describe the

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -111,6 +111,24 @@
     <div id="content">
 
       <div id="dashboard" class="container-fluid" hidden>
+        <div class="btn-toolbar">
+          <div class="btn-group" id="dashboard-range-buttons">
+            <button class="btn btn-default" data-seconds="604800">7d</button>
+            <button class="btn btn-default" data-seconds="86400">24h</button>
+            <button class="btn btn-default" data-seconds="43200">12h</button>
+            <button class="btn btn-default" data-seconds="21600">6h</button>
+            <button class="btn btn-default" data-seconds="10800">3h</button>
+            <button class="btn btn-default" data-seconds="3600">1h</button>
+            <button class="btn btn-default" data-seconds="1800">30min</button>
+            <button class="btn btn-default" data-seconds="300">5min</button>
+          </div>
+          <div class="btn-group">
+            <button class="btn btn-default" id="dashboard-scroll-left">&lt;</button>
+            <button class="btn btn-default" id="dashboard-scroll-right">&gt;</button>
+          </div>
+        </div>
+        <br>
+        <br>
         <div class="row">
           <div class="col-md-12">
             <ul class="nav nav-tabs">

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -108,6 +108,7 @@ BRIDGE_CHECKS = \
 	test-fs \
 	test-metrics \
 	test-pcp \
+	test-pcp-archives \
 	test-httpstream \
 	$(NULL)
 
@@ -175,6 +176,12 @@ test_pcp_SOURCES = \
 	src/bridge/mock-transport.c src/bridge/mock-transport.h
 test_pcp_CFLAGS = $(libcockpit_bridge_a_CFLAGS)
 test_pcp_LDADD = $(libcockpit_bridge_LIBS) -ldl
+
+test_pcp_archives_SOURCES = \
+	src/bridge/test-pcp-archives.c \
+	src/bridge/mock-transport.c src/bridge/mock-transport.h
+test_pcp_archives_CFLAGS = $(libcockpit_bridge_a_CFLAGS)
+test_pcp_archives_LDADD = $(libcockpit_bridge_LIBS) -ldl -lpcp_import
 
 test_httpstream_SOURCES = \
 	src/bridge/test-httpstream.c \

--- a/src/bridge/cockpitpcpmetrics.c
+++ b/src/bridge/cockpitpcpmetrics.c
@@ -112,16 +112,23 @@ build_meta (CockpitPcpMetrics *self,
   JsonArray *instances;
   JsonObject *root;
   pmValueSet *vs;
-  gint64 timestamp;
+  struct timeval now_timeval;
+  gint64 timestamp, now;
   char *instance;
   int i, j;
   int rc;
 
+  gettimeofday (&now_timeval, NULL);
+
   timestamp = (result->timestamp.tv_sec * 1000) +
               (result->timestamp.tv_usec / 1000);
 
+  now = (now_timeval.tv_sec * 1000) +
+        (now_timeval.tv_usec / 1000);
+
   root = json_object_new ();
   json_object_set_int_member (root, "timestamp", timestamp);
+  json_object_set_int_member (root, "now", now);
   json_object_set_int_member (root, "interval", self->interval);
 
   metrics = json_array_new ();

--- a/src/bridge/cockpitpcpmetrics.c
+++ b/src/bridge/cockpitpcpmetrics.c
@@ -136,7 +136,7 @@ build_meta (CockpitPcpMetrics *self,
       /* Instances
        */
       vs = result->vset[i];
-      if (vs->numval < 0 || (vs->numval == 1 && vs->vlist[0].inst == PM_IN_NULL))
+      if (vs->numval < 0 || self->metrics[i].desc.indom == PM_INDOM_NULL)
         {
           /* When negative numval is an error code ... we don't care */
         }
@@ -342,7 +342,7 @@ build_samples (CockpitPcpMetrics *self,
       /* When negative numval is an error code ... we don't care */
       if (vs->numval < 0)
         json_array_add_null_element (output);
-      else if (vs->numval == 1 && vs->vlist[0].inst == PM_IN_NULL)
+      else if (self->metrics[i].desc.indom == PM_INDOM_NULL)
         json_array_add_element (output, build_sample (self, result, i, 0));
       else
         {

--- a/src/bridge/test-pcp-archives.c
+++ b/src/bridge/test-pcp-archives.c
@@ -1,0 +1,373 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitmetrics.h"
+#include "mock-transport.h"
+
+#include "common/cockpittest.h"
+#include "common/cockpitjson.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <sys/stat.h>
+
+#include <pcp/pmapi.h>
+#include <pcp/impl.h>
+#include <pcp/import.h>
+
+static void
+init_mock_archives (void)
+{
+  g_assert (system ("rm -rf mock-archives && mkdir mock-archives") == 0);
+
+  g_assert (pmiStart ("mock-archives/0", 0) >= 0);
+  g_assert (pmiAddMetric ("mock.value", PM_ID_NULL,
+                          PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+                          pmiUnits (0, 0, 0, 0, 0, 0)) >= 0);
+  g_assert (pmiPutValue ("mock.value", NULL, "10") >= 0);
+  g_assert (pmiWrite (0, 0) >= 0);
+  g_assert (pmiPutValue ("mock.value", NULL, "11") >= 0);
+  g_assert (pmiWrite (1, 0) >= 0);
+  g_assert (pmiPutValue ("mock.value", NULL, "12") >= 0);
+  g_assert (pmiWrite (2, 0) >= 0);
+  g_assert (pmiEnd () >= 0);
+
+  g_assert (pmiStart ("mock-archives/1", 0) >= 0);
+  g_assert (pmiAddMetric ("mock.value", PM_ID_NULL,
+                          PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+                          pmiUnits (0, 0, 0, 0, 0, 0)) >= 0);
+  g_assert (pmiAddMetric ("mock.late", PM_ID_NULL,
+                          PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
+                          pmiUnits (0, 0, 0, 0, 0, 0)) >= 0);
+  g_assert (pmiPutValue ("mock.value", NULL, "13") >= 0);
+  g_assert (pmiPutValue ("mock.late", NULL, "30") >= 0);
+  g_assert (pmiWrite (3, 0) >= 0);
+  g_assert (pmiPutValue ("mock.value", NULL, "14") >= 0);
+  g_assert (pmiPutValue ("mock.late", NULL, "31") >= 0);
+  g_assert (pmiWrite (4, 0) >= 0);
+  g_assert (pmiPutValue ("mock.value", NULL, "15") >= 0);
+  g_assert (pmiPutValue ("mock.late", NULL, "32") >= 0);
+  g_assert (pmiWrite (5, 0) >= 0);
+  g_assert (pmiEnd () >= 0);
+}
+
+typedef struct AtTeardown {
+  struct AtTeardown *link;
+  void (*func) (void *);
+  void *data;
+} AtTeardown;
+
+typedef struct {
+  MockTransport *transport;
+  CockpitChannel *channel;
+  gchar *problem;
+  gboolean channel_closed;
+
+  AtTeardown *at_teardown;
+} TestCase;
+
+static void
+on_channel_close (CockpitChannel *channel,
+                  const gchar *problem,
+                  gpointer user_data)
+{
+  TestCase *tc = user_data;
+  g_assert (tc->channel_closed == FALSE);
+  tc->problem = g_strdup (problem);
+  tc->channel_closed = TRUE;
+}
+
+static void
+on_transport_closed (CockpitTransport *transport,
+                     const gchar *problem,
+                     gpointer user_data)
+{
+  g_assert_not_reached ();
+}
+
+static void
+setup (TestCase *tc,
+       gconstpointer data)
+{
+  tc->transport = mock_transport_new ();
+  g_signal_connect (tc->transport, "closed", G_CALLBACK (on_transport_closed), NULL);
+  tc->channel = NULL;
+  tc->at_teardown = NULL;
+}
+
+static void
+at_teardown (TestCase *tc, void *func, void *data)
+{
+  AtTeardown *item = g_new0 (AtTeardown, 1);
+
+  item->func = func;
+  item->data = data;
+  item->link = tc->at_teardown;
+  tc->at_teardown = item;
+}
+
+static void
+setup_metrics_channel_json (TestCase *tc, JsonObject *options)
+{
+  tc->channel = cockpit_metrics_open (COCKPIT_TRANSPORT (tc->transport), "1234", options);
+  tc->channel_closed = FALSE;
+  g_signal_connect (tc->channel, "closed", G_CALLBACK (on_channel_close), tc);
+  cockpit_channel_prepare (tc->channel);
+}
+
+static GBytes *
+recv_bytes (TestCase *tc)
+{
+  GBytes *msg;
+  while ((msg = mock_transport_pop_channel (tc->transport, "1234")) == NULL)
+    g_main_context_iteration (NULL, TRUE);
+  return msg;
+}
+
+static JsonObject *
+recv_json_object (TestCase *tc)
+{
+  GBytes *msg = recv_bytes (tc);
+  JsonObject *res = cockpit_json_parse_bytes (msg, NULL);
+  g_assert (res != NULL);
+  at_teardown (tc, json_object_unref, res);
+  return res;
+}
+
+static JsonNode *
+recv_json (TestCase *tc)
+{
+  GBytes *msg = recv_bytes (tc);
+  gsize length = g_bytes_get_size (msg);
+  JsonNode *res = cockpit_json_parse (g_bytes_get_data (msg, NULL), length, NULL);
+  g_assert (res != NULL);
+  at_teardown (tc, json_node_free, res);
+  return res;
+}
+
+static void
+teardown (TestCase *tc,
+          gconstpointer data)
+{
+  cockpit_assert_expected ();
+
+  g_object_unref (tc->transport);
+
+  if (tc->channel)
+    {
+      g_object_add_weak_pointer (G_OBJECT (tc->channel), (gpointer *)&tc->channel);
+      g_object_unref (tc->channel);
+      g_assert (tc->channel == NULL);
+    }
+
+  while (tc->at_teardown)
+    {
+      AtTeardown *item = tc->at_teardown;
+      tc->at_teardown = item->link;
+      item->func (item->data);
+      g_free (item);
+    }
+
+  g_free (tc->problem);
+}
+
+static JsonObject *
+json_obj (const gchar *str)
+{
+  GError *error = NULL;
+  JsonObject *res = cockpit_json_parse_object (str, -1, &error);
+  g_assert_no_error (error);
+  return res;
+}
+
+static void
+assert_sample_msg (const char *domain,
+                   const char *file,
+                   int line,
+                   const char *func,
+                   TestCase *tc,
+                   const gchar *json_str)
+{
+  JsonNode *node = recv_json (tc);
+  g_assert_cmpint (json_node_get_node_type (node), ==, JSON_NODE_ARRAY);
+  _cockpit_assert_json_eq_msg (domain, file, line, func, json_node_get_array (node), json_str);
+}
+
+#define assert_sample(tc, json) \
+  (assert_sample_msg (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, (tc), (json)))
+
+static void
+test_metrics_single_archive (TestCase *tc,
+                             gconstpointer unused)
+{
+  JsonObject *options = json_obj("{ 'source': '" BUILDDIR "/mock-archives/0',"
+                                 "  'metrics': [ { 'name': 'mock.value' } ],"
+                                 "  'interval': 1000"
+                                 "}");
+
+  setup_metrics_channel_json (tc, options);
+
+  JsonObject *meta = recv_json_object (tc);
+  cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
+                          "[ { 'name': 'mock.value', 'type': 'number', 'units': '', 'semantics': 'instant' } ]");
+
+  assert_sample (tc, "[[10],[11],[12]]");
+
+  json_object_unref (options);
+}
+
+static void
+test_metrics_archive_limit (TestCase *tc,
+                            gconstpointer unused)
+{
+  JsonObject *options = json_obj("{ 'source': '" BUILDDIR "/mock-archives/0',"
+                                 "  'metrics': [ { 'name': 'mock.value' } ],"
+                                 "  'interval': 1000,"
+                                 "  'limit': 2"
+                                 "}");
+
+  setup_metrics_channel_json (tc, options);
+
+  JsonObject *meta = recv_json_object (tc);
+  cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
+                          "[ { 'name': 'mock.value', 'type': 'number', 'units': '', 'semantics': 'instant' } ]");
+
+  assert_sample (tc, "[[10],[11]]");
+
+  json_object_unref (options);
+}
+
+static void
+test_metrics_archive_timestamp (TestCase *tc,
+                                gconstpointer unused)
+{
+  JsonObject *options = json_obj("{ 'source': '" BUILDDIR "/mock-archives/0',"
+                                 "  'metrics': [ { 'name': 'mock.value' } ],"
+                                 "  'interval': 1000,"
+                                 "  'timestamp': 1000"
+                                 "}");
+
+  setup_metrics_channel_json (tc, options);
+
+  JsonObject *meta = recv_json_object (tc);
+  cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
+                          "[ { 'name': 'mock.value', 'type': 'number', 'units': '', 'semantics': 'instant' } ]");
+
+  assert_sample (tc, "[[11],[12]]");
+
+  json_object_unref (options);
+}
+
+static void
+test_metrics_archive_directory (TestCase *tc,
+                                gconstpointer unused)
+{
+  JsonObject *meta;
+  JsonObject *options = json_obj("{ 'source': '" BUILDDIR "/mock-archives',"
+                                 "  'metrics': [ { 'name': 'mock.value' } ],"
+                                 "  'interval': 1000"
+                                 "}");
+
+  setup_metrics_channel_json (tc, options);
+
+  meta = recv_json_object (tc);
+  cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
+                          "[ { 'name': 'mock.value', 'type': 'number', 'units': '', 'semantics': 'instant' } ]");
+  assert_sample (tc, "[[10],[11],[12]]");
+
+  meta = recv_json_object (tc);
+  cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
+                          "[ { 'name': 'mock.value', 'type': 'number', 'units': '', 'semantics': 'instant' } ]");
+  assert_sample (tc, "[[13],[14],[15]]");
+
+  json_object_unref (options);
+}
+
+static void
+test_metrics_archive_directory_timestamp (TestCase *tc,
+                                          gconstpointer unused)
+{
+  JsonObject *meta;
+  JsonObject *options = json_obj("{ 'source': '" BUILDDIR "/mock-archives',"
+                                 "  'metrics': [ { 'name': 'mock.value' } ],"
+                                 "  'interval': 1000,"
+                                 "  'timestamp': 4000"
+                                 "}");
+
+  setup_metrics_channel_json (tc, options);
+
+  meta = recv_json_object (tc);
+  cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
+                          "[ { 'name': 'mock.value', 'type': 'number', 'units': '', 'semantics': 'instant' } ]");
+  assert_sample (tc, "[[14],[15]]");
+
+  json_object_unref (options);
+}
+
+static void
+test_metrics_archive_directory_late_metric (TestCase *tc,
+                                            gconstpointer unused)
+{
+  cockpit_expect_warning ("*no such metric: mock.late (Unknown metric name)*");
+
+  JsonObject *meta;
+  JsonObject *options = json_obj("{ 'source': '" BUILDDIR "/mock-archives',"
+                                 "  'metrics': [ { 'name': 'mock.late' } ],"
+                                 "  'interval': 1000"
+                                 "}");
+
+  setup_metrics_channel_json (tc, options);
+
+  meta = recv_json_object (tc);
+  cockpit_assert_json_eq (json_object_get_array_member (meta, "metrics"),
+                          "[ { 'name': 'mock.late', 'type': 'number', 'units': '', 'semantics': 'instant' } ]");
+  assert_sample (tc, "[[30],[31],[32]]");
+
+  json_object_unref (options);
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+  cockpit_test_init (&argc, &argv);
+
+  if (chdir (BUILDDIR) < 0)
+    g_assert_not_reached ();
+
+  init_mock_archives ();
+
+  g_test_add ("/metrics/single-archive", TestCase, NULL,
+              setup, test_metrics_single_archive, teardown);
+  g_test_add ("/metrics/archive-limit", TestCase, NULL,
+              setup, test_metrics_archive_limit, teardown);
+  g_test_add ("/metrics/archive-timestamp", TestCase, NULL,
+              setup, test_metrics_archive_timestamp, teardown);
+  g_test_add ("/metrics/archive-directory", TestCase, NULL,
+              setup, test_metrics_archive_directory, teardown);
+  g_test_add ("/metrics/archive-directory-timestamp", TestCase, NULL,
+              setup, test_metrics_archive_directory_timestamp, teardown);
+  g_test_add ("/metrics/archive-directory-late-metric", TestCase, NULL,
+              setup, test_metrics_archive_directory_late_metric, teardown);
+
+  return g_test_run ();
+}

--- a/tools/pcp.supp
+++ b/tools/pcp.supp
@@ -8,3 +8,13 @@
    fun:pmGetConfig
    ...
 }
+{
+   pcp_interp_hash_leak: http://oss.sgi.com/bugzilla/show_bug.cgi?id=1057
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   fun:__pmHashAdd
+   fun:__pmLogFetchInterp
+   fun:__pmLogFetch
+   ...
+}


### PR DESCRIPTION
Followup pull requests:

- Use metrics channels for other plots
- Scrolling/zooming
- Config UI for the logger

Instructions:

Create `/var/lib/pcp/config/pmlogconf/tools/cockpit` with this content:

```
#pmlogconf-setup 2.0
ident   Metrics used by Cockpit
force   include
        kernel.all.cpu.nice
        kernel.all.cpu.user
        kernel.all.cpu.sys
        mem.util.used
        network.interface.total.bytes
        disk.dev.total_bytes
```

Run this command:

```
/usr/libexec/pcp/bin/pmlogconf /var/lib/pcp/config/pmlogger/config.default
```

and hold down the Return key for about 10 seconds until the shell prompt reappers.  Check that the cockpit metrics have been added.

Start (or restart) pmlogger:

```
systemctl enable pmcd
systemctl enable pmlogger
systemctl start pmcd
systemctl start pmlogger
```

