### PR TITLE
Koji task fixes

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -63,7 +63,9 @@ if test -n "${NOCONFIGURE:-}"; then
 fi
 
 cd $olddir
-rm -f $srcdir/Makefile
+if [ -z "${NOREDIRECTMAKEFILE:-}" ]; then
+    rm -f $srcdir/Makefile
+fi
 $srcdir/configure --enable-maintainer-mode ${AUTOGEN_CONFIGURE_ARGS:-} "$@" || exit $?
 
 # Put a redirect makefile here

--- a/test/koji/run-build
+++ b/test/koji/run-build
@@ -54,7 +54,7 @@ def main():
 
         # Do a build
         subprocess.check_call(["../../../tools/make-srpm", dist])
-        cmd = ["koji", "build", "--scratch", system, glob.glob("*.src.rpm")[0]]
+        cmd = ["koji", "build", "--wait", "--scratch", system, glob.glob("*.src.rpm")[0]]
         subprocess.check_call(cmd)
     finally:
         shutil.rmtree(directory)

--- a/test/koji/run-build
+++ b/test/koji/run-build
@@ -41,9 +41,13 @@ def main():
     # Converts fedora-23 to f23
     system = testinfra.DEFAULT_IMAGE[0] + testinfra.DEFAULT_IMAGE.split("-")[-1]
 
+    # Don't overwrite a Makefile in autogen.sh
+    env = os.environ.copy()
+    env["NOREDIRECTMAKEFILE"] = "1"
+
     # Make a distribution
     try:
-        subprocess.check_call(["../../../autogen.sh && make dist"], shell=True)
+        subprocess.check_call(["../../../autogen.sh && make dist"], shell=True, env=env)
         with open(os.path.join(directory, "GNUmakefile"), "w") as f:
             f.write('include Makefile\nprint-DIST_ARCHIVES:\n\t@echo $(DIST_ARCHIVES)')
         dist = subprocess.check_output(["make", "-s", "print-DIST_ARCHIVES"]).strip()


### PR DESCRIPTION
Fixes to make it easier to run ```github-task --head koji/fedora-24``` or similar.