### PR TITLE
Test: shutdown restart

### DIFF
--- a/test/check-shutdown-restart
+++ b/test/check-shutdown-restart
@@ -42,8 +42,8 @@ class TestShutdownRestart(MachineCase):
         b.click("#shutdown-delay button")
         b.click("a.opt span:contains('No Delay')")
         b.click("#shutdown-action")
-        b.wait_popdown("shutdown-dialog")
         b.switch_to_top()
+        # we don't need to wait for the dialog to close here, just the disconnect
         b.wait_popup("disconnected-dialog")
         m.wait_reboot()
         self.start_cockpit()
@@ -61,8 +61,8 @@ class TestShutdownRestart(MachineCase):
         b.click("#shutdown-delay button")
         b.click("a.opt span:contains('No Delay')")
         b.click("#shutdown-action")
-        b.wait_popdown("shutdown-dialog")
         b.switch_to_top()
+        # we don't need to wait for the dialog to close here, just the disconnect
         b.wait_popup("disconnected-dialog")
         m.wait_poweroff()
 

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -943,9 +943,7 @@ class VirtMachine(Machine):
     def kill(self):
         # stop system immediately, with potential data loss
         # to shutdown gracefully, use shutdown()
-        if hasattr(self, '_domain') and self._domain:
-            if self._domain.isActive():
-                self._domain.destroy()
+        # we just delete the variables and let libvirt clean up for us
         self._cleanup(quick=True)
 
     def wait_poweroff(self, timeout_sec=120):


### PR DESCRIPTION
We lose the ability to check for a dialog that properly closes. Alternatively, we could trigger a delayed shutdown - but how do we reliably detect that across the different test systems? It doesn't seem worth waiting a minute for this test every time it runs just to have a delay. Using a specific shutdown time might error prone when run on test systems under load.