### PR TITLE
fix alignment issues in container run dialog due to bigger font

### DIFF
--- a/pkg/shell/shell.css
+++ b/pkg/shell/shell.css
@@ -606,7 +606,7 @@ ul.available-interfaces-group {
 .containers-run-inline form .fa-plus {
     height: 26px;
     width: 26px;
-    padding: 8px;
+    padding: 4px;
     float: right;
     margin-left: 5px;
 }
@@ -649,7 +649,7 @@ ul.available-interfaces-group {
       width: 40%;
   }
   #select-linked-containers input {
-      max-width: 75%;
+      max-width: 73%;
   }
 }
 


### PR DESCRIPTION
Happened due to increased font size that came with updated Patternfly version.