### PR TITLE
tools: Split out cockpit-ssh into its own subpackage

### DIFF
--- a/containers/kubernetes/install.sh
+++ b/containers/kubernetes/install.sh
@@ -13,7 +13,7 @@ elif [ -z "$VERSION" ] && [ -z "$OFFLINE" ]; then
 fi
 
 # Install packages without dependencies
-/container/scripts/install-rpms.sh cockpit-ws
+/container/scripts/install-rpms.sh cockpit-ws cockpit-dashboard
 /container/scripts/install-rpms.sh --nodeps cockpit-bridge
 /container/scripts/install-rpms.sh -a noarch --nodeps cockpit-system
 /container/scripts/install-rpms.sh --nodeps cockpit-kubernetes

--- a/containers/ws/install-package.sh
+++ b/containers/ws/install-package.sh
@@ -11,7 +11,7 @@ fi
 
 OS=$(rpm -q --qf "%{release}" basesystem | sed -n -e 's/^[0-9]*\.\(\S\+\).*/\1/p')
 
-rpm=$(ls /container/rpms/cockpit-ws*.rpm || true)
+rpm=$(ls /container/rpms/cockpit-ws*.rpm /container/rpms/cockpit-dashboard*.rpm || true)
 
 if [ -z "$RELEASE" ]; then
     RELEASE=1
@@ -19,20 +19,20 @@ fi
 
 # If there are rpm files in the current directory we'll install those
 if [ -n "$rpm" ]; then
-    $INSTALLER -y install /container/rpms/cockpit-ws*.rpm
+    $INSTALLER -y install /container/rpms/cockpit-ws*.rpm /container/rpms/cockpit-dashboard*.rpm
 
 elif [ -n "$USE_REPO" ]; then
-    "$INSTALLER" -y install cockpit-ws
+    "$INSTALLER" -y install cockpit-ws cockpit-dashboard
 
 # If there is a url set, pull the version from there
 # requires the build arg VERSION to be set
 elif [ -n "$COCKPIT_RPM_URL" ]; then
-    "$INSTALLER" -y install "$COCKPIT_RPM_URL/$VERSION/$RELEASE.$OS/x86_64/cockpit-ws-$VERSION-$RELEASE.$OS.x86_64.rpm"
+    "$INSTALLER" -y install "$COCKPIT_RPM_URL/$VERSION/$RELEASE.$OS/x86_64/cockpit-ws-$VERSION-$RELEASE.$OS.x86_64.rpm" "$COCKPIT_RPM_URL/$VERSION/$RELEASE.$OS/x86_64/cockpit-dashboard-$VERSION-$RELEASE.$OS.x86_64.rpm"
 
 # Otherwise just do the standard install
 # requires the build arg VERSION to be set
 else
-    "$INSTALLER" -y install cockpit-ws-$VERSION-$RELEASE.$OS
+    "$INSTALLER" -y install cockpit-ws-$VERSION-$RELEASE.$OS cockpit-dashboard-$VERSION-$RELEASE.$OS
 fi
 
 "$INSTALLER" clean all

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -318,8 +318,6 @@
     <div id="content">
       <!-- Initially populate these frames -->
       <iframe class="container-frame"
-          name="cockpit1:localhost/dashboard" src="../dashboard/index.html#/"></iframe>
-      <iframe class="container-frame"
           name="cockpit1:localhost/system" src="../system/index.html#/"></iframe>
     </div>
 

--- a/test/images/scripts/lib/atomic.install
+++ b/test/images/scripts/lib/atomic.install
@@ -169,23 +169,31 @@ class AtomicCockpitInstaller:
             return None
 
     def update_container(self):
-        """ Install the latest cockpit-ws in our container"""
-        install = None
+        """ Install the latest cockpit-ws and cockpit-dashboard in our container"""
+        ws = None
+        dashboard = None
         for package in self.rpms:
             if 'cockpit-ws' in package:
-                install = package
-                break
+                ws = package
+            if 'cockpit-dashboard' in package:
+                dashboard = package
 
-        if self.verbose:
-            print "installing cockpit-ws in container"
-
-        if install:
-            path = "/host" + install;
+        if ws or dashboard:
             subprocess.check_call(["docker", "run", "--name", "build-cockpit",
                                    "-d", "--privileged", "-v", "/:/host",
                                    "cockpit/ws", "sleep", "1d"])
