### PR TITLE
bridge: Minor PCP metrics fixes

### DIFF
--- a/src/bridge/cockpitpcpmetrics.c
+++ b/src/bridge/cockpitpcpmetrics.c
@@ -1096,8 +1096,8 @@ my_pmParseUnitsStr(const char *str, pmUnits *out, double *multiplier)
                                               [PM_TIME_MIN]  = 60,
                                               [PM_TIME_HOUR] = 3600 };
         // guaranteed by __pmParseUnitsStrPart; ensure in-range array access
-        assert (dividend.scaleTime >= PM_TIME_NSEC && dividend.scaleTime <= PM_TIME_HOUR);
-        assert (divisor.scaleTime >= PM_TIME_NSEC && divisor.scaleTime <= PM_TIME_HOUR);
+        assert (dividend.scaleTime <= PM_TIME_HOUR);
+        assert (divisor.scaleTime <= PM_TIME_HOUR);
         *multiplier *= pow (time_scales[dividend.scaleTime], -(double)dividend.dimTime);
         *multiplier *= pow (time_scales[divisor.scaleTime], (double)divisor.dimTime);
         if (out->dimTime == 0) // became dimensionless?

--- a/src/bridge/mock-pmda.c
+++ b/src/bridge/mock-pmda.c
@@ -168,6 +168,7 @@ mock_control (const char *cmd, ...)
       int val = va_arg (ap, int);
       counter64 += val;
     }
+  va_end(ap);
 }
 
 void


### PR DESCRIPTION
* Don't assert >= 0 for unsigned integers since it will always be true
* use va_end in mock

Suggested by coverity