### PR TITLE
base: Locale operates globally for an entire document

### DIFF
--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -1463,34 +1463,40 @@
       <ulink url="https://www.gnu.org/software/gettext/"><code>gettext()</code></ulink> like
       API for easy translation of strings.</para>
 
+    <refsection id="latest-locale-language">
+      <title>cockpit.language</title>
+      <para>The current locale language code. This is set based on the
+        <link linkend="latest-locale-locale"><code>cockpit.locale()</code></link> data loaded.</para>
+    </refsection>
+
     <refsection id="latest-locale-locale">
       <title>cockpit.locale()</title>
 <programlisting>
- locale = cockpit.locale(po, [translate])
+ cockpit.locale(po)
 </programlisting>
 
       <para>Load locale information for a given <code>po</code> data. The data should
         be JSON data in the <ulink url="https://www.npmjs.org/package/po2json">po2json</ulink>
-        format. If <code>translate</code> is set to <code>true</code> then the
-        document will be scanned for translatable tags and they will be translated according
-        to the strings in <code>po</code>.</para>
+        format. The data will be loaded globally. If <code>po</code> data has already been
+        loaded, then this will extend that loaded data with additional strings. Any identical
+        translations strings will be replaced with the new strings.</para>
 
-      <para>The returned object has various methods below, in particular the
-        <link linkend="latest-locale-gettext"><code>locale.gettext()</code></link> function
-        can be used to translate strings.</para>
+      <para>Various methods such as
+        <link linkend="latest-locale-gettext"><code>cockpit.gettext()</code></link> make use
+        of the loaded data.</para>
     </refsection>
 
     <refsection id="latest-locale-gettext">
-      <title>locale.gettext()</title>
+      <title>cockpit.gettext()</title>
 <programlisting>
- translated = locale.gettext([context], string)
- var _ = locale.gettext
- var C_ = locale.gettext
+ translated = cockpit.gettext([context], string)
+ var _ = cockpit.gettext
+ var C_ = cockpit.gettext
  translated = _("string")
  translated = C_("context", "string")
 </programlisting>
 
-      <para>Lookup <code>string</code> for translation in the bundle. The translated string will
+      <para>Lookup <code>string</code> for translation in the loaded locale data. The translated string will
         be returned, or <code>string</code> will be returned if no such translated string is
         present. The <code>context</code> argument is an optional string used to qualify the
         string.</para>
@@ -1500,20 +1506,21 @@
     </refsection>
 
     <refsection id="latest-locale-noop">
-      <title>locale.noop()</title>
+      <title>cockpit.noop()</title>
 <programlisting>
-  var N_ = locale.noop
-  var NC_ = locale.noop
+  var N_ = cockpit.noop
+  var NC_ = cockpit.noop
 </programlisting>
 
       <para>A noop function suitable for assigning to <code>N_</code> or <code>NC_</code> so that
-        gettext scanners will be able to find translatable strings.</para>
+        gettext scanners will be able to find translatable strings. More specifically this function
+        returns its last argument.</para>
     </refsection>
 
     <refsection id="latest-locale-ngettext">
-      <title>locale.ngettext()</title>
+      <title>cockpit.ngettext()</title>
 <programlisting>
- translated = locale.ngettext([context], string1, stringN, number)
+ translated = cockpit.ngettext([context], string1, stringN, number)
 </programlisting>
 
       <para>Lookup a string appropriate for a pluralization form of the <code>number</code>.
@@ -1524,6 +1531,18 @@
 
       <para>The <code>context</code> argument is an optional string used to qualify the string.</para>
     </refsection>
+
+    <refsection id="latest-locale-translate">
+      <title>cockpit.translate()</title>
+<programlisting>
+ cockpit.translate([sel])
+</programlisting>
+
+      <para>The document will be scanned for translatable tags and they will be translated according
+        to the strings in loaded locale data. If <code>sel</code> is specified, this should be a jQuery
+        selector for the specific part of the document to translate.</para>
+    </refsection>
+
   </refsection>
 
   <refsection>

