### PR TITLE
WIP: Refactor how we spawn auth/session processes

### DIFF
--- a/doc/login.md
+++ b/doc/login.md
@@ -24,8 +24,7 @@ this.
 
 
 ```
-WWW-Authenticate X-Login-Reply base64(prompt)
-X-Conversation: conversation
+WWW-Authenticate X-Conversation conversation base64(prompt)
 ```
 
 This may be accompanied by a JSON object in the body of the response to provide additional context.
@@ -42,8 +41,7 @@ Cockpit will then display the prompt and provide a field for the user to type th
 To send the answer the Authorization header is built like this.
 
 ```
-Authorization: X-Login-Reply base64(response)
-X-Conversation: conversation
+Authorization: X-Conversation conversation base64(response)
 ```
 
 Where conversation is the same conversation that was received with the WWW-Authenticate response.

--- a/doc/login.md
+++ b/doc/login.md
@@ -24,7 +24,8 @@ this.
 
 
 ```
-WWW-Authenticate X-Login-Reply id base64(prompt)
+WWW-Authenticate X-Login-Reply base64(prompt)
+X-Conversation: conversation
 ```
 
 This may be accompanied by a JSON object in the body of the response to provide additional context.
@@ -41,9 +42,10 @@ Cockpit will then display the prompt and provide a field for the user to type th
 To send the answer the Authorization header is built like this.
 
 ```
-X-Login-Reply id base64(response)
+Authorization: X-Login-Reply base64(response)
+X-Conversation: conversation
 ```
 
-Where id is the same id that was received with the WWW-Authenticate challenge header.
+Where conversation is the same conversation that was received with the WWW-Authenticate response.
 
 This can continue until either a success or an error response is received.

--- a/src/ws/cockpitauth.h
+++ b/src/ws/cockpitauth.h
@@ -39,10 +39,6 @@ G_BEGIN_DECLS
 #define COCKPIT_AUTH_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), COCKPIT_TYPE_AUTH, CockpitAuthClass))
 #define COCKPIT_IS_AUTH_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), COCKPIT_TYPE_AUTH))
 
-typedef enum {
-    COCKPIT_AUTH_COOKIE_INSECURE = 1 << 1
-} CockpitAuthFlags;
-
 typedef struct _CockpitAuth        CockpitAuth;
 typedef struct _CockpitAuthClass   CockpitAuthClass;
 
@@ -92,14 +88,12 @@ gchar *         cockpit_auth_nonce           (CockpitAuth *self);
 void            cockpit_auth_login_async     (CockpitAuth *self,
                                               const gchar *path,
                                               GHashTable *headers,
-                                              const gchar *conversation,
-                                              const gchar *remote_peer,
+                                              GIOStream *connection,
                                               GAsyncReadyCallback callback,
                                               gpointer user_data);
 
 JsonObject *    cockpit_auth_login_finish    (CockpitAuth *self,
                                               GAsyncResult *result,
-                                              CockpitAuthFlags flags,
                                               GHashTable *out_headers,
                                               GError **error);
 
