### PR TITLE
Polish image expiry, retrival, vm-prep etc.

### DIFF
--- a/VERIFY
+++ b/VERIFY
@@ -2,4 +2,8 @@
 
 set -e
 
+if ! $IP address show dev cockpit1 > /dev/null 2> /dev/null; then
+  sudo ./vm-prep
+fi
+
 $(dirname $0)/test/check-verify --install "$@"

--- a/test/testinfra.py
+++ b/test/testinfra.py
@@ -56,6 +56,9 @@ TESTING = "Testing in progress"
 NOT_TESTED = "Not yet tested"
 NO_TESTING = "Manual testing required"
 
+# Days after which images expire if not in use
+IMAGE_EXPIRE = 14
+
 __all__ = (
     'Sink',
     'GitHub',
@@ -63,7 +66,8 @@ __all__ = (
     'DEFAULT_IMAGE',
     'HOSTNAME',
     'TESTING',
-    'NOT_TESTED'
+    'NOT_TESTED',
+    'IMAGE_EXPIRE',
 )
 
 def arg_parser():

--- a/test/testsuite-prepare
+++ b/test/testsuite-prepare
@@ -46,10 +46,6 @@ require_binary() {
   fi
 }
 
-if ! silent $IP address show dev cockpit1; then
-  sudo ./vm-prep
-fi
-
 # The Atomic variants can't build their own packages, so we build in
 # their non-Atomic siblings.  For example, fedora-atomic is build
 # in fedora-22.

--- a/test/vm-create
+++ b/test/vm-create
@@ -27,11 +27,14 @@
 import argparse
 import guestfs
 import os
+import shutil
 import subprocess
 import sys
 
 import testvm
 import testinfra
+
+BASE = os.path.dirname(__file__)
 
 parser = argparse.ArgumentParser(description='Create a virtual machine image')
 parser.add_argument('-v', '--verbose', action='store_true', help='Display verbose progress details')
@@ -97,7 +100,7 @@ class MachineBuilder:
         if self.machine.verbose:
             gf.set_trace(1)
         try:
-            gf.add_drive_opts(self.machine._image_image, readonly=False)
+            gf.add_drive_opts(self.machine.image_file, readonly=False)
             gf.launch()
             # try to mount device directly
             devices = gf.list_devices()
@@ -131,11 +134,11 @@ class MachineBuilder:
 
         bootstrap_script = "./guest/%s.bootstrap" % (self.machine.image, )
 
-        if os.path.exists(self.machine._image_image):
-            os.unlink(self.machine._image_image)
+        if os.path.exists(self.machine.image_file):
+            os.unlink(self.machine.image_file)
 
         if os.path.isfile(bootstrap_script):
-            subprocess.check_call([ bootstrap_script, self.machine._image_image ])
+            subprocess.check_call([ bootstrap_script, self.machine.image_file ])
         else:
             raise testvm.Failure("Unsupported OS %s: %s not found." % (self.machine.image, bootstrap_script))
 
@@ -218,12 +221,47 @@ class MachineBuilder:
 
         self.run_selinux_relabel()
 
+    def save(self):
+        data_dir = os.path.join(os.environ.get("TEST_DATA", self.machine.test_dir), "images")
+        images_dir = os.path.join(self.machine.test_dir, "images")
+
+        if not os.path.exists(data_dir):
+            os.makedirs(data_dir, 0750)
+
+        if not os.path.exists(self.machine.image_file):
+            raise Failure("Nothing to save.")
+
+        partial = os.path.join(data_dir, self.machine.image + ".partial")
+
+        # Copy image via convert, to make it sparse again
+        subprocess.check_call([ "qemu-img", "convert", "-O", "qcow2", self.machine.image_file, partial ])
+
+        # Hash the image here
+        (sha, x1, x2) = subprocess.check_output([ "sha1sum", partial ]).partition(" ")
+        if not sha:
+            raise Failure("sha1sum returned invalid output")
+
+        name = self.machine.image + "-" + sha + ".qcow2"
+        data_file = os.path.join(data_dir, name)
+        shutil.move(partial, data_file)
+
+        # Update the images symlink
+        if os.path.islink(self.machine.image_base):
+            os.unlink(self.machine.image_base)
+        os.symlink(name, self.machine.image_base)
+
+        # Handle alternate TEST_DATA
+        image_file = os.path.join(images_dir, name)
+        if not os.path.exists(image_file):
+            os.symlink(os.path.abspath(data_file), image_file)
+
 try:
+    os.chdir(BASE)
     machine = testvm.VirtMachine(verbose=args.verbose, image=args.image)
     builder = MachineBuilder(machine)
     builder.build()
     if not args.no_save:
-        machine.save()
+        builder.save()
 except testvm.Failure, ex:
     print >> sys.stderr, "vm-create:", ex
     sys.exit(1)

--- a/test/vm-download
+++ b/test/vm-download
@@ -84,6 +84,11 @@ def download(image, force, stores):
     os.close(fd)
     shutil.move(temp, dest)
 
+    # Handle alternate TEST_DATA
+    image_file = os.path.join(IMAGES, os.readlink(link))
+    if not os.path.exists(image_file):
+        os.symlink(os.path.abspath(dest), image_file)
+
 def prune():
     targets = []
     for filename in os.listdir(IMAGES):

--- a/test/vm-download
+++ b/test/vm-download
@@ -33,13 +33,7 @@ IMAGES = os.path.join(BASE, "images")
 DATA = os.path.join(os.environ.get("TEST_DATA", BASE), "images")
 DEVNULL = open("/dev/null", "r+")
 
-#
-# To override the location per operating system you can define variables like this:
-#
-# TEST_IMAGES=http://example.com/default/
-# TEST_IMAGES_FEDORA=https://myserver.com/fedora/
-#
-
+CONFIG = "~/.config/image-stores"
 DEFAULT = "https://fedorapeople.org/groups/cockpit/images/"
 
 def download(image, force, stores):
@@ -55,11 +49,13 @@ def download(image, force, stores):
         return
 
     if not stores:
-        stores = []
-        store = os.environ.get("TEST_IMAGES_" + image.split("-")[0].upper(), None)
-        if store:
-            stores.append(store)
-        stores.append(os.environ.get("TEST_IMAGES", DEFAULT))
+        config = os.path.expanduser(CONFIG)
+        if os.path.exists(config):
+            with open(config, 'r') as fp:
+                stores = fp.read().strip().split("\n")
+        else:
+            stores = []
+        stores.append(DEFAULT)
 
     for store in stores:
         try:

--- a/test/vm-download
+++ b/test/vm-download
@@ -41,14 +41,7 @@ DEVNULL = open("/dev/null", "r+")
 
 DEFAULT = "https://fedorapeople.org/groups/cockpit/images/"
 
-parser = argparse.ArgumentParser(description='Download a virtual machine')
-parser.add_argument("--force", action="store_true", help="Force unnecessary downloads")
-parser.add_argument("--store", action="append", help="Where to find images")
-parser.add_argument("--prune", action="store_true", help="Remove unused images")
-parser.add_argument('image', nargs='*')
-args = parser.parse_args()
-
-def download(image):
+def download(image, force, stores):
     link = os.path.join(IMAGES, image)
     if not os.path.islink(link):
         parser.error("image link does not exist: " + image)
@@ -57,12 +50,10 @@ def download(image):
         os.makedirs(DATA)
 
     dest = os.path.join(DATA, os.readlink(link))
-    if not args.force and os.path.exists(dest):
+    if not force and os.path.exists(dest):
         return
 
-    if args.store:
-        stores = args.store
-    else:
+    if not stores:
         stores = []
         store = os.environ.get("TEST_IMAGES_" + image.split("-")[0].upper(), None)
         if store:
@@ -114,11 +105,22 @@ def every():
             result.append(filename)
     return result
 
-# By default download all links
-if not args.image and not args.prune:
-    args.image = every()
+def main():
+    parser = argparse.ArgumentParser(description='Download a virtual machine')
+    parser.add_argument("--force", action="store_true", help="Force unnecessary downloads")
+    parser.add_argument("--store", action="append", help="Where to find images")
+    parser.add_argument("--prune", action="store_true", help="Remove unused images")
+    parser.add_argument('image', nargs='*')
+    args = parser.parse_args()
 
-if args.prune:
-    prune()
-for image in args.image:
-    download(image)
+    # By default download all links
+    if not args.image and not args.prune:
+        args.image = every()
+
+    if args.prune:
+        prune()
+    for image in args.image:
+        download(image, args.force, args.store)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/vm-download
+++ b/test/vm-download
@@ -24,6 +24,7 @@ import subprocess
 import shutil
 import sys
 import tempfile
+import time
 
 import testinfra
 
@@ -89,7 +90,8 @@ def download(image, force, stores):
     if not os.path.exists(image_file):
         os.symlink(os.path.abspath(dest), image_file)
 
-def prune():
+def prune(force):
+    now = time.time()
     targets = []
     for filename in os.listdir(IMAGES):
         path = os.path.join(IMAGES, filename)
@@ -98,7 +100,9 @@ def prune():
             targets.append(target)
     for filename in os.listdir(DATA):
         path = os.path.join(DATA, filename)
-        if os.path.isfile(path) and path.endswith(".qcow2") and path not in targets:
+        if not force and os.stat(path).st_mtime > now - testinfra.IMAGE_EXPIRE * 86400:
+            continue
+        if os.path.isfile(path) and "." in path and path not in targets:
             sys.stderr.write("Pruning {0}\n".format(filename))
             os.unlink(path)
 
@@ -123,7 +127,7 @@ def main():
         args.image = every()
 
     if args.prune:
-        prune()
+        prune(args.force)
     for image in args.image:
         download(image, args.force, args.store)
 

--- a/test/vm-prep
+++ b/test/vm-prep
@@ -78,10 +78,13 @@ EOF
 		echo "$rule" >> ${qemu_config_dir}/bridge.conf
 	fi
 
-  # HACK: selinux issues with qemu-bridge-helper prevent bridge creation for additional network adapters
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1267217
-  # we can circumvent this with a custom selinux policy
-  (cd files && make -f /usr/share/selinux/devel/Makefile ./cockpit_test_bridge.pp && semodule -i ./cockpit_test_bridge.pp)
+    # HACK: selinux issues with qemu-bridge-helper prevent bridge creation for additional network adapters
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1267217
+    # we can circumvent this with a custom selinux policy
+    case "$(LANG=C getenforce)" in
+    *Enforcing*)
+        (cd $BASE/files && make -f /usr/share/selinux/devel/Makefile ./cockpit_test_bridge.pp && semodule -i ./cockpit_test_bridge.pp)
+    esac
 }
 
 unprepare()

