### PR TITLE
test: Increase timeout for troubleshoot machine curtains

### DIFF
--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -375,7 +375,7 @@ class TestMultiMachine(MachineCase):
         break_bridge(m2)
         self.login_and_go(None)
         b.go(machine_path)
-        with b.wait_timeout(120):
+        with b.wait_timeout(240):
             start_machine_troubleshoot(b)
 
         check_failed_state(b, "Cockpit is not installed")


### PR DESCRIPTION
These can take a long time to appear depending on the state
of the TCP connection and other factors.