### PR TITLE
bridge: Line buffer cockpit-polkit stderr output

### DIFF
--- a/src/bridge/cockpitpolkithelper.c
+++ b/src/bridge/cockpitpolkithelper.c
@@ -107,6 +107,9 @@ main (int argc, char *argv[])
   /* Cleanup the umask */
   umask (077);
 
+  /* Line buffering for stderr */
+  setvbuf(stderr, NULL, _IOLBF, 0);
+
   /* check that we are setuid root */
   if (geteuid () != 0)
     errx (2, "needs to be setuid root");


### PR DESCRIPTION
This gets mixed in with cockpit-bridge output since they share
the same fd on stderr. We can see this in the various test
instances from time to time. Make it clearer by line buffering
this output.