### PR TITLE
Error stream options cleanup

### DIFF
--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -267,9 +267,9 @@
           <listitem><para>The directory to spawn the process in.</para></listitem>
         </varlistentry>
         <varlistentry>
-          <term><code>"error"</code></term>
+          <term><code>"err"</code></term>
           <listitem><para>Controls where the standard error is sent. By default it is logged
-            to the journal. If set to <code>"output"</code> it is included in with the
+            to the journal. If set to <code>"out"</code> it is included in with the
             output data.</para></listitem>
         </varlistentry>
         <varlistentry>

--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -270,7 +270,8 @@
           <term><code>"err"</code></term>
           <listitem><para>Controls where the standard error is sent. By default it is logged
             to the journal. If set to <code>"out"</code> it is included in with the
-            output data.</para></listitem>
+            output data. If set to <code>"ignore"</code> then the error output is discarded.
+            When the <code>"pty"</code> field is set, this field has no effect.</para></listitem>
         </varlistentry>
         <varlistentry>
           <term><code>"host"</code></term>

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -543,7 +543,7 @@ You can't specify both "unix" and "spawn" together. When "spawn" is set the
 following options can be specified:
 
  * "directory": The directory to spawn the process in.
- * "error": If "spawn" is set, and "error" is set to "output", then stderr
+ * "err": If "spawn" is set, and "err" is set to "out", then stderr
    is included in the payload data. If "pty" is set then stderr is always
    included.
  * "environ": This is a list of additional environment variables for the new

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -544,7 +544,8 @@ following options can be specified:
 
  * "directory": The directory to spawn the process in.
  * "err": If "spawn" is set, and "err" is set to "out", then stderr
-   is included in the payload data. If "pty" is set then stderr is always
+   is included in the payload data. If "err" is set to "ignore" then, the
+   stderr output will be discarded. If "pty" is set then stderr is always
    included.
  * "environ": This is a list of additional environment variables for the new
    spawned process. The variables are in the form of "NAME=VALUE". The default

