### PR TITLE
Implement a pretty HTTP failure page

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -79,6 +79,7 @@ DISTCHECK_CONFIGURE_FLAGS=						        \
 
 AM_CPPFLAGS = \
 	-I$(top_builddir) \
+	-I$(top_builddir)/src \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src \
 	-DSRCDIR=\"$(abs_srcdir)\" \

--- a/pkg/base1/test-http.html
+++ b/pkg/base1/test-http.html
@@ -98,7 +98,7 @@ asyncTest("not found", function() {
             strictEqual(ex.problem, null, "mapped to cockpit code");
             strictEqual(ex.status, 404, "has status code");
             equal(ex.message, "Not Found", "has reason");
-            equal(data, "<html><head><title>404 Not Found</title></head><body>Not Found</body></html>", "got body");
+            equal(data, "<html><head><title>Not Found</title></head><body>Not Found</body></html>\n", "got body");
         })
         .always(function() {
             equal(this.state(), "rejected", "should fail");

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -37,10 +37,12 @@
 
 #include "deprecated/cockpitdbusjson1.h"
 
+#include "common/cockpitassets.h"
 #include "common/cockpitjson.h"
 #include "common/cockpitlog.h"
 #include "common/cockpitpipetransport.h"
 #include "common/cockpitunixfd.h"
+#include "common/cockpitwebresponse.h"
 
 #include <errno.h>
 #include <stdio.h>
@@ -486,6 +488,9 @@ run_bridge (const gchar *interactive)
   ssh_auth_sock = g_getenv ("SSH_AUTH_SOCK");
   if (ssh_auth_sock != NULL && ssh_auth_sock[0] != '\0')
       auth_address = g_unix_socket_address_new (ssh_auth_sock);
+
+  g_resources_register (cockpitassets_get_resource ());
+  cockpit_web_failure_resource = "/org/cockpit-project/Cockpit/fail.html";
 
   cockpit_channel_internal_address ("ssh-agent", auth_address);
 

--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -270,7 +270,7 @@ test_not_found (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_pop_channel (tc->transport, "444");
-  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{}}", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
 }
 
 static const Fixture fixture_unknown_package = {
@@ -289,7 +289,7 @@ test_unknown_package (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_pop_channel (tc->transport, "444");
-  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{}}", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
 }
 
 static const Fixture fixture_no_path = {
@@ -308,7 +308,7 @@ test_no_path (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_pop_channel (tc->transport, "444");
-  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{}}", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
 }
 
 static const Fixture fixture_bad_path = {
@@ -327,7 +327,7 @@ test_bad_path (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_pop_channel (tc->transport, "444");
-  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{}}", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
 }
 
 static const Fixture fixture_no_package = {
@@ -346,7 +346,7 @@ test_no_package (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_pop_channel (tc->transport, "444");
-  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{}}", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
 }
 
 static const Fixture fixture_bad_package = {
@@ -367,7 +367,7 @@ test_bad_package (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_pop_channel (tc->transport, "444");
-  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{}}", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
 }
 
 static void

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -10,18 +10,32 @@ test-dbus-generated.c: Makefile.am $(srcdir)/src/common/com.redhat.Cockpit.DBusT
 		$(srcdir)/src/common/com.redhat.Cockpit.DBusTests.xml \
 		$(NULL)
 
+src/common/cockpitassets.h: src/common/cockpitassets.gresource.xml
+	@$(MKDIR_P) $(dir $@)
+	$(AM_V_GEN) glib-compile-resources --target=$@ --generate-header --sourcedir=$(dir $<) $<
+src/common/cockpitassets.c: src/common/cockpitassets.gresource.xml src/common/fail.html
+	@$(MKDIR_P) $(dir $@)
+	$(AM_V_GEN) glib-compile-resources --target=$@ --generate-source --sourcedir=$(dir $<) $<
+
 test_built_sources = $(test_dbus_generated)
 mock_dbus_sources = \
 	src/common/mock-service.c \
 	src/common/mock-service.h \
 	$(NULL)
 
-BUILT_SOURCES += $(test_built_sources)
-CLEANFILES += $(test_built_sources)
+COCKPIT_ASSETS = \
+       src/common/cockpitassets.h \
+       src/common/cockpitassets.c \
+       $(NULL)
+
+BUILT_SOURCES += $(test_built_sources) $(COCKPIT_ASSETS)
+CLEANFILES += $(test_built_sources) $(COCKPIT_ASSETS)
 
 EXTRA_DIST += \
 	src/common/mock-content \
 	src/common/com.redhat.Cockpit.DBusTests.xml \
+	src/common/cockpitassets.gresource.xml \
+	src/common/fail.html \
 	$(NULL)
 
 noinst_LIBRARIES += libcockpit-common.a
@@ -68,6 +82,7 @@ libcockpit_common_a_SOURCES = \
 	src/common/cockpitwebserver.c \
 	src/common/cockpitconf.h \
 	src/common/cockpitconf.c \
+	$(COCKPIT_ASSETS)
 	$(NULL)
 
 libcockpit_common_a_CFLAGS = \
@@ -129,6 +144,7 @@ test_unixsignal_LDADD = $(libcockpit_common_a_LIBS)
 test_webresponse_SOURCES = \
 	src/common/test-webresponse.c \
 	src/common/mock-io-stream.c src/common/mock-io-stream.h \
+	$(COCKPIT_ASSETS) \
 	$(NULL)
 test_webresponse_CFLAGS = $(libcockpit_common_a_CFLAGS)
 test_webresponse_LDADD = $(libcockpit_common_a_LIBS)

--- a/src/common/cockpitassets.gresource.xml
+++ b/src/common/cockpitassets.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/org/cockpit-project/Cockpit/">
+    <file>fail.html</file>
+  </gresource>
+</gresources>

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -39,6 +39,8 @@ typedef struct _CockpitWebResponse        CockpitWebResponse;
 
 extern const gchar *  cockpit_web_exception_escape_root;
 
+extern const gchar *  cockpit_web_failure_resource;
+
 GType                 cockpit_web_response_get_type      (void) G_GNUC_CONST;
 
 CockpitWebResponse *  cockpit_web_response_new           (GIOStream *io,

--- a/src/common/fail.html
+++ b/src/common/fail.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>@@message@@</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+	body {
+            margin: 0;
+            font-family: "Open Sans", Helvetica, Arial, sans-serif;
+            font-size: 12px;
+            line-height: 1.66666667;
+            color: #333333;
+            background-color: #f5f5f5;
+        }
+        img {
+            border: 0;
+            vertical-align: middle;
+        }
+        h1 {
+            font-weight: 300;
+        }
+        p {
+            margin: 0 0 10px;
+        }
+        @font-face {
+            font-family: 'Open Sans';
+            font-style: normal;
+            font-weight: 300;
+            src: url('/cockpit/static/fonts/OpenSans-Light-webfont.woff') format('woff');
+        }
+        @font-face {
+            font-family: 'Open Sans';
+            font-style: normal;
+            font-weight: 400;
+            src: url('/cockpit/static/fonts/OpenSans-Regular-webfont.woff') format('woff');
+        }
+        .blank-slate-pf {
+            text-align: center;
+            padding: 90px 120px;
+        }
+    </style>
+</head>
+<body>
+    <div class="blank-slate-pf">
+        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAWGSURBVGiBzZtNaJxFGMd/z2R3YxHbtZa2pqdcPInS9CCUov3QiuhF2hIUjOZrd5NA9VoPuiJSTx6S0s27SVxJ8aOpPSgqpbZVlIIIJirqtRdNpBU3FUqhm53HQzZpPjfvm51J8oeFZd5n5v/8eWbemXfmGcETBgcHt1prm1S1CWgSkUZV3QIkgS0Vs5vAZOV3DRhV1VFr7Wh3d3fRh1/isrFcLrerrq7uKHBMVffW2P4fqjocj8fPtLe3jzty0Y3gfD7/pLX2hIjsB4yLNufAAleste90dXV9W2tjNQkOgmCfqr4lIgdrdSQMROSqtfbNTCZzedVtrKbSwMDAjnK5nBOR51dLXAtU9Yt4PJ5eTVePLDgIgmPAaWBb1LqOURSRV1Op1JkolUILHhkZSRSLxUHgpciu+cX7QCadTpfCGIcSPDQ0dF+pVDonIk/X5Jo/XAaOpNPpmysZrig4l8vtMsZcAB524ZlH/AI8k06nJ6oZVZ1Cent7NxtjvmTjiwV4FLhYKBSS1YyWjXBlzH4FHKrRkY82bdqUamlpuVXNaHh4+N7bt2/ngRdr5LsIPLfcmF42wsVisZ/axaKqV1YSC9DS0nJLVa/UygccZnoWWRJLCu7v728GWh2QIyKJCLb3uOAEOirT5yIsEhwEwTYR6XVEDFAfwdaVYIDTAwMDOxYWLhIsIjlgu0Pi0CKi9IYQ2Gat7VtYOE9wZW181CFpJBHWWpcRBjiWz+efmFswT7CIvO2YEFUN3aWNMVG6fyhYa9+YxzHzJwiCA6q63zUhEcawhwgjIgfnRnluhF93TVZBaBE+IgxgrT0xywEQBMGDwAEfZKq6nmMYABF5amhoqAHuRrgZqPNBFiVqviIMmFKpdAQqglW12RNRpJeWrwgDGGOaAczg4OBWEXnMF1GU1ZPHCKOqewuFQtJYa5twvHu5gCj0GI7SG1YBuXPnzm5jrd3jkSSSCIdr6eXa32NEZLdnktAiPEcYVd1tRKTRJwnr9/GwFBqNqlbdIXCAKIK9Rhi43zB91uMTGynCScPdgy1f2HARVs8kG0mwNUwfVfrERurSk4bpM1qfCCVYVQVwueOxFCY3TIT7+voSeFzxVVA0TJ+8+4TJZrOxEHa+xy+qes0Ao76Jdu7cueLiJpFIPOTbDxEZi6nqqIjfniQiP+bz+Z9VdWoZkzjQ5NWJaYzGYrHYWLlcVvyOn6Sn/bIo0EQiMWY6Ojr+BX5YZ2fWAldbW1snDYCInF1vb9YAZwFiAOVy+VNjzHu4z8ABQETax8fHP8hms3ap56oq+Xz+BeBDH/xAGTgPFYFdXV1/Ad94IqOaWAAR0YmJiU988QOXZw7KZyMqIu/6YqsmNorNamGtPTnzf1ZwKpW6BHzni3S9ICJX5ya0eT9bWm+IyNJnSzAb5c/X1COPEJHPOjs752UVLHorx+PxDuD6mnnlD/+USqXMwsJFgtva2m6o6mtr45M/iEhPT0/P3wvLl5x3M5nMxyIy7Io8m82uOL+HsYmAQiqVGlnqwbIkyWSy01FWDQ0NDa9UE6Sq0tDQ4Crz4BKQXu5h1Q+G3t7ezfX19d8Djzhyxjd+TyQS+1pbW5fd1KjajY4fP/6fMeZZ4DfnrrnHr7FY7HA1sRBi7dzZ2flnLBbbC1xw5pp7XAIeD5M/HTV9OA+8XItnHjAIdDtNH56LDZQgfl1EulOp1PkolVa1y5HL5baLSP96XQEAzsXj8Z62trYbUSvWfMkDyOIgCTUM1u2Sx0IEQXBARE6o6iHcbyKUga9V9WQmk6n5a87pxt2pU6ceiMfjR0SkxcFFrZ9E5IyqjqyU5R4F3nYqC4VCcmpqavYqnrW2UUSSTB/PzhzRzlzDK1K5igeMJhKJsZXm09XifyIP5eSF+BKpAAAAAElFTkSuQmC">
+        <h1>@@message@@</h1>
+    </div>
+</body>
+</html>

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -29,6 +29,7 @@
 #include "cockpitws.h"
 #include "cockpithandlers.h"
 
+#include "common/cockpitassets.h"
 #include "common/cockpitcertificate.h"
 #include "common/cockpitconf.h"
 #include "common/cockpitlog.h"
@@ -103,6 +104,10 @@ calculate_static_roots (GHashTable *os_release)
 
   /* Allow branding symlinks to escape these roots into /usr/share/pixmaps */
   cockpit_web_exception_escape_root = "/usr/share/pixmaps";
+
+  /* Load the fail template */
+  g_resources_register (cockpitassets_get_resource ());
+  cockpit_web_failure_resource = "/org/cockpit-project/Cockpit/fail.html";
 
   return roots;
 }

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -1617,9 +1617,14 @@ test_resource_not_found (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 404 Not Found\r\n"
-                           "Content-Length: 76\r\n"
-                           "\r\n"
-                           "<html><head><title>404 Not Found</title></head><body>Not Found</body></html>", -1);
+                           "Content-Type: text/html; charset=utf8\r\n"
+                           "Transfer-Encoding: chunked\r\n"
+                           "\r\n13\r\n"
+                           "<html><head><title>\r\n9\r\n"
+                           "Not Found\r\n15\r\n"
+                           "</title></head><body>\r\n9\r\n"
+                           "Not Found\r\nf\r\n"
+                           "</body></html>\n\r\n0\r\n\r\n", -1);
   g_bytes_unref (bytes);
   g_object_unref (response);
 }
