### PR TITLE
Make the kube-client stuff more useful

### DIFF
--- a/pkg/registry/scripts/kube-client-cockpit.js
+++ b/pkg/registry/scripts/kube-client-cockpit.js
@@ -463,7 +463,7 @@
                  * connect discovery stuff. Otherwise ask our connect service
                  * for connection info, and do discovery.
                  */
-                if (config && config.payload)
+                if (config && config.port)
                     connect = config;
                 else
                     connect = $injector.get('cockpitKubeDiscover')();
@@ -471,7 +471,8 @@
                 $q.when(connect, function connected(options) {
                     var opts = angular.extend({ }, config, options, {
                         path: path,
-                        method: method
+                        method: method,
+                        payload: "http-stream2"
                     });
 
                     opts.headers = angular.extend(heads, opts.headers || { });
@@ -583,11 +584,10 @@
                 var last, aux, req;
                 defer = $q.defer();
 
-                var cp = "http-stream2";
                 var schemes = [
-                    { port: 8080, payload: cp },
-                    { port: 8443, tls: { }, payload: cp },
-                    { port: 6443, tls: { }, payload: cp }
+                    { port: 8080 },
+                    { port: 8443, tls: { } },
+                    { port: 6443, tls: { } },
                 ];
 
                 function step(options, kubeConfig) {

--- a/pkg/registry/scripts/kube-client-cockpit.js
+++ b/pkg/registry/scripts/kube-client-cockpit.js
@@ -365,7 +365,7 @@
                         if (stopping)
                             return;
 
-                        var msg = "watching " + path + " failed:";
+                        var msg = "watching " + path + " failed: ";
                         var problem = options.problem;
                         var status = response.status;
 

--- a/pkg/registry/scripts/kube-client.js
+++ b/pkg/registry/scripts/kube-client.js
@@ -984,7 +984,7 @@
                 return promise;
             }
 
-            function removeResource(/* ... */) {
+            function deleteResource(/* ... */) {
                 var path = resourcePath(arguments);
                 var resource = loader.objects[path];
                 var promise = new KubeRequest("DELETE", path);
@@ -995,8 +995,8 @@
             }
 
             return {
-                create: createObjects,
-                remove: removeResource
+                "create": createObjects,
+                "delete": deleteResource
             };
         }
     ])

--- a/pkg/registry/scripts/kube-client.js
+++ b/pkg/registry/scripts/kube-client.js
@@ -864,18 +864,39 @@
                 }
             });
 
-            function select(what) {
-                var results, indexed = false;
-                if (!what) {
-                    what = loader.objects;
-                    indexed = true;
+            function selection(what, indexed) {
+                return cached(what).selection || mixinSelection(what, undefined, indexed);
+            }
 
-                } else if (angular.isArray(what) || typeof (what) != "object") {
-                    console.warn("You should pass object dicts or null to kubeSelect()");
-                    return null;
+            function select(arg) {
+                var what, meta, i, len;
+                if (!arg) {
+                    return selection(loader.objects, true);
+
+                } else if (typeof arg == "object") {
+                    if (typeof arg.kind == "string") {
+                        if (arg.items) {
+                            arg = arg.items;
+                        } else {
+                            arg = [ arg ];
+                        }
+                    }
+
+                    if (typeof arg.length == "number") {
+                        what = { };
+                        for (i = 0, len = arg.length; i < len; i++) {
+                            meta = arg[i].metadata || { };
+                            what[meta.selfLink || i] = arg[i];
+                        }
+                        return selection(what);
+
+                    } else {
+                        return selection(arg);
+                    }
                 }
 
-                return cached(what).selection || mixinSelection(what, undefined, indexed);
+                console.warn("Pass resources or resource dicts or null to kubeSelect()");
+                return selection({ });
             }
 
             /* A seldom used 'static' method */

--- a/pkg/registry/tests/test-kube-client.html
+++ b/pkg/registry/tests/test-kube-client.html
@@ -458,7 +458,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
             methods.create(CREATE_ITEMS, "namespace2").then(function() {
                 ok("/api/v1/namespaces/namespace2/pods/pod1" in loader.objects, "pod created");
-                methods.remove("/api/v1/namespaces/namespace2/pods/pod1").then(function() {
+                methods.delete("/api/v1/namespaces/namespace2/pods/pod1").then(function() {
                     ok(true, "remove succeeded");
                     watch.finally(function() {
                         ok(!("/api/v1/namespaces/namespace2/pods/pod1" in loader.objects), "pod was removed");


### PR DESCRIPTION
Some changes to the kube-client:

Filters are already complex, as they have to carefully pull out the data from an object or from match criteria. This should make them much simpler to implement.

One can now pass in kubernetes objects including List and have the right thing happen. Passing in an array of objects does the right thing too.

It's fine to use 'delete' as a funciton name, in fact javascript standards do this (see WeakMap)

