### PR TITLE
tools: Add another GLib and PCP suppression

### DIFF
--- a/tools/glib.supp
+++ b/tools/glib.supp
@@ -481,3 +481,13 @@
    fun:g_strdup
    fun:g_tls_connection_gnutls_init_priorities
 }
+{
+   g_tls_connection_gnutls_heisenbug_likely_same_as_above
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:g_malloc
+   fun:g_strdup
+   ...
+   fun:g_tls_client_connection_new
+}

--- a/tools/pcp.supp
+++ b/tools/pcp.supp
@@ -18,3 +18,12 @@
    fun:__pmLogFetch
    ...
 }
+{
+   pm_connect_local_string_leak
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:strdup
+   ...
+   fun:__pmConnectLocal
+}


### PR DESCRIPTION
The glib-networking one seems to already be covered, but this matches
without debug info installed.