### PR TITLE
Show "unstable" wording when building "unbranded"

### DIFF
--- a/branding/default/branding.css
+++ b/branding/default/branding.css
@@ -1,0 +1,10 @@
+
+/* When built from git show 'unstable' message */
+.login-unstable {
+    display: block;
+}
+
+.login-stable {
+    display: none;
+}
+

--- a/branding/fedora/branding.css
+++ b/branding/fedora/branding.css
@@ -4,11 +4,3 @@
     padding: 0 !important;
     height: 24px;
 }
-
-.login-unstable {
-    display: none;
-}
-
-.login-stable {
-    display: block;
-}

--- a/src/static/login.html
+++ b/src/static/login.html
@@ -737,8 +737,8 @@ label {
           <p>
             <label id="server-name" class="control-label">Server: </label>
           </p>
-          <p class="login-unstable">Not ready for use on production servers.</p>
-          <p class="login-stable" hidden>Log in with your server user account.</p>
+          <p class="login-unstable" hidden>Not ready for use on production servers.</p>
+          <p class="login-stable">Log in with your server user account.</p>
         </div><!--/.col-*-->
 
         <div id="login-fatal" style="display: none;">


### PR DESCRIPTION
When building from git or without server branding, show the
unstable "Not ready for use with production servers."

But elsewhere, when branding is present, we don't and cannot
speak for the stability of the whole server. So hide the
message by default in these cases.