### PR TITLE
Fix the hang of test-kerberos when it fails

### DIFF
--- a/src/common/cockpittest.c
+++ b/src/common/cockpittest.c
@@ -187,6 +187,7 @@ void
 cockpit_test_init (int *argc,
                    char ***argv)
 {
+  static gchar path[2048];
   gchar *basename;
 
   signal (SIGPIPE, SIG_IGN);
@@ -194,6 +195,9 @@ cockpit_test_init (int *argc,
   g_setenv ("GIO_USE_VFS", "local", TRUE);
   g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
   g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
+
+  g_assert (g_snprintf (path, sizeof (path), "%s:%s", BUILDDIR, g_getenv ("PATH")) < sizeof (path));
+  g_setenv ("PATH", path, TRUE);
 
   g_type_init ();
 

--- a/src/ws/mock-kdc
+++ b/src/ws/mock-kdc
@@ -42,13 +42,6 @@ check_require kadmin.local krb5kdc kdb5_util
 
 dir=$(mktemp -d)
 
-cleanup()
-{
-    rm -rf $dir/
-}
-
-trap "cleanup" SIGTERM SIGINT
-
 # Generate the KDC configuration file
 sed -e "s,[@]dir[@],$dir,g" mock-krb5.conf.in > $dir/krb5.conf
 sed -e "s,[@]dir[@],$dir,g" mock-kdc.conf.in > $dir/kdc.conf
@@ -91,4 +84,4 @@ done
 # Run krb5kdc
 LC_ALL=C krb5kdc -n -r COCKPIT.MOCK 2>&1
 
-cleanup
+rm -rf $dir/

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -783,12 +783,12 @@ fdwalk (int (*cb)(void *data, int fd),
 static int
 session (char **env)
 {
-  char *argv[] = { PACKAGE_BIN_DIR "/cockpit-bridge", NULL };
+  char *argv[] = { "cockpit-bridge", NULL };
   debug ("executing bridge: %s", argv[0]);
   if (env)
-    execve (argv[0], argv, env);
+    execvpe (argv[0], argv, env);
   else
-    execv (argv[0], argv);
+    execvp (argv[0], argv);
   warn ("can't exec %s", argv[0]);
   return 127;
 }

--- a/src/ws/test-kerberos.c
+++ b/src/ws/test-kerberos.c
@@ -397,7 +397,8 @@ static void
 on_kdc_setup (gpointer user_data)
 {
   /* Kill all sub processes when this process exits */
-  prctl (PR_SET_PDEATHSIG, 15);
+  if (prctl (PR_SET_PDEATHSIG, SIGTERM) < 0)
+    g_critical ("prctl failed: %s", g_strerror (errno));
 
   /* Start a new session for this process */
   setsid ();

--- a/src/ws/test-kerberos.c
+++ b/src/ws/test-kerberos.c
@@ -360,7 +360,7 @@ test_authenticate (TestCase *test,
 
   include_cookie_as_if_client (out_headers, out_headers);
 
-  service = cockpit_auth_check_cookie (test->auth, "/cockpit", out_headers);
+  service = cockpit_auth_check_cookie (test->auth, "/cockpit+test", out_headers);
   g_assert (service != NULL);
 
   creds = cockpit_web_service_get_creds (service);
@@ -443,6 +443,7 @@ mock_kdc_start (void)
         {
           if (errno != EAGAIN && errno != EINTR)
             g_error ("couldn't read from mock-kdc: %s", g_strerror (errno));
+            break;
         }
       else
         {

--- a/src/ws/test-kerberos.c
+++ b/src/ws/test-kerberos.c
@@ -530,6 +530,9 @@ main (int argc,
 
   cockpit_test_init (&argc, &argv);
 
+  /* Try to debug crashing during tests */
+  signal (SIGABRT, cockpit_test_signal_backtrace);
+
   mock_kdc_start ();
 
   g_test_add ("/kerberos/authenticate", TestCase, NULL,

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -79,6 +79,8 @@ BuildRequires: gdb
 %if %{defined gitcommit}
 BuildRequires: npm
 BuildRequires: nodejs
+# For kerberos tests
+BuildRequires: krb5-server
 %endif
 
 # For selinux


### PR DESCRIPTION
When test-kerberos fails, the mock-kdc script hangs. Fix it.