### PR TITLE
tools: Fix make-source running from a developer checkout

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -244,6 +244,9 @@ endif
 install-data-local:: install-doc-local
 	@true
 
+print-%:
+	@echo $($*)
+
 # Subdirectories to distribute everything that's committed to git
 COMMITTED_DIST = \
 	bower_components/ \

--- a/tools/make-source
+++ b/tools/make-source
@@ -28,9 +28,8 @@ base=$(cd $(dirname $0); pwd -P)
 cd $base/..
 
 # Configure the source for making a tarball in a temporary directory, unless
-# the source has already been configured in-tree (a Makefile that is not the
-# redirect Makefile exists).
-if test ! -f Makefile || ! grep --quiet --no-messages "^REDIRECT" Makefile; then
+# the source has already been configured
+if test ! -f Makefile; then
     rm -rf tmp-dist
     mkdir -p tmp-dist
     if [ -f .tarball ]; then
@@ -44,5 +43,5 @@ else
 fi
 
 make -C $builddir --silent dist-gzip distdir=cockpit-wip 1>&2
-
-echo $PWD/$builddir/cockpit-wip.tar.gz
+directory=$(make -C $builddir --silent print-abs_builddir)
+echo $directory/cockpit-wip.tar.gz

--- a/tools/make-source
+++ b/tools/make-source
@@ -30,7 +30,7 @@ cd $base/..
 # Configure the source for making a tarball in a temporary directory, unless
 # the source has already been configured in-tree (a Makefile that is not the
 # redirect Makefile exists).
-if test ! -f Makefile || grep --quiet --no-messages "^REDIRECT" Makefile; then
+if test ! -f Makefile || ! grep --quiet --no-messages "^REDIRECT" Makefile; then
     rm -rf tmp-dist
     mkdir -p tmp-dist
     if [ -f .tarball ]; then


### PR DESCRIPTION
One of the conditions for rerunning autogen.sh in tmp-dist
was inverted