### PR TITLE
ws: Package cache headers

### DIFF
--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -640,18 +640,6 @@ handle_package_checksum (CockpitWebServer *server,
   return TRUE;
 }
 
-static void
-add_cache_header (GHashTable *headers,
-                  CockpitPackages *packages,
-                  GHashTable *out_headers)
-{
-  const gchar *pragma;
-
-  pragma = g_hash_table_lookup (headers, "Pragma");
-  if (packages->checksum && (!pragma || !strstr (pragma, "no-cache")))
-    g_hash_table_insert (out_headers, g_strdup ("Cache-Control"), g_strdup ("max-age=31556926, public"));
-}
-
 static gboolean
 handle_package_manifests_js (CockpitWebServer *server,
                              const gchar *path,
@@ -669,7 +657,6 @@ handle_package_manifests_js (CockpitWebServer *server,
   suffix = g_bytes_new_static (");", 2);
 
   out_headers = cockpit_web_server_new_table ();
-  add_cache_header (headers, packages, out_headers);
 
   cockpit_web_response_content (response, out_headers, prefix, content, suffix, NULL);
 
@@ -691,7 +678,6 @@ handle_package_manifests_json (CockpitWebServer *server,
   GBytes *content;
 
   out_headers = cockpit_web_server_new_table ();
-  add_cache_header (headers, packages, out_headers);
 
   content = cockpit_json_write_bytes (packages->json);
 
@@ -737,8 +723,6 @@ handle_packages (CockpitWebServer *server,
       cockpit_web_response_error (response, 404, NULL, NULL);
       goto out;
     }
-
-  add_cache_header (headers, packages, out_headers);
 
   bytes = cockpit_web_response_negotiation (filename, package->paths, &chosen, &error);
   if (error)

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -37,6 +37,13 @@ typedef enum {
   COCKPIT_WEB_RESPONSE_SENT,
 } CockpitWebResponding;
 
+typedef enum {
+  COCKPIT_WEB_RESPONSE_CACHE_UNSET,
+  COCKPIT_WEB_RESPONSE_NO_CACHE,
+  COCKPIT_WEB_RESPONSE_CACHE_FOREVER,
+  COCKPIT_WEB_RESPONSE_CACHE_PRIVATE,
+} CockpitCacheType;
+
 typedef struct _CockpitWebResponse        CockpitWebResponse;
 
 extern const gchar *  cockpit_web_exception_escape_root;
@@ -101,7 +108,6 @@ void                  cockpit_web_response_gerror        (CockpitWebResponse *se
 
 void                  cockpit_web_response_file          (CockpitWebResponse *response,
                                                           const gchar *escaped,
-                                                          gboolean cache_forever,
                                                           const gchar **roots);
 
 GBytes *              cockpit_web_response_gunzip        (GBytes *bytes,
@@ -120,6 +126,9 @@ gboolean     cockpit_web_should_suppress_output_error    (const gchar *logname,
 gboolean     cockpit_web_response_is_simple_token        (const gchar *string);
 
 gboolean     cockpit_web_response_is_header_value        (const gchar *string);
+
+void         cockpit_web_response_set_cache_type         (CockpitWebResponse *self,
+                                                          CockpitCacheType cache_type);
 
 G_END_DECLS
 

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -381,7 +381,7 @@ cockpit_web_server_default_handle_resource (CockpitWebServer *self,
                                             CockpitWebResponse *response)
 {
   if (self->document_roots)
-    cockpit_web_response_file (response, path, FALSE, (const gchar **)self->document_roots);
+    cockpit_web_response_file (response, path, (const gchar **)self->document_roots);
   else
     cockpit_web_response_error (response, 404, NULL, NULL);
   return TRUE;

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -301,7 +301,8 @@ send_login_html (CockpitWebResponse *response,
   g_bytes_unref (environment);
 
   cockpit_web_response_add_filter (response, filter);
-  cockpit_web_response_file (response, "/login.html", FALSE, ws->static_roots);
+  cockpit_web_response_set_cache_type (response, COCKPIT_WEB_RESPONSE_NO_CACHE);
+  cockpit_web_response_file (response, "/login.html", ws->static_roots);
   g_object_unref (filter);
 }
 
@@ -528,7 +529,8 @@ cockpit_handler_default (CockpitWebServer *server,
       else if (g_str_has_prefix (remainder, "/static/"))
         {
           /* Static stuff is served without authentication */
-          cockpit_web_response_file (response, remainder + 8, TRUE, data->static_roots);
+          cockpit_web_response_set_cache_type (response, COCKPIT_WEB_RESPONSE_CACHE_FOREVER);
+          cockpit_web_response_file (response, remainder + 8, data->static_roots);
           return TRUE;
         }
     }
@@ -565,7 +567,7 @@ cockpit_handler_root (CockpitWebServer *server,
                       CockpitHandlerData *ws)
 {
   /* Don't cache forever */
-  cockpit_web_response_file (response, path, FALSE, ws->static_roots);
+  cockpit_web_response_file (response, path, ws->static_roots);
   return TRUE;
 }
 

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -151,6 +151,8 @@ test_resource_simple (TestResourceCase *tc,
                            "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
                            "Transfer-Encoding: chunked\r\n"
+                           "Cache-Control: max-age=86400, private\r\n"
+                           "Vary: Cookie\r\n"
                            "\r\n"
                            "52\r\n"
                            "<html>\n"
@@ -331,8 +333,8 @@ test_resource_checksum (TestResourceCase *tc,
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
                            "ETag: \"$386257ed81a663cdd7ee12633056dee18d60ddca\"\r\n"
-                           "Cache-Control: max-age=31556926, public\r\n"
                            "Transfer-Encoding: chunked\r\n"
+                           "Cache-Control: max-age=31556926, public\r\n"
                            "\r\n"
                            "32\r\n"
                            "These are the contents of file.ext\nOh marmalaaade\n"
@@ -518,6 +520,8 @@ test_resource_language_suffix (TestResourceCase *tc,
                            "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
                            "Transfer-Encoding: chunked\r\n"
+                           "Cache-Control: max-age=86400, private\r\n"
+                           "Vary: Cookie\r\n"
                            "\r\n"
                            "62\r\n"
                            "<html>\n"
@@ -557,6 +561,8 @@ test_resource_language_fallback (TestResourceCase *tc,
                            "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
                            "Transfer-Encoding: chunked\r\n"
+                           "Cache-Control: max-age=86400, private\r\n"
+                           "Vary: Cookie\r\n"
                            "\r\n"
                            "52\r\n"
                            "<html>\n"
@@ -595,11 +601,13 @@ test_resource_gzip_encoding (TestResourceCase *tc,
                            "Content-Encoding: gzip\r\n"
                            "Content-Type: text/plain\r\n"
                            "Transfer-Encoding: chunked\r\n"
+                           "Cache-Control: max-age=86400, private\r\n"
+                           "Vary: Cookie\r\n"
                            "\r\n"
                            "34\r\n"
                            "\x1F\x8B\x08\x08N1\x03U\x00\x03test-file.txt\x00sT(\xCEM\xCC\xC9Q(I-"
                            ".QH\xCB\xCCI\xE5\x02\x00>PjG\x12\x00\x00\x00\x0D\x0A" "0\x0D\x0A\x0D\x0A",
-                           160);
+                           213);
   g_bytes_unref (bytes);
   g_object_unref (response);
 }

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -504,8 +504,8 @@ on_handle_resource (CockpitWebServer *server,
   inject_address (response, "bus_address", bus_address);
   inject_address (response, "direct_address", direct_address);
 
-  cockpit_web_response_file (response, rebuilt, FALSE,
-                             cockpit_web_server_get_document_roots (server));
+  cockpit_web_response_set_cache_type (response, COCKPIT_WEB_RESPONSE_NO_CACHE);
+  cockpit_web_response_file (response, rebuilt,  cockpit_web_server_get_document_roots (server));
 
   g_strfreev (parts);
   g_free (rebuilt);


### PR DESCRIPTION
When a file is served from packages use a private shortish cache that vary's on cookie, unless the file was requested by hash, in which case we set a long public cache.

This keeps users from being served the cached shell and seeing a "disconnected" page when coming back to cockpit without a valid cookie.