### PR TITLE
playground: Make it clear the cancelled dialog waits for promise

### DIFF
--- a/pkg/playground/jquery-patterns.js
+++ b/pkg/playground/jquery-patterns.js
@@ -53,19 +53,22 @@ require([
     /* A mock operation, cancellable with progress */
     function operation() {
         var deferred = $.Deferred();
-        var interval, count = 0;
-        window.setInterval(function() {
+        var count = 0;
+        var interval = window.setInterval(function() {
             count += 1;
             deferred.notify("Step " + count);
         }, 500);
         window.setTimeout(function() {
-            window.clearTimeout(interval);
+            window.clearInterval(interval);
             deferred.resolve();
         }, 5000);
         var promise = deferred.promise();
         promise.cancel = function() {
-            window.clearTimeout(interval);
-            deferred.reject();
+            window.clearInterval(interval);
+            deferred.notify("Cancelling...");
+            window.setTimeout(function() {
+                deferred.reject();
+            }, 1000);
         };
         return promise;
     }


### PR DESCRIPTION
When the dialog pattern is cancelled, it cancels any running
promise (if possible). It then waits for the promise to resolve
or reject before hiding the window.

This behavior doesn't change, but since we're reimplementing this
behavior in React, make the jQuery interaction case more clear
in the playground.