### PR TITLE
Image refresh for fedora-testing

### DIFF
--- a/test/images/fedora-testing
+++ b/test/images/fedora-testing
@@ -1,1 +1,0 @@
-fedora-testing-b63cfb976b33a266806b2862c452bc80137488f0.qcow2


### PR DESCRIPTION
Image creation for fedora-testing in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-testing-2016-03-16/