### PR TITLE
test: Provide a default location for RHEL subscription creds

### DIFF
--- a/test/images/scripts/rhel-7.bootstrap
+++ b/test/images/scripts/rhel-7.bootstrap
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 BASE=$(dirname $0)
-$BASE/virt-builder-fedora "$1" rhel-7.2 x86_64 $SUBSCRIPTION_PATH
+$BASE/virt-builder-fedora "$1" rhel-7.2 x86_64 ${SUBSCRIPTION_PATH:-~/.rhel}


### PR DESCRIPTION
When building a RHEL image, have a default location to read
the subscription credentials, rather than forcing people to
set an environment variable.