### PR TITLE
test: Setup a longer timeout on the journal tests

### DIFF
--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -30,6 +30,8 @@ class TestJournal(MachineCase):
 
     def testBasic(self):
         b = self.browser
+        b.wait_timeout(120)
+
         m = self.machine
 
         self.allow_restart_journal_messages()


### PR DESCRIPTION
These fail on loaded machines.