### PR TITLE
test: Create Rawhide images by updating from Fedora 22

### DIFF
--- a/test/guest/cockpit-fedora-rawhide.setup
+++ b/test/guest/cockpit-fedora-rawhide.setup
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-set -x
+set -ex
 
 echo foobar | passwd --stdin root
 
@@ -37,6 +37,10 @@ echo 'NETWORKING=yes' > /etc/sysconfig/network
 useradd -u 1000 -c Administrator -G wheel admin
 echo foobar | passwd --stdin admin
 
+# We need storaged 2.
+#
+dnf -y copr enable phatina/storaged
+
 # Let's upgrade dnf first and then use the new dnf to upgrade
 # the rest. This helps avoid things like:
 #
@@ -46,6 +50,12 @@ dnf -y upgrade dnf
 
 dnf -y upgrade
 dnf -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
+
+# Enable Rawhide repositores and update
+#
+dnf -y install fedora-repos-rawhide
+sed -i 's/enabled=0/enabled=1/' /etc/yum.repos.d/fedora-rawhide.repo
+dnf -y upgrade
 
 rm -rf /var/log/journal/*
 echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" > /etc/sysctl.d/50-coredump.conf

--- a/test/guest/fedora-rawhide.bootstrap
+++ b/test/guest/fedora-rawhide.bootstrap
@@ -1,3 +1,9 @@
 #! /bin/bash
 
-./fedora.install "$1" "$2" "http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/$2/os"
+# Rawhide starts out as Fedora 22.  The setup script will update it as
+# far as possible towards Rawhide.
+#
+# (Once Fedora 23 is released, we should switch to that as the basis.)
+
+BASE=$(dirname $0)
+$BASE/fedora.build "$1" fedora-22 "$2"


### PR DESCRIPTION
This has a higher chance of ending up with a working system than
trying to cleanly install Rawhide from scratch, and we are more
interested in testing as many packages from Rawhide as possible, than
we are in testing Rawhide itself.