### PR TITLE
test: Don't cache virt-builder templates during a GitHub task

### DIFF
--- a/test/github-task
+++ b/test/github-task
@@ -61,7 +61,7 @@ def main():
         if not config:
             print "Unknown image:", image
             return 1
-        task = testimagetask.GithubImageTask("refresh-" + image, image, config)
+        task = testimagetask.GithubImageTask("refresh-" + image, image, config, None)
     else:
         sys.stderr.write("Talking to GitHub ...\n")
         task_entries = github.scan(opts.publish, opts.context, opts.except_context)

--- a/test/guest/debian-unstable.bootstrap
+++ b/test/guest/debian-unstable.bootstrap
@@ -7,7 +7,12 @@ BASE=$(dirname $0)
 out=$1
 arch=$2
 
+if [ "$VIRT_BUILDER_NO_CACHE" == "yes" ]; then
+    virt_builder_caching="--no-cache"
+fi
+
 virt-builder debian-8 \
+             $virt_builder_caching \
              --output "$out" \
              --size 8G \
              --format qcow2 \

--- a/test/guest/fedora.build
+++ b/test/guest/fedora.build
@@ -41,9 +41,14 @@ os=$2
 arch=$3
 test -z "$BOOTSTRAP_VOLUME_SIZE" && BOOTSTRAP_VOLUME_SIZE="8G"
 
+if [ "$VIRT_BUILDER_NO_CACHE" == "yes" ]; then
+    virt_builder_caching="--no-cache"
+fi
+
 # we can't use virt-builder --ssh-inject until all our target systems support this
 
 virt-builder "$os" \
+             $virt_builder_caching \
              --output "$out" \
              --size $BOOTSTRAP_VOLUME_SIZE \
              --format qcow2 \

--- a/test/testimagetask.py
+++ b/test/testimagetask.py
@@ -201,6 +201,7 @@ class GithubImageTask(object):
             cmd += [ "--store", self.config['store'] ]
         cmd += [ self.image ]
 
+        os.environ['VIRT_BUILDER_NO_CACHE'] = "yes"
         proc = subprocess.Popen(cmd)
         self.overtaken = False
         ret = testinfra.wait_testing(proc, check)


### PR DESCRIPTION
It might be too small.