### PR TITLE
Added Alt-Origin in order to allow a trusted alternative origin (settable in /etc/cockpit/alt_origin)

### DIFF
--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -1755,11 +1755,26 @@ create_web_socket_server_for_stream (const gchar **protocols,
                          query ? query : "");
 
   origins = cockpit_conf_strv ("WebService", "Origins", ' ');
+  
   if (origins == NULL)
     {
       origin = g_strdup_printf ("%s://%s", secure ? "https" : "http", host);
+      
+      GError *error = NULL;
+      gsize len;
+      gchar *alt_origin = NULL;
+      g_file_get_contents ("/etc/cockpit/alt_origin", &alt_origin, &len, &error);
+      
+      size_t ln = strlen(alt_origin) - 1;
+      if(alt_origin[ln] == '\n')
+          alt_origin[ln] = '\0';
+
+      g_message("AltOrigin: %s", alt_origin);
+    
+
       defaults[0] = origin;
-      defaults[1] = NULL;
+      defaults[1] = alt_origin;
+      defaults[2] = NULL;
       origins = (const gchar **)defaults;
     }
 


### PR DESCRIPTION
By doing this we could set a "trusted origin" in order to fix the #2053 issue and any other apache related error.

httpd configuration (it does work with the patch)
```
<VirtualHost *:443>
ServerName cockpit.sv1
ProxyPreserveHost On

#Socket proxy
ProxyPass /socket "wss://127.0.0.1:9090/socket"

#General app proxy
ProxyPass / http://127.0.0.1:9090/
ProxyPassReverse / http://127.0.0.1:9090/

</VirtualHost>
```