### PR TITLE
test: Retest results in "error" state, but low priority

### DIFF
--- a/test/testinfra.py
+++ b/test/testinfra.py
@@ -161,10 +161,16 @@ class GitHub(object):
                     last = status
                     break
 
+        priority = baseline
+
+        # This commit definitively succeeds or fails
         if state in [ "success", "failure" ]:
             return 0
 
-        priority = baseline
+        # This test errored, we try again but low priority
+        elif state in [ "error" ]:
+            update = None
+            priority = 4
 
         if priority > 0:
             if "priority" in labels:


### PR DESCRIPTION
When prioritizing things, keep testing things in "error" state but make them low priority.