### PR TITLE
Disable delete button for transport host

### DIFF
--- a/pkg/shell/cockpit-dashboard.js
+++ b/pkg/shell/cockpit-dashboard.js
@@ -471,6 +471,11 @@ PageDashboard.prototype = {
                 });
 
                 target.html(text);
+                $(".delete-localhost").tooltip({
+                      title : _("You are currently connected directly to this server. You cannot delete it.")
+                });
+                $(".delete-localhost").toggleClass('disabled', true);
+                $(".delete-localhost").toggleClass('servers-privileged', false);
                 update_servers_privileged();
                 update_series();
             }

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -99,7 +99,7 @@
           {{! state can be 'failed' or 'connected' }}
           <a data-address="{{address}}" class="list-group-item {{state}}"
               style="border-left-color: {{ color }};" target="_parent" href="/#/@{{address}}/system/host">
-            <button class="btn btn-danger edit-button servers-privileged pficon btn-delete pficon-delete"></button>
+            <button class="btn btn-danger edit-button servers-privileged pficon btn-delete pficon-delete delete-{{address}}"></button>
             <button class="btn btn-default edit-button servers-privileged pficon pficon-edit"></button>
             <img class="host-avatar" src="{{render_avatar}}">
             <span>{{label}}</span>

--- a/test/check-dashboard
+++ b/test/check-dashboard
@@ -99,6 +99,7 @@ class TestDashboard(MachineCase):
         b2.login_and_go("dashboard", href="/dashboard/list", host=None)
         self.inject_extras(b2)
         self.wait_dashboard_addresses (b2, [ "localhost" ])
+        b.wait_present("#dashboard-hosts a:nth-child(1) button.pficon-delete.disabled")
 
         self.add_machine (b, m2.address)
         self.wait_dashboard_addresses (b, [ "localhost", m2.address ])


### PR DESCRIPTION
Depends on #1996. Fixes 1529

We may eventually want to do something server side for this as well, but since that is in process of being refactored it didn't seem worth to to change that code now.