### PR TITLE
kubernetes: Track container state correctly

### DIFF
--- a/pkg/kubernetes/views/container-panel.html
+++ b/pkg/kubernetes/views/container-panel.html
@@ -21,7 +21,7 @@
                 </kube-console>
             </div>
         </tab>
-        <tab heading="Shell" select="connect('shell')">
+        <tab heading="Shell" select="connect('shell')" ng-if="container.status.state.running">
             <div class="panel-body">
                 <kube-shell namespace="{{item.metadata.namespace}}"
                     pod="{{item.metadata.name}}"

--- a/pkg/kubernetes/views/container-panel.html
+++ b/pkg/kubernetes/views/container-panel.html
@@ -5,7 +5,7 @@
             <i class="fa fa-cube"></i>
         </div>
         <div class="listing-status">
-            {{item.status.phase}}
+            <span ng-repeat="(state, value) in container.status.state">{{state}}</span>
         </div>
     </div>
     <h3 class="listing-title" ng-click="select(id)">{{container.spec.name}}</h3>

--- a/pkg/kubernetes/views/containers-page.html
+++ b/pkg/kubernetes/views/containers-page.html
@@ -20,7 +20,7 @@
                 <td>{{item.metadata.name}}</td>
                 <td>{{item.metadata.namespace}}</td>
                 <td>{{item.spec.nodeName}}</td>
-                <td>{{item.status.phase}}</td>
+                <td><span ng-repeat="(name, value) in container.status.state">{{name}}</span></td>
             </tr>
             <tr ng-repeat-end class="listing-panel" ng-if="selected(id)">
                 <td cockpit-listing-panel kind="Container" colspan="5">


### PR DESCRIPTION
 * Only show the shell view if the container is running
 * Show actual container state, not Pod state