### PR TITLE
Add radix to parseInt calls

### DIFF
--- a/pkg/kubernetes/scripts/charts.js
+++ b/pkg/kubernetes/scripts/charts.js
@@ -116,7 +116,7 @@
                     if (!maxSize || isNaN(maxSize)) {
                         maxSize = 64;
                     } else {
-                        maxSize = parseInt(maxSize);
+                        maxSize = parseInt(maxSize, 10);
                         if (maxSize < 5)
                             maxSize = 5;
                         else if (maxSize > 64)

--- a/pkg/lib/machines.js
+++ b/pkg/lib/machines.js
@@ -383,7 +383,7 @@
             }
 
             if (port_spot > -1) {
-                var port = parseInt(conn_to.substring(port_spot+1));
+                var port = parseInt(conn_to.substring(port_spot+1), 10);
                 if (!isNaN(port)) {
                     parts.port = port;
                     conn_to = conn_to.substring(0, port_spot);

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -345,7 +345,7 @@
         function pull_time() {
             return cockpit.spawn(["date", "+%s"])
                 .then(function (now) {
-                    client.time_offset = parseInt(now)*1000 - new Date().getTime();
+                    client.time_offset = parseInt(now, 10) * 1000 - new Date().getTime();
                 });
         }
 

--- a/pkg/storaged/dialog.js
+++ b/pkg/storaged/dialog.js
@@ -223,9 +223,9 @@
                 else if (f.SelectOne)
                     vals[n] = $f.val();
                 else if (f.SizeInput)
-                    vals[n] = parseInt($f.val())*1024*1024;
+                    vals[n] = parseInt($f.val(), 10)*1024*1024;
                 else if (f.SizeSlider)
-                    vals[n] = parseInt($f.val());
+                    vals[n] = parseInt($f.val(), 10);
                 else if (f.CheckBox)
                     vals[n] = $f.prop('checked');
                 else if (f.SelectMany) {

--- a/src/base1/test-http.js
+++ b/src/base1/test-http.js
@@ -319,7 +319,7 @@ QUnit.asyncTest("address with params", function() {
     // use our window's host and port to request external
     assert.expect(2);
 
-    cockpit.http({ port: parseInt(window.location.port),
+    cockpit.http({ port: parseInt(window.location.port, 10),
                    address: window.location.hostname })
         .get("/mock/qs", { "key": "value", "name": "Scruffy the Janitor" })
         .done(function(resp) {

--- a/test/common/log.html
+++ b/test/common/log.html
@@ -165,8 +165,8 @@ function extract(text) {
                 });
     var entries = [];
     if (m = tap_range.exec(text)) {
-        first = parseInt(m[1]);
-        last = parseInt(m[2]);
+        first = parseInt(m[1], 10);
+        last = parseInt(m[2], 10);
         total = last-first+1;
 
         passed = 0;
@@ -240,15 +240,15 @@ function extract(text) {
             entries.push({ idx: entry.idx, entry: entry, html: Mustache.render(entry_template, entry) });
         });
         entries.sort(function(a, b) {
-            a = isNaN(parseInt(a.idx)) ? a.idx : parseInt(a.idx)
-            b = isNaN(parseInt(b.idx)) ? b.idx : parseInt(b.idx)
+            a = isNaN(parseInt(a.idx), 10) ? a.idx : parseInt(a.idx, 10);
+            b = isNaN(parseInt(b.idx), 10) ? b.idx : parseInt(b.idx, 10);
             return a < b ? -1 : (a > b ? 1 : 0);
         });
         altered_text = Mustache.render(tests_template, { tests: entries });
         // for the overview list, put the failed entries first
         entries.sort(function(a, b) {
-                var a_idx = isNaN(parseInt(a.idx)) ? a.idx : parseInt(a.idx)
-                var b_idx = isNaN(parseInt(b.idx)) ? b.idx : parseInt(b.idx)
+                var a_idx = isNaN(parseInt(a.idx, 10)) ? a.idx : parseInt(a.idx, 10);
+                var b_idx = isNaN(parseInt(b.idx, 10)) ? b.idx : parseInt(b.idx, 10);
                 if (a.entry.skipped == b.entry.skipped)
                     return a_idx < b_idx ? -1 : (a_idx > b_idx ? 1 : 0);
                 else if (!a.entry.skipped)


### PR DESCRIPTION
Some versions of javascript use the first argument to guess the radix if none is provided.