### PR TITLE
More info in 'request timed out' message

### DIFF
--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -751,6 +751,7 @@ typedef struct {
   gint delayed_reply;
   CockpitWebServer *web_server;
   gboolean eof_okay;
+  gint num;
   GSource *source;
   GSource *timeout;
 } CockpitRequest;
@@ -1190,9 +1191,9 @@ on_request_timeout (gpointer data)
 {
   CockpitRequest *request = data;
   if (request->eof_okay)
-    g_debug ("request timed out, closing");
+    g_debug ("request %d timed out, closing", request->num);
   else
-    g_message ("request timed out, closing");
+    g_message ("request %d timed out, closing", request->num);
   cockpit_request_finish (request);
   return FALSE;
 }
@@ -1214,6 +1215,7 @@ cockpit_request_start (CockpitWebServer *self,
 
   /* Right before a successive request, EOF is not unexpected */
   request->eof_okay = !first;
+  request->num++;
 
   request->timeout = g_timeout_source_new_seconds (cockpit_webserver_request_timeout);
   g_source_set_callback (request->timeout, on_request_timeout, request, NULL);


### PR DESCRIPTION
This is for debugging failures, to see how browsers are
interacting with the requests.