### PR TITLE
Remove moment.js from the base package

### DIFF
--- a/pkg/base1/Makefile.am
+++ b/pkg/base1/Makefile.am
@@ -5,7 +5,6 @@ nodist_base_DATA = \
 	pkg/base1/cockpit.min.css.gz \
 	pkg/base1/require.min.js.gz \
 	pkg/base1/term.min.js.gz \
-	pkg/base1/moment.min.js.gz \
 	pkg/base1/mustache.min.js.gz \
 	pkg/base1/jquery.min.js.gz \
 	pkg/base1/cockpit.min.js.gz \
@@ -31,7 +30,6 @@ basedebug_DATA = \
 	pkg/base1/patterns.js \
 	pkg/base1/term.css \
 	pkg/base1/term.js \
-	pkg/base1/moment.js \
 	pkg/base1/mustache.js \
 	pkg/base1/jquery.js \
 	pkg/base1/react.js \
@@ -52,8 +50,6 @@ base_BUNDLE = \
 pkg/base1/bundle.min.js: $(base_BUNDLE)
 	$(AM_V_GEN) $(srcdir)/tools/missing $(srcdir)/tools/jsbundle $@ $^
 pkg/base1/jquery.min.js: pkg/base1/jquery.js
-	$(MIN_JS_RULE)
-pkg/base1/moment.min.js: pkg/base1/moment.js
 	$(MIN_JS_RULE)
 pkg/base1/mustache.min.js: pkg/base1/mustache.js
 	$(MIN_JS_RULE)
@@ -111,7 +107,6 @@ CLEANFILES += \
 	pkg/base1/cockpit.min.css \
 	pkg/base1/jquery.min.js \
 	pkg/base1/patterns.min.js \
-	pkg/base1/moment.min.js \
 	pkg/base1/mustache.min.js \
 	pkg/base1/react.min.js \
 	pkg/base1/require.min.js \
@@ -126,7 +121,6 @@ EXTRA_DIST += \
 	pkg/base1/jquery.min.js \
 	pkg/base1/require.min.js \
 	pkg/base1/mustache.min.js \
-	pkg/base1/moment.min.js \
 	pkg/base1/react.min.js \
 	pkg/base1/term.min.js \
 	pkg/base1/test-dbus-common.js \

--- a/pkg/base1/moment.js
+++ b/pkg/base1/moment.js
@@ -1,1 +1,0 @@
-../../bower_components/momentjs/moment.js

--- a/pkg/kubernetes/Makefile.am
+++ b/pkg/kubernetes/Makefile.am
@@ -86,6 +86,8 @@ pkg/kubernetes/angular.min.js: $(shared_ANGULAR)
 	$(MIN_JS_RULE)
 pkg/kubernetes/d3.min.js: pkg/kubernetes/d3.js
 	$(MIN_JS_RULE)
+pkg/kubernetes/moment.min.js: pkg/kubernetes/moment.js
+	$(MIN_JS_RULE)
 
 # Registry files
 
@@ -111,6 +113,7 @@ registry_MIN = \
 registry_BUNDLE = \
 	pkg/kubernetes/angular.min.js \
 	pkg/kubernetes/d3.min.js \
+	pkg/kubernetes/moment.min.js \
 	$(registry_MIN) \
 	pkg/kubernetes/registry-templates.js \
 	$(NULL)
@@ -234,6 +237,7 @@ kubernetes_MIN = \
 kubernetes_BUNDLE = \
 	pkg/kubernetes/angular.min.js \
 	pkg/kubernetes/d3.min.js \
+	pkg/kubernetes/moment.min.js \
 	$(kubernetes_MIN) \
 	pkg/kubernetes/kubernetes-templates.js \
 	$(NULL)
@@ -271,6 +275,7 @@ kubernetesdebug_DATA = \
 	pkg/kubernetes/kubernetes.js \
 	pkg/kubernetes/kubernetes.css \
 	pkg/kubernetes/index.html \
+	pkg/kubernetes/moment.js \
 	pkg/kubernetes/registry.js \
 	pkg/kubernetes/registry.css \
 	pkg/kubernetes/registry.html \
@@ -294,6 +299,7 @@ CLEANFILES += \
 	pkg/kubernetes/d3.min.js \
 	pkg/kubernetes/kubernetes.min.css\
 	pkg/kubernetes/index.min.html \
+	pkg/kubernetes/moment.min.js \
 	pkg/kubernetes/kubernetes.min.js \
 	pkg/kubernetes/kubernetes-templates.js \
 	pkg/kubernetes/registry.min.css \
