### PR TITLE
storaged: Don't offer PV actions that we know will fail

### DIFF
--- a/pkg/docker/storage.jsx
+++ b/pkg/docker/storage.jsx
@@ -479,7 +479,7 @@ define([
                         _("You don't have permission to manage the Docker storage pool."));
                 else
                     $('#storage-unsupported-message').text(
-                        _("The Docker storage pool can not be managed on this system."));
+                        _("The Docker storage pool cannot be managed on this system."));
                 $("#storage-unsupported").show();
                 $("#storage-details").hide();
             } else {

--- a/pkg/storaged/details.js
+++ b/pkg/storaged/details.js
@@ -166,7 +166,7 @@ define([
                                 Title: _("Passphrase"),
                                 validate: function (phrase) {
                                     if (phrase === "")
-                                        return _("Passphrase can not be empty");
+                                        return _("Passphrase cannot be empty");
                                 },
                                 visible: is_encrypted
                               },
@@ -610,7 +610,7 @@ define([
 
                                       var fsys = (block && block.IdUsage == "filesystem");
                                       if (!fsys && vals.size < lvol.Size)
-                                          return error(_("This logical volume can not be made smaller."));
+                                          return error(_("This logical volume cannot be made smaller."));
 
                                       var options = { };
                                       if (fsys)
@@ -1660,7 +1660,7 @@ define([
                 var action = null;
                 var excuse = null;
                 if (pvols.length == 1) {
-                    excuse = _("The last physical volume of a volume group can not be removed.");
+                    excuse = _("The last physical volume of a volume group cannot be removed.");
                 } else if (pvol.FreeSize < pvol.Size) {
                     if (pvol.Size <= vgroup.FreeSize)
                         action = "pvol_empty_and_remove";

--- a/pkg/storaged/details.js
+++ b/pkg/storaged/details.js
@@ -882,13 +882,16 @@ define([
                               }
                             });
             },
-            pvol_empty: function vgroup_add_disk(path) {
+            pvol_empty_and_remove: function vgroup_add_disk(path) {
                 var pvol = client.blocks_pvol[path];
                 var vgroup = pvol && client.vgroups[pvol.VolumeGroup];
                 if (!vgroup)
                     return;
 
-                return vgroup.EmptyDevice(path, {});
+                return (vgroup.EmptyDevice(path, {})
+                        .then(function () {
+                            vgroup.RemoveDevice(path, true, {});
+                        }));
             },
             pvol_remove: function vgroup_add_disk(path) {
                 var pvol = client.blocks_pvol[path];
@@ -976,9 +979,13 @@ define([
                 });
         });
 
-        function create_simple_btn(title, action, args) {
-            return mustache.render('<button class="btn btn-default storage-privileged" data-action="{{Action}}" data-args="{{Args}}">{{Title}}</button>',
-                                   { Title: title, Action: action, Args: JSON.stringify(args) });
+        function create_simple_btn(title, action, args, excuse) {
+            if (action)
+                return mustache.render('<button class="btn btn-default storage-privileged" data-action="{{Action}}" data-args="{{Args}}">{{Title}}</button>',
+                                       { Title: title, Action: action, Args: JSON.stringify(args) });
+            else
+                return mustache.render('<button class="btn btn-default tooltip-ct" disabled title="{{Excuse}}">{{Title}}</button>',
+                                       { Title: title, Excuse: excuse });
         }
 
         var action_btn_tmpl = $("#action-btn-tmpl").html();
@@ -1634,6 +1641,8 @@ define([
             if (!vgroup)
                 return;
 
+            var pvols = client.vgroups_pvols[vgroup.path];
+
             if (vgroup.NeedsPolling && poll_timer === null) {
                 poll_timer = window.setInterval(function () { vgroup.Poll(); }, 2000);
             } else if (!vgroup.NeedsPolling && poll_timer !== null) {
@@ -1648,10 +1657,20 @@ define([
 
             function make_pvol(pvol) {
                 var block = client.blocks[pvol.path];
-                var actions = [
-                    { action: "pvol_remove", title: _("Remove") },
-                    { action: "pvol_empty",  title: _("Empty") }
-                ];
+                var action = null;
+                var excuse = null;
+                if (pvols.length == 1) {
+                    excuse = _("The last physical volume of a volume group can not be removed.");
+                } else if (pvol.FreeSize < pvol.Size) {
+                    if (pvol.Size <= vgroup.FreeSize)
+                        action = "pvol_empty_and_remove";
+                    else
+                        excuse = cockpit.format(_("There is not enough free space elsewhere to remove this physical volume.  At least $0 more free space is needed."),
+                                                utils.fmt_size(pvol.Size - vgroup.FreeSize));
+                } else {
+                    action = "pvol_remove";
+                }
+                var btn = create_simple_btn (_("Remove"), action, [ pvol.path ], excuse);
                 return {
                     dbus: block,
                     LinkTarget: utils.get_block_link_target(client, pvol.path),
@@ -1659,11 +1678,8 @@ define([
                     Sizes: cockpit.format(_("$0, $1 free"),
                                           utils.fmt_size(pvol.Size),
                                           utils.fmt_size(pvol.FreeSize)),
-                    Button: mustache.render(action_btn_tmpl,
-                                            { arg: pvol.path,
-                                              def: actions[0], // Remove
-                                              actions: actions
-                                            })
+                    Button: btn
+
                 };
             }
 
@@ -1679,7 +1695,7 @@ define([
                                                                      def: actions[0], // Rename
                                                                      actions: actions
                                                                    }),
-                                     PVols: client.vgroups_pvols[vgroup.path].map(make_pvol),
+                                     PVols: pvols.map(make_pvol),
                                      Content: mustache.render(content_tmpl,
                                                               { Title: _("Logical Volumes"),
                                                                 Entries: volume_group_content_entries(vgroup)
@@ -1698,9 +1714,12 @@ define([
             else if (type == 'vgroup')
                 html = render_vgroup();
 
-            if (html)
+
+            if (html) {
+                $('#detail button.tooltip-ct').tooltip('destroy');
                 $('#detail').amend(html);
-            else
+                $('#detail button.tooltip-ct').tooltip();
+            } else
                 $('#detail').text(_("Not found"));
 
             jobs.update('#storage-detail');

--- a/pkg/storaged/dialog.js
+++ b/pkg/storaged/dialog.js
@@ -258,9 +258,9 @@ define([
                 if (isNaN(val))
                     msg = _("Size must be a number");
                 if (val === 0)
-                    msg = _("Size can not be zero");
+                    msg = _("Size cannot be zero");
                 if (val < 0)
-                    msg = _("Size can not be negative");
+                    msg = _("Size cannot be negative");
                 if (!field.AllowInfinite && val > field.Max)
                     msg = _("Size is too large");
             }

--- a/pkg/storaged/overview.js
+++ b/pkg/storaged/overview.js
@@ -515,7 +515,7 @@ define([
                                 Title: _("Server Address"),
                                 validate: function (val) {
                                     if (val === "")
-                                        return _("Server address can not be empty.");
+                                        return _("Server address cannot be empty.");
                                 }
                               },
                               { TextInput: "username",

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -104,15 +104,15 @@ define([
 
     utils.validate_lvm2_name = function validate_lvm2_name(name) {
         if (name === "")
-            return _("Name can not be empty.");
+            return _("Name cannot be empty.");
         if (name.length > 127)
-            return _("Name can not be longer than 127 characters.");
+            return _("Name cannot be longer than 127 characters.");
         var m = name.match(/[^a-zA-Z0-9+._-]/);
         if (m) {
             if (m[0].search(/\s+/) === -1)
-                return cockpit.format(_("Name can not contain the character '$0'."), m[0]);
+                return cockpit.format(_("Name cannot contain the character '$0'."), m[0]);
             else
-                    return cockpit.format(_("Name can not contain whitespace."), m[0]);
+                    return cockpit.format(_("Name cannot contain whitespace."), m[0]);
         }
     };
 

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -144,7 +144,7 @@ class TestStorage(StorageCase):
         self.dialog_wait_val("size", 20)
         self.dialog_set_val("size", 10)
         self.dialog_apply()
-        self.dialog_wait_error(None, "This logical volume can not be made smaller.")
+        self.dialog_wait_error(None, "This logical volume cannot be made smaller.")
         self.dialog_cancel()
 
         # grow it

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -51,6 +51,10 @@ class TestStorage(StorageCase):
         b.wait_in_text("#pvols", "DISK1")
         b.wait_in_text("#pvols", "DISK2")
 
+        # Both of them should be empty and removable
+        b.wait_present('#pvols li:nth-child(1) button[data-action="pvol_remove"]')
+        b.wait_present('#pvols li:nth-child(2) button[data-action="pvol_remove"]')
+
         # Create two logical volumes
         m.execute("lvcreate TEST1 -n one -L 20m")
         b.wait_in_text("#content", "Logical Volume \"one\"")
@@ -69,6 +73,9 @@ class TestStorage(StorageCase):
         m.execute("pvmove %s &>/dev/null || true" % dev_2)
         m.execute("vgreduce TEST1 %s" % dev_2)
         b.wait_not_in_text("#pvols", "DISK2")
+
+        # The remaining lone disk is not removable
+        b.wait_present('#pvols li:nth-child(1) button[disabled]')
 
         # Wipe the disk and make sure lvmetad forgets about it.  This
         # might help with reusing it in the second half of this test.
@@ -169,9 +176,8 @@ class TestStorage(StorageCase):
         self.assertEqual(m.execute("grep %s /etc/fstab || true" % mount_point_one), "")
 
         # remove disk
-        m.execute("pvmove /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK2 &>/dev/null || true")
-        b.wait_action_btn('#pvols li:nth-child(2) .btn-group', "Remove")
-        b.click_action_btn('#pvols li:nth-child(2) .btn-group')
+        b.wait_present('#pvols li:nth-child(2) button')
+        b.click('#pvols li:nth-child(2) button')
         b.wait_not_in_text("#pvols", "DISK2")
         b.wait_in_text("#detail .info-table-ct", "48 MiB")
 
@@ -200,6 +206,10 @@ class TestStorage(StorageCase):
 
         self.content_action(1, "Resize")
         self.dialog({ "size": 70 })
+
+        # There is not enough free space to remove any of the disks.
+        b.wait_present('#pvols li:nth-child(1) button[disabled]')
+        b.wait_present('#pvols li:nth-child(2) button[disabled]')
 
         # use almost all of the pool by erasing the thin volume
         self.content_default_action(2, "Format")


### PR DESCRIPTION
Specifically, "Remove" is only offered for empty PVs, and "Empty" is
only offered when there is enough free space elsewhere for the pvmove.

Also, the last PV is never allowed to be removed, even if empty.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1354421