### PR TITLE
Fix Turkish language name

### DIFF
--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -8,7 +8,7 @@
         "da": "Dansk",
         "pl": "Polski",
         "pt_BR": "Portugueses",
-        "tr": "Türk",
+        "tr": "Türkçe",
         "uk": "Українська"
     }
 }


### PR DESCRIPTION
Hello,

I noticed that translation of Turkish word to Turkish is wrong in the manifest.json file. It must be Türkçe not Türk. So I am try to fix that with this PR.