### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,0 @@
-debian-unstable-218578145d7680bdb8a224c9643d271b5d5991bc.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-05-05/