### PR TITLE
Use 'loginctl terminate-user' to kill a user session

### DIFF
--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -988,7 +988,7 @@ PageAccount.prototype = {
     },
 
     logout_account: function() {
-        cockpit.spawn(["/usr/bin/loginctl", "kill-user", this.account["name"]],
+        cockpit.spawn(["/usr/bin/loginctl", "terminate-user", this.account["name"]],
                       { "superuser": "try", err: "message"})
            .done($.proxy (this, "get_logged"))
            .fail(show_unexpected_error);

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -74,7 +74,7 @@ def add_machine(b, address, known_host=False):
     b.enter_page("/system", host=address)
 
 def kill_user_admin(machine):
-    machine.execute("loginctl kill-user admin")
+    machine.execute("loginctl terminate-user admin")
 
 def change_ssh_port(machine, port=None, timeout_sec=120):
     try:

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -31,7 +31,7 @@ import re
 def kill_user_admin(machine):
     # logind from systemd 208 is buggy, so we use systemd directly if it fails
     # https://bugs.freedesktop.org/show_bug.cgi?id=71092
-    machine.execute("loginctl kill-user admin || systemctl kill user-1000.slice")
+    machine.execute("loginctl terminate-user admin || systemctl kill user-1000.slice")
 
 def authorize_user(m, user):
     m.execute("mkdir -p /home/{0}/.ssh".format(user))

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -58,7 +58,7 @@ class TestSession(MachineCase):
         wait_session(True)
 
         # Kill session from the outside
-        m.execute("loginctl kill-user admin")
+        m.execute("loginctl terminate-user admin")
         wait_session(False)
 
         b.relogin("/system", "admin")


### PR DESCRIPTION
The kill-user command just sends a signal, doesn't actually
guarantee that the processes exit, or the session goes away.