### PR TITLE
Ignore SELinux preventing systemd-coredump from working

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -520,7 +520,9 @@ systemctl start docker
                                     "request timed out, closing",
                                     "PolicyKit daemon disconnected from the bus.",
                                     "We are no longer a registered authentication agent.",
-                                    ".*: failed to retrieve resource: terminated"
+                                    ".*: failed to retrieve resource: terminated",
+                                    # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1253319
+                                    'audit:.*denied.*2F6D656D66643A73642D73797374656D642D636F726564756D202864656C.*',
                                     )
 
     def allow_authorize_journal_messages(self):


### PR DESCRIPTION
Fixes this issue: 

```
Unexpected journal message 'audit: type=1400 audit(1443297273.799:590): avc:  denied  { read write } for  pid=227 comm="systemd-journal" path=2F6D656D66643A73642D73797374656D642D636F726564756D202864656C6574656429 dev="tmpfs" ino=21391 scontext=system_u:system_r:syslogd_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=0'
Journal database copied to check-keys-testAuthorizedKeys-10.111.111.14-FAIL.journal
```