### PR TITLE
kubernetes: fix up list header spacing

### DIFF
--- a/pkg/kubernetes/styles/projects.less
+++ b/pkg/kubernetes/styles/projects.less
@@ -22,10 +22,6 @@ table.project-body {
     }
 }
 
-table.listing > thead td {
-    padding-top: 0px;
-}
-
 .listing-head .pficon-project {
     margin-bottom: 10px;
 }


### PR DESCRIPTION
Make sure headers are futher away from the list above than from the
objects below that belongs to them.

Fixes #4227