### PR TITLE
docker: implement new design

### DIFF
--- a/pkg/docker/containers-view.jsx
+++ b/pkg/docker/containers-view.jsx
@@ -1,0 +1,459 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+'use strict';
+
+var cockpit = require('cockpit');
+var _ = cockpit.gettext;
+
+var $ = require("jquery");
+var docker = require('./docker');
+var util = require('./util');
+var searchImage = require("./search");
+var React = require('react');
+var Listing = require('cockpit-components-listing.jsx');
+var Select = require('cockpit-components-select.jsx');
+var moment = require('moment');
+
+var Dropdown = React.createClass({
+    getDefaultProps: function () {
+        return {
+            actions: [ { label: '' } ]
+        };
+    },
+
+    handleClick: function (event) {
+        if (event.button !== 0)
+            return;
+
+        var action = this.props.actions[event.currentTarget.getAttribute('data-value')];
+        if (!action.disabled && action.onActivate)
+            action.onActivate();
+    },
+
+    render: function () {
+        return (
+            <div className="btn-group">
+                <button className="btn btn-default" type="button" data-value="0" onClick={this.handleClick}>
+                    <span>{ this.props.actions[0].label }</span>
+                </button>
+                <button className="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                    <div className="caret"></div>
+                </button>
+                <ul className="dropdown-menu dropdown-menu-right" role="menu">
+                    {
+                        this.props.actions.map(function (action, index) {
+                            return (
+                                <li className={ action.disabled ? 'disabled' : '' }>
+                                    <a data-value={index} onClick={this.handleClick}>{action.label}</a>
+                                </li>
+                            );
+                        }.bind(this))
+                    }
+                </ul>
+            </div>
+        );
+    }
+});
+
+var ContainerHeader = React.createClass({
+    getInitialState: function () {
+        return {
+            filter: 'running',
+            filterText: ''
+        }
+    },
+
+    filterChanged: function () {
+        if (this.props.onFilterChanged)
+            this.props.onFilterChanged(this.state.filter, this.state.filterText);
+    },
+
+    handleFilterChange: function (value) {
+        this.setState({ filter: value }, this.filterChanged);
+    },
+
+    handleFilterTextChange: function (event) {
+        this.setState({ filterText: this.refs.filterTextInput.value }, this.filterChanged);
+    },
+
+    render: function () {
+        return (
+            <div>
+                <Select.Select id="containers-containers-filter" initial="running" onChange={this.handleFilterChange}>
+                    <Select.SelectEntry data='all'>{_('Everything')}</Select.SelectEntry>
+                    <Select.SelectEntry data='running'>{_('Images and running containers')}</Select.SelectEntry>
+                </Select.Select>
+                <input type="text"
+                       id="containers-filter"
+                       ref="filterTextInput"
+                       className="form-control"
+                       placeholder={_('Type to filter…')}
+                       onChange={this.handleFilterTextChange} />
+            </div>
+        );
+    }
+});
+
+var ContainerDetails = React.createClass({
+    render: function () {
+        var container = this.props.container;
+        return (
+            <div className='listing-body'>
+                <dl>
+                    <dt>{_('Id')}      </dt> <dd>{ container.Id }</dd>
+                    <dt>{_('Created')} </dt> <dd>{ container.Created }</dd>
+                    <dt>{_('Image')}   </dt> <dd>{ container.Image }</dd>
+                    <dt>{_('Commmand')}</dt> <dd>{ util.render_container_cmdline(container) }</dd>
+                    <dt>{_('State')}   </dt> <dd>{ util.render_container_state(container.State) }</dd>
+                </dl>
+            </div>
+        );
+    }
+});
+
+var ContainerList = React.createClass({
+    getDefaultProps: function () {
+        return {
+            client: {},
+            onlyShowRunning: true,
+            filterText: ''
+        };
+    },
+
+    getInitialState: function () {
+        return {
+            containers: []
+        };
+    },
+
+    navigateToContainer: function (container) {
+        cockpit.location.go([ container.Id ]);
+    },
+
+    startContainer: function (container) {
+        this.props.client.start(container.Id).fail(util.show_unexpected_error);
+    },
+
+    stopContainer: function (container) {
+        this.props.client.stop(container.Id).fail(util.show_unexpected_error);
+    },
+
+    restartContainer: function (container) {
+        this.props.client.restart(container.Id).fail(util.show_unexpected_error);
+    },
+
+    deleteContainer: function (container, event) {
+        if (event.button !== 0)
+            return;
+
+        util.confirm(cockpit.format(_("Please confirm deletion of $0"), docker.truncate_id(container.Id)),
+                     _("Deleting a container will erase all data in it."),
+                     _("Delete"))
+                         .done(function () {
+                             util.docker_container_delete(this.props.client, container.Id,
+                                 function() { }, function () { });
+                         }.bind(this));
+    },
+
+    containersChanged: function () {
+        var containers = Object.keys(this.props.client.containers).map(function (id) {
+            return this.props.client.containers[id];
+        }.bind(this));
+
+        containers.sort(function (a, b) {
+            return new Date(b.Created).getTime() - new Date(a.Created).getTime();
+        });
+
+        this.setState({ containers: containers });
+    },
+
+    componentDidMount: function () {
+        $(this.props.client).on('container.containers', this.containersChanged);
+        $(this.props.client).on('container.container-details', this.containersChanged);
+    },
+
+    componentWillUnmount: function () {
+        $(this.props.client).off('container.containers', this.containersChanged);
+        $(this.props.client).off('container.container-details', this.containersChanged);
+    },
+
+    render: function () {
+        var filtered = this.state.containers.filter(function (container) {
+            if (this.props.onlyShowRunning && !container.State.Running)
+                return false;
+
+            if (container.Name.toLowerCase().indexOf(this.props.filterText.toLowerCase()) < 0)
+                return false;
+
+            return true;
+        }.bind(this));
+
+        var rows = filtered.map(function (container) {
+            var isRunning = !!container.State.Running;
+
+            var columns = [
+                { name: container.Name.replace(/^\//, ''), header: true },
+                docker.truncate_id(container.Image),
+                util.render_container_cmdline(container),
+                util.format_cpu_usage(container.CpuUsage),
+                util.format_memory_and_limit(container.MemoryUsage, container.MemoryLimit),
+                container.State.Status
+            ];
+
+            var startStopActions = [];
+            if (isRunning)
+                startStopActions.push({ label: _('Stop'), onActivate: this.stopContainer.bind(this, container) });
+            else
+                startStopActions.push({ label: _('Start'), onActivate: this.startContainer.bind(this, container) });
+
+            startStopActions.push({
+                label: _('Restart'),
+                onActivate: this.restartContainer.bind(this, container),
+                disabled: !isRunning
+            });
+
+            var actions = [
+                <button className="btn btn-danger btn-delete pficon pficon-delete"
+                        onClick={ this.deleteContainer.bind(this, container) } />,
+                <button className="btn btn-default"
+                        disabled={isRunning}
+                        data-container-id={container.Id}
+                        data-toggle="modal" data-target="#container-commit-dialog">
+                    {_("Commit")}
+                </button>,
+                <Dropdown actions={startStopActions} />
+            ];
+
+            var tabs = [
+                {
+                    name: _('Details'),
+                    renderer: ContainerDetails,
+                    data: { container: container }
+                }
+            ];
+
+            return <Listing.ListingRow key={container.Id}
+                                       columns={columns}
+                                       tabRenderers={tabs}
+                                       navigateToItem={ this.navigateToContainer.bind(this, container) }
+                                       listingActions={actions}/>;
+        }, this);
+
+        var columnTitles =  [ _('Name'), _('Image'), _('Command'), _('CPU'), _('Memory'), _('State')];
+
+        var emptyCaption;
+        if (this.props.onlyShowRunning) {
+            if (this.props.filterText === '')
+                emptyCaption = _('No running containers');
+            else
+                emptyCaption = _('No running containers that match the current filter');
+        } else {
+            if (this.props.filterText === '')
+                emptyCaption = _('No containers');
+            else
+                emptyCaption = _('No containers that match the current filter');
+        }
+
+        return (
+            <Listing.Listing title={_('Containers')} columnTitles={columnTitles} emptyCaption={emptyCaption}>
+                {rows}
+            </Listing.Listing>
+        );
+    }
+});
+
+var ImageDetails = React.createClass({
+    render: function () {
+        var image = this.props.image;
+        var created = moment.unix(image.Created);
+        var entrypoint = '';
+        var command = '';
+        var ports = [];
+
+        if (image.Config) {
+            entrypoint = image.Config.Entrypoint;
+            command = image.Config.Cmd;
+            ports = image.Config.ExposedPorts || [];
+        }
+
+        return (
+            <div className='listing-body'>
+                <dl>
+                    <dt>Id         </dt> <dd title={image.Id}>{ docker.truncate_id(image.Id) }</dd>
+                    <dt>Entrypoint </dt> <dd>{ util.quote_cmdline(entrypoint) }</dd>
+                    <dt>Command    </dt> <dd>{ util.quote_cmdline(command) }</dd>
+                    <dt>Created    </dt> <dd title={ created.toLocaleString() }>{ created.fromNow() }</dd>
+                    <dt>Author     </dt> <dd>{ image.Author}</dd>
+                    <dt>Ports      </dt> <dd>{ ports.join(', ')  }</dd>
+                </dl>
+            </div>
+        );
+    }
+});
+
+var ImageList = React.createClass({
+    getDefaultProps: function () {
+        return {
+            client: {}
+        };
+    },
+
+    getInitialState: function () {
+        return {
+            images: [],
+            pulling: []
+        };
+    },
+
+    navigateToImage: function (image) {
+        cockpit.location.go([ 'image', image.Id ]);
+    },
+
+    handleSearchImageClick: function (event) {
+        if (event.button !== 0)
+            return;
+
+        searchImage(this.props.client).then(function (repo, tag, registry) {
+            this.props.client.pull(repo, tag, registry);
+        }.bind(this));
+    },
+
+    deleteImage: function (image, event) {
+        if (event.button !== 0)
+            return;
+
+        util.confirm(cockpit.format(_('Delete $0'), image.RepoTags[0]),
+                     _('Are you sure you want to delete this image?'), _('Delete')).
+            done(function () {
+                this.props.client.rmi(image.Id).
+                    fail(function(ex) {
+                        util.show_unexpected_error(ex);
+                    });
+            }.bind(this));
+    },
+
+    showRunImageDialog: function (event) {
+        $('#containers_run_image_dialog').modal('show', event.currentTarget);
+        event.stopPropagation();
+    },
+
+    imagesChanged: function () {
+        var images = Object.keys(this.props.client.images).map(function (id) {
+            return this.props.client.images[id];
+        }.bind(this));
+
+        images.sort(function (a, b) {
+            return b.Created - a.Created; /* unix timestamps */
+        });
+
+        this.setState({ images: images });
+    },
+
+    pullingChanged: function () {
+        this.setState({ pulling: this.props.client.pulling });
+    },
+
+    componentDidMount: function () {
+        $(this.props.client).on('image.containers', this.imagesChanged);
+        $(this.props.client).on('pulling.containers', this.pullingChanged);
+    },
+
+    componentWillUnmount: function () {
+        $(this.props.client).off('image.containers', this.imagesChanged);
+        $(this.props.client).off('pulling.containers', this.pullingChanged);
+    },
+
+    render: function () {
+        var imageRows = this.state.images.map(function (image) {
+            var columns = [
+                { name: image.RepoTags[0], header: true },
+                moment.unix(image.Created).fromNow(),
+                cockpit.format_bytes(image.VirtualSize),
+                {
+                    element: <button className="btn btn-default btn-control-ct fa fa-play"
+                                     onClick={ this.showRunImageDialog.bind(this) }
+                                     data-image={image.Id} />,
+                    tight: true
+                }
+            ];
+
+            var tabs = [
+                {
+                    name: _('Details'),
+                    renderer: ImageDetails,
+                    data: { image: image }
+                }
+            ];
+
+            var actions = [
+                <button className="btn btn-danger btn-delete pficon pficon-delete"
+                        onClick={ this.deleteImage.bind(this, image) } />
+            ];
+
+            return <Listing.ListingRow key={image.Id}
+                                       columns={columns}
+                                       tabRenderers={tabs}
+                                       navigateToItem={ this.navigateToImage.bind(this, image) }
+                                       listingActions={actions}/>;
+        }, this);
+
+        var getNewImageAction = <a onClick={this.handleSearchImageClick} className="card-pf-link-with-icon pull-right">
+                                    <span className="pficon pficon-add-circle-o"></span>Get new image
+                                </a>;
+
+        var columnTitles = [ _('Name'), _('Created'), _('Size'), '' ];
+
+        var pendingRows = this.state.pulling.map(function (job) {
+            if (job.error)
+                return <p className="status has-error">{job.error}</p>;
+
+            var detail = '';
+            if (job.progress) {
+                detail = (
+                    <span>
+                        ({ cockpit.format_bytes(job.progress.current) }
+                        &nbsp;/&nbsp;
+                        { cockpit.format_bytes(job.progress.total) })
+                    </span>
+                );
+            }
+
+            return <p className="status">{job.name}: {job.status} {detail}</p>;
+        });
+
+        return (
+            <div>
+                <Listing.Listing title={_('Images')}
+                                 columnTitles={columnTitles}
+                                 emptyCaption={_("No images")}
+                                 actions={getNewImageAction}>
+                    {imageRows}
+                </Listing.Listing>
+                {pendingRows}
+            </div>
+        );
+    }
+});
+
+module.exports = {
+    ContainerHeader: ContainerHeader,
+    ContainerList: ContainerList,
+    ImageList: ImageList
+};

--- a/pkg/docker/details.js
+++ b/pkg/docker/details.js
@@ -88,52 +88,6 @@
                     }
                     $('#container-resources-dialog').dialog('promise', prom);
                 });
