### PR TITLE
test: Disable Docker registry access on Atomic hosts

### DIFF
--- a/test/images/continuous-atomic
+++ b/test/images/continuous-atomic
@@ -1,1 +1,1 @@
-continuous-atomic-b48009bcd6389af400eeb2a608cbdadca275ca21.qcow2
+continuous-atomic-b8d5fc5621d303fd01042fc8f0b12da61b0945ed.qcow2

--- a/test/images/fedora-atomic
+++ b/test/images/fedora-atomic
@@ -1,1 +1,1 @@
-fedora-atomic-e37efff411fa96c2cf66de63b3a8b8b686d98a03.qcow2
+fedora-atomic-5b283cb9e21585f61b158a0139f0e624b8733e0b.qcow2

--- a/test/images/rhel-atomic
+++ b/test/images/rhel-atomic
@@ -1,1 +1,1 @@
-rhel-atomic-91d8e7d8c4e378f1eb28a8b02cb7ccbf5908f36b.qcow2
+rhel-atomic-d5e0544247f58ab778219aa786d21ecdc610b7a0.qcow2

--- a/test/images/rhel-atomic
+++ b/test/images/rhel-atomic
@@ -1,1 +1,1 @@
-rhel-atomic-09e330de24df7c30f59deaf05e6890ada84ed72d.qcow2
+rhel-atomic-91d8e7d8c4e378f1eb28a8b02cb7ccbf5908f36b.qcow2

--- a/test/images/scripts/continuous-atomic.setup
+++ b/test/images/scripts/continuous-atomic.setup
@@ -20,20 +20,13 @@ set -e
 
 # The docker pool should grow automatically as needed, but we grow it
 # explicitly here anyway.  This is hopefully more reliable.
-systemctl start docker
+# HACK: docker falls over regularly, print its log if it does
+systemctl start docker || journalctl -u docker
 lvresize atomicos/root        -l+50%FREE -r
 lvresize atomicos/docker-pool -l+100%FREE
 
 # Configure kubernetes. Since this writes to /etc have to do before upgrade
 /var/lib/testvm/kubernetes-container.setup
-
-# Switch to continuous stream
-ostree remote add --set=gpg-verify=false centos-atomic-continuous https://ci.centos.org/artifacts/sig-atomic/rdgo/centos-continuous/ostree/repo/
-rpm-ostree rebase centos-atomic-continuous:centos-atomic-host/7/x86_64/devel/continuous
-
-ostree checkout centos-atomic-continuous:centos-atomic-host/7/x86_64/devel/continuous /var/local-tree
-
-systemctl start docker || journalctl -u docker
 
 # we need cockpit/ws as well
 docker pull cockpit/ws
@@ -41,11 +34,17 @@ docker pull cockpit/ws
 # docker images that we need for integration testing
 /var/lib/testvm/docker-images.setup
 
+# Configure core dumps
+echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" > /etc/sysctl.d/50-coredump.conf
+
+# Switch to continuous stream
+ostree remote add --set=gpg-verify=false centos-atomic-continuous https://ci.centos.org/artifacts/sig-atomic/rdgo/centos-continuous/ostree/repo/
+rpm-ostree rebase centos-atomic-continuous:centos-atomic-host/7/x86_64/devel/continuous
+
+ostree checkout centos-atomic-continuous:centos-atomic-host/7/x86_64/devel/continuous /var/local-tree
+
 # reduce image size
 /var/lib/testvm/zero-disk.setup
 
 # Final tweaks
-
 rm -rf /var/log/journal/*
-echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" > /etc/sysctl.d/50-coredump.conf
-printf "[Coredump]\nStorage=journal\n" > /etc/systemd/coredump.conf

--- a/test/images/scripts/lib/atomic.setup
+++ b/test/images/scripts/lib/atomic.setup
@@ -22,13 +22,21 @@ set -e
 
 # The docker pool should grow automatically as needed, but we grow it
 # explicitly here anyway.  This is hopefully more reliable.
-systemctl start docker
+# HACK: docker falls over regularly, print its log if it does
+systemctl start docker || journalctl -u docker
 lvresize atomicos/root        -l+50%FREE -r
 lvresize atomicos/docker-pool -l+100%FREE
 
 # Configure kubernetes. Since this writes to /etc have to do before upgrade
 /var/lib/testvm/kubernetes.setup
 
+# we need cockpit/ws as well
+docker pull cockpit/ws
+
+# docker images that we need for integration testing
+/var/lib/testvm/docker-images.setup
+
+# fully upgrade host. Anything past this point can't touch /etc
 # Upgrade host if there is a valid upgrade available (we might be on a RC)
 if rpm-ostree upgrade --check; then
     atomic host upgrade
@@ -47,20 +55,8 @@ fi
 
 ostree checkout "$checkout" /var/local-tree
 
-# HACK: docker falls over regularly, print its log if it does
-systemctl start docker || journalctl -u docker
-
-# we need cockpit/ws as well
-docker pull cockpit/ws
-
-# docker images that we need for integration testing
-/var/lib/testvm/docker-images.setup
-
 # reduce image size
 /var/lib/testvm/zero-disk.setup
 
 # Final tweaks
-
 rm -rf /var/log/journal/*
-echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" > /etc/sysctl.d/50-coredump.conf
-printf "[Coredump]\nStorage=journal\n" > /etc/systemd/coredump.conf

--- a/test/images/scripts/lib/docker-images.setup
+++ b/test/images/scripts/lib/docker-images.setup
@@ -33,3 +33,8 @@ cat >> /etc/hosts <<EOF
 127.0.0.1       gcr.io
 127.0.0.1       registry.access.redhat.com
 EOF
+
+# Disable messing with /etc/hosts on systems using cloud-init
+if [ -f /etc/cloud/cloud.cfg ]; then
+    sed -i '/etc_hosts/d' /etc/cloud/cloud.cfg
+fi

--- a/test/images/scripts/rhel-atomic.bootstrap
+++ b/test/images/scripts/rhel-atomic.bootstrap
@@ -4,7 +4,6 @@
 set -e
 
 url="http://cdn.stage.redhat.com/content/dist/rhel/atomic/7/7Server/x86_64/images/"
-prefix="rhel-atomic-cloud-7.2"
 
 BASE=$(dirname $0)
-$BASE/atomic.bootstrap "$1" "$url" "$prefix"
+$BASE/atomic.bootstrap "$1" "$url" "rhel-atomic-cloud-7.2.[0-9\.]+.x86_64.qcow2"


### PR DESCRIPTION
For reliablility our tests need to run without Docker registry
access, so we've been disabling that in /etc/hosts. Sadly this
didn't kick in on Atomic machines ... which resulted in tests
with timeouts.

Two fixes:

 * Make all changes to /etc before OSTree upgrades
 * Disable touching /etc/hosts in cloud.cfg