### PR TITLE
Fix language regression and add tests

### DIFF
--- a/pkg/shell/Makefile.am
+++ b/pkg/shell/Makefile.am
@@ -7,7 +7,7 @@ nodist_shell_DATA = \
 	pkg/shell/po.js.gz \
 	pkg/shell/shell.min.css.gz \
 	pkg/shell/shell.min.html.gz \
-	$(shell_PO:.js=.min.js.gz) \
+	$(shell_PO:.js=.js.gz) \
 	$(NULL)
 
 shell_TEMPLATES = \

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -21,6 +21,7 @@ define([
     "jquery",
     "base1/cockpit",
     "./mustache",
+    "shell/po",
     "domain/operation",
     "performance/dialog",
     "system/server",
@@ -31,9 +32,10 @@ define([
     "system/bootstrap-combobox",
     "./patterns",
     "./flot",
-], function($, cockpit, Mustache, domain, performance, server, service, plot, host_keys_script) {
+], function($, cockpit, Mustache, po, domain, performance, server, service, plot, host_keys_script) {
 "use strict";
 
+cockpit.locale(po);
 var _ = cockpit.gettext;
 var C_ = cockpit.gettext;
 

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -608,7 +608,7 @@ cockpit_web_server_parse_languages (GHashTable *headers,
   if (defawlt)
     {
       lang = g_new0 (Language, 1);
-      lang->qvalue = 1;
+      lang->qvalue = 0.1;
       lang->value = defawlt;
       g_ptr_array_add (langs, lang);
     }

--- a/src/common/test-webserver.c
+++ b/src/common/test-webserver.c
@@ -239,7 +239,7 @@ test_languages_cookie (void)
   g_assert (result != NULL);
 
   string = g_strjoinv (", ", result);
-  g_assert_cmpstr (string, ==, "pig, en-us, en, de, en");
+  g_assert_cmpstr (string, ==, "en-us, en, de, pig, en");
 
   g_free (string);
   g_strfreev (result);

--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -479,7 +479,7 @@ cockpit_channel_response_create (CockpitWebService *service,
 static gboolean
 is_resource_a_package_file (const gchar *path)
 {
-  return path && path[0] && strchr (path, '/') != NULL;
+  return path && path[0] && strchr (path + 1, '/') != NULL;
 }
 
 static gboolean
@@ -535,7 +535,7 @@ parse_host_and_etag (CockpitWebService *service,
     {
       languages = cockpit_web_server_parse_languages (headers, "C");
       *etag = g_strdup_printf ("\"%s-%s\"", where, languages[0]);
-      g_free (languages);
+      g_strfreev (languages);
     }
   else
     {

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -100,6 +100,22 @@ WantedBy=default.target
         b.switch_to_frame("cockpit1:localhost/playground/test")
         b.wait_text("#hidden", "hidden")
 
+        # Lets try changing the language
+        # Translations are not ready for RHEL yet
+        if "rhel" not in m.image:
+            b.switch_to_top()
+            b.click("#content-user-name")
+            b.click(".display-language-menu a")
+            b.wait_popup('display-language')
+            b.set_val("#display-language select", "de")
+            b.click("#display-language-select-button")
+            b.expect_load()
+            b.wait_present("#content")
+            b.go("/system")
+            b.enter_page("/system")
+            b.wait_present("#server")
+            b.wait_in_text("#server", "Neustarten")
+
         self.allow_journal_messages("Failed to get realtime timestamp: Cannot assign requested address")
 
     def testFrameReload(self):


### PR DESCRIPTION
Fix building of PO files. These should not have a .min extension. The language extension takes the place of .min in content negotiation. Regression since around 7144c597a79facaaf8196e2b570691d4624a5b3b. The regression persisted because in debug mode on developers machines multiple copies of the PO js files were installed.
    
In addition we now add a simple test for changing the language ... and surprise surprise, had to fix a lot of other caching and language behavior. If it's not tested it doesn't work.