### PR TITLE
terminal: Start terminal in home directory or root

### DIFF
--- a/pkg/systemd/terminal.js
+++ b/pkg/systemd/terminal.js
@@ -21,7 +21,7 @@ define([
         /* if we don't have user information yet, retry soon
          * abort wait and just use default shell if we exceed time limit
          */
-        if (!current_user && ((new Date()) - shell_update_started < 1000)) {
+        if (current_user.shell === undefined && ((new Date()) - shell_update_started < 1000)) {
             terminal_timer = window.setTimeout(start_terminal, 50);
             return;
         }
@@ -48,6 +48,7 @@ define([
                 "TERM=xterm-256color",
                 "PATH=/sbin:/bin:/usr/sbin:/usr/bin"
             ],
+            "directory": current_user.home || "/",
             "pty": true
         });
 

--- a/test/check-terminal
+++ b/test/check-terminal
@@ -37,11 +37,15 @@ class TestTerminal(MachineCase):
         def wait_line(i,t):
             b.wait_text(line_sel(i), line_text(t))
 
+        b.wait_present('#terminal .terminal')
         b.focus('#terminal .terminal')
 
         # wait for prompt in first line and remember it
         b.wait_text_not(line_sel(1), line_text(""))
         prompt = b.text(line_sel(1))
+
+        # Make sure we are started in home directory
+        self.assertIn("~]$", prompt)
 
         # Run some commands
         b.key_press( [ 'w', 'h', 'o', 'a', 'm', 'i', 'Return' ] )


### PR DESCRIPTION
This fixes two regressions:

 * We weren't actually waiting for the users shell
 * The shell wasn't started in the user's home directory.