-
-            var commit = $('#container-commit-dialog')[0];
-            $(commit).
-                on("show.bs.modal", function() {
-                    var info = self.client.containers[self.container_id];
-
-                    $(commit).find(".container-name").text(self.name);
-
-                    var image = self.client.images[info.Config.Image];
-                    var repo = "";
-                    if (image && image.RepoTags)
-                        repo = image.RepoTags[0].split(":", 1)[0];
-                    $(commit).find(".container-repository").attr('value', repo);
-
-                    $(commit).find(".container-tag").attr('value', "");
-
-                    cockpit.user().done(function (user) {
-                        var author = user.full_name || user.name;
-                        $(commit).find(".container-author").attr('value', author);
-                    });
-
-                    var command = "";
-                    if (info.Config)
-                        command = util.quote_cmdline(info.Config.Cmd);
-                    if (!command)
-                        command = info.Command;
-                    $(commit).find(".container-command").attr('value', command);
-                }).
-                find(".btn-primary").on("click", function() {
-                    var location = cockpit.location;
-                    var run = { "Cmd": util.unquote_cmdline($(commit).find(".container-command").val()) };
-                    var options = {
-                        "author": $(commit).find(".container-author").val()
-                    };
-                    var tag = $(commit).find(".container-tag").val();
-                    if (tag)
-                        options["tag"] = tag;
-                    var repository = $(commit).find(".container-repository").val();
-                    self.client.commit(self.container_id, repository, options, run).
-                        fail(function(ex) {
-                            util.show_unexpected_error(ex);
-                        }).
-                        done(function() {
-                            location.go("/");
-                        });
-                });
         },
 
         enter: function(container_id) {
@@ -154,6 +108,8 @@
                 if (id == self.container_id)
                     self.update();
             });
