### PR TITLE
Test: add missing "install" command to host setup script

### DIFF
--- a/test-avocado/lib/host_setup.sh
+++ b/test-avocado/lib/host_setup.sh
@@ -35,7 +35,7 @@ function echolog(){
 }
 
 function host_dependencies_fedora(){
-    sudo yum -y yum-plugin-copr
+    sudo yum -y install yum-plugin-copr
     sudo yum -y copr enable fsimonce/virt-deploy
     sudo yum -y copr enable lmr/Autotest
     sudo yum -y install $HS_BASE_PCKGS


### PR DESCRIPTION
Script needs to install yum-plugin-copr on F21 if it's missing.