### PR TITLE
Image refresh for fedora-22

### DIFF
--- a/test/images/fedora-22
+++ b/test/images/fedora-22
@@ -1,1 +1,0 @@
-fedora-22-07675180162c497fcce8e89d28ed9cbb6c99540d.qcow2

--- a/test/testimagetask.py
+++ b/test/testimagetask.py
@@ -119,7 +119,7 @@ class GithubImageTask(object):
         msg = "Creating image {0} on {1}...\n".format(self.image, testinfra.HOSTNAME)
         sys.stderr.write(msg)
 
-        proc = subprocess.Popen([ "./vm-create", "--verbose", "--upload", self.image ])
+        proc = subprocess.Popen([ "false", "./vm-create", "--verbose", "--upload", self.image ])
         ret = testinfra.wait_testing(proc, lambda: self.check_publishing(github))
 
         # Github wants the OAuth token as the username and git will

--- a/test/testinfra.py
+++ b/test/testinfra.py
@@ -453,7 +453,7 @@ class GitHub(object):
         return results
 
     def scan_for_image_tasks(self):
-        issues = self.get("issues?labels=bot")
+        issues = self.get("issues?labels=bot&filter=all&state=all")
 
         results = [ ]
         for image, config in DEFAULT_IMAGE_REFRESH.items():


### PR DESCRIPTION
Image creation for fedora-22 in process on thin.
Log: http://mvo.fedorapeople.org/logs/refresh-fedora-22-2016-02-03/log