### PR TITLE
storage: Add chunk size 0 option in RAID add dialog

### DIFF
--- a/pkg/storaged/overview.js
+++ b/pkg/storaged/overview.js
@@ -402,7 +402,10 @@ define([
                                     { value: "512", Title: _("512 KB"), selected: true },
                                     { value: "1024", Title: _("1 MB") },
                                     { value: "2048", Title: _("2 MB") }
-                                ]
+                                ],
+                                visible: function (vals) {
+                                    return vals.level != "raid1";
+                                }
                               },
                               { SelectMany: "disks",
                                 Title: _("Disks"),
@@ -421,7 +424,7 @@ define([
                               Title: _("Create"),
                               action: function (vals) {
                                   return client.manager.MDRaidCreate(vals.disks, vals.level,
-                                                                     vals.name, vals.chunk * 1024,
+                                                                     vals.name, (vals.chunk || 0)* 1024,
                                                                      { });
                               }
                           }

--- a/pkg/storaged/overview.js
+++ b/pkg/storaged/overview.js
@@ -387,7 +387,7 @@ define([
                                     { value: "raid4",  Title: _("RAID 4 (Dedicated Parity)") },
                                     { value: "raid5",  Title: _("RAID 5 (Distributed Parity)"), selected: true },
                                     { value: "raid6",  Title: _("RAID 6 (Double Distributed Parity)") },
-                                    { value: "raid10", Title: _("AID 10 (Stripe of Mirrors)") }
+                                    { value: "raid10", Title: _("RAID 10 (Stripe of Mirrors)") }
                                 ]
                               },
                               { SelectOne: "chunk",

--- a/test/check-storage-mdraid
+++ b/test/check-storage-mdraid
@@ -188,8 +188,8 @@ class TestStorage(StorageCase):
         self.raid_action("Delete")
         self.confirm()
         with b.wait_timeout(120):
-	    b.wait_visible("#storage")
-	    b.wait_not_in_text ("#mdraids", "ARR")
+            b.wait_visible("#storage")
+            b.wait_not_in_text ("#mdraids", "ARR")
 
 if __name__ == '__main__':
     test_main()

--- a/test/check-storage-raid1
+++ b/test/check-storage-raid1
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+from testlib import *
+from storagelib import *
+
+class TestStorage(StorageCase):
+    def testRaidLevelOne(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+        b.wait_in_text("#drives", "VirtIO")
+
+        # Add four two and make a RAID out of them
+        m.add_disk("50M", serial="DISK1")
+        m.add_disk("50M", serial="DISK2")
+        b.wait_in_text("#drives", "DISK1")
+        b.wait_in_text("#drives", "DISK2")
+
+        b.click("#create-mdraid")
+        self.dialog_wait_open()
+        self.dialog_set_val("level", "raid1")
+        self.dialog_select("disks", "DISK1", True)
+        self.dialog_select("disks", "DISK2", True)
+        self.dialog_set_val("name", "SOMERAID")
+        # The dialog should make sure that the Chunk size is ignored (has to be 0 for RAID 1)
+        self.dialog_apply()
+        self.dialog_wait_close()
+        b.wait_in_text("#mdraids", "SOMERAID")
+
+
+if __name__ == '__main__':
+    test_main()


### PR DESCRIPTION
RAID level 1 setup throws an error if the chunk size isn't 0.

Fixes #3123 

As a follow-up we should either offer `AUTO` or automatically select chunk size 0 for RAID level 1 if the user hasn't changed the chunk size.