### PR TITLE
common: Move COCKPIT_CONFIG_FILE definition

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -276,9 +276,6 @@ AC_DEFINE_UNQUOTED([PATH_SSH_ADD], ["$SSH_ADD"], [Location of ssh-add binary])
 AC_PATH_PROG([SSH_AGENT], [ssh-agent], [/usr/bin/ssh-agent], [$PATH:/usr/local/bin:/usr/bin:/bin])
 AC_DEFINE_UNQUOTED([PATH_SSH_AGENT], ["$SSH_AGENT"], [Location of ssh-agent binary])
 
-# Config
-AC_DEFINE_UNQUOTED([COCKPIT_CONFIG_FILE],["$sysconfdir/cockpit/cockpit.conf"],[Configuration file])
-
 changequote(,)dnl
 if test "x$GCC" = "xyes"; then
   CFLAGS="-Wall \

--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -65,7 +65,7 @@
 
           <informalexample>
             <programlisting language="js">
-[Webservice]
+[WebService]
 Origins = https://somedomain1.com https://somedomain2.com:9090
             </programlisting>
           </informalexample>

--- a/src/common/cockpitconf.c
+++ b/src/common/cockpitconf.c
@@ -23,7 +23,7 @@
 
 static GHashTable *cockpit_conf = NULL;
 static GHashTable *cached_strvs = NULL;
-const gchar *cockpit_config_file = COCKPIT_CONFIG_FILE;
+const gchar *cockpit_config_file = PACKAGE_SYSCONF_DIR "/cockpit/cockpit.conf";
 
 static gboolean
 load_key_file (const gchar *file_path,

--- a/test/check-connection
+++ b/test/check-connection
@@ -121,4 +121,11 @@ class TestConnection(MachineCase):
             ".*Peer failed to perform TLS handshake",
             ".*Error performing TLS handshake: Could not negotiate a supported cipher suite.")
 
+    def testConfigOrigins(self):
+        m = self.machine
+        self.start_cockpit()
+        m.execute('echo "[WebService]\nOrigins = http://other-origin:9090 http://localhost:9090" > /etc/cockpit/cockpit.conf')
+        m.execute('curl -s -f -N -H "Connection: Upgrade" -H "Upgrade: websocket" -H "Origin: http://other-origin:9090" -H "Host: localhost:9090" -H "Sec-Websocket-Key: 3sc2c9IzwRUc3BlSIYwtSA==" -H "Sec-Websocket-Version: 13" http://localhost:9090/socket')
+        self.allow_journal_messages('peer did not close io when expected')
+
 test_main()


### PR DESCRIPTION
We need prefix to be expanded properly, so better to set this using AM_CPPFLAGS