### PR TITLE
networkmanager: Fix onoff switches

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2226,7 +2226,6 @@ PageNetworkInterface.prototype = {
                                     $('<td colspan="2">').text(device_state_text(dev))),
                                    $('<td style="text-align:right">').append(
                                        switchbox(is_active, function(val) {
-    console.log("is_active", val);
                                            if (val) {
                                                slave_con.activate(iface.Device).
                                                    fail(show_unexpected_error);
@@ -2297,7 +2296,12 @@ function PageNetworkInterface(model) {
 }
 
 function switchbox(val, callback) {
-    return $('<div class="btn-onoff">').onoff();
+    var onoff = $('<div class="btn-onoff">').onoff();
+    onoff.onoff("value", val);
+    onoff.on("change", function () {
+        callback(onoff.onoff("value"));
+    });
+    return onoff;
 }
 
 PageNetworkIpSettings.prototype = {
@@ -2424,6 +2428,9 @@ PageNetworkIpSettings.prototype = {
                                         text(_("-")).
                                         click(remove(i)))));
                         })));
+
+            // For testing
+            panel.attr("data-field", p);
 
             panel.enable_add = function enable_add(val) {
                 add_btn.prop('disabled', !val);

--- a/test/check-networking
+++ b/test/check-networking
@@ -157,6 +157,18 @@ class TestNetworking(MachineCase):
         m.execute("nmcli c up '%s'" % id)
         b.wait_in_text("tr:contains('Status')", "10.111.")
 
+        # Switch off automatic DNS
+        b.click("tr:contains('IPv4') button")
+        b.wait_popup("network-ip-settings-dialog")
+        b.wait_text("#network-ip-settings-dialog [data-field='dns'] .btn.active", "On")
+        b.click("#network-ip-settings-dialog [data-field='dns'] .btn:contains('Off')")
+        # The "DNS Search Domains" setting should follow suit
+        b.wait_text("#network-ip-settings-dialog [data-field='dns_search'] .btn.active", "Off")
+        b.click("#network-ip-settings-dialog button:contains('Apply')")
+        b.wait_popdown("network-ip-settings-dialog")
+
+        self.assertIn("yes", m.execute("nmcli -f ipv4.ignore-auto-dns c s '%s'" % id))
+
     def testBond(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
The conversion in 5a3230787b18e7b7acfc1ae3f51107d8c8cc8beb was
incomplete and some of the switches didn't do anything.