### PR TITLE
base1, kubernetes: Cancel a dialog when browser hash navigation

### DIFF
--- a/pkg/base1/patterns.js
+++ b/pkg/base1/patterns.js
@@ -216,6 +216,10 @@ define([
             console.warn("unknown dialog action: " + action);
     };
 
+    window.addEventListener("hashchange", function() {
+        $(".modal").modal("hide");
+    });
+
     /*
      * OnOff switch pattern
      */

--- a/pkg/kubernetes/scripts/dialog.js
+++ b/pkg/kubernetes/scripts/dialog.js
@@ -113,6 +113,7 @@
 
                     var cancel = queryFirst(element, ".btn-cancel");
                     cancel.on("click", dismissDialog);
+                    scope.$on("$routeChangeStart", dismissDialog);
 
                     scope.$on("$destroy", function() {
                         cancel.off("click", dismissDialog);


### PR DESCRIPTION
This only happens with browser navigation. If one navigates by
clicking on another component and then comes back the dialog
is still present.