### PR TITLE
test: Allow repository steps to be optional for rhel-7 setup

### DIFF
--- a/test/guest/fedora-22.setup
+++ b/test/guest/fedora-22.setup
@@ -58,7 +58,7 @@ maybe firewall-cmd --permanent --add-port 8765/tcp
 
 echo 'NETWORKING=yes' > /etc/sysconfig/network
 
-useradd -u 1000 -c Administrator -G wheel admin
+useradd -c Administrator -G wheel admin
 echo foobar | passwd --stdin admin
 
 # Let's upgrade dnf first and then use the new dnf to upgrade
@@ -79,7 +79,7 @@ dnf -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
 
 # Prepare for building
 dnf -y install mock
-useradd -u 2000 -c Builder -G mock builder
+useradd -c Builder -G mock builder
 su - builder -c "mock --installdeps $TEST_SOURCE_PACKAGE"
 
 dnf clean all

--- a/test/guest/fedora-23.setup
+++ b/test/guest/fedora-23.setup
@@ -58,7 +58,7 @@ maybe firewall-cmd --permanent --add-port 8765/tcp
 
 echo 'NETWORKING=yes' > /etc/sysconfig/network
 
-useradd -u 1000 -c Administrator -G wheel admin
+useradd -c Administrator -G wheel admin
 echo foobar | passwd --stdin admin
 
 # Let's upgrade dnf first and then use the new dnf to upgrade
@@ -72,7 +72,7 @@ dnf -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
 
 # Prepare for building
 dnf -y install mock dnf-plugins-core
-useradd -u 2000 -c Builder -G mock builder
+useradd -c Builder -G mock builder
 
 # HACK - mock --installdeps with yum is broken, it seems that it can't
 # run any package scriptlets.  Yum is deprecated anyway so we just use

--- a/test/guest/fedora-stock.setup
+++ b/test/guest/fedora-stock.setup
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-useradd -u 1000 -c Administrator -G wheel admin
+useradd -c Administrator -G wheel admin
 echo foobar | passwd --stdin admin
 
 dnf -y update

--- a/test/guest/fedora-testing.setup
+++ b/test/guest/fedora-testing.setup
@@ -58,7 +58,7 @@ maybe firewall-cmd --permanent --add-port 8765/tcp
 
 echo 'NETWORKING=yes' > /etc/sysconfig/network
 
-useradd -u 1000 -c Administrator -G wheel admin
+useradd -c Administrator -G wheel admin
 echo foobar | passwd --stdin admin
 
 # Let's upgrade dnf first and then use the new dnf to upgrade
@@ -74,7 +74,7 @@ dnf -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
 
 # Prepare for building
 dnf -y install mock dnf-plugins-core
-useradd -u 2000 -c Builder -G mock builder
+useradd -c Builder -G mock builder
 
 # HACK - mock --installdeps with yum is broken, it seems that it can't
 # run any package scriptlets.  Yum is deprecated anyway so we just use

--- a/test/guest/rhel-7.setup
+++ b/test/guest/rhel-7.setup
@@ -126,14 +126,16 @@ echo foobar | passwd --stdin admin
 # To enable persistent logging
 mkdir -p /var/log/journal
 
-# HACK: docker falls over regularly, print its log if it does
-systemctl start docker || journalctl -u docker
+if type "docker" >/dev/null 2>&1; then
+    # HACK: docker falls over regularly, print its log if it does
+    systemctl start docker || journalctl -u docker
 
-# docker image that we need for integration testing
-docker pull busybox:latest
-docker pull busybox:buildroot-2014.02
-docker pull submod/helloapache
-docker pull submod/atomicapp
+    # docker image that we need for integration testing
+    docker pull busybox:latest
+    docker pull busybox:buildroot-2014.02
+    docker pull submod/helloapache
+    docker pull submod/atomicapp
+fi
 
 # HACK - kdump.service interferes with our storage tests, by loading
 # the system for some time after boot and thereby causing a race

--- a/test/guest/rhel-7.setup
+++ b/test/guest/rhel-7.setup
@@ -110,10 +110,13 @@ if [ ! -f "$SKIP_REPO_FLAG" ]; then
     subscription-manager unregister
 fi
 
-maybe() { if type "$1" >/dev/null 2>&1; then "$@"; fi; }
-
 # For the D-Bus test server
-maybe firewall-cmd --permanent --add-port 8765/tcp
+if type "firewall-cmd" >/dev/null 2>&1; then
+    FIREWALL_STATE=$(firewall-cmd --state || true)
+    if [ "$FIREWALL_STATE" == "running" ]; then
+        firewall-cmd --permanent --add-port 8765/tcp
+    fi
+fi
 
 echo 'NETWORKING=yes' > /etc/sysconfig/network
 

--- a/test/guest/rhel-7.setup
+++ b/test/guest/rhel-7.setup
@@ -100,9 +100,12 @@ if [ ! -f "$SKIP_REPO_FLAG" ]; then
     rm -rf /tmp/dep
 fi
 
