### PR TITLE
kubernetes: Make 'New project' work for non admin users

### DIFF
--- a/pkg/kubernetes/scripts/kube-client.js
+++ b/pkg/kubernetes/scripts/kube-client.js
@@ -1060,8 +1060,8 @@
                 var wantNs = false;
 
                 objects.forEach(function(resource) {
-                    var meta = resource.metadata;
-                    if (resource.kind == "Namespace" && meta && meta.name === namespace)
+                    var meta = resource.metadata || { };
+                    if ((resource.kind == "Namespace" || resource.kind == "Project") && meta.name === namespace)
                         haveNs = true;
                     var schema = SCHEMA[resource.kind] || SCHEMA[""];
                     if (!schema.global)
@@ -1101,7 +1101,7 @@
                             var resp = response.data;
 
                             /* Ignore failures creating the namespace if it already exists */
-                            if (resource.kind == "Namespace" && resp && resp.code === 409) {
+                            if (resource.kind == "Namespace" && resp && (resp.code === 409 || resp.code === 403)) {
                                 debug("skipping namespace creation");
                                 step();
                             } else {

--- a/pkg/kubernetes/scripts/kube-client.js
+++ b/pkg/kubernetes/scripts/kube-client.js
@@ -52,6 +52,7 @@
         { kind: "RoleBinding", type: "rolebindings", api: OPENSHIFT },
         { kind: "Route", type: "routes", api: OPENSHIFT },
         { kind: "Project", type: "projects", api: OPENSHIFT, global: true, create: -90 },
+        { kind: "ProjectRequest", type: "projectrequests", api: OPENSHIFT, global: true, create: -90 },
         { kind: "ReplicationController", type: "replicationcontrollers", api: KUBE, create: -60 },
         { kind: "Service", type: "services", api: KUBE, create: -80 },
         { kind: "User", type: "users", api: OPENSHIFT, global: true },

--- a/pkg/kubernetes/scripts/registry/projects.js
+++ b/pkg/kubernetes/scripts/registry/projects.js
@@ -24,6 +24,7 @@
         'ngRoute',
         'kubeClient',
         'kubernetes.listing',
+        'ui.cockpit',
     ])
 
     .config(['$routeProvider',

--- a/pkg/kubernetes/scripts/registry/projects.js
+++ b/pkg/kubernetes/scripts/registry/projects.js
@@ -290,10 +290,10 @@
                 var display = fields.display.trim();
                 var description = fields.description.trim();
 
-                var project = {
-                    kind: "Project",
-                    apiVersion: "v1",
-                    metadata: {
+                var request = {
+                    kind: "ProjectRequest",
+                    apiVersion:"v1",
+                    metadata:{
                         name: fields.name.trim(),
                         annotations: {
                             "openshift.io/description": description,
@@ -302,9 +302,9 @@
                     }
                 };
 
-                return methods.check(project, { "metadata.name": "#project-new-name" })
+                return methods.check(request, { "metadata.name": "#project-new-name" })
                     .then(function() {
-                        return methods.create(project);
+                        return methods.create(request);
                     });
             };
         }

--- a/pkg/kubernetes/tests/test-projects.html
+++ b/pkg/kubernetes/tests/test-projects.html
@@ -27,6 +27,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <script src="../../base1/angular.js"></script>
     <script src="../scripts/kube-client.js"></script>
     <script src="../scripts/listing.js"></script>
+    <script src="../scripts/dialog.js"></script>
     <script src="../scripts/registry/projects.js"></script>
 </head>
 <body>

--- a/pkg/kubernetes/views/registry-dashboard-page.html
+++ b/pkg/kubernetes/views/registry-dashboard-page.html
@@ -15,7 +15,7 @@
             </table>
         </div>
         <div class="card-pf-footer">
-            <a ng-click="createProject()" class="card-pf-link-with-icon">
+            <a ng-click="createProject()" class="card-pf-link-with-icon new-project-link">
                 <i class="pficon pficon-add-circle-o"></i><span translatable="yes">New project</span>
             </a>
         </div>

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -261,7 +261,7 @@ class TestRegistry(MachineCase):
 
         # Add postgres into the stream
         output = o.execute("oc get imagestream --namespace=marmalade --output=json busybee")
-        self.assertNotIn(output, "postgres")
+        self.assertNotIn("postgres", output)
         b.click(".pficon-edit")
         b.wait_present("modal-dialog")
         b.wait_visible("#imagestream-modify-populate")
@@ -273,7 +273,7 @@ class TestRegistry(MachineCase):
         b.click(".btn-primary")
         b.wait_not_present("modal-dialog")
         output = o.execute("oc get imagestream --namespace=marmalade --output=json busybee")
-        self.assertNotIn(output, "postgres")
+        self.assertIn("postgres", output)
 
         # Remove postgres into the stream
         b.click(".pficon-edit")
@@ -285,7 +285,7 @@ class TestRegistry(MachineCase):
         b.click(".btn-primary")
         b.wait_not_present("modal-dialog")
         output = o.execute("oc get imagestream --namespace=marmalade --output=json busybee")
-        self.assertNotIn(output, "postgres")
+        self.assertNotIn("postgres", output)
 
         # Go to the images view and create a new imagestream
         b.click("#content a[href='#/images/marmalade']")

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -379,5 +379,27 @@ class TestRegistry(MachineCase):
         b.wait_visible(".dashboard-images:nth-child(1)")
         b.wait_not_in_text(".card-pf-wide.dashboard-images", "default/busybox")
 
+        output = o.execute("oc get projects")
+        self.assertNotIn("llama", output)
+        b.wait_not_in_text(".dashboard-images:first-child", "llama")
+
+        # Create a new project
+        b.click(".new-project-link")
+        b.wait_present("modal-dialog")
+        b.wait_visible("#project-new-name")
+        b.set_val("#project-new-name", "invalid...!")
+        b.click(".btn-primary")
+        b.wait_visible(".dialog-error")
+        b.set_val("#project-new-name", "llama")
+        b.set_val("#project-new-display", "Display llama")
+        b.set_val("#project-new-description", "Description goes here")
+        b.click(".btn-primary")
+        b.wait_not_present("modal-dialog")
+
+        # Check that the projcet exists
+        output = o.execute("oc get projects")
+        self.assertIn("llama", output)
+        b.wait_in_text(".dashboard-images:first-child", "llama")
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Make the 'New Project' stuff work for non-admin users. We have to use a special openshift API called  projectrequest

In addition this makes the dialogs work again. They were completely broken after the recent registry and kubernetes merge.
