### PR TITLE
bridge: No test failures when cockpit-polkit is exiting

### DIFF
--- a/src/bridge/cockpitpolkitagent.c
+++ b/src/bridge/cockpitpolkitagent.c
@@ -450,7 +450,11 @@ cockpit_polkit_agent_register (CockpitTransport *transport,
   subject = polkit_unix_session_new_for_process_sync (getpid (), cancellable, &error);
   if (subject == NULL)
     {
-      g_warning ("couldn't create polkit session subject: %s", error->message);
+      /*
+       * This can happen if there's a race between the polkit request and closing of
+       * Cockpit. So it's not unheard of. We can complain, but not too loudly.
+       */
+      g_message ("couldn't create polkit session subject: %s", error->message);
       goto out;
     }
 


### PR DESCRIPTION
If cockpit-bridge cockpit-polkit is exiting at the right time
then the pid lookup will fail. This isn't a programming or system
issue, so change g_warning() to g_message().