### PR TITLE
Use a simpler git version for configure.ac

### DIFF
--- a/tools/git-version-gen
+++ b/tools/git-version-gen
@@ -9,7 +9,7 @@ fi
 
 generate() {
 	if [ -d .git ]; then
-		git describe | sed 's/-[0-9]\+-g/-git/'
+		git describe | sed 's/-[0-9]\+-g.*/.x/'
 	else
 		cat $1
 	fi


### PR DESCRIPTION
Because configure.ac VERSION is not updated for every commit,
it's incorrect to include the commit id in the version number.
So just add '.x' if we're not right at a tag.

That is: ```0.73.x``` instead of ```0.73-git6f46301```

In addition, the latter version numbers are not compatible
with a whole bunch of packaging software (not that they're
usually released) because they include a '-'.