### PR TITLE
legacy: Get images from base1 package.

### DIFF
--- a/pkg/legacy/cockpit.css
+++ b/pkg/legacy/cockpit.css
@@ -332,21 +332,21 @@ code, kbd, pre, samp {
 .btn-play:hover,
 .btn-play:active,
 .btn-play:focus {
-    background-image: url(../base/images/play.png);
+    background-image: url(../base1/images/play.png);
 }
 
 .btn-stop,
 .btn-stop:hover,
 .btn-stop:active,
 .btn-stop:focus {
-    background-image: url(../base/images/stop.png);
+    background-image: url(../base1/images/stop.png);
 }
 
 .btn-eject,
 .btn-eject:hover,
 .btn-eject:active,
 .btn-eject:focus {
-    background-image: url(../base/images/eject.png);
+    background-image: url(../base1/images/eject.png);
 }
 
 .waiting {


### PR DESCRIPTION
I missed this during review, sorry.
