### PR TITLE
Collision detection fixes

### DIFF
--- a/test/check-verify
+++ b/test/check-verify
@@ -50,17 +50,22 @@ def check_publishing(sink, github):
     github.debug = False
     current = status.get("description", None)
     if current and current != expected:
+        sink.status.pop("github", None)
+        sink.status.pop("badge", None)
+        sink.status.pop("irc", None)
         raise RuntimeError("Verify collision: " + current)
 
 def stop_publishing(sink, ret):
     def mark_failed():
-        sink.status["github"]["status"]["state"] = "failure"
+        if "github" in sink.status:
+            sink.status["github"]["status"]["state"] = "failure"
         if 'badge' in sink.status:
             sink.status['badge']['status'] = "failed"
         if "irc" in sink.status: # Never send success messages to IRC
             sink.status["irc"]["channel"] = "#cockpit"
     def mark_passed():
-        sink.status["github"]["status"]["state"] = "success"
+        if "github" in sink.status:
+            sink.status["github"]["status"]["state"] = "success"
         if 'badge' in sink.status:
             sink.status['badge']['status'] = "passed"
     if isinstance(ret, basestring):
@@ -73,7 +78,8 @@ def stop_publishing(sink, ret):
         message = "{0} tests failed".format(ret)
         mark_failed()
     sink.status["message"] = message
-    sink.status["github"]["status"]["description"] = message
+    if "github" in sink.status:
+        sink.status["github"]["status"]["description"] = message
     del sink.status["extras"]
     sink.flush()
 

--- a/test/check-verify
+++ b/test/check-verify
@@ -45,7 +45,9 @@ def start_publishing(github, host, name, revision):
 
 def check_publishing(sink, github):
     expected = sink.status["github"]["status"]["description"]
+    github.debug = True # HACK: Temporary while debugging GitHub issues
     status = github.status(sink.status["revision"])
+    github.debug = False
     current = status.get("description", None)
     if current and current != expected:
         raise RuntimeError("Verify collision: " + current)

--- a/test/testinfra.py
+++ b/test/testinfra.py
@@ -232,7 +232,7 @@ class GitHub(object):
                 priority -= 1
 
             # Is testing already in progress?
-            if last.get("description", None) == TESTING:
+            if last.get("description", "").startswith(TESTING):
                 update = None
                 priority = 0
 

--- a/test/testinfra.py
+++ b/test/testinfra.py
@@ -152,6 +152,7 @@ class GitHub(object):
         self.base = base
         self.conn = None
         self.token = None
+        self.debug = False
         try:
             gt = open(os.path.expanduser(TOKEN), "r")
             self.token = gt.read().strip()
@@ -177,7 +178,7 @@ class GitHub(object):
             headers["Authorization"] = "token " + self.token
         if not self.conn:
             self.conn = httplib.HTTPSConnection("api.github.com", strict=True)
-        # conn.set_debuglevel(1)
+        self.conn.set_debuglevel(self.debug and 1 or 0)
         self.conn.request(method, self.qualify(resource), data, headers)
         response = self.conn.getresponse()
         output = response.read()


### PR DESCRIPTION
 * Don't update github when verify collision failed
 * Debug github problems by showing more debug info
 * Check for testing prefix instead of whole status