### PR TITLE
kubernetes: Basic Add Node Dialog

### DIFF
--- a/pkg/kubernetes/Makefile.am
+++ b/pkg/kubernetes/Makefile.am
@@ -19,6 +19,7 @@ kubernetesdebug_DATA = \
 	pkg/kubernetes/cluster.html \
 	pkg/kubernetes/dashboard.js \
 	pkg/kubernetes/kubernetes.js \
+	pkg/kubernetes/node.js \
 	pkg/kubernetes/tool.html \
 	pkg/kubernetes/deploy.js \
 	$(NULL)
@@ -30,6 +31,7 @@ kubernetes_BUNDLE = \
 	pkg/kubernetes/client.min.js \
 	pkg/kubernetes/dashboard.min.js \
 	pkg/kubernetes/deploy.min.js \
+	pkg/kubernetes/node.min.js \
 	$(NULL)
 
 pkg/kubernetes/kubernetes.min.js: $(kubernetes_BUNDLE)

--- a/pkg/kubernetes/cluster.html
+++ b/pkg/kubernetes/cluster.html
@@ -106,7 +106,8 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
       <div id="node-list" class="panel panel-default dashboard-list">
         <div class="panel-heading">
           <span style="float: right;">
-            <button title="Add Kubernetes Node" class="btn btn-primary fa fa-plus"></button>
+            <button title="Add Kubernetes Node" id="add-node" class="btn btn-primary fa fa-plus"
+                data-toggle="modal" data-target="#node-dialog"></button>
           </span>
           <span translatable="yes">Kubernetes Nodes</span>
         </div>
@@ -225,6 +226,57 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
           </div>
         </div>
       </div>
+    </div>
+
+    <div class="modal" id="node-dialog" tabindex="-1" role="dialog" data-backdrop="static">
+      <div class="modal-dialog modal-md">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title" translatable="yes">Add Cluster Node </h4>
+          </div>
+          <div class="modal-body">
+            <table class="cockpit-form-table">
+              <tr>
+                <td class="top"><label class="control-label" for="node-name" translatable="yes"
+                        placeholder="eg: 198.51.10.25">Address</label></td>
+                <td class="top"><input id="node-address" type="text" class="form-control"></td>
+              </tr>
+              <tr>
+                <td class="top"><label class="control-label" for="node-name" translatable="yes"
+                        placeholder="eg: node-1">Name</label></td>
+                <td class="top"><input id="node-name" type="text" class="form-control"></td>
+              </tr>
+              <tr class="node-configure-header">
+                <td colspan="2" class="header">Configuration</td>
+              </tr>
+              <tr class="configure-option">
+                <td></td>
+                <td>
+                  <label>
+                    <input type="checkbox">
+                    <span translatable="yes">Configure Kubelet and Proxy</span>
+                  </label>
+                </td>
+              </tr>
+              <tr class="configure-option">
+                <td></td>
+                <td>
+                  <label>
+                    <input type="checkbox">
+                    <span translatable="yes">Configure Flannel networking</span>
+                  </label>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div class="modal-footer">
+            <button class="btn btn-default" translatable="yes" data-dismiss="modal">Cancel</button>
+            <button class="btn btn-primary" translatable="yes">Add</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </div>
 
   <script>
@@ -234,6 +286,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
           "kubernetes/angular",
           "kubernetes/deploy",
           "kubernetes/adjust",
