### PR TITLE
package.json: Add less build dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "jed": "*",
     "jshint": "*",
     "jshint-loader": "*",
+    "less": ">2.5.0",
     "less-loader": "~2.2.3",
     "po2json": "*",
     "promise": "*",


### PR DESCRIPTION
It seems this is not inferred automatically and less-loader
needs this in order to function.

Various builders, such as verify machines, or contributors still had "less" in their node_modules/ which means fewer than expected people were affected by this bug.