### PR TITLE
test: Prevent agressive teardown of the system during journal test

### DIFF
--- a/test/check-journal
+++ b/test/check-journal
@@ -199,7 +199,7 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
 
         # insert messages as errors because we know these will be shown by default
         m.execute("logger -p user.err --tag check-journal BEFORE BOOT");
-        m.spawn("sleep 0.1 && reboot", "reboot")
+        m.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")
         m.wait_reboot()
         m.execute("logger -p user.err --tag check-journal AFTER BOOT");
 


### PR DESCRIPTION
It seems we're losing log lines during reboot, and some tests
are failing because of that. Lets sync the disk before rebooting.

Fixes issues like:

	File "check-journal", line 215, in testBasic
  	  [ "check-journal", "BEFORE BOOT", "" ]