### PR TITLE
shell: Unquote the Etag we get from server which contains checksum

### DIFF
--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -858,8 +858,8 @@ define([
                 .done(function(manis) {
                     machine.components = self.build(manis);
                     var etag = req.getResponseHeader("ETag");
-                    if (etag)
-                        machine.checksum = etag;
+                    if (etag) /* and remove quotes */
+                        machine.checksum = etag.replace(/^"?(.+)"?$/,'$1');
                 })
                 .fail(function(ex) {
                     console.warn("failed to load manifests from " + machine.address + ": " + ex);


### PR DESCRIPTION
ETags are generally quoted, but we don't want to use a quoted
checksum in our URLs