### PR TITLE
Test: disable docker.testExpose again on Fedora 22

### DIFF
--- a/test/check-docker
+++ b/test/check-docker
@@ -167,6 +167,10 @@ class TestDocker(MachineCase):
         m = self.machine
         self.allow_journal_messages('.*denied.*name_connect.*docker.*')
 
+        if m.os == "fedora-22":
+            print "Skipping TestDocker.testExpose on Fedora 22"
+            return
+
         m.execute("systemctl start docker")
 
         self.login_and_go("containers", href="/docker/containers")


### PR DESCRIPTION
there seem to be some socket errors that need to be looked into