### PR TITLE
systemd: Only render units that have loaded successfully

### DIFF
--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -641,8 +641,8 @@ define([
                 if (cur_unit_id == unit_id) {
                     var unit = systemd_client.proxy('org.freedesktop.systemd1.Unit', path);
                     cur_unit = unit;
-                    unit.wait(function () {
-                        if (cur_unit == unit) {
+                    unit.wait(function() {
+                        if (unit.valid && cur_unit == unit) {
                             render();
                             $(cur_unit).on('changed', render);
                             $("#service-valid").show();

--- a/pkg/systemd/service.js
+++ b/pkg/systemd/service.js
@@ -70,12 +70,19 @@ define([
     var systemd_client;
     var systemd_manager;
 
+    function wait_valid(proxy, callback) {
+        proxy.wait(function() {
+            if (proxy.valid)
+                callback();
+        });
+    }
+
     function with_systemd_manager(done) {
         if (!systemd_manager) {
             systemd_client = cockpit.dbus("org.freedesktop.systemd1", { superuser: "try" });
             systemd_manager = systemd_client.proxy("org.freedesktop.systemd1.Manager",
                                                    "/org/freedesktop/systemd1");
-            systemd_manager.wait(function () {
+            wait_valid(systemd_manager, function() {
                 systemd_manager.Subscribe().
                     fail(function (error) {
                         if (error.name != "org.freedesktop.systemd1.AlreadySubscribed")
@@ -83,7 +90,7 @@ define([
                     });
             });
         }
-        systemd_manager.wait(done);
+        wait_valid(systemd_manager, done);
     }
 
     function proxy(name) {
@@ -135,7 +142,7 @@ define([
                 done(function (path) {
                     unit = systemd_client.proxy('org.freedesktop.systemd1.Unit', path);
                     $(unit).on('changed', update_from_unit);
-                    unit.wait(update_from_unit);
+                    wait_valid(unit, update_from_unit);
                 }).
                 fail(function (error) {
                     self.exists = false;


### PR DESCRIPTION
Symptom is:

```
TypeError: 'undefined' is not an object (evaluating 'p.LoadError[1]')
```