### PR TITLE
bridge: Include os-release fields and package list in "init" message

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -83,6 +83,7 @@ The following fields are defined:
  * "host": The host being communicated with.
  * "problem": A problem occurred during init.
  * "csrf-token": The web service will send a csrf-token for external channels.
+ * "os-release": The bridge sends fields from /etc/os-release which identify the system.
 
 If a problem occurs that requires shutdown of a transport, then the "problem"
 field can be set to indicate why the shutdown will be shortly occurring.

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -84,6 +84,7 @@ The following fields are defined:
  * "problem": A problem occurred during init.
  * "csrf-token": The web service will send a csrf-token for external channels.
  * "os-release": The bridge sends fields from /etc/os-release which identify the system.
+ * "packages": The bridge sends a list of package names on the system.
 
 If a problem occurs that requires shutdown of a transport, then the "problem"
 field can be set to indicate why the shutdown will be shortly occurring.

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -154,6 +154,7 @@ BRIDGE_CHECKS = \
 	test-setup \
 	test-websocketstream \
 	test-environment \
+	test-bridge \
 	$(NULL)
 
 mock_bridge_SOURCES = src/bridge/mock-bridge.c
@@ -162,6 +163,10 @@ mock_bridge_CFLAGS = \
 	$(COCKPIT_BRIDGE_CFLAGS) \
 	$(NULL)
 mock_bridge_LDADD = $(libcockpit_bridge_LIBS)
