### PR TITLE
Fail tests when g_critical()

### DIFF
--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -245,6 +245,7 @@ send_init_command (CockpitTransport *transport)
 static void
 setup_dbus_daemon (gpointer addrfd)
 {
+  g_unsetenv ("G_DEBUG");
   cockpit_unix_fd_close_all (3, GPOINTER_TO_INT (addrfd));
 }
 

--- a/src/ws/cockpit-testing.service.in
+++ b/src/ws/cockpit-testing.service.in
@@ -5,7 +5,7 @@ Requires=cockpit-testing.socket
 Conflicts=cockpit.service
 
 [Service]
-Environment=G_MESSAGES_DEBUG=cockpit-ws
+Environment=G_MESSAGES_DEBUG=cockpit-ws G_DEBUG=fatal-criticals
 ExecStart=@libexecdir@/cockpit-ws --no-tls
 User=@user@
 Group=@group@


### PR DESCRIPTION
Fail tests when g_warning() or g_critical()
    
We force an abort() to happen in these cases.
