### PR TITLE
shell: Handle message event with null source

### DIFF
--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -892,10 +892,10 @@ define([
                 return;
 
             var data = event.data;
-            if (typeof data !== "string")
+            var child = event.source;
+            if (!child || typeof data !== "string")
                 return;
 
-            var child = event.source;
             var source = source_by_name[child.name];
 
             /* Closing the transport */


### PR DESCRIPTION
This happens during testing. It's documented on MDN to happen in
certain cases where the message comes from chrome.

Example:

  TypeError: 'null' is not an object (evaluating 'i.name')