### PR TITLE
Ignore 'authentication-failed' when retrieving plot data

### DIFF
--- a/pkg/shell/plot.js
+++ b/pkg/shell/plot.js
@@ -520,8 +520,12 @@ shell.plot = function plot(element, x_range_seconds, x_stop_seconds) {
 
         function channel_closed(ev, options, desc) {
             real_time_channel = null;
-            if (options.problem && options.problem != "terminated" && options.problem != "disconnected")
+            if (options.problem &&
+                options.problem != "terminated" &&
+                options.problem != "disconnected" &&
+                options.problem != "authentication-failed") {
                 console.log("problem retrieving " + desc + " metrics data: " + options.problem);
+            }
         }
 
         real_time_channel = channel_sampler($.extend({ }, chanopts, {


### PR DESCRIPTION
This happens when servers are not set up correctly, and is not
a plot related failure. Just ends up being noise.