### PR TITLE
test: Remove known failure (docker logs)

### DIFF
--- a/test/naughty/3174-docker-logs-broken
+++ b/test/naughty/3174-docker-logs-broken
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-docker", line 81, in testBasic
-    self.wait_for_message(message)

--- a/test/naughty/3174-docker-logs-broken-2
+++ b/test/naughty/3174-docker-logs-broken-2
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-docker", line 213, in testExpose
-    self.wait_for_message(message)


### PR DESCRIPTION
The current fedora-23 image has a newer version of docker.
https://bugzilla.redhat.com/show_bug.cgi?id=1281552

Fixes #3174