### PR TITLE
Image refresh for fedora-atomic

### DIFF
--- a/test/images/fedora-atomic
+++ b/test/images/fedora-atomic
@@ -1,1 +1,0 @@
-fedora-atomic-e2edcf249b6d30f6854054a116f29622bb2b8f1b.qcow2


### PR DESCRIPTION
Image creation for fedora-atomic in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-atomic-2016-03-15/