### PR TITLE
registry: Implement simple image tag deletion

### DIFF
--- a/pkg/registry/Makefile.am
+++ b/pkg/registry/Makefile.am
@@ -3,6 +3,7 @@ registry_VIEWS = \
 	pkg/registry/views/filter-bar.html \
 	pkg/registry/views/image-body.html \
 	pkg/registry/views/image-config.html \
+	pkg/registry/views/image-delete.html \
 	pkg/registry/views/image-meta.html \
 	pkg/registry/views/image-listing.html \
 	pkg/registry/views/image-page.html \

--- a/pkg/registry/scripts/dialog.js
+++ b/pkg/registry/scripts/dialog.js
@@ -124,10 +124,15 @@
     ]);
 
     function queryAll(element, selector) {
-        var result = [];
-        var i, len = element.length;
-        for (i = 0; i < len; i++)
-            result.push.apply(result, element[i].querySelectorAll(selector));
+        var list, result = [];
+        var j, i, jlen, len = element.length;
+        for (i = 0; i < len; i++) {
+            list = element[i].querySelectorAll(selector);
+            if (list) {
+                for (j = 0, jlen = list.length; j < jlen; j++)
+                    result.push(list[i]);
+            }
+        }
         return angular.element(result);
     }
 

--- a/pkg/registry/scripts/kube-client.js
+++ b/pkg/registry/scripts/kube-client.js
@@ -42,6 +42,7 @@
         { kind: "Image", type: "images", api: OPENSHIFT, global: true },
         { kind: "ImageStream", type: "imagestreams", api: OPENSHIFT },
         { kind: "ImageStreamImage", type: "imagestreamimages", api: OPENSHIFT },
+        { kind: "ImageStreamTag", type: "imagestreamtags", api: OPENSHIFT },
         { kind: "Namespace", type: "namespaces", api: KUBE, global: true, create: -100 },
         { kind: "Node", type: "nodes", api: KUBE, global: true },
         { kind: "Pod", type: "pods", api: KUBE, create: -20 },

--- a/pkg/registry/views/image-delete.html
+++ b/pkg/registry/views/image-delete.html
@@ -1,0 +1,10 @@
+<modal-dialog>
+    <div class="modal-header">
+        <h3 class="modal-title" translatable="yes">Remove image tag</h3>
+    </div>
+    <div class="modal-body" translatable="yes">Do you want to remove the image tagged as '{{stream.metadata.namespace}}/{{stream.metadata.name}}:{{tag.tag}}'?</div>
+    <div class="modal-footer">
+        <button class="btn btn-default btn-cancel" translatable="yes">Cancel</button>
+        <button class="btn btn-danger" translatable="yes" ng-click="complete(performDelete())">Delete</button>
+    </div>
+</modal-dialog>

--- a/pkg/registry/views/image-page.html
+++ b/pkg/registry/views/image-page.html
@@ -1,12 +1,13 @@
 <div class="content-filter">
     <div class="listing-actions">
-        <button class="btn btn-danger btn-delete pficon pficon-delete" disabled></button>
+        <button class="btn btn-danger btn-delete pficon pficon-delete"
+            ng-click="deleteTag(stream, tag)"></button>
     </div>
     <h3>
         <i class="pficon pficon-image"></i>
         {{ stream.metadata.namespace }}/{{ stream.metadata.name}}:{{ tag.tag }}
     </h3>
-    <a ng-href="#/images/{{ stream.metadata.namespace }}/{{ imagestream.metadata.name }}"
+    <a ng-href="#/images/{{ stream.metadata.namespace }}/{{ stream.metadata.name }}"
         translatable="yes" class="hidden-xs">Show all images</a>
 </div>
 

--- a/pkg/registry/views/image-panel.html
+++ b/pkg/registry/views/image-panel.html
@@ -1,7 +1,8 @@
 <div>
     <div class="listing-head" ng-click="listing.collapse(id, $event)">
         <div class="listing-actions">
-            <button class="btn btn-danger btn-delete pficon pficon-delete"></button>
+            <button class="btn btn-danger btn-delete pficon pficon-delete"
+                ng-click="deleteTag(stream, tag)"></button>
         </div>
         <h3><i class="pficon pficon-image"></i>{{ names[0] }}</h3>
         <ul class="nav nav-tabs nav-tabs-pf">

--- a/test/verify/check-registry
+++ b/test/verify/check-registry
@@ -73,5 +73,28 @@ class TestRegistry(MachineCase):
         b.wait_present(".listing-head h3")
         b.wait_in_text(".listing-head h3", "marmalade/busybee:0.x")
 
+        # Delete the tagged image from its own screen
+        b.go("#/images/marmalade/busybee:0.x")
+        b.wait_in_text(".content-filter h3", "marmalade/busybee:0.x")
+        b.click(".pficon-delete")
+        b.wait_present("modal-dialog")
+        b.click("modal-dialog .btn-danger")
+        b.wait_not_present("modal-dialog")
+
+        # Should redirect to the imagestream page
+        b.wait_in_text(".content-filter", "Show all image streams")
+        self.assertNotIn("0.x", b.text("#content"))
+
+        # Delete via the main UI
+        b.wait_present("tbody[data-id='marmalade/busybee:latest']")
+        b.click("tbody[data-id='marmalade/busybee:latest'] tr td span.image-tag")
+        b.click(".listing-head .pficon-delete")
+        b.wait_present("modal-dialog")
+        b.click("modal-dialog .btn-danger")
+        b.wait_not_present("modal-dialog")
+
+        # All tags here have been removed
+        b.wait_not_present(".image-tag")
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
This doesn't go around and look for all the other cases of this
image according to the designs. That's because we don't yet have
that capability.

So just stick with the simple delete image tag.