### PR TITLE
common: handle 0-length json strings

### DIFF
--- a/src/common/cockpitjson.c
+++ b/src/common/cockpitjson.c
@@ -587,6 +587,14 @@ cockpit_json_parse_bytes (GBytes *data,
                           GError **error)
 {
   gsize length = g_bytes_get_size (data);
+
+  if (length == 0)
+    {
+      g_set_error (error, JSON_PARSER_ERROR, JSON_PARSER_ERROR_PARSE,
+                   "JSON data was empty");
+      return NULL;
+    }
+
   return cockpit_json_parse_object (g_bytes_get_data (data, NULL), length, error);
 }
 


### PR DESCRIPTION
cockpit_json_parse_object() doesn't accept @data being NULL, but GBytes
may return NULL when its size is 0 (and GMappedFile returns such a
GBytes).

Without this, cockpit_json_parse_bytes() can return NULL without setting
@error.

Fixes #4891