### PR TITLE
Makefile.am: Be quieter during 'make dist'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -256,8 +256,8 @@ COMMITTED_DIST = \
 # Build up the distribution using $COMMITTED_DIST and include node_modules and bower licenses
 dist-hook: dist-doc-hook
 	( git -C $(srcdir) ls-tree HEAD --name-only -r $(COMMITTED_DIST) || echo $(COMMITTED_DIST) ) | \
-		tar -C $(srcdir) -cf - -T - | tar -C $(distdir) -xvf -
-	tar -C $(srcdir) -cf - --exclude='phantomjs*' --exclude='jshint*' node_modules/ | tar -C $(distdir) -xvf -
+		tar -C $(srcdir) -cf - -T - | tar -C $(distdir) -xf -
+	tar -C $(srcdir) -cf - --exclude='phantomjs*' --exclude='jshint*' node_modules/ | tar -C $(distdir) -xf -
 	echo $(VERSION) > $(distdir)/.tarball
 	$(srcdir)/tools/build-copying $(distdir)/node_modules > $(distdir)/COPYING.node
 	$(srcdir)/tools/build-copying $(BOWER) > $(distdir)/COPYING.bower


### PR DESCRIPTION
In order to use 'make dist' in tools/make-source (See #4178)
the 'make --silent dist' target should run quietly.