### PR TITLE
registry: Add override.json to debug data

### DIFF
--- a/pkg/registry/Makefile.am
+++ b/pkg/registry/Makefile.am
@@ -49,6 +49,7 @@ registrydebug_DATA = \
 	pkg/registry/bundle.js \
 	pkg/registry/bundle.css \
 	pkg/registry/index.html \
+	pkg/registry/override.json \
 	$(NULL)
 
 install-data-hook::


### PR DESCRIPTION
When debugging, the override.json needs to be deployed as well,
otherwise CSP will complain about the source files.