### PR TITLE
shell: Fix auth-methods-results when syncing users

### DIFF
--- a/pkg/shell/machine-dialogs.js
+++ b/pkg/shell/machine-dialogs.js
@@ -889,12 +889,12 @@ define([
                 if (ex.problem == "access-denied") {
                     needs_root = true;
                     if (!methods && machines.has_auth_results)
-                        /* We need to know if password auth is
+                        /* TODO: We need to know if password auth is
                          * supported but we only get that when the transport
-                         * closes. Passing a blank host-key will open
-                         * a private channel that fails
+                         * closes. Passing an invalid username should
+                         * open new transport that fails.
                          */
-                        try_to_connect(dialog.address, { "host-key" : "" })
+                        try_to_connect(dialog.address, { "user" : "1" })
                             .fail(function(ex) {
                                 methods = ex['auth-method-results'];
                             })


### PR DESCRIPTION
We need a failing transport to detect if password auth is supported when syncing users. This uses an invalid user name to trigger it.

This is a bit of a hack because it makes the assumption that a numeric user name is invalid everywhere. Alternatives might be to add an explicit auth-methods option that would open a private channel doesn't try any other, just gathers the methods. Or we could have a control command that can get this info from a CockpitSession that has init_received.

