### PR TITLE
test: Rename fedora image creation scripts

### DIFF
--- a/test/guest/centos-7.bootstrap
+++ b/test/guest/centos-7.bootstrap
@@ -1,4 +1,4 @@
 #! /bin/bash
 
 BASE=$(dirname $0)
-$BASE/fedora.build "$1" centos-7.1 x86_64
+$BASE/virt-builder-fedora "$1" centos-7.1 x86_64

--- a/test/guest/fedora-22.bootstrap
+++ b/test/guest/fedora-22.bootstrap
@@ -1,4 +1,4 @@
 #! /bin/bash
 
 BASE=$(dirname $0)
-$BASE/fedora.build "$1" fedora-22 x86_64
+$BASE/virt-builder-fedora "$1" fedora-22 x86_64

--- a/test/guest/fedora-23.bootstrap
+++ b/test/guest/fedora-23.bootstrap
@@ -18,4 +18,4 @@
 # 02110-1301 USA.
 
 BASE=$(dirname $0)
-$BASE/fedora.build "$1" fedora-23 x86_64
+$BASE/virt-builder-fedora "$1" fedora-23 x86_64

--- a/test/guest/fedora-testing.bootstrap
+++ b/test/guest/fedora-testing.bootstrap
@@ -19,4 +19,4 @@
 # 02110-1301 USA.
 
 BASE=$(dirname $0)
-$BASE/fedora.build "$1" fedora-23 x86_64
+$BASE/virt-builder-fedora "$1" fedora-23 x86_64

--- a/test/guest/openshift.bootstrap
+++ b/test/guest/openshift.bootstrap
@@ -1,4 +1,4 @@
 #! /bin/bash
 
 BASE=$(dirname $0)
-$BASE/fedora.build "$1" fedora-23 x86_64
+$BASE/virt-builder-fedora "$1" fedora-23 x86_64

--- a/test/guest/rhel-7.bootstrap
+++ b/test/guest/rhel-7.bootstrap
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 BASE=$(dirname $0)
-$BASE/fedora.build "$1" rhel-7.2 x86_64 $SUBSCRIPTION_PATH
+$BASE/virt-builder-fedora "$1" rhel-7.2 x86_64 $SUBSCRIPTION_PATH

--- a/test/guest/selenium.bootstrap
+++ b/test/guest/selenium.bootstrap
@@ -22,4 +22,4 @@ set -ex
 
 BASE=$(dirname $0)
 
-$BASE/fedora.build "$1" fedora-23 x86_64
+$BASE/virt-builder-fedora "$1" fedora-23 x86_64

--- a/test/guest/virt-builder-fedora
+++ b/test/guest/virt-builder-fedora
@@ -21,7 +21,7 @@
 set -ex
 
 if [ "$#" -lt 3 ]; then
-    echo >&2 "Usage: fedora.build IMAGE OS ARCH [SUBSCRIPTION_PATH]"
+    echo >&2 "Usage: virt-builder-fedora IMAGE OS ARCH [SUBSCRIPTION_PATH]"
     exit 1
 fi
 

--- a/test/guest/virt-install-fedora
+++ b/test/guest/virt-install-fedora
@@ -25,7 +25,7 @@
 set -ex
 
 if [ "$#" != 3 ]; then
-    echo >&2 "Usage: fedora.install IMAGE ARCH URL"
+    echo >&2 "Usage: virt-install-fedora IMAGE ARCH URL"
     exit 1
 fi
 


### PR DESCRIPTION
The name collision between fedora.install that creates an image
and the one that installs packages was confusing.
The two alternative image creation scripts are now called
virt-builder-fedora and virt-install-fedora.