### PR TITLE
test: Match github-task contexts on any substring match

### DIFF
--- a/test/testinfra.py
+++ b/test/testinfra.py
@@ -334,10 +334,10 @@ class GitHub(object):
         if context:
             for ctx in contexts.keys():
                 if except_context:
-                    if ctx.startswith(context):
+                    if context in ctx:
                         contexts.pop(ctx)
                 else:
-                    if not ctx.startswith(context):
+                    if context not in ctx:
                         contexts.pop(ctx)
 
         results = []


### PR DESCRIPTION
Look for the specified context string in the available contexts,
rather than expecting it as a prefix.