### PR TITLE
Fewer timestamps

### DIFF
--- a/pkg/shell/shell.css
+++ b/pkg/shell/shell.css
@@ -173,6 +173,12 @@ html, body {
     min-width: 55px;
 }
 
+/* Make the time range buttons equal width */
+
+#dashboard-range-buttons button {
+    width: 70px;
+}
+
 
 /* Style a button group */
 

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -115,11 +115,8 @@
           <div class="btn-group" id="dashboard-range-buttons">
             <button class="btn btn-default" data-seconds="604800">1 week</button>
             <button class="btn btn-default" data-seconds="86400">1 day</button>
-            <button class="btn btn-default" data-seconds="43200">12 hours</button>
             <button class="btn btn-default" data-seconds="21600">6 hours</button>
-            <button class="btn btn-default" data-seconds="10800">3 hours</button>
             <button class="btn btn-default" data-seconds="3600">1 hour</button>
-            <button class="btn btn-default" data-seconds="1800">30 minutes</button>
             <button class="btn btn-default" data-seconds="300">5 minutes</button>
           </div>
           <div class="btn-group">

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -113,14 +113,14 @@
       <div id="dashboard" class="container-fluid" hidden>
         <div class="btn-toolbar">
           <div class="btn-group" id="dashboard-range-buttons">
-            <button class="btn btn-default" data-seconds="604800">7d</button>
-            <button class="btn btn-default" data-seconds="86400">24h</button>
-            <button class="btn btn-default" data-seconds="43200">12h</button>
-            <button class="btn btn-default" data-seconds="21600">6h</button>
-            <button class="btn btn-default" data-seconds="10800">3h</button>
-            <button class="btn btn-default" data-seconds="3600">1h</button>
-            <button class="btn btn-default" data-seconds="1800">30min</button>
-            <button class="btn btn-default" data-seconds="300">5min</button>
+            <button class="btn btn-default" data-seconds="604800">1 week</button>
+            <button class="btn btn-default" data-seconds="86400">1 day</button>
+            <button class="btn btn-default" data-seconds="43200">12 hours</button>
+            <button class="btn btn-default" data-seconds="21600">6 hours</button>
+            <button class="btn btn-default" data-seconds="10800">3 hours</button>
+            <button class="btn btn-default" data-seconds="3600">1 hour</button>
+            <button class="btn btn-default" data-seconds="1800">30 minutes</button>
+            <button class="btn btn-default" data-seconds="300">5 minutes</button>
           </div>
           <div class="btn-group">
             <button class="btn btn-default" id="dashboard-scroll-left">&lt;</button>


### PR DESCRIPTION
Summary of changes:
* Cosmetic fix to the buttons
* Avoid short forms of time units.
* 5 instead of 8 timestamps should still allow for good navigation. Maybe a better number would be 4, but hard to know what to kill.