### PR TITLE
Cleaner portal shutdown

### DIFF
--- a/src/bridge/cockpitinternalmetrics.c
+++ b/src/bridge/cockpitinternalmetrics.c
@@ -373,42 +373,38 @@ convert_metric_description (CockpitInternalMetrics *self,
       if (!cockpit_json_get_string (json_node_get_object (node), "name", NULL, &name)
           || name == NULL)
         {
-          g_warning ("%s: invalid \"metrics\" option was specified (no name for metric %d)",
-                     self->name, index);
+          g_warning ("invalid \"metrics\" option was specified (no name for metric %d)", index);
           return FALSE;
         }
 
       if (!cockpit_json_get_string (json_node_get_object (node), "units", NULL, &units))
         {
-          g_warning ("%s: invalid units for metric %s (not a string)",
-                     self->name, name);
+          g_warning ("invalid units for metric %s (not a string)", name);
           return FALSE;
         }
 
       if (!cockpit_json_get_string (json_node_get_object (node), "derive", NULL, &info->derive))
         {
-          g_warning ("%s: invalid derivation mode for metric %s (not a string)",
-                     self->name, name);
+          g_warning ("invalid derivation mode for metric %s (not a string)", name);
           return FALSE;
         }
     }
   else
     {
-      g_warning ("%s: invalid \"metrics\" option was specified (not an object for metric %d)",
-                 self->name, index);
+      g_warning ("invalid \"metrics\" option was specified (not an object for metric %d)", index);
       return FALSE;
     }
 
   MetricDescription *desc = find_metric_description (name);
   if (desc == NULL)
     {
-      g_message ("%s: unknown internal metric %s", self->name, name);
+      g_message ("unknown internal metric %s", name);
     }
   else
     {
       if (units && g_strcmp0 (desc->units, units) != 0)
         {
-          g_warning ("%s: %s has units %s, not %s", self->name, name, desc->units, units);
+          g_warning ("%s has units %s, not %s", name, desc->units, units);
           return FALSE;
         }
 
@@ -438,14 +434,14 @@ cockpit_internal_metrics_prepare (CockpitChannel *channel)
   /* "instances" option */
   if (!cockpit_json_get_strv (options, "instances", NULL, (gchar ***)&self->instances))
     {
-      g_warning ("%s: invalid \"instances\" option (not an array of strings)", self->name);
+      g_warning ("invalid \"instances\" option (not an array of strings)");
       goto out;
     }
 
   /* "omit-instances" option */
   if (!cockpit_json_get_strv (options, "omit-instances", NULL, (gchar ***)&self->omit_instances))
     {
-      g_warning ("%s: invalid \"omit-instances\" option (not an array of strings)", self->name);
+      g_warning ("invalid \"omit-instances\" option (not an array of strings)");
       goto out;
     }
 
@@ -453,7 +449,7 @@ cockpit_internal_metrics_prepare (CockpitChannel *channel)
   self->n_metrics = 0;
   if (!cockpit_json_get_array (options, "metrics", NULL, &metrics))
     {
-      g_warning ("%s: invalid \"metrics\" option was specified (not an array)", self->name);
+      g_warning ("invalid \"metrics\" option was specified (not an array)");
       goto out;
     }
   if (metrics)
@@ -475,12 +471,12 @@ cockpit_internal_metrics_prepare (CockpitChannel *channel)
   /* "interval" option */
   if (!cockpit_json_get_int (options, "interval", 1000, &self->interval))
     {
-      g_warning ("%s: invalid \"interval\" option", self->name);
+      g_warning ("invalid \"interval\" option");
       goto out;
     }
   else if (self->interval <= 0 || self->interval > G_MAXINT)
     {
-      g_warning ("%s: invalid \"interval\" value: %" G_GINT64_FORMAT, self->name, self->interval);
+      g_warning ("invalid \"interval\" value: %" G_GINT64_FORMAT, self->interval);
       goto out;
     }
 

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -101,13 +101,11 @@ install-exec-hook::
 EXTRA_DIST += \
 	src/ws/cockpit.service.in \
 	src/ws/cockpit-testing.service.in \
-	src/ws/test-server.service.in \
 	$(firewall_DATA) \
 	$(NULL)
 
 CLEANFILES += \
 	cockpit-testing.service \
-	test-server.service \
 	cockpit.service \
 	$(NULL)
 
@@ -157,14 +155,7 @@ test_server_LDADD = 					\
 	-lpam 						\
 	$(NULL)
 
-testassets_systemdunit_data += \
-	$(srcdir)/src/ws/cockpit-testing.socket \
-	$(srcdir)/src/ws/test-server.socket
-
-test-server.service : src/ws/test-server.service.in Makefile
-	$(AM_V_GEN) sed -e "s|\@libexecdir\@|$(libexecdir)|;s|\@datadir\@|$(datadir)|" $< > $@
-noinst_DATA += test-server.service
-testassets_systemdunit_data += test-server.service
+testassets_systemdunit_data += $(srcdir)/src/ws/cockpit-testing.socket
 
 WS_CHECKS = \
 	test-creds \

--- a/src/ws/test-server.service.in
+++ b/src/ws/test-server.service.in
@@ -1,6 +1,0 @@
-[Unit]
-Description=Test Server
-
-[Service]
-WorkingDirectory=@datadir@/cockpit-test-assets
-ExecStart=/usr/bin/runcon -t unconfined_service_t -- @datadir@/cockpit-test-assets/test-server

--- a/src/ws/test-server.socket
+++ b/src/ws/test-server.socket
@@ -1,5 +1,0 @@
-[Unit]
-Description=Test Server Socket
-
-[Socket]
-ListenStream=8765

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -140,9 +140,6 @@ The Cockpit Web Service listens on the network, and authenticates users.
 
 %prep
 %setup -q
-%if 0%{?fedora} == 20
-	sed -i s/unconfined_service_t/unconfined_t/g src/ws/test-server.service.in
-%endif
 
 %build
 %if %{defined gitcommit}
@@ -413,8 +410,6 @@ pulls in some necessary packages via dependencies.
 %{_datadir}/polkit-1/rules.d
 %{_unitdir}/cockpit-testing.service
 %{_unitdir}/cockpit-testing.socket
-%{_unitdir}/test-server.service
-%{_unitdir}/test-server.socket
 
 %endif
 


### PR DESCRIPTION
Have portal disconnect from transport later
    
This allows us to continue to block requests during shutdown, that shouldn't make it to the local bridge.
