### PR TITLE
debian: also depend on upstream docker package

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -95,7 +95,7 @@ Description: Cockpit Shell user interface package
 Package: cockpit-docker
 Architecture: amd64 armel armhf i386
 Depends: ${misc:Depends},
-         docker.io (>= 1.3.0)
+         docker.io (>= 1.3.0) | docker-engine (>= 1.3.0)
 Description: Cockpit user interface for Docker containers
  The Cockpit components for interacting with Docker and user interface.
  This package is not yet complete.


### PR DESCRIPTION
The docker package depends on the 'docker.io' upstream debian package.
Allow 'docker-engine' as an alternate package name, which is the name of
the package in the repository on dockerproject.org.

Thanks to msl09 for this suggestion.