--- a/test/vm-prep
+++ b/test/vm-prep
@@ -19,6 +19,7 @@
 VIRSH=/bin/virsh
 QEMU_BRIDGE_HELPER=/usr/libexec/qemu-bridge-helper
 
+BASE=$(dirname $0)
 SELF=vm-prep
 
 set -euf
@@ -53,7 +54,7 @@ DEVICE=$NETWORK_NAME
 NM_CONTROLLED=no
 EOF
 
-    $VIRSH net-define ./guest/network-cockpit.xml
+    $VIRSH net-define $BASE/guest/network-cockpit.xml
 	$VIRSH net-autostart $NETWORK_NAME
 	$VIRSH net-start $NETWORK_NAME
 

--- a/test/vm-run
+++ b/test/vm-run
@@ -18,6 +18,7 @@
 
 import argparse
 import os
+import subprocess
 import sys
 
 import testvm
@@ -37,6 +38,18 @@ args = parser.parse_args()
 try:
     os.chdir(BASE)
     machine = testvm.VirtMachine(verbose=args.verbose, image=args.image)
+
+    # Check that things are configured
+    with open(os.devnull, 'w') as fp:
+        if subprocess.call(["ip", "address", "show", "dev", "cockpit1"], stdout=fp, stderr=fp) != 0:
+            raise Exception("vm-run: please run: sudo {0}/vm-prep".format(BASE))
+
+    # Check that image is downloaded
+    if not os.path.exists(machine.image_base):
+        ret = subprocess.call(["./vm-download", args.image])
+        if ret != 0:
+            sys.exit(ret)
+
     machine.qemu_console(maintain=args.maintain,
                          memory_mb=args.memory,
                          cpus=args.cpus)

