### PR TITLE
systemd: Fix regression where datepicker doesn't show up

### DIFF
--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -10,7 +10,7 @@
     <script src="../base1/cockpit.js"></script>
     <script src="../shell/po.js"></script>
 </head>
-<body hidden>
+<body id="services-page" hidden>
 
   <script id="services-units-tmpl" type="x-template/mustache">
     <div class="panel panel-default">

--- a/pkg/systemd/timer.css
+++ b/pkg/systemd/timer.css
@@ -128,7 +128,8 @@ input#boot-time {
     line-height: 14px;
 }
 
-.datepicker-dropdown, .prev, .next {
+#services-page .datepicker-dropdown .prev,
+#services-page .datepicker-dropdown .next {
     display: none;
     visibility: hidden;
 }


### PR DESCRIPTION
The datepicker doesn't show up anymore in the System Time
dialog. This happened since the timer code was merged and
the CSS was reorganized there.