### PR TITLE
systemd: Allow configuration of additional NTP servers.

### DIFF
--- a/doc/guide/feature-systemd.xml
+++ b/doc/guide/feature-systemd.xml
@@ -46,6 +46,13 @@ Africa/Algiers
 ...
 </programlisting>
 
+  <para>Cockpit can manage the list of NTP servers used by
+    <code>systemd-timesyncd</code> by putting its own file into
+    <code>/etc/systemd/timesynd.conf.d/</code>.  Note that
+    <code>systemd-timesyncd</code> is not always enabled, depending on
+    the configuration of the machine.  In that case, Cockpit disabled the
+    UI for managing the list of NTP servers.</para>
+
   <para>Cockpit restarts or powers down the machine by using the
     <ulink url="http://www.freedesktop.org/software/systemd/man/shutdown.html"><code>shutdown</code></ulink>
     command. To perform similar tasks from the command line, run it directly:</para>

--- a/pkg/systemd/Makefile.am
+++ b/pkg/systemd/Makefile.am
@@ -1,6 +1,7 @@
 systemddir = $(pkgdatadir)/system
 nodist_systemd_DATA = \
 	pkg/systemd/bundle.min.js.gz \
+	pkg/systemd/host.min.css.gz \
 	pkg/systemd/index.min.html.gz \
 	pkg/systemd/journal.min.css.gz \
 	pkg/systemd/logs.min.html.gz \
@@ -14,6 +15,7 @@ systemd_DATA = \
 
 systemddebugdir = $(debugdir)$(systemddir)
 systemddebug_DATA = \
+	pkg/systemd/host.css \
 	pkg/systemd/host.js \
 	pkg/systemd/index.html \
 	pkg/systemd/bundle.js \
@@ -60,6 +62,7 @@ TESTS += $(systemd_TESTS)
 
 CLEANFILES += \
 	pkg/systemd/bundle.min.js \
+	pkg/systemd/host.min.css \
 	pkg/systemd/index.min.html \
 	pkg/systemd/journal.min.css \
 	pkg/systemd/logs.min.html \
@@ -71,6 +74,7 @@ CLEANFILES += \
 
 EXTRA_DIST += \
 	pkg/systemd/bundle.min.js \
+	pkg/systemd/host.min.css \
 	pkg/systemd/index.min.html \
 	pkg/systemd/journal.min.css \
 	pkg/systemd/logs.min.html \

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -31,3 +31,7 @@
 .systime-inline .form-group:first-of-type .form-control {
     margin: 0 4px 0 0;
 }
+
+.systime-inline .form-group .form-control {
+    width: 214px;
+}

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -1,3 +1,8 @@
+.popover {
+    max-width: none;
+    white-space: nowrap;
+}
+
 .systime-inline form .pficon-close,
 .systime-inline form .fa-plus {
     height: 26px;

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -1,0 +1,28 @@
+.systime-inline form .pficon-close,
+.systime-inline form .fa-plus {
+    height: 26px;
+    width: 26px;
+    padding: 4px;
+    float: right;
+    margin-left: 5px;
+}
+
+.systime-inline .form-inline {
+    background: #f4f4f4;
+    border-width: 0 1px 1px 1px;
+    border-style: solid;
+    border-color: #bababa;
+    padding: 4px;
+}
+
+.systime-inline .form-inline:first-of-type {
+    border-top: 1px solid #bababa;
+}
+
+.systime-inline .form-control {
+    margin: 0 4px;
+}
+
+.systime-inline .form-group:first-of-type .form-control {
+    margin: 0 4px 0 0;
+}

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -195,6 +195,30 @@ PageServer.prototype = {
             $('#system_information_systime_button').text(self.server_time.format(true));
         });
 
