### PR TITLE
storaged: Don't show multipath alert when state is unknown.

### DIFF
--- a/pkg/storaged/devices.js
+++ b/pkg/storaged/devices.js
@@ -92,7 +92,9 @@ define([
         var multipathd_service = utils.get_multipathd_service();
 
         function update_multipath_broken() {
-            $('#multipath-broken').toggle(client.broken_multipath_present && multipathd_service.state !== "running");
+            // When in doubt, assume it is running
+            var multipathd_running = !multipathd_service.state || multipathd_service.state === "running";
+            $('#multipath-broken').toggle(client.broken_multipath_present && !multipathd_running);
         }
 
         $(multipathd_service).on('changed', update_multipath_broken);


### PR DESCRIPTION
Otherwise it will briefly flicker while the page is loading until the
service state has been received.