--- a/examples/package-no-jquery/test.html
+++ b/examples/package-no-jquery/test.html
@@ -63,7 +63,7 @@ $ sudo systemctl restart cockpit</pre>
             var options = {
                 "payload": "stream",
                 "spawn": [ "ping", address.value ],
-                "error": "output",
+                "err": "out",
             };
             channel = cockpit.channel(options);
             channel.onmessage = function(ev, data) {

--- a/examples/package-simple/test.html
+++ b/examples/package-simple/test.html
@@ -57,7 +57,7 @@ $ sudo systemctl restart cockpit</pre>
             $("#failure").empty();
 
             var cmd = [ "ping", $("#address").val() ];
-            proc = cockpit.spawn(cmd, { "error": "output" }).
+            proc = cockpit.spawn(cmd, { "err": "out" }).
                 stream(function(data) {
                     output.append(document.createTextNode(data));
                 }).

--- a/pkg/base1/test-spawn-proc.html
+++ b/pkg/base1/test-spawn-proc.html
@@ -85,7 +85,7 @@ asyncTest("error log", function() {
 
 asyncTest("error output", function() {
     expect(2);
-    cockpit.spawn(["/bin/sh", "-c", "echo hi; echo yo >&2"], { error: "output" }).
+    cockpit.spawn(["/bin/sh", "-c", "echo hi; echo yo >&2"], { err: "out" }).
         done(function(resp) {
             equal(resp, "hi\nyo\n", "showed up");
         }).

--- a/pkg/shell/cockpit-accounts.js
+++ b/pkg/shell/cockpit-accounts.js
@@ -25,13 +25,6 @@
 var shell = shell || { };
 (function($, cockpit, shell) {
 
-function make_set(array) {
-    var s = { };
-    for (var i = 0; i < array.length; i++)
-        s[array[i]] = true;
-    return s;
-}
-
 function update_accounts_privileged() {
     shell.update_privileged_ui(
         shell.default_permission, ".accounts-privileged",
@@ -44,48 +37,6 @@ function update_accounts_privileged() {
 }
 
 $(shell.default_permission).on("changed", update_accounts_privileged);
-
-function fill_canvas(canvas, overlay, data, width, callback)
-{
-    var img = new window.Image();
-    img.onerror = function () {
-        shell.show_error_dialog(_("Can't use this file"), _("Can't read it."));
-    };
-    img.onload = function () {
-        canvas.width = width;
-        canvas.height = canvas.width * (img.height/img.width);
-        overlay.width = canvas.width;
-        overlay.height = canvas.height;
-        var ctxt = canvas.getContext("2d");
-        ctxt.clearRect(0, 0, canvas.width, canvas.height);
-        ctxt.drawImage(img, 0, 0, canvas.width, canvas.height);
-        callback ();
-    };
-    img.src = data;
-}
-
-function canvas_data(canvas, x1, y1, x2, y2, width, height, format)
-{
-    var dest = $('<canvas/>')[0];
-    dest.width = width;
-    dest.height = height;
-    var dest_w, dest_h;
-    var img_w = x2 - x1, img_h = y2 - y1;
-    if (img_w > img_h) {
-        dest_w = width;
-        dest_h = dest_w * (img_h/img_w);
-    } else {
-        dest_h = height;
-        dest_w = dest_h * (img_w/img_h);
-    }
-    var ctxt = dest.getContext("2d");
-    ctxt.drawImage (canvas,
-                    x1, y1, img_w, img_h,
-                    (width - dest_w)/2, (height - dest_h)/2, dest_w, dest_h);
-    return dest.toDataURL(format);
-}
-
-// XXX - make private
 
 function on_account_changes(client, id, func) {
     function object_added(event, obj) {

--- a/pkg/shell/cockpit-server.js
+++ b/pkg/shell/cockpit-server.js
@@ -345,7 +345,7 @@ PageServer.prototype = {
         }
 
         cockpit.spawn(["grep", "\\w", "bios_vendor", "bios_version", "bios_date", "sys_vendor", "product_name"],
-                      { directory: "/sys/devices/virtual/dmi/id" })
+                      { directory: "/sys/devices/virtual/dmi/id", err: "ignore" })
             .done(function(output) {
                 var fields = parse_lines(output);
                 $("#system_information_bios_text").text(fields.bios_vendor + " " +
@@ -359,7 +359,7 @@ PageServer.prototype = {
             });
 
         cockpit.spawn(["grep", "\\w", "product_serial", "chassis_serial"],
-                      { directory: "/sys/devices/virtual/dmi/id", superuser: true })
+                      { directory: "/sys/devices/virtual/dmi/id", superuser: true, err: "ignore" })
             .done(function(output) {
                 var fields = parse_lines(output);
                 $("#system_information_asset_tag_text").text(fields.product_serial ||

--- a/pkg/subscriptions/subscriptions.js
+++ b/pkg/subscriptions/subscriptions.js
@@ -347,7 +347,7 @@ define([
              * 'subscription-manager status' will only return with exit code 0 if all is well (and subscriptions current)
              */
             cockpit.spawn(['subscription-manager', 'status'],
-                    { directory: '/', superuser: true, environ: ['LC_ALL=C'], error: "output" })
+                    { directory: '/', superuser: true, environ: ['LC_ALL=C'], err: "out" })
                 .stream(function(text) {
                     status_buffer += text;
                     return text.length;
@@ -397,7 +397,7 @@ define([
              * without translations and parse the output
              */
             var buffer = '';
-            var process = cockpit.spawn(args, { directory: '/', superuser: true, environ: ['LC_ALL=C'], error: "output" })
+            var process = cockpit.spawn(args, { directory: '/', superuser: true, environ: ['LC_ALL=C'], err: "out" })
                 .stream(function(text) {
                     buffer += text;
                     return text.length;

--- a/src/bridge/cockpitstream.c
+++ b/src/bridge/cockpitstream.c
@@ -353,8 +353,10 @@ cockpit_stream_prepare (CockpitChannel *channel)
         }
 
       flags = COCKPIT_PIPE_STDERR_TO_LOG;
-      if (error && g_str_equal (error, "out"))
+      if (g_strcmp0 (error, "out") == 0)
         flags = COCKPIT_PIPE_STDERR_TO_STDOUT;
+      else if (g_strcmp0 (error, "ignore") == 0)
+        flags = COCKPIT_PIPE_STDERR_TO_NULL;
 
       self->name = g_strdup (argv[0]);
       if (!cockpit_json_get_string (options, "directory", NULL, &dir))

--- a/src/bridge/cockpitstream.c
+++ b/src/bridge/cockpitstream.c
@@ -346,14 +346,14 @@ cockpit_stream_prepare (CockpitChannel *channel)
 
   if (argv)
     {
-      if (!cockpit_json_get_string (options, "error", NULL, &error))
+      if (!cockpit_json_get_string (options, "err", NULL, &error))
         {
-          g_warning ("invalid \"error\" options for stream channel");
+          g_warning ("invalid \"err\" options for stream channel");
           goto out;
         }
 
       flags = COCKPIT_PIPE_STDERR_TO_LOG;
-      if (error && g_str_equal (error, "output"))
+      if (error && g_str_equal (error, "out"))
         flags = COCKPIT_PIPE_STDERR_TO_STDOUT;
 
       self->name = g_strdup (argv[0]);

--- a/src/common/cockpitpipe.c
+++ b/src/common/cockpitpipe.c
@@ -906,7 +906,8 @@ cockpit_pipe_connect (const gchar *name,
 }
 
 static GSpawnFlags
-calculate_spawn_flags (const gchar **env)
+calculate_spawn_flags (const gchar **env,
+                       CockpitPipeFlags pflags)
 {
   GSpawnFlags flags = G_SPAWN_DO_NOT_REAP_CHILD;
   gboolean path_flag = FALSE;
@@ -923,6 +924,9 @@ calculate_spawn_flags (const gchar **env)
 
   if (!path_flag)
     flags |= G_SPAWN_SEARCH_PATH;
+
+  if (pflags & COCKPIT_PIPE_STDERR_TO_NULL)
+    flags |= G_SPAWN_STDERR_TO_DEV_NULL;
 
   return flags;
 }
@@ -1033,7 +1037,7 @@ cockpit_pipe_spawn (const gchar **argv,
   GPid pid = 0;
 
   g_spawn_async_with_pipes (directory, (gchar **)argv, (gchar **)env,
-                            calculate_spawn_flags (env),
+                            calculate_spawn_flags (env, flags),
                             (flags & COCKPIT_PIPE_STDERR_TO_STDOUT) ? stderr_to_stdout : NULL, NULL,
                             &pid, &session_stdin, &session_stdout,
                             (flags & COCKPIT_PIPE_STDERR_TO_LOG) ? &session_stderr : NULL, &error);

--- a/src/common/cockpitpipe.h
+++ b/src/common/cockpitpipe.h
@@ -28,6 +28,7 @@ typedef enum {
   COCKPIT_PIPE_FLAGS_NONE = 0,
   COCKPIT_PIPE_STDERR_TO_LOG = 1 << 0,
   COCKPIT_PIPE_STDERR_TO_STDOUT = 1 << 1,
+  COCKPIT_PIPE_STDERR_TO_NULL = 1 << 2,
 } CockpitPipeFlags;
 
 #define COCKPIT_TYPE_PIPE         (cockpit_pipe_get_type ())


### PR DESCRIPTION
Add option to streams to ignore stderr output

Change the stream 'error' field to 'err'. This changes where stderr goes. Having it be called 'error' was confusing because it made you think of the failed process.
