### PR TITLE
test: Remove known issues for fedora-testing

### DIFF
--- a/test/verify/naughty-fedora-24/3968-atomicapp-broken-golang-16
+++ b/test/verify/naughty-fedora-24/3968-atomicapp-broken-golang-16
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-openshift", line 211, in testDeployDialog
-    b.wait_popdown("deploy-app-dialog")

--- a/test/verify/naughty-fedora-24/4270-kubernetes-avc
+++ b/test/verify/naughty-fedora-24/4270-kubernetes-avc
@@ -1,1 +1,0 @@
-op=security_compute_av reason=bounds scontext=system_u:system_r

--- a/test/verify/naughty-fedora-testing/3968-atomicapp-broken-golang-16
+++ b/test/verify/naughty-fedora-testing/3968-atomicapp-broken-golang-16
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-openshift", line 211, in testDeployDialog
-    b.wait_popdown("deploy-app-dialog")

--- a/test/verify/naughty-fedora-testing/4270-kubernetes-avc
+++ b/test/verify/naughty-fedora-testing/4270-kubernetes-avc
@@ -1,1 +1,0 @@
-op=security_compute_av reason=bounds scontext=system_u:system_r


### PR DESCRIPTION
The reason we keep a fedora-testing image around is to discover new issues early, not to hide them. Luckily neither of these issues have happened in the last months.

Follow up: In another pull request we should update the fedora-testing image to Fedora 25.