### PR TITLE
test: Enable setroubleshoot on RHEL

### DIFF
--- a/test/images/scripts/rhel-7.setup
+++ b/test/images/scripts/rhel-7.setup
@@ -84,6 +84,15 @@ sos \
 tuned \
 "
 
+# If the RHEL version is new enough, install setroubleshoot-server
+RHEL_VERSION=`rpm -q redhat-release-server`
+OLD_VERSION="redhat-release-server-7.2"
+if [ "${RHEL_VERSION/$OLD_VERSION}" = "$RHEL_VERSION" ]; then
+    echo "Skipping setroubleshoot-server"
+else
+    COCKPIT_DEPS+=" setroubleshoot-server"
+fi
+
 # We also install the packages necessary to join a FreeIPA domain so
 # that we don't have to go to the network during a test run.
 # on epel/rhel we have ipa-client instead of freeipa-client

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -22,6 +22,7 @@ import parent
 from testlib import *
 
 import os
+import re
 import subprocess
 import unittest
 
@@ -54,12 +55,23 @@ ssh -o StrictHostKeyChecking=no -o 'BatchMode=yes' -i ~/.ssh/test-avc-rsa localh
 mv -f ~/.ssh/authorized_keys.test-avc ~/.ssh/authorized_keys
 """
 
-@unittest.skipIf("rhel" in os.environ.get("TEST_OS", ""), "DBUS API of setroubleshoot too old.")
+# We aren't running these tests on anything older than 7.2 for now, and starting 7.3 we have setroubleshoot
+def rhel_is_too_old(machine):
+    expression = """redhat-release-server-(.*)\.el.\.x86_64"""
+    version = machine.execute('rpm -q redhat-release-server', quiet=True)
+    matches = re.match(expression, version)
+    return matches.group(1).startswith("7.2")
+
 @unittest.skipIf("centos" in os.environ.get("TEST_OS", ""), "DBUS API of setroubleshoot too old.")
 @unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No setroubleshoot on debian.")
 @unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "No setroubleshoot on atomic systems.")
 class TestSelinux(MachineCase):
     def testTroubleshootAlerts(self):
+        # if this is a rhel system and it's too old, skip
+        if "rhel" in os.environ.get("TEST_OS", "") and rhel_is_too_old(self.machine):
+            self.machine.message("Skipping test because the detected RHEL version is too old.")
+            return
+
         b = self.browser
 
         self.login_and_go("/selinux/setroubleshoot")
@@ -150,6 +162,11 @@ class TestSelinux(MachineCase):
         #b.wait_in_text("body", "No SELinux alerts.")
 
     def testEnforcingToggle(self):
+        # if this is a rhel system and it's too old, skip
+        if "rhel" in os.environ.get("TEST_OS", "") and rhel_is_too_old(self.machine):
+            self.machine.message("Skipping test because the detected RHEL version is too old.")
+            return
+
         b = self.browser
         m = self.machine
 


### PR DESCRIPTION
Install setroubleshoot-server on rhel systems if available.
Also, don't skip the tests categorically on rhel - check if the system is new enough, first.