### PR TITLE
Backport: kubernetes: Only set websocket protocols if we actually have them

### DIFF
--- a/pkg/kubernetes/scripts/kube-client-cockpit.js
+++ b/pkg/kubernetes/scripts/kube-client-cockpit.js
@@ -533,7 +533,7 @@
                     if (angular.isArray(protocols))
                         valid = base64 = protocols.indexOf("base64.channel.k8s.io") !== -1;
                     else
-                        valid = base64 = "base64.channel.k8s.io";
+                        valid = base64 = protocols === "base64.channel.k8s.io";
                 }
 
                 if (valid) {
@@ -609,7 +609,7 @@
                     channel = cockpit.channel(angular.extend({ }, options, {
                         payload: "websocket-stream1",
                         path: url,
-                        protocols: protocols,
+                        protocols: protocols.length > 0 ? protocols : undefined,
                     }));
 
                     channel.addEventListener("close", function(ev, options) {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1394675

Upstream commit:
d220e21d0eb75ca2361d77393d6840167001298b
    kubernetes: Only set websocket protocols if we actually have them

Signed-off-by: Stef Walter <stefw@redhat.com>
 * Brought in a single related line from fb72d3c4