### PR TITLE
tools: Add fPIC to cockpit spec.

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -4,7 +4,7 @@
 
 # Our SELinux policy gets built in tests and f21 and lower
 %if %{defined gitcommit}
-%define extra_flags CFLAGS='-O2 -Wall -Werror'
+%define extra_flags CFLAGS='-O2 -Wall -Werror -fPIC'
 %define selinux 1
 %endif
 %if 0%{?fedora} > 0 && 0%{?fedora} <= 21


### PR DESCRIPTION
Fedora >F23 now builds packages with _hardened_build 1. See https://fedorahosted.org/fesco/ticket/1384