### PR TITLE
Image refresh for fedora-atomic

### DIFF
--- a/test/images/fedora-atomic
+++ b/test/images/fedora-atomic
@@ -1,1 +1,1 @@
-fedora-atomic-fb64f8710ab25c4bb5626d030f342c8bb85adc1c.qcow2
+fedora-atomic-21dd745a25fa50c5038e42eb034fd56bb38184f0.qcow2


### PR DESCRIPTION
Image creation for fedora-atomic in process on host37-rack09.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-atomic-2016-06-28/