### PR TITLE
bridge: Skip package add if manifest setup fails

### DIFF
--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -599,6 +599,7 @@ maybe_add_package (GHashTable *listing,
     {
       cockpit_package_free (package);
       package = NULL;
+      goto out;
     }
 
   g_hash_table_replace (listing, package->name, package);


### PR DESCRIPTION
Otherwise we'd try to dereference a null pointer.

Coverity found this one.