### PR TITLE
Click full navbar dropdown

### DIFF
--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -27,7 +27,7 @@
             <a><span class="oops-status" translatable="yes">Ooops!</span></a>
           </li>
           <li class="dropdown">
-            <a class="dropdown-toggle" data-toggle="dropdown">
+            <a id="navbar-dropdown" class="dropdown-toggle" data-toggle="dropdown">
               <span class="pficon pficon-user"></span>
               <span id="content-user-name"></span><b class="caret"></b>
             </a>

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -892,10 +892,10 @@ define([
                 return;
 
             var data = event.data;
-            if (typeof data !== "string")
+            var child = event.source;
+            if (!child || typeof data !== "string")
                 return;
 
-            var child = event.source;
             var source = source_by_name[child.name];
 
             /* Closing the transport */

--- a/test/check-keys
+++ b/test/check-keys
@@ -56,7 +56,7 @@ class TestKeys(MachineCase):
             b.switch_to_top()
             b.wait_text('#content-user-name', user_name)
 
-            b.click('#content-user-name')
+            b.click('#navbar-dropdown')
             b.click('#go-account')
             b.enter_page("/users")
             b.wait_text("#account-user-name", user);
@@ -187,7 +187,7 @@ class TestKeys(MachineCase):
         self.assertNotIn(id_dsa, keys)
         self.assertNotIn(old_dsa, keys)
 
-        b.click("#content-user-name")
+        b.click("#navbar-dropdown")
         b.click("#credentials-item")
 
         # Check the key display

--- a/test/check-menu
+++ b/test/check-menu
@@ -27,7 +27,7 @@ class TestMenu(MachineCase):
         self.login_and_go("/system")
 
         b.switch_to_top()
-        b.click('#content-user-name')
+        b.click('#navbar-dropdown')
         b.wait_visible('a[data-target="#about"]')
         b.click('a[data-target="#about"]')
         b.wait_popup('about')

--- a/test/check-reauthorize
+++ b/test/check-reauthorize
@@ -37,7 +37,7 @@ class TestReauthorize(MachineCase):
 
         # Deauthorize
         b.leave_page()
-        b.click("#content-user-name")
+        b.click("#navbar-dropdown")
         b.click("#credentials-item")
         b.click("#credential-authorize button")
         b.wait_not_present("#credential-authorize button")
@@ -63,7 +63,7 @@ class TestReauthorize(MachineCase):
 
         # Deauthorize
         b.leave_page()
-        b.click("#content-user-name")
+        b.click("#navbar-dropdown")
         b.click("#credentials-item")
         b.click("#credential-authorize button")
         b.wait_not_present("#credential-authorize button")

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -368,8 +368,8 @@ class Browser:
 
     def logout(self):
         self.switch_to_top()
-        self.wait_present("#content-user-name")
-        self.click("#content-user-name")
+        self.wait_present("#navbar-dropdown")
+        self.click("#navbar-dropdown")
         self.click('#go-logout')
         self.expect_load()
 


### PR DESCRIPTION
Click on the full user menu dropdown, and not just the name

This fixes issues like this:

```
./check-loopback
Journal database copied to check-loopback-testBasic-10.111.124.11-FAIL.journal
Page error: #content-user-name is not visible
EWrote check-loopback-testBasic-FAIL.png
Warning: Permanently added '10.111.124.11' (ECDSA) to the list of known hosts.

======================================================================
ERROR: testBasic (__main__.TestLoopback)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./check-loopback", line 37, in testBasic
    b.logout()
  File "/home/hubbot/hubbot/be7648258167a9ee3f95fa1e34d1e7f1cebbbf74_f22_x86-64/test/testlib.py", line 372, in logout
    self.click("#content-user-name")
  File "/home/hubbot/hubbot/be7648258167a9ee3f95fa1e34d1e7f1cebbbf74_f22_x86-64/test/testlib.py", line 159, in click
    self.call_js_func('ph_click', selector, force)
  File "/home/hubbot/hubbot/be7648258167a9ee3f95fa1e34d1e7f1cebbbf74_f22_x86-64/test/testlib.py", line 151, in call_js_func
    return self.phantom.eval("%s(%s)" % (func, ','.join(map(jsquote, args))))
  File "/home/hubbot/hubbot/be7648258167a9ee3f95fa1e34d1e7f1cebbbf74_f22_x86-64/test/testlib.py", line 610, in <lambda>
    return lambda *args: self._invoke(name, *args)
  File "/home/hubbot/hubbot/be7648258167a9ee3f95fa1e34d1e7f1cebbbf74_f22_x86-64/test/testlib.py", line 633, in _invoke
    raise Error(res['error'])
Error: #content-user-name is not visible

----------------------------------------------------------------------
```