### PR TITLE
bridge: Better handling of portal failure and fallback

### DIFF
--- a/src/bridge/cockpitportal.c
+++ b/src/bridge/cockpitportal.c
@@ -368,11 +368,13 @@ send_to_portal (CockpitPortal *self,
       return TRUE;
 
     case PORTAL_FAILED:
-      if (channel && !(flags & COCKPIT_PORTAL_FALLBACK) &&
-          g_hash_table_contains (self->channels, channel))
+      if ((flags & COCKPIT_PORTAL_FALLBACK) == 0)
         {
-          g_hash_table_remove (self->channels, channel);
-          send_close_channel (self, channel, self->problem);
+          if (channel && g_hash_table_contains (self->channels, channel))
+            {
+              g_hash_table_remove (self->channels, channel);
+              send_close_channel (self, channel, self->problem);
+            }
           return TRUE;
         }
       return FALSE;


### PR DESCRIPTION
Fix some of the corner cases where a message that should not
have fallback did get sent to the local bridge, when a portal
failed.

Fixes #3101