### PR TITLE
Add backtrace handler to test-webservice to debug issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache: apt
 before_install:
   - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
   - sudo apt-get update -qq
-  - sudo apt-get install automake autoconf intltool xsltproc libglib2.0-dev libpolkit-gobject-1-dev libpolkit-agent-1-dev phantomjs gtk-doc-tools libjson-glib-dev libnm-glib-dev libpam0g-dev libssh-dev libsystemd-daemon-dev libsystemd-journal-dev libjson-perl libjavascript-minifier-xs-perl pkg-config glib-networking valgrind libkeyutils-dev xmlto xsltproc libpcp3-dev libpcp-pmda3-dev libpcp-import1-dev pcp liblvm2-dev libgudev-1.0-dev libgirepository1.0-dev
+  - sudo apt-get install automake autoconf intltool xsltproc libglib2.0-dev libpolkit-gobject-1-dev libpolkit-agent-1-dev phantomjs gtk-doc-tools libjson-glib-dev libnm-glib-dev libpam0g-dev libssh-dev libsystemd-daemon-dev libsystemd-journal-dev libjson-perl libjavascript-minifier-xs-perl pkg-config glib-networking valgrind libkeyutils-dev xmlto xsltproc libpcp3-dev libpcp-pmda3-dev libpcp-import1-dev pcp liblvm2-dev libgudev-1.0-dev libgirepository1.0-dev gdb
 
 script:
   - gcc ./tools/careful-cat.c -o careful-cat; set -o pipefail; (./autogen.sh --prefix=/usr --enable-strict && make V=1 all && sudo make enable-root-tests && make distcheck && make -j8 check-memory) 2>&1 | ./careful-cat

--- a/src/common/cockpittest.c
+++ b/src/common/cockpittest.c
@@ -39,6 +39,10 @@
 #include <netinet/ip6.h>
 #include <ifaddrs.h>
 
+#include <sys/select.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+
 /*
  * HACK: We can't yet use g_test_expect_message() and friends.
  * They were pretty broken until GLib 2.40 if you have any debug
@@ -466,20 +470,165 @@ _cockpit_assert_bytes_eq_msg (const char *domain,
                                expect, exp_len);
 }
 
+/*
+ * This gdb code only works if /proc/sys/kernel/yama/ptrace_scope is set to zero
+ * See: https://wiki.ubuntu.com/SecurityTeam/Roadmap/KernelHardening#ptrace%20Protection
+ */
+
+static gboolean stack_trace_done = FALSE;
+
+static void
+stack_trace_sigchld (int signum)
+{
+  stack_trace_done = TRUE;
+}
+
+static void
+stack_trace (char **args)
+{
+  pid_t pid;
+  int in_fd[2];
+  int out_fd[2];
+  fd_set fdset;
+  fd_set readset;
+  struct timeval tv;
+  int sel, idx, state;
+  char buffer[256];
+  char c;
+
+  stack_trace_done = FALSE;
+  signal (SIGCHLD, stack_trace_sigchld);
+
+  if ((pipe (in_fd) == -1) || (pipe (out_fd) == -1))
+    {
+      perror ("unable to open pipe");
+      _exit (0);
+    }
+
+  pid = fork ();
+  if (pid == 0)
+    {
+      /* Save stderr for printing failure below */
+      int old_err = dup (2);
+      fcntl (old_err, F_SETFD, fcntl (old_err, F_GETFD) | FD_CLOEXEC);
+
+      close (0); dup (in_fd[0]);   /* set the stdin to the in pipe */
+      close (1); dup (out_fd[1]);  /* set the stdout to the out pipe */
+
+      execvp (args[0], args);      /* exec gdb */
+
+      /* Print failure to original stderr */
+      perror ("exec gdb failed");
+      _exit (0);
+    }
+  else if (pid == (pid_t) -1)
+    {
+      perror ("unable to fork");
+      _exit (0);
+    }
+
+  FD_ZERO (&fdset);
+  FD_SET (out_fd[0], &fdset);
+
+  write (in_fd[1], "backtrace\n", 10);
+  write (in_fd[1], "quit\n", 5);
+
+  idx = 0;
+  state = 0;
+
+  while (1)
+    {
+      readset = fdset;
+      tv.tv_sec = 1;
+      tv.tv_usec = 0;
+
+      sel = select (FD_SETSIZE, &readset, NULL, NULL, &tv);
+      if (sel == -1)
+        break;
+
+      if ((sel > 0) && (FD_ISSET (out_fd[0], &readset)))
+        {
+          if (read (out_fd[0], &c, 1))
+            {
+              switch (state)
+                {
+                case 0:
+                  if (c == '#')
+                    {
+                      state = 1;
+                      idx = 0;
+                      buffer[idx++] = c;
+                    }
+                  break;
+                case 1:
+                  buffer[idx++] = c;
+                  if ((c == '\n') || (c == '\r'))
+                    {
+                      buffer[idx] = 0;
+                      fprintf (stderr, "%s", buffer);
+                      state = 0;
+                      idx = 0;
+                    }
+                  break;
+                default:
+                  break;
+                }
+            }
+        }
+      else if (stack_trace_done)
+        break;
+    }
+
+  close (in_fd[0]);
+  close (in_fd[1]);
+  close (out_fd[0]);
+  close (out_fd[1]);
+  _exit (0);
+}
+
+static void
+gdb_stack_trace (void)
+{
+  pid_t pid;
+  gchar buf[16];
+  gchar *args[4] = { "gdb", "-p", buf, NULL };
+  int status;
+
+  sprintf (buf, "%u", (guint) getpid ());
+
+  pid = fork ();
+  if (pid == 0)
+    {
+      stack_trace (args);
+      _exit (0);
+    }
+  else if (pid == (pid_t) -1)
+    {
+      perror ("unable to fork gdb");
+      return;
+    }
+
+  waitpid (pid, &status, 0);
+}
+
 void
 cockpit_test_signal_backtrace (int sig)
 {
   void *array[16];
   size_t size;
 
-  // get void*'s for all entries on the stack
+  signal (sig, SIG_DFL);
+
+  /* Try to trace with gdb first */
+  gdb_stack_trace ();
+
+  /* In case above didn't work, print raw stack trace */
   size = backtrace (array, G_N_ELEMENTS (array));
 
-  // print out all the frames to stderr
+  /* print out all the frames to stderr */
   fprintf (stderr, "Error: signal %s:\n", strsignal (sig));
   backtrace_symbols_fd (array, size, STDERR_FILENO);
 
-  signal (sig, SIG_DFL);
   raise (sig);
 }
 

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -2028,6 +2028,9 @@ main (int argc,
    */
   g_timeout_add_seconds (1, on_hack_raise_sigchld, NULL);
 
+  /* Try to debug crashing during tests */
+  signal (SIGSEGV, cockpit_test_signal_backtrace);
+
   /* We don't want to test the ping functionality in these tests */
   cockpit_ws_ping_interval = G_MAXUINT;
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -78,6 +78,7 @@ BuildRequires: glib2-devel >= 2.37.4
 BuildRequires: systemd-devel
 BuildRequires: polkit
 BuildRequires: pcp-libs-devel
+BuildRequires: gdb
 
 %if %{defined gitcommit}
 BuildRequires: npm


### PR DESCRIPTION
Produce better backtraces with gdb when possible
    
Note that this may require this sysctl to be set on the system:
    
    /proc/sys/kernel/yama/ptrace_scope = 0
    
https://wiki.ubuntu.com/SecurityTeam/Roadmap/KernelHardening#ptrace%20Protection
