### PR TITLE
Fsdir changes

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -593,6 +593,8 @@ The following options can be specified in the "open" control message:
 
  * "path": The path name of the directory to watch.  This should be an
    absolute path.
+ * "watch": Boolean, when true the channel be will watch the directory
+    and signal on changes.
 
 The channel will send a number of JSON messages that list the current
 content of the directory.  These messages have a "event" field with

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -577,6 +577,9 @@ fields:
  * "other": The absolute path name of the other file in case of a "moved"
    event.
 
+ * "type": If the event was created this contains the type of the new file.
+   Will be one of: file, directory, link, special or unknown.
+
 In case of an error, the channel will be closed.  In addition to the
 usual "problem" field, the "close" control message sent by the server
 might have the following additional fields:
@@ -593,14 +596,15 @@ The following options can be specified in the "open" control message:
 
  * "path": The path name of the directory to watch.  This should be an
    absolute path.
- * "watch": Boolean, when true the channel be will watch the directory
-    and signal on changes.
+ * "watch": Boolean, when true the directory will be watched and signal
+    on changes.
 
 The channel will send a number of JSON messages that list the current
 content of the directory.  These messages have a "event" field with
-value "present" and a "path" field that holds the (relative) name of
-the file.  After all files have been listed a message with an "event"
-field of "present-done" is sent.
+value "present", a "path" field that holds the (relative) name of
+the file and a type field. Type will be one of: file, directory, link,
+special or unknown. After all files have been listed a message with an
+"event" field of "present-done" is sent.
 
 Other messages on the stream signal changes to the directory, in the
 same format as used by the "fswatch1" payload type.

--- a/src/bridge/cockpitchannel.c
+++ b/src/bridge/cockpitchannel.c
@@ -798,12 +798,12 @@ cockpit_channel_get_options (CockpitChannel *self)
 }
 
 /**
- * cockpit_channel_get_option:
+ * cockpit_channel_close_options
  * @self: a channel
  *
- * Called by implementations to get the channel's open options.
+ * Called by implementations to get the channel's close options.
  *
- * Returns: (transfer none): the open options, should not be NULL
+ * Returns: (transfer none): the close options, should not be NULL
  */
 JsonObject *
 cockpit_channel_close_options (CockpitChannel *self)

--- a/src/bridge/cockpitfsdir.c
+++ b/src/bridge/cockpitfsdir.c
@@ -127,7 +127,8 @@ on_files_listed (GObject *source_object,
       json_object_set_string_member (msg, "event", "present");
       json_object_set_string_member
         (msg, "path", g_file_info_get_attribute_byte_string (info, G_FILE_ATTRIBUTE_STANDARD_NAME));
-      json_object_set_int_member (msg, "type", g_file_info_get_file_type (info));
+      json_object_set_string_member
+        (msg, "type", cockpit_file_type_to_string (g_file_info_get_file_type (info)));
       msg_bytes = cockpit_json_write_bytes (msg);
       json_object_unref (msg);
       cockpit_channel_send (COCKPIT_CHANNEL(self), msg_bytes, FALSE);

--- a/src/bridge/cockpitfsdir.c
+++ b/src/bridge/cockpitfsdir.c
@@ -127,6 +127,8 @@ on_files_listed (GObject *source_object,
       json_object_set_string_member (msg, "event", "present");
       json_object_set_string_member
         (msg, "path", g_file_info_get_attribute_byte_string (info, G_FILE_ATTRIBUTE_STANDARD_NAME));
+      json_object_set_int_member
+        (msg, "type", g_file_info_get_file_type (info));
       msg_bytes = cockpit_json_write_bytes (msg);
       json_object_unref (msg);
       cockpit_channel_send (COCKPIT_CHANNEL(self), msg_bytes, FALSE);

--- a/src/bridge/cockpitfsdir.h
+++ b/src/bridge/cockpitfsdir.h
@@ -33,6 +33,6 @@ GType              cockpit_fsdir_get_type     (void) G_GNUC_CONST;
 CockpitChannel *   cockpit_fsdir_open         (CockpitTransport *transport,
                                                const gchar *channel_id,
                                                const gchar *path,
-                                               const gboolean nowatch);
+                                               const gboolean watch);
 
 #endif /* COCKPIT_FSDIR_H__ */

--- a/src/bridge/cockpitfsdir.h
+++ b/src/bridge/cockpitfsdir.h
@@ -32,6 +32,7 @@ GType              cockpit_fsdir_get_type     (void) G_GNUC_CONST;
 
 CockpitChannel *   cockpit_fsdir_open         (CockpitTransport *transport,
                                                const gchar *channel_id,
-                                               const gchar *path);
+                                               const gchar *path,
+                                               const gboolean nowatch);
 
 #endif /* COCKPIT_FSDIR_H__ */

