### PR TITLE
test: Also take style.visibility into account

### DIFF
--- a/test/phantom-lib.js
+++ b/test/phantom-lib.js
@@ -149,7 +149,7 @@ function ph_set_checked (sel, val)
 function ph_is_visible (sel)
 {
     var el = ph_find(sel);
-    return (el.offsetWidth > 0 || el.offsetHeight > 0);
+    return (el.offsetWidth > 0 || el.offsetHeight > 0) && el.style.visibility != "hidden";
 }
 
 function ph_is_present(sel)


### PR DESCRIPTION
When waiting for an element to become visible.

This is needed for b.wait_visible('#login') on the login page, at
least.