### PR TITLE
Use colors suggested by Patternfly folks for listing

### DIFF
--- a/pkg/base1/cockpit.css
+++ b/pkg/base1/cockpit.css
@@ -680,11 +680,7 @@ div.listing-maybe div.listing-body {
 
 /* When panel is a row of a table: head is white */
 tr.listing-item + tr.listing-panel div.listing-head {
-    background-color: white;
     border-top: 3px solid #0099d3;
-}
-tr.listing-item + tr.listing-panel div.listing-body {
-    background-color: #f6f6f6;
 }
 
 tbody.active .listing-head {
@@ -838,6 +834,7 @@ tbody.open tr.listing-head {
     border-style: solid;
     border-width: 1px 1px 0px 1px;
     border-top: 3px solid #0099d3;
+    background-color: #f6f6f6;
 }
 
 tr.listing-head + tr.listing-head {
@@ -851,7 +848,6 @@ tr.listing-head + tr.listing-head td {
 tr.listing-body td {
     padding: 20px 25px;
     font-size: 13px;
-    background-color: #f6f6f6;
 }
 
 .listing-body .alert {


### PR DESCRIPTION
With the head more gray and the body of the panel more white.
This matches up with how the timeline was colored.