### PR TITLE
Respect timeouts for 'reload' and 'expect-reload'

### DIFF
--- a/test/phantom-driver
+++ b/test/phantom-driver
@@ -192,10 +192,10 @@ function step ()
             wait_open(on_load);
             page.open(cmd.url);
         } else if (cmd.cmd == "reload") {
-            wait_reload(on_load);
+            wait_reload(on_load, cmd.timeout);
             page.reload();
         } else if (cmd.cmd == "expect-reload") {
-            wait_reload(on_load);
+            wait_reload(on_load, cmd.timeout);
         } else if (cmd.cmd == "inject") {
             inject_basics();
             var ret = page.injectJs(cmd.file);

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -134,7 +134,7 @@ class Browser:
     def reload(self):
         self.switch_to_top()
         self.wait_js_cond("ph_select('iframe.container-frame').every(function (e) { return e.getAttribute('data-loaded'); })")
-        self.phantom.reload()
+        self.phantom.reload(self.phantom_wait_timeout)
 
     def expect_reload(self):
         self.phantom.expect_reload(self.phantom_wait_timeout)
@@ -614,8 +614,8 @@ class Phantom:
         if status != "success":
             raise Error(status)
 
-    def reload(self):
-        status = self.run({'cmd': 'reload'})
+    def reload(self, timeout):
+        status = self.run({'cmd': 'reload', 'timeout': timeout*1000})
         if status != "success":
             raise Error(status)
 


### PR DESCRIPTION
These did not respect the test timeouts. And the default of
10 seconds was too short in some rare cases on a heavily loaded
integration test server