### PR TITLE
vagrant: Fix version check failing

### DIFF
--- a/tools/fail.html
+++ b/tools/fail.html
@@ -1,0 +1,1 @@
+../src/common/fail.html

--- a/tools/git-version-check
+++ b/tools/git-version-check
@@ -26,5 +26,5 @@ if [ "${VERSION%.x}" = "${TAG%.x}" ]; then
 else
     echo "git-version-check: installed cockpit does not match sources: $VERSION != $TAG"
     MESSAGE="The installed version of cockpit is incompatible with the sources"
-    sed "s/@@message@@/$MESSAGE/g" "$BASE/../src/common/fail.html" > $OVERRIDE
+    sed "s/@@message@@/$MESSAGE/g" "$BASE/fail.html" > $OVERRIDE
 fi


### PR DESCRIPTION
By moving fail.html into a location that is actually synched into the
virtual machine.