### PR TITLE
test: Unbreak the sit -s test argument

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -673,7 +673,10 @@ def sit():
     The current test case is suspended so that the user can inspect
     the browser.
     """
-    raw_input ("Press RET to continue... ")
+    sys.stdout.write("Press Ctrl-C to continue... ")
+    sys.stdout.flush()
+    while True:
+        sleep(60)
 
 def merge(*args):
     return dict(reduce(lambda x,y: x + y, map(lambda d: d.items(), args), [ ]))


### PR DESCRIPTION
Don't rely on stdin, since everyone seems to break that over
and over again.