### PR TITLE
Put backtraces in place in bridge for tracking down assertions

### DIFF
--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -41,6 +41,7 @@
 #include "common/cockpitjson.h"
 #include "common/cockpitlog.h"
 #include "common/cockpitpipetransport.h"
+#include "common/cockpittest.h"
 #include "common/cockpitunixfd.h"
 #include "common/cockpitwebresponse.h"
 
@@ -440,6 +441,17 @@ run_bridge (const gchar *interactive)
       g_setenv ("HOME", pwd->pw_dir, TRUE);
       g_setenv ("SHELL", pwd->pw_shell, TRUE);
     }
+
+  /*
+   * Trying to track down assertions in the bridge in various corner cases.
+   * If G_DEBUG is set (as it is during testing) then ask gdb to print
+   * backtraces when SIGABRT happens.
+   *
+   * HACK: This should be removed once we track down the following issue:
+   * cockpit_pipe_write: assertion '!self->priv->closing' failed
+   */
+  if (g_getenv ("G_DEBUG"))
+    signal (SIGABRT, cockpit_test_signal_backtrace);
 
   /*
    * This process talks on stdin/stdout. However lots of stuff wants to write


### PR DESCRIPTION
We are to track down assertions in the bridge in various corner cases.
If G_DEBUG is set (as it is during testing) then ask gdb to print
backtraces when SIGABRT happens.

Example of such an assertion:

```
  cockpit_pipe_write: assertion '!self->priv->closing' failed
```