### PR TITLE
tools: Add warning and tweak spec file slightly

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -1,10 +1,20 @@
-# Globals that might be defined elsewhere
+#
+# This file is maintained at the following location:
+# https://github.com/cockpit-project/cockpit/blob/master/tools/cockpit.spec
+#
+# If you are editing this file in another location, changes will likely
+# be clobbered the next time an automated release is done.
+#
+# Check first cockpit-devel@lists.fedorahosted.org
+#
+# Globals that may be defined elsewhere
 #  * gitcommit xxxx
 #  * selinux 1
 #  * tag 0.71
+#
 
 %define branding auto
-%define rel 1
+%define rev 1
 
 %if %{defined gitcommit}
 %define extra_flags CFLAGS='-O2 -Wall -Werror -fPIC -g'
@@ -40,7 +50,7 @@ Version:        %{gitcommit}
 %else
 Version:        %{tag}
 %endif
-Release:        %{rel}%{?dist}
+Release:        %{rev}%{?dist}
 Summary:        A user interface for Linux servers
 
 License:        LGPLv2+


### PR DESCRIPTION
When this file is copied to other locations, such as built in
Fedora we don't want people to accidentally edit it and then
have their changes overwritten.

This generally applies to koji branches on which we're doing
continuous deployment. Once we stop on a given koji branch
we can remove this warning from that version of the spec file.

Also change the 'rel' variable to 'rev' to use clearer terminology