### PR TITLE
travis: don't install recommended packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
   - sudo apt-get update -qq
   - >
-    sudo apt-get install
+    sudo apt-get --no-install-recommends install
     autoconf
     automake
     gdb


### PR DESCRIPTION
Cockpit doesn't need them to build. In particular, this stops
downloading texlive (an indirect dependency of xmlto) on every CI run,
which should make them considerably faster.