### PR TITLE
kubernetes: Add connect() method and try multiple ports

### DIFF
--- a/pkg/kubernetes/README.md
+++ b/pkg/kubernetes/README.md
@@ -10,7 +10,7 @@ This sets up a single machine kubernetes master and minion:
     $ sudo yum install kubernetes
 
 Now in order to support the latest v1beta3 API, we need to build kubernetes
-from source or use a version later than v0.14.0:
+from source or use a version later than v0.15.0:
 
     $ sudo yum install kubernetes
     $ sudo yum install etcd docker
@@ -39,13 +39,24 @@ You should find a 'Kubernetes Master' item on the 'Tools' menu in Cockpit.
 
 Now put some objects into kubernetes:
 
-    $ cd /path/to/cockpit/pkg/kubernetes/examples/guestbook_ns
-    $ kubectl create -f redis-master.json
-    $ kubectl create -f redis-master-service.json
-    $ kubectl create -f redis-slave-service.json
-    $ kubectl create -f redis-slave-controller.json
-    $ kubectl create -f frontend-service.json
-    $ kubectl create -f frontend-controller.json
+    $ cd /path/to/cockpit/pkg/kubernetes/examples
+    $ kubectl create -f k8s-sample-app.json
 
 More information on these example objects, and what you can get running
 with them here: https://github.com/GoogleCloudPlatform/kubernetes/tree/master/examples/guestbook
+
+
+Openshift
+---------
+
+Openshift is really Kubernetes underneath. To run with Openshift, you currently have
+to disable Openshift authorization. Run the following commands to do that. If you're
+running openshift in a container then run the first command:
+
+    $ sudo docker exec -it openshift-origin bash
+    # osadm policy add-role-to-user cluster-admin system:anonymous
+    # osadm policy add-role-to-user cluster-admin system:anonymous --namespace=master
+    # osadm policy add-cluster-role-to-user cluster-admin system:anonymous
+
+Different versions of Openshift require different commands, hence the scattersho
+running all three.

--- a/pkg/kubernetes/dashboard.js
+++ b/pkg/kubernetes/dashboard.js
@@ -5,6 +5,8 @@ define([
 ], function($, angular) {
     'use strict';
 
+    var phantom_checkpoint = phantom_checkpoint || function () { };
+
     /* TODO: Migrate this to angular */
     $("#content").on("click", "#services-enable-change", function() {
         $("#service-list").toggleClass("editable");
@@ -29,6 +31,7 @@ define([
             $scope.pods = pods;
             $([services, nodes, pods]).on("changed", function() {
                 $scope.$digest();
+                phantom_checkpoint();
             });
         }]);
 });

--- a/pkg/kubernetes/test-kubernetes.html
+++ b/pkg/kubernetes/test-kubernetes.html
@@ -307,6 +307,15 @@ function kube_apiserver(req) {
     }
 
     var parts = path.substring(1).split("/");
+
+    /* The API check */
+    if (parts.length == 1 && parts[0] == "api") {
+        req.mock_respond(200, "OK", { }, JSON.stringify({
+            versions: [ "v1beta3" ]
+        }));
+        return true;
+    }
+
     if (parts[0] != "api" && parts[1] != "v1beta3")
         return false;
 

--- a/test/check-kubernetes
+++ b/test/check-kubernetes
@@ -73,4 +73,21 @@ class TestKubernetes(MachineCase):
         b.dialog_complete("#node-dialog", result="fail")
         b.dialog_cancel("#node-dialog")
 
+class TestSsl(MachineCase):
+    def testConnect(self):
+        m = self.machine
+        b = self.browser
+
+        # Start a kube-apiserver with a 'wrong' http port, forcing use of https
+        m.execute("echo 'KUBE_API_PORT=\"--port=1111\"' >> /etc/kubernetes/apiserver")
+        m.execute("sed -i s/8080/1111/g /etc/kubernetes/*")
+        m.execute("systemctl start etcd kube-apiserver kube-controller-manager docker kube-proxy kubelet")
+
+        self.login_and_go("/kubernetes/cluster", host=None)
+        b.wait_in_text("#node-list", "127.0.0.1")
+
+        # Check that this failed as a double check
+        output = m.execute("curl -sS http://localhost:8080/api 2>&1 || true")
+        self.assertIn("Connection refused", output)
+
 test_main()

--- a/test/check-kubernetes
+++ b/test/check-kubernetes
@@ -23,12 +23,31 @@ import json
 import os
 import sys
 
-class TestKubernetes(MachineCase):
+class KubernetesCase(MachineCase):
+
+    # HACK: https://github.com/GoogleCloudPlatform/kubernetes/issues/8311
+    # Work around for the fact that kube-apiserver doesn't notify about startup
+    # We wait until available or timeout.
+    def wait_api_server(self, port=8080, timeout=60):
+        waiter = """
+        port=%d
+        timeout=%d
+        for a in $(seq 0 $timeout); do
+            if curl -o /dev/null -s http://localhost:$port; then
+                break
+            fi
+            sleep 0.5
+        done
+        """ % (port, timeout * 2)
+        self.machine.execute(script=waiter)
+
+class TestKubernetes(KubernetesCase):
     def setUp(self):
         MachineCase.setUp(self)
         m = self.machine
         m.execute("systemctl start etcd kube-apiserver kube-controller-manager docker kube-proxy kubelet")
         m.upload(["mock-k8s-tiny-app.json"], "/tmp")
+        self.wait_api_server()
 
     def testDashboard(self):
         b = self.browser
@@ -73,7 +92,7 @@ class TestKubernetes(MachineCase):
         b.dialog_complete("#node-dialog", result="fail")
         b.dialog_cancel("#node-dialog")
 
-class TestSsl(MachineCase):
+class TestSsl(KubernetesCase):
     def testConnect(self):
         m = self.machine
         b = self.browser
@@ -82,6 +101,7 @@ class TestSsl(MachineCase):
         m.execute("echo 'KUBE_API_PORT=\"--port=1111\"' >> /etc/kubernetes/apiserver")
         m.execute("sed -i s/8080/1111/g /etc/kubernetes/*")
         m.execute("systemctl start etcd kube-apiserver kube-controller-manager docker kube-proxy kubelet")
+        self.wait_api_server(port=1111)
 
         self.login_and_go("/kubernetes/cluster", host=None)
         b.wait_in_text("#node-list", "127.0.0.1")


### PR DESCRIPTION
Try multiple ports 8080, 8440, 6443 when connecting to kubernetes api-server. This allows us to check non-ssl and ssl. Necessary to connect to Openshift.
    
In the future the connect() method will allow us to implement a curtain over the dashboard when connectivity fails, telling the user about that. Not done in this commit.
    
Add test for this.
