### PR TITLE
test: Skip 'make check' when installing for avocado/selenium tasks

### DIFF
--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -173,6 +173,7 @@ def main():
     parser = argparse.ArgumentParser(description='Run Cockpit Avocado test(s)')
     parser.add_argument('-v', '--verbose', dest="verbosity", action='store_true',
                         help='Verbose output')
+    parser.add_argument('-q', '--quick', action='store_true', help='Build faster')
     parser.add_argument('--install', dest='install', action='store_true',
                         help='Build and install Cockpit into test VMs')
     parser.add_argument("-b", "--browser", choices=['none', 'firefox', 'chrome'],
@@ -191,7 +192,13 @@ def main():
         sys.stderr.write("Building and installing Cockpit ...\n")
         subprocess.check_call([ os.path.join(topdir, "vm-download"), testinfra.DEFAULT_IMAGE, "selenium" ])
         subprocess.check_call([ os.path.join(topdir, "vm-reset") ])
-        subprocess.check_call([ os.path.join(topdir, "vm-install") ])
+
+        cmd = [ os.path.join(topdir, "vm-install") ]
+        if opts.verbosity:
+            cmd.append("--verbose")
+        if opts.quick:
+            cmd.append("--quick")
+        subprocess.check_call(cmd)
 
     regular_tests = [ "checklogin-basic.py", "checklogin-raw.py" ]
     browser_tests = [ "selenium-login.py" ]

--- a/test/github-task
+++ b/test/github-task
@@ -204,14 +204,14 @@ def main():
             cmd.append("--verbose")
 
     elif prefix == "avocado":
-        cmd = [ "./avocado/run-tests", "--install", "--tests" ]
+        cmd = [ "./avocado/run-tests", "--install", "--quick", "--tests" ]
         if opts.verbose:
             cmd.append("--verbose")
 
     elif prefix == "selenium":
         if value not in ['firefox', 'chrome']:
             ret = "Unknown browser for selenium test"
-        cmd = [ "./avocado/run-tests", "--install", "--selenium-tests", "--browser", value]
+        cmd = [ "./avocado/run-tests", "--install", "--quick", "--selenium-tests", "--browser", value]
         if opts.verbose:
             cmd.append("--verbose")
 


### PR DESCRIPTION
The idea of running 'make check' during our integration tests is
to have that run on various operating systems. The goal of the
avocado and selenium tests, when run during integration, is not
to do a spread of operating systems. So we can skip this step.