### PR TITLE
Image refresh for fedora-23

### DIFF
--- a/test/images/fedora-23
+++ b/test/images/fedora-23
@@ -1,1 +1,1 @@
-fedora-23-0e66fce82e3d9e0aa399ef06573e387674f3ffac.qcow2
+fedora-23-da67981bcaac027489f74fe1db47262e8fcb1bb7.qcow2


### PR DESCRIPTION
Image creation for fedora-23 in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-23-2016-03-01/