### PR TITLE
test: Don't use a global 'naughty' directory

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -813,7 +813,7 @@ class Naughty(object):
         return True
 
     def check_issue(self, trace):
-        directories =  [ os.path.join(testinfra.TEST_DIR, "verify", "naughty") ]
+        directories =  [ ]
         image_naughty = os.path.join(testinfra.TEST_DIR, "verify", "naughty-" + testinfra.DEFAULT_IMAGE)
         if os.path.exists(image_naughty):
             directories.append(image_naughty)


### PR DESCRIPTION
Instead expect a directory per operating system. This is about
tracking bugs in the operating system, and that can't be a global
thing.

If for whatever reason a bug exists in all operating systems,
then a naughty file, and upstream bugs, should be filed against
all of them.

Blocked on:

 * [x] https://github.com/cockpit-project/cockpit/pull/5252