### PR TITLE
bridge: Implement minimum package version checks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -146,6 +146,7 @@ distclean-local::
 	rm -rf dist/
 install-data-local:: $(WEBPACK_INSTALL)
 	tar -cf - $^ | tar -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
+	$(SED_SUBST) -i $(DESTDIR)$(pkgdatadir)/*/manifest.json
 uninstall-local::
 	rm -rf $(DESTDIR)$(pkgdatadir)
 dist-hook:: $(WEBPACK_INPUTS) $(WEBPACK_OUTPUTS)

--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -109,6 +109,12 @@ $ cockpit-bridge --packages
           field overrides that name.</para></listitem>
       </varlistentry>
       <varlistentry>
+        <term>requires</term>
+        <listitem><para>An optional JSON object that contains a <code>"cockpit"</code>
+          string version number. The package will only be usable if the Cockpit bridge
+          and javascript base are equal or newer than the given version number.</para></listitem>
+      </varlistentry>
+      <varlistentry>
         <term>tools</term>
         <listitem><para>An optional JSON object containing all the tools that this package
           provides. These will be added into the Cockpit user interface under the 'Tools' menu.
@@ -141,6 +147,9 @@ $ cockpit-bridge --packages
 <programlisting>
 {
   "version": 0,
+  "require": {
+      "cockpit": "120"
+  },
   "tools": {
      "mytool": {
         "label": "My Tool",

--- a/pkg/dashboard/manifest.json
+++ b/pkg/dashboard/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": 0,
+    "version": "@VERSION@",
     "requires": {
 	"cockpit": "0.114"
     },

--- a/pkg/dashboard/manifest.json
+++ b/pkg/dashboard/manifest.json
@@ -1,5 +1,8 @@
 {
     "version": 0,
+    "requires": {
+	"cockpit": "0.114"
+    },
 
     "dashboard": {
         "index": {

--- a/pkg/docker/manifest.json
+++ b/pkg/docker/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": 0,
+    "version": "@VERSION@",
     "requires": {
 	"cockpit": "0.114"
     },

--- a/pkg/docker/manifest.json
+++ b/pkg/docker/manifest.json
@@ -1,5 +1,8 @@
 {
     "version": 0,
+    "requires": {
+	"cockpit": "0.114"
+    },
 
     "menu": {
         "index": {

--- a/pkg/kubernetes/manifest.json
+++ b/pkg/kubernetes/manifest.json
@@ -1,4 +1,8 @@
 {
+    "requires": {
+	"cockpit": "0.114"
+    },
+
     "dashboard": {
         "index": {
             "label": "Cluster",

--- a/pkg/kubernetes/manifest.json
+++ b/pkg/kubernetes/manifest.json
@@ -1,4 +1,5 @@
 {
+    "version": "@VERSION@",
     "requires": {
 	"cockpit": "0.114"
     },

--- a/pkg/networkmanager/manifest.json
+++ b/pkg/networkmanager/manifest.json
@@ -1,6 +1,9 @@
 {
     "version": 0,
     "name": "network",
+    "requires": {
+	"cockpit": "0.114"
+    },
 
     "menu": {
         "index": {

--- a/pkg/networkmanager/manifest.json
+++ b/pkg/networkmanager/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": 0,
+    "version": "@VERSION@",
     "name": "network",
     "requires": {
 	"cockpit": "0.114"

--- a/pkg/ostree/manifest.json
+++ b/pkg/ostree/manifest.json
@@ -1,6 +1,10 @@
 {
     "version": 0,
     "name": "updates",
+    "requires": {
+	"cockpit": "0.114"
+    },
+
     "tools": {
         "ostree": {
             "label": "Software Updates",

--- a/pkg/ostree/manifest.json
+++ b/pkg/ostree/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": 0,
+    "version": "@VERSION@",
     "name": "updates",
     "requires": {
 	"cockpit": "0.114"

--- a/pkg/playground/manifest.json
+++ b/pkg/playground/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": 0,
+    "version": "@VERSION@",
     "requires": {
 	"cockpit": "0.114"
     },

--- a/pkg/playground/manifest.json
+++ b/pkg/playground/manifest.json
@@ -1,5 +1,8 @@
 {
     "version": 0,
+    "requires": {
+	"cockpit": "0.114"
+    },
 
     "tools": {
         "patterns": {

--- a/pkg/realmd/manifest.json
+++ b/pkg/realmd/manifest.json
@@ -1,4 +1,7 @@
 {
     "version": 0,
-    "name": "domain"
+    "name": "domain",
+    "requires": {
+	"cockpit": "0.114"
+    }
 }

--- a/pkg/realmd/manifest.json
+++ b/pkg/realmd/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": 0,
+    "version": "@VERSION@",
     "name": "domain",
     "requires": {
 	"cockpit": "0.114"

--- a/pkg/selinux/manifest.json
+++ b/pkg/selinux/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": 0,
+    "version": "@VERSION@",
     "requires": {
 	"cockpit": "0.114"
     },

--- a/pkg/selinux/manifest.json
+++ b/pkg/selinux/manifest.json
@@ -1,5 +1,8 @@
 {
     "version": 0,
+    "requires": {
+	"cockpit": "0.114"
+    },
 
     "tools": {
         "setroubleshoot": {

--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -1,5 +1,8 @@
 {
     "version": 0,
+    "requires": {
+	"cockpit": "0.114"
+    },
 
     "linguas": {
         "en": "English",

--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": 0,
+    "version": "@VERSION@",
     "requires": {
 	"cockpit": "0.114"
     },

--- a/pkg/sosreport/manifest.json
+++ b/pkg/sosreport/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": 0,
+    "version": "@VERSION@",
     "requires": {
 	"cockpit": "0.114"
     },

--- a/pkg/sosreport/manifest.json
+++ b/pkg/sosreport/manifest.json
@@ -1,5 +1,8 @@
 {
     "version": 0,
+    "requires": {
+	"cockpit": "0.114"
+    },
 
     "tools": {
         "index": {

--- a/pkg/storaged/manifest.json
+++ b/pkg/storaged/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": 0,
+    "version": "@VERSION@",
     "name": "storage",
     "requires": {
 	"cockpit": "0.114"

--- a/pkg/storaged/manifest.json
+++ b/pkg/storaged/manifest.json
@@ -1,6 +1,9 @@
 {
     "version": 0,
     "name": "storage",
+    "requires": {
+	"cockpit": "0.114"
+    },
 
     "menu": {
         "index": {

--- a/pkg/subscriptions/manifest.json
+++ b/pkg/subscriptions/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": 0,
+    "version": "@VERSION@",
     "requires": {
 	"cockpit": "0.114"
     },

--- a/pkg/subscriptions/manifest.json
+++ b/pkg/subscriptions/manifest.json
@@ -1,5 +1,8 @@
 {
     "version": 0,
+    "requires": {
+	"cockpit": "0.114"
+    },
 
     "tools": {
         "index": {

--- a/pkg/systemd/manifest.json
+++ b/pkg/systemd/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": 0,
+    "version": "@VERSION@",
     "name": "system",
 
     "requires": {

--- a/pkg/systemd/manifest.json
+++ b/pkg/systemd/manifest.json
@@ -2,6 +2,10 @@
     "version": 0,
     "name": "system",
 
+    "requires": {
+	"cockpit": "0.114"
+    },
+
     "menu": {
         "index": {
             "label": "System",

--- a/pkg/tuned/manifest.json
+++ b/pkg/tuned/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": 0,
+    "version": "@VERSION@",
     "name": "performance",
     "requires": {
 	"cockpit": "0.114"

--- a/pkg/tuned/manifest.json
+++ b/pkg/tuned/manifest.json
@@ -1,4 +1,7 @@
 {
     "version": 0,
-    "name": "performance"
+    "name": "performance",
+    "requires": {
+	"cockpit": "0.114"
+    }
 }

--- a/pkg/users/manifest.json
+++ b/pkg/users/manifest.json
@@ -1,5 +1,5 @@
 {
-    "version": 0,
+    "version": "@VERSION@",
     "requires": {
 	"cockpit": "0.114"
     },

--- a/pkg/users/manifest.json
+++ b/pkg/users/manifest.json
@@ -1,5 +1,8 @@
 {
     "version": 0,
+    "requires": {
+	"cockpit": "0.114"
+    },
 
     "tools": {
         "index": {

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -2,6 +2,7 @@
 [encoding: UTF-8]
 # List of source files outside of pkg/ containing translatable strings.
 src/bridge/cockpitdbussetup.c
+src/bridge/cockpitpackages.c
 src/common/cockpitcertificate.c
 src/common/cockpitconnect.c
 src/ws/cockpit.appdata.xml.in

--- a/src/base1/manifest.json
+++ b/src/base1/manifest.json
@@ -1,4 +1,3 @@
 {
-    "version": 0,
-    "alias": "latest"
+    "version": "@VERSION@"
 }

--- a/src/base1/test-http.html
+++ b/src/base1/test-http.html
@@ -59,6 +59,9 @@ asyncTest("simple request", function() {
         .done(function(data) {
             deepEqual(JSON.parse(data), {
                 version: 0,
+                'requires': {
+                    "cockpit": "0.114"
+                },
                 tools: {
                     'patterns': {
                         label: "Design Patterns",

--- a/src/base1/test-http.html
+++ b/src/base1/test-http.html
@@ -58,7 +58,7 @@ asyncTest("simple request", function() {
     cockpit.http({ "internal": "/test-server" }).get("/pkg/playground/manifest.json")
         .done(function(data) {
             deepEqual(JSON.parse(data), {
-                version: 0,
+                version: "@VERSION@",
                 'requires': {
                     "cockpit": "0.114"
                 },

--- a/src/base1/test-stub.html
+++ b/src/base1/test-stub.html
@@ -97,7 +97,7 @@ asyncTest("http", function() {
     cockpit.http({ "internal": "/test-server" }).get("/pkg/playground/manifest.json")
         .done(function(data) {
             deepEqual(JSON.parse(data), {
-                version: 0,
+                version: "@VERSION@",
                 requires: {
                     cockpit: "0.114"
                 },

--- a/src/base1/test-stub.html
+++ b/src/base1/test-stub.html
@@ -98,6 +98,9 @@ asyncTest("http", function() {
         .done(function(data) {
             deepEqual(JSON.parse(data), {
                 version: 0,
+                requires: {
+                    cockpit: "0.114"
+                },
                 tools: {
                     'patterns': {
                         label: "Design Patterns",

--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -558,7 +558,8 @@ check_package_compatible (CockpitPackage *package,
    */
   if (minimum && cockpit_version_compare (PACKAGE_VERSION, minimum) < 0)
     {
-      g_message ("%s: package requires a later version of cockpit: %s", package->name, minimum);
+      g_message ("%s: package requires a later version of cockpit: %s > %s",
+                 package->name, minimum, PACKAGE_VERSION);
       package->unavailable = g_strdup_printf (_("This package requires Cockpit version %s or later"), minimum);
     }
 

