### PR TITLE
Port some of SELinux module to ES6

### DIFF
--- a/pkg/selinux/selinux-client.es6
+++ b/pkg/selinux/selinux-client.es6
@@ -17,9 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-var cockpit = require("cockpit");
-
-var client = {};
+import cockpit from 'cockpit';
 
 /* until we have a good dbus interface to get selinux status updates,
  * we resort to polling
@@ -48,7 +46,7 @@ var status = {
  *
  * Since we're screenscraping we need to run this in LC_ALL=C mode
  */
-client.init = function(statusChangedCallback) {
+export function init(statusChangedCallback) {
     var refreshInfo = function() {
         cockpit.spawn(statusCommand, { err: 'message', environ: [ "LC_ALL=C" ] }).then(
             function(output) {
@@ -118,12 +116,10 @@ client.init = function(statusChangedCallback) {
         refreshInfo();
 
     return status;
-};
+}
 
 // returns a promise of the command used to set enforcing mode
-client.setEnforcing = function(enforcingMode) {
+export function setEnforcing(enforcingMode) {
     var command = ["setenforce", (enforcingMode?"1":"0")];
     return cockpit.spawn(command, { superuser: true, err: "message" });
-};
-
-module.exports = client;
+}

--- a/pkg/selinux/setroubleshoot.js
+++ b/pkg/selinux/setroubleshoot.js
@@ -23,7 +23,7 @@ var _ = cockpit.gettext;
 var React = require("react");
 
 var troubleshootClient = require("./setroubleshoot-client");
-var selinuxClient = require("./selinux-client");
+var selinuxClient = require("./selinux-client.es6");
 var troubleshootView = require("./setroubleshoot-view.jsx");
 
 var initStore = function(rootElement) {

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -9,6 +9,7 @@ src/ws/cockpit.desktop.in
 src/ws/cockpithandlers.c
 pkg/tuned/dialog.js
 pkg/selinux/setroubleshoot.js
+pkg/selinux/selinux-client.es6
 pkg/selinux/setroubleshoot-client.js
 pkg/shell/patterns.js
 pkg/shell/machine-dialogs.js


### PR DESCRIPTION
Note: This pull request is dependent on others. Only the last few commits are specifically for this pull request.

This is a proof of concept for using Babel + ES6 + Webpack.

This lets us use ES6 yay. However we limit ourselves to Babel 5.x for now because Babel 6.x was so huge (10 times the size) that it was posing as a blocker to progress.
