### PR TITLE
storaged: Use correct name "block.device.written"

### DIFF
--- a/pkg/storaged/overview.js
+++ b/pkg/storaged/overview.js
@@ -329,7 +329,7 @@ define([
 
         var write_plot_data = {
             direct: "disk.dev.write_bytes",
-            internal: "block.device.write",
+            internal: "block.device.written",
             units: "bytes",
             derive: "rate",
             threshold: 1000


### PR DESCRIPTION
and not "block.device.write".

Thanks subzero01
Fixes #2976