### PR TITLE
Don't put gzip files of pkg resources in the tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -214,10 +214,13 @@ install-data-local:: install-doc-local
 
 dist-hook: dist-doc-hook
 	echo $(VERSION) > $(distdir)/.tarball
+	ln -s networkmanager $(distdir)/pkg/network
+	ln -s realmd $(distdir)/pkg/domain
+	ln -s storaged $(distdir)/pkg/storage
 	ln -s systemd $(distdir)/pkg/system
 
 distcheck-hook: dist-doc-hook
-	@true
+	$(srcdir)/tools/check-dist $(distdir)
 
 upload-pot:
 	zanata-cli push --project-config "$(srcdir)/tools/zanata.xml" -s "$(builddir)/po" -t "$(srcdir)/po"

--- a/pkg/base1/Makefile.am
+++ b/pkg/base1/Makefile.am
@@ -4,7 +4,7 @@ basedir = $(pkgdatadir)/base1
 base_GEN = \
 	$(addprefix po/po.,$(addsuffix .js,$(LINGUAS))) \
 	$(NULL)
-base_GZ = \
+nodist_base_DATA = \
 	pkg/base1/angular.min.js.gz \
 	pkg/base1/cockpit.min.css.gz \
 	pkg/base1/po.js.gz \
@@ -18,7 +18,6 @@ base_GZ = \
 	$(NULL)
 base_DATA = \
 	pkg/base1/manifest.json \
-	$(base_GZ) \
 	$(NULL)
 
 basedebugdir = $(debugdir)$(basedir)
@@ -27,6 +26,7 @@ basedebug_DATA = \
 	pkg/base1/bootstrap-datepicker.js \
 	pkg/base1/bootstrap-select.js \
 	pkg/base1/bootstrap-combobox.js \
+	pkg/base1/bundle.js \
 	pkg/base1/cockpit.css \
 	pkg/base1/patternfly.css \
 	pkg/base1/patternfly-additions.css \
@@ -63,13 +63,6 @@ install-data-local::
 
 basefontsdir = $(pkgdatadir)/base1/fonts
 basefonts_DATA = \
-	pkg/base1/fonts/fontawesome.woff.gz \
-	pkg/base1/fonts/patternfly.woff.gz \
-	pkg/base1/fonts/glyphicons.woff.gz \
-	$(NULL)
-
-basefontsdebugdir = $(debugdir)$(basefontsdir)
-basefontsdebug_DATA = \
 	pkg/base1/fonts/fontawesome.woff \
 	pkg/base1/fonts/patternfly.woff \
 	pkg/base1/fonts/glyphicons.woff \
@@ -111,7 +104,7 @@ CLEANFILES += \
 	pkg/base1/patterns.min.js \
 	pkg/base1/bootstrap-combobox.min.js \
 	$(base_GEN) \
-	$(base_GZ) \
+	$(nodist_base_DATA) \
 	$(NULL)
 
 EXTRA_DIST += \
@@ -120,6 +113,7 @@ EXTRA_DIST += \
 	pkg/base1/bootstrap-datepicker.min.js \
 	pkg/base1/bootstrap-combobox.min.js \
 	pkg/base1/bundle.min.js \
+	pkg/base1/cockpit.min.css \
 	pkg/base1/jquery.min.js \
 	pkg/base1/require.min.js \
 	pkg/base1/mustache.min.js \

--- a/pkg/base1/require-loaders.js
+++ b/pkg/base1/require-loaders.js
@@ -36,9 +36,9 @@ define('data', function() {
             } else if (xhr.status == 200) {
                 onload(xhr.responseText);
             } else if (xhr.statusText) {
-                onload.error(new Error(xhr.statusText));
+                onload.error(new Error(name + ": " + xhr.statusText));
             } else {
-                onload.error(new Error(xhr.status + " error"));
+                onload.error(new Error(name + ": " + xhr.status + " error"));
             }
         };
         xhr.overrideMimeType("text/plain");

