### PR TITLE
bridge: When we find a GDBusObjectManager track it properly

### DIFF
--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -181,7 +181,7 @@ $(client).on("owner", function(event, owner) { ... })
   <refsection id="cockpit-dbus-proxy">
     <title>client.proxy</title>
 <programlisting>
-proxy = client.proxy([interface, path])
+proxy = client.proxy([interface, path], [options])
 </programlisting>
 
     <para>Create proxy javascript object for a DBus <code>interface</code>. At the
@@ -265,6 +265,10 @@ $(proxy).on("Signal", function(event, arg1, arg2) {
     <para>Signals that do not start with an upper case letter can be subscribed to by
       using <link linkend="cockpit-dbus-proxy-signal"><code>proxy.onsignal</code></link>
       directly.</para>
+
+    <para>Usually a proxy asks the <code>client</code> to watch and notify it of changes
+      to the relevant object or path. You can pass an <code>options</code> argument with
+      the <code>watch</code> field set to <code>false</code> to prevent this.</para>
   </refsection>
 
   <refsection id="cockpit-dbus-proxy-client">
@@ -387,7 +391,7 @@ $(proxy).on("signal", function(event, name, args) {
   <refsection id="cockpit-dbus-proxies">
     <title>client.proxies</title>
 <programlisting>
-proxies = client.proxies([interface], [path_namespace])
+proxies = client.proxies([interface], [path_namespace], [options])
 </programlisting>
 
     <para>Create <link linkend="cockpit-dbus-proxy">proxy javascript objects</link> for
@@ -422,6 +426,10 @@ for (proxy in proxies) {
 
     <para>Use the <code>proxies.wait()</code> function to be notified when the initial
       set of proxies has been populated.</para>
+
+    <para>Usually a proxies ask the <code>client</code> to watch and be notified of changes
+      to the relevant object or path. You can pass an <code>options</code> argument with
+      the <code>watch</code> field set to <code>false</code> to prevent this.</para>
   </refsection>
 
   <refsection id="cockpit-dbus-proxies-wait">

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -1550,7 +1550,7 @@ function full_scope(cockpit, $, po) {
             waits.fireWith(self);
     }
 
-    function DBusProxies(client, cache, iface, path_namespace) {
+    function DBusProxies(client, cache, iface, path_namespace, options) {
         var self = this;
 
         var waits = $.Callbacks("once memory");
@@ -1574,10 +1574,13 @@ function full_scope(cockpit, $, po) {
         client.subscribe(match);
 
         /* Watch for property changes */
-        client.watch(match).always(function() { waits.fire(); });
+        if (options.watch !== false)
+            client.watch(match).always(function() { waits.fireWith(self); });
+        else
+            waits.fireWith(self);
 
         /* Already added watch/subscribe, tell proxies not to */
-        var options = { watch: false, subscribe: false };
+        options = $.extend({ watch: false, subscribe: false }, options);
 
         function update(props, path) {
             var proxy = self[path];
@@ -1862,13 +1865,15 @@ function full_scope(cockpit, $, po) {
             return new Constructor(self, cache, iface, String(path), options);
         };
 
-        self.proxies = function proxies(iface, path_namespace) {
+        self.proxies = function proxies(iface, path_namespace, options) {
             if (!iface)
                 iface = name;
             if (!path_namespace)
                 path_namespace = "/";
+            if (!options)
+                options = { };
             ensure_cache();
-            return new DBusProxies(self, cache, String(iface), String(path_namespace));
+            return new DBusProxies(self, cache, String(iface), String(path_namespace), options);
         };
 
     }

--- a/src/bridge/cockpitpaths.c
+++ b/src/bridge/cockpitpaths.c
@@ -130,6 +130,16 @@ cockpit_paths_new (void)
   return g_tree_new_full (tree_path_cmp, NULL, g_free, NULL);
 }
 
+/*
+ * cockpit_paths_add:
+ * @tree: The tree to add to
+ * @path: The path to add
+ *
+ * Adds the path if this path or a parent is not already
+ * in the tree. Will return %NULL if the path is already
+ * in the tree ... otherwise will return the internally
+ * reallocated path.
+ */
 const gchar *
 cockpit_paths_add (GTree *tree,
                    const gchar *path)
@@ -144,9 +154,10 @@ cockpit_paths_add (GTree *tree,
       pd->data = (gchar *)(pd + 1);
       memcpy ((gchar *)pd->data, path, key.len + 1);
       g_tree_replace (tree, pd, pd);
+      return pd->data;
     }
 
-  return pd->data;
+  return NULL;
 }
 
 gboolean

--- a/src/bridge/test-paths.c
+++ b/src/bridge/test-paths.c
@@ -136,7 +136,7 @@ test_paths_add_remove (void)
 
   /* Add same one again */
   check = cockpit_paths_add (paths, "/two");
-  g_assert (value == check); /* Same allocation */
+  g_assert (check == NULL); /* Already present */
 
   g_assert_cmpstr (cockpit_paths_contain (paths, "/one"), ==, "/one");
   g_assert_cmpstr (cockpit_paths_contain (paths, "/two"), ==, "/two");


### PR DESCRIPTION
If we find a GDBusObjectManager at a given path, we should not only mark the subtree as being managed, but also initiate looking for any objects in that managed area matching our watch criteria.
    
We do this by calling GetManagedObjects on the subtree.
