### PR TITLE
kubernetes: Fix race test pod which is in Pending state

### DIFF
--- a/pkg/kubernetes/views/container-panel.html
+++ b/pkg/kubernetes/views/container-panel.html
@@ -10,8 +10,9 @@
         <a ng-click="tab('main', $event)" translatable="yes">Container</a></li>
         <li ng-class="{active: tab('logs')}">
             <a ng-click="tab('logs', $event); connect('console')" translatable="yes">Logs</a></li>
-        <li ng-class="{active: tab('shell')}" ng-if="container.status.state.running">
-            <a ng-click="tab('shell', $event); connect('shell')" translatable="yes">Shell</a></li>
+        <li ng-class="{active: tab('shell')}"
+            ng-if="item.status.phase == 'Running' && container.status.state.running">
+                <a ng-click="tab('shell', $event); connect('shell')" translatable="yes">Shell</a></li>
     </ul>
 </div>
 <div class="listing-body" ng-show="tab('main')">
@@ -22,7 +23,8 @@
         container="{{container.spec.name}}">
     </kube-console>
 </div>
-<div class="listing-body" ng-show="tab('shell') && container.status.state.running">
+<div class="listing-body" ng-show="tab('shell')"
+    ng-if="item.status.phase == 'Running' && container.status.state.running">
     <kube-shell namespace="{{item.metadata.namespace}}" pod="{{item.metadata.name}}"
         container="{{container.spec.name}}">
     </kube-shell>

--- a/test/check-kubernetes
+++ b/test/check-kubernetes
@@ -190,6 +190,7 @@ class TestKubernetes(KubernetesCase):
         def line_sel(i):
             return '#terminal .terminal div:nth-child(%d)' % i
 
+        b.wait_present("#content .listing-panel li a:contains('Shell')")
         b.click("#content .listing-panel li a:contains('Shell')")
         b.wait_present(".listing-panel div.terminal")
         b.wait_visible(".listing-panel div.terminal")


### PR DESCRIPTION
Only show the 'Shell' tab once both pod and container are running.
Otherwise kubectl complains about execing a process in it