### PR TITLE
systemd: Ignore systemd AlreadySubscribed errors.

### DIFF
--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -760,7 +760,9 @@ define([
         systemd_manager.wait(function () {
             systemd_manager.Subscribe().
                 fail(function (error) {
-                    console.log(error);
+                    if (error.name != "org.freedesktop.systemd1.AlreadySubscribed" &&
+                        error.name != "org.freedesktop.DBus.Error.FileExists")
+                        console.warn("Subscribing to systemd signals failed", error);
                 });
             update();
         });

--- a/pkg/systemd/service.js
+++ b/pkg/systemd/service.js
@@ -85,7 +85,8 @@ define([
             wait_valid(systemd_manager, function() {
                 systemd_manager.Subscribe().
                     fail(function (error) {
-                        if (error.name != "org.freedesktop.systemd1.AlreadySubscribed")
+                        if (error.name != "org.freedesktop.systemd1.AlreadySubscribed" &&
+                            error.name != "org.freedesktop.DBus.Error.FileExists")
                             console.warn("Subscribing to systemd signals failed", error);
                     });
             });


### PR DESCRIPTION
They are harmless and happen frequently.