### PR TITLE
test: Kill VM when _qemu_start() raises an exception

### DIFF
--- a/test/testvm.py
+++ b/test/testvm.py
@@ -855,7 +855,7 @@ class VirtMachine(Machine):
                 self._domain.start()
             self._maintaining = maintain
         except:
-            self._cleanup()
+            self.kill()
             raise
 
     def _static_lease_from_mac(self, mac):


### PR DESCRIPTION
Otherwise we have stragler VMs hanging around, and if these
are specific flavors, then this affects following tests.