### PR TITLE
storaged: Print debugging output at end of check-storage-mdraid

### DIFF
--- a/test/check-storage-mdraid
+++ b/test/check-storage-mdraid
@@ -22,6 +22,12 @@ from testlib import *
 from storagelib import *
 
 class TestStorage(StorageCase):
+    def tearDown(self):
+        # HACK - for debugging https://github.com/cockpit-project/cockpit/issues/2924
+        print self.machine.execute("parted -s /dev/md127 print || true")
+        print self.machine.execute("lsblk || true")
+        MachineCase.tearDown(self)
+
     def wait_states(self, states):
         self.browser.wait_js_func("""(function(states) {
           var found = { };


### PR DESCRIPTION
To help with https://github.com/cockpit-project/cockpit/issues/2924