### PR TITLE
docker: replace character with html character

### DIFF
--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -63,7 +63,7 @@
       <h1 translatable="yes">Docker is not installed or activated on the system</h1>
       {{/notfound}}
       {{#other}}
-      <h1 translatable="yes">Can't connect to Docker</h1>
+      <h1 translatable="yes">Can&rsquo;t connect to Docker</h1>
       <p>{{.}}</p>
       {{/other}}
       <div class="blank-slate-pf-main-action">


### PR DESCRIPTION
The aphostrophe used to write the word "don't" made some editors,
and github in particular, confused about how to handle the highlight.
Replace it with &acute;

Fixes #4367