### PR TITLE
ws: Timeouts for authentication processes

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -46,6 +46,7 @@ For example
 [bearer]
 action = spawn-login-with-header
 command = example-verify-token
+timeout = 300
 ```
 
 The default command is ```cockpit-session``` it is able to handle basic and gssapi
@@ -59,6 +60,11 @@ The command will be called with two arguments
 cockpit-ws will then send contents of the Authorization http header, without the
 auth scheme, on fd #3 to the command. Once the command has processed the credentials
 it MUST write a JSON response to fd #3.
+
+By default cockpit-ws will wait a maximum of 30 seconds to receive this response.
+The number of seconds to wait can be adjusted by adding a timeout parameter along
+side the auth schema configuration in your config file. The given value should be
+a number between 1 and 900.
 
 An error response should contain the following fields:
 

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -44,11 +44,15 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 
 #define ACTION_SPAWN_HEADER "spawn-login-with-header"
 #define ACTION_SPAWN_DECODE "spawn-login-with-decoded"
 #define ACTION_SSH "remote-login-ssh"
 #define ACTION_NONE "none"
+
+#define MAX_AUTH_TIMEOUT 900
+#define MIN_AUTH_TIMEOUT 1
 
 /* Timeout of authenticated session when no connections */
 guint cockpit_ws_service_idle = 15;
@@ -56,8 +60,12 @@ guint cockpit_ws_service_idle = 15;
 /* Timeout of everything when noone is connected */
 guint cockpit_ws_process_idle = 90;
 
+/* The amount of time a spawned process has to complete authentication */
+guint cockpit_ws_auth_process_timeout = 30;
+
 /* Maximum number of pending authentication requests */
 const gchar *cockpit_ws_max_startups = NULL;
+
 static guint max_startups = 10;
 
 static guint sig__idling = 0;
@@ -307,6 +315,32 @@ type_option (const gchar *type,
   return default_str;
 }
 
+static guint
+timeout_option (const gchar *type)
+{
+  guint timeout = cockpit_ws_auth_process_timeout;
+  guint64 conf_timeout;
+  const gchar* conf = type_option (type, "timeout", NULL);
+
+  if (conf)
+    {
+      conf_timeout = g_ascii_strtoull (conf, NULL, 10);
+      if (errno == ERANGE || errno == EINVAL)
+        timeout = cockpit_ws_auth_process_timeout;
+      else if (conf_timeout > MAX_AUTH_TIMEOUT || conf_timeout > UINT_MAX)
+        timeout = (MAX_AUTH_TIMEOUT > UINT_MAX) ? UINT_MAX : MAX_AUTH_TIMEOUT;
+      else if (conf_timeout < MIN_AUTH_TIMEOUT)
+        timeout = MIN_AUTH_TIMEOUT;
+      else
+        timeout = (guint)conf_timeout;
+
+      if (conf_timeout != timeout)
+        g_message ("Invalid %s timeout value '%s', setting to %u", type, conf, timeout);
+    }
+
+  return timeout;
+}
+
 /* ------------------------------------------------------------------------
  *  Login by spawning a new command
  */
@@ -321,6 +355,7 @@ typedef struct {
   gchar *auth_type;
   gchar *application;
   const gchar *command;
+  guint timeout;
 } SpawnLoginData;
 
 static void
@@ -337,10 +372,31 @@ spawn_login_data_free (gpointer data)
     g_object_unref (sl->auth_pipe);
   if (sl->authorization)
     g_bytes_unref (sl->authorization);
+
+  if (sl->timeout)
+    g_source_remove (sl->timeout);
+
   g_free (sl->auth_type);
   g_free (sl->application);
   g_free (sl->remote_peer);
   g_free (sl);
+}
+
+static gboolean
+on_spawn_timeout_cleanup (gpointer user_data)
+{
+  SpawnLoginData *sl = user_data;
+
+  g_warning ("spawn login timed out during auth");
+
+  sl->timeout = 0;
+  if (sl->auth_pipe)
+    cockpit_pipe_close (sl->auth_pipe, "timeout");
+
+  if (sl->process_pid)
+    kill (sl->process_pid, SIGTERM);
+
+  return FALSE;
 }
 
 static void
@@ -370,12 +426,26 @@ on_spawn_login_done (CockpitPipe *pipe,
                      gpointer user_data)
 {
   GSimpleAsyncResult *result = G_SIMPLE_ASYNC_RESULT (user_data);
+  SpawnLoginData *sl;
+  const gchar *msg;
+
+  sl = g_simple_async_result_get_op_res_gpointer (G_SIMPLE_ASYNC_RESULT (result));
+  if (sl->timeout)
+    {
+      g_source_remove (sl->timeout);
+      sl->timeout = 0;
+    }
 
   if (problem)
     {
       g_warning ("spawn login failed during auth: %s", problem);
-      g_simple_async_result_set_error (result, COCKPIT_ERROR, COCKPIT_ERROR_FAILED,
-                                       "Internal error in login process");
+      if (g_strcmp0 (problem, "timeout") == 0)
+        msg = "Authentication failed: Timeout";
+      else
+        msg = "Internal error in login process";
+
+      g_simple_async_result_set_error (result, COCKPIT_ERROR,
+                                       COCKPIT_ERROR_FAILED, "%s", msg);
     }
 
   g_simple_async_result_complete (result);
@@ -617,6 +687,7 @@ cockpit_auth_spawn_login_async (CockpitAuth *self,
   SpawnLoginData *sl;
   GBytes *input = NULL;
   const gchar *command;
+  guint timeout_secs;
   int pwfds[2] = { -1, -1 };
   GError *error = NULL;
 
@@ -631,6 +702,8 @@ cockpit_auth_spawn_login_async (CockpitAuth *self,
                                       cockpit_auth_spawn_login_async);
 
   command = type_option(type, "command", cockpit_ws_session_program);
+  timeout_secs = timeout_option(type);
+
   input = cockpit_auth_parse_authorization (headers, decode_header);
   if (!input && !gssapi_not_avail && g_strcmp0 (type, "negotiate") == 0)
     input = g_bytes_new_static ("", 0);
@@ -645,6 +718,7 @@ cockpit_auth_spawn_login_async (CockpitAuth *self,
       argv[0] = sl->command = command;
       sl->process_in = -1;
       sl->process_out = -1;
+      sl->timeout = g_timeout_add_seconds (timeout_secs, on_spawn_timeout_cleanup, sl);
 
       g_simple_async_result_set_op_res_gpointer (result, sl, spawn_login_data_free);
 

--- a/src/ws/cockpitws.h
+++ b/src/ws/cockpitws.h
@@ -34,6 +34,7 @@ extern const gchar *cockpit_ws_default_host_header;
 extern gint cockpit_ws_specific_ssh_port;
 extern guint cockpit_ws_ping_interval;
 extern gint cockpit_ws_session_timeout;
+extern guint cockpit_ws_auth_process_timeout;
 
 /* From cockpitauth.c */
 extern guint cockpit_ws_service_idle;

--- a/src/ws/mock-auth-command
+++ b/src/ws/mock-auth-command
@@ -51,6 +51,11 @@ case $auth in
     "with-error")
         echo "{ \"error\": \"unknown\", \"message\": \"detail for error\" }" >&3
         ;;
+    "too-slow")
+        sleep 10
+        echo "{\"user\": \"me\", \"login-data\": { \"login\": \"data\"} }" >&3
+        success=1
+        ;;
     *)
         ;;
 esac

--- a/src/ws/mock-config.conf
+++ b/src/ws/mock-config.conf
@@ -21,5 +21,10 @@ command = bad-command
 action = spawn-login-with-header
 command = mock-auth-command
 
+[timeout-scheme]
+action = spawn-login-with-header
+command = mock-auth-command
+timeout = 1
+
 [none]
 action = none

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -432,6 +432,15 @@ test_custom_fail (Test *test,
 }
 
 static void
+test_custom_timeout (Test *test,
+                     gconstpointer data)
+{
+  cockpit_expect_warning ("*spawn login timed out during auth");
+  cockpit_expect_warning ("*spawn login failed during auth: timeout*");
+  test_custom_fail (test, data);
+}
+
+static void
 test_bad_command (Test *test,
                   gconstpointer data)
 {
@@ -544,6 +553,11 @@ static const ErrorFixture fixture_auth_no_write = {
   .error_message = "Authentication failed: no results",
   .header = "testscheme no-write",
   .warning = "*JSON data was empty"
+};
+
+static const ErrorFixture fixture_auth_timeout = {
+  .error_message = "Authentication failed: Timeout",
+  .header = "timeout-scheme too-slow",
 };
 
 typedef struct {
@@ -689,6 +703,8 @@ main (int argc,
               setup_normal, test_custom_fail, teardown_normal);
   g_test_add ("/auth/custom-no-write", Test, &fixture_auth_no_write,
               setup_normal, test_custom_fail, teardown_normal);
+  g_test_add ("/auth/custom-timeout", Test, &fixture_auth_timeout,
+              setup_normal, test_custom_timeout, teardown_normal);
   g_test_add ("/auth/none", Test, &fixture_auth_none,
               setup_normal, test_custom_fail, teardown_normal);
   g_test_add ("/auth/bad-command", Test, &fixture_bad_command,


### PR DESCRIPTION
Kill spawned authentication processes that don't write a response within a specified time limit.