### PR TITLE
shell: Add a global 'cockpit' in index.html

### DIFF
--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -359,6 +359,9 @@
             "base1/cockpit",
             "shell/index"
         ], function(cockpit, index) {
+            /* For debugging and such */
+            window.cockpit = cockpit;
+
             /* Drain any initial messages we receive into the router */
             cockpit.transport.wait(function() {
                 window.removeEventListener("message", message_queue, false);


### PR DESCRIPTION
When doing testing or demos it is really handy to have 'cockpit'
in the global javascript environment.