### PR TITLE
selinux: Show more meaningful error on connection error

### DIFF
--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -233,7 +233,7 @@ var SETroubleshootPage = React.createClass({
                 description = _("Connecting...");
             } else {
                 icon = <i className="fa fa-exclamation-circle" />;
-                description = _("Couldn't connect to SETroubleshoot daemon");
+                description = _("Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-server is installed.");
             }
 
             return (


### PR DESCRIPTION
For this, name the necessary package to install (setroubleshoot-server).
On a regular installation, this should be present, but in some cases
it might not be.

Fixes #4324

![screenshot from 2016-04-29 14-00-00](https://cloud.githubusercontent.com/assets/8711649/14915420/10b9bcf2-0e13-11e6-83b9-bf9776af71ad.png)