### PR TITLE
common: Disable as much GIO module loading as possible in tests

### DIFF
--- a/src/common/cockpittest.c
+++ b/src/common/cockpittest.c
@@ -175,6 +175,10 @@ cockpit_test_init (int *argc,
 
   signal (SIGPIPE, SIG_IGN);
 
+  g_setenv ("GIO_USE_VFS", "local", TRUE);
+  g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
+  g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
+
   g_type_init ();
 
   if (*argc > 0)


### PR DESCRIPTION
We disable this in all our other processes, do it in the tests
too.