### PR TITLE
test: Reset entire test/tmp directory and logs/images

### DIFF
--- a/test/vm-reset
+++ b/test/vm-reset
@@ -31,4 +31,5 @@ case ${1:-} in
 	;;
 esac
 
-rm -rf $BASE/tmp/run/* $BASE/tmp/run/.*??
+rm -rf $BASE/tmp/*
+rm -f $BASE/*.log $BASE/*.png $BASE/*.avocado


### PR DESCRIPTION
Cleanup better before running tests. This allows the test
verify machines to not "leak" disk space.