### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,1 @@
-debian-unstable-77f986b149b268ca5b59108cfe25cc746cbc6fa1.qcow2
+debian-unstable-694a895bd2a88a7abe200c808fbfa2a4dc53b66c.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on cockpit-9.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-11-11/