### PR TITLE
shell: Disable saving vlan without a parent.

### DIFF
--- a/pkg/shell/cockpit-networking.js
+++ b/pkg/shell/cockpit-networking.js
@@ -3042,6 +3042,8 @@ PageNetworkVlanSettings.prototype = {
         function change() {
             // XXX - parse errors
             options.parent = shell.select_btn_selected(parent_btn);
+            $("#network-vlan-settings-apply").toggleClass("disabled", !options.parent);
+
             options.id = parseInt(id_input.val(), 10);
 
             if (auto_update_name && options.parent && options.id)


### PR DESCRIPTION
Fixes #1095 

Note that if there are no parents there will still be a javascript error. This isn't a regression though, it is caused by bootstrap-select and fixed in a newer version.

https://github.com/silviomoreto/bootstrap-select/commit/17e258dfef4532d4fc8215d3f1e761cc8b4ff3da

But i noticed that this newer version was rolledbacked here https://github.com/stefwalter/cockpit/commit/363590021a4b8428ba3aa96e5afa2ed902aa1abe. I'm not sure what exact problems it caused but it didn't want to reintroduce them.

Unless someone has a different suggestion, I think this is still fine to merge and the errors will go away once we are able to make the jump.