### PR TITLE
base1: change the important css rules for on/off buttons

### DIFF
--- a/pkg/base1/cockpit.css
+++ b/pkg/base1/cockpit.css
@@ -375,7 +375,7 @@ a {
 }
 
 .btn-onoff-ct .btn {
-    color: transparent !important;
+    color: transparent;
 }
 
 .btn-onoff-ct .btn:first-child {
@@ -393,11 +393,12 @@ a {
 
 .btn-onoff-ct .btn.active {
     background-color: #0086CF;
-    color: white !important;
+    color: white;
 }
 
 .btn-onoff-ct .btn.disabled {
     pointer-events: none;
+    color: transparent !important;
 }
 
 .btn-onoff-ct .btn.active.disabled {


### PR DESCRIPTION
Patternfly only brings down the big !important rules hammer on the
disabled classes, so it's better to only apply !important on the
disabled classes that we need to override in Cockpit for the
on/off widget.