### PR TITLE
Cockpit: add template package

### DIFF
--- a/create_package
+++ b/create_package
@@ -1,0 +1,115 @@
+#!/bin/bash
+# This file is part of Cockpit.
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+SELF=create_package
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+set -eu
+
+usage()
+{
+    echo >&2 "usage: $SELF [-f] -n package_name"
+    echo >&2 ""
+    echo >&2 "-f: overwrite existing files"
+    echo >&2 "-n package_name:"
+    echo >&2 "    pass the package name to use"
+    echo >&2 "    This will be used as the directory name and as the visible name in Cockpit."
+    echo >&2 "    The name is not allowed to contain whitespace."
+}
+
+package_name=
+force_creation=0
+while getopts ":fn:" opt; do
+  case $opt in
+    f)
+      force_creation=1
+      ;;
+    n)
+      package_name=$OPTARG
+      ;;
+    \?)
+      usage
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$package_name" ]; then
+    echo "Error: $SELF requires a package_name argument" >&2
+    echo ""
+    usage
+    exit 1
+fi
+
+package_dir=$SCRIPT_DIR/pkg/$package_name
+
+declare -a target_filenames=(\
+    "$package_dir/bundle.js" \
+    "$package_dir/index.html" \
+    "$package_dir/$package_name.js" \
+    "$package_dir/Makefile.am" \
+    "$package_dir/manifest.json" \
+    "$package_dir/$package_name.css" \
+    "$package_dir/test.html" \
+    )
+
+if [[ $force_creation -eq 0 ]]; then
+    if [[ -d $package_dir ]]; then
+        echo "Package directory '$package_dir' already exists. Use -f to overwrite."
+        exit 1
+    fi
+    for f in "${target_filenames[@]}"
+    do
+        if [[ -f $f ]]; then
+            echo "File '$f' already exists. Use -f to overwrite."
+            exit 1
+        fi
+    done
+fi
+
+# copy our template
+mkdir -vp $package_dir
+for f in $SCRIPT_DIR/pkg/template/*; do
+    cp -vr $f $package_dir/
+done
+
+# some files need to be renamed
+mv $package_dir/package.js $package_dir/$package_name.js
+mv $package_dir/package.css $package_dir/$package_name.css
+
+# insert package name where necesary
+for f in "${target_filenames[@]}"
+do
+    sed -i "s/PACKAGE_NAME/$package_name/g" "$f"
+done
+
+include_line="include pkg/$package_name/Makefile.am"
+if grep -Fxq "$include_line" "$SCRIPT_DIR/Makefile.am"
+then
+    echo "base Makefile.am already has an entry for package $package_name, not changing the Makefile"
+else
+    # make sure we insert this somewhere with the other packages
+    modified_makefile=$(awk '/include pkg\//{seen++} seen && !/include pkg\//{print "'"$include_line"'"; seen=0} 1' "$SCRIPT_DIR/Makefile.am")
+    echo "$modified_makefile" > "$SCRIPT_DIR/Makefile.am"
+    echo "inserted entry into base Makefile.am"
+fi

--- a/pkg/template/Makefile.am
+++ b/pkg/template/Makefile.am
@@ -1,0 +1,53 @@
+PACKAGE_NAMEdir = $(pkgdatadir)/PACKAGE_NAME
+nodist_PACKAGE_NAME_DATA = \
+	pkg/PACKAGE_NAME/bundle.min.js.gz \
+	pkg/PACKAGE_NAME/index.min.html.gz \
+	pkg/PACKAGE_NAME/PACKAGE_NAME.min.css.gz \
+	$(NULL)
+PACKAGE_NAME_DATA = \
+	pkg/PACKAGE_NAME/manifest.json \
+	$(NULL)
+
+PACKAGE_NAMEdebugdir = $(debugdir)$(PACKAGE_NAMEdir)
+PACKAGE_NAMEdebug_DATA = \
+	pkg/PACKAGE_NAME/bundle.js \
+	pkg/PACKAGE_NAME/index.html \
+	pkg/PACKAGE_NAME/PACKAGE_NAME.js \
+	pkg/PACKAGE_NAME/PACKAGE_NAME.css \
+	$(NULL)
+
+PACKAGE_NAME_BUNDLE = \
+	pkg/PACKAGE_NAME/PACKAGE_NAME.min.js \
+	$(NULL)
+
+pkg/PACKAGE_NAME/bundle.min.js: $(PACKAGE_NAME_BUNDLE)
+	$(AM_V_GEN) $(srcdir)/tools/missing $(srcdir)/tools/jsbundle $@ $^
+
+PACKAGE_NAMEimagesdir = $(pkgdatadir)/PACKAGE_NAME/images
+PACKAGE_NAMEimages_DATA = \
+	$(NULL)
+
+PACKAGE_NAME_TESTS = \
+	pkg/PACKAGE_NAME/test.html \
+	$(NULL)
+
+TESTS += $(PACKAGE_NAME_TESTS)
+
+CLEANFILES += \
+	pkg/PACKAGE_NAME/bundle.min.js \
+	pkg/PACKAGE_NAME/index.min.html \
+	pkg/PACKAGE_NAME/PACKAGE_NAME.min.css \
+	$(PACKAGE_NAME_BUNDLE) \
+	$(nodist_PACKAGE_NAME_DATA) \
+	$(NULL)
+
+EXTRA_DIST += \
+	pkg/PACKAGE_NAME/bundle.min.js \
+	pkg/PACKAGE_NAME/index.min.html \
+	pkg/PACKAGE_NAME/PACKAGE_NAME.min.css \
+	$(PACKAGE_NAME_DATA) \
+	$(PACKAGE_NAMEdebug_DATA) \
+	$(PACKAGE_NAMEimages_DATA) \
+	$(PACKAGE_NAME_TESTS) \
+	$(PACKAGE_NAME_BUNDLE) \
+	$(NULL)

--- a/pkg/template/bundle.js
+++ b/pkg/template/bundle.js
@@ -1,0 +1,1 @@
+/* Empty. Replaced in production by a javascript bundle. */

