### PR TITLE
test: Clean up test image dependencies

### DIFF
--- a/test/guest/fedora-22.setup
+++ b/test/guest/fedora-22.setup
@@ -77,9 +77,6 @@ dnf -y upgrade
 #
 dnf -y copr enable phatina/storaged
 
-# We need avocado for some integration tests
-dnf -y -q copr enable lmr/Autotest
-
 dnf -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
 
 # Prepare for building

--- a/test/guest/fedora-testing.setup
+++ b/test/guest/fedora-testing.setup
@@ -71,10 +71,6 @@ dnf config-manager --set-enabled updates-testing
 dnf -y upgrade dnf
 dnf -y upgrade
 
-# We need avocado for some integration tests
-dnf -y -q copr enable lmr/Autotest
-
-
 dnf -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
 
 # Prepare for building

--- a/test/guest/rhel-7.setup
+++ b/test/guest/rhel-7.setup
@@ -97,9 +97,6 @@ rpm -Uvh epel-release-*.rpm
 cd
 rm -rf /tmp/dep
 
-# get autotest
-wget -T 15 -t 4 -O /etc/yum.repos.d/lmr-Autotest-epel-7.repo https://copr.fedoraproject.org/coprs/lmr/Autotest/repo/epel-7/lmr-Autotest-epel-7.repo
-
 yum install --nogpgcheck -y $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
 
 # Prepare for building


### PR DESCRIPTION
Avocado testing repositories don't need to be enabled on systems
that won't be running avocado tests.

This is a follow-up to #3526.
Since the changes are minor and don't actually affect the installed packages, I don't think we need new images.