### PR TITLE
common: Use local socket address when checking for localhost

### DIFF
--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -1143,7 +1143,7 @@ on_socket_input (GSocket *socket,
     {
       is_tls = FALSE;
       redirect_tls = TRUE;
-      addr = g_socket_connection_get_remote_address (G_SOCKET_CONNECTION (request->io), NULL);
+      addr = g_socket_connection_get_local_address (G_SOCKET_CONNECTION (request->io), NULL);
       if (G_IS_INET_SOCKET_ADDRESS (addr))
         {
           inet = g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS (addr));


### PR DESCRIPTION
When we check for a local connection (and don't require TLS redirection) check that the local socket address is in the localhost netblock.

Previously we used the remote address, but machines are technically free to choose a non local address as the source address.

The local networks (like 127.0.0.0/8) are explicitly not routable off machine. Therefore this does not present a security issue.

This manifested itself in a failure of the /web-server/no-redirect-localhost test.