### PR TITLE
tools/glib.supp: Extend with gobject_init

### DIFF
--- a/tools/glib.supp
+++ b/tools/glib.supp
@@ -1,3 +1,14 @@
+# This GLib suppressions file is known to be used at least by:
+#
+#  - rpm-software-management/libhif
+#
+# This file should be treated as canonical.
+{
+   gobject_init_1
+   Memcheck:Leak
+   ...
+   fun:gobject_init
+}
 {
    g_type_register_static_1
    Memcheck:Leak
@@ -501,4 +512,10 @@
    fun:g_thread_new
    ...
    fun:g_unix_signal_add_full
+}
+{
+   glib_worker_1
+   Memcheck:Leak
+   ...
+   fun:glib_worker_main
 }


### PR DESCRIPTION
I'm trying to fix the
https://github.com/rpm-software-management/libhif tests which use
valgrind on RHEL7, and was looking for a maintained supressions file.
I had to add one change.