### PR TITLE
users: Fix tooltip when user isn't allowed to create accounts

### DIFF
--- a/pkg/shell/controls.js
+++ b/pkg/shell/controls.js
@@ -170,7 +170,8 @@ module.Slider = function Slider() {
 
 $(document).ready(setup_sliders);
 
-module.update_privileged_ui = function update_privileged_ui(perm, selector, denied_message) {
+// placement is optional, "top", "left", "bottom", "right"
+module.update_privileged_ui = function update_privileged_ui(perm, selector, denied_message, placement) {
     var allowed = (perm.allowed !== false);
     $(selector).each(function() {
         // preserve old title first time to use when allowed
@@ -180,16 +181,22 @@ module.update_privileged_ui = function update_privileged_ui(perm, selector, deni
                $(this).data(allowed_key) === false)
             $(this).data(allowed_key, $(this).attr('title') || "");
 
-        $(this).tooltip({ html: true });
-        if ($(this).hasClass("disabled") === allowed) {
-          $(this).toggleClass("disabled", !allowed)
-               .attr('data-original-title', null);
+        var options = { html: true };
+        if (placement)
+            options['placement'] = placement;
 
-          if (allowed)
-              $(this).attr('title', $(this).data(allowed_key));
-          else
-              $(this).attr('title', denied_message);
-          $(this).tooltip('fixTitle');
+        $(this).tooltip(options);
+
+        if ($(this).hasClass("disabled") === allowed) {
+            $(this).toggleClass("disabled", !allowed)
+                 .attr('data-original-title', null);
+
+            if (allowed)
+                $(this).attr('title', $(this).data(allowed_key));
+            else
+                $(this).attr('title', denied_message);
+
+            $(this).tooltip('fixTitle');
         }
     });
 };

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -42,7 +42,8 @@ function update_accounts_privileged() {
         ".accounts-privileged:not('.accounts-current-account')",
         cockpit.format(
             _("The user <b>$0</b> is not permitted to modify accounts"),
-            permission.user ? permission.user.name : '')
+            permission.user ? permission.user.name : ''),
+        "right"
     );
     $(".accounts-privileged").find("input")
         .attr('disabled', permission.allowed === false ||


### PR DESCRIPTION
This tooltip was overflowing to the top, so we now show it on the right.
Even with translations, this shouldn't overflow.

Bug https://bugzilla.redhat.com/show_bug.cgi?id=1340749

![screenshot from 2016-06-23 11-51-25](https://cloud.githubusercontent.com/assets/8711649/16299180/38e08f98-3939-11e6-91d2-b0f20a5d4dfe.png)