### PR TITLE
spec: Add comments describing what the meta package can require

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -81,7 +81,9 @@ BuildRequires: krb5-server
 # For documentation
 BuildRequires: xmlto
 
-# Mandatory components of "cockpit"
+# This is the "cockpit" metapackage. It should only
+# Require, Suggest or Recommend other cockpit-xxx subpackages
+
 Requires: %{name}-bridge = %{version}-%{release}
 Requires: %{name}-ws = %{version}-%{release}
 Requires: %{name}-shell = %{version}-%{release}


### PR DESCRIPTION
The meta package should only require other cockpit subpackages.