### PR TITLE
kuberenetes: Solve loading races that results in stale data

### DIFF
--- a/pkg/kubernetes/tests/test-projects.html
+++ b/pkg/kubernetes/tests/test-projects.html
@@ -108,7 +108,7 @@ function suite(fixtures) {
             rolesArray = projectUtil.getAllRoles();
             equal(rolesArray.length, 0, "no values passed 2");
             rolesArray = projectUtil.getAllRoles(user.one(), "financeprj")
-            equal(rolesArray.length, 2, "values passed");
+            equal(rolesArray.length, 3, "values passed");
 
             var regRolesArray = projectUtil.getRegistryRoles(user.one(), "financeprj")
             equal(regRolesArray[0], "Admin", "getRegistryRoles displayRole values");


### PR DESCRIPTION
We have a race between the other ways we load data ei KubeMethods callbacks and watchers, where sometimes we end up keeping the older data. For example if a putResource callback is called after the watchers had already gotten further updates for the item we just saved, the newer data is lost. This causes the data to be stale and is causing test flakes as well.

This assumes that 1) resourceVersion is going to be a number and 2) newer items will have greater numbers than older ones . Although this matches the current kubernetes implementation they don't explicitly make these guarantees in their documentation. We do already sort on resourceVersion in the registry but obviously this is relying on it in a much greater way.

There are probably other ways to solve this but that will probably involve cordinating between the various loading code paths which could get tricky to get right and prone to races.