### PR TITLE
test: Use a single libvirt connection

### DIFF
--- a/test/README
+++ b/test/README
@@ -8,7 +8,8 @@ Fedora:
 
   # yum install npm python-libguestfs qemu mock qemu-kvm python \
          curl libvirt-client openssl rpmdevtools libguestfs-tools \
-         rpm-build krb5-workstation python-lxml expect selinux-policy-devel
+         rpm-build krb5-workstation python-lxml expect \
+         selinux-policy-devel net-tools
 
 Testing requires phantomjs globally on the system, not just inside the cockpit package.
 

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -637,8 +637,6 @@ class VirtMachine(Machine):
 
         # network names are currently hardcoded into network-cockpit.xml
         self.network_name = self._read_network_name()
-        self.system_connection = self._libvirt_connection(hypervisor = "qemu:///system", read_only = True)
-        self.dhcp_net = self.system_connection.networkLookupByName(self.network_name)
 
         # we can't see the network itself as non-root, create it using vm-prep as root
 
@@ -893,25 +891,28 @@ class VirtMachine(Machine):
         if static_lease:
             return static_lease["ip"]
 
-        # we didn't find it in the network description, so get it from the dhcp lease information
+        # we didn't find it in the network description, so get it from the arp
+        # arp output looks like this.
+        #
+        # Address      HWtype  HWaddress         Flags Mask   Iface
+        # 10.111.111.1 ether   9e:00:00:00:00:01 C            cockpit1
+        # ...
 
-        # our network is defined system wide, so we need a different hypervisor connection
-        # if there are multiple matches for the mac, get the most current one
         start_time = time.time()
         while (time.time() - start_time) < timeout_sec:
             try:
-                with stdchannel_redirected(sys.stderr, os.devnull):
-                    applicable_leases = self.dhcp_net.DHCPLeases(mac)
+                output = subprocess.check_output(["arp", "-ni", self.network_name])
             except:
-                time.sleep(1)
-                continue
-            if applicable_leases:
-                return sorted(applicable_leases, key=lambda lease: lease['expirytime'], reverse=True)[0]['ipaddr']
+                pass
+            else:
+                for line in output.split("\n"):
+                    parts = re.split(' +', line)
+                    if parts[2].lower() == mac.lower():
+                        return parts[0]
             time.sleep(1)
 
         macs = self._qemu_network_macs()
-        lease_info = "\n".join(map(lambda lease: str(lease), self.dhcp_net.DHCPLeases()))
-        raise Failure("Can't resolve IP of %s\nAll current addresses: [%s]\nAll leases: %s" % (mac, ", ".join(macs), lease_info))
+        raise Failure("Can't resolve IP of %s\nAll current addresses: [%s]\n%s" % (mac, ", ".join(macs), output))
 
     def reset_reboot_flag(self):
         self.event_handler.reset_domain_reboot_status(self._domain)


### PR DESCRIPTION
Talking to multiple libvirts complicates the case of testing in
a container.

Although this doesn't preclude us from using qemu:///system in the
future, but in either case we use a single libvirt. The bridge is
still managed by the system libvirt, but we don't nede to talk to
it when using qemu:///session.