### PR TITLE
test: Expose the Error object from testlib

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -51,6 +51,7 @@ __all__ = (
     'Browser',
     'MachineCase',
     'skipImage',
+    'Error',
 
     'sit',
     'wait',


### PR DESCRIPTION
So that we can import it and use it elsewhere. This fixes the
error case handling in check-multi-os.