### PR TITLE
Ignore or handle ECONNRESET failures on older GLib

### DIFF
--- a/src/common/cockpitstream.c
+++ b/src/common/cockpitstream.c
@@ -21,6 +21,9 @@
 
 #include "cockpitstream.h"
 
+#include <errno.h>
+#include <string.h>
+
 /**
  * CockpitStream:
  *
@@ -280,6 +283,11 @@ set_problem_from_error (CockpitStream *self,
            g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_EOF) ||
            (self->priv->received && g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_MISC)))
     problem = "disconnected";
+#if !GLIB_CHECK_VERSION(2,43,2)
+  else if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_FAILED) &&
+           strstr (error->message, g_strerror (ECONNRESET)))
+    problem = "disconnected";
+#endif
   else if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT))
     problem = "timeout";
   else if (g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_NOT_TLS) ||

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -112,6 +112,9 @@ GBytes *              cockpit_web_response_negotiation   (const gchar *path,
                                                           gchar **actual,
                                                           GError **error);
 
+gboolean     cockpit_web_should_suppress_output_error    (const gchar *logname,
+                                                          GError *error);
+
 G_END_DECLS
 
 #endif /* __COCKPIT_RESPONSE_H__ */

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -259,23 +259,6 @@ cockpit_web_server_set_property (GObject *object,
     }
 }
 
-#if !GLIB_CHECK_VERSION(2,43,2)
-#define G_IO_ERROR_CONNECTION_CLOSED G_IO_ERROR_BROKEN_PIPE
-#endif
-
-static gboolean
-should_suppress_output_error (GError *error)
-{
-  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) ||
-      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE))
-    {
-      g_debug ("http output error: %s", error->message);
-      return TRUE;
-    }
-
-  return FALSE;
-}
-
 static void
 on_io_closed (GObject *stream,
               GAsyncResult *result,
@@ -285,7 +268,7 @@ on_io_closed (GObject *stream,
 
   if (!g_io_stream_close_finish (G_IO_STREAM (stream), result, &error))
     {
-      if (!should_suppress_output_error (error))
+      if (!cockpit_web_should_suppress_output_error ("http", error))
         g_message ("http close error: %s", error->message);
       g_error_free (error);
     }


### PR DESCRIPTION
Older GLib before 2.43.2 doesn't return G_IO_CONNECTION_CLOSED properly
so to to detect it and handle it.

This shuold fix a Travis failure:

(test-server:16119): cockpit-protocol-WARNING **: /mock/stream: couldn't write web output: Error sending data: Connection reset by peer