### PR TITLE
Set the SELinux context correctly for certificates

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -150,6 +150,7 @@ SED_SUBST = sed \
         -e 's,[@]VERSION[@],$(VERSION),g' \
         -e 's,[@]user[@],$(COCKPIT_USER),g' \
         -e 's,[@]group[@],$(COCKPIT_GROUP),g' \
+        -e 's,[@]selinux_config_type[@],$(COCKPIT_SELINUX_CONFIG_TYPE),g' \
         $(NULL)
 
 GDBUS_CODEGEN = $(top_srcdir)/tools/gdbus-unbreak-codegen

--- a/configure.ac
+++ b/configure.ac
@@ -255,6 +255,10 @@ AC_DEFINE_UNQUOTED([PATH_SSH_ADD], ["$SSH_ADD"], [Location of ssh-add binary])
 AC_PATH_PROG([SSH_AGENT], [ssh-agent], [/usr/bin/ssh-agent], [$PATH:/usr/local/bin:/usr/bin:/bin])
 AC_DEFINE_UNQUOTED([PATH_SSH_AGENT], ["$SSH_AGENT"], [Location of ssh-agent binary])
 
+# chcon
+AC_PATH_PROG([CHCON], [chcon], [/usr/bin/chcon], [$PATH:/usr/local/bin:/usr/bin:/bin])
+AC_DEFINE_UNQUOTED([PATH_CHCON], ["$CHCON"], [Location of chcon binary])
+
 changequote(,)dnl
 if test "x$GCC" = "xyes"; then
   CFLAGS="-Wall \
@@ -299,7 +303,6 @@ AC_ARG_WITH(cockpit_group,
 			   [Group for running cockpit]
                           )
            )
-
 if test -z "$with_cockpit_user"; then
     COCKPIT_USER=root
     COCKPIT_GROUP=
@@ -314,6 +317,15 @@ fi
 
 AC_SUBST(COCKPIT_USER)
 AC_SUBST(COCKPIT_GROUP)
+
+AC_ARG_WITH(selinux_config_type,
+	    AS_HELP_STRING([--with-selinux-config-type=<type>],
+			   [SELinux context type for cockpit config files]
+                          )
+           )
+
+COCKPIT_SELINUX_CONFIG_TYPE=$with_selinux_config_type
+AC_SUBST(COCKPIT_SELINUX_CONFIG_TYPE)
 
 # Documentation
 
@@ -461,6 +473,7 @@ echo "
         cockpit-ws:                 ${enable_ws}
         cockpit-ws user:            ${COCKPIT_USER}
         cockpit-ws group:           ${COCKPIT_GROUP}
+        selinux config type:        ${COCKPIT_SELINUX_CONFIG_TYPE}
 
         Maintainer mode:            ${USE_MAINTAINER_MODE}
         Building docs:              ${enable_doc}
@@ -476,4 +489,5 @@ echo "
         ssh-agent:                  ${SSH_AGENT}
         sudo:                       ${SUDO}
         usermod:                    ${USERMOD}
+        chcon:                      ${CHCON}
 "

--- a/src/ws/cockpit.service.in
+++ b/src/ws/cockpit.service.in
@@ -3,7 +3,7 @@ Description=Cockpit Web Service
 Documentation=man:cockpit-ws(8)
 
 [Service]
-ExecStartPre=@sbindir@/remotectl certificate --ensure --user=root --group=@group@
+ExecStartPre=@sbindir@/remotectl certificate --ensure --user=root --group=@group@ --selinux-type=@selinux_config_type@
 ExecStart=@libexecdir@/cockpit-ws
 PermissionsStartOnly=true
 User=@user@

--- a/test/check-connection
+++ b/test/check-connection
@@ -161,7 +161,7 @@ class TestConnection(MachineCase):
         m.execute('semanage port -m -t websm_port_t -p tcp 443 && mkdir -p /etc/systemd/system/cockpit.socket.d/ && printf "[Socket]\nListenStream=\nListenStream=443" > /etc/systemd/system/cockpit.socket.d/listen.conf')
         m.execute('systemctl daemon-reload && systemctl restart cockpit.socket')
 
-        output = m.execute('wget --no-check-certificate -O - https://localhost')
+        output = m.execute('wget --no-check-certificate -O - https://localhost 2>&1 || true')
         self.assertIn('Cockpit starting...', output)
 
         output = m.execute('wget --no-check-certificate -O - https://localhost:9090 2>&1 || true')

--- a/test/check-connection
+++ b/test/check-connection
@@ -125,8 +125,11 @@ class TestConnection(MachineCase):
             m.message(output)
             self.fail("RC4 cipher should not have been usable")
 
-        # Install a certificate chain
+        # Install a certificate chain, and give it an arbitrary bad file context
         m.upload(["files/cert-chain.cert"], "/etc/cockpit/ws-certs.d")
+        m.execute("chcon --type svirt_sandbox_file_t /etc/cockpit/ws-certs.d/cert-chain.cert")
+
+        # This should also reset the file context
         m.execute("systemctl restart cockpit")
 
         # Should use the new certificates and entire chain should show up

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -145,7 +145,7 @@ The Cockpit Web Service listens on the network, and authenticates users.
 %if %{defined gitcommit}
 env NOCONFIGURE=1 ./autogen.sh
 %endif
-%configure --disable-static --disable-silent-rules --with-cockpit-user=cockpit-ws --with-branding=%{branding}
+%configure --disable-static --disable-silent-rules --with-cockpit-user=cockpit-ws --with-branding=%{branding} --with-selinux-config-type=etc_t
 make -j %{?extra_flags} all
 
 %check


### PR DESCRIPTION
Set the SELinux context correctly for certificates
    
The SELinux policy doesn't do this for us, and since the user will be creating files in this directory, help them by setting the SELinux context correctly, similar to how we set the unix user and group.
    
See also: https://bugzilla.redhat.com/show_bug.cgi?id=1282709
