### PR TITLE
shell: Hide the archive graph toolbar on dashboard by default

### DIFF
--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -110,7 +110,7 @@
       <div id="dashboard" class="container-fluid" hidden>
         <div class="row">
           <div class="col-md-12">
-            <div id="dashboard-toolbar" class="pull-right">
+            <div id="dashboard-toolbar" class="pull-right" hidden>
               <div class="btn-toolbar">
                 <div class="btn-group" id="dashboard-range-buttons">
                   <button class="btn btn-default" data-seconds="604800">1 week</button>


### PR DESCRIPTION
This fixes flicker when it's hidden immediately after we discover
that we have no archive data. In the opposite case, it doesn't look
like flicker.