### PR TITLE
test: Use /proc to lookup ARP instead of arp command

### DIFF
--- a/test/README
+++ b/test/README
@@ -9,7 +9,7 @@ Fedora:
   # yum install npm python-libguestfs qemu mock qemu-kvm python \
          curl libvirt-client openssl rpmdevtools libguestfs-tools \
          rpm-build krb5-workstation python-lxml expect rsync \
-         selinux-policy-devel net-tools xz
+         selinux-policy-devel xz
 
 Testing requires phantomjs globally on the system, not just inside the cockpit package.
 

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -864,21 +864,18 @@ class VirtMachine(Machine):
         # we didn't find it in the network description, so get it from the arp
         # arp output looks like this.
         #
-        # Address      HWtype  HWaddress         Flags Mask   Iface
-        # 10.111.111.1 ether   9e:00:00:00:00:01 C            cockpit1
+        # IP address     HW type  Flags  HW address         Mask  Device
+        # 10.111.118.45  0x1      0x0    9e:00:03:72:00:04  *     cockpit1
         # ...
 
         start_time = time.time()
         while (time.time() - start_time) < timeout_sec:
-            try:
-                output = subprocess.check_output(["arp", "-ni", self.network_name])
-            except:
-                pass
-            else:
-                for line in output.split("\n"):
-                    parts = re.split(' +', line)
-                    if len(parts) > 2 and parts[2].lower() == mac.lower():
-                        return parts[0]
+            with open("/proc/net/arp", "r") as fp:
+                output = fp.read()
+            for line in output.split("\n"):
+                parts = re.split(' +', line)
+                if len(parts) > 5 and parts[3].lower() == mac.lower() and parts[5] == self.network_name:
+                    return parts[0]
             time.sleep(1)
 
         macs = self._qemu_network_macs()


### PR DESCRIPTION
Less testing dependencies, more reliability.