### PR TITLE
test: Add known storaged issue to fedora-24

### DIFF
--- a/test/verify/naughty-fedora-24/4181-confused-storaged
+++ b/test/verify/naughty-fedora-24/4181-confused-storaged
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-storage-luks", line 56, in testLuks
+    b.wait_in_text("#content", "unlocked")


### PR DESCRIPTION
The fix in storaged 2.5.1 actually made this worse.