### PR TITLE
kubernetes: Refactor create logic

### DIFF
--- a/pkg/kubernetes/test-kubernetes.html
+++ b/pkg/kubernetes/test-kubernetes.html
@@ -379,6 +379,9 @@ function kube_api_get(req, parts, query) {
     } else if (what == "replicationcontrollers") {
         regexp = /namespaces\/.+\/replicationcontrollers\//;
         kind = "ReplicationControllerList";
+    } else if (what == "events") {
+        regexp = /namespaces\/.+\/events\//;
+        kind = "EventList";
 
     /* Nothing found */
     } else {

--- a/pkg/kubernetes/test-kubernetes.html
+++ b/pkg/kubernetes/test-kubernetes.html
@@ -104,7 +104,7 @@ function MockHttp(callback) {
             if (responsers)
                 responsers.fire(status, headers || []);
             if (status < 200 || status > 299)
-                dfd.reject(new HttpError(status, reason, body));
+                dfd.reject(new HttpError(status, reason, body), body);
             else if (body !== undefined)
                 req.mock_data(body, false);
         };
@@ -254,6 +254,16 @@ var kube_last = 100;
 
 var kude_data = { };
 
+function guid() {
+    function s4() {
+        return Math.floor((1 + Math.random()) * 0x10000)
+            .toString(16)
+            .substring(1);
+    }
+    return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
+           s4() + '-' + s4() + s4() + s4();
+}
+
 function kube_update(key, item) {
     var type;
     if (!item) {
@@ -262,7 +272,7 @@ function kube_update(key, item) {
             item = kube_data[key];
             delete kube_data[key];
         } else {
-            return;
+            return null;
         }
     } else {
         if (kube_data[key])
@@ -274,10 +284,13 @@ function kube_update(key, item) {
 
     if (!item.metadata)
         item.metadata = { };
+    if (!item.metadata.uid)
+        item.metadata.uid = guid();
     item.metadata.resourceVersion = kube_last;
     kube_last += 1;
 
     $(kube_data).triggerHandler("notify", [ type, key, item ]);
+    return item;
 }
 
 function kube_apiserver(req) {
@@ -297,14 +310,20 @@ function kube_apiserver(req) {
     if (parts[0] != "api" && parts[1] != "v1beta3")
         return false;
 
-    if (req.method !== "GET") {
-        req.mock_respond(405, "Unsupported method");
-        return;
-    }
-
-    var resourceVersion = null;
-
     parts = parts.slice(2);
+
+    if (req.method === "POST") {
+        return kube_api_post(req, parts, query);
+    } else if (req.method === "GET") {
+        return kube_api_get(req, parts, query);
+    } else {
+        req.mock_respond(405, "Unsupported method");
+        return true;
+    }
+}
+
+function kube_api_get(req, parts, query) {
+    var resourceVersion = null;
 
     /* Figure out if this is a watch */
     var watch = false;
@@ -410,6 +429,57 @@ function kube_apiserver(req) {
         respond_watch();
     else
         respond_get();
+}
+
+function kube_api_post(req, parts, query) {
+    var namespace;
+    var section;
+
+    if (parts.length === 3) {
+        if (parts[0] != "namespaces")
+            return false;
+        namespace = parts[1];
+        section = parts[2];
+    } else if (parts.length === 1) {
+        section = parts[0];
+    } else {
+        return false;
+    }
+
+    var item;
+    try {
+        item = JSON.parse(req.body);
+    } catch(ex) {
+        req.mock_respond(400, "Bad JSON");
+        return;
+    }
+
+    var kind = item.kind;
+    var meta = item.metadata || { };
+    var name = meta.name;
+
+    if (!kind || !meta || !name) {
+        req.mock_respond(400, "Bad fields in JSON");
+        return;
+    }
+
+    if (kind.toLowerCase() + "s" != section) {
+        req.mock_respond(400, "Bad section of URI");
+        return;
+    }
+
+    parts.push(name);
+    var key = parts.join("/");
+
+    if (kube_data[key]) {
+        req.mock_respond(409, "Already exists", { "Content-Type": "application/json" },
+                         JSON.stringify({ code: 409, message: "Already exists" }));
+        return;
+    }
+
+    kube_update(key, item);
+    req.mock_respond(200, "OK", { "Content-Type": "application/json" }, JSON.stringify(item));
+    return true;
 }
 
 function etcd_server(req) {
@@ -640,6 +710,144 @@ require([
 
         /* No error should be thrown on immediate close*/
         client.close();
+    });
+
+    var create_items = [
+        {
+            "kind": "Pod",
+            "apiVersion": "v1beta3",
+            "metadata": {
+                "name": "pod1",
+                "uid": "d072fb85-f70e-11e4-b829-10c37bdb8410",
+                "resourceVersion": "634203",
+                "labels": {
+                    "name": "pod1"
+                    },
+            },
+            "spec": {
+                "volumes": null,
+                "containers": [{
+                    "name": "database",
+                    "image": "mysql",
+                    "ports": [{ "containerPort": 3306, "protocol": "TCP" }],
+                }],
+                "host": "127.0.0.1"
+            }
+        },{
+            "kind": "Node",
+            "apiVersion": "v1beta3",
+            "metadata": {
+                "name": "node1",
+                "uid": "6e51438e-d161-11e4-acbc-10c37bdb8410",
+                "resourceVersion": "634539",
+            },
+            "spec": {
+                "externalID": "172.2.3.1"
+            }
+        }
+    ];
+
+    asyncTest("create", function() {
+        expect(6);
+
+        var client = kubernetes.k8client();
+
+        client.create(create_items, "namespace1")
+            .done(function() {
+                equal(kube_data["namespaces/namespace1/pods/pod1"].metadata.name, "pod1", "pod created");
+                equal(kube_data["nodes/node1"].metadata.name, "node1", "node created");
+                equal(kube_data["namespaces/namespace1"].metadata.name, "namespace1", "namespace created");
+
+                equal(client.objects["d072fb85-f70e-11e4-b829-10c37bdb8410"].metadata.name, "pod1", "pod object");
+                equal(client.objects["6e51438e-d161-11e4-acbc-10c37bdb8410"].metadata.name, "node1", "node object");
+            })
+            .always(function() {
+                equal(this.state(), "resolved", "succeeded");
+                $(client).off();
+                client.close();
+                start();
+            });
+    });
+
+    asyncTest("create namespace exists", function() {
+        expect(7);
+
+        var client = kubernetes.k8client();
+
+        var namespace_item = {
+            "apiVersion" : "v1beta3",
+            "kind" : "Namespace",
+            "metadata" : { "name": "namespace1" }
+        };
+
+        client.create(namespace_item)
+            .always(function() {
+                    equal(this.state(), "resolved", "namespace succeeded");
+                    equal(kube_data["namespaces/namespace1"].metadata.name, "namespace1", "namespace created");
+
+                    client.create(create_items, "namespace1")
+                        .done(function() {
+                            equal(kube_data["namespaces/namespace1/pods/pod1"].metadata.name, "pod1",
+                                  "pod created");
+                            equal(kube_data["nodes/node1"].metadata.name, "node1", "node created");
+
+                            equal(client.objects["d072fb85-f70e-11e4-b829-10c37bdb8410"].metadata.name,
+                                  "pod1", "pod object");
+                            equal(client.objects["6e51438e-d161-11e4-acbc-10c37bdb8410"].metadata.name,
+                                  "node1", "node object");
+                        })
+                        .always(function() {
+                            equal(this.state(), "resolved", "succeeded");
+
+                            $(client).off();
+                            client.close();
+                            start();
+                        });
+            });
+    });
+
+    asyncTest("create namespace default", function() {
+        expect(5);
+
+        var client = kubernetes.k8client();
+
+        client.create(create_items)
+            .done(function() {
+                equal(kube_data["namespaces/default/pods/pod1"].metadata.name, "pod1", "pod created");
+                equal(kube_data["nodes/node1"].metadata.name, "node1", "node created");
+
+                equal(client.objects["d072fb85-f70e-11e4-b829-10c37bdb8410"].metadata.name, "pod1", "pod object");
+                equal(client.objects["6e51438e-d161-11e4-acbc-10c37bdb8410"].metadata.name, "node1", "node object");
+            })
+            .always(function() {
+                equal(this.state(), "resolved", "succeeded");
+
+                $(client).off();
+                client.close();
+                start();
+            });
+    });
+
+    asyncTest("create object exists", function() {
+        expect(3);
+
+        var client = kubernetes.k8client();
+
+        var items = create_items.slice();
+        items.push(items[0]);
+
+        client.create(items, "namespace1")
+            .fail(function(ex, response) {
+                equal(ex.status, 409, "http already exists");
+                equal(response.code, 409, "kubernetes already exists");
+            })
+            .always(function() {
+                equal(this.state(), "rejected", "failed");
+
+                $(client).off();
+                client.close();
+                start();
+            });
     });
 
     QUnit.module("large", {

--- a/pkg/kubernetes/tool.html
+++ b/pkg/kubernetes/tool.html
@@ -187,13 +187,13 @@ require([
                 return;
             }
             if (entityType == "pod") {
-                client.create_pod(jsondata);
+                client.create(jsondata);
             } else if (entityType == "node") {
-                client.create_nodes(jsondata);
+                client.create(jsondata);
             } else if (entityType == "replicationcontroller") {
-                client.create_replicationcontroller(jsondata);
+                client.create(jsondata);
             } else if (entityType == "service") {
-               client.create_service(jsondata);
+               client.create(jsondata);
             }
             $("#add-dialog").modal('hide');
             $("#add-dialog-apply").off('click');


### PR DESCRIPTION
Refactor a KubernetesClient.create() function
    
This is a general function that tries to create any kind of item in the right namespace. This is refactored out of the deploy.js logic, so that it can be tested and reused.
