### PR TITLE
Make panel height auto adjustable

### DIFF
--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -151,16 +151,6 @@
     text-overflow: ellipsis;
 }
 
-.panel .panel-heading > span {
-    float: right;
-}
-
-/* Display properly when there are several tags */
-#image-details .panel-heading {
-    min-height: 44px;
-    height: auto;
-}
-
 .image-col-tags {
     width: 40%;
 }
@@ -243,9 +233,10 @@
     height: 120px;
 }
 
-#image-details .panel-heading,
-#container-details .panel-heading {
-    height: 44px;
+/* Display properly when there are several tags */
+#image-details .panel-heading {
+    min-height: 44px;
+    height: auto;
 }
 
 #image-details .panel-heading .pull-right,

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -155,6 +155,12 @@
     float: right;
 }
 
+/* Display properly when there are several tags */
+#image-details .panel-heading {
+    min-height: 44px;
+    height: auto;
+}
+
 .image-col-tags {
     width: 40%;
 }

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -107,7 +107,7 @@
       <br/>
       <div class="panel panel-default" id="containers-containers">
         <div class="panel-heading">
-          <span>
+          <span class="pull-right">
               <div class="btn-group dropdown" id="containers-containers-filter">
                   <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
                       <span translatable="yes">All</span>
@@ -150,7 +150,7 @@
     <div class="col-md-12 col-lg-4">
       <div class="panel panel-default" id="containers-images">
         <div class="panel-heading">
-          <span>
+          <span class="pull-right">
             <button class="btn btn-primary" id="containers-images-search" translatable="yes">
               Get new image
             </button>
@@ -182,8 +182,6 @@
     </ol>
     <div class="panel-default panel">
       <div class="panel-heading col-sm-12">
-        Container:
-        <span id="container-details-names"></span>
         <div class="pull-right">
           <button class="btn btn-default" id="container-details-start">Start</button>
           <button class="btn btn-default" id="container-details-stop">Stop</button>
@@ -195,6 +193,8 @@
           </button>
           <div class="spinner" hidden></div>
         </div>
+        Container:
+        <span id="container-details-names"></span>
       </div>
       <div class="panel-body">
         <table class="cockpit-info-table col-sm-5">
@@ -273,12 +273,12 @@
     </ol>
     <div class="panel-default panel">
       <div class="panel-heading col-sm-12">
-        Image: <span id="image-details-tags"></span>
-        <div class="pull-right" style="height:25px" id="image-details-buttons">
+        <div class="pull-right" id="image-details-buttons">
           <button class="btn btn-default" id="image-details-run">Run</button>
           <button class="btn btn-danger" id="image-details-delete">Delete</button>
           <div class="spinner" hidden></div>
         </div>
+        Image: <span id="image-details-tags"></span>
       </div>
       <div class="panel-body">
         <table class="cockpit-info-table">

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -181,21 +181,19 @@
       <li class="active"></li>
     </ol>
     <div class="panel-default panel">
-      <div class="panel-heading">
-        <div class="col-sm-12">
-          Container:
-          <span id="container-details-names"></span>
-          <div class="pull-right">
-            <button class="btn btn-default" id="container-details-start">Start</button>
-            <button class="btn btn-default" id="container-details-stop">Stop</button>
-            <button class="btn btn-default" id="container-details-restart">Restart</button>
-            <button class="btn btn-danger" id="container-details-delete">Delete</button>
-            <button class="btn btn-default" id="container-details-commit"
-                    data-toggle="modal" data-target="#container-commit-dialog">
-              Commit
-            </button>
-            <div class="spinner" hidden></div>
-          </div>
+      <div class="panel-heading col-sm-12">
+        Container:
+        <span id="container-details-names"></span>
+        <div class="pull-right">
+          <button class="btn btn-default" id="container-details-start">Start</button>
+          <button class="btn btn-default" id="container-details-stop">Stop</button>
+          <button class="btn btn-default" id="container-details-restart">Restart</button>
+          <button class="btn btn-danger" id="container-details-delete">Delete</button>
+          <button class="btn btn-default" id="container-details-commit"
+                  data-toggle="modal" data-target="#container-commit-dialog">
+            Commit
+          </button>
+          <div class="spinner" hidden></div>
         </div>
       </div>
       <div class="panel-body">
@@ -274,14 +272,12 @@
       <li class="active"></li>
     </ol>
     <div class="panel-default panel">
-      <div class="panel-heading">
-        <div class="col-sm-12">
-          Image: <span id="image-details-tags"></span>
-          <div class="pull-right" id="image-details-buttons">
-            <button class="btn btn-default" id="image-details-run">Run</button>
-            <button class="btn btn-danger" id="image-details-delete">Delete</button>
-            <div class="spinner" hidden></div>
-          </div>
+      <div class="panel-heading col-sm-12">
+        Image: <span id="image-details-tags"></span>
+        <div class="pull-right" style="height:25px" id="image-details-buttons">
+          <button class="btn btn-default" id="image-details-run">Run</button>
+          <button class="btn btn-danger" id="image-details-delete">Delete</button>
+          <div class="spinner" hidden></div>
         </div>
       </div>
       <div class="panel-body">

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -181,7 +181,7 @@
       <li class="active"></li>
     </ol>
     <div class="panel-default panel">
-      <div class="panel-heading col-sm-12">
+      <div class="panel-heading">
         <div class="pull-right">
           <button class="btn btn-default" id="container-details-start">Start</button>
           <button class="btn btn-default" id="container-details-stop">Stop</button>
@@ -272,7 +272,7 @@
       <li class="active"></li>
     </ol>
     <div class="panel-default panel">
-      <div class="panel-heading col-sm-12">
+      <div class="panel-heading">
         <div class="pull-right" id="image-details-buttons">
           <button class="btn btn-default" id="image-details-run">Run</button>
           <button class="btn btn-danger" id="image-details-delete">Delete</button>


### PR DESCRIPTION
The `.panel-heading` class has a minimum height and allows auto adjusting with ovewrflow
The container and image div in docker index.html should not overwrite the .panel-heading class height.

After fix the panel heading will resize after the height of the contained div:

![image](https://cloud.githubusercontent.com/assets/3206281/13492411/2286871a-e138-11e5-859d-d7d9fd01428b.png)
