### PR TITLE
ws: Fix test-auth to ignore another warning in bad command test

### DIFF
--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -526,6 +526,8 @@ test_bad_command (Test *test,
   cockpit_expect_possible_log ("cockpit-ws", G_LOG_LEVEL_WARNING,
                                "*Auth pipe closed: internal-error*");
   cockpit_expect_possible_log ("cockpit-ws", G_LOG_LEVEL_WARNING,
+                               "*Auth pipe closed: not-found*");
+  cockpit_expect_possible_log ("cockpit-ws", G_LOG_LEVEL_WARNING,
                                "*Auth pipe closed: terminated*");
   cockpit_expect_possible_log ("cockpit-ws", G_LOG_LEVEL_WARNING,
                                "*couldn't write: Connection refused*");


### PR DESCRIPTION
The "bad command" test can produce all sorts of warnings because
it uses multiple processes. So lets add another one we're seeing
here:

```
cockpit-ws-WARNING **: bad-command: Auth pipe closed: not-found
**
cockpit-protocol:ERROR:src/ws/test-auth.c:533:test_bad_command: Got unexpected message: bad-command: Auth pipe closed: not-found instead of cockpit-protocol-Message: *couldn't write: Connection refused*
./test-auth terminated with SIGABRT
FAIL: test-auth 37 /auth/bad-command
```

@petervo Does this look right?