### PR TITLE
Use the appropriate compiler via the exported variable to help/fix cross compiling

### DIFF
--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -164,7 +164,7 @@ CLEANFILES += mock-pmda.so
 # for this.
 #
 mock-pmda.so: src/bridge/mock-pmda.c
-	$(AM_V_CCLD) gcc -g -fPIC -shared \
+	$(AM_V_CCLD) $(CC) -fPIC -shared \
 		-DSRCDIR=\"$(abs_srcdir)\" \
 		-o mock-pmda.so $(srcdir)/src/bridge/mock-pmda.c -lpcp_pmda -lpcp
 


### PR DESCRIPTION
We have some build tools prefixed with the host architecture, so you can call the one you want to build for, for example you'll find /usr/${host}/bin/${host}-gcc and possibly multiple /usr/${host}/bin/${target}-gcc. cockpit already uses $(CC) in src/reauthorize/Makefile-reauthorize.am, but in src/bridge/Makefile.am the gcc command is hardcoded and results in a compile error:

gcc -g -fPIC -shared \
        -DSRCDIR=\"/var/tmp/paludis/build/sys-apps-cockpit-0.51/work/cockpit-0.51\" \
        -o mock-pmda.so ./src/bridge/mock-pmda.c -lpcp_pmda -lpcp
Makefile:8116: recipe for target 'mock-pmda.so' failed
make[2]: Leaving directory '/var/tmp/paludis/build/sys-apps-cockpit-0.51/work/cockpit-0.51'
Makefile:6984: recipe for target 'all-recursive' failed
make[1]: Leaving directory '/var/tmp/paludis/build/sys-apps-cockpit-0.51/work/cockpit-0.51'
Makefile:2646: recipe for target 'all' failed
make[2]: gcc: Command not found
make[2]: *** [mock-pmda.so] Error 127
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2