### PR TITLE
test: Add known failure in check-dashboard

### DIFF
--- a/test/naughty/3147-dashboard-edit
+++ b/test/naughty/3147-dashboard-edit
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-dashboard", line 175, in testEdit
+    b.wait_not_attr("#dashboard-hosts .list-group-item[data-address='localhost']", "style", old_style)


### PR DESCRIPTION
The dashboard edit test sometimes fails to register
the style change.