### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-8fe78d194366778126873ee73d746dd745b51a30.qcow2
+debian-unstable-b08093458d28d8e71f149155bfd299a406041ffd.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-02-25/