### PR TITLE
test: Allow verify machines to rebase on non-master branches

### DIFF
--- a/test/common/testinfra.py
+++ b/test/common/testinfra.py
@@ -575,6 +575,7 @@ class GitHub(object):
             revision = pull["head"]["sha"]
             statuses = self.statuses(revision)
             login = pull["head"]["user"]["login"]
+            base = pull["base"]["ref"]  # The branch this pull request targets
 
             for context in contexts.keys():
                 status = statuses.get(context, None)
@@ -595,8 +596,8 @@ class GitHub(object):
 
                 (priority, changes) = self.prioritize(status, labels, baseline, context)
                 if update_status(revision, context, status, changes):
-                    results.append(GitHub.TaskEntry(priority, GithubPullTask("pull-%d" % number, revision,
-                                                                             "pull/%d/head" % number, context)))
+                    pulltask = GithubPullTask("pull-%d" % number, revision, "pull/%d/head" % number, context, base)
+                    results.append(GitHub.TaskEntry(priority, pulltask))
 
         return results
 

--- a/test/common/testpulltask.py
+++ b/test/common/testpulltask.py
@@ -23,11 +23,12 @@ import traceback
 import testinfra
 
 class GithubPullTask(object):
-    def __init__(self, name, revision, ref, context):
+    def __init__(self, name, revision, ref, context, base=None):
         self.name = name
         self.revision = revision
         self.ref = ref
         self.context = context
+        self.base = base or "master"
 
         self.sink = None
         self.github_status_data = None
@@ -119,13 +120,13 @@ class GithubPullTask(object):
 
     def rebase(self, offline=False):
         try:
-            sys.stderr.write("Rebasing onto origin/master ...\n")
+            sys.stderr.write("Rebasing onto origin/" + self.base + " ...\n")
             if not offline:
-                subprocess.check_call([ "git", "fetch", "origin", "master" ])
+                subprocess.check_call([ "git", "fetch", "origin", self.base ])
             if self.sink:
-                master = subprocess.check_output([ "git", "rev-parse", "origin/master" ]).strip()
+                master = subprocess.check_output([ "git", "rev-parse", "origin/" + self.base ]).strip()
                 self.sink.status["master"] = master
-            subprocess.check_call([ "git", "rebase", "origin/master" ])
+            subprocess.check_call([ "git", "rebase", "origin/" + self.base ])
             return None
         except:
             subprocess.call([ "git", "rebase", "--abort" ])


### PR DESCRIPTION
This allows us to start using our test suite against non-master
stuff ... it also forces cherry-picked changes to update the
test suite appropriately for their branch.