### PR TITLE
Image refresh for fedora-atomic

### DIFF
--- a/test/images/fedora-atomic
+++ b/test/images/fedora-atomic
@@ -1,1 +1,1 @@
-fedora-atomic-fb64f8710ab25c4bb5626d030f342c8bb85adc1c.qcow2
+fedora-atomic-5d7a62bb1cc35de51d640426e6b1e3862b21f437.qcow2


### PR DESCRIPTION
Image creation for fedora-atomic in process on host32-rack06.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-atomic-2016-06-21/