### PR TITLE
test: Use parted in a less racy fashion

### DIFF
--- a/test/check-storage
+++ b/test/check-storage
@@ -901,10 +901,11 @@ class TestStorage(MachineCase):
         self.add_disk("50M", "DISK2")
         b.wait_in_text("#storage_drives", "DISK1")
         b.wait_in_text("#storage_drives", "DISK2")
-        m.execute("parted -s /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 mktable msdos")
-        m.execute("parted -s /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 mkpart extended 0 50")
-        m.execute("parted -s /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 mkpart logical ext2 1 25")
-        m.execute("parted -s /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 mkpart logical ext2 25 50")
+        script = """mktable msdos \
+mkpart extended 0 50 \
+mkpart logical ext2 1 25 \
+mkpart logical ext2 25 50"""
+        m.execute("parted -s /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 " + script)
         m.execute("udevadm settle")
         m.execute("mke2fs -L TEST /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1-part5")
         b.wait_dbus_prop("com.redhat.Cockpit.Storage.Block", "IdLabel", "TEST")


### PR DESCRIPTION
Instead of heavily loading the system 5 times with ssh connections,
disk access, logging, between creating each piece of the partition
information ... just do it in one shot.