### PR TITLE
Implement WebSocket client in cockpit-bridge

### DIFF
--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -1402,6 +1402,11 @@ http = cockpit.http(options)
 
     </refsection>
 
+    <refsection id="cockpit-http-options">
+      <title>http.options</title>
+      <para>The channel options used to make the http requests.</para>
+    </refsection>
+
     <refsection id="cockpit-http-get">
       <title>http.get()</title>
 <programlisting>

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -603,6 +603,16 @@ the following fields:
 Any data to be sent should be sent via the channel, and then the channel
 should be closed without a problem.
 
+Payload: websocket-stream1
+--------------------------
+
+This channel payload implements a WebSocket client. The data in the
+channel is the message frames.
+
+Most of same options for http-stream2 apply here.
+
+The response headers are send back in a "response" control message.
+
 Payload: stream
 ---------------
 

--- a/pkg/base1/Makefile.am
+++ b/pkg/base1/Makefile.am
@@ -110,6 +110,7 @@ base_TESTS = \
 	pkg/base1/test-series.html \
 	pkg/base1/test-cache.html \
 	pkg/base1/test-framed-cache.html \
+	pkg/base1/test-websocket.html \
 	$(NULL)
 
 TESTS += $(base_TESTS)

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -2419,6 +2419,7 @@ function full_scope(cockpit, $, po) {
     function HttpClient(endpoint, options) {
         var self = this;
 
+        self.options = options;
         options.payload = "http-stream1";
 
         if (endpoint !== undefined) {

--- a/pkg/base1/test-websocket.html
+++ b/pkg/base1/test-websocket.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<!--
+  This file is part of Cockpit.
+
+  Copyright (C) 2016 Red Hat, Inc.
+
+  Cockpit is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+
+  Cockpit is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+-->
+<html>
+  <head>
+    <title>Websocket Channel Tests</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../../tools/qunit.css" type="text/css" media="screen" />
+    <script type="text/javascript" src="../../tools/qunit.js"></script>
+
+    <script type="text/javascript" src="cockpit.js"></script>
+  </head>
+  <body>
+    <h1 id="qunit-header">Websocket Channel Tests</h1>
+    <h2 id="qunit-banner"></h2><div id="qunit-testrunner-toolbar"></div>
+    <h2 id="qunit-userAgent"></h2><ol id="qunit-tests"></ol>
+    <div id="qunit-fixture">test markup, will be hidden</div>
+    <div id="done-flag" style="display:none">Done</div>
+  </body>
+<script type="text/javascript">
+
+asyncTest("external channel websocket", function() {
+    expect(3);
+
+    var query = window.btoa(JSON.stringify({
+        payload: "websocket-stream1",
+        address: "localhost",
+        port: parseInt(window.location.port, 10),
+        path: "/cockpit/echosocket/",
+    }));
+
+    var count = 0;
+    var ws = new WebSocket("ws://" + location.host + "/cockpit/channel/" +
+                           cockpit.transport.csrf_token + '?' + query);
+    ws.onopen = function() {
+        ok(true, "websocket is open");
+        ws.send("oh marmalade");
+    };
+    ws.onerror = function() {
+        ok(false, "websocket error");
+    };
+    ws.onmessage = function(ev) {
+        if (count == 0) {
+            equal(ev.data, "OH MARMALADE", "got payload");
+            ws.send("another test");
+            count += 1;
+        } else {
+            equal(ev.data, "ANOTHER TEST", "got payload again");
+            ws.close(1000);
+        }
+    };
+    ws.onclose = function(ev) {
+        start();
+    }
+});
+
+asyncTest("bad channel options websocket", function() {
+
+
+    var payloads = [
+        window.btoa(JSON.stringify({
+            payload: "websocket-stream1",
+            address: "localhost",
+            port: 'bad',
+            path: "/cockpit/echosocket/",
+        })),
+        window.btoa(JSON.stringify({
+            payload: "websocket-stream1",
+            address: "localhost",
+            port: parseInt(window.location.port, 10),
+        }))
+    ];
+    expect(payloads.length * 3);
+    function step() {
+        var query = payloads.shift();
+        var url = "ws://" + location.host + "/cockpit/channel/" +
+                               cockpit.transport.csrf_token + '?' + query;
+        console.log(url);
+        var ws = new WebSocket(url);
+        ws.onopen = function() {
+            ok(true, "websocket opened");
+        };
+        ws.onclose = function(ev) {
+            console.log(ev);
+            ok(!ev.wasClean, url + "websocket unclean shutdown");
+            notEqual(ev.code, 0, url + "websocket error code");
+            ws = null;
+            if (payloads.length == 0)
+                start();
+            else
+                step();
+        };
+    }
+    step();
+});
+
+cockpit.transport.wait(function() {
+    QUnit.start();
+});
+
+</script>
+</html>

--- a/pkg/kubernetes/views/container-panel.html
+++ b/pkg/kubernetes/views/container-panel.html
@@ -9,22 +9,21 @@
         <li ng-class="{active: tab('main')}">
         <a ng-click="tab('main', $event)" translatable="yes">Container</a></li>
         <li ng-class="{active: tab('logs')}">
-            <a ng-click="tab('logs', $event); connect('console')" translatable="yes">Logs</a></li>
+            <a ng-click="tab('logs', $event); tabbed = true" translatable="yes">Logs</a></li>
         <li ng-class="{active: tab('shell')}"
             ng-if="item.status.phase == 'Running' && container.status.state.running">
-                <a ng-click="tab('shell', $event); connect('shell')" translatable="yes">Shell</a></li>
+                <a ng-click="tab('shell', $event); tabbed = true" translatable="yes">Shell</a></li>
     </ul>
 </div>
 <div class="listing-body" ng-show="tab('main')">
     <kube-container-body></kube-container-body>
 </div>
 <div class="listing-body" ng-show="tab('logs')">
-    <kube-console namespace="{{item.metadata.namespace}}" pod="{{item.metadata.name}}"
-        container="{{container.spec.name}}">
+    <kube-console pod="item" container="container.spec.name" prevent="!tabbed">
     </kube-console>
 </div>
 <div class="listing-body" ng-show="tab('shell')"
     ng-if="item.status.phase == 'Running' && container.status.state.running">
-    <kubernetes-container-terminal pod="item" container="container.spec.name">
+    <kubernetes-container-terminal pod="item" container="container.spec.name" prevent="!tabbed">
     </kubernetes-container-terminal>
 </div>

--- a/pkg/kubernetes/views/pod-panel.html
+++ b/pkg/kubernetes/views/pod-panel.html
@@ -13,9 +13,9 @@
             <li ng-class="{active: tab('main')}"><a ng-click="tab('main', $event)">Pod</a></li>
             <li ng-class="{active: tab('containers')}"><a ng-click="tab('containers', $event)">Containers</a></li>
             <li ng-class="{active: tab('logs')}">
-                <a ng-click="tab('logs', $event); connect('console')">Logs</a></li>
+                <a ng-click="tab('logs', $event); tabbed = true">Logs</a></li>
             <li ng-class="{active: tab('shell')}">
-                <a ng-click="tab('shell', $event); connect('shell')">Shell</a></li>
+                <a ng-click="tab('shell', $event); tabbed = true">Shell</a></li>
         </ul>
     </div>
     <div class="listing-body" ng-show="tab('main')">
@@ -28,15 +28,14 @@
     </div>
     <div class="listing-body" ng-show="tab('logs')">
         <div class="container-fluid" ng-repeat="container in containers">
-            <kube-console namespace="{{item.metadata.namespace}}"
-                pod="{{item.metadata.name}}" container="{{container.spec.name}}">
+            <kube-console pod="item" container="container.spec.name" prevent="!tabbed">
             </kube-console>
         </div>
     </div>
     <div class="listing-body" ng-show="tab('shell')">
         <div class="container-fluid" ng-repeat="container in containers"
             ng-if="item.status.phase == 'Running' && container.status.state.running">
-            <kubernetes-container-terminal pod="item" container="container.spec.name">
+            <kubernetes-container-terminal pod="item" container="container.spec.name" prevent="!tabbed">
             </kubernetes-container-terminal>
         </div>
     </div>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -51,6 +51,7 @@ pkg/users/authorized-keys.js
 pkg/users/local.js
 src/bridge/cockpitdbussetup.c
 src/common/cockpitcertificate.c
+src/common/cockpitconnect.c
 src/ws/cockpit.appdata.xml.in
 src/ws/cockpit.desktop.in
 src/ws/cockpithandlers.c

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -21,6 +21,8 @@ libcockpit_stub_a_SOURCES = \
 	src/bridge/cockpitpaths.h \
 	src/bridge/cockpitnullchannel.c \
 	src/bridge/cockpitnullchannel.h \
+	src/bridge/cockpitwebsocketstream.c \
+	src/bridge/cockpitwebsocketstream.h \
 	$(NULL)
 
 libcockpit_stub_a_CFLAGS = \

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -154,6 +154,7 @@ BRIDGE_CHECKS = \
 	test-metrics \
 	test-httpstream \
 	test-setup \
+	test-websocketstream \
 	$(NULL)
 
 mock_bridge_SOURCES = src/bridge/mock-bridge.c
@@ -214,6 +215,12 @@ test_httpstream_SOURCES = \
 	src/bridge/mock-transport.c src/bridge/mock-transport.h
 test_httpstream_CFLAGS = $(libcockpit_bridge_a_CFLAGS)
 test_httpstream_LDADD = $(libcockpit_bridge_LIBS) -ldl
+
+test_websocketstream_SOURCES = \
+	src/bridge/test-websocketstream.c \
+	src/bridge/mock-transport.c src/bridge/mock-transport.h
+test_websocketstream_CFLAGS = $(libcockpit_bridge_a_CFLAGS)
+test_websocketstream_LDADD = $(libcockpit_bridge_LIBS) -ldl
 
 noinst_PROGRAMS += $(BRIDGE_CHECKS) mock-bridge
 TESTS += $(BRIDGE_CHECKS)

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -18,6 +18,8 @@
  */
 #include "config.h"
 
+#include "cockpitbridge.h"
+
 #include "cockpitchannel.h"
 #include "cockpitdbusinternal.h"
 #include "cockpitdbusjson.h"
@@ -34,7 +36,7 @@
 #include "cockpitinternalmetrics.h"
 #include "cockpitpolkitagent.h"
 #include "cockpitportal.h"
-#include "cockpitbridge.h"
+#include "cockpitwebsocketstream.h"
 
 #include "common/cockpitassets.h"
 #include "common/cockpitjson.h"
@@ -75,6 +77,7 @@ static CockpitPayloadType payload_types[] = {
   { "null", cockpit_null_channel_get_type },
   { "echo", cockpit_echo_channel_get_type },
   { "metrics1", cockpit_internal_metrics_get_type },
+  { "websocket-stream1", cockpit_web_socket_stream_get_type },
   { NULL },
 };
 

--- a/src/bridge/cockpitchannel.h
+++ b/src/bridge/cockpitchannel.h
@@ -23,7 +23,7 @@
 #include <glib-object.h>
 #include <json-glib/json-glib.h>
 
-#include "common/cockpitstream.h"
+#include "common/cockpitconnect.h"
 #include "common/cockpittransport.h"
 
 G_BEGIN_DECLS
@@ -101,12 +101,7 @@ void                cockpit_channel_internal_address  (const gchar *name,
 
 gboolean            cockpit_channel_remove_internal_address (const gchar *name);
 
-GSocketConnectable * cockpit_channel_parse_connectable (CockpitChannel *self,
-                                                       gchar **possible_name,
-                                                       gboolean *local_address);
-
-CockpitStreamOptions * cockpit_channel_parse_stream   (CockpitChannel *self,
-                                                       gboolean local_address);
+CockpitConnectable * cockpit_channel_parse_stream     (CockpitChannel *self);
 
 G_END_DECLS
 

--- a/src/bridge/cockpithttpstream.c
+++ b/src/bridge/cockpithttpstream.c
@@ -291,21 +291,23 @@ parse_transfer_encoding (CockpitHttpStream *self,
   return TRUE;
 }
 
-static gboolean
-parse_keep_alive (CockpitHttpStream *self,
-                  const gchar *version,
-                  GHashTable *headers)
+gboolean
+cockpit_http_stream_parse_keep_alive (const gchar *version,
+                                      GHashTable *headers)
 {
   const gchar *header;
 
   header = g_hash_table_lookup (headers, "Connection");
 
-  g_debug ("%s: got Connection of %s on %s response", self->name, header, version);
-
   if (!header)
     {
+      g_debug ("got no \"Connection\" header on %s response", version);
       if (version && g_ascii_strcasecmp (version, "HTTP/1.1") == 0)
         header = "keep-alive";
+    }
+  else
+    {
+      g_debug ("got \"Connection\" header of %s on %s response", header, version);
     }
 
   /*
@@ -316,7 +318,15 @@ parse_keep_alive (CockpitHttpStream *self,
    * to tell us.
    */
 
-  self->keep_alive = (header && strstr (header, "keep-alive") != NULL);
+  return (header && strstr (header, "keep-alive") != NULL);
+}
+
+static gboolean
+parse_keep_alive (CockpitHttpStream *self,
+                  const gchar *version,
+                  GHashTable *headers)
+{
+  self->keep_alive = cockpit_http_stream_parse_keep_alive (version, headers);
   return TRUE;
 }
 

--- a/src/bridge/cockpithttpstream.h
+++ b/src/bridge/cockpithttpstream.h
@@ -28,6 +28,9 @@ G_BEGIN_DECLS
 
 #define COCKPIT_TYPE_HTTP_STREAM         (cockpit_http_stream_get_type ())
 
-GType              cockpit_http_stream_get_type     (void) G_GNUC_CONST;
+GType              cockpit_http_stream_get_type           (void) G_GNUC_CONST;
+
+gboolean           cockpit_http_stream_parse_keep_alive   (const gchar *version,
+                                                           GHashTable *headers);
 
 #endif /* COCKPIT_HTTP_STREAM_H__ */

--- a/src/bridge/cockpitwebsocketstream.c
+++ b/src/bridge/cockpitwebsocketstream.c
@@ -297,6 +297,7 @@ cockpit_web_socket_stream_prepare (CockpitChannel *channel)
   CockpitConnectable *connectable = NULL;
   JsonObject *options;
   const gchar *path;
+  gboolean started = FALSE;
 
   COCKPIT_CHANNEL_CLASS (cockpit_web_socket_stream_parent_class)->prepare (channel);
 
@@ -326,10 +327,15 @@ cockpit_web_socket_stream_prepare (CockpitChannel *channel)
   self->binary = json_object_has_member (options, "binary");
 
   cockpit_connect_stream_full (connectable, NULL, on_socket_connect, g_object_ref (self));
+  started = TRUE;
 
 out:
   if (connectable)
-    cockpit_connectable_unref (connectable);
+    {
+      cockpit_connectable_unref (connectable);
+      if (!started)
+        cockpit_channel_close (channel, "protocol-error");
+    }
 }
 
 static void

--- a/src/bridge/cockpitwebsocketstream.c
+++ b/src/bridge/cockpitwebsocketstream.c
@@ -1,0 +1,389 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitwebsocketstream.h"
+#include "cockpitchannel.h"
+
+#include "common/cockpitconnect.h"
+#include "common/cockpitstream.h"
+#include "common/cockpitjson.h"
+
+#include "websocket/websocket.h"
+
+#include <string.h>
+
+/**
+ * CockpitWebSocketStream:
+ *
+ * A #CockpitChannel that represents a WebSocket client
+ *
+ * The payload type for this channel is 'websocket-stream1'.
+ */
+
+#define COCKPIT_WEB_SOCKET_STREAM(o)    (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_WEB_SOCKET_STREAM, CockpitWebSocketStream))
+
+typedef struct _CockpitWebSocketStream {
+  CockpitChannel parent;
+
+  /* The nickname for debugging and logging */
+  gchar *url;
+  gchar *origin;
+
+  /* The connection */
+  WebSocketConnection *client;
+  gulong sig_open;
+  gulong sig_message;
+  gulong sig_closing;
+  gulong sig_close;
+
+  gboolean binary;
+  gboolean closed;
+} CockpitWebSocketStream;
+
+typedef struct {
+  CockpitChannelClass parent_class;
+} CockpitWebSocketStreamClass;
+
+G_DEFINE_TYPE (CockpitWebSocketStream, cockpit_web_socket_stream, COCKPIT_TYPE_CHANNEL);
+
+static void
+cockpit_web_socket_stream_recv (CockpitChannel *channel,
+                                GBytes *message)
+{
+  CockpitWebSocketStream *self = COCKPIT_WEB_SOCKET_STREAM (channel);
+  WebSocketDataType type;
+  WebSocketState state;
+
+  /* Should never be called before cockpit_channel_ready() */
+  g_return_if_fail (self->client != NULL);
+
+  state = web_socket_connection_get_ready_state (self->client);
+  g_return_if_fail (state >= WEB_SOCKET_STATE_OPEN);
+
+  if (state == WEB_SOCKET_STATE_OPEN)
+    {
+      type = self->binary ? WEB_SOCKET_DATA_BINARY : WEB_SOCKET_DATA_TEXT;
+      web_socket_connection_send (self->client, type, NULL, message);
+    }
+}
+
+static gboolean
+cockpit_web_socket_stream_control (CockpitChannel *channel,
+                                   const gchar *command,
+                                   JsonObject *options)
+{
+  CockpitWebSocketStream *self = COCKPIT_WEB_SOCKET_STREAM (channel);
+
+  if (!g_str_equal (command, "done"))
+    return FALSE;
+
+  if (self->client && web_socket_connection_get_ready_state (self->client) == WEB_SOCKET_STATE_OPEN)
+    web_socket_connection_close (self->client, WEB_SOCKET_CLOSE_NORMAL, "disconnected");
+
+  return TRUE;
+}
+
+static void
+cockpit_web_socket_stream_close (CockpitChannel *channel,
+                                 const gchar *problem)
+{
+  CockpitWebSocketStream *self = COCKPIT_WEB_SOCKET_STREAM (channel);
+
+  self->closed = TRUE;
+  if (self->client && web_socket_connection_get_ready_state (self->client) < WEB_SOCKET_STATE_CLOSING)
+    {
+      if (problem)
+        web_socket_connection_close (self->client, WEB_SOCKET_CLOSE_ABNORMAL, problem);
+      else
+        web_socket_connection_close (self->client, WEB_SOCKET_CLOSE_NORMAL, "disconnected");
+    }
+  COCKPIT_CHANNEL_CLASS (cockpit_web_socket_stream_parent_class)->close (channel, problem);
+}
+
+static void
+cockpit_web_socket_stream_init (CockpitWebSocketStream *self)
+{
+
+}
+
+static void
+on_web_socket_open (WebSocketConnection *connection,
+                    gpointer user_data)
+{
+  CockpitWebSocketStream *self = COCKPIT_WEB_SOCKET_STREAM (user_data);
+  CockpitChannel *channel = COCKPIT_CHANNEL (user_data);
+  JsonObject *object;
+  JsonObject *headers;
+  GHashTableIter iter;
+  gpointer key, value;
+
+  headers = json_object_new ();
+
+  g_hash_table_iter_init (&iter, web_socket_client_get_headers (WEB_SOCKET_CLIENT (self->client)));
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    json_object_set_string_member (headers, key, value);
+
+  object = json_object_new ();
+  json_object_set_object_member (object, "headers", headers);
+
+  cockpit_channel_control (channel, "response", object);
+  json_object_unref (object);
+
+  cockpit_channel_ready (channel);
+}
+
+static void
+on_web_socket_message (WebSocketConnection *connection,
+                       WebSocketDataType type,
+                       GBytes *message,
+                       gpointer user_data)
+{
+  CockpitChannel *channel = COCKPIT_CHANNEL (user_data);
+  cockpit_channel_send (channel, message, type == WEB_SOCKET_DATA_TEXT);
+}
+
+static gboolean
+on_web_socket_closing (WebSocketConnection *connection,
+                       gpointer user_data)
+{
+  CockpitChannel *channel = COCKPIT_CHANNEL (user_data);
+  cockpit_channel_control (channel, "done", NULL);
+  return TRUE;
+}
+
+static void
+on_web_socket_close (WebSocketConnection *connection,
+                     gpointer user_data)
+{
+  CockpitChannel *channel = COCKPIT_CHANNEL (user_data);
+  const gchar *problem;
+  gushort code;
+
+  code = web_socket_connection_get_close_code (connection);
+  problem = web_socket_connection_get_close_data (connection);
+
+  if (code == WEB_SOCKET_CLOSE_NORMAL || code == WEB_SOCKET_CLOSE_GOING_AWAY)
+    {
+      problem = NULL;
+    }
+  else if (problem == NULL || !problem[0])
+    {
+      switch (code)
+        {
+        case WEB_SOCKET_CLOSE_NO_STATUS:
+        case WEB_SOCKET_CLOSE_ABNORMAL:
+          problem = "disconnected";
+          break;
+        case WEB_SOCKET_CLOSE_PROTOCOL:
+        case WEB_SOCKET_CLOSE_UNSUPPORTED_DATA:
+        case WEB_SOCKET_CLOSE_BAD_DATA:
+        case WEB_SOCKET_CLOSE_POLICY_VIOLATION:
+        case WEB_SOCKET_CLOSE_TOO_BIG:
+        case WEB_SOCKET_CLOSE_TLS_HANDSHAKE:
+          problem = "protocol-error";
+          break;
+        case WEB_SOCKET_CLOSE_NO_EXTENSION:
+          problem = "unsupported";
+          break;
+        default:
+          problem = "internal-error";
+          break;
+        }
+    }
+
+  cockpit_channel_close (channel, problem);
+}
+
+static void
+on_socket_connect (GObject *object,
+                   GAsyncResult *result,
+                   gpointer user_data)
+{
+  CockpitWebSocketStream *self = COCKPIT_WEB_SOCKET_STREAM (user_data);
+  CockpitChannel *channel = COCKPIT_CHANNEL (self);
+  const gchar *problem = "protocol-error";
+  gchar **protocols = NULL;
+  GList *l, *names = NULL;
+  GError *error = NULL;
+  JsonObject *options;
+  JsonObject *headers;
+  const gchar *value;
+  JsonNode *node;
+  GIOStream *io;
+
+  io = cockpit_connect_stream_finish (result, &error);
+  if (error)
+    {
+      problem = cockpit_stream_problem (error, self->origin, "couldn't connect", NULL);
+      goto out;
+    }
+
+  options = cockpit_channel_get_options (channel);
+
+  if (!cockpit_json_get_strv (options, "protocols", NULL, &protocols))
+    {
+      g_warning ("%s: invalid \"protocol\" value in WebSocket stream request", self->origin);
+      goto out;
+    }
+
+  self->client = web_socket_client_new_for_stream (self->url, self->origin, (const gchar **)protocols, io);
+
+  node = json_object_get_member (options, "headers");
+  if (node)
+    {
+      if (!JSON_NODE_HOLDS_OBJECT (node))
+        {
+          g_warning ("%s: invalid \"headers\" field in WebSocket stream request", self->origin);
+          goto out;
+        }
+
+      headers = json_node_get_object (node);
+      names = json_object_get_members (headers);
+      for (l = names; l != NULL; l = g_list_next (l))
+        {
+          node = json_object_get_member (headers, l->data);
+          if (!node || !JSON_NODE_HOLDS_VALUE (node) || json_node_get_value_type (node) != G_TYPE_STRING)
+            {
+              g_warning ("%s: invalid header value in WebSocket stream request: %s",
+                         self->origin, (gchar *)l->data);
+              goto out;
+            }
+          value = json_node_get_string (node);
+
+          g_debug ("%s: sending header: %s %s", self->origin, (gchar *)l->data, value);
+          web_socket_client_include_header (WEB_SOCKET_CLIENT (self->client), l->data, value);
+        }
+    }
+
+  self->sig_open = g_signal_connect (self->client, "open", G_CALLBACK (on_web_socket_open), self);
+  self->sig_message = g_signal_connect (self->client, "message", G_CALLBACK (on_web_socket_message), self);
+  self->sig_closing = g_signal_connect (self->client, "closing", G_CALLBACK (on_web_socket_closing), self);
+  self->sig_close = g_signal_connect (self->client, "close", G_CALLBACK (on_web_socket_close), self);
+
+  problem = NULL;
+
+out:
+  if (problem)
+    cockpit_channel_close (channel, problem);
+  g_clear_error (&error);
+  g_strfreev (protocols);
+  if (io)
+    g_object_unref (io);
+  g_list_free (names);
+}
+
+static void
+cockpit_web_socket_stream_prepare (CockpitChannel *channel)
+{
+  CockpitWebSocketStream *self = COCKPIT_WEB_SOCKET_STREAM (channel);
+  CockpitConnectable *connectable = NULL;
+  JsonObject *options;
+  const gchar *path;
+
+  COCKPIT_CHANNEL_CLASS (cockpit_web_socket_stream_parent_class)->prepare (channel);
+
+  if (self->closed)
+    goto out;
+
+  connectable = cockpit_channel_parse_stream (channel);
+  if (!connectable)
+    goto out;
+
+  options = cockpit_channel_get_options (channel);
+  if (!cockpit_json_get_string (options, "path", NULL, &path))
+    {
+      g_warning ("%s: bad \"path\" field in WebSocket stream request", self->origin);
+      goto out;
+    }
+  else if (path == NULL || path[0] != '/')
+    {
+      g_warning ("%s: invalid or missing \"path\" field in WebSocket stream request", self->origin);
+      goto out;
+    }
+
+  self->url = g_strdup_printf ("%s://%s%s", connectable->tls ? "wss" : "ws", connectable->name, path);
+  self->origin = g_strdup_printf ("%s://%s", connectable->tls ? "https" : "http", connectable->name);
+
+  /* Parsed elsewhere */
+  self->binary = json_object_has_member (options, "binary");
+
+  cockpit_connect_stream_full (connectable, NULL, on_socket_connect, g_object_ref (self));
+
+out:
+  if (connectable)
+    cockpit_connectable_unref (connectable);
+}
+
+static void
+cockpit_web_socket_stream_dispose (GObject *object)
+{
+  CockpitWebSocketStream *self = COCKPIT_WEB_SOCKET_STREAM (object);
+
+  if (self->client)
+    {
+      if (web_socket_connection_get_ready_state (self->client) < WEB_SOCKET_STATE_CLOSING)
+        web_socket_connection_close (self->client, WEB_SOCKET_CLOSE_GOING_AWAY, "disconnected");
+      g_signal_handler_disconnect (self->client, self->sig_open);
+      g_signal_handler_disconnect (self->client, self->sig_message);
+      g_signal_handler_disconnect (self->client, self->sig_closing);
+      g_signal_handler_disconnect (self->client, self->sig_close);
+      g_object_unref (self->client);
+      self->client = NULL;
+    }
+
+  G_OBJECT_CLASS (cockpit_web_socket_stream_parent_class)->dispose (object);
+}
+
+static void
+cockpit_web_socket_stream_finalize (GObject *object)
+{
+  CockpitWebSocketStream *self = COCKPIT_WEB_SOCKET_STREAM (object);
+
+  g_free (self->url);
+  g_free (self->origin);
+  g_assert (self->client == NULL);
+
+  G_OBJECT_CLASS (cockpit_web_socket_stream_parent_class)->finalize (object);
+}
+
+static void
+cockpit_web_socket_stream_constructed (GObject *object)
+{
+  static const gchar *caps[] = { "tls-certificates", "address", NULL };
+  G_OBJECT_CLASS (cockpit_web_socket_stream_parent_class)->constructed (object);
+  g_object_set (object, "capabilities", &caps, NULL);
+}
+
+static void
+cockpit_web_socket_stream_class_init (CockpitWebSocketStreamClass *klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  CockpitChannelClass *channel_class = COCKPIT_CHANNEL_CLASS (klass);
+
+  gobject_class->dispose = cockpit_web_socket_stream_dispose;
+  gobject_class->finalize = cockpit_web_socket_stream_finalize;
+  gobject_class->constructed = cockpit_web_socket_stream_constructed;
+
+  channel_class->prepare = cockpit_web_socket_stream_prepare;
+  channel_class->control = cockpit_web_socket_stream_control;
+  channel_class->recv = cockpit_web_socket_stream_recv;
+  channel_class->close = cockpit_web_socket_stream_close;
+}

--- a/src/bridge/cockpitwebsocketstream.h
+++ b/src/bridge/cockpitwebsocketstream.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COCKPIT_WEB_SOCKET_STREAM_H__
+#define COCKPIT_WEB_SOCKET_STREAM_H__
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+#define COCKPIT_TYPE_WEB_SOCKET_STREAM         (cockpit_web_socket_stream_get_type ())
+
+GType              cockpit_web_socket_stream_get_type     (void) G_GNUC_CONST;
+
+#endif /* COCKPIT_WEB_SOCKET_STREAM_H__ */

--- a/src/bridge/stub.c
+++ b/src/bridge/stub.c
@@ -25,6 +25,7 @@
 #include "cockpithttpstream.h"
 #include "cockpitnullchannel.h"
 #include "cockpitpackages.h"
+#include "cockpitwebsocketstream.h"
 
 #include "common/cockpittransport.h"
 #include "common/cockpitassets.h"
@@ -56,6 +57,7 @@ static CockpitPayloadType payload_types[] = {
   { "http-stream2", cockpit_http_stream_get_type },
   { "null", cockpit_null_channel_get_type },
   { "echo", cockpit_echo_channel_get_type },
+  { "websocket-stream1", cockpit_web_socket_stream_get_type },
   { NULL },
 };
 

--- a/src/bridge/test-channel.c
+++ b/src/bridge/test-channel.c
@@ -23,6 +23,7 @@
 #include "mock-transport.h"
 
 #include "common/cockpitjson.h"
+#include "common/cockpitstream.h"
 #include "common/cockpittest.h"
 
 #include <json-glib/json-glib.h>
@@ -431,11 +432,11 @@ test_capable (void)
 static void
 test_invalid_internal (void)
 {
+  CockpitConnectable *connectable;
   JsonObject *options;
   MockTransport *transport;
   CockpitChannel *channel;
   JsonObject *sent;
-  GSocketConnectable *connectable;
 
   options = json_object_new ();
   json_object_set_string_member (options, "internal", "test");
@@ -447,7 +448,7 @@ test_invalid_internal (void)
                           "options", options,
                           NULL);
   json_object_unref (options);
-  connectable = cockpit_channel_parse_connectable (channel, NULL, NULL);
+  connectable = cockpit_channel_parse_stream (channel);
   g_assert (connectable == NULL);
   while (g_main_context_iteration (NULL, FALSE));
 
@@ -484,12 +485,11 @@ test_parse_port (void)
   JsonObject *options;
   MockTransport *transport;
   CockpitChannel *channel;
-  GSocketConnectable *connectable;
+  CockpitConnectable *connectable;
   GSocketAddress *address;
   GInetAddress *expected_ip;
   GInetAddress *got_ip; // owned by address
   gchar *name = NULL;
-  gboolean local = -1; /* yup */
 
   expected_ip = g_inet_address_new_from_string (cockpit_bridge_local_address);
 
@@ -503,7 +503,7 @@ test_parse_port (void)
                           "options", options,
                           NULL);
   json_object_unref (options);
-  connectable = cockpit_channel_parse_connectable (channel, NULL, &local);
+  connectable = cockpit_channel_parse_stream (channel);
   address = cockpit_channel_parse_address (channel, &name);
 
   g_assert (g_socket_address_get_family (address) == G_SOCKET_FAMILY_IPV4);
@@ -512,10 +512,10 @@ test_parse_port (void)
   got_ip = g_inet_socket_address_get_address ((GInetSocketAddress *)address);
   g_assert (g_inet_address_equal (got_ip, expected_ip));
 
-  g_assert_cmpint (local, ==, TRUE);
+  g_assert_cmpint (connectable->local, ==, TRUE);
 
   g_object_unref (channel);
-  g_object_unref (connectable);
+  cockpit_connectable_unref (connectable);
   g_object_unref (transport);
   g_object_unref (address);
   g_object_unref (expected_ip);
@@ -529,12 +529,11 @@ test_parse_address (void)
   JsonObject *options;
   MockTransport *transport;
   CockpitChannel *channel;
-  GSocketConnectable *connectable;
+  CockpitConnectable *connectable;
   GSocketAddress *address;
   GInetAddress *expected_ip;
   GInetAddress *got_ip; // owned by address
   gchar *name = NULL;
-  gboolean local = -1; /* yup */
 
   expected_ip = g_inet_address_new_from_string ("10.1.1.1");
 
@@ -549,7 +548,9 @@ test_parse_address (void)
                           "options", options,
                           NULL);
   json_object_unref (options);
-  connectable = cockpit_channel_parse_connectable (channel, NULL, &local);
+  connectable = cockpit_channel_parse_stream (channel);
+  g_assert (connectable != NULL);
+
   address = cockpit_channel_parse_address (channel, &name);
 
   g_assert (g_socket_address_get_family (address) == G_SOCKET_FAMILY_IPV4);
@@ -558,10 +559,10 @@ test_parse_address (void)
   got_ip = g_inet_socket_address_get_address ((GInetSocketAddress *)address);
   g_assert (g_inet_address_equal (got_ip, expected_ip));
 
-  g_assert_cmpint (local, ==, FALSE);
+  g_assert_cmpint (connectable->local, ==, FALSE);
 
   g_object_unref (channel);
-  g_object_unref (connectable);
+  cockpit_connectable_unref (connectable);
   g_object_unref (transport);
   g_object_unref (address);
   g_object_unref (expected_ip);

--- a/src/bridge/test-httpstream.c
+++ b/src/bridge/test-httpstream.c
@@ -268,8 +268,6 @@ test_cannot_connect (TestGeneral *tt,
     g_main_context_iteration (NULL, TRUE);
 
   object = mock_transport_pop_control (tt->transport);
-  cockpit_assert_json_eq (object, "{\"command\":\"ready\",\"channel\":\"444\"}");
-  object = mock_transport_pop_control (tt->transport);
   cockpit_assert_json_eq (object, "{\"command\":\"close\",\"channel\":\"444\",\"problem\":\"not-found\"}");
 }
 

--- a/src/bridge/test-websocketstream.c
+++ b/src/bridge/test-websocketstream.c
@@ -1,0 +1,222 @@
+
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitwebsocketstream.h"
+#include "cockpitchannel.h"
+
+#include "common/cockpittest.h"
+#include "common/cockpitwebresponse.h"
+#include "common/cockpitwebserver.h"
+#include "websocket/websocketclient.h"
+
+#include "mock-transport.h"
+
+#include <string.h>
+
+static void
+on_closed_get_problem (CockpitChannel *channel,
+                       const gchar *problem,
+                       gpointer user_data)
+{
+  gchar **result = user_data;
+  g_assert (problem != NULL);
+  g_assert (*result == NULL);
+  *result = g_strdup (problem);
+}
+
+typedef struct {
+  MockTransport *transport;
+  CockpitWebServer *server;
+  GIOStream *client;
+  guint port;
+  gchar *origin;
+  gchar *url;
+  gboolean ws_closed;
+} TestCase;
+
+static void
+on_socket_message (WebSocketConnection *self,
+                   WebSocketDataType type,
+                   GBytes *message,
+                   gpointer user_data)
+{
+  GByteArray *array = g_bytes_unref_to_array (g_bytes_ref (message));
+  GBytes *payload;
+  guint i;
+
+  /* Capitalize and relay back */
+  for (i = 0; i < array->len; i++)
+    array->data[i] = g_ascii_toupper (array->data[i]);
+
+  payload = g_byte_array_free_to_bytes (array);
+  web_socket_connection_send (self, type, NULL, payload);
+  g_bytes_unref (payload);
+}
+
+static void
+on_socket_close (WebSocketConnection *ws,
+                 gpointer user_data)
+{
+  TestCase *test = user_data;
+  g_object_unref (ws);
+  test->ws_closed = TRUE;
+}
+
+static gboolean
+handle_socket (CockpitWebServer *server,
+               const gchar *path,
+               GIOStream *io_stream,
+               GHashTable *headers,
+               GByteArray *input,
+               gpointer data)
+{
+  const gchar *origins[] = { NULL, NULL };
+  const gchar *protocols[] = { "one", "two", "three", NULL };
+  WebSocketConnection *ws = NULL;
+  TestCase *test = data;
+
+  if (!g_str_equal (path, "/socket"))
+    return FALSE;
+
+  origins[0] = test->origin;
+  ws = web_socket_server_new_for_stream (test->url, (const gchar **)origins,
+                                         protocols, io_stream, headers, input);
+
+  g_signal_connect (ws, "message", G_CALLBACK (on_socket_message), NULL);
+  g_signal_connect (ws, "close", G_CALLBACK (on_socket_close), test);
+  return TRUE;
+}
+
+
+static void
+setup (TestCase *test,
+       gconstpointer data)
+{
+  test->server = cockpit_web_server_new (0, NULL, NULL, NULL, NULL);
+  test->port = cockpit_web_server_get_port (test->server);
+  test->transport = mock_transport_new ();
+  test->ws_closed = FALSE;
+  test->origin = g_strdup_printf ("http://localhost:%u", test->port);
+  test->url = g_strdup_printf ("ws://localhost:%u/socket", test->port);
+  g_signal_connect (test->server, "handle-stream",
+                    G_CALLBACK (handle_socket), test);
+}
+
+static void
+teardown (TestCase *test,
+          gconstpointer data)
+{
+  g_object_unref (test->server);
+  g_object_unref (test->transport);
+
+  g_free (test->origin);
+  g_free (test->url);
+  cockpit_assert_expected ();
+}
+
+static void
+test_basic (TestCase *test,
+            gconstpointer data)
+{
+  JsonObject *options;
+  CockpitChannel *channel;
+  GBytes *bytes = NULL;
+  GBytes *recv = NULL;
+
+  options = json_object_new ();
+  json_object_set_int_member (options, "port", test->port);
+  json_object_set_string_member (options, "payload", "websocket-stream1");
+  json_object_set_string_member (options, "path", "/socket");
+
+  channel = g_object_new (COCKPIT_TYPE_WEB_SOCKET_STREAM,
+                          "transport", test->transport,
+                          "id", "444",
+                          "options", options,
+                          NULL);
+  json_object_unref (options);
+
+  bytes = g_bytes_new ("Message", 7);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (test->transport), "444", bytes);
+  g_bytes_unref (bytes);
+
+  while (mock_transport_count_sent (test->transport) < 3)
+    g_main_context_iteration (NULL, TRUE);
+
+  recv = mock_transport_pop_channel (test->transport, "444");
+  cockpit_assert_bytes_eq (recv, "MESSAGE", 7);
+  g_bytes_unref (recv);
+
+  cockpit_channel_close (channel, "ending");
+
+  while (!test->ws_closed)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_object_unref (channel);
+}
+
+static void
+test_bad_origin (TestCase *test,
+                 gconstpointer data)
+{
+  JsonObject *options;
+  CockpitChannel *channel;
+  gchar *problem = NULL;
+
+  options = json_object_new ();
+  json_object_set_int_member (options, "port", test->port);
+  json_object_set_string_member (options, "payload", "websocket-stream1");
+  json_object_set_string_member (options, "path", "/socket");
+
+  g_free (test->origin);
+  test->origin = g_strdup ("bad-origin");
+
+  channel = g_object_new (COCKPIT_TYPE_WEB_SOCKET_STREAM,
+                          "transport", test->transport,
+                          "id", "444",
+                          "options", options,
+                          NULL);
+  g_signal_connect (channel, "closed", G_CALLBACK (on_closed_get_problem), &problem);
+  json_object_unref (options);
+
+  while (problem == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_assert_cmpstr (problem, ==, "internal-error");
+  while (!test->ws_closed)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_object_unref (channel);
+  g_free (problem);
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+  cockpit_test_init (&argc, &argv);
+
+  g_test_add ("/websocket-stream/test_basic", TestCase, NULL,
+              setup, test_basic, teardown);
+  g_test_add ("/websocket-stream/test_bad_origin", TestCase, NULL,
+              setup, test_bad_origin, teardown);
+  return g_test_run ();
+}

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -46,6 +46,8 @@ nodist_libcockpit_common_a_SOURCES = \
 libcockpit_common_a_SOURCES = \
 	src/common/cockpitcertificate.c \
 	src/common/cockpitcertificate.h \
+	src/common/cockpitconnect.c \
+	src/common/cockpitconnect.h \
 	src/common/cockpitenums.h \
 	src/common/cockpiterror.h src/common/cockpiterror.c \
 	src/common/cockpithash.c \
@@ -112,6 +114,7 @@ COCKPIT_CHECKS = \
 	test-hex \
 	test-json \
 	test-pipe \
+	test-connect \
 	test-stream \
 	test-transport \
 	test-unixsignal \
@@ -121,6 +124,11 @@ COCKPIT_CHECKS = \
 	test-config \
 	test-unicode \
 	$(NULL)
+
+
+test_connect_CFLAGS = $(libcockpit_common_a_CFLAGS)
+test_connect_SOURCES = src/common/test-connect.c
+test_connect_LDADD = $(libcockpit_common_a_LIBS)
 
 test_hash_CFLAGS = $(libcockpit_common_a_CFLAGS)
 test_hash_SOURCES = src/common/test-hash.c

--- a/src/common/cockpitconnect.c
+++ b/src/common/cockpitconnect.c
@@ -1,0 +1,279 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitconnect.h"
+
+#include <glib/gi18n.h>
+
+CockpitConnectable *
+cockpit_connectable_ref (CockpitConnectable *connectable)
+{
+  g_return_val_if_fail (connectable != NULL, NULL);
+
+  if (connectable->refs <= 0)
+    {
+      connectable = g_memdup (connectable, sizeof (CockpitConnectable));
+      g_object_ref (connectable->address);
+      if (connectable->tls_cert)
+        g_object_ref (connectable->tls_cert);
+      if (connectable->tls_database)
+        g_object_ref (connectable->tls_database);
+      connectable->name = g_strdup (connectable->name ? connectable->name : "connect");
+      connectable->refs = 1;
+    }
+  else
+    {
+      connectable->refs++;
+    }
+
+  return connectable;
+}
+
+void
+cockpit_connectable_unref (gpointer data)
+{
+  CockpitConnectable *connectable = data;
+
+  g_return_if_fail (connectable != NULL);
+  g_return_if_fail (connectable->refs > 0);
+
+  if (--connectable->refs == 0)
+    {
+      if (connectable->tls_cert)
+        g_object_unref (connectable->tls_cert);
+      if (connectable->tls_database)
+        g_object_unref (connectable->tls_database);
+      g_object_unref (connectable->address);
+      g_free (connectable->name);
+      g_free (connectable);
+    }
+}
+
+typedef struct {
+  CockpitConnectable *connectable;
+  GSocketAddressEnumerator *enumerator;
+  GCancellable *cancellable;
+  GIOStream *io;
+  GError *error;
+} ConnectStream;
+
+static void
+connect_stream_free (gpointer data)
+{
+  ConnectStream *cs = data;
+  if (cs->connectable)
+    cockpit_connectable_unref (cs->connectable);
+  if (cs->cancellable)
+    g_object_unref (cs->cancellable);
+  g_object_unref (cs->enumerator);
+  g_clear_error (&cs->error);
+  if (cs->io)
+    g_object_unref (cs->io);
+  g_free (cs);
+}
+
+static void
+on_address_next (GObject *object,
+                 GAsyncResult *result,
+                 gpointer user_data);
+
+static void
+on_socket_connect (GObject *object,
+                   GAsyncResult *result,
+                   gpointer user_data)
+{
+  GSimpleAsyncResult *simple = G_SIMPLE_ASYNC_RESULT (user_data);
+  ConnectStream *cs = g_simple_async_result_get_op_res_gpointer (simple);
+  CockpitConnectable *connectable = cs->connectable;
+  GError *error = NULL;
+
+  g_socket_connection_connect_finish (G_SOCKET_CONNECTION (object), result, &error);
+
+  g_debug ("%s: connected", connectable->name);
+
+  if (error)
+    {
+      g_debug ("%s: couldn't connect: %s", connectable->name, error->message);
+      g_clear_error (&cs->error);
+      cs->error = error;
+
+      g_socket_address_enumerator_next_async (cs->enumerator, cs->cancellable,
+                                              on_address_next, g_object_ref (simple));
+    }
+  else
+    {
+      g_debug ("%s: connected", connectable->name);
+
+      if (connectable->tls)
+        {
+          cs->io = g_tls_client_connection_new (G_IO_STREAM (object), NULL, &error);
+          if (cs->io)
+            {
+              g_debug ("%s: tls handshake", connectable->name);
+
+              g_tls_client_connection_set_validation_flags (G_TLS_CLIENT_CONNECTION (cs->io),
+                                                            connectable->tls_flags);
+
+              if (connectable->tls_cert)
+                g_tls_connection_set_certificate (G_TLS_CONNECTION (cs->io), connectable->tls_cert);
+              if (connectable->tls_database)
+                g_tls_connection_set_database (G_TLS_CONNECTION (cs->io), connectable->tls_database);
+
+              /* We track data end the same way we do for HTTP */
+              g_tls_connection_set_require_close_notify (G_TLS_CONNECTION (cs->io), FALSE);
+            }
+        }
+      else
+        {
+          cs->io = g_object_ref (object);
+        }
+
+      g_simple_async_result_complete (simple);
+    }
+
+  g_object_unref (object);
+  g_object_unref (simple);
+}
+
+static void
+on_address_next (GObject *object,
+                 GAsyncResult *result,
+                 gpointer user_data)
+{
+  GSimpleAsyncResult *simple = G_SIMPLE_ASYNC_RESULT (user_data);
+  ConnectStream *cs = g_simple_async_result_get_op_res_gpointer (simple);
+  CockpitConnectable *connectable = cs->connectable;
+  GSocketConnection *connection;
+  GSocketAddress *address;
+  GError *error = NULL;
+  GSocket *sock;
+
+  address = g_socket_address_enumerator_next_finish (G_SOCKET_ADDRESS_ENUMERATOR (object),
+                                                     result, &error);
+
+  if (error)
+    {
+      g_debug ("%s: couldn't resolve: %s", connectable->name, error->message);
+      g_clear_error (&cs->error);
+      cs->error = error;
+      g_simple_async_result_complete (simple);
+    }
+  else if (address)
+    {
+      sock = g_socket_new (g_socket_address_get_family (address), G_SOCKET_TYPE_STREAM, 0, &error);
+      if (sock)
+        {
+          g_socket_set_blocking (sock, FALSE);
+
+          connection = g_socket_connection_factory_create_connection (sock);
+          g_object_unref (sock);
+
+          g_socket_connection_connect_async (connection, address, cs->cancellable,
+                                             on_socket_connect, g_object_ref (simple));
+        }
+
+      if (error)
+        {
+          g_debug ("%s: couldn't open socket: %s", connectable->name, error->message);
+          g_clear_error (&cs->error);
+          cs->error = error;
+          g_simple_async_result_complete (simple);
+        }
+      g_object_unref (address);
+    }
+  else
+    {
+      if (!cs->error)
+          g_message ("%s: no addresses found", connectable->name);
+      g_simple_async_result_complete (simple);
+    }
+
+  g_object_unref (simple);
+}
+
+void
+cockpit_connect_stream (GSocketConnectable *address,
+                        GCancellable *cancellable,
+                        GAsyncReadyCallback callback,
+                        gpointer user_data)
+{
+  CockpitConnectable connectable = { .address = address };
+
+  g_return_if_fail (G_IS_SOCKET_CONNECTABLE (address));
+  g_return_if_fail (!cancellable || G_IS_CANCELLABLE (cancellable));
+
+  cockpit_connect_stream_full (&connectable, cancellable, callback, user_data);
+}
+
+void
+cockpit_connect_stream_full (CockpitConnectable *connectable,
+                             GCancellable *cancellable,
+                             GAsyncReadyCallback callback,
+                             gpointer user_data)
+{
+  GSimpleAsyncResult *simple;
+  ConnectStream *cs;
+
+  g_return_if_fail (connectable != NULL);
+  g_return_if_fail (G_IS_SOCKET_CONNECTABLE (connectable->address));
+  g_return_if_fail (!cancellable || G_IS_CANCELLABLE (cancellable));
+
+  simple = g_simple_async_result_new (NULL, callback, user_data, cockpit_connect_stream);
+  cs = g_new0 (ConnectStream, 1);
+  cs->connectable = cockpit_connectable_ref (connectable);
+  cs->cancellable = cancellable ? g_object_ref (cancellable) : NULL;
+  cs->enumerator = g_socket_connectable_enumerate (connectable->address);
+  g_simple_async_result_set_op_res_gpointer (simple, cs, connect_stream_free);
+
+  g_socket_address_enumerator_next_async (cs->enumerator, NULL,
+                                          on_address_next, g_object_ref (simple));
+
+  g_object_unref (simple);
+}
+
+GIOStream *
+cockpit_connect_stream_finish (GAsyncResult *result,
+                               GError **error)
+{
+  GSimpleAsyncResult *simple;
+  ConnectStream *cs;
+
+  g_return_val_if_fail (g_simple_async_result_is_valid (result, NULL, cockpit_connect_stream), NULL);
+
+  simple = G_SIMPLE_ASYNC_RESULT (result);
+  cs = g_simple_async_result_get_op_res_gpointer (simple);
+
+  if (cs->io)
+    {
+      return g_object_ref (cs->io);
+    }
+  else if (cs->error)
+    {
+      g_propagate_error (error, cs->error);
+      cs->error = NULL;
+      return NULL;
+    }
+  else
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_HOST_NOT_FOUND, _("No addresses found"));
+      return NULL;
+    }
+}

