### PR TITLE
subscriptions: Fix a potential issue identified by Coverity

### DIFF
--- a/pkg/subscriptions/subscriptions-client.js
+++ b/pkg/subscriptions/subscriptions-client.js
@@ -309,7 +309,10 @@ var requestUpdate = function() {
         });
 
     /* TODO: Don't use a timeout here. Needs better API */
-    updateTimeout = window.setTimeout(statusUpdateFailed.bind(this, "timeout"), 30000);
+    updateTimeout = window.setTimeout(
+        function() {
+            statusUpdateFailed("timeout");
+        }, 30000);
 };
 
 function processStatusOutput(text, exitDetails) {


### PR DESCRIPTION
A part of the timeout method to detect lacking communication with
the entitlement DBUS API depended on the 'this' context being
properly set. By defining an explicit function instead of using
bind, we can avoid the issue entirely.