### PR TITLE
Implement a "ready" control message

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -178,6 +178,20 @@ This possible "result" values are:
 
 Other fields may be present in a close message.
 
+Command: ready
+--------------
+
+The "ready" command indicates that the channel implementation (usually
+the bridge) is in a ready and settled state. It is not normally necessary to
+listen to this control message, since it is possible to start sending payload
+over a channel immediately after the open message has been sent.
+
+The following fields are defined:
+
+ * "channel": The id of the channel
+
+Other fields may be present in a ready message.
+
 Command: done
 -------------
 

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -688,8 +688,8 @@ The channel will send a number of JSON messages that list the current
 content of the directory.  These messages have a "event" field with
 value "present", a "path" field that holds the (relative) name of
 the file and a type field. Type will be one of: file, directory, link,
-special or unknown. After all files have been listed a message with an
-"event" field of "present-done" is sent.
+special or unknown. After all files have been listed the "ready"
+control message will be sent.
 
 Other messages on the stream signal changes to the directory, in the
 same format as used by the "fswatch1" payload type.

--- a/pkg/base1/test-echo.html
+++ b/pkg/base1/test-echo.html
@@ -36,15 +36,21 @@
 <script type="text/javascript">
 
 asyncTest("basic", function() {
-    expect(3);
+    expect(4);
 
     var channel = cockpit.channel({ "payload": "echo" });
+    var pass = 0;
 
     $(channel).on("control", function(ev, options) {
-        equal(options.command, "done", "got done");
-        channel.close();
-        $(channel).off();
-        start();
+        if (pass == 0) {
+            equal(options.command, "ready", "got ready");
+            pass += 1;
+        } else {
+            equal(options.command, "done", "got done");
+            channel.close();
+            $(channel).off();
+            start();
+        }
     });
 
     $(channel).on("message", function(ev, payload) {

--- a/src/bridge/cockpitchannel.c
+++ b/src/bridge/cockpitchannel.c
@@ -743,6 +743,7 @@ cockpit_channel_ready (CockpitChannel *self)
       g_queue_free (queue);
     }
 
+  cockpit_channel_control (self, "ready", NULL);
   self->priv->ready = TRUE;
 
   /* No more data coming? */

--- a/src/bridge/cockpitfslist.c
+++ b/src/bridge/cockpitfslist.c
@@ -109,16 +109,6 @@ on_files_listed (GObject *source_object,
 
   if (files == NULL)
     {
-      JsonObject *msg;
-      GBytes *msg_bytes;
-
-      msg = json_object_new ();
-      json_object_set_string_member (msg, "event", "present-done");
-      msg_bytes = cockpit_json_write_bytes (msg);
-      json_object_unref (msg);
-      cockpit_channel_send (COCKPIT_CHANNEL(self), msg_bytes, FALSE);
-      g_bytes_unref (msg_bytes);
-
       g_clear_object (&self->cancellable);
       g_object_unref (source_object);
 

--- a/src/bridge/cockpitfslist.c
+++ b/src/bridge/cockpitfslist.c
@@ -122,6 +122,8 @@ on_files_listed (GObject *source_object,
       g_clear_object (&self->cancellable);
       g_object_unref (source_object);
 
+      cockpit_channel_ready (COCKPIT_CHANNEL (self));
+
       if (self->monitor == NULL)
         {
           cockpit_channel_control (COCKPIT_CHANNEL (self), "done", NULL);
@@ -241,13 +243,6 @@ cockpit_fslist_prepare (CockpitChannel *channel)
   self->cancellable = g_cancellable_new ();
 
   file = g_file_new_for_path (self->path);
-  g_file_enumerate_children_async (file,
-                                   G_FILE_ATTRIBUTE_STANDARD_NAME "," G_FILE_ATTRIBUTE_STANDARD_TYPE,
-                                   G_FILE_QUERY_INFO_NONE,
-                                   G_PRIORITY_DEFAULT,
-                                   self->cancellable,
-                                   on_enumerator_ready,
-                                   self);
 
   if (watch)
     {
@@ -264,7 +259,13 @@ cockpit_fslist_prepare (CockpitChannel *channel)
       self->sig_changed = g_signal_connect (self->monitor, "changed", G_CALLBACK (on_changed), self);
     }
 
-  cockpit_channel_ready (channel);
+  g_file_enumerate_children_async (file,
+                                   G_FILE_ATTRIBUTE_STANDARD_NAME "," G_FILE_ATTRIBUTE_STANDARD_TYPE,
+                                   G_FILE_QUERY_INFO_NONE,
+                                   G_PRIORITY_DEFAULT,
+                                   self->cancellable,
+                                   on_enumerator_ready,
+                                   self);
   problem = NULL;
 
 out:

--- a/src/bridge/cockpitfsread.c
+++ b/src/bridge/cockpitfsread.c
@@ -221,7 +221,6 @@ cockpit_fsread_prepare (CockpitChannel *channel)
         {
           options = cockpit_channel_close_options (channel);
           json_object_set_string_member (options, "tag", "-");
-          cockpit_channel_ready (channel);
           cockpit_channel_close (channel, NULL);
           problem = NULL;
         }

--- a/src/bridge/test-channel.c
+++ b/src/bridge/test-channel.c
@@ -255,6 +255,7 @@ test_close_transport (TestCase *tc,
                       gconstpointer unused)
 {
   MockEchoChannel *chan;
+  JsonObject *control;
   GBytes *sent;
   gchar *problem = NULL;
 
@@ -273,6 +274,8 @@ test_close_transport (TestCase *tc,
   g_assert (chan->close_called == TRUE);
 
   g_assert_cmpstr (problem, ==, "boooo");
+  control = mock_transport_pop_control (tc->transport);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
   g_assert (mock_transport_pop_control (tc->transport) == NULL);
 
   g_free (problem);

--- a/src/bridge/test-fs.c
+++ b/src/bridge/test-fs.c
@@ -165,6 +165,15 @@ recv_json (TestCase *tc)
   return res;
 }
 
+static JsonObject *
+recv_control (TestCase *tc)
+{
+  JsonObject *msg;
+  while ((msg = mock_transport_pop_control (tc->transport)) == NULL)
+    g_main_context_iteration (NULL, TRUE);
+  return msg;
+}
+
 static void
 close_channel (TestCase *tc,
                const gchar *problem)
@@ -796,9 +805,8 @@ test_dir_simple (TestCase *tc,
   g_assert_cmpstr (json_object_get_string_member (event, "type"), ==, "file");
   json_object_unref (event);
 
-  event = recv_json (tc);
-  g_assert_cmpstr (json_object_get_string_member (event, "event"), ==, "present-done");
-  json_object_unref (event);
+  control = recv_control (tc);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
 
   g_free (base);
 
@@ -826,9 +834,8 @@ test_dir_simple_no_watch (TestCase *tc,
   g_assert_cmpstr (json_object_get_string_member (event, "type"), ==, "file");
   json_object_unref (event);
 
-  event = recv_json (tc);
-  g_assert_cmpstr (json_object_get_string_member (event, "event"), ==, "present-done");
-  json_object_unref (event);
+  control = recv_control (tc);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
 
   g_free (base);
 
@@ -864,9 +871,8 @@ test_dir_watch (TestCase *tc,
 
   setup_fslist_channel (tc, tc->test_dir, TRUE);
 
-  event = recv_json (tc);
-  g_assert_cmpstr (json_object_get_string_member (event, "event"), ==, "present-done");
-  json_object_unref (event);
+  control = recv_control (tc);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
 
   set_contents (tc->test_path, "Hello!");
 

--- a/src/bridge/test-fs.c
+++ b/src/bridge/test-fs.c
@@ -279,6 +279,9 @@ test_read_simple (TestCase *tc,
   assert_received (tc, "Hello!");
 
   control = mock_transport_pop_control (tc->transport);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
+
+  control = mock_transport_pop_control (tc->transport);
   g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "done");
 
   control = mock_transport_pop_control (tc->transport);
@@ -345,6 +348,9 @@ test_read_changed (TestCase *tc,
   wait_channel_closed (tc);
 
   control = mock_transport_pop_control (tc->transport);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
+
+  control = mock_transport_pop_control (tc->transport);
   g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "done");
 
   control = mock_transport_pop_control (tc->transport);
@@ -376,6 +382,9 @@ test_read_replaced (TestCase *tc,
   assert_received (tc, "Hello!");
 
   control = mock_transport_pop_control (tc->transport);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
+
+  control = mock_transport_pop_control (tc->transport);
   g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "done");
 
   control = mock_transport_pop_control (tc->transport);
@@ -405,6 +414,9 @@ test_read_removed (TestCase *tc,
   assert_received (tc, "Hello!");
 
   control = mock_transport_pop_control (tc->transport);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
+
+  control = mock_transport_pop_control (tc->transport);
   g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "done");
 
   control = mock_transport_pop_control (tc->transport);
@@ -430,6 +442,9 @@ test_write_simple (TestCase *tc,
   assert_contents (tc->test_path, "Hello!");
 
   control = mock_transport_pop_control (tc->transport);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
+
+  control = mock_transport_pop_control (tc->transport);
   tag = cockpit_get_file_tag (tc->test_path);
   g_assert (json_object_get_member (control, "problem") == NULL);
   g_assert_cmpstr (json_object_get_string_member (control, "tag"), ==, tag);
@@ -452,6 +467,9 @@ test_write_multiple (TestCase *tc,
   wait_channel_closed (tc);
 
   assert_contents (tc->test_path, "Hello!");
+
+  control = mock_transport_pop_control (tc->transport);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
 
   control = mock_transport_pop_control (tc->transport);
   tag = cockpit_get_file_tag (tc->test_path);
@@ -479,6 +497,9 @@ test_write_remove (TestCase *tc,
   g_assert (g_file_test (tc->test_path, G_FILE_TEST_EXISTS) == FALSE);
 
   control = mock_transport_pop_control (tc->transport);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
+
+  control = mock_transport_pop_control (tc->transport);
   g_assert (json_object_get_member (control, "problem") == NULL);
   g_assert_cmpstr (json_object_get_string_member (control, "tag"), ==, "-");
 }
@@ -498,6 +519,9 @@ test_write_remove_nonexistent (TestCase *tc,
   wait_channel_closed (tc);
 
   g_assert (g_file_test (tc->test_path, G_FILE_TEST_EXISTS) == FALSE);
+
+  control = mock_transport_pop_control (tc->transport);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
 
   control = mock_transport_pop_control (tc->transport);
   g_assert (json_object_get_member (control, "problem") == NULL);
@@ -522,6 +546,9 @@ test_write_empty (TestCase *tc,
   wait_channel_closed (tc);
 
   assert_contents (tc->test_path, "");
+
+  control = mock_transport_pop_control (tc->transport);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
 
   control = mock_transport_pop_control (tc->transport);
   tag = cockpit_get_file_tag (tc->test_path);
@@ -572,6 +599,9 @@ test_write_expect_non_existent (TestCase *tc,
   assert_contents (tc->test_path, "Hello!");
 
   control = mock_transport_pop_control (tc->transport);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
+
+  control = mock_transport_pop_control (tc->transport);
   tag = cockpit_get_file_tag (tc->test_path);
   g_assert (json_object_get_member (control, "problem") == NULL);
   g_assert_cmpstr (json_object_get_string_member (control, "tag"), ==, tag);
@@ -619,6 +649,9 @@ test_write_expect_tag (TestCase *tc,
   assert_contents (tc->test_path, "Hello!");
 
   control = mock_transport_pop_control (tc->transport);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
+
+  control = mock_transport_pop_control (tc->transport);
   tag = cockpit_get_file_tag (tc->test_path);
   g_assert (json_object_get_member (control, "problem") == NULL);
   g_assert_cmpstr (json_object_get_string_member (control, "tag"), ==, tag);
@@ -644,6 +677,9 @@ test_write_expect_tag_fail (TestCase *tc,
   wait_channel_closed (tc);
 
   assert_contents (tc->test_path, "Tschüss!");
+
+  control = mock_transport_pop_control (tc->transport);
+  g_assert_cmpstr (json_object_get_string_member (control, "command"), ==, "ready");
 
   control = mock_transport_pop_control (tc->transport);
   tag = cockpit_get_file_tag (tc->test_path);

--- a/src/bridge/test-httpstream.c
+++ b/src/bridge/test-httpstream.c
@@ -216,9 +216,9 @@ test_http_stream2 (TestGeneral *tt,
     g_main_context_iteration (NULL, TRUE);
 
   object = mock_transport_pop_control (tt->transport);
-  g_assert (object != NULL);
+  cockpit_assert_json_eq (object, "{\"command\":\"ready\",\"channel\":\"444\"}");
+  object = mock_transport_pop_control (tt->transport);
   cockpit_assert_json_eq (object, "{\"command\":\"response\",\"channel\":\"444\",\"status\":200,\"reason\":\"OK\",\"headers\":{}}");
-  json_object_unref (object);
 
   data = mock_transport_combine_output (tt->transport, "444", &count);
   cockpit_assert_bytes_eq (data, "Da Da Da", -1);


### PR DESCRIPTION
The "ready" command indicates that the channel implementation (usually the bridge) is in a ready and settled state. It is not normally necessary to listen to this control message, since it is possible to start sending payload over a channel immediately after the open message has been sent.
