### PR TITLE
ws: Look for "login-data" in spawn login results.

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -68,6 +68,9 @@ An error response should contain the following fields:
 A successful response must contain a ```user``` field with the user
 name of the user that was just logged in. Additional fields may be present.
 
+If a successful response contains a ```login-data``` field and that field contains a valid
+json object that object will be included in the HTTP response sent to client.
+
 Once the response has been sent fd #3 should be closed and a bridge should be launched
 speaking the cockpit protocol on stdin and stdout.
 

--- a/src/common/cockpitjson.c
+++ b/src/common/cockpitjson.c
@@ -133,6 +133,33 @@ cockpit_json_get_array (JsonObject *options,
     }
 }
 
+gboolean
+cockpit_json_get_object (JsonObject *options,
+                         const gchar *member,
+                         JsonObject *defawlt,
+                         JsonObject **value)
+{
+  JsonNode *node;
+
+  node = json_object_get_member (options, member);
+  if (!node)
+    {
+      if (value)
+        *value = defawlt;
+      return TRUE;
+    }
+  else if (json_node_get_node_type (node) == JSON_NODE_OBJECT)
+    {
+      if (value)
+        *value = json_node_get_object (node);
+      return TRUE;
+    }
+  else
+    {
+      return FALSE;
+    }
+}
+
 /**
  * cockpit_json_get_strv:
  * @options: the json object

--- a/src/common/cockpitjson.h
+++ b/src/common/cockpitjson.h
@@ -81,6 +81,11 @@ gboolean       cockpit_json_get_array         (JsonObject *object,
                                                JsonArray *defawlt,
                                                JsonArray **value);
 
+gboolean       cockpit_json_get_object        (JsonObject *options,
+                                               const gchar *member,
+                                               JsonObject *defawlt,
+                                               JsonObject **value);
+
 gboolean       cockpit_json_get_null          (JsonObject *object,
                                                const gchar *member,
                                                gboolean *present);

--- a/src/common/test-json.c
+++ b/src/common/test-json.c
@@ -30,6 +30,7 @@ static const gchar *test_data =
   "   \"string\": \"value\","
   "   \"number\": 55,"
   "   \"array\": [ \"one\", \"two\", \"three\" ],"
+  "   \"object\": { \"test\": \"one\" },"
   "   \"bool\": true,"
   "   \"null\": null"
   "}";
@@ -235,6 +236,39 @@ test_get_array (TestCase *tc,
   g_assert (ret == FALSE);
 
   json_array_unref (defawlt);
+}
+
+static void
+test_get_object (TestCase *tc,
+                gconstpointer data)
+{
+  JsonObject *defawlt = json_object_new ();
+  gboolean ret;
+  JsonObject *value;
+
+  ret = cockpit_json_get_object (tc->root, "object", NULL, &value);
+  g_assert (ret == TRUE);
+  g_assert (value != NULL);
+  g_assert_cmpstr (json_object_get_string_member (value, "test"), ==, "one");
+
+  ret = cockpit_json_get_object (tc->root, "object", NULL, NULL);
+  g_assert (ret == TRUE);
+
+  ret = cockpit_json_get_object (tc->root, "unknown", NULL, &value);
+  g_assert (ret == TRUE);
+  g_assert (value == NULL);
+
+  ret = cockpit_json_get_object (tc->root, "unknown", defawlt, &value);
+  g_assert (ret == TRUE);
+  g_assert (value == defawlt);
+
+  ret = cockpit_json_get_object (tc->root, "number", NULL, &value);
+  g_assert (ret == FALSE);
+
+  ret = cockpit_json_get_object (tc->root, "array", NULL, NULL);
+  g_assert (ret == FALSE);
+
+  json_object_unref (defawlt);
 }
 
 static void
@@ -583,6 +617,8 @@ main (int argc,
               setup, test_get_strv, teardown);
   g_test_add ("/json/get-array", TestCase, NULL,
               setup, test_get_array, teardown);
+  g_test_add ("/json/get-object", TestCase, NULL,
+              setup, test_get_object, teardown);
 
   g_test_add_func ("/json/parser-trims", test_parser_trims);
   g_test_add_func ("/json/parser-empty", test_parser_empty);

--- a/src/ws/cockpitcreds.h
+++ b/src/ws/cockpitcreds.h
@@ -23,6 +23,8 @@
 #include <glib.h>
 #include <glib-object.h>
 
+#include <json-glib/json-glib.h>
+
 #include <gssapi/gssapi.h>
 
 G_BEGIN_DECLS
@@ -34,6 +36,7 @@ typedef struct _CockpitCreds       CockpitCreds;
 #define COCKPIT_CRED_RHOST        "rhost"
 #define COCKPIT_CRED_GSSAPI       "gssapi"
 #define COCKPIT_CRED_CSRF_TOKEN   "csrf-token"
+#define COCKPIT_CRED_LOGIN_DATA   "login-data"
 
 #define         COCKPIT_TYPE_CREDS           (cockpit_creds_get_type ())
 
@@ -72,6 +75,8 @@ gss_cred_id_t   cockpit_creds_push_thread_default_gssapi (CockpitCreds *creds);
 
 gboolean        cockpit_creds_pop_thread_default_gssapi  (CockpitCreds *creds,
                                                           gss_cred_id_t gss_cred);
+
+JsonObject *    cockpit_creds_get_login_data             (CockpitCreds *creds);
 
 G_END_DECLS
 

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -318,11 +318,16 @@ send_login_response (CockpitWebResponse *response,
                      GHashTable *headers)
 {
   JsonObject *object;
+  JsonObject *login_data;
   GBytes *content;
 
   object = json_object_new ();
   json_object_set_string_member (object, "user", cockpit_creds_get_user (creds));
   json_object_set_string_member (object, "csrf-token", cockpit_creds_get_csrf_token (creds));
+
+  login_data = cockpit_creds_get_login_data (creds);
+  if (login_data)
+      json_object_set_object_member (object, "login-data", json_object_ref (login_data));
 
   content = cockpit_json_write_bytes (object);
   json_object_unref (object);

--- a/src/ws/mock-auth-command
+++ b/src/ws/mock-auth-command
@@ -33,6 +33,14 @@ case $auth in
         echo "{\"user\": \"me\" }" >&3
         success=1
         ;;
+    "success-with-data")
+        echo "{\"user\": \"me\", \"login-data\": { \"login\": \"data\"} }" >&3
+        success=1
+        ;;
+    "success-bad-data")
+        echo "{\"user\": \"me\", \"login-data\": \"bad\" }" >&3
+        success=1
+        ;;
     "no-user")
         echo "{ }" >&3
         ;;

--- a/src/ws/test-creds.c
+++ b/src/ws/test-creds.c
@@ -164,6 +164,54 @@ test_equal (void)
   cockpit_creds_unref (app);
 }
 
+static void
+test_login_data (void)
+{
+  JsonObject *object;
+  const gchar *invalid = "invalid";
+  const gchar *no_data = "{ \"no-data\" : \"none\" }";
+  const gchar *invalid_login = "{ \"login-data\" : \"invalid\" }";
+  const gchar *valid = "{ \"login-data\" : { \"login\": \"data\" } }";
+  CockpitCreds *creds;
+  CockpitCreds *creds2;
+  CockpitCreds *creds3;
+  CockpitCreds *creds4;
+  CockpitCreds *creds5;
+
+  creds = cockpit_creds_new ("user", "app", NULL);
+
+  cockpit_expect_warning ("*received bad json data:*");
+  creds2 = cockpit_creds_new ("user", "app",
+                              COCKPIT_CRED_LOGIN_DATA, invalid, NULL);
+
+  creds3 = cockpit_creds_new ("user", "app",
+                              COCKPIT_CRED_LOGIN_DATA, no_data, NULL);
+
+  cockpit_expect_warning ("*received bad login-data:*");
+  creds4 = cockpit_creds_new ("user", "app",
+                              COCKPIT_CRED_LOGIN_DATA, invalid_login, NULL);
+
+  creds5 = cockpit_creds_new ("user", "app",
+                              COCKPIT_CRED_LOGIN_DATA, valid, NULL);
+
+  g_assert (creds != NULL);
+
+  g_assert_null (cockpit_creds_get_login_data (creds));
+  g_assert_null (cockpit_creds_get_login_data (creds2));
+  g_assert_null (cockpit_creds_get_login_data (creds3));
+  g_assert_null (cockpit_creds_get_login_data (creds4));
+
+  object = cockpit_creds_get_login_data (creds5);
+  g_assert_cmpstr ("data", ==, json_object_get_string_member (object, "login"));
+
+  cockpit_creds_unref (creds);
+  cockpit_creds_unref (creds2);
+  cockpit_creds_unref (creds3);
+  cockpit_creds_unref (creds4);
+  cockpit_creds_unref (creds5);
+
+  cockpit_assert_expected ();
+}
 
 int
 main (int argc,
@@ -178,6 +226,7 @@ main (int argc,
   g_test_add_func ("/creds/hash", test_hash);
   g_test_add_func ("/creds/equal", test_equal);
   g_test_add_func ("/creds/has_gssapi", test_gssapi);
+  g_test_add_func ("/creds/login-data", test_login_data);
 
   return g_test_run ();
 }


### PR DESCRIPTION
Allows custom login commands to add data to the HTTP response on a successful login.