### PR TITLE
kubernetes: Remove template line at the bottom of page

### DIFF
--- a/pkg/kubernetes/cluster.html
+++ b/pkg/kubernetes/cluster.html
@@ -60,13 +60,6 @@
               <td>{{service.namespace}}</td>
               <td></td>
             </tr>
-            <tr>
-              <td>...</td>
-              <td></td>
-              <td></td>
-	      <td></td>
-              <td class="icons" title="Scaling down"><span class="fa fa-chevron-circle-down"></span></td>
-            </tr>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
This ellipsis line was just remainder from the design HTML.