+
+            $('#container-details-commit')[0].dataset.containerId = container_id;
 
             this.update();
         },

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -299,6 +299,20 @@
     text-align: right;
 }
 
+#containers-header {
+    background: #f5f5f5;
+    border-bottom: 1px solid #ddd;
+    padding: 10px 20px;
+    width: 100%;
+}
+
+#containers-header input[type="text"] {
+    display: inline-block;
+    vertical-align: middle;
+    width: 200px;
+    margin-left: 6px;
+}
+
 /*
  * Styling of bar graphs. See controls.js for more details
  */
@@ -527,4 +541,10 @@ table.drive-list td:nth-child(2) img {
 .modal-body .alert {
     margin-bottom: -20px;
     margin-top: 30px;
+}
+
+.status {
+    padding-left: 32px;
+    padding-top: 1em;
+    color: #888;
 }

--- a/pkg/docker/docker.js
+++ b/pkg/docker/docker.js
@@ -750,5 +750,15 @@
         return num;
     };
 
+    /*
+     * Returns the short id of a docker container or image id.
+     */
+    docker.truncate_id = function (id) {
+        var c = id.indexOf(':');
+        if (c >= 0)
+            id = id.slice(c + 1);
+        return id.substr(0, 12);
+    };
+
     module.exports = docker;
 }());

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -85,87 +85,34 @@
 
   <!-- OVERVIEW -->
 
