### PR TITLE
Use babel-loader instead of jsx-loader when building webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "Cockpit isn't a Node package, these are devel time deps, not needed to build tarball either",
   "private": true,
   "devDependencies": {
+    "babel": "^5.0.0",
+    "babel-core": "^5.0.0",
+    "babel-loader": "^5.0.0",
     "copy-webpack-plugin": "*",
     "css-loader": "^0.23.1",
     "esprima": "*",
@@ -11,7 +14,6 @@
     "jed": "*",
     "jshint": "*",
     "jshint-loader": "*",
-    "jsx-loader": "*",
     "less": ">2.5.0",
     "po2json": "*",
     "promise": "*",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -122,6 +122,10 @@ module.exports = {
                 test: /\.js$/, // include .js files
                 exclude: /lib\/.*\/|\/node_modules\//, // exclude external dependencies
                 loader: "jshint-loader"
+            },
+            {
+                test: /\.es6$/, // include .js files
+                loader: "jshint-loader?esversion=6"
             }
         ],
         loaders: [
@@ -135,7 +139,11 @@ module.exports = {
             },
             {
                 test: /\.jsx$/,
-                loader: "jsx-loader"
+                loader: "babel-loader"
+            },
+            {
+                test: /\.es6$/,
+                loader: "babel-loader"
             }
         ]
     },


### PR DESCRIPTION
This lets us use ES6 yay. However we limit ourselves to Babel 5.x
for now because Babel 6.x was so huge (10 times the size) that it
was posing as a blocker to progress.