### PR TITLE
Drop dbus paths from configure summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -452,8 +452,6 @@ echo "
         datadir:                    ${datadir}
         sysconfdir:                 ${sysconfdir}
         localstatedir:              ${localstatedir}
-        dbusservicedir:             ${dbusservicedir}
-        dbussystemdir:              ${dbussystemdir}
         pamdir:                     ${pamdir}
 
         compiler:                   ${CC}


### PR DESCRIPTION
Those paths are no longer used after the refactoring.

Closes #3162