### PR TITLE
tools: Bump kubernetes dependency to one with the v1 API

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -361,7 +361,7 @@ This package is not yet complete.
 
 %package kubernetes
 Summary: Cockpit user interface for Kubernetes cluster
-Requires: kubernetes >= 0.16.2
+Requires: kubernetes >= 0.20.0
 
 %description kubernetes
 The Cockpit components for visualizing and configuring a Kubernetes


### PR DESCRIPTION
We migrated away from the v1beta3 API to the v1 API in the
commit 3fcb59d461cb68155bccbe6cb8e3cd8e26ba4482

Need to bump the kubernetes dependency as well.