### PR TITLE
tools: No install-time dependency on realmd

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -137,7 +137,6 @@ Requires: mdadm
 Requires: lvm2
 %if 0%{?rhel} == 0
 Requires: udisks2 >= 2.1.0
-Requires: realmd
 %else
 Provides: %{name}-subscriptions = %{version}-%{release}
 Requires: subscription-manager >= 1.13


### PR DESCRIPTION
Some systems like Atomic don't include realmd, and would rather
join doimains in other ways (TBD) ... so just disable those options
when realmd isn't present.