### PR TITLE
guide: Fix the example URLs in the embedding documentation

### DIFF
--- a/doc/guide/api-container.xml
+++ b/doc/guide/api-container.xml
@@ -27,7 +27,7 @@
     <refsection>
       <title>Description</title>
 <programlisting>
- &lt;iframe src="http://server:9090/cockpit/container/console.html"
+ &lt;iframe src="http://server:9090/cockpit/@localhost/container/console.html"
      width="600" height="400"&gt;&lt;/iframe&gt;
 </programlisting>
 
@@ -38,7 +38,7 @@
       <variablelist>
         <varlistentry>
           <term>Component URL</term>
-          <listitem><para><code>/cockpit/server/terminal.html</code></para></listitem>
+          <listitem><para><code>/cockpit/@localhost/server/terminal.html</code></para></listitem>
         </varlistentry>
         <varlistentry>
           <term>Container Identifier</term>

--- a/doc/guide/api-server.xml
+++ b/doc/guide/api-server.xml
@@ -24,7 +24,7 @@
     <refsection>
       <title>Description</title>
 <programlisting>
- &lt;iframe src="http://server:9090/cockpit/server/log.html"
+ &lt;iframe src="http://server:9090/cockpit/@localhost/server/log.html"
      width="600" height="400"&gt;&lt;/iframe&gt;
 </programlisting>
 
@@ -34,7 +34,7 @@
       <variablelist>
         <varlistentry>
           <term>Component URL</term>
-          <listitem><para><code>/cockpit/server/log.html</code></para></listitem>
+          <listitem><para><code>/cockpit/@localhost/server/log.html</code></para></listitem>
         </varlistentry>
         <varlistentry>
           <term>Filter by priority</term>
@@ -98,7 +98,7 @@
     <refsection>
       <title>Description</title>
 <programlisting>
- &lt;iframe src="http://server:9090/cockpit/server/terminal.html"
+ &lt;iframe src="http://server:9090/cockpit/@localhost/server/terminal.html"
      width="600" height="400"&gt;&lt;/iframe&gt;
 </programlisting>
 
@@ -108,7 +108,7 @@
       <variablelist>
         <varlistentry>
           <term>Component URL</term>
-          <listitem><para><code>/cockpit/server/terminal.html</code></para></listitem>
+          <listitem><para><code>/cockpit/@localhost/server/terminal.html</code></para></listitem>
         </varlistentry>
       </variablelist>
 


### PR DESCRIPTION
These need to be updated for the changes that we made
to the package system.