### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-7044fb0b800d1a77278a447bcff16b422188c38b.qcow2
+debian-unstable-10e1b36f824da73fa6e6e8a21d32a16c7cc75e8d.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on ibm-hs22-04.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-07-14/