### PR TITLE
tools: Add libssh leak ignore for valgrind

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -122,6 +122,7 @@ VALGRIND_SUPPRESSIONS = \
 	tools/pcp.supp \
 	tools/unknown.supp \
 	tools/zlib.supp \
+	tools/libssh.supp \
 	$(NULL)
 
 valgrind-suppressions: $(VALGRIND_SUPPRESSIONS)

--- a/tools/libssh.supp
+++ b/tools/libssh.supp
@@ -1,0 +1,8 @@
+
+{
+   ssh_userauth_agent_leak
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   fun:ssh_userauth_agent
+}


### PR DESCRIPTION
Sent patch upstream for the actual leak:

https://red.libssh.org/issues/208