### PR TITLE
common: Order certificates alphabetically

### DIFF
--- a/src/common/cockpitcertificate.c
+++ b/src/common/cockpitcertificate.c
@@ -242,8 +242,8 @@ load_cert_from_dir (const gchar *dir_name,
 
   if (p->len > 0)
     {
-      ret = p->pdata[p->len - 1];
-      p->pdata[p->len - 1] = NULL;
+      ret = p->pdata[0];
+      p->pdata[0] = NULL;
     }
 
 out:

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -132,8 +132,8 @@ class TestConnection(MachineCase):
             self.fail("RC4 cipher should not have been usable")
 
         # Install a certificate chain, and give it an arbitrary bad file context
-        m.upload([ "verify/files/cert-chain.cert" ], "/etc/cockpit/ws-certs.d")
-        m.execute("! selinuxenabled || chcon --type svirt_sandbox_file_t /etc/cockpit/ws-certs.d/cert-chain.cert")
+        m.upload([ "verify/files/cert-chain.cert" ], "/etc/cockpit/ws-certs.d/-cert-chain.cert")
+        m.execute("! selinuxenabled || chcon --type svirt_sandbox_file_t /etc/cockpit/ws-certs.d/-cert-chain.cert")
 
         # This should also reset the file context
         m.restart_cockpit()


### PR DESCRIPTION
In the docs we say that we pick the first one alphabetically but in reality we were picking the last. This is a breaking change if anyone was relying on the old behavior. But since we haven't yet guaranteed complete backwards compatibility it may be ok. Otherwise we'll need to change the docs.