### PR TITLE
test: Optimizations

### DIFF
--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -166,18 +166,19 @@ def run_avocado(avocado_tests, verbose, browser, download_logs):
     selenium = testvm.VirtMachine(image="selenium", label="selenium", verbose=verbose) if use_selenium else None
 
     try:
-        machine.start()
+        # just start the machine without waiting for it to boot, get the ip address later
+        machine.start(wait_for_ip=False)
         if selenium:
+            # actually wait here, because starting selenium takes a while
             selenium.start()
-
-        machine.wait_boot()
-        machine.start_cockpit()
-        if selenium:
             selenium.wait_boot()
 
             # start selenium on the server
             selenium.upload([ "avocado/selenium_start.sh"], "/root")
             selenium.execute(command="/root/selenium_start.sh")
+
+        machine.wait_boot()
+        machine.start_cockpit()
 
         machine.execute("adduser test")
         machine.execute("echo superhardpasswordtest5554 | passwd --stdin test")

--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -1151,6 +1151,9 @@ class VirtMachine(Machine):
         if not self.event_handler.wait_for_running(self._domain, timeout_sec=wait_for_running_timeout ):
             raise Failure("Machine %s didn't start." % (self.address))
 
+        if not self.address:
+            self.address = self._ip_from_mac(self.macaddr)
+
         # if we allow a reboot, the connection to test for a finished boot may be interrupted
         # by the reboot, causing an exception
         try:

--- a/test/containers/check-kubernetes-openshift
+++ b/test/containers/check-kubernetes-openshift
@@ -105,7 +105,7 @@ class RegistryMachine(OCMachine):
 
 class OCCase(kubelib.KubernetesCase):
     def setUp(self, macaddr=None, memory_mb=None, cpus=None):
-        self.machine = self.new_machine(image='openshift')
+        self.machine = self.new_machine(machine_key='openshift', image='openshift')
         self.machine.start(macaddr=macaddr, memory_mb=memory_mb, cpus=cpus)
         self.machine.wait_boot()
 

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -22,7 +22,7 @@ import json
 import parent
 from testlib import *
 
