### PR TITLE
storaged: Avoid flickering of multipath warning.

### DIFF
--- a/pkg/storaged/devices.js
+++ b/pkg/storaged/devices.js
@@ -92,9 +92,10 @@ define([
         var multipathd_service = utils.get_multipathd_service();
 
         function update_multipath_broken() {
-            // When in doubt, assume it is running
+            // When in doubt, assume everything is alright
             var multipathd_running = !multipathd_service.state || multipathd_service.state === "running";
-            $('#multipath-broken').toggle(client.broken_multipath_present && !multipathd_running);
+            var multipath_broken = client.broken_multipath_present === true;
+            $('#multipath-broken').toggle(multipath_broken && !multipathd_running);
         }
 
         $(multipathd_service).on('changed', update_multipath_broken);


### PR DESCRIPTION
While client.broken_multipath_present is 'undefined' initially, the
condition would evaluate to 'undefined' (since 'undefined && true ===
undefined') and $(...).toggle(undefined) would show and hide the
banner repeatedly.