### PR TITLE
test: Shorten ssh control path if too long

### DIFF
--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -192,6 +192,10 @@ class Machine:
 
         control = os.path.join(testinfra.TEST_DIR, "tmp", "ssh-%h-%p-%r-" + str(os.getpid()))
 
+        # unix domain socket names aren't allowed to be too long
+        if len(control) > 108:
+            control = os.path.join(tempfile.tempdir, "ssh-%h-%p-%r-" + str(os.getpid()))
+
         cmd = [
             "ssh",
             "-p", str(self.ssh_port),


### PR DESCRIPTION
Unix domain sockets have a maximum length of UNIX_PATH_MAX,
usually 108 characters. With long paths of the git checkout,
this can make the name of our tmp directory too long.

In those cases, fall back to using python's default temp dir.