### PR TITLE
tools: Use 'make-rpms' to build host native packages

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -54,7 +54,18 @@ In addition for testing the following dependencies are required:
 
     $ sudo npm install -g phantomjs
 
-## Building and installing
+## Building and Installing RPMs
+
+If you wish to test out a development branch on Fedora, you can just
+build installable RPMs.
+
+    $ tools/make-rpms --verbose
+    $ sudo yum install noarch/cockpit*-wip-1.rpm x86_64/cockpit*-wip-1.rpm
+
+If you want to develop Cockpit, then skip this section, and build from
+source.
+
+## Building and Installing from source
 
 Cockpit uses the autotools and thus there are the familiar `./configure`
 script and the familar Makefile targets.

--- a/Makefile.am
+++ b/Makefile.am
@@ -181,8 +181,8 @@ uninstall-local:: uninstall-doc-local
 
 install-data-hook::
 	mkdir -p $(DESTDIR)$(localstatedir)/lib/cockpit
-	-chgrp wheel $(DESTDIR)$(localstatedir)/lib/cockpit
-	-chmod 775 $(DESTDIR)$(localstatedir)/lib/cockpit
+	chgrp wheel $(DESTDIR)$(localstatedir)/lib/cockpit || true
+	chmod 775 $(DESTDIR)$(localstatedir)/lib/cockpit
 
 LATEST = latest/
 

