### PR TITLE
kubernetes: Display oops for angularjs handled exceptions

### DIFF
--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -3187,15 +3187,20 @@ function full_scope(cockpit, $, po) {
      * involving cockpit.transport or any of that logic.
      */
 
+    cockpit.oops = function oops() {
+        if (window.parent !== window &&
+            window.parent.options && window.parent.options.sink &&
+            window.parent.options.protocol == "cockpit1") {
+            window.parent.postMessage("\n{ \"command\": \"oops\" }", origin);
+        }
+    };
+
     var old_onerror;
 
-    if (window.navigator.userAgent.indexOf("PhantomJS") == -1 &&
-        window.parent !== window &&
-        window.parent.options && window.parent.options.sink &&
-        window.parent.options.protocol == "cockpit1") {
+    if (window.navigator.userAgent.indexOf("PhantomJS") == -1) {
         old_onerror = window.onerror;
         window.onerror = function(msg, url, line) {
-            window.parent.postMessage("\n{ \"command\": \"oops\" }", origin);
+            cockpit.oops();
             if (old_onerror)
                 return old_onerror(msg, url, line);
             return false;

--- a/pkg/kubernetes/app.js
+++ b/pkg/kubernetes/app.js
@@ -1,8 +1,9 @@
 define([
     "jquery",
+    "base1/cockpit",
     "kubernetes/angular",
     "kubernetes/client"
-], function($, angular, kubernetes) {
+], function($, cockpit, angular, kubernetes) {
     'use strict';
 
     function KubernetesService(client) {
@@ -244,6 +245,19 @@ define([
         .config(['$routeProvider', function($routeProvider) {
             $routeProvider.otherwise({ redirectTo: '/' });
         }])
+
+        /* Override the default angularjs exception handler */
+        .factory('$exceptionHandler', ['$log', function($log) {
+            return function(exception, cause) {
+
+                /* Displays an oops if we're running in cockpit */
+                cockpit.oops();
+
+                /* And log with the default implementation */
+                $log.error.apply($log, arguments);
+            };
+        }])
+
         .factory('kubernetesClient', function() {
             return kubernetes.k8client();
         })


### PR DESCRIPTION
angularjs normally intercepts all exceptions. So we insert ourselves into the exception handler to manually show the oops when an exception happens.
