### PR TITLE
Simpler building of SRPM

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -317,8 +317,9 @@ install-data-local:: doc/guide/html/index.html
 uninstall-local::
 	rm -rf $(DESTDIR)$(htmldir)
 
-print-%:
-	@echo $($*)
+# See tools/make-source
+dump-dist-gzip:
+	@echo "$(abs_builddir)/$(distdir).tar.gz"
 
 # Subdirectories to distribute everything that's committed to git
 COMMITTED_DIST = \

--- a/test/images/scripts/lib/debian.install
+++ b/test/images/scripts/lib/debian.install
@@ -40,11 +40,11 @@ if [ -n "$do_build" ]; then
     mkdir build-results
     resultdir=$PWD/build-results
 
-    ln -sf cockpit-wip.tar.gz cockpit_0.orig.tar.gz
+    ln -sf cockpit-*.tar.gz cockpit_0.orig.tar.gz
 
-    rm -rf cockpit-wip
-    tar -xzf cockpit-wip.tar.gz
-    ( cd cockpit-wip
+    rm -rf cockpit-*/
+    tar -xzf cockpit-*.tar.gz
+    ( cd cockpit-*/
       cp -rp tools/debian debian
       debuild -S -uc -us
     )

--- a/test/images/scripts/lib/make-srpm
+++ b/test/images/scripts/lib/make-srpm
@@ -4,16 +4,16 @@ set -eu
 
 tar=$1
 
-version=$(echo $1 | sed -n 's|.*cockpit-\([^ -/]\+\)\.tar\..*|\1|p')
+version=$(echo "$1" | sed -n 's|.*cockpit-\([^ -/]\+\)\.tar\..*|\1|p')
 if [ -z "$version" ]; then
     echo "make-srpm: couldn't parse version from tarball: $1"
     exit 2
 fi
 
+# We actually modify the spec so that the srpm is standalone buildable
 modify_spec() {
-sed -e "1i\
+sed -e "/^Version:.*/d" -e "1i\
 %define wip wip\nVersion: $version\n"
-    -e "/^Version:.*/d"
 }
 
 tmpdir=$(mktemp -d $PWD/srpm-build.XXXXXX)

--- a/test/images/scripts/lib/make-srpm
+++ b/test/images/scripts/lib/make-srpm
@@ -11,20 +11,13 @@ if [ -z "$version" ]; then
 fi
 
 modify_spec() {
-case $version in
-wip)
-sed '1i\
-%define gitcommit wip'
-;;
-*)
-sed "1i\
-Version: $version"
-esac
+sed -e "1i\
+%define wip wip\nVersion: $version\n"
+    -e "/^Version:.*/d"
 }
 
 tmpdir=$(mktemp -d $PWD/srpm-build.XXXXXX)
 tar xaf "$1" -O cockpit-$version/tools/cockpit.spec | modify_spec > $tmpdir/cockpit.spec
-
 
 rpmbuild -bs \
          --quiet \

--- a/test/koji/run-build
+++ b/test/koji/run-build
@@ -36,27 +36,15 @@ def main():
     parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output (unsupported)')
     opts = parser.parse_args()
 
-    directory = tempfile.mkdtemp(prefix="koji-dist.", dir=os.path.join(testinfra.TEST_DIR, "tmp"))
-    os.chdir(directory)
-
     # Converts fedora-23 to f23
     system = testinfra.DEFAULT_IMAGE[0] + testinfra.DEFAULT_IMAGE.split("-")[-1]
 
-    # Don't overwrite a Makefile in autogen.sh
-    env = os.environ.copy()
-    env["NOREDIRECTMAKEFILE"] = "1"
+    make_srpm = os.path.join(testinfra.TEST_DIR, "..", "tools", "make-srpm")
+    srpm = subprocess.check_output([make_srpm], shell=True).strip()
 
-    # Make a distribution
-    try:
-        subprocess.check_call(["../../../autogen.sh && make dist"], shell=True, env=env)
-        archives = subprocess.check_output(["make", "-s", "print-DIST_ARCHIVES"]).strip().split(" ")
-
-        # Do a build
-        subprocess.check_call(["../../../tools/make-srpm", archives[0]])
-        cmd = ["koji", "build", "--wait", "--scratch", system, glob.glob("*.src.rpm")[0]]
-        subprocess.check_call(cmd)
-    finally:
-        shutil.rmtree(directory)
+    # Do a build
+    cmd = ["koji", "build", "--wait", "--scratch", system, srpm]
+    subprocess.check_call(cmd)
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -9,16 +9,11 @@
 #
 # Globals that may be defined elsewhere
 #  * Version 122
