### PR TITLE
static: Store login-data in localStorage

### DIFF
--- a/pkg/kubernetes/scripts/kube-client-cockpit.js
+++ b/pkg/kubernetes/scripts/kube-client-cockpit.js
@@ -891,7 +891,7 @@
                     return defer.promise;
 
                 var last, req, kubectl, loginOptions;
-                var loginData = window.sessionStorage.getItem('login-data');
+                var loginData = window.localStorage.getItem('login-data');
                 defer = $q.defer();
 
                 var schemes = [

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -764,8 +764,12 @@ define([
         if (self.language_sel)
             setup_language(self.language_sel);
 
-        if (self.brand_sel)
-            self.default_title = setup_brand(self.brand_sel);
+        var cal_title;
+        if (self.brand_sel) {
+            cal_title = setup_brand(self.brand_sel, self.default_title);
+            if (cal_title)
+                self.default_title = cal_title;
+        }
 
         if (self.about_sel)
             setup_about(self.about_sel);

--- a/pkg/shell/index-no-machines.js
+++ b/pkg/shell/index-no-machines.js
@@ -44,7 +44,7 @@ define([
         default_title: default_title
     });
 
-    var login_data = window.sessionStorage.getItem('login-data');
+    var login_data = window.localStorage.getItem('login-data');
     if (login_data) {
         var data = JSON.parse(login_data);
         $("#content-user-name").text(data["displayName"]);

--- a/pkg/shell/index-stub.js
+++ b/pkg/shell/index-stub.js
@@ -62,7 +62,7 @@ define([
 
     indexes.machines_index(options, machines, loader, dialogs);
 
-    var login_data = window.sessionStorage.getItem('login-data');
+    var login_data = window.localStorage.getItem('login-data');
     if (login_data) {
         var data = JSON.parse(login_data);
         $("#content-user-name").text(data["displayName"]);

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -2136,6 +2136,7 @@ function basic_scope(cockpit, jquery) {
 
     cockpit.logout = function logout(reload) {
         window.sessionStorage.clear();
+        window.localStorage.removeItem('login-data');
         if (reload !== false)
             reload_after_disconnect = true;
         ensure_transport(function(transport) {

--- a/src/static/login.html
+++ b/src/static/login.html
@@ -10,6 +10,7 @@
         var phantom_checkpoint = phantom_checkpoint || function () { };
 
         (function(console) {
+            window.localStorage.removeItem('login-data');
             var environment = window.environment || { };
             var oauth = environment.OAuth || null;
             if (oauth) {
@@ -332,7 +333,11 @@
                 if (response && response["login-data"]) {
                     str = JSON.stringify(response["login-data"]);
                     try {
-                        window.sessionStorage.setItem('login-data', str);
+                        /* login-data is tied to the auth cookie, since
+                         * cookies are available after the page
+                         * session ends login-data should be too.
+                         */
+                        window.localStorage.setItem('login-data', str);
                     } catch(ex) {
                         console.warn("Error storing login-data:", ex);
                     }

--- a/test/common/phantom-driver.js
+++ b/test/common/phantom-driver.js
@@ -44,7 +44,7 @@
 
 var page = require('webpage').create();
 var sys = require('system');
-
+var injected = false;
 var onCheckpoint;
 var waitTimeout;
 var didTimeout;
@@ -59,7 +59,15 @@ function slot() {
 var canary = slot();
 function inject_basics() {
     var i, len;
+
     if (!page.evaluate(function(x) { return x in window; }, canary)) {
+        if (!injected) {
+            page.evaluate(function(x) {
+                localStorage.clear();
+            });
+        }
+
+        injected = true;
         for (i = 1, len = sys.args.length; i < len; i++) {
             page.injectJs(sys.args[i]);
             page.evaluate(function(x) {

--- a/test/common/phantom-lib.js
+++ b/test/common/phantom-lib.js
@@ -5,8 +5,6 @@
  * for routine operations.
  */
 
-localStorage.clear();
-
 function ph_select_query(sel) {
     var list, i, els = [], startIdx, braceCounter, searchText, containsSelector;
     containsSelector = ':contains(';

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -606,10 +606,9 @@ class KubernetesCommonTests(VolumeTests):
         m = self.machine
         b = self.browser
 
-        m.execute("kubectl create -f /tmp/mock-k8s-tiny-app.json")
-
         # The service has loaded and containers instantiated
         self.login_and_go("/kubernetes")
+        m.execute("kubectl create -f /tmp/mock-k8s-tiny-app.json")
         b.wait_present("#service-list tr[data-name='mock'] td.containers")
         with b.wait_timeout(120):
             b.wait_text("#service-list tr[data-name='mock'] td.containers", "1")


### PR DESCRIPTION
Because login-data is tied to the cookie we want it to stay around as long as that cookie is valid. sessionStorage is cleared when when the page session ends. Instead store in localStorage and explicitly delete it on logout or whenever the login page is shown.