### PR TITLE
test: Ignore broken 'cockpit-polkit:' line in journal

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -543,6 +543,7 @@ class MachineCase(unittest.TestCase):
         '.*Reauthorizing unix-user:.*',
         '.*user .* was reauthorized.*',
         'cockpit-polkit helper exited with status: 0',
+        'cockpit-polkit:',
 
         # Reboots are ok
         "-- Reboot --",


### PR DESCRIPTION
This shows up due to poor journal integration on Jessie and Ubuntu.