### PR TITLE
networkmanager: Handle race with udevadm info refresh

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -760,7 +760,7 @@ function NetworkManagerModel() {
             return;
 
         push_refresh();
-        cockpit.spawn(["udevadm", "info", obj.Udi]).
+        cockpit.spawn(["udevadm", "info", obj.Udi], { err: 'message' }).
             done(function(res) {
                 var props = { };
                 function snarf_prop(line, env, prop) {
@@ -776,7 +776,11 @@ function NetworkManagerModel() {
                 set_object_properties(obj, props);
             }).
             fail(function(ex) {
-                console.warn(ex);
+                /* udevadm info exits with 4 when device doesn't exist */
+                if (ex.exit_status !== 4) {
+                    console.warn(ex.message);
+                    console.warn(ex);
+                }
             }).
             always(pop_refresh);
     }


### PR DESCRIPTION
When using 'udevadm info' the device may have disappeared
by the time we get to it. So handle the case where it returns
the exit status 4, which means not found.

Fixes this journal message:

```
Unknown device, --name=, --path=, or absolute path in /dev/ or /sys expected.
```

https://github.com/systemd/systemd/blob/b26fa1a2fbcfee7d03b0c8fd15ec3aa64ae70b9f/src/udev/udevadm-info.c#L407