### PR TITLE
test: Add known issue for Fedora 25 storaged crash

### DIFF
--- a/test/verify/naughty-fedora-25/5378-storaged-udisksd-crash
+++ b/test/verify/naughty-fedora-25/5378-storaged-udisksd-crash
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+  File "./verify/check-storage-lvm2", line 113, in testLvm
+    "DISK2": True }})
+*
+Error: timeout
+Message recipient disconnected from message bus without replying


### PR DESCRIPTION
Known issue #5378

Storaged (the udisksd) process crashes. But we cannot
figure out the crash dump and start to diagnose the
issue due to SELinux getting in the way.