### PR TITLE
docker: Explicitly create volume group if necessary

### DIFF
--- a/pkg/docker/cockpit-atomic-storage
+++ b/pkg/docker/cockpit-atomic-storage
@@ -5,7 +5,8 @@
 # Storaged and hosts some code that is too experimental to even
 # consider adding it to "atomic storage".
 #
-# It can 'monitor', 'reset-and-reduce', 'add', and 'reset-and-add'.
+# It can 'monitor', 'reset-and-reduce', 'add', 'reset-and-add', and
+# 'create-vgroup'.
 
 # MONITOR
 #
@@ -67,12 +68,19 @@
 # reset will allow docker-storage-setup to finally succeed and create
 # a proper thinpool.
 
+# CREATE-VGROUP
+#
+# This both resets the pool before adding the devices, and also
+# configures docker-storage-setup to use the given volume group.  This
+# is used on systems that don't already have a volume group.
+
 import sys
 import os
 import subprocess
 import json
 import re
 import select
+import errno
 
 ## Utils
 
@@ -95,14 +103,18 @@ def query_pvs(pv, fields):
 
 def list_pvs(vgroup):
     res = [ ]
-    for l in check_output([ "pvs", "--noheadings", "-o",  "vg_name,pv_name" ]).splitlines():
-        fields = l.split()
-        if len(fields) == 2 and fields[0] == vgroup:
-            res.append(fields[1])
+    if vgroup:
+        for l in check_output([ "pvs", "--noheadings", "-o",  "vg_name,pv_name" ]).splitlines():
+            fields = l.split()
+            if len(fields) == 2 and fields[0] == vgroup:
+                res.append(fields[1])
     return res
 
 def list_lvs(vgroup):
-    return [s.strip() for s in check_output([ "lvs", "--noheadings", "-o", "name", vgroup ]).splitlines()]
+    if vgroup:
+        return [s.strip() for s in check_output([ "lvs", "--noheadings", "-o", "name", vgroup ]).splitlines()]
+    else:
+        return [ ]
 
 def list_parents(dev):
     return check_output([ "lsblk", "-snlp", "-o", "NAME", dev ]).splitlines()[1:]
