### PR TITLE
Make storaged/override.json not depend on Webpack

### DIFF
--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -3,6 +3,12 @@ TESTS += \
 	pkg/storaged/test-util.html \
 	$(NULL)
 
+# HACK: https://github.com/storaged-project/storaged/pull/68
+storageddir = $(pkgdatadir)/storaged
+nodist_storaged_DATA = \
+       pkg/storaged/override.json \
+       $(NULL)
+
 if WITH_GOLANG
 
 AM_V_GO = $(am__v_GO_@AM_V@)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -150,7 +150,6 @@ var info = {
 
         "storaged/index.html",
         "storaged/manifest.json",
-        "storaged/override.json",
         "storaged/images/storage-array.png",
         "storaged/images/storage-disk.png",
 


### PR DESCRIPTION
This file is generated by configure and thus shouldn't require
Webpack and node to run in order to be installed.

Yes this is ugly. This file is a hack around:

https://github.com/storaged-project/storaged/pull/68

Fixes #4987