### PR TITLE
docker: Fix display of HTTP headers in docker terminal

### DIFF
--- a/pkg/docker/docker.js
+++ b/pkg/docker/docker.js
@@ -59,7 +59,8 @@ define([
             });
 
         self.process = function process(buffer) {
-                term.write(decoder.decode(buffer));
+            term.write(decoder.decode(buffer));
+            return buffer.length;
         };
 
         term.on('data', function(data) {


### PR DESCRIPTION
This was due to an invalid return value from the processing
function.