### PR TITLE
test: Fix regression in check-multi-machine-key test

### DIFF
--- a/test/testvm.py
+++ b/test/testvm.py
@@ -243,6 +243,11 @@ class Machine:
 
     def _kill_ssh_master(self):
         if self.ssh_master:
+            try:
+                os.unlink(self.ssh_master)
+            except OSError as e:
+                if e.errno != errno.ENOENT:
+                    raise
             self.ssh_master = None
         if self.ssh_process:
             self.ssh_process.stdin.close()

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -79,10 +79,10 @@ class TestMultiMachineKeyAuth(MachineCase):
         self.machine2.start()
         self.machine2.wait_boot()
         # Add user
-        self.machine2.wait_execute()
         self.machine2.execute("useradd user -c 'User' || true")
         self.machine2.execute("sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config")
         self.machine2.execute("( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service")
+        self.machine2.wait_execute()
 
     def tearDown(self):
         if self.runner and self.runner.wasSuccessful():

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -79,9 +79,10 @@ class TestMultiMachineKeyAuth(MachineCase):
         self.machine2.start()
         self.machine2.wait_boot()
         # Add user
-        self.machine2.execute("useradd user -c 'User' || true")
-        self.machine2.execute("sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config")
-        self.machine2.execute("( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service")
+        self.machine2.disconnect()
+        self.machine2.execute("useradd user -c 'User' || true", direct=True)
+        self.machine2.execute("sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config", direct=True)
+        self.machine2.execute("( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service", direct=True)
         self.machine2.wait_execute()
 
     def tearDown(self):


### PR DESCRIPTION
This test was broken during the recent rename of wait_ssh()
to wait_execute(). Fix it back.