### PR TITLE
containers: Move the ws container into this repository

### DIFF
--- a/containers/Makefile.am
+++ b/containers/Makefile.am
@@ -5,7 +5,7 @@ CLEANFILES += $(KUBERNETES_DIR)/rpms
 
 kubernetes-container:
 	rm -rf $(KUBERNETES_DIR)/rpms && mkdir -p $(KUBERNETES_DIR)/rpms
-	cd $(KUBERNETES_DIR)/rpms && ../../../tools/make-rpms
+	cd $(KUBERNETES_DIR)/rpms && $(abs_srcdir)/tools/make-rpms
 	sudo docker build -t cockpit/kubernetes $(KUBERNETES_DIR)
 
 kubernetes-container-shell:
@@ -17,3 +17,16 @@ kubernetes-container-shell:
 		--env KUBERNETES_INSECURE=true \
 		--env=COCKPIT_KUBE_INSECURE=true \
 		cockpit/kubernetes /bin/bash
+
+WS_DIR = $(srcdir)/containers/ws
+
+CLEANFILES += $(WS_DIR)/rpms
+
+ws-container:
+	rm -rf $(WS_DIR)/rpms && mkdir -p $(WS_DIR)/rpms
+	cd $(WS_DIR)/rpms && $(abs_srcdir)/tools/make-rpms
+	sudo docker build -t cockpit/ws $(WS_DIR)
+
+ws-container-shell:
+	sudo docker run -ti --rm --publish=9001:9090 \
+		cockpit/ws /bin/bash

