### PR TITLE
Image refresh for centos-7

### DIFF
--- a/test/images/centos-7
+++ b/test/images/centos-7
@@ -1,1 +1,0 @@
-centos-7-feb0076b05b88563ac18b988572e875d5d35ec38.qcow2


### PR DESCRIPTION
Image creation for centos-7 in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-centos-7-2016-09-24/