### PR TITLE
test: Add ability to trigger verification after review

### DIFF
--- a/test/trigger-verify
+++ b/test/trigger-verify
@@ -12,10 +12,35 @@ def main():
     parser.add_argument('-f', '--force',
                         help='Force setting the status even if the program logic thinks it shouldn''t be done',
                         action="store_true")
+    parser.add_argument('image', action='store', nargs='?',
+                        help='The operating system image to verify against')
     opts = parser.parse_args()
 
     github = testinfra.GitHub()
-    github.trigger(pull_number = opts.pull, force = opts.force)
+
+    context = opts.image or testinfra.DEFAULT_IMAGE
+    sys.stderr.write("triggering pull {0} for context {1}\n".format(opts.pull, context))
+    pull = github.get("pulls/" + opts.pull)
+
+    # triggering is manual, so don't prevent triggering a user that isn't on the whitelist
+    # but issue a warning in case of an oversight
+    login = pull["head"]["user"]["login"]
+    if login not in github.whitelist:
+        sys.stderr.write("warning: pull request author '{0}' isn't in github-whitelist.\n".format(login))
+
+    revision = pull['head']['sha']
+    statuses = github.statuses(revision)
+    status = statuses.get(context, { })
+    if status.get("state", "empty") not in ["empty", "error", "failure"]:
+        if opts.force:
+            sys.stderr.write("Pull request isn't in error state, but forcing update.\n")
+        else:
+            sys.stderr.write("Pull request isn't in error state. Status is: '{0}'\n".format(status["state"]))
+            return 1
+
+    changes = { "state": "pending", "description": testinfra.NOT_TESTED, "context": context }
+    github.post("statuses/" + revision, changes)
+    return 0
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
We can use the ```test/trigger-verify``` to trigger pull requests that the verifiers don't pick up automatically.

Also move the tool style logic out of testinfra, that's really for shared code.