### PR TITLE
storaged: Do a dry-run during formatting

### DIFF
--- a/pkg/storaged/details.js
+++ b/pkg/storaged/details.js
@@ -227,6 +227,7 @@
                                       vals.type = vals.custom;
 
                                   var options = { 'no-block': { t: 'b', v: true },
+                                                  'dry-run-first': { t: 'b', v: true },
                                                   'tear-down': { t: 'b', v: true }
                                                 };
                                   if (vals.erase != "no")

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import parent
+from testlib import *
+from storagelib import *
+
+class TestStorage(StorageCase):
+    def testFormatTooSmall(self):
+        m = self.machine
+        b = self.browser
+
+        # Some day storaged/udisks will support the "dry-run-first"
+        # option.
+        #
+        # https://github.com/storaged-project/storaged/pull/82
+
+        storaged_supports_dry_run = (self.storaged_version >= [ 2, 6, 3])
+
+        self.login_and_go("/storage")
+        b.wait_in_text("#drives", "VirtIO")
+
+        # Try to format a disk that is too small for XFS.
+
+        m.add_disk("5M", serial="DISK1")
+        b.wait_in_text("#drives", "DISK1")
+        b.click('#drives tr:contains("DISK1")')
+        b.wait_visible('#storage-detail')
+
+        self.content_default_action(1, "Format")
+        self.dialog_wait_open()
+        self.dialog_set_val("type",  "xfs")
+        self.dialog_apply()
+
+        if storaged_supports_dry_run:
+            self.dialog_wait_error(None, "Error creating file system")
+        else:
+            self.dialog_wait_close()
+
+if __name__ == '__main__':
+    test_main()

--- a/test/verify/naughty-fedora-25/5041-storaged-selinux-broken-0
+++ b/test/verify/naughty-fedora-25/5041-storaged-selinux-broken-0
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+  File "storagelib.py", line 38, in setUp
+    ver = self.machine.execute("busctl --system get-property org.freedesktop.UDisks2 /org/freedesktop/UDisks2/Manager org.freedesktop.UDisks2.Manager Version")
+  File "testvm.py", line 412, in execute
+    raise subprocess.CalledProcessError(proc.returncode, command, output=output)
+CalledProcessError: Command 'busctl --system get-property org.freedesktop.UDisks2 /org/freedesktop/UDisks2/Manager org.freedesktop.UDisks2.Manager Version' returned non-zero exit status 1

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -19,6 +19,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import re
 from testlib import *
 
 def content_action_btn(index):
@@ -32,6 +33,16 @@ class StorageCase(MachineCase):
 
         MachineCase.setUp(self)
         self.storagectl_cmd = self.machine.execute("for cmd in storagedctl storagectl udisksctl; do if which $cmd 2>/dev/null; then break; fi; done").strip()
+
+        if "udisksctl" in self.storagectl_cmd:
+            ver = self.machine.execute("busctl --system get-property org.freedesktop.UDisks2 /org/freedesktop/UDisks2/Manager org.freedesktop.UDisks2.Manager Version")
+        else:
+            ver = self.machine.execute("busctl --system get-property org.storaged.Storaged /org/storaged/Storaged/Manager org.storaged.Storaged.Manager Version")
+        m = re.match('s "(.*)"', ver)
+        if m:
+            self.storaged_version = map(int, m.group(1).split("."))
+        else:
+            self.storaged_version = [ 0 ]
 
     def inode(self, f):
         return self.machine.execute("stat -L '%s' -c %%i" % f)


### PR DESCRIPTION
This allows us to show errors when the "mkfs" command will complain
about its parameters.  A concrete case is trying to make a xfs
filesystem on a very small block device.

Fixes #4576