### PR TITLE
kubernetes: Display registry host name better

### DIFF
--- a/pkg/kubernetes/scripts/kube-client-cockpit.js
+++ b/pkg/kubernetes/scripts/kube-client-cockpit.js
@@ -1008,7 +1008,7 @@
                     return promise;
 
                 var settings = {
-                    registry: {},
+                    registry: { host: "registry" },
                     flavor: "kubernetes",
                     isAdmin: false,
                 };
@@ -1016,8 +1016,10 @@
                 var env_p = CockpitEnvironment()
                     .then(function(result) {
                         var value = result["REGISTRY_HOST"];
-                        if (value)
+                        if (value) {
                             settings.registry.host = value;
+                            settings.registry.host.explicit = true;
+                        }
 
                     }, function(ex) {});
 

--- a/pkg/kubernetes/styles/images.less
+++ b/pkg/kubernetes/styles/images.less
@@ -109,7 +109,7 @@ pre {
     border: none;
     font-family: Monospace, Menlo, Consolas;
 
-    em {
+    em, span.placeholder {
         font-weight: bold;
         font-style: normal;
     }
@@ -120,3 +120,4 @@ pre {
     color: @metadata-color;
     padding: 0px 5px;
 }
+

--- a/pkg/kubernetes/views/image-body.html
+++ b/pkg/kubernetes/views/image-body.html
@@ -30,4 +30,4 @@
     <i class="fa fa-info-circle"></i>
     <span translatable="yes">To pull this image:</span>
 </p>
-<pre>$ sudo docker pull {{stream.status.dockerImageRepository}}:{{tag.tag}}</pre>
+<pre>$ sudo docker pull <span ng-class="{ placeholder: !settings.registry.host.explicit }">{{settings.registry.host}}</span>/{{names[0]}}</pre>

--- a/pkg/kubernetes/views/imagestream-body.html
+++ b/pkg/kubernetes/views/imagestream-body.html
@@ -9,5 +9,5 @@
     <i class="fa fa-info-circle"></i>
     <span translatable="yes">To push to an image to this image stream:</span>
 </p>
-<pre>$ sudo docker tag <em>myimage</em> {{stream.status.dockerImageRepository}}:<em>tag</em>
-$ sudo docker push {{stream.status.dockerImageRepository}}</pre>
+<pre>$ sudo docker tag <em>myimage</em> <span ng-class="{ placeholder: !settings.registry.host.explicit }">{{settings.registry.host}}</span>/{{ stream.metadata.namespace }}/{{ stream.metadata.name}}:<em>tag</em>
+$ sudo docker push <span ng-class="{ placeholder: !settings.registry.host.explicit }">{{settings.registry.host}}</span>/{{ stream.metadata.namespace }}/{{ stream.metadata.name}}</pre>

--- a/pkg/kubernetes/views/registry-dashboard-page.html
+++ b/pkg/kubernetes/views/registry-dashboard-page.html
@@ -100,16 +100,12 @@
                 <span class="pficon pficon-warning-triangle-o"></span>
                 <span translatable="yes">Your login credentials do not give you access to use the docker registry from the command line.</span>
             </div>
-            <pre ng-if="settings.registry.password && settings.registry.host">$ sudo docker login -p {{settings.registry.password}} -e unused -u unused {{settings.registry.host}}</pre>
-            <pre ng-if="settings.registry.password && !settings.registry.host">$ sudo docker login -p {{settings.registry.password}} -e unused -u unused <em>registry</em></pre>
+<pre ng-if="settings.registry.password">$ sudo docker login -p {{settings.registry.password}} -e unused -u unused <span ng-class="{ placeholder: !settings.registry.host.explicit }">{{settings.registry.host}}</span></pre>
             <p translatable="yes">Push an image:</p>
-<pre ng-if="settings.registry.host">$ sudo docker tag <em>myimage</em> {{settings.registry.host}}/<em>project</em>/<em>name:tag</em>
-$ sudo docker push {{settings.registry.host}}/<em>project</em>/<em>name</em></pre>
-<pre ng-if="!settings.registry.host">$ sudo docker tag <em>myimage</em> <em>registry</em>/<em>project</em>/<em>name:tag</em>
-$ sudo docker push <em>registry</em>/<em>project</em>/<em>name</em></pre>
+<pre>$ sudo docker tag <em>myimage</em> <span ng-class="{ placeholder: !settings.registry.host.explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name:tag</em>
+$ sudo docker push <span ng-class="{ placeholder: !settings.registry.host.explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name</em></pre>
             <p translatable="yes">Pull an image:</p>
-<pre ng-if="settings.registry.host">$ sudo docker pull {{settings.registry.host}}/<em>project</em>/<em>name:tag</em></pre>
-<pre ng-if="!settings.registry.host">$ sudo docker pull <em>registry</em>/<em>project</em>/<em>name:tag</em></pre>
+<pre ng-if="settings.registry.host">$ sudo docker pull <span ng-class="{ placeholder: !settings.registry.host.explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name:tag</em></pre>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Display correct registry host name on the image and imagestream
pages, and make the display on the dashboard more consistent.

Fixes #4166