### PR TITLE
Scheduled shutdown date

### DIFF
--- a/pkg/shell/shell.css
+++ b/pkg/shell/shell.css
@@ -439,22 +439,6 @@ html.index-page body {
     border: none;
 }
 
-#shutdown-dialog td {
-  padding-right: 20px;
-}
-
-#shutdown-dialog .opt {
-  padding: 1px 10px;
-}
-
-#shutdown-delay {
-  min-width: 150px;
-}
-
-#shutdown-group {
-  overflow: visible;
-}
-
 #systime-date-input {
     display: inline;
     width: 150px;

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -167,19 +167,36 @@ a.disabled {
 #sich-note-2 {
     margin: 0;
 }
+#shutdown-dialog td {
+  padding-right: 20px;
+  vertical-align: top;
+}
 
-#shutdown-message {
+#shutdown-dialog .opt {
+  padding: 1px 10px;
+}
+
+#shutdown-dialog .dropdown {
+  min-width: 150px;
+}
+
+#shutdown-group {
+  overflow: visible;
+}
+
+#shutdown-dialog textarea {
     resize: none;
     margin-bottom: 10px;
 }
 
-#shutdown-time input {
-    width: 3em;
+#shutdown-dialog input {
     display: inline;
+    width: 10em;
 }
 
-#shutdown-time span {
-    font-weight: bold;
+#shutdown-dialog .shutdown-hours,
+#shutdown-dialog .shutdown-minutes {
+    width: 3em;
 }
 
 #system_information_ssh_keys .list-group-item {

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -472,14 +472,27 @@
                                 </div>
                             </td>
                             <td>
-                                <div id="shutdown-time">
-                                    <input class="form-control" value="18"/>
-                                    <span>:</span>
-                                    <input class="form-control" value="00"/>
+                                <div class="row" id="shutdown-time">
+                                    <div class="col-md-7">
+                                        <input type='text' class="col-md-offset-1 form-control"
+                                            id="shutdown-date-input"/>
+                                    </div>
+                                    <div class="col-md-5 row nomargin nopadding">
+                                        <div class="col-md-offset-1 col-md-5 nopadding">
+                                            <input type='text' class="form-control" id="shutdown-time-hours"/>
+                                        </div>
+                                        <div class="col-md-1 text-center nopadding">:</div>
+                                        <div class="col-md-5 nopadding">
+                                            <input type='text' class="form-control" id="shutdown-time-minutes"/>
+                                        </div>
+                                    </div>
                                 </div>
                             </td>
                         </tr>
                     </table>
+                    <div class="has-error">
+                        <span id="shutdown-parse-error" class="help-block"></span>
+                    </div>
                 </div>
                 <div class="modal-footer">
                     <button class="btn btn-default btn-danger" translatable="yes" data-dismiss="modal">

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -447,12 +447,14 @@
                     <h4 class="modal-title"></h4>
                 </div>
                 <div class="modal-body">
-                    <textarea class="form-control" id="shutdown-message">
+                    <textarea class="form-control">
                     </textarea>
                     <table>
                         <tr>
-                            <td translatable="yes">Delay</td>
-                            <td id="shutdown-delay">
+                            <td>
+                                <label translatable="yes">Delay</label>
+                            </td>
+                            <td>
                                 <div class="btn-group bootstrap-select dropdown form-control">
                                     <button class="btn btn-default dropdown-toggle" type="button"
                                         data-toggle="dropdown">
@@ -472,33 +474,21 @@
                                 </div>
                             </td>
                             <td>
-                                <div class="row" id="shutdown-time">
-                                    <div class="col-md-7">
-                                        <input type='text' class="col-md-offset-1 form-control"
-                                            id="shutdown-date-input"/>
-                                    </div>
-                                    <div class="col-md-5 row nomargin nopadding">
-                                        <div class="col-md-offset-1 col-md-5 nopadding">
-                                            <input type='text' class="form-control" id="shutdown-time-hours"/>
-                                        </div>
-                                        <div class="col-md-1 text-center nopadding">:</div>
-                                        <div class="col-md-5 nopadding">
-                                            <input type='text' class="form-control" id="shutdown-time-minutes"/>
-                                        </div>
-                                    </div>
+                                <div>
+                                    <input class="form-control shutdown-date" type="text">
+                                    <input class="form-control shutdown-hours" type="text">
+                                    :
+                                    <input class="form-control shutdown-minutes" type="text">
                                 </div>
                             </td>
                         </tr>
                     </table>
-                    <div class="has-error">
-                        <span id="shutdown-parse-error" class="help-block"></span>
-                    </div>
                 </div>
                 <div class="modal-footer">
-                    <button class="btn btn-default btn-danger" translatable="yes" data-dismiss="modal">
+                    <button class="btn btn-default" translatable="yes" data-dismiss="modal">
                         Cancel
                     </button>
