### PR TITLE
kubernetes: Track items on containers page properly

### DIFF
--- a/pkg/kubernetes/containers.js
+++ b/pkg/kubernetes/containers.js
@@ -63,6 +63,7 @@ define([
                         container = items[key];
                         id = pod.metadata.namespace + "/pod/" + pod.metadata.name + "/" + container.spec.name;
                         result[id] = container;
+                        container.key = id;
                     }
                     return result;
                 };

--- a/pkg/kubernetes/views/containers-page.html
+++ b/pkg/kubernetes/views/containers-page.html
@@ -13,8 +13,8 @@
                 <th translatable="yes">Status</th>
             </tr>
         </thead>
-        <tbody ng-repeat="item in pods | orderObjectBy:['metedata.namespace', 'metadata.name']">
-            <tr ng-repeat-start="(id, container) in containers(item)"
+        <tbody ng-repeat="item in pods | orderObjectBy:['metedata.namespace', 'metadata.name'] track by item.key">
+            <tr ng-repeat-start="(id, container) in containers(item) track by container.key"
                 ng-click="select(id)" ng-if="!quiet && !selected(id)">
                 <th>{{container.spec.name}}</th>
                 <td>{{item.metadata.name}}</td>


### PR DESCRIPTION
Otherwise when they change they get reset to their default
state, which is irrating and causes tests to fail intertimmently.