### PR TITLE
docker: Don't start each container after run creates one

### DIFF
--- a/pkg/docker/run.js
+++ b/pkg/docker/run.js
@@ -602,7 +602,8 @@ define([
                 "Tty": tty,
                 "ExposedPorts": exposed_ports,
                 "HostConfig": {
-                    "Links": links
+                    "Links": links,
+                    "PortBindings": port_bindings,
                 }
             };
 
@@ -621,7 +622,7 @@ define([
                     util.show_unexpected_error(ex);
                 }).
                 done(function(result) {
-                    PageRunImage.client.start(result.Id, { "PortBindings": port_bindings }).
+                    PageRunImage.client.start(result.Id).
                         fail(function(ex) {
                             util.show_unexpected_error(ex);
                         });


### PR DESCRIPTION
This causes docker to discard some of the settings we applied
during the /containers/create POST request, such as the soon
coming RestartPolicy.