### PR TITLE
systemd: Sometimes the LoadError field is undefined

### DIFF
--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -644,7 +644,7 @@ $(function() {
                                            Unit: cur_unit,
                                            Since: since,
                                            HasLoadError: cur_unit.LoadState !== "loaded",
-                                           LoadError: cur_unit.LoadError[1],
+                                           LoadError: cur_unit.LoadError ? cur_unit.LoadError[1] : null,
                                            UnitFileState: cur_unit_file_state,
                                            TemplateDescription: template_description,
                                            UnitButton: unit_action_btn,


### PR DESCRIPTION
We see this on Debian Unstable. I'm unsure of the root cause.

@mvollmer Do you have any ideas how this would be happening? The LoadError field is something that has been around in the unit interface for years. It's not something new. In addition the top of this function checks for unit object validity. However, from a brief reading, none of the other access to properties of ```cur_unit``` would fail based on undefined properties.