### PR TITLE
guide: Clarify the API stability warnings in documentation

### DIFF
--- a/doc/guide/embedding.xml
+++ b/doc/guide/embedding.xml
@@ -7,13 +7,6 @@
   <para>Cockpit can be embedded in other web applications either as a whole or specific
     Cockpit components can be integrated.</para>
 
-  <warning>
-    <para>None of the following is stable at this time.</para>
-
-    <para>In addition, any APIs or behavior not explicitly documented here is an
-      internal API and can be changed at any time.</para>
-  </warning>
-
   <section id="embedding-full">
     <title>Embedding the Cockpit Interface</title>
 

--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -213,14 +213,9 @@ mypackage/test.min.js.gz
     <para>Cockpit has API available for writing packages. There is no API available
       for external callers to invoke via HTTP, REST or otherwise.</para>
 
-    <warning>
-      <para>Unless an API is explicitly marked as stable, it is unstable and can
-        be changed when Cockpit is upgraded.</para>
-    </warning>
-
     <para>API from various packages can be used to implement Cockpit packages. Each package
       listed here has some API available for use. Only the API explicitly documented should
-      be used. In some cases even though the API is available it is not (yet) stable.</para>
+      be used.</para>
 
     <itemizedlist>
       <listitem><para><link linkend="development">API Listing</link></para></listitem>


### PR DESCRIPTION
Now that the javascript API is stable, and the base1 package
is stable, we can clarify these warnings in the documentation.