### PR TITLE
shell: Avoid Math.log2

### DIFF
--- a/pkg/shell/cockpit-dashboard.js
+++ b/pkg/shell/cockpit-dashboard.js
@@ -65,7 +65,7 @@ var common_plot_options = {
 
 function memory_ticks(opts) {
     // Not more than 5 ticks, nicely rounded to powers of 2.
-    var size = Math.pow(2.0, Math.ceil(Math.log2(opts.max/5)));
+    var size = Math.pow(2.0, Math.ceil(Math.log(opts.max/5)/Math.LN2));
     var ticks = [ ];
     for (var t = 0; t < opts.max; t += size)
         ticks.push(t);


### PR DESCRIPTION
It is not supported by all browsers, such as phantomjs.