-            subprocess.check_call(["docker", "exec", "build-cockpit",
-                                   "rpm", "-U", "--force", path])
+            if ws:
+                if self.verbose:
+                    print "updating cockpit-ws in container"
+                path = "/host" + ws;
+                subprocess.check_call(["docker", "exec", "build-cockpit",
+                                       "rpm", "-U", "--force", path])
+            if dashboard:
+                if self.verbose:
+                    print "updating cockpit-dashboard in container"
+                path = "/host" + dashboard;
+                subprocess.check_call(["docker", "exec", "build-cockpit",
+                                       "rpm", "-U", "--force", path])
             subprocess.check_call(["docker", "commit", "build-cockpit",
                                    "cockpit/ws"])
             subprocess.check_call(["docker", "kill", "build-cockpit"])

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -70,6 +70,7 @@ class DashBoardHelpers:
             b.click('#dashboard_setup_server_dialog .btn-primary')
         b.wait_popdown('dashboard_setup_server_dialog')
 
+@skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestBasicDashboard(MachineCase, DashBoardHelpers):
     additional_machines = {
         'machine2': { },
@@ -183,6 +184,7 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
         self.allow_hostkey_messages()
         self.allow_journal_messages(".*server offered unsupported authentication methods: password public-key.*")
 
+@skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestDashboardSetup(MachineCase, DashBoardHelpers):
     additional_machines = {
         'machine2': { }
@@ -276,6 +278,7 @@ class TestDashboardSetup(MachineCase, DashBoardHelpers):
         m2.execute("ps aux | grep cockpit-bridge | grep admin")
         self.allow_hostkey_messages()
 
+@skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestDashboardEditLimits(MachineCase, DashBoardHelpers):
     def testEdit(self):
         b = self.browser

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -106,6 +106,7 @@ def change_ssh_port(machine, port=None, timeout_sec=120):
 
     raise error
 
+@skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestMultiMachineAdd(MachineCase):
     additional_machines = {
         'machine2': { },
@@ -144,9 +145,11 @@ class TestMultiMachineAdd(MachineCase):
         b.go("/dashboard")
         b.enter_page("/dashboard")
         kill_user_admin(m2)
+        b.wait_present("#dashboard-hosts a[data-address='%s'] img" % m2.address)
         b.wait_attr("#dashboard-hosts a[data-address='%s'] img" % m2.address, 'src', '../shell/images/server-error.png')
 
         kill_user_admin(m3)
+        b.wait_present("#dashboard-hosts a[data-address='%s'] img" % m3.address)
         b.wait_attr("#dashboard-hosts a[data-address='%s'] img" % m3.address, 'src', '../shell/images/server-error.png')
 
         # Navigating reconnects
@@ -180,6 +183,7 @@ class TestMultiMachineAdd(MachineCase):
                                     ".*: bridge program failed: Child process exited with code .*")
 
 
+@skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestMultiMachine(MachineCase):
     additional_machines = {
         'machine2': { }

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -217,22 +217,6 @@ class TestMultiMachineKeyAuth(MachineCase):
         # Change user
         authorize_user(m2, "user")
 
-        b.go("/dashboard")
-        b.enter_page("/dashboard")
-        b.click('#dashboard-enable-edit')
-        b.wait_visible("#dashboard-hosts .list-group-item[data-address='{0}'] button.pficon-edit".format(m2.address))
-        b.click("#dashboard-hosts .list-group-item[data-address='{0}'] button.pficon-edit".format(m2.address))
-        b.wait_popup('host-edit-dialog')
-        b.wait_visible('#host-edit-user')
-        self.assertEqual(b.val("#host-edit-user"), "")
-        b.set_val('#host-edit-user', 'user')
-        b.click('#host-edit-apply')
-        b.wait_popdown('host-edit-dialog')
-        b.wait_not_present("iframe.container-frame[name='cockpit1:{0}/system']".format(m2.address))
-
-        b.click("#dashboard-hosts .list-group-item[data-address='{0}']".format(m2.address))
-        b.enter_page("/system", host="user@{0}".format(m2.address))
-
         self.allow_restart_journal_messages()
         self.allow_hostkey_messages()
         # Might happen when killing the bridge.
@@ -246,6 +230,28 @@ class TestMultiMachineKeyAuth(MachineCase):
                                     "Error executing command as another user: Not authorized",
                                     "This incident has been reported.",
                                     "sudo: a password is required")
+
+        # No dashboard on Atomic Host
+        if m1.image in [ "continuous-atomic", "fedora-atomic", "rhel-atomic" ]:
+            return
+
+        b.go("/dashboard")
+        b.enter_page("/dashboard")
+        b.click('#dashboard-enable-edit')
+        b.wait_present("#dashboard-hosts .list-group-item[data-address='{0}']".format(m2.address))
+        b.wait_visible("#dashboard-hosts .list-group-item[data-address='{0}'] button.pficon-edit".format(m2.address))
+        b.click("#dashboard-hosts .list-group-item[data-address='{0}'] button.pficon-edit".format(m2.address))
+        b.wait_popup('host-edit-dialog')
+        b.wait_visible('#host-edit-user')
+        self.assertEqual(b.val("#host-edit-user"), "")
+        b.set_val('#host-edit-user', 'user')
+        b.click('#host-edit-apply')
+        b.wait_popdown('host-edit-dialog')
+        b.wait_not_present("iframe.container-frame[name='cockpit1:{0}/system']".format(m2.address))
+
+        b.click("#dashboard-hosts .list-group-item[data-address='{0}']".format(m2.address))
+        b.enter_page("/system", host="user@{0}".format(m2.address))
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-multi-os
+++ b/test/verify/check-multi-os
@@ -170,6 +170,7 @@ class TestMultiOS(MachineCase):
         self.allow_journal_messages("couldn't run usermod command: Child process exited with code 6")
         self.allow_journal_messages("usermod: user 'postfix' does not exist")
 
+    @skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
     def testFedora22(self):
         try:
             self.checkStock()
@@ -183,6 +184,7 @@ class TestMultiOSDirect(MachineCase):
         'fedora-23-stock': { 'machine': { 'image': 'fedora-23-stock' } }
     }
 
+    @skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
     def testFedora23Direct(self):
         b = self.browser
 

--- a/tools/debian/cockpit-dashboard.install
+++ b/tools/debian/cockpit-dashboard.install
@@ -1,0 +1,2 @@
+usr/lib/cockpit/cockpit-ssh
+usr/share/cockpit/dashboard/

--- a/tools/debian/cockpit-system.install
+++ b/tools/debian/cockpit-system.install
@@ -1,4 +1,3 @@
-usr/share/cockpit/dashboard/
 usr/share/cockpit/realmd/
 usr/share/cockpit/shell/
 usr/share/cockpit/systemd/

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -4,7 +4,6 @@ lib/systemd/system/cockpit.service
 lib/systemd/system/cockpit.socket
 lib/*/security/pam_ssh_add.so
 usr/lib/cockpit/cockpit-session
-usr/lib/cockpit/cockpit-ssh
 usr/lib/cockpit/cockpit-ws
 usr/lib/firewalld/services/cockpit.xml
 usr/sbin/remotectl

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -38,6 +38,7 @@ Package: cockpit
 Architecture: any
 Depends: ${misc:Depends},
          cockpit-bridge (= ${binary:Version}),
+         cockpit-dashboard (= ${binary:Version}),
          cockpit-ws (= ${binary:Version}),
          cockpit-system (= ${binary:Version}),
          xdg-utils
@@ -117,6 +118,16 @@ Provides: cockpit-realmd,
 Description: Cockpit admin interface for a system
  Cockpit admin interface package for configuring and
  troubleshooting a system.
+
+Package: cockpit-dashboard
+Architecture: any
+Depends: ${misc:Depends},
+         ${shlibs:Depends},
+         cockpit-ws (= ${binary:Version})
+Provides: cockpit-ssh
+Description: Cockpit SSH remoting and dashboard
+  Cockpit support for remoting to other servers, bastion hosts, and
+  a basic dashboard.
 
 Package: cockpit-storaged
 Architecture: any


### PR DESCRIPTION
Both the dashboard and cockpit-ssh process go into this subpackage: cockpit-dashboard
    
Note that until we have a stable interface between cockpit-ws and its authentication processes, we need to require identical versions between cockpit-ws and cockpit-dashboard.
    
In addition for the time being we have cockpit-ws unconditionally require cockpit-dashboard.

 * [x] Update packaging
 * [x] Decide on a good name: cockpit-dashboard

Depends on:

 * [x] #5600