--- a/src/bridge/mock-resource/home/cockpit/incompatible/manifest.json
+++ b/src/bridge/mock-resource/home/cockpit/incompatible/manifest.json
@@ -1,0 +1,6 @@
+{
+    "description": "incompatible package",
+    "requires": {
+        "cockpit": "999.5"
+    }
+}

--- a/src/bridge/mock-resource/home/cockpit/incompatible/test.html
+++ b/src/bridge/mock-resource/home/cockpit/incompatible/test.html
@@ -1,0 +1,6 @@
+<html>
+<head>
+<title>In incompatible dir</title>
+</head>
+<body>In incompatible dir</body>
+</html>

--- a/src/bridge/mock-resource/home/cockpit/requires/manifest.json
+++ b/src/bridge/mock-resource/home/cockpit/requires/manifest.json
@@ -1,0 +1,6 @@
+{
+    "description": "requires package",
+    "requires": {
+        "unknown": "requirement"
+    }
+}

--- a/src/bridge/mock-resource/home/cockpit/requires/test.html
+++ b/src/bridge/mock-resource/home/cockpit/requires/test.html
@@ -1,0 +1,6 @@
+<html>
+<head>
+<title>In requires dir</title>
+</head>
+<body>In requires dir</body>
+</html>

--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -92,7 +92,7 @@ setup (TestCase *tc,
     }
   else
     {
-      cockpit_expect_message ("incompatible: package requires a later version of cockpit: 999.5");
+      cockpit_expect_message ("incompatible: package requires a later version of cockpit: 999.5*");
       cockpit_expect_message ("requires: package has an unknown requirement: unknown");
     }
 
