### PR TITLE
kubernetes: Use simpler registry sidebar

### DIFF
--- a/pkg/kubernetes/Makefile.am
+++ b/pkg/kubernetes/Makefile.am
@@ -75,7 +75,6 @@ registry_LESS = \
 	pkg/kubernetes/styles/registry.less \
 	pkg/kubernetes/styles/dropdown.less \
 	pkg/kubernetes/styles/filter.less \
-	pkg/kubernetes/styles/sidebar.less \
 	$(NULL)
 
 registry_MIN = \
@@ -186,6 +185,7 @@ kubernetes_LESS = \
 	pkg/kubernetes/styles/container-terminal.less \
 	pkg/kubernetes/styles/details.less \
 	pkg/kubernetes/styles/revealable.less \
+	pkg/kubernetes/styles/sidebar.less \
 	pkg/kubernetes/styles/topology.less \
 	pkg/kubernetes/styles/topology-graph.less \
 	pkg/kubernetes/styles/volumes.less \

--- a/pkg/kubernetes/index.html
+++ b/pkg/kubernetes/index.html
@@ -64,7 +64,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 </head>
 <body ng-app='kubernetes' ng-controller="MainCtrl" ng-class="{'cards-pf': viewActive(null)}" hidden>
     <div ng-cloak ng-if="!curtains">
-        <div class="nav-pf-vertical icon-sidebar">
+        <div class="nav-pf-vertical nav-sidebar">
             <ul class="list-group">
                 <li class="list-group-item" ng-class="{ active: viewActive(null)}">
                     <a ng-href="#{{ viewUrl(null) }}">

--- a/pkg/kubernetes/registry.html
+++ b/pkg/kubernetes/registry.html
@@ -56,23 +56,23 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 <body ng-app='registry' ng-controller="MainCtrl" ng-class="{'cards-pf': viewActive(null)}" hidden>
     <div ng-cloak ng-if="!curtains">
-        <div class="nav-pf-vertical icon-sidebar">
-            <ul class="list-group">
-                <li class="list-group-item" ng-class="{ active: viewActive(null)}">
+        <div class="icon-sidebar">
+            <ul>
+                <li ng-class="{ active: viewActive(null)}">
                     <a ng-href="#{{ viewUrl(null) }}">
-                        <i class="fa fa-dashboard fa-fw" title="Overview"></i>
+                        <i class="fa fa-dashboard fa-fw" title="Overview"></i><br>
                         <span class="list-group-item-value" translatable="yes">Overview</span>
                     </a>
                 </li>
-                <li class="list-group-item" ng-class="{ active: viewActive('images')}">
+                <li ng-class="{ active: viewActive('images')}">
                     <a ng-href="#{{ viewUrl('images') }}">
-                        <i class="pficon pficon-image fa-fw" title="Images"></i>
+                        <i class="pficon pficon-image fa-fw" title="Images"></i><br>
                         <span class="list-group-item-value" translatable="yes">Images</span>
                     </a>
                 </li>
-                <li class="list-group-item" ng-class="{ active: viewActive('projects')}">
+                <li ng-class="{ active: viewActive('projects')}">
                     <a ng-href="#{{ viewUrl('projects') }}">
-                        <i class="pficon pficon-project fa-fw" title="Projects"></i>
+                        <i class="pficon pficon-project fa-fw" title="Projects"></i><br>
                         <span class="list-group-item-value" translatable="yes">Projects</span>
                     </a>
                 </li>

--- a/pkg/kubernetes/styles/registry.less
+++ b/pkg/kubernetes/styles/registry.less
@@ -1,9 +1,7 @@
 @import "variables.less";
 
-/* Depends on number of items in the sidebar */
-@sidebar-height-lg: 250px;
+@icon-sidebar-width: 100px;
 
-@import "sidebar.less";
 @import "filter.less";
 @import "dropdown.less";
 @import "dashboard.less";
@@ -130,3 +128,87 @@
     border: none;
 }
 
+#content {
+    margin-left: unit(@icon-sidebar-width, px);
+}
+
+.content-filter {
+    left: unit(@icon-sidebar-width - 10, px);
+}
+
+/* A different sidebar */
+.icon-sidebar {
+    width: unit(@icon-sidebar-width, px);
+
+    ul {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        width: unit(@icon-sidebar-width - 10, px);
+        height: 100%;
+        position: fixed;
+        background-color: @nav-pf-vertical-bg-color;
+        top: 0px;
+        z-index: 1;
+
+        li {
+            border-bottom: 1px solid @nav-pf-vertical-item-border-color;
+            display: block;
+            font-size: 13px;
+
+            a {
+                border-bottom: 0;
+                color: @nav-pf-vertical-color;
+                background-color: @nav-pf-vertical-bg-color;
+                padding: 15px 11px 15px 9px;
+                text-align: center;
+                display: block;
+                text-decoration: none;
+                position: relative;
+
+                i {
+                    display: inline;
+                    font-size: 20px;
+                    line-height: 20px;
+                    color: @nav-pf-vertical-icon-color;
+                }
+
+                i.pficon-image {
+                    font-size: 24px;
+                    line-height: 20px;
+                }
+            }
+
+            a:hover {
+                color: @nav-pf-vertical-active-color;
+                background-color: @nav-pf-vertical-active-bg-color;
+
+                i {
+                    color: @nav-pf-vertical-active-icon-color;
+                }
+            }
+        }
+
+        li.active {
+            a  {
+                color: @nav-pf-vertical-active-color;
+                background-color: @nav-pf-vertical-active-bg-color;
+
+		i {
+			color: @link-color;
+		}
+            }
+
+            a:after {
+                content: '';
+                width: 4px;
+                height: 100%;
+                left: 0;
+                top: 0;
+                display: block;
+                position: absolute;
+                background-color: @link-color;
+            }
+        }
+    }
+}

--- a/pkg/kubernetes/styles/sidebar.less
+++ b/pkg/kubernetes/styles/sidebar.less
@@ -1,7 +1,7 @@
 /*
  * Full large size sidebar.
  */
-.icon-sidebar {
+.nav-sidebar {
     width: unit(@sidebar-width-xl, px);
     height: 100%;
     position: fixed;
@@ -30,7 +30,7 @@
  * Very small. Only icons
  */
 @media (max-width: @screen-sm-min) {
-    .icon-sidebar {
+    .nav-sidebar {
         width: unit(@sidebar-width-sm, px);
         .list-group-item-value {
             display: none !important;
@@ -55,7 +55,7 @@
  * Short window. Text next to icons.
  */
 @media (min-width: @screen-sm-min) and (max-width: @screen-lg-min), (min-width: @screen-sm-min) and (max-height: @sidebar-height-lg) {
-    .icon-sidebar {
+    .nav-sidebar {
         width: unit(@sidebar-width-md, px);
         a {
             padding: 8px !important;


### PR DESCRIPTION
Use a sidebar for the standalone registry that's simpler than
the one we show for kubernetes. Use colors from Patternfly's
vertical navigation, but use the layout from the old sidebar.