### PR TITLE
test: Let cockpit.spec build the RHEL packages on RHEL

### DIFF
--- a/test/guest/lib/fedora.install
+++ b/test/guest/lib/fedora.install
@@ -8,7 +8,7 @@ cockpit-debuginfo"
 do_build=
 do_install=
 mock_opts=""
-args=$(getopt -o "vqs:" -l "verbose,quick,skip:,build,install" -- "$@")
+args=$(getopt -o "vqs:" -l "verbose,quick,skip:,build,install,rhel" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do
 	case $1 in
@@ -28,6 +28,14 @@ $2"
                 ;;
             --install)
                 do_install=t
+                ;;
+            --rhel)
+                # For RHEL we actually build in EPEL, which is based
+                # on CentOS.  On CentOS, the spec file has both
+                # %centos and %rhel defined, but it gives precedence
+                # to %centos, as it must.  To make it produce the RHEL
+                # packages, we explicitly undefine %centos here.
+                mock_opts="$mock_opts --define='centos 0'"
                 ;;
 	    --)
 		shift

--- a/test/guest/rhel-7.install
+++ b/test/guest/rhel-7.install
@@ -2,4 +2,4 @@
 
 set -e
 
-/var/lib/testvm/fedora.install --skip "cockpit-kubernetes" "$@"
+/var/lib/testvm/fedora.install --rhel --skip "cockpit-kubernetes" "$@"


### PR DESCRIPTION
and not the CentOS ones.