### PR TITLE
spec: Remove docker requirement in cockpit-shell

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -353,10 +353,6 @@ Provides: %{name}-subscriptions = %{version}-%{release}
 Requires: subscription-manager >= 1.13
 Provides: %{name}-networkmanager = %{version}-%{release}
 Requires: NetworkManager
-%ifarch x86_64 armv7hl
-Provides: %{name}-docker = %{version}-%{release}
-Requires: docker >= 1.3.0
-%endif
 %endif
 Provides: %{name}-assets
 Obsoletes: %{name}-assets < 0.32


### PR DESCRIPTION
The docker subpackage was split out for RHEL in
c7db01ce6ccb6bd24fd7dbcc30e7740edbf8a824.
Shell doesn't need to depend on docker anymore.

Bug https://bugzilla.redhat.com/show_bug.cgi?id=1349375