### PR TITLE
Various fixes to address subscriptions test flakiness

### DIFF
--- a/pkg/subscriptions/subscriptions.js
+++ b/pkg/subscriptions/subscriptions.js
@@ -275,6 +275,7 @@ require([
             }
             /* if output isn't as expected, maybe not properly installed? */
             if (text.indexOf('Overall Status:') === -1) {
+                console.log(text);
                 $('#subscription-manager-not-found').show();
                 $('#subscription-manager-not-accessible').hide();
                 return;
@@ -354,11 +355,14 @@ require([
         /* request update via DBus */
         function update_subscriptions() {
             status_update_requested = false;
-            var call = service.call(
+            service.call(
                 '/EntitlementStatus',
                 'com.redhat.SubscriptionManager.EntitlementStatus',
                 'check_status',
-                []);
+                []).catch(function(ex) {
+                console.warn("EntitlementStatus.check_status() failed:", ex);
+            });
+
             /* TODO: Don't use a timeout here. Needs better API */
             update_timeout = window.setTimeout(status_update_failed, 30000);
         }

--- a/pkg/subscriptions/subscriptions.js
+++ b/pkg/subscriptions/subscriptions.js
@@ -491,7 +491,7 @@ require([
                 .done(function() {
                     $('#subscriptions-register-dialog').modal('hide');
                     /* trigger update just in case */
-                    update_subscriptions();
+                    get_subscription_details();
                 })
                 .fail(function(ex) {
                     if (ex.problem == "cancelled")

--- a/pkg/subscriptions/subscriptions.js
+++ b/pkg/subscriptions/subscriptions.js
@@ -359,7 +359,8 @@ require([
                 'com.redhat.SubscriptionManager.EntitlementStatus',
                 'check_status',
                 []);
-            update_timeout = window.setTimeout(status_update_failed, 10000);
+            /* TODO: Don't use a timeout here. Needs better API */
+            update_timeout = window.setTimeout(status_update_failed, 30000);
         }
 
         function linkify_message(message) {

--- a/pkg/subscriptions/subscriptions.js
+++ b/pkg/subscriptions/subscriptions.js
@@ -571,8 +571,6 @@ require([
         }
 
         return {
-            'update_subscriptions': update_subscriptions,
-            'get_status':           get_overall_status,
             'register_system':      register_system
         };
     }


### PR DESCRIPTION
 * More logging
 * Longer timeouts (even though the timeouts themselves are hacks around lousy API)
 * Force an update after subscribing.
