### PR TITLE
systemd: consistently refer to it as Logs

### DIFF
--- a/pkg/systemd/logs.html
+++ b/pkg/systemd/logs.html
@@ -65,7 +65,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
   <div id="journal-entry" class="container-fluid" hidden>
     <ol class="breadcrumb">
-      <li><a id="journal-navigate-home" translatable="yes">Journal</a></li>
+      <li><a id="journal-navigate-home" translatable="yes">Logs</a></li>
       <li class="active" translatable="yes">Entry</li>
     </ol>
     <div class="panel panel-default">

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -137,7 +137,7 @@
     <div id="service-valid">
       <div id="service-unit"></div>
       <div class="panel panel-default cockpit-log-panel" id="service-log-box">
-        <div class="panel-heading" translatable="yes">Service Journal</div>
+        <div class="panel-heading" translatable="yes">Service Logs</div>
         <div class="panel-body" id="service-log"></div>
       </div>
     </div>


### PR DESCRIPTION
There were two cases in the UI where it was still called Journal.
Changed that to "Logs" so it's the same across Cockpit.

Fixes issue #3858