### PR TITLE
docker: Refactor pull request code

### DIFF
--- a/pkg/shell/cockpit-docker.js
+++ b/pkg/shell/cockpit-docker.js
@@ -1540,8 +1540,8 @@ PageSearchImage.prototype = {
 
         insert_table_sorted($('#containers-images table'), tr);
 
-        var created = tr.children('td').eq(1);
-        var size = tr.children('td').eq(2);
+        var created = tr.children('td.container-col-created');
+        var size = tr.children('td.image-col-size-text');
 
         var failed = false;
         var layers = {};


### PR DESCRIPTION
Migrate the pull functionality into docker.js
    
This allows the logic to be moved away from the presentation layer. Also gets this ready for reuse outside of the containers page, such as with the Atomic App Entity work.
