### PR TITLE
tools: Require rpm-ostree daemon binary

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -374,10 +374,10 @@ The Cockpit component for managing storage.  This package uses Storaged.
 
 %package ostree
 Summary: Cockpit user interface for rpm-ostree
-%if 0%{?rhel}
-Requires: rpm-ostree-client >= 2015.11-1
-%else
+%if 0%{?fedora} > 0 && 0%{?fedora} < 24
 Requires: rpm-ostree >= 2015.10-1
+%else
+Requires: /usr/libexec/rpm-ostreed
 %endif
 
 %description ostree


### PR DESCRIPTION
Centos wants to be able to build trees with both rpm-ostree and rpm-ostree-client. Since fedora was
only distro to release a incompatible version of rpm-ostreed, we can depend on the binary everywhere else.

The downside of this is that if centos continues to mix things like that we don't be able to require specific versions in the future.