--- a/src/common/cockpitconnect.h
+++ b/src/common/cockpitconnect.h
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __COCKPIT_CONNECT_H__
+#define __COCKPIT_CONNECT_H__
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+typedef struct {
+  gint refs;
+  gchar *name;
+
+  /* Where to connect to */
+  GSocketConnectable *address;
+
+  /* TLS flags */
+  gboolean tls;
+  gboolean local;
+  GTlsCertificateFlags tls_flags;
+  GTlsCertificate *tls_cert;
+  GTlsDatabase *tls_database;
+} CockpitConnectable;
+
+CockpitConnectable *    cockpit_connectable_ref    (CockpitConnectable *connectable);
+
+void                    cockpit_connectable_unref  (gpointer data);
+
+void                    cockpit_connect_stream        (GSocketConnectable *address,
+                                                       GCancellable *cancellable,
+                                                       GAsyncReadyCallback callback,
+                                                       gpointer user_data);
+
+
+void                    cockpit_connect_stream_full   (CockpitConnectable *connectable,
+                                                       GCancellable *cancellable,
+                                                       GAsyncReadyCallback callback,
+                                                       gpointer user_data);
+
+GIOStream *             cockpit_connect_stream_finish (GAsyncResult *result,
+                                                       GError **error);
+
+G_END_DECLS
+
+#endif /* __COCKPIT_STREAM_H__ */

