### PR TITLE
test: Fix check-storage-mdraid race with broad selector

### DIFF
--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -97,7 +97,7 @@ class TestStorage(StorageCase):
         self.dialog_wait_close()
         b.wait_in_text("#mdraids", "ARR")
 
-        b.click('tr:contains("ARR")')
+        b.click('#mdraids tr:contains("ARR")')
         b.wait_visible('#storage-detail')
 
         self.wait_states({ "QEMU QEMU HARDDISK (DISK1)": "In Sync",


### PR DESCRIPTION
This should just match in the #mdraids section.