### PR TITLE
Image refresh for fedora-atomic

### DIFF
--- a/test/images/fedora-atomic
+++ b/test/images/fedora-atomic
@@ -1,1 +1,1 @@
-fedora-atomic-4063988f81cd6066909d22cf844da8d062642f3b.qcow2
+fedora-atomic-09b38c3b8d0b7bd2036bbe4b7769dd86d13996b5.qcow2


### PR DESCRIPTION
Image creation for fedora-atomic in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-atomic-2016-03-22/