### PR TITLE
common: Don't add BasicConstraints with cA = TRUE in our cert

### DIFF
--- a/src/common/cockpitcertificate.c
+++ b/src/common/cockpitcertificate.c
@@ -54,6 +54,7 @@ openssl_make_dummy_cert (const gchar *key_file,
     "-out", out_file,
     "-outform", "PEM",
     "-subj", "/CN=localhost",
+    "-extensions", "v3_req",
     NULL
   };
 


### PR DESCRIPTION
The default certificate generated by openssl seems to be one that
is a CA certificate, and not appropriate for use on a server. We
use the 'v3_req' extensions configuration to generate a more
appropriate certificate.