### PR TITLE
More selinux tweaks

### DIFF
--- a/pkg/selinux/selinux-client.js
+++ b/pkg/selinux/selinux-client.js
@@ -103,8 +103,24 @@ client.init = function(statusChangedCallback) {
         );
     };
 
-    refreshInfo();
-    window.setInterval(refreshInfo, pollingInterval);
+    var polling = null;
+
+    function setupPolling() {
+        if (cockpit.hidden) {
+            window.clearInterval(polling);
+            polling = null;
+        } else if (polling === null) {
+            polling = window.setInterval(refreshInfo, pollingInterval);
+            refreshInfo();
+        }
+    }
+
+    cockpit.addEventListener("visibilitychange", setupPolling);
+    setupPolling();
+
+    /* The first time */
+    if (polling === null)
+        refreshInfo();
 
     return status;
 };

--- a/pkg/selinux/selinux-client.js
+++ b/pkg/selinux/selinux-client.js
@@ -50,10 +50,12 @@ var status = {
  *   - enforcing:       boolean (current selinux mode of the system, false if permissive or selinux disabled)
  *   - configEnforcing: boolean (mode the system is configured to boot in, may differ from current mode)
  * errorMessage:    optional, if getting the status failed, here will be additional info
+ *
+ * Since we're screenscraping we need to run this in LC_ALL=C mode
  */
 client.init = function(statusChangedCallback) {
     var refreshInfo = function() {
-        cockpit.spawn(statusCommand, { err: 'message' }).then(
+        cockpit.spawn(statusCommand, { err: 'message', environ: [ "LC_ALL=C" ] }).then(
             function(output) {
                 /* parse output that looks like this:
                  *   SELinux status:                 enabled

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -189,5 +189,20 @@ class TestSelinux(MachineCase):
         # warning should disappear
         b.wait_not_in_text("div.selinux-policy-ct", "Setting deviates")
 
+        # Switch to another page
+        b.switch_to_top()
+        b.go("/system")
+        b.enter_page("/system")
+
+        # Now on another page change the status
+        m.execute("setenforce 0")
+
+        # Switch back into the page and we get the updated status
+        b.switch_to_top()
+        b.go("/selinux/setroubleshoot")
+        b.enter_page("/selinux/setroubleshoot")
+        b.wait_in_text(on_off_selector_active, "Off")
+        b.wait_in_text("div.selinux-policy-ct", "Setting deviates")
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Run sestatus with LC_ALL=C so we  can be sure to screenscrape it appropriately.

No polling in when component in the background.