### PR TITLE
test: Compare mac address case insensitively

### DIFF
--- a/test/testvm.py
+++ b/test/testvm.py
@@ -860,10 +860,9 @@ class VirtMachine(Machine):
 
     def _static_lease_from_mac(self, mac):
         for h in self._network_description.find(".//dhcp"):
-            if h.get("mac") == mac:
-                return { "ip":   h.get("ip"),
-                         "name": h.get("name")
-                       }
+            netmac = h.get("mac") or ""
+            if netmac.lower() == mac.lower():
+                return { "ip":   h.get("ip"), "name": h.get("name") }
         return None
 
     def _ip_from_mac(self, mac, timeout_sec = 300):


### PR DESCRIPTION
Fixes this bug:

```
Wrote TestRealms-testIpa-FAIL.png
Warning: Permanently added '10.111.122.207' (ECDSA) to the list of known hosts.
Journal database copied to TestRealms-testIpa-10.111.122.207-FAIL.journal
Journal extracted to TestRealms-testIpa-10.111.122.207-FAIL.log
not ok 7 testIpa (check_realms.TestRealms)
Traceback (most recent call last):
  File "check-realms", line 40, in testIpa
    ipa.start()
  File "/home/hubbot/hubbot/fedora-22-x86_64-1445952463/test/testvm.py", line 853, in start
    self._start_qemu(maintain=maintain, macaddr=macaddr)
  File "/home/hubbot/hubbot/fedora-22-x86_64-1445952463/test/testvm.py", line 836, in _start_qemu
    self.address = self._ip_from_mac(self.macaddr)
  File "/home/hubbot/hubbot/fedora-22-x86_64-1445952463/test/testvm.py", line 896, in _ip_from_mac
    raise Failure("Can't resolve IP of %s\nAll current addresses: [%s]\n%s" % (mac, ", ".join(macs), output))
Failure: Can't resolve IP of 52:54:00:9e:00:f0
All current addresses: [52:54:00:9e:00:f0]
```