### PR TITLE
test: Ignore old systemd message when encountering strange journals

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -581,6 +581,9 @@ class MachineCase(unittest.TestCase):
                                     'audit:.*denied.*systemd-logind.*nologin.*',
                                     'localhost: dropping message while waiting for child to exit',
                                     '.*: GDBus.Error:org.freedesktop.PolicyKit1.Error.Failed: .*',
+
+                                    # HACK: https://github.com/systemd/systemd/pull/1758
+                                    'Error was encountered while opening journal files:.*'
                                     )
 
     def allow_authorize_journal_messages(self):


### PR DESCRIPTION
This logic in systemd has now been replaced in commit
4f52b822b05c373f40fea1a41ae3ade5d5ff558e to ignore invalid journal
files.