### PR TITLE
test: Disconnect SSH master when waiting for reboot

### DIFF
--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -1153,6 +1153,7 @@ class VirtMachine(Machine):
         self.event_handler.reset_domain_reboot_status(self._domain)
 
     def wait_reboot(self, wait_for_running_timeout=120):
+        self.disconnect()
         if not self.event_handler.wait_for_reboot(self._domain):
             raise Failure("system didn't notify us about a reboot")
         # we may have to check for a new dhcp lease, but the old one can be active for a bit


### PR DESCRIPTION
This is a pretty good hint that the SSH process should
disconnect. It's my hope that this fixes issues with:

Failure: SSH master process exited with code: 255