### PR TITLE
Don't complain if data is queued on a closing pipe

### DIFF
--- a/src/common/cockpitpipe.c
+++ b/src/common/cockpitpipe.c
@@ -870,7 +870,6 @@ cockpit_pipe_write (CockpitPipe *self,
                     GBytes *data)
 {
   g_return_if_fail (COCKPIT_IS_PIPE (self));
-  g_return_if_fail (!self->priv->closing);
 
   /* If self->priv->io is already gone but we are still waiting for the
      child to exit, then we haven't emitted the "close" signal yet


### PR DESCRIPTION
This is the case where the pipe is closing in an orderly
fashion but there's still data remaining to be sent. Allow
additional data to be queued along with it. These are almost
always messages about the closure.

If the pipe is closing with a problem, it obviously closes
immediately and drops queued data.

Fixes #2823