### PR TITLE
ws: Delay ssh logins until we know we have a bridge

### DIFF
--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -77,6 +77,7 @@ EXTRA_DIST += \
 	src/ws/mock_cert \
 	src/ws/mock_known_hosts \
 	src/ws/mock-pid-cat \
+	src/ws/mock-cat-with-init \
 	src/ws/mock-kdc \
 	src/ws/mock-krb5.conf.in \
 	src/ws/mock-kdc.conf.in \
@@ -320,6 +321,7 @@ noinst_PROGRAMS += \
 
 noinst_SCRIPTS += \
 	src/ws/mock-pid-cat \
+	src/ws/mock-cat-with-init \
 	$(NULL)
 
 TESTS += $(WS_CHECKS)

--- a/src/ws/mock-cat-with-init
+++ b/src/ws/mock-cat-with-init
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Here we send a init message the exec cat
+
+/usr/bin/printf "22\n{ \"command\" : \"init\" }"
+exec /bin/cat

--- a/src/ws/mock-echo.c
+++ b/src/ws/mock-echo.c
@@ -34,6 +34,7 @@ main (void)
   gssize count;
   gint i;
 
+  g_print ("22\n{ \"command\" : \"init\" }");
   for (i = 0; TRUE; i++)
     {
       count = read (0, buffer, sizeof (buffer));

--- a/src/ws/test-sshtransport.c
+++ b/src/ws/test-sshtransport.c
@@ -196,6 +196,14 @@ setup_mock_sshd (TestCase *tc,
 static guint old_process_timeout = 0;
 static guint old_response_timeout = 0;
 
+static const TestFixture fixture_mock_echo = {
+  .ssh_command = BUILDDIR "/mock-echo"
+};
+
+static const TestFixture fixture_cat = {
+  .ssh_command =  SRCDIR "/src/ws/mock-cat-with-init"
+};
+
 static void
 setup_transport (TestCase *tc,
                  gconstpointer data)
@@ -245,7 +253,7 @@ setup_transport (TestCase *tc,
     }
   command = fixture->ssh_command;
   if (!command)
-    command = "cat";
+    command = fixture_cat.ssh_command;
 
   if (fixture->expect_key)
     expect_knownhosts = g_strdup_printf ("[127.0.0.1]:%d %s", (int)tc->ssh_port, fixture->expect_key);
@@ -345,14 +353,6 @@ on_closed_set_flag (CockpitTransport *transport,
   g_assert (*flag == FALSE);
   *flag = TRUE;
 }
-
-static const TestFixture fixture_mock_echo = {
-  .ssh_command = BUILDDIR "/mock-echo"
-};
-
-static const TestFixture fixture_cat = {
-  .ssh_command = "cat"
-};
 
 static void
 test_echo_and_close (TestCase *tc,

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -40,6 +40,15 @@ class TestLoopback(MachineCase):
         m.wait_for_cockpit_running()
 
         b.login_and_go("/system", user="admin")
+        b.logout()
+        b.wait_visible("#login")
+
+        m.execute("rm /usr/bin/cockpit-bridge")
+        b.set_val('#login-user-input', "admin")
+        b.set_val('#login-password-input', "foobar")
+        b.click('#login-button')
+        b.wait_visible('#login-fatal')
+        self.assertIn("no-cockpit", b.text('#login-fatal'));
 
         m.execute("sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config")
 
@@ -50,7 +59,7 @@ class TestLoopback(MachineCase):
         #
         m.execute("! systemctl --quiet is-enabled sshd || systemctl restart sshd")
 
-        b.logout()
+        b.reload()
         b.wait_visible("#login")
         b.set_val('#login-user-input', "admin")
         b.set_val('#login-password-input', "foobar")


### PR DESCRIPTION
This allows us to display a no-cockpit message on the login screen. Rather than having a race where the session is terminated after a successful login because there is no cockpit-bridge present but before the browser has had a chance to reload. Leaving the user back at the login screen without any error message.