### PR TITLE
registry: Support watching multiple namespaces

### DIFF
--- a/pkg/registry/scripts/dashboard.js
+++ b/pkg/registry/scripts/dashboard.js
@@ -22,7 +22,8 @@
 
     angular.module('registry.dashboard', [
         'ngRoute',
-        'ui.cockpit'
+        'ui.cockpit',
+        'registry.images',
     ])
 
     .config(['$routeProvider',
@@ -40,11 +41,21 @@
         'kubeLoader',
         'kubeSelect',
         'projectActions',
-        function($scope, loader, select, projectActions) {
+        'imageData',
+        'filterService',
+        function($scope, loader, select, projectActions, imageData, filterService) {
             loader.load("projects");
             loader.watch("users");
             loader.watch("groups");
-            loader.watch("imagestreams");
+
+            /*
+             * For now the dashboard  has to watch all images in
+             * order to display the 'Images pushed recently' data
+             *
+             * In the future we want to have a metadata or filtering
+             * service that we can query for that data.
+             */
+            imageData.watchImages();
 
             var c = loader.listen(function() {
                 $scope.projects = select().kind("Project");

--- a/pkg/registry/scripts/images.js
+++ b/pkg/registry/scripts/images.js
@@ -366,11 +366,7 @@
             }
 
             function listImagestreams() {
-                var result = select().kind("ImageStream");
-                var namespace = loader.namespace();
-                if (namespace)
-                    result = result.namespace(namespace);
-                return result;
+                return select().kind("ImageStream");
             }
 
             function imageLayers(image) {

--- a/pkg/registry/tests/test-kube-client.html
+++ b/pkg/registry/tests/test-kube-client.html
@@ -172,7 +172,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
         }
     ]);
 
-    kubeTest("set namespace", 10, FIXTURE_BASIC, [
+    kubeTest("set namespace", 7, FIXTURE_BASIC, [
         "$q",
         "kubeLoader",
         "kubeSelect",
@@ -180,35 +180,25 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
             return loader.watch("pods").then(function() {
                 var pods = select().kind("Pod");
                 equal(pods.length, 3, "number of pods");
-                strictEqual(loader.namespace(), null, "namespace is null");
+                strictEqual(loader.limits.namespace, null, "namespace is null");
 
-                strictEqual(loader.namespace("other"), "other", "namespace change");
-                strictEqual(loader.namespace(), "other", "namespace is other");
+                loader.limit({ namespace: "other" });
+                strictEqual(loader.limits.namespace, "other", "namespace is other");
 
                 pods = select().kind("Pod");
-                equal(pods.length, 0, "pods gone");
+                equal(pods.length, 1, "pods from namespace other");
+                ok("/api/v1/namespaces/other/pods/apache" in pods, "other pod")
 
+                loader.limit({ namespace: null });
+                strictEqual(loader.limits.namespace, null, "namespace is null again");
                 var defer = $q.defer();
                 var listened = false;
                 var x = loader.listen(function() {
                     if (listened) {
                         pods = select().kind("Pod");
-                        equal(pods.length, 1, "pods from namespace other");
-                        ok("/api/v1/namespaces/other/pods/apache" in pods, "other pod")
+                        equal(pods.length, 3, "all pods back");
                         x.cancel();
-
-                        strictEqual(loader.namespace(null), null, "namespace to null");
-                        strictEqual(loader.namespace(), null, "namespace is null again");
-                        listened = false;
-                        x = loader.listen(function() {
-                            if (listened) {
-                                pods = select().kind("Pod");
-                                equal(pods.length, "3", "all pods back");
-                                x.cancel();
-                                defer.resolve();
-                            }
-                            listened = true;
-                        });
+                        defer.resolve();
                     }
                     listened = true;
                 });

--- a/pkg/registry/views/filter-bar.html
+++ b/pkg/registry/views/filter-bar.html
@@ -29,9 +29,9 @@
         <li ng-class="{ checked: !filter.namespace() }">
             <a ng-click="filter.namespace(null)">All Projects</a>
         </li>
-        <li ng-repeat="(key, object) in namespaces() track by key"
-            ng-class="{ checked: object.metadata.name == filter.namespace() }">
-            <a ng-click="filter.namespace(object.metadata.name)">{{object.metadata.name}}</a>
+        <li ng-repeat="name in filter.namespaces() track by name"
+            ng-class="{ checked: name == filter.namespace() }">
+            <a ng-click="filter.namespace(name)">{{name}}</a>
         </li>
     </ul>
 </div>


### PR DESCRIPTION
Kubernetes and Openshift don't support watches that span multiple
namespaces if the logged in user cannot view global objects.

Update kubeLoader to support limiting to multiple namespaces, instead
of loading global objects with a null namespace.