### PR TITLE
kubernetes: Run tests after policy data loads

### DIFF
--- a/pkg/kubernetes/tests/test-projects.html
+++ b/pkg/kubernetes/tests/test-projects.html
@@ -54,17 +54,26 @@ function suite(fixtures) {
     ])
 
     function projectsTest(name, count, fixtures, func) {
-        test(name, function() {
+        asyncTest(name, function() {
             expect(count);
+
             inject([
                 "kubeLoader",
-                function(loader, data) {
+                "kubeSelect",
+                "projectPolicy",
+                function(loader, select, pol, data) {
                     loader.reset(true);
                     if (fixtures)
                         loader.handle(fixtures);
+
+                    var interval = window.setInterval(function () {
+                        if (select().kind("RoleBinding").length == 6) {
+                            window.clearInterval(interval);
+                            inject(func);
+                        }
+                    }, 10);
                 }
             ]);
-            inject(func);
         });
     }
 
@@ -82,6 +91,7 @@ function suite(fixtures) {
             var group = select().kind("Group").name("finance");
             equal(projectUtil.formatMembers(user.one().groups, 'Users'),
                 "4 Users", "number of users");
+            start();
         }
     ]);
 
@@ -106,9 +116,10 @@ function suite(fixtures) {
             equal(regRolesArray.length, 0, "no values passed 3 ");
             regRolesArray = projectUtil.getRegistryRoles();
             equal(regRolesArray.length, 0, "no values passed 4");
-         
+
             equal(projectUtil.isRegistryRole(user.one(), "Admin", "financeprj"), true, "check if registry role");
             equal(projectUtil.isRoles(user.one(), "financeprj"), true, "check if any role exist");
+            start();
         }
     ]);
 
@@ -214,7 +225,7 @@ suite([
             "userNames": null,
             "groupNames": null,
             "subjects": [
-              
+
             ],
             "roleRef": {
               "name": "admin"
@@ -351,7 +362,7 @@ suite([
             "userNames": null,
             "groupNames": null,
             "subjects": [
-              
+
             ],
             "roleRef": {
               "name": "view"


### PR DESCRIPTION
Because projectPolicy listens on loader and then loads more objects, wait for that load to finish before starting the tests. The reason this test wasn't flaking is that in both cases the rolesArray.length happened to be 2 even though there it was actually returning different objects ["admin", "registry-admin"] in one case and ["edit", "registry-admin"] in the other.