### PR TITLE
test: Remove cockpit-bridge and test-server from test-assets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -185,7 +185,6 @@ install-test-assets: $(testassets_programs) $(testassets_data) $(testassets_syst
         done
 	cd $(srcdir); for d in $(testassets_data); do $(INSTALL_DATA) -D $$d $(DESTDIR)$(testassetsdir)/$$d; done
 	for d in $(testassets_systemdunit_data); do $(INSTALL_DATA) $$d $(DESTDIR)$(systemdunitdir); done
-	ln -sn $(libexecdir)/cockpit-bridge $(DESTDIR)$(testassetsdir)/cockpit-bridge
 
 clean-local:
 	find $(builddir) -name '*.gc??' -delete

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -148,8 +148,6 @@ EXTRA_DIST += \
 noinst_PROGRAMS += test-server
 check_PROGRAMS += test-server
 
-testassets_programs += test-server
-
 test_server_SOURCES = src/ws/test-server.c $(mock_dbus_sources)
 nodist_test_server_SOURCES = $(test_built_sources)
 test_server_CFLAGS = 					\


### PR DESCRIPTION
They are not needed.