### PR TITLE
ws: Don't constantly be in endless loop in cockpit-ssh

### DIFF
--- a/src/ws/ssh.c
+++ b/src/ws/ssh.c
@@ -1542,7 +1542,7 @@ cockpit_ssh_relay_new (ssh_session session,
   ssh_set_channel_callbacks (channel, &relay->channel_cbs);
   ssh_set_blocking (session, 0);
   cockpit_unix_fd_add (ssh_get_fd (session),
-                       G_IO_IN | G_IO_OUT | G_IO_PRI | G_IO_ERR | G_IO_HUP | G_IO_NVAL,
+                       G_IO_IN | G_IO_PRI | G_IO_ERR | G_IO_HUP | G_IO_NVAL,
                        do_event_poll, relay);
   ssh_event_add_session (relay->event, session);
 


### PR DESCRIPTION
We don't need to remain in an endless loop in cockpit-ssh.

This happened because we were polling on G_IO_OUT, but then
in turn just doing looping blocking writes when writing to
the output channel.

In addition this should fix a number of test failures where
we were seeing the cockpit/ws container timing out under
heavy load.