### PR TITLE
test: Ignore 'Operation cancelled' in expect_load()

### DIFF
--- a/test/common/phantom-driver.js
+++ b/test/common/phantom-driver.js
@@ -127,7 +127,7 @@ var driver = {
              * yet cancelling and failing its load. We're experimenting by disabling
              * this specific failure and seeing its effect on the tests.
              */
-            if (ex.errorString === "Network access is disabled.")
+            if (ex.errorString === "Network access is disabled." || ex.errorString === "Operation cancelled")
                 sys.stderr.writeLine("expect_load ignoring: " + ex.errorString)
             else
                 failure = ex.errorString + " " + ex.url;


### PR DESCRIPTION
This failure seems to happen after doing a Cockpit logout
in the tests. It's possible that this is due to an iframe
that hasn't loaded yet cancelling and failing its load.

Lets experiment disabling this specific failure and seeing
its effect on the tests.