### PR TITLE
kubernetes: Namespace aware object selection and infer

### DIFF
--- a/pkg/kubernetes/app.js
+++ b/pkg/kubernetes/app.js
@@ -25,7 +25,7 @@ define([
                 calculated.containers = "0";
 
                 if (service.spec && service.spec.selector) {
-                    var pods = client.select(service.spec.selector);
+                    var pods = client.select(service.spec.selector, service.metadata.namespace);
 
                     /* calculate "x of y" containers, where x is the current
                        number and y is the expected number. If x==y then only

--- a/pkg/kubernetes/client.js
+++ b/pkg/kubernetes/client.js
@@ -282,8 +282,10 @@ define([
                 if (meta.resourceVersion && meta.resourceVersion > self.resourceVersion)
                     self.resourceVersion = meta.resourceVersion;
 
-                items[meta.uid] = item;
-                self.objects[meta.uid] = item;
+                var uid = meta.uid;
+
+                items[uid] = item;
+                self.objects[uid] = item;
 
                 /* Add various bits to index, for quick lookup */
                 var i, keys, length;
@@ -291,20 +293,20 @@ define([
                     keys = [];
                     for (i in meta.labels)
                         keys.push(i + meta.labels[i]);
-                    index.add(keys, meta.uid);
+                    index.add(keys, uid);
                 }
                 var spec = item.spec;
                 if (spec && spec.selector) {
                     keys = [];
                     for (i in spec.selector)
                         keys.push(i + spec.selector[i]);
-                    index.add(keys, meta.uid);
+                    index.add(keys, uid);
                 }
 
                 /* Index the host for quick lookup */
                 var status = item.status;
                 if (status && status.host)
-                    index.add([ status.host ], meta.uid);
+                    index.add([ status.host ], uid);
 
                 trigger();
             }

--- a/pkg/kubernetes/test-kubernetes.html
+++ b/pkg/kubernetes/test-kubernetes.html
@@ -648,38 +648,50 @@ require([
         $(client).on("pods", function(ev) {
 
             /* Select everything odd, 500 pods */
-            var results = client.select({ "type": "odd" });
+            var results = client.select({ "type": "odd" }, "default");
             equal(results.length, 500, "correct amount");
             ok(has_unique_uids(results), "unique objects");
 
+            /* Select everything odd, but wrong namespace, no pods */
+            var results = client.select({ "type": "odd" }, "other");
+            equal(results.length, 0, "other namespace no pods");
+
             /* The same ones selected even when a second (present) label */
-            results = client.select({ "type": "odd", "tag": "silly"  });
+            results = client.select({ "type": "odd", "tag": "silly"  }, "default");
             equal(results.length, 500, "with additional label");
             ok(has_unique_uids(results), "unique objects with additional label");
 
             /* Nothing selected when additional invalid field */
-            results = client.select({ "type": "odd", "tag": "billy"  });
+            results = client.select({ "type": "odd", "tag": "billy"  }, "default");
             equal(results.length, 0, "no objects");
 
             /* Limit by kind */
-            var results = client.select({ "type": "odd" }, "Pod");
+            var results = client.select({ "type": "odd" }, "default", "Pod");
             equal(results.length, 500, "by kind");
             ok(has_unique_uids(results), "unique objects by kind");
 
             /* Limit by invalid kind */
-            var results = client.select({ "type": "odd" }, "Ood");
+            var results = client.select({ "type": "odd" }, "default", "Ood");
             equal(results.length, 0, "nothing for invalid kind");
 
             /* Everything selected when no selector */
-            results = client.select(null);
-            equal(results.length, 1007, "all objects");
+            results = client.select(null, "default");
+            equal(results.length, 1006, "all objects");
 
             /* Everything selected when no selector */
-            results = client.select(null, "Pod");
+            results = client.select(null, "default", "Pod");
             equal(results.length, 1002, "all pods");
 
+            /* Nothing selected when bad namespace */
+            results = client.select(null, "other");
+            equal(results.length, 0, "other namespace no objects");
+
+            /* Get the node when a null namespace */
+            results = client.select(null, undefined);
+            equal(results.length, 1, "without namespace");
+
             /* Nothing selected when empty selector */
-            results = client.select({ });
+            results = client.select({ }, "default");
             equal(results.length, 0, "no objects");
 
             $(client).off("pods");
@@ -693,31 +705,39 @@ require([
         $(client).on("pods", function(ev) {
 
             /* Start simple, exactly the labels selector matches */
-            var results = client.infer({ "tag": "silly", "type": "odd" });
+            var results = client.infer({ "tag": "silly", "type": "odd" }, "default");
             equal(results.length, 1, "selected replication controller");
             equal(results[0].metadata.name, "oddcontroller", "got oddcontroller");
 
+            /* Other namespace, no match */
+            var results = client.infer({ "tag": "silly", "type": "odd" }, "other");
+            equal(results.length, 0, "selected no controller");
+
             /* Now with extra labels, as you'd usually see it */
-            results = client.infer({ "tag": "silly", "type": "odd", "another": "value" });
+            results = client.infer({ "tag": "silly", "type": "odd", "another": "value" }, "default");
             equal(results.length, 1, "selected controller with extra labels");
             equal(results[0].metadata.name, "oddcontroller", "got oddcontroller with extra labels");
 
             /* Make two replication controllers match */
-            results = client.infer({ "tag": "silly", "type": "odd", "another": "value", "factor3": "yes" });
+            results = client.infer({ "tag":"silly", "type":"odd", "another":"value", "factor3":"yes" }, "default");
             equal(results.length, 2, "two replication controllers");
             equal(results[0].metadata.name, "oddcontroller", "got oddcontroller in set");
             equal(results[1].metadata.name, "3controller", "got 3controller in set");
 
             /* Everything inferred when no labels */
-            results = client.infer(null);
+            results = client.infer(null, "default");
             equal(results.length, 4, "all objects with selectors");
 
             /* Everything inferred when no labels */
-            results = client.infer(null, "ReplicationController");
+            results = client.infer(null, "default", "ReplicationController");
             equal(results.length, 2, "all replication controllers with selectors");
 
+            /* Nothing when wrong label */
+            results = client.infer(null, "other");
+            equal(results.length, 0, "no objects with other namespace");
+
             /* Nothing inferred when empty label */
-            results = client.infer({ });
+            results = client.infer({ }, "default");
             equal(results.length, 0, "no objects");
 
             $(client).off("pods");


### PR DESCRIPTION
When we select objects within Kubernetes, we must always do that within a single namespace. This is how kube-apiserver itself operates.
    
Add a namespace parameter to client.select() and client.infer().
    
By passing undefined to the namespace parameter, one can select objects without a namespace such as nodes, or namespace objects themselves.