### PR TITLE
Make check-multi-machine work with debuginfo installed

### DIFF
--- a/test/check-multi-machine
+++ b/test/check-multi-machine
@@ -153,9 +153,9 @@ class TestMultiMachine(MachineCase):
 
         # Modify the terminals to be different on the two machines.
         m1.needs_writable_usr()
-        m1.execute("gunzip -c /usr/share/cockpit/system/terminal.min.html.gz | sed -e 's|</body>|magic-m1-token</body>|' > /usr/share/cockpit/system/terminal.min.html")
+        m1.execute("gunzip -c /usr/share/cockpit/system/terminal.min.html.gz | sed -e 's|</body>|magic-m1-token</body>|' > /usr/share/cockpit/system/terminal.html")
         m2.needs_writable_usr()
-        m2.execute("gunzip -c /usr/share/cockpit/system/terminal.min.html.gz | sed -e 's|</body>|magic-m2-token</body>|' > /usr/share/cockpit/system/terminal.min.html")
+        m2.execute("gunzip -c /usr/share/cockpit/system/terminal.min.html.gz | sed -e 's|</body>|magic-m2-token</body>|' > /usr/share/cockpit/system/terminal.html")
 
         self.login_and_go("dashboard", href="dashboard/list", host=None)
         inject_extras(b)


### PR DESCRIPTION
Otherwise a terminal.html file is present and the terminal.min.html
stuff doesn't take effect.