--- a/pkg/template/index.html
+++ b/pkg/template/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<!--
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<html>
+<head>
+    <title translatable="yes">PACKAGE_NAME</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="../base1/cockpit.css" type="text/css" rel="stylesheet">
+    <link href="PACKAGE_NAME.css" type="text/css" rel="stylesheet">
+    <script src="../base1/bundle.js"></script>
+    <script src="bundle.js"></script>
+<script>
+    require([
+        "jquery",
+        "PACKAGE_NAME/PACKAGE_NAME",
+    ], function($, PACKAGE_NAME) {
+        PACKAGE_NAME.init();
+    });
+</script>
+</head>
+
+<body>
+  <!-- CURTAIN -->
+  <div id="unsupported" hidden>
+    <div class="blank-slate-pf">
+      <h1 translatable="yes">Nothing here yet.</h1>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/pkg/template/manifest.json
+++ b/pkg/template/manifest.json
@@ -1,0 +1,10 @@
+{
+    "version": 0,
+    "name": "PACKAGE_NAME",
+
+    "tools": {
+        "index": {
+            "label": "PACKAGE_NAME"
+        }
+    }
+}

--- a/pkg/template/package.css
+++ b/pkg/template/package.css
@@ -1,0 +1,18 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */

--- a/pkg/template/package.js
+++ b/pkg/template/package.js
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+define([
+    "jquery",
+    "base1/cockpit",
+    "base1/mustache",
+    "translated!base1/po",
+], function($, cockpit, mustache, po) {
+    /* setting the locale and translating should only happen in the main js file of a package */
+    cockpit.locale(po);
+
+    var _ = cockpit.gettext;
+    var C_ = cockpit.gettext;
+
+    /* a sample function we use in the test */
+    function test_function() {
+        return 1;
+    }
+
+    /* we call this from index.html */
+    function init_page() {
+        $('#unsupported').show();
+    }
+
+    return {
+        init: init_page,
+        test_function: test_function
+    };
+
+});

--- a/pkg/template/test.html
+++ b/pkg/template/test.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+  This file is part of Cockpit.
+
+  Copyright (C) 2015 Red Hat, Inc.
+
+  Cockpit is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+
+  Cockpit is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<html>
+  <head>
+    <title>Util Tests</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../../tools/qunit.css" type="text/css" media="screen" />
+    <script type="text/javascript" src="../../tools/qunit.js"></script>
+
+    <script src="../base1/bundle.js"></script>
+  </head>
+  <body>
+    <h1 id="qunit-header">Tests</h1>
+    <h2 id="qunit-banner"></h2><div id="qunit-testrunner-toolbar"></div>
+    <h2 id="qunit-userAgent"></h2><ol id="qunit-tests"></ol>
+    <div id="qunit-fixture">test markup, will be hidden</div>
+    <div id="done-flag" style="display:none">Done</div>
+    <div id="testing"></div>
+  </body>
+<script type="text/javascript">
+
+require([
+    "PACKAGE_NAME/PACKAGE_NAME"
+], function(PACKAGE_NAME) {
+
+test("some_test", function() {
+    strictEqual(PACKAGE_NAME.test_function(), 1, "test function output")
+});
+
+QUnit.start();
+
+});
+
+</script>
+</html>


### PR DESCRIPTION
Also a shell script that copies the template and renames it.
Adds entry to the Makefile, but not cockpit.spec for a package.

This is to ease the addition of new packages, especially the repetitiveness of creating the Makefile properly.

Maybe this is an interim option until we've made the build process easier?