### PR TITLE
Run integration tests with G_SLICE=always-malloc

### DIFF
--- a/src/ws/cockpit-testing.service.in
+++ b/src/ws/cockpit-testing.service.in
@@ -5,7 +5,7 @@ Requires=cockpit-testing.socket
 Conflicts=cockpit.service
 
 [Service]
-Environment=G_MESSAGES_DEBUG=cockpit-ws G_DEBUG=fatal-criticals
+Environment=G_MESSAGES_DEBUG=cockpit-ws G_DEBUG=fatal-criticals G_SLICE=always-malloc,debug-blocks
 ExecStart=@libexecdir@/cockpit-ws --no-tls
 User=@user@
 Group=@group@

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -921,6 +921,7 @@ pass_to_child (int signo)
 static const char *env_names[] = {
   "G_DEBUG",
   "G_MESSAGES_DEBUG",
+  "G_SLICE",
   NULL
 };
 


### PR DESCRIPTION
As well as the debug-blocks option. This will give us much better
feedback if we have memory corruption, and it happens during testing.