### PR TITLE
Use mv -f when moving temp files around

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,13 +28,15 @@ V_GZIP = $(V_GZIP_$(V))
 V_GZIP_ = $(V_GZIP_$(AM_DEFAULT_VERBOSITY))
 V_GZIP_0 = @echo "  GZIP    " $@;
 
+MV = mv -f
+
 .css.min.css:
 	@$(MKDIR_P) $(dir $@)
 	$(AM_V_GEN) $(srcdir)/tools/missing $(srcdir)/tools/r.js -o cssIn=$< optimizeCss=standard logLevel=3 out=$@
 .js.min.js:
 	@$(MKDIR_P) $(dir $@)
 	$(V_CHECK) $(srcdir)/tools/missing $(srcdir)/tools/jshint $<
-	$(AM_V_GEN) $(srcdir)/tools/missing $(srcdir)/tools/uglifyjs $< --mangle > $@.tmp && mv $@.tmp $@
+	$(AM_V_GEN) $(srcdir)/tools/missing $(srcdir)/tools/uglifyjs $< --mangle > $@.tmp && $(MV) $@.tmp $@
 .html.min.html:
 	@$(MKDIR_P) $(dir $@)
 	$(V_CHECK) $(srcdir)/tools/missing $(srcdir)/tools/jshint --extract=always $<
@@ -42,19 +44,19 @@ V_GZIP_0 = @echo "  GZIP    " $@;
 
 .min.css.min.css.gz:
 	@$(MKDIR_P) $(dir $@)
-	$(V_GZIP) gzip -c $< > $@.tmp && mv $@.tmp $@
+	$(V_GZIP) gzip -c $< > $@.tmp && $(MV) $@.tmp $@
 .min.html.min.html.gz:
 	@$(MKDIR_P) $(dir $@)
-	$(V_GZIP) gzip -c $< > $@.tmp && mv $@.tmp $@
+	$(V_GZIP) gzip -c $< > $@.tmp && $(MV) $@.tmp $@
 .js.js.gz:
 	@$(MKDIR_P) $(dir $@)
-	$(V_GZIP) gzip -c $< > $@.tmp && mv $@.tmp $@
+	$(V_GZIP) gzip -c $< > $@.tmp && $(MV) $@.tmp $@
 .min.js.min.js.gz:
 	@$(MKDIR_P) $(dir $@)
-	$(V_GZIP) gzip -c $< > $@.tmp && mv $@.tmp $@
+	$(V_GZIP) gzip -c $< > $@.tmp && $(MV) $@.tmp $@
 .woff.woff.gz:
 	@$(MKDIR_P) $(dir $@)
-	$(V_GZIP) gzip -c $< > $@.tmp && mv $@.tmp $@
+	$(V_GZIP) gzip -c $< > $@.tmp && $(MV) $@.tmp $@
 
 po/po.%.js: po/%.po
 	@$(MKDIR_P) $(dir $@)

--- a/pkg/base1/Makefile.am
+++ b/pkg/base1/Makefile.am
@@ -41,7 +41,7 @@ pkg/base1/bundle.min.js: $(base_BUNDLE)
 	$(AM_V_GEN) $(srcdir)/tools/missing $(srcdir)/tools/jsbundle $@ $^
 pkg/base1/term.min.js: pkg/base1/term.js
 	@$(MKDIR_P) $(dir $@)
-	$(AM_V_GEN) $(srcdir)/tools/missing $(srcdir)/tools/uglifyjs $< --mangle > $@.tmp && mv $@.tmp $@
+	$(AM_V_GEN) $(srcdir)/tools/missing $(srcdir)/tools/uglifyjs $< --mangle > $@.tmp && $(MV) $@.tmp $@
 
 install-data-local::
 	$(MKDIR_P) $(DESTDIR)$(basedebugdir)

--- a/tools/cssbundle
+++ b/tools/cssbundle
@@ -35,5 +35,5 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -n "$output" ]; then
-    mv $output.tmp $output
+    mv -f $output.tmp $output
 fi

--- a/tools/gdbus-unbreak-codegen
+++ b/tools/gdbus-unbreak-codegen
@@ -32,5 +32,5 @@ if [ -n "$generate_c_code" ]; then
 #undef GLIB_VERSION_MAX_ALLOWED\
 #endif' \
 		"$generate_c_code.c" > "$generate_c_code.$$"
-	mv "$generate_c_code.$$" "$generate_c_code.c"
+	mv -f "$generate_c_code.$$" "$generate_c_code.c"
 fi


### PR DESCRIPTION
This avoids silly prompts for permission to overwrite.