### PR TITLE
Quick builds and check during builds

### DIFF
--- a/src/bridge/test-fs.c
+++ b/src/bridge/test-fs.c
@@ -33,6 +33,8 @@
 #include <errno.h>
 #include <sys/stat.h>
 
+#define TIMEOUT 30
+
 typedef struct {
   MockTransport *transport;
   CockpitChannel *channel;
@@ -67,6 +69,8 @@ static void
 setup (TestCase *tc,
        gconstpointer data)
 {
+  alarm (TIMEOUT);
+
   tc->transport = mock_transport_new ();
   g_signal_connect (tc->transport, "closed", G_CALLBACK (on_transport_closed), NULL);
   tc->channel = NULL;
@@ -203,6 +207,8 @@ teardown (TestCase *tc,
   g_free (tc->test_dir);
 
   g_free (tc->problem);
+
+  alarm (0);
 }
 
 static GBytes *

--- a/test/testsuite-prepare
+++ b/test/testsuite-prepare
@@ -5,14 +5,37 @@ set -e
 make_rpms_opts=
 cockpit_create_opts=
 install_selinux=yes
+install_opts=
 
+usage()
+{
+    echo "usage: testsuite-prepare [--clean] [--quick] [--verbose]"
+}
+
+
+args=$(getopt -o "h,v,c,q" -l "help,verbose,clean,quick" -- "$@")
+eval set -- "$args"
 while [ $# -gt 0 ]; do
     case $1 in
-	--clean)
-            make_rpms_opts="--clean"
-            cockpit_create_opts="--force --no-save"
-            install_selinux=no
-	    ;;
+    -c|--clean)
+        mock_rpms_opts="$mock_rpms_opts --clean"
+        cockpit_create_opts="--force --no-save"
+        install_selinux=no
+        ;;
+    -q|--quick)
+        mock_rpm_opts="$mock_rpm_opts --quick"
+        ;;
+    -v|--verbose)
+        install_opts="$install_opts -v"
+        ;;
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    --)
+        shift
+        break
+        ;;
     esac
     shift
 done
@@ -64,4 +87,4 @@ fi
 TEST_OS=fedora-22 ./vm-create -v -f stock
 TEST_OS=centos-7  ./vm-create -v -f stock
 
-./vm-install -f cockpit $rpms
+./vm-install $install_opts -f cockpit $rpms

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -179,7 +179,7 @@ The Cockpit Web Service listens on the network, and authenticates users.
 env NOCONFIGURE=1 ./autogen.sh
 %endif
 %configure --disable-static --disable-silent-rules --with-cockpit-user=cockpit-ws --with-branding=%{branding}
-make -j1 %{?extra_flags} all
+make -j %{?extra_flags} all
 %if 0%{?selinux}
 make selinux
 %endif

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -4,11 +4,15 @@
 
 %define branding auto
 
-# Our SELinux policy gets built in tests and f21 and lower
 %if %{defined gitcommit}
 %define extra_flags CFLAGS='-O2 -Wall -Werror -fPIC'
-%define selinux 1
 %define branding default
+%endif
+
+#Defaults for our SELinux policy toggle
+%if %{undefined selinux}
+%if %{defined gitcommit}
+%define selinux 1
 %endif
 %if 0%{?fedora} > 0 && 0%{?fedora} <= 21
 %define selinux 1
@@ -18,6 +22,7 @@
 %endif
 %if 0%{?centos}
 %define rhel 0
+%endif
 %endif
 
 %define _hardened_build 1
@@ -76,7 +81,7 @@ BuildRequires: nodejs
 %endif
 
 # For selinux
-%if %{defined selinux}
+%if 0%{?selinux}
 BuildRequires: selinux-policy-devel
 BuildRequires: checkpolicy
 BuildRequires: selinux-policy-doc
@@ -175,7 +180,7 @@ env NOCONFIGURE=1 ./autogen.sh
 %endif
 %configure --disable-static --disable-silent-rules --with-cockpit-user=cockpit-ws --with-branding=%{branding}
 make -j1 %{?extra_flags} all
-%if %{defined selinux}
+%if 0%{?selinux}
 make selinux
 %endif
 
@@ -196,7 +201,7 @@ mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/pam.d
 install -p -m 644 %{SOURCE1} $RPM_BUILD_ROOT%{_sysconfdir}/pam.d/cockpit
 rm -f %{buildroot}/%{_libdir}/cockpit/*.so
 install -p -m 644 AUTHORS COPYING README.md %{buildroot}%{_docdir}/%{name}/
-%if %{defined selinux}
+%if 0%{?selinux}
 install -d %{buildroot}%{_datadir}/selinux/targeted
 install -p -m 644 cockpit.pp %{buildroot}%{_datadir}/selinux/targeted/
 %endif
@@ -401,7 +406,7 @@ pulls in some necessary packages via dependencies.
 
 %endif
 
-%if %{defined selinux}
+%if 0%{?selinux}
 
 %package selinux-policy
 Summary: SELinux policy for Cockpit testing

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -185,8 +185,7 @@ make selinux
 %endif
 
 %check
-# The check doesnt run on koji as it requires network
-# make check
+make -j check
 
 %install
 make install DESTDIR=%{buildroot}

--- a/tools/make-rpms
+++ b/tools/make-rpms
@@ -25,12 +25,15 @@ base=$(cd $(dirname $0)/../; pwd -P)
 
 usage()
 {
-	echo "usage: make-rpms [--clean] [--verbose]"
+	echo "usage: make-rpms [--clean] [--quick] [--verbose]"
 }
 
 mock_opts=""
 mock_clean_opts="--no-clean --no-cleanup-after"
-args=$(getopt -o "h,v,c" -l "help,verbose,clean" -- "$@")
+mock_define="unused"
+mock_value="0"
+
+args=$(getopt -o "h,v,c,q" -l "help,verbose,clean,quick" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do
 	case $1 in
@@ -43,6 +46,10 @@ while [ $# -gt 0 ]; do
 	-v|--verbose)
 		mock_opts="$mock_opts --verbose"
 		;;
+    -q|--quick)
+        mock_define="selinux" mock_value="0"
+        mock_opts="$mock_opts --offline --nocheck"
+        ;;
 	-h|--help)
 		usage
 		exit 0
@@ -124,7 +131,7 @@ fi
 touch -r /etc/mock/$mockos-$arch.cfg $base/mock/$os-$arch-cockpit.cfg
 
 if LANG=C /usr/bin/mock --quiet $mock_opts $mock_clean_opts --configdir=$base/mock/ \
-	--resultdir $base/mock -r $os-$arch-cockpit $srpm; then
+	--resultdir $base/mock -r $os-$arch-cockpit --define="$mock_define $mock_value" $srpm; then
     grep "^Wrote: .*\.\($arch\|noarch\)\.rpm$" $base/mock/build.log | while read l; do
         p=$(basename "$l") # knocks off the "Wrote:" part as well...
         echo $p


### PR DESCRIPTION
First off all, this enable 'make check' during builds

Also, enable parallel build when building spec file

Add --quick option to make-rpms and testsuite-prepare This is useful for people who want to iterate quickly on the tests. The --quick option enables the following:
 * Disables %check in the spec file
 * Prevents hitting repo data when building in mock
 * Prevents building of selinux stuff
    
In addition we make --verbose work better
    
One can now do:
    
        $ tools/make-rpms --quick
        $ cd test
        $ ./testsuite-prepare --quick
        $ ./testsuite-prepare --verbose
