### PR TITLE
cockpit.format_number() returns empty string for undefined

### DIFF
--- a/doc/guide/cockpit-util.xml
+++ b/doc/guide/cockpit-util.xml
@@ -40,23 +40,54 @@ array = cockpit.format_bytes(number, [factor, separate])
 
     <para>If the <code>number</code> is less than the <code>factor</code> or an unknown factor
       was passed in, then the formatted number is returned without a suffix. If <code>separate</code>
-      is true, returns an array of <code>[formatted_number, suffix]</code> unless no suffix is returned.</para>
+      is true, returns an array of <code>[formatted_number, suffix]</code> or
+      <code>[formatted_number]</code> if returned without a suffix.</para>
+  </refsection>
+
+  <refsection id="cockpit-format-number">
+    <title>cockpit.format_number()</title>
+<programlisting>
+string = cockpit.format_number(number)
+</programlisting>
+    <para>Formats <code>number</code> into a displayable <code>string</code>. If the number is not
+      an integer, it is rounded to a single decimal place precision. If the number is near zero, but
+      not quite zero it is rounded up or down to a single decimal place.</para>
   </refsection>
 
   <refsection>
     <title>cockpit.format_bytes_per_sec()</title>
 <programlisting>
- string = cockpit.format_bytes_per_sec(number)
+ string = cockpit.format_bytes_per_sec(number, [factor])
+ array = cockpit.format_bytes_per_sec(number, [factor, separate])
 </programlisting>
     <para>Format <code>number</code> of bytes into a displayable speed <code>string</code>.</para>
+
+    <para>If specifying 1000 or 1024 is specified as a <code>factor</code> then an appropriate suffix
+      will be chosen. By default the <code>factor</code> is 1024.  You can pass a string suffix as a
+      <code>factor</code> in which case the resulting number will be formatted with the same suffix.</para>
+
+    <para>If the <code>number</code> is less than the <code>factor</code> or an unknown factor
+      was passed in, then the formatted number is returned without a suffix. If <code>separate</code>
+      is true, returns an array of <code>[formatted_number, suffix]</code> or
+      <code>[formatted_number]</code> if returned without a suffix.</para>
   </refsection>
 
   <refsection>
     <title>cockpit.format_bits_per_sec()</title>
 <programlisting>
-  string = cockpit.format_bits_per_sec(number)
+  string = cockpit.format_bits_per_sec(number, [factor])
+ array = cockpit.format_bytes_per_sec(number, [factor, separate])
 </programlisting>
     <para>Format <code>number</code> of bits into a displayable speed <code>string</code>.</para>
+
+    <para>If specifying 1000 or 1024 is specified as a <code>factor</code> then an appropriate suffix
+      will be chosen. By default the <code>factor</code> is 1024.  You can pass a string suffix as a
+      <code>factor</code> in which case the resulting number will be formatted with the same suffix.</para>
+
+    <para>If the <code>number</code> is less than the <code>factor</code> or an unknown factor
+      was passed in, then the formatted number is returned without a suffix. If <code>separate</code>
+      is true, returns an array of <code>[formatted_number, suffix]</code> or
+      <code>[formatted_number]</code> if returned without a suffix.</para>
   </refsection>
 
   <refsection id="cockpit-info">

--- a/doc/guide/cockpit-util.xml
+++ b/doc/guide/cockpit-util.xml
@@ -42,6 +42,9 @@ array = cockpit.format_bytes(number, [factor, separate])
       was passed in, then the formatted number is returned without a suffix. If <code>separate</code>
       is true, returns an array of <code>[formatted_number, suffix]</code> or
       <code>[formatted_number]</code> if returned without a suffix.</para>
+
+    <para>If <code>number</code> is <code>null</code> or <code>undefined</code> an empty string or
+      an array without a suffix will be returned.</para>
   </refsection>
 
   <refsection id="cockpit-format-number">
@@ -52,6 +55,9 @@ string = cockpit.format_number(number)
     <para>Formats <code>number</code> into a displayable <code>string</code>. If the number is not
       an integer, it is rounded to a single decimal place precision. If the number is near zero, but
       not quite zero it is rounded up or down to a single decimal place.</para>
+
+    <para>If <code>number</code> is <code>null</code> or <code>undefined</code> an empty string
+      will be returned.</para>
   </refsection>
 
   <refsection>
