### PR TITLE
networkmanager: Use interface name as connection settings id

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1612,7 +1612,7 @@ PageNetworking.prototype = {
         PageNetworkBondSettings.settings =
             {
                 connection: {
-                    id: uuid,
+                    id: iface,
                     autoconnect: false,
                     type: "bond",
                     uuid: uuid,
@@ -1645,7 +1645,7 @@ PageNetworking.prototype = {
         PageNetworkTeamSettings.settings =
             {
                 connection: {
-                    id: uuid,
+                    id: iface,
                     autoconnect: false,
                     type: "team",
                     uuid: uuid,
@@ -1676,7 +1676,7 @@ PageNetworking.prototype = {
         PageNetworkBridgeSettings.settings =
             {
                 connection: {
-                    id: uuid,
+                    id: iface,
                     autoconnect: false,
                     type: "bridge",
                     uuid: uuid,
@@ -1697,7 +1697,7 @@ PageNetworking.prototype = {
     },
 
     add_vlan: function () {
-        var iface, i, uuid;
+        var uuid;
 
         uuid = generate_uuid();
 
@@ -1707,7 +1707,7 @@ PageNetworking.prototype = {
         PageNetworkVlanSettings.settings =
             {
                 connection: {
-                    id: uuid,
+                    id: "",
                     autoconnect: false,
                     type: "vlan",
                     uuid: uuid,
@@ -3105,6 +3105,7 @@ PageNetworkBondSettings.prototype = {
                     change(function (event) {
                         var val = $(event.target).val();
                         settings.bond.interface_name = val;
+                        settings.connection.id = val;
                         settings.connection.interface_name = val;
                     });
         body.find('#network-bond-settings-members').
@@ -3270,6 +3271,7 @@ PageNetworkTeamSettings.prototype = {
                     change(function (event) {
                         var val = $(event.target).val();
                         settings.team.interface_name = val;
+                        settings.connection.id = val;
                         settings.connection.interface_name = val;
                     });
         body.find('#network-team-settings-members').
@@ -3498,6 +3500,7 @@ PageNetworkBridgeSettings.prototype = {
                       change(function (event) {
                                 var val = $(event.target).val();
                                 options.interface_name = val;
+                                settings.connection.id = val;
                                 settings.connection.interface_name = val;
                             });
         body.find('#network-bridge-settings-slave-interfaces').
@@ -3684,6 +3687,7 @@ PageNetworkVlanSettings.prototype = {
                 name_input.val(options.parent + "." + options.id);
 
             options.interface_name = name_input.val();
+            settings.connection.id = options.interface_name;
             settings.connection.interface_name = options.interface_name;
         }
 

--- a/test/verify/check-networking
+++ b/test/verify/check-networking
@@ -224,6 +224,10 @@ class TestNetworking(MachineCase):
         b.wait_popdown("network-bond-settings-dialog")
         b.wait_present("#networking-interfaces tr[data-interface='tbond']")
 
+        # Check that the configuration file has the expected sane name
+        # on systems that use "network-scripts".
+        m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbond")
+
         # Check that the members are displayed
         b.click("#networking-interfaces tr[data-interface='tbond'] td:first-child")
         b.wait_visible("#network-interface")
@@ -285,6 +289,10 @@ class TestNetworking(MachineCase):
         b.wait_popdown("network-team-settings-dialog")
         b.wait_present("#networking-interfaces tr[data-interface='tteam']")
 
+        # Check that the configuration file has the expected sane name
+        # on systems that use "network-scripts".
+        m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tteam")
+
         # Check that the members are displayed
         b.click("#networking-interfaces tr[data-interface='tteam'] td:first-child")
         b.wait_visible("#network-interface")
@@ -342,6 +350,10 @@ class TestNetworking(MachineCase):
         b.click("#network-bridge-settings-dialog button:contains('Apply')")
         b.wait_popdown("network-bridge-settings-dialog")
         b.wait_present("#networking-interfaces tr[data-interface='tbridge']")
+
+        # Check that the configuration file has the expected sane name
+        # on systems that use "network-scripts".
+        m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbridge")
 
         # Delete the bridge
         b.click("#networking-interfaces tr[data-interface='tbridge'] td:first-child")


### PR DESCRIPTION
This is much friendlier.  The ID does not need to be unique, so we
don't have to worry about name clashes.

Fixes #4888
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1367378