### PR TITLE
Don't report our TTY in 'w' or 'who' commands

### DIFF
--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -680,7 +680,7 @@ utmp_log (int login)
   ut.ut_tv.tv_sec = tv.tv_sec;
   ut.ut_tv.tv_usec = tv.tv_usec;
 
-  ut.ut_type = login ? USER_PROCESS : DEAD_PROCESS;
+  ut.ut_type = login ? LOGIN_PROCESS : DEAD_PROCESS;
   ut.ut_pid = pid;
 
   pututline (&ut);


### PR DESCRIPTION
GUI sessions aren't reported there. So we add our cockpit session with the utmp LOGIN_PROCESS flag instead of USER_PROCESS.
    
Obviously logind and loginctl still track our session as expected.

cockpit-bridge doesn't run in a TTY, although it does create pty's when necessary. So don't add a ut_line to the utmp log.
