### PR TITLE
Playground: add react terminal widget

### DIFF
--- a/pkg/base1/Makefile.am
+++ b/pkg/base1/Makefile.am
@@ -17,6 +17,7 @@ nodist_base_DATA = \
 	pkg/base1/cockpit.min.js.gz \
 	pkg/base1/bundle.min.js.gz \
 	pkg/base1/react.min.js.gz \
+	pkg/base1/cockpit-components.min.js.gz \
 	$(base_GEN:.js=.min.js.gz) \
 	$(NULL)
 base_DATA = \
@@ -44,6 +45,7 @@ basedebug_DATA = \
 	pkg/base1/mustache.js \
 	pkg/base1/jquery.js \
 	pkg/base1/cockpit.js \
+	pkg/base1/cockpit-components.js \
 	$(base_GEN) \
 	$(NULL)
 
@@ -73,6 +75,14 @@ pkg/base1/term.min.js: pkg/base1/term.js
 	$(MIN_JS_RULE)
 pkg/base1/react.min.js: pkg/base1/react.js
 	$(MIN_JS_RULE)
+pkg/base1/cockpit-components.min.js: pkg/base1/cockpit-components.js
+	$(MIN_JS_RULE)
+
+REACT_COMPONENTS = \
+	pkg/base1/cockpit-components-terminal.js
+
+pkg/base1/cockpit-components.js: $(REACT_COMPONENTS)
+	$(JSMODULE) -o pkg/base1/cockpit-components.js $(REACT_COMPONENTS)
 
 install-data-local::
 	$(MKDIR_P) $(DESTDIR)$(basedebugdir)
@@ -132,6 +142,10 @@ CLEANFILES += \
 	pkg/base1/react.min.js \
 	pkg/base1/require.min.js \
 	pkg/base1/term.min.js \
+	pkg/base1/cockpit-components.js \
+	pkg/base1/cockpit-components.min.js \
+	pkg/base1/cockpit-components-terminal.js \
+	$(REACT_COMPONENTS) \
 	$(base_GEN) \
 	$(base_GEN:.js=.min.js) \
 	$(nodist_base_DATA) \
@@ -150,7 +164,10 @@ EXTRA_DIST += \
 	pkg/base1/moment.min.js \
 	pkg/base1/react.min.js \
 	pkg/base1/term.min.js \
+	pkg/base1/cockpit-components.js \
+	pkg/base1/cockpit-components.min.js \
 	pkg/base1/test-dbus-common.js \
+	$(REACT_COMPONENTS) \
 	$(base_BUNDLE) \
 	$(base_GEN) \
 	$(base_GEN:.js=.min.js) \

