### PR TITLE
test: Skip all storage tests on Atomic.

### DIFF
--- a/test/storagelib.py
+++ b/test/storagelib.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import os
 from testlib import *
 
 def content_action_btn(index):
@@ -25,6 +26,10 @@ def content_action_btn(index):
 
 class StorageCase(MachineCase):
     def setUp(self):
+
+        if "atomic" in os.getenv("TEST_OS"):
+            self.skipTest("No storage on Atomic")
+
         MachineCase.setUp(self)
         # Install a udev rule to work around the fact that serials from
         # VirtIO devices don't seem to appear early enough for udev to


### PR DESCRIPTION
Because Cockpit doesn't do storage on Atomic.