### PR TITLE
test: Remove hack for SELinux + rhsmcertd

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -568,9 +568,6 @@ class MachineCase(unittest.TestCase):
         "(audit: )?type=1400 .*denied.*comm=\"cockpit-ws\".*name=\"unix\".*dev=\"proc\".*",
         "(audit: )?type=1400 .*denied.*comm=\"ssh-transport-c\".*name=\"unix\".*dev=\"proc\".*",
 
-        # https://bugzilla.redhat.com/show_bug.cgi?id=1299054
-        "(audit: )?type=1400 .*denied.*comm=\"rhsmcertd-worke\".*name=\".dbenv.lock\".*",
-
         # SELinux fighting with systemd: https://bugzilla.redhat.com/show_bug.cgi?id=1253319
         "(audit: )?type=1400 audit.*systemd-journal.*path=2F6D656D66643A73642D73797374656D642D636F726564756D202864656C6574656429",
 


### PR DESCRIPTION
Apparently this is supposed to be fixed:

https://bugzilla.redhat.com/show_bug.cgi?id=1299054