### PR TITLE
Image refresh for fedora-24

### DIFF
--- a/test/images/fedora-24
+++ b/test/images/fedora-24
@@ -1,1 +1,0 @@
-fedora-24-0b4598775ace30751a7f0cf0888ced39436ebf86.qcow2


### PR DESCRIPTION
Image creation for fedora-24 in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-24-2016-03-11/