### PR TITLE
base1: Include all channel options in open command

### DIFF
--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -686,14 +686,11 @@ function Channel(options) {
         transport.register(id, on_control, on_message);
 
         /* Now open the channel */
-        var command = {
-            "command" : "open",
-            "channel": id
-        };
-        for (var i in options) {
-            if (options.hasOwnProperty(i) && command[i] === undefined)
-                command[i] = options[i];
-        }
+        var command = { };
+        for (var i in options)
+            command[i] = options[i];
+        command.command = "open";
+        command.channel = id;
 
         if (!command.host) {
             if (default_host)


### PR DESCRIPTION
Previously certain options like 'watch' were completely
ignored, because javascript Object has functions with these names.