### PR TITLE
kubernetes: Fix the alignment of Services in the topology view

### DIFF
--- a/pkg/kubernetes/styles/topology.less
+++ b/pkg/kubernetes/styles/topology.less
@@ -68,3 +68,6 @@ kubernetes-topology-icon {
     font-size: 22px;
 }
 
+.kube-topology g.Service text {
+    font-size: 22px;
+}

--- a/pkg/kubernetes/views/topology-page.html
+++ b/pkg/kubernetes/views/topology-page.html
@@ -74,7 +74,7 @@
     </g>
     <g class="Service" id="vertex-Service">
       <circle r="15"></circle>
-      <text y="10" x="1">&#xe61e;</text>
+      <text y="10" x="-1">&#xe61e;</text>
     </g>
     <g class="ReplicationController" id="vertex-ReplicationController">
       <circle r="15"></circle>


### PR DESCRIPTION
These icons seem to have changed size after a Patternfly update.