### PR TITLE
Evaluation of promises in test code, and phantom-driver cleanup

### DIFF
--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -816,7 +816,7 @@ define([
 
             /* Note that we ignore tracknig for old shell code */
             if (current_frame && current_frame.contentWindow === child &&
-                child.name.indexOf("/shell/shell") === -1) {
+                child.name && child.name.indexOf("/shell/shell") === -1) {
                 hash = child.location.hash;
                 if (hash.indexOf("#") === 0)
                     hash = hash.substring(1);

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -600,6 +600,12 @@ main (int argc,
 
   signal (SIGPIPE, SIG_IGN);
 
+  /* Debugging issues during testing */
+#if WITH_DEBUG
+  signal (SIGABRT, cockpit_test_signal_backtrace);
+  signal (SIGSEGV, cockpit_test_signal_backtrace);
+#endif
+
   /*
    * We have to tell GLib about an alternate default location for XDG_DATA_DIRS
    * if we've been compiled with a different prefix. GLib caches that, so need

--- a/src/bridge/cockpitdbuscache.c
+++ b/src/bridge/cockpitdbuscache.c
@@ -538,11 +538,10 @@ introspect_flush (CockpitDBusCache *self)
       /* Steal everything, more could be added by callback */
       for (;;)
         {
-
-          id = g_queue_pop_head (self->introspects);
-          if (!id)
+          id = g_queue_pop_tail (self->introspects);
+          if (!id || id->introspecting)
             break;
-          g_queue_push_tail (queue, id);
+          g_queue_push_head (queue, id);
         }
 
       id = g_queue_pop_head (queue);

--- a/src/bridge/cockpitdbuscache.c
+++ b/src/bridge/cockpitdbuscache.c
@@ -508,6 +508,7 @@ introspect_next (CockpitDBusCache *self)
     {
       if (g_cancellable_is_cancelled (self->cancellable))
         {
+          g_queue_pop_head (self->introspects);
           introspect_complete (self, id);
         }
       else

--- a/src/static/login.html
+++ b/src/static/login.html
@@ -215,9 +215,9 @@
                     } else {
                         fatal(xhr.status + " error");
                     }
-                    phantom_checkpoint();
                     id("login-button").removeAttribute('disabled');
                     id("login-spinner").style.display = 'none';
+                    phantom_checkpoint();
                 };
                 xhr.send();
             }

--- a/src/ws/cockpit-testing.service.in
+++ b/src/ws/cockpit-testing.service.in
@@ -6,6 +6,7 @@ Conflicts=cockpit.service
 
 [Service]
 Environment=G_MESSAGES_DEBUG=cockpit-ws G_DEBUG=fatal-criticals G_SLICE=always-malloc,debug-blocks
+ExecStartPre=sh -c 'echo 0 > /proc/sys/kernel/yama/ptrace_scope'
 ExecStart=@libexecdir@/cockpit-ws --no-tls
 User=@user@
 Group=@group@

--- a/test-avocado/checklogin-basic.py
+++ b/test-avocado/checklogin-basic.py
@@ -83,7 +83,7 @@ class checklogin_basic(cockpit.Test):
 
         # Login as admin
         login("admin", "foobar")
-        b.expect_reload()
+        b.expect_load()
         b.wait_present("#content")
         b.wait_text('#content-user-name', 'Administrator')
 

--- a/test/check-accounts
+++ b/test/check-accounts
@@ -84,10 +84,10 @@ class TestAccounts(MachineCase):
         b.wait_present("#account-role-checkbox-10:not(:checked)")
         b.set_checked("#account-role-checkbox-10", True)
         b.wait_present("#account-role-checkbox-10:checked")
-        wait(lambda: "jussi" in m.execute("grep wheel /etc/group"), delay=1, tries=10)
+        b.wait(lambda: "jussi" in m.execute("grep wheel /etc/group"))
         b.set_checked("#account-role-checkbox-10", False)
         b.wait_present("#account-role-checkbox-10:not(:checked)")
-        wait(lambda: "jussi" not in m.execute("grep wheel /etc/group"), delay=1, tries=10)
+        b.wait(lambda: "jussi" not in m.execute("grep wheel /etc/group"))
         m.execute("/usr/sbin/usermod jussi -G 10 -a")
         b.wait_present("#account-role-checkbox-10:checked")
 

--- a/test/check-accounts
+++ b/test/check-accounts
@@ -119,7 +119,7 @@ class TestAccounts(MachineCase):
         b.set_val("#login-user-input", "jussi")
         b.set_val("#login-password-input", 'ö5 foobar')
         b.click('#login-button')
-        b.expect_reload()
+        b.expect_load()
         b.wait_present('#content')
 
         self.allow_journal_messages("Password quality check failed:")

--- a/test/check-connection
+++ b/test/check-connection
@@ -45,7 +45,7 @@ class TestConnection(MachineCase):
         b.set_val("#login-user-input", "admin")
         b.set_val("#login-password-input", "foobar")
         b.click('#login-button')
-        b.expect_reload()
+        b.expect_load()
         b.enter_page("/system")
 
         # take cockpit-ws down on the server page
@@ -54,7 +54,7 @@ class TestConnection(MachineCase):
         b.wait_popup("disconnected-dialog")
         m.execute("systemctl start cockpit-testing.socket")
         b.click('#disconnected-reconnect')
-        b.expect_reload()
+        b.expect_load()
         b.wait_visible("#login")
         b.set_val("#login-user-input", "admin")
         b.set_val("#login-password-input", "foobar")
@@ -70,7 +70,7 @@ class TestConnection(MachineCase):
         b.set_val("#login-user-input", "admin")
         b.set_val("#login-password-input", "foobar")
         b.click('#login-button')
-        b.expect_reload()
+        b.expect_load()
         b.enter_page("/system")
 
         # sever the connection on the server page
@@ -81,7 +81,7 @@ class TestConnection(MachineCase):
         b.wait_in_text('#disconnected-error', "Connection has timed out.")
         m.execute("iptables -D INPUT 1")
         b.click('#disconnected-reconnect')
-        b.expect_reload()
+        b.expect_load()
         b.enter_page("/system")
 
         self.allow_restart_journal_messages()

--- a/test/check-embed
+++ b/test/check-embed
@@ -32,13 +32,14 @@ class TestEmbed(MachineCase):
         b.wait_present("#embed-loaded")
         b.set_val("#embed-address", "http://" + m.address)
         b.click("#embed-full")
+        b.expect_load()
         b.wait_present("iframe[name='embed-full'][loaded]")
         b.switch_to_frame("embed-full")
         b.wait_visible("#login")
         b.set_val('#login-user-input', "admin")
         b.set_val('#login-password-input', "foobar")
         b.click('#login-button')
-        b.expect_reload()
+        b.expect_load()
 
         # Page should show automatically now that other frame logged in
         b.switch_to_top()

--- a/test/check-keys
+++ b/test/check-keys
@@ -48,7 +48,7 @@ class TestKeys(MachineCase):
             b.set_val("#login-user-input", user)
             b.set_val("#login-password-input", password)
             b.click('#login-button')
-            b.expect_reload()
+            b.expect_load()
             b.enter_page("/system")
             b.switch_to_top()
             b.wait_text('#content-user-name', user_name)

--- a/test/check-kubernetes
+++ b/test/check-kubernetes
@@ -182,7 +182,21 @@ class TestKubernetes(KubernetesCase):
         b.click("#content .listing-panel li a:contains('Logs')")
         b.wait_present(".listing-panel pre.logs")
         b.wait_visible(".listing-panel pre.logs")
-        b.wait_in_text(".listing-panel pre.logs", "HelloMessage.")
+
+        # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1261459
+        # This is broken in Fedora 22
+        # b.wait_in_text(".listing-panel pre.logs", "HelloMessage.")
+
+        def line_sel(i):
+            return '#terminal .terminal div:nth-child(%d)' % i
+
+        b.click("#content .listing-panel li a:contains('Shell')")
+        b.wait_present(".listing-panel div.terminal")
+        b.wait_visible(".listing-panel div.terminal")
+        b.wait_in_text(".listing-panel .terminal div:nth-child(1)", "#")
+        b.focus('.listing-panel .terminal')
+        b.key_press( [ 'w', 'h', 'o', 'a', 'm', 'i', 'Return' ] )
+        b.wait_in_text(".listing-panel .terminal div:nth-child(2)", "root")
 
         # Check that service shows up on listing view
         b.click("a[href='#/list']")

--- a/test/check-kubernetes
+++ b/test/check-kubernetes
@@ -219,7 +219,7 @@ class TestKubernetes(KubernetesCase):
 
         # Click the filter button to make only selected
         b.click(".filter-menu .btn:first-child")
-        self.assertEqual(b.text(".filter-menu li.active"), " Only selected items ")
+        b.wait_text(".filter-menu li.active", " Only selected items ")
         self.assertFalse(b.is_present(".details-listing thead th"))
         self.assertFalse(b.is_present(".details-listing tbody tr.listing-item"))
         self.assertTrue(b.is_present(".details-listing tr.listing-panel"))
@@ -227,10 +227,10 @@ class TestKubernetes(KubernetesCase):
         # Clear the selection via the menu
         b.click(".filter-menu .btn.dropdown-toggle")
         b.click(".filter-menu li:last-child a")
+        b.wait_text(".filter-menu li.active", " View all items ")
         self.assertTrue(b.is_present(".details-listing thead th"))
         self.assertTrue(b.is_present(".details-listing tbody tr.listing-item"))
         self.assertFalse(b.is_present(".details-listing tr.listing-panel"))
-        self.assertEqual(b.text(".filter-menu li.active"), " View all items ")
 
         # Back to dashboard
         b.click("a[href='#/']")

--- a/test/check-login
+++ b/test/check-login
@@ -71,7 +71,7 @@ class TestLogin(MachineCase):
         b.open("/system")
         login("admin", "foobar")
         with b.wait_timeout(10) as r:
-            b.expect_reload()
+            b.expect_load()
         b.wait_present("#content")
         b.wait_text('#content-user-name', 'Administrator')
 

--- a/test/check-multi-machine
+++ b/test/check-multi-machine
@@ -244,7 +244,7 @@ class TestMultiMachine(MachineCase):
         # Bad host also bounces
         b.go("/@10.0.0.0/playground/test")
         b.wait_present(".curtains");
-        self.assertEqual(b.text(".curtains h1"), "Couldn't connect to the machine")
+        b.wait_text(".curtains h1", "Couldn't connect to the machine")
         self.assertEqual(b.text(".curtains p"), "Cannot connect to an unknown machine")
 
         self.allow_restart_journal_messages()

--- a/test/check-multi-machine-key
+++ b/test/check-multi-machine-key
@@ -67,24 +67,12 @@ LOAD_KEYS = [
 KEY_IDS = [
 
 ]
-def test_keys(b, keys):
-    b.call_js_func("""(function () {
-        require(["base1/cockpit"], function(cockpit) {
-            window.test_result = null;
-            cockpit.spawn([ "ssh-add", "-l" ]).
-                done(function (data) {
-                    window.test_result = data;
-                }).
-                fail(function (error) {
-                    console.log(error);
-                });
-        });
-    })""",)
-
-    b.wait_js_func("(function (expected) { return window.test_result == expected; })", "\n".join(keys) + "\n")
-
 @unittest.skipIf("atomic" in os.environ.get("TEST_OS", "") or "rhel" in os.environ.get("TEST_OS", ""), "key auth: not supported")
 class TestMultiMachineKeyAuth(MachineCase):
+
+    def check_keys(self, keys):
+        self.assertEqual(self.browser.eval_js("require('base1/cockpit').spawn([ 'ssh-add', '-l' ])"),
+                         "\n".join(keys) + "\n")
 
     def setUp(self):
         MachineCase.setUp(self)
@@ -137,7 +125,7 @@ class TestMultiMachineKeyAuth(MachineCase):
             assert False, "No running ssh-agent found"
 
         # Check our keys were loaded.
-        test_keys(b, [
+        self.check_keys([
             "2048 SHA256:SRvBhCmkCEVnJ6ascVH0AoVEbS3nPbowZkNevJnXtgw /home/admin/.ssh/id_rsa (RSA)",
             "256 SHA256:dyHF4jiKz6RolQqORIATqhbZ4kil5cyiMQWizbQWU8k /home/admin/.ssh/id_ecdsa (ECDSA)",
             "256 SHA256:Uht4NX54Gjz62cNA8+LrHo63HiFW/i5aWg/cl/A3X+c /home/admin/.ssh/id_ed25519 (ED25519)",

--- a/test/check-multi-os
+++ b/test/check-multi-os
@@ -83,7 +83,7 @@ class TestMultiOS(MachineCase):
             browser.set_val('#login-user-input', browser.default_user)
             browser.set_val('#login-password-input', "foobar")
             browser.click('#login-button')
-            browser.expect_reload()
+            browser.expect_load()
             browser.wait_present('#content')
             browser.wait_visible('#content')
             if page:

--- a/test/check-multi-os
+++ b/test/check-multi-os
@@ -49,43 +49,19 @@ def add_machine(b, address):
     b.click('#dashboard_setup_next')
     b.wait_popdown('dashboard_setup_server_dialog')
 
-def test_spawn(b, address):
-    b.call_js_func("""(function (address) {
-        require(["base1/cockpit"], function(cockpit) {
-            window.test_result = null;
-            cockpit.spawn([ "echo", "hi" ], { host: address }).
-                done(function (data) {
-                    window.test_result = data;
-                }).
-                fail(function (error) {
-                    console.log(error);
-                });
-        });
-    })""", address)
-
-    b.wait_js_func("(function (expected) { return window.test_result == expected; })",
-                   "hi\n")
-
-def test_dbus(b, address):
-    b.call_js_func("""(function (address) {
-        require(["base1/cockpit"], function(cockpit) {
-            window.test_result = null;
-            var p = cockpit.dbus("org.freedesktop.DBus", { host: address }).proxy("org.freedesktop.DBus", "/");
-            p.wait(function() {
-                if (p.valid) {
-                    p.GetId().
-                        done(function (id) {
-                            window.test_result = id;
-                        });
-                }
-            });
-        });
-    })""", address)
-
-    b.wait_js_func("(function () { return window.test_result != null; })");
-
-
 class TestMultiOS(MachineCase):
+    def check_spawn(self, b, address):
+        result = b.call_js_func("""(function(address) {
+            return require("base1/cockpit").spawn(['echo', 'hi'], { host: address });
+        })""", address)
+        self.assertEqual(result, "hi\n")
+
+    def check_dbus(self, b, address):
+        b.call_js_func("""(function(address) {
+            return require("base1/cockpit").dbus("org.freedesktop.DBus", { host: address })
+                .proxy("org.freedesktop.DBus", "/").call("GetId");
+        })""", address)
+
     def checkStock(self, system):
         dev_m = self.machine
         dev_b = self.browser
@@ -143,11 +119,11 @@ class TestMultiOS(MachineCase):
         dev_dashboard_addresses.append(stock_m.address)
         wait_dashboard_addresses (dev_b, dev_dashboard_addresses)
 
-        test_dbus(stock_b, dev_m.address)
-        test_dbus(dev_b, stock_m.address)
+        self.check_dbus(stock_b, dev_m.address)
+        self.check_dbus(dev_b, stock_m.address)
 
-        test_spawn(stock_b, dev_m.address)
-        test_spawn(dev_b, stock_m.address)
+        self.check_spawn(stock_b, dev_m.address)
+        self.check_spawn(dev_b, stock_m.address)
 
         dev_b.switch_to_top()
         dev_b.go("/@%s/network/interfaces" % stock_m.address)

--- a/test/check-networking
+++ b/test/check-networking
@@ -56,7 +56,7 @@ class TestNetworking(MachineCase):
             self.browser.wait(is_valid)
         except:
             print "Interface %s didn't show up." % iface
-            print self.browser.eval_js("return $('#networking-interfaces').html();")
+            print self.browser.eval_js("$('#networking-interfaces').html();")
             print self.machine.execute("grep . /sys/class/net/*/address")
             raise
 

--- a/test/check-networking
+++ b/test/check-networking
@@ -56,7 +56,7 @@ class TestNetworking(MachineCase):
             self.browser.wait(is_valid)
         except:
             print "Interface %s didn't show up." % iface
-            print self.browser.eval_js("$('#networking-interfaces').html();")
+            print self.browser.eval_js("$('#networking-interfaces').html()")
             print self.machine.execute("grep . /sys/class/net/*/address")
             raise
 

--- a/test/check-roles
+++ b/test/check-roles
@@ -40,7 +40,7 @@ class TestRoles(MachineCase):
         b.open("/system")
         b.wait_visible("#login")
         login("user", "foobar")
-        b.expect_reload()
+        b.expect_load()
         b.enter_page("/system")
         b.switch_to_top()
         b.wait_text('#content-user-name', 'User')

--- a/test/check-services
+++ b/test/check-services
@@ -109,6 +109,7 @@ ExecStart=/usr/bin/test-service %I
 
         b.go("#/")
         b.wait_in_text("#services", "test-fail.service")
+        b.wait_visible(svc_sel("test-fail.service"))
         b.click(svc_sel("test-fail.service"))
         b.wait_visible('#service-valid')
         b.wait_in_text('#service-valid', "inactive")

--- a/test/check-session
+++ b/test/check-session
@@ -59,7 +59,7 @@ class TestSession(MachineCase):
         b.set_val("#login-user-input", "admin")
         b.set_val("#login-password-input", "foobar")
         b.click('#login-button')
-        b.expect_reload()
+        b.expect_load()
         b.enter_page("/system")
         wait_session(True)
 

--- a/test/check-storage-msdos
+++ b/test/check-storage-msdos
@@ -68,7 +68,7 @@ class TestStorage(StorageCase):
         # Create a extended partition to fill the rest of the disk
         self.content_single_action(2, "Create Partition")
         self.dialog_wait_open()
-        self.assertEqual(b.attr("option[value='dos-extended']", "disabled"), "")
+        b.wait_not_attr("option[value='dos-extended']", "disabled", "disabled")
         self.dialog_set_val("type", "dos-extended")
         self.dialog_wait_not_visible("name")
         self.dialog_wait_not_visible("mounting")

--- a/test/check-storage-multipath
+++ b/test/check-storage-multipath
@@ -40,7 +40,7 @@ class TestStorage(StorageCase):
             b.wait_text(detail_row_name(index), name)
 
         def check_free_block_devices(expected):
-            blocks = b.eval_js ("return ph_texts('#dialog [data-field=\"disks\"] .checkbox')")
+            blocks = b.eval_js("ph_texts('#dialog [data-field=\"disks\"] .checkbox')")
             if len(blocks) != len(expected):
                 return False
             for i in range(len(expected)):

--- a/test/check-storage-unused
+++ b/test/check-storage-unused
@@ -60,7 +60,7 @@ mkpart logical ext2 24 48"""
         # are offered as free block devices.
 
         def check_free_block_devices():
-            blocks = b.eval_js ("return ph_texts('#dialog [data-field=\"disks\"] .checkbox')")
+            blocks = b.eval_js("ph_texts('#dialog [data-field=\"disks\"] .checkbox')")
             return len(blocks) == 2 and "/dev/sda6" in blocks[0] and "/dev/sdb" in blocks[1]
 
         self.dialog_with_retry(trigger = lambda: b.click('#create-mdraid'),

--- a/test/phantom-driver
+++ b/test/phantom-driver
@@ -95,11 +95,11 @@ var driver = {
     },
 
     reload: function(respond) {
-        this.expect_reload(respond);
-        page.reload({ result: null });
+        this.expect_load(respond);
+        page.reload();
     },
 
-    expect_reload: function(respond) {
+    expect_load: function(respond) {
         var failure = null;
         var res = null;
 
@@ -108,7 +108,7 @@ var driver = {
             page.onLoadFinished = null;
             clearTimeout(wait);
             if (res === "success")
-                respond({ result: null });
+                respond({ result: res });
             else
                 respond({ error: res });
         }
@@ -137,7 +137,7 @@ var driver = {
             wait = setTimeout(function() {
                 wait = null;
                 finish();
-            }, 200);
+            }, 500);
         };
     },
 

--- a/test/phantom-driver
+++ b/test/phantom-driver
@@ -24,7 +24,7 @@
  * This program reads a line from stdin, executes the command
  * specified by it, and replies back with a line on stdout.
  *
- * The two main commands are "do" and "wait". "Do" will execute
+ * The two main commands are "eval" and "wait". "eval" will execute
  * arbitrary JavaScript in the context of the web page.  "Wait" will
  * run the event loop of the browser until the given condition is
  * true.
@@ -48,38 +48,17 @@ var page = require('webpage').create();
 var sys = require('system');
 
 var onCheckpoint;
-var lastError;
 var waitTimeout;
 var didTimeout;
 
-function arm_timeout(timeout) {
-    if (waitTimeout)
-        return false;
-
-    didTimeout = false;
-    waitTimeout = setTimeout (function () {
-        waitTimeout = null;
-        didTimeout = true;
-        if (onCheckpoint)
-            onCheckpoint();
-    }, timeout || 5000);
-    return true;
-}
-
-function disarm_timeout() {
-    if (!waitTimeout)
-        return false;
-
-    clearTimeout(waitTimeout);
-    waitTimeout = null;
-    didTimeout = false;
-    return true;
-}
-
 page.viewportSize = { width: 800, height: 480 };
 
-var canary = "phantom-canary" + -(Date());
+var unique = 1;
+function slot() {
+    return "phantom-slot-" + (unique++);
+}
 
+var canary = slot();
 function inject_basics() {
     var i, len;
     if (!page.evaluate(function(x) { return x in window; }, canary)) {
@@ -96,9 +75,7 @@ function inject_basics() {
 }
 
 var driver = {
-    timeout: 60 * 1000,
-
-    open: function(url) {
+    open: function(respond, url) {
         var failure = null;
 
         page.onResourceError = function(ex) {
@@ -109,7 +86,7 @@ var driver = {
             page.onLoadFinished = null;
             page.onResourceError = null;
             if (status == "success")
-                respond();
+                respond({ result: null });
             else
                 respond({ error: failure || status });
         };
@@ -117,32 +94,24 @@ var driver = {
 	page.open(url);
     },
 
-    reload: function() {
-        this.expect_reload();
-        page.reload();
+    reload: function(respond) {
+        this.expect_reload(respond);
+        page.reload({ result: null });
     },
 
-    expect_reload: function() {
+    expect_reload: function(respond) {
         var failure = null;
         var res = null;
-        var timer = null;
 
         function finish() {
             page.onResourceError = null;
             page.onLoadFinished = null;
             clearTimeout(wait);
-            clearTimeout(timer);
             if (res === "success")
-                respond();
+                respond({ result: null });
             else
                 respond({ error: res });
         }
-
-        timer = setTimeout(function() {
-            timer = null;
-            res = "timeout";
-            finish();
-        }, this.timeout);
 
         page.onResourceError = function(ex) {
             failure = ex.errorString + " " + ex.url;
@@ -172,103 +141,129 @@ var driver = {
         };
     },
 
-    switch_frame: function(name) {
+    switch_frame: function(respond, name) {
         if (page.switchToFrame(name))
-            respond();
+            respond({ result: null });
         else
             respond({ error: "Can't switch to frame: " + name });
     },
 
-    switch_top: function() {
+    switch_top: function(respond) {
         page.switchToMainFrame();
-        respond();
+        respond({ result: null });
     },
 
-    show: function(file) {
+    show: function(respond, file) {
         if (!file)
             file = "page.png"
         page.render(file);
         sys.stderr.writeLine("Wrote " + file)
-        respond();
+        respond({ result: null });
     },
 
-    quit: function() {
+    quit: function(respond) {
         sys.stdout.writeLine(JSON.stringify({ result: true }));
         phantom.exit(0);
     },
 
-    sit: function() {
+    sit: function(respond) {
         sys.stdout.writeLine(JSON.stringify({ result: true }));
         // fall through to the phantom event loop
     },
 
-    eval: function(code) {
-        lastError = null;
+    eval: function(respond, code) {
+	var x = slot();
+
+        /* Execute the code and put result in slot */
         inject_basics();
-        var func = "function () { " + code + "}";
-        try {
-            var val = page.evaluate(func);
-        } catch(ex) {
-            respond({ error: String(ex) });
-        }
-        respond({ result: val });
+        page.evaluate("function(x) { window[x] = (" + code + ") }", x);
+
+        /* Check for value in the slot and/or wait for it if promise */
+        return function check() {
+            inject_basics();
+            var result = page.evaluate(function(x) {
+                var res = null, val;
+
+                if (!(x in window))
+                    return null; /* not ready */
+
+                val = window[x];
+                delete window[x];
+
+                /* A promise */
+                if (val && typeof(val.always) === "function") {
+                    val.always(function(v) {
+                        if (this.state() === "rejected")
+                            throw v;
+                        else
+                            window[x] = v;
+                        phantom_checkpoint();
+                    });
+
+                    /* Not yet ready */
+                    return null;
+
+                /* Any other value besides a promise */
+                } else {
+                    res = { result: val === undefined ? null : val };
+                }
+
+                return res;
+            }, x);
+
+            if (result)
+                respond(result);
+        };
     },
 
-    wait: function(cond) {
+    wait: function(respond, cond) {
         var func = "function () { return " + cond + "}";
-        var local_timeout;
-
-        function resp(out) {
-            onCheckpoint = null;
-            if (local_timeout)
-                disarm_timeout();
-            respond(out);
-        }
-
-        function check() {
+        return function check() {
             inject_basics();
             var val = page.evaluate(func);
-            if (val) {
-                if (didTimeout) {
-                    sys.stderr.writeLine("WARNING: condition '" + cond +
-                            "' was true after timeout, add some more checkpoints");
-                }
-                resp({ result: val });
-            } else if (didTimeout) {
-                resp ({ error: "timeout" });
-            }
+            if (val)
+                respond({ result: val });
         }
-
-        onCheckpoint = check;
-        local_timeout = arm_timeout(this.timeout);
-        check();
     },
 
-    arm_timeout: function() {
-        if (arm_timeout(this.timeout))
-            respond({ result: true });
-        else
+    arm_timeout: function(respond, timeout) {
+        if (waitTimeout) {
             respond({ error: "timeout already armed" });
-    },
-
-    disarm_timeout: function() {
-        if (disarm_timeout())
-            respond({ result: true });
-        else
-            respond({ error: "no timeout armed" });
-    },
-
-    wait_checkpoint: function() {
-        onCheckpoint = function () {
-            onCheckpoint = null;
-            if (didTimeout)
-                respond({ error: "timeout" });
-            else
-                respond({ result: true });
+            return;
         }
+
+        didTimeout = false;
+        waitTimeout = setTimeout(function() {
+            waitTimeout = null;
+            didTimeout = true;
+        }, timeout || 5000);
+        respond({ result: true });
     },
 
-    keys: function(type, keys, modifier) {
+    wait_checkpoint: function(respond) {
+        var first = true;
+        return function check() {
+            if (didTimeout)
+                respond({ error: "timeout happened" });
+            if (!first)
+                respond({ result: null });
+            first = false;
+        };
+    },
+
+    disarm_timeout: function(respond) {
+        if (!waitTimeout) {
+            respond({ error: "no timeout armed" });
+            return;
+        }
+
+        clearTimeout(waitTimeout);
+        waitTimeout = null;
+        didTimeout = false;
+        respond({ result: true });
+    },
+
+    keys: function(respond, type, keys, modifier) {
         var i;
         if (typeof keys == "string") {
             page.sendEvent(type, keys, null, null, modifier || 0);
@@ -280,59 +275,88 @@ var driver = {
                 page.sendEvent(type, k, null, null, modifier || 0);
             }
         }
-        respond();
+        respond({ result: null });
     },
 
-    upload_file: function(selector, file) {
+    upload_file: function(respond, selector, file) {
         page.uploadFile(selector, file);
-        respond();
+        respond({ result: null });
     },
 
-    ping: function() {
+    ping: function(respond) {
         respond({ result: "pong" });
     },
 };
 
-var first = true;
+function step() {
+    var line = sys.stdin.readLine();
+    var cmd = null, args;
 
-function respond(out) {
-    if (!first) {
-        if (lastError) {
-            out = { error: lastError };
-            lastError = null;
-        } else if (arguments.length === 0) {
-            out = { result: null };
-        }
-        sys.stdout.writeLine(JSON.stringify(out));
+    var responded = false;
+    var timeout = null;
+    var check = null;
+
+    try {
+        cmd = JSON.parse(line || "null");
+    } catch(ex) {
+        sys.stderr.writeLine("ERROR: Couldn't parse message: " + String(ex));
     }
 
-    first = false;
+    if (!cmd) {
+        phantom.exit(0);
+        return;
+    }
 
-    setTimeout(function() {
-        var line = sys.stdin.readLine();
+    /* Timeout is cleared when responding */
+    timeout = window.setTimeout(function() {
+        if (check)
+            check();
+        if (responded)
+            sys.stderr.writeLine("WARNING: " + line + " was true after timeout, add more checkpoints");
+        else
+            respond({ error: "timeout" });
+    }, cmd.timeout || 60 * 1000);
 
-        if (line == "" && sys.stdin.atEnd()) {
-            phantom.exit(0);
+    /* This function is called when functions want to respond */
+    function respond(out) {
+        var line = JSON.stringify(out);
+        if (responded) {
+            sys.stderr.writeLine("WARNING: Already responded, discarding result: " + line);
             return;
         }
 
-        var cmd;
-        try {
-            cmd = JSON.parse(line);
-        } catch(ex) {
-            respond({ error: String(ex) });
-            return;
-        }
+        window.clearTimeout(timeout);
+        page.onError = null;
+        timeout = null;
+        responded = true;
+        onCheckpoint = null;
 
-        if (onCheckpoint) {
-            respond({ error: "assertion: onCheckpoint should be cleared in phantom-driver" });
-        } else if (cmd.cmd in driver) {
-            driver.timeout = cmd.timeout || driver.timeout;
-            driver[cmd.cmd].apply(driver, cmd.args || args);
-        } else {
-            respond({ error: "No such method defined: " + cmd.cmd });
-        }
-    }, 0);
+        sys.stdout.writeLine(line);
+        step();
+    };
+
+    page.onError = function(msg, trace) {
+        var i, backtrace = "";
+        for (i = 0; i < trace.length; i++)
+            backtrace += "\n" + trace[i].file + " " + trace[i].line + " " + trace[i].function;
+        sys.stderr.writeLine("Page error: " + msg + backtrace);
+        respond({ error: msg });
+    }
+
+    if (cmd.cmd in driver) {
+        args = (cmd.args || []).slice();
+        args.unshift(respond);
+        check = driver[cmd.cmd].apply(driver, args);
+    } else {
+        respond({ error: "No such method defined: " + cmd.cmd });
+    }
+
+    /* Caller has not responded */
+    if (!responded && check) {
+        check();
+        if (!responded)
+            onCheckpoint = check;
+    }
 }
 
 page.onConsoleMessage = function(msg, lineNum, sourceId) {
@@ -344,14 +368,4 @@ page.onConsoleMessage = function(msg, lineNum, sourceId) {
         sys.stderr.writeLine('> ' + msg);
 };
 
-page.onError = function(msg, trace) {
-    var i;
-    var backtrace = "";
-    for (i = 0; i < trace.length; i++)
-        backtrace += "\n" + trace[i].file + " " + trace[i].line + " " + trace[i].function;
-    sys.stderr.writeLine("Page error: " + msg + backtrace);
-    lastError = msg;
-}
-
-/* Get ready for message */
-respond();
+step();

--- a/test/phantom-driver
+++ b/test/phantom-driver
@@ -78,14 +78,6 @@ function disarm_timeout() {
 
 page.viewportSize = { width: 800, height: 480 };
 
-function result(out) {
-    if (lastError) {
-        out = { error: lastError };
-        lastError = null;
-    }
-    sys.stdout.writeLine(JSON.stringify(out));
-}
-
 var canary = "phantom-canary" + -(Date());
 
 function inject_basics() {
@@ -103,11 +95,36 @@ function inject_basics() {
     }
 }
 
-function step ()
-{
-    function wait_reload(callback, timeout) {
+var driver = {
+    timeout: 60 * 1000,
+
+    open: function(url) {
         var failure = null;
-        var result = null;
+
+        page.onResourceError = function(ex) {
+            failure = ex.errorString + " " + ex.url;
+        };
+
+        page.onLoadFinished = function(status) {
+            page.onLoadFinished = null;
+            page.onResourceError = null;
+            if (status == "success")
+                respond();
+            else
+                respond({ error: failure || status });
+        };
+
+	page.open(url);
+    },
+
+    reload: function() {
+        this.expect_reload();
+        page.reload();
+    },
+
+    expect_reload: function() {
+        var failure = null;
+        var res = null;
         var timer = null;
 
         function finish() {
@@ -115,22 +132,25 @@ function step ()
             page.onLoadFinished = null;
             clearTimeout(wait);
             clearTimeout(timer);
-            callback(result);
+            if (res === "success")
+                respond();
+            else
+                respond({ error: res });
         }
 
         timer = setTimeout(function() {
             timer = null;
-            result = "timeout";
+            res = "timeout";
             finish();
-        }, timeout || 10000);
+        }, this.timeout);
 
         page.onResourceError = function(ex) {
             failure = ex.errorString + " " + ex.url;
         };
 
-	/*
-	 * HACK: phantomjs fires the page.onLoadFinished() handler
-	 * for each iframe, sometimes with the iframe triggering the
+        /*
+         * HACK: phantomjs fires the page.onLoadFinished() handler
+         * for each iframe, sometimes with the iframe triggering the
          * event first. This leads to race conditions.
          *
          * The only work around is to use a timeout.
@@ -142,173 +162,176 @@ function step ()
             if (status != "success" && failure)
                 status = failure;
             failure = null;
-            if (!result || result != "success")
-                result = status;
-	    clearTimeout(wait);
-	    wait = setTimeout(function() {
+            if (!res || res != "success")
+                res = status;
+            clearTimeout(wait);
+            wait = setTimeout(function() {
                 wait = null;
                 finish();
             }, 200);
         };
+    },
+
+    switch_frame: function(name) {
+        if (page.switchToFrame(name))
+            respond();
+        else
+            respond({ error: "Can't switch to frame: " + name });
+    },
+
+    switch_top: function() {
+        page.switchToMainFrame();
+        respond();
+    },
+
+    show: function(file) {
+        if (!file)
+            file = "page.png"
+        page.render(file);
+        sys.stderr.writeLine("Wrote " + file)
+        respond();
+    },
+
+    quit: function() {
+        sys.stdout.writeLine(JSON.stringify({ result: true }));
+        phantom.exit(0);
+    },
+
+    sit: function() {
+        sys.stdout.writeLine(JSON.stringify({ result: true }));
+        // fall through to the phantom event loop
+    },
+
+    eval: function(code) {
+        lastError = null;
+        inject_basics();
+        var func = "function () { " + code + "}";
+        try {
+            var val = page.evaluate(func);
+        } catch(ex) {
+            respond({ error: String(ex) });
+        }
+        respond({ result: val });
+    },
+
+    wait: function(cond) {
+        var func = "function () { return " + cond + "}";
+        var local_timeout;
+
+        function resp(out) {
+            onCheckpoint = null;
+            if (local_timeout)
+                disarm_timeout();
+            respond(out);
+        }
+
+        function check() {
+            inject_basics();
+            var val = page.evaluate(func);
+            if (val) {
+                if (didTimeout) {
+                    sys.stderr.writeLine("WARNING: condition '" + cond +
+                            "' was true after timeout, add some more checkpoints");
+                }
+                resp({ result: val });
+            } else if (didTimeout) {
+                resp ({ error: "timeout" });
+            }
+        }
+
+        onCheckpoint = check;
+        local_timeout = arm_timeout(this.timeout);
+        check();
+    },
+
+    arm_timeout: function() {
+        if (arm_timeout(this.timeout))
+            respond({ result: true });
+        else
+            respond({ error: "timeout already armed" });
+    },
+
+    disarm_timeout: function() {
+        if (disarm_timeout())
+            respond({ result: true });
+        else
+            respond({ error: "no timeout armed" });
+    },
+
+    wait_checkpoint: function() {
+        onCheckpoint = function () {
+            onCheckpoint = null;
+            if (didTimeout)
+                respond({ error: "timeout" });
+            else
+                respond({ result: true });
+        }
+    },
+
+    keys: function(type, keys, modifier) {
+        var i;
+        if (typeof keys == "string") {
+            page.sendEvent(type, keys, null, null, modifier || 0);
+        } else {
+            for (i = 0; i < keys.length; i++) {
+                var k = keys[i];
+                if (typeof k == "string" && k.length > 1)
+                    k = page.event.key[k];
+                page.sendEvent(type, k, null, null, modifier || 0);
+            }
+        }
+        respond();
+    },
+
+    upload_file: function(selector, file) {
+        page.uploadFile(selector, file);
+        respond();
+    },
+
+    ping: function() {
+        respond({ result: "pong" });
+    },
+};
+
+var first = true;
+
+function respond(out) {
+    if (!first) {
+        if (lastError) {
+            out = { error: lastError };
+            lastError = null;
+        } else if (arguments.length === 0) {
+            out = { result: null };
+        }
+        sys.stdout.writeLine(JSON.stringify(out));
     }
 
-    function wait_open(callback) {
-        var failure = null;
+    first = false;
 
-        page.onResourceError = function(ex) {
-            failure = ex.errorString + " " + ex.url;
-        };
+    setTimeout(function() {
+        var line = sys.stdin.readLine();
 
-        page.onLoadFinished = function(status) {
-            if (status != "success" && failure)
-                status = failure;
-            page.onLoadFinished = null;
-            page.onResourceError = null;
-            callback(status);
-        };
-    }
-
-    setTimeout(function () {
-        if (onCheckpoint)
-            throw "nope";
-
-        var cmdline = sys.stdin.readLine();
-
-        if (cmdline == "" && sys.stdin.atEnd()) {
+        if (line == "" && sys.stdin.atEnd()) {
             phantom.exit(0);
             return;
         }
 
-        // sys.stderr.writeLine(cmdline);
-
-        var cmd = JSON.parse(cmdline);
-
-        function on_load(status) {
-            sys.stdout.writeLine(JSON.stringify({ result: status }));
-            step();
+        var cmd;
+        try {
+            cmd = JSON.parse(line);
+        } catch(ex) {
+            respond({ error: String(ex) });
+            return;
         }
 
-        if (cmd.cmd == "open") {
-            wait_open(on_load);
-            page.open(cmd.url);
-        } else if (cmd.cmd == "reload") {
-            wait_reload(on_load, cmd.timeout);
-            page.reload();
-        } else if (cmd.cmd == "expect-reload") {
-            wait_reload(on_load, cmd.timeout);
-        } else if (cmd.cmd == "inject") {
-            inject_basics();
-            var ret = page.injectJs(cmd.file);
-            result({ result: ret });
-            step();
-        } else if (cmd.cmd == "switch") {
-            if (page.switchToFrame(cmd.name))
-                result({ result: true });
-            else
-                result({ error: "Can't switch to frame" });
-            step();
-        } else if (cmd.cmd == "switch_top") {
-            page.switchToMainFrame();
-            result({ result: true });
-            step();
-        } else if (cmd.cmd == "switch_parent") {
-            if (page.switchToParentFrame())
-                result({ result: true });
-            else
-                result({ error: "Can't switch to parent frame" });
-            step();
-        } else if (cmd.cmd == "show") {
-            page.render(cmd.file || "page.png");
-            result({ result: true });
-            step();
-        } else if (cmd.cmd == "quit") {
-            result({ result: true });
-            phantom.exit(0);
-        } else if (cmd.cmd == "sit") {
-            result({ result: true });
-            // fall through to the phantom event loop
-        } else if (cmd.cmd == "do") {
-            lastError = null;
-            inject_basics();
-            var func = "function () { " + cmd.code + "}";
-            var val = page.evaluate (func);
-            result({ result: val });
-            step ();
-        } else if (cmd.cmd == "wait") {
-            var func = "function () { return " + cmd.cond + "}";
-            var local_timeout;
-
-            function respond(val)
-            {
-                onCheckpoint = null;
-                result(val);
-                if (local_timeout)
-                    disarm_timeout();
-                step ();
-            }
-
-            function check() {
-                inject_basics();
-                var val = page.evaluate (func);
-                if (val) {
-                    if (didTimeout)
-                        sys.stderr.writeLine("WARNING: condition '" + cmd.cond + "' was true after timeout, add some more checkpoints");
-                    respond ({result: val});
-                } else if (didTimeout)
-                    respond ({timeout: true});
-            }
-
-            onCheckpoint = check;
-
-            local_timeout = arm_timeout(cmd.timeout);
-            check ();
-        } else if (cmd.cmd == "armtimeout") {
-            if (arm_timeout(cmd.timeout))
-                result({ result: true });
-            else
-                result({ error: "timeout already armed" });
-            step();
-        } else if (cmd.cmd == "disarmtimeout") {
-            if (disarm_timeout(cmd.timeout))
-                result({ result: true });
-            else
-                result({ error: "no timeout armed" });
-            step();
-        } else if (cmd.cmd == "waitcheckpoint") {
-            onCheckpoint = function () {
-                onCheckpoint = null;
-                if (didTimeout)
-                    result({ timeout: true });
-                else
-                    result({ result: true });
-                step();
-            }
-        } else if (cmd.cmd == "keys") {
-            var i;
-            if (typeof cmd.keys == "string")
-                page.sendEvent (cmd.type, cmd.keys, null, null, cmd.modifier || 0);
-            else {
-                for (i = 0; i < cmd.keys.length; i++) {
-                    var k = cmd.keys[i];
-                    if (typeof k == "string" && k.length > 1)
-                        k = page.event.key[k];
-                    page.sendEvent (cmd.type, k, null, null, cmd.modifier || 0);
-                }
-            }
-            result({ result: true });
-            step ();
-        } else if (cmd.cmd == "upload") {
-            page.uploadFile(cmd.selector, cmd.file);
-            result({ result: true });
-            step();
-        } else if (cmd.cmd == "ping") {
-            result({ result: "pong" });
-            step();
+        if (onCheckpoint) {
+            respond({ error: "assertion: onCheckpoint should be cleared in phantom-driver" });
+        } else if (cmd.cmd in driver) {
+            driver.timeout = cmd.timeout || driver.timeout;
+            driver[cmd.cmd].apply(driver, cmd.args || args);
         } else {
-            result({ error: "?" });
-            step ();
+            respond({ error: "No such method defined: " + cmd.cmd });
         }
-
     }, 0);
 }
 
@@ -330,4 +353,5 @@ page.onError = function(msg, trace) {
     lastError = msg;
 }
 
-step();
+/* Get ready for message */
+respond();

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -93,7 +93,7 @@ class Browser:
         self.phantom = Phantom("en_US.utf8")
 
     def title(self):
-        return self.phantom.eval('document.title');
+        return self.phantom.eval('document.title')
 
     def open(self, href):
         """
@@ -269,10 +269,10 @@ class Browser:
         self.wait_not_visible('#' + id)
 
     def arm_timeout(self):
-        return self.phantom.arm_timeout(self.phantom.timeout)
+        return self.phantom.arm_timeout(self.phantom.timeout * 1000)
 
     def disarm_timeout(self):
-        return self.phantom.disarm_timeout(self.phantom.timeout)
+        return self.phantom.disarm_timeout()
 
     def wait_checkpoint(self):
         return self.phantom.wait_checkpoint()
@@ -633,7 +633,7 @@ class Phantom:
             if arg_trace:
                 print "<-", repr(res['result'])
             return res['result']
-        raise Error("unexpected")
+        raise Error("unexpected: " + line.strip())
 
     def start(self):
         environ = os.environ.copy()

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -132,8 +132,8 @@ class Browser:
         self.wait_js_cond("ph_select('iframe.container-frame').every(function (e) { return e.getAttribute('data-loaded'); })")
         self.phantom.reload()
 
-    def expect_reload(self):
-        self.phantom.expect_reload()
+    def expect_load(self):
+        self.phantom.expect_load()
 
     def switch_to_frame(self, name):
         self.phantom.switch_frame(name)
@@ -359,7 +359,7 @@ class Browser:
         self.set_val('#login-user-input', user)
         self.set_val('#login-password-input', "foobar")
         self.click('#login-button')
-        self.expect_reload()
+        self.expect_load()
         self.wait_present('#content')
         self.wait_visible('#content')
         if path:
@@ -367,9 +367,10 @@ class Browser:
 
     def logout(self):
         self.switch_to_top()
+        self.wait_present("#content-user-name")
         self.click("#content-user-name")
         self.click('#go-logout')
-        self.expect_reload()
+        self.expect_load()
 
     def relogin(self, path=None, user=None):
         if user is None:
@@ -379,7 +380,7 @@ class Browser:
         self.set_val("#login-user-input", user)
         self.set_val("#login-password-input", "foobar")
         self.click('#login-button')
-        self.expect_reload()
+        self.expect_load()
         self.wait_present('#content')
         self.wait_visible('#content')
         if path:

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -17,7 +17,7 @@
 %define rev 1
 
 %if %{defined gitcommit}
-%define extra_flags CFLAGS='-O2 -Wall -Werror -fPIC -g'
+%define extra_flags CFLAGS='-O2 -Wall -Werror -fPIC -g -DWITH_DEBUG'
 %define branding default
 %endif
 


### PR DESCRIPTION
This pull requests implements waiting on promises in test code. So we can evaluate an expression that returns a promise, and in python we'll only get back a response (or exception) when the promise completes.

In addition I've cleaned up the phantom-driver and Phantom implementations.