### PR TITLE
Disable NetworkManager on CI network bridge

### DIFF
--- a/test/vm-prep
+++ b/test/vm-prep
@@ -32,8 +32,8 @@ usage()
 prepare()
 {
 	if silent $VIRSH net-info cockpit; then
-		$VIRSH net-destroy cockpit
-		$VIRSH net-undefine cockpit
+		$VIRSH net-destroy cockpit || true
+		$VIRSH net-undefine cockpit || true
 	fi
 
 	xml=$(mktemp)

--- a/test/vm-prep
+++ b/test/vm-prep
@@ -36,6 +36,13 @@ prepare()
 		$VIRSH net-undefine cockpit || true
 	fi
 
+	# HACK: NetworkManager races with dnsmasq-dhcp on bridge
+	# https://bugzilla.redhat.com/show_bug.cgi?id=1205081
+	cat > /etc/sysconfig/network-scripts/ifcfg-cockpit0 << EOF
+DEVICE=cockpit0
+NM_CONTROLLED=no
+EOF
+
 	xml=$(mktemp)
 cat > $xml << EOF
 <network>


### PR DESCRIPTION
When running the ./VERIFY test suite with a Fedora 22 host machine, NetworkManager on the host races with dnsmasq-dhcp and often prevents the VMs from getting an address.

This works around the issue. However it does so by making NetworkManager ignore the ```cockpit0``` interface. If you've already run the test suite once before, you'll need to do the following before this fix will take effect:

```
$ sudo test/vm-prep -u
```