### PR TITLE
autogen.sh: Add force flag to bower update command

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -43,7 +43,7 @@ find node_modules -name test | xargs rm -rf
 
 # Build dependencies: See bower_components/README
 find bower_components -mindepth 1 -name README -prune -o -print | xargs rm -rf
-node_modules/.bin/bower update
+node_modules/.bin/bower -f update
 
 rm -rf autom4te.cache
 


### PR DESCRIPTION
This prevents bower from asking silly questions about versions.
We already specify all the versions in the file.