### PR TITLE
docker: Fix race setting up max MemorySlider value

### DIFF
--- a/pkg/docker/util.js
+++ b/pkg/docker/util.js
@@ -353,9 +353,11 @@ define([
             set: function(v) {
                 var old_max = max;
                 max = v;
-                $(slider).
-                    prop("value", (slider.value*old_max) / max).
-                    trigger("change");
+                if (slider) {
+                    $(slider).
+                        prop("value", (slider.value * old_max) / max).
+                        trigger("change");
+                }
             }
         });
 


### PR DESCRIPTION
This happens from time to time in the tests:

TypeError: undefined is not an object (evaluating 'c.value')