### PR TITLE
lib: Treat React dialogs as a singleton

### DIFF
--- a/lib/cockpit-components-dialog.jsx
+++ b/lib/cockpit-components-dialog.jsx
@@ -185,6 +185,7 @@ var DialogFooter = React.createClass({
 /*
  * React template for a Cockpit dialog
  * The primary action button is disabled while its action is in progress (waiting for promise)
+ * Removes focus on other elements on showing
  * Expected props:
  *  - title (string)
  *  - no_backdrop optional, skip backdrop if true
@@ -201,6 +202,11 @@ var Dialog = React.createClass({
         no_backdrop: React.PropTypes.bool,
         body: React.PropTypes.element.isRequired,
         footer: React.PropTypes.element.isRequired,
+    },
+    componentDidMount: function() {
+        // if we used a button to open this, make sure it's not focused anymore
+        if (document.activeElement)
+            document.activeElement.blur();
     },
     render: function() {
         var backdrop;

--- a/lib/cockpit-components-dialog.jsx
+++ b/lib/cockpit-components-dialog.jsx
@@ -230,8 +230,15 @@ var Dialog = React.createClass({
  * For this, create a containing DOM node at the body level
  */
 var show_modal_dialog = function(dialog_props, footer_props) {
+    var dialog_name = 'cockpit_modal_dialog';
+    // don't allow nested dialogs
+    if (document.getElementById(dialog_name)) {
+        console.warn('Unable to create nested dialog');
+        return;
+    }
     // create an element to render into
     var root_element = document.createElement("div");
+    root_element.id = dialog_name;
     document.body.appendChild(root_element);
 
     // register our own on-close callback

--- a/pkg/playground/react-demo-dialog.jsx
+++ b/pkg/playground/react-demo-dialog.jsx
@@ -87,6 +87,19 @@
                                 <Select.Select />
                             </td>
                         </tr>
+                        <tr>
+                            <td className="top">
+                                <label className="control-label">
+                                    {_("Nested dialog")}
+                                </label>
+                            </td>
+                            <td>
+                                <button id="open-nested" onClick={ this.props.clickNested }>
+                                    {_("Try to nest dialog")}
+                                </button>
+                                <span>{_("Doesn't open a dialog, only shows a warning in the console.")}</span>
+                            </td>
+                        </tr>
                     </table>
                 </div>
             );

--- a/pkg/playground/react-patterns.js
+++ b/pkg/playground/react-patterns.js
@@ -72,7 +72,7 @@
     var on_standard_demo_clicked = function(static_error) {
         var dialog_props = {
             'title': _("Example React Dialog"),
-            'body': React.createElement(demo_dialog),
+            'body': React.createElement(demo_dialog, { 'clickNested': on_standard_demo_clicked }),
         };
         var footer_props = {
             'actions': [


### PR DESCRIPTION
Only allow one to be open at a time and also blur() after opening a dialog to remove potential focus from the triggering button/element.