### PR TITLE
Use /etc/shadow when no secret in kernel keyring

### DIFF
--- a/doc/reauthorize.md
+++ b/doc/reauthorize.md
@@ -176,6 +176,9 @@ cockpit-bridge polkit agent:
      * ```nonce = "$6$" encode_alnum(read("/dev/urandom", 16))```
      * ```challenge = "crypt1:" encode_hex(user) ":" salt ":" nonce```
    * If no ```secret``` is present in session kernel keyring
+     * Lookup shadow sp_spwdp entry, and use that as a secret, if present
+       and is a valid salted crypt hash.
+   * If no ```secret``` available
      * ```challenge = "gssapi1:" encode_hex(user)```
    * Send ```challenge``` to cockpit-ws
    * Wait for ```response``` from cockpit-ws

--- a/src/reauthorize/test-reauthorize.c
+++ b/src/reauthorize/test-reauthorize.c
@@ -319,7 +319,7 @@ test_password_no_prepare (void)
 {
   char *challenge = NULL;
 
-  assert_num_eq (mock_reauthorize ("perform", user, NULL, &challenge), REAUTHORIZE_NO);
+  assert_num_eq (mock_reauthorize ("perform", "unknown", NULL, &challenge), REAUTHORIZE_NO);
 
   free (challenge);
 }

--- a/test/check-reauthorize
+++ b/test/check-reauthorize
@@ -70,4 +70,19 @@ class TestReauthorize(MachineCase):
 
         self.assertEqual(b.text(".super-channel span"), 'result: access-denied')
 
+    def testShadow(self):
+        m = self.machine
+        b = self.browser
+
+        # Delete pam_reauthorize.so from everything in /etc/pam.d/*
+        # This causes the code to be forced to use the shadow logic
+        m.execute("sed -i '/pam_reauthorize/d' /etc/pam.d/*")
+
+        self.login_and_go("/playground/test")
+
+        b.click(".cockpit-internal-reauthorize .btn")
+        b.wait_in_text(".cockpit-internal-reauthorize span", 'result:')
+
+        self.assertEqual(b.text(".cockpit-internal-reauthorize span"), 'result: authorized')
+
 test_main()


### PR DESCRIPTION
If pam_reauthorize.so is not in the PAM stack and didn't have a
chance to put the secret in the kernel keyring, we can fall
back to /etc/shadow.