-                    <button class="btn btn-danger" id="shutdown-action">
+                    <button class="btn btn-danger">
                     </button>
                 </div>
             </div>

--- a/pkg/systemd/shutdown.js
+++ b/pkg/systemd/shutdown.js
@@ -1,0 +1,181 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+var $ = require("jquery");
+var cockpit = require("cockpit");
+
+/* These add themselves to jQuery so just including is enough */
+require("patterns");
+require("bootstrap-datepicker/dist/js/bootstrap-datepicker");
+
+var _ = cockpit.gettext;
+
+/* The server time object */
+var server_time = null;
+
+/* The current operation */
+var operation = null;
+
+/* The entry point, shows the dialog */
+module.exports = function shutdown(op, st) {
+    operation = op;
+    server_time = st;
+    $('#shutdown-dialog').modal('show');
+};
+
+$('#shutdown-dialog .shutdown-date').datepicker({
+    autoclose: true,
+    todayHighlight: true,
+    format: 'yyyy-mm-dd',
+    startDate: "today",
+});
+
+$("#shutdown-dialog input")
+    .on('focusout', update)
+    .on('change', update);
+
+/* The delay in the dialog */
+var delay = 0;
+$("#shutdown-dialog .dropdown li")
+    .on("click", function(ev) {
+        delay = $(this).attr("value");
+        update();
+    });
+
+/* Prefilling the date if it's been set */
+var cached_date = null;
+$('#shutdown-dialog .shutdown-date')
+    .on('focusin', function() {
+        cached_date = $(this).val();
+    })
+    .on('focusout', function() {
+        if ($(this).val().length === 0)
+            $(this).val(cached_date);
+    });
+
+$("#shutdown-dialog").on("show.bs.modal", function(ev) {
+
+    /* The date picker also triggers this event, since it is modal */
+    if (ev.target.id !== "shutdown-dialog")
+        return;
+
+    $("#shutdown-dialog textarea").
+        val("").
+        attr("placeholder", _("Message to logged in users")).
+        attr("rows", 5);
+
+    /* Track the value correctly */
+    delay = $("#shutdown-dialog li:first-child").attr("value");
+
+    server_time.wait().then(function() {
+        $('#shutdown-dialog .shutdown-date').val(server_time.format());
+        $('#shutdown-dialog .shutdown-hours').val(server_time.utc_fake_now.getUTCHours());
+        $('#shutdown-dialog .shutdown-minutes').val(server_time.utc_fake_now.getUTCMinutes());
+    });
+
+    if (operation == 'shutdown') {
+        $('#shutdown-dialog .modal-title').text(_("Shut Down"));
+        $("#shutdown-dialog .btn-danger").text(_("Shut Down"));
+    } else {
+        $('#shutdown-dialog .modal-title').text(_("Restart"));
+        $("#shutdown-dialog .btn-danger").text(_("Restart"));
+    }
+
+    update();
+});
+
+function update() {
+    $("#shutdown-dialog input").parent().toggle(delay == "x");
+    $("#shutdown-dialog .dropdown button span").text($("#shutdown-dialog li[value='" + delay + "']").text());
+
+    var val = parseInt($('#shutdown-dialog .shutdown-minutes').val(), 10);
+    if (val < 10)
+        $('#shutdown-dialog .shutdown-minutes').val("0" + val);
+}
+
+/* Validate the input fields */
+function calculate() {
+    if (delay != "x")
+        return cockpit.resolve("+" + delay);
+
+    var datestr = $("#shutdown-dialog .shutdown-date").val();
+    var hourstr = $("#shutdown-dialog .shutdown-hours").val();
+    var minstr = $("#shutdown-dialog .shutdown-minutes").val();
+
+    var h = parseInt(hourstr, 10);
+    var m = parseInt(minstr, 10);
+
+    var time_error = false;
+    if (isNaN(h) || h < 0 || h > 23  ||
+        isNaN(m) || m < 0 || m > 59) {
+        time_error = true;
+    }
+
+    var date = new Date(datestr);
+
+    var date_error = false;
+    if (isNaN(date.getTime()) || date.getTime() < 0)
+        date_error = true;
+
+    var ex = null;
+    if (time_error && date_error) {
+        ex = new Error(_("Invalid date format and invalid time format"));
+    } else if (time_error) {
+        ex = new Error (_("Invalid time format"));
+    } else if (date_error) {
+        ex = new Error (_("Invalid date format"));
+    }
+
+    if (ex) {
+        ex.target = "table td:last-child div";
+        return cockpit.reject(ex);
+    }
+
+    var cmd = ["date", "--date=" + datestr + " " + hourstr + ":" + minstr, "+%s"];
+    return cockpit.spawn(cmd, { err: "message" }).then(function(data) {
+        var input_timestamp = parseInt(data, 10);
+        var server_timestamp = parseInt(server_time.now.getTime() / 1000, 10);
+        var offset = Math.ceil((input_timestamp - server_timestamp) / 60);
+        if (offset < 0) {
+            console.log("Shutdown offset in minutes is in the past:", offset);
+            ex = new Error(_("Cannot schedule event in the past"));
+            ex.target = "table td:last-child div";
+            return cockpit.reject(ex);
+        }
+
+        return "+" + offset;
+    });
+}
+
+/* Perform the actual action */
+function perform(message) {
+    return calculate().then(function(when) {
+        var arg = (operation == "shutdown") ? "--poweroff" : "--reboot";
+        var message = $("#shutdown-dialog textarea").val();
+        if (operation == "restart")
+            cockpit.hint("restart");
+        return cockpit.spawn(["shutdown", arg, when, message], { superuser: true, err: "message" });
+    });
+}
+
+/* Perform the action */
+
+$("#shutdown-dialog .btn-danger").click(function() {
+    $("#shutdown-dialog").dialog("promise", perform());
+});

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -231,6 +231,9 @@ class Browser:
     def wait_val(self, selector, val):
         return self.wait_js_func('ph_has_val', selector, val)
 
