### PR TITLE
test: Add 'koji/fedora-23' and 'koji/fedora-24' builds

### DIFF
--- a/test/common/testinfra.py
+++ b/test/common/testinfra.py
@@ -61,6 +61,8 @@ DEFAULT_VERIFY = {
     'selenium/firefox': [ 'master', 'pulls' ],
     'selenium/chrome': [ 'master', 'pulls' ],
     'container/kubernetes': [ ],
+    'koji/fedora-23': [ ],
+    'koji/fedora-24': [ ],
 }
 
 TESTING = "Testing in progress"

--- a/test/common/testpulltask.py
+++ b/test/common/testpulltask.py
@@ -155,7 +155,7 @@ class GithubPullTask(object):
         os.environ["TEST_NAME"] = self.name
         os.environ["TEST_REVISION"] = self.revision
 
-        if prefix == 'container':
+        if prefix in [ 'container', 'selenium' ]:
             os.environ["TEST_OS"] = 'fedora-23'
         else:
             os.environ["TEST_OS"] = value
@@ -175,7 +175,6 @@ class GithubPullTask(object):
         elif prefix == "avocado":
             cmd = [ "timeout", "60m", "./avocado/run-tests", "--install", "--quick", "--tests" ]
         elif prefix == "selenium":
-            os.environ["TEST_OS"] = "fedora-23"
             if value not in ['firefox', 'chrome']:
                 ret = "Unknown browser for selenium test"
             cmd = [ "timeout", "60m", "./avocado/run-tests", "--install", "--quick", "--selenium-tests", "--browser", value]

--- a/test/common/testpulltask.py
+++ b/test/common/testpulltask.py
@@ -174,6 +174,8 @@ class GithubPullTask(object):
             cmd = [ "timeout", "120m", "./verify/run-tests", "--install", "--jobs", str(opts.jobs) ]
         elif prefix == "avocado":
             cmd = [ "timeout", "60m", "./avocado/run-tests", "--install", "--quick", "--tests" ]
+        elif prefix == "koji":
+            cmd = [ "timeout", "120m", "./koji/run-build" ]
         elif prefix == "selenium":
             if value not in ['firefox', 'chrome']:
                 ret = "Unknown browser for selenium test"

--- a/test/koji/run-build
+++ b/test/koji/run-build
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import glob
+import os
+import subprocess
+import sys
+import shutil
+import tempfile
+
+sys.dont_write_bytecode = True
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from common import testinfra
+
+def main():
+    parser = argparse.ArgumentParser(description='Run cockpit build and unit tests in Koji')
+    opts = parser.parse_args()
+
+    directory = tempfile.mkdtemp(prefix="koji-dist.", dir=os.path.join(testinfra.TEST_DIR, "tmp"))
+    os.chdir(directory)
+
+    # Converts fedora-23 to f23
+    system = testinfra.DEFAULT_IMAGE[0] + testinfra.DEFAULT_IMAGE.split("-")[-1]
+
+    # Make a distribution
+    try:
+        subprocess.check_call(["../../../autogen.sh && make dist"], shell=True)
+        with open(os.path.join(directory, "GNUmakefile"), "w") as f:
+            f.write('include Makefile\nprint-DIST_ARCHIVES:\n\t@echo $(DIST_ARCHIVES)')
+        dist = subprocess.check_output(["make", "-s", "print-DIST_ARCHIVES"]).strip()
+
+        # Do a build
+        subprocess.check_call(["../../../tools/make-srpm", dist])
+        cmd = ["koji", "build", "--scratch", system, glob.glob("*.src.rpm")[0]]
+        subprocess.check_call(cmd)
+    finally:
+        shutil.rmtree(directory)
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
These are tasks for building a pull request or master in koji. Currently this is interesting before signing off on a release ... to see if it builds on different architectures and so on.