### PR TITLE
terminal: Show terminal title in the upper left

### DIFF
--- a/pkg/server-systemd/terminal.html
+++ b/pkg/server-systemd/terminal.html
@@ -65,6 +65,10 @@ require([
             if (channel && channel.valid)
                 channel.send(data);
         });
+
+        term.on('title', function(title) {
+            $("#terminal-title").text(title);
+        });
     }
 
     function show() {
@@ -89,9 +93,7 @@ require([
 <body style="display: none;">
     <div class="panel panel-default console-container">
         <div class="panel-heading">
-            <span translatable="yes">
-                Terminal
-            </span>
+            <tt id="terminal-title" translatable="yes">Terminal</tt>
             <button id="terminal-reset" class="btn btn-default pull-right" translatable="yes">Reset</button>
         </div>
         <div id="terminal" class="console">

--- a/test/check-terminal
+++ b/test/check-terminal
@@ -51,6 +51,9 @@ class TestTerminal(MachineCase):
         b.key_press([ 'e', 'c', 'h', 'o', ' ',  'ä', 'ö', 'ü', 'Return' ])
         wait_line(4, u'äöü')
 
+        # The '@' sign is in the default prompt
+        b.wait_in_text("#terminal-title", '@')
+
     def testReset(self):
         b = self.browser;
         m = self.machine;


### PR DESCRIPTION
This replaces the 'Terminal' string. The terminal title is usually
the current working directory along with login info, however the
running process can change it. In gnome-terminal you see this as
the window titlebar.