### PR TITLE
kubernetes: Toggle nulecule deployment option

### DIFF
--- a/pkg/kubernetes/deploy.js
+++ b/pkg/kubernetes/deploy.js
@@ -38,6 +38,15 @@ define([
 
     var run_stage = false;
 
+    /* Only add the nulecule option if the basic
+     * dependencies are met.
+     */
+    nulecule.check_requirements().done(function () {
+        $("#deploy-app-type option[value='nulecule']")
+            .toggleClass('hidden', false);
+        $("#deploy-app-type").selectpicker('refresh');
+    });
+
     function finish_success() {
         var current_namespace = client.namespace();
         var added_namespace = $("#deploy-app-namespace").val();

--- a/pkg/kubernetes/index.html
+++ b/pkg/kubernetes/index.html
@@ -128,7 +128,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
                   <div id="deploy-app-type-area">
                     <select id="deploy-app-type" class="btn btn-default form-control selectpicker deploy-app-type-text">
                       <option translatable="yes" class="deploy-app-type-text" value="manifest">Kubernetes Manifest</option>
-                      <option translatable="yes" class="deploy-app-type-text" value="nulecule">Nulecule Application</option>
+                      <option translatable="yes" class="deploy-app-type-text hidden" value="nulecule">Nulecule Application</option>
                     </select>
                   </div>
                 </td>

--- a/pkg/kubernetes/nulecule.js
+++ b/pkg/kubernetes/nulecule.js
@@ -17,6 +17,18 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+/* Try to load docker and if it's not available
+ * return an empty module instead of an error
+ */
+require(['docker/docker'],
+    function () {},
+    function (err) {
+        require.undef("docker/docker");
+        define("docker/docker", [], function () {});
+        require(['docker/docker'], function () {});
+    }
+);
+
 define([
     "jquery",
     "base1/cockpit",
@@ -449,6 +461,16 @@ define([
 
     nulecule.nuleculeclient =  function client() {
         return new NuleculeClient();
+    };
+
+    nulecule.check_requirements =  function () {
+        if (docker) {
+            return cockpit.spawn(["ls", "/usr/bin/atomic"]);
+        } else {
+            var deferred = $.Deferred();
+            deferred.reject("No docker");
+            return deferred;
+        }
     };
 
     return nulecule;


### PR DESCRIPTION
When cockpit won't support nulecule, hide the deployment option.