### PR TITLE
Expanded listing rows shouldn't be navigatable

### DIFF
--- a/pkg/kubernetes/scripts/listing.js
+++ b/pkg/kubernetes/scripts/listing.js
@@ -88,10 +88,13 @@
                         ev.stopPropagation();
                 };
 
-                self.activate = function expand(id, ev) {
-                    var emitted;
-                    if (checkBrowserEvent(ev))
-                        emitted = scope.$emit("activate", id);
+                self.activate = function activate(id, ev) {
+                    if (checkBrowserEvent(ev)) {
+                        if (self.expanded(id))
+                            self.collapse(id);
+                        else
+                            scope.$emit("activate", id);
+                    }
                 };
 
                 self.collapse = function collapse(id, ev) {

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -375,14 +375,14 @@ class KubernetesCommonTests(VolumeTests):
         self.assertTrue(b.is_present(".details-listing tbody:not(.open) tr.listing-ct-item"))
 
         # Click into service
-        b.click(".details-listing tbody[data-id='services/default/mock'] tr.listing-ct-item")
+        b.click(".details-listing tbody[data-id='services/mynamespace1/mock'] tr.listing-ct-item")
         b.wait_in_text(".listing-ct-inline", "Service")
         b.wait_in_text(".listing-ct-inline", "Endpoints")
         b.wait_present(".content-filter h3")
         b.wait_text(".content-filter h3", "mock")
         b.click("a.hidden-xs")
         b.wait_present("#content .details-listing")
-        b.wait_present(".details-listing tbody[data-id='services/default/mock']")
+        b.wait_present(".details-listing tbody[data-id='services/mynamespace1/mock']")
         b.wait_not_present("#pods")
         b.wait_not_present("#replication-controllers")
 


### PR DESCRIPTION
Clicking on an expanded row in a listing view shouldn't make it
navigate to the detailed target.