### PR TITLE
Corrected command to revert changes to UI

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -196,7 +196,7 @@ only for the user which ran the above command.
 
 To revert the above change, run:
 
-    $ rm ~/.local/share/cockpit
+    $ rm ~/.local/share/cockpit/*
 
 ## Debug logging of Cockpit processes
 


### PR DESCRIPTION
Adding a trailing asterisk to the command $ rm ~/.local/share/cockpit would serve the result.