### PR TITLE
ws: Actually exit when idle

### DIFF
--- a/doc/man/cockpit-ws.xml
+++ b/doc/man/cockpit-ws.xml
@@ -92,7 +92,7 @@ $ sudo remotectl certificate
       <citerefentry>
         <refentrytitle>systemd</refentrytitle><manvolnum>1</manvolnum>
       </citerefentry>
-      then <command>cockpit-ws</command> will exit after 10 minutes
+      then <command>cockpit-ws</command> will exit after 90 seconds
       if nobody logs in, or after the last user is disconnected.
     </para>
   </refsect1>

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -62,7 +62,7 @@
 guint cockpit_ws_service_idle = 15;
 
 /* Timeout of everything when noone is connected */
-guint cockpit_ws_process_idle = 600;
+guint cockpit_ws_process_idle = 90;
 
 static guint sig__idling = 0;
 
@@ -1198,6 +1198,7 @@ static void
 on_web_service_destroy (CockpitWebService *service,
                         gpointer data)
 {
+  on_web_service_idling (service, data);
   cockpit_authenticated_destroy (data);
 }
 


### PR DESCRIPTION
The logic to actually exit when cockpit-ws is idle had regressed
and it would no longer quit.

Add a test to cover the case.