### PR TITLE
subscriptions: Increase the status update timeout

### DIFF
--- a/pkg/subscriptions/subscriptions-client.js
+++ b/pkg/subscriptions/subscriptions-client.js
@@ -312,7 +312,7 @@ function requestUpdate() {
     updateTimeout = window.setTimeout(
         function() {
             statusUpdateFailed("timeout");
-        }, 30000);
+        }, 60000);
 }
 
 function processStatusOutput(text, exitDetails) {


### PR DESCRIPTION
We hit this 30 second timeout in the tests. That means people
may hit it in real life. Lets increase it.