### PR TITLE
build: Make sure there's always a Version set in the spec file

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -34,6 +34,8 @@
 Name:           cockpit
 %if %{defined gitcommit}
 Version:        %{gitcommit}
+%else
+Version:        wip
 %endif
 Release:        1%{?dist}
 Summary:        A user interface for Linux servers


### PR DESCRIPTION
Let `Version` default to 'wip'.

This avoids an error while building our release container.