### PR TITLE
test: Only skip tests on specific images

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -50,6 +50,7 @@ __all__ = (
     'arg_parser',
     'Browser',
     'MachineCase',
+    'skipImage',
 
     'sit',
     'wait',
@@ -771,6 +772,12 @@ def list_directories(dirs):
         for f in os.listdir(d):
             result.append(os.path.join(d, f))
     return result
+
+def skipImage(reason, *args):
+    image = testinfra.DEFAULT_IMAGE
+    if image in args:
+        return unittest.skip("{0}: {1}".format(image, reason))
+    return lambda func: func
 
 class Naughty(object):
     def normalize_traceback(self, trace):

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -181,7 +181,7 @@ class TestConnection(MachineCase):
 
         self.allow_journal_messages('peer did not close io when expected')
 
-    @unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "different way of changing ports")
+    @skipImage("Atomic changes ports differently", "fedora-atomic", "rhel-atomic", "continuous-atomic")
     def testSocketPort(self):
         m = self.machine
 
@@ -198,7 +198,7 @@ class TestConnection(MachineCase):
 
         self.allow_journal_messages(".*Peer failed to perform TLS handshake")
 
-    @unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "no local cockpit-ws")
+    @skipImage("Atomic doesn't have cockpit-ws", "fedora-atomic", "rhel-atomic", "continuous-atomic")
     def testCommandline(self):
         m = self.machine
         m.execute('mkdir -p /test/cockpit/ws-certs.d && echo "[WebService]\nLoginTitle = A Custom Title" > /test/cockpit/cockpit.conf')

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -333,7 +333,7 @@ CMD ["/bin/sh"]
 
         self.allow_journal_messages('.*denied.*name_connect.*docker.*')
 
-    @unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "we can't use cockpit on atomic if docker is stopped")
+    @skipImage("No Cockpit on Atomic with Docker stopped", "fedora-atomic", "rhel-atomic", "continuous-atomic")
     def testFailure(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -217,9 +217,8 @@ class TestDockerStorage(MachineCase):
         b.wait_not_in_text("#storage-drives", "DISK2")
         check_loopback(False)
 
+    @skipImage("Switching vgroups not tested on loopbacked docker storage", "continuous-atomic", "debian-unstable", "fedora-atomic", "rhel-atomic", "ubuntu-1604")
     def testDevmapperVGroup(self):
-        if not initially_loopbacked(self.machine):
-            return unittest.skip("Switching vgroups not yet tested")
         self.testDevmapper("dockah")
 
 if __name__ == '__main__':

--- a/test/verify/check-keys
+++ b/test/verify/check-keys
@@ -28,8 +28,8 @@ FP_MD5 = "93:40:9e:67:82:78:a8:99:89:39:d5:ba:e0:50:70:e1"
 FP_SHA256 = "SHA256:SRvBhCmkCEVnJ6ascVH0AoVEbS3nPbowZkNevJnXtgw"
 KEY = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDG4iipTovcMg0xn+089QLNKVGpP2Pgq2duxHgAXre2XgA3dZL+kooioGFwBQSEjbWssKy82hKIN/W82/lQtL6krf7JQWnT3LZwD5DPsvHFKhOLghbiFzSI0uEL4NFFcZOMo5tGLrM5LsZsaIkkv5QkAE0tHIyeYinK6dQ2d8ZsfmgqxHDUQUWnz1T75X9fWQsUugSWI+8xAe0cfa4qZRz/IC+K7DEB3x4Ot5pl8FBuydJj/gb+Lwo2Vs27/d87W/0KHCqOHNwaVC8RBb1WcmXRDDetLGH1A9m5x7Ip/KU/cyvWWxw8S4VKZkTIcrGUhFYJDnjtE3Axz+D7agtps41t test-name"
 
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=805030
-@unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No ssh keys on Debian (yet).")
+# HACK: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=805030
+@skipImage("Too old libssh", "debian-unstable")
 class TestKeys(MachineCase):
     def testAuthorizedKeys(self):
         m = self.machine

--- a/test/verify/check-kubernetes
+++ b/test/verify/check-kubernetes
@@ -27,8 +27,7 @@ import unittest
 from testlib import *
 import kubelib
 
-@unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No kubernetes on Debian (yet).")
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "No kubernetes on Ubuntu (yet).")
+@skipImage("No kubernetes packaged", "debian-unstable", "ubuntu-1604")
 class TestKubernetes(kubelib.KubernetesCase, kubelib.KubernetesCommonTests):
 
     def setUp(self):
