### PR TITLE
Include valgrind and gdb in the test vms

### DIFF
--- a/test/cockpit.conf
+++ b/test/cockpit.conf
@@ -1,7 +1,7 @@
-{ 'tags': { 'fedora-22':         '17',
-            'rhel-7':            '7',
+{ 'tags': { 'fedora-22':         '18',
+            'rhel-7':            '8',
             'fedora-atomic-22':  '2',
-            'fedora-rawhide':    '3',
+            'fedora-rawhide':    '4',
             'fedora-22-testing': '3'
           }
 }

--- a/test/guest/cockpit-fedora-22.setup
+++ b/test/guest/cockpit-fedora-22.setup
@@ -16,7 +16,7 @@ COCKPIT_DEPS="udisks2 json-glib realmd glib-networking libssh selinux-policy-tar
 #
 IPA_CLIENT_PACKAGES="freeipa-client oddjob oddjob-mkhomedir sssd"
 
-TEST_PACKAGES="systemtap-runtime-virtguest"
+TEST_PACKAGES="systemtap-runtime-virtguest valgrind gdb"
 
 rm -rf /etc/sysconfig/iptables
 

--- a/test/guest/cockpit-fedora-rawhide.setup
+++ b/test/guest/cockpit-fedora-rawhide.setup
@@ -23,7 +23,7 @@ COCKPIT_DEPS="udisks2 json-glib realmd glib-networking libssh selinux-policy-tar
 #
 IPA_CLIENT_PACKAGES="freeipa-client oddjob oddjob-mkhomedir sssd"
 
-TEST_PACKAGES="systemtap-runtime-virtguest"
+TEST_PACKAGES="systemtap-runtime-virtguest valgrind gdb"
 
 rm -rf /etc/sysconfig/iptables
 

--- a/test/guest/cockpit-rhel-7.setup
+++ b/test/guest/cockpit-rhel-7.setup
@@ -62,6 +62,8 @@ sssd \
 
 TEST_PACKAGES="\
 systemtap-runtime-virtguest \
+valgrind
+gdb
 "
 
 yum install --nogpgcheck -y $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES

--- a/test/guest/cockpit-rhel-7.setup
+++ b/test/guest/cockpit-rhel-7.setup
@@ -1,13 +1,20 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # register system
 subscription-manager register --auto-attach --username=`cat ~/.rhel/login` --password=`cat ~/.rhel/pass`
 # remove credentials from test machine
 rm -rf ~/.rhel
 
-yum -y install wget yum-utils
+# These are in the magic base image but seem to have become
+# unavailable for some reason.
+#
+yum -y --disablerepo=rhel-7-server-rt-beta-rpms --disablerepo=rhel-sap-hana-for-rhel-7-server-rpms install yum-utils
+yum-config-manager --disable rhel-7-server-rt-beta-rpms
+yum-config-manager --disable rhel-sap-hana-for-rhel-7-server-rpms
+
+yum -y install wget
 cd /etc/yum.repos.d
 
 # we need the cockpit-preview copr for updated glib2


### PR DESCRIPTION
So that we can use it an a moments notice to debug a certain
pull request or use it in a backtrace.