### PR TITLE
doc: Make all the sections have predictable ids

### DIFF
--- a/doc/guide/api-base1.xml
+++ b/doc/guide/api-base1.xml
@@ -54,7 +54,7 @@
       <refpurpose>Patternfly standard style sheets</refpurpose>
     </refnamediv>
 
-    <refsection>
+    <refsection id="api-base1-patternfly-description">
       <title>Description</title>
 
 <programlisting>
@@ -77,7 +77,7 @@
       <refpurpose>jQuery library</refpurpose>
     </refnamediv>
 
-    <refsection>
+    <refsection id="api-base1-jquery-description">
       <title>Description</title>
 <programlisting>
 &lt;script src="../base1/jquery.js"&gt;&lt;/script&gt;
@@ -109,7 +109,7 @@
       <refpurpose>Require JS javascript loader</refpurpose>
     </refnamediv>
 
-    <refsection>
+    <refsection id="api-base1-require-description">
       <title>Description</title>
 
 <programlisting>

--- a/doc/guide/api-cockpit.xml
+++ b/doc/guide/api-cockpit.xml
@@ -11,7 +11,7 @@
     <refpurpose>Basic cockpit API to interact with the system</refpurpose>
   </refnamediv>
 
-  <refsection>
+  <refsection id="api-cockpit-loading">
     <title>Loading cockpit.js</title>
     <para><code>cockpit.js</code> should be loaded via a script tag.</para>
 

--- a/doc/guide/api-container.xml
+++ b/doc/guide/api-container.xml
@@ -21,7 +21,7 @@
       <refpurpose>Container console component</refpurpose>
     </refnamediv>
 
-    <refsection>
+    <refsection id="api-console-html-description">
       <title>Description</title>
 <programlisting>
 &lt;iframe src="http://server:9090/cockpit/@localhost/docker/console.html"

--- a/doc/guide/api-shell.xml
+++ b/doc/guide/api-shell.xml
@@ -21,7 +21,7 @@
       <refpurpose>Main cockpit shell, for a single machine</refpurpose>
     </refnamediv>
 
-    <refsection>
+    <refsection id="api-shell-html-description">
       <title>Description</title>
 <programlisting>
 &lt;iframe src="http://127.0.0.1:9090/cockpit+app/@localhost/shell/index.html"

--- a/doc/guide/api-system.xml
+++ b/doc/guide/api-system.xml
@@ -21,7 +21,7 @@
       <refpurpose>System log component</refpurpose>
     </refnamediv>
 
-    <refsection>
+    <refsection id="api-logs-html-description">
       <title>Description</title>
 <programlisting>
 &lt;iframe src="http://127.0.0.1:9090/cockpit+app/@localhost/system/logs.html"
@@ -95,7 +95,7 @@
       <refpurpose>Server terminal component</refpurpose>
     </refnamediv>
 
-    <refsection>
+    <refsection id="api-terminal-html-description">
       <title>Description</title>
 <programlisting>
 &lt;iframe src="http://127.0.0.1:9090/cockpit+app/@localhost/system/terminal.html"

--- a/doc/guide/cockpit-cache.xml
+++ b/doc/guide/cockpit-cache.xml
@@ -14,7 +14,7 @@
     other objects.</para>
 </refsynopsisdiv>
 
-  <refsection>
+  <refsection id="cockpit-cache-func">
     <title>cockpit.cache()</title>
 <programlisting>
 cache = cockpit.cache(key, provider, consumer)
