### PR TITLE
ws: Don't print invalid info about HTTP server in logs

### DIFF
--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -171,8 +171,6 @@ main (int argc,
   g_signal_connect (server, "handle-resource::/apple-touch-icon.png",
                     G_CALLBACK (cockpit_handler_root), &data);
 
-  g_info ("HTTP Server listening on port %d", opt_port);
-
   g_main_loop_run (loop);
 
   ret = 0;


### PR DESCRIPTION
This is unnecessary, and wrong.