### PR TITLE
docker: Allow deleting containers from lists

### DIFF
--- a/pkg/shell/shell.css
+++ b/pkg/shell/shell.css
@@ -365,16 +365,34 @@ ul.available-interfaces-group {
     width: 10%;
 }
 
+#image-details-containers .cell-buttons,
+#image-details-containers .table > tbody > tr > .cell-buttons,
 #containers .cell-buttons,
 #containers .table > tbody > tr > .cell-buttons {
-    width: auto;
+    padding-left: 4px;
+    padding-bottom: 4px;
+    padding-top: 4px;
+    padding-right: 15px;
+    text-align: right;
+    width: 44px;
 }
 
+#image-details-containers .cell-buttons button,
+#image-details-containers .table > tbody > tr > .cell-buttons button,
 #containers .cell-buttons button,
 #containers .table > tbody > tr > .cell-buttons button {
-    position: absolute;
-    right: 30px;
+    max-width: 26px;
+    max-height: 26px;
 }
+
+#image-details-containers .container-col-danger,
+#image-details-containers .table > tbody > tr > .container-col-danger,
+#containers .container-col-danger,
+#containers .table > tbody > tr > .container-col-danger {
+    padding-right: 4px;
+    width: 34px;
+}
+
 
 /*
  * The oops status in the navbar, used when an unhandled exception

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -792,7 +792,8 @@
                   <th class="container-col-cpu">CPU</th>
                   <th class="container-col-memory-graph">Memory</th>
                   <th class="container-col-memory-text"></th>
-                  <th class="cell-buttons"><!-- Action --></th>
+                  <th class="container-col-danger cell-buttons"><button class="btn btn-default btn-control fa fa-check enable-danger" ></button></th>
+                  <th class="container-col-actions cell-buttons"><!-- Action --></th>
                 </tr>
               </thead>
               <tbody>
@@ -978,7 +979,8 @@
                 <th class="container-col-cpu">CPU</th>
                 <th class="container-col-memory-graph">Memory</th>
                 <th class="container-col-memory-text"></th>
-                <th class="cell-buttons"><!-- Action --></th>
+                <th class="container-col-danger cell-buttons"><button class="btn btn-default btn-control fa fa-check enable-danger"></button></th>
+                <th class="container-col-actions cell-buttons"><!-- Action --></th>
               </tr>
             </thead>
             <tbody>

--- a/test/check-docker
+++ b/test/check-docker
@@ -56,6 +56,23 @@ class TestDocker(MachineCase):
         b.wait_popdown("containers_run_image_dialog")
         b.wait_in_text("#containers-containers", "PROBE")
 
+        # delete it.
+        b.wait_in_text('#containers-containers tbody tr:last', "PROBE")
+        b.call_js_func("ph_has_attr", "#containers-containers tbody tr:last button.btn-delete", "disabled",  "true")
+        b.click("#containers-containers button.enable-danger")
+        b.call_js_func("ph_has_attr", "#containers-containers tbody tr:last button.btn-delete", "disabled",  "false")
+        b.click("#containers-containers tbody tr:last button.btn-delete")
+        b.wait_js_func('!ph_is_present', "#containers-containers tbody tr")
+
+        # Start it again
+        b.click('#containers-images tr:contains("container-probe") button.btn-play')
+        b.wait_popup("containers_run_image_dialog")
+        b.set_val("#containers-run-image-name", "PROBE")
+        b.set_val("#containers-run-image-command", "/bin/container-probe")
+        b.click("#containers-run-image-run");
+        b.wait_popdown("containers_run_image_dialog")
+        b.wait_in_text("#containers-containers", "PROBE")
+
         # Check output of the probe
         b.click('#containers-containers tr:contains("PROBE")')
         b.wait_page("container-details")


### PR DESCRIPTION
I implemented the 2nd design even though adding another column changed quite a few things layout wise. I don't know why the buttons were absolutely positioned before changing that made this easier but it's possible that was needed for something and this breaks it. I also added the same styles to the container list on the images page. That had a very different style, i'm not sure if it was missed or intentional. One other thing to note, deleting a running container will error, we could force it if everything thinks that isn't ok.