### PR TITLE
Document the dashboard auth setup process

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -1,0 +1,57 @@
+
+Cockpit Setup Mechanisms
+========================
+
+Cockpit has a very strong concept of the user who is logged in. When adding
+a machine to the dashboard, the same user should be available on all the
+machines.
+
+In general it is ideal if the identity is kept in sync using a domain, such
+as a FreeIPA domain. However to make things work in an ad-hoc deployment,
+Cockpit offers to setup the other machine to authenticate similarly enough
+so that it can be successfully added to the dashboard.
+
+This is implemented using an extensible DBus interface on the internal
+cockpit-bridge bus. It looks like this:
+
+```
+node /setup {
+  interface cockpit.Setup {
+    methods:
+      Prepare(in  s mechanism,
+              out v data);
+      Transfer(in  s mechanism,
+               in  v data,
+               out v data);
+      Commit(in  s mechanism,
+             in  v data);
+    signals:
+    properties:
+      readonly as Mechanisms = ['passwd1'];
+  };
+```
+
+There are multiple mechanisms for doing the setup. The basic one is called
+```passwd1``` and syncs user accounts, passwords, and group membership.
+
+On the destination machine the ```Prepare()``` method is invoked with
+the ```mechanism``` type, and produces some data.
+
+The prepared data is passed to the ```Transfer()``` function on the source
+machine, which returns additional data.
+
+The transferred data is passed to the ```Commit()``` function on the
+destination machine to complete the setup.
+
+passwd1
+-------
+
+The format of ```passwd``` data is a DBus variant containing a tuple that
+looks like this: ```(asas)```. That is, two arrays of strings. The first array
+is a set of passwd(5) lines. The second array is a set of group(5) lines.
+
+The passwd(5) lines contain hashed passwords. We only transfer accounts
+that are not determined to be "system" accounts. We do not sync UIDs and
+GIDs. Nor do we change the shell / home directory of accounts that already
+exist. Groups are not created on the remote system, but membership is
+added to where necessary.

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -238,6 +238,7 @@ static void
 send_init_command (CockpitTransport *transport)
 {
   const gchar *checksum;
+  const gchar *name;
   JsonObject *object;
   GBytes *bytes;
 
@@ -248,6 +249,11 @@ send_init_command (CockpitTransport *transport)
   checksum = cockpit_packages_get_checksum (packages);
   if (checksum)
     json_object_set_string_member (object, "checksum", checksum);
+
+  /* Happens when we're in --interact mode */
+  name = cockpit_dbus_internal_name ();
+  if (name)
+    json_object_set_string_member (object, "bridge-dbus-name", name);
 
   bytes = cockpit_json_write_bytes (object);
   cockpit_transport_send (transport, NULL, bytes);
@@ -458,7 +464,7 @@ run_bridge (const gchar *interactive)
     daemon_pid = start_dbus_daemon ();
 
   packages = cockpit_packages_new ();
-  cockpit_dbus_internal_startup ();
+  cockpit_dbus_internal_startup (interactive != NULL);
 
   if (interactive)
     {

--- a/src/bridge/cockpitdbusinternal.h
+++ b/src/bridge/cockpitdbusinternal.h
@@ -29,7 +29,9 @@ GDBusConnection *     cockpit_dbus_internal_client       (void);
 
 GDBusConnection *     cockpit_dbus_internal_server       (void);
 
-void                  cockpit_dbus_internal_startup      (void);
+const gchar *         cockpit_dbus_internal_name         (void);
+
+void                  cockpit_dbus_internal_startup      (gboolean interact);
 
 void                  cockpit_dbus_internal_cleanup      (void);
 

--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -1963,14 +1963,14 @@ cockpit_dbus_json_prepare (CockpitChannel *channel)
           goto out;
         }
 
-      self->name = NULL;
-
       self->connection = cockpit_dbus_internal_client ();
       if (self->connection == NULL)
         {
           problem = "internal-error";
           goto out;
         }
+
+      self->name = cockpit_dbus_internal_name ();
 
       subscribe_and_cache (self);
       cockpit_channel_ready (channel);

--- a/src/bridge/test-setup.c
+++ b/src/bridge/test-setup.c
@@ -41,7 +41,7 @@ static void
 setup (TestCase *tc,
        gconstpointer unused)
 {
-  cockpit_dbus_internal_startup ();
+  cockpit_dbus_internal_startup (FALSE);
 
   cockpit_dbus_setup_startup ();
   while (g_main_context_iteration (NULL, FALSE));


### PR DESCRIPTION
Also, use session bus for internal DBus communications when bridge is used in interactive mode.
