### PR TITLE
Update require-config.js

### DIFF
--- a/pkg/base1/require-config.js
+++ b/pkg/base1/require-config.js
@@ -1,6 +1,7 @@
 (function(require) {
     require.config({
         baseUrl: "../",
+        waitSeconds: 30,
         paths: {
             "jquery": "base1/jquery"
         }


### PR DESCRIPTION
Increase the number of seconds to wait before giving up on loading a script. The default is 7 seconds, which is causing timeouts on slow networks