### PR TITLE
shell: render dashboard less often

### DIFF
--- a/pkg/shell/cockpit-dashboard.js
+++ b/pkg/shell/cockpit-dashboard.js
@@ -410,7 +410,22 @@ PageDashboard.prototype = {
                 update_series();
             }
 
-            return render;
+            /* delay and throttle rendering
+               events shouldn't fire continuously anyway,
+               so in case of a burst it's better to wait a bit before we start rendering
+             */
+            function throttled_render() {
+                var timer = null;
+                return function() {
+                    if (timer === null) {
+                        timer = window.setTimeout(function () {
+                            timer = null;
+                            render();
+                        }, 500);
+                    }
+                };
+            }
+            return throttled_render();
         }
 
         function plot_refresh() {


### PR DESCRIPTION
alternative to #2411

If you want to delay rendering a bit like you said, but still throttle, then this is a simpler alternative.
The timer variable contains "need_rendering" and the order of the instructions is closer to what one would use in an environment with parallel execution.