### PR TITLE
Migrate to using babel 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "description": "Cockpit isn't a Node package, these are devel time deps, not needed to build tarball either",
   "private": true,
   "devDependencies": {
-    "babel-core": "~5.8.38",
-    "babel-loader": "~5.4.2",
+    "babel-core": "~6.2.0",
+    "babel-loader": "~6.2.0",
+    "babel-preset-es2015": "~6.2.0",
+    "babel-preset-react": "~6.2.0",
     "bower": "~1.7.9",
     "clean-css": "~3.4.20",
     "copy-webpack-plugin": "~3.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -364,11 +364,17 @@ module.exports = {
             },
             {
                 test: /\.jsx$/,
-                loader: "babel-loader"
+                loader: "babel-loader",
+                query: {
+                    presets: ["react"]
+                }
             },
             {
                 test: /\.es6$/,
-                loader: "babel-loader"
+                loader: "babel-loader",
+                query: {
+                    presets: ["es2015"]
+                }
             },
             {
                 test: /\.less$/,


### PR DESCRIPTION
This is requested by packagers who are packaging newer versions of these build tools.

The node_modules/ directory is full of all sorts of duplicate files. We use the hardlink command while building the tarball to make duplicate files be hardlinks.
