### PR TITLE
configure: Insist on building from tarball or git directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,17 @@ AC_INIT([Cockpit],
         [cockpit],
         [http://www.cockpit-project.org/])
 
+# The above git-version-gen command can either use .git or a .tarball file
+# in the top level directory to determine the version. If that didn't work
+# bail early. Cockpit needs to know its own version number
+AC_MSG_CHECKING(that PACKAGE_VERSION is properly set)
+if test -z "$PACKAGE_VERSION"; then
+  AC_MSG_RESULT(no)
+  AC_MSG_ERROR(Please build from a .git checkout or .tar.xz tarball)
+else
+  AC_MSG_RESULT(yes)
+fi
+
 AC_CONFIG_SRCDIR([src])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([tools])


### PR DESCRIPTION
Cockpit uses either a .tarball file in the actual 'make dist'
tarball or the .git directory to determine its own version number.

Cockpit needs to know its own version number. Refuse to build
if it can't be determined. This is a 'fail early' prevention
to builds succeeding, tests passing, but not running properly.

Issue #5103