### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-300696f748a7065482b96f3c96b8c900c2eb930c.qcow2
+debian-unstable-adece82f020769a16d02b71404d2126ec0d507e8.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on cockpit-c.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-08-19/