### PR TITLE
remotectl: Don't fail if chcon fails to reset SELinux file type

### DIFF
--- a/src/remotectl/certificate.c
+++ b/src/remotectl/certificate.c
@@ -140,7 +140,7 @@ ensure_certificate (const gchar *user,
         {
           g_message ("couldn't change SELinux type context '%s' for certificate: %s: %s",
                      selinux, path, error->message);
-          goto out;
+          /* keep going, don't fail hard here */
         }
     }
 


### PR DESCRIPTION
When setting up the certificate SELinux file type, we call chcon.
But that can fail for all sorts of unpredictable reasons, so just
fall through. The resulting warning will be informative in the
logs anyway.