### PR TITLE
ws: Catch mock ssh disconnect properly

### DIFF
--- a/src/ws/mock-sshd.c
+++ b/src/ws/mock-sshd.c
@@ -532,7 +532,7 @@ mock_ssh_server (const gchar *server_addr,
   if (ssh_handle_key_exchange (state.session))
     {
       msg = ssh_get_error (state.session);
-      if (!strstr (msg, "SSH_MESSAGE_DISCONNECT"))
+      if (!strstr (msg, "_DISCONNECT"))
         g_critical ("key exchange failed: %s", msg);
       return 1;
     }


### PR DESCRIPTION
Account for this error:

```
CRITICAL **: key exchange failed: Received SSH_MSG_DISCONNECT: 11:Bye Bye
````