### PR TITLE
 docker: Complete the concept of the filter bar

### DIFF
--- a/pkg/docker/details.js
+++ b/pkg/docker/details.js
@@ -49,7 +49,7 @@
         setup: function() {
             var self = this;
 
-            $('#container-details .breadcrumb a').on("click", function() {
+            $('#container-details .content-filter a').on("click", function() {
                 cockpit.location.go('/');
             });
 
@@ -189,7 +189,7 @@
             $('#container-details-resource-row').toggle(!!info.State.Running);
 
             this.name = util.render_container_name(info.Name);
-            $('#container-details .breadcrumb .active').text(this.name);
+            $('#container-details .content-filter h3 span').text(this.name);
 
             var port_bindings = [ ];
             if (info.NetworkSettings)

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -299,18 +299,57 @@
     text-align: right;
 }
 
-#containers-header {
+.content-filter {
     background: #f5f5f5;
     border-bottom: 1px solid #ddd;
-    padding: 10px 20px;
+    padding: 10px 16px 10px 20px;
+    position: fixed;
     width: 100%;
+    top: 0px;
+    right: 0px;
+    z-index: 1;
+    height: 50px;
 }
 
-#containers-header input[type="text"] {
+.content-filter + div {
+    margin-top: 70px;
+}
+
+.content-filter input[type="text"] {
     display: inline-block;
     vertical-align: middle;
     width: 200px;
     margin-left: 6px;
+}
+
+.content-filter h3 {
+    display: inline;
+    font-size: 18px;
+    line-height: 28px;
+}
+
+.content-filter i {
+    font-size: 24px;
+    position: relative;
+    padding-right: 3px;
+}
+
+.content-filter i.pficon-image {
+    top: 3px;
+}
+
+.content-filter i.fa {
+    margin-top: 2px;
+    font-size: 18px;
+    line-height: 28px;
+}
+
+.content-filter i.fa-cube {
+    font-size: 22px;
+}
+
+.content-filter a {
+    padding-left: 30px;
 }
 
 /*

--- a/pkg/docker/image.js
+++ b/pkg/docker/image.js
@@ -55,7 +55,7 @@
         setup: function() {
             var self = this;
 
-            $('#image-details .breadcrumb a').on("click", function() {
+            $('#image-details .content-filter a').on("click", function() {
                 cockpit.location.go('/');
             });
 
@@ -120,7 +120,7 @@
             if (info.RepoTags && info.RepoTags.length > 0)
                 this.name = info.RepoTags[0];
 
-            $('#image-details .breadcrumb .active').text(this.name);
+            $('#image-details .content-filter h3 span').text(this.name);
 
             $('#image-details-id').text(info.Id);
             $('#image-details-tags').html(util.multi_line(info.RepoTags));

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -86,7 +86,7 @@
   <!-- OVERVIEW -->
 
   <div id="containers" hidden>
-    <div id="containers-header"></div>
+    <div class="content-filter"></div>
     <div class="container-fluid page-ct">
       <div class="col-md-12 col-lg-8">
         <div class="row">
@@ -119,10 +119,13 @@
   <!-- CONTAINER DETAILS -->
 
   <div id="container-details" class="container-fluid" hidden>
-    <ol class="breadcrumb">
-      <li><a translatable="yes">Containers</a></li>
-      <li class="active"></li>
-    </ol>
+    <div class="content-filter">
+      <h3>
+        <i class="fa fa-cube fa-fw"></i>
+        <span></span>
+      </h3>
+      <a translatable="yes">Show all containers</a>
+    </div>
     <div class="panel-default panel">
       <div class="panel-heading">
         <div class="pull-right">
@@ -230,10 +233,13 @@
   <!-- IMAGE DETAILS -->
 
   <div id="image-details" class="container-fluid" hidden>
-    <ol class="breadcrumb">
-      <li><a translatable="yes">Containers</a></li>
-      <li class="active"></li>
-    </ol>
+    <div class="content-filter">
+      <h3>
+        <i class="pficon pficon-image"></i>
+        <span></span>
+      </h3>
+      <a translatable="yes">Show all images</a>
+    </div>
     <div class="panel-default panel">
       <div class="panel-heading">
         <div class="pull-right" id="image-details-buttons">

--- a/pkg/docker/overview.js
+++ b/pkg/docker/overview.js
@@ -41,7 +41,7 @@
      */
 
     function init_overview (client) {
-        var headerNode = document.getElementById('containers-header');
+        var headerNode = document.querySelector('#containers .content-filter');
         var containerNode = document.getElementById('containers-containers');
         var imageNode = document.getElementById('containers-images');
 

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -142,7 +142,7 @@ class TestDocker(MachineCase):
                          set(["/PROBE1:/PROBE2/alias1", "/PROBE1:/PROBE2/alias2"]))
 
         # delete PROBE2 from dash
-        b.click("#container-details ol.breadcrumb a")
+        b.click("#container-details .content-filter a")
         b.wait_visible("#containers-containers")
         b.wait_in_text('#containers-containers', "PROBE2")
         b.click('#containers-containers tbody tr:contains("PROBE2") td.listing-ct-toggle')


### PR DESCRIPTION
Sync up the concept with how we've done this in the Cluster page.
The idea is that when we're displaying just one thing, the filter bar
indicates that we're filtered to just that one item.

As in the kubernetes designs we have link to go back to the
unfiltered view. This is consistent with other designs, and if
we want it to behave differently we should do that everywhere.