### PR TITLE
test: Add workaround for docker restart issue

### DIFF
--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -377,6 +377,11 @@ CMD ["/bin/sh"]
         b = self.browser
         m = self.machine
 
+        # HACK: https://github.com/docker/docker/issues/25246
+        if m.image in [ "debian-unstable" ]:
+            m.execute("printf '\\n\\n[Service]\\nKillMode=process\\n' >> /lib/systemd/system/docker.service")
+            m.execute("systemctl daemon-reload")
+
         m.execute("systemctl start docker")
 
         self.login_and_go("/docker")


### PR DESCRIPTION
The version of docker.service on Debian ships a bad
KillMode setting. See:

https://github.com/docker/docker/blob/master/contrib/init/systemd/docker.service#L25

This fixes issue in check-docker testRestart