### PR TITLE
bridge: Include detailed debugging of DBus batches

### DIFF
--- a/pkg/realmd/Makefile.am
+++ b/pkg/realmd/Makefile.am
@@ -28,7 +28,7 @@ TESTS += $(realmd_TESTS)
 
 CLEANFILES += \
 	pkg/realmd/bundle.min.js \
-	$(realmd_BUNDLE) \
+	pkg/realmd/operation.min.js \
 	$(nodist_realmd_DATA) \
 	$(NULL)
 

--- a/test/check-multi-machine
+++ b/test/check-multi-machine
@@ -232,7 +232,7 @@ class TestMultiMachine(MachineCase):
         b.go(m2_path)
         b.wait_not_visible(".curtains .spinner")
         if b.is_visible(".curtains"):
-            b.wait_present(".curtains button:not(.disabled)")
+            b.wait_visible(".curtains button:not(.disabled)")
             b.click(".curtains button:not(.disabled)")
             b.wait_not_visible(".curtains")
         b.enter_page("/playground/test", m2.address)


### PR DESCRIPTION
This includes this code again and reverts commit
66787a307f5a4cdb55eae52b020dfceb883a2b00. This bug is again causing
problems:

```
cockpit-bridge:ERROR:src/bridge/cockpitdbuscache.c:265:batch_unref: assertion failed: (batch->refs > 0)
```