-  <div id="containers" class="container-fluid page-ct" hidden>
-    <div class="col-md-12 col-lg-8">
-      <div class="row">
-        <div class="col-sm-6">
-          <div>
-            <span class="plot-unit" id="containers-cpu-unit">%</span><span class="plot-title" translatable="yes">Combined CPU usage</span>
+  <div id="containers" hidden>
+    <div id="containers-header"></div>
+    <div class="container-fluid page-ct">
+      <div class="col-md-12 col-lg-8">
+        <div class="row">
+          <div class="col-sm-4">
+            <div>
+              <span class="plot-unit" id="containers-cpu-unit">%</span><span class="plot-title" translatable="yes">Combined CPU usage</span>
+            </div>
+            <div id="containers-cpu-graph"></div>
           </div>
-          <div id="containers-cpu-graph"></div>
-        </div>
-        <div class="col-sm-6">
-          <div>
-            <span class="plot-unit" id="containers-mem-unit"></span><span class="plot-title" translatable="yes">Combined memory usage</span>
+          <div class="col-sm-4">
+            <div>
+              <span class="plot-unit" id="containers-mem-unit"></span><span class="plot-title" translatable="yes">Combined memory usage</span>
+            </div>
+            <div id="containers-mem-graph"></div>
           </div>
-          <div id="containers-mem-graph"></div>
-        </div>
-      </div>
-      <br/>
-      <div class="panel panel-default" id="containers-containers">
-        <div class="panel-heading">
-          <span class="pull-right">
-              <div class="btn-group dropdown" id="containers-containers-filter">
-                  <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
-                      <span translatable="yes">Running</span>
-                      <div class="caret"></div>
-                  </button>
-                  <ul class="dropdown-menu dropdown-menu-right">
-                      <li><a translatable="yes" value="all">All</a></li>
-                      <li><a translatable="yes" value="running">Running</a></li>
-                  </ul>
+          <div class="col-sm-4">
+            <div class="panel-body">
+              <div id="containers-storage-details">
               </div>
