### PR TITLE
common: Convert http Accept style codes to locale codes

### DIFF
--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -9,9 +9,9 @@
         "es": "Español",
         "fr": "Français",
         "pl": "Polski",
-        "pt_BR": "Portugueses",
+        "pt-br": "Portugueses",
         "tr": "Türkçe",
         "uk": "Українська",
-        "zh_CN": "中文"
+        "zh-cn": "中文"
     }
 }

--- a/src/common/mock-content/test-file.zh_CN.txt
+++ b/src/common/mock-content/test-file.zh_CN.txt
@@ -1,0 +1,1 @@
+A translated test file

--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -1169,6 +1169,24 @@ test_negotiation_with_listing (void)
 }
 
 static void
+test_negotiation_locale (void)
+{
+  gchar *chosen = NULL;
+  GError *error = NULL;
+  GBytes *bytes;
+
+  bytes = cockpit_web_response_negotiation (SRCDIR "/src/common/mock-content/test-file.txt",
+                                            NULL, "zh-cn", &chosen, &error);
+
+  cockpit_assert_bytes_eq (bytes, "A translated test file\n", -1);
+  g_assert_no_error (error);
+  g_bytes_unref (bytes);
+
+  g_assert_cmpstr (chosen, ==, SRCDIR "/src/common/mock-content/test-file.zh_CN.txt");
+  g_free (chosen);
+}
+
+static void
 test_negotiation_notfound (void)
 {
   gchar *chosen = NULL;
@@ -1287,6 +1305,7 @@ main (int argc,
 
   g_test_add_func ("/web-response/negotiation/first", test_negotiation_first);
   g_test_add_func ("/web-response/negotiation/last", test_negotiation_last);
+  g_test_add_func ("/web-response/negotiation/locale", test_negotiation_locale);
   g_test_add_func ("/web-response/negotiation/prune", test_negotiation_prune);
   g_test_add_func ("/web-response/negotiation/with-listing", test_negotiation_with_listing);
   g_test_add_func ("/web-response/negotiation/notfound", test_negotiation_notfound);


### PR DESCRIPTION
Http Accept language codes are case insensitive and use a dash as the language / country separator.

Locale codes, such as the ones used by zanata in our po files the language is always lower case and the country in upper. Underscore is used as a separator.

Use http style codes in the manifest and convert to locale style codes when looking for a matching file.