### PR TITLE
test: Disable internet access in check-sosreport

### DIFF
--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -30,8 +30,12 @@ import unittest
 class TestSOS(MachineCase):
     def testBasic(self):
         b = self.browser
+        m = self.machine
 
         self.login_and_go("/sosreport")
+
+        # Disable default gateway to prevent external internet access during testing
+        m.execute("ip route del default")
 
         b.click('[data-target="#sos"]')
         b.wait_visible("#sos")


### PR DESCRIPTION
This removes the default gateway and disables internet access
in the check-sosreport test. The goal is to remove races that
depend on responses from Red Hat servers.