### PR TITLE
test: Allow connection to fail on restart

### DIFF
--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -33,6 +33,7 @@ class TestJournal(MachineCase):
 
         self.allow_restart_journal_messages()
         self.allow_journal_messages(".*Failed to get realtime timestamp: Cannot assign requested address.*")
+        self.allow_journal_messages("g_dbus_connection_call_finish_internal: assertion 'G_IS_DBUS_CONNECTION (connection)' failed")
 
         def inject_extras():
             b.eval_js("""


### PR DESCRIPTION
I've seen this a few times on fedora atomic (e.g. [here](https://fedorapeople.org/groups/cockpit/logs/pull-3727-9cd5091c-verify-fedora-atomic/log.html#62)):
```
# ----------------------------------------------------------------------
# testBasic (check_shutdown_restart.TestShutdownRestart)
#
Restarting browser...
> transport closed: disconnected
> can't get NTPSynchronized property Server has closed the connection.
Unexpected journal message 'g_dbus_connection_call_finish_internal: assertion 'G_IS_DBUS_CONNECTION (connection)' failed'
Journal database copied to TestShutdownRestart-testBasic-10.111.112.103-FAIL.journal
Journal extracted to TestShutdownRestart-testBasic-10.111.112.103-FAIL.log
Journal database copied to TestShutdownRestart-testBasic-10.111.126.226-FAIL.journal
Journal extracted to TestShutdownRestart-testBasic-10.111.126.226-FAIL.log
Wrote TestShutdownRestart-testBasic-FAIL.png
Journal database copied to TestShutdownRestart-testBasic-10.111.112.103-FAIL.journal
Journal extracted to TestShutdownRestart-testBasic-10.111.112.103-FAIL.log
Journal database copied to TestShutdownRestart-testBasic-10.111.126.226-FAIL.journal
Journal extracted to TestShutdownRestart-testBasic-10.111.126.226-FAIL.log
not ok 62 testBasic (check_shutdown_restart.TestShutdownRestart)
Traceback (most recent call last):
  File "./verify/check-shutdown-restart", line 70, in testBasic
    self.check_journal_messages()
  File "/build/cockpit/test/testlib.py", line 607, in check_journal_messages
    raise Error(first)
Error: g_dbus_connection_call_finish_internal: assertion 'G_IS_DBUS_CONNECTION (connection)' failed
```
