### PR TITLE
Increase the iSCSI iscsid and phantomjs timeouts

### DIFF
--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -31,9 +31,13 @@ class TestStorage(StorageCase):
     def testISCSI(self):
         m = self.machine
         b = self.browser
+        b.wait_timeout(120)
 
         target_iqn = "iqn.2015-09.cockpit.lan"
         initiator_iqn = "iqn.2015-10.cockpit.lan"
+
+        # Increase the iSCSI timeouts for heavy load during our testing
+        m.execute("""sed -i 's|^\(node\..*log.*_timeout = \).*|\\1 60|' /etc/iscsi/iscsid.conf""")
 
         # Setup a iSCSI target with authentication for discovery and join
         #


### PR DESCRIPTION
    These tests seem to timeout both at the iSCSI level with a
    message like 'iSCSI PDU timed out' and also while waiting
    for the dialog to complete.
