### PR TITLE
We don't need to complain about storaged missing

### DIFF
--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -223,7 +223,7 @@
       <div id="storage" hidden>
         <div class="alert alert-error" id="storage-not-supported" hidden>
           <span class="fa fa-exclamation-circle"></span>
-          <span translatable="yes">The UDisks and/or storaged API is not available on this system.</span>
+          <span translatable="yes">The UDisks API is not available on this system.</span>
         </div>
 
         <div class="col-md-8 col-lg-9">


### PR DESCRIPTION
Since we ship 'storaged' 0.x along with Cockpit, don't complain
about it missing. It's just UDisks.