### PR TITLE
test: Use more defaults

### DIFF
--- a/test/common/testinfra.py
+++ b/test/common/testinfra.py
@@ -150,6 +150,34 @@ __all__ = (
     'TEST_DIR',
 )
 
+def determine_github_base():
+    # pick a base
+    try:
+        # see where we get master from, e.g. origin
+        get_remote_command = ["git", "config", "--local", "--get", "branch.master.remote"]
+        remote = subprocess.Popen(get_remote_command, stdout=subprocess.PIPE, cwd=TEST_DIR).communicate()[0].strip()
+        # see if we have a git checkout - it can be in https or ssh format
+        formats = [
+            re.compile("""https:\/\/github\.com\/(.*)\.git"""),
+            re.compile("""git@github.com:(.*)\.git""")
+            ]
+        remote_output = subprocess.Popen(
+                ["git", "ls-remote", "--get-url", remote],
+                stdout=subprocess.PIPE, cwd=TEST_DIR
+            ).communicate()[0].strip()
+        for f in formats:
+            m = f.match(remote_output)
+            if m:
+                return list(m.groups())[0]
+    except:
+        sys.stderr.write("Unable to get git repo information, using defaults\n")
+
+    # if we still don't have something, default to cockpit-project/cockpit
+    return "cockpit-project/cockpit"
+
+# github base to use
+GITHUB_BASE = "/repos/{0}/".format(os.environ.get("GITHUB_BASE", determine_github_base()))
+
 def read_whitelist():
     # Try to load the whitelists
     # Always expect the in-tree version to be present
@@ -278,7 +306,7 @@ def dict_is_subset(full, check):
     return True
 
 class GitHub(object):
-    def __init__(self, base="/repos/cockpit-project/cockpit/"):
+    def __init__(self, base=GITHUB_BASE):
         self.base = base
         self.conn = None
         self.token = None

--- a/test/github-limits
+++ b/test/github-limits
@@ -50,7 +50,7 @@ def main():
 
     future_timestamp = datetime.datetime.utcnow() + datetime.timedelta(seconds=3600)
 
-    github = testinfra.GitHub("/repos/cockpit-project/cockpit/")
+    github = testinfra.GitHub()
     headers = { 'If-Modified-Since': httpdate(future_timestamp) }
     response = github.request("GET", "git/refs/heads/master", "", headers)
     sys.stdout.write("Rate limits:\n")

--- a/test/github-scan
+++ b/test/github-scan
@@ -35,7 +35,7 @@ def main():
                         help='The test context to scan for tasks')
     opts = parser.parse_args()
 
-    github = testinfra.GitHub("/repos/cockpit-project/cockpit/")
+    github = testinfra.GitHub()
 
     for entry in github.scan(not opts.dry, opts.context, opts.except_context):
         sys.stdout.write("{0}: {1}\n".format(entry.priority, entry.task.description()))


### PR DESCRIPTION
Use explicit mentions of cockpit-project/cockpit less often and rely on extracting that info from the git checkout where possible.

Should we use regular expressions for this?