### PR TITLE
Image refresh for fedora-testing

### DIFF
--- a/test/images/fedora-testing
+++ b/test/images/fedora-testing
@@ -1,1 +1,0 @@
-fedora-testing-8e2264e6a82597630b008bbfbee457954a6ec3af.qcow2


### PR DESCRIPTION
Image creation for fedora-testing in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-testing-2016-02-02/