### PR TITLE
Explicitly activate the "TEST" connection in check-networking

### DIFF
--- a/test/check-networking
+++ b/test/check-networking
@@ -92,14 +92,20 @@ class TestNetworking(MachineCase):
 
         self.login_and_go("/network")
 
-        # Add interface, wait for it to be recognized and activated by
-        # Network Manager, and switch to its page
+        # We create two connection settings for the new interface and
+        # explicitly activate one.  This tests whether Cockpit picks
+        # up the right one, and also protects us against pre-existing
+        # connection settings that might otherwise interfere.
 
         mac = "52:54:00:9e:00:F2"
         m.execute("nmcli c a type ethernet ifname '*' con-name TEST mac %s" % mac)
+        m.execute("nmcli c a type ethernet ifname '*' con-name TEST2 mac %s" % mac)
         m.execute("nmcli c m TEST ipv4.method link-local")
 
         iface = self.add_iface(mac)
+        wait(lambda: m.execute('nmcli d | grep %s | grep -v unavailable' % iface))
+        m.execute('nmcli c up TEST')
+
         self.wait_for_iface(iface)
         b.click("#networking-interfaces tr[data-interface='%s']" % iface)
         b.wait_visible("#network-interface")

--- a/test/guest/fedora-atomic.setup
+++ b/test/guest/fedora-atomic.setup
@@ -18,12 +18,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-# HACK - https://github.com/cockpit-project/cockpit/issues/3338
-# Use mac's in name policy, prevents interference from network-scripts
-mkdir -p /etc/systemd/network
-printf "[Link]\nNamePolicy=kernel database onboard mac\nMACAddressPolicy=persistent" > /etc/systemd/network/99-default.link
-rm /etc/udev/rules.d/80-net-setup-link.rules
-
 # fully upgrade host first
 atomic host upgrade
 

--- a/test/images/fedora-atomic
+++ b/test/images/fedora-atomic
@@ -1,1 +1,1 @@
-fedora-atomic-da42ff7d38639746c0b06bcc47a2f97f04a498c6.qcow2
+fedora-atomic-6260f86fc3892d7a77d4911f891d0516ec06d7e7.qcow2


### PR DESCRIPTION
Depends on #3381 

Fixes #3338 