### PR TITLE
examples: Add kubernetes nginx example that works on openshift

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,6 @@
+# Some Kubernetes examples
+
+If you're using this with the openshift image in test/images then you'll
+need to run the following to access services:
+
+$ sudo route add -net 172.30.0.0/16 gw 10.111.112.101

--- a/examples/kubernetes/nginx-pod.json
+++ b/examples/kubernetes/nginx-pod.json
@@ -1,0 +1,25 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "name": "tiny-nginx",
+        "labels": {
+            "name": "tiny-nginx"
+        }
+    },
+    "spec": {
+        "containers": [
+            {
+                "name": "tiny-nginx",
+                "image": "fedora/nginx",
+                "ports": [
+                    {
+                        "containerPort": 80,
+                        "protocol": "TCP"
+                    }
+                ]
+            }
+        ]
+    }
+}
+

--- a/examples/kubernetes/nginx-rc.json
+++ b/examples/kubernetes/nginx-rc.json
@@ -1,0 +1,35 @@
+{
+    "kind": "ReplicationController",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "tiny-nginx"
+    },
+    "spec": {
+        "replicas": 2,
+        "selector": {
+            "name": "tiny-nginx"
+        },
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "tiny-nginx"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "tiny-nginx",
+                        "image": "fedora/nginx",
+                        "ports": [
+                            {
+                                "containerPort": 80,
+                                "protocol": "TCP"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}
+

--- a/examples/kubernetes/nginx-service.json
+++ b/examples/kubernetes/nginx-service.json
@@ -1,0 +1,18 @@
+{
+ "kind":"Service",
+ "apiVersion":"v1",
+ "metadata":{
+    "name":"tiny-nginx"
+ },
+ "spec":{
+     "ports": [{
+         "name": "",
+         "protocol": "TCP",
+         "port": 80,
+         "targetPort": 80
+     }],
+    "selector":{
+       "name":"tiny-nginx"
+    }
+ }
+}

--- a/test/containers/check-kubernetes-openshift
+++ b/test/containers/check-kubernetes-openshift
@@ -102,6 +102,9 @@ class TestOpenshift(kubelib.KubernetesCase, kubelib.OpenshiftCommonTests):
         self.openshift = self.machine
         self.machine.wait_oc()
 
+        # Expect the default container user limitations during testing
+        self.openshift.execute("oc patch scc restricted -p '{ \"runAsUser\": { \"type\": \"MustRunAsRange\" } }'")
+
     def testLogin(self):
         b = self.browser
         self.machine.start_cockpit()

--- a/test/images/openshift
+++ b/test/images/openshift
@@ -1,1 +1,1 @@
-openshift-519f5094591a0c5413b22fc5a611b2704bef6b93.qcow2
+openshift-36bae62cf21f35cc971f96fa0e7c8d23741b6ff6.qcow2

--- a/test/images/scripts/openshift.setup
+++ b/test/images/scripts/openshift.setup
@@ -61,6 +61,10 @@ cp /openshift.local.config/master/admin.kubeconfig /root/.kube/config
 # Check if we can connect to openshift
 wait oc get namespaces
 
+# Tell openshift to allow root containers by default. Otherwise most
+# development examples just plain fail to work
+oc patch scc restricted -p '{ "runAsUser": { "type": "RunAsAny" } }'
+
 # Deploy the registry
 oadm registry --credentials=/openshift.local.config/master/openshift-registry.kubeconfig
 

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -63,6 +63,9 @@ class TestOpenshift(MachineCase, OpenshiftCommonTests):
 
         wait_oc(self.openshift)
 
+        # Expect the default container user limitations during testing
+        self.openshift.execute("oc patch scc restricted -p '{ \"runAsUser\": { \"type\": \"MustRunAsRange\" } }'")
+
     @unittest.skipIf(True, "Nulecule deploys temporarily removed.")
     def testDeployDialog(self):
         b = self.browser


### PR DESCRIPTION
The upstream nginx examples don't work on openshift or
atomic platform.