### PR TITLE
add sample nulecule app in kubernetes/examples folder

### DIFF
--- a/pkg/kubernetes/examples/nulecule_app/guestbook-go/Dockerfile
+++ b/pkg/kubernetes/examples/nulecule_app/guestbook-go/Dockerfile
@@ -1,0 +1,6 @@
+FROM projectatomic/atomicapp:dev
+
+MAINTAINER Subin <sub-mods@redhat.com>
+
+ADD /Nulecule /Dockerfile README.md /application-entity/
+ADD /artifacts /application-entity/artifacts

--- a/pkg/kubernetes/examples/nulecule_app/guestbook-go/Nulecule
+++ b/pkg/kubernetes/examples/nulecule_app/guestbook-go/Nulecule
@@ -1,0 +1,25 @@
+---
+specversion: 0.0.2
+id: guestbookgo-app
+
+metadata:
+  name: Guestbook-Go App
+  appversion: 0.0.1
+  description: Atomic app for deploying the k8s guestbook-go app
+graph:
+  - name: frontend
+    params:
+      - name: image
+        description: The frontend part
+        default: stefwalter/example-guestbook-php-redis:v2
+      - name: hostport
+        description: The host TCP port as the external endpoint
+        default: 80
+      - name: publicip
+        description: The IP address or addresses at which your app can be reached
+    artifacts:
+      kubernetes:
+        - file://artifacts/k8s/guestbook-controller.json
+        - file://artifacts/k8s/guestbook-service.json
+  - name: redis-centos7-atomicapp
+    source: docker://submod/redis-centos7-atomicapp

