### PR TITLE
test: Repeat the test when booting the VM times out.

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -602,8 +602,21 @@ def test_main():
         suite = unittest.TestLoader().loadTestsFromNames(args.tests, module=__main__)
     else:
         suite = unittest.TestLoader().loadTestsFromModule(__main__)
-    runner = unittest.TextTestRunner(verbosity=args.verbosity, failfast=True, resultclass=Result)
-    result = runner.run(suite)
+
+    tries = 0
+    repeat_this = True
+    while repeat_this and tries < 5:
+        runner = unittest.TextTestRunner(verbosity=args.verbosity, failfast=True, resultclass=Result)
+        result = runner.run(suite)
+        repeat_this = False
+        for e in result.errors:
+            if "RepeatThis: " in e[1]:
+                repeat_this = True
+        tries += 1
+
+    if repeat_this:
+        print "Not repeating after %d spurious failures" % tries
+
     sys.exit(not result.wasSuccessful())
 
 class Error(Exception):

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -42,6 +42,9 @@ class Failure(Exception):
     def __str__(self):
         return self.msg
 
+class RepeatThis(Failure):
+    pass
+
 class Machine:
     boot_hook = None
 
@@ -711,8 +714,9 @@ class QemuMachine(Machine):
                         ready_to_login = True
                     (unused, sep, output) = output.rpartition("\n")
             if time.time() - now > 600:
+                # HACK - https://bugzilla.redhat.com/show_bug.cgi?id=1205529
                 sys.stdout.write("Boot log:\n" + all_output + "\n")
-                raise Failure("qemu vm boot timed out")
+                raise RepeatThis("qemu vm boot timed out")
 
         if p.poll():
             raise Failure("qemu did not run successfully: %d" % (p.returncode, ))


### PR DESCRIPTION
It's not super clean to grep the textual backtrace, but it's the most straightforward approach given the TestResult class.
