### PR TITLE
Add cockpit-stub 

### DIFF
--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -1,17 +1,39 @@
 
 noinst_LIBRARIES += \
+	libcockpit-stub.a \
 	libcockpit-bridge.a \
 	$(NULL)
 
-libcockpit_bridge_a_SOURCES = \
+libcockpit_stub_a_SOURCES = \
 	src/bridge/cockpitbridge.c \
 	src/bridge/cockpitbridge.h \
+	src/bridge/cockpitchannel.c \
+	src/bridge/cockpitchannel.h \
+	src/bridge/cockpitechochannel.c \
+	src/bridge/cockpitechochannel.h \
+	src/bridge/cockpithttpstream.c \
+	src/bridge/cockpithttpstream.h \
+	src/bridge/cockpitinteracttransport.c \
+	src/bridge/cockpitinteracttransport.h \
+	src/bridge/cockpitpackages.c \
+	src/bridge/cockpitpackages.h \
+	src/bridge/cockpitpaths.c \
+	src/bridge/cockpitpaths.h \
+	src/bridge/cockpitnullchannel.c \
+	src/bridge/cockpitnullchannel.h \
+	$(NULL)
+
+libcockpit_stub_a_CFLAGS = \
+	-I$(srcdir)/src/bridge \
+	-DG_LOG_DOMAIN=\"cockpit-bridge\" \
+	$(COCKPIT_CFLAGS) \
+	$(NULL)
+
+libcockpit_bridge_a_SOURCES = \
 	src/bridge/cockpitblocksamples.c \
 	src/bridge/cockpitblocksamples.h \
 	src/bridge/cockpitcgroupsamples.c \
 	src/bridge/cockpitcgroupsamples.h \
-	src/bridge/cockpitchannel.c \
-	src/bridge/cockpitchannel.h \
 	src/bridge/cockpitcpusamples.c \
 	src/bridge/cockpitcpusamples.h \
 	src/bridge/cockpitdbuscache.c \
@@ -27,18 +49,8 @@ libcockpit_bridge_a_SOURCES = \
 	src/bridge/cockpitdbususer.c \
 	src/bridge/cockpitdisksamples.c \
 	src/bridge/cockpitdisksamples.h \
-	src/bridge/cockpitechochannel.c \
-	src/bridge/cockpitechochannel.h \
-	src/bridge/cockpithttpstream.c \
-	src/bridge/cockpithttpstream.h \
-	src/bridge/cockpitinteracttransport.c \
-	src/bridge/cockpitinteracttransport.h \
-	src/bridge/cockpitpackages.c \
-	src/bridge/cockpitpackages.h \
 	src/bridge/cockpitinternalmetrics.c \
 	src/bridge/cockpitinternalmetrics.h \
-	src/bridge/cockpitpaths.c \
-	src/bridge/cockpitpaths.h \
 	src/bridge/cockpitpipechannel.c \
 	src/bridge/cockpitpipechannel.h \
 	src/bridge/cockpitpolkitagent.c \
@@ -55,8 +67,6 @@ libcockpit_bridge_a_SOURCES = \
 	src/bridge/cockpitnetdevsamples.h \
 	src/bridge/cockpitnetworksamples.c \
 	src/bridge/cockpitnetworksamples.h \
-	src/bridge/cockpitnullchannel.c \
-	src/bridge/cockpitnullchannel.h \
 	src/bridge/cockpitsamples.c \
 	src/bridge/cockpitsamples.h \
 	src/bridge/cockpitfsread.c \
@@ -75,8 +85,16 @@ libcockpit_bridge_a_CFLAGS = \
 	$(COCKPIT_BRIDGE_CFLAGS) \
 	$(NULL)
 
+libcockpit_stub_LIBS = \
+	libcockpit-stub.a \
+	libcockpit-common.a \
+	libwebsocket.a \
+	$(COCKPIT_LIBS) \
+	$(NULL)
+
 libcockpit_bridge_LIBS = \
 	libcockpit-bridge.a \
