### PR TITLE
shell: Permissions on host management UI.

### DIFF
--- a/pkg/shell/cockpit-dashboard.js
+++ b/pkg/shell/cockpit-dashboard.js
@@ -200,6 +200,16 @@ function host_edit_dialog(addr) {
         });
 }
 
+function update_servers_privileged() {
+    shell.update_privileged_ui(
+        shell.default_permission, ".servers-privileged",
+        cockpit.format(
+            _("The user <b>$0</b> is not permitted to manage servers"),
+            cockpit.user.name)
+    );
+}
+$(shell.default_permission).on("changed", update_servers_privileged);
+
 PageDashboard.prototype = {
     _init: function() {
         this.id = "dashboard";
@@ -414,6 +424,7 @@ PageDashboard.prototype = {
                 });
 
                 target.html(text);
+                update_servers_privileged();
                 update_series();
             }
 
@@ -512,6 +523,7 @@ PageDashboard.prototype = {
     },
 
     show: function() {
+        update_servers_privileged();
         this.plots[0].resize();
         this.toggle_edit(false);
     },

--- a/pkg/shell/cockpit-main.js
+++ b/pkg/shell/cockpit-main.js
@@ -259,15 +259,6 @@ function pick_unused_host_color() {
     return "gray";
 }
 
-function update_servers_privileged() {
-    shell.update_privileged_ui(
-        shell.default_permission, ".servers-privileged",
-        cockpit.format(
-            _("The user <b>$0</b> is not permitted to add servers"),
-            cockpit.user.name)
-    );
-}
-
 function hosts_init() {
 
     var host_info = shell.hosts;
@@ -441,10 +432,6 @@ function hosts_init() {
         $(host_proxies).on('added removed changed', update);
         update();
     });
-
-
-    $(shell.default_permission).on("changed", update_servers_privileged);
-    update_servers_privileged();
 }
 
 function update_global_nav() {

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -75,8 +75,8 @@
           {{! state can be 'failed' or 'connected' }}
           <a data-address="{{address}}" class="list-group-item {{state}}"
               style="border-left-color: {{ color }};" target="_parent" href="/#/@{{address}}/system/host">
-            <button class="btn btn-danger edit-button pficon btn-delete pficon-delete"></button>
-            <button class="btn btn-default edit-button pficon pficon-edit"></button>
+            <button class="btn btn-danger edit-button servers-privileged pficon btn-delete pficon-delete"></button>
+            <button class="btn btn-default edit-button servers-privileged pficon pficon-edit"></button>
             <img class="host-avatar" src="{{render_avatar}}">
             <span>{{display_name}}</span>
           </a>


### PR DESCRIPTION
Fixes #1096.

The host management is going to be reworked in #1867.  That will solve some bigger issues with host managment, but for now disabling the buttons for users who don't have permission is a better experience.