### PR TITLE
systemd: Use hostnamed's OperatingSystemPrettyName

### DIFF
--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -174,7 +174,6 @@ PageServer.prototype = {
     _init: function() {
         this.id = "server";
         this.server_time = null;
-        this.os_file_name = "/etc/os-release";
         this.client = null;
         this.hostname_proxy = null;
     },
@@ -349,35 +348,6 @@ PageServer.prototype = {
                                      '/org/freedesktop/hostname1');
         self.kernel_hostname = null;
 
-        // HACK: We really should use OperatingSystemPrettyName
-        // from hostname1 here. Once we require system > 211
-        // we should change this.
-        function parse_pretty_name(data, tag, ex) {
-            if (ex) {
-                console.warn("couldn't load os data: " + ex);
-                data = "";
-            }
-
-            if (!data)
-                data = "";
-
-            var lines = data.split("\n");
-            for (var i = 0; i < lines.length; i++) {
-                var parts = lines[i].split("=");
-                if (parts[0] === "PRETTY_NAME") {
-                    var text = parts[1];
-                    try {
-                        text = JSON.parse(text);
-                    } catch (e) {}
-                    $("#system_information_os_text").text(text);
-                    break;
-                }
-            }
-        }
-
-        self.os_file = cockpit.file(self.os_file_name);
-        self.os_file.watch(parse_pretty_name);
-
         var series;
 
         /* CPU graph */
@@ -545,6 +515,7 @@ PageServer.prototype = {
             if (!str)
                 str = _("Set Host name");
             $("#system_information_hostname_button").text(str);
+            $("#system_information_os_text").text(self.hostname_proxy.OperatingSystemPrettyName || "");
         }
 
         cockpit.spawn(["hostname"], { err: "ignore" })
@@ -573,9 +544,6 @@ PageServer.prototype = {
         self.memory_plot.destroy();
         self.disk_plot.destroy();
         self.network_plot.destroy();
-
-        self.os_file.close();
-        self.os_file = null;
 
         $(self.hostname_proxy).off();
         self.hostname_proxy = null;

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -38,24 +38,28 @@ class TestSystemInfo(MachineCase):
         m = self.machine
         b = self.browser
 
+        # /etc/os-release might be a symlink and file watching doesn't
+        # follow symlinks, so we remove it and then create a regular
+        # file.
+        #
+        # In addition hostnamed does not expect os-release to change so
+        # we force a restart. Usually any such changes to os-release are
+        # expected to happen during reboot, or picked up after a reboot.
+        #
+        # subscription-manager also screws with os-release so set it
+        # to immutable
+        #
+        m.execute("rm /etc/os-release")
+        m.write("/etc/os-release", os_release)
+        m.execute("chattr +i /etc/os-release && (systemctl restart systemd-hostnamed || systemctl restart hostnamed)")
+
         self.login_and_go("/system")
 
         b.wait_present('#system_information_os_text')
         b.wait_visible('#system_information_os_text')
 
-        # /etc/os-release might be a symlink and file watching doesn't
-        # follow symlinks, so we remove it and then create a regular
-        # file.
-        #
-        m.execute("rm /etc/os-release")
-        m.write("/etc/os-release", os_release)
-
         b.wait_text('#system_information_os_text',
                     "Foobar Adventure Linux Server 2.0 (Day of Doom)")
-
-        m.write("/etc/os-release", os_release.replace ("2.0", "2.1").replace("Day of Doom", "A New Morning"))
-        b.wait_text('#system_information_os_text',
-                    "Foobar Adventure Linux Server 2.1 (A New Morning)")
 
         m.execute("hostnamectl set-hostname --pretty 'Adventure Box'")
         b.wait_in_text('#system_information_hostname_button', "Adventure Box")


### PR DESCRIPTION
Instead of reading /etc/os-release use the DBus property available
in systemd 211 and later. If the user is running an earlier version
of systemd then this info will simply not display.

Besides removing a hack, the goal is to also fix an issue with
the tests failing here intermittently.