### PR TITLE
Add dialog pattern "promise" which compines "wait" and "failure"

### DIFF
--- a/pkg/dashboard/list.js
+++ b/pkg/dashboard/list.js
@@ -175,14 +175,7 @@ function host_edit_dialog(machine_manager, host) {
             label: $('#host-edit-name').val()
         };
         var promise = machine_manager.change(machine.key, values);
-        promise
-            .done(function() {
-                dlg.modal('hide');
-            })
-            .fail(function(ex) {
-                dlg.dialog('failure', ex);
-            });
-        dlg.dialog('wait', promise);
+        dlg.dialog('promise', promise);
     });
     $('#host-edit-avatar').off('click');
     $('#host-edit-avatar').on('click', function () {

--- a/pkg/kubernetes/adjust.js
+++ b/pkg/kubernetes/adjust.js
@@ -173,15 +173,7 @@ define([
             return;
 
         var promise = perform(tasks);
-        dialog.dialog("wait", promise);
-
-        promise
-            .fail(function(ex) {
-                dialog.dialog("failure", ex);
-            })
-            .done(function() {
-                dialog.modal("hide");
-            });
+        dialog.dialog("promise", promise);
     });
 });
 

--- a/pkg/kubernetes/details.js
+++ b/pkg/kubernetes/details.js
@@ -24,17 +24,8 @@ define([
         delete_entity_dlg.find('.modal-body').text(cockpit.format(_("Delete $0 $1?"), entity.kind, entity.metadata.name));
 
         delete_btn.on('click', function() {
-            var deferred = $.Deferred();
-            delete_entity_dlg.dialog("wait", deferred.promise());
-            delete_entity_dlg.dialog("failure", null);
-
-            k8client.remove(entity.metadata.selfLink)
-                .fail(function(ex) {
-                    delete_entity_dlg.dialog("failure", ex);
-                })
-                .done(function() {
-                    delete_entity_dlg.modal("hide");
-                });
+            var promise = k8client.remove(entity.metadata.selfLink);
+            delete_entity_dlg.dialog("promise", promise);
         });
     });
 
@@ -103,15 +94,7 @@ define([
             }
 
             var promise = update_replica(entity);
-            adjust_entity_dlg.dialog("wait", promise);
-
-            promise
-                .fail(function(ex) {
-                    adjust_entity_dlg.dialog("failure", ex);
-                })
-                .done(function() {
-                    adjust_entity_dlg.modal("hide");
-                });
+            adjust_entity_dlg.dialog("promise", promise);
         });
 
     });
@@ -120,17 +103,8 @@ define([
         var pod = $(e.relatedTarget).attr('data-link');
 
         delete_pod_btn.on('click', function() {
-            var deferred = $.Deferred();
-            delete_pod_dlg.dialog("wait", deferred.promise());
-            delete_pod_dlg.dialog("failure", null);
-
-            k8client.remove(pod)
-                .fail(function(ex) {
-                    delete_pod_dlg.dialog("failure", ex);
-                })
-                .done(function() {
-                    delete_pod_dlg.modal("hide");
-                });
+            var promise = k8client.remove(pod);
+            delete_pod_dlg.dialog("promise", promise);
         });
     });
 

--- a/pkg/kubernetes/node.js
+++ b/pkg/kubernetes/node.js
@@ -119,15 +119,7 @@ define([
             return;
 
         var promise = kube.create(items);
-        dialog.dialog("wait", promise);
-
-        promise
-            .fail(function(ex) {
-                dialog.dialog("failure", ex);
-            })
-            .done(function() {
-                dialog.modal("hide");
-            });
+        dialog.dialog("promise", promise);
     });
 });
 

--- a/pkg/storaged/dialog.js
+++ b/pkg/storaged/dialog.js
@@ -134,17 +134,7 @@ define([
             var vals = get_validated_field_values();
             if (vals !== null) {
                 var promise = def.Action.action(vals);
-                if (promise) {
-                    $dialog.dialog('wait', promise);
-                    promise
-                        .done(function () {
-                            $dialog.modal('hide');
-                        })
-                        .fail(function (err) {
-                            $dialog.dialog('failure', err);
-                        });
-                } else
-                    $dialog.modal('hide');
+                $dialog.dialog('promise', promise);
             }
         });
 

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -734,8 +734,7 @@ PageSystemInformationChangeSystime.prototype = {
 
         server_time.timedate.call('SetNTP', [$('#change_systime').val() == 'ntp_time', true])
             .fail(function(err) {
-                show_unexpected_error(err);
-                $("#system_information_change_systime").modal('hide');
+                $("#system_information_change_systime").dialog("failure", err);
             })
             .done(function() {
                 if (! $('#systime-timezones').prop('disabled')) {

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -478,14 +478,8 @@ PageAccountsCreate.prototype = {
                 $("#accounts-create-dialog").dialog("failure", ex);
             })
             .done(function() {
-                promise = chain(tasks)
-                    .done(function() {
-                        $('#accounts-create-dialog').modal('hide');
-                    })
-                    .fail(function(ex) {
-                        $("#accounts-create-dialog").dialog("failure", ex);
-                    });
-                $("#accounts-create-dialog").dialog("wait", promise);
+                promise = chain(tasks);
+                $("#accounts-create-dialog").dialog("promise", promise);
             });
 
         $("#accounts-create-dialog").dialog("wait", promise);
@@ -652,14 +646,7 @@ PageAccount.prototype = {
 
         var key = $("#authorized-keys-text").val();
         var promise = this.authorized_keys.add_key(key);
-        $("#add-authorized-key-dialog").dialog("wait", promise);
-        promise
-            .done(function() {
-                $("#add-authorized-key-dialog").modal('hide');
-            })
-            .fail(function(ex) {
-                $("#add-authorized-key-dialog").dialog("failure", ex);
-            });
+        $("#add-authorized-key-dialog").dialog("promise", promise);
     },
 
     get_user: function() {
@@ -1094,14 +1081,7 @@ PageAccountSetPassword.prototype = {
                 else
                     promise = passwd_change(user, password);
 
-                promise
-                    .done(function() {
-                        $('#account-set-password-dialog').modal('hide');
-                    })
-                    .fail(function(ex) {
-                        $("#account-set-password-dialog").dialog("failure", ex);
-                    });
-                $("#account-set-password-dialog").dialog("wait", promise);
+                $("#account-set-password-dialog").dialog("promise", promise);
             })
             .fail(function(ex) {
                 $("#account-set-password-meter-message").hide();


### PR DESCRIPTION
Add dialog pattern "promise" which compines "wait" and "failure"
    
The promise pattern combines the "wait" and "failure" pattern. If the promise resolves, then the dialog hides, if the promise is rejected then the dialog shows the error.
    
This removes a lot of boilerplate code.
