### PR TITLE
Image refresh for fedora-22

### DIFF
--- a/test/images/fedora-22
+++ b/test/images/fedora-22
@@ -1,1 +1,1 @@
-fedora-22-07675180162c497fcce8e89d28ed9cbb6c99540d.qcow2
+fedora-22-bb220f18d80deaf00aecf40bb79a9556c01d75b7.qcow2


### PR DESCRIPTION
Image creation for fedora-22 in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-22-2016-02-13/