### PR TITLE
test: Don't write byte code in python github entry points

### DIFF
--- a/test/check-verify
+++ b/test/check-verify
@@ -9,10 +9,10 @@ import sys
 import traceback
 import unittest
 
+sys.dont_write_bytecode = True
+
 import testlib
 import testinfra
-
-sys.dont_write_bytecode = True
 
 EXCLUDE = [
     'check-verify',

--- a/test/check-verify
+++ b/test/check-verify
@@ -163,7 +163,9 @@ def main():
     github = testinfra.GitHub()
 
     revision = subprocess.check_output([ "git", "rev-parse", "HEAD" ]).strip()
-    name = os.environ.get("TEST_NAME", "test")
+    name = os.environ.get("TEST_NAME")
+    if not name:
+        name = "test"
 
     if opts.publish:
         sink = start_publishing(github, opts.publish, name, revision, image)

--- a/test/github-limits
+++ b/test/github-limits
@@ -22,6 +22,8 @@ import argparse
 import datetime
 import sys
 
+sys.dont_write_bytecode = True
+
 import testinfra
 
 def httpdate(dt):

--- a/test/github-scan
+++ b/test/github-scan
@@ -21,6 +21,8 @@
 import argparse
 import sys
 
+sys.dont_write_bytecode = True
+
 import testinfra
 
 def main():

--- a/test/github-task
+++ b/test/github-task
@@ -23,9 +23,9 @@ import os
 import subprocess
 import sys
 
-import testinfra
-
 sys.dont_write_bytecode = True
+
+import testinfra
 
 def main():
     parser = argparse.ArgumentParser(description='Perform next testing task from Github')

--- a/test/github-trigger
+++ b/test/github-trigger
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
-import testinfra
+import sys
 
 sys.dont_write_bytecode = True
+
+import testinfra
 
 def main():
     parser = argparse.ArgumentParser(description='Manually trigger CI Robots')


### PR DESCRIPTION
There were some directives here before, but we need to have
these before loading any local modules.

Otherwise this can cause the verify instances to have problems
when we use 'git reset --hard' but byte code remains behind.