### PR TITLE
verify: Wait for cockpit-pcp in check-metrics

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -118,7 +118,7 @@ class TestMetrics(MachineCase):
         m = self.machine
 
         self.login_and_go("/system")
-        m.execute("pgrep cockpit-pcp")
+        wait(lambda: m.execute("pgrep cockpit-pcp"))
 
         self.check_host_metrics()
 
@@ -133,6 +133,7 @@ class TestMetrics(MachineCase):
         m.execute("! pgrep cockpit-pcp")
 
         self.check_host_metrics()
+        m.execute("! pgrep cockpit-pcp")
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Fix the race that sometimes happens in the tests when we check
whether cockpit-pcp is running before it actually runs.