### PR TITLE
bridge: Make loading manifests.js work well without AMD

### DIFF
--- a/doc/guide/cockpit-manifest.xml
+++ b/doc/guide/cockpit-manifest.xml
@@ -10,17 +10,11 @@
   <refsection>
     <title>Loading Manifests</title>
     <para>You can load manifest info by loading the <code>./manifest.json</code> file in
-      your package. In addition there is a shortcut: if you're using AMD loading you can
-      use a special module id to access all the manifests in one shot:</para>
+      your package. In addition there is a shortcut, by loading the <code>../manifests.json</code>
+      you can load all the manifests at once.</para>
 
-<programlisting>
-define([
-    'manifests',
-    'other.dep'
-], function(manifests, other) {
-    var manifest = manifests['package'];
-});
-</programlisting>
+    <para>Lastly load the <code>../manifests.js</code> file to register the manifests at
+      the <code>cockpit.manifests</code> global variable.</para>
   </refsection>
 
 </refentry>

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -896,6 +896,9 @@ function basic_scope(cockpit, jquery) {
         return obj;
     };
 
+    /* These can be filled in by loading ../manifests.js */
+    cockpit.manifests = { };
+
     /* ------------------------------------------------------------
      * Text Encoding
      */

--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -796,14 +796,18 @@ handle_package_manifests_js (CockpitWebServer *server,
                              CockpitWebResponse *response,
                              CockpitPackages *packages)
 {
+  const gchar *template =
+    "(function (root, data) { if (typeof define === 'function' && define.amd) { define(data); }"
+    " if(typeof cockpit === 'object') { cockpit.manifests = data; }"
+    " else { root.manifests = data; } }(this, ";
   GHashTable *out_headers;
   GBytes *content;
   GBytes *prefix;
   GBytes *suffix;
 
-  prefix = g_bytes_new_static ("define(", 7);
+  prefix = g_bytes_new_static (template, strlen (template));
   content = cockpit_json_write_bytes (packages->json);
-  suffix = g_bytes_new_static (");", 2);
+  suffix = g_bytes_new_static ("));", 3);
 
   out_headers = cockpit_web_server_new_table ();
 


### PR DESCRIPTION
This can now work with normal &lt;script&gt; tags. We register the manifests
at cockpit.manifests global variable in that case.