### PR TITLE
Makefile: Setup DIST_ARCHIVES correctly for multiple outputs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -339,6 +339,10 @@ dist-hook::
 DIST_TAR_MAIN = tar --format=posix -cf - --exclude='node_modules' --exclude='bower_components' "$(distdir)"
 DIST_TAR_CACHE = tar --format=posix -cf - "$(distdir)/node_modules" "$(distdir)/bower_components" "$(distdir)/package.json" "$(distdir)/bower.json" "$(distdir)/.bowerrc"
 
+DIST_ARCHIVES = \
+	cockpit-$(VERSION).tar.xz \
+	cockpit-cache-$(VERSION).tar.xz
+
 dist-gzip: distdir
 	$(DIST_TAR_MAIN) | GZIP=$(GZIP_ENV) gzip -c > $(distdir).tar.gz
 	$(DIST_TAR_CACHE) | GZIP=$(GZIP_ENV) gzip -c > cockpit-cache-$(VERSION).tar.gz

--- a/test/koji/run-build
+++ b/test/koji/run-build
@@ -49,12 +49,10 @@ def main():
     # Make a distribution
     try:
         subprocess.check_call(["../../../autogen.sh && make dist"], shell=True, env=env)
-        with open(os.path.join(directory, "GNUmakefile"), "w") as f:
-            f.write('include Makefile\nprint-DIST_ARCHIVES:\n\t@echo $(DIST_ARCHIVES)')
-        dist = subprocess.check_output(["make", "-s", "print-DIST_ARCHIVES"]).strip()
+        archives = subprocess.check_output(["make", "-s", "print-DIST_ARCHIVES"]).strip().split(" ")
 
         # Do a build
-        subprocess.check_call(["../../../tools/make-srpm", dist])
+        subprocess.check_call(["../../../tools/make-srpm", archives[0]])
         cmd = ["koji", "build", "--wait", "--scratch", system, glob.glob("*.src.rpm")[0]]
         subprocess.check_call(cmd)
     finally:


### PR DESCRIPTION
Now that we have multiple outputs from 'make dist' the
DIST_ARCHIVES should report that, so that tools such as
cockpituous can pull in the right stuff.