### PR TITLE
bridge: Don't crash when unable to retrieve PCP instance names.

### DIFF
--- a/src/bridge/cockpitpcpmetrics.c
+++ b/src/bridge/cockpitpcpmetrics.c
@@ -190,7 +190,7 @@ build_meta (CockpitPcpMetrics *self,
               */
               {
                 JsonNode *string_element = json_node_alloc ();
-                json_node_init_string (string_element, instance);
+                json_node_init_string (string_element, instance? instance : "");
                 json_array_add_element (instances, string_element);
               }
 


### PR DESCRIPTION
Passing NULL to json_node_init_string results in a crash.

Fixes #2850