### PR TITLE
shell: Move UDisks2 storage into its own package.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -237,6 +237,7 @@ include pkg/realmd/Makefile.am
 include pkg/shell/Makefile.am
 include pkg/subscriptions/Makefile.am
 include pkg/systemd/Makefile.am
+include pkg/udisks2/Makefile.am
 include src/bridge/Makefile.am
 include src/common/Makefile-common.am
 include src/legacy/Makefile.am

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -442,7 +442,7 @@ define([
             } else if (component == "network/interfaces") {
                 component = "shell/shell";
                 hash = "/networking" + hash;
-            } else if (component == "storage/devices") {
+            } else if (component == "udisks2/devices") {
                 component = "shell/shell";
                 hash = "/storage" + hash;
             } else if (component == "users/local") {

--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -18,11 +18,6 @@
             "path": "network/interfaces",
             "label": "Networking",
             "order": 10
-        },
-        "_storage_": {
-            "path": "storage/devices",
-            "label": "Storage",
-            "order": 15
         }
     },
 

--- a/pkg/udisks2/Makefile.am
+++ b/pkg/udisks2/Makefile.am
@@ -1,0 +1,8 @@
+udisks2dir = $(pkgdatadir)/udisks2
+udisks2_DATA = \
+	pkg/udisks2/manifest.json \
+	$(NULL)
+
+EXTRA_DIST += \
+	$(udisks2_DATA) \
+	$(NULL)

--- a/pkg/udisks2/manifest.json
+++ b/pkg/udisks2/manifest.json
@@ -1,0 +1,12 @@
+{
+    "version": 0,
+
+    "menu": {
+        "_storage_": {
+            "path": "udisks2/devices",
+            "label": "Storage",
+            "order": 15
+        }
+    }
+
+}

--- a/test/check-storage-udisks2
+++ b/test/check-storage-udisks2
@@ -70,7 +70,7 @@ class TestStorage(MachineCase):
         m = self.machine
         b = self.browser
 
-        self.login_and_go("storage", href="/storage/devices")
+        self.login_and_go("storage", href="/udisks2/devices")
         b.wait_in_text("#storage_drives", "VirtIO")
 
         # Add a disk, partition it, format it, and finally remove it.
@@ -99,7 +99,7 @@ class TestStorage(MachineCase):
         m = self.machine
         b = self.browser
 
-        self.login_and_go("storage", href="/storage/devices")
+        self.login_and_go("storage", href="/udisks2/devices")
 
         # Add a disk
         self.add_disk("50M", serial="MYDISK")
@@ -200,7 +200,7 @@ class TestStorage(MachineCase):
         # don't do that for now.  A workaround would be to reboot the
         # machine.
 
-        self.login_and_go("storage", href="/storage/devices")
+        self.login_and_go("storage", href="/udisks2/devices")
 
         # Add a disk
         self.add_disk("50M", serial="MYDISK")
@@ -263,7 +263,7 @@ class TestStorage(MachineCase):
         m = self.machine
         b = self.browser
 
-        self.login_and_go("storage", href="/storage/devices")
+        self.login_and_go("storage", href="/udisks2/devices")
 
         # Add a disk and partition it
         self.add_disk("50M", serial="MYDISK")
@@ -381,7 +381,7 @@ class TestStorage(MachineCase):
         m = self.machine
         b = self.browser
 
-        self.login_and_go("storage", href="/storage/devices")
+        self.login_and_go("storage", href="/udisks2/devices")
         b.wait_in_text("#storage_drives", "VirtIO")
 
         # Add four disks and make a RAID out of three of them
@@ -521,7 +521,7 @@ class TestStorage(MachineCase):
         m = self.machine
         b = self.browser
 
-        self.login_and_go("storage", href="/storage/devices")
+        self.login_and_go("storage", href="/udisks2/devices")
         b.wait_in_text("#storage_drives", "VirtIO")
 
         # Add a slow disk and format it
@@ -556,7 +556,7 @@ class TestStorage(MachineCase):
         if m.os == "rhel-7":
             return
 
-        self.login_and_go("storage", href="/storage/devices")
+        self.login_and_go("storage", href="/udisks2/devices")
         b.wait_in_text("#storage_drives", "VirtIO")
 
         self.add_disk("50M", serial="DISK1")
@@ -740,7 +740,7 @@ class TestStorage(MachineCase):
         m = self.machine
         b = self.browser
 
-        self.login_and_go("storage", href="/storage/devices")
+        self.login_and_go("storage", href="/udisks2/devices")
         b.wait_in_text("#storage_drives", "VirtIO")
         self.add_disk("500M", serial="DISK1")
 
@@ -782,7 +782,7 @@ class TestStorage(MachineCase):
         m = self.machine
         b = self.browser
 
