### PR TITLE
Don't minimize webpack javascript in debug mode

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -132,7 +132,7 @@ EXTRA_DIST += Makefile-webpack.deps $(WEBPACK_CONFIG)
 
 @INCLUDE_WEBPACK_DEPS@
 
-WEBPACK_RULE = $(V_WEBPACK) SRCDIR=$(srcdir) BUILDDIR=$(builddir) \
+WEBPACK_RULE = $(V_WEBPACK) NODE_ENV=$(NODE_ENV) SRCDIR=$(srcdir) BUILDDIR=$(builddir) \
 	       $(srcdir)/tools/missing $(srcdir)/tools/webpack-make -d $@ $<
 
 Makefile-webpack.deps: $(WEBPACK_CONFIG) tools/webpack-make $(WEBPACK_INPUTS)

--- a/configure.ac
+++ b/configure.ac
@@ -426,11 +426,14 @@ if test "$enable_debug" = "yes"; then
 elif test "$enable_debug" = "no"; then
   debug_status="no"
   CFLAGS="$CFLAGS -O2"
+  NODE_ENV="production"
 else
   debug_status="default"
+  NODE_ENV="production"
 fi
 AM_CONDITIONAL(WITH_DEBUG, test "$enable_debug" = "yes")
 AC_MSG_RESULT($debug_status)
+AC_SUBST(NODE_ENV)
 AC_SUBST(debugdir)
 
 # Coverage

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-tools": "*",
     "requirejs": "*",
     "stdio": "*",
+    "strict-loader": "*",
     "style-loader": "^0.13.1",
     "uglify-js": "*",
     "uglifycss": "*",

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -17,9 +17,6 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-"use strict";
-
 var $ = require("jquery");
 var cockpit = require("cockpit");
 
@@ -1232,5 +1229,3 @@ function init() {
 }
 
 $(init);
-
-}());

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -110,6 +110,10 @@ module.exports = {
         ],
         loaders: [
             {
+                test: /\.js$/,
+                loader: 'strict' // Adds "use strict"
+            },
+            {
                 test: /\.css$/,
                 loader: extract.extract("style-loader", "css-loader")
             }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,9 @@ var srcdir = process.env.SRCDIR || __dirname;
 var pkgdir = srcdir + path.sep + "pkg";
 var distdir = (process.env.BUILDDIR || __dirname) + path.sep + "dist";
 
+/* A standard nodejs and webpack pattern */
+var production = process.env.NODE_ENV === 'production';
+
 /*
  * Note that we're avoiding the use of path.join as webpack and nodejs
  * want relative paths that start with ./ explicitly.
@@ -61,6 +64,20 @@ Object.keys(entries).forEach(function(key) {
 files = files.map(function(value) {
     return { from: pkgdir + path.sep + value, to: value };
 });
+
+var plugins = [
+    new copy(files),
+    new extract("[name].css")
+];
+
+/* Only minimize when in production mode */
+if (production) {
+    plugins.unshift(new webpack.optimize.UglifyJsPlugin({
+        compress: {
+            warnings: false
+        },
+    }));
+}
 
 module.exports = {
     resolve: {
@@ -79,18 +96,7 @@ module.exports = {
         sourceMapFilename: "[file].map",
     },
     externals: externals,
-    plugins: [
-        new webpack.optimize.UglifyJsPlugin({
-            compress: {
-                warnings: false
-            },
-            exclude: [
-                "/\.css$/",
-            ]
-        }),
-        new copy(files),
-        new extract("[name].css")
-    ],
+    plugins: plugins,
 
     devtool: "source-map",
 


### PR DESCRIPTION
Don't minimize webpack javascript in debug mode. In addition, automatically add "use strict".

Also remove unnecessary private scoping from migrated webpack code.