### PR TITLE
Fix content security policy

### DIFF
--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -86,10 +86,14 @@ $ cockpit-bridge --packages
     <variablelist>
       <varlistentry>
         <term>content-security-policy</term>
-        <listitem><para>By default Cockpit serves packages using a strict
+        <listitem>
+          <para>By default Cockpit serves packages using a strict
             <ulink url="https://en.wikipedia.org/wiki/Content_Security_Policy">Content Security Policy</ulink>,
             which among other things does not allow inline styles or scripts. This can
-            be overriden on a per-package basis, with this setting.</para></listitem>
+            be overriden on a per-package basis, with this setting.</para>
+          <para>If the overriden content security policy does not contain a <code>default-src</code> or
+            <code>connect-src</code> these will be added to to the poli8cy from the manifest.</para>
+        </listitem>
       </varlistentry>
       <varlistentry>
         <term>menu</term>

--- a/examples/package-simple/manifest.json
+++ b/examples/package-simple/manifest.json
@@ -7,5 +7,5 @@
         }
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/examples/pinger/manifest.json
+++ b/examples/pinger/manifest.json
@@ -8,5 +8,5 @@
         }
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/examples/poc-vnc/manifest.json
+++ b/examples/poc-vnc/manifest.json
@@ -7,6 +7,6 @@
         }
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 
 }

--- a/examples/zoner/manifest.json
+++ b/examples/zoner/manifest.json
@@ -8,5 +8,5 @@
         }
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/pkg/dashboard/manifest.json
+++ b/pkg/dashboard/manifest.json
@@ -9,5 +9,5 @@
         }
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/pkg/docker/manifest.json
+++ b/pkg/docker/manifest.json
@@ -8,5 +8,5 @@
         }
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/pkg/kubernetes/manifest.json
+++ b/pkg/kubernetes/manifest.json
@@ -6,5 +6,5 @@
         }
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/pkg/networkmanager/manifest.json
+++ b/pkg/networkmanager/manifest.json
@@ -9,5 +9,5 @@
         }
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/pkg/ostree/manifest.json
+++ b/pkg/ostree/manifest.json
@@ -8,5 +8,5 @@
         }
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/pkg/registry/index.html
+++ b/pkg/registry/index.html
@@ -17,7 +17,7 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
-<html lang="en" class="no-js">
+<html lang="en" ng-csp class="no-js">
 <head>
 <meta charset="utf-8">
 <title translatable="yes">Image Registry</title>
@@ -47,7 +47,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 </head>
 
-<body ng-csp ng-app='registry' ng-controller="MainCtrl">
+<body ng-app='registry' ng-controller="MainCtrl">
     <div ng-cloak>
         <div class="icon-sidebar">
             <div>

--- a/pkg/registry/override.json
+++ b/pkg/registry/override.json
@@ -1,0 +1,4 @@
+{
+    "comment": "Local debugging overrides to the manifest",
+    "content-security-policy": "style-src 'self' 'unsafe-inline' 'unsafe-eval'"
+}

--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -12,5 +12,5 @@
         "uk": "Українська"
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/pkg/sosreport/manifest.json
+++ b/pkg/sosreport/manifest.json
@@ -7,5 +7,5 @@
         }
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/pkg/storaged/manifest.json
+++ b/pkg/storaged/manifest.json
@@ -9,5 +9,5 @@
         }
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/pkg/subscriptions/manifest.json
+++ b/pkg/subscriptions/manifest.json
@@ -7,5 +7,5 @@
         }
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/pkg/systemd/manifest.json
+++ b/pkg/systemd/manifest.json
@@ -23,5 +23,5 @@
         }
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/pkg/users/manifest.json
+++ b/pkg/users/manifest.json
@@ -7,5 +7,5 @@
         }
     },
 
-    "content-security-policy": "'self' 'unsafe-inline' 'unsafe-eval'"
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
 }

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -148,7 +148,7 @@ test_resource_simple (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self'\r\n"
+                           "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "\r\n"
@@ -515,7 +515,7 @@ test_resource_language_suffix (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self'\r\n"
+                           "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "\r\n"
@@ -554,7 +554,7 @@ test_resource_language_fallback (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self'\r\n"
+                           "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "\r\n"


### PR DESCRIPTION
Note that browsers need to be explicitly told they can connect to a WebSocket. This is non-obvious, but it stems from the fact that some browsers treat 'https' and 'wss' as different protocols.

Since each component could establish a WebSocket connection back to cockpit-ws, we need to insert that into the policy.

Add a non-installed override.json for styles allowing less.js to work with CSP.

The CSP overrides we shipped in the various manifest.json files for compatibility were broken and didn't include the default-src directive
