### PR TITLE
bridge: Don't refuse package when it has invalid file names

### DIFF
--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -131,9 +131,11 @@ package_walk_file (GChecksum *checksum,
   gboolean ret = FALSE;
   GBytes *bytes;
 
+  /* Skip invalid files: we refuse to serve them (below) */
   if (!validate_path (filename))
     {
-      g_warning ("package has an invalid path name: %s", filename);
+      g_debug ("package has an invalid path name: %s", filename);
+      ret = TRUE;
       goto out;
     }
 

--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -389,18 +389,6 @@ test_bad_receive (TestCase *tc,
   g_assert_cmpstr (tc->problem, ==, "protocol-error");
 }
 
-static const Fixture fixture_list_bad_directory = {
-    .datadirs = { SRCDIR "/src/bridge/mock-resource/bad-directory", NULL },
-    .expect = "package * invalid *name*",
-    .path = "/manifests.json"
-};
-
-static const Fixture fixture_list_bad_file = {
-    .datadirs = { SRCDIR "/src/bridge/mock-resource/bad-file", NULL },
-    .expect = "package * invalid *name*",
-    .path = "/manifests.json"
-};
-
 static const Fixture fixture_list_bad_name = {
     .datadirs = { SRCDIR "/src/bridge/mock-resource/bad-package", NULL },
     .expect = "package * invalid *name*",
@@ -531,10 +519,6 @@ main (int argc,
   g_test_add ("/packages/bad-package", TestCase, &fixture_bad_package,
               setup, test_bad_package, teardown);
 
-  g_test_add ("/packages/listing-bad-directory", TestCase, &fixture_list_bad_directory,
-              setup, test_list_bad_name, teardown);
-  g_test_add ("/packages/listing-bad-file", TestCase, &fixture_list_bad_file,
-              setup, test_list_bad_name, teardown);
   g_test_add ("/packages/listing-bad-name", TestCase, &fixture_list_bad_name,
               setup, test_list_bad_name, teardown);
 


### PR DESCRIPTION
We do refuse to serve them, but this prevents erroneous files
from gumming up an install of Cockpit.