### PR TITLE
lib: Fix detection of jQuery objects for Firefox 49

### DIFF
--- a/lib/journal.js
+++ b/lib/journal.js
@@ -230,7 +230,7 @@
 
     function output_funcs_for_box(box) {
         /* Dereference any jQuery object here */
-        if (box.append)
+        if (box.jquery)
             box = box[0];
 
         Mustache.parse(day_header_template);


### PR DESCRIPTION
Starting with Firefox 49, DOM elements also have a 'append' method:

https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append