### PR TITLE
Fix breakage when make-srpm is called from a make target

### DIFF
--- a/tools/make-srpm
+++ b/tools/make-srpm
@@ -23,6 +23,13 @@ if [ $# -gt 1 ]; then
     exit 2
 fi
 
+# When running in an external make this breaks our use
+# of make in the make-srpm lib tool and make-source
+
+export MAKEFLAGS=
+export MAKELEVEL=
+export MFLAGS=
+
 base=$(cd $(dirname $0); pwd -P)
 
 if [ -z ${1-} ]; then


### PR DESCRIPTION
This is because we use the 'make' tool in make-source and make-srpm
in specific ways (such as with --silent) and we cannot let the
external make pass flags to the internal make.

This fixes the 'make kubernetes-container' target