### PR TITLE
debian: make a non-native package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ org.freedesktop.UDisks2.h
 /po/po.*.js.gz
 /.vagrant
 /test_rsa_key
+/tmp-dist
 
 /pkg/kubernetes/kubernetes-templates.js
 /pkg/kubernetes/registry-templates.js

--- a/autogen.sh
+++ b/autogen.sh
@@ -36,7 +36,6 @@ olddir=$(pwd)
 cd $srcdir
 
 npm install # see package.json
-cp package.json node_modules # for tools/make-source
 find node_modules -name test | xargs rm -rf
 
 rm -rf autom4te.cache
@@ -68,7 +67,7 @@ rm -f $srcdir/Makefile
 $srcdir/configure --enable-maintainer-mode ${AUTOGEN_CONFIGURE_ARGS:-} "$@" || exit $?
 
 # Put a redirect makefile here
-if [ ! -f $srcdir/Makefile ]; then
+if [ -z "${NOREDIRECTMAKEFILE:-}" -a ! -f $srcdir/Makefile ]; then
     cat $srcdir/tools/Makefile.redirect > $srcdir/Makefile
     printf "\nREDIRECT = %s\n" "$(realpath $olddir)" >> $srcdir/Makefile
 fi

--- a/test/images/scripts/lib/debian.install
+++ b/test/images/scripts/lib/debian.install
@@ -39,22 +39,27 @@ if [ -n "$do_build" ]; then
     rm -rf build-results
     mkdir build-results
     resultdir=$PWD/build-results
-    ( cd $(dirname "$tar")
-      rm -rf cockpit-wip
-      tar xzf "$tar"
-      mv cockpit-wip/tools/debian cockpit-wip/debian
-      dpkg-source --compression=gzip -b cockpit-wip
 
-      # Some unit tests want a real network interface
-      echo USENETWORK=yes     >>~/.pbuilderrc
+    ln -sf cockpit-wip.tar.gz cockpit_0.orig.tar.gz
 
-      # Pbuilder doesn't seem to give enough rights to its default
-      # build user (anymore) to run the unit tests
-      echo BUILDUSERID=0      >>~/.pbuilderrc
-      echo BUILDUSERNAME=root >>~/.pbuilderrc
-
-      pbuilder --build --buildresult "$resultdir" --logfile "$resultdir/build.log" cockpit_0.dsc >$stdout_dest
+    rm -rf cockpit-wip
+    tar -xzf cockpit-wip.tar.gz
+    ( cd cockpit-wip
+      mv tools/debian .
+      debuild -S -uc -us
     )
+
+    # Some unit tests want a real network interface
+    echo USENETWORK=yes     >>~/.pbuilderrc
+
+    # Pbuilder doesn't seem to give enough rights to its default
+    # build user (anymore) to run the unit tests
+    echo BUILDUSERID=0      >>~/.pbuilderrc
+    echo BUILDUSERNAME=root >>~/.pbuilderrc
+
+    pbuilder build --buildresult "$resultdir" \
+                   --logfile "$resultdir/build.log" \
+                   cockpit_0-1.dsc >$stdout_dest
 fi
 
 # Install

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -156,9 +156,6 @@ The Cockpit Web Service listens on the network, and authenticates users.
 
 %build
 exec 2>&1
-%if %{defined gitcommit}
-env NOCONFIGURE=1 ./autogen.sh
-%endif
 %configure --disable-silent-rules --with-cockpit-user=cockpit-ws --with-branding=auto --with-selinux-config-type=etc_t
 make -j4 %{?extra_flags} all
 

--- a/tools/debian/changelog
+++ b/tools/debian/changelog
@@ -1,4 +1,4 @@
-cockpit (0) UNRELEASED; urgency=medium
+cockpit (0-1) UNRELEASED; urgency=medium
 
   * Work in progress
 

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -3,10 +3,7 @@
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 %:
-	dh $@ --with autoreconf
-
-override_dh_autoreconf:
-	NOCONFIGURE=t dh_autoreconf ./autogen.sh
+	dh $@
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
@@ -17,6 +14,13 @@ override_dh_auto_install:
 	dh_auto_install -- install-test-assets
 	mkdir -p debian/tmp/etc/pam.d
 	install -p -m 644 tools/cockpit.debian.pam debian/tmp/etc/pam.d/cockpit
+
+override_dh_systemd_enable:
+	dh_systemd_enable -p cockpit-ws --name=cockpit cockpit.socket
+
+override_dh_systemd_start:
+	dh_systemd_start -p cockpit-ws cockpit.socket
+	dh_systemd_start -p cockpit-ws --no-start --restart-after-upgrade cockpit.service
 
 override_dh_install:
 	dh_install --list-missing -Xusr/src/debug

--- a/tools/debian/source/format
+++ b/tools/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)

--- a/tools/make-source
+++ b/tools/make-source
@@ -24,28 +24,22 @@ if [ $# != 0 ]; then
 fi
 
 base=$(cd $(dirname $0); pwd -P)
-outdir=$(pwd -P)
-
-# Make a .tar.gz with the source code
 
 cd $base/..
 
-if [ -d .git ]; then
-    git archive HEAD --prefix cockpit-wip/ --output $outdir/cockpit-wip.tar
-    if ! diff -qN package.json node_modules/package.json > /dev/null; then
-        # this needs to be really quiet on stdout, since output is used to install packages
-        npm install --silent 1>&2
-        cp package.json node_modules/package.json
-    fi
-    tar -rf $outdir/cockpit-wip.tar --transform='s|^|cockpit-wip/|S' --exclude='phantomjs*' node_modules
+# Configure the source for making a tarball in a temporary directory, unless
+# the source has already been configured in-tree (a Makefile that is not the
+# redirect Makefile exists).
+if test ! -f Makefile || grep --quiet --no-messages "^REDIRECT" Makefile; then
+  if [ ! -f tmp-dist/Makefile ]; then
+      mkdir -p tmp-dist
+      (cd tmp-dist && NOREDIRECTMAKEFILE=t ../autogen.sh) 1>&2
+  fi
+  builddir=tmp-dist
 else
-    tar -cf $outdir/cockpit-wip.tar --transform='s|^|cockpit-wip/|S' .
+  builddir=.
 fi
 
-# Make sure to include the .tarball in our tarball
-echo "wip" > $outdir/.tarball
-tar -rf $outdir/cockpit-wip.tar --transform='s|^|cockpit-wip/|S' -C $outdir .tarball
-rm $outdir/.tarball
+make -C $builddir --silent dist-gzip distdir=cockpit-wip 1>&2
 
-gzip -f --fast $outdir/cockpit-wip.tar
-echo $outdir/cockpit-wip.tar.gz
+echo $PWD/$builddir/cockpit-wip.tar.gz


### PR DESCRIPTION
These are preferred by debian and allow us to use the released tarball
and not call autogen.sh when building the binary package.