### PR TITLE
Fix race in check-networking with ignore-auto-dns

### DIFF
--- a/test/verify/check-networking
+++ b/test/verify/check-networking
@@ -157,7 +157,7 @@ class TestNetworking(MachineCase):
         b.click("#network-ip-settings-dialog button:contains('Apply')")
         b.wait_popdown("network-ip-settings-dialog")
 
-        self.assertIn("yes", m.execute("nmcli -f ipv4.ignore-auto-dns connection show TEST"))
+        wait(lambda: "yes" in m.execute("nmcli -f ipv4.ignore-auto-dns connection show TEST"))
 
     def testBond(self):
         b = self.browser


### PR DESCRIPTION
Seems like there's a race in check-networting where the NetworkManager
settings aren't always applied immediately.