### PR TITLE
Never reconnect a cockpit transport

### DIFF
--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -43,14 +43,6 @@ function is_array(it) {
     return Object.prototype.toString.call(it) === '[object Array]';
 }
 
-function BasicError(problem, message) {
-    this.problem = problem;
-    this.message = message || cockpit.message(problem);
-    this.toString = function() {
-        return this.message;
-    };
-}
-
 /* -------------------------------------------------------------------------
  * Channels
  *
@@ -994,6 +986,14 @@ function basic_scope(cockpit) {
 
 
 function full_scope(cockpit, $, po) {
+
+    function BasicError(problem, message) {
+        this.problem = problem;
+        this.message = message || cockpit.message(problem);
+        this.toString = function() {
+            return this.message;
+        };
+    }
 
     /* ---------------------------------------------------------------------
      * User and system information

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -438,8 +438,6 @@ function Transport() {
     };
 
     self.close = function close(options) {
-        if (self === default_transport)
-            default_transport = null;
         if (!options)
             options = { "problem": "disconnected" };
         options.command = "close";
@@ -529,13 +527,11 @@ function Transport() {
     self.send_data = function send_data(data) {
         if (!ws) {
             console.log("transport closed, dropped message: ", data);
-        } else if (ws.readyState != 1) {
-            console.log("transport not ready (" + ws.readyState + "), dropped message: ", data);
+            return false;
         } else {
             ws.send(data);
             return true;
         }
-        return false;
     };
 
     self.send_message = function send_message(channel, payload) {
@@ -970,6 +966,8 @@ function basic_scope(cockpit) {
             if (problem)
                 options = {"problem": problem };
             default_transport.close(options);
+            default_transport = null;
+            this.options = { };
         },
         origin: origin,
         options: { },

--- a/pkg/base1/test-chan.html
+++ b/pkg/base1/test-chan.html
@@ -56,15 +56,13 @@ function MockPeer() {
     this.close = function(options) { throw "not reached"; };
 }
 
-window.mock = { url: "ws://url", last_transport: true };
+window.mock = { url: "ws://url" };
 var force_default_host = null;
 var mock_peer = new MockPeer();
 
 QUnit.testDone(function() {
     mock_peer = new MockPeer();
-    if (window.mock.last_transport)
-        window.mock.last_transport.close();
-    window.mock.last_transport = null;
+    cockpit.transport.close();
 });
 
 /* Mock WebSocket */

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -164,7 +164,7 @@ define([
 
     $("#disconnected-dialog").on("show.bs.modal", function() {
         /* Try to reconnect right away ... so that reconnect button has a chance */
-        cockpit.channel({ payload: "null" });
+        new window.WebSocket(cockpit.transport.uri(), "cockpit1");
         $('#disconnected-error').text(cockpit.message(watchdog_problem));
         phantom_checkpoint();
     });

--- a/pkg/shell/machines.js
+++ b/pkg/shell/machines.js
@@ -577,7 +577,7 @@ define([
 
     module.known_hosts_path = known_hosts_path;
 
-    $(cockpit.info).on("changed", function () {
+    cockpit.transport.wait(function() {
         var caps = cockpit.transport.options.capabilities || [];
         module.allow_connection_string = $.inArray("connection-string", caps) != -1;
         module.has_auth_results = $.inArray("auth-method-results", caps) != -1;

--- a/test/check-shutdown-restart
+++ b/test/check-shutdown-restart
@@ -49,8 +49,7 @@ class TestShutdownRestart(MachineCase):
         # we don't need to wait for the dialog to close here, just the disconnect
         b.wait_popup("disconnected-dialog")
         m.wait_reboot()
-        self.start_cockpit()
-        b.relogin("/system")
+        self.login_and_go("/system")
 
         self.allow_restart_journal_messages()
         self.allow_journal_messages("Shutdown scheduled for .*")

--- a/test/vm-run
+++ b/test/vm-run
@@ -17,10 +17,13 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
+import os
 import sys
 
 import testvm
 import testinfra
+
+BASE = os.path.dirname(__file__)
 
 parser = argparse.ArgumentParser(description='Run a test machine')
 parser.add_argument('-v', '--verbose', action='store_true', help='Display verbose details')
@@ -32,6 +35,7 @@ parser.add_argument('image', nargs='?', default=testinfra.DEFAULT_IMAGE, help='T
 args = parser.parse_args()
 
 try:
+    os.chdir(BASE)
     machine = testvm.VirtMachine(verbose=args.verbose, image=args.image)
     machine.qemu_console(maintain=args.maintain,
                          memory_mb=args.memory,


### PR DESCRIPTION
We have to refresh the page anyway in order to get things back to a consistent state, even if we avoid logging in again.

Opening the transport again automatically simply leads to races during shutdown, reboot, or problem conditions.