### PR TITLE
test: Allow specifying an running machine with certain tests

### DIFF
--- a/test/testvm.py
+++ b/test/testvm.py
@@ -452,6 +452,63 @@ class Machine:
         else:
             return "wheel"
 
+    def start_cockpit(self, atomic_wait_for_host="localhost", tls=False):
+        """Start Cockpit.
+
+        Cockpit is not running when the test virtual machine starts up, to
+        allow you to make modifications before it starts.
+        """
+        if "atomic" in self.image:
+            # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1228776
+            # we want to run:
+            # self.execute("atomic run cockpit/ws --no-tls")
+            # but atomic doesn't forward the parameter, so we use the resulting command
+            # also we need to wait for cockpit to be up and running
+            cmd = """#!/bin/sh
+            systemctl start docker &&
+            """
+            if tls:
+                cmd += "/usr/bin/docker run -d --privileged --pid=host -v /:/host cockpit/ws /container/atomic-run --local-ssh\n"
+            else:
+                cmd += "/usr/bin/docker run -d --privileged --pid=host -v /:/host cockpit/ws /container/atomic-run --local-ssh --no-tls\n"
+            with Timeout(seconds=30, error_message="Timeout while waiting for cockpit/ws to start"):
+                self.execute(script=cmd)
+                self.wait_for_cockpit_running(atomic_wait_for_host)
+        elif tls:
+            self.execute(script="""#!/bin/sh
+            rm -f /etc/systemd/system/cockpit.service.d/notls.conf &&
+            systemctl daemon-reload &&
+            systemctl start cockpit.socket
+            """)
+        else:
+            self.execute(script="""#!/bin/sh
+            mkdir -p /etc/systemd/system/cockpit.service.d/ &&
+            rm -f /etc/systemd/system/cockpit.service.d/notls.conf &&
+            systemctl daemon-reload &&
+            printf \"[Service]\nExecStartPre=-/bin/sh -c 'echo 0 > /proc/sys/kernel/yama/ptrace_scope'\nExecStart=\n%s --no-tls\n\" `systemctl cat cockpit.service | grep ExecStart=` > /etc/systemd/system/cockpit.service.d/notls.conf &&
+            systemctl daemon-reload &&
+            systemctl start cockpit.socket
+            """)
+
+    def restart_cockpit(self):
+        """Restart Cockpit.
+        """
+        if "atomic" in self.image:
+            with Timeout(seconds=30, error_message="Timeout while waiting for cockpit/ws to restart"):
+                self.execute("docker restart `docker ps | grep cockpit/ws | awk '{print $1;}'`")
+                self.wait_for_cockpit_running()
+        else:
+            self.execute("systemctl restart cockpit.socket")
+
+    def stop_cockpit(self):
+        """Stop Cockpit.
+        """
+        if "atomic" in self.image:
+            with Timeout(seconds=30, error_message="Timeout while waiting for cockpit/ws to stop"):
+                self.execute("docker kill `docker ps | grep cockpit/ws | awk '{print $1;}'`")
+        else:
+            self.execute("systemctl stop cockpit.socket")
+
 class VirtEventHandler():
     """ VirtEventHandler registers event handlers (currently: boot, resume, reboot) for libvirt domain instances
         It requires an existing libvirt connection handle, because libvirt requires the domain
@@ -1210,59 +1267,3 @@ done;
         with Timeout(seconds=30, error_message="Timeout while waiting for cockpit/ws to start"):
             self.execute(script=WAIT_COCKPIT_RUNNING)
 
-    def start_cockpit(self, atomic_wait_for_host="localhost", tls=False):
-        """Start Cockpit.
-
-        Cockpit is not running when the test virtual machine starts up, to
-        allow you to make modifications before it starts.
-        """
-        if "atomic" in self.image:
-            # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1228776
-            # we want to run:
-            # self.execute("atomic run cockpit/ws --no-tls")
-            # but atomic doesn't forward the parameter, so we use the resulting command
-            # also we need to wait for cockpit to be up and running
-            cmd = """#!/bin/sh
-            systemctl start docker &&
-            """
-            if tls:
-                cmd += "/usr/bin/docker run -d --privileged --pid=host -v /:/host cockpit/ws /container/atomic-run --local-ssh\n"
-            else:
-                cmd += "/usr/bin/docker run -d --privileged --pid=host -v /:/host cockpit/ws /container/atomic-run --local-ssh --no-tls\n"
-            with Timeout(seconds=30, error_message="Timeout while waiting for cockpit/ws to start"):
-                self.execute(script=cmd)
-                self.wait_for_cockpit_running(atomic_wait_for_host)
-        elif tls:
-            self.execute(script="""#!/bin/sh
-            rm -f /etc/systemd/system/cockpit.service.d/notls.conf &&
-            systemctl daemon-reload &&
-            systemctl start cockpit.socket
-            """)
-        else:
-            self.execute(script="""#!/bin/sh
-            mkdir -p /etc/systemd/system/cockpit.service.d/ &&
-            rm -f /etc/systemd/system/cockpit.service.d/notls.conf &&
-            systemctl daemon-reload &&
-            printf \"[Service]\nExecStartPre=-/bin/sh -c 'echo 0 > /proc/sys/kernel/yama/ptrace_scope'\nExecStart=\n%s --no-tls\n\" `systemctl cat cockpit.service | grep ExecStart=` > /etc/systemd/system/cockpit.service.d/notls.conf &&
-            systemctl daemon-reload &&
-            systemctl start cockpit.socket
-            """)
-
-    def restart_cockpit(self):
-        """Restart Cockpit.
-        """
-        if "atomic" in self.image:
-            with Timeout(seconds=30, error_message="Timeout while waiting for cockpit/ws to restart"):
-                self.execute("docker restart `docker ps | grep cockpit/ws | awk '{print $1;}'`")
-                self.wait_for_cockpit_running()
-        else:
-            self.execute("systemctl restart cockpit.socket")
-
-    def stop_cockpit(self):
-        """Stop Cockpit.
-        """
-        if "atomic" in self.image:
-            with Timeout(seconds=30, error_message="Timeout while waiting for cockpit/ws to stop"):
-                self.execute("docker kill `docker ps | grep cockpit/ws | awk '{print $1;}'`")
-        else:
-            self.execute("systemctl stop cockpit.socket")


### PR DESCRIPTION
This allows specifying an already running machine with certain
test/verify/check- tests.

Pass a --machine=10.1.1.5 argument when running the tests. Obviously
the machine needs to be configured as the tests expect. And the test
cannot expect multiple machines.