### PR TITLE
networkmanager: Make team support configurable via packages

### DIFF
--- a/pkg/networkmanager-team/manifest.json
+++ b/pkg/networkmanager-team/manifest.json
@@ -1,0 +1,7 @@
+{
+    "version": "1.0",
+
+    "config": {
+        "enable_teams": true
+    }
+}

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -28,6 +28,7 @@
     <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="../shell/po.js"></script>
+    <script src="../manifests.js"></script>
     <script src="network.js"></script>
 </head>
 <body hidden>

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1445,6 +1445,11 @@ PageNetworking.prototype = {
         $("#networking-add-bridge").click($.proxy(this, "add_bridge"));
         $("#networking-add-vlan").click($.proxy(this, "add_vlan"));
 
+        var enable_teams = (cockpit.manifests["networkmanager-team"] &&
+                            cockpit.manifests["networkmanager-team"].config &&
+                            cockpit.manifests["networkmanager-team"].config.enable_teams);
+        $("#networking-add-team").toggle(enable_teams);
+
         function highlight_netdev_row(event, id) {
             $('#networking-interfaces tr').removeClass('highlight-ct');
             if (id) {

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -216,6 +216,9 @@ find %{buildroot}%{_datadir}/%{name}/storaged -type f >> storaged.list
 echo '%dir %{_datadir}/%{name}/networkmanager' > networkmanager.list
 find %{buildroot}%{_datadir}/%{name}/networkmanager -type f >> networkmanager.list
 
+echo '%dir %{_datadir}/%{name}/networkmanager-team' > networkmanager-team.list
+find %{buildroot}%{_datadir}/%{name}/networkmanager-team -type f >> networkmanager-team.list
+
 echo '%dir %{_datadir}/%{name}/ostree' > ostree.list
 find %{buildroot}%{_datadir}/%{name}/ostree -type f >> ostree.list
 
@@ -449,7 +452,7 @@ Requires: %{name}-shell >= %{stable_api}
 Requires: NetworkManager
 # Optional components (only when soft deps are supported)
 %if 0%{?fedora} >= 24 || 0%{?rhel} >= 8
-Recommends: NetworkManager-team
+Recommends: %{name}-networkmanager-team
 %endif
 BuildArch: noarch
 
@@ -457,6 +460,16 @@ BuildArch: noarch
 The Cockpit component for managing networking.  This package uses NetworkManager.
 
 %files networkmanager -f networkmanager.list
+
+%package networkmanager-team
+Summary: Cockpit user interface add-on for networking teams, using NetworkManager
+Requires: NetworkManager-team
+BuildArch: noarch
+
+%description networkmanager-team
+A Cockpit add-on for managing networking team.  This package uses NetworkManager.
+
+%files networkmanager-team -f networkmanager-team.list
 
 %endif
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -115,6 +115,7 @@ var info = {
 
         "networkmanager/index.html",
         "networkmanager/manifest.json",
+        "networkmanager-team/manifest.json",
 
         "ostree/manifest.json",
         "ostree/index.html",


### PR DESCRIPTION
This is an alternative to #5045.  Whether or not Cockpit shows the "Add Team" button can be controlled by installing (or not) the cockpit-networkmanager-team package.

I think this doesn't actually work when the Cockpit packages move into a container.
