### PR TITLE
bridge: The "environ" of a "spawn" channel adds to environment

### DIFF
--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -253,8 +253,9 @@
         </varlistentry>
         <varlistentry>
           <term><code>"environ"</code></term>
-          <listitem><para>A javascript plain object that contains strings to be used as
-            an environment for the new process.</para></listitem>
+          <listitem><para>An optional array that contains strings to be used as
+            additional environment variables for the new process. These are
+            <code>"NAME=VALUE"</code> strings.</para></listitem>
         </varlistentry>
         <varlistentry>
           <term><code>"pty"</code></term>

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -543,8 +543,9 @@ following options can be specified:
  * "error": If "spawn" is set, and "error" is set to "output", then stderr
    is included in the payload data. If "pty" is set then stderr is always
    included.
- * "environ": This is the environment for the new spawned process. If unset,
-   then the environment is inherited from the cockpit-bridge.
+ * "environ": This is a list of additional environment variables for the new
+   spawned process. The variables are in the form of "NAME=VALUE". The default
+   environment is inherited from cockpit-bridge.
  * "pty": Execute the command as a terminal pty.
 
 If an "done" is sent to the bridge on this channel, then the socket and/or pipe


### PR DESCRIPTION
Rather than replacing the environment, which is almost never useful
the "environ" option of a "spawn" channel adds to the environment.

If one really wants to clear the environment, one can use /usr/bin/env
to do so.