@@ -312,6 +318,7 @@ EXTRA_DIST += \
 	pkg/kubernetes/index.min.html \
 	pkg/kubernetes/kubernetes.min.js \
 	pkg/kubernetes/kubernetes-templates.js \
+	pkg/kubernetes/moment.min.js \
 	pkg/kubernetes/registry.min.css \
 	pkg/kubernetes/registry.min.html \
 	pkg/kubernetes/registry.min.js \

--- a/pkg/kubernetes/index.html
+++ b/pkg/kubernetes/index.html
@@ -25,7 +25,6 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="../base1/cockpit.css">
   <link rel="stylesheet" href="kubernetes.css">
-  <script src="../base1/moment.js"></script>
   <script src="../base1/cockpit.js"></script>
   <script src="../base1/term.js"></script>
   <script src="kubernetes.js"></script>
@@ -36,6 +35,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   <script src="angular.js"></script>
   <script src="angular-route.js"></script>
   <script src="d3.js"></script>
+  <script src="moment.js"></script>
   <script src="ui-bootstrap.js"></script>
   <script src="ui-bootstrap-tpls.js"></script>
   <script src="scripts/kube-client.js"></script>

--- a/pkg/kubernetes/moment.js
+++ b/pkg/kubernetes/moment.js
@@ -1,0 +1,1 @@
+../../bower_components/momentjs/moment.js

--- a/pkg/kubernetes/registry.html
+++ b/pkg/kubernetes/registry.html
@@ -27,7 +27,6 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 <link rel="stylesheet" href="../base1/cockpit.css">
 <link rel="stylesheet" href="registry.css">
 
-<script src="../base1/moment.js"></script>
 <script src="../base1/cockpit.js"></script>
 <script src="registry.js"></script>
 
@@ -37,6 +36,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 <script src="angular.js"></script>
 <script src="angular-route.js"></script>
 <script src="d3.js"></script>
+<script src="moment.js"></script>
 <script src="ui-bootstrap.js"></script>
 <script src="ui-bootstrap-tpls.js"></script>
 <script src="scripts/connection.js"></script>

--- a/pkg/ostree/Makefile.am
+++ b/pkg/ostree/Makefile.am
@@ -15,6 +15,7 @@ ostreedebug_DATA = \
 	pkg/ostree/ostree.css \
 	pkg/ostree/app.js \
 	pkg/ostree/client.js \
+	pkg/ostree/moment.js \
 	pkg/ostree/ostree.js \
 	pkg/ostree/index.html \
 	$(NULL)
@@ -32,9 +33,12 @@ pkg/ostree/angular.min.js: $(ostree_ANGULAR)
 ostree_BUNDLE = \
 	pkg/ostree/angular.min.js \
 	pkg/ostree/client.min.js \
+	pkg/ostree/moment.min.js \
 	pkg/ostree/app.min.js \
 	$(NULL)
 
+pkg/ostree/moment.min.js: pkg/ostree/moment.js
+	$(MIN_JS_RULE)
 pkg/ostree/ostree.min.js: $(ostree_BUNDLE)
 	$(AM_V_GEN) $(srcdir)/tools/missing $(srcdir)/tools/jsbundle $@ $^
 
@@ -42,6 +46,7 @@ CLEANFILES += \
 	pkg/ostree/angular.min.js \
 	pkg/ostree/ostree.min.css \
 	pkg/ostree/index.min.html \
+	pkg/ostree/moment.min.js \
 	pkg/ostree/ostree.min.js \
 	$(ostree_BUNDLE) \
 	$(nodist_ostree_DATA) \
@@ -50,6 +55,7 @@ CLEANFILES += \
 EXTRA_DIST += \
 	pkg/ostree/angular.min.js \
 	pkg/ostree/index.min.html \
+	pkg/ostree/moment.min.js \
 	pkg/ostree/ostree.min.js \
 	pkg/ostree/ostree.min.css \
 	$(ostree_BUNDLE) \

--- a/pkg/ostree/app.js
+++ b/pkg/ostree/app.js
@@ -3,7 +3,7 @@
 require([
     "jquery",
     "base1/cockpit",
-    "base1/moment",
+    "updates/moment",
     "translated!shell/po",
     "updates/client",
 ], function($, cockpit, moment, po, client) {

--- a/pkg/ostree/moment.js
+++ b/pkg/ostree/moment.js
@@ -1,0 +1,1 @@
+../../bower_components/momentjs/moment.js


### PR DESCRIPTION
We're working on stabilizing the API, and this isn't part of it. Future work will fix up the bundling into the single page applications.
