### PR TITLE
kubernetes: Display blank slate and blank pane

### DIFF
--- a/pkg/base1/cockpit.css
+++ b/pkg/base1/cockpit.css
@@ -397,6 +397,20 @@ a {
     min-width: 26px;
 }
 
+/* Well and Blankslate */
+
+.panel .well {
+    margin-bottom: 0px;
+    border: none;
+    border-radius: 0px;
+    background-color: #FAFAFA;
+}
+
+.well.blank-slate-pf {
+    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.05) inset;
+    padding-top: 40px;
+}
+
 /* Alert fixups */
 
 .alert {

--- a/pkg/kubernetes/app.css
+++ b/pkg/kubernetes/app.css
@@ -44,6 +44,12 @@ path.line.highlight {
 
 /* Page global stuff */
 
+.curtains {
+    height: 100%;
+    width: 100%;
+    position: fixed;
+}
+
 .container-fluid {
     margin-top: 0px;
     padding-left: 0px;
@@ -209,4 +215,19 @@ input.adjust-replica {
 
 #adjust-dialog .modal-dialog {
     width: 400px;
+}
+
+/* HACK: https://github.com/patternfly/patternfly/issues/75 */
+.blank-slate-pf .fa {
+    color: #999999;
+}
+
+.blank-slate-pf .spinner-lg {
+    height: 58px;
+    width: 58px;
+}
+
+/* Used to hide angular elements until they are ready */
+[ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
+    display: none !important;
 }

--- a/pkg/kubernetes/app.js
+++ b/pkg/kubernetes/app.js
@@ -276,6 +276,38 @@ define([
 
                 /* Used by child scopes */
                 $scope.client = client;
+
+                /* When set then we hide the application */
+                $scope.curtains = { state: 'silent' };
+
+                var timeout = window.setTimeout(function() {
+                    $scope.curtains = { state: 'connecting' };
+                    $scope.$digest();
+                    timeout = null;
+                }, 1000);
+
+                function handle(promise) {
+                    promise
+                        .always(function() {
+                            window.clearTimeout(timeout);
+                            timeout = null;
+                        })
+                        .done(function() {
+                            $scope.curtains = null;
+                            $scope.$digest();
+                        })
+                        .fail(function(ex) {
+                            $scope.curtains = { state: 'failed', failure: ex };
+                            $scope.$digest();
+                        });
+                }
+
+                handle(client.connect());
+
+                $scope.reconnect = function reconnect() {
+                    $scope.curtains = { state: 'connecting' };
+                    handle(client.connect(true));
+                };
         }])
 
         /* Override the default angularjs exception handler */

--- a/pkg/kubernetes/app.js
+++ b/pkg/kubernetes/app.js
@@ -258,19 +258,24 @@ define([
         }])
 
         .controller('MainCtrl', [
+            '$scope',
             '$route',
             '$routeParams',
             '$location',
-            function($route, $routeParams, $location) {
-                this.$route = $route;
-                this.$location = $location;
-                this.$routeParams = $routeParams;
+            'kubernetesClient',
+            function($scope, $route, $routeParams, $location, client) {
+                $scope.$route = $route;
+                $scope.$location = $location;
+                $scope.$routeParams = $routeParams;
 
                 /* Used to set detect which route is active */
-                this.is_active = function is_active(template) {
-                    var current = this.$route.current;
+                $scope.is_active = function is_active(template) {
+                    var current = $scope.$route.current;
                     return current && current.loadedTemplateUrl === template;
                 };
+
+                /* Used by child scopes */
+                $scope.client = client;
         }])
 
         /* Override the default angularjs exception handler */

--- a/pkg/kubernetes/client.js
+++ b/pkg/kubernetes/client.js
@@ -609,6 +609,7 @@ define([
 
         /*
          * connect:
+         * @force: Force a new connection
          *
          * Starts connecting to the kube-apiserver if not connected.
          * This means figuring out which port kube-apiserver is
@@ -620,8 +621,8 @@ define([
          * complete, and any done callbacks will happen
          * immediately.
          */
-        self.connect = function connect() {
-            if (!connected) {
+        self.connect = function connect(force) {
+            if (force || !connected) {
                 connected = connect_api_server()
                     .done(function(http, response) {
                         self.flavor = response.flavor;
@@ -659,7 +660,7 @@ define([
          * May be invoked immediately if already.
          */
         self.wait = function wait(callback) {
-            loaded.done(callback);
+            loaded.always(callback);
         };
 
         /*

--- a/pkg/kubernetes/cluster.html
+++ b/pkg/kubernetes/cluster.html
@@ -29,8 +29,8 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   <script src="../kubernetes/kubernetes.js"></script>
 </head>
 <body>
-  <div ng-controller="MainCtrl as main">
-      <div class="kube-sidebar">
+    <div ng-controller="MainCtrl as main" ng-cloak>
+      <div class="kube-sidebar" ng-if="!curtains">
         <div>
           <ul>
             <li ng-class="{ active: main.is_active('dashboard.html')}">
@@ -52,7 +52,24 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
         </div>
       </div>
 
-      <div id="content" class="container-fluid" ng-view></div>
+      <div id="content" class="container-fluid" ng-view ng-if="!curtains">
+      </div>
+
+      <div class="curtains blank-slate-pf" ng-if="curtains && curtains.state != 'silent'">
+        <div class="blank-slate-pf-icon">
+          <div class="spinner spinner-lg" ng-if="curtains.state == 'connecting'"></div>
+          <i class="fa fa-exclamation-circle" ng-if="curtains.failure && curtains.failure.status != 403"></i>
+          <i class="fa fa-lock" ng-if="curtains.failure.status == 403"></i>
+        </div>
+        <h1 ng-if="curtains.state == 'connecting'" translatable="yes">Connecting to Kubernetes</h1>
+        <h1 ng-if="curtains.state == 'failed'" translatable="yes">Couldn't connect to Kubernetes server</h1>
+        <p ng-if="curtains.message">{{curtains.failure.message}}</p>
+        <div class="blank-slate-pf-main-action" ng-if="curtains.state == 'failed'">
+          <button class="btn btn-primary btn-lg" translatable="yes" ng-click="reconnect()">
+            Reconnect
+          </button>
+        </div>
+      </div>
     </div>
 
   <script type="text/ng-template" id="dashboard.html">

--- a/pkg/kubernetes/cluster.html
+++ b/pkg/kubernetes/cluster.html
@@ -86,7 +86,22 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
           </div>
           <span translatable="yes">Kubernetes Services</span>
         </div>
-        <table class="table table-hover">
+        <div class="well blank-slate-pf spacious" ng-if="state == 'failed'">
+          <div class="blank-slate-pf-icon">
+            <i ng-if="failure.status == 403" class="fa fa-lock"></i>
+            <i ng-if="failure.status != 403" class="fa fa-exclamation-circle"></i>
+          </div>
+          <h3 translatable="yes">Couldn't list services</h3>
+          <p>{{failure.message}}</p>
+        </div>
+        <div class="well blank-slate-pf spacious" ng-if="state == 'empty'">
+          <div class="blank-slate-pf-icon">
+            <i class="fa fa-rocket"></i>
+          </div>
+          <h3>No services present</h3>
+          <p translatable="yes">You can deploy an application to your cluster.</p>
+        </div>
+        <table class="table table-hover" ng-if="state == 'ready'">
           <thead>
             <tr>
               <th translatable="yes">Name</th>

--- a/pkg/kubernetes/dashboard.js
+++ b/pkg/kubernetes/dashboard.js
@@ -31,15 +31,13 @@ define([
         .controller('DashboardCtrl', [
                 '$scope',
                 '$location',
-                'kubernetesClient',
                 'kubernetesServices',
                 'kubernetesNodes',
                 'kubernetesPods',
-                function($scope, $location, client, services, nodes, pods) {
+                function($scope, $location, services, nodes, pods) {
             $scope.services = services;
             $scope.nodes = nodes;
             $scope.pods = pods;
-            $scope.client = client;
 
             $scope.jumpService = function jumpService(ev, service) {
                 var target = $(ev.target);
@@ -62,7 +60,7 @@ define([
                 $scope.$broadcast("highlight", uid);
             };
 
-            $([client, services, nodes, pods]).on("changed", function() {
+            $([services, nodes, pods]).on("changed", function() {
                 $scope.$digest();
                 phantom_checkpoint();
             });

--- a/pkg/kubernetes/graphs.js
+++ b/pkg/kubernetes/graphs.js
@@ -526,6 +526,8 @@ define([
 
         function resized() {
             width = $(selector).outerWidth() - 10;
+            if (width < 0)
+                width = 0;
             adjust();
         }
 

--- a/pkg/kubernetes/test-kubernetes.html
+++ b/pkg/kubernetes/test-kubernetes.html
@@ -563,7 +563,7 @@ require([
         expect(3);
 
         var client = kubernetes.k8client();
-        client.wait(function() {
+        client.watches.nodes.wait().always(function() {
             var nodes = client.select("Node");
             ok("f530580d-a169-11e4-8651-10c37bdb8410" in nodes, "found node");
             var node = nodes["f530580d-a169-11e4-8651-10c37bdb8410"];
@@ -579,7 +579,7 @@ require([
         expect(3);
 
         var client = kubernetes.k8client();
-        client.wait(function() {
+        client.watches.pods.wait().always(function() {
             var pods = client.select("Pod");
             equal(pods.items.length, 2, "number of pods");
             var pod = pods["11768037-ab8a-11e4-9a7c-080027300d85"];
@@ -601,7 +601,7 @@ require([
         var pods = client.select("Pod");
         client.track(pods);
 
-        client.wait(function() {
+        client.watches.pods.wait().always(function() {
             ready = true;
 
             equal(pods.items.length, 2, "number of pods");
@@ -656,7 +656,7 @@ require([
         var pods = client.select("Pod");
         client.track(pods);
 
-        client.wait(function() {
+        client.watches.pods.wait().always(function() {
             ready = true;
 
             equal(pods.items.length, 2, "number of pods");
@@ -705,7 +705,7 @@ require([
         var pods = client.select("Pod");
         client.track(pods);
 
-        client.wait(function() {
+        client.watches.pods.wait().always(function() {
             ready = true;
 
             equal(pods.items.length, 2, "number of pods");
@@ -739,7 +739,7 @@ require([
 
         var client = kubernetes.k8client();
 
-        client.wait(function() {
+        client.watches.services.wait().always(function() {
             var services = client.select("Service");
             var svc = services.items[0];
             equal(services.items.length, 2, "number of services");
@@ -922,7 +922,7 @@ require([
 
         var client = kubernetes.k8client();
 
-        client.wait(function() {
+        client.watches.pods.wait().always(function() {
             var items = client.select();
             client.track(items);
 
@@ -966,7 +966,7 @@ require([
 
     asyncTest("select", function() {
         var client = kubernetes.k8client();
-        client.wait(function() {
+        client.watches.pods.wait().always(function() {
 
             /* Select everything odd, 500 pods */
             var results = client.select(null, "default", { "type": "odd" });
@@ -1022,7 +1022,7 @@ require([
 
     asyncTest("infer", function() {
         var client = kubernetes.k8client();
-        client.wait(function() {
+        client.watches.pods.wait().always(function() {
 
             /* Start simple, exactly the labels selector matches */
             var results = client.infer(null, "default", { "tag": "silly", "type": "odd" });
@@ -1067,7 +1067,7 @@ require([
 
     asyncTest("hosting", function() {
         var client = kubernetes.k8client();
-        client.wait(function() {
+        client.watches.pods.wait().always(function() {
 
             /* Find out which pods this node is hosting */
             var results = client.hosting("Pod", "127.0.0.1");

--- a/pkg/kubernetes/topology.js
+++ b/pkg/kubernetes/topology.js
@@ -42,12 +42,12 @@ define([
 
         .controller('TopologyCtrl', [
             '$scope',
-            'kubernetesClient',
-            function($scope, client) {
-                $scope.client = client;
+            function($scope) {
                 $scope.items = { };
                 $scope.relations = [ ];
+                $scope.selected = null;
 
+                var client = $scope.client;
                 var ready = false;
                 var all = { };
 

--- a/pkg/kubernetes/topology.js
+++ b/pkg/kubernetes/topology.js
@@ -135,6 +135,11 @@ define([
                     $(all).off();
                 });
 
+                all = client.select();
+                client.track(all);
+                $(all).on("changed", digest);
+                digest();
+
                 ready = true;
             }
         ]);


### PR DESCRIPTION
Add blank slate to the services in dashboard
    
This shows a reason why no services are listed. 

Display a full screen curtain before connected
    
We display a full screen curtain before connected. The screen displays a spinner while connecting, and reconnection options if failed to connect.
    
The screen waits for 1 second to show, so we don't have too much flicker.