### PR TITLE
Image refresh for fedora-22

### DIFF
--- a/test/images/fedora-22
+++ b/test/images/fedora-22
@@ -1,1 +1,0 @@
-fedora-22-07675180162c497fcce8e89d28ed9cbb6c99540d.qcow2

--- a/test/testimagetask.py
+++ b/test/testimagetask.py
@@ -53,6 +53,16 @@ class GithubImageTask(object):
         self.sink = testinfra.Sink(host, identifier, status)
 
     def check_publishing(self, github):
+        # If the most recently created issue for our image does not
+        # mention our host, we have been overtaken and should stop.
+
+        expected_title = testinfra.ISSUE_TITLE_IMAGE_REFRESH.format(self.image)
+        expected_description = "Image creation for %s in process on %s." % (self.image, testinfra.HOSTNAME)
+
+        issues = self.get("issues?labels=bot&filter=all&state=all")
+        for issue in issues:
+            if issue['title'] == expected_title:
+                return issue['description'].startswith(expected_description)
         return True
 
     def stop_publishing(self, github, ret, branch):


### PR DESCRIPTION
Image creation for fedora-22 in process on thin.
Log: http://mvo.fedorapeople.org/logs/refresh-fedora-22-2016-02-05/log