### PR TITLE
test: Fix race with setting up os-release during boot

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -40,6 +40,9 @@ class TestSystemInfo(MachineCase):
 
         self.login_and_go("/system")
 
+        b.wait_present('#system_information_os_text')
+        b.wait_visible('#system_information_os_text')
+
         # /etc/os-release might be a symlink and file watching doesn't
         # follow symlinks, so we remove it and then create a regular
         # file.


### PR DESCRIPTION
On Fedora 23 if we setup /etc/os-release during boot it'll be
overwritten with the wrong info. Likely due to
subscription-manager