### PR TITLE
Split check-verify into github-task

### DIFF
--- a/test/check-verify
+++ b/test/check-verify
@@ -9,6 +9,7 @@ import sys
 import traceback
 import unittest
 
+import testlib
 import testinfra
 
 sys.dont_write_bytecode = True
@@ -18,15 +19,15 @@ EXCLUDE = [
     'check-example'
 ]
 
-def start_publishing(github, host, name, revision, context):
-    identifier = name + "-" + revision[0:8] + "-" + context
+def start_publishing(github, host, name, revision, image):
+    identifier = name + "-" + revision[0:8] + "-" + image
     description = "{0} [{1}]".format(testinfra.TESTING, testinfra.HOSTNAME)
     status = {
         "github": {
             "resource": github.qualify("statuses/" + revision),
             "status": {
                 "state": "pending",
-                "context": context,
+                "context": "verify/" + image,
                 "description": description,
             }
         },
@@ -37,8 +38,8 @@ def start_publishing(github, host, name, revision, context):
     if name == "master":
         status['irc'] = { }    # Only send to IRC when master
         status['badge'] = {
-            'name': context,
-            'description': context,
+            'name': image,
+            'description': image,
             'status': 'running'
         }
     return testinfra.Sink(host, identifier, status)
@@ -131,17 +132,14 @@ def run(opts, sink):
             suite.addTest(loader.loadTestsFromModule(module))
 
     # And now load new testlib, and run all the tests we got
-    import testlib
     return testlib.test_main(opts=opts, suite=suite)
 
 def main():
-    parser = testinfra.arg_parser()
+    parser = testlib.arg_parser()
     parser.add_argument('--publish', dest='publish', action='store',
                         help='Publish results centrally to a sink')
     parser.add_argument('--rebase', dest='rebase', action='store_true',
                         help='Rebase onto master before running tests')
-    parser.add_argument('--github', dest='github', action='store',
-                        help='Test something from GitHub (next, scan, NNNN)')
     parser.add_argument('--install', dest='install', action='store_true',
                         help='Build and install Cockpit into test VMs')
     parser.add_argument('--quick', dest='quick', action='store_true',
@@ -155,55 +153,20 @@ def main():
     revision = None
     status = { }
     sink = None
-    name = "test"
     revision = None
     badge = False
-    context = opts.image or testinfra.DEFAULT_IMAGE
+    image = opts.image or testinfra.DEFAULT_IMAGE
 
     os.chdir(os.path.dirname(__file__))
 
     # In case we need it
     github = testinfra.GitHub()
 
-    # These are implied
-    if opts.github:
-        opts.install = True
-        opts.rebase = True
-
-    # When letting github decide what to test
-    if opts.github in [ "next", "scan" ]:
-        sys.stderr.write("Talking to GitHub ...\n")
-        for (priority, name, revision, ref, context) in github.scan(opts.publish, opts.image):
-            if opts.github == "scan":
-                return 0 # Only scanning, no tests
-
-            # Get the relevant commit
-            subprocess.check_call([ "git", "fetch", "origin", ref ])
-            subprocess.check_call([ "git", "checkout", revision ])
-            break
-
-        # Nothing to test
-        else:
-            if opts.github == "next":
-                return 1
-            return 0
-
-    # A specific github thing to test
-    elif opts.github:
-        try:
-            ref = "pull/{0}/head".format(int(opts.github))
-            name = "pull-" + opts.github
-        except:
-            ref = opts.github
-            name = opts.github.replace("/", "-")
-        subprocess.check_call([ "git", "fetch", "origin", ref ])
-        subprocess.check_call([ "git", "checkout", "FETCH_HEAD" ])
-
-    if not revision:
-        revision = subprocess.check_output([ "git", "rev-parse", "HEAD" ]).strip()
+    revision = subprocess.check_output([ "git", "rev-parse", "HEAD" ]).strip()
+    name = os.environ.get("TEST_NAME", "test")
 
     if opts.publish:
-        sink = start_publishing(github, opts.publish, name, revision, context)
+        sink = start_publishing(github, opts.publish, name, revision, image)
         os.environ["TEST_ATTACHMENTS"] = sink.attachments
 
     # Master is always thorough
@@ -212,10 +175,11 @@ def main():
 
     # Tell any subprocesses what we are testing
     os.environ["TEST_REVISION"] = revision
-    testinfra.DEFAULT_IMAGE = context
-    os.environ["TEST_OS"] = context
+    testinfra.DEFAULT_IMAGE = image
+    os.environ["TEST_OS"] = image
 
-    sys.stderr.write("Testing {0} for {1} with {2} on {3}...\n".format(revision, name, context, testinfra.HOSTNAME))
+    msg = "Testing {0} for {1} with {2} on {3}...\n".format(revision, name, image, testinfra.HOSTNAME)
+    sys.stderr.write(msg)
 
     try:
         if opts.rebase:
@@ -225,7 +189,7 @@ def main():
 
         # Check if we are still publishing, in case some other verify
         # machine collided with our test
-        if opts.github and sink:
+        if sink:
             check_publishing(sink, github)
 
         ret = run(opts, sink)
@@ -236,10 +200,6 @@ def main():
     # All done
     if sink:
         stop_publishing(sink, ret)
-
-    # This script is always successful in github case
-    if opts.github:
-        return 0
 
     # But normally we return number of tests failed
     return ret

--- a/test/github-scan
+++ b/test/github-scan
@@ -27,12 +27,14 @@ def main():
     parser = argparse.ArgumentParser(description='Test infrastructure: scan and update status of pull requests on github')
     parser.add_argument('-d', '--dry', action="store_true", default=False,
                         help='Don''t actually change anything on github')
-    parser.add_argument('image', action='store', nargs='?',
-                        help='The operating system image to scan against')
+    parser.add_argument('--except', dest='except_context', action='store_true',
+                        help='Scan for anything except the specified context')
+    parser.add_argument('context', action='store', nargs='?',
+                        help='The test context to scan for tasks')
     opts = parser.parse_args()
 
     github = testinfra.GitHub("/repos/cockpit-project/cockpit/")
-    for (priority, name, revision, ref, context) in github.scan(not opts.dry, opts.image):
+    for (priority, name, revision, ref, context) in github.scan(not opts.dry, opts.context, opts.except_context):
         sys.stdout.write("{0}: {1} ({2} {3})\n".format(name, revision, priority, context))
 
 if __name__ == '__main__':

--- a/test/github-task
+++ b/test/github-task
@@ -1,4 +1,80 @@
-#!/bin/sh
+#!/usr/bin/env python
 
-BASE=$(dirname $0)
-exec $BASE/check-verify --github=next "$@"
+# This file is part of Cockpit.
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import fnmatch
+import os
+import subprocess
+import sys
+
+import testinfra
+
+sys.dont_write_bytecode = True
+
+def main():
+    parser = argparse.ArgumentParser(description='Perform next testing task from Github')
+    parser.add_argument('-j', '--jobs', dest="jobs", type=int,
+                        default=os.environ.get("TEST_JOBS", 1), help="Number of concurrent jobs")
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='Verbose output')
+    parser.add_argument('--publish', dest='publish', action='store',
+                        help='Publish results centrally to a sink')
+    parser.add_argument('--except', dest='except_context', action='store_true',
+                        help='Choose tasks from any context except the one specified')
+    parser.add_argument('context', action='store', nargs='?',
+                        help='The test context to choose tasks from')
+    opts = parser.parse_args()
+
+    os.chdir(os.path.dirname(__file__))
+    github = testinfra.GitHub()
+
+    # When letting github decide what to test
+    sys.stderr.write("Talking to GitHub ...\n")
+    for (priority, name, revision, ref, context) in github.scan(opts.publish, opts.context, opts.except_context):
+        break
+    else: # Nothing to test
+        return 1
+
+    os.environ["TEST_NAME"] = name
+
+    # Split a value like verify/fedora-23
+    (prefix, unused, value) = context.partition("/")
+
+    # Figure out what to do next
+    if prefix == "verify":
+        subprocess.check_call([ "git", "fetch", "origin", ref ])
+        subprocess.check_call([ "git", "checkout", revision ])
+
+        os.environ["TEST_OS"] = value
+        cmd = [ "./check-verify", "--install", "--rebase", "--jobs", str(opts.jobs) ]
+
+        if opts.publish:
+            cmd.append("--publish=" + opts.publish)
+        if opts.verbose:
+            cmd.append("--verbose")
+
+        subprocess.call(cmd)
+        return 0
+
+    else:
+        sys.stderr.write("github-task: unknown context: " + context)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/github-trigger
+++ b/test/github-trigger
@@ -8,18 +8,15 @@ sys.dont_write_bytecode = True
 
 def main():
     parser = argparse.ArgumentParser(description='Manually trigger CI Robots')
-    parser.add_argument('pull')
-    parser.add_argument('-f', '--force',
-                        help='Force setting the status even if the program logic thinks it shouldn''t be done',
-                        action="store_true")
-    parser.add_argument('image', action='store', nargs='?',
-                        help='The operating system image to verify against')
+    parser.add_argument('-f', '--force', action="store_true",
+                        help='Force setting the status even if the program logic thinks it shouldn''t be done')
+    parser.add_argument('pull', help='The pull request to trigger')
+    parser.add_argument('context', help='The github task context to trigger')
     opts = parser.parse_args()
 
     github = testinfra.GitHub()
 
-    context = opts.image or testinfra.DEFAULT_IMAGE
-    sys.stderr.write("triggering pull {0} for context {1}\n".format(opts.pull, context))
+    sys.stderr.write("triggering pull {0} for context {1}\n".format(opts.pull, opts.context))
     pull = github.get("pulls/" + opts.pull)
 
     # triggering is manual, so don't prevent triggering a user that isn't on the whitelist
@@ -30,7 +27,7 @@ def main():
 
     revision = pull['head']['sha']
     statuses = github.statuses(revision)
-    status = statuses.get(context, { })
+    status = statuses.get(opts.context, { })
     if status.get("state", "empty") not in ["empty", "error", "failure"]:
         if opts.force:
             sys.stderr.write("Pull request isn't in error state, but forcing update.\n")
@@ -38,7 +35,7 @@ def main():
             sys.stderr.write("Pull request isn't in error state. Status is: '{0}'\n".format(status["state"]))
             return 1
 
-    changes = { "state": "pending", "description": testinfra.NOT_TESTED, "context": context }
+    changes = { "state": "pending", "description": testinfra.NOT_TESTED, "context": opts.context }
     github.post("statuses/" + revision, changes)
     return 0
 


### PR DESCRIPTION
This is a script that chooses a task from GitHub based on Status API, open pull requests and so on. This functionality used to be included in 'check-verify --next'

This is split out from check-verify so that it can run other things besides check-verify