-#  * gitcommit xxxx
+#  * wip 1
 #
 
-%if %{defined gitcommit}
-%define extra_flags CFLAGS='-O2 -Wall -Werror -fPIC -g -DWITH_DEBUG'
-%define required_base %{gitcommit}
-%else
 # earliest base that the subpackages work on
 %define required_base 122
-%endif
 
 %if 0%{?centos}
 %define rhel 0
@@ -32,20 +27,17 @@
 %endif
 
 Name:           cockpit
-%if %{defined gitcommit}
-Version:        %{gitcommit}
-%else
-Version:        wip
-%endif
-Release:        1%{?dist}
 Summary:        A user interface for Linux servers
 
 License:        LGPLv2+
 URL:            http://cockpit-project.org/
 
-%if %{defined gitcommit}
+Version:        0
+%if %{defined wip}
+Release:        1.%{wip}%{?dist}
 Source0:        cockpit-%{version}.tar.gz
 %else
+Release:        1%{?dist}
 Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{version}/cockpit-%{version}.tar.xz
 %endif
 
@@ -71,11 +63,8 @@ BuildRequires: glib2-devel >= 2.37.4
 BuildRequires: systemd-devel
 BuildRequires: polkit
 BuildRequires: pcp-libs-devel
-BuildRequires: gdb
-
-%if %{defined gitcommit}
 BuildRequires: krb5-server
-%endif
+BuildRequires: gdb
 
 # For documentation
 BuildRequires: xmlto
@@ -174,7 +163,7 @@ make -j4 check
 
 %install
 make install DESTDIR=%{buildroot}
-%if %{defined gitcommit} || 0%{?rhel}
+%if %{defined wip} || 0%{?rhel}
 make install-test-assets DESTDIR=%{buildroot}
 %else
 rm -rf %{buildroot}/%{_datadir}/%{name}/playground
@@ -246,7 +235,7 @@ touch docker.list
 %endif
 
 %ifarch x86_64
-%if %{defined gitcommit}
+%if %{defined wip}
 %else
 rm %{buildroot}/%{_datadir}/%{name}/kubernetes/override.json
 %endif
@@ -278,12 +267,7 @@ cat subscriptions.list sosreport.list networkmanager.list selinux.list >> shell.
 # https://fedoraproject.org/wiki/PackagingDrafts/Go
 %global _dwz_low_mem_die_limit 0
 
-# Only strip out debug info in non wip builds
-%if %{defined gitcommit}
-%define find_debug_info %{nil}
-%else
 %define find_debug_info %{_rpmconfigdir}/find-debuginfo.sh %{?_missing_build_ids_terminate_build:--strict-build-id} %{?_include_minidebuginfo:-m} %{?_find_debuginfo_dwz_opts} %{?_find_debuginfo_opts} "%{_builddir}/%{?buildsubdir}"
-%endif
 
 # Redefine how debug info is built to slip in our extra debug files
 %define __debug_install_post   \
@@ -543,7 +527,7 @@ cluster. Installed on the Kubernetes master. This package is not yet complete.
 %endif
 
 # we only build test assets on rhel or if we're building from a specific commit
-%if %{defined gitcommit} || 0%{?rhel}
+%if %{defined wip} || 0%{?rhel}
 
 %package test-assets
 Summary: Additional stuff for testing Cockpit

--- a/tools/make-source
+++ b/tools/make-source
@@ -27,6 +27,10 @@ base=$(cd $(dirname $0); pwd -P)
 
 cd $base/..
 
+dump_dist_gzip() {
+    make -C "$1" -s dump-dist-gzip
+}
+
 # Configure the source for making a tarball in a temporary directory, unless
 # the source has already been configured
 if test ! -f Makefile; then
@@ -42,6 +46,5 @@ else
     builddir=.
 fi
 
-make -j8 -C $builddir --silent V=1 dist-gzip distdir=cockpit-wip 1>&2
-directory=$(make -C $builddir --silent print-abs_builddir)
-echo $directory/cockpit-wip.tar.gz
+make -j8 -C $builddir --silent dist-gzip 1>&2
+make -C "$builddir" --silent dump-dist-gzip


### PR DESCRIPTION
This further simplifies the building of SRPM and make-source. Cleans up test/koji/run-tests as well. Follows on from the work that @larsu did to use real tarballs when running integration tests.
