### PR TITLE
test: Fix race in check-journal

### DIFF
--- a/test/naughty-fedora-atomic/3306-atomic-not-persist-journal
+++ b/test/naughty-fedora-atomic/3306-atomic-not-persist-journal
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "./check-journal", line 217, in testBasic
-    [ "check-journal", "BEFORE BOOT", "" ]
-  File "./check-journal", line 106, in wait_log_lines
-    })""", expected)

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -185,11 +185,6 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
         b.go("#/?prio=*&start=oldest&service=slow10.service")
         wait_slow10()
 
-        if "208" in m.execute("journalctl --version"):
-            # HACK - Old versions of journalctl get the rest wrong.
-            # https://bugzilla.redhat.com/show_bug.cgi?id=1211972
-            return
-
         # insert messages as errors because we know these will be shown by default
         m.execute("systemctl start systemd-journald.service")
         m.execute("logger -p user.err --tag check-journal BEFORE BOOT");

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -191,7 +191,13 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
             return
 
         # insert messages as errors because we know these will be shown by default
+        m.execute("systemctl start systemd-journald.service")
         m.execute("logger -p user.err --tag check-journal BEFORE BOOT");
+        b.go("#/?tag=check-journal")
+        wait_log_lines([ "January 1, 2050", [ "check-journal", "BEFORE BOOT", "" ] ])
+        m.execute("systemctl stop systemd-journald.service")
+
+        # Now reboot things
         m.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")
         m.wait_reboot()
         m.execute("logger -p user.err --tag check-journal AFTER BOOT");


### PR DESCRIPTION
Sometimes when we start a system, log something, and reboot it
the journal hasn't had time to start up properly. So make our
check-journal test less racy.

systemd and its journal have ways of caching data in memory
before they're ready to sync them to disk. Those are likely
coming into play here.