### PR TITLE
add allowAnyScope to cockpit/kube openshift template

### DIFF
--- a/containers/openshift-cockpit.template
+++ b/containers/openshift-cockpit.template
@@ -160,6 +160,7 @@
         },
         "respondWithChallenges": false,
         "secret": "${OPENSHIFT_OAUTH_CLIENT_SECRET}",
+        "allowAnyScope": true,
         "redirectURIs": [
             "${COCKPIT_KUBE_URL}"
         ]


### PR DESCRIPTION
Fixes error `The OAuthClient "cockpit-oauth-client" is invalid.
scopeRestrictions: Required value: required when allowAnyScope is false` introduced by https://github.com/openshift/origin/pull/8848