### PR TITLE
Docker: fix publish ports on start, add test case

### DIFF
--- a/pkg/shell/cockpit-docker.js
+++ b/pkg/shell/cockpit-docker.js
@@ -1743,10 +1743,15 @@ function DockerClient(machine) {
     /* Actually connect initially */
     perform_connect();
 
-    this.start = function start(id) {
+    this.start = function start(id, options) {
         waiting(id);
         docker_debug("starting:", id);
-        return http.post("/v1.10/containers/" + encodeURIComponent(id) + "/start")
+        return http.request({
+                method: "POST",
+                path: "/v1.10/containers/" + encodeURIComponent(id) + "/start",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(options || { })
+            })
             .fail(function(ex) {
                 docker_debug("start failed:", id, ex);
             })

--- a/test/check-docker
+++ b/test/check-docker
@@ -105,6 +105,56 @@ class TestDocker(MachineCase):
         self.confirm()
         b.wait_page("containers")
 
+    def testExpose(self):
+        b = self.browser
+        m = self.machine
+        self.allow_journal_messages('.*denied.*name_connect.*docker.*')
+
+        m.execute("systemctl start docker.socket")
+        m.execute("usermod -G wheel,docker admin")
+
+        self.login_and_go("containers")
+
+        port = 3380;
+
+        # Import the container-probe image and wait for it to appear
+        m.upload(["container-probe.tar.gz"], "/var/tmp/container-probe.tar.gz")
+        m.execute("docker import - test/container-probe </var/tmp/container-probe.tar.gz")
+        b.wait_in_text("#containers-images", "container-probe")
+
+        # Create an updated image, expose a port
+        m.execute("mkdir /var/tmp/container-probe2")
+        m.execute("""echo -e '
+FROM test/container-probe
+MAINTAINER cockpit
+EXPOSE %d
+CMD ["/bin/container-probe", "%d"]
+' > /var/tmp/container-probe2/Dockerfile""" % (port, port))
+        m.execute("docker build -t test/container-probe2 /var/tmp/container-probe2");
+
+        # Wait for it to appear
+        b.wait_in_text("#containers-images", "container-probe2")
+
+        # Run it
+        b.click('#containers-images tr:contains("container-probe2") button.btn-play')
+        b.wait_popup("containers_run_image_dialog")
+        b.set_val("#containers-run-image-name", "PROBE2")
+        b.set_val(".port-map input", port)
+        b.click("#containers-run-image-run");
+        b.wait_popdown("containers_run_image_dialog")
+        b.wait_in_text("#containers-containers", "PROBE2")
+
+        # Check output of the probe
+        b.click('#containers-containers tr:contains("PROBE2")')
+        b.wait_page("container-details")
+        b.wait_in_text("#container-terminal", "Hello from container-probe.")
+        b.wait_in_text("#container-details-ports", "0.0.0.0:%d -> %d/tcp" % (port, port))
+
+        # Check connection on port
+        expected_message = "Sending messages"
+        data = m.execute("exec 3<>/dev/tcp/localhost/%d; cat <&3" % (port))
+        check_eq(data, expected_message)
+
     def testFailure(self):
         b = self.browser
         m = self.machine

--- a/test/container-probe.c
+++ b/test/container-probe.c
@@ -1,7 +1,89 @@
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <errno.h>
+
+void
+error(const char *msg)
+{
+  perror (msg);
+  exit (1);
+}
+
+const char *message_to_send = "Sending messages";
+
+void
+listen_on_port (int port)
+{
+  int sock_fd, new_sock_fd;
+  socklen_t cli_len;
+  struct sockaddr_in serv_addr, cli_addr;
+  int bytes_written;
+  int message_length = strlen(message_to_send);
+
+  sock_fd = socket (AF_INET, SOCK_STREAM, 0);
+  if (sock_fd < 0)
+    error("ERROR while opening socket");
+
+  bzero ((char *) &serv_addr, sizeof (serv_addr));
+  serv_addr.sin_family = AF_INET;
+  serv_addr.sin_addr.s_addr = INADDR_ANY;
+  serv_addr.sin_port = htons (port);
+
+  if (bind (sock_fd, (struct sockaddr *) &serv_addr, sizeof (serv_addr)) < 0)
+    error("ERROR on binding");
+  listen (sock_fd,5);
+
+  cli_len = sizeof (cli_addr);
+
+  new_sock_fd = accept (sock_fd, (struct sockaddr *) &cli_addr, &cli_len);
+  if (new_sock_fd < 0)
+    error("ERROR on accept");
+
+  bytes_written = 0;
+  while (bytes_written < message_length)
+    {
+      int ret = write (new_sock_fd, message_to_send + bytes_written, message_length - bytes_written);
+      if (ret < 0)
+        {
+          if (errno == EINTR || errno == EAGAIN)
+            continue;
+          error("ERROR while writing to socket");
+          break;
+        }
+      bytes_written += ret;
+    }
+
+  if (bytes_written < message_length)
+    error("ERROR while writing to socket");
+
+  close (new_sock_fd);
+  close (sock_fd);
+}
+
+/* optional arguments: ports on which to wait for a connection and send a message
+ * ports will be served consecutively in the order they are passed
+ */
 
 int
 main (int argc, char **argv)
 {
+  int arg_index;
   printf ("Hello from container-probe.\n");
+  for (arg_index = 1; arg_index < argc; ++arg_index)
+    {
+      char *pEnd;
+      int port = (int) strtol(argv[arg_index], &pEnd, 10);
+      if (port != 0)
+        {
+          printf ("Waiting for connection on port %i.\n", port);
+          listen_on_port (port);
+        }
+    }
+  return 0;
 }
+


### PR DESCRIPTION
pass options to docker API when starting a container
container-probe listens on sockets and prints message
fixes #1685