### PR TITLE
test: Fix network team test on fedora-atomic

### DIFF
--- a/test/common/testinfra.py
+++ b/test/common/testinfra.py
@@ -76,7 +76,6 @@ DEFAULT_IMAGE_REFRESH = {
     'fedora-23': {
         'triggers': [
             "verify/fedora-23",
-            "verify/fedora-atomic",  # builds in fedora-23
             "avocado/fedora-23",
             "selenium/firefox",
             "selenium/chrome"
@@ -84,6 +83,7 @@ DEFAULT_IMAGE_REFRESH = {
     },
     'fedora-24': {
         'triggers': [
+            "verify/fedora-atomic",  # builds in fedora-24
             "verify/fedora-24",
         ]
     },

--- a/test/images/fedora-atomic
+++ b/test/images/fedora-atomic
@@ -1,1 +1,1 @@
-fedora-atomic-8e829dacb19a659add6c943dc3fe18a01d31a043.qcow2
+fedora-atomic-c0d9653d11905ae01aadf9a355d9168b0ddaed33.qcow2

--- a/test/images/scripts/fedora-atomic.bootstrap
+++ b/test/images/scripts/fedora-atomic.bootstrap
@@ -3,8 +3,8 @@
 
 set -e
 
-url="http://download.fedoraproject.org/pub/fedora/linux/releases/23/Cloud/x86_64/Images"
-prefix="Fedora-Cloud-Atomic-23"
+url="https://download.fedoraproject.org/pub/alt/atomic/stable/CloudImages/x86_64/images/"
+prefix="Fedora-Atomic-24"
 
 BASE=$(dirname $0)
 $BASE/atomic.bootstrap "$1" "$url" "$prefix"

--- a/test/verify/check-networking
+++ b/test/verify/check-networking
@@ -279,6 +279,22 @@ class TestNetworking(MachineCase):
         self.wait_for_iface(iface1)
         self.wait_for_iface(iface2)
 
+        # HACK - Avoid active slaves
+        #
+        # If an interface is active before Cockpit turns it into a
+        # slave, Cockpit will try to keep it active with the new
+        # settings.  This will fail on the Atomics because they don't
+        # have the "team" plugin installed.
+        #
+        # So we explicitly disconnect the interfaces.  Cockpit will
+        # then not try to activate them again, and we will end up with
+        # a new inactive team.  It can't be activated, but we don't
+        # care about that here.
+        #
+        m.execute("nmcli dev dis %s && nmcli dev dis %s" % (iface1, iface2))
+        b.wait_in_text("#networking-interfaces tr[data-interface='%s']" % iface1, "Inactive")
+        b.wait_in_text("#networking-interfaces tr[data-interface='%s']" % iface2, "Inactive")
+
         # team them
         b.click("button:contains('Add Team')")
         b.wait_popup("network-team-settings-dialog")

--- a/test/verify/testsuite-prepare
+++ b/test/verify/testsuite-prepare
@@ -43,9 +43,9 @@ if __name__ == "__main__":
 
     # The Atomic variants can't build their own packages, so we build in
     # their non-Atomic siblings.  For example, fedora-atomic is build
-    # in fedora-23
+    # in fedora-24
     if test_os == "fedora-atomic":
-        build_os = "fedora-23"
+        build_os = "fedora-24"
     elif test_os == "rhel-atomic":
         build_os = "rhel-7"
     elif test_os == "continuous-atomic":


### PR DESCRIPTION
This works, but it's terrible.

Basically, we can write the configuration files for teams on the Atomics, but we can not activate any of them because of the missing plugin.

This change makes it so that nothing is activated in the test.

By chance, the interfaces are already inactive on rhel-atomic and fedora-atomic when it was based on Fedora 23, so the test is passing there.  On Fedora 24, the interfaces are active by default, and the test fails.

It might be better to just skip teams on the Atomics.  Dunno.