### PR TITLE
Image refresh for fedora-23

### DIFF
--- a/test/images/fedora-23
+++ b/test/images/fedora-23
@@ -1,1 +1,1 @@
-fedora-23-898c28217cffbf9c9f883a122fff8a28b2967cce.qcow2
+fedora-23-ccf0e469e0de0a4faf327911193be1e15e6c5098.qcow2


### PR DESCRIPTION
Image creation for fedora-23 in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-23-2016-02-09/