### PR TITLE
static: Catch exceptions when checking Cockpit requirements

### DIFF
--- a/src/static/login.html
+++ b/src/static/login.html
@@ -67,7 +67,13 @@
 
             function requisites() {
                 function req(name, obj) {
-                    var ret = (obj[name]);
+                    var ret;
+                    try {
+                        ret = (obj[name]);
+                    } catch(ex) {
+                        fatal("The web browser configuration prevents Cockpit from running (inaccessible " + name + ")");
+                        throw ex;
+                    }
                     if (!ret)
                         fatal("This web browser is too old to run Cockpit (missing " + name + ")");
                     return ret;


### PR DESCRIPTION
In certain cases requirements are present but inaccessible. For
example Firefox has an annoying issue where if you ask it for cookie
confirmation then it will refuse access to localStorage and throw
exceptions.

http://meyerweb.com/eric/thoughts/2012/04/25/firefox-failing-localstorage/

Catch these errors and display something.

Downstream bug:

https://bugzilla.redhat.com/show_bug.cgi?id=1227207