### PR TITLE
test: Don't crash when TEST_ATTACHMENTS is unset

### DIFF
--- a/test/testsuite-prepare
+++ b/test/testsuite-prepare
@@ -83,7 +83,7 @@ if [ -z "$rpms" ]; then
   exit 1
 fi
 
-if [ -n "$TEST_ATTACHMENTS" ]; then
+if [ -n "${TEST_ATTACHMENTS:-}" ]; then
     mkdir "$TEST_ATTACHMENTS"/mock
     cp -r ../mock/*.log "$TEST_ATTACHMENTS"/mock
 fi


### PR DESCRIPTION
The code didn't take "set -u" into account.