### PR TITLE
test: Fix call to download_dir

### DIFF
--- a/test/testvm.py
+++ b/test/testvm.py
@@ -230,7 +230,8 @@ class Machine:
         if command:
             assert not environment, "Not yet supported"
             cmd += [command]
-            self.message("+", command)
+            if not quiet:
+                self.message("+", command)
         else:
             assert not input, "input not supported to script"
             cmd += ["sh", "-s"]

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -359,7 +359,7 @@ class Machine:
             subprocess.check_call(cmd)
             subprocess.check_call([ "find", dest, "-type", "f", "-exec", "chmod", "0644", "{}", ";" ])
         except:
-            self.message("Error while downloading journal")
+            self.message("Error while downloading directory '{0}'".format(source))
 
     def write(self, dest, content):
         """Write a file into the test machine


### PR DESCRIPTION
Also properly check results without resorting to exception handling.

Using exceptions for this is just bad design.

@jscotka This enabled the download of the full avocado results directory. Screenshots aren't generated in every case, but this needs to happen in a different place.