### PR TITLE
Update .gitignore for build stragglers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ depcomp
 /cockpit.8
 /cockpit.service
 /cockpit.conf.5
+/cockpit-*.xz
 /*.js
 /containers/*/rpms
 /cockpit.service
@@ -62,6 +63,8 @@ depcomp
 /test/kdc
 /cockpit-session
 /cockpit-stub
+/cockpit-kube-auth
+/cockpit-kube-launch
 /test-session
 /cockpit-bridge
 /remotectl
@@ -126,7 +129,7 @@ org.freedesktop.UDisks2.h
 /pkg/base1/fonts/*.gz
 /pkg/base1/po.js.gz
 /po/po.*.js
-/po/po.*.js.gz
+po*.js.gz
 /.vagrant
 /test_rsa_key
 /tmp-dist


### PR DESCRIPTION
These show up when building in tree.