### PR TITLE
test: Remove known issue for kubectl exec failure

### DIFF
--- a/test/naughty/3012-kubectl-exec-upgrade-fail
+++ b/test/naughty/3012-kubectl-exec-upgrade-fail
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-kubernetes", line 197, in testDashboard
-    b.wait_in_text(".listing-panel .terminal div:nth-child(1)", "#")


### PR DESCRIPTION
This update is now in the Fedora 23 images:

https://bodhi.fedoraproject.org/updates/FEDORA-2015-c7fa818f3f

Fixes #3012