### PR TITLE
test: Help 'parted' create valid extended partitions.

### DIFF
--- a/test/check-storage
+++ b/test/check-storage
@@ -898,8 +898,8 @@ class TestStorage(MachineCase):
         b.wait_in_text("#storage_drives", "DISK1")
         b.wait_in_text("#storage_drives", "DISK2")
         script = """mktable msdos \
-mkpart extended 1M 50 \
-mkpart logical ext2 1 24 \
+mkpart extended 1 50 \
+mkpart logical ext2 2 24 \
 mkpart logical ext2 24 48"""
         m.execute("parted -s /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 " + script)
         m.execute("udevadm settle")


### PR DESCRIPTION
It seems that a logical partition can not start at the same place as
the extended partition with some versions of parted, so we move the
first logical partition one meg towards the end.

Otherwise we might get this error: "Error informing the kernel about
modifications to partition /dev/sda5 -- Device or resource busy."

XXX - link to bug here.