-yum -y install mock
-useradd -u 2000 -c Builder -G mock builder
-su - builder -c "mock --verbose --installdeps $TEST_SOURCE_PACKAGE"
+# only install mock and build if TEST_SOURCE_PACKAGE is set
+if [ -n "$TEST_SOURCE_PACKAGE" ]; then
+    yum -y install mock
+    useradd -u 2000 -c Builder -G mock builder
+    su - builder -c "mock --verbose --installdeps $TEST_SOURCE_PACKAGE"
+fi
 
 if [ ! -f "$SKIP_REPO_FLAG" ]; then
     subscription-manager unregister

--- a/test/guest/rhel-7.setup
+++ b/test/guest/rhel-7.setup
@@ -102,7 +102,7 @@ fi
 # only install mock and build if TEST_SOURCE_PACKAGE is set
 if [ -n "$TEST_SOURCE_PACKAGE" ]; then
     yum -y install mock
-    useradd -u 2000 -c Builder -G mock builder
+    useradd -c Builder -G mock builder
     su - builder -c "mock --verbose --installdeps $TEST_SOURCE_PACKAGE"
 fi
 
@@ -120,7 +120,7 @@ fi
 
 echo 'NETWORKING=yes' > /etc/sysconfig/network
 
-useradd -u 1000 -c Administrator -G wheel admin
+useradd -c Administrator -G wheel admin
 echo foobar | passwd --stdin admin
 
 # To enable persistent logging

--- a/test/guest/rhel-7.setup
+++ b/test/guest/rhel-7.setup
@@ -9,13 +9,21 @@ set -e
 xfs_growfs /
 df -h /
 
-# Remove any internal files
-rm /etc/yum.repos.d/download.devel.redhat.com.repo
+# If the file /root/.skip_repos is present on the machine,
+# all actions regarding the repositories will be skipped:
+# subscriptions, adding repos, deleting existing entries
+SKIP_REPO_FLAG="/root/.skip_repos"
 
-# register system
-subscription-manager register --auto-attach --username=`cat ~/.rhel/login` --password=`cat ~/.rhel/pass`
-# remove credentials from test machine
-rm -rf ~/.rhel
+if [ ! -f "$SKIP_REPO_FLAG" ]; then
+    # Remove any internal files
+    rm /etc/yum.repos.d/download.devel.redhat.com.repo
+
+    # register system
+    subscription-manager register --auto-attach --username=`cat ~/.rhel/login` --password=`cat ~/.rhel/pass`
+    # remove credentials from test machine
+    rm -rf ~/.rhel
+fi
+
 
 # Only start logging here.  Otherwise the subscription credentials
 # appear in the output above.
@@ -25,16 +33,18 @@ set -x
 yum -y install wget
 cd /etc/yum.repos.d
 
-# Configure repositories.
-#
-# HACK - "htb" doesn't work right now, but we can use "beta".  Once
-# possible, we should do without any beta repositories.
-#
-yum -y --disablerepo=rhel-7-server-htb-rpms install yum-utils
-yum-config-manager --enable rhel-7-server-optional-rpms
-yum-config-manager --enable rhel-7-server-extras-rpms
-yum-config-manager --disable rhel-7-server-htb-rpms
-yum-config-manager --enable rhel-7-server-beta-rpms
+if [ ! -f "$SKIP_REPO_FLAG" ]; then
+    # Configure repositories.
+    #
+    # HACK - "htb" doesn't work right now, but we can use "beta".  Once
+    # possible, we should do without any beta repositories.
+    #
+    yum -y --disablerepo=rhel-7-server-htb-rpms install yum-utils
+    yum-config-manager --enable rhel-7-server-optional-rpms
+    yum-config-manager --enable rhel-7-server-extras-rpms
+    yum-config-manager --disable rhel-7-server-htb-rpms
+    yum-config-manager --enable rhel-7-server-beta-rpms
+fi
 
 yum --nogpgcheck -y update
 
@@ -80,19 +90,23 @@ yum install --nogpgcheck -y $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
 
 # Prepare for building
 
-# enable epel for mock
-mkdir /tmp/dep
-cd /tmp/dep
-wget -T 15 -t 4 http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-rpm -Uvh epel-release-*.rpm
-cd
-rm -rf /tmp/dep
+if [ ! -f "$SKIP_REPO_FLAG" ]; then
+    # enable epel for mock
+    mkdir /tmp/dep
+    cd /tmp/dep
+    wget -T 15 -t 4 http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    rpm -Uvh epel-release-*.rpm
+    cd
+    rm -rf /tmp/dep
+fi
 
 yum -y install mock
 useradd -u 2000 -c Builder -G mock builder
 su - builder -c "mock --verbose --installdeps $TEST_SOURCE_PACKAGE"
 
-subscription-manager unregister
+if [ ! -f "$SKIP_REPO_FLAG" ]; then
+    subscription-manager unregister
+fi
 
 maybe() { if type "$1" >/dev/null 2>&1; then "$@"; fi; }
 

--- a/test/guest/rhel-7.setup
+++ b/test/guest/rhel-7.setup
@@ -31,7 +31,6 @@ fi
 set -x
 
 yum -y install wget
-cd /etc/yum.repos.d
 
 if [ ! -f "$SKIP_REPO_FLAG" ]; then
     # Configure repositories.


### PR DESCRIPTION
Some images are prepared with custom repositories before the
setup script is run.