### PR TITLE
Print warnings when using deprecated Cockpit javascript

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -295,8 +295,6 @@ include doc/Makefile-doc.am
 include doc/guide/Makefile-guide.am
 include doc/man/Makefile-man.am
 
-noinst_DATA += doc/guide/html
-
 dist-doc-hook:
 	@true
 

--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -76,6 +76,8 @@ EXTRA_DIST += \
 	doc/guide/version.in \
 	$(NULL)
 
+noinst_DATA += doc/guide/html/index.html
+
 CLEANFILES += \
 	doc/guide/html/* \
 	*.tmp \
@@ -84,7 +86,7 @@ CLEANFILES += \
 doc/guide/html/%.woff: dist/fonts/%.woff
 	$(V_COPY) $(MKDIR_P) doc/guide/html && cp -L $^ $@.tmp && $(MV) $@.tmp $@
 
-doc/guide/html: $(GUIDE_DOCBOOK) $(GUIDE_INCLUDES) $(man_MANS) $(GUIDE_STATIC) $(GUIDE_XSLT) $(GUIDE_FONTS)
+doc/guide/html/index.html: $(GUIDE_DOCBOOK) $(GUIDE_INCLUDES) $(man_MANS) $(GUIDE_STATIC) $(GUIDE_XSLT) $(GUIDE_FONTS)
 	$(AM_V_GEN) $(MKDIR_P) doc/guide/html/ && \
 		cp $(addprefix $(srcdir)/,$(GUIDE_STATIC)) doc/guide/html/ && \
 		LANG=en_US.UTF-8 $(XMLTO) html -m $(srcdir)/doc/guide/gtk-doc.xsl -o doc/guide/html/ \

--- a/doc/guide/api-base1.xml
+++ b/doc/guide/api-base1.xml
@@ -99,29 +99,4 @@
 
   </refentry>
 
-  <refentry id="api-base1-require">
-    <refmeta>
-      <refentrytitle>require.js</refentrytitle>
-    </refmeta>
-
-    <refnamediv>
-      <refname>require.js</refname>
-      <refpurpose>Require JS javascript loader</refpurpose>
-    </refnamediv>
-
-    <refsection id="api-base1-require-description">
-      <title>Description</title>
-
-<programlisting>
-&lt;script src="../base1/require.js"&gt;&lt;/script&gt;
-</programlisting>
-
-      <para>This is the Require JS javascript loader. It supports Asynchronous Module Definition
-        and allows javascript modules to declare dependencies to load.</para>
-
-      <para>The current Require JS version is 2.1.x.</para>
-    </refsection>
-
-  </refentry>
-
 </reference>

--- a/examples/ocserv/ocserv.css
+++ b/examples/ocserv/ocserv.css
@@ -19,10 +19,13 @@
 
 /* ---------------------------------------------------------------------------------------------------- */
 
