### PR TITLE
base: More debug info when receiving message before init

### DIFF
--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -573,7 +573,7 @@ function Transport() {
         if (waiting_for_init) {
             waiting_for_init = false;
             if (data.command != "close" || data.channel) {
-                console.error ("received message before init");
+                console.error("received message before init: ", data.command);
                 data = { "problem": "protocol-error" };
             }
             self.close(data);


### PR DESCRIPTION
This happens sometimes during testing. This should make it
easier to reason about.