@@ -109,7 +103,7 @@ CockpitWebService *  cockpit_auth_check_cookie    (CockpitAuth *self,
 
 gchar *         cockpit_auth_parse_application    (const gchar *path);
 
-GBytes *        cockpit_auth_parse_authorization      (GHashTable *headers,
+GBytes *        cockpit_auth_steal_authorization      (GHashTable *headers,
                                                        gboolean base64_decode);
 
 gchar *        cockpit_auth_parse_authorization_type  (GHashTable *headers);

--- a/src/ws/cockpitauth.h
+++ b/src/ws/cockpitauth.h
@@ -70,6 +70,7 @@ struct _CockpitAuthClass
   void           (* login_async)         (CockpitAuth *auth,
                                           const gchar *path,
                                           GHashTable *headers,
+                                          const gchar *conversation,
                                           const gchar *remote_peer,
                                           GAsyncReadyCallback callback,
                                           gpointer user_data);
@@ -91,6 +92,7 @@ gchar *         cockpit_auth_nonce           (CockpitAuth *self);
 void            cockpit_auth_login_async     (CockpitAuth *self,
                                               const gchar *path,
                                               GHashTable *headers,
+                                              const gchar *conversation,
                                               const gchar *remote_peer,
                                               GAsyncReadyCallback callback,
                                               gpointer user_data);

--- a/src/ws/cockpitauthprocess.c
+++ b/src/ws/cockpitauthprocess.c
@@ -718,6 +718,7 @@ cockpit_auth_process_write_auth_bytes (CockpitAuthProcess *self,
 gboolean
 cockpit_auth_process_start (CockpitAuthProcess *self,
                             const gchar** command_args,
+                            const gchar** environment,
                             gint agent_fd,
                             gboolean should_respond,
                             GError **error)

--- a/src/ws/cockpitauthprocess.c
+++ b/src/ws/cockpitauthprocess.c
@@ -71,7 +71,7 @@ struct  _CockpitAuthProcess {
   gboolean closed;
   gboolean pipe_closed;
 
-  gchar *id;
+  gchar *conversation;
   gchar *logname;
   gchar *name;
 
@@ -97,7 +97,7 @@ enum
   PROP_IDLE_TIMEOUT,
   PROP_PIPE_TIMEOUT,
   PROP_PROCESS_AUTH_FD,
-  PROP_ID,
+  PROP_CONVERSATION,
   PROP_LOGNAME,
   PROP_NAME,
 };
@@ -168,7 +168,7 @@ cockpit_auth_process_finalize (GObject *object)
     close (self->child_data.auth_fd);
   self->child_data.auth_fd = -1;
 
-  g_free (self->id);
+  g_free (self->conversation);
   g_free (self->logname);
   g_free (self->name);
   G_OBJECT_CLASS (cockpit_auth_process_parent_class)->finalize (object);
@@ -378,7 +378,7 @@ cockpit_auth_process_init (CockpitAuthProcess *self)
   self->max_idle = default_timeout;
   self->max_wait_pipe = default_timeout;
   self->send_signal = FALSE;
-  self->id = NULL;
+  self->conversation = NULL;
 }
 
 static void
@@ -446,8 +446,8 @@ cockpit_auth_process_set_property (GObject *object,
   case PROP_PROCESS_AUTH_FD:
     self->child_data.wanted_fd_number = g_value_get_uint (value);
     break;
-  case PROP_ID:
-    self->id = g_value_dup_string (value);
+  case PROP_CONVERSATION:
+    self->conversation = g_value_dup_string (value);
     break;
   case PROP_LOGNAME:
     self->logname = g_value_dup_string (value);
@@ -503,8 +503,8 @@ cockpit_auth_process_class_init (CockpitAuthProcessClass *klass)
                                                       G_PARAM_CONSTRUCT_ONLY |
                                                       G_PARAM_STATIC_STRINGS));
 
-  g_object_class_install_property (gobject_class, PROP_ID,
-                                   g_param_spec_string ("id",
+  g_object_class_install_property (gobject_class, PROP_CONVERSATION,
+                                   g_param_spec_string ("conversation",
                                                         NULL,
                                                         NULL,
                                                         NULL,
@@ -689,10 +689,10 @@ cockpit_auth_process_get_authenticated_user (CockpitAuthProcess *self,
 }
 
 const gchar *
-cockpit_auth_process_get_id (CockpitAuthProcess *self)
+cockpit_auth_process_get_conversation (CockpitAuthProcess *self)
 {
   g_return_val_if_fail (self != NULL, NULL);
-  return self->id;
+  return self->conversation;
 }
 
 /* ----------------------------------------------------------------------------

--- a/src/ws/cockpitauthprocess.h
+++ b/src/ws/cockpitauthprocess.h
@@ -36,8 +36,6 @@ typedef struct      _CockpitAuthProcessClass        CockpitAuthProcessClass;
 
 GType              cockpit_auth_process_get_type    (void) G_GNUC_CONST;
 
-const gchar *      cockpit_auth_process_get_id      (CockpitAuthProcess *self);
-
 gboolean           cockpit_auth_process_start       (CockpitAuthProcess *self,
                                                      const gchar** command_args,
                                                      gint agent_fd,
@@ -46,6 +44,7 @@ gboolean           cockpit_auth_process_start       (CockpitAuthProcess *self,
 
 void               cockpit_auth_process_terminate   (CockpitAuthProcess *self);
 
+const gchar *      cockpit_auth_process_get_conversation        (CockpitAuthProcess *self);
 
 CockpitPipe *      cockpit_auth_process_claim_as_pipe           (CockpitAuthProcess *self);
 

--- a/src/ws/cockpitauthprocess.h
+++ b/src/ws/cockpitauthprocess.h
@@ -37,7 +37,8 @@ typedef struct      _CockpitAuthProcessClass        CockpitAuthProcessClass;
 GType              cockpit_auth_process_get_type    (void) G_GNUC_CONST;
 
 gboolean           cockpit_auth_process_start       (CockpitAuthProcess *self,
-                                                     const gchar** command_args,
+                                                     const gchar** argv,
+                                                     const gchar** env,
                                                      gint agent_fd,
                                                      gboolean should_respond,
                                                      GError **error);

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -399,6 +399,7 @@ on_login_complete (GObject *object,
   CockpitAuthFlags flags = 0;
   GHashTable *headers;
   GIOStream *io_stream;
+  const gchar *conversation;
   GBytes *content;
 
   io_stream = cockpit_web_response_get_stream (response);
@@ -407,6 +408,11 @@ on_login_complete (GObject *object,
 
   headers = cockpit_web_server_new_table ();
   response_data = cockpit_auth_login_finish (COCKPIT_AUTH (object), result, flags, headers, &error);
+
+  /* Make a keep-alive connection work as our conversation medium */
+  conversation = g_object_get_data (G_OBJECT (io_stream), "conversation");
+  g_assert (conversation != NULL);
+  g_hash_table_insert (headers, g_strdup ("X-Conversation"), g_strdup (conversation));
 
   if (error)
     {
@@ -449,6 +455,9 @@ handle_login (CockpitHandlerData *data,
   GIOStream *io_stream;
   CockpitCreds *creds;
   JsonObject *creds_json = NULL;
+  const gchar *conversation;
+  const gchar *stored;
+  gchar *value;
 
   if (service)
     {
@@ -457,18 +466,35 @@ handle_login (CockpitHandlerData *data,
       creds_json = cockpit_creds_to_json (creds);
       send_login_response (response, creds_json, out_headers);
       g_hash_table_unref (out_headers);
-    }
-  else
-    {
-      io_stream = cockpit_web_response_get_stream (response);
-      remote_peer = get_remote_address (io_stream);
-      cockpit_auth_login_async (data->auth, path, headers, remote_peer,
-                                on_login_complete, g_object_ref (response));
-      g_free (remote_peer);
+      json_object_unref (creds_json);
+      return;
     }
 
-  if (creds_json)
-    json_object_unref (creds_json);
+  io_stream = cockpit_web_response_get_stream (response);
+
+  /*
+   * Figure out the conversation we're going to use for this login
+   * Note we respect both a X-Conversation header, and as a fallback
+   * the keep-alive connection. This allows for Negotiate authentication
+   * connection based conversations.
+   */
+  conversation = g_hash_table_lookup (headers, "X-Conversation");
+
+  /* Store the conversation appropriately on the connection stream itself */
+  stored = g_object_get_data (G_OBJECT (io_stream), "conversation");
+  if (!conversation || g_strcmp0 (conversation, stored) != 0)
+    {
+      if (conversation)
+        value = g_strdup (conversation);
+      else
+        conversation = value = cockpit_auth_nonce (data->auth);
+      g_object_set_data_full (G_OBJECT (io_stream), "conversation", value, g_free);
+    }
+
+  remote_peer = get_remote_address (io_stream);
+  cockpit_auth_login_async (data->auth, path, headers, conversation, remote_peer,
+                            on_login_complete, g_object_ref (response));
+  g_free (remote_peer);
 }
 
 static void

--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -254,10 +254,12 @@
                             challenge = xhr.getResponseHeader("WWW-Authenticate")
                             if (challenge && challenge.substring(0, 14) === 'X-Login-Reply ') {
                                 prompt_data = get_prompt_from_challenge(challenge, xhr.responseText);
-                                if (prompt_data)
+                                if (prompt_data) {
+                                    prompt_data.conversation = xhr.getResponseHeader("X-Conversation");
                                     show_converse(prompt_data);
-                                else
+                                } else {
                                     fatal(xhr.statusText);
+                                }
                             } else {
                                 fatal(xhr.statusText);
                             }
@@ -385,7 +387,7 @@
                     id("conversation-input").removeEventListener("keydown", key_down);
                     id("login-button").removeEventListener("click", call_converse);
                     login_failure(null, true);
-                    converse(prompt_data.id, id("conversation-input").value);
+                    converse(prompt_data.conversation, id("conversation-input").value);
                 }
 
                 function key_down(e) {
@@ -409,19 +411,17 @@
                 var parts;
                 var prompt;
                 var resp;
-                var id;
                 var prompt;
 
                 if (!header)
                     return;
 
                 parts = header.split(' ');
-                if (parts[0].toLowerCase() !== 'X-Login-Reply' && parts.length != 3)
+                if (parts[0].toLowerCase() !== 'X-Login-Reply' && parts.length != 2)
                     return;
 
-                id = parts[1];
                 try {
-                    prompt = atob (parts[2]);
+                    prompt = atob (parts[1]);
                 } catch (err) {
                     if (window.console)
                         console.error("Invalid prompt data", err);
@@ -436,7 +436,6 @@
                     resp = {};
                 }
 
-                resp.id = id;
                 resp.prompt = prompt;
                 return resp;
             }
@@ -463,10 +462,12 @@
                         challenge = xhr.getResponseHeader("WWW-Authenticate")
                         if (challenge && challenge.substring(0, 14) === 'X-Login-Reply ') {
                             prompt_data = get_prompt_from_challenge(challenge, xhr.responseText);
-                            if (prompt_data)
+                            if (prompt_data) {
+                                prompt_data.conversation = xhr.getResponseHeader("X-Conversation");
                                 show_converse(prompt_data);
-                            else
+                            } else {
                                 fatal("Internal Error: Invalid challenge header");
+                            }
                         } else {
                             if (window.console)
                                 console.log(xhr.statusText);
@@ -502,9 +503,10 @@
                 send_login_request("GET", headers, false);
             }
 
-            function converse(id, msg) {
+            function converse(conversation, msg) {
                 var headers = {
-                    "Authorization": "X-Login-Reply " + id + " " + btoa(utf8(msg))
+                    "Authorization": "X-Login-Reply " + btoa(utf8(msg)),
+                    "X-Conversation": conversation,
                 };
                 send_login_request("GET", headers, true);
             }

--- a/src/ws/mock-auth.c
+++ b/src/ws/mock-auth.c
@@ -63,6 +63,7 @@ static void
 mock_auth_login_async (CockpitAuth *auth,
                        const gchar *path,
                        GHashTable *headers,
+                       const gchar *conversation,
                        const gchar *remote_peer,
                        GAsyncReadyCallback callback,
                        gpointer user_data)

--- a/src/ws/mock-auth.c
+++ b/src/ws/mock-auth.c
@@ -80,8 +80,7 @@ mock_auth_login_async (CockpitAuth *auth,
   g_object_set_data_full (G_OBJECT (result), "remote", g_strdup (remote_peer), g_free);
   g_object_set_data_full (G_OBJECT (result), "application", cockpit_auth_parse_application (path), g_free);
 
-  type = cockpit_auth_parse_authorization_type (headers);
-  userpass = cockpit_auth_parse_authorization (headers, TRUE);
+  type = cockpit_auth_steal_authorization (headers, &userpass, TRUE);
   if (userpass && g_str_equal (type, "basic"))
     {
       split = g_strsplit (g_bytes_get_data (userpass, NULL), ":", 2);

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -193,7 +193,7 @@ test_login_with_cookie (Test *test,
   user = g_get_user_name ();
   headers = mock_auth_basic_header (user, PASSWORD);
 
-  cockpit_auth_login_async (test->auth, path, headers, NULL, on_ready_get_result, &result);
+  cockpit_auth_login_async (test->auth, path, headers, "test", NULL, on_ready_get_result, &result);
   g_hash_table_unref (headers);
   while (result == NULL)
     g_main_context_iteration (NULL, TRUE);
@@ -410,7 +410,7 @@ setup_default (Test *test,
       user = g_get_user_name ();
       headers = mock_auth_basic_header (user, PASSWORD);
 
-      cockpit_auth_login_async (test->auth, fixture->auth, headers, NULL, on_ready_get_result, &result);
+      cockpit_auth_login_async (test->auth, fixture->auth, headers, "test", NULL, on_ready_get_result, &result);
       g_hash_table_unref (headers);
       while (result == NULL)
         g_main_context_iteration (NULL, TRUE);

--- a/src/ws/test-kerberos.c
+++ b/src/ws/test-kerberos.c
@@ -328,7 +328,7 @@ test_authenticate (TestCase *test,
   build_authorization_header (in_headers, &output);
   gss_release_buffer (&minor, &output);
 
-  cockpit_auth_login_async (test->auth, "/cockpit+test", in_headers, NULL, on_ready_get_result, &result);
+  cockpit_auth_login_async (test->auth, "/cockpit+test", in_headers, "test", NULL, on_ready_get_result, &result);
   g_hash_table_unref (in_headers);
 
   while (result == NULL)


### PR DESCRIPTION
Refactoring of CockpitAuth with some goals:

 * Differences between launching cockpit-session and cockpit-ssh should be minimal and configurable.
 * Consistent arguments to cockpit-ssh and cockpit-session and other auth processes: just the target ```[user@]host```. Commands can accept other options or arguments, but these are not passed by CockpitAuth.
 * Pass certain information such as ```RHOST``` via an environment variable.
 * Pass in the entire Authorization header to auth process, optionally normalizing, optional base64 decoding.