### PR TITLE
ws: Remove full-name support from cockpit-session

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -491,7 +491,6 @@ create_creds_for_spawn_authenticated (CockpitAuth *self,
                                       JsonObject *results,
                                       const gchar *raw_data)
 {
-  const gchar *fullname = NULL;
   const gchar *password = NULL;
   const gchar *gssapi_creds = NULL;
   CockpitCreds *creds = NULL;
@@ -511,18 +510,11 @@ create_creds_for_spawn_authenticated (CockpitAuth *self,
       gssapi_creds = NULL;
     }
 
-  if (!cockpit_json_get_string (results, "full-name", NULL, &fullname))
-    {
-      g_warning ("received bad full-name from %s", sl->command);
-      fullname = NULL;
-    }
-
   csrf_token = cockpit_auth_nonce (self);
 
   creds = cockpit_creds_new (user,
                              sl->application,
                              COCKPIT_CRED_LOGIN_DATA, raw_data,
-                             COCKPIT_CRED_FULLNAME, fullname,
                              COCKPIT_CRED_PASSWORD, password,
                              COCKPIT_CRED_RHOST, sl->remote_peer,
                              COCKPIT_CRED_GSSAPI, gssapi_creds,

--- a/src/ws/cockpitcreds.c
+++ b/src/ws/cockpitcreds.c
@@ -36,7 +36,6 @@ struct _CockpitCreds {
   gint poisoned;
   gchar *user;
   gchar *application;
-  gchar *fullname;
   gchar *password;
   gchar *rhost;
   gchar *gssapi_creds;
@@ -56,7 +55,6 @@ cockpit_creds_free (gpointer data)
 
   g_free (creds->user);
   g_free (creds->application);
-  g_free (creds->fullname);
   cockpit_secclear (creds->password, -1);
   g_free (creds->password);
   g_free (creds->rhost);
@@ -148,8 +146,6 @@ cockpit_creds_new (const gchar *user,
       type = va_arg (va, const char *);
       if (type == NULL)
         break;
-      else if (g_str_equal (type, COCKPIT_CRED_FULLNAME))
-        creds->fullname = g_strdup (va_arg (va, const char *));
       else if (g_str_equal (type, COCKPIT_CRED_PASSWORD))
         creds->password = g_strdup (va_arg (va, const char *));
       else if (g_str_equal (type, COCKPIT_CRED_RHOST))
@@ -233,13 +229,6 @@ cockpit_creds_get_application (CockpitCreds *creds)
 {
   g_return_val_if_fail (creds != NULL, NULL);
   return creds->application;
-}
-
-const gchar *
-cockpit_creds_get_fullname (CockpitCreds *creds)
-{
-  g_return_val_if_fail (creds != NULL, NULL);
-  return creds->fullname;
 }
 
 const gchar *

--- a/src/ws/cockpitcreds.h
+++ b/src/ws/cockpitcreds.h
@@ -31,7 +31,6 @@ G_BEGIN_DECLS
 
 typedef struct _CockpitCreds       CockpitCreds;
 
-#define COCKPIT_CRED_FULLNAME     "full-name"
 #define COCKPIT_CRED_PASSWORD     "password"
 #define COCKPIT_CRED_RHOST        "rhost"
 #define COCKPIT_CRED_GSSAPI       "gssapi"
@@ -53,8 +52,6 @@ void            cockpit_creds_unref          (gpointer creds);
 void            cockpit_creds_poison         (CockpitCreds *creds);
 
 const gchar *   cockpit_creds_get_user       (CockpitCreds *creds);
-
-const gchar *   cockpit_creds_get_fullname   (CockpitCreds *creds);
 
 const gchar *   cockpit_creds_get_password   (CockpitCreds *creds);
 

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -499,11 +499,7 @@ perform_basic (void)
 
   write_auth_begin (res);
   if (res == PAM_SUCCESS && pwd)
-    {
-      write_auth_string ("user", pwd->pw_name);
-      if (pwd->pw_gecos)
-        write_auth_string ("full-name", pwd->pw_gecos);
-    }
+    write_auth_string ("user", pwd->pw_name);
   write_auth_end ();
 
   if (res != PAM_SUCCESS)
@@ -637,11 +633,7 @@ perform_gssapi (void)
 out:
   write_auth_begin (res);
   if (pwd)
-    {
-      write_auth_string ("user", pwd->pw_name);
-      if (pwd->pw_gecos)
-        write_auth_string ("full-name", pwd->pw_gecos);
-    }
+    write_auth_string ("user", pwd->pw_name);
   if (output.value)
     write_auth_hex ("gssapi-output", output.value, output.length);
 


### PR DESCRIPTION
This should have removed around the time that CockpitDBusUser
was introduced in the bridge.

Nothing uses it any longer. This is purely internal to the
cockpit-ws cockpit-session interaction and doesn't currently
constitute an API break. In addition there are fallbacks for
the NULL case already.