### PR TITLE
tools: The LANG language and locale affect tarball creation

### DIFF
--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -75,6 +75,6 @@ CLEANFILES += \
 doc/guide/html: $(GUIDE_DOCBOOK) $(GUIDE_INCLUDES) $(man_MANS) $(GUIDE_STATIC) $(GUIDE_XSLT)
 	$(AM_V_GEN) mkdir -p doc/guide/html/ && rm -rf doc/guide/html/* && \
 		cp --dereference $(srcdir)/doc/guide/static/* doc/guide/html/ && \
-		$(XMLTO) html -m $(srcdir)/doc/guide/gtk-doc.xsl -o doc/guide/html/ \
+		LANG=en_US.UTF-8 $(XMLTO) html -m $(srcdir)/doc/guide/gtk-doc.xsl -o doc/guide/html/ \
 			--searchpath $(abs_builddir):$(abs_srcdir):$(abs_builddir)/doc/guide \
 			$(srcdir)/$(GUIDE_DOCBOOK)

--- a/tools/build-copying
+++ b/tools/build-copying
@@ -4,7 +4,7 @@ set -euf
 
 found=""
 cat $1/README
-find $1 -name 'COPYING' -o -name '*LICENSE*' -print | sort | while read filename; do
+find $1 -name 'COPYING' -o -name '*LICENSE*' -print | LC_ALL=C sort | while read filename; do
     directory=$(dirname $filename)
     name=$(basename $directory)
 


### PR DESCRIPTION
Varying these make the generated files far less predictable than
they should be, including order of text, and HTML encoding.

Resulting patches between tarballs become far too large.