### PR TITLE
test: Ignore one more docker SELinux failure

### DIFF
--- a/test/verify/naughty-rhel-7/4978-docker-selinux-broken-9
+++ b/test/verify/naughty-rhel-7/4978-docker-selinux-broken-9
@@ -1,1 +1,1 @@
-scontext=system_u:system_r:unconfined_service_t:s0 tcontext=system_u:system_r:svirt_lxc_net_t:s0:c452,c638 tclass=process
+scontext=system_u:system_r:unconfined_service_t:s0 tcontext=system_u:system_r:svirt_lxc_net_t


### PR DESCRIPTION
As seen in:

type=1400 audit(1476707583.493:4): avc:  denied  { transition } for  pid=1613 comm="exe" path="/usr/bin/pod" dev="dm-1" ino=6385664 scontext=system_u:system_r:unconfined_service_t:s0 tcontext=system_u:system_r:svirt_lxc_net_t:s0:c212,c751 tclass=process