### PR TITLE
Fix ambigious text match in check-docker

### DIFF
--- a/test/check-docker
+++ b/test/check-docker
@@ -71,34 +71,34 @@ class TestDocker(MachineCase):
         # Run it
         b.click('#containers-images tr:contains("busybox:latest") button.fa-play')
         b.wait_popup("containers_run_image_dialog")
-        b.set_val("#containers-run-image-name", "PROBE")
+        b.set_val("#containers-run-image-name", "PROBE1")
         b.set_val("#containers-run-image-command", "/bin/echo '%s'" % (message))
         b.click("#containers-run-image-run");
         b.wait_popdown("containers_run_image_dialog")
-        b.wait_in_text("#containers-containers", "PROBE")
+        b.wait_in_text("#containers-containers", "PROBE1")
 
         # Check output of the probe
-        b.click('#containers-containers tr:contains("PROBE")')
+        b.click('#containers-containers tr:contains("PROBE1")')
         b.wait_visible('#container-details')
         # The terminal uses NO-BREAK SPACE so we check for that here
         self.wait_for_message(message)
         b.wait_in_text("#container-details-state", "Exited")
 
-        self.del_container_from_details("PROBE")
+        self.del_container_from_details("PROBE1")
 
         # Run it without TTY and make sure it keeps running so that we
         # can link to it.
         b.click('#containers-images tr:contains("busybox:latest") button.fa-play')
         b.wait_popup("containers_run_image_dialog")
-        b.set_val("#containers-run-image-name", "PROBE")
+        b.set_val("#containers-run-image-name", "PROBE1")
         b.set_val("#containers-run-image-command", "/bin/sh -c 'echo \"%s\"; sleep 10000'" % (message))
         b.click("#containers-run-image-with-terminal");
         b.click("#containers-run-image-run");
         b.wait_popdown("containers_run_image_dialog")
-        b.wait_in_text("#containers-containers", "PROBE")
+        b.wait_in_text("#containers-containers", "PROBE1")
 
         # Check not linked
-        info = json.loads(m.execute('docker inspect PROBE'))
+        info = json.loads(m.execute('docker inspect PROBE1'))
         self.assertEqual(info[0]["HostConfig"]["Links"], None)
 
         # Create another container linked to old one
@@ -110,36 +110,37 @@ class TestDocker(MachineCase):
         b.wait_visible("#select-linked-containers:empty");
         b.click("#link-containers");
         b.wait_visible("#select-linked-containers:parent");
-        b.set_val("#select-linked-containers form:last-child select.selectpicker", "PROBE")
+        b.set_val("#select-linked-containers form:last-child select.selectpicker", "PROBE1")
         b.set_val("#select-linked-containers form:last-child  input[name='alias']", "alias1")
         b.click("#select-linked-containers form:last-child  button.fa-plus");
-        b.set_val("#select-linked-containers form:last-child  select.selectpicker", "PROBE")
+        b.set_val("#select-linked-containers form:last-child  select.selectpicker", "PROBE1")
         b.set_val("#select-linked-containers form:last-child  input[name='alias']", "alias2")
         b.click("#containers-run-image-run");
         b.wait_popdown("containers_run_image_dialog")
         b.wait_in_text("#containers-containers", "PROBE2")
+        b.wait_present("#containers-containers tbody tr:contains('PROBE2'):contains('Stopped')")
 
         # Check links
         info = json.loads(m.execute('docker inspect PROBE2'))
         self.assertEqual(set(info[0]["HostConfig"]["Links"]),
-                         set(["/PROBE:/PROBE2/alias1", "/PROBE:/PROBE2/alias2"]))
+                         set(["/PROBE1:/PROBE2/alias1", "/PROBE1:/PROBE2/alias2"]))
 
         # delete PROBE2
-        b.wait_in_text('#containers-containers tbody tr:first', "PROBE2")
-        b.wait_not_visible("#containers-containers tbody tr:first button.btn-delete")
+        b.wait_in_text('#containers-containers tbody', "PROBE2")
+        b.wait_not_visible("#containers-containers tbody tr:contains('PROBE2') button.btn-delete")
         b.click("#containers-containers button.enable-danger")
-        b.wait_visible("#containers-containers tbody tr:first button.btn-delete")
-        b.wait_not_present("#containers-containers tbody tr:first button.btn-delete.disabled")
-        b.click("#containers-containers tbody tr:first button.btn-delete")
+        b.wait_visible("#containers-containers tbody tr:contains('PROBE2') button.btn-delete")
+        b.wait_not_present("#containers-containers tbody tr:contains('PROBE2') button.btn-delete.disabled")
+        b.click("#containers-containers tbody tr:contains('PROBE2') button.btn-delete")
         with b.wait_timeout(20):
             try:
-                b.wait_not_in_text('#containers-containers tbody tr:first', "PROBE2")
+                b.wait_not_in_text('#containers-containers tbody', "PROBE2")
             except:
                 self.confirm()
-                b.wait_not_in_text('#containers-containers tbody tr:first', "PROBE2")
+                b.wait_not_in_text('#containers-containers tbody', "PROBE2")
 
-        # Check output of PROBE
-        b.click('#containers-containers tr:contains("PROBE")')
+        # Check output of PROBE1
+        b.click('#containers-containers tr:contains("PROBE1")')
         b.wait_visible("#container-details")
         self.wait_for_message(message)
         b.call_js_func("ph_count_check", ".logs",  1)
@@ -154,7 +155,7 @@ class TestDocker(MachineCase):
         b.click("#container-details-stop")
         b.wait_in_text("#container-details-state", "Exited")
 
-        self.del_container_from_details("PROBE")
+        self.del_container_from_details("PROBE1")
 
         # Delete image
         b.click('#containers-images tr:contains("busybox:latest")')
@@ -260,7 +261,7 @@ CMD ["/listen-on-port.sh", "%(port)d", "%(message)s"]
         # Wait for exit
         b.wait_in_text("#container-details-state", "Exited")
 
-        self.del_container_from_details("PROBE")
+        self.del_container_from_details("PROBE1")
 
     @unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "we can't use cockpit on atomic if docker is stopped")
     def testFailure(self):

--- a/test/check-docker
+++ b/test/check-docker
@@ -118,14 +118,20 @@ class TestDocker(MachineCase):
         b.click("#containers-run-image-run");
         b.wait_popdown("containers_run_image_dialog")
         b.wait_in_text("#containers-containers", "PROBE2")
-        b.wait_present("#containers-containers tbody tr:contains('PROBE2'):contains('Stopped')")
+
+        # Wait for PROBE2 to Exit
+        b.click('#containers-containers tr:contains("PROBE2")')
+        b.wait_visible("#container-details")
+        b.wait_in_text("#container-details-state", "Exited")
 
         # Check links
         info = json.loads(m.execute('docker inspect PROBE2'))
         self.assertEqual(set(info[0]["HostConfig"]["Links"]),
                          set(["/PROBE1:/PROBE2/alias1", "/PROBE1:/PROBE2/alias2"]))
 
-        # delete PROBE2
+        # delete PROBE2 from dash
+        b.click("#container-details ol.breadcrumb a")
+        b.wait_visible("#containers-containers")
         b.wait_in_text('#containers-containers tbody', "PROBE2")
         b.wait_not_visible("#containers-containers tbody tr:contains('PROBE2') button.btn-delete")
         b.click("#containers-containers button.enable-danger")


### PR DESCRIPTION
Fix this issue that sometimes happens:

Error: #containers-containers tr:contains("PROBE") is ambigous