### PR TITLE
base1: Tweak mustache.js to allow individual AMD loading.

### DIFF
--- a/pkg/base1/Makefile.am
+++ b/pkg/base1/Makefile.am
@@ -155,8 +155,7 @@ update-lib:: update-bower
 	$(srcdir)/tools/cssbundle -o $(srcdir)/pkg/base1/patternfly.css \
 	    patternfly.css \
 	    $(BOWER)/bootstrap-datepicker/dist/css/bootstrap-datepicker.css
-	$(srcdir)/tools/jsbundle $(srcdir)/pkg/base1/mustache.js \
-		$(BOWER)/mustache/mustache.js
+	cp $(BOWER)/mustache/mustache.js $(srcdir)/pkg/base1/mustache.js
 	$(srcdir)/tools/uglifyjs $(BOWER)/mustache/mustache.js > \
 		$(srcdir)/pkg/base1/mustache.min.js
 	$(srcdir)/tools/jsbundle $(srcdir)/pkg/base1/term.js \

--- a/pkg/base1/mustache.js
+++ b/pkg/base1/mustache.js
@@ -1,4 +1,3 @@
-
 /*!
  * mustache.js - Logic-less {{mustache}} templates with JavaScript
  * http://github.com/janl/mustache.js
@@ -13,7 +12,7 @@
     var mustache = {};
     factory(mustache);
     if (typeof define === "function" && define.amd) {
-      define("mustache/mustache", mustache); // AMD
+      define(mustache); // AMD
     } else {
       root.Mustache = mustache; // <script>
     }
@@ -569,5 +568,3 @@
   mustache.Writer = Writer;
 
 }));
-
-//# sourceURL=mustache/mustache.js


### PR DESCRIPTION
Otherwise, when installing without DBGDIR, the dashboard produces this error:

```
TypeError: Mustache is undefined
```