### PR TITLE
Add a feature page to the guide for SELinux

### DIFF
--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -31,6 +31,7 @@ GUIDE_INCLUDES = \
 	doc/guide/feature-ostree.xml \
 	doc/guide/feature-pcp.xml \
 	doc/guide/feature-realmd.xml \
+	doc/guide/feature-selinux.xml \
 	doc/guide/feature-sosreport.xml \
 	doc/guide/feature-storaged.xml \
 	doc/guide/feature-subscription.xml \

--- a/doc/guide/cockpit-guide.xml
+++ b/doc/guide/cockpit-guide.xml
@@ -44,6 +44,7 @@
     <xi:include href="feature-subscription.xml"/>
     <xi:include href="feature-kubernetes.xml"/>
     <xi:include href="feature-machines.xml"/>
+    <xi:include href="feature-selinux.xml"/>
     <xi:include href="feature-tuned.xml"/>
     <xi:include href="feature-sosreport.xml"/>
     <xi:include href="feature-ostree.xml"/>

--- a/doc/guide/feature-selinux.xml
+++ b/doc/guide/feature-selinux.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
+	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
+<chapter id="feature-selinux">
+  <title>SELinux Policy</title>
+
+  <para>If present on the system Cockpit can set the SELinux mode to enforcing or permissive.
+    It can also use <code>setroubleshootd</code> to show audit issues and apply suggested
+    fixes.</para>
+
+  <para>To perform similar tasks from the command line use the <code>setenforce</code> and
+    <code>sealert</code> tools.</para>
+
+  <para>To clear out all the information that <code>setroubleshootd</code> tracks, you
+    can use a commands like:</para>
+
+<programlisting>
+$ <command>sudo killall setroubleshootd</command>
+$ <command>sudo rm -rf /var/lib/setroubleshoot/*</command>
+</programlisting>
+
+</chapter>


### PR DESCRIPTION
This is pretty basic to start, but it was missing and should
be there.