### PR TITLE
test: Ignore erroneous RHEL SELinux denied in check-realms

### DIFF
--- a/test/check-realms
+++ b/test/check-realms
@@ -114,6 +114,9 @@ class TestRealms(MachineCase):
         b.click(".realms-op-cancel")
         b.wait_popdown("realms-op")
 
+        # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1256636
+        self.allow_journal_messages(".*type=1400 audit.*denied.*nsupdate.*nsswitch.conf.*realmd_var_lib_t.*")
+
 KRB5_TEMPLATE = """
 [logging]
  default = FILE:%(dir)s/krb5.log


### PR DESCRIPTION
Workaround for: https://bugzilla.redhat.com/show_bug.cgi?id=1256636