### PR TITLE
branding: Don't hide the login hint on RHEL

### DIFF
--- a/branding/rhel/branding.css
+++ b/branding/rhel/branding.css
@@ -28,8 +28,3 @@ body.login-pf {
     content: "${NAME}";
     font-weight: bold;
 }
-
-.login-note {
-    color: transparent;
-    position: relative;
-}


### PR DESCRIPTION
Previously we used to display other text here, but now we
can just show the default text.