### PR TITLE
ws: Drain errbuf correctly when no lines are found

### DIFF
--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -1110,11 +1110,12 @@ drain_error_buffer (CockpitSshTransport *self)
       if (len > 0)
           g_printerr ("%s", data);
       g_string_erase (self->errbuf, 0, -1);
+      pos = NULL;
     }
   else
     {
-      /* Drain the remainder */
-      g_string_erase (self->errbuf, 0, pos - self->errbuf->str);
+      /* Drain the stuff that was consumed */
+      g_string_erase (self->errbuf, 0, self->errbuf->len - len);
     }
 }
 


### PR DESCRIPTION
This is a regression introduced in 8beee96e9576c398c331843961d861f2abc69ce8
Fails on certain architectures with a precondition fail in
g_string_erase()