### PR TITLE
Image refresh for fedora-22

### DIFF
--- a/test/images/fedora-22
+++ b/test/images/fedora-22
@@ -1,1 +1,0 @@
-fedora-22-07675180162c497fcce8e89d28ed9cbb6c99540d.qcow2


### PR DESCRIPTION
Image creation for fedora-22 in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-22-2016-02-02/