### PR TITLE
login, shell: Fix textual branding for Chrome.

### DIFF
--- a/branding/default/branding.css
+++ b/branding/default/branding.css
@@ -29,12 +29,10 @@ body.login-pf {
     width: 486px;
     height: 18px;
     background-image: url("/cockpit/static/brand-large.png");
-    content: "none";
 }
 
 #index-brand {
     width: 270px;
     height: 10px;
     background-image: url("/cockpit/static/brand.png");
-    content: "none";
 }

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -75,7 +75,7 @@ define([
             return;
 
         var len, content = window.getComputedStyle(elt).content;
-        if (content != "none") {
+        if (content && content != "none") {
             len = content.length;
             if ((content[0] === '"' || content[0] === '\'') &&
                 len > 2 && content[len - 1] === content[0])

--- a/src/static/login.html
+++ b/src/static/login.html
@@ -56,7 +56,7 @@
                     return;
 
                 var len, content = window.getComputedStyle(elt).content;
-                if (content != "none") {
+                if (content && content != "none") {
                     len = content.length;
                     if ((content[0] === '"' || content[0] === '\'') &&
                         len > 2 && content[len - 1] === content[0])


### PR DESCRIPTION
Firefox return "none" for an absent 'content' style property, while
Chrome returns "".