### PR TITLE
Use SSH connection multiplexing when dealing with test machines

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -445,6 +445,7 @@ class MachineCase(unittest.TestCase):
             if len(self.machines) != 0:
                 raise unittest.SkipTest("Cannot run multiple machines if a specific machine address is specified")
             machine = testvm.Machine(address=arg_address, image=image, verbose=arg_trace, label=self.label())
+            self.addCleanup(lambda: machine.disconnect())
         else:
             if not machine_class:
                 machine_class = testvm.VirtMachine

--- a/test/testvm.py
+++ b/test/testvm.py
@@ -99,9 +99,7 @@ class Machine:
         self.image = image or testinfra.DEFAULT_IMAGE
         self.test_dir = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
         self.vm_username = "root"
-        self.vm_password = "foobar"
         self.address = address
-        self.mac = None
         self.label = label or "UNKNOWN"
         self.ssh_master = None
         self.ssh_process = None

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -75,6 +75,38 @@ def add_machine(b, address, known_host=False):
 def kill_user_admin(machine):
     machine.execute("loginctl kill-user admin")
 
+def change_ssh_port(machine, port=None, timeout_sec=120):
+    try:
+        port = int(port)
+    except:
+        port = 22
+
+    # Keep in mind that not all operating systems have firewalld
+    machine.execute("firewall-cmd --permanent --zone=public --add-port={0}/tcp || true".format(port))
+    machine.execute("firewall-cmd --reload || true")
+    machine.execute("! selinuxenabled || semanage port -a -t ssh_port_t -p tcp {0}".format(port))
+    machine.execute("sed -i 's/.*Port .*/Port {0}/' /etc/ssh/sshd_config".format(port))
+
+    # We stop the sshd.socket unit and just go with a regular
+    # daemon.  This is more portable and reloading/restarting the
+    # socket doesn't seem to work well.
+    #
+    machine.execute("( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service")
+    machine.ssh_port = port
+
+    start_time = time.time()
+    error = None
+    while (time.time() - start_time) < timeout_sec:
+        try:
+            machine.execute("true", quiet=True)
+            return
+        except Exception, e:
+            error = e
+        time.sleep(0.5)
+
+    raise error
+
+
 class TestMultiMachine(MachineCase):
     def setUp(self):
         MachineCase.setUp(self)
@@ -408,7 +440,8 @@ class TestMultiMachine(MachineCase):
         b.wait_visible("#login")
 
         m1.execute("! selinuxenabled || semanage port -a -t ssh_port_t -p tcp 2222")
-        m2.change_ssh_port(2222)
+        change_ssh_port(m2, 2222)
+        m2.disconnect()
         self.login_and_go(None)
         b.go(machine_path)
         b.wait_visible(".curtains div.spinner")


### PR DESCRIPTION
This makes things more efficient, but more importantly, once an SSH connection is open, the state of the parent sshd process or service on the target system shouldn't affect our ability to run commands.