--- a/pkg/base/test-locale.html
+++ b/pkg/base/test-locale.html
@@ -56,16 +56,19 @@ test("public api", function() {
 });
 
 test("gettext", function() {
-    var loc = cockpit.locale(pig_latin);
-    equal(loc.lang, "pig", "correct lang");
-    equal(loc.gettext("Marmalade"), "Armalademay", "returned translation");
-    equal(loc.gettext("explain", "Marmalade"), "ArmaladeMAY", "with context");
-    equal(loc.gettext("Blah"), "Blah", "english default");
-    equal(loc.gettext("explain", "Blah"), "Blah", "english default context");
+    cockpit.locale(null); /* clear it */
+    cockpit.locale(pig_latin);
+    equal(cockpit.language, "pig", "correct lang");
+    equal(cockpit.gettext("Marmalade"), "Armalademay", "returned translation");
+    equal(cockpit.gettext("explain", "Marmalade"), "ArmaladeMAY", "with context");
+    equal(cockpit.gettext("Blah"), "Blah", "english default");
+    equal(cockpit.gettext("explain", "Blah"), "Blah", "english default context");
 });
 
 test("underscore", function() {
-    var _ = cockpit.locale(pig_latin).gettext;
+    cockpit.locale(null); /* clear it */
+    cockpit.locale(pig_latin);
+    var _ = cockpit.gettext;
     var C_ = _;
     equal(_("Marmalade"), "Armalademay", "returned translation");
     equal(_("Blah"), "Blah", "english default");
@@ -74,27 +77,29 @@ test("underscore", function() {
 });
 
 test("ngettext simple", function() {
-    var loc = cockpit.locale(pig_latin);
-    equal(loc.ngettext("$0 bucket", "$0 buckets", 0), "$0 ucketsbay", "zero things");
-    equal(loc.ngettext("$0 bucket", "$0 buckets", 1), "$0 ucketbay", "one thing");
-    equal(loc.ngettext("$0 bucket", "$0 buckets", 5), "$0 ucketsbay", "multiple things");
-    equal(loc.ngettext("explain", "$0 bucket", "$0 buckets", 0), "$0 ucketsBAY", "zero things context");
-    equal(loc.ngettext("explain", "$0 bucket", "$0 buckets", 1), "$0 ucketBAY", "one thing context");
-    equal(loc.ngettext("explain", "$0 bucket", "$0 buckets", 5), "$0 ucketsBAY", "multiple things context");
-    equal(loc.ngettext("$0 mop", "$0 mops", 1), "$0 mop", "default one");
-    equal(loc.ngettext("$0 mop", "$0 mops", 2), "$0 mops", "default multiple");
-    equal(loc.ngettext("explain", "$0 mop", "$0 mops", 1), "$0 mop", "default one context");
-    equal(loc.ngettext("explain", "$0 mop", "$0 mops", 2), "$0 mops", "default multiple context");
+    cockpit.locale(null); /* clear it */
+    cockpit.locale(pig_latin);
+    equal(cockpit.ngettext("$0 bucket", "$0 buckets", 0), "$0 ucketsbay", "zero things");
+    equal(cockpit.ngettext("$0 bucket", "$0 buckets", 1), "$0 ucketbay", "one thing");
+    equal(cockpit.ngettext("$0 bucket", "$0 buckets", 5), "$0 ucketsbay", "multiple things");
+    equal(cockpit.ngettext("explain", "$0 bucket", "$0 buckets", 0), "$0 ucketsBAY", "zero things context");
+    equal(cockpit.ngettext("explain", "$0 bucket", "$0 buckets", 1), "$0 ucketBAY", "one thing context");
+    equal(cockpit.ngettext("explain", "$0 bucket", "$0 buckets", 5), "$0 ucketsBAY", "multiple things context");
+    equal(cockpit.ngettext("$0 mop", "$0 mops", 1), "$0 mop", "default one");
+    equal(cockpit.ngettext("$0 mop", "$0 mops", 2), "$0 mops", "default multiple");
+    equal(cockpit.ngettext("explain", "$0 mop", "$0 mops", 1), "$0 mop", "default one context");
+    equal(cockpit.ngettext("explain", "$0 mop", "$0 mops", 2), "$0 mops", "default multiple context");
 });
 
 test("ngettext complex", function() {
-    var loc = cockpit.locale(ru);
-    equal(loc.ngettext("$0 bit", "$0 bits", 0), "$0 бит", "zero things");
-    equal(loc.ngettext("$0 bit", "$0 bits", 1), "$0 бит", "one thing");
-    equal(loc.ngettext("$0 bit", "$0 bits", 5), "$0 бит", "multiple things");
-    equal(loc.ngettext("$0 bit", "$0 bits", 23), "$0 бита", "genitive singular");
-    equal(loc.ngettext("$0 mop", "$0 mops", 1), "$0 mop", "default one");
-    equal(loc.ngettext("$0 mop", "$0 mops", 2), "$0 mops", "default multiple");
+    cockpit.locale(null); /* clear it */
+    cockpit.locale(ru);
+    equal(cockpit.ngettext("$0 bit", "$0 bits", 0), "$0 бит", "zero things");
+    equal(cockpit.ngettext("$0 bit", "$0 bits", 1), "$0 бит", "one thing");
+    equal(cockpit.ngettext("$0 bit", "$0 bits", 5), "$0 бит", "multiple things");
+    equal(cockpit.ngettext("$0 bit", "$0 bits", 23), "$0 бита", "genitive singular");
+    equal(cockpit.ngettext("$0 mop", "$0 mops", 1), "$0 mop", "default one");
+    equal(cockpit.ngettext("$0 mop", "$0 mops", 2), "$0 mops", "default multiple");
 });
 
 QUnit.start();

--- a/pkg/kubernetes/kubernetes.js
+++ b/pkg/kubernetes/kubernetes.js
@@ -24,7 +24,8 @@ define([
 ], function($, cockpit, po) {
     "use strict";
 
-    var _ = cockpit.locale(po).gettext;
+    cockpit.locale(po);
+    var _ = cockpit.gettext;
 
     var kubernetes = { };
 

--- a/pkg/kubernetes/tool.html
+++ b/pkg/kubernetes/tool.html
@@ -11,12 +11,11 @@ require([
     "jquery",
     "latest/cockpit",
     "latest/mustache",
-    "kubernetes/kubernetes",
-    "latest/po"
-], function($, cockpit, Mustache, kubernetes, po) {
+    "kubernetes/kubernetes"
+], function($, cockpit, Mustache, kubernetes) {
     var client = kubernetes.k8client();
     var etcdclient = kubernetes.etcdclient();
-    var _ = cockpit.locale(po).gettext;
+    var _ = cockpit.gettext;
 
     function view_renderer() {
         var template = $("#kubernetes-view-tmpl").html();

--- a/pkg/playground/test.html
+++ b/pkg/playground/test.html
@@ -43,9 +43,9 @@ require([
     'latest/cockpit',
     'playground/po'
 ], function($, cockpit, po) {
-    var loc = cockpit.locale(po);
-    var _ = loc.gettext;
-    var C_ = loc.gettext;
+    cockpit.locale(po);
+    var _ = cockpit.gettext;
+    var C_ = cockpit.gettext;
 
     $("#translation").text(_("Translation"));
     $("#reverse").text(C_("reverse", "Translation"));

--- a/pkg/server-systemd/log.html
+++ b/pkg/server-systemd/log.html
@@ -14,7 +14,9 @@ require([
     "server-systemd/server",
     "latest/po"
 ], function($, cockpit, server, po) {
-    var _ = cockpit.locale(po, true).gettext;
+    cockpit.locale(po);
+    cockpit.translate();
+    var _ = cockpit.gettext;
 
     var filler;
 

--- a/pkg/server-systemd/server.js
+++ b/pkg/server-systemd/server.js
@@ -18,14 +18,12 @@
  */
 define([
     "jquery",
-    "latest/cockpit",
-    "latest/po"
-], function($, cockpit, po) {
+    "latest/cockpit"
+], function($, cockpit) {
     "use strict";
 
-    var locale = cockpit.locale(po, false);
-    var _ = locale.gettext;
-    var C_ = locale.gettext;
+    var _ = cockpit.gettext;
+    var C_ = cockpit.gettext;
 
     var server = { };
 

--- a/pkg/server-systemd/terminal.html
+++ b/pkg/server-systemd/terminal.html
@@ -17,7 +17,9 @@ require([
     "latest/term",
     "latest/po"
 ], function($, cockpit, Terminal, po) {
-    var _ = cockpit.locale(po, true).gettext;
+    cockpit.locale(po);
+    cockpit.translate();
+    var _ = cockpit.gettext;
 
     var term = null;
     var channel = null;

--- a/pkg/shell/cockpit-language.js
+++ b/pkg/shell/cockpit-language.js
@@ -48,7 +48,7 @@ PageDisplayLanguageDialog.prototype = {
                 $.each(pkg.manifest.linguas, function(i, code) {
                     var name = names[code] || code;
                     var $el = $("<option>").text(name).val(code);
-                    if (code == shell.language_code)
+                    if (code == cockpit.language)
                         $el.attr("selected", "true");
                     $("#display-language-list").append($el);
                 });

--- a/pkg/shell/cockpit-main.js
+++ b/pkg/shell/cockpit-main.js
@@ -19,11 +19,6 @@
 
 /* MAIN
 
-   - shell.language_code
-
-   Information about the selected display language.  'language_code'
-   contains the symbol identifying the language, such as "de" or "fi".
-
    - client = shell.dbus(address, [options])
    - client.release()
 
@@ -51,7 +46,6 @@ var modules = modules ||  { };
 
 (function($, cockpit, shell, modules) {
 
-shell.language_code = null;
 shell.pages = [];
 shell.dialogs = [];
 
@@ -93,9 +87,8 @@ function init() {
  * But we still want to know the language code, so load the locale po
  */
 
-var locale = cockpit.locale({ }, false);
 require(["latest/po"], function(po) {
-    shell.language_code = (po[""] ? po[""]["language"] : null);
+    cockpit.locale(po);
 });
 shell.i18n = function i18n(string, context) {
     return string;


### PR DESCRIPTION
This is much more like what actuall GNU gettext() does.

 * PO data only need to be loaded by the document
 * Multiple PO files can be loaded and combined (think plugins)
 * Other code can use the loaded translations via cockpit.gettext()
 * Translating the current page is explicit, because only the page
   knowns when all translations have been loaded.