### PR TITLE
kubernetes: Unbreak the adjust service button

### DIFF
--- a/pkg/kubernetes/dashboard.js
+++ b/pkg/kubernetes/dashboard.js
@@ -8,7 +8,7 @@ define([
     var phantom_checkpoint = phantom_checkpoint || function () { };
 
     /* TODO: Migrate this to angular */
-    $("#content").on("click", "#services-enable-change", function() {
+    $("body").on("click", "#services-enable-change", function() {
         $("#service-list").toggleClass("editable");
         $("#services-enable-change").toggleClass("active");
     });


### PR DESCRIPTION
This was broken due to moving stuff into the angular view.

At some point this should be driven using angularjs.