### PR TITLE
enable cockpit-docker on more arches

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -92,7 +92,7 @@ Requires: %{name}-shell = %{version}-%{release}
 %if 0%{?fedora} >= 24 || 0%{?rhel} >= 8
 Recommends: %{name}-networkmanager = %{version}-%{release}
 Recommends: %{name}-storaged = %{version}-%{release}
-%ifarch x86_64 armv7hl
+%ifarch x86_64 %{arm} aarch64 ppc64 ppc64le
 Recommends: %{name}-docker = %{version}-%{release}
 %endif
 Suggests: %{name}-pcp = %{version}-%{release}
@@ -230,7 +230,7 @@ echo '%dir %{_datadir}/%{name}/selinux' > selinux.list
 find %{buildroot}%{_datadir}/%{name}/selinux -type f >> selinux.list
 %endif
 
-%ifarch x86_64 armv7hl
+%ifarch x86_64 %{arm} aarch64 ppc64 ppc64le
 echo '%dir %{_datadir}/%{name}/docker' > docker.list
 find %{buildroot}%{_datadir}/%{name}/docker -type f >> docker.list
 %else
@@ -492,7 +492,7 @@ utility setroubleshoot to diagnose and resolve SELinux issues.
 
 %endif
 
-%ifarch x86_64 armv7hl
+%ifarch x86_64 %{arm} aarch64 ppc64 ppc64le
 
 %package docker
 Summary: Cockpit user interface for Docker containers


### PR DESCRIPTION
use %%{arm} macro for 32 bit arm
enable aarch64 ppc64 ppc64le as they all have docker

Signed-off-by: Dennis Gilmore <dennis@ausil.us>