### PR TITLE
Add a Nulecule integration test

### DIFF
--- a/pkg/docker/docker.js
+++ b/pkg/docker/docker.js
@@ -108,6 +108,23 @@ define([
         return promise;
     };
 
+    /* Gets image info locally */
+    docker.inspect_image = function inspect_image(image) {
+        var dfd = $.Deferred();
+        http.get("/v1.12/images/" + encodeURIComponent(image) + "/json")
+            .done(function(data) {
+                dfd.resolve(JSON.parse(data));
+            })
+            .fail(function(ex) {
+                dfd.reject(ex);
+            });
+        var promise = dfd.promise();
+        promise.cancel = function cancel() {
+            return promise;
+        };
+        return promise;
+    };
+
     function DockerTerminal(parent, channel) {
         var self = this;
 

--- a/pkg/kubernetes/nulecule.js
+++ b/pkg/kubernetes/nulecule.js
@@ -19,8 +19,9 @@
 
 define([
     "jquery",
-    "base1/cockpit"
-], function($, cockpit) {
+    "base1/cockpit",
+    "docker/docker"
+], function($, cockpit, docker) {
     "use strict";
 
     var nulecule = { };
@@ -178,20 +179,55 @@ define([
             return promise;
         }
 
+        function ensure_image_exists(image) {
+            var deferred = $.Deferred();
+            docker.inspect_image(image)
+                .done(function(data) {
+                    deferred.resolve();
+                })
+                .fail(function(ex) {
+                    var tag = "latest";
+                    var tagl = image.split(":");
+                    if(tagl.length > 1)
+                        tag = tag[1];
+
+                    docker.pull(image, tag)
+                        .progress(function(msg) {
+                            deferred.notify(msg);
+                        })
+                        .done(function(d) {
+                            deferred.resolve();
+                        })
+                        .fail(function(ex) {
+                            deferred.reject(ex);
+                        });
+                });
+            return deferred.promise();
+        }
+
         function check_versions(image) {
             var deferred = $.Deferred();
             check_atomic_version()
                 .done(function() {
-                    check_nulecule_version(image)
-                        .done(function(version_info) {
-                            deferred.resolve(version_info);
+                    ensure_image_exists(image)
+                        .progress(function(msg) {
+                            deferred.notify(msg);
+                        })
+                        .done(function() {
+                            check_nulecule_version(image)
+                                .done(function(version_info) {
+                                    deferred.resolve(version_info);
+                                })
+                                .fail(function(err) {
+                                    deferred.reject(err);
+                                });
                         })
                         .fail(function(err) {
                             deferred.reject(err);
                         });
                 })
                 .fail(function(err) {
-                    deferred.reject(err);
+                    deferred.reject(new Error(_("Unable to pull Nulecule app image.")));
                 });
             var promise = deferred.promise();
             return promise;
@@ -285,6 +321,9 @@ define([
                 delete_tmp();
 
             check_versions(image)
+                .progress(function(msg){
+                    deferred.notify(msg);
+                })
                 .done(function(version_info) {
                     var atomicapp_version = version_info.atomicappversion.trim();
                     if ( atomicapp_version == MINIMUM_SUPPORTED_ATOMICAPP_VERSION ) {

--- a/test/check-kubernetes
+++ b/test/check-kubernetes
@@ -205,4 +205,62 @@ class TestConnection(KubernetesCase):
         output = m.execute("curl -k -sS https://localhost:6443/api 2>&1 || true")
         self.assertIn("Unauthorized", output)
 
+
+@unittest.skipIf("rhel-7" == os.environ.get("TEST_OS", ""), "Skipping check-nulecule on rhel-7.")
+class TestNulecule(KubernetesCase):
+    def setUp(self):
+        MachineCase.setUp(self)
+        m = self.machine
+
+        self.fix_apiserver_config()
+        m.execute("systemctl start etcd kube-apiserver kube-controller-manager kube-scheduler docker kube-proxy kubelet")
+
+        self.wait_api_server()
+
+    def testDeployDialog(self):
+        b = self.browser
+        m = self.machine
+        b.wait_timeout(120)
+
+        self.login_and_go("/kubernetes/cluster", host=None)
+        b.wait_present("#node-list")
+        b.wait_in_text("#node-list", "127.0.0.1")
+
+        # 1)check atomic version
+        output = m.execute("atomic -v")
+        self.assertTrue(output >= 1.1)
+
+        # 2) fail  invalid image
+        b.click("#deploy-app")
+        b.wait_popup("deploy-app-dialog")
+        b.set_val("#deploy-app-type", "nulecule")
+        b.set_val("#deploy-app-nulecule-image", "submod/helloapache1")
+        b.set_val("#deploy-app-namespace", "mynamespace")
+        b.click("#deploy-app-start")
+        b.dialog_complete("#deploy-app-dialog", result="fail")
+        b.dialog_cancel("#deploy-app-dialog")
+
+        # 3) pass when valid image
+        b.click("#deploy-app")
+        b.wait_popup("deploy-app-dialog")
+        b.set_val("#deploy-app-type", "nulecule")
+        b.set_val("#deploy-app-nulecule-image", "submod/helloapache")
+        b.set_val("#deploy-app-namespace", "mynamespace")
+        b.click("#deploy-app-start")
+        self.allow_journal_messages('Could not find any image matching "submod/helloapache".')
+        b.wait_not_attr("#deploy-app-start", "disabled", "disabled")
+        b.dialog_cancel("#deploy-app-dialog")
+
+        # 4) fail when atomic is not installed
+        m.needs_writable_usr()
+        m.execute("rm /usr/bin/atomic")
+        b.click("#deploy-app")
+        b.wait_popup("deploy-app-dialog")
+        b.set_val("#deploy-app-type", "nulecule")
+        b.set_val("#deploy-app-nulecule-image", "submod/helloapache")
+        b.set_val("#deploy-app-namespace", "mynamespace")
+        b.click("#deploy-app-start")
+        b.dialog_complete("#deploy-app-dialog", result="fail")
+        b.dialog_cancel("#deploy-app-dialog")
+
 test_main()


### PR DESCRIPTION
Pushing this again for testing.

 * Pull image before validating with atomic info
 * Don't throw away atomic install/run output

Closes #2683
Closes #2663
Fixes #2557
Fixes #2624

Signed-off-by: Stef Walter <stefw@redhat.com>
 * Don't use dnf to get rid of atomic during testing, as dnf
   is not available on Atomic
 * Fix up style problems
 * Fix atomic version comparison