### PR TITLE
selinux: timestamps, alert levels and alert dismissal

### DIFF
--- a/pkg/base1/cockpit-components-listing.jsx
+++ b/pkg/base1/cockpit-components-listing.jsx
@@ -129,7 +129,7 @@ define([
             var count_display = null;
 
             var header_entries = this.props.columns.map(function(itm) {
-                if (typeof itm === 'string' || itm instanceof String || React.isValidElement(itm))
+                if (typeof itm === 'string' || itm === null || itm instanceof String || React.isValidElement(itm))
                     return (<td>{itm}</td>);
                 else if ('header' in itm && itm.header)
                     return (<th>{itm.name}</th>);

--- a/pkg/base1/cockpit-components-listing.jsx
+++ b/pkg/base1/cockpit-components-listing.jsx
@@ -38,6 +38,7 @@ define([
      *     if tabRenderers isn't set, item can't be expanded inline
      * navigateToItem optional: callback triggered when a row is clicked, pattern suggests navigation
      *     to view expanded item details, if not set, navigation isn't available
+     * listingDetail optional: text rendered next to action buttons, similar style to the tab headers
      * listingActions optional: buttons that are presented as actions for the expanded item
      */
     var ListingRow = React.createClass({
@@ -180,6 +181,15 @@ define([
                         tabs.push(<div className="listing-ct-body" key={tabIdx} hidden>{row}</div>);
                 }
 
+                var listingDetail;
+                if ('listingDetail' in this.props) {
+                    listingDetail = (
+                        <span className="listing-ct-caption">
+                            {this.props.listingDetail}
+                        </span>
+                    );
+                }
+
                 return (
                     <tbody className="open">
                         {listing_item}
@@ -187,6 +197,7 @@ define([
                             <td colSpan={ header_entries.length + (expand_toggle?1:0) }>
                                 <div className="listing-ct-head">
                                     <div className="listing-ct-actions">
+                                        {listingDetail}
                                         {this.props.listingActions}
                                     </div>
                                     <ul className="nav nav-tabs nav-tabs-pf">

--- a/pkg/base1/cockpit.css
+++ b/pkg/base1/cockpit.css
@@ -574,6 +574,14 @@ tr.listing-ct-item th {
     padding: 10px 10px 10px 15px;
 }
 
+/* Listing caption is text next to the actions, text should be similar to nav (.nav-tabs-pf > li > a)*/
+.listing-ct-actions > .listing-ct-caption {
+    font-size: 13px;
+    vertical-align: middle;
+    color: #4d5258;
+    padding-right: 5px;
+}
+
 /* Listing actions can be used directly as a cell */
 tr.listing-ct-item td.listing-ct-actions,
 td.listing-ct-actions {

--- a/pkg/selinux/Makefile.am
+++ b/pkg/selinux/Makefile.am
@@ -3,6 +3,7 @@ PKGDIR=pkg/selinux
 setroubleshoot_MODULES = \
 	$(PKGDIR)/setroubleshoot.js \
 	$(PKGDIR)/setroubleshoot-client.js \
+	$(PKGDIR)/moment.js \
 	$(NULL)
 
 setroubleshoot_TESTS = \
@@ -29,7 +30,12 @@ setroubleshootdebug_DATA = \
 	$(PKGDIR)/setroubleshoot-client.js \
 	$(PKGDIR)/setroubleshoot-view.jsx \
 	$(PKGDIR)/setroubleshoot-view.js \
+	$(PKGDIR)/moment.js \
 	$(NULL)
+
+# moment.js can't be parsed as strictly as our own modules
+$(PKGDIR)/moment.min.js: $(PKGDIR)/moment.js
+	$(MIN_JS_RULE)
 
 setroubleshoot_MIN = \
 	$(setroubleshoot_MODULES:.js=.min.js) \

--- a/pkg/selinux/moment.js
+++ b/pkg/selinux/moment.js
@@ -1,0 +1,1 @@
+../../bower_components/momentjs/moment.js

--- a/pkg/selinux/setroubleshoot-client.js
+++ b/pkg/selinux/setroubleshoot-client.js
@@ -111,7 +111,10 @@ client.init = function() {
           doText
           analysisId: plugin id. It can be used in org.fedoraproject.SetroubleshootFixit.run_fix()
           fixable: True when an alert is fixable by a plugin
-          reportBug: True when an alert should be reported to bugzilla
+          reportBug: True when an alert should be reported
+      firstSeen: when the alert was seen for the first time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
+      lastSeen: when the alert was seen for the last time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
+      level: "green", "yellow" or "red"
     */
     client.getAlert = function(localId) {
         var dfdResult = $.Deferred();
@@ -124,6 +127,13 @@ client.init = function() {
                   auditEvent: result[3],
                   pluginAnalysis: result[4],
                 };
+                // these values are available starting setroubleshoot-3.2.25
+                // HACK https://bugzilla.redhat.com/show_bug.cgi?id=1306700
+                if (result.length >= 8) {
+                    details.firstSeen = result[5];
+                    details.lastSeen = result[6];
+                    details.level = result[7];
+                }
                 // cleanup analysis
                 details.pluginAnalysis = details.pluginAnalysis.map(function(itm) {
                     return {

--- a/pkg/selinux/setroubleshoot-client.js
+++ b/pkg/selinux/setroubleshoot-client.js
@@ -20,7 +20,8 @@
 define([
     "jquery",
     "base1/cockpit",
-], function($, cockpit) {
+    "selinux/moment",
+], function($, cockpit, moment) {
 
 "use strict";
 var _ = cockpit.gettext;
@@ -113,8 +114,8 @@ client.init = function(capabilitiesChangedCallback) {
           analysisId: plugin id. It can be used in org.fedoraproject.SetroubleshootFixit.run_fix()
           fixable: True when an alert is fixable by a plugin
           reportBug: True when an alert should be reported
-      firstSeen: when the alert was seen for the first time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
-      lastSeen: when the alert was seen for the last time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
+      firstSeen: when the alert was seen for the first time, momentjs object
+      lastSeen: when the alert was seen for the last time, momentjs object
       level: "green", "yellow" or "red"
     */
     client.getAlert = function(localId) {
@@ -131,8 +132,8 @@ client.init = function(capabilitiesChangedCallback) {
                 // these values are available starting setroubleshoot-3.2.25
                 // HACK https://bugzilla.redhat.com/show_bug.cgi?id=1306700
                 if (result.length >= 8) {
-                    details.firstSeen = result[5];
-                    details.lastSeen = result[6];
+                    details.firstSeen = moment(result[5]);
+                    details.lastSeen = moment(result[6]);
                     details.level = result[7];
                 }
                 // cleanup analysis

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -279,7 +279,14 @@ var SETroubleshootPage = React.createClass({
                         data: itm,
                     },
                 ];
-                var columns = [ { name: itm.description, 'header': true } ];
+                // if the alert has level "red", it's critical
+                var criticalAlert = null;
+                if (itm.details && 'level' in itm.details && itm.details.level == "red")
+                    criticalAlert = <span className="fa fa-exclamation-triangle" />;
+                var columns = [
+                    criticalAlert,
+                    { name: itm.description, 'header': true }
+                ];
                 if (itm.count > 1)
                     columns.push(<span className="badge">{itm.count}</span>);
                 return (

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -21,7 +21,8 @@ define([
     "base1/react",
     "base1/cockpit",
     "base1/cockpit-components-listing",
-], function(React, cockpit, cockpitListing) {
+    "selinux/moment",
+], function(React, cockpit, cockpitListing, moment) {
 
 "use strict";
 
@@ -282,10 +283,14 @@ var SETroubleshootPage = React.createClass({
                 itm.runFix = self.props.runFix;
                 var listingDetail;
                 if (itm.details && 'firstSeen' in itm.details) {
-                    if (itm.details.reportCount >= 2)
-                        listingDetail = cockpit.format(_("Occurred between $0 and $1"), itm.details.firstSeen, itm.details.lastSeen);
-                    else
-                        listingDetail = cockpit.format(_("Occurred $0"), itm.details.firstSeen);
+                    if (itm.details.reportCount >= 2) {
+                        listingDetail = cockpit.format(_("Occurred between $0 and $1"),
+                                                       itm.details.firstSeen.calendar(),
+                                                       itm.details.lastSeen.calendar()
+                                                      );
+                    } else {
+                        listingDetail = cockpit.format(_("Occurred $0"), itm.details.firstSeen.calendar());
+                    }
                 }
                 var onDeleteClick;
                 if (itm.details)

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -254,6 +254,13 @@ var SETroubleshootPage = React.createClass({
             }
             var entries = this.props.entries.map(function(itm) {
                 itm.runFix = self.props.runFix;
+                var listingDetail;
+                if (itm.details && 'firstSeen' in itm.details) {
+                    if (itm.details.reportCount >= 2)
+                        listingDetail = cockpit.format(_("Occurred between $0 and $1"), itm.details.firstSeen, itm.details.lastSeen);
+                    else
+                        listingDetail = cockpit.format(_("Occurred $0"), itm.details.firstSeen);
+                }
                 var dismissAction = (
                     <button
                         title="Dismiss"
@@ -279,7 +286,8 @@ var SETroubleshootPage = React.createClass({
                     <cockpitListing.ListingRow
                         columns={columns}
                         tabRenderers={tabRenderers}
-                        listingActions={ [ dismissAction ] } />
+                        listingDetail={listingDetail}
+                        listingActions={ [dismissAction] } />
                 );
             });
 

--- a/pkg/selinux/setroubleshoot.css
+++ b/pkg/selinux/setroubleshoot.css
@@ -49,3 +49,22 @@
     height: 100%;
     width: 100%;
 }
+
+/* warning icon for critical (level "red") setroubleshoot alerts */
+.listing-ct-item .fa-exclamation-triangle {
+    color: #c00;
+    vertical-align: middle;
+    font-size: 150%;
+}
+
+/* make sure the other columns don't spread out too much
+ * the warning icon might not even be present at all
+ */
+.listing-ct-item > th {
+    width: 100%;
+}
+
+/* remove padding from warning icon column */
+.listing-ct-item :nth-child(2) {
+    padding: 0;
+}

--- a/pkg/selinux/setroubleshoot.css
+++ b/pkg/selinux/setroubleshoot.css
@@ -68,3 +68,8 @@
 .listing-ct-item :nth-child(2) {
     padding: 0;
 }
+
+/* if we have an error at the top of the page, give it some space */
+div.alert-ct-top {
+    margin-top: 10px;
+}


### PR DESCRIPTION
These new features aren't supported by all setroubleshoot versions yet, but the code dynamically checks if they are present.

This is what level "red" alerts look like ("green" and "yellow" don't get an icon):
![screenshot from 2016-05-18 12-19-19](https://cloud.githubusercontent.com/assets/8711649/15355646/4c074172-1cf4-11e6-8e67-391d2a0cbfff.png)
If no alert has a warning icon, the "icon column" disappears.


This is what an error looks like when dismissal fails (on success it just disappears):
![screenshot from 2016-05-18 11-07-13](https://cloud.githubusercontent.com/assets/8711649/15355636/3f293de8-1cf4-11e6-8d9f-7892b9c5ab0d.png)
