### PR TITLE
test: Remove leading 'test/' for testing context

### DIFF
--- a/test/testinfra.py
+++ b/test/testinfra.py
@@ -137,7 +137,7 @@ class GitHub(object):
         self.available = self.token and True or False
 
     def context(self):
-        return "test/" + OS + "/" + ARCH
+        return OS + "/" + ARCH
 
     def qualify(self, resource):
         return urlparse.urljoin(self.base, resource)


### PR DESCRIPTION
The status context is unique to tests anyway. Leading
the context with 'test/' is redundant.