### PR TITLE
ws: Fix use of g_string_erase() on arm7hl

### DIFF
--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -1109,7 +1109,7 @@ drain_error_buffer (CockpitSshTransport *self)
     {
       if (len > 0)
           g_printerr ("%s", data);
-      g_string_erase (self->errbuf, 0, -1);
+      g_string_erase (self->errbuf, 0, self->errbuf->len);
       pos = NULL;
     }
   else


### PR DESCRIPTION
It seems like we need this in order to pass build on Fedora 23 arm7hl.
Not sure what the deal is exactly, but it's really hard to debug,
and this is equivalent to the previous code, and makes it work.