### PR TITLE
no snippets for socket listen directives

### DIFF
--- a/doc/guide/listen.xml
+++ b/doc/guide/listen.xml
@@ -35,6 +35,7 @@
 
 <programlisting>
 [Socket]
+ListenStream=
 ListenStream=443
 </programlisting>
 

--- a/doc/guide/listen.xml
+++ b/doc/guide/listen.xml
@@ -28,20 +28,14 @@
     <para>On servers with
       <ulink url="http://www.freedesktop.org/wiki/Software/systemd/"><code>systemd</code></ulink>
       Cockpit starts on demand via socket activation. To change its port and/or address
-      you should copy <code>/usr/lib/systemd/system/cockpit.socket</code> to
-      <code>/etc/systemd/system/cockpit.socket</code> and edit the <code>ListenStream</code>
-      option to specify the desired TCP port.</para>
+      you should place the following content in the
+      <code>/etc/systemd/system/cockpit.socket.d/listen.conf</code> file. Create the file
+      and directories in that path which not already exist. The <code>ListenStream</code>
+      option specifies the desired TCP port.</para>
 
 <programlisting>
-[Unit]
-Description=Cockpit Web Service Socket
-Documentation=man:cockpit-ws(8)
-
 [Socket]
 ListenStream=443
-
-[Install]
-WantedBy=sockets.target
 </programlisting>
 
     <para>In order for the changes to take effect, run the following commands:</para>

--- a/doc/guide/listen.xml
+++ b/doc/guide/listen.xml
@@ -28,14 +28,20 @@
     <para>On servers with
       <ulink url="http://www.freedesktop.org/wiki/Software/systemd/"><code>systemd</code></ulink>
       Cockpit starts on demand via socket activation. To change its port and/or address
-      you should place the following content in the
-      <code>/etc/systemd/system/cockpit.socket.d/listen.conf</code> file. Create the file
-      and directories in that path which not already exist. The <code>ListenStream</code>
-      option specifies the desired TCP port.</para>
+      you should copy <code>/usr/lib/systemd/system/cockpit.socket</code> to
+      <code>/etc/systemd/system/cockpit.socket</code> and edit the <code>ListenStream</code>
+      option to specify the desired TCP port.</para>
 
 <programlisting>
+[Unit]
+Description=Cockpit Web Service Socket
+Documentation=man:cockpit-ws(8)
+
 [Socket]
 ListenStream=443
+
+[Install]
+WantedBy=sockets.target
 </programlisting>
 
     <para>In order for the changes to take effect, run the following commands:</para>


### PR DESCRIPTION
systemd allows multiple Listen directives to be declared in a single
socket unit.  To *change* the activation port instead of adding a second
port, use a full override unit instead of a snippet.