### PR TITLE
Test: remove some static ip requirements

### DIFF
--- a/test/check-networking
+++ b/test/check-networking
@@ -24,8 +24,7 @@ import os
 
 class TestNetworking(MachineCase):
     def setUp(self):
-        # we need a static ip for this test
-        MachineCase.setUp(self, macaddr='52:54:00:9e:00:F2')
+        MachineCase.setUp(self)
 
     def get_iface(self, m, mac):
         def getit():
@@ -97,7 +96,7 @@ class TestNetworking(MachineCase):
         # Add interface, wait for it to be recognized and activated by
         # Network Manager, and switch to its page
 
-        mac = "52:54:00:9e:00:F5"
+        mac = "52:54:00:9e:00:F2"
         label = "test"
         m.execute("echo -e 'TYPE=Ethernet\nHWADDR=%s\nBOOTPROTO=autoip\n' >/etc/sysconfig/network-scripts/ifcfg-%s" % (mac, label))
         m.execute("nmcli c reload")
@@ -163,8 +162,8 @@ class TestNetworking(MachineCase):
         # Switching off rp_filter doesn't seem to be enough in the
         # case of bonds.
 
-        iface1 = self.get_iface(m, m.add_netiface(mac="52:54:00:9e:00:f1"));
-        iface2 = self.get_iface(m, m.add_netiface(mac="52:54:00:9e:00:f5", vlan=1))
+        iface1 = self.get_iface(m, m.add_netiface());
+        iface2 = self.get_iface(m, m.add_netiface(vlan=1))
         self.wait_for_iface(iface1)
         self.wait_for_iface(iface2)
 

--- a/test/guest/network-cockpit.xml
+++ b/test/guest/network-cockpit.xml
@@ -16,7 +16,6 @@
       <host mac='52:54:00:9e:00:F2' ip='10.111.112.102' name='f2.cockpit.lan' cockpit:test="check-networking"/>
       <host mac='52:54:00:9e:00:F3' ip='10.111.112.103' name='f3.cockpit.lan' cockpit:test="check-shutdown-restart"/>
       <host mac='52:54:00:9e:00:F4' ip='10.111.112.104' name='f4.cockpit.lan' cockpit:test="check-journal"/>
-      <host mac='52:54:00:9e:00:F5' ip='10.111.112.105' name='f5.cockpit.lan' cockpit:test="check-networking_secondary"/>
     </dhcp>
   </ip>
 </network>


### PR DESCRIPTION
check-networking doesn't need static ip addresses for all tests

This should prevent some test timeouts.