### PR TITLE
test: Fix check-system-info on rhel-atomic image

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -71,7 +71,7 @@ class TestSystemInfo(MachineCase):
         b.click("#system_information_change_hostname button:contains('Change')")
         b.wait_popdown("system_information_change_hostname")
 
-        if "fedora-atomic" in m.image:
+        if "atomic" in m.image:
             b.wait_present('#system-ostree-version')
             b.wait_visible('#system-ostree-version')
             b.wait_text('#system-ostree-version-link', "cockpit-base.1")


### PR DESCRIPTION
This shows the OSTree version now. This was causing failures
in many test runs.