### PR TITLE
ws: Expect possible cockpit-protocol error message

### DIFF
--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -523,6 +523,8 @@ test_bad_command (Test *test,
                                "*Auth pipe closed: terminated*");
   cockpit_expect_possible_log ("cockpit-ws", G_LOG_LEVEL_WARNING,
                                "*couldn't write: Connection refused*");
+  cockpit_expect_possible_log ("cockpit-protocol", G_LOG_LEVEL_MESSAGE,
+                               "*couldn't write: Connection refused*");
   test_custom_fail (test, data);
 }
 


### PR DESCRIPTION
Happens when auth is configured to use a bad-command and it happens to exit before the pipe has finished
writing.

https://fedorapeople.org/groups/cockpit/logs/pull-5182-e419bee3-verify-debian-unstable/build-results/build.log