### PR TITLE
HTML injection in cockpit-ws instead of cockpit-bridge

### DIFF
--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -4,7 +4,6 @@
     <title>Cockpit</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <base href="/cockpit/@@base@@/shell/index.html">
     <link href="../base1/cockpit.css" rel="stylesheet">
     <link href="../../static/branding.css" rel="stylesheet">
     <link href="shell.css" rel="stylesheet">

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -78,6 +78,10 @@ libcockpit_common_a_SOURCES = \
 	src/common/cockpitunixfd.h \
 	src/common/cockpitunixsignal.c \
 	src/common/cockpitunixsignal.h \
+	src/common/cockpitwebfilter.h \
+	src/common/cockpitwebfilter.c \
+	src/common/cockpitwebinject.h \
+	src/common/cockpitwebinject.c \
 	src/common/cockpitwebresponse.h \
 	src/common/cockpitwebresponse.c \
 	src/common/cockpitwebserver.h \

--- a/src/common/cockpitwebfilter.c
+++ b/src/common/cockpitwebfilter.c
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitwebfilter.h"
+
+/**
+ * CockpitWebFilter
+ *
+ * A filter used to filter the output of a CockpitWebResponse.
+ */
+
+typedef CockpitWebFilterIface CockpitWebFilterInterface;
+G_DEFINE_INTERFACE (CockpitWebFilter, cockpit_web_filter, 0);
+
+static void
+cockpit_web_filter_default_init (CockpitWebFilterIface *iface)
+{
+
+}
+
+/**
+ * cockpit_web_filter_push:
+ * @filter: filter to push a block of bytes into
+ * @queue: block of bytes to filter
+ * @function: filter calls this function with bytes generated
+ * @data: value to pass to function
+ *
+ * Called to send data through a filter. The filter should call
+ * the @function with any data it generates. If the filter wants
+ * to pass through the @queue data, then it needs to call @function
+ * with it.
+ */
+void
+cockpit_web_filter_push (CockpitWebFilter *filter,
+                         GBytes *queue,
+                         void (* function) (gpointer, GBytes *),
+                         gpointer data)
+{
+  CockpitWebFilterIface *iface;
+
+  iface = COCKPIT_WEB_FILTER_GET_IFACE (filter);
+  g_return_if_fail (iface != NULL);
+
+  g_assert (iface->push);
+  (iface->push) (filter, queue, function, data);
+}

--- a/src/common/cockpitwebfilter.h
+++ b/src/common/cockpitwebfilter.h
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COCKPIT_WEB_FILTER_H__
+#define COCKPIT_WEB_FILTER_H__
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define COCKPIT_TYPE_WEB_FILTER            (cockpit_web_filter_get_type ())
+#define COCKPIT_WEB_FILTER(inst)            (G_TYPE_CHECK_INSTANCE_CAST ((inst), COCKPIT_TYPE_WEB_FILTER, CockpitWebFilter))
+#define COCKPIT_IS_WEB_FILTER(inst)         (G_TYPE_CHECK_INSTANCE_TYPE ((inst), COCKPIT_TYPE_WEB_FILTER))
+#define COCKPIT_WEB_FILTER_GET_IFACE(inst)  (G_TYPE_INSTANCE_GET_INTERFACE ((inst), COCKPIT_TYPE_WEB_FILTER, CockpitWebFilterIface))
+
+typedef struct _CockpitWebFilter CockpitWebFilter;
+typedef struct _CockpitWebFilterIface CockpitWebFilterIface;
+
+struct _CockpitWebFilterIface {
+  GTypeInterface parent_iface;
+
+  void       (* push)            (CockpitWebFilter *filter,
+                                  GBytes *block,
+                                  void (* function) (gpointer, GBytes *),
+                                  gpointer data);
+};
+
+GType               cockpit_web_filter_get_type     (void) G_GNUC_CONST;
+
+void                cockpit_web_filter_push         (CockpitWebFilter *filter,
+                                                     GBytes *queue,
+                                                     void (* function) (gpointer, GBytes *),
+                                                     gpointer data);
+
+G_END_DECLS
+
+#endif /* COCKPIT_WEB_FILTER_H__ */

