### PR TITLE
tools: Use DNF instead of YUM for building on Fedora

### DIFF
--- a/test/README
+++ b/test/README
@@ -15,7 +15,7 @@ Fedora:
 
   # yum install trickle npm python-libguestfs qemu mock qemu-kvm python \
          curl libvirt-client fakeroot glibc-static openssl \
-         rpm-build krb5-workstation python-lxml
+         rpm-build krb5-workstation python-lxml dnf
 
 Testing requires phantomjs globally on the system, not just inside the cockpit package.
 

--- a/tools/make-rpms
+++ b/tools/make-rpms
@@ -98,6 +98,7 @@ else
     cp --preserve=timestamps /etc/mock/$os-$arch.cfg $base/mock/$os-$arch-cockpit.cfg
     cat >>$base/mock/$os-$arch-cockpit.cfg <<EOF
 config_opts['root'] = "$os-$arch-cockpit"
+config_opts['package_manager'] = 'dnf'
 config_opts['yum.conf'] += """
 [updates-testing]
 enabled=1


### PR DESCRIPTION
Otherwise our make-rpms fails on Fedora 22 and Rawhide