### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-4906c6dfde5a455a4392f38d433b48e4ed2c1914.qcow2
+debian-unstable-40beb6a9d38fa81c4ef73e6e0cac7c323f0652e7.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-02-03/