### PR TITLE
docker: Fix weird layout of containers on image page

### DIFF
--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -135,14 +135,17 @@
 }
 
 #containers #containers-containers .table,
-#containers #containers-images .table {
+#containers #containers-images .table,
+#image-details-containers .table {
     table-layout: fixed;
 }
 
 #containers #containers-containers .table th,
 #containers #containers-containers .table td,
 #containers #containers-images .table th,
-#containers #containers-images .table td {
+#containers #containers-images .table td,
+#image-details #image-details-containers .table th,
+#image-details #image-details-containers .table td {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
The containers table on each image page had layout and clipping
issues. This fix gives them the same behaviour as all other
container tables.

Fixes #2989