### PR TITLE
base1: Increase health check interval to 1 minute.

### DIFF
--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -308,13 +308,20 @@ function Transport() {
             }
         }
 
+        /* HACK - we allow for one minute of silence since some
+         *        versions of NetworkManager seem to cause a total
+         *        network blackout of 30 seconds or so when making
+         *        configuration changes.
+         *
+         * https://bugzilla.redhat.com/show_bug.cgi?id=1211287
+         */
         check_health_timer = window.setInterval(function () {
             if (!got_message) {
                 console.log("health check failed");
                 self.close({ "problem": "timeout" });
             }
             got_message = false;
-        }, 10000);
+        }, 60000);
     }
 
     if (!ws) {

--- a/test/check-connection
+++ b/test/check-connection
@@ -45,7 +45,8 @@ class TestConnection(MachineCase):
         # take cockpit-ws down on the server page
         m.execute("systemctl stop cockpit-testing.socket")
         b.switch_to_top()
-        b.wait_popup("disconnected-dialog")
+        with b.wait_timeout(120):
+            b.wait_popup("disconnected-dialog")
         m.execute("systemctl start cockpit-testing.socket")
         b.click('#disconnected-reconnect')
         b.expect_reload()
@@ -66,7 +67,7 @@ class TestConnection(MachineCase):
         # severe the connection on the server page
 	m.execute("iptables -I INPUT 1 -p tcp --dport 9090 -j REJECT")
         b.switch_to_top()
-        with b.wait_timeout(60):
+        with b.wait_timeout(120):
             b.wait_popup("disconnected-dialog")
         b.wait_in_text('#disconnected-error', "Connection has timed out.")
         m.execute("iptables -D INPUT 1")

--- a/test/check-networking
+++ b/test/check-networking
@@ -176,11 +176,10 @@ class TestNetworking(MachineCase):
 
 if 'TEST_OS' in os.environ and os.environ['TEST_OS'] == "rhel-7":
 
-    # HACK - We lose all connectivity to the VM for about 30 seconds
-    #        after changing the config of the additional network
-    #        interfaces.
+    # HACK - Some details in the NM behavior are different on RHEL 7,
+    #        and we haven't worked through that yet.
     #
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1211287
+    # https://github.com/cockpit-project/cockpit/issues/2270
     #
     print "Skipping check-networking on RHEL 7"
 else:


### PR DESCRIPTION
As a workaround for
https://bugzilla.redhat.com/show_bug.cgi?id=1211287 since we now
encounter that bug also on Fedora.

Consequently, we can re-enable check-networking on RHEL 7.