### PR TITLE
 Use relative URLs to refer to static resources

### DIFF
--- a/doc/urls.md
+++ b/doc/urls.md
@@ -5,7 +5,7 @@ Cockpit URL paths
 This is developer documentation about the various URL paths in Cockpit
 and their characteristics:
 
- * ```/static``` static files available without authentication. Files
+ * ```/cockpit/static``` static files available without authentication. Files
    are cached for as long as possible, and names *must* change when the
    contents of the file changes.
 

--- a/lib/patternfly.v1.1.3.css
+++ b/lib/patternfly.v1.1.3.css
@@ -8441,31 +8441,31 @@ table.datatable th:active {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 300;
-  src: url('/static/fonts/OpenSans-Light-webfont.woff') format('woff');
+  src: url('../../static/fonts/OpenSans-Light-webfont.woff') format('woff');
 }
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 400;
-  src: url('/static/fonts/OpenSans-Regular-webfont.woff') format('woff');
+  src: url('../../static/fonts/OpenSans-Regular-webfont.woff') format('woff');
 }
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 600;
-  src: url('/static/fonts/OpenSans-Semibold-webfont.woff') format('woff');
+  src: url('../../static/fonts/OpenSans-Semibold-webfont.woff') format('woff');
 }
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 700;
-  src: url('/static/fonts/OpenSans-Bold-webfont.woff') format('woff');
+  src: url('../../static/fonts/OpenSans-Bold-webfont.woff') format('woff');
 }
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 800;
-  src: url('/static/fonts/OpenSans-ExtraBold-webfont.woff') format('woff');
+  src: url('../../static/fonts/OpenSans-ExtraBold-webfont.woff') format('woff');
 }
 .form-control[disabled],
 .form-control[readonly],

--- a/pkg/legacy/patternfly.css
+++ b/pkg/legacy/patternfly.css
@@ -7695,31 +7695,31 @@ fieldset[disabled] .btn-primary.active {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 300;
-  src: url('/static/fonts/OpenSans-Light-webfont.woff') format('woff');
+  src: url('../../static/fonts/OpenSans-Light-webfont.woff') format('woff');
 }
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 400;
-  src: url('/static/fonts/OpenSans-Regular-webfont.woff') format('woff');
+  src: url('../../static/fonts/OpenSans-Regular-webfont.woff') format('woff');
 }
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 600;
-  src: url('/static/fonts/OpenSans-Semibold-webfont.woff') format('woff');
+  src: url('../../static/fonts/OpenSans-Semibold-webfont.woff') format('woff');
 }
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 700;
-  src: url('/static/fonts/OpenSans-Bold-webfont.woff') format('woff');
+  src: url('../../static/fonts/OpenSans-Bold-webfont.woff') format('woff');
 }
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 800;
-  src: url('/static/fonts/OpenSans-ExtraBold-webfont.woff') format('woff');
+  src: url('../../static/fonts/OpenSans-ExtraBold-webfont.woff') format('woff');
 }
 .form-control[disabled],
 .form-control[readonly],

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -19,7 +19,7 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <img class="navbar-brand" height="25" src="/static/brand.png" alt="Cockpit" />
+        <img class="navbar-brand" height="25" src="../../static/brand.png" alt="Cockpit" />
       </div>
       <div class="collapse navbar-collapse navbar-collapse-1">
         <ul class="nav navbar-nav navbar-utility">

--- a/src/static/login.html
+++ b/src/static/login.html
@@ -527,13 +527,13 @@ label {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 400;
-  src: url('/static/fonts/OpenSans-Regular-webfont.woff') format('woff');
+  src: url('/cockpit/static/fonts/OpenSans-Regular-webfont.woff') format('woff');
 }
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 700;
-  src: url('/static/fonts/OpenSans-Bold-webfont.woff') format('woff');
+  src: url('/cockpit/static/fonts/OpenSans-Bold-webfont.woff') format('woff');
 }
 .form-control:hover {
   border-color: #7BB2DD;
@@ -651,7 +651,7 @@ label {
 
         /* Login page specific overrides */
         body {
-            background: url("/static/bg-login.jpg") no-repeat 50% 0;
+            background: url("/cockpit/static/bg-login.jpg") no-repeat 50% 0;
             background-size: auto;
             background-color: #101010;
             color: #fff;
@@ -686,13 +686,13 @@ label {
   </head>
   <body class="login-pf">
     <span id="badge">
-      <img src="/static/logo.png" alt="" />
+      <img src="/cockpit/static/logo.png" alt="" />
     </span>
     <div class="container">
       <div class="row">
         <div class="col-sm-12">
           <div id="brand">
-            <img src="/static/brand-large.png" alt="Branding Large">
+            <img src="/cockpit/static/brand-large.png" alt="Branding Large">
           </div><!--/#brand-->
         </div><!--/.col-*-->
 

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -161,6 +161,12 @@ cockpit_handler_resource (CockpitWebServer *server,
 {
   CockpitWebService *service;
 
+  if (g_str_has_prefix (path, "/cockpit/static/"))
+    {
+      cockpit_web_response_file (response, path + 16, TRUE, ws->static_roots);
+      return TRUE;
+    }
+
   service = cockpit_auth_check_cookie (ws->auth, headers);
   if (service)
     {
@@ -303,18 +309,6 @@ cockpit_handler_login (CockpitWebServer *server,
 }
 
 /* ---------------------------------------------------------------------------------------------------- */
-
-gboolean
-cockpit_handler_static (CockpitWebServer *server,
-                        const gchar *path,
-                        GHashTable *headers,
-                        CockpitWebResponse *response,
-                        CockpitHandlerData *ws)
-{
-  /* Cache forever */
-  cockpit_web_response_file (response, path + 8, TRUE, ws->static_roots);
-  return TRUE;
-}
 
 gboolean
 cockpit_handler_root (CockpitWebServer *server,

--- a/src/ws/cockpithandlers.h
+++ b/src/ws/cockpithandlers.h
@@ -50,12 +50,6 @@ gboolean       cockpit_handler_root              (CockpitWebServer *server,
                                                   CockpitWebResponse *response,
                                                   CockpitHandlerData *ws);
 
-gboolean       cockpit_handler_static            (CockpitWebServer *server,
-                                                  const gchar *path,
-                                                  GHashTable *headers,
-                                                  CockpitWebResponse *response,
-                                                  CockpitHandlerData *ws);
-
 gboolean       cockpit_handler_resource          (CockpitWebServer *server,
                                                   const gchar *path,
                                                   GHashTable *headers,

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -145,8 +145,6 @@ main (int argc,
 
   g_signal_connect (server, "handle-resource::/",
                     G_CALLBACK (cockpit_handler_resource), &data);
-  g_signal_connect (server, "handle-resource::/static/",
-                    G_CALLBACK (cockpit_handler_static), &data);
   g_signal_connect (server, "handle-resource::/cockpit/",
                     G_CALLBACK (cockpit_handler_resource), &data);
 


### PR DESCRIPTION
This applies when logged in. The static resources are available under /cockpit/static

Depends on #1909 
