### PR TITLE
bridge: Return PEM data when TLS validation fails

### DIFF
--- a/src/bridge/test-websocketstream.c
+++ b/src/bridge/test-websocketstream.c
@@ -24,6 +24,7 @@
 #include "cockpitchannel.h"
 
 #include "common/cockpittest.h"
+#include "common/cockpitjson.h"
 #include "common/cockpitwebresponse.h"
 #include "common/cockpitwebserver.h"
 #include "websocket/websocketclient.h"
@@ -208,6 +209,154 @@ test_bad_origin (TestCase *test,
   g_free (problem);
 }
 
+typedef struct {
+  GTlsCertificate *certificate;
+  MockTransport *transport;
+  CockpitWebServer *server;
+  guint port;
+  gchar *origin;
+  gchar *url;
+  gboolean ws_closed;
+} TestTls;
+
+static void
+setup_tls (TestTls *test,
+           gconstpointer data)
+{
+  GError *error = NULL;
+
+  test->certificate = g_tls_certificate_new_from_files (SRCDIR "/src/bridge/mock-server.crt",
+                                                        SRCDIR "/src/bridge/mock-server.key", &error);
+  g_assert_no_error (error);
+  test->server = cockpit_web_server_new (0, test->certificate, NULL, NULL, &error);
+  g_assert_no_error (error);
+
+  test->port = cockpit_web_server_get_port (test->server);
+  test->transport = mock_transport_new ();
+  test->ws_closed = FALSE;
+  test->origin = g_strdup_printf ("https://localhost:%u", test->port);
+  test->url = g_strdup_printf ("wss://localhost:%u/socket", test->port);
+  g_signal_connect (test->server, "handle-stream",
+                    G_CALLBACK (handle_socket), test);
+}
+
+static void
+teardown_tls (TestTls *test,
+          gconstpointer data)
+{
+  g_object_unref (test->certificate);
+  g_object_unref (test->server);
+  g_object_unref (test->transport);
+
+  g_free (test->origin);
+  g_free (test->url);
+}
+
+
+static const gchar fixture_tls_authority_good[] =
+  "{ \"authority\": { \"file\": \"" SRCDIR "/src/bridge/mock-server.crt\" } }";
+
+static void
+test_tls_authority_good (TestTls *test,
+                         gconstpointer json)
+{
+  JsonObject *tls;
+  JsonObject *options;
+  CockpitChannel *channel;
+  GBytes *bytes = NULL;
+  GBytes *recv = NULL;
+  GError *error = NULL;
+
+  tls = cockpit_json_parse_object (json, -1, &error);
+  g_assert_no_error (error);
+
+  options = json_object_new ();
+  json_object_set_int_member (options, "port", test->port);
+  json_object_set_string_member (options, "payload", "websocket-stream1");
+  json_object_set_string_member (options, "path", "/socket");
+  json_object_set_object_member (options, "tls", tls);
+
+  channel = g_object_new (COCKPIT_TYPE_WEB_SOCKET_STREAM,
+                          "transport", test->transport,
+                          "id", "444",
+                          "options", options,
+                          NULL);
+
+  json_object_unref (options);
+
+  bytes = g_bytes_new ("Message", 7);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (test->transport), "444", bytes);
+  g_bytes_unref (bytes);
+
+  while (mock_transport_count_sent (test->transport) < 3)
+    g_main_context_iteration (NULL, TRUE);
+
+  recv = mock_transport_pop_channel (test->transport, "444");
+  cockpit_assert_bytes_eq (recv, "MESSAGE", 7);
+  g_bytes_unref (recv);
+
+  cockpit_channel_close (channel, "ending");
+
+  while (!test->ws_closed)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_object_unref (channel);
+}
+
+static const gchar fixture_tls_authority_bad[] =
+  "{ \"authority\": { \"file\": \"" SRCDIR "/src/bridge/mock-client.crt\" } }";
+
+static void
+test_tls_authority_bad (TestTls *test,
+                         gconstpointer json)
+{
+  CockpitChannel *channel;
+  JsonObject *options;
+  JsonObject *tls;
+  GError *error = NULL;
+
+  GBytes *bytes;
+  JsonObject *resp;
+  gchar *expected_pem = NULL;
+  gchar *expected_json = NULL;
+  const gchar *expected_fmt;
+
+  g_object_get (test->certificate, "certificate-pem", &expected_pem, NULL);
+  g_assert_true (expected_pem != NULL);
+
+  tls = cockpit_json_parse_object (json, -1, &error);
+  g_assert_no_error (error);
+
+  options = json_object_new ();
+  json_object_set_int_member (options, "port", test->port);
+  json_object_set_string_member (options, "payload", "websocket-stream1");
+  json_object_set_string_member (options, "path", "/socket");
+  json_object_set_object_member (options, "tls", tls);
+
+  channel = g_object_new (COCKPIT_TYPE_WEB_SOCKET_STREAM,
+                          "transport", test->transport,
+                          "id", "444",
+                          "options", options,
+                          NULL);
+  json_object_unref (options);
+
+  bytes = g_bytes_new ("Message", 7);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (test->transport), "444", bytes);
+  g_bytes_unref (bytes);
+
+  while (mock_transport_count_sent (test->transport) < 1)
+    g_main_context_iteration (NULL, TRUE);
+
+  resp = mock_transport_pop_control (test->transport);
+  expected_fmt = "{\"command\":\"close\",\"channel\":\"444\",\"problem\":\"unknown-hostkey\", \"rejected-certificate\":\"%s\"}";
+  expected_json = g_strdup_printf (expected_fmt, expected_pem);
+  cockpit_assert_json_eq (resp, expected_json);
+
+  g_object_unref (channel);
+  g_free (expected_pem);
+  g_free (expected_json);
+}
+
 int
 main (int argc,
       char *argv[])
@@ -218,5 +367,9 @@ main (int argc,
               setup, test_basic, teardown);
   g_test_add ("/websocket-stream/test_bad_origin", TestCase, NULL,
               setup, test_bad_origin, teardown);
+  g_test_add ("/websocket/tls/authority-good", TestTls, fixture_tls_authority_good,
+              setup_tls, test_tls_authority_good, teardown_tls);
+  g_test_add ("/websocket/tls/authority-bad", TestTls, fixture_tls_authority_bad,
+              setup_tls, test_tls_authority_bad, teardown_tls);
   return g_test_run ();
 }

--- a/src/websocket/websocketconnection.c
+++ b/src/websocket/websocketconnection.c
@@ -550,6 +550,20 @@ _web_socket_connection_error_and_close (WebSocketConnection *self,
   else
     code = WEB_SOCKET_CLOSE_GOING_AWAY;
 
+  if (!self->pv->server_side && error && error->domain == G_TLS_ERROR)
+    {
+      self->pv->peer_close_code = WEB_SOCKET_CLOSE_TLS_HANDSHAKE;
+      if (g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_NOT_TLS) ||
+          g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_MISC))
+        {
+          self->pv->peer_close_data = g_strdup ("protocol-error");
+        }
+      else if (g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_BAD_CERTIFICATE))
+        {
+          self->pv->peer_close_data = g_strdup ("unknown-hostkey");
+        }
+    }
+
   if (!_web_socket_connection_error (self, error))
     return;
 


### PR DESCRIPTION
Return the PEM data of the certificate that failed validation as part of the close message for http-stream and websocket-stream channels.