### PR TITLE
registry: Fix bugs in kubeSelect() with objects or null

### DIFF
--- a/pkg/registry/scripts/kube-client.js
+++ b/pkg/registry/scripts/kube-client.js
@@ -970,39 +970,40 @@
                 }
             });
 
-            function selection(what, indexed) {
-                return cached(what).selection || mixinSelection(what, undefined, indexed);
-            }
+            var empty = { };
 
             function select(arg) {
-                var what, meta, i, len;
-                if (!arg) {
-                    return selection(loader.objects, true);
-
-                } else if (typeof arg == "object") {
-                    if (typeof arg.kind == "string") {
-                        if (arg.items) {
-                            arg = arg.items;
-                        } else {
-                            arg = [ arg ];
-                        }
-                    }
-
-                    if (typeof arg.length == "number") {
-                        what = { };
-                        for (i = 0, len = arg.length; i < len; i++) {
-                            meta = arg[i].metadata || { };
-                            what[meta.selfLink || i] = arg[i];
-                        }
-                        return selection(what);
-
-                    } else {
-                        return selection(arg);
-                    }
+                var cache, indexed = false;
+                if (arg === undefined) {
+                    arg = loader.objects;
+                    indexed = true;
+                } else if (!arg) {
+                    arg = empty;
                 }
 
-                console.warn("Pass resources or resource dicts or null to kubeSelect()");
-                return selection({ });
+                /* Next the specific object */
+                if (typeof arg !== "object") {
+                    console.warn("Pass resources or resource dicts or null to kubeSelect()");
+                    arg = empty;
+                }
+
+                cache = cached(arg);
+                if (cache.selection)
+                    return cache.selection;
+
+                /* A single resource object */
+                var meta, single;
+                if (typeof arg.kind === "string") {
+                    if (!cache.single) {
+                        meta = arg.meta || { };
+                        single = { };
+                        single[meta.selfLink || 1] = arg;
+                        cache.single = mixinSelection(single, undefined, false);
+                    }
+                    return cache.single;
+                }
+
+                return mixinSelection(arg, undefined, indexed);
             }
 
             /* A seldom used 'static' method */

--- a/pkg/registry/tests/test-kube-client.html
+++ b/pkg/registry/tests/test-kube-client.html
@@ -604,11 +604,23 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
         }
     ]);
 
-    kubeTest("select", 10, FIXTURE_LARGE, [
+    kubeTest("select", 12, FIXTURE_LARGE, [
         "kubeLoader",
         "kubeSelect",
         function(loader, select) {
             return loader.watch("pods").then(function() {
+                var image = { kind: "Image" };
+
+                /* same thing twice */
+                var first = select(image);
+                var second = select(image);
+                strictEqual(first, second, "identical for single object");
+
+                /* null thing twice */
+                var first = select(null);
+                var second = select(null);
+                strictEqual(first, second, "identical for null object");
+
                 /* Select everything odd, 500 pods */
                 var results = select().namespace("default").label({ "type": "odd" });
                 equal(results.length, 500, "correct amount");


### PR DESCRIPTION
When passing a resource object or null to kubeSelect() a
different selection was returned each time. This would kill
caching and cause angular problems.

Be more strict in what we accept and return from kubeSelect()
and always return the same selection for the same input