@@ -40,8 +39,7 @@ class TestKubernetes(kubelib.KubernetesCase, kubelib.KubernetesCommonTests):
         m.upload(["verify/files/mock-k8s-tiny-app.json"], "/tmp")
         self.wait_api_server()
 
-@unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No kubernetes on Debian (yet).")
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "No kubernetes on Ubuntu (yet).")
+@skipImage("No kubernetes packaged", "debian-unstable", "ubuntu-1604")
 class TestConnection(kubelib.KubernetesCase):
     def testConnect(self):
         m = self.machine
@@ -227,8 +225,7 @@ class TestConnection(kubelib.KubernetesCase):
                                     "connection unexpectedly closed by peer",
                                     ".*: Error sending data: Broken pipe.*")
 
-@unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No kubernetes on Debian (yet).")
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "No kubernetes on Ubuntu (yet).")
+@skipImage("No kubernetes packaged", "debian-unstable", "ubuntu-1604")
 @unittest.skipIf(True, "Nulecule deploys temporarily removed.")
 class TestNulecule(kubelib.KubernetesCase):
     def setUp(self):

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -24,7 +24,7 @@ import time
 import os
 import unittest
 
-@unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "unnecessary on atomic, container is started this way")
+@skipImage("Atomic always uses loopback", "fedora-atomic", "rhel-atomic", "continuous-atomic")
 class TestLoopback(MachineCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -34,7 +34,7 @@ def readFile(name):
 # echo "options kvm-intel nested=1" > /etc/modprobe.d/kvm-intel.conf
 # rmmod kvm-intel && modprobe kvm-intel || true
 
-@unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "Don't run virtual machine tests on atomic systems.")
+@skipImage("Atomic cannot run virtual machines", "fedora-atomic", "rhel-atomic", "continuous-atomic")
 class TestMachines(MachineCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -131,7 +131,6 @@ class TestMetrics(MachineCase):
         b.wait_js_func("ph_flot_data_plateau", "#server_network_traffic_graph", 300*1000, None, 5, "net io");
         m.execute("kill %d" % net_pid)
 
-    @unittest.skipIf("rhel" in os.environ.get("TEST_OS", ""), "No PCP on RHEL.")
     @unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "No PCP on Atomics.")
     def testPcp(self):
         b = self.browser

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -131,7 +131,7 @@ class TestMetrics(MachineCase):
         b.wait_js_func("ph_flot_data_plateau", "#server_network_traffic_graph", 300*1000, None, 5, "net io");
         m.execute("kill %d" % net_pid)
 
-    @unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "No PCP on Atomics.")
+    @skipImage("No PCP available on Atomic", "fedora-atomic", "rhel-atomic", "continuous-atomic")
     def testPcp(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -59,9 +59,8 @@ KEY_IDS_MD5 = [
     "256 b5:80:1b:f5:98:89:2a:39:f3:78:b3:64:5c:64:33:17 /home/admin/.ssh/id_ed25519 (ED25519)"
 ]
 
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=805030
-@unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No ssh keys on Debian (yet).")
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "libssh too old on Ubuntu.")
+# HACK: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=805030
+@skipImage("libssh is too old", "debian-unstable", "ubuntu-1604")
 class TestMultiMachineKeyAuth(MachineCase):
     additional_machines = {
         'machine2': { }

--- a/test/verify/check-networking
+++ b/test/verify/check-networking
@@ -27,8 +27,7 @@ import unittest
 # https://github.com/cockpit-project/cockpit/issues/1308
 # https://github.com/cockpit-project/cockpit/issues/3341
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=808162
-@unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No networking on Debian (yet).")
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "No networking on Debian (yet).")
+@skipImage("Networking is disabled", "debian-unstable", "ubuntu-1604")
 class TestNetworking(MachineCase):
     def setUp(self):
         MachineCase.setUp(self)
@@ -414,11 +413,8 @@ class TestNetworking(MachineCase):
         iface = "tun0"
 
         # Create a tun device and let NetworkManager manage it
-        try:
-            m.execute("ip tuntap add mode tun dev %s" % iface)
-            m.execute("nmcli --wait 0 dev con %s" % iface)
-        except:
-            return unittest.skip("No 'tun' support.")
+        m.execute("ip tuntap add mode tun dev %s" % iface)
+        m.execute("nmcli --wait 0 dev con %s" % iface)
 
         self.login_and_go("/network")
         self.wait_for_iface(iface)
@@ -456,7 +452,7 @@ NM_CONTROLLED=no
         self.browser.wait_present(sel)
         self.browser.wait_visible(sel)
 
