### PR TITLE
Kill channels

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -102,6 +102,7 @@ The following fields are defined:
  * "host": The destination host for the channel, defaults to "localhost"
  * "user": Optional alternate user for authenticating with host
  * "superuser": When true, try to run this channel as root.
+ * "tag": A tag that can later be used with the "kill" command.
 
 If "binary" is set then this channel transfers binary messages. If "binary"
 is set to "base64" then messages in the channel are encoded using "base64",
@@ -228,6 +229,21 @@ Example authorize challenge and response messages:
         "cookie": "555",
         "response": "crypt1:$6$r0oetn2039ntoen..."
     }
+
+Command: kill
+-------------
+
+The "kill" command terminates a whole set of channels. It is sent by the frontend
+and processed by cockpit-ws.
+
+The following fields are defined:
+
+ * "host": optional string kills channels with the given host
+ * "tag": optional string to select only channels opened with the given "tag"
+
+If no fields are specified then all channels are terminated. The "kill" command
+is not forwarded.
+
 
 Command: logout
 ---------------

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -102,7 +102,7 @@ The following fields are defined:
  * "host": The destination host for the channel, defaults to "localhost"
  * "user": Optional alternate user for authenticating with host
  * "superuser": When true, try to run this channel as root.
- * "tag": A tag that can later be used with the "kill" command.
+ * "group": A group that can later be used with the "kill" command.
 
 If "binary" is set then this channel transfers binary messages. If "binary"
 is set to "base64" then messages in the channel are encoded using "base64",
@@ -239,7 +239,7 @@ and processed by cockpit-ws.
 The following fields are defined:
 
  * "host": optional string kills channels with the given host
- * "tag": optional string to select only channels opened with the given "tag"
+ * "group": optional string to select only channels opened with the given "group"
 
 If no fields are specified then all channels are terminated. The "kill" command
 is not forwarded.

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -911,6 +911,17 @@ function basic_scope(cockpit) {
         });
     };
 
+    cockpit.kill = function kill(host, tag) {
+        var options = { "command": "kill" };
+        if (host)
+            options.host = host;
+        if (tag)
+            options.tag = tag;
+        ensure_transport(function(transport) {
+            transport.send_control(options);
+        });
+    };
+
     cockpit.transport = {
         inject: function inject(message) {
             if (!default_transport)

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -911,12 +911,12 @@ function basic_scope(cockpit) {
         });
     };
 
-    cockpit.kill = function kill(host, tag) {
+    cockpit.kill = function kill(host, group) {
         var options = { "command": "kill" };
         if (host)
             options.host = host;
-        if (tag)
-            options.tag = tag;
+        if (group)
+            options.group = group;
         ensure_transport(function(transport) {
             transport.send_control(options);
         });

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -683,6 +683,11 @@ define([
                 /* Only control messages with a channel are forwardable */
                 } else if (control.channel === undefined) {
                     return;
+
+                /* Add the frame's tag to all open channel messages */
+                } else if (control.command == "open") {
+                    control.tag = frame.name;
+                    data = "\n" + JSON.stringify(control);
                 }
             }
 
@@ -725,6 +730,8 @@ define([
                 return;
             }
 
+            /* Close all channels for this frame */
+            cockpit.kill(null, child.name);
             delete frame_peers_by_seed[peer.channel_seed];
             delete frame_peers_by_name[child.name];
         };

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -202,7 +202,10 @@ define([
             maybe_ready();
         })
         .on("added changed", function(ev, machine) {
-            machine.connect();
+            if (machine.visible)
+                machine.connect();
+            else
+                frames.remove(machine);
             update_machines();
             if (machines.loaded)
                 navigate();

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -237,7 +237,7 @@ define([
                 });
             });
         })
