### PR TITLE
shell: Only display 'Account Settings' menu item when ready

### DIFF
--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -750,7 +750,7 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
         function setup_account(id, user) {
             $(id).on("click", function() {
                 self.jump({ host: "localhost", component: "users", hash: "/" + user.name });
-            });
+            }).show();
         }
 
         /* User information */

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -41,8 +41,8 @@
                 <a data-toggle="modal" data-target="#about" translatable="yes">About Cockpit</a>
               </li>
               <li class="divider"></li>
-              <li>
-                <a id="go-account" translatable="yes">Account Settings</a>
+              <li id="go-account" hidden>
+                <a translatable="yes">Account Settings</a>
               </li>
               <li>
                   <a data-toggle="modal" data-target="#credentials-dialog"

--- a/test/avocado/checklogin-basic.py
+++ b/test/avocado/checklogin-basic.py
@@ -87,6 +87,7 @@ class checklogin_basic(Test):
         b.wait_text('#content-user-name', 'Administrator')
 
         b.click("#content-user-name")
+        b.wait_visible('#go-account')
         b.click('#go-account')
         b.enter_page("/users")
         b.wait_text("#account-user-name", "admin")

--- a/test/verify/check-keys
+++ b/test/verify/check-keys
@@ -60,6 +60,7 @@ class TestKeys(MachineCase):
             b.wait_text('#content-user-name', user_name)
 
             b.click('#navbar-dropdown')
+            b.wait_visible('#go-account')
             b.click('#go-account')
             b.enter_page("/users")
             b.wait_text("#account-user-name", user);

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -87,6 +87,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_text('#content-user-name', 'Administrator')
 
         b.click("#content-user-name")
+        b.wait_visible('#go-account')
         b.click('#go-account')
         b.enter_page("/users")
         b.wait_text ("#account-user-name", "admin")

--- a/test/verify/check-roles
+++ b/test/verify/check-roles
@@ -54,6 +54,7 @@ class TestRoles(MachineCase):
 
         # Check permissions for own account
         b.click('#content-user-name')
+        b.wait_visible('#go-account')
         b.click('#go-account')
         b.enter_page("/users")
 

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -70,6 +70,7 @@ class TestSession(MachineCase):
         b.wait_visible("#content")
         b.wait_text('#content-user-name', 'Administrator')
         b.click('#content-user-name')
+        b.wait_visible('#go-account')
         b.click('#go-account')
         b.enter_page("/users")
         b.wait_text ("#account-user-name", "admin")

--- a/test/verify/naughty-centos-7/5010-selinux-password-expiry
+++ b/test/verify/naughty-centos-7/5010-selinux-password-expiry
@@ -1,3 +1,3 @@
 Traceback (most recent call last):
-  File "./verify/check-login", line 164, in testExpired
+  File "./verify/check-login", line 165, in testExpired
     b.wait_in_text("#conversation-prompt", "Retype")

--- a/test/verify/naughty-fedora-24/5010-selinux-password-expiry
+++ b/test/verify/naughty-fedora-24/5010-selinux-password-expiry
@@ -1,3 +1,3 @@
 Traceback (most recent call last):
-  File "./verify/check-login", line 164, in testExpired
+  File "./verify/check-login", line 165, in testExpired
     b.wait_in_text("#conversation-prompt", "Retype")

--- a/test/verify/naughty-fedora-25/5010-selinux-password-expiry
+++ b/test/verify/naughty-fedora-25/5010-selinux-password-expiry
@@ -1,3 +1,3 @@
 Traceback (most recent call last):
-  File "./verify/check-login", line 164, in testExpired
+  File "./verify/check-login", line 165, in testExpired
     b.wait_in_text("#conversation-prompt", "Retype")

--- a/test/verify/naughty-fedora-testing/5010-selinux-password-expiry
+++ b/test/verify/naughty-fedora-testing/5010-selinux-password-expiry
@@ -1,3 +1,3 @@
 Traceback (most recent call last):
-  File "./verify/check-login", line 164, in testExpired
+  File "./verify/check-login", line 165, in testExpired
     b.wait_in_text("#conversation-prompt", "Retype")

--- a/test/verify/naughty-rhel-7/5010-selinux-password-expiry
+++ b/test/verify/naughty-rhel-7/5010-selinux-password-expiry
@@ -1,3 +1,3 @@
 Traceback (most recent call last):
-  File "./verify/check-login", line 164, in testExpired
+  File "./verify/check-login", line 165, in testExpired
     b.wait_in_text("#conversation-prompt", "Retype")


### PR DESCRIPTION
We need user information to load before the 'Account Settings'
menu item is ready. In the tests sometimes we race with this.
Fix the race, and real world corner case.