### PR TITLE
lib: Listing pattern noexpand

### DIFF
--- a/lib/cockpit-components-listing.css
+++ b/lib/cockpit-components-listing.css
@@ -38,3 +38,7 @@ div.listing-ct-head {
 table.listing-ct > caption a {
         font-size: 16px;
 }
+
+tbody tr.listing-ct-noexpand {
+    cursor: default;
+}

--- a/lib/cockpit-components-listing.jsx
+++ b/lib/cockpit-components-listing.jsx
@@ -142,8 +142,9 @@ var ListingRow = React.createClass({
                 return (<td>{itm.name}</td>);
         });
 
+        var allowExpand = (this.props.tabRenderers.length > 0);
         var expandToggle = null;
-        if (this.props.tabRenderers.length > 0) {
+        if (allowExpand) {
             expandToggle = <td className="listing-ct-toggle" onClick={ allowNavigate?this.handleExpandClick:undefined }>
                                <i className="fa fa-fw"></i>
                            </td>;
@@ -154,8 +155,8 @@ var ListingRow = React.createClass({
         var listingItemClasses = ["listing-ct-item"];
         if (!allowNavigate)
             listingItemClasses.push("listing-ct-nonavigate");
-        if (this.props.tabRenderers.length > 0)
-            listingItemClasses.push("listing-ct-canexpand");
+        if (!allowExpand)
+            listingItemClasses.push("listing-ct-noexpand");
 
         var listingItem = (
             <tr className={ listingItemClasses.join(' ') }

--- a/lib/cockpit-components-listing.jsx
+++ b/lib/cockpit-components-listing.jsx
@@ -75,7 +75,7 @@ var ListingRow = React.createClass({
         if (!e || e.button !== 0)
             return;
 
-        var willBeExpanded = !this.state.expanded;
+        var willBeExpanded = !this.state.expanded && this.props.tabRenderers.length > 0;
         this.setState( { expanded: willBeExpanded });
 
         var loadedTabs = {};
@@ -147,10 +147,16 @@ var ListingRow = React.createClass({
             expandToggle = <td className="listing-ct-toggle" onClick={ allowNavigate?this.handleExpandClick:undefined }>
                                <i className="fa fa-fw"></i>
                            </td>;
+        } else {
+            expandToggle = <td className="listing-ct-toggle"></td>;
         }
+
         var listingItemClasses = ["listing-ct-item"];
         if (!allowNavigate)
             listingItemClasses.push("listing-ct-nonavigate");
+        if (this.props.tabRenderers.length > 0)
+            listingItemClasses.push("listing-ct-canexpand");
+
         var listingItem = (
             <tr className={ listingItemClasses.join(' ') }
                 onClick={ allowNavigate?this.handleNavigateClick:this.handleExpandClick }>

--- a/pkg/playground/react-demo-listing.jsx
+++ b/pkg/playground/react-demo-listing.jsx
@@ -114,6 +114,8 @@
                  <cockpitListing.ListingRow
                      columns={ [ { name: "with button", 'header': true }, 'aoeuaoeu', '127.30.168.10', rowAction ] }
                      tabRenderers={tabRenderers}/>
+                 <cockpitListing.ListingRow
+                     columns={ [ { name: 'nothing to expand', 'header': true }, 'some text', '127.30.168.11', 'some state' ] }/>
              </cockpitListing.Listing>
         );
         React.render(listing, rootElement);

--- a/src/base1/cockpit.css
+++ b/src/base1/cockpit.css
@@ -469,6 +469,9 @@ table.listing-ct thead th:last-child {
 tbody tr.listing-ct-item {
     border-top: 1px solid #eee;
     border-bottom: 1px solid #eee;
+}
+
+tbody tr.listing-ct-canexpand {
     cursor: pointer;
 }
 
@@ -531,7 +534,7 @@ tbody:not(.open) tr.listing-ct-item.listing-ct-nonavigate:hover td.listing-ct-to
 
 /* use gray for a row that's expanded or if navigation isn't available */
 tbody.open tr.listing-ct-item:hover,
-tr.listing-ct-item.listing-ct-nonavigate:hover {
+tr.listing-ct-canexpand.listing-ct-nonavigate:hover {
     background-color: #ededed;
 }
 

--- a/src/base1/cockpit.css
+++ b/src/base1/cockpit.css
@@ -469,9 +469,6 @@ table.listing-ct thead th:last-child {
 tbody tr.listing-ct-item {
     border-top: 1px solid #eee;
     border-bottom: 1px solid #eee;
-}
-
-tbody tr.listing-ct-canexpand {
     cursor: pointer;
 }
 
@@ -534,7 +531,7 @@ tbody:not(.open) tr.listing-ct-item.listing-ct-nonavigate:hover td.listing-ct-to
 
 /* use gray for a row that's expanded or if navigation isn't available */
 tbody.open tr.listing-ct-item:hover,
-tr.listing-ct-canexpand.listing-ct-nonavigate:hover {
+tr.listing-ct-item.listing-ct-nonavigate:hover {
     background-color: #ededed;
 }
 


### PR DESCRIPTION
Update to the listing pattern changes in #5097 

We shouldn't update cockpit.css lightly, since that is stable API. If we change the hover effect for the listing pattern, this will affect older packages that are used with a newer base.