### PR TITLE
webserver: add option to disable tls redirects

### DIFF
--- a/doc/guide/https.xml
+++ b/doc/guide/https.xml
@@ -20,6 +20,9 @@
       <listitem><para>Certain URLs, like <code>/ping</code> are not required to use
         HTTPS.</para></listitem>
     </itemizedlist>
+
+    <para>This behavior can be overridden by setting the
+      <code>AllowUnencrypted</code> option in <code>cockpit.conf</code>.</para>
   </section>
     
   <section id="https-certificates">

--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -84,6 +84,15 @@ Origins = https://somedomain1.com https://somedomain2.com:9090
              number of unauthenticated connections reaches <literal>full</literal> (60).</para>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term><option>AllowUnencrypted</option></term>
+        <listitem>
+          <para>If true, cockpit will accept unencrypted HTTP connections. Otherwise, it
+            redirects all HTTP connections to HTTPS. Exceptions are connections from
+            localhost and for certain URLs (like <code>/ping</code>). Defaults to
+            false.</para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -54,6 +54,7 @@ struct _CockpitWebServer {
   GString *ssl_exception_prefix;
   gint request_timeout;
   gint request_max;
+  gboolean redirect_tls;
 
   GSocketService *socket_service;
   GMainContext *main_context;
@@ -82,7 +83,8 @@ enum
   PROP_CERTIFICATE,
   PROP_DOCUMENT_ROOTS,
   PROP_SSL_EXCEPTION_PREFIX,
-  PROP_SOCKET_ACTIVATED
+  PROP_SOCKET_ACTIVATED,
+  PROP_REDIRECT_TLS
 };
 
 static gint sig_handle_stream = 0;
@@ -108,6 +110,7 @@ cockpit_web_server_init (CockpitWebServer *server)
                                             cockpit_request_free, NULL);
   server->main_context = g_main_context_ref_thread_default ();
   server->ssl_exception_prefix = g_string_new ("");
+  server->redirect_tls = TRUE;
 }
 
 static void
@@ -175,6 +178,10 @@ cockpit_web_server_get_property (GObject *object,
 
     case PROP_SOCKET_ACTIVATED:
       g_value_set_boolean (value, server->socket_activated);
+      break;
+
+    case PROP_REDIRECT_TLS:
+      g_value_set_boolean (value, server->redirect_tls);
       break;
 
     default:
@@ -251,6 +258,10 @@ cockpit_web_server_set_property (GObject *object,
 
     case PROP_SSL_EXCEPTION_PREFIX:
       g_string_assign (server->ssl_exception_prefix, g_value_get_string (value));
+      break;
+
+    case PROP_REDIRECT_TLS:
+      server->redirect_tls = g_value_get_boolean (value);
       break;
 
     default:
@@ -426,6 +437,10 @@ cockpit_web_server_class_init (CockpitWebServerClass *klass)
                                    g_param_spec_boolean ("socket-activated", NULL, NULL, FALSE,
                                                         G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
 
+  g_object_class_install_property (gobject_class, PROP_REDIRECT_TLS,
+                                   g_param_spec_boolean ("redirect-tls", NULL, NULL, TRUE,
+                                                         G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
+
   sig_handle_stream = g_signal_new ("handle-stream",
                                     G_OBJECT_CLASS_TYPE (klass),
                                     G_SIGNAL_RUN_LAST,
@@ -494,6 +509,23 @@ cockpit_web_server_get_port (CockpitWebServer *self)
 {
   g_return_val_if_fail (COCKPIT_IS_WEB_SERVER (self), -1);
   return self->port;
+}
+
+void
+cockpit_web_server_set_redirect_tls (CockpitWebServer *self,
+                                     gboolean          redirect_tls)
+{
+  g_return_if_fail (COCKPIT_IS_WEB_SERVER (self));
+
+  self->redirect_tls = redirect_tls;
+}
+
+gboolean
+cockpit_web_server_get_redirect_tls (CockpitWebServer *self)
+{
+  g_return_val_if_fail (COCKPIT_IS_WEB_SERVER (self), FALSE);
+
+  return self->redirect_tls;
 }
 
 GHashTable *
@@ -1121,14 +1153,17 @@ on_socket_input (GSocket *socket,
   if (first_byte != 22 && first_byte != 0x80)
     {
       is_tls = FALSE;
-      redirect_tls = TRUE;
-      addr = g_socket_connection_get_local_address (G_SOCKET_CONNECTION (request->io), NULL);
-      if (G_IS_INET_SOCKET_ADDRESS (addr))
+      redirect_tls = request->web_server->redirect_tls;
+      if (redirect_tls)
         {
-          inet = g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS (addr));
-          redirect_tls = !g_inet_address_get_is_loopback (inet);
+          addr = g_socket_connection_get_local_address (G_SOCKET_CONNECTION (request->io), NULL);
+          if (G_IS_INET_SOCKET_ADDRESS (addr))
+            {
+              inet = g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS (addr));
+              redirect_tls = !g_inet_address_get_is_loopback (inet);
+            }
+          g_clear_object (&addr);
         }
-      g_clear_object (&addr);
     }
 
   if (is_tls)

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -65,6 +65,11 @@ gint               cockpit_web_server_get_port             (CockpitWebServer *se
 
 const gchar **     cockpit_web_server_get_document_roots   (CockpitWebServer *self);
 
+void               cockpit_web_server_set_redirect_tls     (CockpitWebServer *self,
+                                                            gboolean          redirect_tls);
+
+gboolean           cockpit_web_server_get_redirect_tls     (CockpitWebServer *self);
+
 G_END_DECLS
 
 #endif /* __COCKPIT_WEB_SERVER_H__ */

--- a/src/common/test-webserver.c
+++ b/src/common/test-webserver.c
@@ -521,6 +521,19 @@ test_webserver_noredirect_exception (TestCase *tc,
   g_free (resp);
 }
 
+static void
+test_webserver_noredirect_override (TestCase *tc,
+                                    gconstpointer data)
+{
+  gchar *resp;
+
+  cockpit_web_server_set_redirect_tls (tc->web_server, FALSE);
+
+  resp = perform_http_request (tc->hostport, "GET /pkg/shell/index.html HTTP/1.0\r\nHost:test\r\n\r\n", NULL);
+  cockpit_assert_strmatch (resp, "HTTP/* 200 *\r\n*");
+  g_free (resp);
+}
+
 static gboolean
 on_oh_resource (CockpitWebServer *server,
                 const gchar *path,
@@ -726,6 +739,8 @@ main (int argc,
               setup, test_webserver_noredirect_localhost, teardown);
   g_test_add ("/web-server/no-redirect-exception", TestCase, &fixture_with_cert,
               setup, test_webserver_noredirect_exception, teardown);
+  g_test_add ("/web-server/no-redirect-override", TestCase, &fixture_with_cert,
+              setup, test_webserver_noredirect_override, teardown);
 
   g_test_add ("/web-server/handle-resource", TestCase, NULL,
               setup, test_handle_resource, teardown);

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -187,6 +187,8 @@ main (int argc,
       goto out;
     }
 
+  cockpit_web_server_set_redirect_tls (server, !cockpit_conf_bool ("WebService", "AllowUnencrypted", FALSE));
+
   if (cockpit_web_server_get_socket_activated (server))
     g_signal_connect_swapped (data.auth, "idling", G_CALLBACK (g_main_loop_quit), loop);
 


### PR DESCRIPTION
We already allow non-tls connections from localhost. Making this an option is useful for hacking on a cockpit that is running inside a VM.