### PR TITLE
Change position of branding.css in HTML <head>.

### DIFF
--- a/pkg/dashboard/index.html
+++ b/pkg/dashboard/index.html
@@ -23,8 +23,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="../base1/cockpit.css" rel="stylesheet">
-    <link href="../../static/branding.css" rel="stylesheet">
     <link href="../shell/index.css" rel="stylesheet">
+    <link href="../../static/branding.css" rel="stylesheet">
     <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="../shell/po.js"></script>

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -5,8 +5,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="../base1/cockpit.css" rel="stylesheet">
-    <link href="../../static/branding.css" rel="stylesheet">
     <link href="index.css" rel="stylesheet">
+    <link href="../../static/branding.css" rel="stylesheet">
     <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="../manifests.js"></script>

--- a/pkg/shell/simple.html
+++ b/pkg/shell/simple.html
@@ -5,8 +5,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="../base1/cockpit.css" rel="stylesheet">
-    <link href="../../static/branding.css" rel="stylesheet">
     <link href="index.css" rel="stylesheet">
+    <link href="../../static/branding.css" rel="stylesheet">
     <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="../manifests.js"></script>

--- a/pkg/shell/stub.html
+++ b/pkg/shell/stub.html
@@ -5,8 +5,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="../base1/cockpit.css" rel="stylesheet">
-    <link href="../../static/branding.css" rel="stylesheet">
     <link href="index.css" rel="stylesheet">
+    <link href="../../static/branding.css" rel="stylesheet">
     <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="../manifests.js"></script>


### PR DESCRIPTION
UI customization can be strengthened if branding.css becomes the last stylesheet listed in common HTML `<head>` tags.  This would allow for overriding selectors in other CSS files using the `!important` declaration.