### PR TITLE
cockpit graphs(CPU/Memory) are gray color #1617

### DIFF
--- a/pkg/shell/cockpit-cpu-status.js
+++ b/pkg/shell/cockpit-cpu-status.js
@@ -64,10 +64,10 @@ PageCpuStatus.prototype = {
 
         this.plot = shell.setup_complicated_plot("#cpu_status_graph",
                                                    resmon,
-                                                   [{color: "rgb(200,200,200)"},
-                                                    {color: "rgb(150,150,150)"},
-                                                    {color: "rgb(100,100,100)"},
-                                                    {color: "rgb( 50, 50, 50)"}
+                                                   [{color: "#4daf4a"},
+                                                    {color: "#377eb8"},
+                                                    {color: "#ff7f00"},
+                                                    {color: "#e41a1c"}
                                                    ],
                                                    options);
 

--- a/pkg/shell/cockpit-memory-status.js
+++ b/pkg/shell/cockpit-memory-status.js
@@ -63,10 +63,10 @@ PageMemoryStatus.prototype = {
 
         this.plot = shell.setup_complicated_plot("#memory_status_graph",
                                                    resmon,
-                                                   [{color: "rgb(200,200,200)"},
-                                                    {color: "rgb(150,150,150)"},
-                                                    {color: "rgb(100,100,100)"},
-                                                    {color: "rgb( 50, 50, 50)"}
+                                                   [{color: "#4daf4a"},
+                                                    {color: "#377eb8"},
+                                                    {color: "#ff7f00"},
+                                                    {color: "#e41a1c"}
                                                    ],
                                                    options);
     },


### PR DESCRIPTION
Simple short-term fix to replace greyscale plot colors with something more differentiable.

![screen shot 2015-04-25 at 11 05 20 am](https://cloud.githubusercontent.com/assets/2435101/7334099/1af8cf2c-eb3d-11e4-8566-6e39b3d2cba6.png)
