### PR TITLE
test: Don't exit prematurly in test_main with empty argv

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -1007,7 +1007,7 @@ def test_main(argv=None, suite=None, attachments=None):
 
     runner = TapRunner(verbosity=args.verbosity, jobs=args.jobs, thorough=args.thorough)
     ret = runner.run(suite)
-    if argv:
+    if argv is not None:
         return ret
     sys.exit(ret)
 


### PR DESCRIPTION
Otherwise, the process exits early and check-verify --publish=... will
not send the final status nor the attachements.