### PR TITLE
images: Use a proper IPA image

### DIFF
--- a/test/images/ipa-fedora-22-x86_64
+++ b/test/images/ipa-fedora-22-x86_64
@@ -1,1 +1,1 @@
-ipa-fedora-22-x86_64-3.qcow2
+ipa-fedora-22-x86_64-2f190ca0d255732e49d26b4c380d4a3cabaa27fa.qcow2


### PR DESCRIPTION
We've properly hashed the old IPA image and given it a new name
so that all the test machines download it. The previous IPA image
that some of the test machines had would just hang.