### PR TITLE
networkmanager: Use active-backup as default for new bonds

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1566,7 +1566,7 @@ PageNetworking.prototype = {
                 },
                 bond: {
                     options: {
-                        mode: "balance-rr"
+                        mode: "active-backup"
                     },
                     interface_name: iface
                 }


### PR DESCRIPTION
This is the safe choice.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1348066