### PR TITLE
Fix phantom-lib to correctly determine element visibility

### DIFF
--- a/test/check-docker
+++ b/test/check-docker
@@ -106,9 +106,9 @@ class TestDocker(MachineCase):
         b.set_val("#containers-run-image-name", "PROBE2")
         b.set_val("#containers-run-image-command", "/bin/echo '%s'" % (message))
         b.click("#containers-run-image-with-terminal");
-        b.wait_not_visible("#select-linked-containers");
+        b.wait_visible("#select-linked-containers:empty");
         b.click("#link-containers");
-        b.wait_visible("#select-linked-containers");
+        b.wait_visible("#select-linked-containers:parent");
         b.set_val("#select-linked-containers form:last-child select.selectpicker", "PROBE")
         b.set_val("#select-linked-containers form:last-child  input[name='alias']", "alias1")
         b.click("#select-linked-containers form:last-child  button.fa-plus");

--- a/test/check-kubernetes
+++ b/test/check-kubernetes
@@ -70,6 +70,7 @@ class TestKubernetes(KubernetesCase):
         m = self.machine
 
         self.login_and_go("/kubernetes/cluster", host=None)
+        b.wait_present("#node-list")
         b.wait_in_text("#node-list", "127.0.0.1")
 
         m.execute("kubectl create -f /tmp/mock-k8s-tiny-app.json")
@@ -158,6 +159,7 @@ class TestSsl(KubernetesCase):
         self.wait_api_server(port=6443, scheme='https')
 
         self.login_and_go("/kubernetes/cluster", host=None)
+        b.wait_present("#node-list")
         b.wait_in_text("#node-list", "127.0.0.1")
 
         # Check that this failed as a double check
@@ -190,6 +192,7 @@ class TestAuth(KubernetesCase):
         self.wait_api_server(port=6443, scheme='https')
 
         self.login_and_go("/kubernetes/cluster", host=None)
+        b.wait_present("#service-list")
         b.wait_in_text("#service-list", "You can deploy an application to your cluster.")
 
         # Check that this failed as a double check

--- a/test/check-openshift
+++ b/test/check-openshift
@@ -47,6 +47,7 @@ class TestOpenshift(MachineCase):
         b = self.browser
 
         self.login_and_go("/kubernetes/cluster", host=None)
+        b.wait_present("#service-list")
         b.wait_in_text("#service-list", "registry")
 
 test_main()

--- a/test/check-pages
+++ b/test/check-pages
@@ -47,10 +47,12 @@ WantedBy=default.target
         b.enter_page("/system/init")
         b.reload()
         b.enter_page("/system/init")
+        b.wait_present("#service-unit .panel-heading")
         b.wait_text("#service-unit .panel-heading", "Test Service")
 
         self.restart_cockpit()
         b.relogin("/system/init")
+        b.wait_present("#service-unit .panel-heading")
         b.wait_text("#service-unit .panel-heading", "Test Service")
 
         # Navigate inside an iframe

--- a/test/phantom-lib.js
+++ b/test/phantom-lib.js
@@ -131,7 +131,7 @@ function ph_set_checked (sel, val)
 function ph_is_visible (sel)
 {
     var el = ph_find(sel);
-    return !(el.offsetWidth <= 0 || el.offsetHeight <= 0);
+    return (el.offsetWidth > 0 || el.offsetHeight > 0);
 }
 
 function ph_is_present(sel)


### PR DESCRIPTION
Previously we were checking if either width or height are zero.
But this means that empty, visible elements were showing up
as visible. This causes all sorts of confusion.

Fix this to be correct, and fix up some tests that were relying
on this faulty behavior.

Also fix load race in various tests: Wait for the relevant pages to show up.