--- a/src/common/cockpitstream.c
+++ b/src/common/cockpitstream.c
@@ -58,6 +58,7 @@ struct _CockpitStreamPrivate {
   gboolean received;
 };
 
+static guint cockpit_stream_sig_open;
 static guint cockpit_stream_sig_read;
 static guint cockpit_stream_sig_close;
 
@@ -518,6 +519,8 @@ initialize_io (CockpitStream *self)
   g_source_attach (self->priv->in_source, self->priv->context);
 
   start_output (self);
+
+  g_signal_emit (self, cockpit_stream_sig_open, 0);
 }
 
 static void
@@ -657,6 +660,15 @@ cockpit_stream_class_init (CockpitStreamClass *klass)
   g_object_class_install_property (gobject_class, PROP_PROBLEM,
                 g_param_spec_string ("problem", "problem", "problem", NULL,
                                      G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+
+  /**
+   * CockpitStream::open:
+   *
+   * Emitted when actually open and connected.
+   */
+  cockpit_stream_sig_open = g_signal_new ("open", COCKPIT_TYPE_STREAM, G_SIGNAL_RUN_LAST,
+                                          G_STRUCT_OFFSET (CockpitStreamClass, open),
+                                          NULL, NULL, NULL, G_TYPE_NONE, 0);
 
   /**
    * CockpitStream::read:

--- a/src/common/cockpitstream.c
+++ b/src/common/cockpitstream.c
@@ -40,12 +40,10 @@ enum {
 struct _CockpitStreamPrivate {
   gchar *name;
   GMainContext *context;
-  CockpitStreamOptions *options;
 
   gboolean closed;
   gboolean closing;
-  GSocketAddressEnumerator *connecting;
-  GError *connect_error;
+  CockpitConnectable *connecting;
   gchar *problem;
 
   GIOStream *io;
@@ -113,11 +111,10 @@ close_immediately (CockpitStream *self,
 
   if (self->priv->connecting)
     {
-      g_object_unref (self->priv->connecting);
+      cockpit_connectable_unref (self->priv->connecting);
       self->priv->connecting = NULL;
     }
 
-  g_clear_error (&self->priv->connect_error);
   self->priv->closed = TRUE;
 
   g_debug ("%s: closing stream%s%s", self->priv->name,
@@ -203,15 +200,15 @@ close_output (CockpitStream *self)
 #endif
 
 static gchar *
-describe_certificate_errors (CockpitStream *self)
+describe_certificate_errors (GIOStream *io)
 {
   GTlsCertificateFlags flags;
   GString *str;
 
-  if (!G_IS_TLS_CONNECTION (self->priv->io))
+  if (!G_IS_TLS_CONNECTION (io))
     return NULL;
 
-  flags = g_tls_connection_get_peer_certificate_errors (G_TLS_CONNECTION (self->priv->io));
+  flags = g_tls_connection_get_peer_certificate_errors (G_TLS_CONNECTION (io));
   if (flags == 0)
     return NULL;
 
@@ -261,10 +258,11 @@ describe_certificate_errors (CockpitStream *self)
   return g_string_free (str, FALSE);
 }
 
-static void
-set_problem_from_error (CockpitStream *self,
+const gchar *
+cockpit_stream_problem (GError *error,
+                        const gchar *name,
                         const gchar *summary,
-                        GError *error)
+                        GIOStream *io)
 {
   const gchar *problem = NULL;
   gchar *details = NULL;
@@ -280,8 +278,7 @@ set_problem_from_error (CockpitStream *self,
     problem = "not-found";
   else if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE) ||
            g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) ||
-           g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_EOF) ||
-           (self->priv->received && g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_MISC)))
+           g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_EOF))
     problem = "disconnected";
 #if !GLIB_CHECK_VERSION(2,43,2)
   else if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_FAILED) &&
@@ -291,29 +288,52 @@ set_problem_from_error (CockpitStream *self,
   else if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT))
     problem = "timeout";
   else if (g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_NOT_TLS) ||
-           (!self->priv->received && g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_MISC)))
+           g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_MISC))
     problem = "protocol-error";
   else if (g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_BAD_CERTIFICATE))
     {
       problem = "unknown-hostkey";
-      details = describe_certificate_errors (self);
+      if (io != NULL)
+        details = describe_certificate_errors (io);
     }
-
-  g_free (self->priv->problem);
 
   if (problem)
     {
-      g_message ("%s: %s: %s%s%s", self->priv->name, summary, error->message,
+      g_message ("%s: %s: %s%s%s", name, summary, error->message,
                  details ? ": " : "", details ? details : "");
-      self->priv->problem = g_strdup (problem);
     }
   else
     {
-      g_warning ("%s: %s: %s", self->priv->name, summary, error->message);
-      self->priv->problem = g_strdup ("internal-error");
+      g_warning ("%s: %s: %s", name, summary, error->message);
+      problem = "internal-error";
     }
 
   g_free (details);
+  return problem;
+}
+
+static void
+set_problem_from_error (CockpitStream *self,
+                        const gchar *summary,
+                        GError *error)
+{
+  const gchar *problem;
+
+  if (g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_MISC))
+    {
+      g_message ("%s: %s: %s", self->priv->name, summary, error->message);
+      if (self->priv->received)
+        problem = "disconnected";
+      else
+        problem = "protocol-error";
+    }
+  else
+    {
+      problem = cockpit_stream_problem (error, self->priv->name, summary, self->priv->io);
+    }
+
+  g_free (self->priv->problem);
+  self->priv->problem = g_strdup (problem);
 }
 
 static gboolean
@@ -488,7 +508,7 @@ initialize_io (CockpitStream *self)
 
   if (self->priv->connecting)
     {
-      g_object_unref (self->priv->connecting);
+      cockpit_connectable_unref (self->priv->connecting);
       self->priv->connecting = NULL;
     }
 
@@ -573,10 +593,6 @@ cockpit_stream_dispose (GObject *object)
 
   while (self->priv->out_queue->head)
     g_bytes_unref (g_queue_pop_head (self->priv->out_queue));
-
-  if (self->priv->options)
-    cockpit_stream_options_unref (self->priv->options);
-  self->priv->options = NULL;
 
   G_OBJECT_CLASS (cockpit_stream_parent_class)->dispose (object);
 }
@@ -770,168 +786,46 @@ cockpit_close_later (CockpitStream *self)
 }
 
 static void
-on_address_next (GObject *object,
-                 GAsyncResult *result,
-                 gpointer user_data);
-
-static void
-on_socket_connect (GObject *object,
+on_connect_stream (GObject *object,
                    GAsyncResult *result,
                    gpointer user_data)
 {
-  CockpitStream *self = user_data;
+  CockpitStream *self = COCKPIT_STREAM (user_data);
   GError *error = NULL;
 
-  g_socket_connection_connect_finish (G_SOCKET_CONNECTION (object), result, &error);
-
-  if (!error && !self->priv->closed)
-    {
-      g_debug ("%s: connected", self->priv->name);
-
-      if (self->priv->options && self->priv->options->tls_client)
-        {
-          self->priv->io = g_tls_client_connection_new (G_IO_STREAM (object), NULL, &error);
-          if (self->priv->io)
-            {
-              g_debug ("%s: tls handshake", self->priv->name);
-
-              g_tls_client_connection_set_validation_flags (G_TLS_CLIENT_CONNECTION (self->priv->io),
-                                                            self->priv->options->tls_client_flags);
-
-              if (self->priv->options->tls_cert)
-                {
-                  g_tls_connection_set_certificate (G_TLS_CONNECTION (self->priv->io),
-                                                    self->priv->options->tls_cert);
-                }
-              if (self->priv->options->tls_database)
-                {
-                  g_tls_connection_set_database (G_TLS_CONNECTION (self->priv->io),
-                                                 self->priv->options->tls_database);
-                }
-
-              /* We track data end the same way we do for HTTP */
-              g_tls_connection_set_require_close_notify (G_TLS_CONNECTION (self->priv->io), FALSE);
-            }
-        }
-      else
-        {
-          self->priv->io = g_object_ref (object);
-        }
-    }
-
+  self->priv->io = cockpit_connect_stream_finish (result, &error);
   if (error)
     {
-      g_debug ("%s: couldn't connect: %s", self->priv->name, error->message);
-      g_clear_error (&self->priv->connect_error);
-      self->priv->connect_error = error;
-
-      g_socket_address_enumerator_next_async (self->priv->connecting, NULL,
-                                              on_address_next, g_object_ref (self));
+      set_problem_from_error (self, "couldn't connect", error);
+      close_immediately (self, NULL);
+      g_error_free (error);
     }
   else
     {
       initialize_io (self);
     }
 
