### PR TITLE
Some fixes to our setuid processes

### DIFF
--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -441,6 +441,9 @@ run_bridge (const gchar *interactive)
       g_setenv ("SHELL", pwd->pw_shell, TRUE);
     }
 
+  /* Reset the umask, typically this is done in .bashrc for a login shell */
+  umask (022);
+
   /*
    * This process talks on stdin/stdout. However lots of stuff wants to write
    * to stdout, such as g_debug, and uses fd 1 to do that. Reroute fd 1 so that

--- a/src/bridge/cockpitpolkithelper.c
+++ b/src/bridge/cockpitpolkithelper.c
@@ -28,6 +28,7 @@
 #include <polkit/polkit.h>
 
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <err.h>
 #include <errno.h>
 #include <pwd.h>
@@ -102,6 +103,9 @@ main (int argc, char *argv[])
 
   /* set a minimal environment */
   setenv ("PATH", "/usr/sbin:/usr/bin:/sbin:/bin", 1);
+
+  /* Cleanup the umask */
+  umask (077);
 
   /* check that we are setuid root */
   if (geteuid () != 0)

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -30,13 +30,15 @@
 #include <string.h>
 
 #include <security/pam_appl.h>
+
+#include <sys/types.h>
 #include <sys/signal.h>
+#include <sys/stat.h>
 #include <sys/resource.h>
 #include <dirent.h>
 #include <sched.h>
 #include <utmp.h>
 #include <unistd.h>
-#include <sys/types.h>
 #include <pwd.h>
 #include <sys/wait.h>
 #include <grp.h>
@@ -963,6 +965,9 @@ main (int argc,
 
   if (argc != 3)
     errx (2, "invalid arguments to cockpit-session");
+
+  /* Cleanup the umask */
+  umask (077);
 
   save_environment ();
 


### PR DESCRIPTION
Trying to run the host PAM stack is a deadend. There's far too many places where this can fall over. So this code will likely never be used successfully, lets remove it.
    
This is not currently in use in the cockpit-ws privileged container.

In addition, add umask() calls to setuid processes. This makes for more predictable behavior in these security sensitive processes.
