### PR TITLE
Update the CSS for on-off to hide inactive text

### DIFF
--- a/pkg/base1/cockpit.css
+++ b/pkg/base1/cockpit.css
@@ -374,6 +374,10 @@ a {
     background-color: white;
 }
 
+.btn-onoff-ct .btn {
+    color: transparent !important;
+}
+
 .btn-onoff-ct .btn:first-child {
     border-bottom-left-radius: 3px;
     border-top-left-radius: 3px;
@@ -389,7 +393,7 @@ a {
 
 .btn-onoff-ct .btn.active {
     background-color: #0086CF;
-    color: white;
+    color: white !important;
 }
 
 .btn-onoff-ct .btn.disabled {


### PR DESCRIPTION
Don't show both 'On' and 'Off'. Use a look more like patternfly
where only the currently selected option is shown.