### PR TITLE
test: Ignore 'Journal file truncated' journal message

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -587,6 +587,9 @@ class MachineCase(unittest.TestCase):
         # HACK: https://github.com/systemd/systemd/pull/1758
         'Error was encountered while opening journal files:.*',
         'Failed to get data: Cannot assign requested address',
+
+        # Various operating systems see this from time to time
+        "Journal file.*truncated, ignoring file.",
     ]
 
     def allow_journal_messages(self, *patterns):


### PR DESCRIPTION
This particularly happens on user journal files.