### PR TITLE
test: Ignore SELinux fighting with rhsmcertd-worker

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -592,6 +592,9 @@ systemctl start docker
         # https://bugzilla.redhat.com/show_bug.cgi?id=1298171
         "type=1400 .*denied.*comm=\"iptables\".*name=\"xtables.lock\".*",
 
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1299054
+        "type=1400 .*denied.*comm=\"rhsmcertd-worke\".*name=\".dbenv.lock\".*",
+
         # SELinux fighting with systemd: https://bugzilla.redhat.com/show_bug.cgi?id=1253319
         "(audit: )?type=1400 audit.*systemd-journal.*path=2F6D656D66643A73642D73797374656D642D636F726564756D202864656C6574656429",
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1299054