### PR TITLE
base: Only override alert styling for alerts in dialogs

### DIFF
--- a/pkg/base1/cockpit.css
+++ b/pkg/base1/cockpit.css
@@ -352,20 +352,20 @@ a {
 
 /* Alert fixups */
 
-.alert {
+.modal-content .alert {
     text-align: left;
     padding-top: 5px;
     padding-bottom: 5px;
 }
 
-.alert .fa {
+.modal-content .alert .fa {
     position: absolute;
     left: 10px;
     top: 6px;
     font-size: 20px;
 }
 
-.alert .pficon {
+.modal-content .alert .pficon {
     top: 5px;
 }
 


### PR DESCRIPTION
We had some overrides that made the alerts a bit shorter.
This was primarily for dialogs, so make them apply to those only.