### PR TITLE
Handle error status == 0 and show a login prompt

### DIFF
--- a/src/static/login.html
+++ b/src/static/login.html
@@ -131,6 +131,8 @@
                         show_login();
                     } else if (xhr.statusText) {
                         fatal(xhr.statusText);
+                    } else if (xhr.status == 0) {
+                        show_login();
                     } else {
                         fatal(xhr.status + " error");
                     }


### PR DESCRIPTION
This happens when we return a Negotiate response that Windows doesn't understand, or doesn't have credentials for. We just fall through to the default behavior of trying to log in.
