### PR TITLE
Bump RPM requirement for storaged packages

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -378,7 +378,7 @@ This package contains the Cockpit shell UI assets.
 
 %package storaged
 Summary: Cockpit user interface for storage, using Storaged
-Requires: %{name}-bridge >= %{stable_api}
+Requires: %{name}-bridge >= %{version}-%{release}
 Requires: %{name}-shell >= %{stable_api}
 Requires: storaged >= 2.1.1
 %if 0%{?fedora} >= 24 || 0%{?rhel} >= 8


### PR DESCRIPTION
It loads /manifests.js and requires a newer version of Cockpit.
Unfortunately earlier versions of the /manifests.js, assumed
that AMD and require.js were in play. This is no longer the case.

More related work in the following pull request:

Issue #4976