### PR TITLE
subscriptions: make sure page content is not glued to the top

### DIFF
--- a/pkg/subscriptions/index.html
+++ b/pkg/subscriptions/index.html
@@ -95,7 +95,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
       </button>
     </div>
 
-    <div id="subscriptions-system-status" class="container-fluid" hidden>
+    <div id="subscriptions-system-status" class="container-fluid page" hidden>
       <div class="panel panel-default">
         <div class="panel-heading">
           <span translatable="yes">Installed Products</span>


### PR DESCRIPTION
Probably due to 3e345a16f75d9d4701427309add7b8c9405ae3de the
content was glued to the top of the page.
Give the content some space to breathe again.

Fixes issue #3811