### PR TITLE
ws: Implement MaxStartups for cockpit-ws

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -92,3 +92,12 @@ If not provided host will default to 127.0.0.1
 # None
 
 The ```none``` action forces an immediate authentication denied message.
+
+# Limits
+
+Like ```sshd``` cockpit can be configured to limit the number of concurrent
+login attempts allowed. This is done by adding a ```MaxStartups```
+option to the ```WebService``` section of your cockpit configuration.
+Additional connections will be dropped until authentication succeeds or
+the connections are closed. See the man page for cockpit.conf for more
+details. By default the limit is set to 10.

--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -75,6 +75,22 @@ Origins = https://somedomain1.com https://somedomain2.com:9090
         <term><option>LoginTitle</option></term>
         <listitem><para>Set the browser title for the login screen.</para></listitem>
       </varlistentry>
+      <varlistentry>
+        <term><option>MaxStartups</option></term>
+        <listitem><para>Same as the <command>sshd</command> configuration option by the same name.
+            Specifies the maximum number of concurrent login attempts
+            allowed. Additional connections will be dropped until authentication
+            succeeds or the connections are closed. Defaults to 10.</para>
+
+            <para>Alternatively, random early drop can be enabled by specifying the
+             three colon separated values <literal>start:rate:full</literal> (e.g.
+             "10:30:60"). Cockpit will start refusing authentication attempts with a
+             probability of <literal>rate/100</literal> (30%) if there are currently
+             <literal>start</literal> (10) unauthenticated connections.  The probability
+             increases linearly and all connection attempts are refused if the
+             number of unauthenticated connections reaches <literal>full</literal> (60).</para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/src/ws/cockpitauth.h
+++ b/src/ws/cockpitauth.h
@@ -51,6 +51,10 @@ struct _CockpitAuth
   guint64 nonce_seed;
   gboolean login_loopback;
   gulong timeout_tag;
+  guint startups;
+  guint max_startups;
+  guint max_startups_begin;
+  guint max_startups_rate;
 };
 
 struct _CockpitAuthClass

--- a/src/ws/cockpitws.h
+++ b/src/ws/cockpitws.h
@@ -38,6 +38,7 @@ extern gint cockpit_ws_session_timeout;
 /* From cockpitauth.c */
 extern guint cockpit_ws_service_idle;
 extern guint cockpit_ws_process_idle;
+extern const gchar *cockpit_ws_max_startups;
 
 G_END_DECLS
 

--- a/src/ws/mock-auth-command
+++ b/src/ws/mock-auth-command
@@ -23,6 +23,10 @@ set -euf
 auth=$(cat <&3)
 success=0
 case $auth in
+    "failslow")
+        sleep 2
+        echo "{ \"error\": \"authentication-failed\" }" >&3
+        ;;
     "fail")
         echo "{ \"error\": \"authentication-failed\" }" >&3
         ;;

--- a/src/ws/mock-config.conf
+++ b/src/ws/mock-config.conf
@@ -11,6 +11,7 @@ one = 1
 [WebService]
 Origins = https://another-place.com https://another-place.com:9090
 Shell = /second/test.html
+MaxStartups = 1
 
 [badcommand]
 action = spawn-login-with-header


### PR DESCRIPTION
A simplified version of sshd's MaxStartups. Limits the number processes that cockpitauth will spawn.
Once the limit is hit additional connections will be dropped until authentication succeeds or the connections are closed.