-          </span>
-          Containers
-        </div>
-        <table class="table table-hover filter-unimportant">
-          <thead>
-            <tr>
-              <th class="container-column-name">Name</th>
-              <th class="container-column-image">Image</th>
-              <th class="container-column-command">Command</th>
-              <th class="container-column-cpu">CPU</th>
-              <th class="container-column-memory-graph">Memory</th>
-              <th class="container-column-memory-text"></th>
-              <th class="container-column-actions cell-buttons"></th>
-            </tr>
-          </thead>
-          <tbody>
-          </tbody>
-        </table>
-      </div>
-    </div>
-    <div class="col-md-12 col-lg-4">
-      <div class="panel panel-default" id="containers-storage">
-        <div class="panel-body">
-          <div id="containers-storage-details">
+            </div>
           </div>
         </div>
+        <br/>
       </div>
-    </div>
-    <div class="col-md-12 col-lg-4">
-      <div class="panel panel-default" id="containers-images">
-        <div class="panel-heading">
-          <span class="pull-right">
-            <button class="btn btn-primary" id="containers-images-search" translatable="yes">
-              Get new image
-            </button>
-          </span>
-          Images
-        </div>
-        <table class="table table-hover">
-          <thead>
-            <tr>
-              <th class="image-column-tags">Tags</th>
-              <th class="image-column-created">Created</th>
-              <th class="image-column-size-text">Size</th>
-              <th class="cell-buttons"><!-- Action --></th>
-            </tr>
-          </thead>
-          <tbody>
-          </tbody>
-        </table>
-      </div>
+      <div id="containers-containers"></div>
+      <div id="containers-images"></div>
     </div>
   </div>
 

