### PR TITLE
test: Fix delete race in check-registry

### DIFF
--- a/test/verify/check-registry
+++ b/test/verify/check-registry
@@ -143,7 +143,7 @@ class TestRegistry(MachineCase):
         # Delete via the main UI
         b.wait_present("tbody[data-id='marmalade/busybee:latest']")
         b.click("tbody[data-id='marmalade/busybee:latest'] tr:first-child td:first-child")
-        b.click(".listing-head .pficon-delete")
+        b.click("tbody[data-id='marmalade/busybee:latest'] .listing-head .pficon-delete")
         b.wait_present("modal-dialog")
         b.click("modal-dialog .btn-danger")
         b.wait_not_present("modal-dialog")


### PR DESCRIPTION
Sometimes this isn't the only image left, given the image tag
deletion race dealt with in an earlier commit. Click the right
delete button.