### PR TITLE
Makefile: Older versions of git don't have -C option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -220,7 +220,7 @@ install-data-local:: install-doc-local
 
 dist-hook: dist-doc-hook
 	echo $(VERSION) > $(distdir)/.tarball
-	-(git -C $(srcdir) ls-tree HEAD --name-only -r bower_components/ || echo bower_components/ ) | tar -C $(srcdir) -cf - -T - | tar -C $(distdir) -xvf -
+	-(cd $(srcdir) git ls-tree HEAD --name-only -r bower_components/ || echo bower_components/ ) | tar -C $(srcdir) -cf - -T - | tar -C $(distdir) -xvf -
 
 distcheck-hook: dist-doc-hook
 	$(srcdir)/tools/check-dist $(distdir)

--- a/tools/git-version-gen
+++ b/tools/git-version-gen
@@ -11,7 +11,8 @@ fi
 
 generate() {
 	if [ -d $BASE/../.git ]; then
-		git -C $BASE/.. describe | sed 's/-[0-9]\+-g.*/.x/'
+        cd $BASE/..
+		git describe | sed 's/-[0-9]\+-g.*/.x/'
 	else
 		cat $1
 	fi


### PR DESCRIPTION
The older versions of git don't have a -C option. You can see this
on Travis:

Unknown option: -C