### PR TITLE
Prevent polkit agent from complaining during shutdown

### DIFF
--- a/src/bridge/cockpitpolkitagent.c
+++ b/src/bridge/cockpitpolkitagent.c
@@ -515,6 +515,13 @@ out:
 void
 cockpit_polkit_agent_unregister (gpointer handle)
 {
+  guint handler = 0;
+
+  /* Everything is shutting down at this point, prevent polkit from complaining */
+  handler = g_log_set_handler (NULL, G_LOG_LEVEL_WARNING, cockpit_null_log_handler, NULL);
+
   if (handle)
     polkit_agent_listener_unregister (handle);
+
+  g_log_remove_handler (NULL, handler);
 }


### PR DESCRIPTION
During bridge shutdown lots of stuff is going on, the dbus-daemon
is dying and polkit likes to complain about this. Make it be quiet.

Example message:

Error unregistering authentication agent: The connection is closed