### PR TITLE
Don't show 'normal' in branding text

### DIFF
--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -87,7 +87,7 @@ define([
             return;
 
         var len, content = style.content;
-        if (content && content != "none") {
+        if (content && content != "none" && content != "normal") {
             len = content.length;
             if ((content[0] === '"' || content[0] === '\'') &&
                 len > 2 && content[len - 1] === content[0])


### PR DESCRIPTION
This shows up on IE as an overlap of the branding image once
logged in.