### PR TITLE
test: Work around broken kube-apiserver config.

### DIFF
--- a/test/check-kubernetes
+++ b/test/check-kubernetes
@@ -44,12 +44,18 @@ class KubernetesCase(MachineCase):
         """ % (port, timeout * 2, scheme)
         self.machine.execute(script=waiter)
 
+    # HACK - https://bugzilla.redhat.com/show_bug.cgi?id=1243827
+    def fix_apiserver_config(self):
+        self.machine.execute("sed -i /etc/kubernetes/apiserver -e 's/4001/2379/'")
+
+
 @unittest.skipIf("rhel-7" == os.environ.get("TEST_OS", ""), "Skipping check-kubernetes on rhel-7.")
 class TestKubernetes(KubernetesCase):
     def setUp(self):
         MachineCase.setUp(self)
         m = self.machine
 
+        self.fix_apiserver_config()
         m.execute("systemctl start etcd kube-apiserver kube-controller-manager docker kube-proxy kubelet")
         m.upload(["mock-k8s-tiny-app.json"], "/tmp")
         self.wait_api_server()
@@ -106,6 +112,7 @@ class TestSsl(KubernetesCase):
         # Start a kube-apiserver with a 'wrong' http port, forcing use of https
         m.execute("echo 'KUBE_API_PORT=\"--port=1111\"' >> /etc/kubernetes/apiserver")
         m.execute("sed -i s/8080/1111/g /etc/kubernetes/*")
+        self.fix_apiserver_config()
         m.execute("systemctl start etcd kube-apiserver kube-controller-manager docker kube-proxy kubelet")
         self.wait_api_server(port=6443, scheme='https')
 
@@ -135,6 +142,7 @@ class TestAuth(KubernetesCase):
         m.upload(["mock-kube-config-basic.json"], "/tmp")
         m.execute("mkdir -p /home/admin/.kube/ && mv /tmp/mock-kube-config-basic.json /home/admin/.kube/config")
 
+        self.fix_apiserver_config()
         m.execute("systemctl start etcd kube-apiserver")
         self.wait_api_server(port=6443, scheme='https')
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1243827