### PR TITLE
cockpit-ws: allow to define Kerberos keytab for cockpit-session

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -320,6 +320,7 @@ typedef struct {
   gchar *remote_peer;
   gchar *auth_type;
   gchar *application;
+  gchar **envp;
   const gchar *command;
 } SpawnLoginData;
 
@@ -336,6 +337,7 @@ spawn_login_data_free (gpointer data)
   g_free (sl->auth_type);
   g_free (sl->application);
   g_free (sl->remote_peer);
+  g_strfreev (sl->envp);
   g_free (sl);
 }
 
@@ -362,6 +364,7 @@ spawn_child_setup (gpointer data)
 
 static CockpitPipe *
 spawn_process (const gchar *command,
+               gchar **envp,
                const gchar *type,
                GBytes *input,
                const gchar *remote_peer,
@@ -388,7 +391,7 @@ spawn_process (const gchar *command,
 
   g_debug ("spawning %s", argv[0]);
 
-  if (!g_spawn_async_with_pipes (NULL, (gchar **) argv, NULL,
+  if (!g_spawn_async_with_pipes (NULL, (gchar **) argv, envp,
                                  G_SPAWN_DO_NOT_REAP_CHILD | G_SPAWN_LEAVE_DESCRIPTORS_OPEN,
                                  spawn_child_setup, GINT_TO_POINTER (pwfds[1]),
                                  &pid, &in_fd, &out_fd, NULL, &error))
@@ -678,6 +681,7 @@ cockpit_auth_spawn_login_async (CockpitAuth *self,
   SpawnLoginData *sl;
   GBytes *input = NULL;
   const gchar *command;
+  const gchar *keytab;
 
   result = g_simple_async_result_new (G_OBJECT (self), callback, user_data,
                                       cockpit_auth_spawn_login_async);
@@ -695,10 +699,19 @@ cockpit_auth_spawn_login_async (CockpitAuth *self,
       sl->authorization = g_bytes_ref (input);
       sl->application = g_strdup (application);
       sl->command = command;
+      sl->envp = NULL;
 
       g_simple_async_result_set_op_res_gpointer (result, sl, spawn_login_data_free);
 
-      sl->process_pipe = spawn_process (command, type,
+      /* Allow redefining Kerberos keytab via cockpit.conf for GSSAPI use */
+      keytab = type_option (type, "keytab", NULL);
+      if (keytab && !gssapi_not_avail)
+        {
+          sl->envp = g_get_environ ();
+          sl->envp = g_environ_setenv (sl->envp, "KRB5_KTNAME", keytab, TRUE);
+        }
+
+      sl->process_pipe = spawn_process (command, sl->envp, type,
                                          input, remote_peer,
                                          &sl->auth_pipe);
 


### PR DESCRIPTION
Cockpit allows to authenticate with GSSAPI. As it is running as
a web server, browsers will use HTTP/cockpit.server@REALM as
a Kerberos service principal. Cockpit code uses default keytab
to search for HTTP/cockpit.server@REALM keys.

Allow cockpit-ws to redefine Kerberos keytab location with cockpit.conf:

[Negotiate]
  keytab = /path/to/keytab.file

When Cockpit runs on the same server as FreeIPA master, FreeIPA already
manages keys to HTTP/cockpit.server@REALM principal. Given that
cockpit-session runs as a privileged process, it would be able to retrieve
keys from the FreeIPA's /etc/httpd/conf/ipa.keytab with the following
configuration:

[Negotiate]
  keytab = /etc/httpd/conf/ipa.keytab

Signed-off-by: Alexander Bokovoy abokovoy@redhat.com