--- a/pkg/base1/require.js
+++ b/pkg/base1/require.js
@@ -2133,9 +2133,9 @@ define('data', function() {
             } else if (xhr.status == 200) {
                 onload(xhr.responseText);
             } else if (xhr.statusText) {
-                onload.error(new Error(xhr.statusText));
+                onload.error(new Error(name + ": " + xhr.statusText));
             } else {
-                onload.error(new Error(xhr.status + " error"));
+                onload.error(new Error(name + ": " + xhr.status + " error"));
             }
         };
         xhr.overrideMimeType("text/plain");

--- a/pkg/base1/require.min.js
+++ b/pkg/base1/require.min.js
@@ -49,9 +49,9 @@ define('data', function() {
             } else if (xhr.status == 200) {
                 onload(xhr.responseText);
             } else if (xhr.statusText) {
-                onload.error(new Error(xhr.statusText));
+                onload.error(new Error(name + ": " + xhr.statusText));
             } else {
-                onload.error(new Error(xhr.status + " error"));
+                onload.error(new Error(name + ": " + xhr.status + " error"));
             }
         };
         xhr.overrideMimeType("text/plain");

--- a/pkg/dashboard/Makefile.am
+++ b/pkg/dashboard/Makefile.am
@@ -1,12 +1,11 @@
 
 dashboarddir = $(pkgdatadir)/dashboard
-dashboard_GZ = \
+nodist_dashboard_DATA = \
 	pkg/dashboard/bundle.min.js.gz \
 	pkg/dashboard/index.min.html.gz \
 	$(NULL)
 dashboard_DATA = \
 	pkg/dashboard/manifest.json \
-	$(dashboard_GZ) \
 	$(NULL)
 
 dashboarddebugdir = $(debugdir)$(dashboarddir)
@@ -28,8 +27,8 @@ pkg/dashboard/bundle.min.js: $(dashboard_BUNDLE)
 CLEANFILES += \
 	pkg/dashboard/bundle.min.js \
 	pkg/dashboard/index.min.html \
-	$(networkmanager_BUNDLE) \
-	$(networkmanager_GZ) \
+	$(dashboard_BUNDLE) \
+	$(nodist_dashboard_DATA) \
 	$(NULL)
 
 EXTRA_DIST += \

--- a/pkg/docker/Makefile.am
+++ b/pkg/docker/Makefile.am
@@ -1,6 +1,6 @@
 
 dockerdir = $(pkgdatadir)/docker
-docker_GZ = \
+nodist_docker_DATA = \
 	pkg/docker/bundle.min.js.gz \
 	pkg/docker/console.min.html.gz \
 	pkg/docker/docker.min.css.gz \
@@ -9,7 +9,6 @@ docker_GZ = \
 	$(NULL)
 docker_DATA = \
 	pkg/docker/manifest.json \
-	$(docker_GZ) \
 	$(NULL)
 
 dockerdebugdir = $(debugdir)$(dockerdir)
@@ -52,13 +51,14 @@ TESTS += $(docker_TESTS)
 
 CLEANFILES += \
 	pkg/docker/bundle.min.js \
-	pkg/docker/bundle.min.js \
 	$(docker_BUNDLE) \
-	$(docker_GZ) \
+	$(nodist_docker_DATA) \
 	$(NULL)
 
 EXTRA_DIST += \
 	pkg/docker/bundle.min.js \
+	pkg/docker/console.min.html \
+	pkg/docker/docker.min.css \
 	pkg/docker/index.min.html \
 	$(docker_DATA) \
 	$(dockerdebug_DATA) \

--- a/pkg/kubernetes/Makefile.am
+++ b/pkg/kubernetes/Makefile.am
@@ -1,13 +1,12 @@
 
 kubernetesdir = $(pkgdatadir)/kubernetes
-kubernetes_GZ = \
+nodist_kubernetes_DATA = \
 	pkg/kubernetes/app.min.css.gz \
 	pkg/kubernetes/index.min.html.gz \
 	pkg/kubernetes/kubernetes.min.js.gz \
 	$(NULL)
 kubernetes_DATA = \
 	pkg/kubernetes/manifest.json \
