### PR TITLE
Simplify styling of the tools menu

### DIFF
--- a/pkg/shell/shell.css
+++ b/pkg/shell/shell.css
@@ -896,10 +896,31 @@ iframe.container-frame {
     margin-top: 30px;
 }
 
+#sidebar > .nav-category {
+    padding-bottom: 5px;
+}
+
+#tools-menu > .panel {
+  border: none;
+  box-shadow: none;
+}
+
 #tools-menu > .panel > .panel-heading {
   height: auto;
   padding-left: 0px;
   margin-left: 4px;
+  background: none;
+  border-bottom: none;
+}
+
+#tools-menu .panel-title a {
+  font-weight: normal;
+  font-size: 13px;
+  display: block;
+}
+
+#tools-panel > .panel-body {
+  border: none;
 }
 
 #sidebar-tools > li > a {


### PR DESCRIPTION
It looks out of place all 3D rounded. It's meant to be a place to put less used items, and not be the main focus of attention.
