### PR TITLE
tools: Suppress valgrind errors during exit()

### DIFF
--- a/tools/unknown.supp
+++ b/tools/unknown.supp
@@ -437,3 +437,11 @@
    ...
    fun:getaddrinfo
 }
+{
+   libc_freeres
+   Memcheck:Free
+   fun:free
+   fun:__libc_freeres
+   ...
+   fun:exit
+}


### PR DESCRIPTION
```
Invalid free() / delete / delete[] / realloc()
  at 0x4C2BDEC: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
  by 0x5EB043B: __libc_freeres (in /lib/x86_64-linux-gnu/libc-2.19.so)
  by 0x4A256BC: _vgnU_freeres (in /usr/lib/valgrind/vgpreload_core-amd64-linux.so)
  by 0x5D864CA: __run_exit_handlers (exit.c:97)
  by 0x5D86554: exit (exit.c:104)
  by 0x5D6BECB: (below main) (libc-start.c:321)
Address 0x61093c0 is 0 bytes inside data symbol "noai6ai_cached"
```