### PR TITLE
Remove a bunch of jQuery basic usage in cockpit.js

### DIFF
--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -1727,12 +1727,12 @@ translated = cockpit.ngettext([context], string1, stringN, number)
     <refsection id="cockpit-locale-translate">
       <title>cockpit.translate()</title>
 <programlisting>
-cockpit.translate([sel])
+cockpit.translate([el])
 </programlisting>
 
       <para>The document will be scanned for translatable tags and they will be translated according
-        to the strings in loaded locale data. If <code>sel</code> is specified, this should be a jQuery
-        selector for the specific part of the document to translate.</para>
+        to the strings in loaded locale data. If <code>el</code> is specified, this should be a DOM
+        element for the specific part of the document to translate.</para>
     </refsection>
 
   </refsection>

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -2137,24 +2137,23 @@ function full_scope(cockpit, $, po) {
         /* Callback that wants a stream response, see below */
         var buffer = channel.buffer(null);
 
-        $(channel).
-            on("close", function(event, options) {
-                var data = buffer.squash();
-                spawn_debug("process closed:", JSON.stringify(options));
-                if (data)
-                    spawn_debug("process output:", data);
-                if (options.message !== undefined)
-                    spawn_debug("process error:", options.message);
+        channel.addEventListener("close", function(event, options) {
+            var data = buffer.squash();
+            spawn_debug("process closed:", JSON.stringify(options));
+            if (data)
+                spawn_debug("process output:", data);
+            if (options.message !== undefined)
+                spawn_debug("process error:", options.message);
 
-                if (options.problem)
-                    dfd.reject(new ProcessError(options, name));
-                else if (options["exit-status"] || options["exit-signal"])
-                    dfd.reject(new ProcessError(options, name), data);
-                else if (options.message !== undefined)
-                    dfd.resolve(data, options.message);
-                else
-                    dfd.resolve(data);
-            });
+            if (options.problem)
+                dfd.reject(new ProcessError(options, name));
+            else if (options["exit-status"] || options["exit-signal"])
+                dfd.reject(new ProcessError(options, name), data);
+            else if (options.message !== undefined)
+                dfd.resolve(data, options.message);
+            else
+                dfd.resolve(data);
+        });
 
         var jpromise = dfd.promise;
         dfd.promise = function() {

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -55,6 +55,20 @@ function is_plain_object(x) {
     return is_object(x) && Object.prototype.toString.call(x) === '[object Object]';
 }
 
+function extend(to/* , from ... */) {
+    var j, len, key, from;
+    for (j = 1, len = arguments.length; j < len; j++) {
+        from = arguments[j];
+        if (from) {
+            for (key in from) {
+                if (from[key] !== undefined)
+                    to[key] = from[key];
+            }
+        }
+    }
+    return to;
+}
+
 /* -------------------------------------------------------------------------
  * Channels
  *
@@ -1868,7 +1882,7 @@ function full_scope(cockpit, $, po) {
 
     init_callback = function(options) {
         if (options.system)
-            $.extend(cockpit.info, options.system);
+            extend(cockpit.info, options.system);
         if (options.system)
             cockpit.info.dispatchEvent("changed");
     };
@@ -2144,7 +2158,7 @@ function full_scope(cockpit, $, po) {
             args["spawn"].push(String(command));
         }
         if (options !== undefined)
-            $.extend(args, options);
+            extend(args, options);
 
         var name = args["spawn"][0] || "process";
         var channel = cockpit.channel(args);
@@ -2172,7 +2186,7 @@ function full_scope(cockpit, $, po) {
 
         var jpromise = dfd.promise;
         dfd.promise = function() {
-            return $.extend(jpromise.apply(this, arguments), {
+            return extend(jpromise.apply(this, arguments), {
                 stream: function(callback) {
                     buffer.callback = callback;
                     return this;
@@ -2275,7 +2289,7 @@ function full_scope(cockpit, $, po) {
             if (!self.data[path][iface])
                 self.data[path][iface] = props;
             else
-                props = $.extend(self.data[path][iface], props);
+                props = extend(self.data[path][iface], props);
             emit(path, iface, props);
         };
 
@@ -2393,7 +2407,7 @@ function full_scope(cockpit, $, po) {
 
         function update(props) {
             if (props) {
-                $.extend(self.data, props);
+                extend(self.data, props);
                 if (!defined)
                     define();
                 valid = true;
@@ -2455,7 +2469,7 @@ function full_scope(cockpit, $, po) {
             waits.fireWith(self);
 
         /* Already added watch/subscribe, tell proxies not to */
-        options = $.extend({ watch: false, subscribe: false }, options);
+        options = extend({ watch: false, subscribe: false }, options);
 
         function update(props, path) {
             var proxy = self[path];
@@ -2490,7 +2504,7 @@ function full_scope(cockpit, $, po) {
                 track = true;
 
             delete options['track'];
-            $.extend(args, options);
+            extend(args, options);
         }
         args.payload = "dbus-json3";
         args.name = name;
@@ -2569,7 +2583,7 @@ function full_scope(cockpit, $, po) {
                 notify(msg.notify);
             } else if (msg.meta) {
                 ensure_cache();
-                $.extend(cache.meta, msg.meta);
+                extend(cache.meta, msg.meta);
             } else if (msg.owner !== undefined) {
                 self.dispatchEvent("owner", msg.owner);
 
@@ -2723,7 +2737,7 @@ function full_scope(cockpit, $, po) {
 
             var jpromise = dfd.promise;
             dfd.promise = function() {
-                return $.extend(jpromise.apply(this, arguments), {
+                return extend(jpromise.apply(this, arguments), {
                     remove: function remove() {
                         delete calls[id];
                         if (channel && channel.valid) {
@@ -2798,7 +2812,7 @@ function full_scope(cockpit, $, po) {
             close: close
         };
 
-        var base_channel_options = $.extend({ }, options);
+        var base_channel_options = extend({ }, options);
         delete base_channel_options.syntax;
 
         function parse(str) {
@@ -2823,7 +2837,7 @@ function full_scope(cockpit, $, po) {
                 return read_promise;
 
             var dfd = $.Deferred();
-            var opts = $.extend({ }, base_channel_options, {
+            var opts = extend({ }, base_channel_options, {
                 payload: "fsread1",
                 path: path
             });
@@ -2895,7 +2909,7 @@ function full_scope(cockpit, $, po) {
             if (replace_channel)
                 replace_channel.close("abort");
 
-            var opts = $.extend({ }, base_channel_options, {
+            var opts = extend({ }, base_channel_options, {
                 payload: "fsreplace1",
                 path: path,
                 tag: expected_tag
@@ -2981,7 +2995,7 @@ function full_scope(cockpit, $, po) {
                 if (watch_channel)
                     return;
 
-                var opts = $.extend({ }, base_channel_options, {
+                var opts = extend({ }, base_channel_options, {
                     payload: "fswatch1",
                     path: path
                 });
@@ -3051,7 +3065,7 @@ function full_scope(cockpit, $, po) {
         var header;
 
         if (po) {
-            $.extend(po_data, po);
+            extend(po_data, po);
             header = po[""];
         } else {
             po_data = { };
@@ -3241,11 +3255,11 @@ function full_scope(cockpit, $, po) {
             var headers = req.headers;
             delete req.headers;
 
-            $.extend(req, options);
+            extend(req, options);
 
             /* Combine the headers */
             if (options.headers && headers)
-                req.headers = $.extend({ }, options.headers, headers);
+                req.headers = extend({ }, options.headers, headers);
             else if (options.headers)
                 req.headers = options.headers;
             else
@@ -3327,7 +3341,7 @@ function full_scope(cockpit, $, po) {
 
             var jpromise = dfd.promise;
             dfd.promise = function mypromise() {
-                var ret = $.extend(jpromise.apply(this, arguments), {
+                var ret = extend(jpromise.apply(this, arguments), {
                     stream: function(callback) {
                         streamer = callback;
                         return this;
@@ -3515,7 +3529,7 @@ function full_scope(cockpit, $, po) {
                 following = true;
             }
 
-            var options = $.extend({
+            var options = extend({
                 payload: "metrics1",
                 interval: interval,
                 source: "internal"
@@ -3647,7 +3661,7 @@ function full_scope(cockpit, $, po) {
             var archive_options_list = [ ];
             for (var i = 0; i < options_list.length; i++) {
                 if (options_list[i].archive_source) {
-                    archive_options_list.push($.extend({}, options_list[i],
+                    archive_options_list.push(extend({}, options_list[i],
                                                        { "source": options_list[i].archive_source,
                                                          timestamp: timestamp,
                                                          limit: limit

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -3081,12 +3081,17 @@ function full_scope(cockpit, $, po) {
         cockpit.language = lang;
     };
 
-    cockpit.translate = function translate(sel) {
-        $("[translatable=\"yes\"]", sel).each(function(i, e) {
-            var $e = $(e);
-            var translated = cockpit.gettext(e.getAttribute("context"), $e.text());
-            $(e).removeAttr("translatable").text(translated);
-        });
+    cockpit.translate = function translate(el) {
+        var list = (el || document).querySelectorAll("[translatable=\"yes\"]");
+        var e, translated, i, len;
+        if (list) {
+            for (i = 0, len = list.length; i < len; i++) {
+                e = list[i];
+                translated = cockpit.gettext(e.getAttribute("context"), e.textContent);
+                e.removeAttribute("translatable");
+                e.textContent = translated;
+            }
+        }
     };
 
     cockpit.gettext = function gettext(context, string) {

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -2133,7 +2133,7 @@ function full_scope(cockpit, $, po) {
             else
                 this.message = cockpit.format(_("$0 failed"), name);
         } else {
-            this.message = $.trim(this.message);
+            this.message = this.message.trim();
         }
 
         this.toString = function() {

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -2347,9 +2347,11 @@ function full_scope(cockpit, $, po) {
             "data": { value: { }, enumerable: false }
         });
 
-        Object.defineProperty(self, $.expando, {
-            value: { }, writable: true, enumerable: false
-        });
+        if (typeof $ === "function") {
+            Object.defineProperty(self, $.expando, {
+                value: { }, writable: true, enumerable: false
+            });
+        }
 
         if (!options)
             options = { };
@@ -2452,9 +2454,11 @@ function full_scope(cockpit, $, po) {
                       enumerable: false, writable: false }
         });
 
-        Object.defineProperty(self, $.expando, {
-            value: { }, writable: true, enumerable: false
-        });
+        if (typeof $ === "function") {
+            Object.defineProperty(self, $.expando, {
+                value: { }, writable: true, enumerable: false
+            });
+        }
 
         /* Subscribe to signals once for all proxies */
         var match = { "interface": iface, "path_namespace": path_namespace };

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -3239,6 +3239,12 @@ function full_scope(cockpit, $, po) {
             options.capabilities.push("address");
         }
 
+        function param(obj) {
+            return Object.keys(obj).map(function(k) {
+                return encodeURIComponent(k) + '=' + encodeURIComponent(obj[k]);
+            }).join('&').split('%20').join('+'); /* split/join because phantomjs */
+        }
+
         self.request = function request(req) {
             var dfd = new $.Deferred();
 
@@ -3248,9 +3254,9 @@ function full_scope(cockpit, $, po) {
                 req.method = "GET";
             if (req.params) {
                 if (req.path.indexOf("?") === -1)
-                    req.path += "?" + $.param(req.params);
+                    req.path += "?" + param(req.params);
                 else
-                    req.path += "&" + $.param(req.params);
+                    req.path += "&" + param(req.params);
             }
             delete req.params;
 

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -3591,7 +3591,7 @@ function full_scope(cockpit, $, po) {
                     meta = message;
                     timestamp = 0;
                     if (meta.now && meta.timestamp)
-                        timestamp = meta.timestamp + ($.now() - meta.now);
+                        timestamp = meta.timestamp + (Date.now() - meta.now);
                     beg = Math.floor(timestamp / interval);
                     callback(beg, meta, null, options_list[0]);
 
@@ -3666,7 +3666,7 @@ function full_scope(cockpit, $, po) {
         }
 
         self.fetch = function fetch(beg, end) {
-            var timestamp = beg * interval - $.now();
+            var timestamp = beg * interval - Date.now();
             var limit = end - beg;
 
             var archive_options_list = [ ];

--- a/pkg/base1/test-spawn.html
+++ b/pkg/base1/test-spawn.html
@@ -76,7 +76,7 @@ function MockPeer() {
             payload = String(payload);
         window.setTimeout(function() {
             if (channel.valid)
-                $(channel).trigger("message", [payload]);
+                channel.dispatchEvent("message", payload);
             else
                 console.log("dropping message after close from MockPeer");
         }, 5);
@@ -88,7 +88,7 @@ function MockPeer() {
         window.setTimeout(function() {
             if (channel.valid) {
                 channel.valid = false;
-                $(channel).trigger("close", [options || { }]);
+                channel.dispatchEvent("close", options || { });
             }
         }, 5);
     }
@@ -97,6 +97,7 @@ function MockPeer() {
     var last_channel = 0;
 
     function MockChannel(options) {
+        cockpit.event_target(this);
         this.number = last_channel++;
         this.options = options;
         this.valid = true;
@@ -117,7 +118,7 @@ function MockPeer() {
             console.assert(arguments.length <= 1);
             this.valid = false;
             window.setTimeout(function() { $(peer).trigger("closed", [channel, options || { }]); }, 5);
-            $(this).triggerHandler("close", [options || { }]);
+            this.dispatchEvent("close", options || { });
         };
 
         this.buffer = function(callback) {


### PR DESCRIPTION
Removes use of a bunch of basic jQuery functions in cockpit.js. Each commit message has a description of what's going on.

The following remain for later pull requests: Promises, proxy.wait(), proxies.wait()