### PR TITLE
tools: Fix make running parallel builds of webpack

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -141,6 +141,9 @@ noinst_SCRIPTS += $(WEBPACK_DEPS) $(WEBPACK_INSTALL)
 CLEANFILES += $(WEBPACK_DEPS) $(WEBPACK_OUTPUTS)
 EXTRA_DIST += $(WEBPACK_DEPS) $(WEBPACK_CONFIG)
 
+Makefile-%.deps: $(WEBPACK_CONFIG)
+	$(WEBPACK_RULE) -d $@ $<
+
 -include Makefile-dashboard.deps
 -include Makefile-docker.deps
 -include Makefile-kubernetes.deps
@@ -160,9 +163,6 @@ EXTRA_DIST += $(WEBPACK_DEPS) $(WEBPACK_CONFIG)
 
 WEBPACK_RULE = $(V_WEBPACK) NODE_ENV=$(NODE_ENV) SRCDIR=$(srcdir) BUILDDIR=$(builddir) \
 	       $(srcdir)/tools/missing $(srcdir)/tools/webpack-make
-
-Makefile-%.deps: $(WEBPACK_CONFIG)
-	$(WEBPACK_RULE) -d $@ $<
 
 all-local:: $(WEBPACK_DEPS) $(WEBPACK_OUTPUTS) $(WEBPACK_INSTALL)
 	@true

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -94,15 +94,14 @@ function generateDeps(makefile, stats) {
 	"",
     ];
 
+    lines.push(makefile + ": $(WEBPACK_CONFIG) $(" + prefix + "_INPUTS)");
+    lines.push("\t$(WEBPACK_RULE) -d " + makefile + " $(WEBPACK_CONFIG)");
+
     outputs.forEach(function(name) {
-        lines.push(name + ": $(WEBPACK_CONFIG) $(" + prefix + "_INPUTS)");
-        if (makefile)
-            lines.push("\t$(WEBPACK_RULE) -d " + makefile + " $(WEBPACK_CONFIG)");
-        else
-            lines.push("\t$(WEBPACK_RULE) $(WEBPACK_CONFIG)");
+        lines.push(name + ": " + makefile);
+        lines.push("")
     });
 
-    lines.push("");
     lines.push("WEBPACK_INPUTS += $(" + prefix + "_INPUTS)");
     lines.push("WEBPACK_OUTPUTS += $(" + prefix + "_OUTPUTS)");
     lines.push("WEBPACK_INSTALL += $(" + prefix + "_INSTALL)");


### PR DESCRIPTION
When multiple files in the same package are changed, we only
need to run webpack once. We can parallelize between multiple
packages, but not further. Previously webpack was being run
too many times in parallel once for each modified file in
a package directory.