### PR TITLE
test: Don't say 'All tests passed' on success

### DIFF
--- a/test/github-task
+++ b/test/github-task
@@ -102,7 +102,7 @@ def stop_publishing(sink, ret):
         message = ret
         mark_failed()
     elif ret == 0:
-        message = "All tests passed"
+        message = "Tests passed"
         mark_passed()
     else:
         message = "{0} tests failed".format(ret)


### PR DESCRIPTION
This implies that every single test passed, whereas we routinely
skip tests and ignore known issues. Lets just say 'Tests passed'