### PR TITLE
fix check for atomic version

### DIFF
--- a/test/check-kubernetes
+++ b/test/check-kubernetes
@@ -349,8 +349,8 @@ class TestNulecule(KubernetesCase):
         b.wait_in_text("#node-list", "127.0.0.1")
 
         # 1)check atomic version
-        output = m.execute("atomic -v")
-        self.assertTrue(output >= 1.1)
+        output = m.execute("atomic -v 2>&1")
+        self.assertTrue(float(output) >= 1.1)
 
         # 2) fail  invalid image
         b.click("#deploy-app")


### PR DESCRIPTION
argparse package in python outputs version info to stderr
so need to redirect to make testcase to work.