-	$(kubernetes_GZ) \
 	$(NULL)
 
 kubernetes_VIEWS = \
@@ -88,11 +87,11 @@ kubernetes_BUNDLE = \
 	$(NULL)
 
 # Bundles all the view templates into a $templateCache loadable
-pkg/kubernetes/templates.min.js: $(kubernetes_VIEWS)
+pkg/kubernetes/templates.js: $(kubernetes_VIEWS)
 	$(AM_V_GEN) $(srcdir)/tools/missing $(srcdir)/tools/ngbundle -d kubernetes/app -o $@ $^
 
 # Everything else into a nice big bundle
-pkg/kubernetes/kubernetes.min.js: $(kubernetes_BUNDLE) pkg/kubernetes/templates.min.js
+pkg/kubernetes/kubernetes.min.js: $(kubernetes_BUNDLE) pkg/kubernetes/templates.js
 	$(AM_V_GEN) $(srcdir)/tools/missing $(srcdir)/tools/jsbundle $@ $^
 
 kubernetes_TESTS = \
@@ -105,15 +104,16 @@ CLEANFILES += \
 	pkg/kubernetes/app.min.css \
 	pkg/kubernetes/index.min.html \
 	pkg/kubernetes/kubernetes.min.js \
-	pkg/kubernetes/templates.min.js \
+	pkg/kubernetes/templates.js \
 	$(kubernetes_MIN) \
-	$(kubernetes_GZ) \
+	$(nodist_kubernetes_DATA) \
 	$(NULL)
 
 EXTRA_DIST += \
+	pkg/kubernetes/app.min.css \
 	pkg/kubernetes/index.min.html \
 	pkg/kubernetes/kubernetes.min.js \
-	pkg/kubernetes/templates.min.js \
+	pkg/kubernetes/templates.js \
 	$(kubernetes_BUNDLE) \
 	$(kubernetes_DATA) \
 	$(kubernetesdebug_DATA) \

--- a/pkg/networkmanager/Makefile.am
+++ b/pkg/networkmanager/Makefile.am
@@ -1,12 +1,11 @@
 networkmanagerdir = $(pkgdatadir)/network
-networkmanager_GZ = \
+nodist_networkmanager_DATA = \
 	pkg/networkmanager/bundle.min.js.gz \
 	pkg/networkmanager/index.min.html.gz \
 	pkg/networkmanager/networking.min.css.gz \
 	$(NULL)
 networkmanager_DATA = \
 	pkg/networkmanager/manifest.json \
-	$(networkmanager_GZ) \
 	$(NULL)
 
 networkmanagerdebugdir = $(debugdir)$(networkmanagerdir)
@@ -32,13 +31,15 @@ TESTS += $(networkmanager_TESTS)
 CLEANFILES += \
 	pkg/networkmanager/bundle.min.js \
 	pkg/networkmanager/index.min.html \
+	pkg/networkmanager/networking.min.css \
 	$(networkmanager_BUNDLE) \
-	$(networkmanager_GZ) \
+	$(nodist_networkmanager_DATA) \
 	$(NULL)
 
 EXTRA_DIST += \
 	pkg/networkmanager/bundle.min.js \
 	pkg/networkmanager/index.min.html \
+	pkg/networkmanager/networking.min.css \
 	$(networkmanager_DATA) \
 	$(networkmanagerdebug_DATA) \
 	$(networkmanager_TESTS) \

--- a/pkg/realmd/Makefile.am
+++ b/pkg/realmd/Makefile.am
@@ -1,6 +1,8 @@
 realmddir = $(pkgdatadir)/domain
-realmd_DATA = \
+nodist_realmd_DATA = \
 	pkg/realmd/bundle.min.js.gz \
+	$(NULL)
+realmd_DATA = \
 	pkg/realmd/manifest.json \
 	$(NULL)
 
