### PR TITLE
common: Work around misconfigured systemd not passing a socket

### DIFF
--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -26,10 +26,13 @@
 
 #include "websocket/websocket.h"
 
+#include <sys/socket.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
 #include <systemd/sd-daemon.h>
 
 guint cockpit_webserver_request_timeout = 30;
@@ -1184,6 +1187,19 @@ cockpit_web_server_initable_init (GInitable *initable,
         {
           GSocket *s = NULL;
           gboolean b;
+          int type;
+          socklen_t l = sizeof (type);
+
+          /*
+           * HACK: Workaround g_error() happy code in GSocket
+           * https://bugzilla.gnome.org/show_bug.cgi?id=746339
+           */
+          if (getsockopt (fd, SOL_SOCKET, SO_TYPE, &type, &l) < 0)
+            {
+              g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                           "invalid socket passed via systemd activation: %d: %s", fd, g_strerror (errno));
+              goto out;
+            }
 
           s = g_socket_new_from_fd (fd, error);
           if (s == NULL)


### PR DESCRIPTION
Previously this would just kill the process. We should instead
produce an intelligible message, and not necessarily dump core.

https://bugzilla.gnome.org/show_bug.cgi?id=746339

Fixes #1931