### PR TITLE
selinux: Remove unneeded content-security-policy directive

### DIFF
--- a/pkg/selinux/manifest.json
+++ b/pkg/selinux/manifest.json
@@ -6,6 +6,5 @@
             "label": "SELinux Troubleshoot",
             "order": 8
         }
-    },
-    "content-security-policy": "default-src 'self'"
+    }
 }


### PR DESCRIPTION
We should just use the default here. The default is strict