@@ -1646,9 +1651,14 @@ test_resource_no_path (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 404 Not Found\r\n"
-                           "Content-Length: 76\r\n"
-                           "\r\n"
-                           "<html><head><title>404 Not Found</title></head><body>Not Found</body></html>", -1);
+                           "Content-Type: text/html; charset=utf8\r\n"
+                           "Transfer-Encoding: chunked\r\n"
+                           "\r\n13\r\n"
+                           "<html><head><title>\r\n9\r\n"
+                           "Not Found\r\n15\r\n"
+                           "</title></head><body>\r\n9\r\n"
+                           "Not Found\r\nf\r\n"
+                           "</body></html>\n\r\n0\r\n\r\n", -1);
   g_bytes_unref (bytes);
   g_object_unref (response);
 }
@@ -1683,9 +1693,14 @@ test_resource_failure (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 500 Internal Server Error\r\n"
-                           "Content-Length: 100\r\n"
-                           "\r\n"
-                           "<html><head><title>500 Internal Server Error</title></head><body>Internal Server Error</body></html>", -1);
+                           "Content-Type: text/html; charset=utf8\r\n"
+                           "Transfer-Encoding: chunked\r\n"
+                           "\r\n13\r\n"
+                           "<html><head><title>\r\n15\r\n"
+                           "Internal Server Error\r\n15\r\n"
+                           "</title></head><body>\r\n15\r\n"
+                           "Internal Server Error\r\nf\r\n"
+                           "</body></html>\n\r\n0\r\n\r\n", -1);
   g_bytes_unref (bytes);
   g_object_unref (response);
 }
