### PR TITLE
docker: Add support for pulling from a specific registry

### DIFF
--- a/pkg/docker/docker.js
+++ b/pkg/docker/docker.js
@@ -52,10 +52,22 @@ define([
      * been downloaded, or fails with an error. The progress callbacks
      * on the download are called with status updates from docker.
      */
-    docker.pull = function pull(repo, tag) {
+    docker.pull = function pull(repo, tag, registry) {
         var dfd = $.Deferred();
 
-        docker_debug("pulling: " + repo + ", tag: " + tag);
+        if (!tag)
+            tag = "latest";
+
+        /*
+         * Although in theory the docker images/create API has
+         * a registry parameter, when you use it the resulting
+         * image is labeled completely wrong.
+         */
+
+        if (registry)
+            repo = registry + "/" + repo;
+
+        console.log("pulling: " + repo + ":" + tag);
 
         var options = {
             method: "POST",
@@ -63,7 +75,7 @@ define([
             body: "",
             params: {
                 fromImage: repo,
-                tag: tag || "latest",
+                tag: tag
             }
         };
 

--- a/pkg/shell/cockpit-docker.js
+++ b/pkg/shell/cockpit-docker.js
@@ -1523,6 +1523,7 @@ PageSearchImage.prototype = {
 
     start_download: function(event) {
         var repo = $('#containers-search-download').data('repo');
+        var registry = $('#containers-search-download').data('registry') || undefined;
         var tag = $('#containers-search-tag').val();
 
         $('#containers-search-tag').prop('disabled', true);
@@ -1546,7 +1547,7 @@ PageSearchImage.prototype = {
         var failed = false;
         var layers = {};
 
-        docker.pull(repo, tag).
+        docker.pull(repo, tag, registry).
             progress(function(message, progress) {
                 if("id" in progress) {
                     var new_string = progress['status'];
@@ -1613,6 +1614,7 @@ PageSearchImage.prototype = {
                           $('#containers-search-tag').val('latest');
                           $('#containers-search-tag').prop('disabled', false);
                           $('#containers-search-download').data('repo', entry.name);
+                          $('#containers-search-download').data('registry', entry.registry_name);
                           $('#containers-search-download').prop('disabled', false);
                       });
                       row.data('entry', entry);

--- a/pkg/shell/cockpit-docker.js
+++ b/pkg/shell/cockpit-docker.js
@@ -1540,8 +1540,8 @@ PageSearchImage.prototype = {
 
         insert_table_sorted($('#containers-images table'), tr);
 
-        var created = tr.children('td').eq(1);
-        var size = tr.children('td').eq(2);
+        var created = tr.children('td.container-col-created');
+        var size = tr.children('td.image-col-size-text');
 
         var failed = false;
         var layers = {};


### PR DESCRIPTION
The registry is typed in the search dialog just like it would be on the command line.

An example to try is: ```registry.access.redhat.com/rhel7```