@@ -388,6 +400,7 @@ def get_info(got_uevent):
 
         return { "loopback": os.path.exists("/var/lib/docker/devicemapper/devicemapper/data"),
                  "can_manage": can_manage,
+                 "vgroup": vgroup,
                  "total": total,
                  "used": used,
                  "pool_devices": pool_devices,
@@ -402,17 +415,24 @@ def print_info(data):
         sys.stdout.flush()
 
 def cmd_monitor():
-    # Figure out whether we can manage the pool.  For that, we need
-    # both a volume group to work with, and a recent enough version of
-    # the "atomic" utility.
+    # Figure out whether we can manage the pool.  For that, we
+    # need a recent enough version of the "atomic" utility.
     global can_manage
     can_manage = False
     try:
-        if get_dss_vgroup() != "":
-            with open("/dev/null", "w") as dev_null:
-                can_manage = call([ "atomic", "storage", "--help" ], stdout=dev_null) == 0
-    except:
+        help_text = check_output([ "atomic", "storage", "modify", "--help" ])
+    except subprocess.CalledProcessError:
         pass
+    except OSError as ex:
+        if ex.errno != errno.ENOENT:
+            raise
+    else:
+        if get_dss_vgroup() != "":
+            can_manage = True
+        else:
+            # If the pool ins't yet in a volume group, we need the
+            # --vgroup option to create one.
+            can_manage = "--vgroup" in help_text
 
     old_info = get_info(True)
     print_info(old_info)
@@ -440,7 +460,10 @@ def get_dss_vgroup():
         for l in open("/proc/mounts", "r").readlines():
             fields = l.split()
             if fields[1] == "/" and fields[0].startswith("/dev"):
-                vgroup = check_output([ "lvs", "--noheadings", "-o",  "vg_name", fields[0]]).strip()
+                try:
+                    vgroup = check_output([ "lvs", "--noheadings", "-o",  "vg_name", fields[0]]).strip()
+                except subprocess.CalledProcessError:
+                    pass
     return vgroup
 
 def cmd_reset_and_reduce():
@@ -491,6 +514,18 @@ def cmd_reset_and_add(devs):
     finally:
         call([ "systemctl", "start", "docker" ])
 
+def cmd_create_vgroup(devs):
+    atomic_cmd = [ "atomic", "storage", "modify", "--vgroup", "atomic-storage" ]
+    for d in devs:
+        check_call([ "wipefs", "-a", d ])
+        atomic_cmd.extend([ "--add-device", d ])
+    try:
+        check_call([ "systemctl", "stop", "docker" ])
+        check_call([ "atomic", "storage", "reset" ])
+        check_call(atomic_cmd)
+    finally:
+        call([ "systemctl", "start", "docker" ])
+
 ## Main
 
 if sys.argv[1] == "monitor":
@@ -501,3 +536,5 @@ elif sys.argv[1] == "add":
     cmd_add(sys.argv[2:])
 elif sys.argv[1] == "reset-and-add":
     cmd_reset_and_add(sys.argv[2:])
+elif sys.argv[1] == "create-vgroup":
+    cmd_create_vgroup(sys.argv[2:])

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -33,24 +33,14 @@ from common.vmmanage import get_build_image
 
 # Returns whether Cockpit can add disks and reset the pool.
 #
-def can_manage(machine, vg):
-    # Atomic is all set.
-    if machine.image in [ "rhel-atomic", "fedora-atomic", "continuous-atomic" ]:
-        return True
-
-    # Fedora 25, too
-    if machine.image in [ "fedora-25", "fedora-testing" ]:
-        return True
-
-    # Fedora 24 has new enough "atomic", but the OS is not in a volume
-    # group by default.  We can manage it when we explicitly configure
-    # a dedicated volume group.
-    if machine.image in [ "fedora-24" ]:
-        return vg != ""
-
-    # Everyone else either has no "atomic" at all or a version that is
-    # too old.
-    return False
+def can_manage(machine):
+    return machine.image in [ "fedora-25",
+                              "fedora-testing",
+                              "fedora-24",
+                              "rhel-7",
+                              "rhel-atomic",
+                              "fedora-atomic",
+                              "continuous-atomic" ]
 
 # Returns whether Docker uses devmapper with loopback by default.
 # Cockpit will force the user away from this.
@@ -69,6 +59,13 @@ def initially_loopbacked(machine):
     # have a root volume group at all.
     return True
 
+# Returns whether the pool is initially in a volume group.  If not,
+# Cockpit will create a dedicated volume group when the first device
+# is added.
+#
+def initially_without_vgroup(machine):
+    return machine.image in [ "fedora-24", "rhel-7" ]
+
 class TestDockerStorage(MachineCase):
 
     def testOverview(self):
@@ -81,10 +78,10 @@ class TestDockerStorage(MachineCase):
         b.wait_present("#containers-storage-details .free-text")
         b.wait_text_not("#containers-storage-details .free-text", "")
 
-        if can_manage(m, ""):
+        if can_manage(m):
             b.wait_present("#containers-storage-details a")
 
-    def testDevmapper(self, vg=""):
+    def testDevmapper(self):
         m = self.machine
 
         # On the Atomics, we use two machines: one for running
@@ -105,11 +102,10 @@ class TestDockerStorage(MachineCase):
             login_machine = self.machine
             b = self.browser
 
-        if can_manage(m, vg):
+        if can_manage(m):
             # Allow docker-storage-setup to be happy with our very small disks
             m.write("/etc/sysconfig/docker-storage-setup",
-                    'MIN_DATA_SIZE=80M\n' +
-                    'VG="%s"\n' % vg)
+                    'MIN_DATA_SIZE=80M\n')
 
         def check_loopback(val):
             if val:
@@ -117,9 +113,16 @@ class TestDockerStorage(MachineCase):
             else:
                 m.execute("! (losetup -l -O BACK-FILE | grep -q /var/lib/docker)")
 
+        def check_atomic_vgroup(val):
+            if val:
+                m.execute("vgs atomic-storage")
+            else:
+                m.execute("! vgs atomic-storage")
+
         m.execute("systemctl start docker")
 
         check_loopback(initially_loopbacked(m))
