### PR TITLE
kubernetes: Add anonymous access policy control

### DIFF
--- a/pkg/kubernetes/tests/test-projects.html
+++ b/pkg/kubernetes/tests/test-projects.html
@@ -95,7 +95,7 @@ function suite(fixtures) {
         }
     ]);
 
-    projectsTest("policy checks", 10, fixtures, [
+    projectsTest("policy checks", 11, fixtures, [
         "projectData",
         'kubeSelect',
         function(projectUtil, select) {
@@ -117,7 +117,8 @@ function suite(fixtures) {
             regRolesArray = projectUtil.getRegistryRoles();
             equal(regRolesArray.length, 0, "no values passed 4");
 
-            equal(projectUtil.isRegistryRole(user.one(), "Admin", "financeprj"), true, "check if registry role");
+            equal(projectUtil.isRegistryRole(user.one(), "Admin", "financeprj"), true, "check if Admin registry role");
+            equal(projectUtil.isRegistryRole("system:anonymous", "Pull", "financeprj"), true, "check if Pull registry role");
             equal(projectUtil.isRoles(user.one(), "financeprj"), true, "check if any role exist");
             start();
         }
@@ -342,6 +343,10 @@ suite([
               {
                 "kind": "User",
                 "name": "sunny"
+              },
+              {
+                "kind": "SystemGroup",
+                "name": "system:anonymous"
               }
             ],
             "roleRef": {

--- a/pkg/kubernetes/views/imagestream-body.html
+++ b/pkg/kubernetes/views/imagestream-body.html
@@ -10,13 +10,19 @@
 <dl>
     <dt translatable="yes">Access Policy</dt>
     <dd>
-      <div ng-if="sharedImages(stream.metadata.namespace)" >
+      <div ng-if="sharedImages(stream.metadata.namespace) == 'anonymous'" >
+        <a translatable="yes" ng-href="#/projects/{{ stream.metadata.namespace }}">
+          Images may be pulled by anonymous users
+        </a>
+        <i title="Images accessible to anonymous users" class="fa fa-unlock imagestream-lock"></i>
+      </div>
+      <div ng-if="sharedImages(stream.metadata.namespace) == 'shared'" >
         <a translatable="yes" ng-href="#/projects/{{ stream.metadata.namespace }}">
           Images may be pulled by any authenticated user or group
         </a>
-        <i title="Images shared with non-members" class="fa fa-unlock imagestream-lock"></i>
+        <i title="Images accessible to authenticated users" class="fa fa-lock imagestream-lock"></i>
       </div>
-      <div ng-if="!sharedImages(stream.metadata.namespace)">
+      <div ng-if="!sharedImages(stream.metadata.namespace) == 'private'">
         <a translatable="yes" ng-href="#/projects/{{ stream.metadata.namespace }}">
           Images may only be pulled by specific users or groups
         </a>

--- a/pkg/kubernetes/views/project-body.html
+++ b/pkg/kubernetes/views/project-body.html
@@ -1,9 +1,14 @@
-<p ng-if="sharedImages(project()) == true">
+<p ng-if="sharedImages(project()) == 'anonymous'">
     <span translatable="yes">
-        <a ng-click="modifyProject(project())">Project access policy</a> allows all authenticated users to pull images. Grant additional access to specific members below.
+        <a ng-click="modifyProject(project())">Project access policy</a> allows anonymous users to pull images. Grant additional push or admin access to specific members below.
     </span>
 </p>
-<p ng-if="sharedImages(project()) == false">
+<p ng-if="sharedImages(project()) == 'shared'">
+    <span translatable="yes">
+        <a ng-click="modifyProject(project())">Project access policy</a> allows any authenticated user to pull images. Grant additional push or admin access to specific members below.
+    </span>
+</p>
+<p ng-if="sharedImages(project()) == 'private'">
     <span translatable="yes">
         <a ng-click="modifyProject(project())">Project access policy</a> only allows specific members to access images. Grant access to specific members below.
     </span>

--- a/pkg/kubernetes/views/registry-dashboard-page.html
+++ b/pkg/kubernetes/views/registry-dashboard-page.html
@@ -28,9 +28,11 @@
             <table class="table table-striped table-hover">
                 <tr ng-repeat="(key, project) in projects() track by key" data-name="{{ project.metadata.name }}">
                     <td>
-                        <i ng-if="sharedImages(project) == true" title="Images shared with non-members"
-                            class="fa fa-unlock imagestream-lock dashboard-access"></i>
-                        <i ng-if="sharedImages(project) == false" title="Images only accessible to members"
+                        <i ng-if="sharedImages(project) == 'anonymous'" title="Images accessible to anonymous users"
+                          class="fa fa-unlock imagestream-lock dashboard-access"></i>
+                        <i ng-if="sharedImages(project) == 'shared'" title="Images accessible to authenticated users"
+                            class="fa fa-unlock-alt imagestream-lock dashboard-access"></i>
+                        <i ng-if="sharedImages(project) == 'private'" title="Images only accessible to members"
                             class="fa fa-lock imagestream-lock dashboard-access"></i>
                         <i ng-if="sharedImages(project) == null" title="Accessibility data not yet loaded"
                             class="fa fa-ellipsis-h imagestream-lock dashboard-access"></i>

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -733,7 +733,7 @@ class TestRegistry(MachineCase):
         b.click(".content-filter .pficon-edit")
         b.wait_present("modal-dialog")
         b.wait_visible("#project-access-policy")
-        b.wait_in_text("#project-access-policy button", "Allow only specific users or groups to pull images")
+        b.wait_in_text("#project-access-policy button", "Private: Allow only specific users or groups to pull images")
         b.click("#project-access-policy button")
         b.wait_visible("#project-access-policy .dropdown-menu")
         b.click("#project-access-policy a[value='shared']")
@@ -742,8 +742,29 @@ class TestRegistry(MachineCase):
         b.wait_not_in_text(".listing-ct-body", "Project access policy allows all authenticated users to pull images. Grant additional access to specific members below.")
         output = o.execute("oc policy who-can get --namespace=marmalade imagestreams/layers")
         self.assertIn("system:authenticated", output)
+        self.assertNotIn("system:anonymous", output)
 
-        # Change it from the terminal
+        # Look for change in state
+        b.go("#/")
+        b.wait_present("tr[data-name='marmalade'] .fa-unlock-alt")
+
+        # Change project to shared
+        b.go("#/projects/marmalade")
+        b.wait_in_text(".content-filter h3", "marmalade")
+        b.click(".content-filter .pficon-edit")
+        b.wait_present("modal-dialog")
+        b.wait_visible("#project-access-policy")
+        b.wait_in_text("#project-access-policy button", "Shared: Allow any authenticated user to pull images")
+        b.click("#project-access-policy button")
+        b.wait_visible("#project-access-policy .dropdown-menu")
+        b.click("#project-access-policy a[value='anonymous']")
+        b.click(".btn-primary")
+        b.wait_not_present("modal-dialog")
+        b.wait_in_text(".listing-ct-body", "Project access policy allows anonymous users to pull images. Grant additional push or admin access to specific members below.")
+        output = o.execute("oc policy who-can get --namespace=marmalade imagestreams/layers")
+        self.assertIn("system:anonymous", output)
+
+        # Look for change in state
         b.go("#/")
         b.wait_present("tr[data-name='marmalade'] .fa-unlock")
 


### PR DESCRIPTION
This allows admins to change the settings of a project so that images can be pulled by anonymous users, without a 'docker login' requirement.

I've fixed this up from #4791 and added tests.