### PR TITLE
Fix the alignment of input checkbox labels

### DIFF
--- a/pkg/base1/cockpit.css
+++ b/pkg/base1/cockpit.css
@@ -152,11 +152,15 @@ a {
     font-weight: bold;
     text-align: left;
     color: #4D5258;
-    padding: 13px 0 10px 0;
+    padding: 20px 0 10px 0;
 }
 
 .cockpit-form-table input[type='checkbox'] {
     margin: 8px;
+}
+
+.cockpit-form-table label input[type='checkbox'] {
+    margin-right: 4px;
 }
 
 .cockpit-form-table label {
@@ -165,6 +169,11 @@ a {
 
 .cockpit-form-table td.top label {
     margin-top: 4px;
+}
+
+.cockpit-form-table label span {
+    color: #888;
+    vertical-align: super;
 }
 
 .journal-lines .panel-heading {


### PR DESCRIPTION
Labels were aligned below the checkbox and looked unsightly. In addition the color of the label was incorrect. Corrected to match other labels.