### PR TITLE
Image refresh for fedora-22

### DIFF
--- a/test/images/fedora-22
+++ b/test/images/fedora-22
@@ -1,1 +1,1 @@
-fedora-22-e02ff36dfc80c8bc173836cbf0052593ab95db3a.qcow2
+fedora-22-7675f8aca6f945a521474dcf73e40fd50048eea6.qcow2


### PR DESCRIPTION
Image creation for fedora-22 in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-22-2016-03-01/