### PR TITLE
docker: Restart Policies

### DIFF
--- a/pkg/docker/details.js
+++ b/pkg/docker/details.js
@@ -194,6 +194,7 @@ define([
             $('#container-details-image').text("");
             $('#container-details-command').text("");
             $('#container-details-state').text("");
+            $('#container-details-restart-policy').text("");
             $('#container-details-ports-row').hide();
             $('#container-details-links-row').hide();
             $('#container-details-resource-row').hide();
@@ -232,6 +233,7 @@ define([
             $('#container-details-image').text(info.Image);
             $('#container-details-command').text(util.render_container_cmdline(info));
             $('#container-details-state').text(util.render_container_state(info.State));
+            $('#container-details-restart-policy').text(util.render_container_restart_policy(info.HostConfig.RestartPolicy));
 
             $('#container-details-ports-row').toggle(port_bindings.length > 0);
             $('#container-details-ports').html(util.multi_line(port_bindings));

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -222,6 +222,12 @@
     max-width: 150px;
 }
 
+#restart-policy-select > button > span.pull-left {
+    overflow: hidden;
+    width: 100%;
+    text-align: left;
+}
+
 #restart-policy-retries-container {
     display: inline;
     margin-left: 4px;

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -229,6 +229,7 @@
 
 #restart-policy-retries {
   max-width: 50px;
+  display: inline;
 }
 
 /* Hack to remove size column */

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -210,26 +210,26 @@
 }
 
 @media (min-width: 768px) {
-  #select-linked-containers .form-group {
-      width: 40%;
-  }
-  #select-linked-containers input {
-      max-width: 73%;
-  }
+    #select-linked-containers .form-group {
+        width: 40%;
+    }
+    #select-linked-containers input {
+        max-width: 73%;
+    }
 }
 
 #restart-policy-select {
-  max-width: 150px;
+    max-width: 150px;
 }
 
 #restart-policy-retries-container {
-  display: inline;
-  margin-left: 4px;
+    display: inline;
+    margin-left: 4px;
 }
 
 #restart-policy-retries {
-  max-width: 50px;
-  display: inline;
+    max-width: 50px;
+    display: inline;
 }
 
 /* Hack to remove size column */

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -218,6 +218,19 @@
   }
 }
 
