### PR TITLE
kubernetes: Keep the dateRelative generated times fresh

### DIFF
--- a/pkg/kubernetes/scripts/date.js
+++ b/pkg/kubernetes/scripts/date.js
@@ -22,15 +22,46 @@
 (function() {
     "use strict";
 
-    angular.module('kubernetes.date', [])
+    angular.module('kubernetes.date', [
+        "kubeClient"
+    ])
 
-    .filter('dateRelative', function() {
-        return function(timestamp) {
-            if (!timestamp) {
-                return timestamp;
+    .factory('refreshEveryMin', [
+        "$rootScope",
+        "$window",
+        "kubeLoader",
+        function($rootScope, $window, loader) {
+            var last = 0;
+            var interval = 60000;
+            var tol = 500;
+
+            loader.listen(function() {
+                last = (new Date()).getTime();
+            });
+
+            $window.setInterval(function() {
+                var now = (new Date()).getTime();
+                if ((now - last) + tol >= interval)
+                    $rootScope.$applyAsync();
+                last = now;
+            }, interval);
+
+            return {};
+        }
+    ])
+
+    .filter('dateRelative', [
+        "refreshEveryMin",
+        function() {
+            function dateRelative(timestamp) {
+                if (!timestamp) {
+                    return timestamp;
+                }
+                return moment(timestamp).fromNow();
             }
-            return moment(timestamp).fromNow();
-        };
-    });
+            dateRelative.$stateful = true;
+            return dateRelative;
+        }
+    ]);
 
 }());

--- a/pkg/kubernetes/scripts/nodes.js
+++ b/pkg/kubernetes/scripts/nodes.js
@@ -25,6 +25,7 @@
     angular.module('kubernetes.nodes', [
         'ngRoute',
         'kubeClient',
+        'kubernetes.date',
         'kubernetes.listing',
         'kubeUtils',
         'ui.cockpit',

--- a/pkg/kubernetes/scripts/registry.js
+++ b/pkg/kubernetes/scripts/registry.js
@@ -28,6 +28,7 @@
         'ui.bootstrap',
         'ui.bootstrap.popover',
         'kubernetes.app',
+        'kubernetes.date',
         'registry.images',
         'registry.projects',
         'registry.policy',

--- a/pkg/kubernetes/scripts/volumes.js
+++ b/pkg/kubernetes/scripts/volumes.js
@@ -25,6 +25,7 @@
     angular.module('kubernetes.volumes', [
         'ngRoute',
         'kubeClient',
+        'kubernetes.date',
         'kubernetes.listing',
         'ui.cockpit',
     ])

--- a/pkg/kubernetes/tests/test-nodes.html
+++ b/pkg/kubernetes/tests/test-nodes.html
@@ -31,6 +31,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <script src="../scripts/kube-client.js"></script>
     <script src="../scripts/kube-client-cockpit.js"></script>
     <script src="../scripts/listing.js"></script>
+    <script src="../scripts/date.js"></script>
     <script src="../scripts/dialog.js"></script>
     <script src="../scripts/nodes.js"></script>
     <script src="../scripts/charts.js"></script>

--- a/pkg/kubernetes/tests/test-volumes.html
+++ b/pkg/kubernetes/tests/test-volumes.html
@@ -31,6 +31,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <script src="../scripts/kube-client.js"></script>
     <script src="../scripts/kube-client-cockpit.js"></script>
     <script src="../scripts/listing.js"></script>
+    <script src="../scripts/date.js"></script>
     <script src="../scripts/dialog.js"></script>
     <script src="../scripts/volumes.js"></script>
     <script src="../scripts/utils.js"></script>


### PR DESCRIPTION
I don't really like having to do this, but without it our relative dates get stale. It's especially noticeable on newly created items. The alternative might be to always round to the nearest day.