### PR TITLE
tools: Rely on the spec file to require openssl

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:21
 MAINTAINER "Stef Walter" <stefw@redhat.com>
 
-RUN yum -y update && yum install -y sed openssl && yum clean all
+RUN yum -y update && yum install -y sed && yum clean all
 
 # A repo where we can find recent Cockpit builds for Fedora
 ADD cockpit-preview.repo /etc/yum.repos.d/


### PR DESCRIPTION
Having openssl listed explicitly here in the Dockerfile was
just a short term work around.