### PR TITLE
Only support iSCSI when storaged can list sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,4 @@ Test*.log
 cockpit-wip.tar*
 Test*.png
 
+/pkg/storaged/override.json

--- a/configure.ac
+++ b/configure.ac
@@ -304,6 +304,20 @@ changequote([,])dnl
 
 AC_CHECK_FUNCS(fdwalk)
 
+# Storaged
+
+# HACK - Storaged before 2.5.3 doesn't tell us when it supports
+#        sessions, so we allow it to be switched off explicitly.
+#
+# https://github.com/storaged-project/storaged/pull/68
+
+AC_ARG_WITH(storaged-iscsi-sessions,
+            AC_HELP_STRING([--with-storaged-iscsi-sessions=yes/no],
+                           [Whether storaged supports listing iSCSI sessions]),
+            [],
+            [with_storaged_iscsi_sessions=yes])
+AC_SUBST(with_storaged_iscsi_sessions)
+
 # Address sanitizer
 
 AC_MSG_CHECKING([for asan flags])
@@ -475,6 +489,7 @@ AC_SUBST(PAM_LIBS)
 
 AC_OUTPUT([
 Makefile
+pkg/storaged/override.json
 doc/guide/version
 po/Makefile.in
 ])

--- a/pkg/storaged/Makefile.am
+++ b/pkg/storaged/Makefile.am
@@ -3,6 +3,7 @@ nodist_storaged_DATA = \
 	pkg/storaged/bundle.min.js.gz \
 	pkg/storaged/index.min.html.gz \
 	pkg/storaged/storage.min.css.gz \
+	pkg/storaged/override.json \
 	$(NULL)
 storaged_DATA = \
 	pkg/storaged/manifest.json \
@@ -80,5 +81,6 @@ EXTRA_DIST += \
 	pkg/storaged/index.min.html \
 	pkg/storaged/plot.min.css \
 	pkg/storaged/storage.min.css \
+	pkg/storaged/override.json.in \
 	$(storaged_BUNDLE) \
 	$(NULL)

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -363,8 +363,11 @@ define([
                                          client.manager_iscsi = proxy("Manager.ISCSI.Initiator", "Manager");
                                          wait_all([ client.manager_lvm2, client.manager_iscsi],
                                                   function () {
+                                                      var iscsi = (config.with_storaged_iscsi_sessions == "yes" &&
+                                                                   client.manager_iscsi.valid &&
+                                                                   client.manager_iscsi.SessionsSupported !== false);
                                                       client.features = { lvm2: client.manager_lvm2.valid,
-                                                                          iscsi: config.with_storaged_iscsi_sessions == "yes" && client.manager_iscsi.valid
+                                                                          iscsi: iscsi
                                                                         };
                                                       callback();
                                                   });

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -20,11 +20,16 @@
 define([
     "jquery",
     "base1/cockpit",
-    "storage/utils"
-], function($, cockpit, utils) {
+    "storage/utils",
+    "manifests"
+], function($, cockpit, utils, manifests) {
 
     /* STORAGED CLIENT
      */
+
+    var config = { };
+    if (manifests["storage"] && manifests["storage"]["config"])
+        config = manifests["storage"]["config"];
 
     var client = { };
 
@@ -359,7 +364,7 @@ define([
                                          wait_all([ client.manager_lvm2, client.manager_iscsi],
                                                   function () {
                                                       client.features = { lvm2: client.manager_lvm2.valid,
-                                                                          iscsi: client.manager_iscsi.valid
+                                                                          iscsi: config.with_storaged_iscsi_sessions == "yes" && client.manager_iscsi.valid
                                                                         };
                                                       callback();
                                                   });

--- a/pkg/storaged/override.json.in
+++ b/pkg/storaged/override.json.in
@@ -1,0 +1,5 @@
+{
+    "config": {
+        "with_storaged_iscsi_sessions": "@with_storaged_iscsi_sessions@"
+    }
+}

--- a/pkg/storaged/overview.js
+++ b/pkg/storaged/overview.js
@@ -36,13 +36,8 @@ define([
 
     function init_overview(client, jobs) {
 
-        function update_features() {
-            $('#vgroups').toggle(client.features.lvm2);
-            $('#iscsi-sessions').toggle(client.features.iscsi);
-        }
-
-        $(client.features).on("changed", update_features);
-        update_features();
+        $('#vgroups').toggle(client.features.lvm2);
+        $('#iscsi-sessions').toggle(client.features.iscsi);
 
         var mdraids_tmpl = $("#mdraids-tmpl").html();
         mustache.parse(mdraids_tmpl);

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -25,7 +25,6 @@ import parent
 from testlib import *
 from storagelib import *
 
-@unittest.skipIf("rhel-7" in os.environ.get("TEST_OS", ""), "No storaged-iscsi on RHEL-7.")
 @unittest.skipIf("centos" in os.environ.get("TEST_OS", ""), "No storaged-iscsi on CentOS.")
 @unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No storaged-iscsi on Debian.")
 class TestStorage(StorageCase):
@@ -33,6 +32,16 @@ class TestStorage(StorageCase):
         m = self.machine
         b = self.browser
         b.wait_timeout(120)
+
+        # rhel-7 is missing the iSCSI session API
+        if m.image == "rhel-7":
+            self.login_and_go("/storage")
+            # The optional parts of the UI have been configured
+            # properly before the page is shown, so we can now
+            # reliably check for the visibility of the iSCSI panel.
+            # It won't show up later asynchronously.
+            b.wait_not_visible("#iscsi-sessions")
+            return
 
         target_iqn = "iqn.2015-09.cockpit.lan"
         initiator_iqn = "iqn.2015-10.cockpit.lan"

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -153,7 +153,7 @@ The Cockpit Web Service listens on the network, and authenticates users.
 
 %build
 exec 2>&1
-%configure --disable-silent-rules --with-cockpit-user=cockpit-ws --with-branding=auto --with-selinux-config-type=etc_t
+%configure --disable-silent-rules --with-cockpit-user=cockpit-ws --with-branding=auto --with-selinux-config-type=etc_t %{?rhel:--without-storaged-iscsi-sessions}
 make -j4 %{?extra_flags} all
 
 %check


### PR DESCRIPTION
Depending on the patchlevel of libiscsi, storaged might or might not
be able to list iSCSI sessions.
