### PR TITLE
test: Ignore another form of 'user was reauthorized'

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -541,7 +541,7 @@ class MachineCase(unittest.TestCase):
 
         # Reauth stuff
         '.*Reauthorizing unix-user:.*',
-        'cockpit-polkit:.*user .* was reauthorized.*',
+        '.*user .* was reauthorized.*',
         'cockpit-polkit helper exited with status: 0',
 
         # Reboots are ok


### PR DESCRIPTION
This is again seen on Ubuntu, which seems to have their
journal logging connected differntly. Catches the message:

Error: user admin was reauthorized

