### PR TITLE
shell: Fix response when connecting to untrusted host

### DIFF
--- a/pkg/shell/machine-dialogs.js
+++ b/pkg/shell/machine-dialogs.js
@@ -554,7 +554,7 @@ define([
                 inner.fail(function(ex) {
                     if ((ex.problem == "invalid-hostkey" ||
                         ex.problem == "unknown-hostkey") &&
-                        !machine.on_disk) {
+                        machine && !machine.on_disk) {
                             dialog.machines_ins.change(dialog.address, {
                                 'host_key': null
                             });


### PR DESCRIPTION
In the javascript code, the machine object can be null.

I got an Ooops while trying to connect to a second host.