### PR TITLE
ws: Prevent use of SSL 3, TLS 1.0 and insecure ciphers like RC4

### DIFF
--- a/doc/guide/https.xml
+++ b/doc/guide/https.xml
@@ -33,4 +33,25 @@
 
   </section>
 
+  <section id="https-compat">
+    <title>SSL Versions and Ciphers</title>
+
+    <para>By default Cockpit will only use modern secure ciphers and versions of TLS.
+      In particular SSL v3.0 is disabled by default, as well as the RC4 cipher.</para>
+
+    <para>If you wish to enable these legacy protocols and algorithms you can do so
+      by passing an environment variable to cockpit-ws. Place the following in the
+      <code>/etc/systemd/system/cockpit.service.d/ssl.conf</code> file. Create the
+      file and directories in that path which don't already exist.</para>
+
+<programlisting>
+[Service]
+Environment=G_TLS_GNUTLS_PRIORITY=NORMAL:%COMPAT
+</programlisting>
+
+    <para>The environment variable value is a
+      <ulink url="http://gnutls.org/manual/html_node/Priority-Strings.html#Priority-Strings">GnuTLS priority string</ulink>.</para>
+
+  </section>
+
 </chapter>

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -74,6 +74,8 @@ main (int argc,
   /* Any interaction with a krb5 ccache should be explicit */
   g_setenv ("KRB5CCNAME", "FILE:/dev/null", TRUE);
 
+  g_setenv ("G_TLS_GNUTLS_PRIORITY", "SECURE128:%LATEST_RECORD_VERSION:-VERS-SSL3.0:-VERS-TLS1.0", FALSE);
+
   g_type_init ();
 
   ssh_threads_set_callbacks (ssh_threads_get_pthread());

--- a/test/README
+++ b/test/README
@@ -7,7 +7,7 @@ To run the tests, you need to install the following packages on
 Fedora:
 
   # yum install trickle nbd-server npm python-libguestfs qemu mock qemu-kvm python \
-         curl libvirt-client libvirtd qemu-nbd fakeroot glibc-static
+         curl libvirt-client libvirtd qemu-nbd fakeroot glibc-static openssl
 
 Testing requires phantomjs globally on the system, not just inside the cockpit package.
 

--- a/test/check-connection
+++ b/test/check-connection
@@ -20,6 +20,8 @@
 
 from testlib import *
 
+import subprocess
+
 class TestConnection(MachineCase):
     def testBasic(self):
         b = self.browser
@@ -71,5 +73,48 @@ class TestConnection(MachineCase):
         b.wait_page("server")
 
         self.allow_restart_journal_messages()
+
+    def testTls(self):
+        m = self.machine
+
+        # Start Cockpit with TLS
+        m.execute("systemctl start cockpit.socket")
+
+        null = open("/dev/null")
+        args = ['openssl', 's_client', '-connect',  m.address + ":9090" ]
+
+        # A normal TLS connection works
+        m.message(repr(args))
+        output = subprocess.check_output(args, stdin=null, stderr=subprocess.STDOUT)
+        m.message(output)
+        self.assertIn("DONE", output)
+
+        # SSLv3 should not work
+        try:
+            cmd = args + [ '-ssl3' ]
+            m.message(repr(cmd))
+            output = subprocess.check_output(cmd, stdin=null, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError, ex:
+            m.message(ex.output)
+            self.assertIn("wrong version number", ex.output)
+        else:
+            m.message(output)
+            self.fail("SSL3 should not have been successful")
+
+        # RC4 should not work
+        try:
+            cmd = args + [ '-cipher', 'RC4' ]
+            m.message(repr(cmd))
+            output = subprocess.check_output(cmd, stdin=null, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError, ex:
+            m.message(ex.output)
+            self.assertIn("ssl handshake failure", ex.output)
+        else:
+            m.message(output)
+            self.fail("RC4 cipher should not have been usable")
+
+        self.allow_journal_messages(
+            ".*Peer failed to perform TLS handshake",
+            ".*Error performing TLS handshake: Could not negotiate a supported cipher suite.")
 
 test_main()


### PR DESCRIPTION
Tell GnuTLS we want to be strict about TLS and RC4, and avoid
insecure ciphers and protocols. This restricts the browsers that
can connect to Cockpit somewhat. But we already have high requirements
because of our WebSocket usage.

Document how to relax the restrictions if an administrator has to
do so.

Add tests to check that this actually works.

Fixes #1801