### PR TITLE
test: rpm-ostree known issue has been fixed

### DIFF
--- a/test/verify/naughty-rhel-atomic/4738-rpm-ostree-update-broken
+++ b/test/verify/naughty-rhel-atomic/4738-rpm-ostree-update-broken
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-ostree", line 166, in testOstree
-    b.wait_present('table.listing-ct tbody:nth-child(3) i.fa-circle')


### PR DESCRIPTION
Resolves #4738 on RHEL Atomic. Fedora Atomic 23 and 24 are both still broken.