### PR TITLE
test: Don't read qemu console output during boot.

### DIFF
--- a/test/README
+++ b/test/README
@@ -15,7 +15,7 @@ Fedora:
 
   # yum install trickle npm python-libguestfs qemu mock qemu-kvm python \
          curl libvirt-client fakeroot glibc-static openssl \
-         rpm-build krb5-workstation
+         rpm-build krb5-workstation python-lxml
 
 Testing requires phantomjs globally on the system, not just inside the cockpit package.
 

--- a/test/network-cockpit.xml
+++ b/test/network-cockpit.xml
@@ -1,0 +1,38 @@
+<network>
+	<name>cockpit</name>
+	<uuid>f3605fa4-0763-41ea-8143-49da3bf73262</uuid>
+	<forward mode='nat'>
+		<nat>
+			<port start='1024' end='65535'/>
+		</nat>
+	</forward>
+	<bridge name='cockpit0' stp='on' delay='0' />
+	<mac address='52:54:00:b8:d2:b5'/>
+	<domain name='cockpit.lan'/>
+	<ip address='10.111.111.200' netmask='255.255.255.0'>
+		<dhcp>
+                        <host mac='52:54:00:9e:00:00' ip='10.111.111.10'   name='m10.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:01' ip='10.111.111.11'   name='m11.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:02' ip='10.111.111.12'   name='m12.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:03' ip='10.111.111.13'   name='m13.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:04' ip='10.111.111.14'   name='m14.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:05' ip='10.111.111.15'   name='m15.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:06' ip='10.111.111.16'   name='m16.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:07' ip='10.111.111.17'   name='m17.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:08' ip='10.111.111.18'   name='m18.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:09' ip='10.111.111.19'   name='m19.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:0a' ip='10.111.111.20'   name='m20.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:0b' ip='10.111.111.21'   name='m21.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:0c' ip='10.111.111.22'   name='m22.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:0d' ip='10.111.111.23'   name='m23.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:0e' ip='10.111.111.24'   name='m24.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:0f' ip='10.111.111.25'   name='m25.cockpit.lan'/>
+
+                        <host mac='52:54:00:9e:00:F0' ip='10.111.111.100' name='f0.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:F1' ip='10.111.111.101' name='f1.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:F2' ip='10.111.111.102' name='f2.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:F3' ip='10.111.111.103' name='f3.cockpit.lan'/>
+                        <host mac='52:54:00:9e:00:F4' ip='10.111.111.104' name='f4.cockpit.lan'/>
+		</dhcp>
+	</ip>
+</network>

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -362,7 +362,8 @@ class MachineCase(unittest.TestCase):
     machines = [ ]
 
     def new_machine(self, flavor=None):
-        m = self.machine_class(verbose=arg_trace, flavor=flavor)
+        (unused, sep, label) = self.id().rpartition(".")
+        m = self.machine_class(verbose=arg_trace, flavor=flavor, label="%s-%s" % (program_name, label))
         self.addCleanup(lambda: m.kill())
         self.machines.append(m)
         return m

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -49,7 +49,7 @@ class RepeatThis(Failure):
 class Machine:
     boot_hook = None
 
-    def __init__(self, address=None, flavor=None, system=None, arch=None, verbose=False):
+    def __init__(self, address=None, flavor=None, system=None, arch=None, verbose=False, label=None):
         self.verbose = verbose
         self.flavor = flavor or DEFAULT_FLAVOR
 
@@ -67,6 +67,7 @@ class Machine:
         self.test_data = os.environ.get("TEST_DATA") or self.test_dir
         self.address = address
         self.mac = None
+        self.label = label or "UNKNOWN"
 
     def getconf(self, key):
         return key in self.conf and self.conf[key]
@@ -628,13 +629,11 @@ class QemuMachine(Machine):
 
         self.message(*cmd)
 
-        # Used by the qemu maintenance console
         if tty:
+            # Used by the qemu maintenance console
             return subprocess.Popen(cmd)
-
-        quoted = " ".join("'%s'" % x for x in cmd)
-        cmd = [ "/bin/sh", "-c", quoted + " </dev/null >/dev/null" ]
-        return subprocess.Popen(cmd)
+        else:
+            return subprocess.Popen(cmd, stdout=open("run/qemu-%s-%s.log" % (self.label, self.macaddr), "w"))
 
     def _monitor_qemu(self, command):
         assert self._monitor

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -376,7 +376,6 @@ class QemuMachine(Machine):
         self._monitor = None
         self._disks = { }
         self._locks = [ ]
