### PR TITLE
test: Add reconnect argument to browser.enter_page()

### DIFF
--- a/test/check-multi-machine
+++ b/test/check-multi-machine
@@ -230,12 +230,7 @@ class TestMultiMachine(MachineCase):
 
         # path should reconnect at this point
         b.go(m2_path)
-        b.wait_not_visible(".curtains .spinner")
-        if b.is_visible(".curtains"):
-            b.wait_present(".curtains button:not(.disabled)")
-            b.click(".curtains button:not(.disabled)")
-            b.wait_not_visible(".curtains")
-        b.enter_page("/playground/test", m2.address)
+        b.enter_page("/playground/test", m2.address, reconnect=True)
         # image is back because it page was reloaded after disconnection
         b.wait_present("img[src='hammer.gif']");
         b.switch_to_top()

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -292,7 +292,7 @@ class Browser:
         self.click(sel + " " + button)
         self.wait_not_visible(sel)
 
-    def enter_page(self, path, host=None):
+    def enter_page(self, path, host=None, reconnect=True):
         """Wait for a page to become current.
 
         Arguments:
@@ -308,10 +308,22 @@ class Browser:
         frame = "cockpit1:" + frame
 
         self.switch_to_top()
-        self.wait_present("iframe.container-frame[name='%s'][data-loaded]" % frame)
-        self.wait_visible("iframe.container-frame[name='%s']" % frame)
-        self.switch_to_frame(frame)
 
+        while True:
+            try:
+                self.wait_present("iframe.container-frame[name='%s'][data-loaded]" % frame)
+                self.wait_visible("iframe.container-frame[name='%s']" % frame)
+                break
+            except Error, ex:
+                if reconnect and ex.value == 'timeout':
+                    reconnect = False
+                    if self.is_present(".curtains button"):
+                        self.click(".curtains button", True)
+                        self.wait_not_visible(".curtains")
+                        continue
+                raise exc_info[0], exc_info[1], exc_info[2]
+
+        self.switch_to_frame(frame)
         self.wait_present("body")
         self.wait_visible("body")
 


### PR DESCRIPTION
It's always present in the curtains.