### PR TITLE
networkmanager: Ensure enough padding for network addresses

### DIFF
--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -28,6 +28,27 @@
     padding-bottom: 0;
 }
 
+.network-ip-settings-row table {
+    margin-top: 10px;
+}
+
+.network-ip-settings-row tr {
+  background: #F4F4F4;
+    border: 1px solid #BABABA;
+}
+
+.network-ip-settings-row tr td {
+    padding: 4px;
+}
+
+.network-ip-settings-row .btn-default {
+    margin-right: 5px;
+}
+
+.network-ip-settings-row tr td .btn-default {
+    margin-right: 4px;
+}
+
 .available-interfaces-group input[type='checkbox'] {
     margin: 4px 4px 4px -20px;
 }


### PR DESCRIPTION
This brings them closer in style to NTP servers and
Container ports UIs.

Fixes #2991