### PR TITLE
verify: Force a time sync before joining a domain

### DIFF
--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -178,6 +178,9 @@ for x in 1 2 3 4 5 6 7 8 9 10; do
         sleep $x
     fi
 done
+
+ntpdate %(addr)s
+
 if ! echo '%(password)s' | realm join -U admin cockpit.lan; then
     journalctl -u realmd.service
 fi


### PR DESCRIPTION
Normally this would happen after joining the domain, at some point
when ntpd gets around to it. However because our tests are agressive
this can conflict with us trying to use kerberos as a service
and the time jumping around during that test.