@@ -26,8 +28,8 @@ TESTS += $(realmd_TESTS)
 
 CLEANFILES += \
 	pkg/realmd/bundle.min.js \
-	pkg/realmd/operation.min.js \
-	$(systed_BUNDLE) \
+	$(realmd_BUNDLE) \
+	$(nodist_realmd_DATA) \
 	$(NULL)
 
 EXTRA_DIST += \

--- a/pkg/shell/Makefile.am
+++ b/pkg/shell/Makefile.am
@@ -1,5 +1,5 @@
 shelldir = $(pkgdatadir)/shell
-shell_GZ = \
+nodist_shell_DATA = \
 	pkg/shell/shell.min.js.gz \
 	pkg/shell/bundle.min.js.gz \
 	pkg/shell/shell.min.css.gz \
@@ -7,7 +7,6 @@ shell_GZ = \
 shell_DATA = \
 	pkg/shell/index.min.html \
 	pkg/shell/manifest.json \
-	$(shell_GZ) \
 	$(NULL)
 
 shelldebugdir = $(debugdir)$(shelldir)
@@ -68,15 +67,17 @@ TESTS += $(shell_TESTS)
 # ----------------------------------------------------------------------------------------------------
 
 CLEANFILES += \
+	pkg/shell/shell.min.css \
 	pkg/shell/shell.min.js \
 	pkg/shell/bundle.min.js \
 	pkg/shell/index.min.html \
 	$(shell_BUNDLE) \
-	$(shell_GZ) \
+	$(nodist_shell_DATA) \
 	$(shell_MINFILES) \
 	$(NULL)
 
 EXTRA_DIST += \
+	pkg/shell/shell.min.css \
 	pkg/shell/shell.min.js \
 	pkg/shell/bundle.min.js \
 	pkg/shell/index.min.html \

--- a/pkg/storaged/Makefile.am
+++ b/pkg/storaged/Makefile.am
@@ -1,12 +1,11 @@
 storageddir = $(pkgdatadir)/storage
-storaged_GZ = \
+nodist_storaged_DATA = \
 	pkg/storaged/bundle.min.js.gz \
 	pkg/storaged/index.min.html.gz \
 	pkg/storaged/storage.min.css.gz \
 	$(NULL)
 storaged_DATA = \
 	pkg/storaged/manifest.json \
-	$(storaged_GZ) \
 	$(NULL)
 
 storageddebugdir = $(debugdir)$(storageddir)
@@ -53,13 +52,15 @@ TESTS += $(storaged_TESTS)
 CLEANFILES += \
 	pkg/storaged/bundle.min.js \
 	pkg/storaged/index.min.html \
+	pkg/storaged/storage.min.css \
 	$(storaged_BUNDLE) \
-	$(storaged_GZ) \
+	$(nodist_storaged_DATA) \
 	$(NULL)
 
 EXTRA_DIST += \
 	pkg/storaged/bundle.min.js \
 	pkg/storaged/index.min.html \
+	pkg/storaged/storage.min.css \
 	$(storaged_DATA) \
 	$(storageddebug_DATA) \
 	$(storagedimages_DATA) \

--- a/pkg/subscriptions/Makefile.am
+++ b/pkg/subscriptions/Makefile.am
@@ -1,13 +1,12 @@
 
 subscriptionsdir = $(pkgdatadir)/subscriptions
-subscriptions_GZ = \
+nodist_subscriptions_DATA = \
 	pkg/subscriptions/index.min.html.gz \
 	pkg/subscriptions/subscriptions.min.css.gz \
 	pkg/subscriptions/subscriptions.min.js.gz \
 	$(NULL)
 subscriptions_DATA = \
 	pkg/subscriptions/manifest.json \
-	$(subscriptions_GZ) \
 	$(NULL)
 
 subscriptionsdebugdir = $(debugdir)$(subscriptionsdir)
