### PR TITLE
test: Cause any uncaught javascript exception to fail integration tests

### DIFF
--- a/pkg/shell/cockpit-plot.js
+++ b/pkg/shell/cockpit-plot.js
@@ -120,7 +120,8 @@ function setup_plot(graph_id, grid, data, user_options) {
     function resize() {
         if (plot && running) {
             sync_divs ();
-            plot.resize();
+            if (inner_div.width() > 0 && inner_div.height() > 0)
+                plot.resize();
             refresh();
         }
     }
@@ -276,7 +277,8 @@ function setup_plot_x(graph_id, resmon, data, user_options, store_samples) {
     {
         if (plot && running) {
             sync_divs ();
-            plot.resize();
+            if (inner_div.width() > 0 && inner_div.height() > 0)
+                plot.resize();
             refresh();
         }
     }

--- a/pkg/shell/cockpit-server.js
+++ b/pkg/shell/cockpit-server.js
@@ -438,6 +438,9 @@ PageServer.prototype = {
             });
 
         function hostname_text() {
+            if (!self.hostname_proxy)
+                return;
+
             var pretty_hostname = self.hostname_proxy.PrettyHostname;
             var static_hostname = self.hostname_proxy.StaticHostname;
 

--- a/test/phantom-driver
+++ b/test/phantom-driver
@@ -53,6 +53,14 @@ var waitTimeout;
 
 page.viewportSize = { width: 800, height: 480 };
 
+function result(out) {
+    if (lastError) {
+        out = { error: lastError };
+        lastError = null;
+    }
+    sys.stdout.writeLine(JSON.stringify(out));
+}
+
 function step ()
 {
     setTimeout(function () {
@@ -79,7 +87,7 @@ function step ()
             if (status != "success" && page.failure)
                 status = page.failure;
             page.failure = null;
-            sys.stdout.writeLine(JSON.stringify({result: status}));
+            result({ result: status });
             step ();
         }
 
@@ -106,49 +114,46 @@ function step ()
             }, cmd.timeout || 10000);
         } else if (cmd.cmd == "inject") {
             var ret = page.injectJs(cmd.file);
-            sys.stdout.writeLine(JSON.stringify({result: ret}));
+            result({ result: ret });
             step();
         } else if (cmd.cmd == "switch") {
             if (page.switchToFrame(cmd.name))
-                sys.stdout.writeLine(JSON.stringify({result: true}));
+                result({ result: true });
             else
-                sys.stdout.writeLine(JSON.stringify({error: "Can't switch to frame"}));
+                result({ error: "Can't switch to frame" });
             step();
         } else if (cmd.cmd == "switch_top") {
             page.switchToMainFrame();
-            sys.stdout.writeLine(JSON.stringify({result: true}));
+            result({ result: true });
             step();
         } else if (cmd.cmd == "switch_parent") {
             if (page.switchToParentFrame())
-                sys.stdout.writeLine(JSON.stringify({result: true}));
+                result({ result: true });
             else
-                sys.stdout.writeLine(JSON.stringify({error: "Can't switch to parent frame"}));
+                result({ error: "Can't switch to parent frame" });
             step();
         } else if (cmd.cmd == "show") {
             page.render(cmd.file || "page.png");
-            sys.stdout.writeLine(JSON.stringify({result: true}));
+            result({ result: true });
             step();
         } else if (cmd.cmd == "quit") {
-            sys.stdout.writeLine(JSON.stringify({result: true}));
+            result({ result: true });
             phantom.exit(0);
         } else if (cmd.cmd == "sit") {
-            sys.stdout.writeLine(JSON.stringify({result: true}));
+            result({ result: true });
             // fall through to the phantom event loop
         } else if (cmd.cmd == "do") {
             lastError = null;
             var func = "function () { " + cmd.code + "}";
             var val = page.evaluate (func);
-            if (lastError)
-                sys.stdout.writeLine(JSON.stringify({error: lastError}));
-            else
-                sys.stdout.writeLine(JSON.stringify({result: val}));
+            result({ result: val });
             step ();
         } else if (cmd.cmd == "wait") {
             var func = "function () { return " + cmd.cond + "}";
 
             function respond(val)
             {
-                sys.stdout.writeLine(JSON.stringify(val));
+                result(val);
                 clearTimeout(waitTimeout);
                 onCheckpoint = null;
                 waitTimeout = null;
@@ -157,7 +162,6 @@ function step ()
 
             function check(is_timeout)
             {
-                lastError = null;
                 var val = page.evaluate (func);
                 if (lastError)
                     respond ({error: lastError});
@@ -190,14 +194,17 @@ function step ()
                     page.sendEvent (cmd.type, k, null, null, cmd.modifier || 0);
                 }
             }
-            sys.stdout.writeLine(JSON.stringify({result: true}));
+            result({ result: true });
             step ();
         } else if (cmd.cmd == "upload") {
             page.uploadFile(cmd.selector, cmd.file);
-            sys.stdout.writeLine(JSON.stringify({result: true}));
+            result({ result: true });
+            step();
+        } else if (cmd.cmd == "ping") {
+            result({ result: "pong" });
             step();
         } else {
-            sys.stdout.writeLine(JSON.stringify({error: "?"}));
+            result({ error: "?" });
             step ();
         }
 

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -622,6 +622,7 @@ class Phantom:
         self.run({'cmd': 'keys', 'type': type, 'keys': keys })
 
     def quit(self):
+        self.run({'cmd': 'ping'})
         self.driver.stdin.close()
         self.driver.wait()
 

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -561,7 +561,7 @@ class Phantom:
         if lang:
             environ["LC_ALL"] = lang
         self.driver = subprocess.Popen([ "%s/phantom-driver" % topdir ], env=environ,
-                                       stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+                                       stdout=subprocess.PIPE, stdin=subprocess.PIPE, close_fds=True)
         self.frame = None
 
     def run(self, args):


### PR DESCRIPTION
Any uncaught exception causes the next request to phantom-driver to fail with that error. In addition we ping the driver when done to make sure we don't miss any exceptions.

Fix the exception in check-docker

Close the file descriptors when running phantomjs.

