### PR TITLE
session: Never pass on signals without actually having a child

### DIFF
--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -891,7 +891,8 @@ fork_session (char **env)
 static void
 pass_to_child (int signo)
 {
-  kill (child, signo);
+  if (child > 0)
+    kill (child, signo);
 }
 
 /* Environment variables to transfer */


### PR DESCRIPTION
This avoids a infinite loop when a signal comes in after setting the
handler but before setting the child PID.

Fixes #3763