### PR TITLE
base1: Install react.js with --enable-debug

### DIFF
--- a/pkg/base1/Makefile.am
+++ b/pkg/base1/Makefile.am
@@ -45,6 +45,7 @@ basedebug_DATA = \
 	pkg/base1/moment.js \
 	pkg/base1/mustache.js \
 	pkg/base1/jquery.js \
+	pkg/base1/react.js \
 	pkg/base1/cockpit.js \
 	$(REACT_COMPONENTS) \
 	$(base_GEN) \


### PR DESCRIPTION
Otherwise configuring with --enable-debug and running `make install` will cause `base1/react` to not be found.
