### PR TITLE
test: Let vm-download fix symlinks in images dir

### DIFF
--- a/test/vm-download
+++ b/test/vm-download
@@ -41,6 +41,12 @@ def download(link, force, stores):
         os.makedirs(DATA)
 
     dest = os.path.join(DATA, os.readlink(link))
+
+    # we have the file but there is not valid link
+    if os.path.exists(dest) and not os.path.exists(link):
+        os.symlink(dest, os.path.join(IMAGES, os.readlink(link)))
+
+    # file already exists
     if not force and os.path.exists(dest):
         return
 


### PR DESCRIPTION
Cleaning the git repo can remove symlinks in the test/images directory.
If the image is still present in TEST_DATA/images, we need to
recreate the symlinks in order for tests to run properly.