### PR TITLE
travis: Use silent Makefile rules.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_install:
   - sudo apt-get install automake autoconf intltool xsltproc libglib2.0-dev libpolkit-gobject-1-dev libpolkit-agent-1-dev phantomjs gtk-doc-tools libjson-glib-dev libnm-glib-dev libpam0g-dev libssh-dev libsystemd-daemon-dev libsystemd-journal-dev libjson-perl libjavascript-minifier-xs-perl pkg-config glib-networking valgrind libkeyutils-dev xmlto xsltproc libpcp3-dev libpcp-pmda3-dev libpcp-import1-dev pcp liblvm2-dev libgudev-1.0-dev libgirepository1.0-dev
 
 script:
-  - ./autogen.sh --prefix=/usr --enable-strict && make V=1 all && sudo make enable-root-tests && make distcheck && make -j8 check-memory
+  - ./autogen.sh --prefix=/usr --enable-strict && make all && sudo make enable-root-tests && make distcheck && make -j8 check-memory

--- a/Makefile.am
+++ b/Makefile.am
@@ -73,7 +73,6 @@ SUBDIRS = . po
 DISTCHECK_CONFIGURE_FLAGS=						        \
 	--disable-debug \
 	--disable-coverage \
-	--disable-silent-rules \
 	--enable-prefix-only \
 	$(NULL)
 


### PR DESCRIPTION
Travis can apparently choke when the build writes a lot of output
quickly, such as a long command to remove files during "make
distclean".

I don't have ironclad evidence, but I have seen some writes to stdout
fail with EAGAIN.