### PR TITLE
Return data on http and spawn failures

### DIFF
--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -341,7 +341,7 @@
     <refsection id="cockpit-spawn-fail">
       <title>process.fail()</title>
 <programlisting>
- process.fail(function(exception) { ... })
+ process.fail(function(exception[, data]) { ... })
 </programlisting>
       <para>This is a standard
         <ulink url="http://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
@@ -368,6 +368,9 @@
             This is <code>null</code> if the process did not terminate because of a signal.</para></listitem>
         </varlistentry>
       </variablelist>
+
+      <para>If the process actually ran and produced output before failing, it will be available in
+        the <code>data</code> argument. Otherwise this argument will be <code>undefined</code>.</para>
     </refsection>
 
     <refsection id="cockpit-spawn-always">
@@ -1407,7 +1410,7 @@
     <refsection id="cockpit-http-fail">
       <title>request.fail()</title>
 <programlisting>
- request.fail(function(exception) { ... })
+ request.fail(function(exception[, data]) { ... })
 </programlisting>
       <para>This is a standard
         <ulink url="http://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
@@ -1439,6 +1442,9 @@
             no response was received.</para></listitem>
         </varlistentry>
       </variablelist>
+
+      <para>If the request returned a response body, it will be available in
+        the <code>data</code> argument. Otherwise this argument will be <code>undefined</code>.</para>
     </refsection>
 
     <refsection id="cockpit-http-always">

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -1220,13 +1220,13 @@ function full_scope(cockpit, $, po) {
 
         $(channel).
             on("close", function(event, options) {
+                var data = buffer.squash();
                 spawn_debug("process closed:", JSON.stringify(options));
                 if (options.problem) {
                     dfd.reject(new ProcessError(options.problem));
                 } else if (options["exit-status"] || options["exit-signal"]) {
-                    dfd.reject(new ProcessError(options["exit-status"], options["exit-signal"]));
+                    dfd.reject(new ProcessError(options["exit-status"], options["exit-signal"]), data);
                 } else {
-                    var data = buffer.squash();
                     spawn_debug("process output:", data);
                     dfd.resolve(data);
                 }
@@ -2379,7 +2379,7 @@ function full_scope(cockpit, $, po) {
                                 message = body;
                         }
                         http_debug("http status: ", resp.status);
-                        dfd.reject(new HttpError(resp.status, resp.reason, message));
+                        dfd.reject(new HttpError(resp.status, resp.reason, message), body);
 
                     } else {
                         http_debug("http done");

--- a/pkg/base1/test-http.html
+++ b/pkg/base1/test-http.html
@@ -83,17 +83,18 @@ asyncTest("with params", function() {
 });
 
 asyncTest("not found", function() {
-    expect(5);
+    expect(6);
 
     cockpit.http({ "internal": "test-server" })
         .get("/not/found")
         .response(function(status, headers) {
             equal(status, 404, "status code");
         })
-        .fail(function(ex) {
+        .fail(function(ex, data) {
             strictEqual(ex.problem, null, "mapped to cockpit code");
             strictEqual(ex.status, 404, "has status code");
             equal(ex.message, "Not Found", "has reason");
+            equal(data, "<html><head><title>404 Not Found</title></head><body>Not Found</body></html>", "got body");
         })
         .always(function() {
             equal(this.state(), "rejected", "should fail");

--- a/pkg/base1/test-spawn.html
+++ b/pkg/base1/test-spawn.html
@@ -269,18 +269,20 @@ asyncTest("with problem", function() {
 });
 
 asyncTest("with status", function() {
-    expect(4);
+    expect(5);
 
     var peer = new MockPeer();
     $(peer).on("opened", function(event, channel) {
+        peer.send(channel, "the data");
         peer.close(channel, {"exit-status": 5});
     });
 
     cockpit.spawn("/unused").
-        fail(function(ex) {
+        fail(function(ex, data) {
             strictEqual(ex.problem, null, "got null problem");
             ok(isNaN(ex.exit_signal), "got no signal");
             strictEqual(ex.exit_status, 5, "got status");
+            equal(data, "the data", "got data even with exit status");
         }).
         always(function() {
             equal(this.state(), "rejected", "should fail");
@@ -289,18 +291,20 @@ asyncTest("with status", function() {
 });
 
 asyncTest("with signal", function() {
-    expect(4);
+    expect(5);
 
     var peer = new MockPeer();
     $(peer).on("opened", function(event, channel) {
+        peer.send(channel, "signal data here");
         peer.close(channel, {"exit-signal": "TERM"});
     });
 
     cockpit.spawn("/unused").
-        fail(function(ex) {
+        fail(function(ex, data) {
             strictEqual(ex.problem, null, "got null problem");
             strictEqual(ex.exit_signal, "TERM", "got signal");
             ok(isNaN(ex.exit_status), "got no status");
+            equal(data, "signal data here", "got data even with signal");
         }).
         always(function() {
             equal(this.state(), "rejected", "should fail");


### PR DESCRIPTION
If data was returned, either as an HTTP body, or process output,
make it available in the promise.fail() callback as a second argument.