### PR TITLE
Image refresh for fedora-testing

### DIFF
--- a/test/images/fedora-testing
+++ b/test/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-957c6bb981d6a7a7964ec7aeda89a5aef8f87e8b.qcow2
+fedora-testing-06106c53724f437b71a7a332ccd5ca8269597142.qcow2


### PR DESCRIPTION
Image creation for fedora-testing in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-testing-2016-02-09/