### PR TITLE
test: improvements to vm-run

### DIFF
--- a/test/testvm.py
+++ b/test/testvm.py
@@ -826,10 +826,15 @@ class VirtMachine(Machine):
             self.address = self._ip_from_mac(self.macaddr)
 
     # start virsh console
-    def qemu_console(self, snapshot=False, macaddr=None):
+    def qemu_console(self, maintain=True, macaddr=None):
         try:
-            self._start_qemu(maintain=not snapshot, macaddr=macaddr, wait_for_ip=False)
+            self._start_qemu(maintain=maintain, macaddr=macaddr, wait_for_ip=False)
             self.message("started machine %s with address %s" % (self._domain.name(), self.address))
+            if maintain:
+                self.message("Changes are written to the image file.")
+                self.message("WARNING: Uncontrolled shutdown can lead to a corrupted image.")
+            else:
+                self.message("All changes are discarded, the image file won't be changed.")
             print "console, to quit use Ctrl+], Ctrl+5 (depending on locale)"
             proc = subprocess.Popen("virsh -c qemu:///session console %s" % self._domain.ID(), shell=True)
             proc.wait()

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -838,6 +838,15 @@ class VirtMachine(Machine):
             print "console, to quit use Ctrl+], Ctrl+5 (depending on locale)"
             proc = subprocess.Popen("virsh -c qemu:///session console %s" % self._domain.ID(), shell=True)
             proc.wait()
+            try:
+                if maintain:
+                    self.shutdown()
+                else:
+                    self.kill()
+            except libvirt.libvirtError, le:
+                # the domain may have already been freed (shutdown) while the console was running
+                self.message("libvirt error during shutdown: %s" % (le.get_error_message()))
+
         except:
             raise
         finally:

--- a/test/vm-run
+++ b/test/vm-run
@@ -24,12 +24,12 @@ import testvm
 parser = argparse.ArgumentParser(description='Run a test machine')
 parser.add_argument('-v', '--verbose', action='store_true', help='Display verbose details')
 parser.add_argument('-f', '--flavor', action='store', help='The flavor to run')
-parser.add_argument('-s', '--snapshot', action='store_true', help='Changes are not permanent')
+parser.add_argument('-m', '--maintain', action='store_true', help='Changes are permanent')
 args = parser.parse_args()
 
 try:
     machine = testvm.VirtMachine(verbose=args.verbose, flavor=args.flavor)
-    machine.qemu_console(args.snapshot)
+    machine.qemu_console(args.maintain)
 except testvm.Failure, ex:
     print >> sys.stderr, "vm-run:", ex
     sys.exit(1)


### PR DESCRIPTION
* Default mode is now: discard changes, use `--maintain` or `-m` to keep them. This is consistent with the rest of the testing code.
* After the console has quit, explicitly `shutdown` or `kill` the vm, depending on the state of `maintain`. Not doing this meant libvirt just killed the machine, resulting in possible data corruption if the changes were to be saved.