### PR TITLE
test: Skip tun check-networking test on debian-unstable

### DIFF
--- a/test/verify/check-networking
+++ b/test/verify/check-networking
@@ -410,7 +410,7 @@ class TestNetworking(MachineCase):
         b.wait_visible("#networking")
         b.wait_not_present("#networking-interfaces tr[data-interface='tvlan']")
 
-    @skipImage("No 'tun' support", "centos-7", "rhel-atomic", "ubuntu-1604")
+    @skipImage("No 'tun' support", "debian-unstable", "centos-7", "rhel-atomic", "ubuntu-1604")
     def testOther(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
There doesn't seem to be support there. We see:

```
Error: Failed to add/activate new connection: Connection 'tun0' is not available on the device tun0 at this time.
Command 'nmcli --wait 0 dev con tun0' returned non-zero exit status 4
```