### PR TITLE
spec: pam_ssh_add.so should be part of cockpit-ws

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -285,12 +285,10 @@ cat subscriptions.list docker.list >> shell.list
 
 %files bridge
 %doc %{_mandir}/man1/cockpit-bridge.1.gz
-%doc %{_mandir}/man8/pam_ssh_add.8.gz
 %{_bindir}/cockpit-bridge
 %attr(4755, -, -) %{_libexecdir}/cockpit-polkit
 %{_libexecdir}/cockpit-wrapper
 %{_libdir}/security/pam_reauthorize.so
-%{_libdir}/security/pam_ssh_add.so
 %{_datadir}/dbus-1/services/com.redhat.Cockpit.service
 
 %files doc
@@ -317,12 +315,14 @@ cat subscriptions.list docker.list >> shell.list
 %doc %{_mandir}/man5/cockpit.conf.5.gz
 %doc %{_mandir}/man8/cockpit-ws.8.gz
 %doc %{_mandir}/man8/remotectl.8.gz
+%doc %{_mandir}/man8/pam_ssh_add.8.gz
 %config(noreplace) %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/pam.d/cockpit
 %{_unitdir}/cockpit.service
 %{_unitdir}/cockpit.socket
 %{_prefix}/lib/firewalld/services/cockpit.xml
 %{_sbindir}/remotectl
+%{_libdir}/security/pam_ssh_add.so
 %{_libexecdir}/cockpit-ws
 %attr(4750, root, cockpit-ws) %{_libexecdir}/cockpit-session
 %attr(775, -, wheel) %{_localstatedir}/lib/%{name}


### PR DESCRIPTION
This file should be part of cockpit-ws and not cockpit-bridge
since, at least for the forseeable future, it will be used as
part of the cockpit PAM stack.