### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-a0b7b03326d36adf8672e6cb4eed57fd0e5f2ae1.qcow2
+debian-unstable-0b9230f824ebf1677ef3ad70c34275a7efd05704.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-06-02/