### PR TITLE
kubernetes: Only display the last lines of container logs

### DIFF
--- a/test/check-kubernetes
+++ b/test/check-kubernetes
@@ -173,6 +173,13 @@ class TestKubernetes(KubernetesCase):
         b.wait_present("#content .containers-listing tbody tr th")
         self.assertEqual(b.text("#content .containers-listing tbody:first-of-type tr th"), "mock-container")
 
+        # Check that container log output shows up
+        b.click("#content .containers-listing tbody:first-of-type tr th")
+        b.click("#content .listing-panel li a:contains('Logs')")
+        b.wait_present(".listing-panel pre.logs")
+        b.wait_visible(".listing-panel pre.logs")
+        b.wait_in_text(".listing-panel pre.logs", "HelloMessage.")
+
         # Check that service shows up on listing view
         b.click("a[href='#/list']")
         b.wait_present("#content .details-listing")

--- a/test/files/mock-k8s-tiny-app.json
+++ b/test/files/mock-k8s-tiny-app.json
@@ -26,7 +26,7 @@
                   "containers":[{
                     "name": "mock-container",
                     "image": "busybox:buildroot-2014.02",
-                    "command": [ "/bin/sleep", "1000" ],
+                    "command": [ "/bin/sh", "-c", "for x in $(seq 1 1000); do echo 'HelloMessage.' >&2; sleep 1; done" ],
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"


### PR DESCRIPTION
Otherwise this completely overwhelms the browser.

We wish we could have kubernetes or kubectl do this, but they're
not capable of it yet:

https://github.com/kubernetes/kubernetes/issues/12447

Also add more to the integration test to see container log output.