### PR TITLE
shell: Only set component frame location when it actually changes.

### DIFF
--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -555,8 +555,9 @@ require([
 
             var frame = list[component];
             if (frame) {
-                frame.setAttribute('src', frame.url + "#" + hash);
-
+                var src_attr = frame.url + "#" + hash;
+                if (frame.getAttribute('src') != src_attr)
+                    frame.setAttribute('src', src_attr);
             } else {
                 frame = document.createElement("iframe");
                 frame.setAttribute("class", "container-frame");


### PR DESCRIPTION
The outer shell does not follow local navigation inside a legacy
component and each call to navigate() would therefore undo that local
navigation.  Calls to navigate() can happen quite spontaneously and
are interfering with tests like check-roles.