-  g_object_unref (object);
   g_object_unref (self);
 }
 
-static void
-on_address_next (GObject *object,
-                 GAsyncResult *result,
-                 gpointer user_data)
-{
-  CockpitStream *self = user_data;
-  GSocketConnection *connection;
-  GSocketAddress *address;
-  GError *error = NULL;
-  GSocket *sock;
-
-  address = g_socket_address_enumerator_next_finish (G_SOCKET_ADDRESS_ENUMERATOR (object),
-                                                     result, &error);
-
-  if (error)
-    {
-      set_problem_from_error (self, "couldn't resolve", error);
-      g_error_free (error);
-      close_immediately (self, NULL);
-    }
-  else if (address)
-    {
-      sock = g_socket_new (g_socket_address_get_family (address), G_SOCKET_TYPE_STREAM, 0, &error);
-      if (sock)
-        {
-          g_socket_set_blocking (sock, FALSE);
-
-          connection = g_socket_connection_factory_create_connection (sock);
-          g_object_unref (sock);
-
-          g_socket_connection_connect_async (connection, address, NULL,
-                                             on_socket_connect, g_object_ref (self));
-        }
-
-      if (error)
-        {
-          g_debug ("%s: couldn't open socket: %s", self->priv->name, error->message);
-          g_clear_error (&self->priv->connect_error);
-          self->priv->connect_error = error;
-        }
-      g_object_unref (address);
-    }
-  else
-    {
-      if (self->priv->connect_error)
-        {
-          set_problem_from_error (self, "couldn't connect", self->priv->connect_error);
-          close_immediately (self, NULL);
-        }
-      else
-        {
-          g_message ("%s: no addresses found", self->priv->name);
-          close_immediately (self, "not-found");
-        }
-    }
-
-  g_object_unref (self);
-}
-
-/**
- * cockpit_stream_connect:
- * @name: name for pipe, for debugging
- * @address: socket address to connect to
- *
- * Create a new pipe connected as a client to the given socket
- * address, which can be a unix or inet address. Will connect
- * in stream mode.
- *
- * If the connection fails, a pipe is still returned. It will
- * close once the main loop is run with an appropriate problem.
- *
- * Returns: (transfer full): newly allocated CockpitStream.
- */
 CockpitStream *
 cockpit_stream_connect (const gchar *name,
-                        GSocketConnectable *connectable,
-                        CockpitStreamOptions *options)
+                        CockpitConnectable *connectable)
 {
-  CockpitStream *stream;
+  CockpitStream *self;
 
-  g_return_val_if_fail (G_IS_SOCKET_CONNECTABLE (connectable), NULL);
+  g_return_val_if_fail (connectable != NULL, NULL);
 
-  stream = g_object_new (COCKPIT_TYPE_STREAM,
-                         "io-stream", NULL,
-                         "name", name,
-                         NULL);
+  self = g_object_new (COCKPIT_TYPE_STREAM,
+                       "io-stream", NULL,
+                       "name", name,
+                       NULL);
 
-  if (options)
-    stream->priv->options = cockpit_stream_options_ref (options);
+  self->priv->connecting = cockpit_connectable_ref (connectable);
+  cockpit_connect_stream_full (self->priv->connecting, NULL,
+                               on_connect_stream, g_object_ref (self));
 
-  stream->priv->connecting = g_socket_connectable_enumerate (connectable);
-  g_socket_address_enumerator_next_async (stream->priv->connecting, NULL,
-                                          on_address_next, g_object_ref (stream));
-
-  return stream;
+  return self;
 }
 
 /**
@@ -986,29 +880,4 @@ cockpit_stream_new (const gchar *name,
                        "name", name,
                        "io-stream", io_stream,
                        NULL);
-}
-
-CockpitStreamOptions *
-cockpit_stream_options_ref (CockpitStreamOptions *options)
-{
-  g_return_val_if_fail (options != NULL, NULL);
-  options->refs++;
-  return options;
-}
-
-void
-cockpit_stream_options_unref (gpointer data)
-{
-  CockpitStreamOptions *options = data;
-
-  g_return_if_fail (options != NULL);
-
-  if (--(options->refs) <= 0)
-    {
-      if (options->tls_cert)
-        g_object_unref (options->tls_cert);
-      if (options->tls_database)
-        g_object_unref (options->tls_database);
-      g_free (options);
-    }
 }

--- a/src/common/cockpitstream.h
+++ b/src/common/cockpitstream.h
@@ -22,21 +22,9 @@
 
 #include <gio/gio.h>
 
+#include "cockpitconnect.h"
+
 G_BEGIN_DECLS
-
-typedef struct {
-  gint refs;
-
-  /* TLS flags */
-  gboolean tls_client;
-  GTlsCertificateFlags tls_client_flags;
-  GTlsCertificate *tls_cert;
-  GTlsDatabase *tls_database;
-} CockpitStreamOptions;
-
-CockpitStreamOptions *  cockpit_stream_options_ref    (CockpitStreamOptions *options);
-
-void                    cockpit_stream_options_unref  (gpointer data);
 
 #define COCKPIT_TYPE_STREAM         (cockpit_stream_get_type ())
 #define COCKPIT_STREAM(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_STREAM, CockpitStream))
