### PR TITLE
base1: Add cockpit.hidden and cockpit.onvisibilitychange

### DIFF
--- a/doc/guide/cockpit-location.xml
+++ b/doc/guide/cockpit-location.xml
@@ -155,5 +155,32 @@ cockpit.jump(path, [ host ])
         currently displayed, then the jump will not happen, and this function has no effect.</para>
     </refsection>
 
+    <refsection id="cockpit-jump-hidden">
+      <title>cockpit.hidden</title>
+
+      <para>A boolean property that indicates if the current component page is visible or hidden.
+        When the code or user jumps to another component, the prior one remains loaded and initialized
+        but is hidden. Use this property together with the
+        <link linkend="cockpit-jump-visibilitychange"><code>cockpit.onvisibilitychange</code></link>
+        event to decide whether or not to perform expensive tasks to update the interface.</para>
+
+      <para>This property is analogous to the <code>document.hidden</code> page visibility API, but
+        works with the document and frame implementation of Cockpit.</para>
+    </refsection>
+
+    <refsection id="cockpit-jump-visibilitychange">
+      <title>cockpit.onvisibilitychange</title>
+
+<programlisting>
+cockpit.onvisibilitychange = function() { ... }
+</programlisting>
+
+      <para>This event is emitted when the
+        <link linkend="cockpit-jump-hidden"><code>cockpit.hidden</code></link> property changes.
+        This event is similar to the <code>document.onvisibilitychange</code> API, but works with
+        the document and frame implementation of Cockpit.</para>
+
+    </refsection>
+
   </refsection>
 </refentry>

--- a/pkg/base1/test-chan.html
+++ b/pkg/base1/test-chan.html
@@ -163,7 +163,7 @@ test("public api", function() {
     equal(typeof channel.close, "function", "channel.close() is a function");
     strictEqual(channel.valid, true, "channel.valid is set");
     equal(typeof cockpit.logout, "function", "cockpit.logout is a function");
-    equal(typeof cockpit.transport, "object", "cockpit.transport is a function");
+    equal(typeof cockpit.transport, "object", "cockpit.transport is an object");
     equal(typeof cockpit.transport.close, "function", "cockpit.transport.close is a function");
     equal(typeof cockpit.transport.options, "object", "cockpit.transport.options is a object");
 

--- a/pkg/playground/test.html
+++ b/pkg/playground/test.html
@@ -36,6 +36,8 @@
           <button class="btn btn-default" id="delete-file">Delete /tmp/counter</button>
         </div>
         <textarea id="edit-file"></textarea>
+        <br/>
+        Visibility: <label id="hidden"></label>
     </div>
 </body>
 </html>

--- a/pkg/playground/test.js
+++ b/pkg/playground/test.js
@@ -119,5 +119,12 @@ require([
         });
 
         $("body").show();
+
+        function show_hidden() {
+            $("#hidden").text(cockpit.hidden ? "hidden" : "visible");
+        }
+
+        $(cockpit).on("visibilitychange", show_hidden);
+        show_hidden();
     });
 });

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -90,6 +90,16 @@ WantedBy=default.target
         b.switch_to_top()
         b.wait_js_cond("window.location.hash == '#/0/1?length=1'")
 
+        # This should be visible now
+        b.switch_to_frame("cockpit1:localhost/playground/test")
+        b.wait_text("#hidden", "visible")
+
+        # This should now say invisible
+        b.switch_to_top()
+        b.go("/@localhost/system/services")
+        b.switch_to_frame("cockpit1:localhost/playground/test")
+        b.wait_text("#hidden", "hidden")
+
         self.allow_journal_messages("Failed to get realtime timestamp: Cannot assign requested address")
 
     def testFrameReload(self):


### PR DESCRIPTION
We want components to have notification and info on whether they
are in the foreground and visible, or not. For components that
need to do polling of some sort, this is vital.

I would like to have used document.hidden and document.onvisibilitychange.
Unfortunately the latter do not act correctly with iframes. This is
explicit documented design choice.

So similar to how we have cockpit.location and friends, we now have
analogs cockpit.hidden and cockpit.onvisibilitychange

 * [x] Actually test that this works
 * [x] Integration tests
 * [x] Documentation