### PR TITLE
storage: Fix adjective

### DIFF
--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -482,7 +482,7 @@
             </td>
           </tr>
           <tr>
-            <td translatable="yes" context="storage">Multipath Devices</td>
+            <td translatable="yes" context="storage">Multipathed Devices</td>
             <td>{{#Devices}}{{.}} {{/Devices}}</td>
           </tr>
           {{/Multipath}}

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -67,10 +67,10 @@ class TestStorage(StorageCase):
         b.wait_in_text(detail_row_value(5), "/dev/sda")
 
         # Add another path to the same disk.  The primary device file
-        # should disappear and multipath devices should be listed.
+        # should disappear and multipathed devices should be listed.
         m.add_disk_path(disk)
         b.wait_text_not(detail_row_value(5), "/dev/sda")
-        wait_detail_row(6, "Multipath Devices")
+        wait_detail_row(6, "Multipathed Devices")
         b.wait_in_text(detail_row_value(6), "/dev/sda")
         b.wait_in_text(detail_row_value(6), "/dev/sdb")
 


### PR DESCRIPTION
Properly speaking, these devices have been multipathed (by multipath).
The parent device of the devices is the actual "multipath" device.