+
+test_bridge_SOURCES = src/bridge/test-bridge.c
+test_bridge_CFLAGS = $(libcockpit_bridge_a_CFLAGS)
+test_bridge_LDADD = $(libcockpit_bridge_LIBS)
 
 test_channel_SOURCES = \
 	src/bridge/test-channel.c \

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -96,10 +96,10 @@ send_init_command (CockpitTransport *transport,
                    GHashTable *os_release)
 {
   const gchar *checksum;
-  const gchar *name;
   const gchar *value;
   JsonObject *object;
   JsonObject *block;
+  gchar **names;
   GBytes *bytes;
   gint i;
 
@@ -116,10 +116,13 @@ send_init_command (CockpitTransport *transport,
   if (checksum)
     json_object_set_string_member (object, "checksum", checksum);
 
-  /* Happens when we're in --interact mode */
-  name = cockpit_dbus_internal_name ();
-  if (name)
-    json_object_set_string_member (object, "bridge-dbus-name", name);
+  /* This is encoded as an object to allow for future expansion */
+  block = json_object_new ();
+  names = cockpit_packages_get_names (packages);
+  for (i = 0; names && names[i] != NULL; i++)
+    json_object_set_null_member (block, names[i]);
+  json_object_set_object_member (object, "packages", block);
+  g_free (names);
 
   if (os_release)
     {

--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -997,6 +997,30 @@ cockpit_packages_get_checksum (CockpitPackages *packages)
   return packages->checksum;
 }
 
+gchar **
+cockpit_packages_get_names (CockpitPackages *packages)
+{
+  GHashTableIter iter;
+  GPtrArray *array;
+  gpointer key;
+  gpointer value;
+  CockpitPackage *package;
+
+  g_return_val_if_fail (packages != NULL, NULL);
+
+  array = g_ptr_array_new ();
+  g_hash_table_iter_init (&iter, packages->listing);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    {
+      package = value;
+      if (!package->unavailable)
+        g_ptr_array_add (array, key);
+    }
+  g_ptr_array_add (array, NULL);
+
+  return (gchar **)g_ptr_array_free (array, FALSE);
+}
+
 void
 cockpit_packages_free (CockpitPackages *packages)
 {

--- a/src/bridge/cockpitpackages.h
+++ b/src/bridge/cockpitpackages.h
@@ -29,6 +29,8 @@ CockpitPackages * cockpit_packages_new              (void);
 
 const gchar *     cockpit_packages_get_checksum     (CockpitPackages *packages);
 
+gchar **          cockpit_packages_get_names        (CockpitPackages *packages);
+
 gchar *           cockpit_packages_resolve          (CockpitPackages *packages,
                                                      const gchar *name,
                                                      const gchar *path,

--- a/src/bridge/test-bridge.c
+++ b/src/bridge/test-bridge.c
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "common/cockpitjson.h"
+#include "common/cockpitpipe.h"
+#include "common/cockpitpipetransport.h"
+#include "common/cockpittest.h"
+
+#include <json-glib/json-glib.h>
+
+#include <gio/gio.h>
+
+static gboolean
+on_recv_get_bytes (CockpitTransport *transport,
+                   const gchar *channel,
+                   GBytes *data,
+                   gpointer user_data)
+{
+  GBytes **result = (GBytes **)user_data;
+  g_assert_cmpstr (channel, ==, NULL);
+  g_assert (result != NULL);
+  g_assert (*result == NULL);
+  *result = g_bytes_ref (data);
+  return TRUE;
+}
+
+static void
+on_closed_not_reached (CockpitTransport *transport,
+                       const gchar *problem)
+{
+  g_assert_cmpstr (problem, ==, NULL);
+  g_assert_not_reached ();
+}
+
+static void
+test_bridge_init (void)
+{
+  CockpitTransport *transport;
+  CockpitPipe *pipe;
+  GBytes *bytes = NULL;
+  JsonObject *object;
+  JsonObject *os_release;
+  GError *error = NULL;
+
+  const gchar *argv[] = {
+    BUILDDIR "/cockpit-bridge",
+    NULL
+  };
+
+  pipe = cockpit_pipe_spawn (argv, NULL, NULL, COCKPIT_PIPE_FLAGS_NONE);
+  transport = cockpit_pipe_transport_new (pipe);
+  g_object_unref (pipe);
+
+  g_signal_connect (transport, "recv", G_CALLBACK (on_recv_get_bytes), &bytes);
+  g_signal_connect (transport, "closed", G_CALLBACK (on_closed_not_reached), NULL);
+
+  while (bytes == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_signal_handlers_disconnect_by_func (transport, on_recv_get_bytes, &bytes);
+  g_signal_handlers_disconnect_by_func (transport, on_closed_not_reached, NULL);
+
+  g_object_unref (transport);
+
+  object = cockpit_json_parse_bytes (bytes, &error);
+  g_assert_no_error (error);
+  g_bytes_unref (bytes);
+
+  g_assert_cmpstr (json_object_get_string_member (object, "command"), ==, "init");
+
+  os_release = json_object_get_object_member (object, "os-release");
+  g_assert (os_release != NULL);
+  g_assert (json_object_has_member (os_release, "NAME"));
+
+  json_object_unref (object);
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+  g_setenv ("XDG_DATA_DIRS", SRCDIR "/src/bridge/mock-resource/system", TRUE);
+  g_setenv ("XDG_DATA_HOME", SRCDIR "/src/bridge/mock-resource/home", TRUE);
+
+  cockpit_test_init (&argc, &argv);
+
+  g_test_add_func ("/bridge/init-message", test_bridge_init);
+
+  return g_test_run ();
+}

--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -29,6 +29,7 @@
 #include "common/cockpitjson.h"
 #include "common/cockpittest.h"
 
+#include <stdlib.h>
 #include <string.h>
 
 extern const gchar **cockpit_bridge_data_dirs;
@@ -598,6 +599,33 @@ test_resolve_not_found (TestCase *tc,
   g_assert (path == NULL);
 }
 
+static int
+compar_str (const void *pa,
+            const void *pb)
+{
+  return strcmp (*(const char**)pa, *(const char**)pb);
+}
+
+static void
+test_get_names (TestCase *tc,
+                gconstpointer fixture)
+{
+  gchar **names;
+  gchar *result;
+
+  names = cockpit_packages_get_names (tc->packages);
+  g_assert (names != NULL);
+
+  qsort (names, g_strv_length (names), sizeof (gchar *), compar_str);
+  result = g_strjoinv (", ", names);
+
+  /* Note that unavailable packages are not included */
+  g_assert_cmpstr (result, ==, "another, second, test");
+
+  g_free (result);
+  g_free (names);
+}
+
 int
 main (int argc,
       char *argv[])
@@ -652,6 +680,9 @@ main (int argc,
               setup_basic, test_resolve_bad_package, teardown_basic);
   g_test_add ("/packages/resolve/not-found", TestCase, NULL,
               setup_basic, test_resolve_not_found, teardown_basic);
+
+  g_test_add ("/packages/get-names", TestCase, NULL,
+              setup_basic, test_get_names, teardown_basic);
 
   return g_test_run ();
 }

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -254,7 +254,7 @@ build_environment (GHashTable *os_release)
    * the corresponding information is not a leak.
    */
   static const gchar *release_fields[] = {
-    "NAME", "VERSION", "ID", "VERSION_ID", "PRETTY_NAME", "VARIANT", "VARIANT_ID", "CPE_NAME",
+    "NAME", "ID", "PRETTY_NAME", "VARIANT", "VARIANT_ID", "CPE_NAME",
   };
 
   static const gchar *prefix = "\n    <script>\nvar environment = ";


### PR DESCRIPTION
In both the embedding case, the container case, and the RHEL 6 case we want to be able to identify the target system and figure out if cockpit packages are installed. This pull request sets up the stage for that.

In the future:

 * We'll use the os-release field to determine what's going on the target system.
 * We'll use the packages field to determine packages are available there, or try to serve them locally, using the os-release to select a set locally.