### PR TITLE
doc: Remove reference to .ssh/identity

### DIFF
--- a/doc/guide/authentication.xml
+++ b/doc/guide/authentication.xml
@@ -64,7 +64,6 @@
       or encrypted with the same password that was used to login.</para>
 
 <programlisting>
-~/.ssh/identity
 ~/.ssh/id_rsa
 ~/.ssh/id_dsa
 ~/.ssh/id_ed25519


### PR DESCRIPTION
Depending on the openssh version ssh1 keys might not be loaded by default.

See 817169b2281e06c11306502de2db44023cea2ca1.