### PR TITLE
Pull the autoconf version from latest git tag

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -216,6 +216,7 @@ install-data-local:: install-doc-local
 	@true
 
 dist-hook: dist-doc-hook
+	echo $(VERSION) > $(distdir)/.tarball
 	ln -s systemd $(distdir)/pkg/system
 
 distcheck-hook: dist-doc-hook

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 AC_INIT([Cockpit],
-        [0.71],
+        [m4_esyscmd([tools/git-version-gen .tarball])],
         [devel@lists.cockpit-project.org],
         [cockpit],
         [http://www.cockpit-project.org/])

--- a/tools/git-version-gen
+++ b/tools/git-version-gen
@@ -1,0 +1,19 @@
+#!/bin/sh -euf
+
+set -euf
+
+if [ $# -ne 1 ]; then
+	echo "usage: git-version-get fallback-file" >&2
+	exit 2
+fi
+
+generate() {
+	if [ -d .git ]; then
+		git describe | sed 's/-[0-9]\+-g/-git/'
+	else
+		cat $1
+	fi
+}
+
+# Omit the trailing new line, so this can be used directly
+generate $1 | tr -d "\n\r"


### PR DESCRIPTION
This removes one source of information duplication when doing a release.

Note that for tarballs, we use the version saved into the ```.tarball``` file. This file only exists in tarballs.