-        self._hack_power_off_via_reset = False
 
     def _setup_fstab(self,gf):
         gf.write("/etc/fstab", "/dev/vda / ext4 defaults\n")
@@ -762,7 +761,6 @@ class QemuMachine(Machine):
 
     def wait_poweroff(self):
         assert self._process
-        buffer = ""
         while self._process.poll() is None:
             fd = self._process.stdout.fileno()
             ret = select.select([fd], [], [], 1)
@@ -770,27 +768,13 @@ class QemuMachine(Machine):
                 data = os.read(fd, 1024)
                 if self.verbose:
                     sys.stdout.write(data)
-
-                # HACK: Work around for qemu exit not working
-                # https://bugzilla.redhat.com/show_bug.cgi?id=1139387
-                buffer += data
-                if self._hack_power_off_via_reset and "reboot: Restarting system" in buffer:
-                    self.kill()
-                    return
-                elif "reboot: System halted" in buffer:
-                    self.kill()
-                    return
-
         self._cleanup()
 
     def shutdown(self):
         assert self._process
         try:
             if self._process.poll() is None:
-                # HACK: Work around for qemu system_powerdown not working
-                # https://bugzilla.redhat.com/show_bug.cgi?id=1139387
-                self._monitor_qemu("sendkey ctrl-alt-delete")
-                self._hack_power_off_via_reset = True
+                self._monitor_qemu("system_powerdown")
                 self.wait_poweroff()
         except:
             self._cleanup()

--- a/test/vm-install
+++ b/test/vm-install
@@ -28,7 +28,7 @@ parser.add_argument('rpms', metavar='RPM', nargs='*', help='RPMS to install')
 args = parser.parse_args()
 
 try:
-    machine = testvm.QemuMachine(verbose=args.verbose, flavor=args.flavor)
+    machine = testvm.QemuMachine(verbose=args.verbose, flavor=args.flavor, label="install")
     machine.install(args.rpms)
 except testvm.Failure, ex:
     print >> sys.stderr, "vm-install:", ex

--- a/test/vm-prep
+++ b/test/vm-prep
@@ -43,50 +43,7 @@ DEVICE=cockpit0
 NM_CONTROLLED=no
 EOF
 
-	xml=$(mktemp)
-cat > $xml << EOF
-<network>
-	<name>cockpit</name>
-	<uuid>f3605fa4-0763-41ea-8143-49da3bf73262</uuid>
-	<forward mode='nat'>
-		<nat>
-			<port start='1024' end='65535'/>
-		</nat>
-	</forward>
-	<bridge name='cockpit0' stp='on' delay='0' />
-	<mac address='52:54:00:b8:d2:b5'/>
-	<domain name='cockpit.lan'/>
-	<ip address='10.111.111.200' netmask='255.255.255.0'>
-		<dhcp>
-                        <host mac='52:54:00:9e:00:00' ip='10.111.111.10'   name='m10.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:01' ip='10.111.111.11'   name='m11.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:02' ip='10.111.111.12'   name='m12.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:03' ip='10.111.111.13'   name='m13.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:04' ip='10.111.111.14'   name='m14.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:05' ip='10.111.111.15'   name='m15.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:06' ip='10.111.111.16'   name='m16.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:07' ip='10.111.111.17'   name='m17.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:08' ip='10.111.111.18'   name='m18.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:09' ip='10.111.111.19'   name='m19.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:0a' ip='10.111.111.20'   name='m20.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:0b' ip='10.111.111.21'   name='m21.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:0c' ip='10.111.111.22'   name='m22.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:0d' ip='10.111.111.23'   name='m23.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:0e' ip='10.111.111.24'   name='m24.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:0f' ip='10.111.111.25'   name='m25.cockpit.lan'/>
-
-                        <host mac='52:54:00:9e:00:F0' ip='10.111.111.100' name='f0.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:F1' ip='10.111.111.101' name='f1.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:F2' ip='10.111.111.102' name='f2.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:F3' ip='10.111.111.103' name='f3.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:F4' ip='10.111.111.104' name='f4.cockpit.lan'/>
-		</dhcp>
-	</ip>
-</network>
-EOF
-
-	$VIRSH net-define $xml
-	rm $xml
+	$VIRSH net-define ./network-cockpit.xml
 
 	$VIRSH net-autostart cockpit
 	$VIRSH net-start cockpit


### PR DESCRIPTION
This isn't reliable anymore: https://bugzilla.redhat.com/show_bug.cgi?id=1205529

To compensate, we import the "mac to ip" mapping from the network
definition and wait for "/run/nologin" to disappear to signal that
user logins are now possible.