### PR TITLE
kubernetes: Fix the endpoint test

### DIFF
--- a/pkg/kubernetes/test-kubernetes.html
+++ b/pkg/kubernetes/test-kubernetes.html
@@ -520,7 +520,7 @@ require([
     var cockpit_http = cockpit.http;
     cockpit.http = function(endpoint) {
         /* Our mock kubernetes apiserver */
-        if (endpoint == 8080)
+        if (endpoint == 8080 || endpoint == 8443)
             return new MockHttp(kube_apiserver);
 
         /* For now etcd just returns not-found */
@@ -529,7 +529,7 @@ require([
 
         /* Catch any other requests, fail test */
         else
-            throw "Unexpected mock http endpoint";
+            throw "Unexpected mock http endpoint " + endpoint;
     };
 
     /* A fresh set of kube_data for each test */


### PR DESCRIPTION
Account for port 8443 ... This is until the kubectl proxy branch
lands.