### PR TITLE
Prevent browser navigation when clicking shell links

### DIFF
--- a/pkg/dashboard/list.js
+++ b/pkg/dashboard/list.js
@@ -35,6 +35,7 @@ var _ = cockpit.gettext;
 $(document).on("click", "a[data-address]", function(ev) {
     cockpit.jump("/", $(this).attr("data-address"));
     ev.preventDefault();
+    return false;
 });
 
 var common_plot_options = {

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -482,7 +482,7 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
         /* Handles an href link as seen below */
         $(document).on("click", "a[href]", function(ev) {
             var a = this;
-            if (window.location.host === a.host) {
+            if (!a.host || window.location.host === a.host) {
                 self.jump(a.getAttribute('href'));
                 ev.preventDefault();
                 phantom_checkpoint();

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -109,6 +109,7 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
         $("#machine-link").on("click", function(ev) {
             if (machines.list.length == 1) {
                 index.jump({ host: machines.list[0].address, sidebar: true, component: "" });
+                ev.preventDefault();
                 return false;
             }
         });

--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -252,7 +252,13 @@ def main():
     opts = parser.parse_args()
 
     regular_tests = [ "checklogin-basic.py", "checklogin-raw.py" ]
-    browser_tests = [ "selenium-base.py", "selenium-storage.py", "selenium-docker.py", "selenium-sosreport.py" ]
+    browser_tests = [
+        "selenium-base.py",
+        "selenium-navigate.py",
+        "selenium-storage.py",
+        "selenium-docker.py",
+        "selenium-sosreport.py"
+    ]
 
     if opts.regular_tests:
         opts.tests += regular_tests

--- a/test/avocado/selenium-navigate.py
+++ b/test/avocado/selenium-navigate.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+
+# we need to be able to find and import seleniumlib, so add this directory
+import os
+import sys
+
+machine_test_dir = os.path.dirname(os.path.abspath(__file__))
+if not machine_test_dir in sys.path:
+    sys.path.insert(1, machine_test_dir)
+
+from avocado import main
+from seleniumlib import *
+
+class NavigateTestSuite(SeleniumTest):
+    """
+    :avocado: enable
+    """
+    def testNavigateNoReload(self):
+        self.login()
+        self.wait_id("sidebar")
+
+        # Bring up a dialog on system page
+        self.click(self.wait_link('System', cond=clickable))
+        self.wait_frame("system")
+        self.click(self.wait_id('system_information_systime_button', cond=clickable))
+        self.wait_id('system_information_change_systime', cond=visible)
+        self.mainframe()
+
+        # Now navigate to the logs
+        self.click(self.wait_link('Logs', cond=clickable))
+        self.wait_frame("logs")
+        self.wait_id("journal-current-day")
+        self.mainframe()
+
+        # Now navigate back to system page
+        self.click(self.wait_link('System', cond=clickable))
+        self.wait_frame("system")
+        self.wait_id('system_information_change_systime', cond=visible)
+
+        self.error = False
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
These should use pushState, and that doesn't seem to be taking
effect in internet explorer. Lets see if this helps.
