### PR TITLE
test: Run check-machines on more systems

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-1c9ad89edfed75e001c560f9c37f9542a2c84d80.qcow2
+debian-unstable-4932882eeab9799285ad1ad4d7cc9cae2c7a0a4e.qcow2

--- a/test/images/scripts/debian-unstable.setup
+++ b/test/images/scripts/debian-unstable.setup
@@ -20,6 +20,7 @@ libpolkit-agent-1-0 \
 libpolkit-gobject-1-0 \
 libpwquality-tools \
 libssh-4 \
+libvirt-daemon-system \
 network-manager \
 pcp \
 policykit-1 \
@@ -78,6 +79,7 @@ TEST_PACKAGES="\
 curl \
 gdb \
 systemd-coredump \
+virtinst \
 "
 
 useradd -m -U -c Administrator -G sudo -s /bin/bash admin
@@ -98,6 +100,9 @@ echo "apt-get -y install fakeroot $COCKPIT_BUILD_DEPS" >debian-8.install-build-d
 pbuilder --execute --save-after-exec debian-8.install-build-deps
 # Disable build-dep installation for the real builds
 echo PBUILDERSATISFYDEPENDSCMD=true >~/.pbuilderrc
+
+# Debian does not automatically start the default libvirt network
+virsh net-autostart default
 
 # HACK: docker falls over regularly, print its log if it does
 systemctl start docker || journalctl -u docker

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -30,21 +30,13 @@ def readFile(name):
             content = f.read().replace('\n', '')
     return content
 
+# If this test fails to run, the host machine needs:
+# echo "options kvm-intel nested=1" > /etc/modprobe.d/kvm-intel.conf
+# rmmod kvm-intel && modprobe kvm-intel || true
+
 @unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "Don't run virtual machine tests on atomic systems.")
 class TestMachines(MachineCase):
-    def tryEnableNestedVirt(self):
-        m = self.machine
-        m.execute(command='(rmmod kvm-intel; modprobe kvm-intel nested=1) || true', quiet=True)
-        m.execute(command='(rmmod kvm-amd; modprobe kvm-amd nested=1) || true', quiet=True)
-
-        nestedIntel = readFile('/sys/module/kvm_intel/parameters/nested')
-        nestedAmd = readFile('/sys/module/kvm_amd/parameters/nested')
-        return 'Y' == nestedIntel or '1' == nestedAmd
-
     def testBasic(self):
-        if not self.tryEnableNestedVirt():
-            raise unittest.SkipTest('Nested virtualization is not enabled on this test image, skipping the test')
-
         b = self.browser
         m = self.machine
 

--- a/test/vm-prep
+++ b/test/vm-prep
@@ -79,6 +79,16 @@ EOF
         echo "$rule" >> ${qemu_config_dir}/bridge.conf
       fi
   done
+
+    # We really want nested virtualization
+    if [ ! -f /etc/modprobe.d/kvm-intel.conf ]; then
+        echo "options kvm-intel nested=1" > /etc/modprobe.d/kvm-intel.conf
+        rmmod kvm-intel && modprobe kvm-intel || true
+    fi
+    if [ ! -f /etc/modprobe.d/kvm-amd.conf ]; then
+        echo "options kvm-amd nested=1" > /etc/modprobe.d/kvm-amd.conf
+        rmmod kvm-amd && modprobe kvm-amd || true
+    fi
 }
 
 unprepare()

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -419,7 +419,7 @@ The Cockpit components for managing software updates for ostree based systems.
 %files ostree -f ostree.list
 
 %package machines
-Summary: Cockpit user interface for rpm-machines
+Summary: Cockpit user interface for virtual machines
 Requires: %{name}-bridge >= %{stable_api}
 Requires: %{name}-shell >= %{stable_api}
 Requires: libvirt

--- a/tools/debian/cockpit-machines.install
+++ b/tools/debian/cockpit-machines.install
@@ -1,0 +1,1 @@
+usr/share/cockpit/machines/

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -102,6 +102,13 @@ Description: Cockpit user interface for Docker containers
  The Cockpit components for interacting with Docker and user interface.
  This package is not yet complete.
 
+Package: cockpit-machines
+Architecture: any
+Depends: ${misc:Depends},
+         libvirt-daemon-system
+Description: Cockpit user interface for virtual machines
+ The Cockpit components for managing virtual machines.
+
 Package: cockpit-test-assets
 Architecture: any
 Depends: ${misc:Depends},


### PR DESCRIPTION
First of all it's far too easy to ignore the check-machines test
and skip it. This shouldn't be the case. The test machines should
have nested virtualization configured.

Secondly unloading and loading the kvm-intel kernel module in
the kernel causes a race with udev, and ends up with messages
like this:

Could not access KVM kernel module: Permission denied
failed to initialize KVM: Permission denied

This is due to rules in /usr/lib/udev/rules.d which set the
permissions not having run yet.