### PR TITLE
test: Skip vm tests on atomic

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -30,6 +30,7 @@ def readFile(name):
             content = f.read().replace('\n', '')
     return content
 
+@unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "Don't run virtual machine tests on atomic systems.")
 class TestMachines(MachineCase):
     def tryEnableNestedVirt(self):
         print 'tryEnableNestedVirt() called'

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -44,8 +44,7 @@ class TestMachines(MachineCase):
 
     def testBasic(self):
         if not self.tryEnableNestedVirt():
-            print 'Nested virtualization is not enabled on this test image, skipping the test'
-            return
+            raise unittest.SkipTest('Nested virtualization is not enabled on this test image, skipping the test')
 
         b = self.browser
         m = self.machine

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -33,10 +33,9 @@ def readFile(name):
 @unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "Don't run virtual machine tests on atomic systems.")
 class TestMachines(MachineCase):
     def tryEnableNestedVirt(self):
-        print 'tryEnableNestedVirt() called'
         m = self.machine
-        m.execute('(rmmod kvm-intel && modprobe kvm-intel nested=1) || true')
-        m.execute('(rmmod kvm-amd && modprobe kvm-amd nested=1) || true')
+        m.execute(command='(rmmod kvm-intel && modprobe kvm-intel nested=1) || true', quiet=True)
+        m.execute(command='(rmmod kvm-amd && modprobe kvm-amd nested=1) || true', quiet=True)
 
         nestedIntel = readFile('/sys/module/kvm_intel/parameters/nested')
         nestedAmd = readFile('/sys/module/kvm_amd/parameters/nested')


### PR DESCRIPTION
We usually don't have all the dependencies there and likely
won't install the cockpit subpackage for vm management either.

https://fedorapeople.org/groups/cockpit/logs/pull-4878-64155c35-verify-rhel-atomic/log.html#91