### PR TITLE
test: Add cockpituous to the github whitelist

### DIFF
--- a/test/files/github-whitelist
+++ b/test/files/github-whitelist
@@ -1,4 +1,5 @@
 andreasn
+cockpituous
 dperpeet
 jscotka
 mvollmer


### PR DESCRIPTION
We need this so that automatically created images are
also automatically tested.

For pull requests like #3604 