### PR TITLE
systemd: make sure journal entry properties don't overflow

### DIFF
--- a/pkg/systemd/journal.css
+++ b/pkg/systemd/journal.css
@@ -135,4 +135,5 @@
 /* Make sure to not break log message lines in order to preserve information */
 #journal-entry .cockpit-info-table td {
     white-space: normal;
+    word-break: break-all;
 }

--- a/pkg/systemd/journal.css
+++ b/pkg/systemd/journal.css
@@ -131,3 +131,8 @@
     white-space: nowrap;
     vertical-align: middle;
 }
+
+/* Make sure to not break log message lines in order to preserve information */
+#journal-entry .cockpit-info-table td {
+    white-space: normal;
+}


### PR DESCRIPTION
Preserving the full string is crutial for tracking down an issue.
Fixes issue #3818