### PR TITLE
ostree: Install debugdata to right place

### DIFF
--- a/pkg/ostree/Makefile.am
+++ b/pkg/ostree/Makefile.am
@@ -10,7 +10,7 @@ ostree_DATA = \
 	pkg/ostree/manifest.json \
 	$(NULL)
 
-ostreedebugdir = $(DBGDIR)$(ostreedir)
+ostreedebugdir = $(debugdir)$(ostreedir)
 ostreedebug_DATA = \
 	pkg/ostree/ostree.css \
 	pkg/ostree/app.js \


### PR DESCRIPTION
We accidentally shipped the debugdata along with the main package.
This isn't such a major issue, but this commit should fix the
problem.