### PR TITLE
users: Show error messages from pwscore command

### DIFF
--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -239,7 +239,7 @@ function parse_group_content(content) {
 function password_quality(password) {
     var dfd = $.Deferred();
 
-    cockpit.spawn('/usr/bin/pwscore', { "environ": ["LC_ALL=C"] })
+    cockpit.spawn('/usr/bin/pwscore', { "err": "message" })
        .input(password)
        .done(function(content) {
            var quality = parseInt(content, 10);
@@ -255,8 +255,8 @@ function password_quality(password) {
                dfd.resolve("excellent");
            }
        })
-       .fail(function() {
-           dfd.reject(new Error(_("Password is not acceptable")));
+       .fail(function(ex) {
+           dfd.reject(new Error(ex.message || _("Password is not acceptable")));
        });
 
     return dfd.promise();

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -107,7 +107,7 @@ class TestAccounts(MachineCase):
         b.set_val("#account-set-password-pw2", 'a')
         b.click('#account-set-password-apply')
         b.wait_present(".check-passwords.has-error")
-        self.assertEqual(b.text(".check-passwords.has-error .dialog-error.help-block"), "Password is not acceptable")
+        b.wait_in_text(".check-passwords.has-error .dialog-error.help-block", "Password quality check failed:")
 
         good_password_2 = "cEwghLY§X9R&m8RLwk4Xfed9Bw="
         # Now set to something valid


### PR DESCRIPTION
This tells the user more about why the password isn't
acceptable.

We also crun the pwscore without LC_ALL=C because we want
to use the actual logged in locale. This doesn't affect the
integer that is printed on success.