### PR TITLE
Image refresh for fedora-testing

### DIFF
--- a/test/images/fedora-testing
+++ b/test/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-28f500215d2e3b7cb612dd033aabbef39cc37a19.qcow2
+fedora-testing-b63cfb976b33a266806b2862c452bc80137488f0.qcow2


### PR DESCRIPTION
Image creation for fedora-testing in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-testing-2016-03-01/