### PR TITLE
ws: Set ptrace scope right in cockpit-testing

### DIFF
--- a/src/ws/cockpit-testing.service.in
+++ b/src/ws/cockpit-testing.service.in
@@ -6,7 +6,8 @@ Conflicts=cockpit.service
 
 [Service]
 Environment=G_MESSAGES_DEBUG=cockpit-ws G_DEBUG=fatal-criticals G_SLICE=always-malloc,debug-blocks
-ExecStartPre=sh -c 'echo 0 > /proc/sys/kernel/yama/ptrace_scope'
+ExecStartPre=-/bin/sh -c 'echo 0 > /proc/sys/kernel/yama/ptrace_scope'
 ExecStart=@libexecdir@/cockpit-ws --no-tls
+PermissionsStartOnly=true
 User=@user@
 Group=@group@


### PR DESCRIPTION
This allows backtraces to happen from within a child process, as
we do in our gdb backtrace handler.

Systemd was ignoring this because: Executable path is not absolute