### PR TITLE
debian: make cockpit-ws depend on glib-networking

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -77,7 +77,8 @@ Description: Cockpit PCP integration
 Package: cockpit-ws
 Architecture: any
 Depends: ${misc:Depends},
-         ${shlibs:Depends}
+         ${shlibs:Depends},
+         glib-networking
 Description: Cockpit Web Service
  The Cockpit Web Service listens on the network, and authenticates
  users.


### PR DESCRIPTION
cockpit-ws errors out if the TLS backend is not installed.

Fixes #3927