### PR TITLE
common: Rename MAX_SEQ_PACKET to MAX_PACKET_SIZE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -511,7 +511,7 @@ AC_MSG_RESULT($enable_strict)
 AC_SUBST(REAUTHORIZE_LIBS)
 AC_SUBST(PAM_LIBS)
 
-AC_DEFINE([MAX_SEQ_PACKET], [65536], [Maximum size of seq packet messages])
+AC_DEFINE([MAX_PACKET_SIZE], [65536], [Maximum size of packet messages])
 
 AC_OUTPUT([
 Makefile

--- a/src/common/cockpitpipe.c
+++ b/src/common/cockpitpipe.c
@@ -276,18 +276,18 @@ dispatch_input (gint fd,
    */
   if (cond != G_IO_HUP)
     {
-      g_byte_array_set_size (self->priv->in_buffer, len + MAX_SEQ_PACKET);
+      g_byte_array_set_size (self->priv->in_buffer, len + MAX_PACKET_SIZE);
       if (self->priv->seq_packet)
         {
           g_debug ("%s: receiving input", self->priv->name);
-          vec.iov_len = MAX_SEQ_PACKET;
+          vec.iov_len = MAX_PACKET_SIZE;
           vec.iov_base = self->priv->in_buffer->data + len;
           ret = recvmsg (self->priv->in_fd, &msg, 0);
         }
       else
         {
           g_debug ("%s: reading input %x", self->priv->name, cond);
-          ret = read (self->priv->in_fd, self->priv->in_buffer->data + len, MAX_SEQ_PACKET);
+          ret = read (self->priv->in_fd, self->priv->in_buffer->data + len, MAX_PACKET_SIZE);
         }
 
       errn = errno;

--- a/src/ws/mock-auth-command.c
+++ b/src/ws/mock-auth-command.c
@@ -35,7 +35,7 @@
 static char *
 read_seqpacket_message (int fd)
 {
-  struct iovec vec = { .iov_len = MAX_SEQ_PACKET, };
+  struct iovec vec = { .iov_len = MAX_PACKET_SIZE, };
   struct msghdr msg;
   int r;
 

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -80,7 +80,7 @@ read_seqpacket_message (int fd,
                         const char *what,
                         size_t *out_len)
 {
-  struct iovec vec = { .iov_len = MAX_SEQ_PACKET, };
+  struct iovec vec = { .iov_len = MAX_PACKET_SIZE, };
   struct msghdr msg;
   int r;
 

--- a/src/ws/ssh.c
+++ b/src/ws/ssh.c
@@ -305,7 +305,7 @@ out:
 static gchar *
 wait_for_auth_fd_reply (CockpitSshData *data)
 {
-  struct iovec vec = { .iov_len = MAX_SEQ_PACKET, };
+  struct iovec vec = { .iov_len = MAX_PACKET_SIZE, };
   struct msghdr msg;
   int r;
 


### PR DESCRIPTION
Rename since this is now used as the default size for all CockpitPipe reads, not just SOCK_SEQPACKET pipes.

Unimportant follow up to #5227. Feel free to close if you think it's unnecessary.