### PR TITLE
Test: storage tests require writable /usr

### DIFF
--- a/test/storagelib.py
+++ b/test/storagelib.py
@@ -27,6 +27,7 @@ class StorageCase(MachineCase):
         # VirtIO devices don't seem to appear early enough for udev to
         # pick them up reliably.  We just wait a bit.
         #
+        self.machine.needs_writable_usr()
         self.machine.write("/usr/lib/udev/rules.d/59-fixup-serial.rules",
              'SUBSYSTEM=="block" KERNEL=="vd*" IMPORT{program}="/bin/sh -c \'sleep 0.5; s=$(cat /sys/block/$(basename $tempnode)/serial); echo ID_SERIAL=$s\'"')
         self.machine.execute("udevadm control --reload; udevadm trigger")


### PR DESCRIPTION
notify test machine of this so it can be remounted for atomic systems