### PR TITLE
shell: Only optionally load docker component code

### DIFF
--- a/pkg/shell/cockpit-main.js
+++ b/pkg/shell/cockpit-main.js
@@ -63,12 +63,19 @@ function maybe_init() {
 /* HACK: Until all of the shell is loaded via AMD */
 require([
     "system/server",
-    "docker/docker"
-], function(server, docker) {
+    "manifests"
+], function(server, manifests) {
     modules.server = server;
-    modules.docker = docker;
-    modules.loaded = true;
-    maybe_init();
+    if (manifests["docker"]) {
+        require([ "docker/docker" ], function (docker) {
+            modules.docker = docker;
+            modules.loaded = true;
+            maybe_init();
+        });
+    } else {
+        modules.loaded = true;
+        maybe_init();
+    }
 });
 
 function init() {


### PR DESCRIPTION
This is an ugly hack, because of the way the shell is built. It will go away when the docker stuff moves fully into its own component.

Necessary because certain platforms don't and can't have a docker dependency.
