### PR TITLE
systemd: Handle case where os-release file disappears

### DIFF
--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -358,6 +358,9 @@ PageServer.prototype = {
                 data = "";
             }
 
+            if (!data)
+                data = "";
+
             var lines = data.split("\n");
             for (var i = 0; i < lines.length; i++) {
                 var parts = lines[i].split("=");


### PR DESCRIPTION
Handle case where os-release file disappears

Fixes a test race.