### PR TITLE
Split "not-authorized" into "access-denied" and "authentication-failed"

### DIFF
--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -304,7 +304,7 @@
 	  <listitem><para>Try to spawn the process as root instead of the logged in user. If the
             currently logged in user is not permitted to become root (eg: via <code>pkexec</code>)
 	    then the <code>client</code> will immediately be
-	    <link linkend="cockpit-dbus-onclose">closed</link> with a <code>"not-authorized"</code>
+	    <link linkend="cockpit-dbus-onclose">closed</link> with a <code>"access-denied"</code>
             problem code.</para></listitem>
 	</varlistentry>
       </variablelist>
@@ -428,6 +428,14 @@
     <para>Cockpit represents problems with standardized problem string codes.</para>
     <variablelist>
       <varlistentry>
+        <term><code>"access-denied"</code></term>
+        <listitem><para>The user is not permitted to perform the action in question.</para></listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><code>"authentication-failed"</code></term>
+        <listitem><para>User authentication failed.</para></listitem>
+      </varlistentry>
+      <varlistentry>
         <term><code>"internal-error"</code></term>
         <listitem><para>An unexpected internal error without further info. This should
           not happen during the normal course of operations.</para></listitem>
@@ -440,10 +448,6 @@
       <varlistentry>
         <term><code>"no-session"</code></term>
         <listitem><para>Cockpit is not logged in.</para></listitem>
-      </varlistentry>
-      <varlistentry>
-        <term><code>"not-authorized"</code></term>
-        <listitem><para>The user is not permitted to perform the action in question.</para></listitem>
       </varlistentry>
       <varlistentry>
         <term><code>"not-found"</code></term>
@@ -597,7 +601,7 @@
             administrative users. If the currently logged in user is not
             permitted to become root (eg: via <code>pkexec</code>) then the <code>client</code> will
             immediately be <link linkend="cockpit-dbus-onclose">closed</link> with a
-            <code>"not-authorized"</code> problem code.</para></listitem>
+            <code>"access-denied"</code> problem code.</para></listitem>
         </varlistentry>
         <varlistentry>
           <term><code>"track"</code></term>
@@ -1310,7 +1314,7 @@
           <listitem><para>Try to open this channel as root. If the currently logged in user is not
 	    permitted to become root (eg: via <code>pkexec</code>) then the <code>channel</code> will
             immediately be <link linkend="cockpit-channels-close-ev">closed</link> with a
-            <code>"not-authorized"</code> problem code.</para></listitem>
+            <code>"access-denied"</code> problem code.</para></listitem>
         </varlistentry>
       </variablelist>
 
@@ -1960,7 +1964,7 @@ handle = file.watch(callback, error_callback);
           <listitem><para>Try to open this channel as root. If the currently logged in user is not
 	    permitted to become root (eg: via <code>pkexec</code>) then the <code>channel</code> will
             immediately be <link linkend="cockpit-channels-close-ev">closed</link> with a
-            <code>"not-authorized"</code> problem code.</para></listitem>
+            <code>"access-denied"</code> problem code.</para></listitem>
         </varlistentry>
       </variablelist>
 

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -140,7 +140,7 @@ The channel id must be set.  An example of a close:
     {
         "command": "close",
         "channel" : "5x",
-        "problem": "not-authorized"
+        "problem": "access-denied"
     }
 
 Any protocol participant can send this message. The cockpit-bridge and cockpit-ws
@@ -926,7 +926,8 @@ doubt use "internal-error".
  * "internal-error"
  * "no-cockpit"
  * "no-session"
- * "not-authorized"
+ * "access-denied"
+ * "authentication-failed"
  * "not-found"
  * "terminated"
  * "timeout"

--- a/pkg/base/cockpit.js
+++ b/pkg/base/cockpit.js
@@ -2217,7 +2217,9 @@ function full_scope(cockpit, $, po) {
             return _("Your session has been terminated.");
         else if (problem == "no-session")
             return _("Your session has expired. Please log in again.");
-        else if (problem == "not-authorized")
+        else if (problem == "access-denied")
+            return _("Not permitted to perform this action.");
+        else if (problem == "authentication-failed")
             return _("Login failed");
         else if (problem == "unknown-hostkey")
             return _("Untrusted host");

--- a/pkg/playground/test.html
+++ b/pkg/playground/test.html
@@ -61,7 +61,7 @@ require([
                  $(".cockpit-internal-reauthorize span").text("result: authorized");
              }).
              fail(function() {
-                 $(".cockpit-internal-reauthorize span").text("result: not-authorized");
+                 $(".cockpit-internal-reauthorize span").text("result: access-denied");
              });
          });
 

