### PR TITLE
Show a warning when adding too many machines

### DIFF
--- a/branding/rhel/branding.css
+++ b/branding/rhel/branding.css
@@ -46,3 +46,14 @@ body.login-pf {
     left: 0px;
 }
 
+.dashboard-machine-warning {
+    display: block !important;
+}
+
+.dashboard-machine-limit span {
+    display: none
+}
+
+.dashboard-machine-limit:after {
+    content: "5";
+}

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -1027,6 +1027,10 @@ function full_scope(cockpit, $, po) {
         }
     });
 
+    /* ------------------------------------------------------------------------
+     * Override for broken browser behavior
+     */
+
     document.addEventListener("click", function(ev) {
         if ($(ev.target).hasClass('disabled'))
           ev.stopPropagation();

--- a/pkg/dashboard/list.html
+++ b/pkg/dashboard/list.html
@@ -23,6 +23,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="../base1/cockpit.css" rel="stylesheet">
+    <link href="../../static/branding.css" rel="stylesheet">
     <link href="../shell/shell.css" rel="stylesheet">
     <script src="../base1/bundle.js"></script>
     <script src="../shell/bundle.js"></script>
@@ -206,7 +207,12 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <div class="spinner spinner-sm pull-left" id="dashboard_setup_spinner" hidden></div>
+                    <div class="alert alert-warning dialog-error dashboard-machine-warning">
+                        <span class="pficon pficon-warning-triangle-o"></span>
+                        Connecting simultaneously to more than
+                        <span class="dashboard-machine-limit"><span>20</span></span>
+                        machines is unsupported.
+                    </div>
                     <button class="btn btn-default" id="dashboard_setup_prev">Previous</button>
                     <button class="btn btn-primary" id="dashboard_setup_next">Next</button>
                 </div>

--- a/pkg/dashboard/list.js
+++ b/pkg/dashboard/list.js
@@ -1009,6 +1009,8 @@ function PageSetupServer() {
 
 function host_setup(machines) {
     PageSetupServer.machines = machines;
+    var limit = parseInt($(".dashboard-machine-limit").text(), 10);
+    $('.dashboard-machine-warning').toggle(limit * 0.75 <= machines.list.length);
     $('#dashboard_setup_server_dialog').modal('show');
 }
 

--- a/pkg/dashboard/manifest.json
+++ b/pkg/dashboard/manifest.json
@@ -7,5 +7,7 @@
             "label": "Dashboard",
             "order": 0
         }
-    }
+    },
+
+    "limit": 5
 }

--- a/pkg/shell/shell.css
+++ b/pkg/shell/shell.css
@@ -169,6 +169,11 @@ html, body {
     min-width: 55px;
 }
 
+/* This warning is not displayed by default */
+.dashboard-machine-warning {
+    display: none;
+}
+
 /* Make the time range buttons equal width */
 
 #dashboard-range-buttons button {


### PR DESCRIPTION
Show a warning when adding too many machines to the dashboard.
We can reasonably expect about 20 to work well. The underlying
technology could support somewhat more, around 100 or so.
But the UI needs work to get to there.

In addition RHEL has requested that there be a warning about 5
machines on RHEL.