### PR TITLE
common: Stream stderr to the journal from each process

### DIFF
--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -391,7 +391,7 @@ run_bridge (const gchar *interactive)
   int outfd;
   uid_t uid;
 
-  cockpit_set_journal_logging (!isatty (2));
+  cockpit_set_journal_logging (G_LOG_DOMAIN, !isatty (2));
 
   /* Always set environment variables early */
   uid = geteuid();

--- a/src/bridge/cockpitpcp.c
+++ b/src/bridge/cockpitpcp.c
@@ -211,7 +211,7 @@ main (int argc,
       return 2;
     }
 
-  cockpit_set_journal_logging (!isatty (2));
+  cockpit_set_journal_logging (G_LOG_DOMAIN, !isatty (2));
 
   /*
    * This process talks on stdin/stdout. However lots of stuff wants to write

--- a/src/common/cockpitlog.h
+++ b/src/common/cockpitlog.h
@@ -34,7 +34,8 @@ void     cockpit_journal_log_handler    (const gchar *log_domain,
                                          const gchar *message,
                                          gpointer user_data);
 
-void     cockpit_set_journal_logging    (gboolean only);
+void     cockpit_set_journal_logging    (const gchar *stderr_domain,
+                                         gboolean only);
 
 /*
  * GLib doesn't have g_info() yet:

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -132,7 +132,7 @@ main (int argc,
   if (g_getenv ("PATH") == NULL)
     g_setenv ("PATH", "/usr/bin:/bin:/usr/sbin:/sbin", TRUE);
 
-  cockpit_set_journal_logging (!isatty (2));
+  cockpit_set_journal_logging (G_LOG_DOMAIN, !isatty (2));
 
   g_debug ("cockpit daemon version %s starting", PACKAGE_VERSION);
 

--- a/src/remotectl/remotectl.c
+++ b/src/remotectl/remotectl.c
@@ -81,7 +81,7 @@ main (int argc,
   signal (SIGPIPE, SIG_IGN);
 
   /* Send a copy of everything to the journal */
-  cockpit_set_journal_logging (FALSE);
+  cockpit_set_journal_logging (G_LOG_DOMAIN, FALSE);
 
   /* g_message in this domain becomes command output */
   g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -91,7 +91,7 @@ main (int argc,
       goto out;
     }
 
-  cockpit_set_journal_logging (!isatty (2));
+  cockpit_set_journal_logging (NULL, !isatty (2));
 
   if (opt_no_tls)
     {


### PR DESCRIPTION
When running without a tty as stdin, stream our stderr (ie: fd 2)
to the journal. Previously we would only do this with g_printerr()
and this caused confusing messages which look like they're coming
from the wrong process:

cockpit-ws[26201]: Error Parsing ASCII PMNS: Cannot open "/var/lib/pcp/pmns/root"