+	libcockpit-stub.a \
 	libcockpit-common.a \
 	libwebsocket.a \
 	$(COCKPIT_BRIDGE_LIBS) \
@@ -98,6 +116,16 @@ cockpit_bridge_LDADD = $(libcockpit_bridge_LIBS)
 cockpit_polkit_SOURCES = src/bridge/cockpitpolkithelper.c
 cockpit_polkit_CFLAGS = $(COCKPIT_POLKIT_CFLAGS)
 cockpit_polkit_LDADD = libreauthorize.a $(REAUTHORIZE_LIBS) $(COCKPIT_POLKIT_LIBS)
+
+libexec_PROGRAMS += cockpit-stub
+
+cockpit_stub_SOURCES = src/bridge/stub.c
+cockpit_stub_CFLAGS = \
+	-I$(srcdir)/src/bridge \
+	-DG_LOG_DOMAIN=\"cockpit-bridge\" \
+	$(COCKPIT_CFLAGS) \
+	$(NULL)
+cockpit_stub_LDADD = $(libcockpit_stub_LIBS)
 
 # polkit-agent-helper-1 need to be setuid root because polkit wants
 # responses to come from a root process
@@ -209,6 +237,8 @@ libexec_PROGRAMS += cockpit-pcp
 noinst_LIBRARIES += libcockpit-pcp.a
 
 libcockpit_pcp_a_SOURCES = \
+	src/bridge/cockpitbridge.c \
+	src/bridge/cockpitbridge.h \
 	src/bridge/cockpitchannel.c \
 	src/bridge/cockpitchannel.h \
 	src/bridge/cockpitmetrics.c \

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -4,6 +4,8 @@ noinst_LIBRARIES += \
 	$(NULL)
 
 libcockpit_bridge_a_SOURCES = \
+	src/bridge/cockpitbridge.c \
+	src/bridge/cockpitbridge.h \
 	src/bridge/cockpitblocksamples.c \
 	src/bridge/cockpitblocksamples.h \
 	src/bridge/cockpitcgroupsamples.c \

