### PR TITLE
kubernetes: When listing images show no duplicate

### DIFF
--- a/pkg/kubernetes/scripts/images.js
+++ b/pkg/kubernetes/scripts/images.js
@@ -493,7 +493,10 @@
                     return select().kind("ImageStream").listTagNames(image.metadata.name);
                 },
                 imageLabels: function imageLabels(image) {
-                    return select(image).dockerImageConfig().dockerConfigLabels().one();
+                    var labels = select(image).dockerImageConfig().dockerConfigLabels().one();
+                    if (labels && angular.equals({ }, labels))
+                        labels = null;
+                    return labels;
                 },
                 configCommand: configCommand,
             };

--- a/pkg/kubernetes/scripts/images.js
+++ b/pkg/kubernetes/scripts/images.js
@@ -146,7 +146,7 @@
 
 
                 if ($scope.tag)
-                    $scope.image = select().kind("Image").taggedBy($scope.tag).one();
+                    $scope.image = select().kind("Image").taggedFirst($scope.tag).one();
                 if ($scope.image) {
                     $scope.names = data.imageTagNames($scope.image);
                     $scope.config = data.imageConfig($scope.image);
@@ -351,13 +351,24 @@
             loader.listen(handle_imagestreams);
 
             /*
-             * Filters selection to those with names that are
+             * Filters selection to those with names that is
              * in the given TagEvent.
              */
             select.register("taggedBy", function(tag) {
                 var i, len, results = { };
                 for (i = 0, len = tag.items.length; i < len; i++)
                     this.name(tag.items[i].image).extend(results);
+                return select(results);
+            });
+
+            /*
+             * Filters selection to those with names that is in the first
+             * item in the given TagEvent.
+             */
+            select.register("taggedFirst", function(tag) {
+                var len, results = { };
+                if (tag.items.length)
+                    this.name(tag.items[0].image).extend(results);
                 return select(results);
             });
 
@@ -482,8 +493,8 @@
                 allStreams: function allStreams() {
                     return select().kind("ImageStream");
                 },
-                imagesByTag: function imagesByTag(tag) {
-                    return select().kind("Image").taggedBy(tag);
+                imageByTag: function imageByTag(tag) {
+                    return select().kind("Image").taggedFirst(tag);
                 },
                 imageLayers: imageLayers,
                 imageConfig: function imageConfig(image) {

--- a/pkg/kubernetes/tests/test-images.html
+++ b/pkg/kubernetes/tests/test-images.html
@@ -112,6 +112,31 @@ function suite(fixtures) {
         }
     ]);
 
+    imagesTest("filter taggedFirst", 4, fixtures, [
+        "kubeSelect",
+        "imageData",
+        function(select, data) {
+            var tag = { "tag": "2.5", "items": [
+                { "image": "sha256:beadfbc3da8d183c245ab5bad4dd185dacde72dbe81b270926e60e705e534afb" },
+                { "image": "sha256:0885eeaec4514820b2c879100425e9ea10beaf4412db7f67acfe53b4df2b9450" }
+            ]};
+
+            var images = select().kind("Image").taggedFirst(tag);
+            equal(images.length, 1, "number of images");
+            ok("/oapi/v1/images/sha256:beadfbc3da8d183c245ab5bad4dd185dacde72dbe81b270926e60e705e534afb" in images, "matched busybee");
+            ok(!("/oapi/v1/images/sha256:0885eeaec4514820b2c879100425e9ea10beaf4412db7f67acfe53b4df2b9450" in images), "didn't match juggs");
+
+            var tag = { "tag": "2.5", "items": [
+                { "image": "sha256:00329beccad118aa937e839d536d753ee612b67f8feb6adb519e7f5aa6e75fbe" },
+                { "image": "sha256:0085eeaec4514820b2c879100425e9ea10beaf4412db7f67acfe53b4df2b9450" }
+            ]};
+
+            var images = select().kind("Image").taggedFirst(tag);
+            equal(images.length, 0, "no images matched");
+        }
+    ]);
+
+
     imagesTest("filter listTagNames", 3, fixtures, [
         "kubeSelect",
         "imageData",

--- a/pkg/kubernetes/views/image-listing.html
+++ b/pkg/kubernetes/views/image-listing.html
@@ -34,7 +34,7 @@
            ng-init="iid = sid + ':' + tag.tag" data-id="{{ iid }}"
            ng-class="{open: listing.expanded(iid), last: $last, first: $first}">
         <tr ng-click="listing.activate(iid)" class="listing-item tag-item"
-            ng-repeat-start="image in imagesByTag(tag) track by image.metadata.name">
+            ng-repeat-start="image in imageByTag(tag)">
             <td ng-click="listing.toggle(iid, $event)"
                 class="listing-toggle">
                 <i class="fa fa-fw"></i>
@@ -46,7 +46,7 @@
                 </div>
                 <div class="row">
                     <div class="col col-xs-6 text-left" ng-if="conf.author">{{ conf.author }}</div>
-                    <div class="col col-xs-6 text-left" ng-if="!conf.author">sdfasdfas {{ image.dockerImageMetadata.Author }}</div>
+                    <div class="col col-xs-6 text-left" ng-if="!conf.author">{{ image.dockerImageMetadata.Author }}</div>
                     <div class="col col-xs-6" title="{{ tag.items[0].created }}">{{ tag.items[0].created | dateRelative }}</div>
                 </div>
             </td>


### PR DESCRIPTION
The Openshift API has multiple images listed in each tag of
an ImageStream and keeps old ones as they get replaced. Only
show the top one for now.

In the future there may be some work to show a history of the
tag. But for now this reflects what people expect.