### PR TITLE
Image refresh for fedora-24

### DIFF
--- a/test/images/fedora-24
+++ b/test/images/fedora-24
@@ -1,1 +1,1 @@
-fedora-24-125aa8a4f6c2a411320ea880f591b28081d9fc86.qcow2
+fedora-24-d3a895e8fe8b0dbf4eb0824c3df1f82a1b6e2a47.qcow2


### PR DESCRIPTION
Image creation for fedora-24 in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-24-2016-05-02/