### PR TITLE
Fix 'Bad file descriptor' error in stream test

### DIFF
--- a/src/common/cockpitstream.c
+++ b/src/common/cockpitstream.c
@@ -96,6 +96,9 @@ static void
 close_immediately (CockpitStream *self,
                    const gchar *problem)
 {
+  GError *error = NULL;
+  GIOStream *io;
+
   if (self->priv->closed)
     return;
 
@@ -125,9 +128,16 @@ close_immediately (CockpitStream *self,
 
   if (self->priv->io)
     {
-      g_io_stream_close_async (self->priv->io, G_PRIORITY_DEFAULT, NULL, NULL, NULL);
-      g_object_unref (self->priv->io);
+      io = self->priv->io;
       self->priv->io = NULL;
+
+      g_io_stream_close (io, NULL, &error);
+      if (error)
+        {
+          g_message ("%s: close failed: %s", self->priv->name, error->message);
+          g_clear_error (&error);
+        }
+      g_object_unref (io);
     }
 
   g_debug ("%s: closed", self->priv->name);

--- a/src/common/test-stream.c
+++ b/src/common/test-stream.c
@@ -437,8 +437,6 @@ test_write_error (void)
 
   g_assert_cmpstr (echo_stream->problem, ==, "internal-error");
 
-  close (fds[1]);
-
   g_object_unref (echo_stream);
 }
 


### PR DESCRIPTION
This is caused by one test closing the file descriptor for the next and results in:
    
```
(test-stream:15798): cockpit-protocol-WARNING **: read-combined: couldn't read: Error reading from file descriptor: Bad file descriptor
```