### PR TITLE
Skip the test-kerberos tests when running as root

### DIFF
--- a/src/ws/test-kerberos.c
+++ b/src/ws/test-kerberos.c
@@ -95,7 +95,6 @@ setup (TestCase *test,
 
   krb5_free_principal (test->krb, principal);
   krb5_get_init_creds_opt_free (test->krb, opt);
-  krb5_free_cred_contents (test->krb, &creds);
 
   g_assert (code != ENOMEM);
   if (code != 0)
@@ -104,6 +103,7 @@ setup (TestCase *test,
       return;
     }
 
+  krb5_free_cred_contents (test->krb, &creds);
   g_free (name);
 
   if (krb5_cc_get_full_name (test->krb, test->ccache, &test->ccache_name) != 0)

--- a/src/ws/test-kerberos.c
+++ b/src/ws/test-kerberos.c
@@ -118,6 +118,9 @@ static void
 teardown (TestCase *test,
           gconstpointer data)
 {
+  if (!mock_kdc_available)
+    return;
+
   if (test->ccache)
     krb5_cc_close (test->krb, test->ccache);
   if (test->ccache_name)
@@ -303,7 +306,7 @@ test_authenticate (TestCase *test,
 
   if (!mock_kdc_available)
     {
-      cockpit_test_skip ("kdc not available to test against");
+      cockpit_test_skip ("mock kdc not available to test against");
       return;
     }
 
@@ -533,7 +536,8 @@ main (int argc,
   /* Try to debug crashing during tests */
   signal (SIGABRT, cockpit_test_signal_backtrace);
 
-  mock_kdc_start ();
+  if (g_strcmp0 (g_get_user_name (), "root") != 0)
+    mock_kdc_start ();
 
   g_test_add ("/kerberos/authenticate", TestCase, NULL,
               setup, test_authenticate, teardown);


### PR DESCRIPTION
It looks like the name 'root' is treated as special by the mock kdc that we start up.
