### PR TITLE
Better fonts in the guide

### DIFF
--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -73,7 +73,7 @@ CLEANFILES += \
 
 doc/guide/html: $(GUIDE_DOCBOOK) $(GUIDE_INCLUDES) $(man_MANS) $(GUIDE_STATIC) $(GUIDE_XSLT)
 	$(AM_V_GEN) mkdir -p doc/guide/html/ && rm -rf doc/guide/html/* && \
-		cp $(srcdir)/doc/guide/static/* doc/guide/html/ && \
+		cp --dereference $(srcdir)/doc/guide/static/* doc/guide/html/ && \
 		$(XMLTO) html -m $(srcdir)/doc/guide/gtk-doc.xsl -o doc/guide/html/ \
 			--searchpath $(abs_builddir):$(abs_srcdir):$(abs_builddir)/doc/guide \
 			$(srcdir)/$(GUIDE_DOCBOOK)

--- a/doc/guide/static/OpenSans-Bold-webfont.woff
+++ b/doc/guide/static/OpenSans-Bold-webfont.woff
@@ -1,0 +1,1 @@
+../../../bower_components/patternfly/dist/fonts/OpenSans-Bold-webfont.woff

--- a/doc/guide/static/OpenSans-BoldItalic-webfont.woff
+++ b/doc/guide/static/OpenSans-BoldItalic-webfont.woff
@@ -1,0 +1,1 @@
+../../../bower_components/patternfly/dist/fonts/OpenSans-BoldItalic-webfont.woff

--- a/doc/guide/static/OpenSans-ExtraBold-webfont.woff
+++ b/doc/guide/static/OpenSans-ExtraBold-webfont.woff
@@ -1,0 +1,1 @@
+../../../bower_components/patternfly/dist/fonts/OpenSans-ExtraBold-webfont.woff

--- a/doc/guide/static/OpenSans-ExtraBoldItalic-webfont.woff
+++ b/doc/guide/static/OpenSans-ExtraBoldItalic-webfont.woff
@@ -1,0 +1,1 @@
+../../../bower_components/patternfly/dist/fonts/OpenSans-ExtraBoldItalic-webfont.woff

--- a/doc/guide/static/OpenSans-Italic-webfont.woff
+++ b/doc/guide/static/OpenSans-Italic-webfont.woff
@@ -1,0 +1,1 @@
+../../../bower_components/patternfly/dist/fonts/OpenSans-Italic-webfont.woff

--- a/doc/guide/static/OpenSans-Light-webfont.woff
+++ b/doc/guide/static/OpenSans-Light-webfont.woff
@@ -1,0 +1,1 @@
+../../../bower_components/patternfly/dist/fonts/OpenSans-Light-webfont.woff

--- a/doc/guide/static/OpenSans-LightItalic-webfont.woff
+++ b/doc/guide/static/OpenSans-LightItalic-webfont.woff
@@ -1,0 +1,1 @@
+../../../bower_components/patternfly/dist/fonts/OpenSans-LightItalic-webfont.woff

--- a/doc/guide/static/OpenSans-Regular-webfont.woff
+++ b/doc/guide/static/OpenSans-Regular-webfont.woff
@@ -1,0 +1,1 @@
+../../../bower_components/patternfly/dist/fonts/OpenSans-Regular-webfont.woff

--- a/doc/guide/static/OpenSans-Semibold-webfont.woff
+++ b/doc/guide/static/OpenSans-Semibold-webfont.woff
@@ -1,0 +1,1 @@
+../../../bower_components/patternfly/dist/fonts/OpenSans-Semibold-webfont.woff

--- a/doc/guide/static/OpenSans-SemiboldItalic-webfont.woff
+++ b/doc/guide/static/OpenSans-SemiboldItalic-webfont.woff
@@ -1,0 +1,1 @@
+../../../bower_components/patternfly/dist/fonts/OpenSans-SemiboldItalic-webfont.woff

--- a/doc/guide/static/style.css
+++ b/doc/guide/static/style.css
@@ -1,5 +1,36 @@
 @import url("gtk-doc.css");
 
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: url('OpenSans-Light-webfont.woff') format('woff');
+}
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: url('OpenSans-Regular-webfont.woff') format('woff');
+}
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: url('OpenSans-Semibold-webfont.woff') format('woff');
+}
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: url('OpenSans-Bold-webfont.woff') format('woff');
+}
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 800;
+  src: url('OpenSans-ExtraBold-webfont.woff') format('woff');
+}
+
 H1.guides {
 	background-color: #238b49;
 	color: white;
@@ -11,7 +42,7 @@ H1.guides {
 DIV.guides {
 	margin-left: 20px;
 	margin-right: 20px;
-	font-family: Open Sans, Verdana, Arial, 'Bitstream Vera Sans', Helvetica, sans-serif;
+	font-family: 'Open Sans', Verdana, Arial, 'Bitstream Vera Sans', Helvetica, sans-serif;
 	font-size: 13px;
 }
 
@@ -46,7 +77,7 @@ TABLE.navigation TH:first-child {
 
 .shortcuts a {
 	color: white !important;
-	font-family: Open Sans, Verdana, Arial, 'Bitstream Vera Sans', Helvetica, sans-serif;
+	font-family: 'Open Sans', Verdana, Arial, 'Bitstream Vera Sans', Helvetica, sans-serif;
 }
 
 P.title {
@@ -90,7 +121,7 @@ DIV.index,
 DIV.footer,
 DIV.section,
 DIV.part {
-	font-family: Open Sans, Verdana, Arial, 'Bitstream Vera Sans', Helvetica, sans-serif;
+	font-family: 'Open Sans', Verdana, Arial, 'Bitstream Vera Sans', Helvetica, sans-serif;
 	font-size: 11pt;
 	line-height: 160%;
 }


### PR DESCRIPTION
Fix the use of Open Sans in the guide. Currently it looks very strange on certain operating systems.