### PR TITLE
Fix failure of 'webpack --watch' with extracted chunks

### DIFF
--- a/pkg/docker/containers.js
+++ b/pkg/docker/containers.js
@@ -32,6 +32,10 @@
     var image_details = require("./image");
     var storage = require("./storage.jsx");
 
+    require("page.css");
+    require("table.css");
+    require("./docker.css");
+
     var _ = cockpit.gettext;
     var C_ = cockpit.gettext;
 

--- a/pkg/docker/details.js
+++ b/pkg/docker/details.js
@@ -29,6 +29,7 @@
     var docker = require("./docker");
     var util = require("./util");
 
+    require("console.css");
 
     var _ = cockpit.gettext;
     var C_ = cockpit.gettext;

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -1,9 +1,3 @@
-@import "/page.css";
-
-@import "/console.css";
-@import "/plot.css";
-@import "/table.css";
-
 /* For table rows containing interactive controls like bars */
 .info-table-ct tr.interactive td {
     line-height: 26px;

--- a/pkg/docker/overview.js
+++ b/pkg/docker/overview.js
@@ -33,6 +33,8 @@
     var bar = require("./bar");
     var view = require("./containers-view.jsx");
 
+    require("plot.css");
+
     var _ = cockpit.gettext;
     var C_ = cockpit.gettext;
 

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -27,6 +27,12 @@ var journal = require('journal');
 /* jQuery extensions */
 require('patterns');
 
+require("page.css");
+require("table.css");
+require("plot.css");
+require("journal.css");
+require("./networking.css");
+
 var _ = cockpit.gettext;
 var C_ = cockpit.gettext;
 

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -1,8 +1,3 @@
-@import url("/page.css");
-@import url("/table.css");
-@import url("/plot.css");
-@import url("/journal.css");
-
 .ipv4-address {
   display: inline;
 }

--- a/pkg/storaged/devices.js
+++ b/pkg/storaged/devices.js
@@ -29,6 +29,12 @@
     var details = require("./details");
     var utils = require("./utils");
 
+    require("page.css");
+    require("table.css");
+    require("plot.css");
+    require("journal.css");
+    require("./storage.css");
+
     var _ = cockpit.gettext;
     var C_ = cockpit.gettext;
 

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -17,11 +17,6 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-@import url("/page.css");
-@import url("/table.css");
-@import url("/plot.css");
-@import url("/journal.css");
-
 #storage {
     padding-left: 5px;
     padding-right: 5px;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,8 +9,7 @@ var info = {
         ],
 
         "docker/docker": [
-            "docker/containers.js",
-            "docker/docker.css",
+            "docker/containers.js"
         ],
         "docker/console": [
             "docker/console.js",
@@ -31,8 +30,7 @@ var info = {
         ],
 
         "networkmanager/network": [
-            "networkmanager/interfaces.js",
-            "networkmanager/networking.css",
+            "networkmanager/interfaces.js"
         ],
 
         "ostree/ostree": [
@@ -88,8 +86,7 @@ var info = {
         ],
 
         "storaged/storage": [
-            "storaged/devices.js",
-            "storaged/storage.css",
+            "storaged/devices.js"
         ],
 
         "subscriptions/subscriptions": [


### PR DESCRIPTION
This should fix the strange failure of 'webpack --watch' with
the following message related to CSS files:

``` Order in extracted chunk undefined```

There are upstream pull requests in webpack which work to fix
this, but for now we just work around the issue.

https://github.com/webpack/extract-text-webpack-plugin/issues/166