### PR TITLE
Fix volumes page Angular track by errors

### DIFF
--- a/pkg/kubernetes/views/dashboard-page.html
+++ b/pkg/kubernetes/views/dashboard-page.html
@@ -80,7 +80,7 @@
                     <span class="pficon pficon-info"></span>
                     <a href="#{{ viewUrl('volumes', true) }}">
                         <span class="card-pf-aggregate-status-text">{{status.volumes.PendingClaims.length}}</span>
-                        <span class="card-pf-aggregate-status-text" translatable="yes">Pending Volume Claims</span>
+                        <span class="card-pf-aggregate-status-text" translatable="yes">pending volume claims</span>
                     </a>
                 </span>
             </p>

--- a/pkg/kubernetes/views/volumes-page.html
+++ b/pkg/kubernetes/views/volumes-page.html
@@ -21,7 +21,7 @@
             <th translatable="yes">Status</th>
         </tr>
     </thead>
-    <tbody ng-repeat-start="item in pvs track by item.metadata.name"
+    <tbody ng-repeat-start="item in pvs track by item.metadata.uid"
            ng-init="sid = item.metadata.name"
            data-id="{{ sid }}" ng-class="{ open: listing.expanded(sid) }">
         <tr ng-click="listing.activate(sid)" class="listing-ct-item">
@@ -62,7 +62,7 @@
             <th></th>
         </tr>
     </thead>
-    <tbody ng-repeat-start="item in pending track by item.metadata.name"
+    <tbody ng-repeat-start="item in pending track by item.metadata.uid"
            ng-init="sid = item.metadata.namespace + '/' + item.metadata.name"
            data-id="{{ sid }}">
         <tr ng-click="createPV(item)" class="listing-ct-item">

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -74,7 +74,11 @@ class VolumeTests(object):
         m.upload(["verify/files/mock-volume-tiny-app.json"], "/tmp")
         m.execute("kubectl create -f /tmp/mock-volume-tiny-app.json")
 
+        # By adding another volume claim more issues are found
+        m.execute("kubectl create namespace another && kubectl create --namespace=another -f /tmp/mock-volume-tiny-app.json")
+
         b.wait_present(".pvc-notice a")
+        b.wait_in_text(".pvc-notice a", "2 pending volume claims")
         b.click(".pvc-notice a")
         b.wait_present(".pvc-listing")
 
@@ -89,13 +93,12 @@ class VolumeTests(object):
         b.wait_not_in_text("modal-dialog .modal-body ul", "mock-volume-claim")
         b.click("modal-dialog button.btn-danger")
         b.wait_not_present("modal-dialog")
-        b.wait_not_present(".pvc-listing")
+        b.wait_not_present("tbody[data-id='default/mock-volume-claim']")
 
         m.execute("kubectl delete rc/mock-volume")
         m.upload(["verify/files/mock-volume-tiny-app.json"], "/tmp")
         m.execute("kubectl create -f /tmp/mock-volume-tiny-app.json")
 
-        b.wait_present(".pvc-listing")
         b.wait_present("tbody[data-id='default/mock-volume-claim']")
         b.wait_in_text("tbody[data-id='default/mock-volume-claim']", "5Gi")
         b.click("tbody[data-id='default/mock-volume-claim'] tr")
@@ -113,6 +116,8 @@ class VolumeTests(object):
         b.wait_not_present("modal-dialog")
 
         b.wait_present(".pv-listing tbody[data-id='pv1']")
+
+        m.execute("kubectl delete namespace another")
         b.wait_not_present(".pvc-listing")
 
     def testVolumes(self):


### PR DESCRIPTION
Since there can be duplicate item names in volume claims, we  should track by uid instead. Otherwise people get errors in the javascript console and the page fails.
