### PR TITLE
Prune unused node modules in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -35,7 +35,9 @@ PKG_NAME="Cockpit"
 olddir=$(pwd)
 cd $srcdir
 
+npm prune
 npm install # see package.json
+
 find node_modules -name test | xargs rm -rf
 
 rm -rf autom4te.cache


### PR DESCRIPTION
This helps keep things clean, but more importantly allows the
verify machines and semaphore to react properly to upgraded
node devel dependencies.
