### PR TITLE
shell: Display key name or comment in Authentication box

### DIFF
--- a/pkg/shell/credentials.js
+++ b/pkg/shell/credentials.js
@@ -476,7 +476,7 @@ define([
                     row = rows[id];
                     key = keys.items[id];
                     if (key) {
-                        text(row, ".credential-label", key.name);
+                        text(row, ".credential-label", key.name || key.comment);
                         text(row, ".credential-type", key.type);
                         text(row, ".credential-fingerprint", key.fingerprint);
                         text(row, ".credential-comment", key.comment);


### PR DESCRIPTION
When a key is deleted from the file system, but still
loaded in the ssh-agent we should display its comment
if there's no name from a key file.

This allows the user to see which key represents.

The onoff button is still disabled though, because
ssh-add does not have a way removing specific keys from
the ssh-agent by their fingerprint.

Fixes #4069