### PR TITLE
reauthorize: Don't complain about revoked keys

### DIFF
--- a/src/reauthorize/reauthorize.c
+++ b/src/reauthorize/reauthorize.c
@@ -570,8 +570,8 @@ lookup_reauthorize_secret (const char *user,
   key = keyctl_search (KEY_SPEC_SESSION_KEYRING, "user", name, 0);
   if (key < 0)
     {
-      /* missing key is not an error */
-      if (errno == ENOKEY)
+      /* missing key or revoked key is not an error */
+      if (errno == ENOKEY || errno == EKEYREVOKED)
         {
           ret = 0;
           *secret = NULL;


### PR DESCRIPTION
We see these when the kernel keyring has not been populated
with a key (due to SSH auth for example). It's not an error.