### PR TITLE
Image refresh for fedora-23

### DIFF
--- a/test/images/fedora-23
+++ b/test/images/fedora-23
@@ -1,1 +1,0 @@
-fedora-23-946fbd5cf8508688e7ca96360b93f5aac94a2513.qcow2


### PR DESCRIPTION
Image creation for fedora-23 in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-23-2016-03-29/