### PR TITLE
ws: Return 502 when external channel is disconnected

### DIFF
--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -234,7 +234,8 @@ cockpit_channel_response_close (CockpitChannelResponse *chesp,
       else if (g_str_equal (problem, "no-host") ||
                g_str_equal (problem, "no-cockpit") ||
                g_str_equal (problem, "unknown-hostkey") ||
-               g_str_equal (problem, "authentication-failed"))
+               g_str_equal (problem, "authentication-failed") ||
+               g_str_equal (problem, "disconnected"))
         {
           g_debug ("%s: remote server unavailable: %s", chesp->logname, problem);
           cockpit_web_response_error (chesp->response, 502, NULL, NULL);


### PR DESCRIPTION
This happens if while getting ready to serve a resource
from the bridge the bridge then disconnects. We already
handle thatcase during the serving of the resource, but
lets handle it appropriately if it happens at the start.

Related error message:

```
/base1/fonts/glyphicons.woff: external channel failed: disconnected
```