### PR TITLE
test: Add way to run an openshift node

### DIFF
--- a/test/images/openshift
+++ b/test/images/openshift
@@ -1,1 +1,1 @@
-openshift-36bae62cf21f35cc971f96fa0e7c8d23741b6ff6.qcow2
+openshift-ecbfa426c4fb64ef707747f71d3678a501a4949c.qcow2

--- a/test/images/openshift-node
+++ b/test/images/openshift-node
@@ -1,0 +1,1 @@
+openshift

--- a/test/images/scripts/openshift.setup
+++ b/test/images/scripts/openshift.setup
@@ -44,7 +44,11 @@ docker pull openshift/origin
 container=$(docker create openshift/origin)
 docker cp $container:/usr/bin - | tar -C /usr -xf - bin/openshift bin/oc bin/oadm bin/kubectl
 
-printf "[Unit]\nDescription=Openshift\n[Service]\nExecStart=/usr/bin/openshift start --master=10.111.112.101\n[Install]\nWantedBy=multi-user.target\n" > /etc/systemd/system/openshift.service
+# Runs a master if on the right address, otherwise runs a node
+printf '#!/bin/sh -ex\nif /usr/sbin/ip addr | /usr/bin/grep -i "52:54:00:9e:00:f1"; then\n/usr/bin/openshift start --master=10.111.112.101\nelse\n/usr/bin/hostnamectl set-hostname node-$(/usr/bin/cat /etc/machine-id)\n/usr/bin/openshift start node --kubeconfig=/openshift.local.config/node-f1.cockpit.lan/node.kubeconfig\nfi\n' > /openshift-run
+chmod +x /openshift-run
+
+printf '[Unit]\nDescription=Openshift\n[Service]\nExecStart=/openshift-run\n[Install]\nWantedBy=multi-user.target\n' > /etc/systemd/system/openshift.service
 
 systemctl daemon-reload
 systemctl enable openshift


### PR DESCRIPTION
Uses the openshift image but runs it with another ip address
which causes it to start up as a node, instead of the master

   ./vm-run openshift-node

For now this is for development, but in the future this will
be used by tests as well