### PR TITLE
fix inline styling regression caused by #1961

### DIFF
--- a/pkg/base/cockpit.css
+++ b/pkg/base/cockpit.css
@@ -260,6 +260,7 @@ code, kbd, pre, samp {
     border-left: 1px #ddd solid;
     border-right: 1px #ddd solid;
     border-top: 1px #ddd solid;
+    border-bottom: 0;
     background-color: #f5f5f5;
     font-weight: bold;
     padding-top: 2px;

--- a/pkg/legacy/cockpit.css
+++ b/pkg/legacy/cockpit.css
@@ -287,6 +287,7 @@ code, kbd, pre, samp {
     border-left: 1px #ddd solid;
     border-right: 1px #ddd solid;
     border-top: 1px #ddd solid;
+    border-bottom: 0;
     background-color: #f5f5f5;
     font-weight: bold;
     padding-top: 2px;


### PR DESCRIPTION
Due to some cache issues I missed this one.
Specifies that the border is 0, so it doesn't inherit the black border by mistake.