### PR TITLE
Test: increase disk size for fedora based images

### DIFF
--- a/test/fedora.bootstrap
+++ b/test/fedora.bootstrap
@@ -55,7 +55,7 @@ autopart
 %end
 EOF
 
-qemu-img create -f qcow2 "$out" 4G
+qemu-img create -f qcow2 "$out" 8G
 
 connect="--connect=qemu:///session"
 name=fedora-builder


### PR DESCRIPTION
Follow-up to #2399
In some cases, disks ipa images could run out of space.

Since images are sparse anyway, increasing the limit doesn't hurt.
