### PR TITLE
common: Fix test-stream teardown when test is skipped

### DIFF
--- a/src/common/test-stream.c
+++ b/src/common/test-stream.c
@@ -647,7 +647,8 @@ static void
 teardown_connect (TestConnect *tc,
                   gconstpointer data)
 {
-  g_object_unref (tc->address);
+  if (tc->address)
+    g_object_unref (tc->address);
   if (tc->conn_source)
     {
       g_source_destroy (tc->conn_source);


### PR DESCRIPTION
Otherwise this complains about a NULL tc->address in the
case where the test is skipped.