--- a/src/bridge/cockpitfswatch.c
+++ b/src/bridge/cockpitfswatch.c
@@ -212,6 +212,7 @@ cockpit_fswatch_prepare (CockpitChannel *channel)
   problem = NULL;
 
 out:
+  g_clear_error (&error);
   if (problem)
     cockpit_channel_close (channel, problem);
 }

--- a/src/bridge/cockpitfswatch.h
+++ b/src/bridge/cockpitfswatch.h
@@ -34,6 +34,8 @@ CockpitChannel *   cockpit_fswatch_open         (CockpitTransport *transport,
                                                  const gchar *channel_id,
                                                  const gchar *path);
 
+gchar *            cockpit_file_type_to_string  (GFileType file_type);
+
 void
 cockpit_fswatch_emit_event (CockpitChannel    *channel,
                             GFile             *file,

--- a/src/bridge/test-fs.c
+++ b/src/bridge/test-fs.c
@@ -877,6 +877,21 @@ test_dir_watch (TestCase *tc,
   g_assert (json_object_get_member (control, "problem") == NULL);
 }
 
+static void
+test_dir_list_fail (TestCase *tc,
+                      gconstpointer unused)
+{
+  JsonObject *control;
+  setup_fsdir_channel (tc, tc->test_path, FALSE);
+
+  // Channel should close automatically
+  wait_channel_closed (tc);
+
+  control = mock_transport_pop_control (tc->transport);
+  g_assert_cmpstr (json_object_get_string_member (control, "problem"), ==, "not-found");
+}
+
+
 int
 main (int argc,
       char *argv[])
@@ -932,6 +947,8 @@ main (int argc,
               setup, test_dir_early_close, teardown);
   g_test_add ("/fsdir/watch", TestCase, NULL,
               setup, test_dir_watch, teardown);
+  g_test_add ("/fsdir/list_fail", TestCase, NULL,
+              setup, test_dir_list_fail, teardown);
 
   return g_test_run ();
 }

--- a/src/bridge/test-fs.c
+++ b/src/bridge/test-fs.c
@@ -728,6 +728,7 @@ test_dir_simple (TestCase *tc,
   event = recv_json (tc);
   g_assert_cmpstr (json_object_get_string_member (event, "event"), ==, "present");
   g_assert_cmpstr (json_object_get_string_member (event, "path"), ==, base);
+  g_assert (json_object_get_int_member (event, "type") == 1);
   json_object_unref (event);
 
   event = recv_json (tc);
@@ -757,6 +758,7 @@ test_dir_simple_no_watch (TestCase *tc,
   event = recv_json (tc);
   g_assert_cmpstr (json_object_get_string_member (event, "event"), ==, "present");
   g_assert_cmpstr (json_object_get_string_member (event, "path"), ==, base);
+  g_assert (json_object_get_int_member (event, "type") == 1);
   json_object_unref (event);
 
   event = recv_json (tc);


### PR DESCRIPTION
This is mostly in preparation for implementing a fs browsing widget for docker volumes. It also addresses #1593. 

I didn't add type to the watch responses as I don't currently have a use case for it and didn't really want to add the extra overhead to get the info object from the file. But it does seems a little odd to include it in one place but not the other. LMK what you think.