### PR TITLE
ws: Message when connection dropped during ssh auth

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -819,6 +819,12 @@ on_remote_login_done (CockpitSshTransport *transport,
                                                "Authentication failed");
             }
         }
+      else if (g_str_equal (problem, "terminated"))
+        {
+              g_simple_async_result_set_error (task, COCKPIT_ERROR,
+                                               COCKPIT_ERROR_AUTHENTICATION_FAILED,
+                                               "Authentication failed: terminated");
+        }
       else
         {
           g_simple_async_result_set_error (task, COCKPIT_ERROR, COCKPIT_ERROR_FAILED,

--- a/static/login.html
+++ b/static/login.html
@@ -303,6 +303,8 @@
                         if (xhr.statusText.indexOf("authentication-not-supported") > -1) {
                             var user = trim(id("login-user-input").value);
                             fatal("The server refused to authenticate '" + user + "' using password authentication, and no other supported authentication methods are available.");
+                        } else if (xhr.statusText.indexOf("terminated") > -1) {
+                            login_failure("Authentication Failed: Server closed connection");
                         } else {
                             login_failure("Wrong user name or password");
                         }

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -64,7 +64,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # Try to login as user with correct password
         login ("user", "abcdefg")
         if 'atomic' in m.image:
-            b.wait_in_text("body", "connect or authenticate: terminated")
+            b.wait_in_text("#login-error-message", "Server closed connection")
         else:
             b.wait_text("#login-error-message", "Permission denied")
 


### PR DESCRIPTION
sshd drop connections to deny users authentication such as when users are denied permission in pam.
It doesn't always tell us why however we can at least display a slightly better message.