### PR TITLE
docker: Fix filtering when image.RepoTags is null

### DIFF
--- a/pkg/docker/containers-view.jsx
+++ b/pkg/docker/containers-view.jsx
@@ -383,7 +383,8 @@ var ImageList = React.createClass({
 
     render: function () {
         var filtered = this.state.images.filter(function (image) {
-            return (image.RepoTags[0].toLowerCase().indexOf(this.props.filterText.toLowerCase()) >= 0);
+            return (image.RepoTags &&
+                    image.RepoTags[0].toLowerCase().indexOf(this.props.filterText.toLowerCase()) >= 0);
         }.bind(this));
 
         var imageRows = filtered.map(function (image) {


### PR DESCRIPTION
This commit should fix this failure:

TypeError: null is not an object (evaluating 'e.RepoTags[0]')