### PR TITLE
kubernetes: Style the node charts to match up with wireframes

### DIFF
--- a/pkg/kubernetes/styles/nodes.less
+++ b/pkg/kubernetes/styles/nodes.less
@@ -25,6 +25,10 @@ div.nodes-delete ul li {
         height: 90px;
     }
 
+    ul.chart-legend {
+        margin-top: 30px;
+    }
+
     li.chart-legend-item {
         float: left;
         display: inline;
@@ -47,11 +51,12 @@ div.nodes-delete ul li {
     flex-basis: 33%;
 
     #os-counts-graph {
-        height: 90px;
+        height: 150px;
     }
 
     h2 {
         text-align: center;
+        margin-bottom: 0;
     }
 
     @media (min-width: 992px) {


### PR DESCRIPTION
As a followup to #4415, this brings the page closer to the wireframes.