### PR TITLE
test: Store coredumps in the journal

### DIFF
--- a/src/selinux/cockpit.te
+++ b/src/selinux/cockpit.te
@@ -99,3 +99,10 @@ optional_policy(`
 optional_policy(`
 	unconfined_domtrans(cockpit_session_t)
 ')
+
+# HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1253319
+#============= syslogd_t ==============
+require {
+	type syslogd_t;
+}
+allow syslogd_t tmpfs_t:file { read write getattr };

--- a/test/cockpit.conf
+++ b/test/cockpit.conf
@@ -1,7 +1,7 @@
-{ 'tags': { 'fedora-22':         '14',
-            'rhel-7':            '4',
-            'fedora-atomic-22':  '0',
-            'fedora-rawhide':    '0',
-            'fedora-22-testing': '0'
+{ 'tags': { 'fedora-22':         '16',
+            'rhel-7':            '6',
+            'fedora-atomic-22':  '2',
+            'fedora-rawhide':    '2',
+            'fedora-22-testing': '2'
           }
 }

--- a/test/guest/cockpit-fedora-22.setup
+++ b/test/guest/cockpit-fedora-22.setup
@@ -45,6 +45,8 @@ dnf -y upgrade
 dnf -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
 
 rm -rf /var/log/journal/*
+echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" > /etc/sysctl.d/50-coredump.conf
+printf "[Coredump]\nStorage=journal\n" > /etc/systemd/coredump.conf
 
 ln -sf ../selinux/config /etc/sysconfig/selinux
 echo 'SELINUX=enforcing' > /etc/selinux/config

--- a/test/guest/cockpit-fedora-atomic-22.setup
+++ b/test/guest/cockpit-fedora-atomic-22.setup
@@ -33,4 +33,8 @@ systemctl start docker
 rpm -qa | grep cockpit > /root/cockpit_packages
 rpm -ql `rpm -qa | grep cockpit` | sort > /root/cockpit_files
 
+rm -rf /var/log/journal/*
+echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" > /etc/sysctl.d/50-coredump.conf
+printf "[Coredump]\nStorage=journal\n" > /etc/systemd/coredump.conf
+
 docker pull busybox

--- a/test/guest/cockpit-fedora-rawhide.setup
+++ b/test/guest/cockpit-fedora-rawhide.setup
@@ -48,7 +48,8 @@ dnf -y upgrade
 dnf -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
 
 rm -rf /var/log/journal/*
-
+echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" > /etc/sysctl.d/50-coredump.conf
+printf "[Coredump]\nStorage=journal\n" > /etc/systemd/coredump.conf
 
 # Audit events to the journal
 rm -f '/etc/systemd/system/multi-user.target.wants/auditd.service'

--- a/test/guest/cockpit-rhel-7.setup
+++ b/test/guest/cockpit-rhel-7.setup
@@ -81,6 +81,8 @@ echo foobar | passwd --stdin admin
 mkdir -p /var/log/journal
 
 rm -rf /var/log/journal/*
+echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" > /etc/sysctl.d/50-coredump.conf
+printf "[Coredump]\nStorage=journal\n" > /etc/systemd/coredump.conf
 
 touch /.autorelabel
 

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -398,6 +398,7 @@ class Machine:
         self.message(" ".join(cmd))
         subprocess.check_call([ "rm", "-rf", dest ])
         subprocess.check_call(cmd)
+        subprocess.check_call([ "find", dest, "-type", "f", "-exec", "chmod", "0644", "{}", ";" ])
 
     def write(self, dest, content):
         """Write a file into the test machine


### PR DESCRIPTION
So we can see them when we extract the journal.

Together with running the tests as fatal-criticals, we should be able to find the source of some of the more sporadic problems that we find.