### PR TITLE
Allow running vm-install against a running machine

### DIFF
--- a/test/vm-install
+++ b/test/vm-install
@@ -33,6 +33,7 @@ if __name__ == "__main__":
     parser.add_argument('-B', '--build-only', action='store_true', help='Only build and download results')
     parser.add_argument('-I', '--install-only', action='store_true', help='Only upload and install')
     parser.add_argument('-c', '--containers', action='store_true', help='Install container images')
+    parser.add_argument('--address', help='Address of already running machine')
     parser.add_argument('image', nargs='?', default=testinfra.DEFAULT_IMAGE, help='The image to use')
     args = parser.parse_args()
 
@@ -40,7 +41,7 @@ if __name__ == "__main__":
     build_image = not args.install_only and (args.build_image or args.image)
     try:
         vmmanage.build_and_install(install_image, build_image, args={"verbose": args.verbose, "sit": args.sit, "quick": args.quick, "build_image": args.build_image,
-                                                            "build_only": args.build_only, "install_only": args.install_only, "containers": args.containers})
+            "build_only": args.build_only, "install_only": args.install_only, "containers": args.containers, "address": args.address})
     except Exception as e:
         print e
         sys.exit(1)


### PR DESCRIPTION
By specifying vm-install --address you can make the install (after
a build) go to a specific running VM or machine.