### PR TITLE
docker: Support linking containers

### DIFF
--- a/pkg/shell/shell.css
+++ b/pkg/shell/shell.css
@@ -587,12 +587,12 @@ ul.available-interfaces-group {
     vertical-align: top;
 }
 
-.containers-run-portmapping {
+.containers-run-inline {
     margin-left: 8px;
 }
 
-.containers-run-portmapping form .pficon-close,
-.containers-run-portmapping form .fa-plus {
+.containers-run-inline form .pficon-close,
+.containers-run-inline form .fa-plus {
     height: 26px;
     width: 26px;
     padding: 8px;
@@ -600,11 +600,7 @@ ul.available-interfaces-group {
     margin-left: 5px;
 }
 
-.containers-run-portmapping input {
-    max-width: 5em;
-}
-
-.containers-run-portmapping .form-inline {
+.containers-run-inline .form-inline {
     background: #f4f4f4;
     border-width: 0 1px 1px 1px;
     border-style: solid;
@@ -612,12 +608,38 @@ ul.available-interfaces-group {
     padding: 4px;
 }
 
-.containers-run-portmapping .form-inline:first-of-type {
+.containers-run-inline .form-inline:first-of-type {
     border-top: 1px solid #bababa;
 }
 
-.containers-run-portmapping .form-control {
+.containers-run-inline .form-control {
   margin: 0 4px;
+}
+
+.containers-run-portmapping input {
+    max-width: 5em;
+}
+
+#select-linked-containers .form-group {
+    width: 80%;
+}
+
+#select-linked-containers label {
+    padding-right: 4px;
+    padding-left: 4px;
+}
+
+#select-linked-containers .form-control {
+    padding-left: 4px;
+}
+
+@media (min-width: 768px) {
+  #select-linked-containers .form-group {
+      width: 40%;
+  }
+  #select-linked-containers input {
+      max-width: 75%;
+  }
 }
 
 /* Hack to remove size column */

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -893,6 +893,10 @@
                 <td>Ports:</td>
                 <td colspan="2" id="container-details-ports"></td>
               </tr>
+              <tr id="container-details-links-row" style="display: none;">
+                <td>Links:</td>
+                <td colspan="2" id="container-details-links"></td>
+              </tr>
               <tr>
                 <td>&nbsp;</td>
                 <td>
@@ -2271,6 +2275,15 @@
       </div>
     </div>
 
+    <script id="container-link-tmpl" type="x-template/mustache">
+      <form class="form-inline">
+        <button type="button" class="btn btn-default fa fa-plus"></button><button type="button" class="btn btn-default pficon-close"></button>
+        <div class="form-group"><select class="form-control selectpicker" name="container"><option value="">select container</option>{{#containers}}<option>{{.}}</option>{{/containers}}</select></div>
+        <div class="form-group"><label translatable="yes">{{alias_label}}</label><input type="text" name="alias" class="form-control"></div>
+      </form>
+
+    </script>
+
     <div class="modal" id="containers_run_image_dialog"
          tabindex="-1" role="dialog"
          data-backdrop="static">
@@ -2335,6 +2348,14 @@
                 <td translatable="yes">With terminal</td>
                 <td class="shrink">
                   <input type="checkbox" id="containers-run-image-with-terminal" checked />
+                </td>
+              </tr>
+              <tr>
+                <td translatable="yes">Links</td>
+                <td colspan="3">
+                  <input type="checkbox" name="link-containers" id="link-containers" checked="false"/><label for="link-containers">Link to another container</label>
+                  <div id="select-linked-containers" class="containers-run-inline">
+                  </div>
                 </td>
               </tr>
             </table>

--- a/test/check-docker
+++ b/test/check-docker
@@ -104,8 +104,8 @@ class TestDocker(MachineCase):
         # Check links, v1.10 of the API doesn't return links
         # so our visual won't work.
         info = json.loads(m.execute('docker inspect PROBE2'))
-        self.assertEqual(info[0]["HostConfig"]["Links"],
-            ["/PROBE:/PROBE2/alias1", "/PROBE:/PROBE2/alias2"])
+        self.assertEqual(set(info[0]["HostConfig"]["Links"]),
+            set(["/PROBE:/PROBE2/alias1", "/PROBE:/PROBE2/alias2"]))
 
         # delete PROBE2
         b.wait_in_text('#containers-containers tbody tr:first', "PROBE2")

--- a/test/check-docker
+++ b/test/check-docker
@@ -19,6 +19,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 from testlib import *
+import json
 
 class TestDocker(MachineCase):
     def confirm(self):
@@ -55,24 +56,6 @@ class TestDocker(MachineCase):
         b.wait_popdown("containers_run_image_dialog")
         b.wait_in_text("#containers-containers", "PROBE")
 
-        # delete it.
-        b.wait_in_text('#containers-containers tbody tr:last', "PROBE")
-        b.wait_not_visible("#containers-containers tbody tr:last button.btn-delete")
-        b.click("#containers-containers button.enable-danger")
-        b.wait_visible("#containers-containers tbody tr:last button.btn-delete")
-        b.wait_not_present("#containers-containers tbody tr:last button.btn-delete.disabled")
-        b.click("#containers-containers tbody tr:last button.btn-delete")
-        b.wait_js_func('!ph_is_present', "#containers-containers tbody tr")
-
-        # Start it again
-        b.click('#containers-images tr:contains("container-probe") button.btn-play')
-        b.wait_popup("containers_run_image_dialog")
-        b.set_val("#containers-run-image-name", "PROBE")
-        b.set_val("#containers-run-image-command", "/bin/container-probe")
-        b.click("#containers-run-image-run");
-        b.wait_popdown("containers_run_image_dialog")
-        b.wait_in_text("#containers-containers", "PROBE")
-
         # Check output of the probe
         b.click('#containers-containers tr:contains("PROBE")')
         b.wait_page("container-details")
@@ -96,7 +79,44 @@ class TestDocker(MachineCase):
         b.wait_popdown("containers_run_image_dialog")
         b.wait_in_text("#containers-containers", "PROBE")
 
-        # Check output of the probe
+        # Check not linked
+        info = json.loads(m.execute('docker inspect PROBE'))
+        self.assertEqual(info[0]["HostConfig"]["Links"], None)
+
+        # Create another container linked to old one
+        b.click('#containers-images tr:contains("container-probe") button.btn-play')
+        b.wait_popup("containers_run_image_dialog")
+        b.set_val("#containers-run-image-name", "PROBE2")
+        b.set_val("#containers-run-image-command", "/bin/container-probe")
+        b.click("#containers-run-image-with-terminal");
+        b.wait_not_visible("#select-linked-containers");
+        b.click("#link-containers");
+        b.wait_visible("#select-linked-containers");
+        b.set_val("#select-linked-containers form:last-child select.selectpicker", "PROBE")
+        b.set_val("#select-linked-containers form:last-child  input[name='alias']", "alias1")
+        b.click("#select-linked-containers form:last-child  button.fa-plus");
+        b.set_val("#select-linked-containers form:last-child  select.selectpicker", "PROBE")
+        b.set_val("#select-linked-containers form:last-child  input[name='alias']", "alias2")
+        b.click("#containers-run-image-run");
+        b.wait_popdown("containers_run_image_dialog")
+        b.wait_in_text("#containers-containers", "PROBE2")
+
+        # Check links, v1.10 of the API doesn't return links
+        # so our visual won't work.
+        info = json.loads(m.execute('docker inspect PROBE2'))
+        self.assertEqual(info[0]["HostConfig"]["Links"],
+            ["/PROBE:/PROBE2/alias1", "/PROBE:/PROBE2/alias2"])
+
+        # delete PROBE2
+        b.wait_in_text('#containers-containers tbody tr:first', "PROBE2")
+        b.wait_not_visible("#containers-containers tbody tr:first button.btn-delete")
+        b.click("#containers-containers button.enable-danger")
+        b.wait_visible("#containers-containers tbody tr:first button.btn-delete")
+        b.wait_not_present("#containers-containers tbody tr:first button.btn-delete.disabled")
+        b.click("#containers-containers tbody tr:first button.btn-delete")
+        b.wait_not_in_text('#containers-containers tbody tr:first', "PROBE2")
+
+        # Check output of PROBE
         b.click('#containers-containers tr:contains("PROBE")')
         b.wait_page("container-details")
         b.wait_in_text("#container-terminal", "Hello from container-probe.")


### PR DESCRIPTION
This implements the design in  issue #1665.

A couple notes/questions:

Only docker api > 1.12 supports listing links on an inspect call. So the details page doesn't contain the link information.

Docker sliently fails to add links if you don't provide a valid alias. This implementation has the same behavior but if we wanted we could do some basic validation in JS. Like making sure both fields are filed out and that there are no duplicates and they and pass a basic regex check. I couldn't find any examples of that sort of thing anywhere in cockpit or what that would look like in a dialog, so I went without. LMK If that's something we want to do.

