### PR TITLE
PCP "not-found" and "not-supported" error codes

### DIFF
--- a/pkg/shell/plot.js
+++ b/pkg/shell/plot.js
@@ -499,10 +499,10 @@ shell.plot = function plot(element, x_range_seconds, x_stop_seconds) {
             real_time_samples_timestamp = vals[0][0];
         }
 
-        function channel_closed(ev, options) {
+        function channel_closed(ev, options, desc) {
             real_time_channel = null;
             if (options.problem)
-                console.log("problem retrieving metrics data: " + options.problem);
+                console.log("problem retrieving " + desc + " metrics data: " + options.problem);
         }
 
         real_time_channel = channel_sampler($.extend({ }, chanopts, {
@@ -518,11 +518,11 @@ shell.plot = function plot(element, x_range_seconds, x_stop_seconds) {
                     interval: real_time_samples_interval,
                     metrics: fallback
                 }), process_samples);
-                $(real_time_channel).on("close", channel_closed);
+                $(real_time_channel).on("close", channel_closed, "internal");
 
             /* Otherwise it could be just a normal failure */
             } else {
-                channel_closed(event, options);
+                channel_closed(event, options, "real time");
             }
         });
 

--- a/pkg/shell/plot.js
+++ b/pkg/shell/plot.js
@@ -512,7 +512,7 @@ shell.plot = function plot(element, x_range_seconds, x_stop_seconds) {
         $(real_time_channel).on("close", function (event, options) {
 
             /* Go for the fallback internal metrics if these metrics are not supported */
-            if (options.problem == "not-supported" && fallback) {
+            if ((options.problem == "not-supported" || options.problem == "not-found") && fallback) {
                 real_time_channel = channel_sampler($.extend({ }, chanopts, {
                     source: "internal",
                     interval: real_time_samples_interval,

--- a/src/bridge/test-pcp-archives.c
+++ b/src/bridge/test-pcp-archives.c
@@ -332,7 +332,7 @@ static void
 test_metrics_archive_directory_late_metric (TestCase *tc,
                                             gconstpointer unused)
 {
-  cockpit_expect_warning ("*no such metric: mock.late (Unknown metric name)*");
+  cockpit_expect_message ("*no such metric: mock.late: Unknown metric name*");
 
   JsonObject *meta;
   JsonObject *options = json_obj("{ 'source': '" BUILDDIR "/mock-archives',"


### PR DESCRIPTION
Return "not-found" and "not-supported" error codes from PCP channels.

 * When PCP fails to initialize
 * When archives are not available
 * When certain metrics are not available

And use those codes to fallback to internal implementations.