### PR TITLE
kubernetes: Count containers not pods

### DIFF
--- a/pkg/kubernetes/app.js
+++ b/pkg/kubernetes/app.js
@@ -43,24 +43,29 @@ define([
                           service.metadata.namespace, "Pod").forEach(function(pod) {
                 if (!pod.status || !pod.status.phase)
                     return;
+                var spec = pod.spec || { };
+                var n = 1;
+                if (spec.containers)
+                    n = spec.containers.length;
                 switch (pod.status.phase) {
                 case "Pending":
                     if (!state)
                         state = "wait";
-                    y++;
+                    y += n;
                     break;
                 case "Running":
-                    x++; y++;
+                    x += n;
+                    y += n;
                     break;
                 case "Succeeded": // don't increment either counter
                     break;
                 case "Unknown":
-                    y++;
+                    y += n;
                     break;
                 case "Failed":
                     /* falls through */
                 default: /* assume failed */
-                    y++;
+                    y += n;
                     state = "fail";
                     break;
                 }
@@ -140,14 +145,21 @@ define([
             var meta = node.metadata || { };
             var spec = node.spec || { };
             var status = node.status || { };
-            var pods = [];
 
             if (spec.externalID)
                 calculated.address = spec.externalID;
-            pods = client.hosting(meta.name, "Pod");
+
+            var count = 0;
+            client.hosting(meta.name, "Pod").forEach(function(pod) {
+                var spec = pod.spec || { };
+                var n = 1;
+                if (spec.containers)
+                    n = spec.containers.length;
+                count += n;
+            });
 
             /* TODO: Calculate number of containers instead of pods */
-            calculated.containers = "" + pods.length;
+            calculated.containers = "" + count;
 
             var state = "";
 

--- a/pkg/kubernetes/examples/k8s-sample-multipod.json
+++ b/pkg/kubernetes/examples/k8s-sample-multipod.json
@@ -1,0 +1,177 @@
+{
+   "kind":"List",
+   "apiVersion":"v1beta1",
+   "items":[
+      {
+         "kind":"ReplicationController",
+         "apiVersion":"v1beta3",
+         "metadata":{
+            "name":"database",
+            "labels":{
+               "name":"database",
+               "template":"ruby-helloworld-sample"
+            }
+         },
+         "spec":{
+            "replicas":1,
+            "selector":{
+               "name":"database",
+               "template":"ruby-helloworld-sample"
+            },
+            "template":{
+               "metadata":{
+                  "labels":{
+                     "name":"database",
+                     "template":"ruby-helloworld-sample"
+                  }
+               },
+               "spec":{
+                  "containers":[
+                     {
+                        "name":"ruby-helloworld-database",
+                        "image":"mysql",
+                        "ports":[
+                           {
+                              "containerPort":3306,
+                              "protocol":"TCP"
+                           }
+                        ],
+                        "env":[
+                           {
+                              "name":"MYSQL_ROOT_PASSWORD",
+                              "key":"MYSQL_ROOT_PASSWORD",
+                              "value":"rQHfVnTo"
+                           },
+                           {
+                              "name":"MYSQL_DATABASE",
+                              "key":"MYSQL_DATABASE",
+                              "value":"root"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            }
+         }
+      },
+      {
+         "kind":"ReplicationController",
+         "apiVersion":"v1beta3",
+         "metadata":{
+            "name":"frontend",
+            "labels":{
+               "name":"frontend",
+               "template":"ruby-helloworld-sample"
+            }
+         },
+         "spec":{
+            "replicas":1,
+            "selector":{
+               "name":"frontend",
+               "template":"ruby-helloworld-sample"
+            },
+            "template":{
+               "metadata":{
+                  "labels":{
+                     "name":"frontend",
+                     "template":"ruby-helloworld-sample"
+                  }
+               },
+               "spec":{
+                  "containers":[
+                     {
+                        "name":"ruby-helloworld",
+                        "image":"openshift/ruby-hello-world",
+                        "ports":[
+                           {
+                              "containerPort":80,
+                              "protocol":"TCP"
+                           }
+                        ],
+                        "env" : [
+                           {
+                              "name":"ADMIN_USERNAME",
+                              "key":"ADMIN_USERNAME",
+                              "value":"admin6TM"
+                           },
+                           {
+                              "name":"ADMIN_PASSWORD",
+                              "key":"ADMIN_PASSWORD",
+                              "value":"xImx1tHR"
+                           },
+                           {
+                              "name":"MYSQL_ROOT_PASSWORD",
+                              "key":"MYSQL_ROOT_PASSWORD",
+                              "value":"rQHfVnTo"
+                           },
+                           {
+                              "name":"MYSQL_DATABASE",
+                              "key":"MYSQL_DATABASE",
+                              "value":"root"
+                           }
+                        ],
+                        "capabilities" : { }
+                     },
+                     {
+                        "name" : "apache-unused",
+                        "image" : "fedora/apache",
+                        "ports" : [
+                           {
+                              "containerPort":8080,
+                              "protocol":"TCP"
+                           }
+                        ],
+                        "env" : [ ],
+                        "capabilities" : { }
+                     }
+                  ]
+               }
+            }
+         }
+      },
+      {
+         "kind":"Service",
+         "apiVersion":"v1beta3",
+         "metadata":{
+            "name":"database",
+            "labels":{
+               "name":"database",
+               "template":"ruby-helloworld-sample"
+            }
+         },
+         "spec":{
+             "ports": [{
+                 "name": "",
+                 "protocol": "TCP",
+                 "port": 80,
+                 "targetPort": 80
+             }],
+            "selector":{
+               "name":"database"
+            }
+         }
+      },
+      {
+         "kind":"Service",
+         "apiVersion":"v1beta3",
+         "metadata":{
+            "name":"frontend",
+            "labels":{
+               "name":"frontend",
+               "template":"ruby-helloworld-sample"
+            }
+         },
+         "spec":{
+             "ports": [{
+                 "name": "",
+                 "protocol": "TCP",
+                 "port": 5432,
+                 "targetPort": 8080
+             }],
+            "selector":{
+               "name":"frontend"
+            }
+         }
+      }
+   ]
+}


### PR DESCRIPTION
On the dashboard we should count containers, not pods.
    
Multi-container pods aren't *that* common, but we should reflect the number of containers in the 'Kubernetes Services' and 'Kubernetes Nodes' listings correctly.
