### PR TITLE
docker: add "Security" tab to image listing

### DIFF
--- a/pkg/docker/atomic.js
+++ b/pkg/docker/atomic.js
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+var cockpit = require("cockpit");
+var moment = require("moment");
+
+var atomic = {};
+cockpit.event_target(atomic);
+
+var bus = cockpit.dbus();
+var intervalId;
+
+function sanitizeVulnerableInfo (id, info) {
+    return {
+        id: id,
+        successful: info.Successful === true || info.Successful === "true",
+        scanType: info["Scan Type"],
+        finishedTime: moment(info.FinishedTime),
+        vulnerabilities: info.Vulnerabilities.map(function (v) {
+            return {
+                title: v.Title,
+                description: v.Description,
+                severity: v.Severity
+            };
+        })
+    };
+}
+
+function updateVulnerableInfo() {
+    bus.call("/org/atomic/object", "org.atomic", "VulnerableInfo", [], { name: 'org.atomic' })
+        .done(function (reply) {
+            var infos = {};
+
+            try {
+                infos = JSON.parse(reply[0]);
+            } catch (error) {
+                /* ignore errors (same as when org.atomic doesn't exist) */
+            }
+
+            var promises;
+
+            /* Atomic sometimes returns containers for which it doesn't
+             * have scan results. Remove those. */
+            var ids = Object.keys(infos).filter(function (id) { return infos[id].json_file; });
+
+            if (ids.length > 0) {
+                promises = ids.map(function (id) {
+                    return cockpit.file(infos[id].json_file, { syntax: JSON }).read();
+                });
+
+                cockpit.all(promises).done(function () {
+                    var detailedInfos = {};
+
+                    for (var i = 0; i < arguments.length; i++)
+                        detailedInfos[ids[i]] = sanitizeVulnerableInfo(ids[i], arguments[i]);
+
+                    atomic.dispatchEvent("vulnerableInfoChanged", detailedInfos);
+                });
+            }
+        }.bind(this));
+}
+
+function visibilityChanged() {
+    if (cockpit.hidden) {
+        window.clearInterval(intervalId);
+        intervalId = undefined;
+    } else {
+        if (!intervalId) {
+            updateVulnerableInfo();
+            intervalId = window.setInterval(updateVulnerableInfo, 10000);
+        }
+    }
+}
+
+cockpit.onvisibilitychange = visibilityChanged;
+visibilityChanged();
+
+module.exports = atomic;