+          "kubernetes/node",
           "kubernetes/app",
           "kubernetes/dashboard"
       ], function(cockpit, po, angular) {

--- a/pkg/kubernetes/node.js
+++ b/pkg/kubernetes/node.js
@@ -1,0 +1,133 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+define([
+    "jquery",
+    "base1/cockpit",
+    "base1/patterns",
+    "base1/mustache",
+    "kubernetes/client"
+], function(jQuery, cockpit, patterns, Mustache, kubernetes) {
+    "use strict";
+
+    var _ = cockpit.gettext;
+    var $ = jQuery.scoped("#node-dialog", patterns);
+
+    var kube = null;
+
+    var regex = /^[a-z0-9.]+$/i;
+    var dialog = $("#node-dialog", document);
+
+    dialog
+        .on("show.bs.modal", function(ev) {
+            kube = kubernetes.k8client();
+
+            /* We don't support configuration for now */
+            $(".configure-option input")
+                .attr("disabled", "disabled");
+
+            $("#node-name").val('');
+            $("#node-address").val('');
+        })
+        .on("shown.bs.modal", function() {
+            $("#node-address").focus();
+        })
+        .on("hide.bs.modal", function(ev) {
+            kube.close();
+            kube = null;
+        });
+
+    function gather() {
+        var failures = [];
+        var items = [];
+
+        var name = $("#node-name").val().trim();
+        var address = $("#node-address").val().trim();
+
+        var ex;
+        if (!address)
+            ex = new Error(_("Please type an address"));
+        else if (!regex.test(address))
+            ex = new Error(_("The address contains invalid characters"));
+        if (ex) {
+            ex.target = "#node-address";
+            failures.push(ex);
+        }
+
+        if (name && !regex.test(name)) {
+            ex = new Error(_("The name contains invalid charaters"));
+            ex.target = "#node-name";
+            failures.push(ex);
+        }
+
+        if (failures.length) {
+            dialog.dialog("failure", failures);
+            return null;
+        }
+
+        if (!name)
+            name = address;
+
+        var item = {
+            "kind": "Node",
+            "apiVersion": "v1beta3",
+            "metadata": {
+                "name": name
+            },
+            "spec": {
+                "externalID": address
+            }
+        };
+
+        return [ item ];
+    }
+
+    var name_dirty = false;
+
+    $("#node-name").on("input", function() {
+        name_dirty = true;
+    });
+    $("#node-address").on("input", function() {
+        if (!name_dirty)
+            $("#node-name").val($(this).val());
+    });
+
+    dialog.on('keypress', function(e) {
+        if (e.keyCode === 13)
+            $(".btn-primary").trigger('click');
+    });
+
+    $(".btn-primary").on("click", function() {
+        var items = gather();
+        if (!items)
+            return;
+
+        var promise = kube.create(items);
+        dialog.dialog("wait", promise);
+
+        promise
+            .fail(function(ex) {
+                dialog.dialog("failure", ex);
+            })
+            .done(function() {
+                dialog.modal("hide");
+            });
+    });
+});
+

--- a/test/check-kubernetes
+++ b/test/check-kubernetes
@@ -56,4 +56,21 @@ class TestKubernetes(MachineCase):
         b.dialog_complete("#deploy-app-dialog", result="fail")
         b.dialog_cancel("#deploy-app-dialog")
 
+        # Successfully add node via dialog
+        b.click("#add-node")
+        b.wait_popup("node-dialog")
+        b.set_val("#node-name", "mynode")
+        b.set_val("#node-address", "myaddress")
+        b.dialog_complete("#node-dialog")
+        b.wait_in_text("#node-list", "mynode")
+        b.wait_in_text("#node-list", "myaddress")
+
+        # Fail add node via dialog
+        b.click("#add-node")
+        b.wait_popup("node-dialog")
+        b.set_val("#node-name", "!!!!")
+        b.set_val("#node-address", "!!!!")
+        b.dialog_complete("#node-dialog", result="fail")
+        b.dialog_cancel("#node-dialog")
+
 test_main()


### PR DESCRIPTION
Basic Add cluster node dialog

https://github.com/cockpit-project/cockpit/wiki/Feature:-Kubernetes:-Add-cluster-node
    
For now the configuration options are disabled. We don't support that yet. That will be a separate pull request. This part is important for making this usable. But first we just want to get the UI in place.

Note that we don't actually check connectivity to that node. Currently the dialog just adds the node to Kubernetes, and then Kubernetes itself reports connectivity asyncronously.

