### PR TITLE
test: Remove workaround for stuck session in check-session.

### DIFF
--- a/test/check-session
+++ b/test/check-session
@@ -52,14 +52,7 @@ class TestSession(MachineCase):
         # Logout
         b.logout()
         b.wait_visible("#login")
-
-        # HACK - sometimes the session gets stuck forever in state 'closing' with no processes.
-        #        https://bugs.freedesktop.org/show_bug.cgi?id=89024
-        try:
-            wait_session(False)
-        except:
-            print ("WARNING: ran into https://bugs.freedesktop.org/show_bug.cgi?id=89024, skipping rest of test")
-            return
+        wait_session(False)
 
         # Login again
         b.set_val("#login-user-input", "admin")


### PR DESCRIPTION
This reverts commits d54df54fcafa2b50bb479216dc507c856dfcad6f and
472945ae5a3f6d1dc1a045d65c4bb374215b3e01.

Don't merge this even if the tests pass.  They fail randomly, so a PASS doesn't mean that the bug is gone.