### PR TITLE
examples: Add http: to address in embed-cockpit example

### DIFF
--- a/examples/embed-cockpit/application.html
+++ b/examples/embed-cockpit/application.html
@@ -62,7 +62,7 @@
         <div class="row row-cards-pf">
             <div id="embed-links" class="col-xs-3 col-sm-3 col-md-2">
                 <div class="row row-cards-pf">
-                    <input id="embed-address" class="form-control" value="127.0.0.1"/>
+                    <input id="embed-address" class="form-control" value="http://127.0.0.1"/>
                 </div>
                 <div class="card-pf card-pf-accented card-pf-aggregate-status">
                     <h2 class="card-pf-title">
@@ -164,7 +164,7 @@
             ev.preventDefault();
 
             var address = $("#embed-address").val();
-            var url = "http://" + address + ":9090" + href;
+            var url = address + ":9090" + href;
 
             var frame = frames[url];
             if (!frame) {

--- a/test/check-embed
+++ b/test/check-embed
@@ -30,7 +30,7 @@ class TestEmbed(MachineCase):
 
         b.open("file://%s/files/embed-cockpit.html" % os.path.realpath(os.path.dirname(__file__)))
         b.wait_present("#embed-loaded")
-        b.set_val("#embed-address", m.address)
+        b.set_val("#embed-address", "http://" + m.address)
         b.click("#embed-full")
         b.wait_present("iframe[name='embed-full'][loaded]")
         b.switch_to_frame("embed-full")

--- a/test/check-networking
+++ b/test/check-networking
@@ -45,6 +45,7 @@ class TestNetworking(MachineCase):
             element = self.browser.text("#networking-interfaces tr:contains('%s')" % iface)
             for state in valid_states:
                 if state in element:
+                    self.browser.wait_visible("#networking-interfaces tr:contains('%s')" % iface)
                     return
             time.sleep(0.5)
         raise Failure("Interface $s didn't come up" % iface)


### PR DESCRIPTION
This lets us show why self-signed TLS doesn't work for embedding.