### PR TITLE
shell: re-register frame on unload

### DIFF
--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -245,8 +245,16 @@ define([
              * to know when it can switch into the frame and inject
              * its own additions.
              */
-
             $(frame).on("load", function() {
+                /*
+                 * if the frame is reloaded directly
+                 * unregister and reregister to ensure
+                 * fresh channels
+                 */
+                $(this.contentWindow).on("unload", function () {
+                    router.unregister(frame.contentWindow, address);
+                    router.register(frame.contentWindow);
+                });
                 $(this).attr('data-loaded', true);
                 phantom_checkpoint();
                 $(this.contentWindow).on('hashchange', function () {

--- a/test/check-pages
+++ b/test/check-pages
@@ -63,4 +63,27 @@ WantedBy=default.target
         b.switch_to_top()
         b.wait_js_cond("window.location.hash == '#/@localhost/playground/test/0/1?length=1'")
 
+    def testFrameReload(self):
+            b = self.browser
+            frame = "localhost/playground/test"
+
+            self.login_and_go(None)
+            b.go("/@localhost/playground/test")
+            b.wait_present("iframe[name='%s']" % frame)
+
+            b.switch_to_frame(frame)
+            b.wait_present('#file-content')
+            b.wait_text('#file-content', "0")
+            b.click("#modify-file")
+            b.wait_text('#file-content', "1")
+
+            b.switch_to_top()
+            b.eval_js('ph_set_attr("iframe[name=\'%s\']", "data-loaded", null)' % frame)
+            b.eval_js('ph_set_attr("iframe[name=\'%s\']", "src", "../playground/test.html?i=1#/")' % frame)
+            b.wait_present("iframe.container-frame[name='%s'][data-loaded]" % frame)
+
+            b.switch_to_frame(frame)
+            b.wait_present('#file-content')
+            b.wait_text('#file-content', "1")
+
 test_main()


### PR DESCRIPTION
This is a simple fix for #2336. I'm not completely sure this is the best way to go assigning these ids long term, but i figured i'd stick this up here while I think about it a little more.