### PR TITLE
consolidate duration info about test to same format as other verify tests

### DIFF
--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -71,7 +71,7 @@ def tap_output(machine):
         test_log = t['logfile']
         test_time = t['time']
         print "# ----------------------------------------------------------------------"
-        print "# %s (time %d secs)" % (test_name, test_time)
+        print "# %s, duration: %ds" % (test_name, test_time)
         print "#"
         try:
             print machine.execute(command="cat " + test_log, quiet=True)
@@ -80,14 +80,14 @@ def tap_output(machine):
             print e
         print "# TEST LOG END -------"
         if test_status == 'PASS':
-            print "ok %s %s (time %d secs)" % (counter, test_name, test_time)
+            print "ok %s %s, duration: %ds" % (counter, test_name, test_time)
         else:
-            print "not ok %s %s (time %d secs)" % (counter, test_name, test_time)
+            print "not ok %s %s, duration: %ds" % (counter, test_name, test_time)
         counter = counter + 1
     if len(json_info['tests']) != json_info['pass']:
-        print "# %d TESTS FAILED (time: %d secs)" % (len(json_info['tests']) - json_info['pass'], json_info['time'])
+        print "# %d TESTS FAILED, duration: %ds" % (len(json_info['tests']) - json_info['pass'], json_info['time'])
     else:
-        print "# TESTS PASSED (time: %d secs)" %  json_info['time']
+        print "# TESTS PASSED, duration: %ds" %  json_info['time']
 
 def run_avocado_tests(machine, avocado_tests, print_failed=True, env=[]):
     """ Execute avocado on the machine with the passed environment variables and run

--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -25,6 +25,7 @@ import shutil
 import sys
 import subprocess
 import glob
+import re
 
 # we use symlinked files
 # the directory structure breaks on the second run with .pyc files
@@ -67,11 +68,12 @@ def tap_output(machine):
     counter = 1
     for t in json_info['tests']:
         test_status = t['status']
-        test_name = t['test']
+        name_search = re.search("([^/]+):(.*)$", t['test'])
+        test_name = "%s (%s)" % (name_search.group(1), name_search.group(2))
         test_log = t['logfile']
-        test_time = t['time']
+        test_time_string = "duration: %ds" % t['time']
         print "# ----------------------------------------------------------------------"
-        print "# %s, duration: %ds" % (test_name, test_time)
+        print "# %s %s" % (test_name, test_time_string)
         print "#"
         try:
             print machine.execute(command="cat " + test_log, quiet=True)
@@ -80,14 +82,14 @@ def tap_output(machine):
             print e
         print "# TEST LOG END -------"
         if test_status == 'PASS':
-            print "ok %s %s, duration: %ds" % (counter, test_name, test_time)
+            print "ok %s %s %s" % (counter, test_name, test_time_string)
         else:
-            print "not ok %s %s, duration: %ds" % (counter, test_name, test_time)
+            print "not ok %s %s %s" % (counter, test_name, test_time_string)
         counter = counter + 1
     if len(json_info['tests']) != json_info['pass']:
-        print "# %d TESTS FAILED, duration: %ds" % (len(json_info['tests']) - json_info['pass'], json_info['time'])
+        print "# %d TESTS FAILED duration: %ds" % (len(json_info['tests']) - json_info['pass'], json_info['time'])
     else:
-        print "# TESTS PASSED, duration: %ds" %  json_info['time']
+        print "# TESTS PASSED duration: %ds" %  json_info['time']
 
 def run_avocado_tests(machine, avocado_tests, print_failed=True, env=[]):
     """ Execute avocado on the machine with the passed environment variables and run


### PR DESCRIPTION
As discussed with @dperpeet I've consolidated timing info for avocado tests