### PR TITLE
shell: Log failure in credentials.js load function

### DIFF
--- a/pkg/shell/credentials.js
+++ b/pkg/shell/credentials.js
@@ -238,6 +238,7 @@ define([
 
             var dfd = $.Deferred();
             var buffer = "";
+            var output = "";
             var failure = _("Not a valid private key");
 
             var timeout = window.setTimeout(function() {
@@ -255,12 +256,14 @@ define([
                     dfd.resolve();
                 })
                 .fail(function(ex) {
+                    console.log(output);
                     if (ex.constructor.name == "ProcessError")
                         ex = new Error(failure);
                     dfd.reject(ex);
                 })
                 .stream(function(data) {
                     buffer += data;
+                    output += data;
                     if (perm_exp.test(buffer)) {
                         failure = _("Invalid file permissions");
                         buffer = "";


### PR DESCRIPTION
Print the ssh-add failure output to the console.log
when ssh-add fails. We need to parse and interpret both
stdout and stderr, but keep it legible.

Besides helping admins, this will help developers debug
the current ssh-add failure that sometimes happens during
testing.