### PR TITLE
users: rename label since it's not only admin accounts

### DIFF
--- a/pkg/users/manifest.json
+++ b/pkg/users/manifest.json
@@ -3,7 +3,7 @@
 
     "tools": {
         "index": {
-            "label": "Administrator Accounts"
+            "label": "Accounts"
         }
     }
 


### PR DESCRIPTION
Rename the label to reflect that the section also contains
non-administrator accounts.

Fixes #2974