### PR TITLE
common: Refuse to send on pipe transport after it closes

### DIFF
--- a/src/bridge/cockpitportal.c
+++ b/src/bridge/cockpitportal.c
@@ -363,7 +363,8 @@ send_to_portal (CockpitPortal *self,
       return TRUE;
 
     case PORTAL_OPEN:
-      cockpit_transport_send (self->other, channel, payload);
+      if (self->transport)
+        cockpit_transport_send (self->other, channel, payload);
       return TRUE;
 
     case PORTAL_FAILED:

--- a/src/common/cockpitpipetransport.c
+++ b/src/common/cockpitpipetransport.c
@@ -46,6 +46,7 @@ struct _CockpitPipeTransport {
   CockpitTransport parent_instance;
   gchar *name;
   CockpitPipe *pipe;
+  gboolean closed;
   gulong read_sig;
   gulong close_sig;
 };
@@ -150,6 +151,8 @@ on_pipe_close (CockpitPipe *pipe,
   gboolean is_cockpit;
   GError *error = NULL;
   gint status;
+
+  self->closed = TRUE;
 
   /* This function is called by the base class when it is closed */
   if (cockpit_pipe_get_pid (pipe, NULL))
@@ -275,6 +278,12 @@ cockpit_pipe_transport_send (CockpitTransport *transport,
   gchar *prefix_str;
   gsize payload_len;
   gsize channel_len;
+
+  if (self->closed)
+    {
+      g_debug ("dropping message on closed transport");
+      return;
+    }
 
   channel_len = channel_id ? strlen (channel_id) : 0;
   payload_len = g_bytes_get_size (payload);


### PR DESCRIPTION
After a pipe transport closes, refuse to send data on it.