-class TestDashboard(MachineCase):
+class DashBoardHelpers:
     def inject_extras(self, b):
         b.eval_js("""
         dashboard_addresses = function () {
@@ -70,17 +70,18 @@ class TestDashboard(MachineCase):
             b.click('#dashboard_setup_server_dialog .btn-primary')
         b.wait_popdown('dashboard_setup_server_dialog')
 
+class TestBasicDashboard(MachineCase, DashBoardHelpers):
+    additional_machines = {
+        'machine2': { },
+        'machine3': { }
+    }
+
     def testBasic(self):
         b = self.browser
         m = self.machine
 
-        m2 = self.new_machine()
-        m2.start()
-        m2.wait_boot()
-
-        m3 = self.new_machine()
-        m3.start()
-        m3.wait_boot()
+        m2 = self.machines['machine2']
+        m3 = self.machines['machine3']
 
         self.login_and_go("/dashboard")
         self.inject_extras(b)
@@ -183,43 +184,16 @@ class TestDashboard(MachineCase):
         self.allow_hostkey_messages()
         self.allow_journal_messages(".*server offered unsupported authentication methods: password public-key.*")
 
-    def testEdit(self):
-        b = self.browser
-        m = self.machine
-
-        self.login_and_go("/dashboard")
-        self.inject_extras(b)
-        self.wait_dashboard_addresses (b, [ "localhost" ])
-        old_style = b.attr("#dashboard-hosts .list-group-item[data-address='localhost']", "style")
-
-        b.wait_not_visible('#dashboard-hosts a:first-child button.pficon-edit')
-        b.click('#dashboard-enable-edit')
-        b.wait_visible('#dashboard-hosts a:first-child button.pficon-edit')
-
-        b.click('#dashboard-hosts a:first-child button.pficon-edit')
-        b.wait_not_visible('#dashboard-hosts a:first-child button.pficon-edit')
-
-        b.wait_popup('host-edit-dialog')
-        b.set_val('#host-edit-name', "Horst")
-        b.click('#host-edit-color')
-        b.wait_visible('#host-edit-color-popover')
-        b.wait_visible('#host-edit-user[disabled]')
-        b.click('#host-edit-color-popover div.popover-content > div:first-child > div:nth-child(3)')
-        b.wait_not_visible('#host-edit-color-popover')
-        b.click('#host-edit-apply')
-        b.wait_popdown('host-edit-dialog')
-
-        b.wait_in_text('#dashboard-hosts a:first-child span.host-label', "Horst")
-        b.wait_not_attr("#dashboard-hosts .list-group-item[data-address='localhost']", "style", old_style)
-        self.assertEqual(m.execute("hostnamectl --pretty"), "Horst\n")
+class TestDashboardSetup(MachineCase, DashBoardHelpers):
+    additional_machines = {
+        'machine2': { }
+    }
 
     def testSetup(self):
         b = self.browser
 
         m1 = self.machine
-        m2 = self.new_machine()
-        m2.start()
-        m2.wait_boot()
+        m2 = self.machines['machine2']
 
         # lockout admin
         m2.execute("echo admin:badpass | chpasswd")
@@ -302,6 +276,37 @@ class TestDashboard(MachineCase):
 
         m2.execute("ps aux | grep cockpit-bridge | grep admin")
         self.allow_hostkey_messages()
+
+class TestDashboardEditLimits(MachineCase, DashBoardHelpers):
+    def testEdit(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/dashboard")
+        self.inject_extras(b)
+        self.wait_dashboard_addresses (b, [ "localhost" ])
+        old_style = b.attr("#dashboard-hosts .list-group-item[data-address='localhost']", "style")
+
+        b.wait_not_visible('#dashboard-hosts a:first-child button.pficon-edit')
+        b.click('#dashboard-enable-edit')
+        b.wait_visible('#dashboard-hosts a:first-child button.pficon-edit')
+
+        b.click('#dashboard-hosts a:first-child button.pficon-edit')
+        b.wait_not_visible('#dashboard-hosts a:first-child button.pficon-edit')
+
+        b.wait_popup('host-edit-dialog')
+        b.set_val('#host-edit-name', "Horst")
+        b.click('#host-edit-color')
+        b.wait_visible('#host-edit-color-popover')
+        b.wait_visible('#host-edit-user[disabled]')
+        b.click('#host-edit-color-popover div.popover-content > div:first-child > div:nth-child(3)')
+        b.wait_not_visible('#host-edit-color-popover')
+        b.click('#host-edit-apply')
+        b.wait_popdown('host-edit-dialog')
+
+        b.wait_in_text('#dashboard-hosts a:first-child span.host-label', "Horst")
+        b.wait_not_attr("#dashboard-hosts .list-group-item[data-address='localhost']", "style", old_style)
+        self.assertEqual(m.execute("hostnamectl --pretty"), "Horst\n")
 
 
     def testLimits(self):

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -92,7 +92,7 @@ class TestDockerStorage(MachineCase):
         # the pool would kill the cockpit-ws container.
 
         if "atomic" in self.machine.image:
-            m = self.new_machine()
+            m = self.new_machine(machine_key='additional')
             m.start()
             m.wait_boot()
         else:

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -106,18 +106,17 @@ def change_ssh_port(machine, port=None, timeout_sec=120):
 
     raise error
 
+class TestMultiMachineAdd(MachineCase):
+    additional_machines = {
+        'machine2': { },
+        'machine3': { }
+    }
 
-class TestMultiMachine(MachineCase):
     def setUp(self):
         MachineCase.setUp(self)
-        self.machine2 = self.new_machine()
-        self.machine2.start()
-        self.machine2.wait_boot()
+        self.machine2 = self.machines['machine2']
         self.machine2.execute("hostnamectl set-hostname machine2")
-
-        self.machine3 = self.new_machine()
-        self.machine3.start()
-        self.machine3.wait_boot()
+        self.machine3 = self.machines['machine3']
         self.machine3.execute("hostnamectl set-hostname machine3")
 
     def tearDown(self):
@@ -179,6 +178,24 @@ class TestMultiMachine(MachineCase):
                                     "Received message for unknown channel: .*",
                                     ".*: error reading from ssh",
                                     ".*: bridge program failed: Child process exited with code .*")
+
+
+class TestMultiMachine(MachineCase):
+    additional_machines = {
+        'machine2': { }
+    }
+
+    def setUp(self):
+        MachineCase.setUp(self)
+        self.machine2 = self.machines['machine2']
+        self.machine2.execute("hostnamectl set-hostname machine2")
+
+    def tearDown(self):
+        if self.runner and self.runner.wasSuccessful():
+            self.check_journal_messages(self.machine2)
+            if self.machine3:
+                self.check_journal_messages(self.machine3)
+        MachineCase.tearDown(self)
 
     def testExternalPage(self):
         b = self.browser

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -62,6 +62,9 @@ KEY_IDS_MD5 = [
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=805030
 @unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No ssh keys on Debian (yet).")
 class TestMultiMachineKeyAuth(MachineCase):
+    additional_machines = {
+        'machine2': { }
+    }
 
     def load_key(self, name, password):
         self.browser.switch_to_top()
@@ -83,9 +86,8 @@ class TestMultiMachineKeyAuth(MachineCase):
 
     def setUp(self):
         MachineCase.setUp(self)
-        self.machine2 = self.new_machine()
-        self.machine2.start()
-        self.machine2.wait_boot()
+        self.machine2 = self.machines['machine2']
+
         # Add user
         self.machine2.disconnect()
         self.machine2.execute("useradd user -c 'User' || true", direct=True)

--- a/test/verify/check-multi-os
+++ b/test/verify/check-multi-os
@@ -63,6 +63,10 @@ def new_add_machine(b, address):
     b.wait_popdown('dashboard_setup_server_dialog')
 
 class TestMultiOS(MachineCase):
+    additional_machines = {
+        'fedora-stock': { 'machine': { 'image': 'fedora-stock' } }
+    }
+
     def check_spawn(self, b, address):
         result = b.call_js_func("""(function(address) {
             return require("base1/cockpit").spawn(['echo', 'hi'], { host: address });
@@ -75,7 +79,7 @@ class TestMultiOS(MachineCase):
                 .proxy("org.freedesktop.DBus", "/").call("GetId");
         })""", address)
 
-    def checkStock(self, image):
+    def checkStock(self):
         dev_m = self.machine
         dev_b = self.browser
 
@@ -113,9 +117,7 @@ class TestMultiOS(MachineCase):
             browser.switch_to_frame(frame)
             browser.wait_visible('#' + page)
 
-        stock_m = self.new_machine(image=image)
-        stock_m.start()
-        stock_m.wait_boot()
+        stock_m = self.machines['fedora-stock']
         stock_b = self.new_browser(stock_m.address)
 
         stock_login_and_go(stock_b, "dashboard", href="/dashboard/list", host=None)
@@ -172,7 +174,7 @@ class TestMultiOS(MachineCase):
         self.allow_journal_messages("usermod: user 'postfix' does not exist")
 
     def testFedora22(self):
-        self.checkStock('fedora-stock')
+        self.checkStock()
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -51,13 +51,14 @@ def wait_project(machine, project):
 
 @unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No kubernetes on Debian (yet).")
 class TestOpenshift(MachineCase, OpenshiftCommonTests):
+    additional_machines = {
+        'openshift': { 'machine': { 'image': 'openshift' } }
+    }
 
     def setUp(self):
         super(TestOpenshift, self).setUp()
 
-        self.openshift = self.new_machine(image="openshift")
-        self.openshift.start()
-        self.openshift.wait_boot()
+        self.openshift = self.machines['openshift']
         self.openshift.upload(["verify/files/mock-app-openshift.json"], "/tmp")
         tmpfile = os.path.join(self.tmpdir, "config")
         self.openshift.download("/root/.kube/config", tmpfile)
@@ -288,13 +289,14 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
 
 @unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No kubernetes on Debian (yet).")
 class TestRegistry(MachineCase):
+    additional_machines = {
+        'openshift': { 'machine': { 'image': 'openshift' } }
+    }
+
     def setUp(self):
         super(TestRegistry, self).setUp()
 
-        # Start openshift machine
-        self.openshift = self.new_machine(image="openshift")
-        self.openshift.start()
-        self.openshift.wait_boot()
+        self.openshift = self.machines['openshift']
 
         # Sync over the kube config file
         tmpfile = os.path.join(self.tmpdir, "config")

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -33,18 +33,16 @@ def prepare_resolv(machine, address):
 
 @unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "atomic: missing bind-utils")
 class TestRealms(MachineCase):
+    additional_machines = {
+        'ipa': { 'machine': { 'image': 'ipa' } }
+    }
 
     def testIpa(self):
         m = self.machine
         b = self.browser
 
-        # Start the FreeIPA instance and use it as the DNS server
-        #
-        ipa = self.new_machine(image="ipa")
-        ipa.start()
-        ipa.wait_boot()
-
-        prepare_resolv(m, ipa.address)
+        # Use the FreeIPA instance as the DNS server
+        prepare_resolv(m, self.machines['ipa'].address)
 
         # Wait for DNS to work as expected.
         # https://bugzilla.redhat.com/show_bug.cgi?id=1071356#c11
@@ -127,13 +125,8 @@ class TestRealms(MachineCase):
 
         m.execute("echo -e '[providers]\nsssd = no\n' >>%s" % realmd_distro_conf)
 
-        # Start the FreeIPA instance and use it as the DNS server
-        #
-        ipa = self.new_machine(image="ipa")
-        ipa.start()
-        ipa.wait_boot()
-
-        prepare_resolv(m, ipa.address)
+        # Use the FreeIPA instance as the DNS server
+        prepare_resolv(m, self.machines['ipa'].address)
 
         # Wait for DNS to work as expected.
         # https://bugzilla.redhat.com/show_bug.cgi?id=1071356#c11
@@ -191,17 +184,14 @@ ipa-getkeytab -q -s f0.cockpit.lan -p HTTP/x0.cockpit.lan -k /etc/krb5.keytab
 # This is here because our test framework can't run ipa VM's twice
 @unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "atomic: missing bind-utils")
 class TestKerberos(MachineCase):
-    def setUp(self):
-        MachineCase.setUp(self)
-
-        self.ipa = self.new_machine(image="ipa")
-        self.ipa.start()
-        self.ipa.wait_boot()
+    additional_machines = {
+        'ipa': { 'machine': { 'image': 'ipa' } }
+    }
 
     def configure_kerberos(self):
         # Setup a place for kerberos caches
-        args = { "addr": self.ipa.address, "password": "foobarfoo" }
-        prepare_resolv(self.machine, self.ipa.address)
+        args = { "addr": self.machines['ipa'].address, "password": "foobarfoo" }
+        prepare_resolv(self.machine, self.machines['ipa'].address)
         self.machine.execute(script=JOIN_SCRIPT % args)
 
     def tearDown(self):

--- a/test/verify/check-shutdown-restart
+++ b/test/verify/check-shutdown-restart
@@ -25,20 +25,22 @@ import re
 import ast
 
 class TestShutdownRestart(MachineCase):
+    additional_machines = {
+        'machine2': { }
+    }
+
     def setUp(self):
         # we need a static ip for this test
         MachineCase.setUp(self, macaddr='52:54:00:9e:00:F3')
+
         self.machine.execute("hostnamectl set-hostname machine1")
-        self.machine2 = self.new_machine()
-        self.machine2.start()
-        self.machine2.wait_boot()
-        self.machine2.execute("hostnamectl set-hostname machine2")
+        self.machines['machine2'].execute("hostnamectl set-hostname machine2")
 
     def testBasic(self):
         m = self.machine
         b = self.browser
 
-        m2 = self.machine2
+        m2 = self.machines['machine2']
         b2 = self.new_browser(m2.address)
 
         # HACK -https://bugzilla.redhat.com/show_bug.cgi?id=1278287

--- a/test/verify/check-subscriptions
+++ b/test/verify/check-subscriptions
@@ -51,11 +51,13 @@ import time
 
 @unittest.skipIf("rhel-7" != os.environ.get("TEST_OS", ""), "Only testing subscriptions on RHEL systems.")
 class TestSubscriptions(MachineCase):
+    additional_machines = {
+        'candlepin': { 'machine': { 'image': 'candlepin' } }
+    }
+
     def setUp(self):
         MachineCase.setUp(self)
-        self.candlepin = self.new_machine(image="candlepin")
-        self.candlepin.start()
-        self.candlepin.wait_boot()
+        self.candlepin = self.machines['candlepin']
 
         # wait for candlepin to be active and verify
         self.candlepin.execute("systemctl start tomcat")

--- a/test/verify/naughty-rhel-atomic/3455-tmp-read-only-4
+++ b/test/verify/naughty-rhel-atomic/3455-tmp-read-only-4
@@ -1,3 +1,3 @@
 Traceback (most recent call last):
-  File "check-multi-machine", line 314, in testFrameReload
+  File "check-multi-machine", line 331, in testFrameReload
     b.wait_text('#file-content', "1")

--- a/test/verify/naughty/4538-gss-continue-needed
+++ b/test/verify/naughty/4538-gss-continue-needed
@@ -1,3 +1,3 @@
 Traceback (most recent call last):
-  File "./verify/check-realms", line 232, in testNegotiate
+  File "./verify/check-realms", line 222, in testNegotiate
     self.assertIn("HTTP/1.1 200 OK", output)


### PR DESCRIPTION
blocked on #4740 

Boot images simultaneously, I still have a few occurrences to replace.
Results locally:
```
verify/check-multi-machine
# TESTS PASSED [470s on devmachine]
->
# TESTS PASSED [341s on devmachine]


verify/check-openshift
# TESTS PASSED [851s on devmachine]
->
# TESTS PASSED [646s on devmachine]
```
