### PR TITLE
test: The lastlog command is broken for non-root on Atomic Host

### DIFF
--- a/test/naughty-fedora-atomic/4001-lastlog-broken-non-root
+++ b/test/naughty-fedora-atomic/4001-lastlog-broken-non-root
@@ -1,0 +1,1 @@
+/var/log/lastlog: Permission denied

--- a/test/naughty-rhel-atomic/4001-lastlog-broken-non-root
+++ b/test/naughty-rhel-atomic/4001-lastlog-broken-non-root
@@ -1,0 +1,1 @@
+/var/log/lastlog: Permission denied


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1317773
https://bugzilla.redhat.com/show_bug.cgi?id=1317798

Issue #4001