+#restart-policy-select {
+  max-width: 150px;
+}
+
+#restart-policy-retries-container {
+  display: inline;
+  margin-left: 4px;
+}
+
+#restart-policy-retries {
+  max-width: 50px;
+}
+
 /* Hack to remove size column */
 .image-col-size-graph {
     display: none !important;

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -218,6 +218,10 @@
             <td>State:</td>
             <td colspan="2" id="container-details-state"></td>
           </tr>
+          <tr>
+            <td>Restart Policy:</td>
+            <td colspan="2" id="container-details-restart-policy"></td>
+          </tr>
           <tr id="container-details-ports-row" hidden>
             <td>Ports:</td>
             <td colspan="2" id="container-details-ports"></td>

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -513,7 +513,7 @@
                   </div>
                   <div id="restart-policy-retries-container" class="hidden">
                     <label class="control-label" for="restart-policy-retries" translatable="yes">Retries:</label>
-                    <input id="restart-policy-retries" class="form-control" type="text" value="0" name="restart-policy-retries">
+                    <input id="restart-policy-retries" class="form-control" type="number" value="0" min="0" name="restart-policy-retries">
                   </div>
                 </div>
               </td>

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -499,14 +499,22 @@
               <td><label class="control-label" for="restart-policy" translatable="yes">Restart Policy</label></td>
               <td colspan="2">
                 <div class="form-inline form-group">
-                  <select name="restart-policy" id="restart-policy-select" class="form-control">
-                    <option value="no">No</option>
-                    <option value="on-failure">On Failure</option>
-                    <option value="always">Always</option>
-                    <option value="unless-stopped">Unless Stopped</option>
-                  </select>
-                  <label class="control-label" for="restart-policy-retries" translatable="yes">Retries:</label>
-                  <input class="form-control" type="number" name="restart-policy-retries" id="restart-policy-retries" disabled="true">
+                  <div class="btn-group bootstrap-select dropdown form-control" id="restart-policy-select">
+                    <button aria-expanded="false" class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                      <span class="pull-left" translatable="yes" data-value="no">No</span>
+                      <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu" id="restart-policy-dropdown">
+                      <li><a data-value="no">No</a></li>
+                      <li><a data-value="on-failure">On Failure</a></li>
+                      <li><a data-value="always">Always</a></li>
+                      <li><a data-value="unless-stopped">Unless Stopped</a></li>
+                    </ul>
+                  </div>
+                  <div id="restart-policy-retries-container" class="hidden">
+                    <label class="control-label" for="restart-policy-retries" translatable="yes">Retries:</label>
+                    <input id="restart-policy-retries" class="form-control" type="text" value="0" name="restart-policy-retries">
+                  </div>
                 </div>
               </td>
             </tr>

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -505,10 +505,10 @@
                       <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu" id="restart-policy-dropdown">
-                      <li><a data-value="no">No</a></li>
-                      <li><a data-value="on-failure">On Failure</a></li>
-                      <li><a data-value="always">Always</a></li>
-                      <li><a data-value="unless-stopped">Unless Stopped</a></li>
+                      <li><a translatable="yes" data-value="no">No</a></li>
+                      <li><a translatable="yes" data-value="on-failure">On Failure</a></li>
+                      <li><a translatable="yes" data-value="always">Always</a></li>
+                      <li><a translatable="yes" data-value="unless-stopped">Unless Stopped</a></li>
                     </ul>
                   </div>
                   <div id="restart-policy-retries-container" class="hidden">

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -495,6 +495,21 @@
                 </div>
               </td>
             </tr>
+            <tr>
+              <td><label class="control-label" for="restart-policy" translatable="yes">Restart Policy</label></td>
+              <td colspan="2">
+                <div class="form-inline form-group">
+                  <select name="restart-policy" id="restart-policy-select" class="form-control">
+                    <option value="no">No</option>
+                    <option value="on-failure">On Failure</option>
+                    <option value="always">Always</option>
+                    <option value="unless-stopped">Unless Stopped</option>
+                  </select>
+                  <label class="control-label" for="restart-policy-retries" translatable="yes">Retries:</label>
+                  <input class="form-control" type="number" name="restart-policy-retries" id="restart-policy-retries" disabled="true">
+                </div>
+              </td>
+            </tr>
 
           </table>
         </div>

--- a/pkg/docker/run.js
+++ b/pkg/docker/run.js
@@ -184,7 +184,7 @@ define([
             }
 
             var restart_policy_select_button = $('#restart-policy-select > button span.pull-left');
-            restart_policy_select_button.text('No');
+            restart_policy_select_button.text(_("No"));
             restart_policy_select_button.data('name', 'no');
             $('#restart-policy-retries').val('0');
             $('#restart-policy-retries-container').addClass('hidden');

--- a/pkg/docker/run.js
+++ b/pkg/docker/run.js
@@ -617,7 +617,7 @@ define([
                     "Links": links,
                     "RestartPolicy": {
                       "Name": $("#restart-policy-select").val(),
-                      "MaximumRetryCount": parseInt($("#restart-policy-retries").val()) || 0
+                      "MaximumRetryCount": parseInt($("#restart-policy-retries").val(), 10) || 0
                     }
                 }
             };

--- a/pkg/docker/run.js
+++ b/pkg/docker/run.js
@@ -76,7 +76,7 @@ define([
             });
 
             var restart_policy_dropdown = $("#restart-policy-dropdown");
-            var restart_policy_dropdown_selected = $("#restart-policy-select > button span.pull-left")
+            var restart_policy_dropdown_selected = $("#restart-policy-select > button span.pull-left");
 
             restart_policy_dropdown.find("a").on('click', function () {
                 restart_policy_dropdown_selected.text($(this).text());

--- a/pkg/docker/run.js
+++ b/pkg/docker/run.js
@@ -75,13 +75,18 @@ define([
                 self.update('changeFocus', 'links');
             });
 
-            $("#restart-policy-select").change(function() {
-                var selected = $(this).find("option:selected")[0];
+            var restart_policy_dropdown = $("#restart-policy-dropdown");
+            var restart_policy_dropdown_selected = $("#restart-policy-select > button span.pull-left")
 
-                if (selected.value === "on-failure") {
-                    $("#restart-policy-retries").prop('disabled', false);
+            restart_policy_dropdown.find("a").on('click', function () {
+                restart_policy_dropdown_selected.text($(this).text());
+
+                var name = $(this).data('value');
+                restart_policy_dropdown_selected.data('name', name);
+                if (name === 'on-failure') {
+                  $("#restart-policy-retries-container").removeClass('hidden');
                 } else {
-                    $("#restart-policy-retries").prop('disabled', true);
+                  $("#restart-policy-retries-container").addClass('hidden');
                 }
             });
 
@@ -177,6 +182,8 @@ define([
             } else {
                 $('#expose-ports').prop('checked', false);
             }
+
+
         },
 
         configuration_validator: function() {
@@ -616,7 +623,7 @@ define([
                     "PortBindings": port_bindings,
                     "Links": links,
                     "RestartPolicy": {
-                      "Name": $("#restart-policy-select").val(),
+                      "Name": $("#restart-policy-select > button span.pull-left").data('name'),
                       "MaximumRetryCount": parseInt($("#restart-policy-retries").val(), 10) || 0
                     }
                 }

--- a/pkg/docker/run.js
+++ b/pkg/docker/run.js
@@ -75,6 +75,16 @@ define([
                 self.update('changeFocus', 'links');
             });
 
+            $("#restart-policy-select").change(function() {
+                var selected = $(this).find("option:selected")[0];
+
+                if (selected.value === "on-failure") {
+                    $("#restart-policy-retries").prop('disabled', false);
+                } else {
+                    $("#restart-policy-retries").prop('disabled', true);
+                }
+            });
+
             this.validator = this.configuration_validator();
         },
 
@@ -593,6 +603,7 @@ define([
             $("#containers_run_image_dialog").modal('hide');
 
             var tty = $("#containers-run-image-with-terminal").prop('checked');
+
             var options = {
                 "Cmd": util.unquote_cmdline(cmd),
                 "Image": PageRunImage.image_info.Id,
@@ -602,8 +613,12 @@ define([
                 "Tty": tty,
                 "ExposedPorts": exposed_ports,
                 "HostConfig": {
+                    "PortBindings": port_bindings,
                     "Links": links,
-                    "PortBindings": port_bindings
+                    "RestartPolicy": {
+                      "Name": $("#restart-policy-select").val(),
+                      "MaximumRetryCount": parseInt($("#restart-policy-retries").val()) || 0
+                    }
                 }
             };
 

--- a/pkg/docker/run.js
+++ b/pkg/docker/run.js
@@ -84,9 +84,9 @@ define([
                 var name = $(this).data('value');
                 restart_policy_dropdown_selected.data('name', name);
                 if (name === 'on-failure') {
-                  $("#restart-policy-retries-container").removeClass('hidden');
+                    $("#restart-policy-retries-container").removeClass('hidden');
                 } else {
-                  $("#restart-policy-retries-container").addClass('hidden');
+                    $("#restart-policy-retries-container").addClass('hidden');
                 }
             });
 
@@ -627,8 +627,8 @@ define([
                     "PortBindings": port_bindings,
                     "Links": links,
                     "RestartPolicy": {
-                      "Name": $("#restart-policy-select > button span.pull-left").data('name'),
-                      "MaximumRetryCount": parseInt($("#restart-policy-retries").val(), 10) || 0
+                        "Name": $("#restart-policy-select > button span.pull-left").data('name'),
+                        "MaximumRetryCount": parseInt($("#restart-policy-retries").val(), 10) || 0
                     }
                 }
             };

--- a/pkg/docker/run.js
+++ b/pkg/docker/run.js
@@ -603,7 +603,7 @@ define([
                 "ExposedPorts": exposed_ports,
                 "HostConfig": {
                     "Links": links,
-                    "PortBindings": port_bindings,
+                    "PortBindings": port_bindings
                 }
             };
 

--- a/pkg/docker/run.js
+++ b/pkg/docker/run.js
@@ -183,7 +183,11 @@ define([
                 $('#expose-ports').prop('checked', false);
             }
 
-
+            var restart_policy_select_button = $('#restart-policy-select > button span.pull-left');
+            restart_policy_select_button.text('No');
+            restart_policy_select_button.data('name', 'no');
+            $('#restart-policy-retries').val('0');
+            $('#restart-policy-retries-container').addClass('hidden');
         },
 
         configuration_validator: function() {

--- a/pkg/docker/util.js
+++ b/pkg/docker/util.js
@@ -73,6 +73,23 @@ define([
             return cockpit.format(_("Exited $ExitCode"), state);
     };
 
+    util.render_container_restart_policy = function render_restart_policy(policy) {
+      switch (policy.Name) {
+        case "":
+          return "None";
+          break;
+        case "on-failure":
+          var singular = policy.MaximumRetryCount == 1;
+          return "On Failure, retry " + policy.MaximumRetryCount + (singular ? ' time' : ' times');
+          break;
+        default: /* http://stackoverflow.com/a/4878800 */
+          return policy.Name.replace('-', ' ').replace(/\w\S*/g, function(txt) {
+            return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+          });
+          break;
+      }
+    }
+
     util.multi_line = function multi_line(strings) {
         return strings.map(function (str) { return Mustache.render("{{.}}", str); }).join('<br/>');
     };

--- a/pkg/docker/util.js
+++ b/pkg/docker/util.js
@@ -77,10 +77,16 @@ define([
       switch (policy.Name) {
         case "":
           return "None";
+        case "no":
+          return "No";
         case "on-failure":
           var singular = policy.MaximumRetryCount == 1;
           return "On Failure, retry " + policy.MaximumRetryCount + (singular ? ' time' : ' times');
-        default: /* http://stackoverflow.com/a/4878800 */
+        case "always":
+          return "Always";
+        case "unless-stopped":
+          return "Unless Stopped";
+        default: /* Keeping this here just in case. http://stackoverflow.com/a/4878800 */
           return policy.Name.replace('-', ' ').replace(/\w\S*/g, function(txt) {
             return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
           });

--- a/pkg/docker/util.js
+++ b/pkg/docker/util.js
@@ -77,18 +77,15 @@ define([
       switch (policy.Name) {
         case "":
           return "None";
-          break;
         case "on-failure":
           var singular = policy.MaximumRetryCount == 1;
           return "On Failure, retry " + policy.MaximumRetryCount + (singular ? ' time' : ' times');
-          break;
         default: /* http://stackoverflow.com/a/4878800 */
           return policy.Name.replace('-', ' ').replace(/\w\S*/g, function(txt) {
             return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
           });
-          break;
       }
-    }
+    };
 
     util.multi_line = function multi_line(strings) {
         return strings.map(function (str) { return Mustache.render("{{.}}", str); }).join('<br/>');

--- a/pkg/docker/util.js
+++ b/pkg/docker/util.js
@@ -75,17 +75,15 @@ define([
 
     util.render_container_restart_policy = function render_restart_policy(policy) {
       switch (policy.Name) {
-        case "":
-          return "None";
         case "no":
-          return "No";
+          return _("No");
         case "on-failure":
-          var singular = policy.MaximumRetryCount == 1;
-          return "On Failure, retry " + policy.MaximumRetryCount + (singular ? ' time' : ' times');
+          var text = cockpit.ngettext("On failure, retry $0 time", "On failure, retry $0 times", policy.MaximumRetryCount);
+          return cockpit.format(text, policy.MaximumRetryCount);
         case "always":
-          return "Always";
+          return _("Always");
         case "unless-stopped":
-          return "Unless Stopped";
+          return _("Unless Stopped");
         default: /* Keeping this here just in case. http://stackoverflow.com/a/4878800 */
           return policy.Name.replace('-', ' ').replace(/\w\S*/g, function(txt) {
             return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();


### PR DESCRIPTION
Adds Docker Restart Policies (as described [here](https://docs.docker.com/engine/reference/run/#restart-policies-restart) and [here](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.22/#create-a-container)) to the run modal as well as displays current policy on the container detail screen.

Addresses #2496 (sorry @dperpeet, I'm impatient; don't hate me)

![Run Modal](http://i.imgur.com/SU8IJhq.png)
![Container details](http://i.imgur.com/nVE0f1e.png)

I'm still trying to get the backend to cooperate, as it doesn't seem to want to take the `RestartPolicy` option, even though it doesn't show any errors or warnings. 

### TODO: Thanks @andreasn and @stefwalter 
* [x] Fix `RestartPolicy` not being passed to Docker.
* [x] Hide and show retries selection depending on mode
* [x] Modal resetting
* [x] [General styling touch-ups](https://github.com/cockpit-project/cockpit/pull/4172#issuecomment-207354732)