### PR TITLE
test-avocado: Disable /bin/less in cockpit guest.

### DIFF
--- a/test-avocado/lib/guest-cockpit.sh
+++ b/test-avocado/lib/guest-cockpit.sh
@@ -65,3 +65,6 @@ fi
 # Audit events to the journal
 rm -f '/etc/systemd/system/multi-user.target.wants/auditd.service'
 rm -rf /var/log/audit/
+
+# HACK - https://github.com/avocado-framework/avocado/issues/486
+mv -f /bin/less /bin/less.disabled


### PR DESCRIPTION
Otherwise 'avocado run' might use it and hang while waiting for user
input.

See https://github.com/avocado-framework/avocado/issues/486