### PR TITLE
bridge: Use compatible args to sudo for non-interactive

### DIFF
--- a/src/bridge/cockpitportal.c
+++ b/src/bridge/cockpitportal.c
@@ -757,7 +757,7 @@ cockpit_portal_new_superuser (CockpitTransport *transport)
 
   static const gchar *sudo_argv[] = {
     PATH_SUDO,
-    "--non-interactive",
+    "-n", /* non-interactive */
     "cockpit-bridge",
     NULL
   };

--- a/test/check-reauthorize
+++ b/test/check-reauthorize
@@ -102,6 +102,10 @@ class TestReauthorize(MachineCase):
         self.assertEqual(b.text(".super-channel span"), 'result: access-denied')
 
         m.execute("echo 'user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/user-override")
+
+	# RHEL used to require this
+	m.execute("sed -i /requiretty/d /etc/sudoers")
+
         b.logout()
 
         self.login_and_go("/playground/test")


### PR DESCRIPTION
And run the tests without requiretty is sudoers. Older systems
like RHEL used to have this.