### PR TITLE
realmd: Make sure error message doesn't overflow the dialog.

### DIFF
--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -35,3 +35,9 @@
 .systime-inline .form-group .form-control {
     width: 214px;
 }
+
+/* Make sure error message don't overflow the dialog */
+
+.realms-op-diagnostics {
+    max-width: 550px;
+}


### PR DESCRIPTION
Fixes #3222