### PR TITLE
Message if UDisks or storaged is not installed

### DIFF
--- a/pkg/shell/cockpit-storage.js
+++ b/pkg/shell/cockpit-storage.js
@@ -451,6 +451,20 @@ PageStorage.prototype = {
         this.mount_monitor = this.client.get("/com/redhat/Cockpit/MountMonitor",
                                              "com.redhat.Cockpit.MultiResourceMonitor");
         $(this.mount_monitor).on('NewSample.storage', render_mount_samples);
+
+        function update_requirements() {
+            var manager = self.client.lookup("/com/redhat/Cockpit/Storage/Manager",
+                                             "com.redhat.Cockpit.Storage.Manager");
+
+            if (!manager || !manager.HaveUDisks || !manager.HaveStoraged) {
+                $('#storage').children().hide();
+                $("#storage-not-supported").show();
+            }
+        }
+        if (this.client.state == "ready")
+            update_requirements();
+        else
+            $(this.client).on("state-change", update_requirements);
     },
 
     show: function() {

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -176,6 +176,11 @@
       </div>
 
       <div id="storage" hidden>
+        <div class="alert alert-error" id="storage-not-supported" hidden>
+          <span class="fa fa-exclamation-circle"></span>
+          <span translatable="yes">The UDisks and/or storaged API is not available on this system.</span>
+        </div>
+
         <div class="col-md-8 col-lg-9">
 
           <div class="row">

--- a/src/legacy/com.redhat.Cockpit.xml
+++ b/src/legacy/com.redhat.Cockpit.xml
@@ -187,6 +187,9 @@
   -->
   <interface name="com.redhat.Cockpit.Storage.Manager">
 
+    <property name="HaveUDisks" type="b" access="read"/>
+    <property name="HaveStoraged" type="b" access="read"/>
+
     <!--
         MDRaidCreate:
         @blocks: An array of object paths to objects implementing the #com.redhat.Cockpit.Storage.Block interface.

--- a/src/legacy/main.c
+++ b/src/legacy/main.c
@@ -85,7 +85,7 @@ on_sigint (gpointer user_data)
 {
   g_message ("Caught SIGINT. Initiating shutdown");
   g_main_loop_quit (loop);
-  return FALSE;
+  return TRUE;
 }
 
 int

--- a/src/legacy/udisksclient.c
+++ b/src/legacy/udisksclient.c
@@ -137,22 +137,25 @@ udisks_client_finalize (GObject *object)
   if (client->initialization_error != NULL)
     g_error_free (client->initialization_error);
 
-  g_signal_handlers_disconnect_by_func (client->object_manager,
-                                        G_CALLBACK (on_object_added),
-                                        client);
-  g_signal_handlers_disconnect_by_func (client->object_manager,
-                                        G_CALLBACK (on_object_removed),
-                                        client);
-  g_signal_handlers_disconnect_by_func (client->object_manager,
-                                        G_CALLBACK (on_interface_added),
-                                        client);
-  g_signal_handlers_disconnect_by_func (client->object_manager,
-                                        G_CALLBACK (on_interface_removed),
-                                        client);
-  g_signal_handlers_disconnect_by_func (client->object_manager,
-                                        G_CALLBACK (on_interface_proxy_properties_changed),
-                                        client);
-  g_object_unref (client->object_manager);
+  if (client->object_manager)
+    {
+      g_signal_handlers_disconnect_by_func (client->object_manager,
+                                            G_CALLBACK (on_object_added),
+                                            client);
+      g_signal_handlers_disconnect_by_func (client->object_manager,
+                                            G_CALLBACK (on_object_removed),
+                                            client);
+      g_signal_handlers_disconnect_by_func (client->object_manager,
+                                            G_CALLBACK (on_interface_added),
+                                            client);
+      g_signal_handlers_disconnect_by_func (client->object_manager,
+                                            G_CALLBACK (on_interface_removed),
+                                            client);
+      g_signal_handlers_disconnect_by_func (client->object_manager,
+                                            G_CALLBACK (on_interface_proxy_properties_changed),
+                                            client);
+      g_object_unref (client->object_manager);
+    }
 
   if (client->context != NULL)
     g_main_context_unref (client->context);


### PR DESCRIPTION
Show a storage page failure if UDisks is not installed. In addition disable the LVM related buttons if storaged (0.x) is not installed.
