### PR TITLE
test: Fix virt-install for fedora images

### DIFF
--- a/test/images/scripts/virt-install-fedora
+++ b/test/images/scripts/virt-install-fedora
@@ -59,7 +59,7 @@ autopart
 %post
 mkdir /root/.ssh
 chmod 700 /root/.ssh
-echo "$(cat $base/identity.pub)" > /root/.ssh/authorized_keys
+echo "$(cat $base/../../common/identity.pub)" > /root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_keys
 %end
 EOF


### PR DESCRIPTION
The paths to keys have moved.

I stumbled across this in #3962 but we should merge it earlier.