### PR TITLE
docker: Align the filter bar elements correctly

### DIFF
--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -320,6 +320,11 @@
     vertical-align: middle;
     width: 200px;
     margin-left: 6px;
+    margin-top: 2px;
+}
+
+.content-filter .bootstrap-select {
+    margin-top: 2px;
 }
 
 .content-filter h3 {


### PR DESCRIPTION
This is a follow up to #5195. Missed committing this on my laptop.