### PR TITLE
Vagrantfile: Only use rsync for syncing data

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -19,11 +19,20 @@ Vagrant. In the top level directory of the repository, you can run:
     $ sudo vagrant up
 
 Cockpit will listen on port 9090 of the vagrant VM started, and also
-port 9090 of localhost if cockpit is not running locally. Any changes
-you make to the system in the Vagrant VM won't affect the host machine.
+port 9090 of localhost if cockpit is not running locally. Access Cockpit
+at:
+
+    https://localhost:9090
+
+Any changes you make to the system in the Vagrant VM won't affect the
+host machine.
 
 You can edit files in the `pkg/` subdirectory of the Cockpit sources
-and the changes should take effect immediately in the Vagrant VM.
+and the changes should take effect after syncing them to the Vagrant
+VM. Use one of the folowing commands to sync:
+
+    $ sudo vagrant rsync
+    $ sudo vagrant rsync-auto
 
 The Vagrant VM is in debug mode, which means that resources will load
 into your web browser more slowly than in a production install of

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,10 +1,13 @@
 # vi: set ft=ruby :
+#
+# See HACKING.md for how to use this Vagrantfile.
+#
 
 Vagrant.configure(2) do |config|
 
     config.vm.box = "fedora-23-cloud-base"
     config.vm.synced_folder ".", "/vagrant", disabled: true
-    config.vm.synced_folder ".", "/cockpit", type: "nfs", nfs_udp: false
+    config.vm.synced_folder ".", "/cockpit", type: "rsync", rsync__exclude: ['/src/', '/test/', '/node_modules/', '/doc/', '/examples/', '/images/', '/build/', '/x86_64/' ]
     config.vm.network "private_network", ip: "192.168.50.10"
     config.vm.network "forwarded_port", guest: 9090, host: 9090
     config.vm.hostname = "cockpit-devel"


### PR DESCRIPTION
This is because NFS has caused so many problems for people
trying to use the Vagrantfile. It's just not reliable.

The downside is that after this pull request is merged, folks
need to run the following command on the client to sync changes
into the vagrant VM, each time such a change is made:

 $ sudo vagrant rsync