### PR TITLE
base1: Add $(..).dialog('failures', ...)

### DIFF
--- a/pkg/base1/patterns.js
+++ b/pkg/base1/patterns.js
@@ -182,6 +182,8 @@ define([
     $.fn.dialog = function dialog(action /* ... */) {
         if (action === "failure")
             display_errors(this, Array.prototype.slice.call(arguments, 1));
+        else if (action === "failures")
+            display_errors(this, arguments[1]);
         else if (action === "wait")
             display_wait(this, arguments[1]);
         else


### PR DESCRIPTION
To make passing an array easier.