### PR TITLE
configure: Only install debug files when --enable-debug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -380,8 +380,10 @@ if test "$enable_debug" != "no"; then
   AC_DEFINE_UNQUOTED(_DEBUG, 1, [In debug mode])
   CFLAGS="$CFLAGS -g"
 fi
+debugdir=${prefix}/src/debug
 if test "$enable_debug" = "yes"; then
   debug_status="yes"
+  debugdir=
   CFLAGS="$CFLAGS -O0"
 elif test "$enable_debug" = "no"; then
   debug_status="no"
@@ -391,6 +393,7 @@ else
 fi
 AM_CONDITIONAL(WITH_DEBUG, test "$enable_debug" = "yes")
 AC_MSG_RESULT($debug_status)
+AC_SUBST(debugdir)
 
 # Coverage
 

--- a/pkg/base1/Makefile.am
+++ b/pkg/base1/Makefile.am
@@ -18,7 +18,7 @@ base_DATA = \
 	$(base_GEN:.js=.js.gz) \
 	$(NULL)
 
-basedebugdir = $(DBGDIR)$(basedir)
+basedebugdir = $(debugdir)$(basedir)
 basedebug_DATA = \
 	pkg/base1/angular.js \
 	pkg/base1/cockpit.css \
@@ -58,7 +58,7 @@ basefonts_DATA = \
 	pkg/base1/fonts/glyphicons.woff.gz \
 	$(NULL)
 
-basefontsdebugdir = $(DBGDIR)$(basefontsdir)
+basefontsdebugdir = $(debugdir)$(basefontsdir)
 basefontsdebug_DATA = \
 	pkg/base1/fonts/fontawesome.woff \
 	pkg/base1/fonts/patternfly.woff \

--- a/pkg/docker/Makefile.am
+++ b/pkg/docker/Makefile.am
@@ -6,7 +6,7 @@ docker_DATA = \
 	pkg/docker/manifest.json \
 	$(NULL)
 
-dockerdebugdir = $(DBGDIR)$(dockerdir)
+dockerdebugdir = $(debugdir)$(dockerdir)
 dockerdebug_DATA = \
 	pkg/docker/docker.js \
 	pkg/docker/console.html \

--- a/pkg/kubernetes/Makefile.am
+++ b/pkg/kubernetes/Makefile.am
@@ -7,7 +7,7 @@ kubernetes_DATA = \
 	pkg/kubernetes/manifest.json \
 	$(NULL)
 
-kubernetesdebugdir = $(DBGDIR)$(kubernetesdir)
+kubernetesdebugdir = $(debugdir)$(kubernetesdir)
 kubernetesdebug_DATA = \
 	pkg/kubernetes/adjust.js \
 	pkg/kubernetes/app.css \

--- a/pkg/realmd/Makefile.am
+++ b/pkg/realmd/Makefile.am
@@ -4,7 +4,7 @@ realmd_DATA = \
 	pkg/realmd/manifest.json \
 	$(NULL)
 
-realmddebugdir = $(DBGDIR)$(realmddir)
+realmddebugdir = $(debugdir)$(realmddir)
 realmddebug_DATA = \
 	pkg/realmd/bundle.js \
 	pkg/realmd/operation.js \

--- a/pkg/shell/Makefile.am
+++ b/pkg/shell/Makefile.am
@@ -8,7 +8,7 @@ shell_DATA = \
 	pkg/shell/manifest.json \
 	$(NULL)
 
-shelldebugdir = $(DBGDIR)$(shelldir)
+shelldebugdir = $(debugdir)$(shelldir)
 shelldebug_DATA = \
 	pkg/shell/shell.js \
 	pkg/shell/bundle.js \

--- a/pkg/storaged/Makefile.am
+++ b/pkg/storaged/Makefile.am
@@ -6,7 +6,7 @@ storaged_DATA = \
 	pkg/storaged/storage.min.css.gz \
 	$(NULL)
 
-storageddebugdir = $(DBGDIR)$(storageddir)
+storageddebugdir = $(debugdir)$(storageddir)
 storageddebug_DATA = \
 	pkg/storaged/bundle.js \
 	pkg/storaged/details.js \

--- a/pkg/subscriptions/Makefile.am
+++ b/pkg/subscriptions/Makefile.am
@@ -7,7 +7,7 @@ subscriptions_DATA = \
 	pkg/subscriptions/manifest.json \
 	$(NULL)
 
-subscriptionsdebugdir = $(DBGDIR)$(subscriptionsdir)
+subscriptionsdebugdir = $(debugdir)$(subscriptionsdir)
 subscriptionsdebug_DATA = \
 	pkg/subscriptions/subscriptions.html \
 	pkg/subscriptions/subscriptions.js \

--- a/pkg/systemd/Makefile.am
+++ b/pkg/systemd/Makefile.am
@@ -8,7 +8,7 @@ systemd_DATA = \
 	pkg/systemd/journal.min.css.gz \
 	$(NULL)
 
-systemddebugdir = $(DBGDIR)$(systemddir)
+systemddebugdir = $(debugdir)$(systemddir)
 systemddebug_DATA = \
 	pkg/systemd/bundle.js \
 	pkg/systemd/init.js \

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -184,7 +184,7 @@ make selinux
 # make check
 
 %install
-make install DESTDIR=%{buildroot} DBGDIR=/debug
+make install DESTDIR=%{buildroot}
 %if %{defined gitcommit}
 make install-test-assets DESTDIR=%{buildroot}
 mkdir -p %{buildroot}/%{_datadir}/polkit-1/rules.d
@@ -242,10 +242,10 @@ touch kubernetes.list
 sed -i "s|%{buildroot}||" *.list
 
 # Build the package lists for debug package, and move debug files to installed locations
-find %{buildroot}/debug%{_datadir}/%{name} -type f -o -type l > debug.list
-sed -i "s|%{buildroot}/debug||" debug.list
-tar -C %{buildroot}/debug -cf - . | tar -C %{buildroot} -xf -
-rm -rf %{buildroot}/debug
+find %{buildroot}/usr/src/debug%{_datadir}/%{name} -type f -o -type l > debug.list
+sed -i "s|%{buildroot}/usr/src/debug||" debug.list
+tar -C %{buildroot}/usr/src/debug -cf - . | tar -C %{buildroot} -xf -
+rm -rf %{buildroot}/usr/src/debug
 
 # On RHEL subscriptions and docker are part of the shell package
 %if 0%{?rhel}


### PR DESCRIPTION
This makes it easier for packagers to get right. Cockpit should not
be packaged with its debug files in the same package.

For contributors --enable-debug is documented in HACKING.md as the
way that people who are contributing should configure cockpit.