### PR TITLE
storaged: make sure disks with long names don't overflow the dialog

### DIFF
--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -129,13 +129,12 @@
     text-overflow: ellipsis;
 }
 
-.available-disks-group
-{
+.available-disks-group {
     margin-bottom: 0px;
+    max-width: 489px;
 }
 
-.available-disks-group input[type='checkbox']
-{
+.available-disks-group input[type='checkbox'] {
     margin: 4px 4px 4px -20px;
 }
 


### PR DESCRIPTION
Disks with long names had a tendency make the controls flip out
visually, so set a maximum width for them to live within.

Fixes issue #3782