### PR TITLE
travis: Write build output carefully to stdout.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_install:
   - sudo apt-get install automake autoconf intltool xsltproc libglib2.0-dev libpolkit-gobject-1-dev libpolkit-agent-1-dev phantomjs gtk-doc-tools libjson-glib-dev libnm-glib-dev libpam0g-dev libssh-dev libsystemd-daemon-dev libsystemd-journal-dev libjson-perl libjavascript-minifier-xs-perl pkg-config glib-networking valgrind libkeyutils-dev xmlto xsltproc libpcp3-dev libpcp-pmda3-dev libpcp-import1-dev pcp liblvm2-dev libgudev-1.0-dev libgirepository1.0-dev
 
 script:
-  - ./autogen.sh --prefix=/usr --enable-strict && make V=1 all && sudo make enable-root-tests && make distcheck && make -j8 check-memory
+  - gcc ./tools/careful-cat.c -o careful-cat; set -o pipefail; (./autogen.sh --prefix=/usr --enable-strict && make V=1 all && sudo make enable-root-tests && make distcheck && make -j8 check-memory) 2>&1 | ./careful-cat

--- a/tools/careful-cat.c
+++ b/tools/careful-cat.c
@@ -1,0 +1,61 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+
+/* Carefully cat stdin to stdout.
+ *
+ * This uses small writes and handles EAGAIN from write by waiting a
+ * bit and trying again.
+ *
+ * This program is used in Travis to work around this bug:
+ *
+ *    https://github.com/travis-ci/travis-ci/issues/4704
+ */
+
+void
+main (void)
+{
+  char buffer[1024], *ptr;
+  int n, m;
+
+  while (1)
+    {
+      n = read (0, buffer, sizeof(buffer));
+      if (n == 0)
+        break;
+
+      if (n < 0)
+        {
+          perror("read");
+          exit (1);
+        }
+
+      ptr = buffer;
+      while (n > 0)
+        {
+          m = write (1, ptr, n);
+          if (m == 0)
+            {
+              fprintf(stderr, "write: closed\n");
+              exit (1);
+            }
+
+          if (m < 0)
+            {
+              int err = errno;
+              perror("write");
+              if (err != EAGAIN)
+                exit (1);
+              sleep(1);
+            }
+          else
+            {
+              n -= m;
+              ptr += m;
+            }
+        }
+    }
+
+  exit (0);
+}


### PR DESCRIPTION
Stdout/stderr are connected to something that fails big/fast writes
with EAGAIN sometimes.  To defend against this, we pass our output
through careful-cat, which handles EAGAIN.