### PR TITLE
test: Ignore another message in check-session

### DIFF
--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -30,6 +30,7 @@ class TestSession(MachineCase):
         # Might happen when killing the bridge.
         self.allow_journal_messages("localhost: dropping message while waiting for child to exit",
                                     "cockpit-polkit helper was terminated with signal: 15",
+                                    "Error executing command as another user: Not authorized"
                                     ".*No session for cookie")
 
         def wait_session(should_exist):


### PR DESCRIPTION
This happens because we terminate the session, and various
messages can result.