--- a/src/common/cockpitwebinject.c
+++ b/src/common/cockpitwebinject.c
@@ -1,0 +1,179 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitwebinject.h"
+
+#include <string.h>
+
+/**
+ * CockpitWebInject
+ *
+ * This is a CockpitWebFilter which looks for a marker data
+ * and inject additional data after that point. The data is
+ * not injected more than once.
+ */
+struct _CockpitWebInject {
+  GObject parent;
+  goffset partial;
+  GBytes *marker;
+  GBytes *inject;
+};
+
+typedef struct _CockpitInjectClass {
+  GObjectClass parent_class;
+} CockpitWebInjectClass;
+
+static void cockpit_web_filter_inject_iface (CockpitWebFilterIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (CockpitWebInject, cockpit_web_inject, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (COCKPIT_TYPE_WEB_FILTER, cockpit_web_filter_inject_iface)
+)
+
+static void
+cockpit_web_inject_init (CockpitWebInject *self)
+{
+
+}
+
+static void
+cockpit_web_inject_finalize (GObject *object)
+{
+  CockpitWebInject *self = COCKPIT_WEB_INJECT (object);
+
+  if (self->marker)
+    g_bytes_unref (self->marker);
+  if (self->inject)
+    g_bytes_unref (self->inject);
+
+  G_OBJECT_CLASS (cockpit_web_inject_parent_class)->finalize (object);
+}
+
+static void
+cockpit_web_inject_class_init (CockpitWebInjectClass *klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+  gobject_class->finalize = cockpit_web_inject_finalize;
+}
+
+static void
+cockpit_web_inject_push (CockpitWebFilter *filter,
+                         GBytes *block,
+                         void (* function) (gpointer, GBytes *),
+                         gpointer func_data)
+{
+  CockpitWebInject *self = (CockpitWebInject *)filter;
+  const gchar *mark, *data, *pos;
+  gsize mark_len, data_len, at;
+  GBytes *bytes;
+
+  /* Stop searching once injected */
+  if (self->inject)
+    {
+      mark = g_bytes_get_data (self->marker, &mark_len);
+      data = g_bytes_get_data (block, &data_len);
+      at = 0;
+
+      while (at < data_len)
+        {
+          if (self->partial)
+            pos = data + at;
+          else
+            pos = memchr (data + at, mark[0], data_len - at);
+
+          /* Couldn't find the character anywhere? */
+          if (!pos)
+            break;
+
+          for (at = (pos - data); self->partial < mark_len && at < data_len; self->partial++, at++)
+            {
+              if (mark[self->partial] != data[at])
+                break;
+            }
+
+          /* Found a match */
+          if (self->partial == mark_len)
+            {
+              self->partial = 0;
+
+              bytes = g_bytes_new_from_bytes (block, 0, at);
+              function (func_data, bytes);
+              g_bytes_unref (bytes);
+
+              function (func_data, self->inject);
+              g_bytes_unref (self->inject);
+              self->inject = NULL;
+
+              bytes = g_bytes_new_from_bytes (block, at, data_len - at);
+              function (func_data, bytes);
+              g_bytes_unref (bytes);
+
+              block = NULL;
+              break;
+            }
+
+          /* Incomplete match, and more data */
+          else if (at < data_len)
+            {
+              self->partial = 0;
+            }
+        }
+    }
+
+  if (block)
+    function (func_data, block);
+}
+
+static void
+cockpit_web_filter_inject_iface (CockpitWebFilterIface *iface)
+{
+  iface->push = cockpit_web_inject_push;
+}
+
+/**
+ * cockpit_web_filter_new:
+ * @marker: marker to search for
+ * @inject: bytes to inject after marker
+ *
+ * Create a new CockpitWebFilter which injects @inject bytes
+ * after the @marker. It injects the data once.
+ *
+ * Returns: A new CockpitWebFilter
+ */
+CockpitWebFilter *
+cockpit_web_inject_new (const gchar *marker,
+                        GBytes *inject)
+{
+  CockpitWebInject *self;
+  gsize len;
+
+  g_return_val_if_fail (marker != NULL, NULL);
+  g_return_val_if_fail (inject != NULL, NULL);
+
+  len = strlen (marker);
+  g_return_val_if_fail (len > 0, NULL);
+
+  self = g_object_new (COCKPIT_TYPE_WEB_INJECT, NULL);
+  self->marker = g_bytes_new (marker, len);
+  self->inject = g_bytes_ref (inject);
+
+  return COCKPIT_WEB_FILTER (self);
+}

--- a/src/common/cockpitwebinject.h
+++ b/src/common/cockpitwebinject.h
@@ -1,0 +1,40 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COCKPIT_WEB_INJECT_H__
+#define COCKPIT_WEB_INJECT_H__
+
+#include "common/cockpitwebfilter.h"
+
+G_BEGIN_DECLS
+
+#define COCKPIT_TYPE_WEB_INJECT         (cockpit_web_inject_get_type ())
+#define COCKPIT_WEB_INJECT(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_WEB_INJECT, CockpitWebInject))
+#define COCKPIT_IS_WEB_INJECT(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_WEB_INJECT))
+
+typedef struct _CockpitWebInject CockpitWebInject;
+
+GType               cockpit_web_inject_get_type     (void) G_GNUC_CONST;
+
+CockpitWebFilter *  cockpit_web_inject_new          (const gchar *marker,
+                                                     GBytes *inject);
+
+G_END_DECLS
+
+#endif /* COCKPIT_WEB_INJECT_H__ */

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -26,6 +26,7 @@
 #include "config.h"
 
 #include "cockpitwebresponse.h"
+#include "cockpitwebfilter.h"
 
 #include "common/cockpiterror.h"
 #include "common/cockpittemplate.h"
@@ -81,6 +82,8 @@ struct _CockpitWebResponse {
   gboolean done;
   gboolean chunked;
   gboolean keep_alive;
+
+  GList *filters;
 };
 
 typedef struct {
@@ -141,6 +144,8 @@ cockpit_web_response_dispose (GObject *object)
 
   if (!self->done)
     cockpit_web_response_done (self);
+  g_list_free_full (self->filters, g_object_unref);
+  self->filters = NULL;
 
   G_OBJECT_CLASS (cockpit_web_response_parent_class)->dispose (object);
 }
@@ -409,6 +414,69 @@ queue_bytes (CockpitWebResponse *self,
     }
 }
 
