### PR TITLE
test: Force checkout in github-task

### DIFF
--- a/test/common/testpulltask.py
+++ b/test/common/testpulltask.py
@@ -147,7 +147,7 @@ class GithubPullTask(object):
 
         if self.ref:
             subprocess.check_call([ "git", "fetch", "origin", self.ref ])
-            subprocess.check_call([ "git", "checkout", self.revision ])
+            subprocess.check_call([ "git", "checkout", "-f", self.revision ])
 
         # Split a value like verify/fedora-23
         (prefix, unused, value) = self.context.partition("/")


### PR DESCRIPTION
Without this there are combinations of commits that cause all
the verify machines to eventually fail with:

error: The following untracked working tree files would be overwritten by checkout: