### PR TITLE
Don't complain about ioctl when 'make check' on non TTY

### DIFF
--- a/tools/tap-driver
+++ b/tools/tap-driver
@@ -60,8 +60,9 @@ def terminal_width():
             fcntl.ioctl(1, termios.TIOCGWINSZ,
             struct.pack('HHHH', 0, 0, 0, 0)))
         return w
-    except:
-        print >> sys.stderr, sys.exc_info()
+    except IOError, (errno, strerror):
+        if errno != 25: # ENOTTY
+            print >> sys.stderr, errno, strerror, sys.exc_info()
         return sys.maxint;
 
 class Driver:


### PR DESCRIPTION
Removes warnings like this:

```
(<type 'exceptions.IOError'>, IOError(25, 'Inappropriate ioctl for device'), <traceback object at 0x3ffb4fbe4d0>)
```

https://bugzilla.redhat.com/show_bug.cgi?id=1261196