### PR TITLE
add insecure-registry checkbox to modify imagestream

### DIFF
--- a/pkg/kubernetes/scripts/images.js
+++ b/pkg/kubernetes/scripts/images.js
@@ -604,6 +604,7 @@
                 populate: populate,
                 pull: spec.dockerImageRepository || "",
                 tags: tagData.parseSpec(spec),
+                insecure: hasInsecureTag(spec),
             };
 
             $scope.fields = fields;
@@ -625,7 +626,7 @@
                 if (fields.populate != "none")
                     data.spec.dockerImageRepository = fields.pull.trim();
                 if (fields.populate == "tags")
-                    tagData.buildSpec(fields.tags, data.spec);
+                    tagData.buildSpec(fields.tags, data.spec, fields.insecure);
 
                 return methods.patch(stream, data);
             }
@@ -642,7 +643,7 @@
                 if (fields.populate != "none")
                     data.spec = { dockerImageRepository: fields.pull.trim(), };
                 if (fields.populate == "tags")
-                    data.spec = tagData.buildSpec(fields.tags, data.spec);
+                    data.spec = tagData.buildSpec(fields.tags, data.spec, fields.insecure);
 
                 return methods.check(data, {
                     "metadata.name": "#imagestream-modify-name",
@@ -652,8 +653,24 @@
                 });
             }
 
+            function hasInsecureTag(spec) {
+                // loop through tags, check importPolicy.insecure boolean
+                // if one tag is insecure the intent is the imagestream is insecure
+                var insecure = false;
+                if (spec) {
+                    for (var tag in spec.tags) {
+                        if (spec.tags[tag].importPolicy.insecure) {
+                            insecure = spec.tags[tag].importPolicy.insecure;
+                            break;
+                        }
+                    }
+                }
+                return insecure;
+            }
+
             $scope.performCreate = performCreate;
             $scope.performModify = performModify;
+            $scope.hasInsecureTag = hasInsecureTag;
 
             $scope.projects = filter.namespaces;
             angular.extend($scope, dialogData);

--- a/pkg/kubernetes/scripts/images.js
+++ b/pkg/kubernetes/scripts/images.js
@@ -656,7 +656,7 @@
             function hasInsecureTag(spec) {
                 // loop through tags, check importPolicy.insecure boolean
                 // if one tag is insecure the intent is the imagestream is insecure
-                var insecure = false;
+                var insecure;
                 if (spec) {
                     for (var tag in spec.tags) {
                         if (spec.tags[tag].importPolicy.insecure) {

--- a/pkg/kubernetes/scripts/tags.js
+++ b/pkg/kubernetes/scripts/tags.js
@@ -73,10 +73,12 @@
         });
         var tags = [ ];
         angular.forEach(names, function(name) {
-            if (name in already)
+            if (name in already) {
+                already[name].importPolicy = { "insecure": insecure };
                 tags.push(already[name]);
+            }
             else
-                tags.push({ name: name, importPolicy: { insecure: insecure } });
+                tags.push({ name: name });
         });
         spec.tags = tags;
         return spec;

--- a/pkg/kubernetes/scripts/tags.js
+++ b/pkg/kubernetes/scripts/tags.js
@@ -64,7 +64,7 @@
         return names;
     }
 
-    function buildSpec(names, spec) {
+    function buildSpec(names, spec, insecure) {
         var already = { };
         if (!spec)
             spec = { };
@@ -76,7 +76,7 @@
             if (name in already)
                 tags.push(already[name]);
             else
-                tags.push({ name: name });
+                tags.push({ name: name, importPolicy: { insecure: insecure } });
         });
         spec.tags = tags;
         return spec;

--- a/pkg/kubernetes/scripts/tags.js
+++ b/pkg/kubernetes/scripts/tags.js
@@ -78,7 +78,7 @@
                 tags.push(already[name]);
             }
             else
-                tags.push({ name: name });
+                tags.push({ name: name, "importPolicy": { "insecure": insecure } });
         });
         spec.tags = tags;
         return spec;

--- a/pkg/kubernetes/tests/test-tags.html
+++ b/pkg/kubernetes/tests/test-tags.html
@@ -70,10 +70,10 @@ function suite() {
             deepEqual(spec, {
                 "dockerImageRepository": "busybox",
                 "tags": [
-                    { "name": "2.5" },
+                    { "name": "2.5", "importPolicy": { "insecure": true } },
                     { "annotations": null, "from": { "kind": "DockerImage", "name": "busybox:latest" },
                         "generation": 2, "importPolicy": { "insecure": true }, "name": "latest" },
-                    { "name": "second" }
+                    { "name": "second", "importPolicy": { "insecure": true } }
                 ]
             }, "build spec correctly");
         }

--- a/pkg/kubernetes/tests/test-tags.html
+++ b/pkg/kubernetes/tests/test-tags.html
@@ -66,13 +66,13 @@ function suite() {
         "imageTagData",
         function(data) {
             var spec = angular.extend({ }, specData);
-            spec = data.buildSpec(["2.5", "latest", "second"], spec);
+            spec = data.buildSpec(["2.5", "latest", "second"], spec, true);
             deepEqual(spec, {
                 "dockerImageRepository": "busybox",
                 "tags": [
                     { "name": "2.5" },
                     { "annotations": null, "from": { "kind": "DockerImage", "name": "busybox:latest" },
-                        "generation": 2, "importPolicy": {}, "name": "latest" },
+                        "generation": 2, "importPolicy": { "insecure": true }, "name": "latest" },
                     { "name": "second" }
                 ]
             }, "build spec correctly");
@@ -150,7 +150,9 @@ var specData = {
                 "name": "busybox:latest"
             },
             "generation": 2,
-            "importPolicy": {}
+            "importPolicy": {
+                "insecure": false
+            }
         }
     ]
 };

--- a/pkg/kubernetes/views/imagestream-modify.html
+++ b/pkg/kubernetes/views/imagestream-modify.html
@@ -81,6 +81,13 @@
                     </div>
                 </td>
             </tr>
+            <tr ng-show="fields.populate == 'tags'">
+                <td></td>
+                <td>
+                    <input type="checkbox" ng-checked="hasInsecureTag(stream.spec)" ng-model="fields.insecure">
+                    <span translatable="yes">Remote registry is insecure</span>
+                </td>
+            </tr>
         </table>
     </div>
     <div class="modal-footer">


### PR DESCRIPTION
Initial support for ["insecure registry" boolean](https://docs.openshift.org/latest/rest_api/openshift_v1.html#v1-tagimportpolicy), applied per tag.