### PR TITLE
systemd: Respect 'start' when following the journal.

### DIFF
--- a/pkg/systemd/server.js
+++ b/pkg/systemd/server.js
@@ -471,7 +471,10 @@ define([
             done(function() {
                 if (!last) {
                     reached_end();
-                    procs.push(server.journal(match, { follow: true, count: 0 }).
+                    procs.push(server.journal(match, { follow: true, count: 0,
+                                                       boot: options["boot"],
+                                                       since: options["since"]
+                                                     }).
                         fail(query_error).
                         stream(function(entries) {
                             prepend_entries(entries);


### PR DESCRIPTION
If the initial query for old journal entries comes up empty, the
subsequent query that follows newly appearing entries should start at
the same place.