### PR TITLE
tools: Have make-source clean out tmp-dist directory

### DIFF
--- a/tools/make-source
+++ b/tools/make-source
@@ -31,17 +31,16 @@ cd $base/..
 # the source has already been configured in-tree (a Makefile that is not the
 # redirect Makefile exists).
 if test ! -f Makefile || grep --quiet --no-messages "^REDIRECT" Makefile; then
-  if [ ! -f tmp-dist/Makefile ]; then
-      mkdir -p tmp-dist
-      if [ -f .tarball ]; then
+    rm -rf tmp-dist
+    mkdir -p tmp-dist
+    if [ -f .tarball ]; then
         (cd tmp-dist && ../configure) 1>&2
-      else
+    else
         (cd tmp-dist && NOREDIRECTMAKEFILE=t ../autogen.sh) 1>&2
-      fi
-  fi
-  builddir=tmp-dist
+    fi
+    builddir=tmp-dist
 else
-  builddir=.
+    builddir=.
 fi
 
 make -C $builddir --silent dist-gzip distdir=cockpit-wip 1>&2


### PR DESCRIPTION
When major changes to the build system occur, such as changes
in Makefile.am files, often the verify machines fail to
keep up due to things already built in the tmp-dist directory.

This makes things more reliable in those cases.

In cases where ./configure or ./autogen.sh has been called
manually elsewhere, this should have no effect. In other words
it should not affect developers, or increase their time to get
test instances prepared.

Developers have to deal with these cases anyway by running
'make clean' in their repository.