### PR TITLE
test: Fix race checking for container in check-docker

### DIFF
--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -340,6 +340,7 @@ CMD ["/listen-on-port.sh", "%(port)d", "%(message)s"]
         b.wait_in_text("#containers-images", "busybox:latest")
         b.wait_present("#containers-containers tr:contains(\"YAYRESTART\")")
         b.wait_visible("#containers-containers tr:contains(\"YAYRESTART\")")
+        b.wait_present("#containers-containers tr:contains(\"NORESTART\")")
         b.wait_not_visible("#containers-containers tr:contains(\"NORESTART\")")
 
 


### PR DESCRIPTION
Wait for the NORESTART container info te be loaded before verifying
that it's not visible.