### PR TITLE
shell: Correctly transcribe !startsWith to indexOf !== 0.

### DIFF
--- a/pkg/shell/cockpit-networking.js
+++ b/pkg/shell/cockpit-networking.js
@@ -747,7 +747,7 @@ function NetworkManagerModel() {
     }
 
     function refresh_udev(obj) {
-        if (obj.Udi.indexOf("/sys/") === -1)
+        if (obj.Udi.indexOf("/sys/") !== 0)
             return;
 
         push_refresh();


### PR DESCRIPTION
This was missed when reviewing 286aa9ed4d0336b98c28e52faed2af95bf99e3de.