### PR TITLE
test: Increase the timeout for check-kubernetes starting a container

### DIFF
--- a/test/check-kubernetes
+++ b/test/check-kubernetes
@@ -110,7 +110,8 @@ class TestKubernetes(KubernetesCase):
         b.dialog_cancel("#node-dialog")
 
         # Make sure pod has started
-        b.wait_text("#service-list tr[data-name='mock']:first-of-type td.containers", "1")
+        with b.wait_timeout(120):
+            b.wait_text("#service-list tr[data-name='mock']:first-of-type td.containers", "1")
         b.click("#service-list tr[data-name='mock']:first-of-type")
 
         # Check that clicking on service goes to containers


### PR DESCRIPTION
We had a higher timeout in another test already. Make it consistent.