### PR TITLE
Makefile.redirect: Default to multiple make jobs when in developer mode

### DIFF
--- a/tools/Makefile.redirect
+++ b/tools/Makefile.redirect
@@ -1,9 +1,9 @@
 # This redirects all make targets to builddir
 all:
-	$(MAKE) -C $(REDIRECT) all
+	$(MAKE) $(ARG) -C $(REDIRECT) all
 %:
-	$(MAKE) -C $(REDIRECT) $@
+	$(MAKE) $(ARG) -C $(REDIRECT) $@
 ifeq ($(MAKEFLAGS), )
-JOBARG = -j4
+ARG = -j8
 endif
 # REDIRECT=build


### PR DESCRIPTION
Since webpack takes a long time, and parallelizes extremely well
we should default to using multiple make jobs when in developer
(ie: autogen.sh) mode.

This doesn't affect cases where the caller has already specified a
jobs -j argument.

This also doesn't affect building from the tarball, where
Makefile.redirect is not used.

This also doesn't affect folks who build in their own source tree.

In order to make this take effect on an already running checkout
one would need to:

    $ make distclean
    $ cd build
    $ ../autogen.sh --prefix=/usr --enable-debug ...