### PR TITLE
doc: Remove Mustache from the documentation

### DIFF
--- a/doc/guide/api-base1.xml
+++ b/doc/guide/api-base1.xml
@@ -104,31 +104,6 @@
 
   </refentry>
 
-  <refentry id="api-base1-mustache">
-    <refmeta>
-      <refentrytitle>mustache.js</refentrytitle>
-    </refmeta>
-
-    <refnamediv>
-      <refname>mustache.js</refname>
-      <refpurpose>mustache templating</refpurpose>
-    </refnamediv>
-
-    <refsection>
-      <title>Description</title>
-<programlisting>
-&lt;script src="../base1/mustache.js"&gt;&lt;/script&gt;
-</programlisting>
-
-      <para>To use <ulink url="http://mustache.github.io/">Mustache</ulink> in your package include
-        the above script.</para>
-
-      <para>The current mustache version is 0.8. In the <code>latest</code> package we may
-        track relatively recent versions of mustache. Other packages may provide more stable versions
-        of mustache in the future.</para>
-    </refsection>
-  </refentry>
-
   <refentry id="api-base1-patternfly">
     <refmeta>
       <refentrytitle>patternfly.css</refentrytitle>


### PR DESCRIPTION
We keep mustache in the base1 package because others out of tree
packages are already using it. However it's not documented as part
of our API.