### PR TITLE
test: Rebuild the IPA test fixture container

### DIFF
--- a/test/ipa.conf
+++ b/test/ipa.conf
@@ -1,5 +1,5 @@
 { 'mac': 'F0',
   'os':  'fedora-22',
-  'tags': { 'fedora-22': '0'
+  'tags': { 'fedora-22': '1'
           }
 }


### PR DESCRIPTION
Some of the certificates and account passwords were getting old.

