### PR TITLE
Use shadow-utils for local accounts

### DIFF
--- a/pkg/shell/cockpit-accounts.js
+++ b/pkg/shell/cockpit-accounts.js
@@ -584,14 +584,19 @@ PageAccountConfirmDelete.prototype = {
     },
 
     apply: function() {
-        PageAccountConfirmDelete.account.call ('Delete',
-                                               $('#account-confirm-delete-files').prop('checked'),
-                                               function (error) {
-                                                   if (error)
-                                                       shell.show_unexpected_error(error);
-                                               });
-        $('#account-confirm-delete-dialog').modal('hide');
-        cockpit.location = "accounts";
+        var prog = ["/usr/sbin/userdel"];
+
+        if ($('#account-confirm-delete-files').prop('checked'))
+            prog.push("-r");
+
+        prog.push(PageAccountConfirmDelete.account.UserName);
+
+        cockpit.spawn(prog, { "superuser": true })
+           .done(function () {
+              $('#account-confirm-delete-dialog').modal('hide');
+              cockpit.location = "accounts";
+           })
+           .fail(shell.show_unexpected_error);
     }
 };
 

--- a/pkg/shell/cockpit-accounts.js
+++ b/pkg/shell/cockpit-accounts.js
@@ -385,12 +385,11 @@ PageAccountsCreate.prototype = {
         }
 
         if ($('#accounts-create-real-name').val()) {
-
             prog.push('-c');
-            prog.push($('#accounts-create-user-name').val());
+            prog.push($('#accounts-create-real-name').val());
         }
 
-        prog.push($('#accounts-create-real-name').val());
+        prog.push($('#accounts-create-user-name').val());
 
         cockpit.spawn(prog, { "superuser": true })
            .done(function () {

--- a/pkg/shell/cockpit-accounts.js
+++ b/pkg/shell/cockpit-accounts.js
@@ -473,8 +473,8 @@ PageAccount.prototype = {
                    self.roles[j] = { };
                    self.roles[j]["name"] = self.groups[i]["name"];
                    self.roles[j]["desc"] = self.groups[i]["name"] == "wheel" ?
-                                           "Server Administrator" :
-                                           "Containter Administrator";
+                                           _("Server Administrator") :
+                                           _("Container Administrator");
                    self.roles[j]["id"] = self.groups[i]["gid"];
                    self.roles[j]["member"] = is_user_in_group(shell.get_page_param('id'), self.groups[i]);
                    j++;

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -645,7 +645,7 @@
           <table>
             <tr>
               <td translatable="yes">Real Name</td>
-              <td style="vertical-align:bottom"><input id="account-real-name" class="form-control"></td>
+              <td style="vertical-align:bottom"><input id="account-real-name" class="form-control accounts-privileged"></td>
             </tr>
             <tr>
               <td translatable="yes">User Name</td>

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -644,11 +644,7 @@
         <center>
           <table>
             <tr>
-              <td>
-                <input data-role="none" type="file"
-                       id="account-avatar-uploader" style="display:none"/>
-                <img id="account-pic" width="128" height="128">
-              </td>
+              <td translatable="yes">Real Name</td>
               <td style="vertical-align:bottom"><input id="account-real-name" class="form-control"></td>
             </tr>
             <tr>

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -1342,6 +1342,15 @@
           <div class="modal-body">
             <table class="cockpit-form-table">
               <tr>
+                <td translatable="yes">Old Password</td>
+                <td>
+                  <div class="check-passwords">
+                    <input class="form-control" type="password"
+                           id="account-set-password-old"/>
+                  </div>
+                </td>
+              </tr>
+              <tr>
                 <td translatable="yes">New Password</td>
                 <td>
                   <div class="check-passwords">

--- a/test/check-accounts
+++ b/test/check-accounts
@@ -80,7 +80,7 @@ class TestAccounts(MachineCase):
         b.set_val('#accounts-create-locked', "no")
         b.click('#account-change-roles')
         b.wait_popup('account-change-roles-dialog')
-        b.set_checked('#account-role-checkbox-wheel', True)
+        b.set_checked('#account-role-checkbox-10', True)
         b.click('#account-change-roles-apply')
         b.wait_popdown('account-change-roles-dialog')
         check("jussi" in m.execute("grep wheel /etc/group"))

--- a/test/check-roles
+++ b/test/check-roles
@@ -49,7 +49,7 @@ class TestRoles(MachineCase):
         # https://github.com/cockpit-project/cockpit/issues/1248
         self.allow_journal_messages("Can't write /var/lib/cockpit/machines: Failed to create file '/var/lib/cockpit/machines\\..*': Permission denied")
 
-        # change its own name
+        # Try to change its own name
         b.click('#content-user-name')
         b.click('#go-account')
         b.enter_page("account")
@@ -61,7 +61,7 @@ class TestRoles(MachineCase):
         b.wait_present("#account-logout.disabled")
         b.wait_present("#account-change-roles.disabled")
         b.wait_present("#account-change-roles.disabled")
-        b.set_val('#account-real-name', "Userrrr")
+        b.wait_present('#account-real-name.disabled')
 
         # Try to change admins name
         b.go("account?id=admin")
@@ -79,7 +79,6 @@ class TestRoles(MachineCase):
         b.go("account?id=user")
         b.enter_page("account")
         b.wait_text("#account-user-name", "user")
-        b.wait_val("#account-real-name", "Userrrr")
 
         m.execute("usermod -a -G wheel user")
         b.wait_text("#account-roles", "Server Administrator")

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -134,6 +134,9 @@ Cockpit support for reading PCP metrics and loading PCP archives.
 Summary: Cockpit Shell user interface package
 Requires: %{name}-bridge = %{version}-%{release}
 Requires: NetworkManager
+Requires: pcp
+Requires: shadow-utils
+Requires: expect
 Requires: grep
 Requires: /usr/bin/date
 Obsoletes: %{name}-assets


### PR DESCRIPTION
Use shadow utils for changing local accounts. This is a follow on from #1877 

We won't remove the accountsservice yet, since that requires work on cockpit-setup.js. But we'll migrate the accounts page to shadow-utils.