--- a/pkg/docker/util.js
+++ b/pkg/docker/util.js
@@ -122,6 +122,9 @@
     };
 
     util.format_memory_and_limit = function format_memory_and_limit(usage, limit) {
+        if (usage === undefined || isNaN(usage))
+            return "";
+
         var mtext = "";
         var units = 1024;
         var parts;

--- a/test/avocado/selenium-login.py
+++ b/test/avocado/selenium-login.py
@@ -63,8 +63,8 @@ class BasicTestSuite(SeleniumTest):
         if self.wait_xpath("//*[@data-action='docker-start']", fatal=False, overridetry=5, cond=clickable):
             self.click(self.wait_xpath("//*[@data-action='docker-start']",cond=clickable))
         self.wait_id('containers')
-        self.wait_id('containers-storage')
-        self.click(self.wait_id('containers-images-search', cond=clickable))
+        self.wait_id('containers-images')
+        self.click(self.wait_link('Get new image', cond=clickable))
         self.wait_id('containers-search-image-dialog')
         self.send_keys(self.wait_id('containers-search-image-search'), "fedora")
         self.wait_id('containers-search-image-results')
@@ -72,7 +72,7 @@ class BasicTestSuite(SeleniumTest):
         self.click(self.wait_xpath(
             "//div[@id='containers-search-image-dialog']//button[contains(text(), '%s')]" % "Cancel",cond=clickable))
         self.wait_id('containers-search-image-dialog',cond=invisible)
-        self.click(self.wait_id('containers-images-search',cond=clickable))
+        self.click(self.wait_link('Get new image', cond=clickable))
         self.wait_id('containers-search-image-dialog')
         self.send_keys(self.wait_id('containers-search-image-search'), "cockpit")
         self.wait_id('containers-search-image-results')

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -70,7 +70,7 @@ class TestDocker(MachineCase):
         b.wait_visible("#containers-containers")
         b.click("#containers-containers-filter button")
         b.wait_visible("#containers-containers-filter .dropdown-menu")
-        b.click("#containers-containers-filter a[value='all']")
+        b.click("#containers-containers-filter li[data-data='all'] a")
 
         # Run it
         b.click('#containers-images tr:contains("busybox:latest") button.fa-play')
@@ -144,18 +144,16 @@ class TestDocker(MachineCase):
         # delete PROBE2 from dash
         b.click("#container-details ol.breadcrumb a")
         b.wait_visible("#containers-containers")
-        b.wait_in_text('#containers-containers tbody', "PROBE2")
-        b.wait_not_visible("#containers-containers tbody tr:contains('PROBE2') button.btn-delete")
-        b.click("#containers-containers button.enable-danger")
-        b.wait_visible("#containers-containers tbody tr:contains('PROBE2') button.btn-delete")
-        b.wait_not_present("#containers-containers tbody tr:contains('PROBE2') button.btn-delete.disabled")
-        b.click("#containers-containers tbody tr:contains('PROBE2') button.btn-delete")
+        b.wait_in_text('#containers-containers', "PROBE2")
+        b.click('#containers-containers tbody tr:contains("PROBE2") td.listing-ct-toggle')
+        b.wait_visible('#containers-containers tbody tr:contains("PROBE2") + tr button.btn-delete')
+        b.click('#containers-containers tbody tr:contains("PROBE2") + tr button.btn-delete')
         with b.wait_timeout(20):
             try:
-                b.wait_not_in_text('#containers-containers tbody', "PROBE2")
+                b.wait_not_in_text('#containers-containers', "PROBE2")
             except:
                 self.confirm()
-                b.wait_not_in_text('#containers-containers tbody', "PROBE2")
+                b.wait_not_in_text('#containers-containers', "PROBE2")
 
         # Check output of PROBE1
         b.click('#containers-containers tr:contains("PROBE1")')
@@ -276,7 +274,7 @@ CMD ["/listen-on-port.sh", "%(port)d", "%(message)s"]
         # Select to view all running containers
         b.wait_visible("#containers-containers-filter button")
         b.click("#containers-containers-filter button")
-        b.click("#containers-containers-filter li a[value='all']")
+        b.click("#containers-containers-filter li[data-data='all'] a")
 
         # Create an updated image, add environment variable
         m.execute("mkdir /var/tmp/container-probe")
@@ -418,12 +416,16 @@ CMD ["/bin/sh"]
         m.execute("systemctl restart docker")
         self.login_and_go("/docker")
 
+        # show all containers to interact with stopped ones
+        b.wait_visible("#containers-containers")
+        b.click("#containers-containers-filter button")
+        b.wait_visible("#containers-containers-filter .dropdown-menu")
+        b.click("#containers-containers-filter li[data-data='all'] a")
+
         # Now check that one restarts
         b.wait_in_text("#containers-images", "busybox:latest")
-        b.wait_present("#containers-containers tr:contains(\"YAYRESTART\")")
-        b.wait_visible("#containers-containers tr:contains(\"YAYRESTART\")")
-        b.wait_present("#containers-containers tr:contains(\"NORESTART\")")
-        b.wait_not_visible("#containers-containers tr:contains(\"NORESTART\")")
+        b.wait_present('#containers-containers tr:contains("YAYRESTART") td:contains("running")')
+        b.wait_present('#containers-containers tr:contains("NORESTART") td:contains("exited")')
 
     def testResources(self):
         b = self.browser

--- a/test/verify/naughty-rhel-7/4978-docker-selinux-broken-10
+++ b/test/verify/naughty-rhel-7/4978-docker-selinux-broken-10
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "./verify/check-docker", line 238, in testExpose
+    b.wait_popdown("containers_run_image_dialog")

--- a/test/verify/naughty-rhel-7/4978-docker-selinux-broken-11
+++ b/test/verify/naughty-rhel-7/4978-docker-selinux-broken-11
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "./verify/check-docker", line 457, in testResources
+    b.wait_popdown("containers_run_image_dialog")

--- a/test/verify/naughty-rhel-7/4978-docker-selinux-broken-12
+++ b/test/verify/naughty-rhel-7/4978-docker-selinux-broken-12
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "./verify/check-docker", line 396, in testRestart
+    b.wait_popdown("containers_run_image_dialog")

--- a/test/verify/naughty-rhel-7/4978-docker-selinux-broken-13
+++ b/test/verify/naughty-rhel-7/4978-docker-selinux-broken-13
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "./verify/check-docker", line 320, in testVolumesAndEnvironment
+    b.wait_popdown("containers_run_image_dialog")


### PR DESCRIPTION
Working towards the new [design][1] for the docker page.

- [x] row headers in cockpit's current listing view react component look different from the design
- [x] hook up buttons in expanded container row
- ~~[ ] add console and metrics tabs to expanded container row~~
- ~~[ ] maybe add "containers" tab to expanded image row~~
- [x] figure out where to put "get new image" button
- [x] add filtering by name
- ~~[ ] change storage and metric cards~~
- [x] adjust tests

(Edit: postpone some of the goals here to get the bulk of this rewrite in and unblock things.)

![screenshot from 2016-09-01 17-54-57](https://cloud.githubusercontent.com/assets/1221707/18169936/61324250-706d-11e6-8574-9f00844e7e01.png)

[1]: https://raw.githubusercontent.com/cockpit-project/cockpit-design/master/containers/container-list-design.png