### PR TITLE
session: No tty for pam, but session class and type.

### DIFF
--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -402,12 +402,7 @@ open_session (pam_handle_t *pamh)
 
       debug ("opening pam session for %s", name);
 
-      res = pam_set_item (pamh, PAM_TTY, line);
-      if (res != PAM_SUCCESS)
-        {
-          warnx ("couldn't set tty: %s", pam_strerror (pamh, res));
-          return res;
-        }
+      pam_putenv (pamh, "XDG_SESSION_CLASS=user");
 
       res = pam_setcred (pamh, PAM_ESTABLISH_CRED);
       if (res != PAM_SUCCESS)


### PR DESCRIPTION
Systemd-logind expects a real tty and we should set the session class
and type explicitly.

https://bugs.freedesktop.org/show_bug.cgi?id=89024#c1
