### PR TITLE
Split up webpack Makefile stages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ depcomp
 /cockpit.service
 /cockpit.conf.5
 /cockpit-*.xz
-/Makefile-webpack.deps
+/Makefile-*.deps
 /containers/*/rpms
 /cockpit.service
 /cockpit-wrapper

--- a/Makefile.am
+++ b/Makefile.am
@@ -114,25 +114,57 @@ po/po.%.js: po/%.po
 
 V_WEBPACK = $(V_WEBPACK_$(V))
 V_WEBPACK_ = $(V_WEBPACK_$(AM_DEFAULT_VERBOSITY))
-V_WEBPACK_0 = @echo "  WEBPACK  dist/";
+V_WEBPACK_0 = @echo "  WEBPACK  $(@:Makefile-%.deps=%)";
 
-WEBPACK_INPUTS =
-WEBPACK_OUTPUTS =
-WEBPACK_CONFIG = webpack.config.js
+WEBPACK_CONFIG = $(srcdir)/webpack.config.js
 
-noinst_SCRIPTS += Makefile-webpack.deps $(WEBPACK_INSTALL)
-CLEANFILES += Makefile-webpack.deps $(WEBPACK_OUTPUTS)
-EXTRA_DIST += Makefile-webpack.deps $(WEBPACK_CONFIG)
+WEBPACK_DEPS = \
+	Makefile-dashboard.deps \
+	Makefile-docker.deps \
+	Makefile-kubernetes.deps \
+	Makefile-machines.deps \
+	Makefile-networkmanager.deps \
+	Makefile-ostree.deps \
+	Makefile-playground.deps \
+	Makefile-realmd.deps \
+	Makefile-selinux.deps \
+	Makefile-shell.deps \
+	Makefile-sosreport.deps \
+	Makefile-storaged.deps \
+	Makefile-subscriptions.deps \
+	Makefile-systemd.deps \
+	Makefile-tuned.deps \
+	Makefile-users.deps \
+	$(NULL)
 
-@INCLUDE_WEBPACK_DEPS@
+noinst_SCRIPTS += $(WEBPACK_DEPS) $(WEBPACK_INSTALL)
+CLEANFILES += $(WEBPACK_DEPS) $(WEBPACK_OUTPUTS)
+EXTRA_DIST += $(WEBPACK_DEPS) $(WEBPACK_CONFIG)
+
+-include Makefile-dashboard.deps
+-include Makefile-docker.deps
+-include Makefile-kubernetes.deps
+-include Makefile-machines.deps
+-include Makefile-networkmanager.deps
+-include Makefile-ostree.deps
+-include Makefile-playground.deps
+-include Makefile-realmd.deps
+-include Makefile-selinux.deps
+-include Makefile-shell.deps
+-include Makefile-sosreport.deps
+-include Makefile-storaged.deps
+-include Makefile-subscriptions.deps
+-include Makefile-systemd.deps
+-include Makefile-tuned.deps
+-include Makefile-users.deps
 
 WEBPACK_RULE = $(V_WEBPACK) NODE_ENV=$(NODE_ENV) SRCDIR=$(srcdir) BUILDDIR=$(builddir) \
-	       $(srcdir)/tools/missing $(srcdir)/tools/webpack-make -d $@ $<
+	       $(srcdir)/tools/missing $(srcdir)/tools/webpack-make
 
-Makefile-webpack.deps: $(WEBPACK_CONFIG) tools/webpack-make $(WEBPACK_INPUTS)
-	$(WEBPACK_RULE)
+Makefile-%.deps: $(WEBPACK_CONFIG)
+	$(WEBPACK_RULE) -d $@ $<
 
-all-local:: Makefile-webpack.deps $(WEBPACK_OUTPUTS) $(WEBPACK_INSTALL)
+all-local:: $(WEBPACK_DEPS) $(WEBPACK_OUTPUTS) $(WEBPACK_INSTALL)
 	@true
 distclean-local::
 	rm -rf dist/

--- a/configure.ac
+++ b/configure.ac
@@ -511,9 +511,6 @@ AC_MSG_RESULT($enable_strict)
 AC_SUBST(REAUTHORIZE_LIBS)
 AC_SUBST(PAM_LIBS)
 
-# So that we can enforce this include to be evaluated at make runtime
-AC_SUBST([INCLUDE_WEBPACK_DEPS], ["-include Makefile-webpack.deps"])
-
 AC_DEFINE([MAX_AUTH_BUFFER], [65536], [Maximum size of auth message])
 
 AC_OUTPUT([

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -9,15 +9,22 @@ var ops = stdio.getopt({
     deps: { key: "d", args: 1, description: "Output dependencies in Makefile format" }
 });
 
-if (!ops.args || ops.args.length !== 1) {
-    console.log("usage: webpack config");
+if (!ops.args || ops.args.length < 1 || ops.args.length > 2) {
+    console.log("usage: webpack config [section]");
     process.exit(2);
+}
+
+var srcdir = process.env.SRCDIR;
+var makefile = ops.deps;
+var prefix = "section";
+
+if (makefile) {
+    prefix = makefile.split("-")[1].split(".")[0];
+    process.env["ONLYDIR"] = prefix + "/";
 }
 
 var cwd = process.cwd();
 var config = require(path.resolve(cwd, ops.args[0]));
-
-var srcdir = process.env.SRCDIR;
 
 webpack(config, function(err, stats) {
     // process.stdout.write(stats.toString({colors: true}) + "\n");
@@ -35,7 +42,6 @@ webpack(config, function(err, stats) {
         return;
     }
 
-    var makefile = ops.deps;
     if (makefile)
         generateDeps(makefile, stats);
 });
@@ -82,16 +88,24 @@ function generateDeps(makefile, stats) {
     // Output a makefile
 
     var lines = [
-        "WEBPACK_INPUTS += " + inputs.join(" "),
-        "WEBPACK_OUTPUTS += " + outputs.join(" "),
-        "WEBPACK_INSTALL += " + installs.join(" "),
+        prefix + "_INPUTS = " + inputs.join(" "),
+        prefix + "_OUTPUTS = " + outputs.join(" "),
+        prefix + "_INSTALL = " + installs.join(" "),
 	"",
     ];
 
     outputs.forEach(function(name) {
-        lines.push(name + ": $(WEBPACK_CONFIG) $(WEBPACK_INPUTS)");
-        lines.push("\t$(WEBPACK_RULE)");
+        lines.push(name + ": $(WEBPACK_CONFIG) $(" + prefix + "_INPUTS)");
+        if (makefile)
+            lines.push("\t$(WEBPACK_RULE) -d " + makefile + " $(WEBPACK_CONFIG)");
+        else
+            lines.push("\t$(WEBPACK_RULE) $(WEBPACK_CONFIG)");
     });
+
+    lines.push("");
+    lines.push("WEBPACK_INPUTS += $(" + prefix + "_INPUTS)");
+    lines.push("WEBPACK_OUTPUTS += $(" + prefix + "_OUTPUTS)");
+    lines.push("WEBPACK_INSTALL += $(" + prefix + "_INSTALL)");
 
     data = lines.join("\n");
     fs.writeFileSync(makefile, data);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -200,6 +200,7 @@ var srcdir = process.env.SRCDIR || __dirname;
 var pkgdir = srcdir + path.sep + "pkg";
 var distdir = (process.env.BUILDDIR || __dirname) + path.sep + "dist";
 var libdir = path.resolve(srcdir, "lib");
+var section = process.env.ONLYDIR || null;
 
 /* A standard nodejs and webpack pattern */
 var production = process.env.NODE_ENV === 'production';
