### PR TITLE
base: Prevent failure when embedding cockpit in a foreign page

### DIFF
--- a/pkg/base/cockpit.js
+++ b/pkg/base/cockpit.js
@@ -283,13 +283,18 @@ function Transport() {
     var check_health_timer;
     var got_message = false;
 
-    /* See if we should communicate via parent */
-    if (window.parent !== window &&
-        window.parent.options && window.parent.options.sink &&
-        window.parent.options.protocol == "cockpit1") {
-        ws = new ParentWebSocket(window.parent);
+    try {
+	    /* See if we should communicate via parent */
+	    if (window.parent !== window &&
+                window.parent.options && window.parent.options.sink &&
+                window.parent.options.protocol == "cockpit1") {
+               ws = new ParentWebSocket(window.parent);
+            }
+    } catch (ex) {
+	/* permission access errors */
+    }
 
-    } else {
+    if (!ws) {
         var ws_loc = calculate_url();
         transport_debug("connecting to " + ws_loc);
 


### PR DESCRIPTION
When embedding in a foreign page, we get a permission denied
error when trying to access the '.options' on that window. So
just ignore that in this case.