### PR TITLE
Install cockpit-networkmanager on Fedora Atomic

### DIFF
--- a/test/guest/fedora-atomic-22-x86_64-install_packages
+++ b/test/guest/fedora-atomic-22-x86_64-install_packages
@@ -24,7 +24,7 @@ import sys
 
 class AtomicCockpitInstaller:
     root_home = "/root"
-    packages_force_install = ["cockpit-test-assets", "cockpit-kubernetes"]
+    packages_force_install = ["cockpit-test-assets", "cockpit-kubernetes", "cockpit-networkmanager"]
 
     def __init__(self, rpms=None, verbose=False):
         self.verbose = verbose


### PR DESCRIPTION
We need to manually make this happen until Fedora does it for F23
and we start using Fedora 23 Atomic.

Filed Fedora bug:

https://bugzilla.redhat.com/show_bug.cgi?id=1258139