--- a/src/bridge/cockpitbridge.c
+++ b/src/bridge/cockpitbridge.c
@@ -1,0 +1,308 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitchannel.h"
+#include "cockpitbridge.h"
+
+#include "common/cockpitjson.h"
+#include "common/cockpittransport.h"
+
+struct _CockpitBridge {
+  GObjectClass parent;
+
+  gboolean init_received;
+  gulong signal_id;
+
+  CockpitTransport *transport;
+
+  GHashTable *payloads;
+  GHashTable *channels;
+};
+
+struct _CockpitBridgeClass {
+  GObjectClass parent_class;
+};
+
+G_DEFINE_TYPE (CockpitBridge, cockpit_bridge, G_TYPE_OBJECT);
+
+enum {
+  PROP_0,
+  PROP_TRANSPORT,
+  PROP_INIT_RECEIVED,
+};
+
+typedef GType (* TypeFunction) (void);
+
+static void
+on_channel_closed (CockpitChannel *channel,
+                   const gchar *problem,
+                   gpointer user_data)
+{
+  CockpitBridge *self = user_data;
+  g_hash_table_remove (self->channels, cockpit_channel_get_id (channel));
+}
+
+static void
+process_init (CockpitBridge *self,
+              CockpitTransport *transport,
+              JsonObject *options)
+{
+  gint64 version = -1;
+
+  if (!cockpit_json_get_int (options, "version", -1, &version))
+    {
+      g_warning ("invalid version field in init message");
+      cockpit_transport_close (transport, "protocol-error");
+    }
+
+  if (version == 1)
+    {
+      g_debug ("received init message");
+      self->init_received = TRUE;
+    }
+  else
+    {
+      g_message ("unsupported version of cockpit protocol: %" G_GINT64_FORMAT, version);
+      cockpit_transport_close (transport, "not-supported");
+    }
+}
+
+static void
+process_open (CockpitBridge *self,
+              CockpitTransport *transport,
+              const gchar *channel_id,
+              JsonObject *options)
+{
+  CockpitChannel *channel;
+  GType channel_type;
+  TypeFunction channel_function = NULL;
+  const gchar *payload;
+
+  if (!channel_id)
+    {
+      g_warning ("Caller tried to open channel with invalid id");
+      cockpit_transport_close (transport, "protocol-error");
+    }
+  else if (g_hash_table_lookup (self->channels, channel_id))
+    {
+      g_warning ("%s: caller tried to reuse a channel that's already in use", channel_id);
+      cockpit_transport_close (transport, "protocol-error");
+    }
+
+  else
+    {
+      if (!cockpit_json_get_string (options, "payload", NULL, &payload))
+        payload = NULL;
+
+      /* This will close with "not-supported" */
+      channel_type = COCKPIT_TYPE_CHANNEL;
+
+      channel_function = g_hash_table_lookup (self->payloads, payload);
+      if (channel_function != NULL)
+          channel_type = channel_function ();
+
+      channel = g_object_new (channel_type,
+                              "transport", transport,
+                              "id", channel_id,
+                              "options", options,
+                              NULL);
+      g_hash_table_insert (self->channels, g_strdup (channel_id), channel);
+      g_signal_connect (channel, "closed", G_CALLBACK (on_channel_closed), self);
+    }
+}
+
+static gboolean
+on_transport_control (CockpitTransport *transport,
+                      const char *command,
+                      const gchar *channel_id,
+                      JsonObject *options,
+                      GBytes *message,
+                      gpointer user_data)
+{
+  CockpitBridge *self = user_data;
+
+  if (g_str_equal (command, "init"))
+    {
+      process_init (self, transport, options);
+      return TRUE;
+    }
+
+  if (!self->init_received)
+    {
+      g_warning ("caller did not send 'init' message first");
+      cockpit_transport_close (transport, "protocol-error");
+      return TRUE;
+    }
+
+  if (g_str_equal (command, "open"))
+    {
+      process_open (self, transport, channel_id, options);
+      return TRUE;
+    }
+  else if (g_str_equal (command, "close"))
+    {
+      if (!channel_id)
+        {
+          g_warning ("Caller tried to close channel without an id");
+          cockpit_transport_close (transport, "protocol-error");
+        }
+      else
+        {
+          /*
+           * The channel may no longer exist due to a race of the bridge closing
+           * a channel and the web closing it at the same time.
+           */
+
+          g_debug ("already closed channel %s", channel_id);
+        }
+    }
+
+  return FALSE;
+}
+
+static void
+cockpit_bridge_init (CockpitBridge *self)
+{
+  /* Owns the channels */
+  self->channels = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+  self->payloads = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, NULL);
+}
+
+static void
+cockpit_bridge_dispose (GObject *object)
+{
+  CockpitBridge *self = COCKPIT_BRIDGE (object);
+
+  if (self->signal_id)
+    {
+      g_signal_handler_disconnect (self->transport, self->signal_id);
+      self->signal_id = 0;
+    }
+}
+
+static void
+cockpit_bridge_finalize (GObject *object)
+{
+  CockpitBridge *self = COCKPIT_BRIDGE (object);
+
+  if (self->transport)
+    g_object_unref (self->transport);
+
+  g_hash_table_destroy (self->channels);
+  g_hash_table_destroy (self->payloads);
+
+  G_OBJECT_CLASS (cockpit_bridge_parent_class)->finalize (object);
+}
+
+static void
+cockpit_bridge_set_property (GObject *obj,
+                             guint prop_id,
+                             const GValue *value,
+                             GParamSpec *pspec)
+{
+  CockpitBridge *self = COCKPIT_BRIDGE (obj);
+
+  switch (prop_id)
+    {
+    case PROP_INIT_RECEIVED:
+      self->init_received = g_value_get_boolean (value);
+      break;
+    case PROP_TRANSPORT:
+      self->transport = g_value_dup_object (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (obj, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+cockpit_bridge_constructed (GObject *object)
+{
+  CockpitBridge *self = COCKPIT_BRIDGE (object);
+
+  G_OBJECT_CLASS (cockpit_bridge_parent_class)->constructed (object);
+
+  g_return_if_fail (self->transport != NULL);
+
+  self->signal_id = g_signal_connect (self->transport, "control",
+                                      G_CALLBACK (on_transport_control),
+                                      self);
+}
+
+static void
+cockpit_bridge_class_init (CockpitBridgeClass *class)
+{
+  GObjectClass *object_class;
+
+  object_class = G_OBJECT_CLASS (class);
+  object_class->set_property = cockpit_bridge_set_property;
+  object_class->finalize = cockpit_bridge_finalize;
+  object_class->dispose = cockpit_bridge_dispose;
+  object_class->constructed = cockpit_bridge_constructed;
+
+  g_object_class_install_property (object_class, PROP_TRANSPORT,
+                                   g_param_spec_object ("transport", "transport", "transport",
+                                                        COCKPIT_TYPE_TRANSPORT,
+                                                        G_PARAM_WRITABLE |
+                                                        G_PARAM_CONSTRUCT_ONLY |
+                                                        G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (object_class, PROP_INIT_RECEIVED,
+                                   g_param_spec_boolean ("init-received", NULL,
+                                                         NULL, FALSE,
+                                                         G_PARAM_WRITABLE |
+                                                         G_PARAM_CONSTRUCT_ONLY |
+                                                         G_PARAM_STATIC_STRINGS));
+}
+
+static gboolean
+cockpit_bridge_add_payload (CockpitBridge *self,
+                            const gchar *type,
+                            TypeFunction channel_function)
+{
+  return g_hash_table_insert (self->payloads, (gchar *) type,
+                              channel_function);
+}
+
+CockpitBridge *
+cockpit_bridge_new (CockpitTransport *transport,
+                    CockpitPayloadType *payload_types,
+                    gboolean init_received)
+{
+  gint i;
+  CockpitBridge *bridge;
+
+  g_return_val_if_fail (transport != NULL, NULL);
+
+  bridge = g_object_new (COCKPIT_TYPE_BRIDGE,
+                         "transport", transport,
+                         "init-received", init_received,
+                         NULL);
+
+  for (i = 0; payload_types[i].name != NULL; i++)
+    {
+      cockpit_bridge_add_payload (bridge, payload_types[i].name,
+                                  payload_types[i].function);
+    }
+
+  return bridge;
+}

--- a/src/bridge/cockpitbridge.h
+++ b/src/bridge/cockpitbridge.h
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __COCKPIT_BRIDGE_H__
+#define __COCKPIT_BRIDGE_H__
+
+#include "common/cockpittransport.h"
+
+G_BEGIN_DECLS
+
+typedef struct {
+  const gchar *name;
+  GType (* function) (void);
+} CockpitPayloadType;
+
+#define         COCKPIT_TYPE_BRIDGE           (cockpit_bridge_get_type ())
+#define         COCKPIT_BRIDGE(o)            (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_BRIDGE, CockpitBridge))
+#define         COCKPIT_BRIDGE_GET_CLASS(o)   (G_TYPE_INSTANCE_GET_CLASS ((o), COCKPIT_TYPE_BRIDGE, CockpitAuthClass))
+#define         COCKPIT_IS_BRIDGE_CLASS(k)    (G_TYPE_CHECK_CLASS_TYPE ((k), COCKPIT_TYPE_BRIDGE))
+#define         COCKPIT_IS_BRIDGE(o)          (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_BRIDGE))
+
+typedef struct _CockpitBridge        CockpitBridge;
+typedef struct _CockpitBridgeClass   CockpitBridgeClass;
+
+GType           cockpit_bridge_get_type     (void) G_GNUC_CONST;
+
+CockpitBridge * cockpit_bridge_new          (CockpitTransport *transport,
+                                             CockpitPayloadType *supported_payloads,
+                                             gboolean init_received);
+
+G_END_DECLS
+
+#endif /* __COCKPIT_CHANNEL_H__ */

--- a/src/bridge/stub.c
+++ b/src/bridge/stub.c
@@ -1,0 +1,271 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "config.h"
+
+#include "cockpitbridge.h"
+#include "cockpitchannel.h"
+#include "cockpitechochannel.h"
+#include "cockpitinteracttransport.h"
+#include "cockpithttpstream.h"
+#include "cockpitnullchannel.h"
+#include "cockpitpackages.h"
+
+#include "common/cockpittransport.h"
+#include "common/cockpitassets.h"
+#include "common/cockpitjson.h"
+#include "common/cockpitlog.h"
+#include "common/cockpitpipetransport.h"
+#include "common/cockpittest.h"
+#include "common/cockpitunixfd.h"
+#include "common/cockpitwebresponse.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <glib-unix.h>
+#include <glib/gstdio.h>
+
+/* This program is is meant to be used in place of cockpit-bridge
+ * in non-system setting. As such only payloads that make no changes
+ * to the system or support their own forms of authentication (ei: http)
+ * should be included here.
+ */
+
+static CockpitPackages *packages;
+
+static CockpitPayloadType payload_types[] = {
+  { "http-stream1", cockpit_http_stream_get_type },
+  { "http-stream2", cockpit_http_stream_get_type },
+  { "null", cockpit_null_channel_get_type },
+  { "echo", cockpit_echo_channel_get_type },
+  { NULL },
+};
+
+static void
+on_closed_set_flag (CockpitTransport *transport,
+                    const gchar *problem,
+                    gpointer user_data)
+{
+  gboolean *flag = user_data;
+  *flag = TRUE;
+}
+
+static void
+send_init_command (CockpitTransport *transport)
+{
+  const gchar *checksum;
+  JsonObject *object;
+  GBytes *bytes;
+
+  object = json_object_new ();
+  json_object_set_string_member (object, "command", "init");
+  json_object_set_int_member (object, "version", 1);
+
+  checksum = cockpit_packages_get_checksum (packages);
+  if (checksum)
+    json_object_set_string_member (object, "checksum", checksum);
+
+  bytes = cockpit_json_write_bytes (object);
+  json_object_unref (object);
+
+  cockpit_transport_send (transport, NULL, bytes);
+  g_bytes_unref (bytes);
+}
+
+static gboolean
+on_signal_done (gpointer data)
+{
+  gboolean *closed = data;
+  *closed = TRUE;
+  return TRUE;
+}
+
+static int
+run_bridge (const gchar *interactive)
+{
+  CockpitTransport *transport;
+  CockpitBridge *bridge;
+  gboolean terminated = FALSE;
+  gboolean interupted = FALSE;
+  gboolean closed = FALSE;
+  gboolean init_received = FALSE;
+  guint sig_term;
+  guint sig_int;
+  int outfd;
+
+  cockpit_set_journal_logging (G_LOG_DOMAIN, !isatty (2));
+
+  /*
+   * This process talks on stdin/stdout. However lots of stuff wants to write
+   * to stdout, such as g_debug, and uses fd 1 to do that. Reroute fd 1 so that
+   * it goes to stderr, and use another fd for stdout.
+   */
+
+  outfd = dup (1);
+  if (outfd < 0 || dup2 (2, 1) < 1)
+    {
+      g_warning ("bridge couldn't redirect stdout to stderr");
+      outfd = 1;
+    }
+
+  sig_term = g_unix_signal_add (SIGTERM, on_signal_done, &terminated);
+  sig_int = g_unix_signal_add (SIGINT, on_signal_done, &interupted);
+
+  g_type_init ();
+
+  packages = cockpit_packages_new ();
+
+  if (interactive)
+    {
+      /* Allow skipping the init message when interactive */
+      init_received = TRUE;
+      transport = cockpit_interact_transport_new (0, outfd, interactive);
+    }
+  else
+    {
+      transport = cockpit_pipe_transport_new_fds ("stdio", 0, outfd);
+    }
+
+  g_resources_register (cockpitassets_get_resource ());
+  cockpit_web_failure_resource = "/org/cockpit-project/Cockpit/fail.html";
+
+  bridge = cockpit_bridge_new (transport, payload_types, init_received);
+  g_signal_connect (transport, "closed", G_CALLBACK (on_closed_set_flag), &closed);
+  send_init_command (transport);
+
+  while (!terminated && !closed && !interupted)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_object_unref (bridge);
+  g_object_unref (transport);
+  cockpit_packages_free (packages);
+  packages = NULL;
+
+  g_source_remove (sig_term);
+  g_source_remove (sig_int);
+
+  /* So the caller gets the right signal */
+  if (terminated)
+    raise (SIGTERM);
+
+  return 0;
+}
+
+static void
+print_version (void)
+{
+  gint i, offset, len;
+
+  g_print ("Version: %s\n", PACKAGE_VERSION);
+  g_print ("Protocol: 1\n");
+
+  g_print ("Payloads: ");
+  offset = 10;
+  for (i = 0; payload_types[i].name != NULL; i++)
+    {
+      len = strlen (payload_types[i].name);
+      if (offset + len > 70)
+        {
+          g_print ("\n");
+          offset = 0;
+        }
+
+      if (offset == 0)
+        {
+          g_print ("    ");
+          offset = 4;
+        };
+
+      g_print ("%s ", payload_types[i].name);
+      offset += len + 1;
+    }
+}
+
+int
+main (int argc,
+      char **argv)
+{
+  GOptionContext *context;
+  GError *error = NULL;
+  int ret;
+
+  static gboolean opt_packages = FALSE;
+  static gboolean opt_version = FALSE;
+  static gchar *opt_interactive = NULL;
+
+  static GOptionEntry entries[] = {
+    { "interact", 0, 0, G_OPTION_ARG_STRING, &opt_interactive, "Interact with the raw protocol", "boundary" },
+    { "packages", 0, 0, G_OPTION_ARG_NONE, &opt_packages, "Show Cockpit package information", NULL },
+    { "version", 0, 0, G_OPTION_ARG_NONE, &opt_version, "Show Cockpit version information", NULL },
+    { NULL }
+  };
+
+  signal (SIGPIPE, SIG_IGN);
+
+  /* Debugging issues during testing */
+#if WITH_DEBUG
+  signal (SIGABRT, cockpit_test_signal_backtrace);
+  signal (SIGSEGV, cockpit_test_signal_backtrace);
+#endif
+
+  g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
+  g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
+  g_setenv ("GIO_USE_VFS", "local", TRUE);
+
+  context = g_option_context_new (NULL);
+  g_option_context_add_main_entries (context, entries, NULL);
+  g_option_context_set_description (context,
+                                    "cockpit-stub provides a limited number of channels and is meant to be"
+                                    "used in place of cockpit-bridge in non-system setting. When\n"
+                                    "run from the command line one of the options above must be specified.\n");
+
+  g_option_context_parse (context, &argc, &argv, &error);
+  g_option_context_free (context);
+
+  if (error)
+    {
+      g_printerr ("cockpit-stub: %s\n", error->message);
+      g_error_free (error);
+      return 1;
+    }
+
+  if (opt_packages)
+    {
+      cockpit_packages_dump ();
+      return 0;
+    }
+  else if (opt_version)
+    {
+      print_version ();
+      return 0;
+    }
+
+  if (!opt_interactive && isatty (1))
+    {
+      g_printerr ("cockpit-stub: no option specified\n");
+      return 2;
+    }
+
+  ret = run_bridge (opt_interactive);
+
+  g_free (opt_interactive);
+  return ret;
+}

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -295,6 +295,7 @@ cat subscriptions.list docker.list networkmanager.list >> shell.list
 %{_sbindir}/remotectl
 %{_libdir}/security/pam_ssh_add.so
 %{_libexecdir}/cockpit-ws
+%{_libexecdir}/cockpit-stub
 %attr(4750, root, cockpit-ws) %{_libexecdir}/cockpit-session
 %attr(775, -, wheel) %{_localstatedir}/lib/%{name}
 %{_datadir}/%{name}/static


### PR DESCRIPTION
Provides a limited bridge that can be used with logins mechanisms that don't tie back to a user to a real system user with a shell.

This was the best name i came up with, but i'm not really happy with it. Any other ideas?