### PR TITLE
Image refresh for centos-7

### DIFF
--- a/test/images/centos-7
+++ b/test/images/centos-7
@@ -1,1 +1,1 @@
-centos-7-1a9df91d17a2dcebc5b52dd1e0107c5505be9361.qcow2
+centos-7-219ba7f8c3cfbc2e6ce508d1a7d76d16422136b8.qcow2


### PR DESCRIPTION
Image creation for centos-7 in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-centos-7-2016-10-29/
