### PR TITLE
Allow symlinks in branding to anywhere in /usr/share

### DIFF
--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -98,9 +98,6 @@ calculate_static_roots (GHashTable *os_release)
   while (i > 0)
     g_free (dirs[--i]);
 
-  /* Allow branding symlinks to escape these roots into /usr/share/pixmaps */
-  cockpit_web_exception_escape_root = "/usr/share/pixmaps";
-
   /* Load the fail template */
   g_resources_register (cockpitassets_get_resource ());
   cockpit_web_failure_resource = "/org/cockpit-project/Cockpit/fail.html";


### PR DESCRIPTION
There is an auxiliary definsive strategy, to limiting the symlinks
we can follow when serving files over HTTP. But we need to be
able to follow links into /usr/share/pixmaps and /usr/share/icons

Since all of /usr/share contains application installed files, we
allow symlinks to these locations for branding directories to
be able to refer to.