### PR TITLE
Fix the authentication not supported message

### DIFF
--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -2314,6 +2314,8 @@ function full_scope(cockpit, $, po) {
             return _("Not permitted to perform this action.");
         else if (problem == "authentication-failed")
             return _("Login failed");
+        else if (problem == "authentication-not-supported")
+            return _("The server refused to authenticate using any supported methods.");
         else if (problem == "unknown-hostkey")
             return _("Untrusted host");
         else if (problem == "internal-error")

--- a/src/static/login.html
+++ b/src/static/login.html
@@ -198,7 +198,7 @@
                     } else if (xhr.status == 401) {
                         if (window.console)
                             console.log(xhr.statusText);
-                        if (xhr.statusText.indexOf("not-supported") > -1) {
+                        if (xhr.statusText.indexOf("authentication-not-supported") > -1) {
                             var user = trim(id("login-user-input").value);
                             fatal("The server refused to authenticate '" + user + "' using password authentication, and no other supported authentication methods are available.");
                         } else {

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -684,12 +684,12 @@ on_remote_login_done (CockpitSshTransport *transport,
                                            COCKPIT_ERROR_AUTHENTICATION_FAILED,
                                            "Authentication failed");
         }
-      else if (g_str_equal (problem, "not-supported") ||
+      else if (g_str_equal (problem, "authentication-not-supported") ||
                g_str_equal (problem, "no-forwarding"))
         {
           g_simple_async_result_set_error (task, COCKPIT_ERROR,
                                            COCKPIT_ERROR_AUTHENTICATION_FAILED,
-                                           "Authentication failed: no-supported-methods");
+                                           "Authentication failed: authentication-not-supported");
         }
       else
         {

--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -452,7 +452,7 @@ cockpit_ssh_authenticate (CockpitSshData *data)
       g_message ("%s: server offered unsupported authentication methods: %s",
                  data->logname, description);
       g_free (description);
-      problem = "not-supported";
+      problem = "authentication-not-supported";
     }
   else if (!password && gsscreds == GSS_C_NO_CREDENTIAL)
     {

--- a/src/ws/test-sshtransport.c
+++ b/src/ws/test-sshtransport.c
@@ -477,7 +477,7 @@ test_unsupported_auth (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   g_assert_cmpstr (result, ==, problem);
-  g_assert_cmpstr (problem, ==, "not-supported");
+  g_assert_cmpstr (problem, ==, "authentication-not-supported");
   g_free (problem);
   g_free (result);
 }

--- a/test/check-loopback
+++ b/test/check-loopback
@@ -32,4 +32,14 @@ class TestLoopback(MachineCase):
         m.spawn("/usr/libexec/cockpit-ws --local-ssh --no-tls", "cockpit-ws");
         b.login_and_go("/system", user="admin")
 
+        m.execute("sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config")
+
+        b.logout()
+        b.wait_visible("#login")
+        b.set_val('#login-user-input', "admin")
+        b.set_val('#login-password-input', "foobar")
+        b.click('#login-button')
+        b.wait_visible('#login-fatal')
+        self.assertIn("The server refused to authenticate 'admin' using password authentication, and no other supported authentication methods are available.", b.text('#login-fatal'));
+
 test_main()


### PR DESCRIPTION
This wasn't working correctly. In addition since not-supported is
used when talking to older cockpit versions, this resulted in
conflicting uses of the problem code.