### PR TITLE
common: Close the stderr source properly in CockpitPipe

### DIFF
--- a/src/common/cockpitpipe.c
+++ b/src/common/cockpitpipe.c
@@ -171,6 +171,8 @@ close_immediately (CockpitPipe *self,
     stop_input (self);
   if (self->priv->out_source)
     stop_output (self);
+  if (self->priv->err_source)
+    stop_error (self);
 
   if (self->priv->in_fd != -1)
     {


### PR DESCRIPTION
This should happen during close_immediately() and not wait
for the stderr to close itself.

Indicated by failures in the tests about read() being used
with a Bad file descriptor.