@@ -57,7 +57,7 @@ function consumer(value, key) {
 
   </refsection>
 
-  <refsection>
+  <refsection id="cockpit-cache-close">
     <title>cache.close()</title>
 <programlisting>
 cache.close()

--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -11,7 +11,7 @@
     <para>Cockpit allows access to DBus services via this API.</para>
   </refsynopsisdiv>
 
-  <refsection>
+  <refsection id="cockpit-dbus-types">
     <title>DBus Types</title>
     <para>DBus values are represented as javascript values and objects as follows:</para>
 

--- a/doc/guide/cockpit-file.xml
+++ b/doc/guide/cockpit-file.xml
@@ -35,7 +35,7 @@ file.close()
 </programlisting>
   </refsynopsisdiv>
 
-  <refsection>
+  <refsection id="cockpit-file-simple">
     <title>Simple reading and writing</title>
 
     <para>You can read a file with code like this:</para>
@@ -93,7 +93,7 @@ cockpit.file("/path/to/file").replace("my new content\n")
       transactional updates to a file.</para>
   </refsection>
 
-  <refsection>
+  <refsection id="cockpit-file-format">
     <title>File format</title>
     <para>By default, a file is assumed to be text encoded in UTF-8, and the
       <code>read()</code> and <code>replace()</code> functions use strings to
@@ -124,7 +124,7 @@ cockpit.file("/path/to/file", { syntax: syntax_object })
       functions.</para>
   </refsection>
 
-  <refsection>
+  <refsection id="cockpit-file-binary">
     <title>Binary files</title>
     <para>By default the content of the file is assumed to be text encoded as
       UTF-8 and it can not contain zero bytes.  The content is represented
@@ -135,7 +135,7 @@ cockpit.file("/path/to/file", { syntax: syntax_object })
       JavaScript.</para>
   </refsection>
 
-  <refsection>
+  <refsection id="cockpit-file-atomic">
     <title>Atomic modifications</title>
     <para>Use <code>modify()</code> to modify the content of the file safely.  A
       call to <code>modify()</code> will read the content of the file, call
@@ -180,7 +180,7 @@ cockpit.file("/path/to/file").modify(shout)
       given values.</para>
   </refsection>
 
-  <refsection>
+  <refsection id="cockpit-file-notify">
     <title>Change notifications</title>
     <para>Calling <code>watch()</code> will start monitoring the file for
       external changes.
@@ -200,13 +200,13 @@ handle = file.watch(callback);
     <para>To free the resources used for monitoring, call <code>handle.remove()</code>.</para>
   </refsection>
 
-  <refsection>
+  <refsection id="cockpit-file-path">
     <title>file.path</title>
     <para>A string containing the path that was passed to the <code>cockpit.file()</code>
       method.</para>
   </refsection>
 
-  <refsection>
+  <refsection id="cockpit-file-close">
     <title>Closing</title>
     <para>Call the <code>close()</code> method on a file proxy to cancel all
       ongoing operations, such as reading, writing, and monitoring. The

--- a/doc/guide/cockpit-location.xml
+++ b/doc/guide/cockpit-location.xml
@@ -7,7 +7,7 @@
     <refpurpose>Page location and navigation between components</refpurpose>
   </refnamediv>
 
-  <refsection>
+  <refsection id="cockpit-location-general">
     <title>Page location</title>
 
 <programlisting>

--- a/doc/guide/cockpit-manifest.xml
+++ b/doc/guide/cockpit-manifest.xml
@@ -7,7 +7,7 @@
     <refpurpose>Manifest info</refpurpose>
   </refnamediv>
 
-  <refsection>
+  <refsection id="cockpit-manifest-loading">
     <title>Loading Manifests</title>
     <para>You can load manifest info by loading the <code>./manifest.json</code> file in
       your package. In addition there is a shortcut, by loading the <code>../manifests.json</code>

--- a/doc/guide/cockpit-metrics.xml
+++ b/doc/guide/cockpit-metrics.xml
@@ -15,7 +15,7 @@
       <link linkend="cockpit-grid"><code>cockpit.grid()</code></link> facilities.</para>
   </refsynopsisdiv>
 
-  <refsection>
+  <refsection id="cockpit-metrics-function">
     <title>cockpit.metrics()</title>
 <programlisting>
 metrics = cockpit.metrics(interval, options, cache)

--- a/doc/guide/cockpit-util.xml
+++ b/doc/guide/cockpit-util.xml
@@ -60,7 +60,7 @@ string = cockpit.format_number(number)
       will be returned.</para>
   </refsection>
 
-  <refsection>
+  <refsection id="cockpit-format-bytes-per-sec">
     <title>cockpit.format_bytes_per_sec()</title>
 <programlisting>
  string = cockpit.format_bytes_per_sec(number, [factor])
@@ -81,7 +81,7 @@ string = cockpit.format_number(number)
       will be returned.</para>
   </refsection>
 
-  <refsection>
+  <refsection id="cockpit-format-bits-per-sec">
     <title>cockpit.format_bits_per_sec()</title>
 <programlisting>
   string = cockpit.format_bits_per_sec(number, [factor])

--- a/doc/man/cockpit-bridge.xml
+++ b/doc/man/cockpit-bridge.xml
@@ -44,7 +44,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1>
+  <refsect1 id="cockpit-bridge-description">
     <title>DESCRIPTION</title>
     <para>The <command>cockpit-bridge</command> program is used by Cockpit to
       relay messages and commands from the Web front end to the server. Among
@@ -56,7 +56,7 @@
       from the command line.</para>
   </refsect1>
 
-  <refsect1>
+  <refsect1 id="cockpit-bridge-options">
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
@@ -85,7 +85,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1>
+  <refsect1 id="cockpit-bridge-bugs">
     <title>BUGS</title>
     <para>
       Please send bug reports to either the distribution bug tracker or the
@@ -93,13 +93,13 @@
     </para>
   </refsect1>
 
-  <refsect1>
+  <refsect1 id="cockpit-bridge-author">
     <title>AUTHOR</title>
     <para>Cockpit has been written by many
       <ulink url="https://github.com/cockpit-project/cockpit/">contributors</ulink>.</para>
   </refsect1>
 
-  <refsect1>
+  <refsect1 id="cockpit-bridge-also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/cockpit-ws.xml
+++ b/doc/man/cockpit-ws.xml
@@ -47,7 +47,8 @@
   </refsynopsisdiv>
 
 
-  <refsect1><title>DESCRIPTION</title>
+  <refsect1 id="cockpit-ws-description">
+    <title>DESCRIPTION</title>
     <para>
       The <command>cockpit-ws</command> program is the web service
       component used for communication between the browser application
@@ -64,7 +65,7 @@
     </para>
   </refsect1>
 
-  <refsect1>
+  <refsect1 id="cockpit-ws-transport">
     <title>TRANSPORT SECURITY</title>
     <para>
       To specify the TLS certificate the web service should use, simply
@@ -86,7 +87,7 @@ $ sudo remotectl certificate
 </programlisting>
   </refsect1>
 
-  <refsect1>
+  <refsect1 id="cockpit-ws-timeout">
     <title>TIMEOUT</title>
     <para>
       When started via
@@ -98,7 +99,7 @@ $ sudo remotectl certificate
     </para>
   </refsect1>
 
-  <refsect1>
+  <refsect1 id="cockpit-ws-options">
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
@@ -155,7 +156,7 @@ $ sudo remotectl certificate
     </variablelist>
   </refsect1>
 
-  <refsect1>
+  <refsect1 id="cockpit-ws-environment">
     <title>ENVIRONMENT</title>
     <para>
       The <command>cockpit-ws</command> process will use the <literal>XDG_CONFIG_DIRS</literal>
@@ -176,7 +177,7 @@ $ sudo remotectl certificate
     </para>
   </refsect1>
 
-  <refsect1>
+  <refsect1 id="cockpit-ws-bugs">
     <title>BUGS</title>
     <para>
       Please send bug reports to either the distribution bug tracker or the
@@ -184,13 +185,13 @@ $ sudo remotectl certificate
     </para>
   </refsect1>
 
-  <refsect1>
+  <refsect1 id="cockpit-ws-author">
     <title>AUTHOR</title>
     <para>Cockpit has been written by many
       <ulink url="https://github.com/cockpit-project/cockpit/">contributors</ulink>.</para>
   </refsect1>
 
-  <refsect1>
+  <refsect1 id="cockpit-ws-also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -35,7 +35,8 @@
     <refpurpose>Cockpit configuration file</refpurpose>
   </refnamediv>
 
-  <refsect1><title>DESCRIPTION</title>
+  <refsect1 id="cockpit-conf-description">
+    <title>DESCRIPTION</title>
   <para>
     Cockpit can be configured via /etc/cockpit/cockpit.conf.  That file has a INI
     file syntax and thus contains key / value pairs, grouped into topical groups. See the
@@ -46,7 +47,7 @@
     the port change the systemd <filename>cockpit.socket</filename> file.</para>
   </refsect1>
 
-  <refsect1 id="webservice">
+  <refsect1 id="cockpit-conf-webservice">
 	  <title>WebService</title>
 	  <variablelist>
 	    <varlistentry>
@@ -106,7 +107,7 @@ Origins = https://somedomain1.com https://somedomain2.com:9090
     </variablelist>
   </refsect1>
 
-  <refsect1 id="oauth">
+  <refsect1 id="cockpit-conf-oauth">
 	  <title>OAuth</title>
         <para>Cockpit can be configured to support the <ulink url="https://tools.ietf.org/html/rfc6749#section-4.2">
         implicit grant</ulink> OAuth authorization flow. When successful the resulting oauth
@@ -142,7 +143,7 @@ Origins = https://somedomain1.com https://somedomain2.com:9090
     </variablelist>
   </refsect1>
 
-  <refsect1>
+  <refsect1 id="cockpit-conf-bugs">
     <title>BUGS</title>
     <para>
       Please send bug reports to either the distribution bug tracker or the
@@ -150,13 +151,13 @@ Origins = https://somedomain1.com https://somedomain2.com:9090
     </para>
   </refsect1>
 
-  <refsect1>
+  <refsect1 id="cockpit-conf-author">
     <title>AUTHOR</title>
     <para>Cockpit has been written by many
       <ulink url="https://github.com/cockpit-project/cockpit/">contributors</ulink>.</para>
   </refsect1>
 
-  <refsect1>
+  <refsect1 id="cockpit-conf-also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>


### PR DESCRIPTION
If the sections have randomized ids like ```idm47845730136032```
then they look like differences when patches are generated
for commits by release-source.