### PR TITLE
ws: Make the auth_fd configurable in cockpit-ws

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -58,10 +58,13 @@ The command will be called with two arguments
  * remote host: The remote host to use with pam.
 
 cockpit-ws will then send contents of the Authorization http header, without the
-auth scheme, on fd #3 to the command. Once the command has processed the credentials
-it MUST write a JSON response to fd #3. Cockpit opens this fd using SOCK_SEQPACKET so
-messages can be sent and received in one operation. Each message should be no more
-than 65536 bytes.
+auth scheme, on a special authentication fd to the command. By default this is fd #3.
+Once the command has processed the credentials it MUST write a JSON response to the
+same authentication fd. Cockpit opens this fd using SOCK_SEQPACKET so messages can be
+sent and received in one operation. Each message should be no more than 65536 bytes.
+If your command needs to use a different FD for some reason you may add a ```authFD```
+option to your auth schema configuration. The configured number must be greater than
+2 and less than 1024.
 
 By default cockpit-ws will wait a maximum of 30 seconds to receive this response.
 The number of seconds to wait can be adjusted by adding a timeout parameter along

--- a/src/ws/mock-auth-command.c
+++ b/src/ws/mock-auth-command.c
@@ -98,98 +98,102 @@ main (int argc,
       char **argv)
 {
   int success = 0;
+  int fd = AUTH_FD;
   char *data = NULL;
 
-  data = read_seqpacket_message (AUTH_FD);
+  if (argc > 2 && strcmp (argv[1], "testscheme-fd-4") == 0)
+    fd = 4;
+
+  data = read_seqpacket_message (fd);
   if (strcmp (data, "failslow") == 0)
     {
       sleep (2);
-      write_resp (AUTH_FD, "{ \"error\": \"authentication-failed\" }");
+      write_resp (fd, "{ \"error\": \"authentication-failed\" }");
     }
   else if (strcmp (data, "fail") == 0)
     {
-      write_resp (AUTH_FD, "{ \"error\": \"authentication-failed\" }");
+      write_resp (fd, "{ \"error\": \"authentication-failed\" }");
     }
   else if (strcmp (data, "denied") == 0)
     {
-      write_resp (AUTH_FD, "{ \"error\": \"permission-denied\" }");
+      write_resp (fd, "{ \"error\": \"permission-denied\" }");
     }
   else if (strcmp (data, "success") == 0)
     {
-      write_resp (AUTH_FD, "{\"user\": \"me\" }");
+      write_resp (fd, "{\"user\": \"me\" }");
       success = 1;
     }
   else if (strcmp (data, "success-with-data") == 0)
     {
-      write_resp (AUTH_FD, "{\"user\": \"me\", \"login-data\": { \"login\": \"data\"} }");
+      write_resp (fd, "{\"user\": \"me\", \"login-data\": { \"login\": \"data\"} }");
       success = 1;
     }
   else if (strcmp (data, "two-step") == 0)
     {
       free(data);
-      write_resp (AUTH_FD, "{\"prompt\": \"type two\" }");
-      data = read_seqpacket_message (AUTH_FD);
+      write_resp (fd, "{\"prompt\": \"type two\" }");
+      data = read_seqpacket_message (fd);
       if (!data || strcmp (data, "two") != 0)
         {
-          write_resp (AUTH_FD, "{ \"error\": \"authentication-failed\" }");
+          write_resp (fd, "{ \"error\": \"authentication-failed\" }");
         }
       else
         {
-          write_resp (AUTH_FD, "{\"user\": \"me\" }");
+          write_resp (fd, "{\"user\": \"me\" }");
           success = 1;
         }
     }
   else if (strcmp (data, "three-step") == 0)
     {
       free(data);
-      write_resp (AUTH_FD, "{\"prompt\": \"type two\" }");
-      data = read_seqpacket_message (AUTH_FD);
+      write_resp (fd, "{\"prompt\": \"type two\" }");
+      data = read_seqpacket_message (fd);
       if (!data || strcmp (data, "two") != 0)
         {
-          write_resp (AUTH_FD, "{ \"error\": \"authentication-failed\" }");
+          write_resp (fd, "{ \"error\": \"authentication-failed\" }");
           goto out;
         }
 
-      write_resp (AUTH_FD, "{\"prompt\": \"type three\" }");
+      write_resp (fd, "{\"prompt\": \"type three\" }");
       free(data);
-      data = read_seqpacket_message (AUTH_FD);
+      data = read_seqpacket_message (fd);
       if (!data || strcmp (data, "three") != 0)
         {
-          write_resp (AUTH_FD, "{ \"error\": \"authentication-failed\" }");
+          write_resp (fd, "{ \"error\": \"authentication-failed\" }");
         }
       else
         {
-          write_resp (AUTH_FD, "{\"user\": \"me\" }");
+          write_resp (fd, "{\"user\": \"me\" }");
           success = 1;
         }
       success = 1;
     }
   else if (strcmp (data, "success-bad-data") == 0)
     {
-      write_resp (AUTH_FD, "{\"user\": \"me\", \"login-data\": \"bad\" }");
+      write_resp (fd, "{\"user\": \"me\", \"login-data\": \"bad\" }");
       success = 1;
     }
   else if (strcmp (data, "no-user") == 0)
     {
-      write_resp (AUTH_FD, "{ }");
+      write_resp (fd, "{ }");
     }
   else if (strcmp (data, "with-error") == 0)
     {
-      write_resp (AUTH_FD, "{ \"error\": \"unknown\", \"message\": \"detail for error\" }");
+      write_resp (fd, "{ \"error\": \"unknown\", \"message\": \"detail for error\" }");
     }
   else if (strcmp (data, "with-error") == 0)
     {
-      write_resp (AUTH_FD, "{ \"error\": \"unknown\", \"message\": \"detail for error\" }");
+      write_resp (fd, "{ \"error\": \"unknown\", \"message\": \"detail for error\" }");
     }
   else if (strcmp (data, "too-slow") == 0)
     {
       sleep (10);
-      write_resp (AUTH_FD, "{\"user\": \"me\", \"login-data\": { \"login\": \"data\"} }");
+      write_resp (fd, "{\"user\": \"me\", \"login-data\": { \"login\": \"data\"} }");
       success = 1;
     }
 
 out:
-  close(AUTH_FD);
+  close(fd);
 
   if (success)
     execlp ("cat", "cat", NULL);

--- a/src/ws/mock-config.conf
+++ b/src/ws/mock-config.conf
@@ -22,6 +22,11 @@ action = spawn-login-with-header
 command = mock-auth-command
 response-timeout = 2
 
+[testscheme-fd-4]
+action = spawn-login-with-header
+command = mock-auth-command
+authFD = 4
+
 [timeout-scheme]
 action = spawn-login-with-header
 command = mock-auth-command

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -524,6 +524,12 @@ static const SuccessFixture fixture_data = {
   .header = "testscheme success-with-data"
 };
 
+static const SuccessFixture fixture_auth_fd = {
+  .warning = NULL,
+  .data = "data",
+  .header = "testscheme-fd-4 success-with-data"
+};
+
 static const ErrorFixture fixture_bad_command = {
   .error_code = COCKPIT_ERROR_FAILED,
   .error_message = "Internal error in login process",
@@ -1005,6 +1011,8 @@ main (int argc,
   g_test_add ("/auth/idle-timeout", Test, NULL, setup, test_idle_timeout, teardown);
   g_test_add ("/auth/process-timeout", Test, NULL, setup, test_process_timeout, teardown);
   g_test_add ("/auth/custom-success", Test, &fixture_no_data,
+              setup_normal, test_custom_success, teardown_normal);
+  g_test_add ("/auth/custom-success-auth-fd", Test, &fixture_auth_fd,
               setup_normal, test_custom_success, teardown_normal);
   g_test_add ("/auth/custom-success-bad-data", Test, &fixture_bad_data,
               setup_normal, test_custom_success, teardown_normal);


### PR DESCRIPTION
Some commands are not able to use fd 3, because reasons. While that's dumb, we can be more flexible by allowing the auth fd number to be configurable along side the command. The command still needs to know what fd number to expect but this gives cockpit-ws a little more flexibility.