### PR TITLE
kubernetes: Remove unnecessary Patternfly shims

### DIFF
--- a/pkg/kubernetes/app.css
+++ b/pkg/kubernetes/app.css
@@ -9,51 +9,6 @@
     padding: 60px;
 }
 
-/* TODO: Need to reconcile Cockpit tables with latest patternfly */
-.table > thead {
-    background-color: white;
-    background-image: none;
-}
-
-.table > thead > tr > th {
-    border-bottom-width: 1px;
-}
-
-.table > thead > tr > th:first-child,
-.table > tbody > tr > td:first-child {
-    padding-left: 15px;
-}
-
-.table th,
-.table td {
-    padding-top: 8px !important;
-    padding-bottom: 8px !important;
-}
-
-.table td.icons {
-    padding: 5px !important;
-    text-align: center;
-}
-
-.table span.fa {
-    font-size: 24px;
-    color: black;
-    display: inline-block;
-}
-
-.table span.fa.failed {
-    color: #af151a;
-}
-
-.table td {
-    cursor: pointer;
-}
-
-button.fa {
-    min-height: 25px;
-}
-
-
 #deploy-app-deploying > span {
     margin-left: 7px;
 }


### PR DESCRIPTION
Remove unnecessary CSS from before new patternfly was completely integrated properly.