-        .off("removed", function(ev, frame) {
+        .on("removed", function(ev, frame) {
             router.unregister(frame.contentWindow);
             $(frame.contentWindow).off();
             $(frame).off();
@@ -535,7 +535,7 @@ define([
             var address = machine.address;
             if (!address)
                 address = "localhost";
-            var list = iframes[machines.address];
+            var list = iframes[machine.address];
             if (list) {
                 delete iframes[address];
                 $.each(list, function(i, frame) {

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -684,9 +684,9 @@ define([
                 } else if (control.channel === undefined) {
                     return;
 
-                /* Add the frame's tag to all open channel messages */
+                /* Add the frame's group to all open channel messages */
                 } else if (control.command == "open") {
-                    control.tag = frame.name;
+                    control.group = frame.name;
                     data = "\n" + JSON.stringify(control);
                 }
             }

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -1110,6 +1110,7 @@ lookup_or_open_session_for_host (CockpitWebService *self,
 {
   CockpitSession *session = NULL;
   CockpitTransport *transport;
+  const gchar *hostname;
 
   if (host == NULL || g_strcmp0 (host, "") == 0)
     host = "localhost";
@@ -1119,14 +1120,15 @@ lookup_or_open_session_for_host (CockpitWebService *self,
   if (!session)
     {
       /* Used during testing */
+      hostname = host;
       if (g_strcmp0 (host, "localhost") == 0)
         {
           if (cockpit_ws_specific_ssh_port != 0)
-            host = "127.0.0.1";
+            hostname = "127.0.0.1";
         }
 
       transport = g_object_new (COCKPIT_TYPE_SSH_TRANSPORT,
-                                "host", host,
+                                "host", hostname,
                                 "port", cockpit_ws_specific_ssh_port,
                                 "command", cockpit_ws_bridge_program,
                                 "creds", creds,

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -1300,10 +1300,18 @@ dispatch_inbound_command (CockpitWebService *self,
     }
   else if (g_strcmp0 (command, "close") == 0)
     {
-      session = cockpit_session_by_channel (&self->sessions, channel);
-      valid = process_close (self, socket, session, channel, options);
-      if (valid && session && !session->sent_done)
-        cockpit_transport_send (session->transport, NULL, payload);
+      if (channel == NULL)
+        {
+          g_warning ("got close command without a channel");
+          valid = FALSE;
+        }
+      else
+        {
+          session = cockpit_session_by_channel (&self->sessions, channel);
+          valid = process_close (self, socket, session, channel, options);
+          if (valid && session && !session->sent_done)
+            cockpit_transport_send (session->transport, NULL, payload);
+        }
     }
   else if (channel)
     {

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -762,7 +762,7 @@ process_kill (CockpitWebService *self,
     {
       channel = l->data;
 
-      g_debug ("%s: killing channel: %s", socket->id, (gchar *)channel);
+      g_debug ("%s killing channel: %s", socket->id, (gchar *)channel);
 
       /* Send a close message to both parties */
       payload = build_control ("command", "close", "channel", (gchar *)channel, "problem", "terminated", NULL);

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -1091,8 +1091,8 @@ test_fail_spawn (TestCase *test,
 }
 
 static void
-test_kill_tags (TestCase *test,
-                gconstpointer data)
+test_kill_group (TestCase *test,
+                 gconstpointer data)
 {
   WebSocketConnection *ws;
   GBytes *received = NULL;
@@ -1126,12 +1126,12 @@ test_kill_tags (TestCase *test,
   g_hash_table_add (seen, "b");
   g_hash_table_add (seen, "c");
 
-  send_control_message (ws, "open", "a", "payload", "echo", "tag", "test", NULL);
-  send_control_message (ws, "open", "b", "payload", "echo", "tag", "test", NULL);
-  send_control_message (ws, "open", "c", "payload", "echo", "tag", "test", NULL);
+  send_control_message (ws, "open", "a", "payload", "echo", "group", "test", NULL);
+  send_control_message (ws, "open", "b", "payload", "echo", "group", "test", NULL);
+  send_control_message (ws, "open", "c", "payload", "echo", "group", "test", NULL);
 
   /* Kill all the above channels */
-  send_control_message (ws, "kill", NULL, "tag", "test", NULL);
+  send_control_message (ws, "kill", NULL, "group", "test", NULL);
 
   /* All the close messages */
   while (g_hash_table_size (seen) > 0)
@@ -1211,9 +1211,9 @@ test_kill_host (TestCase *test,
   g_hash_table_add (seen, "c");
   g_hash_table_add (seen, "4");
 
-  send_control_message (ws, "open", "a", "payload", "echo", "tag", "test", NULL);
-  send_control_message (ws, "open", "b", "payload", "echo", "tag", "test", NULL);
-  send_control_message (ws, "open", "c", "payload", "echo", "tag", "test", NULL);
+  send_control_message (ws, "open", "a", "payload", "echo", "group", "test", NULL);
+  send_control_message (ws, "open", "b", "payload", "echo", "group", "test", NULL);
+  send_control_message (ws, "open", "c", "payload", "echo", "group", "test", NULL);
 
   /* Kill all the above channels */
   send_control_message (ws, "kill", NULL, "host", "localhost", NULL);
@@ -2071,8 +2071,8 @@ main (int argc,
               &fixture_hixie76, setup_for_socket,
               test_fail_spawn, teardown_for_socket);
 
-  g_test_add ("/web-service/kill-tags", TestCase, &fixture_rfc6455,
-              setup_for_socket, test_kill_tags, teardown_for_socket);
+  g_test_add ("/web-service/kill-group", TestCase, &fixture_rfc6455,
+              setup_for_socket, test_kill_group, teardown_for_socket);
   g_test_add ("/web-service/kill-host", TestCase, &fixture_rfc6455,
               setup_for_socket, test_kill_host, teardown_for_socket);
 


### PR DESCRIPTION
In javascript we have absolutely no access to the garbage collector. In particular cleaning up resources on cockpit-ws or cockpit-bridge when javascript objects go away is very tedious.

We mitigate this by having various components in different framed documents. When such a framed document goes away, all of its channels should be closed. Until now we were not doing this.

Here we implement a helpful facility in cockpit-ws which lets us tag and close whole sets of channels in one shot. This will also allow us to close all channels connected to a specific host.