### PR TITLE
static: Automatically focus the user field in login screen

### DIFF
--- a/src/static/login.html
+++ b/src/static/login.html
@@ -305,7 +305,6 @@
                 id("server-name").appendChild(b);
 
                 login_note("Log in with your server user account.");
-                id("login-user-input").focus();
                 id("login-user-input").addEventListener("keydown", function(e) {
                     login_failure(null);
                     if (e.which == 13)
@@ -318,6 +317,7 @@
                         call_login();
                 });
                 show_form();
+                id("login-user-input").focus();
                 phantom_checkpoint();
             }
 

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -51,6 +51,9 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         def login(user, password):
             b.wait_visible("#login")
+            b.wait_visible("#login-user-input")
+            # :focus selector doesn't work in phantomjs
+            b.wait_js_cond("document.activeElement.getAttribute('id') === 'login-user-input'")
             b.set_val('#login-user-input', user)
             b.set_val('#login-password-input', password)
             b.click('#login-button')


### PR DESCRIPTION
We used to automatically focus this field. However this no
longer happened once we started supporting PAM conversations.