### PR TITLE
Hold reference during processing of messages

### DIFF
--- a/src/common/cockpitpipetransport.c
+++ b/src/common/cockpitpipetransport.c
@@ -81,6 +81,8 @@ on_pipe_read (CockpitPipe *pipe,
   guint32 i, size;
   gchar *data;
 
+  g_object_ref (self);
+
   for (;;)
     {
       size = 0;
@@ -135,6 +137,8 @@ on_pipe_read (CockpitPipe *pipe,
           cockpit_pipe_close (pipe, "internal-error");
         }
     }
+
+  g_object_unref (self);
 }
 
 static void

--- a/test/ipa.conf
+++ b/test/ipa.conf
@@ -1,5 +1,5 @@
 { 'mac': 'F0',
   'os':  'fedora-22',
-  'tags': { 'fedora-22': '0'
+  'tags': { 'fedora-22': '1'
           }
 }


### PR DESCRIPTION
This prevents use-after-free in tests, where a message triggers
the test completion.