### PR TITLE
Make check-verify respect its image argument

### DIFF
--- a/test/check-verify
+++ b/test/check-verify
@@ -158,7 +158,7 @@ def main():
     name = "test"
     revision = None
     badge = False
-    context = None
+    context = opts.image or testinfra.DEFAULT_IMAGE
 
     os.chdir(os.path.dirname(__file__))
 
@@ -201,8 +201,6 @@ def main():
 
     if not revision:
         revision = subprocess.check_output([ "git", "rev-parse", "HEAD" ]).strip()
-    if not context:
-        context = testinfra.DEFAULT_IMAGE
 
     if opts.publish:
         sink = start_publishing(github, opts.publish, name, revision, context)


### PR DESCRIPTION
Even when not scanning github we should respect any image
passed in on the command line, and prefer it to TEST_OS