### PR TITLE
Listing view

### DIFF
--- a/lib/cockpit-components-listing.css
+++ b/lib/cockpit-components-listing.css
@@ -25,3 +25,7 @@
  * The goal is to have all style rules specific to the listing pattern be here
  * instead of in the base package
  */
+
+table.listing-ct > caption a {
+        font-size: 16px;
+}

--- a/lib/cockpit-components-listing.css
+++ b/lib/cockpit-components-listing.css
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * This file contains some of the style for the listing view component in
+ * cockpit-components-listing.jsx. Other rules can be found in cockpit.css in
+ * the base package.
+ *
+ * The goal is to have all style rules specific to the listing pattern be here
+ * instead of in the base package
+ */

--- a/lib/cockpit-components-listing.css
+++ b/lib/cockpit-components-listing.css
@@ -26,6 +26,15 @@
  * instead of in the base package
  */
 
+div.listing-ct-head {
+        overflow: visible;
+}
+
+.listing-ct-head .btn-group,
+.listing-ct-head button:not(.dropdown-toggle) {
+        margin-left: 0.3em;
+}
+
 table.listing-ct > caption a {
         font-size: 16px;
 }

--- a/lib/cockpit-components-listing.jsx
+++ b/lib/cockpit-components-listing.jsx
@@ -136,6 +136,8 @@ var ListingRow = React.createClass({
                 return (<td>{itm}</td>);
             else if ('header' in itm && itm.header)
                 return (<th>{itm.name}</th>);
+            else if ('tight' in itm && itm.tight)
+                return (<td className="listing-ct-actions">{itm.name || itm.element}</td>);
             else
                 return (<td>{itm.name}</td>);
         });

