### PR TITLE
bridge: Process "host" field in "init" message

### DIFF
--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -388,7 +388,7 @@ run_bridge (const gchar *interactive,
   gboolean terminated = FALSE;
   gboolean interupted = FALSE;
   gboolean closed = FALSE;
-  gboolean init_received = FALSE;
+  const gchar *init_host = NULL;
   GHashTable *os_release = NULL;
   CockpitPortal *super = NULL;
   CockpitPortal *pcp = NULL;
@@ -467,7 +467,7 @@ run_bridge (const gchar *interactive,
   if (interactive)
     {
       /* Allow skipping the init message when interactive */
-      init_received = TRUE;
+      init_host = "localhost";
       transport = cockpit_interact_transport_new (0, outfd, interactive);
     }
   else
@@ -488,7 +488,7 @@ run_bridge (const gchar *interactive,
 
   pcp = cockpit_portal_new_pcp (transport);
 
-  bridge = cockpit_bridge_new (transport, payload_types, init_received);
+  bridge = cockpit_bridge_new (transport, payload_types, init_host);
   cockpit_dbus_user_startup (pwd);
   cockpit_dbus_setup_startup ();
   cockpit_dbus_environment_startup ();

--- a/src/bridge/cockpitbridge.h
+++ b/src/bridge/cockpitbridge.h
@@ -42,7 +42,7 @@ GType           cockpit_bridge_get_type     (void) G_GNUC_CONST;
 
 CockpitBridge * cockpit_bridge_new          (CockpitTransport *transport,
                                              CockpitPayloadType *supported_payloads,
-                                             gboolean init_received);
+                                             const gchar *init_host);
 
 G_END_DECLS
 

--- a/src/bridge/cockpitchannel.c
+++ b/src/bridge/cockpitchannel.c
@@ -371,7 +371,6 @@ cockpit_channel_real_prepare (CockpitChannel *channel)
   CockpitChannel *self = COCKPIT_CHANNEL (channel);
   JsonObject *options;
   const gchar *binary;
-  const gchar *payload;
 
   options = cockpit_channel_get_options (self);
 
@@ -380,19 +379,7 @@ cockpit_channel_real_prepare (CockpitChannel *channel)
 
   if (G_OBJECT_TYPE (channel) == COCKPIT_TYPE_CHANNEL)
     {
-      if (!cockpit_json_get_string (options, "payload", NULL, &payload))
-        payload = NULL;
-
-      if (payload)
-        {
-          g_warning ("bridge doesn't support payloads of type: %s", payload);
-          cockpit_channel_close (channel, "not-supported");
-        }
-      else
-        {
-          g_warning ("no payload type present in request to open channel");
-          cockpit_channel_close (channel, "protocol-error");
-        }
+      cockpit_channel_close (channel, "not-supported");
       return;
     }
 

--- a/src/bridge/cockpitpcp.c
+++ b/src/bridge/cockpitpcp.c
@@ -135,7 +135,7 @@ main (int argc,
 
   transport = cockpit_pipe_transport_new_fds ("stdio", 0, outfd);
 
-  bridge = cockpit_bridge_new (transport, payload_types, FALSE);
+  bridge = cockpit_bridge_new (transport, payload_types, NULL);
   g_signal_connect (transport, "closed", G_CALLBACK (on_closed_set_flag), &closed);
   send_init_command (transport);
 

--- a/src/bridge/stub.c
+++ b/src/bridge/stub.c
@@ -113,7 +113,7 @@ run_bridge (const gchar *interactive)
   gboolean terminated = FALSE;
   gboolean interupted = FALSE;
   gboolean closed = FALSE;
-  gboolean init_received = FALSE;
+  const gchar *init_host = NULL;
   guint sig_term;
   guint sig_int;
   int outfd;
@@ -146,7 +146,7 @@ run_bridge (const gchar *interactive)
   if (interactive)
     {
       /* Allow skipping the init message when interactive */
-      init_received = TRUE;
+      init_host = "localhost";
       transport = cockpit_interact_transport_new (0, outfd, interactive);
     }
   else
@@ -157,7 +157,7 @@ run_bridge (const gchar *interactive)
   g_resources_register (cockpitassets_get_resource ());
   cockpit_web_failure_resource = "/org/cockpit-project/Cockpit/fail.html";
 
-  bridge = cockpit_bridge_new (transport, payload_types, init_received);
+  bridge = cockpit_bridge_new (transport, payload_types, init_host);
   cockpit_dbus_environment_startup ();
 
   g_signal_connect (transport, "closed", G_CALLBACK (on_closed_set_flag), &closed);

--- a/src/common/cockpitpipetransport.h
+++ b/src/common/cockpitpipetransport.h
@@ -49,6 +49,7 @@ CockpitPipe *      cockpit_pipe_transport_get_pipe   (CockpitPipeTransport *self
 void               cockpit_transport_read_from_pipe  (CockpitTransport *self,
                                                       const gchar *logname,
                                                       CockpitPipe *pipe,
+                                                      gboolean *closed,
                                                       GByteArray *input,
                                                       gboolean end_of_data);
 G_END_DECLS

--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -216,7 +216,7 @@ on_pipe_read (CockpitPipe *pipe,
 {
   CockpitSshTransport *self = COCKPIT_SSH_TRANSPORT (user_data);
   cockpit_transport_read_from_pipe (COCKPIT_TRANSPORT (self), self->logname,
-                                    pipe, input, end_of_data);
+                                    pipe, &self->closed, input, end_of_data);
 }
 
 static void


### PR DESCRIPTION
This message tells us which host we're operating as. We validate that the field is present in the init message. In addition we check that any open message either has no "host" field or an identical "host" field.
    
Later on down the road we may want the bridge to be able to call out to other hosts or containers, and hence the early validation and returning "not-supported" when the bridge is not capable of that.
