### PR TITLE
Image refresh for fedora-testing

### DIFF
--- a/test/images/fedora-testing
+++ b/test/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-1adcc27ccf1e4bd6b4247f76223c2c93cf212612.qcow2
+fedora-testing-8656bbe8528f2c2e56dd581dc4f6298be2a0adec.qcow2


### PR DESCRIPTION
Image creation for fedora-testing in process on ibm-x3950x5-01.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-testing-2016-07-09/