### PR TITLE
Support old UDisks2, kinda.

### DIFF
--- a/doc/guide/feature-storaged.xml
+++ b/doc/guide/feature-storaged.xml
@@ -10,6 +10,18 @@
     system. This functionality is present in the Cockpit
     <emphasis>storaged</emphasis> package.</para>
 
+  <para>The <code>storaged</code> project is originally based on a project called
+    <ulink url="https://www.freedesktop.org/wiki/Software/udisks/"><code>udisks</code></ulink>
+    and added support for many more features such as
+    <ulink url="https://en.wikipedia.org/wiki/Logical_Volume_Manager_(Linux)">LVM</ulink>,
+    <ulink url="https://en.wikipedia.org/wiki/ISCSI">iSCSI</ulink>,
+    <ulink url="https://en.wikipedia.org/wiki/Linux_DM_Multipath">Multipath</ulink>, and
+    <ulink url="https://btrfs.wiki.kernel.org/index.php/Main_Page">BTRFS</ulink>.
+    The same tools and backwards compatible API are available between <code>storaged</code>
+    and <code>udisks</code> the projects. Cockpit can use <code>udisks</code> but disables
+    many of it's storage related features, including updating <code>/etc/fstab</code>
+    and <code>/etc/crypttab</code> for stability reasons.</para>
+
   <para>For non root users, storaged controls access to its APIs via
     <link linkend="privileges">Policy Kit</link> and a user logged into Cockpit will have
     the same permissions as they do from the command line.</para>
@@ -17,7 +29,7 @@
   <para>To perform similar tasks from the command line, use the <code>storagedctl</code> command:</para>
 
 <programlisting>
-$ <command>storagedctl dump</command>
+$ <command>udisksctl dump</command>
 ...
 </programlisting>
 

--- a/pkg/storaged/details.js
+++ b/pkg/storaged/details.js
@@ -1115,8 +1115,13 @@
                 [ { title: _("Format"),             action: "format" }
                 ];
 
+            var disable_delete = false;
+            // The old UDisks2 can't properly delete unlocked luks devices
+            if (client.is_old_udisks2 && is_crypto && !is_crypto_locked)
+                disable_delete = true;
+
             var delete_action_spec =
-                [ { title: _("Delete"),             action: "delete" }
+                [ { title: _("Delete"),             action: "delete", disabled: disable_delete }
                 ];
 
             var default_op = null;

--- a/pkg/storaged/details.js
+++ b/pkg/storaged/details.js
@@ -1527,6 +1527,11 @@
                                    );
             }
 
+            /* Older versions of Udisks/storaged don't have a Running property */
+            var running = mdraid.Running;
+            if (running === undefined)
+                running = mdraid.ActiveDevices && mdraid.ActiveDevices.length > 0;
+
             var mdraid_model = {
                 dbus: mdraid,
                 Name: utils.mdraid_name(mdraid),
@@ -1534,7 +1539,7 @@
                 Level: level,
                 Bitmap: bitmap,
                 Degraded: degraded_message,
-                State: mdraid.Running? _("Running") : _("Not running"),
+                State: running ? _("Running") : _("Not running"),
             };
 
             var block_model = null;
@@ -1580,7 +1585,7 @@
             ];
 
             var def_action;
-            if (mdraid.Running)
+            if (running)
                 def_action = actions[1];  // Stop
             else
                 def_action = actions[0];  // Start

--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -364,8 +364,9 @@
       </button>
       <ul class="dropdown-menu action-dropdown-menu" role="menu">
         {{#actions}}
-        <li class="presentation {{#disabled}}disabled{{/disabled}}">
-          <a class=" storage-privileged" data-action="{{action}}" data-arg="{{arg}}" role="menuitem">{{title}}</a>
+        <li class="presentation">
+          <a class="{{#disabled}}disabled{{/disabled}}"
+             data-action="{{action}}" data-arg="{{arg}}" role="menuitem">{{title}}</a>
         </li>
         {{/actions}}
       </ul>

--- a/pkg/storaged/test-util.js
+++ b/pkg/storaged/test-util.js
@@ -33,4 +33,27 @@ QUnit.test("format_delay", function() {
     }
 });
 
+QUnit.test("compare_versions", function() {
+    var checks = [
+        [ "",      "",      0 ],
+        [ "0",     "0",     0 ],
+        [ "1",     "0",     1 ],
+        [ "0",     "1",    -1 ],
+        [ "2",     "1.9",   1 ],
+        [ "2.0",   "2",     1 ],
+        [ "2.1.6", "2.5",  -1 ],
+        [ "2..6",  "2.0.6", 0 ],
+    ];
+
+    function sign(n) {
+        return (n === 0) ? 0 : (n < 0)? -1 : 1;
+    }
+
+    assert.expect(checks.length);
+    for (var i = 0; i < checks.length; i++) {
+        assert.strictEqual(sign(utils.compare_versions(checks[i][0], checks[i][1])), checks[i][2],
+                           "compare_versions(" + checks[i][0] + ", " + checks[i][1] + ") = " + checks[i][2]);
+    }
+});
+
 QUnit.start();

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -34,6 +34,25 @@
 
     var utils = { };
 
+    utils.compare_versions = function compare_versions(a, b) {
+        function to_ints(str) {
+            return str.split(".").map(function (s) { return s ? parseInt(s, 10) : 0; });
+        }
+
+        var a_ints = to_ints(a);
+        var b_ints = to_ints(b);
+        var len = Math.min(a_ints.length, b_ints.length);
+        var i;
+
+        for (i = 0; i < len; i++) {
+            if (a_ints[i] == b_ints[i])
+                continue;
+            return a_ints[i] - b_ints[i];
+        }
+
+        return a_ints.length - b_ints.length;
+    };
+
     var hostnamed = cockpit.dbus("org.freedesktop.hostname1").proxy();
 
     utils.array_find = function array_find(array, pred) {

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -86,14 +86,16 @@ class TestStorage(StorageCase):
 
         self.wait_in_storaged_configuration("weird,options")
 
-        # Delete the partition
-        self.content_action(1, "Delete")
-        self.confirm()
-        b.wait_in_text("#content", "Free Space")
-        b.wait_not_in_text("#content", "ENCRYPTED")
+        # Delete the partition.  This only works properly on new
+        # implementations of Storaged/UDisks2.
 
-        assert m.execute("grep -v ^# /etc/crypttab || true").strip() == ""
-        assert m.execute("grep %s /etc/fstab || true" % mount_point_secret) == ""
+        if self.storaged_version > [ 2, 3 ]:
+            self.content_action(1, "Delete")
+            self.confirm()
+            b.wait_in_text("#content", "Free Space")
+            b.wait_not_in_text("#content", "ENCRYPTED")
+            assert m.execute("grep -v ^# /etc/crypttab || true").strip() == ""
+            assert m.execute("grep %s /etc/fstab || true" % mount_point_secret) == ""
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
This is my version of old UDisks2 support, based on @stefwalter:s.

The biggest thing is that I have completely removed support for fstab and crypttab.  Storaged does a lot more in that area.  See the 'config-items', 'track-parents', and 'tear-down' options in its documentation.  I think these options are important to have viable fstab and crypttab support. 
