### PR TITLE
bridge: Set client host to null after freeing

### DIFF
--- a/src/bridge/cockpithttpstream.c
+++ b/src/bridge/cockpithttpstream.c
@@ -963,6 +963,7 @@ cockpit_http_stream_prepare (CockpitChannel *channel)
       json_object_has_member (options, "internal"))
     {
       g_free (self->client->host);
+      self->client->host = NULL;
       connectable = cockpit_channel_parse_connectable (channel, &host);
       if (!connectable)
         goto out;


### PR DESCRIPTION
@stefwalter This fixes the travis error on #2483.

I'm not sure that this (https://github.com/cockpit-project/cockpit/blob/master/src/bridge/cockpithttpstream.c#L965) g_free is actually needed there as opposed to just letting the free here (https://github.com/cockpit-project/cockpit/blob/master/src/bridge/cockpithttpstream.c#L989) handle it. Removing the one on L965 also fixes the issue.