### PR TITLE
shell: More clear wording for the multi-host login troubleshooting

### DIFF
--- a/pkg/shell/templates/change-auth.html
+++ b/pkg/shell/templates/change-auth.html
@@ -10,7 +10,7 @@
     {{/available}}
 
     {{#available}}
-    <p translatable="yes">Cockpit was unable to log into {{#strong}}{{host}}{{/strong}} you can change your authentication credentials below. You may prefer to {{#sync_link}}synchronize users{{/sync_link}}.</p>
+    <p translatable="yes">Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can change your authentication credentials below. You may prefer to {{#sync_link}}synchronize accounts and passwords{{/sync_link}}.</p>
 
     <div>
         <table class="cockpit-form-table">


### PR DESCRIPTION
Fix some punctuation. In addition make it clear that the user can
synchronize passwords in addition to the admin accounts.