### PR TITLE
storaged: Wait for mdraid to be valid before calling Delete()

### DIFF
--- a/pkg/storaged/details.js
+++ b/pkg/storaged/details.js
@@ -603,10 +603,12 @@
                                   Title: _("Delete"),
                                   Danger: _("Deleting a RAID device will erase all data on it."),
                                   action: function (vals) {
-                                      return client.mdraids[path].Delete({ 'tear-down': { t: 'b', v: true } }).
-                                          done(function () {
-                                              location.go('/');
-                                          });
+                                      return mdraid.wait().then(function() {
+                                          return mdraid.Delete({ 'tear-down': { t: 'b', v: true } }).
+                                              done(function () {
+                                                  location.go('/');
+                                              });
+                                      });
                                   }
                               }
                             });


### PR DESCRIPTION
We've seen this race during the tests:

undefined is not a function (evaluating 'e.mdraids[t].Delete({"tear-down":{t:"b",v:!0}})')

Marking priority because this is a testing failure.