### PR TITLE
kubernetes: Use <code> styling for displaying docker commands

### DIFF
--- a/pkg/kubernetes/styles/dashboard.less
+++ b/pkg/kubernetes/styles/dashboard.less
@@ -95,3 +95,10 @@
     margin-right: 5px;
     color: #72767b;
 }
+
+code {
+    display: block;
+    white-space: pre;
+    font-size: 13px;
+    margin-bottom: 1em;
+}

--- a/pkg/kubernetes/views/image-body.html
+++ b/pkg/kubernetes/views/image-body.html
@@ -32,4 +32,4 @@
     <i class="fa fa-info-circle"></i>
     <span translatable="yes">To pull this image:</span>
 </p>
-<pre>$ sudo docker pull <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/{{names[0]}}</pre>
+<code>$ sudo docker pull <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/{{names[0]}}</code>

--- a/pkg/kubernetes/views/image-config.html
+++ b/pkg/kubernetes/views/image-config.html
@@ -1,4 +1,4 @@
-<pre>{{ configCommand(config) }}</pre>
+<code>{{ configCommand(config) }}</code>
 <div class="row">
     <dl class="col-xs-12 col-sm-12 col-md-4">
         <dt translatable="yes">Run as</dt>

--- a/pkg/kubernetes/views/imagestream-body.html
+++ b/pkg/kubernetes/views/imagestream-body.html
@@ -32,5 +32,5 @@
     <i class="fa fa-info-circle"></i>
     <span translatable="yes">To push to an image to this image stream:</span>
 </p>
-<pre>$ sudo docker tag <em>myimage</em> <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/{{ stream.metadata.namespace }}/{{ stream.metadata.name}}:<em>tag</em>
-$ sudo docker push <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/{{ stream.metadata.namespace }}/{{ stream.metadata.name}}</pre>
+<code>$ sudo docker tag <em>myimage</em> <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/{{ stream.metadata.namespace }}/{{ stream.metadata.name}}:<em>tag</em>
+$ sudo docker push <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/{{ stream.metadata.namespace }}/{{ stream.metadata.name}}</code>

--- a/pkg/kubernetes/views/registry-dashboard-page.html
+++ b/pkg/kubernetes/views/registry-dashboard-page.html
@@ -108,12 +108,12 @@
                 <span class="pficon pficon-warning-triangle-o"></span>
                 <span translatable="yes">Your login credentials do not give you access to use the docker registry from the command line.</span>
             </div>
-<pre ng-if="settings.registry.password">$ sudo docker login -p {{settings.registry.password}} -e unused -u unused <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span></pre>
+<code ng-if="settings.registry.password">$ sudo docker login -p {{settings.registry.password}} -e unused -u unused <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span></code>
             <p translatable="yes">Push an image:</p>
-<pre>$ sudo docker tag <em>myimage</em> <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name:tag</em>
-$ sudo docker push <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name</em></pre>
+<code>$ sudo docker tag <em>myimage</em> <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name:tag</em>
+$ sudo docker push <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name</em></code>
             <p translatable="yes">Pull an image:</p>
-<pre ng-if="settings.registry.host">$ sudo docker pull <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name:tag</em></pre>
+<code ng-if="settings.registry.host">$ sudo docker pull <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name:tag</em></code>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This is what Patternfly and Openshift Web Console uses, so lets
just use the same styling. However we continue to display this
as a block rather than inline.