### PR TITLE
tools: Update bower version of object-describer

### DIFF
--- a/tools/bower.json
+++ b/tools/bower.json
@@ -9,7 +9,7 @@
         "d3": "#3.5.5",
         "jquery": "#2.1.0",
         "jquery-flot": "#0.8.3",
-        "kubernetes-object-describer": "0.0.14",
+        "kubernetes-object-describer": "0.0.15",
         "mustache": "#0.8.1",
         "patternfly": "#1.1.3",
         "qunit": "#1.14.0",


### PR DESCRIPTION
We already included the changes in 0.0.15, but didn't yet update
the bower.json version number.