### PR TITLE
Add CSRF token credentials to CockpitCreds

### DIFF
--- a/src/ws/cockpitauth.h
+++ b/src/ws/cockpitauth.h
@@ -76,6 +76,8 @@ GType           cockpit_auth_get_type        (void) G_GNUC_CONST;
 
 CockpitAuth *   cockpit_auth_new             (gboolean login_loopback);
 
+gchar *         cockpit_auth_nonce           (CockpitAuth *self);
+
 void            cockpit_auth_login_async     (CockpitAuth *self,
                                               const gchar *path,
                                               GHashTable *headers,

--- a/src/ws/cockpitcreds.c
+++ b/src/ws/cockpitcreds.c
@@ -39,6 +39,7 @@ struct _CockpitCreds {
   gchar *password;
   gchar *rhost;
   gchar *gssapi_creds;
+  gchar *csrf_token;
   krb5_context krb5_ctx;
   krb5_ccache krb5_ccache;
   gchar *krb5_ccache_name;
@@ -58,6 +59,7 @@ cockpit_creds_free (gpointer data)
   g_free (creds->password);
   g_free (creds->rhost);
   g_free (creds->gssapi_creds);
+  g_free (creds->csrf_token);
 
   if (creds->krb5_ctx)
     {
@@ -116,6 +118,8 @@ cockpit_creds_new (const gchar *user,
         creds->rhost = g_strdup (va_arg (va, const char *));
       else if (g_str_equal (type, COCKPIT_CRED_GSSAPI))
         creds->gssapi_creds = g_strdup (va_arg (va, const char *));
+      else if (g_str_equal (type, COCKPIT_CRED_CSRF_TOKEN))
+        creds->csrf_token = g_strdup (va_arg (va, const char *));
       else
         g_assert_not_reached ();
     }
@@ -205,6 +209,13 @@ cockpit_creds_get_password (CockpitCreds *creds)
   if (g_atomic_int_get (&creds->poisoned))
       return NULL;
   return creds->password;
+}
+
+const gchar *
+cockpit_creds_get_csrf_token (CockpitCreds *creds)
+{
+  g_return_val_if_fail (creds != NULL, NULL);
+  return creds->csrf_token;
 }
 
 /**

--- a/src/ws/cockpitcreds.h
+++ b/src/ws/cockpitcreds.h
@@ -29,10 +29,11 @@ G_BEGIN_DECLS
 
 typedef struct _CockpitCreds       CockpitCreds;
 
-#define COCKPIT_CRED_FULLNAME "full-name"
-#define COCKPIT_CRED_PASSWORD "password"
-#define COCKPIT_CRED_RHOST    "rhost"
-#define COCKPIT_CRED_GSSAPI   "gssapi"
+#define COCKPIT_CRED_FULLNAME     "full-name"
+#define COCKPIT_CRED_PASSWORD     "password"
+#define COCKPIT_CRED_RHOST        "rhost"
+#define COCKPIT_CRED_GSSAPI       "gssapi"
+#define COCKPIT_CRED_CSRF_TOKEN   "csrf-token"
 
 #define         COCKPIT_TYPE_CREDS           (cockpit_creds_get_type ())
 
@@ -55,6 +56,8 @@ const gchar *   cockpit_creds_get_fullname   (CockpitCreds *creds);
 const gchar *   cockpit_creds_get_password   (CockpitCreds *creds);
 
 const gchar *   cockpit_creds_get_rhost      (CockpitCreds *creds);
+
+const gchar *   cockpit_creds_get_csrf_token (CockpitCreds *creds);
 
 gboolean        cockpit_creds_equal          (gconstpointer v1,
                                               gconstpointer v2);

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -255,7 +255,9 @@ on_handle_stream_socket (CockpitWebServer *server,
       value = g_strdup_printf ("%d", server_port);
       env = g_environ_setenv (g_get_environ (), "COCKPIT_TEST_SERVER_PORT", value, TRUE);
 
-      creds = cockpit_creds_new (g_get_user_name (), "test", NULL);
+      creds = cockpit_creds_new (g_get_user_name (), "test",
+                                 COCKPIT_CRED_CSRF_TOKEN, "myspecialtoken",
+                                 NULL);
       pipe = cockpit_pipe_spawn ((const gchar **)bridge_argv, (const gchar **)env, NULL, FALSE);
       transport = cockpit_pipe_transport_new (pipe);
       service = cockpit_web_service_new (creds, transport);


### PR DESCRIPTION
These are used when we need an nonce to protect GET requests
and other CSRF protections. The new sideband code will use this.