### PR TITLE
test: Fix race in check-registry when deleting tag

### DIFF
--- a/test/verify/check-registry
+++ b/test/verify/check-registry
@@ -138,11 +138,11 @@ class TestRegistry(MachineCase):
 
         # Should redirect to the imagestream page
         b.wait_in_text(".content-filter", "Show all image streams")
-        self.assertNotIn("0.x", b.text("#content"))
+        b.wait_not_in_text("#content", "0.x")
 
         # Delete via the main UI
         b.wait_present("tbody[data-id='marmalade/busybee:latest']")
-        b.click("tbody[data-id='marmalade/busybee:latest'] tr td span.image-tag")
+        b.click("tbody[data-id='marmalade/busybee:latest'] tr:first-child td:first-child")
         b.click(".listing-head .pficon-delete")
         b.wait_present("modal-dialog")
         b.click("modal-dialog .btn-danger")


### PR DESCRIPTION
In theory kube-client.js ensures that when deleting something,
it should be removed from the loader.

However ImageStream tags are deleted by removing an ImageStreamTag
object, and we expect the change to show up in an ImageStream
object status fields. So this will wait until kubernetes tells us
that the image tag has been removed from the imagestream. Also
reflects reality, so hesitant to monkey patch a fix for this that
tries to ensure view is consistent immediately.