### PR TITLE
shell: Drop overlay color when we see one in machines.json

### DIFF
--- a/pkg/shell/machines.js
+++ b/pkg/shell/machines.js
@@ -102,6 +102,11 @@ define([
             for (host in hosts) {
                 var old_machine = machines[host] || { };
                 var old_conns = old_machine.connection_string;
+
+                /* Invert logic for color, always respect what's on disk */
+                if (content[host] && content[host].color && overlay[host])
+                    delete overlay[host].color;
+
                 machine = sync(old_machine, content[host], overlay[host]);
 
                 /* Fill in defaults */


### PR DESCRIPTION
Normally the overlay logic is used to override machines.json
but in this specific case we want it to just fill in a default
value.