### PR TITLE
Intercept per-test results correctly

### DIFF
--- a/test/check-example
+++ b/test/check-example
@@ -25,6 +25,13 @@ import time
 import unittest
 
 class TestExample(MachineCase):
+    def testFail(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/system")
+        self.assertFalse(True)
+
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -42,6 +49,9 @@ class TestSimple(unittest.TestCase):
         self.assertTrue(True)
 
     def testTwo(self):
+        self.assertFalse(True)
+
+    def testThree(self):
         self.assertTrue(True)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously we would fail an entire test run when one test failed. But recent changes have fixed this.
    
The side effect was that the tearDown() code wasn't tracking the state of a given tests results correctly. Tests that would succeed, would print out screenshots and download journals if a prior test had failed.
    
Use a different mechanism for determining whether a test fails in its tearDown() method.
    
Note that we cannot move the code out of tearDown() because it needs to occur before the machine, browser, or other resources have been torn down.