### PR TITLE
Fix races in container tests waiting for Cockpit running

### DIFF
--- a/test/containers/check-kubernetes
+++ b/test/containers/check-kubernetes
@@ -46,7 +46,7 @@ class KubernetesContainerMachine(VirtMachine):
             iptables -I INPUT 4 -i docker0 -j ACCEPT
             /usr/bin/docker run -d -e COCKPIT_KUBE_INSECURE=true -e KUBERNETES_INSECURE=true -e KUBERNETES_SERVICE_PORT=6443 -e KUBERNETES_SERVICE_HOST={0} -p 9090:9090 cockpit/kubernetes
             """.format(host))
-        self.wait_for_cockpit_running(self.address)
+        self.wait_for_cockpit_running(self.address, seconds=180)
 
 class KubernetesContainerCase(kubelib.KubernetesCase):
     machine_class = KubernetesContainerMachine

--- a/test/containers/check-kubernetes-openshift
+++ b/test/containers/check-kubernetes-openshift
@@ -66,7 +66,7 @@ class OCMachine(VirtMachine):
         i = 0
         while True:
             try:
-                self.execute("oc status")
+                self.execute("oc status 2>&1")
                 break;
             except:
                 if i > 20:
@@ -98,7 +98,7 @@ class OCMachine(VirtMachine):
 
         self.execute("oc process -f /tmp/cockpit-openshift-template.json -v {0} > out.json".format(','.join(args)))
         self.execute("oc create -f out.json")
-        self.wait_for_cockpit_running(self.address, port=30000)
+        self.wait_for_cockpit_running(self.address, seconds=180, port=30000)
 
 class RegistryMachine(OCMachine):
     run_registry = True


### PR DESCRIPTION
This function is used for more than just atomic images. Move the check for the atomic image into the caller.
    
In addition, make the check for cockpit running to be far more resilient, timeout hung connections, and setup a longer default.
    
This fixes a whole slew of testing races
