### PR TITLE
base1: Fix number input padding

### DIFF
--- a/pkg/base1/cockpit.css
+++ b/pkg/base1/cockpit.css
@@ -1005,3 +1005,8 @@ div.timeline.timeline-end .timeline-md {
     left: 0;
     right: 0;
 }
+
+/* Fix number input padding to move spinners to the right */
+input[type=number] {
+  padding: 0 0 0 5px;
+}


### PR DESCRIPTION
Fixes spinners on input appearing too far left; moves them to the edge of the input box.

Mentioned in https://github.com/cockpit-project/cockpit/pull/4172#issuecomment-208800122

There's an upstream bug filed on PatternFly for this: https://github.com/patternfly/patternfly/issues/255
