### PR TITLE
build: Don't use -Werror=aggregate-return

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -248,7 +248,7 @@ if test "x$GCC" = "xyes"; then
           -Werror=implicit-function-declaration \
           -Werror=pointer-arith -Werror=init-self \
           -Werror=format-security \
-          -Werror=missing-include-dirs -Werror=aggregate-return $CFLAGS"
+          -Werror=missing-include-dirs $CFLAGS"
 fi
 changequote([,])dnl
 


### PR DESCRIPTION
Some APIs (such as libpcp_import, liblvm2app) might use aggregate returns and we
can't do anything about this.

Also, there is nothing wrong with aggregate returns anymore.