### PR TITLE
test: Don't clear mock caches on rhel-7

### DIFF
--- a/test/guest/lib/zero-disk.setup
+++ b/test/guest/lib/zero-disk.setup
@@ -18,9 +18,26 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-# on Debian we don't want to delete pbuilder or cracklib
+# We don't want to delete the pbuilder caches since we need them
+# during build.  Mock with --offline and dnf is happy without caches,
+# but with yum it isn't, so we provide an option to also leave the
+# mock caches in place.
+#
+# We also want to keep cracklib since otherwise password quality
+# checks break on Debian.
+
+keep="! -path /var/cache/pbuilder ! -path /var/cache/cracklib"
+while [ $# -gt 0 ]; do
+    case $1 in
+	--keep-mock-cache)
+            keep="$keep ! -path /var/cache/mock"
+	    ;;
+    esac
+    shift
+done
+
 if [ -d "/var/cache" ]; then
-    find /var/cache/* -maxdepth 0 -depth -name "*" ! -path /var/cache/pbuilder ! -path /var/cache/cracklib -exec rm -rf {} \;
+    find /var/cache/* -maxdepth 0 -depth -name "*" $keep -exec rm -rf {} \;
 fi
 rm -rf /var/tmp/*
 rm -rf /var/log/journal/*

--- a/test/guest/rhel-7.setup
+++ b/test/guest/rhel-7.setup
@@ -137,7 +137,7 @@ if type "docker" >/dev/null 2>&1; then
 fi
 
 yum clean all
-/var/lib/testvm/zero-disk.setup
+/var/lib/testvm/zero-disk.setup --keep-mock-cache
 
 # HACK - kdump.service interferes with our storage tests, by loading
 # the system for some time after boot and thereby causing a race

--- a/test/images/rhel-7
+++ b/test/images/rhel-7
@@ -1,1 +1,1 @@
-rhel-7-d91e28c24b01c0e23a18e50a641bcb9971e3b34f.qcow2
+rhel-7-e3d2a3c636cd2c2c54626e22b86e7f17063de6cc.qcow2


### PR DESCRIPTION
This also includes a new rhel-7 image.