### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-4932882eeab9799285ad1ad4d7cc9cae2c7a0a4e.qcow2
+debian-unstable-736a84151b482daa2b2cd0d756554856fecccfde.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-10-28/