### PR TITLE
Image refresh for fedora-atomic

### DIFF
--- a/test/images/fedora-atomic
+++ b/test/images/fedora-atomic
@@ -1,1 +1,1 @@
-fedora-atomic-67babbe5ab57df0afb6bda1d1622926b305b298a.qcow2
+fedora-atomic-bc2be0c5cf644ba9da9cef6c5b2ab32d7ddc6f67.qcow2


### PR DESCRIPTION
Image creation for fedora-atomic in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-atomic-2016-04-12/