### PR TITLE
kubernetes: Prevent the test-images from throwing exception

### DIFF
--- a/pkg/kubernetes/scripts/images.js
+++ b/pkg/kubernetes/scripts/images.js
@@ -312,6 +312,9 @@
                         var interim = { kind: "Image", apiVersion: "v1", metadata: { name: item.image } };
                         loader.handle(interim);
 
+                        if (!watching)
+                            return;
+
                         var name = meta.name + "@" + item.image;
                         loader.load("ImageStreamImage", name, meta.namespace).then(function(resource) {
                             var image = resource.image;

--- a/pkg/kubernetes/scripts/kube-client.js
+++ b/pkg/kubernetes/scripts/kube-client.js
@@ -361,12 +361,11 @@
 
     .factory("kubeLoader", [
         "$q",
-        "$exceptionHandler",
         "$timeout",
         "KubeWatch",
         "KubeRequest",
         "KUBE_SCHEMA",
-        function($q, $exceptionHandler, $timeout, KubeWatch, KubeRequest, KUBE_SCHEMA) {
+        function($q, $timeout, KubeWatch, KubeRequest, KUBE_SCHEMA) {
             var callbacks = [];
             var limits = { namespace: null };
 
@@ -455,12 +454,8 @@
                 var i, len, func;
                 for (i = 0, len = callbacks.length; i < len; i++) {
                     func = callbacks[i];
-                    try {
-                        if (func)
-                            func.apply(self, arguments);
-                    } catch (e) {
-                        $exceptionHandler(e);
-                    }
+                    if (func)
+                        func.apply(self, arguments);
                 }
             }
 
@@ -1274,7 +1269,7 @@
     .factory("MissingKubeRequest", [
         function() {
             return function MissingKubeRequest(path, callback) {
-                throw "no KubeRequestFactory set";
+                throw new Error("no KubeRequestFactory set");
             };
         }
     ])
@@ -1332,7 +1327,7 @@
     .factory("MissingKubeSocket", [
         function() {
             return function MissingKubeSocket(path, callback) {
-                throw "no KubeSocketFactory set";
+                throw Error("no KubeSocketFactory set");
             };
         }
     ])
@@ -1389,7 +1384,7 @@
     .factory("MissingKubeWatch", [
         function() {
             return function MissingKubeWatch(path, callback) {
-                throw "no KubeWatchFactory set";
+                throw Error("no KubeWatchFactory set");
             };
         }
     ])
@@ -1420,7 +1415,7 @@
     .factory("MissingKubeDiscoverSettings", [
         function() {
             return function MissingKubeDiscoverSettings(path, callback) {
-                throw "no KubeDiscoverSettingsFactory set";
+                throw Error("no KubeDiscoverSettingsFactory set");
             };
         }
     ]);

--- a/pkg/kubernetes/tests/test-images.html
+++ b/pkg/kubernetes/tests/test-images.html
@@ -92,13 +92,13 @@ function suite(fixtures) {
         "imageData",
         function(select, data) {
             var tag = { "tag": "2.5", "items": [
-                { "image": "sha256:d0329beccad118aa937e839d536d753ee612b67f8feb6adb519e7f5aa6e75fbe" },
+                { "image": "sha256:beadfbc3da8d183c245ab5bad4dd185dacde72dbe81b270926e60e705e534afb" },
                 { "image": "sha256:0885eeaec4514820b2c879100425e9ea10beaf4412db7f67acfe53b4df2b9450" }
             ]};
 
             var images = select().kind("Image").taggedBy(tag);
             equal(images.length, 2, "number of images");
-            ok("/oapi/v1/images/sha256:d0329beccad118aa937e839d536d753ee612b67f8feb6adb519e7f5aa6e75fbe" in images, "matched busybee");
+            ok("/oapi/v1/images/sha256:beadfbc3da8d183c245ab5bad4dd185dacde72dbe81b270926e60e705e534afb" in images, "matched busybee");
             ok("/oapi/v1/images/sha256:0885eeaec4514820b2c879100425e9ea10beaf4412db7f67acfe53b4df2b9450" in images, "matched juggs");
 
             var tag = { "tag": "2.5", "items": [


### PR DESCRIPTION
Previously it was throwing "no KubeRequestFactory set"

This would cause 'make check' to sometimes fail.