-    @unittest.skipIf("fedora-25" not in os.environ.get("TEST_OS", ""), "No network checkpoints here.")
+    @skipImage("No network checkpoint support", "centos-7", "continuous-atomic", "debian-unstable", "fedora-24", "fedora-atomic", "rhel-7", "rhel-atomic", "ubuntu-1604")
     def testCheckpoint(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -49,8 +49,7 @@ def wait_project(machine, project):
             i = i + 1
             time.sleep(2)
 
-@unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No kubernetes on Debian (yet).")
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "No kubernetes on Ubuntu (yet).")
+@skipImage("Kubernetes not packaged", "debian-unstable", "ubuntu-1604")
 class TestOpenshift(MachineCase, OpenshiftCommonTests):
     additional_machines = {
         'openshift': { 'machine': { 'image': 'openshift' } }
@@ -290,8 +289,7 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         b.wait_present(".details-listing tbody[data-id='pods/default/helloapache'] th")
         self.assertEqual(b.text(".details-listing tbody[data-id='pods/default/helloapache'] th"), "helloapache")
 
-@unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No kubernetes on Debian (yet).")
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "No kubernetes on Ubuntu (yet).")
+@skipImage("Kubernetes not packaged", "debian-unstable", "ubuntu-1604")
 class TestRegistry(MachineCase):
     additional_machines = {
         'openshift': { 'machine': { 'image': 'openshift' } }

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -73,7 +73,7 @@ def generate_new_commit(m, pkg_to_remove):
     command = "ostree commit -s cockpit-tree2 --repo {0} -b {1} --add-metadata-string version=cockpit-base.2 --tree=dir={2}"
     m.execute(command.format(*commit_args))
 
-@unittest.skipIf("atomic" not in os.environ.get("TEST_OS", ""), "Skipping check-ostree on non atomic systems.")
+@skipImage("No OSTree available", "centos-7", "debian-unstable", "fedora-24", "fedora-25", "rhel-7", "ubuntu-1604")
 class OstreeRestartCase(MachineCase):
 
     def setUp(self):
@@ -263,7 +263,7 @@ class OstreeRestartCase(MachineCase):
         self.allow_restart_journal_messages()
 
 
-@unittest.skipIf("atomic" not in os.environ.get("TEST_OS", ""), "Skipping check-ostree on non atomic systems.")
+@skipImage("No OSTree available", "centos-7", "debian-unstable", "fedora-24", "fedora-25", "rhel-7", "ubuntu-1604")
 class OstreeCase(MachineCase):
 
     def testPermission(self):

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -31,7 +31,7 @@ def prepare_resolv(machine, address):
     # so instead of overwriting, delete it and write a new one
     machine.execute("echo -e 'domain cockpit.lan\nsearch cockpit.lan\nnameserver %s\n' >/etc/resolv2.conf; mv /etc/resolv2.conf /etc/resolv.conf; chattr +i /etc/resolv.conf" % address)
 
-@unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "atomic: missing bind-utils")
+@skipImage("No realmd available", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestRealms(MachineCase):
     additional_machines = {
         'ipa': { 'machine': { 'image': 'ipa' } }
@@ -171,7 +171,7 @@ ipa-getkeytab -q -s f0.cockpit.lan -p HTTP/x0.cockpit.lan -k /etc/krb5.keytab
 """
 
 # This is here because our test framework can't run ipa VM's twice
-@unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "atomic: missing bind-utils")
+@skipImage("No realmd available", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestKerberos(MachineCase):
     additional_machines = {
         'ipa': { 'machine': { 'image': 'ipa' } }

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -54,10 +54,8 @@ ssh -o StrictHostKeyChecking=no -o 'BatchMode=yes' -i ~/.ssh/test-avc-rsa localh
 mv -f ~/.ssh/authorized_keys.test-avc ~/.ssh/authorized_keys
 """
 
-@unittest.skipIf("centos" in os.environ.get("TEST_OS", ""), "DBUS API of setroubleshoot too old.")
-@unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No setroubleshoot on debian.")
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "No setroubleshoot on Ubuntu.")
-@unittest.skipIf("atomic" in os.environ.get("TEST_OS", ""), "No setroubleshoot on atomic systems.")
+@skipImage("DBus API of setroubleshoot too old", "centos-7")
+@skipImage("No setroubleshoot", "continuous-atomic", "debian-unstable", "fedora-atomic", "rhel-atomic", "ubuntu-1604")
 class TestSelinux(MachineCase):
     def testTroubleshootAlerts(self):
         b = self.browser

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -25,9 +25,7 @@ import os
 import subprocess
 import unittest
 
-@unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No sosreport on Debian.")
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "No sosreport on Ubuntu.")
-@unittest.skipIf("continuous-atomic" in os.environ.get("TEST_OS", ""), "No sosreport on Centos Atomic.")
+@skipImage("No sosreport", "continuous-atomic", "debian-unstable", "ubuntu-1604")
 class TestSOS(MachineCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -24,7 +24,7 @@ import unittest
 from testlib import *
 from storagelib import *
 
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "UDisks doesn't have support for LVM")
+@skipImage("UDisks doesn't have support for LVM", "ubuntu-1604")
 class TestStorage(StorageCase):
     def testHiddenLuks(self):
         m = self.machine

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -25,9 +25,8 @@ import parent
 from testlib import *
 from storagelib import *
 
