### PR TITLE
test: Wait for 'data-ready' when entering a page, not 'data-loaded'.

### DIFF
--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -922,13 +922,6 @@ define([
             child.addEventListener("unload", on_unload);
             child.addEventListener("hashchange", on_hashchange);
 
-            /*
-             * Setting the "data-loaded" attribute helps the testsuite
-             * know when it can switch into the frame and inject its
-             * own additions.
-             */
-            frame.setAttribute('data-loaded', '1');
-
             perform_track(child);
             phantom_checkpoint();
 

--- a/test/check-multi-os
+++ b/test/check-multi-os
@@ -112,7 +112,7 @@ class TestMultiOS(MachineCase):
             else:
                 frame = "localhost/shell/shell"
             browser.switch_to_top()
-            browser.wait_present("iframe.container-frame[name='%s'][data-loaded]" % frame)
+            browser.wait_present("iframe.container-frame[name='%s'][data-ready]" % frame)
             browser.wait_visible("iframe.container-frame[name='%s']" % frame)
             browser.switch_to_frame(frame)
             browser.wait_visible('#' + page)
@@ -157,7 +157,7 @@ class TestMultiOS(MachineCase):
         stock_b.switch_to_top()
         stock_b.go("#/@%s/system/index" % dev_m.address)
         stock_b.wait_present("iframe.container-frame[name='%s/system/index']" % dev_m.address)
-        stock_b.wait_present("iframe.container-frame[name='%s/system/index'][data-loaded]" % dev_m.address)
+        stock_b.wait_present("iframe.container-frame[name='%s/system/index'][data-ready]" % dev_m.address)
         stock_b.switch_to_frame('%s/system/index' % dev_m.address)
         stock_b.wait_present("#system_information_hardware_text")
         stock_b.wait_text_not("#system_information_hardware_text", "")
@@ -166,7 +166,7 @@ class TestMultiOS(MachineCase):
         stock_b.switch_to_top()
         stock_b.go("#/@%s" % dev_m.address)
         stock_b.wait_present("iframe.container-frame[name='%s/shell/shell']" % dev_m.address)
-        stock_b.wait_present("iframe.container-frame[name='%s/shell/shell'][data-loaded]" % dev_m.address)
+        stock_b.wait_present("iframe.container-frame[name='%s/shell/shell'][data-ready]" % dev_m.address)
         stock_b.switch_to_frame('%s/shell/shell' % dev_m.address)
         stock_b.wait_present(".curtains")
 

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -126,7 +126,7 @@ class Browser:
 
     def reload(self):
         self.switch_to_top()
-        self.wait_js_cond("ph_select('iframe.container-frame').every(function (e) { return e.getAttribute('data-loaded'); })")
+        self.wait_js_cond("ph_select('iframe.container-frame').every(function (e) { return e.getAttribute('data-ready'); })")
         self.phantom.reload()
 
     def expect_load(self):
@@ -313,7 +313,7 @@ class Browser:
 
         while True:
             try:
-                self.wait_present("iframe.container-frame[name='%s'][data-loaded]" % frame)
+                self.wait_present("iframe.container-frame[name='%s'][data-ready]" % frame)
                 self.wait_not_visible(".curtains")
                 self.wait_visible("iframe.container-frame[name='%s']" % frame)
                 break


### PR DESCRIPTION
The 'data-loaded' attribute is set when the code inside the iframe
opens its transport (usually when the first channel is opened), while
'data-ready' is set when the code declares itself to be ready by
showing its body.

The latter is thus a better indicator when the tests can start to
interact with the page.  The first channel might be opened too early
or the page might be ready without opening any channels.