### PR TITLE
storaged: harmonize sizes of disks in storage dialogs

### DIFF
--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -142,7 +142,7 @@
 }
 
 .available-disks-group .list-group-item label {
-    padding: 10px 15px;
+    padding: 3px 10px;
 }
 
 .available-disks-group .checkbox label {

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -149,9 +149,19 @@
     width: 100%;
 }
 
+.available-disks-group .checkbox label span {
+    display: block;
+    margin-left: 20px;
+    margin-top: 6px;
+    line-height: 20px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .available-disks-group .checkbox label input[type="checkbox"] {
     margin-left: auto;
-    position: relative;
+    margin-top: 8px;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
Make the list of disks in the storage dialogs the same size as the ones
in the network dialogs.