### PR TITLE
Image refresh for fedora-atomic

### DIFF
--- a/test/images/fedora-atomic
+++ b/test/images/fedora-atomic
@@ -1,1 +1,0 @@
-fedora-atomic-36ca3cfde61459f42cd759bd5ffe6b539cdfbc49.qcow2


### PR DESCRIPTION
Image creation for fedora-atomic in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-atomic-2016-05-24/