### PR TITLE
lib/select: Change 'initial' prop

### DIFF
--- a/lib/cockpit-components-select.jsx
+++ b/lib/cockpit-components-select.jsx
@@ -56,8 +56,7 @@
         getInitialState: function() {
             return {
                 open: false,
-                currentData: undefined,
-                currentValue: undefined,
+                currentData: this.props.initial,
                 documentClickHandler: undefined,
             };
         },
@@ -74,9 +73,9 @@
 
                 this.setState({ open: false });
                 // if the item didn't change, don't do anything
-                if (elementValue === this.state.currentValue && elementData === this.state.currentData)
+                if (elementData === this.state.currentData)
                     return;
-                this.setState({ currentValue: elementValue, currentData: elementData });
+                this.setState({ currentData: elementData });
                 if (this.props.onChange)
                     this.props.onChange(elementData);
             } else {
@@ -85,26 +84,20 @@
         },
         render: function() {
             var self = this;
-            var currentValue = this.state.currentValue;
-            if (currentValue === undefined && 'initial' in this.props)
-                currentValue = this.props.initial;
+            var currentValue;
 
-            var listItems;
-            if (this.props.children) {
-                listItems = this.props.children.map(function(itm) {
-                    var data = ('data' in itm.props)?itm.props.data:undefined;
-                    // we need to have some kind of value
-                    var value = (itm.props.children !== undefined)?itm.props.children:textForUndefined;
-                    // if we don't have anything selected, take the first item
-                    if (currentValue === undefined) {
-                        currentValue = value;
-                        self.setState({ currentValue: currentValue, currentData: data });
-                        self.props.onChange(data);
-                    }
-                    return <li data-value={value} data-data={data}>{itm}</li>;
-                });
-            }
-            var classes = "btn-group bootstrap-select dropdown form-control";
+            var listItems = React.Children.map(this.props.children, function(itm) {
+                var data = ('data' in itm.props) ? itm.props.data : undefined;
+                // we need to have some kind of value
+                var value = (itm.props.children !== undefined) ? itm.props.children : textForUndefined;
+                if (data === self.state.currentData)
+                    currentValue = value;
+                // if there's no initial value, use the first one
+                else if (!self.props.initial && currentValue === undefined)
+                    currentValue = value;
+                return <li data-value={value} data-data={data}>{itm}</li>;
+            });
+            var classes = "btn-group bootstrap-select dropdown";
             if (this.state.open)
                 classes += " open";
 
@@ -133,7 +126,7 @@
             data: React.PropTypes.string.isRequired,
         },
         render: function() {
-            var value = (this.props.children !== undefined)?this.props.children:textForUndefined;
+            var value = (this.props.children !== undefined) ? this.props.children : textForUndefined;
             return <a>{value}</a>;
         }
     });

--- a/pkg/playground/react-demo-dialog.jsx
+++ b/pkg/playground/react-demo-dialog.jsx
@@ -57,9 +57,8 @@
                                 <Select.Select onChange={this.selectChanged} id="primary-select">
                                     <Select.SelectEntry data='one'>{_("One")}</Select.SelectEntry>
                                     <Select.SelectEntry data='two'>{_("Two")}</Select.SelectEntry>
-                                    <Select.SelectEntry>{_("Three")}</Select.SelectEntry>
+                                    <Select.SelectEntry data='three'>{_("Three")}</Select.SelectEntry>
                                     <Select.SelectEntry data='four'></Select.SelectEntry>
-                                    <Select.SelectEntry></Select.SelectEntry>
                                 </Select.Select>
                             </td>
                         </tr>
@@ -70,10 +69,10 @@
                                 </label>
                             </td>
                             <td>
-                                <Select.Select initial={_("Two")}>
-                                    <Select.SelectEntry>{_("One")}</Select.SelectEntry>
-                                    <Select.SelectEntry>{_("Two")}</Select.SelectEntry>
-                                    <Select.SelectEntry>{_("Three")}</Select.SelectEntry>
+                                <Select.Select initial="two">
+                                    <Select.SelectEntry data="one">{_("One")}</Select.SelectEntry>
+                                    <Select.SelectEntry data="two">{_("Two")}</Select.SelectEntry>
+                                    <Select.SelectEntry data="three">{_("Three")}</Select.SelectEntry>
                                 </Select.Select>
                             </td>
                         </tr>

--- a/pkg/subscriptions/subscriptions-register.jsx
+++ b/pkg/subscriptions/subscriptions-register.jsx
@@ -112,7 +112,7 @@ var PatternDialogBody = React.createClass({
                         </td>
                         <td>
                             <Select.Select key='urlSource' onChange={ this.props.onChange.bind(this, 'url') }
-                                           id="subscription-register-url" initial={ urlEntries['default'] }>
+                                           id="subscription-register-url" initial="default">
                                 <Select.SelectEntry data='default' key='default'>{ urlEntries['default'] }</Select.SelectEntry>
                                 <Select.SelectEntry data='custom' key='custom'>{ urlEntries['custom'] }</Select.SelectEntry>
                             </Select.Select>


### PR DESCRIPTION
The 'initial' prop of the select component used to be filled with the
initial item's label. Change that to use the 'data' attribute to be more
consistent with other UI toolkits and the onChange() callback, whose
first parameter is also the 'data' attribute.

Entails a few small changes to make the component more conformant to
React best practices:

- Don't save currentValue in state, because it can be derived from
  currentData in render().
- Don't call setState() in render(), as that might lead to an
  infinite loop.
- Don't use this.props.children directly, because it is documented as an
  opaque object.