### PR TITLE
Don't repeat Fedora branding badge

### DIFF
--- a/branding/fedora/branding.css
+++ b/branding/fedora/branding.css
@@ -9,6 +9,7 @@ body.login-pf {
     height: 80px;
     background-image: url("logo.png");
     background-size: contain;
+    background-repeat: no-repeat;
 }
 
 #brand {


### PR DESCRIPTION
This happens in Fedora when the fedora logos are not installed