### PR TITLE
Add a data-key attribute to Kubernetes Listing

### DIFF
--- a/pkg/kubernetes/client.js
+++ b/pkg/kubernetes/client.js
@@ -884,6 +884,13 @@ define([
             if (prev && prev.metadata.resourceVersion === version)
                 return;
 
+            /* Place this on the item as a hidden property */
+            Object.defineProperty(item, 'key', {
+                enumerable: false,
+                configurable: false,
+                value: key
+            });
+
             var version = meta.resourceVersion;
             if (version && version > self.resourceVersion)
                 self.resourceVersion = version;

--- a/pkg/kubernetes/test-kubernetes.html
+++ b/pkg/kubernetes/test-kubernetes.html
@@ -574,7 +574,7 @@ require([
     });
 
     asyncTest("list nodes", function() {
-        expect(3);
+        expect(6);
 
         var client = kubernetes.k8client();
         client.watches.nodes.wait().always(function() {
@@ -583,6 +583,14 @@ require([
             var node = nodes["Node:f530580d-a169-11e4-8651-10c37bdb8410"];
             equal(node.metadata.name, "127.0.0.1", "localhost node");
             equal(typeof node.spec.capacity, "object", "node has resources");
+
+            /* Check basic key behavior */
+            equal(node.key, "Node:f530580d-a169-11e4-8651-10c37bdb8410", "key is set correctly");
+
+            /* Key should not be encoded as JSON */
+            var parsed = JSON.parse(JSON.stringify(node));
+            ok(!("key" in parsed), "key should not be serialized")
+            strictEqual(parsed.key, undefined, "key not be undefined after serialize");
 
             client.close();
             start();


### PR DESCRIPTION
This allows code like action buttons to correctly identify the item that a row in the listing refers to.