### PR TITLE
WIP - Temporarily stop use of slice allocator in CockpitDBusCache

### DIFF
--- a/src/bridge/cockpitdbuscache.c
+++ b/src/bridge/cockpitdbuscache.c
@@ -28,6 +28,16 @@
 
 #define DEBUG_BATCHES 1
 
+/* While debugging a problem, disable the GSlice memory allocator */
+#undef g_slice_new
+#define g_slice_new(type) (g_malloc (sizeof (type)))
+
+#undef g_slice_new0
+#define g_slice_new0(type) (g_malloc0 (sizeof (type)))
+
+#undef g_slice_free
+#define g_slice_free(type, x) (g_free (x))
+
 /*
  * This is a cache of properties which tracks updates. The best way to do
  * this is via ObjectManager. But it also does introspection and uses that

--- a/src/ws/cockpit-testing.service.in
+++ b/src/ws/cockpit-testing.service.in
@@ -5,7 +5,7 @@ Requires=cockpit-testing.socket
 Conflicts=cockpit.service
 
 [Service]
-Environment=G_MESSAGES_DEBUG=cockpit-ws G_DEBUG=fatal-criticals
+Environment=G_MESSAGES_DEBUG=cockpit-ws G_DEBUG=fatal-criticals G_SLICE=always-malloc,debug-blocks
 ExecStart=@libexecdir@/cockpit-ws --no-tls
 User=@user@
 Group=@group@

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -921,6 +921,7 @@ pass_to_child (int signo)
 static const char *env_names[] = {
   "G_DEBUG",
   "G_MESSAGES_DEBUG",
+  "G_SLICE",
   NULL
 };
 


### PR DESCRIPTION
The system memory allocator has a lot more safeguards, and if we're
having memory corruption, as indicated in #2618, then we should use
it for now.