### PR TITLE
test: Allow polkit reauthorization to fail during check-connection

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -88,6 +88,8 @@ class TestConnection(MachineCase):
         b.expect_load()
         b.enter_page("/system")
 
+        # Reauthorization can fail due to disconnects above
+        self.allow_journal_messages("cockpit-polkit: user admin reauthorization failed")
         self.allow_restart_journal_messages()
 
     def testTls(self):


### PR DESCRIPTION
This journal message can show up due to the disconnections
that the test makes happen.