@@ -211,6 +212,10 @@ var production = process.env.NODE_ENV === 'production';
 
 /* Qualify all the paths in entries */
 Object.keys(info.entries).forEach(function(key) {
+    if (section && key.indexOf(section) !== 0) {
+        delete info.entries[key];
+        return;
+    }
     info.entries[key] = info.entries[key].map(function(value) {
         if (value.indexOf("/") === -1)
             return value;
@@ -220,9 +225,12 @@ Object.keys(info.entries).forEach(function(key) {
 });
 
 /* Qualify all the paths in files listed */
-info.files = info.files.map(function(value) {
-    return { from: pkgdir + path.sep + value, to: value };
+var files = [];
+info.files.forEach(function(value) {
+    if (!section || value.indexOf(section) === 0)
+        files.push({ from: pkgdir + path.sep + value, to: value });
 });
+info.files = files;
 
 var plugins = [
     new webpack.DefinePlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,10 @@
 
 var info = {
     entries: {
+        "dashboard/dashboard": [
+            "dashboard/list.js",
+        ],
+
         "docker/docker": [
             "docker/containers.js",
             "docker/docker.css",
@@ -11,9 +15,7 @@ var info = {
         "docker/console": [
             "docker/console.js",
         ],
-        "dashboard/dashboard": [
-            "dashboard/list.js",
-        ],
+
         "kubernetes/kubernetes": [
             "kubernetes/styles/main.less",
             "kubernetes/scripts/main.js",
@@ -22,14 +24,22 @@ var info = {
             "kubernetes/styles/registry.less",
             "kubernetes/scripts/registry.js",
         ],
+
+        "machines/machines": [
+            "machines/index.js",
+            "machines/machines.css",
+        ],
+
         "networkmanager/network": [
             "networkmanager/interfaces.js",
             "networkmanager/networking.css",
         ],
+
         "ostree/ostree": [
             "ostree/app.js",
             "ostree/ostree.css",
         ],
+
         "playground/jquery-patterns": [
             "playground/jquery-patterns.js",
         ],
@@ -48,13 +58,16 @@ var info = {
         "playground/test": [
             "playground/test",
         ],
+
         "realmd/domain": [
             "realmd/operation.js",
         ],
+
         "selinux/selinux": [
             "selinux/setroubleshoot.js",
             "selinux/setroubleshoot.css",
         ],
+
         "shell/index": [
             "shell/index.js",
             "shell/shell.css",
@@ -65,18 +78,22 @@ var info = {
         "shell/index-no-machines": [
             "shell/index-no-machines.js",
         ],
+
         "sosreport/sosreport": [
             "sosreport/index.js",
             "sosreport/sosreport.css",
         ],
+
         "storaged/storage": [
             "storaged/devices.js",
             "storaged/storage.css",
         ],
+
         "subscriptions/subscriptions": [
             "subscriptions/main.js",
             "subscriptions/subscriptions.css",
         ],
+
         "systemd/services": [
             "systemd/init.js",
         ],
@@ -90,13 +107,11 @@ var info = {
         "systemd/terminal": [
             "systemd/terminal.jsx",
         ],
+
         "tuned/performance": [
             "tuned/dialog.js",
         ],
-        "machines/machines": [
-            "machines/index.js",
-            "machines/machines.css",
-        ],
+
         "users/users": [
             "users/local.js",
             "users/users.css",
@@ -104,18 +119,21 @@ var info = {
     },
 
     files: [
+        "dashboard/index.html",
+        "dashboard/manifest.json",
+
         "docker/console.html",
         "docker/manifest.json",
         "docker/index.html",
         "docker/images/drive-harddisk-symbolic.svg",
 
-        "dashboard/index.html",
-        "dashboard/manifest.json",
-
         "kubernetes/manifest.json",
         "kubernetes/override.json",
         "kubernetes/index.html",
         "kubernetes/registry.html",
+
+        "machines/index.html",
+        "machines/manifest.json",
 
         "networkmanager/index.html",
         "networkmanager/manifest.json",
@@ -157,6 +175,9 @@ var info = {
         "storaged/images/storage-array.png",
         "storaged/images/storage-disk.png",
 
+        "subscriptions/index.html",
+        "subscriptions/manifest.json",
+
         "systemd/index.html",
         "systemd/logs.html",
         "systemd/manifest.json",
@@ -167,12 +188,6 @@ var info = {
 
         "users/index.html",
         "users/manifest.json",
-
-        "subscriptions/index.html",
-        "subscriptions/manifest.json",
-
-        "machines/index.html",
-        "machines/manifest.json"
     ]
 };
 


### PR DESCRIPTION
When running 'make' we want to just run webpack on those packages
which have had changes. So split up the logic a bit, in particular
how we hookup to make rules.

Running 'webpack' should still build everything.