### PR TITLE
test: Quieten down check-system-info

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -83,7 +83,7 @@ class TestSystemInfo(MachineCase):
 
         supports_alt = False
         try:
-            m.execute("ssh-keygen -l -f /etc/ssh/weirdname -E md5")
+            m.execute(command="ssh-keygen -l -f /etc/ssh/weirdname -E md5", quiet=True)
             supports_alt = True
         except subprocess.CalledProcessError:
             pass


### PR DESCRIPTION
We try to call ssh-keygen with the parameter -E and check if that fails.
In that case, we don't need the whole list of allowed parameters, so
mark that command to be executed quietly on the test machine.