### PR TITLE
Image refresh for fedora-testing

### DIFF
--- a/test/images/fedora-testing
+++ b/test/images/fedora-testing
@@ -1,1 +1,0 @@
-fedora-testing-79f78430488dbd37e1715a338671f3ca521645fb.qcow2


### PR DESCRIPTION
Image creation for fedora-testing in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-testing-2016-02-16/