### PR TITLE
storaged: fix disk list style in lvm dialog.

### DIFF
--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -131,7 +131,6 @@
 
 .available-disks-group {
     margin-bottom: 0px;
-    max-width: 489px;
 }
 
 .available-disks-group input[type='checkbox'] {
@@ -160,6 +159,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    max-width: 450px;
 }
 
 .available-disks-group .checkbox label input[type="checkbox"] {


### PR DESCRIPTION
Shorten the label itself, and not the surronding box.
This makes it a bit more flexible.

Fixes issue #3901