### PR TITLE
Fix regression displaying account on system

### DIFF
--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -739,7 +739,6 @@ PageAccount.prototype = {
            })
            .fail(function() {
                self.lastLogin = null;
-               self.account = null;
                self.update();
            });
     },


### PR DESCRIPTION
This happens on atomic where lastlog fails. We shouldn't be clearing account info in this case.