### PR TITLE
test: Use /etc/systemd instead of /usr/lib/systemd

### DIFF
--- a/test/check-journal
+++ b/test/check-journal
@@ -34,8 +34,6 @@ class TestJournal(MachineCase):
             # HACK - https://bugzilla.redhat.com/show_bug.cgi?id=1253649
             return
 
-        m.needs_writable_usr()
-
         self.allow_restart_journal_messages()
         self.allow_journal_messages(".*Failed to get realtime timestamp: Cannot assign requested address.*")
 
@@ -75,7 +73,7 @@ class TestJournal(MachineCase):
         # process around for a bit longer after the last line has been
         # output.
         #
-        m.write("/usr/lib/systemd/system/log123.service",
+        m.write("/etc/systemd/system/log123.service",
 """
 [Unit]
 Description=123 different log lines
@@ -84,7 +82,7 @@ Description=123 different log lines
 ExecStart=/bin/sh -c '/usr/bin/seq 123; sleep 10'
 """)
 
-        m.write("/usr/lib/systemd/system/slow10.service",
+        m.write("/etc/systemd/system/slow10.service",
 """
 [Unit]
 Description=Slowly log 10 identical lines

--- a/test/check-pages
+++ b/test/check-pages
@@ -24,8 +24,7 @@ class TestPages(MachineCase):
     def testBasic(self):
         m = self.machine
         b = self.browser
-        m.needs_writable_usr()
-        m.write("/usr/lib/systemd/system/test.service",
+        m.write("/etc/systemd/system/test.service",
 """
 [Unit]
 Description=Test Service

--- a/test/check-services
+++ b/test/check-services
@@ -25,8 +25,7 @@ class TestServices(MachineCase):
         m = self.machine
         b = self.browser
 
-        m.needs_writable_usr()
-        m.write("/usr/lib/systemd/system/test.service",
+        m.write("/etc/systemd/system/test.service",
 """
 [Unit]
 Description=Test Service
@@ -49,7 +48,7 @@ while true; do
   echo WORKING
 done
 """)
-        m.write("/usr/lib/systemd/system/test-fail.service",
+        m.write("/etc/systemd/system/test-fail.service",
 """
 [Unit]
 Description=Failing Test Service
@@ -57,7 +56,7 @@ Description=Failing Test Service
 [Service]
 ExecStart=/usr/bin/false
 """)
-        m.write("/usr/lib/systemd/system/test-template@.service",
+        m.write("/etc/systemd/system/test-template@.service",
 """
 [Unit]
 Description=Test Template for %I
@@ -139,8 +138,7 @@ ExecStart=/usr/bin/test-service %I
         m = self.machine
         b = self.browser
 
-        m.needs_writable_usr()
-        m.write("/usr/lib/systemd/system/test.service",
+        m.write("/etc/systemd/system/test.service",
 """
 [Unit]
 Description=Test Service


### PR DESCRIPTION
This works on Fedora, Debian, and with a read-only /usr.