### PR TITLE
Connect to loopback on either IPv4 and IPv6

### DIFF
--- a/src/bridge/cockpitchannel.h
+++ b/src/bridge/cockpitchannel.h
@@ -98,6 +98,9 @@ GSocketAddress *    cockpit_channel_parse_address     (CockpitChannel *self,
 void                cockpit_channel_internal_address  (const gchar *name,
                                                        GSocketAddress *address);
 
+GSocketConnectable * cockpit_channel_parse_connectable (CockpitChannel *self,
+                                                       gchar **possible_name);
+
 CockpitStreamOptions * cockpit_channel_parse_stream   (CockpitChannel *self);
 
 G_END_DECLS

--- a/src/bridge/cockpithttpstream.c
+++ b/src/bridge/cockpithttpstream.c
@@ -895,7 +895,7 @@ cockpit_http_stream_prepare (CockpitChannel *channel)
 {
   CockpitHttpStream *self = COCKPIT_HTTP_STREAM (channel);
   CockpitStreamOptions *stream_options = NULL;
-  GSocketAddress *address = NULL;
+  GSocketConnectable *connectable = NULL;
   const gchar *connection;
   JsonObject *options;
 
@@ -925,11 +925,11 @@ cockpit_http_stream_prepare (CockpitChannel *channel)
       if (!stream_options)
         goto out;
 
-      address = cockpit_channel_parse_address (channel, self->name ? NULL : &self->name);
-      if (!address)
+      connectable = cockpit_channel_parse_connectable (channel, self->name ? NULL : &self->name);
+      if (!connectable)
         goto out;
 
-      self->stream = cockpit_stream_connect (self->name, address, stream_options);
+      self->stream = cockpit_stream_connect (self->name, connectable, stream_options);
     }
 
   /* Parsed elsewhere */
@@ -941,8 +941,8 @@ cockpit_http_stream_prepare (CockpitChannel *channel)
   cockpit_channel_ready (channel);
 
 out:
-  if (address)
-    g_object_unref (address);
+  if (connectable)
+    g_object_unref (connectable);
   if (stream_options)
     cockpit_stream_options_unref (stream_options);
 }

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -39,6 +39,8 @@ libcockpit_common_a_SOURCES = \
 	src/common/cockpitjson.c \
 	src/common/cockpitjson.h \
 	src/common/cockpitlog.h src/common/cockpitlog.c \
+	src/common/cockpitloopback.c \
+	src/common/cockpitloopback.h \
 	src/common/cockpitmemory.c \
 	src/common/cockpitmemory.h \
 	src/common/cockpittypes.h \

