### PR TITLE
shell: Log when frame src is missing

### DIFF
--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -125,6 +125,7 @@ define([
 
                     /* HACK: Because phantomjs sometimes has half loaded iframes */
                     } else {
+                        console.log("remove frame because it is missing a src");
                         if (frame.contentWindow)
                             $(frame.contentWindow).off();
                         $(frame).remove();


### PR DESCRIPTION
This is to confirm if the the missing src hacks is the cause the test failures.