### PR TITLE
test: Fix RHEL testing dependencies

### DIFF
--- a/test/images/scripts/rhel-7.setup
+++ b/test/images/scripts/rhel-7.setup
@@ -85,8 +85,8 @@ sssd \
 
 TEST_PACKAGES="\
 systemtap-runtime-virtguest \
-valgrind
-gdb
+valgrind \
+gdb \
 "
 
 # enable epel for mock and avocado


### PR DESCRIPTION
The linebreaks weren't properly escaped in 274569972c970e5009a8fa048dcf1bb72db0d527