### PR TITLE
bridge: Don't send Content-Length header for non-POST requests

### DIFF
--- a/src/bridge/cockpithttpstream.c
+++ b/src/bridge/cockpithttpstream.c
@@ -760,7 +760,8 @@ send_http_request (CockpitHttpStream *self)
   for (l = request; l != NULL; l = g_list_next (l))
     total += g_bytes_get_size (l->data);
 
-  g_string_append_printf (string, "Content-Length: %" G_GSIZE_FORMAT "\r\n", total);
+  if (request || g_ascii_strcasecmp (method, "POST") == 0)
+    g_string_append_printf (string, "Content-Length: %" G_GSIZE_FORMAT "\r\n", total);
   g_string_append (string, "\r\n");
 
   bytes = g_string_free_to_bytes (string);


### PR DESCRIPTION
When sending a non-POST request, if no data has been sent in the
channel, then don't send a Content-Length header in the HTTP request.

This is in keeping with the HTTP RFC, which says we should not send
Content-Length without data for methods whose semantics do not include
a body.