### PR TITLE
test: Mark flavor in the network-cockpit.xml

### DIFF
--- a/test/README
+++ b/test/README
@@ -138,19 +138,16 @@ IP address.  This means that you can launch multiple test machines
 from a single image, maybe to use multiple machines inside a single
 test case, or to run multiple test cases in parallel.
 
-If you want a fixed MAC for a given flavor, you can create the
-"guest/FLAVOR.conf" file in this directory with a content like this:
+If you want a fixed MAC for a given flavor, you can set a cockpit:flavor
+attribute in the guest/network-cockpit.xml file, like this:
 
-    { 'mac': "F0" }
+	<host mac='52:54:00:9e:00:F0'
+		ip='10.111.111.100'
+		name='f0.cockpit.lan'
+		cockpit:flavor="ipa"/>
 
 Whenever a test machine of the flavor is launched, it will receive
 this MAC, and you can thus only run one of them at any given time.
-
-If you specify only two hex-digits with the "mac" configuration
-option, a default prefix will be used.  The suffices "F0", "F1", "F2",
-"F3", and "F4" will be assigned the fixed IP addresses 10.111.111.100
-to 10.111.111.104.  DNS will resolve "f0.cockpit.lan",
-"f1.cockpit.lan", etc to these addresses.
 
 A test machine image created by vm-create doesn't contain any Cockpit
 code in it yet.  You can build and install the currently checked out

--- a/test/guest/ipa.conf
+++ b/test/guest/ipa.conf
@@ -1,4 +1,4 @@
-{ "mac": "F0",
+{
   "os":  "fedora-22",
   "tags": { "fedora-22": "2"
           }

--- a/test/guest/network-cockpit.xml
+++ b/test/guest/network-cockpit.xml
@@ -10,7 +10,7 @@
 	<mac address='52:54:00:b8:d2:b5'/>
 	<domain name='cockpit.lan'/>
 	<ip address='10.111.111.200' netmask='255.255.255.0'>
-		<dhcp>
+		<dhcp xmlns:cockpit="urn:cockpit-project.org:cockpit">
                         <host mac='52:54:00:9e:00:00' ip='10.111.111.10'   name='m10.cockpit.lan'/>
                         <host mac='52:54:00:9e:00:01' ip='10.111.111.11'   name='m11.cockpit.lan'/>
                         <host mac='52:54:00:9e:00:02' ip='10.111.111.12'   name='m12.cockpit.lan'/>
@@ -28,8 +28,10 @@
                         <host mac='52:54:00:9e:00:0e' ip='10.111.111.24'   name='m24.cockpit.lan'/>
                         <host mac='52:54:00:9e:00:0f' ip='10.111.111.25'   name='m25.cockpit.lan'/>
 
-                        <host mac='52:54:00:9e:00:F0' ip='10.111.111.100' name='f0.cockpit.lan'/>
-                        <host mac='52:54:00:9e:00:F1' ip='10.111.111.101' name='f1.cockpit.lan'/>
+			<host mac='52:54:00:9e:00:F0' ip='10.111.111.100' name='f0.cockpit.lan'
+				cockpit:flavor="ipa"/>
+			<host mac='52:54:00:9e:00:F1' ip='10.111.111.101' name='f1.cockpit.lan'
+				cockpit:flavor="openshift"/>
                         <host mac='52:54:00:9e:00:F2' ip='10.111.111.102' name='f2.cockpit.lan'/>
                         <host mac='52:54:00:9e:00:F3' ip='10.111.111.103' name='f3.cockpit.lan'/>
                         <host mac='52:54:00:9e:00:F4' ip='10.111.111.104' name='f4.cockpit.lan'/>

--- a/test/guest/openshift.conf
+++ b/test/guest/openshift.conf
@@ -1,4 +1,4 @@
-{ "mac": "F1",
+{
   "os":  "fedora-22",
   "tags": { "fedora-22": "0"
           }

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -461,15 +461,6 @@ class Machine:
             messages = [ ]
         return messages
 
-def highest_version(names, os):
-    # XXX - maybe use the "rpm" module.
-
-    names = filter(lambda n: not "rescue" in n, names)
-    sorted = subprocess.check_output("echo '%s' | rpmdev-sort" % "\n".join(names),
-                                     shell=True).split("\n")
-    sorted = filter(lambda n: not n == "", sorted)
-    return sorted[len(sorted)-1]
-
 class QemuMachine(Machine):
     macaddr_prefix = "52:54:00:9e:00"
 

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -462,8 +462,6 @@ class Machine:
         return messages
 
 class QemuMachine(Machine):
-    macaddr_prefix = "52:54:00:9e:00"
-
     def __init__(self, **args):
         Machine.__init__(self, **args)
         self.run_dir = os.path.join(self.test_dir, "run")
@@ -938,7 +936,12 @@ class QemuMachine(Machine):
 
     def add_netiface(self, mac, vlan=0):
         if len(mac) == 2:
-            mac = self.macaddr_prefix + ":" + mac
+            tree = etree.parse(open("./network-cockpit.xml"))
+            for h in tree.find(".//dhcp"):
+                macaddr = h.get("mac")
+                if macaddr:
+                    mac = macaddr[:-2] + mac
+                    break
         self._monitor_qemu("device_add e1000,vlan=%s,mac=%s" % (vlan,mac));
         return mac
 


### PR DESCRIPTION
This is a step in the direction of cleaning up the various flavor
JSON, image tags and revisions.