### PR TITLE
base1: ensure correct 'binary' option in file channels

### DIFF
--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -764,6 +764,8 @@ function Channel(options) {
                 command.binary = "base64";
                 base64 = true;
             }
+        } else {
+            delete command.binary;
         }
 
         transport.send_control(command);

--- a/src/base1/test-echo.html
+++ b/src/base1/test-echo.html
@@ -62,43 +62,22 @@ asyncTest("basic", function() {
     channel.send("the payload");
 });
 
-asyncTest("base64", function() {
-    expect(1);
-
-    var channel = cockpit.channel({
-        "payload": "http-stream1",
-        "method": "GET",
-        "internal": "packages",
-        "path": "/another/test.html",
-        "binary": "base64"
-    });
-
-    var first = true;
-    channel.control({ "command": "done" });
-
-    $(channel).on("message", function(ev, payload) {
-        if (first) {
-            first = false;
-            return;
-        }
-        strictEqual(payload, "PGh0bWw+CjxoZWFkPgo8dGl0bGU+SW4gaG9tZSBkaXI8L3RpdGxlPgo8L2hlYWQ+Cjxib2R5PkluIGhvbWUgZGlyPC9ib2R5Pgo8L2h0bWw+Cg==", "got the right payload");
-        $(channel).off();
-        start();
-    });
-});
-
-asyncTest("base64 empty", function() {
-    expect(1);
+asyncTest("binary empty", function() {
+    expect(2);
 
     var channel = cockpit.channel({
         "payload": "echo",
-        "binary": "base64"
+        "binary": true
     });
 
     var first = true;
 
     $(channel).on("message", function(ev, payload) {
-        strictEqual(payload, "", "got the right payload");
+        if (window.Uint8Array)
+            ok(payload instanceof window.Uint8Array, "got a byte array");
+        else
+            ok($.isArray(payload), "got a byte array");
+        strictEqual(payload.length, 0, "got the right payload");
         $(channel).off();
         start();
     });

--- a/src/base1/test-file.html
+++ b/src/base1/test-file.html
@@ -99,6 +99,16 @@ asyncTest("binary read", function() {
         });
 });
 
+/* regression: passing 'binary: false' made cockpit-ws close the whole connection */
+asyncTest("binary false", function() {
+    expect(1);
+    cockpit.file(dir + "/foo.bin", { binary: false }).read().
+        done(function() {
+            equal(this.state(), "resolved", "didn't fail");
+            start();
+        });
+});
+
 asyncTest("simple replace", function() {
     expect(2);
     cockpit.file(dir + "/bar").replace("4321\n").


### PR DESCRIPTION
Typing

    cockpit.file('/etc/hostname', { binary: false })

into a web console makes `cockpit-ws` close the connection immediately. This is allowed according to the docs.

This fixes it by making sure we don't pass `binary` as a boolean field into the options of `cockpit.channel()`.