--- a/pkg/base1/cockpit-components-terminal.jsx
+++ b/pkg/base1/cockpit-components-terminal.jsx
@@ -1,0 +1,130 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+define([
+    "react",
+    "base1/term",
+], function(React, Term) {
+
+"use strict";
+
+/*
+ * A terminal component that communicates over a cockpit channel.
+ *
+ * The only required property is 'channel', which must point to a cockpit
+ * stream channel.
+ *
+ * The size of the terminal defaults to 80 by 25. It can be changed with the
+ * 'rows' and 'cols' properties.
+ *
+ * If the 'onTitleChanged' callback property is set, it will be called whenever
+ * the title of the terminal changes.
+ */
+var Terminal = React.createClass({
+    propTypes: {
+        cols: React.PropTypes.number,
+        rows: React.PropTypes.number,
+        channel: React.PropTypes.object.isRequired,
+        onTitleChanged: React.PropTypes.func
+    },
+
+    getDefaultProps: function () {
+        return {
+            cols: 80,
+            rows: 25
+        };
+    },
+
+    componentWillMount: function () {
+        var term = new Term({
+            cols: this.props.cols,
+            rows: this.props.rows,
+            screenKeys: true
+        });
+
+        term.on('data', function(data) {
+            if (this.props.channel.valid)
+                this.props.channel.send(data);
+        }.bind(this));
+
+        if (this.props.onTitleChanged)
+            term.on('title', this.props.onTitleChanged);
+
+        this.setState({ terminal: term });
+    },
+
+    componentDidMount: function () {
+        this.state.terminal.open(this.refs.terminal);
+        this.connectChannel();
+    },
+
+    componentWillUpdate: function (nextProps) {
+        if (nextProps.cols !== this.props.cols || nextProps.rows !== this.props.rows)
+            this.state.terminal.resize(nextProps.cols, nextProps.rows);
+
+        if (nextProps.channel !== this.props.channel) {
+            this.state.terminal.reset();
+            this.disconnectChannel();
+        }
+    },
+
+    componentDidUpdate: function (prevProps) {
+        if (prevProps.channel !== this.props.channel)
+            this.connectChannel();
+    },
+
+    render: function () {
+        // ensure react never reuses this div by keying it with the terminal widget
+        return <div ref="terminal" key={this.state.terminal} />;
+    },
+
+    componentWillUnmount: function () {
+        this.disconnectChannel();
+        this.state.terminal.destroy();
+    },
+
+    onChannelMessage: function (event, data) {
+        this.state.terminal.write(data);
+    },
+
+    onChannelClose: function (event, options) {
+        var term = this.state.terminal;
+        term.write('\x1b[31m' + (options.problem || 'disconnected') + '\x1b[m\r\n');
+        term.cursorHidden = true;
+        term.refresh(term.y, term.y);
+    },
+
+    connectChannel: function () {
+        var channel = this.props.channel;
+        if (channel && channel.valid) {
+            channel.addEventListener('message', this.onChannelMessage.bind(this));
+            channel.addEventListener('close', this.onChannelClose.bind(this));
+        }
+    },
+
+    disconnectChannel: function () {
+        if (this.props.channel) {
+            this.props.channel.removeEventListener('message', this.onChannelMessage);
+            this.props.channel.removeEventListener('close', this.onChannelClose);
+        }
+    }
+});
+
+return { Terminal: Terminal };
+});

--- a/pkg/playground/react-patterns.html
+++ b/pkg/playground/react-patterns.html
@@ -15,7 +15,11 @@
     <button id="demo-show-dialog" class="btn btn-default" translatable="yes">Show Dialog</button>
     <button id="demo-show-error-dialog" class="btn btn-default" translatable="yes">Show Error-Dialog</button>
     <div id="demo-dialog-result"></div>
+
     <hr>
+
+    <h3>Terminal</h3>
+    <div id="demo-react-terminal"></div>
 </div>
 
 </body>

--- a/pkg/playground/react-patterns.js
+++ b/pkg/playground/react-patterns.js
@@ -22,7 +22,8 @@ require([
     "react",
     "performance/dialog-view",
     "playground/react-demo-dialog",
-], function(cockpit, React, dialog_pattern, demo_dialog) {
+    "base1/cockpit-components",
+], function(cockpit, React, dialog_pattern, demo_dialog, components) {
 
 "use strict";
 
@@ -94,5 +95,23 @@ var on_standard_demo_clicked = function(static_error) {
 
 document.getElementById('demo-show-dialog').addEventListener("click", on_standard_demo_clicked.bind(null, null), false);
 document.getElementById('demo-show-error-dialog').addEventListener("click", on_standard_demo_clicked.bind(null, 'Some static error'), false);
+
+
+cockpit.user.addEventListener('changed', function (user) {
+    var channel = cockpit.channel({
+        "payload": "stream",
+        "spawn": [cockpit.user.shell || '/bin/bash', "-i"],
+        "environ": [
+            "TERM=xterm-256color",
+            "PATH=/sbin:/bin:/usr/sbin:/usr/bin"
+        ],
+        "directory": cockpit.user.home || '/',
+        "pty": true
+    });
+
+    React.render(React.createElement(components.Terminal, {
+        channel: channel,
+    }), document.getElementById('demo-react-terminal'));
+});
 
 });


### PR DESCRIPTION
Wrap term.js in a react component. It operates on a cockpit channel, so it should be usable for both docker and the "Terminal" tab.

This is on top of @dperpeet's pull request which adds a react playground page (#4266). I'm puting this up for people to look at, but please don't merge it yet.