### PR TITLE
bridge: Print warnings when returning "internal-error"

### DIFF
--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -2010,6 +2010,7 @@ cockpit_dbus_json_prepare (CockpitChannel *channel)
       self->connection = cockpit_dbus_internal_client ();
       if (self->connection == NULL)
         {
+          g_warning ("no internal DBus connection");
           problem = "internal-error";
           goto out;
         }

--- a/src/bridge/cockpitmetrics.c
+++ b/src/bridge/cockpitmetrics.c
@@ -189,7 +189,10 @@ on_timeout_tick (gpointer data)
   else if (next_interval / 1000 <= G_MAXUINT)
     self->priv->timeout = g_timeout_add_seconds (next_interval / 1000, on_timeout_tick, self);
   else
-    cockpit_channel_close (COCKPIT_CHANNEL (self), "internal-error");
+    {
+      g_warning ("invalid metric timeout tick offset");
+      cockpit_channel_close (COCKPIT_CHANNEL (self), "internal-error");
+    }
 
   return FALSE;
 }


### PR DESCRIPTION
These are cases where we don't put info in the logs for general
errors.