### PR TITLE
bridge: Don't complain 'The connection is closed' during introspect

### DIFF
--- a/src/bridge/cockpitdbuscache.c
+++ b/src/bridge/cockpitdbuscache.c
@@ -415,7 +415,8 @@ dbus_error_matches_unknown (GError *error)
   gboolean ret = FALSE;
 
   if (g_error_matches (error, G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_METHOD) ||
-      g_error_matches (error, G_DBUS_ERROR, G_DBUS_ERROR_ACCESS_DENIED))
+      g_error_matches (error, G_DBUS_ERROR, G_DBUS_ERROR_ACCESS_DENIED) ||
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CLOSED))
     return TRUE;
 
 #if GLIB_CHECK_VERSION(2,42,0)


### PR DESCRIPTION
The bridge could be exiting while we're trying to introspect.
This is a normal situation.