### PR TITLE
bridge: Increase metrics interpolation precision.

### DIFF
--- a/src/bridge/cockpitmetrics.c
+++ b/src/bridge/cockpitmetrics.c
@@ -411,7 +411,7 @@ compute_and_maybe_push_value (CockpitMetrics *self,
 
       if (self->priv->interpolate && !isnan (last_val))
         {
-          val = last_val * (1.0 - interpol_r) + val * interpol_r;
+          val = last_val * (1.0L - interpol_r) + val * interpol_r;
           self->priv->next_data[metric][next_instance] = val;
         }
 


### PR DESCRIPTION
This let's us get away a little bit longer with using exact equality
in test-metrics.

Fixes #2545