### PR TITLE
Bump required version to 0.16.2 or later

### DIFF
--- a/pkg/kubernetes/README.md
+++ b/pkg/kubernetes/README.md
@@ -10,7 +10,7 @@ This sets up a single machine kubernetes master and minion:
     $ sudo yum install kubernetes
 
 Now in order to support the latest v1beta3 API, we need to build kubernetes
-from source or use a version later than v0.15.0:
+from source or use a version later than v0.16.2:
 
     $ sudo yum install kubernetes
     $ sudo yum install etcd docker

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -366,7 +366,7 @@ This package is not yet complete.
 
 %package kubernetes
 Summary: Cockpit user interface for Kubernetes cluster
-Requires: kubernetes
+Requires: kubernetes >= 0.16.2
 
 %description kubernetes
 The Cockpit components for visualizing and configuring a Kubernetes


### PR DESCRIPTION
The kubectl config command we use for auth requires this version
or later.