### PR TITLE
 Corrected command to revert changes to UI

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -196,7 +196,7 @@ only for the user which ran the above command.
 
 To revert the above change, run:
 
-    $ rm ~/.local/share/cockpit
+    $ rm -r ~/.local/share/cockpit
 
 ## Debug logging of Cockpit processes
 


### PR DESCRIPTION
The option -r when used with rm will remove ~/.local/share/cockpit , not rm alone.