### PR TITLE
journal: Don't print non-string values as raw numbers

### DIFF
--- a/pkg/systemd/journal.js
+++ b/pkg/systemd/journal.js
@@ -77,7 +77,7 @@ define([
         out.empty();
 
         function show_entry(entry) {
-            $('#journal-entry-message').text(entry["MESSAGE"]);
+            $('#journal-entry-message').text(journal_renderer.make_printable(entry["MESSAGE"]));
 
             var d = new Date(entry["__REALTIME_TIMESTAMP"] / 1000);
             $('#journal-entry-date').text(d.toString());
@@ -99,7 +99,7 @@ define([
                             $('<td style="text-align:right">').
                                 text(key),
                             $('<td style="text-align:left">').
-                                text(entry[key])));
+                                text(journal_renderer.make_printable(entry[key]))));
                 }
             });
         }

--- a/pkg/systemd/renderer.js
+++ b/pkg/systemd/renderer.js
@@ -35,6 +35,17 @@ define([
 
     var journal_renderer = {};
 
+    function make_printable(value) {
+        if ($.type(value) == "string")
+            return value;
+        else if (value.length !== undefined)
+            return cockpit.format(_("[$0 bytes of binary data]"), value.length);
+        else
+            return _("[binary data]");
+    }
+
+    journal_renderer.make_printable = make_printable;
+
     journal_renderer.output_funcs_for_box = function output_funcs_for_box(box) {
         Mustache.parse(day_header_template);
         Mustache.parse(line_template);
@@ -354,7 +365,7 @@ define([
                 bootid: journal_entry["_BOOT_ID"],
                 ident: journal_entry["SYSLOG_IDENTIFIER"] || journal_entry["_COMM"],
                 prio: journal_entry["PRIORITY"],
-                message: journal_entry["MESSAGE"]
+                message: make_printable(journal_entry["MESSAGE"])
             };
         }
 

--- a/pkg/systemd/renderer.js
+++ b/pkg/systemd/renderer.js
@@ -36,7 +36,9 @@ define([
     var journal_renderer = {};
 
     function make_printable(value) {
-        if ($.type(value) == "string")
+        if (value === undefined)
+            return _("[no data]");
+        else if ($.type(value) == "string")
             return value;
         else if (value.length !== undefined)
             return cockpit.format(_("[$0 bytes of binary data]"), value.length);

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -251,5 +251,27 @@ s.send("MESSAGE=Hello \\01 World\\nPRIORITY=3\\nFOO=bar\\nBIN=a\\01b\\02c\\03\\n
         wait_field("FOO", "bar")
         wait_field("BIN", "[6 bytes of binary data]")
 
+    def testNoMessage(self):
+        b = self.browser
+        m = self.machine
+
+        m.execute(
+"""
+python -c '
+import socket
+s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+s.connect("/run/systemd/journal/socket")
+s.send("PRIORITY=3\\nFOO=bar\\n")'
+""")
+
+        self.login_and_go("/system/logs")
+
+        sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('[no data]')"
+        b.wait_present(sel)
+        b.wait_visible(sel)
+        b.click(sel)
+
+        b.wait_text("#journal-entry-message", "[no data]")
+
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -222,5 +222,34 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
                          [ "check-journal", "BEFORE BOOT", "" ]
                      ])
 
+    def testBinary(self):
+        b = self.browser
+        m = self.machine
+
+        m.execute(
+"""
+python -c '
+import socket
+s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+s.connect("/run/systemd/journal/socket")
+s.send("MESSAGE=Hello \\01 World\\nPRIORITY=3\\nFOO=bar\\nBIN=a\\01b\\02c\\03\\n")'
+""")
+
+        self.login_and_go("/system/logs")
+
+        sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('[13 bytes of binary data]')"
+        b.wait_present(sel)
+        b.wait_visible(sel)
+        b.click(sel)
+
+        b.wait_text("#journal-entry-message", "[13 bytes of binary data]")
+
+        def wait_field(name, value):
+            row_sel = "#journal-entry-fields tr:contains('" + name + "')"
+            b.wait_present(row_sel + " td:nth-child(2):contains('" + value + "')")
+
+        wait_field("FOO", "bar")
+        wait_field("BIN", "[6 bytes of binary data]")
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Instead, print them like journalctl --output=verbose does.

Also, handle missing MESSAGE fields.

Fixes #3825
Fixes #3817