--- a/src/common/cockpitloopback.c
+++ b/src/common/cockpitloopback.c
@@ -1,0 +1,155 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitloopback.h"
+
+struct _CockpitLoopback {
+  GSocketAddressEnumerator parent;
+  GQueue addresses;
+};
+
+struct _CockpitLoopbackClass {
+  GSocketAddressEnumeratorClass parent_class;
+};
+
+static void cockpit_loopback_connectable_iface (GSocketConnectableIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (CockpitLoopback, cockpit_loopback, G_TYPE_SOCKET_ADDRESS_ENUMERATOR,
+                         G_IMPLEMENT_INTERFACE (G_TYPE_SOCKET_CONNECTABLE, cockpit_loopback_connectable_iface)
+)
+
+static void
+cockpit_loopback_init (CockpitLoopback *self)
+{
+  g_queue_init (&self->addresses);
+}
+
+static void
+cockpit_loopback_finalize (GObject *object)
+{
+  CockpitLoopback *self = COCKPIT_LOOPBACK (object);
+
+  while (!g_queue_is_empty (&self->addresses))
+    g_object_unref (g_queue_pop_head (&self->addresses));
+  g_queue_clear (&self->addresses);
+
+  G_OBJECT_CLASS (cockpit_loopback_parent_class)->finalize (object);
+}
+
+static GSocketAddress *
+cockpit_loopback_next (GSocketAddressEnumerator *enumerator,
+                       GCancellable *cancellable,
+                       GError **error)
+{
+  CockpitLoopback *self = COCKPIT_LOOPBACK (enumerator);
+  return g_queue_pop_head (&self->addresses);
+}
+
+static void
+cockpit_loopback_next_async (GSocketAddressEnumerator *enumerator,
+                             GCancellable *cancellable,
+                             GAsyncReadyCallback callback,
+                             gpointer user_data)
+{
+  CockpitLoopback *self = COCKPIT_LOOPBACK (enumerator);
+  GSimpleAsyncResult *res;
+  GSocketAddress *address;
+  GError *error = NULL;
+
+  address = cockpit_loopback_next (enumerator, cancellable, &error);
+  g_assert (error == NULL);
+
+  res = g_simple_async_result_new (G_OBJECT (self), callback, user_data, NULL);
+  g_simple_async_result_set_op_res_gpointer (res, address, address ? g_object_unref : NULL);
+  g_simple_async_result_complete_in_idle (res);
+  g_object_unref (res);
+}
+
+static GSocketAddress *
+cockpit_loopback_next_finish (GSocketAddressEnumerator *enumerator,
+                              GAsyncResult *result,
+                              GError **error)
+{
+  GSocketAddress *address;
+
+  address = g_simple_async_result_get_op_res_gpointer (G_SIMPLE_ASYNC_RESULT (result));
+  if (address)
+    g_object_ref (address);
+  return address;
+}
+
+static void
+cockpit_loopback_class_init (CockpitLoopbackClass *klass)
+{
+  GSocketAddressEnumeratorClass *enumerator_class = G_SOCKET_ADDRESS_ENUMERATOR_CLASS (klass);
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+  gobject_class->finalize = cockpit_loopback_finalize;
+
+  enumerator_class->next = cockpit_loopback_next;
+  enumerator_class->next_async = cockpit_loopback_next_async;
+  enumerator_class->next_finish = cockpit_loopback_next_finish;
+}
+
+static void
+ref_to_queue (gpointer data,
+              gpointer user_data)
+{
+  g_queue_push_tail (user_data, g_object_ref (data));
+}
+
+static GSocketAddressEnumerator *
+cockpit_loopback_enumerate (GSocketConnectable *connectable)
+{
+  CockpitLoopback *self = COCKPIT_LOOPBACK (connectable);
+  CockpitLoopback *copy;
+
+  copy = g_object_new (COCKPIT_TYPE_LOOPBACK, NULL);
+  g_queue_foreach (&self->addresses, ref_to_queue, &copy->addresses);
+
+  return G_SOCKET_ADDRESS_ENUMERATOR (copy);
+}
+
+static void
+cockpit_loopback_connectable_iface (GSocketConnectableIface *iface)
+{
+  iface->enumerate = cockpit_loopback_enumerate;
+  iface->proxy_enumerate = cockpit_loopback_enumerate;
+}
+
+GSocketConnectable *
+cockpit_loopback_new (guint16 port)
+{
+  CockpitLoopback *self;
+  GInetAddress *addr;
+
+  self = g_object_new (COCKPIT_TYPE_LOOPBACK, NULL);
+
+  addr = g_inet_address_new_loopback (G_SOCKET_FAMILY_IPV6);
+  g_queue_push_tail (&self->addresses, g_inet_socket_address_new (addr, port));
+  g_object_unref (addr);
+
+  addr = g_inet_address_new_loopback (G_SOCKET_FAMILY_IPV4);
+  g_queue_push_tail (&self->addresses, g_inet_socket_address_new (addr, port));
+  g_object_unref (addr);
+
+  return G_SOCKET_CONNECTABLE (self);
+}

--- a/src/common/cockpitloopback.h
+++ b/src/common/cockpitloopback.h
@@ -1,0 +1,40 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __COCKPIT_LOOPBACK_H__
+#define __COCKPIT_LOOPBACK_H__
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+#define COCKPIT_TYPE_LOOPBACK         (cockpit_loopback_get_type ())
+#define COCKPIT_LOOPBACK(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_LOOPBACK, CockpitLoopback))
+#define COCKPIT_IS_LOOPBACK(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_LOOPBACK))
+
+typedef struct _CockpitLoopback        CockpitLoopback;
+typedef struct _CockpitLoopbackClass   CockpitLoopbackClass;
+
+GType                 cockpit_loopback_get_type     (void) G_GNUC_CONST;
+
+GSocketConnectable *  cockpit_loopback_new          (guint16 port);
+
+G_END_DECLS
+
+#endif /* __COCKPIT_LOOPBACK_H__ */

--- a/src/common/cockpitstream.h
+++ b/src/common/cockpitstream.h
@@ -68,7 +68,7 @@ CockpitStream *    cockpit_stream_new          (const gchar *name,
                                                 GIOStream *stream);
 
 CockpitStream *    cockpit_stream_connect      (const gchar *name,
-                                                GSocketAddress *address,
+                                                GSocketConnectable *connectable,
                                                 CockpitStreamOptions *options);
 
 void               cockpit_stream_write        (CockpitStream *self,


### PR DESCRIPTION
 Use a GSocketConnectable to connect to streams. This means we can try multiple addresses in turn. Implement a test for this as well.
    
This is necessary for sucky servers, that don't listen on both IPv6 and IPv4 locally. Kubernetes doesn't listen on both IPv4 and IPv6, so try both in turn on the given port.

In the future we may want to add local addresses as well. Needs more thought.