### PR TITLE
vagrant: remove kvm-intel hacks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure(2) do |config|
     config.vm.post_up_message = "You can now access Cockpit at http://localhost:9090 (login as 'admin' with password 'foobar')"
 
     config.vm.provider "libvirt" do |libvirt|
-        libvirt.memory = 2048 # or 1024 if nested virtualization is not needed
+        libvirt.memory = 1024
         libvirt.nested = true
         libvirt.cpu_mode = "host-model"
     end
@@ -51,11 +51,6 @@ Vagrant.configure(2) do |config|
         systemctl start cockpit.socket
 
         printf "[WebService]\nAllowUnencrypted=true\n" > /etc/cockpit/cockpit.conf
-
-        sudo sh -c "rmmod kvm_intel && modprobe kvm_intel nested=1 && echo 'options kvm_intel nested=1' >> /etc/modprobe.d/kvm.conf" | true
-        sudo sh -c "rmmod kvm_amd && modprobe kvm_amd nested=1 && echo 'options kvm_amd nested=1' >> /etc/modprobe.d/kvm.conf" | true
-        echo Nested virtualization: && cat /sys/module/kvm_intel/parameters/nested
-        sudo systemctl start libvirtd
 
         systemctl daemon-reload
     SHELL


### PR DESCRIPTION
nested=1 only needs to be set on the host, not inside the VM.

These lines fail when nested virtualization is not enabled on the host.