### PR TITLE
test: Remove "--progress" option in check-verify

### DIFF
--- a/test/check-verify
+++ b/test/check-verify
@@ -22,7 +22,7 @@ LANG=C
 export LANG
 
 if which "parallel" >/dev/null 2>/dev/null; then
-  RUNNER="parallel --gnu --progress -j ${TEST_JOBS:-1}"
+  RUNNER="parallel --gnu -j ${TEST_JOBS:-1}"
 else
   RUNNER="sh -e"
 fi


### PR DESCRIPTION
Otherwise we get a lot of noise in the testing logs.