### PR TITLE
reauthorize: A valid return should be zero

### DIFF
--- a/src/reauthorize/reauthorize.c
+++ b/src/reauthorize/reauthorize.c
@@ -713,7 +713,7 @@ reauthorize_user (const char *challenge,
     }
 
   ret = hex_decode (beg, len, &result, &user_len);
-  if (ret < 0)
+  if (ret != 0)
     {
       message ("invalid reauthorize challenge: bad hex encoding");
       return ret;


### PR DESCRIPTION
Coverity complained about a memory leak in the reauth tests because the tests assume that the only time memory is allocated is when the return code is zero. I couldn't see any reason for a valid hex_decode to return anything other than zero, so i changed the check there, but if I'm missing something we can fix the memory issue in a different way.