### PR TITLE
shell: Don't dereference an undefined during disconnect logic

### DIFF
--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -186,8 +186,8 @@ define([
 
     var watchdog = cockpit.channel({ "payload": "null" });
     $(watchdog).on("close", function(event, options) {
-        console.warn("transport closed: " + options.problem);
-        watchdog_problem = options.problem;
+        watchdog_problem = options.problem || "disconnected";
+        console.warn("transport closed: " + watchdog_problem);
         $('.modal[role="dialog"]').modal('hide');
         $('#disconnected-dialog').modal('show');
         phantom_checkpoint();


### PR DESCRIPTION
> transport closed: undefined
Page error: TypeError: 'undefined' is not an object (evaluating 'e.message')