### PR TITLE
base1: Distribute react.min.js file

### DIFF
--- a/pkg/base1/Makefile.am
+++ b/pkg/base1/Makefile.am
@@ -154,6 +154,7 @@ EXTRA_DIST += \
 	pkg/base1/require.min.js \
 	pkg/base1/mustache.min.js \
 	pkg/base1/moment.min.js \
+	pkg/base1/react.min.js \
 	pkg/base1/term.min.js \
 	pkg/base1/test-dbus-common.js \
 	$(base_BUNDLE) \


### PR DESCRIPTION
Or the build on certain operating systems from a tarball fails:

```
/usr/bin/env: node: No such file or directory
WARNING: './tools/uglifyjs' is missing on your system.
```