### PR TITLE
test: atomic command is now unbroken on Fedora 23 Atomic Host

### DIFF
--- a/test/naughty/3307-atomic-command-broken-dbus
+++ b/test/naughty/3307-atomic-command-broken-dbus
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-kubernetes", line 377, in testDeployDialog
-    output = m.execute("atomic -v 2>&1")


### PR DESCRIPTION
Fixes #3307