### PR TITLE
test: Only run firewall-cmd when its installed

### DIFF
--- a/test/images/scripts/lib/fedora.install
+++ b/test/images/scripts/lib/fedora.install
@@ -60,7 +60,9 @@ if [ -n "$do_install" ]; then
     packages=$(find build-results -name "*.rpm" -not -name "*.src.rpm" | grep -vF "$skip")
     rpm -U --force $packages
 
-    firewall-cmd --add-service=cockpit --permanent
+    if type firewall-cmd > /dev/null 2> /dev/null; then
+        firewall-cmd --add-service=cockpit --permanent
+    fi
 
     rm -rf /var/log/journal/*
     rm -rf /var/lib/NetworkManager/dhclient-*.lease


### PR DESCRIPTION
This makes the install script more useful against arbitrary
machines. That is test/vm-install --address X.Y.Z.A