@@ -527,7 +527,7 @@ static void
 setup_basic (TestCase *tc,
              gconstpointer data)
 {
-  cockpit_expect_message ("incompatible: package requires a later version of cockpit: 999.5");
+  cockpit_expect_message ("incompatible: package requires a later version of cockpit: 999.5*");
   cockpit_expect_message ("requires: package has an unknown requirement: unknown");
   tc->packages = cockpit_packages_new ();
 }

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -70,6 +70,8 @@ libcockpit_common_a_SOURCES = \
 	src/common/cockpitunixfd.h \
 	src/common/cockpitunixsignal.c \
 	src/common/cockpitunixsignal.h \
+	src/common/cockpitversion.c \
+	src/common/cockpitversion.h \
 	src/common/cockpitwebfilter.h \
 	src/common/cockpitwebfilter.c \
 	src/common/cockpitwebinject.h \
@@ -115,6 +117,7 @@ COCKPIT_CHECKS = \
 	test-webserver \
 	test-config \
 	test-unicode \
+	test-version \
 	$(NULL)
 
 
@@ -158,6 +161,10 @@ test_unicode_LDADD = $(libcockpit_common_a_LIBS)
 test_unixsignal_CFLAGS = $(libcockpit_common_a_CFLAGS)
 test_unixsignal_SOURCES = src/common/test-unixsignal.c
 test_unixsignal_LDADD = $(libcockpit_common_a_LIBS)
