### PR TITLE
Ignore a journal message in check-networking

### DIFF
--- a/test/check-networking
+++ b/test/check-networking
@@ -180,6 +180,9 @@ class TestNetworking(MachineCase):
         b.wait_visible("#networking")
         b.wait_not_in_text("#networking-interfaces", "tbond")
 
+        # Due to above reload
+        self.allow_journal_messages(".*Connection reset by peer.*")
+
     def testBridge(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Happens due to the reload.

As seen here: http://files.cockpit-project.org/hubbot/822efc40c7c084ea6f9c061e93a1cff29c4e48b6_r7_x86-64/hubbot.html