### PR TITLE
Make PCP an optional build dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -192,13 +192,30 @@ COCKPIT_WS_LIBS="$COCKPIT_WS_LIBS -lcrypt"
 REAUTHORIZE_LIBS="$REAUTHORIZE_LIBS -lcrypt"
 
 # pcp
-AC_CHECK_HEADER([pcp/pmapi.h], ,
-  [AC_MSG_ERROR([Couldn't find pcp headers. Try installing pcp-libs-devel])]
-)
-AC_CHECK_LIB(pcp, pmNewContext, [ true ],
-  [AC_MSG_ERROR([Couldn't find pcp library. Try installing pcp-libs-devel])]
-)
-COCKPIT_PCP_LIBS="$COCKPIT_PCP_LIBS -lpcp -lm"
+AC_MSG_CHECKING([whether to build with PCP])
+AC_ARG_ENABLE(pcp, AC_HELP_STRING([--disable-pcp], [Disable usage of PCP]))
+
+if test "$enable_pcp" = "no"; then
+  AC_MSG_RESULT($enable_pcp)
+
+else
+  if test "$enable_pcp" = ""; then
+    disable_msg="(perhaps --disable-pcp)"
+  fi
+
+  enable_pcp="yes"
+  AC_MSG_RESULT($enable_pcp)
+
+  AC_CHECK_HEADER([pcp/pmapi.h], ,
+    [AC_MSG_ERROR([Couldn't find pcp headers $disable_msg])]
+  )
+  AC_CHECK_LIB(pcp, pmNewContext, [ true ],
+    [AC_MSG_ERROR([Couldn't find pcp library $disable_msg])]
+  )
+  COCKPIT_PCP_LIBS="$COCKPIT_PCP_LIBS -lpcp -lm"
+fi
+
+AM_CONDITIONAL([ENABLE_PCP], [test "$enable_pcp" = "yes"])
 
 # gssapi
 AC_CHECK_LIB(gssapi_krb5, gss_import_cred,
@@ -472,6 +489,7 @@ echo "
         Debug mode:                 ${debug_status}
         With coverage:              ${enable_coverage}
         With address sanitizer:     ${asan_status}
+        With PCP:                   ${enable_pcp}
 	Branding:                   ${BRAND}
         Supports key auth:          ${key_auth}
 "

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -1,7 +1,6 @@
 
 noinst_LIBRARIES += \
 	libcockpit-bridge.a \
-	libcockpit-pcp.a \
 	$(NULL)
 
 libcockpit_bridge_a_SOURCES = \
@@ -83,31 +82,10 @@ libcockpit_bridge_LIBS = \
 	$(COCKPIT_BRIDGE_LIBS) \
 	$(NULL)
 
-libcockpit_pcp_a_SOURCES = \
-	src/bridge/cockpitchannel.c \
-	src/bridge/cockpitchannel.h \
-	src/bridge/cockpitmetrics.c \
-	src/bridge/cockpitmetrics.h \
-	src/bridge/cockpitpcpmetrics.c \
-	src/bridge/cockpitpcpmetrics.h \
-	$(NULL)
-
-libcockpit_pcp_a_CFLAGS = \
-	-I$(srcdir)/src/bridge \
-	-DG_LOG_DOMAIN=\"cockpit-pcp\" \
-	$(COCKPIT_PCP_CFLAGS) \
-	$(NULL)
-
-libcockpit_pcp_LIBS = \
-	libcockpit-pcp.a \
-	libcockpit-common.a \
-	$(COCKPIT_PCP_LIBS) \
-	$(NULL)
-
 # -----------------------------------------------------------------------------
 
 bin_PROGRAMS += cockpit-bridge
-libexec_PROGRAMS += cockpit-polkit cockpit-pcp
+libexec_PROGRAMS += cockpit-polkit
 
 cockpit_bridge_SOURCES = src/bridge/bridge.c
 cockpit_bridge_CFLAGS = \
@@ -116,13 +94,6 @@ cockpit_bridge_CFLAGS = \
 	$(COCKPIT_BRIDGE_CFLAGS) \
 	$(NULL)
 cockpit_bridge_LDADD = $(libcockpit_bridge_LIBS)
-
-cockpit_pcp_SOURCES = src/bridge/cockpitpcp.c
-cockpit_pcp_CFLAGS = \
-	-DG_LOG_DOMAIN=\"cockpit-pcp\" \
-	$(COCKPIT_PCP_CFLAGS) \
-	$(NULL)
-cockpit_pcp_LDADD = $(libcockpit_pcp_LIBS)
 
 cockpit_polkit_SOURCES = src/bridge/cockpitpolkithelper.c
 cockpit_polkit_CFLAGS = $(COCKPIT_POLKIT_CFLAGS)
@@ -153,23 +124,9 @@ BRIDGE_CHECKS = \
 	test-packages \
 	test-fs \
 	test-metrics \
-	test-pcp \
-	test-pcp-archives \
 	test-httpstream \
 	test-setup \
 	$(NULL)
-
-noinst_DATA += mock-pmda.so
-
-CLEANFILES += mock-pmda.so
-
-# This is non-portable, but I don't feel like dragging in libtool just
-# for this.
-#
-mock-pmda.so: src/bridge/mock-pmda.c
-	$(AM_V_CCLD) $(CC) -fPIC -shared \
-		-DSRCDIR=\"$(abs_srcdir)\" \
-		-o mock-pmda.so $(srcdir)/src/bridge/mock-pmda.c -lpcp_pmda -lpcp
 
 mock_bridge_SOURCES = src/bridge/mock-bridge.c
 mock_bridge_CFLAGS = \
@@ -229,18 +186,6 @@ test_metrics_SOURCES = \
 test_metrics_CFLAGS = $(libcockpit_bridge_a_CFLAGS)
 test_metrics_LDADD = $(libcockpit_bridge_LIBS)
 
-test_pcp_SOURCES = \
-	src/bridge/test-pcp.c \
-	src/bridge/mock-transport.c src/bridge/mock-transport.h
-test_pcp_CFLAGS = $(libcockpit_pcp_a_CFLAGS)
-test_pcp_LDADD = $(libcockpit_pcp_LIBS) -ldl
-
-test_pcp_archives_SOURCES = \
-	src/bridge/test-pcp-archives.c \
-	src/bridge/mock-transport.c src/bridge/mock-transport.h
-test_pcp_archives_CFLAGS = $(libcockpit_pcp_a_CFLAGS)
-test_pcp_archives_LDADD = $(libcockpit_pcp_LIBS) -ldl -lpcp_import
-
 test_httpstream_SOURCES = \
 	src/bridge/test-httpstream.c \
 	src/bridge/mock-transport.c src/bridge/mock-transport.h
@@ -260,3 +205,71 @@ EXTRA_DIST += \
 	src/bridge/mock-server.crt \
 	src/bridge/mock-server.key \
 	$(NULL)
+
+# -----------------------------------------------------------------------------
+# PCP
+
+if ENABLE_PCP
+
+libexec_PROGRAMS += cockpit-pcp
+
+noinst_LIBRARIES += libcockpit-pcp.a
+
+libcockpit_pcp_a_SOURCES = \
+	src/bridge/cockpitchannel.c \
+	src/bridge/cockpitchannel.h \
+	src/bridge/cockpitmetrics.c \
+	src/bridge/cockpitmetrics.h \
+	src/bridge/cockpitpcpmetrics.c \
+	src/bridge/cockpitpcpmetrics.h \
+	$(NULL)
+
+libcockpit_pcp_a_CFLAGS = \
+	-I$(srcdir)/src/bridge \
+	-DG_LOG_DOMAIN=\"cockpit-pcp\" \
+	$(COCKPIT_PCP_CFLAGS) \
+	$(NULL)
+
+libcockpit_pcp_LIBS = \
+	libcockpit-pcp.a \
+	libcockpit-common.a \
+	$(COCKPIT_PCP_LIBS) \
+	$(NULL)
+
+cockpit_pcp_SOURCES = src/bridge/cockpitpcp.c
+cockpit_pcp_CFLAGS = \
+	-DG_LOG_DOMAIN=\"cockpit-pcp\" \
+	$(COCKPIT_PCP_CFLAGS) \
+	$(NULL)
+cockpit_pcp_LDADD = $(libcockpit_pcp_LIBS)
+
+BRIDGE_CHECKS += \
+	test-pcp \
+	test-pcp-archives \
+	$(NULL)
+
+noinst_DATA += mock-pmda.so
+
+CLEANFILES += mock-pmda.so
+
+# This is non-portable, but I don't feel like dragging in libtool just
+# for this.
+#
+mock-pmda.so: src/bridge/mock-pmda.c
+	$(AM_V_CCLD) $(CC) -fPIC -shared \
+		-DSRCDIR=\"$(abs_srcdir)\" \
+		-o mock-pmda.so $(srcdir)/src/bridge/mock-pmda.c -lpcp_pmda -lpcp
+
+test_pcp_SOURCES = \
+	src/bridge/test-pcp.c \
+	src/bridge/mock-transport.c src/bridge/mock-transport.h
+test_pcp_CFLAGS = $(libcockpit_pcp_a_CFLAGS)
+test_pcp_LDADD = $(libcockpit_pcp_LIBS) -ldl
+
+test_pcp_archives_SOURCES = \
+	src/bridge/test-pcp-archives.c \
+	src/bridge/mock-transport.c src/bridge/mock-transport.h
+test_pcp_archives_CFLAGS = $(libcockpit_pcp_a_CFLAGS)
+test_pcp_archives_LDADD = $(libcockpit_pcp_LIBS) -ldl -lpcp_import
+
+endif


### PR DESCRIPTION
It was already an optional runtime dependency. Some folks
like those on Arch were having a hard time with this dep.