--- a/pkg/base1/test-cache.html
+++ b/pkg/base1/test-cache.html
@@ -100,7 +100,6 @@ asyncTest("multi cache", function() {
         equal(typeof result, "function", "provider2 got result function");
 
         var timer = window.setTimeout(function() {
-            console.log("provider2 setting value");
             result({ myobject: "value2" });
         }, 200);
 

--- a/pkg/base1/test-time.html
+++ b/pkg/base1/test-time.html
@@ -42,7 +42,6 @@ asyncTest("get wall time", function() {
     var dbus = cockpit.dbus(null, { "bus": "internal" });
     dbus.call("/time", "cockpit.Time", "GetWallTime", [ ])
         .done(function(reply) {
-            console.log(reply);
             ok(reply[0] > 1000000000000, "in right range");
             ok(reply[0] < 9000000000000, "in right range");
         })

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -100,9 +100,8 @@ cockpit_polkit_LDADD = libreauthorize.a $(REAUTHORIZE_LIBS) $(COCKPIT_POLKIT_LIB
 # polkit-agent-helper-1 need to be setuid root because polkit wants
 # responses to come from a root process
 install-data-hook::
-	-chown root:0 $(DESTDIR)$(libexecdir)/cockpit-polkit
-	-chown root:0 $(DESTDIR)$(libexecdir)/cockpit-polkit
-	-chmod 4755 $(DESTDIR)$(libexecdir)/cockpit-polkit
+	chown -f root:0 $(DESTDIR)$(libexecdir)/cockpit-polkit || true
+	chmod -f 4755 $(DESTDIR)$(libexecdir)/cockpit-polkit
 
 EXTRA_DIST += \
 	src/bridge/cockpit.pam.insecure \

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -99,8 +99,8 @@ firewall_DATA = src/ws/cockpit.xml
 # If running cockpit-ws as a non-standard user, we also set up
 # cockpit-session to be setuid root, but only runnable by cockpit-session
 install-exec-hook::
-	-chown root:$(COCKPIT_GROUP) $(DESTDIR)$(libexecdir)/cockpit-session
-	-test "$(COCKPIT_USER)" != "root" && chmod 4750 $(DESTDIR)$(libexecdir)/cockpit-session
+	chown -f root:$(COCKPIT_GROUP) $(DESTDIR)$(libexecdir)/cockpit-session || true
+	test "$(COCKPIT_USER)" != "root" && chmod -f 4750 $(DESTDIR)$(libexecdir)/cockpit-session || true
 
 EXTRA_DIST += \
 	src/ws/cockpit.service.in \
@@ -286,7 +286,7 @@ TESTS += $(WS_CHECKS)
 
 install-exec-hook::
 	mkdir -p $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d
-	-chmod 755 $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d
+	chmod 755 $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d
 
 update-known-hosts:
 	cat $(srcdir)/src/ws/mock_*.pub | \

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -142,13 +142,15 @@ The Cockpit Web Service listens on the network, and authenticates users.
 %setup -q
 
 %build
+exec 2>&1
 %if %{defined gitcommit}
 env NOCONFIGURE=1 ./autogen.sh
 %endif
-%configure --disable-static --disable-silent-rules --with-cockpit-user=cockpit-ws --with-branding=%{branding} --with-selinux-config-type=etc_t
+%configure --disable-silent-rules --with-cockpit-user=cockpit-ws --with-branding=%{branding} --with-selinux-config-type=etc_t
 make -j4 %{?extra_flags} all
 
 %check
+exec 2>&1
 make -j4 check
 
 %install

--- a/tools/make-rpms
+++ b/tools/make-rpms
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of Cockpit.
 #
-# Copyright (C) 2013 Red Hat, Inc.
+# Copyright (C) 2015 Red Hat, Inc.
 #
 # Cockpit is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License as published by
@@ -16,40 +16,28 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-set -eu
+set -euf
 
 base=$(cd $(dirname $0)/../; pwd -P)
 
-# For the TEST_OS defines
-. $base/test/testlib.sh
-
 usage()
 {
-	echo "usage: make-rpms [--clean] [--quick] [--verbose]"
+	echo "usage: make-rpms [--quick] [--verbose]"
 }
 
-mock_opts=""
-mock_clean_opts="--no-clean --no-cleanup-after"
-mock_define="unused"
-mock_value="0"
+quiet="--quiet"
+check=""
 
-args=$(getopt -o "h,v,c,q,r:" -l "help,verbose,clean,quick" -- "$@")
+args=$(getopt -o "h,v" -l "help,quick,verbose" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do
 	case $1 in
-	-c|--clean)
-        # We always use --no-cleanup-after because a
-        # --no-clean build can not start with a chroot that
-        # has been cleaned previously.
-		mock_clean_opts="--no-cleanup-after"
-		;;
 	-v|--verbose)
-		mock_opts="$mock_opts --verbose"
+		quiet=""
 		;;
-	-q|--quick)
-		mock_define="selinux" mock_value="0"
-		mock_opts="$mock_opts --offline --nocheck"
-		;;
+    -q|--quick)
+        check="--nocheck"
+        ;;
 	-h|--help)
 		usage
 		exit 0
@@ -67,82 +55,17 @@ if [ $# -ne 0 ]; then
 	exit 2
 fi
 
-if test $(id -u) = 0; then
-    echo "Don't run this as root!"
-    exit 1
-fi
+srpm="$($base/tools/make-srpm)"
 
-make_srpm=$base/tools/make-srpm
+tmpdir=$(mktemp -d $PWD/rpm-build.XXXXXX)
+rpmbuild --rebuild $check $quiet \
+    --define "_sourcedir $tmpdir" \
+    --define "_specdir $tmpdir" \
+    --define "_builddir $tmpdir" \
+    --define "_srcrpmdir $tmpdir" \
+    --define "_rpmdir $tmpdir/output" \
+    --define "_buildrootdir $tmpdir/build" \
+    $srpm
 
-# $os is the TEST_OS value that we are building for, without changes.
-# $mockos the mock configuration we are using as the basis for it.
-
-os=${TEST_OS:-}
-
-mockos=$os
-# if we're building for atomic, generate regular fedora packages
-if [[ "$os" =~ "fedora-atomic" ]]; then
-    mockos=${os/-atomic/}
-elif [ "$os" = "fedora-testing" ]; then
-    mockos="fedora-22"
-fi
-
-# Will have a lookup overide once we have non x86_64
-arch=x86_64
-
-srpm=$("$make_srpm" "$@")
-rm -rf $base/mock/*
-
-mockcfgdir=${TEST_DATA:-$base}/mock
-
-# Create our custom config
-mkdir -p $base/mock $mockcfgdir
-cp --preserve=timestamps /etc/mock/site-defaults.cfg $mockcfgdir
-cp --preserve=timestamps /etc/mock/logging.ini $mockcfgdir
-mockcfg=$mockcfgdir/$os-$arch-cockpit.cfg
-
-if [ "$os" == "rhel-7" ]; then
-    mockos="epel-7"
-    # get epel packages instead, they don't require a subscription
-    cp --preserve=timestamps /etc/mock/$mockos-$arch.cfg $mockcfg
-    cat >>$mockcfg <<EOF
-config_opts['root'] = "$os-$arch-cockpit"
-config_opts['yum.conf'] += """
-[sgallagh-cockpit-preview]
-name=Copr repo for cockpit-preview owned by sgallagh
-baseurl=https://copr-be.cloud.fedoraproject.org/results/sgallagh/cockpit-preview/$os-$arch/
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/sgallagh/cockpit-preview/pubkey.gpg
-enabled=1
-"""
-EOF
-else
-    cp --preserve=timestamps /etc/mock/$mockos-$arch.cfg $mockcfg
-    cat >>$mockcfg <<EOF
-config_opts['root'] = "$os-$arch-cockpit"
-EOF
-    if [[ "$os" =~ "-testing" ]]; then
-        cat >>$mockcfg <<EOF
-config_opts['yum.conf'] += """
-[updates-testing]
-enabled=1
-"""
-EOF
-    fi
-fi
-
-touch -r /etc/mock/$mockos-$arch.cfg $mockcfg
-
-if LANG=C /usr/bin/mock --quiet $mock_opts $mock_clean_opts --configdir=$mockcfgdir \
-	--resultdir $base/mock -r $os-$arch-cockpit --define="$mock_define $mock_value" $srpm; then
-    grep "^Wrote: .*\.\($arch\|noarch\)\.rpm$" $base/mock/build.log | while read l; do
-        p=$(basename "$l") # knocks off the "Wrote:" part as well...
-        echo $p
-        mv $base/mock/$p .
-    done
-    exit 0
-else
-    echo >&2 FAILED
-    exit 1
-fi
+find $tmpdir/output -name '*.rpm' -printf '%f\n' -exec mv {} . \;
+rm -r $tmpdir


### PR DESCRIPTION
This is the quick path to testing out a Cockpit commit on an RPM
based system. It doesn't require mock, or a VM or anything else
besides all the development dependencies.