### PR TITLE
Polkit _is_ a build dependency.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -240,7 +240,7 @@ AC_PATH_PROG([USERMOD], [usermod], [/usr/sbin/usermod], [$PATH:/usr/local/sbin:/
 AC_DEFINE_UNQUOTED([PATH_USERMOD],["$USERMOD"],[Location of usermod binary])
 
 # pkexec
-AC_PATH_PROG([PKEXEC], [pkexec], [/usr/sbin/pkexec], [$PATH:/usr/local/sbin:/usr/sbin:/sbin])
+AC_PATH_PROG([PKEXEC], [pkexec], [/usr/bin/pkexec], [$PATH:/usr/local/sbin:/usr/sbin:/sbin])
 AC_DEFINE_UNQUOTED([PATH_PKEXEC], ["$PKEXEC"], [Location of pkexec binary])
 
 # sudo

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -81,6 +81,7 @@ BuildRequires: sed
 
 BuildRequires: glib2-devel >= 2.37.4
 BuildRequires: systemd-devel
+BuildRequires: polkit
 BuildRequires: pcp-libs-devel
 BuildRequires: gdb
 


### PR DESCRIPTION
When we get the path of pkexec wrong, cockpit-bridge falls back to sudo, but sudo fails with "a password is required" (as expected on f22). This means that "superuser" channels don't work anymore and the tests fail.

Our mock buildroots probably have polkit installed anyway, from earlier builds, and thus this failure doesn't happen consistently. It does happen in our clean master builds, though.
