### PR TITLE
kubernetes: Fix registry host display

### DIFF
--- a/pkg/kubernetes/scripts/kube-client-cockpit.js
+++ b/pkg/kubernetes/scripts/kube-client-cockpit.js
@@ -1046,7 +1046,10 @@
                     return promise;
 
                 var settings = {
-                    registry: {},
+                    registry: {
+                        host: "registry",
+                        host_explicit: false
+                    },
                     flavor: "kubernetes",
                     isAdmin: false,
                     canChangeConnection: false,
@@ -1055,8 +1058,10 @@
                 var env_p = CockpitEnvironment()
                     .then(function(result) {
                         var value = result["REGISTRY_HOST"];
-                        if (value)
+                        if (value) {
                             settings.registry.host = value;
+                            settings.registry.host_explicit = true;
+                        }
 
                     }, function(ex) {});
 

--- a/pkg/kubernetes/views/image-body.html
+++ b/pkg/kubernetes/views/image-body.html
@@ -30,4 +30,4 @@
     <i class="fa fa-info-circle"></i>
     <span translatable="yes">To pull this image:</span>
 </p>
-<pre>$ sudo docker pull <span ng-class="{ placeholder: !settings.registry.host.explicit }">{{settings.registry.host}}</span>/{{names[0]}}</pre>
+<pre>$ sudo docker pull <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/{{names[0]}}</pre>

--- a/pkg/kubernetes/views/imagestream-body.html
+++ b/pkg/kubernetes/views/imagestream-body.html
@@ -9,5 +9,5 @@
     <i class="fa fa-info-circle"></i>
     <span translatable="yes">To push to an image to this image stream:</span>
 </p>
-<pre>$ sudo docker tag <em>myimage</em> <span ng-class="{ placeholder: !settings.registry.host.explicit }">{{settings.registry.host}}</span>/{{ stream.metadata.namespace }}/{{ stream.metadata.name}}:<em>tag</em>
-$ sudo docker push <span ng-class="{ placeholder: !settings.registry.host.explicit }">{{settings.registry.host}}</span>/{{ stream.metadata.namespace }}/{{ stream.metadata.name}}</pre>
+<pre>$ sudo docker tag <em>myimage</em> <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/{{ stream.metadata.namespace }}/{{ stream.metadata.name}}:<em>tag</em>
+$ sudo docker push <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/{{ stream.metadata.namespace }}/{{ stream.metadata.name}}</pre>

--- a/pkg/kubernetes/views/registry-dashboard-page.html
+++ b/pkg/kubernetes/views/registry-dashboard-page.html
@@ -100,12 +100,12 @@
                 <span class="pficon pficon-warning-triangle-o"></span>
                 <span translatable="yes">Your login credentials do not give you access to use the docker registry from the command line.</span>
             </div>
-<pre ng-if="settings.registry.password">$ sudo docker login -p {{settings.registry.password}} -e unused -u unused <span ng-class="{ placeholder: !settings.registry.host.explicit }">{{settings.registry.host}}</span></pre>
+<pre ng-if="settings.registry.password">$ sudo docker login -p {{settings.registry.password}} -e unused -u unused <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span></pre>
             <p translatable="yes">Push an image:</p>
-<pre>$ sudo docker tag <em>myimage</em> <span ng-class="{ placeholder: !settings.registry.host.explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name:tag</em>
-$ sudo docker push <span ng-class="{ placeholder: !settings.registry.host.explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name</em></pre>
+<pre>$ sudo docker tag <em>myimage</em> <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name:tag</em>
+$ sudo docker push <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name</em></pre>
             <p translatable="yes">Pull an image:</p>
-<pre ng-if="settings.registry.host">$ sudo docker pull <span ng-class="{ placeholder: !settings.registry.host.explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name:tag</em></pre>
+<pre ng-if="settings.registry.host">$ sudo docker pull <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name:tag</em></pre>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Restores code that was lost in a conflict between #4207 and #4190 but makes the explicit flag a separate value to prevent chrome errors like.

```Cannot create property on string```