### PR TITLE
shell: Remove unused service-add-dialog

### DIFF
--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -2386,44 +2386,6 @@
       </div>
     </div>
 
-    <div class="modal" id="service-add-dialog"
-         tabindex="-1" role="dialog"
-         data-backdrop="static">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title">Add Service</h4>
-          </div>
-          <div class="modal-body">
-            <ul class="list-group" id="service-add-images">
-            </ul>
-            <table class="cockpit-form-table">
-              <tr>
-                <td translatable="yes">Image</td>
-                <td>
-                  <input class="form-control" id="service-add-image">
-                </td>
-              </tr>
-              <tr>
-                <td translatable="yes">Name</td>
-                <td>
-                  <input class="form-control" id="service-add-name">
-                </td>
-              </tr>
-            </table>
-          </div>
-          <div class="modal-footer">
-            <button class="btn btn-default" translatable="yes" data-dismiss="modal">
-              Cancel
-            </button>
-            <button class="btn btn-primary" translatable="yes" id="service-add-add">
-              Add
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <div class="modal" id="network-bond-settings-dialog"
          tabindex="-1" role="dialog"
          data-backdrop="static">


### PR DESCRIPTION
This was removed when the services page was moved into a component.