### PR TITLE
test: Use wget to test cockpit-ws port change

### DIFF
--- a/test/check-connection
+++ b/test/check-connection
@@ -161,10 +161,10 @@ class TestConnection(MachineCase):
         m.execute('semanage port -m -t websm_port_t -p tcp 443 && mkdir -p /etc/systemd/system/cockpit.socket.d/ && printf "[Socket]\nListenStream=\nListenStream=443" > /etc/systemd/system/cockpit.socket.d/listen.conf')
         m.execute('systemctl daemon-reload && systemctl restart cockpit.socket')
 
-        output = m.execute('curl -k -s https://localhost')
+        output = m.execute('wget --no-check-certificate -O - https://localhost')
         self.assertIn('Cockpit starting...', output)
 
-        output = m.execute('curl -k https://localhost:9090 2>&1 || true')
+        output = m.execute('wget --no-check-certificate -O - https://localhost:9090 2>&1 || true')
         self.assertIn('Connection refused', output)
 
         self.allow_journal_messages(".*Peer failed to perform TLS handshake")


### PR DESCRIPTION
This is because on certain operating systems curl isn't up to
our strict standards of TLS we use in cockpit-ws.