### PR TITLE
tools: When building in make-source be more verbose

### DIFF
--- a/tools/make-source
+++ b/tools/make-source
@@ -42,6 +42,6 @@ else
     builddir=.
 fi
 
-make -j8 -C $builddir --silent dist-gzip distdir=cockpit-wip 1>&2
+make -j8 -C $builddir --silent V=1 dist-gzip distdir=cockpit-wip 1>&2
 directory=$(make -C $builddir --silent print-abs_builddir)
 echo $directory/cockpit-wip.tar.gz


### PR DESCRIPTION
Show the actual commands being executed when make-source needs
to build something in order to build a tarball. This is part
of the verify machines workflow, and we want it to be pretty
visible.

I'm having trouble diagnosing a build failure for #5284 due to this.