### PR TITLE
test: Remove known issue for UUID not in cryptab

### DIFF
--- a/test/verify/naughty/3055-uuid-etc-crypttab
+++ b/test/verify/naughty/3055-uuid-etc-crypttab
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-storage-luks", line 61, in testLuks
-    assert m.execute("grep 'UUID=' /etc/crypttab") != ""


### PR DESCRIPTION
This doesn't  have an upstream issue, and applies to all operating systems. It masks too many failures.

This has been factored out of #5232

Fixes #3055
