### PR TITLE
Bump required cockpit version number in packages

### DIFF
--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -1,7 +1,7 @@
 {
     "version": "@VERSION@",
     "requires": {
-	"cockpit": "118"
+	"cockpit": "122"
     },
 
     "linguas": {

--- a/pkg/storaged/manifest.json
+++ b/pkg/storaged/manifest.json
@@ -2,7 +2,7 @@
     "version": "@VERSION@",
     "name": "storage",
     "requires": {
-	"cockpit": "118"
+	"cockpit": "122"
     },
 
     "menu": {


### PR DESCRIPTION
These weren't bumped along with the others.

Follow-up to https://github.com/cockpit-project/cockpit/commit/85261713fc21468664116b651ee5f6b10794bcf7
