### PR TITLE
kubernetes: Call initMessageEvent properly

### DIFF
--- a/pkg/kubernetes/client.js
+++ b/pkg/kubernetes/client.js
@@ -938,7 +938,7 @@ define([
                         if (!mev.initMessageEvent)
                             mev = new window.MessageEvent('message', { 'data': data });
                         else
-                            mev.initMessageEvent('message', false, false, data, "");
+                            mev.initMessageEvent('message', false, false, data, null, null, window, null);
                         ws.dispatchEvent(mev);
                     });
 

--- a/pkg/kubernetes/containers.js
+++ b/pkg/kubernetes/containers.js
@@ -299,7 +299,7 @@ define([
                                 if (!mev.initMessageEvent)
                                     mev = new window.MessageEvent('message', { 'data': data });
                                 else
-                                    mev.initMessageEvent('message', false, false, data, "");
+                                    mev.initMessageEvent('message', false, false, data, null, null, window, null);
                                 ws.dispatchEvent(mev);
                             });
 


### PR DESCRIPTION
Firefox 0.44.x and later require that we pass all the arguments.
Fair enough.