### PR TITLE
ws: Assert that test fixture isn't null

### DIFF
--- a/src/ws/test-sshtransport.c
+++ b/src/ws/test-sshtransport.c
@@ -145,6 +145,8 @@ setup_transport (TestCase *tc,
                  gconstpointer data)
 {
   const TestFixture *fixture = data;
+  g_assert_nonnull(fixture);
+
   const gchar *password = fixture->client_password ? fixture->client_password : PASSWORD;
   CockpitCreds *creds;
   const gchar *known_hosts;
@@ -175,12 +177,9 @@ setup_transport (TestCase *tc,
   if (!command)
     command = "cat";
 
-  if (fixture)
-    {
-      if (fixture->expect_key)
-        expect_knownhosts = g_strdup_printf ("[127.0.0.1]:%d %s", (int)tc->ssh_port, fixture->expect_key);
-      ignore_key = fixture->ignore_key;
-    }
+    if (fixture->expect_key)
+      expect_knownhosts = g_strdup_printf ("[127.0.0.1]:%d %s", (int)tc->ssh_port, fixture->expect_key);
+    ignore_key = fixture->ignore_key;
 
   tc->transport = g_object_new (COCKPIT_TYPE_SSH_TRANSPORT,
                                 "host", "127.0.0.1",


### PR DESCRIPTION
Removes inconsistent if checks, suggested by coverity.