### PR TITLE
More version compatibility fixes

### DIFF
--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -299,6 +299,17 @@ function Transport() {
     if (window.parent !== window && window.name.indexOf("cockpit1:") === 0)
         ws = new ParentWebSocket(window.parent);
 
+    /* HACK: Compatibility if we're hosted by older Cockpit versions */
+    try {
+           /* See if we should communicate via parent */
+           if (!ws && window.parent !== window && window.parent.options &&
+                window.parent.options.protocol == "cockpit1") {
+               ws = new ParentWebSocket(window.parent);
+            }
+    } catch (ex) {
+       /* permission access errors */
+    }
+
     if (!ws) {
         var ws_loc = calculate_url();
         transport_debug("connecting to " + ws_loc);

--- a/pkg/shell/Makefile.am
+++ b/pkg/shell/Makefile.am
@@ -3,6 +3,7 @@ shell_GZ = \
 	pkg/shell/shell.min.js.gz \
 	pkg/shell/bundle.min.js.gz \
 	pkg/shell/shell.min.css.gz \
+	pkg/shell/shell.min.html.gz \
 	$(NULL)
 shell_DATA = \
 	pkg/shell/index.min.html \
@@ -18,6 +19,7 @@ shelldebug_DATA = \
 	pkg/shell/index.js \
 	pkg/shell/machines.js \
 	pkg/shell/shell.css \
+	pkg/shell/shell.html \
 	pkg/shell/dbus.js \
 	pkg/shell/controls.js \
 	pkg/shell/plot.js \
@@ -71,6 +73,7 @@ CLEANFILES += \
 	pkg/shell/shell.min.js \
 	pkg/shell/bundle.min.js \
 	pkg/shell/index.min.html \
+	pkg/shell/shell.min.html \
 	$(shell_BUNDLE) \
 	$(shell_GZ) \
 	$(shell_MINFILES) \
@@ -80,6 +83,7 @@ EXTRA_DIST += \
 	pkg/shell/shell.min.js \
 	pkg/shell/bundle.min.js \
 	pkg/shell/index.min.html \
+	pkg/shell/shell.min.html \
 	$(shell_DATA) \
 	$(shell_BUNDLE) \
 	$(shell_SHELL) \

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -319,7 +319,7 @@ define([
             state.host = "localhost";
         }
         if (path.length && path[path.length - 1] == "index")
-            path = path.pop();
+            path.pop();
         state.component = path.join("/");
         return state;
     }

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Things have moved</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="../base1/cockpit.css" rel="stylesheet">
+</head>
+<body>
+    <div class="blank-slate-pf curtains">
+        <div class="blank-slate-pf-icon">
+            <span class="fa fa-meh-o"></span>
+        </div>
+        <h1>Things have moved</h1>
+        <p>This old version of Cockpit doesn't know where to find default pages. Use the navigation menus to help it find its way.</p>
+    </div>
+</body>
+</html>

--- a/test/check-connection
+++ b/test/check-connection
@@ -125,7 +125,13 @@ class TestConnection(MachineCase):
         m = self.machine
         self.start_cockpit()
         m.execute('echo "[WebService]\nOrigins = http://other-origin:9090 http://localhost:9090" > /etc/cockpit/cockpit.conf')
-        m.execute('curl -s -f -N -H "Connection: Upgrade" -H "Upgrade: websocket" -H "Origin: http://other-origin:9090" -H "Host: localhost:9090" -H "Sec-Websocket-Key: 3sc2c9IzwRUc3BlSIYwtSA==" -H "Sec-Websocket-Version: 13" http://localhost:9090/cockpit/socket')
+        output = m.execute('curl -s -f -N -H "Connection: Upgrade" -H "Upgrade: websocket" -H "Origin: http://other-origin:9090" -H "Host: localhost:9090" -H "Sec-Websocket-Key: 3sc2c9IzwRUc3BlSIYwtSA==" -H "Sec-Websocket-Version: 13" http://localhost:9090/cockpit/socket')
+        self.assertIn('"no-session"', output)
+
+        # The socket should also answer at /socket
+        output = m.execute('curl -s -f -N -H "Connection: Upgrade" -H "Upgrade: websocket" -H "Origin: http://other-origin:9090" -H "Host: localhost:9090" -H "Sec-Websocket-Key: 3sc2c9IzwRUc3BlSIYwtSA==" -H "Sec-Websocket-Version: 13" http://localhost:9090/socket')
+        self.assertIn('"no-session"', output)
+
         self.allow_journal_messages('peer did not close io when expected')
 
 test_main()

--- a/test/check-multi-os
+++ b/test/check-multi-os
@@ -164,6 +164,18 @@ class TestMultiOS(MachineCase):
         stock_b.switch_to_top()
         stock_b.go("#/@%s/system/index" % dev_m.address)
         stock_b.wait_present("iframe.container-frame[name='%s/system/index']" % dev_m.address)
+        stock_b.wait_present("iframe.container-frame[name='%s/system/index'][data-loaded]" % dev_m.address)
+        stock_b.switch_to_frame('%s/system/index' % dev_m.address)
+        stock_b.wait_present("#system_information_hardware_text")
+        stock_b.wait_text_not("#system_information_hardware_text", "")
+
+        # Shows a curtains when accessing to default page from old system
+        stock_b.switch_to_top()
+        stock_b.go("#/@%s" % dev_m.address)
+        stock_b.wait_present("iframe.container-frame[name='%s/shell/shell']" % dev_m.address)
+        stock_b.wait_present("iframe.container-frame[name='%s/shell/shell'][data-loaded]" % dev_m.address)
+        stock_b.switch_to_frame('%s/shell/shell' % dev_m.address)
+        stock_b.wait_present(".curtains")
 
         # Messages from previous versions of cockpit
         self.allow_journal_messages("g_hash_table_iter_next: assertion 'ri->version == ri->hash_table->version' failed")


### PR DESCRIPTION
Some more fixes for the recent changes and componentization. These fix breakage when an old version of cockpit adds a newer one to its dashboard.

 * Support connections to /socket in addition /cockpit/socket
 * Support the old style frame message forwarding discovery flags.
 * Put a fallback shell.html in place
