### PR TITLE
base1: Propagate failure data properly when waiting on DBus proxies

### DIFF
--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -2783,11 +2783,11 @@ function basic_scope(cockpit, jquery) {
 
         client.subscribe({ "path": path, "interface": iface }, signal, options.subscribe !== false);
 
-        function waited() {
+        function waited(ex) {
             if (valid)
                 waits.resolve();
             else
-                waits.reject();
+                waits.reject(ex);
         }
 
         /* If watching then do a proper watch, otherwise object is done */


### PR DESCRIPTION
When waiting on a DBus proxy, propagate the error code correctly
into the promise returned from the .wait() method.