### PR TITLE
ws: Remove no-forwarding as a problem message

### DIFF
--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -209,7 +209,6 @@ cockpit_channel_response_close (CockpitChannelResponse *chesp,
         }
       else if (g_str_equal (problem, "no-host") ||
                g_str_equal (problem, "no-cockpit") ||
-               g_str_equal (problem, "no-forwarding") ||
                g_str_equal (problem, "unknown-hostkey") ||
                g_str_equal (problem, "authentication-failed"))
         {

--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -579,6 +579,7 @@ cockpit_ssh_authenticate (CockpitSshData *data)
       else if (!has_creds)
         {
           result_string = "not-provided";
+          methods_tried = methods_tried | method;
         }
       else
         {
@@ -624,16 +625,6 @@ cockpit_ssh_authenticate (CockpitSshData *data)
       g_message ("%s: server offered unsupported authentication methods: %s",
                  data->logname, description);
       g_free (description);
-      problem = "authentication-not-supported";
-    }
-  else if (!(methods_tried & SSH_AUTH_METHOD_PASSWORD) &&
-           !(methods_tried & SSH_AUTH_METHOD_GSSAPI_MIC))
-    {
-      problem = "no-forwarding";
-    }
-  else
-    {
-      problem = "authentication-failed";
     }
 
 out:

--- a/src/ws/test-sshtransport.c
+++ b/src/ws/test-sshtransport.c
@@ -507,43 +507,11 @@ test_unsupported_auth (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   g_assert_cmpstr (result, ==, problem);
-  g_assert_cmpstr (problem, ==, "authentication-not-supported");
+  g_assert_cmpstr (problem, ==, "authentication-failed");
   g_free (problem);
   g_free (result);
 
   check_auth_results (tc, "no-server-support", "no-server-support", "no-server-support");
-}
-
-static const TestFixture fixture_no_forwarding = {
-  .ssh_command = BUILDDIR "/mock-echo",
-  .no_password = TRUE,
-};
-
-static void
-test_no_forwarding (TestCase *tc,
-                    gconstpointer data)
-{
-  gchar *problem = NULL;
-  gchar *result = NULL;
-
-  g_signal_connect (tc->transport, "result", G_CALLBACK (on_closed_get_problem), &result);
-  g_signal_connect (tc->transport, "closed", G_CALLBACK (on_closed_get_problem), &problem);
-
-  /* Gets fired first */
-  while (problem == NULL)
-    g_main_context_iteration (NULL, TRUE);
-
-  g_assert_cmpstr (result, ==, problem);
-#ifdef HAVE_SSH_SET_AGENT_SOCKET
-  g_assert_cmpstr (problem, ==, "no-forwarding");
-#else
-  g_assert_cmpstr (problem, ==, "authentication-not-supported");
-#endif
-
-  g_free (problem);
-  g_free (result);
-
-  check_auth_results (tc, "denied", "not-provided", "no-server-support");
 }
 
 static const TestFixture fixture_auth_failed = {
@@ -947,8 +915,6 @@ main (int argc,
               setup_transport, test_terminate_problem, teardown);
   g_test_add ("/ssh-transport/unsupported-auth", TestCase, &fixture_unsupported_auth,
               setup_transport, test_unsupported_auth, teardown);
-  g_test_add ("/ssh-transport/no-forwarding", TestCase, &fixture_no_forwarding,
-              setup_transport, test_no_forwarding, teardown);
   g_test_add ("/ssh-transport/auth-failed", TestCase,
               &fixture_auth_failed, setup_transport,
               test_auth_failed, teardown);

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -901,17 +901,12 @@ test_specified_creds_overide_host (TestCase *test,
 
 static void
 test_user_host_fail (TestCase *test,
-                      gconstpointer data)
+                     gconstpointer data)
 {
   WebSocketConnection *ws;
   GBytes *received = NULL;
   CockpitWebService *service;
-#ifdef HAVE_SSH_SET_AGENT_SOCKET
-  const gchar *expect_problem = "no-forwarding";
-#else
-  const gchar *expect_problem = "authentication-not-supported";
-#endif
-
+  const gchar *expect_problem = "authentication-failed";
 
   start_web_service_and_create_client (test, data, &ws, &service);
   WAIT_UNTIL (web_socket_connection_get_ready_state (ws) != WEB_SOCKET_STATE_CONNECTING);


### PR DESCRIPTION
As well as authentication-not-supported, look at the auth results instead.