### PR TITLE
shell: Remove straggler link for jQuery flot

### DIFF
--- a/pkg/shell/Makefile.am
+++ b/pkg/shell/Makefile.am
@@ -36,7 +36,6 @@ shell_DATA = \
 	shell.js \
 	shell.min.js \
 	pkg/shell/attrchange.js \
-	pkg/shell/jquery-flot.js \
 	pkg/shell/shell.css \
 	pkg/shell/shell.html \
 	pkg/shell/shell.min.html \

--- a/pkg/shell/jquery-flot.js
+++ b/pkg/shell/jquery-flot.js
@@ -1,1 +1,0 @@
-../../lib/jquery-flot.v0.7.js


### PR DESCRIPTION
This has been loaded in the main jQuery bundle for a while now.