### PR TITLE
systemd : fixes missing input check for systime.

### DIFF
--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -815,6 +815,7 @@ PageSystemInformationChangeSystime.prototype = {
         $('#systime-time-hours').on('input', enable_apply_button);
         $('#systime-date-input').on('input', enable_apply_button);
         $('#systime-timezones').on('change', enable_apply_button);
+        $('#change_systime').on('click', enable_apply_button);
         $('#systime-date-input').on('focusin', $.proxy(this, "store_date"));
         $('#systime-date-input').on('focusout', $.proxy(this, "restore_date"));
 
@@ -1095,17 +1096,18 @@ PageSystemInformationChangeSystime.prototype = {
     },
 
     check_input: function() {
-        var time_error = false;
         var date_error = false;
         var timezone_error = false;
         var new_date;
 
-        var hours = parseInt($('#systime-time-hours').val(), 10);
-        var minutes = parseInt($('#systime-time-minutes').val(), 10);
+        var hours = $('#systime-time-hours').val();
+        var minutes = $('#systime-time-minutes').val();
+        var time_error = !/^[0-9]+$/.test(hours.trim()) || !/^[0-9]+$/.test(minutes.trim());
 
-        if (isNaN(hours) || hours < 0 || hours > 23  ||
-            isNaN(minutes) || minutes < 0 || minutes > 59) {
-           time_error = true;
+        if (!time_error) {
+            hours = Number(hours);
+            minutes = Number(minutes);
+            time_error = hours < 0 || hours > 23 || minutes < 0 || minutes > 59;
         }
 
         new_date = new Date($("#systime-date-input").val());
@@ -1132,7 +1134,8 @@ PageSystemInformationChangeSystime.prototype = {
         $('#systime-time-minutes').toggleClass("has-error", ! time_error);
         $('#systime-date-input').toggleClass("has-error", ! date_error);
 
-        $('#systime-parse-error').parents('tr').toggle(time_error || date_error);
+        $('#systime-parse-error').parents('tr').toggleClass("has-error", time_error || date_error);
+        $('#systime-parse-error').toggle(time_error || date_error);
         $('#systime-timezone-error').parents('tr').toggle(timezone_error);
 
         if (time_error || date_error || timezone_error) {
@@ -1152,6 +1155,7 @@ PageSystemInformationChangeSystime.prototype = {
         $("#change_systime button span").text(text);
         $('#systime-manual-row, #systime-manual-error-row').toggle(manual_time);
         $('#systime-ntp-servers-row').toggle(ntp_time_custom);
+        $('#systime-parse-error').hide();
     },
 
     sync_ntp_servers: function() {


### PR DESCRIPTION
![screenshot from 2016-06-29 04-53-21](https://cloud.githubusercontent.com/assets/7456909/16442396/eca56386-3def-11e6-843f-c1716810d52c.png)
![screenshot from 2016-06-29 11-04-10](https://cloud.githubusercontent.com/assets/7456909/16442403/f32b39c4-3def-11e6-8320-fcab70c8dc67.png)

Some of the invalid hours and minutes inputs allowed now are: 21s ,12k, 45str etc.
Invalid hour input generally shows  "date exited with code 1" instead of "Invalid time format".
 