### PR TITLE
test: Remove SELinux systemd-nologin workaround

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -607,8 +607,6 @@ class MachineCase(unittest.TestCase):
                                     ".*: failed to retrieve resource: terminated",
                                     # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1253319
                                     'audit:.*denied.*2F6D656D66643A73642D73797374656D642D636F726564756D202864656C.*',
-                                    # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1317389
-                                    'audit:.*denied.*systemd-logind.*nologin.*',
                                     'audit:.*denied.*comm="systemd-user-se".*nologin.*',
 
                                     'localhost: dropping message while waiting for child to exit',


### PR DESCRIPTION
So that we can see if this happens again, as requested in:

https://bugzilla.redhat.com/show_bug.cgi?id=1276601

Closes #3091