### PR TITLE
networkmanager: Hack for NetworkManager support on Debian

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -325,7 +325,8 @@ changequote([,])dnl
 
 AC_CHECK_FUNCS(fdwalk)
 
-# Storaged
+
+# Package specific settings
 
 # HACK - Storaged before 2.5.3 doesn't tell us when it supports
 #        sessions, so we allow it to be switched off explicitly.

--- a/configure.ac
+++ b/configure.ac
@@ -340,6 +340,19 @@ AC_ARG_WITH(storaged-iscsi-sessions,
             [with_storaged_iscsi_sessions=yes])
 AC_SUBST(with_storaged_iscsi_sessions)
 
+# HACK - Debian has a broken policy for NetworkManager where it
+#        only allows local sessions or root to perform actions.
+#
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=808162
+
+AC_ARG_WITH(networkmanager-needs-root,
+	    AC_HELP_STRING([--with-networkmanager-needs-root=yes/no],
+			   [Whether NetworkManager requires root access]),
+            [],
+	    [with_networkmanager_needs_root=yes])
+AC_SUBST(with_networkmanager_needs_root)
+
+
 # Address sanitizer
 
 AC_MSG_CHECKING([for asan flags])
@@ -516,6 +529,7 @@ AC_DEFINE([MAX_PACKET_SIZE], [65536], [Maximum size of packet messages])
 
 AC_OUTPUT([
 Makefile
+pkg/networkmanager/override.json
 pkg/storaged/override.json
 doc/guide/version
 po/Makefile.in

--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -10,7 +10,14 @@ nodist_storaged_DATA = \
        pkg/storaged/override.json \
        $(NULL)
 
+# HACK: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=808162
+networkmanagerdir = $(pkgdatadir)/networkmanager
+nodist_networkmanager_DATA = \
+       pkg/networkmanager/override.json \
+       $(NULL)
+
 EXTRA_DIST += \
+	pkg/networkmanager/override.json.in \
 	pkg/storaged/override.json.in \
 	pkg/lib/qunit-template.html \
 	$(pkg_TESTS)

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -27,6 +27,7 @@
     <link href="network.css" type="text/css" rel="stylesheet">
     <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
+    <script src="../manifests.js"></script>
     <script src="../shell/po.js"></script>
     <script src="network.js"></script>
 </head>

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -188,7 +188,15 @@ function NetworkManagerModel() {
     var self = this;
     var byteorder = null;
 
-    var client = cockpit.dbus("org.freedesktop.NetworkManager");
+    /* HACK: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=808162 */
+    var hacks = { };
+    if (cockpit.manifests["network"] && cockpit.manifests["network"]["hacks"])
+        hacks = cockpit.manifests["network"]["hacks"];
+    var options = { };
+    if (hacks.with_networkmanager_needs_root)
+        options["superuser"] = "try";
+
+    var client = cockpit.dbus("org.freedesktop.NetworkManager", options);
 
     self.client = client;
 

--- a/pkg/networkmanager/override.json.in
+++ b/pkg/networkmanager/override.json.in
@@ -1,0 +1,5 @@
+{
+    "hacks": {
+        "with_networkmanager_needs_root": "@with_networkmanager_needs_root@"
+    }
+}

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -29,9 +29,9 @@
      */
 
     /* HACK: https://github.com/storaged-project/storaged/pull/68 */
-    var config = { };
-    if (cockpit.manifests["storage"] && cockpit.manifests["storage"]["config"])
-        config = cockpit.manifests["storage"]["config"];
+    var hacks = { };
+    if (cockpit.manifests["storage"] && cockpit.manifests["storage"]["hacks"])
+        hacks = cockpit.manifests["storage"]["hacks"];
 
     var client = { };
 
@@ -361,7 +361,7 @@
                     client.manager_iscsi = proxy("Manager.ISCSI.Initiator", "Manager");
                     wait_all([ client.manager_lvm2, client.manager_iscsi],
                             function () {
-                                var iscsi = (config.with_storaged_iscsi_sessions != "no" &&
+                                var iscsi = (hacks.with_storaged_iscsi_sessions != "no" &&
                                         client.manager_iscsi.valid &&
                                         client.manager_iscsi.SessionsSupported !== false);
                                 defer.resolve({ lvm2: client.manager_lvm2.valid, iscsi: iscsi });

--- a/pkg/storaged/override.json.in
+++ b/pkg/storaged/override.json.in
@@ -1,5 +1,5 @@
 {
-    "config": {
+    "hacks": {
         "with_storaged_iscsi_sessions": "@with_storaged_iscsi_sessions@"
     }
 }

--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-736a84151b482daa2b2cd0d756554856fecccfde.qcow2
+debian-unstable-77f986b149b268ca5b59108cfe25cc746cbc6fa1.qcow2

--- a/test/images/scripts/debian-unstable.setup
+++ b/test/images/scripts/debian-unstable.setup
@@ -20,6 +20,7 @@ libpolkit-agent-1-0 \
 libpolkit-gobject-1-0 \
 libpwquality-tools \
 libssh-4 \
+libteam-utils \
 libvirt-daemon-system \
 network-manager \
 pcp \

--- a/test/verify/check-networking
+++ b/test/verify/check-networking
@@ -262,6 +262,7 @@ class TestNetworking(MachineCase):
         self.allow_journal_messages(".*Connection reset by peer.*",
                                     "connection unexpectedly closed by peer")
 
+    @unittest.skipIf("ubuntu-1604" in os.environ.get("TEST_OS", ""), "NetworkManager-team not packaged on Ubuntu")
     def testTeam(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networking
+++ b/test/verify/check-networking
@@ -24,11 +24,6 @@ import time
 import os
 import unittest
 
-# https://github.com/cockpit-project/cockpit/issues/1308
-# https://github.com/cockpit-project/cockpit/issues/3341
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=808162
-@unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No networking on Debian (yet).")
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "No networking on Debian (yet).")
 class TestNetworking(MachineCase):
     def setUp(self):
         MachineCase.setUp(self)
@@ -184,7 +179,10 @@ class TestNetworking(MachineCase):
         b.logout()
 
         # Now mark this interface as unmanaged
-        m.execute("echo -e 'NM_CONTROLLED=no\\nDEVICE=\"{0}\"\\n' >> /etc/sysconfig/network-scripts/ifcfg-{0}".format(unmanaged))
+        if "ubuntu" in m.image or "debian" in m.image:
+            m.execute("printf 'iface {0} inet static\n' >> /etc/network/interfaces".format(unmanaged))
+        else:
+            m.execute("echo -e 'NM_CONTROLLED=no\\nDEVICE=\"{0}\"\\n' >> /etc/sysconfig/network-scripts/ifcfg-{0}".format(unmanaged))
         m.execute("systemctl restart NetworkManager")
 
         # Log in and make sure it doesn't show up
@@ -229,7 +227,8 @@ class TestNetworking(MachineCase):
 
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
-        m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbond")
+        if "ubuntu" not in m.image and "debian" not in m.image:
+            m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbond")
 
         # Check that the members are displayed
         b.click("#networking-interfaces tr[data-interface='tbond'] td:first-child")
@@ -301,7 +300,8 @@ class TestNetworking(MachineCase):
 
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
-        m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tteam")
+        if "ubuntu" not in m.image and "debian" not in m.image:
+            m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tteam")
 
         # Check that the members are displayed
         b.click("#networking-interfaces tr[data-interface='tteam'] td:first-child")
@@ -363,7 +363,8 @@ class TestNetworking(MachineCase):
 
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
-        m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbridge")
+        if "ubuntu" not in m.image and "debian" not in m.image:
+            m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbridge")
 
         # Delete the bridge
         b.click("#networking-interfaces tr[data-interface='tbridge'] td:first-child")
@@ -437,6 +438,8 @@ class TestNetworking(MachineCase):
         b.wait_popdown("network-ip-settings-dialog")
         b.wait_in_text("tr:contains('Status')", "1.2.3.4/24")
 
+    @unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "Can not mark unmanaged by mac address")
+    @unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "Can not mark unmanaged by mac address")
     def testUnmanaged(self):
         b = self.browser
         m = self.machine

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -388,7 +388,11 @@ This package contains the Cockpit shell UI assets.
 
 %package storaged
 Summary: Cockpit user interface for storage, using Storaged
+# Lock bridge dependency due to --with-storaged-iscsi-sessions
+# which uses new less stable /manifests.js request path.
+%if 0%{?rhel}
 Requires: %{name}-bridge >= %{version}-%{release}
+%endif
 Requires: %{name}-shell >= %{required_base}
 Requires: storaged >= 2.1.1
 %if 0%{?fedora} >= 24 || 0%{?rhel} >= 8

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -70,9 +70,10 @@ Description: Cockpit bridge server-side component
 
 Package: cockpit-networkmanager
 Architecture: any
+# Lock bridge dependency due to --with-networkmanager-needs-root
+# which uses new less stable /manifests.js request path.
 depends: ${misc:Depends},
          cockpit-bridge (= ${binary:Version}),
-         cockpit-shell (= ${binary:Version}),
          network-manager
 Description: Cockpit user interface for networking
  The Cockpit components for interacting with networking configuration.

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -71,6 +71,8 @@ Description: Cockpit bridge server-side component
 Package: cockpit-networkmanager
 Architecture: any
 depends: ${misc:Depends},
+         cockpit-bridge (= ${binary:Version}),
+         cockpit-shell (= ${binary:Version}),
          network-manager
 Description: Cockpit user interface for networking
  The Cockpit components for interacting with networking configuration.

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -7,6 +7,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
+		--with-networkmanager-needs-root=yes \
 		--with-pamdir=/lib/$(DEB_HOST_MULTIARCH)/security \
 		--libexecdir=/usr/lib/cockpit
 


### PR DESCRIPTION
On Debian and Ubuntu NetworkManager only allows access to local sessions and to root. This is broken.
    
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=808162
    
When built with the --with-networkmanager-needs-root option we try to escalate privileges to root before accessing NetworkManager.
    
Because this ties the networkmanager package to configure.ac we tie the versions more tightly together on Debian and Ubuntu.