### PR TITLE
test: Add global timeout to github task

### DIFF
--- a/test/testpulltask.py
+++ b/test/testpulltask.py
@@ -139,16 +139,16 @@ class GithubPullTask(object):
         ret = None
         # Figure out what to do next
         if prefix == "verify":
-            cmd = [ "./check-verify", "--install", "--jobs", str(opts.jobs) ]
+            cmd = [ "timeout", "60m", "./check-verify", "--install", "--jobs", str(opts.jobs) ]
         elif prefix == "avocado":
-            cmd = [ "./avocado/run-tests", "--install", "--quick", "--tests" ]
+            cmd = [ "timeout", "20m", "./avocado/run-tests", "--install", "--quick", "--tests" ]
         elif prefix == "selenium":
             os.environ["TEST_OS"] = "fedora-23"
             if value not in ['firefox', 'chrome']:
                 ret = "Unknown browser for selenium test"
-            cmd = [ "./avocado/run-tests", "--install", "--quick", "--selenium-tests", "--browser", value]
+            cmd = [ "timeout", "20m", "./avocado/run-tests", "--install", "--quick", "--selenium-tests", "--browser", value]
         elif prefix == "image":
-            cmd = [ "./containers/run-tests", "--install", "--container", value]
+            cmd = [ "timeout", "90m", "./containers/run-tests", "--install", "--container", value]
         else:
             ret = "Unknown context"
 


### PR DESCRIPTION
These tests might hang for some reason and we want our machines to
recover automatically.