### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-7044fb0b800d1a77278a447bcff16b422188c38b.qcow2
+debian-unstable-a63847d150384d1dd7381e3e776412ac8fb75bb0.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-07-28/