+static void
+queue_block (CockpitWebResponse *self,
+             GBytes *block)
+{
+  gsize length = g_bytes_get_size (block);
+  GBytes *bytes;
+  gchar *data;
+
+  /*
+   * We cannot queue chunks of length zero. Besides being silly, this
+   * messes with chunked encoding. The 0 length block means end of
+   * response.
+   */
+  if (length == 0)
+    return;
+
+  g_debug ("%s: queued %d bytes", self->logname, (int)length);
+
+  if (!self->chunked)
+    {
+      queue_bytes (self, block);
+    }
+  else
+    {
+      /* Required for chunked transfer encoding. */
+      data = g_strdup_printf ("%x\r\n", (unsigned int)length);
+      bytes = g_bytes_new_take (data, strlen (data));
+      queue_bytes (self, bytes);
+      g_bytes_unref (bytes);
+
+      queue_bytes (self, block);
+
+      bytes = g_bytes_new_static ("\r\n", 2);
+      queue_bytes (self, bytes);
+      g_bytes_unref (bytes);
+    }
+}
+
+typedef struct {
+  CockpitWebResponse *response;
+  GList *filters;
+} QueueStep;
+
+static void
+queue_filter (gpointer data,
+              GBytes *bytes)
+{
+  QueueStep *qs = data;
+  QueueStep qn = { .response = qs->response };
+
+  g_return_if_fail (bytes != NULL);
+
+  if (qs->filters)
+    {
+      qn.filters = qs->filters->next;
+      cockpit_web_filter_push (qs->filters->data, bytes, queue_filter, &qn);
+    }
+  else
+    {
+      queue_block (qs->response, bytes);
+    }
+}
+
 /**
  * cockpit_web_response_queue:
  * @self: the response
@@ -433,9 +501,7 @@ gboolean
 cockpit_web_response_queue (CockpitWebResponse *self,
                             GBytes *block)
 {
-  gchar *data;
-  GBytes *bytes;
-  gsize length;
+  QueueStep qn = { .response = self };
 
   g_return_val_if_fail (COCKPIT_IS_WEB_RESPONSE (self), FALSE);
   g_return_val_if_fail (block != NULL, FALSE);
@@ -447,36 +513,8 @@ cockpit_web_response_queue (CockpitWebResponse *self,
       return FALSE;
     }
 
-  length = g_bytes_get_size (block);
-  g_debug ("%s: queued %d bytes", self->logname, (int)length);
-
-  /*
-   * We cannot queue chunks of length zero. Besides being silly, this
-   * messes with chunked encoding. The 0 length block means end of
-   * response.
-   */
-  if (length == 0)
-    return TRUE;
-
-  if (!self->chunked)
-    {
-      queue_bytes (self, block);
-    }
-  else
-    {
-      /* Required for chunked transfer encoding. */
-      data = g_strdup_printf ("%x\r\n", (unsigned int)g_bytes_get_size (block));
-      bytes = g_bytes_new_take (data, strlen (data));
-      queue_bytes (self, bytes);
-      g_bytes_unref (bytes);
-
-      queue_bytes (self, block);
-
-      bytes = g_bytes_new_static ("\r\n", 2);
-      queue_bytes (self, bytes);
-      g_bytes_unref (bytes);
-    }
-
+  qn.filters = self->filters;
+  queue_filter (&qn, block);
   return TRUE;
 }
 
