### PR TITLE
Image refresh for fedora-testing

### DIFF
--- a/test/images/fedora-testing
+++ b/test/images/fedora-testing
@@ -1,1 +1,0 @@
-fedora-testing-809d0a370bee827859e87203ac54335d8bc880ee.qcow2


### PR DESCRIPTION
Image creation for fedora-testing in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-testing-2016-03-30/