--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -1,0 +1,36 @@
+FROM fedora:22
+MAINTAINER "Stef Walter" <stefw@redhat.com>
+
+RUN dnf -y update
+RUN dnf install sed
+
+ARG RELEASE
+ARG VERSION
+
+# If there are rpm files in the current directory we'll install those,
+# otherwise use cockpit-preview repo. The Dockerfile is a hack around
+# Dockerfile lack of support for branches
+ADD rpms/*.rpm /tmp/
+
+# Again see above ... we do our branching in shell script
+RUN cd /tmp && ( ls *.rpm > /dev/null 2> /dev/null && dnf -y install cockpit-ws*.rpm || dnf -y install sed https://kojipkgs.fedoraproject.org/packages/cockpit/$VERSION/$RELEASE.fc23/x86_64/cockpit-ws-$VERSION-$RELEASE.fc23.x86_64.rpm ) && dnf clean all
+
+# And the stuff that starts the container
+RUN mkdir -p /container && ln -s /host/proc/1 /container/target-namespace
+ADD atomic-install /container/atomic-install
+ADD atomic-uninstall /container/atomic-uninstall
+ADD atomic-run /container/atomic-run
+RUN chmod -v +x /container/atomic-install
+RUN chmod -v +x /container/atomic-uninstall
+RUN chmod -v +x /container/atomic-run
+
+# Make the container think it's the host OS version
+RUN rm -f /etc/os-release /usr/lib/os-release && ln -sv /host/etc/os-release /etc/os-release && ln -sv /host/usr/lib/os-release /usr/lib/os-release
+
+LABEL INSTALL /usr/bin/docker run -ti --rm --privileged -v /:/host IMAGE /container/atomic-install
+LABEL UNINSTALL /usr/bin/docker run -ti --rm --privileged -v /:/host IMAGE /container/atomic-uninstall
+LABEL RUN /usr/bin/docker run -d --privileged --pid=host -v /:/host IMAGE /container/atomic-run --local-ssh
+
+# Look ma, no EXPOSE
+
+CMD ["/container/atomic-run"]

--- a/containers/ws/README.md
+++ b/containers/ws/README.md
@@ -1,0 +1,18 @@
+# Cockpit Web Service Container
+
+Atomic contains the Cockpit bridge process, but not the Web Service. This means you can add an Atomic host to another Cockpit dashboard, but not connect to it directly.
+
+If you want to connect directly to your Atomic Host with your web browser, use this privileged container.
+
+Run it like so:
+
+    # atomic run cockpit/ws
+
+And then use your web browser to log into port 9090 on your host IP address as usual.
+
+Important: This expects that Atomic (the host operating system) has the cockpit-bridge executable and cockpit-shell package.
+
+## More Info
+
+ * [Cockpit Project](https://cockpit-project.org)
+ * [Cockpit Development](https://github.com/cockpit-project/cockpit)

--- a/containers/ws/atomic-install
+++ b/containers/ws/atomic-install
@@ -1,0 +1,47 @@
+#!/bin/sh -eu
+
+# This is the install script for cockpit-ws when run in a privileged container
+# We expect that cockpit-bridge and related stuff is already in the host.
+#
+# The host file system must be mounted at /host
+
+cd /
+PATH="/bin:/sbin"
+
+if [ ! -d /host/etc -o ! -d /host/proc -o ! -d /host/var/run ]; then
+    echo "cockpit-run: host file system is not mounted at /host" >&2
+    exit 1
+fi
+if [ ! -f /host/usr/bin/cockpit-bridge ]; then
+    echo "cockpit-run: cockpit-bridge must be installed in the host" >&2
+    exit 1
+fi
+if [ ! -d /host/usr/share/cockpit ]; then
+    echo "cockpit-run: cockpit-shell and other resources must be installed in the host" >&2
+    exit 1
+fi
+if [ -f /host/usr/libexec/cockpit-ws ]; then
+    echo "cockpit-ws must not be installed in the host" >&2
+    exit 1
+fi
+
+set -x
+
+# Copy the cockpit pam file into the host, since the PAM stack is gonna run
+# on the host with host PAM modules, and the host files, such as /etc/shadow
+# However we must ensure that it doesn't have selinux stuff ... because well,
+# containers and SELinux don't mix (yet?)
+sed -e '/pam_selinux/d' -e '/pam_sepermit/d' /etc/pam.d/cockpit > /host/etc/pam.d/cockpit
+
+# Make sure that we have required directories in the host
+mkdir -p /host/etc/cockpit/ws-certs.d
+chmod 755 /host/etc/cockpit/ws-certs.d
+chown root:root /host/etc/cockpit/ws-certs.d
+
+mkdir -p /host/var/lib/cockpit
+chmod 775 /host/var/lib/cockpit
+chown root:wheel /host/var/lib/cockpit
+
+# Ensure we have certificates
+/bin/mount --bind /host/etc/cockpit /etc/cockpit
+/usr/sbin/remotectl certificate --ensure

--- a/containers/ws/atomic-run
+++ b/containers/ws/atomic-run
@@ -1,0 +1,20 @@
+#!/bin/sh -eu
+
+# This is the startup script for cockpit-ws when run in a privileged container
+#
+# The host file system must be mounted at /host
+#
+
+cd /
+PATH="/bin:/sbin"
+
+# Run the install command just to be sure
+/container/atomic-install || exit $?
+
+set +x
+
+/bin/mount --bind /host/usr/share/pixmaps /usr/share/pixmaps
+/bin/mount --bind /host/var /var
+
+# And run cockpit-ws
+exec /usr/bin/nsenter --net=/container/target-namespace/ns/net --uts=/container/target-namespace/ns/uts -- /usr/libexec/cockpit-ws "$@"

--- a/containers/ws/atomic-uninstall
+++ b/containers/ws/atomic-uninstall
@@ -1,0 +1,30 @@
+#!/bin/sh -eu
+
+# This is the install script for Cockpit when run in a privileged container
+#
+# The host file system must be mounted at /host
+
+cd /
+PATH="/bin:/sbin"
+
+if [ ! -d /host/etc -o ! -d /host/proc -o ! -d /host/var/run ]; then
+    echo "host file system is not mounted at /host" >&2
+    exit 1
+fi
+if [ ! -f /host/usr/bin/cockpit-bridge ]; then
+    echo "cockpit-bridge must be installed in the host" >&2
+    exit 1
+fi
+if [ ! -d /host/usr/share/cockpit ]; then
+    echo "cockpit-shell and other resources must be installed in the host" >&2
+    exit 1
+fi
+if [ -f /host/usr/libexec/cockpit-ws ]; then
+    echo "cockpit-ws must not be installed in the host" >&2
+    exit 1
+fi
+
+set -x
+
+# Everything else is settings and should remain
+rm -f /host/etc/pam.d/cockpit


### PR DESCRIPTION
It was in a strange little cockpit-containers repository.
Due to the way the Docker Hub demands write access to
the places where it looks for Dockerfile. However now
that we've worked around this in our continuous delivery
scripts, we can have this in our main repo.