### PR TITLE
ws: g_assert_nonnull is a newer macro

### DIFF
--- a/src/ws/test-sshtransport.c
+++ b/src/ws/test-sshtransport.c
@@ -145,7 +145,7 @@ setup_transport (TestCase *tc,
                  gconstpointer data)
 {
   const TestFixture *fixture = data;
-  g_assert_nonnull(fixture);
+  g_assert(fixture != NULL);
 
   const gchar *password = fixture->client_password ? fixture->client_password : PASSWORD;
   CockpitCreds *creds;


### PR DESCRIPTION
Macro is not defined on glib2-devel-2.38.2-2.fc20.x86_64 at least.