### PR TITLE
Makefile: Fix for older versions of git

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -255,7 +255,7 @@ COMMITTED_DIST = \
 
 # Build up the distribution using $COMMITTED_DIST and include node_modules and bower licenses
 dist-hook: dist-doc-hook
-	( git -C $(srcdir) ls-tree HEAD --name-only -r $(COMMITTED_DIST) || echo $(COMMITTED_DIST) ) | \
+	( cd $(srcdir); git ls-tree HEAD --name-only -r $(COMMITTED_DIST) || echo $(COMMITTED_DIST) ) | \
 		tar -C $(srcdir) -cf - -T - | tar -C $(distdir) -xf -
 	tar -C $(srcdir) -cf - --exclude='phantomjs*' --exclude='jshint*' node_modules/ | tar -C $(distdir) -xf -
 	echo $(VERSION) > $(distdir)/.tarball


### PR DESCRIPTION
Older versions of git don't support -C. Change to the directory
explicitly instead.