### PR TITLE
base1: Allow null host values in jump

### DIFF
--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -228,7 +228,10 @@
       <para>Ask Cockpit to jump to another component. The location of the current component will
         not be affected. The <code>path</code> argument can be a string path, starting with <code>/</code>
         or an array containing the parts of a path that will be joined to create a path. If <code>host</code>
-        is not specified, then the component on the same host as the caller will be displayed.</para>
+        is not specified, then the component on the same host as the caller will be displayed. If
+        host is null, then the host portion of the path will be removed, displaying the component on
+        the host that cockpit is connected directly to. This is mostly useful for displaying a
+        dashboard or other multi-machine components.</para>
       <para>If the calling component is not running within Cockpit, or the calling component is not
         currently displayed, then the jump will not happen, and this function has no effect.</para>
     </refsection>

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -1162,7 +1162,7 @@ function full_scope(cockpit, $, po) {
         else
             path = "" + path;
         var options = { command: "jump", location: path };
-        if (host)
+        if (host !== undefined)
             options.host = host;
         cockpit.transport.inject("\n" + JSON.stringify(options));
     };


### PR DESCRIPTION
When a null value is given for host remove the
host portion of the path. This allows the outer
shell running on the main host to dictate what
gets displayed.

Mainly useful for jumping to "/" going either to
the dashboard or the server page as appropriate.