### PR TITLE
ws: Remove auth command from error message

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -593,15 +593,13 @@ parse_cockpit_spawn_results (CockpitAuth *self,
                  json_error ? json_error->message : NULL);
       g_error_free (json_error);
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
-                   "Invalid data from %s: no results",
-                   sl->command);
+                   "Authentication failed: no results");
     }
   else if (!cockpit_json_get_string (results, "error", NULL, &error_str) ||
            !cockpit_json_get_string (results, "message", NULL, &message))
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
-                   "Invalid data from %s: invalid results",
-                   sl->command);
+                   "Authentication failed: invalid results");
     }
   else
     {
@@ -610,7 +608,7 @@ parse_cockpit_spawn_results (CockpitAuth *self,
           if (!cockpit_json_get_string (results, "user", NULL, &user) || !user)
             {
               g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
-                           "Invalid data from %s process: missing user", sl->command);
+                           "Authentication failed: missing user");
             }
           else
             {
@@ -647,8 +645,7 @@ parse_cockpit_spawn_results (CockpitAuth *self,
               g_debug ("error from %s: %s: %s", sl->command,
                        error_str, message);
               g_set_error (error, COCKPIT_ERROR, COCKPIT_ERROR_FAILED,
-                           "Invalid data from %s: %s: %s",
-                           sl->command,
+                           "Authentication failed: %s: %s",
                            error_str,
                            message);
             }

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -450,13 +450,13 @@ static const ErrorFixture fixture_auth_denied = {
 };
 
 static const ErrorFixture fixture_auth_no_user = {
-  .error_message = "Invalid data from mock-auth-command process: missing user",
+  .error_message = "Authentication failed: missing user",
   .header = "testscheme no-user",
 };
 
 static const ErrorFixture fixture_auth_with_error = {
   .error_code = COCKPIT_ERROR_FAILED,
-  .error_message = "Invalid data from mock-auth-command: unknown: detail for error",
+  .error_message = "Authentication failed: unknown: detail for error",
   .header = "testscheme with-error",
 };
 
@@ -467,7 +467,7 @@ static const ErrorFixture fixture_auth_none = {
 };
 
 static const ErrorFixture fixture_auth_no_write = {
-  .error_message = "Invalid data from mock-auth-command: no results",
+  .error_message = "Authentication failed: no results",
   .header = "testscheme no-write",
   .warning = "*JSON data was empty"
 };


### PR DESCRIPTION
I changed my mind and now think that the auth command used is better left out of the displayed message and only used in the logged message.