--- a/test/vm-upload
+++ b/test/vm-upload
@@ -11,12 +11,7 @@ BASE = os.path.dirname(__file__)
 IMAGES = os.path.join(BASE, "images")
 DATA = os.path.join(os.environ.get("TEST_DATA", BASE), "images")
 
-parser = argparse.ArgumentParser(description='Upload virtual machine images')
-parser.add_argument("--store", default=UPLOAD, help="Where to send images")
-parser.add_argument('image', nargs='+')
-args = parser.parse_args()
-
-def upload(source):
+def upload(store, source):
     name = os.path.basename(source)
 
     # Compress the image
@@ -26,21 +21,30 @@ def upload(source):
         subprocess.check_call(xz, stdout=fp)
 
     # And upload the compressed version
-    dest = os.path.join(args.store, name + ".xz")
+    dest = os.path.join(store, name + ".xz")
     subprocess.check_call(["rsync", "--progress", compressed, dest])
 
     # Remove the compressed version
     os.unlink(compressed)
 
-sources = []
-for image in args.image:
-    link = os.path.join(IMAGES, image)
-    if not os.path.islink(link):
-        parser.error("image link does not exist: " + image)
-    source = os.path.join(DATA, os.readlink(link))
-    if not os.path.isfile(source):
-        parser.error("image does not exist: " + image)
-    sources.append(source)
+def main():
+    parser = argparse.ArgumentParser(description='Upload virtual machine images')
+    parser.add_argument("--store", default=UPLOAD, help="Where to send images")
+    parser.add_argument('image', nargs='*')
+    args = parser.parse_args()
 
