### PR TITLE
test: Favor older pull requests with the same priority

### DIFF
--- a/test/common/testinfra.py
+++ b/test/common/testinfra.py
@@ -581,6 +581,10 @@ class GitHub(object):
                 status = statuses.get(context, None)
                 baseline = BASELINE_PRIORITY
 
+                # modify the baseline slightly to favor older pull requests, so that we don't
+                # end up with a bunch of half tested pull requests
+                baseline += 1.0 - (min(100000, float(number)) / 100000)
+
                 # Only create new status for those requested
                 if not status:
                     if context not in pull_contexts:

--- a/test/github-scan
+++ b/test/github-scan
@@ -38,7 +38,7 @@ def main():
     github = testinfra.GitHub()
 
     for entry in github.scan(not opts.dry, opts.context, opts.except_context):
-        sys.stdout.write("{0}: {1}\n".format(entry.priority, entry.task.description()))
+        sys.stdout.write("{0}: {1}\n".format(int(entry.priority), entry.task.description()))
 
     for image, wait_time in github.scan_image_wait_times().items():
         # Images with wait_time <= 0 are already included in the list


### PR DESCRIPTION
That way we don't have a lot of half tested pull requests during
busy times.