+    def wait_not_val(self, selector, val):
+        return self.wait_js_func('!ph_has_val', selector, val)
+
     def wait_attr(self, selector, attr, val):
         return self.wait_js_func('ph_has_attr', selector, attr, val)
 

--- a/test/verify/check-shutdown-restart
+++ b/test/verify/check-shutdown-restart
@@ -52,10 +52,10 @@ class TestShutdownRestart(MachineCase):
         m.reset_reboot_flag()
         b.click("#shutdown-group button.btn-danger")
         b.wait_popup("shutdown-dialog")
-        b.wait_in_text("#shutdown-action", 'Restart')
-        b.click("#shutdown-delay button")
+        b.wait_in_text("#shutdown-dialog .btn-danger", 'Restart')
+        b.click("#shutdown-dialog .dropdown button")
         b.click("a:contains('No Delay')")
-        b.click("#shutdown-action")
+        b.click("#shutdown-dialog .btn-danger")
         b.switch_to_top()
 
         b.wait_visible(".curtains-ct")
@@ -93,10 +93,10 @@ class TestShutdownRestart(MachineCase):
         m.reset_reboot_flag()
         b2.click("#shutdown-group button.btn-danger")
         b2.wait_popup("shutdown-dialog")
-        b2.wait_in_text("#shutdown-action", 'Restart')
-        b2.click("#shutdown-delay button")
+        b2.wait_in_text("#shutdown-dialog .btn-danger", 'Restart')
+        b2.click("#shutdown-dialog .dropdown button")
         b2.click("a:contains('No Delay')")
-        b2.click("#shutdown-action")
+        b2.click("#shutdown-dialog .btn-danger")
         b2.switch_to_top()
 
         b2.wait_visible(".curtains-ct")
@@ -108,17 +108,26 @@ class TestShutdownRestart(MachineCase):
         b2.wait_not_visible(".curtains-ct")
         b2.enter_page("/system", host=m.address, reconnect=False)
 
-        # Poweroff
+        # Power off with invalid date
         self.login_and_go("/system")
         b.enter_page("/system")
         b.click("#shutdown-group span.caret")
         b.click("#shutdown-group a:contains('Shut Down')")
         b.wait_popup("shutdown-dialog")
-        b.wait_in_text("#shutdown-action", 'Shut Down')
-        b.click("#shutdown-delay button")
-        b.click("a:contains('No Delay')")
-        b.click("#shutdown-action")
+        b.click("#shutdown-dialog .dropdown button")
+        b.click("a:contains('Specific Time')")
+        b.wait_not_val("#shutdown-dialog input.shutdown-hours", "")
+        old = b.val("#shutdown-dialog input.shutdown-hours")
+        b.set_val("#shutdown-dialog input.shutdown-hours", "blah")
+        b.click("#shutdown-dialog .btn-danger")
+        b.wait_present("#shutdown-dialog .dialog-error")
+        b.wait_text("#shutdown-dialog .dialog-error", "Invalid time format")
+
+        # Now set a correct time and power off
+        b.set_val("#shutdown-dialog input.shutdown-hours", old)
+        b.click("#shutdown-dialog .btn-danger")
         b.switch_to_top()
+
         # we don't need to wait for the dialog to close here, just the disconnect
         b.wait_visible(".curtains-ct")
         b.wait_in_text(".curtains-ct h1", "Disconnected")


### PR DESCRIPTION
Finishes work in #2419

And refactor the shutdown dialog into its own file and use the standard jQuery patterns and promises.

Also add tests for the new specific time functionality.

Closes #2419
Fixes #33

Depends on: 

* [x] #5415 
* [x] #2419