### PR TITLE
Explicitly set the minimum requirement for glib2

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -52,6 +52,10 @@ BuildRequires: docbook-style-xsl
 BuildRequires: keyutils-libs-devel
 BuildRequires: dbus-devel
 BuildRequires: glib-networking
+
+# There is a segfault in g_source_add_child_source that was fixed in
+# glib2 2.37.4
+BuildRequires: glib2-devel >= 2.37.4
 BuildRequires: systemd
 BuildRequires: polkit
 BuildRequires: pcp-libs-devel
@@ -137,6 +141,10 @@ This package contains the Cockpit shell UI assets.
 %package ws
 Summary: Cockpit Web Service
 Requires: glib-networking
+
+# There is a segfault in g_source_add_child_source that was fixed in
+# glib2 2.37.4
+Requires: glib2 >= 2.37.4
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd


### PR DESCRIPTION
There is a segfault that occurs on RHEL/CentOS 7.0 systems. We
need to ensure that if someone builds on that platform, they do so
with a fixed glib2.