### PR TITLE
fix broken search loupe in container search dialog

### DIFF
--- a/pkg/shell/shell.css
+++ b/pkg/shell/shell.css
@@ -543,8 +543,12 @@ ul.available-interfaces-group {
 }
 
 #containers-search-image-search {
-    background: url("images/search-icon.png") no-repeat 3px;
-    padding-left: 20px;
+    padding-left: 25px;
+}
+
+#containers-search-image-dialog .containers-search-image-search-icon {
+    left: 0;
+    top: 0;
 }
 
 #containers-search-image-waiting.spinner {

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -2260,7 +2260,11 @@
             <h4 class="modal-title">Image Search</h4>
           </div>
           <div class="modal-body">
-            <input type="search" class="form-control" id="containers-search-image-search"/>
+            <div class="form-group has-feedback">
+              <input type="search" class="form-control" id="containers-search-image-search"/>
+              <span class="fa fa-search form-control-feedback containers-search-image-search-icon"></span>
+            </div>
+            
             <div id="containers-search-image-waiting"></div>
             <div id="containers-search-image-results">
               <table class="table table-hover">


### PR DESCRIPTION
This broke a while back. As a bonus this uses a font icon now.