### PR TITLE
storaged: Make sure disk names doesn't get cut off abruptly

### DIFF
--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -82,7 +82,7 @@
             <div><img  src="images/storage-array.png"></div>
           </td>
           <td class="row">
-            <span class="col-md-12">{{Name}}</span>
+            <span class="col-md-12 storage-disk-name">{{Name}}</span>
             <br>
             <span class="col-md-12 col-lg-5 storage-disk-size">{{Size}}</span>
           </td>
@@ -116,7 +116,7 @@
             <div><img  src="images/storage-array.png"></div>
           </td>
           <td class="row">
-            <span class="col-md-12">{{Name}}</span>
+            <span class="col-md-12 storage-disk-name">{{Name}}</span>
             <br>
             <span class="col-md-12 col-lg-5 storage-disk-size">{{Size}}</span>
           </td>
@@ -184,7 +184,7 @@
                  style="visibility:hidden;margin-top:5px"></div>
           </td>
           <td class="row">
-            <span class="col-md-12">{{Name}}</span>
+            <span class="col-md-12 storage-disk-name">{{Name}}</span>
             <br>
             <span class="col-md-12 col-lg-5 storage-disk-size">{{Description}}</span>
           </td>

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -121,6 +121,11 @@
     padding-right: 5px;
 }
 
+#storage .storage-sidebar .storage-disk-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .available-disks-group
 {
     margin-bottom: 0px;


### PR DESCRIPTION
This happens a lot with iSCSI device names.
Fixes issue #2987