@@ -708,10 +746,10 @@ finish_headers (CockpitWebResponse *self,
 
   if (status != 304)
     {
-      if (length >= 0)
+      if (length >= 0 && !self->filters)
         g_string_append_printf (string, "Content-Length: %" G_GSSIZE_FORMAT "\r\n", length);
 
-      if (length < 0 || seen & HEADER_CONTENT_ENCODING)
+      if (length < 0 || seen & HEADER_CONTENT_ENCODING || self->filters)
         {
           self->chunked = TRUE;
           g_string_append_printf (string, "Transfer-Encoding: chunked\r\n");
@@ -1226,6 +1264,16 @@ cockpit_web_response_pop_path (CockpitWebResponse *self)
     return g_strdup (beg);
   else
     return NULL;
+}
+
+void
+cockpit_web_response_add_filter (CockpitWebResponse *self,
+                                 CockpitWebFilter *filter)
+{
+  g_return_if_fail (COCKPIT_IS_WEB_RESPONSE (self));
+  g_return_if_fail (COCKPIT_IS_WEB_FILTER (filter));
+  g_return_if_fail (self->count == 0);
+  self->filters = g_list_append (self->filters, g_object_ref (filter));
 }
 
 /**

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -22,6 +22,8 @@
 
 #include <gio/gio.h>
 
+#include "cockpitwebfilter.h"
+
 G_BEGIN_DECLS
 
 #define COCKPIT_TYPE_WEB_RESPONSE         (cockpit_web_response_get_type ())
@@ -57,6 +59,9 @@ GIOStream *           cockpit_web_response_get_stream    (CockpitWebResponse *se
 CockpitWebResponding  cockpit_web_response_get_state     (CockpitWebResponse *self);
 
 gchar *               cockpit_web_response_pop_path      (CockpitWebResponse *self);
+
+void                  cockpit_web_response_add_filter    (CockpitWebResponse *self,
+                                                          CockpitWebFilter *filter);
 
 void                  cockpit_web_response_headers       (CockpitWebResponse *self,
                                                           guint status,

--- a/src/static/login.html
+++ b/src/static/login.html
@@ -10,9 +10,7 @@
         var phantom_checkpoint = phantom_checkpoint || function () { };
 
         (function(console) {
-
-            /* Filled in by cockpit-ws handler */
-            var initial_environment = @@environment@@;
+            var environment = window.environment || { };
 
             function unquote(str) {
                 str = str.trim();
@@ -61,7 +59,7 @@
                     if ((content[0] === '"' || content[0] === '\'') &&
                         len > 2 && content[len - 1] === content[0])
                         content = content.substr(1, len - 2);
-                    elt.innerHTML = format(content, initial_environment["os-release"]) || def;
+                    elt.innerHTML = format(content, environment["os-release"]) || def;
                 }
             }
 
@@ -100,7 +98,7 @@
                 if (!requisites())
                     return;
 
-                var os_release = JSON.stringify(initial_environment["os-release"]);
+                var os_release = JSON.stringify(environment["os-release"]);
                 localStorage.setItem('os-release', os_release);
 
                 /* Try automatic/kerberos authentication? */
@@ -144,9 +142,9 @@
 
             function show_login() {
                 /* Show the login screen */
-                document.title = initial_environment.hostname;
+                document.title = environment.hostname;
                 var b = document.createElement("b");
-                b.appendChild(document.createTextNode(initial_environment.hostname));
+                b.appendChild(document.createTextNode(environment.hostname));
                 id("server-name").appendChild(b);
                 id("login").style.visibility = 'visible';
                 id("login-user-input").focus();

--- a/tools/unknown.supp
+++ b/tools/unknown.supp
@@ -417,3 +417,14 @@
    fun:start_thread
    fun:clone
 }
+{
+   gcov_exit
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:gcov_do_dump
+   fun:gcov_exit
+   fun:__run_exit_handlers
+   fun:exit
+   fun:(below main)
+}


### PR DESCRIPTION
In order to pass certain values (like ```<base>```) to the javascript code, we have to inject it into the HTML. If we're going to fix #1788 then we need to do this in cockpit-ws, rather than cockpit-bridge.

This pull requests implements a filter in CockpitWebResponse which can perform these sorts of tasks. In the future we can also use this filter functionality to do on the fly gzip compression for non compressed resources if we want to.

It would actually be awesome if we could read avoid HTML injection all together and just use headers. Unfortunately javascript can access pretty much zero of the headers of the response, with the exception of cookies.