### PR TITLE
realmd: Install realmd stuff into 'realmd' package directory

### DIFF
--- a/pkg/realmd/Makefile.am
+++ b/pkg/realmd/Makefile.am
@@ -1,4 +1,4 @@
-realmddir = $(pkgdatadir)/domain
+realmddir = $(pkgdatadir)/realmd
 nodist_realmd_DATA = \
 	pkg/realmd/bundle.min.js.gz \
 	$(NULL)

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -194,8 +194,8 @@ find %{buildroot}%{_datadir}/%{name}/base1 -type f >> shell.list
 echo '%dir %{_datadir}/%{name}/dashboard' >> shell.list
 find %{buildroot}%{_datadir}/%{name}/dashboard -type f >> shell.list
 
-echo '%dir %{_datadir}/%{name}/domain' >> shell.list
-find %{buildroot}%{_datadir}/%{name}/domain -type f >> shell.list
+echo '%dir %{_datadir}/%{name}/realmd' >> shell.list
+find %{buildroot}%{_datadir}/%{name}/realmd -type f >> shell.list
 
 echo '%dir %{_datadir}/%{name}/shell' >> shell.list
 find %{buildroot}%{_datadir}/%{name}/shell -type f >> shell.list

--- a/tools/debian/cockpit-shell.install
+++ b/tools/debian/cockpit-shell.install
@@ -1,6 +1,6 @@
 usr/share/cockpit/base1/
 usr/share/cockpit/dashboard/
-usr/share/cockpit/domain/
+usr/share/cockpit/realmd/
 usr/share/cockpit/shell/
 usr/share/cockpit/system/
 usr/share/cockpit/users/


### PR DESCRIPTION
Now that we have the "name" field in manifest.json, we should be installing to directories that more clearly reflect what the package is implemented about.