### PR TITLE
Correctly match selectors for RCs (Kube-Topology)

### DIFF
--- a/pkg/kubernetes/scripts/kube-client.js
+++ b/pkg/kubernetes/scripts/kube-client.js
@@ -874,22 +874,16 @@
                     if (object) {
                         keyo = filter.digests.call(null, object);
                         keyo.sort();
-                        match = false;
+                        matches = 0;
 
-                        /* Search for first key */
-                        for (j = 0, jl = keyo.length; !match && j < jl; j++) {
-                            if (keys[0] === keyo[j]) {
-                                match = true;
-                                for (k = 0; match && k < keyn; k++) {
-                                    if (keys[k] !== keyo[j + k])
-                                        match = false;
-                                }
-                            }
-                        }
+                        for (k = 0; k < keyn; k++)
+                            for (j = 0; j < keyo.length; j++)
+                                if (keys[k] === keyo[j])
+                                    matches++;
 
-                        if (match) {
+                        if (matches == keys.length) {
                             results[link] = object;
-                            count += 1;
+                            count += matches;
                         }
                     }
                 }

--- a/pkg/kubernetes/scripts/kube-client.js
+++ b/pkg/kubernetes/scripts/kube-client.js
@@ -855,7 +855,7 @@
             }
 
             function digestsFilter(filter, what, criteria) {
-                var keys, keyn, keyo, k, link, match, object, possible;
+                var keys, keyn, keyo, k, link, matches, object, possible;
                 var p, pl, j, jl;
                 var results = { }, count = 0;
 


### PR DESCRIPTION
Resolves an issue stopping RCs from correctly gaining their relationship with Pods.

When a RC has multiple selectors and its Pods have matching selectors (plus additional labels) and the final required matching label is last on the Pod, the relationship does not get created. This leaves stray RCs in these circumstances.

![Before](http://dev.prbrds.com/m/NsFDxiGZnH.png)
![After](http://dev.prbrds.com/m/6FNgsy5YCI.png)
