### PR TITLE
test: added ignoring exception in teardown phase in case test passed

### DIFF
--- a/test/avocado/seleniumlib.py
+++ b/test/avocado/seleniumlib.py
@@ -104,7 +104,11 @@ class SeleniumTest(Test):
             self.driver.close()
             self.driver.quit()
         except Exception as e:
-            raise Exception('ERR: Unable to close WEBdriver', str(e))
+            self.get_debug_logs()
+            if self.error:
+                raise Exception('ERR: Unable to close WEBdriver', str(e))
+            else:
+                self.log.info('ERR: Unable to close WEBdriver: {0}'.format(e))
 
     def get_debug_logs(self, logs=['browser','driver','client','server']):
         for log in logs:


### PR DESCRIPTION
@stefwalter sent me a log https://fedorapeople.org/groups/cockpit/logs/pull-3843-05f5322e-selenium-firefox/log.html
where it seems that test passed, only closing driver failed, means that something bad happen, but unable to debug it. added debugging logs to output and did not crash in case test passed.
