### PR TITLE
Image refresh for fedora-atomic

### DIFF
--- a/test/images/fedora-atomic
+++ b/test/images/fedora-atomic
@@ -1,1 +1,1 @@
-fedora-atomic-6260f86fc3892d7a77d4911f891d0516ec06d7e7.qcow2
+fedora-atomic-64f5e52096e7f0949372c469bf48c53ad9ac96d1.qcow2


### PR DESCRIPTION
Image creation for fedora-atomic in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-atomic-2016-02-02/