-/* Hacks on top for now */
-
-html, body {
+.curtain-ocserv {
+    top: 0px;
+    left: 0px;
     height: 100%;
+    width: 100%;
+    position: absolute;
+    z-index: 1;
 }
 
 .ocserv-users-id {

--- a/examples/ocserv/ocserv.html
+++ b/examples/ocserv/ocserv.html
@@ -24,7 +24,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <meta charset="utf-8">
     <link href="../base1/cockpit.css" type="text/css" rel="stylesheet">
     <link href="ocserv.css" type="text/css" rel="stylesheet">
-    <script type="text/javascript" src="../base1/cockpit.js"></script>
+    <script type="text/javascript" src="../base1/bundle.js"></script>
 </head>
 <body>
 

--- a/examples/ocserv/ocserv.html
+++ b/examples/ocserv/ocserv.html
@@ -26,9 +26,17 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <link href="ocserv.css" type="text/css" rel="stylesheet">
     <script type="text/javascript" src="../base1/bundle.js"></script>
 </head>
-<body>
+<body hidden>
 
-    <div id="status-info" class="container-fluid">
+    <div class="curtain-ocserv blank-slate-pf" hidden>
+      <div class="blank-slate-pf-icon">
+        <div class="fa fa-exclamation-circle"></div>
+      </div>
+      <h1>Couldn't connect to OpenConnect Server</h1>
+      <p></p>
+    </div>
+
+    <div id="status-info" class="container-fluid page-ct">
         <div class="panel panel-default">
             <div class="panel-heading">
                <span id="head">Server status</span>
@@ -73,7 +81,8 @@ require([
         occtl_status_run();
 
         function occtl_users_run() {
-            var proc = cockpit.spawn(["/usr/bin/occtl", "-n", "-j", "show", "users"]);
+            var proc = cockpit.spawn(["/usr/bin/occtl", "-n", "-j", "show", "users"],
+                                     { err: "message", superuser: "try" });
             proc.done(occtl_users_success);
             proc.stream(occtl_users_output);
             proc.fail(occtl_users_fail);
@@ -115,10 +124,18 @@ require([
                 );
                 $("#users-table-tbody").append(row);
             });
+
+            $('.curtain-ocserv').hide();
+            $('body').show();
         }
 
-        function occtl_users_fail() {
-            console.warn("FAIL!");
+        function occtl_users_fail(ex) {
+            if (ex.problem == "not-found")
+                console.warn("occtl executable was not found");
+            else
+                console.warn(cockpit.message(ex));
+            $('.curtain-ocserv').show();
+            $('body').show();
         }
 
         function occtl_users_output(data) {
@@ -132,7 +149,8 @@ require([
 
             status_raw = "";
 
-            var proc = cockpit.spawn(["/usr/bin/occtl", "-n", "-j", "show", "status"]);
+            var proc = cockpit.spawn(["/usr/bin/occtl", "-n", "-j", "show", "status"],
+                                     { err: "message", superuser: "try" });
             proc.done(occtl_status_success);
             proc.stream(occtl_status_output);
             proc.fail(occtl_status_fail);
@@ -146,25 +164,29 @@ require([
                     console.warn(e, obj);
             }
 
-            $("#status_table").empty();
-
+            $("#status-table").empty();
             if (!obj) {
                 occtl_status_fail();
             } else {
-                $("#status_table").append('<tr><td>Status</td><td>' +
-                    obj.Status + '</td></tr>').toString();
-                $("#status_table").append('<tr><td>Uptime</td><td>' +
-                    obj["_Up since"] + '</td></tr>').toString();
-                $("#status_table").append('<tr><td>Connected users</td><td>' +
-                    obj["Clients"] + '</td></tr>').toString();
-                $("#status_table").append('<tr><td>IPs in ban list</td><td>' +
-                    obj["IPs in ban list"] + '</td></tr>').toString();
+                $("#status-table").append('<tr><td>Status</td><td>' +
+                    obj.Status + '</td></tr>');
+                $("#status-table").append('<tr><td>Uptime</td><td>' +
+                    obj["_Up since"] + '</td></tr>');
+                $("#status-table").append('<tr><td>Connected users</td><td>' +
+                    obj["Clients"] + '</td></tr>');
+                $("#status-table").append('<tr><td>IPs in ban list</td><td>' +
+                    obj["IPs in ban list"] + '</td></tr>');
             }
         }
 
-        function occtl_status_fail() {
-            $("#status_table").empty();
-            $("#status_table").append('<tr><td>Status</td><td>offline</td></tr>').toString();
+        function occtl_status_fail(ex) {
+            console.log("status fail", ex);
+            var message = ex ? cockpit.message(ex) : "offline";
+            $("#status-table")
+                .empty()
+                .append('<tr>')
+                    .append($('<td>Status</td>'),
+                            $('<td>').text(message));
         }
 
 });

--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -8,7 +8,6 @@ nodist_base_DATA = \
 	dist/base1/mustache.min.js.gz \
 	dist/base1/jquery.min.js.gz \
 	dist/base1/cockpit.min.js.gz \
-	dist/base1/bundle.min.js.gz \
 	$(NULL)
 base_DATA = \
 	dist/base1/manifest.json \
@@ -16,7 +15,6 @@ base_DATA = \
 
 basedebugdir = $(debugdir)$(basedir)
 basedebug_DATA = \
-	dist/base1/bundle.min.js.map \
 	dist/base1/cockpit.min.css.map \
 	dist/base1/patternfly.min.css.map \
 	dist/base1/mustache.min.js.map \
@@ -31,7 +29,7 @@ UGLIFY_JS = $(srcdir)/node_modules/.bin/uglifyjs
 
 MIN_JS_RULE = \
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	$(srcdir)/tools/missing $(UGLIFY_JS) $^ --mangle \
+	$(srcdir)/tools/missing $(UGLIFY_JS) $^ --mangle --comments 'preserve' \
 		--source-map $@.map --source-map-url $(notdir $@).map --source-map-include-sources > $@.tmp && \
 	$(MV) $@.tmp $@
 
@@ -41,14 +39,9 @@ dist/base1/cockpit.min.css: src/base1/cockpit.css
 dist/base1/patternfly.min.css: dist/base1/patternfly-base.css dist/base1/patternfly-additions.css
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
 	$(srcdir)/tools/missing $(CLEAN_CSS) --output=$@ --source-map --source-map-inline-sources $^
-dist/base1/bundle.js: dist/base1/require.js src/base1/cockpit.js dist/base1/jquery.js
+dist/base1/require.js: src/base1/deprecated.js src/base1/require-config.js src/base1/require-loaders.js
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	cat $^ > $@.tmp && $(MV) $@.tmp $@
-dist/base1/bundle.min.js: dist/base1/bundle.js
-	$(MIN_JS_RULE)
-dist/base1/require.js: src/base1/require-config.js src/base1/require-loaders.js
-	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	cat $(srcdir)/src/base1/require-config.js $(BOWER)/requirejs/require.js $(srcdir)/src/base1/require-loaders.js > $@.tmp && $(MV) $@.tmp $@
+	cat $(srcdir)/src/base1/deprecated.js $(srcdir)/src/base1/require-config.js $(BOWER)/requirejs/require.js $(srcdir)/src/base1/require-loaders.js > $@.tmp && $(MV) $@.tmp $@
 dist/base1/require.min.js: dist/base1/require.js
 	$(MIN_JS_RULE)
 dist/base1/jquery.js:
@@ -61,9 +54,9 @@ dist/base1/cockpit.js: src/base1/cockpit.js
 	$(COPY_RULE)
 dist/base1/cockpit.min.js: dist/base1/cockpit.js
 	$(MIN_JS_RULE)
-dist/base1/mustache.js:
+dist/base1/mustache.js: src/base1/deprecated.js
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
-	cp $(BOWER)/mustache/mustache.js $@.tmp && $(MV) $@.tmp $@
+	cat $(srcdir)/src/base1/deprecated.js $(BOWER)/mustache/mustache.js > $@.tmp && $(MV) $@.tmp $@
 dist/base1/mustache.min.js: dist/base1/mustache.js
 	$(MIN_JS_RULE)
 dist/base1/manifest.json: src/base1/manifest.json
@@ -71,8 +64,6 @@ dist/base1/manifest.json: src/base1/manifest.json
 
 
 # All map files are built as side effects of minification
-dist/base1/bundle.min.js.map: dist/base1/bundle.min.js
-
 dist/base1/require.min.js.map: dist/base1/require.min.js
 
 dist/base1/cockpit.min.js.map: dist/base1/cockpit.min.js
@@ -115,6 +106,9 @@ basefonts_DATA = \
 	dist/base1/fonts/patternfly.woff \
 	dist/base1/fonts/glyphicons.woff \
 	$(NULL)
+
+install-data-local::
+	$(LN_S) -nf require.min.js.gz $(DESTDIR)$(pkgdatadir)/base1/bundle.min.js.gz
 
 # Tests run with QUnit
 
@@ -213,9 +207,6 @@ TESTS += $(base_TESTS)
 noinst_SCRIPTS += $(base_TESTS)
 
 EXTRA_DIST += \
-	dist/base1/bundle.js \
-	dist/base1/bundle.min.js \
-	dist/base1/bundle.min.js.map \
 	dist/base1/cockpit.js \
 	dist/base1/cockpit.min.css \
 	dist/base1/cockpit.min.css.map \
@@ -239,6 +230,7 @@ EXTRA_DIST += \
 	dist/base1/simple-tap.js \
 	src/base1/cockpit.css \
 	src/base1/cockpit.js \
+	src/base1/deprecated.js \
 	src/base1/manifest.json \
 	src/base1/require-config.js \
 	src/base1/require-loaders.js \

--- a/src/base1/deprecated.js
+++ b/src/base1/deprecated.js
@@ -1,0 +1,4 @@
+/* @preserve: WARNING: This javascript file in the base1 package is deprecated */
+console.warn("Deprecated: " +
+             ((new Error).fileName || "This javascript file").split("/").reverse()[0] +
+             " in the Cockpit base1 package is deprecated");

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -301,6 +301,7 @@ cat subscriptions.list sosreport.list networkmanager.list selinux.list >> shell.
 %doc %{_mandir}/man1/cockpit.1.gz
 
 %files bridge -f base.list
+%{_datadir}/%{name}/base1/bundle.min.js.gz
 %doc %{_mandir}/man1/cockpit-bridge.1.gz
 %{_bindir}/cockpit-bridge
 %attr(4755, -, -) %{_libexecdir}/cockpit-polkit


### PR DESCRIPTION
We put deprecated warnings both in the javascript file and in print them in the browser console when the deprecated files are used.
    
Secondly we make bundle.js just be a link to require.js. Users of bundle.js were using AMD ... and this will continue to work, albeit in a deprecated slower fashion.
    
Remove require.js from the documentation. It's deprecated, not documented.
