### PR TITLE
kubernetes: Graph fixes and tweaks

### DIFF
--- a/pkg/kubernetes/client.js
+++ b/pkg/kubernetes/client.js
@@ -1134,7 +1134,7 @@ define([
 
         var kube = kubernetes.k8client();
 
-        var last = null;
+        var last = { };
 
         var unique = 0;
 
@@ -1194,6 +1194,7 @@ define([
                 if (!name)
                     continue;
 
+                names[name] = name;
                 mapping[name] = { "": name };
                 id = name;
 
@@ -1230,7 +1231,6 @@ define([
                         if (!item)
                             item = items[offset - base] = { };
                         item[name] = stat;
-                        names[name] = name;
                     }
                 }
             }
@@ -1245,12 +1245,11 @@ define([
             /* Now for each offset, if it's a duplicate, put in a copy */
             for(name in names) {
                 len = items.length;
-                last = undefined;
                 for (i = 0; i < len; i++) {
                     if (items[i][name] === undefined)
-                        items[i][name] = last;
+                        items[i][name] = last[name];
                     else
-                        last = items[i][name];
+                        last[name] = items[i][name];
                 }
             }
 

--- a/pkg/kubernetes/graphs.js
+++ b/pkg/kubernetes/graphs.js
@@ -523,17 +523,26 @@ define([
         $(window).on('resize', resized);
         resized();
 
-        window.setInterval(jump, grid.interval);
+        var timer = window.setInterval(jump, grid.interval);
 
-        return element;
+        return {
+            close: function close() {
+                $(window).off('resize', resized);
+                window.clearInterval(timer);
+                grid.close();
+            }
+        };
     }
 
-    return angular.module('kubernetes.graph', [ 'ngRoute' ])
+    return angular.module('kubernetes.graph', [])
         .directive('kubernetesServiceGraph', function() {
             return {
                 restrict: 'E',
                 link: function($scope, element, attributes) {
-                    service_graph(element[0]);
+                    var graph = service_graph(element[0]);
+                    element.on('$destroy', function() {
+                        graph.close();
+                    });
                 }
             };
         });

--- a/pkg/kubernetes/graphs.js
+++ b/pkg/kubernetes/graphs.js
@@ -29,33 +29,6 @@ define([
     var _ = cockpit.gettext;
     var module = { };
 
-    var colors = [
-        "#0099d3",
-        "#67d300",
-        "#d39e00",
-        "#d3007c",
-        "#00d39f",
-        "#00d1d3",
-        "#00618a",
-        "#4c8a00",
-        "#8a6600",
-        "#9b005b",
-        "#008a55",
-        "#008a8a",
-        "#00b9ff",
-        "#7dff00",
-        "#ffbe00",
-        "#ff0096",
-        "#00ffc0",
-        "#00fdff",
-        "#023448",
-        "#264802",
-        "#483602",
-        "#590034",
-        "#024830",
-        "#024848"
-    ];
-
     function ServiceMap(kube) {
         var self = this;
 
@@ -368,6 +341,8 @@ define([
             left: 60
         };
 
+        var colors = d3.scale.category20();
+
         var element = d3.select(selector).append("svg");
         var stage = element.append("g")
             .attr("transform", "translate(" + margins.left + "," + margins.top + ")");
@@ -501,7 +476,7 @@ define([
                 .data(rows, function(d, i) { return i; });
 
             var trans = series
-                .style("stroke", function(d, i) { return colors[i % colors.length]; })
+                .style("stroke", function(d, i) { return colors(i); })
                 .attr("d", function(d) { return line(d); });
 
             series.enter().append("path")

--- a/pkg/kubernetes/graphs.js
+++ b/pkg/kubernetes/graphs.js
@@ -363,7 +363,7 @@ define([
 
         var margins = {
             top: 12,
-            right: 10,
+            right: 15,
             bottom: 40,
             left: 60
         };

--- a/pkg/kubernetes/graphs.js
+++ b/pkg/kubernetes/graphs.js
@@ -502,7 +502,7 @@ define([
 
             var trans = series
                 .style("stroke", function(d, i) { return colors[i % colors.length]; })
-                .interrupt().transition().attr("d", function(d) { return line(d); });
+                .attr("d", function(d) { return line(d); });
 
             series.enter().append("path")
                 .attr("class", "line");

--- a/pkg/kubernetes/graphs.js
+++ b/pkg/kubernetes/graphs.js
@@ -254,7 +254,9 @@ define([
                     res = undefined;
                 } else {
                     res = (value - last);
-                    if (res > max) {
+                    if (res < 0) {
+                        res = undefined;
+                    } else if (res > max) {
                         row.maximum = max = res;
                         change_queued = true;
                     }


### PR DESCRIPTION
Some graph fixes and tweaks:

 * Use D3 colors
 * Turn off smooth transations
 * Show N minutes in graph, rather than time
 * No moving X axis grid
 * Fix margins
 * No negative values
 * Fill in gaps in cAdvisor data properly.
 * Close the graph when it's not visible.