### PR TITLE
test: Restart just the cockpit service in tests

### DIFF
--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -606,7 +606,7 @@ class Machine:
                 self.execute("docker restart `docker ps | grep cockpit/ws | awk '{print $1;}'`")
             self.wait_for_cockpit_running()
         else:
-            self.execute("systemctl restart cockpit.socket")
+            self.execute("systemctl restart cockpit")
 
     def stop_cockpit(self):
         """Stop Cockpit.


### PR DESCRIPTION
During testing we just need to restart the cockpit service
not the socket itself. Restarting the socket unfortunately
sporadically results in results in linger issues on certain
operating systems, like this:

systemd[1]: Stopping Cockpit Web Service...
systemd[1]: Stopping Cockpit Web Service Socket.
systemd[1]: cockpit.socket failed to listen on sockets: Address already in use
systemd[1]: Failed to listen on Cockpit Web Service Socket.