### PR TITLE
networkmanager: Fix regression re activation of virtual interfaces

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2144,8 +2144,8 @@ PageNetworkInterface.prototype = {
                 modify,
                 cockpit.format(_("Deleting <b>$0</b> will break the connection to the server, " +
                                  "and will make the administration UI unavailable."),
-                               self.iface.Name),
-                cockpit.format(_("Delete $0"), self.iface.Name));
+                               self.dev_name),
+                cockpit.format(_("Delete $0"), self.dev_name));
         }
     },
 
@@ -2176,8 +2176,8 @@ PageNetworkInterface.prototype = {
             modify,
             cockpit.format(_("Switching on <b>$0</b>  will break the connection to the server, " +
                              "and will make the administration UI unavailable."),
-                           self.dev.Interface),
-            cockpit.format(_("Switch on $0"), self.dev.Interface));
+                           self.dev_name),
+            cockpit.format(_("Switch on $0"), self.dev_name));
     },
 
     disconnect: function() {
@@ -2201,8 +2201,8 @@ PageNetworkInterface.prototype = {
             modify,
             cockpit.format(_("Switching off <b>$0</b>  will break the connection to the server, " +
                              "and will make the administration UI unavailable."),
-                           self.dev.Interface),
-            cockpit.format(_("Switch off $0"), self.dev.Interface));
+                           self.dev_name),
+            cockpit.format(_("Switch off $0"), self.dev_name));
     },
 
     update: function() {

--- a/test/verify/check-networking
+++ b/test/verify/check-networking
@@ -371,6 +371,36 @@ class TestNetworking(MachineCase):
         b.wait_visible("#networking")
         b.wait_not_present("#networking-interfaces tr[data-interface='tbridge']")
 
+    def testVlan(self):
+        b = self.browser
+        m = self.machine
+
+        iface = self.get_iface(m, m.macaddr)
+
+        self.login_and_go("/network")
+        self.wait_for_iface(iface)
+
+        # Make a VLAN interface
+        b.click("button:contains('Add VLAN')")
+        b.wait_popup("network-vlan-settings-dialog")
+        b.set_val("#network-vlan-settings-dialog tr:contains('Name') input", "tvlan")
+        b.set_val("#network-vlan-settings-dialog tr:contains('VLAN Id') input", "123")
+        b.click("#network-vlan-settings-dialog button:contains('Apply')")
+        b.wait_popdown("network-vlan-settings-dialog")
+        b.wait_present("#networking-interfaces tr[data-interface='tvlan']")
+
+        # Activate it.  It wont get an IP address, but that's okay.
+        b.click("#networking-interfaces tr[data-interface='tvlan'] td:first-child")
+        b.wait_visible("#network-interface")
+        b.wait_in_text("tr:contains('Status')", "Inactive")
+        b.click(".panel-heading .btn:contains('On')")
+        b.wait_not_in_text("tr:contains('Status')", "Inactive")
+
+        # Delete it
+        b.click("#network-interface button:contains('Delete')")
+        b.wait_visible("#networking")
+        b.wait_not_present("#networking-interfaces tr[data-interface='tvlan']")
+
     def testOther(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Commit 29d0ca0e "networkmanager: Checkpoints" broke this by not taking
into account that `self.dev` is null for inactivate virtual interfaces
such as bridges, bonds, and vlans.

See https://bugzilla.redhat.com/show_bug.cgi?id=1390605 but this might
not be the complete fix for it.