+        check_atomic_vgroup(False)
 
         if login_machine == self.machine:
             self.login_and_go("/docker#/storage")
@@ -157,7 +160,7 @@ class TestDockerStorage(MachineCase):
             b.enter_page("/docker", host=m.address)
             b.wait_visible("#storage")
 
-        if not can_manage(m, vg):
+        if not can_manage(m):
             b.wait_visible("#storage-unsupported")
             return
 
@@ -170,7 +173,7 @@ class TestDockerStorage(MachineCase):
         b.click("#storage-drives .btn-primary")
         b.wait_present(".modal-dialog:contains(Add Additional Storage)")
         b.wait_in_text(".modal-dialog:contains(Add Additional Storage)", "DISK1")
-        if initially_loopbacked(m):
+        if initially_loopbacked(m) or initially_without_vgroup(m):
             b.wait_in_text(".modal-dialog:contains(Add Additional Storage) .alert-message",
                            "The storage pool will be reset")
         b.click(".modal-dialog:contains(Add Additional Storage) .btn-danger")
@@ -178,6 +181,7 @@ class TestDockerStorage(MachineCase):
         b.wait_not_in_text("#storage-drives", "DISK1")
 
         check_loopback(False)
+        check_atomic_vgroup(initially_without_vgroup(m))
 
         # Add a second disk
 
@@ -201,6 +205,7 @@ class TestDockerStorage(MachineCase):
         b.wait_not_present(".modal-dialog:contains(Reset Storage Pool)")
 
         check_loopback(initially_loopbacked(m))
+        check_atomic_vgroup(False)
 
         b.wait_in_text("#storage-drives", "DISK1")
         b.wait_in_text("#storage-drives", "DISK2")
@@ -213,17 +218,15 @@ class TestDockerStorage(MachineCase):
         b.wait_present(".modal-dialog:contains(Add Additional Storage)")
         b.wait_in_text(".modal-dialog:contains(Add Additional Storage)", "DISK1")
         b.wait_in_text(".modal-dialog:contains(Add Additional Storage)", "DISK2")
-        if initially_loopbacked(m):
+        if initially_loopbacked(m) or initially_without_vgroup(m):
             b.wait_in_text(".modal-dialog:contains(Add Additional Storage) .alert-message",
                            "The storage pool will be reset")
         b.click(".modal-dialog:contains(Add Additional Storage) .btn-danger")
         b.wait_not_in_text("#storage-drives", "DISK1")
         b.wait_not_in_text("#storage-drives", "DISK2")
-        check_loopback(False)
 
-    @skipImage("Switching vgroups not tested on loopbacked docker storage", "continuous-atomic", "debian-testing", "fedora-atomic", "rhel-atomic", "ubuntu-1604")
-    def testDevmapperVGroup(self):
-        self.testDevmapper("dockah")
+        check_loopback(False)
+        check_atomic_vgroup(initially_without_vgroup(m))
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -38,6 +38,7 @@ def can_manage(machine):
                               "fedora-testing",
                               "fedora-24",
                               "rhel-7",
+                              "centos-7",
                               "rhel-atomic",
                               "fedora-atomic",
                               "continuous-atomic" ]
@@ -59,12 +60,12 @@ def initially_loopbacked(machine):
     # have a root volume group at all.
     return True
 
-# Returns whether the pool is initially in a volume group.  If not,
-# Cockpit will create a dedicated volume group when the first device
-# is added.
+# Returns whether the pool is initially in a volume group or not.  If
+# not, Cockpit will create a dedicated volume group when the first
+# device is added.
 #
 def initially_without_vgroup(machine):
-    return machine.image in [ "fedora-24", "rhel-7" ]
+    return machine.image in [ "fedora-24", "rhel-7", "centos-7" ]
 
 class TestDockerStorage(MachineCase):
 


### PR DESCRIPTION
If the docker storage pool is not in a volume group, Cockpit now
creates one.

This needs "atomic storage modify --vgroup", which will be in atomic 1.10.6,  think.
