### PR TITLE
test: Compress journal directories

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -37,6 +37,7 @@ import random
 import re
 import json
 import signal
+import subprocess
 import tempfile
 import time
 import unittest
@@ -650,7 +651,10 @@ systemctl start docker
                 with open(log, "w") as fp:
                     subprocess.call(["journalctl", "--directory", dir], stdout=fp)
                 print "Journal extracted to %s" % (log)
-                attach(dir)
+                # compress the journal and attach that
+                archive = "{0}.tar.gz".format(dir)
+                subprocess.call(["tar", "cfz", archive, dir])
+                attach(archive)
                 attach(log)
 
 some_failed = False


### PR DESCRIPTION
Since we can't open them directly in the browser anyway,
create a tarball to save disk space and transfer that to the sink.