### PR TITLE
bridge: Set no-cache when packages has no checksum

### DIFF
--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -658,6 +658,9 @@ handle_package_manifests_js (CockpitWebServer *server,
 
   out_headers = cockpit_web_server_new_table ();
 
+  if (!packages->checksum)
+    cockpit_web_response_set_cache_type (response, COCKPIT_WEB_RESPONSE_NO_CACHE);
+
   cockpit_web_response_content (response, out_headers, prefix, content, suffix, NULL);
 
   g_hash_table_unref (out_headers);
@@ -680,6 +683,9 @@ handle_package_manifests_json (CockpitWebServer *server,
   out_headers = cockpit_web_server_new_table ();
 
   content = cockpit_json_write_bytes (packages->json);
+
+  if (!packages->checksum)
+    cockpit_web_response_set_cache_type (response, COCKPIT_WEB_RESPONSE_NO_CACHE);
 
   cockpit_web_response_content (response, out_headers, content, NULL);
 
@@ -759,6 +765,9 @@ handle_packages (CockpitWebServer *server,
                                g_strdup (package->content_security_policy));
         }
     }
+
+  if (!packages->checksum)
+    cockpit_web_response_set_cache_type (response, COCKPIT_WEB_RESPONSE_NO_CACHE);
 
   cockpit_web_response_headers_full (response, 200, "OK", -1, out_headers);
 

--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -164,7 +164,7 @@ test_simple (TestCase *tc,
   g_assert_cmpstr (tc->problem, ==, NULL);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
-  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{}}"
+  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Cache-Control\":\"no-cache, no-store\"}}"
                            "These are the contents of file.ext\nOh marmalaaade\n", -1);
   g_assert_cmpuint (count, ==, 2);
   g_bytes_unref (data);
@@ -200,7 +200,7 @@ test_large (TestCase *tc,
 
   /* Should not have been sent as one block */
   g_assert_cmpuint (count, ==, 8);
-  prefix = "{\"status\":200,\"reason\":\"OK\",\"headers\":{}}";
+  prefix = "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Cache-Control\":\"no-cache, no-store\"}}";
   g_assert_cmpuint (g_bytes_get_size (data), >, strlen (prefix));
   g_assert (strncmp (g_bytes_get_data (data, NULL), prefix, strlen (prefix)) == 0);
   sub = g_bytes_new_from_bytes (data, strlen (prefix), g_bytes_get_size (data) - strlen (prefix));
@@ -233,7 +233,7 @@ test_listing (TestCase *tc,
   object = cockpit_json_parse_bytes (message, &error);
   g_assert_no_error (error);
   cockpit_assert_json_eq (object,
-                          "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Content-Type\":\"application/json\"}}");
+                          "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Cache-Control\":\"no-cache, no-store\",\"Content-Type\":\"application/json\"}}");
   json_object_unref (object);
 
   message = mock_transport_pop_channel (tc->transport, "444");

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -150,8 +150,8 @@ test_resource_simple (TestResourceCase *tc,
                            "HTTP/1.1 200 OK\r\n"
                            "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
+                           "Cache-Control: no-cache, no-store\r\n"
                            "Transfer-Encoding: chunked\r\n"
-                           "Cache-Control: max-age=86400, private\r\n"
                            "Vary: Cookie\r\n"
                            "\r\n"
                            "52\r\n"
@@ -519,8 +519,8 @@ test_resource_language_suffix (TestResourceCase *tc,
                            "HTTP/1.1 200 OK\r\n"
                            "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
+                           "Cache-Control: no-cache, no-store\r\n"
                            "Transfer-Encoding: chunked\r\n"
-                           "Cache-Control: max-age=86400, private\r\n"
                            "Vary: Cookie\r\n"
                            "\r\n"
                            "62\r\n"
@@ -560,8 +560,8 @@ test_resource_language_fallback (TestResourceCase *tc,
                            "HTTP/1.1 200 OK\r\n"
                            "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
+                           "Cache-Control: no-cache, no-store\r\n"
                            "Transfer-Encoding: chunked\r\n"
-                           "Cache-Control: max-age=86400, private\r\n"
                            "Vary: Cookie\r\n"
                            "\r\n"
                            "52\r\n"
@@ -600,14 +600,14 @@ test_resource_gzip_encoding (TestResourceCase *tc,
                            "HTTP/1.1 200 OK\r\n"
                            "Content-Encoding: gzip\r\n"
                            "Content-Type: text/plain\r\n"
+                           "Cache-Control: no-cache, no-store\r\n"
                            "Transfer-Encoding: chunked\r\n"
-                           "Cache-Control: max-age=86400, private\r\n"
                            "Vary: Cookie\r\n"
                            "\r\n"
                            "34\r\n"
                            "\x1F\x8B\x08\x08N1\x03U\x00\x03test-file.txt\x00sT(\xCEM\xCC\xC9Q(I-"
                            ".QH\xCB\xCCI\xE5\x02\x00>PjG\x12\x00\x00\x00\x0D\x0A" "0\x0D\x0A\x0D\x0A",
-                           213);
+                           209);
   g_bytes_unref (bytes);
   g_object_unref (response);
 }


### PR DESCRIPTION
Fixes regression in chrome caused by #4064