### PR TITLE
test: Ignore restart messages in testCreateTimer

### DIFF
--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -464,5 +464,7 @@ WantedBy=default.target
         self.assertIn("hello", m.execute("cat /tmp/hello"))
         m.execute("timedatectl set-ntp on")
 
+        self.allow_restart_journal_messages()
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Otherwise this causes spurious test failures.