### PR TITLE
spec: Subpackage fixes

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -145,6 +145,8 @@ Requires: /usr/bin/date
 %if 0%{?rhel}
 Provides: %{name}-subscriptions = %{version}-%{release}
 Requires: subscription-manager >= 1.13
+Provides: %{name}-networkmanager = %{version}-%{release}
+Requires: NetworkManager
 %ifarch x86_64 armv7hl
 Provides: %{name}-docker = %{version}-%{release}
 Requires: docker >= 1.3.0
@@ -256,9 +258,9 @@ sed -i "s|%{buildroot}/usr/src/debug||" debug.list
 tar -C %{buildroot}/usr/src/debug -cf - . | tar -C %{buildroot} -xf -
 rm -rf %{buildroot}/usr/src/debug
 
-# On RHEL subscriptions and docker are part of the shell package
+# On RHEL subscriptions, networkmanager, and docker are part of the shell package
 %if 0%{?rhel}
-cat subscriptions.list docker.list >> shell.list
+cat subscriptions.list docker.list networkmanager.list >> shell.list
 %endif
 
 # Only strip out debug info in non wip builds
@@ -359,6 +361,15 @@ subscription management.
 
 %files subscriptions -f subscriptions.list
 
+%package networkmanager
+Summary: Cockpit user interface for networking, using NetworkManager
+Requires: NetworkManager
+
+%description networkmanager
+The Cockpit component for managing networking.  This package uses NetworkManager.
+
+%files networkmanager -f networkmanager.list
+
 %ifarch x86_64 armv7hl
 
 %package docker
@@ -397,15 +408,6 @@ Requires: storaged >= 2.1.1
 The Cockpit component for managing storage.  This package uses Storaged.
 
 %files storaged -f storaged.list
-
-%package networkmanager
-Summary: Cockpit user interface for networking, using NetworkManager
-Requires: NetworkManager
-
-%description networkmanager
-The Cockpit component for managing networking.  This package uses NetworkManager.
-
-%files networkmanager -f networkmanager.list
 
 %if %{defined gitcommit}
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -364,6 +364,7 @@ subscription management.
 %package networkmanager
 Summary: Cockpit user interface for networking, using NetworkManager
 Requires: NetworkManager
+BuildArch: noarch
 
 %description networkmanager
 The Cockpit component for managing networking.  This package uses NetworkManager.
@@ -403,6 +404,7 @@ cluster. Installed on the Kubernetes master. This package is not yet complete.
 %package storaged
 Summary: Cockpit user interface for storage, using Storaged
 Requires: storaged >= 2.1.1
+BuildArch: noarch
 
 %description storaged
 The Cockpit component for managing storage.  This package uses Storaged.

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -135,30 +135,6 @@ Requires: pcp
 %description pcp
 Cockpit support for reading PCP metrics and loading PCP archives.
 
-%package shell
-Summary: Cockpit Shell user interface package
-Requires: %{name}-bridge = %{version}-%{release}
-Requires: shadow-utils
-Requires: grep
-Requires: libpwquality
-Requires: /usr/bin/date
-%if 0%{?rhel}
-Provides: %{name}-subscriptions = %{version}-%{release}
-Requires: subscription-manager >= 1.13
-Provides: %{name}-networkmanager = %{version}-%{release}
-Requires: NetworkManager
-%ifarch x86_64 armv7hl
-Provides: %{name}-docker = %{version}-%{release}
-Requires: docker >= 1.3.0
-%endif
-%endif
-Provides: %{name}-assets
-Obsoletes: %{name}-assets < 0.32
-BuildArch: noarch
-
-%description shell
-This package contains the Cockpit shell UI assets.
-
 %package ws
 Summary: Cockpit Web Service
 Requires: glib-networking
@@ -313,8 +289,6 @@ cat subscriptions.list docker.list networkmanager.list >> shell.list
 # be out of sync with reality.
 /usr/share/pcp/lib/pmlogger reload
 
-%files shell -f shell.list
-
 %files ws
 %doc %{_mandir}/man5/cockpit.conf.5.gz
 %doc %{_mandir}/man8/cockpit-ws.8.gz
@@ -345,6 +319,42 @@ test -f %{_bindir}/firewall-cmd && firewall-cmd --reload --quiet || true
 
 %postun ws
 %systemd_postun_with_restart cockpit.socket
+
+%package shell
+Summary: Cockpit Shell user interface package
+Requires: %{name}-bridge = %{version}-%{release}
+Requires: shadow-utils
+Requires: grep
+Requires: libpwquality
+Requires: /usr/bin/date
+%if 0%{?rhel}
+Provides: %{name}-subscriptions = %{version}-%{release}
+Requires: subscription-manager >= 1.13
+Provides: %{name}-networkmanager = %{version}-%{release}
+Requires: NetworkManager
+%ifarch x86_64 armv7hl
+Provides: %{name}-docker = %{version}-%{release}
+Requires: docker >= 1.3.0
+%endif
+%endif
+Provides: %{name}-assets
+Obsoletes: %{name}-assets < 0.32
+BuildArch: noarch
+
+%description shell
+This package contains the Cockpit shell UI assets.
+
+%files shell -f shell.list
+
+%package storaged
+Summary: Cockpit user interface for storage, using Storaged
+Requires: storaged >= 2.1.1
+BuildArch: noarch
+
+%description storaged
+The Cockpit component for managing storage.  This package uses Storaged.
+
+%files storaged -f storaged.list
 
 # Conditionally built packages below
 
@@ -400,16 +410,6 @@ cluster. Installed on the Kubernetes master. This package is not yet complete.
 %files kubernetes -f kubernetes.list
 
 %endif
-
-%package storaged
-Summary: Cockpit user interface for storage, using Storaged
-Requires: storaged >= 2.1.1
-BuildArch: noarch
-
-%description storaged
-The Cockpit component for managing storage.  This package uses Storaged.
-
-%files storaged -f storaged.list
 
 %if %{defined gitcommit}
 


### PR DESCRIPTION
 * Add noarch where appropriate
 * cockpit-networkmanager is not a subpackage on RHEL.