### PR TITLE
Fix the resolving of webpack lib/ directory from in tree builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -123,7 +123,7 @@ module.exports = {
             "react": "react-lite-cockpit/dist/react-lite.js",
             "term": "term.js-cockpit/src/term.js",
         },
-        modulesDirectories: [ srcdir + path.sep + "lib" ]
+        modulesDirectories: [ path.resolve(srcdir, "lib") ]
     },
     resolveLoader: {
         root: path.resolve(srcdir, 'node_modules')


### PR DESCRIPTION
Running 'make dist' from deeply nested trees wasn't working.