### PR TITLE
test: Normalize traceback file paths when comparing known issues

### DIFF
--- a/test/testinfra.py
+++ b/test/testinfra.py
@@ -43,7 +43,7 @@ def arg_parser():
                         help='Trace machine boot and commands')
     parser.add_argument('-q', '--quiet', dest='verbosity', action='store_const',
                         const=0, help='Quiet output')
-    parser.add_argument('--thorough', dest='thorough', action='store',
+    parser.add_argument('--thorough', dest='thorough', action='store_true',
                         help='Thorough mode, no skipping known issues')
     parser.add_argument('-s', "--sit", dest='sit', action='store_true',
                         help="Sit and wait after test failure")

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -731,6 +731,10 @@ class Naughty(object):
     def __init__(self):
         self.github = None
 
+    def normalize_traceback(self, trace):
+        # All file paths converted to basename
+        return re.sub(r'File "[^"]*/([^/"]+)"', 'File "\\1"', trace.strip())
+
     def post_github(self, number, err):
         if not self.github:
             self.github = testinfra.GitHub()
@@ -758,7 +762,7 @@ class Naughty(object):
 
     def check_issue(self, trace):
         directory = "./naughty"
-        trace = trace.strip()
+        trace = self.normalize_traceback(trace)
         number = 0
         for naughty in os.listdir(directory):
             (prefix, unused, name) = naughty.partition("-")
@@ -767,7 +771,7 @@ class Naughty(object):
             except:
                 continue
             with open(os.path.join(directory, naughty), "r") as fp:
-                contents = fp.read().strip()
+                contents = self.normalize_traceback(fp.read())
             if contents in trace:
                 number = n
         if not number:


### PR DESCRIPTION
Otherwise these only really work when there was no file path
in either the source traceback or the file in the test/naughty
directory.