### PR TITLE
shell: Encode password properly before passing to expect

### DIFF
--- a/pkg/shell/cockpit-accounts.js
+++ b/pkg/shell/cockpit-accounts.js
@@ -164,25 +164,31 @@ function change_password(user_name, old_pass, new_pass, success_call, failure_ca
     var expect_in;
     var call;
 
+    var percent = /%/g;
+    if (old_pass)
+        old_pass = encodeURIComponent(old_pass).replace(percent, "\\x");
+    if (new_pass)
+        new_pass = encodeURIComponent(new_pass).replace(percent, "\\x");
+
     if (cockpit.user["user"] == user_name) {
         expect_in  = 'spawn passwd;' +
             'expect "Changing password for user ' + user_name + '";' +
             'expect "Changing password for ' + user_name + '";' +
             'expect "(current) UNIX password: ";' +
-            'send "' + old_pass + '\\r";' +
+            'send -- "' + old_pass + '\\r";' +
             'expect "New password: ";' +
-            'send "' + new_pass + '\\r";' +
+            'send -- "' + new_pass + '\\r";' +
             'expect "Retype new password: ";' +
-            'send "' + new_pass + '\\r";' +
+            'send -- "' + new_pass + '\\r";' +
             'expect "passwd: all authentication tokens updated successfully.";';
         call = cockpit.spawn([ "/usr/bin/expect"], { "environ": ["LC_ALL=C"]});
     } else {
         expect_in = 'spawn passwd ' + user_name + ';' +
             'expect "Changing password for user ' + user_name + '";' +
             'expect "New password: ";' +
-            'send "' + new_pass + '\\r";' +
+            'send -- "' + new_pass + '\\r";' +
             'expect "Retype new password: ";' +
-            'send "' + new_pass + '\\r";' +
+            'send -- "' + new_pass + '\\r";' +
             'expect "passwd: all authentication tokens updated successfully.";';
         call = cockpit.spawn([ "/usr/bin/expect"], {"superuser" : true, "environ": ["LC_ALL=C"]});
     }

--- a/test/check-accounts
+++ b/test/check-accounts
@@ -85,4 +85,26 @@ class TestAccounts(MachineCase):
         b.wait_popdown('account-change-roles-dialog')
         check("jussi" in m.execute("grep wheel /etc/group"))
 
+        # Change the password of this account
+        b.go("account?id=jussi")
+        b.enter_page("account")
+        b.set_val('#accounts-create-locked', "no")
+        b.click('#account-set-password')
+        b.wait_popup('account-set-password-dialog')
+        b.set_val("#account-set-password-pw1", 'ö5"')
+        b.set_val("#account-set-password-pw2", 'ö5"')
+        b.click('#account-set-password-apply')
+        b.wait_popdown('account-set-password-dialog')
+
+        # Logout and login with the new password
+        b.logout()
+        self.allow_restart_journal_messages()
+        b.open("system/host")
+        b.wait_visible("#login")
+        b.set_val("#login-user-input", "jussi")
+        b.set_val("#login-password-input", 'ö5"')
+        b.click('#login-button')
+        b.expect_reload()
+        b.wait_present('#content')
+
 test_main()


### PR DESCRIPTION
We use an expect script to drive the passwd command, and we need
to encode the password before passing it to expect.

Or else we get messages like this:

cockpit-bridge[31652]: extra characters after close-quote
cockpit-bridge[31652]: while executing
cockpit-bridge[31652]: "send ""\"

Add test for this case.