### PR TITLE
test: Update the o.client.lookup Fedora 22 known issue

### DIFF
--- a/test/verify/naughty/5127-fedora-22-dbus-client-fail
+++ b/test/verify/naughty/5127-fedora-22-dbus-client-fail
@@ -1,3 +1,1 @@
-  File "/build/cockpit/test/common/testlib.py", line 711, in _invoke
-    raise Error(res['error'])
 Error: TypeError: null is not an object (evaluating 'o.client.lookup')


### PR DESCRIPTION
The line numbers changed here.

See Issue #5127