### PR TITLE
tools: Use nsenter in a compatible way

### DIFF
--- a/tools/atomic-run
+++ b/tools/atomic-run
@@ -16,4 +16,4 @@ set +x
 /bin/mount --bind /host/var /var
 
 # And run cockpit-ws
-exec /usr/bin/nsenter --net=/host/proc/1/ns/net --uts=/host/proc/1/ns/uts /usr/libexec/cockpit-ws "$@"
+exec /usr/bin/nsenter --net=/host/proc/1/ns/net --uts=/host/proc/1/ns/uts -- /usr/libexec/cockpit-ws "$@"


### PR DESCRIPTION
On RHEL Atomic, there's an older nsenter which requires the -- argument
to determine when to stop parsing args.