### PR TITLE
kubernetes: Fix examples for kubernetes 0.14.0

### DIFF
--- a/pkg/kubernetes/README.md
+++ b/pkg/kubernetes/README.md
@@ -10,7 +10,7 @@ This sets up a single machine kubernetes master and minion:
     $ sudo yum install kubernetes
 
 Now in order to support the latest v1beta3 API, we need to build kubernetes
-from source or use a version later than v0.13.0:
+from source or use a version later than v0.14.0:
 
     $ sudo yum install kubernetes
     $ sudo yum install etcd docker

--- a/pkg/kubernetes/examples/database-service.json
+++ b/pkg/kubernetes/examples/database-service.json
@@ -9,12 +9,15 @@
       }
   },
   "spec": {
-      "port": 5432,
-      "protocol": "TCP",
+      "ports": [{
+          "name": "",
+          "port": 5432,
+          "protocol": "TCP",
+          "targetPort": 3306
+      }],
       "selector": {
           "name": "database"
       },
-      "containerPort": 3306,
       "sessionAffinity": "None"
   }
 }

--- a/pkg/kubernetes/examples/frontend-service.json
+++ b/pkg/kubernetes/examples/frontend-service.json
@@ -9,12 +9,15 @@
         }
     },
     "spec": {
-        "port": 5432,
-        "protocol": "TCP",
+        "ports": [{
+            "name": "",
+            "port": 5432,
+            "protocol": "TCP",
+            "targetPort": 8080
+        }],
         "selector": {
             "name": "frontend-ruby"
         },
-        "containerPort": 8080,
         "sessionAffinity": "None"
     }
 }

--- a/pkg/kubernetes/examples/guestbook_ns/frontend-service.json
+++ b/pkg/kubernetes/examples/guestbook_ns/frontend-service.json
@@ -3,16 +3,18 @@
   "apiVersion": "v1beta3",
   "metadata": {
     "name": "frontend",
-    "namespace": "default",
-    "labels": {},
+    "labels": {}
   },
   "spec": {
-    "port": 80,
-    "protocol": "TCP",
+    "ports": [{
+      "name": "",
+      "port": 80,
+      "protocol": "TCP",
+      "targetPort": 80
+    }],
     "selector": {
       "name": "frontend"
     },
-    "containerPort": 80,
     "sessionAffinity": "None"
   }
 }

--- a/pkg/kubernetes/examples/guestbook_ns/redis-master-service.json
+++ b/pkg/kubernetes/examples/guestbook_ns/redis-master-service.json
@@ -3,15 +3,17 @@
     "apiVersion": "v1beta3",
     "metadata": {
         "name": "redis-master",
-        "namespace": "default",
         "labels": {
             "name": "redis-master"
         }
     },
     "spec": {
-        "port": 6379,
-        "containerPort": 6379,
-        "protocol": "TCP",
+        "ports": [{
+            "name": "",
+            "port": 6379,
+            "protocol": "TCP",
+            "targetPort": 6379
+        }],
         "selector": {
             "name": "redis-master"
         },

--- a/pkg/kubernetes/examples/guestbook_ns/redis-slave-service.json
+++ b/pkg/kubernetes/examples/guestbook_ns/redis-slave-service.json
@@ -3,15 +3,17 @@
     "apiVersion": "v1beta3",
     "metadata": {
         "name": "redisslave",
-        "namespace": "default",
         "labels": {
             "name": "redisslave"
         }
     },
     "spec": {
-        "port": 6379,
-        "containerPort": 6379,
-        "protocol": "TCP",
+        "ports": [{
+            "name": "",
+            "port": 6379,
+            "protocol": "TCP",
+            "targetPort": 6379
+        }],
         "selector": {
             "name": "redisslave"
         },

--- a/pkg/kubernetes/examples/k8s-sample-app.json
+++ b/pkg/kubernetes/examples/k8s-sample-app.json
@@ -130,9 +130,12 @@
             }
          },
          "spec":{
-            "port":5434,
-            "containerPort":3306,
-            "protocol":"TCP",
+             "ports": [{
+                 "name": "",
+                 "protocol": "TCP",
+                 "port": 5434,
+                 "targetPort": 3306
+             }],
             "selector":{
                "name":"database"
             }
@@ -149,9 +152,12 @@
             }
          },
          "spec":{
-            "port":5432,
-            "containerPort":8080,
-            "protocol":"TCP",
+             "ports": [{
+                 "name": "",
+                 "protocol": "TCP",
+                 "port": 5432,
+                 "targetPort": 8080
+             }],
             "selector":{
                "name":"frontend"
             }


### PR DESCRIPTION
And bump our development version. Incompatible changes were made
to the service ports specification, among other things.