@@ -72,8 +60,7 @@ CockpitStream *    cockpit_stream_new          (const gchar *name,
                                                 GIOStream *stream);
 
 CockpitStream *    cockpit_stream_connect      (const gchar *name,
-                                                GSocketConnectable *connectable,
-                                                CockpitStreamOptions *options);
+                                                CockpitConnectable *connectable);
 
 void               cockpit_stream_write        (CockpitStream *self,
                                                 GBytes *data);
@@ -84,6 +71,11 @@ void               cockpit_stream_close        (CockpitStream *self,
 const gchar *      cockpit_stream_get_name     (CockpitStream *self);
 
 GByteArray *       cockpit_stream_get_buffer   (CockpitStream *self);
+
+const gchar *      cockpit_stream_problem      (GError *error,
+                                                const gchar *name,
+                                                const gchar *summary,
+                                                GIOStream *stream);
 
 G_END_DECLS
 

--- a/src/common/cockpitstream.h
+++ b/src/common/cockpitstream.h
@@ -46,6 +46,8 @@ struct _CockpitStreamClass {
 
   /* signals */
 
+  void        (* open)        (CockpitStream *stream);
+
   void        (* read)        (CockpitStream *pipe,
                                GByteArray *buffer,
                                gboolean eof);

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -67,8 +67,7 @@ struct _CockpitWebServerClass {
                                 const gchar *path,
                                 GIOStream *io_stream,
                                 GHashTable *headers,
-                                GByteArray *input,
-                                guint in_length);
+                                GByteArray *input);
 
   gboolean (* handle_resource) (CockpitWebServer *server,
                                 const gchar *path,
@@ -301,8 +300,7 @@ cockpit_web_server_default_handle_stream (CockpitWebServer *self,
                                           const gchar *path,
                                           GIOStream *io_stream,
                                           GHashTable *headers,
-                                          GByteArray *input,
-                                          guint in_length)
+                                          GByteArray *input)
 {
   CockpitWebResponse *response;
   gboolean claimed = FALSE;
@@ -436,12 +434,11 @@ cockpit_web_server_class_init (CockpitWebServerClass *klass)
                                     NULL, /* accu_data */
                                     g_cclosure_marshal_generic,
                                     G_TYPE_BOOLEAN,
-                                    5,
+                                    4,
                                     G_TYPE_STRING,
                                     G_TYPE_IO_STREAM,
                                     G_TYPE_HASH_TABLE,
-                                    G_TYPE_BYTE_ARRAY,
-                                    G_TYPE_UINT);
+                                    G_TYPE_BYTE_ARRAY);
 
   sig_handle_resource = g_signal_new ("handle-resource",
                                       G_OBJECT_CLASS_TYPE (klass),
@@ -826,8 +823,7 @@ path_has_prefix (const gchar *path,
 static void
 process_request (CockpitRequest *request,
                  const gchar *path,
-                 GHashTable *headers,
-                 guint length)
+                 GHashTable *headers)
 {
   gboolean claimed = FALSE;
 
@@ -854,7 +850,6 @@ process_request (CockpitRequest *request,
                  request->io,
                  headers,
                  request->buffer,
-                 length,
                  &claimed);
 
   if (!claimed)
@@ -955,7 +950,7 @@ parse_and_process_request (CockpitRequest *request)
     }
 
   g_byte_array_remove_range (request->buffer, 0, off1 + off2);
-  process_request (request, path, headers, length);
+  process_request (request, path, headers);
 
 out:
   if (headers)

--- a/src/common/test-connect.c
+++ b/src/common/test-connect.c
@@ -1,0 +1,313 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitconnect.h"
+
+#include "cockpitloopback.h"
+#include "cockpittest.h"
+#include "mock-io-stream.h"
+
+#include <glib.h>
+#include <glib-unix.h>
+#include <glib/gstdio.h>
+#include <gio/gunixsocketaddress.h>
+#include <gio/gunixinputstream.h>
+#include <gio/gunixoutputstream.h>
+
+#include <sys/uio.h>
+#include <string.h>
+
+/* ----------------------------------------------------------------------------
+ * Mock
+ */
+
+/* ----------------------------------------------------------------------------
+ * Tests
+ */
+
+typedef struct {
+  GSocket *listen_sock;
+  GSource *listen_source;
+  GSocket *conn_sock;
+  GSource *conn_source;
+  GSocketAddress *address;
+  gboolean skip_ipv6_loopback;
+  guint16 port;
+} TestConnect;
+
+static void
+on_ready_get_result (GObject *object,
+                     GAsyncResult *result,
+                     gpointer user_data)
+{
+  GAsyncResult **retval = user_data;
+  g_assert (retval != NULL);
+  g_assert (*retval == NULL);
+  *retval = g_object_ref (result);
+}
+
+static gboolean
+on_socket_input (GSocket *socket,
+                 GIOCondition cond,
+                 gpointer user_data)
+{
+  gchar buffer[1024];
+  GError *error = NULL;
+  gssize ret, wret;
+
+  ret = g_socket_receive (socket, buffer, sizeof (buffer), NULL, &error);
+  g_assert_no_error (error);
+
+  if (ret == 0)
+    {
+      g_socket_shutdown (socket, FALSE, TRUE, &error);
+      g_assert_no_error (error);
+      return FALSE;
+    }
+
+  g_assert (ret > 0);
+  wret = g_socket_send (socket, buffer, ret, NULL, &error);
+  g_assert_no_error (error);
+  g_assert (wret == ret);
+  return TRUE;
+}
+
+static gboolean
+on_socket_connection (GSocket *socket,
+                      GIOCondition cond,
+                      gpointer user_data)
+{
+  TestConnect *tc = user_data;
+  GError *error = NULL;
+
+  g_assert (tc->conn_source == NULL);
+  tc->conn_sock = g_socket_accept (tc->listen_sock, NULL, &error);
+  g_assert_no_error (error);
+
+  tc->conn_source = g_socket_create_source (tc->conn_sock, G_IO_IN, NULL);
+  g_source_set_callback (tc->conn_source, (GSourceFunc)on_socket_input, tc, NULL);
+  g_source_attach (tc->conn_source, NULL);
+
+  /* Only one connection */
+  return FALSE;
+}
+
+static void
+setup_connect (TestConnect *tc,
+               gconstpointer data)
+{
+  GError *error = NULL;
+  GInetAddress *inet;
+  GSocketAddress *address;
+  GSocketFamily family = GPOINTER_TO_INT (data);
+
+  if (family == G_SOCKET_FAMILY_INVALID)
+    family = G_SOCKET_FAMILY_IPV4;
+
+  inet = g_inet_address_new_loopback (family);
+  address = g_inet_socket_address_new (inet, 0);
+  g_object_unref (inet);
+
+  tc->listen_sock = g_socket_new (family, G_SOCKET_TYPE_STREAM,
+                                  G_SOCKET_PROTOCOL_DEFAULT, &error);
+  g_assert_no_error (error);
+
+  g_socket_bind (tc->listen_sock, address, TRUE, &error);
+  g_object_unref (address);
+
+  if (error != NULL && family == G_SOCKET_FAMILY_IPV6)
+    {
+      /* Some test runners don't have IPv6 loopback, strangely enough */
+      g_clear_error (&error);
+      tc->skip_ipv6_loopback = TRUE;
+      return;
+    }
+
+  g_assert_no_error (error);
+
+  tc->address = g_socket_get_local_address (tc->listen_sock, &error);
+  g_assert_no_error (error);
+
+  tc->port = g_inet_socket_address_get_port (G_INET_SOCKET_ADDRESS (tc->address));
+
+  g_socket_listen (tc->listen_sock, &error);
+  g_assert_no_error (error);
+
+  tc->listen_source = g_socket_create_source (tc->listen_sock, G_IO_IN, NULL);
+  g_source_set_callback (tc->listen_source, (GSourceFunc)on_socket_connection, tc, NULL);
+  g_source_attach (tc->listen_source, NULL);
+}
+
+static void
+teardown_connect (TestConnect *tc,
+                  gconstpointer data)
+{
+  if (tc->address)
+    g_object_unref (tc->address);
+  if (tc->conn_source)
+    {
+      g_source_destroy (tc->conn_source);
+      g_source_unref (tc->conn_source);
+    }
+  if (tc->listen_source)
+    {
+      g_source_destroy (tc->listen_source);
+      g_source_unref (tc->listen_source);
+    }
+  g_clear_object (&tc->listen_sock);
+  g_clear_object (&tc->conn_sock);
+}
+
+static void
+test_connect (TestConnect *tc,
+              gconstpointer user_data)
+{
+  GAsyncResult *result = NULL;
+  GError *error = NULL;
+  GIOStream *io;
+
+  cockpit_connect_stream (G_SOCKET_CONNECTABLE (tc->address), NULL, on_ready_get_result, &result);
+
+  while (result == NULL)
+    g_main_context_iteration (NULL, TRUE);
+  g_assert (result != NULL);
+  io = cockpit_connect_stream_finish (result, &error);
+  g_assert_no_error (error);
+  g_object_unref (result);
+  g_assert (io != NULL);
+
+  while (tc->conn_sock == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_object_unref (io);
+}
+
+static void
+test_connect_loopback (TestConnect *tc,
+                       gconstpointer user_data)
+{
+  CockpitConnectable connectable = { 0 };
+  GAsyncResult *result = NULL;
+  GError *error = NULL;
+  GIOStream *io;
+
+  if (tc->skip_ipv6_loopback)
+    {
+      cockpit_test_skip ("no loopback for ipv6 found");
+      return;
+    }
+
+  connectable.address = cockpit_loopback_new (tc->port);
+  cockpit_connect_stream_full (&connectable, NULL, on_ready_get_result, &result);
+  g_object_unref (connectable.address);
+
+  while (result == NULL)
+    g_main_context_iteration (NULL, TRUE);
+  g_assert (result != NULL);
+  io = cockpit_connect_stream_finish (result, &error);
+  g_assert_no_error (error);
+  g_object_unref (result);
+  g_assert (io != NULL);
+
+  while (tc->conn_sock == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_object_unref (io);
+}
+
+static void
+test_fail_not_found (void)
+{
+  GAsyncResult *result = NULL;
+  GSocketAddress *address;
+  GError *error = NULL;
+  GIOStream *io;
+
+  address = g_unix_socket_address_new ("/non-existent");
+  cockpit_connect_stream (G_SOCKET_CONNECTABLE (address), NULL, on_ready_get_result, &result);
+  g_object_unref (address);
+
+  while (result == NULL)
+    g_main_context_iteration (NULL, TRUE);
+  g_assert (result != NULL);
+  io = cockpit_connect_stream_finish (result, &error);
+  g_object_unref (result);
+  g_assert (io == NULL);
+
+  g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+  g_error_free (error);
+}
+
+static void
+test_fail_access_denied (void)
+{
+  GAsyncResult *result = NULL;
+  GSocketAddress *address;
+  GError *error = NULL;
+  GIOStream *io;
+  gchar *unix_path;
+  gint fd;
+
+  if (geteuid () == 0)
+    {
+      cockpit_test_skip ("running as root");
+      return;
+    }
+
+  unix_path = g_strdup ("/tmp/cockpit-test-XXXXXX.sock");
+  fd = g_mkstemp (unix_path);
+  g_assert_cmpint (fd, >=, 0);
+
+  address = g_unix_socket_address_new ("/non-existent");
+  cockpit_connect_stream (G_SOCKET_CONNECTABLE (address), NULL, on_ready_get_result, &result);
+  g_object_unref (address);
+
+  while (result == NULL)
+    g_main_context_iteration (NULL, TRUE);
+  g_assert (result != NULL);
+  io = cockpit_connect_stream_finish (result, &error);
+  g_object_unref (result);
+  g_assert (io == NULL);
+
+  g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+  g_error_free (error);
+
+  g_free (unix_path);
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+  cockpit_test_init (&argc, &argv);
+
+  g_test_add ("/connect/simple", TestConnect, NULL,
+              setup_connect, test_connect, teardown_connect);
+  g_test_add ("/connect/loopback-ipv4", TestConnect, GINT_TO_POINTER (G_SOCKET_FAMILY_IPV4),
+              setup_connect, test_connect_loopback, teardown_connect);
+  g_test_add ("/connect/loopback-ipv6", TestConnect, GINT_TO_POINTER (G_SOCKET_FAMILY_IPV6),
+              setup_connect, test_connect_loopback, teardown_connect);
+
+  g_test_add_func ("/connect/not-found", test_fail_not_found);
+  g_test_add_func ("/connect/access-denied", test_fail_access_denied);
+
+  return g_test_run ();
+}

--- a/src/websocket/test-websocket.c
+++ b/src/websocket/test-websocket.c
@@ -558,6 +558,7 @@ test_handshake (Test *test,
 {
   gboolean open_event_client = FALSE;
   gboolean open_event_server = FALSE;
+  GHashTable *headers;
 
   g_signal_connect (test->client, "open", G_CALLBACK (on_open_set_flag), &open_event_client);
   g_signal_connect (test->server, "open", G_CALLBACK (on_open_set_flag), &open_event_server);
@@ -567,6 +568,17 @@ test_handshake (Test *test,
 
   WAIT_UNTIL (web_socket_connection_get_ready_state (test->server) != WEB_SOCKET_STATE_CONNECTING);
   g_assert_cmpint (web_socket_connection_get_ready_state (test->server), ==, WEB_SOCKET_STATE_OPEN);
+
+  headers = web_socket_client_get_headers (WEB_SOCKET_CLIENT (test->client));
+  g_assert (headers != NULL);
+#if 0
+  GHashTableIter iter;
+  gpointer key, value;
+  g_hash_table_iter_init (&iter, headers);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    g_printerr ("headers: %s %s\n", (gchar *)key, (gchar *)value);
+#endif
+  g_assert_cmpstr (g_hash_table_lookup (headers, "connection"), ==, "Upgrade");
 
   g_assert (open_event_client);
   g_assert (open_event_server);

--- a/src/websocket/websocketclient.h
+++ b/src/websocket/websocketclient.h
@@ -47,6 +47,8 @@ void                  web_socket_client_include_header     (WebSocketClient *sel
                                                             const gchar *name,
                                                             const gchar *value);
 
+GHashTable *          web_socket_client_get_headers        (WebSocketClient *self);
+
 G_END_DECLS
 
 #endif /* __WEB_SOCKET_CLIENT_H__ */

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -88,7 +88,6 @@ cockpit_handler_socket (CockpitWebServer *server,
                         GIOStream *io_stream,
                         GHashTable *headers,
                         GByteArray *input,
-                        guint in_length,
                         CockpitHandlerData *ws)
 {
   CockpitWebService *service = NULL;
@@ -128,7 +127,6 @@ cockpit_handler_external (CockpitWebServer *server,
                           GIOStream *io_stream,
                           GHashTable *headers,
                           GByteArray *input,
-                          guint in_length,
                           CockpitHandlerData *ws)
 {
   CockpitWebResponse *response = NULL;

--- a/src/ws/cockpithandlers.h
+++ b/src/ws/cockpithandlers.h
@@ -38,7 +38,6 @@ gboolean       cockpit_handler_socket            (CockpitWebServer *server,
                                                   GIOStream *io_stream,
                                                   GHashTable *headers,
                                                   GByteArray *input,
-                                                  guint in_length,
                                                   CockpitHandlerData *data);
 
 gboolean       cockpit_handler_external          (CockpitWebServer *server,
@@ -46,7 +45,6 @@ gboolean       cockpit_handler_external          (CockpitWebServer *server,
                                                   GIOStream *io_stream,
                                                   GHashTable *headers,
                                                   GByteArray *input,
-                                                  guint in_length,
                                                   CockpitHandlerData *data);
 
 gboolean       cockpit_handler_root              (CockpitWebServer *server,

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -673,7 +673,7 @@ test_socket_unauthenticated (void)
   /* Matching the above origin */
   cockpit_ws_default_host_header = "127.0.0.1";
 
-  g_assert (cockpit_handler_socket (NULL, "/cockpit/socket", io_b, NULL, NULL, 0, NULL));
+  g_assert (cockpit_handler_socket (NULL, "/cockpit/socket", io_b, NULL, NULL, NULL));
 
   g_signal_connect (client, "message", G_CALLBACK (on_message_get_bytes), &received);
 

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -229,7 +229,6 @@ on_handle_stream_socket (CockpitWebServer *server,
                          GIOStream *io_stream,
                          GHashTable *headers,
                          GByteArray *input,
-                         guint in_length,
                          gpointer user_data)
 {
   CockpitTransport *transport;
@@ -284,7 +283,6 @@ on_handle_stream_external (CockpitWebServer *server,
                            GIOStream *io_stream,
                            GHashTable *headers,
                            GByteArray *input,
-                           guint in_length,
                            gpointer user_data)
 {
   CockpitWebResponse *response;

--- a/test/kubelib.py
+++ b/test/kubelib.py
@@ -179,10 +179,7 @@ class KubernetesCommonTests(object):
         b.click("#content .listing-panel li a:contains('Logs')")
         b.wait_present(".listing-panel pre.logs")
         b.wait_visible(".listing-panel pre.logs")
-
-        # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1261459
-        # This is broken in Fedora 22
-        # b.wait_in_text(".listing-panel pre.logs", "HelloMessage.")
+        b.wait_in_text(".listing-panel pre.logs", "HelloMessage.")
 
         def line_sel(i):
             return '#terminal .terminal div:nth-child(%d)' % i


### PR DESCRIPTION
Certain APIs like Docker and Kuberenetes API server are using WebSockets in certain place. Implement a WebSocket client in cockpit-bridge.