### PR TITLE
containers: Quote the registry /etc/os-release properly

### DIFF
--- a/containers/kubernetes/registry-brand
+++ b/containers/kubernetes/registry-brand
@@ -1,3 +1,3 @@
-NAME=Atomic Registry
+NAME="Atomic Registry"
 ID=registry
-PRETTY_NAME=Atomic Registry
+PRETTY_NAME="Atomic Registry"


### PR DESCRIPTION
Values with spaces in an /etc/os-release file are meant to
be quoted with double quotes.