### PR TITLE
ws: Branding updates

### DIFF
--- a/doc/branding.md
+++ b/doc/branding.md
@@ -77,5 +77,5 @@ The ```branding.css``` file should override the following areas of the navigatio
         content: "${NAME} <b>${VARIANT}</b>";
     }
 
-Notice how we can use variables from ```/etc/os-release``` in the branding. This can
-only be done in the specific CSS selectors mentioned above.
+Notice how we can use variables from ```/etc/os-release``` in the branding.
+The value for these variables come from the machine that cockpit is logged into.

--- a/doc/urls.md
+++ b/doc/urls.md
@@ -13,7 +13,9 @@ are valid for any application, just replace ```/cockpit/``` with ```/cockpit+app
 
  * ```/cockpit/static``` static files available without authentication. Files
    are cached for as long as possible, and names *must* change when the
-   contents of the file changes.
+   contents of the file changes. The exception to this is when the application
+   refers to a different machine. In that case the user must be authenticated
+   to serve those files and the cache varies on cookie.
 
  * ```/cockpit/login``` authenticates a user and sets cookie based on application
  name.

--- a/src/bridge/mock-resource/system/cockpit/static/branding.css
+++ b/src/bridge/mock-resource/system/cockpit/static/branding.css
@@ -1,0 +1,3 @@
+#badge {
+    background-image: url("logo.png");
+}

--- a/src/common/cockpitjson.c
+++ b/src/common/cockpitjson.c
@@ -935,3 +935,47 @@ cockpit_json_write (JsonNode *node,
 
   return retval;
 }
+
+JsonObject *
+cockpit_json_from_hash_table (GHashTable *hash_table,
+                              const gchar **fields)
+{
+  JsonObject *block = NULL;
+  gint i;
+  const gchar *value;
+
+  if (hash_table)
+   {
+     block = json_object_new ();
+     for (i = 0; fields[i] != NULL; i++)
+       {
+         value = g_hash_table_lookup (hash_table, fields[i]);
+         if (value)
+           json_object_set_string_member (block, fields[i], value);
+         else
+           json_object_set_null_member (block, fields[i]);
+       }
+   }
+
+  return block;
+}
+
+GHashTable *
+cockpit_json_to_hash_table (JsonObject *object,
+                            const gchar **fields)
+{
+  gint i;
+  GHashTable *hash_table = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+
+  for (i = 0; fields[i] != NULL; i++)
+    {
+      const gchar *value;
+      if (!cockpit_json_get_string (object, fields[i], NULL, &value))
+        continue;
+
+      if (value)
+        g_hash_table_insert (hash_table, g_strdup (fields[i]), g_strdup (value));
+   }
+
+  return hash_table;
+}

--- a/src/common/cockpitjson.h
+++ b/src/common/cockpitjson.h
@@ -95,4 +95,9 @@ guint          cockpit_json_int_hash          (gconstpointer v);
 gboolean       cockpit_json_int_equal         (gconstpointer v1,
                                                gconstpointer v2);
 
+JsonObject *   cockpit_json_from_hash_table   (GHashTable *hash_table,
+                                               const gchar **fields);
+
+GHashTable *   cockpit_json_to_hash_table     (JsonObject *object,
+                                               const gchar **fields);
 #endif /* COCKPIT_JSON_H__ */

--- a/src/common/cockpitsystem.c
+++ b/src/common/cockpitsystem.c
@@ -28,6 +28,24 @@
 #include <string.h>
 #include <unistd.h>
 
+static const gchar *os_release_fields[] = {
+  "NAME",
+  "VERSION",
+  "ID",
+  "VERSION_ID",
+  "PRETTY_NAME",
+  "VARIANT",
+  "VARIANT_ID",
+  "CPE_NAME",
+  NULL
+};
+
+const gchar **
+cockpit_system_os_release_fields (void)
+{
+  return os_release_fields;
+}
+
 GHashTable *
 cockpit_system_load_os_release (void)
 {

--- a/src/common/cockpitsystem.h
+++ b/src/common/cockpitsystem.h
@@ -21,12 +21,17 @@
 #define __COCKPIT_SYSTEM_H__
 
 #include <glib.h>
+#include "cockpitjson.h"
 
 G_BEGIN_DECLS
 
 GHashTable *         cockpit_system_load_os_release            (void);
 
 GBytes *             cockpit_system_random_nonce               (gsize length);
+
+GHashTable *         cockpit_system_load_os_release            (void);
+
+const gchar **       cockpit_system_os_release_fields          (void);
 
 G_END_DECLS
 

--- a/src/common/cockpittemplate.c
+++ b/src/common/cockpittemplate.c
@@ -28,7 +28,9 @@
 #define VARCHARS "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._"
 
 static gchar *
-find_variable (const gchar *data,
+find_variable (const gchar *start_marker,
+               const gchar *end_marker,
+               const gchar *data,
                const gchar *end,
                const gchar **before,
                const gchar **after)
@@ -40,22 +42,20 @@ find_variable (const gchar *data,
 
   for (;;)
     {
-      /* Look for @@xxxx@@ */
-      a = memchr (data, '@', end - data);
+      /* Look for start_marker to end_marker */
+      a = memmem (data, strlen(data), start_marker, strlen (start_marker));
       if (a == NULL)
         return NULL;
-      data = a + 1;
-      if (data[0] != '@')
-        continue;
-      data++;
+
+      data = a + strlen (start_marker);
       b = data;
-      c = memchr (data, '@', end - data);
+
+      c = memmem (data, strlen(data), end_marker, strlen (end_marker));
       if (c == NULL)
         return NULL;
-      data = c + 1;
-      if (data[0] != '@')
-        continue;
-      d = data + 1;
+
+      data = c + strlen (end_marker);
+      d = data;
 
       /*
        * We've found a variable like this:
@@ -65,7 +65,6 @@ find_variable (const gchar *data,
        *
        * Check that the name makes sense.
        */
-
       if (b != c && b + strspn (b, VARCHARS) == c)
         break;
     }
@@ -80,6 +79,8 @@ find_variable (const gchar *data,
 GList *
 cockpit_template_expand (GBytes *input,
                          CockpitTemplateFunc func,
+                         const gchar *start_marker,
+                         const gchar *end_marker,
                          gpointer user_data)
 {
   GList *output = NULL;
@@ -97,7 +98,7 @@ cockpit_template_expand (GBytes *input,
 
   for (;;)
     {
-      name = find_variable (data, end, &before, &after);
+      name = find_variable (start_marker, end_marker, data, end, &before, &after);
       if (name == NULL)
         break;
 

--- a/src/common/cockpittemplate.h
+++ b/src/common/cockpittemplate.h
@@ -27,6 +27,8 @@ typedef GBytes * (* CockpitTemplateFunc)          (const gchar *variable,
 
 GList *           cockpit_template_expand         (GBytes *input,
                                                    CockpitTemplateFunc func,
+                                                   const gchar *start_marker,
+                                                   const gchar *end_marker,
                                                    gpointer user_data);
 
 #endif /* COCKPIT_TEMPLATE_H__ */

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -136,6 +136,10 @@ void         cockpit_web_response_set_cache_type         (CockpitWebResponse *se
 
 const gchar *  cockpit_web_response_get_url_root         (CockpitWebResponse *response);
 
+void           cockpit_web_response_template             (CockpitWebResponse *response,
+                                                          const gchar *escaped,
+                                                          const gchar **roots,
+                                                          GHashTable *values);
 
 G_END_DECLS
 

--- a/src/common/mock-content/test.css
+++ b/src/common/mock-content/test.css
@@ -1,0 +1,3 @@
+#brand {
+    content: "${NAME} <b>${VARIANT}</b>";
+}

--- a/src/common/test-json.c
+++ b/src/common/test-json.c
@@ -273,6 +273,44 @@ test_get_object (TestCase *tc,
 }
 
 static void
+test_hashtable_objects (void)
+{
+  JsonObject *object = json_object_new ();
+  GHashTable *ht = NULL;
+  const gchar *fields[] = {
+    "test",
+    "test2",
+    "test4",
+    "test5",
+    NULL,
+  };
+
+  json_object_set_string_member (object, "test", "one");
+  json_object_set_string_member (object, "test2", "two");
+  json_object_set_string_member (object, "test3", "three");
+  json_object_set_null_member (object, "test4");
+  json_object_set_string_member (object, "test5", "five");
+
+  ht = cockpit_json_to_hash_table (object, fields);
+  g_assert_cmpstr (g_hash_table_lookup (ht, "test"), ==, "one");
+  g_assert_cmpstr (g_hash_table_lookup (ht, "test2"), ==, "two");
+  g_assert_cmpstr (g_hash_table_lookup (ht, "test5"), ==, "five");
+  g_assert_false (g_hash_table_contains (ht, "test3"));
+  g_assert_false (g_hash_table_contains (ht, "test4"));
+  json_object_unref (object);
+
+  object = cockpit_json_from_hash_table (ht, fields);
+  g_assert_cmpstr (json_object_get_string_member (object, "test"), ==, "one");
+  g_assert_cmpstr (json_object_get_string_member (object, "test2"), ==, "two");
+  g_assert_cmpstr (json_object_get_string_member (object, "test5"), ==, "five");
+  g_assert_false (json_object_has_member (object, "test3"));
+  g_assert_true (json_object_get_null_member (object, "test4"));
+
+  json_object_unref (object);
+  g_hash_table_unref (ht);
+}
+
+static void
 test_int_hash (void)
 {
   gint64 one = 1;
@@ -670,6 +708,7 @@ main (int argc,
     }
 
   g_test_add_func ("/json/write/infinite-nan", test_write_infinite_nan);
+  g_test_add_func ("/json/hashtable-objects", test_hashtable_objects);
 
 
   return g_test_run ();

--- a/src/common/test-template.c
+++ b/src/common/test-template.c
@@ -60,18 +60,27 @@ lookup_table (const char *name,
 }
 
 typedef struct {
+  const char *start;
+  const char *end;
   const char *name;
   const char *input;
   const char *output[8];
 } Fixture;
 
 static const Fixture expand_fixtures[] = {
-  { "simple", "Test @@oh@@ suffix", { "Test ", "marmalade", " suffix", NULL } },
-  { "extra-at", "Te@st @@oh@@ suffix", { "Te@st ", "marmalade", " suffix", NULL } },
-  { "no-ending", "Test @@oh@@ su@@ffix", { "Test ", "marmalade", " su@@ffix", NULL } },
-  { "extra-at-after", "Test @@oh@@ su@@ff@ix", { "Test ", "marmalade", " su@@ff@ix", NULL } },
-  { "unknown", "Test @@unknown@@ suffix", { "Test ", "@@unknown@@", " suffix", NULL } },
-  { "lots", "Oh @@oh@@ says Scruffy @@empty@@ the @@Scruffy@@",
+  { "@@", "@@", "simple", "Test @@oh@@ suffix", { "Test ", "marmalade", " suffix", NULL } },
+  { "@@", "@@", "extra-at", "Te@st @@oh@@ suffix", { "Te@st ", "marmalade", " suffix", NULL } },
+  { "@@", "@@", "no-ending", "Test @@oh@@ su@@ffix", { "Test ", "marmalade", " su@@ffix", NULL } },
+  { "@@", "@@", "extra-at-after", "Test @@oh@@ su@@ff@ix", { "Test ", "marmalade", " su@@ff@ix", NULL } },
+  { "@@", "@@", "unknown", "Test @@unknown@@ suffix", { "Test ", "@@unknown@@", " suffix", NULL } },
+  { "@@", "@@", "lots", "Oh @@oh@@ says Scruffy @@empty@@ the @@Scruffy@@",
+      { "Oh ", "marmalade", " says Scruffy ", " the ", "janitor", NULL }
+  },
+  { "${", "}", "brackets-simple", "Test ${oh} suffix", { "Test ", "marmalade", " suffix", NULL } },
+  { "${", "}", "brackets-not-full", "Te$st ${oh} suffix", { "Te$st ", "marmalade", " suffix", NULL } },
+  { "${", "}", "brackets-no-ending", "Test ${oh} su${ffix", { "Test ", "marmalade", " su${ffix", NULL } },
+  { "${", "}", "brackets-unknown", "Test ${unknown} suffix", { "Test ", "${unknown}", " suffix", NULL } },
+  { "${", "}", "brackets-lots", "Oh ${oh} says Scruffy ${empty} the ${Scruffy}",
       { "Oh ", "marmalade", " says Scruffy ", " the ", "janitor", NULL }
   },
 };
@@ -88,7 +97,7 @@ test_expand (TestCase *tc,
 
   input = g_bytes_new_static (fixture->input, strlen (fixture->input));
 
-  output = cockpit_template_expand (input, lookup_table, tc->variables);
+  output = cockpit_template_expand (input, lookup_table, fixture->start, fixture->end, tc->variables);
   g_bytes_unref (input);
 
   for (i = 0, l = output; fixture->output[i] != NULL; i++, l = g_list_next (l))

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -23,6 +23,8 @@ libcockpit_ws_a_SOURCES = \
 	src/ws/cockpitauthprocess.c \
 	src/ws/cockpitcertificate.c \
 	src/ws/cockpitcertificate.h \
+	src/ws/cockpitbranding.h \
+	src/ws/cockpitbranding.c \
 	src/ws/cockpitchannelresponse.h \
 	src/ws/cockpitchannelresponse.c \
 	src/ws/cockpitchannelsocket.h \

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -840,7 +840,7 @@ cockpit_auth_spawn_login_async (CockpitAuth *self,
   result = g_simple_async_result_new (G_OBJECT (self), callback, user_data,
                                       cockpit_auth_spawn_login_async);
 
-  application = cockpit_auth_parse_application (path);
+  application = cockpit_auth_parse_application (path, NULL);
   authorization = cockpit_auth_steal_authorization (headers, connection,
                                                     &type, &conversation);
 
@@ -1058,7 +1058,7 @@ authenticated_for_headers (CockpitAuth *self,
   g_return_val_if_fail (self != NULL, FALSE);
   g_return_val_if_fail (in_headers != NULL, FALSE);
 
-  application = cockpit_auth_parse_application (path);
+  application = cockpit_auth_parse_application (path, NULL);
   if (!application)
     return NULL;
 
@@ -1352,7 +1352,8 @@ cockpit_auth_new (gboolean login_loopback)
 }
 
 gchar *
-cockpit_auth_parse_application (const gchar *path)
+cockpit_auth_parse_application (const gchar *path,
+                                gboolean *is_host)
 {
   const gchar *pos;
   gchar *tmp = NULL;
@@ -1390,6 +1391,9 @@ cockpit_auth_parse_application (const gchar *path)
     {
       val = g_strdup ("cockpit");
     }
+
+  if (is_host)
+    *is_host = application_parse_host (val) != NULL;
 
   g_free (tmp);
   return val;

--- a/src/ws/cockpitauth.h
+++ b/src/ws/cockpitauth.h
@@ -101,7 +101,8 @@ CockpitWebService *  cockpit_auth_check_cookie    (CockpitAuth *self,
                                                    const gchar *path,
                                                    GHashTable *in_headers);
 
-gchar *         cockpit_auth_parse_application    (const gchar *path);
+gchar *         cockpit_auth_parse_application    (const gchar *path,
+                                                   gboolean *is_host);
 
 GBytes *        cockpit_auth_steal_authorization      (GHashTable *headers,
                                                        GIOStream *connection,

--- a/src/ws/cockpitbranding.c
+++ b/src/ws/cockpitbranding.c
@@ -1,0 +1,227 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "common/cockpitwebserver.h"
+#include "common/cockpittransport.h"
+#include "common/cockpitsystem.h"
+
+#include "cockpitauth.h"
+#include "cockpitbranding.h"
+#include "cockpitsshtransport.h"
+#include "cockpitwebservice.h"
+
+static const gchar * const*
+get_system_data_dirs (void)
+{
+  const gchar *env;
+
+  env = g_getenv ("XDG_DATA_DIRS");
+  if (env && env[0])
+    return g_get_system_data_dirs ();
+
+  return NULL;
+}
+
+static void
+add_system_dirs (GPtrArray *dirs)
+{
+  const gchar * const* system;
+  system = get_system_data_dirs ();
+  while (system && system[0])
+    {
+      g_ptr_array_add (dirs, g_build_filename (system[0], "cockpit", "static", NULL));
+      system++;
+    }
+}
+
+gchar **
+cockpit_branding_calculate_static_roots (const gchar *os_id,
+                                         const gchar *os_variant_id,
+                                         gboolean is_local)
+{
+  GPtrArray *dirs;
+  gchar **roots;
+
+  dirs = g_ptr_array_new_with_free_func (g_free);
+
+  if (is_local)
+    add_system_dirs (dirs);
+
+  if (os_id)
+    {
+      if (os_variant_id)
+          g_ptr_array_add (dirs, g_strdup_printf (DATADIR "/cockpit/branding/%s-%s", os_id, os_variant_id));
+      g_ptr_array_add (dirs, g_strdup_printf (DATADIR "/cockpit/branding/%s", os_id));
+    }
+
+  if (!is_local)
+    add_system_dirs (dirs);
+
+  g_ptr_array_add (dirs, g_strdup (DATADIR "/cockpit/branding/default"));
+  g_ptr_array_add (dirs, g_strdup (DATADIR "/cockpit/static"));
+  g_ptr_array_add (dirs, NULL);
+
+  roots = cockpit_web_server_resolve_roots ((const gchar **)dirs->pdata);
+
+  g_ptr_array_free (dirs, TRUE);
+  return roots;
+}
+
+static void
+serve_branding_css_file (CockpitWebResponse *response,
+                         const gchar *path,
+                         const gchar **roots,
+                         GHashTable *os_release)
+{
+  if (os_release)
+    cockpit_web_response_template (response, path, roots, os_release);
+  else
+    cockpit_web_response_file (response, path, roots);
+}
+
+typedef struct {
+  const gchar *path;
+  CockpitWebResponse *response;
+  CockpitTransport *transport;
+} CockpitBrandingData;
+
+
+static void
+on_init_ready (GObject *object,
+               GAsyncResult *result,
+               gpointer user_data)
+{
+  CockpitBrandingData *data = user_data;
+
+  GHashTable *os_release = NULL;
+  gchar **roots = NULL;
+  JsonObject *os = NULL;
+  gboolean responded = FALSE;
+  JsonObject *init = NULL;
+
+  init = cockpit_web_service_get_transport_init_message_finish (COCKPIT_WEB_SERVICE (object),
+                                                                result);
+  if (!init)
+    goto out;
+
+  roots = g_object_get_data (G_OBJECT (data->transport), "static-roots");
+  if (!roots)
+    {
+      if (cockpit_json_get_object (init, "os-release", NULL, &os) && os)
+        os_release = cockpit_json_to_hash_table (os, cockpit_system_os_release_fields ());
+
+      if (os_release)
+        {
+          roots = cockpit_branding_calculate_static_roots (g_hash_table_lookup (os_release, "ID"),
+                                                           g_hash_table_lookup (os_release, "VARIANT_ID"),
+                                                           FALSE);
+          g_object_set_data_full (G_OBJECT (data->transport), "os-release", os_release,
+                                  (GDestroyNotify) g_hash_table_unref);
+        }
+      else
+        {
+          roots = cockpit_branding_calculate_static_roots (NULL, NULL, FALSE);
+        }
+
+      g_object_set_data_full (G_OBJECT (data->transport), "static-roots", roots,
+                              (GDestroyNotify) g_strfreev);
+    }
+  else
+    {
+      os_release = g_object_get_data (G_OBJECT (data->transport), "os-release");
+    }
+
+  serve_branding_css_file (data->response, data->path,
+                           (const gchar **)roots, os_release);
+  responded = TRUE;
+
+out:
+  if (!responded)
+    cockpit_web_response_error (data->response, 502, NULL, NULL);
+
+  g_object_unref (data->transport);
+  g_object_unref (data->response);
+  g_free (data);
+}
+
+
+
+static void
+serve_branding_css_with_init_data (CockpitWebService *service,
+                                   CockpitWebResponse *response,
+                                   const gchar *path)
+{
+  CockpitBrandingData *cbd = NULL;
+  JsonObject *open = json_object_new ();
+  cbd = g_new0 (CockpitBrandingData, 1);
+  cbd->response = g_object_ref (response);
+  cbd->path = path;
+
+  json_object_set_string_member (open, "host", "localhost");
+  cbd->transport = g_object_ref (cockpit_web_service_ensure_transport (service, open));
+  json_object_unref (open);
+
+  cockpit_web_service_get_transport_init_message_aysnc (service, cbd->transport,
+                                                        on_init_ready, cbd);
+}
+
+void
+cockpit_branding_serve (CockpitWebService *service,
+                        CockpitWebResponse *response,
+                        const gchar *full_path,
+                        const gchar *static_path,
+                        GHashTable *local_os_release,
+                        const gchar **local_roots)
+{
+  gboolean is_host = FALSE;
+  gchar *application = cockpit_auth_parse_application (full_path, &is_host);
+
+  /* Must be logged in to use a host url */
+  if (is_host && !service)
+    {
+      cockpit_web_response_error (response, 403, NULL, NULL);
+      goto out;
+    }
+
+  if (is_host)
+    cockpit_web_response_set_cache_type (response, COCKPIT_WEB_RESPONSE_CACHE_PRIVATE);
+  else
+    cockpit_web_response_set_cache_type (response, COCKPIT_WEB_RESPONSE_CACHE_FOREVER);
+
+  if (g_str_has_suffix (static_path, ".css"))
+    {
+      if (!is_host)
+        {
+          serve_branding_css_file (response, static_path, local_roots, local_os_release);
+        }
+      else
+        {
+          serve_branding_css_with_init_data (service, response, static_path);
+        }
+    }
+  else
+    {
+      cockpit_web_response_file (response, static_path, local_roots);
+    }
+
+out:
+  g_free (application);
+}

--- a/src/ws/cockpitbranding.h
+++ b/src/ws/cockpitbranding.h
@@ -1,0 +1,40 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __COCKPIT_BRANDING_H__
+#define __COCKPIT_BRANDING_H__
+
+G_BEGIN_DECLS
+
+#include "cockpitwebservice.h"
+
+gchar **        cockpit_branding_calculate_static_roots     (const gchar *os_id,
+                                                             const gchar *os_variant_id,
+                                                             gboolean is_local);
+
+void            cockpit_branding_serve                      (CockpitWebService *service,
+                                                             CockpitWebResponse *response,
+                                                             const gchar *full_path,
+                                                             const gchar *static_path,
+                                                             GHashTable *local_os_release,
+                                                             const gchar **local_roots);
+
+G_END_DECLS
+
+#endif /* __COCKPIT_BRANDING_H__ */

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -21,6 +21,7 @@
 
 #include "cockpithandlers.h"
 
+#include "cockpitbranding.h"
 #include "cockpitchannelresponse.h"
 #include "cockpitchannelsocket.h"
 #include "cockpitwebservice.h"
@@ -522,6 +523,9 @@ cockpit_handler_default (CockpitWebServer *server,
              g_str_has_prefix (path, "/cockpit+") ||
              g_str_equal (path, "/cockpit");
 
+  // Check for auth
+  service = cockpit_auth_check_cookie (data->auth, path, headers);
+
   /* Stuff in /cockpit or /cockpit+xxx */
   if (resource)
     {
@@ -535,15 +539,11 @@ cockpit_handler_default (CockpitWebServer *server,
         }
       else if (g_str_has_prefix (remainder, "/static/"))
         {
-          /* Static stuff is served without authentication */
-          cockpit_web_response_set_cache_type (response, COCKPIT_WEB_RESPONSE_CACHE_FOREVER);
-          cockpit_web_response_file (response, remainder + 8, data->static_roots);
+          cockpit_branding_serve (service, response, path, remainder + 8,
+                                  data->os_release, data->static_roots);
           return TRUE;
         }
     }
-
-  /* Remainder of stuff needs authentication */
-  service = cockpit_auth_check_cookie (data->auth, path, headers);
 
   if (resource)
     {

--- a/src/ws/cockpitwebservice.h
+++ b/src/ws/cockpitwebservice.h
@@ -81,6 +81,13 @@ gboolean                cockpit_web_service_parse_external   (JsonObject *open,
                                                               const gchar **content_disposition,
                                                               gchar ***protocols);
 
+void           cockpit_web_service_get_transport_init_message_aysnc  (CockpitWebService *self,
+                                                                      CockpitTransport *transport,
+                                                                      GAsyncReadyCallback callback,
+                                                                      gpointer user_data);
+
+JsonObject *   cockpit_web_service_get_transport_init_message_finish (CockpitWebService *self,
+                                                                      GAsyncResult *result);
 G_END_DECLS
 
 #endif /* __COCKPIT_WEB_SERVICE_H__ */

--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -96,7 +96,7 @@
                     if ((content[0] === '"' || content[0] === '\'') &&
                         len > 2 && content[len - 1] === content[0])
                         content = content.substr(1, len - 2);
-                    elt.innerHTML = format(content, environment["os-release"]) || def;
+                    elt.innerHTML = format(content) || def;
                 }
             }
 

--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -188,8 +188,21 @@
             function boot() {
                 window.onload = null;
 
-                brand("badge", "");
-                brand("brand", "Cockpit");
+                setup_path_globals (window.location.pathname);
+
+                // Setup title
+                var title = environment.title;
+                if (!title)
+                    title = environment.hostname;
+                document.title = title;
+
+                if (application.indexOf("cockpit+=") === 0) {
+                    id("brand").style.display = "none";
+                    id("badge").style.display = "none";
+                } else {
+                    brand("badge", "");
+                    brand("brand", "Cockpit");
+                }
 
                 id("option-group").addEventListener("click", toggle_options);
                 id("server-clear").addEventListener("click", function () {
@@ -206,8 +219,6 @@
                 if (logout_intent)
                     sessionStorage.removeItem("logout-intent");
                 localStorage.setItem('os-release', os_release);
-
-                setup_path_globals (window.location.pathname);
 
                 /* Try automatic/kerberos authentication? */
                 if (oauth) {
@@ -407,12 +418,7 @@
 
             function show_login() {
                 /* Show the login screen */
-                var title = environment.title;
-                if (!title)
-                    title = environment.hostname;
-
-                document.title = title;
-                id("server-name").textContent = title;
+                id("server-name").textContent = document.title;
                 login_note("Log in with your server user account.");
                 id("login-user-input").addEventListener("keydown", function(e) {
                     login_failure(null);

--- a/src/ws/mock-auth.c
+++ b/src/ws/mock-auth.c
@@ -76,7 +76,9 @@ mock_auth_login_async (CockpitAuth *auth,
 
   result = g_simple_async_result_new (G_OBJECT (auth), callback, user_data, NULL);
 
-  g_object_set_data_full (G_OBJECT (result), "application", cockpit_auth_parse_application (path), g_free);
+  g_object_set_data_full (G_OBJECT (result), "application",
+                          cockpit_auth_parse_application (path, NULL),
+                          g_free);
 
   userpass = cockpit_auth_steal_authorization (headers, connection, &type, &conversation);
   if (userpass && g_str_equal (type, "basic"))

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -94,48 +94,60 @@ test_application (Test *test,
                   gconstpointer data)
 {
   gchar *application = NULL;
+  gboolean is_host = FALSE;
 
-  application = cockpit_auth_parse_application ("/");
+  application = cockpit_auth_parse_application ("/", &is_host);
   g_assert_cmpstr ("cockpit", ==, application);
+  g_assert_false (is_host);
   g_clear_pointer (&application, g_free);
 
-  application = cockpit_auth_parse_application ("/=");
+  application = cockpit_auth_parse_application ("/=", &is_host);
   g_assert_cmpstr ("cockpit", ==, application);
+  g_assert_false (is_host);
   g_clear_pointer (&application, g_free);
 
-  application = cockpit_auth_parse_application ("/other/other");
+  application = cockpit_auth_parse_application ("/other/other", &is_host);
   g_assert_cmpstr ("cockpit", ==, application);
+  g_assert_false (is_host);
   g_clear_pointer (&application, g_free);
 
-  application = cockpit_auth_parse_application ("/=other/other");
+  application = cockpit_auth_parse_application ("/=other/other", &is_host);
+  g_assert_true (is_host);
   g_assert_cmpstr ("cockpit+=other", ==, application);
   g_clear_pointer (&application, g_free);
 
-  application = cockpit_auth_parse_application ("/=other");
+  application = cockpit_auth_parse_application ("/=other", &is_host);
+  g_assert_true (is_host);
   g_assert_cmpstr ("cockpit+=other", ==, application);
   g_clear_pointer (&application, g_free);
 
-  application = cockpit_auth_parse_application ("/=other/");
+  application = cockpit_auth_parse_application ("/=other/", &is_host);
+  g_assert_true (is_host);
   g_assert_cmpstr ("cockpit+=other", ==, application);
   g_clear_pointer (&application, g_free);
 
-  application = cockpit_auth_parse_application ("/cockpit");
+  application = cockpit_auth_parse_application ("/cockpit", &is_host);
   g_assert_cmpstr ("cockpit", ==, application);
+  g_assert_false (is_host);
   g_clear_pointer (&application, g_free);
 
-  application = cockpit_auth_parse_application ("/cockpit/login");
+  application = cockpit_auth_parse_application ("/cockpit/login", &is_host);
   g_assert_cmpstr ("cockpit", ==, application);
+  g_assert_false (is_host);
   g_clear_pointer (&application, g_free);
 
-  application = cockpit_auth_parse_application ("/cockpit+application");
+  application = cockpit_auth_parse_application ("/cockpit+application", &is_host);
+  g_assert_cmpstr ("cockpit+application", ==, application);
+  g_assert_false (is_host);
+  g_clear_pointer (&application, g_free);
+
+  application = cockpit_auth_parse_application ("/cockpit+application/", &is_host);
+  g_assert_false (is_host);
   g_assert_cmpstr ("cockpit+application", ==, application);
   g_clear_pointer (&application, g_free);
 
-  application = cockpit_auth_parse_application ("/cockpit+application/");
-  g_assert_cmpstr ("cockpit+application", ==, application);
-  g_clear_pointer (&application, g_free);
-
-  application = cockpit_auth_parse_application ("/cockpit+application/other/other");
+  application = cockpit_auth_parse_application ("/cockpit+application/other/other", &is_host);
+  g_assert_false (is_host);
   g_assert_cmpstr ("cockpit+application", ==, application);
   g_clear_pointer (&application, g_free);
 }

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -675,16 +675,32 @@ static const DefaultFixture fixture_resource_login = {
 
 static const DefaultFixture fixture_static_simple = {
   .path = "/cockpit/static/branding.css",
-  .auth = NULL,
+  .auth = "/cockpit",
   .expect = "HTTP/1.1 200*"
+    "Cache-Control: max-age=31556926, public*"
     "#badge*"
     "url(\"logo.png\");*"
+};
+
+static const DefaultFixture fixture_host_static = {
+  .path = "/cockpit+=host/static/branding.css",
+  .auth = "/cockpit+=host",
+  .expect = "HTTP/1.1 200*"
+    "Cache-Control: max-age=86400, private*"
+    "#badge*"
+    "url(\"logo.png\");*"
+};
+
+static const DefaultFixture fixture_host_static_no_auth = {
+  .path = "/cockpit+=host/static/branding.css",
+  .expect = "HTTP/1.1 403*"
 };
 
 static const DefaultFixture fixture_static_application = {
   .path = "/cockpit+application/static/branding.css",
   .auth = NULL,
   .expect = "HTTP/1.1 200*"
+    "Cache-Control: max-age=31556926, public*"
     "#badge*"
     "url(\"logo.png\");*"
 };
@@ -876,6 +892,10 @@ main (int argc,
               setup_default, test_default, teardown_default);
 
   g_test_add ("/handlers/static/simple", Test, &fixture_static_simple,
+              setup_default, test_default, teardown_default);
+  g_test_add ("/handlers/static/host-static", Test, &fixture_host_static,
+              setup_default, test_default, teardown_default);
+  g_test_add ("/handlers/static/host-static-no-auth", Test, &fixture_host_static_no_auth,
               setup_default, test_default, teardown_default);
   g_test_add ("/handlers/static/application", Test, &fixture_static_application,
               setup_default, test_default, teardown_default);

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -205,6 +205,11 @@ class TestMultiMachine(MachineCase):
         m = self.machine
 
         name = self.machine.execute("hostname")
+
+        # Change os-release pretty name on m2
+        m2.execute("sed -i '/NAME=.*/d' /etc/os-release")
+        m2.execute("echo 'NAME=\"A Pretty Name\"' >> /etc/os-release")
+
         b.switch_to_top()
         b.go("{}/system".format(root));
         b.enter_page("/system")
@@ -221,6 +226,8 @@ class TestMultiMachine(MachineCase):
         b.open("{0}={1}".format(root, m2.address))
         b.wait_visible("#login")
         b.wait_visible("#server-name")
+        b.wait_not_visible("#badge")
+        b.wait_not_visible("#brand")
         b.wait_in_text("#server-name", m2.address)
         b.set_val("#login-user-input", "admin")
         b.set_val("#login-password-input", "alt-password")
@@ -229,7 +236,11 @@ class TestMultiMachine(MachineCase):
         b.enter_page("/system")
         b.wait_in_text('#system_information_hostname_button', "machine2")
         b.switch_to_top()
+
+        # Branding uses m2 pretty name
+        b.wait_in_text ("#index-brand", "A Pretty Name")
         b.wait_js_cond('window.location.pathname == "{0}={1}/system"'.format(root, m2.address))
+
         b.click("a[href='/dashboard']")
         b.enter_page("/dashboard")
         b.wait_present("a[data-address='localhost']")

--- a/test/verify/check-multi-os
+++ b/test/verify/check-multi-os
@@ -208,6 +208,8 @@ class TestMultiOSDirect(MachineCase):
         # Access stock directly from dev
         b.open("/={}".format(stock_m.address))
         b.wait_visible("#login")
+        b.wait_not_visible("#badge")
+        b.wait_not_visible("#brand")
         b.set_val("#login-user-input", "admin")
         b.set_val("#login-password-input", "foobar")
         b.click('#login-button')
@@ -221,6 +223,9 @@ class TestMultiOSDirect(MachineCase):
         b.wait_visible("body")
         b.wait_in_text('#system_information_hostname_button', "stock")
         b.switch_to_top()
+
+        # Branding uses default because there is no os information
+        b.wait_in_text("#index-brand", "Cockpit")
         b.wait_js_cond('window.location.pathname.indexOf("shell/index.html") > -1')
 
 if __name__ == '__main__':


### PR DESCRIPTION
Improve branding when connected to a different machine

Hide some branding on login page when connecting directly to another machine.

Provide the OS release data to static css files and process them as a template. This allows us to brand based on the actual machine we are connected to rather than the machine that cockpit-ws is running.