### PR TITLE
test: Ignore unexpected SELinux denial of /proc/net/unix

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -542,6 +542,10 @@ class MachineCase(unittest.TestCase):
         # https://bugzilla.redhat.com/show_bug.cgi?id=1298171
         "type=1400 .*denied.*comm=\"iptables\".*name=\"xtables.lock\".*",
 
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1242656
+        "type=1400 .*denied.*comm=\"cockpit-ws\".*name=\"unix\".*dev=\"proc\".*",
+        "type=1400 .*denied.*comm=\"ssh-transport-c\".*name=\"unix\".*dev=\"proc\".*",
+
         # https://bugzilla.redhat.com/show_bug.cgi?id=1299054
         "type=1400 .*denied.*comm=\"rhsmcertd-worke\".*name=\".dbenv.lock\".*",
 


### PR DESCRIPTION
This is a failure that seems to happen for no reason in
Fedora 24 and later. Neither Cockpit or libssh accesses this
file explicitly. As far as I can tell, neither do any systemd
libraries that we load.

I'd like to figure this out. Once we have a reply from SELinux
upstream for how to get a backtrace on this denial we can start
to diagnose the issue further.

https://bugzilla.redhat.com/show_bug.cgi?id=1242656