### PR TITLE
lvm: Make cockpit-lvm initialize even if its helper crashes

### DIFF
--- a/src/legacy/lvm/manager.c
+++ b/src/legacy/lvm/manager.c
@@ -134,6 +134,7 @@ lvm_update_from_variant (GPid pid,
   if (error != NULL)
     {
       g_critical ("%s", error->message);
+      lvm_update_done (data);
       return;
     }
 


### PR DESCRIPTION
LVM (and especially lvm2app) is really fragile. It's easy for our
cockpit-lvm-helper to get into situations where it crashes.

Make sure to continue cockpit-lvm setup in that case, so that the
rest of Cockpit doesn't hang waiting for a daemon that never
initializes.