### PR TITLE
tools: Build RPMS with _hardened_build option

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -22,6 +22,8 @@
 %define rhel 0
 %endif
 
+%define _hardened_build 1
+
 Name:           cockpit
 %if %{defined gitcommit}
 Version:        %{gitcommit}


### PR DESCRIPTION
This is used by some downstreams, and it's good to check if
our continuous integration breaks with it set.