### PR TITLE
Add CSS for dialog section headings

### DIFF
--- a/pkg/base1/cockpit.css
+++ b/pkg/base1/cockpit.css
@@ -133,6 +133,10 @@ a {
     width: 5px; /* will be expanded by nowrap */
 }
 
+.cockpit-form-table td[colspan] {
+    text-align: inherit;
+}
+
 .cockpit-form-table td {
     height: 26px;
 }
@@ -146,6 +150,8 @@ a {
 .cockpit-form-table td.header {
     font-weight: bold;
     text-align: left;
+    color: #4D5258;
+    padding: 13px 0 10px 0;
 }
 
 .cockpit-form-table input[type='checkbox'] {


### PR DESCRIPTION
This works with .cockpit-form-table, so isn't completely PatternFly upstream compatible. That'll be the case until we use normal Patternfly forms (if we do).