### PR TITLE
Limit the maximum dropdown-menu height and scroll

### DIFF
--- a/src/base1/cockpit.css
+++ b/src/base1/cockpit.css
@@ -970,3 +970,10 @@ input[type=number] {
 .btn.fa-plus {
     padding-top: 4px;
 }
+
+/* Limit dropdown menus to 90% of the viewport size */
+.dropdown-menu {
+    height: auto;
+    overflow-x: hidden;
+    max-height: 90vh;
+}


### PR DESCRIPTION
When a dropdown menu gets too large, the first option is that it
should probably be replaced by another control, such as a searchable
list.

However in places where the expansion is a corner case, or the screen
is very small we should show a scrollable menu. That's what this pull
request does.

Issue #4944