-for source in sources:
-    upload(source)
+    sources = []
+    for image in args.image:
+        link = os.path.join(IMAGES, image)
+        if not os.path.islink(link):
+            parser.error("image link does not exist: " + image)
+        source = os.path.join(DATA, os.readlink(link))
+        if not os.path.isfile(source):
+            parser.error("image does not exist: " + image)
+        sources.append(source)
+
+    for source in sources:
+        upload(args.store, source)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/vm-upload
+++ b/test/vm-upload
@@ -7,6 +7,8 @@ import os
 import subprocess
 import sys
 
+import testinfra
+
 BASE = os.path.dirname(__file__)
 IMAGES = os.path.join(BASE, "images")
 DATA = os.path.join(os.environ.get("TEST_DATA", BASE), "images")
@@ -27,11 +29,39 @@ def upload(store, source):
     # Remove the compressed version
     os.unlink(compressed)
 
+def prune(store):
+    # Get a list of all currently in use files
+    current = []
+    for filename in os.listdir(IMAGES):
+        path = os.path.join(IMAGES, filename)
+        if os.path.islink(path):
+            current.append(os.readlink(path))
+
+    # Get remote list of files order than the given date
+    (host, unused, path) = store.partition(":")
+    cmd = ["ssh", host, "--", "find", path, "-mtime", "+{0}".format(testinfra.IMAGE_EXPIRE), "-print0"]
+    output = subprocess.check_output(cmd)
+
+    remove = []
+    for path in output.strip('\0').split('\0'):
+        for name in current:
+            if name in path:
+                break
+        else:
+            remove.append(path)
+
+    cmd = ["ssh", host, "--", "echo", "rm", "-v" ] + remove
+    subprocess.check_call(cmd)
+
 def main():
     parser = argparse.ArgumentParser(description='Upload virtual machine images')
     parser.add_argument("--store", default=UPLOAD, help="Where to send images")
+    parser.add_argument("--prune", action='store_true', help="Where to send images")
     parser.add_argument('image', nargs='*')
     args = parser.parse_args()
+
+    if args.prune:
+        prune(args.store)
 
     sources = []
     for image in args.image:


### PR DESCRIPTION
A lot of related work to the test image and run infrastructure:

 * Download missing image automatically in ```./vm-run``` and warn about missing ```./vm-prep```
 * Don't run ```./vm-prep``` in ```./testsuite-prepare```
 * Run ```./vm-prep``` in ```VERIFY```
 * ```./vm-prep``` can be run from any directory
 * Image expiry in ```vm-upload``` and ```vm-download```
 * Multiple alternate image stores
 * Only run vm-prep selinux stuff when selinux is on
 * Cleanup vm-upload, vm-download, and vm-create