### PR TITLE
test: Ignore message about cockpit-polkit in check-session test

### DIFF
--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -29,6 +29,7 @@ class TestSession(MachineCase):
         self.allow_restart_journal_messages()
         # Might happen when killing the bridge.
         self.allow_journal_messages("localhost: dropping message while waiting for child to exit",
+                                    "cockpit-polkit helper was terminated with signal: 15",
                                     ".*No session for cookie")
 
         def wait_session(should_exist):


### PR DESCRIPTION
This is a test that kills a user session, and produces messages
like this. Recently we changed this test so it actually works,
and now we're seeing the messages.