### PR TITLE
guide: Clarify socket port setting

### DIFF
--- a/doc/guide/listen.xml
+++ b/doc/guide/listen.xml
@@ -39,6 +39,19 @@ ListenStream=
 ListenStream=443
 </programlisting>
 
+    <para>NOTE: The first empty line is intentional. <code>systemd</code> allows multiple <code>Listen</code> directives to be declared in a single socket unit. To change the activation port instead of adding a second port, use a full override unit instead of a snippet.</para>
+
+    <para>Cockpit can actually listen on multiple ports, also:</para>
+
+<programlisting>
+[Socket]
+ListenStream=
+ListenStream=443
+ListenStream=7777
+</programlisting>
+
+    <para>As above, it's recommended to start with an override unit, otherwise it's possible one of your multiple listen addresses might conflict.</para>
+
     <para>In order for the changes to take effect, run the following commands:</para>
 
 <programlisting>


### PR DESCRIPTION
* Easy to get caught out with the empty line if you're not familiar with systemd
* Add note about being able to listen on multiple ports. In testing running on multiple ports worked for me on

This also closes #4436, as because I wasn't setting an override unit, 9090 would conflict 👍 