### PR TITLE
kubernetes: Fix exception about duplicates in imagestreams() names

### DIFF
--- a/pkg/kubernetes/views/image-listing.html
+++ b/pkg/kubernetes/views/image-listing.html
@@ -15,7 +15,7 @@
             <th translatable="yes">Last Updated</th>
         </tr>
     </thead>
-    <tbody ng-repeat-start="stream in imagestreams() track by stream.metadata.name"
+    <tbody ng-repeat-start="(link, stream) in imagestreams() track by link"
            ng-init="sid = stream.metadata.namespace + '/' + stream.metadata.name"
            data-id="{{ sid }}" class="active" ng-class="{open: listing.expanded(sid)}">
         <tr class="listing-item imagestream-item" ng-click="listing.toggle(sid)">


### PR DESCRIPTION
This fixes an Angular exception.

Duplicates in a repeater are not allowed. Use 'track by' expression to specify unique keys. Repeater: stream in imagestreams() track by stream.metadata.name, Duplicate key: busybox, Duplicate value: