### PR TITLE
kubernetes: Make sure topology actions don't dissappear of the screen

### DIFF
--- a/pkg/kubernetes/styles/topology.less
+++ b/pkg/kubernetes/styles/topology.less
@@ -50,7 +50,7 @@ kubernetes-topology-icon {
 
 .topology-actions {
     float: right;
-    margin-right: 10px;
+    margin-right: 20px;
 }
 
 .kube-topology g.ReplicationController text {


### PR DESCRIPTION
Give the topology actions in the sidebar some margin in order for them
to not render partly outside the screen.

Fixes #4241