### PR TITLE
test: This SELinux alert is no longer a known issue

### DIFF
--- a/test/verify/naughty-fedora-24/4062-ssh-transport-c-audit
+++ b/test/verify/naughty-fedora-24/4062-ssh-transport-c-audit
@@ -1,1 +1,0 @@
- comm="ssh-transport-c" name="unix" dev="proc"


### PR DESCRIPTION
This SELinux alert is handled in testlib.py and is no longer a
known issue. It's not clear that Cockpit can do anything to resolve
this problem, and there are several bugs upstream.

https://bugzilla.redhat.com/show_bug.cgi?id=1242656
Fixes #4062