### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-adece82f020769a16d02b71404d2126ec0d507e8.qcow2
+debian-unstable-1c9ad89edfed75e001c560f9c37f9542a2c84d80.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on cockpit-9.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-08-26/