### PR TITLE
IE fixes

### DIFF
--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -408,6 +408,8 @@ on_login_complete (GObject *object,
   headers = cockpit_web_server_new_table ();
   response_data = cockpit_auth_login_finish (COCKPIT_AUTH (object), result, flags, headers, &error);
 
+  /* Never cache a login response */
+  cockpit_web_response_set_cache_type (response, COCKPIT_WEB_RESPONSE_NO_CACHE);
   if (error)
     {
       if (response_data)

--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -133,8 +133,19 @@
             /* Sets values for application, url_root and login_path */
             function setup_path_globals (path) {
                 var parser = document.createElement('a');
+                var base = document.baseURI;
+                var base_tags;
+                /* Some IEs don't support baseURI */
+                if (!base) {
+                    base_tags = document.getElementsByTagName ("base");
+                    if (base_tags.length > 0)
+                        base = base_tags[0].href;
+                    else
+                        base = "/";
+                }
+
                 path = path || "/";
-                parser.href = document.baseURI;
+                parser.href = base;
                 if (parser.pathname != "/") {
                     url_root = parser.pathname.replace(/^\/+|\/+$/g, '');
                     window.localStorage.setItem('url-root', url_root);


### PR DESCRIPTION
Have a fall back for when the browser doesn't provide ```document.baseURI``` and explicitly set no-cache on all login responses.

This should fix:
https://bugzilla.redhat.com/show_bug.cgi?id=1378810
https://bugzilla.redhat.com/show_bug.cgi?id=1393740