### PR TITLE
kubernetes: Don't deref null channel object after disconnected

### DIFF
--- a/pkg/kubernetes/details.js
+++ b/pkg/kubernetes/details.js
@@ -240,7 +240,7 @@ define([
                             });
 
                         term.on('data', function(data) {
-                            if (channel.valid)
+                            if (channel && channel.valid)
                                 channel.send(data);
                         });
                     }


### PR DESCRIPTION
This is a regression from the 'kubectl exec' reworking that
was done recently:

commit 40b39443293a483f24b53e2608e6e13de34910a1