### PR TITLE
test: Only enable epel if we want to use mock

### DIFF
--- a/test/images/scripts/rhel-7.setup
+++ b/test/images/scripts/rhel-7.setup
@@ -147,6 +147,8 @@ if [ -n "$TEST_SOURCE" ]; then
     su builder -c "/usr/bin/mock --verbose --installdeps $srpm"
 fi
 
+yum clean all
+
 if [ ! -f "$SKIP_REPO_FLAG" ]; then
     subscription-manager unregister
 fi
@@ -180,7 +182,6 @@ if type "docker" >/dev/null 2>&1; then
     /var/lib/testvm/docker-images.setup
 fi
 
-yum clean all
 /var/lib/testvm/zero-disk.setup --keep-mock-cache
 
 # HACK - kdump.service interferes with our storage tests, by loading

--- a/test/images/scripts/rhel-7.setup
+++ b/test/images/scripts/rhel-7.setup
@@ -147,7 +147,7 @@ if [ -n "$TEST_SOURCE" ]; then
     su builder -c "/usr/bin/mock --verbose --installdeps $srpm"
 fi
 
-yum clean all
+yum clean all || true
 
 if [ ! -f "$SKIP_REPO_FLAG" ]; then
     subscription-manager unregister

--- a/test/images/scripts/rhel-7.setup
+++ b/test/images/scripts/rhel-7.setup
@@ -115,17 +115,6 @@ qemu-system-x86 \
 qemu-kvm \
 "
 
-# enable epel for mock and avocado
-if [ ! -f "$SKIP_REPO_FLAG" ]; then
-    mkdir /tmp/dep
-    cd /tmp/dep
-    yum -y install wget
-    wget -T 15 -t 4 http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    rpm -Uvh epel-release-*.rpm
-    cd
-    rm -rf /tmp/dep
-fi
-
 yum install --nogpgcheck -y $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
 
 # For debugging storaged crashes
@@ -135,7 +124,24 @@ debuginfo-install -y storaged storaged-lvm2 storaged-iscsi
 
 # only install mock and build if TEST_SOURCE is set
 if [ -n "$TEST_SOURCE" ]; then
-    yum -y install mock rpm-build
+    yum -y install rpm-build
+
+    # enable epel for mock
+    if [ ! -f "$SKIP_REPO_FLAG" ]; then
+        mkdir /tmp/dep
+        cd /tmp/dep
+        yum -y install wget
+        wget -T 15 -t 4 http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+        yum -y remove wget
+        rpm -Uvh epel-release-*.rpm
+        cd
+        rm -rf /tmp/dep
+    fi
+    yum -y install mock
+
+    # disable epel again
+    yum-config-manager --disable 'epel*'
+
     useradd -c Builder -G mock builder
     srpm=$(/var/lib/testvm/make-srpm $TEST_SOURCE)
     su builder -c "/usr/bin/mock --verbose --installdeps $srpm"


### PR DESCRIPTION
This doesn't require building a new image since enabling the epel repository was done last in any case and our test runners currently don't use the `SKIP_REPO_FLAG`.