### PR TITLE
bridge: Fix race in test-setup /commit/passwd1... tests

### DIFF
--- a/src/bridge/test-setup.c
+++ b/src/bridge/test-setup.c
@@ -289,6 +289,8 @@ test_commit_passwd1 (TestCase *tc,
   gchar *contents;
 
   cockpit_bridge_path_passwd = SRCDIR "/src/bridge/mock-setup/remote-passwd";
+  cockpit_bridge_path_group = SRCDIR "/src/bridge/mock-setup/remote-group";
+  cockpit_bridge_path_shadow = SRCDIR "/src/bridge/mock-setup/remote-shadow";
   cockpit_bridge_path_newusers = SRCDIR "/src/bridge/mock-setup/newusers";
   cockpit_bridge_path_chpasswd = SRCDIR "/src/bridge/mock-setup/chpasswd";
   cockpit_bridge_path_usermod = SRCDIR "/src/bridge/mock-setup/usermod";
@@ -354,6 +356,8 @@ test_commit_passwd1_no_crypt_method (TestCase *tc,
    */
 
   cockpit_bridge_path_passwd = SRCDIR "/src/bridge/mock-setup/remote-passwd";
+  cockpit_bridge_path_group = SRCDIR "/src/bridge/mock-setup/remote-group";
+  cockpit_bridge_path_shadow = SRCDIR "/src/bridge/mock-setup/remote-shadow";
   cockpit_bridge_path_newusers = SRCDIR "/src/bridge/mock-setup/newusers";
   cockpit_bridge_path_chpasswd = SRCDIR "/src/bridge/mock-setup/chpasswd";
   cockpit_bridge_path_usermod = SRCDIR "/src/bridge/mock-setup/usermod";


### PR DESCRIPTION
These tests would only succeed when run in the right order after
other tests in the same binary. I've now fixed them so they run
on their own.

Marking as priority since this I've seen this cause the test suite to fail.