### PR TITLE
ws: Ignore one more possible message during test-auth

### DIFF
--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -525,6 +525,8 @@ test_bad_command (Test *test,
                                "*couldn't write: Connection refused*");
   cockpit_expect_possible_log ("cockpit-protocol", G_LOG_LEVEL_MESSAGE,
                                "*couldn't write: Connection refused*");
+  cockpit_expect_possible_log ("cockpit-protocol", G_LOG_LEVEL_MESSAGE,
+                               "*couldn't send: Connection refused*");
   test_custom_fail (test, data);
 }
 


### PR DESCRIPTION
This happens rarely but is a possible test failure, as
seen here:

```
cockpit-protocol-Message: bad-command: couldn't send: Connection refused
**
cockpit-protocol:ERROR:src/ws/test-auth.c:527:test_bad_command: Got unexpected message: bad-command: couldn't send: Connection refused instead of cockpit-protocol-Message: *couldn't write: Connection refused*
./test-auth terminated with SIGABRT
```