### PR TITLE
doc: Comment how to add dashboard items

### DIFF
--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -102,6 +102,13 @@
         <term>version</term>
         <listitem><para>An informational version number for the package.</para></listitem>
       </varlistentry>
+      <varlistentry>
+        <term>dashboard</term>
+        <listitem><para>An optional JSON object containing any dashboard items that this package
+          provides. These will be added into the Cockpit user interface dashboard.
+          Each property on this object is named for the identifier of such an item, and the
+          property value is a JSON object described below.</para></listitem>
+      </varlistentry>
     </variablelist>
 
     <para>Menu items and tools are registered using JSON objects that have the


### PR DESCRIPTION
The package manifest also allows the addition of dashboard items, this
just wasn't documented.
This patch adds a baseline documentation.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>