### PR TITLE
ws: Remove = from cookie names

### DIFF
--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -582,7 +582,10 @@ cockpit_web_server_parse_cookie (GHashTable *headers,
   const gchar *pos;
   const gchar *value;
   const gchar *end;
+  gboolean at_start = TRUE;
   gchar *decoded;
+  gint diff;
+  gint offset;
 
   header = g_hash_table_lookup (headers, "Cookie");
   if (!header)
@@ -591,11 +594,26 @@ cockpit_web_server_parse_cookie (GHashTable *headers,
   for (;;)
     {
       pos = strstr (header, name);
-      if (!pos || (pos != header && *(pos - 1) != ';' && !g_ascii_isspace (*(pos - 1))))
+      if (!pos)
         return NULL;
 
+      if (pos != header)
+        {
+          diff = strlen(header) - strlen(pos);
+          offset = 1;
+          at_start = FALSE;
+          while (offset < diff) {
+            if (!g_ascii_isspace (*(pos - offset)))
+              {
+                at_start = *(pos - offset) == ';';
+                break;
+              }
+            offset++;
+          }
+        }
+
       pos += strlen (name);
-      if (*pos == '=')
+      if (*pos == '=' && at_start)
         {
           value = pos + 1;
           end = strchr (value, ';');
@@ -608,7 +626,10 @@ cockpit_web_server_parse_cookie (GHashTable *headers,
 
           return decoded;
         }
-
+      else
+        {
+          at_start = FALSE;
+        }
       header = pos;
     }
 }

--- a/src/common/test-webserver.c
+++ b/src/common/test-webserver.c
@@ -156,6 +156,33 @@ test_cookie_multiple (void)
 }
 
 static void
+test_cookie_overlap (void)
+{
+  GHashTable *table = cockpit_web_server_new_table ();
+  gchar *result;
+
+  g_hash_table_insert (table, g_strdup ("Cookie"), g_strdup ("cookie1cookie1cookie1=value;cookie1=cookie23-value2;   cookie2=a value for cookie23=inline; cookie23=value3"));
+
+  result = cockpit_web_server_parse_cookie (table, "cookie1cookie1cookie1");
+  g_assert_cmpstr (result, ==, "value");
+  g_free (result);
+
+  result = cockpit_web_server_parse_cookie (table, "cookie1");
+  g_assert_cmpstr (result, ==, "cookie23-value2");
+  g_free (result);
+
+  result = cockpit_web_server_parse_cookie (table, "cookie2");
+  g_assert_cmpstr (result, ==, "a value for cookie23=inline");
+  g_free (result);
+
+  result = cockpit_web_server_parse_cookie (table, "cookie23");
+  g_assert_cmpstr (result, ==, "value3");
+  g_free (result);
+
+  g_hash_table_unref (table);
+}
+
+static void
 test_cookie_no_header (void)
 {
   GHashTable *table = cockpit_web_server_new_table ();
@@ -907,6 +934,7 @@ main (int argc,
 
   g_test_add_func ("/web-server/cookie/simple", test_cookie_simple);
   g_test_add_func ("/web-server/cookie/multiple", test_cookie_multiple);
+  g_test_add_func ("/web-server/cookie/overlap", test_cookie_overlap);
   g_test_add_func ("/web-server/cookie/no-header", test_cookie_no_header);
   g_test_add_func ("/web-server/cookie/substring", test_cookie_substring);
   g_test_add_func ("/web-server/cookie/decode", test_cookie_decode);

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -92,10 +92,12 @@ on_ready_get_result (GObject *source,
 
 static void
 include_cookie_as_if_client (GHashTable *resp_headers,
-                             GHashTable *req_headers)
+                             GHashTable *req_headers,
+                             const gchar *cookie_name)
 {
   gchar *cookie;
   gchar *end;
+  gchar *expected = g_strdup_printf ("%s=", cookie_name);
 
   cookie = g_strdup (g_hash_table_lookup (resp_headers, "Set-Cookie"));
   g_assert (cookie != NULL);
@@ -103,7 +105,10 @@ include_cookie_as_if_client (GHashTable *resp_headers,
   g_assert (end != NULL);
   end[0] = '\0';
 
+  g_assert (strncmp (cookie, expected, strlen(expected)) == 0);
+
   g_hash_table_insert (req_headers, g_strdup ("Cookie"), cookie);
+  g_free (expected);
 }
 
 static void
@@ -181,7 +186,7 @@ test_userpass_cookie_check (Test *test,
   response = cockpit_auth_login_finish (test->auth, result, 0, headers, &error);
 
   /* Get the service */
-  include_cookie_as_if_client (headers, headers);
+  include_cookie_as_if_client (headers, headers, "cockpit");
   service = cockpit_auth_check_cookie (test->auth, "/cockpit", headers);
 
   g_object_unref (result);
@@ -201,7 +206,7 @@ test_userpass_cookie_check (Test *test,
   prev_creds = creds;
   creds = NULL;
 
-  include_cookie_as_if_client (headers, headers);
+  include_cookie_as_if_client (headers, headers, "cockpit");
 
   service = cockpit_auth_check_cookie (test->auth, "/cockpit", headers);
   g_assert (prev_service == service);
@@ -341,7 +346,7 @@ test_idle_timeout (Test *test,
   g_assert_no_error (error);
 
   /* Logged in ... the webservice is idle though */
-  include_cookie_as_if_client (headers, headers);
+  include_cookie_as_if_client (headers, headers, "cockpit");
   service = cockpit_auth_check_cookie (test->auth, "/cockpit", headers);
   g_assert (service != NULL);
   g_assert (cockpit_web_service_get_idling (service));
@@ -462,6 +467,7 @@ typedef struct {
   const gchar *password;
   const gchar *application;
   const gchar *remote_peer;
+  const gchar *cookie_name;
 } SuccessFixture;
 
 static void
@@ -563,7 +569,8 @@ test_custom_success (Test *test,
   g_assert (response != NULL);
   json_object_unref (response);
 
-  include_cookie_as_if_client (headers, headers);
+  include_cookie_as_if_client (headers, headers,
+                               fix->cookie_name ? fix->cookie_name : "cockpit");
   service = cockpit_auth_check_cookie (test->auth, path, headers);
   creds = cockpit_web_service_get_creds (service);
   g_assert_cmpstr (user, ==, cockpit_creds_get_user (creds));
@@ -597,7 +604,8 @@ static const SuccessFixture fixture_ssh_remote_basic = {
   .path = "/cockpit+=machine",
   .user = "remote-user",
   .password = "this is the machine password",
-  .application = "cockpit+=machine"
+  .application = "cockpit+=machine",
+  .cookie_name = "machine-cockpit+machine"
 };
 
 static const SuccessFixture fixture_ssh_no_data = {
@@ -610,7 +618,8 @@ static const SuccessFixture fixture_ssh_remote_switched = {
   .data = NULL,
   .header = "testscheme ssh-remote-switch",
   .path = "/cockpit+=machine",
-  .application = "cockpit+=machine"
+  .application = "cockpit+=machine",
+  .cookie_name = "machine-cockpit+machine"
 };
 
 static const SuccessFixture fixture_ssh_local_peer = {
@@ -618,7 +627,8 @@ static const SuccessFixture fixture_ssh_local_peer = {
   .header = "testscheme ssh-local-peer",
   .path = "/cockpit+=machine",
   .application = "cockpit+=machine",
-  .remote_peer = "127.0.0.1"
+  .remote_peer = "127.0.0.1",
+  .cookie_name = "machine-cockpit+machine"
 };
 
 static const SuccessFixture fixture_ssh_alt_default = {
@@ -631,6 +641,7 @@ static const SuccessFixture fixture_ssh_alt = {
   .path = "/cockpit+=machine",
   .application = "cockpit+=machine",
   .header = "testsshscheme ssh-alt-machine",
+  .cookie_name = "machine-cockpit+machine"
 };
 
 static const SuccessFixture fixture_ssh_bad_data = {
@@ -911,7 +922,7 @@ test_multi_step_success (Test *test,
       json_object_unref (response);
     }
 
-  include_cookie_as_if_client (headers, headers);
+  include_cookie_as_if_client (headers, headers, "cockpit");
   service = cockpit_auth_check_cookie (test->auth, "/cockpit", headers);
   creds = cockpit_web_service_get_creds (service);
   g_assert_cmpstr ("me", ==, cockpit_creds_get_user (creds));


### PR DESCRIPTION
Having a = in our cookie names is problematic as most browsers split on the first =. Rename the cookie to machine-cockpit+xxx to remove the need for a =

I hind sight i probably should have chosen a different sep char, But i think we are stuck with this for now.