### PR TITLE
Include host name at beginning of testing log

### DIFF
--- a/test/check-verify
+++ b/test/check-verify
@@ -217,7 +217,7 @@ def main():
     testinfra.DEFAULT_IMAGE = context
     os.environ["TEST_OS"] = context
 
-    sys.stderr.write("Testing {0} for {1} on {2} ...\n".format(revision, name, context))
+    sys.stderr.write("Testing {0} for {1} with {2} on {3}...\n".format(revision, name, context, testinfra.HOSTNAME))
 
     try:
         if opts.rebase:


### PR DESCRIPTION
So that we know where install problems happen.