### PR TITLE
systemd: Show full string for  Hardware info and OS name.

### DIFF
--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -169,6 +169,13 @@
     font-weight: bold;
 }
 
+#system_information_hardware_text,
+#system_information_os_text {
+    overflow: visible;
+    white-space: normal;
+    word-wrap: break-word;
+}
+
 @media (min-width: 500px) {
   .cockpit-modal-md {
     width: 400px;


### PR DESCRIPTION
The labels for hardware info and OS got cut at the end.
This was especially common on VMs running certain OS variants.
This change makes an exception for those two info labels.

Fixes issue #4314