### PR TITLE
test: OSTree regression is fixed upstream

### DIFF
--- a/test/images/continuous-atomic
+++ b/test/images/continuous-atomic
@@ -1,1 +1,1 @@
-continuous-atomic-2918b3fa1c3a7a40bc47bc30598a27767860f858.qcow2
+continuous-atomic-d3e68edc39f86bfe448b010328cf338b08c4039d.qcow2

--- a/test/verify/naughty-continuous-atomic/4738-rpm-ostree-update-broken
+++ b/test/verify/naughty-continuous-atomic/4738-rpm-ostree-update-broken
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-ostree", line 165, in testOstree
-    b.wait_present('table.listing-ct tbody:nth-child(3) i.fa-circle')


### PR DESCRIPTION
Still broken in fedora and rhel.