### PR TITLE
test: Fix race where sosreport takes too long

### DIFF
--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -36,7 +36,7 @@ class TestSOS(MachineCase):
         b.click('[data-target="#sos"]')
         b.wait_visible("#sos")
 
-        with b.wait_timeout(180):
+        with b.wait_timeout(360):
             b.wait_visible("#sos-download")
 
         # There doesn't seem to be a easy way to do a real download


### PR DESCRIPTION
There's not much we can do to speed this up. Real code can take
a while to run. I've seen the screenshot here and it's just waiting
for sosreport to complete. Lets wait for it longer.