### PR TITLE
cockpit.spec: polkit is not a build dependency

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -81,7 +81,6 @@ BuildRequires: sed
 
 BuildRequires: glib2-devel >= 2.37.4
 BuildRequires: systemd-devel
-BuildRequires: polkit
 BuildRequires: pcp-libs-devel
 BuildRequires: gdb
 


### PR DESCRIPTION
Fixes #2942