### PR TITLE
kubernetes: Escape CSS newline correctly

### DIFF
--- a/pkg/kubernetes/styles/images.less
+++ b/pkg/kubernetes/styles/images.less
@@ -77,7 +77,7 @@ dl.image-tags {
     }
 
     .image-tag:after {
-        content: '\a';
+        content: "\F00A";
         white-space: pre;
     }
 }


### PR DESCRIPTION
Due to the combination of webpack and less this newline
escape sequence was being prematurely unescaped during
builds. This resulted in a literal 'A' character on the screen.