### PR TITLE
test: Add pod-infrastructure container image to rhel-atomic

### DIFF
--- a/test/images/rhel-atomic
+++ b/test/images/rhel-atomic
@@ -1,1 +1,1 @@
-rhel-atomic-b6da034f5860f2306a44245870f070c590d6e680.qcow2
+rhel-atomic-eb7f88b20c288f9aa2c824dfe09192be7653780c.qcow2

--- a/test/images/scripts/rhel-atomic.setup
+++ b/test/images/scripts/rhel-atomic.setup
@@ -12,5 +12,6 @@ trap "subscription-manager unregister" EXIT
 systemctl start docker || journalctl -u docker
 
 docker pull rhel7/rhel-tools
+docker pull registry.access.redhat.com/rhel7/pod-infrastructure:latest
 
 /var/lib/testvm/atomic.setup


### PR DESCRIPTION
This is needed to have the kubernetes tests pass. They've been
failing since we turned off pulling of images during the testing.