### PR TITLE
test: Pull cockpit/ws docker image when setting up the Atomics

### DIFF
--- a/test/guest/lib/atomic.setup
+++ b/test/guest/lib/atomic.setup
@@ -29,6 +29,9 @@ ostree checkout "$ref" /var/local-tree
 # docker images that we need for integration testing
 /var/lib/testvm/docker-images.setup
 
+# we need cockpit/ws as well
+docker pull cockpit/ws
+
 # reduce image size
 /var/lib/testvm/zero-disk.setup
 

--- a/test/images/fedora-atomic
+++ b/test/images/fedora-atomic
@@ -1,1 +1,1 @@
-fedora-atomic-c93cb6949e7d03141de742477ba42f15e4225762.qcow2
+fedora-atomic-7d92b89ca74022ee8ccb3c93948046fa0f3dde1b.qcow2


### PR DESCRIPTION
This was accidentally dropped by c4c528b.