### PR TITLE
Image refresh for fedora-testing

### DIFF
--- a/test/images/fedora-testing
+++ b/test/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-0d37a6316d78d8d0b370c1657836c1a3f96b4007.qcow2
+fedora-testing-0987689c0fc76b8d611530b9638db6c47cdd6358.qcow2


### PR DESCRIPTION
Image creation for fedora-testing in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-testing-2016-05-21/