### PR TITLE
test: Fix issues with arguments not working in check-kubernetes

### DIFF
--- a/test/containers/run-tests
+++ b/test/containers/run-tests
@@ -74,7 +74,7 @@ def run(opts):
             suite.addTest(loader.loadTestsFromModule(module))
 
     # And now load new testlib, and run all the tests we got
-    return testlib.test_main(opts=opts, suite=suite)
+    return testlib.test_main(options=opts, suite=suite)
 
 def main():
     parser = testlib.arg_parser()

--- a/test/verify/check-kubernetes
+++ b/test/verify/check-kubernetes
@@ -19,20 +19,20 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent
-from testlib import *
 import json
 import os
 import sys
 import unittest
 
-from kubelib import *
+from testlib import *
+import kubelib
 
 @unittest.skipIf("rhel-7" == os.environ.get("TEST_OS", ""), "Skipping check-kubernetes on rhel-7.")
 @unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No kubernetes on Debian (yet).")
-class TestKubernetes(KubernetesCase, KubernetesCommonTests):
+class TestKubernetes(kubelib.KubernetesCase, kubelib.KubernetesCommonTests):
 
     def setUp(self):
-        KubernetesCase.setUp(self)
+        kubelib.KubernetesCase.setUp(self)
         m = self.machine
 
         self.start_kubernetes()
@@ -42,7 +42,7 @@ class TestKubernetes(KubernetesCase, KubernetesCommonTests):
 
 @unittest.skipIf("rhel-7" == os.environ.get("TEST_OS", ""), "Skipping check-kubernetes on rhel-7.")
 @unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No kubernetes on Debian (yet).")
-class TestConnection(KubernetesCase):
+class TestConnection(kubelib.KubernetesCase):
     def testConnect(self):
         m = self.machine
         b = self.browser
@@ -230,9 +230,9 @@ class TestConnection(KubernetesCase):
 @unittest.skipIf("rhel-7" == os.environ.get("TEST_OS", ""), "Skipping check-nulecule on rhel-7.")
 @unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No kubernetes on Debian (yet).")
 @unittest.skipIf(True, "Nulecule deploys temporarily removed.")
-class TestNulecule(KubernetesCase):
+class TestNulecule(kubelib.KubernetesCase):
     def setUp(self):
-        KubernetesCase.setUp(self)
+        kubelib.KubernetesCase.setUp(self)
         m = self.machine
 
         self.start_kubernetes()

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -19,8 +19,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import os
-
-from common.testlib import *
+import testlib
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -30,7 +29,7 @@ __all__ = (
     'OpenshiftCommonTests',
 )
 
-class KubernetesCase(MachineCase):
+class KubernetesCase(testlib.MachineCase):
 
     def start_kubernetes(self):
         self.machine.execute("systemctl start docker || journalctl -u docker")

--- a/test/verify/run-tests
+++ b/test/verify/run-tests
@@ -56,7 +56,7 @@ def run(opts):
             suite.addTest(loader.loadTestsFromModule(module))
 
     # And now load new testlib, and run all the tests we got
-    return testlib.test_main(opts=opts, suite=suite)
+    return testlib.test_main(options=opts, suite=suite)
 
 def main():
     parser = testlib.arg_parser()


### PR DESCRIPTION
This is due to the python strangeness that 'from xxx import *' creates a snapshot of everything in the module rather than reusing the module in its entirety.
