### PR TITLE
tools: Update Debian control files for required base

### DIFF
--- a/tools/debian/cockpit.substvars
+++ b/tools/debian/cockpit.substvars
@@ -1,0 +1,1 @@
+RequiredBase=122

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -37,15 +37,15 @@ Homepage: http://cockpit-project.org/
 Package: cockpit
 Architecture: any
 Depends: ${misc:Depends},
-         cockpit-bridge,
-         cockpit-ws,
-         cockpit-shell,
+         cockpit-bridge (= ${binary:Version}),
+         cockpit-ws (= ${binary:Version}),
+         cockpit-shell (= ${binary:Version}),
          xdg-utils
-Recommends: cockpit-docker,
-            cockpit-storaged,
-            cockpit-networkmanager
-Suggests: cockpit-doc,
-          cockpit-pcp
+Recommends: cockpit-docker (= ${binary:Version}),
+            cockpit-storaged (= ${binary:Version}),
+            cockpit-networkmanager (= ${binary:Version})
+Suggests: cockpit-doc (= ${binary:Version}),
+          cockpit-pcp (= ${binary:Version})
 Description: User interface for Linux servers
  Cockpit runs in a browser and can manage your network of GNU/Linux
  machines.
@@ -70,10 +70,8 @@ Description: Cockpit bridge server-side component
 
 Package: cockpit-networkmanager
 Architecture: any
-# Lock bridge dependency due to --with-networkmanager-needs-root
-# which uses new less stable /manifests.js request path.
 depends: ${misc:Depends},
-         cockpit-bridge (= ${binary:Version}),
+         cockpit-bridge (>= ${RequiredBase}),
          network-manager
 Description: Cockpit user interface for networking
  The Cockpit components for interacting with networking configuration.
@@ -90,6 +88,7 @@ Description: Cockpit PCP integration
 Package: cockpit-storaged
 Architecture: any
 Depends: ${misc:Depends},
+         cockpit-bridge (>= ${RequiredBase}),
          udisks2 | storaged
 Description: Cockpit user interface for storage
  The Cockpit components for interacting with storage.
@@ -107,7 +106,7 @@ Package: cockpit-shell
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
-         cockpit-bridge (= ${binary:Version}),
+         cockpit-bridge (= ${RequiredBase}),
          libpwquality-tools
 Description: Cockpit Shell user interface package
  This package contains the Cockpit shell UI assets.
@@ -115,6 +114,7 @@ Description: Cockpit Shell user interface package
 Package: cockpit-docker
 Architecture: amd64 armel armhf i386
 Depends: ${misc:Depends},
+         cockpit-bridge (>= ${RequiredBase}),
          docker.io (>= 1.3.0) | docker-engine (>= 1.3.0),
          python
 Description: Cockpit user interface for Docker containers
@@ -123,6 +123,7 @@ Description: Cockpit user interface for Docker containers
 Package: cockpit-machines
 Architecture: any
 Depends: ${misc:Depends},
+         cockpit-bridge (>= ${RequiredBase}),
          libvirt-daemon-system
 Description: Cockpit user interface for virtual machines
  The Cockpit components for managing virtual machines.
@@ -130,5 +131,6 @@ Description: Cockpit user interface for virtual machines
 Package: cockpit-test-assets
 Architecture: any
 Depends: ${misc:Depends},
+         cockpit-bridge,
          openssh-client
 Description: Addition files for the Cockpit integration tests

--- a/tools/debian/substvars
+++ b/tools/debian/substvars
@@ -1,0 +1,1 @@
+RequiredBase=122


### PR DESCRIPTION
The internal javascript API in 0.114 is considered stable
in the base1 package. So subpackages can use any version of
cockpit-bridge and cockpit-shell 0.114 or later.

Note that storaged is bound tightly to the version due to
the way certain options are driven through configure.ac.