### PR TITLE
tools: Add semaphore commands

### DIFF
--- a/tools/semaphore-prepare
+++ b/tools/semaphore-prepare
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sudo apt-get update
+sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libgirepository1.0-dev libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-journal-dev pcp pkg-config valgrind xmlto xsltproc

--- a/tools/semaphore-run
+++ b/tools/semaphore-run
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+./autogen.sh --prefix=/usr --enable-strict --with-systemdunitdir=/tmp
+make V=1 all
+sudo make enable-root-tests
+make distcheck
+make -j8 check-memory


### PR DESCRIPTION
Due to the problems with travis we wanted to try some other CI solutions. You can see this used here, running off of cockpituous' repo:

https://semaphoreci.com/cockpituous/cockpit/branches/semaphore/builds/2

If this is merged, i'll update the repo to point to cockpit-project/cockpit, and add people to notifications. Unfortunately there is no IRC integration, though we could do something with webhooks if we wanted to.

For comparison, there's also a branch with circleci: https://circleci.com/gh/cockpituous/cockpit/3