### PR TITLE
test: Add memory/cpu parameters to vm-run

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -480,9 +480,9 @@ class MachineCase(unittest.TestCase):
             if stopTestRun is not None:
                 stopTestRun()
 
-    def setUp(self, macaddr=None):
+    def setUp(self, macaddr=None, memory_mb=None, cpus=None):
         self.machine = self.new_machine()
-        self.machine.start(macaddr=macaddr)
+        self.machine.start(macaddr=macaddr,memory_mb=memory_mb, cpus=cpus)
         if arg_trace:
             print "starting machine %s" % (self.machine.address)
         self.machine.wait_boot()

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -626,6 +626,9 @@ class VirtEventHandler():
         self.eventLoopThread.start()
 
 class VirtMachine(Machine):
+    memory_mb = None
+    cpus = None
+
     def __init__(self, **args):
         Machine.__init__(self, **args)
 
@@ -764,8 +767,11 @@ class VirtMachine(Machine):
         raise Failure("Couldn't find unused mac address for '%s'" % (self.image))
 
     def _start_qemu(self, maintain=False, macaddr=None, wait_for_ip=True, memory_mb=None, cpus=None):
-        memory_mb = memory_mb or MEMORY_MB;
-        cpus = cpus or 1
+        memory_mb = memory_mb or VirtMachine.memory_mb or MEMORY_MB;
+        cpus = cpus or VirtMachine.cpus or 1
+        print "memory: "
+        print memory_mb
+        time.sleep(5)
 
         # make sure we have a clean slate
         self._cleanup()

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -854,9 +854,9 @@ class VirtMachine(Machine):
             self.address = self._ip_from_mac(self.macaddr)
 
     # start virsh console
-    def qemu_console(self, maintain=True, macaddr=None):
+    def qemu_console(self, maintain=True, macaddr=None, memory_mb=None, cpus=None):
         try:
-            self._start_qemu(maintain=maintain, macaddr=macaddr, wait_for_ip=False)
+            self._start_qemu(maintain=maintain, macaddr=macaddr, wait_for_ip=False, memory_mb=memory_mb, cpus=cpus)
             self.message("started machine %s with address %s" % (self._domain.name(), self.address))
             if maintain:
                 self.message("Changes are written to the image file.")

--- a/test/vm-run
+++ b/test/vm-run
@@ -25,12 +25,17 @@ import testinfra
 parser = argparse.ArgumentParser(description='Run a test machine')
 parser.add_argument('-v', '--verbose', action='store_true', help='Display verbose details')
 parser.add_argument('-m', '--maintain', action='store_true', help='Changes are permanent')
+parser.add_argument('-M', '--memory', default=None, type=int, help='Memory (in MiB) of the target machine')
+parser.add_argument('-C', '--cpus', default=None, type=int, help='Number of cpus in the target machine')
+
 parser.add_argument('image', nargs='?', default=testinfra.DEFAULT_IMAGE, help='The image to run')
 args = parser.parse_args()
 
 try:
     machine = testvm.VirtMachine(verbose=args.verbose, image=args.image)
-    machine.qemu_console(args.maintain)
+    machine.qemu_console(maintain=args.maintain,
+                         memory_mb=args.memory,
+                         cpus=args.cpus)
 except testvm.Failure, ex:
     print >> sys.stderr, "vm-run:", ex
     sys.exit(1)


### PR DESCRIPTION
The underlying scripts allow setting the amount of memory in the vm
and the number of cpus before booting. We now also expose them
in vm-run.

Too bad `-m` was already taken by the maintain flag...