### PR TITLE
tools: Use a UMD format for po2json files

### DIFF
--- a/pkg/shell/po.js
+++ b/pkg/shell/po.js
@@ -1,1 +1,7 @@
-define({"": { "language": "en" }});
+(function (root, data) {
+    if (typeof define === 'function' && define.amd) {
+        define(data);
+    } else {
+        root.po = data;
+    }
+}(this, {"": { "language": "en" }}));

--- a/tools/po2json
+++ b/tools/po2json
@@ -90,7 +90,7 @@ po2json.parseFile(input, { "fuzzy": true }, function(err, jsonData) {
     }
 
     if (module)
-        data = "define(" + data + ");";
+	data = "(function (root, data) { if (typeof define === 'function' && define.amd) { define(data); } else { root.po = data; } }(this, " + data + "));";
 
     fs.writeFile(output, data, function(err) {
         if (err)


### PR DESCRIPTION
This allows the PO files to be used by non-AMD modules. A global
po object is exported in this case.