### PR TITLE
kubernetes: The merge removed Content-Security-Policy

### DIFF
--- a/pkg/kubernetes/index.html
+++ b/pkg/kubernetes/index.html
@@ -17,7 +17,7 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
-<html lang="en" class="no-js">
+<html lang="en" ng-csp class="no-js">
 <head>
   <meta charset="utf-8">
   <title translatable="yes">Kubernetes Cluster</title>

--- a/pkg/kubernetes/manifest.json
+++ b/pkg/kubernetes/manifest.json
@@ -4,7 +4,5 @@
             "label": "Cluster",
             "order": 1
         }
-    },
-
-    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
+    }
 }

--- a/pkg/kubernetes/override.json
+++ b/pkg/kubernetes/override.json
@@ -1,10 +1,11 @@
 {
+    "comment": "Local debugging overrides to the manifest",
+    "content-security-policy": "style-src 'self' 'unsafe-inline' 'unsafe-eval'",
+
     "dashboard": {
         "registry": {
             "label": "Image Registry",
             "order": 3
         }
-    },
-
-    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
+    }
 }


### PR DESCRIPTION
The merge of the kubernetes component broke the Content-Security-Policy
settings for the registry. Lets start to enforce that again.