### PR TITLE
Lookup ssh-agent address from environment on the fly

### DIFF
--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -413,8 +413,6 @@ run_bridge (const gchar *interactive)
   guint sig_int;
   int outfd;
   uid_t uid;
-  const gchar *ssh_auth_sock;
-  GSocketAddress *auth_address = NULL;
 
   cockpit_set_journal_logging (G_LOG_DOMAIN, !isatty (2));
 
@@ -489,17 +487,8 @@ run_bridge (const gchar *interactive)
       super = cockpit_portal_new_superuser (transport);
     }
 
-  ssh_auth_sock = g_getenv ("SSH_AUTH_SOCK");
-  if (ssh_auth_sock != NULL && ssh_auth_sock[0] != '\0')
-      auth_address = g_unix_socket_address_new (ssh_auth_sock);
-
   g_resources_register (cockpitassets_get_resource ());
   cockpit_web_failure_resource = "/org/cockpit-project/Cockpit/fail.html";
-
-  cockpit_channel_internal_address ("ssh-agent", auth_address);
-
-  if (auth_address)
-      g_object_unref (auth_address);
 
   pcp = cockpit_portal_new_pcp (transport);
 

--- a/src/bridge/cockpitchannel.c
+++ b/src/bridge/cockpitchannel.c
@@ -911,6 +911,35 @@ safe_unref (gpointer data)
     g_object_unref (object);
 }
 
+static gboolean
+lookup_internal (const gchar *name,
+                 GSocketConnectable **connectable)
+{
+  const gchar *env;
+
+  g_assert (name != NULL);
+  g_assert (connectable != NULL);
+
+  if (g_str_equal (name, "ssh-agent"))
+    {
+      *connectable = NULL;
+      env = g_getenv ("SSH_AUTH_SOCK");
+      if (env != NULL && env[0] != '\0')
+        *connectable = G_SOCKET_CONNECTABLE (g_unix_socket_address_new (env));
+      else
+        *connectable = NULL;
+      return TRUE;
+    }
+
+  if (internal_addresses)
+    {
+      return g_hash_table_lookup_extended (internal_addresses, name, NULL,
+                                           (gpointer *)connectable);
+    }
+
+  return FALSE;
+}
+
 void
 cockpit_channel_internal_address (const gchar *name,
                                   GSocketAddress *address)
@@ -1029,7 +1058,8 @@ cockpit_channel_parse_connectable (CockpitChannel *self,
     }
   else if (internal)
     {
-      gboolean reg = FALSE;
+      gboolean reg = lookup_internal (internal, &connectable);
+
       if (internal_addresses)
         {
           reg = g_hash_table_lookup_extended(internal_addresses,

--- a/src/ws/mock-agent-bridge.c
+++ b/src/ws/mock-agent-bridge.c
@@ -182,7 +182,6 @@ int
 main (int argc,
       char **argv)
 {
-  GSocketAddress *auth_address = NULL;
   CockpitTransport *transport;
   gboolean terminated = FALSE;
   gboolean interupted = FALSE;
@@ -220,8 +219,7 @@ main (int argc,
       outfd = 1;
     }
 
-  auth_address = g_unix_socket_address_new (ssh_auth_sock);
-  cockpit_channel_internal_address ("ssh-agent", auth_address);
+  g_setenv ("SSH_AUTH_SOCK", ssh_auth_sock, TRUE);
   if (!g_spawn_sync (BUILDDIR, (gchar **)agent_argv, NULL,
                 G_SPAWN_DEFAULT, NULL, NULL,
                 &agent_output, &agent_error,
@@ -300,7 +298,6 @@ main (int argc,
     g_main_context_iteration (NULL, TRUE);
 
   g_object_unref (transport);
-  g_object_unref (auth_address);
   g_hash_table_destroy (channels);
 
   g_source_remove (sig_term);


### PR DESCRIPTION
This allows the bridge to change its SSH_AUTH_SOCK environment
variable and have new connections to the agent connect to the
new bridge.