### PR TITLE
doc: Add documentation for "host" args

### DIFF
--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -279,9 +279,10 @@ process = cockpit.spawn(args, [options])
         </varlistentry>
         <varlistentry>
           <term><code>"host"</code></term>
-          <listitem><para>The remote host to spawn the process on. If no host is specified
-            then the correct one will be automatically selected based on the page
-            calling this function.</para></listitem>
+          <listitem><para>The remote host to spawn the process on. If an alternate user
+            or port is required it can be specified as <code>"user@myhost:port"</code>.
+            If no host is specified then the correct one will be automatically selected based
+            on the page calling this function.</para></listitem>
         </varlistentry>
         <varlistentry>
           <term><code>"environ"</code></term>
@@ -637,8 +638,9 @@ client = cockpit.dbus(name, [options])
         </varlistentry>
         <varlistentry>
           <term><code>"host"</code></term>
-          <listitem><para>The host to open the channel to. If no host is specified
-            then the correct one will be automatically selected based on the page
+          <listitem><para>The host to open the channel to. If an alternate user or port is
+            required it can be specified as <code>"user@myhost:port"</code>. If no host
+            is specified then the correct one will be automatically selected based on the page
             calling this function.</para></listitem>
         </varlistentry>
         <varlistentry>
@@ -2484,9 +2486,10 @@ channel = cockpit.channel(options)
         </varlistentry>
         <varlistentry>
           <term><code>"host"</code></term>
-          <listitem><para>The host to open the channel to. If no host is specified
-            then the correct one will be automatically selected based on the page
-            calling this function.</para></listitem>
+          <listitem><para>The host to open the channel to. If an alternate user or port is
+            required it can be specified as <code>"user@myhost:port"</code>. If no host
+            is specified then the correct one will be automatically selected based on the
+            page calling this function.</para></listitem>
         </varlistentry>
         <varlistentry>
           <term><code>"payload"</code></term>

--- a/doc/guide/cockpit-channel.xml
+++ b/doc/guide/cockpit-channel.xml
@@ -37,8 +37,9 @@ channel = cockpit.channel(options)
       </varlistentry>
       <varlistentry>
         <term><code>"host"</code></term>
-        <listitem><para>The host to open the channel to. If no host is specified
-          then the correct one will be automatically selected based on the page
+        <listitem><para>The host to open the channel to. If an alternate user or port is
+          required it can be specified as <code>"user@myhost:port"</code>. If no host
+          is specified then the correct one will be automatically selected based on the page
           calling this function.</para></listitem>
       </varlistentry>
       <varlistentry>

--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -110,8 +110,9 @@ client = cockpit.dbus(name, [options])
       </varlistentry>
       <varlistentry>
         <term><code>"host"</code></term>
-        <listitem><para>The host to open the channel to. If no host is specified
-          then the correct one will be automatically selected based on the page
+        <listitem><para>The host to open the channel to. If an alternate user or port is
+          required it can be specified as <code>"user@myhost:port"</code>. If no host is
+          specified then the correct one will be automatically selected based on the page
           calling this function.</para></listitem>
       </varlistentry>
       <varlistentry>

--- a/doc/guide/cockpit-spawn.xml
+++ b/doc/guide/cockpit-spawn.xml
@@ -49,8 +49,9 @@ process = cockpit.spawn(args, [options])
       </varlistentry>
       <varlistentry>
         <term><code>"host"</code></term>
-        <listitem><para>The remote host to spawn the process on. If no host is specified
-          then the correct one will be automatically selected based on the page
+        <listitem><para>The remote host to spawn the process on. If an alternate user or port is
+          required it can be specified as <code>"user@myhost:port"</code>. If no host is
+          specified then the correct one will be automatically selected based on the page
           calling this function.</para></listitem>
       </varlistentry>
       <varlistentry>


### PR DESCRIPTION
When using a "host" option to a cockpit function, if an alternate user or port is needed it needs to be
specified.