### PR TITLE
Test: Start libvirt event handler after initialization

### DIFF
--- a/test/testvm.py
+++ b/test/testvm.py
@@ -422,11 +422,11 @@ class VirtEventHandler():
         self.data_lock = threading.RLock()
         self.signal_condition = threading.Condition(self.data_lock)
 
-        self.virEventLoopNativeStart()
-
         # only show debug messages for specific domains, since
         # we might have multiple event handlers at any given time
         self.debug_domains = []
+
+        self.virEventLoopNativeStart()
 
     def allow_domain_debug_output(self, dom_name):
         with self.data_lock:


### PR DESCRIPTION
In the event handler callback for libvirt events, we access members of
the event handler object. We have to make sure we initialize
all of these before we access them in the callback function, since
a callback can be triggered at any time from other libvirt domains
on the system.

The race could manifest via very minimal tracebacks:
```
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/libvirt.py", line 4405, in _dispatchDomainEventLifecycleCallback
```