### PR TITLE
It's normal to disconnect mid-packet on reboot (and other happy things)

### DIFF
--- a/src/common/cockpitpipetransport.c
+++ b/src/common/cockpitpipetransport.c
@@ -134,8 +134,8 @@ on_pipe_read (CockpitPipe *pipe,
       /* Received a partial message */
       if (input->len > 0)
         {
-          g_warning ("%s: received truncated %d byte frame", self->name, input->len);
-          cockpit_pipe_close (pipe, "internal-error");
+          g_debug ("%s: received truncated %d byte frame", self->name, input->len);
+          cockpit_pipe_close (pipe, "disconnected");
         }
     }
 

--- a/src/common/cockpittransport.c
+++ b/src/common/cockpittransport.c
@@ -172,6 +172,44 @@ cockpit_transport_emit_closed (CockpitTransport *transport,
   g_signal_emit (transport, signals[CLOSED], 0, problem);
 }
 
+static GBytes *
+parse_frame (GBytes *message,
+             gboolean expect,
+             gchar **channel)
+{
+  const gchar *data;
+  gsize length;
+  const gchar *line;
+  gsize channel_len;
+
+  g_return_val_if_fail (message != NULL, NULL);
+
+  data = g_bytes_get_data (message, &length);
+  line = memchr (data, '\n', length);
+  if (!line)
+    {
+      if (expect)
+        g_message ("received invalid message without channel prefix");
+      return NULL;
+    }
+
+  channel_len = line - data;
+  if (memchr (data, '\0', channel_len) != NULL)
+    {
+      if (expect)
+        g_message ("received massage with invalid channel prefix");
+      return NULL;
+    }
+
+  if (channel_len)
+    *channel = g_strndup (data, channel_len);
+  else
+    *channel = NULL;
+
+  channel_len++;
+  return g_bytes_new_from_bytes (message, channel_len, length - channel_len);
+}
+
 /**
  * cockpit_transport_parse_frame:
  * @message: message to parse
@@ -189,35 +227,14 @@ GBytes *
 cockpit_transport_parse_frame (GBytes *message,
                                gchar **channel)
 {
-  const gchar *data;
-  gsize length;
-  const gchar *line;
-  gsize channel_len;
+  return parse_frame (message, TRUE, channel);
+}
 
-  g_return_val_if_fail (message != NULL, NULL);
-
-  data = g_bytes_get_data (message, &length);
-  line = memchr (data, '\n', length);
-  if (!line)
-    {
-      g_warning ("Received invalid message without channel prefix");
-      return NULL;
-    }
-
-  channel_len = line - data;
-  if (memchr (data, '\0', channel_len) != NULL)
-    {
-      g_warning ("Received massage with invalid channel prefix");
-      return NULL;
-    }
-
-  if (channel_len)
-    *channel = g_strndup (data, channel_len);
-  else
-    *channel = NULL;
-
-  channel_len++;
-  return g_bytes_new_from_bytes (message, channel_len, length - channel_len);
+GBytes *
+cockpit_transport_maybe_frame (GBytes *message,
+                               gchar **channel)
+{
+  return parse_frame (message, FALSE, channel);
 }
 
 /**

--- a/src/common/cockpittransport.h
+++ b/src/common/cockpittransport.h
@@ -93,6 +93,9 @@ void        cockpit_transport_emit_closed    (CockpitTransport *transport,
 GBytes *    cockpit_transport_parse_frame    (GBytes *message,
                                               gchar **channel);
 
+GBytes *    cockpit_transport_maybe_frame    (GBytes *message,
+                                              gchar **channel);
+
 gboolean    cockpit_transport_parse_command  (GBytes *payload,
                                               const gchar **command,
                                               const gchar **channel,

--- a/src/common/test-transport.c
+++ b/src/common/test-transport.c
@@ -494,7 +494,7 @@ test_parse_frame_bad (void)
   GBytes *message;
   GBytes *payload;
 
-  cockpit_expect_warning ("*invalid channel prefix");
+  cockpit_expect_message ("*invalid channel prefix");
 
   message = g_bytes_new_static ("b\x00y\ntest", 8);
   payload = cockpit_transport_parse_frame (message, &channel);
@@ -504,7 +504,7 @@ test_parse_frame_bad (void)
 
   cockpit_assert_expected ();
 
-  cockpit_expect_warning ("*invalid message without channel prefix");
+  cockpit_expect_message ("*invalid message without channel prefix");
 
   channel = NULL;
   message = g_bytes_new_static ("test", 4);
@@ -514,6 +514,27 @@ test_parse_frame_bad (void)
   g_free (channel);
 
   cockpit_assert_expected ();
+}
+
+static void
+test_parse_frame_maybe (void)
+{
+  gchar *channel = NULL;
+  GBytes *message;
+  GBytes *payload;
+
+  message = g_bytes_new_static ("b\x00y\ntest", 8);
+  payload = cockpit_transport_maybe_frame (message, &channel);
+  g_assert (payload == NULL);
+  g_bytes_unref (message);
+  g_free (channel);
+
+  channel = NULL;
+  message = g_bytes_new_static ("test", 4);
+  payload = cockpit_transport_maybe_frame (message, &channel);
+  g_assert (payload == NULL);
+  g_bytes_unref (message);
+  g_free (channel);
 }
 
 static void
@@ -604,8 +625,9 @@ main (int argc,
 
   cockpit_test_init (&argc, &argv);
 
-  g_test_add_func ("/transport/parse-frame", test_parse_frame);
-  g_test_add_func ("/transport/parse-frame-bad", test_parse_frame_bad);
+  g_test_add_func ("/transport/parse-frame/ok", test_parse_frame);
+  g_test_add_func ("/transport/parse-frame/bad", test_parse_frame_bad);
+  g_test_add_func ("/transport/parse-frame/maybe", test_parse_frame_maybe);
 
   g_test_add_func ("/transport/parse-command/normal", test_parse_command);
   g_test_add_func ("/transport/parse-command/no-channel", test_parse_command_no_channel);

--- a/src/common/test-transport.c
+++ b/src/common/test-transport.c
@@ -416,8 +416,6 @@ test_read_truncated (void)
   out = dup (2);
   g_assert (out >= 0);
 
-  cockpit_expect_warning ("*received truncated 1 byte frame");
-
   /* Pass in a read end of the pipe */
   transport = cockpit_pipe_transport_new_fds ("test", fds[0], out);
   g_signal_connect (transport, "closed", G_CALLBACK (on_closed_get_problem), &problem);
