### PR TITLE
test: Known issue for GSS_S_CONTINUE_NEEDED

### DIFF
--- a/test/verify/naughty/4538-gss-continue-needed
+++ b/test/verify/naughty/4538-gss-continue-needed
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "./verify/check-realms", line 232, in testNegotiate
+    self.assertIn("HTTP/1.1 200 OK", output)


### PR DESCRIPTION
Unfortunately there isn't a good way to detect if it failed for a different reason. Since this is pretty much the only way this test fails, the test is essentially skipped. If we do decide to merge this we probably need to make sure it doesn't stay in for too long.