### PR TITLE
Add --verbose argument to koji run-tests

### DIFF
--- a/test/koji/run-build
+++ b/test/koji/run-build
@@ -33,6 +33,7 @@ from common import testinfra
 
 def main():
     parser = argparse.ArgumentParser(description='Run cockpit build and unit tests in Koji')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output (unsupported)')
     opts = parser.parse_args()
 
     directory = tempfile.mkdtemp(prefix="koji-dist.", dir=os.path.join(testinfra.TEST_DIR, "tmp"))


### PR DESCRIPTION
The github-task command wants to run things this way when the
verify machines run this task.

We don't yet do anything with this argument. There doesn't seem
to be a simple way to pass an argument to 'koji build' which
just dumps all the build logs to the output.