### PR TITLE
Selinux: Fix progress message and error display for alert details

### DIFF
--- a/pkg/selinux/setroubleshoot-client.js
+++ b/pkg/selinux/setroubleshoot-client.js
@@ -138,6 +138,8 @@ client.init = function() {
                 dfd_result.resolve(details);
             })
             .fail(function(ex) {
+                console.warn("Unable to get alert for id " + local_id);
+                console.warn(ex);
                 dfd_result.reject(new Error(_("Unable to get alert") + ": " + local_id));
             });
         return dfd_result.promise();

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -66,7 +66,8 @@ var SELinuxEventDetails = React.createClass({
                 <EmptyState
                     icon={ <div className="spinner spinner-lg" /> }
                     description="Waiting for details..."
-                    message={ null } />
+                    message={ null }
+                    relative={ true }/>
             );
         }
         var self = this;
@@ -152,6 +153,16 @@ var SELinuxEventDetails = React.createClass({
 /* Show the audit log events for an alert */
 var SELinuxEventLog = React.createClass({
     render: function() {
+        if (!this.props.details) {
+            // details should be requested by default, so we just need to wait for them
+            return (
+                <EmptyState
+                    icon={ <div className="spinner spinner-lg" /> }
+                    description="Waiting for details..."
+                    message={ null }
+                    relative={ true }/>
+            );
+        }
         var self = this;
         var log_entries = this.props.details.audit_event.map(function(itm, idx) {
             // use the alert id and index in the event log array as the data key for react
@@ -261,8 +272,11 @@ var EmptyState = React.createClass({
         if (this.props.message)
             message = <p>{this.props.message}</p>;
 
+        var curtains = "curtains";
+        if (this.props.relative)
+            curtains = "curtains-relative";
         return (
-            <div className="curtains blank-slate-pf">
+            <div className={curtains + "blank-slate-pf"}>
                 <div className="blank-slate-pf-icon">
                     { this.props.icon }
                 </div>

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -24,12 +24,6 @@ define([
 "use strict";
 
 /* Show details for an alert, including possible solutions */
-  /* running solution entry.fix
-                      plugin: analysis_id,
-                    running: true,
-                    result: null,
-                    success: false,
-  */
 var SELinuxEventDetails = React.createClass({
     getInitialState: function() {
         var expanded;
@@ -62,10 +56,11 @@ var SELinuxEventDetails = React.createClass({
     render: function() {
         if (!this.props.details) {
             // details should be requested by default, so we just need to wait for them
+            var waiting = (this.props.details === undefined);
             return (
                 <EmptyState
-                    icon={ <div className="spinner spinner-lg" /> }
-                    description="Waiting for details..."
+                    icon={ waiting ? 'waiting' : 'error' }
+                    description={ waiting ? 'Waiting for details...' : 'Unable to get alert details.' }
                     message={ null }
                     relative={ true }/>
             );
@@ -155,10 +150,11 @@ var SELinuxEventLog = React.createClass({
     render: function() {
         if (!this.props.details) {
             // details should be requested by default, so we just need to wait for them
+            var waiting = (this.props.details === undefined);
             return (
                 <EmptyState
-                    icon={ <div className="spinner spinner-lg" /> }
-                    description="Waiting for details..."
+                    icon={ waiting ? 'waiting' : 'error' }
+                    description={ waiting ? 'Waiting for details...' : 'Unable to get alert details.' }
                     message={ null }
                     relative={ true }/>
             );
@@ -261,6 +257,9 @@ var SELinuxEvent = React.createClass({
 
 /* Implements a subset of the PatternFly Empty State pattern
  * https://www.patternfly.org/patterns/empty-state/
+ * Special values for icon property:
+ *   - 'waiting' - display spinner
+ *   - 'error'   - display error icon
  */
 var EmptyState = React.createClass({
     render: function() {
@@ -275,10 +274,16 @@ var EmptyState = React.createClass({
         var curtains = "curtains";
         if (this.props.relative)
             curtains = "curtains-relative";
+
+        var icon = this.props.icon;
+        if (icon == 'waiting')
+            icon = <div className="spinner spinner-lg"></div>;
+        else if (icon == 'error')
+            icon = <div className="pficon pficon-error-circle-o"></div>;
         return (
-            <div className={curtains + "blank-slate-pf"}>
+            <div className={curtains + " blank-slate-pf"}>
                 <div className="blank-slate-pf-icon">
-                    { this.props.icon }
+                    { icon }
                 </div>
                 { description }
                 { message }

--- a/pkg/selinux/setroubleshoot.css
+++ b/pkg/selinux/setroubleshoot.css
@@ -52,3 +52,8 @@ div#app h3 {
 .setroubleshoot-progress-message {
     vertical-align: top;
 }
+
+.curtains-relative {
+    height: 100%;
+    width: 100%;
+}


### PR DESCRIPTION
I found this while testing a broken setroubleshoot-server package from https://bodhi.fedoraproject.org/updates/FEDORA-2016-1665e574a3
There is a backend dbus script error that we properly catch, but it is more helpful to the user to actually display something and not just keep showing a spinner.