### PR TITLE
test: Don't fail when loading invalid JSON from Github cache

### DIFF
--- a/test/testinfra.py
+++ b/test/testinfra.py
@@ -272,7 +272,10 @@ class GitHub(object):
             if not os.path.exists(path):
                 return None
             with open(path, 'r') as fp:
-                return json.load(fp)
+                try:
+                    return json.load(fp)
+                except ValueError:
+                    return None
         else:
             with open(path, 'w') as fp:
                 json.dump(response, fp)


### PR DESCRIPTION
This is a real world scenario that has happened on certain
verify machines. One file in the cache directory contains
invalid JSON data, and this causes github-task to fail.