### PR TITLE
test: Add timing info

### DIFF
--- a/test/common/log.html
+++ b/test/common/log.html
@@ -135,8 +135,8 @@
         <script>
 
 var tap_range = /^([0-9]+)\.\.([0-9]+)$/m;
-var tap_result = /^(ok|not ok) ([0-9]+) (.*$)/gm;
-var tap_skipped = /^ok [0-9]+ ([^#].*) # SKIP (.*$)/gm;
+var tap_result = /^(ok|not ok) ([0-9]+) (.*\))(?: duration: ([0-9]+s))?(?: # SKIP .*)?$$/gm;
+var tap_skipped = /^ok [0-9]+ ([^#].*\))(?: duration: ([^#]*))? # SKIP (.*$)/gm;
 var image_file = /([A-Za-z0-9-]+)\.(png)$/gm;
 var journal_file = /(Journal extracted to )([A-Za-z0-9\-\.]+)\.(log)$/gm;
 var test_header_start = "# ----------------------------------------------------------------------"
@@ -198,11 +198,16 @@ function extract(text) {
             } else if (m = tap_result.exec(segment)) {
                 entry.idx = m[2];
                 entry.id = m[2];
+                // our regex cuts this off
+                m[3] += ")";
                 entry.title = entry.id + ": " + m[3];
+                if (m[4])
+                    entry.title += ", duration: " + m[4];
+
                 if(m[1] == "ok") {
                     if (m = tap_skipped.exec(segment)) {
                         entry.title = entry.id + ": " + m[1];
-                        entry.reason = m[2];
+                        entry.reason = m[3];
                         entry.skipped = true;
                         entry.passed = false;
                         skipped += 1;

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -788,17 +788,17 @@ class TapResult(unittest.TestResult):
         super(TapResult, self).__init__(stream, descriptions, verbosity)
 
     def ok(self, test):
-        data = "ok {0} {1}\n".format(self.offset, str(test))
+        data = "ok {0} {1} duration: {2}s\n".format(self.offset, str(test), int(time.time() - self.start_time))
         sys.stdout.write(data)
 
     def not_ok(self, test, err):
-        data = "not ok {0} {1}\n".format(self.offset, str(test))
+        data = "not ok {0} {1} duration: {2}s\n".format(self.offset, str(test), int(time.time() - self.start_time))
         if err:
             data += self._exc_info_to_string(err, test)
         sys.stdout.write(data)
 
     def skip(self, test, reason):
-        sys.stdout.write("ok {0} {1} # SKIP {2}\n".format(self.offset, str(test), reason))
+        sys.stdout.write("ok {0} {1} duration: {2}s # SKIP {3}\n".format(self.offset, str(test), int(time.time() - self.start_time), reason))
 
     def known_issue(self, test, err):
         string = self._exc_info_to_string(err, test)
@@ -812,6 +812,7 @@ class TapResult(unittest.TestResult):
         super(TapResult, self).stop()
 
     def startTest(self, test):
+        self.start_time = time.time()
         self.offset += 1
         sys.stdout.write("# {0}\n# {1}\n#\n".format('-' * 70, str(test)))
         super(TapResult, self).startTest(test)


### PR DESCRIPTION
In order to test this, download any raw logfile (I used [this one](https://fedorapeople.org/groups/cockpit/logs/pull-4734-32e96aee-verify-rhel-7/log)) into the test/common directory and open log.html.

This can help us track down tests that take a long time.