--- a/pkg/kubernetes/examples/nulecule_app/guestbook-go/README.md
+++ b/pkg/kubernetes/examples/nulecule_app/guestbook-go/README.md
@@ -1,0 +1,26 @@
+This is the [guestbook-go](https://github.com/GoogleCloudPlatform/kubernetes/tree/master/examples/guestbook-go) sample application from the kubernetes project, packaged as an atomic application based on the nulecule specification. 
+
+Kubernetes is currently the only supported provider. You'll need to run this from a workstation that has the atomic CLI and kubectl client that can connect to a kubernetes master. This example depends on kube-dns being configured on your kubernetes cluster.
+
+### Step 1
+
+Build this app:
+
+```
+atomicapp build $USER/guestbookgo-app
+```
+
+### Step 2 
+
+Run this app:
+
+```
+atomic run $USER/guestbookgo-app
+```
+
+You'll be prompted to replace the value `publicip` with an IP address or addresses at which your app can be reached. On a single machine kubernetes cluster, for instance, you would provide the IP address of your single kubelet.
+
+### Step 3
+
+Access the guestbook. After the images are pulled (may take a few minutes), you should be able to access the guestbook-go app at port 3000 of the IP address you provided.
+

--- a/pkg/kubernetes/examples/nulecule_app/guestbook-go/answers.conf
+++ b/pkg/kubernetes/examples/nulecule_app/guestbook-go/answers.conf
@@ -1,0 +1,2 @@
+[general]
+provider = kubernetes

--- a/pkg/kubernetes/examples/nulecule_app/guestbook-go/artifacts/k8s/guestbook-controller.json
+++ b/pkg/kubernetes/examples/nulecule_app/guestbook-go/artifacts/k8s/guestbook-controller.json
@@ -1,0 +1,37 @@
+    {
+      "kind": "ReplicationController",
+      "apiVersion": "v1beta3",
+      "metadata": {
+        "name": "frontend",
+        "labels": {
+          "name": "frontend"
+        }
+      },
+      "spec": {
+        "replicas": 3,
+        "selector": {
+          "name": "frontend"
+        },
+        "template": {
+          "metadata": {
+            "labels": {
+              "name":"frontend"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "php-redis",
+                "image":"$image",
+                "ports": [
+                   {
+                     "containerPort": 80,
+                     "protocol": "TCP"
+                   }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }

--- a/pkg/kubernetes/examples/nulecule_app/guestbook-go/artifacts/k8s/guestbook-service.json
+++ b/pkg/kubernetes/examples/nulecule_app/guestbook-go/artifacts/k8s/guestbook-service.json
@@ -1,0 +1,22 @@
+{
+      "kind": "Service",
+      "apiVersion": "v1beta3",
+      "metadata": {
+        "name": "frontend",
+        "labels": {
+          "name": "frontend"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "port":$hostport,
+            "targetPort":80,
+            "protocol":"TCP"
+          }
+        ],
+        "selector":{
+          "name":"frontend"
+        }
+      }
+    }

--- a/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/Dockerfile
+++ b/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/Dockerfile
@@ -1,0 +1,6 @@
+FROM projectatomic/atomicapp:dev
+
+MAINTAINER Subin <sub-mods@redhat.com>
+
+ADD /Nulecule /Dockerfile README.md /application-entity/
+ADD /artifacts /application-entity/artifacts

--- a/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/Nulecule
+++ b/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/Nulecule
@@ -1,0 +1,34 @@
+---
+specversion: 0.0.2
+id: redis-atomicapp
+
+metadata:
+  name: Redis App
+  appversion: 0.0.1
+  description: Redis atomic app
+graph:
+  - name: redismaster-app
+    params:
+      - name: image
+        description: The redis master part
+        default: stefwalter/redis:latest
+      - name: hostport
+        description: The host TCP port as the external endpoint
+        default: 6379
+    artifacts:
+      kubernetes:
+        - file://artifacts/k8s/redis-master-controller.json
+        - file://artifacts/k8s/redis-master-service.json
+  - name: redisslave-app
+    params:
+      - name: image
+        description: The redis slave part
+        default: stefwalter/redis-slave:v2
+      - name: hostport
+        description: The host TCP port as the external endpoint
+        default: 6379
+    artifacts:
+      kubernetes:
+        - file://artifacts/k8s/redis-slave-controller.json
+        - file://artifacts/k8s/redis-slave-service.json
+

--- a/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/README.md
+++ b/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/README.md
@@ -1,0 +1,21 @@
+This is a redis sample application, in which redis master and slave components are packaged as an atomic application based on the nulecule specification. 
+
+Kubernetes is currently the only supported provider. You'll need to run this from a workstation that has the atomic CLI and kubectl client that can connect to a kubernetes master. This example depends on kube-dns being configured on your kubernetes cluster.
+
+### Step 1
+
+Build this app:
+
+```
+atomicapp build $USER/redis-centos7-atomicapp
+```
+
+### Step 2 
+
+Run this app:
+
+```
+atomic run $USER/redis-centos7-atomicapp
+```
+
+

--- a/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/answers.conf
+++ b/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/answers.conf
@@ -1,0 +1,2 @@
+[general]
+provider = kubernetes

--- a/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/artifacts/k8s/redis-master-controller.json
+++ b/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/artifacts/k8s/redis-master-controller.json
@@ -1,0 +1,39 @@
+{
+   "kind":"ReplicationController",
+   "apiVersion":"v1beta3",
+   "id":"redis-master",
+   "metadata":{
+      "name":"redis-master",
+      "labels":{
+         "name": "redis-master"
+      }
+   },
+   "spec":{
+      "replicas":1,
+      "selector":{
+         "name": "redis-master"
+      },
+      "template":{
+         "metadata":{
+            "labels":{
+               "name": "redis-master"
+            }
+         },
+         "spec":{
+            "containers":[
+               {
+                  "name":"redis-master",
+                  "image":"$image",
+                  "ports":[
+                     {
+                        "name":"redis-server",
+                        "containerPort":6379,
+                        "protocol":"TCP"
+                     }
+                  ]
+               }
+            ]
+         }
+      }
+   }
+}

--- a/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/artifacts/k8s/redis-master-service.json
+++ b/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/artifacts/k8s/redis-master-service.json
@@ -1,0 +1,22 @@
+{
+      "kind": "Service",
+      "apiVersion": "v1beta3",
+      "metadata": {
+        "name": "redis-master",
+        "labels": {
+          "name": "redis-master"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "port": 6379,
+            "targetPort": 6379,
+            "protocol": "TCP"
+          }
+        ],
+        "selector":{
+          "name": "redis-master"
+        }
+      }
+    }

--- a/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/artifacts/k8s/redis-slave-controller.json
+++ b/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/artifacts/k8s/redis-slave-controller.json
@@ -1,0 +1,37 @@
+    {
+      "kind": "ReplicationController",
+      "apiVersion": "v1beta3",
+      "metadata": {
+        "name": "redis-slave",
+        "labels": {
+          "name": "redis-slave"
+        }
+      },
+      "spec": {
+        "replicas": 2,
+        "selector": {
+          "name": "redis-slave"
+        },
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "redis-slave"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "slave",
+                "image":"$image",
+                "ports": [
+                  {
+                    "containerPort": 6379,
+                    "protocol": "TCP"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }

--- a/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/artifacts/k8s/redis-slave-service.json
+++ b/pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/artifacts/k8s/redis-slave-service.json
@@ -1,0 +1,22 @@
+    {
+      "kind": "Service",
+      "apiVersion": "v1beta3",
+      "metadata": {
+        "name": "redis-slave",
+        "labels": {
+          "name": "redis-slave"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "port": 6379,
+            "targetPort": 6379,
+            "protocol": "TCP"
+          }
+        ],
+        "selector": {
+          "name": "redis-slave"
+        }
+      }
+    }


### PR DESCRIPTION
add sample nulecule app in kubernetes/examples folder

To build the apps
cd pkg/kubernetes/examples/nulecule_app/guestbook-go
sudo docker build -t <user>/guestbookphp-app .

cd pkg/kubernetes/examples/nulecule_app/redis-centos7-atomicapp/
sudo docker build -t  <user>/redis-centos7-atomicapp .