### PR TITLE
lib: Don't dereference null machine in MachinePort.load()

### DIFF
--- a/pkg/lib/machine-dialogs.js
+++ b/pkg/lib/machine-dialogs.js
@@ -515,8 +515,10 @@
 
         self.load = function() {
             var machine = dialog.machines_ins.lookup(dialog.address);
-            if (!machine)
+            if (!machine) {
                 dialog.get_sel().modal('hide');
+                return;
+            }
 
             dialog.render({ 'port' : machine.port,
                             'allow_connection_string' : machines.allow_connection_string });


### PR DESCRIPTION
This fixes a flakey test, and likely a real world corner case.

@petervo The fact that this load() function calls the modal hide() seems dubious. Is that intended? Can you review this patch?