### PR TITLE
test: Ignore SELinux sporadic failures of /proc/net/unix in cockpit-ssh

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -570,6 +570,7 @@ class MachineCase(unittest.TestCase):
         # https://bugzilla.redhat.com/show_bug.cgi?id=1242656
         "(audit: )?type=1400 .*denied.*comm=\"cockpit-ws\".*name=\"unix\".*dev=\"proc\".*",
         "(audit: )?type=1400 .*denied.*comm=\"ssh-transport-c\".*name=\"unix\".*dev=\"proc\".*",
+        "(audit: )?type=1400 .*denied.*comm=\"cockpit-ssh\".*name=\"unix\".*dev=\"proc\".*",
 
         # https://bugzilla.redhat.com/show_bug.cgi?id=1374820
         "(audit: )?type=1400 .*denied.*comm=\"systemd\" path=\"/run/systemd/inaccessible/blk\".*",


### PR DESCRIPTION
These errors are being tracked in bugzilla, and used to happen
sporadically in cockpit-ws. They now happen in cockpit-ssh.

https://bugzilla.redhat.com/show_bug.cgi?id=1242656
