### PR TITLE
test: Make the virt-builder script more compatible

### DIFF
--- a/test/images/scripts/virt-builder-fedora
+++ b/test/images/scripts/virt-builder-fedora
@@ -35,7 +35,7 @@ if [ "$#" -gt 3 ]; then
       --upload $subscription_path/login:/root/.rhel/login \
       --upload $subscription_path/pass:/root/.rhel/pass"
 else
-    subscription_args="--touch /root/.skip_repos"
+    subscription_args="--write /root/.skip_repos:"
 fi
 
 BASE=$(dirname $0)


### PR DESCRIPTION
The option --touch flag isn't supported on older versions of virt-builder. We can just use --write instead.