@@ -70,6 +76,9 @@ string = cockpit.format_number(number)
       was passed in, then the formatted number is returned without a suffix. If <code>separate</code>
       is true, returns an array of <code>[formatted_number, suffix]</code> or
       <code>[formatted_number]</code> if returned without a suffix.</para>
+
+    <para>If <code>number</code> is <code>null</code> or <code>undefined</code> an empty string or array
+      will be returned.</para>
   </refsection>
 
   <refsection>
@@ -88,6 +97,9 @@ string = cockpit.format_number(number)
       was passed in, then the formatted number is returned without a suffix. If <code>separate</code>
       is true, returns an array of <code>[formatted_number, suffix]</code> or
       <code>[formatted_number]</code> if returned without a suffix.</para>
+
+    <para>If <code>number</code> is <code>null</code> or <code>undefined</code> an empty string or array
+      will be returned.</para>
   </refsection>
 
   <refsection id="cockpit-info">

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -1336,7 +1336,9 @@ function basic_scope(cockpit, jquery) {
         /* TODO: Make the decimal separator translatable */
 
         /* only show as integer if we have a natural number */
-        if (number % 1 === 0)
+        if (!number && number !== 0)
+            return "";
+        else if (number % 1 === 0)
             return number.toString();
         else
             return number.toFixed(1);
@@ -1345,16 +1347,22 @@ function basic_scope(cockpit, jquery) {
     function format_units(number, suffixes, factor, separate) {
         var quotient;
         var suffix = null;
+        var key, keys;
+        var divisor;
+        var y, x, i;
 
         /* Find that factor string */
-        if (typeof (factor) === "string") {
+        if (!number && number !== 0) {
+            suffix = null;
+
+        } else if (typeof (factor) === "string") {
             /* Prefer larger factors */
-            var keys = [];
-            for (var key in suffixes)
+            keys = [];
+            for (key in suffixes)
                 keys.push(key);
             keys.sort().reverse();
-            for (var y = 0; y < keys.length; y++) {
-                for (var x = 0; x < suffixes[keys[y]].length; x++) {
+            for (y = 0; y < keys.length; y++) {
+                for (x = 0; x < suffixes[keys[y]].length; x++) {
                     if (factor == suffixes[keys[y]][x]) {
                         number = number / Math.pow(keys[y], x);
                         suffix = factor;
@@ -1367,8 +1375,8 @@ function basic_scope(cockpit, jquery) {
 
         /* @factor is a number */
         } else if (factor in suffixes) {
-            var divisor = 1;
-            for (var i = 0; i < suffixes[factor].length; i++) {
+            divisor = 1;
+            for (i = 0; i < suffixes[factor].length; i++) {
                 quotient = number / divisor;
                 if (quotient < factor) {
                     number = quotient;
@@ -1380,10 +1388,9 @@ function basic_scope(cockpit, jquery) {
         }
 
         var string_representation = cockpit.format_number(number);
-
         var ret;
 
-        if (suffix)
+        if (string_representation && suffix)
             ret = [string_representation, suffix];
         else
             ret = [string_representation];

--- a/pkg/base1/test-format.html
+++ b/pkg/base1/test-format.html
@@ -64,7 +64,9 @@ test("format_number", function () {
         [ 123.0, "123" ],
         [ 123.01, "123.0" ],
         [ -123.0, "-123" ],
-        [ -123.01, "-123.0" ]
+        [ -123.01, "-123.0" ],
+        [ null, "" ],
+        [ undefined, "" ],
     ];
 
     expect(checks.length);
@@ -94,6 +96,8 @@ test("format_bytes", function() {
         [ 2000000, "KiB", "1953.1 KiB" ],
         [ 1, "KB", "0.1 KB" ],
         [ 0, "KB", "0 KB" ],
+        [ undefined, "KB", "" ],
+        [ null, "KB", "" ],
     ];
 
     var i, split;


### PR DESCRIPTION
If the number input is undefined we these formatting functions return an empty string. This is for formatting displayable output and this is appropriate display behavior in this case, rather than throwing cryptic exceptions.
    
This affects cockpit.format_number(), cockpit.format_bytes(), cockpit.format_bytes_per_sec(), and cockpit.format_bits_per_sec().
    
If callers wish to handle this case differently from the default behavior they should do so before or after calling these methods.