### PR TITLE
Key auth code cleanup

### DIFF
--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -483,11 +483,12 @@ run_bridge (const gchar *interactive)
 
   ssh_auth_sock = g_getenv ("SSH_AUTH_SOCK");
   if (ssh_auth_sock != NULL && ssh_auth_sock[0] != '\0')
-    {
       auth_address = g_unix_socket_address_new (ssh_auth_sock);
-      cockpit_channel_internal_address ("ssh-agent", auth_address);
+
+  cockpit_channel_internal_address ("ssh-agent", auth_address);
+
+  if (auth_address)
       g_object_unref (auth_address);
-    }
 
   pcp = cockpit_portal_new_pcp (transport);
 

--- a/src/bridge/cockpitchannel.h
+++ b/src/bridge/cockpitchannel.h
@@ -98,6 +98,8 @@ GSocketAddress *    cockpit_channel_parse_address     (CockpitChannel *self,
 void                cockpit_channel_internal_address  (const gchar *name,
                                                        GSocketAddress *address);
 
+gboolean            cockpit_channel_remove_internal_address (const gchar *name);
+
 GSocketConnectable * cockpit_channel_parse_connectable (CockpitChannel *self,
                                                        gchar **possible_name);
 

--- a/src/ws/mock-agent-bridge.c
+++ b/src/ws/mock-agent-bridge.c
@@ -213,13 +213,6 @@ main (int argc,
   g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
   g_setenv ("GIO_USE_VFS", "local", TRUE);
 
-  if (error)
-    {
-      g_printerr ("mock-agent-bridge: %s\n", error->message);
-      ret = 1;
-      goto out;
-    }
-
   outfd = dup (1);
   if (outfd < 0 || dup2 (2, 1) < 1)
     {
@@ -249,7 +242,8 @@ main (int argc,
   pid_line = strstr(agent_output, "SSH_AGENT_PID=");
   if (pid_line)
     {
-      sscanf (pid_line, "SSH_AGENT_PID=%d;", &agent);
+      if (sscanf (pid_line, "SSH_AGENT_PID=%d;", &agent) != 1)
+        g_warning ("couldn't find pid in %s", pid_line);
     }
 
   if (agent < 1)


### PR DESCRIPTION
Don't warn when no agent is available.
Coverity suggested mock bridge cleanup.