### PR TITLE
shell: Catch up with docker changes

### DIFF
--- a/pkg/docker/docker.js
+++ b/pkg/docker/docker.js
@@ -204,6 +204,7 @@ define([
             channel = cockpit.channel({
                 "payload": "stream",
                 "unix": "/var/run/docker.sock",
+                "superuser": true,
                 "binary": true
             });
 

--- a/pkg/shell/cockpit-docker.js
+++ b/pkg/shell/cockpit-docker.js
@@ -314,7 +314,7 @@ function setup_for_failure(page, client, address) {
     });
 
     $('#containers-failure-start').on('click.failure', function () {
-        cockpit.spawn([ "systemctl", "start", "docker.socket" ], { "host": address, "superuser": true }).
+        cockpit.spawn([ "systemctl", "start", "docker" ], { "host": address, "superuser": true }).
             done(function () {
                 client.close();
                 client.connect().
@@ -1803,7 +1803,7 @@ function DockerClient(machine) {
     function perform_connect() {
         got_failure = false;
         connected = $.Deferred();
-        http = cockpit.http("/var/run/docker.sock");
+        http = cockpit.http("/var/run/docker.sock", { superuser: true });
 
         connect_events();
 

--- a/src/bridge/cockpitsuperchannels.c
+++ b/src/bridge/cockpitsuperchannels.c
@@ -263,7 +263,7 @@ on_transport_control (CockpitTransport *transport,
       return TRUE;
     }
 
-  if (g_str_equal (command, "close") && channel)
+  if (channel)
     {
       if (self->channels && g_hash_table_lookup (self->channels, channel))
         {

--- a/test/check-dashboard
+++ b/test/check-dashboard
@@ -195,6 +195,9 @@ class TestDashboard(MachineCase):
 
         # Create some users on m1 and m2.
 
+        m1.execute("groupadd docker")
+        m2.execute("groupadd docker")
+
         m1.execute("useradd junior -G docker")
         m1.execute("echo foobar | passwd --stdin junior")
 

--- a/test/check-docker
+++ b/test/check-docker
@@ -37,8 +37,7 @@ class TestDocker(MachineCase):
                                     '.*denied.*create.*name="key\\.json".*',
                                     '.*denied.*write open.*path="/\\.docker/key\\.json".*')
 
-        m.execute("systemctl start docker.socket")
-        m.execute("usermod -G wheel,docker admin")
+        m.execute("systemctl start docker")
 
         self.login_and_go("containers")
 
@@ -128,8 +127,7 @@ class TestDocker(MachineCase):
         m = self.machine
         self.allow_journal_messages('.*denied.*name_connect.*docker.*')
 
-        m.execute("systemctl start docker.socket")
-        m.execute("usermod -G wheel,docker admin")
+        m.execute("systemctl start docker")
 
         self.login_and_go("containers")
 
@@ -228,34 +226,28 @@ CMD ["/bin/container-probe", "%d"]
         m = self.machine
 
         # Make sure Docker isn't running and go to the containers page
-        # as "admin".
+        # as "admin" without the "wheel" group.
+        m.execute("systemctl stop docker")
+        m.execute("usermod -G '' admin")
+        self.allow_journal_messages("Can't write /var/lib/cockpit/machines: Failed to create file '/var/lib/cockpit/machines\\..*': Permission denied")
 
-        m.execute("systemctl stop docker.service docker.socket")
         self.login_and_go("containers")
 
-        # Docker isn't running, but we can start it.
-        b.wait_visible("#containers-failure")
-        b.wait_text("#containers-failure-message", "Docker is not installed or activated on the system")
-        b.wait_visible("#containers-failure-start")
-        b.click("#containers-failure-start")
-
-        # However, we can't access the socket
+        # We can not become root, so we can't access docker.
         b.wait_visible("#containers-failure")
         b.wait_text("#containers-failure-message", "Not authorized to access Docker on this system")
         b.wait_visible("#containers-failure-retry")
 
-        # Give "admin" access via the docker group and login again
-        m.execute("usermod -G wheel,docker admin")
+        # Give "admin" access via the wheel group and login again
+        m.execute("usermod -G wheel admin")
         b.relogin("containers")
         self.allow_restart_journal_messages()
-        b.wait_visible("#containers-containers")
 
-        # Restart the daemon, wait for the failure, and reconnect.
-        m.execute("systemctl restart docker.service")
+        # Now we can become root and start docker
         b.wait_visible("#containers-failure")
-        b.wait_visible("#containers-failure-retry")
-        b.click("#containers-failure-retry")
-        b.wait_not_visible("#containers-failure")
+        b.wait_text("#containers-failure-message", "Docker is not installed or activated on the system")
+        b.wait_visible("#containers-failure-start")
+        b.click("#containers-failure-start")
         b.wait_visible("#containers-containers")
 
 test_main()

--- a/test/check-roles
+++ b/test/check-roles
@@ -81,6 +81,8 @@ class TestRoles(MachineCase):
         m = self.machine
         b = self.browser
 
+        m.execute("groupadd docker")
+
         self.login_and_go("accounts")
         b.go("account?id=admin")
 


### PR DESCRIPTION
No more "docker" group: Access docker via 'sudo' and adapt tests that assume the "Container Administrator" role.
    
No more "docker.socket" unit: Just use "docker.service".

Depends on #1751.
