### PR TITLE
test: Don't crash when `last == None' in prioritize function

### DIFF
--- a/test/testinfra.py
+++ b/test/testinfra.py
@@ -230,7 +230,7 @@ class GitHub(object):
                 priority -= 1
 
             # Is testing already in progress?
-            if last.get("description", None) == TESTING:
+            if last and last.get("description", None) == TESTING:
                 update = None
                 priority = 0
 


### PR DESCRIPTION
The cockpit-verify workers are broken by this currently.