### PR TITLE
test: Ignore debug messages from systemd libraries

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -591,6 +591,12 @@ systemctl start docker
                                     'audit:.*denied.*2F6D656D66643A73642D73797374656D642D636F726564756D202864656C.*',
                                     'localhost: dropping message while waiting for child to exit',
                                     '.*: GDBus.Error:org.freedesktop.PolicyKit1.Error.Failed: .*',
+
+                                    # Messages from systemd libraries when they are in debug mode
+                                    'Successfully loaded SELinux database in.*',
+                                    'calling: info',
+                                    'Sent message type=method_call sender=.*',
+                                    'Got message type=method_return sender=.*',
                                     )
 
     def allow_authorize_journal_messages(self):


### PR DESCRIPTION
At times the kernel is booted with 'systemd.log_level=debug' and
all the systemd libraries produce messages like these from within
our own processes. Just ignore them.

In most cases these messages are logged with LOG_DEBUG priority
level. However because our tests are so intense, often these messages
occur before the journal has come up. Therefore these messages go
through the kmsg log, and arrive back in the journal later without
their priority level.