### PR TITLE
shell: Fix how the iframe content is sized

### DIFF
--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -624,20 +624,17 @@ define([
     function recalculate_layout() {
         var topnav = $('#topnav');
         var sidebar = $('#sidebar');
+        var content = $('#content');
 
         var window_height = $(window).height();
-        var window_width = $(window).width();
         var topnav_height = topnav.height();
-        var sidebar_width = sidebar.is(':visible') ? sidebar.outerWidth() : 0;
 
         var y = window_height - topnav_height;
-        if (current_frame) {
-            $(current_frame)
-                .height(Math.abs(y))
-                .width(Math.abs(window_width - sidebar_width));
-        }
-
+        $(current_frame).height(Math.floor(y));
         sidebar.height(y);
+
+        var sidebar_width = sidebar.is(':visible') ? sidebar.outerWidth() : 0;
+        content.css("margin-left", sidebar_width + "px");
     }
 
     $(window).on('resize', function () {

--- a/pkg/shell/shell.css
+++ b/pkg/shell/shell.css
@@ -548,9 +548,14 @@ html, body {
    margin-right: 0;
 }
 
+#content {
+    position: relative;
+}
+
 iframe.container-frame {
     display: none;
     border: none;
+    width: 100%;
 }
 
 /* Otherwise the datepicker is confused when in a modal */


### PR DESCRIPTION
There's a strange issue in Firefox where it reports window sizes
as counded up integers, whereas really they're smaller. And this
caused the iframe to flow poorly.

Remove the logic that sets an explicit width on the iframes.

https://bugzilla.redhat.com/show_bug.cgi?id=1282059