### PR TITLE
build: Remove auto tools dependency in specfile

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -52,7 +52,6 @@ BuildRequires: pkgconfig(json-glib-1.0)
 BuildRequires: pkgconfig(polkit-agent-1) >= 0.105
 BuildRequires: pam-devel
 
-BuildRequires: autoconf automake
 BuildRequires: intltool
 BuildRequires: libssh-devel >= %{libssh_version}
 BuildRequires: openssl-devel


### PR DESCRIPTION
This was a leftover from the old way we built/released.
The tarballs now shouldn't require autoconf or automake to build.