@@ -428,7 +426,7 @@ test_read_truncated (void)
 
   WAIT_UNTIL (problem != NULL);
 
-  g_assert_cmpstr (problem, ==, "internal-error");
+  g_assert_cmpstr (problem, ==, "disconnected");
   g_free (problem);
 
   g_object_unref (transport);

--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -184,6 +184,7 @@ cockpit_channel_response_close (CockpitChannelResponse *chesp,
           cockpit_web_response_error (chesp->response, 404, NULL, NULL);
         }
       else if (g_str_equal (problem, "no-host") ||
+               g_str_equal (problem, "no-cockpit") ||
                g_str_equal (problem, "no-forwarding") ||
                g_str_equal (problem, "unknown-hostkey") ||
                g_str_equal (problem, "authentication-failed"))

--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -199,7 +199,10 @@ cockpit_channel_response_close (CockpitChannelResponse *chesp,
     }
   else
     {
-      g_message ("%s: failure while serving resource: %s", chesp->logname, problem);
+      if (g_str_equal (problem, "disconnected"))
+        g_debug ("%s: failure while serving resource: %s", chesp->logname, problem);
+      else
+        g_message ("%s: failure while serving resource: %s", chesp->logname, problem);
       cockpit_web_response_abort (chesp->response);
     }
 

--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -1125,8 +1125,8 @@ drain_buffer (CockpitSshTransport *self)
       /* Received a partial message */
       if (self->buffer->len > 0)
         {
-          g_warning ("%s: received truncated %d byte frame", self->logname, (int)self->buffer->len);
-          close_immediately (self, "internal-error");
+          g_debug ("%s: received truncated %d byte frame", self->logname, (int)self->buffer->len);
+          close_immediately (self, "disconnected");
         }
     }
 }

--- a/src/ws/test-sshtransport.c
+++ b/src/ws/test-sshtransport.c
@@ -746,14 +746,19 @@ test_expect_empty_key (TestCase *tc,
   g_free (problem);
 }
 
-
+/* The output from this will go to stderr */
 static const TestFixture fixture_bad_command = {
-  .ssh_command = "/nonexistant 2> /dev/null",
+  .ssh_command = "/nonexistant",
+};
+
+/* Yes this makes a difference with bash, output goes to stdout */
+static const TestFixture fixture_command_not_found = {
+  .ssh_command = "nonexistant-command",
 };
 
 static void
-test_bad_command (TestCase *tc,
-                  gconstpointer data)
+test_no_cockpit (TestCase *tc,
+                 gconstpointer data)
 {
   gchar *problem = NULL;
 
@@ -930,7 +935,9 @@ main (int argc,
 #endif
 #endif
   g_test_add ("/ssh-transport/bad-command", TestCase, &fixture_bad_command,
-              setup_transport, test_bad_command, teardown);
+              setup_transport, test_no_cockpit, teardown);
+  g_test_add ("/ssh-transport/command-not-found", TestCase, &fixture_command_not_found,
+              setup_transport, test_no_cockpit, teardown);
   g_test_add ("/ssh-transport/close-while-connecting", TestCase, &fixture_cat,
               setup_transport, test_close_while_connecting, teardown);
   g_test_add_func ("/ssh-transport/cannot-connect", test_cannot_connect);

--- a/test/check-multi-machine
+++ b/test/check-multi-machine
@@ -429,7 +429,6 @@ class TestMultiMachine(MachineCase):
         self.allow_journal_messages('.*: couldn\'t connect: Connection refused',
                                     '.* failed to retrieve resource: hostkey-changed',
                                     '.* host key for server has changed to: .*',
-                                    '.*: incorrect protocol: received invalid length prefix',
                                     '.*: received truncated .*')
 
 if __name__ == '__main__':

--- a/test/check-multi-machine
+++ b/test/check-multi-machine
@@ -427,7 +427,6 @@ class TestMultiMachine(MachineCase):
 
         self.allow_hostkey_messages()
         self.allow_journal_messages('.*: couldn\'t connect: Connection refused',
-                                    '.* failed to retrieve resource: protocol-error',
                                     '.* failed to retrieve resource: hostkey-changed',
                                     '.* host key for server has changed to: .*',
                                     '.*: incorrect protocol: received invalid length prefix',


### PR DESCRIPTION
When rebooting a system, we may be in the middle of receiving
a packet over the pipe transport. We should treat this as a
"disconnected" problem.

In addition when serving resources, we can abort properly in
this scenario without making an insane amount of noise.