### PR TITLE
test: Include sizzle.js as a file for simplicity

### DIFF
--- a/test/sizzle.js
+++ b/test/sizzle.js
@@ -2046,11 +2046,11 @@ if ( !assert(function( div ) {
 }
 
 // EXPOSE
-if ( typeof define === "function" && define.amd ) {
+if ( typeof define === "function" && define.amd_disabled ) {
 	define(function() { return Sizzle; });
 // Sizzle requires that there be a global window in Common-JS like environments
-} else if ( typeof module !== "undefined" && module.exports ) {
-	module.exports = Sizzle;
+} else if ( typeof module !== "undefined" && module.exports_disabled ) {
+	module.exports_disabled = Sizzle;
 } else {
 	window.Sizzle = Sizzle;
 }

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -126,10 +126,7 @@ class Browser:
         self.init_after_load()
 
     def init_after_load(self):
-        # Prevent sizzle from registering with AMD loader, and also claiming the usual global name
-        with open("%s/sizzle.js" % topdir) as file:
-            js = "var define = null; " + file.read()
-            self.phantom.do(js)
+        self.phantom.inject("%s/sizzle.js" % topdir)
         self.phantom.inject("%s/phantom-lib.js" % topdir)
         self.phantom.do("ph_init()")
 

--- a/tools/Makefile-tools.am
+++ b/tools/Makefile-tools.am
@@ -30,7 +30,8 @@ update-lib:: update-bower
 	    $(BOWER)/qunit-tap/lib/qunit-tap.js \
 	    $(srcdir)/tools/qunit-config.js
 	cp $(BOWER)/qunit/qunit/qunit.css $(srcdir)/tools/qunit.css
-	cp $(BOWER)/sizzle/dist/sizzle.js $(srcdir)/test/sizzle.js
+	sed -e 's/define\.amd/define\.amd_disabled/' -e 's/module\.exports/module\.exports_disabled/' \
+		$(BOWER)/sizzle/dist/sizzle.js > $(srcdir)/test/sizzle.js
 
 if WITH_COVERAGE
 coverage:


### PR DESCRIPTION
Now that we're pulling from bower, we can modify sizzle.js with
the changes we need in advance.