### PR TITLE
Use kubectl exec and logs to connect to containers

### DIFF
--- a/pkg/kubernetes/cluster.html
+++ b/pkg/kubernetes/cluster.html
@@ -294,12 +294,12 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
           </div>
         </tab>
         <tab heading="Console" select="connect('console')">
-          <kube-console host="{{pod.spec.nodeName}}" id="{{container.status.containerID}}">
-          </kube-console>
+          <kube-console namespace="{{pod.metadata.namespace}}" pod="{{pod.metadata.name}}"
+            container="{{container.spec.name}}"></kube-console>
         </tab>
         <tab heading="Shell" select="connect('shell')">
-          <kube-console host="{{pod.spec.nodeName}}" id="{{container.status.containerID}}" shell="true">
-          </kube-console>
+          <kube-shell namespace="{{pod.metadata.namespace}}" pod="{{pod.metadata.name}}"
+            container="{{container.spec.name}}"></kube-console>
         </tab>
       </tabset>
     </div>


### PR DESCRIPTION
This avoids the common case where kubernetes knows about more hosts than cockpit, and cockpit fails with no-host or untrusted-key problems    in the Kubernetes containter terminal or log screens.
    
The internal APIs for kubectl exec and kubectl logs are undocumented     and use HTTP/2. Therefore we just execute the kubectl command to     use those APIs rather than implementing all that ourselves.
