### PR TITLE
system: Fix title case in 'Server Time' dialog

### DIFF
--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -395,7 +395,7 @@
                         </tr>
                         <tr>
                             <td><label class="control-label" for="change_systime"
-                                       translatable="yes">Set time</label></td>
+                                       translatable="yes">Set Time</label></td>
                             <td>
                                 <div class="btn-group bootstrap-select dropdown form-control" id="change_systime">
                                     <button class="btn btn-default dropdown-toggle" type="button"


### PR DESCRIPTION
Minor fix. Should be Headline case.