### PR TITLE
guide: Remove ListenAddress from instructions to change port

### DIFF
--- a/doc/guide/listen.xml
+++ b/doc/guide/listen.xml
@@ -36,7 +36,6 @@
 <programlisting>
 [Socket]
 ListenStream=443
-ListenAddress=0.0.0.0
 </programlisting>
 
     <para>In order for the changes to take effect, run the following commands:</para>


### PR DESCRIPTION
The ListenAddress doesn't seem to have ever been a valid
systemd configuration directive.