### PR TITLE
test: Wait for network interface row to be visible as well.

### DIFF
--- a/test/check-networking
+++ b/test/check-networking
@@ -50,6 +50,7 @@ class TestNetworking(MachineCase):
             return False
 
         self.browser.wait_present(sel)
+        self.browser.wait_visible(sel)
         self.browser.wait(is_valid)
 
     def switch_off_rp_filter(self, m):


### PR DESCRIPTION
Possibly fixes #2903 

Maybe this is all that is needed.  Can't hurt in any case.
