### PR TITLE
tools: Distribute valgrind suppressions

### DIFF
--- a/tools/Makefile-tools.am
+++ b/tools/Makefile-tools.am
@@ -21,6 +21,7 @@ EXTRA_DIST += \
 	tools/qunit.js \
 	tools/qunit-config.js \
 	tools/gdbus-unbreak-codegen \
+	$(VALGRIND_SUPPRESSIONS)
 	$(NULL)
 
 DISTCLEANFILES += \


### PR DESCRIPTION
So that people can run 'check-memory' on their tarball builds