### PR TITLE
test: Download images as they are needed rather than up front

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -64,6 +64,7 @@ opts.attachments = None
 opts.revision = None
 opts.address = None
 opts.jobs = 1
+opts.network = True
 
 def attach(filename):
     if not opts.attachments:
@@ -449,7 +450,7 @@ class MachineCase(unittest.TestCase):
         else:
             if not machine_class:
                 machine_class = testvm.VirtMachine
-            machine = machine_class(verbose=opts.trace, image=image, label=self.label())
+            machine = machine_class(verbose=opts.trace, image=image, label=self.label(), fetch=opts.network)
             self.addCleanup(lambda: machine.kill())
 
         self.machines.append(machine)
@@ -990,9 +991,11 @@ def arg_parser():
                         help='Thorough mode, no skipping known issues')
     parser.add_argument('-s', "--sit", dest='sit', action='store_true',
                         help="Sit and wait after test failure")
+    parser.add_argument('--nonet', dest="network", action="store_false",
+                        help="Don't go online to download images or data")
     parser.add_argument('tests', nargs='*')
 
-    parser.set_defaults(verbosity=1)
+    parser.set_defaults(verbosity=1, network=True)
     return parser
 
 def test_main(options=None, suite=None, attachments=None, **kwargs):

--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -38,6 +38,7 @@ import threading
 import time
 
 import testinfra
+import vmimages
 
 import xml.etree.ElementTree as etree
 
@@ -89,7 +90,7 @@ class RepeatableFailure(Failure):
     pass
 
 class Machine:
-    def __init__(self, address=None, image=None, verbose=False, label=None):
+    def __init__(self, address=None, image=None, verbose=False, label=None, fetch=True):
         self.verbose = verbose
 
         # Currently all images are x86_64. When that changes we will have
@@ -97,6 +98,7 @@ class Machine:
         self.arch = "x86_64"
 
         self.image = image or testinfra.DEFAULT_IMAGE
+        self.fetch = fetch
         self.vm_username = "root"
         self.address = address
         self.label = label or "UNKNOWN"
@@ -557,6 +559,7 @@ class Machine:
         Cockpit is not running when the test virtual machine starts up, to
         allow you to make modifications before it starts.
         """
+
         if "atomic" in self.image:
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1228776
             # we want to run:
@@ -1058,6 +1061,9 @@ class VirtMachine(Machine):
             self._cleanup()
 
     def start(self, maintain=False, macaddr=None, memory_mb=None, cpus=None, wait_for_ip=True):
+        if self.fetch:
+            vmimages.download_images([self.image], False, [])
+
         tries = 0
         while True:
             try:

--- a/test/verify/testsuite-prepare
+++ b/test/verify/testsuite-prepare
@@ -27,8 +27,6 @@ from common import testinfra
 from common import vmimages
 from common import vmmanage
 
-image_list=["ipa", "openshift", "fedora-stock"]
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
             description='Prepare testig environment, download images and build and install cockpit',
@@ -53,8 +51,7 @@ if __name__ == "__main__":
 
     os.system(os.path.join(testinfra.TEST_DIR,"vm-reset"))
     try:
-        vmimages.download_images(set((test_os, build_os)), args.force, [])
-        vmimages.download_images(image_list, args.force, [])
+        vmimages.download_images([build_os], args.force, [])
     except Exception as e:
         print "unable to download all necessary images", e
         sys.exit(1)


### PR DESCRIPTION
It's often the case that users of testsuite-prepare don't want
or need to pull all the images, if only running a specific
subset of the tests.

I'd like to work towards making our testing code more composable
and this is one step in that direction.

One can specify --nonet to the tests (similar argument to xsltproc
and friends) in order to prevent fetching images from the network.