### PR TITLE
Simplify vagrant

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -24,8 +24,8 @@ at:
 
     https://localhost:9090
 
-Any changes you make to the system in the Vagrant VM won't affect the
-host machine.
+and login with user `admin` and password `foobar`. Any changes you
+make to the system in the Vagrant VM won't affect the host machine.
 
 You can edit files in the `pkg/` subdirectory of the Cockpit sources
 and the changes should take effect after syncing them to the Vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,7 +40,7 @@ Vagrant.configure(2) do |config|
 
         dnf copr enable -y @cockpit/cockpit-preview
         dnf install -y docker kubernetes atomic subscription-manager etcd pcp realmd \
-		NetworkManager storaged storaged-lvm2 git yum-utils
+		NetworkManager storaged storaged-lvm2 git yum-utils tuned
         dnf install -y cockpit cockpit-pcp
         debuginfo-install -y cockpit cockpit-pcp
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,6 +51,8 @@ Vagrant.configure(2) do |config|
         printf "[Service]\nExecStartPre=/cockpit/tools/git-version-check\n" > \
             /etc/systemd/system/cockpit.service.d/version.conf
 
+        printf "[WebService]\nAllowUnencrypted=true\n" > /etc/cockpit/cockpit.conf
+
         systemctl daemon-reload
     SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,6 +29,9 @@ Vagrant.configure(2) do |config|
         getent passwd admin >/dev/null || useradd -u 1000 -c Administrator -G wheel admin
         echo foobar | passwd --stdin admin
 
+        usermod -a -G wheel vagrant
+        chfn -f Vagrant vagrant
+
         mkdir -p /root/.local/share /home/admin/.local/share /usr/local/share
         ln -snf /cockpit/pkg /usr/local/share/cockpit
         ln -snf /cockpit/pkg /root/.local/share/cockpit

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ Vagrant.configure(2) do |config|
     config.vm.network "private_network", ip: "192.168.50.10"
     config.vm.network "forwarded_port", guest: 9090, host: 9090
     config.vm.hostname = "cockpit-devel"
+    config.vm.post_up_message = "You can now access Cockpit at https://localhost:9090 (login as 'admin' with password 'foobar')"
 
     config.vm.provider "libvirt" do |libvirt, override|
         override.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/23/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-23-20151030.x86_64.vagrant-libvirt.box"


### PR DESCRIPTION
Make getting started with Vagrant a bit easier by giving the default user more privileges and disabling tls redirects.

Depends on #3886