### PR TITLE
ws: Don't fail test-webservice if mock-sshd fails

### DIFF
--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -182,9 +182,9 @@ stop_mock_sshd (GPid mock_sshd) {
   else if (status != 0)
     {
       if (WIFSIGNALED (status))
-        g_critical ("mock-sshd terminated: %d", WTERMSIG (status));
+        g_message ("mock-sshd terminated: %d", WTERMSIG (status));
       else
-        g_critical ("mock-sshd failed: %d", WEXITSTATUS (status));
+        g_message ("mock-sshd failed: %d", WEXITSTATUS (status));
     }
   g_spawn_close_pid (mock_sshd);
 }


### PR DESCRIPTION
We're not testing mock-sshd. If the functionality in test-webservice works, then that's good. mock-sshd can exit and fail in different ways depending on timing.