### PR TITLE
Image refresh for fedora-23

### DIFF
--- a/test/images/fedora-23
+++ b/test/images/fedora-23
@@ -1,1 +1,0 @@
-fedora-23-0cb312e9fcbd50c42e026f6bfc7ebcd802c11be3.qcow2


### PR DESCRIPTION
Image creation for fedora-23 in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-23-2016-02-02/