### PR TITLE
test: Remove storaged known issue about LVM2 pool sizes

### DIFF
--- a/test/verify/naughty/4574-incorrrect-fs-usage
+++ b/test/verify/naughty/4574-incorrrect-fs-usage
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-storage-mounting", line 97, in testMounting
-    wait_ratio_in_range(bar_selector, 0.5, 1.0)


### PR DESCRIPTION
This has been fixed in storaged 2.5.2

Fixes #4547