### PR TITLE
shell: We can always try password auth

### DIFF
--- a/pkg/shell/machine-dialogs.js
+++ b/pkg/shell/machine-dialogs.js
@@ -267,7 +267,7 @@ define([
 
     function can_try_method(methods, method) {
         if (is_method_supported(methods, method))
-            return methods[method] != "not-provided";
+            return method == 'password' || methods[method] != "not-provided";
         return false;
     }
 


### PR DESCRIPTION
Without this change, the "change-auth" trouble shooting dialog would
degrade to the "you have to fix your SSH config" dead-end for systems
that don't support ssh key auth.

For those systems, there would be no method that can_try_method
returns true for.