--- a/pkg/shell/cockpit-docker.js
+++ b/pkg/shell/cockpit-docker.js
@@ -279,7 +279,7 @@ function setup_for_failure(page, client) {
         else if (ex.problem == "not-found") {
             msg = _("Docker is not installed or activated on the system");
             show_start = true;
-        } else if (ex.problem == "not-authorized")
+        } else if (ex.problem == "access-denied")
             msg = _("Not authorized to access Docker on this system");
         else
             msg = cockpit.format(_("Can't connect to Docker: $0"), ex.toString());

--- a/pkg/shell/cockpit-server.js
+++ b/pkg/shell/cockpit-server.js
@@ -366,7 +366,7 @@ PageServer.prototype = {
                                                              fields.chassis_serial);
             })
             .fail(function(ex) {
-                if (ex.problem != "not-authorized")
+                if (ex.problem != "access-denied")
                     console.warn("couldn't read serial dmi info: " + ex);
             });
 

--- a/pkg/shell/cockpit-setup.js
+++ b/pkg/shell/cockpit-setup.js
@@ -290,7 +290,7 @@ PageSetupServer.prototype = {
                     $('#dashboard_setup_action_fingerprint').text(client.error_details["host-fingerprint"]);
                     self.connect_server();
                     return;
-                } else if (client.error == "not-authorized") {
+                } else if (client.error == "authentication-failed") {
                     /* The given credentials didn't work.  Ask the
                      * user to try again.
                      */

--- a/pkg/subscriptions/subscriptions.js
+++ b/pkg/subscriptions/subscriptions.js
@@ -275,7 +275,7 @@ define([
         function process_status_output(text, exit_details) {
             hide_progress_message();
 
-            if (exit_details.problem === 'not-authorized') {
+            if (exit_details.problem === 'access-denied') {
                 $('#subscription-manager-not-found').hide();
                 $('#subscription-manager-not-accessible').show();
                 return;

--- a/src/bridge/cockpitfslist.c
+++ b/src/bridge/cockpitfslist.c
@@ -72,7 +72,7 @@ static const gchar *
 error_to_problem (GError *error)
 {
   if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED))
-    return "not-authorized";
+    return "access-denied";
   else if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
     return "not-found";
   else if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_DIRECTORY))

--- a/src/bridge/cockpitfsread.c
+++ b/src/bridge/cockpitfsread.c
@@ -230,7 +230,7 @@ cockpit_fsread_prepare (CockpitChannel *channel)
           if (err == EPERM || err == EACCES)
             {
               g_debug ("%s: couldn't open: %s", self->path, strerror (err));
-              problem = "not-authorized";
+              problem = "access-denied";
             }
           else
             {

--- a/src/bridge/cockpitfsreplace.c
+++ b/src/bridge/cockpitfsreplace.c
@@ -68,7 +68,7 @@ prepare_for_close_with_errno (CockpitFsreplace *self,
   if (err == EPERM || err == EACCES)
     {
       g_debug ("%s: %s: %s", self->path, diagnostic, strerror (err));
-      return "not-authorized";
+      return "access-denied";
     }
   else
     {

--- a/src/bridge/cockpitportal.c
+++ b/src/bridge/cockpitportal.c
@@ -180,7 +180,7 @@ on_other_closed (CockpitTransport *transport,
       if (WIFEXITED (status))
         {
            if (WEXITSTATUS (status) == 127 || WEXITSTATUS (status) == 126)
-             problem = "not-authorized";
+             problem = "access-denied";
         }
     }
 

--- a/src/bridge/test-fs.c
+++ b/src/bridge/test-fs.c
@@ -316,7 +316,7 @@ test_read_denied (TestCase *tc,
   wait_channel_closed (tc);
 
   control = mock_transport_pop_control (tc->transport);
-  g_assert_cmpstr (json_object_get_string_member (control, "problem"), ==, "not-authorized");
+  g_assert_cmpstr (json_object_get_string_member (control, "problem"), ==, "access-denied");
 }
 
 static void
@@ -544,7 +544,7 @@ test_write_denied (TestCase *tc,
   wait_channel_closed (tc);
 
   control = mock_transport_pop_control (tc->transport);
-  g_assert_cmpstr (json_object_get_string_member (control, "problem"), ==, "not-authorized");
+  g_assert_cmpstr (json_object_get_string_member (control, "problem"), ==, "access-denied");
 
   g_assert (chmod (tc->test_dir, 0777) >= 0);
 }

--- a/src/bridge/test-stream.c
+++ b/src/bridge/test-stream.c
@@ -658,7 +658,7 @@ test_fail_not_found (void)
 }
 
 static void
-test_fail_not_authorized (void)
+test_fail_access_denied (void)
 {
   CockpitTransport *transport;
   CockpitChannel *channel;
@@ -691,7 +691,7 @@ test_fail_not_authorized (void)
   while (problem == NULL)
     g_main_context_iteration (NULL, TRUE);
 
-  g_assert_cmpstr (problem, ==, "not-authorized");
+  g_assert_cmpstr (problem, ==, "access-denied");
   g_free (problem);
   g_free (unix_path);
   close (fd);
@@ -727,7 +727,7 @@ main (int argc,
   g_test_add_func ("/stream/spawn/pty", test_spawn_pty);
 
   g_test_add_func ("/test-stream/fail/not-found", test_fail_not_found);
-  g_test_add_func ("/test-stream/fail/not-authorized", test_fail_not_authorized);
+  g_test_add_func ("/test-stream/fail/access-denied", test_fail_access_denied);
 
   return g_test_run ();
 }

--- a/src/common/cockpitpipe.c
+++ b/src/common/cockpitpipe.c
@@ -320,7 +320,7 @@ set_problem_from_connect_errno (CockpitPipe *self,
   const gchar *problem = NULL;
 
   if (errn == EPERM || errn == EACCES)
-    problem = "not-authorized";
+    problem = "access-denied";
   else if (errn == ENOENT || errn == ECONNREFUSED)
     problem = "not-found";
 
@@ -1058,7 +1058,7 @@ cockpit_pipe_spawn (const gchar **argv,
         problem = "not-found";
       else if (g_error_matches (error, G_SPAWN_ERROR, G_SPAWN_ERROR_PERM) ||
                g_error_matches (error, G_SPAWN_ERROR, G_SPAWN_ERROR_ACCES))
-        problem = "not-authorized";
+        problem = "access-denied";
 
       if (problem)
         {

--- a/src/common/cockpitpipetransport.c
+++ b/src/common/cockpitpipetransport.c
@@ -158,7 +158,7 @@ on_pipe_close (CockpitPipe *pipe,
           else if (WIFEXITED (status) && WEXITSTATUS (status) == 127)
             problem = "no-cockpit";      // cockpit-bridge not installed
           else if (WIFEXITED (status) && WEXITSTATUS (status) == 255)
-            problem = "terminated";      // ssh failed or got a signal, etc.
+            problem = "terminated";      // failed or got a signal, etc.
           else if (!g_spawn_check_exit_status (status, &error))
             {
               problem = "internal-error";

--- a/src/common/cockpitpipetransport.c
+++ b/src/common/cockpitpipetransport.c
@@ -155,10 +155,6 @@ on_pipe_close (CockpitPipe *pipe,
           status = cockpit_pipe_exit_status (pipe);
           if (WIFSIGNALED (status) && WTERMSIG (status) == SIGTERM)
             problem = "terminated";
-          else if (WIFEXITED (status) && WEXITSTATUS (status) == 5)
-            problem = "not-authorized";  // wrong password
-          else if (WIFEXITED (status) && WEXITSTATUS (status) == 6)
-            problem = "unknown-hostkey";
           else if (WIFEXITED (status) && WEXITSTATUS (status) == 127)
             problem = "no-cockpit";      // cockpit-bridge not installed
           else if (WIFEXITED (status) && WEXITSTATUS (status) == 255)

--- a/src/common/test-pipe.c
+++ b/src/common/test-pipe.c
@@ -1062,7 +1062,7 @@ test_fail_not_found (void)
 }
 
 static void
-test_fail_not_authorized (void)
+test_fail_access_denied (void)
 {
   CockpitPipe *pipe;
   GSocketAddress *address;
@@ -1099,7 +1099,7 @@ test_fail_not_authorized (void)
 
   cockpit_assert_expected ();
 
-  g_assert_cmpstr (problem, ==, "not-authorized");
+  g_assert_cmpstr (problem, ==, "access-denied");
   g_free (unix_path);
   g_free (problem);
   g_object_unref (pipe);
@@ -1201,7 +1201,7 @@ main (int argc,
   g_test_add_func ("/pipe/problem-later", test_problem_later);
 
   g_test_add_func ("/test-stream/connect/not-found", test_fail_not_found);
-  g_test_add_func ("/test-stream/connect/not-authorized", test_fail_not_authorized);
+  g_test_add_func ("/test-stream/connect/access-denied", test_fail_access_denied);
 
   return g_test_run ();
 }

--- a/src/common/test-webserver.c
+++ b/src/common/test-webserver.c
@@ -506,8 +506,8 @@ test_webserver_not_found (TestCase *tc,
 }
 
 static void
-test_webserver_not_authorized (TestCase *tc,
-                               gconstpointer user_data)
+test_webserver_access_denied (TestCase *tc,
+                              gconstpointer user_data)
 {
   gchar *resp;
   gsize length;
@@ -767,8 +767,8 @@ main (int argc,
               setup, test_webserver_host_header, teardown);
   g_test_add ("/web-server/not-found", TestCase, NULL,
               setup, test_webserver_not_found, teardown);
-  g_test_add ("/web-server/not-authorized", TestCase, NULL,
-              setup, test_webserver_not_authorized, teardown);
+  g_test_add ("/web-server/access-denied", TestCase, NULL,
+              setup, test_webserver_access_denied, teardown);
 
   g_test_add ("/web-server/redirect-notls", TestCase, &fixture_with_cert,
               setup, test_webserver_redirect_notls, teardown);

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -636,7 +636,7 @@ on_remote_login_done (CockpitSshTransport *transport,
 
   if (problem)
     {
-      if (g_str_equal (problem, "not-authorized"))
+      if (g_str_equal (problem, "authentication-failed"))
         {
           g_simple_async_result_set_error (task, COCKPIT_ERROR,
                                            COCKPIT_ERROR_AUTHENTICATION_FAILED,

--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -301,7 +301,7 @@ cockpit_ssh_authenticate (CockpitSshData *data)
   int methods;
   int rc;
 
-  problem = "not-authorized";
+  problem = "authentication-failed";
 
   rc = ssh_userauth_none (data->session, NULL);
   if (rc == SSH_AUTH_ERROR)
@@ -409,7 +409,7 @@ cockpit_ssh_authenticate (CockpitSshData *data)
       g_message ("%s: server offered unsupported authentication methods: %s",
                  data->logname, description);
       g_free (description);
-      problem = "not-authorized";
+      problem = "authentication-failed";
     }
   else if (!password && gsscreds == GSS_C_NO_CREDENTIAL)
     {
@@ -417,7 +417,7 @@ cockpit_ssh_authenticate (CockpitSshData *data)
     }
   else
     {
-      problem = "not-authorized";
+      problem = "authentication-failed";
     }
 
 out:

--- a/src/ws/test-sshtransport.c
+++ b/src/ws/test-sshtransport.c
@@ -458,7 +458,7 @@ test_unsupported_auth (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   g_assert_cmpstr (result, ==, problem);
-  g_assert_cmpstr (problem, ==, "not-authorized");
+  g_assert_cmpstr (problem, ==, "authentication-failed");
   g_free (problem);
   g_free (result);
 }
@@ -478,7 +478,7 @@ test_auth_failed (TestCase *tc,
   while (problem == NULL)
     g_main_context_iteration (NULL, TRUE);
 
-  g_assert_cmpstr (problem, ==, "not-authorized");
+  g_assert_cmpstr (problem, ==, "authentication-failed");
   g_free (problem);
 }
 

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -850,7 +850,7 @@ test_specified_creds_fail (TestCase *test,
   WAIT_UNTIL (received != NULL);
 
   /* Should have gotten a failure message, about the credentials */
-  expect_control_message (received, "close", "4", "problem", "not-authorized", NULL);
+  expect_control_message (received, "close", "4", "problem", "authentication-failed", NULL);
   g_bytes_unref (received);
 
   close_client_and_stop_web_service (test, ws, service);

--- a/test/check-reauthorize
+++ b/test/check-reauthorize
@@ -45,7 +45,7 @@ class TestReauthorize(MachineCase):
 	b.click(".cockpit-internal-reauthorize .btn")
 	b.wait_in_text(".cockpit-internal-reauthorize span", 'result:')
 
-	self.assertEqual(b.text(".cockpit-internal-reauthorize span"), 'result: not-authorized')
+	self.assertEqual(b.text(".cockpit-internal-reauthorize span"), 'result: access-denied')
 
     def testSuper(self):
         m = self.machine
@@ -68,6 +68,6 @@ class TestReauthorize(MachineCase):
         b.click(".super-channel .btn")
         b.wait_in_text(".super-channel span", 'result:')
 
-        self.assertEqual(b.text(".super-channel span"), 'result: not-authorized')
+        self.assertEqual(b.text(".super-channel span"), 'result: access-denied')
 
 test_main()


### PR DESCRIPTION
These are really two different error codes, and conflating them
only led to confusion.