### PR TITLE
test: Ignore common DBus failure on shutdown

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -611,6 +611,7 @@ class MachineCase(unittest.TestCase):
 
                                     'localhost: dropping message while waiting for child to exit',
                                     '.*: GDBus.Error:org.freedesktop.PolicyKit1.Error.Failed: .*',
+                                    '.*g_dbus_connection_call_finish_internal.*G_IS_DBUS_CONNECTION.*',
                                     )
 
     def allow_authorize_journal_messages(self):


### PR DESCRIPTION
Due to the multi-threaded nature of the DBus worker this message
can show up on restart. It doesn't actually affect users, so
lets just ignore it in the tests that restart a machine.