### PR TITLE
kubernetes: Fix regressions in Nodes table

### DIFF
--- a/pkg/kubernetes/app.js
+++ b/pkg/kubernetes/app.js
@@ -119,34 +119,42 @@ define([
         var node = { };
 
         function calculate() {
-            var x = 0;
-            var y = 0;
-
             if (calculated)
                 return calculated;
 
             calculated = {
                 containers: "0",
+                address: ""
             };
 
-            /* TODO: Calculate number of containers */
-            if (node.metadata && node.metadata.name) {
-                var pods = client.hosting(node.metadata.name);
-                calculated.containers = "" + pods.length;
-            }
+            var meta = node.metadata || { };
+            var spec = node.spec || { };
+            var pods = [];
+
+            if (spec.externalID)
+                calculated.address = spec.externalID;
+            pods = client.hosting(meta.name, "Pod");
+
+            /* TODO: Calculate number of containers instead of pods */
+            calculated.containers = "" + pods.length;
 
             return calculated;
         }
 
-        Object.defineProperty(self, "containers", {
-            get: function get() { return calculate().containers; }
+        Object.defineProperties(self, {
+            containers: {
+                enumerable: true,
+                get: function() { return calculate().containers; }
+            },
+            address: {
+                enumerable: true,
+                get: function() { return calculate().address; }
+            }
         });
 
         self.apply = function apply(item) {
-            var status = item.status || { };
             var meta = item.metadata || { };
             self.name = meta.name;
-            self.address = status.hostIP;
             calculated = null;
             node = item;
         };

--- a/pkg/kubernetes/client.js
+++ b/pkg/kubernetes/client.js
@@ -318,8 +318,8 @@ define([
 
             /* Index the host for quick lookup */
             var status = item.status;
-            if (status && status.host)
-                index.add([ status.host ], uid);
+            if (spec && spec.host)
+                index.add([ spec.host ], uid);
 
             trigger(type, item.kind);
         }
@@ -552,6 +552,7 @@ define([
         /**
          * client.hosting()
          * @host: the node host name, required
+         * @kind: limit to this kind of object
          *
          * Find out which objects are being hosted at the given node. These
          * have a obj.status.host property equal to the @host name passed into
@@ -559,14 +560,17 @@ define([
          *
          * Returns: an array of kubernetes objects
          */
-        this.hosting = function hosting(host) {
+        this.hosting = function hosting(host, kind) {
             var possible = index.select([ host ]);
             var obj, j, length = possible.length;
             var results = [];
             for (j = 0; j < length; j++) {
                 obj = self.objects[possible[j]];
-                if (obj && obj.status && obj.status.host === host)
-                    results.push(obj);
+                if (!obj || !obj.spec || obj.spec.host != host)
+                    continue;
+                if (kind && obj.kind !== kind)
+                    continue;
+                results.push(obj);
             }
             return results;
         };

--- a/pkg/kubernetes/mock-basic.js
+++ b/pkg/kubernetes/mock-basic.js
@@ -2,7 +2,7 @@ define({
     "nodes/127.0.0.1": {
         "kind": "Node",
         "metadata": {
-            "id": "127.0.0.1",
+            "name": "127.0.0.1",
             "uid": "f530580d-a169-11e4-8651-10c37bdb8410",
             "creationTimestamp": "2015-01-21T13:35:18+01:00",
             "resourceVersion": 1,
@@ -54,7 +54,8 @@ define({
             "restartPolicy": {
                 "always": {}
             },
-            "dnsPolicy": "ClusterFirst"
+            "dnsPolicy": "ClusterFirst",
+            "host": "127.0.0.1"
         },
         "status": {
             "phase": "Running",
@@ -64,7 +65,6 @@ define({
                     "status": "Full"
                 }
             ],
-            "host": "127.0.0.1",
             "hostIP": "127.0.0.1",
             "podIP": "172.17.4.173",
             "info": {

--- a/pkg/kubernetes/test-kubernetes.html
+++ b/pkg/kubernetes/test-kubernetes.html
@@ -484,7 +484,7 @@ require([
         $(client).on("nodes", function(ev) {
             var node = client.nodes[0];
             equal(client.nodes.length, 1, "number of nodes");
-            equal(node.metadata.id, "127.0.0.1", "localhost node");
+            equal(node.metadata.name, "127.0.0.1", "localhost node");
             equal(typeof node.spec.capacity, "object", "node has resources");
 
             $(client).off("nodes");
@@ -766,7 +766,7 @@ require([
         $(client).on("pods", function(ev) {
 
             /* Find out which pods this node is hosting */
-            var results = client.hosting("127.0.0.1");
+            var results = client.hosting("127.0.0.1", "Pod");
             equal(results.length, 1, "selected hosted pods");
             equal(results[0].metadata.name, "wordpress", "got wordpress pod");
 


### PR DESCRIPTION
Changes in Kubernetes 0.15.0 broke the 'Kubernetes Nodes' table display.
