### PR TITLE
Test: change tap-phantom for more flexible build dir location

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -70,7 +70,7 @@ LOG_COMPILER = $(top_srcdir)/tools/tap-gtester
 TEST_EXTENSIONS = .html
 HTML_LOG_DRIVER = $(top_srcdir)/tools/tap-driver
 if WITH_PHANTOMJS
-HTML_LOG_COMPILER = $(top_srcdir)/tools/tap-phantom $(builddir)/test-server
+HTML_LOG_COMPILER = $(top_srcdir)/tools/tap-phantom $(builddir)/test-server $(top_srcdir)/
 else
 HTML_LOG_DRIVER_FLAGS = --missing=phantomjs
 endif

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -286,7 +286,7 @@ on_handle_resource (CockpitWebServer *server,
                     CockpitWebResponse *response,
                     gpointer user_data)
 {
-  gchar *alloc = NULL;;
+  gchar *alloc = NULL;
 
   g_assert (g_str_has_prefix (path, "/pkg"));
 

--- a/tools/tap-phantom
+++ b/tools/tap-phantom
@@ -33,8 +33,22 @@ if (phantom.args.length == 1) {
 } else if (phantom.args.length == 2) {
     server = sys.args[1];
     url = sys.args[2];
+} else if (phantom.args.length == 3) {
+    /* strip prefix from url
+     * We need this to compensate for automake test generation behavior:
+     * The tests are called with the path (relative to the build directory) of the testfile,
+     * but from the build directory. Some tests make assumptions regarding the structure of the
+     * filename. In order to make sure that they receive the same name, regardless of actual
+     * build directory location, we need to strip that prefix (path from build to source directory)
+     * from the filename
+     */
+    server = sys.args[1];
+    prefix = sys.args[2];
+    url = sys.args[3];
+    if (url.indexOf(prefix) == 0)
+        url = url.slice(prefix.length);
 } else {
-    console.log('usage: tap-phantom [server] file');
+    console.log('usage: tap-phantom [server [prefix]] file');
     phantom.exit(2);
 }
 


### PR DESCRIPTION
fixes #1822 
Pass relative location of source directory (from build directory) to tap-phantom. There, strip this prefix from the passed url, before it's passed to the webserver.

I couldn't find an automake option to do this differently. It would work if in rule `.html.log:` of the generated Makefile, the use of `"$$tst"` were replaced by `"$$f"`.