### PR TITLE
build: Fix typo in webconfig

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ var info = {
             "docker/containers.js",
             "docker/docker.css",
         ],
-        "docker/console.js": [
+        "docker/console": [
             "docker/console.js",
         ],
         "dashboard/dashboard": [


### PR DESCRIPTION
Extra '.js' resulted in the distributed file docker/console.js.js.gz.