### PR TITLE
examples: Add a GTK+ Broadway example

### DIFF
--- a/examples/gtk-broadway/gtk.html
+++ b/examples/gtk-broadway/gtk.html
@@ -1,0 +1,94 @@
+<head>
+<title>GTK Example</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<script src="../base1/cockpit.js"></script>
+<style type="text/css">
+body { overflow: hidden; }
+</style>
+<script>
+    "use strict";
+
+    function broadway_js() {
+        /* Force connections through our own path */
+        var RealWebSocket = window.WebSocket;
+        window.WebSocket = function(loc, protocols) {
+            var url, loc = window.location.toString();
+            if (loc.indexOf('http:') === 0)
+                url = "ws://" + window.location.host;
+            else if (loc.indexOf('https:') === 0)
+                url = "wss://" + window.location.host;
+            url += "/cockpit/channel/" + cockpit.transport.csrf_token + "?" + window.btoa(JSON.stringify({
+                payload: "websocket-stream1",
+                address: "127.0.0.1",
+                port: 8085,
+                path: "/socket",
+                binary: "raw",
+            }));
+            return new RealWebSocket(url, protocols);
+        };
+
+        var script = document.createElement("script");
+        script.async = true;
+        script.type = 'text/javascript';
+        script.src = "/cockpit/channel/" + cockpit.transport.csrf_token + "?" + window.btoa(JSON.stringify({
+            payload: "http-stream2",
+            address: "127.0.0.1",
+            port: 8085,
+            binary: "raw",
+            method: "GET",
+            path: "/broadway.js",
+        }));
+
+        script.onload = function() {
+            connect(); /* defined in broadway.js */
+        };
+
+        script.onerror = function() {
+            console.warn("failed to load broadway.js");
+        };
+
+        document.head.appendChild(script);
+    }
+
+    function process(cmd, env) {
+        var proc = cockpit.channel({
+            "payload": "stream",
+            "spawn": cmd,
+            "err": "out",
+            "environ": env || undefined,
+        });
+
+        proc.addEventListener("message", function(ev, payload) {
+            console.log(payload);
+        });
+
+        proc.addEventListener("close", function(ev, options) {
+            console.warn(cmd[0] +  " exited " + (options.problem || ""));
+        });
+
+        return proc;
+    }
+
+    function applications() {
+        var environ = [ "GDK_BACKEND=broadway", "BROADWAY_DISPLAY=:5", "LANG=en_US.UTF-8" ];
+        process(["nautilus"], environ);
+        process(["gnome-calculator"], environ);
+    }
+
+    var started = false;
+    var broadwayd = process(["broadwayd", ":5"]);
+    broadwayd.addEventListener("message", function(ev, payload) {
+        if (!started) {
+            started = true;
+            broadway_js();
+            applications();
+        }
+    });
+</script>
+</head>
+<body>
+
+</body>
+</html>
+

--- a/examples/gtk-broadway/manifest.json
+++ b/examples/gtk-broadway/manifest.json
@@ -1,0 +1,12 @@
+{
+    "version": 0,
+
+    "tools": {
+        "gtk": {
+            "label": "GTK+ Example",
+            "path": "gtk.html"
+        }
+    },
+
+    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
+}

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -573,6 +573,7 @@ main (int argc,
   if (!g_getenv ("XDG_DATA_DIRS") && !g_str_equal (DATADIR, "/usr/share"))
     g_setenv ("XDG_DATA_DIRS", DATADIR, TRUE);
 
+  g_setenv ("LANG", "en_US.UTF-8", FALSE);
   g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
   g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
   g_setenv ("GIO_USE_VFS", "local", TRUE);

--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -441,8 +441,10 @@ cockpit_channel_response_create (CockpitWebService *service,
   chesp->transport = g_object_ref (transport);
   chesp->headers = g_hash_table_ref (headers);
   chesp->channel = cockpit_web_service_unique_channel (service);
-  chesp->logname = logname ? logname : chesp->channel;
   chesp->open = json_object_ref (open);
+
+  if (!cockpit_json_get_string (open, "path", chesp->channel, &chesp->logname))
+    chesp->logname = chesp->channel;
 
   json_object_set_string_member (open, "command", "open");
   json_object_set_string_member (open, "channel", chesp->channel);

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -203,7 +203,7 @@ cockpit_handler_external (CockpitWebServer *server,
   else
     {
       upgrade = g_hash_table_lookup (headers, "Upgrade");
-      if (upgrade && g_ascii_strcasecmp (upgrade, "websocket"))
+      if (upgrade && g_ascii_strcasecmp (upgrade, "websocket") == 0)
         {
           cockpit_channel_socket_open (service, open, path, io_stream, headers, input);
         }


### PR DESCRIPTION
This is an example that lets you use GTK+ (!) apps inside of Cockpit. GTK+ has broadway, which is HTML5 and WebSocket based and Cockpit provides the session for it.