+        var ntp_status_tmpl = $("#ntp-status-tmpl").html();
+        Mustache.parse(this.ntp_status_tmpl);
+
+        function update_ntp_status() {
+            var status = (self.server_time.timesyncd_service.service &&
+                          self.server_time.timesyncd_service.service.StatusText);
+
+            if (!status || status === "") {
+                $('#system_information_systime_ntp_status').html("");
+                return;
+            }
+
+            if (status == "Idle.")
+                status = null;
+
+            var model = {
+                TimesyncdStatus: status
+            };
+            $('#system_information_systime_ntp_status').html(Mustache.render(ntp_status_tmpl, model));
+        }
+
+        $(self.server_time.timesyncd_service).on("changed", update_ntp_status);
+        update_ntp_status();
+
         self.plot_controls = shell.setup_plot_controls($('#server'), $('#server-graph-toolbar'));
 
         var pmcd_service = service.proxy("pmcd");

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -164,8 +164,6 @@ PageServer.prototype = {
         var self = this;
         update_hostname_privileged();
 
-        self.timedate = cockpit.dbus('org.freedesktop.timedate1').proxy();
-
         $('#shutdown-group').append(
               shell.action_btn(
                   function (op) { self.shutdown(op); },

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -731,6 +731,8 @@ PageSystemInformationChangeSystime.prototype = {
         $('#change_systime').val(self.server_time.timedate.NTP ?
                                  (self.custom_ntp_enabled ? 'ntp_time_custom' : 'ntp_time')
                                  : 'manual_time');
+        $('#change_systime [value="ntp_time"]').
+            attr("disabled", !self.server_time.timedate.CanNTP? "disabled" : null);
         $('#change_systime [value="ntp_time_custom"]').
             attr("disabled", !self.custom_ntp_supported? "disabled" : null);
         $('#change_systime').selectpicker('refresh');

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -270,6 +270,10 @@ PageServer.prototype = {
             self.server_time.poll_ntp_synchronized();
         }, 5000);
 
+        $('#server').on('click', "[data-goto-sync-errors]", function () {
+            cockpit.jump("/system/services/#/systemd-timesyncd.service");
+        });
+
         self.plot_controls = shell.setup_plot_controls($('#server'), $('#server-graph-toolbar'));
 
         var pmcd_service = service.proxy("pmcd");

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -24,6 +24,20 @@
 </head>
 <body hidden>
 
+    <script id="ntp-status-icon-tmpl" type="x-template/mustache">
+      {{#Synched}}
+      <span class="fa fa-lg fa-info-circle"></span>
+      {{/Synched}}
+      {{^Synched}}
+      {{#Server}}
+      <span class="spinner spinner-xs spinner-inline"></span>
+      {{/Server}}
+      {{^Server}}
+      <span class="fa fa-lg fa-exclamation-circle" style="color:red"></span>
+      {{/Server}}
+      {{/Synched}}
+    </script>
+
     <script id="ntp-status-tmpl" type="x-template/mustache">
       {{#Synched}}
       {{#Server}}
@@ -83,7 +97,6 @@
                          tabindex="0" role="button" data-toggle="popover"
                          data-trigger="focus" data-placement="top"
                          data-html="true" data-content="">
-                        <span class="fa fa-lg fa-info-circle"></span>
                       </a>
                     </td>
                 </tr>

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -53,6 +53,7 @@
       {{/Server}}
       {{^Server}}
       <div translatable="yes">Not synchronized</div>
+      <a data-goto-sync-errors style="font-size:smaller">Log messages</a>
       {{/Server}}
       {{/Synched}}
       {{#SubStatus}}

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -25,12 +25,25 @@
 <body hidden>
 
     <script id="ntp-status-tmpl" type="x-template/mustache">
-      {{#TimesyncdStatus}}
-      <div>{{.}}</div>
-      {{/TimesyncdStatus}}
-      {{^TimesyncdStatus}}
-      <div translatable="yes">Not synchronized to any time server.</div>
-      {{/TimesyncdStatus}}
+      {{#Synched}}
+      {{#Server}}
+      <div translatable="yes">Synchronized with {{Server}}</div>
+      {{/Server}}
+      {{^Server}}
+      <div translatable="yes">Synchronized</div>
+      {{/Server}}
+      {{/Synched}}
+      {{^Synched}}
+      {{#Server}}
+      <div translatable="yes">Trying to synchronize with {{Server}}</div>
+      {{/Server}}
+      {{^Server}}
+      <div translatable="yes">Not synchronized</div>
+      {{/Server}}
+      {{/Synched}}
+      {{#SubStatus}}
+      <div style="font-size:smaller">{{SubStatus}}</div>
+      {{/SubStatus}}
     </script>
 
     <div id="server" class="container-fluid">
@@ -66,7 +79,12 @@
                     <td>System Time</td>
                     <td><button class="btn btn-default systime-privileged"
                                 id="system_information_systime_button"></button>
-                      <div id="system_information_systime_ntp_status" style="white-space:normal"></div>
+                      <a hidden id="system_information_systime_ntp_status"
+                         tabindex="0" role="button" data-toggle="popover"
+                         data-trigger="focus" data-placement="top"
+                         data-html="true" data-content="">
+                        <span class="fa fa-lg fa-info-circle"></span>
+                      </a>
                     </td>
                 </tr>
                 <tr>

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -24,6 +24,15 @@
 </head>
 <body hidden>
 
+    <script id="ntp-status-tmpl" type="x-template/mustache">
+      {{#TimesyncdStatus}}
+      <div>{{.}}</div>
+      {{/TimesyncdStatus}}
+      {{^TimesyncdStatus}}
+      <div translatable="yes">Not synchronized to any time server.</div>
+      {{/TimesyncdStatus}}
+    </script>
+
     <div id="server" class="container-fluid">
         <div class="col-md-4 col-lg-3 cockpit-info-table-container">
             <table class="cockpit-info-table">
@@ -56,7 +65,9 @@
                 <tr>
                     <td>System Time</td>
                     <td><button class="btn btn-default systime-privileged"
-                            id="system_information_systime_button"></button></td>
+                                id="system_information_systime_button"></button>
+                      <div id="system_information_systime_ntp_status" style="white-space:normal"></div>
+                    </td>
                 </tr>
                 <tr>
                     <td translatable="yes">Power Options</td>

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -7,6 +7,7 @@
     <link href="../base1/cockpit.css" rel="stylesheet">
     <link href="../shell/shell.css" rel="stylesheet">
     <link href="../shell/plot.css" rel="stylesheet">
+    <link href="../system/host.css" rel="stylesheet">
     <script src="../base1/bundle.js"></script>
     <script src="../shell/bundle.js"></script>
     <script src="../shell/shell.js"></script>
@@ -210,6 +211,20 @@
         </div>
     </div>
 
+    <script id="ntp-servers-tmpl" type="x-template/mustache">
+      <div class="systime-inline">
+        {{#NTPServers}}
+        <form class="form-inline">
+          <button data-action="add" data-index={{index}} class="btn btn-default fa fa-plus"/>
+          <button data-action="del" data-index={{index}} class="btn btn-default pficon-close"/>
+          <div class="form-group">
+            <input type="text" class="form-control" value="{{Value}}" placeholder="{{Placeholder}}">
+          </div>
+        </form>
+        {{/NTPServers}}
+      </div>
+    </script>
+
     <div class="modal" id="system_information_change_systime" tabindex="-1"
         role="dialog" data-backdrop="static">
         <div class="modal-dialog cockpit-modal-md">
@@ -219,32 +234,6 @@
                 </div>
                 <div class="modal-body">
                     <table class="cockpit-form-table">
-                        <tr>
-                            <td><label class="control-label" for="change_systime"
-                                    translatable="yes">Set time</label></td>
-                            <td>
-                                <select class="form-control selectpicker" id="change_systime">
-                                    <option value="manual_time">Manually set the time</option>
-                                    <option value="ntp_time">Set time automatically using NTP</option>
-                                </select>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td></td>
-                            <td>
-                                <input type='text' class="form-control" id="systime-date-input"/>
-                                <input type='text' class="form-control" id="systime-time-hours"/>
-                                :
-                                <input type='text' class="form-control" id="systime-time-minutes"/>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                            </td>
-                            <td class="has-error">
-                                <span id="systime-parse-error" class="help-block"></span>
-                            </td>
-                        </tr>
                         <tr>
                             <td>
                                 <label class="control-label" translatable="yes">Time Zone</label>
@@ -260,6 +249,38 @@
                                 <span id="systime-timezone-error" class="help-block" translatable="yes">
                                     Invalid time zone
                                 </span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><label class="control-label" for="change_systime"
+                                       translatable="yes">Set time</label></td>
+                            <td>
+                                <select class="form-control selectpicker" id="change_systime">
+                                    <option value="manual_time">Manually</option>
+                                    <option value="ntp_time">Automatically using NTP</option>
+                                    <option value="ntp_time_custom">Automatically using specific NTP servers</option>
+                                </select>
+                            </td>
+                        </tr>
+                        <tr id="systime-manual-row">
+                            <td></td>
+                            <td>
+                                <input type='text' class="form-control" id="systime-date-input"/>
+                                <input type='text' class="form-control" id="systime-time-hours"/>
+                                :
+                                <input type='text' class="form-control" id="systime-time-minutes"/>
+                            </td>
+                        </tr>
+                        <tr id="systime-manual-error-row">
+                            <td>
+                            </td>
+                            <td class="has-error">
+                                <span id="systime-parse-error" class="help-block"></span>
+                            </td>
+                        </tr>
+                        <tr id="systime-ntp-servers-row">
+                            <td></td>
+                            <td id="systime-ntp-servers">
                             </td>
                         </tr>
                     </table>

--- a/pkg/systemd/service.js
+++ b/pkg/systemd/service.js
@@ -108,6 +108,7 @@ define([
 
             start: start,
             stop: stop,
+            restart: restart,
 
             enable: enable,
             disable: disable
@@ -279,6 +280,10 @@ define([
 
         function stop() {
             return call_manager_with_job("StopUnit", [ name, "replace" ]);
+        }
+
+        function restart() {
+            return call_manager_with_job("RestartUnit", [ name, "replace" ]);
         }
 
         function enable() {

--- a/src/bridge/cockpitdbuscache.c
+++ b/src/bridge/cockpitdbuscache.c
@@ -819,8 +819,8 @@ on_get_reply (GObject *source,
     {
       if (!g_cancellable_is_cancelled (self->cancellable))
         {
-          g_message ("%s: couldn't get property %s %s at %s", self->logname,
-                     gd->iface->name, gd->property, gd->path);
+          g_message ("%s: couldn't get property %s %s at %s: %s", self->logname,
+                     gd->iface->name, gd->property, gd->path, error->message);
         }
       g_error_free (error);
     }

--- a/test/check-system-info
+++ b/test/check-system-info
@@ -20,6 +20,8 @@
 
 from testlib import *
 import time
+import unittest
+import os
 
 os_release = """
 NAME="Foobar Adventure Linux Server"
@@ -86,6 +88,11 @@ class TestSystemInfo(MachineCase):
         # make sure system is on expected timezone EEST
         m.execute("LC_ALL=C timedatectl set-timezone Europe/Helsinki")
 
+        # Something gets confused when systemd-timesyncd isn't
+        # available.  This is harmless.
+        #
+        self.allow_journal_messages("org.freedesktop.systemd1: couldn't get property org.freedesktop.systemd1.Service ExecMain at /org/freedesktop/systemd1/unit/systemd_2dtimedated_2eservice: GDBus.Error:org.freedesktop.DBus.Error.UnknownProperty: Unknown property")
+
         self.login_and_go("/system")
 
         # Make sure the date loads
@@ -133,6 +140,54 @@ class TestSystemInfo(MachineCase):
         self.assertIn("%s: no" % network_time_prefix, m.execute("LC_ALL=C timedatectl"))
         self.assertIn("Mon Jun  4 06:34:", m.execute("LC_ALL=C date"))
         self.assertIn("EEST 2018\n", m.execute("LC_ALL=C date"))
+
+    @unittest.skipIf("rhel-7" == os.environ.get("TEST_OS", ""), "No NTP servers config on rhel-7.")
+    def testTimeServers(self):
+        m = self.machine
+        b = self.browser
+
+        conf = "/etc/systemd/timesyncd.conf.d/50-cockpit.conf"
+
+        # Use systemd-timedated as the provider of
+        # org.freedesktop.timedate1 instead of timedatex.
+        m.execute("systemctl disable timedatex; systemctl stop timedatex")
+
+        self.login_and_go("/system")
+
+        # Wait until everything is ready to go...
+        b.wait_text_not("#system_information_systime_button", "")
+
+        # Add two NTP servers.  We can't expect the servers to be used, so
+        # we only test that they get added.
+        b.click("#system_information_systime_button")
+        b.wait_popup("system_information_change_systime")
+        b.set_val("#change_systime", "ntp_time_custom")
+        b.wait_visible("#systime-ntp-servers")
+        b.wait_present("#systime-ntp-servers form:nth-child(1) input")
+        b.set_val("#systime-ntp-servers form:nth-child(1) input", "0.pool.ntp.org")
+        b.click('#systime-ntp-servers form:nth-child(1) button[data-action="add"]')
+        b.wait_present("#systime-ntp-servers form:nth-child(2) input")
+        b.set_val("#systime-ntp-servers form:nth-child(2) input", "1.pool.ntp.org")
+        b.click("#systime-apply-button")
+        b.wait_popdown("system_information_change_systime")
+
+        self.assertIn("0.pool.ntp.org", m.execute("grep '^NTP=' %s" % conf))
+        self.assertIn("1.pool.ntp.org", m.execute("grep '^NTP=' %s" % conf))
+
+        # Set conf from the outside, check that we pick that up, and
+        # switch to default servers.
+        m.write(conf, "[Time]\nNTP=2.pool.ntp.org\n")
+        b.click("#system_information_systime_button")
+        b.wait_popup("system_information_change_systime")
+        b.wait_visible("#systime-ntp-servers")
+        b.wait_present("#systime-ntp-servers form:nth-child(1)")
+        b.wait_val("#systime-ntp-servers form:nth-child(1) input", "2.pool.ntp.org")
+        b.set_val("#change_systime", "ntp_time")
+        b.wait_not_visible("#systime-ntp-servers")
+        b.click("#systime-apply-button")
+        b.wait_popdown("system_information_change_systime")
+
+        self.assertIn("2.pool.ntp.org", m.execute("grep '^#NTP=' %s" % conf))
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Note, when manually testing this, make sure that "timedatex" is not installed or when it is installed, that is is disabled (systemctl disable timedatex).  If it is enabled, the UI will not allow configuration of NTP servers.