### PR TITLE
shell: Don't do anything with flot when invisible

### DIFF
--- a/pkg/shell/plot.js
+++ b/pkg/shell/plot.js
@@ -138,11 +138,11 @@ shell.plot = function plot(element, x_range_seconds, x_stop_seconds) {
     var grid;
 
     function refresh_now() {
-        if (flot === null) {
-            if (element.height() === 0 || element.width() === 0)
-                return;
+        if (element.height() === 0 || element.width() === 0)
+            return;
+
+        if (flot === null)
             flot = $.plot(element, flot_data, options);
-        }
 
         flot.setData(flot_data);
         var axes = flot.getAxes();


### PR DESCRIPTION
Flot caches the results of measuring text, but measuring doesn't work
while the element is invisible and always return zeroes.  Flot would
cache these wrong results and would use them when the plot becomes
visible again.

The visible effect is that some axis labels show up in the wrong
place.