### PR TITLE
tools: Drop a "-testing" suffix in make-rpms.

### DIFF
--- a/tools/make-rpms
+++ b/tools/make-rpms
@@ -74,6 +74,10 @@ if [[ "$os" =~ "fedora-atomic" ]]; then
 else
     os=$os
 fi
+
+# drop a "-testing" suffix
+os=${os/%-testing/}
+
 arch=${TEST_ARCH:-}
 
 srpm=$("$make_srpm" "$@")


### PR DESCRIPTION
This allows mock to build f22 rpms for the fedora-22-testing OS
variant.
