### PR TITLE
Don't fail with IndexError when arp output is unexpected

### DIFF
--- a/test/testvm.py
+++ b/test/testvm.py
@@ -887,7 +887,7 @@ class VirtMachine(Machine):
             else:
                 for line in output.split("\n"):
                     parts = re.split(' +', line)
-                    if parts[2].lower() == mac.lower():
+                    if len(parts) > 2 and parts[2].lower() == mac.lower():
                         return parts[0]
             time.sleep(1)
 


### PR DESCRIPTION
Otherwise we get:

```
if parts[2].lower() == mac.lower():
    IndexError: list index out of range
```
