### PR TITLE
common: Suppressed ECONNRESET warnings in HTTP code paths

### DIFF
--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -253,11 +253,16 @@ cockpit_web_response_get_stream  (CockpitWebResponse *self)
   return self->io;
 }
 
+#if !GLIB_CHECK_VERSION(2,43,2)
+#define G_IO_ERROR_CONNECTION_CLOSED G_IO_ERROR_BROKEN_PIPE
+#endif
+
 static gboolean
 should_suppress_output_error (CockpitWebResponse *self,
                               GError *error)
 {
-  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE))
+  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) ||
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE))
     {
       g_debug ("%s: output error: %s", self->logname, error->message);
       return TRUE;

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -253,6 +253,23 @@ cockpit_web_server_set_property (GObject *object,
     }
 }
 
+#if !GLIB_CHECK_VERSION(2,43,2)
+#define G_IO_ERROR_CONNECTION_CLOSED G_IO_ERROR_BROKEN_PIPE
+#endif
+
+static gboolean
+should_suppress_output_error (GError *error)
+{
+  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) ||
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE))
+    {
+      g_debug ("http output error: %s", error->message);
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
 static void
 on_io_closed (GObject *stream,
               GAsyncResult *result,
@@ -262,9 +279,7 @@ on_io_closed (GObject *stream,
 
   if (!g_io_stream_close_finish (G_IO_STREAM (stream), result, &error))
     {
-      if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE))
-        g_debug ("http close error: %s", error->message);
-      else
+      if (!should_suppress_output_error (error))
         g_message ("http close error: %s", error->message);
       g_error_free (error);
     }


### PR DESCRIPTION
This was causing problems with the tests. The error code
G_IO_ERROR_CONNECTION_CLOSED was added in glib 2.42.2