### PR TITLE
shell: Use a narrower sidebar

### DIFF
--- a/pkg/shell/shell.css
+++ b/pkg/shell/shell.css
@@ -510,12 +510,12 @@ html, body {
     padding-left: 15px;
     padding-right: 15px;
     position: static;
-    min-width: 209px;
+    min-width: 179px;
 }
 
 #machine-link span {
     display: inline-block;
-    width: 130px;
+    width: 100px;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
@@ -616,7 +616,7 @@ iframe.container-frame {
 /* For when displayed normally */
 @media (min-width: 768px) {
     #sidebar {
-        width: 210px;
+        width: 180px;
     }
     .machine-avatar {
         display: inline;

--- a/pkg/sosreport/manifest.json
+++ b/pkg/sosreport/manifest.json
@@ -3,7 +3,7 @@
 
     "tools": {
         "index": {
-            "label": "Create diagnostic report"
+            "label": "Diagnostic report"
         }
     },
 


### PR DESCRIPTION
Make the sidebar 30px narrow. There's a lot of wasted space here
and it becomes really apparent at zoom. Admins like their screen
real estate