### PR TITLE
test: Make testpulltask standalone

### DIFF
--- a/test/common/testpulltask.py
+++ b/test/common/testpulltask.py
@@ -1,3 +1,22 @@
+#!/usr/bin/env python
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
 import os
 import subprocess
 import sys
@@ -100,10 +119,11 @@ class GithubPullTask(object):
             return False
         return True
 
-    def rebase(self):
+    def rebase(self, offline=False):
         try:
             sys.stderr.write("Rebasing onto origin/master ...\n")
-            subprocess.check_call([ "git", "fetch", "origin", "master" ])
+            if not offline:
+                subprocess.check_call([ "git", "fetch", "origin", "master" ])
             if self.sink:
                 master = subprocess.check_output([ "git", "rev-parse", "origin/master" ]).strip()
                 self.sink.status["master"] = master
@@ -188,7 +208,8 @@ class GithubPullTask(object):
         if cmd and opts.verbose:
             cmd.append("--verbose")
 
-        ret = ret or self.rebase()
+        offline = ('offline' in opts) and opts.offline
+        ret = ret or self.rebase(offline)
 
         # Actually run the tests
         if not ret:
@@ -200,3 +221,5 @@ class GithubPullTask(object):
         # All done
         if self.sink:
             self.stop_publishing(ret)
+
+        return ret

--- a/test/github-task
+++ b/test/github-task
@@ -42,19 +42,26 @@ def main():
                         help='Instead of choosing from GitHub, refresh the given image')
     parser.add_argument('--except', dest='except_context', action='store_true',
                         help='Choose tasks from any context except the one specified')
+    parser.add_argument('-n', '--name', dest='name',
+                        default='pull', help='Name of the testing task, used for the identifier. Examples: "master", "pull-1234"')
+    parser.add_argument('-o', '--offline', action='store_true',
+                        help='Work offline, don''t fetch new data from origin for rebase')
     parser.add_argument('context', action='store', nargs='?',
                         help='The test context to choose tasks from')
     opts = parser.parse_args()
 
     os.chdir(os.path.dirname(__file__))
-    github = testinfra.GitHub()
+
+    # only instantiate a GitHub object if we aren't working offline
+    github = None if opts.offline else testinfra.GitHub()
 
     # When letting github decide what to test
     if opts.head:
         name = "test"
         revision = subprocess.check_output([ "git", "rev-parse", "HEAD" ]).strip()
         context = opts.context or "verify/" + testinfra.DEFAULT_IMAGE
-        task = testpulltask.GithubPullTask("test", revision, None, context)
+        name = opts.name or "test"
+        task = testpulltask.GithubPullTask(name, revision, None, context)
     elif opts.refresh:
         image = opts.refresh
         config = testinfra.DEFAULT_IMAGE_REFRESH.get(image, None)
@@ -63,6 +70,9 @@ def main():
             return 1
         task = testimagetask.GithubImageTask("refresh-" + image, image, config, None)
     else:
+        if opts.offline:
+            print "Unable to contact GitHub in offline mode"
+            return 1
         sys.stderr.write("Talking to GitHub ...\n")
         task_entries = github.scan(opts.publish, opts.context, opts.except_context)
         if len(task_entries) > 0:
@@ -70,9 +80,11 @@ def main():
         else: # Nothing to test
             return 1
 
-    task.run(opts, github)
-
-    return 0
+    ret = task.run(opts, github)
+    if isinstance(ret, basestring):
+        print ret
+        return 1
+    return ret
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
For automated testing we want to use test pull requests as a standalone
task without communicating with GitHub.
As a side effect, this makes it easier to run the tests while developing.