### PR TITLE
base1: Add cockpit.reject() utility function

### DIFF
--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -1280,6 +1280,10 @@ function basic_scope(cockpit, jquery) {
         return deferred.promise;
     };
 
+    cockpit.reject = function reject(ex) {
+        return cockpit.defer().reject(ex).promise;
+    };
+
     cockpit.defer = function() {
         return new Deferred();
     };


### PR DESCRIPTION
This creates a new defered, rejects it, and returns its promise.
Used from within .then() callbacks. A solid alternative to
accepting thrown exceptions as rejections.