### PR TITLE
test: SELinux breaks systemd coredumps, ignore related messages

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -586,6 +586,9 @@ systemctl start docker
         "(audit: )?type=1403 audit.*",
         "(audit: )?type=1404 audit.*",
 
+        # SELinux fighting with systemd: https://bugzilla.redhat.com/show_bug.cgi?id=1253319
+        "(audit: )?type=1400 audit.*systemd-journal.*path=2F6D656D66643A73642D73797374656D642D636F726564756D202864656C6574656429",
+
         # Messages from systemd libraries when they are in debug mode
         'Successfully loaded SELinux database in.*',
         'calling: info',


### PR DESCRIPTION
SELinux policy breaks system coredumps in Fedora 23. Ignore related
messages:

https://bugzilla.redhat.com/show_bug.cgi?id=1253319