### PR TITLE
test: Re-triggering tests on a pull request keeps details link

### DIFF
--- a/test/github-trigger
+++ b/test/github-trigger
@@ -54,6 +54,12 @@ def trigger_pull(github, opts):
                 continue
         sys.stderr.write("{0}: triggering on pull request {1}\n".format(context, opts.pull))
         changes = { "state": "pending", "description": testinfra.NOT_TESTED, "context": context }
+
+        # Keep the old link for reference, until testing starts again
+        link = status.get("target_url", None)
+        if link:
+            changes["target_url"] = link
+
         github.post("statuses/" + revision, changes)
 
     return ret


### PR DESCRIPTION
The 'Details' link on a re-triggered test will be kept until the
tests start running again. This is for two reasons:

 1. A simple way to show that the test has run before
 2. A way to refer to the latest results, even when further
    retesting is scheduled.