### PR TITLE
test: The file log.html is retrieved from master

### DIFF
--- a/test/testpulltask.py
+++ b/test/testpulltask.py
@@ -42,8 +42,7 @@ class GithubPullTask(object):
             },
             "revision": self.revision,
             "link": "log.html",
-            "extras": [ "https://raw.githubusercontent.com/cockpit-project/cockpit/" +
-                        self.revision + "/test/files/log.html" ],
+            "extras": [ "https://raw.githubusercontent.com/cockpit-project/cockpit/master/test/files/log.html" ],
 
             "onaborted": {
                 "github": {


### PR DESCRIPTION
It's no use pretending that it's retrieved from a revision when
actually it's retrieved using logic based in master. The path
is based on what's set in master, and not in a branch. Until that
changes lets just retrieve log.html from master.