### PR TITLE
test: Add another case of the known issues around wipefs

### DIFF
--- a/test/naughty/2938-wipefs-no-such-file-or-directory
+++ b/test/naughty/2938-wipefs-no-such-file-or-directory
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-storage-luks", line 53, in testLuks
+    "mount_point": mount_point_secret })


### PR DESCRIPTION
The actual error is:

Error wiping newly created partition /dev/sda1: Command-line `wipefs -a
"/dev/sda1"' exited with non-zero exit status 1: wipefs: error: /dev/sda1:
probing initialization failed: No such file or directory

Issue #2938