### PR TITLE
networkmanager: Use default flags for new VLAN devices

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -748,6 +748,8 @@ function NetworkManagerModel() {
             set("vlan", "parent",         's', settings.vlan.parent);
             set("vlan", "id",             'u', settings.vlan.id);
             set("vlan", "interface-name", 's', settings.vlan.interface_name);
+            // '1' is the default, but we need to set it explicitly anyway.
+            set("vlan", "flags",          'u', 1);
         }
 
         if (settings.ethernet) {

--- a/test/verify/check-networking
+++ b/test/verify/check-networking
@@ -396,6 +396,11 @@ class TestNetworking(MachineCase):
         b.click(".panel-heading .btn:contains('On')")
         b.wait_not_in_text("tr:contains('Status')", "Inactive")
 
+        # Check that the actual kernel device has the REORDER_HDR flag
+        # set.  NetworkManager stopped doing that for connections
+        # created via D-Bus at some point.
+        self.assertIn("REORDER_HDR", m.execute("ip -d link show tvlan | grep vlan"))
+
         # Delete it
         b.click("#network-interface button:contains('Delete')")
         b.wait_visible("#networking")


### PR DESCRIPTION
The default in the D-Bus API is not the real default, see

https://developer.gnome.org/NetworkManager/unstable/nm-settings.html#id-1.2.6.4.26

Setting the REORDER_HEADERS flag seems to be important in practice, see

https://bugzilla.redhat.com/show_bug.cgi?id=1390605