+
+test_version_CFLAGS = $(libcockpit_common_a_CFLAGS)
+test_version_SOURCES = src/common/test-version.c
+test_version_LDADD = $(libcockpit_common_a_LIBS)
 
 test_webresponse_SOURCES = \
 	src/common/test-webresponse.c \

--- a/src/common/cockpitversion.c
+++ b/src/common/cockpitversion.c
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitversion.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+gint
+cockpit_version_compare (const gchar *one,
+                         const gchar *two)
+{
+  gchar **p1 = g_strsplit (one, ".", -1);
+  gchar **p2 = g_strsplit (two, ".", -1);
+  gchar *e1, *e2;
+  gulong v1, v2;
+  gint ret = 0;
+  gint i = 0;
+
+  while (p1[i] != NULL && p2[i] != NULL)
+    {
+      e1 = e2 = NULL;
+      v1 = strtoul (p1[i], &e1, 10);
+      v2 = strtoul (p2[i], &e2, 10);
+
+      /* Compare as numbers */
+      if (e1 && e1[0] == '\0' && e2 && e2[0] == '\0')
+        {
+          if (v1 < v2)
+            {
+              ret = -1;
+              break;
+            }
+          else if (v1 > v2)
+            {
+              ret = 1;
+              break;
+            }
+        }
+      else
+        {
+          ret = strcmp (p1[i], p2[i]);
+          if (ret != 0)
+            break;
+        }
+
+      i++;
+    }
+
+  if (p1[i] && !p2[i])
+    ret = 1;
+  else if (!p1[i] && p2[i])
+    ret = -1;
+
+  g_strfreev (p1);
+  g_strfreev (p2);
+  return ret;
+}

--- a/src/common/cockpitversion.h
+++ b/src/common/cockpitversion.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __COCKPIT_VERSION_H__
+#define __COCKPIT_VERSION_H__
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+gint          cockpit_version_compare       (const gchar *one,
+                                             const gchar *two);
+
+G_END_DECLS
+
+#endif /* __COCKPIT_VERSION_H__ */

--- a/src/common/test-version.c
+++ b/src/common/test-version.c
@@ -1,0 +1,95 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitversion.h"
+
+#include "common/cockpittest.h"
+
+#include <string.h>
+
+typedef struct {
+  const gchar *one;
+  const gchar *two;
+  const gint result;
+} Fixture;
+
+static void
+test_compare_version (gconstpointer data)
+{
+  const Fixture *fixture = data;
+  gint res;
+
+  g_assert (data != NULL);
+
+  res = cockpit_version_compare (fixture->one, fixture->two);
+
+  /* Normalize */
+  if (res < 0)
+    res = -1;
+  else if (res > 0)
+    res = 1;
+
+  g_assert_cmpint (res, ==, fixture->result);
+}
+
+static const Fixture fixtures[] = {
+  { "", "", 0 },
+  { "0", "", 1 },
+  { "", "5", -1 },
+  { "0", "0", 0 },
+  { "0", "0.1", -1 },
+  { "0.2", "0", 1 },
+  { "0.2.3", "0", 1 },
+  { "1.0", "1.0", 0 },
+  { "1.0", "1.1", -1 },
+  { "1.3", "1.1", 1 },
+  { "1.2.3", "1.2.3", 0 },
+  { "1.2.3", "1.2.5", -1 },
+  { "1.2.8", "1.2.5", 1 },
+  { "55", "55", 0 },
+  { "5abc", "5abc", 0 },
+  { "5abc", "5abcd", -1 },
+  { "5xyz", "5abcd", 1 },
+  { "abc", "abc", 0 },
+  { "xyz", "abc", 1 },
+};
+
+int
+main (int argc,
+      char *argv[])
+{
+  gchar *name;
+  gint i;
+
+  cockpit_test_init (&argc, &argv);
+
+  for (i = 0; i < G_N_ELEMENTS (fixtures); i++)
+    {
+      g_assert (fixtures[i].one != NULL);
+      g_assert (fixtures[i].two != NULL);
+      name = g_strdup_printf ("/version/compare/%s_%s", fixtures[i].one, fixtures[i].two);
+
+      g_test_add_data_func (name, fixtures + i, test_compare_version);
+      g_free (name);
+    }
+
+  return g_test_run ();
+}


### PR DESCRIPTION
This is so packages can check that the Cockpit bridge and base package are at least a given version. We expect the bridge and base package to be shipped together.
