### PR TITLE
kubernetes: Tolerate variations of json content types

### DIFF
--- a/pkg/kubernetes/scripts/kube-client-cockpit.js
+++ b/pkg/kubernetes/scripts/kube-client-cockpit.js
@@ -703,7 +703,8 @@
                         }
 
                         var headers = response.headers || { };
-                        if (headers[CONTENT_TYPE] == JSON_TYPE) {
+                        var content_type = headers[CONTENT_TYPE] || headers[CONTENT_TYPE.toLowerCase()] || "";
+                        if (content_type.lastIndexOf(JSON_TYPE, 0) === 0) {
                             try {
                                 response.data = JSON.parse(response.data);
                             } catch (ex) {


### PR DESCRIPTION
Valid content-types can include a charset. 

Also some servers lower case their headers when they really shouldn't but we don't need to be that strict.