### PR TITLE
test: Try all image store urls in turn

### DIFF
--- a/test/vm-download
+++ b/test/vm-download
@@ -30,6 +30,7 @@ import testinfra
 BASE = os.path.dirname(__file__)
 IMAGES = os.path.join(BASE, "images")
 DATA = os.path.join(os.environ.get("TEST_DATA", BASE), "images")
+DEVNULL = open("/dev/null", "r+")
 
 #
 # To override the location per operating system you can define variables like this:
@@ -44,7 +45,7 @@ STORE = os.environ.get(ENVVAR, os.environ.get("TEST_IMAGES", DEFAULT))
 
 parser = argparse.ArgumentParser(description='Download a virtual machine')
 parser.add_argument("--force", action="store_true", help="Force unnecessary downloads")
-parser.add_argument("--store", default=STORE, help="Where to find images")
+parser.add_argument("--store", action="append", help="Where to find images")
 parser.add_argument("--prune", action="store_true", help="Remove unused images")
 parser.add_argument('image', nargs='*')
 args = parser.parse_args()
@@ -58,7 +59,13 @@ def download(image):
     if not args.force and os.path.exists(dest):
         return
 
-    source = os.path.join(args.store, os.path.basename(dest)) + ".xz"
+    for store in args.store:
+        try:
+            source = os.path.join(store, os.path.basename(dest)) + ".xz"
+            subprocess.check_call(["curl", "-s", "-f", "-I", source], stdout=DEVNULL)
+            break
+        except:
+            continue
 
     sys.stderr.write("{0}\n".format(source))
     (fd, temp) = tempfile.mkstemp(suffix=".partial", prefix=os.path.basename(dest), dir=DATA)
@@ -96,6 +103,14 @@ def every():
         if os.path.islink(link):
             result.append(filename)
     return result
+
+# Add in the defaults image stores if not specified
+if not args.store:
+    args.store = []
+    envvar = "TEST_IMAGES_" + testinfra.OS.split("-")[0].upper()
+    if envvar in os.environ:
+        args.store.append(os.environ[envvar])
+    args.store.append(os.environ.get("TEST_IMAGES", DEFAULT))
 
 # By default download all links
 if not args.image and not args.prune:


### PR DESCRIPTION
This allows overriding the source of just some of the images.
The vm-download script will try to access the image at all the
various --store arguments (or TEST_IMAGE_XXX envvars). The first
one that doesn't return a failure like 404 will be used to retrieve
the image.