### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-0e00fa937434f2910c56e6928d54752df16ff87b.qcow2
+debian-unstable-a0b7b03326d36adf8672e6cb4eed57fd0e5f2ae1.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-05-26/