### PR TITLE
docker: Make the 'Change resource limits' dialog actually work

### DIFF
--- a/pkg/docker/Makefile.am
+++ b/pkg/docker/Makefile.am
@@ -24,6 +24,7 @@ dockerdebug_DATA = \
 	pkg/docker/image.js \
 	pkg/docker/index.html \
 	pkg/docker/mustache.js \
+	pkg/docker/patterns.js \
 	pkg/docker/overview.js \
 	pkg/docker/run.js \
 	pkg/docker/search.js \
@@ -39,6 +40,7 @@ docker_BUNDLE = \
 	pkg/docker/containers.min.js \
 	pkg/docker/image.min.js \
 	pkg/docker/mustache.min.js \
+	pkg/docker/patterns.min.js \
 	pkg/docker/overview.min.js \
 	pkg/docker/run.min.js \
 	pkg/docker/search.min.js \

--- a/pkg/docker/details.js
+++ b/pkg/docker/details.js
@@ -22,7 +22,8 @@ define([
     "base1/cockpit",
     "./mustache",
     "./docker",
-    "./util"
+    "./util",
+    "./patterns",
 ], function($, cockpit, Mustache, docker, util) {
     var _ = cockpit.gettext;
     var C_ = cockpit.gettext;
@@ -68,12 +69,9 @@ define([
                     self.cpu_priority.value = info.CpuPriority || undefined;
                 }).
                 find(".btn-primary").on("click", function() {
-                    self.client.change_memory_limit(self.container_id, self.memory_limit.value);
-                    var swap = self.memory_limit.value;
-                    if (!isNaN(swap))
-                        swap *= 2;
-                    self.client.change_swap_limit(self.container_id, swap);
-                    self.client.change_cpu_priority(self.container_id, self.cpu_priority.value);
+                    var mem = self.client.change_memory_limit(self.container_id, self.memory_limit.value);
+                    var cpu = self.client.change_cpu_priority(self.container_id, self.cpu_priority.value);
+                    $('#container-resources-dialog').dialog('promise', cockpit.all(mem, cpu));
                 });
 
             var commit = $('#container-commit-dialog')[0];

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -627,7 +627,7 @@
           <button class="btn btn-default" translatable="yes" data-dismiss="modal">
             Cancel
           </button>
-          <button class="btn btn-primary" translatable="yes" data-dismiss="modal">
+          <button class="btn btn-primary" translatable="yes">
             Change
           </button>
         </div>

--- a/pkg/docker/patterns.js
+++ b/pkg/docker/patterns.js
@@ -1,0 +1,1 @@
+../../lib/patterns.js


### PR DESCRIPTION
Although this only affects a running container as you would sorta
expect ... it now actually works.

We fix how errors are displayed in the dialog and progress is
displayed.

Also fix races between changing the three settings.

We have to be careful in which order we set the memory and memory swap
limits. In particular when setting -1 we have to clear the swap
limit first, and then go for the memory limit.