### PR TITLE
base1: Add spinner before buttons in dialog

### DIFF
--- a/pkg/base1/patterns.js
+++ b/pkg/base1/patterns.js
@@ -120,7 +120,7 @@ define([
         $("<div class='spinner spinner-sm'>").appendTo(wait);
         var message = $("<span>").appendTo(wait);
 
-        sel.find(".modal-footer").prepend(wait);
+        sel.find(".modal-footer button").first().before(wait);
 
         var data = new DialogWait(promise);
         sel.data("dialog-wait", data);


### PR DESCRIPTION
This prevents it from jumping into things like alerts that may also
be shown in the .modal-footer