### PR TITLE
test: Make vm-install work correctly for fedora-24

### DIFF
--- a/test/vm-install
+++ b/test/vm-install
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     install_image = not args.build_only and args.image
     build_image = not args.install_only and (args.build_image or args.image)
     try:
-        vmmanage.build_and_install(install_image, build_image, args={"verbose": args.verbose, "sit": args.sit, "quick": args.quick, "build_image": args.build_image,
+        vmmanage.build_and_install(install_image, build_image, args={"verbose": args.verbose, "sit": args.sit, "quick": args.quick, "build_image": build_image,
             "build_only": args.build_only, "install_only": args.install_only, "containers": args.containers, "address": args.address})
     except Exception as e:
         print e


### PR DESCRIPTION
The build_image in args needed to be populated correctly or
the build will fail for the default image type.