### PR TITLE
base1: fix long words overflowing alerts in dialogs.

### DIFF
--- a/src/base1/cockpit.css
+++ b/src/base1/cockpit.css
@@ -276,10 +276,13 @@ a {
 
 /* Alert fixups */
 
+/* HACK: word-wrap workaround for long alerts https://github.com/patternfly/patternfly/issues/491 */
+
 .modal-content .alert {
     text-align: left;
     padding-top: 5px;
     padding-bottom: 5px;
+    word-wrap: break-word;
 }
 
 .modal-content .alert .fa {


### PR DESCRIPTION
Fixes issue #5068