### PR TITLE
Fix memory leaks and make valgrind actually find more

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,6 @@
 NULL =
 man_MANS =
 BUILT_SOURCES =
-CLEANFILES = $(man_MANS)
 bin_PROGRAMS =
 check_SCRIPTS =
 check_PROGRAMS =
@@ -16,6 +15,11 @@ TESTS =
 
 dist_systemdunit_DATA   =
 nodist_systemdunit_DATA =
+
+CLEANFILES = \
+	$(man_MANS) \
+	valgrind-suppressions \
+	$(NULL)
 
 DISTCLEANFILES = \
 	$(srcdir)/Makefile \

--- a/Makefile.am
+++ b/Makefile.am
@@ -139,6 +139,7 @@ VALGRIND_SUPPRESSIONS = \
 	tools/glib.supp \
 	tools/pthread.supp \
 	tools/travis.supp \
+	tools/polkit.supp \
 	tools/pcp.supp \
 	tools/unknown.supp \
 	tools/zlib.supp \

--- a/src/bridge/cockpitdbuscache.c
+++ b/src/bridge/cockpitdbuscache.c
@@ -26,7 +26,7 @@
 
 #include <string.h>
 
-#define DEBUG_BATCHES 1
+#define DEBUG_BATCHES 0
 
 /*
  * This is a cache of properties which tracks updates. The best way to do

--- a/src/bridge/cockpitdbuscache.c
+++ b/src/bridge/cockpitdbuscache.c
@@ -1273,6 +1273,7 @@ cockpit_dbus_cache_finalize (GObject *object)
   CockpitDBusCache *self = COCKPIT_DBUS_CACHE (object);
 
   g_clear_object (&self->connection);
+  g_object_unref (self->cancellable);
 
   g_free (self->name);
   g_free (self->logname);
@@ -1287,6 +1288,7 @@ cockpit_dbus_cache_finalize (GObject *object)
 
   g_hash_table_unref (self->introsent);
   g_hash_table_unref (self->introspected);
+  g_hash_table_unref (self->cache);
 
   g_hash_table_destroy (self->interned);
   g_list_free_full (self->trash, g_free);
@@ -1514,6 +1516,8 @@ process_introspect_children (CockpitDBusCache *self,
                                 NULL, NULL, NULL);
             }
         }
+
+      g_free (child_path);
     }
 
   /* Anything remaining in snapshot stays */

--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -783,6 +783,8 @@ build_json_error (GError *error)
   g_dbus_error_strip_remote_error (error);
 
   json_array_add_string_element (reply, error_name != NULL ? error_name : "");
+  g_free (error_name);
+
   if (error->message)
     json_array_add_string_element (args, error->message);
   json_array_add_array_element (reply, args);
@@ -1140,7 +1142,7 @@ handle_dbus_call_on_interface (CockpitDBusJson *self,
 {
   GVariant *parameters = NULL;
   GError *error = NULL;
-  GDBusMessage *message;
+  GDBusMessage *message = NULL;
 
   g_return_if_fail (call->param_type != NULL);
   parameters = parse_json (call->args, call->param_type, &error);
@@ -1177,6 +1179,8 @@ out:
     }
   if (call)
     call_data_free (call);
+  if (message)
+    g_object_unref (message);
 }
 
 static void

--- a/src/common/cockpitlog.c
+++ b/src/common/cockpitlog.c
@@ -153,6 +153,10 @@ cockpit_set_journal_logging (const gchar *stderr_domain,
 {
   int fd;
 
+  /* Don't log to journal while being tested by test-server */
+  if (g_getenv ("COCKPIT_TEST_SERVER_PORT") != NULL)
+    only = FALSE;
+
   old_handler = g_log_set_default_handler (cockpit_journal_log_handler, NULL);
 
   /* SELinux won't let us always open the sd_journal_stream_fd

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -595,7 +595,7 @@ on_name_lost (GDBusConnection *connection,
               const gchar *name,
               gpointer user_data)
 {
-  g_assert_not_reached ();
+
 }
 
 static gboolean

--- a/tools/polkit.supp
+++ b/tools/polkit.supp
@@ -1,0 +1,10 @@
+{
+   server_freeLeak: https://bugs.freedesktop.org/show_bug.cgi?id=85506
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   ...
+   fun:server_new
+   fun:polkit_agent_listener_register_with_options
+   ...
+}

--- a/tools/tap-phantom
+++ b/tools/tap-phantom
@@ -27,6 +27,7 @@ var child = require("child_process");
 
 var url = null;
 var server = [];
+var proc;
 
 /*
  * Strip prefix from url
@@ -111,10 +112,14 @@ function run(url) {
 
     page.onConsoleMessage = function(msg, lineNum, sourceId) {
         /* All done with testing */
-        if (msg === "phantom-tap-done")
-            setTimeout(function() { phantom.exit(0); }, 0);
+        if (msg === "phantom-tap-done") {
+            if (proc) {
+                proc.kill("TERM");
+            } else {
+                setTimeout(function() { phantom.exit(0); }, 0);
+            }
 
-        else if (msg == "phantom-tap-error")
+        } else if (msg == "phantom-tap-error")
             setTimeout(function() { phantom.exit(1); }, 0);
 
 	else if (msg == "phantom-tap-expect-resource-error")
@@ -167,7 +172,7 @@ function launch() {
     var running = false;
     var buffer = "";
 
-    var proc = child.spawn(server[0], server.slice(1));
+    proc = child.spawn(server[0], server.slice(1));
     if (proc.pid === 0) {
        console.log("tap-phantom: couldn't spawn: " + server[0]);
        phantom.exit(127);
@@ -187,7 +192,8 @@ function launch() {
         sys.stderr.write(data);
     });
     proc.on("exit", function(code) {
-        console.log(server[0] + " exited unsuccessfully");
+	if (code != 0)
+            sys.stderr.writeLine(server[0] + " exited unsuccessfully: " + code);
         phantom.exit(code);
     });
 }

--- a/tools/travis.supp
+++ b/tools/travis.supp
@@ -84,3 +84,16 @@
    fun:g_test_run_suite
    fun:g_test_run
 }
+{
+   ubuntu_leak_dbus_message_from_blob
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:g_malloc
+   fun:g_slice_alloc
+   obj:/lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0
+   fun:g_variant_new_dict_entry
+   ...
+   fun:g_dbus_message_new_from_blob
+   ...
+}


### PR DESCRIPTION
I found a major memory leak in CockpitDBusJson then i wondered why it wasn't be tracked by 'make check-memory'. Turns out none of the html based tests have had their cockpit-bridge process checked for memory leaks, just invalid  memory accesses

Fixed this issue, and several other leaks.