### PR TITLE
Don't complain if an expected cgroup file goes away

### DIFF
--- a/src/bridge/cockpitcgroupsamples.c
+++ b/src/bridge/cockpitcgroupsamples.c
@@ -42,7 +42,11 @@ read_double (const gchar *prefix,
   path = g_build_filename (prefix, suffix, NULL);
   if (!g_file_get_contents (path, &file_contents, &len, &error))
     {
-      g_message ("error loading file: %s: %s", path, error->message);
+      if (g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT) ||
+          g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NODEV))
+        g_debug ("samples file not found: %s", path);
+      else
+        g_message ("error loading file: %s: %s", path, error->message);
       g_error_free (error);
       ret = -1;
     }


### PR DESCRIPTION
This can happen while walking the cgroup tree.

Fixes warnings like this:

```
error loading file: /sys/fs/cgroup/memory/system.slice/sys-kernel-debug.mount/memory.usage_in_bytes: Error reading file '/sys/fs/cgroup/memory/system.slice/sys-kernel-debug.mount/memory.usage_in_bytes': No such device
```

or

```
error loading file: /sys/fs/cgroup/memory/system.slice/sys-kernel-debug.mount/memory.memsw.usage_in_bytes: Failed to open file '/sys/fs/cgroup/memory/system.slice/sys-kernel-debug.mount/memory.memsw.usage_in_bytes': No such file or directory
```