### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-0693bd9ed710a2f81d5468351212eba2b1edcefa.qcow2
+debian-unstable-15807cb0a3b8f41a6c92dd743c101262fc4fae77.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-03-24/