--- a/pkg/docker/containers-view.jsx
+++ b/pkg/docker/containers-view.jsx
@@ -290,7 +290,7 @@ var ImageDetails = React.createClass({
         if (image.Config) {
             entrypoint = image.Config.Entrypoint;
             command = image.Config.Cmd;
-            ports = image.Config.ExposedPorts || [];
+            ports = Object.keys(image.Config.ExposedPorts || {});
         }
 
         return (

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -1,3 +1,16 @@
+
+.listing-ct-body-header {
+    margin-bottom: 1.5em;
+}
+
+.vulnerability-row-ct-docker {
+    line-height: 2.5em;
+}
+
+.vulnerability-row-ct-docker:not(:last-child) {
+    border-bottom: 1px solid #BABABA;
+}
+
 /* For table rows containing interactive controls like bars */
 .info-table-ct tr.interactive td {
     line-height: 26px;

--- a/pkg/lib/cockpit-components-listing.jsx
+++ b/pkg/lib/cockpit-components-listing.jsx
@@ -24,6 +24,7 @@ var React = require('react');
 require('./listing.css');
 
 /* entry for an alert in the listing, can be expanded (with details) or standard
+ * rowId optional: an identifier for the row which will be set as "data-row-id" attribute on the <tr>
  * columns list of columns to show in the header
  *     columns to show, can be a string, react component or object with { name: 'name', 'header': false }
  *     'header' (or if simple string) defaults to false
@@ -44,6 +45,7 @@ require('./listing.css');
  */
 var ListingRow = React.createClass({
     propTypes: {
+        rowId: React.PropTypes.string,
         columns: React.PropTypes.array.isRequired,
         tabRenderers: React.PropTypes.array,
         navigateToItem: React.PropTypes.func,
@@ -159,7 +161,8 @@ var ListingRow = React.createClass({
             listingItemClasses.push("listing-ct-noexpand");
 
         var listingItem = (
-            <tr className={ listingItemClasses.join(' ') }
+            <tr data-row-id={ this.props.rowId }
+                className={ listingItemClasses.join(' ') }
                 onClick={ allowNavigate?this.handleNavigateClick:this.handleExpandClick }>
                 {expandToggle}
                 {headerEntries}

--- a/pkg/lib/listing.css
+++ b/pkg/lib/listing.css
@@ -66,6 +66,10 @@ table.listing-ct tbody.open + thead {
     border-top: none;
 }
 
+tbody tr.listing-ct-item.listing-ct-warning {
+    background-color: #fbc7c7;
+}
+
 tbody.open tr.listing-ct-item {
     background-color: #ededed;
     border-bottom: none;

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -498,5 +498,80 @@ CMD ["/bin/sh"]
         # This should be updated
         b.wait_in_text("#container-details-cpu-row", "1024 shares")
 
+@skipImage("Skip on systems without atomic", "centos-7", "debian-8", "debian-unstable", "ubuntu-1604")
+class TestAtomicScan(MachineCase):
+    def testBasic(self):
+        b = self.browser
+        m = self.machine
+
+        m.execute("systemctl start docker")
+
+        # HACK put scan results for one of the images into /var/lib/atomic
+        #
+        # This mimics what `atomic scan` would put there. A cleaner solution
+        # would be to run `atomic scan` on a known bad image from this test, so
+        # that the test is independent of atomic's internal data structures.
+
+        infos = json.loads(m.execute("docker inspect docker.io/busybox"))
+        image_id = infos[0]["Id"]
+        short_id = image_id.replace("sha256:", "")
+        result_path = os.path.join("/var/lib/atomic/atomic_scan_openscap/2016-12-11-12-09-57-674487/", short_id)
+        result_filename = os.path.join(result_path, "json")
+
+        scan_summary = {
+            short_id: {
+                "Scan Type": "Standards Compliance",
+                "json_file": result_filename,
+                "Scanner": "openscap",
+                "Time": "2016-12-11T12:09:59",
+                "Vulnerable": True,
+                "UUID": short_id
+            }
+        }
+
+        scan_result = {
+            "Scanner": "openscap",
+            "Vulnerabilities": [
+                {
+                    "Description": "\nThe RPM package management system can check file access\npermissions of installed software packages, including many that are\nimportant to system security. \nAfter locating a file with incorrect permissions, run the following command to determine which package owns it:\n",
+                    "Title": "Verify and Correct File Permissions with RPM",
+                    "Custom": {
+                        "XCCDF result": "fail"
+                    },
+                    "Severity": "Low"
+                },
+                {
+                    "Description": "\nSystem executables are stored in the following directories by default:\n",
+                    "Title": "Verify that System Executables Have Restrictive Permissions",
+                    "Custom": {
+                        "XCCDF result": "fail"
+                    },
+                    "Severity": "Moderate"
+                }
+            ],
+            "Finished Time": "2016-12-11T12:10:27",
+            "UUID": "/scanin/d6fe5fdc49c2886ccad1c781d38a0c9fe679c6e7ca0297d23186c385873e86fa",
+            "Scan Type": "Standard Compliance",
+            "Time": "2016-12-11T12:09:59",
+            "Successful": "true"
+        }
+
+        m.execute("mkdir -p " + result_path)
+        m.execute("echo '%s' > /var/lib/atomic/scan_summary.json" % json.dumps(scan_summary))
+        m.execute("echo '%s' > %s" % (json.dumps(scan_result), result_filename))
+
+        self.login_and_go("/docker")
+
+        row_selector = '#containers-images tr[data-row-id="%s"]' % image_id
+
+        # warning badge should exist
+        b.wait_present(row_selector + ' td span.pficon-warning-triangle-o')
+        b.wait_visible(row_selector + ' td span.pficon-warning-triangle-o')
+
+        # Security tab should exist
+        b.click(row_selector + ' td.listing-ct-toggle')
+        b.wait_visible(row_selector + ' + tr a:contains("Security")')
+
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Add a "Security" tab to the image listing, if the "org.atomic" D-Bus service exists and that particular image has been scanned already.

You cannot initiate a scan from cockpit, yet (the "Scan again" button that doesn't work).

To try it out, install atomic and a scanner, for example `atomic install fedora/atomic_scan_openscap` and run `atomic scan [image]`. The security tab should then show up for that image.
