### PR TITLE
Kube template should have a DeploymentConfig obj

### DIFF
--- a/images/kubernetes/deploy-examples/cockpit-openshift-template.json
+++ b/images/kubernetes/deploy-examples/cockpit-openshift-template.json
@@ -47,7 +47,7 @@
    ],
    "objects": [
       {
-         "kind":"ReplicationController",
+         "kind":"DeploymentConfig",
          "apiVersion":"v1",
          "metadata":{
             "name":"cockpit-kube",


### PR DESCRIPTION
In OpenShift a DeploymentConfig is the primary object that enables native pod updating. The ReplicationController object is implied in the dc.