### PR TITLE
kubernetes: Don't show Labels in image metadata if no labels

### DIFF
--- a/pkg/kubernetes/scripts/images.js
+++ b/pkg/kubernetes/scripts/images.js
@@ -493,7 +493,10 @@
                     return select().kind("ImageStream").listTagNames(image.metadata.name);
                 },
                 imageLabels: function imageLabels(image) {
-                    return select(image).dockerImageConfig().dockerConfigLabels().one();
+                    var labels = select(image).dockerImageConfig().dockerConfigLabels().one();
+                    if (labels && angular.equals({ }, labels))
+                        labels = null;
+                    return labels;
                 },
                 configCommand: configCommand,
             };


### PR DESCRIPTION
When there's no labels in the metadata, just return null, and
hide the Labels header.