### PR TITLE
test: Set disk image size during build via env variable

### DIFF
--- a/test/guest/fedora.build
+++ b/test/guest/fedora.build
@@ -28,9 +28,10 @@ fi
 out=$1
 os=$2
 arch=$3
+test -z "$BOOTSTRAP_VOLUME_SIZE" && BOOTSTRAP_VOLUME_SIZE="8G"
 
 virt-builder "$os" \
              --output "$out" \
-             --size 8G \
+             --size $BOOTSTRAP_VOLUME_SIZE \
              --format qcow2 \
              --arch "$arch"


### PR DESCRIPTION
Set a default size for new fedora-like images, but allow
an environment variable as well.

@mvollmer Does it make sense to do this, or should we just make the disk larger? @jscotka had an issue where the 8G image didn't seem to be enough for the build step... They should be created in a sparse fashion anyway, correct?