--- a/lib/cockpit-components-listing.jsx
+++ b/lib/cockpit-components-listing.jsx
@@ -17,257 +17,251 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function (root, factory) {
-    /* globals module */
-    if (typeof exports === 'object') {
-        module.exports = factory(require('react'));
-    } else if (typeof define === 'function' && define.amd) {
-        define(['./react'], factory);
-    }
-}(this, function(React) {
-    "use strict";
+"use strict";
 
-    /* entry for an alert in the listing, can be expanded (with details) or standard
-     * columns list of columns to show in the header
-     *     columns to show, can be a string, react component or object with { name: 'name', 'header': false }
-     *     'header' (or if simple string) defaults to false
-     *     in case 'header' is true, <th> is used for the entries, otherwise <td>
-     * tabRenderers optional: list of tab renderers for inline expansion, array of objects with
-     *     - name tab name (has to be unique in the entry, used as react key)
-     *     - renderer react component
-     *     - data render data passed to the tab renderer
-     *     - presence 'always', 'onlyActive', 'loadOnDemand', default: 'loadOnDemand'
-     *         - 'always' once a row is expanded, this tab is always rendered, but invisible if not active
-     *         - 'onlyActive' the tab is only rendered when active
-     *         - 'loadOnDemand' the tab is first rendered when it becomes active, then follows 'always' behavior
-     *     if tabRenderers isn't set, item can't be expanded inline
-     * navigateToItem optional: callback triggered when a row is clicked, pattern suggests navigation
-     *     to view expanded item details, if not set, navigation isn't available
-     * listingDetail optional: text rendered next to action buttons, similar style to the tab headers
-     * listingActions optional: buttons that are presented as actions for the expanded item
-     */
-    var ListingRow = React.createClass({
-        propTypes: {
-            columns: React.PropTypes.array.isRequired,
-            tabRenderers: React.PropTypes.array,
-            navigateToItem: React.PropTypes.func,
-        },
-        getDefaultProps: function () {
-            return {
-                tabRenderers: [],
-                navigateToItem: null,
-            };
-        },
-        getInitialState: function() {
-            return {
-                expanded: false, // show expanded view if true, otherwise one line compact
-                activeTab: 0,    // currently active tab in expanded mode, defaults to first tab
-                loadedTabs: {},  // which tabs were already loaded - this is important for 'loadOnDemand' setting
-                                 // contains tab indices
-            };
-        },
-        handleNavigateClick: function(e) {
-            // only consider primary mouse button
-            if (!e || e.button !== 0)
-                return;
-            this.props.navigateToItem();
-        },
-        handleExpandClick: function(e) {
-            // only consider primary mouse button
-            if (!e || e.button !== 0)
-                return;
+var React = require('react');
 
-            var willBeExpanded = !this.state.expanded;
-            this.setState( { expanded: willBeExpanded });
+require('./cockpit-components-listing.css');
 
-            var loadedTabs = {};
-            // unload all tabs if not expanded
-            if (willBeExpanded) {
-                // see if we should preload some tabs
-                var tabIdx;
-                var tabPresence;
-                for (tabIdx = 0; tabIdx < this.props.tabRenderers.length; tabIdx++) {
-                    if ('presence' in this.props.tabRenderers[tabIdx])
-                        tabPresence = this.props.tabRenderers[tabIdx].presence;
-                    else
-                        tabPresence = 'default';
-                    // the active tab is covered by separate logic
-                    if (tabPresence == 'always')
-                        loadedTabs[tabIdx] = true;
-                }
-                // ensure the active tab is loaded
-                loadedTabs[this.state.activeTab] = true;
-            }
+/* entry for an alert in the listing, can be expanded (with details) or standard
+ * columns list of columns to show in the header
+ *     columns to show, can be a string, react component or object with { name: 'name', 'header': false }
+ *     'header' (or if simple string) defaults to false
+ *     in case 'header' is true, <th> is used for the entries, otherwise <td>
+ * tabRenderers optional: list of tab renderers for inline expansion, array of objects with
+ *     - name tab name (has to be unique in the entry, used as react key)
+ *     - renderer react component
+ *     - data render data passed to the tab renderer
+ *     - presence 'always', 'onlyActive', 'loadOnDemand', default: 'loadOnDemand'
+ *         - 'always' once a row is expanded, this tab is always rendered, but invisible if not active
+ *         - 'onlyActive' the tab is only rendered when active
+ *         - 'loadOnDemand' the tab is first rendered when it becomes active, then follows 'always' behavior
+ *     if tabRenderers isn't set, item can't be expanded inline
+ * navigateToItem optional: callback triggered when a row is clicked, pattern suggests navigation
+ *     to view expanded item details, if not set, navigation isn't available
+ * listingDetail optional: text rendered next to action buttons, similar style to the tab headers
+ * listingActions optional: buttons that are presented as actions for the expanded item
+ */
+var ListingRow = React.createClass({
+    propTypes: {
+        columns: React.PropTypes.array.isRequired,
+        tabRenderers: React.PropTypes.array,
+        navigateToItem: React.PropTypes.func,
+    },
+    getDefaultProps: function () {
+        return {
+            tabRenderers: [],
+            navigateToItem: null,
+        };
+    },
+    getInitialState: function() {
+        return {
+            expanded: false, // show expanded view if true, otherwise one line compact
+            activeTab: 0,    // currently active tab in expanded mode, defaults to first tab
+            loadedTabs: {},  // which tabs were already loaded - this is important for 'loadOnDemand' setting
+                             // contains tab indices
+        };
+    },
+    handleNavigateClick: function(e) {
+        // only consider primary mouse button
+        if (!e || e.button !== 0)
+            return;
+        this.props.navigateToItem();
+    },
+    handleExpandClick: function(e) {
+        // only consider primary mouse button
+        if (!e || e.button !== 0)
+            return;
 
-            this.setState( { loadedTabs: loadedTabs });
+        var willBeExpanded = !this.state.expanded;
+        this.setState( { expanded: willBeExpanded });
 
-            e.stopPropagation();
-            e.preventDefault();
-        },
-        handleTabClick: function(tabIdx, e) {
-            // only consider primary mouse button
-            if (!e || e.button !== 0)
-                return;
-            var prevTab = this.state.activeTab;
-            var prevTabPresence = 'default';
-            var loadedTabs = this.state.loadedTabs;
-            if (prevTab !== tabIdx) {
-                // see if we need to unload the previous tab
-                if ('presence' in this.props.tabRenderers[prevTab])
-                    prevTabPresence = this.props.tabRenderers[prevTab].presence;
-
-                if (prevTabPresence == 'onlyActive')
-                    delete loadedTabs[prevTab];
-
-                // ensure the new tab is loaded and update state
-                loadedTabs[tabIdx] = true;
-                this.setState({ loadedTabs: loadedTabs, activeTab: tabIdx });
-            }
-            e.stopPropagation();
-            e.preventDefault();
-        },
-        render: function() {
-            var self = this;
-            // only enable navigation if a function is provided and the row isn't expanded (prevnt accidental navigation)
-            var allow_navigate = !!this.props.navigateToItem && !this.state.expanded;
-            var bodyProps = { className: '', onClick: this.handleClick };
-            var count_display = null;
-
-            var header_entries = this.props.columns.map(function(itm) {
-                if (typeof itm === 'string' || itm === null || itm instanceof String || React.isValidElement(itm))
-                    return (<td>{itm}</td>);
-                else if ('header' in itm && itm.header)
-                    return (<th>{itm.name}</th>);
+        var loadedTabs = {};
+        // unload all tabs if not expanded
+        if (willBeExpanded) {
+            // see if we should preload some tabs
+            var tabIdx;
+            var tabPresence;
+            for (tabIdx = 0; tabIdx < this.props.tabRenderers.length; tabIdx++) {
+                if ('presence' in this.props.tabRenderers[tabIdx])
+                    tabPresence = this.props.tabRenderers[tabIdx].presence;
                 else
-                    return (<td>{itm.name}</td>);
-            });
-
-            var expand_toggle = null;
-            if (this.props.tabRenderers.length > 0) {
-                expand_toggle = <td className="listing-ct-toggle" onClick={ allow_navigate?this.handleExpandClick:undefined }>
-                                    <i className="fa fa-fw"></i>
-                                </td>;
+                    tabPresence = 'default';
+                // the active tab is covered by separate logic
+                if (tabPresence == 'always')
+                    loadedTabs[tabIdx] = true;
             }
-            var listing_item_classes = ["listing-ct-item"];
-            if (!allow_navigate)
-                listing_item_classes.push("listing-ct-nonavigate");
-            var listing_item = (
-                <tr className={ listing_item_classes.join(' ') }
-                    onClick={ allow_navigate?this.handleNavigateClick:this.handleExpandClick }>
-                    {expand_toggle}
-                    {header_entries}
-                </tr>
-            );
-
-            if (this.state.expanded) {
-                if (this.props.count > 1)
-                    count_display = <span className="pull-right">{ this.props.count + " occurrences"}</span>;
-                var links = this.props.tabRenderers.map(function(itm, idx) {
-                    return (
-                        <li key={idx} className={ (idx === self.state.activeTab) ? "active" : ""} >
-                            <a href="#" onClick={ self.handleTabClick.bind(self, idx) }>{itm.name}</a>
-                        </li>
-                    );
-                });
-                var tabs = [];
-                var tabIdx;
-                var Renderer;
-                var renderer_data;
-                var row;
-                for (tabIdx = 0; tabIdx < this.props.tabRenderers.length; tabIdx++) {
-                    Renderer = this.props.tabRenderers[tabIdx].renderer;
-                    renderer_data = this.props.tabRenderers[tabIdx].data;
-                    if (tabIdx !== this.state.activeTab && !(tabIdx in this.state.loadedTabs))
-                        continue;
-                    row = <Renderer key={ this.props.tabRenderers[tabIdx].name } hidden={ (tabIdx !== this.state.activeTab) } {...renderer_data} />;
-                    if (tabIdx === this.state.activeTab)
-                        tabs.push(<div className="listing-ct-body" key={tabIdx}>{row}</div>);
-                    else
-                        tabs.push(<div className="listing-ct-body" key={tabIdx} hidden>{row}</div>);
-                }
-
-                var listingDetail;
-                if ('listingDetail' in this.props) {
-                    listingDetail = (
-                        <span className="listing-ct-caption">
-                            {this.props.listingDetail}
-                        </span>
-                    );
-                }
-
-                return (
-                    <tbody className="open">
-                        {listing_item}
-                        <tr className="listing-ct-panel">
-                            <td colSpan={ header_entries.length + (expand_toggle?1:0) }>
-                                <div className="listing-ct-head">
-                                    <div className="listing-ct-actions">
-                                        {listingDetail}
-                                        {this.props.listingActions}
-                                    </div>
-                                    <ul className="nav nav-tabs nav-tabs-pf">
-                                        {links}
-                                    </ul>
-                                </div>
-                                {tabs}
-                            </td>
-                        </tr>
-                    </tbody>
-                );
-            } else {
-                return (
-                    <tbody>
-                        {listing_item}
-                        <tr className="listing-ct-panel"/>
-                    </tbody>
-                );
-            }
+            // ensure the active tab is loaded
+            loadedTabs[this.state.activeTab] = true;
         }
-    });
 
-    /* Implements a PatternFly 'List View' pattern
-     * https://www.patternfly.org/list-view/
-     * Properties:
-     * - title
-     * - fullWidth optional: set width to 100% of parent, defaults to true
-     * - emptyCaption header caption to show if list is empty, defaults to "No entries"
-     */
-    var Listing = React.createClass({
-        propTypes: {
-            title: React.PropTypes.string.isRequired,
-            fullWidth: React.PropTypes.bool,
-            emptyCaption: React.PropTypes.string.isRequired,
-        },
-        getDefaultProps: function () {
-            return {
-                fullWidth: true,
-            };
-        },
-        render: function() {
-            var bodyClasses = ["listing", "listing-ct"];
-            if (this.props.fullWidth)
-                bodyClasses.push("listing-ct-wide");
-            var headerClasses;
-            var headerRow = <tr/>;
-            if (!this.props.children || this.props.children.length === 0) {
-                headerClasses = "listing-ct-empty";
-                headerRow = <tr><td>{this.props.emptyCaption}</td></tr>;
+        this.setState( { loadedTabs: loadedTabs });
+
+        e.stopPropagation();
+        e.preventDefault();
+    },
+    handleTabClick: function(tabIdx, e) {
+        // only consider primary mouse button
+        if (!e || e.button !== 0)
+            return;
+        var prevTab = this.state.activeTab;
+        var prevTabPresence = 'default';
+        var loadedTabs = this.state.loadedTabs;
+        if (prevTab !== tabIdx) {
+            // see if we need to unload the previous tab
+            if ('presence' in this.props.tabRenderers[prevTab])
+                prevTabPresence = this.props.tabRenderers[prevTab].presence;
+
+            if (prevTabPresence == 'onlyActive')
+                delete loadedTabs[prevTab];
+
+            // ensure the new tab is loaded and update state
+            loadedTabs[tabIdx] = true;
+            this.setState({ loadedTabs: loadedTabs, activeTab: tabIdx });
+        }
+        e.stopPropagation();
+        e.preventDefault();
+    },
+    render: function() {
+        var self = this;
+        // only enable navigation if a function is provided and the row isn't expanded (prevnt accidental navigation)
+        var allowNavigate = !!this.props.navigateToItem && !this.state.expanded;
+        var bodyProps = { className: '', onClick: this.handleClick };
+        var countDisplay = null;
+
+        var headerEntries = this.props.columns.map(function(itm) {
+            if (typeof itm === 'string' || itm === null || itm instanceof String || React.isValidElement(itm))
+                return (<td>{itm}</td>);
+            else if ('header' in itm && itm.header)
+                return (<th>{itm.name}</th>);
+            else
+                return (<td>{itm.name}</td>);
+        });
+
+        var expandToggle = null;
+        if (this.props.tabRenderers.length > 0) {
+            expandToggle = <td className="listing-ct-toggle" onClick={ allowNavigate?this.handleExpandClick:undefined }>
+                               <i className="fa fa-fw"></i>
+                           </td>;
+        }
+        var listingItemClasses = ["listing-ct-item"];
+        if (!allowNavigate)
+            listingItemClasses.push("listing-ct-nonavigate");
+        var listingItem = (
+            <tr className={ listingItemClasses.join(' ') }
+                onClick={ allowNavigate?this.handleNavigateClick:this.handleExpandClick }>
+                {expandToggle}
+                {headerEntries}
+            </tr>
+        );
+
+        if (this.state.expanded) {
+            if (this.props.count > 1)
+                countDisplay = <span className="pull-right">{ this.props.count + " occurrences"}</span>;
+            var links = this.props.tabRenderers.map(function(itm, idx) {
+                return (
+                    <li key={idx} className={ (idx === self.state.activeTab) ? "active" : ""} >
+                        <a href="#" onClick={ self.handleTabClick.bind(self, idx) }>{itm.name}</a>
+                    </li>
+                );
+            });
+            var tabs = [];
+            var tabIdx;
+            var Renderer;
+            var rendererData;
+            var row;
+            for (tabIdx = 0; tabIdx < this.props.tabRenderers.length; tabIdx++) {
+                Renderer = this.props.tabRenderers[tabIdx].renderer;
+                rendererData = this.props.tabRenderers[tabIdx].data;
+                if (tabIdx !== this.state.activeTab && !(tabIdx in this.state.loadedTabs))
+                    continue;
+                row = <Renderer key={ this.props.tabRenderers[tabIdx].name } hidden={ (tabIdx !== this.state.activeTab) } {...rendererData} />;
+                if (tabIdx === this.state.activeTab)
+                    tabs.push(<div className="listing-ct-body" key={tabIdx}>{row}</div>);
+                else
+                    tabs.push(<div className="listing-ct-body" key={tabIdx} hidden>{row}</div>);
             }
+
+            var listingDetail;
+            if ('listingDetail' in this.props) {
+                listingDetail = (
+                    <span className="listing-ct-caption">
+                        {this.props.listingDetail}
+                    </span>
+                );
+            }
+
             return (
-                <table className={ bodyClasses.join(" ") }>
-                    <caption className="cockpit-caption">{this.props.title}</caption>
-                    <thead className={headerClasses}>
-                        {headerRow}
-                    </thead>
-                    {this.props.children}
-                </table>
+                <tbody className="open">
+                    {listingItem}
+                    <tr className="listing-ct-panel">
+                        <td colSpan={ headerEntries.length + (expandToggle?1:0) }>
+                            <div className="listing-ct-head">
+                                <div className="listing-ct-actions">
+                                    {listingDetail}
+                                    {this.props.listingActions}
+                                </div>
+                                <ul className="nav nav-tabs nav-tabs-pf">
+                                    {links}
+                                </ul>
+                            </div>
+                            {tabs}
+                        </td>
+                    </tr>
+                </tbody>
             );
-        },
-    });
+        } else {
+            return (
+                <tbody>
+                    {listingItem}
+                    <tr className="listing-ct-panel"/>
+                </tbody>
+            );
+        }
+    }
+});
 
-    return {
-        ListingRow: ListingRow,
-        Listing: Listing,
-    };
+/* Implements a PatternFly 'List View' pattern
+ * https://www.patternfly.org/list-view/
+ * Properties:
+ * - title
+ * - fullWidth optional: set width to 100% of parent, defaults to true
+ * - emptyCaption header caption to show if list is empty, defaults to "No entries"
+ */
+var Listing = React.createClass({
+    propTypes: {
+        title: React.PropTypes.string.isRequired,
+        fullWidth: React.PropTypes.bool,
+        emptyCaption: React.PropTypes.string.isRequired,
+    },
+    getDefaultProps: function () {
+        return {
+            fullWidth: true,
+        };
+    },
+    render: function() {
+        var bodyClasses = ["listing", "listing-ct"];
+        if (this.props.fullWidth)
+            bodyClasses.push("listing-ct-wide");
+        var headerClasses;
+        var headerRow = <tr/>;
+        if (!this.props.children || this.props.children.length === 0) {
+            headerClasses = "listing-ct-empty";
+            headerRow = <tr><td>{this.props.emptyCaption}</td></tr>;
+        }
+        return (
+            <table className={ bodyClasses.join(" ") }>
+                <caption className="cockpit-caption">{this.props.title}</caption>
+                <thead className={headerClasses}>
+                    {headerRow}
+                </thead>
+                {this.props.children}
+            </table>
+        );
+    },
+});
 
-}));
+module.exports = {
+    ListingRow: ListingRow,
+    Listing: Listing,
+};

--- a/lib/cockpit-components-listing.jsx
+++ b/lib/cockpit-components-listing.jsx
@@ -47,6 +47,8 @@ var ListingRow = React.createClass({
         columns: React.PropTypes.array.isRequired,
         tabRenderers: React.PropTypes.array,
         navigateToItem: React.PropTypes.func,
+        listingDetail: React.PropTypes.node,
+        listingActions: React.PropTypes.arrayOf(React.PropTypes.node)
     },
     getDefaultProps: function () {
         return {
@@ -228,18 +230,21 @@ var ListingRow = React.createClass({
  * - fullWidth optional: set width to 100% of parent, defaults to true
  * - emptyCaption header caption to show if list is empty, defaults to "No entries"
  * - columnTitles: array of column titles, as strings
+ * - actions: additional listing-wide actions (displayed next to the list's title)
  */
 var Listing = React.createClass({
     propTypes: {
         title: React.PropTypes.string.isRequired,
         fullWidth: React.PropTypes.bool,
         emptyCaption: React.PropTypes.string.isRequired,
-        columnTitles: React.PropTypes.arrayOf(React.PropTypes.string)
+        columnTitles: React.PropTypes.arrayOf(React.PropTypes.string),
+        actions: React.PropTypes.arrayOf(React.PropTypes.node)
     },
     getDefaultProps: function () {
         return {
             fullWidth: true,
-            columnTitles: []
+            columnTitles: [],
+            actions: []
         };
     },
     render: function() {
@@ -263,7 +268,7 @@ var Listing = React.createClass({
         }
         return (
             <table className={ bodyClasses.join(" ") }>
-                <caption className="cockpit-caption">{this.props.title}</caption>
+                <caption className="cockpit-caption">{this.props.title}{this.props.actions}</caption>
                 <thead className={headerClasses}>
                     {headerRow}
                 </thead>

--- a/lib/cockpit-components-listing.jsx
+++ b/lib/cockpit-components-listing.jsx
@@ -227,16 +227,19 @@ var ListingRow = React.createClass({
  * - title
  * - fullWidth optional: set width to 100% of parent, defaults to true
  * - emptyCaption header caption to show if list is empty, defaults to "No entries"
+ * - columnTitles: array of column titles, as strings
  */
 var Listing = React.createClass({
     propTypes: {
         title: React.PropTypes.string.isRequired,
         fullWidth: React.PropTypes.bool,
         emptyCaption: React.PropTypes.string.isRequired,
+        columnTitles: React.PropTypes.arrayOf(React.PropTypes.string)
     },
     getDefaultProps: function () {
         return {
             fullWidth: true,
+            columnTitles: []
         };
     },
     render: function() {
@@ -244,10 +247,19 @@ var Listing = React.createClass({
         if (this.props.fullWidth)
             bodyClasses.push("listing-ct-wide");
         var headerClasses;
-        var headerRow = <tr/>;
+        var headerRow;
         if (!this.props.children || this.props.children.length === 0) {
             headerClasses = "listing-ct-empty";
             headerRow = <tr><td>{this.props.emptyCaption}</td></tr>;
+        } else if (this.props.columnTitles.length) {
+            headerRow = (
+                <tr>
+                    <th className="listing-ct-toggle"></th>
+                    { this.props.columnTitles.map(function (title) { return <th>{title}</th>; }) }
+                </tr>
+            );
+        } else {
+           headerRow = <tr/>
         }
         return (
             <table className={ bodyClasses.join(" ") }>

--- a/pkg/playground/react-demo-listing.jsx
+++ b/pkg/playground/react-demo-listing.jsx
@@ -51,6 +51,21 @@
             window.alert("navigated to item: " + msg);
         };
 
+        var handleAddClick = function(event) {
+            if (event.button !== 0)
+                return;
+
+            window.alert('This link could open a dialog to create a new entry');
+        };
+
+        var handlePlayClick = function(event) {
+            if (event.button !== 0)
+                return;
+
+            window.alert('This is a row-specific action');
+            event.stopPropagation();
+        };
+
         var tabRenderers = [
             {
                 name: 'onlyActive',
@@ -77,15 +92,27 @@
             },
         ];
 
+        var addLink = <a className="pull-right" onClick={handleAddClick}>Add Row</a>;
+
+        var rowAction = {
+            element: <button className="btn btn-default btn-control fa fa-play" onClick={handlePlayClick} />,
+            tight: true
+        };
+
         // create the dialog
         var listing = (
-            <cockpitListing.Listing title="Demo Listing Pattern with expandable rows">
+            <cockpitListing.Listing title="Demo Listing Pattern with expandable rows"
+                                    actions={addLink}
+                                    columnTitles={['Name', 'Random', 'IP', 'State']}>
                  <cockpitListing.ListingRow
                      columns={ [ { name: 'standard', 'header': true }, 'aoeuaoeu', '127.30.168.10', 'Running' ] }
                      tabRenderers={tabRenderers}
                      navigateToItem={navigateToItem.bind(this, 'frontend')}/>
                  <cockpitListing.ListingRow
                      columns={ [ { name: "can't navigate", 'header': true }, 'aoeuaoeu', '127.30.168.10', 'Running' ] }
+                     tabRenderers={tabRenderers}/>
+                 <cockpitListing.ListingRow
+                     columns={ [ { name: "with button", 'header': true }, 'aoeuaoeu', '127.30.168.10', rowAction ] }
                      tabRenderers={tabRenderers}/>
              </cockpitListing.Listing>
         );

--- a/pkg/playground/react-patterns.html
+++ b/pkg/playground/react-patterns.html
@@ -5,6 +5,7 @@
     <title>Cockpit React Patterns Usage</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="../base1/cockpit.css" type="text/css" rel="stylesheet">
+    <link href="react-patterns.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="react-patterns.js"></script>
 </head>


### PR DESCRIPTION
This branch contains some additions to the listing view we need for #4952.

I'd like the css for the listing view (and in the future, other widgets) to be in their own files, maybe even automatically namespaced. Changing `cockpit.css` for changes like this prone to errors, as that file is technically part of our stable API now.

So, I've removed the UMD-loadability from `cockpit-components-listing.jsx` so that I can `require` a css file in there and have it be picked up by weback. I don't think the react listing is used by anything that doesn't use webpack anymore.