### PR TITLE
Use sudo in deploy-cockpit script

### DIFF
--- a/tools/deploy-cockpit
+++ b/tools/deploy-cockpit
@@ -12,4 +12,4 @@ cockpit-selinux-policy-"
 RPMS=$($BASE/make-rpms | grep -vF "$SKIP" | tr '\n' ' ')
 
 scp $RPMS $1:
-ssh $1 "set -x && dnf --assumeyes reinstall $RPMS && systemctl restart cockpit"
+ssh $1 "set -x && sudo dnf --assumeyes reinstall $RPMS && sudo systemctl restart cockpit"


### PR DESCRIPTION
On Atomic nodes we cannot log in as root, but sudo works without
reauthentication. Any reauthentication will happen in terminal anyway.