### PR TITLE
test: Add known storaged issues for fedora-23 and fedora-testing

### DIFF
--- a/test/verify/naughty-fedora-23/4107-no-maximum-pools
+++ b/test/verify/naughty-fedora-23/4107-no-maximum-pools
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-storage-lvm2", line 168, in testLvm
+    "name": "pool" })

--- a/test/verify/naughty-fedora-testing/4107-no-maximum-pools
+++ b/test/verify/naughty-fedora-testing/4107-no-maximum-pools
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-storage-lvm2", line 168, in testLvm
+    "name": "pool" })


### PR DESCRIPTION
The issue is fixed with storaged-2.5.0, which is only in fedora-24.