### PR TITLE
test: Work around phantomjs onLoadFinished being unreliable

### DIFF
--- a/test/containers/check-kubernetes
+++ b/test/containers/check-kubernetes
@@ -88,6 +88,7 @@ class TestKubernetesLogin(KubernetesContainerCase):
         self.wait_api_server(port=6443, scheme='https')
 
         b.reload()
+        b.wait_visible("#login")
         login("admin", "bad")
         b.wait_text_not("#login-error-message", "")
         b.wait_visible('#login-button')

--- a/test/verify/check-embed
+++ b/test/verify/check-embed
@@ -35,7 +35,6 @@ class TestEmbed(MachineCase):
         b.wait_present("#embed-loaded")
         b.set_val("#embed-address", "http://" + m.address)
         b.click("#embed-full")
-        b.expect_load()
         b.wait_present("iframe[name='embed-full'][loaded]")
         b.switch_to_frame("embed-full")
         b.wait_visible("#login")

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -603,7 +603,6 @@ class TestMultiMachine(MachineCase):
 
         b.eval_js('ph_set_attr("iframe[name=\'%s\']", "data-ready", null)' % frame)
         b.eval_js('ph_set_attr("iframe[name=\'%s\']", "src", "../playground/test.html?i=1#/")' % frame)
-        b.expect_load()
         b.wait_present("iframe.container-frame[name='%s'][data-ready]" % frame)
 
         b.enter_page("/playground/test", m2.address)

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -132,7 +132,6 @@ WantedBy=default.target
         b.switch_to_top()
         b.eval_js('ph_set_attr("iframe[name=\'%s\']", "data-ready", null)' % frame)
         b.eval_js('ph_set_attr("iframe[name=\'%s\']", "src", "../playground/test.html?i=1#/")' % frame)
-        b.expect_load()
         b.wait_present("iframe.container-frame[name='%s'][data-ready]" % frame)
 
         b.enter_page("/playground/test")


### PR DESCRIPTION
The page.onLoadFinished event gets triggered for frames, sometimes
out of order. So instead of trying to make that work, just use it
as a checkpoint in phantom-driver.js ... and actually check if the
page's document thinks its loaded and is at the right page.

We also use our injected canary to check when and if the page has
been reloaded.

 * If the URL is wrong the page is not yet loaded.
 * If the document.readyState is still loading the page is not (re)loaded.
 * If canary is still the same as before the page is not reloaded.