### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,0 @@
-debian-unstable-dfc18f11ced843711aa5475cba09a0b436c5e961.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-03-17/