-        self.login_and_go("storage", href="/storage/devices")
+        self.login_and_go("storage", href="/udisks2/devices")
         b.wait_in_text("#storage_drives", "VirtIO")
 
         self.add_disk("50M", serial="DISK1")
@@ -843,7 +843,7 @@ class TestStorage(MachineCase):
         m = self.machine
         b = self.browser
 
-        self.login_and_go("storage", href="/storage/devices")
+        self.login_and_go("storage", href="/udisks2/devices")
 
         self.add_disk("50M", serial="DISK1")
         b.wait_in_text("#storage_drives", "DISK1")
@@ -880,7 +880,7 @@ class TestStorage(MachineCase):
         m = self.machine
         b = self.browser
 
-        self.login_and_go("storage", href="/storage/devices")
+        self.login_and_go("storage", href="/udisks2/devices")
         b.wait_in_text("#storage_drives", "VirtIO")
 
         # The following block devices should not be offered for creating a
@@ -924,7 +924,7 @@ mkpart logical ext2 24 48"""
         m = self.machine
         b = self.browser
 
-        self.login_and_go("storage", href="/storage/devices")
+        self.login_and_go("storage", href="/udisks2/devices")
         b.wait_in_text("#storage_drives", "VirtIO")
 
         self.add_disk("50M", "DISK1")

--- a/test/check-verify
+++ b/test/check-verify
@@ -46,18 +46,18 @@ $RUNNER <<EOF
 ./check-services
 ./check-networking
 ./check-pages
-./check-storage TestStorage.testBasic
-./check-storage TestStorage.testMounting
-./check-storage TestStorage.testDosParts
-./check-storage TestStorage.testLuks
-./check-storage TestStorage.testRaid
-./check-storage TestStorage.testJobs
-./check-storage TestStorage.testLvm
-./check-storage TestStorage.testUsed
-./check-storage TestStorage.testHidden
-./check-storage TestStorage.testUnused
-./check-storage TestStorage.testResize
-./check-storage TestStorage.testIgnored
+./check-storage-udisks2 TestStorage.testBasic
+./check-storage-udisks2 TestStorage.testMounting
+./check-storage-udisks2 TestStorage.testDosParts
+./check-storage-udisks2 TestStorage.testLuks
+./check-storage-udisks2 TestStorage.testRaid
+./check-storage-udisks2 TestStorage.testJobs
+./check-storage-udisks2 TestStorage.testLvm
+./check-storage-udisks2 TestStorage.testUsed
+./check-storage-udisks2 TestStorage.testHidden
+./check-storage-udisks2 TestStorage.testUnused
+./check-storage-udisks2 TestStorage.testResize
+./check-storage-udisks2 TestStorage.testIgnored
 ./check-journal
 ./check-terminal
 ./check-accounts

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -97,6 +97,9 @@ Requires: %{name}-docker = %{version}-%{release}
 %if 0%{?rhel}
 Requires: %{name}-subscriptions = %{version}-%{release}
 %endif
+%if 0%{?rhel} == 0
+Requires: %{name}-udisks2
+%endif
 
 %description
 Cockpit runs in a browser and can manage your network of GNU/Linux
@@ -136,11 +139,7 @@ Requires: shadow-utils
 Requires: grep
 Requires: libpwquality
 Requires: /usr/bin/date
-Requires: mdadm
-Requires: lvm2
-%if 0%{?rhel} == 0
-Requires: udisks2 >= 2.1.0
-%else
+%if 0%{?rhel}
 Provides: %{name}-subscriptions = %{version}-%{release}
 Requires: subscription-manager >= 1.13
 %ifarch x86_64 armv7hl
@@ -223,6 +222,9 @@ find %{buildroot}%{_datadir}/%{name}/system -type f >> shell.list
 
 echo '%dir %{_datadir}/%{name}/subscriptions' > subscriptions.list
 find %{buildroot}%{_datadir}/%{name}/subscriptions -type f >> subscriptions.list
+
+echo '%dir %{_datadir}/%{name}/udisks2' > udisks2.list
+find %{buildroot}%{_datadir}/%{name}/udisks2 -type f >> udisks2.list
 
 %ifarch x86_64 armv7hl
 echo '%dir %{_datadir}/%{name}/docker' > docker.list
@@ -376,6 +378,19 @@ cluster. Installed on the Kubernetes master. This package is not yet complete.
 %files kubernetes -f kubernetes.list
 
 %endif
+
+%package udisks2
+Summary: Cockpit user interface for storage, using UDisks2
+Requires: %{name}-shell
+Requires: mdadm
+Requires: lvm2
+Requires: udisks2 >= 2.1.0
+
+%description udisks2
+The Cockpit component for managing storage.  This package uses UDisks2.
+
+%files udisks2 -f udisks2.list
+
 
 %if %{defined gitcommit}
 


### PR DESCRIPTION
This makes it optional and we can provide alternative storage packages
or leave it out completely.  The code is all still in the same place
in the "shell" package to keep this change small.
