### PR TITLE
lib: Log global dialog errors to console

### DIFF
--- a/lib/cockpit-components-dialog.jsx
+++ b/lib/cockpit-components-dialog.jsx
@@ -101,6 +101,10 @@ var DialogFooter = React.createClass({
                     if (self.props.dialog_done)
                         self.props.dialog_done(false);
                 }
+
+                /* Always log global dialog errors for easier debugging */
+                console.warn(error);
+
                 self.setState({ action_in_progress: false, error_message: error });
             })
             .progress(this.update_progress.bind(this));
@@ -289,6 +293,9 @@ var show_modal_dialog = function(props, footerProps) {
         dialogObj.render();
     };
     dialogObj.setFooterProps = function(footerProps) {
+        /* Always log error messages to console for easier debugging */
+        if (footerProps.static_error)
+            console.warn(footerProps.static_error);
         dialogObj.footerProps = footerProps;
         if (dialogObj.footerProps === null || dialogObj.footerProps === undefined)
             dialogObj.footerProps = { };

--- a/lib/patterns.js
+++ b/lib/patterns.js
@@ -65,8 +65,12 @@
 
     function global_error(sel, error) {
         var alert = $("<div class='alert alert-danger dialog-error'>");
-        alert.text(error.message || error.toString());
+        var text = error.message || error.toString();
+        alert.text(text);
         $("<span class='fa fa-exclamation-triangle'>").prependTo(alert);
+
+        /* Always log global dialog errors for easier debugging */
+        console.warn(text);
 
         var footer = sel.find(".modal-footer");
         if (footer.length)


### PR DESCRIPTION
When a global (non-field related) dialog error is displayed
also log it to the console. This makes it easier when debugging,
copying and pasting, and most importantly when diagnosing test
failures.