### PR TITLE
spec: Don't depend on subscriptions on CentOS

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -81,7 +81,8 @@ Requires: %{name}-shell = %{version}-%{release}
 %ifarch x86_64
 Requires: %{name}-docker = %{version}-%{release}
 %endif
-%if 0%{?rhel}
+# Only depend on subscriptions if we are on RHEL, not on CentOS
+%if 0%{?rhel} && 0%{?centos} == 0
 Requires: %{name}-subscriptions = %{version}-%{release}
 %endif
 %if %{defined selinux}


### PR DESCRIPTION
subscription-manager is a RHEL only thing. Thus cockpit-subscriptions
should only be a default dependency of cockpit on RHEL.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>