### PR TITLE
bridge: Escape auto added Host header in HTTP requests

### DIFF
--- a/pkg/base1/test-http.html
+++ b/pkg/base1/test-http.html
@@ -55,7 +55,7 @@ test("public api", function() {
 asyncTest("simple request", function() {
     expect(2);
 
-    cockpit.http({ "internal": "test-server" }).get("/pkg/playground/manifest.json")
+    cockpit.http({ "internal": "/test-server" }).get("/pkg/playground/manifest.json")
         .done(function(data) {
             deepEqual(JSON.parse(data), {
                 version: 0,
@@ -75,7 +75,7 @@ asyncTest("simple request", function() {
 asyncTest("with params", function() {
     expect(2);
 
-    cockpit.http({ "internal": "test-server" })
+    cockpit.http({ "internal": "/test-server" })
         .get("/mock/qs", { "key": "value", "name": "Scruffy the Janitor" })
         .done(function(resp) {
             equal(resp, "key=value&name=Scruffy+the+Janitor", "right query string");
@@ -89,7 +89,7 @@ asyncTest("with params", function() {
 asyncTest("not found", function() {
     expect(6);
 
-    cockpit.http({ "internal": "test-server" })
+    cockpit.http({ "internal": "/test-server" })
         .get("/not/found")
         .response(function(status, headers) {
             equal(status, 404, "status code");
@@ -111,7 +111,7 @@ asyncTest("streaming", function() {
 
     var at = 0;
     var got = "";
-    cockpit.http({ "internal": "test-server" })
+    cockpit.http({ "internal": "/test-server" })
         .get("/mock/stream")
         .stream(function(resp) {
             got += resp;
@@ -130,7 +130,7 @@ asyncTest("streaming", function() {
 asyncTest("close", function() {
     expect(4);
 
-    var req = cockpit.http({ "internal": "test-server" }).get("/mock/stream");
+    var req = cockpit.http({ "internal": "/test-server" }).get("/mock/stream");
 
     var at = 0;
     req.stream(function(resp) {
@@ -151,7 +151,7 @@ asyncTest("close", function() {
 asyncTest("headers", function() {
     expect(3);
 
-    cockpit.http({ "internal": "test-server" })
+    cockpit.http({ "internal": "/test-server" })
         .get("/mock/headers", null, { "Header1": "booo", "Header2": "yay value" })
         .response(function(status, headers) {
             equal(status, 201, "status code");
@@ -168,10 +168,25 @@ asyncTest("headers", function() {
         });
 });
 
+asyncTest("escape host header", function() {
+    expect(3);
+
+    cockpit.http({ "internal": "/test-server" })
+        .get("/mock/host", null, { })
+        .response(function(status, headers) {
+            equal(status, 201, "status code");
+            deepEqual(headers.Host, "%2Ftest-server", "got back escaped headers");
+        })
+        .always(function() {
+            equal(this.state(), "resolved", "split response didn't fail");
+            start();
+        });
+});
+
 asyncTest("connection headers", function() {
     expect(3);
 
-    cockpit.http({ "internal": "test-server", "headers": { "Header1": "booo", "Header2": "not this" }})
+    cockpit.http({ "internal": "/test-server", "headers": { "Header1": "booo", "Header2": "not this" }})
         .get("/mock/headers", null, { "Header2": "yay value", "Header0": "extra" })
         .response(function(status, headers) {
             equal(status, 201, "status code");
@@ -192,7 +207,7 @@ asyncTest("connection headers", function() {
 test("http promise recursive", function() {
     expect(7);
 
-    var promise = cockpit.http({ "internal": "test-server" }).get("/")
+    var promise = cockpit.http({ "internal": "/test-server" }).get("/")
 
     var target = { };
     var promise2 = promise.promise(target);
@@ -216,13 +231,13 @@ asyncTest("http keep alive", function() {
      */
 
     var first;
-    cockpit.http({ "internal": "test-server", "connection": "marmalade" }).get("/mock/connection")
+    cockpit.http({ "internal": "/test-server", "connection": "marmalade" }).get("/mock/connection")
         .always(function() {
             equal(this.state(), "resolved", "response didn't fail");
         })
         .done(function(data) {
             first = data;
-            cockpit.http({ "internal": "test-server", "connection": "marmalade" }).get("/mock/connection")
+            cockpit.http({ "internal": "/test-server", "connection": "marmalade" }).get("/mock/connection")
                 .done(function(data) {
                     equal(first, data, "same connection");
                 })
@@ -242,13 +257,13 @@ asyncTest("http connection different", function() {
      */
 
     var first;
-    cockpit.http({ "internal": "test-server", "connection": "one" }).get("/mock/connection")
+    cockpit.http({ "internal": "/test-server", "connection": "one" }).get("/mock/connection")
         .always(function() {
             equal(this.state(), "resolved", "response didn't fail");
         })
         .done(function(data) {
             first = data;
-            cockpit.http({ "internal": "test-server", "connection": "two" }).get("/mock/connection")
+            cockpit.http({ "internal": "/test-server", "connection": "two" }).get("/mock/connection")
                 .done(function(data) {
                     notEqual(first, data, "different connection");
                 })
@@ -267,7 +282,7 @@ asyncTest("http connection without address ", function() {
      */
 
     var first;
-    cockpit.http({ "internal": "test-server", "connection": "one" }).get("/mock/connection")
+    cockpit.http({ "internal": "/test-server", "connection": "one" }).get("/mock/connection")
         .always(function() {
             equal(this.state(), "resolved", "response didn't fail");
         })

--- a/src/bridge/cockpitchannel.c
+++ b/src/bridge/cockpitchannel.c
@@ -644,7 +644,7 @@ cockpit_channel_class_init (CockpitChannelClass *klass)
     {
       inet = g_inet_address_new_loopback (G_SOCKET_FAMILY_IPV4);
       address = g_inet_socket_address_new (inet, atoi (port));
-      cockpit_channel_internal_address ("test-server", address);
+      cockpit_channel_internal_address ("/test-server", address);
       g_object_unref (address);
       g_object_unref (inet);
     }

--- a/src/bridge/cockpithttpstream.c
+++ b/src/bridge/cockpithttpstream.c
@@ -831,7 +831,11 @@ send_http_request (CockpitHttpStream *self)
     }
 
   if (!had_host)
-    g_string_append_printf (string, "Host: %s\r\n", self->client->connectable->name);
+    {
+      g_string_append (string, "Host: ");
+      g_string_append_uri_escaped (string, self->client->connectable->name, "[]!%$&()*+,-.:;=\\_~", FALSE);
+      g_string_append (string, "\r\n");
+    }
   if (!had_encoding)
     g_string_append (string, "Accept-Encoding: identity\r\n");
 

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -175,6 +175,22 @@ mock_http_headers (CockpitWebResponse *response,
 }
 
 static gboolean
+mock_http_host (CockpitWebResponse *response,
+                GHashTable *in_headers)
+{
+  GHashTable *headers;
+
+  headers = cockpit_web_server_new_table();
+  g_hash_table_insert (headers, g_strdup ("Host"), g_strdup (g_hash_table_lookup (in_headers, "Host")));
+  cockpit_web_response_headers_full (response, 201, "Yoo Hoo", -1, headers);
+  cockpit_web_response_complete (response);
+
+  g_hash_table_unref (headers);
+
+  return TRUE;
+}
+
+static gboolean
 mock_http_connection (CockpitWebResponse *response)
 {
   GIOStream *io;
@@ -209,6 +225,8 @@ on_handle_mock (CockpitWebServer *server,
     return mock_http_stream (response);
   if (g_str_equal (path, "/headers"))
     return mock_http_headers (response, headers);
+  if (g_str_equal (path, "/host"))
+    return mock_http_host (response, headers);
   if (g_str_equal (path, "/connection"))
     return mock_http_connection (response);
   else


### PR DESCRIPTION
If the bridge is adding a Host header to an HTTP request
and it containts unsupported charecters, then escape them.

This helps us work with golang 1.6 and other strict HTTP
implementations

Update the test-server tests so we can more easily test
this behavior.

Fixes #3828