### PR TITLE
tools: Add a known leak for res_vinit

### DIFF
--- a/tools/unknown.supp
+++ b/tools/unknown.supp
@@ -428,3 +428,12 @@
    fun:exit
    fun:(below main)
 }
+{
+   res_vinit
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:__res_vinit
+   ...
+   fun:getaddrinfo
+}


### PR DESCRIPTION
This function leaks in glibc. Called by libssh via getaddrinfo()