### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-736a84151b482daa2b2cd0d756554856fecccfde.qcow2
+debian-unstable-e20afebbfad06c2ba3d4573c71ec6ece14ead4a6.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-11-04/