-@unittest.skipIf("centos" in os.environ.get("TEST_OS", ""), "No storaged-iscsi on CentOS.")
-@unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No storaged-iscsi on Debian.")
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "Udisks doesn't have support for iSCSI")
+@skipImage("storaged-iscsi not packaged", "centos-7", "debian-unstable")
+@skipImage("UDisks doesn't have support for iSCSI", "ubuntu-1604")
 class TestStorage(StorageCase):
     def testISCSI(self):
         m = self.machine

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -24,7 +24,7 @@ import unittest
 from testlib import *
 from storagelib import *
 
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "Udisks doesn't have support for LVM")
+@skipImage("UDisks doesn't have support for LVM", "ubuntu-1604")
 class TestStorage(StorageCase):
     def testLvm(self):
         m = self.machine

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -25,8 +25,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No multipath on Debian (yet).")
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "Udisks doesn't have support for LVM")
+@skipImage("UDisks doesn't have support for multipath", "ubuntu-1604")
 class TestStorage(StorageCase):
     def testBasic(self):
         m = self.machine

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -24,7 +24,7 @@ import unittest
 from testlib import *
 from storagelib import *
 
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "Udisks doesn't have support for LVM")
+@skipImage("UDisks doesn't have support for LVM", "ubuntu-1604")
 class TestStorage(StorageCase):
     def testResize(self):
         m = self.machine

--- a/test/verify/check-subscriptions
+++ b/test/verify/check-subscriptions
@@ -49,7 +49,7 @@ import time
 # register with: activation key "awesome_os_pool" and org "admin"
 # or: subscription-manager register --activationkey awesome_os_pool --org admin --serverurl https://$IP:8443/candlepin
 
-@unittest.skipIf("rhel-7" != os.environ.get("TEST_OS", ""), "Only testing subscriptions on RHEL systems.")
+@skipImage("No subscriptions", "centos-7", "continuous-atomic", "debian-unstable", "fedora-24", "fedora-25", "fedora-atomic", "ubuntu-1604")
 class TestSubscriptions(MachineCase):
     additional_machines = {
         'candlepin': { 'machine': { 'image': 'candlepin' } }

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -246,10 +246,7 @@ class TestSystemInfo(MachineCase):
         self.assertIn("Mon Jun  4 06:34:", m.execute("LC_ALL=C date"))
         self.assertIn("EEST 2018\n", m.execute("LC_ALL=C date"))
 
-    @unittest.skipIf("rhel-7" == os.environ.get("TEST_OS", ""), "No NTP servers config on rhel-7.")
-    @unittest.skipIf("centos" in os.environ.get("TEST_OS", ""), "No NTP servers config on centos.")
-    @unittest.skipIf("continuous-atomic" == os.environ.get("TEST_OS", ""), "No NTP servers config on continuous-atomic.")
-    @unittest.skipIf("rhel-atomic" == os.environ.get("TEST_OS", ""), "No NTP servers config on rhel-atomic.")
+    @skipImage("No NTP servers config", "centos-7", "continuous-atomic", "rhel-7", "rhel-atomic")
     def testTimeServers(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-tuned
+++ b/test/verify/check-tuned
@@ -23,9 +23,7 @@ from testlib import *
 import unittest
 import os
 
-@unittest.skipIf("debian" in os.environ.get("TEST_OS", ""), "No tuned on Debian.")
-@unittest.skipIf("ubuntu" in os.environ.get("TEST_OS", ""), "No tuned on Ubuntu.")
-@unittest.skipIf("fedora-atomic" in os.environ.get("TEST_OS", ""), "No tuned on Fedora Atomic.")
+@skipImage("No tuned packaged", "debian-unstable", "fedora-atomic", "ubuntu-1604")
 class TestTuned(MachineCase):
     def testBasic(self):
         b = self.browser


### PR DESCRIPTION
The wildcard skips cause us to ignore test failures long after the functionality starts to work on the target operating system.
    
We should explicitly skip tests on specific operating systems.
    
In addition no tests should be skipped on canary images, such as fedora-testing.
