### PR TITLE
Implement http-stream2 protocol payload

### DIFF
--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -102,6 +102,7 @@ static struct {
 } payload_types[] = {
   { "dbus-json3", cockpit_dbus_json_get_type },
   { "http-stream1", cockpit_http_stream_get_type },
+  { "http-stream2", cockpit_http_stream_get_type },
   { "stream", cockpit_pipe_channel_get_type },
   { "fsread1", cockpit_fsread_get_type },
   { "fsreplace1", cockpit_fsreplace_get_type },

--- a/src/bridge/cockpitchannel.h
+++ b/src/bridge/cockpitchannel.h
@@ -60,10 +60,9 @@ struct _CockpitChannelClass
   void        (* recv)        (CockpitChannel *channel,
                                GBytes *message);
 
-  void        (* options)     (CockpitChannel *channel,
+  gboolean    (* control)     (CockpitChannel *channel,
+                               const gchar *command,
                                JsonObject *options);
-
-  void        (* done)        (CockpitChannel *channel);
 
   void        (* close)       (CockpitChannel *channel,
                                const gchar *problem);
@@ -80,13 +79,15 @@ const gchar *       cockpit_channel_get_id            (CockpitChannel *self);
 
 void                cockpit_channel_prepare           (CockpitChannel *self);
 
+void                cockpit_channel_control           (CockpitChannel *self,
+                                                       const gchar *command,
+                                                       JsonObject *message);
+
 void                cockpit_channel_ready             (CockpitChannel *self);
 
 void                cockpit_channel_send              (CockpitChannel *self,
                                                        GBytes *payload,
                                                        gboolean valid_utf8);
-
-void                cockpit_channel_done              (CockpitChannel *self);
 
 JsonObject *        cockpit_channel_get_options       (CockpitChannel *self);
 

--- a/src/bridge/cockpitechochannel.c
+++ b/src/bridge/cockpitechochannel.c
@@ -50,11 +50,19 @@ cockpit_echo_channel_recv (CockpitChannel *channel,
   cockpit_channel_send (channel, message, FALSE);
 }
 
-static void
-cockpit_echo_channel_done (CockpitChannel *channel)
+static gboolean
+cockpit_echo_channel_control (CockpitChannel *channel,
+                              const gchar *command,
+                              JsonObject *options)
 {
-  g_debug ("received echo channel done");
-  cockpit_channel_done (channel);
+  if (g_str_equal (command, "done"))
+    {
+      g_debug ("received echo channel done");
+      cockpit_channel_control (channel, command, options);
+      return TRUE;
+    }
+
+  return FALSE;
 }
 
 static void
@@ -76,6 +84,6 @@ cockpit_echo_channel_class_init (CockpitEchoChannelClass *klass)
   CockpitChannelClass *channel_class = COCKPIT_CHANNEL_CLASS (klass);
 
   channel_class->prepare = cockpit_echo_channel_prepare;
+  channel_class->control = cockpit_echo_channel_control;
   channel_class->recv = cockpit_echo_channel_recv;
-  channel_class->done = cockpit_echo_channel_done;
 }

--- a/src/bridge/cockpitfslist.c
+++ b/src/bridge/cockpitfslist.c
@@ -124,7 +124,7 @@ on_files_listed (GObject *source_object,
 
       if (self->monitor == NULL)
         {
-          cockpit_channel_done (COCKPIT_CHANNEL (self));
+          cockpit_channel_control (COCKPIT_CHANNEL (self), "done", NULL);
           cockpit_channel_close (COCKPIT_CHANNEL (self), NULL);
         }
       return;

--- a/src/bridge/cockpitfsread.c
+++ b/src/bridge/cockpitfsread.c
@@ -69,7 +69,7 @@ on_idle_send_block (gpointer data)
   if (payload == NULL)
     {
       self->idler = 0;
-      cockpit_channel_done (channel);
+      cockpit_channel_control (channel, "done", NULL);
 
       problem = NULL;
       if (self->fd >= 0 && self->start_tag)


### PR DESCRIPTION
Since http-stream is a stream, it shouldn't send metadata in the main payload. http-stream1 is semantically incorrect in this regard, so we invent http-stream2 to fix that.
    
We don't use this anywhere yet, because we can't rely in it being available. But we want to get this right and use it in the future.