### PR TITLE
tools: Run 'npm install' in make-source when necessary

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -36,6 +36,7 @@ olddir=$(pwd)
 cd $srcdir
 
 npm install # see package.json
+cp package.json node_modules # for tools/make-source
 find node_modules -name test | xargs rm -rf
 
 rm -rf autom4te.cache

--- a/tools/make-source
+++ b/tools/make-source
@@ -32,9 +32,11 @@ cd $base/..
 
 if [ -d .git ]; then
     git archive HEAD --prefix cockpit-wip/ --output $outdir/cockpit-wip.tar
-    if [ -d node_modules ]; then
-        tar -rf $outdir/cockpit-wip.tar --transform='s|^|cockpit-wip/|S' --exclude='phantomjs*' node_modules
+    if ! diff -qN package.json node_modules/package.json > /dev/null; then
+        npm install --silent
+        cp package.json node_modules/package.json
     fi
+    tar -rf $outdir/cockpit-wip.tar --transform='s|^|cockpit-wip/|S' --exclude='phantomjs*' node_modules
 else
     tar -cf $outdir/cockpit-wip.tar --transform='s|^|cockpit-wip/|S' .
 fi


### PR DESCRIPTION
If package.json has changed or no node_modules exists run
npm install during ```tools/make-source```

This lets the verify machines get the right node modules
into the builder vms.