### PR TITLE
doc: Add documentation for using user in "host" args

### DIFF
--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -281,7 +281,8 @@ process = cockpit.spawn(args, [options])
           <term><code>"host"</code></term>
           <listitem><para>The remote host to spawn the process on. If no host is specified
             then the correct one will be automatically selected based on the page
-            calling this function.</para></listitem>
+            calling this function. If an alternate user is required, then it must be
+            specified as a <code>"user@myhost"</code> value.</para></listitem>
         </varlistentry>
         <varlistentry>
           <term><code>"environ"</code></term>
@@ -639,7 +640,8 @@ client = cockpit.dbus(name, [options])
           <term><code>"host"</code></term>
           <listitem><para>The host to open the channel to. If no host is specified
             then the correct one will be automatically selected based on the page
-            calling this function.</para></listitem>
+            calling this function. If an alternate user is required, then it must be
+            specified as a <code>"user@myhost"</code> value.</para></listitem>
         </varlistentry>
         <varlistentry>
           <term><code>"superuser"</code></term>
@@ -2486,7 +2488,8 @@ channel = cockpit.channel(options)
           <term><code>"host"</code></term>
           <listitem><para>The host to open the channel to. If no host is specified
             then the correct one will be automatically selected based on the page
-            calling this function.</para></listitem>
+            calling this function. If an alternate user is required, then it must be
+            specified as a <code>"user@myhost"</code> value.</para></listitem>
         </varlistentry>
         <varlistentry>
           <term><code>"payload"</code></term>

--- a/doc/guide/cockpit-channel.xml
+++ b/doc/guide/cockpit-channel.xml
@@ -39,7 +39,8 @@ channel = cockpit.channel(options)
         <term><code>"host"</code></term>
         <listitem><para>The host to open the channel to. If no host is specified
           then the correct one will be automatically selected based on the page
-          calling this function.</para></listitem>
+          calling this function. If an alternate user is required, then it must be
+            specified as a <code>"user@myhost"</code> value.</para></listitem>
       </varlistentry>
       <varlistentry>
         <term><code>"payload"</code></term>

--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -112,7 +112,8 @@ client = cockpit.dbus(name, [options])
         <term><code>"host"</code></term>
         <listitem><para>The host to open the channel to. If no host is specified
           then the correct one will be automatically selected based on the page
-          calling this function.</para></listitem>
+          calling this function. If an alternate user is required, then it must be
+            specified as a <code>"user@myhost"</code> value.</para></listitem>
       </varlistentry>
       <varlistentry>
         <term><code>"superuser"</code></term>

--- a/doc/guide/cockpit-spawn.xml
+++ b/doc/guide/cockpit-spawn.xml
@@ -51,7 +51,8 @@ process = cockpit.spawn(args, [options])
         <term><code>"host"</code></term>
         <listitem><para>The remote host to spawn the process on. If no host is specified
           then the correct one will be automatically selected based on the page
-          calling this function.</para></listitem>
+          calling this function. If an alternate user is required, then it must be
+            specified as a <code>"user@myhost"</code> value.</para></listitem>
       </varlistentry>
       <varlistentry>
         <term><code>"environ"</code></term>


### PR DESCRIPTION
When using a "host" option to a cockpit function, if an alternate
user is require it needs to be specified.