### PR TITLE
kubernetes: Listen for and load Kubernetes events

### DIFF
--- a/pkg/kubernetes/app.js
+++ b/pkg/kubernetes/app.js
@@ -147,7 +147,7 @@ define([
         };
     }
 
-    function builder(type, client, Constructor) {
+    function builder(type, events, client, Constructor) {
         var objects = { };
 
         function build() {
@@ -173,7 +173,7 @@ define([
             });
             $(objects).triggerHandler("changed");
         }
-        $(client).on(type, build);
+        $(client).on(events, build);
         build();
 
         return objects;
@@ -190,9 +190,9 @@ define([
             return kubernetes.k8client();
         })
         .factory('kubernetesServices', ['kubernetesClient', function(client) {
-            return builder('services', client, KubernetesService);
+            return builder('services', 'services pods', client, KubernetesService);
         }])
         .factory('kubernetesNodes', ['kubernetesClient', function(client) {
-            return builder('nodes', client, KubernetesNode);
+            return builder('nodes', 'nodes pods', client, KubernetesNode);
         }]);
 });

--- a/pkg/kubernetes/app.js
+++ b/pkg/kubernetes/app.js
@@ -8,26 +8,27 @@ define([
     function KubernetesService(client) {
         var self = this;
 
-        var version;
         var service = { };
-        var calculated = { };
+        var calculated;
 
         /* compute current and expected number of containers and return these
            values as a formatted string.
         */
         function calculate() {
-            if (version === client.resourceVersion)
+            if (calculated)
                 return calculated;
 
-            var spec = service.spec || { };
+            calculated = {
+                containers: "0",
+                ports: "",
+            };
 
-            version = client.resourceVersion;
+            var spec = service.spec || { };
 
             /* Calculate number of containers */
 
             var x = 0;
             var y = 0;
-            calculated.containers = "0";
 
             /*
              * Calculate "x of y" containers, where x is the current
@@ -107,30 +108,33 @@ define([
             self.address = spec.portalIP;
             self.namespace = meta.namespace;
             service = item;
+            calculated = null;
         };
     }
 
     function KubernetesNode(client) {
         var self = this;
 
-        var version;
-        var calculated = { };
+        var calculated;
         var node = { };
 
         function calculate() {
             var x = 0;
             var y = 0;
-            if (version !== client.resourceVersion) {
-                version = client.resourceVersion;
 
-                calculated.containers = "0";
+            if (calculated)
+                return calculated;
 
-                /* TODO: Calculate number of containers */
-                if (node.metadata && node.metadata.name) {
-                    var pods = client.hosting(node.metadata.name);
-                    calculated.containers = "" + pods.length;
-                }
+            calculated = {
+                containers: "0",
+            };
+
+            /* TODO: Calculate number of containers */
+            if (node.metadata && node.metadata.name) {
+                var pods = client.hosting(node.metadata.name);
+                calculated.containers = "" + pods.length;
             }
+
             return calculated;
         }
 
@@ -143,6 +147,7 @@ define([
             var meta = item.metadata || { };
             self.name = meta.name;
             self.address = status.hostIP;
+            calculated = null;
             node = item;
         };
     }

--- a/pkg/kubernetes/client.js
+++ b/pkg/kubernetes/client.js
@@ -287,6 +287,8 @@ define([
         function handle_updated(item, type) {
             var meta = item.metadata;
 
+            debug("item", item);
+
             if (meta.resourceVersion && meta.resourceVersion > self.resourceVersion)
                 self.resourceVersion = meta.resourceVersion;
 
@@ -324,6 +326,7 @@ define([
 
         function handle_removed(item, type) {
             var key = item.metadata.uid;
+            debug("remove", item);
             delete self.objects[key];
             trigger(type, item.kind);
         }
@@ -363,6 +366,8 @@ define([
 
             var type = involved.kind.toLowerCase() + "s";
             uri += "/" + type + "/" + involved.name;
+
+            debug("pulling", uri);
 
             api.get(uri)
                 .fail(function(ex) {


### PR DESCRIPTION
Events are a list of things that happened in Kubernetes. Currently they seem to be limited to container state changes. Use these to refresh pod information, in addition to exposing them to callers of the client.
