### PR TITLE
Enable weak dependencies for F24+

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -82,17 +82,48 @@ BuildRequires: krb5-server
 # For documentation
 BuildRequires: xmlto
 
+# == Mandatory components of cockpit == #
+
 Requires: %{name}-bridge = %{version}-%{release}
-Requires: %{name}-networkmanager = %{version}-%{release}
 Requires: %{name}-ws = %{version}-%{release}
 Requires: %{name}-shell = %{version}-%{release}
-Requires: %{name}-storaged = %{version}-%{release}
-%ifarch x86_64 armv7hl
-Requires: %{name}-docker = %{version}-%{release}
-%endif
+
+
 %if 0%{?rhel}
 Requires: %{name}-subscriptions = %{version}-%{release}
 %endif
+
+# == Optional components == #
+
+# Fedora 24+ supports "soft" dependencies
+%if 0%{?fedora} >= 24 || 0%{?rhel} >= 8
+
+Recommends: %{name}-networkmanager = %{version}-%{release}
+Recommends: %{name}-storaged = %{version}-%{release}
+
+%ifarch x86_64 armv7hl
+Recommends: %{name}-docker = %{version}-%{release}
+%endif
+
+# Suggests: are components that may provide additional
+# functionality in some environments, but are not common
+# enough to be installed by default. Packaging tools may
+# present these as a list of optional things the user
+# may wish to install.
+Suggests: %{name}-pcp = %{version}-%{release}
+Suggests: %{name}-kubernetes = %{version}-%{release}
+
+# Older releases need to have strict requirements
+%else
+Requires: %{name}-networkmanager = %{version}-%{release}
+Requires: %{name}-storaged = %{version}-%{release}
+
+%ifarch x86_64 armv7hl
+Requires: %{name}-docker = %{version}-%{release}
+%endif
+
+%endif
+
 
 %description
 Cockpit runs in a browser and can manage your network of GNU/Linux


### PR DESCRIPTION
This will allow us to install cockpit's standard capabilities with the `cockpit` meta-package, but remove some unneeded pieces without removing the meta-package.