@@ -21,7 +20,7 @@ CLEANFILES += \
 	pkg/subscriptions/index.min.html \
 	pkg/subscriptions/subscriptions.min.js \
 	pkg/subscriptions/subscriptions.min.css \
-	$(subscriptions_GZ) \
+	$(nodist_subscriptions_DATA) \
 	$(NULL)
 
 EXTRA_DIST += \

--- a/pkg/systemd/Makefile.am
+++ b/pkg/systemd/Makefile.am
@@ -1,5 +1,5 @@
 systemddir = $(pkgdatadir)/system
-systemd_GZ = \
+nodist_systemd_DATA = \
 	pkg/systemd/bundle.min.js.gz \
 	pkg/systemd/index.min.html.gz \
 	pkg/systemd/journal.min.css.gz \
@@ -10,7 +10,6 @@ systemd_GZ = \
 	$(NULL)
 systemd_DATA = \
 	pkg/systemd/manifest.json \
-	$(systemd_GZ) \
 	$(NULL)
 
 systemddebugdir = $(debugdir)$(systemddir)
@@ -62,17 +61,20 @@ TESTS += $(systemd_TESTS)
 CLEANFILES += \
 	pkg/systemd/bundle.min.js \
 	pkg/systemd/index.min.html \
+	pkg/systemd/journal.min.css \
 	pkg/systemd/logs.min.html \
 	pkg/systemd/services.min.html \
 	pkg/systemd/terminal.min.html \
 	$(systemd_MIN) \
-	$(systemd_GZ) \
+	$(nodist_systemd_DATA) \
 	$(NULL)
 
 EXTRA_DIST += \
 	pkg/systemd/bundle.min.js \
 	pkg/systemd/index.min.html \
+	pkg/systemd/journal.min.css \
 	pkg/systemd/logs.min.html \
+	pkg/systemd/service.min.js \
 	pkg/systemd/services.min.html \
 	pkg/systemd/terminal.min.html \
 	$(systemd_DATA) \

--- a/pkg/users/Makefile.am
+++ b/pkg/users/Makefile.am
@@ -1,12 +1,11 @@
 usersdir = $(pkgdatadir)/users
-users_GZ = \
+nodist_users_DATA = \
 	pkg/users/bundle.min.js.gz \
 	pkg/users/index.min.html.gz \
 	pkg/users/users.min.css.gz \
 	$(NULL)
 users_DATA = \
 	pkg/users/manifest.json \
-	$(users_GZ) \
 	$(NULL)
 
 users_SCRIPTS = \
@@ -46,14 +45,16 @@ TESTS += $(users_TESTS)
 CLEANFILES += \
 	pkg/users/bundle.min.js \
 	pkg/users/index.min.html \
+	pkg/users/users.min.css \
 	$(users_BUNDLEFILES) \
-	$(users_GZ) \
+	$(nodist_users_DATA) \
 	$(NULL)
 
 EXTRA_DIST += \
 	pkg/users/mock \
 	pkg/users/bundle.min.js \
 	pkg/users/index.min.html \
+	pkg/users/users.min.css \
 	$(users_DATA) \
 	$(usersdebug_DATA) \
 	$(users_TESTS) \

--- a/tools/check-dist
+++ b/tools/check-dist
@@ -1,0 +1,14 @@
+#!/bin/sh -eu
+
+# Check for mistakes in tarball distribution
+
+find $1/pkg -name '*.gz' -print | tee /dev/stderr | sort | while read file; do
+        echo "Refusing to distribute gzip files" >&2
+        exit 1
+done
+
+find $1/pkg -name '*.min.*' -print | sed 's/\.min\././' |
+    xargs -n1 sh -uc 'test -f $0 || echo $0' | tee /dev/stderr | sort | while read file; do
+        echo "Refusing to distribute minified files without original" >&2
+        exit 1
+done


### PR DESCRIPTION
These should be compressed on during the build. In addition this hide several distribution bugs, where actual files were missing from the tarball so distribute those.

Also make sure we distribute non-minified files for any minified files we put in the tarball.