### PR TITLE
bridge: Fix double free in cockpit_block_samples

### DIFF
--- a/src/bridge/cockpitblocksamples.c
+++ b/src/bridge/cockpitblocksamples.c
@@ -36,7 +36,6 @@ cockpit_block_samples (CockpitSamples *samples)
   if (!g_file_get_contents ("/proc/diskstats", &contents, &len, &error))
     {
       g_message ("error loading contents /proc/diskstats: %s", error->message);
-      g_error_free (error);
       goto out;
     }
 


### PR DESCRIPTION
This happens when /proc/diskstats cannot be read.

Fixes #3812