### PR TITLE
test: Fix regression that fetches while creating an image

### DIFF
--- a/test/vm-create
+++ b/test/vm-create
@@ -186,7 +186,7 @@ class MachineBuilder:
 try:
     os.chdir(BASE)
     testvm.VirtMachine.memory_mb = 2048
-    machine = testvm.VirtMachine(verbose=args.verbose, image=args.image)
+    machine = testvm.VirtMachine(verbose=args.verbose, image=args.image, fetch=False)
     builder = MachineBuilder(machine)
     builder.build()
     if not args.no_save:


### PR DESCRIPTION
During vm-create we shouldn't be downloading already created
images.

Broke in:

commit 4987f7da90418589cceda6022ea105363744d454