### PR TITLE
kubernetes: Connect to local machine if node address is 127.0.0.1

### DIFF
--- a/pkg/kubernetes/details.js
+++ b/pkg/kubernetes/details.js
@@ -109,7 +109,7 @@ define([
                 restrict: 'E',
                 link: function(scope, element, attrs) {
                     var options = { };
-                    if (attrs.host && attrs.host != "localhost")
+                    if (attrs.host && attrs.host != "localhost" && attrs.host != "127.0.0.1")
                         options.host = attrs.host;
 
                     var id = attrs.id || "";


### PR DESCRIPTION
I'd like to have a better solution for this. But in the meantime, this is a work around for a commonly encountered bug.