### PR TITLE
test: Disable sshd reloading in debian-unstable

### DIFF
--- a/test/guest/debian-unstable.setup
+++ b/test/guest/debian-unstable.setup
@@ -111,3 +111,5 @@ sed -i 's/^PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
 # unreachable temporarily.
 #
 chmod a-x /etc/init.d/ssh
+mkdir -p /etc/systemd/system/sshd.service.d/
+printf "[Service]\nExecReload=\n" > /etc/systemd/system/sshd.service.d/noreload.conf

--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-b08093458d28d8e71f149155bfd299a406041ffd.qcow2
+debian-unstable-52099175703d8d3075c8dd43cd732251ef5ebefd.qcow2


### PR DESCRIPTION
This prevents the tests from working correctly, since the sshd
service is being reloaded every time the network configuration
changes.