@@ -1862,9 +1877,14 @@ test_resource_no_checksum (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 404 Not Found\r\n"
-                           "Content-Length: 76\r\n"
-                           "\r\n"
-                           "<html><head><title>404 Not Found</title></head><body>Not Found</body></html>", -1);
+                           "Content-Type: text/html; charset=utf8\r\n"
+                           "Transfer-Encoding: chunked\r\n"
+                           "\r\n13\r\n"
+                           "<html><head><title>\r\n9\r\n"
+                           "Not Found\r\n15\r\n"
+                           "</title></head><body>\r\n9\r\n"
+                           "Not Found\r\nf\r\n"
+                           "</body></html>\n\r\n0\r\n\r\n", -1);
   g_bytes_unref (bytes);
   g_object_unref (response);
 }
@@ -1891,9 +1911,14 @@ test_resource_bad_checksum (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 404 Not Found\r\n"
-                           "Content-Length: 76\r\n"
-                           "\r\n"
-                           "<html><head><title>404 Not Found</title></head><body>Not Found</body></html>", -1);
+                           "Content-Type: text/html; charset=utf8\r\n"
+                           "Transfer-Encoding: chunked\r\n"
+                           "\r\n13\r\n"
+                           "<html><head><title>\r\n9\r\n"
+                           "Not Found\r\n15\r\n"
+                           "</title></head><body>\r\n9\r\n"
+                           "Not Found\r\nf\r\n"
+                           "</body></html>\n\r\n0\r\n\r\n", -1);
   g_bytes_unref (bytes);
   g_object_unref (response);
 }


### PR DESCRIPTION
This is used in the case of 404's and such.

Uses the patternfly blank-slate styling, but we make sure that the page doesn't pull in anything external, except for fonts.