### PR TITLE
test: Ignore journal 'was reauthorized' message more clearly

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -540,7 +540,7 @@ class MachineCase(unittest.TestCase):
 
         # Reauth stuff
         '.*Reauthorizing unix-user:.*',
-        '.*user .* was reauthorized',
+        'cockpit-polkit:.*user .* was reauthorized.*',
         'cockpit-polkit helper exited with status: 0',
 
         # Reboots are ok


### PR DESCRIPTION
On Ubuntu we see journal messages like this:

```
cockpit-polkit: user admin was reauthorizedcockpit-polkit:
```