### PR TITLE
subscriptions: Include cockpit.css in subscriptions

### DIFF
--- a/pkg/subscriptions/subscriptions.html
+++ b/pkg/subscriptions/subscriptions.html
@@ -22,6 +22,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 <head>
   <title>Subscriptions</title>
   <meta charset="utf-8">
+  <link href="../base1/cockpit.css" rel="stylesheet">
   <link href="subscriptions.css" rel="stylesheet">
   <script type="text/javascript" src="../base1/bundle.js"></script>
 </head>


### PR DESCRIPTION
This is necessary to get the basic styles