### PR TITLE
docker: Fix hovering over containers in the graph

### DIFF
--- a/lib/plot.js
+++ b/lib/plot.js
@@ -461,11 +461,11 @@ module.plot = function plot(element, x_range_seconds, x_stop_seconds) {
         var instances = { };
         var last_instance = null;
 
-        function add_instance(name) {
+        function add_instance(name, selector) {
             if (instances[name])
                 return;
 
-            var instance_data = $.extend({}, opts);
+            var instance_data = $.extend({ selector: selector }, opts);
             var factor = desc.factor || 1;
             var threshold = desc.threshold || 0;
             var metrics_row;
@@ -538,7 +538,7 @@ module.plot = function plot(element, x_range_seconds, x_stop_seconds) {
             for (name in instances) {
                 var d = instances[name].data;
                 if (d[index] && d[index][1] && d[index][2] <= pos.y && pos.y <= d[index][1])
-                    return name;
+                    return instances[name].selector || name;
             }
             return false;
         }

--- a/pkg/docker/overview.js
+++ b/pkg/docker/overview.js
@@ -64,10 +64,9 @@ define([
             return false;
         });
 
-        function highlight_container_row(event, id) {
-            id = client.container_from_cgroup(id) || id;
+        function highlight_container_row(event, selector) {
             $('#containers-containers tr').removeClass('highlight-ct');
-            $('#' + id).addClass('highlight-ct');
+            $(selector).addClass('highlight-ct');
         }
 
         var cpu_data = {
@@ -142,8 +141,8 @@ define([
 
         function render_container(id, container) {
             if (container && container.CGroup) {
-                cpu_series.add_instance(container.CGroup);
-                mem_series.add_instance(container.CGroup);
+                cpu_series.add_instance(container.CGroup, "#" + id);
+                mem_series.add_instance(container.CGroup, "#" + id);
             }
             util.render_container(client, $('#containers-containers'),
                                   "", id, container, danger_enabled);


### PR DESCRIPTION
There's an exception hovering over the graph on the containers
page, where container_from_cgroup() is not defined. Lets fix
this by adding an option to the plot code to pass a custom
selector for highlighting the relevant row.

Fixes #4755