### PR TITLE
Actually check following flag in cockpit.metrics()

### DIFF
--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -2824,8 +2824,11 @@ function full_scope(cockpit, $, po) {
             if (options_list.length === 0)
                 return;
 
-            if (!is_archive)
+            if (!is_archive) {
+                if (following)
+                    return;
                 following = true;
+            }
 
             var options = $.extend({
                 payload: "metrics1",


### PR DESCRIPTION
This way we don't open up multiple channels to follow a given
set of metrics