### PR TITLE
test: Remove known issue where session doesn't exit

### DIFF
--- a/test/verify/naughty/3042-wait-session-false
+++ b/test/verify/naughty/3042-wait-session-false
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "check-session", line 50, in testBasic
-    wait_session(False)
-  File "check-session", line 39, in wait_session
-    wait(cond)

--- a/test/verify/naughty/3042-wait-session-false-2
+++ b/test/verify/naughty/3042-wait-session-false-2
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-session", line 62, in testBasic
-    wait_session(False)


### PR DESCRIPTION
This hasn't happened in 2 months, and likely has been patched
by all the operating system.

Fixes #3042