### PR TITLE
Makefile.am: Link --as-needed to reduce library footprint

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -93,6 +93,8 @@ AM_CPPFLAGS = \
 	-D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT \
 	$(NULL)
 
+AM_LDFLAGS = -Wl,--as-needed
+
 LOG_DRIVER = $(top_srcdir)/tools/tap-driver
 LOG_COMPILER = $(top_srcdir)/tools/tap-gtester
 


### PR DESCRIPTION
In cockpit-bridge and other Cockpit executables we hoist a
lot of indirect dependencies in libraries we may never use.

Since libraries can be loaded on demand, this is a minor but
simple and effective cleanup.