### PR TITLE
po: Make our po files and extraction compatible with angular-gettext

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -246,6 +246,8 @@ SED_SUBST = sed \
         -e 's,[@]selinux_config_type[@],$(COCKPIT_SELINUX_CONFIG_TYPE),g' \
         $(NULL)
 
+UGLIFY_JS = $(srcdir)/node_modules/.bin/uglifyjs
+
 testassetsdir = $(datadir)/cockpit-test-assets
 testassets_programs =
 testassets_data =

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
     "dependencies": {
         "angular": "1.3.14",
         "angular-bootstrap": "0.13.0",
+        "angular-gettext": "2.3.8",
         "angular-route": "1.3.14",
         "bootstrap": "3.3.6",
         "bootstrap-datepicker": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "exports-loader": "~0.6.3",
     "extend": "~3.0.0",
     "extract-text-webpack-plugin": "~1.0.1",
+    "htmlparser": "~1.7.7",
     "html-minifier": "~0.7.2",
     "html-webpack-plugin": "~2.22.0",
     "imports-loader": "~0.6.5",

--- a/pkg/ostree/app.js
+++ b/pkg/ostree/app.js
@@ -6,6 +6,7 @@
 
     var angular = require('angular');
     require('angular-route');
+    require('angular-gettext/dist/angular-gettext.js');
     require('angular-bootstrap/ui-bootstrap.js');
     require('angular-bootstrap/ui-bootstrap-tpls.js');
 
@@ -51,6 +52,7 @@
 
     angular.module('ostree', [
             'ngRoute',
+            'gettext',
         ])
         .config([
             '$routeProvider',

--- a/pkg/ostree/index.html
+++ b/pkg/ostree/index.html
@@ -20,12 +20,13 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 <html ng-csp>
 
 <head>
-  <title translatable="yes">Software Updates</title>
+  <title translate>Software Updates</title>
   <meta charset="utf-8">
   <link href="../base1/patternfly.css" rel="stylesheet">
   <link href="ostree.css" rel="stylesheet">
   <script src="../base1/cockpit.js"></script>
   <script src="ostree.js"></script>
+  <script src="../shell/po.js"></script>
 </head>
 <body ng-app='ostree' hidden>
 
@@ -45,7 +46,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
                 {{ error }}
             </div>
             <div class="listing-ct-actions">
-                <button class="btn btn-default" ng-class="{ disabled: runningMethod, enabled: !runningMethod }" ng-click="checkForUpgrades()" translatable="yes">Check for Updates</button>
+                <button class="btn btn-default" ng-class="{ disabled: runningMethod, enabled: !runningMethod }" ng-click="checkForUpgrades()" translate>Check for Updates</button>
             </div>
         </div>
     </div>
@@ -67,37 +68,33 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
                 <button ng-class="{ disabled: runningMethod, enabled: !runningMethod }"
                         ng-click="doUpgrade(item.osname.v, item.checksum.v)"
                         ng-if="matches('CachedUpdate') && !matches('DefaultDeployment')"
-                        class="btn btn-primary" translatable="yes">
-                    Update and Reboot
-                </button>
+                        class="btn btn-primary" translate>Update and Reboot</button>
                 <button ng-class="{ disabled: runningMethod, enabled: !runningMethod }"
                         ng-click="doRollback(item.osname.v)"
                         ng-if="matches('RollbackDeployment') && !matches('CachedUpdate')"
-                        translatable="yes" class="btn btn-default">Roll Back and Reboot</button>
+                        translate class="btn btn-default">Roll Back and Reboot</button>
             </div>
             <h3>{{ item | releaseName }}</h3>
             <div ng-if="!isRunning" class="listing-ct-status">
               <span ng-if="!error">
                   <span ng-if="matches('BootedDeployment')">
                     <i class="pficon pficon-ok"></i>
-                    <span translatable="yes">Running</span>
+                    <span translate>Running</span>
                   </span>
-                  <span ng-if="!matches('BootedDeployment') && matches('DefaultDeployment')" translatable="yes">
-                    Default
-                  </span>
-                  <span ng-if="!matches('BootedDeployment') && !matches('DefaultDeployment')" translatable="yes">
-                    Available
-                  </span>
+                  <span ng-if="!matches('BootedDeployment') && matches('DefaultDeployment')"
+                        translate>Default</span>
+                  <span ng-if="!matches('BootedDeployment') && !matches('DefaultDeployment')"
+                        translate>Available</span>
               </span>
-              <span ng-if="error" translatable="yes">Failed</span>
+              <span ng-if="error" translate>Failed</span>
             </div>
             <div ng-if="isRunning" class="listing-ct-status">
                 <div class="ostree-progress" ng-if="progressMsg">{{ progressMsg }}</div>
-                <div class="ostree-progress" ng-if="!progressMsg" translatable="yes">Updating</div>
+                <div class="ostree-progress" ng-if="!progressMsg" translate>Updating</div>
             </div>
             <ul class="nav nav-tabs nav-tabs-pf">
-                <li ng-class="{active: activeTab('tree')}"><a translatable="yes" ng-click="switchTab('tree')">Tree</a></li>
-                <li ng-class="{active: activeTab('packages') }"><a translatable="yes" ng-click="switchTab('packages')">Packages</a></li>
+                <li ng-class="{active: activeTab('tree')}"><a translate ng-click="switchTab('tree')">Tree</a></li>
+                <li ng-class="{active: activeTab('packages') }"><a translate ng-click="switchTab('packages')">Packages</a></li>
             </ul>
         </div>
         <div class="listing-ct-error alert" ng-if="error">
@@ -108,23 +105,23 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
             <div class="row">
                 <div class="col-sm-6">
                     <dl>
-                        <dt ng-if="item.osname.v" translatable="yes">Operating System</dt>
+                        <dt ng-if="item.osname.v" translate>Operating System</dt>
                         <dd class="os" ng-if="item.osname.v"> {{ item.osname.v }}</dd>
-                        <dt ng-if="item.version.v" translatable="yes">Version</dt>
+                        <dt ng-if="item.version.v" translate>Version</dt>
                         <dd class="version" ng-if="item.version.v">{{ item.version.v }}</dd>
-                        <dt ng-if="item.timestamp.v" translatable="yes">Released</dt>
+                        <dt ng-if="item.timestamp.v" translate>Released</dt>
                         <dd class="timestamp" ng-if="item.timestamp.v" title="{{ item.timestamp.v | dateFormat }}">{{ item.timestamp.v | timeAgo }}</dd>
                     </dl>
                 </div>
                 <div class="col-sm-6" ng-if="packages">
                     <dl>
-                        <dt ng-if="packages.adds" translatable="yes">Additions</dt>
+                        <dt ng-if="packages.adds" translate>Additions</dt>
                         <dd class="adds" ng-if="packages.adds">{{ packages.adds.length|packages }}</dd>
-                        <dt ng-if="packages.removes" translatable="yes">Removals</dt>
+                        <dt ng-if="packages.removes" translate>Removals</dt>
                         <dd class="removes" ng-if="packages.removes">{{ packages.removes.length|packages }}</dd>
-                        <dt ng-if="packages.up" translatable="yes">Updates</dt>
+                        <dt ng-if="packages.up" translate>Updates</dt>
                         <dd class="updates" ng-if="packages.up">{{ packages.up.length|packages }}</dd>
-                        <dt ng-if="packages.down" translatable="yes">Downgrades</dt>
+                        <dt ng-if="packages.down" translate>Downgrades</dt>
                         <dd class="downgrades" ng-if="packages.down">{{ packages.down.length|packages }}</dd>
                     </dl>
                 </div>
@@ -132,30 +129,29 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
         </div>
         <div class="listing-ct-body hidden packages" ng-class="{active: activeTab('packages')}">
             <div class="row">
-                <div class="col-sm-6" ng-if="packages.empty" translatable="yes">
-                    This deployment contains the same packages as your currently booted system
-                </div>
+                <div class="col-sm-6" ng-if="packages.empty"
+                    translate>This deployment contains the same packages as your currently booted system</div>
                 <div class="col-sm-6" ng-if="packages.adds">
                     <dl class="additions full-width">
-                        <dt translatable="yes">Additions</dt>
+                        <dt translate>Additions</dt>
                         <dd ng-repeat="package in packages.adds">{{package.name}}-{{package.version}}.{{package.arch}}</dd>
                     </dl>
                 </div>
                 <div class="col-sm-6" ng-if="packages.removes">
                     <dl class="removals full-width">
-                        <dt translatable="yes">Removals</dt>
+                        <dt translate>Removals</dt>
                         <dd ng-repeat="package in packages.removes">{{package.name}}-{{package.version}}.{{package.arch}}</dd>
                     </dl>
                 </div>
                 <div class="col-sm-6" ng-if="packages.up">
                     <dl class="upgrades full-width">
-                        <dt translatable="yes">Updates</dt>
+                        <dt translate>Updates</dt>
                         <dd ng-repeat="package in packages.up">{{package.name}}-{{package.version}}.{{package.arch}}</dd>
                     </dl>
                 </div>
                 <div class="col-sm-6" ng-if="packages.down">
                     <dl class="downgrades full-width">
-                        <dt translatable="yes">Downgrades</dt>
+                        <dt translate>Downgrades</dt>
                         <dd ng-repeat="package in packages.down">{{package.name}}-{{package.version}}.{{package.arch}}</dd>
                     </dl>
                 </div>
@@ -183,7 +179,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <thead>
         <tr>
             <td colspan="2">
-                <h3 translatable="yes" ng-if="os_list.length == 1">Operating System Updates</h3>
+                <h3 translate ng-if="os_list.length == 1">Operating System Updates</h3>
                 <h3 ng-if="os_list.length > 1">{{ os }}</h3>
             </td>
         </tr>
@@ -215,14 +211,12 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
                 <div class="spinner spinner-lg" ng-if="curtains.state == 'connecting'"></div>
                 <i class="fa fa-exclamation-circle" ng-if="curtains.failure"></i>
             </div>
-            <h1 ng-if="curtains.state == 'connecting'" translatable="yes">Connecting</h1>
-            <h1 ng-if="curtains.state == 'failed'" translatable="yes">Unable to communicate with OSTree</h1>
-            <h1 ng-if="curtains.state == 'empty'" translatable="yes">No Deployments</h1>
+            <h1 ng-if="curtains.state == 'connecting'" translate>Connecting to OSTree</h1>
+            <h1 ng-if="curtains.state == 'failed'" translate>Unable to communicate with OSTree</h1>
+            <h1 ng-if="curtains.state == 'empty'" translate>No Deployments</h1>
             <p ng-if="curtains.message">{{curtains.message}}</p>
             <div class="blank-slate-pf-main-action" ng-if="curtains.state == 'failed' && !curtains.final">
-                <button class="btn btn-primary btn-lg" translatable="yes" ng-click="reconnect()">
-                    Reconnect
-                </button>
+                <button class="btn btn-primary btn-lg" translate ng-click="reconnect()">Reconnect</button>
             </div>
         </div>
     </div>

--- a/pkg/ostree/manifest.json
+++ b/pkg/ostree/manifest.json
@@ -2,7 +2,7 @@
     "version": "@VERSION@",
     "name": "updates",
     "requires": {
-	"cockpit": "122"
+	"cockpit": "124.x"
     },
 
     "tools": {

--- a/pkg/playground/translate.html
+++ b/pkg/playground/translate.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html ng-csp>
 <head>
     <meta charset="utf-8">
     <title>Cockpit playground</title>
@@ -7,7 +7,6 @@
     <link href="../base1/patternfly.css" type="text/css" rel="stylesheet">
     <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
-    <script src="../shell/po.js"></script>
 </head>
 <body hidden>
     <div id="internal" class="container-fluid">
@@ -167,36 +166,41 @@
         <hr>
         <h2>Angular Translations</h2>
 
-        <p>In Angular use these forms. These are not properly translated in this demo page:<p>
-
-        <p>
-            <code>&lt;translate&gt;Cancel&lt;/translate&gt;</code>
-            = <translate>Cancel</translate>
-        </p>
+        <p>In Angular use these forms:<p>
 
         <p>
             <code>&lt;span translate&gt;Ready&lt;/span&gt;</code>
-            = <span translate>Ready</span>
+            = <span translate id="angular-translate">Ready</span>
         </p>
 
         <p>
-            <code>&lt;span translate&gt;Delete {{ item.kind }}&lt;/span&gt;</code>
-            = <span translate>Delete {{ item.kind }}</span>
+            <code>&lt;span translate translate-context="verb"&gt;Ready&lt;/span&gt;</code>
+            = <span translate translate-context="verb" id="angular-context">Ready</span>
         </p>
 
         <p>
-            <code>&lt;span translate translate-n="percentFree"
-            translate-plural="{{$count}}% Free"&gt;1% Free&lt;/span&gt;</code>
-            = <span translate translate-n="percentFree" translate-plural="{{$count}}% Free">1% Free</span>
+            <code>&lt;span translate&gt;Delete '{{ name }}'&lt;/span&gt;</code>
+            = <span translate ng-init="name='Marmalade'"id="angular-interpolate">Delete '{{ name }}'</span>
         </p>
+
+        <!--
+        <p ng-init="count=5" >
+            <code>&lt;span translate translate-n="count"
+                translate-plural="{&zwj;{count}} hours"&gt;{&zwj;{count}} hour&lt;/span&gt;</code>
+            = <span translate translate-n="count" translate-plural="{{count}} hours"
+                id="angular-plural">1 hour</span>
+        </p>
+        -->
 
         <p>When translating Angular we <b>not support</b>:<p>
         <ul>
             <li>The <code>translatable</code> attribute.</li>
             <li>The <code>translate="attr"</code> translating of attribute values.</li>
             <li>The <code>{{value|translate}}</code> filter, even though documented on angular-gettext.</li>
+            <li>The <code>&lt;translate&gt;</code> element</li>
         </ul>
     </div>
     <script src="translate.js"></script>
+    <script src="../shell/po.js"></script>
 </body>
 </html>

--- a/pkg/playground/translate.html
+++ b/pkg/playground/translate.html
@@ -11,15 +11,18 @@
 </head>
 <body hidden>
     <div id="internal" class="container-fluid">
-        <h2>HTML Translations</h2>
-        <p>
-            <code>&lt;span translatable="yes"&gt;Cancel&lt;/span&gt;</code>
-            = <span translatable="yes" id="translatable-html">Cancel</span>
-        </p>
+        <h2>HTML translations</h2>
+
+        <p>For translating HTML use these forms:<p>
 
         <p>
             <code>&lt;span translate&gt;Ready&lt;/span&gt;</code>
             = <span translate id="translate-html">Ready</span>
+        </p>
+
+        <p>
+            <code>&lt;span translate translate-context="verb"&gt;Ready&lt;/span&gt;</code>
+            = <span translate translate-context="verb" id="translate-html-context">Ready</span>
         </p>
 
         <p>
@@ -28,11 +31,51 @@
         </p>
 
         <p>
-            <code>&lt;span translate-title title="Unavailable"&gt;Button&lt;/span&gt;</code>
-            = <span translate-title title="Unavailable" id="translate-html-title">Button</span>
+            <code>&lt;span translate="title" title="Unavailable"&gt;Cancel&lt;/span&gt;</code>
+            = <span translate="title" title="Unavailable" id="translate-html-title">Cancel</span>
         </p>
 
-        <h2>Mustache Translations</h2>
+        <p>
+            <code>&lt;span translate="yes title" title="Unavailable"&gt;Cancel&lt;/span&gt;</code>
+            = <span translate="yes title" title="Unavailable" id="translate-html-yes-title">Cancel</span>
+        </p>
+
+        <p>Note that we do <b>not support</b>:<p>
+        <ul>
+            <li>Interpolation of variables.</li>
+            <li>Pluralization</li>
+            <li>The <code>&lt;translate&gt;</code> element</li>
+        </ul>
+
+        <hr>
+
+        <h2>Old Glade style</h2>
+
+        <p>The old Glade style is not recommended:<p>
+
+        <p>
+            <code>&lt;span translatable="yes"&gt;Empty&lt;/span&gt;</code>
+            = <span translatable="yes" id="translatable-glade">Empty</span>
+        </p>
+
+        <p>
+            <code>&lt;span translatable="yes" context="verb"&gt;Empty&lt;/span&gt;</code>
+            = <span translatable="yes" context="verb" id="translatable-glade-context">Empty</span>
+        </p>
+
+        <p>Note that we do <b>not support</b>:<p>
+        <ul>
+            <li>Interpolation of variables.</li>
+            <li>Tranlatable attributes.</li>
+            <li>Pluralization</li>
+            <li>The <code>&lt;translate&gt;</code> element</li>
+        </ul>
+
+        <hr>
+
+        <h2>Mustache translations</h2>
+
+        <p>For translating Mustache use these forms:<p>
 
         <div id="mustache-output">
         </div>
@@ -54,12 +97,27 @@
             </p>
 
             <p>
-                <code>&lt;span translate-title title="Error"&gt;Button&lt;/span&gt;</code>
-                = <span translate-title title="Error" id="translate-mustache-title">Button</span>
+                <code>&lt;span translate="title" title="Error"&gt;User&lt;/span&gt;</code>
+                = <span translate="title" title="Error" id="translate-mustache-title">User</span>
+            </p>
+
+            <p>
+                <code>&lt;span translate="yes title" title="Error"&gt;User&lt;/span&gt;</code>
+                = <span translate="yes title" title="Error" id="translate-mustache-yes-title">User</span>
             </p>
         </script>
 
+        <p>Note that we do <b>not support</b>:<p>
+        <ul>
+            <li>Interpolation of variables.</li>
+            <li>Pluralization</li>
+            <li>The <code>&lt;translate&gt;</code> element</li>
+        </ul>
+        <hr>
+
         <h2>Code Translations</h2>
+
+        <p>For translating in javascript code, use these forms:</p>
 
         <p>
             <code>_("Empty")</code>
@@ -106,6 +164,38 @@
             = <span id="ngettext-context-disks-2"></span>
         </p>
 
+        <hr>
+        <h2>Angular Translations</h2>
+
+        <p>In Angular use these forms. These are not properly translated in this demo page:<p>
+
+        <p>
+            <code>&lt;translate&gt;Cancel&lt;/translate&gt;</code>
+            = <translate>Cancel</translate>
+        </p>
+
+        <p>
+            <code>&lt;span translate&gt;Ready&lt;/span&gt;</code>
+            = <span translate>Ready</span>
+        </p>
+
+        <p>
+            <code>&lt;span translate&gt;Delete {{ item.kind }}&lt;/span&gt;</code>
+            = <span translate>Delete {{ item.kind }}</span>
+        </p>
+
+        <p>
+            <code>&lt;span translate translate-n="percentFree"
+            translate-plural="{{$count}}% Free"&gt;1% Free&lt;/span&gt;</code>
+            = <span translate translate-n="percentFree" translate-plural="{{$count}}% Free">1% Free</span>
+        </p>
+
+        <p>When translating Angular we <b>not support</b>:<p>
+        <ul>
+            <li>The <code>translatable</code> attribute.</li>
+            <li>The <code>translate="attr"</code> translating of attribute values.</li>
+            <li>The <code>{{value|translate}}</code> filter, even though documented on angular-gettext.</li>
+        </ul>
     </div>
     <script src="translate.js"></script>
 </body>

--- a/pkg/playground/translate.js
+++ b/pkg/playground/translate.js
@@ -1,44 +1,55 @@
 var $ = require("jquery");
 var cockpit = require("cockpit");
 var mustache = require("mustache");
+var angular = require('angular');
+require('angular-gettext/dist/angular-gettext.js');
 
 var _ = cockpit.gettext;
 var C_ = cockpit.gettext;
 
-cockpit.translate();
+$(function () {
+    cockpit.translate();
 
-var text = _("Empty");
-$("#underscore-empty").text(text);
+    var text = _("Empty");
+    $("#underscore-empty").text(text);
 
-text = _("verb", "Empty");
-$("#underscore-context-empty").text(text);
+    text = _("verb", "Empty");
+    $("#underscore-context-empty").text(text);
 
-text = C_("verb", "Empty");
-$("#cunderscore-context-empty").text(text);
+    text = C_("verb", "Empty");
+    $("#cunderscore-context-empty").text(text);
 
-text = cockpit.gettext("Control");
-$("#gettext-control").text(text);
+    text = cockpit.gettext("Control");
+    $("#gettext-control").text(text);
 
-text = cockpit.gettext("key", "Control");
-$("#gettext-context-control").text(text);
+    text = cockpit.gettext("key", "Control");
+    $("#gettext-context-control").text(text);
 
-text = cockpit.ngettext("$0 disk is missing", "$0 disks are missing", 1);
-$("#ngettext-disks-1").text(text);
+    text = cockpit.ngettext("$0 disk is missing", "$0 disks are missing", 1);
+    $("#ngettext-disks-1").text(text);
 
-text = cockpit.ngettext("$0 disk is missing", "$0 disks are missing", 2);
-$("#ngettext-disks-2").text(text);
+    text = cockpit.ngettext("$0 disk is missing", "$0 disks are missing", 2);
+    $("#ngettext-disks-2").text(text);
 
-text = cockpit.ngettext("disk-non-rotational", "$0 disk is missing", "$0 disks are missing", 1);
-$("#ngettext-context-disks-1").text(text);
+    text = cockpit.ngettext("disk-non-rotational", "$0 disk is missing", "$0 disks are missing", 1);
+    $("#ngettext-context-disks-1").text(text);
 
-text = cockpit.ngettext("disk-non-rotational", "$0 disk is missing", "$0 disks are missing", 2);
-$("#ngettext-context-disks-2").text(text);
+    text = cockpit.ngettext("disk-non-rotational", "$0 disk is missing", "$0 disks are missing", 2);
+    $("#ngettext-context-disks-2").text(text);
 
-var template = $("#mustache-input").text();
-var output = $.parseHTML(mustache.render(template));
-cockpit.translate(output);
-$("#mustache-output").empty().append(output);
+    var template = $("#mustache-input").text();
+    var output = $.parseHTML(mustache.render(template));
+    cockpit.translate(output);
+    $("#mustache-output").empty().append(output);
 
-cockpit.transport.wait(function() {
-    $("body").show();
+    var module = angular.module('playgroundTranslate', [ 'gettext' ]);
+
+    module.run(["$rootScope", function($rootScope) {
+        cockpit.transport.wait(function() {
+            $rootScope.$digest();
+            $("body").show();
+        });
+    }]);
+    angular.bootstrap(document, ['playgroundTranslate']);
+
 });

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -89,7 +89,7 @@ po/cockpit.pre.pot: po/POTFILES.pre.in
 
 # Combine the above pot files into one
 po/cockpit.pot: po/cockpit.c.pot po/cockpit.js.pot po/cockpit.pre.pot
-	$(MSGCAT) --output-file=$@ $^
+	$(MSGCAT) --sort-output --use-first --output-file=$@ $^
 
 # Actually update the old translations with new translatable text
 update-po: po/cockpit.pot

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -42,27 +42,20 @@ install-data-local:: $(MO_FILES)
 uninstall-local::
 	for lang in $(LINGUAS); do rm -f $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo; done
 
-# A target that pre-extracts things ready for xgettext to work on
-# This currently just does what intltoolize used to do
-# TODO: Does not yet handle translations of attributes or angular-gettext
-prepare-po::
-	rm -rf ./tmp/pkg/
-	( cd $(srcdir) && find pkg/ -name '*.html' ) | while read name; do \
-		$(INTLTOOL_EXTRACT) -l --type=gettext/glade $(srcdir)/$$name && \
-		$(MKDIR_P) ./tmp/`dirname $$name` && mv ./tmp/`basename $$name`.h ./tmp/$$name.h; \
-	done
-
 # Lists of files we need to extract from
 po/POTFILES.c.in:
 	$(MKDIR_P) $(notdir $@)
 	( cd $(srcdir) && find src/ws/ src/bridge/ -name '*.c' ) > $@
+po/POTFILES.html.in:
+	$(MKDIR_P) $(notdir $@)
+	( cd $(srcdir) && find pkg/ -name '*.html' ) > $@
 po/POTFILES.js.in:
 	$(MKDIR_P) $(notdir $@)
 	( cd $(srcdir) && find src/base1/ pkg/ -name '*.js' -o -name '*.jsx' -o -name '*.es6' ) > $@
 po/POTFILES.pre.in: prepare-po
 	$(MKDIR_P) $(notdir $@)
 	( cd tmp/ && find . -type f ) > $@
-.PHONY: po/POTFILES.c.in po/POTFILES.js.in po/POTFILES.pre.in
+.PHONY: po/POTFILES.c.in po/POTFILES.html.in po/POTFILES.js.in po/POTFILES.pre.in
 
 # Extract from GLib based C code files
 po/cockpit.c.pot: po/POTFILES.c.in
@@ -71,6 +64,10 @@ po/cockpit.c.pot: po/POTFILES.c.in
 		--keyword=g_dgettext:2 --keyword=g_dngettext:2,3 --keyword=g_dpgettext:2 \
 		--keyword=g_dpgettext2=2c,3 \
 		--from-code=UTF-8 --directory=$(srcdir) --files-from=$^
+
+# Extract translate attribute, Glade style, angular-gettext HTML translations
+po/cockpit.html.pot: po/POTFILES.html.in
+	$(srcdir)/tools/missing $(srcdir)/po/html2po -d $(srcdir) -f $^ -o $@
 
 # Extract cockpit style javascript translations
 po/cockpit.js.pot: po/POTFILES.js.in
@@ -88,7 +85,7 @@ po/cockpit.pre.pot: po/POTFILES.pre.in
 		--from-code=UTF-8 --directory=$(builddir)/tmp --files-from=$^
 
 # Combine the above pot files into one
-po/cockpit.pot: po/cockpit.c.pot po/cockpit.js.pot po/cockpit.pre.pot
+po/cockpit.pot: po/cockpit.c.pot po/cockpit.html.pot po/cockpit.js.pot po/cockpit.pre.pot
 	$(MSGCAT) --sort-output --use-first --output-file=$@ $^
 
 # Actually update the old translations with new translatable text

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -25,8 +25,10 @@ FILTER_PO_SRC_WS = sed -ne 's|.*\(\(\.\.\)\?/src/ws/[^:]\+\).*|-N \1|p' $<
 # Include everything not in src/ws in the javascript file
 po/po.%.js: po/%.po
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	$(MSGGREP) --invert-match `$(FILTER_PO_SRC_WS)` $< > $@.tmp && \
-	$(srcdir)/tools/missing $(srcdir)/po/po2json --module $@.tmp $@
+	$(MSGGREP) --invert-match `$(FILTER_PO_SRC_WS)` $< > $@.po.tmp && \
+	$(srcdir)/tools/missing $(srcdir)/po/po2json -m $(srcdir)/po/po.js -o $@.js.tmp $@.po.tmp && \
+	$(srcdir)/tools/missing $(UGLIFY_JS) $@.js.tmp --mangle --beautify > $@.tmp && \
+	rm -f $@.po.tmp $@.js.tmp && mv $@.tmp $@
 
 # Always build the binary gettext data
 all-local:: $(MO_FILES) $(PO_JAVASCRIPT)
@@ -42,16 +44,21 @@ install-data-local:: $(MO_FILES)
 uninstall-local::
 	for lang in $(LINGUAS); do rm -f $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo; done
 
+# General code packages to translate
+TRANSLATE = \
+	pkg/ \
+	$(NULL)
+
 # Lists of files we need to extract from
 po/POTFILES.c.in:
 	$(MKDIR_P) $(notdir $@)
 	( cd $(srcdir) && find src/ws/ src/bridge/ -name '*.c' ) > $@
 po/POTFILES.html.in:
 	$(MKDIR_P) $(notdir $@)
-	( cd $(srcdir) && find pkg/ -name '*.html' ) > $@
+	( cd $(srcdir) && find $(TRANSLATE) -name '*.html' ) > $@
 po/POTFILES.js.in:
 	$(MKDIR_P) $(notdir $@)
-	( cd $(srcdir) && find src/base1/ pkg/ -name '*.js' -o -name '*.jsx' -o -name '*.es6' ) > $@
+	( cd $(srcdir) && find src/base1/ $(TRANSLATE) -name '*.js' -o -name '*.jsx' -o -name '*.es6' ) > $@
 po/POTFILES.pre.in: prepare-po
 	$(MKDIR_P) $(notdir $@)
 	( cd tmp/ && find . -type f ) > $@
@@ -76,6 +83,7 @@ po/cockpit.js.pot: po/POTFILES.js.in
 		--keyword=N_ --keyword=NC_:1c,2 \
 		--keyword=gettext:1,1t --keyword=gettext:1c,2,2t \
 		--keyword=ngettext:1,2,3t --keyword=ngettext:1c,2,3,4t \
+		--keyword=gettextCatalog.getString:1,3c --keyword=gettextCatalog.getPlural:2,3,4c \
 		--from-code=UTF-8 --directory=$(srcdir) --files-from=$^
 
 # Extract pre-processed prepare-po data in tmp/

--- a/po/ca.po
+++ b/po/ca.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-17 19:28+0100\n"
+"POT-Creation-Date: 2016-11-18 06:44+0100\n"
 "PO-Revision-Date: 2016-08-09 04:37-0400\n"
 "Last-Translator: Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>\n"
 "Language-Team: Catalan\n"
@@ -15,178 +15,487 @@ msgstr ""
 "X-Generator: Zanata 3.9.6\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
-#: src/ws/cockpitcertificate.c:359
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr ""
-
-#: src/ws/cockpitcertificate.c:364
-msgid "No PEM-encoded private key found"
-msgstr ""
-
-#: src/ws/cockpitcertificate.c:374
-msgid "Could not parse PEM-encoded private key"
-msgstr ""
-
-#: src/ws/cockpitcertificate.c:398
-msgid "No PEM-encoded certificate found"
-msgstr ""
-
-#: src/ws/cockpitcertificate.c:407
-msgid "Could not parse PEM-encoded certificate"
-msgstr ""
-
-#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
-#: src/bridge/cockpitdbussetup.c:625
+#: pkg/shell/index.html:227
 #, fuzzy
-msgid "Unsupported setup mechanism"
-msgstr "Mecanisme de configuració no suportat: %s"
-
-#: src/bridge/cockpitdbussetup.c:236
-msgid "Couldn't list users"
-msgstr "No s'han pogut llistar els usuaris"
-
-#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
-msgid "Bad data passed for passwd1 mechanism"
-msgstr "S'han passat dades dolentes al mecanisme del passwd1"
-
-#: src/bridge/cockpitdbussetup.c:382
-msgid "Couldn't load user data"
-msgstr "No s'han pogut carregar les dades de l'usuari"
-
-#: src/bridge/cockpitdbussetup.c:467
-msgid "Couldn't change user groups"
-msgstr "No s'han pogut canviar els grups de l'usuari"
-
-#: src/bridge/cockpitdbussetup.c:520
-msgid "Couldn't change user password"
-msgstr "No s'ha pogut canviar la contrasenya de l'usuari"
-
-#: src/bridge/cockpitdbussetup.c:544
-msgid "Couldn't create new users"
-msgstr "No s'han pogut crear els nous usuaris"
-
-#: src/bridge/cockpitdbussetup.c:642
-msgid "Couldn't list local users"
-msgstr "No s'han pogut llistar els usuaris locals"
-
-#: src/bridge/cockpitpackages.c:459
-#, c-format
-msgid "This package requires Cockpit version %s or later"
+msgid "                                                Comment                                            "
 msgstr ""
+"\n"
+"                                    Zona horària no vàlida\n"
+"                                "
 
-#: src/bridge/cockpitpackages.c:470
-msgid "This package is not compatible with this version of Cockpit"
-msgstr ""
-
-#: src/base1/cockpit.js:2586
-msgid "$0 killed with signal $1"
-msgstr "$0 es va matar amb el senyal $1"
-
-#: src/base1/cockpit.js:2588
-msgid "$0 exited with code $1"
-msgstr "$0 va sortir amb el codi $1"
-
-#: src/base1/cockpit.js:2590
-msgid "$0 failed"
-msgstr "$0 ha fallat"
-
-#: src/base1/cockpit.js:3667
-msgid "Your session has been terminated."
-msgstr "La vostra sessió ha estat finalitzada."
-
-#: src/base1/cockpit.js:3669
-msgid "Your session has expired. Please log in again."
-msgstr "La vostra sessió ha vençut. Si us plau, torneu a iniciar la sessió."
-
-#: src/base1/cockpit.js:3671
-msgid "Not permitted to perform this action."
-msgstr "No es permet realitzar aquesta acció."
-
-#: src/base1/cockpit.js:3673
-msgid "Login failed"
-msgstr "Ha fallat l'inici de sessió"
-
-#: src/base1/cockpit.js:3675
-msgid "The server refused to authenticate using any supported methods."
-msgstr ""
-"El servidor ha refusat l'autenticació mitjançant qualsevol dels mètodes "
-"compatibles."
-
-#: src/base1/cockpit.js:3677
-msgid "Untrusted host"
-msgstr ""
-
-#: src/base1/cockpit.js:3679
-msgid "Host key is incorrect"
-msgstr "La clau d'amfitrió és incorrecta"
-
-#: src/base1/cockpit.js:3681
-msgid "Internal error"
-msgstr "Error intern"
-
-#: src/base1/cockpit.js:3683
-msgid "Connection has timed out."
-msgstr "La connexió ha excedit el temps."
-
-#: src/base1/cockpit.js:3685
-msgid "Cockpit is not installed on the system."
-msgstr "Cockpit no està instal·lat al sistema."
-
-#: src/base1/cockpit.js:3687
-msgid "Cannot forward login credentials"
-msgstr ""
-
-#: src/base1/cockpit.js:3689
-msgid "Server has closed the connection."
-msgstr ""
-
-#: src/base1/cockpit.js:3691
-msgid "Cockpit is not compatible with the software on the system."
-msgstr ""
-
-#: src/base1/cockpit.js:3693
-msgid "Cockpit could not contact the given host."
-msgstr ""
-
-#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:19
+#: pkg/shell/index.html:235
 #, fuzzy
-msgid "Control"
-msgstr "Contenidor"
+msgid "                                                Fingerprint                                            "
+msgstr ""
+"\n"
+"                                    Zona horària no vàlida\n"
+"                                "
 
-#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
-#: pkg/playground/translate.js:22
+#: pkg/shell/index.html:231
 #, fuzzy
-msgctxt "key"
-msgid "Control"
-msgstr "Contenidor"
+msgid "                                                Type                                            "
+msgstr ""
+"\n"
+"                                    Zona horària no vàlida\n"
+"                                "
 
-#: src/base1/test-locale.js:46 src/base1/test-locale.js:56
-#: pkg/playground/translate.js:10
-msgid "Empty"
-msgstr "Buida"
-
-#: src/base1/test-locale.js:47 src/base1/test-locale.js:58
-#: pkg/playground/translate.js:16
+#: pkg/systemd/index.html:389
 #, fuzzy
-msgctxt "verb"
-msgid "Empty"
-msgstr "Buida"
+msgid ""
+"                                    Invalid time "
+"zone                                "
+msgstr ""
+"\n"
+"                                    Zona horària no vàlida\n"
+"                                "
 
-#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
-#: src/base1/test-locale.js:66 pkg/storaged/details.js:1557
-#: pkg/playground/translate.js:25 pkg/playground/translate.js:28
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] ""
-msgstr[1] ""
+#: pkg/kubernetes/views/project-body.html:80
+#, fuzzy
+msgid ""
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}                                "
+msgstr ""
+"\n"
+"                                    Zona horària no vàlida\n"
+"                                "
 
-#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
-#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
-#: pkg/playground/translate.js:34
-msgctxt "disk-non-rotational"
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
+#: pkg/kubernetes/views/user-body.html:22
+#, fuzzy
+msgid ""
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}                                "
+msgstr ""
+"\n"
+"                                    Zona horària no vàlida\n"
+"                                "
+
+#: pkg/kubernetes/views/user-panel.html:39
+#, fuzzy
+msgid ""
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}                            "
+msgstr ""
+"\n"
+"                                Selecciona\n"
+"                            "
+
+#: pkg/kubernetes/views/project-body.html:37
+#, fuzzy
+msgid ""
+"                                {{ getRegistryRoles(user, project())."
+"join() }}                            "
+msgstr ""
+"\n"
+"                                Selecciona\n"
+"                            "
+
+#: pkg/systemd/index.html:485 pkg/systemd/index.html:504
+#, fuzzy
+msgid "                        Cancel                    "
+msgstr ""
+"\n"
+"                        Cancel·la\n"
+"                    "
+
+#: pkg/kubernetes/views/user-add-membership.html:9
+#, fuzzy
+msgid "                        Group or Project                    "
+msgstr ""
+"\n"
+"                        Grup o projecte\n"
+"                    "
+
+#: pkg/kubernetes/views/add-user-dialog.html:19
+#: pkg/kubernetes/views/user-modify.html:19
+#, fuzzy
+msgid "                        Identity                    "
+msgstr ""
+"\n"
+"                        Identitat\n"
+"                    "
+
+#: pkg/kubernetes/views/add-user-dialog.html:9
+#: pkg/kubernetes/views/user-modify.html:9
+#: pkg/kubernetes/views/add-group-dialog.html:9
+#, fuzzy
+msgid "                        Name                    "
+msgstr ""
+"\n"
+"                        Nom\n"
+"                    "
+
+#: pkg/kubernetes/views/user-add-membership.html:30
+#, fuzzy
+msgid "                        Role                    "
+msgstr ""
+"\n"
+"                        Rol\n"
+"                    "
+
+#: pkg/kubernetes/views/user-group-add.html:9
+#, fuzzy
+msgid "                        User                    "
+msgstr ""
+"\n"
+"                        Nom\n"
+"                    "
+
+#: pkg/ostree/index.html:88
+#, fuzzy
+msgid "                    Available                  "
+msgstr ""
+"\n"
+"                    Disponible\n"
+"                  "
+
+#: pkg/ostree/index.html:85
+#, fuzzy
+msgid "                    Default                  "
+msgstr ""
+"\n"
+"                    Per defecte\n"
+"                  "
+
+#: pkg/ostree/index.html:223
+#, fuzzy
+msgid "                    Reconnect                "
+msgstr ""
+"\n"
+"                    Torna a connectar\n"
+"                "
+
+#: pkg/ostree/index.html:135
+#, fuzzy
+msgid ""
+"                    This deployment contains the same packages as your "
+"currently booted system                "
+msgstr ""
+"\n"
+"                    Aquest desplegament conté els mateixos paquets que el "
+"sistema arrencat actualment\n"
+"                "
+
+#: pkg/ostree/index.html:67
+#, fuzzy
+msgid "                    Update and reboot                "
+msgstr ""
+"\n"
+"                    Actualitza i reinicia\n"
+"                "
+
+#: pkg/kubernetes/registry.html:74 pkg/kubernetes/index.html:104
+#, fuzzy
+msgid "                Reconnect            "
+msgstr ""
+"\n"
+"                Torna a connectar\n"
+"            "
+
+#: pkg/sosreport/index.html:57
+msgid ""
+"                The generated archive contains data "
+"considered                sensitive and its content should be reviewed by "
+"the                originating organization before being passed to "
+"any                third party.              "
+msgstr ""
+
+#: pkg/shell/index.html:304 pkg/shell/stub.html:157
+#, fuzzy
+msgid "                Tools              "
+msgstr ""
+"\n"
+"                Eines\n"
+"              "
+
+#: pkg/kubernetes/index.html:107
+#, fuzzy
+msgid "                Troubleshoot            "
+msgstr ""
+"\n"
+"                Eines\n"
+"              "
+
+#: pkg/shell/simple.html:105 pkg/shell/index.html:126 pkg/shell/stub.html:119
+#: pkg/storaged/index.html:862
+#, fuzzy
+msgid "              Cancel            "
+msgstr ""
+"\n"
+"              Cancel·la\n"
+"            "
+
+#: pkg/shell/index.html:147 pkg/shell/stub.html:140
+#, fuzzy
+msgid "              Close            "
+msgstr ""
+"\n"
+"              Tanca\n"
+"            "
+
+#: pkg/shell/simple.html:70 pkg/shell/index.html:83 pkg/shell/stub.html:76
+#, fuzzy
+msgid ""
+"              Cockpit is an interactive Linux server admin "
+"interface.            "
+msgstr ""
+"\n"
+"              Cockpit és una interfície d'administració de servidor Linux "
+"interactiva.\n"
+"            "
+
+#: pkg/shell/simple.html:79 pkg/shell/index.html:92 pkg/shell/stub.html:85
+#, fuzzy
+msgid "              Licensed under the GNU LGPL version 2.1            "
+msgstr ""
+"\n"
+"                    Usuari\n"
+"                  "
+
+#: pkg/shell/simple.html:129
+#, fuzzy
+msgid "              Log in again            "
+msgstr ""
+"\n"
+"              Torna a iniciar la sessió\n"
+"            "
+
+#: pkg/shell/simple.html:73 pkg/shell/index.html:86 pkg/shell/stub.html:79
+#, fuzzy
+msgid "              Project website            "
+msgstr ""
+"\n"
+"              Tanca\n"
+"            "
+
+#: pkg/shell/simple.html:108 pkg/shell/index.html:129 pkg/shell/stub.html:122
+#, fuzzy
+msgid "              Select            "
+msgstr ""
+"\n"
+"              Selecciona\n"
+"            "
+
+#: pkg/shell/simple.html:126
+#, fuzzy
+msgid "              Try to reconnect            "
+msgstr ""
+"\n"
+"              Prova a tornar a connectar\n"
+"            "
+
+#: pkg/users/index.html:361
+#, fuzzy
+msgid "            Add key          "
+msgstr ""
+"\n"
+"            Afegeix una clau\n"
+"          "
+
+#: pkg/networkmanager/index.html:582 pkg/networkmanager/index.html:610
+#: pkg/networkmanager/index.html:638 pkg/networkmanager/index.html:666
+#: pkg/networkmanager/index.html:694 pkg/networkmanager/index.html:722
+#: pkg/networkmanager/index.html:750 pkg/networkmanager/index.html:778
+#, fuzzy
+msgid "            Apply          "
+msgstr ""
+"\n"
+"            Aplica\n"
+"          "
+
+#: pkg/users/index.html:269 pkg/users/index.html:297 pkg/users/index.html:358
+#: pkg/docker/index.html:584 pkg/docker/index.html:622
+#: pkg/docker/index.html:688 pkg/docker/index.html:744
+#: pkg/docker/index.html:790 pkg/networkmanager/index.html:579
+#: pkg/networkmanager/index.html:607 pkg/networkmanager/index.html:635
+#: pkg/networkmanager/index.html:663 pkg/networkmanager/index.html:691
+#: pkg/networkmanager/index.html:719 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:775
+#, fuzzy
+msgid "            Cancel          "
+msgstr ""
+"\n"
+"            Cancel·la\n"
+"          "
+
+#: pkg/docker/index.html:691
+#, fuzzy
+msgid "            Change          "
+msgstr ""
+"\n"
+"            Canvia\n"
+"          "
+
+#: pkg/users/index.html:45
+#, fuzzy
+msgid "            Close          "
+msgstr ""
+"\n"
+"            Tanca\n"
+"          "
+
+#: pkg/docker/index.html:747
+#, fuzzy
+msgid "            Commit          "
+msgstr ""
+"\n"
+"            Consigna\n"
+"          "
+
+#: pkg/users/index.html:207
+#, fuzzy
+msgid "            Create          "
+msgstr ""
+"\n"
+"            Crea\n"
+"          "
+
+#: pkg/users/index.html:300 pkg/networkmanager/index.html:533
+#, fuzzy
+msgid "            Delete          "
+msgstr ""
+"\n"
+"            Suprimeix\n"
+"          "
+
+#: pkg/docker/index.html:625
+#, fuzzy
+msgid "            Download          "
+msgstr ""
+"\n"
+"            Baixa\n"
+"          "
+
+#: pkg/docker/index.html:587
+#, fuzzy
+msgid "            Run          "
+msgstr ""
+"\n"
+"            Executa\n"
+"          "
+
+#: pkg/users/index.html:272
+#, fuzzy
+msgid "            Set          "
+msgstr ""
+"\n"
+"            Estableix\n"
+"          "
+
+#: pkg/kubernetes/views/imagestream-body.html:14
+msgid "          Images may be pulled by anonymous users        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:20
+msgid ""
+"          Images may be pulled by any authenticated user or group        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:26
+msgid "          Images may only be pulled by specific users or groups        "
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:9
+#, fuzzy
+msgid "         {{ labels.url }}    "
+msgstr ""
+"\n"
+"            Cancel·la\n"
+"          "
+
+#: pkg/kubernetes/views/project-body.html:2
+msgid ""
+"        Project access policy allows anonymous users to pull images. Grant "
+"additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:7
+msgid ""
+"        Project access policy allows any authenticated user to pull images. "
+"Grant additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:12
+msgid ""
+"        Project access policy only allows specific members to access images. "
+"Grant access to specific members below.    "
+msgstr ""
+
+#: pkg/sosreport/index.html:39
+msgid ""
+"        The collected information will be stored locally on the system.      "
+msgstr ""
+
+#: pkg/storaged/index.html:51
+#, fuzzy
+msgid ""
+"        There are devices with multiple paths on the system, but the "
+"multipath service is not running.      "
+msgstr ""
+"\n"
+"        Hi ha dispositius amb diversos camins al sistema, però no s'està "
+"executant el servei de multicamí.\n"
+"      "
+
+#: pkg/sosreport/index.html:34
+msgid ""
+"        This tool will collect system configuration and diagnostic        "
+"information from this system for use with diagnosing problems        with "
+"the system.      "
+msgstr ""
+
+#: pkg/docker/storage.jsx:242
+msgid " (shared with the OS)"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:8
+msgid " 1\"Do you want to delete the following Nodes?"
+msgstr ""
+
+#: pkg/storaged/overview.js:253
+msgid "$0 Block Device"
+msgstr "Dispositiu de blocs $0"
+
+#: pkg/storaged/details.js:1546
+msgid "$0 Chunk Size"
+msgstr "$0 de mida del tros"
+
+#: pkg/storaged/details.js:1544
+msgid "$0 Disks"
+msgstr "$0 discs"
+
+#: pkg/storaged/details.js:1387
+msgid "$0 Extended Partition"
+msgstr "Partició estesa $0"
+
+#: pkg/storaged/details.js:1221
+msgctxt "storage-id-desc"
+msgid "$0 File System"
+msgstr "sistema de fitxers $0"
+
+#: pkg/storaged/details.js:1375
+msgid "$0 Free Space"
+msgstr "$0 d'espai lliure"
+
+#: pkg/storaged/details.js:1367
+msgid "$0 Free Space for Logical Partitions"
+msgstr "$0 d'espai lliure per a les particions lògiques"
+
+#: pkg/storaged/details.js:1711
+msgid "$0 Free Space for Logical Volumes"
+msgstr "$0 d'espai lliure per als volums lògics"
+
+#: pkg/storaged/details.js:1370
+msgid "$0 Free Space for Primary Partitions"
+msgstr "$0 d'espai lliure per a les particions primàries"
+
+#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
+msgid "$0 Template"
+msgstr "Plantilla $0"
+
+#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+msgid "$0 bit"
+msgid_plural "$0 bits"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -206,577 +515,40 @@ msgid_plural "$0 bytes"
 msgstr[0] "bytes"
 msgstr[1] "bytes"
 
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
-msgid "$0 bit"
-msgid_plural "$0 bits"
+#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
+#: src/base1/test-locale.js:66 pkg/playground/translate.js:25
+#: pkg/playground/translate.js:28 pkg/storaged/details.js:1557
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/systemd/host.js:43
-msgid "The user <b>$0</b> is not permitted to modify hostnames"
-msgstr "A l'usuari <b>$0</b> no se li permet modificar el noms dels amfitrions"
-
-#: pkg/systemd/host.js:559
-msgid "Set Host name"
-msgstr "Estableix el nom de l'amfitrió"
-
-#: pkg/systemd/host.js:661
-msgid "failed to list ssh host keys: $0"
-msgstr ""
-
-#: pkg/systemd/host.js:1113
-msgid "Need at least one NTP server"
-msgstr "Com a mínim es necessita un servidor NTP"
-
-#: pkg/systemd/host.js:1190
-msgid "Invalid date format and invalid time format"
-msgstr "format no vàlid de la data i l'hora"
-
-#: pkg/systemd/host.js:1192
-msgid "Invalid time format"
-msgstr "format d'hora no vàlid"
-
-#: pkg/systemd/host.js:1194
-msgid "Invalid date format"
-msgstr "format de data no vàlid"
-
-#: pkg/systemd/host.js:1250
-msgid "NTP Server"
-msgstr "Servidor NTP"
-
-#: pkg/systemd/host.js:1300
-msgid "Message to logged in users"
-msgstr "Missatge als usuaris que hagin iniciat la sessió"
-
-#: pkg/systemd/host.js:1307 pkg/systemd/host.js:1309
-#: pkg/systemd/index.html.h:19
-msgid "Shutdown"
-msgstr "Atura"
-
-#: pkg/systemd/host.js:1311 pkg/systemd/host.js:1313 pkg/systemd/init.js:517
-#: pkg/systemd/index.html.h:18
-msgid "Restart"
-msgstr "Reinicia"
-
-#: pkg/systemd/host.js:1381
-msgctxt "page-title"
-msgid "CPU Status"
-msgstr "Estat de la CPU"
-
-#: pkg/systemd/host.js:1413 pkg/systemd/index.html.h:24
-msgid "I/O Wait"
-msgstr "Espera d'E/S"
-
-#: pkg/systemd/host.js:1414 pkg/systemd/index.html.h:25
-msgid "Kernel"
-msgstr "Nucli del sistema operatiu"
-
-#: pkg/systemd/host.js:1415 pkg/subscriptions/subscriptions-register.jsx:76
-#: pkg/systemd/index.html.h:26 pkg/kubernetes/views/auth-form.html.h:6
-#: pkg/kubernetes/views/volume-body.html.h:20
-#: pkg/kubernetes/views/user-panel.html.h:1 pkg/playground/translate.html.h:3
-#: pkg/dashboard/index.html.h:8
-msgid "User"
-msgstr "Usuari"
-
-#: pkg/systemd/host.js:1416 pkg/systemd/index.html.h:27
-msgid "Nice"
-msgstr "Nice"
-
-#: pkg/systemd/host.js:1466
-msgctxt "page-title"
-msgid "Memory"
-msgstr "Memòria"
-
-#: pkg/systemd/host.js:1499 pkg/systemd/index.html.h:28
-msgid "Swap Used"
-msgstr "Intercanvi utilitzat"
-
-#: pkg/systemd/host.js:1500 pkg/systemd/index.html.h:29
-msgid "Cached"
-msgstr "Emmagatzemat temporalment"
-
-#: pkg/systemd/host.js:1501 pkg/docker/storage.jsx:313
-#: pkg/kubernetes/scripts/nodes.js:828 pkg/kubernetes/scripts/nodes.js:837
-#: pkg/systemd/index.html.h:30
-msgid "Used"
-msgstr "Utilitzat"
-
-#: pkg/systemd/host.js:1502 pkg/docker/storage.jsx:298
-#: pkg/docker/storage.jsx:320 pkg/systemd/index.html.h:31
-msgid "Free"
-msgstr "Lliure"
-
-#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
-msgid "unknown"
-msgstr "desconegut"
-
-#: pkg/systemd/init.js:269 pkg/systemd/services.html.h:17
-#: pkg/kubernetes/views/project-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:5
-msgid "Description"
-msgstr "Descripció"
-
-#: pkg/systemd/init.js:270
-msgid "Id"
-msgstr "Id"
-
-#: pkg/systemd/init.js:272
-msgid "Next Run"
-msgstr ""
-
-#: pkg/systemd/init.js:273
-msgid "Last Trigger"
-msgstr ""
-
-#: pkg/systemd/init.js:274 pkg/kubernetes/views/container-body.html.h:6
-#: pkg/kubernetes/views/details-page.html.h:8
-msgid "State"
-msgstr "Estat"
-
-#: pkg/systemd/init.js:301
-msgid "Enabled"
-msgstr "Habilitat"
-
-#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
-msgid "Disabled"
-msgstr "Inhabilitat"
-
-#: pkg/systemd/init.js:303
-msgid "Static"
-msgstr "Estàtic"
-
-#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
-msgid "$0 Template"
-msgstr "Plantilla $0"
-
-#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
-msgid "Start"
-msgstr "Inicia"
-
-#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
-msgid "Stop"
-msgstr "Atura"
-
-#: pkg/systemd/init.js:518
-msgid "Reload"
-msgstr "Recarrega"
-
-#: pkg/systemd/init.js:519
-msgid "Reload or Restart"
-msgstr "Recarrega o reinicia"
-
-#: pkg/systemd/init.js:520
-msgid "Try Restart"
-msgstr "Prova de reiniciar"
-
-#: pkg/systemd/init.js:521
-msgid "Reload or Try Restart"
-msgstr "Recarrega o prova de reiniciar"
-
-#: pkg/systemd/init.js:522
-msgid "Isolate"
-msgstr "Aïlla"
-
-#: pkg/systemd/init.js:541
-msgid "Enable"
-msgstr "Habilita"
-
-#: pkg/systemd/init.js:542
-msgid "Enable Forcefully"
-msgstr "Habilita-ho forçosament"
-
-#: pkg/systemd/init.js:543
-msgid "Disable"
-msgstr "Inhabilita"
-
-#: pkg/systemd/init.js:544
-msgid "Preset"
-msgstr "Preajusta"
-
-#: pkg/systemd/init.js:545
-msgid "Preset Forcefully"
-msgstr "Preajusta-ho forçosament"
-
-#: pkg/systemd/init.js:546
-msgid "Mask"
-msgstr "Emmascara"
-
-#: pkg/systemd/init.js:547
-msgid "Mask Forcefully"
-msgstr "Emmascara-ho forçosament"
-
-#: pkg/systemd/init.js:548
-msgid "Unmask"
-msgstr "Desemmascara"
-
-#: pkg/systemd/init.js:621
-msgid "Since $0"
-msgstr "Des de $0"
-
-#: pkg/systemd/init.js:639
-msgid "This unit is an instance of the $0 template."
-msgstr "Aquesta unitat és una instantània de la plantilla $0."
-
-#: pkg/systemd/init.js:834
-#, fuzzy
-msgid "The user <b>$0</b> does not have permissions for creating timers"
-msgstr "A l'usuari <b>$0</b> no se li permet gestionar els servidors"
-
-#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
-#, fuzzy
-msgid "This field cannot be empty."
-msgstr "El nom no pot estar en blanc."
-
-#: pkg/systemd/init.js:1147
-msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
-msgstr ""
-
-#: pkg/systemd/init.js:1169
-#, fuzzy
-msgid "Invalid number."
-msgstr "Clau no vàlida"
-
-#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
-msgid "Hour needs to be a number between 0-23"
-msgstr ""
-
-#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
-msgid "Minute needs to be a number between 0-59"
-msgstr ""
-
-#: pkg/systemd/init.js:1218
-#, fuzzy
-msgid "Invalid date format."
-msgstr "format de data no vàlid"
-
-#: pkg/systemd/init.js:1222
-msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
-msgstr ""
-
-#: pkg/systemd/logs.js:69
-msgid "Load earlier entries"
-msgstr "Carrega les entrades anteriors"
-
-#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
-#: pkg/systemd/logs.js:175
-msgid "Loading..."
-msgstr "S'està carregant..."
-
-#: pkg/systemd/logs.js:130
-msgid "Go to"
-msgstr "Vés a"
-
-#: pkg/systemd/logs.js:257
-msgid "Journal entry"
-msgstr "Entrada de les publicacions"
-
-#: pkg/systemd/logs.js:284
-msgid "Journal entry not found"
-msgstr "Entrada no trobada de les publicacions"
-
-#: pkg/tuned/dialog.js:94
-msgid "Tuned is not available"
-msgstr "Tuned no està disponible"
-
-#: pkg/tuned/dialog.js:96
-msgid "Tuned is not running"
-msgstr "Tuned no s'està executant"
-
-#: pkg/tuned/dialog.js:98
-msgid "Tuned is off"
-msgstr "Tuned no està aturat"
-
-#: pkg/tuned/dialog.js:100
-msgid "This system is using the recommended profile"
-msgstr "El sistema està utilitzant el perfil recomanat"
-
-#: pkg/tuned/dialog.js:102
-msgid "This system is using a custom profile"
-msgstr "El sistema està utilitzant un perfil personalitzat"
-
-#: pkg/tuned/dialog.js:114
-msgid "Communication with tuned has failed"
-msgstr "Ha fallat la comunicació amb tuned"
-
-#: pkg/tuned/dialog.js:133
-msgid "Failed to disable tuned profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:145
-msgid "Failed to switch profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:169
-msgid "Failed to enable tuned"
-msgstr ""
-
-#: pkg/tuned/dialog.js:171
-msgid "Failed to disable tuned"
-msgstr ""
-
-#: pkg/tuned/dialog.js:191
-msgid "Change Performance Profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:200
-msgid "Change Profile"
-msgstr "Canvia el perfil"
-
-#: pkg/tuned/dialog.js:233 pkg/kubernetes/views/service-body.html.h:7
-#: pkg/kubernetes/views/pod-panel.html.h:2
-#: pkg/kubernetes/views/image-config.html.h:8
-#: pkg/kubernetes/views/imagestream-body.html.h:12
-#: pkg/kubernetes/views/pod-page.html.h:5
-msgid "None"
-msgstr "Cap"
-
-#: pkg/tuned/dialog.js:234
-msgid "Disable tuned"
-msgstr "Inhabilita tuned"
-
-#: pkg/tuned/dialog.js:262
-msgid "Tuned has failed to start"
-msgstr "Tuned ha fallat en iniciar-se"
-
-#: pkg/tuned/change-profile.jsx:52
-#, fuzzy
-msgid "recommended"
-msgstr "MII (recomanat)"
-
-#: pkg/lib/journal.js:209
-msgid "[no data]"
-msgstr "[sense dades]"
-
-#: pkg/lib/journal.js:213
-msgid "[$0 bytes of binary data]"
-msgstr "[$0 bytes de dades binàries]"
-
-#: pkg/lib/journal.js:215
-msgid "[binary data]"
-msgstr "[dades binàries]"
-
-#: pkg/lib/journal.js:241
-msgid "Reboot"
-msgstr "Rearrencada"
-
-#: pkg/lib/machine-dialogs.js:364
-msgid "This machine has already been added."
-msgstr "La màquina ja ha estat afegida."
-
-#: pkg/lib/machine-dialogs.js:380
-msgid ""
-"This version of cockpit-ws does not support connecting to a host with an "
-"alternate user or port"
-msgstr ""
-"Aquesta versió decockpit-ws no és compatible amb la connexió a un amfitrió "
-"amb un usuari o port alternatius"
-
-#: pkg/lib/machine-dialogs.js:386
-msgid "The IP address or host name cannot contain whitespace."
-msgstr "L'adreça IP o el nom d'amfitrió no poden contenir espais en blanc."
-
-#: pkg/lib/machine-dialogs.js:412
-msgid "Failed to add machine: $0"
-msgstr "No s'ha pogut afegir la màquina: $0"
-
-#: pkg/lib/machine-dialogs.js:429
-msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:447
-msgid "Enter IP address or host name"
-msgstr "Introduïu l'adreça IP o el nom de l'amfitrió"
-
-#: pkg/lib/machine-dialogs.js:494
-msgid "Failed to edit machine: $0"
-msgstr "No s'ha pogut editar la màquina: $0"
-
-#: pkg/lib/cockpit-components-dialog.jsx:136 pkg/sosreport/index.js:55
-#: pkg/systemd/services.html.h:34 pkg/lib/machine-sync-users.html.h:7
-#: pkg/lib/machine-add.html.h:5 pkg/lib/machine-change-port.html.h:6
-#: pkg/lib/machine-change-auth.html.h:11 pkg/storaged/index.html.h:22
-#: pkg/realmd/operation.html.h:10 pkg/kubernetes/views/node-delete.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:3
-#: pkg/kubernetes/views/pvc-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:3
-#: pkg/kubernetes/views/auth-form.html.h:13
-#: pkg/kubernetes/views/node-add.html.h:7
-#: pkg/kubernetes/views/user-group-add.html.h:5
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:4
-#: pkg/kubernetes/views/route-modify.html.h:3
-#: pkg/kubernetes/views/image-delete.html.h:3
-#: pkg/kubernetes/views/pv-delete.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:4
-#: pkg/kubernetes/views/item-delete.html.h:4
-#: pkg/kubernetes/views/add-user-dialog.html.h:8
-#: pkg/kubernetes/views/user-add-membership.html.h:8
-#: pkg/kubernetes/views/deploy.html.h:4
-#: pkg/kubernetes/views/user-modify.html.h:8
-#: pkg/kubernetes/views/pv-modify.html.h:21
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:5
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:3
-#: pkg/kubernetes/views/imagestream-delete.html.h:3
-#: pkg/kubernetes/views/user-remove-membership.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:7
-#: pkg/kubernetes/views/add-role-dialog.html.h:3
-#: pkg/kubernetes/views/service-modify.html.h:4
-#: pkg/kubernetes/views/project-delete.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:9
-#: pkg/kubernetes/views/user-group-remove.html.h:2
-#: pkg/playground/translate.html.h:2 pkg/dashboard/index.html.h:12
-msgid "Cancel"
-msgstr "Cancel·la"
-
-#: pkg/lib/cockpit-components-dialog.jsx:155
-msgid "Ok"
-msgstr ""
-
-#: pkg/lib/credentials.js:182
-msgid "No such file or directory"
-msgstr "El fitxer o directori no existeix"
-
-#: pkg/lib/credentials.js:186
-msgid "The passwords do not match."
-msgstr "Les contrasenyes no coincideixen."
-
-#: pkg/lib/credentials.js:191
-msgid "Prompting via ssh-keygen timed out"
-msgstr ""
-
-#: pkg/lib/credentials.js:213 pkg/users/local.js:78
-msgid "Old password not accepted"
-msgstr "Contrasenya antiga no acceptada"
-
-#: pkg/lib/credentials.js:223 pkg/users/local.js:112 pkg/users/local.js:144
-msgid "Failed to change password"
-msgstr "Ha fallat el canvi de contrasenya"
-
-#: pkg/lib/credentials.js:231 pkg/users/local.js:120
-msgid "New password was not accepted"
-msgstr "No s'ha acceptat la nova contrasenya"
-
-#: pkg/lib/credentials.js:248
-msgid "Not a valid private key"
-msgstr "No és una clau privada vàlida"
-
-#: pkg/lib/credentials.js:251
-msgid "Prompting via ssh-add timed out"
-msgstr ""
-
-#: pkg/lib/credentials.js:274
-msgid "Invalid file permissions"
-msgstr "Permisos de fitxer no vàlids"
-
-#: pkg/lib/credentials.js:278
-msgid "Password not accepted"
-msgstr "Contrasenya no acceptada"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:22
-#: pkg/shell/index.html.h:27 pkg/storaged/index.html.h:52
-#: pkg/playground/jquery-patterns.html.h:2
-msgid "On"
-msgstr "Engegat"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:23
-#: pkg/shell/index.html.h:28 pkg/storaged/index.html.h:53
-#: pkg/playground/jquery-patterns.html.h:3
-msgid "Off"
-msgstr "Apagat"
-
-#: pkg/shell/base_index.js:670 pkg/users/local.js:1164
-#: pkg/docker/index.html.h:69 pkg/networkmanager/index.html.h:65
-msgid "Unexpected error"
-msgstr "Error inesperat"
-
-#: pkg/shell/base_index.js:671
-msgid "Cockpit had an unexpected internal error. <br/><br/>"
-msgstr "Cockpit va tenir un error intern inesperat. <br/><br/>"
-
-#: pkg/shell/base_index.js:672
-msgid "You can try restarting Cockpit by pressing refresh in your browser. "
-msgstr ""
-"Podeu provar de tornar a iniciar Cockpit, en prémer refresca al vostre "
-"navegador. "
-
-#: pkg/shell/base_index.js:673
-msgid "The javascript console contains details about this error "
-msgstr "La consola javascript conté els detalls sobre aquest error."
-
-#: pkg/shell/base_index.js:674
-msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
-msgstr "(<b>Ctrl-Maj-J</b> en la majoria dels navegadors)."
-
-#: pkg/shell/indexes.js:126 pkg/shell/indexes.js:497 pkg/shell/simple.html.h:17
-msgid "Disconnected"
-msgstr "Desconnectat"
-
-#: pkg/shell/indexes.js:253
-msgid "Machines"
-msgstr "Màquines"
-
-#: pkg/shell/indexes.js:314
-msgid "The machine is restarting"
-msgstr "La màquina s'està reiniciant"
-
-#: pkg/shell/indexes.js:317
-msgid "Connecting to the machine"
-msgstr "S'està connectant a la màquina"
-
-#: pkg/shell/indexes.js:320
-msgid "Couldn't connect to the machine"
-msgstr "No s'ha pogut connectar a la màquina"
-
-#: pkg/shell/indexes.js:322
-msgid "Cannot connect to an unknown machine"
-msgstr "No es pot connectar a una màquina desconeguda"
-
-#: pkg/ostree/client.js:56
-msgid "Receiving delta parts"
-msgstr "S'estan rebent les parts de deltes"
-
-#: pkg/ostree/client.js:58
-msgid "Receiving metadata objects"
-msgstr "S'estan rebent els objectes de metadades"
-
-#: pkg/ostree/client.js:61
-msgid "Receiving objects: $0%"
-msgstr "S'estan rebent objectes: $0%"
-
-#: pkg/ostree/client.js:64
-msgid "Writing objects"
-msgstr "S'estan escrivint els objectes"
-
-#: pkg/ostree/client.js:66
-msgid "Scanning metadata"
-msgstr "S'estan escanejant les metadades"
-
-#: pkg/ostree/client.js:500
-msgid "OS $0 not found"
-msgstr "SO $0 no trobat"
-
-#: pkg/ostree/app.js:81
-msgid "Not authorized to update software on this system"
-msgstr "No autoritzat per actualitzar el programari en aquest sistema"
-
-#: pkg/ostree/app.js:83
-msgid "OSTree is not available on this system"
-msgstr "OSTree no està disponible en aquest sistema"
-
-#: pkg/ostree/app.js:101
-msgid "No OSTree deployments found"
-msgstr "No s'ha trobat desplegaments OSTree"
-
-#: pkg/ostree/app.js:219
-msgid "Checking for updates"
-msgstr "S'està comprovant si hi ha actualitzacions"
+#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
+#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
+#: pkg/playground/translate.js:34
+msgctxt "disk-non-rotational"
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/base1/cockpit.js:2588
+msgid "$0 exited with code $1"
+msgstr "$0 va sortir amb el codi $1"
+
+#: src/base1/cockpit.js:2590
+msgid "$0 failed"
+msgstr "$0 ha fallat"
+
+#: src/base1/cockpit.js:2586
+msgid "$0 killed with signal $1"
+msgstr "$0 es va matar amb el senyal $1"
+
+#: pkg/selinux/setroubleshoot-view.jsx:440
+msgid "$0 occurrence"
+msgid_plural "$1 occurrences"
+msgstr[0] ""
+msgstr[1] ""
 
 #: pkg/ostree/app.js:307
 msgid "$0 package"
@@ -786,691 +558,34 @@ msgstr "$0 paquet"
 msgid "$0 packages"
 msgstr "$0 paquets"
 
-#: pkg/selinux/setroubleshoot.js:65
-msgid "Error while setting SELinux mode: '$0'"
-msgstr ""
+#: pkg/docker/util.js:124
+msgid "$0 shares"
+msgstr "$0 comparticions"
 
-#: pkg/selinux/setroubleshoot.js:238
-msgid "Not connected"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot.js:275
-msgid "Error while connecting."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:82
-msgid "Applying solution..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:90
-msgid "Solution applied successfully"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:97
-#, fuzzy
-msgid "Solution failed"
-msgstr "Ha fallat l'inici de sessió"
-
-#: pkg/selinux/setroubleshoot-view.jsx:107
-msgid "Apply this solution"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:114
-msgid "Unable to apply this solution automatically"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:118
-msgid "solution details"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:309
-msgid "SELinux system status is unknown."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:317
-#, fuzzy
-msgid "SELinux is disabled on the system."
-msgstr "Cockpit no està instal·lat al sistema."
-
-#: pkg/selinux/setroubleshoot-view.jsx:324
-msgid "The configured state is unknown, it might change on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:326
-msgid ""
-"Setting deviates from the configured state and will revert on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:330
-#, fuzzy
-msgid "SELinux Policy"
-msgstr "Política del DNS"
-
-#: pkg/selinux/setroubleshoot-view.jsx:332
-msgid "Enforce policy:"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:382 pkg/kubernetes/index.html.h:10
-#: pkg/kubernetes/registry.html.h:5
-msgid "Connecting..."
-msgstr "S'està connectant..."
-
-#: pkg/selinux/setroubleshoot-view.jsx:385
-msgid ""
-"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
-"server is installed."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:400
-msgid "Occurred between $0 and $1"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:405
-msgid "Occurred $0"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:440
-msgid "$0 occurrence"
-msgid_plural "$1 occurrences"
+#: pkg/kubernetes/scripts/nodes.js:870
+#, c-format
+msgid "$0% Free"
+msgid_plural "$0% Free"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:478
-msgid "SELinux Access Control Errors"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:479
-msgid "No SELinux alerts."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:52
-msgid "Unable to start setroubleshootd"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:157
-msgid "Unable to get alert"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:172
-msgid "Unable to run fix"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:187
-msgid "Failed to delete alert"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:192
-msgid "Error while deleting alert"
-msgstr ""
-
-#: pkg/storaged/dialog.js:267
-msgid "Size must be a number"
-msgstr ""
-
-#: pkg/storaged/dialog.js:269
-#, fuzzy
-msgid "Size cannot be zero"
-msgstr "El nom no pot estar en blanc."
-
-#: pkg/storaged/dialog.js:271
-#, fuzzy
-msgid "Size cannot be negative"
-msgstr "El nom no pot estar en blanc."
-
-#: pkg/storaged/dialog.js:273
-msgid "Size is too large"
-msgstr ""
-
-#: pkg/storaged/details.js:85
-msgid "Device $0 is mounted on $1"
-msgstr "El dispositiu $0 està muntat a $1"
-
-#: pkg/storaged/details.js:91
-msgid "Device $0 is a member of RAID Array $1"
-msgstr "El dispositiu $0 és un membre de la matriu RAID $1"
-
-#: pkg/storaged/details.js:97
-msgid "Device $0 is a physical volume of $1"
-msgstr "El dispositiu $0 és un volum físic de $1"
-
-#: pkg/storaged/details.js:113
-msgid "Create partition on $0"
-msgstr "Crea una partició a $0"
-
-#: pkg/storaged/details.js:115
-msgid "Format $0"
-msgstr "Formata $0"
-
-#: pkg/storaged/details.js:177
-msgid "XFS - Red Hat Enterprise Linux 7 default"
-msgstr "XFS - per defecte Red Hat Enterprise Linux 7"
-
-#: pkg/storaged/details.js:178
-msgid "ext4 - Red Hat Enterprise Linux 6 default"
-msgstr "ext4 - per defecte a Red Hat Enterprise Linux 6"
-
-#: pkg/storaged/details.js:179
-msgid "Encrypted XFS (LUKS)"
-msgstr "XFS xifrat (LUKS)"
-
-#: pkg/storaged/details.js:180
-msgid "Encrypted EXT4 (LUKS)"
-msgstr "EXT4 xifrat (LUKS)"
-
-#: pkg/storaged/details.js:181
-msgid "VFAT - Compatible with all systems and devices"
-msgstr "VFAT - Compatible amb tots els sistemes i dispositius"
-
-#: pkg/storaged/details.js:182
-msgid "NTFS - Compatible with most systems"
-msgstr "NTFS - Compatible amb la majoria dels sistemes"
-
-#: pkg/storaged/details.js:183
-msgid "Extended Partition"
-msgstr "Partició estesa"
-
-#: pkg/storaged/details.js:185
-msgid "No Filesystem"
-msgstr "Sense sistema de fitxers"
-
-#: pkg/storaged/details.js:186
-msgid "Custom (Enter filesystem type)"
-msgstr "Personalitzat (introduïu el tipus del sistema de fitxers)"
-
-#: pkg/storaged/details.js:192 pkg/storaged/details.js:664
-#: pkg/storaged/details.js:735 pkg/storaged/details.js:773
-#: pkg/storaged/details.js:909 pkg/storaged/index.html.h:20
-#: pkg/kubernetes/views/volumes-page.html.h:11
-msgid "Size"
-msgstr "Mida"
-
-#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
-msgid "Erase"
-msgstr "Esborra"
-
-#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
-msgid "Don't overwrite existing data"
-msgstr "No sobreescriguis les dades existents"
-
-#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
-msgid "Overwrite existing data with zeros"
-msgstr "Sobreescriu les dades existents amb zeros"
-
-#: pkg/storaged/details.js:207 pkg/shell/index.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:4
-#: pkg/kubernetes/views/deploy.html.h:2 pkg/kubernetes/views/pv-modify.html.h:3
-msgid "Type"
-msgstr "Tipus"
-
-#: pkg/storaged/details.js:211 pkg/storaged/details.js:429
-#: pkg/storaged/details.js:709 pkg/storaged/details.js:731
-#: pkg/storaged/details.js:769 pkg/storaged/details.js:798
-#: pkg/storaged/details.js:864 pkg/storaged/overview.js:417
-#: pkg/storaged/overview.js:490 pkg/storaged/overview.js:624
-#: pkg/storaged/overview.js:702 pkg/storaged/index.html.h:18
-#: pkg/networkmanager/index.html.h:16
-#: pkg/kubernetes/views/project-listing.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:3
-#: pkg/kubernetes/views/volume-body.html.h:11
-#: pkg/kubernetes/views/containers-listing.html.h:2
-#: pkg/kubernetes/views/volumes-page.html.h:3
-#: pkg/kubernetes/views/pv-claim.html.h:1
-#: pkg/kubernetes/views/pv-modify.html.h:6
-#: pkg/kubernetes/views/image-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:15
-#: pkg/kubernetes/views/nodes-page.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:3
-#: pkg/kubernetes/views/details-page.html.h:4
-#: pkg/kubernetes/views/service-modify.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:3
-msgid "Name"
-msgstr "Nom"
-
-#: pkg/storaged/details.js:215
-msgid "Filesystem type"
-msgstr "Tipus de sistema de fitxers"
-
-#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
-msgid "Passphrase"
-msgstr "Contrasenya"
-
-#: pkg/storaged/details.js:224
-#, fuzzy
-msgid "Passphrase cannot be empty"
-msgstr "La contrasenya no pot estar en blanc"
-
-#: pkg/storaged/details.js:229
-msgid "Confirm passphrase"
-msgstr "Confirmació de la contrasenya"
-
-#: pkg/storaged/details.js:232
-msgid "Passphrases do not match"
-msgstr "Les contrasenyes no coincideixen"
-
-#: pkg/storaged/details.js:237
-msgid "Store passphrase"
-msgstr "Emmagatzema la contrasenya"
-
-#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
-#: pkg/storaged/details.js:1115
-msgid "Encryption Options"
-msgstr "Opcions de xifrat"
-
-#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
-msgid "Mounting"
-msgstr "Muntatge"
-
-#: pkg/storaged/details.js:247 pkg/storaged/details.js:435
-#: pkg/subscriptions/subscriptions-register.jsx:101 pkg/docker/index.html.h:23
-#: pkg/kubernetes/views/image-config.html.h:2
-msgid "Default"
-msgstr "Predeterminat"
-
-#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
-msgid "Custom"
-msgstr "Personalitzat"
-
-#: pkg/storaged/details.js:253 pkg/storaged/details.js:440
-#: pkg/storaged/index.html.h:19
-msgid "Mount Point"
-msgstr "Punt de muntatge"
-
-#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
-msgid "Mount Options"
-msgstr "Opcions de muntatge"
-
-#: pkg/storaged/details.js:266
-msgid "Create partition"
-msgstr "Crea una partició"
-
-#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
-#: pkg/storaged/details.js:1142
-msgid "Format"
-msgstr "Formata"
-
-#: pkg/storaged/details.js:268
-msgid "Formatting a storage device will erase all data on it."
-msgstr ""
-"La formatació d'un dispositiu d'emmagatzematge eliminarà totes les dades "
-"contingudes."
-
-#: pkg/storaged/details.js:335
-msgid "Format Disk $0"
-msgstr "Formata el disc $0"
-
-#: pkg/storaged/details.js:346
-msgid "Partitioning"
-msgstr "Particionatge"
-
-#: pkg/storaged/details.js:348
-msgid "Compatible with all systems and devices (MBR)"
-msgstr "Compatible amb tots els sistemes i dispositius (MBR)"
-
-#: pkg/storaged/details.js:349
-msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr "Compatible amb els sistemes moderns i els discs durs > 2TB (GPT)"
-
-#: pkg/storaged/details.js:352
-msgid "No partitioning"
-msgstr "Sense particionatge"
-
-#: pkg/storaged/details.js:358
-msgid "Formatting a disk will erase all data on it."
-msgstr "La formatació d'un disc eliminarà totes les dades contingudes."
-
-#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
-msgid "Filesystem Options"
-msgstr "Opcions del sistema de fitxers"
-
-#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
-msgid "Apply"
-msgstr "Aplica"
-
-#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
-#: pkg/storaged/details.js:1110
-msgid "Unlock"
-msgstr "Desbloqueja"
-
-#: pkg/storaged/details.js:527
-msgid "Stored Passphrase"
-msgstr "Contrasenya emmagatzemada"
-
-#: pkg/storaged/details.js:531 pkg/kubernetes/views/volume-body.html.h:32
-msgid "Options"
-msgstr "Opcions"
-
-#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
-msgid "Add Disks"
-msgstr "Afegeix discs"
-
-#: pkg/storaged/details.js:567 pkg/storaged/details.js:933
-#: pkg/storaged/overview.js:448 pkg/storaged/overview.js:495
-#: pkg/storaged/index.html.h:55
-msgid "Disks"
-msgstr "Discs"
-
-#: pkg/storaged/details.js:579 pkg/storaged/details.js:948
-#: pkg/storaged/overview.js:501
-msgid "At least one disk is needed."
-msgstr "Com a mínim es necessita un disc."
-
-#: pkg/storaged/details.js:584 pkg/storaged/details.js:953
-#: pkg/storaged/overview.js:629 pkg/storaged/overview.js:657
-#: pkg/lib/machine-add.html.h:6 pkg/kubernetes/views/node-add.html.h:8
-#: pkg/kubernetes/views/user-group-add.html.h:6
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:5
-#: pkg/kubernetes/views/add-user-dialog.html.h:9
-#: pkg/kubernetes/views/user-add-membership.html.h:9
-#: pkg/kubernetes/views/add-role-dialog.html.h:4
-msgid "Add"
-msgstr "Afegeix"
-
-#: pkg/storaged/details.js:625 pkg/storaged/details.js:821
-#: pkg/storaged/details.js:1016 pkg/docker/details.js:271
-#: pkg/docker/image.js:151 pkg/docker/containers-view.jsx:166
-msgid "Please confirm deletion of $0"
-msgstr "Si us plau, confirmeu la supressió de $0"
-
-#: pkg/storaged/details.js:630 pkg/storaged/details.js:827
-#: pkg/storaged/details.js:1022 pkg/storaged/details.js:1151
-#: pkg/storaged/details.js:1616 pkg/storaged/details.js:1776
-#: pkg/docker/details.js:273 pkg/docker/image.js:153
-#: pkg/docker/containers-view.jsx:168 pkg/kubernetes/scripts/volumes.js:218
-#: pkg/users/index.html.h:9 pkg/kubernetes/views/node-delete.html.h:5
-#: pkg/kubernetes/views/pvc-delete.html.h:5
-#: pkg/kubernetes/views/image-delete.html.h:4
-#: pkg/kubernetes/views/pv-delete.html.h:5
-#: pkg/kubernetes/views/item-delete.html.h:5
-#: pkg/kubernetes/views/imagestream-delete.html.h:4
-#: pkg/kubernetes/views/user-remove-membership.html.h:3
-#: pkg/kubernetes/views/project-delete.html.h:3
-msgid "Delete"
-msgstr "Suprimeix"
-
-#: pkg/storaged/details.js:631
-msgid "Deleting a RAID device will erase all data on it."
-msgstr "La supressió d'un dispositiu RAID n'esborrarà totes les dades."
-
-#: pkg/storaged/details.js:661
-msgid "Resize Logical Volume"
-msgstr "Redimensiona el volum lògic"
-
-#: pkg/storaged/details.js:673
-msgid "Resize Filesystem"
-msgstr "Redimensiona el sistema de fitxers"
-
-#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
-msgid "Resize"
-msgstr "Redimensiona"
-
-#: pkg/storaged/details.js:690
-msgid "This logical volume cannot be made smaller."
-msgstr ""
-
-#: pkg/storaged/details.js:706
-msgid "Renamee Logical Volume"
-msgstr "Reanomena el volum lògic"
-
-#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
-#: pkg/storaged/details.js:1775
-msgid "Rename"
-msgstr "Reanomena"
-
-#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
-msgid "Create Snapshot"
-msgstr "Crea una instantània"
-
-#: pkg/storaged/details.js:745 pkg/storaged/details.js:781
-#: pkg/storaged/details.js:804 pkg/storaged/details.js:915
-#: pkg/storaged/overview.js:461 pkg/storaged/overview.js:506
-#: pkg/kubernetes/views/add-group-dialog.html.h:6
-#: pkg/kubernetes/views/project-modify.html.h:8
-msgid "Create"
-msgstr "Crea"
-
-#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
-msgid "Create Thin Volume"
-msgstr "Crea un volum disgregat"
-
-#: pkg/storaged/details.js:795
-msgid "Rename Volume Group"
-msgstr "Reanomena un grup de volums"
-
-#: pkg/storaged/details.js:826
-msgid "Deleting a volume group will erase all data on it."
-msgstr "La supressió d'un grup de volums n'esborrarà totes les dades."
-
-#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
-msgid "Create Logical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:869
-msgid "Purpose"
-msgstr ""
-
-#: pkg/storaged/details.js:871
-msgid "Block device for filesystems"
-msgstr ""
-
-#: pkg/storaged/details.js:874
-msgid "Pool for thinly provisioned volumes"
-msgstr ""
-
-#: pkg/storaged/details.js:1009
-msgid "Deleting a logical volume will delete all data in it."
-msgstr "La supressió d'un volum lògic n'esborrarà totes les dades."
-
-#: pkg/storaged/details.js:1012
-msgid "Deleting a partition will delete all data in it."
-msgstr "La supressió d'una partició n'esborrarà totes les dades."
-
-#: pkg/storaged/details.js:1053 pkg/storaged/overview.js:689
-#: pkg/storaged/devices.js:119 pkg/users/local.js:1155
-#: pkg/systemd/services.html.h:14
-msgid "Error"
-msgstr "Error"
-
-#: pkg/storaged/details.js:1099
-msgid "Mount"
-msgstr "Munta"
-
-#: pkg/storaged/details.js:1100
-msgid "Unmount"
-msgstr "Desmunta"
-
-#: pkg/storaged/details.js:1109
-msgid "Lock"
-msgstr "Bloqueja"
-
-#: pkg/storaged/details.js:1127
-msgid "Activate"
-msgstr "Activa"
-
-#: pkg/storaged/details.js:1130
-msgid "Deactivate"
-msgstr "Desactiva"
-
-#: pkg/storaged/details.js:1221
-msgctxt "storage-id-desc"
-msgid "$0 File System"
-msgstr "sistema de fitxers $0"
-
-#: pkg/storaged/details.js:1224
-msgctxt "storage-id-desc"
-msgid "Linux MD-RAID Component"
-msgstr "Component MD-RAID de Linux"
-
-#: pkg/storaged/details.js:1226
-msgctxt "storage-id-desc"
-msgid "LVM2 Physical Volume"
-msgstr "Volum físic LVM2"
-
-#: pkg/storaged/details.js:1228
-msgctxt "storage-id-desc"
-msgid "RAID Member"
-msgstr "Membre RAID"
-
-#: pkg/storaged/details.js:1245
-msgctxt "storage-id-desc"
-msgid "LUKS Encrypted"
-msgstr "LUKS xifrat"
-
-#: pkg/storaged/details.js:1247
-msgctxt "storage-id-desc"
-msgid "Encrypted"
-msgstr "Xifrat"
-
-#: pkg/storaged/details.js:1251
-msgctxt "storage-id-desc"
-msgid "Swap Space"
-msgstr "espai d'intercanvi"
-
-#: pkg/storaged/details.js:1253
-msgctxt "storage-id-desc"
-msgid "Other Data"
-msgstr "Altres dades"
-
-#: pkg/storaged/details.js:1256
-msgctxt "storage-id-desc"
-msgid "Unrecognized Data"
-msgstr "Dades no reconegudes"
-
-#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
-msgid "$size $partition"
-msgstr "$partition de $size"
-
-#: pkg/storaged/details.js:1278
-msgid "mounted on $0"
-msgstr "s'ha muntat a $0"
-
-#: pkg/storaged/details.js:1280
-msgid "not mounted"
-msgstr "no muntat"
-
-#: pkg/storaged/details.js:1284
-msgid "unlocked"
-msgstr "desbloquejat"
-
-#: pkg/storaged/details.js:1286
-msgid "locked"
-msgstr "bloquejat"
-
-#: pkg/storaged/details.js:1367
-msgid "$0 Free Space for Logical Partitions"
-msgstr "$0 d'espai lliure per a les particions lògiques"
-
-#: pkg/storaged/details.js:1370
-msgid "$0 Free Space for Primary Partitions"
-msgstr "$0 d'espai lliure per a les particions primàries"
-
-#: pkg/storaged/details.js:1375
-msgid "$0 Free Space"
-msgstr "$0 d'espai lliure"
-
-#: pkg/storaged/details.js:1379
-msgid "Create Partition"
-msgstr "Crea una partició"
-
-#: pkg/storaged/details.js:1387
-msgid "$0 Extended Partition"
-msgstr "Partició estesa $0"
-
-#: pkg/storaged/details.js:1424
-msgid "Logical Partition"
-msgstr "Partició lògica"
-
-#: pkg/storaged/details.js:1426
-msgid "Primary Partition"
-msgstr "Partició primària"
-
-#: pkg/storaged/details.js:1428 pkg/kubernetes/views/volume-body.html.h:5
-msgid "Partition"
-msgstr "Partició"
-
-#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
-msgid "Content"
-msgstr "Contingut"
-
-#: pkg/storaged/details.js:1533
-msgid "RAID 0"
-msgstr "RAID 0"
-
-#: pkg/storaged/details.js:1534
-msgid "RAID 1"
-msgstr "RAID 1"
-
-#: pkg/storaged/details.js:1535
-msgid "RAID 4"
-msgstr "RAID 4"
-
-#: pkg/storaged/details.js:1536
-msgid "RAID 5"
-msgstr "RAID 5"
-
-#: pkg/storaged/details.js:1537
-msgid "RAID 6"
-msgstr "RAID 6"
-
-#: pkg/storaged/details.js:1538
-msgid "RAID 10"
-msgstr "RAID 10"
-
-#: pkg/storaged/details.js:1539
-msgid "RAID ($0)"
-msgstr "RAID ($0)"
-
-#: pkg/storaged/details.js:1544
-msgid "$0 Disks"
-msgstr "$0 discs"
-
-#: pkg/storaged/details.js:1546
-msgid "$0 Chunk Size"
-msgstr "$0 de mida del tros"
-
-#: pkg/storaged/details.js:1574 pkg/ostree/index.html.h:7
-msgid "Running"
-msgstr "En execució"
-
-#: pkg/storaged/details.js:1574
-msgid "Not running"
-msgstr "No s'està executant"
-
-#: pkg/storaged/details.js:1592
-msgid "FAILED"
-msgstr "FALLAT"
-
-#: pkg/storaged/details.js:1593
-msgid "In Sync"
-msgstr "En sincronització"
-
-#: pkg/storaged/details.js:1594
-msgid "Spare"
-msgstr "Recanvi"
-
-#: pkg/storaged/details.js:1594
-msgid "Recovering"
-msgstr "Recuperació"
-
-#: pkg/storaged/details.js:1595
-msgid "Write-mostly"
-msgstr "Escriptura-majoritària"
-
-#: pkg/storaged/details.js:1596
-msgid "Blocked"
-msgstr "Bloquejat"
-
-#: pkg/storaged/details.js:1597
-msgid "Unknown ($0)"
-msgstr "Desconegut ($0)"
-
-#: pkg/storaged/details.js:1614
-msgid "Start Scrubbing"
-msgstr "Inicia el tractament de neteja"
-
-#: pkg/storaged/details.js:1615
-msgid "Stop Scrubbing"
-msgstr "Atura el tractament de neteja"
+#: pkg/kubernetes/scripts/nodes.js:872
+msgid "$0% Used"
+msgid_plural "$0% Used"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/storaged/details.js:1765
+msgid "$0, $1 free"
+msgstr "$0 amb $1 lliures"
+
+#: pkg/networkmanager/interfaces.js:2473
+msgid "$mtu"
+msgstr "$mtu"
+
+#: pkg/storaged/utils.js:157
+msgid "$name (from $host)"
+msgstr "$name (de $host)"
 
 #: pkg/storaged/details.js:1653
 msgid "$size $desc"
@@ -1485,217 +600,2835 @@ msgstr ""
 msgid "$size $desc<br/>($state)"
 msgstr "$desc de $size<br/>($state)"
 
-#: pkg/storaged/details.js:1692
-msgid "active, but unsupported"
-msgstr "actiu, però no suportat"
+#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
+msgid "$size $partition"
+msgstr "$partition de $size"
 
-#: pkg/storaged/details.js:1692
-msgid "inactive"
-msgstr "inactiu"
+#: pkg/docker/details.js:144
+msgid "${hip}:${hport} -> $cport"
+msgstr "${hip}:${hport} -> $cport"
 
-#: pkg/storaged/details.js:1711
-msgid "$0 Free Space for Logical Volumes"
-msgstr "$0 d'espai lliure per als volums lògics"
-
-#: pkg/storaged/details.js:1751
-msgid "The last physical volume of a volume group cannot be removed."
+#: pkg/subscriptions/subscriptions-client.js:198
+msgid "'Organization' required to register."
 msgstr ""
 
-#: pkg/storaged/details.js:1756
+#: pkg/subscriptions/subscriptions-client.js:202
+msgid "'Organization' required when using activation keys."
+msgstr ""
+
+#: pkg/shell/base_index.js:674
+msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
+msgstr "(<b>Ctrl-Maj-J</b> en la majoria dels navegadors)."
+
+#: pkg/storaged/overview.js:440
+msgid "1 MiB"
+msgstr "1 MiB"
+
+#: pkg/systemd/index.html:459 pkg/systemd/index.html:463
+msgid "1 Minute"
+msgstr "1 minut"
+
+#: pkg/storaged/index.html:312 pkg/networkmanager/index.html:55
+#: pkg/networkmanager/index.html:501
+msgid "1 day"
+msgstr "1 dia"
+
+#: pkg/storaged/index.html:310 pkg/networkmanager/index.html:53
+#: pkg/networkmanager/index.html:499
+msgid "1 hour"
+msgstr "1 hora"
+
+#: pkg/storaged/index.html:313 pkg/networkmanager/index.html:56
+#: pkg/networkmanager/index.html:502
+msgid "1 week"
+msgstr "1 setmana"
+
+#: pkg/playground/translate.html:190
+#, fuzzy
+msgid "1% Free"
+msgid_plural "{{$count}}% Free"
+msgstr[0] "Lliure"
+msgstr[1] "Lliure"
+
+#: pkg/storaged/overview.js:438
+msgid "128 KiB"
+msgstr "128 KiB"
+
+#: pkg/storaged/overview.js:435
+msgid "16 KiB"
+msgstr "16 KiB"
+
+#: pkg/storaged/overview.js:441
+msgid "2 MiB"
+msgstr "2 MiB"
+
+#: pkg/systemd/index.html:465
+msgid "20 Minutes"
+msgstr "20 minuts"
+
+#: pkg/storaged/overview.js:436
+msgid "32 KiB"
+msgstr "32 KiB"
+
+#: pkg/storaged/overview.js:433
+msgid "4 KiB"
+msgstr "4 KiB"
+
+#: pkg/systemd/index.html:466
+msgid "40 Minutes"
+msgstr "40 minuts"
+
+#: pkg/systemd/index.html:464
+msgid "5 Minutes"
+msgstr "5 minuts"
+
+#: pkg/storaged/index.html:309 pkg/networkmanager/index.html:52
+#: pkg/networkmanager/index.html:498
+msgid "5 minutes"
+msgstr "5 minuts"
+
+#: pkg/storaged/overview.js:439
+msgid "512 KiB"
+msgstr "512 KiB"
+
+#: pkg/storaged/index.html:311 pkg/networkmanager/index.html:54
+#: pkg/networkmanager/index.html:500
+msgid "6 hours"
+msgstr "6 hores"
+
+#: pkg/systemd/index.html:467
+msgid "60 Minutes"
+msgstr "60 minuts"
+
+#: pkg/storaged/overview.js:437
+msgid "64 KiB"
+msgstr "64 KiB"
+
+#: pkg/storaged/overview.js:434
+msgid "8 KiB"
+msgstr "8 KiB"
+
+#: pkg/networkmanager/interfaces.js:1826
+msgid "802.3ad"
+msgstr "802.3ad"
+
+#: pkg/networkmanager/interfaces.js:1843
+#, fuzzy
+msgid "802.3ad LACP"
+msgstr "802.3ad"
+
+#: pkg/systemd/services.html:446
+msgid ":"
+msgstr ""
+
+#: pkg/storaged/utils.js:220
+msgid "<span>Encrypted $0</span>"
+msgstr "<span>Xifrat $0</span>"
+
+#: pkg/storaged/utils.js:212
+msgid "<span>Encrypted Logical Volume of $0</span>"
+msgstr "<span>Volum lògic xifrat de $0</span>"
+
+#: pkg/storaged/utils.js:214
+msgid "<span>Encrypted Partition of $0</span>"
+msgstr "<span>Partició xifrada de $0</span>"
+
+#: pkg/storaged/utils.js:216
+msgid "<span>Logical Volume of $0</span>"
+msgstr "<span>Volum lògic de $0</span>"
+
+#: pkg/storaged/utils.js:218
+msgid "<span>Partition of $0</span>"
+msgstr "<span>Partició de $0</span>"
+
+#: pkg/lib/machine-not-supported.html:5
 msgid ""
-"There is not enough free space elsewhere to remove this physical volume.  At "
-"least $0 more free space is needed."
+"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
+"strong}}."
+msgstr ""
+"Una versió compatible de Cockpit no està instal·lada a {{#strong}}{{host}}{{/"
+"strong}}."
+
+#: cockpit.desktop.in.h:2
+msgid "A user interface for GNU/Linux servers"
+msgstr "Una interfície d'usuari per als servidors GNU/Linux"
+
+#: pkg/networkmanager/interfaces.js:1834
+msgid "ARP"
+msgstr "ARP"
+
+#: pkg/networkmanager/interfaces.js:2502
+msgid "ARP Monitoring"
+msgstr "Monitoratge ARP"
+
+#: pkg/networkmanager/interfaces.js:1855
+#, fuzzy
+msgid "ARP Ping"
+msgstr "Monitoratge ARP"
+
+#: pkg/kubernetes/scripts/volumes.js:193
+msgid "AWS Elastic Block Store"
 msgstr ""
 
-#: pkg/storaged/details.js:1765
-msgid "$0, $1 free"
-msgstr "$0 amb $1 lliures"
+#: pkg/shell/simple.html:41 pkg/shell/simple.html:67 pkg/shell/index.html:41
+#: pkg/shell/index.html:80 pkg/shell/stub.html:41 pkg/shell/stub.html:73
+msgid "About Cockpit"
+msgstr "Quant a Cockpit"
 
-#: pkg/storaged/details.js:1792
-msgid "Logical Volumes"
-msgstr "Volums lògics"
+#: pkg/users/index.html:105 pkg/users/index.html:191
+msgid "Access"
+msgstr "Accés"
 
-#: pkg/storaged/details.js:1822 pkg/docker/details.js:177
-#: pkg/docker/image.js:112
-msgid "Not found"
-msgstr "No s'ha trobat"
+#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pv-claim.html:9
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-body.html:9
+msgid "Access Modes"
+msgstr ""
 
-#: pkg/storaged/overview.js:180
+#: pkg/kubernetes/views/project-modify.html:49
+#: pkg/kubernetes/views/imagestream-body.html:11
+msgid "Access Policy"
+msgstr "Política d'accés"
+
+#: pkg/subscriptions/subscriptions-view.jsx:191
+#, fuzzy
+msgid "Access denied"
+msgstr "Accés"
+
+#: pkg/shell/index.html:45
+msgid "Account Settings"
+msgstr "Paràmetres dels comptes"
+
+#: pkg/users/index.html:63
+msgid "Account not available or cannot be edited."
+msgstr "El compte no està disponible o no es pot editar."
+
+#: pkg/users/index.html:71
+msgid "Accounts"
+msgstr "Comptes"
+
+#: pkg/users/local.js:284 pkg/users/local.js:594
+msgctxt "page-title"
+msgid "Accounts"
+msgstr "Comptes"
+
+#: pkg/storaged/details.js:1127
+msgid "Activate"
+msgstr "Activa"
+
+#: pkg/storaged/jobs.js:148
+msgid "Activating $target"
+msgstr "S'està activant $target"
+
+#: pkg/subscriptions/subscriptions-register.jsx:164
+#, fuzzy
+msgid "Activation Key"
+msgstr "Activa"
+
+#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
+msgid "Active"
+msgstr "Activa"
+
+#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
+msgid "Active Backup"
+msgstr "Activa la còpia de seguretat"
+
+#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
+msgid "Actual"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1828
+msgid "Adaptive load balancing"
+msgstr "Balanceig de càrrega adaptativa"
+
+#: pkg/networkmanager/interfaces.js:1827
+msgid "Adaptive transmit load balancing"
+msgstr "Balanceig de càrrega de transmissió adaptativa"
+
+#: pkg/kubernetes/views/add-user-dialog.html:31
+#: pkg/kubernetes/views/node-add.html:50
+#: pkg/kubernetes/views/user-add-membership.html:53
+#: pkg/kubernetes/views/add-member-role-dialog.html:61
+#: pkg/kubernetes/views/user-group-add.html:32
+#: pkg/kubernetes/views/add-role-dialog.html:8 pkg/lib/machine-add.html:43
+msgid "Add"
+msgstr "Afegeix"
+
+#: pkg/networkmanager/interfaces.js:2836
+msgid "Add $0"
+msgstr ""
+
+#: pkg/docker/storage.jsx:363
+msgid "Add Additional Storage"
+msgstr ""
+
+#: pkg/networkmanager/index.html:86
+msgid "Add Bond"
+msgstr "Afegeix un enllaç"
+
+#: pkg/networkmanager/index.html:88
+msgid "Add Bridge"
+msgstr "Afegeix un pont"
+
+#: pkg/kubernetes/views/node-add.html:3
+msgid "Add Cluster Node"
+msgstr ""
+
+#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
+msgid "Add Disks"
+msgstr "Afegeix discs"
+
+#: pkg/kubernetes/views/add-group-dialog.html:3
+msgid "Add Group"
+msgstr "Afegeix un grup"
+
+#: pkg/kubernetes/views/nodes-page.html:34
+msgid "Add Kubernetes Node"
+msgstr ""
+
+#: pkg/lib/machine-add.html:4
+msgid "Add Machine to Dashboard"
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:38
+#: pkg/kubernetes/views/add-member-role-dialog.html:4
+#: pkg/kubernetes/views/group-panel.html:29
+#: pkg/kubernetes/views/user-group-add.html:3
+#: pkg/kubernetes/views/project-body.html:108
+msgid "Add Member"
+msgstr "Afegeix un membre"
+
+#: pkg/kubernetes/views/user-panel.html:76
+#: pkg/kubernetes/views/user-body.html:67
+msgid "Add Membership"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:11
+#: pkg/kubernetes/views/auth-form.html:20
+msgid "Add New Cluster"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:67
+#: pkg/kubernetes/views/auth-form.html:76
+msgid "Add New User"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:3
+msgid "Add Role"
+msgstr "Afegeix un rol"
+
+#: pkg/networkmanager/index.html:87
+#, fuzzy
+msgid "Add Team"
+msgstr "Afegeix un membre"
+
+#: pkg/kubernetes/views/add-user-dialog.html:3
+#: pkg/kubernetes/views/project-listing.html:83
+msgid "Add User"
+msgstr "Afegeix un usuari"
+
+#: pkg/networkmanager/index.html:89
+msgid "Add VLAN"
+msgstr "Afegeix una VLAN"
+
+#: pkg/storaged/overview.js:515
+msgid "Add iSCSI Portal"
+msgstr "Afegeix un portal iSCSI"
+
+#: pkg/kubernetes/views/user-add-membership.html:3
+msgid "Add membership"
+msgstr ""
+
+#: pkg/users/index.html:351
+msgid "Add public key"
+msgstr "Afegeix una clau pública"
+
+#: pkg/networkmanager/interfaces.js:2833
+msgid "Adding <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/users/authorized-keys.js:108
+msgid "Adding key"
+msgstr "S'està afegint la clau"
+
+#: pkg/storaged/jobs.js:153
+msgid "Adding physical volume to $target"
+msgstr "S'està afegint el volum físic a $target"
+
+#: pkg/docker/index.html:329
+msgid "Additional Storage"
+msgstr ""
+
+#: pkg/ostree/index.html:121 pkg/ostree/index.html:140
+msgid "Additions"
+msgstr "Addicions"
+
+#: pkg/kubernetes/views/node-add.html:8
+#: pkg/kubernetes/views/dashboard-page.html:157
+#: pkg/kubernetes/views/details-page.html:174
+#: pkg/kubernetes/views/nodes-page.html:43
+#: pkg/kubernetes/views/auth-form.html:29 pkg/kubernetes/views/node-body.html:5
+#: pkg/lib/machine-add.html:11
+msgid "Address"
+msgstr "Adreça"
+
+#: pkg/kubernetes/views/details-page.html:37
+msgid "Addresses"
+msgstr "Adreces"
+
+#: pkg/kubernetes/views/service-modify.html:25
+msgid "Adjust"
+msgstr "Ajusta"
+
+#: pkg/kubernetes/views/pv-modify.html:3
+msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-modify.html:3
+msgid "Adjust Replication Controller {{ item.metadata.name }}"
+msgstr ""
+
+#: pkg/kubernetes/views/route-modify.html:3
+msgid "Adjust Route"
+msgstr "Ajusta la ruta"
+
+#: pkg/kubernetes/views/service-modify.html:3
+msgid "Adjust Service"
+msgstr "Ajusta el servei"
+
+#: pkg/kubernetes/views/project-body.html:56
+msgid "Admin"
+msgstr ""
+
+#: pkg/systemd/services.html:389 pkg/systemd/services.html:393
+#, fuzzy
+msgid "After system boot"
+msgstr "Registra el sistema"
+
+#: pkg/systemd/logs.html:50
+msgid "All"
+msgstr "Tots"
+
+#: pkg/kubernetes/views/filter-project.html:4
+msgid "All Projects"
+msgstr "Tots els projectes"
+
+#: pkg/kubernetes/views/details-page.html:6
+msgid "All Types"
+msgstr "Tots els tipus"
+
+#: pkg/docker/storage.jsx:366
+msgid ""
+"All data on selected disks will be erased and disks will be added to the "
+"storage pool."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:112
+msgid "All healthy"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:74
+msgid "All images"
+msgstr "Totes les imatges"
+
+#: pkg/kubernetes/views/dashboard-page.html:69
+msgid "All in use"
+msgstr "Tots en ús"
+
+#: pkg/kubernetes/views/dashboard-page.html:37
+msgid "All running"
+msgstr ""
+
+#: pkg/docker/index.html:569
+msgid "Always"
+msgstr "Sempre"
+
+#: pkg/kubernetes/views/imagestream-meta.html:2
+#: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/image-meta.html:9
+#: pkg/kubernetes/views/node-body.html:57
+msgid "Annotations"
+msgstr "Anotacions"
+
+#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
+msgid "Apply"
+msgstr "Aplica"
+
+#: pkg/selinux/setroubleshoot-view.jsx:107
+msgid "Apply this solution"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:82
+msgid "Applying solution..."
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:12
+msgid "Architecture"
+msgstr "Arquitectura"
+
+#: pkg/storaged/index.html:451
 msgctxt "storage"
-msgid "Hard Disk"
-msgstr "Disc dur"
+msgid "Assessment"
+msgstr "Avaluació"
 
-#: pkg/storaged/overview.js:182
-msgctxt "storage"
-msgid "Solid-State Disk"
-msgstr "Disc d'estat sòlid"
+#: pkg/systemd/index.html:81
+msgid "Asset Tag"
+msgstr "Etiqueta de recurs"
 
-#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
-msgctxt "storage"
-msgid "Removable Drive"
-msgstr "Disc extraïble"
+#: pkg/storaged/overview.js:455
+msgid "At least $0 disks are needed."
+msgstr "Com a mínim es necessiten $0 discs."
 
-#: pkg/storaged/overview.js:189
+#: pkg/storaged/overview.js:501 pkg/storaged/details.js:579
+#: pkg/storaged/details.js:948
+msgid "At least one disk is needed."
+msgstr "Com a mínim es necessita un disc."
+
+#: pkg/systemd/services.html:394
+#, fuzzy
+msgid "At specific time"
+msgstr "Temps específic"
+
+#: pkg/networkmanager/interfaces.js:813
+msgid "Authenticating"
+msgstr "S'està autenticant"
+
+#: pkg/realmd/operation.html:34 pkg/shell/index.html:48
+#: pkg/shell/index.html:159 pkg/kubernetes/views/auth-form.html:85
+#: pkg/lib/machine-change-auth.html:32
+msgid "Authentication"
+msgstr "Autenticació"
+
+#: pkg/lib/machine-auth-failed.html:2
+msgid "Authentication Failed"
+msgstr "L'autenticació ha fallat"
+
+#: pkg/docker/index.html:730 pkg/kubernetes/views/image-body.html:12
+#: pkg/kubernetes/views/image-listing.html:15
+msgid "Author"
+msgstr "Autor"
+
+#: pkg/users/index.html:130
+msgid "Authorized Public SSH Keys"
+msgstr "Claus SSH públiques autoritzades"
+
+#: pkg/networkmanager/index.html:165
+msgid "Automatic"
+msgstr "Automàtic"
+
+#: pkg/networkmanager/interfaces.js:1814
+msgid "Automatic (DHCP only)"
+msgstr "Automàtica, tan sols DHCP"
+
+#: pkg/networkmanager/interfaces.js:1804
+msgid "Automatic (DHCP)"
+msgstr "Automàtica (DHCP)"
+
+#: pkg/systemd/index.html:406
+msgid "Automatically using NTP"
+msgstr "Automàticament mitjançant NTP"
+
+#: pkg/systemd/index.html:407
+msgid "Automatically using specific NTP servers"
+msgstr "Automàticament mitjançant servidors NTP específics"
+
+#: pkg/lib/machine-change-auth.html:66
+msgid "Available"
+msgstr "Disponible"
+
+#: pkg/storaged/overview.js:619
+msgid "Available targets on $0"
+msgstr "Objectius disponibles en $0"
+
+#: pkg/dashboard/index.html:177
+msgid "Avatar"
+msgstr "Avatar"
+
+#: pkg/kubernetes/scripts/volumes.js:207
+msgid "Azure"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
+msgid "Bad data passed for passwd1 mechanism"
+msgstr "S'han passat dades dolentes al mecanisme del passwd1"
+
+#: pkg/networkmanager/index.html:389
+msgid "Balancer"
+msgstr ""
+
+#: pkg/storaged/index.html:560
 msgctxt "storage"
-msgid "Optical Drive"
-msgstr "Unitat òptica"
+msgid "Bitmap"
+msgstr "Mapa de bits"
+
+#: pkg/storaged/index.html:414
+msgid "Block Device"
+msgstr "Dispositiu de blocs"
+
+#: pkg/storaged/details.js:871
+msgid "Block device for filesystems"
+msgstr ""
+
+#: pkg/storaged/details.js:1596
+msgid "Blocked"
+msgstr "Bloquejat"
+
+#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
+#: pkg/networkmanager/interfaces.js:2507
+msgid "Bond"
+msgstr "Enllaç"
+
+#: pkg/networkmanager/index.html:596
+msgid "Bond Settings"
+msgstr "Ajusts de l'enllaç"
+
+#: pkg/kubernetes/views/node-body.html:17
+msgid "Boot ID"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
+#: pkg/networkmanager/interfaces.js:2584
+msgid "Bridge"
+msgstr "Pont"
+
+#: pkg/networkmanager/index.html:708
+msgid "Bridge Port Settings"
+msgstr "Ajusts del port del pont"
+
+#: pkg/networkmanager/index.html:680
+msgid "Bridge Settings"
+msgstr "Ajusts del pont"
+
+#: pkg/networkmanager/interfaces.js:2605
+msgid "Bridge port"
+msgstr "Port del pont"
+
+#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
+msgid "Broadcast"
+msgstr "Difusió"
+
+#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#, fuzzy
+msgid "Broken configuration"
+msgstr "Configuració desconeguda"
+
+#: pkg/kubernetes/views/image-body.html:16
+msgid "Built"
+msgstr ""
+
+#: pkg/dashboard/index.html:70
+msgid "CPU"
+msgstr "CPU"
+
+#: pkg/systemd/host.js:1381
+msgctxt "page-title"
+msgid "CPU Status"
+msgstr "Estat de la CPU"
+
+#: pkg/kubernetes/scripts/nodes.js:712
+msgid "CPU Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:490 pkg/docker/index.html:669
+msgid "CPU priority"
+msgstr "Prioritat de CPU"
+
+#: pkg/systemd/index.html:247
+msgid "Cached"
+msgstr "Emmagatzemat temporalment"
+
+#: pkg/docker/index.html:63
+msgid "Can&rsquo;t connect to Docker"
+msgstr "No es pot connectar a Docker"
+
+#: pkg/systemd/services.html:465 pkg/dashboard/index.html:189
+#: pkg/playground/translate.html:40 pkg/playground/translate.html:174
+#: pkg/realmd/operation.html:90 pkg/kubernetes/views/pv-modify.html:202
+#: pkg/kubernetes/views/item-delete.html:10
+#: pkg/kubernetes/views/add-user-dialog.html:30
+#: pkg/kubernetes/views/project-modify.html:71
+#: pkg/kubernetes/views/node-add.html:49
+#: pkg/kubernetes/views/pvc-delete.html:14
+#: pkg/kubernetes/views/node-delete.html:14
+#: pkg/kubernetes/views/imagestream-modify.html:96
+#: pkg/kubernetes/views/imagestream-delete.html:7
+#: pkg/kubernetes/views/user-modify.html:30
+#: pkg/kubernetes/views/add-group-dialog.html:20
+#: pkg/kubernetes/views/project-delete.html:8
+#: pkg/kubernetes/views/service-modify.html:24
+#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/kubernetes/views/user-group-remove.html:9
+#: pkg/kubernetes/views/user-add-membership.html:52
+#: pkg/kubernetes/views/add-member-role-dialog.html:60
+#: pkg/kubernetes/views/group-delete.html:20
+#: pkg/kubernetes/views/image-delete.html:7 pkg/kubernetes/views/deploy.html:61
+#: pkg/kubernetes/views/user-group-add.html:31
+#: pkg/kubernetes/views/auth-form.html:128
+#: pkg/kubernetes/views/auth-rejected-cert.html:31
+#: pkg/kubernetes/views/replicationcontroller-modify.html:16
+#: pkg/kubernetes/views/pv-delete.html:10
+#: pkg/kubernetes/views/add-role-dialog.html:7
+#: pkg/kubernetes/views/route-modify.html:16
+#: pkg/kubernetes/views/user-delete.html:24
+#: pkg/kubernetes/views/remove-role-dialog.html:7 pkg/storaged/index.html:289
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:79
+msgid "Cancel"
+msgstr "Cancel·la"
+
+#: pkg/shell/indexes.js:322
+msgid "Cannot connect to an unknown machine"
+msgstr "No es pot connectar a una màquina desconeguda"
+
+#: src/ws/cockpitcertificate.c:359
+msgid "Cannot decrypt PEM-encoded private key"
+msgstr ""
+
+#: src/base1/cockpit.js:3707
+msgid "Cannot forward login credentials"
+msgstr ""
+
+#: pkg/realmd/operation.js:417
+msgid "Cannot join a domain because realmd is not available on this system"
+msgstr ""
+"No es pot unir a un domini perquè realmd no està disponible en aquest sistema"
+
+#: pkg/kubernetes/views/pv-modify.html:44
+#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pv-body.html:13
+msgid "Capacity"
+msgstr ""
+
+#: pkg/storaged/index.html:443 pkg/storaged/index.html:519
+#: pkg/storaged/index.html:551 pkg/storaged/index.html:630
+msgctxt "storage"
+msgid "Capacity"
+msgstr "Capacitat"
+
+#: pkg/networkmanager/interfaces.js:2276
+msgid "Carrier"
+msgstr "Portadora"
+
+#: pkg/kubernetes/scripts/volumes.js:203
+msgid "Ceph Filesystem Mount"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:97
+msgid "Ceph Monitors"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:204
+#: pkg/kubernetes/views/project-modify.html:74
+#: pkg/kubernetes/views/replicationcontroller-modify.html:17
+#: pkg/kubernetes/views/route-modify.html:17
+msgid "Change"
+msgstr "Canvia"
+
+#: pkg/shell/index.html:278
+msgid "Change Password"
+msgstr "Canvia la contrasenya"
+
+#: pkg/tuned/dialog.js:191
+msgid "Change Performance Profile"
+msgstr ""
+
+#: pkg/tuned/dialog.js:200
+msgid "Change Profile"
+msgstr "Canvia el perfil"
+
+#: pkg/kubernetes/views/user-modify.html:3
+msgid "Change User"
+msgstr ""
+
+#: pkg/storaged/overview.js:699
+msgid "Change iSCSI Initiator Name"
+msgstr "Canvia el nom d'iniciador iSCSI"
+
+#: pkg/kubernetes/views/imagestream-modify.html:4
+msgid "Change image stream"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:10
+msgid "Change project"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2872
+#, fuzzy
+msgid "Change the settings"
+msgstr "Ajusts de la connexió"
+
+#: pkg/networkmanager/interfaces.js:2870
+msgid "Changing the settings will break the connection to the server, "
+msgstr ""
+
+#: pkg/ostree/index.html:48
+msgid "Check for updates"
+msgstr "Comprova si hi ha actualitzacions"
+
+#: pkg/networkmanager/interfaces.js:817
+msgid "Checking IP"
+msgstr "S'està comprovant la IP"
+
+#: pkg/storaged/jobs.js:143
+#, fuzzy
+msgid "Checking RAID Device $target"
+msgstr "S'està creant el dispositiu RAID $target"
+
+#: pkg/storaged/jobs.js:144
+#, fuzzy
+msgid "Checking and Repairing RAID Device $target"
+msgstr "S'està creant el dispositiu RAID $target"
+
+#: pkg/lib/machine-change-auth.html:70
+msgid "Checking for public keys"
+msgstr "S'està comprovant si hi ha claus públiques"
+
+#: pkg/ostree/app.js:219
+msgid "Checking for updates"
+msgstr "S'està comprovant si hi ha actualitzacions"
+
+#: pkg/shell/simple.html:100 pkg/shell/index.html:121 pkg/shell/stub.html:114
+msgid "Choose the language to be used in the application"
+msgstr "Seleccioneu l'idioma per utilitzar amb l'aplicació"
+
+#: pkg/storaged/overview.js:431
+msgid "Chunk Size"
+msgstr "Mida del tros"
+
+#: pkg/kubernetes/scripts/volumes.js:202
+msgid "Cinder"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
+msgid "Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:4
+msgid "Claim Name"
+msgstr ""
+
+#: pkg/storaged/jobs.js:135
+msgid "Cleaning up for $target"
+msgstr "Neteja de $target"
+
+#: pkg/kubernetes/views/auth-form.html:88
+msgid "Client Certificate"
+msgstr ""
+
+#: pkg/systemd/services.html:306 pkg/systemd/services.html:324
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-invalid-hostkey.html:19
+msgid "Close"
+msgstr "Tanca"
+
+#: pkg/kubernetes/views/auth-form.html:5
+msgid "Cluster"
+msgstr "Clúster"
+
+#: cockpit.desktop.in.h:1
+msgid "Cockpit"
+msgstr "Cockpit"
+
+#: pkg/lib/machine-dialogs.js:429
+msgid ""
+"Cockpit could not contact the given host $0. Make sure it has ssh running on "
+"port $1, or specify another port in the address."
+msgstr ""
+
+#: src/base1/cockpit.js:3713
+msgid "Cockpit could not contact the given host."
+msgstr ""
+
+#: pkg/shell/base_index.js:671
+msgid "Cockpit had an unexpected internal error. <br/><br/>"
+msgstr "Cockpit va tenir un error intern inesperat. <br/><br/>"
+
+#: cockpit.appdata.xml.in.h:1
+msgid ""
+"Cockpit is a server manager that makes it easy to administer your Linux "
+"servers via a web browser. Jumping between the terminal and the web tool is "
+"no problem. A service started via Cockpit can be stopped via the terminal. "
+"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
+"journal interface."
+msgstr ""
+"Cockpit és una eina de gestió de servidors que facilita l'administració dels "
+"vostres servidors Linux a través d'un navegador web. Saltar entre el "
+"terminal i l'eina web no és cap problema. Un servei iniciat a través de "
+"Cockpit es pot aturar a través del terminal. De la mateixa manera, si es "
+"produeix un error en el terminal, es pot observar en la interfície de les "
+"publicacions de Cockpit."
+
+#: src/base1/cockpit.js:3711
+msgid "Cockpit is not compatible with the software on the system."
+msgstr ""
+
+#: pkg/lib/machine-not-supported.html:2
+msgid "Cockpit is not installed"
+msgstr "Cockpit no està instal·lat"
+
+#: src/base1/cockpit.js:3705
+msgid "Cockpit is not installed on the system."
+msgstr "Cockpit no està instal·lat al sistema."
+
+#: cockpit.appdata.xml.in.h:2
+msgid ""
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
+"tasks such as storage administration, inspecting journals and starting and "
+"stopping services. You can monitor and administer several servers at the "
+"same time. Just add them with a single click and your machines will look "
+"after its buddies."
+msgstr ""
+"Cockpit és perfecte per als nous administradors de sistemes, els permet "
+"realitzar fàcilment les tasques senzilles com ara l'administració de "
+"l'emmagatzematge, la inspecció de les publicacions i iniciar i aturar els "
+"serveis. Podeu monitorar i administrar diversos servidors a la vegada. Només "
+"heu d'afegir-los amb tan sols un clic i les vostres màquines es veuran al "
+"cantó de les altres."
+
+#: pkg/lib/machine-change-port.html:9
+msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
+msgstr "Cockpit no ha pogut contactar amb {{#strong}}{{host}}{{/strong}}."
+
+#: pkg/lib/machine-auth-failed.html:15
+msgid ""
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:9
+msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+"Cockpit no ha pogut iniciar la sessió a {{#strong}}{{host}}{{/strong}}."
+
+#: pkg/lib/machine-auth-failed.html:6
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
+"machine with cockpit you will need to enable one of the following "
+"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:13
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
+"change your authentication credentials below. {{#can_sync}}You may prefer to "
+"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+msgstr ""
+
+#: pkg/dashboard/index.html:171 pkg/lib/machine-add.html:27
+msgid "Color"
+msgstr "Color"
+
+#: pkg/docker/index.html:95
+msgid "Combined CPU usage"
+msgstr "Ús combinat de CPU"
+
+#: pkg/docker/index.html:101
+msgid "Combined memory usage"
+msgstr "Ús combinat de memòria"
+
+#: pkg/systemd/services.html:370 pkg/docker/index.html:466
+#: pkg/docker/index.html:736
+msgid "Command"
+msgstr "Ordre"
+
+#: pkg/docker/run.js:332
+#, fuzzy
+msgid "Command can't be empty"
+msgstr "El nom no pot estar en blanc."
+
+#: pkg/docker/containers-view.jsx:239
+#, fuzzy
+msgid "Commit"
+msgstr "Comentari"
+
+#: pkg/tuned/dialog.js:114
+msgid "Communication with tuned has failed"
+msgstr "Ha fallat la comunicació amb tuned"
+
+#: pkg/storaged/details.js:348
+msgid "Compatible with all systems and devices (MBR)"
+msgstr "Compatible amb tots els sistemes i dispositius (MBR)"
+
+#: pkg/storaged/details.js:349
+msgid "Compatible with modern system and hard disks > 2TB (GPT)"
+msgstr "Compatible amb els sistemes moderns i els discs durs > 2TB (GPT)"
+
+#: pkg/realmd/operation.html:28
+msgid "Computer OU"
+msgstr "OU de l'ordinador"
+
+#: pkg/kubernetes/views/node-add.html:24
+msgid "Configuration"
+msgstr "Configuració"
+
+#: pkg/networkmanager/interfaces.js:2441
+msgid "Configure"
+msgstr "Configura"
+
+#: pkg/kubernetes/views/node-add.html:42
+msgid "Configure Flannel networking"
+msgstr "Configura la xarxa Flannel"
+
+#: pkg/kubernetes/views/node-add.html:32
+msgid "Configure Kubelet and Proxy"
+msgstr "Configura el Kubelet i el servidor intermediari"
+
+#: pkg/networkmanager/interfaces.js:811
+msgid "Configuring"
+msgstr "S'està configurant"
+
+#: pkg/networkmanager/interfaces.js:815
+msgid "Configuring IP"
+msgstr "S'està configurant la IP"
+
+#: pkg/users/index.html:171 pkg/shell/index.html:262
+msgid "Confirm"
+msgstr "Confirmació"
+
+#: pkg/users/index.html:247
+msgid "Confirm New Password"
+msgstr "Confirmació de la nova contrasenya"
+
+#: pkg/storaged/details.js:229
+msgid "Confirm passphrase"
+msgstr "Confirmació de la contrasenya"
+
+#: pkg/kubernetes/views/auth-form.html:130
+#: pkg/kubernetes/views/auth-rejected-cert.html:33
+#: pkg/lib/machine-unknown-hostkey.html:22
+msgid "Connect"
+msgstr "Connecta"
+
+#: pkg/networkmanager/interfaces.js:2637
+msgid "Connect automatically"
+msgstr "Connecta automàticament"
+
+#: pkg/ostree/index.html:218
+msgid "Connecting"
+msgstr "S'està connectant"
+
+#: pkg/lib/machine-add.html:39
+msgid ""
+"Connecting simultaneously to more than {{ limit }} machines is unsupported."
+msgstr ""
+
+#: pkg/docker/index.html:54
+msgid "Connecting to Docker"
+msgstr "S'està connectant al Docker"
+
+#: pkg/shell/indexes.js:317
+msgid "Connecting to the machine"
+msgstr "S'està connectant a la màquina"
+
+#: pkg/kubernetes/registry.html:70 pkg/kubernetes/index.html:100
+msgid "Connecting..."
+msgstr "S'està connectant..."
+
+#: pkg/kubernetes/views/auth-dialog.html:4
+msgid "Connection Error"
+msgstr "Error de connexió"
+
+#: pkg/kubernetes/scripts/connection.js:516
+msgid "Connection Error: $0"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-dialog.html:3
+msgid "Connection Settings"
+msgstr "Ajusts de la connexió"
+
+#: src/base1/cockpit.js:3703
+msgid "Connection has timed out."
+msgstr "La connexió ha excedit el temps."
+
+#: pkg/networkmanager/index.html:812
+#, fuzzy
+msgid "Connection will be lost"
+msgstr "La connexió ha excedit el temps."
+
+#: pkg/docker/console.html:4 pkg/kubernetes/views/container-panel.html:4
+#: pkg/kubernetes/views/image-panel.html:12
+#: pkg/kubernetes/views/container-body.html:4
+#: pkg/kubernetes/views/container-page-inline.html:2
+#: pkg/kubernetes/views/image-page.html:19
+msgid "Container"
+msgstr "Contenidor"
+
+#: pkg/users/local.js:684
+msgid "Container Administrator"
+msgstr "Administrador del contenidor"
+
+#: pkg/kubernetes/views/container-body.html:10
+msgid "Container ID"
+msgstr "Id. de contenidor"
+
+#: pkg/docker/index.html:459 pkg/docker/index.html:646
+#: pkg/docker/index.html:712
+msgid "Container Name"
+msgstr "Nom del contenidor"
+
+#: pkg/kubernetes/views/node-body.html:21
+msgid "Container Runtime Version"
+msgstr "Versió de l'entorn d'execució del contenidor"
+
+#: pkg/docker/util.js:490
+msgid ""
+"Container is currently marked as not running, but regular stopping failed."
+msgstr ""
+"El contenidor actualment està marcat com a no en execució, però va fallar "
+"l'aturada normal."
+
+#: pkg/docker/util.js:488
+msgid "Container is currently running."
+msgstr "El contenidor s'està executant actualment."
+
+#: pkg/docker/index.html:23 pkg/docker/index.html:309
+#: pkg/kubernetes/views/pod-page.html:36
+#: pkg/kubernetes/views/dashboard-page.html:158
+#: pkg/kubernetes/views/dashboard-page.html:199
+#: pkg/kubernetes/views/containers-listing.html:5 pkg/kubernetes/index.html:51
+msgid "Containers"
+msgstr "Contenidors"
+
+#: pkg/docker/details.js:47 pkg/docker/image.js:43
+msgctxt "page-title"
+msgid "Containers"
+msgstr "Contenidors"
+
+#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
+msgid "Content"
+msgstr "Contingut"
+
+#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
+#: pkg/playground/translate.js:19
+#, fuzzy
+msgid "Control"
+msgstr "Contenidor"
+
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
+#: pkg/playground/translate.js:22
+#, fuzzy
+msgctxt "key"
+msgid "Control"
+msgstr "Contenidor"
+
+#: pkg/docker/storage.jsx:404
+#, fuzzy
+msgid "Could not add all disks"
+msgstr "No es van poder llistar els serveis"
+
+#: pkg/lib/machine-change-port.html:4
+msgid "Could not contact {{host}}"
+msgstr "No s'ha pogut contactar amb {{host}}"
+
+#: pkg/kubernetes/views/dashboard-page.html:142
+msgid "Could not list services"
+msgstr "No es van poder llistar els serveis"
+
+#: src/ws/cockpitcertificate.c:407
+msgid "Could not parse PEM-encoded certificate"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:374
+msgid "Could not parse PEM-encoded private key"
+msgstr ""
+
+#: pkg/docker/storage.jsx:446
+msgid "Could not reset the storage pool"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:467
+msgid "Couldn't change user groups"
+msgstr "No s'han pogut canviar els grups de l'usuari"
+
+#: src/bridge/cockpitdbussetup.c:520
+msgid "Couldn't change user password"
+msgstr "No s'ha pogut canviar la contrasenya de l'usuari"
+
+#: pkg/selinux/setroubleshoot-view.jsx:385
+msgid ""
+"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
+"server is installed."
+msgstr ""
+
+#: pkg/kubernetes/registry.html:71 pkg/kubernetes/index.html:101
+msgid "Couldn't connect to server"
+msgstr "No s'ha pogut connectar al servidor"
+
+#: pkg/shell/indexes.js:320
+msgid "Couldn't connect to the machine"
+msgstr "No s'ha pogut connectar a la màquina"
+
+#: src/bridge/cockpitdbussetup.c:544
+msgid "Couldn't create new users"
+msgstr "No s'han pogut crear els nous usuaris"
+
+#: pkg/kubernetes/scripts/connection.js:514
+msgid "Couldn't find running API server"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:196
+#, fuzzy
+msgid ""
+"Couldn't get system subscription status. Please ensure subscription-manager "
+"is installed."
+msgstr ""
+"\n"
+"        Per gestionar les subscripcions d'aquest sistema, si us plau, "
+"comproveu que subscription-manager estigui instal·lat.\n"
+"      "
+
+#: src/bridge/cockpitdbussetup.c:642
+msgid "Couldn't list local users"
+msgstr "No s'han pogut llistar els usuaris locals"
+
+#: src/bridge/cockpitdbussetup.c:236
+msgid "Couldn't list users"
+msgstr "No s'han pogut llistar els usuaris"
+
+#: src/bridge/cockpitdbussetup.c:382
+msgid "Couldn't load user data"
+msgstr "No s'han pogut carregar les dades de l'usuari"
+
+#: pkg/kubernetes/views/project-modify.html:72
+#: pkg/kubernetes/views/add-group-dialog.html:21
+msgid "Create"
+msgstr "Crea"
+
+#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
+msgid "Create Logical Volume"
+msgstr ""
+
+#: pkg/users/index.html:54 pkg/users/index.html:143
+msgid "Create New Account"
+msgstr "Crea un nou compte"
+
+#: pkg/storaged/details.js:1379
+msgid "Create Partition"
+msgstr "Crea una partició"
+
+#: pkg/storaged/overview.js:414
+msgid "Create RAID Device"
+msgstr "Crea un dispositiu RAID"
+
+#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
+msgid "Create Snapshot"
+msgstr "Crea una instantània"
+
+#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
+msgid "Create Thin Volume"
+msgstr "Crea un volum disgregat"
+
+#: pkg/systemd/services.html:336
+#, fuzzy
+msgid "Create Timers"
+msgstr "Crea un volum disgregat"
+
+#: pkg/storaged/overview.js:487
+msgid "Create Volume Group"
+msgstr "Crea un grup de volums"
+
+#: pkg/sosreport/index.html:50
+msgid "Create diagnostic report"
+msgstr "Crea l'informe de diagnòstic"
+
+#: pkg/kubernetes/views/imagestream-modify.html:3
+msgid "Create image stream"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
+#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
+#, fuzzy
+msgid "Create it"
+msgstr "Crea"
+
+#: pkg/storaged/details.js:266
+msgid "Create partition"
+msgstr "Crea una partició"
+
+#: pkg/storaged/details.js:113
+msgid "Create partition on $0"
+msgstr "Crea una partició a $0"
+
+#: pkg/storaged/index.html:381
+msgid "Create partition table"
+msgstr "Crea la taula de particions"
+
+#: pkg/sosreport/index.html:42
+msgid "Create report"
+msgstr "Crea l'informe"
+
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/replicationcontroller-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7 pkg/kubernetes/views/route-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3
+msgid "Created"
+msgstr "Creat"
+
+#: pkg/storaged/jobs.js:142
+msgid "Creating RAID Device $target"
+msgstr "S'està creant el dispositiu RAID $target"
+
+#: pkg/storaged/jobs.js:130
+msgid "Creating filesystem on $target"
+msgstr "S'està creat el sistema de fitxers a $target"
+
+#: pkg/storaged/jobs.js:156
+msgid "Creating logical volume $target"
+msgstr "S'està creant el volum lògic $target"
+
+#: pkg/storaged/jobs.js:134
+msgid "Creating partition $target"
+msgstr "S'està creant la partició $target"
+
+#: pkg/storaged/jobs.js:150
+msgid "Creating snapshot of $target"
+msgstr "S'està creant una instantània de $target"
+
+#: pkg/networkmanager/interfaces.js:4064
+msgid "Creating this VLAN will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3436
+msgid "Creating this bond will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3842
+msgid "Creating this bridge will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3611
+msgid "Creating this team will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:151
+msgid "Creating volume group $target"
+msgstr "S'està creant el grup de volums $target"
+
+#: pkg/systemd/logs.html:41
+msgid "Current boot"
+msgstr "Arrencada actual"
+
+#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
+msgid "Custom"
+msgstr "Personalitzat"
+
+#: pkg/storaged/details.js:186
+msgid "Custom (Enter filesystem type)"
+msgstr "Personalitzat (introduïu el tipus del sistema de fitxers)"
+
+#: pkg/subscriptions/subscriptions-register.jsx:102
+#, fuzzy
+msgid "Custom URL"
+msgstr "Personalitzat"
+
+#: pkg/storaged/index.html:454
+msgid "DISK IS FAILING"
+msgstr "EL DISC ESTÀ FALLANT"
+
+#: pkg/networkmanager/interfaces.js:3018
+msgid "DNS"
+msgstr "DNS"
+
+#: pkg/kubernetes/views/pod-body.html:14
+msgid "DNS Policy"
+msgstr "Política del DNS"
+
+#: pkg/networkmanager/interfaces.js:3022
+msgid "DNS Search Domains"
+msgstr "Dominis de cerca DNS"
+
+#: pkg/dashboard/index.html:22
+msgid "Dashboard"
+msgstr ""
+
+#: pkg/storaged/details.js:1130
+msgid "Deactivate"
+msgstr "Desactiva"
+
+#: pkg/networkmanager/interfaces.js:823
+msgid "Deactivating"
+msgstr "S'està desactivant"
+
+#: pkg/storaged/jobs.js:149
+msgid "Deactivating $target"
+msgstr "S'està desactivant $target"
+
+#: pkg/docker/index.html:379 pkg/docker/index.html:383
+#: pkg/kubernetes/views/image-config.html:6
+msgid "Default"
+msgstr "Predeterminat"
+
+#: pkg/systemd/index.html:454
+msgid "Delay"
+msgstr "Retard"
+
+#: pkg/users/index.html:79 pkg/kubernetes/views/item-delete.html:11
+#: pkg/kubernetes/views/pvc-delete.html:15
+#: pkg/kubernetes/views/node-delete.html:15
+#: pkg/kubernetes/views/imagestream-delete.html:8
+#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/kubernetes/views/image-delete.html:8
+#: pkg/kubernetes/views/pv-delete.html:11
+msgid "Delete"
+msgstr "Suprimeix"
+
+#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
+msgid "Delete $0"
+msgstr "Suprimeix $0"
+
+#: pkg/users/index.html:292
+msgid "Delete Files"
+msgstr "Suprimeix els fitxers"
+
+#: pkg/kubernetes/views/node-delete.html:4
+msgid "Delete Node"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:3
+msgid "Delete Persistent Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:3
+msgid "Delete Persistent Volume Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/project-delete.html:3
+msgid "Delete Project"
+msgstr "Suprimeix el projecte"
+
+#: pkg/kubernetes/views/nodes-page.html:3
+msgid "Delete Selected"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:3
+msgid "Delete image stream"
+msgstr ""
+
+#: pkg/playground/translate.html:184 pkg/kubernetes/views/item-delete.html:3
+msgid "Delete {{ item.kind }}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
+msgid "Deleting $target"
+msgstr "S'està suprimint $target"
+
+#: pkg/networkmanager/interfaces.js:2156
+msgid "Deleting <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:7
+msgid ""
+"Deleting a Pod will kill all associated containers. Pods may be "
+"automatically created again in some cases."
+msgstr ""
+
+#: pkg/storaged/details.js:631
+msgid "Deleting a RAID device will erase all data on it."
+msgstr "La supressió d'un dispositiu RAID n'esborrarà totes les dades."
+
+#: pkg/docker/containers-view.jsx:167 pkg/docker/details.js:272
+msgid "Deleting a container will erase all data in it."
+msgstr "La supressió d'un contenidor n'esborrarà totes les dades."
+
+#: pkg/storaged/details.js:1009
+msgid "Deleting a logical volume will delete all data in it."
+msgstr "La supressió d'un volum lògic n'esborrarà totes les dades."
+
+#: pkg/storaged/details.js:1012
+msgid "Deleting a partition will delete all data in it."
+msgstr "La supressió d'una partició n'esborrarà totes les dades."
+
+#: pkg/storaged/details.js:826
+msgid "Deleting a volume group will erase all data on it."
+msgstr "La supressió d'un grup de volums n'esborrarà totes les dades."
+
+#: pkg/docker/image.js:152
+msgid ""
+"Deleting an image will delete it, but you can probably download it again if "
+"you need it later.  Unless this image has never been pushed to a repository, "
+"that is, in which case you probably can't download it again."
+msgstr ""
+"La supressió d'una imatge ho suprimirà, però probablement es pot baixar de "
+"nou si es necessita més endavant. Llevat que aquesta imatge mai hagi estat "
+"empesa a un dipòsit, que ho és, en aquest cas probablement no pugueu baixar-"
+"ho de nou."
+
+#: pkg/storaged/jobs.js:152
+msgid "Deleting volume group $target"
+msgstr "S'està suprimint el grup de volums $target"
+
+#: pkg/kubernetes/views/dashboard-page.html:131
+#: pkg/kubernetes/views/deploy.html:62
+msgid "Deploy"
+msgstr "Desplega"
+
+#: pkg/kubernetes/views/deploy.html:3
+msgid "Deploy Application"
+msgstr "Desplega l'aplicació"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:22
+msgid "Deployment Causes"
+msgstr "Causes del desplegament"
+
+#: pkg/kubernetes/views/deploymentconfig-panel.html:8
+#: pkg/kubernetes/views/deploymentconfig-page.html:12
+msgid "Deployment Config"
+msgstr "Configuració de desplegament"
+
+#: pkg/kubernetes/views/details-page.html:98
+msgid "Deployment Configs"
+msgstr "Configuracions del desplegament"
+
+#: pkg/systemd/services.html:356 pkg/kubernetes/views/project-modify.html:40
+#: pkg/kubernetes/views/image-body.html:6
+#: pkg/kubernetes/views/project-listing.html:15
+#: pkg/kubernetes/views/project-listing.html:54
+msgid "Description"
+msgstr "Descripció"
+
+#: pkg/shell/index.html:197 pkg/kubernetes/index.html:63
+msgid "Details"
+msgstr "Detalls"
+
+#: pkg/storaged/index.html:543
+msgctxt "storage"
+msgid "Device"
+msgstr "Dispositiu"
+
+#: pkg/storaged/details.js:91
+msgid "Device $0 is a member of RAID Array $1"
+msgstr "El dispositiu $0 és un membre de la matriu RAID $1"
+
+#: pkg/storaged/details.js:97
+msgid "Device $0 is a physical volume of $1"
+msgstr "El dispositiu $0 és un volum físic de $1"
+
+#: pkg/storaged/details.js:85
+msgid "Device $0 is mounted on $1"
+msgstr "El dispositiu $0 està muntat a $1"
+
+#: pkg/storaged/index.html:467 pkg/storaged/index.html:473
+#: pkg/storaged/index.html:515
+msgctxt "storage"
+msgid "Device File"
+msgstr "Fitxer de dispositiu"
+
+#: pkg/sosreport/index.html:22
+msgid "Diagnostic reports"
+msgstr "Informes de diagnòstic"
+
+#: pkg/kubernetes/views/image-body.html:20
+msgid "Digest"
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:7
+#: pkg/kubernetes/views/volume-body.html:28
+msgid "Directory"
+msgstr "Directori"
+
+#: pkg/systemd/init.js:543
+msgid "Disable"
+msgstr "Inhabilita"
+
+#: pkg/tuned/dialog.js:234
+msgid "Disable tuned"
+msgstr "Inhabilita tuned"
+
+#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
+msgid "Disabled"
+msgstr "Inhabilitat"
+
+#: pkg/shell/simple.html:120
+msgid "Disconnected"
+msgstr "Desconnectat"
+
+#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+msgid "Disk"
+msgstr "Disc"
+
+#: pkg/dashboard/index.html:73
+#, fuzzy
+msgid "Disk I/O"
+msgstr "El disc està bé"
+
+#: pkg/kubernetes/scripts/nodes.js:720
+msgid "Disk Utilization: $0%"
+msgstr "Utilització del disc: $0%"
+
+#: pkg/storaged/index.html:457
+msgid "Disk is OK"
+msgstr "El disc està bé"
+
+#: pkg/storaged/index.html:584
+msgid "Disks"
+msgstr "Discs"
+
+#: pkg/shell/simple.html:37 pkg/shell/simple.html:97 pkg/shell/index.html:37
+#: pkg/shell/index.html:118 pkg/shell/stub.html:37 pkg/shell/stub.html:111
+msgid "Display Language"
+msgstr "Idioma de la pantalla"
+
+#: pkg/kubernetes/views/project-modify.html:31
+msgid "Display name"
+msgstr "Nom a mostrar"
+
+#: pkg/kubernetes/views/add-role-dialog.html:5
+msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:5
+msgid ""
+"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}' image stream?"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:6
+msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:6
+msgid ""
+"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:6
+msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:7
+msgid "Do you want to delete this Node?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:5
+msgid ""
+"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+"{{stream.metadata.name}}:{{tag.tag}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/remove-role-dialog.html:5
+msgid ""
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:11
+msgid "Docker Version"
+msgstr "Versió de Docker"
+
+#: pkg/docker/index.html:60
+msgid "Docker is not installed or activated on the system"
+msgstr "Docker no està activat o instal·lat al sistema"
+
+#: pkg/systemd/index.html:107
+msgid "Domain"
+msgstr "Domini"
+
+#: pkg/realmd/operation.js:148
+msgid "Domain $0 could not be contacted"
+msgstr "No s'ha pogut contactar amb el domini $0"
+
+#: pkg/realmd/operation.js:220
+msgid "Domain $0 is not supported"
+msgstr "El domini $0 no és compatible"
+
+#: pkg/realmd/operation.html:11
+msgid "Domain Address"
+msgstr "Adreça del domini"
+
+#: pkg/realmd/operation.html:59
+msgid "Domain Administrator Name"
+msgstr "Nom de l'administrador del domini"
+
+#: pkg/realmd/operation.html:65
+msgid "Domain Administrator Password"
+msgstr "Contrasenya de l'administrador del domini"
+
+#: pkg/systemd/services.html:426 pkg/systemd/services.html:430
+msgid "Don't Repeat"
+msgstr ""
+
+#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
+msgid "Don't overwrite existing data"
+msgstr "No sobreescriguis les dades existents"
+
+#: pkg/sosreport/index.html:74
+msgid "Done!"
+msgstr "Fet!"
+
+#: pkg/ostree/index.html:127 pkg/ostree/index.html:158
+msgid "Downgrades"
+msgstr "Reversions"
+
+#: pkg/storaged/index.html:411
+msgid "Drive"
+msgstr "Unitat"
 
 #: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
 msgctxt "storage"
 msgid "Drive"
 msgstr "Unitat"
 
-#: pkg/storaged/overview.js:253
-msgid "$0 Block Device"
-msgstr "Dispositiu de blocs $0"
+#: pkg/kubernetes/views/volume-body.html:128
+msgid "Driver"
+msgstr "Controlador"
 
-#: pkg/storaged/overview.js:414
-msgid "Create RAID Device"
-msgstr "Crea un dispositiu RAID"
+#: pkg/storaged/index.html:166
+msgid "Drives"
+msgstr "Unitats"
 
-#: pkg/storaged/overview.js:420
-msgid "RAID Level"
-msgstr "Nivell RAID"
+#: pkg/docker/run.js:360
+msgid "Duplicate alias"
+msgstr "Àlies duplicat"
 
-#: pkg/storaged/overview.js:422
-msgid "RAID 0 (Stripe)"
-msgstr "RAID 0 (segmentació)"
+#: pkg/docker/run.js:293
+msgid "Duplicate port"
+msgstr "Port duplicat"
 
-#: pkg/storaged/overview.js:423
-msgid "RAID 1 (Mirror)"
-msgstr "RAID 1 (rèplica)"
+#: pkg/storaged/jobs.js:120
+msgid "Ejecting $target"
+msgstr "S'està expulsant $target"
 
-#: pkg/storaged/overview.js:424
-msgid "RAID 4 (Dedicated Parity)"
-msgstr "RAID 4 (paritat dedicada)"
+#: pkg/playground/translate.html:58
+msgid "Empty"
+msgstr "Buida"
 
-#: pkg/storaged/overview.js:425
-msgid "RAID 5 (Distributed Parity)"
-msgstr "RAID 5 (paritat distribuïda)"
-
-#: pkg/storaged/overview.js:426
-msgid "RAID 6 (Double Distributed Parity)"
-msgstr "RAID 5 (doble paritat distribuïda)"
-
-#: pkg/storaged/overview.js:427
-msgid "RAID 10 (Stripe of Mirrors)"
-msgstr "RAID 10 (segmentació de rèpliques)"
-
-#: pkg/storaged/overview.js:431
-msgid "Chunk Size"
-msgstr "Mida del tros"
-
-#: pkg/storaged/overview.js:433
-msgid "4 KiB"
-msgstr "4 KiB"
-
-#: pkg/storaged/overview.js:434
-msgid "8 KiB"
-msgstr "8 KiB"
-
-#: pkg/storaged/overview.js:435
-msgid "16 KiB"
-msgstr "16 KiB"
-
-#: pkg/storaged/overview.js:436
-msgid "32 KiB"
-msgstr "32 KiB"
-
-#: pkg/storaged/overview.js:437
-msgid "64 KiB"
-msgstr "64 KiB"
-
-#: pkg/storaged/overview.js:438
-msgid "128 KiB"
-msgstr "128 KiB"
-
-#: pkg/storaged/overview.js:439
-msgid "512 KiB"
-msgstr "512 KiB"
-
-#: pkg/storaged/overview.js:440
-msgid "1 MiB"
-msgstr "1 MiB"
-
-#: pkg/storaged/overview.js:441
-msgid "2 MiB"
-msgstr "2 MiB"
-
-#: pkg/storaged/overview.js:455
-msgid "At least $0 disks are needed."
-msgstr "Com a mínim es necessiten $0 discs."
-
-#: pkg/storaged/overview.js:487
-msgid "Create Volume Group"
-msgstr "Crea un grup de volums"
-
-#: pkg/storaged/overview.js:515
-msgid "Add iSCSI Portal"
-msgstr "Afegeix un portal iSCSI"
-
-#: pkg/storaged/overview.js:518
-msgid "Server Address"
-msgstr "Adreça del servidor"
-
-#: pkg/storaged/overview.js:521
+#: pkg/playground/translate.html:63
 #, fuzzy
-msgid "Server address cannot be empty."
-msgstr "L'adreça del servidor no pot estar en blanc."
+msgctxt "verb"
+msgid "Empty"
+msgstr "Buida"
 
-#: pkg/storaged/overview.js:533 pkg/realmd/operation.html.h:11
-msgid "Next"
-msgstr "Següent"
+#: pkg/kubernetes/scripts/volumes.js:196
+msgid "Empty Directory"
+msgstr "Directori buit"
 
-#: pkg/storaged/overview.js:577 pkg/storaged/overview.js:668
-#: pkg/subscriptions/subscriptions-client.js:194
+#: pkg/storaged/jobs.js:155
+msgid "Emptying $target"
+msgstr "S'està buidant $target"
+
+#: pkg/systemd/init.js:541
+msgid "Enable"
+msgstr "Habilita"
+
+#: pkg/systemd/init.js:542
+msgid "Enable Forcefully"
+msgstr "Habilita-ho forçosament"
+
+#: pkg/systemd/init.js:301
+msgid "Enabled"
+msgstr "Habilitat"
+
+#: pkg/storaged/details.js:1247
+msgctxt "storage-id-desc"
+msgid "Encrypted"
+msgstr "Xifrat"
+
+#: pkg/storaged/details.js:180
+msgid "Encrypted EXT4 (LUKS)"
+msgstr "EXT4 xifrat (LUKS)"
+
+#: pkg/storaged/details.js:179
+msgid "Encrypted XFS (LUKS)"
+msgstr "XFS xifrat (LUKS)"
+
+#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
+#: pkg/storaged/details.js:1115
+msgid "Encryption Options"
+msgstr "Opcions de xifrat"
+
+#: pkg/kubernetes/views/pv-modify.html:93
+msgid "Endpoint"
+msgstr "Extrem"
+
+#: pkg/kubernetes/views/volume-body.html:40
+msgid "Endpoint Name"
+msgstr "Nom de l'extrem"
+
+#: pkg/kubernetes/views/service-page.html:14
+#: pkg/kubernetes/views/service-panel.html:9
+msgid "Endpoints"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:38
+msgid "Ends"
+msgstr "Acaba"
+
+#: pkg/selinux/setroubleshoot-view.jsx:332
+msgid "Enforce policy:"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:447
+msgid "Enter IP address or host name"
+msgstr "Introduïu l'adreça IP o el nom de l'amfitrió"
+
+#: pkg/systemd/logs.html:60
+msgid "Entry"
+msgstr "Entrada"
+
+#: pkg/docker/index.html:547 pkg/kubernetes/views/image-config.html:17
+#: pkg/kubernetes/views/container-body.html:26
+msgid "Environment"
+msgstr "Entorn"
+
+#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
+msgid "Erase"
+msgstr "Esborra"
+
+#: pkg/docker/storage.jsx:423
+msgid "Erase containers and reset storage pool"
+msgstr ""
+
+#: pkg/docker/storage.jsx:360
+msgid "Erase containers, reformat disks, and add them"
+msgstr ""
+
+#: pkg/storaged/jobs.js:129
+msgid "Erasing $target"
+msgstr "S'està esborrant $target"
+
+#: pkg/systemd/services.html:318 pkg/playground/translate.html:101
+#: pkg/playground/translate.html:106
+msgid "Error"
+msgstr "Error"
+
+#: pkg/kubernetes/scripts/connection.js:650
+msgid "Error getting certificate details: $0"
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:13
+msgid "Error loading users: {{perm_failed}}"
+msgstr "S'ha produït un error en carregar els usuaris: {{perm_failed}}"
+
+#: pkg/docker/util.js:491
+msgid "Error message from Docker:"
+msgstr "Missatge d'error del Docker:"
+
+#: pkg/users/authorized-keys.js:115
+msgid "Error saving authorized keys: "
+msgstr "S'ha produït un error en desar les claus autoritzades:"
+
+#: pkg/selinux/setroubleshoot.js:275
+msgid "Error while connecting."
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:192
+msgid "Error while deleting alert"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot.js:65
+msgid "Error while setting SELinux mode: '$0'"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:88
+msgid "Error writing kubectl config"
+msgstr ""
+
+#: pkg/systemd/logs.html:47
+msgid "Errors"
+msgstr "Errors"
+
+#: pkg/networkmanager/index.html:764
+msgid "Ethernet MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1854
+msgid "Ethtool"
+msgstr ""
+
+#: pkg/users/local.js:429 pkg/users/local.js:1104
+msgid "Excellent password"
+msgstr "Contrasenya excel·lent"
+
+#: pkg/docker/util.js:96
+msgid "Exited $ExitCode"
+msgstr "Sortida $ExitCode"
+
+#: pkg/docker/index.html:529
+msgid "Expose container ports"
+msgstr ""
+
+#: pkg/storaged/details.js:183
+msgid "Extended Partition"
+msgstr "Partició estesa"
+
+#: pkg/storaged/details.js:1592
+msgid "FAILED"
+msgstr "FALLAT"
+
+#: pkg/ostree/index.html:92
+msgid "Failed"
+msgstr "Ha fallat"
+
+#: pkg/lib/machine-dialogs.js:412
+msgid "Failed to add machine: $0"
+msgstr "No s'ha pogut afegir la màquina: $0"
+
+#: pkg/users/local.js:112 pkg/users/local.js:144 pkg/lib/credentials.js:223
+msgid "Failed to change password"
+msgstr "Ha fallat el canvi de contrasenya"
+
+#: pkg/selinux/setroubleshoot-client.js:187
+msgid "Failed to delete alert"
+msgstr ""
+
+#: pkg/tuned/dialog.js:171
+msgid "Failed to disable tuned"
+msgstr ""
+
+#: pkg/tuned/dialog.js:133
+msgid "Failed to disable tuned profile"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:494
+msgid "Failed to edit machine: $0"
+msgstr "No s'ha pogut editar la màquina: $0"
+
+#: pkg/tuned/dialog.js:169
+msgid "Failed to enable tuned"
+msgstr ""
+
+#: pkg/users/index.html:338
+msgid "Failed to load authorized keys."
+msgstr "Ha fallat la càrrega de les claus autoritzades."
+
+#: pkg/docker/containers.js:64
+msgid "Failed to start Docker: $0"
+msgstr "Ha fallat l'inici del Docker: $0"
+
+#: pkg/docker/util.js:544
+msgid "Failed to stop Docker scope: $0"
+msgstr "Ha fallat l'aturada de l'àmbit del Docker: $0"
+
+#: pkg/tuned/dialog.js:145
+msgid "Failed to switch profile"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:204
+msgid "Fibre Channel"
+msgstr ""
+
+#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
+msgid "Filesystem Options"
+msgstr "Opcions del sistema de fitxers"
+
+#: pkg/kubernetes/views/pv-modify.html:180
+#: pkg/kubernetes/views/volume-body.html:6
+#: pkg/kubernetes/views/volume-body.html:16
+#: pkg/kubernetes/views/volume-body.html:62
+#: pkg/kubernetes/views/volume-body.html:83
+#: pkg/kubernetes/views/volume-body.html:91
+#: pkg/kubernetes/views/volume-body.html:120
+#: pkg/kubernetes/views/volume-body.html:132
+msgid "Filesystem Type"
+msgstr "Tipus de sistema de fitxers"
+
+#: pkg/storaged/details.js:215
+msgid "Filesystem type"
+msgstr "Tipus de sistema de fitxers"
+
+#: pkg/storaged/index.html:225
+msgid "Filesystems"
+msgstr "Sistemes de fitxers"
+
+#: pkg/lib/machine-unknown-hostkey.html:10
+msgid "Fingerprint"
+msgstr "Empremta"
+
+#: pkg/storaged/index.html:426
+msgctxt "storage"
+msgid "Firmware Version"
+msgstr "Versió de microprogramari"
+
+#: pkg/kubernetes/scripts/volumes.js:206
+msgid "Flex"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:205
+msgid "Flocker"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:125
+msgid "Flocker Dataset Name"
+msgstr ""
+
+#: pkg/docker/util.js:503
+msgid "Force Delete"
+msgstr "Força la supressió"
+
+#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
+#: pkg/storaged/details.js:1142
+msgid "Format"
+msgstr "Formata"
+
+#: pkg/storaged/details.js:115
+msgid "Format $0"
+msgstr "Formata $0"
+
+#: pkg/storaged/details.js:335
+msgid "Format Disk $0"
+msgstr "Formata el disc $0"
+
+#: pkg/storaged/details.js:358
+msgid "Formatting a disk will erase all data on it."
+msgstr "La formatació d'un disc eliminarà totes les dades contingudes."
+
+#: pkg/storaged/details.js:268
+msgid "Formatting a storage device will erase all data on it."
+msgstr ""
+"La formatació d'un dispositiu d'emmagatzematge eliminarà totes les dades "
+"contingudes."
+
+#: pkg/networkmanager/interfaces.js:2577
+msgid "Forward delay $forward_delay"
+msgstr "Retard del reenviament $forward_delay"
+
+#: pkg/systemd/index.html:255
+msgid "Free"
+msgstr "Lliure"
+
+#: pkg/users/index.html:86 pkg/users/index.html:148
+msgid "Full Name"
+msgstr "Nom complet"
+
+#: pkg/kubernetes/scripts/volumes.js:192
+msgid "GCE Persistent Disk"
+msgstr ""
+
+#: pkg/docker/index.html:180
+msgid "Gateway:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2628
+msgid "General"
+msgstr "General"
+
+#: pkg/sosreport/index.html:66
+msgid "Generating report"
+msgstr "S'està generant l'informe"
+
+#: pkg/kubernetes/scripts/volumes.js:194
+msgid "Git Repository"
+msgstr "Dipòsit git"
+
+#: pkg/kubernetes/scripts/volumes.js:198
+msgid "Gluster FS"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:872
+msgid "GlusterFS"
+msgstr ""
+
+#: pkg/systemd/logs.js:130
+msgid "Go to"
+msgstr "Vés a"
+
+#: pkg/storaged/index.html:307 pkg/networkmanager/index.html:50
+#: pkg/networkmanager/index.html:496
+msgid "Go to now"
+msgstr "Vés a ara"
+
+#: pkg/kubernetes/views/group-page.html:21
+#: pkg/kubernetes/views/group-panel.html:12
+msgid "Group Members"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:48
+#: pkg/kubernetes/views/user-delete.html:14
+msgid "Groups"
+msgstr "Grups"
+
+#: pkg/networkmanager/index.html:268
+msgid "Hair Pin mode"
+msgstr "Mode hairpin"
+
+#: pkg/networkmanager/interfaces.js:2603
+msgid "Hairpin mode"
+msgstr "Mode hairpin"
+
+#: pkg/docker/storage.jsx:157
+#, fuzzy
+msgid "Hard Disk"
+msgstr "Disc dur"
+
+#: pkg/storaged/overview.js:180
+msgctxt "storage"
+msgid "Hard Disk"
+msgstr "Disc dur"
+
+#: pkg/systemd/index.html:77
+msgid "Hardware"
+msgstr "Maquinari"
+
+#: pkg/networkmanager/interfaces.js:2579
+msgid "Hello time $hello_time"
+msgstr "Hello time $hello_time"
+
+#: pkg/kubernetes/views/details-page.html:73
+#: pkg/kubernetes/views/route-body.html:9
+#: pkg/kubernetes/views/route-modify.html:8
+msgid "Host"
+msgstr "Amfitrió"
+
+#: pkg/systemd/index.html:102 pkg/dashboard/index.html:151
+msgid "Host Name"
+msgstr "Nom d'amfitrió"
+
+#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
+msgid "Host Path"
+msgstr ""
+
+#: src/base1/cockpit.js:3699
+msgid "Host key is incorrect"
+msgstr "La clau d'amfitrió és incorrecta"
+
+#: pkg/systemd/services.html:442
+#, fuzzy
+msgid "Hour : Minute"
+msgstr "1 minut"
+
+#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
+msgid "Hour needs to be a number between 0-23"
+msgstr ""
+
+#: pkg/systemd/services.html:408
+#, fuzzy
+msgid "Hours"
+msgstr "6 hores"
+
+#: pkg/systemd/index.html:221
+msgid "I/O Wait"
+msgstr "Espera d'E/S"
+
+#: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
+msgid "IP"
+msgstr "IP"
+
+#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
+msgid "IP Address"
+msgstr "Adreça IP"
+
+#: pkg/docker/index.html:172
+msgid "IP Address:"
+msgstr "Adreça IP:"
+
+#: pkg/docker/index.html:176
+msgid "IP Prefix Length:"
+msgstr ""
+
+#: pkg/networkmanager/index.html:568
+msgid "IP Settings"
+msgstr "Ajusts de la IP"
+
+#: pkg/networkmanager/interfaces.js:2641
+msgid "IPv4"
+msgstr "IPv4"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv4 Settings"
+msgstr "Ajustos d'IPv4"
+
+#: pkg/networkmanager/interfaces.js:2642
+msgid "IPv6"
+msgstr "IPv6"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv6 Settings"
+msgstr "Ajustos d'IPv6"
+
+#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
+msgid "ISCSI"
+msgstr "ISCSI"
+
+#: pkg/systemd/init.js:270
+msgid "Id"
+msgstr "Id"
+
+#: pkg/networkmanager/interfaces.js:2620
+msgid "Id $id"
+msgstr "Id. $id"
+
+#: pkg/kubernetes/views/image-body.html:22
+msgid "Identifier"
+msgstr "Identificador"
+
+#: pkg/kubernetes/views/user-page.html:23
+#: pkg/kubernetes/views/user-panel.html:18
+msgid "Identities"
+msgstr "Identitats"
+
+#: pkg/kubernetes/views/project-listing.html:91
+msgid "Identity"
+msgstr "Identitat"
+
+#: pkg/networkmanager/interfaces.js:1817
+msgid "Ignore"
+msgstr "Ignora"
+
+#: pkg/docker/index.html:452 pkg/kubernetes/views/image-panel.html:9
+#: pkg/kubernetes/views/container-body.html:6
+#: pkg/kubernetes/views/image-page.html:16
+msgid "Image"
+msgstr "Imatge"
+
+#: pkg/docker/image.js:77
+msgid "Image $0"
+msgstr "Imatge $0"
+
+#: pkg/kubernetes/views/container-body.html:8
+msgid "Image ID"
+msgstr "Id. d'imatge"
+
+#: pkg/kubernetes/views/image-meta.html:16
+msgid "Image Layers"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:58
+msgid "Image Name"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:23
+msgid "Image Registry"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-page.html:16
+msgid "Image Stream"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:135
+#, fuzzy
+msgid "Image commands"
+msgstr "Ordres  de Docker"
+
+#: pkg/kubernetes/views/imagestream-body.html:34
+msgid "Image count"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:48
+#: pkg/kubernetes/views/registry-dashboard-page.html:19
+#: pkg/kubernetes/views/imagestream-page.html:18
+#: pkg/kubernetes/views/image-listing.html:9 pkg/kubernetes/index.html:77
+msgid "Images"
+msgstr "Imatges"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:17
+msgid "Images by project"
+msgstr "Imatges per projecte"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:54
+msgid "Images pushed recently"
+msgstr ""
+
+#: pkg/storaged/details.js:1593
+msgid "In Sync"
+msgstr "En sincronització"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:81
+msgid ""
+"In order to begin pushing images to the registry, use the commands below."
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:6
+msgid ""
+"In order to begin pushing images to the registry, you need to create a "
+"project."
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:50
+msgid ""
+"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
+"strong}}.        {{/needs_root}}                                    User "
+"name                                                                            "
+"{{#allows_password}}                            "
+"Password                                                                            "
+"{{/allows_password}}            "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
+#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
+msgid "Inactive"
+msgstr "Inactiu"
+
+#: pkg/lib/machine-invalid-hostkey.html:2
+msgid "Incorrect Host Key"
+msgstr "Clau d'amfitrió incorrecta"
+
+#: pkg/docker/storage.jsx:282
+msgid "Information about the Docker storage pool is not available."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:222
+#, fuzzy
+msgid "Installed products"
+msgstr "Productes instal·lats"
+
+#: pkg/systemd/services.html:135
+msgid "Instantiate"
+msgstr "Instancia"
+
+#: pkg/kubernetes/views/pv-modify.html:169
+#: pkg/kubernetes/views/volume-body.html:81
+msgid "Interface"
+msgstr "Interfície"
+
+#: pkg/networkmanager/index.html:84
+msgid "Interfaces"
+msgstr "Interfícies"
+
+#: src/base1/cockpit.js:3701
+msgid "Internal error"
+msgstr "Error intern"
+
+#: pkg/subscriptions/subscriptions-client.js:196
+#, fuzzy
+msgid "Invalid credentials"
+msgstr "Port no vàlid"
+
+#: pkg/systemd/host.js:1194
+msgid "Invalid date format"
+msgstr "format de data no vàlid"
+
+#: pkg/systemd/host.js:1190
+msgid "Invalid date format and invalid time format"
+msgstr "format no vàlid de la data i l'hora"
+
+#: pkg/systemd/init.js:1218
+#, fuzzy
+msgid "Invalid date format."
+msgstr "format de data no vàlid"
+
+#: pkg/lib/credentials.js:274
+msgid "Invalid file permissions"
+msgstr "Permisos de fitxer no vàlids"
+
+#: pkg/users/index.html:322
+msgid "Invalid key"
+msgstr "Clau no vàlida"
+
+#: pkg/systemd/init.js:1169
+#, fuzzy
+msgid "Invalid number."
+msgstr "Clau no vàlida"
+
+#: pkg/docker/run.js:283
+msgid "Invalid port"
+msgstr "Port no vàlid"
+
+#: pkg/systemd/host.js:1192
+msgid "Invalid time format"
+msgstr "format d'hora no vàlid"
+
+#: pkg/subscriptions/subscriptions-client.js:194 pkg/storaged/overview.js:577
+#: pkg/storaged/overview.js:668
 msgid "Invalid username or password"
 msgstr "El nom d'usuari o la contrasenya no són vàlids"
 
-#: pkg/storaged/overview.js:582
-msgid "Unknown host name"
-msgstr "Nom d'amfitrió desconegut"
+#: pkg/lib/machine-change-port.html:15
+msgid "Is sshd running on a different port?"
+msgstr "S'està executant sshd en un port diferent?"
 
-#: pkg/storaged/overview.js:586
-msgid "Unable to reach server"
-msgstr "No es pot arribar al servidor"
+#: pkg/systemd/init.js:522
+msgid "Isolate"
+msgstr "Aïlla"
 
-#: pkg/storaged/overview.js:619
-msgid "Available targets on $0"
-msgstr "Objectius disponibles en $0"
+#: pkg/storaged/index.html:280
+msgid "Jobs"
+msgstr "Treballs"
 
-#: pkg/storaged/overview.js:623 pkg/systemd/services.html.h:2
-msgid "Targets"
-msgstr "Objectius"
+#: pkg/realmd/operation.js:96
+msgid "Join"
+msgstr "Uneix-te"
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-add.html.h:2
-#: pkg/kubernetes/views/node-body.html.h:2
-#: pkg/kubernetes/views/auth-form.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:16
-#: pkg/kubernetes/views/nodes-page.html.h:7
-#: pkg/kubernetes/views/details-page.html.h:19
-msgid "Address"
-msgstr "Adreça"
+#: pkg/realmd/operation.js:453
+msgid "Join Domain"
+msgstr "Uneix-te al domini"
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-change-port.html.h:5
-msgid "Port"
-msgstr "Port"
+#: pkg/realmd/operation.js:347
+msgid "Joining this domain is not supported"
+msgstr "La unió a aquest domini no està admesa"
 
-#: pkg/storaged/overview.js:699
-msgid "Change iSCSI Initiator Name"
-msgstr "Canvia el nom d'iniciador iSCSI"
+#: pkg/systemd/logs.js:257
+msgid "Journal entry"
+msgstr "Entrada de les publicacions"
 
-#: pkg/storaged/overview.js:707 pkg/kubernetes/views/route-modify.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:22
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:4
-#: pkg/kubernetes/views/project-modify.html.h:9
-msgid "Change"
-msgstr "Canvia"
+#: pkg/systemd/logs.js:284
+msgid "Journal entry not found"
+msgstr "Entrada no trobada de les publicacions"
 
-#: pkg/storaged/utils.js:88
-msgctxt "format-bytes"
-msgid "bytes"
-msgstr "bytes"
+#: pkg/lib/machine-auth-failed.html:10
+msgid "Kerberos Based SSO"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:69
+msgid "Kerberos Ticket"
+msgstr "Tiquet de Kerberos"
+
+#: pkg/systemd/index.html:225
+msgid "Kernel"
+msgstr "Nucli del sistema operatiu"
+
+#: pkg/kubernetes/views/node-body.html:19
+msgid "Kernel Version"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:67
+msgid "Key Ring Path"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:23
+msgid "Kubelet Version"
+msgstr "Versió de Kubelet"
+
+#: pkg/kubernetes/index.html:23
+msgid "Kubernetes Cluster"
+msgstr "Clúster Kubernetes"
+
+#: pkg/networkmanager/index.html:473
+msgid "LACP Key"
+msgstr ""
+
+#: pkg/storaged/details.js:1245
+msgctxt "storage-id-desc"
+msgid "LUKS Encrypted"
+msgstr "LUKS xifrat"
+
+#: pkg/storaged/details.js:1226
+msgctxt "storage-id-desc"
+msgid "LVM2 Physical Volume"
+msgstr "Volum físic LVM2"
+
+#: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/replicationcontroller-body.html:17
+#: pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/route-body.html:22
+#: pkg/kubernetes/views/image-meta.html:3
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
+msgid "Labels"
+msgstr "Etiquetes"
+
+#: pkg/systemd/logs.html:42
+msgid "Last 24 hours"
+msgstr "Les últimes 24 hores"
+
+#: pkg/systemd/logs.html:43
+msgid "Last 7 days"
+msgstr "Els últims 7 dies"
+
+#: pkg/kubernetes/views/node-body.html:49
+msgid "Last Heartbeat"
+msgstr ""
+
+#: pkg/users/index.html:100
+msgid "Last Login"
+msgstr "Últim inici de sessió"
+
+#: pkg/kubernetes/views/node-body.html:51
+msgid "Last Status Change"
+msgstr ""
+
+#: pkg/systemd/init.js:273
+msgid "Last Trigger"
+msgstr ""
+
+#: pkg/kubernetes/views/image-listing.html:16
+msgid "Last Updated"
+msgstr "Últim cop actualitzat"
+
+#: pkg/kubernetes/views/details-page.html:107
+msgid "Latest Version"
+msgstr "Última versió"
+
+#: pkg/realmd/operation.js:101
+msgid "Leave"
+msgstr "Abandona"
+
+#: pkg/networkmanager/index.html:315
+msgid "Link Monitoring"
+msgstr "Monitoratge de l'enllaç"
+
+#: pkg/networkmanager/index.html:397
+#, fuzzy
+msgid "Link Watch"
+msgstr "Enllaça localment"
+
+#: pkg/networkmanager/index.html:350 pkg/networkmanager/index.html:432
+msgid "Link down delay"
+msgstr "Retard del baixament de l'enllaç"
+
+#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
+msgid "Link local"
+msgstr "Enllaça localment"
+
+#: pkg/networkmanager/index.html:341 pkg/networkmanager/index.html:423
+msgid "Link up delay"
+msgstr "Retard de l'aixecament de l'enllaç"
+
+#: pkg/docker/index.html:514
+msgid "Links"
+msgstr "Enllaços"
+
+#: pkg/storaged/details.js:1224
+msgctxt "storage-id-desc"
+msgid "Linux MD-RAID Component"
+msgstr "Component MD-RAID de Linux"
+
+#: pkg/networkmanager/interfaces.js:1841
+#, fuzzy
+msgid "Load Balancing"
+msgstr "Balanceig de càrrega adaptativa"
+
+#: pkg/systemd/logs.js:69
+msgid "Load earlier entries"
+msgstr "Carrega les entrades anteriors"
+
+#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
+#: pkg/systemd/logs.js:175
+msgid "Loading..."
+msgstr "S'està carregant..."
+
+#: pkg/users/index.html:23
+msgid "Local Accounts"
+msgstr "Comptes locals"
+
+#: pkg/docker/storage.jsx:188
+#, fuzzy
+msgid "Local Disks"
+msgstr "$0 discs"
+
+#: pkg/storaged/details.js:1109
+msgid "Lock"
+msgstr "Bloqueja"
+
+#: pkg/users/index.html:109 pkg/users/index.html:196
+msgid "Lock Account"
+msgstr "Bloqueja el compte"
+
+#: pkg/storaged/jobs.js:122
+msgid "Locking $target"
+msgstr "S'està bloquejant $target"
+
+#: pkg/lib/machine-change-auth.html:80
+msgid "Log In"
+msgstr "Inici de la sessió"
+
+#: pkg/lib/machine-change-auth.html:4
+msgid "Log in to {{host}}"
+msgstr "Inicia la sessió a {{host}}"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:116
+msgid "Log into OpenShift command line tools:"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:101
+#, fuzzy
+msgid "Log into the registry:"
+msgstr "Inicia la sessió a {{host}}"
+
+#: pkg/shell/simple.html:45 pkg/shell/index.html:52 pkg/shell/stub.html:45
+msgid "Log out"
+msgstr "Tanca la sessió"
+
+#: pkg/users/local.js:839
+msgid "Logged In"
+msgstr "Autenticat"
+
+#: pkg/storaged/details.js:1424
+msgid "Logical Partition"
+msgstr "Partició lògica"
+
+#: pkg/kubernetes/views/pv-modify.html:158
+#: pkg/kubernetes/views/volume-body.html:79
+#: pkg/kubernetes/views/volume-body.html:118
+msgid "Logical Unit Number"
+msgstr "Número de la unitat lògica"
+
+#: pkg/storaged/utils.js:172
+msgid "Logical Volume"
+msgstr "Volum lògic"
+
+#: pkg/storaged/utils.js:170
+msgid "Logical Volume (Snapshot)"
+msgstr "Volum lògic (instantània)"
+
+#: pkg/storaged/details.js:1792
+msgid "Logical Volumes"
+msgstr "Volums lògics"
+
+#: pkg/subscriptions/subscriptions-register.jsx:140
+#, fuzzy
+msgid "Login"
+msgstr "Últim inici de sessió"
+
+#: pkg/lib/machine-change-auth.html:68
+msgid "Login Password"
+msgstr "Contrasenya d'inici de sessió"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:96
+#, fuzzy
+msgid "Login commands"
+msgstr "Ordres  de Docker"
+
+#: src/base1/cockpit.js:3693
+msgid "Login failed"
+msgstr "Ha fallat l'inici de sessió"
+
+#: pkg/subscriptions/subscriptions-client.js:200
+msgid "Login/password or activation key required to register."
+msgstr ""
+
+#: pkg/systemd/logs.html:59 pkg/kubernetes/views/container-panel.html:6
+#: pkg/kubernetes/views/container-page-inline.html:8
+msgid "Logs"
+msgstr "Registres"
+
+#: pkg/dashboard/index.html:110
+msgid "Lost connection. Trying to reconnect"
+msgstr "S'ha perdut la connexió. S'intenta connectar de nou"
+
+#: pkg/docker/index.html:184
+msgid "MAC Address:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1833
+msgid "MII (Recommended)"
+msgstr "MII (recomanat)"
+
+#: pkg/networkmanager/interfaces.js:2477
+msgid "MTU"
+msgstr "MTU"
+
+#: pkg/networkmanager/interfaces.js:4139
+msgid "MTU must be a positive number"
+msgstr ""
+
+#: pkg/systemd/index.html:85 pkg/kubernetes/views/node-body.html:15
+msgid "Machine ID"
+msgstr "Id. de màquina"
+
+#: pkg/systemd/index.html:282
+msgid "Machine SSH Key Fingerprints"
+msgstr ""
+
+#: pkg/shell/indexes.js:253
+msgid "Machines"
+msgstr "Màquines"
+
+#: pkg/kubernetes/scripts/dashboard.js:460
+msgid "Manifest"
+msgstr "Manifest"
+
+#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
+msgid "Manual"
+msgstr "Manual"
+
+#: pkg/systemd/index.html:401 pkg/systemd/index.html:405
+msgid "Manually"
+msgstr "Manualment"
+
+#: pkg/storaged/jobs.js:140
+msgid "Marking $target as faulty"
+msgstr "S'està ficant $target com a defectuós"
+
+#: pkg/systemd/init.js:546
+msgid "Mask"
+msgstr "Emmascara"
+
+#: pkg/systemd/init.js:547
+msgid "Mask Forcefully"
+msgstr "Emmascara-ho forçosament"
+
+#: pkg/networkmanager/interfaces.js:2483
+msgid "Master"
+msgstr "Màster"
+
+#: pkg/networkmanager/interfaces.js:2581
+msgid "Maximum message age $max_age"
+msgstr "Envelliment màxim del missatge $max_age"
+
+#: pkg/kubernetes/views/volume-body.html:34
+msgid "Medium"
+msgstr "Mitjà"
+
+#: pkg/kubernetes/views/project-listing.html:92
+msgid "Member of"
+msgstr "Membre de"
+
+#: pkg/kubernetes/views/project-listing.html:16
+#: pkg/kubernetes/views/project-listing.html:55
+#: pkg/networkmanager/index.html:291
+msgid "Members"
+msgstr "Membres"
+
+#: pkg/kubernetes/views/project-page.html:29
+#: pkg/kubernetes/views/user-panel.html:11
+#: pkg/kubernetes/views/user-panel.html:27
+#: pkg/kubernetes/views/user-body.html:4
+msgid "Membership"
+msgstr "Pertinença"
+
+#: pkg/dashboard/index.html:71 pkg/playground/translate.html:91
+msgid "Memory"
+msgstr "Memòria"
+
+#: pkg/systemd/host.js:1466
+msgctxt "page-title"
+msgid "Memory"
+msgstr "Memòria"
+
+#: pkg/kubernetes/scripts/nodes.js:716
+msgid "Memory Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:473 pkg/docker/index.html:652
+msgid "Memory limit"
+msgstr "Límit de memòria"
+
+#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
+msgid "Message"
+msgstr "Missatge"
+
+#: pkg/systemd/host.js:1300
+msgid "Message to logged in users"
+msgstr "Missatge als usuaris que hagin iniciat la sessió"
+
+#: pkg/kubernetes/views/image-panel.html:15
+#: pkg/kubernetes/views/imagestream-page.html:21
+#: pkg/kubernetes/views/image-page.html:22
+msgid "Metadata"
+msgstr "Metadades"
+
+#: pkg/docker/index.html:487 pkg/docker/index.html:666
+msgid "MiB"
+msgstr "MiB"
+
+#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
+msgid "Minute needs to be a number between 0-59"
+msgstr ""
+
+#: pkg/systemd/services.html:407
+#, fuzzy
+msgid "Minutes"
+msgstr "5 minuts"
+
+#: pkg/networkmanager/index.html:299
+msgid "Mode"
+msgstr "Mode"
+
+#: pkg/storaged/index.html:421
+msgctxt "storage"
+msgid "Model"
+msgstr "Model"
+
+#: pkg/kubernetes/views/user-modify.html:31
+msgid "Modify"
+msgstr "Modifica"
+
+#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
+msgid "Modifying $target"
+msgstr "S'està modificant $target"
+
+#: pkg/networkmanager/index.html:323
+msgid "Monitoring Interval"
+msgstr "Interval del monitoratge"
+
+#: pkg/networkmanager/index.html:332
+msgid "Monitoring Targets"
+msgstr "Objectius del monitoratge"
+
+#: pkg/kubernetes/views/volume-body.html:54
+msgid "Monitors"
+msgstr ""
+
+#: pkg/realmd/operation.js:366
+msgid "More"
+msgstr "Més"
+
+#: pkg/storaged/details.js:1099
+msgid "Mount"
+msgstr "Munta"
+
+#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
+msgid "Mount Location"
+msgstr ""
+
+#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
+msgid "Mount Options"
+msgstr "Opcions de muntatge"
+
+#: pkg/storaged/index.html:231
+msgid "Mount Point"
+msgstr "Punt de muntatge"
+
+#: pkg/docker/index.html:540
+msgid "Mount container volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
+msgid "Mounting"
+msgstr "Muntatge"
+
+#: pkg/storaged/jobs.js:126
+msgid "Mounting $target"
+msgstr "S'està muntat $target"
+
+#: pkg/storaged/index.html:508
+msgctxt "storage"
+msgid "Multipathed Devices"
+msgstr "Dispositius amb multicamí"
+
+#: pkg/kubernetes/scripts/volumes.js:860
+msgid "NFS"
+msgstr "NFS"
+
+#: pkg/kubernetes/scripts/volumes.js:199
+msgid "NFS Mount"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1856
+msgid "NSNA Ping"
+msgstr ""
+
+#: pkg/storaged/details.js:182
+msgid "NTFS - Compatible with most systems"
+msgstr "NTFS - Compatible amb la majoria dels sistemes"
+
+#: pkg/systemd/host.js:1250
+msgid "NTP Server"
+msgstr "Servidor NTP"
+
+#: pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/project-modify.html:16
+#: pkg/kubernetes/views/node-add.html:16
+#: pkg/kubernetes/views/volumes-page.html:19
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/image-body.html:2
+#: pkg/kubernetes/views/imagestream-modify.html:10
+#: pkg/kubernetes/views/service-modify.html:9
+#: pkg/kubernetes/views/dashboard-page.html:156
+#: pkg/kubernetes/views/dashboard-page.html:198
+#: pkg/kubernetes/views/details-page.html:34
+#: pkg/kubernetes/views/details-page.html:70
+#: pkg/kubernetes/views/details-page.html:103
+#: pkg/kubernetes/views/details-page.html:137
+#: pkg/kubernetes/views/details-page.html:171
+#: pkg/kubernetes/views/pv-claim.html:4
+#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/kubernetes/views/project-listing.html:14
+#: pkg/kubernetes/views/project-listing.html:53
+#: pkg/kubernetes/views/project-listing.html:90
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/volume-body.html:31 pkg/storaged/index.html:230
+#: pkg/networkmanager/index.html:95 pkg/networkmanager/index.html:113
+#: pkg/networkmanager/index.html:150 pkg/networkmanager/index.html:183
+#: pkg/networkmanager/index.html:282 pkg/networkmanager/index.html:364
+msgid "Name"
+msgstr "Nom"
 
 #: pkg/storaged/utils.js:129
 #, fuzzy
@@ -1717,376 +3450,1221 @@ msgstr "El nom no pot contenir el caràcter «$0»."
 msgid "Name cannot contain whitespace."
 msgstr "El nom no pot contenir cap espai en blanc."
 
-#: pkg/storaged/utils.js:157
-msgid "$name (from $host)"
-msgstr "$name (de $host)"
+#: pkg/kubernetes/views/service-body.html:5
+#: pkg/kubernetes/views/replicationcontroller-body.html:5
+#: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/pod-body.html:5
+#: pkg/kubernetes/views/dashboard-page.html:160
+#: pkg/kubernetes/views/details-page.html:36
+#: pkg/kubernetes/views/details-page.html:72
+#: pkg/kubernetes/views/details-page.html:105
+#: pkg/kubernetes/views/details-page.html:139
+#: pkg/kubernetes/views/details-page.html:173
+#: pkg/kubernetes/views/pv-claim.html:6
+#: pkg/kubernetes/views/containers-listing.html:14
+#: pkg/kubernetes/views/route-body.html:5
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
+msgid "Namespace"
+msgstr "Espai de noms"
+
+#: pkg/kubernetes/scripts/dashboard.js:374
+msgid "Namespace cannot be empty."
+msgstr "L'espai de noms no pot estar en blanc."
+
+#: pkg/systemd/host.js:1113
+msgid "Need at least one NTP server"
+msgstr "Com a mínim es necessita un servidor NTP"
+
+#: pkg/dashboard/index.html:72 pkg/playground/translate.html:96
+msgid "Network"
+msgstr "Xarxa"
+
+#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:485
+msgid "Networking"
+msgstr "Xarxa"
+
+#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
+msgctxt "page-title"
+msgid "Networking"
+msgstr "Xarxa"
+
+#: pkg/networkmanager/index.html:124
+msgid "Networking Logs"
+msgstr "Registres de la xarxa"
+
+#: pkg/users/local.js:841
+msgid "Never"
+msgstr "Mai"
+
+#: pkg/kubernetes/views/project-listing.html:46
+msgid "New Group"
+msgstr "Nou grup"
+
+#: pkg/users/index.html:236 pkg/shell/index.html:255
+msgid "New Password"
+msgstr "Contrasenya nova"
+
+#: pkg/kubernetes/views/project-listing.html:7
+msgid "New Project"
+msgstr "Nou projecte"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/image-listing.html:7
+msgid "New image stream"
+msgstr ""
+
+#: pkg/users/local.js:120 pkg/lib/credentials.js:231
+msgid "New password was not accepted"
+msgstr "No s'ha acceptat la nova contrasenya"
+
+#: pkg/kubernetes/views/project-modify.html:4
+#: pkg/kubernetes/views/registry-dashboard-page.html:9
+#: pkg/kubernetes/views/registry-dashboard-page.html:48
+msgid "New project"
+msgstr "Nou projecte"
+
+#: pkg/realmd/operation.html:91
+msgid "Next"
+msgstr "Següent"
+
+#: pkg/systemd/init.js:272
+msgid "Next Run"
+msgstr ""
+
+#: pkg/systemd/index.html:233
+msgid "Nice"
+msgstr "Nice"
+
+#: pkg/docker/index.html:563 pkg/docker/index.html:567
+msgid "No"
+msgstr "No"
+
+#: pkg/systemd/index.html:469
+msgid "No Delay"
+msgstr "Sense retard"
+
+#: pkg/ostree/index.html:220
+msgid "No Deployments"
+msgstr "Sense desplegaments"
+
+#: pkg/storaged/details.js:185
+msgid "No Filesystem"
+msgstr "Sense sistema de fitxers"
+
+#: pkg/ostree/app.js:101
+msgid "No OSTree deployments found"
+msgstr "No s'ha trobat desplegaments OSTree"
+
+#: src/ws/cockpitcertificate.c:398
+msgid "No PEM-encoded certificate found"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:364
+msgid "No PEM-encoded private key found"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:39
+msgid "No Pods are using this claim"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:479
+msgid "No SELinux alerts."
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:10
+msgid "No Volume Bound"
+msgstr ""
+
+#: pkg/docker/storage.jsx:194
+msgid "No additional local storage found."
+msgstr ""
+
+#: pkg/docker/run.js:350
+msgid "No alias specified"
+msgstr "Sense especificar l'àlies"
+
+#: pkg/sosreport/index.js:115
+msgid "No archive has been created."
+msgstr "No s'ha creat cap arxiu."
+
+#: pkg/networkmanager/interfaces.js:1326
+msgid "No carrier"
+msgstr "Sense portadora"
+
+#: pkg/docker/run.js:384
+msgid "No container specified"
+msgstr "Sense especificar el contenidor"
+
+#: pkg/storaged/index.html:193
+msgid "No drives attached"
+msgstr "Sense unitats connectades"
+
+#: pkg/kubernetes/views/project-listing.html:74
+msgid "No groups are present."
+msgstr ""
+
+#: pkg/systemd/index.html:28
+msgid "No host keys found."
+msgstr ""
+
+#: pkg/storaged/index.html:158
+msgid "No iSCSI targets set up"
+msgstr "Sense destinacions iSCSI preparades"
+
+#: pkg/kubernetes/views/image-listing.html:70
+msgid "No image streams are present."
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:80
+msgid "No images pushed"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:223
+#, fuzzy
+msgid "No installed products on the system."
+msgstr "Cockpit no està instal·lat al sistema."
+
+#: pkg/storaged/index.html:446
+msgid "No media inserted"
+msgstr "Sense mitjans inserits"
+
+#: pkg/kubernetes/scripts/dashboard.js:384
+msgid ""
+"No metadata file was selected. Please select a Kubernetes metadata file."
+msgstr ""
+"Sense seleccionar el fitxer de metadades. Si us plau, seleccioneu un fitxer "
+"de metadades del Kubernetes."
+
+#: pkg/kubernetes/views/dashboard-page.html:117
+msgid "No nodes in cluster"
+msgstr ""
+
+#: pkg/storaged/details.js:352
+msgid "No partitioning"
+msgstr "Sense particionatge"
+
+#: pkg/kubernetes/views/dashboard-page.html:40
+msgid "No pods deployed"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:6
+msgid "No pods replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/node-capacity.html:11
+msgid "No pods scheduled"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:10
+msgid "No pods selected"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:37
+msgid "No projects are present."
+msgstr ""
+
+#: pkg/users/local.js:405
+msgid "No real name specified"
+msgstr "Sense especificar el nom real"
+
+#: pkg/storaged/index.html:87
+msgid "No storage set up as RAID"
+msgstr "Cap emmagatgematge preparat com a RAID"
+
+#: pkg/lib/credentials.js:182
+msgid "No such file or directory"
+msgstr "El fitxer o directori no existeix"
+
+#: pkg/users/local.js:400
+msgid "No user name specified"
+msgstr "Sense especificar el nom d'usuari"
+
+#: pkg/kubernetes/views/project-listing.html:112
+msgid "No users are present."
+msgstr ""
+
+#: pkg/storaged/index.html:120
+msgid "No volume groups created"
+msgstr "Cap grup de volums creat"
+
+#: pkg/kubernetes/views/volumes-page.html:44
+msgid "No volumes are present."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:73
+msgid "No volumes in use"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:18 pkg/kubernetes/views/node-panel.html:7
+#: pkg/kubernetes/views/containers-listing.html:15
+#: pkg/kubernetes/views/node-page.html:14
+#: pkg/kubernetes/views/topology-page.html:41
+msgid "Node"
+msgstr "Node"
+
+#: pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:192
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:45
+msgid "Nodes"
+msgstr "Nodes"
+
+#: pkg/kubernetes/views/topology-page.html:42
+msgid "Nodes are the machines that run your containers."
+msgstr "Els nodes són les màquines que executen els vostres contenidors."
+
+#: pkg/kubernetes/views/service-body.html:15
+#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
+#: pkg/kubernetes/views/image-config.html:25
+#: pkg/kubernetes/views/imagestream-body.html:33
+msgid "None"
+msgstr "Cap"
+
+#: pkg/playground/translate.html:30 pkg/kubernetes/views/details-page.html:53
+#: pkg/kubernetes/views/node-body.html:42
+msgid "Not Ready"
+msgstr "No a punt"
+
+#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
+msgid "Not a valid number of replicas"
+msgstr "No és un nombre vàlid de rèpliques"
+
+#: pkg/lib/credentials.js:248
+msgid "Not a valid private key"
+msgstr "No és una clau privada vàlida"
+
+#: pkg/kubernetes/scripts/details.js:546
+msgid "Not a valid value for Host"
+msgstr "No és un valor vàlid per a l'amfitrió"
+
+#: pkg/docker/index.html:57
+msgid "Not authorized to access Docker on this system"
+msgstr "No s'autoritza l'accés Docker en aquest sistema"
+
+#: pkg/ostree/app.js:81
+msgid "Not authorized to update software on this system"
+msgstr "No autoritzat per actualitzar el programari en aquest sistema"
+
+#: pkg/networkmanager/interfaces.js:805
+msgid "Not available"
+msgstr "No disponible"
+
+#: pkg/selinux/setroubleshoot.js:238
+msgid "Not connected"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:122
+msgid "Not deployed"
+msgstr "No desplegat"
+
+#: pkg/docker/details.js:177 pkg/docker/image.js:112
+#: pkg/storaged/details.js:1822
+msgid "Not found"
+msgstr "No s'ha trobat"
+
+#: src/base1/cockpit.js:3691
+msgid "Not permitted to perform this action."
+msgstr "No es permet realitzar aquesta acció."
+
+#: pkg/storaged/details.js:1574
+msgid "Not running"
+msgstr "No s'està executant"
+
+#: pkg/systemd/index.html:62
+msgid "Not synchronized"
+msgstr "No sincronitzat"
+
+#: pkg/systemd/services.html:299
+msgid "Note"
+msgstr "Nota"
+
+#: pkg/systemd/logs.html:49
+msgid "Notices"
+msgstr "Anuncis"
+
+#: pkg/kubernetes/views/node-body.html:13
+msgid "OS"
+msgstr "SO"
+
+#: pkg/ostree/client.js:500
+msgid "OS $0 not found"
+msgstr "SO $0 no trobat"
+
+#: pkg/kubernetes/views/nodes-page.html:19
+msgid "OS Versions"
+msgstr ""
+
+#: pkg/ostree/app.js:83
+msgid "OSTree is not available on this system"
+msgstr "OSTree no està disponible en aquest sistema"
+
+#: pkg/selinux/setroubleshoot-view.jsx:405
+msgid "Occurred $0"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:400
+msgid "Occurred between $0 and $1"
+msgstr ""
+
+#: pkg/systemd/index.html:157 pkg/playground/jquery-patterns.html:95
+#: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:189
+#: pkg/storaged/index.html:565
+msgid "Off"
+msgstr "Apagat"
+
+#: pkg/lib/cockpit-components-dialog.jsx:155
+msgid "Ok"
+msgstr ""
+
+#: pkg/users/index.html:226 pkg/shell/index.html:248
+msgid "Old Password"
+msgstr "Contrasenya antiga"
+
+#: pkg/users/local.js:78 pkg/lib/credentials.js:213
+msgid "Old password not accepted"
+msgstr "Contrasenya antiga no acceptada"
+
+#: pkg/systemd/index.html:153 pkg/playground/jquery-patterns.html:91
+#: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:185
+#: pkg/storaged/index.html:564
+msgid "On"
+msgstr "Engegat"
+
+#: pkg/kubernetes/views/image-meta.html:7
+msgid "On Build"
+msgstr ""
+
+#: pkg/docker/index.html:568
+msgid "On Failure"
+msgstr ""
+
+#: pkg/docker/util.js:104
+msgid "On failure, retry $0 time"
+msgid_plural "On failure, retry $0 times"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/realmd/operation.html:71
+msgid "One Time Password"
+msgstr "Contrasenya d'un sol cop"
+
+#: pkg/systemd/init.js:1147
+msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
+msgstr ""
+
+#: pkg/shell/simple.html:28 pkg/shell/index.html:28 pkg/shell/stub.html:28
+msgid "Ooops!"
+msgstr "Ooops!"
+
+#: pkg/systemd/index.html:89 pkg/ostree/index.html:111
+#: pkg/kubernetes/views/nodes-page.html:42
+msgid "Operating System"
+msgstr "Sistema operatiu"
+
+#: pkg/ostree/index.html:186
+msgid "Operating System Updates"
+msgstr "Actualitzacions del sistema operatiu"
+
+#: pkg/storaged/jobs.js:166
+msgid "Operation '$operation' on $target"
+msgstr "L'operació '$operation' en $target"
+
+#: pkg/storaged/overview.js:189
+msgctxt "storage"
+msgid "Optical Drive"
+msgstr "Unitat òptica"
+
+#: pkg/kubernetes/views/volume-body.html:130
+msgid "Options"
+msgstr "Opcions"
+
+#: pkg/subscriptions/subscriptions-register.jsx:176
+#, fuzzy
+msgid "Organization"
+msgstr "Traducció"
+
+#: pkg/storaged/details.js:1253
+msgctxt "storage-id-desc"
+msgid "Other Data"
+msgstr "Altres dades"
+
+#: pkg/storaged/index.html:202
+msgid "Other Devices"
+msgstr "Altres dispositius"
+
+#: pkg/docker/index.html:319 pkg/kubernetes/registry.html:42
+#: pkg/kubernetes/index.html:39
+msgid "Overview"
+msgstr ""
+
+#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
+msgid "Overwrite existing data with zeros"
+msgstr "Sobreescriu les dades existents amb zeros"
+
+#: pkg/kubernetes/views/volume-body.html:4
+msgid "PD Name"
+msgstr ""
+
+#: pkg/ostree/index.html:100
+msgid "Packages"
+msgstr "Paquets"
+
+#: pkg/networkmanager/index.html:133
+msgid "Parent"
+msgstr "Pare"
+
+#: pkg/networkmanager/interfaces.js:2619
+msgid "Parent $parent"
+msgstr "Pare $parent"
+
+#: pkg/networkmanager/interfaces.js:1372
+msgid "Part of "
+msgstr "Part de"
+
+#: pkg/kubernetes/views/volume-body.html:8
+#: pkg/kubernetes/views/volume-body.html:18
+msgid "Partition"
+msgstr "Partició"
+
+#: pkg/storaged/details.js:346
+msgid "Partitioning"
+msgstr "Particionatge"
+
+#: pkg/networkmanager/interfaces.js:1848
+msgid "Passive"
+msgstr ""
+
+#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
+msgid "Passphrase"
+msgstr "Contrasenya"
+
+#: pkg/storaged/details.js:224
+#, fuzzy
+msgid "Passphrase cannot be empty"
+msgstr "La contrasenya no pot estar en blanc"
+
+#: pkg/storaged/details.js:232
+msgid "Passphrases do not match"
+msgstr "Les contrasenyes no coincideixen"
+
+#: pkg/users/index.html:115 pkg/users/index.html:160 pkg/shell/index.html:199
+#: pkg/shell/index.html:212 pkg/kubernetes/views/auth-form.html:105
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+msgid "Password"
+msgstr "Contrasenya"
+
+#: pkg/users/local.js:259
+msgid "Password is not acceptable"
+msgstr "La contrasenya no és acceptable"
+
+#: pkg/users/local.js:247
+msgid "Password is too weak"
+msgstr "La contrasenya és massa feble"
+
+#: pkg/lib/credentials.js:278
+msgid "Password not accepted"
+msgstr "Contrasenya no acceptada"
+
+#: pkg/kubernetes/views/pv-modify.html:126
+#: pkg/kubernetes/views/volume-body.html:37
+#: pkg/kubernetes/views/volume-body.html:49
+#: pkg/kubernetes/views/volume-body.html:101
+msgid "Path"
+msgstr "Camí"
+
+#: pkg/networkmanager/index.html:259
+msgid "Path cost"
+msgstr "Cost del camí"
+
+#: pkg/networkmanager/interfaces.js:2601
+msgid "Path cost $path_cost"
+msgstr "Cost del camí $path_cost"
+
+#: pkg/systemd/services.html:56
+msgid "Paths"
+msgstr "Camins"
+
+#: pkg/kubernetes/views/volumes-page.html:53
+msgid "Pending Volume Claims"
+msgstr ""
+
+#: pkg/systemd/index.html:143
+msgid "Performance Profile"
+msgstr "Perfil de rendiment"
+
+#: pkg/kubernetes/views/volumes-page.html:14
+msgid "Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:16
+msgid "Phase"
+msgstr "Fase"
+
+#: pkg/storaged/index.html:641
+msgid "Physical Volumes"
+msgstr "Volums físics"
+
+#: pkg/networkmanager/index.html:405
+#, fuzzy
+msgid "Ping Interval"
+msgstr "Interval del monitoratge"
+
+#: pkg/networkmanager/index.html:414
+#, fuzzy
+msgid "Ping Target"
+msgstr "S'està bloquejant $target"
+
+#: pkg/docker/containers-view.jsx:166 pkg/docker/details.js:271
+#: pkg/docker/image.js:151 pkg/storaged/details.js:625
+#: pkg/storaged/details.js:821 pkg/storaged/details.js:1016
+msgid "Please confirm deletion of $0"
+msgstr "Si us plau, confirmeu la supressió de $0"
+
+#: pkg/docker/util.js:501
+msgid "Please confirm forced deletion of $0"
+msgstr "Si us plau, confirmeu la supressió forçada de $0"
+
+#: pkg/kubernetes/scripts/dashboard.js:441
+msgid "Please create another namespace for $0 \"$1\""
+msgstr "Si us plau, creeu un altre espai de noms per a $0 \"$1\""
+
+#: pkg/kubernetes/scripts/volumes.js:574
+msgid "Please provide a GlusterFS volume name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:554
+msgid "Please provide a username"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:632
+msgid "Please provide a valid NFS server"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:539
+msgid "Please provide a valid address"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:805
+msgid "Please provide a valid filesystem type"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:813
+msgid "Please provide a valid interface"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:797
+msgid "Please provide a valid logical unit number"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:477
+msgid "Please provide a valid name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:376
+msgid "Please provide a valid namespace."
+msgstr "Si us plau, un espai de noms vàlid."
+
+#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
+msgid "Please provide a valid path"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:789
+msgid "Please provide a valid qualified name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:485
+msgid "Please provide a valid storage capacity."
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:781
+msgid "Please provide a valid target"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:469
+msgid "Please select a valid access mode"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:565
+msgid "Please select a valid endpoint"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:493
+msgid "Please select a valid policy option."
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:397
+msgid "Please type an address"
+msgstr "Si us plau, introduïu una adreça"
+
+#: pkg/kubernetes/views/pod-page.html:12
+#: pkg/kubernetes/views/containers-listing.html:12
+#: pkg/kubernetes/views/topology-page.html:14
+msgid "Pod"
+msgstr "Pod"
+
+#: pkg/kubernetes/views/pod-body.html:20
+msgid "Pod Address"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:4
+#: pkg/kubernetes/views/service-endpoint.html:9
+msgid "Pod Endpoints"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:4
+msgid "Pod Replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:15
+#: pkg/kubernetes/views/replicationcontroller-pods.html:11
+msgid "Pod Selector"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:17
+#: pkg/kubernetes/views/dashboard-page.html:18
+#: pkg/kubernetes/views/details-page.html:166
+#: pkg/kubernetes/views/pv-claim.html:37
+#: pkg/kubernetes/views/replicationcontroller-panel.html:12
+msgid "Pods"
+msgstr "Pods"
+
+#: pkg/kubernetes/views/topology-page.html:15
+msgid ""
+"Pods contain one or more containers that run                together on a "
+"node, containing your application code."
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:60
+msgid "Pool Name"
+msgstr ""
 
 #: pkg/storaged/utils.js:166
 msgid "Pool for Thin Logical Volumes"
 msgstr "Agrupació per als volums lògics disgregats"
 
-#: pkg/storaged/utils.js:168
-msgid "Thin Logical Volume"
-msgstr "Volums lògics disgregats"
+#: pkg/storaged/details.js:874
+msgid "Pool for thinly provisioned volumes"
+msgstr ""
 
-#: pkg/storaged/utils.js:170
-msgid "Logical Volume (Snapshot)"
-msgstr "Volum lògic (instantània)"
+#: pkg/kubernetes/views/imagestream-modify.html:45
+msgid "Populate"
+msgstr "Pobla"
 
-#: pkg/storaged/utils.js:172
-msgid "Logical Volume"
-msgstr "Volum lògic"
+#: pkg/lib/machine-change-port.html:23
+msgid "Port"
+msgstr "Port"
 
-#: pkg/storaged/utils.js:212
-msgid "<span>Encrypted Logical Volume of $0</span>"
-msgstr "<span>Volum lògic xifrat de $0</span>"
+#: pkg/docker/index.html:525 pkg/kubernetes/views/service-body.html:13
+#: pkg/kubernetes/views/image-config.html:23
+#: pkg/kubernetes/views/container-body.html:12
+#: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:373
+msgid "Ports"
+msgstr "Ports"
 
-#: pkg/storaged/utils.js:214
-msgid "<span>Encrypted Partition of $0</span>"
-msgstr "<span>Partició xifrada de $0</span>"
+#: pkg/systemd/index.html:123
+msgid "Power Options"
+msgstr "Opcions d'energia"
 
-#: pkg/storaged/utils.js:216
-msgid "<span>Logical Volume of $0</span>"
-msgstr "<span>Volum lògic de $0</span>"
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length"
+msgstr "Longitud del prefix"
 
-#: pkg/storaged/utils.js:218
-msgid "<span>Partition of $0</span>"
-msgstr "<span>Partició de $0</span>"
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length or Netmask"
+msgstr "Longitud del prefix o Màscara de xarxa"
 
-#: pkg/storaged/utils.js:220
-msgid "<span>Encrypted $0</span>"
-msgstr "<span>Xifrat $0</span>"
+#: pkg/networkmanager/interfaces.js:809
+msgid "Preparing"
+msgstr "S'està preparant"
+
+#: pkg/systemd/init.js:544
+msgid "Preset"
+msgstr "Preajusta"
+
+#: pkg/systemd/init.js:545
+msgid "Preset Forcefully"
+msgstr "Preajusta-ho forçosament"
+
+#: pkg/systemd/index.html:310
+msgid "Pretty Host Name"
+msgstr "Nom de l'amfitrió de nivell superior"
+
+#: pkg/networkmanager/index.html:307
+msgid "Primary"
+msgstr "Principal"
+
+#: pkg/storaged/details.js:1426
+msgid "Primary Partition"
+msgstr "Partició primària"
+
+#: pkg/networkmanager/index.html:250 pkg/networkmanager/index.html:446
+#: pkg/networkmanager/index.html:464
+msgid "Priority"
+msgstr "Prioritat"
+
+#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
+msgid "Priority $priority"
+msgstr "Prioritat $priority"
+
+#: pkg/subscriptions/subscriptions-view.jsx:33
+msgid "Product ID"
+msgstr "Id. del producte"
+
+#: pkg/subscriptions/subscriptions-view.jsx:32
+msgid "Product name"
+msgstr "Nom del producte"
+
+#: pkg/kubernetes/views/service-body.html:4
+#: pkg/kubernetes/views/replicationcontroller-body.html:4
+#: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/imagestream-modify.html:21
+#: pkg/kubernetes/views/pod-body.html:4
+#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/details-page.html:35
+#: pkg/kubernetes/views/details-page.html:71
+#: pkg/kubernetes/views/details-page.html:104
+#: pkg/kubernetes/views/details-page.html:138
+#: pkg/kubernetes/views/details-page.html:172
+#: pkg/kubernetes/views/containers-listing.html:13
+#: pkg/kubernetes/views/route-body.html:4
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
+msgid "Project"
+msgstr "Projecte"
+
+#: pkg/kubernetes/views/project-body.html:20
+msgid "Project Members"
+msgstr "Membres del projecte"
+
+#: pkg/kubernetes/views/filter-project.html:5
+msgid "Project:"
+msgstr "Projecte:"
+
+#: pkg/kubernetes/registry.html:54 pkg/kubernetes/views/group-delete.html:10
+#: pkg/kubernetes/views/project-listing.html:9
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:84
+msgid "Projects"
+msgstr "Projectes"
+
+#: pkg/users/local.js:82
+msgid "Prompting via passwd timed out"
+msgstr "Expiració de temps en la deferència a través passwd"
+
+#: pkg/lib/credentials.js:251
+msgid "Prompting via ssh-add timed out"
+msgstr ""
+
+#: pkg/lib/credentials.js:191
+msgid "Prompting via ssh-keygen timed out"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:125
+msgid "Proxy"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:25
+msgid "Proxy Version"
+msgstr "Versió del servidor intermediari"
+
+#: pkg/shell/index.html:198 pkg/lib/machine-auth-failed.html:9
+msgid "Public Key"
+msgstr "Clau pública"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:150
+msgid "Pull an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:66
+msgid "Pull from"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:31
+msgid "Pull repository"
+msgstr ""
+
+#: pkg/storaged/details.js:869
+msgid "Purpose"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:140
+msgid "Push an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:147
+#: pkg/kubernetes/views/volume-body.html:77
+msgid "Qualified Name"
+msgstr ""
+
+#: pkg/storaged/details.js:1539
+msgid "RAID ($0)"
+msgstr "RAID ($0)"
+
+#: pkg/storaged/details.js:1533
+msgid "RAID 0"
+msgstr "RAID 0"
+
+#: pkg/storaged/overview.js:422
+msgid "RAID 0 (Stripe)"
+msgstr "RAID 0 (segmentació)"
+
+#: pkg/storaged/details.js:1534
+msgid "RAID 1"
+msgstr "RAID 1"
+
+#: pkg/storaged/overview.js:423
+msgid "RAID 1 (Mirror)"
+msgstr "RAID 1 (rèplica)"
+
+#: pkg/storaged/details.js:1538
+msgid "RAID 10"
+msgstr "RAID 10"
+
+#: pkg/storaged/overview.js:427
+msgid "RAID 10 (Stripe of Mirrors)"
+msgstr "RAID 10 (segmentació de rèpliques)"
+
+#: pkg/storaged/details.js:1535
+msgid "RAID 4"
+msgstr "RAID 4"
+
+#: pkg/storaged/overview.js:424
+msgid "RAID 4 (Dedicated Parity)"
+msgstr "RAID 4 (paritat dedicada)"
+
+#: pkg/storaged/details.js:1536
+msgid "RAID 5"
+msgstr "RAID 5"
+
+#: pkg/storaged/overview.js:425
+msgid "RAID 5 (Distributed Parity)"
+msgstr "RAID 5 (paritat distribuïda)"
+
+#: pkg/storaged/details.js:1537
+msgid "RAID 6"
+msgstr "RAID 6"
+
+#: pkg/storaged/overview.js:426
+msgid "RAID 6 (Double Distributed Parity)"
+msgstr "RAID 5 (doble paritat distribuïda)"
+
+#: pkg/storaged/index.html:537
+msgid "RAID Device"
+msgstr "Dispositiu RAID"
 
 #: pkg/storaged/utils.js:233
 msgid "RAID Device $0"
 msgstr "Dispositiu RAID $0"
 
-#: pkg/storaged/utils.js:239
-msgid "Volume Group $0"
-msgstr "Grup de volums $0"
+#: pkg/storaged/index.html:65
+msgid "RAID Devices"
+msgstr "Dispositius RAID"
 
-#: pkg/storaged/jobs.js:119
-msgid "SMART self-test of $target"
-msgstr "Autotest SMART de $target."
+#: pkg/storaged/overview.js:420
+msgid "RAID Level"
+msgstr "Nivell RAID"
 
-#: pkg/storaged/jobs.js:120
-msgid "Ejecting $target"
-msgstr "S'està expulsant $target"
+#: pkg/storaged/index.html:555
+msgctxt "storage"
+msgid "RAID Level"
+msgstr "Nivell RAID"
 
-#: pkg/storaged/jobs.js:121
-msgid "Unlocking $target"
-msgstr "S'està desbloquejant $target"
+#: pkg/storaged/details.js:1228
+msgctxt "storage-id-desc"
+msgid "RAID Member"
+msgstr "Membre RAID"
 
-#: pkg/storaged/jobs.js:122
-msgid "Locking $target"
-msgstr "S'està bloquejant $target"
+#: pkg/kubernetes/scripts/volumes.js:200
+msgid "Rados Block Device"
+msgstr ""
 
-#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
-msgid "Modifying $target"
-msgstr "S'està modificant $target"
+#: pkg/kubernetes/views/pv-modify.html:194
+#: pkg/kubernetes/views/volume-body.html:10
+#: pkg/kubernetes/views/volume-body.html:20
+#: pkg/kubernetes/views/volume-body.html:44
+#: pkg/kubernetes/views/volume-body.html:51
+#: pkg/kubernetes/views/volume-body.html:71
+#: pkg/kubernetes/views/volume-body.html:85
+#: pkg/kubernetes/views/volume-body.html:93
+#: pkg/kubernetes/views/volume-body.html:110
+#: pkg/kubernetes/views/volume-body.html:122
+#: pkg/kubernetes/views/volume-body.html:136
+#: pkg/kubernetes/views/volume-body.html:143
+msgid "Read Only"
+msgstr "Tan sols lectura"
 
-#: pkg/storaged/jobs.js:124
-msgid "Starting swapspace $target"
-msgstr "S'està iniciant l'espai d'intercanvi $target"
+#: pkg/kubernetes/scripts/volumes.js:211
+msgid "Read and write from a single node"
+msgstr ""
 
-#: pkg/storaged/jobs.js:125
-msgid "Stopping swapspace $target"
-msgstr "S'està aturant l'espai d'intercanvi $target"
+#: pkg/kubernetes/scripts/volumes.js:213
+msgid "Read and write from multiple nodes"
+msgstr ""
 
-#: pkg/storaged/jobs.js:126
-msgid "Mounting $target"
-msgstr "S'està muntat $target"
+#: pkg/kubernetes/scripts/volumes.js:212
+msgid "Read only from multiple nodes"
+msgstr ""
 
-#: pkg/storaged/jobs.js:127
-msgid "Unmounting $target"
-msgstr "S'està desmuntat $target"
+#: pkg/docker/index.html:385
+msgid "ReadOnly"
+msgstr ""
 
-#: pkg/storaged/jobs.js:129
-msgid "Erasing $target"
-msgstr "S'està esborrant $target"
+#: pkg/docker/index.html:384
+msgid "ReadWrite"
+msgstr ""
 
-#: pkg/storaged/jobs.js:130
-msgid "Creating filesystem on $target"
-msgstr "S'està creat el sistema de fitxers a $target"
+#: pkg/storaged/index.html:327
+msgid "Reading"
+msgstr "Lectura"
 
-#: pkg/storaged/jobs.js:131
-msgid "Setting up loop device $target"
-msgstr "S'està preparant el dispositiu de bucles $target"
+#: pkg/playground/translate.html:20 pkg/playground/translate.html:179
+#: pkg/kubernetes/views/details-page.html:52
+#: pkg/kubernetes/views/node-body.html:41
+msgid "Ready"
+msgstr "A punt"
 
-#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
-msgid "Deleting $target"
-msgstr "S'està suprimint $target"
-
-#: pkg/storaged/jobs.js:134
-msgid "Creating partition $target"
-msgstr "S'està creant la partició $target"
-
-#: pkg/storaged/jobs.js:135
-msgid "Cleaning up for $target"
-msgstr "Neteja de $target"
-
-#: pkg/storaged/jobs.js:136
-msgid "Securely erasing $target"
-msgstr "S'està eliminant de forma segura $target"
-
-#: pkg/storaged/jobs.js:137
-msgid "Very securely erasing $target"
-msgstr "S'està eliminant de forma molt segura $target"
-
-#: pkg/storaged/jobs.js:138
-msgid "Stopping RAID Device $target"
-msgstr "S'està aturant el dispositiu RAID $target"
-
-#: pkg/storaged/jobs.js:139
-msgid "Starting RAID Device $target"
-msgstr "S'està iniciant el dispositiu RAID $target"
-
-#: pkg/storaged/jobs.js:140
-msgid "Marking $target as faulty"
-msgstr "S'està ficant $target com a defectuós"
-
-#: pkg/storaged/jobs.js:141
-msgid "Removing $target from RAID Device"
-msgstr "S'està eliminant $target  del dispositiu RAID"
-
-#: pkg/storaged/jobs.js:142
-msgid "Creating RAID Device $target"
-msgstr "S'està creant el dispositiu RAID $target"
-
-#: pkg/storaged/jobs.js:143
+#: pkg/playground/translate.html:25
 #, fuzzy
-msgid "Checking RAID Device $target"
-msgstr "S'està creant el dispositiu RAID $target"
+msgctxt "verb"
+msgid "Ready"
+msgstr "A punt"
 
-#: pkg/storaged/jobs.js:144
-#, fuzzy
-msgid "Checking and Repairing RAID Device $target"
-msgstr "S'està creant el dispositiu RAID $target"
+#: pkg/systemd/index.html:319
+msgid "Real Host Name"
+msgstr "Nom real de l'amfitrió"
+
+#: pkg/kubernetes/views/node-body.html:45
+msgid "Reason"
+msgstr "Raó"
+
+#: pkg/lib/journal.js:241
+msgid "Reboot"
+msgstr "Rearrencada"
+
+#: pkg/networkmanager/index.html:75 pkg/networkmanager/index.html:98
+#: pkg/networkmanager/index.html:116 pkg/networkmanager/index.html:521
+#: pkg/networkmanager/index.html:551
+msgid "Receiving"
+msgstr "Recepció"
+
+#: pkg/ostree/client.js:56
+msgid "Receiving delta parts"
+msgstr "S'estan rebent les parts de deltes"
+
+#: pkg/ostree/client.js:58
+msgid "Receiving metadata objects"
+msgstr "S'estan rebent els objectes de metadades"
+
+#: pkg/ostree/client.js:61
+msgid "Receiving objects: $0%"
+msgstr "S'estan rebent objectes: $0%"
+
+#: pkg/systemd/logs.html:40
+msgid "Recent"
+msgstr "Recent"
+
+#: pkg/kubernetes/views/pv-modify.html:56 pkg/kubernetes/views/pv-body.html:6
+msgid "Reclaim Policy"
+msgstr ""
+
+#: pkg/shell/simple.html:144 pkg/shell/index.html:327 pkg/shell/stub.html:180
+msgid "Reconnect"
+msgstr "Torna a connectar"
+
+#: pkg/storaged/details.js:1594
+msgid "Recovering"
+msgstr "Recuperació"
 
 #: pkg/storaged/jobs.js:145
 #, fuzzy
 msgid "Recovering RAID Device $target"
 msgstr "S'està aturant el dispositiu RAID $target"
 
-#: pkg/storaged/jobs.js:146
-msgid "Synchronizing RAID Device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:148
-msgid "Activating $target"
-msgstr "S'està activant $target"
-
-#: pkg/storaged/jobs.js:149
-msgid "Deactivating $target"
-msgstr "S'està desactivant $target"
-
-#: pkg/storaged/jobs.js:150
-msgid "Creating snapshot of $target"
-msgstr "S'està creant una instantània de $target"
-
-#: pkg/storaged/jobs.js:151
-msgid "Creating volume group $target"
-msgstr "S'està creant el grup de volums $target"
-
-#: pkg/storaged/jobs.js:152
-msgid "Deleting volume group $target"
-msgstr "S'està suprimint el grup de volums $target"
-
-#: pkg/storaged/jobs.js:153
-msgid "Adding physical volume to $target"
-msgstr "S'està afegint el volum físic a $target"
-
-#: pkg/storaged/jobs.js:154
-msgid "Removing physical volume from $target"
-msgstr "S'està eliminant el volum físic de $target"
-
-#: pkg/storaged/jobs.js:155
-msgid "Emptying $target"
-msgstr "S'està buidant $target"
-
-#: pkg/storaged/jobs.js:156
-msgid "Creating logical volume $target"
-msgstr "S'està creant el volum lògic $target"
-
-#: pkg/storaged/jobs.js:157
-msgid "Renaming $target"
-msgstr "S'està reanomenant $target"
-
-#: pkg/storaged/jobs.js:158
-msgid "Resizing $target"
-msgstr "S'està redimensionant $target"
-
-#: pkg/storaged/jobs.js:166
-msgid "Operation '$operation' on $target"
-msgstr "L'operació '$operation' en $target"
-
-#: pkg/storaged/jobs.js:180
-msgid "unknown target"
-msgstr "objectiu desconegut"
-
-#: pkg/storaged/permissions.js:61
-msgid "The user <b>$0</b> is not permitted to manage storage"
-msgstr "A l'usuari <b>$0</b> no se li permet gestionar l'emmagatzematge"
-
-#: pkg/realmd/operation.js:96
-msgid "Join"
-msgstr "Uneix-te"
-
-#: pkg/realmd/operation.js:101
-msgid "Leave"
-msgstr "Abandona"
-
-#: pkg/realmd/operation.js:148
-msgid "Domain $0 could not be contacted"
-msgstr "No s'ha pogut contactar amb el domini $0"
-
-#: pkg/realmd/operation.js:220
-msgid "Domain $0 is not supported"
-msgstr "El domini $0 no és compatible"
-
-#: pkg/realmd/operation.js:347
-msgid "Joining this domain is not supported"
-msgstr "La unió a aquest domini no està admesa"
-
-#: pkg/realmd/operation.js:366
-msgid "More"
-msgstr "Més"
-
-#: pkg/realmd/operation.js:417
-msgid "Cannot join a domain because realmd is not available on this system"
-msgstr ""
-"No es pot unir a un domini perquè realmd no està disponible en aquest sistema"
-
-#: pkg/realmd/operation.js:436
-msgid "The user <b>$0</b> is not permitted to modify realms"
-msgstr "A l'usuari <b>$0</b> no se li permet modificar els reialmes"
-
-#: pkg/realmd/operation.js:453
-msgid "Join Domain"
-msgstr "Uneix-te al domini"
-
-#: pkg/docker/run.js:246 pkg/docker/util.js:102
-#: pkg/networkmanager/interfaces.js:2280 pkg/kubernetes/scripts/volumes.js:992
-#: pkg/docker/index.html.h:46
-msgid "No"
-msgstr "No"
-
-#: pkg/docker/run.js:261 pkg/docker/console.html.h:1
-#: pkg/kubernetes/views/image-panel.html.h:2
-#: pkg/kubernetes/views/container-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:1
-#: pkg/kubernetes/views/image-page.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:1
-msgid "Container"
-msgstr "Contenidor"
-
-#: pkg/docker/run.js:263 pkg/kubernetes/views/route-modify.html.h:2
-#: pkg/kubernetes/views/route-body.html.h:4
-#: pkg/kubernetes/views/details-page.html.h:12
-msgid "Host"
-msgstr "Amfitrió"
-
-#: pkg/docker/run.js:283
-msgid "Invalid port"
-msgstr "Port no vàlid"
-
-#: pkg/docker/run.js:293
-msgid "Duplicate port"
-msgstr "Port duplicat"
-
-#: pkg/docker/run.js:332
-#, fuzzy
-msgid "Command can't be empty"
-msgstr "El nom no pot estar en blanc."
-
-#: pkg/docker/run.js:350
-msgid "No alias specified"
-msgstr "Sense especificar l'àlies"
-
-#: pkg/docker/run.js:360
-msgid "Duplicate alias"
-msgstr "Àlies duplicat"
-
-#: pkg/docker/run.js:384
-msgid "No container specified"
-msgstr "Sense especificar el contenidor"
-
-#: pkg/docker/details.js:47 pkg/docker/image.js:43
-msgctxt "page-title"
-msgid "Containers"
-msgstr "Contenidors"
-
-#: pkg/docker/details.js:144
-msgid "${hip}:${hport} -> $cport"
-msgstr "${hip}:${hport} -> $cport"
-
-#: pkg/docker/details.js:272 pkg/docker/containers-view.jsx:167
-msgid "Deleting a container will erase all data in it."
-msgstr "La supressió d'un contenidor n'esborrarà totes les dades."
-
-#: pkg/docker/storage.jsx:156
-#, fuzzy
-msgid "Solid-State Disk"
-msgstr "Disc d'estat sòlid"
-
-#: pkg/docker/storage.jsx:157
-#, fuzzy
-msgid "Hard Disk"
-msgstr "Disc dur"
-
-#: pkg/docker/storage.jsx:158 pkg/storaged/index.html.h:33
-msgid "Drive"
-msgstr "Unitat"
-
-#: pkg/docker/storage.jsx:188
-#, fuzzy
-msgid "Local Disks"
-msgstr "$0 discs"
-
-#: pkg/docker/storage.jsx:194
-msgid "No additional local storage found."
-msgstr ""
-
-#: pkg/docker/storage.jsx:242
-msgid " (shared with the OS)"
-msgstr ""
-
-#: pkg/docker/storage.jsx:282
-msgid "Information about the Docker storage pool is not available."
-msgstr ""
-
-#: pkg/docker/storage.jsx:314
-msgid "Total"
+#: pkg/kubernetes/scripts/volumes.js:219
+msgid "Recycle"
 msgstr ""
 
 #: pkg/docker/storage.jsx:348
 msgid "Reformat and add disks"
 msgstr ""
 
-#: pkg/docker/storage.jsx:355
-msgid ""
-"The storage pool will be reset to optimize its layout.  All containers will "
-"be erased."
+#: pkg/kubernetes/views/pv-modify.html:205
+msgid "Register"
 msgstr ""
 
-#: pkg/docker/storage.jsx:360
-msgid "Erase containers, reformat disks, and add them"
+#: pkg/kubernetes/views/volumes-page.html:12
+msgid "Register New Volume"
 msgstr ""
 
-#: pkg/docker/storage.jsx:363
-msgid "Add Additional Storage"
+#: pkg/kubernetes/views/pv-modify.html:4
+msgid "Register Persistent Volume"
 msgstr ""
 
-#: pkg/docker/storage.jsx:366
-msgid ""
-"All data on selected disks will be erased and disks will be added to the "
-"storage pool."
+#: pkg/subscriptions/main.js:74
+msgid "Register system"
+msgstr "Registra el sistema"
+
+#: pkg/ostree/index.html:115
+msgid "Released"
 msgstr ""
 
-#: pkg/docker/storage.jsx:404
+#: pkg/systemd/init.js:518
+msgid "Reload"
+msgstr "Recarrega"
+
+#: pkg/systemd/init.js:519
+msgid "Reload or Restart"
+msgstr "Recarrega o reinicia"
+
+#: pkg/systemd/init.js:521
+msgid "Reload or Try Restart"
+msgstr "Recarrega o prova de reiniciar"
+
+#: pkg/kubernetes/views/imagestream-modify.html:89
+msgid "Remote registry is insecure"
+msgstr ""
+
+#: cockpit.desktop.in.h:3
+msgid "Remote;Administration;"
+msgstr "Remot;Administració;"
+
+#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
+msgctxt "storage"
+msgid "Removable Drive"
+msgstr "Disc extraïble"
+
+#: pkg/ostree/index.html:123 pkg/ostree/index.html:146
+msgid "Removals"
+msgstr "Supressions"
+
+#: pkg/kubernetes/views/user-group-remove.html:10
+#: pkg/kubernetes/views/group-delete.html:21
+#: pkg/kubernetes/views/user-delete.html:25
+#: pkg/kubernetes/views/remove-role-dialog.html:8
+msgid "Remove"
+msgstr "Elimina"
+
+#: pkg/networkmanager/interfaces.js:2791
 #, fuzzy
-msgid "Could not add all disks"
-msgstr "No es van poder llistar els serveis"
+msgid "Remove $0"
+msgstr "Elimina"
+
+#: pkg/kubernetes/views/group-delete.html:3
+msgid "Remove Group"
+msgstr "Suprimeix el grup"
+
+#: pkg/kubernetes/views/user-group-remove.html:3
+msgid "Remove Member"
+msgstr "Suprimeix el membre"
+
+#: pkg/kubernetes/views/remove-role-dialog.html:3
+msgid "Remove Role"
+msgstr ""
+
+#: pkg/kubernetes/views/user-delete.html:3
+msgid "Remove User"
+msgstr "Suprimeix l'usuari"
+
+#: pkg/kubernetes/views/image-delete.html:3
+msgid "Remove image tag"
+msgstr ""
+
+#: pkg/kubernetes/views/user-remove-membership.html:3
+msgid "Remove membership"
+msgstr ""
+
+#: pkg/storaged/jobs.js:141
+msgid "Removing $target from RAID Device"
+msgstr "S'està eliminant $target  del dispositiu RAID"
+
+#: pkg/networkmanager/interfaces.js:2788
+msgid "Removing <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:154
+msgid "Removing physical volume from $target"
+msgstr "S'està eliminant el volum físic de $target"
+
+#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
+#: pkg/storaged/details.js:1775
+msgid "Rename"
+msgstr "Reanomena"
+
+#: pkg/storaged/details.js:795
+msgid "Rename Volume Group"
+msgstr "Reanomena un grup de volums"
+
+#: pkg/storaged/details.js:706
+msgid "Renamee Logical Volume"
+msgstr "Reanomena el volum lògic"
+
+#: pkg/storaged/jobs.js:157
+msgid "Renaming $target"
+msgstr "S'està reanomenant $target"
+
+#: pkg/systemd/services.html:432
+msgid "Repeat Daily"
+msgstr ""
+
+#: pkg/systemd/services.html:431
+msgid "Repeat Hourly"
+msgstr ""
+
+#: pkg/systemd/services.html:434
+msgid "Repeat Monthly"
+msgstr ""
+
+#: pkg/systemd/services.html:433
+msgid "Repeat Weekly"
+msgstr ""
+
+#: pkg/systemd/services.html:435
+msgid "Repeat Yearly"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-body.html:9
+#: pkg/kubernetes/views/details-page.html:141
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
+#: pkg/kubernetes/views/replicationcontroller-modify.html:8
+msgid "Replicas"
+msgstr "Rèpliques"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:14
+#: pkg/kubernetes/views/replicationcontroller-panel.html:10
+#: pkg/kubernetes/views/topology-page.html:23
+msgid "Replication Controller"
+msgstr "Controlador de replicació"
+
+#: pkg/kubernetes/views/details-page.html:132
+msgid "Replication Controllers"
+msgstr "Controladors de replicació"
+
+#: pkg/kubernetes/views/topology-page.html:24
+msgid ""
+"Replication controllers dynamically create instances of                pods "
+"from templates, and remove pods when necessary."
+msgstr ""
+
+#: pkg/docker/index.html:718
+msgid "Repository"
+msgstr "Dipòsit"
+
+#: pkg/kubernetes/views/volume-body.html:24
+msgid "Repository URL"
+msgstr "URl del dipòsit"
+
+#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
+msgid "Requested"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:13
+msgid "Requests"
+msgstr "Peticions"
+
+#: pkg/kubernetes/views/auth-form.html:54
+msgid "Requires Authentication"
+msgstr ""
+
+#: pkg/docker/index.html:323
+msgid "Reset"
+msgstr "Restableix"
 
 #: pkg/docker/storage.jsx:417
 #, fuzzy
@@ -2099,388 +4677,600 @@ msgid ""
 "the pool."
 msgstr ""
 
-#: pkg/docker/storage.jsx:423
-msgid "Erase containers and reset storage pool"
+#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
+msgid "Resize"
+msgstr "Redimensiona"
+
+#: pkg/storaged/details.js:673
+msgid "Resize Filesystem"
+msgstr "Redimensiona el sistema de fitxers"
+
+#: pkg/storaged/details.js:661
+msgid "Resize Logical Volume"
+msgstr "Redimensiona el volum lògic"
+
+#: pkg/storaged/jobs.js:158
+msgid "Resizing $target"
+msgstr "S'està redimensionant $target"
+
+#: pkg/systemd/index.html:126 pkg/systemd/index.html:133
+msgid "Restart"
+msgstr "Reinicia"
+
+#: pkg/kubernetes/views/container-body.html:20
+msgid "Restart Count"
+msgstr "Reinicia el compte"
+
+#: pkg/docker/index.html:558 pkg/kubernetes/views/pod-body.html:10
+msgid "Restart Policy"
+msgstr "Reinicia la política"
+
+#: pkg/kubernetes/scripts/volumes.js:217
+msgid "Retain"
 msgstr ""
 
-#: pkg/docker/storage.jsx:446
-msgid "Could not reset the storage pool"
+#: pkg/docker/index.html:574
+msgid "Retries:"
 msgstr ""
 
-#: pkg/docker/storage.jsx:482
-#, fuzzy
-msgid "You don't have permission to manage the Docker storage pool."
-msgstr ""
-"No teniu el permís per visualitzar les claus públiques autoritzades per "
-"aquest compte."
-
-#: pkg/docker/storage.jsx:485
-#, fuzzy
-msgid "The Docker storage pool cannot be managed on this system."
-msgstr "L'API «storaged» no està disponible en aquest sistema."
-
-#: pkg/docker/image.js:77
-msgid "Image $0"
-msgstr "Imatge $0"
-
-#: pkg/docker/image.js:152
-msgid ""
-"Deleting an image will delete it, but you can probably download it again if "
-"you need it later.  Unless this image has never been pushed to a repository, "
-"that is, in which case you probably can't download it again."
-msgstr ""
-"La supressió d'una imatge ho suprimirà, però probablement es pot baixar de "
-"nou si es necessita més endavant. Llevat que aquesta imatge mai hagi estat "
-"empesa a un dipòsit, que ho és, en aquest cas probablement no pugueu baixar-"
-"ho de nou."
-
-#: pkg/docker/util.js:94
-msgid "Up since $StartedAt"
-msgstr "Aixecat des de $StartedAt"
-
-#: pkg/docker/util.js:96
-msgid "Exited $ExitCode"
-msgstr "Sortida $ExitCode"
-
-#: pkg/docker/util.js:104
-msgid "On failure, retry $0 time"
-msgid_plural "On failure, retry $0 times"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/docker/util.js:107 pkg/docker/index.html.h:48
-msgid "Always"
-msgstr "Sempre"
-
-#: pkg/docker/util.js:109 pkg/docker/index.html.h:49
-msgid "Unless Stopped"
+#: pkg/subscriptions/subscriptions-view.jsx:188
+msgid "Retrieving subscription status..."
 msgstr ""
 
-#: pkg/docker/util.js:123
-msgid "default"
-msgstr "per defecte"
+#: pkg/kubernetes/views/volume-body.html:26
+msgid "Revision"
+msgstr "Revisió"
 
-#: pkg/docker/util.js:124
-msgid "$0 shares"
-msgstr "$0 comparticions"
+#: pkg/users/index.html:94 pkg/kubernetes/views/add-member-role-dialog.html:39
+#: pkg/kubernetes/views/project-body.html:21
+msgid "Roles"
+msgstr "Rols"
 
-#: pkg/docker/util.js:231
-msgid "Stopped"
-msgstr "Aturat"
-
-#: pkg/docker/util.js:488
-msgid "Container is currently running."
-msgstr "El contenidor s'està executant actualment."
-
-#: pkg/docker/util.js:490
-msgid ""
-"Container is currently marked as not running, but regular stopping failed."
+#: pkg/ostree/index.html:73
+msgid "Roll back and reboot"
 msgstr ""
-"El contenidor actualment està marcat com a no en execució, però va fallar "
-"l'aturada normal."
-
-#: pkg/docker/util.js:491
-msgid "Error message from Docker:"
-msgstr "Missatge d'error del Docker:"
-
-#: pkg/docker/util.js:501
-msgid "Please confirm forced deletion of $0"
-msgstr "Si us plau, confirmeu la supressió forçada de $0"
-
-#: pkg/docker/util.js:503
-msgid "Force Delete"
-msgstr "Força la supressió"
-
-#: pkg/docker/util.js:544
-msgid "Failed to stop Docker scope: $0"
-msgstr "Ha fallat l'aturada de l'àmbit del Docker: $0"
-
-#: pkg/docker/containers-view.jsx:239
-#, fuzzy
-msgid "Commit"
-msgstr "Comentari"
-
-#: pkg/docker/containers.js:64
-msgid "Failed to start Docker: $0"
-msgstr "Ha fallat l'inici del Docker: $0"
-
-#: pkg/users/authorized-keys.js:103
-msgid "Validating key"
-msgstr "S'està validant la clau"
-
-#: pkg/users/authorized-keys.js:108
-msgid "Adding key"
-msgstr "S'està afegint la clau"
-
-#: pkg/users/authorized-keys.js:115
-msgid "Error saving authorized keys: "
-msgstr "S'ha produït un error en desar les claus autoritzades:"
-
-#: pkg/users/authorized-keys.js:118
-msgid "The key you provided was not valid."
-msgstr "La clau que heu proporcionat no era vàlida."
-
-#: pkg/users/local.js:40
-msgid "The user <b>$0</b> is not permitted to modify accounts"
-msgstr "A l'usuari <b>$0</b> no se li permet modificar els comptes"
-
-#: pkg/users/local.js:57
-msgid "Unable to delete root account"
-msgstr "No es pot suprimir el compte de root"
-
-#: pkg/users/local.js:59
-msgid "Unable to rename root account"
-msgstr "No es pot reanomenar el compte de root"
-
-#: pkg/users/local.js:82
-msgid "Prompting via passwd timed out"
-msgstr "Expiració de temps en la deferència a través passwd"
-
-#: pkg/users/local.js:247
-msgid "Password is too weak"
-msgstr "La contrasenya és massa feble"
-
-#: pkg/users/local.js:259
-msgid "Password is not acceptable"
-msgstr "La contrasenya no és acceptable"
-
-#: pkg/users/local.js:284 pkg/users/local.js:594
-msgctxt "page-title"
-msgid "Accounts"
-msgstr "Comptes"
-
-#: pkg/users/local.js:395 pkg/users/local.js:1082
-msgid "The passwords do not match"
-msgstr "Les contrasenyes no coincideixen"
-
-#: pkg/users/local.js:400
-msgid "No user name specified"
-msgstr "Sense especificar el nom d'usuari"
-
-#: pkg/users/local.js:405
-msgid "No real name specified"
-msgstr "Sense especificar el nom real"
-
-#: pkg/users/local.js:429 pkg/users/local.js:1104
-msgid "Excellent password"
-msgstr "Contrasenya excel·lent"
-
-#: pkg/users/local.js:501
-msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
-msgstr ""
-
-#: pkg/users/local.js:509
-msgid "This user name already exists"
-msgstr "Aquest nom d'usuari ja existeix"
-
-#: pkg/users/local.js:682 pkg/users/local.js:683
-msgid "Server Administrator"
-msgstr "Administrador del servidor"
-
-#: pkg/users/local.js:684
-msgid "Container Administrator"
-msgstr "Administrador del contenidor"
-
-#: pkg/users/local.js:839
-msgid "Logged In"
-msgstr "Autenticat"
-
-#: pkg/users/local.js:841
-msgid "Never"
-msgstr "Mai"
-
-#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
-msgid "Delete $0"
-msgstr "Suprimeix $0"
-
-#: pkg/sosreport/index.js:49 pkg/sosreport/index.js:113
-#: pkg/systemd/services.html.h:13 pkg/lib/machine-invalid-hostkey.html.h:4
-#: pkg/lib/machine-auth-failed.html.h:7
-#: pkg/lib/machine-unknown-hostkey.html.h:4
-#: pkg/lib/machine-change-port.html.h:8 pkg/lib/machine-not-supported.html.h:3
-#: pkg/shell/index.html.h:37
-msgid "Close"
-msgstr "Tanca"
-
-#: pkg/sosreport/index.js:115
-msgid "No archive has been created."
-msgstr "No s'ha creat cap arxiu."
-
-#: pkg/networkmanager/interfaces.js:598 pkg/networkmanager/interfaces.js:1051
-#: pkg/networkmanager/interfaces.js:2255 pkg/networkmanager/interfaces.js:2257
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:753 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/kubernetes/views/node-body.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:6
-#: pkg/kubernetes/views/pv-claim.html.h:7
-#: pkg/kubernetes/views/image-body.html.h:6
-#: pkg/kubernetes/views/pv-body.html.h:5
-msgid "Unknown"
-msgstr "Desconegut"
-
-#: pkg/networkmanager/interfaces.js:805
-msgid "Not available"
-msgstr "No disponible"
-
-#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
-#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
-msgid "Inactive"
-msgstr "Inactiu"
-
-#: pkg/networkmanager/interfaces.js:809
-msgid "Preparing"
-msgstr "S'està preparant"
-
-#: pkg/networkmanager/interfaces.js:811
-msgid "Configuring"
-msgstr "S'està configurant"
-
-#: pkg/networkmanager/interfaces.js:813
-msgid "Authenticating"
-msgstr "S'està autenticant"
-
-#: pkg/networkmanager/interfaces.js:815
-msgid "Configuring IP"
-msgstr "S'està configurant la IP"
-
-#: pkg/networkmanager/interfaces.js:817
-msgid "Checking IP"
-msgstr "S'està comprovant la IP"
-
-#: pkg/networkmanager/interfaces.js:819
-msgid "Waiting"
-msgstr "S'està esperant"
-
-#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
-msgid "Active"
-msgstr "Activa"
-
-#: pkg/networkmanager/interfaces.js:823
-msgid "Deactivating"
-msgstr "S'està desactivant"
-
-#: pkg/networkmanager/interfaces.js:825 pkg/ostree/index.html.h:14
-msgid "Failed"
-msgstr "Ha fallat"
-
-#: pkg/networkmanager/interfaces.js:1326
-msgid "No carrier"
-msgstr "Sense portadora"
-
-#: pkg/networkmanager/interfaces.js:1372
-msgid "Part of "
-msgstr "Part de"
-
-#: pkg/networkmanager/interfaces.js:1420
-msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr "A l'usuari <b>$0</b> no se li permet modificar els ajustos de xarxa"
-
-#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
-msgctxt "page-title"
-msgid "Networking"
-msgstr "Xarxa"
-
-#: pkg/networkmanager/interfaces.js:1804
-msgid "Automatic (DHCP)"
-msgstr "Automàtica (DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
-msgid "Link local"
-msgstr "Enllaça localment"
-
-#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
-msgid "Manual"
-msgstr "Manual"
-
-#: pkg/networkmanager/interfaces.js:1807
-msgid "Shared"
-msgstr "Compartida"
-
-#: pkg/networkmanager/interfaces.js:1813 pkg/networkmanager/interfaces.js:2475
-#: pkg/networkmanager/interfaces.js:3019 pkg/networkmanager/interfaces.js:3023
-#: pkg/networkmanager/interfaces.js:3029 pkg/networkmanager/index.html.h:22
-msgid "Automatic"
-msgstr "Automàtic"
-
-#: pkg/networkmanager/interfaces.js:1814
-msgid "Automatic (DHCP only)"
-msgstr "Automàtica, tan sols DHCP"
-
-#: pkg/networkmanager/interfaces.js:1817
-msgid "Ignore"
-msgstr "Ignora"
 
 #: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
 msgid "Round Robin"
 msgstr "Round Robin"
 
-#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
-msgid "Active Backup"
-msgstr "Activa la còpia de seguretat"
+#: pkg/kubernetes/views/route-page.html:14
+#: pkg/kubernetes/views/route-panel.html:9
+msgid "Route"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1824
-msgid "XOR"
-msgstr "XOR"
+#: pkg/kubernetes/views/details-page.html:65
+msgid "Routes"
+msgstr "Rutes"
 
-#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
-msgid "Broadcast"
-msgstr "Difusió"
-
-#: pkg/networkmanager/interfaces.js:1826
-msgid "802.3ad"
-msgstr "802.3ad"
-
-#: pkg/networkmanager/interfaces.js:1827
-msgid "Adaptive transmit load balancing"
-msgstr "Balanceig de càrrega de transmissió adaptativa"
-
-#: pkg/networkmanager/interfaces.js:1828
-msgid "Adaptive load balancing"
-msgstr "Balanceig de càrrega adaptativa"
-
-#: pkg/networkmanager/interfaces.js:1833
-msgid "MII (Recommended)"
-msgstr "MII (recomanat)"
-
-#: pkg/networkmanager/interfaces.js:1834
-msgid "ARP"
-msgstr "ARP"
-
-#: pkg/networkmanager/interfaces.js:1841
+#: pkg/systemd/services.html:384
 #, fuzzy
-msgid "Load Balancing"
-msgstr "Balanceig de càrrega adaptativa"
+msgid "Run"
+msgstr "Executa com"
 
-#: pkg/networkmanager/interfaces.js:1843
+#: pkg/kubernetes/views/image-config.html:4
+msgid "Run as"
+msgstr "Executa com"
+
+#: pkg/networkmanager/index.html:381
 #, fuzzy
-msgid "802.3ad LACP"
-msgstr "802.3ad"
+msgid "Runner"
+msgstr "En execució"
 
-#: pkg/networkmanager/interfaces.js:1848
-msgid "Passive"
+#: pkg/ostree/index.html:83
+msgid "Running"
+msgstr "En execució"
+
+#: pkg/selinux/setroubleshoot-view.jsx:478
+msgid "SELinux Access Control Errors"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1854
-msgid "Ethtool"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1855
+#: pkg/selinux/setroubleshoot-view.jsx:330
 #, fuzzy
-msgid "ARP Ping"
-msgstr "Monitoratge ARP"
+msgid "SELinux Policy"
+msgstr "Política del DNS"
 
-#: pkg/networkmanager/interfaces.js:1856
-msgid "NSNA Ping"
+#: pkg/selinux/setroubleshoot.html:23
+msgid "SELinux Troubleshoot"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2156
-msgid "Deleting <b>$0</b> will break the connection to the server, "
+#: pkg/selinux/setroubleshoot-view.jsx:317
+#, fuzzy
+msgid "SELinux is disabled on the system."
+msgstr "Cockpit no està instal·lat al sistema."
+
+#: pkg/selinux/setroubleshoot-view.jsx:309
+msgid "SELinux system status is unknown."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2188
-msgid "Switching on <b>$0</b>  will break the connection to the server, "
+#: pkg/storaged/jobs.js:119
+msgid "SMART self-test of $target"
+msgstr "Autotest SMART de $target."
+
+#: pkg/networkmanager/index.html:218
+msgid "STP Forward delay"
+msgstr "Retard del reenviament STP"
+
+#: pkg/networkmanager/index.html:227
+msgid "STP Hello time"
+msgstr "STP Hello time"
+
+#: pkg/networkmanager/index.html:236
+msgid "STP Maximum message age"
+msgstr "Envelliment màxim del missatge STP"
+
+#: pkg/networkmanager/index.html:209
+msgid "STP Priority"
+msgstr "Prioritat STP"
+
+#: pkg/systemd/services.html:466
+msgid "Save"
+msgstr ""
+
+#: pkg/ostree/client.js:66
+msgid "Scanning metadata"
+msgstr "S'estan escanejant les metadades"
+
+#: pkg/kubernetes/views/node-capacity.html:9
+msgid "Scheduled Pods"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:322
+msgid "Scheduling Disabled"
+msgstr ""
+
+#: pkg/systemd/services.html:402 pkg/systemd/services.html:406
+msgid "Seconds"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:195
+msgid "Secret"
+msgstr "Secret"
+
+#: pkg/kubernetes/views/volume-body.html:106
+msgid "Secret File"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:141
+msgid "Secret Name"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:69
+#: pkg/kubernetes/views/volume-body.html:108
+#: pkg/kubernetes/views/volume-body.html:134
+msgid "Secret Volume"
+msgstr ""
+
+#: pkg/systemd/index.html:93
+msgid "Secure Shell Keys"
+msgstr ""
+
+#: pkg/storaged/jobs.js:136
+msgid "Securely erasing $target"
+msgstr "S'està eliminant de forma segura $target"
+
+#: pkg/kubernetes/views/file-button.html:4
+msgid "Select Manifest File..."
+msgstr "Selecciona el fitxer del manifest..."
+
+#: pkg/kubernetes/views/topology-page.html:7
+msgid "Select an object to see more details."
+msgstr "Seleccioneu un objecte per veure'n més detalls. "
+
+#: pkg/lib/machine-sync-users.html:8
+msgid ""
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
+msgstr ""
+"Seleccioneu els usuaris que vulgueu que estiguin sincronitzats amb "
+"{{#strong}}{{host}}{{/strong}}"
+
+#: pkg/networkmanager/index.html:69 pkg/networkmanager/index.html:97
+#: pkg/networkmanager/index.html:115 pkg/networkmanager/index.html:515
+#: pkg/networkmanager/index.html:550
+msgid "Sending"
+msgstr "Enviament"
+
+#: pkg/storaged/index.html:432
+msgctxt "storage"
+msgid "Serial Number"
+msgstr "Número de sèrie"
+
+#: pkg/kubernetes/views/pv-modify.html:82
+#: pkg/kubernetes/views/volume-body.html:47
+msgid "Server"
+msgstr ""
+
+#: pkg/storaged/overview.js:518
+msgid "Server Address"
+msgstr "Adreça del servidor"
+
+#: pkg/users/local.js:682 pkg/users/local.js:683
+msgid "Server Administrator"
+msgstr "Administrador del servidor"
+
+#: pkg/storaged/overview.js:521
+#, fuzzy
+msgid "Server address cannot be empty."
+msgstr "L'adreça del servidor no pot estar en blanc."
+
+#: src/base1/cockpit.js:3709
+msgid "Server has closed the connection."
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:12
+#: pkg/kubernetes/views/service-panel.html:8
+#: pkg/kubernetes/views/topology-page.html:32
+msgid "Service"
+msgstr "Servei"
+
+#: pkg/kubernetes/views/pod-body.html:12
+msgid "Service Account"
+msgstr "Compte del servei"
+
+#: pkg/systemd/services.html:279
+msgid "Service Logs"
+msgstr "Registres del servei"
+
+#: pkg/systemd/services.html:342
+#, fuzzy
+msgid "Service name"
+msgstr "Servei"
+
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:272
+#: pkg/kubernetes/views/dashboard-page.html:134
+#: pkg/kubernetes/views/details-page.html:29
+msgid "Services"
+msgstr "Serveis"
+
+#: pkg/kubernetes/views/topology-page.html:33
+msgid ""
+"Services group pods and provide a common DNS                name and an "
+"optional, load-balanced IP address to access them."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:20
+msgid "Session Affinity"
+msgstr ""
+
+#: pkg/dashboard/index.html:190
+msgid "Set"
+msgstr "Estableix"
+
+#: pkg/systemd/host.js:559
+msgid "Set Host name"
+msgstr "Estableix el nom de l'amfitrió"
+
+#: pkg/users/index.html:117 pkg/users/index.html:221
+msgid "Set Password"
+msgstr "Estableix la contrasenya"
+
+#: pkg/systemd/index.html:395
+msgid "Set Time"
+msgstr "Ajusta l'hora"
+
+#: pkg/docker/index.html:551
+msgid "Set container environment variables"
+msgstr ""
+
+#: pkg/networkmanager/index.html:172
+msgid "Set to"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:326
+msgid ""
+"Setting deviates from the configured state and will revert on the next boot."
+msgstr ""
+
+#: pkg/storaged/jobs.js:131
+msgid "Setting up loop device $target"
+msgstr "S'està preparant el dispositiu de bucles $target"
+
+#: pkg/kubernetes/views/volume-body.html:139
+msgid "Share Name"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1807
+msgid "Shared"
+msgstr "Compartida"
+
+#: pkg/kubernetes/views/container-panel.html:9
+#: pkg/kubernetes/views/container-page-inline.html:14
+msgid "Shell"
+msgstr "Shell"
+
+#: pkg/kubernetes/views/container-page.html:4
+msgid "Show all Containers"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:8
+msgid "Show all Deployment Configs"
+msgstr ""
+
+#: pkg/kubernetes/views/node-page.html:8
+msgid "Show all Nodes"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:9
+msgid "Show all Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-container.html:4
+msgid "Show all Pod Containers"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:8
+msgid "Show all Pods"
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:16
+#: pkg/kubernetes/views/group-page.html:14
+#: pkg/kubernetes/views/project-page.html:23
+msgid "Show all Projects"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:10
+msgid "Show all Replication Controllers"
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:10
+msgid "Show all Routes"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:8
+msgid "Show all Services"
+msgstr ""
+
+#: pkg/docker/index.html:127
+#, fuzzy
+msgid "Show all containers"
+msgstr "Mostra totes les imatges"
+
+#: pkg/kubernetes/views/imagestream-page.html:12
+msgid "Show all image streams"
+msgstr ""
+
+#: pkg/docker/index.html:241 pkg/kubernetes/views/image-page.html:11
+msgid "Show all images"
+msgstr "Mostra totes les imatges"
+
+#: pkg/systemd/index.html:94
+msgid "Show fingerprints"
+msgstr "Mostra les empremptes"
+
+#: pkg/systemd/index.html:136
+msgid "Shutdown"
+msgstr "Atura"
+
+#: pkg/kubernetes/views/container-body.html:18
+msgid "Since"
+msgstr "Des de"
+
+#: pkg/systemd/init.js:621
+msgid "Since $0"
+msgstr "Des de $0"
+
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/storaged/index.html:232
+msgid "Size"
+msgstr "Mida"
+
+#: pkg/storaged/dialog.js:271
+#, fuzzy
+msgid "Size cannot be negative"
+msgstr "El nom no pot estar en blanc."
+
+#: pkg/storaged/dialog.js:269
+#, fuzzy
+msgid "Size cannot be zero"
+msgstr "El nom no pot estar en blanc."
+
+#: pkg/storaged/dialog.js:273
+msgid "Size is too large"
+msgstr ""
+
+#: pkg/storaged/dialog.js:267
+msgid "Size must be a number"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:43
+#: pkg/kubernetes/views/auth-rejected-cert.html:11
+msgid "Skip Certificate Verification"
+msgstr ""
+
+#: pkg/systemd/services.html:54
+msgid "Sockets"
+msgstr "Sockets"
+
+#: pkg/ostree/index.html:23
+msgid "Software Updates"
+msgstr "Actualitzacions de programari"
+
+#: pkg/docker/storage.jsx:156
+#, fuzzy
+msgid "Solid-State Disk"
+msgstr "Disc d'estat sòlid"
+
+#: pkg/storaged/overview.js:182
+msgctxt "storage"
+msgid "Solid-State Disk"
+msgstr "Disc d'estat sòlid"
+
+#: pkg/selinux/setroubleshoot-view.jsx:90
+msgid "Solution applied successfully"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:97
+#, fuzzy
+msgid "Solution failed"
+msgstr "Ha fallat l'inici de sessió"
+
+#: pkg/kubernetes/scripts/volumes.js:908
+msgid "Sorry, I don't know how to modify this volume"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:8
+msgid "Source URL"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2573
+msgid "Spanning Tree Protocol"
+msgstr "STP (Spanning Tree Protocol)"
+
+#: pkg/networkmanager/index.html:200
+msgid "Spanning Tree Protocol (STP)"
+msgstr "STP (Spanning Tree Protocol)"
+
+#: pkg/storaged/details.js:1594
+msgid "Spare"
+msgstr "Recanvi"
+
+#: pkg/systemd/index.html:470
+msgid "Specific Time"
+msgstr "Temps específic"
+
+#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
+msgid "Start"
+msgstr "Inicia"
+
+#: pkg/docker/index.html:68
+msgid "Start Docker"
+msgstr "Inicia Docker"
+
+#: pkg/storaged/index.html:49
+msgid "Start Multipath"
+msgstr "Inicia el multicamí"
+
+#: pkg/storaged/details.js:1614
+msgid "Start Scrubbing"
+msgstr "Inicia el tractament de neteja"
+
+#: pkg/storaged/jobs.js:139
+msgid "Starting RAID Device $target"
+msgstr "S'està iniciant el dispositiu RAID $target"
+
+#: pkg/storaged/jobs.js:124
+msgid "Starting swapspace $target"
+msgstr "S'està iniciant l'espai d'intercanvi $target"
+
+#: pkg/subscriptions/subscriptions-view.jsx:37
+msgid "Starts"
+msgstr "Comença"
+
+#: pkg/kubernetes/views/container-body.html:16
+#: pkg/kubernetes/views/details-page.html:38
+#: pkg/kubernetes/views/details-page.html:175
+msgid "State"
+msgstr "Estat"
+
+#: pkg/storaged/index.html:571
+msgctxt "storage"
+msgid "State"
+msgstr "Estat"
+
+#: pkg/systemd/init.js:303
+msgid "Static"
+msgstr "Estàtic"
+
+#: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/containers-listing.html:16
+#: pkg/kubernetes/views/nodes-page.html:44
+#: pkg/kubernetes/views/pvc-body.html:13 pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/pv-body.html:24
+msgid "Status"
+msgstr "Estat"
+
+#: pkg/subscriptions/subscriptions-view.jsx:146
+#, fuzzy
+msgid "Status: $0"
+msgstr "Estat"
+
+#: pkg/subscriptions/subscriptions-view.jsx:141
+msgid "Status: System isn't registered"
+msgstr ""
+
+#: pkg/networkmanager/index.html:455
+msgid "Sticky"
+msgstr ""
+
+#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
+msgid "Stop"
+msgstr "Atura"
+
+#: pkg/storaged/details.js:1615
+msgid "Stop Scrubbing"
+msgstr "Atura el tractament de neteja"
+
+#: pkg/kubernetes/views/image-config.html:10
+msgid "Stop with"
+msgstr "Atura amb"
+
+#: pkg/docker/util.js:231
+msgid "Stopped"
+msgstr "Aturat"
+
+#: pkg/storaged/jobs.js:138
+msgid "Stopping RAID Device $target"
+msgstr "S'està aturant el dispositiu RAID $target"
+
+#: pkg/storaged/jobs.js:125
+msgid "Stopping swapspace $target"
+msgstr "S'està aturant l'espai d'intercanvi $target"
+
+#: pkg/storaged/index.html:23 pkg/storaged/index.html:672
+msgid "Storage"
+msgstr "Emmagatzematge"
+
+#: pkg/storaged/index.html:686
+msgid "Storage Log"
+msgstr "Registre de l'emmagatzematge"
+
+#: pkg/storaged/index.html:342
+msgid "Storage Logs"
+msgstr "Registres de l'emmagatzematge"
+
+#: pkg/docker/index.html:324
+msgid "Storage pool"
+msgstr ""
+
+#: pkg/systemd/index.html:148
+msgid "Store Performance Data"
+msgstr "Emmagatzema dades de rendiment"
+
+#: pkg/storaged/details.js:237
+msgid "Store passphrase"
+msgstr "Emmagatzema la contrasenya"
+
+#: pkg/storaged/details.js:527
+msgid "Stored Passphrase"
+msgstr "Contrasenya emmagatzemada"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:12
+msgid ""
+"Strategy            {{item.spec.strategy.type}}            Latest "
+"Version            {{ item.status.latestVersion }}            Not "
+"deployed        "
+msgstr ""
+
+#: pkg/subscriptions/index.html:22
+msgid "Subscriptions"
+msgstr "Subscripcions"
+
+#: pkg/kubernetes/views/image-body.html:4
+msgid "Summary"
+msgstr "Resum"
+
+#: pkg/storaged/details.js:1251
+msgctxt "storage-id-desc"
+msgid "Swap Space"
+msgstr "espai d'intercanvi"
+
+#: pkg/systemd/index.html:243
+msgid "Swap Used"
+msgstr "Intercanvi utilitzat"
+
+#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
+msgid "Switch off $0"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2191 pkg/networkmanager/interfaces.js:2765
@@ -2491,384 +5281,158 @@ msgstr ""
 msgid "Switching off <b>$0</b>  will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
-msgid "Switch off $0"
+#: pkg/networkmanager/interfaces.js:2773
+msgid "Switching off <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
-#: pkg/networkmanager/interfaces.js:2507
-msgid "Bond"
-msgstr "Enllaç"
+#: pkg/networkmanager/interfaces.js:2188
+msgid "Switching on <b>$0</b>  will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2762
+msgid "Switching on <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:75
+msgid "Synchronize"
+msgstr "Sincronitza"
+
+#: pkg/dashboard/index.html:188 pkg/lib/machine-sync-users.html:4
+msgid "Synchronize users"
+msgstr "Sincronitza els usuaris"
+
+#: pkg/systemd/index.html:54
+msgid "Synchronized"
+msgstr "Sincronitzat"
+
+#: pkg/systemd/index.html:51
+msgid "Synchronized with {{Server}}"
+msgstr "Sincronitzat amb {{Server}}"
+
+#: pkg/storaged/jobs.js:146
+msgid "Synchronizing RAID Device $target"
+msgstr ""
+
+#: pkg/systemd/index.html:4
+#, fuzzy
+msgid "System"
+msgstr "Hora del sistema"
+
+#: pkg/systemd/services.html:53
+msgid "System Services"
+msgstr "Serveis del sistema"
+
+#: pkg/systemd/index.html:112
+msgid "System Time"
+msgstr "Hora del sistema"
+
+#: pkg/docker/index.html:349
+msgid "TCP"
+msgstr "TCP"
+
+#: pkg/kubernetes/views/route-body.html:12
+msgid "TLS Termination"
+msgstr "Finalització TLS"
+
+#: pkg/docker/index.html:724
+msgid "Tag"
+msgstr "Tag"
+
+#: pkg/kubernetes/views/image-body.html:27
+#: pkg/kubernetes/views/imagestream-modify.html:76
+#: pkg/kubernetes/views/image-listing.html:14
+msgid "Tags"
+msgstr "Etiquetes"
+
+#: pkg/kubernetes/views/pv-modify.html:136
+msgid "Target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:75
+msgid "Target Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:114
+msgid "Target World Wide Names"
+msgstr ""
+
+#: pkg/systemd/services.html:52
+msgid "Targets"
+msgstr "Objectius"
 
 #: pkg/networkmanager/interfaces.js:2235 pkg/networkmanager/interfaces.js:2247
 #: pkg/networkmanager/interfaces.js:2530
 msgid "Team"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
-#: pkg/networkmanager/interfaces.js:2622
-msgid "VLAN"
-msgstr "VLAN"
-
-#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
-#: pkg/networkmanager/interfaces.js:2584
-msgid "Bridge"
-msgstr "Pont"
-
-#: pkg/networkmanager/interfaces.js:2276
-msgid "Carrier"
-msgstr "Portadora"
-
-#: pkg/networkmanager/interfaces.js:2279 pkg/kubernetes/scripts/volumes.js:990
-msgid "Yes"
-msgstr "Sí"
-
-#: pkg/networkmanager/interfaces.js:2299
-#: pkg/subscriptions/subscriptions-view.jsx:36
-#: pkg/kubernetes/views/node-body.html.h:14
-#: pkg/kubernetes/views/containers-listing.html.h:7
-#: pkg/kubernetes/views/volumes-page.html.h:5
-#: pkg/kubernetes/views/pv-claim.html.h:6
-#: pkg/kubernetes/views/nodes-page.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:5 pkg/kubernetes/views/pv-body.html.h:4
-msgid "Status"
-msgstr "Estat"
-
-#: pkg/networkmanager/interfaces.js:2310
-msgid "This device cannot be managed here."
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2342
-msgid "Unknown configuration"
-msgstr "Configuració desconeguda"
-
-#: pkg/networkmanager/interfaces.js:2441
-msgid "Configure"
-msgstr "Configura"
-
-#: pkg/networkmanager/interfaces.js:2473
-msgid "$mtu"
-msgstr "$mtu"
-
-#: pkg/networkmanager/interfaces.js:2477
-msgid "MTU"
-msgstr "MTU"
-
-#: pkg/networkmanager/interfaces.js:2483
-msgid "Master"
-msgstr "Màster"
-
-#: pkg/networkmanager/interfaces.js:2502
-msgid "ARP Monitoring"
-msgstr "Monitoratge ARP"
-
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
-#, fuzzy
-msgid "Broken configuration"
-msgstr "Configuració desconeguda"
-
 #: pkg/networkmanager/interfaces.js:2558
 #, fuzzy
 msgid "Team Port"
 msgstr "Port"
 
-#: pkg/networkmanager/interfaces.js:2573
-msgid "Spanning Tree Protocol"
-msgstr "STP (Spanning Tree Protocol)"
-
-#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
-msgid "Priority $priority"
-msgstr "Prioritat $priority"
-
-#: pkg/networkmanager/interfaces.js:2577
-msgid "Forward delay $forward_delay"
-msgstr "Retard del reenviament $forward_delay"
-
-#: pkg/networkmanager/interfaces.js:2579
-msgid "Hello time $hello_time"
-msgstr "Hello time $hello_time"
-
-#: pkg/networkmanager/interfaces.js:2581
-msgid "Maximum message age $max_age"
-msgstr "Envelliment màxim del missatge $max_age"
-
-#: pkg/networkmanager/interfaces.js:2601
-msgid "Path cost $path_cost"
-msgstr "Cost del camí $path_cost"
-
-#: pkg/networkmanager/interfaces.js:2603
-msgid "Hairpin mode"
-msgstr "Mode hairpin"
-
-#: pkg/networkmanager/interfaces.js:2605
-msgid "Bridge port"
-msgstr "Port del pont"
-
-#: pkg/networkmanager/interfaces.js:2619
-msgid "Parent $parent"
-msgstr "Pare $parent"
-
-#: pkg/networkmanager/interfaces.js:2620
-msgid "Id $id"
-msgstr "Id. $id"
-
-#: pkg/networkmanager/interfaces.js:2628
-msgid "General"
-msgstr "General"
-
-#: pkg/networkmanager/interfaces.js:2637
-msgid "Connect automatically"
-msgstr "Connecta automàticament"
-
-#: pkg/networkmanager/interfaces.js:2641
-msgid "IPv4"
-msgstr "IPv4"
-
-#: pkg/networkmanager/interfaces.js:2642
-msgid "IPv6"
-msgstr "IPv6"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/networkmanager/index.html.h:33
-#: pkg/kubernetes/views/project-listing.html.h:5
-msgid "Members"
-msgstr "Membres"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/docker/index.html.h:39
-#: pkg/networkmanager/index.html.h:24
-#: pkg/kubernetes/views/service-body.html.h:6
-#: pkg/kubernetes/views/image-config.html.h:7
-#: pkg/kubernetes/views/container-body.html.h:5
-msgid "Ports"
-msgstr "Ports"
-
-#: pkg/networkmanager/interfaces.js:2762
-msgid "Switching on <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2773
-msgid "Switching off <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2788
-msgid "Removing <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2791
+#: pkg/networkmanager/index.html:652
 #, fuzzy
-msgid "Remove $0"
-msgstr "Elimina"
+msgid "Team Port Settings"
+msgstr "Ajusts del port del pont"
 
-#: pkg/networkmanager/interfaces.js:2833
-msgid "Adding <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2836
-msgid "Add $0"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2870
-msgid "Changing the settings will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2872
+#: pkg/networkmanager/index.html:624
 #, fuzzy
-msgid "Change the settings"
-msgstr "Ajusts de la connexió"
+msgid "Team Settings"
+msgstr "Ajusts de la IP"
 
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length or Netmask"
-msgstr "Longitud del prefix o Màscara de xarxa"
+#: pkg/kubernetes/views/replicationcontroller-page.html:20
+#: pkg/kubernetes/views/deploymentconfig-panel.html:10
+#: pkg/kubernetes/views/deploymentconfig-page.html:15
+#: pkg/kubernetes/views/replicationcontroller-panel.html:14
+msgid "Template"
+msgstr "Plantilla"
 
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length"
-msgstr "Longitud del prefix"
+#: pkg/systemd/terminal.html:4
+msgid "Terminal"
+msgstr "Terminal"
 
-#: pkg/networkmanager/interfaces.js:3011
-#: pkg/kubernetes/views/details-page.html.h:7
-msgid "Addresses"
-msgstr "Adreces"
+#: pkg/users/index.html:78
+msgid "Terminate Session"
+msgstr "Acaba la sessió"
 
-#: pkg/networkmanager/interfaces.js:3018
-msgid "DNS"
-msgstr "DNS"
-
-#: pkg/networkmanager/interfaces.js:3022
-msgid "DNS Search Domains"
-msgstr "Dominis de cerca DNS"
-
-#: pkg/networkmanager/interfaces.js:3027
-#: pkg/kubernetes/views/details-page.html.h:11
-msgid "Routes"
-msgstr "Rutes"
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv4 Settings"
-msgstr "Ajustos d'IPv4"
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv6 Settings"
-msgstr "Ajustos d'IPv6"
-
-#: pkg/networkmanager/interfaces.js:3436
-msgid "Creating this bond will break the connection to the server, "
+#: pkg/networkmanager/index.html:38
+msgid "Testing connection"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
-#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
+#: pkg/storaged/index.html:40
+msgid "The \"storaged\" API is not available on this system."
+msgstr "L'API «storaged» no està disponible en aquest sistema."
+
+#: pkg/docker/storage.jsx:485
 #, fuzzy
-msgid "Create it"
-msgstr "Crea"
+msgid "The Docker storage pool cannot be managed on this system."
+msgstr "L'API «storaged» no està disponible en aquest sistema."
 
-#: pkg/networkmanager/interfaces.js:3611
-msgid "Creating this team will break the connection to the server, "
+#: pkg/lib/machine-dialogs.js:386
+msgid "The IP address or host name cannot contain whitespace."
+msgstr "L'adreça IP o el nom d'amfitrió no poden contenir espais en blanc."
+
+#: pkg/storaged/index.html:532
+msgid "The RAID Array is in a degraded state"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3842
-msgid "Creating this bridge will break the connection to the server, "
+#: pkg/kubernetes/scripts/nodes.js:399
+msgid "The address contains invalid characters"
+msgstr "L'adreça conté caràcters no vàlids"
+
+#: pkg/lib/machine-unknown-hostkey.html:6
+msgid ""
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:4064
-msgid "Creating this VLAN will break the connection to the server, "
+#: pkg/selinux/setroubleshoot-view.jsx:324
+msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:4139
-msgid "MTU must be a positive number"
+#: pkg/kubernetes/views/container-page-inline.html:22
+msgid "The container '{{ target }}' does not exist."
 msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:196
-#, fuzzy
-msgid "Invalid credentials"
-msgstr "Port no vàlid"
-
-#: pkg/subscriptions/subscriptions-client.js:198
-msgid "'Organization' required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:200
-msgid "Login/password or activation key required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:202
-msgid "'Organization' required when using activation keys."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:64
-#: pkg/kubernetes/views/volume-body.html.h:16
-#: pkg/kubernetes/views/pv-modify.html.h:11
-msgid "Server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:88
-#: pkg/subscriptions/subscriptions-register.jsx:152
-#: pkg/lib/machine-auth-failed.html.h:3 pkg/lib/machine-sync-users.html.h:6
-#: pkg/lib/machine-change-auth.html.h:6 pkg/shell/index.html.h:31
-#: pkg/users/index.html.h:16 pkg/kubernetes/views/auth-form.html.h:11
-msgid "Password"
-msgstr "Contrasenya"
-
-#: pkg/subscriptions/subscriptions-register.jsx:102
-#, fuzzy
-msgid "Custom URL"
-msgstr "Personalitzat"
-
-#: pkg/subscriptions/subscriptions-register.jsx:110
-msgid "URL"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:125
-msgid "Proxy"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:132
-msgid "Use proxy server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:140
-#, fuzzy
-msgid "Login"
-msgstr "Últim inici de sessió"
-
-#: pkg/subscriptions/subscriptions-register.jsx:164
-#, fuzzy
-msgid "Activation Key"
-msgstr "Activa"
-
-#: pkg/subscriptions/subscriptions-register.jsx:176
-#, fuzzy
-msgid "Organization"
-msgstr "Traducció"
-
-#: pkg/subscriptions/main.js:45 pkg/subscriptions/subscriptions-view.jsx:143
-#: pkg/kubernetes/views/pv-modify.html.h:23
-msgid "Register"
-msgstr ""
-
-#: pkg/subscriptions/main.js:74
-msgid "Register system"
-msgstr "Registra el sistema"
-
-#: pkg/subscriptions/subscriptions-view.jsx:32
-msgid "Product name"
-msgstr "Nom del producte"
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product ID"
-msgstr "Id. del producte"
-
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/index.html.h:13
-#: pkg/shell/index.html.h:14 pkg/shell/stub.html.h:9 pkg/shell/simple.html.h:9
-#: pkg/ostree/index.html.h:19
-msgid "Version"
-msgstr "Versió"
-
-#: pkg/subscriptions/subscriptions-view.jsx:35
-#: pkg/kubernetes/views/image-config.html.h:5
-msgid "Architecture"
-msgstr "Arquitectura"
-
-#: pkg/subscriptions/subscriptions-view.jsx:37
-msgid "Starts"
-msgstr "Comença"
-
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Ends"
-msgstr "Acaba"
-
-#: pkg/subscriptions/subscriptions-view.jsx:141
-msgid "Status: System isn't registered"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:146
-#, fuzzy
-msgid "Status: $0"
-msgstr "Estat"
-
-#: pkg/subscriptions/subscriptions-view.jsx:148
-msgid "Unregister"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:154
-#, fuzzy
-msgid "Unregistering system..."
-msgstr "S'està registrant el sistema..."
-
-#: pkg/subscriptions/subscriptions-view.jsx:161
-#: pkg/subscriptions/index.html.h:1
-msgid "Subscriptions"
-msgstr "Subscripcions"
-
-#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/ostree/index.html.h:15
-msgid "Updating"
-msgstr "S'està actualitzant"
-
-#: pkg/subscriptions/subscriptions-view.jsx:188
-msgid "Retrieving subscription status..."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:191
-#, fuzzy
-msgid "Access denied"
-msgstr "Accés"
 
 #: pkg/subscriptions/subscriptions-view.jsx:192
 #, fuzzy
@@ -2879,331 +5443,685 @@ msgstr ""
 "aquest sistema.\n"
 "      "
 
-#: pkg/subscriptions/subscriptions-view.jsx:195
-#, fuzzy
-msgid "Unable to connect"
-msgstr "No es pot arribar al servidor"
-
-#: pkg/subscriptions/subscriptions-view.jsx:196
-#, fuzzy
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
+#: pkg/kubernetes/views/deploymentconfig-page.html:25
+msgid "The deployment config '{{ target }}' does not exist."
 msgstr ""
-"\n"
-"        Per gestionar les subscripcions d'aquest sistema, si us plau, "
-"comproveu que subscription-manager estigui instal·lat.\n"
-"      "
 
-#: pkg/subscriptions/subscriptions-view.jsx:222
-#, fuzzy
-msgid "Installed products"
-msgstr "Productes instal·lats"
+#: pkg/kubernetes/views/group-page.html:47
+msgid "The group '{{ groupName }}' does not exist."
+msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:223
-#, fuzzy
-msgid "No installed products on the system."
-msgstr "Cockpit no està instal·lat al sistema."
+#: pkg/shell/base_index.js:673
+msgid "The javascript console contains details about this error "
+msgstr "La consola javascript conté els detalls sobre aquest error."
 
-#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "No és un nombre vàlid de rèpliques"
+#: pkg/lib/machine-invalid-hostkey.html:8
+msgid ""
+"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
+"in use. Unless this machine was recently replaced, it is likely that someone "
+"is trying to attack your connection to this machine."
+msgstr ""
+
+#: pkg/users/authorized-keys.js:118
+msgid "The key you provided was not valid."
+msgstr "La clau que heu proporcionat no era vàlida."
+
+#: pkg/storaged/details.js:1751
+msgid "The last physical volume of a volume group cannot be removed."
+msgstr ""
+
+#: pkg/shell/indexes.js:314
+msgid "The machine is restarting"
+msgstr "La màquina s'està reiniciant"
 
 #: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
 msgid "The maximum number of replicas is 128"
 msgstr "El nombre màxim de rèpliques és 128"
 
-#: pkg/kubernetes/scripts/details.js:546
-msgid "Not a valid value for Host"
-msgstr "No és un valor vàlid per a l'amfitrió"
-
-#: pkg/kubernetes/scripts/details.js:655
-msgid "Updating $0..."
-msgstr "S'està actualitzant $0..."
-
-#: pkg/kubernetes/scripts/graphs.js:601 pkg/kubernetes/scripts/nodes.js:711
-#: pkg/kubernetes/scripts/nodes.js:817 pkg/dashboard/index.html.h:2
-msgid "CPU"
-msgstr "CPU"
-
-#: pkg/kubernetes/scripts/graphs.js:606 pkg/kubernetes/scripts/nodes.js:715
-#: pkg/kubernetes/scripts/nodes.js:826 pkg/dashboard/index.html.h:3
-msgid "Memory"
-msgstr "Memòria"
-
-#: pkg/kubernetes/scripts/graphs.js:611 pkg/dashboard/index.html.h:4
-msgid "Network"
-msgstr "Xarxa"
-
-#: pkg/kubernetes/scripts/nodes.js:319 pkg/kubernetes/views/node-body.html.h:16
-#: pkg/kubernetes/views/details-page.html.h:10
-msgid "Not Ready"
-msgstr "No a punt"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
-msgstr ""
-
-#: pkg/kubernetes/scripts/nodes.js:324 pkg/kubernetes/views/node-body.html.h:15
-#: pkg/kubernetes/views/details-page.html.h:9
-msgid "Ready"
-msgstr "A punt"
-
-#: pkg/kubernetes/scripts/nodes.js:397
-msgid "Please type an address"
-msgstr "Si us plau, introduïu una adreça"
-
-#: pkg/kubernetes/scripts/nodes.js:399
-msgid "The address contains invalid characters"
-msgstr "L'adreça conté caràcters no vàlids"
-
 #: pkg/kubernetes/scripts/nodes.js:407
 msgid "The name contains invalid characters"
 msgstr "El nom conté caràcters no vàlids"
 
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
+#: pkg/kubernetes/views/node-page.html:23
+msgid "The node '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
+#: pkg/kubernetes/views/node-alerts.html:7
+msgid "The node doesn't have enough disk space"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
-msgid "Disk"
-msgstr "Disc"
-
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
-msgstr "Utilització del disc: $0%"
-
-#: pkg/kubernetes/scripts/nodes.js:870
-#, c-format
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/kubernetes/scripts/nodes.js:872
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/kubernetes/scripts/connection.js:88
-msgid "Error writing kubectl config"
+#: pkg/kubernetes/views/node-alerts.html:11
+msgid "The node doesn't have enough free memory"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:514
-msgid "Couldn't find running API server"
+#: pkg/users/local.js:395 pkg/users/local.js:1082
+msgid "The passwords do not match"
+msgstr "Les contrasenyes no coincideixen"
+
+#: pkg/lib/credentials.js:186
+msgid "The passwords do not match."
+msgstr "Les contrasenyes no coincideixen."
+
+#: pkg/kubernetes/views/pv-page.html:21
+msgid "The persistent volume '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:516
-msgid "Connection Error: $0"
+#: pkg/kubernetes/views/pod-page.html:40
+msgid "The pod '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:539
-msgid "Please provide a valid address"
+#: pkg/kubernetes/views/project-page.html:34
+msgid "The project '{{ projName }}' does not exist."
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:554
-msgid "Please provide a username"
+#: pkg/kubernetes/views/replicationcontroller-page.html:30
+msgid "The replication controller '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:650
-msgid "Error getting certificate details: $0"
+#: pkg/kubernetes/views/route-page.html:19
+msgid "The route '{{ target }}' does not exist."
 msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
-msgstr "Dipòsit git"
-
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr "Secret"
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr "Directori buit"
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
-msgid "Host Path"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:199
-msgid "NFS Mount"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
-msgid "ISCSI"
-msgstr "ISCSI"
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:469
-msgid "Please select a valid access mode"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:477
-msgid "Please provide a valid name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:485
-msgid "Please provide a valid storage capacity."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:493
-msgid "Please select a valid policy option."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:565
-msgid "Please select a valid endpoint"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:574
-msgid "Please provide a GlusterFS volume name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:632
-msgid "Please provide a valid NFS server"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
-msgid "Please provide a valid path"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:781
-msgid "Please provide a valid target"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:789
-msgid "Please provide a valid qualified name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:797
-msgid "Please provide a valid logical unit number"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:805
-msgid "Please provide a valid filesystem type"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:813
-msgid "Please provide a valid interface"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:860
-msgid "NFS"
-msgstr "NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:872
-msgid "GlusterFS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:908
-msgid "Sorry, I don't know how to modify this volume"
-msgstr ""
-
-#: pkg/kubernetes/scripts/charts.js:113
-msgid "Unavailable"
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "L'espai de noms no pot estar en blanc."
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "Si us plau, un espai de noms vàlid."
-
-#: pkg/kubernetes/scripts/dashboard.js:384
-msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr ""
-"Sense seleccionar el fitxer de metadades. Si us plau, seleccioneu un fitxer "
-"de metadades del Kubernetes."
 
 #: pkg/kubernetes/scripts/dashboard.js:386
 msgid "The selected file is not a valid Kubernetes application manifest."
 msgstr "El fitxer seleccionat no és un manifest d'aplicació Kubernetes vàlid."
 
-#: pkg/kubernetes/scripts/dashboard.js:401
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr "No es pot llegir el fitxer del manifest del Kubernetes. Codi $0."
+#: src/base1/cockpit.js:3695
+msgid "The server refused to authenticate using any supported methods."
+msgstr ""
+"El servidor ha refusat l'autenticació mitjançant qualsevol dels mètodes "
+"compatibles."
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:2
+msgid "The server uses a certificate signed by an unknown authority."
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:19
+msgid "The service '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/docker/storage.jsx:355
+msgid ""
+"The storage pool will be reset to optimize its layout.  All containers will "
+"be erased."
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:29
+msgid "The user '{{ userName }}' does not exist."
+msgstr ""
+
+#: pkg/systemd/init.js:834
+#, fuzzy
+msgid "The user <b>$0</b> does not have permissions for creating timers"
+msgstr "A l'usuari <b>$0</b> no se li permet gestionar els servidors"
+
+#: pkg/dashboard/list.js:209
+msgid "The user <b>$0</b> is not permitted to manage servers"
+msgstr "A l'usuari <b>$0</b> no se li permet gestionar els servidors"
+
+#: pkg/storaged/permissions.js:61
+msgid "The user <b>$0</b> is not permitted to manage storage"
+msgstr "A l'usuari <b>$0</b> no se li permet gestionar l'emmagatzematge"
+
+#: pkg/users/local.js:40
+msgid "The user <b>$0</b> is not permitted to modify accounts"
+msgstr "A l'usuari <b>$0</b> no se li permet modificar els comptes"
+
+#: pkg/systemd/host.js:43
+msgid "The user <b>$0</b> is not permitted to modify hostnames"
+msgstr "A l'usuari <b>$0</b> no se li permet modificar el noms dels amfitrions"
+
+#: pkg/networkmanager/interfaces.js:1420
+msgid "The user <b>$0</b> is not permitted to modify network settings"
+msgstr "A l'usuari <b>$0</b> no se li permet modificar els ajustos de xarxa"
+
+#: pkg/realmd/operation.js:436
+msgid "The user <b>$0</b> is not permitted to modify realms"
+msgstr "A l'usuari <b>$0</b> no se li permet modificar els reialmes"
+
+#: pkg/users/local.js:501
+msgid ""
+"The user name can only consist of letters from a-z, digits, dots, dashes and "
+"underscores."
+msgstr ""
+
+#: pkg/users/index.html:332
+msgid "There are no authorized public keys for this account."
+msgstr "No hi ha cap clau pública autoritzada per aquest compte."
+
+#: pkg/storaged/details.js:1756
+msgid ""
+"There is not enough free space elsewhere to remove this physical volume.  At "
+"least $0 more free space is needed."
+msgstr ""
+
+#: pkg/storaged/utils.js:168
+msgid "Thin Logical Volume"
+msgstr "Volums lògics disgregats"
+
+#: pkg/kubernetes/views/pvc-delete.html:8
+msgid ""
+"This claim is in use. Deleting it may cause issues with the following pod:"
+msgstr ""
+
+#: pkg/systemd/init.js:1222
+msgid ""
+"This day doesn't exist in all months.<br> The timer will only be executed in "
+"months that have 31st."
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2310
+msgid "This device cannot be managed here."
+msgstr ""
+
+#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
+#, fuzzy
+msgid "This field cannot be empty."
+msgstr "El nom no pot estar en blanc."
+
+#: pkg/storaged/details.js:690
+msgid "This logical volume cannot be made smaller."
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:364
+msgid "This machine has already been added."
+msgstr "La màquina ja ha estat afegida."
+
+#: pkg/realmd/operation.html:89
+msgid "This may take a while"
+msgstr "Això pot trigar una estona"
+
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid ""
+"This option is for single node testing only – local storage will not work in "
+"a multi-node cluster"
+msgstr ""
+
+#: src/bridge/cockpitpackages.c:470
+msgid "This package is not compatible with this version of Cockpit"
+msgstr ""
+
+#: src/bridge/cockpitpackages.c:459
+#, c-format
+msgid "This package requires Cockpit version %s or later"
+msgstr ""
+
+#: pkg/tuned/dialog.js:102
+msgid "This system is using a custom profile"
+msgstr "El sistema està utilitzant un perfil personalitzat"
+
+#: pkg/tuned/dialog.js:100
+msgid "This system is using the recommended profile"
+msgstr "El sistema està utilitzant el perfil recomanat"
+
+#: pkg/systemd/init.js:639
+msgid "This unit is an instance of the $0 template."
+msgstr "Aquesta unitat és una instantània de la plantilla $0."
+
+#: pkg/systemd/services.html:302
+#, fuzzy
+msgid "This unit is not designed to be enabled explicitly.          "
+msgstr ""
+"Aquesta unitat no està dissenyada perquè s'habiliti de forma explícita.\n"
+"          "
+
+#: pkg/users/local.js:509
+msgid "This user name already exists"
+msgstr "Aquest nom d'usuari ja existeix"
+
+#: pkg/lib/machine-dialogs.js:380
+msgid ""
+"This version of cockpit-ws does not support connecting to a host with an "
+"alternate user or port"
+msgstr ""
+"Aquesta versió decockpit-ws no és compatible amb la connexió a un amfitrió "
+"amb un usuari o port alternatius"
+
+#: pkg/kubernetes/views/pv-delete.html:7
+msgid ""
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:23
+msgid "This volume has not been claimed"
+msgstr ""
+
+#: pkg/systemd/index.html:379
+msgid "Time Zone"
+msgstr "Zona horària"
+
+#: pkg/systemd/services.html:55
+msgid "Timers"
+msgstr "Rellotges"
+
+#: pkg/kubernetes/views/image-body.html:33
+msgid "To pull this image:"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:39
+msgid "To push to an image to this image stream:"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:11
+msgid ""
+"To try a different port you will need to upgrade cockpit-ws to a newer "
+"version."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:116
+msgid "Token"
+msgstr ""
+
+#: pkg/kubernetes/index.html:57
+msgid "Topology"
+msgstr ""
+
+#: pkg/docker/storage.jsx:314
+msgid "Total"
+msgstr ""
+
+#: pkg/ostree/index.html:99
+msgid "Tree"
+msgstr "Arbre"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:32
+msgid "Triggers"
+msgstr "Disparadors"
+
+#: pkg/shell/index.html:328 pkg/shell/stub.html:181
+msgid "Troubleshoot"
+msgstr "Soluciona el problema"
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:21
+msgid "Trust this certificate for this connection"
+msgstr ""
+
+#: pkg/systemd/init.js:520
+msgid "Try Restart"
+msgstr "Prova de reiniciar"
+
+#: pkg/docker/index.html:71 pkg/docker/index.html:74
+msgid "Try again"
+msgstr "Torna-ho a intentar"
+
+#: pkg/systemd/index.html:59
+msgid "Trying to synchronize with {{Server}}"
+msgstr "S'està intentant la sincronització amb {{Server}}"
+
+#: pkg/tuned/dialog.js:262
+msgid "Tuned has failed to start"
+msgstr "Tuned ha fallat en iniciar-se"
+
+#: pkg/tuned/dialog.js:94
+msgid "Tuned is not available"
+msgstr "Tuned no està disponible"
+
+#: pkg/tuned/dialog.js:96
+msgid "Tuned is not running"
+msgstr "Tuned no s'està executant"
+
+#: pkg/tuned/dialog.js:98
+msgid "Tuned is off"
+msgstr "Tuned no està aturat"
+
+#: pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/pv-modify.html:10
+#: pkg/kubernetes/views/volumes-page.html:20 pkg/kubernetes/views/deploy.html:9
+msgid "Type"
+msgstr "Tipus"
+
+#: pkg/kubernetes/views/details-page.html:7
+msgid "Type:"
+msgstr "Tipus:"
+
+#: pkg/subscriptions/subscriptions-register.jsx:110
+msgid "URL"
+msgstr ""
+
+#: pkg/storaged/index.html:547 pkg/storaged/index.html:626
+msgctxt "storage"
+msgid "UUID"
+msgstr "UUID"
+
+#: pkg/selinux/setroubleshoot-view.jsx:114
+msgid "Unable to apply this solution automatically"
+msgstr ""
+
+#: pkg/ostree/index.html:219
+msgid "Unable to communicate with OSTree"
+msgstr "No es pot comunicar amb OSTree"
+
+#: pkg/subscriptions/subscriptions-view.jsx:195
+#, fuzzy
+msgid "Unable to connect"
+msgstr "No es pot arribar al servidor"
 
 #: pkg/kubernetes/scripts/dashboard.js:413
 msgid "Unable to decode Kubernetes application manifest."
 msgstr ""
 
-#: pkg/kubernetes/scripts/dashboard.js:441
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "Si us plau, creeu un altre espai de noms per a $0 \"$1\""
+#: pkg/users/local.js:57
+msgid "Unable to delete root account"
+msgstr "No es pot suprimir el compte de root"
 
-#: pkg/kubernetes/scripts/dashboard.js:460
-msgid "Manifest"
-msgstr "Manifest"
+#: pkg/selinux/setroubleshoot-client.js:157
+msgid "Unable to get alert"
+msgstr ""
 
-#: pkg/dashboard/list.js:209
-msgid "The user <b>$0</b> is not permitted to manage servers"
-msgstr "A l'usuari <b>$0</b> no se li permet gestionar els servidors"
+#: pkg/storaged/overview.js:586
+msgid "Unable to reach server"
+msgstr "No es pot arribar al servidor"
+
+#: pkg/kubernetes/scripts/dashboard.js:401
+msgid "Unable to read the Kubernetes application manifest. Code $0."
+msgstr "No es pot llegir el fitxer del manifest del Kubernetes. Codi $0."
+
+#: pkg/users/local.js:59
+msgid "Unable to rename root account"
+msgstr "No es pot reanomenar el compte de root"
+
+#: pkg/selinux/setroubleshoot-client.js:172
+msgid "Unable to run fix"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:52
+msgid "Unable to start setroubleshootd"
+msgstr ""
+
+#: pkg/playground/translate.html:35 pkg/playground/translate.html:40
+msgid "Unavailable"
+msgstr ""
+
+#: pkg/docker/index.html:763 pkg/networkmanager/index.html:792
+msgid "Unexpected error"
+msgstr "Error inesperat"
+
+#: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/image-body.html:15
+#: pkg/kubernetes/views/pv-claim.html:31 pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
+msgid "Unknown"
+msgstr "Desconegut"
+
+#: pkg/storaged/details.js:1597
+msgid "Unknown ($0)"
+msgstr "Desconegut ($0)"
+
+#: pkg/lib/machine-unknown-hostkey.html:2
+msgid "Unknown Host Key"
+msgstr "Clau desconeguda d'amfitrió"
+
+#: pkg/networkmanager/interfaces.js:2342
+msgid "Unknown configuration"
+msgstr "Configuració desconeguda"
+
+#: pkg/storaged/overview.js:582
+msgid "Unknown host name"
+msgstr "Nom d'amfitrió desconegut"
+
+#: pkg/docker/index.html:570
+msgid "Unless Stopped"
+msgstr ""
+
+#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
+#: pkg/storaged/details.js:1110
+msgid "Unlock"
+msgstr "Desbloqueja"
+
+#: pkg/shell/index.html:220
+msgid "Unlock Key"
+msgstr ""
+
+#: pkg/storaged/jobs.js:121
+msgid "Unlocking $target"
+msgstr "S'està desbloquejant $target"
+
+#: pkg/networkmanager/index.html:108
+#, fuzzy
+msgid "Unmanaged Interfaces"
+msgstr "Interfícies"
+
+#: pkg/systemd/init.js:548
+msgid "Unmask"
+msgstr "Desemmascara"
+
+#: pkg/storaged/details.js:1100
+msgid "Unmount"
+msgstr "Desmunta"
+
+#: pkg/storaged/jobs.js:127
+msgid "Unmounting $target"
+msgstr "S'està desmuntat $target"
+
+#: pkg/users/index.html:315
+msgid "Unnamed"
+msgstr "Sense nom"
+
+#: pkg/storaged/details.js:1256
+msgctxt "storage-id-desc"
+msgid "Unrecognized Data"
+msgstr "Dades no reconegudes"
+
+#: pkg/subscriptions/subscriptions-view.jsx:148
+msgid "Unregister"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:154
+#, fuzzy
+msgid "Unregistering system..."
+msgstr "S'està registrant el sistema..."
+
+#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
+#: src/bridge/cockpitdbussetup.c:625
+#, fuzzy
+msgid "Unsupported setup mechanism"
+msgstr "Mecanisme de configuració no suportat: %s"
+
+#: src/base1/cockpit.js:3697
+msgid "Untrusted host"
+msgstr ""
+
+#: pkg/docker/util.js:94
+msgid "Up since $StartedAt"
+msgstr "Aixecat des de $StartedAt"
+
+#: pkg/lib/machine-change-port.html:41
+msgid "Update"
+msgstr "Actualitza"
+
+#: pkg/ostree/index.html:125 pkg/ostree/index.html:152
+msgid "Updates"
+msgstr "Actualitzacions"
+
+#: pkg/ostree/index.html:96
+msgid "Updating"
+msgstr "S'està actualitzant"
+
+#: pkg/kubernetes/scripts/details.js:655
+msgid "Updating $0..."
+msgstr "S'està actualitzant $0..."
+
+#: pkg/shell/index.html:165
+msgid "Use my password for privileged tasks and to connect to other machines"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:132
+msgid "Use proxy server"
+msgstr ""
+
+#: pkg/shell/index.html:172
+msgid "Use the following keys to authenticate against other systems"
+msgstr ""
+
+#: pkg/systemd/index.html:251
+msgid "Used"
+msgstr "Utilitzat"
+
+#: pkg/systemd/index.html:229 pkg/dashboard/index.html:158
+#: pkg/playground/translate.html:86 pkg/playground/translate.html:106
+#: pkg/kubernetes/views/user-panel.html:9
+#: pkg/kubernetes/views/auth-form.html:61
+#: pkg/kubernetes/views/volume-body.html:64
+#: pkg/kubernetes/views/volume-body.html:103
+msgid "User"
+msgstr "Usuari"
+
+#: pkg/users/index.html:90 pkg/users/index.html:154
+#: pkg/realmd/operation.html:47
+msgid "User Name"
+msgstr "Nom d'usuari"
+
+#: pkg/realmd/operation.html:53
+msgid "User Password"
+msgstr "Contrasenya d'usuari"
+
+#: pkg/lib/machine-change-auth.html:18
+msgid "User name"
+msgstr "Nom d'usuari"
+
+#: pkg/kubernetes/views/add-member-role-dialog.html:15
+msgid "User or Group"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:94
+msgid "Username"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:85
+msgid "Users"
+msgstr "Usuaris"
+
+#: pkg/storaged/details.js:181
+msgid "VFAT - Compatible with all systems and devices"
+msgstr "VFAT - Compatible amb tots els sistemes i dispositius"
+
+#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
+#: pkg/networkmanager/interfaces.js:2622
+msgid "VLAN"
+msgstr "VLAN"
+
+#: pkg/networkmanager/index.html:141
+msgid "VLAN Id"
+msgstr "Id. VLAN"
+
+#: pkg/networkmanager/index.html:736
+msgid "VLAN Settings"
+msgstr "Ajusts de la VLAN"
+
+#: pkg/users/authorized-keys.js:103
+msgid "Validating key"
+msgstr "S'està validant la clau"
+
+#: pkg/systemd/index.html:98 pkg/ostree/index.html:113 pkg/shell/simple.html:77
+#: pkg/shell/index.html:90 pkg/shell/stub.html:83
+msgid "Version"
+msgstr "Versió"
+
+#: pkg/storaged/jobs.js:137
+msgid "Very securely erasing $target"
+msgstr "S'està eliminant de forma molt segura $target"
+
+#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
+#: pkg/kubernetes/views/pvc-body.html:6
+msgid "Volume"
+msgstr "Volum"
+
+#: pkg/storaged/index.html:620
+msgid "Volume Group"
+msgstr "Grup de volums"
+
+#: pkg/storaged/utils.js:239
+msgid "Volume Group $0"
+msgstr "Grup de volums $0"
+
+#: pkg/storaged/index.html:98
+msgid "Volume Groups"
+msgstr "Grups de volums"
+
+#: pkg/kubernetes/views/volume-body.html:14
+#: pkg/kubernetes/views/volume-body.html:89
+msgid "Volume ID"
+msgstr "Id. del volum"
+
+#: pkg/kubernetes/views/pv-modify.html:115
+#: pkg/kubernetes/views/volume-body.html:42
+msgid "Volume Name"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
+msgid "Volume Type"
+msgstr ""
+
+#: pkg/docker/index.html:536 pkg/kubernetes/views/pod-page.html:18
+#: pkg/kubernetes/views/image-config.html:28
+#: pkg/kubernetes/views/dashboard-page.html:47 pkg/kubernetes/index.html:70
+msgid "Volumes"
+msgstr "Volums"
+
+#: pkg/networkmanager/interfaces.js:819
+msgid "Waiting"
+msgstr "S'està esperant"
+
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid "Warning:"
+msgstr ""
+
+#: pkg/systemd/logs.html:48
+msgid "Warnings"
+msgstr "Advertències"
+
+#: pkg/systemd/services.html:409
+msgid "Weeks"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:5
+msgid "Welcome to the Image Registry"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:61
+msgid "When"
+msgstr ""
+
+#: pkg/docker/index.html:507
+msgid "With terminal"
+msgstr "Amb el terminal"
+
+#: pkg/storaged/index.html:438
+msgctxt "storage"
+msgid "World Wide Name"
+msgstr "WWN (World Wide Name)"
+
+#: pkg/storaged/details.js:1595
+msgid "Write-mostly"
+msgstr "Escriptura-majoritària"
+
+#: pkg/storaged/index.html:333
+msgid "Writing"
+msgstr "Escriptura"
+
+#: pkg/ostree/client.js:64
+msgid "Writing objects"
+msgstr "S'estan escrivint els objectes"
+
+#: pkg/storaged/details.js:177
+msgid "XFS - Red Hat Enterprise Linux 7 default"
+msgstr "XFS - per defecte Red Hat Enterprise Linux 7"
+
+#: pkg/networkmanager/interfaces.js:1824
+msgid "XOR"
+msgstr "XOR"
+
+#: pkg/kubernetes/scripts/volumes.js:990 pkg/networkmanager/interfaces.js:2279
+msgid "Yes"
+msgstr "Sí"
+
+#: pkg/lib/machine-sync-users.html:47
+msgid ""
+"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
+"synchronize users, a user with superuser privileges is required."
+msgstr ""
 
 #: pkg/dashboard/list.js:394
 msgid ""
@@ -3212,1373 +6130,30 @@ msgstr ""
 "Actualment esteu connectat directament a aquest servidor. No podeu suprimir-"
 "ho."
 
-#: cockpit.appdata.xml.in.h:1
+#: pkg/kubernetes/views/auth-rejected-cert.html:3
 msgid ""
-"Cockpit is a server manager that makes it easy to administer your Linux "
-"servers via a web browser. Jumping between the terminal and the web tool is "
-"no problem. A service started via Cockpit can be stopped via the terminal. "
-"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
-"journal interface."
-msgstr ""
-"Cockpit és una eina de gestió de servidors que facilita l'administració dels "
-"vostres servidors Linux a través d'un navegador web. Saltar entre el "
-"terminal i l'eina web no és cap problema. Un servei iniciat a través de "
-"Cockpit es pot aturar a través del terminal. De la mateixa manera, si es "
-"produeix un error en el terminal, es pot observar en la interfície de les "
-"publicacions de Cockpit."
-
-#: cockpit.appdata.xml.in.h:2
-msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
-"stopping services. You can monitor and administer several servers at the "
-"same time. Just add them with a single click and your machines will look "
-"after its buddies."
-msgstr ""
-"Cockpit és perfecte per als nous administradors de sistemes, els permet "
-"realitzar fàcilment les tasques senzilles com ara l'administració de "
-"l'emmagatzematge, la inspecció de les publicacions i iniciar i aturar els "
-"serveis. Podeu monitorar i administrar diversos servidors a la vegada. Només "
-"heu d'afegir-los amb tan sols un clic i les vostres màquines es veuran al "
-"cantó de les altres."
-
-#: cockpit.desktop.in.h:1 pkg/shell/index.html.h:1 pkg/shell/stub.html.h:1
-#: pkg/shell/simple.html.h:1
-msgid "Cockpit"
-msgstr "Cockpit"
-
-#: cockpit.desktop.in.h:2
-msgid "A user interface for GNU/Linux servers"
-msgstr "Una interfície d'usuari per als servidors GNU/Linux"
-
-#: cockpit.desktop.in.h:3
-msgid "Remote;Administration;"
-msgstr "Remot;Administració;"
-
-#: pkg/systemd/index.html.h:1
-#, fuzzy
-msgid "System"
-msgstr "Hora del sistema"
-
-#: pkg/systemd/index.html.h:2
-msgid "No host keys found."
+"You can bypass the certificate check, but any data you send to the server "
+"could be intercepted by others."
 msgstr ""
 
-#: pkg/systemd/index.html.h:3
-msgid "Synchronized with {{Server}}"
-msgstr "Sincronitzat amb {{Server}}"
-
-#: pkg/systemd/index.html.h:4
-msgid "Synchronized"
-msgstr "Sincronitzat"
-
-#: pkg/systemd/index.html.h:5
-msgid "Trying to synchronize with {{Server}}"
-msgstr "S'està intentant la sincronització amb {{Server}}"
-
-#: pkg/systemd/index.html.h:6
-msgid "Not synchronized"
-msgstr "No sincronitzat"
-
-#: pkg/systemd/index.html.h:7
-msgid "Hardware"
-msgstr "Maquinari"
-
-#: pkg/systemd/index.html.h:8
-msgid "Asset Tag"
-msgstr "Etiqueta de recurs"
-
-#: pkg/systemd/index.html.h:9 pkg/kubernetes/views/node-body.html.h:6
-msgid "Machine ID"
-msgstr "Id. de màquina"
-
-#: pkg/systemd/index.html.h:10 pkg/ostree/index.html.h:18
-#: pkg/kubernetes/views/nodes-page.html.h:6
-msgid "Operating System"
-msgstr "Sistema operatiu"
-
-#: pkg/systemd/index.html.h:11
-msgid "Secure Shell Keys"
-msgstr ""
-
-#: pkg/systemd/index.html.h:12
-msgid "Show fingerprints"
-msgstr "Mostra les empremptes"
-
-#: pkg/systemd/index.html.h:14 pkg/dashboard/index.html.h:7
-msgid "Host Name"
-msgstr "Nom d'amfitrió"
-
-#: pkg/systemd/index.html.h:15
-msgid "Domain"
-msgstr "Domini"
-
-#: pkg/systemd/index.html.h:16
-msgid "System Time"
-msgstr "Hora del sistema"
-
-#: pkg/systemd/index.html.h:17
-msgid "Power Options"
-msgstr "Opcions d'energia"
-
-#: pkg/systemd/index.html.h:20
-msgid "Performance Profile"
-msgstr "Perfil de rendiment"
-
-#: pkg/systemd/index.html.h:21
-msgid "Store Performance Data"
-msgstr "Emmagatzema dades de rendiment"
-
-#: pkg/systemd/index.html.h:32
-msgid "Machine SSH Key Fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:33
-msgid "Pretty Host Name"
-msgstr "Nom de l'amfitrió de nivell superior"
-
-#: pkg/systemd/index.html.h:34
-msgid "Real Host Name"
-msgstr "Nom real de l'amfitrió"
-
-#: pkg/systemd/index.html.h:35
-msgid "Time Zone"
-msgstr "Zona horària"
-
-#: pkg/systemd/index.html.h:36
-msgid ""
-"\n"
-"                                    Invalid time zone\n"
-"                                "
-msgstr ""
-"\n"
-"                                    Zona horària no vàlida\n"
-"                                "
-
-#: pkg/systemd/index.html.h:39
-msgid "Set Time"
-msgstr "Ajusta l'hora"
-
-#: pkg/systemd/index.html.h:40
-msgid "Manually"
-msgstr "Manualment"
-
-#: pkg/systemd/index.html.h:41
-msgid "Automatically using NTP"
-msgstr "Automàticament mitjançant NTP"
-
-#: pkg/systemd/index.html.h:42
-msgid "Automatically using specific NTP servers"
-msgstr "Automàticament mitjançant servidors NTP específics"
-
-#: pkg/systemd/index.html.h:43
-msgid "Delay"
-msgstr "Retard"
-
-#: pkg/systemd/index.html.h:44
-msgid "1 Minute"
-msgstr "1 minut"
-
-#: pkg/systemd/index.html.h:45
-msgid "5 Minutes"
-msgstr "5 minuts"
-
-#: pkg/systemd/index.html.h:46
-msgid "20 Minutes"
-msgstr "20 minuts"
-
-#: pkg/systemd/index.html.h:47
-msgid "40 Minutes"
-msgstr "40 minuts"
-
-#: pkg/systemd/index.html.h:48
-msgid "60 Minutes"
-msgstr "60 minuts"
-
-#: pkg/systemd/index.html.h:49
-msgid "No Delay"
-msgstr "Sense retard"
-
-#: pkg/systemd/index.html.h:50
-msgid "Specific Time"
-msgstr "Temps específic"
-
-#: pkg/systemd/index.html.h:51
-msgid ""
-"\n"
-"                        Cancel\n"
-"                    "
-msgstr ""
-"\n"
-"                        Cancel·la\n"
-"                    "
-
-#: pkg/systemd/logs.html.h:1
-msgid "Journal"
-msgstr "Publicacions"
-
-#: pkg/systemd/logs.html.h:2
-msgid "Recent"
-msgstr "Recent"
-
-#: pkg/systemd/logs.html.h:3
-msgid "Current boot"
-msgstr "Arrencada actual"
-
-#: pkg/systemd/logs.html.h:4
-msgid "Last 24 hours"
-msgstr "Les últimes 24 hores"
-
-#: pkg/systemd/logs.html.h:5
-msgid "Last 7 days"
-msgstr "Els últims 7 dies"
-
-#: pkg/systemd/logs.html.h:6
-msgid "Errors"
-msgstr "Errors"
-
-#: pkg/systemd/logs.html.h:7
-msgid "Warnings"
-msgstr "Advertències"
-
-#: pkg/systemd/logs.html.h:8
-msgid "Notices"
-msgstr "Anuncis"
-
-#: pkg/systemd/logs.html.h:9
-msgid "All"
-msgstr "Tots"
-
-#: pkg/systemd/logs.html.h:10 pkg/kubernetes/views/container-panel.html.h:2
-#: pkg/kubernetes/views/container-page-inline.html.h:2
-msgid "Logs"
-msgstr "Registres"
-
-#: pkg/systemd/logs.html.h:11
-msgid "Entry"
-msgstr "Entrada"
-
-#: pkg/systemd/services.html.h:1 pkg/kubernetes/views/dashboard-page.html.h:12
-#: pkg/kubernetes/views/details-page.html.h:3
-msgid "Services"
-msgstr "Serveis"
-
-#: pkg/systemd/services.html.h:3
-msgid "System Services"
-msgstr "Serveis del sistema"
-
-#: pkg/systemd/services.html.h:4
-msgid "Sockets"
-msgstr "Sockets"
-
-#: pkg/systemd/services.html.h:5
-msgid "Timers"
-msgstr "Rellotges"
-
-#: pkg/systemd/services.html.h:6
-msgid "Paths"
-msgstr "Camins"
-
-#: pkg/systemd/services.html.h:7
-msgid "Instantiate"
-msgstr "Instancia"
-
-#: pkg/systemd/services.html.h:8
-msgid "{{days_text}}"
-msgstr ""
-
-#: pkg/systemd/services.html.h:9
-msgid "Service Logs"
-msgstr "Registres del servei"
-
-#: pkg/systemd/services.html.h:10
-msgid "Note"
-msgstr "Nota"
-
-#: pkg/systemd/services.html.h:11
-msgid ""
-"This unit is not designed to be enabled explicitly.\n"
-"          "
-msgstr ""
-"Aquesta unitat no està dissenyada perquè s'habiliti de forma explícita.\n"
-"          "
-
-#: pkg/systemd/services.html.h:15
-#, fuzzy
-msgid "Create Timers"
-msgstr "Crea un volum disgregat"
-
-#: pkg/systemd/services.html.h:16
-#, fuzzy
-msgid "Service name"
-msgstr "Servei"
-
-#: pkg/systemd/services.html.h:18 pkg/docker/index.html.h:32
-msgid "Command"
-msgstr "Ordre"
-
-#: pkg/systemd/services.html.h:19
-#, fuzzy
-msgid "Run"
-msgstr "Executa com"
-
-#: pkg/systemd/services.html.h:20
-#, fuzzy
-msgid "After system boot"
-msgstr "Registra el sistema"
-
-#: pkg/systemd/services.html.h:21
-#, fuzzy
-msgid "At specific time"
-msgstr "Temps específic"
-
-#: pkg/systemd/services.html.h:22
-msgid "Seconds"
-msgstr ""
-
-#: pkg/systemd/services.html.h:23
-#, fuzzy
-msgid "Minutes"
-msgstr "5 minuts"
-
-#: pkg/systemd/services.html.h:24
-#, fuzzy
-msgid "Hours"
-msgstr "6 hores"
-
-#: pkg/systemd/services.html.h:25
-msgid "Weeks"
-msgstr ""
-
-#: pkg/systemd/services.html.h:26
-msgid "Don't Repeat"
-msgstr ""
-
-#: pkg/systemd/services.html.h:27
-msgid "Repeat Hourly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:28
-msgid "Repeat Daily"
-msgstr ""
-
-#: pkg/systemd/services.html.h:29
-msgid "Repeat Weekly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:30
-msgid "Repeat Monthly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:31
-msgid "Repeat Yearly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:32
-#, fuzzy
-msgid "Hour : Minute"
-msgstr "1 minut"
-
-#: pkg/systemd/services.html.h:33
-msgid ":"
-msgstr ""
-
-#: pkg/systemd/services.html.h:35
-msgid "Save"
-msgstr ""
-
-#: pkg/systemd/terminal.html.h:1
-msgid "Terminal"
-msgstr "Terminal"
-
-#: pkg/lib/machine-invalid-hostkey.html.h:1
-msgid "Incorrect Host Key"
-msgstr "Clau d'amfitrió incorrecta"
-
-#: pkg/lib/machine-invalid-hostkey.html.h:2
-msgid ""
-"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
-"in use. Unless this machine was recently replaced, it is likely that someone "
-"is trying to attack your connection to this machine."
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:3
+#: pkg/kubernetes/views/dashboard-page.html:150
+msgid "You can deploy an application to your cluster."
+msgstr "Podeu desplegar una aplicació al vostre clúster."
+
+#: pkg/lib/machine-invalid-hostkey.html:11
 msgid ""
 "You can remove the previously stored key by running the following command"
 msgstr ""
 "Podeu suprimir la clau prèviament emmagatzemada amb l'execució de la següent "
 "ordre"
 
-#: pkg/lib/machine-auth-failed.html.h:1
-msgid "Authentication Failed"
-msgstr "L'autenticació ha fallat"
-
-#: pkg/lib/machine-auth-failed.html.h:2
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
-"machine with cockpit you will need to enable one of the following "
-"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
+#: pkg/shell/base_index.js:672
+msgid "You can try restarting Cockpit by pressing refresh in your browser. "
 msgstr ""
+"Podeu provar de tornar a iniciar Cockpit, en prémer refresca al vostre "
+"navegador. "
 
-#: pkg/lib/machine-auth-failed.html.h:4 pkg/shell/index.html.h:30
-msgid "Public Key"
-msgstr "Clau pública"
-
-#: pkg/lib/machine-auth-failed.html.h:5
-msgid "Kerberos Based SSO"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:6
-msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:1 pkg/dashboard/index.html.h:11
-msgid "Synchronize users"
-msgstr "Sincronitza els usuaris"
-
-#: pkg/lib/machine-sync-users.html.h:2
-msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
-msgstr ""
-"Seleccioneu els usuaris que vulgueu que estiguin sincronitzats amb "
-"{{#strong}}{{host}}{{/strong}}"
-
-#: pkg/lib/machine-sync-users.html.h:3
-msgid "Error loading users: {{perm_failed}}"
-msgstr "S'ha produït un error en carregar els usuaris: {{perm_failed}}"
-
-#: pkg/lib/machine-sync-users.html.h:4
-msgid ""
-"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
-"synchronize users, a user with superuser privileges is required."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:5 pkg/lib/machine-change-auth.html.h:4
-msgid "User name"
-msgstr "Nom d'usuari"
-
-#: pkg/lib/machine-sync-users.html.h:8
-msgid "Synchronize"
-msgstr "Sincronitza"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:1
-msgid "Unknown Host Key"
-msgstr "Clau desconeguda d'amfitrió"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:2
-msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:3 pkg/shell/index.html.h:4
-msgid "Fingerprint"
-msgstr "Empremta"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:5
-#: pkg/kubernetes/views/auth-form.html.h:14
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:6
-msgid "Connect"
-msgstr "Connecta"
-
-#: pkg/lib/machine-add.html.h:1
-msgid "Add Machine to Dashboard"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:3 pkg/dashboard/index.html.h:9
-msgid "Color"
-msgstr "Color"
-
-#: pkg/lib/machine-add.html.h:4
-msgid ""
-"Connecting simultaneously to more than {{ limit }} machines is unsupported."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:1
-msgid "Could not contact {{host}}"
-msgstr "No s'ha pogut contactar amb {{host}}"
-
-#: pkg/lib/machine-change-port.html.h:2
-msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
-msgstr "Cockpit no ha pogut contactar amb {{#strong}}{{host}}{{/strong}}."
-
-#: pkg/lib/machine-change-port.html.h:3
-msgid ""
-"To try a different port you will need to upgrade cockpit-ws to a newer "
-"version."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:4
-msgid "Is sshd running on a different port?"
-msgstr "S'està executant sshd en un port diferent?"
-
-#: pkg/lib/machine-change-port.html.h:7
-msgid "Update"
-msgstr "Actualitza"
-
-#: pkg/lib/machine-not-supported.html.h:1
-msgid "Cockpit is not installed"
-msgstr "Cockpit no està instal·lat"
-
-#: pkg/lib/machine-not-supported.html.h:2
-msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
-msgstr ""
-"Una versió compatible de Cockpit no està instal·lada a {{#strong}}{{host}}{{/"
-"strong}}."
-
-#: pkg/lib/machine-change-auth.html.h:1
-msgid "Log in to {{host}}"
-msgstr "Inicia la sessió a {{host}}"
-
-#: pkg/lib/machine-change-auth.html.h:2
-msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-"Cockpit no ha pogut iniciar la sessió a {{#strong}}{{host}}{{/strong}}."
-
-#: pkg/lib/machine-change-auth.html.h:3
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:5 pkg/shell/index.html.h:9
-#: pkg/realmd/operation.html.h:3 pkg/kubernetes/views/auth-form.html.h:8
-msgid "Authentication"
-msgstr "Autenticació"
-
-#: pkg/lib/machine-change-auth.html.h:7
-msgid "Available"
-msgstr "Disponible"
-
-#: pkg/lib/machine-change-auth.html.h:8
-msgid "Login Password"
-msgstr "Contrasenya d'inici de sessió"
-
-#: pkg/lib/machine-change-auth.html.h:9
-msgid "Kerberos Ticket"
-msgstr "Tiquet de Kerberos"
-
-#: pkg/lib/machine-change-auth.html.h:10
-msgid "Checking for public keys"
-msgstr "S'està comprovant si hi ha claus públiques"
-
-#: pkg/lib/machine-change-auth.html.h:12
-msgid "Log In"
-msgstr "Inici de la sessió"
-
-#: pkg/shell/shell.html.h:1
-msgid "Things have moved"
-msgstr ""
-
-#: pkg/shell/index.html.h:2
-msgid "Comment"
-msgstr "Comentari"
-
-#: pkg/shell/index.html.h:5 pkg/shell/stub.html.h:2 pkg/shell/simple.html.h:2
-msgid "Ooops!"
-msgstr "Ooops!"
-
-#: pkg/shell/index.html.h:6 pkg/shell/stub.html.h:3 pkg/shell/simple.html.h:3
-msgid "Display Language"
-msgstr "Idioma de la pantalla"
-
-#: pkg/shell/index.html.h:7 pkg/shell/stub.html.h:4 pkg/shell/simple.html.h:4
-msgid "About Cockpit"
-msgstr "Quant a Cockpit"
-
-#: pkg/shell/index.html.h:8
-msgid "Account Settings"
-msgstr "Paràmetres dels comptes"
-
-#: pkg/shell/index.html.h:10 pkg/shell/stub.html.h:5 pkg/shell/simple.html.h:5
-msgid "Log out"
-msgstr "Tanca la sessió"
-
-#: pkg/shell/index.html.h:11 pkg/shell/stub.html.h:6 pkg/shell/simple.html.h:6
-msgid ""
-"\n"
-"              Cockpit is an interactive Linux server admin interface.\n"
-"            "
-msgstr ""
-"\n"
-"              Cockpit és una interfície d'administració de servidor Linux "
-"interactiva.\n"
-"            "
-
-#: pkg/shell/index.html.h:15 pkg/shell/stub.html.h:10
-#: pkg/shell/simple.html.h:10
-msgid "Choose the language to be used in the application"
-msgstr "Seleccioneu l'idioma per utilitzar amb l'aplicació"
-
-#: pkg/shell/index.html.h:16 pkg/shell/stub.html.h:11
-#: pkg/shell/simple.html.h:11 pkg/storaged/index.html.h:59
-msgid ""
-"\n"
-"              Cancel\n"
-"            "
-msgstr ""
-"\n"
-"              Cancel·la\n"
-"            "
-
-#: pkg/shell/index.html.h:19 pkg/shell/stub.html.h:14
-#: pkg/shell/simple.html.h:14
-msgid ""
-"\n"
-"              Select\n"
-"            "
-msgstr ""
-"\n"
-"              Selecciona\n"
-"            "
-
-#: pkg/shell/index.html.h:22 pkg/shell/stub.html.h:17
-msgid ""
-"\n"
-"              Close\n"
-"            "
-msgstr ""
-"\n"
-"              Tanca\n"
-"            "
-
-#: pkg/shell/index.html.h:25
-msgid "Use my password for privileged tasks and to connect to other machines"
-msgstr ""
-
-#: pkg/shell/index.html.h:26
-msgid "Use the following keys to authenticate against other systems"
-msgstr ""
-
-#: pkg/shell/index.html.h:29 pkg/kubernetes/index.html.h:6
-msgid "Details"
-msgstr "Detalls"
-
-#: pkg/shell/index.html.h:32
-msgid "Unlock Key"
-msgstr ""
-
-#: pkg/shell/index.html.h:33 pkg/users/index.html.h:23
-msgid "Old Password"
-msgstr "Contrasenya antiga"
-
-#: pkg/shell/index.html.h:34 pkg/users/index.html.h:24
-msgid "New Password"
-msgstr "Contrasenya nova"
-
-#: pkg/shell/index.html.h:35 pkg/users/index.html.h:19
-msgid "Confirm"
-msgstr "Confirmació"
-
-#: pkg/shell/index.html.h:36
-msgid "Change Password"
-msgstr "Canvia la contrasenya"
-
-#: pkg/shell/index.html.h:38 pkg/shell/stub.html.h:20
-msgid ""
-"\n"
-"                Tools\n"
-"              "
-msgstr ""
-"\n"
-"                Eines\n"
-"              "
-
-#: pkg/shell/index.html.h:41 pkg/shell/stub.html.h:23
-#: pkg/shell/simple.html.h:24
-msgid "Reconnect"
-msgstr "Torna a connectar"
-
-#: pkg/shell/index.html.h:42 pkg/shell/stub.html.h:24
-msgid "Troubleshoot"
-msgstr "Soluciona el problema"
-
-#: pkg/shell/simple.html.h:18
-msgid ""
-"\n"
-"              Try to reconnect\n"
-"            "
-msgstr ""
-"\n"
-"              Prova a tornar a connectar\n"
-"            "
-
-#: pkg/shell/simple.html.h:21
-msgid ""
-"\n"
-"              Log in again\n"
-"            "
-msgstr ""
-"\n"
-"              Torna a iniciar la sessió\n"
-"            "
-
-#: pkg/ostree/index.html.h:1
-msgid "Software Updates"
-msgstr "Actualitzacions de programari"
-
-#: pkg/ostree/index.html.h:2
-msgid "Check for updates"
-msgstr "Comprova si hi ha actualitzacions"
-
-#: pkg/ostree/index.html.h:3
-msgid ""
-"\n"
-"                    Update and reboot\n"
-"                "
-msgstr ""
-"\n"
-"                    Actualitza i reinicia\n"
-"                "
-
-#: pkg/ostree/index.html.h:6
-msgid "Roll back and reboot"
-msgstr ""
-
-#: pkg/ostree/index.html.h:8
-msgid ""
-"\n"
-"                    Default\n"
-"                  "
-msgstr ""
-"\n"
-"                    Per defecte\n"
-"                  "
-
-#: pkg/ostree/index.html.h:11
-msgid ""
-"\n"
-"                    Available\n"
-"                  "
-msgstr ""
-"\n"
-"                    Disponible\n"
-"                  "
-
-#: pkg/ostree/index.html.h:16
-msgid "Tree"
-msgstr "Arbre"
-
-#: pkg/ostree/index.html.h:17
-msgid "Packages"
-msgstr "Paquets"
-
-#: pkg/ostree/index.html.h:20
-msgid "Released"
-msgstr ""
-
-#: pkg/ostree/index.html.h:21
-msgid "Additions"
-msgstr "Addicions"
-
-#: pkg/ostree/index.html.h:22
-msgid "Removals"
-msgstr "Supressions"
-
-#: pkg/ostree/index.html.h:23
-msgid "Updates"
-msgstr "Actualitzacions"
-
-#: pkg/ostree/index.html.h:24
-msgid "Downgrades"
-msgstr "Reversions"
-
-#: pkg/ostree/index.html.h:25
-msgid ""
-"\n"
-"                    This deployment contains the same packages as your "
-"currently booted system\n"
-"                "
-msgstr ""
-"\n"
-"                    Aquest desplegament conté els mateixos paquets que el "
-"sistema arrencat actualment\n"
-"                "
-
-#: pkg/ostree/index.html.h:28
-msgid "Operating System Updates"
-msgstr "Actualitzacions del sistema operatiu"
-
-#: pkg/ostree/index.html.h:29
-msgid "Connecting"
-msgstr "S'està connectant"
-
-#: pkg/ostree/index.html.h:30
-msgid "Unable to communicate with OSTree"
-msgstr "No es pot comunicar amb OSTree"
-
-#: pkg/ostree/index.html.h:31
-msgid "No Deployments"
-msgstr "Sense desplegaments"
-
-#: pkg/ostree/index.html.h:32
-msgid ""
-"\n"
-"                    Reconnect\n"
-"                "
-msgstr ""
-"\n"
-"                    Torna a connectar\n"
-"                "
-
-#: pkg/selinux/setroubleshoot.html.h:1
-msgid "SELinux Troubleshoot"
-msgstr ""
-
-#: pkg/machines/index.html.h:1
-msgid "Virtual Machines Management"
-msgstr ""
-
-#: pkg/storaged/index.html.h:1
-msgid "Storage"
-msgstr "Emmagatzematge"
-
-#: pkg/storaged/index.html.h:2
-msgid "The \"storaged\" API is not available on this system."
-msgstr "L'API «storaged» no està disponible en aquest sistema."
-
-#: pkg/storaged/index.html.h:3
-msgid "Start Multipath"
-msgstr "Inicia el multicamí"
-
-#: pkg/storaged/index.html.h:4
-msgid ""
-"\n"
-"        There are devices with multiple paths on the system, but the "
-"multipath service is not running.\n"
-"      "
-msgstr ""
-"\n"
-"        Hi ha dispositius amb diversos camins al sistema, però no s'està "
-"executant el servei de multicamí.\n"
-"      "
-
-#: pkg/storaged/index.html.h:7
-msgid "RAID Devices"
-msgstr "Dispositius RAID"
-
-#: pkg/storaged/index.html.h:8
-msgid "No storage set up as RAID"
-msgstr "Cap emmagatgematge preparat com a RAID"
-
-#: pkg/storaged/index.html.h:9
-msgid "Volume Groups"
-msgstr "Grups de volums"
-
-#: pkg/storaged/index.html.h:10
-msgid "No volume groups created"
-msgstr "Cap grup de volums creat"
-
-#: pkg/storaged/index.html.h:11
-msgid "iSCSI Targets"
-msgstr "Destinacions iSCSI"
-
-#: pkg/storaged/index.html.h:12
-msgid "{{Address}}:{{Port}}"
-msgstr "{{Address}}:{{Port}}"
-
-#: pkg/storaged/index.html.h:13
-msgid "No iSCSI targets set up"
-msgstr "Sense destinacions iSCSI preparades"
-
-#: pkg/storaged/index.html.h:14
-msgid "Drives"
-msgstr "Unitats"
-
-#: pkg/storaged/index.html.h:15
-msgid "No drives attached"
-msgstr "Sense unitats connectades"
-
-#: pkg/storaged/index.html.h:16
-msgid "Other Devices"
-msgstr "Altres dispositius"
-
-#: pkg/storaged/index.html.h:17
-msgid "Filesystems"
-msgstr "Sistemes de fitxers"
-
-#: pkg/storaged/index.html.h:21
-msgid "Jobs"
-msgstr "Treballs"
-
-#: pkg/storaged/index.html.h:23 pkg/networkmanager/index.html.h:3
-msgid "Go to now"
-msgstr "Vés a ara"
-
-#: pkg/storaged/index.html.h:24 pkg/networkmanager/index.html.h:4
-msgid "5 minutes"
-msgstr "5 minuts"
-
-#: pkg/storaged/index.html.h:25 pkg/networkmanager/index.html.h:5
-msgid "1 hour"
-msgstr "1 hora"
-
-#: pkg/storaged/index.html.h:26 pkg/networkmanager/index.html.h:6
-msgid "6 hours"
-msgstr "6 hores"
-
-#: pkg/storaged/index.html.h:27 pkg/networkmanager/index.html.h:7
-msgid "1 day"
-msgstr "1 dia"
-
-#: pkg/storaged/index.html.h:28 pkg/networkmanager/index.html.h:8
-msgid "1 week"
-msgstr "1 setmana"
-
-#: pkg/storaged/index.html.h:29
-msgid "Reading"
-msgstr "Lectura"
-
-#: pkg/storaged/index.html.h:30
-msgid "Writing"
-msgstr "Escriptura"
-
-#: pkg/storaged/index.html.h:31
-msgid "Storage Logs"
-msgstr "Registres de l'emmagatzematge"
-
-#: pkg/storaged/index.html.h:32
-msgid "Create partition table"
-msgstr "Crea la taula de particions"
-
-#: pkg/storaged/index.html.h:34
-msgid "Block Device"
-msgstr "Dispositiu de blocs"
-
-#: pkg/storaged/index.html.h:40
-msgid "No media inserted"
-msgstr "Sense mitjans inserits"
-
-#: pkg/storaged/index.html.h:42
-msgid "DISK IS FAILING"
-msgstr "EL DISC ESTÀ FALLANT"
-
-#: pkg/storaged/index.html.h:43
-msgid "Disk is OK"
-msgstr "El disc està bé"
-
-#: pkg/storaged/index.html.h:46
-msgid "The RAID Array is in a degraded state"
-msgstr ""
-
-#: pkg/storaged/index.html.h:47
-msgid "RAID Device"
-msgstr "Dispositiu RAID"
-
-#: pkg/storaged/index.html.h:56
-msgid "Volume Group"
-msgstr "Grup de volums"
-
-#: pkg/storaged/index.html.h:57
-msgid "Physical Volumes"
-msgstr "Volums físics"
-
-#: pkg/storaged/index.html.h:58
-msgid "Storage Log"
-msgstr "Registre de l'emmagatzematge"
-
-#: pkg/realmd/operation.html.h:1
-msgid "Domain Address"
-msgstr "Adreça del domini"
-
-#: pkg/realmd/operation.html.h:2
-msgid "Computer OU"
-msgstr "OU de l'ordinador"
-
-#: pkg/realmd/operation.html.h:4 pkg/users/index.html.h:11
-msgid "User Name"
-msgstr "Nom d'usuari"
-
-#: pkg/realmd/operation.html.h:5
-msgid "User Password"
-msgstr "Contrasenya d'usuari"
-
-#: pkg/realmd/operation.html.h:6
-msgid "Domain Administrator Name"
-msgstr "Nom de l'administrador del domini"
-
-#: pkg/realmd/operation.html.h:7
-msgid "Domain Administrator Password"
-msgstr "Contrasenya de l'administrador del domini"
-
-#: pkg/realmd/operation.html.h:8
-msgid "One Time Password"
-msgstr "Contrasenya d'un sol cop"
-
-#: pkg/realmd/operation.html.h:9
-msgid "This may take a while"
-msgstr "Això pot trigar una estona"
-
-#: pkg/docker/index.html.h:1 pkg/kubernetes/index.html.h:4
-#: pkg/kubernetes/views/containers-listing.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:6
-#: pkg/kubernetes/views/dashboard-page.html.h:17
-msgid "Containers"
-msgstr "Contenidors"
-
-#: pkg/docker/index.html.h:2
-msgid "Connecting to Docker"
-msgstr "S'està connectant al Docker"
-
-#: pkg/docker/index.html.h:3
-msgid "Not authorized to access Docker on this system"
-msgstr "No s'autoritza l'accés Docker en aquest sistema"
-
-#: pkg/docker/index.html.h:4
-msgid "Docker is not installed or activated on the system"
-msgstr "Docker no està activat o instal·lat al sistema"
-
-#: pkg/docker/index.html.h:5
-msgid "Can&rsquo;t connect to Docker"
-msgstr "No es pot connectar a Docker"
-
-#: pkg/docker/index.html.h:6
-msgid "Start Docker"
-msgstr "Inicia Docker"
-
-#: pkg/docker/index.html.h:7
-msgid "Try again"
-msgstr "Torna-ho a intentar"
-
-#: pkg/docker/index.html.h:8
-msgid "Combined CPU usage"
-msgstr "Ús combinat de CPU"
-
-#: pkg/docker/index.html.h:9
-msgid "Combined memory usage"
-msgstr "Ús combinat de memòria"
-
-#: pkg/docker/index.html.h:10
-#, fuzzy
-msgid "Show all containers"
-msgstr "Mostra totes les imatges"
-
-#: pkg/docker/index.html.h:11
-msgid "IP Address:"
-msgstr "Adreça IP:"
-
-#: pkg/docker/index.html.h:12
-msgid "IP Prefix Length:"
-msgstr ""
-
-#: pkg/docker/index.html.h:13
-msgid "Gateway:"
-msgstr ""
-
-#: pkg/docker/index.html.h:14
-msgid "MAC Address:"
-msgstr ""
-
-#: pkg/docker/index.html.h:15 pkg/kubernetes/views/image-page.html.h:1
-msgid "Show all images"
-msgstr "Mostra totes les imatges"
-
-#: pkg/docker/index.html.h:16 pkg/kubernetes/index.html.h:2
-#: pkg/kubernetes/registry.html.h:2
-msgid "Overview"
-msgstr ""
-
-#: pkg/docker/index.html.h:17
-msgid "Reset"
-msgstr "Restableix"
-
-#: pkg/docker/index.html.h:18
-msgid "Storage pool"
-msgstr ""
-
-#: pkg/docker/index.html.h:19
-msgid "Additional Storage"
-msgstr ""
-
-#: pkg/docker/index.html.h:20
-msgid "TCP"
-msgstr "TCP"
-
-#: pkg/docker/index.html.h:21
-msgid "{{host_port_label}}"
-msgstr "{{host_port_label}}"
-
-#: pkg/docker/index.html.h:22
-msgid "{{host_volume_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:24
-msgid "ReadWrite"
-msgstr ""
-
-#: pkg/docker/index.html.h:25
-msgid "ReadOnly"
-msgstr ""
-
-#: pkg/docker/index.html.h:26
-msgid "{{envvar_key_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:27
-msgid "{{envvar_value_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:28
-msgid "select container"
-msgstr "selecciona el contenidor"
-
-#: pkg/docker/index.html.h:29
-msgid "{{alias_label}}"
-msgstr "{{alias_label}}"
-
-#: pkg/docker/index.html.h:30 pkg/kubernetes/views/image-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:2
-#: pkg/kubernetes/views/image-page.html.h:2
-msgid "Image"
-msgstr "Imatge"
-
-#: pkg/docker/index.html.h:31
-msgid "Container Name"
-msgstr "Nom del contenidor"
-
-#: pkg/docker/index.html.h:33
-msgid "Memory limit"
-msgstr "Límit de memòria"
-
-#: pkg/docker/index.html.h:34
-msgid "MiB"
-msgstr "MiB"
-
-#: pkg/docker/index.html.h:35
-msgid "CPU priority"
-msgstr "Prioritat de CPU"
-
-#: pkg/docker/index.html.h:36
-msgid "shares"
-msgstr ""
-
-#: pkg/docker/index.html.h:37
-msgid "With terminal"
-msgstr "Amb el terminal"
-
-#: pkg/docker/index.html.h:38
-msgid "Links"
-msgstr "Enllaços"
-
-#: pkg/docker/index.html.h:40
-msgid "Expose container ports"
-msgstr ""
-
-#: pkg/docker/index.html.h:41 pkg/kubernetes/index.html.h:7
-#: pkg/kubernetes/views/image-config.html.h:9
-#: pkg/kubernetes/views/pod-page.html.h:3
-#: pkg/kubernetes/views/dashboard-page.html.h:4
-msgid "Volumes"
-msgstr "Volums"
-
-#: pkg/docker/index.html.h:42
-msgid "Mount container volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:43 pkg/kubernetes/views/image-config.html.h:6
-#: pkg/kubernetes/views/container-body.html.h:9
-msgid "Environment"
-msgstr "Entorn"
-
-#: pkg/docker/index.html.h:44
-msgid "Set container environment variables"
-msgstr ""
-
-#: pkg/docker/index.html.h:45 pkg/kubernetes/views/pod-body.html.h:4
-msgid "Restart Policy"
-msgstr "Reinicia la política"
-
-#: pkg/docker/index.html.h:47
-msgid "On Failure"
-msgstr ""
-
-#: pkg/docker/index.html.h:50
-msgid "Retries:"
-msgstr ""
-
-#: pkg/docker/index.html.h:51 pkg/users/index.html.h:26
-#: pkg/networkmanager/index.html.h:52
-msgid ""
-"\n"
-"            Cancel\n"
-"          "
-msgstr ""
-"\n"
-"            Cancel·la\n"
-"          "
-
-#: pkg/docker/index.html.h:54
-msgid ""
-"\n"
-"            Run\n"
-"          "
-msgstr ""
-"\n"
-"            Executa\n"
-"          "
-
-#: pkg/docker/index.html.h:57
-msgid ""
-"\n"
-"            Download\n"
-"          "
-msgstr ""
-"\n"
-"            Baixa\n"
-"          "
-
-#: pkg/docker/index.html.h:60
-msgid ""
-"\n"
-"            Change\n"
-"          "
-msgstr ""
-"\n"
-"            Canvia\n"
-"          "
-
-#: pkg/docker/index.html.h:63
-msgid "Repository"
-msgstr "Dipòsit"
-
-#: pkg/docker/index.html.h:64
-msgid "Tag"
-msgstr "Tag"
-
-#: pkg/docker/index.html.h:65 pkg/kubernetes/views/image-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:5
-msgid "Author"
-msgstr "Autor"
-
-#: pkg/docker/index.html.h:66
-msgid ""
-"\n"
-"            Commit\n"
-"          "
-msgstr ""
-"\n"
-"            Consigna\n"
-"          "
-
-#: pkg/users/index.html.h:1
-msgid "Local Accounts"
-msgstr "Comptes locals"
-
-#: pkg/users/index.html.h:2
-msgid ""
-"\n"
-"            Close\n"
-"          "
-msgstr ""
-"\n"
-"            Tanca\n"
-"          "
-
-#: pkg/users/index.html.h:5
-msgid "Create New Account"
-msgstr "Crea un nou compte"
-
-#: pkg/users/index.html.h:6
-msgid "Account not available or cannot be edited."
-msgstr "El compte no està disponible o no es pot editar."
-
-#: pkg/users/index.html.h:7
-msgid "Accounts"
-msgstr "Comptes"
-
-#: pkg/users/index.html.h:8
-msgid "Terminate Session"
-msgstr "Acaba la sessió"
-
-#: pkg/users/index.html.h:10
-msgid "Full Name"
-msgstr "Nom complet"
-
-#: pkg/users/index.html.h:12
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:3
-#: pkg/kubernetes/views/project-body.html.h:2
-msgid "Roles"
-msgstr "Rols"
-
-#: pkg/users/index.html.h:13
-msgid "Last Login"
-msgstr "Últim inici de sessió"
-
-#: pkg/users/index.html.h:14
-msgid "Access"
-msgstr "Accés"
-
-#: pkg/users/index.html.h:15
-msgid "Lock Account"
-msgstr "Bloqueja el compte"
-
-#: pkg/users/index.html.h:17
-msgid "Set Password"
-msgstr "Estableix la contrasenya"
-
-#: pkg/users/index.html.h:18
-msgid "Authorized Public SSH Keys"
-msgstr "Claus SSH públiques autoritzades"
-
-#: pkg/users/index.html.h:20
-msgid ""
-"\n"
-"            Create\n"
-"          "
-msgstr ""
-"\n"
-"            Crea\n"
-"          "
-
-#: pkg/users/index.html.h:25
-msgid "Confirm New Password"
-msgstr "Confirmació de la nova contrasenya"
-
-#: pkg/users/index.html.h:29
-msgid ""
-"\n"
-"            Set\n"
-"          "
-msgstr ""
-"\n"
-"            Estableix\n"
-"          "
-
-#: pkg/users/index.html.h:32
-msgid "Delete Files"
-msgstr "Suprimeix els fitxers"
-
-#: pkg/users/index.html.h:33 pkg/networkmanager/index.html.h:48
-msgid ""
-"\n"
-"            Delete\n"
-"          "
-msgstr ""
-"\n"
-"            Suprimeix\n"
-"          "
-
-#: pkg/users/index.html.h:36
-msgid "Unnamed"
-msgstr "Sense nom"
-
-#: pkg/users/index.html.h:37
-msgid "Invalid key"
-msgstr "Clau no vàlida"
-
-#: pkg/users/index.html.h:38
-msgid "There are no authorized public keys for this account."
-msgstr "No hi ha cap clau pública autoritzada per aquest compte."
-
-#: pkg/users/index.html.h:39
+#: pkg/users/index.html:335
 msgid ""
 "You do not have permission to view the authorized public keys for this "
 "account."
@@ -4586,1447 +6161,14 @@ msgstr ""
 "No teniu el permís per visualitzar les claus públiques autoritzades per "
 "aquest compte."
 
-#: pkg/users/index.html.h:40
-msgid "Failed to load authorized keys."
-msgstr "Ha fallat la càrrega de les claus autoritzades."
-
-#: pkg/users/index.html.h:41
-msgid "Add public key"
-msgstr "Afegeix una clau pública"
-
-#: pkg/users/index.html.h:42
-msgid ""
-"\n"
-"            Add key\n"
-"          "
-msgstr ""
-"\n"
-"            Afegeix una clau\n"
-"          "
-
-#: pkg/sosreport/index.html.h:1
-msgid "Diagnostic reports"
-msgstr "Informes de diagnòstic"
-
-#: pkg/sosreport/index.html.h:2
-msgid ""
-"\n"
-"        This tool will collect system configuration and diagnostic\n"
-"        information from this system for use with diagnosing problems\n"
-"        with the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:7
-msgid ""
-"\n"
-"        The collected information will be stored locally on the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:10
-msgid "Create report"
-msgstr "Crea l'informe"
-
-#: pkg/sosreport/index.html.h:11
-msgid "Create diagnostic report"
-msgstr "Crea l'informe de diagnòstic"
-
-#: pkg/sosreport/index.html.h:12
-msgid ""
-"\n"
-"                The generated archive contains data considered\n"
-"                sensitive and its content should be reviewed by the\n"
-"                originating organization before being passed to any\n"
-"                third party.\n"
-"              "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:18
-msgid "Generating report"
-msgstr "S'està generant l'informe"
-
-#: pkg/sosreport/index.html.h:19
-msgid "Done!"
-msgstr "Fet!"
-
-#: pkg/networkmanager/index.html.h:1
-msgid "Networking"
-msgstr "Xarxa"
-
-#: pkg/networkmanager/index.html.h:2
-msgid "Testing connection"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:9
-msgid "Sending"
-msgstr "Enviament"
-
-#: pkg/networkmanager/index.html.h:10
-msgid "Receiving"
-msgstr "Recepció"
-
-#: pkg/networkmanager/index.html.h:11
-msgid "Interfaces"
-msgstr "Interfícies"
-
-#: pkg/networkmanager/index.html.h:12
-msgid "Add Bond"
-msgstr "Afegeix un enllaç"
-
-#: pkg/networkmanager/index.html.h:13
+#: pkg/docker/storage.jsx:482
 #, fuzzy
-msgid "Add Team"
-msgstr "Afegeix un membre"
-
-#: pkg/networkmanager/index.html.h:14
-msgid "Add Bridge"
-msgstr "Afegeix un pont"
-
-#: pkg/networkmanager/index.html.h:15
-msgid "Add VLAN"
-msgstr "Afegeix una VLAN"
-
-#: pkg/networkmanager/index.html.h:17
-msgid "IP Address"
-msgstr "Adreça IP"
-
-#: pkg/networkmanager/index.html.h:18
-#, fuzzy
-msgid "Unmanaged Interfaces"
-msgstr "Interfícies"
-
-#: pkg/networkmanager/index.html.h:19
-msgid "Networking Logs"
-msgstr "Registres de la xarxa"
-
-#: pkg/networkmanager/index.html.h:20
-msgid "Parent"
-msgstr "Pare"
-
-#: pkg/networkmanager/index.html.h:21
-msgid "VLAN Id"
-msgstr "Id. VLAN"
-
-#: pkg/networkmanager/index.html.h:23
-msgid "Set to"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:25
-msgid "Spanning Tree Protocol (STP)"
-msgstr "STP (Spanning Tree Protocol)"
-
-#: pkg/networkmanager/index.html.h:26
-msgid "STP Priority"
-msgstr "Prioritat STP"
-
-#: pkg/networkmanager/index.html.h:27
-msgid "STP Forward delay"
-msgstr "Retard del reenviament STP"
-
-#: pkg/networkmanager/index.html.h:28
-msgid "STP Hello time"
-msgstr "STP Hello time"
-
-#: pkg/networkmanager/index.html.h:29
-msgid "STP Maximum message age"
-msgstr "Envelliment màxim del missatge STP"
-
-#: pkg/networkmanager/index.html.h:30
-msgid "Priority"
-msgstr "Prioritat"
-
-#: pkg/networkmanager/index.html.h:31
-msgid "Path cost"
-msgstr "Cost del camí"
-
-#: pkg/networkmanager/index.html.h:32
-msgid "Hair Pin mode"
-msgstr "Mode hairpin"
-
-#: pkg/networkmanager/index.html.h:34
-msgid "Mode"
-msgstr "Mode"
-
-#: pkg/networkmanager/index.html.h:35
-msgid "Primary"
-msgstr "Principal"
-
-#: pkg/networkmanager/index.html.h:36
-msgid "Link Monitoring"
-msgstr "Monitoratge de l'enllaç"
-
-#: pkg/networkmanager/index.html.h:37
-msgid "Monitoring Interval"
-msgstr "Interval del monitoratge"
-
-#: pkg/networkmanager/index.html.h:38
-msgid "Monitoring Targets"
-msgstr "Objectius del monitoratge"
-
-#: pkg/networkmanager/index.html.h:39
-msgid "Link up delay"
-msgstr "Retard de l'aixecament de l'enllaç"
-
-#: pkg/networkmanager/index.html.h:40
-msgid "Link down delay"
-msgstr "Retard del baixament de l'enllaç"
-
-#: pkg/networkmanager/index.html.h:41
-#, fuzzy
-msgid "Runner"
-msgstr "En execució"
-
-#: pkg/networkmanager/index.html.h:42
-msgid "Balancer"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:43
-#, fuzzy
-msgid "Link Watch"
-msgstr "Enllaça localment"
-
-#: pkg/networkmanager/index.html.h:44
-#, fuzzy
-msgid "Ping Interval"
-msgstr "Interval del monitoratge"
-
-#: pkg/networkmanager/index.html.h:45
-#, fuzzy
-msgid "Ping Target"
-msgstr "S'està bloquejant $target"
-
-#: pkg/networkmanager/index.html.h:46
-msgid "Sticky"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:47
-msgid "LACP Key"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:51
-msgid "IP Settings"
-msgstr "Ajusts de la IP"
-
-#: pkg/networkmanager/index.html.h:55
-msgid ""
-"\n"
-"            Apply\n"
-"          "
-msgstr ""
-"\n"
-"            Aplica\n"
-"          "
-
-#: pkg/networkmanager/index.html.h:58
-msgid "Bond Settings"
-msgstr "Ajusts de l'enllaç"
-
-#: pkg/networkmanager/index.html.h:59
-#, fuzzy
-msgid "Team Settings"
-msgstr "Ajusts de la IP"
-
-#: pkg/networkmanager/index.html.h:60
-#, fuzzy
-msgid "Team Port Settings"
-msgstr "Ajusts del port del pont"
-
-#: pkg/networkmanager/index.html.h:61
-msgid "Bridge Settings"
-msgstr "Ajusts del pont"
-
-#: pkg/networkmanager/index.html.h:62
-msgid "Bridge Port Settings"
-msgstr "Ajusts del port del pont"
-
-#: pkg/networkmanager/index.html.h:63
-msgid "VLAN Settings"
-msgstr "Ajusts de la VLAN"
-
-#: pkg/networkmanager/index.html.h:64
-msgid "Ethernet MTU"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:66
-#, fuzzy
-msgid "Connection will be lost"
-msgstr "La connexió ha excedit el temps."
-
-#: pkg/kubernetes/index.html.h:1
-msgid "Kubernetes Cluster"
-msgstr "Clúster Kubernetes"
-
-#: pkg/kubernetes/index.html.h:3 pkg/kubernetes/views/dashboard-page.html.h:8
-#: pkg/kubernetes/views/nodes-page.html.h:4
-msgid "Nodes"
-msgstr "Nodes"
-
-#: pkg/kubernetes/index.html.h:5
-msgid "Topology"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:8 pkg/kubernetes/registry.html.h:3
-#: pkg/kubernetes/views/image-listing.html.h:2
-#: pkg/kubernetes/views/imagestream-page.html.h:3
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:5
-msgid "Images"
-msgstr "Imatges"
-
-#: pkg/kubernetes/index.html.h:9 pkg/kubernetes/registry.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:2
-#: pkg/kubernetes/views/project-listing.html.h:2
-#: pkg/kubernetes/views/user-delete.html.h:2
-msgid "Projects"
-msgstr "Projectes"
-
-#: pkg/kubernetes/index.html.h:11 pkg/kubernetes/registry.html.h:6
-msgid "Couldn't connect to server"
-msgstr "No s'ha pogut connectar al servidor"
-
-#: pkg/kubernetes/index.html.h:12 pkg/kubernetes/registry.html.h:7
-msgid ""
-"\n"
-"                Reconnect\n"
-"            "
-msgstr ""
-"\n"
-"                Torna a connectar\n"
-"            "
-
-#: pkg/kubernetes/index.html.h:15
-msgid ""
-"\n"
-"                Troubleshoot\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/registry.html.h:1
-msgid "Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:1
-#: pkg/kubernetes/views/service-body.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:1
-#: pkg/kubernetes/views/containers-listing.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:9
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:18
-#: pkg/kubernetes/views/route-body.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:5
-#: pkg/kubernetes/views/imagestream-modify.html.h:4
-msgid "Project"
-msgstr "Projecte"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:2
-#: pkg/kubernetes/views/service-body.html.h:2
-#: pkg/kubernetes/views/pod-body.html.h:2
-#: pkg/kubernetes/views/containers-listing.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:10
-#: pkg/kubernetes/views/pv-claim.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:19
-#: pkg/kubernetes/views/route-body.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:6
-msgid "Namespace"
-msgstr "Espai de noms"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:3
-#: pkg/kubernetes/views/pod-body.html.h:3
-#: pkg/kubernetes/views/node-body.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:3
-#: pkg/kubernetes/views/route-body.html.h:3
-msgid "Created"
-msgstr "Creat"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:4
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:17
-msgid "Replicas"
-msgstr "Rèpliques"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:5
-#: pkg/kubernetes/views/service-body.html.h:9
-#: pkg/kubernetes/views/pod-body.html.h:10
-#: pkg/kubernetes/views/node-body.html.h:12
-#: pkg/kubernetes/views/image-meta.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:8
-#: pkg/kubernetes/views/route-body.html.h:8
-msgid "Labels"
-msgstr "Etiquetes"
-
-#: pkg/kubernetes/views/service-body.html.h:4
-#: pkg/kubernetes/views/node-body.html.h:3
-msgid "IP"
-msgstr "IP"
-
-#: pkg/kubernetes/views/service-body.html.h:8
-msgid "Session Affinity"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:1
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:10
-msgid "New image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:3
-#: pkg/kubernetes/views/image-body.html.h:10
-#: pkg/kubernetes/views/imagestream-modify.html.h:7
-msgid "Tags"
-msgstr "Etiquetes"
-
-#: pkg/kubernetes/views/image-listing.html.h:5
-msgid "Last Updated"
-msgstr "Últim cop actualitzat"
-
-#: pkg/kubernetes/views/image-listing.html.h:6
-msgid "No image streams are present."
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:1
-msgid "Delete Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:2
-msgid "Do you want to delete this Node?"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:3
-msgid " 1\">Do you want to delete the following Nodes?"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-container.html.h:1
-msgid "Show all Pod Containers"
-msgstr ""
-
-#: pkg/kubernetes/views/image-panel.html.h:3
-#: pkg/kubernetes/views/imagestream-page.html.h:4
-#: pkg/kubernetes/views/image-page.html.h:4
-msgid "Metadata"
-msgstr "Metadades"
-
-#: pkg/kubernetes/views/node-panel.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:8
-#: pkg/kubernetes/views/containers-listing.html.h:6
-#: pkg/kubernetes/views/node-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:11
-msgid "Node"
-msgstr "Node"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:1
-msgid "Show all Replication Controllers"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:2
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:5
-msgid "Replication Controller"
-msgstr "Controlador de replicació"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:2
-#: pkg/kubernetes/views/pv-claim.html.h:9
-#: pkg/kubernetes/views/dashboard-page.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:18
-msgid "Pods"
-msgstr "Pods"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:2
-msgid "Template"
-msgstr "Plantilla"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:5
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/group-delete.html.h:1
-msgid "Remove Group"
-msgstr "Suprimeix el grup"
-
-#: pkg/kubernetes/views/group-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:5
-#: pkg/kubernetes/views/user-group-remove.html.h:3
-msgid "Remove"
-msgstr "Elimina"
-
-#: pkg/kubernetes/views/pvc-delete.html.h:1
-msgid "Delete Persistent Volume Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:2
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:3
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:5
-msgid "Service Account"
-msgstr "Compte del servei"
-
-#: pkg/kubernetes/views/pod-body.html.h:6
-msgid "DNS Policy"
-msgstr "Política del DNS"
-
-#: pkg/kubernetes/views/pod-body.html.h:7
-msgid "Phase"
-msgstr "Fase"
-
-#: pkg/kubernetes/views/pod-body.html.h:9
-msgid "Pod Address"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:5
-msgid "OS"
-msgstr "SO"
-
-#: pkg/kubernetes/views/node-body.html.h:7
-msgid "Boot ID"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:8
-msgid "Kernel Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:9
-msgid "Container Runtime Version"
-msgstr "Versió de l'entorn d'execució del contenidor"
-
-#: pkg/kubernetes/views/node-body.html.h:10
-msgid "Kubelet Version"
-msgstr "Versió de Kubelet"
-
-#: pkg/kubernetes/views/node-body.html.h:11
-msgid "Proxy Version"
-msgstr "Versió del servidor intermediari"
-
-#: pkg/kubernetes/views/node-body.html.h:13
-#: pkg/kubernetes/views/route-body.html.h:9
-msgid "none"
-msgstr "cap"
-
-#: pkg/kubernetes/views/node-body.html.h:17
-msgid "Reason"
-msgstr "Raó"
-
-#: pkg/kubernetes/views/node-body.html.h:18
-#: pkg/kubernetes/views/pv-claim.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:6 pkg/kubernetes/views/pv-body.html.h:6
-msgid "Message"
-msgstr "Missatge"
-
-#: pkg/kubernetes/views/node-body.html.h:19
-msgid "Last Heartbeat"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:20
-msgid "Last Status Change"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:21
-#: pkg/kubernetes/views/image-meta.html.h:3
-#: pkg/kubernetes/views/imagestream-meta.html.h:1
-#: pkg/kubernetes/views/route-body.html.h:10
-msgid "Annotations"
-msgstr "Anotacions"
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:1
-msgid "Remove Role"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:2
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member "
-"{{ fields.member.metadata.name }}?"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:1
-msgid "New Project"
-msgstr "Nou projecte"
-
-#: pkg/kubernetes/views/project-listing.html.h:6
-msgid "No projects are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:7
-msgid "New Group"
-msgstr "Nou grup"
-
-#: pkg/kubernetes/views/project-listing.html.h:8
-#: pkg/kubernetes/views/user-delete.html.h:3
-msgid "Groups"
-msgstr "Grups"
-
-#: pkg/kubernetes/views/project-listing.html.h:9
-msgid "No groups are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:10
-#: pkg/kubernetes/views/add-user-dialog.html.h:1
-msgid "Add User"
-msgstr "Afegeix un usuari"
-
-#: pkg/kubernetes/views/project-listing.html.h:11
-msgid "Users"
-msgstr "Usuaris"
-
-#: pkg/kubernetes/views/project-listing.html.h:12
-msgid "Identity"
-msgstr "Identitat"
-
-#: pkg/kubernetes/views/project-listing.html.h:13
-msgid "Member of"
-msgstr "Membre de"
-
-#: pkg/kubernetes/views/project-listing.html.h:14
-msgid "No users are present."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:1
-msgid "Cluster"
-msgstr "Clúster"
-
-#: pkg/kubernetes/views/auth-form.html.h:2
-msgid "Add New Cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:4
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:3
-msgid "Skip Certificate Verification"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:5
-msgid "Requires Authentication"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:7
-msgid "Add New User"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:9
-msgid "Client Certificate"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:10
-msgid "Username"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:12
-msgid "Token"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:1
-msgid "Add Cluster Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:4
-msgid "Configuration"
-msgstr "Configuració"
-
-#: pkg/kubernetes/views/node-add.html.h:5
-msgid "Configure Kubelet and Proxy"
-msgstr "Configura el Kubelet i el servidor intermediari"
-
-#: pkg/kubernetes/views/node-add.html.h:6
-msgid "Configure Flannel networking"
-msgstr "Configura la xarxa Flannel"
-
-#: pkg/kubernetes/views/volume-body.html.h:1
-#: pkg/kubernetes/views/pvc-body.html.h:1
-msgid "Volume Type"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:2
-msgid "{{ volume | formatVolumeType }}"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:3
-msgid "PD Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:19
-msgid "Filesystem Type"
-msgstr "Tipus de sistema de fitxers"
-
-#: pkg/kubernetes/views/volume-body.html.h:6
-#: pkg/kubernetes/views/pv-modify.html.h:20
-msgid "Read Only"
-msgstr "Tan sols lectura"
-
-#: pkg/kubernetes/views/volume-body.html.h:7
-msgid "Volume ID"
-msgstr "Id. del volum"
-
-#: pkg/kubernetes/views/volume-body.html.h:8
-msgid "Repository URL"
-msgstr "URl del dipòsit"
-
-#: pkg/kubernetes/views/volume-body.html.h:9
-msgid "Revision"
-msgstr "Revisió"
-
-#: pkg/kubernetes/views/volume-body.html.h:10
-#: pkg/kubernetes/views/image-config.html.h:3
-msgid "Directory"
-msgstr "Directori"
-
-#: pkg/kubernetes/views/volume-body.html.h:12
-msgid "Medium"
-msgstr "Mitjà"
-
-#: pkg/kubernetes/views/volume-body.html.h:13
-#: pkg/kubernetes/views/pv-modify.html.h:14
-msgid "Path"
-msgstr "Camí"
-
-#: pkg/kubernetes/views/volume-body.html.h:14
-msgid "Endpoint Name"
-msgstr "Nom de l'extrem"
-
-#: pkg/kubernetes/views/volume-body.html.h:15
-#: pkg/kubernetes/views/pv-modify.html.h:13
-msgid "Volume Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:17
-msgid "Monitors"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:18
-msgid "Image Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:19
-msgid "Pool Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:21
-msgid "Key Ring Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:22
-msgid "Secret Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:23
-msgid "Target Portal"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:24
-#: pkg/kubernetes/views/pv-modify.html.h:16
-msgid "Qualified Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:25
-#: pkg/kubernetes/views/pv-modify.html.h:17
-msgid "Logical Unit Number"
-msgstr "Número de la unitat lògica"
-
-#: pkg/kubernetes/views/volume-body.html.h:26
-#: pkg/kubernetes/views/pv-modify.html.h:18
-msgid "Interface"
-msgstr "Interfície"
-
-#: pkg/kubernetes/views/volume-body.html.h:27
-msgid "Ceph Monitors"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:28
-msgid "Secret File"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:29
-msgid "Target World Wide Names"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:30
-msgid "Flocker Dataset Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:31
-msgid "Driver"
-msgstr "Controlador"
-
-#: pkg/kubernetes/views/volume-body.html.h:33
-msgid "Share Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:34
-msgid "Secret Name"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:2
-msgid "On Build"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:4
-msgid "Docker Version"
-msgstr "Versió de Docker"
-
-#: pkg/kubernetes/views/image-meta.html.h:5
-msgid "Image Layers"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:1
-#: pkg/kubernetes/views/user-page.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:1
-msgid "Show all Projects"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:2
-#: pkg/kubernetes/views/group-panel.html.h:1
-msgid "Group Members"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:3
-#: pkg/kubernetes/views/user-group-add.html.h:1
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:1
-#: pkg/kubernetes/views/group-panel.html.h:2
-#: pkg/kubernetes/views/project-body.html.h:10
-msgid "Add Member"
-msgstr "Afegeix un membre"
-
-#: pkg/kubernetes/views/group-page.html.h:4
-msgid "The group '{{ groupName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/containers-listing.html.h:3
-#: pkg/kubernetes/views/pod-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:2
-msgid "Pod"
-msgstr "Pod"
-
-#: pkg/kubernetes/views/user-body.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:2
-msgid "Membership"
-msgstr "Pertinença"
-
-#: pkg/kubernetes/views/user-body.html.h:2
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:5
-#: pkg/kubernetes/views/user-panel.html.h:7
-msgid "Add Membership"
+msgid "You don't have permission to manage the Docker storage pool."
 msgstr ""
-
-#: pkg/kubernetes/views/user-group-add.html.h:2
-msgid ""
-"\n"
-"                        User\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:2
-msgid "User or Group"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-panel.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:4
-msgid "Mount Location"
-msgstr ""
-
-#: pkg/kubernetes/views/route-modify.html.h:1
-msgid "Adjust Route"
-msgstr "Ajusta la ruta"
-
-#: pkg/kubernetes/views/pv-page.html.h:1
-msgid "Show all Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:2 pkg/kubernetes/views/pvc-body.html.h:3
-#: pkg/kubernetes/views/pv-panel.html.h:1
-msgid "Volume"
-msgstr "Volum"
-
-#: pkg/kubernetes/views/pv-page.html.h:3 pkg/kubernetes/views/pv-panel.html.h:2
-msgid "Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:4
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:1
-msgid "Remove image tag"
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:2
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:1
-msgid "Run as"
-msgstr "Executa com"
-
-#: pkg/kubernetes/views/image-config.html.h:4
-msgid "Stop with"
-msgstr "Atura amb"
-
-#: pkg/kubernetes/views/pv-delete.html.h:1
-msgid "Delete Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:2
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:3
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
-"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
-"may cause issues with any pods depending on it."
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:3
-msgid "Identities"
-msgstr "Identitats"
-
-#: pkg/kubernetes/views/user-page.html.h:3
-msgid "The user '{{ userName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:1
-msgid "Show all Deployment Configs"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:1
-msgid "Deployment Config"
-msgstr "Configuració de desplegament"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:4
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/route-panel.html.h:1
-#: pkg/kubernetes/views/route-page.html.h:2
-msgid "Route"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:1
-msgid "Register New Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:2
-msgid "Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:7
-msgid "No volumes are present."
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:8
-msgid "Pending Volume Claims"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:12
-msgid "When"
-msgstr ""
-
-#: pkg/kubernetes/views/user-delete.html.h:1
-msgid "Remove User"
-msgstr "Suprimeix l'usuari"
-
-#: pkg/kubernetes/views/pv-claim.html.h:3
-#: pkg/kubernetes/views/pv-modify.html.h:10
-#: pkg/kubernetes/views/pvc-body.html.h:7 pkg/kubernetes/views/pv-body.html.h:2
-msgid "Access Modes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:4
-msgid "Requests"
-msgstr "Peticions"
-
-#: pkg/kubernetes/views/pv-claim.html.h:5
-msgid "This volume has not been claimed"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:10
-msgid "No Pods are using this claim"
-msgstr ""
-
-#: pkg/kubernetes/views/filter-project.html.h:1
-msgid "All Projects"
-msgstr "Tots els projectes"
-
-#: pkg/kubernetes/views/filter-project.html.h:2
-msgid "Project:"
-msgstr "Projecte:"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:5
-#: pkg/kubernetes/views/details-page.html.h:14
-msgid "Latest Version"
-msgstr "Última versió"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:6
-msgid "Deployment Causes"
-msgstr "Causes del desplegament"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:7
-msgid "Triggers"
-msgstr "Disparadors"
-
-#: pkg/kubernetes/views/item-delete.html.h:1
-msgid "Delete {{ item.kind }}"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:2
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:3
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:2
-#: pkg/kubernetes/views/user-modify.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:2
-msgid ""
-"\n"
-"                        Name\n"
-"                    "
-msgstr ""
-"\n"
-"                        Nom\n"
-"                    "
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:5
-#: pkg/kubernetes/views/user-modify.html.h:5
-msgid ""
-"\n"
-"                        Identity\n"
-"                    "
-msgstr ""
-"\n"
-"                        Identitat\n"
-"                    "
-
-#: pkg/kubernetes/views/project-body.html.h:1
-msgid "Project Members"
-msgstr "Membres del projecte"
-
-#: pkg/kubernetes/views/project-body.html.h:3
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:6
-msgid "Admin"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:7
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/container-panel.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:3
-msgid "Shell"
-msgstr "Shell"
-
-#: pkg/kubernetes/views/service-endpoint.html.h:1
-msgid "Pod Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:2
-msgid "No pods selected"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:3
-msgid "Pod Selector"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:1
-msgid "Add membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:2
-msgid ""
-"\n"
-"                        Group or Project\n"
-"                    "
-msgstr ""
-"\n"
-"                        Grup o projecte\n"
-"                    "
-
-#: pkg/kubernetes/views/user-add-membership.html.h:5
-msgid ""
-"\n"
-"                        Role\n"
-"                    "
-msgstr ""
-"\n"
-"                        Rol\n"
-"                    "
-
-#: pkg/kubernetes/views/deploy.html.h:1
-msgid "Deploy Application"
-msgstr "Desplega l'aplicació"
-
-#: pkg/kubernetes/views/deploy.html.h:3
-msgid "{{ selected.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:5
-#: pkg/kubernetes/views/dashboard-page.html.h:11
-msgid "Deploy"
-msgstr "Desplega"
-
-#: pkg/kubernetes/views/user-modify.html.h:1
-msgid "Change User"
-msgstr ""
-
-#: pkg/kubernetes/views/user-modify.html.h:9
-msgid "Modify"
-msgstr "Modifica"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:1
-#: pkg/kubernetes/views/project-modify.html.h:6
-msgid "Access Policy"
-msgstr "Política d'accés"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:2
-msgid ""
-"\n"
-"          Images may be pulled by anonymous users\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:5
-msgid ""
-"\n"
-"          Images may be pulled by any authenticated user or group\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:8
-msgid ""
-"\n"
-"          Images may only be pulled by specific users or groups\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:11
-msgid "Pull repository"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:13
-msgid "Image count"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:14
-msgid "{{stream.status.tags.length}}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:15
-msgid "To push to an image to this image stream:"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:1
-msgid "The node doesn't have enough disk space"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:2
-msgid "The node doesn't have enough free memory"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:1
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:2
-msgid "Register Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:4
-msgid "Warning:"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:5
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:7
-#: pkg/kubernetes/views/node-page.html.h:3
-#: pkg/kubernetes/views/pvc-body.html.h:10
-#: pkg/kubernetes/views/pv-body.html.h:3
-msgid "Capacity"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:8
-#: pkg/kubernetes/views/pv-body.html.h:1
-msgid "Reclaim Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:9
-msgid "{{ value }}"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:12
-msgid "Endpoint"
-msgstr "Extrem"
-
-#: pkg/kubernetes/views/pv-modify.html.h:15
-msgid "Target"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-dialog.html.h:1
-msgid "Connection Settings"
-msgstr "Ajusts de la connexió"
-
-#: pkg/kubernetes/views/auth-dialog.html.h:2
-msgid "Connection Error"
-msgstr "Error de connexió"
-
-#: pkg/kubernetes/views/image-body.html.h:2
-msgid "Summary"
-msgstr "Resum"
-
-#: pkg/kubernetes/views/image-body.html.h:4
-msgid "Source URL"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:7
-msgid "Built"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:8
-msgid "Digest"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:9
-msgid "Identifier"
-msgstr "Identificador"
-
-#: pkg/kubernetes/views/image-body.html.h:11
-msgid "To pull this image:"
-msgstr ""
-
-#: pkg/kubernetes/views/service-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:8
-#: pkg/kubernetes/views/service-page.html.h:2
-msgid "Service"
-msgstr "Servei"
-
-#: pkg/kubernetes/views/service-panel.html.h:2
-#: pkg/kubernetes/views/service-page.html.h:3
-msgid "Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:1
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:2
-msgid ""
-"You can bypass the certificate check, but any data you send to the server "
-"could be intercepted by others."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:4
-msgid "Trust this certificate for this connection"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:1
-msgid "Show all Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:7
-msgid "The pod '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:1
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:1
-msgid "Delete image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:2
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:2
-msgid "All running"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:3
-msgid "No pods deployed"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:5
-msgid "All in use"
-msgstr "Tots en ús"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:6
-msgid "No volumes in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:7
-msgid "pending volume claims"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:9
-msgid "All healthy"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:10
-msgid "No nodes in cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:13
-msgid "Could not list services"
-msgstr "No es van poder llistar els serveis"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:14
-msgid "You can deploy an application to your cluster."
-msgstr "Podeu desplegar una aplicació al vostre clúster."
-
-#: pkg/kubernetes/views/imagestream-page.html.h:1
-msgid "Show all image streams"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-page.html.h:2
-msgid "Image Stream"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:3
-msgid "Image ID"
-msgstr "Id. d'imatge"
-
-#: pkg/kubernetes/views/container-body.html.h:4
-msgid "Container ID"
-msgstr "Id. de contenidor"
-
-#: pkg/kubernetes/views/container-body.html.h:7
-msgid "Since"
-msgstr "Des de"
-
-#: pkg/kubernetes/views/container-body.html.h:8
-msgid "Restart Count"
-msgstr "Reinicia el compte"
-
-#: pkg/kubernetes/views/user-remove-membership.html.h:1
-msgid "Remove membership"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:1
-msgid "Delete Selected"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:2
-msgid "OS Versions"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:3
-msgid "Add Kubernetes Node"
-msgstr ""
-
-#: pkg/kubernetes/views/project-page.html.h:3
-msgid "The project '{{ projName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/user-panel.html.h:4
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:1
-msgid "Pod Replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:2
-msgid "No pods replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/container-page.html.h:1
-msgid "Show all Containers"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:1
-msgid "Welcome to the Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:2
-msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:1
-msgid "New project"
-msgstr "Nou projecte"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:4
-msgid "Images by project"
-msgstr "Imatges per projecte"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:6
-msgid "Images pushed recently"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:7
-msgid "All images"
-msgstr "Totes les imatges"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:8
-msgid "No images pushed"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:9
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:11
-#, fuzzy
-msgid "Login commands"
-msgstr "Ordres  de Docker"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:12
-#, fuzzy
-msgid "Log into the registry:"
-msgstr "Inicia la sessió a {{host}}"
+"No teniu el permís per visualitzar les claus públiques autoritzades per "
+"aquest compte."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:13
+#: pkg/kubernetes/views/registry-dashboard-page.html:112
 msgid ""
 "Your login credentials do not give you access to use the docker registry "
 "from the command line."
@@ -6034,252 +6176,177 @@ msgstr ""
 "Les vostres credencials d'inici de sessió no us donen accés a utilitzar el "
 "registre de docker des de la línia d'ordres."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:14
-msgid "Log into OpenShift command line tools:"
+#: src/base1/cockpit.js:3687
+msgid "Your session has been terminated."
+msgstr "La vostra sessió ha estat finalitzada."
+
+#: src/base1/cockpit.js:3689
+msgid "Your session has expired. Please log in again."
+msgstr "La vostra sessió ha vençut. Si us plau, torneu a iniciar la sessió."
+
+#: pkg/lib/journal.js:213
+msgid "[$0 bytes of binary data]"
+msgstr "[$0 bytes de dades binàries]"
+
+#: pkg/lib/journal.js:215
+msgid "[binary data]"
+msgstr "[dades binàries]"
+
+#: pkg/lib/journal.js:209
+msgid "[no data]"
+msgstr "[sense dades]"
+
+#: pkg/storaged/details.js:1692
+msgid "active, but unsupported"
+msgstr "actiu, però no suportat"
+
+#: pkg/storaged/utils.js:88
+msgctxt "format-bytes"
+msgid "bytes"
+msgstr "bytes"
+
+#: pkg/docker/util.js:123
+msgid "default"
+msgstr "per defecte"
+
+#: pkg/storaged/details.js:178
+msgid "ext4 - Red Hat Enterprise Linux 6 default"
+msgstr "ext4 - per defecte a Red Hat Enterprise Linux 6"
+
+#: pkg/systemd/host.js:661
+msgid "failed to list ssh host keys: $0"
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:15
-#, fuzzy
-msgid "Image commands"
-msgstr "Ordres  de Docker"
+#: pkg/storaged/index.html:135
+msgid "iSCSI Targets"
+msgstr "Destinacions iSCSI"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:16
-msgid "Push an image:"
-msgstr ""
+#: pkg/storaged/details.js:1692
+msgid "inactive"
+msgstr "inactiu"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:17
-msgid "Pull an image:"
-msgstr ""
+#: pkg/storaged/details.js:1286
+msgid "locked"
+msgstr "bloquejat"
 
-#: pkg/kubernetes/views/node-page.html.h:1
-msgid "Show all Nodes"
-msgstr ""
+#: pkg/storaged/details.js:1278
+msgid "mounted on $0"
+msgstr "s'ha muntat a $0"
 
-#: pkg/kubernetes/views/node-page.html.h:4
-msgid "The node '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/route-page.html.h:1
-msgid "Show all Routes"
-msgstr ""
-
-#: pkg/kubernetes/views/route-page.html.h:3
-msgid "The route '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:1
-msgid "Select an object to see more details."
-msgstr "Seleccioneu un objecte per veure'n més detalls. "
-
-#: pkg/kubernetes/views/topology-page.html.h:3
-msgid ""
-"Pods contain one or more containers that run\n"
-"                together on a node, containing your application code."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:6
-msgid ""
-"Replication controllers dynamically create instances of\n"
-"                pods from templates, and remove pods when necessary."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:9
-msgid ""
-"Services group pods and provide a common DNS\n"
-"                name and an optional, load-balanced IP address to access "
-"them."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:12
-msgid "Nodes are the machines that run your containers."
-msgstr "Els nodes són les màquines que executen els vostres contenidors."
-
-#: pkg/kubernetes/views/add-group-dialog.html.h:1
-msgid "Add Group"
-msgstr "Afegeix un grup"
-
-#: pkg/kubernetes/views/file-button.html.h:1
-msgid "Select Manifest File..."
-msgstr "Selecciona el fitxer del manifest..."
-
-#: pkg/kubernetes/views/project-modify.html.h:2
-msgid "Change project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-modify.html.h:4
-msgid "Display name"
-msgstr "Nom a mostrar"
-
-#: pkg/kubernetes/views/route-body.html.h:5
-msgid "TLS Termination"
-msgstr "Finalització TLS"
-
-#: pkg/kubernetes/views/route-body.html.h:6
-msgid "yes"
-msgstr "sí"
-
-#: pkg/kubernetes/views/route-body.html.h:7
+#: pkg/kubernetes/views/route-body.html:14
 msgid "no"
 msgstr "no"
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:1
-msgid "Add Role"
-msgstr "Afegeix un rol"
+#: pkg/kubernetes/views/route-body.html:24
+#: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
+msgid "none"
+msgstr "cap"
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:2
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#: pkg/storaged/details.js:1280
+msgid "not mounted"
+msgstr "no muntat"
+
+#: pkg/kubernetes/views/dashboard-page.html:83
+msgid "pending volume claims"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:1
-msgid "All Types"
-msgstr "Tots els tipus"
+#: pkg/tuned/change-profile.jsx:52
+#, fuzzy
+msgid "recommended"
+msgstr "MII (recomanat)"
 
-#: pkg/kubernetes/views/details-page.html.h:2
-msgid "Type:"
-msgstr "Tipus:"
+#: pkg/docker/index.html:426
+msgid "select container"
+msgstr "selecciona el contenidor"
 
-#: pkg/kubernetes/views/details-page.html.h:13
-msgid "Deployment Configs"
-msgstr "Configuracions del desplegament"
+#: pkg/docker/index.html:504 pkg/docker/index.html:683
+msgid "shares"
+msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:15
-msgid "Not deployed"
-msgstr "No desplegat"
+#: pkg/selinux/setroubleshoot-view.jsx:118
+msgid "solution details"
+msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:16
-msgid "Replication Controllers"
-msgstr "Controladors de replicació"
+#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
+msgid "unknown"
+msgstr "desconegut"
 
-#: pkg/kubernetes/views/service-modify.html.h:1
-msgid "Adjust Service"
-msgstr "Ajusta el servei"
+#: pkg/storaged/jobs.js:180
+msgid "unknown target"
+msgstr "objectiu desconegut"
 
-#: pkg/kubernetes/views/service-modify.html.h:3
+#: pkg/storaged/details.js:1284
+msgid "unlocked"
+msgstr "desbloquejat"
+
+#: pkg/kubernetes/views/route-body.html:13
+msgid "yes"
+msgstr "sí"
+
+#: pkg/kubernetes/views/service-modify.html:16
 msgid "{{ item.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:5
-msgid "Adjust"
-msgstr "Ajusta"
-
-#: pkg/kubernetes/views/project-delete.html.h:1
-msgid "Delete Project"
-msgstr "Suprimeix el projecte"
-
-#: pkg/kubernetes/views/pvc-body.html.h:2
-msgid "Claim Name"
+#: pkg/kubernetes/views/deploy.html:27
+msgid "{{ selected.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:4
-msgid "No Volume Bound"
+#: pkg/kubernetes/views/pv-modify.html:61
+#: pkg/kubernetes/views/pv-modify.html:74
+msgid "{{ value }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:8
-msgid "Requested"
+#: pkg/kubernetes/views/volume-body.html:2
+msgid "{{ volume | formatVolumeType }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:9
-msgid "Actual"
+#: pkg/storaged/index.html:147
+msgid "{{Address}}:{{Port}}"
+msgstr "{{Address}}:{{Port}}"
+
+#: pkg/docker/index.html:435
+msgid "{{alias_label}}"
+msgstr "{{alias_label}}"
+
+#: pkg/systemd/services.html:173 pkg/systemd/services.html:202
+msgid "{{days_text}}"
 msgstr ""
 
-#: pkg/kubernetes/views/node-capacity.html.h:1
-msgid "Scheduled Pods"
+#: pkg/docker/index.html:403
+msgid "{{envvar_key_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/node-capacity.html.h:2
-msgid "No pods scheduled"
+#: pkg/docker/index.html:407
+msgid "{{envvar_value_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/container-page-inline.html.h:4
-msgid "The container '{{ target }}' does not exist."
+#: pkg/docker/index.html:359
+msgid "{{host_port_label}}"
+msgstr "{{host_port_label}}"
+
+#: pkg/docker/index.html:373
+msgid "{{host_volume_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:1
-msgid "Create image stream"
+#: pkg/kubernetes/views/imagestream-body.html:35
+msgid "{{stream.status.tags.length}}"
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:2
-msgid "Change image stream"
-msgstr ""
+#~ msgid "Journal"
+#~ msgstr "Publicacions"
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:5
-msgid "Populate"
-msgstr "Pobla"
+#~ msgid "Comment"
+#~ msgstr "Comentari"
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:6
-msgid "Pull from"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:8
-msgid "Remote registry is insecure"
-msgstr ""
-
-#: pkg/kubernetes/views/user-group-remove.html.h:1
-msgid "Remove Member"
-msgstr "Suprimeix el membre"
-
-#: pkg/kubernetes/views/service-page.html.h:1
-msgid "Show all Services"
-msgstr ""
-
-#: pkg/kubernetes/views/service-page.html.h:4
-msgid "The service '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/scripts/frob-layers.html.h:1
-msgid "Image Layers Example"
-msgstr ""
-
-#: pkg/playground/service.html.h:1
-msgid "Cockpit Generic Service Monitor"
-msgstr ""
-
-#: pkg/playground/jquery-patterns.html.h:1
-msgid "Cockpit Pattern Usage"
-msgstr ""
-
-#: pkg/playground/metrics.html.h:1
 #, fuzzy
-msgid "Cockpit Monitoring"
-msgstr "Monitoratge de l'enllaç"
+#~ msgid "Cockpit Monitoring"
+#~ msgstr "Monitoratge de l'enllaç"
 
-#: pkg/playground/test.html.h:1 pkg/playground/translate.html.h:1
-msgid "Cockpit playground"
-msgstr ""
-
-#: pkg/playground/react-patterns.html.h:1
-msgid "Cockpit React Patterns Usage"
-msgstr ""
-
-#: pkg/playground/speed.html.h:1
-msgid "Cockpit Speed Tests"
-msgstr ""
-
-#: pkg/playground/plot.html.h:1
 #, fuzzy
-msgid "Cockpit Plots"
-msgstr "Cockpit"
-
-#: pkg/dashboard/index.html.h:1
-msgid "Dashboard"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:5
-#, fuzzy
-msgid "Disk I/O"
-msgstr "El disc està bé"
-
-#: pkg/dashboard/index.html.h:6
-msgid "Lost connection. Trying to reconnect"
-msgstr "S'ha perdut la connexió. S'intenta connectar de nou"
-
-#: pkg/dashboard/index.html.h:10
-msgid "Avatar"
-msgstr "Avatar"
-
-#: pkg/dashboard/index.html.h:13
-msgid "Set"
-msgstr "Estableix"
+#~ msgid "Cockpit Plots"
+#~ msgstr "Cockpit"
 
 #~ msgid "No addresses found"
 #~ msgstr "No s'ha trobat cap adreça"
@@ -6377,15 +6444,6 @@ msgstr "Estableix"
 #~ "                                Etiqueta\n"
 #~ "                            "
 
-#~ msgid ""
-#~ "\n"
-#~ "                                Select\n"
-#~ "                            "
-#~ msgstr ""
-#~ "\n"
-#~ "                                Selecciona\n"
-#~ "                            "
-
 #~ msgid "One"
 #~ msgstr "Un"
 
@@ -6444,60 +6502,8 @@ msgstr "Estableix"
 #~ "    "
 
 #~ msgctxt "storage"
-#~ msgid "Model"
-#~ msgstr "Model"
-
-#~ msgctxt "storage"
-#~ msgid "Firmware Version"
-#~ msgstr "Versió de microprogramari"
-
-#~ msgctxt "storage"
-#~ msgid "Serial Number"
-#~ msgstr "Número de sèrie"
-
-#~ msgctxt "storage"
-#~ msgid "World Wide Name"
-#~ msgstr "WWN (World Wide Name)"
-
-#~ msgctxt "storage"
-#~ msgid "Capacity"
-#~ msgstr "Capacitat"
-
-#~ msgctxt "storage"
-#~ msgid "Assessment"
-#~ msgstr "Avaluació"
-
-#~ msgctxt "storage"
-#~ msgid "Device File"
-#~ msgstr "Fitxer de dispositiu"
-
-#~ msgctxt "storage"
-#~ msgid "Multipathed Devices"
-#~ msgstr "Dispositius amb multicamí"
-
-#~ msgctxt "storage"
-#~ msgid "Device"
-#~ msgstr "Dispositiu"
-
-#~ msgctxt "storage"
 #~ msgid "Name"
 #~ msgstr "Nom"
-
-#~ msgctxt "storage"
-#~ msgid "UUID"
-#~ msgstr "UUID"
-
-#~ msgctxt "storage"
-#~ msgid "RAID Level"
-#~ msgstr "Nivell RAID"
-
-#~ msgctxt "storage"
-#~ msgid "Bitmap"
-#~ msgstr "Mapa de bits"
-
-#~ msgctxt "storage"
-#~ msgid "State"
-#~ msgstr "Estat"
 
 #~ msgid ""
 #~ "\n"
@@ -6547,15 +6553,6 @@ msgstr "Estableix"
 #~ msgstr ""
 #~ "\n"
 #~ "                    URL\n"
-#~ "                  "
-
-#~ msgid ""
-#~ "\n"
-#~ "                    Login\n"
-#~ "                  "
-#~ msgstr ""
-#~ "\n"
-#~ "                    Usuari\n"
 #~ "                  "
 
 #~ msgid ""

--- a/po/da.po
+++ b/po/da.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-17 19:28+0100\n"
+"POT-Creation-Date: 2016-11-18 06:44+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,172 +17,312 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Zanata 3.8.4\n"
 
-#: src/ws/cockpitcertificate.c:359
-msgid "Cannot decrypt PEM-encoded private key"
+#: pkg/shell/index.html:227
+msgid "                                                Comment                                            "
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:364
-msgid "No PEM-encoded private key found"
+#: pkg/shell/index.html:235
+msgid "                                                Fingerprint                                            "
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:374
-msgid "Could not parse PEM-encoded private key"
+#: pkg/shell/index.html:231
+msgid "                                                Type                                            "
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:398
-msgid "No PEM-encoded certificate found"
+#: pkg/systemd/index.html:389
+msgid ""
+"                                    Invalid time "
+"zone                                "
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:407
-msgid "Could not parse PEM-encoded certificate"
+#: pkg/kubernetes/views/project-body.html:80
+msgid ""
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}                                "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
-#: src/bridge/cockpitdbussetup.c:625
-msgid "Unsupported setup mechanism"
+#: pkg/kubernetes/views/user-body.html:22
+msgid ""
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}                                "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:236
-msgid "Couldn't list users"
+#: pkg/kubernetes/views/user-panel.html:39
+msgid ""
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}                            "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
-msgid "Bad data passed for passwd1 mechanism"
+#: pkg/kubernetes/views/project-body.html:37
+msgid ""
+"                                {{ getRegistryRoles(user, project())."
+"join() }}                            "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:382
-msgid "Couldn't load user data"
+#: pkg/systemd/index.html:485 pkg/systemd/index.html:504
+msgid "                        Cancel                    "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:467
-msgid "Couldn't change user groups"
+#: pkg/kubernetes/views/user-add-membership.html:9
+msgid "                        Group or Project                    "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:520
-msgid "Couldn't change user password"
+#: pkg/kubernetes/views/add-user-dialog.html:19
+#: pkg/kubernetes/views/user-modify.html:19
+msgid "                        Identity                    "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:544
-msgid "Couldn't create new users"
+#: pkg/kubernetes/views/add-user-dialog.html:9
+#: pkg/kubernetes/views/user-modify.html:9
+#: pkg/kubernetes/views/add-group-dialog.html:9
+msgid "                        Name                    "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:642
-msgid "Couldn't list local users"
+#: pkg/kubernetes/views/user-add-membership.html:30
+msgid "                        Role                    "
 msgstr ""
 
-#: src/bridge/cockpitpackages.c:459
-#, c-format
-msgid "This package requires Cockpit version %s or later"
+#: pkg/kubernetes/views/user-group-add.html:9
+msgid "                        User                    "
 msgstr ""
 
-#: src/bridge/cockpitpackages.c:470
-msgid "This package is not compatible with this version of Cockpit"
+#: pkg/ostree/index.html:88
+msgid "                    Available                  "
 msgstr ""
 
-#: src/base1/cockpit.js:2586
-msgid "$0 killed with signal $1"
+#: pkg/ostree/index.html:85
+msgid "                    Default                  "
 msgstr ""
 
-#: src/base1/cockpit.js:2588
-msgid "$0 exited with code $1"
+#: pkg/ostree/index.html:223
+msgid "                    Reconnect                "
 msgstr ""
 
-#: src/base1/cockpit.js:2590
-msgid "$0 failed"
+#: pkg/ostree/index.html:135
+msgid ""
+"                    This deployment contains the same packages as your "
+"currently booted system                "
 msgstr ""
 
-#: src/base1/cockpit.js:3667
-msgid "Your session has been terminated."
+#: pkg/ostree/index.html:67
+msgid "                    Update and reboot                "
 msgstr ""
 
-#: src/base1/cockpit.js:3669
-msgid "Your session has expired. Please log in again."
+#: pkg/kubernetes/registry.html:74 pkg/kubernetes/index.html:104
+msgid "                Reconnect            "
 msgstr ""
 
-#: src/base1/cockpit.js:3671
-msgid "Not permitted to perform this action."
+#: pkg/sosreport/index.html:57
+msgid ""
+"                The generated archive contains data "
+"considered                sensitive and its content should be reviewed by "
+"the                originating organization before being passed to "
+"any                third party.              "
 msgstr ""
 
-#: src/base1/cockpit.js:3673
-msgid "Login failed"
+#: pkg/shell/index.html:304 pkg/shell/stub.html:157
+msgid "                Tools              "
 msgstr ""
 
-#: src/base1/cockpit.js:3675
-msgid "The server refused to authenticate using any supported methods."
+#: pkg/kubernetes/index.html:107
+msgid "                Troubleshoot            "
 msgstr ""
 
-#: src/base1/cockpit.js:3677
-msgid "Untrusted host"
+#: pkg/shell/simple.html:105 pkg/shell/index.html:126 pkg/shell/stub.html:119
+#: pkg/storaged/index.html:862
+msgid "              Cancel            "
 msgstr ""
 
-#: src/base1/cockpit.js:3679
-msgid "Host key is incorrect"
+#: pkg/shell/index.html:147 pkg/shell/stub.html:140
+msgid "              Close            "
 msgstr ""
 
-#: src/base1/cockpit.js:3681
-msgid "Internal error"
+#: pkg/shell/simple.html:70 pkg/shell/index.html:83 pkg/shell/stub.html:76
+msgid ""
+"              Cockpit is an interactive Linux server admin "
+"interface.            "
 msgstr ""
 
-#: src/base1/cockpit.js:3683
-msgid "Connection has timed out."
+#: pkg/shell/simple.html:79 pkg/shell/index.html:92 pkg/shell/stub.html:85
+msgid "              Licensed under the GNU LGPL version 2.1            "
 msgstr ""
 
-#: src/base1/cockpit.js:3685
-msgid "Cockpit is not installed on the system."
+#: pkg/shell/simple.html:129
+msgid "              Log in again            "
 msgstr ""
 
-#: src/base1/cockpit.js:3687
-msgid "Cannot forward login credentials"
+#: pkg/shell/simple.html:73 pkg/shell/index.html:86 pkg/shell/stub.html:79
+msgid "              Project website            "
 msgstr ""
 
-#: src/base1/cockpit.js:3689
-msgid "Server has closed the connection."
+#: pkg/shell/simple.html:108 pkg/shell/index.html:129 pkg/shell/stub.html:122
+msgid "              Select            "
 msgstr ""
 
-#: src/base1/cockpit.js:3691
-msgid "Cockpit is not compatible with the software on the system."
+#: pkg/shell/simple.html:126
+msgid "              Try to reconnect            "
 msgstr ""
 
-#: src/base1/cockpit.js:3693
-msgid "Cockpit could not contact the given host."
+#: pkg/users/index.html:361
+msgid "            Add key          "
 msgstr ""
 
-#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:19
-msgid "Control"
+#: pkg/networkmanager/index.html:582 pkg/networkmanager/index.html:610
+#: pkg/networkmanager/index.html:638 pkg/networkmanager/index.html:666
+#: pkg/networkmanager/index.html:694 pkg/networkmanager/index.html:722
+#: pkg/networkmanager/index.html:750 pkg/networkmanager/index.html:778
+msgid "            Apply          "
 msgstr ""
 
-#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
-#: pkg/playground/translate.js:22
-msgctxt "key"
-msgid "Control"
+#: pkg/users/index.html:269 pkg/users/index.html:297 pkg/users/index.html:358
+#: pkg/docker/index.html:584 pkg/docker/index.html:622
+#: pkg/docker/index.html:688 pkg/docker/index.html:744
+#: pkg/docker/index.html:790 pkg/networkmanager/index.html:579
+#: pkg/networkmanager/index.html:607 pkg/networkmanager/index.html:635
+#: pkg/networkmanager/index.html:663 pkg/networkmanager/index.html:691
+#: pkg/networkmanager/index.html:719 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:775
+msgid "            Cancel          "
 msgstr ""
 
-#: src/base1/test-locale.js:46 src/base1/test-locale.js:56
-#: pkg/playground/translate.js:10
-msgid "Empty"
+#: pkg/docker/index.html:691
+msgid "            Change          "
 msgstr ""
 
-#: src/base1/test-locale.js:47 src/base1/test-locale.js:58
-#: pkg/playground/translate.js:16
-msgctxt "verb"
-msgid "Empty"
+#: pkg/users/index.html:45
+msgid "            Close          "
 msgstr ""
 
-#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
-#: src/base1/test-locale.js:66 pkg/storaged/details.js:1557
-#: pkg/playground/translate.js:25 pkg/playground/translate.js:28
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] ""
-msgstr[1] ""
+#: pkg/docker/index.html:747
+msgid "            Commit          "
+msgstr ""
 
-#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
-#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
-#: pkg/playground/translate.js:34
-msgctxt "disk-non-rotational"
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
+#: pkg/users/index.html:207
+msgid "            Create          "
+msgstr ""
+
+#: pkg/users/index.html:300 pkg/networkmanager/index.html:533
+msgid "            Delete          "
+msgstr ""
+
+#: pkg/docker/index.html:625
+msgid "            Download          "
+msgstr ""
+
+#: pkg/docker/index.html:587
+msgid "            Run          "
+msgstr ""
+
+#: pkg/users/index.html:272
+msgid "            Set          "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:14
+msgid "          Images may be pulled by anonymous users        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:20
+msgid ""
+"          Images may be pulled by any authenticated user or group        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:26
+msgid "          Images may only be pulled by specific users or groups        "
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:9
+msgid "         {{ labels.url }}    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:2
+msgid ""
+"        Project access policy allows anonymous users to pull images. Grant "
+"additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:7
+msgid ""
+"        Project access policy allows any authenticated user to pull images. "
+"Grant additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:12
+msgid ""
+"        Project access policy only allows specific members to access images. "
+"Grant access to specific members below.    "
+msgstr ""
+
+#: pkg/sosreport/index.html:39
+msgid ""
+"        The collected information will be stored locally on the system.      "
+msgstr ""
+
+#: pkg/storaged/index.html:51
+msgid ""
+"        There are devices with multiple paths on the system, but the "
+"multipath service is not running.      "
+msgstr ""
+
+#: pkg/sosreport/index.html:34
+msgid ""
+"        This tool will collect system configuration and diagnostic        "
+"information from this system for use with diagnosing problems        with "
+"the system.      "
+msgstr ""
+
+#: pkg/docker/storage.jsx:242
+msgid " (shared with the OS)"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:8
+msgid " 1\"Do you want to delete the following Nodes?"
+msgstr ""
+
+#: pkg/storaged/overview.js:253
+msgid "$0 Block Device"
+msgstr ""
+
+#: pkg/storaged/details.js:1546
+msgid "$0 Chunk Size"
+msgstr ""
+
+#: pkg/storaged/details.js:1544
+msgid "$0 Disks"
+msgstr ""
+
+#: pkg/storaged/details.js:1387
+msgid "$0 Extended Partition"
+msgstr ""
+
+#: pkg/storaged/details.js:1221
+msgctxt "storage-id-desc"
+msgid "$0 File System"
+msgstr ""
+
+#: pkg/storaged/details.js:1375
+msgid "$0 Free Space"
+msgstr ""
+
+#: pkg/storaged/details.js:1367
+msgid "$0 Free Space for Logical Partitions"
+msgstr ""
+
+#: pkg/storaged/details.js:1711
+msgid "$0 Free Space for Logical Volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:1370
+msgid "$0 Free Space for Primary Partitions"
+msgstr ""
+
+#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
+msgid "$0 Template"
+msgstr ""
+
+#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+msgid "$0 bit"
+msgid_plural "$0 bits"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -200,568 +340,40 @@ msgid_plural "$0 bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
-msgid "$0 bit"
-msgid_plural "$0 bits"
+#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
+#: src/base1/test-locale.js:66 pkg/playground/translate.js:25
+#: pkg/playground/translate.js:28 pkg/storaged/details.js:1557
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/systemd/host.js:43
-msgid "The user <b>$0</b> is not permitted to modify hostnames"
-msgstr ""
-
-#: pkg/systemd/host.js:559
-msgid "Set Host name"
-msgstr ""
-
-#: pkg/systemd/host.js:661
-msgid "failed to list ssh host keys: $0"
-msgstr ""
-
-#: pkg/systemd/host.js:1113
-msgid "Need at least one NTP server"
-msgstr ""
-
-#: pkg/systemd/host.js:1190
-msgid "Invalid date format and invalid time format"
-msgstr ""
-
-#: pkg/systemd/host.js:1192
-msgid "Invalid time format"
-msgstr ""
-
-#: pkg/systemd/host.js:1194
-msgid "Invalid date format"
-msgstr ""
-
-#: pkg/systemd/host.js:1250
-msgid "NTP Server"
-msgstr ""
-
-#: pkg/systemd/host.js:1300
-msgid "Message to logged in users"
-msgstr ""
-
-#: pkg/systemd/host.js:1307 pkg/systemd/host.js:1309
-#: pkg/systemd/index.html.h:19
-msgid "Shutdown"
-msgstr ""
-
-#: pkg/systemd/host.js:1311 pkg/systemd/host.js:1313 pkg/systemd/init.js:517
-#: pkg/systemd/index.html.h:18
-msgid "Restart"
-msgstr ""
-
-#: pkg/systemd/host.js:1381
-msgctxt "page-title"
-msgid "CPU Status"
-msgstr "Tilstand"
-
-#: pkg/systemd/host.js:1413 pkg/systemd/index.html.h:24
-msgid "I/O Wait"
-msgstr ""
-
-#: pkg/systemd/host.js:1414 pkg/systemd/index.html.h:25
-msgid "Kernel"
-msgstr ""
-
-#: pkg/systemd/host.js:1415 pkg/subscriptions/subscriptions-register.jsx:76
-#: pkg/systemd/index.html.h:26 pkg/kubernetes/views/auth-form.html.h:6
-#: pkg/kubernetes/views/volume-body.html.h:20
-#: pkg/kubernetes/views/user-panel.html.h:1 pkg/playground/translate.html.h:3
-#: pkg/dashboard/index.html.h:8
-msgid "User"
-msgstr ""
-
-#: pkg/systemd/host.js:1416 pkg/systemd/index.html.h:27
-msgid "Nice"
-msgstr ""
-
-#: pkg/systemd/host.js:1466
-msgctxt "page-title"
-msgid "Memory"
-msgstr "Hukommelse"
-
-#: pkg/systemd/host.js:1499 pkg/systemd/index.html.h:28
-msgid "Swap Used"
-msgstr ""
-
-#: pkg/systemd/host.js:1500 pkg/systemd/index.html.h:29
-msgid "Cached"
-msgstr ""
-
-#: pkg/systemd/host.js:1501 pkg/docker/storage.jsx:313
-#: pkg/kubernetes/scripts/nodes.js:828 pkg/kubernetes/scripts/nodes.js:837
-#: pkg/systemd/index.html.h:30
-msgid "Used"
-msgstr ""
-
-#: pkg/systemd/host.js:1502 pkg/docker/storage.jsx:298
-#: pkg/docker/storage.jsx:320 pkg/systemd/index.html.h:31
-msgid "Free"
-msgstr ""
-
-#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
-msgid "unknown"
-msgstr ""
-
-#: pkg/systemd/init.js:269 pkg/systemd/services.html.h:17
-#: pkg/kubernetes/views/project-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:5
-msgid "Description"
-msgstr ""
-
-#: pkg/systemd/init.js:270
-msgid "Id"
-msgstr ""
-
-#: pkg/systemd/init.js:272
-msgid "Next Run"
-msgstr ""
-
-#: pkg/systemd/init.js:273
-msgid "Last Trigger"
-msgstr ""
-
-#: pkg/systemd/init.js:274 pkg/kubernetes/views/container-body.html.h:6
-#: pkg/kubernetes/views/details-page.html.h:8
-msgid "State"
-msgstr ""
-
-#: pkg/systemd/init.js:301
-msgid "Enabled"
-msgstr ""
-
-#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
-msgid "Disabled"
-msgstr ""
-
-#: pkg/systemd/init.js:303
-msgid "Static"
-msgstr ""
-
-#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
-msgid "$0 Template"
-msgstr ""
-
-#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
-msgid "Start"
-msgstr ""
-
-#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
-msgid "Stop"
-msgstr ""
-
-#: pkg/systemd/init.js:518
-msgid "Reload"
-msgstr ""
-
-#: pkg/systemd/init.js:519
-msgid "Reload or Restart"
-msgstr ""
-
-#: pkg/systemd/init.js:520
-msgid "Try Restart"
-msgstr ""
-
-#: pkg/systemd/init.js:521
-msgid "Reload or Try Restart"
-msgstr ""
-
-#: pkg/systemd/init.js:522
-msgid "Isolate"
-msgstr ""
-
-#: pkg/systemd/init.js:541
-msgid "Enable"
-msgstr ""
-
-#: pkg/systemd/init.js:542
-msgid "Enable Forcefully"
-msgstr ""
-
-#: pkg/systemd/init.js:543
-msgid "Disable"
-msgstr ""
-
-#: pkg/systemd/init.js:544
-msgid "Preset"
-msgstr ""
-
-#: pkg/systemd/init.js:545
-msgid "Preset Forcefully"
-msgstr ""
-
-#: pkg/systemd/init.js:546
-msgid "Mask"
-msgstr ""
-
-#: pkg/systemd/init.js:547
-msgid "Mask Forcefully"
-msgstr ""
-
-#: pkg/systemd/init.js:548
-msgid "Unmask"
-msgstr ""
-
-#: pkg/systemd/init.js:621
-msgid "Since $0"
-msgstr ""
-
-#: pkg/systemd/init.js:639
-msgid "This unit is an instance of the $0 template."
-msgstr ""
-
-#: pkg/systemd/init.js:834
-msgid "The user <b>$0</b> does not have permissions for creating timers"
-msgstr ""
-
-#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
-msgid "This field cannot be empty."
-msgstr ""
-
-#: pkg/systemd/init.js:1147
-msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
-msgstr ""
-
-#: pkg/systemd/init.js:1169
-msgid "Invalid number."
-msgstr ""
-
-#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
-msgid "Hour needs to be a number between 0-23"
-msgstr ""
-
-#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
-msgid "Minute needs to be a number between 0-59"
-msgstr ""
-
-#: pkg/systemd/init.js:1218
-msgid "Invalid date format."
-msgstr ""
-
-#: pkg/systemd/init.js:1222
-msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
-msgstr ""
-
-#: pkg/systemd/logs.js:69
-msgid "Load earlier entries"
-msgstr ""
-
-#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
-#: pkg/systemd/logs.js:175
-msgid "Loading..."
-msgstr ""
-
-#: pkg/systemd/logs.js:130
-msgid "Go to"
-msgstr ""
-
-#: pkg/systemd/logs.js:257
-msgid "Journal entry"
-msgstr ""
+#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
+#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
+#: pkg/playground/translate.js:34
+msgctxt "disk-non-rotational"
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] ""
+msgstr[1] ""
 
-#: pkg/systemd/logs.js:284
-msgid "Journal entry not found"
+#: src/base1/cockpit.js:2588
+msgid "$0 exited with code $1"
 msgstr ""
 
-#: pkg/tuned/dialog.js:94
-msgid "Tuned is not available"
+#: src/base1/cockpit.js:2590
+msgid "$0 failed"
 msgstr ""
 
-#: pkg/tuned/dialog.js:96
-msgid "Tuned is not running"
+#: src/base1/cockpit.js:2586
+msgid "$0 killed with signal $1"
 msgstr ""
 
-#: pkg/tuned/dialog.js:98
-msgid "Tuned is off"
-msgstr ""
-
-#: pkg/tuned/dialog.js:100
-msgid "This system is using the recommended profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:102
-msgid "This system is using a custom profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:114
-msgid "Communication with tuned has failed"
-msgstr ""
-
-#: pkg/tuned/dialog.js:133
-msgid "Failed to disable tuned profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:145
-msgid "Failed to switch profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:169
-msgid "Failed to enable tuned"
-msgstr ""
-
-#: pkg/tuned/dialog.js:171
-msgid "Failed to disable tuned"
-msgstr ""
-
-#: pkg/tuned/dialog.js:191
-msgid "Change Performance Profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:200
-msgid "Change Profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:233 pkg/kubernetes/views/service-body.html.h:7
-#: pkg/kubernetes/views/pod-panel.html.h:2
-#: pkg/kubernetes/views/image-config.html.h:8
-#: pkg/kubernetes/views/imagestream-body.html.h:12
-#: pkg/kubernetes/views/pod-page.html.h:5
-msgid "None"
-msgstr ""
-
-#: pkg/tuned/dialog.js:234
-msgid "Disable tuned"
-msgstr ""
-
-#: pkg/tuned/dialog.js:262
-msgid "Tuned has failed to start"
-msgstr ""
-
-#: pkg/tuned/change-profile.jsx:52
-msgid "recommended"
-msgstr ""
-
-#: pkg/lib/journal.js:209
-msgid "[no data]"
-msgstr ""
-
-#: pkg/lib/journal.js:213
-msgid "[$0 bytes of binary data]"
-msgstr ""
-
-#: pkg/lib/journal.js:215
-msgid "[binary data]"
-msgstr ""
-
-#: pkg/lib/journal.js:241
-msgid "Reboot"
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:364
-msgid "This machine has already been added."
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:380
-msgid ""
-"This version of cockpit-ws does not support connecting to a host with an "
-"alternate user or port"
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:386
-msgid "The IP address or host name cannot contain whitespace."
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:412
-msgid "Failed to add machine: $0"
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:429
-msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:447
-msgid "Enter IP address or host name"
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:494
-msgid "Failed to edit machine: $0"
-msgstr ""
-
-#: pkg/lib/cockpit-components-dialog.jsx:136 pkg/sosreport/index.js:55
-#: pkg/systemd/services.html.h:34 pkg/lib/machine-sync-users.html.h:7
-#: pkg/lib/machine-add.html.h:5 pkg/lib/machine-change-port.html.h:6
-#: pkg/lib/machine-change-auth.html.h:11 pkg/storaged/index.html.h:22
-#: pkg/realmd/operation.html.h:10 pkg/kubernetes/views/node-delete.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:3
-#: pkg/kubernetes/views/pvc-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:3
-#: pkg/kubernetes/views/auth-form.html.h:13
-#: pkg/kubernetes/views/node-add.html.h:7
-#: pkg/kubernetes/views/user-group-add.html.h:5
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:4
-#: pkg/kubernetes/views/route-modify.html.h:3
-#: pkg/kubernetes/views/image-delete.html.h:3
-#: pkg/kubernetes/views/pv-delete.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:4
-#: pkg/kubernetes/views/item-delete.html.h:4
-#: pkg/kubernetes/views/add-user-dialog.html.h:8
-#: pkg/kubernetes/views/user-add-membership.html.h:8
-#: pkg/kubernetes/views/deploy.html.h:4
-#: pkg/kubernetes/views/user-modify.html.h:8
-#: pkg/kubernetes/views/pv-modify.html.h:21
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:5
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:3
-#: pkg/kubernetes/views/imagestream-delete.html.h:3
-#: pkg/kubernetes/views/user-remove-membership.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:7
-#: pkg/kubernetes/views/add-role-dialog.html.h:3
-#: pkg/kubernetes/views/service-modify.html.h:4
-#: pkg/kubernetes/views/project-delete.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:9
-#: pkg/kubernetes/views/user-group-remove.html.h:2
-#: pkg/playground/translate.html.h:2 pkg/dashboard/index.html.h:12
-msgid "Cancel"
-msgstr "Annullér"
-
-#: pkg/lib/cockpit-components-dialog.jsx:155
-msgid "Ok"
-msgstr ""
-
-#: pkg/lib/credentials.js:182
-msgid "No such file or directory"
-msgstr ""
-
-#: pkg/lib/credentials.js:186
-msgid "The passwords do not match."
-msgstr ""
-
-#: pkg/lib/credentials.js:191
-msgid "Prompting via ssh-keygen timed out"
-msgstr ""
-
-#: pkg/lib/credentials.js:213 pkg/users/local.js:78
-msgid "Old password not accepted"
-msgstr ""
-
-#: pkg/lib/credentials.js:223 pkg/users/local.js:112 pkg/users/local.js:144
-msgid "Failed to change password"
-msgstr ""
-
-#: pkg/lib/credentials.js:231 pkg/users/local.js:120
-msgid "New password was not accepted"
-msgstr ""
-
-#: pkg/lib/credentials.js:248
-msgid "Not a valid private key"
-msgstr ""
-
-#: pkg/lib/credentials.js:251
-msgid "Prompting via ssh-add timed out"
-msgstr ""
-
-#: pkg/lib/credentials.js:274
-msgid "Invalid file permissions"
-msgstr ""
-
-#: pkg/lib/credentials.js:278
-msgid "Password not accepted"
-msgstr ""
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:22
-#: pkg/shell/index.html.h:27 pkg/storaged/index.html.h:52
-#: pkg/playground/jquery-patterns.html.h:2
-msgid "On"
-msgstr ""
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:23
-#: pkg/shell/index.html.h:28 pkg/storaged/index.html.h:53
-#: pkg/playground/jquery-patterns.html.h:3
-msgid "Off"
-msgstr ""
-
-#: pkg/shell/base_index.js:670 pkg/users/local.js:1164
-#: pkg/docker/index.html.h:69 pkg/networkmanager/index.html.h:65
-msgid "Unexpected error"
-msgstr ""
-
-#: pkg/shell/base_index.js:671
-msgid "Cockpit had an unexpected internal error. <br/><br/>"
-msgstr ""
-
-#: pkg/shell/base_index.js:672
-msgid "You can try restarting Cockpit by pressing refresh in your browser. "
-msgstr ""
-
-#: pkg/shell/base_index.js:673
-msgid "The javascript console contains details about this error "
-msgstr ""
-
-#: pkg/shell/base_index.js:674
-msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
-msgstr ""
-
-#: pkg/shell/indexes.js:126 pkg/shell/indexes.js:497 pkg/shell/simple.html.h:17
-msgid "Disconnected"
-msgstr ""
-
-#: pkg/shell/indexes.js:253
-msgid "Machines"
-msgstr ""
-
-#: pkg/shell/indexes.js:314
-msgid "The machine is restarting"
-msgstr ""
-
-#: pkg/shell/indexes.js:317
-msgid "Connecting to the machine"
-msgstr ""
-
-#: pkg/shell/indexes.js:320
-msgid "Couldn't connect to the machine"
-msgstr ""
-
-#: pkg/shell/indexes.js:322
-msgid "Cannot connect to an unknown machine"
-msgstr ""
-
-#: pkg/ostree/client.js:56
-msgid "Receiving delta parts"
-msgstr ""
-
-#: pkg/ostree/client.js:58
-msgid "Receiving metadata objects"
-msgstr ""
-
-#: pkg/ostree/client.js:61
-msgid "Receiving objects: $0%"
-msgstr ""
-
-#: pkg/ostree/client.js:64
-msgid "Writing objects"
-msgstr ""
-
-#: pkg/ostree/client.js:66
-msgid "Scanning metadata"
-msgstr ""
-
-#: pkg/ostree/client.js:500
-msgid "OS $0 not found"
-msgstr ""
-
-#: pkg/ostree/app.js:81
-msgid "Not authorized to update software on this system"
-msgstr ""
-
-#: pkg/ostree/app.js:83
-msgid "OSTree is not available on this system"
-msgstr ""
-
-#: pkg/ostree/app.js:101
-msgid "No OSTree deployments found"
-msgstr ""
-
-#: pkg/ostree/app.js:219
-msgid "Checking for updates"
-msgstr ""
+#: pkg/selinux/setroubleshoot-view.jsx:440
+msgid "$0 occurrence"
+msgid_plural "$1 occurrences"
+msgstr[0] ""
+msgstr[1] ""
 
 #: pkg/ostree/app.js:307
 msgid "$0 package"
@@ -771,685 +383,33 @@ msgstr ""
 msgid "$0 packages"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot.js:65
-msgid "Error while setting SELinux mode: '$0'"
+#: pkg/docker/util.js:124
+msgid "$0 shares"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot.js:238
-msgid "Not connected"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot.js:275
-msgid "Error while connecting."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:82
-msgid "Applying solution..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:90
-msgid "Solution applied successfully"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:97
-msgid "Solution failed"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:107
-msgid "Apply this solution"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:114
-msgid "Unable to apply this solution automatically"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:118
-msgid "solution details"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:309
-msgid "SELinux system status is unknown."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:317
-msgid "SELinux is disabled on the system."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:324
-msgid "The configured state is unknown, it might change on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:326
-msgid ""
-"Setting deviates from the configured state and will revert on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:330
-msgid "SELinux Policy"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:332
-msgid "Enforce policy:"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:382 pkg/kubernetes/index.html.h:10
-#: pkg/kubernetes/registry.html.h:5
-msgid "Connecting..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:385
-msgid ""
-"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
-"server is installed."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:400
-msgid "Occurred between $0 and $1"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:405
-msgid "Occurred $0"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:440
-msgid "$0 occurrence"
-msgid_plural "$1 occurrences"
+#: pkg/kubernetes/scripts/nodes.js:870
+#, c-format
+msgid "$0% Free"
+msgid_plural "$0% Free"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:478
-msgid "SELinux Access Control Errors"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:479
-msgid "No SELinux alerts."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:52
-msgid "Unable to start setroubleshootd"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:157
-msgid "Unable to get alert"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:172
-msgid "Unable to run fix"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:187
-msgid "Failed to delete alert"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:192
-msgid "Error while deleting alert"
-msgstr ""
-
-#: pkg/storaged/dialog.js:267
-msgid "Size must be a number"
-msgstr ""
-
-#: pkg/storaged/dialog.js:269
-msgid "Size cannot be zero"
-msgstr ""
-
-#: pkg/storaged/dialog.js:271
-msgid "Size cannot be negative"
-msgstr ""
-
-#: pkg/storaged/dialog.js:273
-msgid "Size is too large"
-msgstr ""
-
-#: pkg/storaged/details.js:85
-msgid "Device $0 is mounted on $1"
-msgstr ""
-
-#: pkg/storaged/details.js:91
-msgid "Device $0 is a member of RAID Array $1"
-msgstr ""
-
-#: pkg/storaged/details.js:97
-msgid "Device $0 is a physical volume of $1"
-msgstr ""
-
-#: pkg/storaged/details.js:113
-msgid "Create partition on $0"
-msgstr ""
-
-#: pkg/storaged/details.js:115
-msgid "Format $0"
-msgstr ""
-
-#: pkg/storaged/details.js:177
-msgid "XFS - Red Hat Enterprise Linux 7 default"
-msgstr ""
-
-#: pkg/storaged/details.js:178
-msgid "ext4 - Red Hat Enterprise Linux 6 default"
-msgstr ""
-
-#: pkg/storaged/details.js:179
-msgid "Encrypted XFS (LUKS)"
-msgstr ""
-
-#: pkg/storaged/details.js:180
-msgid "Encrypted EXT4 (LUKS)"
-msgstr ""
-
-#: pkg/storaged/details.js:181
-msgid "VFAT - Compatible with all systems and devices"
-msgstr ""
-
-#: pkg/storaged/details.js:182
-msgid "NTFS - Compatible with most systems"
-msgstr ""
-
-#: pkg/storaged/details.js:183
-msgid "Extended Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:185
-msgid "No Filesystem"
-msgstr ""
-
-#: pkg/storaged/details.js:186
-msgid "Custom (Enter filesystem type)"
-msgstr ""
-
-#: pkg/storaged/details.js:192 pkg/storaged/details.js:664
-#: pkg/storaged/details.js:735 pkg/storaged/details.js:773
-#: pkg/storaged/details.js:909 pkg/storaged/index.html.h:20
-#: pkg/kubernetes/views/volumes-page.html.h:11
-msgid "Size"
-msgstr ""
-
-#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
-msgid "Erase"
-msgstr ""
-
-#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
-msgid "Don't overwrite existing data"
-msgstr ""
-
-#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
-msgid "Overwrite existing data with zeros"
-msgstr ""
-
-#: pkg/storaged/details.js:207 pkg/shell/index.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:4
-#: pkg/kubernetes/views/deploy.html.h:2 pkg/kubernetes/views/pv-modify.html.h:3
-msgid "Type"
-msgstr ""
-
-#: pkg/storaged/details.js:211 pkg/storaged/details.js:429
-#: pkg/storaged/details.js:709 pkg/storaged/details.js:731
-#: pkg/storaged/details.js:769 pkg/storaged/details.js:798
-#: pkg/storaged/details.js:864 pkg/storaged/overview.js:417
-#: pkg/storaged/overview.js:490 pkg/storaged/overview.js:624
-#: pkg/storaged/overview.js:702 pkg/storaged/index.html.h:18
-#: pkg/networkmanager/index.html.h:16
-#: pkg/kubernetes/views/project-listing.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:3
-#: pkg/kubernetes/views/volume-body.html.h:11
-#: pkg/kubernetes/views/containers-listing.html.h:2
-#: pkg/kubernetes/views/volumes-page.html.h:3
-#: pkg/kubernetes/views/pv-claim.html.h:1
-#: pkg/kubernetes/views/pv-modify.html.h:6
-#: pkg/kubernetes/views/image-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:15
-#: pkg/kubernetes/views/nodes-page.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:3
-#: pkg/kubernetes/views/details-page.html.h:4
-#: pkg/kubernetes/views/service-modify.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:3
-#, fuzzy
-msgid "Name"
-msgstr "Værtsnavn"
-
-#: pkg/storaged/details.js:215
-msgid "Filesystem type"
-msgstr ""
-
-#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
-msgid "Passphrase"
-msgstr ""
-
-#: pkg/storaged/details.js:224
-msgid "Passphrase cannot be empty"
-msgstr ""
-
-#: pkg/storaged/details.js:229
-msgid "Confirm passphrase"
-msgstr ""
-
-#: pkg/storaged/details.js:232
-msgid "Passphrases do not match"
-msgstr ""
-
-#: pkg/storaged/details.js:237
-msgid "Store passphrase"
-msgstr ""
-
-#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
-#: pkg/storaged/details.js:1115
-msgid "Encryption Options"
-msgstr ""
-
-#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
-msgid "Mounting"
-msgstr ""
-
-#: pkg/storaged/details.js:247 pkg/storaged/details.js:435
-#: pkg/subscriptions/subscriptions-register.jsx:101 pkg/docker/index.html.h:23
-#: pkg/kubernetes/views/image-config.html.h:2
-msgid "Default"
-msgstr ""
-
-#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
-msgid "Custom"
-msgstr ""
-
-#: pkg/storaged/details.js:253 pkg/storaged/details.js:440
-#: pkg/storaged/index.html.h:19
-msgid "Mount Point"
-msgstr ""
-
-#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
-#, fuzzy
-msgid "Mount Options"
-msgstr "Indstillinger"
-
-#: pkg/storaged/details.js:266
-msgid "Create partition"
-msgstr ""
-
-#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
-#: pkg/storaged/details.js:1142
-msgid "Format"
-msgstr ""
-
-#: pkg/storaged/details.js:268
-msgid "Formatting a storage device will erase all data on it."
-msgstr ""
-
-#: pkg/storaged/details.js:335
-msgid "Format Disk $0"
-msgstr ""
-
-#: pkg/storaged/details.js:346
-msgid "Partitioning"
-msgstr ""
-
-#: pkg/storaged/details.js:348
-msgid "Compatible with all systems and devices (MBR)"
-msgstr ""
-
-#: pkg/storaged/details.js:349
-msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr ""
-
-#: pkg/storaged/details.js:352
-msgid "No partitioning"
-msgstr ""
-
-#: pkg/storaged/details.js:358
-msgid "Formatting a disk will erase all data on it."
-msgstr ""
-
-#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
-msgid "Filesystem Options"
-msgstr ""
-
-#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
-msgid "Apply"
-msgstr ""
-
-#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
-#: pkg/storaged/details.js:1110
-msgid "Unlock"
-msgstr ""
-
-#: pkg/storaged/details.js:527
-msgid "Stored Passphrase"
-msgstr ""
-
-#: pkg/storaged/details.js:531 pkg/kubernetes/views/volume-body.html.h:32
-msgid "Options"
-msgstr "Indstillinger"
-
-#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
-msgid "Add Disks"
-msgstr ""
-
-#: pkg/storaged/details.js:567 pkg/storaged/details.js:933
-#: pkg/storaged/overview.js:448 pkg/storaged/overview.js:495
-#: pkg/storaged/index.html.h:55
-#, fuzzy
-msgid "Disks"
-msgstr "Disk I/O"
-
-#: pkg/storaged/details.js:579 pkg/storaged/details.js:948
-#: pkg/storaged/overview.js:501
-msgid "At least one disk is needed."
-msgstr ""
-
-#: pkg/storaged/details.js:584 pkg/storaged/details.js:953
-#: pkg/storaged/overview.js:629 pkg/storaged/overview.js:657
-#: pkg/lib/machine-add.html.h:6 pkg/kubernetes/views/node-add.html.h:8
-#: pkg/kubernetes/views/user-group-add.html.h:6
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:5
-#: pkg/kubernetes/views/add-user-dialog.html.h:9
-#: pkg/kubernetes/views/user-add-membership.html.h:9
-#: pkg/kubernetes/views/add-role-dialog.html.h:4
-msgid "Add"
-msgstr ""
-
-#: pkg/storaged/details.js:625 pkg/storaged/details.js:821
-#: pkg/storaged/details.js:1016 pkg/docker/details.js:271
-#: pkg/docker/image.js:151 pkg/docker/containers-view.jsx:166
-msgid "Please confirm deletion of $0"
-msgstr ""
-
-#: pkg/storaged/details.js:630 pkg/storaged/details.js:827
-#: pkg/storaged/details.js:1022 pkg/storaged/details.js:1151
-#: pkg/storaged/details.js:1616 pkg/storaged/details.js:1776
-#: pkg/docker/details.js:273 pkg/docker/image.js:153
-#: pkg/docker/containers-view.jsx:168 pkg/kubernetes/scripts/volumes.js:218
-#: pkg/users/index.html.h:9 pkg/kubernetes/views/node-delete.html.h:5
-#: pkg/kubernetes/views/pvc-delete.html.h:5
-#: pkg/kubernetes/views/image-delete.html.h:4
-#: pkg/kubernetes/views/pv-delete.html.h:5
-#: pkg/kubernetes/views/item-delete.html.h:5
-#: pkg/kubernetes/views/imagestream-delete.html.h:4
-#: pkg/kubernetes/views/user-remove-membership.html.h:3
-#: pkg/kubernetes/views/project-delete.html.h:3
-msgid "Delete"
-msgstr ""
-
-#: pkg/storaged/details.js:631
-msgid "Deleting a RAID device will erase all data on it."
-msgstr ""
-
-#: pkg/storaged/details.js:661
-msgid "Resize Logical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:673
-msgid "Resize Filesystem"
-msgstr ""
-
-#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
-msgid "Resize"
-msgstr ""
-
-#: pkg/storaged/details.js:690
-msgid "This logical volume cannot be made smaller."
-msgstr ""
-
-#: pkg/storaged/details.js:706
-msgid "Renamee Logical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
-#: pkg/storaged/details.js:1775
-msgid "Rename"
-msgstr ""
-
-#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
-msgid "Create Snapshot"
-msgstr ""
-
-#: pkg/storaged/details.js:745 pkg/storaged/details.js:781
-#: pkg/storaged/details.js:804 pkg/storaged/details.js:915
-#: pkg/storaged/overview.js:461 pkg/storaged/overview.js:506
-#: pkg/kubernetes/views/add-group-dialog.html.h:6
-#: pkg/kubernetes/views/project-modify.html.h:8
-msgid "Create"
-msgstr ""
-
-#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
-msgid "Create Thin Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:795
-msgid "Rename Volume Group"
-msgstr ""
-
-#: pkg/storaged/details.js:826
-msgid "Deleting a volume group will erase all data on it."
-msgstr ""
-
-#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
-msgid "Create Logical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:869
-msgid "Purpose"
-msgstr ""
-
-#: pkg/storaged/details.js:871
-msgid "Block device for filesystems"
-msgstr ""
-
-#: pkg/storaged/details.js:874
-msgid "Pool for thinly provisioned volumes"
-msgstr ""
-
-#: pkg/storaged/details.js:1009
-msgid "Deleting a logical volume will delete all data in it."
-msgstr ""
-
-#: pkg/storaged/details.js:1012
-msgid "Deleting a partition will delete all data in it."
-msgstr ""
-
-#: pkg/storaged/details.js:1053 pkg/storaged/overview.js:689
-#: pkg/storaged/devices.js:119 pkg/users/local.js:1155
-#: pkg/systemd/services.html.h:14
-msgid "Error"
-msgstr ""
-
-#: pkg/storaged/details.js:1099
-msgid "Mount"
-msgstr ""
-
-#: pkg/storaged/details.js:1100
-msgid "Unmount"
-msgstr ""
-
-#: pkg/storaged/details.js:1109
-msgid "Lock"
-msgstr ""
-
-#: pkg/storaged/details.js:1127
-msgid "Activate"
-msgstr ""
-
-#: pkg/storaged/details.js:1130
-msgid "Deactivate"
-msgstr ""
-
-#: pkg/storaged/details.js:1221
-msgctxt "storage-id-desc"
-msgid "$0 File System"
-msgstr ""
-
-#: pkg/storaged/details.js:1224
-msgctxt "storage-id-desc"
-msgid "Linux MD-RAID Component"
-msgstr ""
-
-#: pkg/storaged/details.js:1226
-msgctxt "storage-id-desc"
-msgid "LVM2 Physical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:1228
-msgctxt "storage-id-desc"
-msgid "RAID Member"
-msgstr ""
-
-#: pkg/storaged/details.js:1245
-msgctxt "storage-id-desc"
-msgid "LUKS Encrypted"
-msgstr ""
-
-#: pkg/storaged/details.js:1247
-msgctxt "storage-id-desc"
-msgid "Encrypted"
-msgstr ""
-
-#: pkg/storaged/details.js:1251
-msgctxt "storage-id-desc"
-msgid "Swap Space"
-msgstr ""
-
-#: pkg/storaged/details.js:1253
-msgctxt "storage-id-desc"
-msgid "Other Data"
-msgstr ""
-
-#: pkg/storaged/details.js:1256
-msgctxt "storage-id-desc"
-msgid "Unrecognized Data"
-msgstr ""
-
-#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
-msgid "$size $partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1278
-msgid "mounted on $0"
-msgstr ""
-
-#: pkg/storaged/details.js:1280
-msgid "not mounted"
-msgstr ""
-
-#: pkg/storaged/details.js:1284
-msgid "unlocked"
-msgstr ""
-
-#: pkg/storaged/details.js:1286
-msgid "locked"
-msgstr ""
-
-#: pkg/storaged/details.js:1367
-msgid "$0 Free Space for Logical Partitions"
-msgstr ""
-
-#: pkg/storaged/details.js:1370
-msgid "$0 Free Space for Primary Partitions"
-msgstr ""
-
-#: pkg/storaged/details.js:1375
-msgid "$0 Free Space"
-msgstr ""
-
-#: pkg/storaged/details.js:1379
-msgid "Create Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1387
-msgid "$0 Extended Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1424
-msgid "Logical Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1426
-msgid "Primary Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1428 pkg/kubernetes/views/volume-body.html.h:5
-msgid "Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
-msgid "Content"
-msgstr ""
-
-#: pkg/storaged/details.js:1533
-msgid "RAID 0"
-msgstr ""
-
-#: pkg/storaged/details.js:1534
-msgid "RAID 1"
-msgstr ""
-
-#: pkg/storaged/details.js:1535
-msgid "RAID 4"
-msgstr ""
-
-#: pkg/storaged/details.js:1536
-msgid "RAID 5"
-msgstr ""
-
-#: pkg/storaged/details.js:1537
-msgid "RAID 6"
-msgstr ""
-
-#: pkg/storaged/details.js:1538
-msgid "RAID 10"
-msgstr ""
-
-#: pkg/storaged/details.js:1539
-msgid "RAID ($0)"
-msgstr ""
-
-#: pkg/storaged/details.js:1544
-msgid "$0 Disks"
-msgstr ""
-
-#: pkg/storaged/details.js:1546
-msgid "$0 Chunk Size"
-msgstr ""
-
-#: pkg/storaged/details.js:1574 pkg/ostree/index.html.h:7
-msgid "Running"
-msgstr ""
-
-#: pkg/storaged/details.js:1574
-msgid "Not running"
-msgstr ""
-
-#: pkg/storaged/details.js:1592
-msgid "FAILED"
-msgstr ""
-
-#: pkg/storaged/details.js:1593
-msgid "In Sync"
-msgstr ""
-
-#: pkg/storaged/details.js:1594
-msgid "Spare"
-msgstr ""
-
-#: pkg/storaged/details.js:1594
-msgid "Recovering"
-msgstr ""
-
-#: pkg/storaged/details.js:1595
-msgid "Write-mostly"
-msgstr ""
-
-#: pkg/storaged/details.js:1596
-msgid "Blocked"
-msgstr ""
+#: pkg/kubernetes/scripts/nodes.js:872
+msgid "$0% Used"
+msgid_plural "$0% Used"
+msgstr[0] ""
+msgstr[1] ""
 
-#: pkg/storaged/details.js:1597
-msgid "Unknown ($0)"
+#: pkg/storaged/details.js:1765
+msgid "$0, $1 free"
 msgstr ""
 
-#: pkg/storaged/details.js:1614
-msgid "Start Scrubbing"
+#: pkg/networkmanager/interfaces.js:2473
+msgid "$mtu"
 msgstr ""
 
-#: pkg/storaged/details.js:1615
-msgid "Stop Scrubbing"
+#: pkg/storaged/utils.js:157
+msgid "$name (from $host)"
 msgstr ""
 
 #: pkg/storaged/details.js:1653
@@ -1465,251 +425,127 @@ msgstr ""
 msgid "$size $desc<br/>($state)"
 msgstr ""
 
-#: pkg/storaged/details.js:1692
-msgid "active, but unsupported"
+#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
+msgid "$size $partition"
 msgstr ""
 
-#: pkg/storaged/details.js:1692
-msgid "inactive"
+#: pkg/docker/details.js:144
+msgid "${hip}:${hport} -> $cport"
 msgstr ""
 
-#: pkg/storaged/details.js:1711
-msgid "$0 Free Space for Logical Volumes"
+#: pkg/subscriptions/subscriptions-client.js:198
+msgid "'Organization' required to register."
 msgstr ""
 
-#: pkg/storaged/details.js:1751
-msgid "The last physical volume of a volume group cannot be removed."
+#: pkg/subscriptions/subscriptions-client.js:202
+msgid "'Organization' required when using activation keys."
 msgstr ""
 
-#: pkg/storaged/details.js:1756
-msgid ""
-"There is not enough free space elsewhere to remove this physical volume.  At "
-"least $0 more free space is needed."
-msgstr ""
-
-#: pkg/storaged/details.js:1765
-msgid "$0, $1 free"
-msgstr ""
-
-#: pkg/storaged/details.js:1792
-msgid "Logical Volumes"
-msgstr ""
-
-#: pkg/storaged/details.js:1822 pkg/docker/details.js:177
-#: pkg/docker/image.js:112
-msgid "Not found"
-msgstr ""
-
-#: pkg/storaged/overview.js:180
-msgctxt "storage"
-msgid "Hard Disk"
-msgstr ""
-
-#: pkg/storaged/overview.js:182
-msgctxt "storage"
-msgid "Solid-State Disk"
-msgstr ""
-
-#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
-msgctxt "storage"
-msgid "Removable Drive"
-msgstr ""
-
-#: pkg/storaged/overview.js:189
-msgctxt "storage"
-msgid "Optical Drive"
-msgstr ""
-
-#: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
-msgctxt "storage"
-msgid "Drive"
-msgstr ""
-
-#: pkg/storaged/overview.js:253
-msgid "$0 Block Device"
-msgstr ""
-
-#: pkg/storaged/overview.js:414
-msgid "Create RAID Device"
-msgstr ""
-
-#: pkg/storaged/overview.js:420
-msgid "RAID Level"
-msgstr ""
-
-#: pkg/storaged/overview.js:422
-msgid "RAID 0 (Stripe)"
-msgstr ""
-
-#: pkg/storaged/overview.js:423
-msgid "RAID 1 (Mirror)"
-msgstr ""
-
-#: pkg/storaged/overview.js:424
-msgid "RAID 4 (Dedicated Parity)"
-msgstr ""
-
-#: pkg/storaged/overview.js:425
-msgid "RAID 5 (Distributed Parity)"
-msgstr ""
-
-#: pkg/storaged/overview.js:426
-msgid "RAID 6 (Double Distributed Parity)"
-msgstr ""
-
-#: pkg/storaged/overview.js:427
-msgid "RAID 10 (Stripe of Mirrors)"
-msgstr ""
-
-#: pkg/storaged/overview.js:431
-msgid "Chunk Size"
-msgstr ""
-
-#: pkg/storaged/overview.js:433
-msgid "4 KiB"
-msgstr ""
-
-#: pkg/storaged/overview.js:434
-msgid "8 KiB"
-msgstr ""
-
-#: pkg/storaged/overview.js:435
-msgid "16 KiB"
-msgstr ""
-
-#: pkg/storaged/overview.js:436
-msgid "32 KiB"
-msgstr ""
-
-#: pkg/storaged/overview.js:437
-msgid "64 KiB"
-msgstr ""
-
-#: pkg/storaged/overview.js:438
-msgid "128 KiB"
-msgstr ""
-
-#: pkg/storaged/overview.js:439
-msgid "512 KiB"
+#: pkg/shell/base_index.js:674
+msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
 msgstr ""
 
 #: pkg/storaged/overview.js:440
 msgid "1 MiB"
 msgstr ""
 
+#: pkg/systemd/index.html:459 pkg/systemd/index.html:463
+msgid "1 Minute"
+msgstr ""
+
+#: pkg/storaged/index.html:312 pkg/networkmanager/index.html:55
+#: pkg/networkmanager/index.html:501
+msgid "1 day"
+msgstr ""
+
+#: pkg/storaged/index.html:310 pkg/networkmanager/index.html:53
+#: pkg/networkmanager/index.html:499
+msgid "1 hour"
+msgstr ""
+
+#: pkg/storaged/index.html:313 pkg/networkmanager/index.html:56
+#: pkg/networkmanager/index.html:502
+msgid "1 week"
+msgstr ""
+
+#: pkg/playground/translate.html:190
+msgid "1% Free"
+msgid_plural "{{$count}}% Free"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/storaged/overview.js:438
+msgid "128 KiB"
+msgstr ""
+
+#: pkg/storaged/overview.js:435
+msgid "16 KiB"
+msgstr ""
+
 #: pkg/storaged/overview.js:441
 msgid "2 MiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:455
-msgid "At least $0 disks are needed."
+#: pkg/systemd/index.html:465
+msgid "20 Minutes"
 msgstr ""
 
-#: pkg/storaged/overview.js:487
-msgid "Create Volume Group"
+#: pkg/storaged/overview.js:436
+msgid "32 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:515
-msgid "Add iSCSI Portal"
+#: pkg/storaged/overview.js:433
+msgid "4 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:518
-msgid "Server Address"
+#: pkg/systemd/index.html:466
+msgid "40 Minutes"
 msgstr ""
 
-#: pkg/storaged/overview.js:521
-msgid "Server address cannot be empty."
+#: pkg/systemd/index.html:464
+msgid "5 Minutes"
 msgstr ""
 
-#: pkg/storaged/overview.js:533 pkg/realmd/operation.html.h:11
-msgid "Next"
+#: pkg/storaged/index.html:309 pkg/networkmanager/index.html:52
+#: pkg/networkmanager/index.html:498
+msgid "5 minutes"
 msgstr ""
 
-#: pkg/storaged/overview.js:577 pkg/storaged/overview.js:668
-#: pkg/subscriptions/subscriptions-client.js:194
-msgid "Invalid username or password"
+#: pkg/storaged/overview.js:439
+msgid "512 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:582
-msgid "Unknown host name"
+#: pkg/storaged/index.html:311 pkg/networkmanager/index.html:54
+#: pkg/networkmanager/index.html:500
+msgid "6 hours"
 msgstr ""
 
-#: pkg/storaged/overview.js:586
-msgid "Unable to reach server"
+#: pkg/systemd/index.html:467
+msgid "60 Minutes"
 msgstr ""
 
-#: pkg/storaged/overview.js:619
-msgid "Available targets on $0"
+#: pkg/storaged/overview.js:437
+msgid "64 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:623 pkg/systemd/services.html.h:2
-msgid "Targets"
+#: pkg/storaged/overview.js:434
+msgid "8 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-add.html.h:2
-#: pkg/kubernetes/views/node-body.html.h:2
-#: pkg/kubernetes/views/auth-form.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:16
-#: pkg/kubernetes/views/nodes-page.html.h:7
-#: pkg/kubernetes/views/details-page.html.h:19
-msgid "Address"
+#: pkg/networkmanager/interfaces.js:1826
+msgid "802.3ad"
 msgstr ""
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-change-port.html.h:5
-msgid "Port"
+#: pkg/networkmanager/interfaces.js:1843
+msgid "802.3ad LACP"
 msgstr ""
 
-#: pkg/storaged/overview.js:699
-msgid "Change iSCSI Initiator Name"
+#: pkg/systemd/services.html:446
+msgid ":"
 msgstr ""
 
-#: pkg/storaged/overview.js:707 pkg/kubernetes/views/route-modify.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:22
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:4
-#: pkg/kubernetes/views/project-modify.html.h:9
-msgid "Change"
-msgstr ""
-
-#: pkg/storaged/utils.js:88
-msgctxt "format-bytes"
-msgid "bytes"
-msgstr ""
-
-#: pkg/storaged/utils.js:129
-msgid "Name cannot be empty."
-msgstr ""
-
-#: pkg/storaged/utils.js:131
-msgid "Name cannot be longer than 127 characters."
-msgstr ""
-
-#: pkg/storaged/utils.js:135
-msgid "Name cannot contain the character '$0'."
-msgstr ""
-
-#: pkg/storaged/utils.js:137
-msgid "Name cannot contain whitespace."
-msgstr ""
-
-#: pkg/storaged/utils.js:157
-msgid "$name (from $host)"
-msgstr ""
-
-#: pkg/storaged/utils.js:166
-msgid "Pool for Thin Logical Volumes"
-msgstr ""
-
-#: pkg/storaged/utils.js:168
-msgid "Thin Logical Volume"
-msgstr ""
-
-#: pkg/storaged/utils.js:170
-msgid "Logical Volume (Snapshot)"
-msgstr ""
-
-#: pkg/storaged/utils.js:172
-msgid "Logical Volume"
+#: pkg/storaged/utils.js:220
+msgid "<span>Encrypted $0</span>"
 msgstr ""
 
 #: pkg/storaged/utils.js:212
@@ -1728,104 +564,620 @@ msgstr ""
 msgid "<span>Partition of $0</span>"
 msgstr ""
 
-#: pkg/storaged/utils.js:220
-msgid "<span>Encrypted $0</span>"
+#: pkg/lib/machine-not-supported.html:5
+msgid ""
+"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
+"strong}}."
 msgstr ""
 
-#: pkg/storaged/utils.js:233
-msgid "RAID Device $0"
+#: cockpit.desktop.in.h:2
+msgid "A user interface for GNU/Linux servers"
 msgstr ""
 
-#: pkg/storaged/utils.js:239
-msgid "Volume Group $0"
+#: pkg/networkmanager/interfaces.js:1834
+msgid "ARP"
 msgstr ""
 
-#: pkg/storaged/jobs.js:119
-msgid "SMART self-test of $target"
+#: pkg/networkmanager/interfaces.js:2502
+msgid "ARP Monitoring"
 msgstr ""
 
-#: pkg/storaged/jobs.js:120
-msgid "Ejecting $target"
+#: pkg/networkmanager/interfaces.js:1855
+msgid "ARP Ping"
 msgstr ""
 
-#: pkg/storaged/jobs.js:121
-msgid "Unlocking $target"
+#: pkg/kubernetes/scripts/volumes.js:193
+msgid "AWS Elastic Block Store"
 msgstr ""
 
-#: pkg/storaged/jobs.js:122
-msgid "Locking $target"
+#: pkg/shell/simple.html:41 pkg/shell/simple.html:67 pkg/shell/index.html:41
+#: pkg/shell/index.html:80 pkg/shell/stub.html:41 pkg/shell/stub.html:73
+msgid "About Cockpit"
 msgstr ""
 
-#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
-msgid "Modifying $target"
+#: pkg/users/index.html:105 pkg/users/index.html:191
+msgid "Access"
 msgstr ""
 
-#: pkg/storaged/jobs.js:124
-msgid "Starting swapspace $target"
+#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pv-claim.html:9
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-body.html:9
+msgid "Access Modes"
 msgstr ""
 
-#: pkg/storaged/jobs.js:125
-msgid "Stopping swapspace $target"
+#: pkg/kubernetes/views/project-modify.html:49
+#: pkg/kubernetes/views/imagestream-body.html:11
+msgid "Access Policy"
 msgstr ""
 
-#: pkg/storaged/jobs.js:126
-msgid "Mounting $target"
+#: pkg/subscriptions/subscriptions-view.jsx:191
+msgid "Access denied"
 msgstr ""
 
-#: pkg/storaged/jobs.js:127
-msgid "Unmounting $target"
+#: pkg/shell/index.html:45
+msgid "Account Settings"
 msgstr ""
 
-#: pkg/storaged/jobs.js:129
-msgid "Erasing $target"
+#: pkg/users/index.html:63
+msgid "Account not available or cannot be edited."
 msgstr ""
 
-#: pkg/storaged/jobs.js:130
-msgid "Creating filesystem on $target"
+#: pkg/users/index.html:71
+msgid "Accounts"
 msgstr ""
 
-#: pkg/storaged/jobs.js:131
-msgid "Setting up loop device $target"
+#: pkg/users/local.js:284 pkg/users/local.js:594
+msgctxt "page-title"
+msgid "Accounts"
 msgstr ""
 
-#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
-msgid "Deleting $target"
+#: pkg/storaged/details.js:1127
+msgid "Activate"
 msgstr ""
 
-#: pkg/storaged/jobs.js:134
-msgid "Creating partition $target"
+#: pkg/storaged/jobs.js:148
+msgid "Activating $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:135
-msgid "Cleaning up for $target"
+#: pkg/subscriptions/subscriptions-register.jsx:164
+msgid "Activation Key"
 msgstr ""
 
-#: pkg/storaged/jobs.js:136
-msgid "Securely erasing $target"
+#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
+msgid "Active"
 msgstr ""
 
-#: pkg/storaged/jobs.js:137
-msgid "Very securely erasing $target"
+#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
+msgid "Active Backup"
 msgstr ""
 
-#: pkg/storaged/jobs.js:138
-msgid "Stopping RAID Device $target"
+#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
+msgid "Actual"
 msgstr ""
 
-#: pkg/storaged/jobs.js:139
-msgid "Starting RAID Device $target"
+#: pkg/networkmanager/interfaces.js:1828
+msgid "Adaptive load balancing"
 msgstr ""
 
-#: pkg/storaged/jobs.js:140
-msgid "Marking $target as faulty"
+#: pkg/networkmanager/interfaces.js:1827
+msgid "Adaptive transmit load balancing"
 msgstr ""
 
-#: pkg/storaged/jobs.js:141
-msgid "Removing $target from RAID Device"
+#: pkg/kubernetes/views/add-user-dialog.html:31
+#: pkg/kubernetes/views/node-add.html:50
+#: pkg/kubernetes/views/user-add-membership.html:53
+#: pkg/kubernetes/views/add-member-role-dialog.html:61
+#: pkg/kubernetes/views/user-group-add.html:32
+#: pkg/kubernetes/views/add-role-dialog.html:8 pkg/lib/machine-add.html:43
+msgid "Add"
 msgstr ""
 
-#: pkg/storaged/jobs.js:142
-msgid "Creating RAID Device $target"
+#: pkg/networkmanager/interfaces.js:2836
+msgid "Add $0"
+msgstr ""
+
+#: pkg/docker/storage.jsx:363
+msgid "Add Additional Storage"
+msgstr ""
+
+#: pkg/networkmanager/index.html:86
+msgid "Add Bond"
+msgstr ""
+
+#: pkg/networkmanager/index.html:88
+msgid "Add Bridge"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:3
+msgid "Add Cluster Node"
+msgstr ""
+
+#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
+msgid "Add Disks"
+msgstr ""
+
+#: pkg/kubernetes/views/add-group-dialog.html:3
+msgid "Add Group"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:34
+msgid "Add Kubernetes Node"
+msgstr ""
+
+#: pkg/lib/machine-add.html:4
+msgid "Add Machine to Dashboard"
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:38
+#: pkg/kubernetes/views/add-member-role-dialog.html:4
+#: pkg/kubernetes/views/group-panel.html:29
+#: pkg/kubernetes/views/user-group-add.html:3
+#: pkg/kubernetes/views/project-body.html:108
+msgid "Add Member"
+msgstr ""
+
+#: pkg/kubernetes/views/user-panel.html:76
+#: pkg/kubernetes/views/user-body.html:67
+msgid "Add Membership"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:11
+#: pkg/kubernetes/views/auth-form.html:20
+msgid "Add New Cluster"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:67
+#: pkg/kubernetes/views/auth-form.html:76
+msgid "Add New User"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:3
+msgid "Add Role"
+msgstr ""
+
+#: pkg/networkmanager/index.html:87
+msgid "Add Team"
+msgstr ""
+
+#: pkg/kubernetes/views/add-user-dialog.html:3
+#: pkg/kubernetes/views/project-listing.html:83
+msgid "Add User"
+msgstr ""
+
+#: pkg/networkmanager/index.html:89
+msgid "Add VLAN"
+msgstr ""
+
+#: pkg/storaged/overview.js:515
+msgid "Add iSCSI Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/user-add-membership.html:3
+msgid "Add membership"
+msgstr ""
+
+#: pkg/users/index.html:351
+msgid "Add public key"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2833
+msgid "Adding <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/users/authorized-keys.js:108
+msgid "Adding key"
+msgstr ""
+
+#: pkg/storaged/jobs.js:153
+msgid "Adding physical volume to $target"
+msgstr ""
+
+#: pkg/docker/index.html:329
+msgid "Additional Storage"
+msgstr ""
+
+#: pkg/ostree/index.html:121 pkg/ostree/index.html:140
+msgid "Additions"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:8
+#: pkg/kubernetes/views/dashboard-page.html:157
+#: pkg/kubernetes/views/details-page.html:174
+#: pkg/kubernetes/views/nodes-page.html:43
+#: pkg/kubernetes/views/auth-form.html:29 pkg/kubernetes/views/node-body.html:5
+#: pkg/lib/machine-add.html:11
+msgid "Address"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:37
+msgid "Addresses"
+msgstr ""
+
+#: pkg/kubernetes/views/service-modify.html:25
+msgid "Adjust"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:3
+msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-modify.html:3
+msgid "Adjust Replication Controller {{ item.metadata.name }}"
+msgstr ""
+
+#: pkg/kubernetes/views/route-modify.html:3
+msgid "Adjust Route"
+msgstr ""
+
+#: pkg/kubernetes/views/service-modify.html:3
+msgid "Adjust Service"
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:56
+msgid "Admin"
+msgstr ""
+
+#: pkg/systemd/services.html:389 pkg/systemd/services.html:393
+msgid "After system boot"
+msgstr ""
+
+#: pkg/systemd/logs.html:50
+msgid "All"
+msgstr ""
+
+#: pkg/kubernetes/views/filter-project.html:4
+msgid "All Projects"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:6
+msgid "All Types"
+msgstr ""
+
+#: pkg/docker/storage.jsx:366
+msgid ""
+"All data on selected disks will be erased and disks will be added to the "
+"storage pool."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:112
+msgid "All healthy"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:74
+msgid "All images"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:69
+msgid "All in use"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:37
+msgid "All running"
+msgstr ""
+
+#: pkg/docker/index.html:569
+msgid "Always"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-meta.html:2
+#: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/image-meta.html:9
+#: pkg/kubernetes/views/node-body.html:57
+msgid "Annotations"
+msgstr ""
+
+#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
+msgid "Apply"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:107
+msgid "Apply this solution"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:82
+msgid "Applying solution..."
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:12
+msgid "Architecture"
+msgstr ""
+
+#: pkg/storaged/index.html:451
+msgctxt "storage"
+msgid "Assessment"
+msgstr ""
+
+#: pkg/systemd/index.html:81
+msgid "Asset Tag"
+msgstr ""
+
+#: pkg/storaged/overview.js:455
+msgid "At least $0 disks are needed."
+msgstr ""
+
+#: pkg/storaged/overview.js:501 pkg/storaged/details.js:579
+#: pkg/storaged/details.js:948
+msgid "At least one disk is needed."
+msgstr ""
+
+#: pkg/systemd/services.html:394
+msgid "At specific time"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:813
+msgid "Authenticating"
+msgstr ""
+
+#: pkg/realmd/operation.html:34 pkg/shell/index.html:48
+#: pkg/shell/index.html:159 pkg/kubernetes/views/auth-form.html:85
+#: pkg/lib/machine-change-auth.html:32
+msgid "Authentication"
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:2
+msgid "Authentication Failed"
+msgstr ""
+
+#: pkg/docker/index.html:730 pkg/kubernetes/views/image-body.html:12
+#: pkg/kubernetes/views/image-listing.html:15
+msgid "Author"
+msgstr ""
+
+#: pkg/users/index.html:130
+msgid "Authorized Public SSH Keys"
+msgstr ""
+
+#: pkg/networkmanager/index.html:165
+msgid "Automatic"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1814
+msgid "Automatic (DHCP only)"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1804
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: pkg/systemd/index.html:406
+msgid "Automatically using NTP"
+msgstr ""
+
+#: pkg/systemd/index.html:407
+msgid "Automatically using specific NTP servers"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:66
+msgid "Available"
+msgstr ""
+
+#: pkg/storaged/overview.js:619
+msgid "Available targets on $0"
+msgstr ""
+
+#: pkg/dashboard/index.html:177
+msgid "Avatar"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:207
+msgid "Azure"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
+msgid "Bad data passed for passwd1 mechanism"
+msgstr ""
+
+#: pkg/networkmanager/index.html:389
+msgid "Balancer"
+msgstr ""
+
+#: pkg/storaged/index.html:560
+msgctxt "storage"
+msgid "Bitmap"
+msgstr ""
+
+#: pkg/storaged/index.html:414
+msgid "Block Device"
+msgstr ""
+
+#: pkg/storaged/details.js:871
+msgid "Block device for filesystems"
+msgstr ""
+
+#: pkg/storaged/details.js:1596
+msgid "Blocked"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
+#: pkg/networkmanager/interfaces.js:2507
+msgid "Bond"
+msgstr ""
+
+#: pkg/networkmanager/index.html:596
+msgid "Bond Settings"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:17
+msgid "Boot ID"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
+#: pkg/networkmanager/interfaces.js:2584
+msgid "Bridge"
+msgstr ""
+
+#: pkg/networkmanager/index.html:708
+msgid "Bridge Port Settings"
+msgstr ""
+
+#: pkg/networkmanager/index.html:680
+msgid "Bridge Settings"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2605
+msgid "Bridge port"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
+msgid "Broadcast"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+msgid "Broken configuration"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:16
+msgid "Built"
+msgstr ""
+
+#: pkg/dashboard/index.html:70
+msgid "CPU"
+msgstr ""
+
+#: pkg/systemd/host.js:1381
+msgctxt "page-title"
+msgid "CPU Status"
+msgstr "Tilstand"
+
+#: pkg/kubernetes/scripts/nodes.js:712
+msgid "CPU Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:490 pkg/docker/index.html:669
+msgid "CPU priority"
+msgstr ""
+
+#: pkg/systemd/index.html:247
+msgid "Cached"
+msgstr ""
+
+#: pkg/docker/index.html:63
+msgid "Can&rsquo;t connect to Docker"
+msgstr ""
+
+#: pkg/systemd/services.html:465 pkg/dashboard/index.html:189
+#: pkg/playground/translate.html:40 pkg/playground/translate.html:174
+#: pkg/realmd/operation.html:90 pkg/kubernetes/views/pv-modify.html:202
+#: pkg/kubernetes/views/item-delete.html:10
+#: pkg/kubernetes/views/add-user-dialog.html:30
+#: pkg/kubernetes/views/project-modify.html:71
+#: pkg/kubernetes/views/node-add.html:49
+#: pkg/kubernetes/views/pvc-delete.html:14
+#: pkg/kubernetes/views/node-delete.html:14
+#: pkg/kubernetes/views/imagestream-modify.html:96
+#: pkg/kubernetes/views/imagestream-delete.html:7
+#: pkg/kubernetes/views/user-modify.html:30
+#: pkg/kubernetes/views/add-group-dialog.html:20
+#: pkg/kubernetes/views/project-delete.html:8
+#: pkg/kubernetes/views/service-modify.html:24
+#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/kubernetes/views/user-group-remove.html:9
+#: pkg/kubernetes/views/user-add-membership.html:52
+#: pkg/kubernetes/views/add-member-role-dialog.html:60
+#: pkg/kubernetes/views/group-delete.html:20
+#: pkg/kubernetes/views/image-delete.html:7 pkg/kubernetes/views/deploy.html:61
+#: pkg/kubernetes/views/user-group-add.html:31
+#: pkg/kubernetes/views/auth-form.html:128
+#: pkg/kubernetes/views/auth-rejected-cert.html:31
+#: pkg/kubernetes/views/replicationcontroller-modify.html:16
+#: pkg/kubernetes/views/pv-delete.html:10
+#: pkg/kubernetes/views/add-role-dialog.html:7
+#: pkg/kubernetes/views/route-modify.html:16
+#: pkg/kubernetes/views/user-delete.html:24
+#: pkg/kubernetes/views/remove-role-dialog.html:7 pkg/storaged/index.html:289
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:79
+msgid "Cancel"
+msgstr "Annullér"
+
+#: pkg/shell/indexes.js:322
+msgid "Cannot connect to an unknown machine"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:359
+msgid "Cannot decrypt PEM-encoded private key"
+msgstr ""
+
+#: src/base1/cockpit.js:3707
+msgid "Cannot forward login credentials"
+msgstr ""
+
+#: pkg/realmd/operation.js:417
+msgid "Cannot join a domain because realmd is not available on this system"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:44
+#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pv-body.html:13
+msgid "Capacity"
+msgstr ""
+
+#: pkg/storaged/index.html:443 pkg/storaged/index.html:519
+#: pkg/storaged/index.html:551 pkg/storaged/index.html:630
+msgctxt "storage"
+msgid "Capacity"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2276
+msgid "Carrier"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:203
+msgid "Ceph Filesystem Mount"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:97
+msgid "Ceph Monitors"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:204
+#: pkg/kubernetes/views/project-modify.html:74
+#: pkg/kubernetes/views/replicationcontroller-modify.html:17
+#: pkg/kubernetes/views/route-modify.html:17
+msgid "Change"
+msgstr ""
+
+#: pkg/shell/index.html:278
+msgid "Change Password"
+msgstr ""
+
+#: pkg/tuned/dialog.js:191
+msgid "Change Performance Profile"
+msgstr ""
+
+#: pkg/tuned/dialog.js:200
+msgid "Change Profile"
+msgstr ""
+
+#: pkg/kubernetes/views/user-modify.html:3
+msgid "Change User"
+msgstr ""
+
+#: pkg/storaged/overview.js:699
+msgid "Change iSCSI Initiator Name"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:4
+msgid "Change image stream"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:10
+msgid "Change project"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2872
+msgid "Change the settings"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2870
+msgid "Changing the settings will break the connection to the server, "
+msgstr ""
+
+#: pkg/ostree/index.html:48
+msgid "Check for updates"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:817
+msgid "Checking IP"
 msgstr ""
 
 #: pkg/storaged/jobs.js:143
@@ -1836,76 +1188,823 @@ msgstr ""
 msgid "Checking and Repairing RAID Device $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:145
-msgid "Recovering RAID Device $target"
+#: pkg/lib/machine-change-auth.html:70
+msgid "Checking for public keys"
 msgstr ""
 
-#: pkg/storaged/jobs.js:146
-msgid "Synchronizing RAID Device $target"
+#: pkg/ostree/app.js:219
+msgid "Checking for updates"
 msgstr ""
 
-#: pkg/storaged/jobs.js:148
-msgid "Activating $target"
+#: pkg/shell/simple.html:100 pkg/shell/index.html:121 pkg/shell/stub.html:114
+msgid "Choose the language to be used in the application"
 msgstr ""
 
-#: pkg/storaged/jobs.js:149
-msgid "Deactivating $target"
+#: pkg/storaged/overview.js:431
+msgid "Chunk Size"
 msgstr ""
 
-#: pkg/storaged/jobs.js:150
-msgid "Creating snapshot of $target"
+#: pkg/kubernetes/scripts/volumes.js:202
+msgid "Cinder"
 msgstr ""
 
-#: pkg/storaged/jobs.js:151
-msgid "Creating volume group $target"
+#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
+msgid "Claim"
 msgstr ""
 
-#: pkg/storaged/jobs.js:152
-msgid "Deleting volume group $target"
+#: pkg/kubernetes/views/pvc-body.html:4
+msgid "Claim Name"
 msgstr ""
 
-#: pkg/storaged/jobs.js:153
-msgid "Adding physical volume to $target"
+#: pkg/storaged/jobs.js:135
+msgid "Cleaning up for $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:154
-msgid "Removing physical volume from $target"
+#: pkg/kubernetes/views/auth-form.html:88
+msgid "Client Certificate"
 msgstr ""
 
-#: pkg/storaged/jobs.js:155
-msgid "Emptying $target"
+#: pkg/systemd/services.html:306 pkg/systemd/services.html:324
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-invalid-hostkey.html:19
+msgid "Close"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:5
+msgid "Cluster"
+msgstr ""
+
+#: cockpit.desktop.in.h:1
+msgid "Cockpit"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:429
+msgid ""
+"Cockpit could not contact the given host $0. Make sure it has ssh running on "
+"port $1, or specify another port in the address."
+msgstr ""
+
+#: src/base1/cockpit.js:3713
+msgid "Cockpit could not contact the given host."
+msgstr ""
+
+#: pkg/shell/base_index.js:671
+msgid "Cockpit had an unexpected internal error. <br/><br/>"
+msgstr ""
+
+#: cockpit.appdata.xml.in.h:1
+msgid ""
+"Cockpit is a server manager that makes it easy to administer your Linux "
+"servers via a web browser. Jumping between the terminal and the web tool is "
+"no problem. A service started via Cockpit can be stopped via the terminal. "
+"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
+"journal interface."
+msgstr ""
+
+#: src/base1/cockpit.js:3711
+msgid "Cockpit is not compatible with the software on the system."
+msgstr ""
+
+#: pkg/lib/machine-not-supported.html:2
+msgid "Cockpit is not installed"
+msgstr ""
+
+#: src/base1/cockpit.js:3705
+msgid "Cockpit is not installed on the system."
+msgstr ""
+
+#: cockpit.appdata.xml.in.h:2
+msgid ""
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
+"tasks such as storage administration, inspecting journals and starting and "
+"stopping services. You can monitor and administer several servers at the "
+"same time. Just add them with a single click and your machines will look "
+"after its buddies."
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:9
+msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:15
+msgid ""
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:9
+msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:6
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
+"machine with cockpit you will need to enable one of the following "
+"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:13
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
+"change your authentication credentials below. {{#can_sync}}You may prefer to "
+"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+msgstr ""
+
+#: pkg/dashboard/index.html:171 pkg/lib/machine-add.html:27
+msgid "Color"
+msgstr ""
+
+#: pkg/docker/index.html:95
+msgid "Combined CPU usage"
+msgstr ""
+
+#: pkg/docker/index.html:101
+msgid "Combined memory usage"
+msgstr ""
+
+#: pkg/systemd/services.html:370 pkg/docker/index.html:466
+#: pkg/docker/index.html:736
+msgid "Command"
+msgstr ""
+
+#: pkg/docker/run.js:332
+msgid "Command can't be empty"
+msgstr ""
+
+#: pkg/docker/containers-view.jsx:239
+msgid "Commit"
+msgstr ""
+
+#: pkg/tuned/dialog.js:114
+msgid "Communication with tuned has failed"
+msgstr ""
+
+#: pkg/storaged/details.js:348
+msgid "Compatible with all systems and devices (MBR)"
+msgstr ""
+
+#: pkg/storaged/details.js:349
+msgid "Compatible with modern system and hard disks > 2TB (GPT)"
+msgstr ""
+
+#: pkg/realmd/operation.html:28
+msgid "Computer OU"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:24
+msgid "Configuration"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2441
+msgid "Configure"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:42
+msgid "Configure Flannel networking"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:32
+msgid "Configure Kubelet and Proxy"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:811
+msgid "Configuring"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:815
+msgid "Configuring IP"
+msgstr ""
+
+#: pkg/users/index.html:171 pkg/shell/index.html:262
+msgid "Confirm"
+msgstr ""
+
+#: pkg/users/index.html:247
+msgid "Confirm New Password"
+msgstr ""
+
+#: pkg/storaged/details.js:229
+msgid "Confirm passphrase"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:130
+#: pkg/kubernetes/views/auth-rejected-cert.html:33
+#: pkg/lib/machine-unknown-hostkey.html:22
+msgid "Connect"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2637
+msgid "Connect automatically"
+msgstr ""
+
+#: pkg/ostree/index.html:218
+msgid "Connecting"
+msgstr ""
+
+#: pkg/lib/machine-add.html:39
+msgid ""
+"Connecting simultaneously to more than {{ limit }} machines is unsupported."
+msgstr ""
+
+#: pkg/docker/index.html:54
+msgid "Connecting to Docker"
+msgstr ""
+
+#: pkg/shell/indexes.js:317
+msgid "Connecting to the machine"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:70 pkg/kubernetes/index.html:100
+msgid "Connecting..."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-dialog.html:4
+msgid "Connection Error"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:516
+msgid "Connection Error: $0"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-dialog.html:3
+msgid "Connection Settings"
+msgstr ""
+
+#: src/base1/cockpit.js:3703
+msgid "Connection has timed out."
+msgstr ""
+
+#: pkg/networkmanager/index.html:812
+msgid "Connection will be lost"
+msgstr ""
+
+#: pkg/docker/console.html:4 pkg/kubernetes/views/container-panel.html:4
+#: pkg/kubernetes/views/image-panel.html:12
+#: pkg/kubernetes/views/container-body.html:4
+#: pkg/kubernetes/views/container-page-inline.html:2
+#: pkg/kubernetes/views/image-page.html:19
+msgid "Container"
+msgstr ""
+
+#: pkg/users/local.js:684
+msgid "Container Administrator"
+msgstr ""
+
+#: pkg/kubernetes/views/container-body.html:10
+msgid "Container ID"
+msgstr ""
+
+#: pkg/docker/index.html:459 pkg/docker/index.html:646
+#: pkg/docker/index.html:712
+msgid "Container Name"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:21
+msgid "Container Runtime Version"
+msgstr ""
+
+#: pkg/docker/util.js:490
+msgid ""
+"Container is currently marked as not running, but regular stopping failed."
+msgstr ""
+
+#: pkg/docker/util.js:488
+msgid "Container is currently running."
+msgstr ""
+
+#: pkg/docker/index.html:23 pkg/docker/index.html:309
+#: pkg/kubernetes/views/pod-page.html:36
+#: pkg/kubernetes/views/dashboard-page.html:158
+#: pkg/kubernetes/views/dashboard-page.html:199
+#: pkg/kubernetes/views/containers-listing.html:5 pkg/kubernetes/index.html:51
+msgid "Containers"
+msgstr ""
+
+#: pkg/docker/details.js:47 pkg/docker/image.js:43
+msgctxt "page-title"
+msgid "Containers"
+msgstr ""
+
+#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
+msgid "Content"
+msgstr ""
+
+#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
+#: pkg/playground/translate.js:19
+msgid "Control"
+msgstr ""
+
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
+#: pkg/playground/translate.js:22
+msgctxt "key"
+msgid "Control"
+msgstr ""
+
+#: pkg/docker/storage.jsx:404
+msgid "Could not add all disks"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:4
+msgid "Could not contact {{host}}"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:142
+msgid "Could not list services"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:407
+msgid "Could not parse PEM-encoded certificate"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:374
+msgid "Could not parse PEM-encoded private key"
+msgstr ""
+
+#: pkg/docker/storage.jsx:446
+msgid "Could not reset the storage pool"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:467
+msgid "Couldn't change user groups"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:520
+msgid "Couldn't change user password"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:385
+msgid ""
+"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
+"server is installed."
+msgstr ""
+
+#: pkg/kubernetes/registry.html:71 pkg/kubernetes/index.html:101
+msgid "Couldn't connect to server"
+msgstr ""
+
+#: pkg/shell/indexes.js:320
+msgid "Couldn't connect to the machine"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:544
+msgid "Couldn't create new users"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:514
+msgid "Couldn't find running API server"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:196
+msgid ""
+"Couldn't get system subscription status. Please ensure subscription-manager "
+"is installed."
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:642
+msgid "Couldn't list local users"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:236
+msgid "Couldn't list users"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:382
+msgid "Couldn't load user data"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:72
+#: pkg/kubernetes/views/add-group-dialog.html:21
+msgid "Create"
+msgstr ""
+
+#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
+msgid "Create Logical Volume"
+msgstr ""
+
+#: pkg/users/index.html:54 pkg/users/index.html:143
+msgid "Create New Account"
+msgstr ""
+
+#: pkg/storaged/details.js:1379
+msgid "Create Partition"
+msgstr ""
+
+#: pkg/storaged/overview.js:414
+msgid "Create RAID Device"
+msgstr ""
+
+#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
+msgid "Create Snapshot"
+msgstr ""
+
+#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
+msgid "Create Thin Volume"
+msgstr ""
+
+#: pkg/systemd/services.html:336
+msgid "Create Timers"
+msgstr ""
+
+#: pkg/storaged/overview.js:487
+msgid "Create Volume Group"
+msgstr ""
+
+#: pkg/sosreport/index.html:50
+msgid "Create diagnostic report"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:3
+msgid "Create image stream"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
+#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
+msgid "Create it"
+msgstr ""
+
+#: pkg/storaged/details.js:266
+msgid "Create partition"
+msgstr ""
+
+#: pkg/storaged/details.js:113
+msgid "Create partition on $0"
+msgstr ""
+
+#: pkg/storaged/index.html:381
+msgid "Create partition table"
+msgstr ""
+
+#: pkg/sosreport/index.html:42
+msgid "Create report"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/replicationcontroller-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7 pkg/kubernetes/views/route-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3
+msgid "Created"
+msgstr ""
+
+#: pkg/storaged/jobs.js:142
+msgid "Creating RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:130
+msgid "Creating filesystem on $target"
 msgstr ""
 
 #: pkg/storaged/jobs.js:156
 msgid "Creating logical volume $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:157
-msgid "Renaming $target"
+#: pkg/storaged/jobs.js:134
+msgid "Creating partition $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:158
-msgid "Resizing $target"
+#: pkg/storaged/jobs.js:150
+msgid "Creating snapshot of $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:166
-msgid "Operation '$operation' on $target"
+#: pkg/networkmanager/interfaces.js:4064
+msgid "Creating this VLAN will break the connection to the server, "
 msgstr ""
 
-#: pkg/storaged/jobs.js:180
-msgid "unknown target"
+#: pkg/networkmanager/interfaces.js:3436
+msgid "Creating this bond will break the connection to the server, "
 msgstr ""
 
-#: pkg/storaged/permissions.js:61
-msgid "The user <b>$0</b> is not permitted to manage storage"
+#: pkg/networkmanager/interfaces.js:3842
+msgid "Creating this bridge will break the connection to the server, "
 msgstr ""
 
-#: pkg/realmd/operation.js:96
-msgid "Join"
+#: pkg/networkmanager/interfaces.js:3611
+msgid "Creating this team will break the connection to the server, "
 msgstr ""
 
-#: pkg/realmd/operation.js:101
-msgid "Leave"
+#: pkg/storaged/jobs.js:151
+msgid "Creating volume group $target"
+msgstr ""
+
+#: pkg/systemd/logs.html:41
+msgid "Current boot"
+msgstr ""
+
+#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
+msgid "Custom"
+msgstr ""
+
+#: pkg/storaged/details.js:186
+msgid "Custom (Enter filesystem type)"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:102
+msgid "Custom URL"
+msgstr ""
+
+#: pkg/storaged/index.html:454
+msgid "DISK IS FAILING"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3018
+msgid "DNS"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:14
+msgid "DNS Policy"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3022
+msgid "DNS Search Domains"
+msgstr ""
+
+#: pkg/dashboard/index.html:22
+msgid "Dashboard"
+msgstr ""
+
+#: pkg/storaged/details.js:1130
+msgid "Deactivate"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:823
+msgid "Deactivating"
+msgstr ""
+
+#: pkg/storaged/jobs.js:149
+msgid "Deactivating $target"
+msgstr ""
+
+#: pkg/docker/index.html:379 pkg/docker/index.html:383
+#: pkg/kubernetes/views/image-config.html:6
+msgid "Default"
+msgstr ""
+
+#: pkg/systemd/index.html:454
+msgid "Delay"
+msgstr ""
+
+#: pkg/users/index.html:79 pkg/kubernetes/views/item-delete.html:11
+#: pkg/kubernetes/views/pvc-delete.html:15
+#: pkg/kubernetes/views/node-delete.html:15
+#: pkg/kubernetes/views/imagestream-delete.html:8
+#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/kubernetes/views/image-delete.html:8
+#: pkg/kubernetes/views/pv-delete.html:11
+msgid "Delete"
+msgstr ""
+
+#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
+msgid "Delete $0"
+msgstr ""
+
+#: pkg/users/index.html:292
+msgid "Delete Files"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:4
+msgid "Delete Node"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:3
+msgid "Delete Persistent Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:3
+msgid "Delete Persistent Volume Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/project-delete.html:3
+msgid "Delete Project"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:3
+msgid "Delete Selected"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:3
+msgid "Delete image stream"
+msgstr ""
+
+#: pkg/playground/translate.html:184 pkg/kubernetes/views/item-delete.html:3
+msgid "Delete {{ item.kind }}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
+msgid "Deleting $target"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2156
+msgid "Deleting <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:7
+msgid ""
+"Deleting a Pod will kill all associated containers. Pods may be "
+"automatically created again in some cases."
+msgstr ""
+
+#: pkg/storaged/details.js:631
+msgid "Deleting a RAID device will erase all data on it."
+msgstr ""
+
+#: pkg/docker/containers-view.jsx:167 pkg/docker/details.js:272
+msgid "Deleting a container will erase all data in it."
+msgstr ""
+
+#: pkg/storaged/details.js:1009
+msgid "Deleting a logical volume will delete all data in it."
+msgstr ""
+
+#: pkg/storaged/details.js:1012
+msgid "Deleting a partition will delete all data in it."
+msgstr ""
+
+#: pkg/storaged/details.js:826
+msgid "Deleting a volume group will erase all data on it."
+msgstr ""
+
+#: pkg/docker/image.js:152
+msgid ""
+"Deleting an image will delete it, but you can probably download it again if "
+"you need it later.  Unless this image has never been pushed to a repository, "
+"that is, in which case you probably can't download it again."
+msgstr ""
+
+#: pkg/storaged/jobs.js:152
+msgid "Deleting volume group $target"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:131
+#: pkg/kubernetes/views/deploy.html:62
+msgid "Deploy"
+msgstr ""
+
+#: pkg/kubernetes/views/deploy.html:3
+msgid "Deploy Application"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:22
+msgid "Deployment Causes"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-panel.html:8
+#: pkg/kubernetes/views/deploymentconfig-page.html:12
+msgid "Deployment Config"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:98
+msgid "Deployment Configs"
+msgstr ""
+
+#: pkg/systemd/services.html:356 pkg/kubernetes/views/project-modify.html:40
+#: pkg/kubernetes/views/image-body.html:6
+#: pkg/kubernetes/views/project-listing.html:15
+#: pkg/kubernetes/views/project-listing.html:54
+msgid "Description"
+msgstr ""
+
+#: pkg/shell/index.html:197 pkg/kubernetes/index.html:63
+msgid "Details"
+msgstr ""
+
+#: pkg/storaged/index.html:543
+msgctxt "storage"
+msgid "Device"
+msgstr ""
+
+#: pkg/storaged/details.js:91
+msgid "Device $0 is a member of RAID Array $1"
+msgstr ""
+
+#: pkg/storaged/details.js:97
+msgid "Device $0 is a physical volume of $1"
+msgstr ""
+
+#: pkg/storaged/details.js:85
+msgid "Device $0 is mounted on $1"
+msgstr ""
+
+#: pkg/storaged/index.html:467 pkg/storaged/index.html:473
+#: pkg/storaged/index.html:515
+#, fuzzy
+msgctxt "storage"
+msgid "Device File"
+msgstr "Værtsnavn"
+
+#: pkg/sosreport/index.html:22
+msgid "Diagnostic reports"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:20
+msgid "Digest"
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:7
+#: pkg/kubernetes/views/volume-body.html:28
+msgid "Directory"
+msgstr ""
+
+#: pkg/systemd/init.js:543
+msgid "Disable"
+msgstr ""
+
+#: pkg/tuned/dialog.js:234
+msgid "Disable tuned"
+msgstr ""
+
+#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
+msgid "Disabled"
+msgstr ""
+
+#: pkg/shell/simple.html:120
+msgid "Disconnected"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+#, fuzzy
+msgid "Disk"
+msgstr "Disk I/O"
+
+#: pkg/dashboard/index.html:73
+#, fuzzy
+msgid "Disk I/O"
+msgstr "Disk I/O"
+
+#: pkg/kubernetes/scripts/nodes.js:720
+msgid "Disk Utilization: $0%"
+msgstr ""
+
+#: pkg/storaged/index.html:457
+msgid "Disk is OK"
+msgstr ""
+
+#: pkg/storaged/index.html:584
+#, fuzzy
+msgid "Disks"
+msgstr "Disk I/O"
+
+#: pkg/shell/simple.html:37 pkg/shell/simple.html:97 pkg/shell/index.html:37
+#: pkg/shell/index.html:118 pkg/shell/stub.html:37 pkg/shell/stub.html:111
+msgid "Display Language"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:31
+msgid "Display name"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:5
+msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:5
+msgid ""
+"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}' image stream?"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:6
+msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:6
+msgid ""
+"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:6
+msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:7
+msgid "Do you want to delete this Node?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:5
+msgid ""
+"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+"{{stream.metadata.name}}:{{tag.tag}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/remove-role-dialog.html:5
+msgid ""
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:11
+msgid "Docker Version"
+msgstr ""
+
+#: pkg/docker/index.html:60
+msgid "Docker is not installed or activated on the system"
+msgstr ""
+
+#: pkg/systemd/index.html:107
+msgid "Domain"
 msgstr ""
 
 #: pkg/realmd/operation.js:148
@@ -1916,86 +2015,416 @@ msgstr ""
 msgid "Domain $0 is not supported"
 msgstr ""
 
-#: pkg/realmd/operation.js:347
-msgid "Joining this domain is not supported"
+#: pkg/realmd/operation.html:11
+msgid "Domain Address"
 msgstr ""
 
-#: pkg/realmd/operation.js:366
-msgid "More"
+#: pkg/realmd/operation.html:59
+msgid "Domain Administrator Name"
 msgstr ""
 
-#: pkg/realmd/operation.js:417
-msgid "Cannot join a domain because realmd is not available on this system"
+#: pkg/realmd/operation.html:65
+msgid "Domain Administrator Password"
 msgstr ""
 
-#: pkg/realmd/operation.js:436
-msgid "The user <b>$0</b> is not permitted to modify realms"
+#: pkg/systemd/services.html:426 pkg/systemd/services.html:430
+msgid "Don't Repeat"
 msgstr ""
 
-#: pkg/realmd/operation.js:453
-msgid "Join Domain"
+#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
+msgid "Don't overwrite existing data"
 msgstr ""
 
-#: pkg/docker/run.js:246 pkg/docker/util.js:102
-#: pkg/networkmanager/interfaces.js:2280 pkg/kubernetes/scripts/volumes.js:992
-#: pkg/docker/index.html.h:46
-msgid "No"
+#: pkg/sosreport/index.html:74
+msgid "Done!"
 msgstr ""
 
-#: pkg/docker/run.js:261 pkg/docker/console.html.h:1
-#: pkg/kubernetes/views/image-panel.html.h:2
-#: pkg/kubernetes/views/container-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:1
-#: pkg/kubernetes/views/image-page.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:1
-msgid "Container"
+#: pkg/ostree/index.html:127 pkg/ostree/index.html:158
+msgid "Downgrades"
 msgstr ""
 
-#: pkg/docker/run.js:263 pkg/kubernetes/views/route-modify.html.h:2
-#: pkg/kubernetes/views/route-body.html.h:4
-#: pkg/kubernetes/views/details-page.html.h:12
-msgid "Host"
+#: pkg/storaged/index.html:411
+msgid "Drive"
 msgstr ""
 
-#: pkg/docker/run.js:283
-msgid "Invalid port"
+#: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
+msgctxt "storage"
+msgid "Drive"
 msgstr ""
 
-#: pkg/docker/run.js:293
-msgid "Duplicate port"
+#: pkg/kubernetes/views/volume-body.html:128
+msgid "Driver"
 msgstr ""
 
-#: pkg/docker/run.js:332
-msgid "Command can't be empty"
-msgstr ""
-
-#: pkg/docker/run.js:350
-msgid "No alias specified"
+#: pkg/storaged/index.html:166
+msgid "Drives"
 msgstr ""
 
 #: pkg/docker/run.js:360
 msgid "Duplicate alias"
 msgstr ""
 
-#: pkg/docker/run.js:384
-msgid "No container specified"
+#: pkg/docker/run.js:293
+msgid "Duplicate port"
 msgstr ""
 
-#: pkg/docker/details.js:47 pkg/docker/image.js:43
-msgctxt "page-title"
-msgid "Containers"
+#: pkg/storaged/jobs.js:120
+msgid "Ejecting $target"
 msgstr ""
 
-#: pkg/docker/details.js:144
-msgid "${hip}:${hport} -> $cport"
+#: pkg/playground/translate.html:58
+msgid "Empty"
 msgstr ""
 
-#: pkg/docker/details.js:272 pkg/docker/containers-view.jsx:167
-msgid "Deleting a container will erase all data in it."
+#: pkg/playground/translate.html:63
+msgctxt "verb"
+msgid "Empty"
 msgstr ""
 
-#: pkg/docker/storage.jsx:156
-msgid "Solid-State Disk"
+#: pkg/kubernetes/scripts/volumes.js:196
+msgid "Empty Directory"
+msgstr ""
+
+#: pkg/storaged/jobs.js:155
+msgid "Emptying $target"
+msgstr ""
+
+#: pkg/systemd/init.js:541
+msgid "Enable"
+msgstr ""
+
+#: pkg/systemd/init.js:542
+msgid "Enable Forcefully"
+msgstr ""
+
+#: pkg/systemd/init.js:301
+msgid "Enabled"
+msgstr ""
+
+#: pkg/storaged/details.js:1247
+msgctxt "storage-id-desc"
+msgid "Encrypted"
+msgstr ""
+
+#: pkg/storaged/details.js:180
+msgid "Encrypted EXT4 (LUKS)"
+msgstr ""
+
+#: pkg/storaged/details.js:179
+msgid "Encrypted XFS (LUKS)"
+msgstr ""
+
+#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
+#: pkg/storaged/details.js:1115
+msgid "Encryption Options"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:93
+msgid "Endpoint"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:40
+msgid "Endpoint Name"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:14
+#: pkg/kubernetes/views/service-panel.html:9
+msgid "Endpoints"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:38
+msgid "Ends"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:332
+msgid "Enforce policy:"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:447
+msgid "Enter IP address or host name"
+msgstr ""
+
+#: pkg/systemd/logs.html:60
+msgid "Entry"
+msgstr ""
+
+#: pkg/docker/index.html:547 pkg/kubernetes/views/image-config.html:17
+#: pkg/kubernetes/views/container-body.html:26
+msgid "Environment"
+msgstr ""
+
+#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
+msgid "Erase"
+msgstr ""
+
+#: pkg/docker/storage.jsx:423
+msgid "Erase containers and reset storage pool"
+msgstr ""
+
+#: pkg/docker/storage.jsx:360
+msgid "Erase containers, reformat disks, and add them"
+msgstr ""
+
+#: pkg/storaged/jobs.js:129
+msgid "Erasing $target"
+msgstr ""
+
+#: pkg/systemd/services.html:318 pkg/playground/translate.html:101
+#: pkg/playground/translate.html:106
+msgid "Error"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:650
+msgid "Error getting certificate details: $0"
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:13
+msgid "Error loading users: {{perm_failed}}"
+msgstr ""
+
+#: pkg/docker/util.js:491
+msgid "Error message from Docker:"
+msgstr ""
+
+#: pkg/users/authorized-keys.js:115
+msgid "Error saving authorized keys: "
+msgstr ""
+
+#: pkg/selinux/setroubleshoot.js:275
+msgid "Error while connecting."
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:192
+msgid "Error while deleting alert"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot.js:65
+msgid "Error while setting SELinux mode: '$0'"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:88
+msgid "Error writing kubectl config"
+msgstr ""
+
+#: pkg/systemd/logs.html:47
+msgid "Errors"
+msgstr ""
+
+#: pkg/networkmanager/index.html:764
+msgid "Ethernet MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1854
+msgid "Ethtool"
+msgstr ""
+
+#: pkg/users/local.js:429 pkg/users/local.js:1104
+msgid "Excellent password"
+msgstr ""
+
+#: pkg/docker/util.js:96
+msgid "Exited $ExitCode"
+msgstr ""
+
+#: pkg/docker/index.html:529
+msgid "Expose container ports"
+msgstr ""
+
+#: pkg/storaged/details.js:183
+msgid "Extended Partition"
+msgstr ""
+
+#: pkg/storaged/details.js:1592
+msgid "FAILED"
+msgstr ""
+
+#: pkg/ostree/index.html:92
+msgid "Failed"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:412
+msgid "Failed to add machine: $0"
+msgstr ""
+
+#: pkg/users/local.js:112 pkg/users/local.js:144 pkg/lib/credentials.js:223
+msgid "Failed to change password"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:187
+msgid "Failed to delete alert"
+msgstr ""
+
+#: pkg/tuned/dialog.js:171
+msgid "Failed to disable tuned"
+msgstr ""
+
+#: pkg/tuned/dialog.js:133
+msgid "Failed to disable tuned profile"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:494
+msgid "Failed to edit machine: $0"
+msgstr ""
+
+#: pkg/tuned/dialog.js:169
+msgid "Failed to enable tuned"
+msgstr ""
+
+#: pkg/users/index.html:338
+msgid "Failed to load authorized keys."
+msgstr ""
+
+#: pkg/docker/containers.js:64
+msgid "Failed to start Docker: $0"
+msgstr ""
+
+#: pkg/docker/util.js:544
+msgid "Failed to stop Docker scope: $0"
+msgstr ""
+
+#: pkg/tuned/dialog.js:145
+msgid "Failed to switch profile"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:204
+msgid "Fibre Channel"
+msgstr ""
+
+#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
+msgid "Filesystem Options"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:180
+#: pkg/kubernetes/views/volume-body.html:6
+#: pkg/kubernetes/views/volume-body.html:16
+#: pkg/kubernetes/views/volume-body.html:62
+#: pkg/kubernetes/views/volume-body.html:83
+#: pkg/kubernetes/views/volume-body.html:91
+#: pkg/kubernetes/views/volume-body.html:120
+#: pkg/kubernetes/views/volume-body.html:132
+msgid "Filesystem Type"
+msgstr ""
+
+#: pkg/storaged/details.js:215
+msgid "Filesystem type"
+msgstr ""
+
+#: pkg/storaged/index.html:225
+msgid "Filesystems"
+msgstr ""
+
+#: pkg/lib/machine-unknown-hostkey.html:10
+msgid "Fingerprint"
+msgstr ""
+
+#: pkg/storaged/index.html:426
+#, fuzzy
+msgctxt "storage"
+msgid "Firmware Version"
+msgstr "Version"
+
+#: pkg/kubernetes/scripts/volumes.js:206
+msgid "Flex"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:205
+msgid "Flocker"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:125
+msgid "Flocker Dataset Name"
+msgstr ""
+
+#: pkg/docker/util.js:503
+msgid "Force Delete"
+msgstr ""
+
+#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
+#: pkg/storaged/details.js:1142
+msgid "Format"
+msgstr ""
+
+#: pkg/storaged/details.js:115
+msgid "Format $0"
+msgstr ""
+
+#: pkg/storaged/details.js:335
+msgid "Format Disk $0"
+msgstr ""
+
+#: pkg/storaged/details.js:358
+msgid "Formatting a disk will erase all data on it."
+msgstr ""
+
+#: pkg/storaged/details.js:268
+msgid "Formatting a storage device will erase all data on it."
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2577
+msgid "Forward delay $forward_delay"
+msgstr ""
+
+#: pkg/systemd/index.html:255
+msgid "Free"
+msgstr ""
+
+#: pkg/users/index.html:86 pkg/users/index.html:148
+msgid "Full Name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:192
+msgid "GCE Persistent Disk"
+msgstr ""
+
+#: pkg/docker/index.html:180
+msgid "Gateway:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2628
+msgid "General"
+msgstr ""
+
+#: pkg/sosreport/index.html:66
+msgid "Generating report"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:194
+msgid "Git Repository"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:198
+msgid "Gluster FS"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:872
+msgid "GlusterFS"
+msgstr ""
+
+#: pkg/systemd/logs.js:130
+msgid "Go to"
+msgstr ""
+
+#: pkg/storaged/index.html:307 pkg/networkmanager/index.html:50
+#: pkg/networkmanager/index.html:496
+msgid "Go to now"
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:21
+#: pkg/kubernetes/views/group-panel.html:12
+msgid "Group Members"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:48
+#: pkg/kubernetes/views/user-delete.html:14
+msgid "Groups"
+msgstr ""
+
+#: pkg/networkmanager/index.html:268
+msgid "Hair Pin mode"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2603
+msgid "Hairpin mode"
 msgstr ""
 
 #: pkg/docker/storage.jsx:157
@@ -2003,8 +2432,438 @@ msgstr ""
 msgid "Hard Disk"
 msgstr "Disk I/O"
 
-#: pkg/docker/storage.jsx:158 pkg/storaged/index.html.h:33
-msgid "Drive"
+#: pkg/storaged/overview.js:180
+msgctxt "storage"
+msgid "Hard Disk"
+msgstr ""
+
+#: pkg/systemd/index.html:77
+msgid "Hardware"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2579
+msgid "Hello time $hello_time"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:73
+#: pkg/kubernetes/views/route-body.html:9
+#: pkg/kubernetes/views/route-modify.html:8
+msgid "Host"
+msgstr ""
+
+#: pkg/systemd/index.html:102 pkg/dashboard/index.html:151
+msgid "Host Name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
+msgid "Host Path"
+msgstr ""
+
+#: src/base1/cockpit.js:3699
+msgid "Host key is incorrect"
+msgstr ""
+
+#: pkg/systemd/services.html:442
+msgid "Hour : Minute"
+msgstr ""
+
+#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
+msgid "Hour needs to be a number between 0-23"
+msgstr ""
+
+#: pkg/systemd/services.html:408
+msgid "Hours"
+msgstr ""
+
+#: pkg/systemd/index.html:221
+msgid "I/O Wait"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
+msgid "IP"
+msgstr ""
+
+#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
+msgid "IP Address"
+msgstr ""
+
+#: pkg/docker/index.html:172
+msgid "IP Address:"
+msgstr ""
+
+#: pkg/docker/index.html:176
+msgid "IP Prefix Length:"
+msgstr ""
+
+#: pkg/networkmanager/index.html:568
+msgid "IP Settings"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2641
+msgid "IPv4"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv4 Settings"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2642
+msgid "IPv6"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv6 Settings"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
+msgid "ISCSI"
+msgstr ""
+
+#: pkg/systemd/init.js:270
+msgid "Id"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2620
+msgid "Id $id"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:22
+msgid "Identifier"
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:23
+#: pkg/kubernetes/views/user-panel.html:18
+msgid "Identities"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:91
+msgid "Identity"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1817
+msgid "Ignore"
+msgstr ""
+
+#: pkg/docker/index.html:452 pkg/kubernetes/views/image-panel.html:9
+#: pkg/kubernetes/views/container-body.html:6
+#: pkg/kubernetes/views/image-page.html:16
+msgid "Image"
+msgstr ""
+
+#: pkg/docker/image.js:77
+msgid "Image $0"
+msgstr ""
+
+#: pkg/kubernetes/views/container-body.html:8
+msgid "Image ID"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:16
+msgid "Image Layers"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:58
+#, fuzzy
+msgid "Image Name"
+msgstr "Værtsnavn"
+
+#: pkg/kubernetes/registry.html:23
+msgid "Image Registry"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-page.html:16
+msgid "Image Stream"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:135
+msgid "Image commands"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:34
+msgid "Image count"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:48
+#: pkg/kubernetes/views/registry-dashboard-page.html:19
+#: pkg/kubernetes/views/imagestream-page.html:18
+#: pkg/kubernetes/views/image-listing.html:9 pkg/kubernetes/index.html:77
+msgid "Images"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:17
+msgid "Images by project"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:54
+msgid "Images pushed recently"
+msgstr ""
+
+#: pkg/storaged/details.js:1593
+msgid "In Sync"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:81
+msgid ""
+"In order to begin pushing images to the registry, use the commands below."
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:6
+msgid ""
+"In order to begin pushing images to the registry, you need to create a "
+"project."
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:50
+msgid ""
+"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
+"strong}}.        {{/needs_root}}                                    User "
+"name                                                                            "
+"{{#allows_password}}                            "
+"Password                                                                            "
+"{{/allows_password}}            "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
+#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
+msgid "Inactive"
+msgstr ""
+
+#: pkg/lib/machine-invalid-hostkey.html:2
+msgid "Incorrect Host Key"
+msgstr ""
+
+#: pkg/docker/storage.jsx:282
+msgid "Information about the Docker storage pool is not available."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:222
+msgid "Installed products"
+msgstr ""
+
+#: pkg/systemd/services.html:135
+msgid "Instantiate"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:169
+#: pkg/kubernetes/views/volume-body.html:81
+msgid "Interface"
+msgstr ""
+
+#: pkg/networkmanager/index.html:84
+msgid "Interfaces"
+msgstr ""
+
+#: src/base1/cockpit.js:3701
+msgid "Internal error"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:196
+msgid "Invalid credentials"
+msgstr ""
+
+#: pkg/systemd/host.js:1194
+msgid "Invalid date format"
+msgstr ""
+
+#: pkg/systemd/host.js:1190
+msgid "Invalid date format and invalid time format"
+msgstr ""
+
+#: pkg/systemd/init.js:1218
+msgid "Invalid date format."
+msgstr ""
+
+#: pkg/lib/credentials.js:274
+msgid "Invalid file permissions"
+msgstr ""
+
+#: pkg/users/index.html:322
+msgid "Invalid key"
+msgstr ""
+
+#: pkg/systemd/init.js:1169
+msgid "Invalid number."
+msgstr ""
+
+#: pkg/docker/run.js:283
+msgid "Invalid port"
+msgstr ""
+
+#: pkg/systemd/host.js:1192
+msgid "Invalid time format"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:194 pkg/storaged/overview.js:577
+#: pkg/storaged/overview.js:668
+msgid "Invalid username or password"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:15
+msgid "Is sshd running on a different port?"
+msgstr ""
+
+#: pkg/systemd/init.js:522
+msgid "Isolate"
+msgstr ""
+
+#: pkg/storaged/index.html:280
+msgid "Jobs"
+msgstr ""
+
+#: pkg/realmd/operation.js:96
+msgid "Join"
+msgstr ""
+
+#: pkg/realmd/operation.js:453
+msgid "Join Domain"
+msgstr ""
+
+#: pkg/realmd/operation.js:347
+msgid "Joining this domain is not supported"
+msgstr ""
+
+#: pkg/systemd/logs.js:257
+msgid "Journal entry"
+msgstr ""
+
+#: pkg/systemd/logs.js:284
+msgid "Journal entry not found"
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:10
+msgid "Kerberos Based SSO"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:69
+msgid "Kerberos Ticket"
+msgstr ""
+
+#: pkg/systemd/index.html:225
+msgid "Kernel"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:19
+#, fuzzy
+msgid "Kernel Version"
+msgstr "Version"
+
+#: pkg/kubernetes/views/volume-body.html:67
+msgid "Key Ring Path"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:23
+msgid "Kubelet Version"
+msgstr ""
+
+#: pkg/kubernetes/index.html:23
+msgid "Kubernetes Cluster"
+msgstr ""
+
+#: pkg/networkmanager/index.html:473
+msgid "LACP Key"
+msgstr ""
+
+#: pkg/storaged/details.js:1245
+msgctxt "storage-id-desc"
+msgid "LUKS Encrypted"
+msgstr ""
+
+#: pkg/storaged/details.js:1226
+msgctxt "storage-id-desc"
+msgid "LVM2 Physical Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/replicationcontroller-body.html:17
+#: pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/route-body.html:22
+#: pkg/kubernetes/views/image-meta.html:3
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
+msgid "Labels"
+msgstr ""
+
+#: pkg/systemd/logs.html:42
+msgid "Last 24 hours"
+msgstr ""
+
+#: pkg/systemd/logs.html:43
+msgid "Last 7 days"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:49
+msgid "Last Heartbeat"
+msgstr ""
+
+#: pkg/users/index.html:100
+msgid "Last Login"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:51
+msgid "Last Status Change"
+msgstr ""
+
+#: pkg/systemd/init.js:273
+msgid "Last Trigger"
+msgstr ""
+
+#: pkg/kubernetes/views/image-listing.html:16
+msgid "Last Updated"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:107
+msgid "Latest Version"
+msgstr ""
+
+#: pkg/realmd/operation.js:101
+msgid "Leave"
+msgstr ""
+
+#: pkg/networkmanager/index.html:315
+msgid "Link Monitoring"
+msgstr ""
+
+#: pkg/networkmanager/index.html:397
+msgid "Link Watch"
+msgstr ""
+
+#: pkg/networkmanager/index.html:350 pkg/networkmanager/index.html:432
+msgid "Link down delay"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
+msgid "Link local"
+msgstr ""
+
+#: pkg/networkmanager/index.html:341 pkg/networkmanager/index.html:423
+msgid "Link up delay"
+msgstr ""
+
+#: pkg/docker/index.html:514
+msgid "Links"
+msgstr ""
+
+#: pkg/storaged/details.js:1224
+msgctxt "storage-id-desc"
+msgid "Linux MD-RAID Component"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1841
+msgid "Load Balancing"
+msgstr ""
+
+#: pkg/systemd/logs.js:69
+msgid "Load earlier entries"
+msgstr ""
+
+#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
+#: pkg/systemd/logs.js:175
+msgid "Loading..."
+msgstr ""
+
+#: pkg/users/index.html:23
+msgid "Local Accounts"
 msgstr ""
 
 #: pkg/docker/storage.jsx:188
@@ -2012,48 +2871,1560 @@ msgstr ""
 msgid "Local Disks"
 msgstr "Disk I/O"
 
+#: pkg/storaged/details.js:1109
+msgid "Lock"
+msgstr ""
+
+#: pkg/users/index.html:109 pkg/users/index.html:196
+msgid "Lock Account"
+msgstr ""
+
+#: pkg/storaged/jobs.js:122
+msgid "Locking $target"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:80
+msgid "Log In"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:4
+msgid "Log in to {{host}}"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:116
+msgid "Log into OpenShift command line tools:"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:101
+msgid "Log into the registry:"
+msgstr ""
+
+#: pkg/shell/simple.html:45 pkg/shell/index.html:52 pkg/shell/stub.html:45
+msgid "Log out"
+msgstr ""
+
+#: pkg/users/local.js:839
+msgid "Logged In"
+msgstr ""
+
+#: pkg/storaged/details.js:1424
+msgid "Logical Partition"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:158
+#: pkg/kubernetes/views/volume-body.html:79
+#: pkg/kubernetes/views/volume-body.html:118
+msgid "Logical Unit Number"
+msgstr ""
+
+#: pkg/storaged/utils.js:172
+msgid "Logical Volume"
+msgstr ""
+
+#: pkg/storaged/utils.js:170
+msgid "Logical Volume (Snapshot)"
+msgstr ""
+
+#: pkg/storaged/details.js:1792
+msgid "Logical Volumes"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:140
+msgid "Login"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:68
+msgid "Login Password"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:96
+msgid "Login commands"
+msgstr ""
+
+#: src/base1/cockpit.js:3693
+msgid "Login failed"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:200
+msgid "Login/password or activation key required to register."
+msgstr ""
+
+#: pkg/systemd/logs.html:59 pkg/kubernetes/views/container-panel.html:6
+#: pkg/kubernetes/views/container-page-inline.html:8
+msgid "Logs"
+msgstr ""
+
+#: pkg/dashboard/index.html:110
+msgid "Lost connection. Trying to reconnect"
+msgstr ""
+
+#: pkg/docker/index.html:184
+msgid "MAC Address:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1833
+msgid "MII (Recommended)"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2477
+msgid "MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:4139
+msgid "MTU must be a positive number"
+msgstr ""
+
+#: pkg/systemd/index.html:85 pkg/kubernetes/views/node-body.html:15
+msgid "Machine ID"
+msgstr ""
+
+#: pkg/systemd/index.html:282
+msgid "Machine SSH Key Fingerprints"
+msgstr ""
+
+#: pkg/shell/indexes.js:253
+msgid "Machines"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:460
+msgid "Manifest"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
+msgid "Manual"
+msgstr ""
+
+#: pkg/systemd/index.html:401 pkg/systemd/index.html:405
+msgid "Manually"
+msgstr ""
+
+#: pkg/storaged/jobs.js:140
+msgid "Marking $target as faulty"
+msgstr ""
+
+#: pkg/systemd/init.js:546
+msgid "Mask"
+msgstr ""
+
+#: pkg/systemd/init.js:547
+msgid "Mask Forcefully"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2483
+msgid "Master"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2581
+msgid "Maximum message age $max_age"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:34
+msgid "Medium"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:92
+msgid "Member of"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:16
+#: pkg/kubernetes/views/project-listing.html:55
+#: pkg/networkmanager/index.html:291
+msgid "Members"
+msgstr ""
+
+#: pkg/kubernetes/views/project-page.html:29
+#: pkg/kubernetes/views/user-panel.html:11
+#: pkg/kubernetes/views/user-panel.html:27
+#: pkg/kubernetes/views/user-body.html:4
+msgid "Membership"
+msgstr ""
+
+#: pkg/dashboard/index.html:71 pkg/playground/translate.html:91
+msgid "Memory"
+msgstr ""
+
+#: pkg/systemd/host.js:1466
+msgctxt "page-title"
+msgid "Memory"
+msgstr "Hukommelse"
+
+#: pkg/kubernetes/scripts/nodes.js:716
+msgid "Memory Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:473 pkg/docker/index.html:652
+msgid "Memory limit"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
+msgid "Message"
+msgstr ""
+
+#: pkg/systemd/host.js:1300
+msgid "Message to logged in users"
+msgstr ""
+
+#: pkg/kubernetes/views/image-panel.html:15
+#: pkg/kubernetes/views/imagestream-page.html:21
+#: pkg/kubernetes/views/image-page.html:22
+msgid "Metadata"
+msgstr ""
+
+#: pkg/docker/index.html:487 pkg/docker/index.html:666
+msgid "MiB"
+msgstr ""
+
+#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
+msgid "Minute needs to be a number between 0-59"
+msgstr ""
+
+#: pkg/systemd/services.html:407
+msgid "Minutes"
+msgstr ""
+
+#: pkg/networkmanager/index.html:299
+msgid "Mode"
+msgstr ""
+
+#: pkg/storaged/index.html:421
+msgctxt "storage"
+msgid "Model"
+msgstr ""
+
+#: pkg/kubernetes/views/user-modify.html:31
+msgid "Modify"
+msgstr ""
+
+#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
+msgid "Modifying $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:323
+msgid "Monitoring Interval"
+msgstr ""
+
+#: pkg/networkmanager/index.html:332
+msgid "Monitoring Targets"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:54
+msgid "Monitors"
+msgstr ""
+
+#: pkg/realmd/operation.js:366
+msgid "More"
+msgstr ""
+
+#: pkg/storaged/details.js:1099
+msgid "Mount"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
+#, fuzzy
+msgid "Mount Location"
+msgstr "Indstillinger"
+
+#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
+#, fuzzy
+msgid "Mount Options"
+msgstr "Indstillinger"
+
+#: pkg/storaged/index.html:231
+msgid "Mount Point"
+msgstr ""
+
+#: pkg/docker/index.html:540
+msgid "Mount container volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
+msgid "Mounting"
+msgstr ""
+
+#: pkg/storaged/jobs.js:126
+msgid "Mounting $target"
+msgstr ""
+
+#: pkg/storaged/index.html:508
+msgctxt "storage"
+msgid "Multipathed Devices"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:860
+msgid "NFS"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:199
+msgid "NFS Mount"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1856
+msgid "NSNA Ping"
+msgstr ""
+
+#: pkg/storaged/details.js:182
+msgid "NTFS - Compatible with most systems"
+msgstr ""
+
+#: pkg/systemd/host.js:1250
+msgid "NTP Server"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/project-modify.html:16
+#: pkg/kubernetes/views/node-add.html:16
+#: pkg/kubernetes/views/volumes-page.html:19
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/image-body.html:2
+#: pkg/kubernetes/views/imagestream-modify.html:10
+#: pkg/kubernetes/views/service-modify.html:9
+#: pkg/kubernetes/views/dashboard-page.html:156
+#: pkg/kubernetes/views/dashboard-page.html:198
+#: pkg/kubernetes/views/details-page.html:34
+#: pkg/kubernetes/views/details-page.html:70
+#: pkg/kubernetes/views/details-page.html:103
+#: pkg/kubernetes/views/details-page.html:137
+#: pkg/kubernetes/views/details-page.html:171
+#: pkg/kubernetes/views/pv-claim.html:4
+#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/kubernetes/views/project-listing.html:14
+#: pkg/kubernetes/views/project-listing.html:53
+#: pkg/kubernetes/views/project-listing.html:90
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/volume-body.html:31 pkg/storaged/index.html:230
+#: pkg/networkmanager/index.html:95 pkg/networkmanager/index.html:113
+#: pkg/networkmanager/index.html:150 pkg/networkmanager/index.html:183
+#: pkg/networkmanager/index.html:282 pkg/networkmanager/index.html:364
+#, fuzzy
+msgid "Name"
+msgstr "Værtsnavn"
+
+#: pkg/storaged/utils.js:129
+msgid "Name cannot be empty."
+msgstr ""
+
+#: pkg/storaged/utils.js:131
+msgid "Name cannot be longer than 127 characters."
+msgstr ""
+
+#: pkg/storaged/utils.js:135
+msgid "Name cannot contain the character '$0'."
+msgstr ""
+
+#: pkg/storaged/utils.js:137
+msgid "Name cannot contain whitespace."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:5
+#: pkg/kubernetes/views/replicationcontroller-body.html:5
+#: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/pod-body.html:5
+#: pkg/kubernetes/views/dashboard-page.html:160
+#: pkg/kubernetes/views/details-page.html:36
+#: pkg/kubernetes/views/details-page.html:72
+#: pkg/kubernetes/views/details-page.html:105
+#: pkg/kubernetes/views/details-page.html:139
+#: pkg/kubernetes/views/details-page.html:173
+#: pkg/kubernetes/views/pv-claim.html:6
+#: pkg/kubernetes/views/containers-listing.html:14
+#: pkg/kubernetes/views/route-body.html:5
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
+msgid "Namespace"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:374
+msgid "Namespace cannot be empty."
+msgstr ""
+
+#: pkg/systemd/host.js:1113
+msgid "Need at least one NTP server"
+msgstr ""
+
+#: pkg/dashboard/index.html:72 pkg/playground/translate.html:96
+msgid "Network"
+msgstr ""
+
+#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:485
+msgid "Networking"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
+#, fuzzy
+msgctxt "page-title"
+msgid "Networking"
+msgstr "Netværks Traffik"
+
+#: pkg/networkmanager/index.html:124
+msgid "Networking Logs"
+msgstr ""
+
+#: pkg/users/local.js:841
+msgid "Never"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:46
+msgid "New Group"
+msgstr ""
+
+#: pkg/users/index.html:236 pkg/shell/index.html:255
+#, fuzzy
+msgid "New Password"
+msgstr "Indtast adgangskode"
+
+#: pkg/kubernetes/views/project-listing.html:7
+msgid "New Project"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/image-listing.html:7
+msgid "New image stream"
+msgstr ""
+
+#: pkg/users/local.js:120 pkg/lib/credentials.js:231
+msgid "New password was not accepted"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:4
+#: pkg/kubernetes/views/registry-dashboard-page.html:9
+#: pkg/kubernetes/views/registry-dashboard-page.html:48
+msgid "New project"
+msgstr ""
+
+#: pkg/realmd/operation.html:91
+msgid "Next"
+msgstr ""
+
+#: pkg/systemd/init.js:272
+msgid "Next Run"
+msgstr ""
+
+#: pkg/systemd/index.html:233
+msgid "Nice"
+msgstr ""
+
+#: pkg/docker/index.html:563 pkg/docker/index.html:567
+msgid "No"
+msgstr ""
+
+#: pkg/systemd/index.html:469
+msgid "No Delay"
+msgstr ""
+
+#: pkg/ostree/index.html:220
+msgid "No Deployments"
+msgstr ""
+
+#: pkg/storaged/details.js:185
+msgid "No Filesystem"
+msgstr ""
+
+#: pkg/ostree/app.js:101
+msgid "No OSTree deployments found"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:398
+msgid "No PEM-encoded certificate found"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:364
+msgid "No PEM-encoded private key found"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:39
+msgid "No Pods are using this claim"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:479
+msgid "No SELinux alerts."
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:10
+msgid "No Volume Bound"
+msgstr ""
+
 #: pkg/docker/storage.jsx:194
 msgid "No additional local storage found."
 msgstr ""
 
-#: pkg/docker/storage.jsx:242
-msgid " (shared with the OS)"
+#: pkg/docker/run.js:350
+msgid "No alias specified"
 msgstr ""
 
-#: pkg/docker/storage.jsx:282
-msgid "Information about the Docker storage pool is not available."
+#: pkg/sosreport/index.js:115
+msgid "No archive has been created."
 msgstr ""
 
-#: pkg/docker/storage.jsx:314
-msgid "Total"
+#: pkg/networkmanager/interfaces.js:1326
+msgid "No carrier"
+msgstr ""
+
+#: pkg/docker/run.js:384
+msgid "No container specified"
+msgstr ""
+
+#: pkg/storaged/index.html:193
+msgid "No drives attached"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:74
+msgid "No groups are present."
+msgstr ""
+
+#: pkg/systemd/index.html:28
+msgid "No host keys found."
+msgstr ""
+
+#: pkg/storaged/index.html:158
+msgid "No iSCSI targets set up"
+msgstr ""
+
+#: pkg/kubernetes/views/image-listing.html:70
+msgid "No image streams are present."
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:80
+msgid "No images pushed"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:223
+msgid "No installed products on the system."
+msgstr ""
+
+#: pkg/storaged/index.html:446
+msgid "No media inserted"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:384
+msgid ""
+"No metadata file was selected. Please select a Kubernetes metadata file."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:117
+msgid "No nodes in cluster"
+msgstr ""
+
+#: pkg/storaged/details.js:352
+msgid "No partitioning"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:40
+msgid "No pods deployed"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:6
+msgid "No pods replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/node-capacity.html:11
+msgid "No pods scheduled"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:10
+msgid "No pods selected"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:37
+msgid "No projects are present."
+msgstr ""
+
+#: pkg/users/local.js:405
+msgid "No real name specified"
+msgstr ""
+
+#: pkg/storaged/index.html:87
+msgid "No storage set up as RAID"
+msgstr ""
+
+#: pkg/lib/credentials.js:182
+msgid "No such file or directory"
+msgstr ""
+
+#: pkg/users/local.js:400
+msgid "No user name specified"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:112
+msgid "No users are present."
+msgstr ""
+
+#: pkg/storaged/index.html:120
+msgid "No volume groups created"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:44
+msgid "No volumes are present."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:73
+msgid "No volumes in use"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:18 pkg/kubernetes/views/node-panel.html:7
+#: pkg/kubernetes/views/containers-listing.html:15
+#: pkg/kubernetes/views/node-page.html:14
+#: pkg/kubernetes/views/topology-page.html:41
+msgid "Node"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:192
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:45
+msgid "Nodes"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:42
+msgid "Nodes are the machines that run your containers."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:15
+#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
+#: pkg/kubernetes/views/image-config.html:25
+#: pkg/kubernetes/views/imagestream-body.html:33
+msgid "None"
+msgstr ""
+
+#: pkg/playground/translate.html:30 pkg/kubernetes/views/details-page.html:53
+#: pkg/kubernetes/views/node-body.html:42
+msgid "Not Ready"
+msgstr ""
+
+#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
+msgid "Not a valid number of replicas"
+msgstr ""
+
+#: pkg/lib/credentials.js:248
+msgid "Not a valid private key"
+msgstr ""
+
+#: pkg/kubernetes/scripts/details.js:546
+msgid "Not a valid value for Host"
+msgstr ""
+
+#: pkg/docker/index.html:57
+msgid "Not authorized to access Docker on this system"
+msgstr ""
+
+#: pkg/ostree/app.js:81
+msgid "Not authorized to update software on this system"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:805
+msgid "Not available"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot.js:238
+msgid "Not connected"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:122
+msgid "Not deployed"
+msgstr ""
+
+#: pkg/docker/details.js:177 pkg/docker/image.js:112
+#: pkg/storaged/details.js:1822
+msgid "Not found"
+msgstr ""
+
+#: src/base1/cockpit.js:3691
+msgid "Not permitted to perform this action."
+msgstr ""
+
+#: pkg/storaged/details.js:1574
+msgid "Not running"
+msgstr ""
+
+#: pkg/systemd/index.html:62
+msgid "Not synchronized"
+msgstr ""
+
+#: pkg/systemd/services.html:299
+msgid "Note"
+msgstr ""
+
+#: pkg/systemd/logs.html:49
+msgid "Notices"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:13
+msgid "OS"
+msgstr ""
+
+#: pkg/ostree/client.js:500
+msgid "OS $0 not found"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:19
+msgid "OS Versions"
+msgstr ""
+
+#: pkg/ostree/app.js:83
+msgid "OSTree is not available on this system"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:405
+msgid "Occurred $0"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:400
+msgid "Occurred between $0 and $1"
+msgstr ""
+
+#: pkg/systemd/index.html:157 pkg/playground/jquery-patterns.html:95
+#: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:189
+#: pkg/storaged/index.html:565
+msgid "Off"
+msgstr ""
+
+#: pkg/lib/cockpit-components-dialog.jsx:155
+msgid "Ok"
+msgstr ""
+
+#: pkg/users/index.html:226 pkg/shell/index.html:248
+#, fuzzy
+msgid "Old Password"
+msgstr "Indtast adgangskode"
+
+#: pkg/users/local.js:78 pkg/lib/credentials.js:213
+msgid "Old password not accepted"
+msgstr ""
+
+#: pkg/systemd/index.html:153 pkg/playground/jquery-patterns.html:91
+#: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:185
+#: pkg/storaged/index.html:564
+msgid "On"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:7
+msgid "On Build"
+msgstr ""
+
+#: pkg/docker/index.html:568
+msgid "On Failure"
+msgstr ""
+
+#: pkg/docker/util.js:104
+msgid "On failure, retry $0 time"
+msgid_plural "On failure, retry $0 times"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/realmd/operation.html:71
+msgid "One Time Password"
+msgstr ""
+
+#: pkg/systemd/init.js:1147
+msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
+msgstr ""
+
+#: pkg/shell/simple.html:28 pkg/shell/index.html:28 pkg/shell/stub.html:28
+msgid "Ooops!"
+msgstr ""
+
+#: pkg/systemd/index.html:89 pkg/ostree/index.html:111
+#: pkg/kubernetes/views/nodes-page.html:42
+msgid "Operating System"
+msgstr ""
+
+#: pkg/ostree/index.html:186
+msgid "Operating System Updates"
+msgstr ""
+
+#: pkg/storaged/jobs.js:166
+msgid "Operation '$operation' on $target"
+msgstr ""
+
+#: pkg/storaged/overview.js:189
+msgctxt "storage"
+msgid "Optical Drive"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:130
+msgid "Options"
+msgstr "Indstillinger"
+
+#: pkg/subscriptions/subscriptions-register.jsx:176
+msgid "Organization"
+msgstr ""
+
+#: pkg/storaged/details.js:1253
+msgctxt "storage-id-desc"
+msgid "Other Data"
+msgstr ""
+
+#: pkg/storaged/index.html:202
+msgid "Other Devices"
+msgstr ""
+
+#: pkg/docker/index.html:319 pkg/kubernetes/registry.html:42
+#: pkg/kubernetes/index.html:39
+msgid "Overview"
+msgstr ""
+
+#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
+msgid "Overwrite existing data with zeros"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:4
+#, fuzzy
+msgid "PD Name"
+msgstr "Værtsnavn"
+
+#: pkg/ostree/index.html:100
+msgid "Packages"
+msgstr ""
+
+#: pkg/networkmanager/index.html:133
+msgid "Parent"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2619
+msgid "Parent $parent"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1372
+msgid "Part of "
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:8
+#: pkg/kubernetes/views/volume-body.html:18
+msgid "Partition"
+msgstr ""
+
+#: pkg/storaged/details.js:346
+msgid "Partitioning"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1848
+msgid "Passive"
+msgstr ""
+
+#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
+msgid "Passphrase"
+msgstr ""
+
+#: pkg/storaged/details.js:224
+msgid "Passphrase cannot be empty"
+msgstr ""
+
+#: pkg/storaged/details.js:232
+msgid "Passphrases do not match"
+msgstr ""
+
+#: pkg/users/index.html:115 pkg/users/index.html:160 pkg/shell/index.html:199
+#: pkg/shell/index.html:212 pkg/kubernetes/views/auth-form.html:105
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+msgid "Password"
+msgstr ""
+
+#: pkg/users/local.js:259
+msgid "Password is not acceptable"
+msgstr ""
+
+#: pkg/users/local.js:247
+msgid "Password is too weak"
+msgstr ""
+
+#: pkg/lib/credentials.js:278
+msgid "Password not accepted"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:126
+#: pkg/kubernetes/views/volume-body.html:37
+#: pkg/kubernetes/views/volume-body.html:49
+#: pkg/kubernetes/views/volume-body.html:101
+msgid "Path"
+msgstr ""
+
+#: pkg/networkmanager/index.html:259
+msgid "Path cost"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2601
+msgid "Path cost $path_cost"
+msgstr ""
+
+#: pkg/systemd/services.html:56
+msgid "Paths"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:53
+msgid "Pending Volume Claims"
+msgstr ""
+
+#: pkg/systemd/index.html:143
+msgid "Performance Profile"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:14
+msgid "Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:16
+msgid "Phase"
+msgstr ""
+
+#: pkg/storaged/index.html:641
+msgid "Physical Volumes"
+msgstr ""
+
+#: pkg/networkmanager/index.html:405
+msgid "Ping Interval"
+msgstr ""
+
+#: pkg/networkmanager/index.html:414
+msgid "Ping Target"
+msgstr ""
+
+#: pkg/docker/containers-view.jsx:166 pkg/docker/details.js:271
+#: pkg/docker/image.js:151 pkg/storaged/details.js:625
+#: pkg/storaged/details.js:821 pkg/storaged/details.js:1016
+msgid "Please confirm deletion of $0"
+msgstr ""
+
+#: pkg/docker/util.js:501
+msgid "Please confirm forced deletion of $0"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:441
+msgid "Please create another namespace for $0 \"$1\""
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:574
+msgid "Please provide a GlusterFS volume name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:554
+msgid "Please provide a username"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:632
+msgid "Please provide a valid NFS server"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:539
+msgid "Please provide a valid address"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:805
+msgid "Please provide a valid filesystem type"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:813
+msgid "Please provide a valid interface"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:797
+msgid "Please provide a valid logical unit number"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:477
+msgid "Please provide a valid name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:376
+msgid "Please provide a valid namespace."
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
+msgid "Please provide a valid path"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:789
+msgid "Please provide a valid qualified name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:485
+msgid "Please provide a valid storage capacity."
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:781
+msgid "Please provide a valid target"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:469
+msgid "Please select a valid access mode"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:565
+msgid "Please select a valid endpoint"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:493
+msgid "Please select a valid policy option."
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:397
+msgid "Please type an address"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:12
+#: pkg/kubernetes/views/containers-listing.html:12
+#: pkg/kubernetes/views/topology-page.html:14
+msgid "Pod"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:20
+msgid "Pod Address"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:4
+#: pkg/kubernetes/views/service-endpoint.html:9
+msgid "Pod Endpoints"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:4
+msgid "Pod Replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:15
+#: pkg/kubernetes/views/replicationcontroller-pods.html:11
+msgid "Pod Selector"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:17
+#: pkg/kubernetes/views/dashboard-page.html:18
+#: pkg/kubernetes/views/details-page.html:166
+#: pkg/kubernetes/views/pv-claim.html:37
+#: pkg/kubernetes/views/replicationcontroller-panel.html:12
+msgid "Pods"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:15
+msgid ""
+"Pods contain one or more containers that run                together on a "
+"node, containing your application code."
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:60
+#, fuzzy
+msgid "Pool Name"
+msgstr "Værtsnavn"
+
+#: pkg/storaged/utils.js:166
+msgid "Pool for Thin Logical Volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:874
+msgid "Pool for thinly provisioned volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:45
+msgid "Populate"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:23
+msgid "Port"
+msgstr ""
+
+#: pkg/docker/index.html:525 pkg/kubernetes/views/service-body.html:13
+#: pkg/kubernetes/views/image-config.html:23
+#: pkg/kubernetes/views/container-body.html:12
+#: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:373
+msgid "Ports"
+msgstr ""
+
+#: pkg/systemd/index.html:123
+msgid "Power Options"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length or Netmask"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:809
+msgid "Preparing"
+msgstr ""
+
+#: pkg/systemd/init.js:544
+msgid "Preset"
+msgstr ""
+
+#: pkg/systemd/init.js:545
+msgid "Preset Forcefully"
+msgstr ""
+
+#: pkg/systemd/index.html:310
+msgid "Pretty Host Name"
+msgstr ""
+
+#: pkg/networkmanager/index.html:307
+msgid "Primary"
+msgstr ""
+
+#: pkg/storaged/details.js:1426
+msgid "Primary Partition"
+msgstr ""
+
+#: pkg/networkmanager/index.html:250 pkg/networkmanager/index.html:446
+#: pkg/networkmanager/index.html:464
+msgid "Priority"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
+msgid "Priority $priority"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:33
+msgid "Product ID"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:32
+msgid "Product name"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:4
+#: pkg/kubernetes/views/replicationcontroller-body.html:4
+#: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/imagestream-modify.html:21
+#: pkg/kubernetes/views/pod-body.html:4
+#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/details-page.html:35
+#: pkg/kubernetes/views/details-page.html:71
+#: pkg/kubernetes/views/details-page.html:104
+#: pkg/kubernetes/views/details-page.html:138
+#: pkg/kubernetes/views/details-page.html:172
+#: pkg/kubernetes/views/containers-listing.html:13
+#: pkg/kubernetes/views/route-body.html:4
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
+msgid "Project"
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:20
+msgid "Project Members"
+msgstr ""
+
+#: pkg/kubernetes/views/filter-project.html:5
+msgid "Project:"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:54 pkg/kubernetes/views/group-delete.html:10
+#: pkg/kubernetes/views/project-listing.html:9
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:84
+msgid "Projects"
+msgstr ""
+
+#: pkg/users/local.js:82
+msgid "Prompting via passwd timed out"
+msgstr ""
+
+#: pkg/lib/credentials.js:251
+msgid "Prompting via ssh-add timed out"
+msgstr ""
+
+#: pkg/lib/credentials.js:191
+msgid "Prompting via ssh-keygen timed out"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:125
+msgid "Proxy"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:25
+msgid "Proxy Version"
+msgstr ""
+
+#: pkg/shell/index.html:198 pkg/lib/machine-auth-failed.html:9
+msgid "Public Key"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:150
+msgid "Pull an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:66
+msgid "Pull from"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:31
+msgid "Pull repository"
+msgstr ""
+
+#: pkg/storaged/details.js:869
+msgid "Purpose"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:140
+msgid "Push an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:147
+#: pkg/kubernetes/views/volume-body.html:77
+msgid "Qualified Name"
+msgstr ""
+
+#: pkg/storaged/details.js:1539
+msgid "RAID ($0)"
+msgstr ""
+
+#: pkg/storaged/details.js:1533
+msgid "RAID 0"
+msgstr ""
+
+#: pkg/storaged/overview.js:422
+msgid "RAID 0 (Stripe)"
+msgstr ""
+
+#: pkg/storaged/details.js:1534
+msgid "RAID 1"
+msgstr ""
+
+#: pkg/storaged/overview.js:423
+msgid "RAID 1 (Mirror)"
+msgstr ""
+
+#: pkg/storaged/details.js:1538
+msgid "RAID 10"
+msgstr ""
+
+#: pkg/storaged/overview.js:427
+msgid "RAID 10 (Stripe of Mirrors)"
+msgstr ""
+
+#: pkg/storaged/details.js:1535
+msgid "RAID 4"
+msgstr ""
+
+#: pkg/storaged/overview.js:424
+msgid "RAID 4 (Dedicated Parity)"
+msgstr ""
+
+#: pkg/storaged/details.js:1536
+msgid "RAID 5"
+msgstr ""
+
+#: pkg/storaged/overview.js:425
+msgid "RAID 5 (Distributed Parity)"
+msgstr ""
+
+#: pkg/storaged/details.js:1537
+msgid "RAID 6"
+msgstr ""
+
+#: pkg/storaged/overview.js:426
+msgid "RAID 6 (Double Distributed Parity)"
+msgstr ""
+
+#: pkg/storaged/index.html:537
+msgid "RAID Device"
+msgstr ""
+
+#: pkg/storaged/utils.js:233
+msgid "RAID Device $0"
+msgstr ""
+
+#: pkg/storaged/index.html:65
+msgid "RAID Devices"
+msgstr ""
+
+#: pkg/storaged/overview.js:420
+msgid "RAID Level"
+msgstr ""
+
+#: pkg/storaged/index.html:555
+msgctxt "storage"
+msgid "RAID Level"
+msgstr ""
+
+#: pkg/storaged/details.js:1228
+msgctxt "storage-id-desc"
+msgid "RAID Member"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:200
+msgid "Rados Block Device"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:194
+#: pkg/kubernetes/views/volume-body.html:10
+#: pkg/kubernetes/views/volume-body.html:20
+#: pkg/kubernetes/views/volume-body.html:44
+#: pkg/kubernetes/views/volume-body.html:51
+#: pkg/kubernetes/views/volume-body.html:71
+#: pkg/kubernetes/views/volume-body.html:85
+#: pkg/kubernetes/views/volume-body.html:93
+#: pkg/kubernetes/views/volume-body.html:110
+#: pkg/kubernetes/views/volume-body.html:122
+#: pkg/kubernetes/views/volume-body.html:136
+#: pkg/kubernetes/views/volume-body.html:143
+msgid "Read Only"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:211
+msgid "Read and write from a single node"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:213
+msgid "Read and write from multiple nodes"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:212
+msgid "Read only from multiple nodes"
+msgstr ""
+
+#: pkg/docker/index.html:385
+msgid "ReadOnly"
+msgstr ""
+
+#: pkg/docker/index.html:384
+msgid "ReadWrite"
+msgstr ""
+
+#: pkg/storaged/index.html:327
+msgid "Reading"
+msgstr ""
+
+#: pkg/playground/translate.html:20 pkg/playground/translate.html:179
+#: pkg/kubernetes/views/details-page.html:52
+#: pkg/kubernetes/views/node-body.html:41
+msgid "Ready"
+msgstr ""
+
+#: pkg/playground/translate.html:25
+msgctxt "verb"
+msgid "Ready"
+msgstr ""
+
+#: pkg/systemd/index.html:319
+msgid "Real Host Name"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:45
+msgid "Reason"
+msgstr ""
+
+#: pkg/lib/journal.js:241
+msgid "Reboot"
+msgstr ""
+
+#: pkg/networkmanager/index.html:75 pkg/networkmanager/index.html:98
+#: pkg/networkmanager/index.html:116 pkg/networkmanager/index.html:521
+#: pkg/networkmanager/index.html:551
+msgid "Receiving"
+msgstr ""
+
+#: pkg/ostree/client.js:56
+msgid "Receiving delta parts"
+msgstr ""
+
+#: pkg/ostree/client.js:58
+msgid "Receiving metadata objects"
+msgstr ""
+
+#: pkg/ostree/client.js:61
+msgid "Receiving objects: $0%"
+msgstr ""
+
+#: pkg/systemd/logs.html:40
+msgid "Recent"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:56 pkg/kubernetes/views/pv-body.html:6
+msgid "Reclaim Policy"
+msgstr ""
+
+#: pkg/shell/simple.html:144 pkg/shell/index.html:327 pkg/shell/stub.html:180
+msgid "Reconnect"
+msgstr ""
+
+#: pkg/storaged/details.js:1594
+msgid "Recovering"
+msgstr ""
+
+#: pkg/storaged/jobs.js:145
+msgid "Recovering RAID Device $target"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:219
+msgid "Recycle"
 msgstr ""
 
 #: pkg/docker/storage.jsx:348
 msgid "Reformat and add disks"
 msgstr ""
 
-#: pkg/docker/storage.jsx:355
+#: pkg/kubernetes/views/pv-modify.html:205
+msgid "Register"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:12
+msgid "Register New Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:4
+msgid "Register Persistent Volume"
+msgstr ""
+
+#: pkg/subscriptions/main.js:74
+msgid "Register system"
+msgstr ""
+
+#: pkg/ostree/index.html:115
+msgid "Released"
+msgstr ""
+
+#: pkg/systemd/init.js:518
+msgid "Reload"
+msgstr ""
+
+#: pkg/systemd/init.js:519
+msgid "Reload or Restart"
+msgstr ""
+
+#: pkg/systemd/init.js:521
+msgid "Reload or Try Restart"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:89
+msgid "Remote registry is insecure"
+msgstr ""
+
+#: cockpit.desktop.in.h:3
+msgid "Remote;Administration;"
+msgstr ""
+
+#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
+msgctxt "storage"
+msgid "Removable Drive"
+msgstr ""
+
+#: pkg/ostree/index.html:123 pkg/ostree/index.html:146
+msgid "Removals"
+msgstr ""
+
+#: pkg/kubernetes/views/user-group-remove.html:10
+#: pkg/kubernetes/views/group-delete.html:21
+#: pkg/kubernetes/views/user-delete.html:25
+#: pkg/kubernetes/views/remove-role-dialog.html:8
+msgid "Remove"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2791
+msgid "Remove $0"
+msgstr ""
+
+#: pkg/kubernetes/views/group-delete.html:3
+msgid "Remove Group"
+msgstr ""
+
+#: pkg/kubernetes/views/user-group-remove.html:3
+msgid "Remove Member"
+msgstr ""
+
+#: pkg/kubernetes/views/remove-role-dialog.html:3
+msgid "Remove Role"
+msgstr ""
+
+#: pkg/kubernetes/views/user-delete.html:3
+msgid "Remove User"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:3
+msgid "Remove image tag"
+msgstr ""
+
+#: pkg/kubernetes/views/user-remove-membership.html:3
+msgid "Remove membership"
+msgstr ""
+
+#: pkg/storaged/jobs.js:141
+msgid "Removing $target from RAID Device"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2788
+msgid "Removing <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:154
+msgid "Removing physical volume from $target"
+msgstr ""
+
+#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
+#: pkg/storaged/details.js:1775
+msgid "Rename"
+msgstr ""
+
+#: pkg/storaged/details.js:795
+msgid "Rename Volume Group"
+msgstr ""
+
+#: pkg/storaged/details.js:706
+msgid "Renamee Logical Volume"
+msgstr ""
+
+#: pkg/storaged/jobs.js:157
+msgid "Renaming $target"
+msgstr ""
+
+#: pkg/systemd/services.html:432
+msgid "Repeat Daily"
+msgstr ""
+
+#: pkg/systemd/services.html:431
+msgid "Repeat Hourly"
+msgstr ""
+
+#: pkg/systemd/services.html:434
+msgid "Repeat Monthly"
+msgstr ""
+
+#: pkg/systemd/services.html:433
+msgid "Repeat Weekly"
+msgstr ""
+
+#: pkg/systemd/services.html:435
+msgid "Repeat Yearly"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-body.html:9
+#: pkg/kubernetes/views/details-page.html:141
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
+#: pkg/kubernetes/views/replicationcontroller-modify.html:8
+msgid "Replicas"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:14
+#: pkg/kubernetes/views/replicationcontroller-panel.html:10
+#: pkg/kubernetes/views/topology-page.html:23
+msgid "Replication Controller"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:132
+msgid "Replication Controllers"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:24
 msgid ""
-"The storage pool will be reset to optimize its layout.  All containers will "
-"be erased."
+"Replication controllers dynamically create instances of                pods "
+"from templates, and remove pods when necessary."
 msgstr ""
 
-#: pkg/docker/storage.jsx:360
-msgid "Erase containers, reformat disks, and add them"
+#: pkg/docker/index.html:718
+msgid "Repository"
 msgstr ""
 
-#: pkg/docker/storage.jsx:363
-msgid "Add Additional Storage"
+#: pkg/kubernetes/views/volume-body.html:24
+msgid "Repository URL"
 msgstr ""
 
-#: pkg/docker/storage.jsx:366
-msgid ""
-"All data on selected disks will be erased and disks will be added to the "
-"storage pool."
+#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
+msgid "Requested"
 msgstr ""
 
-#: pkg/docker/storage.jsx:404
-msgid "Could not add all disks"
+#: pkg/kubernetes/views/pv-claim.html:13
+msgid "Requests"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:54
+msgid "Requires Authentication"
+msgstr ""
+
+#: pkg/docker/index.html:323
+msgid "Reset"
 msgstr ""
 
 #: pkg/docker/storage.jsx:417
@@ -2066,375 +4437,591 @@ msgid ""
 "the pool."
 msgstr ""
 
-#: pkg/docker/storage.jsx:423
-msgid "Erase containers and reset storage pool"
+#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
+msgid "Resize"
 msgstr ""
 
-#: pkg/docker/storage.jsx:446
-msgid "Could not reset the storage pool"
+#: pkg/storaged/details.js:673
+msgid "Resize Filesystem"
 msgstr ""
 
-#: pkg/docker/storage.jsx:482
-msgid "You don't have permission to manage the Docker storage pool."
+#: pkg/storaged/details.js:661
+msgid "Resize Logical Volume"
 msgstr ""
 
-#: pkg/docker/storage.jsx:485
-msgid "The Docker storage pool cannot be managed on this system."
+#: pkg/storaged/jobs.js:158
+msgid "Resizing $target"
 msgstr ""
 
-#: pkg/docker/image.js:77
-msgid "Image $0"
+#: pkg/systemd/index.html:126 pkg/systemd/index.html:133
+msgid "Restart"
 msgstr ""
 
-#: pkg/docker/image.js:152
-msgid ""
-"Deleting an image will delete it, but you can probably download it again if "
-"you need it later.  Unless this image has never been pushed to a repository, "
-"that is, in which case you probably can't download it again."
+#: pkg/kubernetes/views/container-body.html:20
+msgid "Restart Count"
 msgstr ""
 
-#: pkg/docker/util.js:94
-msgid "Up since $StartedAt"
+#: pkg/docker/index.html:558 pkg/kubernetes/views/pod-body.html:10
+msgid "Restart Policy"
 msgstr ""
 
-#: pkg/docker/util.js:96
-msgid "Exited $ExitCode"
+#: pkg/kubernetes/scripts/volumes.js:217
+msgid "Retain"
 msgstr ""
 
-#: pkg/docker/util.js:104
-msgid "On failure, retry $0 time"
-msgid_plural "On failure, retry $0 times"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/docker/util.js:107 pkg/docker/index.html.h:48
-msgid "Always"
-msgstr ""
-
-#: pkg/docker/util.js:109 pkg/docker/index.html.h:49
-msgid "Unless Stopped"
-msgstr ""
-
-#: pkg/docker/util.js:123
-msgid "default"
-msgstr ""
-
-#: pkg/docker/util.js:124
-msgid "$0 shares"
-msgstr ""
-
-#: pkg/docker/util.js:231
-msgid "Stopped"
-msgstr ""
-
-#: pkg/docker/util.js:488
-msgid "Container is currently running."
-msgstr ""
-
-#: pkg/docker/util.js:490
-msgid ""
-"Container is currently marked as not running, but regular stopping failed."
-msgstr ""
-
-#: pkg/docker/util.js:491
-msgid "Error message from Docker:"
-msgstr ""
-
-#: pkg/docker/util.js:501
-msgid "Please confirm forced deletion of $0"
-msgstr ""
-
-#: pkg/docker/util.js:503
-msgid "Force Delete"
-msgstr ""
-
-#: pkg/docker/util.js:544
-msgid "Failed to stop Docker scope: $0"
-msgstr ""
-
-#: pkg/docker/containers-view.jsx:239
-msgid "Commit"
-msgstr ""
-
-#: pkg/docker/containers.js:64
-msgid "Failed to start Docker: $0"
-msgstr ""
-
-#: pkg/users/authorized-keys.js:103
-msgid "Validating key"
-msgstr ""
-
-#: pkg/users/authorized-keys.js:108
-msgid "Adding key"
-msgstr ""
-
-#: pkg/users/authorized-keys.js:115
-msgid "Error saving authorized keys: "
-msgstr ""
-
-#: pkg/users/authorized-keys.js:118
-msgid "The key you provided was not valid."
-msgstr ""
-
-#: pkg/users/local.js:40
-msgid "The user <b>$0</b> is not permitted to modify accounts"
-msgstr ""
-
-#: pkg/users/local.js:57
-msgid "Unable to delete root account"
-msgstr ""
-
-#: pkg/users/local.js:59
-msgid "Unable to rename root account"
-msgstr ""
-
-#: pkg/users/local.js:82
-msgid "Prompting via passwd timed out"
-msgstr ""
-
-#: pkg/users/local.js:247
-msgid "Password is too weak"
-msgstr ""
-
-#: pkg/users/local.js:259
-msgid "Password is not acceptable"
-msgstr ""
-
-#: pkg/users/local.js:284 pkg/users/local.js:594
-msgctxt "page-title"
-msgid "Accounts"
-msgstr ""
-
-#: pkg/users/local.js:395 pkg/users/local.js:1082
-msgid "The passwords do not match"
-msgstr ""
-
-#: pkg/users/local.js:400
-msgid "No user name specified"
-msgstr ""
-
-#: pkg/users/local.js:405
-msgid "No real name specified"
-msgstr ""
-
-#: pkg/users/local.js:429 pkg/users/local.js:1104
-msgid "Excellent password"
-msgstr ""
-
-#: pkg/users/local.js:501
-msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
-msgstr ""
-
-#: pkg/users/local.js:509
-msgid "This user name already exists"
-msgstr ""
-
-#: pkg/users/local.js:682 pkg/users/local.js:683
-msgid "Server Administrator"
-msgstr ""
-
-#: pkg/users/local.js:684
-msgid "Container Administrator"
-msgstr ""
-
-#: pkg/users/local.js:839
-msgid "Logged In"
-msgstr ""
-
-#: pkg/users/local.js:841
-msgid "Never"
-msgstr ""
-
-#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
-msgid "Delete $0"
-msgstr ""
-
-#: pkg/sosreport/index.js:49 pkg/sosreport/index.js:113
-#: pkg/systemd/services.html.h:13 pkg/lib/machine-invalid-hostkey.html.h:4
-#: pkg/lib/machine-auth-failed.html.h:7
-#: pkg/lib/machine-unknown-hostkey.html.h:4
-#: pkg/lib/machine-change-port.html.h:8 pkg/lib/machine-not-supported.html.h:3
-#: pkg/shell/index.html.h:37
-msgid "Close"
-msgstr ""
-
-#: pkg/sosreport/index.js:115
-msgid "No archive has been created."
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:598 pkg/networkmanager/interfaces.js:1051
-#: pkg/networkmanager/interfaces.js:2255 pkg/networkmanager/interfaces.js:2257
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:753 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/kubernetes/views/node-body.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:6
-#: pkg/kubernetes/views/pv-claim.html.h:7
-#: pkg/kubernetes/views/image-body.html.h:6
-#: pkg/kubernetes/views/pv-body.html.h:5
-msgid "Unknown"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:805
-msgid "Not available"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
-#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
-msgid "Inactive"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:809
-msgid "Preparing"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:811
-msgid "Configuring"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:813
-msgid "Authenticating"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:815
-msgid "Configuring IP"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:817
-msgid "Checking IP"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:819
-msgid "Waiting"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
-msgid "Active"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:823
-msgid "Deactivating"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:825 pkg/ostree/index.html.h:14
-msgid "Failed"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1326
-msgid "No carrier"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1372
-msgid "Part of "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1420
-msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
-#, fuzzy
-msgctxt "page-title"
-msgid "Networking"
-msgstr "Netværks Traffik"
-
-#: pkg/networkmanager/interfaces.js:1804
-msgid "Automatic (DHCP)"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
-msgid "Link local"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
-msgid "Manual"
+#: pkg/docker/index.html:574
+msgid "Retries:"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1807
-msgid "Shared"
+#: pkg/subscriptions/subscriptions-view.jsx:188
+msgid "Retrieving subscription status..."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1813 pkg/networkmanager/interfaces.js:2475
-#: pkg/networkmanager/interfaces.js:3019 pkg/networkmanager/interfaces.js:3023
-#: pkg/networkmanager/interfaces.js:3029 pkg/networkmanager/index.html.h:22
-msgid "Automatic"
+#: pkg/kubernetes/views/volume-body.html:26
+msgid "Revision"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1814
-msgid "Automatic (DHCP only)"
+#: pkg/users/index.html:94 pkg/kubernetes/views/add-member-role-dialog.html:39
+#: pkg/kubernetes/views/project-body.html:21
+msgid "Roles"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1817
-msgid "Ignore"
+#: pkg/ostree/index.html:73
+msgid "Roll back and reboot"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
 msgid "Round Robin"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
-msgid "Active Backup"
+#: pkg/kubernetes/views/route-page.html:14
+#: pkg/kubernetes/views/route-panel.html:9
+msgid "Route"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1824
-msgid "XOR"
+#: pkg/kubernetes/views/details-page.html:65
+msgid "Routes"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
-msgid "Broadcast"
+#: pkg/systemd/services.html:384
+msgid "Run"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1826
-msgid "802.3ad"
+#: pkg/kubernetes/views/image-config.html:4
+msgid "Run as"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1827
-msgid "Adaptive transmit load balancing"
+#: pkg/networkmanager/index.html:381
+msgid "Runner"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1828
-msgid "Adaptive load balancing"
+#: pkg/ostree/index.html:83
+msgid "Running"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1833
-msgid "MII (Recommended)"
+#: pkg/selinux/setroubleshoot-view.jsx:478
+msgid "SELinux Access Control Errors"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1834
-msgid "ARP"
+#: pkg/selinux/setroubleshoot-view.jsx:330
+msgid "SELinux Policy"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1841
-msgid "Load Balancing"
+#: pkg/selinux/setroubleshoot.html:23
+msgid "SELinux Troubleshoot"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1843
-msgid "802.3ad LACP"
+#: pkg/selinux/setroubleshoot-view.jsx:317
+msgid "SELinux is disabled on the system."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1848
-msgid "Passive"
+#: pkg/selinux/setroubleshoot-view.jsx:309
+msgid "SELinux system status is unknown."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1854
-msgid "Ethtool"
+#: pkg/storaged/jobs.js:119
+msgid "SMART self-test of $target"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1855
-msgid "ARP Ping"
+#: pkg/networkmanager/index.html:218
+msgid "STP Forward delay"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1856
-msgid "NSNA Ping"
+#: pkg/networkmanager/index.html:227
+msgid "STP Hello time"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2156
-msgid "Deleting <b>$0</b> will break the connection to the server, "
+#: pkg/networkmanager/index.html:236
+msgid "STP Maximum message age"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2188
-msgid "Switching on <b>$0</b>  will break the connection to the server, "
+#: pkg/networkmanager/index.html:209
+msgid "STP Priority"
+msgstr ""
+
+#: pkg/systemd/services.html:466
+msgid "Save"
+msgstr ""
+
+#: pkg/ostree/client.js:66
+msgid "Scanning metadata"
+msgstr ""
+
+#: pkg/kubernetes/views/node-capacity.html:9
+msgid "Scheduled Pods"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:322
+msgid "Scheduling Disabled"
+msgstr ""
+
+#: pkg/systemd/services.html:402 pkg/systemd/services.html:406
+msgid "Seconds"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:195
+msgid "Secret"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:106
+msgid "Secret File"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:141
+#, fuzzy
+msgid "Secret Name"
+msgstr "Værtsnavn"
+
+#: pkg/kubernetes/views/volume-body.html:69
+#: pkg/kubernetes/views/volume-body.html:108
+#: pkg/kubernetes/views/volume-body.html:134
+msgid "Secret Volume"
+msgstr ""
+
+#: pkg/systemd/index.html:93
+msgid "Secure Shell Keys"
+msgstr ""
+
+#: pkg/storaged/jobs.js:136
+msgid "Securely erasing $target"
+msgstr ""
+
+#: pkg/kubernetes/views/file-button.html:4
+msgid "Select Manifest File..."
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:7
+msgid "Select an object to see more details."
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:8
+msgid ""
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
+msgstr ""
+
+#: pkg/networkmanager/index.html:69 pkg/networkmanager/index.html:97
+#: pkg/networkmanager/index.html:115 pkg/networkmanager/index.html:515
+#: pkg/networkmanager/index.html:550
+msgid "Sending"
+msgstr ""
+
+#: pkg/storaged/index.html:432
+msgctxt "storage"
+msgid "Serial Number"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:82
+#: pkg/kubernetes/views/volume-body.html:47
+msgid "Server"
+msgstr ""
+
+#: pkg/storaged/overview.js:518
+msgid "Server Address"
+msgstr ""
+
+#: pkg/users/local.js:682 pkg/users/local.js:683
+msgid "Server Administrator"
+msgstr ""
+
+#: pkg/storaged/overview.js:521
+msgid "Server address cannot be empty."
+msgstr ""
+
+#: src/base1/cockpit.js:3709
+msgid "Server has closed the connection."
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:12
+#: pkg/kubernetes/views/service-panel.html:8
+#: pkg/kubernetes/views/topology-page.html:32
+msgid "Service"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:12
+msgid "Service Account"
+msgstr ""
+
+#: pkg/systemd/services.html:279
+msgid "Service Logs"
+msgstr ""
+
+#: pkg/systemd/services.html:342
+#, fuzzy
+msgid "Service name"
+msgstr "Værtsnavn"
+
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:272
+#: pkg/kubernetes/views/dashboard-page.html:134
+#: pkg/kubernetes/views/details-page.html:29
+msgid "Services"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:33
+msgid ""
+"Services group pods and provide a common DNS                name and an "
+"optional, load-balanced IP address to access them."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:20
+msgid "Session Affinity"
+msgstr ""
+
+#: pkg/dashboard/index.html:190
+msgid "Set"
+msgstr ""
+
+#: pkg/systemd/host.js:559
+msgid "Set Host name"
+msgstr ""
+
+#: pkg/users/index.html:117 pkg/users/index.html:221
+msgid "Set Password"
+msgstr ""
+
+#: pkg/systemd/index.html:395
+msgid "Set Time"
+msgstr ""
+
+#: pkg/docker/index.html:551
+msgid "Set container environment variables"
+msgstr ""
+
+#: pkg/networkmanager/index.html:172
+msgid "Set to"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:326
+msgid ""
+"Setting deviates from the configured state and will revert on the next boot."
+msgstr ""
+
+#: pkg/storaged/jobs.js:131
+msgid "Setting up loop device $target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:139
+#, fuzzy
+msgid "Share Name"
+msgstr "Værtsnavn"
+
+#: pkg/networkmanager/interfaces.js:1807
+msgid "Shared"
+msgstr ""
+
+#: pkg/kubernetes/views/container-panel.html:9
+#: pkg/kubernetes/views/container-page-inline.html:14
+msgid "Shell"
+msgstr ""
+
+#: pkg/kubernetes/views/container-page.html:4
+msgid "Show all Containers"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:8
+msgid "Show all Deployment Configs"
+msgstr ""
+
+#: pkg/kubernetes/views/node-page.html:8
+msgid "Show all Nodes"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:9
+msgid "Show all Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-container.html:4
+msgid "Show all Pod Containers"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:8
+msgid "Show all Pods"
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:16
+#: pkg/kubernetes/views/group-page.html:14
+#: pkg/kubernetes/views/project-page.html:23
+msgid "Show all Projects"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:10
+msgid "Show all Replication Controllers"
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:10
+msgid "Show all Routes"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:8
+msgid "Show all Services"
+msgstr ""
+
+#: pkg/docker/index.html:127
+msgid "Show all containers"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-page.html:12
+msgid "Show all image streams"
+msgstr ""
+
+#: pkg/docker/index.html:241 pkg/kubernetes/views/image-page.html:11
+msgid "Show all images"
+msgstr ""
+
+#: pkg/systemd/index.html:94
+msgid "Show fingerprints"
+msgstr ""
+
+#: pkg/systemd/index.html:136
+msgid "Shutdown"
+msgstr ""
+
+#: pkg/kubernetes/views/container-body.html:18
+msgid "Since"
+msgstr ""
+
+#: pkg/systemd/init.js:621
+msgid "Since $0"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/storaged/index.html:232
+msgid "Size"
+msgstr ""
+
+#: pkg/storaged/dialog.js:271
+msgid "Size cannot be negative"
+msgstr ""
+
+#: pkg/storaged/dialog.js:269
+msgid "Size cannot be zero"
+msgstr ""
+
+#: pkg/storaged/dialog.js:273
+msgid "Size is too large"
+msgstr ""
+
+#: pkg/storaged/dialog.js:267
+msgid "Size must be a number"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:43
+#: pkg/kubernetes/views/auth-rejected-cert.html:11
+msgid "Skip Certificate Verification"
+msgstr ""
+
+#: pkg/systemd/services.html:54
+msgid "Sockets"
+msgstr ""
+
+#: pkg/ostree/index.html:23
+msgid "Software Updates"
+msgstr ""
+
+#: pkg/docker/storage.jsx:156
+msgid "Solid-State Disk"
+msgstr ""
+
+#: pkg/storaged/overview.js:182
+msgctxt "storage"
+msgid "Solid-State Disk"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:90
+msgid "Solution applied successfully"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:97
+msgid "Solution failed"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:908
+msgid "Sorry, I don't know how to modify this volume"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:8
+msgid "Source URL"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2573
+msgid "Spanning Tree Protocol"
+msgstr ""
+
+#: pkg/networkmanager/index.html:200
+msgid "Spanning Tree Protocol (STP)"
+msgstr ""
+
+#: pkg/storaged/details.js:1594
+msgid "Spare"
+msgstr ""
+
+#: pkg/systemd/index.html:470
+msgid "Specific Time"
+msgstr ""
+
+#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
+msgid "Start"
+msgstr ""
+
+#: pkg/docker/index.html:68
+msgid "Start Docker"
+msgstr ""
+
+#: pkg/storaged/index.html:49
+msgid "Start Multipath"
+msgstr ""
+
+#: pkg/storaged/details.js:1614
+msgid "Start Scrubbing"
+msgstr ""
+
+#: pkg/storaged/jobs.js:139
+msgid "Starting RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:124
+msgid "Starting swapspace $target"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:37
+msgid "Starts"
+msgstr ""
+
+#: pkg/kubernetes/views/container-body.html:16
+#: pkg/kubernetes/views/details-page.html:38
+#: pkg/kubernetes/views/details-page.html:175
+msgid "State"
+msgstr ""
+
+#: pkg/storaged/index.html:571
+#, fuzzy
+msgctxt "storage"
+msgid "State"
+msgstr "Tilstand"
+
+#: pkg/systemd/init.js:303
+msgid "Static"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/containers-listing.html:16
+#: pkg/kubernetes/views/nodes-page.html:44
+#: pkg/kubernetes/views/pvc-body.html:13 pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/pv-body.html:24
+msgid "Status"
+msgstr "Tilstand"
+
+#: pkg/subscriptions/subscriptions-view.jsx:146
+#, fuzzy
+msgid "Status: $0"
+msgstr "Tilstand"
+
+#: pkg/subscriptions/subscriptions-view.jsx:141
+msgid "Status: System isn't registered"
+msgstr ""
+
+#: pkg/networkmanager/index.html:455
+msgid "Sticky"
+msgstr ""
+
+#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
+msgid "Stop"
+msgstr ""
+
+#: pkg/storaged/details.js:1615
+msgid "Stop Scrubbing"
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:10
+msgid "Stop with"
+msgstr ""
+
+#: pkg/docker/util.js:231
+msgid "Stopped"
+msgstr ""
+
+#: pkg/storaged/jobs.js:138
+msgid "Stopping RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:125
+msgid "Stopping swapspace $target"
+msgstr ""
+
+#: pkg/storaged/index.html:23 pkg/storaged/index.html:672
+msgid "Storage"
+msgstr ""
+
+#: pkg/storaged/index.html:686
+msgid "Storage Log"
+msgstr ""
+
+#: pkg/storaged/index.html:342
+msgid "Storage Logs"
+msgstr ""
+
+#: pkg/docker/index.html:324
+msgid "Storage pool"
+msgstr ""
+
+#: pkg/systemd/index.html:148
+msgid "Store Performance Data"
+msgstr ""
+
+#: pkg/storaged/details.js:237
+msgid "Store passphrase"
+msgstr ""
+
+#: pkg/storaged/details.js:527
+msgid "Stored Passphrase"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:12
+msgid ""
+"Strategy            {{item.spec.strategy.type}}            Latest "
+"Version            {{ item.status.latestVersion }}            Not "
+"deployed        "
+msgstr ""
+
+#: pkg/subscriptions/index.html:22
+msgid "Subscriptions"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:4
+msgid "Summary"
+msgstr ""
+
+#: pkg/storaged/details.js:1251
+msgctxt "storage-id-desc"
+msgid "Swap Space"
+msgstr ""
+
+#: pkg/systemd/index.html:243
+msgid "Swap Used"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
+msgid "Switch off $0"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2191 pkg/networkmanager/interfaces.js:2765
@@ -2445,13 +5032,82 @@ msgstr ""
 msgid "Switching off <b>$0</b>  will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
-msgid "Switch off $0"
+#: pkg/networkmanager/interfaces.js:2773
+msgid "Switching off <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
-#: pkg/networkmanager/interfaces.js:2507
-msgid "Bond"
+#: pkg/networkmanager/interfaces.js:2188
+msgid "Switching on <b>$0</b>  will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2762
+msgid "Switching on <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:75
+msgid "Synchronize"
+msgstr ""
+
+#: pkg/dashboard/index.html:188 pkg/lib/machine-sync-users.html:4
+msgid "Synchronize users"
+msgstr ""
+
+#: pkg/systemd/index.html:54
+msgid "Synchronized"
+msgstr ""
+
+#: pkg/systemd/index.html:51
+msgid "Synchronized with {{Server}}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:146
+msgid "Synchronizing RAID Device $target"
+msgstr ""
+
+#: pkg/systemd/index.html:4
+msgid "System"
+msgstr ""
+
+#: pkg/systemd/services.html:53
+msgid "System Services"
+msgstr ""
+
+#: pkg/systemd/index.html:112
+msgid "System Time"
+msgstr ""
+
+#: pkg/docker/index.html:349
+msgid "TCP"
+msgstr ""
+
+#: pkg/kubernetes/views/route-body.html:12
+msgid "TLS Termination"
+msgstr ""
+
+#: pkg/docker/index.html:724
+msgid "Tag"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:27
+#: pkg/kubernetes/views/imagestream-modify.html:76
+#: pkg/kubernetes/views/image-listing.html:14
+msgid "Tags"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:136
+msgid "Target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:75
+msgid "Target Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:114
+msgid "Target World Wide Names"
+msgstr ""
+
+#: pkg/systemd/services.html:52
+msgid "Targets"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2235 pkg/networkmanager/interfaces.js:2247
@@ -2459,333 +5115,524 @@ msgstr ""
 msgid "Team"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
-#: pkg/networkmanager/interfaces.js:2622
-msgid "VLAN"
+#: pkg/networkmanager/interfaces.js:2558
+msgid "Team Port"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
-#: pkg/networkmanager/interfaces.js:2584
-msgid "Bridge"
+#: pkg/networkmanager/index.html:652
+msgid "Team Port Settings"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2276
-msgid "Carrier"
+#: pkg/networkmanager/index.html:624
+msgid "Team Settings"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2279 pkg/kubernetes/scripts/volumes.js:990
-msgid "Yes"
+#: pkg/kubernetes/views/replicationcontroller-page.html:20
+#: pkg/kubernetes/views/deploymentconfig-panel.html:10
+#: pkg/kubernetes/views/deploymentconfig-page.html:15
+#: pkg/kubernetes/views/replicationcontroller-panel.html:14
+msgid "Template"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2299
-#: pkg/subscriptions/subscriptions-view.jsx:36
-#: pkg/kubernetes/views/node-body.html.h:14
-#: pkg/kubernetes/views/containers-listing.html.h:7
-#: pkg/kubernetes/views/volumes-page.html.h:5
-#: pkg/kubernetes/views/pv-claim.html.h:6
-#: pkg/kubernetes/views/nodes-page.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:5 pkg/kubernetes/views/pv-body.html.h:4
-msgid "Status"
-msgstr "Tilstand"
+#: pkg/systemd/terminal.html:4
+msgid "Terminal"
+msgstr ""
+
+#: pkg/users/index.html:78
+msgid "Terminate Session"
+msgstr ""
+
+#: pkg/networkmanager/index.html:38
+msgid "Testing connection"
+msgstr ""
+
+#: pkg/storaged/index.html:40
+msgid "The \"storaged\" API is not available on this system."
+msgstr ""
+
+#: pkg/docker/storage.jsx:485
+msgid "The Docker storage pool cannot be managed on this system."
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:386
+msgid "The IP address or host name cannot contain whitespace."
+msgstr ""
+
+#: pkg/storaged/index.html:532
+msgid "The RAID Array is in a degraded state"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:399
+msgid "The address contains invalid characters"
+msgstr ""
+
+#: pkg/lib/machine-unknown-hostkey.html:6
+msgid ""
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:324
+msgid "The configured state is unknown, it might change on the next boot."
+msgstr ""
+
+#: pkg/kubernetes/views/container-page-inline.html:22
+msgid "The container '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:192
+msgid "The current user isn't allowed to access system subscription status."
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:25
+msgid "The deployment config '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:47
+msgid "The group '{{ groupName }}' does not exist."
+msgstr ""
+
+#: pkg/shell/base_index.js:673
+msgid "The javascript console contains details about this error "
+msgstr ""
+
+#: pkg/lib/machine-invalid-hostkey.html:8
+msgid ""
+"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
+"in use. Unless this machine was recently replaced, it is likely that someone "
+"is trying to attack your connection to this machine."
+msgstr ""
+
+#: pkg/users/authorized-keys.js:118
+msgid "The key you provided was not valid."
+msgstr ""
+
+#: pkg/storaged/details.js:1751
+msgid "The last physical volume of a volume group cannot be removed."
+msgstr ""
+
+#: pkg/shell/indexes.js:314
+msgid "The machine is restarting"
+msgstr ""
+
+#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
+msgid "The maximum number of replicas is 128"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:407
+msgid "The name contains invalid characters"
+msgstr ""
+
+#: pkg/kubernetes/views/node-page.html:23
+msgid "The node '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/node-alerts.html:7
+msgid "The node doesn't have enough disk space"
+msgstr ""
+
+#: pkg/kubernetes/views/node-alerts.html:11
+msgid "The node doesn't have enough free memory"
+msgstr ""
+
+#: pkg/users/local.js:395 pkg/users/local.js:1082
+msgid "The passwords do not match"
+msgstr ""
+
+#: pkg/lib/credentials.js:186
+msgid "The passwords do not match."
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:21
+msgid "The persistent volume '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:40
+msgid "The pod '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/project-page.html:34
+msgid "The project '{{ projName }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:30
+msgid "The replication controller '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:19
+msgid "The route '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:386
+msgid "The selected file is not a valid Kubernetes application manifest."
+msgstr ""
+
+#: src/base1/cockpit.js:3695
+msgid "The server refused to authenticate using any supported methods."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:2
+msgid "The server uses a certificate signed by an unknown authority."
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:19
+msgid "The service '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/docker/storage.jsx:355
+msgid ""
+"The storage pool will be reset to optimize its layout.  All containers will "
+"be erased."
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:29
+msgid "The user '{{ userName }}' does not exist."
+msgstr ""
+
+#: pkg/systemd/init.js:834
+msgid "The user <b>$0</b> does not have permissions for creating timers"
+msgstr ""
+
+#: pkg/dashboard/list.js:209
+msgid "The user <b>$0</b> is not permitted to manage servers"
+msgstr ""
+
+#: pkg/storaged/permissions.js:61
+msgid "The user <b>$0</b> is not permitted to manage storage"
+msgstr ""
+
+#: pkg/users/local.js:40
+msgid "The user <b>$0</b> is not permitted to modify accounts"
+msgstr ""
+
+#: pkg/systemd/host.js:43
+msgid "The user <b>$0</b> is not permitted to modify hostnames"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1420
+msgid "The user <b>$0</b> is not permitted to modify network settings"
+msgstr ""
+
+#: pkg/realmd/operation.js:436
+msgid "The user <b>$0</b> is not permitted to modify realms"
+msgstr ""
+
+#: pkg/users/local.js:501
+msgid ""
+"The user name can only consist of letters from a-z, digits, dots, dashes and "
+"underscores."
+msgstr ""
+
+#: pkg/users/index.html:332
+msgid "There are no authorized public keys for this account."
+msgstr ""
+
+#: pkg/storaged/details.js:1756
+msgid ""
+"There is not enough free space elsewhere to remove this physical volume.  At "
+"least $0 more free space is needed."
+msgstr ""
+
+#: pkg/storaged/utils.js:168
+msgid "Thin Logical Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:8
+msgid ""
+"This claim is in use. Deleting it may cause issues with the following pod:"
+msgstr ""
+
+#: pkg/systemd/init.js:1222
+msgid ""
+"This day doesn't exist in all months.<br> The timer will only be executed in "
+"months that have 31st."
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2310
 msgid "This device cannot be managed here."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2342
-msgid "Unknown configuration"
+#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
+msgid "This field cannot be empty."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2441
-msgid "Configure"
+#: pkg/storaged/details.js:690
+msgid "This logical volume cannot be made smaller."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2473
-msgid "$mtu"
+#: pkg/lib/machine-dialogs.js:364
+msgid "This machine has already been added."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2477
-msgid "MTU"
+#: pkg/realmd/operation.html:89
+msgid "This may take a while"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2483
-msgid "Master"
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid ""
+"This option is for single node testing only – local storage will not work in "
+"a multi-node cluster"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2502
-msgid "ARP Monitoring"
+#: src/bridge/cockpitpackages.c:470
+msgid "This package is not compatible with this version of Cockpit"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
-msgid "Broken configuration"
+#: src/bridge/cockpitpackages.c:459
+#, c-format
+msgid "This package requires Cockpit version %s or later"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2558
-msgid "Team Port"
+#: pkg/tuned/dialog.js:102
+msgid "This system is using a custom profile"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2573
-msgid "Spanning Tree Protocol"
+#: pkg/tuned/dialog.js:100
+msgid "This system is using the recommended profile"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
-msgid "Priority $priority"
+#: pkg/systemd/init.js:639
+msgid "This unit is an instance of the $0 template."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2577
-msgid "Forward delay $forward_delay"
+#: pkg/systemd/services.html:302
+msgid "This unit is not designed to be enabled explicitly.          "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2579
-msgid "Hello time $hello_time"
+#: pkg/users/local.js:509
+msgid "This user name already exists"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2581
-msgid "Maximum message age $max_age"
+#: pkg/lib/machine-dialogs.js:380
+msgid ""
+"This version of cockpit-ws does not support connecting to a host with an "
+"alternate user or port"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2601
-msgid "Path cost $path_cost"
+#: pkg/kubernetes/views/pv-delete.html:7
+msgid ""
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2603
-msgid "Hairpin mode"
+#: pkg/kubernetes/views/pv-claim.html:23
+msgid "This volume has not been claimed"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2605
-msgid "Bridge port"
+#: pkg/systemd/index.html:379
+msgid "Time Zone"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2619
-msgid "Parent $parent"
+#: pkg/systemd/services.html:55
+msgid "Timers"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2620
-msgid "Id $id"
+#: pkg/kubernetes/views/image-body.html:33
+msgid "To pull this image:"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2628
-msgid "General"
+#: pkg/kubernetes/views/imagestream-body.html:39
+msgid "To push to an image to this image stream:"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2637
-msgid "Connect automatically"
+#: pkg/lib/machine-change-port.html:11
+msgid ""
+"To try a different port you will need to upgrade cockpit-ws to a newer "
+"version."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2641
-msgid "IPv4"
+#: pkg/kubernetes/views/auth-form.html:116
+msgid "Token"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2642
-msgid "IPv6"
+#: pkg/kubernetes/index.html:57
+msgid "Topology"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2727 pkg/networkmanager/index.html.h:33
-#: pkg/kubernetes/views/project-listing.html.h:5
-msgid "Members"
+#: pkg/docker/storage.jsx:314
+msgid "Total"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2727 pkg/docker/index.html.h:39
-#: pkg/networkmanager/index.html.h:24
-#: pkg/kubernetes/views/service-body.html.h:6
-#: pkg/kubernetes/views/image-config.html.h:7
-#: pkg/kubernetes/views/container-body.html.h:5
-msgid "Ports"
+#: pkg/ostree/index.html:99
+msgid "Tree"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2762
-msgid "Switching on <b>$0</b> will break the connection to the server, "
+#: pkg/kubernetes/views/deploymentconfig-body.html:32
+msgid "Triggers"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2773
-msgid "Switching off <b>$0</b> will break the connection to the server, "
+#: pkg/shell/index.html:328 pkg/shell/stub.html:181
+msgid "Troubleshoot"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2788
-msgid "Removing <b>$0</b> will break the connection to the server, "
+#: pkg/kubernetes/views/auth-rejected-cert.html:21
+msgid "Trust this certificate for this connection"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2791
-msgid "Remove $0"
+#: pkg/systemd/init.js:520
+msgid "Try Restart"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2833
-msgid "Adding <b>$0</b> will break the connection to the server, "
+#: pkg/docker/index.html:71 pkg/docker/index.html:74
+msgid "Try again"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2836
-msgid "Add $0"
+#: pkg/systemd/index.html:59
+msgid "Trying to synchronize with {{Server}}"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2870
-msgid "Changing the settings will break the connection to the server, "
+#: pkg/tuned/dialog.js:262
+msgid "Tuned has failed to start"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2872
-msgid "Change the settings"
+#: pkg/tuned/dialog.js:94
+msgid "Tuned is not available"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length or Netmask"
+#: pkg/tuned/dialog.js:96
+msgid "Tuned is not running"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length"
+#: pkg/tuned/dialog.js:98
+msgid "Tuned is off"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3011
-#: pkg/kubernetes/views/details-page.html.h:7
-msgid "Addresses"
+#: pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/pv-modify.html:10
+#: pkg/kubernetes/views/volumes-page.html:20 pkg/kubernetes/views/deploy.html:9
+msgid "Type"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3018
-msgid "DNS"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3022
-msgid "DNS Search Domains"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3027
-#: pkg/kubernetes/views/details-page.html.h:11
-msgid "Routes"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv4 Settings"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv6 Settings"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3436
-msgid "Creating this bond will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
-#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
-msgid "Create it"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3611
-msgid "Creating this team will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3842
-msgid "Creating this bridge will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4064
-msgid "Creating this VLAN will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4139
-msgid "MTU must be a positive number"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:196
-msgid "Invalid credentials"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:198
-msgid "'Organization' required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:200
-msgid "Login/password or activation key required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:202
-msgid "'Organization' required when using activation keys."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:64
-#: pkg/kubernetes/views/volume-body.html.h:16
-#: pkg/kubernetes/views/pv-modify.html.h:11
-msgid "Server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:88
-#: pkg/subscriptions/subscriptions-register.jsx:152
-#: pkg/lib/machine-auth-failed.html.h:3 pkg/lib/machine-sync-users.html.h:6
-#: pkg/lib/machine-change-auth.html.h:6 pkg/shell/index.html.h:31
-#: pkg/users/index.html.h:16 pkg/kubernetes/views/auth-form.html.h:11
-msgid "Password"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:102
-msgid "Custom URL"
+#: pkg/kubernetes/views/details-page.html:7
+msgid "Type:"
 msgstr ""
 
 #: pkg/subscriptions/subscriptions-register.jsx:110
 msgid "URL"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-register.jsx:125
-msgid "Proxy"
+#: pkg/storaged/index.html:547 pkg/storaged/index.html:626
+msgctxt "storage"
+msgid "UUID"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-register.jsx:132
-msgid "Use proxy server"
+#: pkg/selinux/setroubleshoot-view.jsx:114
+msgid "Unable to apply this solution automatically"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-register.jsx:140
-msgid "Login"
+#: pkg/ostree/index.html:219
+msgid "Unable to communicate with OSTree"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-register.jsx:164
-msgid "Activation Key"
+#: pkg/subscriptions/subscriptions-view.jsx:195
+msgid "Unable to connect"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-register.jsx:176
-msgid "Organization"
+#: pkg/kubernetes/scripts/dashboard.js:413
+msgid "Unable to decode Kubernetes application manifest."
 msgstr ""
 
-#: pkg/subscriptions/main.js:45 pkg/subscriptions/subscriptions-view.jsx:143
-#: pkg/kubernetes/views/pv-modify.html.h:23
-msgid "Register"
+#: pkg/users/local.js:57
+msgid "Unable to delete root account"
 msgstr ""
 
-#: pkg/subscriptions/main.js:74
-msgid "Register system"
+#: pkg/selinux/setroubleshoot-client.js:157
+msgid "Unable to get alert"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:32
-msgid "Product name"
+#: pkg/storaged/overview.js:586
+msgid "Unable to reach server"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product ID"
+#: pkg/kubernetes/scripts/dashboard.js:401
+msgid "Unable to read the Kubernetes application manifest. Code $0."
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/index.html.h:13
-#: pkg/shell/index.html.h:14 pkg/shell/stub.html.h:9 pkg/shell/simple.html.h:9
-#: pkg/ostree/index.html.h:19
-msgid "Version"
+#: pkg/users/local.js:59
+msgid "Unable to rename root account"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:35
-#: pkg/kubernetes/views/image-config.html.h:5
-msgid "Architecture"
+#: pkg/selinux/setroubleshoot-client.js:172
+msgid "Unable to run fix"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:37
-msgid "Starts"
+#: pkg/selinux/setroubleshoot-client.js:52
+msgid "Unable to start setroubleshootd"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Ends"
+#: pkg/playground/translate.html:35 pkg/playground/translate.html:40
+msgid "Unavailable"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:141
-msgid "Status: System isn't registered"
+#: pkg/docker/index.html:763 pkg/networkmanager/index.html:792
+msgid "Unexpected error"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:146
-#, fuzzy
-msgid "Status: $0"
-msgstr "Tilstand"
+#: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/image-body.html:15
+#: pkg/kubernetes/views/pv-claim.html:31 pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
+msgid "Unknown"
+msgstr ""
+
+#: pkg/storaged/details.js:1597
+msgid "Unknown ($0)"
+msgstr ""
+
+#: pkg/lib/machine-unknown-hostkey.html:2
+msgid "Unknown Host Key"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2342
+msgid "Unknown configuration"
+msgstr ""
+
+#: pkg/storaged/overview.js:582
+msgid "Unknown host name"
+msgstr ""
+
+#: pkg/docker/index.html:570
+msgid "Unless Stopped"
+msgstr ""
+
+#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
+#: pkg/storaged/details.js:1110
+msgid "Unlock"
+msgstr ""
+
+#: pkg/shell/index.html:220
+msgid "Unlock Key"
+msgstr ""
+
+#: pkg/storaged/jobs.js:121
+msgid "Unlocking $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:108
+msgid "Unmanaged Interfaces"
+msgstr ""
+
+#: pkg/systemd/init.js:548
+msgid "Unmask"
+msgstr ""
+
+#: pkg/storaged/details.js:1100
+msgid "Unmount"
+msgstr ""
+
+#: pkg/storaged/jobs.js:127
+msgid "Unmounting $target"
+msgstr ""
+
+#: pkg/users/index.html:315
+msgid "Unnamed"
+msgstr ""
+
+#: pkg/storaged/details.js:1256
+msgctxt "storage-id-desc"
+msgid "Unrecognized Data"
+msgstr ""
 
 #: pkg/subscriptions/subscriptions-view.jsx:148
 msgid "Unregister"
@@ -2795,342 +5642,217 @@ msgstr ""
 msgid "Unregistering system..."
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:161
-#: pkg/subscriptions/index.html.h:1
-msgid "Subscriptions"
+#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
+#: src/bridge/cockpitdbussetup.c:625
+msgid "Unsupported setup mechanism"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/ostree/index.html.h:15
+#: src/base1/cockpit.js:3697
+msgid "Untrusted host"
+msgstr ""
+
+#: pkg/docker/util.js:94
+msgid "Up since $StartedAt"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:41
+msgid "Update"
+msgstr ""
+
+#: pkg/ostree/index.html:125 pkg/ostree/index.html:152
+msgid "Updates"
+msgstr ""
+
+#: pkg/ostree/index.html:96
 msgid "Updating"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:188
-msgid "Retrieving subscription status..."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:191
-msgid "Access denied"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:192
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:195
-msgid "Unable to connect"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:196
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:222
-msgid "Installed products"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:223
-msgid "No installed products on the system."
-msgstr ""
-
-#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr ""
-
-#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr ""
-
-#: pkg/kubernetes/scripts/details.js:546
-msgid "Not a valid value for Host"
 msgstr ""
 
 #: pkg/kubernetes/scripts/details.js:655
 msgid "Updating $0..."
 msgstr ""
 
-#: pkg/kubernetes/scripts/graphs.js:601 pkg/kubernetes/scripts/nodes.js:711
-#: pkg/kubernetes/scripts/nodes.js:817 pkg/dashboard/index.html.h:2
-msgid "CPU"
+#: pkg/shell/index.html:165
+msgid "Use my password for privileged tasks and to connect to other machines"
 msgstr ""
 
-#: pkg/kubernetes/scripts/graphs.js:606 pkg/kubernetes/scripts/nodes.js:715
-#: pkg/kubernetes/scripts/nodes.js:826 pkg/dashboard/index.html.h:3
-msgid "Memory"
+#: pkg/subscriptions/subscriptions-register.jsx:132
+msgid "Use proxy server"
 msgstr ""
 
-#: pkg/kubernetes/scripts/graphs.js:611 pkg/dashboard/index.html.h:4
-msgid "Network"
+#: pkg/shell/index.html:172
+msgid "Use the following keys to authenticate against other systems"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:319 pkg/kubernetes/views/node-body.html.h:16
-#: pkg/kubernetes/views/details-page.html.h:10
-msgid "Not Ready"
+#: pkg/systemd/index.html:251
+msgid "Used"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
+#: pkg/systemd/index.html:229 pkg/dashboard/index.html:158
+#: pkg/playground/translate.html:86 pkg/playground/translate.html:106
+#: pkg/kubernetes/views/user-panel.html:9
+#: pkg/kubernetes/views/auth-form.html:61
+#: pkg/kubernetes/views/volume-body.html:64
+#: pkg/kubernetes/views/volume-body.html:103
+msgid "User"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:324 pkg/kubernetes/views/node-body.html.h:15
-#: pkg/kubernetes/views/details-page.html.h:9
-msgid "Ready"
-msgstr ""
-
-#: pkg/kubernetes/scripts/nodes.js:397
-msgid "Please type an address"
-msgstr ""
-
-#: pkg/kubernetes/scripts/nodes.js:399
-msgid "The address contains invalid characters"
-msgstr ""
-
-#: pkg/kubernetes/scripts/nodes.js:407
-msgid "The name contains invalid characters"
-msgstr ""
-
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
-msgstr ""
-
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
-msgstr ""
-
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+#: pkg/users/index.html:90 pkg/users/index.html:154
+#: pkg/realmd/operation.html:47
 #, fuzzy
-msgid "Disk"
-msgstr "Disk I/O"
+msgid "User Name"
+msgstr "Værtsnavn"
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
+#: pkg/realmd/operation.html:53
+msgid "User Password"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:870
-#, c-format
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/kubernetes/scripts/nodes.js:872
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/kubernetes/scripts/connection.js:88
-msgid "Error writing kubectl config"
+#: pkg/lib/machine-change-auth.html:18
+msgid "User name"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:514
-msgid "Couldn't find running API server"
+#: pkg/kubernetes/views/add-member-role-dialog.html:15
+msgid "User or Group"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:516
-msgid "Connection Error: $0"
+#: pkg/kubernetes/views/auth-form.html:94
+#, fuzzy
+msgid "Username"
+msgstr "Værtsnavn"
+
+#: pkg/kubernetes/views/project-listing.html:85
+msgid "Users"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:539
-msgid "Please provide a valid address"
+#: pkg/storaged/details.js:181
+msgid "VFAT - Compatible with all systems and devices"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:554
-msgid "Please provide a username"
+#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
+#: pkg/networkmanager/interfaces.js:2622
+msgid "VLAN"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:650
-msgid "Error getting certificate details: $0"
+#: pkg/networkmanager/index.html:141
+msgid "VLAN Id"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
+#: pkg/networkmanager/index.html:736
+msgid "VLAN Settings"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
+#: pkg/users/authorized-keys.js:103
+msgid "Validating key"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
+#: pkg/systemd/index.html:98 pkg/ostree/index.html:113 pkg/shell/simple.html:77
+#: pkg/shell/index.html:90 pkg/shell/stub.html:83
+msgid "Version"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
+#: pkg/storaged/jobs.js:137
+msgid "Very securely erasing $target"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
+#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
+#: pkg/kubernetes/views/pvc-body.html:6
+msgid "Volume"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
-msgid "Host Path"
+#: pkg/storaged/index.html:620
+msgid "Volume Group"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
+#: pkg/storaged/utils.js:239
+msgid "Volume Group $0"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:199
-msgid "NFS Mount"
+#: pkg/storaged/index.html:98
+msgid "Volume Groups"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
+#: pkg/kubernetes/views/volume-body.html:14
+#: pkg/kubernetes/views/volume-body.html:89
+msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
-msgid "ISCSI"
+#: pkg/kubernetes/views/pv-modify.html:115
+#: pkg/kubernetes/views/volume-body.html:42
+#, fuzzy
+msgid "Volume Name"
+msgstr "Værtsnavn"
+
+#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
+msgid "Volume Type"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
+#: pkg/docker/index.html:536 pkg/kubernetes/views/pod-page.html:18
+#: pkg/kubernetes/views/image-config.html:28
+#: pkg/kubernetes/views/dashboard-page.html:47 pkg/kubernetes/index.html:70
+msgid "Volumes"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
+#: pkg/networkmanager/interfaces.js:819
+msgid "Waiting"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid "Warning:"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
+#: pkg/systemd/logs.html:48
+msgid "Warnings"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
+#: pkg/systemd/services.html:409
+msgid "Weeks"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
+#: pkg/kubernetes/views/registry-dashboard-page.html:5
+msgid "Welcome to the Image Registry"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
+#: pkg/kubernetes/views/volumes-page.html:61
+msgid "When"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
+#: pkg/docker/index.html:507
+msgid "With terminal"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
+#: pkg/storaged/index.html:438
+#, fuzzy
+msgctxt "storage"
+msgid "World Wide Name"
+msgstr "Værtsnavn"
+
+#: pkg/storaged/details.js:1595
+msgid "Write-mostly"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
+#: pkg/storaged/index.html:333
+msgid "Writing"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
+#: pkg/ostree/client.js:64
+msgid "Writing objects"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:469
-msgid "Please select a valid access mode"
+#: pkg/storaged/details.js:177
+msgid "XFS - Red Hat Enterprise Linux 7 default"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:477
-msgid "Please provide a valid name"
+#: pkg/networkmanager/interfaces.js:1824
+msgid "XOR"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:485
-msgid "Please provide a valid storage capacity."
+#: pkg/kubernetes/scripts/volumes.js:990 pkg/networkmanager/interfaces.js:2279
+msgid "Yes"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:493
-msgid "Please select a valid policy option."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:565
-msgid "Please select a valid endpoint"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:574
-msgid "Please provide a GlusterFS volume name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:632
-msgid "Please provide a valid NFS server"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
-msgid "Please provide a valid path"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:781
-msgid "Please provide a valid target"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:789
-msgid "Please provide a valid qualified name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:797
-msgid "Please provide a valid logical unit number"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:805
-msgid "Please provide a valid filesystem type"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:813
-msgid "Please provide a valid interface"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:860
-msgid "NFS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:872
-msgid "GlusterFS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:908
-msgid "Sorry, I don't know how to modify this volume"
-msgstr ""
-
-#: pkg/kubernetes/scripts/charts.js:113
-msgid "Unavailable"
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:384
+#: pkg/lib/machine-sync-users.html:47
 msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:401
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:413
-msgid "Unable to decode Kubernetes application manifest."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:441
-msgid "Please create another namespace for $0 \"$1\""
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:460
-msgid "Manifest"
-msgstr ""
-
-#: pkg/dashboard/list.js:209
-msgid "The user <b>$0</b> is not permitted to manage servers"
+"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
+"synchronize users, a user with superuser privileges is required."
 msgstr ""
 
 #: pkg/dashboard/list.js:394
@@ -3138,2955 +5860,203 @@ msgid ""
 "You are currently connected directly to this server. You cannot delete it."
 msgstr ""
 
-#: cockpit.appdata.xml.in.h:1
-msgid ""
-"Cockpit is a server manager that makes it easy to administer your Linux "
-"servers via a web browser. Jumping between the terminal and the web tool is "
-"no problem. A service started via Cockpit can be stopped via the terminal. "
-"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
-"journal interface."
-msgstr ""
-
-#: cockpit.appdata.xml.in.h:2
-msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
-"stopping services. You can monitor and administer several servers at the "
-"same time. Just add them with a single click and your machines will look "
-"after its buddies."
-msgstr ""
-
-#: cockpit.desktop.in.h:1 pkg/shell/index.html.h:1 pkg/shell/stub.html.h:1
-#: pkg/shell/simple.html.h:1
-msgid "Cockpit"
-msgstr ""
-
-#: cockpit.desktop.in.h:2
-msgid "A user interface for GNU/Linux servers"
-msgstr ""
-
-#: cockpit.desktop.in.h:3
-msgid "Remote;Administration;"
-msgstr ""
-
-#: pkg/systemd/index.html.h:1
-msgid "System"
-msgstr ""
-
-#: pkg/systemd/index.html.h:2
-msgid "No host keys found."
-msgstr ""
-
-#: pkg/systemd/index.html.h:3
-msgid "Synchronized with {{Server}}"
-msgstr ""
-
-#: pkg/systemd/index.html.h:4
-msgid "Synchronized"
-msgstr ""
-
-#: pkg/systemd/index.html.h:5
-msgid "Trying to synchronize with {{Server}}"
-msgstr ""
-
-#: pkg/systemd/index.html.h:6
-msgid "Not synchronized"
-msgstr ""
-
-#: pkg/systemd/index.html.h:7
-msgid "Hardware"
-msgstr ""
-
-#: pkg/systemd/index.html.h:8
-msgid "Asset Tag"
-msgstr ""
-
-#: pkg/systemd/index.html.h:9 pkg/kubernetes/views/node-body.html.h:6
-msgid "Machine ID"
-msgstr ""
-
-#: pkg/systemd/index.html.h:10 pkg/ostree/index.html.h:18
-#: pkg/kubernetes/views/nodes-page.html.h:6
-msgid "Operating System"
-msgstr ""
-
-#: pkg/systemd/index.html.h:11
-msgid "Secure Shell Keys"
-msgstr ""
-
-#: pkg/systemd/index.html.h:12
-msgid "Show fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:14 pkg/dashboard/index.html.h:7
-msgid "Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:15
-msgid "Domain"
-msgstr ""
-
-#: pkg/systemd/index.html.h:16
-msgid "System Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:17
-msgid "Power Options"
-msgstr ""
-
-#: pkg/systemd/index.html.h:20
-msgid "Performance Profile"
-msgstr ""
-
-#: pkg/systemd/index.html.h:21
-msgid "Store Performance Data"
-msgstr ""
-
-#: pkg/systemd/index.html.h:32
-msgid "Machine SSH Key Fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:33
-msgid "Pretty Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:34
-msgid "Real Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:35
-msgid "Time Zone"
-msgstr ""
-
-#: pkg/systemd/index.html.h:36
-msgid ""
-"\n"
-"                                    Invalid time zone\n"
-"                                "
-msgstr ""
-
-#: pkg/systemd/index.html.h:39
-msgid "Set Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:40
-msgid "Manually"
-msgstr ""
-
-#: pkg/systemd/index.html.h:41
-msgid "Automatically using NTP"
-msgstr ""
-
-#: pkg/systemd/index.html.h:42
-msgid "Automatically using specific NTP servers"
-msgstr ""
-
-#: pkg/systemd/index.html.h:43
-msgid "Delay"
-msgstr ""
-
-#: pkg/systemd/index.html.h:44
-msgid "1 Minute"
-msgstr ""
-
-#: pkg/systemd/index.html.h:45
-msgid "5 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:46
-msgid "20 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:47
-msgid "40 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:48
-msgid "60 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:49
-msgid "No Delay"
-msgstr ""
-
-#: pkg/systemd/index.html.h:50
-msgid "Specific Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:51
-msgid ""
-"\n"
-"                        Cancel\n"
-"                    "
-msgstr ""
-
-#: pkg/systemd/logs.html.h:1
-msgid "Journal"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:2
-msgid "Recent"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:3
-msgid "Current boot"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:4
-msgid "Last 24 hours"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:5
-msgid "Last 7 days"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:6
-msgid "Errors"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:7
-msgid "Warnings"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:8
-msgid "Notices"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:9
-msgid "All"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:10 pkg/kubernetes/views/container-panel.html.h:2
-#: pkg/kubernetes/views/container-page-inline.html.h:2
-msgid "Logs"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:11
-msgid "Entry"
-msgstr ""
-
-#: pkg/systemd/services.html.h:1 pkg/kubernetes/views/dashboard-page.html.h:12
-#: pkg/kubernetes/views/details-page.html.h:3
-msgid "Services"
-msgstr ""
-
-#: pkg/systemd/services.html.h:3
-msgid "System Services"
-msgstr ""
-
-#: pkg/systemd/services.html.h:4
-msgid "Sockets"
-msgstr ""
-
-#: pkg/systemd/services.html.h:5
-msgid "Timers"
-msgstr ""
-
-#: pkg/systemd/services.html.h:6
-msgid "Paths"
-msgstr ""
-
-#: pkg/systemd/services.html.h:7
-msgid "Instantiate"
-msgstr ""
-
-#: pkg/systemd/services.html.h:8
-msgid "{{days_text}}"
-msgstr ""
-
-#: pkg/systemd/services.html.h:9
-msgid "Service Logs"
-msgstr ""
-
-#: pkg/systemd/services.html.h:10
-msgid "Note"
-msgstr ""
-
-#: pkg/systemd/services.html.h:11
-msgid ""
-"This unit is not designed to be enabled explicitly.\n"
-"          "
-msgstr ""
-
-#: pkg/systemd/services.html.h:15
-msgid "Create Timers"
-msgstr ""
-
-#: pkg/systemd/services.html.h:16
-#, fuzzy
-msgid "Service name"
-msgstr "Værtsnavn"
-
-#: pkg/systemd/services.html.h:18 pkg/docker/index.html.h:32
-msgid "Command"
-msgstr ""
-
-#: pkg/systemd/services.html.h:19
-msgid "Run"
-msgstr ""
-
-#: pkg/systemd/services.html.h:20
-msgid "After system boot"
-msgstr ""
-
-#: pkg/systemd/services.html.h:21
-msgid "At specific time"
-msgstr ""
-
-#: pkg/systemd/services.html.h:22
-msgid "Seconds"
-msgstr ""
-
-#: pkg/systemd/services.html.h:23
-msgid "Minutes"
-msgstr ""
-
-#: pkg/systemd/services.html.h:24
-msgid "Hours"
-msgstr ""
-
-#: pkg/systemd/services.html.h:25
-msgid "Weeks"
-msgstr ""
-
-#: pkg/systemd/services.html.h:26
-msgid "Don't Repeat"
-msgstr ""
-
-#: pkg/systemd/services.html.h:27
-msgid "Repeat Hourly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:28
-msgid "Repeat Daily"
-msgstr ""
-
-#: pkg/systemd/services.html.h:29
-msgid "Repeat Weekly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:30
-msgid "Repeat Monthly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:31
-msgid "Repeat Yearly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:32
-msgid "Hour : Minute"
-msgstr ""
-
-#: pkg/systemd/services.html.h:33
-msgid ":"
-msgstr ""
-
-#: pkg/systemd/services.html.h:35
-msgid "Save"
-msgstr ""
-
-#: pkg/systemd/terminal.html.h:1
-msgid "Terminal"
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:1
-msgid "Incorrect Host Key"
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:2
-msgid ""
-"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
-"in use. Unless this machine was recently replaced, it is likely that someone "
-"is trying to attack your connection to this machine."
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:3
-msgid ""
-"You can remove the previously stored key by running the following command"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:1
-msgid "Authentication Failed"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:2
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
-"machine with cockpit you will need to enable one of the following "
-"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:4 pkg/shell/index.html.h:30
-msgid "Public Key"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:5
-msgid "Kerberos Based SSO"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:6
-msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:1 pkg/dashboard/index.html.h:11
-msgid "Synchronize users"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:2
-msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:3
-msgid "Error loading users: {{perm_failed}}"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:4
-msgid ""
-"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
-"synchronize users, a user with superuser privileges is required."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:5 pkg/lib/machine-change-auth.html.h:4
-msgid "User name"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:8
-msgid "Synchronize"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:1
-msgid "Unknown Host Key"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:2
-msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:3 pkg/shell/index.html.h:4
-msgid "Fingerprint"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:5
-#: pkg/kubernetes/views/auth-form.html.h:14
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:6
-msgid "Connect"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:1
-msgid "Add Machine to Dashboard"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:3 pkg/dashboard/index.html.h:9
-msgid "Color"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:4
-msgid ""
-"Connecting simultaneously to more than {{ limit }} machines is unsupported."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:1
-msgid "Could not contact {{host}}"
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:2
-msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:3
-msgid ""
-"To try a different port you will need to upgrade cockpit-ws to a newer "
-"version."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:4
-msgid "Is sshd running on a different port?"
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:7
-msgid "Update"
-msgstr ""
-
-#: pkg/lib/machine-not-supported.html.h:1
-msgid "Cockpit is not installed"
-msgstr ""
-
-#: pkg/lib/machine-not-supported.html.h:2
-msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:1
-msgid "Log in to {{host}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:2
-msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:3
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:5 pkg/shell/index.html.h:9
-#: pkg/realmd/operation.html.h:3 pkg/kubernetes/views/auth-form.html.h:8
-msgid "Authentication"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:7
-msgid "Available"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:8
-msgid "Login Password"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:9
-msgid "Kerberos Ticket"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:10
-msgid "Checking for public keys"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:12
-msgid "Log In"
-msgstr ""
-
-#: pkg/shell/shell.html.h:1
-msgid "Things have moved"
-msgstr ""
-
-#: pkg/shell/index.html.h:2
-msgid "Comment"
-msgstr ""
-
-#: pkg/shell/index.html.h:5 pkg/shell/stub.html.h:2 pkg/shell/simple.html.h:2
-msgid "Ooops!"
-msgstr ""
-
-#: pkg/shell/index.html.h:6 pkg/shell/stub.html.h:3 pkg/shell/simple.html.h:3
-msgid "Display Language"
-msgstr ""
-
-#: pkg/shell/index.html.h:7 pkg/shell/stub.html.h:4 pkg/shell/simple.html.h:4
-msgid "About Cockpit"
-msgstr ""
-
-#: pkg/shell/index.html.h:8
-msgid "Account Settings"
-msgstr ""
-
-#: pkg/shell/index.html.h:10 pkg/shell/stub.html.h:5 pkg/shell/simple.html.h:5
-msgid "Log out"
-msgstr ""
-
-#: pkg/shell/index.html.h:11 pkg/shell/stub.html.h:6 pkg/shell/simple.html.h:6
-msgid ""
-"\n"
-"              Cockpit is an interactive Linux server admin interface.\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:15 pkg/shell/stub.html.h:10
-#: pkg/shell/simple.html.h:10
-msgid "Choose the language to be used in the application"
-msgstr ""
-
-#: pkg/shell/index.html.h:16 pkg/shell/stub.html.h:11
-#: pkg/shell/simple.html.h:11 pkg/storaged/index.html.h:59
-msgid ""
-"\n"
-"              Cancel\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:19 pkg/shell/stub.html.h:14
-#: pkg/shell/simple.html.h:14
-msgid ""
-"\n"
-"              Select\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:22 pkg/shell/stub.html.h:17
-msgid ""
-"\n"
-"              Close\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:25
-msgid "Use my password for privileged tasks and to connect to other machines"
-msgstr ""
-
-#: pkg/shell/index.html.h:26
-msgid "Use the following keys to authenticate against other systems"
-msgstr ""
-
-#: pkg/shell/index.html.h:29 pkg/kubernetes/index.html.h:6
-msgid "Details"
-msgstr ""
-
-#: pkg/shell/index.html.h:32
-msgid "Unlock Key"
-msgstr ""
-
-#: pkg/shell/index.html.h:33 pkg/users/index.html.h:23
-#, fuzzy
-msgid "Old Password"
-msgstr "Indtast adgangskode"
-
-#: pkg/shell/index.html.h:34 pkg/users/index.html.h:24
-#, fuzzy
-msgid "New Password"
-msgstr "Indtast adgangskode"
-
-#: pkg/shell/index.html.h:35 pkg/users/index.html.h:19
-msgid "Confirm"
-msgstr ""
-
-#: pkg/shell/index.html.h:36
-msgid "Change Password"
-msgstr ""
-
-#: pkg/shell/index.html.h:38 pkg/shell/stub.html.h:20
-msgid ""
-"\n"
-"                Tools\n"
-"              "
-msgstr ""
-
-#: pkg/shell/index.html.h:41 pkg/shell/stub.html.h:23
-#: pkg/shell/simple.html.h:24
-msgid "Reconnect"
-msgstr ""
-
-#: pkg/shell/index.html.h:42 pkg/shell/stub.html.h:24
-msgid "Troubleshoot"
-msgstr ""
-
-#: pkg/shell/simple.html.h:18
-msgid ""
-"\n"
-"              Try to reconnect\n"
-"            "
-msgstr ""
-
-#: pkg/shell/simple.html.h:21
-msgid ""
-"\n"
-"              Log in again\n"
-"            "
-msgstr ""
-
-#: pkg/ostree/index.html.h:1
-msgid "Software Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:2
-msgid "Check for updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:3
-msgid ""
-"\n"
-"                    Update and reboot\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:6
-msgid "Roll back and reboot"
-msgstr ""
-
-#: pkg/ostree/index.html.h:8
-msgid ""
-"\n"
-"                    Default\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:11
-msgid ""
-"\n"
-"                    Available\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:16
-msgid "Tree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:17
-msgid "Packages"
-msgstr ""
-
-#: pkg/ostree/index.html.h:20
-msgid "Released"
-msgstr ""
-
-#: pkg/ostree/index.html.h:21
-msgid "Additions"
-msgstr ""
-
-#: pkg/ostree/index.html.h:22
-msgid "Removals"
-msgstr ""
-
-#: pkg/ostree/index.html.h:23
-msgid "Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:24
-msgid "Downgrades"
-msgstr ""
-
-#: pkg/ostree/index.html.h:25
-msgid ""
-"\n"
-"                    This deployment contains the same packages as your "
-"currently booted system\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:28
-msgid "Operating System Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:29
-msgid "Connecting"
-msgstr ""
-
-#: pkg/ostree/index.html.h:30
-msgid "Unable to communicate with OSTree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:31
-msgid "No Deployments"
-msgstr ""
-
-#: pkg/ostree/index.html.h:32
-msgid ""
-"\n"
-"                    Reconnect\n"
-"                "
-msgstr ""
-
-#: pkg/selinux/setroubleshoot.html.h:1
-msgid "SELinux Troubleshoot"
-msgstr ""
-
-#: pkg/machines/index.html.h:1
-msgid "Virtual Machines Management"
-msgstr ""
-
-#: pkg/storaged/index.html.h:1
-msgid "Storage"
-msgstr ""
-
-#: pkg/storaged/index.html.h:2
-msgid "The \"storaged\" API is not available on this system."
-msgstr ""
-
-#: pkg/storaged/index.html.h:3
-msgid "Start Multipath"
-msgstr ""
-
-#: pkg/storaged/index.html.h:4
-msgid ""
-"\n"
-"        There are devices with multiple paths on the system, but the "
-"multipath service is not running.\n"
-"      "
-msgstr ""
-
-#: pkg/storaged/index.html.h:7
-msgid "RAID Devices"
-msgstr ""
-
-#: pkg/storaged/index.html.h:8
-msgid "No storage set up as RAID"
-msgstr ""
-
-#: pkg/storaged/index.html.h:9
-msgid "Volume Groups"
-msgstr ""
-
-#: pkg/storaged/index.html.h:10
-msgid "No volume groups created"
-msgstr ""
-
-#: pkg/storaged/index.html.h:11
-msgid "iSCSI Targets"
-msgstr ""
-
-#: pkg/storaged/index.html.h:12
-msgid "{{Address}}:{{Port}}"
-msgstr ""
-
-#: pkg/storaged/index.html.h:13
-msgid "No iSCSI targets set up"
-msgstr ""
-
-#: pkg/storaged/index.html.h:14
-msgid "Drives"
-msgstr ""
-
-#: pkg/storaged/index.html.h:15
-msgid "No drives attached"
-msgstr ""
-
-#: pkg/storaged/index.html.h:16
-msgid "Other Devices"
-msgstr ""
-
-#: pkg/storaged/index.html.h:17
-msgid "Filesystems"
-msgstr ""
-
-#: pkg/storaged/index.html.h:21
-msgid "Jobs"
-msgstr ""
-
-#: pkg/storaged/index.html.h:23 pkg/networkmanager/index.html.h:3
-msgid "Go to now"
-msgstr ""
-
-#: pkg/storaged/index.html.h:24 pkg/networkmanager/index.html.h:4
-msgid "5 minutes"
-msgstr ""
-
-#: pkg/storaged/index.html.h:25 pkg/networkmanager/index.html.h:5
-msgid "1 hour"
-msgstr ""
-
-#: pkg/storaged/index.html.h:26 pkg/networkmanager/index.html.h:6
-msgid "6 hours"
-msgstr ""
-
-#: pkg/storaged/index.html.h:27 pkg/networkmanager/index.html.h:7
-msgid "1 day"
-msgstr ""
-
-#: pkg/storaged/index.html.h:28 pkg/networkmanager/index.html.h:8
-msgid "1 week"
-msgstr ""
-
-#: pkg/storaged/index.html.h:29
-msgid "Reading"
-msgstr ""
-
-#: pkg/storaged/index.html.h:30
-msgid "Writing"
-msgstr ""
-
-#: pkg/storaged/index.html.h:31
-msgid "Storage Logs"
-msgstr ""
-
-#: pkg/storaged/index.html.h:32
-msgid "Create partition table"
-msgstr ""
-
-#: pkg/storaged/index.html.h:34
-msgid "Block Device"
-msgstr ""
-
-#: pkg/storaged/index.html.h:40
-msgid "No media inserted"
-msgstr ""
-
-#: pkg/storaged/index.html.h:42
-msgid "DISK IS FAILING"
-msgstr ""
-
-#: pkg/storaged/index.html.h:43
-msgid "Disk is OK"
-msgstr ""
-
-#: pkg/storaged/index.html.h:46
-msgid "The RAID Array is in a degraded state"
-msgstr ""
-
-#: pkg/storaged/index.html.h:47
-msgid "RAID Device"
-msgstr ""
-
-#: pkg/storaged/index.html.h:56
-msgid "Volume Group"
-msgstr ""
-
-#: pkg/storaged/index.html.h:57
-msgid "Physical Volumes"
-msgstr ""
-
-#: pkg/storaged/index.html.h:58
-msgid "Storage Log"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:1
-msgid "Domain Address"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:2
-msgid "Computer OU"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:4 pkg/users/index.html.h:11
-#, fuzzy
-msgid "User Name"
-msgstr "Værtsnavn"
-
-#: pkg/realmd/operation.html.h:5
-msgid "User Password"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:6
-msgid "Domain Administrator Name"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:7
-msgid "Domain Administrator Password"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:8
-msgid "One Time Password"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:9
-msgid "This may take a while"
-msgstr ""
-
-#: pkg/docker/index.html.h:1 pkg/kubernetes/index.html.h:4
-#: pkg/kubernetes/views/containers-listing.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:6
-#: pkg/kubernetes/views/dashboard-page.html.h:17
-msgid "Containers"
-msgstr ""
-
-#: pkg/docker/index.html.h:2
-msgid "Connecting to Docker"
-msgstr ""
-
-#: pkg/docker/index.html.h:3
-msgid "Not authorized to access Docker on this system"
-msgstr ""
-
-#: pkg/docker/index.html.h:4
-msgid "Docker is not installed or activated on the system"
-msgstr ""
-
-#: pkg/docker/index.html.h:5
-msgid "Can&rsquo;t connect to Docker"
-msgstr ""
-
-#: pkg/docker/index.html.h:6
-msgid "Start Docker"
-msgstr ""
-
-#: pkg/docker/index.html.h:7
-msgid "Try again"
-msgstr ""
-
-#: pkg/docker/index.html.h:8
-msgid "Combined CPU usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:9
-msgid "Combined memory usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:10
-msgid "Show all containers"
-msgstr ""
-
-#: pkg/docker/index.html.h:11
-msgid "IP Address:"
-msgstr ""
-
-#: pkg/docker/index.html.h:12
-msgid "IP Prefix Length:"
-msgstr ""
-
-#: pkg/docker/index.html.h:13
-msgid "Gateway:"
-msgstr ""
-
-#: pkg/docker/index.html.h:14
-msgid "MAC Address:"
-msgstr ""
-
-#: pkg/docker/index.html.h:15 pkg/kubernetes/views/image-page.html.h:1
-msgid "Show all images"
-msgstr ""
-
-#: pkg/docker/index.html.h:16 pkg/kubernetes/index.html.h:2
-#: pkg/kubernetes/registry.html.h:2
-msgid "Overview"
-msgstr ""
-
-#: pkg/docker/index.html.h:17
-msgid "Reset"
-msgstr ""
-
-#: pkg/docker/index.html.h:18
-msgid "Storage pool"
-msgstr ""
-
-#: pkg/docker/index.html.h:19
-msgid "Additional Storage"
-msgstr ""
-
-#: pkg/docker/index.html.h:20
-msgid "TCP"
-msgstr ""
-
-#: pkg/docker/index.html.h:21
-msgid "{{host_port_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:22
-msgid "{{host_volume_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:24
-msgid "ReadWrite"
-msgstr ""
-
-#: pkg/docker/index.html.h:25
-msgid "ReadOnly"
-msgstr ""
-
-#: pkg/docker/index.html.h:26
-msgid "{{envvar_key_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:27
-msgid "{{envvar_value_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:28
-msgid "select container"
-msgstr ""
-
-#: pkg/docker/index.html.h:29
-msgid "{{alias_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:30 pkg/kubernetes/views/image-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:2
-#: pkg/kubernetes/views/image-page.html.h:2
-msgid "Image"
-msgstr ""
-
-#: pkg/docker/index.html.h:31
-msgid "Container Name"
-msgstr ""
-
-#: pkg/docker/index.html.h:33
-msgid "Memory limit"
-msgstr ""
-
-#: pkg/docker/index.html.h:34
-msgid "MiB"
-msgstr ""
-
-#: pkg/docker/index.html.h:35
-msgid "CPU priority"
-msgstr ""
-
-#: pkg/docker/index.html.h:36
-msgid "shares"
-msgstr ""
-
-#: pkg/docker/index.html.h:37
-msgid "With terminal"
-msgstr ""
-
-#: pkg/docker/index.html.h:38
-msgid "Links"
-msgstr ""
-
-#: pkg/docker/index.html.h:40
-msgid "Expose container ports"
-msgstr ""
-
-#: pkg/docker/index.html.h:41 pkg/kubernetes/index.html.h:7
-#: pkg/kubernetes/views/image-config.html.h:9
-#: pkg/kubernetes/views/pod-page.html.h:3
-#: pkg/kubernetes/views/dashboard-page.html.h:4
-msgid "Volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:42
-msgid "Mount container volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:43 pkg/kubernetes/views/image-config.html.h:6
-#: pkg/kubernetes/views/container-body.html.h:9
-msgid "Environment"
-msgstr ""
-
-#: pkg/docker/index.html.h:44
-msgid "Set container environment variables"
-msgstr ""
-
-#: pkg/docker/index.html.h:45 pkg/kubernetes/views/pod-body.html.h:4
-msgid "Restart Policy"
-msgstr ""
-
-#: pkg/docker/index.html.h:47
-msgid "On Failure"
-msgstr ""
-
-#: pkg/docker/index.html.h:50
-msgid "Retries:"
-msgstr ""
-
-#: pkg/docker/index.html.h:51 pkg/users/index.html.h:26
-#: pkg/networkmanager/index.html.h:52
-msgid ""
-"\n"
-"            Cancel\n"
-"          "
-msgstr ""
-
-#: pkg/docker/index.html.h:54
-msgid ""
-"\n"
-"            Run\n"
-"          "
-msgstr ""
-
-#: pkg/docker/index.html.h:57
-msgid ""
-"\n"
-"            Download\n"
-"          "
-msgstr ""
-
-#: pkg/docker/index.html.h:60
-msgid ""
-"\n"
-"            Change\n"
-"          "
-msgstr ""
-
-#: pkg/docker/index.html.h:63
-msgid "Repository"
-msgstr ""
-
-#: pkg/docker/index.html.h:64
-msgid "Tag"
-msgstr ""
-
-#: pkg/docker/index.html.h:65 pkg/kubernetes/views/image-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:5
-msgid "Author"
-msgstr ""
-
-#: pkg/docker/index.html.h:66
-msgid ""
-"\n"
-"            Commit\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:1
-msgid "Local Accounts"
-msgstr ""
-
-#: pkg/users/index.html.h:2
-msgid ""
-"\n"
-"            Close\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:5
-msgid "Create New Account"
-msgstr ""
-
-#: pkg/users/index.html.h:6
-msgid "Account not available or cannot be edited."
-msgstr ""
-
-#: pkg/users/index.html.h:7
-msgid "Accounts"
-msgstr ""
-
-#: pkg/users/index.html.h:8
-msgid "Terminate Session"
-msgstr ""
-
-#: pkg/users/index.html.h:10
-msgid "Full Name"
-msgstr ""
-
-#: pkg/users/index.html.h:12
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:3
-#: pkg/kubernetes/views/project-body.html.h:2
-msgid "Roles"
-msgstr ""
-
-#: pkg/users/index.html.h:13
-msgid "Last Login"
-msgstr ""
-
-#: pkg/users/index.html.h:14
-msgid "Access"
-msgstr ""
-
-#: pkg/users/index.html.h:15
-msgid "Lock Account"
-msgstr ""
-
-#: pkg/users/index.html.h:17
-msgid "Set Password"
-msgstr ""
-
-#: pkg/users/index.html.h:18
-msgid "Authorized Public SSH Keys"
-msgstr ""
-
-#: pkg/users/index.html.h:20
-msgid ""
-"\n"
-"            Create\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:25
-msgid "Confirm New Password"
-msgstr ""
-
-#: pkg/users/index.html.h:29
-msgid ""
-"\n"
-"            Set\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:32
-msgid "Delete Files"
-msgstr ""
-
-#: pkg/users/index.html.h:33 pkg/networkmanager/index.html.h:48
-msgid ""
-"\n"
-"            Delete\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:36
-msgid "Unnamed"
-msgstr ""
-
-#: pkg/users/index.html.h:37
-msgid "Invalid key"
-msgstr ""
-
-#: pkg/users/index.html.h:38
-msgid "There are no authorized public keys for this account."
-msgstr ""
-
-#: pkg/users/index.html.h:39
-msgid ""
-"You do not have permission to view the authorized public keys for this "
-"account."
-msgstr ""
-
-#: pkg/users/index.html.h:40
-msgid "Failed to load authorized keys."
-msgstr ""
-
-#: pkg/users/index.html.h:41
-msgid "Add public key"
-msgstr ""
-
-#: pkg/users/index.html.h:42
-msgid ""
-"\n"
-"            Add key\n"
-"          "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:1
-msgid "Diagnostic reports"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:2
-msgid ""
-"\n"
-"        This tool will collect system configuration and diagnostic\n"
-"        information from this system for use with diagnosing problems\n"
-"        with the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:7
-msgid ""
-"\n"
-"        The collected information will be stored locally on the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:10
-msgid "Create report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:11
-msgid "Create diagnostic report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:12
-msgid ""
-"\n"
-"                The generated archive contains data considered\n"
-"                sensitive and its content should be reviewed by the\n"
-"                originating organization before being passed to any\n"
-"                third party.\n"
-"              "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:18
-msgid "Generating report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:19
-msgid "Done!"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:1
-msgid "Networking"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:2
-msgid "Testing connection"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:9
-msgid "Sending"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:10
-msgid "Receiving"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:11
-msgid "Interfaces"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:12
-msgid "Add Bond"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:13
-msgid "Add Team"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:14
-msgid "Add Bridge"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:15
-msgid "Add VLAN"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:17
-msgid "IP Address"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:18
-msgid "Unmanaged Interfaces"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:19
-msgid "Networking Logs"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:20
-msgid "Parent"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:21
-msgid "VLAN Id"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:23
-msgid "Set to"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:25
-msgid "Spanning Tree Protocol (STP)"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:26
-msgid "STP Priority"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:27
-msgid "STP Forward delay"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:28
-msgid "STP Hello time"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:29
-msgid "STP Maximum message age"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:30
-msgid "Priority"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:31
-msgid "Path cost"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:32
-msgid "Hair Pin mode"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:34
-msgid "Mode"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:35
-msgid "Primary"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:36
-msgid "Link Monitoring"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:37
-msgid "Monitoring Interval"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:38
-msgid "Monitoring Targets"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:39
-msgid "Link up delay"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:40
-msgid "Link down delay"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:41
-msgid "Runner"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:42
-msgid "Balancer"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:43
-msgid "Link Watch"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:44
-msgid "Ping Interval"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:45
-msgid "Ping Target"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:46
-msgid "Sticky"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:47
-msgid "LACP Key"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:51
-msgid "IP Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:55
-msgid ""
-"\n"
-"            Apply\n"
-"          "
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:58
-msgid "Bond Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:59
-msgid "Team Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:60
-msgid "Team Port Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:61
-msgid "Bridge Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:62
-msgid "Bridge Port Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:63
-msgid "VLAN Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:64
-msgid "Ethernet MTU"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:66
-msgid "Connection will be lost"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:1
-msgid "Kubernetes Cluster"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:3 pkg/kubernetes/views/dashboard-page.html.h:8
-#: pkg/kubernetes/views/nodes-page.html.h:4
-msgid "Nodes"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:5
-msgid "Topology"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:8 pkg/kubernetes/registry.html.h:3
-#: pkg/kubernetes/views/image-listing.html.h:2
-#: pkg/kubernetes/views/imagestream-page.html.h:3
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:5
-msgid "Images"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:9 pkg/kubernetes/registry.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:2
-#: pkg/kubernetes/views/project-listing.html.h:2
-#: pkg/kubernetes/views/user-delete.html.h:2
-msgid "Projects"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:11 pkg/kubernetes/registry.html.h:6
-msgid "Couldn't connect to server"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:12 pkg/kubernetes/registry.html.h:7
-msgid ""
-"\n"
-"                Reconnect\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:15
-msgid ""
-"\n"
-"                Troubleshoot\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/registry.html.h:1
-msgid "Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:1
-#: pkg/kubernetes/views/service-body.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:1
-#: pkg/kubernetes/views/containers-listing.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:9
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:18
-#: pkg/kubernetes/views/route-body.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:5
-#: pkg/kubernetes/views/imagestream-modify.html.h:4
-msgid "Project"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:2
-#: pkg/kubernetes/views/service-body.html.h:2
-#: pkg/kubernetes/views/pod-body.html.h:2
-#: pkg/kubernetes/views/containers-listing.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:10
-#: pkg/kubernetes/views/pv-claim.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:19
-#: pkg/kubernetes/views/route-body.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:6
-msgid "Namespace"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:3
-#: pkg/kubernetes/views/pod-body.html.h:3
-#: pkg/kubernetes/views/node-body.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:3
-#: pkg/kubernetes/views/route-body.html.h:3
-msgid "Created"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:4
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:17
-msgid "Replicas"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:5
-#: pkg/kubernetes/views/service-body.html.h:9
-#: pkg/kubernetes/views/pod-body.html.h:10
-#: pkg/kubernetes/views/node-body.html.h:12
-#: pkg/kubernetes/views/image-meta.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:8
-#: pkg/kubernetes/views/route-body.html.h:8
-msgid "Labels"
-msgstr ""
-
-#: pkg/kubernetes/views/service-body.html.h:4
-#: pkg/kubernetes/views/node-body.html.h:3
-msgid "IP"
-msgstr ""
-
-#: pkg/kubernetes/views/service-body.html.h:8
-msgid "Session Affinity"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:1
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:10
-msgid "New image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:3
-#: pkg/kubernetes/views/image-body.html.h:10
-#: pkg/kubernetes/views/imagestream-modify.html.h:7
-msgid "Tags"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:5
-msgid "Last Updated"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:6
-msgid "No image streams are present."
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:1
-msgid "Delete Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:2
-msgid "Do you want to delete this Node?"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:3
-msgid " 1\">Do you want to delete the following Nodes?"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-container.html.h:1
-msgid "Show all Pod Containers"
-msgstr ""
-
-#: pkg/kubernetes/views/image-panel.html.h:3
-#: pkg/kubernetes/views/imagestream-page.html.h:4
-#: pkg/kubernetes/views/image-page.html.h:4
-msgid "Metadata"
-msgstr ""
-
-#: pkg/kubernetes/views/node-panel.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:8
-#: pkg/kubernetes/views/containers-listing.html.h:6
-#: pkg/kubernetes/views/node-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:11
-msgid "Node"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:1
-msgid "Show all Replication Controllers"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:2
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:5
-msgid "Replication Controller"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:2
-#: pkg/kubernetes/views/pv-claim.html.h:9
-#: pkg/kubernetes/views/dashboard-page.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:18
-msgid "Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:2
-msgid "Template"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:5
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/group-delete.html.h:1
-msgid "Remove Group"
-msgstr ""
-
-#: pkg/kubernetes/views/group-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:5
-#: pkg/kubernetes/views/user-group-remove.html.h:3
-msgid "Remove"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:1
-msgid "Delete Persistent Volume Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:2
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:3
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:5
-msgid "Service Account"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:6
-msgid "DNS Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:7
-msgid "Phase"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:9
-msgid "Pod Address"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:5
-msgid "OS"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:7
-msgid "Boot ID"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:8
-#, fuzzy
-msgid "Kernel Version"
-msgstr "Version"
-
-#: pkg/kubernetes/views/node-body.html.h:9
-msgid "Container Runtime Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:10
-msgid "Kubelet Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:11
-msgid "Proxy Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:13
-#: pkg/kubernetes/views/route-body.html.h:9
-msgid "none"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:17
-msgid "Reason"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:18
-#: pkg/kubernetes/views/pv-claim.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:6 pkg/kubernetes/views/pv-body.html.h:6
-msgid "Message"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:19
-msgid "Last Heartbeat"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:20
-msgid "Last Status Change"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:21
-#: pkg/kubernetes/views/image-meta.html.h:3
-#: pkg/kubernetes/views/imagestream-meta.html.h:1
-#: pkg/kubernetes/views/route-body.html.h:10
-msgid "Annotations"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:1
-msgid "Remove Role"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:2
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member "
-"{{ fields.member.metadata.name }}?"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:1
-msgid "New Project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:6
-msgid "No projects are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:7
-msgid "New Group"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:8
-#: pkg/kubernetes/views/user-delete.html.h:3
-msgid "Groups"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:9
-msgid "No groups are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:10
-#: pkg/kubernetes/views/add-user-dialog.html.h:1
-msgid "Add User"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:11
-msgid "Users"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:12
-msgid "Identity"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:13
-msgid "Member of"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:14
-msgid "No users are present."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:1
-msgid "Cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:2
-msgid "Add New Cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:4
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:3
-msgid "Skip Certificate Verification"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:5
-msgid "Requires Authentication"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:7
-msgid "Add New User"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:9
-msgid "Client Certificate"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:10
-#, fuzzy
-msgid "Username"
-msgstr "Værtsnavn"
-
-#: pkg/kubernetes/views/auth-form.html.h:12
-msgid "Token"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:1
-msgid "Add Cluster Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:4
-msgid "Configuration"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:5
-msgid "Configure Kubelet and Proxy"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:6
-msgid "Configure Flannel networking"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:1
-#: pkg/kubernetes/views/pvc-body.html.h:1
-msgid "Volume Type"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:2
-msgid "{{ volume | formatVolumeType }}"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:3
-#, fuzzy
-msgid "PD Name"
-msgstr "Værtsnavn"
-
-#: pkg/kubernetes/views/volume-body.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:19
-msgid "Filesystem Type"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:6
-#: pkg/kubernetes/views/pv-modify.html.h:20
-msgid "Read Only"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:7
-msgid "Volume ID"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:8
-msgid "Repository URL"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:9
-msgid "Revision"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:10
-#: pkg/kubernetes/views/image-config.html.h:3
-msgid "Directory"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:12
-msgid "Medium"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:13
-#: pkg/kubernetes/views/pv-modify.html.h:14
-msgid "Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:14
-msgid "Endpoint Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:15
-#: pkg/kubernetes/views/pv-modify.html.h:13
-#, fuzzy
-msgid "Volume Name"
-msgstr "Værtsnavn"
-
-#: pkg/kubernetes/views/volume-body.html.h:17
-msgid "Monitors"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:18
-#, fuzzy
-msgid "Image Name"
-msgstr "Værtsnavn"
-
-#: pkg/kubernetes/views/volume-body.html.h:19
-#, fuzzy
-msgid "Pool Name"
-msgstr "Værtsnavn"
-
-#: pkg/kubernetes/views/volume-body.html.h:21
-msgid "Key Ring Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:22
-msgid "Secret Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:23
-msgid "Target Portal"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:24
-#: pkg/kubernetes/views/pv-modify.html.h:16
-msgid "Qualified Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:25
-#: pkg/kubernetes/views/pv-modify.html.h:17
-msgid "Logical Unit Number"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:26
-#: pkg/kubernetes/views/pv-modify.html.h:18
-msgid "Interface"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:27
-msgid "Ceph Monitors"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:28
-msgid "Secret File"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:29
-msgid "Target World Wide Names"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:30
-msgid "Flocker Dataset Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:31
-msgid "Driver"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:33
-#, fuzzy
-msgid "Share Name"
-msgstr "Værtsnavn"
-
-#: pkg/kubernetes/views/volume-body.html.h:34
-#, fuzzy
-msgid "Secret Name"
-msgstr "Værtsnavn"
-
-#: pkg/kubernetes/views/image-meta.html.h:2
-msgid "On Build"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:4
-msgid "Docker Version"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:5
-msgid "Image Layers"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:1
-#: pkg/kubernetes/views/user-page.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:1
-msgid "Show all Projects"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:2
-#: pkg/kubernetes/views/group-panel.html.h:1
-msgid "Group Members"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:3
-#: pkg/kubernetes/views/user-group-add.html.h:1
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:1
-#: pkg/kubernetes/views/group-panel.html.h:2
-#: pkg/kubernetes/views/project-body.html.h:10
-msgid "Add Member"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:4
-msgid "The group '{{ groupName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/containers-listing.html.h:3
-#: pkg/kubernetes/views/pod-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:2
-msgid "Pod"
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:2
-msgid "Membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:2
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:5
-#: pkg/kubernetes/views/user-panel.html.h:7
-msgid "Add Membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-group-add.html.h:2
-msgid ""
-"\n"
-"                        User\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:2
-msgid "User or Group"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-panel.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:4
-#, fuzzy
-msgid "Mount Location"
-msgstr "Indstillinger"
-
-#: pkg/kubernetes/views/route-modify.html.h:1
-msgid "Adjust Route"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:1
-msgid "Show all Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:2 pkg/kubernetes/views/pvc-body.html.h:3
-#: pkg/kubernetes/views/pv-panel.html.h:1
-msgid "Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:3 pkg/kubernetes/views/pv-panel.html.h:2
-msgid "Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:4
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:1
-msgid "Remove image tag"
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:2
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:1
-msgid "Run as"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:4
-msgid "Stop with"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:1
-msgid "Delete Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:2
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:3
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
-"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
-"may cause issues with any pods depending on it."
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:3
-msgid "Identities"
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:3
-msgid "The user '{{ userName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:1
-msgid "Show all Deployment Configs"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:1
-msgid "Deployment Config"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:4
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/route-panel.html.h:1
-#: pkg/kubernetes/views/route-page.html.h:2
-msgid "Route"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:1
-msgid "Register New Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:2
-msgid "Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:7
-msgid "No volumes are present."
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:8
-msgid "Pending Volume Claims"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:12
-msgid "When"
-msgstr ""
-
-#: pkg/kubernetes/views/user-delete.html.h:1
-msgid "Remove User"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:3
-#: pkg/kubernetes/views/pv-modify.html.h:10
-#: pkg/kubernetes/views/pvc-body.html.h:7 pkg/kubernetes/views/pv-body.html.h:2
-msgid "Access Modes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:4
-msgid "Requests"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:5
-msgid "This volume has not been claimed"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:10
-msgid "No Pods are using this claim"
-msgstr ""
-
-#: pkg/kubernetes/views/filter-project.html.h:1
-msgid "All Projects"
-msgstr ""
-
-#: pkg/kubernetes/views/filter-project.html.h:2
-msgid "Project:"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:5
-#: pkg/kubernetes/views/details-page.html.h:14
-msgid "Latest Version"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:6
-msgid "Deployment Causes"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:7
-msgid "Triggers"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:1
-msgid "Delete {{ item.kind }}"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:2
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:3
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:2
-#: pkg/kubernetes/views/user-modify.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:2
-msgid ""
-"\n"
-"                        Name\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:5
-#: pkg/kubernetes/views/user-modify.html.h:5
-msgid ""
-"\n"
-"                        Identity\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:1
-msgid "Project Members"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:3
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:6
-msgid "Admin"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:7
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/container-panel.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:3
-msgid "Shell"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:1
-msgid "Pod Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:2
-msgid "No pods selected"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:3
-msgid "Pod Selector"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:1
-msgid "Add membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:2
-msgid ""
-"\n"
-"                        Group or Project\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:5
-msgid ""
-"\n"
-"                        Role\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:1
-msgid "Deploy Application"
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:3
-msgid "{{ selected.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:5
-#: pkg/kubernetes/views/dashboard-page.html.h:11
-msgid "Deploy"
-msgstr ""
-
-#: pkg/kubernetes/views/user-modify.html.h:1
-msgid "Change User"
-msgstr ""
-
-#: pkg/kubernetes/views/user-modify.html.h:9
-msgid "Modify"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:1
-#: pkg/kubernetes/views/project-modify.html.h:6
-msgid "Access Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:2
-msgid ""
-"\n"
-"          Images may be pulled by anonymous users\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:5
-msgid ""
-"\n"
-"          Images may be pulled by any authenticated user or group\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:8
-msgid ""
-"\n"
-"          Images may only be pulled by specific users or groups\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:11
-msgid "Pull repository"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:13
-msgid "Image count"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:14
-msgid "{{stream.status.tags.length}}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:15
-msgid "To push to an image to this image stream:"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:1
-msgid "The node doesn't have enough disk space"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:2
-msgid "The node doesn't have enough free memory"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:1
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:2
-msgid "Register Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:4
-msgid "Warning:"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:5
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:7
-#: pkg/kubernetes/views/node-page.html.h:3
-#: pkg/kubernetes/views/pvc-body.html.h:10
-#: pkg/kubernetes/views/pv-body.html.h:3
-msgid "Capacity"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:8
-#: pkg/kubernetes/views/pv-body.html.h:1
-msgid "Reclaim Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:9
-msgid "{{ value }}"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:12
-msgid "Endpoint"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:15
-msgid "Target"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-dialog.html.h:1
-msgid "Connection Settings"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-dialog.html.h:2
-msgid "Connection Error"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:2
-msgid "Summary"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:4
-msgid "Source URL"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:7
-msgid "Built"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:8
-msgid "Digest"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:9
-msgid "Identifier"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:11
-msgid "To pull this image:"
-msgstr ""
-
-#: pkg/kubernetes/views/service-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:8
-#: pkg/kubernetes/views/service-page.html.h:2
-msgid "Service"
-msgstr ""
-
-#: pkg/kubernetes/views/service-panel.html.h:2
-#: pkg/kubernetes/views/service-page.html.h:3
-msgid "Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:1
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:2
+#: pkg/kubernetes/views/auth-rejected-cert.html:3
 msgid ""
 "You can bypass the certificate check, but any data you send to the server "
 "could be intercepted by others."
 msgstr ""
 
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:4
-msgid "Trust this certificate for this connection"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:1
-msgid "Show all Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:7
-msgid "The pod '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:1
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:1
-msgid "Delete image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:2
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:2
-msgid "All running"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:3
-msgid "No pods deployed"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:5
-msgid "All in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:6
-msgid "No volumes in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:7
-msgid "pending volume claims"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:9
-msgid "All healthy"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:10
-msgid "No nodes in cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:13
-msgid "Could not list services"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:14
+#: pkg/kubernetes/views/dashboard-page.html:150
 msgid "You can deploy an application to your cluster."
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-page.html.h:1
-msgid "Show all image streams"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-page.html.h:2
-msgid "Image Stream"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:3
-msgid "Image ID"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:4
-msgid "Container ID"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:7
-msgid "Since"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:8
-msgid "Restart Count"
-msgstr ""
-
-#: pkg/kubernetes/views/user-remove-membership.html.h:1
-msgid "Remove membership"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:1
-msgid "Delete Selected"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:2
-msgid "OS Versions"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:3
-msgid "Add Kubernetes Node"
-msgstr ""
-
-#: pkg/kubernetes/views/project-page.html.h:3
-msgid "The project '{{ projName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/user-panel.html.h:4
+#: pkg/lib/machine-invalid-hostkey.html:11
 msgid ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
+"You can remove the previously stored key by running the following command"
 msgstr ""
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:1
-msgid "Pod Replicated"
+#: pkg/shell/base_index.js:672
+msgid "You can try restarting Cockpit by pressing refresh in your browser. "
 msgstr ""
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:2
-msgid "No pods replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/container-page.html.h:1
-msgid "Show all Containers"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:1
-msgid "Welcome to the Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:2
+#: pkg/users/index.html:335
 msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
+"You do not have permission to view the authorized public keys for this "
+"account."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:1
-msgid "New project"
+#: pkg/docker/storage.jsx:482
+msgid "You don't have permission to manage the Docker storage pool."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:4
-msgid "Images by project"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:6
-msgid "Images pushed recently"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:7
-msgid "All images"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:8
-msgid "No images pushed"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:9
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:11
-msgid "Login commands"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:12
-msgid "Log into the registry:"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:13
+#: pkg/kubernetes/views/registry-dashboard-page.html:112
 msgid ""
 "Your login credentials do not give you access to use the docker registry "
 "from the command line."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:14
-msgid "Log into OpenShift command line tools:"
+#: src/base1/cockpit.js:3687
+msgid "Your session has been terminated."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:15
-msgid "Image commands"
+#: src/base1/cockpit.js:3689
+msgid "Your session has expired. Please log in again."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:16
-msgid "Push an image:"
+#: pkg/lib/journal.js:213
+msgid "[$0 bytes of binary data]"
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:17
-msgid "Pull an image:"
+#: pkg/lib/journal.js:215
+msgid "[binary data]"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html.h:1
-msgid "Show all Nodes"
+#: pkg/lib/journal.js:209
+msgid "[no data]"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html.h:4
-msgid "The node '{{ target }}' does not exist."
+#: pkg/storaged/details.js:1692
+msgid "active, but unsupported"
 msgstr ""
 
-#: pkg/kubernetes/views/route-page.html.h:1
-msgid "Show all Routes"
+#: pkg/storaged/utils.js:88
+msgctxt "format-bytes"
+msgid "bytes"
 msgstr ""
 
-#: pkg/kubernetes/views/route-page.html.h:3
-msgid "The route '{{ target }}' does not exist."
+#: pkg/docker/util.js:123
+msgid "default"
 msgstr ""
 
-#: pkg/kubernetes/views/topology-page.html.h:1
-msgid "Select an object to see more details."
+#: pkg/storaged/details.js:178
+msgid "ext4 - Red Hat Enterprise Linux 6 default"
 msgstr ""
 
-#: pkg/kubernetes/views/topology-page.html.h:3
-msgid ""
-"Pods contain one or more containers that run\n"
-"                together on a node, containing your application code."
+#: pkg/systemd/host.js:661
+msgid "failed to list ssh host keys: $0"
 msgstr ""
 
-#: pkg/kubernetes/views/topology-page.html.h:6
-msgid ""
-"Replication controllers dynamically create instances of\n"
-"                pods from templates, and remove pods when necessary."
+#: pkg/storaged/index.html:135
+msgid "iSCSI Targets"
 msgstr ""
 
-#: pkg/kubernetes/views/topology-page.html.h:9
-msgid ""
-"Services group pods and provide a common DNS\n"
-"                name and an optional, load-balanced IP address to access "
-"them."
+#: pkg/storaged/details.js:1692
+msgid "inactive"
 msgstr ""
 
-#: pkg/kubernetes/views/topology-page.html.h:12
-msgid "Nodes are the machines that run your containers."
+#: pkg/storaged/details.js:1286
+msgid "locked"
 msgstr ""
 
-#: pkg/kubernetes/views/add-group-dialog.html.h:1
-msgid "Add Group"
+#: pkg/storaged/details.js:1278
+msgid "mounted on $0"
 msgstr ""
 
-#: pkg/kubernetes/views/file-button.html.h:1
-msgid "Select Manifest File..."
-msgstr ""
-
-#: pkg/kubernetes/views/project-modify.html.h:2
-msgid "Change project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-modify.html.h:4
-msgid "Display name"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:5
-msgid "TLS Termination"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:6
-msgid "yes"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:7
+#: pkg/kubernetes/views/route-body.html:14
 msgid "no"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:1
-msgid "Add Role"
+#: pkg/kubernetes/views/route-body.html:24
+#: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
+msgid "none"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:2
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#: pkg/storaged/details.js:1280
+msgid "not mounted"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:1
-msgid "All Types"
+#: pkg/kubernetes/views/dashboard-page.html:83
+msgid "pending volume claims"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:2
-msgid "Type:"
+#: pkg/tuned/change-profile.jsx:52
+msgid "recommended"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:13
-msgid "Deployment Configs"
+#: pkg/docker/index.html:426
+msgid "select container"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:15
-msgid "Not deployed"
+#: pkg/docker/index.html:504 pkg/docker/index.html:683
+msgid "shares"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:16
-msgid "Replication Controllers"
+#: pkg/selinux/setroubleshoot-view.jsx:118
+msgid "solution details"
 msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:1
-msgid "Adjust Service"
+#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
+msgid "unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:3
+#: pkg/storaged/jobs.js:180
+msgid "unknown target"
+msgstr ""
+
+#: pkg/storaged/details.js:1284
+msgid "unlocked"
+msgstr ""
+
+#: pkg/kubernetes/views/route-body.html:13
+msgid "yes"
+msgstr ""
+
+#: pkg/kubernetes/views/service-modify.html:16
 msgid "{{ item.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:5
-msgid "Adjust"
+#: pkg/kubernetes/views/deploy.html:27
+msgid "{{ selected.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/project-delete.html.h:1
-msgid "Delete Project"
+#: pkg/kubernetes/views/pv-modify.html:61
+#: pkg/kubernetes/views/pv-modify.html:74
+msgid "{{ value }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:2
-msgid "Claim Name"
+#: pkg/kubernetes/views/volume-body.html:2
+msgid "{{ volume | formatVolumeType }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:4
-msgid "No Volume Bound"
+#: pkg/storaged/index.html:147
+msgid "{{Address}}:{{Port}}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:8
-msgid "Requested"
+#: pkg/docker/index.html:435
+msgid "{{alias_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:9
-msgid "Actual"
+#: pkg/systemd/services.html:173 pkg/systemd/services.html:202
+msgid "{{days_text}}"
 msgstr ""
 
-#: pkg/kubernetes/views/node-capacity.html.h:1
-msgid "Scheduled Pods"
+#: pkg/docker/index.html:403
+msgid "{{envvar_key_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/node-capacity.html.h:2
-msgid "No pods scheduled"
+#: pkg/docker/index.html:407
+msgid "{{envvar_value_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/container-page-inline.html.h:4
-msgid "The container '{{ target }}' does not exist."
+#: pkg/docker/index.html:359
+msgid "{{host_port_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:1
-msgid "Create image stream"
+#: pkg/docker/index.html:373
+msgid "{{host_volume_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:2
-msgid "Change image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:5
-msgid "Populate"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:6
-msgid "Pull from"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:8
-msgid "Remote registry is insecure"
-msgstr ""
-
-#: pkg/kubernetes/views/user-group-remove.html.h:1
-msgid "Remove Member"
-msgstr ""
-
-#: pkg/kubernetes/views/service-page.html.h:1
-msgid "Show all Services"
-msgstr ""
-
-#: pkg/kubernetes/views/service-page.html.h:4
-msgid "The service '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/scripts/frob-layers.html.h:1
-#, fuzzy
-msgid "Image Layers Example"
-msgstr "Værtsnavn"
-
-#: pkg/playground/service.html.h:1
-msgid "Cockpit Generic Service Monitor"
-msgstr ""
-
-#: pkg/playground/jquery-patterns.html.h:1
-msgid "Cockpit Pattern Usage"
-msgstr ""
-
-#: pkg/playground/metrics.html.h:1
-msgid "Cockpit Monitoring"
-msgstr ""
-
-#: pkg/playground/test.html.h:1 pkg/playground/translate.html.h:1
-msgid "Cockpit playground"
-msgstr ""
-
-#: pkg/playground/react-patterns.html.h:1
-msgid "Cockpit React Patterns Usage"
-msgstr ""
-
-#: pkg/playground/speed.html.h:1
-msgid "Cockpit Speed Tests"
-msgstr ""
-
-#: pkg/playground/plot.html.h:1
-msgid "Cockpit Plots"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:1
-msgid "Dashboard"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:5
-#, fuzzy
-msgid "Disk I/O"
-msgstr "Disk I/O"
-
-#: pkg/dashboard/index.html.h:6
-msgid "Lost connection. Trying to reconnect"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:10
-msgid "Avatar"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:13
-msgid "Set"
+#: pkg/kubernetes/views/imagestream-body.html:35
+msgid "{{stream.status.tags.length}}"
 msgstr ""
 
 #, fuzzy
-#~ msgctxt "storage"
-#~ msgid "Firmware Version"
-#~ msgstr "Version"
+#~ msgid "Image Layers Example"
+#~ msgstr "Værtsnavn"
 
 #, fuzzy
 #~ msgctxt "storage"
 #~ msgid "Name"
 #~ msgstr "Værtsnavn"
-
-#, fuzzy
-#~ msgctxt "storage"
-#~ msgid "State"
-#~ msgstr "Tilstand"

--- a/po/de.po
+++ b/po/de.po
@@ -593,22 +593,17 @@ msgstr "1 Minute"
 msgid "1 day"
 msgstr "1 Tag"
 
-#: pkg/storaged/index.html:310 pkg/networkmanager/index.html:53
-#: pkg/networkmanager/index.html:499
-msgid "1 hour"
-msgstr "1 Stunde"
-
 #: pkg/storaged/index.html:313 pkg/networkmanager/index.html:56
 #: pkg/networkmanager/index.html:502
 msgid "1 week"
 msgstr "1 Woche"
 
-#: pkg/playground/translate.html:190
-#, fuzzy
-msgid "1% Free"
-msgid_plural "{{$count}}% Free"
-msgstr[0] "Verfügbar"
-msgstr[1] "Verfügbar"
+#: pkg/storaged/index.html:310 pkg/networkmanager/index.html:53
+#: pkg/networkmanager/index.html:499
+msgid "1 hour"
+msgid_plural "{{count}} hours"
+msgstr[0] "{{count}} Stunde"
+msgstr[1] "{{count}} Stunden"
 
 #: pkg/storaged/overview.js:438
 msgid "128 KiB"
@@ -1956,9 +1951,13 @@ msgstr ""
 msgid "Delete image stream"
 msgstr ""
 
-#: pkg/playground/translate.html:184 pkg/kubernetes/views/item-delete.html:3
+#: pkg/kubernetes/views/item-delete.html:3
 msgid "Delete {{ item.kind }}"
-msgstr ""
+msgstr "{{ item.kind }} löschen"
+
+#: pkg/playground/translate.html:184
+msgid "Delete '{{ name }}'"
+msgstr "'{{ name }}' löschen"
 
 #: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
 msgid "Deleting $target"

--- a/po/de.po
+++ b/po/de.po
@@ -2928,6 +2928,11 @@ msgstr ""
 msgid "Ready"
 msgstr "Bereit"
 
+#: pkg/playground/translate.html:25
+msgctxt "verb"
+msgid "Ready"
+msgstr "Bereiten"
+
 #: pkg/kubernetes/scripts/nodes.js:397
 msgid "Please type an address"
 msgstr "Bitte geben Sie eine Adresse an"
@@ -3143,7 +3148,7 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/charts.js:113
 msgid "Unavailable"
-msgstr ""
+msgstr "Nicht verfügbar"
 
 #: pkg/kubernetes/scripts/dashboard.js:374
 msgid "Namespace cannot be empty."

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-17 19:28+0100\n"
+"POT-Creation-Date: 2016-11-18 06:44+0100\n"
 "PO-Revision-Date: 2016-03-09 01:26-0500\n"
 "Last-Translator: Michael Hofer <mail@michaelhofer.ch>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,176 +19,447 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Zanata 3.9.6\n"
 
-#: src/ws/cockpitcertificate.c:359
-msgid "Cannot decrypt PEM-encoded private key"
+#: pkg/shell/index.html:227
+msgid "                                                Comment                                            "
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:364
-msgid "No PEM-encoded private key found"
+#: pkg/shell/index.html:235
+msgid "                                                Fingerprint                                            "
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:374
-msgid "Could not parse PEM-encoded private key"
+#: pkg/shell/index.html:231
+msgid "                                                Type                                            "
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:398
-msgid "No PEM-encoded certificate found"
+#: pkg/systemd/index.html:389
+msgid ""
+"                                    Invalid time "
+"zone                                "
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:407
-msgid "Could not parse PEM-encoded certificate"
+#: pkg/kubernetes/views/project-body.html:80
+msgid ""
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}                                "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
-#: src/bridge/cockpitdbussetup.c:625
+#: pkg/kubernetes/views/user-body.html:22
+msgid ""
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}                                "
+msgstr ""
+
+#: pkg/kubernetes/views/user-panel.html:39
+msgid ""
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}                            "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:37
+msgid ""
+"                                {{ getRegistryRoles(user, project())."
+"join() }}                            "
+msgstr ""
+
+#: pkg/systemd/index.html:485 pkg/systemd/index.html:504
 #, fuzzy
-msgid "Unsupported setup mechanism"
-msgstr "Nicht unterstützter Setup-Mechanismus: %s"
-
-#: src/bridge/cockpitdbussetup.c:236
-msgid "Couldn't list users"
-msgstr "Benutzer konnten nicht gelistet werden"
-
-#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
-msgid "Bad data passed for passwd1 mechanism"
-msgstr "Fehlerhafte Daten an passwd1 Mechanismus übergeben"
-
-#: src/bridge/cockpitdbussetup.c:382
-msgid "Couldn't load user data"
-msgstr "Benutzerdaten konnten nicht geladen werden"
-
-#: src/bridge/cockpitdbussetup.c:467
-msgid "Couldn't change user groups"
-msgstr "Benutzergruppen konnten nicht geändert werden"
-
-#: src/bridge/cockpitdbussetup.c:520
-msgid "Couldn't change user password"
-msgstr "Passwort konnte nicht geändert werden"
-
-#: src/bridge/cockpitdbussetup.c:544
-msgid "Couldn't create new users"
-msgstr "Neue Benutzer konnten nicht angelegt werden"
-
-#: src/bridge/cockpitdbussetup.c:642
-msgid "Couldn't list local users"
-msgstr "Lokale Benutzer konnten nicht gelistet werden"
-
-#: src/bridge/cockpitpackages.c:459
-#, c-format
-msgid "This package requires Cockpit version %s or later"
+msgid "                        Cancel                    "
 msgstr ""
+"\n"
+"              Abbrechen\n"
+"            "
 
-#: src/bridge/cockpitpackages.c:470
-msgid "This package is not compatible with this version of Cockpit"
-msgstr ""
-
-#: src/base1/cockpit.js:2586
-msgid "$0 killed with signal $1"
-msgstr ""
-
-#: src/base1/cockpit.js:2588
-msgid "$0 exited with code $1"
-msgstr ""
-
-#: src/base1/cockpit.js:2590
-msgid "$0 failed"
-msgstr ""
-
-#: src/base1/cockpit.js:3667
-msgid "Your session has been terminated."
-msgstr ""
-
-#: src/base1/cockpit.js:3669
-msgid "Your session has expired. Please log in again."
-msgstr ""
-
-#: src/base1/cockpit.js:3671
-msgid "Not permitted to perform this action."
-msgstr ""
-
-#: src/base1/cockpit.js:3673
-msgid "Login failed"
-msgstr ""
-
-#: src/base1/cockpit.js:3675
-msgid "The server refused to authenticate using any supported methods."
-msgstr ""
-
-#: src/base1/cockpit.js:3677
-msgid "Untrusted host"
-msgstr ""
-
-#: src/base1/cockpit.js:3679
-msgid "Host key is incorrect"
-msgstr ""
-
-#: src/base1/cockpit.js:3681
-msgid "Internal error"
-msgstr ""
-
-#: src/base1/cockpit.js:3683
-msgid "Connection has timed out."
-msgstr ""
-
-#: src/base1/cockpit.js:3685
-msgid "Cockpit is not installed on the system."
-msgstr ""
-
-#: src/base1/cockpit.js:3687
-msgid "Cannot forward login credentials"
-msgstr ""
-
-#: src/base1/cockpit.js:3689
-msgid "Server has closed the connection."
-msgstr ""
-
-#: src/base1/cockpit.js:3691
-msgid "Cockpit is not compatible with the software on the system."
-msgstr ""
-
-#: src/base1/cockpit.js:3693
-msgid "Cockpit could not contact the given host."
-msgstr ""
-
-#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:19
+#: pkg/kubernetes/views/user-add-membership.html:9
 #, fuzzy
-msgid "Control"
-msgstr "Steuerung"
+msgid "                        Group or Project                    "
+msgstr ""
+"\n"
+"              Erneut verbinden\n"
+"            "
 
-#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
-#: pkg/playground/translate.js:22
-msgctxt "key"
-msgid "Control"
-msgstr "Strg"
+#: pkg/kubernetes/views/add-user-dialog.html:19
+#: pkg/kubernetes/views/user-modify.html:19
+#, fuzzy
+msgid "                        Identity                    "
+msgstr ""
+"\n"
+"                Werkzeuge\n"
+"              "
 
-#: src/base1/test-locale.js:46 src/base1/test-locale.js:56
-#: pkg/playground/translate.js:10
-msgid "Empty"
-msgstr "Leer"
+#: pkg/kubernetes/views/add-user-dialog.html:9
+#: pkg/kubernetes/views/user-modify.html:9
+#: pkg/kubernetes/views/add-group-dialog.html:9
+#, fuzzy
+msgid "                        Name                    "
+msgstr ""
+"\n"
+"                Werkzeuge\n"
+"              "
 
-#: src/base1/test-locale.js:47 src/base1/test-locale.js:58
-#: pkg/playground/translate.js:16
-msgctxt "verb"
-msgid "Empty"
-msgstr "Leeren"
+#: pkg/kubernetes/views/user-add-membership.html:30
+#, fuzzy
+msgid "                        Role                    "
+msgstr ""
+"\n"
+"                Werkzeuge\n"
+"              "
 
-#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
-#: src/base1/test-locale.js:66 pkg/storaged/details.js:1557
-#: pkg/playground/translate.js:25 pkg/playground/translate.js:28
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] "$0 Festplatte fehlt"
-msgstr[1] "$0 Festplatten fehlen"
+#: pkg/kubernetes/views/user-group-add.html:9
+#, fuzzy
+msgid "                        User                    "
+msgstr ""
+"\n"
+"                Werkzeuge\n"
+"              "
 
-#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
-#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
-#: pkg/playground/translate.js:34
-msgctxt "disk-non-rotational"
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] "$0 Datenträger fehlt"
-msgstr[1] "$0 Datenträger fehlen"
+#: pkg/ostree/index.html:88
+#, fuzzy
+msgid "                    Available                  "
+msgstr ""
+"\n"
+"                Werkzeuge\n"
+"              "
+
+#: pkg/ostree/index.html:85
+#, fuzzy
+msgid "                    Default                  "
+msgstr ""
+"\n"
+"                Werkzeuge\n"
+"              "
+
+#: pkg/ostree/index.html:223
+#, fuzzy
+msgid "                    Reconnect                "
+msgstr ""
+"\n"
+"              Erneut verbinden\n"
+"            "
+
+#: pkg/ostree/index.html:135
+msgid ""
+"                    This deployment contains the same packages as your "
+"currently booted system                "
+msgstr ""
+
+#: pkg/ostree/index.html:67
+#, fuzzy
+msgid "                    Update and reboot                "
+msgstr ""
+"\n"
+"                Werkzeuge\n"
+"              "
+
+#: pkg/kubernetes/registry.html:74 pkg/kubernetes/index.html:104
+#, fuzzy
+msgid "                Reconnect            "
+msgstr ""
+"\n"
+"              Erneut verbinden\n"
+"            "
+
+#: pkg/sosreport/index.html:57
+msgid ""
+"                The generated archive contains data "
+"considered                sensitive and its content should be reviewed by "
+"the                originating organization before being passed to "
+"any                third party.              "
+msgstr ""
+
+#: pkg/shell/index.html:304 pkg/shell/stub.html:157
+#, fuzzy
+msgid "                Tools              "
+msgstr ""
+"\n"
+"                Werkzeuge\n"
+"              "
+
+#: pkg/kubernetes/index.html:107
+#, fuzzy
+msgid "                Troubleshoot            "
+msgstr ""
+"\n"
+"                Werkzeuge\n"
+"              "
+
+#: pkg/shell/simple.html:105 pkg/shell/index.html:126 pkg/shell/stub.html:119
+#: pkg/storaged/index.html:862
+#, fuzzy
+msgid "              Cancel            "
+msgstr ""
+"\n"
+"              Abbrechen\n"
+"            "
+
+#: pkg/shell/index.html:147 pkg/shell/stub.html:140
+#, fuzzy
+msgid "              Close            "
+msgstr ""
+"\n"
+"              Schliessen\n"
+"            "
+
+#: pkg/shell/simple.html:70 pkg/shell/index.html:83 pkg/shell/stub.html:76
+#, fuzzy
+msgid ""
+"              Cockpit is an interactive Linux server admin "
+"interface.            "
+msgstr ""
+"\n"
+"              Cockpit ist ein interaktives Administrationsinterface für "
+"Linux Server.\n"
+"            "
+
+#: pkg/shell/simple.html:79 pkg/shell/index.html:92 pkg/shell/stub.html:85
+#, fuzzy
+msgid "              Licensed under the GNU LGPL version 2.1            "
+msgstr ""
+"\n"
+"              Erneut anmelden\n"
+"            "
+
+#: pkg/shell/simple.html:129
+#, fuzzy
+msgid "              Log in again            "
+msgstr ""
+"\n"
+"              Erneut anmelden\n"
+"            "
+
+#: pkg/shell/simple.html:73 pkg/shell/index.html:86 pkg/shell/stub.html:79
+#, fuzzy
+msgid "              Project website            "
+msgstr ""
+"\n"
+"              Schliessen\n"
+"            "
+
+#: pkg/shell/simple.html:108 pkg/shell/index.html:129 pkg/shell/stub.html:122
+#, fuzzy
+msgid "              Select            "
+msgstr ""
+"\n"
+"              Auswählen\n"
+"            "
+
+#: pkg/shell/simple.html:126
+#, fuzzy
+msgid "              Try to reconnect            "
+msgstr ""
+"\n"
+"              Erneut verbinden\n"
+"            "
+
+#: pkg/users/index.html:361
+#, fuzzy
+msgid "            Add key          "
+msgstr ""
+"\n"
+"            Anwenden\n"
+"          "
+
+#: pkg/networkmanager/index.html:582 pkg/networkmanager/index.html:610
+#: pkg/networkmanager/index.html:638 pkg/networkmanager/index.html:666
+#: pkg/networkmanager/index.html:694 pkg/networkmanager/index.html:722
+#: pkg/networkmanager/index.html:750 pkg/networkmanager/index.html:778
+#, fuzzy
+msgid "            Apply          "
+msgstr ""
+"\n"
+"            Anwenden\n"
+"          "
+
+#: pkg/users/index.html:269 pkg/users/index.html:297 pkg/users/index.html:358
+#: pkg/docker/index.html:584 pkg/docker/index.html:622
+#: pkg/docker/index.html:688 pkg/docker/index.html:744
+#: pkg/docker/index.html:790 pkg/networkmanager/index.html:579
+#: pkg/networkmanager/index.html:607 pkg/networkmanager/index.html:635
+#: pkg/networkmanager/index.html:663 pkg/networkmanager/index.html:691
+#: pkg/networkmanager/index.html:719 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:775
+#, fuzzy
+msgid "            Cancel          "
+msgstr ""
+"\n"
+"            Abbrechen\n"
+"          "
+
+#: pkg/docker/index.html:691
+#, fuzzy
+msgid "            Change          "
+msgstr ""
+"\n"
+"            Ändern\n"
+"          "
+
+#: pkg/users/index.html:45
+#, fuzzy
+msgid "            Close          "
+msgstr ""
+"\n"
+"              Schliessen\n"
+"            "
+
+#: pkg/docker/index.html:747
+#, fuzzy
+msgid "            Commit          "
+msgstr ""
+"\n"
+"            Commit\n"
+"          "
+
+#: pkg/users/index.html:207
+#, fuzzy
+msgid "            Create          "
+msgstr ""
+"\n"
+"            Erstellen\n"
+"          "
+
+#: pkg/users/index.html:300 pkg/networkmanager/index.html:533
+#, fuzzy
+msgid "            Delete          "
+msgstr ""
+"\n"
+"            Löschen\n"
+"          "
+
+#: pkg/docker/index.html:625
+#, fuzzy
+msgid "            Download          "
+msgstr ""
+"\n"
+"            Herunterladen\n"
+"          "
+
+#: pkg/docker/index.html:587
+#, fuzzy
+msgid "            Run          "
+msgstr ""
+"\n"
+"            Ausführen\n"
+"          "
+
+#: pkg/users/index.html:272
+#, fuzzy
+msgid "            Set          "
+msgstr ""
+"\n"
+"            Setzen\n"
+"          "
+
+#: pkg/kubernetes/views/imagestream-body.html:14
+msgid "          Images may be pulled by anonymous users        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:20
+msgid ""
+"          Images may be pulled by any authenticated user or group        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:26
+msgid "          Images may only be pulled by specific users or groups        "
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:9
+#, fuzzy
+msgid "         {{ labels.url }}    "
+msgstr ""
+"\n"
+"            Abbrechen\n"
+"          "
+
+#: pkg/kubernetes/views/project-body.html:2
+msgid ""
+"        Project access policy allows anonymous users to pull images. Grant "
+"additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:7
+msgid ""
+"        Project access policy allows any authenticated user to pull images. "
+"Grant additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:12
+msgid ""
+"        Project access policy only allows specific members to access images. "
+"Grant access to specific members below.    "
+msgstr ""
+
+#: pkg/sosreport/index.html:39
+msgid ""
+"        The collected information will be stored locally on the system.      "
+msgstr ""
+
+#: pkg/storaged/index.html:51
+msgid ""
+"        There are devices with multiple paths on the system, but the "
+"multipath service is not running.      "
+msgstr ""
+
+#: pkg/sosreport/index.html:34
+msgid ""
+"        This tool will collect system configuration and diagnostic        "
+"information from this system for use with diagnosing problems        with "
+"the system.      "
+msgstr ""
+
+#: pkg/docker/storage.jsx:242
+msgid " (shared with the OS)"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:8
+msgid " 1\"Do you want to delete the following Nodes?"
+msgstr ""
+
+#: pkg/storaged/overview.js:253
+msgid "$0 Block Device"
+msgstr "$0 blockorientiertes Gerät"
+
+#: pkg/storaged/details.js:1546
+msgid "$0 Chunk Size"
+msgstr "$0 Chunk Size"
+
+#: pkg/storaged/details.js:1544
+msgid "$0 Disks"
+msgstr "$0 Datenträger"
+
+#: pkg/storaged/details.js:1387
+msgid "$0 Extended Partition"
+msgstr ""
+
+#: pkg/storaged/details.js:1221
+msgctxt "storage-id-desc"
+msgid "$0 File System"
+msgstr "$0 Dateisystem"
+
+#: pkg/storaged/details.js:1375
+msgid "$0 Free Space"
+msgstr "$0 freier Speicherplatz"
+
+#: pkg/storaged/details.js:1367
+msgid "$0 Free Space for Logical Partitions"
+msgstr ""
+
+#: pkg/storaged/details.js:1711
+msgid "$0 Free Space for Logical Volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:1370
+msgid "$0 Free Space for Primary Partitions"
+msgstr ""
+
+#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
+msgid "$0 Template"
+msgstr "$0 Template"
+
+#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+msgid "$0 bit"
+msgid_plural "$0 bits"
+msgstr[0] "$0 bit"
+msgstr[1] "$0 bits"
 
 #: src/base1/test-locale.js:73 src/base1/test-locale.js:74
 #: src/base1/test-locale.js:86 src/base1/test-locale.js:87
@@ -204,575 +475,40 @@ msgid_plural "$0 bytes"
 msgstr[0] "$0 byte"
 msgstr[1] "$0 bytes"
 
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
-msgid "$0 bit"
-msgid_plural "$0 bits"
-msgstr[0] "$0 bit"
-msgstr[1] "$0 bits"
+#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
+#: src/base1/test-locale.js:66 pkg/playground/translate.js:25
+#: pkg/playground/translate.js:28 pkg/storaged/details.js:1557
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] "$0 Festplatte fehlt"
+msgstr[1] "$0 Festplatten fehlen"
 
-#: pkg/systemd/host.js:43
-msgid "The user <b>$0</b> is not permitted to modify hostnames"
+#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
+#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
+#: pkg/playground/translate.js:34
+msgctxt "disk-non-rotational"
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] "$0 Datenträger fehlt"
+msgstr[1] "$0 Datenträger fehlen"
+
+#: src/base1/cockpit.js:2588
+msgid "$0 exited with code $1"
 msgstr ""
 
-#: pkg/systemd/host.js:559
-msgid "Set Host name"
-msgstr "Hostname festlegen"
-
-#: pkg/systemd/host.js:661
-msgid "failed to list ssh host keys: $0"
+#: src/base1/cockpit.js:2590
+msgid "$0 failed"
 msgstr ""
 
-#: pkg/systemd/host.js:1113
-msgid "Need at least one NTP server"
+#: src/base1/cockpit.js:2586
+msgid "$0 killed with signal $1"
 msgstr ""
 
-#: pkg/systemd/host.js:1190
-msgid "Invalid date format and invalid time format"
-msgstr ""
-
-#: pkg/systemd/host.js:1192
-msgid "Invalid time format"
-msgstr ""
-
-#: pkg/systemd/host.js:1194
-msgid "Invalid date format"
-msgstr ""
-
-#: pkg/systemd/host.js:1250
-msgid "NTP Server"
-msgstr "NTP Server"
-
-#: pkg/systemd/host.js:1300
-msgid "Message to logged in users"
-msgstr "Nachricht an angemeldete Benutzer"
-
-#: pkg/systemd/host.js:1307 pkg/systemd/host.js:1309
-#: pkg/systemd/index.html.h:19
-msgid "Shutdown"
-msgstr "Herunterfahren"
-
-#: pkg/systemd/host.js:1311 pkg/systemd/host.js:1313 pkg/systemd/init.js:517
-#: pkg/systemd/index.html.h:18
-msgid "Restart"
-msgstr "Neustarten"
-
-#: pkg/systemd/host.js:1381
-msgctxt "page-title"
-msgid "CPU Status"
-msgstr "CPU Status"
-
-#: pkg/systemd/host.js:1413 pkg/systemd/index.html.h:24
-msgid "I/O Wait"
-msgstr ""
-
-#: pkg/systemd/host.js:1414 pkg/systemd/index.html.h:25
-msgid "Kernel"
-msgstr "Kernel"
-
-#: pkg/systemd/host.js:1415 pkg/subscriptions/subscriptions-register.jsx:76
-#: pkg/systemd/index.html.h:26 pkg/kubernetes/views/auth-form.html.h:6
-#: pkg/kubernetes/views/volume-body.html.h:20
-#: pkg/kubernetes/views/user-panel.html.h:1 pkg/playground/translate.html.h:3
-#: pkg/dashboard/index.html.h:8
-msgid "User"
-msgstr "Benutzer"
-
-#: pkg/systemd/host.js:1416 pkg/systemd/index.html.h:27
-msgid "Nice"
-msgstr ""
-
-#: pkg/systemd/host.js:1466
-msgctxt "page-title"
-msgid "Memory"
-msgstr "Speicher"
-
-#: pkg/systemd/host.js:1499 pkg/systemd/index.html.h:28
-msgid "Swap Used"
-msgstr ""
-
-#: pkg/systemd/host.js:1500 pkg/systemd/index.html.h:29
-msgid "Cached"
-msgstr ""
-
-#: pkg/systemd/host.js:1501 pkg/docker/storage.jsx:313
-#: pkg/kubernetes/scripts/nodes.js:828 pkg/kubernetes/scripts/nodes.js:837
-#: pkg/systemd/index.html.h:30
-msgid "Used"
-msgstr "Benutzt"
-
-#: pkg/systemd/host.js:1502 pkg/docker/storage.jsx:298
-#: pkg/docker/storage.jsx:320 pkg/systemd/index.html.h:31
-msgid "Free"
-msgstr "Verfügbar"
-
-#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
-msgid "unknown"
-msgstr ""
-
-#: pkg/systemd/init.js:269 pkg/systemd/services.html.h:17
-#: pkg/kubernetes/views/project-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:5
-msgid "Description"
-msgstr ""
-
-#: pkg/systemd/init.js:270
-msgid "Id"
-msgstr ""
-
-#: pkg/systemd/init.js:272
-msgid "Next Run"
-msgstr ""
-
-#: pkg/systemd/init.js:273
-msgid "Last Trigger"
-msgstr ""
-
-#: pkg/systemd/init.js:274 pkg/kubernetes/views/container-body.html.h:6
-#: pkg/kubernetes/views/details-page.html.h:8
-msgid "State"
-msgstr ""
-
-#: pkg/systemd/init.js:301
-msgid "Enabled"
-msgstr "Aktiviert"
-
-#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
-msgid "Disabled"
-msgstr "Deaktiviert"
-
-#: pkg/systemd/init.js:303
-msgid "Static"
-msgstr "Statisch"
-
-#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
-msgid "$0 Template"
-msgstr "$0 Template"
-
-#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
-msgid "Start"
-msgstr "Starten"
-
-#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
-msgid "Stop"
-msgstr "Stoppen"
-
-#: pkg/systemd/init.js:518
-msgid "Reload"
-msgstr "Neu Laden"
-
-#: pkg/systemd/init.js:519
-msgid "Reload or Restart"
-msgstr "Neu Laden oder Neu Starten"
-
-#: pkg/systemd/init.js:520
-msgid "Try Restart"
-msgstr "Neustart Versuchen"
-
-#: pkg/systemd/init.js:521
-msgid "Reload or Try Restart"
-msgstr "Neu Laden oder Neustart Versuchen"
-
-#: pkg/systemd/init.js:522
-msgid "Isolate"
-msgstr "Isolieren"
-
-#: pkg/systemd/init.js:541
-msgid "Enable"
-msgstr "Einschalten"
-
-#: pkg/systemd/init.js:542
-msgid "Enable Forcefully"
-msgstr "Gewaltsam Einschalten"
-
-#: pkg/systemd/init.js:543
-msgid "Disable"
-msgstr "Ausschalten"
-
-#: pkg/systemd/init.js:544
-msgid "Preset"
-msgstr "Voreinstellen"
-
-#: pkg/systemd/init.js:545
-msgid "Preset Forcefully"
-msgstr "Gewaltsam Voreinstellen"
-
-#: pkg/systemd/init.js:546
-msgid "Mask"
-msgstr "Sperren"
-
-#: pkg/systemd/init.js:547
-msgid "Mask Forcefully"
-msgstr "Maskieren erzwingen"
-
-#: pkg/systemd/init.js:548
-msgid "Unmask"
-msgstr "Freigeben"
-
-#: pkg/systemd/init.js:621
-msgid "Since $0"
-msgstr "Seit $0"
-
-#: pkg/systemd/init.js:639
-msgid "This unit is an instance of the $0 template."
-msgstr ""
-
-#: pkg/systemd/init.js:834
-#, fuzzy
-msgid "The user <b>$0</b> does not have permissions for creating timers"
-msgstr "Der Benutzer <b>$0</b> hat keine Rechte, um Server zu administrieren"
-
-#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
-#, fuzzy
-msgid "This field cannot be empty."
-msgstr "Name darf nicht leer sein."
-
-#: pkg/systemd/init.js:1147
-msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
-msgstr ""
-
-#: pkg/systemd/init.js:1169
-#, fuzzy
-msgid "Invalid number."
-msgstr "Ungültiger Schlüssel"
-
-#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
-msgid "Hour needs to be a number between 0-23"
-msgstr ""
-
-#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
-msgid "Minute needs to be a number between 0-59"
-msgstr ""
-
-#: pkg/systemd/init.js:1218
-#, fuzzy
-msgid "Invalid date format."
-msgstr "Ungültiger Port"
-
-#: pkg/systemd/init.js:1222
-msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
-msgstr ""
-
-#: pkg/systemd/logs.js:69
-msgid "Load earlier entries"
-msgstr "Frühere Einträge laden"
-
-#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
-#: pkg/systemd/logs.js:175
-msgid "Loading..."
-msgstr "Lade..."
-
-#: pkg/systemd/logs.js:130
-msgid "Go to"
-msgstr "Gehe zu"
-
-#: pkg/systemd/logs.js:257
-msgid "Journal entry"
-msgstr "Journal-Eintrag"
-
-#: pkg/systemd/logs.js:284
-msgid "Journal entry not found"
-msgstr "Journal-Eintrag nicht gefunden"
-
-#: pkg/tuned/dialog.js:94
-msgid "Tuned is not available"
-msgstr "Tuned ist nicht verfügbar"
-
-#: pkg/tuned/dialog.js:96
-msgid "Tuned is not running"
-msgstr "Tuned läuft nicht"
-
-#: pkg/tuned/dialog.js:98
-msgid "Tuned is off"
-msgstr "Tuned ist ausgeschaltet"
-
-#: pkg/tuned/dialog.js:100
-msgid "This system is using the recommended profile"
-msgstr "Dieses System benutzt das empfohlene Profil"
-
-#: pkg/tuned/dialog.js:102
-msgid "This system is using a custom profile"
-msgstr "Dieses System benutzt ein benutzerdefiniertes Profil"
-
-#: pkg/tuned/dialog.js:114
-msgid "Communication with tuned has failed"
-msgstr "Kommunikation mit tuned schlug fehl"
-
-#: pkg/tuned/dialog.js:133
-msgid "Failed to disable tuned profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:145
-msgid "Failed to switch profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:169
-msgid "Failed to enable tuned"
-msgstr ""
-
-#: pkg/tuned/dialog.js:171
-msgid "Failed to disable tuned"
-msgstr ""
-
-#: pkg/tuned/dialog.js:191
-msgid "Change Performance Profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:200
-msgid "Change Profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:233 pkg/kubernetes/views/service-body.html.h:7
-#: pkg/kubernetes/views/pod-panel.html.h:2
-#: pkg/kubernetes/views/image-config.html.h:8
-#: pkg/kubernetes/views/imagestream-body.html.h:12
-#: pkg/kubernetes/views/pod-page.html.h:5
-msgid "None"
-msgstr "Kein"
-
-#: pkg/tuned/dialog.js:234
-msgid "Disable tuned"
-msgstr "Tuned deaktivieren"
-
-#: pkg/tuned/dialog.js:262
-msgid "Tuned has failed to start"
-msgstr "Tuned konnte nicht gestartet werden"
-
-#: pkg/tuned/change-profile.jsx:52
-#, fuzzy
-msgid "recommended"
-msgstr "MII (empfohlen)"
-
-#: pkg/lib/journal.js:209
-msgid "[no data]"
-msgstr ""
-
-#: pkg/lib/journal.js:213
-msgid "[$0 bytes of binary data]"
-msgstr ""
-
-#: pkg/lib/journal.js:215
-msgid "[binary data]"
-msgstr ""
-
-#: pkg/lib/journal.js:241
-msgid "Reboot"
-msgstr "Neustart"
-
-#: pkg/lib/machine-dialogs.js:364
-msgid "This machine has already been added."
-msgstr "Diese Maschine wurde bereits hinzugefügt"
-
-#: pkg/lib/machine-dialogs.js:380
-msgid ""
-"This version of cockpit-ws does not support connecting to a host with an "
-"alternate user or port"
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:386
-msgid "The IP address or host name cannot contain whitespace."
-msgstr "IP Adresse oder Hostname darf keine Leerzeichen enthalten."
-
-#: pkg/lib/machine-dialogs.js:412
-msgid "Failed to add machine: $0"
-msgstr "Maschine konnte nicht hinzugefügt werden: $0"
-
-#: pkg/lib/machine-dialogs.js:429
-msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:447
-msgid "Enter IP address or host name"
-msgstr "Geben Sie die IP Adresse oder den Hostnamen an"
-
-#: pkg/lib/machine-dialogs.js:494
-msgid "Failed to edit machine: $0"
-msgstr "Maschine konnte nicht editiert werden: $0"
-
-#: pkg/lib/cockpit-components-dialog.jsx:136 pkg/sosreport/index.js:55
-#: pkg/systemd/services.html.h:34 pkg/lib/machine-sync-users.html.h:7
-#: pkg/lib/machine-add.html.h:5 pkg/lib/machine-change-port.html.h:6
-#: pkg/lib/machine-change-auth.html.h:11 pkg/storaged/index.html.h:22
-#: pkg/realmd/operation.html.h:10 pkg/kubernetes/views/node-delete.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:3
-#: pkg/kubernetes/views/pvc-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:3
-#: pkg/kubernetes/views/auth-form.html.h:13
-#: pkg/kubernetes/views/node-add.html.h:7
-#: pkg/kubernetes/views/user-group-add.html.h:5
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:4
-#: pkg/kubernetes/views/route-modify.html.h:3
-#: pkg/kubernetes/views/image-delete.html.h:3
-#: pkg/kubernetes/views/pv-delete.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:4
-#: pkg/kubernetes/views/item-delete.html.h:4
-#: pkg/kubernetes/views/add-user-dialog.html.h:8
-#: pkg/kubernetes/views/user-add-membership.html.h:8
-#: pkg/kubernetes/views/deploy.html.h:4
-#: pkg/kubernetes/views/user-modify.html.h:8
-#: pkg/kubernetes/views/pv-modify.html.h:21
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:5
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:3
-#: pkg/kubernetes/views/imagestream-delete.html.h:3
-#: pkg/kubernetes/views/user-remove-membership.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:7
-#: pkg/kubernetes/views/add-role-dialog.html.h:3
-#: pkg/kubernetes/views/service-modify.html.h:4
-#: pkg/kubernetes/views/project-delete.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:9
-#: pkg/kubernetes/views/user-group-remove.html.h:2
-#: pkg/playground/translate.html.h:2 pkg/dashboard/index.html.h:12
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: pkg/lib/cockpit-components-dialog.jsx:155
-msgid "Ok"
-msgstr ""
-
-#: pkg/lib/credentials.js:182
-msgid "No such file or directory"
-msgstr "Datei oder Verzeichnis nicht vorhanden"
-
-#: pkg/lib/credentials.js:186
-msgid "The passwords do not match."
-msgstr "Die Passwörter stimmen nicht überein."
-
-#: pkg/lib/credentials.js:191
-msgid "Prompting via ssh-keygen timed out"
-msgstr ""
-
-#: pkg/lib/credentials.js:213 pkg/users/local.js:78
-msgid "Old password not accepted"
-msgstr "Altes Passwort wurde nicht akzeptiert"
-
-#: pkg/lib/credentials.js:223 pkg/users/local.js:112 pkg/users/local.js:144
-msgid "Failed to change password"
-msgstr "Passwort konnte nicht geändert werden"
-
-#: pkg/lib/credentials.js:231 pkg/users/local.js:120
-msgid "New password was not accepted"
-msgstr "Das neue Passwort wurde nicht akzeptiert"
-
-#: pkg/lib/credentials.js:248
-msgid "Not a valid private key"
-msgstr "Ungültiger privater Schlüssel"
-
-#: pkg/lib/credentials.js:251
-msgid "Prompting via ssh-add timed out"
-msgstr ""
-
-#: pkg/lib/credentials.js:274
-msgid "Invalid file permissions"
-msgstr "Ungültige Dateiberechtigungen"
-
-#: pkg/lib/credentials.js:278
-msgid "Password not accepted"
-msgstr "Passwort wurde nicht akzeptiert"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:22
-#: pkg/shell/index.html.h:27 pkg/storaged/index.html.h:52
-#: pkg/playground/jquery-patterns.html.h:2
-msgid "On"
-msgstr "Ein"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:23
-#: pkg/shell/index.html.h:28 pkg/storaged/index.html.h:53
-#: pkg/playground/jquery-patterns.html.h:3
-msgid "Off"
-msgstr "Aus"
-
-#: pkg/shell/base_index.js:670 pkg/users/local.js:1164
-#: pkg/docker/index.html.h:69 pkg/networkmanager/index.html.h:65
-msgid "Unexpected error"
-msgstr "Unerwarteter Fehler"
-
-#: pkg/shell/base_index.js:671
-msgid "Cockpit had an unexpected internal error. <br/><br/>"
-msgstr "Cockpit hat einen internen Fehler festgestellt.<br/><br/>"
-
-#: pkg/shell/base_index.js:672
-msgid "You can try restarting Cockpit by pressing refresh in your browser. "
-msgstr ""
-"Sie können versuchen, Cokpit durch Drücken von Aktualisieren in Ihrem "
-"Browser neu zu starten."
-
-#: pkg/shell/base_index.js:673
-msgid "The javascript console contains details about this error "
-msgstr ""
-
-#: pkg/shell/base_index.js:674
-msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
-msgstr "(<b>Ctrl-Shift-J</b> in den meisten Browsern)."
-
-#: pkg/shell/indexes.js:126 pkg/shell/indexes.js:497 pkg/shell/simple.html.h:17
-msgid "Disconnected"
-msgstr "Getrennt"
-
-#: pkg/shell/indexes.js:253
-msgid "Machines"
-msgstr "Maschinen"
-
-#: pkg/shell/indexes.js:314
-msgid "The machine is restarting"
-msgstr "Die Maschine startet neu"
-
-#: pkg/shell/indexes.js:317
-msgid "Connecting to the machine"
-msgstr "Verbindung zur Maschine wird hergestellt"
-
-#: pkg/shell/indexes.js:320
-msgid "Couldn't connect to the machine"
-msgstr "Verbindung zur Maschine konnte nicht hergstellt werden"
-
-#: pkg/shell/indexes.js:322
-msgid "Cannot connect to an unknown machine"
-msgstr "Kann nicht zu einer unbekannten Maschine verbinden"
-
-#: pkg/ostree/client.js:56
-msgid "Receiving delta parts"
-msgstr "Empfange Delta-Teile"
-
-#: pkg/ostree/client.js:58
-msgid "Receiving metadata objects"
-msgstr "Empfange Metadaten-Objekte"
-
-#: pkg/ostree/client.js:61
-msgid "Receiving objects: $0%"
-msgstr "Empfange Objekte: $0%"
-
-#: pkg/ostree/client.js:64
-msgid "Writing objects"
-msgstr "Schreibe Objekte"
-
-#: pkg/ostree/client.js:66
-msgid "Scanning metadata"
-msgstr "Untersuche Metadaten"
-
-#: pkg/ostree/client.js:500
-msgid "OS $0 not found"
-msgstr "OS $0 nicht gefunden"
-
-#: pkg/ostree/app.js:81
-msgid "Not authorized to update software on this system"
-msgstr ""
-
-#: pkg/ostree/app.js:83
-msgid "OSTree is not available on this system"
-msgstr ""
-
-#: pkg/ostree/app.js:101
-msgid "No OSTree deployments found"
-msgstr ""
-
-#: pkg/ostree/app.js:219
-msgid "Checking for updates"
-msgstr ""
+#: pkg/selinux/setroubleshoot-view.jsx:440
+msgid "$0 occurrence"
+msgid_plural "$1 occurrences"
+msgstr[0] ""
+msgstr[1] ""
 
 #: pkg/ostree/app.js:307
 msgid "$0 package"
@@ -782,690 +518,34 @@ msgstr ""
 msgid "$0 packages"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot.js:65
-msgid "Error while setting SELinux mode: '$0'"
-msgstr ""
+#: pkg/docker/util.js:124
+msgid "$0 shares"
+msgstr "$0 mal geteilt"
 
-#: pkg/selinux/setroubleshoot.js:238
-msgid "Not connected"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot.js:275
-msgid "Error while connecting."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:82
-msgid "Applying solution..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:90
-msgid "Solution applied successfully"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:97
-msgid "Solution failed"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:107
-msgid "Apply this solution"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:114
-msgid "Unable to apply this solution automatically"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:118
-msgid "solution details"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:309
-msgid "SELinux system status is unknown."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:317
-msgid "SELinux is disabled on the system."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:324
-msgid "The configured state is unknown, it might change on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:326
-msgid ""
-"Setting deviates from the configured state and will revert on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:330
-msgid "SELinux Policy"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:332
-msgid "Enforce policy:"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:382 pkg/kubernetes/index.html.h:10
-#: pkg/kubernetes/registry.html.h:5
-msgid "Connecting..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:385
-msgid ""
-"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
-"server is installed."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:400
-msgid "Occurred between $0 and $1"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:405
-msgid "Occurred $0"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:440
-msgid "$0 occurrence"
-msgid_plural "$1 occurrences"
+#: pkg/kubernetes/scripts/nodes.js:870
+#, c-format
+msgid "$0% Free"
+msgid_plural "$0% Free"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:478
-msgid "SELinux Access Control Errors"
+#: pkg/kubernetes/scripts/nodes.js:872
+msgid "$0% Used"
+msgid_plural "$0% Used"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/storaged/details.js:1765
+msgid "$0, $1 free"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:479
-msgid "No SELinux alerts."
+#: pkg/networkmanager/interfaces.js:2473
+msgid "$mtu"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-client.js:52
-msgid "Unable to start setroubleshootd"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:157
-msgid "Unable to get alert"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:172
-msgid "Unable to run fix"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:187
-msgid "Failed to delete alert"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:192
-msgid "Error while deleting alert"
-msgstr ""
-
-#: pkg/storaged/dialog.js:267
-msgid "Size must be a number"
-msgstr ""
-
-#: pkg/storaged/dialog.js:269
-#, fuzzy
-msgid "Size cannot be zero"
-msgstr "Name darf nicht leer sein."
-
-#: pkg/storaged/dialog.js:271
-#, fuzzy
-msgid "Size cannot be negative"
-msgstr "Name darf nicht leer sein."
-
-#: pkg/storaged/dialog.js:273
-msgid "Size is too large"
-msgstr ""
-
-#: pkg/storaged/details.js:85
-msgid "Device $0 is mounted on $1"
-msgstr "Gerät $0 ist eingehängt auf $1"
-
-#: pkg/storaged/details.js:91
-msgid "Device $0 is a member of RAID Array $1"
-msgstr "Gerät $0 ist Mitglied des RAID Arrays $1"
-
-#: pkg/storaged/details.js:97
-msgid "Device $0 is a physical volume of $1"
-msgstr "Gerät $0 ist ein physischer Datenträger von $1"
-
-#: pkg/storaged/details.js:113
-msgid "Create partition on $0"
-msgstr "Partition auf $0 erzeugen"
-
-#: pkg/storaged/details.js:115
-msgid "Format $0"
-msgstr "$0 formatieren"
-
-#: pkg/storaged/details.js:177
-msgid "XFS - Red Hat Enterprise Linux 7 default"
-msgstr "XFS - Red Hat Enterprise Linux 7 default"
-
-#: pkg/storaged/details.js:178
-msgid "ext4 - Red Hat Enterprise Linux 6 default"
-msgstr "ext4 - Red Hat Enterprise Linux 6 default"
-
-#: pkg/storaged/details.js:179
-msgid "Encrypted XFS (LUKS)"
-msgstr "Verschlüsseltes XFS (LUKS)"
-
-#: pkg/storaged/details.js:180
-msgid "Encrypted EXT4 (LUKS)"
-msgstr "Verschlüsseltes EXT4 (LUKS)"
-
-#: pkg/storaged/details.js:181
-msgid "VFAT - Compatible with all systems and devices"
-msgstr "VFAT - Kompatibel mit allen System und Geräten"
-
-#: pkg/storaged/details.js:182
-msgid "NTFS - Compatible with most systems"
-msgstr "NTFS - Kompatibel mit den meisten Systemen"
-
-#: pkg/storaged/details.js:183
-msgid "Extended Partition"
-msgstr "Erweiterte Partition"
-
-#: pkg/storaged/details.js:185
-msgid "No Filesystem"
-msgstr "Kein Dateisystem"
-
-#: pkg/storaged/details.js:186
-msgid "Custom (Enter filesystem type)"
-msgstr "Benutzerdefiniert (Geben Sie den Dateisystemtyp an)"
-
-#: pkg/storaged/details.js:192 pkg/storaged/details.js:664
-#: pkg/storaged/details.js:735 pkg/storaged/details.js:773
-#: pkg/storaged/details.js:909 pkg/storaged/index.html.h:20
-#: pkg/kubernetes/views/volumes-page.html.h:11
-msgid "Size"
-msgstr "Größe"
-
-#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
-msgid "Erase"
-msgstr "Säubern"
-
-#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
-msgid "Don't overwrite existing data"
-msgstr "Vorhandene Daten nicht überschreiben"
-
-#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
-msgid "Overwrite existing data with zeros"
-msgstr "Vorhandene Daten mit Nullen überschreiben"
-
-#: pkg/storaged/details.js:207 pkg/shell/index.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:4
-#: pkg/kubernetes/views/deploy.html.h:2 pkg/kubernetes/views/pv-modify.html.h:3
-msgid "Type"
-msgstr "Typ"
-
-#: pkg/storaged/details.js:211 pkg/storaged/details.js:429
-#: pkg/storaged/details.js:709 pkg/storaged/details.js:731
-#: pkg/storaged/details.js:769 pkg/storaged/details.js:798
-#: pkg/storaged/details.js:864 pkg/storaged/overview.js:417
-#: pkg/storaged/overview.js:490 pkg/storaged/overview.js:624
-#: pkg/storaged/overview.js:702 pkg/storaged/index.html.h:18
-#: pkg/networkmanager/index.html.h:16
-#: pkg/kubernetes/views/project-listing.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:3
-#: pkg/kubernetes/views/volume-body.html.h:11
-#: pkg/kubernetes/views/containers-listing.html.h:2
-#: pkg/kubernetes/views/volumes-page.html.h:3
-#: pkg/kubernetes/views/pv-claim.html.h:1
-#: pkg/kubernetes/views/pv-modify.html.h:6
-#: pkg/kubernetes/views/image-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:15
-#: pkg/kubernetes/views/nodes-page.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:3
-#: pkg/kubernetes/views/details-page.html.h:4
-#: pkg/kubernetes/views/service-modify.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:3
-msgid "Name"
-msgstr "Name"
-
-#: pkg/storaged/details.js:215
-msgid "Filesystem type"
-msgstr "Dateisystemtyp"
-
-#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
-msgid "Passphrase"
-msgstr "Passwort"
-
-#: pkg/storaged/details.js:224
-#, fuzzy
-msgid "Passphrase cannot be empty"
-msgstr "Passphrase darf nicht leer sein"
-
-#: pkg/storaged/details.js:229
-msgid "Confirm passphrase"
-msgstr "Passphrase wiederholen"
-
-#: pkg/storaged/details.js:232
-msgid "Passphrases do not match"
-msgstr "Passphrasen stimmen nicht überein."
-
-#: pkg/storaged/details.js:237
-msgid "Store passphrase"
-msgstr "Passphrase speichern"
-
-#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
-#: pkg/storaged/details.js:1115
-msgid "Encryption Options"
-msgstr "Verschlüsselungsoptionen"
-
-#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
-msgid "Mounting"
-msgstr "Einhängen"
-
-#: pkg/storaged/details.js:247 pkg/storaged/details.js:435
-#: pkg/subscriptions/subscriptions-register.jsx:101 pkg/docker/index.html.h:23
-#: pkg/kubernetes/views/image-config.html.h:2
-msgid "Default"
-msgstr "Standard"
-
-#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
-msgid "Custom"
-msgstr "Benutzerdefiniert"
-
-#: pkg/storaged/details.js:253 pkg/storaged/details.js:440
-#: pkg/storaged/index.html.h:19
-msgid "Mount Point"
-msgstr "Einhängestelle"
-
-#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
-msgid "Mount Options"
-msgstr "Einhängoptionen"
-
-#: pkg/storaged/details.js:266
-msgid "Create partition"
-msgstr "Partition erzeugen"
-
-#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
-#: pkg/storaged/details.js:1142
-msgid "Format"
-msgstr "Formatieren"
-
-#: pkg/storaged/details.js:268
-msgid "Formatting a storage device will erase all data on it."
-msgstr ""
-"Das Formatieren eines Speichergeräts löscht alle darauf vorhandenen Daten."
-
-#: pkg/storaged/details.js:335
-msgid "Format Disk $0"
-msgstr "Datenträger $0 formatieren"
-
-#: pkg/storaged/details.js:346
-msgid "Partitioning"
-msgstr "Partitionierung"
-
-#: pkg/storaged/details.js:348
-msgid "Compatible with all systems and devices (MBR)"
-msgstr "Kompatibel mit allen Systemen und Geräten (MBR)"
-
-#: pkg/storaged/details.js:349
-msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr "Kompatibel mit modernen Systemen und Festplatten > 2TB (GPT)"
-
-#: pkg/storaged/details.js:352
-msgid "No partitioning"
-msgstr "Keine Partitionierung"
-
-#: pkg/storaged/details.js:358
-msgid "Formatting a disk will erase all data on it."
-msgstr ""
-"Das Formatieren eines Datenträgers löscht alle darauf vorhandenen Daten."
-
-#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
-msgid "Filesystem Options"
-msgstr "Dateisystemoptionen"
-
-#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
-msgid "Apply"
-msgstr "Anwenden"
-
-#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
-#: pkg/storaged/details.js:1110
-msgid "Unlock"
-msgstr "Öffnen"
-
-#: pkg/storaged/details.js:527
-msgid "Stored Passphrase"
-msgstr "Gespeichertes Passwort"
-
-#: pkg/storaged/details.js:531 pkg/kubernetes/views/volume-body.html.h:32
-msgid "Options"
-msgstr "Einstellungen"
-
-#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
-msgid "Add Disks"
-msgstr "Datenträger hinzufügen"
-
-#: pkg/storaged/details.js:567 pkg/storaged/details.js:933
-#: pkg/storaged/overview.js:448 pkg/storaged/overview.js:495
-#: pkg/storaged/index.html.h:55
-msgid "Disks"
-msgstr "Datenträger"
-
-#: pkg/storaged/details.js:579 pkg/storaged/details.js:948
-#: pkg/storaged/overview.js:501
-msgid "At least one disk is needed."
-msgstr "Mindestens ein Datenträger ist nötig."
-
-#: pkg/storaged/details.js:584 pkg/storaged/details.js:953
-#: pkg/storaged/overview.js:629 pkg/storaged/overview.js:657
-#: pkg/lib/machine-add.html.h:6 pkg/kubernetes/views/node-add.html.h:8
-#: pkg/kubernetes/views/user-group-add.html.h:6
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:5
-#: pkg/kubernetes/views/add-user-dialog.html.h:9
-#: pkg/kubernetes/views/user-add-membership.html.h:9
-#: pkg/kubernetes/views/add-role-dialog.html.h:4
-msgid "Add"
-msgstr "Hinzufügen"
-
-#: pkg/storaged/details.js:625 pkg/storaged/details.js:821
-#: pkg/storaged/details.js:1016 pkg/docker/details.js:271
-#: pkg/docker/image.js:151 pkg/docker/containers-view.jsx:166
-msgid "Please confirm deletion of $0"
-msgstr "Bitte bestätigen Sie das Löschen von $0"
-
-#: pkg/storaged/details.js:630 pkg/storaged/details.js:827
-#: pkg/storaged/details.js:1022 pkg/storaged/details.js:1151
-#: pkg/storaged/details.js:1616 pkg/storaged/details.js:1776
-#: pkg/docker/details.js:273 pkg/docker/image.js:153
-#: pkg/docker/containers-view.jsx:168 pkg/kubernetes/scripts/volumes.js:218
-#: pkg/users/index.html.h:9 pkg/kubernetes/views/node-delete.html.h:5
-#: pkg/kubernetes/views/pvc-delete.html.h:5
-#: pkg/kubernetes/views/image-delete.html.h:4
-#: pkg/kubernetes/views/pv-delete.html.h:5
-#: pkg/kubernetes/views/item-delete.html.h:5
-#: pkg/kubernetes/views/imagestream-delete.html.h:4
-#: pkg/kubernetes/views/user-remove-membership.html.h:3
-#: pkg/kubernetes/views/project-delete.html.h:3
-msgid "Delete"
-msgstr "Löschen"
-
-#: pkg/storaged/details.js:631
-msgid "Deleting a RAID device will erase all data on it."
-msgstr "Das Löschen eines RAID-Gerätes löscht alle darauf vorhandenen Daten."
-
-#: pkg/storaged/details.js:661
-msgid "Resize Logical Volume"
-msgstr "Größe eines logischen Datenträgers ändern"
-
-#: pkg/storaged/details.js:673
-msgid "Resize Filesystem"
-msgstr "Größe des Dateisystems ändern"
-
-#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
-msgid "Resize"
-msgstr "Größe ändern"
-
-#: pkg/storaged/details.js:690
-msgid "This logical volume cannot be made smaller."
-msgstr ""
-
-#: pkg/storaged/details.js:706
-msgid "Renamee Logical Volume"
-msgstr "Logischen Datenträger umbennen"
-
-#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
-#: pkg/storaged/details.js:1775
-msgid "Rename"
-msgstr "Umbenennen"
-
-#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
-msgid "Create Snapshot"
-msgstr "Snapshot erzeugen"
-
-#: pkg/storaged/details.js:745 pkg/storaged/details.js:781
-#: pkg/storaged/details.js:804 pkg/storaged/details.js:915
-#: pkg/storaged/overview.js:461 pkg/storaged/overview.js:506
-#: pkg/kubernetes/views/add-group-dialog.html.h:6
-#: pkg/kubernetes/views/project-modify.html.h:8
-msgid "Create"
-msgstr "Erstellen"
-
-#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
-msgid "Create Thin Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:795
-msgid "Rename Volume Group"
-msgstr "Datenträgerverbund umbennen"
-
-#: pkg/storaged/details.js:826
-msgid "Deleting a volume group will erase all data on it."
-msgstr ""
-"Das Löschen eines Datenträgerverbunds löscht alle sich darin befindenden "
-"Daten."
-
-#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
-msgid "Create Logical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:869
-msgid "Purpose"
-msgstr ""
-
-#: pkg/storaged/details.js:871
-msgid "Block device for filesystems"
-msgstr ""
-
-#: pkg/storaged/details.js:874
-msgid "Pool for thinly provisioned volumes"
-msgstr ""
-
-#: pkg/storaged/details.js:1009
-msgid "Deleting a logical volume will delete all data in it."
-msgstr ""
-
-#: pkg/storaged/details.js:1012
-msgid "Deleting a partition will delete all data in it."
-msgstr ""
-
-#: pkg/storaged/details.js:1053 pkg/storaged/overview.js:689
-#: pkg/storaged/devices.js:119 pkg/users/local.js:1155
-#: pkg/systemd/services.html.h:14
-msgid "Error"
-msgstr "Fehler"
-
-#: pkg/storaged/details.js:1099
-msgid "Mount"
-msgstr "Einhängen"
-
-#: pkg/storaged/details.js:1100
-msgid "Unmount"
-msgstr "Aushängen"
-
-#: pkg/storaged/details.js:1109
-msgid "Lock"
-msgstr "Schließen"
-
-#: pkg/storaged/details.js:1127
-msgid "Activate"
-msgstr "Aktivieren"
-
-#: pkg/storaged/details.js:1130
-msgid "Deactivate"
-msgstr "Deaktivieren"
-
-#: pkg/storaged/details.js:1221
-msgctxt "storage-id-desc"
-msgid "$0 File System"
-msgstr "$0 Dateisystem"
-
-#: pkg/storaged/details.js:1224
-msgctxt "storage-id-desc"
-msgid "Linux MD-RAID Component"
-msgstr "Linux MD-RAID Komponente"
-
-#: pkg/storaged/details.js:1226
-msgctxt "storage-id-desc"
-msgid "LVM2 Physical Volume"
-msgstr "LVM2 Physikalischer Behälter"
-
-#: pkg/storaged/details.js:1228
-msgctxt "storage-id-desc"
-msgid "RAID Member"
-msgstr "RAID Mitglied"
-
-#: pkg/storaged/details.js:1245
-msgctxt "storage-id-desc"
-msgid "LUKS Encrypted"
-msgstr "LUKS Verschlüsselt"
-
-#: pkg/storaged/details.js:1247
-msgctxt "storage-id-desc"
-msgid "Encrypted"
-msgstr "Verschlüsselt"
-
-#: pkg/storaged/details.js:1251
-msgctxt "storage-id-desc"
-msgid "Swap Space"
-msgstr "Auslagerungsspeicher"
-
-#: pkg/storaged/details.js:1253
-msgctxt "storage-id-desc"
-msgid "Other Data"
-msgstr "Andere Daten"
-
-#: pkg/storaged/details.js:1256
-msgctxt "storage-id-desc"
-msgid "Unrecognized Data"
-msgstr "Unerkannte Daten"
-
-#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
-msgid "$size $partition"
-msgstr "$size $partition"
-
-#: pkg/storaged/details.js:1278
-msgid "mounted on $0"
-msgstr "eingehängt auf $0"
-
-#: pkg/storaged/details.js:1280
-msgid "not mounted"
-msgstr "nicht eingehängt"
-
-#: pkg/storaged/details.js:1284
-msgid "unlocked"
-msgstr "offen"
-
-#: pkg/storaged/details.js:1286
-msgid "locked"
-msgstr "verschlossen"
-
-#: pkg/storaged/details.js:1367
-msgid "$0 Free Space for Logical Partitions"
-msgstr ""
-
-#: pkg/storaged/details.js:1370
-msgid "$0 Free Space for Primary Partitions"
-msgstr ""
-
-#: pkg/storaged/details.js:1375
-msgid "$0 Free Space"
-msgstr "$0 freier Speicherplatz"
-
-#: pkg/storaged/details.js:1379
-msgid "Create Partition"
-msgstr "Partition erzeugen"
-
-#: pkg/storaged/details.js:1387
-msgid "$0 Extended Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1424
-msgid "Logical Partition"
-msgstr "Logische Partition"
-
-#: pkg/storaged/details.js:1426
-msgid "Primary Partition"
-msgstr "Primäre Partition"
-
-#: pkg/storaged/details.js:1428 pkg/kubernetes/views/volume-body.html.h:5
-msgid "Partition"
-msgstr "Partition"
-
-#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
-msgid "Content"
-msgstr "Inhalt"
-
-#: pkg/storaged/details.js:1533
-msgid "RAID 0"
-msgstr "RAID 0"
-
-#: pkg/storaged/details.js:1534
-msgid "RAID 1"
-msgstr "RAID 1"
-
-#: pkg/storaged/details.js:1535
-msgid "RAID 4"
-msgstr "RAID 4"
-
-#: pkg/storaged/details.js:1536
-msgid "RAID 5"
-msgstr "RAID 5"
-
-#: pkg/storaged/details.js:1537
-msgid "RAID 6"
-msgstr "RAID 6"
-
-#: pkg/storaged/details.js:1538
-msgid "RAID 10"
-msgstr "RAID 10"
-
-#: pkg/storaged/details.js:1539
-msgid "RAID ($0)"
-msgstr "RAID ($0)"
-
-#: pkg/storaged/details.js:1544
-msgid "$0 Disks"
-msgstr "$0 Datenträger"
-
-#: pkg/storaged/details.js:1546
-msgid "$0 Chunk Size"
-msgstr "$0 Chunk Size"
-
-#: pkg/storaged/details.js:1574 pkg/ostree/index.html.h:7
-msgid "Running"
-msgstr "Läuft"
-
-#: pkg/storaged/details.js:1574
-msgid "Not running"
-msgstr "Läuft nicht"
-
-#: pkg/storaged/details.js:1592
-msgid "FAILED"
-msgstr "KAPUTT"
-
-#: pkg/storaged/details.js:1593
-msgid "In Sync"
-msgstr "Synchron"
-
-#: pkg/storaged/details.js:1594
-msgid "Spare"
-msgstr "Ersatz"
-
-#: pkg/storaged/details.js:1594
-msgid "Recovering"
-msgstr "Am Erholen"
-
-#: pkg/storaged/details.js:1595
-msgid "Write-mostly"
-msgstr "Hauptsächlich Schreiben"
-
-#: pkg/storaged/details.js:1596
-msgid "Blocked"
-msgstr "Gesperrt"
-
-#: pkg/storaged/details.js:1597
-msgid "Unknown ($0)"
-msgstr "Unbekannt ($0)"
-
-#: pkg/storaged/details.js:1614
-msgid "Start Scrubbing"
-msgstr "Schrubben Starten"
-
-#: pkg/storaged/details.js:1615
-msgid "Stop Scrubbing"
-msgstr "Schrubben Stoppen"
+#: pkg/storaged/utils.js:157
+msgid "$name (from $host)"
+msgstr "$name (von $host)"
 
 #: pkg/storaged/details.js:1653
 msgid "$size $desc"
@@ -1480,217 +560,2815 @@ msgstr ""
 msgid "$size $desc<br/>($state)"
 msgstr ""
 
-#: pkg/storaged/details.js:1692
-msgid "active, but unsupported"
-msgstr "aktiv, aber nicht unterstützt"
+#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
+msgid "$size $partition"
+msgstr "$size $partition"
 
-#: pkg/storaged/details.js:1692
-msgid "inactive"
-msgstr "Inaktiv"
+#: pkg/docker/details.js:144
+msgid "${hip}:${hport} -> $cport"
+msgstr "${hip}:${hport} -> $cport"
 
-#: pkg/storaged/details.js:1711
-msgid "$0 Free Space for Logical Volumes"
+#: pkg/subscriptions/subscriptions-client.js:198
+msgid "'Organization' required to register."
 msgstr ""
 
-#: pkg/storaged/details.js:1751
-msgid "The last physical volume of a volume group cannot be removed."
+#: pkg/subscriptions/subscriptions-client.js:202
+msgid "'Organization' required when using activation keys."
 msgstr ""
 
-#: pkg/storaged/details.js:1756
-msgid ""
-"There is not enough free space elsewhere to remove this physical volume.  At "
-"least $0 more free space is needed."
+#: pkg/shell/base_index.js:674
+msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
+msgstr "(<b>Ctrl-Shift-J</b> in den meisten Browsern)."
+
+#: pkg/storaged/overview.js:440
+msgid "1 MiB"
 msgstr ""
 
-#: pkg/storaged/details.js:1765
-msgid "$0, $1 free"
-msgstr ""
+#: pkg/systemd/index.html:459 pkg/systemd/index.html:463
+msgid "1 Minute"
+msgstr "1 Minute"
 
-#: pkg/storaged/details.js:1792
-msgid "Logical Volumes"
-msgstr ""
+#: pkg/storaged/index.html:312 pkg/networkmanager/index.html:55
+#: pkg/networkmanager/index.html:501
+msgid "1 day"
+msgstr "1 Tag"
 
-#: pkg/storaged/details.js:1822 pkg/docker/details.js:177
-#: pkg/docker/image.js:112
-msgid "Not found"
-msgstr "Nicht gefunden"
+#: pkg/storaged/index.html:310 pkg/networkmanager/index.html:53
+#: pkg/networkmanager/index.html:499
+msgid "1 hour"
+msgstr "1 Stunde"
 
-#: pkg/storaged/overview.js:180
-msgctxt "storage"
-msgid "Hard Disk"
-msgstr "Festplatte"
+#: pkg/storaged/index.html:313 pkg/networkmanager/index.html:56
+#: pkg/networkmanager/index.html:502
+msgid "1 week"
+msgstr "1 Woche"
 
-#: pkg/storaged/overview.js:182
-msgctxt "storage"
-msgid "Solid-State Disk"
-msgstr "Solid-State Datenträger"
+#: pkg/playground/translate.html:190
+#, fuzzy
+msgid "1% Free"
+msgid_plural "{{$count}}% Free"
+msgstr[0] "Verfügbar"
+msgstr[1] "Verfügbar"
 
-#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
-msgctxt "storage"
-msgid "Removable Drive"
-msgstr "Entfernbares Speichergerät"
-
-#: pkg/storaged/overview.js:189
-msgctxt "storage"
-msgid "Optical Drive"
-msgstr "Optisches Speichergerät"
-
-#: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
-msgctxt "storage"
-msgid "Drive"
-msgstr "Speichergerät"
-
-#: pkg/storaged/overview.js:253
-msgid "$0 Block Device"
-msgstr "$0 blockorientiertes Gerät"
-
-#: pkg/storaged/overview.js:414
-msgid "Create RAID Device"
-msgstr "RAID-Gerät erzeugen"
-
-#: pkg/storaged/overview.js:420
-msgid "RAID Level"
-msgstr "RAID Ebene"
-
-#: pkg/storaged/overview.js:422
-msgid "RAID 0 (Stripe)"
-msgstr "RAID 0 (Gestreift)"
-
-#: pkg/storaged/overview.js:423
-msgid "RAID 1 (Mirror)"
-msgstr "RAID 1 (Gespiegelt)"
-
-#: pkg/storaged/overview.js:424
-msgid "RAID 4 (Dedicated Parity)"
-msgstr "RAID 4 (Dedizierte Parität)"
-
-#: pkg/storaged/overview.js:425
-msgid "RAID 5 (Distributed Parity)"
-msgstr "RAID 5 (Verteilte Parität)"
-
-#: pkg/storaged/overview.js:426
-msgid "RAID 6 (Double Distributed Parity)"
-msgstr "RAID 6 (Doppelt Verteilte Parität)"
-
-#: pkg/storaged/overview.js:427
-msgid "RAID 10 (Stripe of Mirrors)"
-msgstr "RID 10 (Gestreifte Spiegel)"
-
-#: pkg/storaged/overview.js:431
-msgid "Chunk Size"
-msgstr "Happengröße"
-
-#: pkg/storaged/overview.js:433
-msgid "4 KiB"
-msgstr ""
-
-#: pkg/storaged/overview.js:434
-msgid "8 KiB"
+#: pkg/storaged/overview.js:438
+msgid "128 KiB"
 msgstr ""
 
 #: pkg/storaged/overview.js:435
 msgid "16 KiB"
 msgstr ""
 
+#: pkg/storaged/overview.js:441
+msgid "2 MiB"
+msgstr ""
+
+#: pkg/systemd/index.html:465
+msgid "20 Minutes"
+msgstr "20 Minuten"
+
 #: pkg/storaged/overview.js:436
 msgid "32 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:437
-msgid "64 KiB"
+#: pkg/storaged/overview.js:433
+msgid "4 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:438
-msgid "128 KiB"
-msgstr ""
+#: pkg/systemd/index.html:466
+msgid "40 Minutes"
+msgstr "40 Minuten"
+
+#: pkg/systemd/index.html:464
+msgid "5 Minutes"
+msgstr "5 Minuten"
+
+#: pkg/storaged/index.html:309 pkg/networkmanager/index.html:52
+#: pkg/networkmanager/index.html:498
+msgid "5 minutes"
+msgstr "5 Minuten"
 
 #: pkg/storaged/overview.js:439
 msgid "512 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:440
-msgid "1 MiB"
+#: pkg/storaged/index.html:311 pkg/networkmanager/index.html:54
+#: pkg/networkmanager/index.html:500
+msgid "6 hours"
+msgstr "6 Stunden"
+
+#: pkg/systemd/index.html:467
+msgid "60 Minutes"
+msgstr "60 Minuten"
+
+#: pkg/storaged/overview.js:437
+msgid "64 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:441
-msgid "2 MiB"
+#: pkg/storaged/overview.js:434
+msgid "8 KiB"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1826
+msgid "802.3ad"
+msgstr "802.3ad"
+
+#: pkg/networkmanager/interfaces.js:1843
+#, fuzzy
+msgid "802.3ad LACP"
+msgstr "802.3ad"
+
+#: pkg/systemd/services.html:446
+msgid ":"
+msgstr ""
+
+#: pkg/storaged/utils.js:220
+msgid "<span>Encrypted $0</span>"
+msgstr ""
+
+#: pkg/storaged/utils.js:212
+msgid "<span>Encrypted Logical Volume of $0</span>"
+msgstr "<span>Verschlüsselter logischer Datenträger von $0</span>"
+
+#: pkg/storaged/utils.js:214
+msgid "<span>Encrypted Partition of $0</span>"
+msgstr ""
+
+#: pkg/storaged/utils.js:216
+msgid "<span>Logical Volume of $0</span>"
+msgstr ""
+
+#: pkg/storaged/utils.js:218
+msgid "<span>Partition of $0</span>"
+msgstr ""
+
+#: pkg/lib/machine-not-supported.html:5
+msgid ""
+"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
+"strong}}."
+msgstr ""
+
+#: cockpit.desktop.in.h:2
+msgid "A user interface for GNU/Linux servers"
+msgstr "Eine Benutzerschnittstelle für GNU/Linux Server"
+
+#: pkg/networkmanager/interfaces.js:1834
+msgid "ARP"
+msgstr "ARP"
+
+#: pkg/networkmanager/interfaces.js:2502
+msgid "ARP Monitoring"
+msgstr "ARP-Überwachung"
+
+#: pkg/networkmanager/interfaces.js:1855
+#, fuzzy
+msgid "ARP Ping"
+msgstr "ARP-Überwachung"
+
+#: pkg/kubernetes/scripts/volumes.js:193
+msgid "AWS Elastic Block Store"
+msgstr ""
+
+#: pkg/shell/simple.html:41 pkg/shell/simple.html:67 pkg/shell/index.html:41
+#: pkg/shell/index.html:80 pkg/shell/stub.html:41 pkg/shell/stub.html:73
+msgid "About Cockpit"
+msgstr "Über Cockpit"
+
+#: pkg/users/index.html:105 pkg/users/index.html:191
+msgid "Access"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pv-claim.html:9
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-body.html:9
+msgid "Access Modes"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:49
+#: pkg/kubernetes/views/imagestream-body.html:11
+msgid "Access Policy"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:191
+msgid "Access denied"
+msgstr ""
+
+#: pkg/shell/index.html:45
+msgid "Account Settings"
+msgstr "Kontoeinstellungen"
+
+#: pkg/users/index.html:63
+msgid "Account not available or cannot be edited."
+msgstr ""
+
+#: pkg/users/index.html:71
+msgid "Accounts"
+msgstr ""
+
+#: pkg/users/local.js:284 pkg/users/local.js:594
+msgctxt "page-title"
+msgid "Accounts"
+msgstr "Konten"
+
+#: pkg/storaged/details.js:1127
+msgid "Activate"
+msgstr "Aktivieren"
+
+#: pkg/storaged/jobs.js:148
+msgid "Activating $target"
+msgstr "Aktiviere $target"
+
+#: pkg/subscriptions/subscriptions-register.jsx:164
+#, fuzzy
+msgid "Activation Key"
+msgstr "Aktivieren"
+
+#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
+msgid "Active"
+msgstr "Aktiv"
+
+#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
+msgid "Active Backup"
+msgstr "Aktive Sicherung"
+
+#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
+msgid "Actual"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1828
+msgid "Adaptive load balancing"
+msgstr "Adaptives Load Balancing (alb)"
+
+#: pkg/networkmanager/interfaces.js:1827
+msgid "Adaptive transmit load balancing"
+msgstr "Adaptives Transmit Load Balancing (tlb)"
+
+#: pkg/kubernetes/views/add-user-dialog.html:31
+#: pkg/kubernetes/views/node-add.html:50
+#: pkg/kubernetes/views/user-add-membership.html:53
+#: pkg/kubernetes/views/add-member-role-dialog.html:61
+#: pkg/kubernetes/views/user-group-add.html:32
+#: pkg/kubernetes/views/add-role-dialog.html:8 pkg/lib/machine-add.html:43
+msgid "Add"
+msgstr "Hinzufügen"
+
+#: pkg/networkmanager/interfaces.js:2836
+msgid "Add $0"
+msgstr ""
+
+#: pkg/docker/storage.jsx:363
+msgid "Add Additional Storage"
+msgstr ""
+
+#: pkg/networkmanager/index.html:86
+msgid "Add Bond"
+msgstr "Bündelung hinzufügen"
+
+#: pkg/networkmanager/index.html:88
+msgid "Add Bridge"
+msgstr "Bridge hinzufügen"
+
+#: pkg/kubernetes/views/node-add.html:3
+msgid "Add Cluster Node"
+msgstr ""
+
+#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
+msgid "Add Disks"
+msgstr "Datenträger hinzufügen"
+
+#: pkg/kubernetes/views/add-group-dialog.html:3
+msgid "Add Group"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:34
+msgid "Add Kubernetes Node"
+msgstr ""
+
+#: pkg/lib/machine-add.html:4
+msgid "Add Machine to Dashboard"
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:38
+#: pkg/kubernetes/views/add-member-role-dialog.html:4
+#: pkg/kubernetes/views/group-panel.html:29
+#: pkg/kubernetes/views/user-group-add.html:3
+#: pkg/kubernetes/views/project-body.html:108
+msgid "Add Member"
+msgstr ""
+
+#: pkg/kubernetes/views/user-panel.html:76
+#: pkg/kubernetes/views/user-body.html:67
+msgid "Add Membership"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:11
+#: pkg/kubernetes/views/auth-form.html:20
+msgid "Add New Cluster"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:67
+#: pkg/kubernetes/views/auth-form.html:76
+msgid "Add New User"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:3
+msgid "Add Role"
+msgstr ""
+
+#: pkg/networkmanager/index.html:87
+msgid "Add Team"
+msgstr ""
+
+#: pkg/kubernetes/views/add-user-dialog.html:3
+#: pkg/kubernetes/views/project-listing.html:83
+msgid "Add User"
+msgstr ""
+
+#: pkg/networkmanager/index.html:89
+msgid "Add VLAN"
+msgstr "VLAN hinzufügen"
+
+#: pkg/storaged/overview.js:515
+msgid "Add iSCSI Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/user-add-membership.html:3
+msgid "Add membership"
+msgstr ""
+
+#: pkg/users/index.html:351
+msgid "Add public key"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2833
+msgid "Adding <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/users/authorized-keys.js:108
+msgid "Adding key"
+msgstr "Schlüssel wird hinzugefügt"
+
+#: pkg/storaged/jobs.js:153
+msgid "Adding physical volume to $target"
+msgstr "Füge physikalischen Datenträger zu $target hinzu"
+
+#: pkg/docker/index.html:329
+msgid "Additional Storage"
+msgstr ""
+
+#: pkg/ostree/index.html:121 pkg/ostree/index.html:140
+msgid "Additions"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:8
+#: pkg/kubernetes/views/dashboard-page.html:157
+#: pkg/kubernetes/views/details-page.html:174
+#: pkg/kubernetes/views/nodes-page.html:43
+#: pkg/kubernetes/views/auth-form.html:29 pkg/kubernetes/views/node-body.html:5
+#: pkg/lib/machine-add.html:11
+msgid "Address"
+msgstr "Adresse"
+
+#: pkg/kubernetes/views/details-page.html:37
+msgid "Addresses"
+msgstr "Adressen"
+
+#: pkg/kubernetes/views/service-modify.html:25
+msgid "Adjust"
+msgstr "Anpassen"
+
+#: pkg/kubernetes/views/pv-modify.html:3
+msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-modify.html:3
+msgid "Adjust Replication Controller {{ item.metadata.name }}"
+msgstr ""
+
+#: pkg/kubernetes/views/route-modify.html:3
+msgid "Adjust Route"
+msgstr ""
+
+#: pkg/kubernetes/views/service-modify.html:3
+msgid "Adjust Service"
+msgstr "Dienst anpassen"
+
+#: pkg/kubernetes/views/project-body.html:56
+msgid "Admin"
+msgstr ""
+
+#: pkg/systemd/services.html:389 pkg/systemd/services.html:393
+msgid "After system boot"
+msgstr ""
+
+#: pkg/systemd/logs.html:50
+msgid "All"
+msgstr "Alle"
+
+#: pkg/kubernetes/views/filter-project.html:4
+msgid "All Projects"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:6
+msgid "All Types"
+msgstr ""
+
+#: pkg/docker/storage.jsx:366
+msgid ""
+"All data on selected disks will be erased and disks will be added to the "
+"storage pool."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:112
+msgid "All healthy"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:74
+msgid "All images"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:69
+msgid "All in use"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:37
+msgid "All running"
+msgstr ""
+
+#: pkg/docker/index.html:569
+msgid "Always"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-meta.html:2
+#: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/image-meta.html:9
+#: pkg/kubernetes/views/node-body.html:57
+msgid "Annotations"
+msgstr ""
+
+#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
+msgid "Apply"
+msgstr "Anwenden"
+
+#: pkg/selinux/setroubleshoot-view.jsx:107
+msgid "Apply this solution"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:82
+msgid "Applying solution..."
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:12
+msgid "Architecture"
+msgstr ""
+
+#: pkg/storaged/index.html:451
+msgctxt "storage"
+msgid "Assessment"
+msgstr "Beurteilung"
+
+#: pkg/systemd/index.html:81
+msgid "Asset Tag"
 msgstr ""
 
 #: pkg/storaged/overview.js:455
 msgid "At least $0 disks are needed."
 msgstr "Mindestens $0 Datenträger sind nötig."
 
-#: pkg/storaged/overview.js:487
-msgid "Create Volume Group"
-msgstr "Datenträgerverbund erstellen"
+#: pkg/storaged/overview.js:501 pkg/storaged/details.js:579
+#: pkg/storaged/details.js:948
+msgid "At least one disk is needed."
+msgstr "Mindestens ein Datenträger ist nötig."
 
-#: pkg/storaged/overview.js:515
-msgid "Add iSCSI Portal"
+#: pkg/systemd/services.html:394
+msgid "At specific time"
 msgstr ""
 
-#: pkg/storaged/overview.js:518
-msgid "Server Address"
+#: pkg/networkmanager/interfaces.js:813
+msgid "Authenticating"
+msgstr "Authentifiziere"
+
+#: pkg/realmd/operation.html:34 pkg/shell/index.html:48
+#: pkg/shell/index.html:159 pkg/kubernetes/views/auth-form.html:85
+#: pkg/lib/machine-change-auth.html:32
+msgid "Authentication"
+msgstr "Authentifizierung"
+
+#: pkg/lib/machine-auth-failed.html:2
+msgid "Authentication Failed"
 msgstr ""
 
-#: pkg/storaged/overview.js:521
-#, fuzzy
-msgid "Server address cannot be empty."
-msgstr "Name darf nicht leer sein."
+#: pkg/docker/index.html:730 pkg/kubernetes/views/image-body.html:12
+#: pkg/kubernetes/views/image-listing.html:15
+msgid "Author"
+msgstr "Autor"
 
-#: pkg/storaged/overview.js:533 pkg/realmd/operation.html.h:11
-msgid "Next"
-msgstr "Weiter"
+#: pkg/users/index.html:130
+msgid "Authorized Public SSH Keys"
+msgstr "Autorisierte öffentliche SSH-Schlüssel"
 
-#: pkg/storaged/overview.js:577 pkg/storaged/overview.js:668
-#: pkg/subscriptions/subscriptions-client.js:194
-msgid "Invalid username or password"
+#: pkg/networkmanager/index.html:165
+msgid "Automatic"
+msgstr "Automatisch"
+
+#: pkg/networkmanager/interfaces.js:1814
+msgid "Automatic (DHCP only)"
+msgstr "Automatisch (nur DHCP)"
+
+#: pkg/networkmanager/interfaces.js:1804
+msgid "Automatic (DHCP)"
+msgstr "Automatisch (DHCP)"
+
+#: pkg/systemd/index.html:406
+msgid "Automatically using NTP"
 msgstr ""
 
-#: pkg/storaged/overview.js:582
-msgid "Unknown host name"
+#: pkg/systemd/index.html:407
+msgid "Automatically using specific NTP servers"
 msgstr ""
 
-#: pkg/storaged/overview.js:586
-msgid "Unable to reach server"
+#: pkg/lib/machine-change-auth.html:66
+msgid "Available"
 msgstr ""
 
 #: pkg/storaged/overview.js:619
 msgid "Available targets on $0"
 msgstr ""
 
-#: pkg/storaged/overview.js:623 pkg/systemd/services.html.h:2
-msgid "Targets"
+#: pkg/dashboard/index.html:177
+msgid "Avatar"
 msgstr ""
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-add.html.h:2
-#: pkg/kubernetes/views/node-body.html.h:2
-#: pkg/kubernetes/views/auth-form.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:16
-#: pkg/kubernetes/views/nodes-page.html.h:7
-#: pkg/kubernetes/views/details-page.html.h:19
-msgid "Address"
-msgstr "Adresse"
+#: pkg/kubernetes/scripts/volumes.js:207
+msgid "Azure"
+msgstr ""
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-change-port.html.h:5
-msgid "Port"
+#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
+msgid "Bad data passed for passwd1 mechanism"
+msgstr "Fehlerhafte Daten an passwd1 Mechanismus übergeben"
+
+#: pkg/networkmanager/index.html:389
+msgid "Balancer"
+msgstr ""
+
+#: pkg/storaged/index.html:560
+msgctxt "storage"
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: pkg/storaged/index.html:414
+msgid "Block Device"
+msgstr ""
+
+#: pkg/storaged/details.js:871
+msgid "Block device for filesystems"
+msgstr ""
+
+#: pkg/storaged/details.js:1596
+msgid "Blocked"
+msgstr "Gesperrt"
+
+#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
+#: pkg/networkmanager/interfaces.js:2507
+msgid "Bond"
+msgstr "Bond"
+
+#: pkg/networkmanager/index.html:596
+msgid "Bond Settings"
+msgstr "Bond Einstellungen"
+
+#: pkg/kubernetes/views/node-body.html:17
+msgid "Boot ID"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
+#: pkg/networkmanager/interfaces.js:2584
+msgid "Bridge"
+msgstr "Brücke"
+
+#: pkg/networkmanager/index.html:708
+msgid "Bridge Port Settings"
+msgstr "Bridge Port Einstellungen"
+
+#: pkg/networkmanager/index.html:680
+msgid "Bridge Settings"
+msgstr "Bridge Einstellungen"
+
+#: pkg/networkmanager/interfaces.js:2605
+msgid "Bridge port"
+msgstr "Bridge-Port"
+
+#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
+msgid "Broadcast"
+msgstr "Broadcast"
+
+#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#, fuzzy
+msgid "Broken configuration"
+msgstr "Unbekannte Konfiguration"
+
+#: pkg/kubernetes/views/image-body.html:16
+msgid "Built"
+msgstr ""
+
+#: pkg/dashboard/index.html:70
+msgid "CPU"
+msgstr "CPU"
+
+#: pkg/systemd/host.js:1381
+msgctxt "page-title"
+msgid "CPU Status"
+msgstr "CPU Status"
+
+#: pkg/kubernetes/scripts/nodes.js:712
+msgid "CPU Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:490 pkg/docker/index.html:669
+msgid "CPU priority"
+msgstr "CPU Priorität"
+
+#: pkg/systemd/index.html:247
+msgid "Cached"
+msgstr ""
+
+#: pkg/docker/index.html:63
+msgid "Can&rsquo;t connect to Docker"
+msgstr ""
+
+#: pkg/systemd/services.html:465 pkg/dashboard/index.html:189
+#: pkg/playground/translate.html:40 pkg/playground/translate.html:174
+#: pkg/realmd/operation.html:90 pkg/kubernetes/views/pv-modify.html:202
+#: pkg/kubernetes/views/item-delete.html:10
+#: pkg/kubernetes/views/add-user-dialog.html:30
+#: pkg/kubernetes/views/project-modify.html:71
+#: pkg/kubernetes/views/node-add.html:49
+#: pkg/kubernetes/views/pvc-delete.html:14
+#: pkg/kubernetes/views/node-delete.html:14
+#: pkg/kubernetes/views/imagestream-modify.html:96
+#: pkg/kubernetes/views/imagestream-delete.html:7
+#: pkg/kubernetes/views/user-modify.html:30
+#: pkg/kubernetes/views/add-group-dialog.html:20
+#: pkg/kubernetes/views/project-delete.html:8
+#: pkg/kubernetes/views/service-modify.html:24
+#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/kubernetes/views/user-group-remove.html:9
+#: pkg/kubernetes/views/user-add-membership.html:52
+#: pkg/kubernetes/views/add-member-role-dialog.html:60
+#: pkg/kubernetes/views/group-delete.html:20
+#: pkg/kubernetes/views/image-delete.html:7 pkg/kubernetes/views/deploy.html:61
+#: pkg/kubernetes/views/user-group-add.html:31
+#: pkg/kubernetes/views/auth-form.html:128
+#: pkg/kubernetes/views/auth-rejected-cert.html:31
+#: pkg/kubernetes/views/replicationcontroller-modify.html:16
+#: pkg/kubernetes/views/pv-delete.html:10
+#: pkg/kubernetes/views/add-role-dialog.html:7
+#: pkg/kubernetes/views/route-modify.html:16
+#: pkg/kubernetes/views/user-delete.html:24
+#: pkg/kubernetes/views/remove-role-dialog.html:7 pkg/storaged/index.html:289
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:79
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: pkg/shell/indexes.js:322
+msgid "Cannot connect to an unknown machine"
+msgstr "Kann nicht zu einer unbekannten Maschine verbinden"
+
+#: src/ws/cockpitcertificate.c:359
+msgid "Cannot decrypt PEM-encoded private key"
+msgstr ""
+
+#: src/base1/cockpit.js:3707
+msgid "Cannot forward login credentials"
+msgstr ""
+
+#: pkg/realmd/operation.js:417
+msgid "Cannot join a domain because realmd is not available on this system"
+msgstr ""
+"Es konnte keiner Domain beigetreten werden, da realmd auf diesem System "
+"nicht verfügbar ist."
+
+#: pkg/kubernetes/views/pv-modify.html:44
+#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pv-body.html:13
+msgid "Capacity"
+msgstr ""
+
+#: pkg/storaged/index.html:443 pkg/storaged/index.html:519
+#: pkg/storaged/index.html:551 pkg/storaged/index.html:630
+msgctxt "storage"
+msgid "Capacity"
+msgstr "Kapazität"
+
+#: pkg/networkmanager/interfaces.js:2276
+msgid "Carrier"
+msgstr "Träger"
+
+#: pkg/kubernetes/scripts/volumes.js:203
+msgid "Ceph Filesystem Mount"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:97
+msgid "Ceph Monitors"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:204
+#: pkg/kubernetes/views/project-modify.html:74
+#: pkg/kubernetes/views/replicationcontroller-modify.html:17
+#: pkg/kubernetes/views/route-modify.html:17
+msgid "Change"
+msgstr ""
+
+#: pkg/shell/index.html:278
+msgid "Change Password"
+msgstr ""
+
+#: pkg/tuned/dialog.js:191
+msgid "Change Performance Profile"
+msgstr ""
+
+#: pkg/tuned/dialog.js:200
+msgid "Change Profile"
+msgstr ""
+
+#: pkg/kubernetes/views/user-modify.html:3
+msgid "Change User"
 msgstr ""
 
 #: pkg/storaged/overview.js:699
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
-#: pkg/storaged/overview.js:707 pkg/kubernetes/views/route-modify.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:22
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:4
-#: pkg/kubernetes/views/project-modify.html.h:9
-msgid "Change"
+#: pkg/kubernetes/views/imagestream-modify.html:4
+msgid "Change image stream"
 msgstr ""
 
-#: pkg/storaged/utils.js:88
-msgctxt "format-bytes"
-msgid "bytes"
-msgstr "Bytes"
+#: pkg/kubernetes/views/project-modify.html:10
+msgid "Change project"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2872
+#, fuzzy
+msgid "Change the settings"
+msgstr "Bridge Port Einstellungen"
+
+#: pkg/networkmanager/interfaces.js:2870
+msgid "Changing the settings will break the connection to the server, "
+msgstr ""
+
+#: pkg/ostree/index.html:48
+msgid "Check for updates"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:817
+msgid "Checking IP"
+msgstr "IP wird überprüft"
+
+#: pkg/storaged/jobs.js:143
+#, fuzzy
+msgid "Checking RAID Device $target"
+msgstr "Erzeuge RAID-Gerät $target"
+
+#: pkg/storaged/jobs.js:144
+#, fuzzy
+msgid "Checking and Repairing RAID Device $target"
+msgstr "Erzeuge RAID-Gerät $target"
+
+#: pkg/lib/machine-change-auth.html:70
+msgid "Checking for public keys"
+msgstr ""
+
+#: pkg/ostree/app.js:219
+msgid "Checking for updates"
+msgstr ""
+
+#: pkg/shell/simple.html:100 pkg/shell/index.html:121 pkg/shell/stub.html:114
+msgid "Choose the language to be used in the application"
+msgstr "Wählen Sie die in der Applikation zu verwendende Sprache"
+
+#: pkg/storaged/overview.js:431
+msgid "Chunk Size"
+msgstr "Happengröße"
+
+#: pkg/kubernetes/scripts/volumes.js:202
+msgid "Cinder"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
+msgid "Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:4
+msgid "Claim Name"
+msgstr ""
+
+#: pkg/storaged/jobs.js:135
+msgid "Cleaning up for $target"
+msgstr "$target wird aufgeräumt"
+
+#: pkg/kubernetes/views/auth-form.html:88
+msgid "Client Certificate"
+msgstr ""
+
+#: pkg/systemd/services.html:306 pkg/systemd/services.html:324
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-invalid-hostkey.html:19
+msgid "Close"
+msgstr "Schliessen"
+
+#: pkg/kubernetes/views/auth-form.html:5
+msgid "Cluster"
+msgstr ""
+
+#: cockpit.desktop.in.h:1
+msgid "Cockpit"
+msgstr "Cockpit"
+
+#: pkg/lib/machine-dialogs.js:429
+msgid ""
+"Cockpit could not contact the given host $0. Make sure it has ssh running on "
+"port $1, or specify another port in the address."
+msgstr ""
+
+#: src/base1/cockpit.js:3713
+msgid "Cockpit could not contact the given host."
+msgstr ""
+
+#: pkg/shell/base_index.js:671
+msgid "Cockpit had an unexpected internal error. <br/><br/>"
+msgstr "Cockpit hat einen internen Fehler festgestellt.<br/><br/>"
+
+#: cockpit.appdata.xml.in.h:1
+msgid ""
+"Cockpit is a server manager that makes it easy to administer your Linux "
+"servers via a web browser. Jumping between the terminal and the web tool is "
+"no problem. A service started via Cockpit can be stopped via the terminal. "
+"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
+"journal interface."
+msgstr ""
+"Cockpit ist ein Server Manager zur einfachen Verwaltung Ihrer Linux Server "
+"via Web Browser. Ein Wechsel zwischen dem Terminal und der Weboberfläche ist "
+"kein Problem. Ein Service, der via Cockpit gestartet wurde, kann im Terminal "
+"beendet werden. Genauso können Fehler, welche im Terminal vorkommen, im "
+"Cockpit Journal angezeigt werden."
+
+#: src/base1/cockpit.js:3711
+msgid "Cockpit is not compatible with the software on the system."
+msgstr ""
+
+#: pkg/lib/machine-not-supported.html:2
+msgid "Cockpit is not installed"
+msgstr ""
+
+#: src/base1/cockpit.js:3705
+msgid "Cockpit is not installed on the system."
+msgstr ""
+
+#: cockpit.appdata.xml.in.h:2
+msgid ""
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
+"tasks such as storage administration, inspecting journals and starting and "
+"stopping services. You can monitor and administer several servers at the "
+"same time. Just add them with a single click and your machines will look "
+"after its buddies."
+msgstr ""
+"Cockpit ist perfekt für neue Systemadministratoren, da es ihnen auf einfache "
+"Weise ermöglicht, simple Aufgaben wie Speicherverwaltung, Journal / Logfile "
+"Analyse oder das Starten und Stoppen von Diensten durchzuführen. Sie können "
+"gleichzeitig mehrere Server überwachen und verwalten. Fügen Sie weitere "
+"Maschinen mit einem Klick hinzu und Ihre Maschinen schauen zu ihren Kumpels."
+
+#: pkg/lib/machine-change-port.html:9
+msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:15
+msgid ""
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:9
+msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:6
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
+"machine with cockpit you will need to enable one of the following "
+"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:13
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
+"change your authentication credentials below. {{#can_sync}}You may prefer to "
+"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+msgstr ""
+
+#: pkg/dashboard/index.html:171 pkg/lib/machine-add.html:27
+msgid "Color"
+msgstr ""
+
+#: pkg/docker/index.html:95
+msgid "Combined CPU usage"
+msgstr ""
+
+#: pkg/docker/index.html:101
+msgid "Combined memory usage"
+msgstr ""
+
+#: pkg/systemd/services.html:370 pkg/docker/index.html:466
+#: pkg/docker/index.html:736
+msgid "Command"
+msgstr "Befehl"
+
+#: pkg/docker/run.js:332
+#, fuzzy
+msgid "Command can't be empty"
+msgstr "Name darf nicht leer sein."
+
+#: pkg/docker/containers-view.jsx:239
+#, fuzzy
+msgid "Commit"
+msgstr "Befehl"
+
+#: pkg/tuned/dialog.js:114
+msgid "Communication with tuned has failed"
+msgstr "Kommunikation mit tuned schlug fehl"
+
+#: pkg/storaged/details.js:348
+msgid "Compatible with all systems and devices (MBR)"
+msgstr "Kompatibel mit allen Systemen und Geräten (MBR)"
+
+#: pkg/storaged/details.js:349
+msgid "Compatible with modern system and hard disks > 2TB (GPT)"
+msgstr "Kompatibel mit modernen Systemen und Festplatten > 2TB (GPT)"
+
+#: pkg/realmd/operation.html:28
+msgid "Computer OU"
+msgstr "Computer OU"
+
+#: pkg/kubernetes/views/node-add.html:24
+msgid "Configuration"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2441
+msgid "Configure"
+msgstr "Konfigurieren"
+
+#: pkg/kubernetes/views/node-add.html:42
+msgid "Configure Flannel networking"
+msgstr "Flannel Netzwerk konfigurieren"
+
+#: pkg/kubernetes/views/node-add.html:32
+msgid "Configure Kubelet and Proxy"
+msgstr "Kubelet und Proxy konfigurieren"
+
+#: pkg/networkmanager/interfaces.js:811
+msgid "Configuring"
+msgstr "Konfiguriere"
+
+#: pkg/networkmanager/interfaces.js:815
+msgid "Configuring IP"
+msgstr "Konfiguriere IP"
+
+#: pkg/users/index.html:171 pkg/shell/index.html:262
+msgid "Confirm"
+msgstr "Bestätigen"
+
+#: pkg/users/index.html:247
+msgid "Confirm New Password"
+msgstr "Neues Passwort wiederholen"
+
+#: pkg/storaged/details.js:229
+msgid "Confirm passphrase"
+msgstr "Passphrase wiederholen"
+
+#: pkg/kubernetes/views/auth-form.html:130
+#: pkg/kubernetes/views/auth-rejected-cert.html:33
+#: pkg/lib/machine-unknown-hostkey.html:22
+msgid "Connect"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2637
+msgid "Connect automatically"
+msgstr "Verbindung automatisch herstellen"
+
+#: pkg/ostree/index.html:218
+msgid "Connecting"
+msgstr ""
+
+#: pkg/lib/machine-add.html:39
+msgid ""
+"Connecting simultaneously to more than {{ limit }} machines is unsupported."
+msgstr ""
+
+#: pkg/docker/index.html:54
+msgid "Connecting to Docker"
+msgstr "Verbinde zu Docker"
+
+#: pkg/shell/indexes.js:317
+msgid "Connecting to the machine"
+msgstr "Verbindung zur Maschine wird hergestellt"
+
+#: pkg/kubernetes/registry.html:70 pkg/kubernetes/index.html:100
+msgid "Connecting..."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-dialog.html:4
+msgid "Connection Error"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:516
+msgid "Connection Error: $0"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-dialog.html:3
+msgid "Connection Settings"
+msgstr ""
+
+#: src/base1/cockpit.js:3703
+msgid "Connection has timed out."
+msgstr ""
+
+#: pkg/networkmanager/index.html:812
+msgid "Connection will be lost"
+msgstr ""
+
+#: pkg/docker/console.html:4 pkg/kubernetes/views/container-panel.html:4
+#: pkg/kubernetes/views/image-panel.html:12
+#: pkg/kubernetes/views/container-body.html:4
+#: pkg/kubernetes/views/container-page-inline.html:2
+#: pkg/kubernetes/views/image-page.html:19
+msgid "Container"
+msgstr "Container"
+
+#: pkg/users/local.js:684
+msgid "Container Administrator"
+msgstr "Container Administrator"
+
+#: pkg/kubernetes/views/container-body.html:10
+msgid "Container ID"
+msgstr ""
+
+#: pkg/docker/index.html:459 pkg/docker/index.html:646
+#: pkg/docker/index.html:712
+msgid "Container Name"
+msgstr "Container Name"
+
+#: pkg/kubernetes/views/node-body.html:21
+msgid "Container Runtime Version"
+msgstr ""
+
+#: pkg/docker/util.js:490
+msgid ""
+"Container is currently marked as not running, but regular stopping failed."
+msgstr ""
+"Der Container ist zur Zeit als nicht als in Ausführung gekennzeichnet, das "
+"reguläre Anhalten schlug jedoch fehlt."
+
+#: pkg/docker/util.js:488
+msgid "Container is currently running."
+msgstr "Der Container läuft zur Zeit."
+
+#: pkg/docker/index.html:23 pkg/docker/index.html:309
+#: pkg/kubernetes/views/pod-page.html:36
+#: pkg/kubernetes/views/dashboard-page.html:158
+#: pkg/kubernetes/views/dashboard-page.html:199
+#: pkg/kubernetes/views/containers-listing.html:5 pkg/kubernetes/index.html:51
+msgid "Containers"
+msgstr "Containers"
+
+#: pkg/docker/details.js:47 pkg/docker/image.js:43
+msgctxt "page-title"
+msgid "Containers"
+msgstr "Containers"
+
+#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
+msgid "Content"
+msgstr "Inhalt"
+
+#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
+#: pkg/playground/translate.js:19
+#, fuzzy
+msgid "Control"
+msgstr "Steuerung"
+
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
+#: pkg/playground/translate.js:22
+msgctxt "key"
+msgid "Control"
+msgstr "Strg"
+
+#: pkg/docker/storage.jsx:404
+msgid "Could not add all disks"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:4
+msgid "Could not contact {{host}}"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:142
+msgid "Could not list services"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:407
+msgid "Could not parse PEM-encoded certificate"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:374
+msgid "Could not parse PEM-encoded private key"
+msgstr ""
+
+#: pkg/docker/storage.jsx:446
+msgid "Could not reset the storage pool"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:467
+msgid "Couldn't change user groups"
+msgstr "Benutzergruppen konnten nicht geändert werden"
+
+#: src/bridge/cockpitdbussetup.c:520
+msgid "Couldn't change user password"
+msgstr "Passwort konnte nicht geändert werden"
+
+#: pkg/selinux/setroubleshoot-view.jsx:385
+msgid ""
+"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
+"server is installed."
+msgstr ""
+
+#: pkg/kubernetes/registry.html:71 pkg/kubernetes/index.html:101
+msgid "Couldn't connect to server"
+msgstr ""
+
+#: pkg/shell/indexes.js:320
+msgid "Couldn't connect to the machine"
+msgstr "Verbindung zur Maschine konnte nicht hergstellt werden"
+
+#: src/bridge/cockpitdbussetup.c:544
+msgid "Couldn't create new users"
+msgstr "Neue Benutzer konnten nicht angelegt werden"
+
+#: pkg/kubernetes/scripts/connection.js:514
+msgid "Couldn't find running API server"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:196
+msgid ""
+"Couldn't get system subscription status. Please ensure subscription-manager "
+"is installed."
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:642
+msgid "Couldn't list local users"
+msgstr "Lokale Benutzer konnten nicht gelistet werden"
+
+#: src/bridge/cockpitdbussetup.c:236
+msgid "Couldn't list users"
+msgstr "Benutzer konnten nicht gelistet werden"
+
+#: src/bridge/cockpitdbussetup.c:382
+msgid "Couldn't load user data"
+msgstr "Benutzerdaten konnten nicht geladen werden"
+
+#: pkg/kubernetes/views/project-modify.html:72
+#: pkg/kubernetes/views/add-group-dialog.html:21
+msgid "Create"
+msgstr "Erstellen"
+
+#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
+msgid "Create Logical Volume"
+msgstr ""
+
+#: pkg/users/index.html:54 pkg/users/index.html:143
+msgid "Create New Account"
+msgstr ""
+
+#: pkg/storaged/details.js:1379
+msgid "Create Partition"
+msgstr "Partition erzeugen"
+
+#: pkg/storaged/overview.js:414
+msgid "Create RAID Device"
+msgstr "RAID-Gerät erzeugen"
+
+#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
+msgid "Create Snapshot"
+msgstr "Snapshot erzeugen"
+
+#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
+msgid "Create Thin Volume"
+msgstr ""
+
+#: pkg/systemd/services.html:336
+#, fuzzy
+msgid "Create Timers"
+msgstr "Erstellen"
+
+#: pkg/storaged/overview.js:487
+msgid "Create Volume Group"
+msgstr "Datenträgerverbund erstellen"
+
+#: pkg/sosreport/index.html:50
+msgid "Create diagnostic report"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:3
+msgid "Create image stream"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
+#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
+#, fuzzy
+msgid "Create it"
+msgstr "Erstellen"
+
+#: pkg/storaged/details.js:266
+msgid "Create partition"
+msgstr "Partition erzeugen"
+
+#: pkg/storaged/details.js:113
+msgid "Create partition on $0"
+msgstr "Partition auf $0 erzeugen"
+
+#: pkg/storaged/index.html:381
+msgid "Create partition table"
+msgstr ""
+
+#: pkg/sosreport/index.html:42
+msgid "Create report"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/replicationcontroller-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7 pkg/kubernetes/views/route-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3
+msgid "Created"
+msgstr ""
+
+#: pkg/storaged/jobs.js:142
+msgid "Creating RAID Device $target"
+msgstr "Erzeuge RAID-Gerät $target"
+
+#: pkg/storaged/jobs.js:130
+msgid "Creating filesystem on $target"
+msgstr "Dateisystem auf $0 wird erzeugt"
+
+#: pkg/storaged/jobs.js:156
+msgid "Creating logical volume $target"
+msgstr "Erzeuge logischen Datenträger $target"
+
+#: pkg/storaged/jobs.js:134
+msgid "Creating partition $target"
+msgstr "Erzeuge Partition $target"
+
+#: pkg/storaged/jobs.js:150
+msgid "Creating snapshot of $target"
+msgstr "Erzeuge Snapshot von $target"
+
+#: pkg/networkmanager/interfaces.js:4064
+msgid "Creating this VLAN will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3436
+msgid "Creating this bond will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3842
+msgid "Creating this bridge will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3611
+msgid "Creating this team will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:151
+msgid "Creating volume group $target"
+msgstr "Erzeuge Datenträgerverbund $target"
+
+#: pkg/systemd/logs.html:41
+msgid "Current boot"
+msgstr ""
+
+#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+#: pkg/storaged/details.js:186
+msgid "Custom (Enter filesystem type)"
+msgstr "Benutzerdefiniert (Geben Sie den Dateisystemtyp an)"
+
+#: pkg/subscriptions/subscriptions-register.jsx:102
+#, fuzzy
+msgid "Custom URL"
+msgstr "Benutzerdefiniert"
+
+#: pkg/storaged/index.html:454
+msgid "DISK IS FAILING"
+msgstr "Datenträger ist FEHLERHAFT"
+
+#: pkg/networkmanager/interfaces.js:3018
+msgid "DNS"
+msgstr "DNS"
+
+#: pkg/kubernetes/views/pod-body.html:14
+msgid "DNS Policy"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3022
+msgid "DNS Search Domains"
+msgstr "DNS Suchdomänen"
+
+#: pkg/dashboard/index.html:22
+msgid "Dashboard"
+msgstr ""
+
+#: pkg/storaged/details.js:1130
+msgid "Deactivate"
+msgstr "Deaktivieren"
+
+#: pkg/networkmanager/interfaces.js:823
+msgid "Deactivating"
+msgstr "Wird deaktiviert"
+
+#: pkg/storaged/jobs.js:149
+msgid "Deactivating $target"
+msgstr "Deaktiviere $target"
+
+#: pkg/docker/index.html:379 pkg/docker/index.html:383
+#: pkg/kubernetes/views/image-config.html:6
+msgid "Default"
+msgstr "Standard"
+
+#: pkg/systemd/index.html:454
+msgid "Delay"
+msgstr "Verzögerung"
+
+#: pkg/users/index.html:79 pkg/kubernetes/views/item-delete.html:11
+#: pkg/kubernetes/views/pvc-delete.html:15
+#: pkg/kubernetes/views/node-delete.html:15
+#: pkg/kubernetes/views/imagestream-delete.html:8
+#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/kubernetes/views/image-delete.html:8
+#: pkg/kubernetes/views/pv-delete.html:11
+msgid "Delete"
+msgstr "Löschen"
+
+#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
+msgid "Delete $0"
+msgstr "$0 löschen"
+
+#: pkg/users/index.html:292
+msgid "Delete Files"
+msgstr "Dateien löschen"
+
+#: pkg/kubernetes/views/node-delete.html:4
+msgid "Delete Node"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:3
+msgid "Delete Persistent Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:3
+msgid "Delete Persistent Volume Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/project-delete.html:3
+msgid "Delete Project"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:3
+msgid "Delete Selected"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:3
+msgid "Delete image stream"
+msgstr ""
+
+#: pkg/playground/translate.html:184 pkg/kubernetes/views/item-delete.html:3
+msgid "Delete {{ item.kind }}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
+msgid "Deleting $target"
+msgstr "Lösche $target"
+
+#: pkg/networkmanager/interfaces.js:2156
+msgid "Deleting <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:7
+msgid ""
+"Deleting a Pod will kill all associated containers. Pods may be "
+"automatically created again in some cases."
+msgstr ""
+
+#: pkg/storaged/details.js:631
+msgid "Deleting a RAID device will erase all data on it."
+msgstr "Das Löschen eines RAID-Gerätes löscht alle darauf vorhandenen Daten."
+
+#: pkg/docker/containers-view.jsx:167 pkg/docker/details.js:272
+msgid "Deleting a container will erase all data in it."
+msgstr ""
+"Das Löschen eines Containers entfernt alle sich darin befindlichen Daten."
+
+#: pkg/storaged/details.js:1009
+msgid "Deleting a logical volume will delete all data in it."
+msgstr ""
+
+#: pkg/storaged/details.js:1012
+msgid "Deleting a partition will delete all data in it."
+msgstr ""
+
+#: pkg/storaged/details.js:826
+msgid "Deleting a volume group will erase all data on it."
+msgstr ""
+"Das Löschen eines Datenträgerverbunds löscht alle sich darin befindenden "
+"Daten."
+
+#: pkg/docker/image.js:152
+msgid ""
+"Deleting an image will delete it, but you can probably download it again if "
+"you need it later.  Unless this image has never been pushed to a repository, "
+"that is, in which case you probably can't download it again."
+msgstr ""
+
+#: pkg/storaged/jobs.js:152
+msgid "Deleting volume group $target"
+msgstr "Lösche Datenträgerverbund ätarget"
+
+#: pkg/kubernetes/views/dashboard-page.html:131
+#: pkg/kubernetes/views/deploy.html:62
+msgid "Deploy"
+msgstr ""
+
+#: pkg/kubernetes/views/deploy.html:3
+msgid "Deploy Application"
+msgstr "Applikation installieren"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:22
+msgid "Deployment Causes"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-panel.html:8
+#: pkg/kubernetes/views/deploymentconfig-page.html:12
+msgid "Deployment Config"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:98
+msgid "Deployment Configs"
+msgstr ""
+
+#: pkg/systemd/services.html:356 pkg/kubernetes/views/project-modify.html:40
+#: pkg/kubernetes/views/image-body.html:6
+#: pkg/kubernetes/views/project-listing.html:15
+#: pkg/kubernetes/views/project-listing.html:54
+msgid "Description"
+msgstr ""
+
+#: pkg/shell/index.html:197 pkg/kubernetes/index.html:63
+msgid "Details"
+msgstr ""
+
+#: pkg/storaged/index.html:543
+msgctxt "storage"
+msgid "Device"
+msgstr "Gerät"
+
+#: pkg/storaged/details.js:91
+msgid "Device $0 is a member of RAID Array $1"
+msgstr "Gerät $0 ist Mitglied des RAID Arrays $1"
+
+#: pkg/storaged/details.js:97
+msgid "Device $0 is a physical volume of $1"
+msgstr "Gerät $0 ist ein physischer Datenträger von $1"
+
+#: pkg/storaged/details.js:85
+msgid "Device $0 is mounted on $1"
+msgstr "Gerät $0 ist eingehängt auf $1"
+
+#: pkg/storaged/index.html:467 pkg/storaged/index.html:473
+#: pkg/storaged/index.html:515
+#, fuzzy
+msgctxt "storage"
+msgid "Device File"
+msgstr "Gerät"
+
+#: pkg/sosreport/index.html:22
+msgid "Diagnostic reports"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:20
+msgid "Digest"
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:7
+#: pkg/kubernetes/views/volume-body.html:28
+msgid "Directory"
+msgstr ""
+
+#: pkg/systemd/init.js:543
+msgid "Disable"
+msgstr "Ausschalten"
+
+#: pkg/tuned/dialog.js:234
+msgid "Disable tuned"
+msgstr "Tuned deaktivieren"
+
+#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: pkg/shell/simple.html:120
+msgid "Disconnected"
+msgstr "Getrennt"
+
+#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+msgid "Disk"
+msgstr ""
+
+#: pkg/dashboard/index.html:73
+#, fuzzy
+msgid "Disk I/O"
+msgstr "Datenträger ist OK"
+
+#: pkg/kubernetes/scripts/nodes.js:720
+msgid "Disk Utilization: $0%"
+msgstr ""
+
+#: pkg/storaged/index.html:457
+msgid "Disk is OK"
+msgstr "Datenträger ist OK"
+
+#: pkg/storaged/index.html:584
+msgid "Disks"
+msgstr "Datenträger"
+
+#: pkg/shell/simple.html:37 pkg/shell/simple.html:97 pkg/shell/index.html:37
+#: pkg/shell/index.html:118 pkg/shell/stub.html:37 pkg/shell/stub.html:111
+msgid "Display Language"
+msgstr "Anzeigesprache"
+
+#: pkg/kubernetes/views/project-modify.html:31
+msgid "Display name"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:5
+msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:5
+msgid ""
+"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}' image stream?"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:6
+msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:6
+msgid ""
+"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:6
+msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:7
+msgid "Do you want to delete this Node?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:5
+msgid ""
+"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+"{{stream.metadata.name}}:{{tag.tag}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/remove-role-dialog.html:5
+msgid ""
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:11
+msgid "Docker Version"
+msgstr ""
+
+#: pkg/docker/index.html:60
+msgid "Docker is not installed or activated on the system"
+msgstr ""
+"Docker ist auf Ihrem System entweder nicht installiert oder nicht aktiviert"
+
+#: pkg/systemd/index.html:107
+msgid "Domain"
+msgstr ""
+
+#: pkg/realmd/operation.js:148
+msgid "Domain $0 could not be contacted"
+msgstr "Die Domain $0 konnte nicht kontaktiert werden"
+
+#: pkg/realmd/operation.js:220
+msgid "Domain $0 is not supported"
+msgstr ""
+
+#: pkg/realmd/operation.html:11
+msgid "Domain Address"
+msgstr "Domänenadressen"
+
+#: pkg/realmd/operation.html:59
+msgid "Domain Administrator Name"
+msgstr "Name des Domain-Administrators"
+
+#: pkg/realmd/operation.html:65
+msgid "Domain Administrator Password"
+msgstr "Passwort des Domain-Administrators"
+
+#: pkg/systemd/services.html:426 pkg/systemd/services.html:430
+msgid "Don't Repeat"
+msgstr ""
+
+#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
+msgid "Don't overwrite existing data"
+msgstr "Vorhandene Daten nicht überschreiben"
+
+#: pkg/sosreport/index.html:74
+msgid "Done!"
+msgstr ""
+
+#: pkg/ostree/index.html:127 pkg/ostree/index.html:158
+msgid "Downgrades"
+msgstr ""
+
+#: pkg/storaged/index.html:411
+msgid "Drive"
+msgstr ""
+
+#: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
+msgctxt "storage"
+msgid "Drive"
+msgstr "Speichergerät"
+
+#: pkg/kubernetes/views/volume-body.html:128
+msgid "Driver"
+msgstr ""
+
+#: pkg/storaged/index.html:166
+msgid "Drives"
+msgstr ""
+
+#: pkg/docker/run.js:360
+msgid "Duplicate alias"
+msgstr "Alias duplizieren"
+
+#: pkg/docker/run.js:293
+msgid "Duplicate port"
+msgstr "Port duplizieren"
+
+#: pkg/storaged/jobs.js:120
+msgid "Ejecting $target"
+msgstr ""
+
+#: pkg/playground/translate.html:58
+msgid "Empty"
+msgstr "Leer"
+
+#: pkg/playground/translate.html:63
+msgctxt "verb"
+msgid "Empty"
+msgstr "Leeren"
+
+#: pkg/kubernetes/scripts/volumes.js:196
+msgid "Empty Directory"
+msgstr ""
+
+#: pkg/storaged/jobs.js:155
+msgid "Emptying $target"
+msgstr "Leere $target"
+
+#: pkg/systemd/init.js:541
+msgid "Enable"
+msgstr "Einschalten"
+
+#: pkg/systemd/init.js:542
+msgid "Enable Forcefully"
+msgstr "Gewaltsam Einschalten"
+
+#: pkg/systemd/init.js:301
+msgid "Enabled"
+msgstr "Aktiviert"
+
+#: pkg/storaged/details.js:1247
+msgctxt "storage-id-desc"
+msgid "Encrypted"
+msgstr "Verschlüsselt"
+
+#: pkg/storaged/details.js:180
+msgid "Encrypted EXT4 (LUKS)"
+msgstr "Verschlüsseltes EXT4 (LUKS)"
+
+#: pkg/storaged/details.js:179
+msgid "Encrypted XFS (LUKS)"
+msgstr "Verschlüsseltes XFS (LUKS)"
+
+#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
+#: pkg/storaged/details.js:1115
+msgid "Encryption Options"
+msgstr "Verschlüsselungsoptionen"
+
+#: pkg/kubernetes/views/pv-modify.html:93
+msgid "Endpoint"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:40
+msgid "Endpoint Name"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:14
+#: pkg/kubernetes/views/service-panel.html:9
+msgid "Endpoints"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:38
+msgid "Ends"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:332
+msgid "Enforce policy:"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:447
+msgid "Enter IP address or host name"
+msgstr "Geben Sie die IP Adresse oder den Hostnamen an"
+
+#: pkg/systemd/logs.html:60
+msgid "Entry"
+msgstr ""
+
+#: pkg/docker/index.html:547 pkg/kubernetes/views/image-config.html:17
+#: pkg/kubernetes/views/container-body.html:26
+msgid "Environment"
+msgstr ""
+
+#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
+msgid "Erase"
+msgstr "Säubern"
+
+#: pkg/docker/storage.jsx:423
+msgid "Erase containers and reset storage pool"
+msgstr ""
+
+#: pkg/docker/storage.jsx:360
+msgid "Erase containers, reformat disks, and add them"
+msgstr ""
+
+#: pkg/storaged/jobs.js:129
+msgid "Erasing $target"
+msgstr "$target wird gelöscht"
+
+#: pkg/systemd/services.html:318 pkg/playground/translate.html:101
+#: pkg/playground/translate.html:106
+msgid "Error"
+msgstr "Fehler"
+
+#: pkg/kubernetes/scripts/connection.js:650
+msgid "Error getting certificate details: $0"
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:13
+msgid "Error loading users: {{perm_failed}}"
+msgstr ""
+
+#: pkg/docker/util.js:491
+msgid "Error message from Docker:"
+msgstr "Fehlermeldung von Docker:"
+
+#: pkg/users/authorized-keys.js:115
+msgid "Error saving authorized keys: "
+msgstr "Fehler beim Speichern der autorisierten Schlüssel:"
+
+#: pkg/selinux/setroubleshoot.js:275
+msgid "Error while connecting."
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:192
+msgid "Error while deleting alert"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot.js:65
+msgid "Error while setting SELinux mode: '$0'"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:88
+msgid "Error writing kubectl config"
+msgstr ""
+
+#: pkg/systemd/logs.html:47
+msgid "Errors"
+msgstr ""
+
+#: pkg/networkmanager/index.html:764
+msgid "Ethernet MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1854
+msgid "Ethtool"
+msgstr ""
+
+#: pkg/users/local.js:429 pkg/users/local.js:1104
+msgid "Excellent password"
+msgstr "Perfektes Passwort!"
+
+#: pkg/docker/util.js:96
+msgid "Exited $ExitCode"
+msgstr "Beendet $ExitCode"
+
+#: pkg/docker/index.html:529
+msgid "Expose container ports"
+msgstr ""
+
+#: pkg/storaged/details.js:183
+msgid "Extended Partition"
+msgstr "Erweiterte Partition"
+
+#: pkg/storaged/details.js:1592
+msgid "FAILED"
+msgstr "KAPUTT"
+
+#: pkg/ostree/index.html:92
+msgid "Failed"
+msgstr "Fehlgeschlagen"
+
+#: pkg/lib/machine-dialogs.js:412
+msgid "Failed to add machine: $0"
+msgstr "Maschine konnte nicht hinzugefügt werden: $0"
+
+#: pkg/users/local.js:112 pkg/users/local.js:144 pkg/lib/credentials.js:223
+msgid "Failed to change password"
+msgstr "Passwort konnte nicht geändert werden"
+
+#: pkg/selinux/setroubleshoot-client.js:187
+msgid "Failed to delete alert"
+msgstr ""
+
+#: pkg/tuned/dialog.js:171
+msgid "Failed to disable tuned"
+msgstr ""
+
+#: pkg/tuned/dialog.js:133
+msgid "Failed to disable tuned profile"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:494
+msgid "Failed to edit machine: $0"
+msgstr "Maschine konnte nicht editiert werden: $0"
+
+#: pkg/tuned/dialog.js:169
+msgid "Failed to enable tuned"
+msgstr ""
+
+#: pkg/users/index.html:338
+msgid "Failed to load authorized keys."
+msgstr ""
+
+#: pkg/docker/containers.js:64
+msgid "Failed to start Docker: $0"
+msgstr "Start von Docker fehlgeschlagen: $0"
+
+#: pkg/docker/util.js:544
+msgid "Failed to stop Docker scope: $0"
+msgstr ""
+
+#: pkg/tuned/dialog.js:145
+msgid "Failed to switch profile"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:204
+msgid "Fibre Channel"
+msgstr ""
+
+#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
+msgid "Filesystem Options"
+msgstr "Dateisystemoptionen"
+
+#: pkg/kubernetes/views/pv-modify.html:180
+#: pkg/kubernetes/views/volume-body.html:6
+#: pkg/kubernetes/views/volume-body.html:16
+#: pkg/kubernetes/views/volume-body.html:62
+#: pkg/kubernetes/views/volume-body.html:83
+#: pkg/kubernetes/views/volume-body.html:91
+#: pkg/kubernetes/views/volume-body.html:120
+#: pkg/kubernetes/views/volume-body.html:132
+msgid "Filesystem Type"
+msgstr ""
+
+#: pkg/storaged/details.js:215
+msgid "Filesystem type"
+msgstr "Dateisystemtyp"
+
+#: pkg/storaged/index.html:225
+msgid "Filesystems"
+msgstr ""
+
+#: pkg/lib/machine-unknown-hostkey.html:10
+msgid "Fingerprint"
+msgstr ""
+
+#: pkg/storaged/index.html:426
+msgctxt "storage"
+msgid "Firmware Version"
+msgstr "Firmware Version"
+
+#: pkg/kubernetes/scripts/volumes.js:206
+msgid "Flex"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:205
+msgid "Flocker"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:125
+msgid "Flocker Dataset Name"
+msgstr ""
+
+#: pkg/docker/util.js:503
+msgid "Force Delete"
+msgstr "Löschen erzwingen"
+
+#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
+#: pkg/storaged/details.js:1142
+msgid "Format"
+msgstr "Formatieren"
+
+#: pkg/storaged/details.js:115
+msgid "Format $0"
+msgstr "$0 formatieren"
+
+#: pkg/storaged/details.js:335
+msgid "Format Disk $0"
+msgstr "Datenträger $0 formatieren"
+
+#: pkg/storaged/details.js:358
+msgid "Formatting a disk will erase all data on it."
+msgstr ""
+"Das Formatieren eines Datenträgers löscht alle darauf vorhandenen Daten."
+
+#: pkg/storaged/details.js:268
+msgid "Formatting a storage device will erase all data on it."
+msgstr ""
+"Das Formatieren eines Speichergeräts löscht alle darauf vorhandenen Daten."
+
+#: pkg/networkmanager/interfaces.js:2577
+msgid "Forward delay $forward_delay"
+msgstr "Weiterleitungsverzögerung $forward_delay"
+
+#: pkg/systemd/index.html:255
+msgid "Free"
+msgstr "Verfügbar"
+
+#: pkg/users/index.html:86 pkg/users/index.html:148
+msgid "Full Name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:192
+msgid "GCE Persistent Disk"
+msgstr ""
+
+#: pkg/docker/index.html:180
+msgid "Gateway:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2628
+msgid "General"
+msgstr "Allgemein"
+
+#: pkg/sosreport/index.html:66
+msgid "Generating report"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:194
+msgid "Git Repository"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:198
+msgid "Gluster FS"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:872
+msgid "GlusterFS"
+msgstr ""
+
+#: pkg/systemd/logs.js:130
+msgid "Go to"
+msgstr "Gehe zu"
+
+#: pkg/storaged/index.html:307 pkg/networkmanager/index.html:50
+#: pkg/networkmanager/index.html:496
+msgid "Go to now"
+msgstr "Zu 'Jetzt' gehen"
+
+#: pkg/kubernetes/views/group-page.html:21
+#: pkg/kubernetes/views/group-panel.html:12
+msgid "Group Members"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:48
+#: pkg/kubernetes/views/user-delete.html:14
+msgid "Groups"
+msgstr ""
+
+#: pkg/networkmanager/index.html:268
+msgid "Hair Pin mode"
+msgstr "Hairpin Modus"
+
+#: pkg/networkmanager/interfaces.js:2603
+msgid "Hairpin mode"
+msgstr "Hairpin-Modus"
+
+#: pkg/docker/storage.jsx:157
+#, fuzzy
+msgid "Hard Disk"
+msgstr "Festplatte"
+
+#: pkg/storaged/overview.js:180
+msgctxt "storage"
+msgid "Hard Disk"
+msgstr "Festplatte"
+
+#: pkg/systemd/index.html:77
+msgid "Hardware"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2579
+msgid "Hello time $hello_time"
+msgstr "Hello-Zeit $hello_time"
+
+#: pkg/kubernetes/views/details-page.html:73
+#: pkg/kubernetes/views/route-body.html:9
+#: pkg/kubernetes/views/route-modify.html:8
+msgid "Host"
+msgstr "Host"
+
+#: pkg/systemd/index.html:102 pkg/dashboard/index.html:151
+msgid "Host Name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
+msgid "Host Path"
+msgstr ""
+
+#: src/base1/cockpit.js:3699
+msgid "Host key is incorrect"
+msgstr ""
+
+#: pkg/systemd/services.html:442
+#, fuzzy
+msgid "Hour : Minute"
+msgstr "1 Minute"
+
+#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
+msgid "Hour needs to be a number between 0-23"
+msgstr ""
+
+#: pkg/systemd/services.html:408
+#, fuzzy
+msgid "Hours"
+msgstr "6 Stunden"
+
+#: pkg/systemd/index.html:221
+msgid "I/O Wait"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
+msgid "IP"
+msgstr ""
+
+#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
+msgid "IP Address"
+msgstr "IP-Adresse"
+
+#: pkg/docker/index.html:172
+msgid "IP Address:"
+msgstr ""
+
+#: pkg/docker/index.html:176
+msgid "IP Prefix Length:"
+msgstr ""
+
+#: pkg/networkmanager/index.html:568
+msgid "IP Settings"
+msgstr "IP Einstellungen"
+
+#: pkg/networkmanager/interfaces.js:2641
+msgid "IPv4"
+msgstr "IPv4"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv4 Settings"
+msgstr "IPv4 Einstellungen"
+
+#: pkg/networkmanager/interfaces.js:2642
+msgid "IPv6"
+msgstr "IPv6"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv6 Settings"
+msgstr "IPv6 Einstellungen"
+
+#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
+msgid "ISCSI"
+msgstr ""
+
+#: pkg/systemd/init.js:270
+msgid "Id"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2620
+msgid "Id $id"
+msgstr "ID $id"
+
+#: pkg/kubernetes/views/image-body.html:22
+msgid "Identifier"
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:23
+#: pkg/kubernetes/views/user-panel.html:18
+msgid "Identities"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:91
+msgid "Identity"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1817
+msgid "Ignore"
+msgstr "Ignorieren"
+
+#: pkg/docker/index.html:452 pkg/kubernetes/views/image-panel.html:9
+#: pkg/kubernetes/views/container-body.html:6
+#: pkg/kubernetes/views/image-page.html:16
+msgid "Image"
+msgstr "Bild"
+
+#: pkg/docker/image.js:77
+msgid "Image $0"
+msgstr "Bild $0"
+
+#: pkg/kubernetes/views/container-body.html:8
+msgid "Image ID"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:16
+msgid "Image Layers"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:58
+msgid "Image Name"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:23
+msgid "Image Registry"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-page.html:16
+msgid "Image Stream"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:135
+msgid "Image commands"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:34
+msgid "Image count"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:48
+#: pkg/kubernetes/views/registry-dashboard-page.html:19
+#: pkg/kubernetes/views/imagestream-page.html:18
+#: pkg/kubernetes/views/image-listing.html:9 pkg/kubernetes/index.html:77
+msgid "Images"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:17
+msgid "Images by project"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:54
+msgid "Images pushed recently"
+msgstr ""
+
+#: pkg/storaged/details.js:1593
+msgid "In Sync"
+msgstr "Synchron"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:81
+msgid ""
+"In order to begin pushing images to the registry, use the commands below."
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:6
+msgid ""
+"In order to begin pushing images to the registry, you need to create a "
+"project."
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:50
+msgid ""
+"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
+"strong}}.        {{/needs_root}}                                    User "
+"name                                                                            "
+"{{#allows_password}}                            "
+"Password                                                                            "
+"{{/allows_password}}            "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
+#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
+msgid "Inactive"
+msgstr "Inaktiv"
+
+#: pkg/lib/machine-invalid-hostkey.html:2
+msgid "Incorrect Host Key"
+msgstr ""
+
+#: pkg/docker/storage.jsx:282
+msgid "Information about the Docker storage pool is not available."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:222
+msgid "Installed products"
+msgstr ""
+
+#: pkg/systemd/services.html:135
+msgid "Instantiate"
+msgstr "Instanzieren"
+
+#: pkg/kubernetes/views/pv-modify.html:169
+#: pkg/kubernetes/views/volume-body.html:81
+msgid "Interface"
+msgstr ""
+
+#: pkg/networkmanager/index.html:84
+msgid "Interfaces"
+msgstr "Schnittstellen"
+
+#: src/base1/cockpit.js:3701
+msgid "Internal error"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:196
+#, fuzzy
+msgid "Invalid credentials"
+msgstr "Ungültiger Port"
+
+#: pkg/systemd/host.js:1194
+msgid "Invalid date format"
+msgstr ""
+
+#: pkg/systemd/host.js:1190
+msgid "Invalid date format and invalid time format"
+msgstr ""
+
+#: pkg/systemd/init.js:1218
+#, fuzzy
+msgid "Invalid date format."
+msgstr "Ungültiger Port"
+
+#: pkg/lib/credentials.js:274
+msgid "Invalid file permissions"
+msgstr "Ungültige Dateiberechtigungen"
+
+#: pkg/users/index.html:322
+msgid "Invalid key"
+msgstr "Ungültiger Schlüssel"
+
+#: pkg/systemd/init.js:1169
+#, fuzzy
+msgid "Invalid number."
+msgstr "Ungültiger Schlüssel"
+
+#: pkg/docker/run.js:283
+msgid "Invalid port"
+msgstr "Ungültiger Port"
+
+#: pkg/systemd/host.js:1192
+msgid "Invalid time format"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:194 pkg/storaged/overview.js:577
+#: pkg/storaged/overview.js:668
+msgid "Invalid username or password"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:15
+msgid "Is sshd running on a different port?"
+msgstr ""
+
+#: pkg/systemd/init.js:522
+msgid "Isolate"
+msgstr "Isolieren"
+
+#: pkg/storaged/index.html:280
+msgid "Jobs"
+msgstr ""
+
+#: pkg/realmd/operation.js:96
+msgid "Join"
+msgstr "Beitreten"
+
+#: pkg/realmd/operation.js:453
+msgid "Join Domain"
+msgstr "Einer Domain beitreten"
+
+#: pkg/realmd/operation.js:347
+msgid "Joining this domain is not supported"
+msgstr ""
+
+#: pkg/systemd/logs.js:257
+msgid "Journal entry"
+msgstr "Journal-Eintrag"
+
+#: pkg/systemd/logs.js:284
+msgid "Journal entry not found"
+msgstr "Journal-Eintrag nicht gefunden"
+
+#: pkg/lib/machine-auth-failed.html:10
+msgid "Kerberos Based SSO"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:69
+msgid "Kerberos Ticket"
+msgstr ""
+
+#: pkg/systemd/index.html:225
+msgid "Kernel"
+msgstr "Kernel"
+
+#: pkg/kubernetes/views/node-body.html:19
+msgid "Kernel Version"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:67
+msgid "Key Ring Path"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:23
+msgid "Kubelet Version"
+msgstr ""
+
+#: pkg/kubernetes/index.html:23
+msgid "Kubernetes Cluster"
+msgstr "Kubernetes Cluster"
+
+#: pkg/networkmanager/index.html:473
+msgid "LACP Key"
+msgstr ""
+
+#: pkg/storaged/details.js:1245
+msgctxt "storage-id-desc"
+msgid "LUKS Encrypted"
+msgstr "LUKS Verschlüsselt"
+
+#: pkg/storaged/details.js:1226
+msgctxt "storage-id-desc"
+msgid "LVM2 Physical Volume"
+msgstr "LVM2 Physikalischer Behälter"
+
+#: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/replicationcontroller-body.html:17
+#: pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/route-body.html:22
+#: pkg/kubernetes/views/image-meta.html:3
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
+msgid "Labels"
+msgstr ""
+
+#: pkg/systemd/logs.html:42
+msgid "Last 24 hours"
+msgstr ""
+
+#: pkg/systemd/logs.html:43
+msgid "Last 7 days"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:49
+msgid "Last Heartbeat"
+msgstr ""
+
+#: pkg/users/index.html:100
+msgid "Last Login"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:51
+msgid "Last Status Change"
+msgstr ""
+
+#: pkg/systemd/init.js:273
+msgid "Last Trigger"
+msgstr ""
+
+#: pkg/kubernetes/views/image-listing.html:16
+msgid "Last Updated"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:107
+msgid "Latest Version"
+msgstr ""
+
+#: pkg/realmd/operation.js:101
+msgid "Leave"
+msgstr "Verlassen"
+
+#: pkg/networkmanager/index.html:315
+msgid "Link Monitoring"
+msgstr "Verbindungsüberwachung"
+
+#: pkg/networkmanager/index.html:397
+#, fuzzy
+msgid "Link Watch"
+msgstr "Link local"
+
+#: pkg/networkmanager/index.html:350 pkg/networkmanager/index.html:432
+msgid "Link down delay"
+msgstr "Verzögerung bei der Deaktivierung einer Verbindung"
+
+#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
+msgid "Link local"
+msgstr "Link local"
+
+#: pkg/networkmanager/index.html:341 pkg/networkmanager/index.html:423
+msgid "Link up delay"
+msgstr "Verzögerung bei der Aktivierung einer Verbindung"
+
+#: pkg/docker/index.html:514
+msgid "Links"
+msgstr "Links"
+
+#: pkg/storaged/details.js:1224
+msgctxt "storage-id-desc"
+msgid "Linux MD-RAID Component"
+msgstr "Linux MD-RAID Komponente"
+
+#: pkg/networkmanager/interfaces.js:1841
+#, fuzzy
+msgid "Load Balancing"
+msgstr "Adaptives Load Balancing (alb)"
+
+#: pkg/systemd/logs.js:69
+msgid "Load earlier entries"
+msgstr "Frühere Einträge laden"
+
+#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
+#: pkg/systemd/logs.js:175
+msgid "Loading..."
+msgstr "Lade..."
+
+#: pkg/users/index.html:23
+msgid "Local Accounts"
+msgstr ""
+
+#: pkg/docker/storage.jsx:188
+#, fuzzy
+msgid "Local Disks"
+msgstr "$0 Datenträger"
+
+#: pkg/storaged/details.js:1109
+msgid "Lock"
+msgstr "Schließen"
+
+#: pkg/users/index.html:109 pkg/users/index.html:196
+msgid "Lock Account"
+msgstr "Konto sperren"
+
+#: pkg/storaged/jobs.js:122
+msgid "Locking $target"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:80
+msgid "Log In"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:4
+msgid "Log in to {{host}}"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:116
+msgid "Log into OpenShift command line tools:"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:101
+msgid "Log into the registry:"
+msgstr ""
+
+#: pkg/shell/simple.html:45 pkg/shell/index.html:52 pkg/shell/stub.html:45
+msgid "Log out"
+msgstr "Abmelden"
+
+#: pkg/users/local.js:839
+msgid "Logged In"
+msgstr "Angemeldet"
+
+#: pkg/storaged/details.js:1424
+msgid "Logical Partition"
+msgstr "Logische Partition"
+
+#: pkg/kubernetes/views/pv-modify.html:158
+#: pkg/kubernetes/views/volume-body.html:79
+#: pkg/kubernetes/views/volume-body.html:118
+msgid "Logical Unit Number"
+msgstr ""
+
+#: pkg/storaged/utils.js:172
+msgid "Logical Volume"
+msgstr "Logischer Datenträger"
+
+#: pkg/storaged/utils.js:170
+msgid "Logical Volume (Snapshot)"
+msgstr ""
+
+#: pkg/storaged/details.js:1792
+msgid "Logical Volumes"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:140
+msgid "Login"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:68
+msgid "Login Password"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:96
+msgid "Login commands"
+msgstr ""
+
+#: src/base1/cockpit.js:3693
+msgid "Login failed"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:200
+msgid "Login/password or activation key required to register."
+msgstr ""
+
+#: pkg/systemd/logs.html:59 pkg/kubernetes/views/container-panel.html:6
+#: pkg/kubernetes/views/container-page-inline.html:8
+msgid "Logs"
+msgstr ""
+
+#: pkg/dashboard/index.html:110
+msgid "Lost connection. Trying to reconnect"
+msgstr "Verbindung verloren. "
+
+#: pkg/docker/index.html:184
+msgid "MAC Address:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1833
+msgid "MII (Recommended)"
+msgstr "MII (empfohlen)"
+
+#: pkg/networkmanager/interfaces.js:2477
+msgid "MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:4139
+msgid "MTU must be a positive number"
+msgstr ""
+
+#: pkg/systemd/index.html:85 pkg/kubernetes/views/node-body.html:15
+msgid "Machine ID"
+msgstr ""
+
+#: pkg/systemd/index.html:282
+msgid "Machine SSH Key Fingerprints"
+msgstr ""
+
+#: pkg/shell/indexes.js:253
+msgid "Machines"
+msgstr "Maschinen"
+
+#: pkg/kubernetes/scripts/dashboard.js:460
+msgid "Manifest"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
+msgid "Manual"
+msgstr "Manuell"
+
+#: pkg/systemd/index.html:401 pkg/systemd/index.html:405
+msgid "Manually"
+msgstr ""
+
+#: pkg/storaged/jobs.js:140
+msgid "Marking $target as faulty"
+msgstr "Markiere $target als fehlerhaft"
+
+#: pkg/systemd/init.js:546
+msgid "Mask"
+msgstr "Sperren"
+
+#: pkg/systemd/init.js:547
+msgid "Mask Forcefully"
+msgstr "Maskieren erzwingen"
+
+#: pkg/networkmanager/interfaces.js:2483
+msgid "Master"
+msgstr "Master"
+
+#: pkg/networkmanager/interfaces.js:2581
+msgid "Maximum message age $max_age"
+msgstr "Maximales Alter der Nachrichten $max_age"
+
+#: pkg/kubernetes/views/volume-body.html:34
+msgid "Medium"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:92
+msgid "Member of"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:16
+#: pkg/kubernetes/views/project-listing.html:55
+#: pkg/networkmanager/index.html:291
+msgid "Members"
+msgstr "Mitglieder"
+
+#: pkg/kubernetes/views/project-page.html:29
+#: pkg/kubernetes/views/user-panel.html:11
+#: pkg/kubernetes/views/user-panel.html:27
+#: pkg/kubernetes/views/user-body.html:4
+msgid "Membership"
+msgstr ""
+
+#: pkg/dashboard/index.html:71 pkg/playground/translate.html:91
+msgid "Memory"
+msgstr "Speicher"
+
+#: pkg/systemd/host.js:1466
+msgctxt "page-title"
+msgid "Memory"
+msgstr "Speicher"
+
+#: pkg/kubernetes/scripts/nodes.js:716
+msgid "Memory Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:473 pkg/docker/index.html:652
+msgid "Memory limit"
+msgstr "Speicherlimite"
+
+#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
+msgid "Message"
+msgstr ""
+
+#: pkg/systemd/host.js:1300
+msgid "Message to logged in users"
+msgstr "Nachricht an angemeldete Benutzer"
+
+#: pkg/kubernetes/views/image-panel.html:15
+#: pkg/kubernetes/views/imagestream-page.html:21
+#: pkg/kubernetes/views/image-page.html:22
+msgid "Metadata"
+msgstr ""
+
+#: pkg/docker/index.html:487 pkg/docker/index.html:666
+msgid "MiB"
+msgstr ""
+
+#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
+msgid "Minute needs to be a number between 0-59"
+msgstr ""
+
+#: pkg/systemd/services.html:407
+#, fuzzy
+msgid "Minutes"
+msgstr "5 Minuten"
+
+#: pkg/networkmanager/index.html:299
+msgid "Mode"
+msgstr "Modus"
+
+#: pkg/storaged/index.html:421
+msgctxt "storage"
+msgid "Model"
+msgstr "Modell"
+
+#: pkg/kubernetes/views/user-modify.html:31
+msgid "Modify"
+msgstr ""
+
+#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
+msgid "Modifying $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:323
+msgid "Monitoring Interval"
+msgstr "Überwachungsintervall"
+
+#: pkg/networkmanager/index.html:332
+msgid "Monitoring Targets"
+msgstr "Überwachungsziele"
+
+#: pkg/kubernetes/views/volume-body.html:54
+msgid "Monitors"
+msgstr ""
+
+#: pkg/realmd/operation.js:366
+msgid "More"
+msgstr "Mehr"
+
+#: pkg/storaged/details.js:1099
+msgid "Mount"
+msgstr "Einhängen"
+
+#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
+msgid "Mount Location"
+msgstr ""
+
+#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
+msgid "Mount Options"
+msgstr "Einhängoptionen"
+
+#: pkg/storaged/index.html:231
+msgid "Mount Point"
+msgstr "Einhängestelle"
+
+#: pkg/docker/index.html:540
+msgid "Mount container volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
+msgid "Mounting"
+msgstr "Einhängen"
+
+#: pkg/storaged/jobs.js:126
+msgid "Mounting $target"
+msgstr "$target wird eingehängt"
+
+#: pkg/storaged/index.html:508
+#, fuzzy
+msgctxt "storage"
+msgid "Multipathed Devices"
+msgstr "Andere Geräte"
+
+#: pkg/kubernetes/scripts/volumes.js:860
+msgid "NFS"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:199
+msgid "NFS Mount"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1856
+msgid "NSNA Ping"
+msgstr ""
+
+#: pkg/storaged/details.js:182
+msgid "NTFS - Compatible with most systems"
+msgstr "NTFS - Kompatibel mit den meisten Systemen"
+
+#: pkg/systemd/host.js:1250
+msgid "NTP Server"
+msgstr "NTP Server"
+
+#: pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/project-modify.html:16
+#: pkg/kubernetes/views/node-add.html:16
+#: pkg/kubernetes/views/volumes-page.html:19
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/image-body.html:2
+#: pkg/kubernetes/views/imagestream-modify.html:10
+#: pkg/kubernetes/views/service-modify.html:9
+#: pkg/kubernetes/views/dashboard-page.html:156
+#: pkg/kubernetes/views/dashboard-page.html:198
+#: pkg/kubernetes/views/details-page.html:34
+#: pkg/kubernetes/views/details-page.html:70
+#: pkg/kubernetes/views/details-page.html:103
+#: pkg/kubernetes/views/details-page.html:137
+#: pkg/kubernetes/views/details-page.html:171
+#: pkg/kubernetes/views/pv-claim.html:4
+#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/kubernetes/views/project-listing.html:14
+#: pkg/kubernetes/views/project-listing.html:53
+#: pkg/kubernetes/views/project-listing.html:90
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/volume-body.html:31 pkg/storaged/index.html:230
+#: pkg/networkmanager/index.html:95 pkg/networkmanager/index.html:113
+#: pkg/networkmanager/index.html:150 pkg/networkmanager/index.html:183
+#: pkg/networkmanager/index.html:282 pkg/networkmanager/index.html:364
+msgid "Name"
+msgstr "Name"
 
 #: pkg/storaged/utils.js:129
 #, fuzzy
@@ -1712,376 +3390,1220 @@ msgstr "Der Name darf nicht das Zeichen '$0' enthalten."
 msgid "Name cannot contain whitespace."
 msgstr "Der Name darf keine Leerzeichen enthalten."
 
-#: pkg/storaged/utils.js:157
-msgid "$name (from $host)"
-msgstr "$name (von $host)"
+#: pkg/kubernetes/views/service-body.html:5
+#: pkg/kubernetes/views/replicationcontroller-body.html:5
+#: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/pod-body.html:5
+#: pkg/kubernetes/views/dashboard-page.html:160
+#: pkg/kubernetes/views/details-page.html:36
+#: pkg/kubernetes/views/details-page.html:72
+#: pkg/kubernetes/views/details-page.html:105
+#: pkg/kubernetes/views/details-page.html:139
+#: pkg/kubernetes/views/details-page.html:173
+#: pkg/kubernetes/views/pv-claim.html:6
+#: pkg/kubernetes/views/containers-listing.html:14
+#: pkg/kubernetes/views/route-body.html:5
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
+msgid "Namespace"
+msgstr "Namespace"
+
+#: pkg/kubernetes/scripts/dashboard.js:374
+msgid "Namespace cannot be empty."
+msgstr "Der Namespace darf nicht leer sein."
+
+#: pkg/systemd/host.js:1113
+msgid "Need at least one NTP server"
+msgstr ""
+
+#: pkg/dashboard/index.html:72 pkg/playground/translate.html:96
+msgid "Network"
+msgstr "Netzwerk"
+
+#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:485
+msgid "Networking"
+msgstr "Netzwerk"
+
+#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
+msgctxt "page-title"
+msgid "Networking"
+msgstr "Netzwerk"
+
+#: pkg/networkmanager/index.html:124
+msgid "Networking Logs"
+msgstr "Netzwerk-Logs"
+
+#: pkg/users/local.js:841
+msgid "Never"
+msgstr "Nie"
+
+#: pkg/kubernetes/views/project-listing.html:46
+msgid "New Group"
+msgstr ""
+
+#: pkg/users/index.html:236 pkg/shell/index.html:255
+msgid "New Password"
+msgstr "Neues Passwort"
+
+#: pkg/kubernetes/views/project-listing.html:7
+msgid "New Project"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/image-listing.html:7
+msgid "New image stream"
+msgstr ""
+
+#: pkg/users/local.js:120 pkg/lib/credentials.js:231
+msgid "New password was not accepted"
+msgstr "Das neue Passwort wurde nicht akzeptiert"
+
+#: pkg/kubernetes/views/project-modify.html:4
+#: pkg/kubernetes/views/registry-dashboard-page.html:9
+#: pkg/kubernetes/views/registry-dashboard-page.html:48
+msgid "New project"
+msgstr ""
+
+#: pkg/realmd/operation.html:91
+msgid "Next"
+msgstr "Weiter"
+
+#: pkg/systemd/init.js:272
+msgid "Next Run"
+msgstr ""
+
+#: pkg/systemd/index.html:233
+msgid "Nice"
+msgstr ""
+
+#: pkg/docker/index.html:563 pkg/docker/index.html:567
+msgid "No"
+msgstr "Nein"
+
+#: pkg/systemd/index.html:469
+msgid "No Delay"
+msgstr "Keine Verzögerung"
+
+#: pkg/ostree/index.html:220
+msgid "No Deployments"
+msgstr ""
+
+#: pkg/storaged/details.js:185
+msgid "No Filesystem"
+msgstr "Kein Dateisystem"
+
+#: pkg/ostree/app.js:101
+msgid "No OSTree deployments found"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:398
+msgid "No PEM-encoded certificate found"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:364
+msgid "No PEM-encoded private key found"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:39
+msgid "No Pods are using this claim"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:479
+msgid "No SELinux alerts."
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:10
+msgid "No Volume Bound"
+msgstr ""
+
+#: pkg/docker/storage.jsx:194
+msgid "No additional local storage found."
+msgstr ""
+
+#: pkg/docker/run.js:350
+msgid "No alias specified"
+msgstr "Kein Alias angegeben"
+
+#: pkg/sosreport/index.js:115
+msgid "No archive has been created."
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1326
+msgid "No carrier"
+msgstr "Kein Träger"
+
+#: pkg/docker/run.js:384
+msgid "No container specified"
+msgstr "Kein Container angegeben"
+
+#: pkg/storaged/index.html:193
+msgid "No drives attached"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:74
+msgid "No groups are present."
+msgstr ""
+
+#: pkg/systemd/index.html:28
+msgid "No host keys found."
+msgstr ""
+
+#: pkg/storaged/index.html:158
+msgid "No iSCSI targets set up"
+msgstr ""
+
+#: pkg/kubernetes/views/image-listing.html:70
+msgid "No image streams are present."
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:80
+msgid "No images pushed"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:223
+#, fuzzy
+msgid "No installed products on the system."
+msgstr ""
+"Docker ist auf Ihrem System entweder nicht installiert oder nicht aktiviert"
+
+#: pkg/storaged/index.html:446
+msgid "No media inserted"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:384
+msgid ""
+"No metadata file was selected. Please select a Kubernetes metadata file."
+msgstr ""
+"Es wurde keine Metadaten-Datei ausgewählt. Bitte geben Sie eine Kubernetes "
+"Metadaten-Datei an. "
+
+#: pkg/kubernetes/views/dashboard-page.html:117
+msgid "No nodes in cluster"
+msgstr ""
+
+#: pkg/storaged/details.js:352
+msgid "No partitioning"
+msgstr "Keine Partitionierung"
+
+#: pkg/kubernetes/views/dashboard-page.html:40
+msgid "No pods deployed"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:6
+msgid "No pods replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/node-capacity.html:11
+msgid "No pods scheduled"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:10
+msgid "No pods selected"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:37
+msgid "No projects are present."
+msgstr ""
+
+#: pkg/users/local.js:405
+msgid "No real name specified"
+msgstr "Es wurde kein echter Name angegeben"
+
+#: pkg/storaged/index.html:87
+msgid "No storage set up as RAID"
+msgstr ""
+
+#: pkg/lib/credentials.js:182
+msgid "No such file or directory"
+msgstr "Datei oder Verzeichnis nicht vorhanden"
+
+#: pkg/users/local.js:400
+msgid "No user name specified"
+msgstr "Es wurde kein Benutzername angegeben."
+
+#: pkg/kubernetes/views/project-listing.html:112
+msgid "No users are present."
+msgstr ""
+
+#: pkg/storaged/index.html:120
+msgid "No volume groups created"
+msgstr "Keine Datenträgerverbünde erzeugt"
+
+#: pkg/kubernetes/views/volumes-page.html:44
+msgid "No volumes are present."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:73
+msgid "No volumes in use"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:18 pkg/kubernetes/views/node-panel.html:7
+#: pkg/kubernetes/views/containers-listing.html:15
+#: pkg/kubernetes/views/node-page.html:14
+#: pkg/kubernetes/views/topology-page.html:41
+msgid "Node"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:192
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:45
+msgid "Nodes"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:42
+msgid "Nodes are the machines that run your containers."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:15
+#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
+#: pkg/kubernetes/views/image-config.html:25
+#: pkg/kubernetes/views/imagestream-body.html:33
+msgid "None"
+msgstr "Kein"
+
+#: pkg/playground/translate.html:30 pkg/kubernetes/views/details-page.html:53
+#: pkg/kubernetes/views/node-body.html:42
+msgid "Not Ready"
+msgstr "Nicht bereit"
+
+#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
+msgid "Not a valid number of replicas"
+msgstr "Keine gültige Anzahl von Repliken"
+
+#: pkg/lib/credentials.js:248
+msgid "Not a valid private key"
+msgstr "Ungültiger privater Schlüssel"
+
+#: pkg/kubernetes/scripts/details.js:546
+msgid "Not a valid value for Host"
+msgstr "Kein gültiger Wert für Host"
+
+#: pkg/docker/index.html:57
+msgid "Not authorized to access Docker on this system"
+msgstr "Keine Berechtigung, auf diesem System Docker zu verwenden"
+
+#: pkg/ostree/app.js:81
+msgid "Not authorized to update software on this system"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:805
+msgid "Not available"
+msgstr "Nicht verfügbar"
+
+#: pkg/selinux/setroubleshoot.js:238
+msgid "Not connected"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:122
+msgid "Not deployed"
+msgstr ""
+
+#: pkg/docker/details.js:177 pkg/docker/image.js:112
+#: pkg/storaged/details.js:1822
+msgid "Not found"
+msgstr "Nicht gefunden"
+
+#: src/base1/cockpit.js:3691
+msgid "Not permitted to perform this action."
+msgstr ""
+
+#: pkg/storaged/details.js:1574
+msgid "Not running"
+msgstr "Läuft nicht"
+
+#: pkg/systemd/index.html:62
+msgid "Not synchronized"
+msgstr ""
+
+#: pkg/systemd/services.html:299
+msgid "Note"
+msgstr ""
+
+#: pkg/systemd/logs.html:49
+msgid "Notices"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:13
+msgid "OS"
+msgstr ""
+
+#: pkg/ostree/client.js:500
+msgid "OS $0 not found"
+msgstr "OS $0 nicht gefunden"
+
+#: pkg/kubernetes/views/nodes-page.html:19
+msgid "OS Versions"
+msgstr ""
+
+#: pkg/ostree/app.js:83
+msgid "OSTree is not available on this system"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:405
+msgid "Occurred $0"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:400
+msgid "Occurred between $0 and $1"
+msgstr ""
+
+#: pkg/systemd/index.html:157 pkg/playground/jquery-patterns.html:95
+#: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:189
+#: pkg/storaged/index.html:565
+msgid "Off"
+msgstr "Aus"
+
+#: pkg/lib/cockpit-components-dialog.jsx:155
+msgid "Ok"
+msgstr ""
+
+#: pkg/users/index.html:226 pkg/shell/index.html:248
+msgid "Old Password"
+msgstr "Altes Passwort"
+
+#: pkg/users/local.js:78 pkg/lib/credentials.js:213
+msgid "Old password not accepted"
+msgstr "Altes Passwort wurde nicht akzeptiert"
+
+#: pkg/systemd/index.html:153 pkg/playground/jquery-patterns.html:91
+#: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:185
+#: pkg/storaged/index.html:564
+msgid "On"
+msgstr "Ein"
+
+#: pkg/kubernetes/views/image-meta.html:7
+msgid "On Build"
+msgstr ""
+
+#: pkg/docker/index.html:568
+msgid "On Failure"
+msgstr ""
+
+#: pkg/docker/util.js:104
+msgid "On failure, retry $0 time"
+msgid_plural "On failure, retry $0 times"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/realmd/operation.html:71
+msgid "One Time Password"
+msgstr "Einmalpasswort"
+
+#: pkg/systemd/init.js:1147
+msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
+msgstr ""
+
+#: pkg/shell/simple.html:28 pkg/shell/index.html:28 pkg/shell/stub.html:28
+msgid "Ooops!"
+msgstr "Ooops!"
+
+#: pkg/systemd/index.html:89 pkg/ostree/index.html:111
+#: pkg/kubernetes/views/nodes-page.html:42
+msgid "Operating System"
+msgstr ""
+
+#: pkg/ostree/index.html:186
+msgid "Operating System Updates"
+msgstr ""
+
+#: pkg/storaged/jobs.js:166
+msgid "Operation '$operation' on $target"
+msgstr "Operation '$operation' auf $target"
+
+#: pkg/storaged/overview.js:189
+msgctxt "storage"
+msgid "Optical Drive"
+msgstr "Optisches Speichergerät"
+
+#: pkg/kubernetes/views/volume-body.html:130
+msgid "Options"
+msgstr "Einstellungen"
+
+#: pkg/subscriptions/subscriptions-register.jsx:176
+#, fuzzy
+msgid "Organization"
+msgstr "Übersetzung"
+
+#: pkg/storaged/details.js:1253
+msgctxt "storage-id-desc"
+msgid "Other Data"
+msgstr "Andere Daten"
+
+#: pkg/storaged/index.html:202
+msgid "Other Devices"
+msgstr "Andere Geräte"
+
+#: pkg/docker/index.html:319 pkg/kubernetes/registry.html:42
+#: pkg/kubernetes/index.html:39
+msgid "Overview"
+msgstr ""
+
+#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
+msgid "Overwrite existing data with zeros"
+msgstr "Vorhandene Daten mit Nullen überschreiben"
+
+#: pkg/kubernetes/views/volume-body.html:4
+msgid "PD Name"
+msgstr ""
+
+#: pkg/ostree/index.html:100
+msgid "Packages"
+msgstr ""
+
+#: pkg/networkmanager/index.html:133
+msgid "Parent"
+msgstr "Parent"
+
+#: pkg/networkmanager/interfaces.js:2619
+msgid "Parent $parent"
+msgstr "Parent $parent"
+
+#: pkg/networkmanager/interfaces.js:1372
+msgid "Part of "
+msgstr "Teil von"
+
+#: pkg/kubernetes/views/volume-body.html:8
+#: pkg/kubernetes/views/volume-body.html:18
+msgid "Partition"
+msgstr "Partition"
+
+#: pkg/storaged/details.js:346
+msgid "Partitioning"
+msgstr "Partitionierung"
+
+#: pkg/networkmanager/interfaces.js:1848
+msgid "Passive"
+msgstr ""
+
+#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
+msgid "Passphrase"
+msgstr "Passwort"
+
+#: pkg/storaged/details.js:224
+#, fuzzy
+msgid "Passphrase cannot be empty"
+msgstr "Passphrase darf nicht leer sein"
+
+#: pkg/storaged/details.js:232
+msgid "Passphrases do not match"
+msgstr "Passphrasen stimmen nicht überein."
+
+#: pkg/users/index.html:115 pkg/users/index.html:160 pkg/shell/index.html:199
+#: pkg/shell/index.html:212 pkg/kubernetes/views/auth-form.html:105
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+msgid "Password"
+msgstr "Passwort"
+
+#: pkg/users/local.js:259
+msgid "Password is not acceptable"
+msgstr "Das Passwort kann nicht akzeptiert werden"
+
+#: pkg/users/local.js:247
+msgid "Password is too weak"
+msgstr "Das gewählte Passwort ist zu schwach"
+
+#: pkg/lib/credentials.js:278
+msgid "Password not accepted"
+msgstr "Passwort wurde nicht akzeptiert"
+
+#: pkg/kubernetes/views/pv-modify.html:126
+#: pkg/kubernetes/views/volume-body.html:37
+#: pkg/kubernetes/views/volume-body.html:49
+#: pkg/kubernetes/views/volume-body.html:101
+msgid "Path"
+msgstr ""
+
+#: pkg/networkmanager/index.html:259
+msgid "Path cost"
+msgstr "Pfadkosten"
+
+#: pkg/networkmanager/interfaces.js:2601
+msgid "Path cost $path_cost"
+msgstr "Pfadkosten $path_cost"
+
+#: pkg/systemd/services.html:56
+msgid "Paths"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:53
+msgid "Pending Volume Claims"
+msgstr ""
+
+#: pkg/systemd/index.html:143
+msgid "Performance Profile"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:14
+msgid "Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:16
+msgid "Phase"
+msgstr ""
+
+#: pkg/storaged/index.html:641
+msgid "Physical Volumes"
+msgstr ""
+
+#: pkg/networkmanager/index.html:405
+#, fuzzy
+msgid "Ping Interval"
+msgstr "Überwachungsintervall"
+
+#: pkg/networkmanager/index.html:414
+#, fuzzy
+msgid "Ping Target"
+msgstr "$target wird gelöscht"
+
+#: pkg/docker/containers-view.jsx:166 pkg/docker/details.js:271
+#: pkg/docker/image.js:151 pkg/storaged/details.js:625
+#: pkg/storaged/details.js:821 pkg/storaged/details.js:1016
+msgid "Please confirm deletion of $0"
+msgstr "Bitte bestätigen Sie das Löschen von $0"
+
+#: pkg/docker/util.js:501
+msgid "Please confirm forced deletion of $0"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:441
+msgid "Please create another namespace for $0 \"$1\""
+msgstr "Bitte erzeugen Sie einen anderen Namespace für $0 \"$1\""
+
+#: pkg/kubernetes/scripts/volumes.js:574
+msgid "Please provide a GlusterFS volume name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:554
+msgid "Please provide a username"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:632
+msgid "Please provide a valid NFS server"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:539
+msgid "Please provide a valid address"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:805
+msgid "Please provide a valid filesystem type"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:813
+msgid "Please provide a valid interface"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:797
+msgid "Please provide a valid logical unit number"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:477
+msgid "Please provide a valid name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:376
+msgid "Please provide a valid namespace."
+msgstr "Bitte geben Sie einen gültigen Namespace an."
+
+#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
+msgid "Please provide a valid path"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:789
+msgid "Please provide a valid qualified name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:485
+msgid "Please provide a valid storage capacity."
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:781
+msgid "Please provide a valid target"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:469
+msgid "Please select a valid access mode"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:565
+msgid "Please select a valid endpoint"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:493
+msgid "Please select a valid policy option."
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:397
+msgid "Please type an address"
+msgstr "Bitte geben Sie eine Adresse an"
+
+#: pkg/kubernetes/views/pod-page.html:12
+#: pkg/kubernetes/views/containers-listing.html:12
+#: pkg/kubernetes/views/topology-page.html:14
+msgid "Pod"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:20
+msgid "Pod Address"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:4
+#: pkg/kubernetes/views/service-endpoint.html:9
+msgid "Pod Endpoints"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:4
+msgid "Pod Replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:15
+#: pkg/kubernetes/views/replicationcontroller-pods.html:11
+msgid "Pod Selector"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:17
+#: pkg/kubernetes/views/dashboard-page.html:18
+#: pkg/kubernetes/views/details-page.html:166
+#: pkg/kubernetes/views/pv-claim.html:37
+#: pkg/kubernetes/views/replicationcontroller-panel.html:12
+msgid "Pods"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:15
+msgid ""
+"Pods contain one or more containers that run                together on a "
+"node, containing your application code."
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:60
+msgid "Pool Name"
+msgstr ""
 
 #: pkg/storaged/utils.js:166
 msgid "Pool for Thin Logical Volumes"
 msgstr "Pool für Thin Logical Volumes"
 
-#: pkg/storaged/utils.js:168
-msgid "Thin Logical Volume"
+#: pkg/storaged/details.js:874
+msgid "Pool for thinly provisioned volumes"
 msgstr ""
 
-#: pkg/storaged/utils.js:170
-msgid "Logical Volume (Snapshot)"
+#: pkg/kubernetes/views/imagestream-modify.html:45
+msgid "Populate"
 msgstr ""
 
-#: pkg/storaged/utils.js:172
-msgid "Logical Volume"
-msgstr "Logischer Datenträger"
-
-#: pkg/storaged/utils.js:212
-msgid "<span>Encrypted Logical Volume of $0</span>"
-msgstr "<span>Verschlüsselter logischer Datenträger von $0</span>"
-
-#: pkg/storaged/utils.js:214
-msgid "<span>Encrypted Partition of $0</span>"
+#: pkg/lib/machine-change-port.html:23
+msgid "Port"
 msgstr ""
 
-#: pkg/storaged/utils.js:216
-msgid "<span>Logical Volume of $0</span>"
+#: pkg/docker/index.html:525 pkg/kubernetes/views/service-body.html:13
+#: pkg/kubernetes/views/image-config.html:23
+#: pkg/kubernetes/views/container-body.html:12
+#: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:373
+msgid "Ports"
+msgstr "Ports"
+
+#: pkg/systemd/index.html:123
+msgid "Power Options"
 msgstr ""
 
-#: pkg/storaged/utils.js:218
-msgid "<span>Partition of $0</span>"
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length"
+msgstr "Präfix"
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length or Netmask"
+msgstr "Präfix oder Netzmaske"
+
+#: pkg/networkmanager/interfaces.js:809
+msgid "Preparing"
+msgstr "Vorbereitung läuft"
+
+#: pkg/systemd/init.js:544
+msgid "Preset"
+msgstr "Voreinstellen"
+
+#: pkg/systemd/init.js:545
+msgid "Preset Forcefully"
+msgstr "Gewaltsam Voreinstellen"
+
+#: pkg/systemd/index.html:310
+msgid "Pretty Host Name"
 msgstr ""
 
-#: pkg/storaged/utils.js:220
-msgid "<span>Encrypted $0</span>"
+#: pkg/networkmanager/index.html:307
+msgid "Primary"
+msgstr "Primär"
+
+#: pkg/storaged/details.js:1426
+msgid "Primary Partition"
+msgstr "Primäre Partition"
+
+#: pkg/networkmanager/index.html:250 pkg/networkmanager/index.html:446
+#: pkg/networkmanager/index.html:464
+msgid "Priority"
+msgstr "Priorität"
+
+#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
+msgid "Priority $priority"
+msgstr "Priorität $priority"
+
+#: pkg/subscriptions/subscriptions-view.jsx:33
+msgid "Product ID"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:32
+msgid "Product name"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:4
+#: pkg/kubernetes/views/replicationcontroller-body.html:4
+#: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/imagestream-modify.html:21
+#: pkg/kubernetes/views/pod-body.html:4
+#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/details-page.html:35
+#: pkg/kubernetes/views/details-page.html:71
+#: pkg/kubernetes/views/details-page.html:104
+#: pkg/kubernetes/views/details-page.html:138
+#: pkg/kubernetes/views/details-page.html:172
+#: pkg/kubernetes/views/containers-listing.html:13
+#: pkg/kubernetes/views/route-body.html:4
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
+msgid "Project"
+msgstr "Projekt"
+
+#: pkg/kubernetes/views/project-body.html:20
+msgid "Project Members"
+msgstr ""
+
+#: pkg/kubernetes/views/filter-project.html:5
+msgid "Project:"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:54 pkg/kubernetes/views/group-delete.html:10
+#: pkg/kubernetes/views/project-listing.html:9
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:84
+msgid "Projects"
+msgstr ""
+
+#: pkg/users/local.js:82
+msgid "Prompting via passwd timed out"
+msgstr ""
+
+#: pkg/lib/credentials.js:251
+msgid "Prompting via ssh-add timed out"
+msgstr ""
+
+#: pkg/lib/credentials.js:191
+msgid "Prompting via ssh-keygen timed out"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:125
+msgid "Proxy"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:25
+msgid "Proxy Version"
+msgstr ""
+
+#: pkg/shell/index.html:198 pkg/lib/machine-auth-failed.html:9
+msgid "Public Key"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:150
+msgid "Pull an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:66
+msgid "Pull from"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:31
+msgid "Pull repository"
+msgstr ""
+
+#: pkg/storaged/details.js:869
+msgid "Purpose"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:140
+msgid "Push an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:147
+#: pkg/kubernetes/views/volume-body.html:77
+msgid "Qualified Name"
+msgstr ""
+
+#: pkg/storaged/details.js:1539
+msgid "RAID ($0)"
+msgstr "RAID ($0)"
+
+#: pkg/storaged/details.js:1533
+msgid "RAID 0"
+msgstr "RAID 0"
+
+#: pkg/storaged/overview.js:422
+msgid "RAID 0 (Stripe)"
+msgstr "RAID 0 (Gestreift)"
+
+#: pkg/storaged/details.js:1534
+msgid "RAID 1"
+msgstr "RAID 1"
+
+#: pkg/storaged/overview.js:423
+msgid "RAID 1 (Mirror)"
+msgstr "RAID 1 (Gespiegelt)"
+
+#: pkg/storaged/details.js:1538
+msgid "RAID 10"
+msgstr "RAID 10"
+
+#: pkg/storaged/overview.js:427
+msgid "RAID 10 (Stripe of Mirrors)"
+msgstr "RID 10 (Gestreifte Spiegel)"
+
+#: pkg/storaged/details.js:1535
+msgid "RAID 4"
+msgstr "RAID 4"
+
+#: pkg/storaged/overview.js:424
+msgid "RAID 4 (Dedicated Parity)"
+msgstr "RAID 4 (Dedizierte Parität)"
+
+#: pkg/storaged/details.js:1536
+msgid "RAID 5"
+msgstr "RAID 5"
+
+#: pkg/storaged/overview.js:425
+msgid "RAID 5 (Distributed Parity)"
+msgstr "RAID 5 (Verteilte Parität)"
+
+#: pkg/storaged/details.js:1537
+msgid "RAID 6"
+msgstr "RAID 6"
+
+#: pkg/storaged/overview.js:426
+msgid "RAID 6 (Double Distributed Parity)"
+msgstr "RAID 6 (Doppelt Verteilte Parität)"
+
+#: pkg/storaged/index.html:537
+msgid "RAID Device"
 msgstr ""
 
 #: pkg/storaged/utils.js:233
 msgid "RAID Device $0"
 msgstr "RAID-Gerät $0"
 
-#: pkg/storaged/utils.js:239
-msgid "Volume Group $0"
-msgstr "Datenträgerverbund $0"
-
-#: pkg/storaged/jobs.js:119
-msgid "SMART self-test of $target"
+#: pkg/storaged/index.html:65
+msgid "RAID Devices"
 msgstr ""
 
-#: pkg/storaged/jobs.js:120
-msgid "Ejecting $target"
+#: pkg/storaged/overview.js:420
+msgid "RAID Level"
+msgstr "RAID Ebene"
+
+#: pkg/storaged/index.html:555
+msgctxt "storage"
+msgid "RAID Level"
+msgstr "RAID Ebene"
+
+#: pkg/storaged/details.js:1228
+msgctxt "storage-id-desc"
+msgid "RAID Member"
+msgstr "RAID Mitglied"
+
+#: pkg/kubernetes/scripts/volumes.js:200
+msgid "Rados Block Device"
 msgstr ""
 
-#: pkg/storaged/jobs.js:121
-msgid "Unlocking $target"
+#: pkg/kubernetes/views/pv-modify.html:194
+#: pkg/kubernetes/views/volume-body.html:10
+#: pkg/kubernetes/views/volume-body.html:20
+#: pkg/kubernetes/views/volume-body.html:44
+#: pkg/kubernetes/views/volume-body.html:51
+#: pkg/kubernetes/views/volume-body.html:71
+#: pkg/kubernetes/views/volume-body.html:85
+#: pkg/kubernetes/views/volume-body.html:93
+#: pkg/kubernetes/views/volume-body.html:110
+#: pkg/kubernetes/views/volume-body.html:122
+#: pkg/kubernetes/views/volume-body.html:136
+#: pkg/kubernetes/views/volume-body.html:143
+msgid "Read Only"
 msgstr ""
 
-#: pkg/storaged/jobs.js:122
-msgid "Locking $target"
+#: pkg/kubernetes/scripts/volumes.js:211
+msgid "Read and write from a single node"
 msgstr ""
 
-#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
-msgid "Modifying $target"
+#: pkg/kubernetes/scripts/volumes.js:213
+msgid "Read and write from multiple nodes"
 msgstr ""
 
-#: pkg/storaged/jobs.js:124
-msgid "Starting swapspace $target"
+#: pkg/kubernetes/scripts/volumes.js:212
+msgid "Read only from multiple nodes"
 msgstr ""
 
-#: pkg/storaged/jobs.js:125
-msgid "Stopping swapspace $target"
+#: pkg/docker/index.html:385
+msgid "ReadOnly"
 msgstr ""
 
-#: pkg/storaged/jobs.js:126
-msgid "Mounting $target"
-msgstr "$target wird eingehängt"
-
-#: pkg/storaged/jobs.js:127
-msgid "Unmounting $target"
-msgstr "$target wird ausgehängt"
-
-#: pkg/storaged/jobs.js:129
-msgid "Erasing $target"
-msgstr "$target wird gelöscht"
-
-#: pkg/storaged/jobs.js:130
-msgid "Creating filesystem on $target"
-msgstr "Dateisystem auf $0 wird erzeugt"
-
-#: pkg/storaged/jobs.js:131
-msgid "Setting up loop device $target"
+#: pkg/docker/index.html:384
+msgid "ReadWrite"
 msgstr ""
 
-#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
-msgid "Deleting $target"
-msgstr "Lösche $target"
+#: pkg/storaged/index.html:327
+msgid "Reading"
+msgstr ""
 
-#: pkg/storaged/jobs.js:134
-msgid "Creating partition $target"
-msgstr "Erzeuge Partition $target"
+#: pkg/playground/translate.html:20 pkg/playground/translate.html:179
+#: pkg/kubernetes/views/details-page.html:52
+#: pkg/kubernetes/views/node-body.html:41
+msgid "Ready"
+msgstr "Bereit"
 
-#: pkg/storaged/jobs.js:135
-msgid "Cleaning up for $target"
-msgstr "$target wird aufgeräumt"
+#: pkg/playground/translate.html:25
+msgctxt "verb"
+msgid "Ready"
+msgstr "Bereiten"
 
-#: pkg/storaged/jobs.js:136
-msgid "Securely erasing $target"
-msgstr "$target wird sicher gelöscht"
+#: pkg/systemd/index.html:319
+msgid "Real Host Name"
+msgstr ""
 
-#: pkg/storaged/jobs.js:137
-msgid "Very securely erasing $target"
-msgstr "$target wird sehr sicher gelöscht"
+#: pkg/kubernetes/views/node-body.html:45
+msgid "Reason"
+msgstr ""
 
-#: pkg/storaged/jobs.js:138
-msgid "Stopping RAID Device $target"
-msgstr "Stoppe RAID-Gerät $target"
+#: pkg/lib/journal.js:241
+msgid "Reboot"
+msgstr "Neustart"
 
-#: pkg/storaged/jobs.js:139
-msgid "Starting RAID Device $target"
-msgstr "Starte RAID-Gerät $target"
+#: pkg/networkmanager/index.html:75 pkg/networkmanager/index.html:98
+#: pkg/networkmanager/index.html:116 pkg/networkmanager/index.html:521
+#: pkg/networkmanager/index.html:551
+msgid "Receiving"
+msgstr "Empfange"
 
-#: pkg/storaged/jobs.js:140
-msgid "Marking $target as faulty"
-msgstr "Markiere $target als fehlerhaft"
+#: pkg/ostree/client.js:56
+msgid "Receiving delta parts"
+msgstr "Empfange Delta-Teile"
 
-#: pkg/storaged/jobs.js:141
-msgid "Removing $target from RAID Device"
-msgstr "Entferne $target vom RAID-Gerät"
+#: pkg/ostree/client.js:58
+msgid "Receiving metadata objects"
+msgstr "Empfange Metadaten-Objekte"
 
-#: pkg/storaged/jobs.js:142
-msgid "Creating RAID Device $target"
-msgstr "Erzeuge RAID-Gerät $target"
+#: pkg/ostree/client.js:61
+msgid "Receiving objects: $0%"
+msgstr "Empfange Objekte: $0%"
 
-#: pkg/storaged/jobs.js:143
-#, fuzzy
-msgid "Checking RAID Device $target"
-msgstr "Erzeuge RAID-Gerät $target"
+#: pkg/systemd/logs.html:40
+msgid "Recent"
+msgstr ""
 
-#: pkg/storaged/jobs.js:144
-#, fuzzy
-msgid "Checking and Repairing RAID Device $target"
-msgstr "Erzeuge RAID-Gerät $target"
+#: pkg/kubernetes/views/pv-modify.html:56 pkg/kubernetes/views/pv-body.html:6
+msgid "Reclaim Policy"
+msgstr ""
+
+#: pkg/shell/simple.html:144 pkg/shell/index.html:327 pkg/shell/stub.html:180
+msgid "Reconnect"
+msgstr "Erneut verbinden"
+
+#: pkg/storaged/details.js:1594
+msgid "Recovering"
+msgstr "Am Erholen"
 
 #: pkg/storaged/jobs.js:145
 #, fuzzy
 msgid "Recovering RAID Device $target"
 msgstr "Stoppe RAID-Gerät $target"
 
-#: pkg/storaged/jobs.js:146
-msgid "Synchronizing RAID Device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:148
-msgid "Activating $target"
-msgstr "Aktiviere $target"
-
-#: pkg/storaged/jobs.js:149
-msgid "Deactivating $target"
-msgstr "Deaktiviere $target"
-
-#: pkg/storaged/jobs.js:150
-msgid "Creating snapshot of $target"
-msgstr "Erzeuge Snapshot von $target"
-
-#: pkg/storaged/jobs.js:151
-msgid "Creating volume group $target"
-msgstr "Erzeuge Datenträgerverbund $target"
-
-#: pkg/storaged/jobs.js:152
-msgid "Deleting volume group $target"
-msgstr "Lösche Datenträgerverbund ätarget"
-
-#: pkg/storaged/jobs.js:153
-msgid "Adding physical volume to $target"
-msgstr "Füge physikalischen Datenträger zu $target hinzu"
-
-#: pkg/storaged/jobs.js:154
-msgid "Removing physical volume from $target"
-msgstr "Entferne physikalischen Datenträger von $target"
-
-#: pkg/storaged/jobs.js:155
-msgid "Emptying $target"
-msgstr "Leere $target"
-
-#: pkg/storaged/jobs.js:156
-msgid "Creating logical volume $target"
-msgstr "Erzeuge logischen Datenträger $target"
-
-#: pkg/storaged/jobs.js:157
-msgid "Renaming $target"
-msgstr "$target wird umbenannt"
-
-#: pkg/storaged/jobs.js:158
-msgid "Resizing $target"
-msgstr "Größenänderung von $target"
-
-#: pkg/storaged/jobs.js:166
-msgid "Operation '$operation' on $target"
-msgstr "Operation '$operation' auf $target"
-
-#: pkg/storaged/jobs.js:180
-msgid "unknown target"
-msgstr "Unbekanntes Ziel"
-
-#: pkg/storaged/permissions.js:61
-msgid "The user <b>$0</b> is not permitted to manage storage"
-msgstr "Der Benutzer <b>$0</b> hat keine Rechte, Speicher zu verwalten."
-
-#: pkg/realmd/operation.js:96
-msgid "Join"
-msgstr "Beitreten"
-
-#: pkg/realmd/operation.js:101
-msgid "Leave"
-msgstr "Verlassen"
-
-#: pkg/realmd/operation.js:148
-msgid "Domain $0 could not be contacted"
-msgstr "Die Domain $0 konnte nicht kontaktiert werden"
-
-#: pkg/realmd/operation.js:220
-msgid "Domain $0 is not supported"
-msgstr ""
-
-#: pkg/realmd/operation.js:347
-msgid "Joining this domain is not supported"
-msgstr ""
-
-#: pkg/realmd/operation.js:366
-msgid "More"
-msgstr "Mehr"
-
-#: pkg/realmd/operation.js:417
-msgid "Cannot join a domain because realmd is not available on this system"
-msgstr ""
-"Es konnte keiner Domain beigetreten werden, da realmd auf diesem System "
-"nicht verfügbar ist."
-
-#: pkg/realmd/operation.js:436
-msgid "The user <b>$0</b> is not permitted to modify realms"
-msgstr "Der Benutzer <b>$0</b> hat keine Rechte, Bereiche zu änden."
-
-#: pkg/realmd/operation.js:453
-msgid "Join Domain"
-msgstr "Einer Domain beitreten"
-
-#: pkg/docker/run.js:246 pkg/docker/util.js:102
-#: pkg/networkmanager/interfaces.js:2280 pkg/kubernetes/scripts/volumes.js:992
-#: pkg/docker/index.html.h:46
-msgid "No"
-msgstr "Nein"
-
-#: pkg/docker/run.js:261 pkg/docker/console.html.h:1
-#: pkg/kubernetes/views/image-panel.html.h:2
-#: pkg/kubernetes/views/container-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:1
-#: pkg/kubernetes/views/image-page.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:1
-msgid "Container"
-msgstr "Container"
-
-#: pkg/docker/run.js:263 pkg/kubernetes/views/route-modify.html.h:2
-#: pkg/kubernetes/views/route-body.html.h:4
-#: pkg/kubernetes/views/details-page.html.h:12
-msgid "Host"
-msgstr "Host"
-
-#: pkg/docker/run.js:283
-msgid "Invalid port"
-msgstr "Ungültiger Port"
-
-#: pkg/docker/run.js:293
-msgid "Duplicate port"
-msgstr "Port duplizieren"
-
-#: pkg/docker/run.js:332
-#, fuzzy
-msgid "Command can't be empty"
-msgstr "Name darf nicht leer sein."
-
-#: pkg/docker/run.js:350
-msgid "No alias specified"
-msgstr "Kein Alias angegeben"
-
-#: pkg/docker/run.js:360
-msgid "Duplicate alias"
-msgstr "Alias duplizieren"
-
-#: pkg/docker/run.js:384
-msgid "No container specified"
-msgstr "Kein Container angegeben"
-
-#: pkg/docker/details.js:47 pkg/docker/image.js:43
-msgctxt "page-title"
-msgid "Containers"
-msgstr "Containers"
-
-#: pkg/docker/details.js:144
-msgid "${hip}:${hport} -> $cport"
-msgstr "${hip}:${hport} -> $cport"
-
-#: pkg/docker/details.js:272 pkg/docker/containers-view.jsx:167
-msgid "Deleting a container will erase all data in it."
-msgstr ""
-"Das Löschen eines Containers entfernt alle sich darin befindlichen Daten."
-
-#: pkg/docker/storage.jsx:156
-#, fuzzy
-msgid "Solid-State Disk"
-msgstr "Solid-State Datenträger"
-
-#: pkg/docker/storage.jsx:157
-#, fuzzy
-msgid "Hard Disk"
-msgstr "Festplatte"
-
-#: pkg/docker/storage.jsx:158 pkg/storaged/index.html.h:33
-msgid "Drive"
-msgstr ""
-
-#: pkg/docker/storage.jsx:188
-#, fuzzy
-msgid "Local Disks"
-msgstr "$0 Datenträger"
-
-#: pkg/docker/storage.jsx:194
-msgid "No additional local storage found."
-msgstr ""
-
-#: pkg/docker/storage.jsx:242
-msgid " (shared with the OS)"
-msgstr ""
-
-#: pkg/docker/storage.jsx:282
-msgid "Information about the Docker storage pool is not available."
-msgstr ""
-
-#: pkg/docker/storage.jsx:314
-msgid "Total"
+#: pkg/kubernetes/scripts/volumes.js:219
+msgid "Recycle"
 msgstr ""
 
 #: pkg/docker/storage.jsx:348
 msgid "Reformat and add disks"
 msgstr ""
 
-#: pkg/docker/storage.jsx:355
+#: pkg/kubernetes/views/pv-modify.html:205
+msgid "Register"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:12
+msgid "Register New Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:4
+msgid "Register Persistent Volume"
+msgstr ""
+
+#: pkg/subscriptions/main.js:74
+msgid "Register system"
+msgstr ""
+
+#: pkg/ostree/index.html:115
+msgid "Released"
+msgstr ""
+
+#: pkg/systemd/init.js:518
+msgid "Reload"
+msgstr "Neu Laden"
+
+#: pkg/systemd/init.js:519
+msgid "Reload or Restart"
+msgstr "Neu Laden oder Neu Starten"
+
+#: pkg/systemd/init.js:521
+msgid "Reload or Try Restart"
+msgstr "Neu Laden oder Neustart Versuchen"
+
+#: pkg/kubernetes/views/imagestream-modify.html:89
+msgid "Remote registry is insecure"
+msgstr ""
+
+#: cockpit.desktop.in.h:3
+msgid "Remote;Administration;"
+msgstr ""
+
+#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
+msgctxt "storage"
+msgid "Removable Drive"
+msgstr "Entfernbares Speichergerät"
+
+#: pkg/ostree/index.html:123 pkg/ostree/index.html:146
+msgid "Removals"
+msgstr ""
+
+#: pkg/kubernetes/views/user-group-remove.html:10
+#: pkg/kubernetes/views/group-delete.html:21
+#: pkg/kubernetes/views/user-delete.html:25
+#: pkg/kubernetes/views/remove-role-dialog.html:8
+msgid "Remove"
+msgstr "Entfernen"
+
+#: pkg/networkmanager/interfaces.js:2791
+#, fuzzy
+msgid "Remove $0"
+msgstr "Entfernen"
+
+#: pkg/kubernetes/views/group-delete.html:3
+msgid "Remove Group"
+msgstr ""
+
+#: pkg/kubernetes/views/user-group-remove.html:3
+msgid "Remove Member"
+msgstr ""
+
+#: pkg/kubernetes/views/remove-role-dialog.html:3
+msgid "Remove Role"
+msgstr ""
+
+#: pkg/kubernetes/views/user-delete.html:3
+msgid "Remove User"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:3
+msgid "Remove image tag"
+msgstr ""
+
+#: pkg/kubernetes/views/user-remove-membership.html:3
+msgid "Remove membership"
+msgstr ""
+
+#: pkg/storaged/jobs.js:141
+msgid "Removing $target from RAID Device"
+msgstr "Entferne $target vom RAID-Gerät"
+
+#: pkg/networkmanager/interfaces.js:2788
+msgid "Removing <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:154
+msgid "Removing physical volume from $target"
+msgstr "Entferne physikalischen Datenträger von $target"
+
+#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
+#: pkg/storaged/details.js:1775
+msgid "Rename"
+msgstr "Umbenennen"
+
+#: pkg/storaged/details.js:795
+msgid "Rename Volume Group"
+msgstr "Datenträgerverbund umbennen"
+
+#: pkg/storaged/details.js:706
+msgid "Renamee Logical Volume"
+msgstr "Logischen Datenträger umbennen"
+
+#: pkg/storaged/jobs.js:157
+msgid "Renaming $target"
+msgstr "$target wird umbenannt"
+
+#: pkg/systemd/services.html:432
+msgid "Repeat Daily"
+msgstr ""
+
+#: pkg/systemd/services.html:431
+msgid "Repeat Hourly"
+msgstr ""
+
+#: pkg/systemd/services.html:434
+msgid "Repeat Monthly"
+msgstr ""
+
+#: pkg/systemd/services.html:433
+msgid "Repeat Weekly"
+msgstr ""
+
+#: pkg/systemd/services.html:435
+msgid "Repeat Yearly"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-body.html:9
+#: pkg/kubernetes/views/details-page.html:141
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
+#: pkg/kubernetes/views/replicationcontroller-modify.html:8
+msgid "Replicas"
+msgstr "Repliken"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:14
+#: pkg/kubernetes/views/replicationcontroller-panel.html:10
+#: pkg/kubernetes/views/topology-page.html:23
+msgid "Replication Controller"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:132
+msgid "Replication Controllers"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:24
 msgid ""
-"The storage pool will be reset to optimize its layout.  All containers will "
-"be erased."
+"Replication controllers dynamically create instances of                pods "
+"from templates, and remove pods when necessary."
 msgstr ""
 
-#: pkg/docker/storage.jsx:360
-msgid "Erase containers, reformat disks, and add them"
+#: pkg/docker/index.html:718
+msgid "Repository"
+msgstr "Repository"
+
+#: pkg/kubernetes/views/volume-body.html:24
+msgid "Repository URL"
 msgstr ""
 
-#: pkg/docker/storage.jsx:363
-msgid "Add Additional Storage"
+#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
+msgid "Requested"
 msgstr ""
 
-#: pkg/docker/storage.jsx:366
-msgid ""
-"All data on selected disks will be erased and disks will be added to the "
-"storage pool."
+#: pkg/kubernetes/views/pv-claim.html:13
+msgid "Requests"
 msgstr ""
 
-#: pkg/docker/storage.jsx:404
-msgid "Could not add all disks"
+#: pkg/kubernetes/views/auth-form.html:54
+msgid "Requires Authentication"
+msgstr ""
+
+#: pkg/docker/index.html:323
+msgid "Reset"
 msgstr ""
 
 #: pkg/docker/storage.jsx:417
@@ -2094,384 +4616,596 @@ msgid ""
 "the pool."
 msgstr ""
 
-#: pkg/docker/storage.jsx:423
-msgid "Erase containers and reset storage pool"
+#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
+msgid "Resize"
+msgstr "Größe ändern"
+
+#: pkg/storaged/details.js:673
+msgid "Resize Filesystem"
+msgstr "Größe des Dateisystems ändern"
+
+#: pkg/storaged/details.js:661
+msgid "Resize Logical Volume"
+msgstr "Größe eines logischen Datenträgers ändern"
+
+#: pkg/storaged/jobs.js:158
+msgid "Resizing $target"
+msgstr "Größenänderung von $target"
+
+#: pkg/systemd/index.html:126 pkg/systemd/index.html:133
+msgid "Restart"
+msgstr "Neustarten"
+
+#: pkg/kubernetes/views/container-body.html:20
+msgid "Restart Count"
 msgstr ""
 
-#: pkg/docker/storage.jsx:446
-msgid "Could not reset the storage pool"
+#: pkg/docker/index.html:558 pkg/kubernetes/views/pod-body.html:10
+msgid "Restart Policy"
 msgstr ""
 
-#: pkg/docker/storage.jsx:482
-#, fuzzy
-msgid "You don't have permission to manage the Docker storage pool."
-msgstr ""
-"Sie haben keine Berechtigung, die autorisierten öffentlichen Schlüssel von "
-"diesem Konto anzuzeigen."
-
-#: pkg/docker/storage.jsx:485
-msgid "The Docker storage pool cannot be managed on this system."
+#: pkg/kubernetes/scripts/volumes.js:217
+msgid "Retain"
 msgstr ""
 
-#: pkg/docker/image.js:77
-msgid "Image $0"
-msgstr "Bild $0"
-
-#: pkg/docker/image.js:152
-msgid ""
-"Deleting an image will delete it, but you can probably download it again if "
-"you need it later.  Unless this image has never been pushed to a repository, "
-"that is, in which case you probably can't download it again."
+#: pkg/docker/index.html:574
+msgid "Retries:"
 msgstr ""
 
-#: pkg/docker/util.js:94
-msgid "Up since $StartedAt"
-msgstr "Läuft seit $StartedAt"
-
-#: pkg/docker/util.js:96
-msgid "Exited $ExitCode"
-msgstr "Beendet $ExitCode"
-
-#: pkg/docker/util.js:104
-msgid "On failure, retry $0 time"
-msgid_plural "On failure, retry $0 times"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/docker/util.js:107 pkg/docker/index.html.h:48
-msgid "Always"
+#: pkg/subscriptions/subscriptions-view.jsx:188
+msgid "Retrieving subscription status..."
 msgstr ""
 
-#: pkg/docker/util.js:109 pkg/docker/index.html.h:49
-msgid "Unless Stopped"
+#: pkg/kubernetes/views/volume-body.html:26
+msgid "Revision"
 msgstr ""
 
-#: pkg/docker/util.js:123
-msgid "default"
-msgstr "Vorgabe"
-
-#: pkg/docker/util.js:124
-msgid "$0 shares"
-msgstr "$0 mal geteilt"
-
-#: pkg/docker/util.js:231
-msgid "Stopped"
-msgstr "Angehalten"
-
-#: pkg/docker/util.js:488
-msgid "Container is currently running."
-msgstr "Der Container läuft zur Zeit."
-
-#: pkg/docker/util.js:490
-msgid ""
-"Container is currently marked as not running, but regular stopping failed."
-msgstr ""
-"Der Container ist zur Zeit als nicht als in Ausführung gekennzeichnet, das "
-"reguläre Anhalten schlug jedoch fehlt."
-
-#: pkg/docker/util.js:491
-msgid "Error message from Docker:"
-msgstr "Fehlermeldung von Docker:"
-
-#: pkg/docker/util.js:501
-msgid "Please confirm forced deletion of $0"
+#: pkg/users/index.html:94 pkg/kubernetes/views/add-member-role-dialog.html:39
+#: pkg/kubernetes/views/project-body.html:21
+msgid "Roles"
 msgstr ""
 
-#: pkg/docker/util.js:503
-msgid "Force Delete"
-msgstr "Löschen erzwingen"
-
-#: pkg/docker/util.js:544
-msgid "Failed to stop Docker scope: $0"
+#: pkg/ostree/index.html:73
+msgid "Roll back and reboot"
 msgstr ""
-
-#: pkg/docker/containers-view.jsx:239
-#, fuzzy
-msgid "Commit"
-msgstr "Befehl"
-
-#: pkg/docker/containers.js:64
-msgid "Failed to start Docker: $0"
-msgstr "Start von Docker fehlgeschlagen: $0"
-
-#: pkg/users/authorized-keys.js:103
-msgid "Validating key"
-msgstr "Schlüssel wird überprüft"
-
-#: pkg/users/authorized-keys.js:108
-msgid "Adding key"
-msgstr "Schlüssel wird hinzugefügt"
-
-#: pkg/users/authorized-keys.js:115
-msgid "Error saving authorized keys: "
-msgstr "Fehler beim Speichern der autorisierten Schlüssel:"
-
-#: pkg/users/authorized-keys.js:118
-msgid "The key you provided was not valid."
-msgstr ""
-
-#: pkg/users/local.js:40
-msgid "The user <b>$0</b> is not permitted to modify accounts"
-msgstr "Der Benutzer <b>$0</b> hat keine Rechte, Konten zu verändern"
-
-#: pkg/users/local.js:57
-msgid "Unable to delete root account"
-msgstr "Root-Konto konnte nicht gelöscht werden"
-
-#: pkg/users/local.js:59
-msgid "Unable to rename root account"
-msgstr "Root-Konto konnte nicht umbenannt werden"
-
-#: pkg/users/local.js:82
-msgid "Prompting via passwd timed out"
-msgstr ""
-
-#: pkg/users/local.js:247
-msgid "Password is too weak"
-msgstr "Das gewählte Passwort ist zu schwach"
-
-#: pkg/users/local.js:259
-msgid "Password is not acceptable"
-msgstr "Das Passwort kann nicht akzeptiert werden"
-
-#: pkg/users/local.js:284 pkg/users/local.js:594
-msgctxt "page-title"
-msgid "Accounts"
-msgstr "Konten"
-
-#: pkg/users/local.js:395 pkg/users/local.js:1082
-msgid "The passwords do not match"
-msgstr "Die Passwörter stimmen nicht überein"
-
-#: pkg/users/local.js:400
-msgid "No user name specified"
-msgstr "Es wurde kein Benutzername angegeben."
-
-#: pkg/users/local.js:405
-msgid "No real name specified"
-msgstr "Es wurde kein echter Name angegeben"
-
-#: pkg/users/local.js:429 pkg/users/local.js:1104
-msgid "Excellent password"
-msgstr "Perfektes Passwort!"
-
-#: pkg/users/local.js:501
-msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
-msgstr ""
-
-#: pkg/users/local.js:509
-msgid "This user name already exists"
-msgstr "Dieser Benutzername existiert bereits"
-
-#: pkg/users/local.js:682 pkg/users/local.js:683
-msgid "Server Administrator"
-msgstr "Server Administrator"
-
-#: pkg/users/local.js:684
-msgid "Container Administrator"
-msgstr "Container Administrator"
-
-#: pkg/users/local.js:839
-msgid "Logged In"
-msgstr "Angemeldet"
-
-#: pkg/users/local.js:841
-msgid "Never"
-msgstr "Nie"
-
-#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
-msgid "Delete $0"
-msgstr "$0 löschen"
-
-#: pkg/sosreport/index.js:49 pkg/sosreport/index.js:113
-#: pkg/systemd/services.html.h:13 pkg/lib/machine-invalid-hostkey.html.h:4
-#: pkg/lib/machine-auth-failed.html.h:7
-#: pkg/lib/machine-unknown-hostkey.html.h:4
-#: pkg/lib/machine-change-port.html.h:8 pkg/lib/machine-not-supported.html.h:3
-#: pkg/shell/index.html.h:37
-msgid "Close"
-msgstr "Schliessen"
-
-#: pkg/sosreport/index.js:115
-msgid "No archive has been created."
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:598 pkg/networkmanager/interfaces.js:1051
-#: pkg/networkmanager/interfaces.js:2255 pkg/networkmanager/interfaces.js:2257
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:753 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/kubernetes/views/node-body.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:6
-#: pkg/kubernetes/views/pv-claim.html.h:7
-#: pkg/kubernetes/views/image-body.html.h:6
-#: pkg/kubernetes/views/pv-body.html.h:5
-msgid "Unknown"
-msgstr "Unbekannt"
-
-#: pkg/networkmanager/interfaces.js:805
-msgid "Not available"
-msgstr "Nicht verfügbar"
-
-#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
-#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
-msgid "Inactive"
-msgstr "Inaktiv"
-
-#: pkg/networkmanager/interfaces.js:809
-msgid "Preparing"
-msgstr "Vorbereitung läuft"
-
-#: pkg/networkmanager/interfaces.js:811
-msgid "Configuring"
-msgstr "Konfiguriere"
-
-#: pkg/networkmanager/interfaces.js:813
-msgid "Authenticating"
-msgstr "Authentifiziere"
-
-#: pkg/networkmanager/interfaces.js:815
-msgid "Configuring IP"
-msgstr "Konfiguriere IP"
-
-#: pkg/networkmanager/interfaces.js:817
-msgid "Checking IP"
-msgstr "IP wird überprüft"
-
-#: pkg/networkmanager/interfaces.js:819
-msgid "Waiting"
-msgstr "Wartet"
-
-#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
-msgid "Active"
-msgstr "Aktiv"
-
-#: pkg/networkmanager/interfaces.js:823
-msgid "Deactivating"
-msgstr "Wird deaktiviert"
-
-#: pkg/networkmanager/interfaces.js:825 pkg/ostree/index.html.h:14
-msgid "Failed"
-msgstr "Fehlgeschlagen"
-
-#: pkg/networkmanager/interfaces.js:1326
-msgid "No carrier"
-msgstr "Kein Träger"
-
-#: pkg/networkmanager/interfaces.js:1372
-msgid "Part of "
-msgstr "Teil von"
-
-#: pkg/networkmanager/interfaces.js:1420
-msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr ""
-"Der User <b>$0</b> hat keine Rechte, die Netzwerkeinstellungen zu verändern."
-
-#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
-msgctxt "page-title"
-msgid "Networking"
-msgstr "Netzwerk"
-
-#: pkg/networkmanager/interfaces.js:1804
-msgid "Automatic (DHCP)"
-msgstr "Automatisch (DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
-msgid "Link local"
-msgstr "Link local"
-
-#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
-msgid "Manual"
-msgstr "Manuell"
-
-#: pkg/networkmanager/interfaces.js:1807
-msgid "Shared"
-msgstr "Geteilt"
-
-#: pkg/networkmanager/interfaces.js:1813 pkg/networkmanager/interfaces.js:2475
-#: pkg/networkmanager/interfaces.js:3019 pkg/networkmanager/interfaces.js:3023
-#: pkg/networkmanager/interfaces.js:3029 pkg/networkmanager/index.html.h:22
-msgid "Automatic"
-msgstr "Automatisch"
-
-#: pkg/networkmanager/interfaces.js:1814
-msgid "Automatic (DHCP only)"
-msgstr "Automatisch (nur DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1817
-msgid "Ignore"
-msgstr "Ignorieren"
 
 #: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
 msgid "Round Robin"
 msgstr "Round Robin"
 
-#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
-msgid "Active Backup"
-msgstr "Aktive Sicherung"
+#: pkg/kubernetes/views/route-page.html:14
+#: pkg/kubernetes/views/route-panel.html:9
+msgid "Route"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1824
-msgid "XOR"
-msgstr "XOR"
+#: pkg/kubernetes/views/details-page.html:65
+msgid "Routes"
+msgstr "Routen"
 
-#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
-msgid "Broadcast"
-msgstr "Broadcast"
-
-#: pkg/networkmanager/interfaces.js:1826
-msgid "802.3ad"
-msgstr "802.3ad"
-
-#: pkg/networkmanager/interfaces.js:1827
-msgid "Adaptive transmit load balancing"
-msgstr "Adaptives Transmit Load Balancing (tlb)"
-
-#: pkg/networkmanager/interfaces.js:1828
-msgid "Adaptive load balancing"
-msgstr "Adaptives Load Balancing (alb)"
-
-#: pkg/networkmanager/interfaces.js:1833
-msgid "MII (Recommended)"
-msgstr "MII (empfohlen)"
-
-#: pkg/networkmanager/interfaces.js:1834
-msgid "ARP"
-msgstr "ARP"
-
-#: pkg/networkmanager/interfaces.js:1841
+#: pkg/systemd/services.html:384
 #, fuzzy
-msgid "Load Balancing"
-msgstr "Adaptives Load Balancing (alb)"
+msgid "Run"
+msgstr "Läuft"
 
-#: pkg/networkmanager/interfaces.js:1843
+#: pkg/kubernetes/views/image-config.html:4
+msgid "Run as"
+msgstr ""
+
+#: pkg/networkmanager/index.html:381
 #, fuzzy
-msgid "802.3ad LACP"
-msgstr "802.3ad"
+msgid "Runner"
+msgstr "Läuft"
 
-#: pkg/networkmanager/interfaces.js:1848
-msgid "Passive"
+#: pkg/ostree/index.html:83
+msgid "Running"
+msgstr "Läuft"
+
+#: pkg/selinux/setroubleshoot-view.jsx:478
+msgid "SELinux Access Control Errors"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1854
-msgid "Ethtool"
+#: pkg/selinux/setroubleshoot-view.jsx:330
+msgid "SELinux Policy"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1855
+#: pkg/selinux/setroubleshoot.html:23
+msgid "SELinux Troubleshoot"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:317
+msgid "SELinux is disabled on the system."
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:309
+msgid "SELinux system status is unknown."
+msgstr ""
+
+#: pkg/storaged/jobs.js:119
+msgid "SMART self-test of $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:218
+msgid "STP Forward delay"
+msgstr "STP Forward Delay"
+
+#: pkg/networkmanager/index.html:227
+msgid "STP Hello time"
+msgstr "STP Hello-Zeitintervall"
+
+#: pkg/networkmanager/index.html:236
+msgid "STP Maximum message age"
+msgstr "STP Maximum Message Age"
+
+#: pkg/networkmanager/index.html:209
+msgid "STP Priority"
+msgstr "STP Priorität"
+
+#: pkg/systemd/services.html:466
+msgid "Save"
+msgstr ""
+
+#: pkg/ostree/client.js:66
+msgid "Scanning metadata"
+msgstr "Untersuche Metadaten"
+
+#: pkg/kubernetes/views/node-capacity.html:9
+msgid "Scheduled Pods"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:322
+msgid "Scheduling Disabled"
+msgstr ""
+
+#: pkg/systemd/services.html:402 pkg/systemd/services.html:406
+msgid "Seconds"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:195
+msgid "Secret"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:106
+msgid "Secret File"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:141
+msgid "Secret Name"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:69
+#: pkg/kubernetes/views/volume-body.html:108
+#: pkg/kubernetes/views/volume-body.html:134
+msgid "Secret Volume"
+msgstr ""
+
+#: pkg/systemd/index.html:93
+msgid "Secure Shell Keys"
+msgstr ""
+
+#: pkg/storaged/jobs.js:136
+msgid "Securely erasing $target"
+msgstr "$target wird sicher gelöscht"
+
+#: pkg/kubernetes/views/file-button.html:4
+msgid "Select Manifest File..."
+msgstr "Wählen Sie eine Manifestdatei aus..."
+
+#: pkg/kubernetes/views/topology-page.html:7
+msgid "Select an object to see more details."
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:8
+msgid ""
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
+msgstr ""
+
+#: pkg/networkmanager/index.html:69 pkg/networkmanager/index.html:97
+#: pkg/networkmanager/index.html:115 pkg/networkmanager/index.html:515
+#: pkg/networkmanager/index.html:550
+msgid "Sending"
+msgstr "Sende"
+
+#: pkg/storaged/index.html:432
+msgctxt "storage"
+msgid "Serial Number"
+msgstr "Seriennummer"
+
+#: pkg/kubernetes/views/pv-modify.html:82
+#: pkg/kubernetes/views/volume-body.html:47
+msgid "Server"
+msgstr ""
+
+#: pkg/storaged/overview.js:518
+msgid "Server Address"
+msgstr ""
+
+#: pkg/users/local.js:682 pkg/users/local.js:683
+msgid "Server Administrator"
+msgstr "Server Administrator"
+
+#: pkg/storaged/overview.js:521
 #, fuzzy
-msgid "ARP Ping"
-msgstr "ARP-Überwachung"
+msgid "Server address cannot be empty."
+msgstr "Name darf nicht leer sein."
 
-#: pkg/networkmanager/interfaces.js:1856
-msgid "NSNA Ping"
+#: src/base1/cockpit.js:3709
+msgid "Server has closed the connection."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2156
-msgid "Deleting <b>$0</b> will break the connection to the server, "
+#: pkg/kubernetes/views/service-page.html:12
+#: pkg/kubernetes/views/service-panel.html:8
+#: pkg/kubernetes/views/topology-page.html:32
+msgid "Service"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2188
-msgid "Switching on <b>$0</b>  will break the connection to the server, "
+#: pkg/kubernetes/views/pod-body.html:12
+msgid "Service Account"
+msgstr ""
+
+#: pkg/systemd/services.html:279
+msgid "Service Logs"
+msgstr ""
+
+#: pkg/systemd/services.html:342
+#, fuzzy
+msgid "Service name"
+msgstr "Gerätedatei"
+
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:272
+#: pkg/kubernetes/views/dashboard-page.html:134
+#: pkg/kubernetes/views/details-page.html:29
+msgid "Services"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:33
+msgid ""
+"Services group pods and provide a common DNS                name and an "
+"optional, load-balanced IP address to access them."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:20
+msgid "Session Affinity"
+msgstr ""
+
+#: pkg/dashboard/index.html:190
+msgid "Set"
+msgstr ""
+
+#: pkg/systemd/host.js:559
+msgid "Set Host name"
+msgstr "Hostname festlegen"
+
+#: pkg/users/index.html:117 pkg/users/index.html:221
+msgid "Set Password"
+msgstr "Passwort setzen"
+
+#: pkg/systemd/index.html:395
+msgid "Set Time"
+msgstr ""
+
+#: pkg/docker/index.html:551
+msgid "Set container environment variables"
+msgstr ""
+
+#: pkg/networkmanager/index.html:172
+msgid "Set to"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:326
+msgid ""
+"Setting deviates from the configured state and will revert on the next boot."
+msgstr ""
+
+#: pkg/storaged/jobs.js:131
+msgid "Setting up loop device $target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:139
+msgid "Share Name"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1807
+msgid "Shared"
+msgstr "Geteilt"
+
+#: pkg/kubernetes/views/container-panel.html:9
+#: pkg/kubernetes/views/container-page-inline.html:14
+msgid "Shell"
+msgstr ""
+
+#: pkg/kubernetes/views/container-page.html:4
+msgid "Show all Containers"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:8
+msgid "Show all Deployment Configs"
+msgstr ""
+
+#: pkg/kubernetes/views/node-page.html:8
+msgid "Show all Nodes"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:9
+msgid "Show all Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-container.html:4
+msgid "Show all Pod Containers"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:8
+msgid "Show all Pods"
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:16
+#: pkg/kubernetes/views/group-page.html:14
+#: pkg/kubernetes/views/project-page.html:23
+msgid "Show all Projects"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:10
+msgid "Show all Replication Controllers"
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:10
+msgid "Show all Routes"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:8
+msgid "Show all Services"
+msgstr ""
+
+#: pkg/docker/index.html:127
+#, fuzzy
+msgid "Show all containers"
+msgstr "Containers"
+
+#: pkg/kubernetes/views/imagestream-page.html:12
+msgid "Show all image streams"
+msgstr ""
+
+#: pkg/docker/index.html:241 pkg/kubernetes/views/image-page.html:11
+msgid "Show all images"
+msgstr ""
+
+#: pkg/systemd/index.html:94
+msgid "Show fingerprints"
+msgstr ""
+
+#: pkg/systemd/index.html:136
+msgid "Shutdown"
+msgstr "Herunterfahren"
+
+#: pkg/kubernetes/views/container-body.html:18
+msgid "Since"
+msgstr "Seit"
+
+#: pkg/systemd/init.js:621
+msgid "Since $0"
+msgstr "Seit $0"
+
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/storaged/index.html:232
+msgid "Size"
+msgstr "Größe"
+
+#: pkg/storaged/dialog.js:271
+#, fuzzy
+msgid "Size cannot be negative"
+msgstr "Name darf nicht leer sein."
+
+#: pkg/storaged/dialog.js:269
+#, fuzzy
+msgid "Size cannot be zero"
+msgstr "Name darf nicht leer sein."
+
+#: pkg/storaged/dialog.js:273
+msgid "Size is too large"
+msgstr ""
+
+#: pkg/storaged/dialog.js:267
+msgid "Size must be a number"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:43
+#: pkg/kubernetes/views/auth-rejected-cert.html:11
+msgid "Skip Certificate Verification"
+msgstr ""
+
+#: pkg/systemd/services.html:54
+msgid "Sockets"
+msgstr ""
+
+#: pkg/ostree/index.html:23
+msgid "Software Updates"
+msgstr ""
+
+#: pkg/docker/storage.jsx:156
+#, fuzzy
+msgid "Solid-State Disk"
+msgstr "Solid-State Datenträger"
+
+#: pkg/storaged/overview.js:182
+msgctxt "storage"
+msgid "Solid-State Disk"
+msgstr "Solid-State Datenträger"
+
+#: pkg/selinux/setroubleshoot-view.jsx:90
+msgid "Solution applied successfully"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:97
+msgid "Solution failed"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:908
+msgid "Sorry, I don't know how to modify this volume"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:8
+msgid "Source URL"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2573
+msgid "Spanning Tree Protocol"
+msgstr "Spanning Tree Protocol"
+
+#: pkg/networkmanager/index.html:200
+msgid "Spanning Tree Protocol (STP)"
+msgstr "Spanning Tree Protocol (STP)"
+
+#: pkg/storaged/details.js:1594
+msgid "Spare"
+msgstr "Ersatz"
+
+#: pkg/systemd/index.html:470
+msgid "Specific Time"
+msgstr ""
+
+#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
+msgid "Start"
+msgstr "Starten"
+
+#: pkg/docker/index.html:68
+msgid "Start Docker"
+msgstr "Docker starten"
+
+#: pkg/storaged/index.html:49
+msgid "Start Multipath"
+msgstr ""
+
+#: pkg/storaged/details.js:1614
+msgid "Start Scrubbing"
+msgstr "Schrubben Starten"
+
+#: pkg/storaged/jobs.js:139
+msgid "Starting RAID Device $target"
+msgstr "Starte RAID-Gerät $target"
+
+#: pkg/storaged/jobs.js:124
+msgid "Starting swapspace $target"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:37
+#, fuzzy
+msgid "Starts"
+msgstr "Starten"
+
+#: pkg/kubernetes/views/container-body.html:16
+#: pkg/kubernetes/views/details-page.html:38
+#: pkg/kubernetes/views/details-page.html:175
+msgid "State"
+msgstr ""
+
+#: pkg/storaged/index.html:571
+msgctxt "storage"
+msgid "State"
+msgstr "Status"
+
+#: pkg/systemd/init.js:303
+msgid "Static"
+msgstr "Statisch"
+
+#: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/containers-listing.html:16
+#: pkg/kubernetes/views/nodes-page.html:44
+#: pkg/kubernetes/views/pvc-body.html:13 pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/pv-body.html:24
+msgid "Status"
+msgstr "Status"
+
+#: pkg/subscriptions/subscriptions-view.jsx:146
+#, fuzzy
+msgid "Status: $0"
+msgstr "Status"
+
+#: pkg/subscriptions/subscriptions-view.jsx:141
+msgid "Status: System isn't registered"
+msgstr ""
+
+#: pkg/networkmanager/index.html:455
+msgid "Sticky"
+msgstr ""
+
+#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
+msgid "Stop"
+msgstr "Stoppen"
+
+#: pkg/storaged/details.js:1615
+msgid "Stop Scrubbing"
+msgstr "Schrubben Stoppen"
+
+#: pkg/kubernetes/views/image-config.html:10
+msgid "Stop with"
+msgstr ""
+
+#: pkg/docker/util.js:231
+msgid "Stopped"
+msgstr "Angehalten"
+
+#: pkg/storaged/jobs.js:138
+msgid "Stopping RAID Device $target"
+msgstr "Stoppe RAID-Gerät $target"
+
+#: pkg/storaged/jobs.js:125
+msgid "Stopping swapspace $target"
+msgstr ""
+
+#: pkg/storaged/index.html:23 pkg/storaged/index.html:672
+msgid "Storage"
+msgstr ""
+
+#: pkg/storaged/index.html:686
+msgid "Storage Log"
+msgstr ""
+
+#: pkg/storaged/index.html:342
+msgid "Storage Logs"
+msgstr ""
+
+#: pkg/docker/index.html:324
+msgid "Storage pool"
+msgstr ""
+
+#: pkg/systemd/index.html:148
+msgid "Store Performance Data"
+msgstr ""
+
+#: pkg/storaged/details.js:237
+msgid "Store passphrase"
+msgstr "Passphrase speichern"
+
+#: pkg/storaged/details.js:527
+msgid "Stored Passphrase"
+msgstr "Gespeichertes Passwort"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:12
+msgid ""
+"Strategy            {{item.spec.strategy.type}}            Latest "
+"Version            {{ item.status.latestVersion }}            Not "
+"deployed        "
+msgstr ""
+
+#: pkg/subscriptions/index.html:22
+msgid "Subscriptions"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:4
+msgid "Summary"
+msgstr ""
+
+#: pkg/storaged/details.js:1251
+msgctxt "storage-id-desc"
+msgid "Swap Space"
+msgstr "Auslagerungsspeicher"
+
+#: pkg/systemd/index.html:243
+msgid "Swap Used"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
+msgid "Switch off $0"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2191 pkg/networkmanager/interfaces.js:2765
@@ -2482,356 +5216,616 @@ msgstr ""
 msgid "Switching off <b>$0</b>  will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
-msgid "Switch off $0"
+#: pkg/networkmanager/interfaces.js:2773
+msgid "Switching off <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
-#: pkg/networkmanager/interfaces.js:2507
-msgid "Bond"
-msgstr "Bond"
+#: pkg/networkmanager/interfaces.js:2188
+msgid "Switching on <b>$0</b>  will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2762
+msgid "Switching on <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:75
+msgid "Synchronize"
+msgstr ""
+
+#: pkg/dashboard/index.html:188 pkg/lib/machine-sync-users.html:4
+msgid "Synchronize users"
+msgstr ""
+
+#: pkg/systemd/index.html:54
+msgid "Synchronized"
+msgstr ""
+
+#: pkg/systemd/index.html:51
+msgid "Synchronized with {{Server}}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:146
+msgid "Synchronizing RAID Device $target"
+msgstr ""
+
+#: pkg/systemd/index.html:4
+msgid "System"
+msgstr ""
+
+#: pkg/systemd/services.html:53
+msgid "System Services"
+msgstr "System Dienste"
+
+#: pkg/systemd/index.html:112
+msgid "System Time"
+msgstr ""
+
+#: pkg/docker/index.html:349
+msgid "TCP"
+msgstr "TCP"
+
+#: pkg/kubernetes/views/route-body.html:12
+msgid "TLS Termination"
+msgstr ""
+
+#: pkg/docker/index.html:724
+msgid "Tag"
+msgstr "Tag"
+
+#: pkg/kubernetes/views/image-body.html:27
+#: pkg/kubernetes/views/imagestream-modify.html:76
+#: pkg/kubernetes/views/image-listing.html:14
+msgid "Tags"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:136
+msgid "Target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:75
+msgid "Target Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:114
+msgid "Target World Wide Names"
+msgstr ""
+
+#: pkg/systemd/services.html:52
+msgid "Targets"
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2235 pkg/networkmanager/interfaces.js:2247
 #: pkg/networkmanager/interfaces.js:2530
 msgid "Team"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
-#: pkg/networkmanager/interfaces.js:2622
-msgid "VLAN"
-msgstr "VLAN"
+#: pkg/networkmanager/interfaces.js:2558
+msgid "Team Port"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
-#: pkg/networkmanager/interfaces.js:2584
-msgid "Bridge"
-msgstr "Brücke"
+#: pkg/networkmanager/index.html:652
+#, fuzzy
+msgid "Team Port Settings"
+msgstr "Bridge Port Einstellungen"
 
-#: pkg/networkmanager/interfaces.js:2276
-msgid "Carrier"
-msgstr "Träger"
+#: pkg/networkmanager/index.html:624
+#, fuzzy
+msgid "Team Settings"
+msgstr "IP Einstellungen"
 
-#: pkg/networkmanager/interfaces.js:2279 pkg/kubernetes/scripts/volumes.js:990
-msgid "Yes"
-msgstr "Ja"
+#: pkg/kubernetes/views/replicationcontroller-page.html:20
+#: pkg/kubernetes/views/deploymentconfig-panel.html:10
+#: pkg/kubernetes/views/deploymentconfig-page.html:15
+#: pkg/kubernetes/views/replicationcontroller-panel.html:14
+msgid "Template"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2299
-#: pkg/subscriptions/subscriptions-view.jsx:36
-#: pkg/kubernetes/views/node-body.html.h:14
-#: pkg/kubernetes/views/containers-listing.html.h:7
-#: pkg/kubernetes/views/volumes-page.html.h:5
-#: pkg/kubernetes/views/pv-claim.html.h:6
-#: pkg/kubernetes/views/nodes-page.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:5 pkg/kubernetes/views/pv-body.html.h:4
-msgid "Status"
-msgstr "Status"
+#: pkg/systemd/terminal.html:4
+msgid "Terminal"
+msgstr ""
+
+#: pkg/users/index.html:78
+msgid "Terminate Session"
+msgstr ""
+
+#: pkg/networkmanager/index.html:38
+msgid "Testing connection"
+msgstr ""
+
+#: pkg/storaged/index.html:40
+msgid "The \"storaged\" API is not available on this system."
+msgstr ""
+
+#: pkg/docker/storage.jsx:485
+msgid "The Docker storage pool cannot be managed on this system."
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:386
+msgid "The IP address or host name cannot contain whitespace."
+msgstr "IP Adresse oder Hostname darf keine Leerzeichen enthalten."
+
+#: pkg/storaged/index.html:532
+msgid "The RAID Array is in a degraded state"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:399
+msgid "The address contains invalid characters"
+msgstr "Das Adressfeld enthält ungültige Zeichen"
+
+#: pkg/lib/machine-unknown-hostkey.html:6
+msgid ""
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:324
+msgid "The configured state is unknown, it might change on the next boot."
+msgstr ""
+
+#: pkg/kubernetes/views/container-page-inline.html:22
+msgid "The container '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:192
+msgid "The current user isn't allowed to access system subscription status."
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:25
+msgid "The deployment config '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:47
+msgid "The group '{{ groupName }}' does not exist."
+msgstr ""
+
+#: pkg/shell/base_index.js:673
+msgid "The javascript console contains details about this error "
+msgstr ""
+
+#: pkg/lib/machine-invalid-hostkey.html:8
+msgid ""
+"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
+"in use. Unless this machine was recently replaced, it is likely that someone "
+"is trying to attack your connection to this machine."
+msgstr ""
+
+#: pkg/users/authorized-keys.js:118
+msgid "The key you provided was not valid."
+msgstr ""
+
+#: pkg/storaged/details.js:1751
+msgid "The last physical volume of a volume group cannot be removed."
+msgstr ""
+
+#: pkg/shell/indexes.js:314
+msgid "The machine is restarting"
+msgstr "Die Maschine startet neu"
+
+#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
+msgid "The maximum number of replicas is 128"
+msgstr "Die maximale Anzahl von Repliken ist 128"
+
+#: pkg/kubernetes/scripts/nodes.js:407
+msgid "The name contains invalid characters"
+msgstr ""
+
+#: pkg/kubernetes/views/node-page.html:23
+msgid "The node '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/node-alerts.html:7
+msgid "The node doesn't have enough disk space"
+msgstr ""
+
+#: pkg/kubernetes/views/node-alerts.html:11
+msgid "The node doesn't have enough free memory"
+msgstr ""
+
+#: pkg/users/local.js:395 pkg/users/local.js:1082
+msgid "The passwords do not match"
+msgstr "Die Passwörter stimmen nicht überein"
+
+#: pkg/lib/credentials.js:186
+msgid "The passwords do not match."
+msgstr "Die Passwörter stimmen nicht überein."
+
+#: pkg/kubernetes/views/pv-page.html:21
+msgid "The persistent volume '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:40
+msgid "The pod '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/project-page.html:34
+msgid "The project '{{ projName }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:30
+msgid "The replication controller '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:19
+msgid "The route '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:386
+msgid "The selected file is not a valid Kubernetes application manifest."
+msgstr ""
+"Die ausgewählte Datei ist kein gültiges Kubernetes Applikationsmanifest."
+
+#: src/base1/cockpit.js:3695
+msgid "The server refused to authenticate using any supported methods."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:2
+msgid "The server uses a certificate signed by an unknown authority."
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:19
+msgid "The service '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/docker/storage.jsx:355
+msgid ""
+"The storage pool will be reset to optimize its layout.  All containers will "
+"be erased."
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:29
+msgid "The user '{{ userName }}' does not exist."
+msgstr ""
+
+#: pkg/systemd/init.js:834
+#, fuzzy
+msgid "The user <b>$0</b> does not have permissions for creating timers"
+msgstr "Der Benutzer <b>$0</b> hat keine Rechte, um Server zu administrieren"
+
+#: pkg/dashboard/list.js:209
+msgid "The user <b>$0</b> is not permitted to manage servers"
+msgstr "Der Benutzer <b>$0</b> hat keine Rechte, um Server zu administrieren"
+
+#: pkg/storaged/permissions.js:61
+msgid "The user <b>$0</b> is not permitted to manage storage"
+msgstr "Der Benutzer <b>$0</b> hat keine Rechte, Speicher zu verwalten."
+
+#: pkg/users/local.js:40
+msgid "The user <b>$0</b> is not permitted to modify accounts"
+msgstr "Der Benutzer <b>$0</b> hat keine Rechte, Konten zu verändern"
+
+#: pkg/systemd/host.js:43
+msgid "The user <b>$0</b> is not permitted to modify hostnames"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1420
+msgid "The user <b>$0</b> is not permitted to modify network settings"
+msgstr ""
+"Der User <b>$0</b> hat keine Rechte, die Netzwerkeinstellungen zu verändern."
+
+#: pkg/realmd/operation.js:436
+msgid "The user <b>$0</b> is not permitted to modify realms"
+msgstr "Der Benutzer <b>$0</b> hat keine Rechte, Bereiche zu änden."
+
+#: pkg/users/local.js:501
+msgid ""
+"The user name can only consist of letters from a-z, digits, dots, dashes and "
+"underscores."
+msgstr ""
+
+#: pkg/users/index.html:332
+msgid "There are no authorized public keys for this account."
+msgstr "Für dieses Konto existieren keine autorisierten öffentlichen Schlüssel"
+
+#: pkg/storaged/details.js:1756
+msgid ""
+"There is not enough free space elsewhere to remove this physical volume.  At "
+"least $0 more free space is needed."
+msgstr ""
+
+#: pkg/storaged/utils.js:168
+msgid "Thin Logical Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:8
+msgid ""
+"This claim is in use. Deleting it may cause issues with the following pod:"
+msgstr ""
+
+#: pkg/systemd/init.js:1222
+msgid ""
+"This day doesn't exist in all months.<br> The timer will only be executed in "
+"months that have 31st."
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2310
 msgid "This device cannot be managed here."
+msgstr ""
+
+#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
+#, fuzzy
+msgid "This field cannot be empty."
+msgstr "Name darf nicht leer sein."
+
+#: pkg/storaged/details.js:690
+msgid "This logical volume cannot be made smaller."
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:364
+msgid "This machine has already been added."
+msgstr "Diese Maschine wurde bereits hinzugefügt"
+
+#: pkg/realmd/operation.html:89
+msgid "This may take a while"
+msgstr "Dies kann eine Weile dauern"
+
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid ""
+"This option is for single node testing only – local storage will not work in "
+"a multi-node cluster"
+msgstr ""
+
+#: src/bridge/cockpitpackages.c:470
+msgid "This package is not compatible with this version of Cockpit"
+msgstr ""
+
+#: src/bridge/cockpitpackages.c:459
+#, c-format
+msgid "This package requires Cockpit version %s or later"
+msgstr ""
+
+#: pkg/tuned/dialog.js:102
+msgid "This system is using a custom profile"
+msgstr "Dieses System benutzt ein benutzerdefiniertes Profil"
+
+#: pkg/tuned/dialog.js:100
+msgid "This system is using the recommended profile"
+msgstr "Dieses System benutzt das empfohlene Profil"
+
+#: pkg/systemd/init.js:639
+msgid "This unit is an instance of the $0 template."
+msgstr ""
+
+#: pkg/systemd/services.html:302
+msgid "This unit is not designed to be enabled explicitly.          "
+msgstr ""
+
+#: pkg/users/local.js:509
+msgid "This user name already exists"
+msgstr "Dieser Benutzername existiert bereits"
+
+#: pkg/lib/machine-dialogs.js:380
+msgid ""
+"This version of cockpit-ws does not support connecting to a host with an "
+"alternate user or port"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:7
+msgid ""
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:23
+msgid "This volume has not been claimed"
+msgstr ""
+
+#: pkg/systemd/index.html:379
+msgid "Time Zone"
+msgstr ""
+
+#: pkg/systemd/services.html:55
+msgid "Timers"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:33
+msgid "To pull this image:"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:39
+msgid "To push to an image to this image stream:"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:11
+msgid ""
+"To try a different port you will need to upgrade cockpit-ws to a newer "
+"version."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:116
+msgid "Token"
+msgstr ""
+
+#: pkg/kubernetes/index.html:57
+msgid "Topology"
+msgstr ""
+
+#: pkg/docker/storage.jsx:314
+msgid "Total"
+msgstr ""
+
+#: pkg/ostree/index.html:99
+msgid "Tree"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:32
+msgid "Triggers"
+msgstr ""
+
+#: pkg/shell/index.html:328 pkg/shell/stub.html:181
+msgid "Troubleshoot"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:21
+msgid "Trust this certificate for this connection"
+msgstr ""
+
+#: pkg/systemd/init.js:520
+msgid "Try Restart"
+msgstr "Neustart Versuchen"
+
+#: pkg/docker/index.html:71 pkg/docker/index.html:74
+msgid "Try again"
+msgstr "Nochmals versuchen"
+
+#: pkg/systemd/index.html:59
+msgid "Trying to synchronize with {{Server}}"
+msgstr ""
+
+#: pkg/tuned/dialog.js:262
+msgid "Tuned has failed to start"
+msgstr "Tuned konnte nicht gestartet werden"
+
+#: pkg/tuned/dialog.js:94
+msgid "Tuned is not available"
+msgstr "Tuned ist nicht verfügbar"
+
+#: pkg/tuned/dialog.js:96
+msgid "Tuned is not running"
+msgstr "Tuned läuft nicht"
+
+#: pkg/tuned/dialog.js:98
+msgid "Tuned is off"
+msgstr "Tuned ist ausgeschaltet"
+
+#: pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/pv-modify.html:10
+#: pkg/kubernetes/views/volumes-page.html:20 pkg/kubernetes/views/deploy.html:9
+msgid "Type"
+msgstr "Typ"
+
+#: pkg/kubernetes/views/details-page.html:7
+msgid "Type:"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:110
+msgid "URL"
+msgstr ""
+
+#: pkg/storaged/index.html:547 pkg/storaged/index.html:626
+msgctxt "storage"
+msgid "UUID"
+msgstr "UUID"
+
+#: pkg/selinux/setroubleshoot-view.jsx:114
+msgid "Unable to apply this solution automatically"
+msgstr ""
+
+#: pkg/ostree/index.html:219
+msgid "Unable to communicate with OSTree"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:195
+#, fuzzy
+msgid "Unable to connect"
+msgstr "Erneut verbinden"
+
+#: pkg/kubernetes/scripts/dashboard.js:413
+msgid "Unable to decode Kubernetes application manifest."
+msgstr ""
+
+#: pkg/users/local.js:57
+msgid "Unable to delete root account"
+msgstr "Root-Konto konnte nicht gelöscht werden"
+
+#: pkg/selinux/setroubleshoot-client.js:157
+msgid "Unable to get alert"
+msgstr ""
+
+#: pkg/storaged/overview.js:586
+msgid "Unable to reach server"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:401
+msgid "Unable to read the Kubernetes application manifest. Code $0."
+msgstr ""
+"Das Kubernetes Applikationsmanifest konnte nicht gelesen werden. Code $0."
+
+#: pkg/users/local.js:59
+msgid "Unable to rename root account"
+msgstr "Root-Konto konnte nicht umbenannt werden"
+
+#: pkg/selinux/setroubleshoot-client.js:172
+msgid "Unable to run fix"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:52
+msgid "Unable to start setroubleshootd"
+msgstr ""
+
+#: pkg/playground/translate.html:35 pkg/playground/translate.html:40
+msgid "Unavailable"
+msgstr "Nicht verfügbar"
+
+#: pkg/docker/index.html:763 pkg/networkmanager/index.html:792
+msgid "Unexpected error"
+msgstr "Unerwarteter Fehler"
+
+#: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/image-body.html:15
+#: pkg/kubernetes/views/pv-claim.html:31 pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: pkg/storaged/details.js:1597
+msgid "Unknown ($0)"
+msgstr "Unbekannt ($0)"
+
+#: pkg/lib/machine-unknown-hostkey.html:2
+msgid "Unknown Host Key"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2342
 msgid "Unknown configuration"
 msgstr "Unbekannte Konfiguration"
 
-#: pkg/networkmanager/interfaces.js:2441
-msgid "Configure"
-msgstr "Konfigurieren"
-
-#: pkg/networkmanager/interfaces.js:2473
-msgid "$mtu"
+#: pkg/storaged/overview.js:582
+msgid "Unknown host name"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2477
-msgid "MTU"
+#: pkg/docker/index.html:570
+msgid "Unless Stopped"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2483
-msgid "Master"
-msgstr "Master"
+#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
+#: pkg/storaged/details.js:1110
+msgid "Unlock"
+msgstr "Öffnen"
 
-#: pkg/networkmanager/interfaces.js:2502
-msgid "ARP Monitoring"
-msgstr "ARP-Überwachung"
+#: pkg/shell/index.html:220
+msgid "Unlock Key"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#: pkg/storaged/jobs.js:121
+msgid "Unlocking $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:108
 #, fuzzy
-msgid "Broken configuration"
-msgstr "Unbekannte Konfiguration"
+msgid "Unmanaged Interfaces"
+msgstr "Schnittstellen"
 
-#: pkg/networkmanager/interfaces.js:2558
-msgid "Team Port"
-msgstr ""
+#: pkg/systemd/init.js:548
+msgid "Unmask"
+msgstr "Freigeben"
 
-#: pkg/networkmanager/interfaces.js:2573
-msgid "Spanning Tree Protocol"
-msgstr "Spanning Tree Protocol"
+#: pkg/storaged/details.js:1100
+msgid "Unmount"
+msgstr "Aushängen"
 
-#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
-msgid "Priority $priority"
-msgstr "Priorität $priority"
+#: pkg/storaged/jobs.js:127
+msgid "Unmounting $target"
+msgstr "$target wird ausgehängt"
 
-#: pkg/networkmanager/interfaces.js:2577
-msgid "Forward delay $forward_delay"
-msgstr "Weiterleitungsverzögerung $forward_delay"
+#: pkg/users/index.html:315
+msgid "Unnamed"
+msgstr "Unbennant"
 
-#: pkg/networkmanager/interfaces.js:2579
-msgid "Hello time $hello_time"
-msgstr "Hello-Zeit $hello_time"
-
-#: pkg/networkmanager/interfaces.js:2581
-msgid "Maximum message age $max_age"
-msgstr "Maximales Alter der Nachrichten $max_age"
-
-#: pkg/networkmanager/interfaces.js:2601
-msgid "Path cost $path_cost"
-msgstr "Pfadkosten $path_cost"
-
-#: pkg/networkmanager/interfaces.js:2603
-msgid "Hairpin mode"
-msgstr "Hairpin-Modus"
-
-#: pkg/networkmanager/interfaces.js:2605
-msgid "Bridge port"
-msgstr "Bridge-Port"
-
-#: pkg/networkmanager/interfaces.js:2619
-msgid "Parent $parent"
-msgstr "Parent $parent"
-
-#: pkg/networkmanager/interfaces.js:2620
-msgid "Id $id"
-msgstr "ID $id"
-
-#: pkg/networkmanager/interfaces.js:2628
-msgid "General"
-msgstr "Allgemein"
-
-#: pkg/networkmanager/interfaces.js:2637
-msgid "Connect automatically"
-msgstr "Verbindung automatisch herstellen"
-
-#: pkg/networkmanager/interfaces.js:2641
-msgid "IPv4"
-msgstr "IPv4"
-
-#: pkg/networkmanager/interfaces.js:2642
-msgid "IPv6"
-msgstr "IPv6"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/networkmanager/index.html.h:33
-#: pkg/kubernetes/views/project-listing.html.h:5
-msgid "Members"
-msgstr "Mitglieder"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/docker/index.html.h:39
-#: pkg/networkmanager/index.html.h:24
-#: pkg/kubernetes/views/service-body.html.h:6
-#: pkg/kubernetes/views/image-config.html.h:7
-#: pkg/kubernetes/views/container-body.html.h:5
-msgid "Ports"
-msgstr "Ports"
-
-#: pkg/networkmanager/interfaces.js:2762
-msgid "Switching on <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2773
-msgid "Switching off <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2788
-msgid "Removing <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2791
-#, fuzzy
-msgid "Remove $0"
-msgstr "Entfernen"
-
-#: pkg/networkmanager/interfaces.js:2833
-msgid "Adding <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2836
-msgid "Add $0"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2870
-msgid "Changing the settings will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2872
-#, fuzzy
-msgid "Change the settings"
-msgstr "Bridge Port Einstellungen"
-
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length or Netmask"
-msgstr "Präfix oder Netzmaske"
-
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length"
-msgstr "Präfix"
-
-#: pkg/networkmanager/interfaces.js:3011
-#: pkg/kubernetes/views/details-page.html.h:7
-msgid "Addresses"
-msgstr "Adressen"
-
-#: pkg/networkmanager/interfaces.js:3018
-msgid "DNS"
-msgstr "DNS"
-
-#: pkg/networkmanager/interfaces.js:3022
-msgid "DNS Search Domains"
-msgstr "DNS Suchdomänen"
-
-#: pkg/networkmanager/interfaces.js:3027
-#: pkg/kubernetes/views/details-page.html.h:11
-msgid "Routes"
-msgstr "Routen"
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv4 Settings"
-msgstr "IPv4 Einstellungen"
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv6 Settings"
-msgstr "IPv6 Einstellungen"
-
-#: pkg/networkmanager/interfaces.js:3436
-msgid "Creating this bond will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
-#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
-#, fuzzy
-msgid "Create it"
-msgstr "Erstellen"
-
-#: pkg/networkmanager/interfaces.js:3611
-msgid "Creating this team will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3842
-msgid "Creating this bridge will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4064
-msgid "Creating this VLAN will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4139
-msgid "MTU must be a positive number"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:196
-#, fuzzy
-msgid "Invalid credentials"
-msgstr "Ungültiger Port"
-
-#: pkg/subscriptions/subscriptions-client.js:198
-msgid "'Organization' required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:200
-msgid "Login/password or activation key required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:202
-msgid "'Organization' required when using activation keys."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:64
-#: pkg/kubernetes/views/volume-body.html.h:16
-#: pkg/kubernetes/views/pv-modify.html.h:11
-msgid "Server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:88
-#: pkg/subscriptions/subscriptions-register.jsx:152
-#: pkg/lib/machine-auth-failed.html.h:3 pkg/lib/machine-sync-users.html.h:6
-#: pkg/lib/machine-change-auth.html.h:6 pkg/shell/index.html.h:31
-#: pkg/users/index.html.h:16 pkg/kubernetes/views/auth-form.html.h:11
-msgid "Password"
-msgstr "Passwort"
-
-#: pkg/subscriptions/subscriptions-register.jsx:102
-#, fuzzy
-msgid "Custom URL"
-msgstr "Benutzerdefiniert"
-
-#: pkg/subscriptions/subscriptions-register.jsx:110
-msgid "URL"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:125
-msgid "Proxy"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:132
-msgid "Use proxy server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:140
-msgid "Login"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:164
-#, fuzzy
-msgid "Activation Key"
-msgstr "Aktivieren"
-
-#: pkg/subscriptions/subscriptions-register.jsx:176
-#, fuzzy
-msgid "Organization"
-msgstr "Übersetzung"
-
-#: pkg/subscriptions/main.js:45 pkg/subscriptions/subscriptions-view.jsx:143
-#: pkg/kubernetes/views/pv-modify.html.h:23
-msgid "Register"
-msgstr ""
-
-#: pkg/subscriptions/main.js:74
-msgid "Register system"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:32
-msgid "Product name"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product ID"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/index.html.h:13
-#: pkg/shell/index.html.h:14 pkg/shell/stub.html.h:9 pkg/shell/simple.html.h:9
-#: pkg/ostree/index.html.h:19
-msgid "Version"
-msgstr "Version"
-
-#: pkg/subscriptions/subscriptions-view.jsx:35
-#: pkg/kubernetes/views/image-config.html.h:5
-msgid "Architecture"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:37
-#, fuzzy
-msgid "Starts"
-msgstr "Starten"
-
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Ends"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:141
-msgid "Status: System isn't registered"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:146
-#, fuzzy
-msgid "Status: $0"
-msgstr "Status"
+#: pkg/storaged/details.js:1256
+msgctxt "storage-id-desc"
+msgid "Unrecognized Data"
+msgstr "Unerkannte Daten"
 
 #: pkg/subscriptions/subscriptions-view.jsx:148
 msgid "Unregister"
@@ -2842,354 +5836,215 @@ msgstr ""
 msgid "Unregistering system..."
 msgstr "Registriere System..."
 
-#: pkg/subscriptions/subscriptions-view.jsx:161
-#: pkg/subscriptions/index.html.h:1
-msgid "Subscriptions"
+#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
+#: src/bridge/cockpitdbussetup.c:625
+#, fuzzy
+msgid "Unsupported setup mechanism"
+msgstr "Nicht unterstützter Setup-Mechanismus: %s"
+
+#: src/base1/cockpit.js:3697
+msgid "Untrusted host"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/ostree/index.html.h:15
+#: pkg/docker/util.js:94
+msgid "Up since $StartedAt"
+msgstr "Läuft seit $StartedAt"
+
+#: pkg/lib/machine-change-port.html:41
+msgid "Update"
+msgstr ""
+
+#: pkg/ostree/index.html:125 pkg/ostree/index.html:152
+msgid "Updates"
+msgstr ""
+
+#: pkg/ostree/index.html:96
 msgid "Updating"
 msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:188
-msgid "Retrieving subscription status..."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:191
-msgid "Access denied"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:192
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:195
-#, fuzzy
-msgid "Unable to connect"
-msgstr "Erneut verbinden"
-
-#: pkg/subscriptions/subscriptions-view.jsx:196
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:222
-msgid "Installed products"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:223
-#, fuzzy
-msgid "No installed products on the system."
-msgstr ""
-"Docker ist auf Ihrem System entweder nicht installiert oder nicht aktiviert"
-
-#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "Keine gültige Anzahl von Repliken"
-
-#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "Die maximale Anzahl von Repliken ist 128"
-
-#: pkg/kubernetes/scripts/details.js:546
-msgid "Not a valid value for Host"
-msgstr "Kein gültiger Wert für Host"
 
 #: pkg/kubernetes/scripts/details.js:655
 msgid "Updating $0..."
 msgstr "Aktualisiere $0..."
 
-#: pkg/kubernetes/scripts/graphs.js:601 pkg/kubernetes/scripts/nodes.js:711
-#: pkg/kubernetes/scripts/nodes.js:817 pkg/dashboard/index.html.h:2
-msgid "CPU"
-msgstr "CPU"
-
-#: pkg/kubernetes/scripts/graphs.js:606 pkg/kubernetes/scripts/nodes.js:715
-#: pkg/kubernetes/scripts/nodes.js:826 pkg/dashboard/index.html.h:3
-msgid "Memory"
-msgstr "Speicher"
-
-#: pkg/kubernetes/scripts/graphs.js:611 pkg/dashboard/index.html.h:4
-msgid "Network"
-msgstr "Netzwerk"
-
-#: pkg/kubernetes/scripts/nodes.js:319 pkg/kubernetes/views/node-body.html.h:16
-#: pkg/kubernetes/views/details-page.html.h:10
-msgid "Not Ready"
-msgstr "Nicht bereit"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
+#: pkg/shell/index.html:165
+msgid "Use my password for privileged tasks and to connect to other machines"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:324 pkg/kubernetes/views/node-body.html.h:15
-#: pkg/kubernetes/views/details-page.html.h:9
-msgid "Ready"
-msgstr "Bereit"
-
-#: pkg/playground/translate.html:25
-msgctxt "verb"
-msgid "Ready"
-msgstr "Bereiten"
-
-#: pkg/kubernetes/scripts/nodes.js:397
-msgid "Please type an address"
-msgstr "Bitte geben Sie eine Adresse an"
-
-#: pkg/kubernetes/scripts/nodes.js:399
-msgid "The address contains invalid characters"
-msgstr "Das Adressfeld enthält ungültige Zeichen"
-
-#: pkg/kubernetes/scripts/nodes.js:407
-msgid "The name contains invalid characters"
+#: pkg/subscriptions/subscriptions-register.jsx:132
+msgid "Use proxy server"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
+#: pkg/shell/index.html:172
+msgid "Use the following keys to authenticate against other systems"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
+#: pkg/systemd/index.html:251
+msgid "Used"
+msgstr "Benutzt"
+
+#: pkg/systemd/index.html:229 pkg/dashboard/index.html:158
+#: pkg/playground/translate.html:86 pkg/playground/translate.html:106
+#: pkg/kubernetes/views/user-panel.html:9
+#: pkg/kubernetes/views/auth-form.html:61
+#: pkg/kubernetes/views/volume-body.html:64
+#: pkg/kubernetes/views/volume-body.html:103
+msgid "User"
+msgstr "Benutzer"
+
+#: pkg/users/index.html:90 pkg/users/index.html:154
+#: pkg/realmd/operation.html:47
+msgid "User Name"
+msgstr "Benutzername"
+
+#: pkg/realmd/operation.html:53
+msgid "User Password"
+msgstr "Benutzerpasswort"
+
+#: pkg/lib/machine-change-auth.html:18
+msgid "User name"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
-msgid "Disk"
+#: pkg/kubernetes/views/add-member-role-dialog.html:15
+msgid "User or Group"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
+#: pkg/kubernetes/views/auth-form.html:94
+msgid "Username"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:870
-#, c-format
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/kubernetes/scripts/nodes.js:872
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/kubernetes/scripts/connection.js:88
-msgid "Error writing kubectl config"
+#: pkg/kubernetes/views/project-listing.html:85
+msgid "Users"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:514
-msgid "Couldn't find running API server"
+#: pkg/storaged/details.js:181
+msgid "VFAT - Compatible with all systems and devices"
+msgstr "VFAT - Kompatibel mit allen System und Geräten"
+
+#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
+#: pkg/networkmanager/interfaces.js:2622
+msgid "VLAN"
+msgstr "VLAN"
+
+#: pkg/networkmanager/index.html:141
+msgid "VLAN Id"
+msgstr "VLAN Kennung"
+
+#: pkg/networkmanager/index.html:736
+msgid "VLAN Settings"
+msgstr "VLAN Einstellungen"
+
+#: pkg/users/authorized-keys.js:103
+msgid "Validating key"
+msgstr "Schlüssel wird überprüft"
+
+#: pkg/systemd/index.html:98 pkg/ostree/index.html:113 pkg/shell/simple.html:77
+#: pkg/shell/index.html:90 pkg/shell/stub.html:83
+msgid "Version"
+msgstr "Version"
+
+#: pkg/storaged/jobs.js:137
+msgid "Very securely erasing $target"
+msgstr "$target wird sehr sicher gelöscht"
+
+#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
+#: pkg/kubernetes/views/pvc-body.html:6
+msgid "Volume"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:516
-msgid "Connection Error: $0"
+#: pkg/storaged/index.html:620
+msgid "Volume Group"
+msgstr "Datenträgerverbund"
+
+#: pkg/storaged/utils.js:239
+msgid "Volume Group $0"
+msgstr "Datenträgerverbund $0"
+
+#: pkg/storaged/index.html:98
+msgid "Volume Groups"
+msgstr "Datenträgerverbünde"
+
+#: pkg/kubernetes/views/volume-body.html:14
+#: pkg/kubernetes/views/volume-body.html:89
+msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:539
-msgid "Please provide a valid address"
+#: pkg/kubernetes/views/pv-modify.html:115
+#: pkg/kubernetes/views/volume-body.html:42
+msgid "Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:554
-msgid "Please provide a username"
+#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
+msgid "Volume Type"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:650
-msgid "Error getting certificate details: $0"
+#: pkg/docker/index.html:536 pkg/kubernetes/views/pod-page.html:18
+#: pkg/kubernetes/views/image-config.html:28
+#: pkg/kubernetes/views/dashboard-page.html:47 pkg/kubernetes/index.html:70
+msgid "Volumes"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
+#: pkg/networkmanager/interfaces.js:819
+msgid "Waiting"
+msgstr "Wartet"
+
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid "Warning:"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
+#: pkg/systemd/logs.html:48
+msgid "Warnings"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
+#: pkg/systemd/services.html:409
+msgid "Weeks"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
+#: pkg/kubernetes/views/registry-dashboard-page.html:5
+msgid "Welcome to the Image Registry"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
+#: pkg/kubernetes/views/volumes-page.html:61
+msgid "When"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
-msgid "Host Path"
+#: pkg/docker/index.html:507
+msgid "With terminal"
+msgstr "Mit Konsole"
+
+#: pkg/storaged/index.html:438
+msgctxt "storage"
+msgid "World Wide Name"
+msgstr "Weltweiter Name"
+
+#: pkg/storaged/details.js:1595
+msgid "Write-mostly"
+msgstr "Hauptsächlich Schreiben"
+
+#: pkg/storaged/index.html:333
+msgid "Writing"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr ""
+#: pkg/ostree/client.js:64
+msgid "Writing objects"
+msgstr "Schreibe Objekte"
 
-#: pkg/kubernetes/scripts/volumes.js:199
-msgid "NFS Mount"
-msgstr ""
+#: pkg/storaged/details.js:177
+msgid "XFS - Red Hat Enterprise Linux 7 default"
+msgstr "XFS - Red Hat Enterprise Linux 7 default"
 
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr ""
+#: pkg/networkmanager/interfaces.js:1824
+msgid "XOR"
+msgstr "XOR"
 
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
-msgid "ISCSI"
-msgstr ""
+#: pkg/kubernetes/scripts/volumes.js:990 pkg/networkmanager/interfaces.js:2279
+msgid "Yes"
+msgstr "Ja"
 
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:469
-msgid "Please select a valid access mode"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:477
-msgid "Please provide a valid name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:485
-msgid "Please provide a valid storage capacity."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:493
-msgid "Please select a valid policy option."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:565
-msgid "Please select a valid endpoint"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:574
-msgid "Please provide a GlusterFS volume name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:632
-msgid "Please provide a valid NFS server"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
-msgid "Please provide a valid path"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:781
-msgid "Please provide a valid target"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:789
-msgid "Please provide a valid qualified name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:797
-msgid "Please provide a valid logical unit number"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:805
-msgid "Please provide a valid filesystem type"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:813
-msgid "Please provide a valid interface"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:860
-msgid "NFS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:872
-msgid "GlusterFS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:908
-msgid "Sorry, I don't know how to modify this volume"
-msgstr ""
-
-#: pkg/kubernetes/scripts/charts.js:113
-msgid "Unavailable"
-msgstr "Nicht verfügbar"
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "Der Namespace darf nicht leer sein."
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "Bitte geben Sie einen gültigen Namespace an."
-
-#: pkg/kubernetes/scripts/dashboard.js:384
+#: pkg/lib/machine-sync-users.html:47
 msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
+"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
+"synchronize users, a user with superuser privileges is required."
 msgstr ""
-"Es wurde keine Metadaten-Datei ausgewählt. Bitte geben Sie eine Kubernetes "
-"Metadaten-Datei an. "
-
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr ""
-"Die ausgewählte Datei ist kein gültiges Kubernetes Applikationsmanifest."
-
-#: pkg/kubernetes/scripts/dashboard.js:401
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr ""
-"Das Kubernetes Applikationsmanifest konnte nicht gelesen werden. Code $0."
-
-#: pkg/kubernetes/scripts/dashboard.js:413
-msgid "Unable to decode Kubernetes application manifest."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:441
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "Bitte erzeugen Sie einen anderen Namespace für $0 \"$1\""
-
-#: pkg/kubernetes/scripts/dashboard.js:460
-msgid "Manifest"
-msgstr ""
-
-#: pkg/dashboard/list.js:209
-msgid "The user <b>$0</b> is not permitted to manage servers"
-msgstr "Der Benutzer <b>$0</b> hat keine Rechte, um Server zu administrieren"
 
 #: pkg/dashboard/list.js:394
 msgid ""
@@ -3198,1331 +6053,28 @@ msgstr ""
 "Sie sind derzeit direkt mit diesem Server verbunden und können ihn deshalb "
 "nicht löschen."
 
-#: cockpit.appdata.xml.in.h:1
+#: pkg/kubernetes/views/auth-rejected-cert.html:3
 msgid ""
-"Cockpit is a server manager that makes it easy to administer your Linux "
-"servers via a web browser. Jumping between the terminal and the web tool is "
-"no problem. A service started via Cockpit can be stopped via the terminal. "
-"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
-"journal interface."
+"You can bypass the certificate check, but any data you send to the server "
+"could be intercepted by others."
 msgstr ""
-"Cockpit ist ein Server Manager zur einfachen Verwaltung Ihrer Linux Server "
-"via Web Browser. Ein Wechsel zwischen dem Terminal und der Weboberfläche ist "
-"kein Problem. Ein Service, der via Cockpit gestartet wurde, kann im Terminal "
-"beendet werden. Genauso können Fehler, welche im Terminal vorkommen, im "
-"Cockpit Journal angezeigt werden."
 
-#: cockpit.appdata.xml.in.h:2
-msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
-"stopping services. You can monitor and administer several servers at the "
-"same time. Just add them with a single click and your machines will look "
-"after its buddies."
+#: pkg/kubernetes/views/dashboard-page.html:150
+msgid "You can deploy an application to your cluster."
 msgstr ""
-"Cockpit ist perfekt für neue Systemadministratoren, da es ihnen auf einfache "
-"Weise ermöglicht, simple Aufgaben wie Speicherverwaltung, Journal / Logfile "
-"Analyse oder das Starten und Stoppen von Diensten durchzuführen. Sie können "
-"gleichzeitig mehrere Server überwachen und verwalten. Fügen Sie weitere "
-"Maschinen mit einem Klick hinzu und Ihre Maschinen schauen zu ihren Kumpels."
 
-#: cockpit.desktop.in.h:1 pkg/shell/index.html.h:1 pkg/shell/stub.html.h:1
-#: pkg/shell/simple.html.h:1
-msgid "Cockpit"
-msgstr "Cockpit"
-
-#: cockpit.desktop.in.h:2
-msgid "A user interface for GNU/Linux servers"
-msgstr "Eine Benutzerschnittstelle für GNU/Linux Server"
-
-#: cockpit.desktop.in.h:3
-msgid "Remote;Administration;"
-msgstr ""
-
-#: pkg/systemd/index.html.h:1
-msgid "System"
-msgstr ""
-
-#: pkg/systemd/index.html.h:2
-msgid "No host keys found."
-msgstr ""
-
-#: pkg/systemd/index.html.h:3
-msgid "Synchronized with {{Server}}"
-msgstr ""
-
-#: pkg/systemd/index.html.h:4
-msgid "Synchronized"
-msgstr ""
-
-#: pkg/systemd/index.html.h:5
-msgid "Trying to synchronize with {{Server}}"
-msgstr ""
-
-#: pkg/systemd/index.html.h:6
-msgid "Not synchronized"
-msgstr ""
-
-#: pkg/systemd/index.html.h:7
-msgid "Hardware"
-msgstr ""
-
-#: pkg/systemd/index.html.h:8
-msgid "Asset Tag"
-msgstr ""
-
-#: pkg/systemd/index.html.h:9 pkg/kubernetes/views/node-body.html.h:6
-msgid "Machine ID"
-msgstr ""
-
-#: pkg/systemd/index.html.h:10 pkg/ostree/index.html.h:18
-#: pkg/kubernetes/views/nodes-page.html.h:6
-msgid "Operating System"
-msgstr ""
-
-#: pkg/systemd/index.html.h:11
-msgid "Secure Shell Keys"
-msgstr ""
-
-#: pkg/systemd/index.html.h:12
-msgid "Show fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:14 pkg/dashboard/index.html.h:7
-msgid "Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:15
-msgid "Domain"
-msgstr ""
-
-#: pkg/systemd/index.html.h:16
-msgid "System Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:17
-msgid "Power Options"
-msgstr ""
-
-#: pkg/systemd/index.html.h:20
-msgid "Performance Profile"
-msgstr ""
-
-#: pkg/systemd/index.html.h:21
-msgid "Store Performance Data"
-msgstr ""
-
-#: pkg/systemd/index.html.h:32
-msgid "Machine SSH Key Fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:33
-msgid "Pretty Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:34
-msgid "Real Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:35
-msgid "Time Zone"
-msgstr ""
-
-#: pkg/systemd/index.html.h:36
-msgid ""
-"\n"
-"                                    Invalid time zone\n"
-"                                "
-msgstr ""
-
-#: pkg/systemd/index.html.h:39
-msgid "Set Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:40
-msgid "Manually"
-msgstr ""
-
-#: pkg/systemd/index.html.h:41
-msgid "Automatically using NTP"
-msgstr ""
-
-#: pkg/systemd/index.html.h:42
-msgid "Automatically using specific NTP servers"
-msgstr ""
-
-#: pkg/systemd/index.html.h:43
-msgid "Delay"
-msgstr "Verzögerung"
-
-#: pkg/systemd/index.html.h:44
-msgid "1 Minute"
-msgstr "1 Minute"
-
-#: pkg/systemd/index.html.h:45
-msgid "5 Minutes"
-msgstr "5 Minuten"
-
-#: pkg/systemd/index.html.h:46
-msgid "20 Minutes"
-msgstr "20 Minuten"
-
-#: pkg/systemd/index.html.h:47
-msgid "40 Minutes"
-msgstr "40 Minuten"
-
-#: pkg/systemd/index.html.h:48
-msgid "60 Minutes"
-msgstr "60 Minuten"
-
-#: pkg/systemd/index.html.h:49
-msgid "No Delay"
-msgstr "Keine Verzögerung"
-
-#: pkg/systemd/index.html.h:50
-msgid "Specific Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:51
-msgid ""
-"\n"
-"                        Cancel\n"
-"                    "
-msgstr ""
-
-#: pkg/systemd/logs.html.h:1
-msgid "Journal"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:2
-msgid "Recent"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:3
-msgid "Current boot"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:4
-msgid "Last 24 hours"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:5
-msgid "Last 7 days"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:6
-msgid "Errors"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:7
-msgid "Warnings"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:8
-msgid "Notices"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:9
-msgid "All"
-msgstr "Alle"
-
-#: pkg/systemd/logs.html.h:10 pkg/kubernetes/views/container-panel.html.h:2
-#: pkg/kubernetes/views/container-page-inline.html.h:2
-msgid "Logs"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:11
-msgid "Entry"
-msgstr ""
-
-#: pkg/systemd/services.html.h:1 pkg/kubernetes/views/dashboard-page.html.h:12
-#: pkg/kubernetes/views/details-page.html.h:3
-msgid "Services"
-msgstr ""
-
-#: pkg/systemd/services.html.h:3
-msgid "System Services"
-msgstr "System Dienste"
-
-#: pkg/systemd/services.html.h:4
-msgid "Sockets"
-msgstr ""
-
-#: pkg/systemd/services.html.h:5
-msgid "Timers"
-msgstr ""
-
-#: pkg/systemd/services.html.h:6
-msgid "Paths"
-msgstr ""
-
-#: pkg/systemd/services.html.h:7
-msgid "Instantiate"
-msgstr "Instanzieren"
-
-#: pkg/systemd/services.html.h:8
-msgid "{{days_text}}"
-msgstr ""
-
-#: pkg/systemd/services.html.h:9
-msgid "Service Logs"
-msgstr ""
-
-#: pkg/systemd/services.html.h:10
-msgid "Note"
-msgstr ""
-
-#: pkg/systemd/services.html.h:11
-msgid ""
-"This unit is not designed to be enabled explicitly.\n"
-"          "
-msgstr ""
-
-#: pkg/systemd/services.html.h:15
-#, fuzzy
-msgid "Create Timers"
-msgstr "Erstellen"
-
-#: pkg/systemd/services.html.h:16
-#, fuzzy
-msgid "Service name"
-msgstr "Gerätedatei"
-
-#: pkg/systemd/services.html.h:18 pkg/docker/index.html.h:32
-msgid "Command"
-msgstr "Befehl"
-
-#: pkg/systemd/services.html.h:19
-#, fuzzy
-msgid "Run"
-msgstr "Läuft"
-
-#: pkg/systemd/services.html.h:20
-msgid "After system boot"
-msgstr ""
-
-#: pkg/systemd/services.html.h:21
-msgid "At specific time"
-msgstr ""
-
-#: pkg/systemd/services.html.h:22
-msgid "Seconds"
-msgstr ""
-
-#: pkg/systemd/services.html.h:23
-#, fuzzy
-msgid "Minutes"
-msgstr "5 Minuten"
-
-#: pkg/systemd/services.html.h:24
-#, fuzzy
-msgid "Hours"
-msgstr "6 Stunden"
-
-#: pkg/systemd/services.html.h:25
-msgid "Weeks"
-msgstr ""
-
-#: pkg/systemd/services.html.h:26
-msgid "Don't Repeat"
-msgstr ""
-
-#: pkg/systemd/services.html.h:27
-msgid "Repeat Hourly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:28
-msgid "Repeat Daily"
-msgstr ""
-
-#: pkg/systemd/services.html.h:29
-msgid "Repeat Weekly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:30
-msgid "Repeat Monthly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:31
-msgid "Repeat Yearly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:32
-#, fuzzy
-msgid "Hour : Minute"
-msgstr "1 Minute"
-
-#: pkg/systemd/services.html.h:33
-msgid ":"
-msgstr ""
-
-#: pkg/systemd/services.html.h:35
-msgid "Save"
-msgstr ""
-
-#: pkg/systemd/terminal.html.h:1
-msgid "Terminal"
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:1
-msgid "Incorrect Host Key"
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:2
-msgid ""
-"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
-"in use. Unless this machine was recently replaced, it is likely that someone "
-"is trying to attack your connection to this machine."
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:3
+#: pkg/lib/machine-invalid-hostkey.html:11
 msgid ""
 "You can remove the previously stored key by running the following command"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html.h:1
-msgid "Authentication Failed"
+#: pkg/shell/base_index.js:672
+msgid "You can try restarting Cockpit by pressing refresh in your browser. "
 msgstr ""
+"Sie können versuchen, Cokpit durch Drücken von Aktualisieren in Ihrem "
+"Browser neu zu starten."
 
-#: pkg/lib/machine-auth-failed.html.h:2
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
-"machine with cockpit you will need to enable one of the following "
-"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:4 pkg/shell/index.html.h:30
-msgid "Public Key"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:5
-msgid "Kerberos Based SSO"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:6
-msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:1 pkg/dashboard/index.html.h:11
-msgid "Synchronize users"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:2
-msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:3
-msgid "Error loading users: {{perm_failed}}"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:4
-msgid ""
-"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
-"synchronize users, a user with superuser privileges is required."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:5 pkg/lib/machine-change-auth.html.h:4
-msgid "User name"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:8
-msgid "Synchronize"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:1
-msgid "Unknown Host Key"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:2
-msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:3 pkg/shell/index.html.h:4
-msgid "Fingerprint"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:5
-#: pkg/kubernetes/views/auth-form.html.h:14
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:6
-msgid "Connect"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:1
-msgid "Add Machine to Dashboard"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:3 pkg/dashboard/index.html.h:9
-msgid "Color"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:4
-msgid ""
-"Connecting simultaneously to more than {{ limit }} machines is unsupported."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:1
-msgid "Could not contact {{host}}"
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:2
-msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:3
-msgid ""
-"To try a different port you will need to upgrade cockpit-ws to a newer "
-"version."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:4
-msgid "Is sshd running on a different port?"
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:7
-msgid "Update"
-msgstr ""
-
-#: pkg/lib/machine-not-supported.html.h:1
-msgid "Cockpit is not installed"
-msgstr ""
-
-#: pkg/lib/machine-not-supported.html.h:2
-msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:1
-msgid "Log in to {{host}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:2
-msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:3
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:5 pkg/shell/index.html.h:9
-#: pkg/realmd/operation.html.h:3 pkg/kubernetes/views/auth-form.html.h:8
-msgid "Authentication"
-msgstr "Authentifizierung"
-
-#: pkg/lib/machine-change-auth.html.h:7
-msgid "Available"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:8
-msgid "Login Password"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:9
-msgid "Kerberos Ticket"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:10
-msgid "Checking for public keys"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:12
-msgid "Log In"
-msgstr ""
-
-#: pkg/shell/shell.html.h:1
-msgid "Things have moved"
-msgstr ""
-
-#: pkg/shell/index.html.h:2
-msgid "Comment"
-msgstr ""
-
-#: pkg/shell/index.html.h:5 pkg/shell/stub.html.h:2 pkg/shell/simple.html.h:2
-msgid "Ooops!"
-msgstr "Ooops!"
-
-#: pkg/shell/index.html.h:6 pkg/shell/stub.html.h:3 pkg/shell/simple.html.h:3
-msgid "Display Language"
-msgstr "Anzeigesprache"
-
-#: pkg/shell/index.html.h:7 pkg/shell/stub.html.h:4 pkg/shell/simple.html.h:4
-msgid "About Cockpit"
-msgstr "Über Cockpit"
-
-#: pkg/shell/index.html.h:8
-msgid "Account Settings"
-msgstr "Kontoeinstellungen"
-
-#: pkg/shell/index.html.h:10 pkg/shell/stub.html.h:5 pkg/shell/simple.html.h:5
-msgid "Log out"
-msgstr "Abmelden"
-
-#: pkg/shell/index.html.h:11 pkg/shell/stub.html.h:6 pkg/shell/simple.html.h:6
-msgid ""
-"\n"
-"              Cockpit is an interactive Linux server admin interface.\n"
-"            "
-msgstr ""
-"\n"
-"              Cockpit ist ein interaktives Administrationsinterface für "
-"Linux Server.\n"
-"            "
-
-#: pkg/shell/index.html.h:15 pkg/shell/stub.html.h:10
-#: pkg/shell/simple.html.h:10
-msgid "Choose the language to be used in the application"
-msgstr "Wählen Sie die in der Applikation zu verwendende Sprache"
-
-#: pkg/shell/index.html.h:16 pkg/shell/stub.html.h:11
-#: pkg/shell/simple.html.h:11 pkg/storaged/index.html.h:59
-msgid ""
-"\n"
-"              Cancel\n"
-"            "
-msgstr ""
-"\n"
-"              Abbrechen\n"
-"            "
-
-#: pkg/shell/index.html.h:19 pkg/shell/stub.html.h:14
-#: pkg/shell/simple.html.h:14
-msgid ""
-"\n"
-"              Select\n"
-"            "
-msgstr ""
-"\n"
-"              Auswählen\n"
-"            "
-
-#: pkg/shell/index.html.h:22 pkg/shell/stub.html.h:17
-msgid ""
-"\n"
-"              Close\n"
-"            "
-msgstr ""
-"\n"
-"              Schliessen\n"
-"            "
-
-#: pkg/shell/index.html.h:25
-msgid "Use my password for privileged tasks and to connect to other machines"
-msgstr ""
-
-#: pkg/shell/index.html.h:26
-msgid "Use the following keys to authenticate against other systems"
-msgstr ""
-
-#: pkg/shell/index.html.h:29 pkg/kubernetes/index.html.h:6
-msgid "Details"
-msgstr ""
-
-#: pkg/shell/index.html.h:32
-msgid "Unlock Key"
-msgstr ""
-
-#: pkg/shell/index.html.h:33 pkg/users/index.html.h:23
-msgid "Old Password"
-msgstr "Altes Passwort"
-
-#: pkg/shell/index.html.h:34 pkg/users/index.html.h:24
-msgid "New Password"
-msgstr "Neues Passwort"
-
-#: pkg/shell/index.html.h:35 pkg/users/index.html.h:19
-msgid "Confirm"
-msgstr "Bestätigen"
-
-#: pkg/shell/index.html.h:36
-msgid "Change Password"
-msgstr ""
-
-#: pkg/shell/index.html.h:38 pkg/shell/stub.html.h:20
-msgid ""
-"\n"
-"                Tools\n"
-"              "
-msgstr ""
-"\n"
-"                Werkzeuge\n"
-"              "
-
-#: pkg/shell/index.html.h:41 pkg/shell/stub.html.h:23
-#: pkg/shell/simple.html.h:24
-msgid "Reconnect"
-msgstr "Erneut verbinden"
-
-#: pkg/shell/index.html.h:42 pkg/shell/stub.html.h:24
-msgid "Troubleshoot"
-msgstr ""
-
-#: pkg/shell/simple.html.h:18
-msgid ""
-"\n"
-"              Try to reconnect\n"
-"            "
-msgstr ""
-"\n"
-"              Erneut verbinden\n"
-"            "
-
-#: pkg/shell/simple.html.h:21
-msgid ""
-"\n"
-"              Log in again\n"
-"            "
-msgstr ""
-"\n"
-"              Erneut anmelden\n"
-"            "
-
-#: pkg/ostree/index.html.h:1
-msgid "Software Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:2
-msgid "Check for updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:3
-msgid ""
-"\n"
-"                    Update and reboot\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:6
-msgid "Roll back and reboot"
-msgstr ""
-
-#: pkg/ostree/index.html.h:8
-msgid ""
-"\n"
-"                    Default\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:11
-msgid ""
-"\n"
-"                    Available\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:16
-msgid "Tree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:17
-msgid "Packages"
-msgstr ""
-
-#: pkg/ostree/index.html.h:20
-msgid "Released"
-msgstr ""
-
-#: pkg/ostree/index.html.h:21
-msgid "Additions"
-msgstr ""
-
-#: pkg/ostree/index.html.h:22
-msgid "Removals"
-msgstr ""
-
-#: pkg/ostree/index.html.h:23
-msgid "Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:24
-msgid "Downgrades"
-msgstr ""
-
-#: pkg/ostree/index.html.h:25
-msgid ""
-"\n"
-"                    This deployment contains the same packages as your "
-"currently booted system\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:28
-msgid "Operating System Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:29
-msgid "Connecting"
-msgstr ""
-
-#: pkg/ostree/index.html.h:30
-msgid "Unable to communicate with OSTree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:31
-msgid "No Deployments"
-msgstr ""
-
-#: pkg/ostree/index.html.h:32
-msgid ""
-"\n"
-"                    Reconnect\n"
-"                "
-msgstr ""
-
-#: pkg/selinux/setroubleshoot.html.h:1
-msgid "SELinux Troubleshoot"
-msgstr ""
-
-#: pkg/machines/index.html.h:1
-msgid "Virtual Machines Management"
-msgstr ""
-
-#: pkg/storaged/index.html.h:1
-msgid "Storage"
-msgstr ""
-
-#: pkg/storaged/index.html.h:2
-msgid "The \"storaged\" API is not available on this system."
-msgstr ""
-
-#: pkg/storaged/index.html.h:3
-msgid "Start Multipath"
-msgstr ""
-
-#: pkg/storaged/index.html.h:4
-msgid ""
-"\n"
-"        There are devices with multiple paths on the system, but the "
-"multipath service is not running.\n"
-"      "
-msgstr ""
-
-#: pkg/storaged/index.html.h:7
-msgid "RAID Devices"
-msgstr ""
-
-#: pkg/storaged/index.html.h:8
-msgid "No storage set up as RAID"
-msgstr ""
-
-#: pkg/storaged/index.html.h:9
-msgid "Volume Groups"
-msgstr "Datenträgerverbünde"
-
-#: pkg/storaged/index.html.h:10
-msgid "No volume groups created"
-msgstr "Keine Datenträgerverbünde erzeugt"
-
-#: pkg/storaged/index.html.h:11
-msgid "iSCSI Targets"
-msgstr ""
-
-#: pkg/storaged/index.html.h:12
-msgid "{{Address}}:{{Port}}"
-msgstr ""
-
-#: pkg/storaged/index.html.h:13
-msgid "No iSCSI targets set up"
-msgstr ""
-
-#: pkg/storaged/index.html.h:14
-msgid "Drives"
-msgstr ""
-
-#: pkg/storaged/index.html.h:15
-msgid "No drives attached"
-msgstr ""
-
-#: pkg/storaged/index.html.h:16
-msgid "Other Devices"
-msgstr "Andere Geräte"
-
-#: pkg/storaged/index.html.h:17
-msgid "Filesystems"
-msgstr ""
-
-#: pkg/storaged/index.html.h:21
-msgid "Jobs"
-msgstr ""
-
-#: pkg/storaged/index.html.h:23 pkg/networkmanager/index.html.h:3
-msgid "Go to now"
-msgstr "Zu 'Jetzt' gehen"
-
-#: pkg/storaged/index.html.h:24 pkg/networkmanager/index.html.h:4
-msgid "5 minutes"
-msgstr "5 Minuten"
-
-#: pkg/storaged/index.html.h:25 pkg/networkmanager/index.html.h:5
-msgid "1 hour"
-msgstr "1 Stunde"
-
-#: pkg/storaged/index.html.h:26 pkg/networkmanager/index.html.h:6
-msgid "6 hours"
-msgstr "6 Stunden"
-
-#: pkg/storaged/index.html.h:27 pkg/networkmanager/index.html.h:7
-msgid "1 day"
-msgstr "1 Tag"
-
-#: pkg/storaged/index.html.h:28 pkg/networkmanager/index.html.h:8
-msgid "1 week"
-msgstr "1 Woche"
-
-#: pkg/storaged/index.html.h:29
-msgid "Reading"
-msgstr ""
-
-#: pkg/storaged/index.html.h:30
-msgid "Writing"
-msgstr ""
-
-#: pkg/storaged/index.html.h:31
-msgid "Storage Logs"
-msgstr ""
-
-#: pkg/storaged/index.html.h:32
-msgid "Create partition table"
-msgstr ""
-
-#: pkg/storaged/index.html.h:34
-msgid "Block Device"
-msgstr ""
-
-#: pkg/storaged/index.html.h:40
-msgid "No media inserted"
-msgstr ""
-
-#: pkg/storaged/index.html.h:42
-msgid "DISK IS FAILING"
-msgstr "Datenträger ist FEHLERHAFT"
-
-#: pkg/storaged/index.html.h:43
-msgid "Disk is OK"
-msgstr "Datenträger ist OK"
-
-#: pkg/storaged/index.html.h:46
-msgid "The RAID Array is in a degraded state"
-msgstr ""
-
-#: pkg/storaged/index.html.h:47
-msgid "RAID Device"
-msgstr ""
-
-#: pkg/storaged/index.html.h:56
-msgid "Volume Group"
-msgstr "Datenträgerverbund"
-
-#: pkg/storaged/index.html.h:57
-msgid "Physical Volumes"
-msgstr ""
-
-#: pkg/storaged/index.html.h:58
-msgid "Storage Log"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:1
-msgid "Domain Address"
-msgstr "Domänenadressen"
-
-#: pkg/realmd/operation.html.h:2
-msgid "Computer OU"
-msgstr "Computer OU"
-
-#: pkg/realmd/operation.html.h:4 pkg/users/index.html.h:11
-msgid "User Name"
-msgstr "Benutzername"
-
-#: pkg/realmd/operation.html.h:5
-msgid "User Password"
-msgstr "Benutzerpasswort"
-
-#: pkg/realmd/operation.html.h:6
-msgid "Domain Administrator Name"
-msgstr "Name des Domain-Administrators"
-
-#: pkg/realmd/operation.html.h:7
-msgid "Domain Administrator Password"
-msgstr "Passwort des Domain-Administrators"
-
-#: pkg/realmd/operation.html.h:8
-msgid "One Time Password"
-msgstr "Einmalpasswort"
-
-#: pkg/realmd/operation.html.h:9
-msgid "This may take a while"
-msgstr "Dies kann eine Weile dauern"
-
-#: pkg/docker/index.html.h:1 pkg/kubernetes/index.html.h:4
-#: pkg/kubernetes/views/containers-listing.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:6
-#: pkg/kubernetes/views/dashboard-page.html.h:17
-msgid "Containers"
-msgstr "Containers"
-
-#: pkg/docker/index.html.h:2
-msgid "Connecting to Docker"
-msgstr "Verbinde zu Docker"
-
-#: pkg/docker/index.html.h:3
-msgid "Not authorized to access Docker on this system"
-msgstr "Keine Berechtigung, auf diesem System Docker zu verwenden"
-
-#: pkg/docker/index.html.h:4
-msgid "Docker is not installed or activated on the system"
-msgstr ""
-"Docker ist auf Ihrem System entweder nicht installiert oder nicht aktiviert"
-
-#: pkg/docker/index.html.h:5
-msgid "Can&rsquo;t connect to Docker"
-msgstr ""
-
-#: pkg/docker/index.html.h:6
-msgid "Start Docker"
-msgstr "Docker starten"
-
-#: pkg/docker/index.html.h:7
-msgid "Try again"
-msgstr "Nochmals versuchen"
-
-#: pkg/docker/index.html.h:8
-msgid "Combined CPU usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:9
-msgid "Combined memory usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:10
-#, fuzzy
-msgid "Show all containers"
-msgstr "Containers"
-
-#: pkg/docker/index.html.h:11
-msgid "IP Address:"
-msgstr ""
-
-#: pkg/docker/index.html.h:12
-msgid "IP Prefix Length:"
-msgstr ""
-
-#: pkg/docker/index.html.h:13
-msgid "Gateway:"
-msgstr ""
-
-#: pkg/docker/index.html.h:14
-msgid "MAC Address:"
-msgstr ""
-
-#: pkg/docker/index.html.h:15 pkg/kubernetes/views/image-page.html.h:1
-msgid "Show all images"
-msgstr ""
-
-#: pkg/docker/index.html.h:16 pkg/kubernetes/index.html.h:2
-#: pkg/kubernetes/registry.html.h:2
-msgid "Overview"
-msgstr ""
-
-#: pkg/docker/index.html.h:17
-msgid "Reset"
-msgstr ""
-
-#: pkg/docker/index.html.h:18
-msgid "Storage pool"
-msgstr ""
-
-#: pkg/docker/index.html.h:19
-msgid "Additional Storage"
-msgstr ""
-
-#: pkg/docker/index.html.h:20
-msgid "TCP"
-msgstr "TCP"
-
-#: pkg/docker/index.html.h:21
-msgid "{{host_port_label}}"
-msgstr "{{host_port_label}}"
-
-#: pkg/docker/index.html.h:22
-msgid "{{host_volume_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:24
-msgid "ReadWrite"
-msgstr ""
-
-#: pkg/docker/index.html.h:25
-msgid "ReadOnly"
-msgstr ""
-
-#: pkg/docker/index.html.h:26
-msgid "{{envvar_key_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:27
-msgid "{{envvar_value_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:28
-msgid "select container"
-msgstr ""
-
-#: pkg/docker/index.html.h:29
-msgid "{{alias_label}}"
-msgstr "{{alias_label}}"
-
-#: pkg/docker/index.html.h:30 pkg/kubernetes/views/image-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:2
-#: pkg/kubernetes/views/image-page.html.h:2
-msgid "Image"
-msgstr "Bild"
-
-#: pkg/docker/index.html.h:31
-msgid "Container Name"
-msgstr "Container Name"
-
-#: pkg/docker/index.html.h:33
-msgid "Memory limit"
-msgstr "Speicherlimite"
-
-#: pkg/docker/index.html.h:34
-msgid "MiB"
-msgstr ""
-
-#: pkg/docker/index.html.h:35
-msgid "CPU priority"
-msgstr "CPU Priorität"
-
-#: pkg/docker/index.html.h:36
-msgid "shares"
-msgstr ""
-
-#: pkg/docker/index.html.h:37
-msgid "With terminal"
-msgstr "Mit Konsole"
-
-#: pkg/docker/index.html.h:38
-msgid "Links"
-msgstr "Links"
-
-#: pkg/docker/index.html.h:40
-msgid "Expose container ports"
-msgstr ""
-
-#: pkg/docker/index.html.h:41 pkg/kubernetes/index.html.h:7
-#: pkg/kubernetes/views/image-config.html.h:9
-#: pkg/kubernetes/views/pod-page.html.h:3
-#: pkg/kubernetes/views/dashboard-page.html.h:4
-msgid "Volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:42
-msgid "Mount container volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:43 pkg/kubernetes/views/image-config.html.h:6
-#: pkg/kubernetes/views/container-body.html.h:9
-msgid "Environment"
-msgstr ""
-
-#: pkg/docker/index.html.h:44
-msgid "Set container environment variables"
-msgstr ""
-
-#: pkg/docker/index.html.h:45 pkg/kubernetes/views/pod-body.html.h:4
-msgid "Restart Policy"
-msgstr ""
-
-#: pkg/docker/index.html.h:47
-msgid "On Failure"
-msgstr ""
-
-#: pkg/docker/index.html.h:50
-msgid "Retries:"
-msgstr ""
-
-#: pkg/docker/index.html.h:51 pkg/users/index.html.h:26
-#: pkg/networkmanager/index.html.h:52
-msgid ""
-"\n"
-"            Cancel\n"
-"          "
-msgstr ""
-"\n"
-"            Abbrechen\n"
-"          "
-
-#: pkg/docker/index.html.h:54
-msgid ""
-"\n"
-"            Run\n"
-"          "
-msgstr ""
-"\n"
-"            Ausführen\n"
-"          "
-
-#: pkg/docker/index.html.h:57
-msgid ""
-"\n"
-"            Download\n"
-"          "
-msgstr ""
-"\n"
-"            Herunterladen\n"
-"          "
-
-#: pkg/docker/index.html.h:60
-msgid ""
-"\n"
-"            Change\n"
-"          "
-msgstr ""
-"\n"
-"            Ändern\n"
-"          "
-
-#: pkg/docker/index.html.h:63
-msgid "Repository"
-msgstr "Repository"
-
-#: pkg/docker/index.html.h:64
-msgid "Tag"
-msgstr "Tag"
-
-#: pkg/docker/index.html.h:65 pkg/kubernetes/views/image-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:5
-msgid "Author"
-msgstr "Autor"
-
-#: pkg/docker/index.html.h:66
-msgid ""
-"\n"
-"            Commit\n"
-"          "
-msgstr ""
-"\n"
-"            Commit\n"
-"          "
-
-#: pkg/users/index.html.h:1
-msgid "Local Accounts"
-msgstr ""
-
-#: pkg/users/index.html.h:2
-msgid ""
-"\n"
-"            Close\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:5
-msgid "Create New Account"
-msgstr ""
-
-#: pkg/users/index.html.h:6
-msgid "Account not available or cannot be edited."
-msgstr ""
-
-#: pkg/users/index.html.h:7
-msgid "Accounts"
-msgstr ""
-
-#: pkg/users/index.html.h:8
-msgid "Terminate Session"
-msgstr ""
-
-#: pkg/users/index.html.h:10
-msgid "Full Name"
-msgstr ""
-
-#: pkg/users/index.html.h:12
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:3
-#: pkg/kubernetes/views/project-body.html.h:2
-msgid "Roles"
-msgstr ""
-
-#: pkg/users/index.html.h:13
-msgid "Last Login"
-msgstr ""
-
-#: pkg/users/index.html.h:14
-msgid "Access"
-msgstr ""
-
-#: pkg/users/index.html.h:15
-msgid "Lock Account"
-msgstr "Konto sperren"
-
-#: pkg/users/index.html.h:17
-msgid "Set Password"
-msgstr "Passwort setzen"
-
-#: pkg/users/index.html.h:18
-msgid "Authorized Public SSH Keys"
-msgstr "Autorisierte öffentliche SSH-Schlüssel"
-
-#: pkg/users/index.html.h:20
-msgid ""
-"\n"
-"            Create\n"
-"          "
-msgstr ""
-"\n"
-"            Erstellen\n"
-"          "
-
-#: pkg/users/index.html.h:25
-msgid "Confirm New Password"
-msgstr "Neues Passwort wiederholen"
-
-#: pkg/users/index.html.h:29
-msgid ""
-"\n"
-"            Set\n"
-"          "
-msgstr ""
-"\n"
-"            Setzen\n"
-"          "
-
-#: pkg/users/index.html.h:32
-msgid "Delete Files"
-msgstr "Dateien löschen"
-
-#: pkg/users/index.html.h:33 pkg/networkmanager/index.html.h:48
-msgid ""
-"\n"
-"            Delete\n"
-"          "
-msgstr ""
-"\n"
-"            Löschen\n"
-"          "
-
-#: pkg/users/index.html.h:36
-msgid "Unnamed"
-msgstr "Unbennant"
-
-#: pkg/users/index.html.h:37
-msgid "Invalid key"
-msgstr "Ungültiger Schlüssel"
-
-#: pkg/users/index.html.h:38
-msgid "There are no authorized public keys for this account."
-msgstr "Für dieses Konto existieren keine autorisierten öffentlichen Schlüssel"
-
-#: pkg/users/index.html.h:39
+#: pkg/users/index.html:335
 msgid ""
 "You do not have permission to view the authorized public keys for this "
 "account."
@@ -4530,1675 +6082,184 @@ msgstr ""
 "Sie haben keine Berechtigung, die autorisierten öffentlichen Schlüssel von "
 "diesem Konto anzuzeigen."
 
-#: pkg/users/index.html.h:40
-msgid "Failed to load authorized keys."
-msgstr ""
-
-#: pkg/users/index.html.h:41
-msgid "Add public key"
-msgstr ""
-
-#: pkg/users/index.html.h:42
-msgid ""
-"\n"
-"            Add key\n"
-"          "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:1
-msgid "Diagnostic reports"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:2
-msgid ""
-"\n"
-"        This tool will collect system configuration and diagnostic\n"
-"        information from this system for use with diagnosing problems\n"
-"        with the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:7
-msgid ""
-"\n"
-"        The collected information will be stored locally on the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:10
-msgid "Create report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:11
-msgid "Create diagnostic report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:12
-msgid ""
-"\n"
-"                The generated archive contains data considered\n"
-"                sensitive and its content should be reviewed by the\n"
-"                originating organization before being passed to any\n"
-"                third party.\n"
-"              "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:18
-msgid "Generating report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:19
-msgid "Done!"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:1
-msgid "Networking"
-msgstr "Netzwerk"
-
-#: pkg/networkmanager/index.html.h:2
-msgid "Testing connection"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:9
-msgid "Sending"
-msgstr "Sende"
-
-#: pkg/networkmanager/index.html.h:10
-msgid "Receiving"
-msgstr "Empfange"
-
-#: pkg/networkmanager/index.html.h:11
-msgid "Interfaces"
-msgstr "Schnittstellen"
-
-#: pkg/networkmanager/index.html.h:12
-msgid "Add Bond"
-msgstr "Bündelung hinzufügen"
-
-#: pkg/networkmanager/index.html.h:13
-msgid "Add Team"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:14
-msgid "Add Bridge"
-msgstr "Bridge hinzufügen"
-
-#: pkg/networkmanager/index.html.h:15
-msgid "Add VLAN"
-msgstr "VLAN hinzufügen"
-
-#: pkg/networkmanager/index.html.h:17
-msgid "IP Address"
-msgstr "IP-Adresse"
-
-#: pkg/networkmanager/index.html.h:18
+#: pkg/docker/storage.jsx:482
 #, fuzzy
-msgid "Unmanaged Interfaces"
-msgstr "Schnittstellen"
-
-#: pkg/networkmanager/index.html.h:19
-msgid "Networking Logs"
-msgstr "Netzwerk-Logs"
-
-#: pkg/networkmanager/index.html.h:20
-msgid "Parent"
-msgstr "Parent"
-
-#: pkg/networkmanager/index.html.h:21
-msgid "VLAN Id"
-msgstr "VLAN Kennung"
-
-#: pkg/networkmanager/index.html.h:23
-msgid "Set to"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:25
-msgid "Spanning Tree Protocol (STP)"
-msgstr "Spanning Tree Protocol (STP)"
-
-#: pkg/networkmanager/index.html.h:26
-msgid "STP Priority"
-msgstr "STP Priorität"
-
-#: pkg/networkmanager/index.html.h:27
-msgid "STP Forward delay"
-msgstr "STP Forward Delay"
-
-#: pkg/networkmanager/index.html.h:28
-msgid "STP Hello time"
-msgstr "STP Hello-Zeitintervall"
-
-#: pkg/networkmanager/index.html.h:29
-msgid "STP Maximum message age"
-msgstr "STP Maximum Message Age"
-
-#: pkg/networkmanager/index.html.h:30
-msgid "Priority"
-msgstr "Priorität"
-
-#: pkg/networkmanager/index.html.h:31
-msgid "Path cost"
-msgstr "Pfadkosten"
-
-#: pkg/networkmanager/index.html.h:32
-msgid "Hair Pin mode"
-msgstr "Hairpin Modus"
-
-#: pkg/networkmanager/index.html.h:34
-msgid "Mode"
-msgstr "Modus"
-
-#: pkg/networkmanager/index.html.h:35
-msgid "Primary"
-msgstr "Primär"
-
-#: pkg/networkmanager/index.html.h:36
-msgid "Link Monitoring"
-msgstr "Verbindungsüberwachung"
-
-#: pkg/networkmanager/index.html.h:37
-msgid "Monitoring Interval"
-msgstr "Überwachungsintervall"
-
-#: pkg/networkmanager/index.html.h:38
-msgid "Monitoring Targets"
-msgstr "Überwachungsziele"
-
-#: pkg/networkmanager/index.html.h:39
-msgid "Link up delay"
-msgstr "Verzögerung bei der Aktivierung einer Verbindung"
-
-#: pkg/networkmanager/index.html.h:40
-msgid "Link down delay"
-msgstr "Verzögerung bei der Deaktivierung einer Verbindung"
-
-#: pkg/networkmanager/index.html.h:41
-#, fuzzy
-msgid "Runner"
-msgstr "Läuft"
-
-#: pkg/networkmanager/index.html.h:42
-msgid "Balancer"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:43
-#, fuzzy
-msgid "Link Watch"
-msgstr "Link local"
-
-#: pkg/networkmanager/index.html.h:44
-#, fuzzy
-msgid "Ping Interval"
-msgstr "Überwachungsintervall"
-
-#: pkg/networkmanager/index.html.h:45
-#, fuzzy
-msgid "Ping Target"
-msgstr "$target wird gelöscht"
-
-#: pkg/networkmanager/index.html.h:46
-msgid "Sticky"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:47
-msgid "LACP Key"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:51
-msgid "IP Settings"
-msgstr "IP Einstellungen"
-
-#: pkg/networkmanager/index.html.h:55
-msgid ""
-"\n"
-"            Apply\n"
-"          "
-msgstr ""
-"\n"
-"            Anwenden\n"
-"          "
-
-#: pkg/networkmanager/index.html.h:58
-msgid "Bond Settings"
-msgstr "Bond Einstellungen"
-
-#: pkg/networkmanager/index.html.h:59
-#, fuzzy
-msgid "Team Settings"
-msgstr "IP Einstellungen"
-
-#: pkg/networkmanager/index.html.h:60
-#, fuzzy
-msgid "Team Port Settings"
-msgstr "Bridge Port Einstellungen"
-
-#: pkg/networkmanager/index.html.h:61
-msgid "Bridge Settings"
-msgstr "Bridge Einstellungen"
-
-#: pkg/networkmanager/index.html.h:62
-msgid "Bridge Port Settings"
-msgstr "Bridge Port Einstellungen"
-
-#: pkg/networkmanager/index.html.h:63
-msgid "VLAN Settings"
-msgstr "VLAN Einstellungen"
-
-#: pkg/networkmanager/index.html.h:64
-msgid "Ethernet MTU"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:66
-msgid "Connection will be lost"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:1
-msgid "Kubernetes Cluster"
-msgstr "Kubernetes Cluster"
-
-#: pkg/kubernetes/index.html.h:3 pkg/kubernetes/views/dashboard-page.html.h:8
-#: pkg/kubernetes/views/nodes-page.html.h:4
-msgid "Nodes"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:5
-msgid "Topology"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:8 pkg/kubernetes/registry.html.h:3
-#: pkg/kubernetes/views/image-listing.html.h:2
-#: pkg/kubernetes/views/imagestream-page.html.h:3
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:5
-msgid "Images"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:9 pkg/kubernetes/registry.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:2
-#: pkg/kubernetes/views/project-listing.html.h:2
-#: pkg/kubernetes/views/user-delete.html.h:2
-msgid "Projects"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:11 pkg/kubernetes/registry.html.h:6
-msgid "Couldn't connect to server"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:12 pkg/kubernetes/registry.html.h:7
-msgid ""
-"\n"
-"                Reconnect\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:15
-msgid ""
-"\n"
-"                Troubleshoot\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/registry.html.h:1
-msgid "Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:1
-#: pkg/kubernetes/views/service-body.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:1
-#: pkg/kubernetes/views/containers-listing.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:9
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:18
-#: pkg/kubernetes/views/route-body.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:5
-#: pkg/kubernetes/views/imagestream-modify.html.h:4
-msgid "Project"
-msgstr "Projekt"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:2
-#: pkg/kubernetes/views/service-body.html.h:2
-#: pkg/kubernetes/views/pod-body.html.h:2
-#: pkg/kubernetes/views/containers-listing.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:10
-#: pkg/kubernetes/views/pv-claim.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:19
-#: pkg/kubernetes/views/route-body.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:6
-msgid "Namespace"
-msgstr "Namespace"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:3
-#: pkg/kubernetes/views/pod-body.html.h:3
-#: pkg/kubernetes/views/node-body.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:3
-#: pkg/kubernetes/views/route-body.html.h:3
-msgid "Created"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:4
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:17
-msgid "Replicas"
-msgstr "Repliken"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:5
-#: pkg/kubernetes/views/service-body.html.h:9
-#: pkg/kubernetes/views/pod-body.html.h:10
-#: pkg/kubernetes/views/node-body.html.h:12
-#: pkg/kubernetes/views/image-meta.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:8
-#: pkg/kubernetes/views/route-body.html.h:8
-msgid "Labels"
-msgstr ""
-
-#: pkg/kubernetes/views/service-body.html.h:4
-#: pkg/kubernetes/views/node-body.html.h:3
-msgid "IP"
-msgstr ""
-
-#: pkg/kubernetes/views/service-body.html.h:8
-msgid "Session Affinity"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:1
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:10
-msgid "New image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:3
-#: pkg/kubernetes/views/image-body.html.h:10
-#: pkg/kubernetes/views/imagestream-modify.html.h:7
-msgid "Tags"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:5
-msgid "Last Updated"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:6
-msgid "No image streams are present."
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:1
-msgid "Delete Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:2
-msgid "Do you want to delete this Node?"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:3
-msgid " 1\">Do you want to delete the following Nodes?"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-container.html.h:1
-msgid "Show all Pod Containers"
-msgstr ""
-
-#: pkg/kubernetes/views/image-panel.html.h:3
-#: pkg/kubernetes/views/imagestream-page.html.h:4
-#: pkg/kubernetes/views/image-page.html.h:4
-msgid "Metadata"
-msgstr ""
-
-#: pkg/kubernetes/views/node-panel.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:8
-#: pkg/kubernetes/views/containers-listing.html.h:6
-#: pkg/kubernetes/views/node-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:11
-msgid "Node"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:1
-msgid "Show all Replication Controllers"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:2
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:5
-msgid "Replication Controller"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:2
-#: pkg/kubernetes/views/pv-claim.html.h:9
-#: pkg/kubernetes/views/dashboard-page.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:18
-msgid "Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:2
-msgid "Template"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:5
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/group-delete.html.h:1
-msgid "Remove Group"
-msgstr ""
-
-#: pkg/kubernetes/views/group-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:5
-#: pkg/kubernetes/views/user-group-remove.html.h:3
-msgid "Remove"
-msgstr "Entfernen"
-
-#: pkg/kubernetes/views/pvc-delete.html.h:1
-msgid "Delete Persistent Volume Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:2
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:3
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:5
-msgid "Service Account"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:6
-msgid "DNS Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:7
-msgid "Phase"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:9
-msgid "Pod Address"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:5
-msgid "OS"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:7
-msgid "Boot ID"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:8
-msgid "Kernel Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:9
-msgid "Container Runtime Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:10
-msgid "Kubelet Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:11
-msgid "Proxy Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:13
-#: pkg/kubernetes/views/route-body.html.h:9
-msgid "none"
-msgstr "kein"
-
-#: pkg/kubernetes/views/node-body.html.h:17
-msgid "Reason"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:18
-#: pkg/kubernetes/views/pv-claim.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:6 pkg/kubernetes/views/pv-body.html.h:6
-msgid "Message"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:19
-msgid "Last Heartbeat"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:20
-msgid "Last Status Change"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:21
-#: pkg/kubernetes/views/image-meta.html.h:3
-#: pkg/kubernetes/views/imagestream-meta.html.h:1
-#: pkg/kubernetes/views/route-body.html.h:10
-msgid "Annotations"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:1
-msgid "Remove Role"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:2
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member "
-"{{ fields.member.metadata.name }}?"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:1
-msgid "New Project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:6
-msgid "No projects are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:7
-msgid "New Group"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:8
-#: pkg/kubernetes/views/user-delete.html.h:3
-msgid "Groups"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:9
-msgid "No groups are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:10
-#: pkg/kubernetes/views/add-user-dialog.html.h:1
-msgid "Add User"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:11
-msgid "Users"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:12
-msgid "Identity"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:13
-msgid "Member of"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:14
-msgid "No users are present."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:1
-msgid "Cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:2
-msgid "Add New Cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:4
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:3
-msgid "Skip Certificate Verification"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:5
-msgid "Requires Authentication"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:7
-msgid "Add New User"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:9
-msgid "Client Certificate"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:10
-msgid "Username"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:12
-msgid "Token"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:1
-msgid "Add Cluster Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:4
-msgid "Configuration"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:5
-msgid "Configure Kubelet and Proxy"
-msgstr "Kubelet und Proxy konfigurieren"
-
-#: pkg/kubernetes/views/node-add.html.h:6
-msgid "Configure Flannel networking"
-msgstr "Flannel Netzwerk konfigurieren"
-
-#: pkg/kubernetes/views/volume-body.html.h:1
-#: pkg/kubernetes/views/pvc-body.html.h:1
-msgid "Volume Type"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:2
-msgid "{{ volume | formatVolumeType }}"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:3
-msgid "PD Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:19
-msgid "Filesystem Type"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:6
-#: pkg/kubernetes/views/pv-modify.html.h:20
-msgid "Read Only"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:7
-msgid "Volume ID"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:8
-msgid "Repository URL"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:9
-msgid "Revision"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:10
-#: pkg/kubernetes/views/image-config.html.h:3
-msgid "Directory"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:12
-msgid "Medium"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:13
-#: pkg/kubernetes/views/pv-modify.html.h:14
-msgid "Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:14
-msgid "Endpoint Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:15
-#: pkg/kubernetes/views/pv-modify.html.h:13
-msgid "Volume Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:17
-msgid "Monitors"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:18
-msgid "Image Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:19
-msgid "Pool Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:21
-msgid "Key Ring Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:22
-msgid "Secret Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:23
-msgid "Target Portal"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:24
-#: pkg/kubernetes/views/pv-modify.html.h:16
-msgid "Qualified Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:25
-#: pkg/kubernetes/views/pv-modify.html.h:17
-msgid "Logical Unit Number"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:26
-#: pkg/kubernetes/views/pv-modify.html.h:18
-msgid "Interface"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:27
-msgid "Ceph Monitors"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:28
-msgid "Secret File"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:29
-msgid "Target World Wide Names"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:30
-msgid "Flocker Dataset Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:31
-msgid "Driver"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:33
-msgid "Share Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:34
-msgid "Secret Name"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:2
-msgid "On Build"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:4
-msgid "Docker Version"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:5
-msgid "Image Layers"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:1
-#: pkg/kubernetes/views/user-page.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:1
-msgid "Show all Projects"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:2
-#: pkg/kubernetes/views/group-panel.html.h:1
-msgid "Group Members"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:3
-#: pkg/kubernetes/views/user-group-add.html.h:1
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:1
-#: pkg/kubernetes/views/group-panel.html.h:2
-#: pkg/kubernetes/views/project-body.html.h:10
-msgid "Add Member"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:4
-msgid "The group '{{ groupName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/containers-listing.html.h:3
-#: pkg/kubernetes/views/pod-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:2
-msgid "Pod"
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:2
-msgid "Membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:2
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:5
-#: pkg/kubernetes/views/user-panel.html.h:7
-msgid "Add Membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-group-add.html.h:2
-msgid ""
-"\n"
-"                        User\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:2
-msgid "User or Group"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-panel.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:4
-msgid "Mount Location"
-msgstr ""
-
-#: pkg/kubernetes/views/route-modify.html.h:1
-msgid "Adjust Route"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:1
-msgid "Show all Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:2 pkg/kubernetes/views/pvc-body.html.h:3
-#: pkg/kubernetes/views/pv-panel.html.h:1
-msgid "Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:3 pkg/kubernetes/views/pv-panel.html.h:2
-msgid "Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:4
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:1
-msgid "Remove image tag"
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:2
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:1
-msgid "Run as"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:4
-msgid "Stop with"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:1
-msgid "Delete Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:2
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:3
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
-"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
-"may cause issues with any pods depending on it."
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:3
-msgid "Identities"
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:3
-msgid "The user '{{ userName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:1
-msgid "Show all Deployment Configs"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:1
-msgid "Deployment Config"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:4
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/route-panel.html.h:1
-#: pkg/kubernetes/views/route-page.html.h:2
-msgid "Route"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:1
-msgid "Register New Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:2
-msgid "Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:7
-msgid "No volumes are present."
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:8
-msgid "Pending Volume Claims"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:12
-msgid "When"
-msgstr ""
-
-#: pkg/kubernetes/views/user-delete.html.h:1
-msgid "Remove User"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:3
-#: pkg/kubernetes/views/pv-modify.html.h:10
-#: pkg/kubernetes/views/pvc-body.html.h:7 pkg/kubernetes/views/pv-body.html.h:2
-msgid "Access Modes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:4
-msgid "Requests"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:5
-msgid "This volume has not been claimed"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:10
-msgid "No Pods are using this claim"
-msgstr ""
-
-#: pkg/kubernetes/views/filter-project.html.h:1
-msgid "All Projects"
-msgstr ""
-
-#: pkg/kubernetes/views/filter-project.html.h:2
-msgid "Project:"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:5
-#: pkg/kubernetes/views/details-page.html.h:14
-msgid "Latest Version"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:6
-msgid "Deployment Causes"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:7
-msgid "Triggers"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:1
-msgid "Delete {{ item.kind }}"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:2
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:3
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:2
-#: pkg/kubernetes/views/user-modify.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:2
-msgid ""
-"\n"
-"                        Name\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:5
-#: pkg/kubernetes/views/user-modify.html.h:5
-msgid ""
-"\n"
-"                        Identity\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:1
-msgid "Project Members"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:3
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:6
-msgid "Admin"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:7
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/container-panel.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:3
-msgid "Shell"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:1
-msgid "Pod Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:2
-msgid "No pods selected"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:3
-msgid "Pod Selector"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:1
-msgid "Add membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:2
-msgid ""
-"\n"
-"                        Group or Project\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:5
-msgid ""
-"\n"
-"                        Role\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:1
-msgid "Deploy Application"
-msgstr "Applikation installieren"
-
-#: pkg/kubernetes/views/deploy.html.h:3
-msgid "{{ selected.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:5
-#: pkg/kubernetes/views/dashboard-page.html.h:11
-msgid "Deploy"
-msgstr ""
-
-#: pkg/kubernetes/views/user-modify.html.h:1
-msgid "Change User"
-msgstr ""
-
-#: pkg/kubernetes/views/user-modify.html.h:9
-msgid "Modify"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:1
-#: pkg/kubernetes/views/project-modify.html.h:6
-msgid "Access Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:2
-msgid ""
-"\n"
-"          Images may be pulled by anonymous users\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:5
-msgid ""
-"\n"
-"          Images may be pulled by any authenticated user or group\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:8
-msgid ""
-"\n"
-"          Images may only be pulled by specific users or groups\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:11
-msgid "Pull repository"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:13
-msgid "Image count"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:14
-msgid "{{stream.status.tags.length}}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:15
-msgid "To push to an image to this image stream:"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:1
-msgid "The node doesn't have enough disk space"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:2
-msgid "The node doesn't have enough free memory"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:1
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:2
-msgid "Register Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:4
-msgid "Warning:"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:5
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:7
-#: pkg/kubernetes/views/node-page.html.h:3
-#: pkg/kubernetes/views/pvc-body.html.h:10
-#: pkg/kubernetes/views/pv-body.html.h:3
-msgid "Capacity"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:8
-#: pkg/kubernetes/views/pv-body.html.h:1
-msgid "Reclaim Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:9
-msgid "{{ value }}"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:12
-msgid "Endpoint"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:15
-msgid "Target"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-dialog.html.h:1
-msgid "Connection Settings"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-dialog.html.h:2
-msgid "Connection Error"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:2
-msgid "Summary"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:4
-msgid "Source URL"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:7
-msgid "Built"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:8
-msgid "Digest"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:9
-msgid "Identifier"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:11
-msgid "To pull this image:"
-msgstr ""
-
-#: pkg/kubernetes/views/service-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:8
-#: pkg/kubernetes/views/service-page.html.h:2
-msgid "Service"
-msgstr ""
-
-#: pkg/kubernetes/views/service-panel.html.h:2
-#: pkg/kubernetes/views/service-page.html.h:3
-msgid "Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:1
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:2
-msgid ""
-"You can bypass the certificate check, but any data you send to the server "
-"could be intercepted by others."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:4
-msgid "Trust this certificate for this connection"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:1
-msgid "Show all Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:7
-msgid "The pod '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:1
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:1
-msgid "Delete image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:2
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:2
-msgid "All running"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:3
-msgid "No pods deployed"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:5
-msgid "All in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:6
-msgid "No volumes in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:7
-msgid "pending volume claims"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:9
-msgid "All healthy"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:10
-msgid "No nodes in cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:13
-msgid "Could not list services"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:14
-msgid "You can deploy an application to your cluster."
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-page.html.h:1
-msgid "Show all image streams"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-page.html.h:2
-msgid "Image Stream"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:3
-msgid "Image ID"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:4
-msgid "Container ID"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:7
-msgid "Since"
-msgstr "Seit"
-
-#: pkg/kubernetes/views/container-body.html.h:8
-msgid "Restart Count"
-msgstr ""
-
-#: pkg/kubernetes/views/user-remove-membership.html.h:1
-msgid "Remove membership"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:1
-msgid "Delete Selected"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:2
-msgid "OS Versions"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:3
-msgid "Add Kubernetes Node"
-msgstr ""
-
-#: pkg/kubernetes/views/project-page.html.h:3
-msgid "The project '{{ projName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/user-panel.html.h:4
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:1
-msgid "Pod Replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:2
-msgid "No pods replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/container-page.html.h:1
-msgid "Show all Containers"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:1
-msgid "Welcome to the Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:2
-msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:1
-msgid "New project"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:4
-msgid "Images by project"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:6
-msgid "Images pushed recently"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:7
-msgid "All images"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:8
-msgid "No images pushed"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:9
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:11
-msgid "Login commands"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:12
-msgid "Log into the registry:"
+msgid "You don't have permission to manage the Docker storage pool."
 msgstr ""
+"Sie haben keine Berechtigung, die autorisierten öffentlichen Schlüssel von "
+"diesem Konto anzuzeigen."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:13
+#: pkg/kubernetes/views/registry-dashboard-page.html:112
 msgid ""
 "Your login credentials do not give you access to use the docker registry "
 "from the command line."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:14
-msgid "Log into OpenShift command line tools:"
+#: src/base1/cockpit.js:3687
+msgid "Your session has been terminated."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:15
-msgid "Image commands"
+#: src/base1/cockpit.js:3689
+msgid "Your session has expired. Please log in again."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:16
-msgid "Push an image:"
+#: pkg/lib/journal.js:213
+msgid "[$0 bytes of binary data]"
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:17
-msgid "Pull an image:"
+#: pkg/lib/journal.js:215
+msgid "[binary data]"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html.h:1
-msgid "Show all Nodes"
+#: pkg/lib/journal.js:209
+msgid "[no data]"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html.h:4
-msgid "The node '{{ target }}' does not exist."
+#: pkg/storaged/details.js:1692
+msgid "active, but unsupported"
+msgstr "aktiv, aber nicht unterstützt"
+
+#: pkg/storaged/utils.js:88
+msgctxt "format-bytes"
+msgid "bytes"
+msgstr "Bytes"
+
+#: pkg/docker/util.js:123
+msgid "default"
+msgstr "Vorgabe"
+
+#: pkg/storaged/details.js:178
+msgid "ext4 - Red Hat Enterprise Linux 6 default"
+msgstr "ext4 - Red Hat Enterprise Linux 6 default"
+
+#: pkg/systemd/host.js:661
+msgid "failed to list ssh host keys: $0"
 msgstr ""
 
-#: pkg/kubernetes/views/route-page.html.h:1
-msgid "Show all Routes"
+#: pkg/storaged/index.html:135
+msgid "iSCSI Targets"
 msgstr ""
 
-#: pkg/kubernetes/views/route-page.html.h:3
-msgid "The route '{{ target }}' does not exist."
-msgstr ""
+#: pkg/storaged/details.js:1692
+msgid "inactive"
+msgstr "Inaktiv"
 
-#: pkg/kubernetes/views/topology-page.html.h:1
-msgid "Select an object to see more details."
-msgstr ""
+#: pkg/storaged/details.js:1286
+msgid "locked"
+msgstr "verschlossen"
 
-#: pkg/kubernetes/views/topology-page.html.h:3
-msgid ""
-"Pods contain one or more containers that run\n"
-"                together on a node, containing your application code."
-msgstr ""
+#: pkg/storaged/details.js:1278
+msgid "mounted on $0"
+msgstr "eingehängt auf $0"
 
-#: pkg/kubernetes/views/topology-page.html.h:6
-msgid ""
-"Replication controllers dynamically create instances of\n"
-"                pods from templates, and remove pods when necessary."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:9
-msgid ""
-"Services group pods and provide a common DNS\n"
-"                name and an optional, load-balanced IP address to access "
-"them."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:12
-msgid "Nodes are the machines that run your containers."
-msgstr ""
-
-#: pkg/kubernetes/views/add-group-dialog.html.h:1
-msgid "Add Group"
-msgstr ""
-
-#: pkg/kubernetes/views/file-button.html.h:1
-msgid "Select Manifest File..."
-msgstr "Wählen Sie eine Manifestdatei aus..."
-
-#: pkg/kubernetes/views/project-modify.html.h:2
-msgid "Change project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-modify.html.h:4
-msgid "Display name"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:5
-msgid "TLS Termination"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:6
-msgid "yes"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:7
+#: pkg/kubernetes/views/route-body.html:14
 msgid "no"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:1
-msgid "Add Role"
+#: pkg/kubernetes/views/route-body.html:24
+#: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
+msgid "none"
+msgstr "kein"
+
+#: pkg/storaged/details.js:1280
+msgid "not mounted"
+msgstr "nicht eingehängt"
+
+#: pkg/kubernetes/views/dashboard-page.html:83
+msgid "pending volume claims"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:2
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#: pkg/tuned/change-profile.jsx:52
+#, fuzzy
+msgid "recommended"
+msgstr "MII (empfohlen)"
+
+#: pkg/docker/index.html:426
+msgid "select container"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:1
-msgid "All Types"
+#: pkg/docker/index.html:504 pkg/docker/index.html:683
+msgid "shares"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:2
-msgid "Type:"
+#: pkg/selinux/setroubleshoot-view.jsx:118
+msgid "solution details"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:13
-msgid "Deployment Configs"
+#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
+msgid "unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:15
-msgid "Not deployed"
+#: pkg/storaged/jobs.js:180
+msgid "unknown target"
+msgstr "Unbekanntes Ziel"
+
+#: pkg/storaged/details.js:1284
+msgid "unlocked"
+msgstr "offen"
+
+#: pkg/kubernetes/views/route-body.html:13
+msgid "yes"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:16
-msgid "Replication Controllers"
-msgstr ""
-
-#: pkg/kubernetes/views/service-modify.html.h:1
-msgid "Adjust Service"
-msgstr "Dienst anpassen"
-
-#: pkg/kubernetes/views/service-modify.html.h:3
+#: pkg/kubernetes/views/service-modify.html:16
 msgid "{{ item.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:5
-msgid "Adjust"
-msgstr "Anpassen"
-
-#: pkg/kubernetes/views/project-delete.html.h:1
-msgid "Delete Project"
+#: pkg/kubernetes/views/deploy.html:27
+msgid "{{ selected.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:2
-msgid "Claim Name"
+#: pkg/kubernetes/views/pv-modify.html:61
+#: pkg/kubernetes/views/pv-modify.html:74
+msgid "{{ value }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:4
-msgid "No Volume Bound"
+#: pkg/kubernetes/views/volume-body.html:2
+msgid "{{ volume | formatVolumeType }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:8
-msgid "Requested"
+#: pkg/storaged/index.html:147
+msgid "{{Address}}:{{Port}}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:9
-msgid "Actual"
+#: pkg/docker/index.html:435
+msgid "{{alias_label}}"
+msgstr "{{alias_label}}"
+
+#: pkg/systemd/services.html:173 pkg/systemd/services.html:202
+msgid "{{days_text}}"
 msgstr ""
 
-#: pkg/kubernetes/views/node-capacity.html.h:1
-msgid "Scheduled Pods"
+#: pkg/docker/index.html:403
+msgid "{{envvar_key_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/node-capacity.html.h:2
-msgid "No pods scheduled"
+#: pkg/docker/index.html:407
+msgid "{{envvar_value_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/container-page-inline.html.h:4
-msgid "The container '{{ target }}' does not exist."
+#: pkg/docker/index.html:359
+msgid "{{host_port_label}}"
+msgstr "{{host_port_label}}"
+
+#: pkg/docker/index.html:373
+msgid "{{host_volume_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:1
-msgid "Create image stream"
+#: pkg/kubernetes/views/imagestream-body.html:35
+msgid "{{stream.status.tags.length}}"
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:2
-msgid "Change image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:5
-msgid "Populate"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:6
-msgid "Pull from"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:8
-msgid "Remote registry is insecure"
-msgstr ""
-
-#: pkg/kubernetes/views/user-group-remove.html.h:1
-msgid "Remove Member"
-msgstr ""
-
-#: pkg/kubernetes/views/service-page.html.h:1
-msgid "Show all Services"
-msgstr ""
-
-#: pkg/kubernetes/views/service-page.html.h:4
-msgid "The service '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/scripts/frob-layers.html.h:1
-msgid "Image Layers Example"
-msgstr ""
-
-#: pkg/playground/service.html.h:1
-msgid "Cockpit Generic Service Monitor"
-msgstr ""
-
-#: pkg/playground/jquery-patterns.html.h:1
-msgid "Cockpit Pattern Usage"
-msgstr ""
-
-#: pkg/playground/metrics.html.h:1
 #, fuzzy
-msgid "Cockpit Monitoring"
-msgstr "Verbindungsüberwachung"
+#~ msgid "Cockpit Monitoring"
+#~ msgstr "Verbindungsüberwachung"
 
-#: pkg/playground/test.html.h:1 pkg/playground/translate.html.h:1
-msgid "Cockpit playground"
-msgstr ""
-
-#: pkg/playground/react-patterns.html.h:1
-msgid "Cockpit React Patterns Usage"
-msgstr ""
-
-#: pkg/playground/speed.html.h:1
-msgid "Cockpit Speed Tests"
-msgstr ""
-
-#: pkg/playground/plot.html.h:1
 #, fuzzy
-msgid "Cockpit Plots"
-msgstr "Cockpit"
-
-#: pkg/dashboard/index.html.h:1
-msgid "Dashboard"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:5
-#, fuzzy
-msgid "Disk I/O"
-msgstr "Datenträger ist OK"
-
-#: pkg/dashboard/index.html.h:6
-msgid "Lost connection. Trying to reconnect"
-msgstr "Verbindung verloren. "
-
-#: pkg/dashboard/index.html.h:10
-msgid "Avatar"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:13
-msgid "Set"
-msgstr ""
+#~ msgid "Cockpit Plots"
+#~ msgstr "Cockpit"
 
 #~ msgid "page-title"
 #~ msgstr "Seitentitel"
@@ -6251,49 +6312,5 @@ msgstr ""
 #~ "              Neues Image holen            "
 
 #~ msgctxt "storage"
-#~ msgid "Model"
-#~ msgstr "Modell"
-
-#~ msgctxt "storage"
-#~ msgid "Firmware Version"
-#~ msgstr "Firmware Version"
-
-#~ msgctxt "storage"
-#~ msgid "Serial Number"
-#~ msgstr "Seriennummer"
-
-#~ msgctxt "storage"
-#~ msgid "World Wide Name"
-#~ msgstr "Weltweiter Name"
-
-#~ msgctxt "storage"
-#~ msgid "Capacity"
-#~ msgstr "Kapazität"
-
-#~ msgctxt "storage"
-#~ msgid "Assessment"
-#~ msgstr "Beurteilung"
-
-#~ msgctxt "storage"
-#~ msgid "Device"
-#~ msgstr "Gerät"
-
-#~ msgctxt "storage"
 #~ msgid "Name"
 #~ msgstr "Name"
-
-#~ msgctxt "storage"
-#~ msgid "UUID"
-#~ msgstr "UUID"
-
-#~ msgctxt "storage"
-#~ msgid "RAID Level"
-#~ msgstr "RAID Ebene"
-
-#~ msgctxt "storage"
-#~ msgid "Bitmap"
-#~ msgstr "Bitmap"
-
-#~ msgctxt "storage"
-#~ msgid "State"
-#~ msgstr "Status"

--- a/po/de.po
+++ b/po/de.po
@@ -1570,6 +1570,10 @@ msgstr ""
 msgid "Connecting to Docker"
 msgstr "Verbinde zu Docker"
 
+#: pkg/ostree/index.html:214
+msgid "Connecting to OSTree"
+msgstr "Verbinde zu OSTree"
+
 #: pkg/shell/indexes.js:317
 msgid "Connecting to the machine"
 msgstr "Verbindung zur Maschine wird hergestellt"

--- a/po/es.po
+++ b/po/es.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-17 19:28+0100\n"
+"POT-Creation-Date: 2016-11-18 06:44+0100\n"
 "PO-Revision-Date: 2016-09-07 07:39-0400\n"
 "Last-Translator: William  Moreno Reyes <williamjmorenor@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -24,176 +24,413 @@ msgstr ""
 "X-Generator: Zanata 3.9.6\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
-#: src/ws/cockpitcertificate.c:359
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr "No se puede descifrar llave privada cifrada con PEM"
-
-#: src/ws/cockpitcertificate.c:364
-msgid "No PEM-encoded private key found"
-msgstr "No se encontró llave privada cifrada con PEM"
-
-#: src/ws/cockpitcertificate.c:374
-msgid "Could not parse PEM-encoded private key"
-msgstr "No se puede resolver llave privada cifrada con PEM"
-
-#: src/ws/cockpitcertificate.c:398
-msgid "No PEM-encoded certificate found"
-msgstr "No se encontró certificado cifrado con PEM"
-
-#: src/ws/cockpitcertificate.c:407
-msgid "Could not parse PEM-encoded certificate"
-msgstr "No es posible descifrar certificado codificado con PEM"
-
-#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
-#: src/bridge/cockpitdbussetup.c:625
-#, fuzzy
-msgid "Unsupported setup mechanism"
-msgstr "Mecanismo de configuración no soportado: %s"
-
-#: src/bridge/cockpitdbussetup.c:236
-msgid "Couldn't list users"
-msgstr "No se puede listar los usuarios"
-
-#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
-msgid "Bad data passed for passwd1 mechanism"
-msgstr "Datos malos, pasados para el mecanismo passwd1"
-
-#: src/bridge/cockpitdbussetup.c:382
-msgid "Couldn't load user data"
-msgstr "No se pudo cargar los datos del usuario"
-
-#: src/bridge/cockpitdbussetup.c:467
-msgid "Couldn't change user groups"
-msgstr "No se pudo cambiar los grupos del usuario"
-
-#: src/bridge/cockpitdbussetup.c:520
-msgid "Couldn't change user password"
-msgstr "No se pudo cambiar la contraseña del usuario"
-
-#: src/bridge/cockpitdbussetup.c:544
-msgid "Couldn't create new users"
-msgstr "No se pueden crear nuevos usuarios"
-
-#: src/bridge/cockpitdbussetup.c:642
-msgid "Couldn't list local users"
-msgstr "No se pueden listar los usuarios locales"
-
-#: src/bridge/cockpitpackages.c:459
-#, c-format
-msgid "This package requires Cockpit version %s or later"
+#: pkg/shell/index.html:227
+msgid "                                                Comment                                            "
 msgstr ""
 
-#: src/bridge/cockpitpackages.c:470
-msgid "This package is not compatible with this version of Cockpit"
+#: pkg/shell/index.html:235
+msgid "                                                Fingerprint                                            "
 msgstr ""
 
-#: src/base1/cockpit.js:2586
-msgid "$0 killed with signal $1"
-msgstr "$0 terminado con señal $1"
+#: pkg/shell/index.html:231
+msgid "                                                Type                                            "
+msgstr ""
 
-#: src/base1/cockpit.js:2588
-msgid "$0 exited with code $1"
-msgstr "$0 Saliendo con código $1"
-
-#: src/base1/cockpit.js:2590
-msgid "$0 failed"
-msgstr "$0 falló"
-
-#: src/base1/cockpit.js:3667
-msgid "Your session has been terminated."
-msgstr "Su sección ha sido terminada"
-
-#: src/base1/cockpit.js:3669
-msgid "Your session has expired. Please log in again."
-msgstr "Su sección a expirado. Por favor inicie sección otra vez"
-
-#: src/base1/cockpit.js:3671
-msgid "Not permitted to perform this action."
-msgstr "No esta permitido ejecutar esta acción."
-
-#: src/base1/cockpit.js:3673
-msgid "Login failed"
-msgstr "Inicio de sesión fallido"
-
-#: src/base1/cockpit.js:3675
-msgid "The server refused to authenticate using any supported methods."
-msgstr "El servido rehusó autenticar usando los métodos soportados."
-
-#: src/base1/cockpit.js:3677
-msgid "Untrusted host"
-msgstr "host inseguro"
-
-#: src/base1/cockpit.js:3679
-msgid "Host key is incorrect"
-msgstr "Tecla del Host es incorrecta"
-
-#: src/base1/cockpit.js:3681
-msgid "Internal error"
-msgstr "Error interno"
-
-#: src/base1/cockpit.js:3683
-msgid "Connection has timed out."
-msgstr "La conexión ha caducado"
-
-#: src/base1/cockpit.js:3685
-msgid "Cockpit is not installed on the system."
-msgstr "Cockpit no esta instalado en el sistema"
-
-#: src/base1/cockpit.js:3687
-msgid "Cannot forward login credentials"
-msgstr "No se pueden re-enviar las credenciales de acceso"
-
-#: src/base1/cockpit.js:3689
-msgid "Server has closed the connection."
-msgstr "El server a cerrado la conexión"
-
-#: src/base1/cockpit.js:3691
-msgid "Cockpit is not compatible with the software on the system."
-msgstr "Cockpit no es compatible con el software en su sistema."
-
-#: src/base1/cockpit.js:3693
-msgid "Cockpit could not contact the given host."
-msgstr "Cockpit no se puede conectar con el host especificado."
-
-#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:19
+#: pkg/systemd/index.html:389
 #, fuzzy
-msgid "Control"
-msgstr "Contenedor"
+msgid ""
+"                                    Invalid time "
+"zone                                "
+msgstr "Organización"
 
-#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
-#: pkg/playground/translate.js:22
+#: pkg/kubernetes/views/project-body.html:80
+msgid ""
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}                                "
+msgstr ""
+
+#: pkg/kubernetes/views/user-body.html:22
+msgid ""
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}                                "
+msgstr ""
+
+#: pkg/kubernetes/views/user-panel.html:39
+msgid ""
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}                            "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:37
+msgid ""
+"                                {{ getRegistryRoles(user, project())."
+"join() }}                            "
+msgstr ""
+
+#: pkg/systemd/index.html:485 pkg/systemd/index.html:504
 #, fuzzy
-msgctxt "key"
-msgid "Control"
-msgstr "Contenedor"
+msgid "                        Cancel                    "
+msgstr "Usuario"
 
-#: src/base1/test-locale.js:46 src/base1/test-locale.js:56
-#: pkg/playground/translate.js:10
-msgid "Empty"
-msgstr "Vaciar"
-
-#: src/base1/test-locale.js:47 src/base1/test-locale.js:58
-#: pkg/playground/translate.js:16
+#: pkg/kubernetes/views/user-add-membership.html:9
 #, fuzzy
-msgctxt "verb"
-msgid "Empty"
-msgstr "Vaciar"
+msgid "                        Group or Project                    "
+msgstr "Reconectar"
 
-#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
-#: src/base1/test-locale.js:66 pkg/storaged/details.js:1557
-#: pkg/playground/translate.js:25 pkg/playground/translate.js:28
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] ""
-msgstr[1] ""
+#: pkg/kubernetes/views/add-user-dialog.html:19
+#: pkg/kubernetes/views/user-modify.html:19
+#, fuzzy
+msgid "                        Identity                    "
+msgstr "Usuario"
 
-#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
-#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
-#: pkg/playground/translate.js:34
-msgctxt "disk-non-rotational"
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
+#: pkg/kubernetes/views/add-user-dialog.html:9
+#: pkg/kubernetes/views/user-modify.html:9
+#: pkg/kubernetes/views/add-group-dialog.html:9
+#, fuzzy
+msgid "                        Name                    "
+msgstr "URL"
+
+#: pkg/kubernetes/views/user-add-membership.html:30
+#, fuzzy
+msgid "                        Role                    "
+msgstr "URL"
+
+#: pkg/kubernetes/views/user-group-add.html:9
+#, fuzzy
+msgid "                        User                    "
+msgstr "URL"
+
+#: pkg/ostree/index.html:88
+#, fuzzy
+msgid "                    Available                  "
+msgstr "Usuario"
+
+#: pkg/ostree/index.html:85
+#, fuzzy
+msgid "                    Default                  "
+msgstr "URL"
+
+#: pkg/ostree/index.html:223
+#, fuzzy
+msgid "                    Reconnect                "
+msgstr "Reconectar"
+
+#: pkg/ostree/index.html:135
+msgid ""
+"                    This deployment contains the same packages as your "
+"currently booted system                "
+msgstr ""
+
+#: pkg/ostree/index.html:67
+#, fuzzy
+msgid "                    Update and reboot                "
+msgstr "URL"
+
+#: pkg/kubernetes/registry.html:74 pkg/kubernetes/index.html:104
+#, fuzzy
+msgid "                Reconnect            "
+msgstr ""
+"\n"
+"              Intentado reconectarse\n"
+"            "
+
+#: pkg/sosreport/index.html:57
+msgid ""
+"                The generated archive contains data "
+"considered                sensitive and its content should be reviewed by "
+"the                originating organization before being passed to "
+"any                third party.              "
+msgstr ""
+
+#: pkg/shell/index.html:304 pkg/shell/stub.html:157
+#, fuzzy
+msgid "                Tools              "
+msgstr ""
+"\n"
+"                Herramientas\n"
+"              "
+
+#: pkg/kubernetes/index.html:107
+#, fuzzy
+msgid "                Troubleshoot            "
+msgstr ""
+"\n"
+"                Herramientas\n"
+"              "
+
+#: pkg/shell/simple.html:105 pkg/shell/index.html:126 pkg/shell/stub.html:119
+#: pkg/storaged/index.html:862
+#, fuzzy
+msgid "              Cancel            "
+msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
+
+#: pkg/shell/index.html:147 pkg/shell/stub.html:140
+#, fuzzy
+msgid "              Close            "
+msgstr ""
+"\n"
+"              Cerrar\n"
+"            "
+
+#: pkg/shell/simple.html:70 pkg/shell/index.html:83 pkg/shell/stub.html:76
+#, fuzzy
+msgid ""
+"              Cockpit is an interactive Linux server admin "
+"interface.            "
+msgstr ""
+"\n"
+"              Cockpit es una interfase interactiva para la administración de "
+"servidores Linux.\n"
+"            "
+
+#: pkg/shell/simple.html:79 pkg/shell/index.html:92 pkg/shell/stub.html:85
+#, fuzzy
+msgid "              Licensed under the GNU LGPL version 2.1            "
+msgstr "Usuario"
+
+#: pkg/shell/simple.html:129
+#, fuzzy
+msgid "              Log in again            "
+msgstr ""
+"\n"
+"              Accediendo nuevamente\n"
+"            "
+
+#: pkg/shell/simple.html:73 pkg/shell/index.html:86 pkg/shell/stub.html:79
+#, fuzzy
+msgid "              Project website            "
+msgstr ""
+"\n"
+"              Cerrar\n"
+"            "
+
+#: pkg/shell/simple.html:108 pkg/shell/index.html:129 pkg/shell/stub.html:122
+#, fuzzy
+msgid "              Select            "
+msgstr ""
+"\n"
+"              Seleccionar\n"
+"            "
+
+#: pkg/shell/simple.html:126
+#, fuzzy
+msgid "              Try to reconnect            "
+msgstr ""
+"\n"
+"              Intentado reconectarse\n"
+"            "
+
+#: pkg/users/index.html:361
+#, fuzzy
+msgid "            Add key          "
+msgstr ""
+"\n"
+"            Aplicar\n"
+"          "
+
+#: pkg/networkmanager/index.html:582 pkg/networkmanager/index.html:610
+#: pkg/networkmanager/index.html:638 pkg/networkmanager/index.html:666
+#: pkg/networkmanager/index.html:694 pkg/networkmanager/index.html:722
+#: pkg/networkmanager/index.html:750 pkg/networkmanager/index.html:778
+#, fuzzy
+msgid "            Apply          "
+msgstr ""
+"\n"
+"            Aplicar\n"
+"          "
+
+#: pkg/users/index.html:269 pkg/users/index.html:297 pkg/users/index.html:358
+#: pkg/docker/index.html:584 pkg/docker/index.html:622
+#: pkg/docker/index.html:688 pkg/docker/index.html:744
+#: pkg/docker/index.html:790 pkg/networkmanager/index.html:579
+#: pkg/networkmanager/index.html:607 pkg/networkmanager/index.html:635
+#: pkg/networkmanager/index.html:663 pkg/networkmanager/index.html:691
+#: pkg/networkmanager/index.html:719 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:775
+#, fuzzy
+msgid "            Cancel          "
+msgstr ""
+"\n"
+"            Cancelar\n"
+"          "
+
+#: pkg/docker/index.html:691
+#, fuzzy
+msgid "            Change          "
+msgstr ""
+"\n"
+"            Cambiar\n"
+"          "
+
+#: pkg/users/index.html:45
+#, fuzzy
+msgid "            Close          "
+msgstr ""
+"\n"
+"              Cerrar\n"
+"            "
+
+#: pkg/docker/index.html:747
+#, fuzzy
+msgid "            Commit          "
+msgstr ""
+"\n"
+"            Commit\n"
+"          "
+
+#: pkg/users/index.html:207
+#, fuzzy
+msgid "            Create          "
+msgstr ""
+"\n"
+"            Cancelar\n"
+"          "
+
+#: pkg/users/index.html:300 pkg/networkmanager/index.html:533
+#, fuzzy
+msgid "            Delete          "
+msgstr ""
+"\n"
+"            Eliminar\n"
+"          "
+
+#: pkg/docker/index.html:625
+#, fuzzy
+msgid "            Download          "
+msgstr ""
+"\n"
+"            Descargar\n"
+"          "
+
+#: pkg/docker/index.html:587
+#, fuzzy
+msgid "            Run          "
+msgstr ""
+"\n"
+"            Correr\n"
+"          "
+
+#: pkg/users/index.html:272
+#, fuzzy
+msgid "            Set          "
+msgstr ""
+"\n"
+"            Eliminar\n"
+"          "
+
+#: pkg/kubernetes/views/imagestream-body.html:14
+msgid "          Images may be pulled by anonymous users        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:20
+msgid ""
+"          Images may be pulled by any authenticated user or group        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:26
+msgid "          Images may only be pulled by specific users or groups        "
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:9
+#, fuzzy
+msgid "         {{ labels.url }}    "
+msgstr ""
+"\n"
+"            Cancelar\n"
+"          "
+
+#: pkg/kubernetes/views/project-body.html:2
+msgid ""
+"        Project access policy allows anonymous users to pull images. Grant "
+"additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:7
+msgid ""
+"        Project access policy allows any authenticated user to pull images. "
+"Grant additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:12
+msgid ""
+"        Project access policy only allows specific members to access images. "
+"Grant access to specific members below.    "
+msgstr ""
+
+#: pkg/sosreport/index.html:39
+msgid ""
+"        The collected information will be stored locally on the system.      "
+msgstr ""
+
+#: pkg/storaged/index.html:51
+msgid ""
+"        There are devices with multiple paths on the system, but the "
+"multipath service is not running.      "
+msgstr ""
+
+#: pkg/sosreport/index.html:34
+msgid ""
+"        This tool will collect system configuration and diagnostic        "
+"information from this system for use with diagnosing problems        with "
+"the system.      "
+msgstr ""
+
+#: pkg/docker/storage.jsx:242
+msgid " (shared with the OS)"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:8
+msgid " 1\"Do you want to delete the following Nodes?"
+msgstr ""
+
+#: pkg/storaged/overview.js:253
+msgid "$0 Block Device"
+msgstr "$0 Dispositivo de Bloque"
+
+#: pkg/storaged/details.js:1546
+msgid "$0 Chunk Size"
+msgstr "$0 tamaño del Chunk "
+
+#: pkg/storaged/details.js:1544
+msgid "$0 Disks"
+msgstr "$0 Discos"
+
+#: pkg/storaged/details.js:1387
+msgid "$0 Extended Partition"
+msgstr "$ partición extendida"
+
+#: pkg/storaged/details.js:1221
+msgctxt "storage-id-desc"
+msgid "$0 File System"
+msgstr "$0 Sistema de Archivos"
+
+#: pkg/storaged/details.js:1375
+msgid "$0 Free Space"
+msgstr "$0 Espacio Libre"
+
+#: pkg/storaged/details.js:1367
+msgid "$0 Free Space for Logical Partitions"
+msgstr "$0 de espacio disponible para particiones logicas"
+
+#: pkg/storaged/details.js:1711
+msgid "$0 Free Space for Logical Volumes"
+msgstr "$0 Espacio Disponible para Volúmenes Lógicos "
+
+#: pkg/storaged/details.js:1370
+msgid "$0 Free Space for Primary Partitions"
+msgstr "$0 Espacio Disponible para Particiones Primarias"
+
+#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
+msgid "$0 Template"
+msgstr "$0 Plantilla"
+
+#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+msgid "$0 bit"
+msgid_plural "$0 bits"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -213,579 +450,40 @@ msgid_plural "$0 bytes"
 msgstr[0] "bytes"
 msgstr[1] "bytes"
 
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
-msgid "$0 bit"
-msgid_plural "$0 bits"
+#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
+#: src/base1/test-locale.js:66 pkg/playground/translate.js:25
+#: pkg/playground/translate.js:28 pkg/storaged/details.js:1557
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/systemd/host.js:43
-msgid "The user <b>$0</b> is not permitted to modify hostnames"
-msgstr "El usuario <b>$0</b> no está autorizado a modificar dominios"
-
-#: pkg/systemd/host.js:559
-msgid "Set Host name"
-msgstr "Establecer nombre del sistema"
-
-#: pkg/systemd/host.js:661
-msgid "failed to list ssh host keys: $0"
-msgstr "incapaz de mostrar llaves de host ssh: $0"
-
-#: pkg/systemd/host.js:1113
-msgid "Need at least one NTP server"
-msgstr "Se requiere al menos un servidor NTP"
-
-#: pkg/systemd/host.js:1190
-msgid "Invalid date format and invalid time format"
-msgstr "Formato de fecha y formato de hora inválidos "
-
-#: pkg/systemd/host.js:1192
-msgid "Invalid time format"
-msgstr "Formato de hora inválido"
-
-#: pkg/systemd/host.js:1194
-msgid "Invalid date format"
-msgstr "Formato de fecha inválido"
-
-#: pkg/systemd/host.js:1250
-msgid "NTP Server"
-msgstr "Servidor NTP"
-
-#: pkg/systemd/host.js:1300
-msgid "Message to logged in users"
-msgstr "Mensaje para usuarios activos "
-
-#: pkg/systemd/host.js:1307 pkg/systemd/host.js:1309
-#: pkg/systemd/index.html.h:19
-msgid "Shutdown"
-msgstr "Apagar"
-
-#: pkg/systemd/host.js:1311 pkg/systemd/host.js:1313 pkg/systemd/init.js:517
-#: pkg/systemd/index.html.h:18
-msgid "Restart"
-msgstr "Reiniciar"
-
-#: pkg/systemd/host.js:1381
-msgctxt "page-title"
-msgid "CPU Status"
-msgstr "Estado del CPU"
-
-#: pkg/systemd/host.js:1413 pkg/systemd/index.html.h:24
-msgid "I/O Wait"
-msgstr "Espera de E/S"
-
-#: pkg/systemd/host.js:1414 pkg/systemd/index.html.h:25
-msgid "Kernel"
-msgstr "Kernel"
-
-#: pkg/systemd/host.js:1415 pkg/subscriptions/subscriptions-register.jsx:76
-#: pkg/systemd/index.html.h:26 pkg/kubernetes/views/auth-form.html.h:6
-#: pkg/kubernetes/views/volume-body.html.h:20
-#: pkg/kubernetes/views/user-panel.html.h:1 pkg/playground/translate.html.h:3
-#: pkg/dashboard/index.html.h:8
-msgid "User"
-msgstr "Usuario"
-
-#: pkg/systemd/host.js:1416 pkg/systemd/index.html.h:27
-msgid "Nice"
-msgstr "Bien"
-
-#: pkg/systemd/host.js:1466
-msgctxt "page-title"
-msgid "Memory"
-msgstr "Memoria"
-
-#: pkg/systemd/host.js:1499 pkg/systemd/index.html.h:28
-msgid "Swap Used"
-msgstr "Swap utilizada"
-
-#: pkg/systemd/host.js:1500 pkg/systemd/index.html.h:29
-msgid "Cached"
-msgstr "En cache"
-
-#: pkg/systemd/host.js:1501 pkg/docker/storage.jsx:313
-#: pkg/kubernetes/scripts/nodes.js:828 pkg/kubernetes/scripts/nodes.js:837
-#: pkg/systemd/index.html.h:30
-msgid "Used"
-msgstr "Usado"
-
-#: pkg/systemd/host.js:1502 pkg/docker/storage.jsx:298
-#: pkg/docker/storage.jsx:320 pkg/systemd/index.html.h:31
-msgid "Free"
-msgstr "Libre"
-
-#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
-msgid "unknown"
-msgstr "desconocido"
-
-#: pkg/systemd/init.js:269 pkg/systemd/services.html.h:17
-#: pkg/kubernetes/views/project-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:5
-msgid "Description"
-msgstr "Descripción "
-
-#: pkg/systemd/init.js:270
-msgid "Id"
-msgstr "Id"
-
-#: pkg/systemd/init.js:272
-msgid "Next Run"
-msgstr "En la próxima ejecución"
-
-#: pkg/systemd/init.js:273
-msgid "Last Trigger"
-msgstr "Última ejecución"
-
-#: pkg/systemd/init.js:274 pkg/kubernetes/views/container-body.html.h:6
-#: pkg/kubernetes/views/details-page.html.h:8
-msgid "State"
-msgstr "Estado"
-
-#: pkg/systemd/init.js:301
-msgid "Enabled"
-msgstr "Habilitado"
-
-#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
-msgid "Disabled"
-msgstr "Deshabilitado"
-
-#: pkg/systemd/init.js:303
-msgid "Static"
-msgstr "Estático"
-
-#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
-msgid "$0 Template"
-msgstr "$0 Plantilla"
-
-#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
-msgid "Start"
-msgstr "Iniciar"
-
-#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
-msgid "Stop"
-msgstr "Detener"
-
-#: pkg/systemd/init.js:518
-msgid "Reload"
-msgstr "Recargar"
-
-#: pkg/systemd/init.js:519
-msgid "Reload or Restart"
-msgstr "Recargue para Reiniciar"
-
-#: pkg/systemd/init.js:520
-msgid "Try Restart"
-msgstr "Intente Reniciar"
-
-#: pkg/systemd/init.js:521
-msgid "Reload or Try Restart"
-msgstr "Recargar o intente reiniciar"
-
-#: pkg/systemd/init.js:522
-msgid "Isolate"
-msgstr "Aislar"
-
-#: pkg/systemd/init.js:541
-msgid "Enable"
-msgstr "Habilitar"
-
-#: pkg/systemd/init.js:542
-msgid "Enable Forcefully"
-msgstr "Habilitar pre-ajuste"
-
-#: pkg/systemd/init.js:543
-msgid "Disable"
-msgstr "Desabilitar"
-
-#: pkg/systemd/init.js:544
-msgid "Preset"
-msgstr "Ajustar"
-
-#: pkg/systemd/init.js:545
-msgid "Preset Forcefully"
-msgstr "Forzar pre-ajuste"
-
-#: pkg/systemd/init.js:546
-msgid "Mask"
-msgstr "Enmascarar"
-
-#: pkg/systemd/init.js:547
-msgid "Mask Forcefully"
-msgstr "Enmascarar "
-
-#: pkg/systemd/init.js:548
-msgid "Unmask"
-msgstr "Desenmascarar"
-
-#: pkg/systemd/init.js:621
-msgid "Since $0"
-msgstr "Desde $0"
-
-#: pkg/systemd/init.js:639
-msgid "This unit is an instance of the $0 template."
-msgstr "Esta unidad es una instancia de la plantilla $0 "
-
-#: pkg/systemd/init.js:834
-#, fuzzy
-msgid "The user <b>$0</b> does not have permissions for creating timers"
-msgstr "El usuario <b>$0</b> no está autorizado para administrar servidores"
-
-#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
-#, fuzzy
-msgid "This field cannot be empty."
-msgstr "Nombre no puede estar vacío."
-
-#: pkg/systemd/init.js:1147
-msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
-msgstr ""
-
-#: pkg/systemd/init.js:1169
-#, fuzzy
-msgid "Invalid number."
-msgstr "Llave inválida"
-
-#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
-msgid "Hour needs to be a number between 0-23"
-msgstr ""
-
-#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
-msgid "Minute needs to be a number between 0-59"
-msgstr ""
-
-#: pkg/systemd/init.js:1218
-#, fuzzy
-msgid "Invalid date format."
-msgstr "Formato de fecha inválido"
-
-#: pkg/systemd/init.js:1222
-msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
-msgstr ""
-
-#: pkg/systemd/logs.js:69
-msgid "Load earlier entries"
-msgstr "Cargar entradas anteriores"
-
-#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
-#: pkg/systemd/logs.js:175
-msgid "Loading..."
-msgstr "Cargando..."
-
-#: pkg/systemd/logs.js:130
-msgid "Go to"
-msgstr "Ir a"
-
-#: pkg/systemd/logs.js:257
-msgid "Journal entry"
-msgstr "Bitacora de entradas"
-
-#: pkg/systemd/logs.js:284
-msgid "Journal entry not found"
-msgstr "Entrada de bitacora no encontrada"
-
-#: pkg/tuned/dialog.js:94
-msgid "Tuned is not available"
-msgstr "Tuned no esta disponible"
-
-#: pkg/tuned/dialog.js:96
-msgid "Tuned is not running"
-msgstr "Tuned no se esta ejecutando"
-
-#: pkg/tuned/dialog.js:98
-msgid "Tuned is off"
-msgstr "Tuned esta apagado"
-
-#: pkg/tuned/dialog.js:100
-msgid "This system is using the recommended profile"
-msgstr "El sistema esta usando el perfil recomendado"
-
-#: pkg/tuned/dialog.js:102
-msgid "This system is using a custom profile"
-msgstr "El sistema esta usando un perfil personalizado"
-
-#: pkg/tuned/dialog.js:114
-msgid "Communication with tuned has failed"
-msgstr "La comunicación con tuned a fallado"
-
-#: pkg/tuned/dialog.js:133
-msgid "Failed to disable tuned profile"
-msgstr "Ha fallado deshabilitar perfil de tuned"
-
-#: pkg/tuned/dialog.js:145
-msgid "Failed to switch profile"
-msgstr "Ha fallado cambiar perfil"
-
-#: pkg/tuned/dialog.js:169
-msgid "Failed to enable tuned"
-msgstr "Ha fallado habilitar tuned"
-
-#: pkg/tuned/dialog.js:171
-msgid "Failed to disable tuned"
-msgstr "Ha fallado deshabilitar tuned"
-
-#: pkg/tuned/dialog.js:191
-msgid "Change Performance Profile"
-msgstr "Cambiar Perfil de Desempeño"
-
-#: pkg/tuned/dialog.js:200
-msgid "Change Profile"
-msgstr "Cambiar Perfil"
-
-#: pkg/tuned/dialog.js:233 pkg/kubernetes/views/service-body.html.h:7
-#: pkg/kubernetes/views/pod-panel.html.h:2
-#: pkg/kubernetes/views/image-config.html.h:8
-#: pkg/kubernetes/views/imagestream-body.html.h:12
-#: pkg/kubernetes/views/pod-page.html.h:5
-msgid "None"
-msgstr "Ninguno"
-
-#: pkg/tuned/dialog.js:234
-msgid "Disable tuned"
-msgstr "Deshabilitar tuned "
-
-#: pkg/tuned/dialog.js:262
-msgid "Tuned has failed to start"
-msgstr "Tuned a fallado al iniciar"
-
-#: pkg/tuned/change-profile.jsx:52
-#, fuzzy
-msgid "recommended"
-msgstr "MII (Recomendado)"
-
-#: pkg/lib/journal.js:209
-msgid "[no data]"
-msgstr "[no hay datos]"
-
-#: pkg/lib/journal.js:213
-msgid "[$0 bytes of binary data]"
-msgstr "[$0 bites de datos binarios]"
-
-#: pkg/lib/journal.js:215
-msgid "[binary data]"
-msgstr "[datos binarios]"
-
-#: pkg/lib/journal.js:241
-msgid "Reboot"
-msgstr "Reiniciar"
-
-#: pkg/lib/machine-dialogs.js:364
-msgid "This machine has already been added."
-msgstr "Esta maquina ya ha sido agregada"
-
-#: pkg/lib/machine-dialogs.js:380
-msgid ""
-"This version of cockpit-ws does not support connecting to a host with an "
-"alternate user or port"
-msgstr ""
-"Esta versión de cockpit-ws no soporta conexiones a un servidor con un "
-"usuario o puerto alterno"
-
-#: pkg/lib/machine-dialogs.js:386
-msgid "The IP address or host name cannot contain whitespace."
-msgstr ""
-"La dirección IP o el nombre de dominio no puede tener espacios en blanco"
-
-#: pkg/lib/machine-dialogs.js:412
-msgid "Failed to add machine: $0"
-msgstr "Fallo al agregar maquina: $0"
-
-#: pkg/lib/machine-dialogs.js:429
-msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
-msgstr ""
-"Cockpit no pudo contactar al servidor $0. Asegúrese que el servidor esta "
-"corriendo ssh en el puerto $1, o especifique otro puerto en la dirección."
-
-#: pkg/lib/machine-dialogs.js:447
-msgid "Enter IP address or host name"
-msgstr "Ingrese la dirección IP o el nombre del host"
-
-#: pkg/lib/machine-dialogs.js:494
-msgid "Failed to edit machine: $0"
-msgstr "Fallo al editar maquina: $0"
-
-#: pkg/lib/cockpit-components-dialog.jsx:136 pkg/sosreport/index.js:55
-#: pkg/systemd/services.html.h:34 pkg/lib/machine-sync-users.html.h:7
-#: pkg/lib/machine-add.html.h:5 pkg/lib/machine-change-port.html.h:6
-#: pkg/lib/machine-change-auth.html.h:11 pkg/storaged/index.html.h:22
-#: pkg/realmd/operation.html.h:10 pkg/kubernetes/views/node-delete.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:3
-#: pkg/kubernetes/views/pvc-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:3
-#: pkg/kubernetes/views/auth-form.html.h:13
-#: pkg/kubernetes/views/node-add.html.h:7
-#: pkg/kubernetes/views/user-group-add.html.h:5
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:4
-#: pkg/kubernetes/views/route-modify.html.h:3
-#: pkg/kubernetes/views/image-delete.html.h:3
-#: pkg/kubernetes/views/pv-delete.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:4
-#: pkg/kubernetes/views/item-delete.html.h:4
-#: pkg/kubernetes/views/add-user-dialog.html.h:8
-#: pkg/kubernetes/views/user-add-membership.html.h:8
-#: pkg/kubernetes/views/deploy.html.h:4
-#: pkg/kubernetes/views/user-modify.html.h:8
-#: pkg/kubernetes/views/pv-modify.html.h:21
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:5
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:3
-#: pkg/kubernetes/views/imagestream-delete.html.h:3
-#: pkg/kubernetes/views/user-remove-membership.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:7
-#: pkg/kubernetes/views/add-role-dialog.html.h:3
-#: pkg/kubernetes/views/service-modify.html.h:4
-#: pkg/kubernetes/views/project-delete.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:9
-#: pkg/kubernetes/views/user-group-remove.html.h:2
-#: pkg/playground/translate.html.h:2 pkg/dashboard/index.html.h:12
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: pkg/lib/cockpit-components-dialog.jsx:155
-msgid "Ok"
-msgstr ""
-
-#: pkg/lib/credentials.js:182
-msgid "No such file or directory"
-msgstr "No existe el archivo o directorio"
-
-#: pkg/lib/credentials.js:186
-msgid "The passwords do not match."
-msgstr "Las contraseñas no coinciden."
-
-#: pkg/lib/credentials.js:191
-msgid "Prompting via ssh-keygen timed out"
-msgstr "Iniciando a través de ssh-keygen tiempo de espera agotado"
-
-#: pkg/lib/credentials.js:213 pkg/users/local.js:78
-msgid "Old password not accepted"
-msgstr "Contraseña antigua no aceptada"
-
-#: pkg/lib/credentials.js:223 pkg/users/local.js:112 pkg/users/local.js:144
-msgid "Failed to change password"
-msgstr "Error al cambiar contraseña"
-
-#: pkg/lib/credentials.js:231 pkg/users/local.js:120
-msgid "New password was not accepted"
-msgstr "Nueva contraseña no fue aceptada"
-
-#: pkg/lib/credentials.js:248
-msgid "Not a valid private key"
-msgstr "No es llave privada valida."
-
-#: pkg/lib/credentials.js:251
-msgid "Prompting via ssh-add timed out"
-msgstr "Expiro el tiempo de espera vía ssh."
-
-#: pkg/lib/credentials.js:274
-msgid "Invalid file permissions"
-msgstr "Permisos de archivo invalidos"
-
-#: pkg/lib/credentials.js:278
-msgid "Password not accepted"
-msgstr "Contraseña no aceptada"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:22
-#: pkg/shell/index.html.h:27 pkg/storaged/index.html.h:52
-#: pkg/playground/jquery-patterns.html.h:2
-msgid "On"
-msgstr "Encencido"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:23
-#: pkg/shell/index.html.h:28 pkg/storaged/index.html.h:53
-#: pkg/playground/jquery-patterns.html.h:3
-msgid "Off"
-msgstr "Apagado"
-
-#: pkg/shell/base_index.js:670 pkg/users/local.js:1164
-#: pkg/docker/index.html.h:69 pkg/networkmanager/index.html.h:65
-msgid "Unexpected error"
-msgstr "Error inesperado"
-
-#: pkg/shell/base_index.js:671
-msgid "Cockpit had an unexpected internal error. <br/><br/>"
-msgstr "Cockpit tuvo un error interno inesperado. <br/><br/>"
-
-#: pkg/shell/base_index.js:672
-msgid "You can try restarting Cockpit by pressing refresh in your browser. "
-msgstr ""
-"Puedes intentar reiniciando Cockpit presionando refrescar en tu navegador."
-
-#: pkg/shell/base_index.js:673
-msgid "The javascript console contains details about this error "
-msgstr "La consola javascript contiene detalles acerca de este error"
-
-#: pkg/shell/base_index.js:674
-msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
-msgstr "(<b>Ctrl-Shift-J</b> en la mayoría de navegadores)."
-
-#: pkg/shell/indexes.js:126 pkg/shell/indexes.js:497 pkg/shell/simple.html.h:17
-msgid "Disconnected"
-msgstr "Desconectado"
-
-#: pkg/shell/indexes.js:253
-msgid "Machines"
-msgstr "Maquinas"
-
-#: pkg/shell/indexes.js:314
-msgid "The machine is restarting"
-msgstr "La máquina se está reiniciando"
-
-#: pkg/shell/indexes.js:317
-msgid "Connecting to the machine"
-msgstr "Conectándose a la máquina"
-
-#: pkg/shell/indexes.js:320
-msgid "Couldn't connect to the machine"
-msgstr "No se pudo conectar a la máquina"
-
-#: pkg/shell/indexes.js:322
-msgid "Cannot connect to an unknown machine"
-msgstr "No se puede conectar a una máquina desconocida"
-
-#: pkg/ostree/client.js:56
-msgid "Receiving delta parts"
-msgstr "Reciviendo deltas"
-
-#: pkg/ostree/client.js:58
-msgid "Receiving metadata objects"
-msgstr "Recibiendo metadatos"
-
-#: pkg/ostree/client.js:61
-msgid "Receiving objects: $0%"
-msgstr "Recibiendo objetos: $0%"
-
-#: pkg/ostree/client.js:64
-msgid "Writing objects"
-msgstr "Escribiendo objetos"
-
-#: pkg/ostree/client.js:66
-msgid "Scanning metadata"
-msgstr "Escaneando metadatos"
-
-#: pkg/ostree/client.js:500
-msgid "OS $0 not found"
-msgstr "OS $0 no encontrado"
-
-#: pkg/ostree/app.js:81
-msgid "Not authorized to update software on this system"
-msgstr "No esta autorizado para actualizar software en este sistema"
-
-#: pkg/ostree/app.js:83
-msgid "OSTree is not available on this system"
-msgstr "OSTree no esta disponible para este sistema"
-
-#: pkg/ostree/app.js:101
-msgid "No OSTree deployments found"
-msgstr "No se encontraron despliegues de OSTree"
-
-#: pkg/ostree/app.js:219
-msgid "Checking for updates"
-msgstr "Chequeando por actualizaciones"
+#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
+#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
+#: pkg/playground/translate.js:34
+msgctxt "disk-non-rotational"
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/base1/cockpit.js:2588
+msgid "$0 exited with code $1"
+msgstr "$0 Saliendo con código $1"
+
+#: src/base1/cockpit.js:2590
+msgid "$0 failed"
+msgstr "$0 falló"
+
+#: src/base1/cockpit.js:2586
+msgid "$0 killed with signal $1"
+msgstr "$0 terminado con señal $1"
+
+#: pkg/selinux/setroubleshoot-view.jsx:440
+msgid "$0 occurrence"
+msgid_plural "$1 occurrences"
+msgstr[0] ""
+msgstr[1] ""
 
 #: pkg/ostree/app.js:307
 msgid "$0 package"
@@ -795,690 +493,34 @@ msgstr "$0 paquete"
 msgid "$0 packages"
 msgstr "$0 paquetes"
 
-#: pkg/selinux/setroubleshoot.js:65
-msgid "Error while setting SELinux mode: '$0'"
-msgstr "Error al establecer modo de SELinux:  '$0'"
+#: pkg/docker/util.js:124
+msgid "$0 shares"
+msgstr "$0 Acciones"
 
-#: pkg/selinux/setroubleshoot.js:238
-msgid "Not connected"
-msgstr "No conectado"
-
-#: pkg/selinux/setroubleshoot.js:275
-msgid "Error while connecting."
-msgstr "Error durante la conexión "
-
-#: pkg/selinux/setroubleshoot-view.jsx:82
-msgid "Applying solution..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:90
-msgid "Solution applied successfully"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:97
-#, fuzzy
-msgid "Solution failed"
-msgstr "Inicio de sesión fallido"
-
-#: pkg/selinux/setroubleshoot-view.jsx:107
-msgid "Apply this solution"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:114
-msgid "Unable to apply this solution automatically"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:118
-msgid "solution details"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:309
-msgid "SELinux system status is unknown."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:317
-#, fuzzy
-msgid "SELinux is disabled on the system."
-msgstr "Cockpit no esta instalado en el sistema"
-
-#: pkg/selinux/setroubleshoot-view.jsx:324
-msgid "The configured state is unknown, it might change on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:326
-msgid ""
-"Setting deviates from the configured state and will revert on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:330
-msgid "SELinux Policy"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:332
-msgid "Enforce policy:"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:382 pkg/kubernetes/index.html.h:10
-#: pkg/kubernetes/registry.html.h:5
-msgid "Connecting..."
-msgstr "Conectando..."
-
-#: pkg/selinux/setroubleshoot-view.jsx:385
-msgid ""
-"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
-"server is installed."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:400
-msgid "Occurred between $0 and $1"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:405
-msgid "Occurred $0"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:440
-msgid "$0 occurrence"
-msgid_plural "$1 occurrences"
-msgstr[0] ""
+#: pkg/kubernetes/scripts/nodes.js:870
+#, fuzzy, c-format
+msgid "$0% Free"
+msgid_plural "$0% Free"
+msgstr[0] "$0% Libre"
 msgstr[1] ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:478
-msgid "SELinux Access Control Errors"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:479
-msgid "No SELinux alerts."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:52
-msgid "Unable to start setroubleshootd"
-msgstr "No se pudo iniciar setroubleshootd"
-
-#: pkg/selinux/setroubleshoot-client.js:157
-msgid "Unable to get alert"
-msgstr "No se pudo obtener alerta"
-
-#: pkg/selinux/setroubleshoot-client.js:172
-msgid "Unable to run fix"
-msgstr "No se ejecutar arreglo"
-
-#: pkg/selinux/setroubleshoot-client.js:187
-msgid "Failed to delete alert"
-msgstr "Error al eliminar la alerta"
-
-#: pkg/selinux/setroubleshoot-client.js:192
-msgid "Error while deleting alert"
-msgstr "Error al eliminar una alerta"
-
-#: pkg/storaged/dialog.js:267
-msgid "Size must be a number"
-msgstr "Tamaña debe ser un número"
-
-#: pkg/storaged/dialog.js:269
-#, fuzzy
-msgid "Size cannot be zero"
-msgstr "Tamaño no puede ser cero"
-
-#: pkg/storaged/dialog.js:271
-#, fuzzy
-msgid "Size cannot be negative"
-msgstr "Tamaño no puede ser negativo"
-
-#: pkg/storaged/dialog.js:273
-msgid "Size is too large"
-msgstr "Tamaño es muy grande"
-
-#: pkg/storaged/details.js:85
-msgid "Device $0 is mounted on $1"
-msgstr "Dispositivo $0 está montado en $1"
-
-#: pkg/storaged/details.js:91
-msgid "Device $0 is a member of RAID Array $1"
-msgstr "Dispositivo $0 es un miembro del Arreglo RAID $1"
-
-#: pkg/storaged/details.js:97
-msgid "Device $0 is a physical volume of $1"
-msgstr "Dispositivo $0 es un volumen físico de $1"
-
-#: pkg/storaged/details.js:113
-msgid "Create partition on $0"
-msgstr "Crear partición en $0"
-
-#: pkg/storaged/details.js:115
-msgid "Format $0"
-msgstr "Formatear $0"
-
-#: pkg/storaged/details.js:177
-msgid "XFS - Red Hat Enterprise Linux 7 default"
-msgstr "XFS - Red Hat Enterprise Linux 7 Predeterminado"
-
-#: pkg/storaged/details.js:178
-msgid "ext4 - Red Hat Enterprise Linux 6 default"
-msgstr "ext4 - Red Hat Enterprise Linux 6 Predeterminado"
-
-#: pkg/storaged/details.js:179
-msgid "Encrypted XFS (LUKS)"
-msgstr "Encriptado XFS (LUKS)"
-
-#: pkg/storaged/details.js:180
-msgid "Encrypted EXT4 (LUKS)"
-msgstr "Encriptado EXT4 (LUKS)"
-
-#: pkg/storaged/details.js:181
-msgid "VFAT - Compatible with all systems and devices"
-msgstr "VFAT - Compatible con todos los sistemas y dispositivos"
-
-#: pkg/storaged/details.js:182
-msgid "NTFS - Compatible with most systems"
-msgstr "NTFS - Compatible con la mayoría de los sistemas"
-
-#: pkg/storaged/details.js:183
-msgid "Extended Partition"
-msgstr "Partición Extendida"
-
-#: pkg/storaged/details.js:185
-msgid "No Filesystem"
-msgstr "Ningún Sistema de Archivos"
-
-#: pkg/storaged/details.js:186
-msgid "Custom (Enter filesystem type)"
-msgstr "Personalizado (Ingrese el sistema de archivos)"
-
-#: pkg/storaged/details.js:192 pkg/storaged/details.js:664
-#: pkg/storaged/details.js:735 pkg/storaged/details.js:773
-#: pkg/storaged/details.js:909 pkg/storaged/index.html.h:20
-#: pkg/kubernetes/views/volumes-page.html.h:11
-msgid "Size"
-msgstr "Tamaño"
-
-#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
-msgid "Erase"
-msgstr "Borrar"
-
-#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
-msgid "Don't overwrite existing data"
-msgstr "No sobreescribir los datos existentes"
-
-#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
-msgid "Overwrite existing data with zeros"
-msgstr "Sobreescribir los datos existentes con ceros"
-
-#: pkg/storaged/details.js:207 pkg/shell/index.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:4
-#: pkg/kubernetes/views/deploy.html.h:2 pkg/kubernetes/views/pv-modify.html.h:3
-msgid "Type"
-msgstr "Tipo"
-
-#: pkg/storaged/details.js:211 pkg/storaged/details.js:429
-#: pkg/storaged/details.js:709 pkg/storaged/details.js:731
-#: pkg/storaged/details.js:769 pkg/storaged/details.js:798
-#: pkg/storaged/details.js:864 pkg/storaged/overview.js:417
-#: pkg/storaged/overview.js:490 pkg/storaged/overview.js:624
-#: pkg/storaged/overview.js:702 pkg/storaged/index.html.h:18
-#: pkg/networkmanager/index.html.h:16
-#: pkg/kubernetes/views/project-listing.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:3
-#: pkg/kubernetes/views/volume-body.html.h:11
-#: pkg/kubernetes/views/containers-listing.html.h:2
-#: pkg/kubernetes/views/volumes-page.html.h:3
-#: pkg/kubernetes/views/pv-claim.html.h:1
-#: pkg/kubernetes/views/pv-modify.html.h:6
-#: pkg/kubernetes/views/image-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:15
-#: pkg/kubernetes/views/nodes-page.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:3
-#: pkg/kubernetes/views/details-page.html.h:4
-#: pkg/kubernetes/views/service-modify.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:3
-msgid "Name"
-msgstr "Nombre"
-
-#: pkg/storaged/details.js:215
-msgid "Filesystem type"
-msgstr "Tipo de sistema de archivos"
-
-#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
-msgid "Passphrase"
-msgstr "Palabra de paso"
-
-#: pkg/storaged/details.js:224
-#, fuzzy
-msgid "Passphrase cannot be empty"
-msgstr "La palabra de paso no puede estar vacía"
-
-#: pkg/storaged/details.js:229
-msgid "Confirm passphrase"
-msgstr "Confirmar palabra de paso"
-
-#: pkg/storaged/details.js:232
-msgid "Passphrases do not match"
-msgstr "Palabra de paso no coincide"
-
-#: pkg/storaged/details.js:237
-msgid "Store passphrase"
-msgstr "Guardar palabra de paso"
-
-#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
-#: pkg/storaged/details.js:1115
-msgid "Encryption Options"
-msgstr "Opciones de cifrado"
-
-#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
-msgid "Mounting"
-msgstr "Montando"
-
-#: pkg/storaged/details.js:247 pkg/storaged/details.js:435
-#: pkg/subscriptions/subscriptions-register.jsx:101 pkg/docker/index.html.h:23
-#: pkg/kubernetes/views/image-config.html.h:2
-msgid "Default"
-msgstr "Predeterminado"
-
-#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
-msgid "Custom"
-msgstr "Personalizar"
-
-#: pkg/storaged/details.js:253 pkg/storaged/details.js:440
-#: pkg/storaged/index.html.h:19
-msgid "Mount Point"
-msgstr "Punto de Montaje"
-
-#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
-msgid "Mount Options"
-msgstr "Opciones de Montaje"
-
-#: pkg/storaged/details.js:266
-msgid "Create partition"
-msgstr "Crear partición"
-
-#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
-#: pkg/storaged/details.js:1142
-msgid "Format"
-msgstr "Formato"
-
-#: pkg/storaged/details.js:268
-msgid "Formatting a storage device will erase all data on it."
-msgstr ""
-"Formatear un dispositivo de almacenamiento eliminará todos los datos en el."
-
-#: pkg/storaged/details.js:335
-msgid "Format Disk $0"
-msgstr "Formatear Disco $0"
-
-#: pkg/storaged/details.js:346
-msgid "Partitioning"
-msgstr "Particionamiento"
-
-#: pkg/storaged/details.js:348
-msgid "Compatible with all systems and devices (MBR)"
-msgstr "Compatible con todos los sistemas y dispositivos (MBR)"
-
-#: pkg/storaged/details.js:349
-msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr "Compatible con los sistemas modernos y discos duros > 2TB (GPT)"
-
-#: pkg/storaged/details.js:352
-msgid "No partitioning"
-msgstr "No particionar"
-
-#: pkg/storaged/details.js:358
-msgid "Formatting a disk will erase all data on it."
-msgstr "Formatear un disco eliminará todos los datos en el."
-
-#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
-msgid "Filesystem Options"
-msgstr "Opciones del Sistema de Archivos"
-
-#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
-msgid "Apply"
-msgstr "Aplicar"
-
-#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
-#: pkg/storaged/details.js:1110
-msgid "Unlock"
-msgstr "Desbloquear"
-
-#: pkg/storaged/details.js:527
-msgid "Stored Passphrase"
-msgstr "Frase de paso guardada"
-
-#: pkg/storaged/details.js:531 pkg/kubernetes/views/volume-body.html.h:32
-msgid "Options"
-msgstr "Opciones"
-
-#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
-msgid "Add Disks"
-msgstr "Añadir Discos"
-
-#: pkg/storaged/details.js:567 pkg/storaged/details.js:933
-#: pkg/storaged/overview.js:448 pkg/storaged/overview.js:495
-#: pkg/storaged/index.html.h:55
-msgid "Disks"
-msgstr "Discos"
-
-#: pkg/storaged/details.js:579 pkg/storaged/details.js:948
-#: pkg/storaged/overview.js:501
-msgid "At least one disk is needed."
-msgstr "Se necesita al menos un disco."
-
-#: pkg/storaged/details.js:584 pkg/storaged/details.js:953
-#: pkg/storaged/overview.js:629 pkg/storaged/overview.js:657
-#: pkg/lib/machine-add.html.h:6 pkg/kubernetes/views/node-add.html.h:8
-#: pkg/kubernetes/views/user-group-add.html.h:6
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:5
-#: pkg/kubernetes/views/add-user-dialog.html.h:9
-#: pkg/kubernetes/views/user-add-membership.html.h:9
-#: pkg/kubernetes/views/add-role-dialog.html.h:4
-msgid "Add"
-msgstr "Agregar"
-
-#: pkg/storaged/details.js:625 pkg/storaged/details.js:821
-#: pkg/storaged/details.js:1016 pkg/docker/details.js:271
-#: pkg/docker/image.js:151 pkg/docker/containers-view.jsx:166
-msgid "Please confirm deletion of $0"
-msgstr "Por favor confirmar la eliminación de $0"
-
-#: pkg/storaged/details.js:630 pkg/storaged/details.js:827
-#: pkg/storaged/details.js:1022 pkg/storaged/details.js:1151
-#: pkg/storaged/details.js:1616 pkg/storaged/details.js:1776
-#: pkg/docker/details.js:273 pkg/docker/image.js:153
-#: pkg/docker/containers-view.jsx:168 pkg/kubernetes/scripts/volumes.js:218
-#: pkg/users/index.html.h:9 pkg/kubernetes/views/node-delete.html.h:5
-#: pkg/kubernetes/views/pvc-delete.html.h:5
-#: pkg/kubernetes/views/image-delete.html.h:4
-#: pkg/kubernetes/views/pv-delete.html.h:5
-#: pkg/kubernetes/views/item-delete.html.h:5
-#: pkg/kubernetes/views/imagestream-delete.html.h:4
-#: pkg/kubernetes/views/user-remove-membership.html.h:3
-#: pkg/kubernetes/views/project-delete.html.h:3
-msgid "Delete"
-msgstr "Eliminar"
-
-#: pkg/storaged/details.js:631
-msgid "Deleting a RAID device will erase all data on it."
-msgstr "Eliminar un dispositivo RAID borrará toda la información en el."
-
-#: pkg/storaged/details.js:661
-msgid "Resize Logical Volume"
-msgstr "Redimensionar Volumen Lógico"
-
-#: pkg/storaged/details.js:673
-msgid "Resize Filesystem"
-msgstr "Redimensionar Sistema de Archivos"
-
-#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
-msgid "Resize"
-msgstr "Redimensionar"
-
-#: pkg/storaged/details.js:690
-#, fuzzy
-msgid "This logical volume cannot be made smaller."
-msgstr "Este volumen lógico no puede hacerse mas pequeño"
-
-#: pkg/storaged/details.js:706
-msgid "Renamee Logical Volume"
-msgstr "Renombrar Volumen Lógico"
-
-#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
-#: pkg/storaged/details.js:1775
-msgid "Rename"
-msgstr "Renombrar"
-
-#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
-msgid "Create Snapshot"
-msgstr "Crear Instantánea"
-
-#: pkg/storaged/details.js:745 pkg/storaged/details.js:781
-#: pkg/storaged/details.js:804 pkg/storaged/details.js:915
-#: pkg/storaged/overview.js:461 pkg/storaged/overview.js:506
-#: pkg/kubernetes/views/add-group-dialog.html.h:6
-#: pkg/kubernetes/views/project-modify.html.h:8
-msgid "Create"
-msgstr "Crear"
-
-#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
-msgid "Create Thin Volume"
-msgstr "Crear Volumen Delgado"
-
-#: pkg/storaged/details.js:795
-msgid "Rename Volume Group"
-msgstr "Renombrar Grupo de Volumen"
-
-#: pkg/storaged/details.js:826
-msgid "Deleting a volume group will erase all data on it."
-msgstr "Eliminar un grupo de volúmenes borrará toda la información en el."
-
-#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
-msgid "Create Logical Volume"
-msgstr "Crear un volumen logico"
-
-#: pkg/storaged/details.js:869
-msgid "Purpose"
-msgstr "Proposito"
-
-#: pkg/storaged/details.js:871
-msgid "Block device for filesystems"
-msgstr ""
-
-#: pkg/storaged/details.js:874
-msgid "Pool for thinly provisioned volumes"
-msgstr ""
-
-#: pkg/storaged/details.js:1009
-msgid "Deleting a logical volume will delete all data in it."
-msgstr "Eliminar un volumen lógico borrará toda la información en el."
-
-#: pkg/storaged/details.js:1012
-msgid "Deleting a partition will delete all data in it."
-msgstr "Eliminar una partición borrará toda la información en el."
-
-#: pkg/storaged/details.js:1053 pkg/storaged/overview.js:689
-#: pkg/storaged/devices.js:119 pkg/users/local.js:1155
-#: pkg/systemd/services.html.h:14
-msgid "Error"
-msgstr "Error"
-
-#: pkg/storaged/details.js:1099
-msgid "Mount"
-msgstr "Montar"
-
-#: pkg/storaged/details.js:1100
-msgid "Unmount"
-msgstr "Desmontar"
-
-#: pkg/storaged/details.js:1109
-msgid "Lock"
-msgstr "Bloquear"
-
-#: pkg/storaged/details.js:1127
-msgid "Activate"
-msgstr "Activar"
-
-#: pkg/storaged/details.js:1130
-msgid "Deactivate"
-msgstr "Desactivar"
-
-#: pkg/storaged/details.js:1221
-msgctxt "storage-id-desc"
-msgid "$0 File System"
-msgstr "$0 Sistema de Archivos"
-
-#: pkg/storaged/details.js:1224
-msgctxt "storage-id-desc"
-msgid "Linux MD-RAID Component"
-msgstr "Componente Linux MD-RAID"
-
-#: pkg/storaged/details.js:1226
-msgctxt "storage-id-desc"
-msgid "LVM2 Physical Volume"
-msgstr "Volumen Físico LVM2"
-
-#: pkg/storaged/details.js:1228
-msgctxt "storage-id-desc"
-msgid "RAID Member"
-msgstr "Miembro RAID"
-
-#: pkg/storaged/details.js:1245
-msgctxt "storage-id-desc"
-msgid "LUKS Encrypted"
-msgstr "LUKS Cifrado"
-
-#: pkg/storaged/details.js:1247
-msgctxt "storage-id-desc"
-msgid "Encrypted"
-msgstr "Cifrado"
-
-#: pkg/storaged/details.js:1251
-msgctxt "storage-id-desc"
-msgid "Swap Space"
-msgstr "Espacio de intercambio"
-
-#: pkg/storaged/details.js:1253
-msgctxt "storage-id-desc"
-msgid "Other Data"
-msgstr "Otros datos"
-
-#: pkg/storaged/details.js:1256
-msgctxt "storage-id-desc"
-msgid "Unrecognized Data"
-msgstr "Dato desnocnocido"
-
-#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
-msgid "$size $partition"
-msgstr "$size $partition"
-
-#: pkg/storaged/details.js:1278
-msgid "mounted on $0"
-msgstr "montado en $0"
-
-#: pkg/storaged/details.js:1280
-msgid "not mounted"
-msgstr "no montado"
-
-#: pkg/storaged/details.js:1284
-msgid "unlocked"
-msgstr "desbloquedo"
-
-#: pkg/storaged/details.js:1286
-msgid "locked"
-msgstr "bloqueado"
-
-#: pkg/storaged/details.js:1367
-msgid "$0 Free Space for Logical Partitions"
-msgstr "$0 de espacio disponible para particiones logicas"
-
-#: pkg/storaged/details.js:1370
-msgid "$0 Free Space for Primary Partitions"
-msgstr "$0 Espacio Disponible para Particiones Primarias"
-
-#: pkg/storaged/details.js:1375
-msgid "$0 Free Space"
-msgstr "$0 Espacio Libre"
-
-#: pkg/storaged/details.js:1379
-msgid "Create Partition"
-msgstr "Crear Partición"
-
-#: pkg/storaged/details.js:1387
-msgid "$0 Extended Partition"
-msgstr "$ partición extendida"
-
-#: pkg/storaged/details.js:1424
-msgid "Logical Partition"
-msgstr "Partición Logica"
-
-#: pkg/storaged/details.js:1426
-msgid "Primary Partition"
-msgstr "Partición Primaria"
-
-#: pkg/storaged/details.js:1428 pkg/kubernetes/views/volume-body.html.h:5
-msgid "Partition"
-msgstr "Partición"
-
-#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
-msgid "Content"
-msgstr "Contenido"
-
-#: pkg/storaged/details.js:1533
-msgid "RAID 0"
-msgstr "RAID 0"
-
-#: pkg/storaged/details.js:1534
-msgid "RAID 1"
-msgstr "RAID 1"
-
-#: pkg/storaged/details.js:1535
-msgid "RAID 4"
-msgstr "RAID 4"
-
-#: pkg/storaged/details.js:1536
-msgid "RAID 5"
-msgstr "RAID 5"
-
-#: pkg/storaged/details.js:1537
-msgid "RAID 6"
-msgstr "RAID 6"
-
-#: pkg/storaged/details.js:1538
-msgid "RAID 10"
-msgstr "RAID 10"
-
-#: pkg/storaged/details.js:1539
-msgid "RAID ($0)"
-msgstr "RAID ($0)"
-
-#: pkg/storaged/details.js:1544
-msgid "$0 Disks"
-msgstr "$0 Discos"
-
-#: pkg/storaged/details.js:1546
-msgid "$0 Chunk Size"
-msgstr "$0 tamaño del Chunk "
-
-#: pkg/storaged/details.js:1574 pkg/ostree/index.html.h:7
-msgid "Running"
-msgstr "Corriendo"
-
-#: pkg/storaged/details.js:1574
-msgid "Not running"
-msgstr "No esta corriendo"
-
-#: pkg/storaged/details.js:1592
-msgid "FAILED"
-msgstr "Fallido"
-
-#: pkg/storaged/details.js:1593
-msgid "In Sync"
-msgstr "En Sincronía"
-
-#: pkg/storaged/details.js:1594
-msgid "Spare"
-msgstr "Libre"
-
-#: pkg/storaged/details.js:1594
-msgid "Recovering"
-msgstr "Recuperando"
-
-#: pkg/storaged/details.js:1595
-msgid "Write-mostly"
-msgstr "Escribir casi todo"
-
-#: pkg/storaged/details.js:1596
-msgid "Blocked"
-msgstr "Bloqueado"
-
-#: pkg/storaged/details.js:1597
-msgid "Unknown ($0)"
-msgstr "Desconocido ($0)"
-
-#: pkg/storaged/details.js:1614
-msgid "Start Scrubbing"
-msgstr "Iniciar Borrado"
-
-#: pkg/storaged/details.js:1615
-msgid "Stop Scrubbing"
-msgstr "Detener Borrado"
+#: pkg/kubernetes/scripts/nodes.js:872
+msgid "$0% Used"
+msgid_plural "$0% Used"
+msgstr[0] "$0% Usado"
+msgstr[1] ""
+
+#: pkg/storaged/details.js:1765
+msgid "$0, $1 free"
+msgstr "$0, $1 disponible"
+
+#: pkg/networkmanager/interfaces.js:2473
+msgid "$mtu"
+msgstr "$mtu"
+
+#: pkg/storaged/utils.js:157
+msgid "$name (from $host)"
+msgstr "$name (de $host)"
 
 #: pkg/storaged/details.js:1653
 msgid "$size $desc"
@@ -1493,217 +535,2829 @@ msgstr "$size $desc<br/>${percent}% lleno"
 msgid "$size $desc<br/>($state)"
 msgstr "$size $desc<br/>($state)"
 
-#: pkg/storaged/details.js:1692
-msgid "active, but unsupported"
-msgstr "activo, pero no soportado"
+#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
+msgid "$size $partition"
+msgstr "$size $partition"
 
-#: pkg/storaged/details.js:1692
-msgid "inactive"
-msgstr "inactivo"
+#: pkg/docker/details.js:144
+msgid "${hip}:${hport} -> $cport"
+msgstr "${hip}:${hport} -> $cport"
 
-#: pkg/storaged/details.js:1711
-msgid "$0 Free Space for Logical Volumes"
-msgstr "$0 Espacio Disponible para Volúmenes Lógicos "
-
-#: pkg/storaged/details.js:1751
-msgid "The last physical volume of a volume group cannot be removed."
+#: pkg/subscriptions/subscriptions-client.js:198
+msgid "'Organization' required to register."
 msgstr ""
 
-#: pkg/storaged/details.js:1756
+#: pkg/subscriptions/subscriptions-client.js:202
+msgid "'Organization' required when using activation keys."
+msgstr ""
+
+#: pkg/shell/base_index.js:674
+msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
+msgstr "(<b>Ctrl-Shift-J</b> en la mayoría de navegadores)."
+
+#: pkg/storaged/overview.js:440
+msgid "1 MiB"
+msgstr "1 MB"
+
+#: pkg/systemd/index.html:459 pkg/systemd/index.html:463
+msgid "1 Minute"
+msgstr "1 Minuto"
+
+#: pkg/storaged/index.html:312 pkg/networkmanager/index.html:55
+#: pkg/networkmanager/index.html:501
+msgid "1 day"
+msgstr "1 día"
+
+#: pkg/storaged/index.html:310 pkg/networkmanager/index.html:53
+#: pkg/networkmanager/index.html:499
+msgid "1 hour"
+msgstr "1 hora"
+
+#: pkg/storaged/index.html:313 pkg/networkmanager/index.html:56
+#: pkg/networkmanager/index.html:502
+msgid "1 week"
+msgstr "1 semana"
+
+#: pkg/playground/translate.html:190
+#, fuzzy
+msgid "1% Free"
+msgid_plural "{{$count}}% Free"
+msgstr[0] "$0% Libre"
+msgstr[1] ""
+
+#: pkg/storaged/overview.js:438
+msgid "128 KiB"
+msgstr "128 KBs"
+
+#: pkg/storaged/overview.js:435
+msgid "16 KiB"
+msgstr "16 KBs"
+
+#: pkg/storaged/overview.js:441
+msgid "2 MiB"
+msgstr "2 MB"
+
+#: pkg/systemd/index.html:465
+msgid "20 Minutes"
+msgstr "20 Minutos"
+
+#: pkg/storaged/overview.js:436
+msgid "32 KiB"
+msgstr "32 KBs"
+
+#: pkg/storaged/overview.js:433
+msgid "4 KiB"
+msgstr "4 KBs"
+
+#: pkg/systemd/index.html:466
+msgid "40 Minutes"
+msgstr "40 Minutos"
+
+#: pkg/systemd/index.html:464
+msgid "5 Minutes"
+msgstr "5 Minutos"
+
+#: pkg/storaged/index.html:309 pkg/networkmanager/index.html:52
+#: pkg/networkmanager/index.html:498
+msgid "5 minutes"
+msgstr "5 minutos"
+
+#: pkg/storaged/overview.js:439
+msgid "512 KiB"
+msgstr "512 KBs"
+
+#: pkg/storaged/index.html:311 pkg/networkmanager/index.html:54
+#: pkg/networkmanager/index.html:500
+msgid "6 hours"
+msgstr "6 horas"
+
+#: pkg/systemd/index.html:467
+msgid "60 Minutes"
+msgstr "60 Minutos"
+
+#: pkg/storaged/overview.js:437
+msgid "64 KiB"
+msgstr "64 KBs"
+
+#: pkg/storaged/overview.js:434
+msgid "8 KiB"
+msgstr "8 KBs"
+
+#: pkg/networkmanager/interfaces.js:1826
+msgid "802.3ad"
+msgstr "802.3ad"
+
+#: pkg/networkmanager/interfaces.js:1843
+#, fuzzy
+msgid "802.3ad LACP"
+msgstr "802.3ad"
+
+#: pkg/systemd/services.html:446
+msgid ":"
+msgstr ""
+
+#: pkg/storaged/utils.js:220
+msgid "<span>Encrypted $0</span>"
+msgstr "<span>Encriptado $0</span>"
+
+#: pkg/storaged/utils.js:212
+msgid "<span>Encrypted Logical Volume of $0</span>"
+msgstr "<span>Volumen Lógico Encriptado de $0</span>"
+
+#: pkg/storaged/utils.js:214
+msgid "<span>Encrypted Partition of $0</span>"
+msgstr "<span>Partición Encriptada de $0</span>"
+
+#: pkg/storaged/utils.js:216
+msgid "<span>Logical Volume of $0</span>"
+msgstr "<span>Volumen Lógico de $0</span>"
+
+#: pkg/storaged/utils.js:218
+msgid "<span>Partition of $0</span>"
+msgstr "<span>Partición de $0</span>"
+
+#: pkg/lib/machine-not-supported.html:5
 msgid ""
-"There is not enough free space elsewhere to remove this physical volume.  At "
-"least $0 more free space is needed."
+"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
+"strong}}."
+msgstr ""
+"Una versión compatible de Cockpit no está instalada en {{#strong}}{{host}}{{/"
+"strong}}."
+
+#: cockpit.desktop.in.h:2
+msgid "A user interface for GNU/Linux servers"
+msgstr "La interface de usuario para servidores GNU/Linux"
+
+#: pkg/networkmanager/interfaces.js:1834
+msgid "ARP"
+msgstr "ARP"
+
+#: pkg/networkmanager/interfaces.js:2502
+msgid "ARP Monitoring"
+msgstr "Supervisión ARP"
+
+#: pkg/networkmanager/interfaces.js:1855
+#, fuzzy
+msgid "ARP Ping"
+msgstr "Supervisión ARP"
+
+#: pkg/kubernetes/scripts/volumes.js:193
+msgid "AWS Elastic Block Store"
 msgstr ""
 
-#: pkg/storaged/details.js:1765
-msgid "$0, $1 free"
-msgstr "$0, $1 disponible"
+#: pkg/shell/simple.html:41 pkg/shell/simple.html:67 pkg/shell/index.html:41
+#: pkg/shell/index.html:80 pkg/shell/stub.html:41 pkg/shell/stub.html:73
+msgid "About Cockpit"
+msgstr "Acerca de Cockpit"
 
-#: pkg/storaged/details.js:1792
-msgid "Logical Volumes"
-msgstr "Volúmenes Lógicos "
+#: pkg/users/index.html:105 pkg/users/index.html:191
+msgid "Access"
+msgstr "Acceder"
 
-#: pkg/storaged/details.js:1822 pkg/docker/details.js:177
-#: pkg/docker/image.js:112
-msgid "Not found"
-msgstr "No encontrado"
+#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pv-claim.html:9
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-body.html:9
+msgid "Access Modes"
+msgstr ""
 
-#: pkg/storaged/overview.js:180
+#: pkg/kubernetes/views/project-modify.html:49
+#: pkg/kubernetes/views/imagestream-body.html:11
+msgid "Access Policy"
+msgstr "Política de Acceso"
+
+#: pkg/subscriptions/subscriptions-view.jsx:191
+#, fuzzy
+msgid "Access denied"
+msgstr "Acceder"
+
+#: pkg/shell/index.html:45
+msgid "Account Settings"
+msgstr "Configuración de la cuenta"
+
+#: pkg/users/index.html:63
+msgid "Account not available or cannot be edited."
+msgstr "Cuenta no disponible o no puede ser editada"
+
+#: pkg/users/index.html:71
+msgid "Accounts"
+msgstr "Cuentas"
+
+#: pkg/users/local.js:284 pkg/users/local.js:594
+msgctxt "page-title"
+msgid "Accounts"
+msgstr "Cuentas"
+
+#: pkg/storaged/details.js:1127
+msgid "Activate"
+msgstr "Activar"
+
+#: pkg/storaged/jobs.js:148
+msgid "Activating $target"
+msgstr "Activando $target"
+
+#: pkg/subscriptions/subscriptions-register.jsx:164
+#, fuzzy
+msgid "Activation Key"
+msgstr "Activar"
+
+#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
+msgid "Active"
+msgstr "Activo"
+
+#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
+msgid "Active Backup"
+msgstr "Respaldo activo"
+
+#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
+msgid "Actual"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1828
+msgid "Adaptive load balancing"
+msgstr "Equilibrio de carga adaptativo"
+
+#: pkg/networkmanager/interfaces.js:1827
+msgid "Adaptive transmit load balancing"
+msgstr "Equilibrio de carga de transmisión adaptativa"
+
+#: pkg/kubernetes/views/add-user-dialog.html:31
+#: pkg/kubernetes/views/node-add.html:50
+#: pkg/kubernetes/views/user-add-membership.html:53
+#: pkg/kubernetes/views/add-member-role-dialog.html:61
+#: pkg/kubernetes/views/user-group-add.html:32
+#: pkg/kubernetes/views/add-role-dialog.html:8 pkg/lib/machine-add.html:43
+msgid "Add"
+msgstr "Agregar"
+
+#: pkg/networkmanager/interfaces.js:2836
+msgid "Add $0"
+msgstr ""
+
+#: pkg/docker/storage.jsx:363
+msgid "Add Additional Storage"
+msgstr ""
+
+#: pkg/networkmanager/index.html:86
+msgid "Add Bond"
+msgstr "Añadir vínculo"
+
+#: pkg/networkmanager/index.html:88
+msgid "Add Bridge"
+msgstr "Añadir Puente"
+
+#: pkg/kubernetes/views/node-add.html:3
+msgid "Add Cluster Node"
+msgstr ""
+
+#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
+msgid "Add Disks"
+msgstr "Añadir Discos"
+
+#: pkg/kubernetes/views/add-group-dialog.html:3
+msgid "Add Group"
+msgstr "Agregar Grupo"
+
+#: pkg/kubernetes/views/nodes-page.html:34
+msgid "Add Kubernetes Node"
+msgstr ""
+
+#: pkg/lib/machine-add.html:4
+msgid "Add Machine to Dashboard"
+msgstr "Agregar Máquina al Tablero de Mandos"
+
+#: pkg/kubernetes/views/group-page.html:38
+#: pkg/kubernetes/views/add-member-role-dialog.html:4
+#: pkg/kubernetes/views/group-panel.html:29
+#: pkg/kubernetes/views/user-group-add.html:3
+#: pkg/kubernetes/views/project-body.html:108
+msgid "Add Member"
+msgstr "Agregar Miembro"
+
+#: pkg/kubernetes/views/user-panel.html:76
+#: pkg/kubernetes/views/user-body.html:67
+msgid "Add Membership"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:11
+#: pkg/kubernetes/views/auth-form.html:20
+msgid "Add New Cluster"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:67
+#: pkg/kubernetes/views/auth-form.html:76
+msgid "Add New User"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:3
+msgid "Add Role"
+msgstr ""
+
+#: pkg/networkmanager/index.html:87
+#, fuzzy
+msgid "Add Team"
+msgstr "Agregar Miembro"
+
+#: pkg/kubernetes/views/add-user-dialog.html:3
+#: pkg/kubernetes/views/project-listing.html:83
+msgid "Add User"
+msgstr ""
+
+#: pkg/networkmanager/index.html:89
+msgid "Add VLAN"
+msgstr "Añadir VLAN"
+
+#: pkg/storaged/overview.js:515
+msgid "Add iSCSI Portal"
+msgstr "Agregar portal iSCSI"
+
+#: pkg/kubernetes/views/user-add-membership.html:3
+msgid "Add membership"
+msgstr ""
+
+#: pkg/users/index.html:351
+msgid "Add public key"
+msgstr "Agregar llave pública"
+
+#: pkg/networkmanager/interfaces.js:2833
+msgid "Adding <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/users/authorized-keys.js:108
+msgid "Adding key"
+msgstr "Agregando llave"
+
+#: pkg/storaged/jobs.js:153
+msgid "Adding physical volume to $target"
+msgstr "Agregando volumen físico a $target"
+
+#: pkg/docker/index.html:329
+msgid "Additional Storage"
+msgstr ""
+
+#: pkg/ostree/index.html:121 pkg/ostree/index.html:140
+msgid "Additions"
+msgstr "Añadidos"
+
+#: pkg/kubernetes/views/node-add.html:8
+#: pkg/kubernetes/views/dashboard-page.html:157
+#: pkg/kubernetes/views/details-page.html:174
+#: pkg/kubernetes/views/nodes-page.html:43
+#: pkg/kubernetes/views/auth-form.html:29 pkg/kubernetes/views/node-body.html:5
+#: pkg/lib/machine-add.html:11
+msgid "Address"
+msgstr "Dirección"
+
+#: pkg/kubernetes/views/details-page.html:37
+msgid "Addresses"
+msgstr "Dirección"
+
+#: pkg/kubernetes/views/service-modify.html:25
+msgid "Adjust"
+msgstr "Ajustar"
+
+#: pkg/kubernetes/views/pv-modify.html:3
+msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-modify.html:3
+msgid "Adjust Replication Controller {{ item.metadata.name }}"
+msgstr ""
+
+#: pkg/kubernetes/views/route-modify.html:3
+msgid "Adjust Route"
+msgstr ""
+
+#: pkg/kubernetes/views/service-modify.html:3
+msgid "Adjust Service"
+msgstr "Ajustar servicio"
+
+#: pkg/kubernetes/views/project-body.html:56
+msgid "Admin"
+msgstr ""
+
+#: pkg/systemd/services.html:389 pkg/systemd/services.html:393
+#, fuzzy
+msgid "After system boot"
+msgstr "Registrar sistema"
+
+#: pkg/systemd/logs.html:50
+msgid "All"
+msgstr "Todos"
+
+#: pkg/kubernetes/views/filter-project.html:4
+msgid "All Projects"
+msgstr "Todos los Proyectos"
+
+#: pkg/kubernetes/views/details-page.html:6
+msgid "All Types"
+msgstr ""
+
+#: pkg/docker/storage.jsx:366
+msgid ""
+"All data on selected disks will be erased and disks will be added to the "
+"storage pool."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:112
+msgid "All healthy"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:74
+msgid "All images"
+msgstr "Todas las imágenes"
+
+#: pkg/kubernetes/views/dashboard-page.html:69
+msgid "All in use"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:37
+msgid "All running"
+msgstr ""
+
+#: pkg/docker/index.html:569
+msgid "Always"
+msgstr "Siempre"
+
+#: pkg/kubernetes/views/imagestream-meta.html:2
+#: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/image-meta.html:9
+#: pkg/kubernetes/views/node-body.html:57
+msgid "Annotations"
+msgstr "Anotaciones"
+
+#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
+msgid "Apply"
+msgstr "Aplicar"
+
+#: pkg/selinux/setroubleshoot-view.jsx:107
+msgid "Apply this solution"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:82
+msgid "Applying solution..."
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:12
+msgid "Architecture"
+msgstr "Arquitectura"
+
+#: pkg/storaged/index.html:451
 msgctxt "storage"
-msgid "Hard Disk"
-msgstr "Disco Duro"
+msgid "Assessment"
+msgstr "Evaluación"
 
-#: pkg/storaged/overview.js:182
-msgctxt "storage"
-msgid "Solid-State Disk"
-msgstr "Disco en Estado Sólido"
+#: pkg/systemd/index.html:81
+msgid "Asset Tag"
+msgstr ""
 
-#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
-msgctxt "storage"
-msgid "Removable Drive"
-msgstr "Disco Removible"
+#: pkg/storaged/overview.js:455
+msgid "At least $0 disks are needed."
+msgstr "Se necesitan al menos $0 discos."
 
-#: pkg/storaged/overview.js:189
+#: pkg/storaged/overview.js:501 pkg/storaged/details.js:579
+#: pkg/storaged/details.js:948
+msgid "At least one disk is needed."
+msgstr "Se necesita al menos un disco."
+
+#: pkg/systemd/services.html:394
+msgid "At specific time"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:813
+msgid "Authenticating"
+msgstr "Autenticando "
+
+#: pkg/realmd/operation.html:34 pkg/shell/index.html:48
+#: pkg/shell/index.html:159 pkg/kubernetes/views/auth-form.html:85
+#: pkg/lib/machine-change-auth.html:32
+msgid "Authentication"
+msgstr "Autenticación"
+
+#: pkg/lib/machine-auth-failed.html:2
+msgid "Authentication Failed"
+msgstr "Autenticación fallida"
+
+#: pkg/docker/index.html:730 pkg/kubernetes/views/image-body.html:12
+#: pkg/kubernetes/views/image-listing.html:15
+msgid "Author"
+msgstr "Autor"
+
+#: pkg/users/index.html:130
+msgid "Authorized Public SSH Keys"
+msgstr "Llaves SSH Públicas Autorizadas"
+
+#: pkg/networkmanager/index.html:165
+msgid "Automatic"
+msgstr "Automático"
+
+#: pkg/networkmanager/interfaces.js:1814
+msgid "Automatic (DHCP only)"
+msgstr "Automático (solo DHCP)"
+
+#: pkg/networkmanager/interfaces.js:1804
+msgid "Automatic (DHCP)"
+msgstr "Automático (DHCP)"
+
+#: pkg/systemd/index.html:406
+msgid "Automatically using NTP"
+msgstr ""
+
+#: pkg/systemd/index.html:407
+msgid "Automatically using specific NTP servers"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:66
+msgid "Available"
+msgstr "Disponible"
+
+#: pkg/storaged/overview.js:619
+msgid "Available targets on $0"
+msgstr "Objetivos disponibles en $0"
+
+#: pkg/dashboard/index.html:177
+msgid "Avatar"
+msgstr "Avatar"
+
+#: pkg/kubernetes/scripts/volumes.js:207
+msgid "Azure"
+msgstr "Azure"
+
+#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
+msgid "Bad data passed for passwd1 mechanism"
+msgstr "Datos malos, pasados para el mecanismo passwd1"
+
+#: pkg/networkmanager/index.html:389
+msgid "Balancer"
+msgstr ""
+
+#: pkg/storaged/index.html:560
 msgctxt "storage"
-msgid "Optical Drive"
-msgstr "Disco Óptico"
+msgid "Bitmap"
+msgstr "Mapa de bits"
+
+#: pkg/storaged/index.html:414
+msgid "Block Device"
+msgstr "Dispositivo de Bloque"
+
+#: pkg/storaged/details.js:871
+msgid "Block device for filesystems"
+msgstr ""
+
+#: pkg/storaged/details.js:1596
+msgid "Blocked"
+msgstr "Bloqueado"
+
+#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
+#: pkg/networkmanager/interfaces.js:2507
+msgid "Bond"
+msgstr "Vínculo"
+
+#: pkg/networkmanager/index.html:596
+msgid "Bond Settings"
+msgstr "Configuración Bond"
+
+#: pkg/kubernetes/views/node-body.html:17
+msgid "Boot ID"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
+#: pkg/networkmanager/interfaces.js:2584
+msgid "Bridge"
+msgstr "Puente"
+
+#: pkg/networkmanager/index.html:708
+msgid "Bridge Port Settings"
+msgstr "Configuración del puerto Bridge"
+
+#: pkg/networkmanager/index.html:680
+msgid "Bridge Settings"
+msgstr "Configuración Bridge"
+
+#: pkg/networkmanager/interfaces.js:2605
+msgid "Bridge port"
+msgstr "Puerto bridge"
+
+#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
+msgid "Broadcast"
+msgstr "Emisión"
+
+#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#, fuzzy
+msgid "Broken configuration"
+msgstr "Configuración desconocida"
+
+#: pkg/kubernetes/views/image-body.html:16
+msgid "Built"
+msgstr "Construido"
+
+#: pkg/dashboard/index.html:70
+msgid "CPU"
+msgstr "CPU"
+
+#: pkg/systemd/host.js:1381
+msgctxt "page-title"
+msgid "CPU Status"
+msgstr "Estado del CPU"
+
+#: pkg/kubernetes/scripts/nodes.js:712
+msgid "CPU Utilization: $0%"
+msgstr "Uso de CPU: $0%"
+
+#: pkg/docker/index.html:490 pkg/docker/index.html:669
+msgid "CPU priority"
+msgstr "Prioridad del CPU"
+
+#: pkg/systemd/index.html:247
+msgid "Cached"
+msgstr "En cache"
+
+#: pkg/docker/index.html:63
+msgid "Can&rsquo;t connect to Docker"
+msgstr ""
+
+#: pkg/systemd/services.html:465 pkg/dashboard/index.html:189
+#: pkg/playground/translate.html:40 pkg/playground/translate.html:174
+#: pkg/realmd/operation.html:90 pkg/kubernetes/views/pv-modify.html:202
+#: pkg/kubernetes/views/item-delete.html:10
+#: pkg/kubernetes/views/add-user-dialog.html:30
+#: pkg/kubernetes/views/project-modify.html:71
+#: pkg/kubernetes/views/node-add.html:49
+#: pkg/kubernetes/views/pvc-delete.html:14
+#: pkg/kubernetes/views/node-delete.html:14
+#: pkg/kubernetes/views/imagestream-modify.html:96
+#: pkg/kubernetes/views/imagestream-delete.html:7
+#: pkg/kubernetes/views/user-modify.html:30
+#: pkg/kubernetes/views/add-group-dialog.html:20
+#: pkg/kubernetes/views/project-delete.html:8
+#: pkg/kubernetes/views/service-modify.html:24
+#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/kubernetes/views/user-group-remove.html:9
+#: pkg/kubernetes/views/user-add-membership.html:52
+#: pkg/kubernetes/views/add-member-role-dialog.html:60
+#: pkg/kubernetes/views/group-delete.html:20
+#: pkg/kubernetes/views/image-delete.html:7 pkg/kubernetes/views/deploy.html:61
+#: pkg/kubernetes/views/user-group-add.html:31
+#: pkg/kubernetes/views/auth-form.html:128
+#: pkg/kubernetes/views/auth-rejected-cert.html:31
+#: pkg/kubernetes/views/replicationcontroller-modify.html:16
+#: pkg/kubernetes/views/pv-delete.html:10
+#: pkg/kubernetes/views/add-role-dialog.html:7
+#: pkg/kubernetes/views/route-modify.html:16
+#: pkg/kubernetes/views/user-delete.html:24
+#: pkg/kubernetes/views/remove-role-dialog.html:7 pkg/storaged/index.html:289
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:79
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: pkg/shell/indexes.js:322
+msgid "Cannot connect to an unknown machine"
+msgstr "No se puede conectar a una máquina desconocida"
+
+#: src/ws/cockpitcertificate.c:359
+msgid "Cannot decrypt PEM-encoded private key"
+msgstr "No se puede descifrar llave privada cifrada con PEM"
+
+#: src/base1/cockpit.js:3707
+msgid "Cannot forward login credentials"
+msgstr "No se pueden re-enviar las credenciales de acceso"
+
+#: pkg/realmd/operation.js:417
+msgid "Cannot join a domain because realmd is not available on this system"
+msgstr ""
+"No es posible unirse al dominio debido a que realmd no está disponible en "
+"este sistema"
+
+#: pkg/kubernetes/views/pv-modify.html:44
+#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pv-body.html:13
+msgid "Capacity"
+msgstr ""
+
+#: pkg/storaged/index.html:443 pkg/storaged/index.html:519
+#: pkg/storaged/index.html:551 pkg/storaged/index.html:630
+msgctxt "storage"
+msgid "Capacity"
+msgstr "Capacidad"
+
+#: pkg/networkmanager/interfaces.js:2276
+msgid "Carrier"
+msgstr "Transporte"
+
+#: pkg/kubernetes/scripts/volumes.js:203
+msgid "Ceph Filesystem Mount"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:97
+msgid "Ceph Monitors"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:204
+#: pkg/kubernetes/views/project-modify.html:74
+#: pkg/kubernetes/views/replicationcontroller-modify.html:17
+#: pkg/kubernetes/views/route-modify.html:17
+msgid "Change"
+msgstr "Cambiar"
+
+#: pkg/shell/index.html:278
+msgid "Change Password"
+msgstr "Cambie la Contraseña"
+
+#: pkg/tuned/dialog.js:191
+msgid "Change Performance Profile"
+msgstr "Cambiar Perfil de Desempeño"
+
+#: pkg/tuned/dialog.js:200
+msgid "Change Profile"
+msgstr "Cambiar Perfil"
+
+#: pkg/kubernetes/views/user-modify.html:3
+msgid "Change User"
+msgstr ""
+
+#: pkg/storaged/overview.js:699
+msgid "Change iSCSI Initiator Name"
+msgstr "Cambiar Nombre Iniciador de iSCSI "
+
+#: pkg/kubernetes/views/imagestream-modify.html:4
+msgid "Change image stream"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:10
+msgid "Change project"
+msgstr "Cambiar proyecto"
+
+#: pkg/networkmanager/interfaces.js:2872
+#, fuzzy
+msgid "Change the settings"
+msgstr "Configuración del puerto Bridge"
+
+#: pkg/networkmanager/interfaces.js:2870
+msgid "Changing the settings will break the connection to the server, "
+msgstr ""
+
+#: pkg/ostree/index.html:48
+msgid "Check for updates"
+msgstr "Buscar actualizaciones"
+
+#: pkg/networkmanager/interfaces.js:817
+msgid "Checking IP"
+msgstr "Comprobando IP"
+
+#: pkg/storaged/jobs.js:143
+#, fuzzy
+msgid "Checking RAID Device $target"
+msgstr "Creando dispositivo RAID $target"
+
+#: pkg/storaged/jobs.js:144
+#, fuzzy
+msgid "Checking and Repairing RAID Device $target"
+msgstr "Creando dispositivo RAID $target"
+
+#: pkg/lib/machine-change-auth.html:70
+msgid "Checking for public keys"
+msgstr "Chequeando llaves públicas"
+
+#: pkg/ostree/app.js:219
+msgid "Checking for updates"
+msgstr "Chequeando por actualizaciones"
+
+#: pkg/shell/simple.html:100 pkg/shell/index.html:121 pkg/shell/stub.html:114
+msgid "Choose the language to be used in the application"
+msgstr "Seleccione el idioma del idioma a utilizar en la aplicación"
+
+#: pkg/storaged/overview.js:431
+msgid "Chunk Size"
+msgstr "Tamaño de la porción"
+
+#: pkg/kubernetes/scripts/volumes.js:202
+msgid "Cinder"
+msgstr "Cinder"
+
+#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
+msgid "Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:4
+msgid "Claim Name"
+msgstr ""
+
+#: pkg/storaged/jobs.js:135
+msgid "Cleaning up for $target"
+msgstr "Limpiando por $target"
+
+#: pkg/kubernetes/views/auth-form.html:88
+msgid "Client Certificate"
+msgstr ""
+
+#: pkg/systemd/services.html:306 pkg/systemd/services.html:324
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-invalid-hostkey.html:19
+msgid "Close"
+msgstr "Cerrar"
+
+#: pkg/kubernetes/views/auth-form.html:5
+msgid "Cluster"
+msgstr ""
+
+#: cockpit.desktop.in.h:1
+msgid "Cockpit"
+msgstr "Cockpit"
+
+#: pkg/lib/machine-dialogs.js:429
+msgid ""
+"Cockpit could not contact the given host $0. Make sure it has ssh running on "
+"port $1, or specify another port in the address."
+msgstr ""
+"Cockpit no pudo contactar al servidor $0. Asegúrese que el servidor esta "
+"corriendo ssh en el puerto $1, o especifique otro puerto en la dirección."
+
+#: src/base1/cockpit.js:3713
+msgid "Cockpit could not contact the given host."
+msgstr "Cockpit no se puede conectar con el host especificado."
+
+#: pkg/shell/base_index.js:671
+msgid "Cockpit had an unexpected internal error. <br/><br/>"
+msgstr "Cockpit tuvo un error interno inesperado. <br/><br/>"
+
+#: cockpit.appdata.xml.in.h:1
+msgid ""
+"Cockpit is a server manager that makes it easy to administer your Linux "
+"servers via a web browser. Jumping between the terminal and the web tool is "
+"no problem. A service started via Cockpit can be stopped via the terminal. "
+"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
+"journal interface."
+msgstr ""
+"Cockpit es un administrador de servidores, que vuelve fácil administrar tus "
+"servidores Linux mediante un navegador web. Saltar entre la terminal y la "
+"herramienta web no es un problema. Un servicio que se inicia en Cockpit "
+"puede ser detenido mediante la terminal. del mismo modo, si un error ocurre "
+"en la terminal, este puede ser visto en Cockpit mediante la interfaz de "
+"bitácora."
+
+#: src/base1/cockpit.js:3711
+msgid "Cockpit is not compatible with the software on the system."
+msgstr "Cockpit no es compatible con el software en su sistema."
+
+#: pkg/lib/machine-not-supported.html:2
+msgid "Cockpit is not installed"
+msgstr "Cockpit no esta instalado"
+
+#: src/base1/cockpit.js:3705
+msgid "Cockpit is not installed on the system."
+msgstr "Cockpit no esta instalado en el sistema"
+
+#: cockpit.appdata.xml.in.h:2
+msgid ""
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
+"tasks such as storage administration, inspecting journals and starting and "
+"stopping services. You can monitor and administer several servers at the "
+"same time. Just add them with a single click and your machines will look "
+"after its buddies."
+msgstr ""
+"Cockpit es perfecto para nuevos administradores de sistemas, permitiendoles "
+"realizar tareas faciles, tales como administración de almacenamiento, "
+"inspeccionar bitacoras e iniciar y detener servicios. Puede monitorear y "
+"administrar muchos servidores al mismo tiempo. Solamente añádelos con un "
+"solo clic y tus computadoras se ocuparan de sus amigos."
+
+#: pkg/lib/machine-change-port.html:9
+msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
+msgstr "Cockpit no fue capaz de contactar {{#strong}}{{host}}{{/strong}}."
+
+#: pkg/lib/machine-auth-failed.html:15
+msgid ""
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:9
+msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+"Cockpit fue incapaz de iniciar session en {{#strong}}{{host}}{{/strong}}."
+
+#: pkg/lib/machine-auth-failed.html:6
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
+"machine with cockpit you will need to enable one of the following "
+"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:13
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
+"change your authentication credentials below. {{#can_sync}}You may prefer to "
+"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+msgstr ""
+
+#: pkg/dashboard/index.html:171 pkg/lib/machine-add.html:27
+msgid "Color"
+msgstr "Color"
+
+#: pkg/docker/index.html:95
+msgid "Combined CPU usage"
+msgstr ""
+
+#: pkg/docker/index.html:101
+msgid "Combined memory usage"
+msgstr "Uso de memoria combinado"
+
+#: pkg/systemd/services.html:370 pkg/docker/index.html:466
+#: pkg/docker/index.html:736
+msgid "Command"
+msgstr "Comando"
+
+#: pkg/docker/run.js:332
+#, fuzzy
+msgid "Command can't be empty"
+msgstr "Nombre no puede estar vacío."
+
+#: pkg/docker/containers-view.jsx:239
+#, fuzzy
+msgid "Commit"
+msgstr "Comentario"
+
+#: pkg/tuned/dialog.js:114
+msgid "Communication with tuned has failed"
+msgstr "La comunicación con tuned a fallado"
+
+#: pkg/storaged/details.js:348
+msgid "Compatible with all systems and devices (MBR)"
+msgstr "Compatible con todos los sistemas y dispositivos (MBR)"
+
+#: pkg/storaged/details.js:349
+msgid "Compatible with modern system and hard disks > 2TB (GPT)"
+msgstr "Compatible con los sistemas modernos y discos duros > 2TB (GPT)"
+
+#: pkg/realmd/operation.html:28
+msgid "Computer OU"
+msgstr "Computadora OU"
+
+#: pkg/kubernetes/views/node-add.html:24
+msgid "Configuration"
+msgstr "Configuración"
+
+#: pkg/networkmanager/interfaces.js:2441
+msgid "Configure"
+msgstr "Configurar"
+
+#: pkg/kubernetes/views/node-add.html:42
+msgid "Configure Flannel networking"
+msgstr "Configurar la red Flannel"
+
+#: pkg/kubernetes/views/node-add.html:32
+msgid "Configure Kubelet and Proxy"
+msgstr "Configurar Kubelet y proxy"
+
+#: pkg/networkmanager/interfaces.js:811
+msgid "Configuring"
+msgstr "Configurando"
+
+#: pkg/networkmanager/interfaces.js:815
+msgid "Configuring IP"
+msgstr "Configurando IP"
+
+#: pkg/users/index.html:171 pkg/shell/index.html:262
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: pkg/users/index.html:247
+msgid "Confirm New Password"
+msgstr "Confirmar Nueva Contraseña"
+
+#: pkg/storaged/details.js:229
+msgid "Confirm passphrase"
+msgstr "Confirmar palabra de paso"
+
+#: pkg/kubernetes/views/auth-form.html:130
+#: pkg/kubernetes/views/auth-rejected-cert.html:33
+#: pkg/lib/machine-unknown-hostkey.html:22
+msgid "Connect"
+msgstr "Conectar"
+
+#: pkg/networkmanager/interfaces.js:2637
+msgid "Connect automatically"
+msgstr "Conectado automáticamente"
+
+#: pkg/ostree/index.html:218
+msgid "Connecting"
+msgstr ""
+
+#: pkg/lib/machine-add.html:39
+msgid ""
+"Connecting simultaneously to more than {{ limit }} machines is unsupported."
+msgstr ""
+"Conectarse simultáneamente a más de {{ limit }} máquinas no está soportado."
+
+#: pkg/docker/index.html:54
+msgid "Connecting to Docker"
+msgstr "Conectando a Docker"
+
+#: pkg/shell/indexes.js:317
+msgid "Connecting to the machine"
+msgstr "Conectándose a la máquina"
+
+#: pkg/kubernetes/registry.html:70 pkg/kubernetes/index.html:100
+msgid "Connecting..."
+msgstr "Conectando..."
+
+#: pkg/kubernetes/views/auth-dialog.html:4
+msgid "Connection Error"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:516
+msgid "Connection Error: $0"
+msgstr "Error de conexión: $0"
+
+#: pkg/kubernetes/views/auth-dialog.html:3
+msgid "Connection Settings"
+msgstr ""
+
+#: src/base1/cockpit.js:3703
+msgid "Connection has timed out."
+msgstr "La conexión ha caducado"
+
+#: pkg/networkmanager/index.html:812
+#, fuzzy
+msgid "Connection will be lost"
+msgstr "La conexión ha caducado"
+
+#: pkg/docker/console.html:4 pkg/kubernetes/views/container-panel.html:4
+#: pkg/kubernetes/views/image-panel.html:12
+#: pkg/kubernetes/views/container-body.html:4
+#: pkg/kubernetes/views/container-page-inline.html:2
+#: pkg/kubernetes/views/image-page.html:19
+msgid "Container"
+msgstr "Contenedor"
+
+#: pkg/users/local.js:684
+msgid "Container Administrator"
+msgstr "Administrador del Contenedor"
+
+#: pkg/kubernetes/views/container-body.html:10
+msgid "Container ID"
+msgstr "ID de Contenedor"
+
+#: pkg/docker/index.html:459 pkg/docker/index.html:646
+#: pkg/docker/index.html:712
+msgid "Container Name"
+msgstr "Nombre del Contenedor"
+
+#: pkg/kubernetes/views/node-body.html:21
+msgid "Container Runtime Version"
+msgstr ""
+
+#: pkg/docker/util.js:490
+msgid ""
+"Container is currently marked as not running, but regular stopping failed."
+msgstr ""
+"El contenedor esta marcado actualmente como que no esta corriendo, pero el "
+"paro regular ha fallado"
+
+#: pkg/docker/util.js:488
+msgid "Container is currently running."
+msgstr "El contenedor esta corriendo actualmente"
+
+#: pkg/docker/index.html:23 pkg/docker/index.html:309
+#: pkg/kubernetes/views/pod-page.html:36
+#: pkg/kubernetes/views/dashboard-page.html:158
+#: pkg/kubernetes/views/dashboard-page.html:199
+#: pkg/kubernetes/views/containers-listing.html:5 pkg/kubernetes/index.html:51
+msgid "Containers"
+msgstr "Contenedores"
+
+#: pkg/docker/details.js:47 pkg/docker/image.js:43
+msgctxt "page-title"
+msgid "Containers"
+msgstr "Contenedores"
+
+#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
+msgid "Content"
+msgstr "Contenido"
+
+#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
+#: pkg/playground/translate.js:19
+#, fuzzy
+msgid "Control"
+msgstr "Contenedor"
+
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
+#: pkg/playground/translate.js:22
+#, fuzzy
+msgctxt "key"
+msgid "Control"
+msgstr "Contenedor"
+
+#: pkg/docker/storage.jsx:404
+#, fuzzy
+msgid "Could not add all disks"
+msgstr "No se pueden listar los servicios"
+
+#: pkg/lib/machine-change-port.html:4
+msgid "Could not contact {{host}}"
+msgstr "No se puedo contactar {{host}}"
+
+#: pkg/kubernetes/views/dashboard-page.html:142
+msgid "Could not list services"
+msgstr "No se pueden listar los servicios"
+
+#: src/ws/cockpitcertificate.c:407
+msgid "Could not parse PEM-encoded certificate"
+msgstr "No es posible descifrar certificado codificado con PEM"
+
+#: src/ws/cockpitcertificate.c:374
+msgid "Could not parse PEM-encoded private key"
+msgstr "No se puede resolver llave privada cifrada con PEM"
+
+#: pkg/docker/storage.jsx:446
+msgid "Could not reset the storage pool"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:467
+msgid "Couldn't change user groups"
+msgstr "No se pudo cambiar los grupos del usuario"
+
+#: src/bridge/cockpitdbussetup.c:520
+msgid "Couldn't change user password"
+msgstr "No se pudo cambiar la contraseña del usuario"
+
+#: pkg/selinux/setroubleshoot-view.jsx:385
+msgid ""
+"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
+"server is installed."
+msgstr ""
+
+#: pkg/kubernetes/registry.html:71 pkg/kubernetes/index.html:101
+msgid "Couldn't connect to server"
+msgstr "No se pudo conectar al servidor"
+
+#: pkg/shell/indexes.js:320
+msgid "Couldn't connect to the machine"
+msgstr "No se pudo conectar a la máquina"
+
+#: src/bridge/cockpitdbussetup.c:544
+msgid "Couldn't create new users"
+msgstr "No se pueden crear nuevos usuarios"
+
+#: pkg/kubernetes/scripts/connection.js:514
+msgid "Couldn't find running API server"
+msgstr "No se puede encontrar un servidor API ejecutandose"
+
+#: pkg/subscriptions/subscriptions-view.jsx:196
+msgid ""
+"Couldn't get system subscription status. Please ensure subscription-manager "
+"is installed."
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:642
+msgid "Couldn't list local users"
+msgstr "No se pueden listar los usuarios locales"
+
+#: src/bridge/cockpitdbussetup.c:236
+msgid "Couldn't list users"
+msgstr "No se puede listar los usuarios"
+
+#: src/bridge/cockpitdbussetup.c:382
+msgid "Couldn't load user data"
+msgstr "No se pudo cargar los datos del usuario"
+
+#: pkg/kubernetes/views/project-modify.html:72
+#: pkg/kubernetes/views/add-group-dialog.html:21
+msgid "Create"
+msgstr "Crear"
+
+#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
+msgid "Create Logical Volume"
+msgstr "Crear un volumen logico"
+
+#: pkg/users/index.html:54 pkg/users/index.html:143
+msgid "Create New Account"
+msgstr "Crear nueva Cuenta"
+
+#: pkg/storaged/details.js:1379
+msgid "Create Partition"
+msgstr "Crear Partición"
+
+#: pkg/storaged/overview.js:414
+msgid "Create RAID Device"
+msgstr "Crear Dispositivo RAID"
+
+#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
+msgid "Create Snapshot"
+msgstr "Crear Instantánea"
+
+#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
+msgid "Create Thin Volume"
+msgstr "Crear Volumen Delgado"
+
+#: pkg/systemd/services.html:336
+#, fuzzy
+msgid "Create Timers"
+msgstr "Crear Volumen Delgado"
+
+#: pkg/storaged/overview.js:487
+msgid "Create Volume Group"
+msgstr "Crear un Grupo de Volúmenes"
+
+#: pkg/sosreport/index.html:50
+msgid "Create diagnostic report"
+msgstr "Crear reporte de diagnóstico"
+
+#: pkg/kubernetes/views/imagestream-modify.html:3
+msgid "Create image stream"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
+#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
+#, fuzzy
+msgid "Create it"
+msgstr "Crear"
+
+#: pkg/storaged/details.js:266
+msgid "Create partition"
+msgstr "Crear partición"
+
+#: pkg/storaged/details.js:113
+msgid "Create partition on $0"
+msgstr "Crear partición en $0"
+
+#: pkg/storaged/index.html:381
+msgid "Create partition table"
+msgstr "Crear tabla de particiones"
+
+#: pkg/sosreport/index.html:42
+msgid "Create report"
+msgstr "Crear reporte"
+
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/replicationcontroller-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7 pkg/kubernetes/views/route-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3
+msgid "Created"
+msgstr "Creado"
+
+#: pkg/storaged/jobs.js:142
+msgid "Creating RAID Device $target"
+msgstr "Creando dispositivo RAID $target"
+
+#: pkg/storaged/jobs.js:130
+msgid "Creating filesystem on $target"
+msgstr "Creando sistema de archivos en $target"
+
+#: pkg/storaged/jobs.js:156
+msgid "Creating logical volume $target"
+msgstr "Creando  Volumen Lógico $target"
+
+#: pkg/storaged/jobs.js:134
+msgid "Creating partition $target"
+msgstr "Creando partición $target"
+
+#: pkg/storaged/jobs.js:150
+msgid "Creating snapshot of $target"
+msgstr "Creando una imagne de $target"
+
+#: pkg/networkmanager/interfaces.js:4064
+msgid "Creating this VLAN will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3436
+msgid "Creating this bond will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3842
+msgid "Creating this bridge will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3611
+msgid "Creating this team will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:151
+msgid "Creating volume group $target"
+msgstr "Creando Grupo de Volumen $target"
+
+#: pkg/systemd/logs.html:41
+msgid "Current boot"
+msgstr "Arranque actual"
+
+#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
+msgid "Custom"
+msgstr "Personalizar"
+
+#: pkg/storaged/details.js:186
+msgid "Custom (Enter filesystem type)"
+msgstr "Personalizado (Ingrese el sistema de archivos)"
+
+#: pkg/subscriptions/subscriptions-register.jsx:102
+#, fuzzy
+msgid "Custom URL"
+msgstr "Personalizar"
+
+#: pkg/storaged/index.html:454
+msgid "DISK IS FAILING"
+msgstr "DISCO ESTÁ FALLANDO"
+
+#: pkg/networkmanager/interfaces.js:3018
+msgid "DNS"
+msgstr "DNS"
+
+#: pkg/kubernetes/views/pod-body.html:14
+msgid "DNS Policy"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3022
+msgid "DNS Search Domains"
+msgstr "Búsqueda Dominios DNS"
+
+#: pkg/dashboard/index.html:22
+msgid "Dashboard"
+msgstr ""
+
+#: pkg/storaged/details.js:1130
+msgid "Deactivate"
+msgstr "Desactivar"
+
+#: pkg/networkmanager/interfaces.js:823
+msgid "Deactivating"
+msgstr "Desactivando"
+
+#: pkg/storaged/jobs.js:149
+msgid "Deactivating $target"
+msgstr "Desactivando $target"
+
+#: pkg/docker/index.html:379 pkg/docker/index.html:383
+#: pkg/kubernetes/views/image-config.html:6
+msgid "Default"
+msgstr "Predeterminado"
+
+#: pkg/systemd/index.html:454
+msgid "Delay"
+msgstr ""
+
+#: pkg/users/index.html:79 pkg/kubernetes/views/item-delete.html:11
+#: pkg/kubernetes/views/pvc-delete.html:15
+#: pkg/kubernetes/views/node-delete.html:15
+#: pkg/kubernetes/views/imagestream-delete.html:8
+#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/kubernetes/views/image-delete.html:8
+#: pkg/kubernetes/views/pv-delete.html:11
+msgid "Delete"
+msgstr "Eliminar"
+
+#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
+msgid "Delete $0"
+msgstr "Eliminar $0"
+
+#: pkg/users/index.html:292
+msgid "Delete Files"
+msgstr "Borrar Ficheros"
+
+#: pkg/kubernetes/views/node-delete.html:4
+msgid "Delete Node"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:3
+msgid "Delete Persistent Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:3
+msgid "Delete Persistent Volume Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/project-delete.html:3
+msgid "Delete Project"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:3
+msgid "Delete Selected"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:3
+msgid "Delete image stream"
+msgstr ""
+
+#: pkg/playground/translate.html:184 pkg/kubernetes/views/item-delete.html:3
+msgid "Delete {{ item.kind }}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
+msgid "Deleting $target"
+msgstr "Eliminando $target"
+
+#: pkg/networkmanager/interfaces.js:2156
+msgid "Deleting <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:7
+msgid ""
+"Deleting a Pod will kill all associated containers. Pods may be "
+"automatically created again in some cases."
+msgstr ""
+
+#: pkg/storaged/details.js:631
+msgid "Deleting a RAID device will erase all data on it."
+msgstr "Eliminar un dispositivo RAID borrará toda la información en el."
+
+#: pkg/docker/containers-view.jsx:167 pkg/docker/details.js:272
+msgid "Deleting a container will erase all data in it."
+msgstr "Eliminar un contenedor eliminara toda la información en él."
+
+#: pkg/storaged/details.js:1009
+msgid "Deleting a logical volume will delete all data in it."
+msgstr "Eliminar un volumen lógico borrará toda la información en el."
+
+#: pkg/storaged/details.js:1012
+msgid "Deleting a partition will delete all data in it."
+msgstr "Eliminar una partición borrará toda la información en el."
+
+#: pkg/storaged/details.js:826
+msgid "Deleting a volume group will erase all data on it."
+msgstr "Eliminar un grupo de volúmenes borrará toda la información en el."
+
+#: pkg/docker/image.js:152
+msgid ""
+"Deleting an image will delete it, but you can probably download it again if "
+"you need it later.  Unless this image has never been pushed to a repository, "
+"that is, in which case you probably can't download it again."
+msgstr ""
+"Borrar una imagen, la borrara, pero tu puedes descargarla de nuevo si tu la "
+"necesitas mas tarde. A menos que esta imagen nunca haya sido colocada a un "
+"repositorio, en cuyo caso no puedas volver a descargarla nuevamente."
+
+#: pkg/storaged/jobs.js:152
+msgid "Deleting volume group $target"
+msgstr "Borrando Grupo de Volumen $target"
+
+#: pkg/kubernetes/views/dashboard-page.html:131
+#: pkg/kubernetes/views/deploy.html:62
+msgid "Deploy"
+msgstr "Desplegar"
+
+#: pkg/kubernetes/views/deploy.html:3
+msgid "Deploy Application"
+msgstr "Desplegar aplicación"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:22
+msgid "Deployment Causes"
+msgstr "Causas de Despliegue"
+
+#: pkg/kubernetes/views/deploymentconfig-panel.html:8
+#: pkg/kubernetes/views/deploymentconfig-page.html:12
+msgid "Deployment Config"
+msgstr "Configuración de Despliegue"
+
+#: pkg/kubernetes/views/details-page.html:98
+msgid "Deployment Configs"
+msgstr "Configuración de despliegue"
+
+#: pkg/systemd/services.html:356 pkg/kubernetes/views/project-modify.html:40
+#: pkg/kubernetes/views/image-body.html:6
+#: pkg/kubernetes/views/project-listing.html:15
+#: pkg/kubernetes/views/project-listing.html:54
+msgid "Description"
+msgstr "Descripción "
+
+#: pkg/shell/index.html:197 pkg/kubernetes/index.html:63
+msgid "Details"
+msgstr "Detalles"
+
+#: pkg/storaged/index.html:543
+msgctxt "storage"
+msgid "Device"
+msgstr "Dispositivo"
+
+#: pkg/storaged/details.js:91
+msgid "Device $0 is a member of RAID Array $1"
+msgstr "Dispositivo $0 es un miembro del Arreglo RAID $1"
+
+#: pkg/storaged/details.js:97
+msgid "Device $0 is a physical volume of $1"
+msgstr "Dispositivo $0 es un volumen físico de $1"
+
+#: pkg/storaged/details.js:85
+msgid "Device $0 is mounted on $1"
+msgstr "Dispositivo $0 está montado en $1"
+
+#: pkg/storaged/index.html:467 pkg/storaged/index.html:473
+#: pkg/storaged/index.html:515
+msgctxt "storage"
+msgid "Device File"
+msgstr "Dispositivo de Fichero"
+
+#: pkg/sosreport/index.html:22
+msgid "Diagnostic reports"
+msgstr "Reportes de diagnostico"
+
+#: pkg/kubernetes/views/image-body.html:20
+msgid "Digest"
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:7
+#: pkg/kubernetes/views/volume-body.html:28
+msgid "Directory"
+msgstr "Directorio"
+
+#: pkg/systemd/init.js:543
+msgid "Disable"
+msgstr "Desabilitar"
+
+#: pkg/tuned/dialog.js:234
+msgid "Disable tuned"
+msgstr "Deshabilitar tuned "
+
+#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
+msgid "Disabled"
+msgstr "Deshabilitado"
+
+#: pkg/shell/simple.html:120
+msgid "Disconnected"
+msgstr "Desconectado"
+
+#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+msgid "Disk"
+msgstr "Disco"
+
+#: pkg/dashboard/index.html:73
+#, fuzzy
+msgid "Disk I/O"
+msgstr "Disco está OK"
+
+#: pkg/kubernetes/scripts/nodes.js:720
+msgid "Disk Utilization: $0%"
+msgstr "Uso de disco: $0%"
+
+#: pkg/storaged/index.html:457
+msgid "Disk is OK"
+msgstr "Disco está OK"
+
+#: pkg/storaged/index.html:584
+msgid "Disks"
+msgstr "Discos"
+
+#: pkg/shell/simple.html:37 pkg/shell/simple.html:97 pkg/shell/index.html:37
+#: pkg/shell/index.html:118 pkg/shell/stub.html:37 pkg/shell/stub.html:111
+msgid "Display Language"
+msgstr "Mostrar Idioma"
+
+#: pkg/kubernetes/views/project-modify.html:31
+msgid "Display name"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:5
+msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:5
+msgid ""
+"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}' image stream?"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:6
+msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:6
+msgid ""
+"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:6
+msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:7
+msgid "Do you want to delete this Node?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:5
+msgid ""
+"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+"{{stream.metadata.name}}:{{tag.tag}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/remove-role-dialog.html:5
+msgid ""
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:11
+msgid "Docker Version"
+msgstr "Versión de Docker"
+
+#: pkg/docker/index.html:60
+msgid "Docker is not installed or activated on the system"
+msgstr "Docker no esta instalado o no esta activo en el sistema"
+
+#: pkg/systemd/index.html:107
+msgid "Domain"
+msgstr "Dominio"
+
+#: pkg/realmd/operation.js:148
+msgid "Domain $0 could not be contacted"
+msgstr "Dominio $0 no puede ser contactado"
+
+#: pkg/realmd/operation.js:220
+msgid "Domain $0 is not supported"
+msgstr "Dominio $0 no esta soportado"
+
+#: pkg/realmd/operation.html:11
+msgid "Domain Address"
+msgstr "Dirección de Dominio"
+
+#: pkg/realmd/operation.html:59
+msgid "Domain Administrator Name"
+msgstr "Nombre del Administrador de Dominio"
+
+#: pkg/realmd/operation.html:65
+msgid "Domain Administrator Password"
+msgstr "Contraseña del Administrador de Dominio"
+
+#: pkg/systemd/services.html:426 pkg/systemd/services.html:430
+msgid "Don't Repeat"
+msgstr ""
+
+#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
+msgid "Don't overwrite existing data"
+msgstr "No sobreescribir los datos existentes"
+
+#: pkg/sosreport/index.html:74
+msgid "Done!"
+msgstr "Hecho!"
+
+#: pkg/ostree/index.html:127 pkg/ostree/index.html:158
+msgid "Downgrades"
+msgstr ""
+
+#: pkg/storaged/index.html:411
+msgid "Drive"
+msgstr "Disco"
 
 #: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
 msgctxt "storage"
 msgid "Drive"
 msgstr "Unidad"
 
-#: pkg/storaged/overview.js:253
-msgid "$0 Block Device"
-msgstr "$0 Dispositivo de Bloque"
+#: pkg/kubernetes/views/volume-body.html:128
+msgid "Driver"
+msgstr ""
 
-#: pkg/storaged/overview.js:414
-msgid "Create RAID Device"
-msgstr "Crear Dispositivo RAID"
+#: pkg/storaged/index.html:166
+msgid "Drives"
+msgstr "Discos"
 
-#: pkg/storaged/overview.js:420
-msgid "RAID Level"
-msgstr "Nivel RAID"
+#: pkg/docker/run.js:360
+msgid "Duplicate alias"
+msgstr "Alias duplicado"
 
-#: pkg/storaged/overview.js:422
-msgid "RAID 0 (Stripe)"
-msgstr "RAID 0 (Stripe)"
+#: pkg/docker/run.js:293
+msgid "Duplicate port"
+msgstr "Puerto duplicado"
 
-#: pkg/storaged/overview.js:423
-msgid "RAID 1 (Mirror)"
-msgstr "RAID 1 (Espejo)"
+#: pkg/storaged/jobs.js:120
+msgid "Ejecting $target"
+msgstr "Expulsando $target"
 
-#: pkg/storaged/overview.js:424
-msgid "RAID 4 (Dedicated Parity)"
-msgstr "RAID 4 (Paridad Dedicada)"
+#: pkg/playground/translate.html:58
+msgid "Empty"
+msgstr "Vaciar"
 
-#: pkg/storaged/overview.js:425
-msgid "RAID 5 (Distributed Parity)"
-msgstr "RAID 5 (Paridad Distribuida)"
-
-#: pkg/storaged/overview.js:426
-msgid "RAID 6 (Double Distributed Parity)"
-msgstr "RAID 6 (Doble Paridad Distribuida)"
-
-#: pkg/storaged/overview.js:427
-msgid "RAID 10 (Stripe of Mirrors)"
-msgstr "RAID 10 (Arreglo de espejos)"
-
-#: pkg/storaged/overview.js:431
-msgid "Chunk Size"
-msgstr "Tamaño de la porción"
-
-#: pkg/storaged/overview.js:433
-msgid "4 KiB"
-msgstr "4 KBs"
-
-#: pkg/storaged/overview.js:434
-msgid "8 KiB"
-msgstr "8 KBs"
-
-#: pkg/storaged/overview.js:435
-msgid "16 KiB"
-msgstr "16 KBs"
-
-#: pkg/storaged/overview.js:436
-msgid "32 KiB"
-msgstr "32 KBs"
-
-#: pkg/storaged/overview.js:437
-msgid "64 KiB"
-msgstr "64 KBs"
-
-#: pkg/storaged/overview.js:438
-msgid "128 KiB"
-msgstr "128 KBs"
-
-#: pkg/storaged/overview.js:439
-msgid "512 KiB"
-msgstr "512 KBs"
-
-#: pkg/storaged/overview.js:440
-msgid "1 MiB"
-msgstr "1 MB"
-
-#: pkg/storaged/overview.js:441
-msgid "2 MiB"
-msgstr "2 MB"
-
-#: pkg/storaged/overview.js:455
-msgid "At least $0 disks are needed."
-msgstr "Se necesitan al menos $0 discos."
-
-#: pkg/storaged/overview.js:487
-msgid "Create Volume Group"
-msgstr "Crear un Grupo de Volúmenes"
-
-#: pkg/storaged/overview.js:515
-msgid "Add iSCSI Portal"
-msgstr "Agregar portal iSCSI"
-
-#: pkg/storaged/overview.js:518
-msgid "Server Address"
-msgstr "Dirección del Servidor"
-
-#: pkg/storaged/overview.js:521
+#: pkg/playground/translate.html:63
 #, fuzzy
-msgid "Server address cannot be empty."
-msgstr "La dirección del Servidor no puede estar bacía "
+msgctxt "verb"
+msgid "Empty"
+msgstr "Vaciar"
 
-#: pkg/storaged/overview.js:533 pkg/realmd/operation.html.h:11
-msgid "Next"
-msgstr "Siguiente"
+#: pkg/kubernetes/scripts/volumes.js:196
+msgid "Empty Directory"
+msgstr "Directorio vació"
 
-#: pkg/storaged/overview.js:577 pkg/storaged/overview.js:668
-#: pkg/subscriptions/subscriptions-client.js:194
+#: pkg/storaged/jobs.js:155
+msgid "Emptying $target"
+msgstr "Eliminando el contenido de $target"
+
+#: pkg/systemd/init.js:541
+msgid "Enable"
+msgstr "Habilitar"
+
+#: pkg/systemd/init.js:542
+msgid "Enable Forcefully"
+msgstr "Habilitar pre-ajuste"
+
+#: pkg/systemd/init.js:301
+msgid "Enabled"
+msgstr "Habilitado"
+
+#: pkg/storaged/details.js:1247
+msgctxt "storage-id-desc"
+msgid "Encrypted"
+msgstr "Cifrado"
+
+#: pkg/storaged/details.js:180
+msgid "Encrypted EXT4 (LUKS)"
+msgstr "Encriptado EXT4 (LUKS)"
+
+#: pkg/storaged/details.js:179
+msgid "Encrypted XFS (LUKS)"
+msgstr "Encriptado XFS (LUKS)"
+
+#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
+#: pkg/storaged/details.js:1115
+msgid "Encryption Options"
+msgstr "Opciones de cifrado"
+
+#: pkg/kubernetes/views/pv-modify.html:93
+msgid "Endpoint"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:40
+msgid "Endpoint Name"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:14
+#: pkg/kubernetes/views/service-panel.html:9
+msgid "Endpoints"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:38
+msgid "Ends"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:332
+msgid "Enforce policy:"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:447
+msgid "Enter IP address or host name"
+msgstr "Ingrese la dirección IP o el nombre del host"
+
+#: pkg/systemd/logs.html:60
+msgid "Entry"
+msgstr "Entrada"
+
+#: pkg/docker/index.html:547 pkg/kubernetes/views/image-config.html:17
+#: pkg/kubernetes/views/container-body.html:26
+msgid "Environment"
+msgstr "Entorno"
+
+#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
+msgid "Erase"
+msgstr "Borrar"
+
+#: pkg/docker/storage.jsx:423
+msgid "Erase containers and reset storage pool"
+msgstr ""
+
+#: pkg/docker/storage.jsx:360
+msgid "Erase containers, reformat disks, and add them"
+msgstr ""
+
+#: pkg/storaged/jobs.js:129
+msgid "Erasing $target"
+msgstr "Borrando $target"
+
+#: pkg/systemd/services.html:318 pkg/playground/translate.html:101
+#: pkg/playground/translate.html:106
+msgid "Error"
+msgstr "Error"
+
+#: pkg/kubernetes/scripts/connection.js:650
+msgid "Error getting certificate details: $0"
+msgstr "Error al obtener los detalles del certificado: $0"
+
+#: pkg/lib/machine-sync-users.html:13
+msgid "Error loading users: {{perm_failed}}"
+msgstr "Error cargando usuarios: {{perm_failed}}"
+
+#: pkg/docker/util.js:491
+msgid "Error message from Docker:"
+msgstr "Mensaje de error de Docker:"
+
+#: pkg/users/authorized-keys.js:115
+msgid "Error saving authorized keys: "
+msgstr "Error al guardar llaves autorizadas:"
+
+#: pkg/selinux/setroubleshoot.js:275
+msgid "Error while connecting."
+msgstr "Error durante la conexión "
+
+#: pkg/selinux/setroubleshoot-client.js:192
+msgid "Error while deleting alert"
+msgstr "Error al eliminar una alerta"
+
+#: pkg/selinux/setroubleshoot.js:65
+msgid "Error while setting SELinux mode: '$0'"
+msgstr "Error al establecer modo de SELinux:  '$0'"
+
+#: pkg/kubernetes/scripts/connection.js:88
+msgid "Error writing kubectl config"
+msgstr "Error escribiendo configuración de kubectl"
+
+#: pkg/systemd/logs.html:47
+msgid "Errors"
+msgstr "Errores"
+
+#: pkg/networkmanager/index.html:764
+msgid "Ethernet MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1854
+msgid "Ethtool"
+msgstr ""
+
+#: pkg/users/local.js:429 pkg/users/local.js:1104
+msgid "Excellent password"
+msgstr "Contraseña excelente "
+
+#: pkg/docker/util.js:96
+msgid "Exited $ExitCode"
+msgstr "Salió $ExitCode"
+
+#: pkg/docker/index.html:529
+msgid "Expose container ports"
+msgstr ""
+
+#: pkg/storaged/details.js:183
+msgid "Extended Partition"
+msgstr "Partición Extendida"
+
+#: pkg/storaged/details.js:1592
+msgid "FAILED"
+msgstr "Fallido"
+
+#: pkg/ostree/index.html:92
+msgid "Failed"
+msgstr "Falló"
+
+#: pkg/lib/machine-dialogs.js:412
+msgid "Failed to add machine: $0"
+msgstr "Fallo al agregar maquina: $0"
+
+#: pkg/users/local.js:112 pkg/users/local.js:144 pkg/lib/credentials.js:223
+msgid "Failed to change password"
+msgstr "Error al cambiar contraseña"
+
+#: pkg/selinux/setroubleshoot-client.js:187
+msgid "Failed to delete alert"
+msgstr "Error al eliminar la alerta"
+
+#: pkg/tuned/dialog.js:171
+msgid "Failed to disable tuned"
+msgstr "Ha fallado deshabilitar tuned"
+
+#: pkg/tuned/dialog.js:133
+msgid "Failed to disable tuned profile"
+msgstr "Ha fallado deshabilitar perfil de tuned"
+
+#: pkg/lib/machine-dialogs.js:494
+msgid "Failed to edit machine: $0"
+msgstr "Fallo al editar maquina: $0"
+
+#: pkg/tuned/dialog.js:169
+msgid "Failed to enable tuned"
+msgstr "Ha fallado habilitar tuned"
+
+#: pkg/users/index.html:338
+msgid "Failed to load authorized keys."
+msgstr "Fallo al cargar llaves autorizadas."
+
+#: pkg/docker/containers.js:64
+msgid "Failed to start Docker: $0"
+msgstr "Fallo al iniciar Docker: $0"
+
+#: pkg/docker/util.js:544
+msgid "Failed to stop Docker scope: $0"
+msgstr "Fallo al detener Docker scope: $0"
+
+#: pkg/tuned/dialog.js:145
+msgid "Failed to switch profile"
+msgstr "Ha fallado cambiar perfil"
+
+#: pkg/kubernetes/scripts/volumes.js:204
+msgid "Fibre Channel"
+msgstr ""
+
+#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
+msgid "Filesystem Options"
+msgstr "Opciones del Sistema de Archivos"
+
+#: pkg/kubernetes/views/pv-modify.html:180
+#: pkg/kubernetes/views/volume-body.html:6
+#: pkg/kubernetes/views/volume-body.html:16
+#: pkg/kubernetes/views/volume-body.html:62
+#: pkg/kubernetes/views/volume-body.html:83
+#: pkg/kubernetes/views/volume-body.html:91
+#: pkg/kubernetes/views/volume-body.html:120
+#: pkg/kubernetes/views/volume-body.html:132
+msgid "Filesystem Type"
+msgstr ""
+
+#: pkg/storaged/details.js:215
+msgid "Filesystem type"
+msgstr "Tipo de sistema de archivos"
+
+#: pkg/storaged/index.html:225
+msgid "Filesystems"
+msgstr "Archivos del sistema"
+
+#: pkg/lib/machine-unknown-hostkey.html:10
+msgid "Fingerprint"
+msgstr "Fingerprint"
+
+#: pkg/storaged/index.html:426
+msgctxt "storage"
+msgid "Firmware Version"
+msgstr "Versión de Firmware"
+
+#: pkg/kubernetes/scripts/volumes.js:206
+msgid "Flex"
+msgstr "Flex"
+
+#: pkg/kubernetes/scripts/volumes.js:205
+msgid "Flocker"
+msgstr "Flocker"
+
+#: pkg/kubernetes/views/volume-body.html:125
+msgid "Flocker Dataset Name"
+msgstr ""
+
+#: pkg/docker/util.js:503
+msgid "Force Delete"
+msgstr "Forzar el borrado"
+
+#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
+#: pkg/storaged/details.js:1142
+msgid "Format"
+msgstr "Formato"
+
+#: pkg/storaged/details.js:115
+msgid "Format $0"
+msgstr "Formatear $0"
+
+#: pkg/storaged/details.js:335
+msgid "Format Disk $0"
+msgstr "Formatear Disco $0"
+
+#: pkg/storaged/details.js:358
+msgid "Formatting a disk will erase all data on it."
+msgstr "Formatear un disco eliminará todos los datos en el."
+
+#: pkg/storaged/details.js:268
+msgid "Formatting a storage device will erase all data on it."
+msgstr ""
+"Formatear un dispositivo de almacenamiento eliminará todos los datos en el."
+
+#: pkg/networkmanager/interfaces.js:2577
+msgid "Forward delay $forward_delay"
+msgstr "Retardo del reenvío $forward_delay"
+
+#: pkg/systemd/index.html:255
+msgid "Free"
+msgstr "Libre"
+
+#: pkg/users/index.html:86 pkg/users/index.html:148
+msgid "Full Name"
+msgstr "Nombre Completo"
+
+#: pkg/kubernetes/scripts/volumes.js:192
+msgid "GCE Persistent Disk"
+msgstr ""
+
+#: pkg/docker/index.html:180
+msgid "Gateway:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2628
+msgid "General"
+msgstr "General"
+
+#: pkg/sosreport/index.html:66
+msgid "Generating report"
+msgstr "Generando reporte"
+
+#: pkg/kubernetes/scripts/volumes.js:194
+msgid "Git Repository"
+msgstr "Repositorio Git"
+
+#: pkg/kubernetes/scripts/volumes.js:198
+msgid "Gluster FS"
+msgstr "Gluster FS"
+
+#: pkg/kubernetes/scripts/volumes.js:872
+msgid "GlusterFS"
+msgstr "GlusterFS"
+
+#: pkg/systemd/logs.js:130
+msgid "Go to"
+msgstr "Ir a"
+
+#: pkg/storaged/index.html:307 pkg/networkmanager/index.html:50
+#: pkg/networkmanager/index.html:496
+msgid "Go to now"
+msgstr "Ir a ahora"
+
+#: pkg/kubernetes/views/group-page.html:21
+#: pkg/kubernetes/views/group-panel.html:12
+msgid "Group Members"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:48
+#: pkg/kubernetes/views/user-delete.html:14
+msgid "Groups"
+msgstr ""
+
+#: pkg/networkmanager/index.html:268
+msgid "Hair Pin mode"
+msgstr "Modo horquilla"
+
+#: pkg/networkmanager/interfaces.js:2603
+msgid "Hairpin mode"
+msgstr "Modo horquilla"
+
+#: pkg/docker/storage.jsx:157
+#, fuzzy
+msgid "Hard Disk"
+msgstr "Disco Duro"
+
+#: pkg/storaged/overview.js:180
+msgctxt "storage"
+msgid "Hard Disk"
+msgstr "Disco Duro"
+
+#: pkg/systemd/index.html:77
+msgid "Hardware"
+msgstr "Hardware"
+
+#: pkg/networkmanager/interfaces.js:2579
+msgid "Hello time $hello_time"
+msgstr "Tiempo de saludo $hello_time"
+
+#: pkg/kubernetes/views/details-page.html:73
+#: pkg/kubernetes/views/route-body.html:9
+#: pkg/kubernetes/views/route-modify.html:8
+msgid "Host"
+msgstr "Anfitrión"
+
+#: pkg/systemd/index.html:102 pkg/dashboard/index.html:151
+msgid "Host Name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
+msgid "Host Path"
+msgstr "Ruta del Host"
+
+#: src/base1/cockpit.js:3699
+msgid "Host key is incorrect"
+msgstr "Tecla del Host es incorrecta"
+
+#: pkg/systemd/services.html:442
+#, fuzzy
+msgid "Hour : Minute"
+msgstr "1 Minuto"
+
+#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
+msgid "Hour needs to be a number between 0-23"
+msgstr ""
+
+#: pkg/systemd/services.html:408
+#, fuzzy
+msgid "Hours"
+msgstr "6 horas"
+
+#: pkg/systemd/index.html:221
+msgid "I/O Wait"
+msgstr "Espera de E/S"
+
+#: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
+msgid "IP"
+msgstr "IP"
+
+#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
+msgid "IP Address"
+msgstr "Dirección IP"
+
+#: pkg/docker/index.html:172
+msgid "IP Address:"
+msgstr ""
+
+#: pkg/docker/index.html:176
+msgid "IP Prefix Length:"
+msgstr ""
+
+#: pkg/networkmanager/index.html:568
+msgid "IP Settings"
+msgstr "Configuración IP"
+
+#: pkg/networkmanager/interfaces.js:2641
+msgid "IPv4"
+msgstr "IPv4"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv4 Settings"
+msgstr "Configuración IPv4"
+
+#: pkg/networkmanager/interfaces.js:2642
+msgid "IPv6"
+msgstr "IPv6"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv6 Settings"
+msgstr "Configuración IPv6"
+
+#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
+msgid "ISCSI"
+msgstr "ISCSI"
+
+#: pkg/systemd/init.js:270
+msgid "Id"
+msgstr "Id"
+
+#: pkg/networkmanager/interfaces.js:2620
+msgid "Id $id"
+msgstr "Id $id"
+
+#: pkg/kubernetes/views/image-body.html:22
+msgid "Identifier"
+msgstr "Identificador"
+
+#: pkg/kubernetes/views/user-page.html:23
+#: pkg/kubernetes/views/user-panel.html:18
+msgid "Identities"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:91
+msgid "Identity"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1817
+msgid "Ignore"
+msgstr "Ignorar"
+
+#: pkg/docker/index.html:452 pkg/kubernetes/views/image-panel.html:9
+#: pkg/kubernetes/views/container-body.html:6
+#: pkg/kubernetes/views/image-page.html:16
+msgid "Image"
+msgstr "Imagén"
+
+#: pkg/docker/image.js:77
+msgid "Image $0"
+msgstr "Imagén $0"
+
+#: pkg/kubernetes/views/container-body.html:8
+msgid "Image ID"
+msgstr "ID de Imagen"
+
+#: pkg/kubernetes/views/image-meta.html:16
+msgid "Image Layers"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:58
+msgid "Image Name"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:23
+msgid "Image Registry"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-page.html:16
+msgid "Image Stream"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:135
+#, fuzzy
+msgid "Image commands"
+msgstr "Conteo de imágenes"
+
+#: pkg/kubernetes/views/imagestream-body.html:34
+msgid "Image count"
+msgstr "Conteo de imágenes"
+
+#: pkg/kubernetes/registry.html:48
+#: pkg/kubernetes/views/registry-dashboard-page.html:19
+#: pkg/kubernetes/views/imagestream-page.html:18
+#: pkg/kubernetes/views/image-listing.html:9 pkg/kubernetes/index.html:77
+msgid "Images"
+msgstr "Imágenes"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:17
+msgid "Images by project"
+msgstr "Imágenes por proyecto"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:54
+msgid "Images pushed recently"
+msgstr ""
+
+#: pkg/storaged/details.js:1593
+msgid "In Sync"
+msgstr "En Sincronía"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:81
+msgid ""
+"In order to begin pushing images to the registry, use the commands below."
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:6
+msgid ""
+"In order to begin pushing images to the registry, you need to create a "
+"project."
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:50
+msgid ""
+"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
+"strong}}.        {{/needs_root}}                                    User "
+"name                                                                            "
+"{{#allows_password}}                            "
+"Password                                                                            "
+"{{/allows_password}}            "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
+#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
+msgid "Inactive"
+msgstr "Inactivo"
+
+#: pkg/lib/machine-invalid-hostkey.html:2
+msgid "Incorrect Host Key"
+msgstr "Llave de Host Incorrecta"
+
+#: pkg/docker/storage.jsx:282
+msgid "Information about the Docker storage pool is not available."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:222
+msgid "Installed products"
+msgstr ""
+
+#: pkg/systemd/services.html:135
+msgid "Instantiate"
+msgstr "Instanciar"
+
+#: pkg/kubernetes/views/pv-modify.html:169
+#: pkg/kubernetes/views/volume-body.html:81
+msgid "Interface"
+msgstr ""
+
+#: pkg/networkmanager/index.html:84
+msgid "Interfaces"
+msgstr "Interfaces"
+
+#: src/base1/cockpit.js:3701
+msgid "Internal error"
+msgstr "Error interno"
+
+#: pkg/subscriptions/subscriptions-client.js:196
+#, fuzzy
+msgid "Invalid credentials"
+msgstr "Puerto invalido"
+
+#: pkg/systemd/host.js:1194
+msgid "Invalid date format"
+msgstr "Formato de fecha inválido"
+
+#: pkg/systemd/host.js:1190
+msgid "Invalid date format and invalid time format"
+msgstr "Formato de fecha y formato de hora inválidos "
+
+#: pkg/systemd/init.js:1218
+#, fuzzy
+msgid "Invalid date format."
+msgstr "Formato de fecha inválido"
+
+#: pkg/lib/credentials.js:274
+msgid "Invalid file permissions"
+msgstr "Permisos de archivo invalidos"
+
+#: pkg/users/index.html:322
+msgid "Invalid key"
+msgstr "Llave inválida"
+
+#: pkg/systemd/init.js:1169
+#, fuzzy
+msgid "Invalid number."
+msgstr "Llave inválida"
+
+#: pkg/docker/run.js:283
+msgid "Invalid port"
+msgstr "Puerto invalido"
+
+#: pkg/systemd/host.js:1192
+msgid "Invalid time format"
+msgstr "Formato de hora inválido"
+
+#: pkg/subscriptions/subscriptions-client.js:194 pkg/storaged/overview.js:577
+#: pkg/storaged/overview.js:668
 msgid "Invalid username or password"
 msgstr "Nombre de usuario o contraseña invalidos"
 
-#: pkg/storaged/overview.js:582
-msgid "Unknown host name"
-msgstr "Nombre de host desconocido "
+#: pkg/lib/machine-change-port.html:15
+msgid "Is sshd running on a different port?"
+msgstr "¿sshd está corriendo en un puerto diferente?"
 
-#: pkg/storaged/overview.js:586
-msgid "Unable to reach server"
-msgstr "Imposible conectar al servidor"
+#: pkg/systemd/init.js:522
+msgid "Isolate"
+msgstr "Aislar"
 
-#: pkg/storaged/overview.js:619
-msgid "Available targets on $0"
-msgstr "Objetivos disponibles en $0"
+#: pkg/storaged/index.html:280
+msgid "Jobs"
+msgstr "Trabajos"
 
-#: pkg/storaged/overview.js:623 pkg/systemd/services.html.h:2
-msgid "Targets"
-msgstr "Objetivos"
+#: pkg/realmd/operation.js:96
+msgid "Join"
+msgstr "Unirse"
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-add.html.h:2
-#: pkg/kubernetes/views/node-body.html.h:2
-#: pkg/kubernetes/views/auth-form.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:16
-#: pkg/kubernetes/views/nodes-page.html.h:7
-#: pkg/kubernetes/views/details-page.html.h:19
-msgid "Address"
-msgstr "Dirección"
+#: pkg/realmd/operation.js:453
+msgid "Join Domain"
+msgstr "Unirse a Dominio"
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-change-port.html.h:5
-msgid "Port"
-msgstr "Puerto"
+#: pkg/realmd/operation.js:347
+msgid "Joining this domain is not supported"
+msgstr "Unirse a este dominio no esta soportado"
 
-#: pkg/storaged/overview.js:699
-msgid "Change iSCSI Initiator Name"
-msgstr "Cambiar Nombre Iniciador de iSCSI "
+#: pkg/systemd/logs.js:257
+msgid "Journal entry"
+msgstr "Bitacora de entradas"
 
-#: pkg/storaged/overview.js:707 pkg/kubernetes/views/route-modify.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:22
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:4
-#: pkg/kubernetes/views/project-modify.html.h:9
-msgid "Change"
-msgstr "Cambiar"
+#: pkg/systemd/logs.js:284
+msgid "Journal entry not found"
+msgstr "Entrada de bitacora no encontrada"
 
-#: pkg/storaged/utils.js:88
-msgctxt "format-bytes"
-msgid "bytes"
-msgstr "bytes"
+#: pkg/lib/machine-auth-failed.html:10
+msgid "Kerberos Based SSO"
+msgstr "SSO Basado en Kerberos"
+
+#: pkg/lib/machine-change-auth.html:69
+msgid "Kerberos Ticket"
+msgstr "Tiquete Kerberos"
+
+#: pkg/systemd/index.html:225
+msgid "Kernel"
+msgstr "Kernel"
+
+#: pkg/kubernetes/views/node-body.html:19
+msgid "Kernel Version"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:67
+msgid "Key Ring Path"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:23
+msgid "Kubelet Version"
+msgstr ""
+
+#: pkg/kubernetes/index.html:23
+msgid "Kubernetes Cluster"
+msgstr "Cluster de Kubernetes"
+
+#: pkg/networkmanager/index.html:473
+msgid "LACP Key"
+msgstr ""
+
+#: pkg/storaged/details.js:1245
+msgctxt "storage-id-desc"
+msgid "LUKS Encrypted"
+msgstr "LUKS Cifrado"
+
+#: pkg/storaged/details.js:1226
+msgctxt "storage-id-desc"
+msgid "LVM2 Physical Volume"
+msgstr "Volumen Físico LVM2"
+
+#: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/replicationcontroller-body.html:17
+#: pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/route-body.html:22
+#: pkg/kubernetes/views/image-meta.html:3
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
+msgid "Labels"
+msgstr "Viñetas"
+
+#: pkg/systemd/logs.html:42
+msgid "Last 24 hours"
+msgstr "Ultimas 24 horas"
+
+#: pkg/systemd/logs.html:43
+msgid "Last 7 days"
+msgstr "Ultimos 7 dias"
+
+#: pkg/kubernetes/views/node-body.html:49
+msgid "Last Heartbeat"
+msgstr "Último Heartbeat"
+
+#: pkg/users/index.html:100
+msgid "Last Login"
+msgstr "Último inicio de sesión"
+
+#: pkg/kubernetes/views/node-body.html:51
+msgid "Last Status Change"
+msgstr "Último Cambio de Estado"
+
+#: pkg/systemd/init.js:273
+msgid "Last Trigger"
+msgstr "Última ejecución"
+
+#: pkg/kubernetes/views/image-listing.html:16
+msgid "Last Updated"
+msgstr "Última Actualización"
+
+#: pkg/kubernetes/views/details-page.html:107
+msgid "Latest Version"
+msgstr "Última Versión"
+
+#: pkg/realmd/operation.js:101
+msgid "Leave"
+msgstr "Abandonar"
+
+#: pkg/networkmanager/index.html:315
+msgid "Link Monitoring"
+msgstr "Monitorear enlace"
+
+#: pkg/networkmanager/index.html:397
+#, fuzzy
+msgid "Link Watch"
+msgstr "Enlace local"
+
+#: pkg/networkmanager/index.html:350 pkg/networkmanager/index.html:432
+msgid "Link down delay"
+msgstr "Desvincular demora"
+
+#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
+msgid "Link local"
+msgstr "Enlace local"
+
+#: pkg/networkmanager/index.html:341 pkg/networkmanager/index.html:423
+msgid "Link up delay"
+msgstr "Vincular demora"
+
+#: pkg/docker/index.html:514
+msgid "Links"
+msgstr "Vinculos"
+
+#: pkg/storaged/details.js:1224
+msgctxt "storage-id-desc"
+msgid "Linux MD-RAID Component"
+msgstr "Componente Linux MD-RAID"
+
+#: pkg/networkmanager/interfaces.js:1841
+#, fuzzy
+msgid "Load Balancing"
+msgstr "Equilibrio de carga adaptativo"
+
+#: pkg/systemd/logs.js:69
+msgid "Load earlier entries"
+msgstr "Cargar entradas anteriores"
+
+#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
+#: pkg/systemd/logs.js:175
+msgid "Loading..."
+msgstr "Cargando..."
+
+#: pkg/users/index.html:23
+msgid "Local Accounts"
+msgstr "Cuentas Locales"
+
+#: pkg/docker/storage.jsx:188
+#, fuzzy
+msgid "Local Disks"
+msgstr "$0 Discos"
+
+#: pkg/storaged/details.js:1109
+msgid "Lock"
+msgstr "Bloquear"
+
+#: pkg/users/index.html:109 pkg/users/index.html:196
+msgid "Lock Account"
+msgstr "Bloquear Cuenta"
+
+#: pkg/storaged/jobs.js:122
+msgid "Locking $target"
+msgstr "Bloquendo $target"
+
+#: pkg/lib/machine-change-auth.html:80
+msgid "Log In"
+msgstr "Iniciar sesión"
+
+#: pkg/lib/machine-change-auth.html:4
+msgid "Log in to {{host}}"
+msgstr "Iniciar sesión en {{host}}"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:116
+msgid "Log into OpenShift command line tools:"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:101
+#, fuzzy
+msgid "Log into the registry:"
+msgstr "Bienvenidos al Registro de Imagen"
+
+#: pkg/shell/simple.html:45 pkg/shell/index.html:52 pkg/shell/stub.html:45
+msgid "Log out"
+msgstr "Cerrar sesión"
+
+#: pkg/users/local.js:839
+msgid "Logged In"
+msgstr "Sesión iniciada"
+
+#: pkg/storaged/details.js:1424
+msgid "Logical Partition"
+msgstr "Partición Logica"
+
+#: pkg/kubernetes/views/pv-modify.html:158
+#: pkg/kubernetes/views/volume-body.html:79
+#: pkg/kubernetes/views/volume-body.html:118
+msgid "Logical Unit Number"
+msgstr ""
+
+#: pkg/storaged/utils.js:172
+msgid "Logical Volume"
+msgstr "Volumen Lógico"
+
+#: pkg/storaged/utils.js:170
+msgid "Logical Volume (Snapshot)"
+msgstr "Volumen Lógico(Captura)"
+
+#: pkg/storaged/details.js:1792
+msgid "Logical Volumes"
+msgstr "Volúmenes Lógicos "
+
+#: pkg/subscriptions/subscriptions-register.jsx:140
+#, fuzzy
+msgid "Login"
+msgstr "Último inicio de sesión"
+
+#: pkg/lib/machine-change-auth.html:68
+msgid "Login Password"
+msgstr "Contraseña de inicio de sesión"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:96
+#, fuzzy
+msgid "Login commands"
+msgstr "Comandos Docker"
+
+#: src/base1/cockpit.js:3693
+msgid "Login failed"
+msgstr "Inicio de sesión fallido"
+
+#: pkg/subscriptions/subscriptions-client.js:200
+msgid "Login/password or activation key required to register."
+msgstr ""
+
+#: pkg/systemd/logs.html:59 pkg/kubernetes/views/container-panel.html:6
+#: pkg/kubernetes/views/container-page-inline.html:8
+msgid "Logs"
+msgstr ""
+
+#: pkg/dashboard/index.html:110
+msgid "Lost connection. Trying to reconnect"
+msgstr "Conexión perdida. Intentando conectarse nuevamente"
+
+#: pkg/docker/index.html:184
+msgid "MAC Address:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1833
+msgid "MII (Recommended)"
+msgstr "MII (Recomendado)"
+
+#: pkg/networkmanager/interfaces.js:2477
+msgid "MTU"
+msgstr "MTU"
+
+#: pkg/networkmanager/interfaces.js:4139
+msgid "MTU must be a positive number"
+msgstr ""
+
+#: pkg/systemd/index.html:85 pkg/kubernetes/views/node-body.html:15
+msgid "Machine ID"
+msgstr ""
+
+#: pkg/systemd/index.html:282
+msgid "Machine SSH Key Fingerprints"
+msgstr ""
+
+#: pkg/shell/indexes.js:253
+msgid "Machines"
+msgstr "Maquinas"
+
+#: pkg/kubernetes/scripts/dashboard.js:460
+msgid "Manifest"
+msgstr "Manifiesto"
+
+#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
+msgid "Manual"
+msgstr "Manual"
+
+#: pkg/systemd/index.html:401 pkg/systemd/index.html:405
+msgid "Manually"
+msgstr ""
+
+#: pkg/storaged/jobs.js:140
+msgid "Marking $target as faulty"
+msgstr "Marcando $target como fallado"
+
+#: pkg/systemd/init.js:546
+msgid "Mask"
+msgstr "Enmascarar"
+
+#: pkg/systemd/init.js:547
+msgid "Mask Forcefully"
+msgstr "Enmascarar "
+
+#: pkg/networkmanager/interfaces.js:2483
+msgid "Master"
+msgstr "Maestro"
+
+#: pkg/networkmanager/interfaces.js:2581
+msgid "Maximum message age $max_age"
+msgstr "Edad máxima del mensaje $max_age"
+
+#: pkg/kubernetes/views/volume-body.html:34
+msgid "Medium"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:92
+msgid "Member of"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:16
+#: pkg/kubernetes/views/project-listing.html:55
+#: pkg/networkmanager/index.html:291
+msgid "Members"
+msgstr "Miembros"
+
+#: pkg/kubernetes/views/project-page.html:29
+#: pkg/kubernetes/views/user-panel.html:11
+#: pkg/kubernetes/views/user-panel.html:27
+#: pkg/kubernetes/views/user-body.html:4
+msgid "Membership"
+msgstr "Afiliación"
+
+#: pkg/dashboard/index.html:71 pkg/playground/translate.html:91
+msgid "Memory"
+msgstr "Memoria"
+
+#: pkg/systemd/host.js:1466
+msgctxt "page-title"
+msgid "Memory"
+msgstr "Memoria"
+
+#: pkg/kubernetes/scripts/nodes.js:716
+msgid "Memory Utilization: $0%"
+msgstr "Uso de memoria: $0%"
+
+#: pkg/docker/index.html:473 pkg/docker/index.html:652
+msgid "Memory limit"
+msgstr "Limite de Memoria "
+
+#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
+msgid "Message"
+msgstr "Mensaje"
+
+#: pkg/systemd/host.js:1300
+msgid "Message to logged in users"
+msgstr "Mensaje para usuarios activos "
+
+#: pkg/kubernetes/views/image-panel.html:15
+#: pkg/kubernetes/views/imagestream-page.html:21
+#: pkg/kubernetes/views/image-page.html:22
+msgid "Metadata"
+msgstr ""
+
+#: pkg/docker/index.html:487 pkg/docker/index.html:666
+msgid "MiB"
+msgstr ""
+
+#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
+msgid "Minute needs to be a number between 0-59"
+msgstr ""
+
+#: pkg/systemd/services.html:407
+#, fuzzy
+msgid "Minutes"
+msgstr "5 Minutos"
+
+#: pkg/networkmanager/index.html:299
+msgid "Mode"
+msgstr "Modo"
+
+#: pkg/storaged/index.html:421
+msgctxt "storage"
+msgid "Model"
+msgstr "Modelo"
+
+#: pkg/kubernetes/views/user-modify.html:31
+msgid "Modify"
+msgstr ""
+
+#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
+msgid "Modifying $target"
+msgstr "Modificando $target"
+
+#: pkg/networkmanager/index.html:323
+msgid "Monitoring Interval"
+msgstr "Monitorear intervalo"
+
+#: pkg/networkmanager/index.html:332
+msgid "Monitoring Targets"
+msgstr "Monitorear objetivos"
+
+#: pkg/kubernetes/views/volume-body.html:54
+msgid "Monitors"
+msgstr ""
+
+#: pkg/realmd/operation.js:366
+msgid "More"
+msgstr "Más"
+
+#: pkg/storaged/details.js:1099
+msgid "Mount"
+msgstr "Montar"
+
+#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
+msgid "Mount Location"
+msgstr ""
+
+#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
+msgid "Mount Options"
+msgstr "Opciones de Montaje"
+
+#: pkg/storaged/index.html:231
+msgid "Mount Point"
+msgstr "Punto de Montaje"
+
+#: pkg/docker/index.html:540
+msgid "Mount container volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
+msgid "Mounting"
+msgstr "Montando"
+
+#: pkg/storaged/jobs.js:126
+msgid "Mounting $target"
+msgstr "Montando $target"
+
+#: pkg/storaged/index.html:508
+msgctxt "storage"
+msgid "Multipathed Devices"
+msgstr "Dispositivos Multipathed"
+
+#: pkg/kubernetes/scripts/volumes.js:860
+msgid "NFS"
+msgstr "NFS"
+
+#: pkg/kubernetes/scripts/volumes.js:199
+msgid "NFS Mount"
+msgstr "Montar NFS"
+
+#: pkg/networkmanager/interfaces.js:1856
+msgid "NSNA Ping"
+msgstr ""
+
+#: pkg/storaged/details.js:182
+msgid "NTFS - Compatible with most systems"
+msgstr "NTFS - Compatible con la mayoría de los sistemas"
+
+#: pkg/systemd/host.js:1250
+msgid "NTP Server"
+msgstr "Servidor NTP"
+
+#: pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/project-modify.html:16
+#: pkg/kubernetes/views/node-add.html:16
+#: pkg/kubernetes/views/volumes-page.html:19
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/image-body.html:2
+#: pkg/kubernetes/views/imagestream-modify.html:10
+#: pkg/kubernetes/views/service-modify.html:9
+#: pkg/kubernetes/views/dashboard-page.html:156
+#: pkg/kubernetes/views/dashboard-page.html:198
+#: pkg/kubernetes/views/details-page.html:34
+#: pkg/kubernetes/views/details-page.html:70
+#: pkg/kubernetes/views/details-page.html:103
+#: pkg/kubernetes/views/details-page.html:137
+#: pkg/kubernetes/views/details-page.html:171
+#: pkg/kubernetes/views/pv-claim.html:4
+#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/kubernetes/views/project-listing.html:14
+#: pkg/kubernetes/views/project-listing.html:53
+#: pkg/kubernetes/views/project-listing.html:90
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/volume-body.html:31 pkg/storaged/index.html:230
+#: pkg/networkmanager/index.html:95 pkg/networkmanager/index.html:113
+#: pkg/networkmanager/index.html:150 pkg/networkmanager/index.html:183
+#: pkg/networkmanager/index.html:282 pkg/networkmanager/index.html:364
+msgid "Name"
+msgstr "Nombre"
 
 #: pkg/storaged/utils.js:129
 #, fuzzy
@@ -1725,377 +3379,1221 @@ msgstr "Nombre no puede contener el caracter '$0'."
 msgid "Name cannot contain whitespace."
 msgstr "Nombre no puede contener espacios en blanco."
 
-#: pkg/storaged/utils.js:157
-msgid "$name (from $host)"
-msgstr "$name (de $host)"
+#: pkg/kubernetes/views/service-body.html:5
+#: pkg/kubernetes/views/replicationcontroller-body.html:5
+#: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/pod-body.html:5
+#: pkg/kubernetes/views/dashboard-page.html:160
+#: pkg/kubernetes/views/details-page.html:36
+#: pkg/kubernetes/views/details-page.html:72
+#: pkg/kubernetes/views/details-page.html:105
+#: pkg/kubernetes/views/details-page.html:139
+#: pkg/kubernetes/views/details-page.html:173
+#: pkg/kubernetes/views/pv-claim.html:6
+#: pkg/kubernetes/views/containers-listing.html:14
+#: pkg/kubernetes/views/route-body.html:5
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
+msgid "Namespace"
+msgstr "Espacio de Nombres"
+
+#: pkg/kubernetes/scripts/dashboard.js:374
+msgid "Namespace cannot be empty."
+msgstr "El nombre de espacio no puede estar vacio"
+
+#: pkg/systemd/host.js:1113
+msgid "Need at least one NTP server"
+msgstr "Se requiere al menos un servidor NTP"
+
+#: pkg/dashboard/index.html:72 pkg/playground/translate.html:96
+msgid "Network"
+msgstr "Red"
+
+#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:485
+msgid "Networking"
+msgstr "Redes"
+
+#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
+msgctxt "page-title"
+msgid "Networking"
+msgstr "Redes"
+
+#: pkg/networkmanager/index.html:124
+msgid "Networking Logs"
+msgstr "Registros de redes"
+
+#: pkg/users/local.js:841
+msgid "Never"
+msgstr "Nunca"
+
+#: pkg/kubernetes/views/project-listing.html:46
+msgid "New Group"
+msgstr ""
+
+#: pkg/users/index.html:236 pkg/shell/index.html:255
+msgid "New Password"
+msgstr "Nueva contraseña"
+
+#: pkg/kubernetes/views/project-listing.html:7
+msgid "New Project"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/image-listing.html:7
+msgid "New image stream"
+msgstr ""
+
+#: pkg/users/local.js:120 pkg/lib/credentials.js:231
+msgid "New password was not accepted"
+msgstr "Nueva contraseña no fue aceptada"
+
+#: pkg/kubernetes/views/project-modify.html:4
+#: pkg/kubernetes/views/registry-dashboard-page.html:9
+#: pkg/kubernetes/views/registry-dashboard-page.html:48
+msgid "New project"
+msgstr "Nuevo proyecto"
+
+#: pkg/realmd/operation.html:91
+msgid "Next"
+msgstr "Siguiente"
+
+#: pkg/systemd/init.js:272
+msgid "Next Run"
+msgstr "En la próxima ejecución"
+
+#: pkg/systemd/index.html:233
+msgid "Nice"
+msgstr "Bien"
+
+#: pkg/docker/index.html:563 pkg/docker/index.html:567
+msgid "No"
+msgstr "No"
+
+#: pkg/systemd/index.html:469
+msgid "No Delay"
+msgstr ""
+
+#: pkg/ostree/index.html:220
+msgid "No Deployments"
+msgstr "No hay Despliegues"
+
+#: pkg/storaged/details.js:185
+msgid "No Filesystem"
+msgstr "Ningún Sistema de Archivos"
+
+#: pkg/ostree/app.js:101
+msgid "No OSTree deployments found"
+msgstr "No se encontraron despliegues de OSTree"
+
+#: src/ws/cockpitcertificate.c:398
+msgid "No PEM-encoded certificate found"
+msgstr "No se encontró certificado cifrado con PEM"
+
+#: src/ws/cockpitcertificate.c:364
+msgid "No PEM-encoded private key found"
+msgstr "No se encontró llave privada cifrada con PEM"
+
+#: pkg/kubernetes/views/pv-claim.html:39
+msgid "No Pods are using this claim"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:479
+msgid "No SELinux alerts."
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:10
+msgid "No Volume Bound"
+msgstr ""
+
+#: pkg/docker/storage.jsx:194
+msgid "No additional local storage found."
+msgstr ""
+
+#: pkg/docker/run.js:350
+msgid "No alias specified"
+msgstr "No se ha especificado un alias"
+
+#: pkg/sosreport/index.js:115
+msgid "No archive has been created."
+msgstr "No archive has been created."
+
+#: pkg/networkmanager/interfaces.js:1326
+msgid "No carrier"
+msgstr "Ningún portador"
+
+#: pkg/docker/run.js:384
+msgid "No container specified"
+msgstr "No se ha especificado un contenedor"
+
+#: pkg/storaged/index.html:193
+msgid "No drives attached"
+msgstr "No hay dispositivos adjuntos"
+
+#: pkg/kubernetes/views/project-listing.html:74
+msgid "No groups are present."
+msgstr ""
+
+#: pkg/systemd/index.html:28
+msgid "No host keys found."
+msgstr ""
+
+#: pkg/storaged/index.html:158
+msgid "No iSCSI targets set up"
+msgstr ""
+
+#: pkg/kubernetes/views/image-listing.html:70
+msgid "No image streams are present."
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:80
+msgid "No images pushed"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:223
+#, fuzzy
+msgid "No installed products on the system."
+msgstr "Cockpit no esta instalado en el sistema"
+
+#: pkg/storaged/index.html:446
+msgid "No media inserted"
+msgstr "No hay media insertada"
+
+#: pkg/kubernetes/scripts/dashboard.js:384
+msgid ""
+"No metadata file was selected. Please select a Kubernetes metadata file."
+msgstr ""
+"No se seleccionó un archivo metadata. Por favor seleccione un archivo "
+"metadata Kebernetes."
+
+#: pkg/kubernetes/views/dashboard-page.html:117
+msgid "No nodes in cluster"
+msgstr ""
+
+#: pkg/storaged/details.js:352
+msgid "No partitioning"
+msgstr "No particionar"
+
+#: pkg/kubernetes/views/dashboard-page.html:40
+msgid "No pods deployed"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:6
+msgid "No pods replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/node-capacity.html:11
+msgid "No pods scheduled"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:10
+msgid "No pods selected"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:37
+msgid "No projects are present."
+msgstr ""
+
+#: pkg/users/local.js:405
+msgid "No real name specified"
+msgstr "Nombre real no especificado"
+
+#: pkg/storaged/index.html:87
+msgid "No storage set up as RAID"
+msgstr ""
+
+#: pkg/lib/credentials.js:182
+msgid "No such file or directory"
+msgstr "No existe el archivo o directorio"
+
+#: pkg/users/local.js:400
+msgid "No user name specified"
+msgstr "Nombre de usuario no especificado"
+
+#: pkg/kubernetes/views/project-listing.html:112
+msgid "No users are present."
+msgstr ""
+
+#: pkg/storaged/index.html:120
+msgid "No volume groups created"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:44
+msgid "No volumes are present."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:73
+msgid "No volumes in use"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:18 pkg/kubernetes/views/node-panel.html:7
+#: pkg/kubernetes/views/containers-listing.html:15
+#: pkg/kubernetes/views/node-page.html:14
+#: pkg/kubernetes/views/topology-page.html:41
+msgid "Node"
+msgstr "Nodo"
+
+#: pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:192
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:45
+msgid "Nodes"
+msgstr "Nodos"
+
+#: pkg/kubernetes/views/topology-page.html:42
+msgid "Nodes are the machines that run your containers."
+msgstr "Nodos son las computadoras que ejecutan sus contenedores"
+
+#: pkg/kubernetes/views/service-body.html:15
+#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
+#: pkg/kubernetes/views/image-config.html:25
+#: pkg/kubernetes/views/imagestream-body.html:33
+msgid "None"
+msgstr "Ninguno"
+
+#: pkg/playground/translate.html:30 pkg/kubernetes/views/details-page.html:53
+#: pkg/kubernetes/views/node-body.html:42
+msgid "Not Ready"
+msgstr "No está listo"
+
+#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
+msgid "Not a valid number of replicas"
+msgstr "No es un número válido de réplicas"
+
+#: pkg/lib/credentials.js:248
+msgid "Not a valid private key"
+msgstr "No es llave privada valida."
+
+#: pkg/kubernetes/scripts/details.js:546
+msgid "Not a valid value for Host"
+msgstr "No es un valor valido para el host"
+
+#: pkg/docker/index.html:57
+msgid "Not authorized to access Docker on this system"
+msgstr "No esta autorizado a acceder a Docker en este sistema"
+
+#: pkg/ostree/app.js:81
+msgid "Not authorized to update software on this system"
+msgstr "No esta autorizado para actualizar software en este sistema"
+
+#: pkg/networkmanager/interfaces.js:805
+msgid "Not available"
+msgstr "No disponible"
+
+#: pkg/selinux/setroubleshoot.js:238
+msgid "Not connected"
+msgstr "No conectado"
+
+#: pkg/kubernetes/views/details-page.html:122
+msgid "Not deployed"
+msgstr ""
+
+#: pkg/docker/details.js:177 pkg/docker/image.js:112
+#: pkg/storaged/details.js:1822
+msgid "Not found"
+msgstr "No encontrado"
+
+#: src/base1/cockpit.js:3691
+msgid "Not permitted to perform this action."
+msgstr "No esta permitido ejecutar esta acción."
+
+#: pkg/storaged/details.js:1574
+msgid "Not running"
+msgstr "No esta corriendo"
+
+#: pkg/systemd/index.html:62
+msgid "Not synchronized"
+msgstr ""
+
+#: pkg/systemd/services.html:299
+msgid "Note"
+msgstr "Nota"
+
+#: pkg/systemd/logs.html:49
+msgid "Notices"
+msgstr "Avisos"
+
+#: pkg/kubernetes/views/node-body.html:13
+msgid "OS"
+msgstr ""
+
+#: pkg/ostree/client.js:500
+msgid "OS $0 not found"
+msgstr "OS $0 no encontrado"
+
+#: pkg/kubernetes/views/nodes-page.html:19
+msgid "OS Versions"
+msgstr ""
+
+#: pkg/ostree/app.js:83
+msgid "OSTree is not available on this system"
+msgstr "OSTree no esta disponible para este sistema"
+
+#: pkg/selinux/setroubleshoot-view.jsx:405
+msgid "Occurred $0"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:400
+msgid "Occurred between $0 and $1"
+msgstr ""
+
+#: pkg/systemd/index.html:157 pkg/playground/jquery-patterns.html:95
+#: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:189
+#: pkg/storaged/index.html:565
+msgid "Off"
+msgstr "Apagado"
+
+#: pkg/lib/cockpit-components-dialog.jsx:155
+msgid "Ok"
+msgstr ""
+
+#: pkg/users/index.html:226 pkg/shell/index.html:248
+msgid "Old Password"
+msgstr "Contraseña vieja"
+
+#: pkg/users/local.js:78 pkg/lib/credentials.js:213
+msgid "Old password not accepted"
+msgstr "Contraseña antigua no aceptada"
+
+#: pkg/systemd/index.html:153 pkg/playground/jquery-patterns.html:91
+#: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:185
+#: pkg/storaged/index.html:564
+msgid "On"
+msgstr "Encencido"
+
+#: pkg/kubernetes/views/image-meta.html:7
+msgid "On Build"
+msgstr "En Construcción"
+
+#: pkg/docker/index.html:568
+msgid "On Failure"
+msgstr ""
+
+#: pkg/docker/util.js:104
+msgid "On failure, retry $0 time"
+msgid_plural "On failure, retry $0 times"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/realmd/operation.html:71
+msgid "One Time Password"
+msgstr "Contraseña de un solo uso"
+
+#: pkg/systemd/init.js:1147
+msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
+msgstr ""
+
+#: pkg/shell/simple.html:28 pkg/shell/index.html:28 pkg/shell/stub.html:28
+msgid "Ooops!"
+msgstr "Ooops!"
+
+#: pkg/systemd/index.html:89 pkg/ostree/index.html:111
+#: pkg/kubernetes/views/nodes-page.html:42
+msgid "Operating System"
+msgstr "Sistema Operativo"
+
+#: pkg/ostree/index.html:186
+msgid "Operating System Updates"
+msgstr "Actualizaciones de Sistema Operativo"
+
+#: pkg/storaged/jobs.js:166
+msgid "Operation '$operation' on $target"
+msgstr "Actividad '$operation' en $target"
+
+#: pkg/storaged/overview.js:189
+msgctxt "storage"
+msgid "Optical Drive"
+msgstr "Disco Óptico"
+
+#: pkg/kubernetes/views/volume-body.html:130
+msgid "Options"
+msgstr "Opciones"
+
+#: pkg/subscriptions/subscriptions-register.jsx:176
+#, fuzzy
+msgid "Organization"
+msgstr "Traducción"
+
+#: pkg/storaged/details.js:1253
+msgctxt "storage-id-desc"
+msgid "Other Data"
+msgstr "Otros datos"
+
+#: pkg/storaged/index.html:202
+msgid "Other Devices"
+msgstr "Otros dispositivos"
+
+#: pkg/docker/index.html:319 pkg/kubernetes/registry.html:42
+#: pkg/kubernetes/index.html:39
+msgid "Overview"
+msgstr ""
+
+#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
+msgid "Overwrite existing data with zeros"
+msgstr "Sobreescribir los datos existentes con ceros"
+
+#: pkg/kubernetes/views/volume-body.html:4
+msgid "PD Name"
+msgstr ""
+
+#: pkg/ostree/index.html:100
+msgid "Packages"
+msgstr "Paquetes"
+
+#: pkg/networkmanager/index.html:133
+msgid "Parent"
+msgstr "Padre"
+
+#: pkg/networkmanager/interfaces.js:2619
+msgid "Parent $parent"
+msgstr "Padre $parent"
+
+#: pkg/networkmanager/interfaces.js:1372
+msgid "Part of "
+msgstr "Parte de"
+
+#: pkg/kubernetes/views/volume-body.html:8
+#: pkg/kubernetes/views/volume-body.html:18
+msgid "Partition"
+msgstr "Partición"
+
+#: pkg/storaged/details.js:346
+msgid "Partitioning"
+msgstr "Particionamiento"
+
+#: pkg/networkmanager/interfaces.js:1848
+msgid "Passive"
+msgstr ""
+
+#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
+msgid "Passphrase"
+msgstr "Palabra de paso"
+
+#: pkg/storaged/details.js:224
+#, fuzzy
+msgid "Passphrase cannot be empty"
+msgstr "La palabra de paso no puede estar vacía"
+
+#: pkg/storaged/details.js:232
+msgid "Passphrases do not match"
+msgstr "Palabra de paso no coincide"
+
+#: pkg/users/index.html:115 pkg/users/index.html:160 pkg/shell/index.html:199
+#: pkg/shell/index.html:212 pkg/kubernetes/views/auth-form.html:105
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+msgid "Password"
+msgstr "Contraseña"
+
+#: pkg/users/local.js:259
+msgid "Password is not acceptable"
+msgstr "La contraseña no es aceptable"
+
+#: pkg/users/local.js:247
+msgid "Password is too weak"
+msgstr "La contraseña en muy débil"
+
+#: pkg/lib/credentials.js:278
+msgid "Password not accepted"
+msgstr "Contraseña no aceptada"
+
+#: pkg/kubernetes/views/pv-modify.html:126
+#: pkg/kubernetes/views/volume-body.html:37
+#: pkg/kubernetes/views/volume-body.html:49
+#: pkg/kubernetes/views/volume-body.html:101
+msgid "Path"
+msgstr ""
+
+#: pkg/networkmanager/index.html:259
+msgid "Path cost"
+msgstr "Costo ruta"
+
+#: pkg/networkmanager/interfaces.js:2601
+msgid "Path cost $path_cost"
+msgstr "Costo ruta $path_cost"
+
+#: pkg/systemd/services.html:56
+msgid "Paths"
+msgstr "Rutas"
+
+#: pkg/kubernetes/views/volumes-page.html:53
+msgid "Pending Volume Claims"
+msgstr ""
+
+#: pkg/systemd/index.html:143
+msgid "Performance Profile"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:14
+msgid "Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:16
+msgid "Phase"
+msgstr ""
+
+#: pkg/storaged/index.html:641
+msgid "Physical Volumes"
+msgstr "Volúmenea Físicos"
+
+#: pkg/networkmanager/index.html:405
+#, fuzzy
+msgid "Ping Interval"
+msgstr "Monitorear intervalo"
+
+#: pkg/networkmanager/index.html:414
+#, fuzzy
+msgid "Ping Target"
+msgstr "Bloquendo $target"
+
+#: pkg/docker/containers-view.jsx:166 pkg/docker/details.js:271
+#: pkg/docker/image.js:151 pkg/storaged/details.js:625
+#: pkg/storaged/details.js:821 pkg/storaged/details.js:1016
+msgid "Please confirm deletion of $0"
+msgstr "Por favor confirmar la eliminación de $0"
+
+#: pkg/docker/util.js:501
+msgid "Please confirm forced deletion of $0"
+msgstr "Por favor confirme, forzar el borrado de $0"
+
+#: pkg/kubernetes/scripts/dashboard.js:441
+msgid "Please create another namespace for $0 \"$1\""
+msgstr "Por favor cree otro nombre de espacio para $0 \"$1\""
+
+#: pkg/kubernetes/scripts/volumes.js:574
+msgid "Please provide a GlusterFS volume name"
+msgstr "Por favor provea un nombre de volumen GlusterFS"
+
+#: pkg/kubernetes/scripts/connection.js:554
+msgid "Please provide a username"
+msgstr "Provea un nombre de usuario"
+
+#: pkg/kubernetes/scripts/volumes.js:632
+msgid "Please provide a valid NFS server"
+msgstr "Por favor provea un servidos NFS valido"
+
+#: pkg/kubernetes/scripts/connection.js:539
+msgid "Please provide a valid address"
+msgstr "Provea una dirección valida"
+
+#: pkg/kubernetes/scripts/volumes.js:805
+msgid "Please provide a valid filesystem type"
+msgstr "Por favor provea un tipo de sistema de archivos valido"
+
+#: pkg/kubernetes/scripts/volumes.js:813
+msgid "Please provide a valid interface"
+msgstr "Por favor provea una interfaz valida"
+
+#: pkg/kubernetes/scripts/volumes.js:797
+msgid "Please provide a valid logical unit number"
+msgstr "Por favor provea un número valido de unidad lógica"
+
+#: pkg/kubernetes/scripts/volumes.js:477
+msgid "Please provide a valid name"
+msgstr "Por favor provea un nombre valido"
+
+#: pkg/kubernetes/scripts/dashboard.js:376
+msgid "Please provide a valid namespace."
+msgstr "Por favor provea un nombre de espacio valido"
+
+#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
+msgid "Please provide a valid path"
+msgstr "Por favor provea una ruta valida"
+
+#: pkg/kubernetes/scripts/volumes.js:789
+msgid "Please provide a valid qualified name"
+msgstr "Por favor provea un nombre cualifica valido"
+
+#: pkg/kubernetes/scripts/volumes.js:485
+msgid "Please provide a valid storage capacity."
+msgstr "Por favor provea una capacidad de almacenamiento valida."
+
+#: pkg/kubernetes/scripts/volumes.js:781
+msgid "Please provide a valid target"
+msgstr "Por favor provea un objetivo valido"
+
+#: pkg/kubernetes/scripts/volumes.js:469
+msgid "Please select a valid access mode"
+msgstr "Por favor seleccionar un modo de acceso valido"
+
+#: pkg/kubernetes/scripts/volumes.js:565
+msgid "Please select a valid endpoint"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:493
+msgid "Please select a valid policy option."
+msgstr "Por favor provea una opción de política valida."
+
+#: pkg/kubernetes/scripts/nodes.js:397
+msgid "Please type an address"
+msgstr "Por favor escriba una dirección"
+
+#: pkg/kubernetes/views/pod-page.html:12
+#: pkg/kubernetes/views/containers-listing.html:12
+#: pkg/kubernetes/views/topology-page.html:14
+msgid "Pod"
+msgstr "Ranura"
+
+#: pkg/kubernetes/views/pod-body.html:20
+msgid "Pod Address"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:4
+#: pkg/kubernetes/views/service-endpoint.html:9
+msgid "Pod Endpoints"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:4
+msgid "Pod Replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:15
+#: pkg/kubernetes/views/replicationcontroller-pods.html:11
+msgid "Pod Selector"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:17
+#: pkg/kubernetes/views/dashboard-page.html:18
+#: pkg/kubernetes/views/details-page.html:166
+#: pkg/kubernetes/views/pv-claim.html:37
+#: pkg/kubernetes/views/replicationcontroller-panel.html:12
+msgid "Pods"
+msgstr "Ranuras"
+
+#: pkg/kubernetes/views/topology-page.html:15
+msgid ""
+"Pods contain one or more containers that run                together on a "
+"node, containing your application code."
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:60
+msgid "Pool Name"
+msgstr ""
 
 #: pkg/storaged/utils.js:166
 msgid "Pool for Thin Logical Volumes"
 msgstr "Reserva para Volúmenes Lógicos Delgados"
 
-#: pkg/storaged/utils.js:168
-msgid "Thin Logical Volume"
-msgstr "Volumen Lógico Delgado"
+#: pkg/storaged/details.js:874
+msgid "Pool for thinly provisioned volumes"
+msgstr ""
 
-#: pkg/storaged/utils.js:170
-msgid "Logical Volume (Snapshot)"
-msgstr "Volumen Lógico(Captura)"
+#: pkg/kubernetes/views/imagestream-modify.html:45
+msgid "Populate"
+msgstr ""
 
-#: pkg/storaged/utils.js:172
-msgid "Logical Volume"
-msgstr "Volumen Lógico"
+#: pkg/lib/machine-change-port.html:23
+msgid "Port"
+msgstr "Puerto"
 
-#: pkg/storaged/utils.js:212
-msgid "<span>Encrypted Logical Volume of $0</span>"
-msgstr "<span>Volumen Lógico Encriptado de $0</span>"
+#: pkg/docker/index.html:525 pkg/kubernetes/views/service-body.html:13
+#: pkg/kubernetes/views/image-config.html:23
+#: pkg/kubernetes/views/container-body.html:12
+#: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:373
+msgid "Ports"
+msgstr "Puertos"
 
-#: pkg/storaged/utils.js:214
-msgid "<span>Encrypted Partition of $0</span>"
-msgstr "<span>Partición Encriptada de $0</span>"
+#: pkg/systemd/index.html:123
+msgid "Power Options"
+msgstr "Opciones de apagado"
 
-#: pkg/storaged/utils.js:216
-msgid "<span>Logical Volume of $0</span>"
-msgstr "<span>Volumen Lógico de $0</span>"
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length"
+msgstr "Tamaño del prefijo"
 
-#: pkg/storaged/utils.js:218
-msgid "<span>Partition of $0</span>"
-msgstr "<span>Partición de $0</span>"
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length or Netmask"
+msgstr "Tamaño del prefijo o máscara de red"
 
-#: pkg/storaged/utils.js:220
-msgid "<span>Encrypted $0</span>"
-msgstr "<span>Encriptado $0</span>"
+#: pkg/networkmanager/interfaces.js:809
+msgid "Preparing"
+msgstr "Preparando"
+
+#: pkg/systemd/init.js:544
+msgid "Preset"
+msgstr "Ajustar"
+
+#: pkg/systemd/init.js:545
+msgid "Preset Forcefully"
+msgstr "Forzar pre-ajuste"
+
+#: pkg/systemd/index.html:310
+msgid "Pretty Host Name"
+msgstr ""
+
+#: pkg/networkmanager/index.html:307
+msgid "Primary"
+msgstr "Primario"
+
+#: pkg/storaged/details.js:1426
+msgid "Primary Partition"
+msgstr "Partición Primaria"
+
+#: pkg/networkmanager/index.html:250 pkg/networkmanager/index.html:446
+#: pkg/networkmanager/index.html:464
+msgid "Priority"
+msgstr "Prioridad"
+
+#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
+msgid "Priority $priority"
+msgstr "Prioridad $priority"
+
+#: pkg/subscriptions/subscriptions-view.jsx:33
+msgid "Product ID"
+msgstr "ID del Producto"
+
+#: pkg/subscriptions/subscriptions-view.jsx:32
+msgid "Product name"
+msgstr "Nombre del Producto"
+
+#: pkg/kubernetes/views/service-body.html:4
+#: pkg/kubernetes/views/replicationcontroller-body.html:4
+#: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/imagestream-modify.html:21
+#: pkg/kubernetes/views/pod-body.html:4
+#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/details-page.html:35
+#: pkg/kubernetes/views/details-page.html:71
+#: pkg/kubernetes/views/details-page.html:104
+#: pkg/kubernetes/views/details-page.html:138
+#: pkg/kubernetes/views/details-page.html:172
+#: pkg/kubernetes/views/containers-listing.html:13
+#: pkg/kubernetes/views/route-body.html:4
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
+msgid "Project"
+msgstr "Proyecto"
+
+#: pkg/kubernetes/views/project-body.html:20
+msgid "Project Members"
+msgstr "Miembros del Proyecto"
+
+#: pkg/kubernetes/views/filter-project.html:5
+msgid "Project:"
+msgstr "Proyecto:"
+
+#: pkg/kubernetes/registry.html:54 pkg/kubernetes/views/group-delete.html:10
+#: pkg/kubernetes/views/project-listing.html:9
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:84
+msgid "Projects"
+msgstr ""
+
+#: pkg/users/local.js:82
+msgid "Prompting via passwd timed out"
+msgstr "Iniciando a través de passwd tiempo de espera agotado"
+
+#: pkg/lib/credentials.js:251
+msgid "Prompting via ssh-add timed out"
+msgstr "Expiro el tiempo de espera vía ssh."
+
+#: pkg/lib/credentials.js:191
+msgid "Prompting via ssh-keygen timed out"
+msgstr "Iniciando a través de ssh-keygen tiempo de espera agotado"
+
+#: pkg/subscriptions/subscriptions-register.jsx:125
+msgid "Proxy"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:25
+msgid "Proxy Version"
+msgstr ""
+
+#: pkg/shell/index.html:198 pkg/lib/machine-auth-failed.html:9
+msgid "Public Key"
+msgstr "Llave pública"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:150
+msgid "Pull an image:"
+msgstr "Halar una imagen:"
+
+#: pkg/kubernetes/views/imagestream-modify.html:66
+msgid "Pull from"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:31
+msgid "Pull repository"
+msgstr ""
+
+#: pkg/storaged/details.js:869
+msgid "Purpose"
+msgstr "Proposito"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:140
+msgid "Push an image:"
+msgstr "Empujar una imagen:"
+
+#: pkg/kubernetes/views/pv-modify.html:147
+#: pkg/kubernetes/views/volume-body.html:77
+msgid "Qualified Name"
+msgstr ""
+
+#: pkg/storaged/details.js:1539
+msgid "RAID ($0)"
+msgstr "RAID ($0)"
+
+#: pkg/storaged/details.js:1533
+msgid "RAID 0"
+msgstr "RAID 0"
+
+#: pkg/storaged/overview.js:422
+msgid "RAID 0 (Stripe)"
+msgstr "RAID 0 (Stripe)"
+
+#: pkg/storaged/details.js:1534
+msgid "RAID 1"
+msgstr "RAID 1"
+
+#: pkg/storaged/overview.js:423
+msgid "RAID 1 (Mirror)"
+msgstr "RAID 1 (Espejo)"
+
+#: pkg/storaged/details.js:1538
+msgid "RAID 10"
+msgstr "RAID 10"
+
+#: pkg/storaged/overview.js:427
+msgid "RAID 10 (Stripe of Mirrors)"
+msgstr "RAID 10 (Arreglo de espejos)"
+
+#: pkg/storaged/details.js:1535
+msgid "RAID 4"
+msgstr "RAID 4"
+
+#: pkg/storaged/overview.js:424
+msgid "RAID 4 (Dedicated Parity)"
+msgstr "RAID 4 (Paridad Dedicada)"
+
+#: pkg/storaged/details.js:1536
+msgid "RAID 5"
+msgstr "RAID 5"
+
+#: pkg/storaged/overview.js:425
+msgid "RAID 5 (Distributed Parity)"
+msgstr "RAID 5 (Paridad Distribuida)"
+
+#: pkg/storaged/details.js:1537
+msgid "RAID 6"
+msgstr "RAID 6"
+
+#: pkg/storaged/overview.js:426
+msgid "RAID 6 (Double Distributed Parity)"
+msgstr "RAID 6 (Doble Paridad Distribuida)"
+
+#: pkg/storaged/index.html:537
+msgid "RAID Device"
+msgstr "Dispositivo RAID"
 
 #: pkg/storaged/utils.js:233
 msgid "RAID Device $0"
 msgstr "Dispositivo RAID $0"
 
-#: pkg/storaged/utils.js:239
-msgid "Volume Group $0"
-msgstr "Grupo de volúmenes $0 "
+#: pkg/storaged/index.html:65
+msgid "RAID Devices"
+msgstr "Dispositivos RAID"
 
-#: pkg/storaged/jobs.js:119
-msgid "SMART self-test of $target"
-msgstr "SMART auto-diagnóstico de $target"
+#: pkg/storaged/overview.js:420
+msgid "RAID Level"
+msgstr "Nivel RAID"
 
-#: pkg/storaged/jobs.js:120
-msgid "Ejecting $target"
-msgstr "Expulsando $target"
+#: pkg/storaged/index.html:555
+msgctxt "storage"
+msgid "RAID Level"
+msgstr "Nivel de RAID"
 
-#: pkg/storaged/jobs.js:121
-msgid "Unlocking $target"
-msgstr "Desbloquendo $target"
+#: pkg/storaged/details.js:1228
+msgctxt "storage-id-desc"
+msgid "RAID Member"
+msgstr "Miembro RAID"
 
-#: pkg/storaged/jobs.js:122
-msgid "Locking $target"
-msgstr "Bloquendo $target"
+#: pkg/kubernetes/scripts/volumes.js:200
+msgid "Rados Block Device"
+msgstr ""
 
-#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
-msgid "Modifying $target"
-msgstr "Modificando $target"
+#: pkg/kubernetes/views/pv-modify.html:194
+#: pkg/kubernetes/views/volume-body.html:10
+#: pkg/kubernetes/views/volume-body.html:20
+#: pkg/kubernetes/views/volume-body.html:44
+#: pkg/kubernetes/views/volume-body.html:51
+#: pkg/kubernetes/views/volume-body.html:71
+#: pkg/kubernetes/views/volume-body.html:85
+#: pkg/kubernetes/views/volume-body.html:93
+#: pkg/kubernetes/views/volume-body.html:110
+#: pkg/kubernetes/views/volume-body.html:122
+#: pkg/kubernetes/views/volume-body.html:136
+#: pkg/kubernetes/views/volume-body.html:143
+msgid "Read Only"
+msgstr ""
 
-#: pkg/storaged/jobs.js:124
-msgid "Starting swapspace $target"
-msgstr "Iniciando espacio de swap $target"
+#: pkg/kubernetes/scripts/volumes.js:211
+msgid "Read and write from a single node"
+msgstr "Lectura y escritura para un solo nodo."
 
-#: pkg/storaged/jobs.js:125
-msgid "Stopping swapspace $target"
-msgstr "Deteniendo espacio de swap $target"
+#: pkg/kubernetes/scripts/volumes.js:213
+msgid "Read and write from multiple nodes"
+msgstr "Lectura y escritura para nodos multiples"
 
-#: pkg/storaged/jobs.js:126
-msgid "Mounting $target"
-msgstr "Montando $target"
+#: pkg/kubernetes/scripts/volumes.js:212
+msgid "Read only from multiple nodes"
+msgstr "Sólo lectura para nodos múltiples"
 
-#: pkg/storaged/jobs.js:127
-msgid "Unmounting $target"
-msgstr "Desmontando $target"
+#: pkg/docker/index.html:385
+msgid "ReadOnly"
+msgstr ""
 
-#: pkg/storaged/jobs.js:129
-msgid "Erasing $target"
-msgstr "Borrando $target"
+#: pkg/docker/index.html:384
+msgid "ReadWrite"
+msgstr ""
 
-#: pkg/storaged/jobs.js:130
-msgid "Creating filesystem on $target"
-msgstr "Creando sistema de archivos en $target"
+#: pkg/storaged/index.html:327
+msgid "Reading"
+msgstr "Leyendo"
 
-#: pkg/storaged/jobs.js:131
-msgid "Setting up loop device $target"
-msgstr "Configurando dispositivo de retorno $target"
+#: pkg/playground/translate.html:20 pkg/playground/translate.html:179
+#: pkg/kubernetes/views/details-page.html:52
+#: pkg/kubernetes/views/node-body.html:41
+msgid "Ready"
+msgstr "Listo"
 
-#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
-msgid "Deleting $target"
-msgstr "Eliminando $target"
-
-#: pkg/storaged/jobs.js:134
-msgid "Creating partition $target"
-msgstr "Creando partición $target"
-
-#: pkg/storaged/jobs.js:135
-msgid "Cleaning up for $target"
-msgstr "Limpiando por $target"
-
-#: pkg/storaged/jobs.js:136
-msgid "Securely erasing $target"
-msgstr "Borrando de forma segura $target"
-
-#: pkg/storaged/jobs.js:137
-msgid "Very securely erasing $target"
-msgstr "Borrando de forma muy segura $target"
-
-#: pkg/storaged/jobs.js:138
-msgid "Stopping RAID Device $target"
-msgstr "Deteniendo dispositivo RAID $target"
-
-#: pkg/storaged/jobs.js:139
-msgid "Starting RAID Device $target"
-msgstr "Iniciando dispositivo RAID $target"
-
-#: pkg/storaged/jobs.js:140
-msgid "Marking $target as faulty"
-msgstr "Marcando $target como fallado"
-
-#: pkg/storaged/jobs.js:141
-msgid "Removing $target from RAID Device"
-msgstr "Removiendo $target del Dispositivo RAID"
-
-#: pkg/storaged/jobs.js:142
-msgid "Creating RAID Device $target"
-msgstr "Creando dispositivo RAID $target"
-
-#: pkg/storaged/jobs.js:143
+#: pkg/playground/translate.html:25
 #, fuzzy
-msgid "Checking RAID Device $target"
-msgstr "Creando dispositivo RAID $target"
+msgctxt "verb"
+msgid "Ready"
+msgstr "Listo"
 
-#: pkg/storaged/jobs.js:144
-#, fuzzy
-msgid "Checking and Repairing RAID Device $target"
-msgstr "Creando dispositivo RAID $target"
+#: pkg/systemd/index.html:319
+msgid "Real Host Name"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:45
+msgid "Reason"
+msgstr "Razón"
+
+#: pkg/lib/journal.js:241
+msgid "Reboot"
+msgstr "Reiniciar"
+
+#: pkg/networkmanager/index.html:75 pkg/networkmanager/index.html:98
+#: pkg/networkmanager/index.html:116 pkg/networkmanager/index.html:521
+#: pkg/networkmanager/index.html:551
+msgid "Receiving"
+msgstr "Recibiendo"
+
+#: pkg/ostree/client.js:56
+msgid "Receiving delta parts"
+msgstr "Reciviendo deltas"
+
+#: pkg/ostree/client.js:58
+msgid "Receiving metadata objects"
+msgstr "Recibiendo metadatos"
+
+#: pkg/ostree/client.js:61
+msgid "Receiving objects: $0%"
+msgstr "Recibiendo objetos: $0%"
+
+#: pkg/systemd/logs.html:40
+msgid "Recent"
+msgstr "Reciente"
+
+#: pkg/kubernetes/views/pv-modify.html:56 pkg/kubernetes/views/pv-body.html:6
+msgid "Reclaim Policy"
+msgstr ""
+
+#: pkg/shell/simple.html:144 pkg/shell/index.html:327 pkg/shell/stub.html:180
+msgid "Reconnect"
+msgstr "Reconectarse"
+
+#: pkg/storaged/details.js:1594
+msgid "Recovering"
+msgstr "Recuperando"
 
 #: pkg/storaged/jobs.js:145
 #, fuzzy
 msgid "Recovering RAID Device $target"
 msgstr "Deteniendo dispositivo RAID $target"
 
-#: pkg/storaged/jobs.js:146
-msgid "Synchronizing RAID Device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:148
-msgid "Activating $target"
-msgstr "Activando $target"
-
-#: pkg/storaged/jobs.js:149
-msgid "Deactivating $target"
-msgstr "Desactivando $target"
-
-#: pkg/storaged/jobs.js:150
-msgid "Creating snapshot of $target"
-msgstr "Creando una imagne de $target"
-
-#: pkg/storaged/jobs.js:151
-msgid "Creating volume group $target"
-msgstr "Creando Grupo de Volumen $target"
-
-#: pkg/storaged/jobs.js:152
-msgid "Deleting volume group $target"
-msgstr "Borrando Grupo de Volumen $target"
-
-#: pkg/storaged/jobs.js:153
-msgid "Adding physical volume to $target"
-msgstr "Agregando volumen físico a $target"
-
-#: pkg/storaged/jobs.js:154
-msgid "Removing physical volume from $target"
-msgstr "Eliminando volumen físico de $target"
-
-#: pkg/storaged/jobs.js:155
-msgid "Emptying $target"
-msgstr "Eliminando el contenido de $target"
-
-#: pkg/storaged/jobs.js:156
-msgid "Creating logical volume $target"
-msgstr "Creando  Volumen Lógico $target"
-
-#: pkg/storaged/jobs.js:157
-msgid "Renaming $target"
-msgstr "Renombrando $target"
-
-#: pkg/storaged/jobs.js:158
-msgid "Resizing $target"
-msgstr "Redimencionando $target"
-
-#: pkg/storaged/jobs.js:166
-msgid "Operation '$operation' on $target"
-msgstr "Actividad '$operation' en $target"
-
-#: pkg/storaged/jobs.js:180
-msgid "unknown target"
-msgstr "destino u objetivo desconocido"
-
-#: pkg/storaged/permissions.js:61
-msgid "The user <b>$0</b> is not permitted to manage storage"
-msgstr "Al usuario <b>$0</b> no le es permitido administrar el almacenamiento "
-
-#: pkg/realmd/operation.js:96
-msgid "Join"
-msgstr "Unirse"
-
-#: pkg/realmd/operation.js:101
-msgid "Leave"
-msgstr "Abandonar"
-
-#: pkg/realmd/operation.js:148
-msgid "Domain $0 could not be contacted"
-msgstr "Dominio $0 no puede ser contactado"
-
-#: pkg/realmd/operation.js:220
-msgid "Domain $0 is not supported"
-msgstr "Dominio $0 no esta soportado"
-
-#: pkg/realmd/operation.js:347
-msgid "Joining this domain is not supported"
-msgstr "Unirse a este dominio no esta soportado"
-
-#: pkg/realmd/operation.js:366
-msgid "More"
-msgstr "Más"
-
-#: pkg/realmd/operation.js:417
-msgid "Cannot join a domain because realmd is not available on this system"
-msgstr ""
-"No es posible unirse al dominio debido a que realmd no está disponible en "
-"este sistema"
-
-#: pkg/realmd/operation.js:436
-msgid "The user <b>$0</b> is not permitted to modify realms"
-msgstr "El usuario <b>$0</b> no está autorizado a modificar dominios"
-
-#: pkg/realmd/operation.js:453
-msgid "Join Domain"
-msgstr "Unirse a Dominio"
-
-#: pkg/docker/run.js:246 pkg/docker/util.js:102
-#: pkg/networkmanager/interfaces.js:2280 pkg/kubernetes/scripts/volumes.js:992
-#: pkg/docker/index.html.h:46
-msgid "No"
-msgstr "No"
-
-#: pkg/docker/run.js:261 pkg/docker/console.html.h:1
-#: pkg/kubernetes/views/image-panel.html.h:2
-#: pkg/kubernetes/views/container-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:1
-#: pkg/kubernetes/views/image-page.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:1
-msgid "Container"
-msgstr "Contenedor"
-
-#: pkg/docker/run.js:263 pkg/kubernetes/views/route-modify.html.h:2
-#: pkg/kubernetes/views/route-body.html.h:4
-#: pkg/kubernetes/views/details-page.html.h:12
-msgid "Host"
-msgstr "Anfitrión"
-
-#: pkg/docker/run.js:283
-msgid "Invalid port"
-msgstr "Puerto invalido"
-
-#: pkg/docker/run.js:293
-msgid "Duplicate port"
-msgstr "Puerto duplicado"
-
-#: pkg/docker/run.js:332
-#, fuzzy
-msgid "Command can't be empty"
-msgstr "Nombre no puede estar vacío."
-
-#: pkg/docker/run.js:350
-msgid "No alias specified"
-msgstr "No se ha especificado un alias"
-
-#: pkg/docker/run.js:360
-msgid "Duplicate alias"
-msgstr "Alias duplicado"
-
-#: pkg/docker/run.js:384
-msgid "No container specified"
-msgstr "No se ha especificado un contenedor"
-
-#: pkg/docker/details.js:47 pkg/docker/image.js:43
-msgctxt "page-title"
-msgid "Containers"
-msgstr "Contenedores"
-
-#: pkg/docker/details.js:144
-msgid "${hip}:${hport} -> $cport"
-msgstr "${hip}:${hport} -> $cport"
-
-#: pkg/docker/details.js:272 pkg/docker/containers-view.jsx:167
-msgid "Deleting a container will erase all data in it."
-msgstr "Eliminar un contenedor eliminara toda la información en él."
-
-#: pkg/docker/storage.jsx:156
-#, fuzzy
-msgid "Solid-State Disk"
-msgstr "Disco en Estado Sólido"
-
-#: pkg/docker/storage.jsx:157
-#, fuzzy
-msgid "Hard Disk"
-msgstr "Disco Duro"
-
-#: pkg/docker/storage.jsx:158 pkg/storaged/index.html.h:33
-msgid "Drive"
-msgstr "Disco"
-
-#: pkg/docker/storage.jsx:188
-#, fuzzy
-msgid "Local Disks"
-msgstr "$0 Discos"
-
-#: pkg/docker/storage.jsx:194
-msgid "No additional local storage found."
-msgstr ""
-
-#: pkg/docker/storage.jsx:242
-msgid " (shared with the OS)"
-msgstr ""
-
-#: pkg/docker/storage.jsx:282
-msgid "Information about the Docker storage pool is not available."
-msgstr ""
-
-#: pkg/docker/storage.jsx:314
-msgid "Total"
-msgstr ""
+#: pkg/kubernetes/scripts/volumes.js:219
+msgid "Recycle"
+msgstr "Reciclar"
 
 #: pkg/docker/storage.jsx:348
 msgid "Reformat and add disks"
 msgstr ""
 
-#: pkg/docker/storage.jsx:355
-msgid ""
-"The storage pool will be reset to optimize its layout.  All containers will "
-"be erased."
+#: pkg/kubernetes/views/pv-modify.html:205
+msgid "Register"
 msgstr ""
 
-#: pkg/docker/storage.jsx:360
-msgid "Erase containers, reformat disks, and add them"
+#: pkg/kubernetes/views/volumes-page.html:12
+msgid "Register New Volume"
 msgstr ""
 
-#: pkg/docker/storage.jsx:363
-msgid "Add Additional Storage"
+#: pkg/kubernetes/views/pv-modify.html:4
+msgid "Register Persistent Volume"
 msgstr ""
 
-#: pkg/docker/storage.jsx:366
-msgid ""
-"All data on selected disks will be erased and disks will be added to the "
-"storage pool."
+#: pkg/subscriptions/main.js:74
+msgid "Register system"
+msgstr "Registrar sistema"
+
+#: pkg/ostree/index.html:115
+msgid "Released"
+msgstr "Lanzado"
+
+#: pkg/systemd/init.js:518
+msgid "Reload"
+msgstr "Recargar"
+
+#: pkg/systemd/init.js:519
+msgid "Reload or Restart"
+msgstr "Recargue para Reiniciar"
+
+#: pkg/systemd/init.js:521
+msgid "Reload or Try Restart"
+msgstr "Recargar o intente reiniciar"
+
+#: pkg/kubernetes/views/imagestream-modify.html:89
+msgid "Remote registry is insecure"
 msgstr ""
 
-#: pkg/docker/storage.jsx:404
+#: cockpit.desktop.in.h:3
+msgid "Remote;Administration;"
+msgstr "Remoto/a; Administración;"
+
+#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
+msgctxt "storage"
+msgid "Removable Drive"
+msgstr "Disco Removible"
+
+#: pkg/ostree/index.html:123 pkg/ostree/index.html:146
+msgid "Removals"
+msgstr "Removidos"
+
+#: pkg/kubernetes/views/user-group-remove.html:10
+#: pkg/kubernetes/views/group-delete.html:21
+#: pkg/kubernetes/views/user-delete.html:25
+#: pkg/kubernetes/views/remove-role-dialog.html:8
+msgid "Remove"
+msgstr "Eliminar"
+
+#: pkg/networkmanager/interfaces.js:2791
 #, fuzzy
-msgid "Could not add all disks"
-msgstr "No se pueden listar los servicios"
+msgid "Remove $0"
+msgstr "Eliminar"
+
+#: pkg/kubernetes/views/group-delete.html:3
+msgid "Remove Group"
+msgstr ""
+
+#: pkg/kubernetes/views/user-group-remove.html:3
+msgid "Remove Member"
+msgstr ""
+
+#: pkg/kubernetes/views/remove-role-dialog.html:3
+msgid "Remove Role"
+msgstr ""
+
+#: pkg/kubernetes/views/user-delete.html:3
+msgid "Remove User"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:3
+msgid "Remove image tag"
+msgstr "Remover etiqueta de imagen"
+
+#: pkg/kubernetes/views/user-remove-membership.html:3
+msgid "Remove membership"
+msgstr ""
+
+#: pkg/storaged/jobs.js:141
+msgid "Removing $target from RAID Device"
+msgstr "Removiendo $target del Dispositivo RAID"
+
+#: pkg/networkmanager/interfaces.js:2788
+msgid "Removing <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:154
+msgid "Removing physical volume from $target"
+msgstr "Eliminando volumen físico de $target"
+
+#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
+#: pkg/storaged/details.js:1775
+msgid "Rename"
+msgstr "Renombrar"
+
+#: pkg/storaged/details.js:795
+msgid "Rename Volume Group"
+msgstr "Renombrar Grupo de Volumen"
+
+#: pkg/storaged/details.js:706
+msgid "Renamee Logical Volume"
+msgstr "Renombrar Volumen Lógico"
+
+#: pkg/storaged/jobs.js:157
+msgid "Renaming $target"
+msgstr "Renombrando $target"
+
+#: pkg/systemd/services.html:432
+msgid "Repeat Daily"
+msgstr ""
+
+#: pkg/systemd/services.html:431
+msgid "Repeat Hourly"
+msgstr ""
+
+#: pkg/systemd/services.html:434
+msgid "Repeat Monthly"
+msgstr ""
+
+#: pkg/systemd/services.html:433
+msgid "Repeat Weekly"
+msgstr ""
+
+#: pkg/systemd/services.html:435
+msgid "Repeat Yearly"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-body.html:9
+#: pkg/kubernetes/views/details-page.html:141
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
+#: pkg/kubernetes/views/replicationcontroller-modify.html:8
+msgid "Replicas"
+msgstr "Réplicas"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:14
+#: pkg/kubernetes/views/replicationcontroller-panel.html:10
+#: pkg/kubernetes/views/topology-page.html:23
+msgid "Replication Controller"
+msgstr "Contolador de replicación"
+
+#: pkg/kubernetes/views/details-page.html:132
+msgid "Replication Controllers"
+msgstr "Controladores de replicación"
+
+#: pkg/kubernetes/views/topology-page.html:24
+msgid ""
+"Replication controllers dynamically create instances of                pods "
+"from templates, and remove pods when necessary."
+msgstr ""
+
+#: pkg/docker/index.html:718
+msgid "Repository"
+msgstr "Repositorio"
+
+#: pkg/kubernetes/views/volume-body.html:24
+msgid "Repository URL"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
+msgid "Requested"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:13
+msgid "Requests"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:54
+msgid "Requires Authentication"
+msgstr ""
+
+#: pkg/docker/index.html:323
+msgid "Reset"
+msgstr "Reiniciar"
 
 #: pkg/docker/storage.jsx:417
 #, fuzzy
@@ -2108,391 +4606,600 @@ msgid ""
 "the pool."
 msgstr ""
 
-#: pkg/docker/storage.jsx:423
-msgid "Erase containers and reset storage pool"
+#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
+msgid "Resize"
+msgstr "Redimensionar"
+
+#: pkg/storaged/details.js:673
+msgid "Resize Filesystem"
+msgstr "Redimensionar Sistema de Archivos"
+
+#: pkg/storaged/details.js:661
+msgid "Resize Logical Volume"
+msgstr "Redimensionar Volumen Lógico"
+
+#: pkg/storaged/jobs.js:158
+msgid "Resizing $target"
+msgstr "Redimencionando $target"
+
+#: pkg/systemd/index.html:126 pkg/systemd/index.html:133
+msgid "Restart"
+msgstr "Reiniciar"
+
+#: pkg/kubernetes/views/container-body.html:20
+msgid "Restart Count"
+msgstr "Conteo de Reinicios"
+
+#: pkg/docker/index.html:558 pkg/kubernetes/views/pod-body.html:10
+msgid "Restart Policy"
 msgstr ""
 
-#: pkg/docker/storage.jsx:446
-msgid "Could not reset the storage pool"
+#: pkg/kubernetes/scripts/volumes.js:217
+msgid "Retain"
+msgstr "Retener"
+
+#: pkg/docker/index.html:574
+msgid "Retries:"
 msgstr ""
 
-#: pkg/docker/storage.jsx:482
-#, fuzzy
-msgid "You don't have permission to manage the Docker storage pool."
-msgstr ""
-"No tiene permiso para ver las llaves públicas autorizadas para esta cuenta."
-
-#: pkg/docker/storage.jsx:485
-msgid "The Docker storage pool cannot be managed on this system."
+#: pkg/subscriptions/subscriptions-view.jsx:188
+msgid "Retrieving subscription status..."
 msgstr ""
 
-#: pkg/docker/image.js:77
-msgid "Image $0"
-msgstr "Imagén $0"
-
-#: pkg/docker/image.js:152
-msgid ""
-"Deleting an image will delete it, but you can probably download it again if "
-"you need it later.  Unless this image has never been pushed to a repository, "
-"that is, in which case you probably can't download it again."
+#: pkg/kubernetes/views/volume-body.html:26
+msgid "Revision"
 msgstr ""
-"Borrar una imagen, la borrara, pero tu puedes descargarla de nuevo si tu la "
-"necesitas mas tarde. A menos que esta imagen nunca haya sido colocada a un "
-"repositorio, en cuyo caso no puedas volver a descargarla nuevamente."
 
-#: pkg/docker/util.js:94
-msgid "Up since $StartedAt"
-msgstr "Arriba desde $StartedAt"
+#: pkg/users/index.html:94 pkg/kubernetes/views/add-member-role-dialog.html:39
+#: pkg/kubernetes/views/project-body.html:21
+msgid "Roles"
+msgstr "Roles"
 
-#: pkg/docker/util.js:96
-msgid "Exited $ExitCode"
-msgstr "Salió $ExitCode"
-
-#: pkg/docker/util.js:104
-msgid "On failure, retry $0 time"
-msgid_plural "On failure, retry $0 times"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/docker/util.js:107 pkg/docker/index.html.h:48
-msgid "Always"
-msgstr "Siempre"
-
-#: pkg/docker/util.js:109 pkg/docker/index.html.h:49
-msgid "Unless Stopped"
-msgstr ""
-"\n"
-"A menos que detenido"
-
-#: pkg/docker/util.js:123
-msgid "default"
-msgstr "Por defecto"
-
-#: pkg/docker/util.js:124
-msgid "$0 shares"
-msgstr "$0 Acciones"
-
-#: pkg/docker/util.js:231
-msgid "Stopped"
-msgstr "Detenido"
-
-#: pkg/docker/util.js:488
-msgid "Container is currently running."
-msgstr "El contenedor esta corriendo actualmente"
-
-#: pkg/docker/util.js:490
-msgid ""
-"Container is currently marked as not running, but regular stopping failed."
-msgstr ""
-"El contenedor esta marcado actualmente como que no esta corriendo, pero el "
-"paro regular ha fallado"
-
-#: pkg/docker/util.js:491
-msgid "Error message from Docker:"
-msgstr "Mensaje de error de Docker:"
-
-#: pkg/docker/util.js:501
-msgid "Please confirm forced deletion of $0"
-msgstr "Por favor confirme, forzar el borrado de $0"
-
-#: pkg/docker/util.js:503
-msgid "Force Delete"
-msgstr "Forzar el borrado"
-
-#: pkg/docker/util.js:544
-msgid "Failed to stop Docker scope: $0"
-msgstr "Fallo al detener Docker scope: $0"
-
-#: pkg/docker/containers-view.jsx:239
-#, fuzzy
-msgid "Commit"
-msgstr "Comentario"
-
-#: pkg/docker/containers.js:64
-msgid "Failed to start Docker: $0"
-msgstr "Fallo al iniciar Docker: $0"
-
-#: pkg/users/authorized-keys.js:103
-msgid "Validating key"
-msgstr "Validando llave"
-
-#: pkg/users/authorized-keys.js:108
-msgid "Adding key"
-msgstr "Agregando llave"
-
-#: pkg/users/authorized-keys.js:115
-msgid "Error saving authorized keys: "
-msgstr "Error al guardar llaves autorizadas:"
-
-#: pkg/users/authorized-keys.js:118
-msgid "The key you provided was not valid."
-msgstr "La llave que envió no era valida."
-
-#: pkg/users/local.js:40
-msgid "The user <b>$0</b> is not permitted to modify accounts"
-msgstr "El usuario <b>$0</b> no tiene permisos para modificar cuentas"
-
-#: pkg/users/local.js:57
-msgid "Unable to delete root account"
-msgstr "No es posible eliminar la cuenta root"
-
-#: pkg/users/local.js:59
-msgid "Unable to rename root account"
-msgstr "No es posible renombrar la cuenta root."
-
-#: pkg/users/local.js:82
-msgid "Prompting via passwd timed out"
-msgstr "Iniciando a través de passwd tiempo de espera agotado"
-
-#: pkg/users/local.js:247
-msgid "Password is too weak"
-msgstr "La contraseña en muy débil"
-
-#: pkg/users/local.js:259
-msgid "Password is not acceptable"
-msgstr "La contraseña no es aceptable"
-
-#: pkg/users/local.js:284 pkg/users/local.js:594
-msgctxt "page-title"
-msgid "Accounts"
-msgstr "Cuentas"
-
-#: pkg/users/local.js:395 pkg/users/local.js:1082
-msgid "The passwords do not match"
-msgstr "Las contraseñas no coinciden."
-
-#: pkg/users/local.js:400
-msgid "No user name specified"
-msgstr "Nombre de usuario no especificado"
-
-#: pkg/users/local.js:405
-msgid "No real name specified"
-msgstr "Nombre real no especificado"
-
-#: pkg/users/local.js:429 pkg/users/local.js:1104
-msgid "Excellent password"
-msgstr "Contraseña excelente "
-
-#: pkg/users/local.js:501
-msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
-msgstr ""
-"El nombre de usuario sólo puede consistir de letras (a-z), dígitos, puntos, "
-"guiones y guiones bajos."
-
-#: pkg/users/local.js:509
-msgid "This user name already exists"
-msgstr "El usuario ya existe"
-
-#: pkg/users/local.js:682 pkg/users/local.js:683
-msgid "Server Administrator"
-msgstr "Administrador del Servidor"
-
-#: pkg/users/local.js:684
-msgid "Container Administrator"
-msgstr "Administrador del Contenedor"
-
-#: pkg/users/local.js:839
-msgid "Logged In"
-msgstr "Sesión iniciada"
-
-#: pkg/users/local.js:841
-msgid "Never"
-msgstr "Nunca"
-
-#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
-msgid "Delete $0"
-msgstr "Eliminar $0"
-
-#: pkg/sosreport/index.js:49 pkg/sosreport/index.js:113
-#: pkg/systemd/services.html.h:13 pkg/lib/machine-invalid-hostkey.html.h:4
-#: pkg/lib/machine-auth-failed.html.h:7
-#: pkg/lib/machine-unknown-hostkey.html.h:4
-#: pkg/lib/machine-change-port.html.h:8 pkg/lib/machine-not-supported.html.h:3
-#: pkg/shell/index.html.h:37
-msgid "Close"
-msgstr "Cerrar"
-
-#: pkg/sosreport/index.js:115
-msgid "No archive has been created."
-msgstr "No archive has been created."
-
-#: pkg/networkmanager/interfaces.js:598 pkg/networkmanager/interfaces.js:1051
-#: pkg/networkmanager/interfaces.js:2255 pkg/networkmanager/interfaces.js:2257
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:753 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/kubernetes/views/node-body.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:6
-#: pkg/kubernetes/views/pv-claim.html.h:7
-#: pkg/kubernetes/views/image-body.html.h:6
-#: pkg/kubernetes/views/pv-body.html.h:5
-msgid "Unknown"
-msgstr "Desconocido"
-
-#: pkg/networkmanager/interfaces.js:805
-msgid "Not available"
-msgstr "No disponible"
-
-#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
-#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
-msgid "Inactive"
-msgstr "Inactivo"
-
-#: pkg/networkmanager/interfaces.js:809
-msgid "Preparing"
-msgstr "Preparando"
-
-#: pkg/networkmanager/interfaces.js:811
-msgid "Configuring"
-msgstr "Configurando"
-
-#: pkg/networkmanager/interfaces.js:813
-msgid "Authenticating"
-msgstr "Autenticando "
-
-#: pkg/networkmanager/interfaces.js:815
-msgid "Configuring IP"
-msgstr "Configurando IP"
-
-#: pkg/networkmanager/interfaces.js:817
-msgid "Checking IP"
-msgstr "Comprobando IP"
-
-#: pkg/networkmanager/interfaces.js:819
-msgid "Waiting"
-msgstr "Esperando"
-
-#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
-msgid "Active"
-msgstr "Activo"
-
-#: pkg/networkmanager/interfaces.js:823
-msgid "Deactivating"
-msgstr "Desactivando"
-
-#: pkg/networkmanager/interfaces.js:825 pkg/ostree/index.html.h:14
-msgid "Failed"
-msgstr "Falló"
-
-#: pkg/networkmanager/interfaces.js:1326
-msgid "No carrier"
-msgstr "Ningún portador"
-
-#: pkg/networkmanager/interfaces.js:1372
-msgid "Part of "
-msgstr "Parte de"
-
-#: pkg/networkmanager/interfaces.js:1420
-msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr ""
-"El usuario <b>$0</b> no está autorizado para modificar la configuración de "
-"la red"
-
-#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
-msgctxt "page-title"
-msgid "Networking"
-msgstr "Redes"
-
-#: pkg/networkmanager/interfaces.js:1804
-msgid "Automatic (DHCP)"
-msgstr "Automático (DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
-msgid "Link local"
-msgstr "Enlace local"
-
-#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
-msgid "Manual"
-msgstr "Manual"
-
-#: pkg/networkmanager/interfaces.js:1807
-msgid "Shared"
-msgstr "Compartido"
-
-#: pkg/networkmanager/interfaces.js:1813 pkg/networkmanager/interfaces.js:2475
-#: pkg/networkmanager/interfaces.js:3019 pkg/networkmanager/interfaces.js:3023
-#: pkg/networkmanager/interfaces.js:3029 pkg/networkmanager/index.html.h:22
-msgid "Automatic"
-msgstr "Automático"
-
-#: pkg/networkmanager/interfaces.js:1814
-msgid "Automatic (DHCP only)"
-msgstr "Automático (solo DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1817
-msgid "Ignore"
-msgstr "Ignorar"
+#: pkg/ostree/index.html:73
+msgid "Roll back and reboot"
+msgstr "Retroceder y reiniciar"
 
 #: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
 msgid "Round Robin"
 msgstr "Round Robin"
 
-#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
-msgid "Active Backup"
-msgstr "Respaldo activo"
+#: pkg/kubernetes/views/route-page.html:14
+#: pkg/kubernetes/views/route-panel.html:9
+msgid "Route"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1824
-msgid "XOR"
-msgstr "XOR"
+#: pkg/kubernetes/views/details-page.html:65
+msgid "Routes"
+msgstr "Rutas"
 
-#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
-msgid "Broadcast"
-msgstr "Emisión"
-
-#: pkg/networkmanager/interfaces.js:1826
-msgid "802.3ad"
-msgstr "802.3ad"
-
-#: pkg/networkmanager/interfaces.js:1827
-msgid "Adaptive transmit load balancing"
-msgstr "Equilibrio de carga de transmisión adaptativa"
-
-#: pkg/networkmanager/interfaces.js:1828
-msgid "Adaptive load balancing"
-msgstr "Equilibrio de carga adaptativo"
-
-#: pkg/networkmanager/interfaces.js:1833
-msgid "MII (Recommended)"
-msgstr "MII (Recomendado)"
-
-#: pkg/networkmanager/interfaces.js:1834
-msgid "ARP"
-msgstr "ARP"
-
-#: pkg/networkmanager/interfaces.js:1841
+#: pkg/systemd/services.html:384
 #, fuzzy
-msgid "Load Balancing"
-msgstr "Equilibrio de carga adaptativo"
+msgid "Run"
+msgstr "Ejecutar como"
 
-#: pkg/networkmanager/interfaces.js:1843
+#: pkg/kubernetes/views/image-config.html:4
+msgid "Run as"
+msgstr "Ejecutar como"
+
+#: pkg/networkmanager/index.html:381
 #, fuzzy
-msgid "802.3ad LACP"
-msgstr "802.3ad"
+msgid "Runner"
+msgstr "Corriendo"
 
-#: pkg/networkmanager/interfaces.js:1848
-msgid "Passive"
+#: pkg/ostree/index.html:83
+msgid "Running"
+msgstr "Corriendo"
+
+#: pkg/selinux/setroubleshoot-view.jsx:478
+msgid "SELinux Access Control Errors"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1854
-msgid "Ethtool"
+#: pkg/selinux/setroubleshoot-view.jsx:330
+msgid "SELinux Policy"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1855
+#: pkg/selinux/setroubleshoot.html:23
+msgid "SELinux Troubleshoot"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:317
 #, fuzzy
-msgid "ARP Ping"
-msgstr "Supervisión ARP"
+msgid "SELinux is disabled on the system."
+msgstr "Cockpit no esta instalado en el sistema"
 
-#: pkg/networkmanager/interfaces.js:1856
-msgid "NSNA Ping"
+#: pkg/selinux/setroubleshoot-view.jsx:309
+msgid "SELinux system status is unknown."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2156
-msgid "Deleting <b>$0</b> will break the connection to the server, "
+#: pkg/storaged/jobs.js:119
+msgid "SMART self-test of $target"
+msgstr "SMART auto-diagnóstico de $target"
+
+#: pkg/networkmanager/index.html:218
+msgid "STP Forward delay"
+msgstr "Retardo del reenvío STP"
+
+#: pkg/networkmanager/index.html:227
+msgid "STP Hello time"
+msgstr "Tiempo de saludo STP"
+
+#: pkg/networkmanager/index.html:236
+msgid "STP Maximum message age"
+msgstr "Edad máxima del mensaje STP"
+
+#: pkg/networkmanager/index.html:209
+msgid "STP Priority"
+msgstr "Prioridad STP"
+
+#: pkg/systemd/services.html:466
+msgid "Save"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2188
-msgid "Switching on <b>$0</b>  will break the connection to the server, "
+#: pkg/ostree/client.js:66
+msgid "Scanning metadata"
+msgstr "Escaneando metadatos"
+
+#: pkg/kubernetes/views/node-capacity.html:9
+msgid "Scheduled Pods"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:322
+msgid "Scheduling Disabled"
+msgstr "Programación deshabilitada "
+
+#: pkg/systemd/services.html:402 pkg/systemd/services.html:406
+msgid "Seconds"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:195
+msgid "Secret"
+msgstr "Secreto"
+
+#: pkg/kubernetes/views/volume-body.html:106
+msgid "Secret File"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:141
+msgid "Secret Name"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:69
+#: pkg/kubernetes/views/volume-body.html:108
+#: pkg/kubernetes/views/volume-body.html:134
+msgid "Secret Volume"
+msgstr ""
+
+#: pkg/systemd/index.html:93
+msgid "Secure Shell Keys"
+msgstr ""
+
+#: pkg/storaged/jobs.js:136
+msgid "Securely erasing $target"
+msgstr "Borrando de forma segura $target"
+
+#: pkg/kubernetes/views/file-button.html:4
+msgid "Select Manifest File..."
+msgstr "Seleccione un archivo Manifiesto..."
+
+#: pkg/kubernetes/views/topology-page.html:7
+msgid "Select an object to see more details."
+msgstr "Selecciona un objeto para ver mas detalles"
+
+#: pkg/lib/machine-sync-users.html:8
+msgid ""
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
+msgstr ""
+"Seleccione el usuario con el que le gustaría sincronizar  {{#strong}}{{host}}"
+"{{/strong}}"
+
+#: pkg/networkmanager/index.html:69 pkg/networkmanager/index.html:97
+#: pkg/networkmanager/index.html:115 pkg/networkmanager/index.html:515
+#: pkg/networkmanager/index.html:550
+msgid "Sending"
+msgstr "Enviando"
+
+#: pkg/storaged/index.html:432
+msgctxt "storage"
+msgid "Serial Number"
+msgstr "Número de serial"
+
+#: pkg/kubernetes/views/pv-modify.html:82
+#: pkg/kubernetes/views/volume-body.html:47
+msgid "Server"
+msgstr ""
+
+#: pkg/storaged/overview.js:518
+msgid "Server Address"
+msgstr "Dirección del Servidor"
+
+#: pkg/users/local.js:682 pkg/users/local.js:683
+msgid "Server Administrator"
+msgstr "Administrador del Servidor"
+
+#: pkg/storaged/overview.js:521
+#, fuzzy
+msgid "Server address cannot be empty."
+msgstr "La dirección del Servidor no puede estar bacía "
+
+#: src/base1/cockpit.js:3709
+msgid "Server has closed the connection."
+msgstr "El server a cerrado la conexión"
+
+#: pkg/kubernetes/views/service-page.html:12
+#: pkg/kubernetes/views/service-panel.html:8
+#: pkg/kubernetes/views/topology-page.html:32
+msgid "Service"
+msgstr "Servicio"
+
+#: pkg/kubernetes/views/pod-body.html:12
+msgid "Service Account"
+msgstr ""
+
+#: pkg/systemd/services.html:279
+msgid "Service Logs"
+msgstr "Bitácoras del Servicio"
+
+#: pkg/systemd/services.html:342
+#, fuzzy
+msgid "Service name"
+msgstr "Servicio"
+
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:272
+#: pkg/kubernetes/views/dashboard-page.html:134
+#: pkg/kubernetes/views/details-page.html:29
+msgid "Services"
+msgstr "Servicios"
+
+#: pkg/kubernetes/views/topology-page.html:33
+msgid ""
+"Services group pods and provide a common DNS                name and an "
+"optional, load-balanced IP address to access them."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:20
+msgid "Session Affinity"
+msgstr ""
+
+#: pkg/dashboard/index.html:190
+msgid "Set"
+msgstr "Establecer"
+
+#: pkg/systemd/host.js:559
+msgid "Set Host name"
+msgstr "Establecer nombre del sistema"
+
+#: pkg/users/index.html:117 pkg/users/index.html:221
+msgid "Set Password"
+msgstr "Establecer contraseña"
+
+#: pkg/systemd/index.html:395
+msgid "Set Time"
+msgstr ""
+
+#: pkg/docker/index.html:551
+msgid "Set container environment variables"
+msgstr ""
+
+#: pkg/networkmanager/index.html:172
+msgid "Set to"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:326
+msgid ""
+"Setting deviates from the configured state and will revert on the next boot."
+msgstr ""
+
+#: pkg/storaged/jobs.js:131
+msgid "Setting up loop device $target"
+msgstr "Configurando dispositivo de retorno $target"
+
+#: pkg/kubernetes/views/volume-body.html:139
+msgid "Share Name"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1807
+msgid "Shared"
+msgstr "Compartido"
+
+#: pkg/kubernetes/views/container-panel.html:9
+#: pkg/kubernetes/views/container-page-inline.html:14
+msgid "Shell"
+msgstr "Shell"
+
+#: pkg/kubernetes/views/container-page.html:4
+msgid "Show all Containers"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:8
+msgid "Show all Deployment Configs"
+msgstr ""
+
+#: pkg/kubernetes/views/node-page.html:8
+msgid "Show all Nodes"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:9
+msgid "Show all Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-container.html:4
+msgid "Show all Pod Containers"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:8
+msgid "Show all Pods"
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:16
+#: pkg/kubernetes/views/group-page.html:14
+#: pkg/kubernetes/views/project-page.html:23
+msgid "Show all Projects"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:10
+msgid "Show all Replication Controllers"
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:10
+msgid "Show all Routes"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:8
+msgid "Show all Services"
+msgstr ""
+
+#: pkg/docker/index.html:127
+#, fuzzy
+msgid "Show all containers"
+msgstr "Mostrar todas las imágenes"
+
+#: pkg/kubernetes/views/imagestream-page.html:12
+msgid "Show all image streams"
+msgstr ""
+
+#: pkg/docker/index.html:241 pkg/kubernetes/views/image-page.html:11
+msgid "Show all images"
+msgstr "Mostrar todas las imágenes"
+
+#: pkg/systemd/index.html:94
+msgid "Show fingerprints"
+msgstr ""
+
+#: pkg/systemd/index.html:136
+msgid "Shutdown"
+msgstr "Apagar"
+
+#: pkg/kubernetes/views/container-body.html:18
+msgid "Since"
+msgstr "Desde"
+
+#: pkg/systemd/init.js:621
+msgid "Since $0"
+msgstr "Desde $0"
+
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/storaged/index.html:232
+msgid "Size"
+msgstr "Tamaño"
+
+#: pkg/storaged/dialog.js:271
+#, fuzzy
+msgid "Size cannot be negative"
+msgstr "Tamaño no puede ser negativo"
+
+#: pkg/storaged/dialog.js:269
+#, fuzzy
+msgid "Size cannot be zero"
+msgstr "Tamaño no puede ser cero"
+
+#: pkg/storaged/dialog.js:273
+msgid "Size is too large"
+msgstr "Tamaño es muy grande"
+
+#: pkg/storaged/dialog.js:267
+msgid "Size must be a number"
+msgstr "Tamaña debe ser un número"
+
+#: pkg/kubernetes/views/auth-form.html:43
+#: pkg/kubernetes/views/auth-rejected-cert.html:11
+msgid "Skip Certificate Verification"
+msgstr ""
+
+#: pkg/systemd/services.html:54
+msgid "Sockets"
+msgstr "Sockets"
+
+#: pkg/ostree/index.html:23
+msgid "Software Updates"
+msgstr "Actualizaciones de Software"
+
+#: pkg/docker/storage.jsx:156
+#, fuzzy
+msgid "Solid-State Disk"
+msgstr "Disco en Estado Sólido"
+
+#: pkg/storaged/overview.js:182
+msgctxt "storage"
+msgid "Solid-State Disk"
+msgstr "Disco en Estado Sólido"
+
+#: pkg/selinux/setroubleshoot-view.jsx:90
+msgid "Solution applied successfully"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:97
+#, fuzzy
+msgid "Solution failed"
+msgstr "Inicio de sesión fallido"
+
+#: pkg/kubernetes/scripts/volumes.js:908
+msgid "Sorry, I don't know how to modify this volume"
+msgstr "Lo siento, no se como modificar este volumen"
+
+#: pkg/kubernetes/views/image-body.html:8
+msgid "Source URL"
+msgstr "URL Fuente"
+
+#: pkg/networkmanager/interfaces.js:2573
+msgid "Spanning Tree Protocol"
+msgstr "Spanning Tree Protocol"
+
+#: pkg/networkmanager/index.html:200
+msgid "Spanning Tree Protocol (STP)"
+msgstr "Spanning Tree Protocol (STP)"
+
+#: pkg/storaged/details.js:1594
+msgid "Spare"
+msgstr "Libre"
+
+#: pkg/systemd/index.html:470
+msgid "Specific Time"
+msgstr ""
+
+#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
+msgid "Start"
+msgstr "Iniciar"
+
+#: pkg/docker/index.html:68
+msgid "Start Docker"
+msgstr "Iniciar a Docker"
+
+#: pkg/storaged/index.html:49
+msgid "Start Multipath"
+msgstr ""
+
+#: pkg/storaged/details.js:1614
+msgid "Start Scrubbing"
+msgstr "Iniciar Borrado"
+
+#: pkg/storaged/jobs.js:139
+msgid "Starting RAID Device $target"
+msgstr "Iniciando dispositivo RAID $target"
+
+#: pkg/storaged/jobs.js:124
+msgid "Starting swapspace $target"
+msgstr "Iniciando espacio de swap $target"
+
+#: pkg/subscriptions/subscriptions-view.jsx:37
+#, fuzzy
+msgid "Starts"
+msgstr "Iniciar"
+
+#: pkg/kubernetes/views/container-body.html:16
+#: pkg/kubernetes/views/details-page.html:38
+#: pkg/kubernetes/views/details-page.html:175
+msgid "State"
+msgstr "Estado"
+
+#: pkg/storaged/index.html:571
+msgctxt "storage"
+msgid "State"
+msgstr "Estado"
+
+#: pkg/systemd/init.js:303
+msgid "Static"
+msgstr "Estático"
+
+#: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/containers-listing.html:16
+#: pkg/kubernetes/views/nodes-page.html:44
+#: pkg/kubernetes/views/pvc-body.html:13 pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/pv-body.html:24
+msgid "Status"
+msgstr "Estado"
+
+#: pkg/subscriptions/subscriptions-view.jsx:146
+#, fuzzy
+msgid "Status: $0"
+msgstr "Estado"
+
+#: pkg/subscriptions/subscriptions-view.jsx:141
+msgid "Status: System isn't registered"
+msgstr ""
+
+#: pkg/networkmanager/index.html:455
+msgid "Sticky"
+msgstr ""
+
+#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
+msgid "Stop"
+msgstr "Detener"
+
+#: pkg/storaged/details.js:1615
+msgid "Stop Scrubbing"
+msgstr "Detener Borrado"
+
+#: pkg/kubernetes/views/image-config.html:10
+msgid "Stop with"
+msgstr "Detener con"
+
+#: pkg/docker/util.js:231
+msgid "Stopped"
+msgstr "Detenido"
+
+#: pkg/storaged/jobs.js:138
+msgid "Stopping RAID Device $target"
+msgstr "Deteniendo dispositivo RAID $target"
+
+#: pkg/storaged/jobs.js:125
+msgid "Stopping swapspace $target"
+msgstr "Deteniendo espacio de swap $target"
+
+#: pkg/storaged/index.html:23 pkg/storaged/index.html:672
+msgid "Storage"
+msgstr "Almacenamiento"
+
+#: pkg/storaged/index.html:686
+msgid "Storage Log"
+msgstr ""
+
+#: pkg/storaged/index.html:342
+msgid "Storage Logs"
+msgstr "Bitácoras de Almacenamiento"
+
+#: pkg/docker/index.html:324
+msgid "Storage pool"
+msgstr ""
+
+#: pkg/systemd/index.html:148
+msgid "Store Performance Data"
+msgstr ""
+
+#: pkg/storaged/details.js:237
+msgid "Store passphrase"
+msgstr "Guardar palabra de paso"
+
+#: pkg/storaged/details.js:527
+msgid "Stored Passphrase"
+msgstr "Frase de paso guardada"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:12
+msgid ""
+"Strategy            {{item.spec.strategy.type}}            Latest "
+"Version            {{ item.status.latestVersion }}            Not "
+"deployed        "
+msgstr ""
+
+#: pkg/subscriptions/index.html:22
+msgid "Subscriptions"
+msgstr "Suscripciones"
+
+#: pkg/kubernetes/views/image-body.html:4
+msgid "Summary"
+msgstr "Resumen"
+
+#: pkg/storaged/details.js:1251
+msgctxt "storage-id-desc"
+msgid "Swap Space"
+msgstr "Espacio de intercambio"
+
+#: pkg/systemd/index.html:243
+msgid "Swap Used"
+msgstr "Swap utilizada"
+
+#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
+msgid "Switch off $0"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2191 pkg/networkmanager/interfaces.js:2765
@@ -2503,1096 +5210,179 @@ msgstr ""
 msgid "Switching off <b>$0</b>  will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
-msgid "Switch off $0"
+#: pkg/networkmanager/interfaces.js:2773
+msgid "Switching off <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
-#: pkg/networkmanager/interfaces.js:2507
-msgid "Bond"
-msgstr "Vínculo"
+#: pkg/networkmanager/interfaces.js:2188
+msgid "Switching on <b>$0</b>  will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2762
+msgid "Switching on <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:75
+msgid "Synchronize"
+msgstr "Sincronizar"
+
+#: pkg/dashboard/index.html:188 pkg/lib/machine-sync-users.html:4
+msgid "Synchronize users"
+msgstr "Sincronizar usuarios"
+
+#: pkg/systemd/index.html:54
+msgid "Synchronized"
+msgstr ""
+
+#: pkg/systemd/index.html:51
+msgid "Synchronized with {{Server}}"
+msgstr "Sincronizado con {{Server}}"
+
+#: pkg/storaged/jobs.js:146
+msgid "Synchronizing RAID Device $target"
+msgstr ""
+
+#: pkg/systemd/index.html:4
+msgid "System"
+msgstr ""
+
+#: pkg/systemd/services.html:53
+msgid "System Services"
+msgstr "Servicios de Sistema"
+
+#: pkg/systemd/index.html:112
+msgid "System Time"
+msgstr ""
+
+#: pkg/docker/index.html:349
+msgid "TCP"
+msgstr ""
+"TCP: Protocolo de Control de Transmisión, por sus siglas en ingles "
+"(Transmission Control Protocol)"
+
+#: pkg/kubernetes/views/route-body.html:12
+msgid "TLS Termination"
+msgstr "Terminación TLS"
+
+#: pkg/docker/index.html:724
+msgid "Tag"
+msgstr "Etiquetas"
+
+#: pkg/kubernetes/views/image-body.html:27
+#: pkg/kubernetes/views/imagestream-modify.html:76
+#: pkg/kubernetes/views/image-listing.html:14
+msgid "Tags"
+msgstr "Etiquetas"
+
+#: pkg/kubernetes/views/pv-modify.html:136
+msgid "Target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:75
+msgid "Target Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:114
+msgid "Target World Wide Names"
+msgstr ""
+
+#: pkg/systemd/services.html:52
+msgid "Targets"
+msgstr "Objetivos"
 
 #: pkg/networkmanager/interfaces.js:2235 pkg/networkmanager/interfaces.js:2247
 #: pkg/networkmanager/interfaces.js:2530
 msgid "Team"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
-#: pkg/networkmanager/interfaces.js:2622
-msgid "VLAN"
-msgstr "VLAN"
-
-#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
-#: pkg/networkmanager/interfaces.js:2584
-msgid "Bridge"
-msgstr "Puente"
-
-#: pkg/networkmanager/interfaces.js:2276
-msgid "Carrier"
-msgstr "Transporte"
-
-#: pkg/networkmanager/interfaces.js:2279 pkg/kubernetes/scripts/volumes.js:990
-msgid "Yes"
-msgstr "Sí"
-
-#: pkg/networkmanager/interfaces.js:2299
-#: pkg/subscriptions/subscriptions-view.jsx:36
-#: pkg/kubernetes/views/node-body.html.h:14
-#: pkg/kubernetes/views/containers-listing.html.h:7
-#: pkg/kubernetes/views/volumes-page.html.h:5
-#: pkg/kubernetes/views/pv-claim.html.h:6
-#: pkg/kubernetes/views/nodes-page.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:5 pkg/kubernetes/views/pv-body.html.h:4
-msgid "Status"
-msgstr "Estado"
-
-#: pkg/networkmanager/interfaces.js:2310
-#, fuzzy
-msgid "This device cannot be managed here."
-msgstr "Este volumen lógico no puede hacerse mas pequeño"
-
-#: pkg/networkmanager/interfaces.js:2342
-msgid "Unknown configuration"
-msgstr "Configuración desconocida"
-
-#: pkg/networkmanager/interfaces.js:2441
-msgid "Configure"
-msgstr "Configurar"
-
-#: pkg/networkmanager/interfaces.js:2473
-msgid "$mtu"
-msgstr "$mtu"
-
-#: pkg/networkmanager/interfaces.js:2477
-msgid "MTU"
-msgstr "MTU"
-
-#: pkg/networkmanager/interfaces.js:2483
-msgid "Master"
-msgstr "Maestro"
-
-#: pkg/networkmanager/interfaces.js:2502
-msgid "ARP Monitoring"
-msgstr "Supervisión ARP"
-
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
-#, fuzzy
-msgid "Broken configuration"
-msgstr "Configuración desconocida"
-
 #: pkg/networkmanager/interfaces.js:2558
 #, fuzzy
 msgid "Team Port"
 msgstr "Puerto"
 
-#: pkg/networkmanager/interfaces.js:2573
-msgid "Spanning Tree Protocol"
-msgstr "Spanning Tree Protocol"
-
-#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
-msgid "Priority $priority"
-msgstr "Prioridad $priority"
-
-#: pkg/networkmanager/interfaces.js:2577
-msgid "Forward delay $forward_delay"
-msgstr "Retardo del reenvío $forward_delay"
-
-#: pkg/networkmanager/interfaces.js:2579
-msgid "Hello time $hello_time"
-msgstr "Tiempo de saludo $hello_time"
-
-#: pkg/networkmanager/interfaces.js:2581
-msgid "Maximum message age $max_age"
-msgstr "Edad máxima del mensaje $max_age"
-
-#: pkg/networkmanager/interfaces.js:2601
-msgid "Path cost $path_cost"
-msgstr "Costo ruta $path_cost"
-
-#: pkg/networkmanager/interfaces.js:2603
-msgid "Hairpin mode"
-msgstr "Modo horquilla"
-
-#: pkg/networkmanager/interfaces.js:2605
-msgid "Bridge port"
-msgstr "Puerto bridge"
-
-#: pkg/networkmanager/interfaces.js:2619
-msgid "Parent $parent"
-msgstr "Padre $parent"
-
-#: pkg/networkmanager/interfaces.js:2620
-msgid "Id $id"
-msgstr "Id $id"
-
-#: pkg/networkmanager/interfaces.js:2628
-msgid "General"
-msgstr "General"
-
-#: pkg/networkmanager/interfaces.js:2637
-msgid "Connect automatically"
-msgstr "Conectado automáticamente"
-
-#: pkg/networkmanager/interfaces.js:2641
-msgid "IPv4"
-msgstr "IPv4"
-
-#: pkg/networkmanager/interfaces.js:2642
-msgid "IPv6"
-msgstr "IPv6"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/networkmanager/index.html.h:33
-#: pkg/kubernetes/views/project-listing.html.h:5
-msgid "Members"
-msgstr "Miembros"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/docker/index.html.h:39
-#: pkg/networkmanager/index.html.h:24
-#: pkg/kubernetes/views/service-body.html.h:6
-#: pkg/kubernetes/views/image-config.html.h:7
-#: pkg/kubernetes/views/container-body.html.h:5
-msgid "Ports"
-msgstr "Puertos"
-
-#: pkg/networkmanager/interfaces.js:2762
-msgid "Switching on <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2773
-msgid "Switching off <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2788
-msgid "Removing <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2791
+#: pkg/networkmanager/index.html:652
 #, fuzzy
-msgid "Remove $0"
-msgstr "Eliminar"
-
-#: pkg/networkmanager/interfaces.js:2833
-msgid "Adding <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2836
-msgid "Add $0"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2870
-msgid "Changing the settings will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2872
-#, fuzzy
-msgid "Change the settings"
+msgid "Team Port Settings"
 msgstr "Configuración del puerto Bridge"
 
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length or Netmask"
-msgstr "Tamaño del prefijo o máscara de red"
-
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length"
-msgstr "Tamaño del prefijo"
-
-#: pkg/networkmanager/interfaces.js:3011
-#: pkg/kubernetes/views/details-page.html.h:7
-msgid "Addresses"
-msgstr "Dirección"
-
-#: pkg/networkmanager/interfaces.js:3018
-msgid "DNS"
-msgstr "DNS"
-
-#: pkg/networkmanager/interfaces.js:3022
-msgid "DNS Search Domains"
-msgstr "Búsqueda Dominios DNS"
-
-#: pkg/networkmanager/interfaces.js:3027
-#: pkg/kubernetes/views/details-page.html.h:11
-msgid "Routes"
-msgstr "Rutas"
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv4 Settings"
-msgstr "Configuración IPv4"
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv6 Settings"
-msgstr "Configuración IPv6"
-
-#: pkg/networkmanager/interfaces.js:3436
-msgid "Creating this bond will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
-#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
+#: pkg/networkmanager/index.html:624
 #, fuzzy
-msgid "Create it"
-msgstr "Crear"
+msgid "Team Settings"
+msgstr "Configuración IP"
 
-#: pkg/networkmanager/interfaces.js:3611
-msgid "Creating this team will break the connection to the server, "
+#: pkg/kubernetes/views/replicationcontroller-page.html:20
+#: pkg/kubernetes/views/deploymentconfig-panel.html:10
+#: pkg/kubernetes/views/deploymentconfig-page.html:15
+#: pkg/kubernetes/views/replicationcontroller-panel.html:14
+msgid "Template"
+msgstr "Plantilla"
+
+#: pkg/systemd/terminal.html:4
+msgid "Terminal"
+msgstr "Terminal"
+
+#: pkg/users/index.html:78
+msgid "Terminate Session"
+msgstr "Terminar sesión"
+
+#: pkg/networkmanager/index.html:38
+msgid "Testing connection"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3842
-msgid "Creating this bridge will break the connection to the server, "
+#: pkg/storaged/index.html:40
+msgid "The \"storaged\" API is not available on this system."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:4064
-msgid "Creating this VLAN will break the connection to the server, "
+#: pkg/docker/storage.jsx:485
+msgid "The Docker storage pool cannot be managed on this system."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:4139
-msgid "MTU must be a positive number"
+#: pkg/lib/machine-dialogs.js:386
+msgid "The IP address or host name cannot contain whitespace."
 msgstr ""
+"La dirección IP o el nombre de dominio no puede tener espacios en blanco"
 
-#: pkg/subscriptions/subscriptions-client.js:196
-#, fuzzy
-msgid "Invalid credentials"
-msgstr "Puerto invalido"
-
-#: pkg/subscriptions/subscriptions-client.js:198
-msgid "'Organization' required to register."
+#: pkg/storaged/index.html:532
+msgid "The RAID Array is in a degraded state"
 msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:200
-msgid "Login/password or activation key required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:202
-msgid "'Organization' required when using activation keys."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:64
-#: pkg/kubernetes/views/volume-body.html.h:16
-#: pkg/kubernetes/views/pv-modify.html.h:11
-msgid "Server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:88
-#: pkg/subscriptions/subscriptions-register.jsx:152
-#: pkg/lib/machine-auth-failed.html.h:3 pkg/lib/machine-sync-users.html.h:6
-#: pkg/lib/machine-change-auth.html.h:6 pkg/shell/index.html.h:31
-#: pkg/users/index.html.h:16 pkg/kubernetes/views/auth-form.html.h:11
-msgid "Password"
-msgstr "Contraseña"
-
-#: pkg/subscriptions/subscriptions-register.jsx:102
-#, fuzzy
-msgid "Custom URL"
-msgstr "Personalizar"
-
-#: pkg/subscriptions/subscriptions-register.jsx:110
-msgid "URL"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:125
-msgid "Proxy"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:132
-msgid "Use proxy server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:140
-#, fuzzy
-msgid "Login"
-msgstr "Último inicio de sesión"
-
-#: pkg/subscriptions/subscriptions-register.jsx:164
-#, fuzzy
-msgid "Activation Key"
-msgstr "Activar"
-
-#: pkg/subscriptions/subscriptions-register.jsx:176
-#, fuzzy
-msgid "Organization"
-msgstr "Traducción"
-
-#: pkg/subscriptions/main.js:45 pkg/subscriptions/subscriptions-view.jsx:143
-#: pkg/kubernetes/views/pv-modify.html.h:23
-msgid "Register"
-msgstr ""
-
-#: pkg/subscriptions/main.js:74
-msgid "Register system"
-msgstr "Registrar sistema"
-
-#: pkg/subscriptions/subscriptions-view.jsx:32
-msgid "Product name"
-msgstr "Nombre del Producto"
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product ID"
-msgstr "ID del Producto"
-
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/index.html.h:13
-#: pkg/shell/index.html.h:14 pkg/shell/stub.html.h:9 pkg/shell/simple.html.h:9
-#: pkg/ostree/index.html.h:19
-msgid "Version"
-msgstr "Versión"
-
-#: pkg/subscriptions/subscriptions-view.jsx:35
-#: pkg/kubernetes/views/image-config.html.h:5
-msgid "Architecture"
-msgstr "Arquitectura"
-
-#: pkg/subscriptions/subscriptions-view.jsx:37
-#, fuzzy
-msgid "Starts"
-msgstr "Iniciar"
-
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Ends"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:141
-msgid "Status: System isn't registered"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:146
-#, fuzzy
-msgid "Status: $0"
-msgstr "Estado"
-
-#: pkg/subscriptions/subscriptions-view.jsx:148
-msgid "Unregister"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:154
-#, fuzzy
-msgid "Unregistering system..."
-msgstr "Registrando el sistema"
-
-#: pkg/subscriptions/subscriptions-view.jsx:161
-#: pkg/subscriptions/index.html.h:1
-msgid "Subscriptions"
-msgstr "Suscripciones"
-
-#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/ostree/index.html.h:15
-msgid "Updating"
-msgstr "Actualizando"
-
-#: pkg/subscriptions/subscriptions-view.jsx:188
-msgid "Retrieving subscription status..."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:191
-#, fuzzy
-msgid "Access denied"
-msgstr "Acceder"
-
-#: pkg/subscriptions/subscriptions-view.jsx:192
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:195
-#, fuzzy
-msgid "Unable to connect"
-msgstr "No se pudo obtener alerta"
-
-#: pkg/subscriptions/subscriptions-view.jsx:196
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:222
-msgid "Installed products"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:223
-#, fuzzy
-msgid "No installed products on the system."
-msgstr "Cockpit no esta instalado en el sistema"
-
-#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "No es un número válido de réplicas"
-
-#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "El número maximo de replicas es 128"
-
-#: pkg/kubernetes/scripts/details.js:546
-msgid "Not a valid value for Host"
-msgstr "No es un valor valido para el host"
-
-#: pkg/kubernetes/scripts/details.js:655
-msgid "Updating $0..."
-msgstr "Actualizando $0..."
-
-#: pkg/kubernetes/scripts/graphs.js:601 pkg/kubernetes/scripts/nodes.js:711
-#: pkg/kubernetes/scripts/nodes.js:817 pkg/dashboard/index.html.h:2
-msgid "CPU"
-msgstr "CPU"
-
-#: pkg/kubernetes/scripts/graphs.js:606 pkg/kubernetes/scripts/nodes.js:715
-#: pkg/kubernetes/scripts/nodes.js:826 pkg/dashboard/index.html.h:3
-msgid "Memory"
-msgstr "Memoria"
-
-#: pkg/kubernetes/scripts/graphs.js:611 pkg/dashboard/index.html.h:4
-msgid "Network"
-msgstr "Red"
-
-#: pkg/kubernetes/scripts/nodes.js:319 pkg/kubernetes/views/node-body.html.h:16
-#: pkg/kubernetes/views/details-page.html.h:10
-msgid "Not Ready"
-msgstr "No está listo"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
-msgstr "Programación deshabilitada "
-
-#: pkg/kubernetes/scripts/nodes.js:324 pkg/kubernetes/views/node-body.html.h:15
-#: pkg/kubernetes/views/details-page.html.h:9
-msgid "Ready"
-msgstr "Listo"
-
-#: pkg/kubernetes/scripts/nodes.js:397
-msgid "Please type an address"
-msgstr "Por favor escriba una dirección"
 
 #: pkg/kubernetes/scripts/nodes.js:399
 msgid "The address contains invalid characters"
 msgstr "La dirección contiene caracteres inválidos"
 
-#: pkg/kubernetes/scripts/nodes.js:407
-msgid "The name contains invalid characters"
-msgstr "El nombre contiene caracteres invalidos"
-
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
-msgstr "Uso de CPU: $0%"
-
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
-msgstr "Uso de memoria: $0%"
-
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
-msgid "Disk"
-msgstr "Disco"
-
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
-msgstr "Uso de disco: $0%"
-
-#: pkg/kubernetes/scripts/nodes.js:870
-#, fuzzy, c-format
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] "$0% Libre"
-msgstr[1] ""
-
-#: pkg/kubernetes/scripts/nodes.js:872
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] "$0% Usado"
-msgstr[1] ""
-
-#: pkg/kubernetes/scripts/connection.js:88
-msgid "Error writing kubectl config"
-msgstr "Error escribiendo configuración de kubectl"
-
-#: pkg/kubernetes/scripts/connection.js:514
-msgid "Couldn't find running API server"
-msgstr "No se puede encontrar un servidor API ejecutandose"
-
-#: pkg/kubernetes/scripts/connection.js:516
-msgid "Connection Error: $0"
-msgstr "Error de conexión: $0"
-
-#: pkg/kubernetes/scripts/connection.js:539
-msgid "Please provide a valid address"
-msgstr "Provea una dirección valida"
-
-#: pkg/kubernetes/scripts/connection.js:554
-msgid "Please provide a username"
-msgstr "Provea un nombre de usuario"
-
-#: pkg/kubernetes/scripts/connection.js:650
-msgid "Error getting certificate details: $0"
-msgstr "Error al obtener los detalles del certificado: $0"
-
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
-msgstr "Repositorio Git"
-
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr "Secreto"
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr "Directorio vació"
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
-msgid "Host Path"
-msgstr "Ruta del Host"
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr "Gluster FS"
-
-#: pkg/kubernetes/scripts/volumes.js:199
-msgid "NFS Mount"
-msgstr "Montar NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
-msgid "ISCSI"
-msgstr "ISCSI"
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr "Cinder"
-
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr "Flocker"
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr "Flex"
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr "Azure"
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr "Lectura y escritura para un solo nodo."
-
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr "Sólo lectura para nodos múltiples"
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr "Lectura y escritura para nodos multiples"
-
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr "Retener"
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr "Reciclar"
-
-#: pkg/kubernetes/scripts/volumes.js:469
-msgid "Please select a valid access mode"
-msgstr "Por favor seleccionar un modo de acceso valido"
-
-#: pkg/kubernetes/scripts/volumes.js:477
-msgid "Please provide a valid name"
-msgstr "Por favor provea un nombre valido"
-
-#: pkg/kubernetes/scripts/volumes.js:485
-msgid "Please provide a valid storage capacity."
-msgstr "Por favor provea una capacidad de almacenamiento valida."
-
-#: pkg/kubernetes/scripts/volumes.js:493
-msgid "Please select a valid policy option."
-msgstr "Por favor provea una opción de política valida."
-
-#: pkg/kubernetes/scripts/volumes.js:565
-msgid "Please select a valid endpoint"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:574
-msgid "Please provide a GlusterFS volume name"
-msgstr "Por favor provea un nombre de volumen GlusterFS"
-
-#: pkg/kubernetes/scripts/volumes.js:632
-msgid "Please provide a valid NFS server"
-msgstr "Por favor provea un servidos NFS valido"
-
-#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
-msgid "Please provide a valid path"
-msgstr "Por favor provea una ruta valida"
-
-#: pkg/kubernetes/scripts/volumes.js:781
-msgid "Please provide a valid target"
-msgstr "Por favor provea un objetivo valido"
-
-#: pkg/kubernetes/scripts/volumes.js:789
-msgid "Please provide a valid qualified name"
-msgstr "Por favor provea un nombre cualifica valido"
-
-#: pkg/kubernetes/scripts/volumes.js:797
-msgid "Please provide a valid logical unit number"
-msgstr "Por favor provea un número valido de unidad lógica"
-
-#: pkg/kubernetes/scripts/volumes.js:805
-msgid "Please provide a valid filesystem type"
-msgstr "Por favor provea un tipo de sistema de archivos valido"
-
-#: pkg/kubernetes/scripts/volumes.js:813
-msgid "Please provide a valid interface"
-msgstr "Por favor provea una interfaz valida"
-
-#: pkg/kubernetes/scripts/volumes.js:860
-msgid "NFS"
-msgstr "NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:872
-msgid "GlusterFS"
-msgstr "GlusterFS"
-
-#: pkg/kubernetes/scripts/volumes.js:908
-msgid "Sorry, I don't know how to modify this volume"
-msgstr "Lo siento, no se como modificar este volumen"
-
-#: pkg/kubernetes/scripts/charts.js:113
-msgid "Unavailable"
-msgstr "No Disponible"
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "El nombre de espacio no puede estar vacio"
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "Por favor provea un nombre de espacio valido"
-
-#: pkg/kubernetes/scripts/dashboard.js:384
+#: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
-"No se seleccionó un archivo metadata. Por favor seleccione un archivo "
-"metadata Kebernetes."
+"La autenticidad del host {{#strong}}{{host}}{{/strong}} no se ha podido "
+"establecer.¿Está seguro que desea continuar con la conexión?"
 
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr ""
-"El archivo seleccionado no es un archivo de manifiesto de aplicación "
-"kubernetes valido"
-
-#: pkg/kubernetes/scripts/dashboard.js:401
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr ""
-"No es posible leer el manifiesto de la aplicación Kubernetes. Código $0."
-
-#: pkg/kubernetes/scripts/dashboard.js:413
-msgid "Unable to decode Kubernetes application manifest."
-msgstr "No es posible decodificar el manifiesto de Kubernetes."
-
-#: pkg/kubernetes/scripts/dashboard.js:441
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "Por favor cree otro nombre de espacio para $0 \"$1\""
-
-#: pkg/kubernetes/scripts/dashboard.js:460
-msgid "Manifest"
-msgstr "Manifiesto"
-
-#: pkg/dashboard/list.js:209
-msgid "The user <b>$0</b> is not permitted to manage servers"
-msgstr "El usuario <b>$0</b> no está autorizado para administrar servidores"
-
-#: pkg/dashboard/list.js:394
-msgid ""
-"You are currently connected directly to this server. You cannot delete it."
-msgstr ""
-"Actualmente estás conectado directamente a este servidor. No puedes "
-"eliminarlo."
-
-#: cockpit.appdata.xml.in.h:1
-msgid ""
-"Cockpit is a server manager that makes it easy to administer your Linux "
-"servers via a web browser. Jumping between the terminal and the web tool is "
-"no problem. A service started via Cockpit can be stopped via the terminal. "
-"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
-"journal interface."
-msgstr ""
-"Cockpit es un administrador de servidores, que vuelve fácil administrar tus "
-"servidores Linux mediante un navegador web. Saltar entre la terminal y la "
-"herramienta web no es un problema. Un servicio que se inicia en Cockpit "
-"puede ser detenido mediante la terminal. del mismo modo, si un error ocurre "
-"en la terminal, este puede ser visto en Cockpit mediante la interfaz de "
-"bitácora."
-
-#: cockpit.appdata.xml.in.h:2
-msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
-"stopping services. You can monitor and administer several servers at the "
-"same time. Just add them with a single click and your machines will look "
-"after its buddies."
-msgstr ""
-"Cockpit es perfecto para nuevos administradores de sistemas, permitiendoles "
-"realizar tareas faciles, tales como administración de almacenamiento, "
-"inspeccionar bitacoras e iniciar y detener servicios. Puede monitorear y "
-"administrar muchos servidores al mismo tiempo. Solamente añádelos con un "
-"solo clic y tus computadoras se ocuparan de sus amigos."
-
-#: cockpit.desktop.in.h:1 pkg/shell/index.html.h:1 pkg/shell/stub.html.h:1
-#: pkg/shell/simple.html.h:1
-msgid "Cockpit"
-msgstr "Cockpit"
-
-#: cockpit.desktop.in.h:2
-msgid "A user interface for GNU/Linux servers"
-msgstr "La interface de usuario para servidores GNU/Linux"
-
-#: cockpit.desktop.in.h:3
-msgid "Remote;Administration;"
-msgstr "Remoto/a; Administración;"
-
-#: pkg/systemd/index.html.h:1
-msgid "System"
+#: pkg/selinux/setroubleshoot-view.jsx:324
+msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
 
-#: pkg/systemd/index.html.h:2
-msgid "No host keys found."
+#: pkg/kubernetes/views/container-page-inline.html:22
+msgid "The container '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/systemd/index.html.h:3
-msgid "Synchronized with {{Server}}"
-msgstr "Sincronizado con {{Server}}"
-
-#: pkg/systemd/index.html.h:4
-msgid "Synchronized"
+#: pkg/subscriptions/subscriptions-view.jsx:192
+msgid "The current user isn't allowed to access system subscription status."
 msgstr ""
 
-#: pkg/systemd/index.html.h:5
-msgid "Trying to synchronize with {{Server}}"
+#: pkg/kubernetes/views/deploymentconfig-page.html:25
+msgid "The deployment config '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/systemd/index.html.h:6
-msgid "Not synchronized"
+#: pkg/kubernetes/views/group-page.html:47
+msgid "The group '{{ groupName }}' does not exist."
 msgstr ""
 
-#: pkg/systemd/index.html.h:7
-msgid "Hardware"
-msgstr "Hardware"
-
-#: pkg/systemd/index.html.h:8
-msgid "Asset Tag"
-msgstr ""
-
-#: pkg/systemd/index.html.h:9 pkg/kubernetes/views/node-body.html.h:6
-msgid "Machine ID"
-msgstr ""
-
-#: pkg/systemd/index.html.h:10 pkg/ostree/index.html.h:18
-#: pkg/kubernetes/views/nodes-page.html.h:6
-msgid "Operating System"
-msgstr "Sistema Operativo"
-
-#: pkg/systemd/index.html.h:11
-msgid "Secure Shell Keys"
-msgstr ""
-
-#: pkg/systemd/index.html.h:12
-msgid "Show fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:14 pkg/dashboard/index.html.h:7
-msgid "Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:15
-msgid "Domain"
-msgstr "Dominio"
-
-#: pkg/systemd/index.html.h:16
-msgid "System Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:17
-msgid "Power Options"
-msgstr "Opciones de apagado"
-
-#: pkg/systemd/index.html.h:20
-msgid "Performance Profile"
-msgstr ""
-
-#: pkg/systemd/index.html.h:21
-msgid "Store Performance Data"
-msgstr ""
-
-#: pkg/systemd/index.html.h:32
-msgid "Machine SSH Key Fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:33
-msgid "Pretty Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:34
-msgid "Real Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:35
-msgid "Time Zone"
-msgstr ""
-
-#: pkg/systemd/index.html.h:36
-msgid ""
-"\n"
-"                                    Invalid time zone\n"
-"                                "
-msgstr ""
-
-#: pkg/systemd/index.html.h:39
-msgid "Set Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:40
-msgid "Manually"
-msgstr ""
-
-#: pkg/systemd/index.html.h:41
-msgid "Automatically using NTP"
-msgstr ""
-
-#: pkg/systemd/index.html.h:42
-msgid "Automatically using specific NTP servers"
-msgstr ""
-
-#: pkg/systemd/index.html.h:43
-msgid "Delay"
-msgstr ""
-
-#: pkg/systemd/index.html.h:44
-msgid "1 Minute"
-msgstr "1 Minuto"
-
-#: pkg/systemd/index.html.h:45
-msgid "5 Minutes"
-msgstr "5 Minutos"
-
-#: pkg/systemd/index.html.h:46
-msgid "20 Minutes"
-msgstr "20 Minutos"
-
-#: pkg/systemd/index.html.h:47
-msgid "40 Minutes"
-msgstr "40 Minutos"
-
-#: pkg/systemd/index.html.h:48
-msgid "60 Minutes"
-msgstr "60 Minutos"
-
-#: pkg/systemd/index.html.h:49
-msgid "No Delay"
-msgstr ""
-
-#: pkg/systemd/index.html.h:50
-msgid "Specific Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:51
-msgid ""
-"\n"
-"                        Cancel\n"
-"                    "
-msgstr ""
-
-#: pkg/systemd/logs.html.h:1
-msgid "Journal"
-msgstr "Bitacora"
-
-#: pkg/systemd/logs.html.h:2
-msgid "Recent"
-msgstr "Reciente"
-
-#: pkg/systemd/logs.html.h:3
-msgid "Current boot"
-msgstr "Arranque actual"
-
-#: pkg/systemd/logs.html.h:4
-msgid "Last 24 hours"
-msgstr "Ultimas 24 horas"
-
-#: pkg/systemd/logs.html.h:5
-msgid "Last 7 days"
-msgstr "Ultimos 7 dias"
-
-#: pkg/systemd/logs.html.h:6
-msgid "Errors"
-msgstr "Errores"
-
-#: pkg/systemd/logs.html.h:7
-msgid "Warnings"
-msgstr "Advertencias"
-
-#: pkg/systemd/logs.html.h:8
-msgid "Notices"
-msgstr "Avisos"
-
-#: pkg/systemd/logs.html.h:9
-msgid "All"
-msgstr "Todos"
-
-#: pkg/systemd/logs.html.h:10 pkg/kubernetes/views/container-panel.html.h:2
-#: pkg/kubernetes/views/container-page-inline.html.h:2
-msgid "Logs"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:11
-msgid "Entry"
-msgstr "Entrada"
-
-#: pkg/systemd/services.html.h:1 pkg/kubernetes/views/dashboard-page.html.h:12
-#: pkg/kubernetes/views/details-page.html.h:3
-msgid "Services"
-msgstr "Servicios"
-
-#: pkg/systemd/services.html.h:3
-msgid "System Services"
-msgstr "Servicios de Sistema"
-
-#: pkg/systemd/services.html.h:4
-msgid "Sockets"
-msgstr "Sockets"
-
-#: pkg/systemd/services.html.h:5
-msgid "Timers"
-msgstr "Temporizadores"
-
-#: pkg/systemd/services.html.h:6
-msgid "Paths"
-msgstr "Rutas"
-
-#: pkg/systemd/services.html.h:7
-msgid "Instantiate"
-msgstr "Instanciar"
-
-#: pkg/systemd/services.html.h:8
-msgid "{{days_text}}"
-msgstr ""
-
-#: pkg/systemd/services.html.h:9
-msgid "Service Logs"
-msgstr "Bitácoras del Servicio"
-
-#: pkg/systemd/services.html.h:10
-msgid "Note"
-msgstr "Nota"
-
-#: pkg/systemd/services.html.h:11
-msgid ""
-"This unit is not designed to be enabled explicitly.\n"
-"          "
-msgstr ""
-"Esta unidad no esta diseñada para ser habilitada explícitamente. \n"
-"          "
-
-#: pkg/systemd/services.html.h:15
-#, fuzzy
-msgid "Create Timers"
-msgstr "Crear Volumen Delgado"
-
-#: pkg/systemd/services.html.h:16
-#, fuzzy
-msgid "Service name"
-msgstr "Servicio"
-
-#: pkg/systemd/services.html.h:18 pkg/docker/index.html.h:32
-msgid "Command"
-msgstr "Comando"
-
-#: pkg/systemd/services.html.h:19
-#, fuzzy
-msgid "Run"
-msgstr "Ejecutar como"
-
-#: pkg/systemd/services.html.h:20
-#, fuzzy
-msgid "After system boot"
-msgstr "Registrar sistema"
-
-#: pkg/systemd/services.html.h:21
-msgid "At specific time"
-msgstr ""
-
-#: pkg/systemd/services.html.h:22
-msgid "Seconds"
-msgstr ""
-
-#: pkg/systemd/services.html.h:23
-#, fuzzy
-msgid "Minutes"
-msgstr "5 Minutos"
-
-#: pkg/systemd/services.html.h:24
-#, fuzzy
-msgid "Hours"
-msgstr "6 horas"
-
-#: pkg/systemd/services.html.h:25
-msgid "Weeks"
-msgstr ""
-
-#: pkg/systemd/services.html.h:26
-msgid "Don't Repeat"
-msgstr ""
-
-#: pkg/systemd/services.html.h:27
-msgid "Repeat Hourly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:28
-msgid "Repeat Daily"
-msgstr ""
-
-#: pkg/systemd/services.html.h:29
-msgid "Repeat Weekly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:30
-msgid "Repeat Monthly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:31
-msgid "Repeat Yearly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:32
-#, fuzzy
-msgid "Hour : Minute"
-msgstr "1 Minuto"
-
-#: pkg/systemd/services.html.h:33
-msgid ":"
-msgstr ""
-
-#: pkg/systemd/services.html.h:35
-msgid "Save"
-msgstr ""
-
-#: pkg/systemd/terminal.html.h:1
-msgid "Terminal"
-msgstr "Terminal"
-
-#: pkg/lib/machine-invalid-hostkey.html.h:1
-msgid "Incorrect Host Key"
-msgstr "Llave de Host Incorrecta"
-
-#: pkg/lib/machine-invalid-hostkey.html.h:2
+#: pkg/shell/base_index.js:673
+msgid "The javascript console contains details about this error "
+msgstr "La consola javascript contiene detalles acerca de este error"
+
+#: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
 "The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
 "in use. Unless this machine was recently replaced, it is likely that someone "
@@ -3603,57 +5393,675 @@ msgstr ""
 "recientemente, es posible que alguien este tratando de atacar tu conexión a "
 "esta máquina."
 
-#: pkg/lib/machine-invalid-hostkey.html.h:3
-msgid ""
-"You can remove the previously stored key by running the following command"
-msgstr ""
-"Usted puede remover la llave almacenada previamente al correr el siguiente "
-"comando"
+#: pkg/users/authorized-keys.js:118
+msgid "The key you provided was not valid."
+msgstr "La llave que envió no era valida."
 
-#: pkg/lib/machine-auth-failed.html.h:1
-msgid "Authentication Failed"
-msgstr "Autenticación fallida"
-
-#: pkg/lib/machine-auth-failed.html.h:2
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
-"machine with cockpit you will need to enable one of the following "
-"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
+#: pkg/storaged/details.js:1751
+msgid "The last physical volume of a volume group cannot be removed."
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html.h:4 pkg/shell/index.html.h:30
-msgid "Public Key"
-msgstr "Llave pública"
+#: pkg/shell/indexes.js:314
+msgid "The machine is restarting"
+msgstr "La máquina se está reiniciando"
 
-#: pkg/lib/machine-auth-failed.html.h:5
-msgid "Kerberos Based SSO"
-msgstr "SSO Basado en Kerberos"
+#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
+msgid "The maximum number of replicas is 128"
+msgstr "El número maximo de replicas es 128"
 
-#: pkg/lib/machine-auth-failed.html.h:6
-msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
+#: pkg/kubernetes/scripts/nodes.js:407
+msgid "The name contains invalid characters"
+msgstr "El nombre contiene caracteres invalidos"
+
+#: pkg/kubernetes/views/node-page.html:23
+msgid "The node '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/lib/machine-sync-users.html.h:1 pkg/dashboard/index.html.h:11
-msgid "Synchronize users"
-msgstr "Sincronizar usuarios"
-
-#: pkg/lib/machine-sync-users.html.h:2
-msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
+#: pkg/kubernetes/views/node-alerts.html:7
+msgid "The node doesn't have enough disk space"
 msgstr ""
-"Seleccione el usuario con el que le gustaría sincronizar  {{#strong}}{{host}}"
-"{{/strong}}"
 
-#: pkg/lib/machine-sync-users.html.h:3
-msgid "Error loading users: {{perm_failed}}"
-msgstr "Error cargando usuarios: {{perm_failed}}"
+#: pkg/kubernetes/views/node-alerts.html:11
+msgid "The node doesn't have enough free memory"
+msgstr ""
 
-#: pkg/lib/machine-sync-users.html.h:4
+#: pkg/users/local.js:395 pkg/users/local.js:1082
+msgid "The passwords do not match"
+msgstr "Las contraseñas no coinciden."
+
+#: pkg/lib/credentials.js:186
+msgid "The passwords do not match."
+msgstr "Las contraseñas no coinciden."
+
+#: pkg/kubernetes/views/pv-page.html:21
+msgid "The persistent volume '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:40
+msgid "The pod '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/project-page.html:34
+msgid "The project '{{ projName }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:30
+msgid "The replication controller '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:19
+msgid "The route '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:386
+msgid "The selected file is not a valid Kubernetes application manifest."
+msgstr ""
+"El archivo seleccionado no es un archivo de manifiesto de aplicación "
+"kubernetes valido"
+
+#: src/base1/cockpit.js:3695
+msgid "The server refused to authenticate using any supported methods."
+msgstr "El servido rehusó autenticar usando los métodos soportados."
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:2
+msgid "The server uses a certificate signed by an unknown authority."
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:19
+msgid "The service '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/docker/storage.jsx:355
+msgid ""
+"The storage pool will be reset to optimize its layout.  All containers will "
+"be erased."
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:29
+msgid "The user '{{ userName }}' does not exist."
+msgstr ""
+
+#: pkg/systemd/init.js:834
+#, fuzzy
+msgid "The user <b>$0</b> does not have permissions for creating timers"
+msgstr "El usuario <b>$0</b> no está autorizado para administrar servidores"
+
+#: pkg/dashboard/list.js:209
+msgid "The user <b>$0</b> is not permitted to manage servers"
+msgstr "El usuario <b>$0</b> no está autorizado para administrar servidores"
+
+#: pkg/storaged/permissions.js:61
+msgid "The user <b>$0</b> is not permitted to manage storage"
+msgstr "Al usuario <b>$0</b> no le es permitido administrar el almacenamiento "
+
+#: pkg/users/local.js:40
+msgid "The user <b>$0</b> is not permitted to modify accounts"
+msgstr "El usuario <b>$0</b> no tiene permisos para modificar cuentas"
+
+#: pkg/systemd/host.js:43
+msgid "The user <b>$0</b> is not permitted to modify hostnames"
+msgstr "El usuario <b>$0</b> no está autorizado a modificar dominios"
+
+#: pkg/networkmanager/interfaces.js:1420
+msgid "The user <b>$0</b> is not permitted to modify network settings"
+msgstr ""
+"El usuario <b>$0</b> no está autorizado para modificar la configuración de "
+"la red"
+
+#: pkg/realmd/operation.js:436
+msgid "The user <b>$0</b> is not permitted to modify realms"
+msgstr "El usuario <b>$0</b> no está autorizado a modificar dominios"
+
+#: pkg/users/local.js:501
+msgid ""
+"The user name can only consist of letters from a-z, digits, dots, dashes and "
+"underscores."
+msgstr ""
+"El nombre de usuario sólo puede consistir de letras (a-z), dígitos, puntos, "
+"guiones y guiones bajos."
+
+#: pkg/users/index.html:332
+msgid "There are no authorized public keys for this account."
+msgstr "No hay llaves públicas autorizadas para esta cuenta."
+
+#: pkg/storaged/details.js:1756
+msgid ""
+"There is not enough free space elsewhere to remove this physical volume.  At "
+"least $0 more free space is needed."
+msgstr ""
+
+#: pkg/storaged/utils.js:168
+msgid "Thin Logical Volume"
+msgstr "Volumen Lógico Delgado"
+
+#: pkg/kubernetes/views/pvc-delete.html:8
+msgid ""
+"This claim is in use. Deleting it may cause issues with the following pod:"
+msgstr ""
+
+#: pkg/systemd/init.js:1222
+msgid ""
+"This day doesn't exist in all months.<br> The timer will only be executed in "
+"months that have 31st."
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2310
+#, fuzzy
+msgid "This device cannot be managed here."
+msgstr "Este volumen lógico no puede hacerse mas pequeño"
+
+#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
+#, fuzzy
+msgid "This field cannot be empty."
+msgstr "Nombre no puede estar vacío."
+
+#: pkg/storaged/details.js:690
+#, fuzzy
+msgid "This logical volume cannot be made smaller."
+msgstr "Este volumen lógico no puede hacerse mas pequeño"
+
+#: pkg/lib/machine-dialogs.js:364
+msgid "This machine has already been added."
+msgstr "Esta maquina ya ha sido agregada"
+
+#: pkg/realmd/operation.html:89
+msgid "This may take a while"
+msgstr "Esto podría tomar un momento"
+
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid ""
+"This option is for single node testing only – local storage will not work in "
+"a multi-node cluster"
+msgstr ""
+
+#: src/bridge/cockpitpackages.c:470
+msgid "This package is not compatible with this version of Cockpit"
+msgstr ""
+
+#: src/bridge/cockpitpackages.c:459
+#, c-format
+msgid "This package requires Cockpit version %s or later"
+msgstr ""
+
+#: pkg/tuned/dialog.js:102
+msgid "This system is using a custom profile"
+msgstr "El sistema esta usando un perfil personalizado"
+
+#: pkg/tuned/dialog.js:100
+msgid "This system is using the recommended profile"
+msgstr "El sistema esta usando el perfil recomendado"
+
+#: pkg/systemd/init.js:639
+msgid "This unit is an instance of the $0 template."
+msgstr "Esta unidad es una instancia de la plantilla $0 "
+
+#: pkg/systemd/services.html:302
+#, fuzzy
+msgid "This unit is not designed to be enabled explicitly.          "
+msgstr ""
+"Esta unidad no esta diseñada para ser habilitada explícitamente. \n"
+"          "
+
+#: pkg/users/local.js:509
+msgid "This user name already exists"
+msgstr "El usuario ya existe"
+
+#: pkg/lib/machine-dialogs.js:380
+msgid ""
+"This version of cockpit-ws does not support connecting to a host with an "
+"alternate user or port"
+msgstr ""
+"Esta versión de cockpit-ws no soporta conexiones a un servidor con un "
+"usuario o puerto alterno"
+
+#: pkg/kubernetes/views/pv-delete.html:7
+msgid ""
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:23
+msgid "This volume has not been claimed"
+msgstr ""
+
+#: pkg/systemd/index.html:379
+msgid "Time Zone"
+msgstr ""
+
+#: pkg/systemd/services.html:55
+msgid "Timers"
+msgstr "Temporizadores"
+
+#: pkg/kubernetes/views/image-body.html:33
+msgid "To pull this image:"
+msgstr "Para halar esta imagen"
+
+#: pkg/kubernetes/views/imagestream-body.html:39
+msgid "To push to an image to this image stream:"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:11
+msgid ""
+"To try a different port you will need to upgrade cockpit-ws to a newer "
+"version."
+msgstr ""
+"Para tratar un puerto diferente usted va a necesitar actualizar cockpit-ws a "
+"una nueva versión."
+
+#: pkg/kubernetes/views/auth-form.html:116
+msgid "Token"
+msgstr ""
+
+#: pkg/kubernetes/index.html:57
+msgid "Topology"
+msgstr ""
+
+#: pkg/docker/storage.jsx:314
+msgid "Total"
+msgstr ""
+
+#: pkg/ostree/index.html:99
+msgid "Tree"
+msgstr "Árbol"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:32
+msgid "Triggers"
+msgstr "Disparadores"
+
+#: pkg/shell/index.html:328 pkg/shell/stub.html:181
+msgid "Troubleshoot"
+msgstr "Soporte"
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:21
+msgid "Trust this certificate for this connection"
+msgstr ""
+
+#: pkg/systemd/init.js:520
+msgid "Try Restart"
+msgstr "Intente Reniciar"
+
+#: pkg/docker/index.html:71 pkg/docker/index.html:74
+msgid "Try again"
+msgstr "Intentar nuevamente"
+
+#: pkg/systemd/index.html:59
+msgid "Trying to synchronize with {{Server}}"
+msgstr ""
+
+#: pkg/tuned/dialog.js:262
+msgid "Tuned has failed to start"
+msgstr "Tuned a fallado al iniciar"
+
+#: pkg/tuned/dialog.js:94
+msgid "Tuned is not available"
+msgstr "Tuned no esta disponible"
+
+#: pkg/tuned/dialog.js:96
+msgid "Tuned is not running"
+msgstr "Tuned no se esta ejecutando"
+
+#: pkg/tuned/dialog.js:98
+msgid "Tuned is off"
+msgstr "Tuned esta apagado"
+
+#: pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/pv-modify.html:10
+#: pkg/kubernetes/views/volumes-page.html:20 pkg/kubernetes/views/deploy.html:9
+msgid "Type"
+msgstr "Tipo"
+
+#: pkg/kubernetes/views/details-page.html:7
+msgid "Type:"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:110
+msgid "URL"
+msgstr ""
+
+#: pkg/storaged/index.html:547 pkg/storaged/index.html:626
+msgctxt "storage"
+msgid "UUID"
+msgstr "UUID"
+
+#: pkg/selinux/setroubleshoot-view.jsx:114
+msgid "Unable to apply this solution automatically"
+msgstr ""
+
+#: pkg/ostree/index.html:219
+msgid "Unable to communicate with OSTree"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:195
+#, fuzzy
+msgid "Unable to connect"
+msgstr "No se pudo obtener alerta"
+
+#: pkg/kubernetes/scripts/dashboard.js:413
+msgid "Unable to decode Kubernetes application manifest."
+msgstr "No es posible decodificar el manifiesto de Kubernetes."
+
+#: pkg/users/local.js:57
+msgid "Unable to delete root account"
+msgstr "No es posible eliminar la cuenta root"
+
+#: pkg/selinux/setroubleshoot-client.js:157
+msgid "Unable to get alert"
+msgstr "No se pudo obtener alerta"
+
+#: pkg/storaged/overview.js:586
+msgid "Unable to reach server"
+msgstr "Imposible conectar al servidor"
+
+#: pkg/kubernetes/scripts/dashboard.js:401
+msgid "Unable to read the Kubernetes application manifest. Code $0."
+msgstr ""
+"No es posible leer el manifiesto de la aplicación Kubernetes. Código $0."
+
+#: pkg/users/local.js:59
+msgid "Unable to rename root account"
+msgstr "No es posible renombrar la cuenta root."
+
+#: pkg/selinux/setroubleshoot-client.js:172
+msgid "Unable to run fix"
+msgstr "No se ejecutar arreglo"
+
+#: pkg/selinux/setroubleshoot-client.js:52
+msgid "Unable to start setroubleshootd"
+msgstr "No se pudo iniciar setroubleshootd"
+
+#: pkg/playground/translate.html:35 pkg/playground/translate.html:40
+msgid "Unavailable"
+msgstr "No Disponible"
+
+#: pkg/docker/index.html:763 pkg/networkmanager/index.html:792
+msgid "Unexpected error"
+msgstr "Error inesperado"
+
+#: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/image-body.html:15
+#: pkg/kubernetes/views/pv-claim.html:31 pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
+msgid "Unknown"
+msgstr "Desconocido"
+
+#: pkg/storaged/details.js:1597
+msgid "Unknown ($0)"
+msgstr "Desconocido ($0)"
+
+#: pkg/lib/machine-unknown-hostkey.html:2
+msgid "Unknown Host Key"
+msgstr "Host Key desconocido"
+
+#: pkg/networkmanager/interfaces.js:2342
+msgid "Unknown configuration"
+msgstr "Configuración desconocida"
+
+#: pkg/storaged/overview.js:582
+msgid "Unknown host name"
+msgstr "Nombre de host desconocido "
+
+#: pkg/docker/index.html:570
+msgid "Unless Stopped"
+msgstr ""
+"\n"
+"A menos que detenido"
+
+#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
+#: pkg/storaged/details.js:1110
+msgid "Unlock"
+msgstr "Desbloquear"
+
+#: pkg/shell/index.html:220
+msgid "Unlock Key"
+msgstr "Llave de Desbloqueo"
+
+#: pkg/storaged/jobs.js:121
+msgid "Unlocking $target"
+msgstr "Desbloquendo $target"
+
+#: pkg/networkmanager/index.html:108
+#, fuzzy
+msgid "Unmanaged Interfaces"
+msgstr "Interfaces"
+
+#: pkg/systemd/init.js:548
+msgid "Unmask"
+msgstr "Desenmascarar"
+
+#: pkg/storaged/details.js:1100
+msgid "Unmount"
+msgstr "Desmontar"
+
+#: pkg/storaged/jobs.js:127
+msgid "Unmounting $target"
+msgstr "Desmontando $target"
+
+#: pkg/users/index.html:315
+msgid "Unnamed"
+msgstr "Sin nombre"
+
+#: pkg/storaged/details.js:1256
+msgctxt "storage-id-desc"
+msgid "Unrecognized Data"
+msgstr "Dato desnocnocido"
+
+#: pkg/subscriptions/subscriptions-view.jsx:148
+msgid "Unregister"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:154
+#, fuzzy
+msgid "Unregistering system..."
+msgstr "Registrando el sistema"
+
+#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
+#: src/bridge/cockpitdbussetup.c:625
+#, fuzzy
+msgid "Unsupported setup mechanism"
+msgstr "Mecanismo de configuración no soportado: %s"
+
+#: src/base1/cockpit.js:3697
+msgid "Untrusted host"
+msgstr "host inseguro"
+
+#: pkg/docker/util.js:94
+msgid "Up since $StartedAt"
+msgstr "Arriba desde $StartedAt"
+
+#: pkg/lib/machine-change-port.html:41
+msgid "Update"
+msgstr "Actualizar"
+
+#: pkg/ostree/index.html:125 pkg/ostree/index.html:152
+msgid "Updates"
+msgstr "Actualizaciones"
+
+#: pkg/ostree/index.html:96
+msgid "Updating"
+msgstr "Actualizando"
+
+#: pkg/kubernetes/scripts/details.js:655
+msgid "Updating $0..."
+msgstr "Actualizando $0..."
+
+#: pkg/shell/index.html:165
+msgid "Use my password for privileged tasks and to connect to other machines"
+msgstr ""
+"Utiliza mi contraseña para tareas privilegiadas y para conectarse a otras "
+"máquinas"
+
+#: pkg/subscriptions/subscriptions-register.jsx:132
+msgid "Use proxy server"
+msgstr ""
+
+#: pkg/shell/index.html:172
+msgid "Use the following keys to authenticate against other systems"
+msgstr "Use la siguiente llave para autenticarse en otros sistemas"
+
+#: pkg/systemd/index.html:251
+msgid "Used"
+msgstr "Usado"
+
+#: pkg/systemd/index.html:229 pkg/dashboard/index.html:158
+#: pkg/playground/translate.html:86 pkg/playground/translate.html:106
+#: pkg/kubernetes/views/user-panel.html:9
+#: pkg/kubernetes/views/auth-form.html:61
+#: pkg/kubernetes/views/volume-body.html:64
+#: pkg/kubernetes/views/volume-body.html:103
+msgid "User"
+msgstr "Usuario"
+
+#: pkg/users/index.html:90 pkg/users/index.html:154
+#: pkg/realmd/operation.html:47
+msgid "User Name"
+msgstr "Nombre de usuario"
+
+#: pkg/realmd/operation.html:53
+msgid "User Password"
+msgstr "Contraseña de usuario"
+
+#: pkg/lib/machine-change-auth.html:18
+msgid "User name"
+msgstr "Nombre de usuario"
+
+#: pkg/kubernetes/views/add-member-role-dialog.html:15
+msgid "User or Group"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:94
+msgid "Username"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:85
+msgid "Users"
+msgstr ""
+
+#: pkg/storaged/details.js:181
+msgid "VFAT - Compatible with all systems and devices"
+msgstr "VFAT - Compatible con todos los sistemas y dispositivos"
+
+#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
+#: pkg/networkmanager/interfaces.js:2622
+msgid "VLAN"
+msgstr "VLAN"
+
+#: pkg/networkmanager/index.html:141
+msgid "VLAN Id"
+msgstr "VLAN Id"
+
+#: pkg/networkmanager/index.html:736
+msgid "VLAN Settings"
+msgstr "Configuración VLAN"
+
+#: pkg/users/authorized-keys.js:103
+msgid "Validating key"
+msgstr "Validando llave"
+
+#: pkg/systemd/index.html:98 pkg/ostree/index.html:113 pkg/shell/simple.html:77
+#: pkg/shell/index.html:90 pkg/shell/stub.html:83
+msgid "Version"
+msgstr "Versión"
+
+#: pkg/storaged/jobs.js:137
+msgid "Very securely erasing $target"
+msgstr "Borrando de forma muy segura $target"
+
+#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
+#: pkg/kubernetes/views/pvc-body.html:6
+msgid "Volume"
+msgstr ""
+
+#: pkg/storaged/index.html:620
+msgid "Volume Group"
+msgstr "Grupo de Volúmenes"
+
+#: pkg/storaged/utils.js:239
+msgid "Volume Group $0"
+msgstr "Grupo de volúmenes $0 "
+
+#: pkg/storaged/index.html:98
+msgid "Volume Groups"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:14
+#: pkg/kubernetes/views/volume-body.html:89
+msgid "Volume ID"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:115
+#: pkg/kubernetes/views/volume-body.html:42
+msgid "Volume Name"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
+msgid "Volume Type"
+msgstr ""
+
+#: pkg/docker/index.html:536 pkg/kubernetes/views/pod-page.html:18
+#: pkg/kubernetes/views/image-config.html:28
+#: pkg/kubernetes/views/dashboard-page.html:47 pkg/kubernetes/index.html:70
+msgid "Volumes"
+msgstr "Volúmenes"
+
+#: pkg/networkmanager/interfaces.js:819
+msgid "Waiting"
+msgstr "Esperando"
+
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid "Warning:"
+msgstr ""
+
+#: pkg/systemd/logs.html:48
+msgid "Warnings"
+msgstr "Advertencias"
+
+#: pkg/systemd/services.html:409
+msgid "Weeks"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:5
+msgid "Welcome to the Image Registry"
+msgstr "Bienvenidos al Registro de Imagen"
+
+#: pkg/kubernetes/views/volumes-page.html:61
+msgid "When"
+msgstr ""
+
+#: pkg/docker/index.html:507
+msgid "With terminal"
+msgstr "Con terminal"
+
+#: pkg/storaged/index.html:438
+msgctxt "storage"
+msgid "World Wide Name"
+msgstr "World Wide Name"
+
+#: pkg/storaged/details.js:1595
+msgid "Write-mostly"
+msgstr "Escribir casi todo"
+
+#: pkg/storaged/index.html:333
+msgid "Writing"
+msgstr "Escribiendo"
+
+#: pkg/ostree/client.js:64
+msgid "Writing objects"
+msgstr "Escribiendo objetos"
+
+#: pkg/storaged/details.js:177
+msgid "XFS - Red Hat Enterprise Linux 7 default"
+msgstr "XFS - Red Hat Enterprise Linux 7 Predeterminado"
+
+#: pkg/networkmanager/interfaces.js:1824
+msgid "XOR"
+msgstr "XOR"
+
+#: pkg/kubernetes/scripts/volumes.js:990 pkg/networkmanager/interfaces.js:2279
+msgid "Yes"
+msgstr "Sí"
+
+#: pkg/lib/machine-sync-users.html:47
 msgid ""
 "You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
 "synchronize users, a user with superuser privileges is required."
@@ -3662,2336 +6070,49 @@ msgstr ""
 "sincronizar usuarios, es requerido un usuario con privilegios de súper "
 "usuario."
 
-#: pkg/lib/machine-sync-users.html.h:5 pkg/lib/machine-change-auth.html.h:4
-msgid "User name"
-msgstr "Nombre de usuario"
-
-#: pkg/lib/machine-sync-users.html.h:8
-msgid "Synchronize"
-msgstr "Sincronizar"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:1
-msgid "Unknown Host Key"
-msgstr "Host Key desconocido"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:2
+#: pkg/dashboard/list.js:394
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
+"You are currently connected directly to this server. You cannot delete it."
 msgstr ""
-"La autenticidad del host {{#strong}}{{host}}{{/strong}} no se ha podido "
-"establecer.¿Está seguro que desea continuar con la conexión?"
+"Actualmente estás conectado directamente a este servidor. No puedes "
+"eliminarlo."
 
-#: pkg/lib/machine-unknown-hostkey.html.h:3 pkg/shell/index.html.h:4
-msgid "Fingerprint"
-msgstr "Fingerprint"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:5
-#: pkg/kubernetes/views/auth-form.html.h:14
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:6
-msgid "Connect"
-msgstr "Conectar"
-
-#: pkg/lib/machine-add.html.h:1
-msgid "Add Machine to Dashboard"
-msgstr "Agregar Máquina al Tablero de Mandos"
-
-#: pkg/lib/machine-add.html.h:3 pkg/dashboard/index.html.h:9
-msgid "Color"
-msgstr "Color"
-
-#: pkg/lib/machine-add.html.h:4
+#: pkg/kubernetes/views/auth-rejected-cert.html:3
 msgid ""
-"Connecting simultaneously to more than {{ limit }} machines is unsupported."
+"You can bypass the certificate check, but any data you send to the server "
+"could be intercepted by others."
 msgstr ""
-"Conectarse simultáneamente a más de {{ limit }} máquinas no está soportado."
 
-#: pkg/lib/machine-change-port.html.h:1
-msgid "Could not contact {{host}}"
-msgstr "No se puedo contactar {{host}}"
+#: pkg/kubernetes/views/dashboard-page.html:150
+msgid "You can deploy an application to your cluster."
+msgstr "Tu puedes desplegar una aplicación a tu cluster"
 
-#: pkg/lib/machine-change-port.html.h:2
-msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
-msgstr "Cockpit no fue capaz de contactar {{#strong}}{{host}}{{/strong}}."
-
-#: pkg/lib/machine-change-port.html.h:3
+#: pkg/lib/machine-invalid-hostkey.html:11
 msgid ""
-"To try a different port you will need to upgrade cockpit-ws to a newer "
-"version."
+"You can remove the previously stored key by running the following command"
 msgstr ""
-"Para tratar un puerto diferente usted va a necesitar actualizar cockpit-ws a "
-"una nueva versión."
+"Usted puede remover la llave almacenada previamente al correr el siguiente "
+"comando"
 
-#: pkg/lib/machine-change-port.html.h:4
-msgid "Is sshd running on a different port?"
-msgstr "¿sshd está corriendo en un puerto diferente?"
-
-#: pkg/lib/machine-change-port.html.h:7
-msgid "Update"
-msgstr "Actualizar"
-
-#: pkg/lib/machine-not-supported.html.h:1
-msgid "Cockpit is not installed"
-msgstr "Cockpit no esta instalado"
-
-#: pkg/lib/machine-not-supported.html.h:2
-msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
-msgstr ""
-"Una versión compatible de Cockpit no está instalada en {{#strong}}{{host}}{{/"
-"strong}}."
-
-#: pkg/lib/machine-change-auth.html.h:1
-msgid "Log in to {{host}}"
-msgstr "Iniciar sesión en {{host}}"
-
-#: pkg/lib/machine-change-auth.html.h:2
-msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-"Cockpit fue incapaz de iniciar session en {{#strong}}{{host}}{{/strong}}."
-
-#: pkg/lib/machine-change-auth.html.h:3
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:5 pkg/shell/index.html.h:9
-#: pkg/realmd/operation.html.h:3 pkg/kubernetes/views/auth-form.html.h:8
-msgid "Authentication"
-msgstr "Autenticación"
-
-#: pkg/lib/machine-change-auth.html.h:7
-msgid "Available"
-msgstr "Disponible"
-
-#: pkg/lib/machine-change-auth.html.h:8
-msgid "Login Password"
-msgstr "Contraseña de inicio de sesión"
-
-#: pkg/lib/machine-change-auth.html.h:9
-msgid "Kerberos Ticket"
-msgstr "Tiquete Kerberos"
-
-#: pkg/lib/machine-change-auth.html.h:10
-msgid "Checking for public keys"
-msgstr "Chequeando llaves públicas"
-
-#: pkg/lib/machine-change-auth.html.h:12
-msgid "Log In"
-msgstr "Iniciar sesión"
-
-#: pkg/shell/shell.html.h:1
-msgid "Things have moved"
-msgstr ""
-
-#: pkg/shell/index.html.h:2
-msgid "Comment"
-msgstr "Comentario"
-
-#: pkg/shell/index.html.h:5 pkg/shell/stub.html.h:2 pkg/shell/simple.html.h:2
-msgid "Ooops!"
-msgstr "Ooops!"
-
-#: pkg/shell/index.html.h:6 pkg/shell/stub.html.h:3 pkg/shell/simple.html.h:3
-msgid "Display Language"
-msgstr "Mostrar Idioma"
-
-#: pkg/shell/index.html.h:7 pkg/shell/stub.html.h:4 pkg/shell/simple.html.h:4
-msgid "About Cockpit"
-msgstr "Acerca de Cockpit"
-
-#: pkg/shell/index.html.h:8
-msgid "Account Settings"
-msgstr "Configuración de la cuenta"
-
-#: pkg/shell/index.html.h:10 pkg/shell/stub.html.h:5 pkg/shell/simple.html.h:5
-msgid "Log out"
-msgstr "Cerrar sesión"
-
-#: pkg/shell/index.html.h:11 pkg/shell/stub.html.h:6 pkg/shell/simple.html.h:6
-msgid ""
-"\n"
-"              Cockpit is an interactive Linux server admin interface.\n"
-"            "
-msgstr ""
-"\n"
-"              Cockpit es una interfase interactiva para la administración de "
-"servidores Linux.\n"
-"            "
-
-#: pkg/shell/index.html.h:15 pkg/shell/stub.html.h:10
-#: pkg/shell/simple.html.h:10
-msgid "Choose the language to be used in the application"
-msgstr "Seleccione el idioma del idioma a utilizar en la aplicación"
-
-#: pkg/shell/index.html.h:16 pkg/shell/stub.html.h:11
-#: pkg/shell/simple.html.h:11 pkg/storaged/index.html.h:59
-msgid ""
-"\n"
-"              Cancel\n"
-"            "
-msgstr ""
-"\n"
-"              Cancelar\n"
-"            "
-
-#: pkg/shell/index.html.h:19 pkg/shell/stub.html.h:14
-#: pkg/shell/simple.html.h:14
-msgid ""
-"\n"
-"              Select\n"
-"            "
-msgstr ""
-"\n"
-"              Seleccionar\n"
-"            "
-
-#: pkg/shell/index.html.h:22 pkg/shell/stub.html.h:17
-msgid ""
-"\n"
-"              Close\n"
-"            "
-msgstr ""
-"\n"
-"              Cerrar\n"
-"            "
-
-#: pkg/shell/index.html.h:25
-msgid "Use my password for privileged tasks and to connect to other machines"
-msgstr ""
-"Utiliza mi contraseña para tareas privilegiadas y para conectarse a otras "
-"máquinas"
-
-#: pkg/shell/index.html.h:26
-msgid "Use the following keys to authenticate against other systems"
-msgstr "Use la siguiente llave para autenticarse en otros sistemas"
-
-#: pkg/shell/index.html.h:29 pkg/kubernetes/index.html.h:6
-msgid "Details"
-msgstr "Detalles"
-
-#: pkg/shell/index.html.h:32
-msgid "Unlock Key"
-msgstr "Llave de Desbloqueo"
-
-#: pkg/shell/index.html.h:33 pkg/users/index.html.h:23
-msgid "Old Password"
-msgstr "Contraseña vieja"
-
-#: pkg/shell/index.html.h:34 pkg/users/index.html.h:24
-msgid "New Password"
-msgstr "Nueva contraseña"
-
-#: pkg/shell/index.html.h:35 pkg/users/index.html.h:19
-msgid "Confirm"
-msgstr "Confirmar"
-
-#: pkg/shell/index.html.h:36
-msgid "Change Password"
-msgstr "Cambie la Contraseña"
-
-#: pkg/shell/index.html.h:38 pkg/shell/stub.html.h:20
-msgid ""
-"\n"
-"                Tools\n"
-"              "
-msgstr ""
-"\n"
-"                Herramientas\n"
-"              "
-
-#: pkg/shell/index.html.h:41 pkg/shell/stub.html.h:23
-#: pkg/shell/simple.html.h:24
-msgid "Reconnect"
-msgstr "Reconectarse"
-
-#: pkg/shell/index.html.h:42 pkg/shell/stub.html.h:24
-msgid "Troubleshoot"
-msgstr "Soporte"
-
-#: pkg/shell/simple.html.h:18
-msgid ""
-"\n"
-"              Try to reconnect\n"
-"            "
-msgstr ""
-"\n"
-"              Intentado reconectarse\n"
-"            "
-
-#: pkg/shell/simple.html.h:21
-msgid ""
-"\n"
-"              Log in again\n"
-"            "
-msgstr ""
-"\n"
-"              Accediendo nuevamente\n"
-"            "
-
-#: pkg/ostree/index.html.h:1
-msgid "Software Updates"
-msgstr "Actualizaciones de Software"
-
-#: pkg/ostree/index.html.h:2
-msgid "Check for updates"
-msgstr "Buscar actualizaciones"
-
-#: pkg/ostree/index.html.h:3
-msgid ""
-"\n"
-"                    Update and reboot\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:6
-msgid "Roll back and reboot"
-msgstr "Retroceder y reiniciar"
-
-#: pkg/ostree/index.html.h:8
-msgid ""
-"\n"
-"                    Default\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:11
-msgid ""
-"\n"
-"                    Available\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:16
-msgid "Tree"
-msgstr "Árbol"
-
-#: pkg/ostree/index.html.h:17
-msgid "Packages"
-msgstr "Paquetes"
-
-#: pkg/ostree/index.html.h:20
-msgid "Released"
-msgstr "Lanzado"
-
-#: pkg/ostree/index.html.h:21
-msgid "Additions"
-msgstr "Añadidos"
-
-#: pkg/ostree/index.html.h:22
-msgid "Removals"
-msgstr "Removidos"
-
-#: pkg/ostree/index.html.h:23
-msgid "Updates"
-msgstr "Actualizaciones"
-
-#: pkg/ostree/index.html.h:24
-msgid "Downgrades"
-msgstr ""
-
-#: pkg/ostree/index.html.h:25
-msgid ""
-"\n"
-"                    This deployment contains the same packages as your "
-"currently booted system\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:28
-msgid "Operating System Updates"
-msgstr "Actualizaciones de Sistema Operativo"
-
-#: pkg/ostree/index.html.h:29
-msgid "Connecting"
-msgstr ""
-
-#: pkg/ostree/index.html.h:30
-msgid "Unable to communicate with OSTree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:31
-msgid "No Deployments"
-msgstr "No hay Despliegues"
-
-#: pkg/ostree/index.html.h:32
-msgid ""
-"\n"
-"                    Reconnect\n"
-"                "
-msgstr "Reconectar"
-
-#: pkg/selinux/setroubleshoot.html.h:1
-msgid "SELinux Troubleshoot"
-msgstr ""
-
-#: pkg/machines/index.html.h:1
-msgid "Virtual Machines Management"
-msgstr ""
-
-#: pkg/storaged/index.html.h:1
-msgid "Storage"
-msgstr "Almacenamiento"
-
-#: pkg/storaged/index.html.h:2
-msgid "The \"storaged\" API is not available on this system."
-msgstr ""
-
-#: pkg/storaged/index.html.h:3
-msgid "Start Multipath"
-msgstr ""
-
-#: pkg/storaged/index.html.h:4
-msgid ""
-"\n"
-"        There are devices with multiple paths on the system, but the "
-"multipath service is not running.\n"
-"      "
-msgstr ""
-
-#: pkg/storaged/index.html.h:7
-msgid "RAID Devices"
-msgstr "Dispositivos RAID"
-
-#: pkg/storaged/index.html.h:8
-msgid "No storage set up as RAID"
-msgstr ""
-
-#: pkg/storaged/index.html.h:9
-msgid "Volume Groups"
-msgstr ""
-
-#: pkg/storaged/index.html.h:10
-msgid "No volume groups created"
-msgstr ""
-
-#: pkg/storaged/index.html.h:11
-msgid "iSCSI Targets"
-msgstr ""
-
-#: pkg/storaged/index.html.h:12
-msgid "{{Address}}:{{Port}}"
-msgstr "{{Address}}:{{Port}}"
-
-#: pkg/storaged/index.html.h:13
-msgid "No iSCSI targets set up"
-msgstr ""
-
-#: pkg/storaged/index.html.h:14
-msgid "Drives"
-msgstr "Discos"
-
-#: pkg/storaged/index.html.h:15
-msgid "No drives attached"
-msgstr "No hay dispositivos adjuntos"
-
-#: pkg/storaged/index.html.h:16
-msgid "Other Devices"
-msgstr "Otros dispositivos"
-
-#: pkg/storaged/index.html.h:17
-msgid "Filesystems"
-msgstr "Archivos del sistema"
-
-#: pkg/storaged/index.html.h:21
-msgid "Jobs"
-msgstr "Trabajos"
-
-#: pkg/storaged/index.html.h:23 pkg/networkmanager/index.html.h:3
-msgid "Go to now"
-msgstr "Ir a ahora"
-
-#: pkg/storaged/index.html.h:24 pkg/networkmanager/index.html.h:4
-msgid "5 minutes"
-msgstr "5 minutos"
-
-#: pkg/storaged/index.html.h:25 pkg/networkmanager/index.html.h:5
-msgid "1 hour"
-msgstr "1 hora"
-
-#: pkg/storaged/index.html.h:26 pkg/networkmanager/index.html.h:6
-msgid "6 hours"
-msgstr "6 horas"
-
-#: pkg/storaged/index.html.h:27 pkg/networkmanager/index.html.h:7
-msgid "1 day"
-msgstr "1 día"
-
-#: pkg/storaged/index.html.h:28 pkg/networkmanager/index.html.h:8
-msgid "1 week"
-msgstr "1 semana"
-
-#: pkg/storaged/index.html.h:29
-msgid "Reading"
-msgstr "Leyendo"
-
-#: pkg/storaged/index.html.h:30
-msgid "Writing"
-msgstr "Escribiendo"
-
-#: pkg/storaged/index.html.h:31
-msgid "Storage Logs"
-msgstr "Bitácoras de Almacenamiento"
-
-#: pkg/storaged/index.html.h:32
-msgid "Create partition table"
-msgstr "Crear tabla de particiones"
-
-#: pkg/storaged/index.html.h:34
-msgid "Block Device"
-msgstr "Dispositivo de Bloque"
-
-#: pkg/storaged/index.html.h:40
-msgid "No media inserted"
-msgstr "No hay media insertada"
-
-#: pkg/storaged/index.html.h:42
-msgid "DISK IS FAILING"
-msgstr "DISCO ESTÁ FALLANDO"
-
-#: pkg/storaged/index.html.h:43
-msgid "Disk is OK"
-msgstr "Disco está OK"
-
-#: pkg/storaged/index.html.h:46
-msgid "The RAID Array is in a degraded state"
+#: pkg/shell/base_index.js:672
+msgid "You can try restarting Cockpit by pressing refresh in your browser. "
 msgstr ""
-
-#: pkg/storaged/index.html.h:47
-msgid "RAID Device"
-msgstr "Dispositivo RAID"
-
-#: pkg/storaged/index.html.h:56
-msgid "Volume Group"
-msgstr "Grupo de Volúmenes"
-
-#: pkg/storaged/index.html.h:57
-msgid "Physical Volumes"
-msgstr "Volúmenea Físicos"
-
-#: pkg/storaged/index.html.h:58
-msgid "Storage Log"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:1
-msgid "Domain Address"
-msgstr "Dirección de Dominio"
-
-#: pkg/realmd/operation.html.h:2
-msgid "Computer OU"
-msgstr "Computadora OU"
-
-#: pkg/realmd/operation.html.h:4 pkg/users/index.html.h:11
-msgid "User Name"
-msgstr "Nombre de usuario"
-
-#: pkg/realmd/operation.html.h:5
-msgid "User Password"
-msgstr "Contraseña de usuario"
-
-#: pkg/realmd/operation.html.h:6
-msgid "Domain Administrator Name"
-msgstr "Nombre del Administrador de Dominio"
-
-#: pkg/realmd/operation.html.h:7
-msgid "Domain Administrator Password"
-msgstr "Contraseña del Administrador de Dominio"
-
-#: pkg/realmd/operation.html.h:8
-msgid "One Time Password"
-msgstr "Contraseña de un solo uso"
-
-#: pkg/realmd/operation.html.h:9
-msgid "This may take a while"
-msgstr "Esto podría tomar un momento"
-
-#: pkg/docker/index.html.h:1 pkg/kubernetes/index.html.h:4
-#: pkg/kubernetes/views/containers-listing.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:6
-#: pkg/kubernetes/views/dashboard-page.html.h:17
-msgid "Containers"
-msgstr "Contenedores"
-
-#: pkg/docker/index.html.h:2
-msgid "Connecting to Docker"
-msgstr "Conectando a Docker"
-
-#: pkg/docker/index.html.h:3
-msgid "Not authorized to access Docker on this system"
-msgstr "No esta autorizado a acceder a Docker en este sistema"
-
-#: pkg/docker/index.html.h:4
-msgid "Docker is not installed or activated on the system"
-msgstr "Docker no esta instalado o no esta activo en el sistema"
-
-#: pkg/docker/index.html.h:5
-msgid "Can&rsquo;t connect to Docker"
-msgstr ""
-
-#: pkg/docker/index.html.h:6
-msgid "Start Docker"
-msgstr "Iniciar a Docker"
-
-#: pkg/docker/index.html.h:7
-msgid "Try again"
-msgstr "Intentar nuevamente"
-
-#: pkg/docker/index.html.h:8
-msgid "Combined CPU usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:9
-msgid "Combined memory usage"
-msgstr "Uso de memoria combinado"
-
-#: pkg/docker/index.html.h:10
-#, fuzzy
-msgid "Show all containers"
-msgstr "Mostrar todas las imágenes"
-
-#: pkg/docker/index.html.h:11
-msgid "IP Address:"
-msgstr ""
-
-#: pkg/docker/index.html.h:12
-msgid "IP Prefix Length:"
-msgstr ""
-
-#: pkg/docker/index.html.h:13
-msgid "Gateway:"
-msgstr ""
-
-#: pkg/docker/index.html.h:14
-msgid "MAC Address:"
-msgstr ""
-
-#: pkg/docker/index.html.h:15 pkg/kubernetes/views/image-page.html.h:1
-msgid "Show all images"
-msgstr "Mostrar todas las imágenes"
-
-#: pkg/docker/index.html.h:16 pkg/kubernetes/index.html.h:2
-#: pkg/kubernetes/registry.html.h:2
-msgid "Overview"
-msgstr ""
-
-#: pkg/docker/index.html.h:17
-msgid "Reset"
-msgstr "Reiniciar"
-
-#: pkg/docker/index.html.h:18
-msgid "Storage pool"
-msgstr ""
-
-#: pkg/docker/index.html.h:19
-msgid "Additional Storage"
-msgstr ""
-
-#: pkg/docker/index.html.h:20
-msgid "TCP"
-msgstr ""
-"TCP: Protocolo de Control de Transmisión, por sus siglas en ingles "
-"(Transmission Control Protocol)"
-
-#: pkg/docker/index.html.h:21
-msgid "{{host_port_label}}"
-msgstr "{{host_port_label}}"
-
-#: pkg/docker/index.html.h:22
-msgid "{{host_volume_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:24
-msgid "ReadWrite"
-msgstr ""
-
-#: pkg/docker/index.html.h:25
-msgid "ReadOnly"
-msgstr ""
-
-#: pkg/docker/index.html.h:26
-msgid "{{envvar_key_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:27
-msgid "{{envvar_value_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:28
-msgid "select container"
-msgstr "seleccionar contenedor"
-
-#: pkg/docker/index.html.h:29
-msgid "{{alias_label}}"
-msgstr "{{alias_label}}"
-
-#: pkg/docker/index.html.h:30 pkg/kubernetes/views/image-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:2
-#: pkg/kubernetes/views/image-page.html.h:2
-msgid "Image"
-msgstr "Imagén"
-
-#: pkg/docker/index.html.h:31
-msgid "Container Name"
-msgstr "Nombre del Contenedor"
-
-#: pkg/docker/index.html.h:33
-msgid "Memory limit"
-msgstr "Limite de Memoria "
-
-#: pkg/docker/index.html.h:34
-msgid "MiB"
-msgstr ""
-
-#: pkg/docker/index.html.h:35
-msgid "CPU priority"
-msgstr "Prioridad del CPU"
-
-#: pkg/docker/index.html.h:36
-msgid "shares"
-msgstr ""
-
-#: pkg/docker/index.html.h:37
-msgid "With terminal"
-msgstr "Con terminal"
-
-#: pkg/docker/index.html.h:38
-msgid "Links"
-msgstr "Vinculos"
-
-#: pkg/docker/index.html.h:40
-msgid "Expose container ports"
-msgstr ""
-
-#: pkg/docker/index.html.h:41 pkg/kubernetes/index.html.h:7
-#: pkg/kubernetes/views/image-config.html.h:9
-#: pkg/kubernetes/views/pod-page.html.h:3
-#: pkg/kubernetes/views/dashboard-page.html.h:4
-msgid "Volumes"
-msgstr "Volúmenes"
-
-#: pkg/docker/index.html.h:42
-msgid "Mount container volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:43 pkg/kubernetes/views/image-config.html.h:6
-#: pkg/kubernetes/views/container-body.html.h:9
-msgid "Environment"
-msgstr "Entorno"
-
-#: pkg/docker/index.html.h:44
-msgid "Set container environment variables"
-msgstr ""
-
-#: pkg/docker/index.html.h:45 pkg/kubernetes/views/pod-body.html.h:4
-msgid "Restart Policy"
-msgstr ""
-
-#: pkg/docker/index.html.h:47
-msgid "On Failure"
-msgstr ""
-
-#: pkg/docker/index.html.h:50
-msgid "Retries:"
-msgstr ""
-
-#: pkg/docker/index.html.h:51 pkg/users/index.html.h:26
-#: pkg/networkmanager/index.html.h:52
-msgid ""
-"\n"
-"            Cancel\n"
-"          "
-msgstr ""
-"\n"
-"            Cancelar\n"
-"          "
-
-#: pkg/docker/index.html.h:54
-msgid ""
-"\n"
-"            Run\n"
-"          "
-msgstr ""
-"\n"
-"            Correr\n"
-"          "
-
-#: pkg/docker/index.html.h:57
-msgid ""
-"\n"
-"            Download\n"
-"          "
-msgstr ""
-"\n"
-"            Descargar\n"
-"          "
-
-#: pkg/docker/index.html.h:60
-msgid ""
-"\n"
-"            Change\n"
-"          "
-msgstr ""
-"\n"
-"            Cambiar\n"
-"          "
-
-#: pkg/docker/index.html.h:63
-msgid "Repository"
-msgstr "Repositorio"
-
-#: pkg/docker/index.html.h:64
-msgid "Tag"
-msgstr "Etiquetas"
-
-#: pkg/docker/index.html.h:65 pkg/kubernetes/views/image-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:5
-msgid "Author"
-msgstr "Autor"
-
-#: pkg/docker/index.html.h:66
-msgid ""
-"\n"
-"            Commit\n"
-"          "
-msgstr ""
-"\n"
-"            Commit\n"
-"          "
-
-#: pkg/users/index.html.h:1
-msgid "Local Accounts"
-msgstr "Cuentas Locales"
-
-#: pkg/users/index.html.h:2
-msgid ""
-"\n"
-"            Close\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:5
-msgid "Create New Account"
-msgstr "Crear nueva Cuenta"
-
-#: pkg/users/index.html.h:6
-msgid "Account not available or cannot be edited."
-msgstr "Cuenta no disponible o no puede ser editada"
-
-#: pkg/users/index.html.h:7
-msgid "Accounts"
-msgstr "Cuentas"
-
-#: pkg/users/index.html.h:8
-msgid "Terminate Session"
-msgstr "Terminar sesión"
-
-#: pkg/users/index.html.h:10
-msgid "Full Name"
-msgstr "Nombre Completo"
-
-#: pkg/users/index.html.h:12
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:3
-#: pkg/kubernetes/views/project-body.html.h:2
-msgid "Roles"
-msgstr "Roles"
-
-#: pkg/users/index.html.h:13
-msgid "Last Login"
-msgstr "Último inicio de sesión"
-
-#: pkg/users/index.html.h:14
-msgid "Access"
-msgstr "Acceder"
-
-#: pkg/users/index.html.h:15
-msgid "Lock Account"
-msgstr "Bloquear Cuenta"
-
-#: pkg/users/index.html.h:17
-msgid "Set Password"
-msgstr "Establecer contraseña"
-
-#: pkg/users/index.html.h:18
-msgid "Authorized Public SSH Keys"
-msgstr "Llaves SSH Públicas Autorizadas"
-
-#: pkg/users/index.html.h:20
-msgid ""
-"\n"
-"            Create\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:25
-msgid "Confirm New Password"
-msgstr "Confirmar Nueva Contraseña"
-
-#: pkg/users/index.html.h:29
-msgid ""
-"\n"
-"            Set\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:32
-msgid "Delete Files"
-msgstr "Borrar Ficheros"
-
-#: pkg/users/index.html.h:33 pkg/networkmanager/index.html.h:48
-msgid ""
-"\n"
-"            Delete\n"
-"          "
-msgstr ""
-"\n"
-"            Eliminar\n"
-"          "
-
-#: pkg/users/index.html.h:36
-msgid "Unnamed"
-msgstr "Sin nombre"
-
-#: pkg/users/index.html.h:37
-msgid "Invalid key"
-msgstr "Llave inválida"
-
-#: pkg/users/index.html.h:38
-msgid "There are no authorized public keys for this account."
-msgstr "No hay llaves públicas autorizadas para esta cuenta."
+"Puedes intentar reiniciando Cockpit presionando refrescar en tu navegador."
 
-#: pkg/users/index.html.h:39
+#: pkg/users/index.html:335
 msgid ""
 "You do not have permission to view the authorized public keys for this "
 "account."
 msgstr ""
 "No tiene permiso para ver las llaves públicas autorizadas para esta cuenta."
 
-#: pkg/users/index.html.h:40
-msgid "Failed to load authorized keys."
-msgstr "Fallo al cargar llaves autorizadas."
-
-#: pkg/users/index.html.h:41
-msgid "Add public key"
-msgstr "Agregar llave pública"
-
-#: pkg/users/index.html.h:42
-msgid ""
-"\n"
-"            Add key\n"
-"          "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:1
-msgid "Diagnostic reports"
-msgstr "Reportes de diagnostico"
-
-#: pkg/sosreport/index.html.h:2
-msgid ""
-"\n"
-"        This tool will collect system configuration and diagnostic\n"
-"        information from this system for use with diagnosing problems\n"
-"        with the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:7
-msgid ""
-"\n"
-"        The collected information will be stored locally on the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:10
-msgid "Create report"
-msgstr "Crear reporte"
-
-#: pkg/sosreport/index.html.h:11
-msgid "Create diagnostic report"
-msgstr "Crear reporte de diagnóstico"
-
-#: pkg/sosreport/index.html.h:12
-msgid ""
-"\n"
-"                The generated archive contains data considered\n"
-"                sensitive and its content should be reviewed by the\n"
-"                originating organization before being passed to any\n"
-"                third party.\n"
-"              "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:18
-msgid "Generating report"
-msgstr "Generando reporte"
-
-#: pkg/sosreport/index.html.h:19
-msgid "Done!"
-msgstr "Hecho!"
-
-#: pkg/networkmanager/index.html.h:1
-msgid "Networking"
-msgstr "Redes"
-
-#: pkg/networkmanager/index.html.h:2
-msgid "Testing connection"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:9
-msgid "Sending"
-msgstr "Enviando"
-
-#: pkg/networkmanager/index.html.h:10
-msgid "Receiving"
-msgstr "Recibiendo"
-
-#: pkg/networkmanager/index.html.h:11
-msgid "Interfaces"
-msgstr "Interfaces"
-
-#: pkg/networkmanager/index.html.h:12
-msgid "Add Bond"
-msgstr "Añadir vínculo"
-
-#: pkg/networkmanager/index.html.h:13
+#: pkg/docker/storage.jsx:482
 #, fuzzy
-msgid "Add Team"
-msgstr "Agregar Miembro"
-
-#: pkg/networkmanager/index.html.h:14
-msgid "Add Bridge"
-msgstr "Añadir Puente"
-
-#: pkg/networkmanager/index.html.h:15
-msgid "Add VLAN"
-msgstr "Añadir VLAN"
-
-#: pkg/networkmanager/index.html.h:17
-msgid "IP Address"
-msgstr "Dirección IP"
-
-#: pkg/networkmanager/index.html.h:18
-#, fuzzy
-msgid "Unmanaged Interfaces"
-msgstr "Interfaces"
-
-#: pkg/networkmanager/index.html.h:19
-msgid "Networking Logs"
-msgstr "Registros de redes"
-
-#: pkg/networkmanager/index.html.h:20
-msgid "Parent"
-msgstr "Padre"
-
-#: pkg/networkmanager/index.html.h:21
-msgid "VLAN Id"
-msgstr "VLAN Id"
-
-#: pkg/networkmanager/index.html.h:23
-msgid "Set to"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:25
-msgid "Spanning Tree Protocol (STP)"
-msgstr "Spanning Tree Protocol (STP)"
-
-#: pkg/networkmanager/index.html.h:26
-msgid "STP Priority"
-msgstr "Prioridad STP"
-
-#: pkg/networkmanager/index.html.h:27
-msgid "STP Forward delay"
-msgstr "Retardo del reenvío STP"
-
-#: pkg/networkmanager/index.html.h:28
-msgid "STP Hello time"
-msgstr "Tiempo de saludo STP"
-
-#: pkg/networkmanager/index.html.h:29
-msgid "STP Maximum message age"
-msgstr "Edad máxima del mensaje STP"
-
-#: pkg/networkmanager/index.html.h:30
-msgid "Priority"
-msgstr "Prioridad"
-
-#: pkg/networkmanager/index.html.h:31
-msgid "Path cost"
-msgstr "Costo ruta"
-
-#: pkg/networkmanager/index.html.h:32
-msgid "Hair Pin mode"
-msgstr "Modo horquilla"
-
-#: pkg/networkmanager/index.html.h:34
-msgid "Mode"
-msgstr "Modo"
-
-#: pkg/networkmanager/index.html.h:35
-msgid "Primary"
-msgstr "Primario"
-
-#: pkg/networkmanager/index.html.h:36
-msgid "Link Monitoring"
-msgstr "Monitorear enlace"
-
-#: pkg/networkmanager/index.html.h:37
-msgid "Monitoring Interval"
-msgstr "Monitorear intervalo"
-
-#: pkg/networkmanager/index.html.h:38
-msgid "Monitoring Targets"
-msgstr "Monitorear objetivos"
-
-#: pkg/networkmanager/index.html.h:39
-msgid "Link up delay"
-msgstr "Vincular demora"
-
-#: pkg/networkmanager/index.html.h:40
-msgid "Link down delay"
-msgstr "Desvincular demora"
-
-#: pkg/networkmanager/index.html.h:41
-#, fuzzy
-msgid "Runner"
-msgstr "Corriendo"
-
-#: pkg/networkmanager/index.html.h:42
-msgid "Balancer"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:43
-#, fuzzy
-msgid "Link Watch"
-msgstr "Enlace local"
-
-#: pkg/networkmanager/index.html.h:44
-#, fuzzy
-msgid "Ping Interval"
-msgstr "Monitorear intervalo"
-
-#: pkg/networkmanager/index.html.h:45
-#, fuzzy
-msgid "Ping Target"
-msgstr "Bloquendo $target"
-
-#: pkg/networkmanager/index.html.h:46
-msgid "Sticky"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:47
-msgid "LACP Key"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:51
-msgid "IP Settings"
-msgstr "Configuración IP"
-
-#: pkg/networkmanager/index.html.h:55
-msgid ""
-"\n"
-"            Apply\n"
-"          "
-msgstr ""
-"\n"
-"            Aplicar\n"
-"          "
-
-#: pkg/networkmanager/index.html.h:58
-msgid "Bond Settings"
-msgstr "Configuración Bond"
-
-#: pkg/networkmanager/index.html.h:59
-#, fuzzy
-msgid "Team Settings"
-msgstr "Configuración IP"
-
-#: pkg/networkmanager/index.html.h:60
-#, fuzzy
-msgid "Team Port Settings"
-msgstr "Configuración del puerto Bridge"
-
-#: pkg/networkmanager/index.html.h:61
-msgid "Bridge Settings"
-msgstr "Configuración Bridge"
-
-#: pkg/networkmanager/index.html.h:62
-msgid "Bridge Port Settings"
-msgstr "Configuración del puerto Bridge"
-
-#: pkg/networkmanager/index.html.h:63
-msgid "VLAN Settings"
-msgstr "Configuración VLAN"
-
-#: pkg/networkmanager/index.html.h:64
-msgid "Ethernet MTU"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:66
-#, fuzzy
-msgid "Connection will be lost"
-msgstr "La conexión ha caducado"
-
-#: pkg/kubernetes/index.html.h:1
-msgid "Kubernetes Cluster"
-msgstr "Cluster de Kubernetes"
-
-#: pkg/kubernetes/index.html.h:3 pkg/kubernetes/views/dashboard-page.html.h:8
-#: pkg/kubernetes/views/nodes-page.html.h:4
-msgid "Nodes"
-msgstr "Nodos"
-
-#: pkg/kubernetes/index.html.h:5
-msgid "Topology"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:8 pkg/kubernetes/registry.html.h:3
-#: pkg/kubernetes/views/image-listing.html.h:2
-#: pkg/kubernetes/views/imagestream-page.html.h:3
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:5
-msgid "Images"
-msgstr "Imágenes"
-
-#: pkg/kubernetes/index.html.h:9 pkg/kubernetes/registry.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:2
-#: pkg/kubernetes/views/project-listing.html.h:2
-#: pkg/kubernetes/views/user-delete.html.h:2
-msgid "Projects"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:11 pkg/kubernetes/registry.html.h:6
-msgid "Couldn't connect to server"
-msgstr "No se pudo conectar al servidor"
-
-#: pkg/kubernetes/index.html.h:12 pkg/kubernetes/registry.html.h:7
-msgid ""
-"\n"
-"                Reconnect\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:15
-msgid ""
-"\n"
-"                Troubleshoot\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/registry.html.h:1
-msgid "Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:1
-#: pkg/kubernetes/views/service-body.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:1
-#: pkg/kubernetes/views/containers-listing.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:9
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:18
-#: pkg/kubernetes/views/route-body.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:5
-#: pkg/kubernetes/views/imagestream-modify.html.h:4
-msgid "Project"
-msgstr "Proyecto"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:2
-#: pkg/kubernetes/views/service-body.html.h:2
-#: pkg/kubernetes/views/pod-body.html.h:2
-#: pkg/kubernetes/views/containers-listing.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:10
-#: pkg/kubernetes/views/pv-claim.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:19
-#: pkg/kubernetes/views/route-body.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:6
-msgid "Namespace"
-msgstr "Espacio de Nombres"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:3
-#: pkg/kubernetes/views/pod-body.html.h:3
-#: pkg/kubernetes/views/node-body.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:3
-#: pkg/kubernetes/views/route-body.html.h:3
-msgid "Created"
-msgstr "Creado"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:4
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:17
-msgid "Replicas"
-msgstr "Réplicas"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:5
-#: pkg/kubernetes/views/service-body.html.h:9
-#: pkg/kubernetes/views/pod-body.html.h:10
-#: pkg/kubernetes/views/node-body.html.h:12
-#: pkg/kubernetes/views/image-meta.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:8
-#: pkg/kubernetes/views/route-body.html.h:8
-msgid "Labels"
-msgstr "Viñetas"
-
-#: pkg/kubernetes/views/service-body.html.h:4
-#: pkg/kubernetes/views/node-body.html.h:3
-msgid "IP"
-msgstr "IP"
-
-#: pkg/kubernetes/views/service-body.html.h:8
-msgid "Session Affinity"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:1
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:10
-msgid "New image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:3
-#: pkg/kubernetes/views/image-body.html.h:10
-#: pkg/kubernetes/views/imagestream-modify.html.h:7
-msgid "Tags"
-msgstr "Etiquetas"
-
-#: pkg/kubernetes/views/image-listing.html.h:5
-msgid "Last Updated"
-msgstr "Última Actualización"
-
-#: pkg/kubernetes/views/image-listing.html.h:6
-msgid "No image streams are present."
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:1
-msgid "Delete Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:2
-msgid "Do you want to delete this Node?"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:3
-msgid " 1\">Do you want to delete the following Nodes?"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-container.html.h:1
-msgid "Show all Pod Containers"
-msgstr ""
-
-#: pkg/kubernetes/views/image-panel.html.h:3
-#: pkg/kubernetes/views/imagestream-page.html.h:4
-#: pkg/kubernetes/views/image-page.html.h:4
-msgid "Metadata"
-msgstr ""
-
-#: pkg/kubernetes/views/node-panel.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:8
-#: pkg/kubernetes/views/containers-listing.html.h:6
-#: pkg/kubernetes/views/node-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:11
-msgid "Node"
-msgstr "Nodo"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:1
-msgid "Show all Replication Controllers"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:2
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:5
-msgid "Replication Controller"
-msgstr "Contolador de replicación"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:2
-#: pkg/kubernetes/views/pv-claim.html.h:9
-#: pkg/kubernetes/views/dashboard-page.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:18
-msgid "Pods"
-msgstr "Ranuras"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:2
-msgid "Template"
-msgstr "Plantilla"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:5
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/group-delete.html.h:1
-msgid "Remove Group"
-msgstr ""
-
-#: pkg/kubernetes/views/group-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:5
-#: pkg/kubernetes/views/user-group-remove.html.h:3
-msgid "Remove"
-msgstr "Eliminar"
-
-#: pkg/kubernetes/views/pvc-delete.html.h:1
-msgid "Delete Persistent Volume Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:2
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:3
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:5
-msgid "Service Account"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:6
-msgid "DNS Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:7
-msgid "Phase"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:9
-msgid "Pod Address"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:5
-msgid "OS"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:7
-msgid "Boot ID"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:8
-msgid "Kernel Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:9
-msgid "Container Runtime Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:10
-msgid "Kubelet Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:11
-msgid "Proxy Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:13
-#: pkg/kubernetes/views/route-body.html.h:9
-msgid "none"
-msgstr "ninguno"
-
-#: pkg/kubernetes/views/node-body.html.h:17
-msgid "Reason"
-msgstr "Razón"
-
-#: pkg/kubernetes/views/node-body.html.h:18
-#: pkg/kubernetes/views/pv-claim.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:6 pkg/kubernetes/views/pv-body.html.h:6
-msgid "Message"
-msgstr "Mensaje"
-
-#: pkg/kubernetes/views/node-body.html.h:19
-msgid "Last Heartbeat"
-msgstr "Último Heartbeat"
-
-#: pkg/kubernetes/views/node-body.html.h:20
-msgid "Last Status Change"
-msgstr "Último Cambio de Estado"
-
-#: pkg/kubernetes/views/node-body.html.h:21
-#: pkg/kubernetes/views/image-meta.html.h:3
-#: pkg/kubernetes/views/imagestream-meta.html.h:1
-#: pkg/kubernetes/views/route-body.html.h:10
-msgid "Annotations"
-msgstr "Anotaciones"
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:1
-msgid "Remove Role"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:2
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member "
-"{{ fields.member.metadata.name }}?"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:1
-msgid "New Project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:6
-msgid "No projects are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:7
-msgid "New Group"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:8
-#: pkg/kubernetes/views/user-delete.html.h:3
-msgid "Groups"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:9
-msgid "No groups are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:10
-#: pkg/kubernetes/views/add-user-dialog.html.h:1
-msgid "Add User"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:11
-msgid "Users"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:12
-msgid "Identity"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:13
-msgid "Member of"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:14
-msgid "No users are present."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:1
-msgid "Cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:2
-msgid "Add New Cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:4
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:3
-msgid "Skip Certificate Verification"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:5
-msgid "Requires Authentication"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:7
-msgid "Add New User"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:9
-msgid "Client Certificate"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:10
-msgid "Username"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:12
-msgid "Token"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:1
-msgid "Add Cluster Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:4
-msgid "Configuration"
-msgstr "Configuración"
-
-#: pkg/kubernetes/views/node-add.html.h:5
-msgid "Configure Kubelet and Proxy"
-msgstr "Configurar Kubelet y proxy"
-
-#: pkg/kubernetes/views/node-add.html.h:6
-msgid "Configure Flannel networking"
-msgstr "Configurar la red Flannel"
-
-#: pkg/kubernetes/views/volume-body.html.h:1
-#: pkg/kubernetes/views/pvc-body.html.h:1
-msgid "Volume Type"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:2
-msgid "{{ volume | formatVolumeType }}"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:3
-msgid "PD Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:19
-msgid "Filesystem Type"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:6
-#: pkg/kubernetes/views/pv-modify.html.h:20
-msgid "Read Only"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:7
-msgid "Volume ID"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:8
-msgid "Repository URL"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:9
-msgid "Revision"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:10
-#: pkg/kubernetes/views/image-config.html.h:3
-msgid "Directory"
-msgstr "Directorio"
-
-#: pkg/kubernetes/views/volume-body.html.h:12
-msgid "Medium"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:13
-#: pkg/kubernetes/views/pv-modify.html.h:14
-msgid "Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:14
-msgid "Endpoint Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:15
-#: pkg/kubernetes/views/pv-modify.html.h:13
-msgid "Volume Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:17
-msgid "Monitors"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:18
-msgid "Image Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:19
-msgid "Pool Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:21
-msgid "Key Ring Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:22
-msgid "Secret Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:23
-msgid "Target Portal"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:24
-#: pkg/kubernetes/views/pv-modify.html.h:16
-msgid "Qualified Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:25
-#: pkg/kubernetes/views/pv-modify.html.h:17
-msgid "Logical Unit Number"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:26
-#: pkg/kubernetes/views/pv-modify.html.h:18
-msgid "Interface"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:27
-msgid "Ceph Monitors"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:28
-msgid "Secret File"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:29
-msgid "Target World Wide Names"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:30
-msgid "Flocker Dataset Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:31
-msgid "Driver"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:33
-msgid "Share Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:34
-msgid "Secret Name"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:2
-msgid "On Build"
-msgstr "En Construcción"
-
-#: pkg/kubernetes/views/image-meta.html.h:4
-msgid "Docker Version"
-msgstr "Versión de Docker"
-
-#: pkg/kubernetes/views/image-meta.html.h:5
-msgid "Image Layers"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:1
-#: pkg/kubernetes/views/user-page.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:1
-msgid "Show all Projects"
+msgid "You don't have permission to manage the Docker storage pool."
 msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:2
-#: pkg/kubernetes/views/group-panel.html.h:1
-msgid "Group Members"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:3
-#: pkg/kubernetes/views/user-group-add.html.h:1
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:1
-#: pkg/kubernetes/views/group-panel.html.h:2
-#: pkg/kubernetes/views/project-body.html.h:10
-msgid "Add Member"
-msgstr "Agregar Miembro"
-
-#: pkg/kubernetes/views/group-page.html.h:4
-msgid "The group '{{ groupName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/containers-listing.html.h:3
-#: pkg/kubernetes/views/pod-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:2
-msgid "Pod"
-msgstr "Ranura"
-
-#: pkg/kubernetes/views/user-body.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:2
-msgid "Membership"
-msgstr "Afiliación"
-
-#: pkg/kubernetes/views/user-body.html.h:2
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:5
-#: pkg/kubernetes/views/user-panel.html.h:7
-msgid "Add Membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-group-add.html.h:2
-msgid ""
-"\n"
-"                        User\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:2
-msgid "User or Group"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-panel.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:4
-msgid "Mount Location"
-msgstr ""
-
-#: pkg/kubernetes/views/route-modify.html.h:1
-msgid "Adjust Route"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:1
-msgid "Show all Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:2 pkg/kubernetes/views/pvc-body.html.h:3
-#: pkg/kubernetes/views/pv-panel.html.h:1
-msgid "Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:3 pkg/kubernetes/views/pv-panel.html.h:2
-msgid "Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:4
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:1
-msgid "Remove image tag"
-msgstr "Remover etiqueta de imagen"
-
-#: pkg/kubernetes/views/image-delete.html.h:2
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:1
-msgid "Run as"
-msgstr "Ejecutar como"
-
-#: pkg/kubernetes/views/image-config.html.h:4
-msgid "Stop with"
-msgstr "Detener con"
-
-#: pkg/kubernetes/views/pv-delete.html.h:1
-msgid "Delete Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:2
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:3
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
-"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
-"may cause issues with any pods depending on it."
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:3
-msgid "Identities"
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:3
-msgid "The user '{{ userName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:1
-msgid "Show all Deployment Configs"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:1
-msgid "Deployment Config"
-msgstr "Configuración de Despliegue"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:4
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/route-panel.html.h:1
-#: pkg/kubernetes/views/route-page.html.h:2
-msgid "Route"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:1
-msgid "Register New Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:2
-msgid "Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:7
-msgid "No volumes are present."
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:8
-msgid "Pending Volume Claims"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:12
-msgid "When"
-msgstr ""
-
-#: pkg/kubernetes/views/user-delete.html.h:1
-msgid "Remove User"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:3
-#: pkg/kubernetes/views/pv-modify.html.h:10
-#: pkg/kubernetes/views/pvc-body.html.h:7 pkg/kubernetes/views/pv-body.html.h:2
-msgid "Access Modes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:4
-msgid "Requests"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:5
-msgid "This volume has not been claimed"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:10
-msgid "No Pods are using this claim"
-msgstr ""
-
-#: pkg/kubernetes/views/filter-project.html.h:1
-msgid "All Projects"
-msgstr "Todos los Proyectos"
-
-#: pkg/kubernetes/views/filter-project.html.h:2
-msgid "Project:"
-msgstr "Proyecto:"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:5
-#: pkg/kubernetes/views/details-page.html.h:14
-msgid "Latest Version"
-msgstr "Última Versión"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:6
-msgid "Deployment Causes"
-msgstr "Causas de Despliegue"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:7
-msgid "Triggers"
-msgstr "Disparadores"
-
-#: pkg/kubernetes/views/item-delete.html.h:1
-msgid "Delete {{ item.kind }}"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:2
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:3
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:2
-#: pkg/kubernetes/views/user-modify.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:2
-msgid ""
-"\n"
-"                        Name\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:5
-#: pkg/kubernetes/views/user-modify.html.h:5
-msgid ""
-"\n"
-"                        Identity\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:1
-msgid "Project Members"
-msgstr "Miembros del Proyecto"
-
-#: pkg/kubernetes/views/project-body.html.h:3
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:6
-msgid "Admin"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:7
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/container-panel.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:3
-msgid "Shell"
-msgstr "Shell"
-
-#: pkg/kubernetes/views/service-endpoint.html.h:1
-msgid "Pod Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:2
-msgid "No pods selected"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:3
-msgid "Pod Selector"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:1
-msgid "Add membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:2
-msgid ""
-"\n"
-"                        Group or Project\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:5
-msgid ""
-"\n"
-"                        Role\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:1
-msgid "Deploy Application"
-msgstr "Desplegar aplicación"
-
-#: pkg/kubernetes/views/deploy.html.h:3
-msgid "{{ selected.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:5
-#: pkg/kubernetes/views/dashboard-page.html.h:11
-msgid "Deploy"
-msgstr "Desplegar"
-
-#: pkg/kubernetes/views/user-modify.html.h:1
-msgid "Change User"
-msgstr ""
-
-#: pkg/kubernetes/views/user-modify.html.h:9
-msgid "Modify"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:1
-#: pkg/kubernetes/views/project-modify.html.h:6
-msgid "Access Policy"
-msgstr "Política de Acceso"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:2
-msgid ""
-"\n"
-"          Images may be pulled by anonymous users\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:5
-msgid ""
-"\n"
-"          Images may be pulled by any authenticated user or group\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:8
-msgid ""
-"\n"
-"          Images may only be pulled by specific users or groups\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:11
-msgid "Pull repository"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:13
-msgid "Image count"
-msgstr "Conteo de imágenes"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:14
-msgid "{{stream.status.tags.length}}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:15
-msgid "To push to an image to this image stream:"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:1
-msgid "The node doesn't have enough disk space"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:2
-msgid "The node doesn't have enough free memory"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:1
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:2
-msgid "Register Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:4
-msgid "Warning:"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:5
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:7
-#: pkg/kubernetes/views/node-page.html.h:3
-#: pkg/kubernetes/views/pvc-body.html.h:10
-#: pkg/kubernetes/views/pv-body.html.h:3
-msgid "Capacity"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:8
-#: pkg/kubernetes/views/pv-body.html.h:1
-msgid "Reclaim Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:9
-msgid "{{ value }}"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:12
-msgid "Endpoint"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:15
-msgid "Target"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-dialog.html.h:1
-msgid "Connection Settings"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-dialog.html.h:2
-msgid "Connection Error"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:2
-msgid "Summary"
-msgstr "Resumen"
-
-#: pkg/kubernetes/views/image-body.html.h:4
-msgid "Source URL"
-msgstr "URL Fuente"
-
-#: pkg/kubernetes/views/image-body.html.h:7
-msgid "Built"
-msgstr "Construido"
-
-#: pkg/kubernetes/views/image-body.html.h:8
-msgid "Digest"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:9
-msgid "Identifier"
-msgstr "Identificador"
-
-#: pkg/kubernetes/views/image-body.html.h:11
-msgid "To pull this image:"
-msgstr "Para halar esta imagen"
-
-#: pkg/kubernetes/views/service-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:8
-#: pkg/kubernetes/views/service-page.html.h:2
-msgid "Service"
-msgstr "Servicio"
-
-#: pkg/kubernetes/views/service-panel.html.h:2
-#: pkg/kubernetes/views/service-page.html.h:3
-msgid "Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:1
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:2
-msgid ""
-"You can bypass the certificate check, but any data you send to the server "
-"could be intercepted by others."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:4
-msgid "Trust this certificate for this connection"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:1
-msgid "Show all Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:7
-msgid "The pod '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:1
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:1
-msgid "Delete image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:2
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:2
-msgid "All running"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:3
-msgid "No pods deployed"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:5
-msgid "All in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:6
-msgid "No volumes in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:7
-msgid "pending volume claims"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:9
-msgid "All healthy"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:10
-msgid "No nodes in cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:13
-msgid "Could not list services"
-msgstr "No se pueden listar los servicios"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:14
-msgid "You can deploy an application to your cluster."
-msgstr "Tu puedes desplegar una aplicación a tu cluster"
-
-#: pkg/kubernetes/views/imagestream-page.html.h:1
-msgid "Show all image streams"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-page.html.h:2
-msgid "Image Stream"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:3
-msgid "Image ID"
-msgstr "ID de Imagen"
-
-#: pkg/kubernetes/views/container-body.html.h:4
-msgid "Container ID"
-msgstr "ID de Contenedor"
-
-#: pkg/kubernetes/views/container-body.html.h:7
-msgid "Since"
-msgstr "Desde"
-
-#: pkg/kubernetes/views/container-body.html.h:8
-msgid "Restart Count"
-msgstr "Conteo de Reinicios"
-
-#: pkg/kubernetes/views/user-remove-membership.html.h:1
-msgid "Remove membership"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:1
-msgid "Delete Selected"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:2
-msgid "OS Versions"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:3
-msgid "Add Kubernetes Node"
-msgstr ""
-
-#: pkg/kubernetes/views/project-page.html.h:3
-msgid "The project '{{ projName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/user-panel.html.h:4
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:1
-msgid "Pod Replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:2
-msgid "No pods replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/container-page.html.h:1
-msgid "Show all Containers"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:1
-msgid "Welcome to the Image Registry"
-msgstr "Bienvenidos al Registro de Imagen"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:2
-msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:1
-msgid "New project"
-msgstr "Nuevo proyecto"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:4
-msgid "Images by project"
-msgstr "Imágenes por proyecto"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:6
-msgid "Images pushed recently"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:7
-msgid "All images"
-msgstr "Todas las imágenes"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:8
-msgid "No images pushed"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:9
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:11
-#, fuzzy
-msgid "Login commands"
-msgstr "Comandos Docker"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:12
-#, fuzzy
-msgid "Log into the registry:"
-msgstr "Bienvenidos al Registro de Imagen"
+"No tiene permiso para ver las llaves públicas autorizadas para esta cuenta."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:13
+#: pkg/kubernetes/views/registry-dashboard-page.html:112
 msgid ""
 "Your login credentials do not give you access to use the docker registry "
 "from the command line."
@@ -5999,252 +6120,180 @@ msgstr ""
 "Tus credenciales de acceso no te dan acceso a usar el registro docker desde "
 "la línea de comandos."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:14
-msgid "Log into OpenShift command line tools:"
+#: src/base1/cockpit.js:3687
+msgid "Your session has been terminated."
+msgstr "Su sección ha sido terminada"
+
+#: src/base1/cockpit.js:3689
+msgid "Your session has expired. Please log in again."
+msgstr "Su sección a expirado. Por favor inicie sección otra vez"
+
+#: pkg/lib/journal.js:213
+msgid "[$0 bytes of binary data]"
+msgstr "[$0 bites de datos binarios]"
+
+#: pkg/lib/journal.js:215
+msgid "[binary data]"
+msgstr "[datos binarios]"
+
+#: pkg/lib/journal.js:209
+msgid "[no data]"
+msgstr "[no hay datos]"
+
+#: pkg/storaged/details.js:1692
+msgid "active, but unsupported"
+msgstr "activo, pero no soportado"
+
+#: pkg/storaged/utils.js:88
+msgctxt "format-bytes"
+msgid "bytes"
+msgstr "bytes"
+
+#: pkg/docker/util.js:123
+msgid "default"
+msgstr "Por defecto"
+
+#: pkg/storaged/details.js:178
+msgid "ext4 - Red Hat Enterprise Linux 6 default"
+msgstr "ext4 - Red Hat Enterprise Linux 6 Predeterminado"
+
+#: pkg/systemd/host.js:661
+msgid "failed to list ssh host keys: $0"
+msgstr "incapaz de mostrar llaves de host ssh: $0"
+
+#: pkg/storaged/index.html:135
+msgid "iSCSI Targets"
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:15
-#, fuzzy
-msgid "Image commands"
-msgstr "Conteo de imágenes"
+#: pkg/storaged/details.js:1692
+msgid "inactive"
+msgstr "inactivo"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:16
-msgid "Push an image:"
-msgstr "Empujar una imagen:"
+#: pkg/storaged/details.js:1286
+msgid "locked"
+msgstr "bloqueado"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:17
-msgid "Pull an image:"
-msgstr "Halar una imagen:"
+#: pkg/storaged/details.js:1278
+msgid "mounted on $0"
+msgstr "montado en $0"
 
-#: pkg/kubernetes/views/node-page.html.h:1
-msgid "Show all Nodes"
-msgstr ""
-
-#: pkg/kubernetes/views/node-page.html.h:4
-msgid "The node '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/route-page.html.h:1
-msgid "Show all Routes"
-msgstr ""
-
-#: pkg/kubernetes/views/route-page.html.h:3
-msgid "The route '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:1
-msgid "Select an object to see more details."
-msgstr "Selecciona un objeto para ver mas detalles"
-
-#: pkg/kubernetes/views/topology-page.html.h:3
-msgid ""
-"Pods contain one or more containers that run\n"
-"                together on a node, containing your application code."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:6
-msgid ""
-"Replication controllers dynamically create instances of\n"
-"                pods from templates, and remove pods when necessary."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:9
-msgid ""
-"Services group pods and provide a common DNS\n"
-"                name and an optional, load-balanced IP address to access "
-"them."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:12
-msgid "Nodes are the machines that run your containers."
-msgstr "Nodos son las computadoras que ejecutan sus contenedores"
-
-#: pkg/kubernetes/views/add-group-dialog.html.h:1
-msgid "Add Group"
-msgstr "Agregar Grupo"
-
-#: pkg/kubernetes/views/file-button.html.h:1
-msgid "Select Manifest File..."
-msgstr "Seleccione un archivo Manifiesto..."
-
-#: pkg/kubernetes/views/project-modify.html.h:2
-msgid "Change project"
-msgstr "Cambiar proyecto"
-
-#: pkg/kubernetes/views/project-modify.html.h:4
-msgid "Display name"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:5
-msgid "TLS Termination"
-msgstr "Terminación TLS"
-
-#: pkg/kubernetes/views/route-body.html.h:6
-msgid "yes"
-msgstr "si"
-
-#: pkg/kubernetes/views/route-body.html.h:7
+#: pkg/kubernetes/views/route-body.html:14
 msgid "no"
 msgstr "no"
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:1
-msgid "Add Role"
+#: pkg/kubernetes/views/route-body.html:24
+#: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
+msgid "none"
+msgstr "ninguno"
+
+#: pkg/storaged/details.js:1280
+msgid "not mounted"
+msgstr "no montado"
+
+#: pkg/kubernetes/views/dashboard-page.html:83
+msgid "pending volume claims"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:2
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#: pkg/tuned/change-profile.jsx:52
+#, fuzzy
+msgid "recommended"
+msgstr "MII (Recomendado)"
+
+#: pkg/docker/index.html:426
+msgid "select container"
+msgstr "seleccionar contenedor"
+
+#: pkg/docker/index.html:504 pkg/docker/index.html:683
+msgid "shares"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:1
-msgid "All Types"
+#: pkg/selinux/setroubleshoot-view.jsx:118
+msgid "solution details"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:2
-msgid "Type:"
-msgstr ""
+#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
+msgid "unknown"
+msgstr "desconocido"
 
-#: pkg/kubernetes/views/details-page.html.h:13
-msgid "Deployment Configs"
-msgstr "Configuración de despliegue"
+#: pkg/storaged/jobs.js:180
+msgid "unknown target"
+msgstr "destino u objetivo desconocido"
 
-#: pkg/kubernetes/views/details-page.html.h:15
-msgid "Not deployed"
-msgstr ""
+#: pkg/storaged/details.js:1284
+msgid "unlocked"
+msgstr "desbloquedo"
 
-#: pkg/kubernetes/views/details-page.html.h:16
-msgid "Replication Controllers"
-msgstr "Controladores de replicación"
+#: pkg/kubernetes/views/route-body.html:13
+msgid "yes"
+msgstr "si"
 
-#: pkg/kubernetes/views/service-modify.html.h:1
-msgid "Adjust Service"
-msgstr "Ajustar servicio"
-
-#: pkg/kubernetes/views/service-modify.html.h:3
+#: pkg/kubernetes/views/service-modify.html:16
 msgid "{{ item.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:5
-msgid "Adjust"
-msgstr "Ajustar"
-
-#: pkg/kubernetes/views/project-delete.html.h:1
-msgid "Delete Project"
+#: pkg/kubernetes/views/deploy.html:27
+msgid "{{ selected.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:2
-msgid "Claim Name"
+#: pkg/kubernetes/views/pv-modify.html:61
+#: pkg/kubernetes/views/pv-modify.html:74
+msgid "{{ value }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:4
-msgid "No Volume Bound"
+#: pkg/kubernetes/views/volume-body.html:2
+msgid "{{ volume | formatVolumeType }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:8
-msgid "Requested"
+#: pkg/storaged/index.html:147
+msgid "{{Address}}:{{Port}}"
+msgstr "{{Address}}:{{Port}}"
+
+#: pkg/docker/index.html:435
+msgid "{{alias_label}}"
+msgstr "{{alias_label}}"
+
+#: pkg/systemd/services.html:173 pkg/systemd/services.html:202
+msgid "{{days_text}}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:9
-msgid "Actual"
+#: pkg/docker/index.html:403
+msgid "{{envvar_key_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/node-capacity.html.h:1
-msgid "Scheduled Pods"
+#: pkg/docker/index.html:407
+msgid "{{envvar_value_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/node-capacity.html.h:2
-msgid "No pods scheduled"
+#: pkg/docker/index.html:359
+msgid "{{host_port_label}}"
+msgstr "{{host_port_label}}"
+
+#: pkg/docker/index.html:373
+msgid "{{host_volume_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/container-page-inline.html.h:4
-msgid "The container '{{ target }}' does not exist."
+#: pkg/kubernetes/views/imagestream-body.html:35
+msgid "{{stream.status.tags.length}}"
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:1
-msgid "Create image stream"
-msgstr ""
+#~ msgid "Journal"
+#~ msgstr "Bitacora"
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:2
-msgid "Change image stream"
-msgstr ""
+#~ msgid "Comment"
+#~ msgstr "Comentario"
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:5
-msgid "Populate"
-msgstr ""
+#~ msgid "Cockpit Pattern Usage"
+#~ msgstr "Patrón de Uso de Cockpit"
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:6
-msgid "Pull from"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:8
-msgid "Remote registry is insecure"
-msgstr ""
-
-#: pkg/kubernetes/views/user-group-remove.html.h:1
-msgid "Remove Member"
-msgstr ""
-
-#: pkg/kubernetes/views/service-page.html.h:1
-msgid "Show all Services"
-msgstr ""
-
-#: pkg/kubernetes/views/service-page.html.h:4
-msgid "The service '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/scripts/frob-layers.html.h:1
-msgid "Image Layers Example"
-msgstr ""
-
-#: pkg/playground/service.html.h:1
-msgid "Cockpit Generic Service Monitor"
-msgstr ""
-
-#: pkg/playground/jquery-patterns.html.h:1
-msgid "Cockpit Pattern Usage"
-msgstr "Patrón de Uso de Cockpit"
-
-#: pkg/playground/metrics.html.h:1
 #, fuzzy
-msgid "Cockpit Monitoring"
-msgstr "Monitorear enlace"
+#~ msgid "Cockpit Monitoring"
+#~ msgstr "Monitorear enlace"
 
-#: pkg/playground/test.html.h:1 pkg/playground/translate.html.h:1
-msgid "Cockpit playground"
-msgstr ""
-
-#: pkg/playground/react-patterns.html.h:1
-msgid "Cockpit React Patterns Usage"
-msgstr ""
-
-#: pkg/playground/speed.html.h:1
-msgid "Cockpit Speed Tests"
-msgstr ""
-
-#: pkg/playground/plot.html.h:1
 #, fuzzy
-msgid "Cockpit Plots"
-msgstr "Cockpit"
-
-#: pkg/dashboard/index.html.h:1
-msgid "Dashboard"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:5
-#, fuzzy
-msgid "Disk I/O"
-msgstr "Disco está OK"
-
-#: pkg/dashboard/index.html.h:6
-msgid "Lost connection. Trying to reconnect"
-msgstr "Conexión perdida. Intentando conectarse nuevamente"
-
-#: pkg/dashboard/index.html.h:10
-msgid "Avatar"
-msgstr "Avatar"
-
-#: pkg/dashboard/index.html.h:13
-msgid "Set"
-msgstr "Establecer"
+#~ msgid "Cockpit Plots"
+#~ msgstr "Cockpit"
 
 #~ msgid "No addresses found"
 #~ msgstr "No se encontraron direcciones"
@@ -6356,60 +6405,8 @@ msgstr "Establecer"
 #~ msgstr "Uno"
 
 #~ msgctxt "storage"
-#~ msgid "Model"
-#~ msgstr "Modelo"
-
-#~ msgctxt "storage"
-#~ msgid "Firmware Version"
-#~ msgstr "Versión de Firmware"
-
-#~ msgctxt "storage"
-#~ msgid "Serial Number"
-#~ msgstr "Número de serial"
-
-#~ msgctxt "storage"
-#~ msgid "World Wide Name"
-#~ msgstr "World Wide Name"
-
-#~ msgctxt "storage"
-#~ msgid "Capacity"
-#~ msgstr "Capacidad"
-
-#~ msgctxt "storage"
-#~ msgid "Assessment"
-#~ msgstr "Evaluación"
-
-#~ msgctxt "storage"
-#~ msgid "Device File"
-#~ msgstr "Dispositivo de Fichero"
-
-#~ msgctxt "storage"
-#~ msgid "Multipathed Devices"
-#~ msgstr "Dispositivos Multipathed"
-
-#~ msgctxt "storage"
-#~ msgid "Device"
-#~ msgstr "Dispositivo"
-
-#~ msgctxt "storage"
 #~ msgid "Name"
 #~ msgstr "Nombre"
-
-#~ msgctxt "storage"
-#~ msgid "UUID"
-#~ msgstr "UUID"
-
-#~ msgctxt "storage"
-#~ msgid "RAID Level"
-#~ msgstr "Nivel de RAID"
-
-#~ msgctxt "storage"
-#~ msgid "Bitmap"
-#~ msgstr "Mapa de bits"
-
-#~ msgctxt "storage"
-#~ msgid "State"
-#~ msgstr "Estado"
 
 #~ msgid ""
 #~ "\n"
@@ -6437,27 +6434,9 @@ msgstr "Establecer"
 
 #~ msgid ""
 #~ "\n"
-#~ "                    URL\n"
-#~ "                  "
-#~ msgstr "URL"
-
-#~ msgid ""
-#~ "\n"
-#~ "                    Login\n"
-#~ "                  "
-#~ msgstr "Usuario"
-
-#~ msgid ""
-#~ "\n"
 #~ "                    Password\n"
 #~ "                  "
 #~ msgstr "Contraseña"
-
-#~ msgid ""
-#~ "\n"
-#~ "                    Organization\n"
-#~ "                  "
-#~ msgstr "Organización"
 
 #~ msgid ""
 #~ "\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-17 19:28+0100\n"
+"POT-Creation-Date: 2016-11-18 06:44+0100\n"
 "PO-Revision-Date: 2016-08-10 12:34-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: French\n"
@@ -18,175 +18,444 @@ msgstr ""
 "X-Generator: Zanata 3.9.6\n"
 "Plural-Forms: nplurals=2; plural=(n > 1)\n"
 
-#: src/ws/cockpitcertificate.c:359
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr "Impossible de déchiffrer la clé privée encodée en PEM"
+#: pkg/shell/index.html:227
+msgid "                                                Comment                                            "
+msgstr ""
 
-#: src/ws/cockpitcertificate.c:364
-msgid "No PEM-encoded private key found"
-msgstr "Clé privée encodée en PEM introuvable"
+#: pkg/shell/index.html:235
+msgid "                                                Fingerprint                                            "
+msgstr ""
 
-#: src/ws/cockpitcertificate.c:374
-msgid "Could not parse PEM-encoded private key"
-msgstr "Échec de l'analyse de la clé privée encodée en PEM"
+#: pkg/shell/index.html:231
+msgid "                                                Type                                            "
+msgstr ""
 
-#: src/ws/cockpitcertificate.c:398
-msgid "No PEM-encoded certificate found"
-msgstr "Certificat encodé en PEM introuvable"
+#: pkg/systemd/index.html:389
+msgid ""
+"                                    Invalid time "
+"zone                                "
+msgstr ""
 
-#: src/ws/cockpitcertificate.c:407
-msgid "Could not parse PEM-encoded certificate"
-msgstr "Échec de l'analyse du certificat encodé en PEM"
+#: pkg/kubernetes/views/project-body.html:80
+msgid ""
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}                                "
+msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
-#: src/bridge/cockpitdbussetup.c:625
+#: pkg/kubernetes/views/user-body.html:22
+msgid ""
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}                                "
+msgstr ""
+
+#: pkg/kubernetes/views/user-panel.html:39
+msgid ""
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}                            "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:37
+msgid ""
+"                                {{ getRegistryRoles(user, project())."
+"join() }}                            "
+msgstr ""
+
+#: pkg/systemd/index.html:485 pkg/systemd/index.html:504
 #, fuzzy
-msgid "Unsupported setup mechanism"
-msgstr "Mécanisme de configuration non pris en charge : %s"
-
-#: src/bridge/cockpitdbussetup.c:236
-msgid "Couldn't list users"
-msgstr "Impossible d'énumérer les utilisateurs"
-
-#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
-msgid "Bad data passed for passwd1 mechanism"
-msgstr "Données incorrectes passées au mécanisme passwd1"
-
-#: src/bridge/cockpitdbussetup.c:382
-msgid "Couldn't load user data"
-msgstr "Impossible de charger les données utilisateur"
-
-#: src/bridge/cockpitdbussetup.c:467
-msgid "Couldn't change user groups"
-msgstr "Impossible de modifier les groupes utilisateurs"
-
-#: src/bridge/cockpitdbussetup.c:520
-msgid "Couldn't change user password"
-msgstr "Impossible de modifier le mot de passe de l'utilisateur"
-
-#: src/bridge/cockpitdbussetup.c:544
-msgid "Couldn't create new users"
-msgstr "Impossible de créer de nouveaux utilisateurs"
-
-#: src/bridge/cockpitdbussetup.c:642
-msgid "Couldn't list local users"
-msgstr "Impossible d'énumérer les utilisateurs locaux"
-
-#: src/bridge/cockpitpackages.c:459
-#, c-format
-msgid "This package requires Cockpit version %s or later"
+msgid "                        Cancel                    "
 msgstr ""
+"\n"
+"              Annuler\n"
+"            "
 
-#: src/bridge/cockpitpackages.c:470
-msgid "This package is not compatible with this version of Cockpit"
-msgstr ""
-
-#: src/base1/cockpit.js:2586
-msgid "$0 killed with signal $1"
-msgstr ""
-
-#: src/base1/cockpit.js:2588
-msgid "$0 exited with code $1"
-msgstr ""
-
-#: src/base1/cockpit.js:2590
-msgid "$0 failed"
-msgstr ""
-
-#: src/base1/cockpit.js:3667
-msgid "Your session has been terminated."
-msgstr ""
-
-#: src/base1/cockpit.js:3669
-msgid "Your session has expired. Please log in again."
-msgstr ""
-
-#: src/base1/cockpit.js:3671
-msgid "Not permitted to perform this action."
-msgstr ""
-
-#: src/base1/cockpit.js:3673
-msgid "Login failed"
-msgstr ""
-
-#: src/base1/cockpit.js:3675
-msgid "The server refused to authenticate using any supported methods."
-msgstr ""
-
-#: src/base1/cockpit.js:3677
-msgid "Untrusted host"
-msgstr ""
-
-#: src/base1/cockpit.js:3679
-msgid "Host key is incorrect"
-msgstr ""
-
-#: src/base1/cockpit.js:3681
-msgid "Internal error"
-msgstr ""
-
-#: src/base1/cockpit.js:3683
-msgid "Connection has timed out."
-msgstr ""
-
-#: src/base1/cockpit.js:3685
-msgid "Cockpit is not installed on the system."
-msgstr ""
-
-#: src/base1/cockpit.js:3687
-msgid "Cannot forward login credentials"
-msgstr ""
-
-#: src/base1/cockpit.js:3689
-msgid "Server has closed the connection."
-msgstr ""
-
-#: src/base1/cockpit.js:3691
-msgid "Cockpit is not compatible with the software on the system."
-msgstr ""
-
-#: src/base1/cockpit.js:3693
-msgid "Cockpit could not contact the given host."
-msgstr ""
-
-#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:19
+#: pkg/kubernetes/views/user-add-membership.html:9
 #, fuzzy
-msgid "Control"
-msgstr "Conteneur"
+msgid "                        Group or Project                    "
+msgstr ""
+"\n"
+"              Tenter de se reconnecter\n"
+"            "
 
-#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
-#: pkg/playground/translate.js:22
+#: pkg/kubernetes/views/add-user-dialog.html:19
+#: pkg/kubernetes/views/user-modify.html:19
 #, fuzzy
-msgctxt "key"
-msgid "Control"
-msgstr "Conteneur"
+msgid "                        Identity                    "
+msgstr ""
+"\n"
+"                Outils\n"
+"              "
 
-#: src/base1/test-locale.js:46 src/base1/test-locale.js:56
-#: pkg/playground/translate.js:10
-msgid "Empty"
+#: pkg/kubernetes/views/add-user-dialog.html:9
+#: pkg/kubernetes/views/user-modify.html:9
+#: pkg/kubernetes/views/add-group-dialog.html:9
+#, fuzzy
+msgid "                        Name                    "
+msgstr ""
+"\n"
+"                Outils\n"
+"              "
+
+#: pkg/kubernetes/views/user-add-membership.html:30
+#, fuzzy
+msgid "                        Role                    "
+msgstr ""
+"\n"
+"                Outils\n"
+"              "
+
+#: pkg/kubernetes/views/user-group-add.html:9
+#, fuzzy
+msgid "                        User                    "
+msgstr ""
+"\n"
+"                Outils\n"
+"              "
+
+#: pkg/ostree/index.html:88
+#, fuzzy
+msgid "                    Available                  "
+msgstr ""
+"\n"
+"                Outils\n"
+"              "
+
+#: pkg/ostree/index.html:85
+#, fuzzy
+msgid "                    Default                  "
+msgstr ""
+"\n"
+"                Outils\n"
+"              "
+
+#: pkg/ostree/index.html:223
+#, fuzzy
+msgid "                    Reconnect                "
+msgstr ""
+"\n"
+"              Tenter de se reconnecter\n"
+"            "
+
+#: pkg/ostree/index.html:135
+msgid ""
+"                    This deployment contains the same packages as your "
+"currently booted system                "
 msgstr ""
 
-#: src/base1/test-locale.js:47 src/base1/test-locale.js:58
-#: pkg/playground/translate.js:16
-msgctxt "verb"
-msgid "Empty"
+#: pkg/ostree/index.html:67
+#, fuzzy
+msgid "                    Update and reboot                "
+msgstr ""
+"\n"
+"                Outils\n"
+"              "
+
+#: pkg/kubernetes/registry.html:74 pkg/kubernetes/index.html:104
+#, fuzzy
+msgid "                Reconnect            "
+msgstr ""
+"\n"
+"              Tenter de se reconnecter\n"
+"            "
+
+#: pkg/sosreport/index.html:57
+msgid ""
+"                The generated archive contains data "
+"considered                sensitive and its content should be reviewed by "
+"the                originating organization before being passed to "
+"any                third party.              "
 msgstr ""
 
-#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
-#: src/base1/test-locale.js:66 pkg/storaged/details.js:1557
-#: pkg/playground/translate.js:25 pkg/playground/translate.js:28
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] ""
-msgstr[1] ""
+#: pkg/shell/index.html:304 pkg/shell/stub.html:157
+#, fuzzy
+msgid "                Tools              "
+msgstr ""
+"\n"
+"                Outils\n"
+"              "
 
-#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
-#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
-#: pkg/playground/translate.js:34
-msgctxt "disk-non-rotational"
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
+#: pkg/kubernetes/index.html:107
+#, fuzzy
+msgid "                Troubleshoot            "
+msgstr ""
+"\n"
+"                Outils\n"
+"              "
+
+#: pkg/shell/simple.html:105 pkg/shell/index.html:126 pkg/shell/stub.html:119
+#: pkg/storaged/index.html:862
+#, fuzzy
+msgid "              Cancel            "
+msgstr ""
+"\n"
+"              Annuler\n"
+"            "
+
+#: pkg/shell/index.html:147 pkg/shell/stub.html:140
+#, fuzzy
+msgid "              Close            "
+msgstr ""
+"\n"
+"              Fermer\n"
+"            "
+
+#: pkg/shell/simple.html:70 pkg/shell/index.html:83 pkg/shell/stub.html:76
+#, fuzzy
+msgid ""
+"              Cockpit is an interactive Linux server admin "
+"interface.            "
+msgstr ""
+"\n"
+"              Cockpit est une interface d'administration Linux interactive.\n"
+"            "
+
+#: pkg/shell/simple.html:79 pkg/shell/index.html:92 pkg/shell/stub.html:85
+#, fuzzy
+msgid "              Licensed under the GNU LGPL version 2.1            "
+msgstr ""
+"\n"
+"              Se reconnecter\n"
+"            "
+
+#: pkg/shell/simple.html:129
+#, fuzzy
+msgid "              Log in again            "
+msgstr ""
+"\n"
+"              Se reconnecter\n"
+"            "
+
+#: pkg/shell/simple.html:73 pkg/shell/index.html:86 pkg/shell/stub.html:79
+#, fuzzy
+msgid "              Project website            "
+msgstr ""
+"\n"
+"              Fermer\n"
+"            "
+
+#: pkg/shell/simple.html:108 pkg/shell/index.html:129 pkg/shell/stub.html:122
+#, fuzzy
+msgid "              Select            "
+msgstr ""
+"\n"
+"              Sélectionner\n"
+"            "
+
+#: pkg/shell/simple.html:126
+#, fuzzy
+msgid "              Try to reconnect            "
+msgstr ""
+"\n"
+"              Tenter de se reconnecter\n"
+"            "
+
+#: pkg/users/index.html:361
+#, fuzzy
+msgid "            Add key          "
+msgstr ""
+"\n"
+"            Appliquer\n"
+"          "
+
+#: pkg/networkmanager/index.html:582 pkg/networkmanager/index.html:610
+#: pkg/networkmanager/index.html:638 pkg/networkmanager/index.html:666
+#: pkg/networkmanager/index.html:694 pkg/networkmanager/index.html:722
+#: pkg/networkmanager/index.html:750 pkg/networkmanager/index.html:778
+#, fuzzy
+msgid "            Apply          "
+msgstr ""
+"\n"
+"            Appliquer\n"
+"          "
+
+#: pkg/users/index.html:269 pkg/users/index.html:297 pkg/users/index.html:358
+#: pkg/docker/index.html:584 pkg/docker/index.html:622
+#: pkg/docker/index.html:688 pkg/docker/index.html:744
+#: pkg/docker/index.html:790 pkg/networkmanager/index.html:579
+#: pkg/networkmanager/index.html:607 pkg/networkmanager/index.html:635
+#: pkg/networkmanager/index.html:663 pkg/networkmanager/index.html:691
+#: pkg/networkmanager/index.html:719 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:775
+#, fuzzy
+msgid "            Cancel          "
+msgstr ""
+"\n"
+"            Annuler\n"
+"           "
+
+#: pkg/docker/index.html:691
+#, fuzzy
+msgid "            Change          "
+msgstr ""
+"\n"
+"            Changer\n"
+"           "
+
+#: pkg/users/index.html:45
+#, fuzzy
+msgid "            Close          "
+msgstr ""
+"\n"
+"              Fermer\n"
+"            "
+
+#: pkg/docker/index.html:747
+#, fuzzy
+msgid "            Commit          "
+msgstr ""
+"\n"
+"            Valider\n"
+"           "
+
+#: pkg/users/index.html:207
+#, fuzzy
+msgid "            Create          "
+msgstr ""
+"\n"
+"            Annuler\n"
+"           "
+
+#: pkg/users/index.html:300 pkg/networkmanager/index.html:533
+#, fuzzy
+msgid "            Delete          "
+msgstr ""
+"\n"
+"            Supprimer\n"
+"          "
+
+#: pkg/docker/index.html:625
+#, fuzzy
+msgid "            Download          "
+msgstr ""
+"\n"
+"            Télécharger\n"
+"           "
+
+#: pkg/docker/index.html:587
+#, fuzzy
+msgid "            Run          "
+msgstr ""
+"\n"
+"            Lancer\n"
+"           "
+
+#: pkg/users/index.html:272
+#, fuzzy
+msgid "            Set          "
+msgstr ""
+"\n"
+"            Supprimer\n"
+"          "
+
+#: pkg/kubernetes/views/imagestream-body.html:14
+msgid "          Images may be pulled by anonymous users        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:20
+msgid ""
+"          Images may be pulled by any authenticated user or group        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:26
+msgid "          Images may only be pulled by specific users or groups        "
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:9
+#, fuzzy
+msgid "         {{ labels.url }}    "
+msgstr ""
+"\n"
+"            Annuler\n"
+"           "
+
+#: pkg/kubernetes/views/project-body.html:2
+msgid ""
+"        Project access policy allows anonymous users to pull images. Grant "
+"additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:7
+msgid ""
+"        Project access policy allows any authenticated user to pull images. "
+"Grant additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:12
+msgid ""
+"        Project access policy only allows specific members to access images. "
+"Grant access to specific members below.    "
+msgstr ""
+
+#: pkg/sosreport/index.html:39
+msgid ""
+"        The collected information will be stored locally on the system.      "
+msgstr ""
+
+#: pkg/storaged/index.html:51
+msgid ""
+"        There are devices with multiple paths on the system, but the "
+"multipath service is not running.      "
+msgstr ""
+
+#: pkg/sosreport/index.html:34
+msgid ""
+"        This tool will collect system configuration and diagnostic        "
+"information from this system for use with diagnosing problems        with "
+"the system.      "
+msgstr ""
+
+#: pkg/docker/storage.jsx:242
+msgid " (shared with the OS)"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:8
+msgid " 1\"Do you want to delete the following Nodes?"
+msgstr ""
+
+#: pkg/storaged/overview.js:253
+msgid "$0 Block Device"
+msgstr ""
+
+#: pkg/storaged/details.js:1546
+msgid "$0 Chunk Size"
+msgstr "taille de bloc $0"
+
+#: pkg/storaged/details.js:1544
+msgid "$0 Disks"
+msgstr "$0 disques"
+
+#: pkg/storaged/details.js:1387
+msgid "$0 Extended Partition"
+msgstr ""
+
+#: pkg/storaged/details.js:1221
+msgctxt "storage-id-desc"
+msgid "$0 File System"
+msgstr "Système de fichier $0"
+
+#: pkg/storaged/details.js:1375
+msgid "$0 Free Space"
+msgstr "$0 d'espace libre"
+
+#: pkg/storaged/details.js:1367
+msgid "$0 Free Space for Logical Partitions"
+msgstr "$0 d'espace libre pour les partitions logiques"
+
+#: pkg/storaged/details.js:1711
+msgid "$0 Free Space for Logical Volumes"
+msgstr "$0 d'espace libre pour les volumes logiques"
+
+#: pkg/storaged/details.js:1370
+msgid "$0 Free Space for Primary Partitions"
+msgstr "$0 d'espace libre pour les partitions primaires"
+
+#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
+msgid "$0 Template"
+msgstr "Modèle de $0"
+
+#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+msgid "$0 bit"
+msgid_plural "$0 bits"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -206,580 +475,40 @@ msgid_plural "$0 bytes"
 msgstr[0] "octets"
 msgstr[1] "octets"
 
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
-msgid "$0 bit"
-msgid_plural "$0 bits"
+#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
+#: src/base1/test-locale.js:66 pkg/playground/translate.js:25
+#: pkg/playground/translate.js:28 pkg/storaged/details.js:1557
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/systemd/host.js:43
-msgid "The user <b>$0</b> is not permitted to modify hostnames"
-msgstr "L'utilisateur <b>$0</b> n'a pas le droit de modifier les noms d'hôtes"
+#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
+#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
+#: pkg/playground/translate.js:34
+msgctxt "disk-non-rotational"
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] ""
+msgstr[1] ""
 
-#: pkg/systemd/host.js:559
-msgid "Set Host name"
-msgstr "Définir le nom d'hôte"
-
-#: pkg/systemd/host.js:661
-msgid "failed to list ssh host keys: $0"
+#: src/base1/cockpit.js:2588
+msgid "$0 exited with code $1"
 msgstr ""
 
-#: pkg/systemd/host.js:1113
-msgid "Need at least one NTP server"
-msgstr "Au moins un serveur NTP est nécessaire"
-
-#: pkg/systemd/host.js:1190
-msgid "Invalid date format and invalid time format"
-msgstr "Formats de date et d'heure invalides"
-
-#: pkg/systemd/host.js:1192
-msgid "Invalid time format"
-msgstr "Format d'heure invalide"
-
-#: pkg/systemd/host.js:1194
-msgid "Invalid date format"
-msgstr "Format de date invalide"
-
-#: pkg/systemd/host.js:1250
-msgid "NTP Server"
-msgstr "Serveur NTP"
-
-#: pkg/systemd/host.js:1300
-msgid "Message to logged in users"
-msgstr "Message aux utilisateurs connectés"
-
-#: pkg/systemd/host.js:1307 pkg/systemd/host.js:1309
-#: pkg/systemd/index.html.h:19
-msgid "Shutdown"
-msgstr "Éteindre"
-
-#: pkg/systemd/host.js:1311 pkg/systemd/host.js:1313 pkg/systemd/init.js:517
-#: pkg/systemd/index.html.h:18
-msgid "Restart"
-msgstr "Redémarrer"
-
-#: pkg/systemd/host.js:1381
-msgctxt "page-title"
-msgid "CPU Status"
-msgstr "État du CPU"
-
-#: pkg/systemd/host.js:1413 pkg/systemd/index.html.h:24
-msgid "I/O Wait"
-msgstr "Attente sur E/S"
-
-#: pkg/systemd/host.js:1414 pkg/systemd/index.html.h:25
-msgid "Kernel"
-msgstr "Noyau"
-
-#: pkg/systemd/host.js:1415 pkg/subscriptions/subscriptions-register.jsx:76
-#: pkg/systemd/index.html.h:26 pkg/kubernetes/views/auth-form.html.h:6
-#: pkg/kubernetes/views/volume-body.html.h:20
-#: pkg/kubernetes/views/user-panel.html.h:1 pkg/playground/translate.html.h:3
-#: pkg/dashboard/index.html.h:8
-msgid "User"
-msgstr "Utilisateur"
-
-#: pkg/systemd/host.js:1416 pkg/systemd/index.html.h:27
-msgid "Nice"
+#: src/base1/cockpit.js:2590
+msgid "$0 failed"
 msgstr ""
 
-#: pkg/systemd/host.js:1466
-msgctxt "page-title"
-msgid "Memory"
-msgstr "Mémoire"
-
-#: pkg/systemd/host.js:1499 pkg/systemd/index.html.h:28
-msgid "Swap Used"
-msgstr "Échange utilisé"
-
-#: pkg/systemd/host.js:1500 pkg/systemd/index.html.h:29
-msgid "Cached"
-msgstr "En cache"
-
-#: pkg/systemd/host.js:1501 pkg/docker/storage.jsx:313
-#: pkg/kubernetes/scripts/nodes.js:828 pkg/kubernetes/scripts/nodes.js:837
-#: pkg/systemd/index.html.h:30
-msgid "Used"
-msgstr "Utilisé(e)"
-
-#: pkg/systemd/host.js:1502 pkg/docker/storage.jsx:298
-#: pkg/docker/storage.jsx:320 pkg/systemd/index.html.h:31
-msgid "Free"
-msgstr "Disponible"
-
-#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
-msgid "unknown"
+#: src/base1/cockpit.js:2586
+msgid "$0 killed with signal $1"
 msgstr ""
 
-#: pkg/systemd/init.js:269 pkg/systemd/services.html.h:17
-#: pkg/kubernetes/views/project-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:5
-msgid "Description"
-msgstr ""
-
-#: pkg/systemd/init.js:270
-msgid "Id"
-msgstr ""
-
-#: pkg/systemd/init.js:272
-msgid "Next Run"
-msgstr ""
-
-#: pkg/systemd/init.js:273
-msgid "Last Trigger"
-msgstr ""
-
-#: pkg/systemd/init.js:274 pkg/kubernetes/views/container-body.html.h:6
-#: pkg/kubernetes/views/details-page.html.h:8
-msgid "State"
-msgstr ""
-
-#: pkg/systemd/init.js:301
-msgid "Enabled"
-msgstr "Activé(e)"
-
-#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
-msgid "Disabled"
-msgstr "Désactivé"
-
-#: pkg/systemd/init.js:303
-msgid "Static"
-msgstr "Statique"
-
-#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
-msgid "$0 Template"
-msgstr "Modèle de $0"
-
-#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
-msgid "Start"
-msgstr "Démarrer"
-
-#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
-msgid "Stop"
-msgstr "Arrêter"
-
-#: pkg/systemd/init.js:518
-msgid "Reload"
-msgstr "Recharger"
-
-#: pkg/systemd/init.js:519
-msgid "Reload or Restart"
-msgstr "Recharger ou redémarrer"
-
-#: pkg/systemd/init.js:520
-msgid "Try Restart"
-msgstr "Essayer de redémarrer"
-
-#: pkg/systemd/init.js:521
-msgid "Reload or Try Restart"
-msgstr "Recharger ou essayer de redémarrer"
-
-#: pkg/systemd/init.js:522
-msgid "Isolate"
-msgstr "Isoler"
-
-#: pkg/systemd/init.js:541
-msgid "Enable"
-msgstr "Activer"
-
-#: pkg/systemd/init.js:542
-msgid "Enable Forcefully"
-msgstr "Forcer l'activation"
-
-#: pkg/systemd/init.js:543
-msgid "Disable"
-msgstr "Désactiver"
-
-#: pkg/systemd/init.js:544
-msgid "Preset"
-msgstr "Préconfigurer"
-
-#: pkg/systemd/init.js:545
-msgid "Preset Forcefully"
-msgstr "Forcer la préconfiguration"
-
-#: pkg/systemd/init.js:546
-msgid "Mask"
-msgstr "Masquer"
-
-#: pkg/systemd/init.js:547
-msgid "Mask Forcefully"
-msgstr "Forcer le masquage"
-
-#: pkg/systemd/init.js:548
-msgid "Unmask"
-msgstr "Démasquer"
-
-#: pkg/systemd/init.js:621
-msgid "Since $0"
-msgstr "Depuis $0"
-
-#: pkg/systemd/init.js:639
-msgid "This unit is an instance of the $0 template."
-msgstr "Cette unité est une instance du modèle $0."
-
-#: pkg/systemd/init.js:834
-#, fuzzy
-msgid "The user <b>$0</b> does not have permissions for creating timers"
-msgstr "L'utilisateur <b>$0</b> n'a pas le droit de gérer des serveurs"
-
-#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
-#, fuzzy
-msgid "This field cannot be empty."
-msgstr "Le nom ne peut être vide."
-
-#: pkg/systemd/init.js:1147
-msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
-msgstr ""
-
-#: pkg/systemd/init.js:1169
-#, fuzzy
-msgid "Invalid number."
-msgstr "Port invalide"
-
-#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
-msgid "Hour needs to be a number between 0-23"
-msgstr ""
-
-#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
-msgid "Minute needs to be a number between 0-59"
-msgstr ""
-
-#: pkg/systemd/init.js:1218
-#, fuzzy
-msgid "Invalid date format."
-msgstr "Format de date invalide"
-
-#: pkg/systemd/init.js:1222
-msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
-msgstr ""
-
-#: pkg/systemd/logs.js:69
-msgid "Load earlier entries"
-msgstr "Charger des entrées antérieures"
-
-#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
-#: pkg/systemd/logs.js:175
-msgid "Loading..."
-msgstr "Chargement..."
-
-#: pkg/systemd/logs.js:130
-msgid "Go to"
-msgstr "Aller à"
-
-#: pkg/systemd/logs.js:257
-msgid "Journal entry"
-msgstr "Entrée de journal"
-
-#: pkg/systemd/logs.js:284
-msgid "Journal entry not found"
-msgstr "Entrée de journal introuvable"
-
-#: pkg/tuned/dialog.js:94
-msgid "Tuned is not available"
-msgstr "Tuned n'est pas disponible"
-
-#: pkg/tuned/dialog.js:96
-msgid "Tuned is not running"
-msgstr "Tuned n'est pas en cours d'exécution"
-
-#: pkg/tuned/dialog.js:98
-msgid "Tuned is off"
-msgstr "Tuned est désactivé"
-
-#: pkg/tuned/dialog.js:100
-msgid "This system is using the recommended profile"
-msgstr "Ce système utilise le profil recommandé"
-
-#: pkg/tuned/dialog.js:102
-msgid "This system is using a custom profile"
-msgstr "Ce système utilise un profil personnalisé"
-
-#: pkg/tuned/dialog.js:114
-msgid "Communication with tuned has failed"
-msgstr "La communication avec tuned a échoué"
-
-#: pkg/tuned/dialog.js:133
-msgid "Failed to disable tuned profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:145
-msgid "Failed to switch profile"
-msgstr "Échec lors du changement de profil"
-
-#: pkg/tuned/dialog.js:169
-msgid "Failed to enable tuned"
-msgstr ""
-
-#: pkg/tuned/dialog.js:171
-msgid "Failed to disable tuned"
-msgstr ""
-
-#: pkg/tuned/dialog.js:191
-msgid "Change Performance Profile"
-msgstr "Modifier le profil de performance"
-
-#: pkg/tuned/dialog.js:200
-msgid "Change Profile"
-msgstr "Modifier le profil"
-
-#: pkg/tuned/dialog.js:233 pkg/kubernetes/views/service-body.html.h:7
-#: pkg/kubernetes/views/pod-panel.html.h:2
-#: pkg/kubernetes/views/image-config.html.h:8
-#: pkg/kubernetes/views/imagestream-body.html.h:12
-#: pkg/kubernetes/views/pod-page.html.h:5
-msgid "None"
-msgstr "Aucun(e)"
-
-#: pkg/tuned/dialog.js:234
-msgid "Disable tuned"
-msgstr "Désactiver tuned"
-
-#: pkg/tuned/dialog.js:262
-msgid "Tuned has failed to start"
-msgstr "Échec du démarrage de tuned"
-
-#: pkg/tuned/change-profile.jsx:52
-#, fuzzy
-msgid "recommended"
-msgstr "MII (Recommandé)"
-
-#: pkg/lib/journal.js:209
-msgid "[no data]"
-msgstr "[aucune donnée]"
-
-#: pkg/lib/journal.js:213
-msgid "[$0 bytes of binary data]"
-msgstr "[$0 octets de données binaires]"
-
-#: pkg/lib/journal.js:215
-msgid "[binary data]"
-msgstr "[données binaires]"
-
-#: pkg/lib/journal.js:241
-msgid "Reboot"
-msgstr "Redémarrer"
-
-#: pkg/lib/machine-dialogs.js:364
-msgid "This machine has already been added."
-msgstr "Cette machine a été déjà été ajoutée."
-
-#: pkg/lib/machine-dialogs.js:380
-msgid ""
-"This version of cockpit-ws does not support connecting to a host with an "
-"alternate user or port"
-msgstr ""
-"Cette version de cockpit-ws ne prend pas en charge la connexion à un hôte "
-"avec un autre utilisateur ou un port différent"
-
-#: pkg/lib/machine-dialogs.js:386
-msgid "The IP address or host name cannot contain whitespace."
-msgstr "L'adresse IP ou nom d'hôte ne peut pas contenir d'espace."
-
-#: pkg/lib/machine-dialogs.js:412
-msgid "Failed to add machine: $0"
-msgstr "Échec lors de l'ajout de la machine : $0"
-
-#: pkg/lib/machine-dialogs.js:429
-msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
-msgstr ""
-"Cockpit ne peut contacter l'hôte indiqué $0. Assurez-vous que ssh est bien "
-"en écoute sur le port $1, ou indiquez un autre port dans l'adresse."
-
-#: pkg/lib/machine-dialogs.js:447
-msgid "Enter IP address or host name"
-msgstr "Entrez l'adresse IP ou le nom d'hôte"
-
-#: pkg/lib/machine-dialogs.js:494
-msgid "Failed to edit machine: $0"
-msgstr "Impossible de modifier la machine : $0"
-
-#: pkg/lib/cockpit-components-dialog.jsx:136 pkg/sosreport/index.js:55
-#: pkg/systemd/services.html.h:34 pkg/lib/machine-sync-users.html.h:7
-#: pkg/lib/machine-add.html.h:5 pkg/lib/machine-change-port.html.h:6
-#: pkg/lib/machine-change-auth.html.h:11 pkg/storaged/index.html.h:22
-#: pkg/realmd/operation.html.h:10 pkg/kubernetes/views/node-delete.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:3
-#: pkg/kubernetes/views/pvc-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:3
-#: pkg/kubernetes/views/auth-form.html.h:13
-#: pkg/kubernetes/views/node-add.html.h:7
-#: pkg/kubernetes/views/user-group-add.html.h:5
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:4
-#: pkg/kubernetes/views/route-modify.html.h:3
-#: pkg/kubernetes/views/image-delete.html.h:3
-#: pkg/kubernetes/views/pv-delete.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:4
-#: pkg/kubernetes/views/item-delete.html.h:4
-#: pkg/kubernetes/views/add-user-dialog.html.h:8
-#: pkg/kubernetes/views/user-add-membership.html.h:8
-#: pkg/kubernetes/views/deploy.html.h:4
-#: pkg/kubernetes/views/user-modify.html.h:8
-#: pkg/kubernetes/views/pv-modify.html.h:21
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:5
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:3
-#: pkg/kubernetes/views/imagestream-delete.html.h:3
-#: pkg/kubernetes/views/user-remove-membership.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:7
-#: pkg/kubernetes/views/add-role-dialog.html.h:3
-#: pkg/kubernetes/views/service-modify.html.h:4
-#: pkg/kubernetes/views/project-delete.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:9
-#: pkg/kubernetes/views/user-group-remove.html.h:2
-#: pkg/playground/translate.html.h:2 pkg/dashboard/index.html.h:12
-msgid "Cancel"
-msgstr "Annuler"
-
-#: pkg/lib/cockpit-components-dialog.jsx:155
-msgid "Ok"
-msgstr ""
-
-#: pkg/lib/credentials.js:182
-msgid "No such file or directory"
-msgstr "Fichier ou répertoire introuvable"
-
-#: pkg/lib/credentials.js:186
-msgid "The passwords do not match."
-msgstr "Les mots de passe ne correspondent pas."
-
-#: pkg/lib/credentials.js:191
-msgid "Prompting via ssh-keygen timed out"
-msgstr "Temps d'attente dépassé sur saisie via ssh-keygen"
-
-#: pkg/lib/credentials.js:213 pkg/users/local.js:78
-msgid "Old password not accepted"
-msgstr "Refus de l'ancien mot de passe "
-
-#: pkg/lib/credentials.js:223 pkg/users/local.js:112 pkg/users/local.js:144
-msgid "Failed to change password"
-msgstr "Échec du changement de mot de passe"
-
-#: pkg/lib/credentials.js:231 pkg/users/local.js:120
-msgid "New password was not accepted"
-msgstr "Refus du nouveau mot de passe"
-
-#: pkg/lib/credentials.js:248
-msgid "Not a valid private key"
-msgstr "Pas une clé privée"
-
-#: pkg/lib/credentials.js:251
-msgid "Prompting via ssh-add timed out"
-msgstr "Temps d'attente dépassé sur saisie avec ssh-add"
-
-#: pkg/lib/credentials.js:274
-msgid "Invalid file permissions"
-msgstr "Permissions sur fichier invalide"
-
-#: pkg/lib/credentials.js:278
-msgid "Password not accepted"
-msgstr "Mot de passe refusé"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:22
-#: pkg/shell/index.html.h:27 pkg/storaged/index.html.h:52
-#: pkg/playground/jquery-patterns.html.h:2
-msgid "On"
-msgstr "Allumé"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:23
-#: pkg/shell/index.html.h:28 pkg/storaged/index.html.h:53
-#: pkg/playground/jquery-patterns.html.h:3
-msgid "Off"
-msgstr "Éteint"
-
-#: pkg/shell/base_index.js:670 pkg/users/local.js:1164
-#: pkg/docker/index.html.h:69 pkg/networkmanager/index.html.h:65
-msgid "Unexpected error"
-msgstr "Erreur inattendue"
-
-#: pkg/shell/base_index.js:671
-msgid "Cockpit had an unexpected internal error. <br/><br/>"
-msgstr "Cockpit a rencontré une erreur interne inattendue. <br/><br/>"
-
-#: pkg/shell/base_index.js:672
-msgid "You can try restarting Cockpit by pressing refresh in your browser. "
-msgstr ""
-"Vous pouvez tenter de redémarrer Cockpit en rafraichissant la page dans "
-"votre navigateur."
-
-#: pkg/shell/base_index.js:673
-msgid "The javascript console contains details about this error "
-msgstr ""
-"La console Javascript contient des informations au sujet de cette erreur."
-
-#: pkg/shell/base_index.js:674
-msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
-msgstr "(<b>Ctrl-Shift-J</b> dans la plupart des navigateurs)."
-
-#: pkg/shell/indexes.js:126 pkg/shell/indexes.js:497 pkg/shell/simple.html.h:17
-msgid "Disconnected"
-msgstr "Déconnecté"
-
-#: pkg/shell/indexes.js:253
-msgid "Machines"
-msgstr "Machines"
-
-#: pkg/shell/indexes.js:314
-msgid "The machine is restarting"
-msgstr "Cette machine redémarre"
-
-#: pkg/shell/indexes.js:317
-msgid "Connecting to the machine"
-msgstr "Connexion à la machine"
-
-#: pkg/shell/indexes.js:320
-msgid "Couldn't connect to the machine"
-msgstr "Impossible de se connecter à la machine"
-
-#: pkg/shell/indexes.js:322
-msgid "Cannot connect to an unknown machine"
-msgstr "Impossible de se connecter à une machine inconnue"
-
-#: pkg/ostree/client.js:56
-msgid "Receiving delta parts"
-msgstr ""
-
-#: pkg/ostree/client.js:58
-msgid "Receiving metadata objects"
-msgstr ""
-
-#: pkg/ostree/client.js:61
-msgid "Receiving objects: $0%"
-msgstr ""
-
-#: pkg/ostree/client.js:64
-msgid "Writing objects"
-msgstr ""
-
-#: pkg/ostree/client.js:66
-msgid "Scanning metadata"
-msgstr ""
-
-#: pkg/ostree/client.js:500
-msgid "OS $0 not found"
-msgstr ""
-
-#: pkg/ostree/app.js:81
-msgid "Not authorized to update software on this system"
-msgstr ""
-
-#: pkg/ostree/app.js:83
-msgid "OSTree is not available on this system"
-msgstr ""
-
-#: pkg/ostree/app.js:101
-msgid "No OSTree deployments found"
-msgstr ""
-
-#: pkg/ostree/app.js:219
-msgid "Checking for updates"
-msgstr ""
+#: pkg/selinux/setroubleshoot-view.jsx:440
+msgid "$0 occurrence"
+msgid_plural "$1 occurrences"
+msgstr[0] ""
+msgstr[1] ""
 
 #: pkg/ostree/app.js:307
 msgid "$0 package"
@@ -789,693 +518,34 @@ msgstr ""
 msgid "$0 packages"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot.js:65
-msgid "Error while setting SELinux mode: '$0'"
-msgstr "Erreur lors de la configuration du mode SELinux : « $0 »"
+#: pkg/docker/util.js:124
+msgid "$0 shares"
+msgstr "$0 partages"
 
-#: pkg/selinux/setroubleshoot.js:238
-msgid "Not connected"
-msgstr "Non connecté"
-
-#: pkg/selinux/setroubleshoot.js:275
-msgid "Error while connecting."
-msgstr "Erreur lors de la connexion."
-
-#: pkg/selinux/setroubleshoot-view.jsx:82
-msgid "Applying solution..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:90
-msgid "Solution applied successfully"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:97
-msgid "Solution failed"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:107
-msgid "Apply this solution"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:114
-msgid "Unable to apply this solution automatically"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:118
-msgid "solution details"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:309
-msgid "SELinux system status is unknown."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:317
-msgid "SELinux is disabled on the system."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:324
-msgid "The configured state is unknown, it might change on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:326
-msgid ""
-"Setting deviates from the configured state and will revert on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:330
-msgid "SELinux Policy"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:332
-msgid "Enforce policy:"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:382 pkg/kubernetes/index.html.h:10
-#: pkg/kubernetes/registry.html.h:5
-msgid "Connecting..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:385
-msgid ""
-"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
-"server is installed."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:400
-msgid "Occurred between $0 and $1"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:405
-msgid "Occurred $0"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:440
-msgid "$0 occurrence"
-msgid_plural "$1 occurrences"
+#: pkg/kubernetes/scripts/nodes.js:870
+#, c-format
+msgid "$0% Free"
+msgid_plural "$0% Free"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:478
-msgid "SELinux Access Control Errors"
+#: pkg/kubernetes/scripts/nodes.js:872
+msgid "$0% Used"
+msgid_plural "$0% Used"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/storaged/details.js:1765
+msgid "$0, $1 free"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:479
-msgid "No SELinux alerts."
+#: pkg/networkmanager/interfaces.js:2473
+msgid "$mtu"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-client.js:52
-msgid "Unable to start setroubleshootd"
-msgstr "Impossible de démarrer setroubleshootd"
-
-#: pkg/selinux/setroubleshoot-client.js:157
-msgid "Unable to get alert"
-msgstr "Impossible d'obtenir l'alerte"
-
-#: pkg/selinux/setroubleshoot-client.js:172
-msgid "Unable to run fix"
-msgstr "Impossible d'exécutif l'action de correction"
-
-#: pkg/selinux/setroubleshoot-client.js:187
-msgid "Failed to delete alert"
-msgstr "Impossible de supprimer l'alerte"
-
-#: pkg/selinux/setroubleshoot-client.js:192
-msgid "Error while deleting alert"
-msgstr "Erreur lors de la suppression de l'alerte"
-
-#: pkg/storaged/dialog.js:267
-msgid "Size must be a number"
-msgstr ""
-
-#: pkg/storaged/dialog.js:269
-#, fuzzy
-msgid "Size cannot be zero"
-msgstr "Le nom ne peut être vide."
-
-#: pkg/storaged/dialog.js:271
-#, fuzzy
-msgid "Size cannot be negative"
-msgstr "Le nom ne peut être vide."
-
-#: pkg/storaged/dialog.js:273
-msgid "Size is too large"
-msgstr ""
-
-#: pkg/storaged/details.js:85
-msgid "Device $0 is mounted on $1"
-msgstr "Le périphérique $0 est monté sur $1"
-
-#: pkg/storaged/details.js:91
-msgid "Device $0 is a member of RAID Array $1"
-msgstr "Le périphérique $0 est membre de la grappe RAID $1"
-
-#: pkg/storaged/details.js:97
-msgid "Device $0 is a physical volume of $1"
-msgstr "Le périphérique $0 est un volume physique de $1"
-
-#: pkg/storaged/details.js:113
-msgid "Create partition on $0"
-msgstr "Créer une partition sur $0"
-
-#: pkg/storaged/details.js:115
-msgid "Format $0"
-msgstr "Formater $0"
-
-#: pkg/storaged/details.js:177
-msgid "XFS - Red Hat Enterprise Linux 7 default"
-msgstr "XFS - Système de fichier par défaut de Red Hat Enterprise Linux 7"
-
-#: pkg/storaged/details.js:178
-msgid "ext4 - Red Hat Enterprise Linux 6 default"
-msgstr "ext4 - Système de fichier par défaut de Red Hat Enterprise Linux 6"
-
-#: pkg/storaged/details.js:179
-msgid "Encrypted XFS (LUKS)"
-msgstr "XFS chiffré (LUKS)"
-
-#: pkg/storaged/details.js:180
-msgid "Encrypted EXT4 (LUKS)"
-msgstr "EXT4 chiffré (LUKS)"
-
-#: pkg/storaged/details.js:181
-msgid "VFAT - Compatible with all systems and devices"
-msgstr "VFAT - Compatible avec tous les systèmes et appareils"
-
-#: pkg/storaged/details.js:182
-msgid "NTFS - Compatible with most systems"
-msgstr "NTFS - Compatible avec la plupart des systèmes"
-
-#: pkg/storaged/details.js:183
-msgid "Extended Partition"
-msgstr "Partition étendue"
-
-#: pkg/storaged/details.js:185
-msgid "No Filesystem"
-msgstr "Aucun système de fichiers"
-
-#: pkg/storaged/details.js:186
-msgid "Custom (Enter filesystem type)"
-msgstr "Personnalisé (indiquer le type de système de fichiers)"
-
-#: pkg/storaged/details.js:192 pkg/storaged/details.js:664
-#: pkg/storaged/details.js:735 pkg/storaged/details.js:773
-#: pkg/storaged/details.js:909 pkg/storaged/index.html.h:20
-#: pkg/kubernetes/views/volumes-page.html.h:11
-msgid "Size"
-msgstr "Taille"
-
-#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
-msgid "Erase"
-msgstr "Effacer"
-
-#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
-msgid "Don't overwrite existing data"
-msgstr "Ne pas écraser les données existantes"
-
-#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
-msgid "Overwrite existing data with zeros"
-msgstr "Écraser les données existantes avec des zéros"
-
-#: pkg/storaged/details.js:207 pkg/shell/index.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:4
-#: pkg/kubernetes/views/deploy.html.h:2 pkg/kubernetes/views/pv-modify.html.h:3
-msgid "Type"
-msgstr "Type"
-
-#: pkg/storaged/details.js:211 pkg/storaged/details.js:429
-#: pkg/storaged/details.js:709 pkg/storaged/details.js:731
-#: pkg/storaged/details.js:769 pkg/storaged/details.js:798
-#: pkg/storaged/details.js:864 pkg/storaged/overview.js:417
-#: pkg/storaged/overview.js:490 pkg/storaged/overview.js:624
-#: pkg/storaged/overview.js:702 pkg/storaged/index.html.h:18
-#: pkg/networkmanager/index.html.h:16
-#: pkg/kubernetes/views/project-listing.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:3
-#: pkg/kubernetes/views/volume-body.html.h:11
-#: pkg/kubernetes/views/containers-listing.html.h:2
-#: pkg/kubernetes/views/volumes-page.html.h:3
-#: pkg/kubernetes/views/pv-claim.html.h:1
-#: pkg/kubernetes/views/pv-modify.html.h:6
-#: pkg/kubernetes/views/image-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:15
-#: pkg/kubernetes/views/nodes-page.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:3
-#: pkg/kubernetes/views/details-page.html.h:4
-#: pkg/kubernetes/views/service-modify.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:3
-msgid "Name"
-msgstr "Nom"
-
-#: pkg/storaged/details.js:215
-msgid "Filesystem type"
-msgstr "Type de système de fichiers"
-
-#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
-msgid "Passphrase"
-msgstr "Phrase de passe"
-
-#: pkg/storaged/details.js:224
-#, fuzzy
-msgid "Passphrase cannot be empty"
-msgstr "La phrase de passe ne peut être vide"
-
-#: pkg/storaged/details.js:229
-msgid "Confirm passphrase"
-msgstr "Confirmer la phrase de passe"
-
-#: pkg/storaged/details.js:232
-msgid "Passphrases do not match"
-msgstr "Les phrases de passe ne correspondent pas."
-
-#: pkg/storaged/details.js:237
-msgid "Store passphrase"
-msgstr "Enregistrer la phrase de passe"
-
-#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
-#: pkg/storaged/details.js:1115
-msgid "Encryption Options"
-msgstr "Options de chiffrement"
-
-#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
-msgid "Mounting"
-msgstr "Montage"
-
-#: pkg/storaged/details.js:247 pkg/storaged/details.js:435
-#: pkg/subscriptions/subscriptions-register.jsx:101 pkg/docker/index.html.h:23
-#: pkg/kubernetes/views/image-config.html.h:2
-msgid "Default"
-msgstr "Par défaut"
-
-#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
-msgid "Custom"
-msgstr "Personnalisé"
-
-#: pkg/storaged/details.js:253 pkg/storaged/details.js:440
-#: pkg/storaged/index.html.h:19
-msgid "Mount Point"
-msgstr "Point de montage"
-
-#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
-msgid "Mount Options"
-msgstr "Options de montage"
-
-#: pkg/storaged/details.js:266
-msgid "Create partition"
-msgstr "Créer la partition"
-
-#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
-#: pkg/storaged/details.js:1142
-msgid "Format"
-msgstr "Formater"
-
-#: pkg/storaged/details.js:268
-msgid "Formatting a storage device will erase all data on it."
-msgstr ""
-"Formater un périphérique de stockage en effacera toutes les données qu'il "
-"contient."
-
-#: pkg/storaged/details.js:335
-msgid "Format Disk $0"
-msgstr "Formater le disque $0"
-
-#: pkg/storaged/details.js:346
-msgid "Partitioning"
-msgstr "Partitionnement"
-
-#: pkg/storaged/details.js:348
-msgid "Compatible with all systems and devices (MBR)"
-msgstr "Compatible avec tous les systèmes et périphériques (MBR)"
-
-#: pkg/storaged/details.js:349
-msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr ""
-"Compatible avec les systèmes modernes et disques durs de taille > 2 Tio (GPT)"
-
-#: pkg/storaged/details.js:352
-msgid "No partitioning"
-msgstr "Aucun partitionnement"
-
-#: pkg/storaged/details.js:358
-msgid "Formatting a disk will erase all data on it."
-msgstr "Formater un disque en effacera toutes les données qu'il contient."
-
-#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
-msgid "Filesystem Options"
-msgstr "Options du système de fichiers"
-
-#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
-msgid "Apply"
-msgstr "Appliquer"
-
-#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
-#: pkg/storaged/details.js:1110
-msgid "Unlock"
-msgstr "Déverrouiller"
-
-#: pkg/storaged/details.js:527
-msgid "Stored Passphrase"
-msgstr "Phrase de passe enregistrée"
-
-#: pkg/storaged/details.js:531 pkg/kubernetes/views/volume-body.html.h:32
-msgid "Options"
-msgstr "Options"
-
-#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
-msgid "Add Disks"
-msgstr "Ajouter des disques"
-
-#: pkg/storaged/details.js:567 pkg/storaged/details.js:933
-#: pkg/storaged/overview.js:448 pkg/storaged/overview.js:495
-#: pkg/storaged/index.html.h:55
-msgid "Disks"
-msgstr "Disques"
-
-#: pkg/storaged/details.js:579 pkg/storaged/details.js:948
-#: pkg/storaged/overview.js:501
-msgid "At least one disk is needed."
-msgstr "Au moins un disque est nécessaire."
-
-#: pkg/storaged/details.js:584 pkg/storaged/details.js:953
-#: pkg/storaged/overview.js:629 pkg/storaged/overview.js:657
-#: pkg/lib/machine-add.html.h:6 pkg/kubernetes/views/node-add.html.h:8
-#: pkg/kubernetes/views/user-group-add.html.h:6
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:5
-#: pkg/kubernetes/views/add-user-dialog.html.h:9
-#: pkg/kubernetes/views/user-add-membership.html.h:9
-#: pkg/kubernetes/views/add-role-dialog.html.h:4
-msgid "Add"
-msgstr "Ajouter"
-
-#: pkg/storaged/details.js:625 pkg/storaged/details.js:821
-#: pkg/storaged/details.js:1016 pkg/docker/details.js:271
-#: pkg/docker/image.js:151 pkg/docker/containers-view.jsx:166
-msgid "Please confirm deletion of $0"
-msgstr "Confirmer la suppression de $0"
-
-#: pkg/storaged/details.js:630 pkg/storaged/details.js:827
-#: pkg/storaged/details.js:1022 pkg/storaged/details.js:1151
-#: pkg/storaged/details.js:1616 pkg/storaged/details.js:1776
-#: pkg/docker/details.js:273 pkg/docker/image.js:153
-#: pkg/docker/containers-view.jsx:168 pkg/kubernetes/scripts/volumes.js:218
-#: pkg/users/index.html.h:9 pkg/kubernetes/views/node-delete.html.h:5
-#: pkg/kubernetes/views/pvc-delete.html.h:5
-#: pkg/kubernetes/views/image-delete.html.h:4
-#: pkg/kubernetes/views/pv-delete.html.h:5
-#: pkg/kubernetes/views/item-delete.html.h:5
-#: pkg/kubernetes/views/imagestream-delete.html.h:4
-#: pkg/kubernetes/views/user-remove-membership.html.h:3
-#: pkg/kubernetes/views/project-delete.html.h:3
-msgid "Delete"
-msgstr "Supprimer"
-
-#: pkg/storaged/details.js:631
-msgid "Deleting a RAID device will erase all data on it."
-msgstr ""
-"Supprimer un périphérique RAID en effacera toutes les données qu'il contient."
-
-#: pkg/storaged/details.js:661
-msgid "Resize Logical Volume"
-msgstr "Redimensionner un volume logique"
-
-#: pkg/storaged/details.js:673
-msgid "Resize Filesystem"
-msgstr "Redimensionner un système de fichiers"
-
-#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
-msgid "Resize"
-msgstr "Redimensionner"
-
-#: pkg/storaged/details.js:690
-msgid "This logical volume cannot be made smaller."
-msgstr ""
-
-#: pkg/storaged/details.js:706
-msgid "Renamee Logical Volume"
-msgstr "Renommer un volume logique"
-
-#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
-#: pkg/storaged/details.js:1775
-msgid "Rename"
-msgstr "Renommer"
-
-#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
-msgid "Create Snapshot"
-msgstr "Créer un instantané"
-
-#: pkg/storaged/details.js:745 pkg/storaged/details.js:781
-#: pkg/storaged/details.js:804 pkg/storaged/details.js:915
-#: pkg/storaged/overview.js:461 pkg/storaged/overview.js:506
-#: pkg/kubernetes/views/add-group-dialog.html.h:6
-#: pkg/kubernetes/views/project-modify.html.h:8
-msgid "Create"
-msgstr "Créer"
-
-#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
-msgid "Create Thin Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:795
-msgid "Rename Volume Group"
-msgstr "Renommer un groupe de volumes"
-
-#: pkg/storaged/details.js:826
-msgid "Deleting a volume group will erase all data on it."
-msgstr ""
-"Supprimer un groupe de volumes en effacera toutes les données qu'il contient."
-
-#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
-msgid "Create Logical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:869
-msgid "Purpose"
-msgstr ""
-
-#: pkg/storaged/details.js:871
-msgid "Block device for filesystems"
-msgstr ""
-
-#: pkg/storaged/details.js:874
-msgid "Pool for thinly provisioned volumes"
-msgstr ""
-
-#: pkg/storaged/details.js:1009
-msgid "Deleting a logical volume will delete all data in it."
-msgstr ""
-"Supprimer un volume logique en effacera toutes les données qu'il contient."
-
-#: pkg/storaged/details.js:1012
-msgid "Deleting a partition will delete all data in it."
-msgstr ""
-"Supprimer une partition en effacera toutes les données qu'elle contient."
-
-#: pkg/storaged/details.js:1053 pkg/storaged/overview.js:689
-#: pkg/storaged/devices.js:119 pkg/users/local.js:1155
-#: pkg/systemd/services.html.h:14
-msgid "Error"
-msgstr "Erreur"
-
-#: pkg/storaged/details.js:1099
-msgid "Mount"
-msgstr "Monter"
-
-#: pkg/storaged/details.js:1100
-msgid "Unmount"
-msgstr "Démonter"
-
-#: pkg/storaged/details.js:1109
-msgid "Lock"
-msgstr "Verrouiller"
-
-#: pkg/storaged/details.js:1127
-msgid "Activate"
-msgstr "Activer"
-
-#: pkg/storaged/details.js:1130
-msgid "Deactivate"
-msgstr "Désactiver"
-
-#: pkg/storaged/details.js:1221
-msgctxt "storage-id-desc"
-msgid "$0 File System"
-msgstr "Système de fichier $0"
-
-#: pkg/storaged/details.js:1224
-msgctxt "storage-id-desc"
-msgid "Linux MD-RAID Component"
-msgstr "Composant MD-RAID Linux"
-
-#: pkg/storaged/details.js:1226
-msgctxt "storage-id-desc"
-msgid "LVM2 Physical Volume"
-msgstr "Volume physique LVM2"
-
-#: pkg/storaged/details.js:1228
-msgctxt "storage-id-desc"
-msgid "RAID Member"
-msgstr "Membre de grappe RAID"
-
-#: pkg/storaged/details.js:1245
-msgctxt "storage-id-desc"
-msgid "LUKS Encrypted"
-msgstr "Chiffré par LUKS"
-
-#: pkg/storaged/details.js:1247
-msgctxt "storage-id-desc"
-msgid "Encrypted"
-msgstr "Chiffré"
-
-#: pkg/storaged/details.js:1251
-msgctxt "storage-id-desc"
-msgid "Swap Space"
-msgstr "Espace d'échange"
-
-#: pkg/storaged/details.js:1253
-msgctxt "storage-id-desc"
-msgid "Other Data"
-msgstr "Autres données"
-
-#: pkg/storaged/details.js:1256
-msgctxt "storage-id-desc"
-msgid "Unrecognized Data"
-msgstr "Données non reconnues"
-
-#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
-msgid "$size $partition"
-msgstr "$size $partition"
-
-#: pkg/storaged/details.js:1278
-msgid "mounted on $0"
-msgstr "monté sur $0"
-
-#: pkg/storaged/details.js:1280
-msgid "not mounted"
-msgstr "non monté"
-
-#: pkg/storaged/details.js:1284
-msgid "unlocked"
-msgstr "déverrouillé"
-
-#: pkg/storaged/details.js:1286
-msgid "locked"
-msgstr "verrouillé"
-
-#: pkg/storaged/details.js:1367
-msgid "$0 Free Space for Logical Partitions"
-msgstr "$0 d'espace libre pour les partitions logiques"
-
-#: pkg/storaged/details.js:1370
-msgid "$0 Free Space for Primary Partitions"
-msgstr "$0 d'espace libre pour les partitions primaires"
-
-#: pkg/storaged/details.js:1375
-msgid "$0 Free Space"
-msgstr "$0 d'espace libre"
-
-#: pkg/storaged/details.js:1379
-msgid "Create Partition"
-msgstr "Créer la partition"
-
-#: pkg/storaged/details.js:1387
-msgid "$0 Extended Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1424
-msgid "Logical Partition"
-msgstr "Partition logique"
-
-#: pkg/storaged/details.js:1426
-msgid "Primary Partition"
-msgstr "Partition primaire"
-
-#: pkg/storaged/details.js:1428 pkg/kubernetes/views/volume-body.html.h:5
-msgid "Partition"
-msgstr "Partition"
-
-#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
-msgid "Content"
-msgstr "Contenu"
-
-#: pkg/storaged/details.js:1533
-msgid "RAID 0"
-msgstr "RAID 0"
-
-#: pkg/storaged/details.js:1534
-msgid "RAID 1"
-msgstr "RAID 1"
-
-#: pkg/storaged/details.js:1535
-msgid "RAID 4"
-msgstr "RAID 4"
-
-#: pkg/storaged/details.js:1536
-msgid "RAID 5"
-msgstr "RAID 5"
-
-#: pkg/storaged/details.js:1537
-msgid "RAID 6"
-msgstr "RAID 6"
-
-#: pkg/storaged/details.js:1538
-msgid "RAID 10"
-msgstr "RAID 10"
-
-#: pkg/storaged/details.js:1539
-msgid "RAID ($0)"
-msgstr "RAID ($0)"
-
-#: pkg/storaged/details.js:1544
-msgid "$0 Disks"
-msgstr "$0 disques"
-
-#: pkg/storaged/details.js:1546
-msgid "$0 Chunk Size"
-msgstr "taille de bloc $0"
-
-#: pkg/storaged/details.js:1574 pkg/ostree/index.html.h:7
-msgid "Running"
-msgstr "En fonctionnement"
-
-#: pkg/storaged/details.js:1574
-msgid "Not running"
-msgstr ""
-
-#: pkg/storaged/details.js:1592
-msgid "FAILED"
-msgstr "EN ÉCHEC"
-
-#: pkg/storaged/details.js:1593
-msgid "In Sync"
-msgstr "En cours de synchronisation"
-
-#: pkg/storaged/details.js:1594
-msgid "Spare"
-msgstr "Rechange"
-
-#: pkg/storaged/details.js:1594
-msgid "Recovering"
-msgstr "Récupération en cours"
-
-#: pkg/storaged/details.js:1595
-msgid "Write-mostly"
-msgstr "Écriture favorisée"
-
-#: pkg/storaged/details.js:1596
-msgid "Blocked"
-msgstr "Bloqué"
-
-#: pkg/storaged/details.js:1597
-msgid "Unknown ($0)"
-msgstr "Inconnu ($0)"
-
-#: pkg/storaged/details.js:1614
-msgid "Start Scrubbing"
-msgstr "Démarrer la scrutation"
-
-#: pkg/storaged/details.js:1615
-msgid "Stop Scrubbing"
-msgstr "Arrêter la scrutation"
+#: pkg/storaged/utils.js:157
+msgid "$name (from $host)"
+msgstr "$name (de $host)"
 
 #: pkg/storaged/details.js:1653
 msgid "$size $desc"
@@ -1490,217 +560,2811 @@ msgstr "$size $desc<br/> rempli à ${percent}%"
 msgid "$size $desc<br/>($state)"
 msgstr "$size $desc<br/>($state)"
 
-#: pkg/storaged/details.js:1692
-msgid "active, but unsupported"
-msgstr "actif, mais non pris en charge"
+#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
+msgid "$size $partition"
+msgstr "$size $partition"
 
-#: pkg/storaged/details.js:1692
-msgid "inactive"
-msgstr "inactif"
+#: pkg/docker/details.js:144
+msgid "${hip}:${hport} -> $cport"
+msgstr "${hip}:${hport} -> $cport"
 
-#: pkg/storaged/details.js:1711
-msgid "$0 Free Space for Logical Volumes"
-msgstr "$0 d'espace libre pour les volumes logiques"
-
-#: pkg/storaged/details.js:1751
-msgid "The last physical volume of a volume group cannot be removed."
+#: pkg/subscriptions/subscriptions-client.js:198
+msgid "'Organization' required to register."
 msgstr ""
 
-#: pkg/storaged/details.js:1756
-msgid ""
-"There is not enough free space elsewhere to remove this physical volume.  At "
-"least $0 more free space is needed."
+#: pkg/subscriptions/subscriptions-client.js:202
+msgid "'Organization' required when using activation keys."
 msgstr ""
 
-#: pkg/storaged/details.js:1765
-msgid "$0, $1 free"
+#: pkg/shell/base_index.js:674
+msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
+msgstr "(<b>Ctrl-Shift-J</b> dans la plupart des navigateurs)."
+
+#: pkg/storaged/overview.js:440
+msgid "1 MiB"
 msgstr ""
 
-#: pkg/storaged/details.js:1792
-msgid "Logical Volumes"
+#: pkg/systemd/index.html:459 pkg/systemd/index.html:463
+msgid "1 Minute"
 msgstr ""
 
-#: pkg/storaged/details.js:1822 pkg/docker/details.js:177
-#: pkg/docker/image.js:112
-msgid "Not found"
-msgstr "Non trouvé"
+#: pkg/storaged/index.html:312 pkg/networkmanager/index.html:55
+#: pkg/networkmanager/index.html:501
+msgid "1 day"
+msgstr "1 jour"
 
-#: pkg/storaged/overview.js:180
-msgctxt "storage"
-msgid "Hard Disk"
-msgstr "Disque dur"
+#: pkg/storaged/index.html:310 pkg/networkmanager/index.html:53
+#: pkg/networkmanager/index.html:499
+msgid "1 hour"
+msgstr "1 heure"
 
-#: pkg/storaged/overview.js:182
-msgctxt "storage"
-msgid "Solid-State Disk"
-msgstr "Disque SSD"
+#: pkg/storaged/index.html:313 pkg/networkmanager/index.html:56
+#: pkg/networkmanager/index.html:502
+msgid "1 week"
+msgstr "1 semaine"
 
-#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
-msgctxt "storage"
-msgid "Removable Drive"
-msgstr "Périphérique amovible"
+#: pkg/playground/translate.html:190
+#, fuzzy
+msgid "1% Free"
+msgid_plural "{{$count}}% Free"
+msgstr[0] "Disponible"
+msgstr[1] "Disponible"
 
-#: pkg/storaged/overview.js:189
-msgctxt "storage"
-msgid "Optical Drive"
-msgstr "Lecteur optique"
-
-#: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
-msgctxt "storage"
-msgid "Drive"
-msgstr ""
-
-#: pkg/storaged/overview.js:253
-msgid "$0 Block Device"
-msgstr ""
-
-#: pkg/storaged/overview.js:414
-msgid "Create RAID Device"
-msgstr "Créer un périphérique RAID"
-
-#: pkg/storaged/overview.js:420
-msgid "RAID Level"
-msgstr "Niveau RAID"
-
-#: pkg/storaged/overview.js:422
-msgid "RAID 0 (Stripe)"
-msgstr "RAID 0 (Réparti par bande)"
-
-#: pkg/storaged/overview.js:423
-msgid "RAID 1 (Mirror)"
-msgstr "RAID 1 (Miroir)"
-
-#: pkg/storaged/overview.js:424
-msgid "RAID 4 (Dedicated Parity)"
-msgstr "RAID 4 (Parité Dédié)"
-
-#: pkg/storaged/overview.js:425
-msgid "RAID 5 (Distributed Parity)"
-msgstr "RAID 5 (Parité Distribué)"
-
-#: pkg/storaged/overview.js:426
-msgid "RAID 6 (Double Distributed Parity)"
-msgstr "RAID 6 (Parité Doublement Distribué)"
-
-#: pkg/storaged/overview.js:427
-msgid "RAID 10 (Stripe of Mirrors)"
-msgstr ""
-
-#: pkg/storaged/overview.js:431
-msgid "Chunk Size"
-msgstr "Taille de bloc"
-
-#: pkg/storaged/overview.js:433
-msgid "4 KiB"
-msgstr ""
-
-#: pkg/storaged/overview.js:434
-msgid "8 KiB"
+#: pkg/storaged/overview.js:438
+msgid "128 KiB"
 msgstr ""
 
 #: pkg/storaged/overview.js:435
 msgid "16 KiB"
 msgstr ""
 
+#: pkg/storaged/overview.js:441
+msgid "2 MiB"
+msgstr ""
+
+#: pkg/systemd/index.html:465
+msgid "20 Minutes"
+msgstr ""
+
 #: pkg/storaged/overview.js:436
 msgid "32 KiB"
+msgstr ""
+
+#: pkg/storaged/overview.js:433
+msgid "4 KiB"
+msgstr ""
+
+#: pkg/systemd/index.html:466
+msgid "40 Minutes"
+msgstr ""
+
+#: pkg/systemd/index.html:464
+msgid "5 Minutes"
+msgstr ""
+
+#: pkg/storaged/index.html:309 pkg/networkmanager/index.html:52
+#: pkg/networkmanager/index.html:498
+msgid "5 minutes"
+msgstr "5 minutes"
+
+#: pkg/storaged/overview.js:439
+msgid "512 KiB"
+msgstr ""
+
+#: pkg/storaged/index.html:311 pkg/networkmanager/index.html:54
+#: pkg/networkmanager/index.html:500
+msgid "6 hours"
+msgstr "6 heures"
+
+#: pkg/systemd/index.html:467
+msgid "60 Minutes"
 msgstr ""
 
 #: pkg/storaged/overview.js:437
 msgid "64 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:438
-msgid "128 KiB"
+#: pkg/storaged/overview.js:434
+msgid "8 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:439
-msgid "512 KiB"
+#: pkg/networkmanager/interfaces.js:1826
+msgid "802.3ad"
+msgstr "802.3ad"
+
+#: pkg/networkmanager/interfaces.js:1843
+#, fuzzy
+msgid "802.3ad LACP"
+msgstr "802.3ad"
+
+#: pkg/systemd/services.html:446
+msgid ":"
 msgstr ""
 
-#: pkg/storaged/overview.js:440
-msgid "1 MiB"
+#: pkg/storaged/utils.js:220
+msgid "<span>Encrypted $0</span>"
+msgstr "<span>$0 chiffré(e)</span>"
+
+#: pkg/storaged/utils.js:212
+msgid "<span>Encrypted Logical Volume of $0</span>"
 msgstr ""
 
-#: pkg/storaged/overview.js:441
-msgid "2 MiB"
+#: pkg/storaged/utils.js:214
+msgid "<span>Encrypted Partition of $0</span>"
+msgstr "<span>Partition chiffrée de $0</span>"
+
+#: pkg/storaged/utils.js:216
+msgid "<span>Logical Volume of $0</span>"
+msgstr "<span>Volume logique de $0</span>"
+
+#: pkg/storaged/utils.js:218
+msgid "<span>Partition of $0</span>"
+msgstr "<span>Partition de $0</span>"
+
+#: pkg/lib/machine-not-supported.html:5
+msgid ""
+"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
+"strong}}."
+msgstr ""
+
+#: cockpit.desktop.in.h:2
+msgid "A user interface for GNU/Linux servers"
+msgstr "Une interface utilisateur pour serveurs GNU/Linux"
+
+#: pkg/networkmanager/interfaces.js:1834
+msgid "ARP"
+msgstr "ARP"
+
+#: pkg/networkmanager/interfaces.js:2502
+msgid "ARP Monitoring"
+msgstr "Supervision ARP"
+
+#: pkg/networkmanager/interfaces.js:1855
+#, fuzzy
+msgid "ARP Ping"
+msgstr "Supervision ARP"
+
+#: pkg/kubernetes/scripts/volumes.js:193
+msgid "AWS Elastic Block Store"
+msgstr ""
+
+#: pkg/shell/simple.html:41 pkg/shell/simple.html:67 pkg/shell/index.html:41
+#: pkg/shell/index.html:80 pkg/shell/stub.html:41 pkg/shell/stub.html:73
+msgid "About Cockpit"
+msgstr "À propos de Cockpit"
+
+#: pkg/users/index.html:105 pkg/users/index.html:191
+msgid "Access"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pv-claim.html:9
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-body.html:9
+msgid "Access Modes"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:49
+#: pkg/kubernetes/views/imagestream-body.html:11
+msgid "Access Policy"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:191
+msgid "Access denied"
+msgstr ""
+
+#: pkg/shell/index.html:45
+msgid "Account Settings"
+msgstr "Paramètres de compte"
+
+#: pkg/users/index.html:63
+msgid "Account not available or cannot be edited."
+msgstr ""
+
+#: pkg/users/index.html:71
+msgid "Accounts"
+msgstr ""
+
+#: pkg/users/local.js:284 pkg/users/local.js:594
+msgctxt "page-title"
+msgid "Accounts"
+msgstr "Comptes"
+
+#: pkg/storaged/details.js:1127
+msgid "Activate"
+msgstr "Activer"
+
+#: pkg/storaged/jobs.js:148
+msgid "Activating $target"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:164
+#, fuzzy
+msgid "Activation Key"
+msgstr "Activer"
+
+#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
+msgid "Active"
+msgstr "Actif"
+
+#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
+msgid "Active Backup"
+msgstr "Active Backup"
+
+#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
+msgid "Actual"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1828
+msgid "Adaptive load balancing"
+msgstr "Adaptive load balancing"
+
+#: pkg/networkmanager/interfaces.js:1827
+msgid "Adaptive transmit load balancing"
+msgstr "Adaptive transmit load balancing"
+
+#: pkg/kubernetes/views/add-user-dialog.html:31
+#: pkg/kubernetes/views/node-add.html:50
+#: pkg/kubernetes/views/user-add-membership.html:53
+#: pkg/kubernetes/views/add-member-role-dialog.html:61
+#: pkg/kubernetes/views/user-group-add.html:32
+#: pkg/kubernetes/views/add-role-dialog.html:8 pkg/lib/machine-add.html:43
+msgid "Add"
+msgstr "Ajouter"
+
+#: pkg/networkmanager/interfaces.js:2836
+msgid "Add $0"
+msgstr ""
+
+#: pkg/docker/storage.jsx:363
+msgid "Add Additional Storage"
+msgstr ""
+
+#: pkg/networkmanager/index.html:86
+msgid "Add Bond"
+msgstr "Ajouter une liaison d'interfaces réseau"
+
+#: pkg/networkmanager/index.html:88
+msgid "Add Bridge"
+msgstr "Ajouter un pont"
+
+#: pkg/kubernetes/views/node-add.html:3
+msgid "Add Cluster Node"
+msgstr ""
+
+#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
+msgid "Add Disks"
+msgstr "Ajouter des disques"
+
+#: pkg/kubernetes/views/add-group-dialog.html:3
+msgid "Add Group"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:34
+msgid "Add Kubernetes Node"
+msgstr ""
+
+#: pkg/lib/machine-add.html:4
+msgid "Add Machine to Dashboard"
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:38
+#: pkg/kubernetes/views/add-member-role-dialog.html:4
+#: pkg/kubernetes/views/group-panel.html:29
+#: pkg/kubernetes/views/user-group-add.html:3
+#: pkg/kubernetes/views/project-body.html:108
+msgid "Add Member"
+msgstr ""
+
+#: pkg/kubernetes/views/user-panel.html:76
+#: pkg/kubernetes/views/user-body.html:67
+msgid "Add Membership"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:11
+#: pkg/kubernetes/views/auth-form.html:20
+msgid "Add New Cluster"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:67
+#: pkg/kubernetes/views/auth-form.html:76
+msgid "Add New User"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:3
+msgid "Add Role"
+msgstr ""
+
+#: pkg/networkmanager/index.html:87
+msgid "Add Team"
+msgstr ""
+
+#: pkg/kubernetes/views/add-user-dialog.html:3
+#: pkg/kubernetes/views/project-listing.html:83
+msgid "Add User"
+msgstr ""
+
+#: pkg/networkmanager/index.html:89
+msgid "Add VLAN"
+msgstr "Ajouter un VLAN"
+
+#: pkg/storaged/overview.js:515
+msgid "Add iSCSI Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/user-add-membership.html:3
+msgid "Add membership"
+msgstr ""
+
+#: pkg/users/index.html:351
+msgid "Add public key"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2833
+msgid "Adding <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/users/authorized-keys.js:108
+msgid "Adding key"
+msgstr "Ajout de la clé"
+
+#: pkg/storaged/jobs.js:153
+msgid "Adding physical volume to $target"
+msgstr ""
+
+#: pkg/docker/index.html:329
+msgid "Additional Storage"
+msgstr ""
+
+#: pkg/ostree/index.html:121 pkg/ostree/index.html:140
+msgid "Additions"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:8
+#: pkg/kubernetes/views/dashboard-page.html:157
+#: pkg/kubernetes/views/details-page.html:174
+#: pkg/kubernetes/views/nodes-page.html:43
+#: pkg/kubernetes/views/auth-form.html:29 pkg/kubernetes/views/node-body.html:5
+#: pkg/lib/machine-add.html:11
+msgid "Address"
+msgstr "Adresse"
+
+#: pkg/kubernetes/views/details-page.html:37
+msgid "Addresses"
+msgstr "Adresses"
+
+#: pkg/kubernetes/views/service-modify.html:25
+msgid "Adjust"
+msgstr "Ajuster"
+
+#: pkg/kubernetes/views/pv-modify.html:3
+msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-modify.html:3
+msgid "Adjust Replication Controller {{ item.metadata.name }}"
+msgstr ""
+
+#: pkg/kubernetes/views/route-modify.html:3
+msgid "Adjust Route"
+msgstr ""
+
+#: pkg/kubernetes/views/service-modify.html:3
+msgid "Adjust Service"
+msgstr "Ajuster le service"
+
+#: pkg/kubernetes/views/project-body.html:56
+msgid "Admin"
+msgstr ""
+
+#: pkg/systemd/services.html:389 pkg/systemd/services.html:393
+msgid "After system boot"
+msgstr ""
+
+#: pkg/systemd/logs.html:50
+msgid "All"
+msgstr "Tout"
+
+#: pkg/kubernetes/views/filter-project.html:4
+msgid "All Projects"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:6
+msgid "All Types"
+msgstr ""
+
+#: pkg/docker/storage.jsx:366
+msgid ""
+"All data on selected disks will be erased and disks will be added to the "
+"storage pool."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:112
+msgid "All healthy"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:74
+msgid "All images"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:69
+msgid "All in use"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:37
+msgid "All running"
+msgstr ""
+
+#: pkg/docker/index.html:569
+msgid "Always"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-meta.html:2
+#: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/image-meta.html:9
+#: pkg/kubernetes/views/node-body.html:57
+msgid "Annotations"
+msgstr ""
+
+#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
+msgid "Apply"
+msgstr "Appliquer"
+
+#: pkg/selinux/setroubleshoot-view.jsx:107
+msgid "Apply this solution"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:82
+msgid "Applying solution..."
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:12
+msgid "Architecture"
+msgstr ""
+
+#: pkg/storaged/index.html:451
+msgctxt "storage"
+msgid "Assessment"
+msgstr ""
+
+#: pkg/systemd/index.html:81
+msgid "Asset Tag"
 msgstr ""
 
 #: pkg/storaged/overview.js:455
 msgid "At least $0 disks are needed."
 msgstr ""
 
-#: pkg/storaged/overview.js:487
-msgid "Create Volume Group"
-msgstr "Créer un groupe de volumes"
+#: pkg/storaged/overview.js:501 pkg/storaged/details.js:579
+#: pkg/storaged/details.js:948
+msgid "At least one disk is needed."
+msgstr "Au moins un disque est nécessaire."
 
-#: pkg/storaged/overview.js:515
-msgid "Add iSCSI Portal"
+#: pkg/systemd/services.html:394
+msgid "At specific time"
 msgstr ""
 
-#: pkg/storaged/overview.js:518
-msgid "Server Address"
+#: pkg/networkmanager/interfaces.js:813
+msgid "Authenticating"
+msgstr "Authentification"
+
+#: pkg/realmd/operation.html:34 pkg/shell/index.html:48
+#: pkg/shell/index.html:159 pkg/kubernetes/views/auth-form.html:85
+#: pkg/lib/machine-change-auth.html:32
+msgid "Authentication"
+msgstr "Authentification"
+
+#: pkg/lib/machine-auth-failed.html:2
+msgid "Authentication Failed"
 msgstr ""
 
-#: pkg/storaged/overview.js:521
-#, fuzzy
-msgid "Server address cannot be empty."
-msgstr "Le nom ne peut être vide."
+#: pkg/docker/index.html:730 pkg/kubernetes/views/image-body.html:12
+#: pkg/kubernetes/views/image-listing.html:15
+msgid "Author"
+msgstr "Auteur"
 
-#: pkg/storaged/overview.js:533 pkg/realmd/operation.html.h:11
-msgid "Next"
-msgstr "Suivant"
-
-#: pkg/storaged/overview.js:577 pkg/storaged/overview.js:668
-#: pkg/subscriptions/subscriptions-client.js:194
-msgid "Invalid username or password"
+#: pkg/users/index.html:130
+msgid "Authorized Public SSH Keys"
 msgstr ""
 
-#: pkg/storaged/overview.js:582
-msgid "Unknown host name"
+#: pkg/networkmanager/index.html:165
+msgid "Automatic"
+msgstr "Automatique"
+
+#: pkg/networkmanager/interfaces.js:1814
+msgid "Automatic (DHCP only)"
+msgstr "Automatique (DHCP uniquement)"
+
+#: pkg/networkmanager/interfaces.js:1804
+msgid "Automatic (DHCP)"
+msgstr "Automatique (DHCP)"
+
+#: pkg/systemd/index.html:406
+msgid "Automatically using NTP"
 msgstr ""
 
-#: pkg/storaged/overview.js:586
-msgid "Unable to reach server"
+#: pkg/systemd/index.html:407
+msgid "Automatically using specific NTP servers"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:66
+msgid "Available"
 msgstr ""
 
 #: pkg/storaged/overview.js:619
 msgid "Available targets on $0"
 msgstr ""
 
-#: pkg/storaged/overview.js:623 pkg/systemd/services.html.h:2
-msgid "Targets"
+#: pkg/dashboard/index.html:177
+msgid "Avatar"
 msgstr ""
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-add.html.h:2
-#: pkg/kubernetes/views/node-body.html.h:2
-#: pkg/kubernetes/views/auth-form.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:16
-#: pkg/kubernetes/views/nodes-page.html.h:7
-#: pkg/kubernetes/views/details-page.html.h:19
-msgid "Address"
-msgstr "Adresse"
+#: pkg/kubernetes/scripts/volumes.js:207
+msgid "Azure"
+msgstr ""
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-change-port.html.h:5
-msgid "Port"
+#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
+msgid "Bad data passed for passwd1 mechanism"
+msgstr "Données incorrectes passées au mécanisme passwd1"
+
+#: pkg/networkmanager/index.html:389
+msgid "Balancer"
+msgstr ""
+
+#: pkg/storaged/index.html:560
+msgctxt "storage"
+msgid "Bitmap"
+msgstr ""
+
+#: pkg/storaged/index.html:414
+msgid "Block Device"
+msgstr ""
+
+#: pkg/storaged/details.js:871
+msgid "Block device for filesystems"
+msgstr ""
+
+#: pkg/storaged/details.js:1596
+msgid "Blocked"
+msgstr "Bloqué"
+
+#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
+#: pkg/networkmanager/interfaces.js:2507
+msgid "Bond"
+msgstr "Bond"
+
+#: pkg/networkmanager/index.html:596
+msgid "Bond Settings"
+msgstr "Réglages de la liaison d'interfaces"
+
+#: pkg/kubernetes/views/node-body.html:17
+msgid "Boot ID"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
+#: pkg/networkmanager/interfaces.js:2584
+msgid "Bridge"
+msgstr "Pont"
+
+#: pkg/networkmanager/index.html:708
+msgid "Bridge Port Settings"
+msgstr "Réglages de port du pont"
+
+#: pkg/networkmanager/index.html:680
+msgid "Bridge Settings"
+msgstr "Réglages du pont"
+
+#: pkg/networkmanager/interfaces.js:2605
+msgid "Bridge port"
+msgstr "Port de pont"
+
+#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
+msgid "Broadcast"
+msgstr "Broadcast"
+
+#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#, fuzzy
+msgid "Broken configuration"
+msgstr "Configuration inconnue"
+
+#: pkg/kubernetes/views/image-body.html:16
+msgid "Built"
+msgstr ""
+
+#: pkg/dashboard/index.html:70
+msgid "CPU"
+msgstr "CPU"
+
+#: pkg/systemd/host.js:1381
+msgctxt "page-title"
+msgid "CPU Status"
+msgstr "État du CPU"
+
+#: pkg/kubernetes/scripts/nodes.js:712
+msgid "CPU Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:490 pkg/docker/index.html:669
+msgid "CPU priority"
+msgstr "Priorité en CPU"
+
+#: pkg/systemd/index.html:247
+msgid "Cached"
+msgstr "En cache"
+
+#: pkg/docker/index.html:63
+msgid "Can&rsquo;t connect to Docker"
+msgstr ""
+
+#: pkg/systemd/services.html:465 pkg/dashboard/index.html:189
+#: pkg/playground/translate.html:40 pkg/playground/translate.html:174
+#: pkg/realmd/operation.html:90 pkg/kubernetes/views/pv-modify.html:202
+#: pkg/kubernetes/views/item-delete.html:10
+#: pkg/kubernetes/views/add-user-dialog.html:30
+#: pkg/kubernetes/views/project-modify.html:71
+#: pkg/kubernetes/views/node-add.html:49
+#: pkg/kubernetes/views/pvc-delete.html:14
+#: pkg/kubernetes/views/node-delete.html:14
+#: pkg/kubernetes/views/imagestream-modify.html:96
+#: pkg/kubernetes/views/imagestream-delete.html:7
+#: pkg/kubernetes/views/user-modify.html:30
+#: pkg/kubernetes/views/add-group-dialog.html:20
+#: pkg/kubernetes/views/project-delete.html:8
+#: pkg/kubernetes/views/service-modify.html:24
+#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/kubernetes/views/user-group-remove.html:9
+#: pkg/kubernetes/views/user-add-membership.html:52
+#: pkg/kubernetes/views/add-member-role-dialog.html:60
+#: pkg/kubernetes/views/group-delete.html:20
+#: pkg/kubernetes/views/image-delete.html:7 pkg/kubernetes/views/deploy.html:61
+#: pkg/kubernetes/views/user-group-add.html:31
+#: pkg/kubernetes/views/auth-form.html:128
+#: pkg/kubernetes/views/auth-rejected-cert.html:31
+#: pkg/kubernetes/views/replicationcontroller-modify.html:16
+#: pkg/kubernetes/views/pv-delete.html:10
+#: pkg/kubernetes/views/add-role-dialog.html:7
+#: pkg/kubernetes/views/route-modify.html:16
+#: pkg/kubernetes/views/user-delete.html:24
+#: pkg/kubernetes/views/remove-role-dialog.html:7 pkg/storaged/index.html:289
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:79
+msgid "Cancel"
+msgstr "Annuler"
+
+#: pkg/shell/indexes.js:322
+msgid "Cannot connect to an unknown machine"
+msgstr "Impossible de se connecter à une machine inconnue"
+
+#: src/ws/cockpitcertificate.c:359
+msgid "Cannot decrypt PEM-encoded private key"
+msgstr "Impossible de déchiffrer la clé privée encodée en PEM"
+
+#: src/base1/cockpit.js:3707
+msgid "Cannot forward login credentials"
+msgstr ""
+
+#: pkg/realmd/operation.js:417
+msgid "Cannot join a domain because realmd is not available on this system"
+msgstr ""
+"Impossible de rejoindre un domaine car reamld n'est pas disponible sur ce "
+"système"
+
+#: pkg/kubernetes/views/pv-modify.html:44
+#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pv-body.html:13
+msgid "Capacity"
+msgstr ""
+
+#: pkg/storaged/index.html:443 pkg/storaged/index.html:519
+#: pkg/storaged/index.html:551 pkg/storaged/index.html:630
+msgctxt "storage"
+msgid "Capacity"
+msgstr "Capacité"
+
+#: pkg/networkmanager/interfaces.js:2276
+msgid "Carrier"
+msgstr "Porteuse"
+
+#: pkg/kubernetes/scripts/volumes.js:203
+msgid "Ceph Filesystem Mount"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:97
+msgid "Ceph Monitors"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:204
+#: pkg/kubernetes/views/project-modify.html:74
+#: pkg/kubernetes/views/replicationcontroller-modify.html:17
+#: pkg/kubernetes/views/route-modify.html:17
+msgid "Change"
+msgstr ""
+
+#: pkg/shell/index.html:278
+msgid "Change Password"
+msgstr ""
+
+#: pkg/tuned/dialog.js:191
+msgid "Change Performance Profile"
+msgstr "Modifier le profil de performance"
+
+#: pkg/tuned/dialog.js:200
+msgid "Change Profile"
+msgstr "Modifier le profil"
+
+#: pkg/kubernetes/views/user-modify.html:3
+msgid "Change User"
 msgstr ""
 
 #: pkg/storaged/overview.js:699
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
-#: pkg/storaged/overview.js:707 pkg/kubernetes/views/route-modify.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:22
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:4
-#: pkg/kubernetes/views/project-modify.html.h:9
-msgid "Change"
+#: pkg/kubernetes/views/imagestream-modify.html:4
+msgid "Change image stream"
 msgstr ""
 
-#: pkg/storaged/utils.js:88
-msgctxt "format-bytes"
-msgid "bytes"
-msgstr "octets"
+#: pkg/kubernetes/views/project-modify.html:10
+msgid "Change project"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2872
+#, fuzzy
+msgid "Change the settings"
+msgstr "Réglages de port du pont"
+
+#: pkg/networkmanager/interfaces.js:2870
+msgid "Changing the settings will break the connection to the server, "
+msgstr ""
+
+#: pkg/ostree/index.html:48
+msgid "Check for updates"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:817
+msgid "Checking IP"
+msgstr "Vérification IP"
+
+#: pkg/storaged/jobs.js:143
+#, fuzzy
+msgid "Checking RAID Device $target"
+msgstr "Périphérique RAID $0"
+
+#: pkg/storaged/jobs.js:144
+msgid "Checking and Repairing RAID Device $target"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:70
+msgid "Checking for public keys"
+msgstr ""
+
+#: pkg/ostree/app.js:219
+msgid "Checking for updates"
+msgstr ""
+
+#: pkg/shell/simple.html:100 pkg/shell/index.html:121 pkg/shell/stub.html:114
+msgid "Choose the language to be used in the application"
+msgstr "Choisir la langue à utiliser dans l'application"
+
+#: pkg/storaged/overview.js:431
+msgid "Chunk Size"
+msgstr "Taille de bloc"
+
+#: pkg/kubernetes/scripts/volumes.js:202
+msgid "Cinder"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
+msgid "Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:4
+msgid "Claim Name"
+msgstr ""
+
+#: pkg/storaged/jobs.js:135
+msgid "Cleaning up for $target"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:88
+msgid "Client Certificate"
+msgstr ""
+
+#: pkg/systemd/services.html:306 pkg/systemd/services.html:324
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-invalid-hostkey.html:19
+msgid "Close"
+msgstr "Fermer"
+
+#: pkg/kubernetes/views/auth-form.html:5
+msgid "Cluster"
+msgstr ""
+
+#: cockpit.desktop.in.h:1
+msgid "Cockpit"
+msgstr "Cockpit"
+
+#: pkg/lib/machine-dialogs.js:429
+msgid ""
+"Cockpit could not contact the given host $0. Make sure it has ssh running on "
+"port $1, or specify another port in the address."
+msgstr ""
+"Cockpit ne peut contacter l'hôte indiqué $0. Assurez-vous que ssh est bien "
+"en écoute sur le port $1, ou indiquez un autre port dans l'adresse."
+
+#: src/base1/cockpit.js:3713
+msgid "Cockpit could not contact the given host."
+msgstr ""
+
+#: pkg/shell/base_index.js:671
+msgid "Cockpit had an unexpected internal error. <br/><br/>"
+msgstr "Cockpit a rencontré une erreur interne inattendue. <br/><br/>"
+
+#: cockpit.appdata.xml.in.h:1
+msgid ""
+"Cockpit is a server manager that makes it easy to administer your Linux "
+"servers via a web browser. Jumping between the terminal and the web tool is "
+"no problem. A service started via Cockpit can be stopped via the terminal. "
+"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
+"journal interface."
+msgstr ""
+
+#: src/base1/cockpit.js:3711
+msgid "Cockpit is not compatible with the software on the system."
+msgstr ""
+
+#: pkg/lib/machine-not-supported.html:2
+msgid "Cockpit is not installed"
+msgstr ""
+
+#: src/base1/cockpit.js:3705
+msgid "Cockpit is not installed on the system."
+msgstr ""
+
+#: cockpit.appdata.xml.in.h:2
+msgid ""
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
+"tasks such as storage administration, inspecting journals and starting and "
+"stopping services. You can monitor and administer several servers at the "
+"same time. Just add them with a single click and your machines will look "
+"after its buddies."
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:9
+msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:15
+msgid ""
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:9
+msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:6
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
+"machine with cockpit you will need to enable one of the following "
+"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:13
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
+"change your authentication credentials below. {{#can_sync}}You may prefer to "
+"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+msgstr ""
+
+#: pkg/dashboard/index.html:171 pkg/lib/machine-add.html:27
+msgid "Color"
+msgstr ""
+
+#: pkg/docker/index.html:95
+msgid "Combined CPU usage"
+msgstr ""
+
+#: pkg/docker/index.html:101
+msgid "Combined memory usage"
+msgstr ""
+
+#: pkg/systemd/services.html:370 pkg/docker/index.html:466
+#: pkg/docker/index.html:736
+msgid "Command"
+msgstr "Commande"
+
+#: pkg/docker/run.js:332
+#, fuzzy
+msgid "Command can't be empty"
+msgstr "Le nom ne peut être vide."
+
+#: pkg/docker/containers-view.jsx:239
+#, fuzzy
+msgid "Commit"
+msgstr "Commande"
+
+#: pkg/tuned/dialog.js:114
+msgid "Communication with tuned has failed"
+msgstr "La communication avec tuned a échoué"
+
+#: pkg/storaged/details.js:348
+msgid "Compatible with all systems and devices (MBR)"
+msgstr "Compatible avec tous les systèmes et périphériques (MBR)"
+
+#: pkg/storaged/details.js:349
+msgid "Compatible with modern system and hard disks > 2TB (GPT)"
+msgstr ""
+"Compatible avec les systèmes modernes et disques durs de taille > 2 Tio (GPT)"
+
+#: pkg/realmd/operation.html:28
+msgid "Computer OU"
+msgstr "OU Computer"
+
+#: pkg/kubernetes/views/node-add.html:24
+msgid "Configuration"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2441
+msgid "Configure"
+msgstr "Configurer"
+
+#: pkg/kubernetes/views/node-add.html:42
+msgid "Configure Flannel networking"
+msgstr "Configurer le réseau Flannel"
+
+#: pkg/kubernetes/views/node-add.html:32
+msgid "Configure Kubelet and Proxy"
+msgstr "Configurer le Kubelet et le mandataire"
+
+#: pkg/networkmanager/interfaces.js:811
+msgid "Configuring"
+msgstr "Configuration"
+
+#: pkg/networkmanager/interfaces.js:815
+msgid "Configuring IP"
+msgstr "Configuration IP"
+
+#: pkg/users/index.html:171 pkg/shell/index.html:262
+msgid "Confirm"
+msgstr ""
+
+#: pkg/users/index.html:247
+msgid "Confirm New Password"
+msgstr ""
+
+#: pkg/storaged/details.js:229
+msgid "Confirm passphrase"
+msgstr "Confirmer la phrase de passe"
+
+#: pkg/kubernetes/views/auth-form.html:130
+#: pkg/kubernetes/views/auth-rejected-cert.html:33
+#: pkg/lib/machine-unknown-hostkey.html:22
+msgid "Connect"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2637
+msgid "Connect automatically"
+msgstr "Connexion automatique"
+
+#: pkg/ostree/index.html:218
+msgid "Connecting"
+msgstr ""
+
+#: pkg/lib/machine-add.html:39
+msgid ""
+"Connecting simultaneously to more than {{ limit }} machines is unsupported."
+msgstr ""
+
+#: pkg/docker/index.html:54
+msgid "Connecting to Docker"
+msgstr "Connexion à Docker"
+
+#: pkg/shell/indexes.js:317
+msgid "Connecting to the machine"
+msgstr "Connexion à la machine"
+
+#: pkg/kubernetes/registry.html:70 pkg/kubernetes/index.html:100
+msgid "Connecting..."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-dialog.html:4
+msgid "Connection Error"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:516
+msgid "Connection Error: $0"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-dialog.html:3
+msgid "Connection Settings"
+msgstr ""
+
+#: src/base1/cockpit.js:3703
+msgid "Connection has timed out."
+msgstr ""
+
+#: pkg/networkmanager/index.html:812
+msgid "Connection will be lost"
+msgstr ""
+
+#: pkg/docker/console.html:4 pkg/kubernetes/views/container-panel.html:4
+#: pkg/kubernetes/views/image-panel.html:12
+#: pkg/kubernetes/views/container-body.html:4
+#: pkg/kubernetes/views/container-page-inline.html:2
+#: pkg/kubernetes/views/image-page.html:19
+msgid "Container"
+msgstr "Conteneur"
+
+#: pkg/users/local.js:684
+msgid "Container Administrator"
+msgstr "Administrateur de conteneurs"
+
+#: pkg/kubernetes/views/container-body.html:10
+msgid "Container ID"
+msgstr ""
+
+#: pkg/docker/index.html:459 pkg/docker/index.html:646
+#: pkg/docker/index.html:712
+msgid "Container Name"
+msgstr "Nom du conteneur"
+
+#: pkg/kubernetes/views/node-body.html:21
+msgid "Container Runtime Version"
+msgstr ""
+
+#: pkg/docker/util.js:490
+msgid ""
+"Container is currently marked as not running, but regular stopping failed."
+msgstr "Le conteneur est marqué comme arrêté, mais l'arrêt normal a échoué."
+
+#: pkg/docker/util.js:488
+msgid "Container is currently running."
+msgstr "Le conteneur est en cours d'exécution"
+
+#: pkg/docker/index.html:23 pkg/docker/index.html:309
+#: pkg/kubernetes/views/pod-page.html:36
+#: pkg/kubernetes/views/dashboard-page.html:158
+#: pkg/kubernetes/views/dashboard-page.html:199
+#: pkg/kubernetes/views/containers-listing.html:5 pkg/kubernetes/index.html:51
+msgid "Containers"
+msgstr "Conteneurs"
+
+#: pkg/docker/details.js:47 pkg/docker/image.js:43
+msgctxt "page-title"
+msgid "Containers"
+msgstr "Conteneurs"
+
+#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
+msgid "Content"
+msgstr "Contenu"
+
+#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
+#: pkg/playground/translate.js:19
+#, fuzzy
+msgid "Control"
+msgstr "Conteneur"
+
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
+#: pkg/playground/translate.js:22
+#, fuzzy
+msgctxt "key"
+msgid "Control"
+msgstr "Conteneur"
+
+#: pkg/docker/storage.jsx:404
+msgid "Could not add all disks"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:4
+msgid "Could not contact {{host}}"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:142
+msgid "Could not list services"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:407
+msgid "Could not parse PEM-encoded certificate"
+msgstr "Échec de l'analyse du certificat encodé en PEM"
+
+#: src/ws/cockpitcertificate.c:374
+msgid "Could not parse PEM-encoded private key"
+msgstr "Échec de l'analyse de la clé privée encodée en PEM"
+
+#: pkg/docker/storage.jsx:446
+msgid "Could not reset the storage pool"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:467
+msgid "Couldn't change user groups"
+msgstr "Impossible de modifier les groupes utilisateurs"
+
+#: src/bridge/cockpitdbussetup.c:520
+msgid "Couldn't change user password"
+msgstr "Impossible de modifier le mot de passe de l'utilisateur"
+
+#: pkg/selinux/setroubleshoot-view.jsx:385
+msgid ""
+"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
+"server is installed."
+msgstr ""
+
+#: pkg/kubernetes/registry.html:71 pkg/kubernetes/index.html:101
+msgid "Couldn't connect to server"
+msgstr ""
+
+#: pkg/shell/indexes.js:320
+msgid "Couldn't connect to the machine"
+msgstr "Impossible de se connecter à la machine"
+
+#: src/bridge/cockpitdbussetup.c:544
+msgid "Couldn't create new users"
+msgstr "Impossible de créer de nouveaux utilisateurs"
+
+#: pkg/kubernetes/scripts/connection.js:514
+msgid "Couldn't find running API server"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:196
+msgid ""
+"Couldn't get system subscription status. Please ensure subscription-manager "
+"is installed."
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:642
+msgid "Couldn't list local users"
+msgstr "Impossible d'énumérer les utilisateurs locaux"
+
+#: src/bridge/cockpitdbussetup.c:236
+msgid "Couldn't list users"
+msgstr "Impossible d'énumérer les utilisateurs"
+
+#: src/bridge/cockpitdbussetup.c:382
+msgid "Couldn't load user data"
+msgstr "Impossible de charger les données utilisateur"
+
+#: pkg/kubernetes/views/project-modify.html:72
+#: pkg/kubernetes/views/add-group-dialog.html:21
+msgid "Create"
+msgstr "Créer"
+
+#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
+msgid "Create Logical Volume"
+msgstr ""
+
+#: pkg/users/index.html:54 pkg/users/index.html:143
+msgid "Create New Account"
+msgstr ""
+
+#: pkg/storaged/details.js:1379
+msgid "Create Partition"
+msgstr "Créer la partition"
+
+#: pkg/storaged/overview.js:414
+msgid "Create RAID Device"
+msgstr "Créer un périphérique RAID"
+
+#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
+msgid "Create Snapshot"
+msgstr "Créer un instantané"
+
+#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
+msgid "Create Thin Volume"
+msgstr ""
+
+#: pkg/systemd/services.html:336
+#, fuzzy
+msgid "Create Timers"
+msgstr "Créer"
+
+#: pkg/storaged/overview.js:487
+msgid "Create Volume Group"
+msgstr "Créer un groupe de volumes"
+
+#: pkg/sosreport/index.html:50
+msgid "Create diagnostic report"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:3
+msgid "Create image stream"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
+#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
+#, fuzzy
+msgid "Create it"
+msgstr "Créer"
+
+#: pkg/storaged/details.js:266
+msgid "Create partition"
+msgstr "Créer la partition"
+
+#: pkg/storaged/details.js:113
+msgid "Create partition on $0"
+msgstr "Créer une partition sur $0"
+
+#: pkg/storaged/index.html:381
+msgid "Create partition table"
+msgstr ""
+
+#: pkg/sosreport/index.html:42
+msgid "Create report"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/replicationcontroller-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7 pkg/kubernetes/views/route-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3
+msgid "Created"
+msgstr ""
+
+#: pkg/storaged/jobs.js:142
+msgid "Creating RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:130
+msgid "Creating filesystem on $target"
+msgstr "Création du système de fichier sur $target"
+
+#: pkg/storaged/jobs.js:156
+msgid "Creating logical volume $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:134
+msgid "Creating partition $target"
+msgstr "Création de la partition sur $target"
+
+#: pkg/storaged/jobs.js:150
+msgid "Creating snapshot of $target"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:4064
+msgid "Creating this VLAN will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3436
+msgid "Creating this bond will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3842
+msgid "Creating this bridge will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3611
+msgid "Creating this team will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:151
+msgid "Creating volume group $target"
+msgstr ""
+
+#: pkg/systemd/logs.html:41
+msgid "Current boot"
+msgstr ""
+
+#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
+msgid "Custom"
+msgstr "Personnalisé"
+
+#: pkg/storaged/details.js:186
+msgid "Custom (Enter filesystem type)"
+msgstr "Personnalisé (indiquer le type de système de fichiers)"
+
+#: pkg/subscriptions/subscriptions-register.jsx:102
+#, fuzzy
+msgid "Custom URL"
+msgstr "Personnalisé"
+
+#: pkg/storaged/index.html:454
+msgid "DISK IS FAILING"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3018
+msgid "DNS"
+msgstr "DNS"
+
+#: pkg/kubernetes/views/pod-body.html:14
+msgid "DNS Policy"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3022
+msgid "DNS Search Domains"
+msgstr "Domaines de recherche DNS"
+
+#: pkg/dashboard/index.html:22
+msgid "Dashboard"
+msgstr ""
+
+#: pkg/storaged/details.js:1130
+msgid "Deactivate"
+msgstr "Désactiver"
+
+#: pkg/networkmanager/interfaces.js:823
+msgid "Deactivating"
+msgstr "Désactivation"
+
+#: pkg/storaged/jobs.js:149
+msgid "Deactivating $target"
+msgstr ""
+
+#: pkg/docker/index.html:379 pkg/docker/index.html:383
+#: pkg/kubernetes/views/image-config.html:6
+msgid "Default"
+msgstr "Par défaut"
+
+#: pkg/systemd/index.html:454
+msgid "Delay"
+msgstr ""
+
+#: pkg/users/index.html:79 pkg/kubernetes/views/item-delete.html:11
+#: pkg/kubernetes/views/pvc-delete.html:15
+#: pkg/kubernetes/views/node-delete.html:15
+#: pkg/kubernetes/views/imagestream-delete.html:8
+#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/kubernetes/views/image-delete.html:8
+#: pkg/kubernetes/views/pv-delete.html:11
+msgid "Delete"
+msgstr "Supprimer"
+
+#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
+msgid "Delete $0"
+msgstr "Supprimer $0"
+
+#: pkg/users/index.html:292
+msgid "Delete Files"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:4
+msgid "Delete Node"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:3
+msgid "Delete Persistent Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:3
+msgid "Delete Persistent Volume Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/project-delete.html:3
+msgid "Delete Project"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:3
+msgid "Delete Selected"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:3
+msgid "Delete image stream"
+msgstr ""
+
+#: pkg/playground/translate.html:184 pkg/kubernetes/views/item-delete.html:3
+msgid "Delete {{ item.kind }}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
+msgid "Deleting $target"
+msgstr "Suppression de $target"
+
+#: pkg/networkmanager/interfaces.js:2156
+msgid "Deleting <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:7
+msgid ""
+"Deleting a Pod will kill all associated containers. Pods may be "
+"automatically created again in some cases."
+msgstr ""
+
+#: pkg/storaged/details.js:631
+msgid "Deleting a RAID device will erase all data on it."
+msgstr ""
+"Supprimer un périphérique RAID en effacera toutes les données qu'il contient."
+
+#: pkg/docker/containers-view.jsx:167 pkg/docker/details.js:272
+msgid "Deleting a container will erase all data in it."
+msgstr "Supprimer un conteneur en supprimera toutes les données"
+
+#: pkg/storaged/details.js:1009
+msgid "Deleting a logical volume will delete all data in it."
+msgstr ""
+"Supprimer un volume logique en effacera toutes les données qu'il contient."
+
+#: pkg/storaged/details.js:1012
+msgid "Deleting a partition will delete all data in it."
+msgstr ""
+"Supprimer une partition en effacera toutes les données qu'elle contient."
+
+#: pkg/storaged/details.js:826
+msgid "Deleting a volume group will erase all data on it."
+msgstr ""
+"Supprimer un groupe de volumes en effacera toutes les données qu'il contient."
+
+#: pkg/docker/image.js:152
+msgid ""
+"Deleting an image will delete it, but you can probably download it again if "
+"you need it later.  Unless this image has never been pushed to a repository, "
+"that is, in which case you probably can't download it again."
+msgstr ""
+"Supprimer une image la supprimera, mais il sera probablement possible de la "
+"récupérer à nouveau plus tard. Si cette image n'a jamais été poussée sur un "
+"dépôt, il ne sera probablement pas possible de la récupérer."
+
+#: pkg/storaged/jobs.js:152
+msgid "Deleting volume group $target"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:131
+#: pkg/kubernetes/views/deploy.html:62
+msgid "Deploy"
+msgstr ""
+
+#: pkg/kubernetes/views/deploy.html:3
+msgid "Deploy Application"
+msgstr "Déployer l'application"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:22
+msgid "Deployment Causes"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-panel.html:8
+#: pkg/kubernetes/views/deploymentconfig-page.html:12
+msgid "Deployment Config"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:98
+msgid "Deployment Configs"
+msgstr ""
+
+#: pkg/systemd/services.html:356 pkg/kubernetes/views/project-modify.html:40
+#: pkg/kubernetes/views/image-body.html:6
+#: pkg/kubernetes/views/project-listing.html:15
+#: pkg/kubernetes/views/project-listing.html:54
+msgid "Description"
+msgstr ""
+
+#: pkg/shell/index.html:197 pkg/kubernetes/index.html:63
+msgid "Details"
+msgstr ""
+
+#: pkg/storaged/index.html:543
+msgctxt "storage"
+msgid "Device"
+msgstr "Périphérique"
+
+#: pkg/storaged/details.js:91
+msgid "Device $0 is a member of RAID Array $1"
+msgstr "Le périphérique $0 est membre de la grappe RAID $1"
+
+#: pkg/storaged/details.js:97
+msgid "Device $0 is a physical volume of $1"
+msgstr "Le périphérique $0 est un volume physique de $1"
+
+#: pkg/storaged/details.js:85
+msgid "Device $0 is mounted on $1"
+msgstr "Le périphérique $0 est monté sur $1"
+
+#: pkg/storaged/index.html:467 pkg/storaged/index.html:473
+#: pkg/storaged/index.html:515
+#, fuzzy
+msgctxt "storage"
+msgid "Device File"
+msgstr "Périphérique"
+
+#: pkg/sosreport/index.html:22
+msgid "Diagnostic reports"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:20
+msgid "Digest"
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:7
+#: pkg/kubernetes/views/volume-body.html:28
+msgid "Directory"
+msgstr ""
+
+#: pkg/systemd/init.js:543
+msgid "Disable"
+msgstr "Désactiver"
+
+#: pkg/tuned/dialog.js:234
+msgid "Disable tuned"
+msgstr "Désactiver tuned"
+
+#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
+msgid "Disabled"
+msgstr "Désactivé"
+
+#: pkg/shell/simple.html:120
+msgid "Disconnected"
+msgstr "Déconnecté"
+
+#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+msgid "Disk"
+msgstr ""
+
+#: pkg/dashboard/index.html:73
+#, fuzzy
+msgid "Disk I/O"
+msgstr "Le disque est OK"
+
+#: pkg/kubernetes/scripts/nodes.js:720
+msgid "Disk Utilization: $0%"
+msgstr ""
+
+#: pkg/storaged/index.html:457
+msgid "Disk is OK"
+msgstr "Le disque est OK"
+
+#: pkg/storaged/index.html:584
+msgid "Disks"
+msgstr "Disques"
+
+#: pkg/shell/simple.html:37 pkg/shell/simple.html:97 pkg/shell/index.html:37
+#: pkg/shell/index.html:118 pkg/shell/stub.html:37 pkg/shell/stub.html:111
+msgid "Display Language"
+msgstr "Langue d'affichage"
+
+#: pkg/kubernetes/views/project-modify.html:31
+msgid "Display name"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:5
+msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:5
+msgid ""
+"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}' image stream?"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:6
+msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:6
+msgid ""
+"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:6
+msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:7
+msgid "Do you want to delete this Node?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:5
+msgid ""
+"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+"{{stream.metadata.name}}:{{tag.tag}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/remove-role-dialog.html:5
+msgid ""
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:11
+msgid "Docker Version"
+msgstr ""
+
+#: pkg/docker/index.html:60
+msgid "Docker is not installed or activated on the system"
+msgstr "Docker n'est pas installé ou activé sur le système"
+
+#: pkg/systemd/index.html:107
+msgid "Domain"
+msgstr ""
+
+#: pkg/realmd/operation.js:148
+msgid "Domain $0 could not be contacted"
+msgstr "Le domaine $0 ne peut être contacté"
+
+#: pkg/realmd/operation.js:220
+msgid "Domain $0 is not supported"
+msgstr ""
+
+#: pkg/realmd/operation.html:11
+msgid "Domain Address"
+msgstr "Adresse de domaine"
+
+#: pkg/realmd/operation.html:59
+msgid "Domain Administrator Name"
+msgstr "Nom de l'administrateur du domaine"
+
+#: pkg/realmd/operation.html:65
+msgid "Domain Administrator Password"
+msgstr "Mot de passe de l'administrateur du domaine"
+
+#: pkg/systemd/services.html:426 pkg/systemd/services.html:430
+msgid "Don't Repeat"
+msgstr ""
+
+#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
+msgid "Don't overwrite existing data"
+msgstr "Ne pas écraser les données existantes"
+
+#: pkg/sosreport/index.html:74
+msgid "Done!"
+msgstr ""
+
+#: pkg/ostree/index.html:127 pkg/ostree/index.html:158
+msgid "Downgrades"
+msgstr ""
+
+#: pkg/storaged/index.html:411
+msgid "Drive"
+msgstr "Disque"
+
+#: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
+msgctxt "storage"
+msgid "Drive"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:128
+msgid "Driver"
+msgstr ""
+
+#: pkg/storaged/index.html:166
+msgid "Drives"
+msgstr "Disques"
+
+#: pkg/docker/run.js:360
+msgid "Duplicate alias"
+msgstr "Alias dupliqué"
+
+#: pkg/docker/run.js:293
+msgid "Duplicate port"
+msgstr "Port dupliqué"
+
+#: pkg/storaged/jobs.js:120
+msgid "Ejecting $target"
+msgstr ""
+
+#: pkg/playground/translate.html:58
+msgid "Empty"
+msgstr ""
+
+#: pkg/playground/translate.html:63
+msgctxt "verb"
+msgid "Empty"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:196
+msgid "Empty Directory"
+msgstr ""
+
+#: pkg/storaged/jobs.js:155
+msgid "Emptying $target"
+msgstr ""
+
+#: pkg/systemd/init.js:541
+msgid "Enable"
+msgstr "Activer"
+
+#: pkg/systemd/init.js:542
+msgid "Enable Forcefully"
+msgstr "Forcer l'activation"
+
+#: pkg/systemd/init.js:301
+msgid "Enabled"
+msgstr "Activé(e)"
+
+#: pkg/storaged/details.js:1247
+msgctxt "storage-id-desc"
+msgid "Encrypted"
+msgstr "Chiffré"
+
+#: pkg/storaged/details.js:180
+msgid "Encrypted EXT4 (LUKS)"
+msgstr "EXT4 chiffré (LUKS)"
+
+#: pkg/storaged/details.js:179
+msgid "Encrypted XFS (LUKS)"
+msgstr "XFS chiffré (LUKS)"
+
+#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
+#: pkg/storaged/details.js:1115
+msgid "Encryption Options"
+msgstr "Options de chiffrement"
+
+#: pkg/kubernetes/views/pv-modify.html:93
+msgid "Endpoint"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:40
+msgid "Endpoint Name"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:14
+#: pkg/kubernetes/views/service-panel.html:9
+msgid "Endpoints"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:38
+msgid "Ends"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:332
+msgid "Enforce policy:"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:447
+msgid "Enter IP address or host name"
+msgstr "Entrez l'adresse IP ou le nom d'hôte"
+
+#: pkg/systemd/logs.html:60
+msgid "Entry"
+msgstr ""
+
+#: pkg/docker/index.html:547 pkg/kubernetes/views/image-config.html:17
+#: pkg/kubernetes/views/container-body.html:26
+msgid "Environment"
+msgstr ""
+
+#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
+msgid "Erase"
+msgstr "Effacer"
+
+#: pkg/docker/storage.jsx:423
+msgid "Erase containers and reset storage pool"
+msgstr ""
+
+#: pkg/docker/storage.jsx:360
+msgid "Erase containers, reformat disks, and add them"
+msgstr ""
+
+#: pkg/storaged/jobs.js:129
+msgid "Erasing $target"
+msgstr "Effacement de $target"
+
+#: pkg/systemd/services.html:318 pkg/playground/translate.html:101
+#: pkg/playground/translate.html:106
+msgid "Error"
+msgstr "Erreur"
+
+#: pkg/kubernetes/scripts/connection.js:650
+msgid "Error getting certificate details: $0"
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:13
+msgid "Error loading users: {{perm_failed}}"
+msgstr ""
+
+#: pkg/docker/util.js:491
+msgid "Error message from Docker:"
+msgstr "Message d'erreur de Docker :"
+
+#: pkg/users/authorized-keys.js:115
+msgid "Error saving authorized keys: "
+msgstr "Erreur pendant l'enregistrement du fichier authorized_keys :"
+
+#: pkg/selinux/setroubleshoot.js:275
+msgid "Error while connecting."
+msgstr "Erreur lors de la connexion."
+
+#: pkg/selinux/setroubleshoot-client.js:192
+msgid "Error while deleting alert"
+msgstr "Erreur lors de la suppression de l'alerte"
+
+#: pkg/selinux/setroubleshoot.js:65
+msgid "Error while setting SELinux mode: '$0'"
+msgstr "Erreur lors de la configuration du mode SELinux : « $0 »"
+
+#: pkg/kubernetes/scripts/connection.js:88
+msgid "Error writing kubectl config"
+msgstr ""
+
+#: pkg/systemd/logs.html:47
+msgid "Errors"
+msgstr ""
+
+#: pkg/networkmanager/index.html:764
+msgid "Ethernet MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1854
+msgid "Ethtool"
+msgstr ""
+
+#: pkg/users/local.js:429 pkg/users/local.js:1104
+msgid "Excellent password"
+msgstr "Mot de passe excellent"
+
+#: pkg/docker/util.js:96
+msgid "Exited $ExitCode"
+msgstr "Code de sortie $ExitCode"
+
+#: pkg/docker/index.html:529
+msgid "Expose container ports"
+msgstr ""
+
+#: pkg/storaged/details.js:183
+msgid "Extended Partition"
+msgstr "Partition étendue"
+
+#: pkg/storaged/details.js:1592
+msgid "FAILED"
+msgstr "EN ÉCHEC"
+
+#: pkg/ostree/index.html:92
+msgid "Failed"
+msgstr "Échec"
+
+#: pkg/lib/machine-dialogs.js:412
+msgid "Failed to add machine: $0"
+msgstr "Échec lors de l'ajout de la machine : $0"
+
+#: pkg/users/local.js:112 pkg/users/local.js:144 pkg/lib/credentials.js:223
+msgid "Failed to change password"
+msgstr "Échec du changement de mot de passe"
+
+#: pkg/selinux/setroubleshoot-client.js:187
+msgid "Failed to delete alert"
+msgstr "Impossible de supprimer l'alerte"
+
+#: pkg/tuned/dialog.js:171
+msgid "Failed to disable tuned"
+msgstr ""
+
+#: pkg/tuned/dialog.js:133
+msgid "Failed to disable tuned profile"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:494
+msgid "Failed to edit machine: $0"
+msgstr "Impossible de modifier la machine : $0"
+
+#: pkg/tuned/dialog.js:169
+msgid "Failed to enable tuned"
+msgstr ""
+
+#: pkg/users/index.html:338
+msgid "Failed to load authorized keys."
+msgstr ""
+
+#: pkg/docker/containers.js:64
+msgid "Failed to start Docker: $0"
+msgstr "Échec du démarrage de Docker : $0"
+
+#: pkg/docker/util.js:544
+msgid "Failed to stop Docker scope: $0"
+msgstr "Échec de l'arrêt de la portée Docker : $0"
+
+#: pkg/tuned/dialog.js:145
+msgid "Failed to switch profile"
+msgstr "Échec lors du changement de profil"
+
+#: pkg/kubernetes/scripts/volumes.js:204
+msgid "Fibre Channel"
+msgstr ""
+
+#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
+msgid "Filesystem Options"
+msgstr "Options du système de fichiers"
+
+#: pkg/kubernetes/views/pv-modify.html:180
+#: pkg/kubernetes/views/volume-body.html:6
+#: pkg/kubernetes/views/volume-body.html:16
+#: pkg/kubernetes/views/volume-body.html:62
+#: pkg/kubernetes/views/volume-body.html:83
+#: pkg/kubernetes/views/volume-body.html:91
+#: pkg/kubernetes/views/volume-body.html:120
+#: pkg/kubernetes/views/volume-body.html:132
+msgid "Filesystem Type"
+msgstr ""
+
+#: pkg/storaged/details.js:215
+msgid "Filesystem type"
+msgstr "Type de système de fichiers"
+
+#: pkg/storaged/index.html:225
+msgid "Filesystems"
+msgstr "Systèmes de fichiers"
+
+#: pkg/lib/machine-unknown-hostkey.html:10
+msgid "Fingerprint"
+msgstr ""
+
+#: pkg/storaged/index.html:426
+#, fuzzy
+msgctxt "storage"
+msgid "Firmware Version"
+msgstr "Version"
+
+#: pkg/kubernetes/scripts/volumes.js:206
+msgid "Flex"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:205
+msgid "Flocker"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:125
+msgid "Flocker Dataset Name"
+msgstr ""
+
+#: pkg/docker/util.js:503
+msgid "Force Delete"
+msgstr "Forcer la suppression"
+
+#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
+#: pkg/storaged/details.js:1142
+msgid "Format"
+msgstr "Formater"
+
+#: pkg/storaged/details.js:115
+msgid "Format $0"
+msgstr "Formater $0"
+
+#: pkg/storaged/details.js:335
+msgid "Format Disk $0"
+msgstr "Formater le disque $0"
+
+#: pkg/storaged/details.js:358
+msgid "Formatting a disk will erase all data on it."
+msgstr "Formater un disque en effacera toutes les données qu'il contient."
+
+#: pkg/storaged/details.js:268
+msgid "Formatting a storage device will erase all data on it."
+msgstr ""
+"Formater un périphérique de stockage en effacera toutes les données qu'il "
+"contient."
+
+#: pkg/networkmanager/interfaces.js:2577
+#, fuzzy
+msgid "Forward delay $forward_delay"
+msgstr "Forward delay $forward_delay"
+
+#: pkg/systemd/index.html:255
+msgid "Free"
+msgstr "Disponible"
+
+#: pkg/users/index.html:86 pkg/users/index.html:148
+msgid "Full Name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:192
+msgid "GCE Persistent Disk"
+msgstr ""
+
+#: pkg/docker/index.html:180
+msgid "Gateway:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2628
+msgid "General"
+msgstr "Général"
+
+#: pkg/sosreport/index.html:66
+msgid "Generating report"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:194
+msgid "Git Repository"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:198
+msgid "Gluster FS"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:872
+msgid "GlusterFS"
+msgstr ""
+
+#: pkg/systemd/logs.js:130
+msgid "Go to"
+msgstr "Aller à"
+
+#: pkg/storaged/index.html:307 pkg/networkmanager/index.html:50
+#: pkg/networkmanager/index.html:496
+msgid "Go to now"
+msgstr "Aller à maintenant"
+
+#: pkg/kubernetes/views/group-page.html:21
+#: pkg/kubernetes/views/group-panel.html:12
+msgid "Group Members"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:48
+#: pkg/kubernetes/views/user-delete.html:14
+msgid "Groups"
+msgstr ""
+
+#: pkg/networkmanager/index.html:268
+msgid "Hair Pin mode"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2603
+msgid "Hairpin mode"
+msgstr ""
+
+#: pkg/docker/storage.jsx:157
+#, fuzzy
+msgid "Hard Disk"
+msgstr "Disque dur"
+
+#: pkg/storaged/overview.js:180
+msgctxt "storage"
+msgid "Hard Disk"
+msgstr "Disque dur"
+
+#: pkg/systemd/index.html:77
+msgid "Hardware"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2579
+msgid "Hello time $hello_time"
+msgstr "Hello time $hello_time"
+
+#: pkg/kubernetes/views/details-page.html:73
+#: pkg/kubernetes/views/route-body.html:9
+#: pkg/kubernetes/views/route-modify.html:8
+msgid "Host"
+msgstr "Hôte"
+
+#: pkg/systemd/index.html:102 pkg/dashboard/index.html:151
+msgid "Host Name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
+msgid "Host Path"
+msgstr ""
+
+#: src/base1/cockpit.js:3699
+msgid "Host key is incorrect"
+msgstr ""
+
+#: pkg/systemd/services.html:442
+msgid "Hour : Minute"
+msgstr ""
+
+#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
+msgid "Hour needs to be a number between 0-23"
+msgstr ""
+
+#: pkg/systemd/services.html:408
+#, fuzzy
+msgid "Hours"
+msgstr "6 heures"
+
+#: pkg/systemd/index.html:221
+msgid "I/O Wait"
+msgstr "Attente sur E/S"
+
+#: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
+msgid "IP"
+msgstr ""
+
+#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
+msgid "IP Address"
+msgstr "Adresse IP"
+
+#: pkg/docker/index.html:172
+msgid "IP Address:"
+msgstr ""
+
+#: pkg/docker/index.html:176
+msgid "IP Prefix Length:"
+msgstr ""
+
+#: pkg/networkmanager/index.html:568
+msgid "IP Settings"
+msgstr "Paramétrage IP"
+
+#: pkg/networkmanager/interfaces.js:2641
+msgid "IPv4"
+msgstr "IPv4"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv4 Settings"
+msgstr "Réglages IPv4"
+
+#: pkg/networkmanager/interfaces.js:2642
+msgid "IPv6"
+msgstr "IPv6"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv6 Settings"
+msgstr "Réglages IPv6"
+
+#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
+msgid "ISCSI"
+msgstr ""
+
+#: pkg/systemd/init.js:270
+msgid "Id"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2620
+msgid "Id $id"
+msgstr "Id $id"
+
+#: pkg/kubernetes/views/image-body.html:22
+msgid "Identifier"
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:23
+#: pkg/kubernetes/views/user-panel.html:18
+msgid "Identities"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:91
+msgid "Identity"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1817
+msgid "Ignore"
+msgstr "Ignorer"
+
+#: pkg/docker/index.html:452 pkg/kubernetes/views/image-panel.html:9
+#: pkg/kubernetes/views/container-body.html:6
+#: pkg/kubernetes/views/image-page.html:16
+msgid "Image"
+msgstr "Image"
+
+#: pkg/docker/image.js:77
+msgid "Image $0"
+msgstr "Image $0"
+
+#: pkg/kubernetes/views/container-body.html:8
+msgid "Image ID"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:16
+msgid "Image Layers"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:58
+msgid "Image Name"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:23
+msgid "Image Registry"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-page.html:16
+msgid "Image Stream"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:135
+msgid "Image commands"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:34
+msgid "Image count"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:48
+#: pkg/kubernetes/views/registry-dashboard-page.html:19
+#: pkg/kubernetes/views/imagestream-page.html:18
+#: pkg/kubernetes/views/image-listing.html:9 pkg/kubernetes/index.html:77
+msgid "Images"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:17
+msgid "Images by project"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:54
+msgid "Images pushed recently"
+msgstr ""
+
+#: pkg/storaged/details.js:1593
+msgid "In Sync"
+msgstr "En cours de synchronisation"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:81
+msgid ""
+"In order to begin pushing images to the registry, use the commands below."
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:6
+msgid ""
+"In order to begin pushing images to the registry, you need to create a "
+"project."
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:50
+msgid ""
+"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
+"strong}}.        {{/needs_root}}                                    User "
+"name                                                                            "
+"{{#allows_password}}                            "
+"Password                                                                            "
+"{{/allows_password}}            "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
+#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
+msgid "Inactive"
+msgstr "Inactif"
+
+#: pkg/lib/machine-invalid-hostkey.html:2
+msgid "Incorrect Host Key"
+msgstr ""
+
+#: pkg/docker/storage.jsx:282
+msgid "Information about the Docker storage pool is not available."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:222
+msgid "Installed products"
+msgstr ""
+
+#: pkg/systemd/services.html:135
+msgid "Instantiate"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:169
+#: pkg/kubernetes/views/volume-body.html:81
+msgid "Interface"
+msgstr ""
+
+#: pkg/networkmanager/index.html:84
+msgid "Interfaces"
+msgstr "Interfaces"
+
+#: src/base1/cockpit.js:3701
+msgid "Internal error"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:196
+#, fuzzy
+msgid "Invalid credentials"
+msgstr "Port invalide"
+
+#: pkg/systemd/host.js:1194
+msgid "Invalid date format"
+msgstr "Format de date invalide"
+
+#: pkg/systemd/host.js:1190
+msgid "Invalid date format and invalid time format"
+msgstr "Formats de date et d'heure invalides"
+
+#: pkg/systemd/init.js:1218
+#, fuzzy
+msgid "Invalid date format."
+msgstr "Format de date invalide"
+
+#: pkg/lib/credentials.js:274
+msgid "Invalid file permissions"
+msgstr "Permissions sur fichier invalide"
+
+#: pkg/users/index.html:322
+msgid "Invalid key"
+msgstr ""
+
+#: pkg/systemd/init.js:1169
+#, fuzzy
+msgid "Invalid number."
+msgstr "Port invalide"
+
+#: pkg/docker/run.js:283
+msgid "Invalid port"
+msgstr "Port invalide"
+
+#: pkg/systemd/host.js:1192
+msgid "Invalid time format"
+msgstr "Format d'heure invalide"
+
+#: pkg/subscriptions/subscriptions-client.js:194 pkg/storaged/overview.js:577
+#: pkg/storaged/overview.js:668
+msgid "Invalid username or password"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:15
+msgid "Is sshd running on a different port?"
+msgstr ""
+
+#: pkg/systemd/init.js:522
+msgid "Isolate"
+msgstr "Isoler"
+
+#: pkg/storaged/index.html:280
+msgid "Jobs"
+msgstr "Tâches"
+
+#: pkg/realmd/operation.js:96
+msgid "Join"
+msgstr "Rejoindre"
+
+#: pkg/realmd/operation.js:453
+msgid "Join Domain"
+msgstr "Rejoindre le domaine"
+
+#: pkg/realmd/operation.js:347
+msgid "Joining this domain is not supported"
+msgstr ""
+
+#: pkg/systemd/logs.js:257
+msgid "Journal entry"
+msgstr "Entrée de journal"
+
+#: pkg/systemd/logs.js:284
+msgid "Journal entry not found"
+msgstr "Entrée de journal introuvable"
+
+#: pkg/lib/machine-auth-failed.html:10
+msgid "Kerberos Based SSO"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:69
+msgid "Kerberos Ticket"
+msgstr ""
+
+#: pkg/systemd/index.html:225
+msgid "Kernel"
+msgstr "Noyau"
+
+#: pkg/kubernetes/views/node-body.html:19
+msgid "Kernel Version"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:67
+msgid "Key Ring Path"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:23
+msgid "Kubelet Version"
+msgstr ""
+
+#: pkg/kubernetes/index.html:23
+msgid "Kubernetes Cluster"
+msgstr "Grappe Kubernetes"
+
+#: pkg/networkmanager/index.html:473
+msgid "LACP Key"
+msgstr ""
+
+#: pkg/storaged/details.js:1245
+msgctxt "storage-id-desc"
+msgid "LUKS Encrypted"
+msgstr "Chiffré par LUKS"
+
+#: pkg/storaged/details.js:1226
+msgctxt "storage-id-desc"
+msgid "LVM2 Physical Volume"
+msgstr "Volume physique LVM2"
+
+#: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/replicationcontroller-body.html:17
+#: pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/route-body.html:22
+#: pkg/kubernetes/views/image-meta.html:3
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
+msgid "Labels"
+msgstr ""
+
+#: pkg/systemd/logs.html:42
+msgid "Last 24 hours"
+msgstr ""
+
+#: pkg/systemd/logs.html:43
+msgid "Last 7 days"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:49
+msgid "Last Heartbeat"
+msgstr ""
+
+#: pkg/users/index.html:100
+msgid "Last Login"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:51
+msgid "Last Status Change"
+msgstr ""
+
+#: pkg/systemd/init.js:273
+msgid "Last Trigger"
+msgstr ""
+
+#: pkg/kubernetes/views/image-listing.html:16
+msgid "Last Updated"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:107
+msgid "Latest Version"
+msgstr ""
+
+#: pkg/realmd/operation.js:101
+msgid "Leave"
+msgstr "Quitter"
+
+#: pkg/networkmanager/index.html:315
+msgid "Link Monitoring"
+msgstr "Surveillance du lien"
+
+#: pkg/networkmanager/index.html:397
+#, fuzzy
+msgid "Link Watch"
+msgstr "Lien local"
+
+#: pkg/networkmanager/index.html:350 pkg/networkmanager/index.html:432
+msgid "Link down delay"
+msgstr "Délai de chute de lien"
+
+#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
+msgid "Link local"
+msgstr "Lien local"
+
+#: pkg/networkmanager/index.html:341 pkg/networkmanager/index.html:423
+msgid "Link up delay"
+msgstr "Délai de montée de lien"
+
+#: pkg/docker/index.html:514
+msgid "Links"
+msgstr "Liens"
+
+#: pkg/storaged/details.js:1224
+msgctxt "storage-id-desc"
+msgid "Linux MD-RAID Component"
+msgstr "Composant MD-RAID Linux"
+
+#: pkg/networkmanager/interfaces.js:1841
+#, fuzzy
+msgid "Load Balancing"
+msgstr "Adaptive load balancing"
+
+#: pkg/systemd/logs.js:69
+msgid "Load earlier entries"
+msgstr "Charger des entrées antérieures"
+
+#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
+#: pkg/systemd/logs.js:175
+msgid "Loading..."
+msgstr "Chargement..."
+
+#: pkg/users/index.html:23
+msgid "Local Accounts"
+msgstr ""
+
+#: pkg/docker/storage.jsx:188
+#, fuzzy
+msgid "Local Disks"
+msgstr "$0 disques"
+
+#: pkg/storaged/details.js:1109
+msgid "Lock"
+msgstr "Verrouiller"
+
+#: pkg/users/index.html:109 pkg/users/index.html:196
+msgid "Lock Account"
+msgstr ""
+
+#: pkg/storaged/jobs.js:122
+msgid "Locking $target"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:80
+msgid "Log In"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:4
+msgid "Log in to {{host}}"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:116
+msgid "Log into OpenShift command line tools:"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:101
+msgid "Log into the registry:"
+msgstr ""
+
+#: pkg/shell/simple.html:45 pkg/shell/index.html:52 pkg/shell/stub.html:45
+msgid "Log out"
+msgstr "Déconnexion"
+
+#: pkg/users/local.js:839
+msgid "Logged In"
+msgstr "Connecté"
+
+#: pkg/storaged/details.js:1424
+msgid "Logical Partition"
+msgstr "Partition logique"
+
+#: pkg/kubernetes/views/pv-modify.html:158
+#: pkg/kubernetes/views/volume-body.html:79
+#: pkg/kubernetes/views/volume-body.html:118
+msgid "Logical Unit Number"
+msgstr ""
+
+#: pkg/storaged/utils.js:172
+msgid "Logical Volume"
+msgstr "Volume logique"
+
+#: pkg/storaged/utils.js:170
+msgid "Logical Volume (Snapshot)"
+msgstr "Volume logique (instantané)"
+
+#: pkg/storaged/details.js:1792
+msgid "Logical Volumes"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:140
+msgid "Login"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:68
+msgid "Login Password"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:96
+msgid "Login commands"
+msgstr ""
+
+#: src/base1/cockpit.js:3693
+msgid "Login failed"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:200
+msgid "Login/password or activation key required to register."
+msgstr ""
+
+#: pkg/systemd/logs.html:59 pkg/kubernetes/views/container-panel.html:6
+#: pkg/kubernetes/views/container-page-inline.html:8
+msgid "Logs"
+msgstr ""
+
+#: pkg/dashboard/index.html:110
+msgid "Lost connection. Trying to reconnect"
+msgstr "Connexion perdue. Tentative de reconnexion."
+
+#: pkg/docker/index.html:184
+msgid "MAC Address:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1833
+msgid "MII (Recommended)"
+msgstr "MII (Recommandé)"
+
+#: pkg/networkmanager/interfaces.js:2477
+msgid "MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:4139
+msgid "MTU must be a positive number"
+msgstr ""
+
+#: pkg/systemd/index.html:85 pkg/kubernetes/views/node-body.html:15
+msgid "Machine ID"
+msgstr ""
+
+#: pkg/systemd/index.html:282
+msgid "Machine SSH Key Fingerprints"
+msgstr ""
+
+#: pkg/shell/indexes.js:253
+msgid "Machines"
+msgstr "Machines"
+
+#: pkg/kubernetes/scripts/dashboard.js:460
+msgid "Manifest"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
+msgid "Manual"
+msgstr "Manuel"
+
+#: pkg/systemd/index.html:401 pkg/systemd/index.html:405
+msgid "Manually"
+msgstr ""
+
+#: pkg/storaged/jobs.js:140
+msgid "Marking $target as faulty"
+msgstr ""
+
+#: pkg/systemd/init.js:546
+msgid "Mask"
+msgstr "Masquer"
+
+#: pkg/systemd/init.js:547
+msgid "Mask Forcefully"
+msgstr "Forcer le masquage"
+
+#: pkg/networkmanager/interfaces.js:2483
+msgid "Master"
+msgstr "Maître"
+
+#: pkg/networkmanager/interfaces.js:2581
+msgid "Maximum message age $max_age"
+msgstr "Âge maximal de message $max_age"
+
+#: pkg/kubernetes/views/volume-body.html:34
+msgid "Medium"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:92
+msgid "Member of"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:16
+#: pkg/kubernetes/views/project-listing.html:55
+#: pkg/networkmanager/index.html:291
+msgid "Members"
+msgstr "Membres"
+
+#: pkg/kubernetes/views/project-page.html:29
+#: pkg/kubernetes/views/user-panel.html:11
+#: pkg/kubernetes/views/user-panel.html:27
+#: pkg/kubernetes/views/user-body.html:4
+msgid "Membership"
+msgstr ""
+
+#: pkg/dashboard/index.html:71 pkg/playground/translate.html:91
+msgid "Memory"
+msgstr "Mémoire"
+
+#: pkg/systemd/host.js:1466
+msgctxt "page-title"
+msgid "Memory"
+msgstr "Mémoire"
+
+#: pkg/kubernetes/scripts/nodes.js:716
+msgid "Memory Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:473 pkg/docker/index.html:652
+msgid "Memory limit"
+msgstr "Limite en mémoire"
+
+#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
+msgid "Message"
+msgstr ""
+
+#: pkg/systemd/host.js:1300
+msgid "Message to logged in users"
+msgstr "Message aux utilisateurs connectés"
+
+#: pkg/kubernetes/views/image-panel.html:15
+#: pkg/kubernetes/views/imagestream-page.html:21
+#: pkg/kubernetes/views/image-page.html:22
+msgid "Metadata"
+msgstr ""
+
+#: pkg/docker/index.html:487 pkg/docker/index.html:666
+msgid "MiB"
+msgstr ""
+
+#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
+msgid "Minute needs to be a number between 0-59"
+msgstr ""
+
+#: pkg/systemd/services.html:407
+#, fuzzy
+msgid "Minutes"
+msgstr "5 minutes"
+
+#: pkg/networkmanager/index.html:299
+msgid "Mode"
+msgstr "Mode"
+
+#: pkg/storaged/index.html:421
+#, fuzzy
+msgctxt "storage"
+msgid "Model"
+msgstr "Mode"
+
+#: pkg/kubernetes/views/user-modify.html:31
+msgid "Modify"
+msgstr ""
+
+#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
+msgid "Modifying $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:323
+msgid "Monitoring Interval"
+msgstr "Intervalle de surveillance"
+
+#: pkg/networkmanager/index.html:332
+msgid "Monitoring Targets"
+msgstr "Cibles à surveiller"
+
+#: pkg/kubernetes/views/volume-body.html:54
+msgid "Monitors"
+msgstr ""
+
+#: pkg/realmd/operation.js:366
+msgid "More"
+msgstr "Plus"
+
+#: pkg/storaged/details.js:1099
+msgid "Mount"
+msgstr "Monter"
+
+#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
+msgid "Mount Location"
+msgstr ""
+
+#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
+msgid "Mount Options"
+msgstr "Options de montage"
+
+#: pkg/storaged/index.html:231
+msgid "Mount Point"
+msgstr "Point de montage"
+
+#: pkg/docker/index.html:540
+msgid "Mount container volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
+msgid "Mounting"
+msgstr "Montage"
+
+#: pkg/storaged/jobs.js:126
+msgid "Mounting $target"
+msgstr "Montage de $target"
+
+#: pkg/storaged/index.html:508
+#, fuzzy
+msgctxt "storage"
+msgid "Multipathed Devices"
+msgstr "Autres Périphériques"
+
+#: pkg/kubernetes/scripts/volumes.js:860
+msgid "NFS"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:199
+msgid "NFS Mount"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1856
+msgid "NSNA Ping"
+msgstr ""
+
+#: pkg/storaged/details.js:182
+msgid "NTFS - Compatible with most systems"
+msgstr "NTFS - Compatible avec la plupart des systèmes"
+
+#: pkg/systemd/host.js:1250
+msgid "NTP Server"
+msgstr "Serveur NTP"
+
+#: pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/project-modify.html:16
+#: pkg/kubernetes/views/node-add.html:16
+#: pkg/kubernetes/views/volumes-page.html:19
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/image-body.html:2
+#: pkg/kubernetes/views/imagestream-modify.html:10
+#: pkg/kubernetes/views/service-modify.html:9
+#: pkg/kubernetes/views/dashboard-page.html:156
+#: pkg/kubernetes/views/dashboard-page.html:198
+#: pkg/kubernetes/views/details-page.html:34
+#: pkg/kubernetes/views/details-page.html:70
+#: pkg/kubernetes/views/details-page.html:103
+#: pkg/kubernetes/views/details-page.html:137
+#: pkg/kubernetes/views/details-page.html:171
+#: pkg/kubernetes/views/pv-claim.html:4
+#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/kubernetes/views/project-listing.html:14
+#: pkg/kubernetes/views/project-listing.html:53
+#: pkg/kubernetes/views/project-listing.html:90
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/volume-body.html:31 pkg/storaged/index.html:230
+#: pkg/networkmanager/index.html:95 pkg/networkmanager/index.html:113
+#: pkg/networkmanager/index.html:150 pkg/networkmanager/index.html:183
+#: pkg/networkmanager/index.html:282 pkg/networkmanager/index.html:364
+msgid "Name"
+msgstr "Nom"
 
 #: pkg/storaged/utils.js:129
 #, fuzzy
@@ -1722,373 +3386,1219 @@ msgstr "Le nom ne peut contenir le caractère « $0 »."
 msgid "Name cannot contain whitespace."
 msgstr "Le nom ne peut contenir d'espace."
 
-#: pkg/storaged/utils.js:157
-msgid "$name (from $host)"
-msgstr "$name (de $host)"
+#: pkg/kubernetes/views/service-body.html:5
+#: pkg/kubernetes/views/replicationcontroller-body.html:5
+#: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/pod-body.html:5
+#: pkg/kubernetes/views/dashboard-page.html:160
+#: pkg/kubernetes/views/details-page.html:36
+#: pkg/kubernetes/views/details-page.html:72
+#: pkg/kubernetes/views/details-page.html:105
+#: pkg/kubernetes/views/details-page.html:139
+#: pkg/kubernetes/views/details-page.html:173
+#: pkg/kubernetes/views/pv-claim.html:6
+#: pkg/kubernetes/views/containers-listing.html:14
+#: pkg/kubernetes/views/route-body.html:5
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
+msgid "Namespace"
+msgstr "Espace de nommage"
 
-#: pkg/storaged/utils.js:166
-msgid "Pool for Thin Logical Volumes"
+#: pkg/kubernetes/scripts/dashboard.js:374
+msgid "Namespace cannot be empty."
+msgstr "L'espace de nommage ne peut être vide."
+
+#: pkg/systemd/host.js:1113
+msgid "Need at least one NTP server"
+msgstr "Au moins un serveur NTP est nécessaire"
+
+#: pkg/dashboard/index.html:72 pkg/playground/translate.html:96
+msgid "Network"
+msgstr "Réseau"
+
+#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:485
+msgid "Networking"
+msgstr "Réseau"
+
+#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
+msgctxt "page-title"
+msgid "Networking"
+msgstr "Réseau"
+
+#: pkg/networkmanager/index.html:124
+msgid "Networking Logs"
+msgstr "Journaux réseau"
+
+#: pkg/users/local.js:841
+msgid "Never"
+msgstr "Jamais"
+
+#: pkg/kubernetes/views/project-listing.html:46
+msgid "New Group"
 msgstr ""
 
-#: pkg/storaged/utils.js:168
-msgid "Thin Logical Volume"
+#: pkg/users/index.html:236 pkg/shell/index.html:255
+msgid "New Password"
 msgstr ""
 
-#: pkg/storaged/utils.js:170
-msgid "Logical Volume (Snapshot)"
-msgstr "Volume logique (instantané)"
-
-#: pkg/storaged/utils.js:172
-msgid "Logical Volume"
-msgstr "Volume logique"
-
-#: pkg/storaged/utils.js:212
-msgid "<span>Encrypted Logical Volume of $0</span>"
+#: pkg/kubernetes/views/project-listing.html:7
+msgid "New Project"
 msgstr ""
 
-#: pkg/storaged/utils.js:214
-msgid "<span>Encrypted Partition of $0</span>"
-msgstr "<span>Partition chiffrée de $0</span>"
-
-#: pkg/storaged/utils.js:216
-msgid "<span>Logical Volume of $0</span>"
-msgstr "<span>Volume logique de $0</span>"
-
-#: pkg/storaged/utils.js:218
-msgid "<span>Partition of $0</span>"
-msgstr "<span>Partition de $0</span>"
-
-#: pkg/storaged/utils.js:220
-msgid "<span>Encrypted $0</span>"
-msgstr "<span>$0 chiffré(e)</span>"
-
-#: pkg/storaged/utils.js:233
-msgid "RAID Device $0"
-msgstr "Périphérique RAID $0"
-
-#: pkg/storaged/utils.js:239
-msgid "Volume Group $0"
-msgstr "Groupe de volumes $0"
-
-#: pkg/storaged/jobs.js:119
-msgid "SMART self-test of $target"
+#: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/image-listing.html:7
+msgid "New image stream"
 msgstr ""
 
-#: pkg/storaged/jobs.js:120
-msgid "Ejecting $target"
+#: pkg/users/local.js:120 pkg/lib/credentials.js:231
+msgid "New password was not accepted"
+msgstr "Refus du nouveau mot de passe"
+
+#: pkg/kubernetes/views/project-modify.html:4
+#: pkg/kubernetes/views/registry-dashboard-page.html:9
+#: pkg/kubernetes/views/registry-dashboard-page.html:48
+msgid "New project"
 msgstr ""
 
-#: pkg/storaged/jobs.js:121
-msgid "Unlocking $target"
+#: pkg/realmd/operation.html:91
+msgid "Next"
+msgstr "Suivant"
+
+#: pkg/systemd/init.js:272
+msgid "Next Run"
 msgstr ""
 
-#: pkg/storaged/jobs.js:122
-msgid "Locking $target"
+#: pkg/systemd/index.html:233
+msgid "Nice"
 msgstr ""
 
-#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
-msgid "Modifying $target"
+#: pkg/docker/index.html:563 pkg/docker/index.html:567
+msgid "No"
+msgstr "Non"
+
+#: pkg/systemd/index.html:469
+msgid "No Delay"
 msgstr ""
 
-#: pkg/storaged/jobs.js:124
-msgid "Starting swapspace $target"
+#: pkg/ostree/index.html:220
+msgid "No Deployments"
 msgstr ""
 
-#: pkg/storaged/jobs.js:125
-msgid "Stopping swapspace $target"
+#: pkg/storaged/details.js:185
+msgid "No Filesystem"
+msgstr "Aucun système de fichiers"
+
+#: pkg/ostree/app.js:101
+msgid "No OSTree deployments found"
 msgstr ""
 
-#: pkg/storaged/jobs.js:126
-msgid "Mounting $target"
-msgstr "Montage de $target"
+#: src/ws/cockpitcertificate.c:398
+msgid "No PEM-encoded certificate found"
+msgstr "Certificat encodé en PEM introuvable"
 
-#: pkg/storaged/jobs.js:127
-msgid "Unmounting $target"
-msgstr "Démontage de $target"
+#: src/ws/cockpitcertificate.c:364
+msgid "No PEM-encoded private key found"
+msgstr "Clé privée encodée en PEM introuvable"
 
-#: pkg/storaged/jobs.js:129
-msgid "Erasing $target"
-msgstr "Effacement de $target"
-
-#: pkg/storaged/jobs.js:130
-msgid "Creating filesystem on $target"
-msgstr "Création du système de fichier sur $target"
-
-#: pkg/storaged/jobs.js:131
-msgid "Setting up loop device $target"
+#: pkg/kubernetes/views/pv-claim.html:39
+msgid "No Pods are using this claim"
 msgstr ""
 
-#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
-msgid "Deleting $target"
-msgstr "Suppression de $target"
-
-#: pkg/storaged/jobs.js:134
-msgid "Creating partition $target"
-msgstr "Création de la partition sur $target"
-
-#: pkg/storaged/jobs.js:135
-msgid "Cleaning up for $target"
+#: pkg/selinux/setroubleshoot-view.jsx:479
+msgid "No SELinux alerts."
 msgstr ""
 
-#: pkg/storaged/jobs.js:136
-msgid "Securely erasing $target"
+#: pkg/kubernetes/views/pvc-body.html:10
+msgid "No Volume Bound"
 msgstr ""
 
-#: pkg/storaged/jobs.js:137
-msgid "Very securely erasing $target"
+#: pkg/docker/storage.jsx:194
+msgid "No additional local storage found."
 msgstr ""
 
-#: pkg/storaged/jobs.js:138
-msgid "Stopping RAID Device $target"
+#: pkg/docker/run.js:350
+msgid "No alias specified"
+msgstr "Aucun alias indiqué"
+
+#: pkg/sosreport/index.js:115
+msgid "No archive has been created."
 msgstr ""
 
-#: pkg/storaged/jobs.js:139
-msgid "Starting RAID Device $target"
+#: pkg/networkmanager/interfaces.js:1326
+msgid "No carrier"
+msgstr "Pas de porteuse"
+
+#: pkg/docker/run.js:384
+msgid "No container specified"
+msgstr "Aucun conteneur indiqué"
+
+#: pkg/storaged/index.html:193
+msgid "No drives attached"
 msgstr ""
 
-#: pkg/storaged/jobs.js:140
-msgid "Marking $target as faulty"
+#: pkg/kubernetes/views/project-listing.html:74
+msgid "No groups are present."
 msgstr ""
 
-#: pkg/storaged/jobs.js:141
-msgid "Removing $target from RAID Device"
+#: pkg/systemd/index.html:28
+msgid "No host keys found."
 msgstr ""
 
-#: pkg/storaged/jobs.js:142
-msgid "Creating RAID Device $target"
+#: pkg/storaged/index.html:158
+msgid "No iSCSI targets set up"
 msgstr ""
 
-#: pkg/storaged/jobs.js:143
+#: pkg/kubernetes/views/image-listing.html:70
+msgid "No image streams are present."
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:80
+msgid "No images pushed"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:223
 #, fuzzy
-msgid "Checking RAID Device $target"
-msgstr "Périphérique RAID $0"
+msgid "No installed products on the system."
+msgstr "Docker n'est pas installé ou activé sur le système"
 
-#: pkg/storaged/jobs.js:144
-msgid "Checking and Repairing RAID Device $target"
+#: pkg/storaged/index.html:446
+msgid "No media inserted"
+msgstr "Aucun média inséré"
+
+#: pkg/kubernetes/scripts/dashboard.js:384
+msgid ""
+"No metadata file was selected. Please select a Kubernetes metadata file."
+msgstr ""
+"Aucun fichier de metadonnées sélectionné. Merci de sélectionner un fichier "
+"de metadonnées Kubernetes."
+
+#: pkg/kubernetes/views/dashboard-page.html:117
+msgid "No nodes in cluster"
 msgstr ""
 
-#: pkg/storaged/jobs.js:145
-msgid "Recovering RAID Device $target"
+#: pkg/storaged/details.js:352
+msgid "No partitioning"
+msgstr "Aucun partitionnement"
+
+#: pkg/kubernetes/views/dashboard-page.html:40
+msgid "No pods deployed"
 msgstr ""
 
-#: pkg/storaged/jobs.js:146
-msgid "Synchronizing RAID Device $target"
+#: pkg/kubernetes/views/replicationcontroller-pods.html:6
+msgid "No pods replicated"
 msgstr ""
 
-#: pkg/storaged/jobs.js:148
-msgid "Activating $target"
+#: pkg/kubernetes/views/node-capacity.html:11
+msgid "No pods scheduled"
 msgstr ""
 
-#: pkg/storaged/jobs.js:149
-msgid "Deactivating $target"
+#: pkg/kubernetes/views/service-endpoint.html:10
+msgid "No pods selected"
 msgstr ""
 
-#: pkg/storaged/jobs.js:150
-msgid "Creating snapshot of $target"
+#: pkg/kubernetes/views/project-listing.html:37
+msgid "No projects are present."
 msgstr ""
 
-#: pkg/storaged/jobs.js:151
-msgid "Creating volume group $target"
+#: pkg/users/local.js:405
+msgid "No real name specified"
+msgstr "Aucun nom réel indiqué."
+
+#: pkg/storaged/index.html:87
+msgid "No storage set up as RAID"
 msgstr ""
 
-#: pkg/storaged/jobs.js:152
-msgid "Deleting volume group $target"
+#: pkg/lib/credentials.js:182
+msgid "No such file or directory"
+msgstr "Fichier ou répertoire introuvable"
+
+#: pkg/users/local.js:400
+msgid "No user name specified"
+msgstr "Aucun nom d'utilisateur indiqué."
+
+#: pkg/kubernetes/views/project-listing.html:112
+msgid "No users are present."
 msgstr ""
 
-#: pkg/storaged/jobs.js:153
-msgid "Adding physical volume to $target"
+#: pkg/storaged/index.html:120
+msgid "No volume groups created"
 msgstr ""
 
-#: pkg/storaged/jobs.js:154
-msgid "Removing physical volume from $target"
+#: pkg/kubernetes/views/volumes-page.html:44
+msgid "No volumes are present."
 msgstr ""
 
-#: pkg/storaged/jobs.js:155
-msgid "Emptying $target"
+#: pkg/kubernetes/views/dashboard-page.html:73
+msgid "No volumes in use"
 msgstr ""
 
-#: pkg/storaged/jobs.js:156
-msgid "Creating logical volume $target"
+#: pkg/kubernetes/views/pod-body.html:18 pkg/kubernetes/views/node-panel.html:7
+#: pkg/kubernetes/views/containers-listing.html:15
+#: pkg/kubernetes/views/node-page.html:14
+#: pkg/kubernetes/views/topology-page.html:41
+msgid "Node"
 msgstr ""
 
-#: pkg/storaged/jobs.js:157
-msgid "Renaming $target"
+#: pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:192
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:45
+msgid "Nodes"
 msgstr ""
 
-#: pkg/storaged/jobs.js:158
-msgid "Resizing $target"
+#: pkg/kubernetes/views/topology-page.html:42
+msgid "Nodes are the machines that run your containers."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:15
+#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
+#: pkg/kubernetes/views/image-config.html:25
+#: pkg/kubernetes/views/imagestream-body.html:33
+msgid "None"
+msgstr "Aucun(e)"
+
+#: pkg/playground/translate.html:30 pkg/kubernetes/views/details-page.html:53
+#: pkg/kubernetes/views/node-body.html:42
+msgid "Not Ready"
+msgstr "Pas prêt"
+
+#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
+msgid "Not a valid number of replicas"
+msgstr "Nombre de répliques invalide"
+
+#: pkg/lib/credentials.js:248
+msgid "Not a valid private key"
+msgstr "Pas une clé privée"
+
+#: pkg/kubernetes/scripts/details.js:546
+msgid "Not a valid value for Host"
+msgstr ""
+
+#: pkg/docker/index.html:57
+msgid "Not authorized to access Docker on this system"
+msgstr "Vous n'êtes pas autorisé à accéder à Docker sur ce système"
+
+#: pkg/ostree/app.js:81
+msgid "Not authorized to update software on this system"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:805
+msgid "Not available"
+msgstr "Indisponible"
+
+#: pkg/selinux/setroubleshoot.js:238
+msgid "Not connected"
+msgstr "Non connecté"
+
+#: pkg/kubernetes/views/details-page.html:122
+msgid "Not deployed"
+msgstr ""
+
+#: pkg/docker/details.js:177 pkg/docker/image.js:112
+#: pkg/storaged/details.js:1822
+msgid "Not found"
+msgstr "Non trouvé"
+
+#: src/base1/cockpit.js:3691
+msgid "Not permitted to perform this action."
+msgstr ""
+
+#: pkg/storaged/details.js:1574
+msgid "Not running"
+msgstr ""
+
+#: pkg/systemd/index.html:62
+msgid "Not synchronized"
+msgstr ""
+
+#: pkg/systemd/services.html:299
+msgid "Note"
+msgstr ""
+
+#: pkg/systemd/logs.html:49
+msgid "Notices"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:13
+msgid "OS"
+msgstr ""
+
+#: pkg/ostree/client.js:500
+msgid "OS $0 not found"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:19
+msgid "OS Versions"
+msgstr ""
+
+#: pkg/ostree/app.js:83
+msgid "OSTree is not available on this system"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:405
+msgid "Occurred $0"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:400
+msgid "Occurred between $0 and $1"
+msgstr ""
+
+#: pkg/systemd/index.html:157 pkg/playground/jquery-patterns.html:95
+#: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:189
+#: pkg/storaged/index.html:565
+msgid "Off"
+msgstr "Éteint"
+
+#: pkg/lib/cockpit-components-dialog.jsx:155
+msgid "Ok"
+msgstr ""
+
+#: pkg/users/index.html:226 pkg/shell/index.html:248
+msgid "Old Password"
+msgstr ""
+
+#: pkg/users/local.js:78 pkg/lib/credentials.js:213
+msgid "Old password not accepted"
+msgstr "Refus de l'ancien mot de passe "
+
+#: pkg/systemd/index.html:153 pkg/playground/jquery-patterns.html:91
+#: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:185
+#: pkg/storaged/index.html:564
+msgid "On"
+msgstr "Allumé"
+
+#: pkg/kubernetes/views/image-meta.html:7
+msgid "On Build"
+msgstr ""
+
+#: pkg/docker/index.html:568
+msgid "On Failure"
+msgstr ""
+
+#: pkg/docker/util.js:104
+msgid "On failure, retry $0 time"
+msgid_plural "On failure, retry $0 times"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/realmd/operation.html:71
+msgid "One Time Password"
+msgstr "Mot de passe à usage unique"
+
+#: pkg/systemd/init.js:1147
+msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
+msgstr ""
+
+#: pkg/shell/simple.html:28 pkg/shell/index.html:28 pkg/shell/stub.html:28
+msgid "Ooops!"
+msgstr "Oups !"
+
+#: pkg/systemd/index.html:89 pkg/ostree/index.html:111
+#: pkg/kubernetes/views/nodes-page.html:42
+msgid "Operating System"
+msgstr ""
+
+#: pkg/ostree/index.html:186
+msgid "Operating System Updates"
 msgstr ""
 
 #: pkg/storaged/jobs.js:166
 msgid "Operation '$operation' on $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:180
-msgid "unknown target"
+#: pkg/storaged/overview.js:189
+msgctxt "storage"
+msgid "Optical Drive"
+msgstr "Lecteur optique"
+
+#: pkg/kubernetes/views/volume-body.html:130
+msgid "Options"
+msgstr "Options"
+
+#: pkg/subscriptions/subscriptions-register.jsx:176
+msgid "Organization"
 msgstr ""
 
-#: pkg/storaged/permissions.js:61
-msgid "The user <b>$0</b> is not permitted to manage storage"
+#: pkg/storaged/details.js:1253
+msgctxt "storage-id-desc"
+msgid "Other Data"
+msgstr "Autres données"
+
+#: pkg/storaged/index.html:202
+msgid "Other Devices"
+msgstr "Autres Périphériques"
+
+#: pkg/docker/index.html:319 pkg/kubernetes/registry.html:42
+#: pkg/kubernetes/index.html:39
+msgid "Overview"
 msgstr ""
 
-#: pkg/realmd/operation.js:96
-msgid "Join"
-msgstr "Rejoindre"
+#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
+msgid "Overwrite existing data with zeros"
+msgstr "Écraser les données existantes avec des zéros"
 
-#: pkg/realmd/operation.js:101
-msgid "Leave"
-msgstr "Quitter"
-
-#: pkg/realmd/operation.js:148
-msgid "Domain $0 could not be contacted"
-msgstr "Le domaine $0 ne peut être contacté"
-
-#: pkg/realmd/operation.js:220
-msgid "Domain $0 is not supported"
+#: pkg/kubernetes/views/volume-body.html:4
+msgid "PD Name"
 msgstr ""
 
-#: pkg/realmd/operation.js:347
-msgid "Joining this domain is not supported"
+#: pkg/ostree/index.html:100
+msgid "Packages"
 msgstr ""
 
-#: pkg/realmd/operation.js:366
-msgid "More"
-msgstr "Plus"
+#: pkg/networkmanager/index.html:133
+msgid "Parent"
+msgstr "Parent"
 
-#: pkg/realmd/operation.js:417
-msgid "Cannot join a domain because realmd is not available on this system"
+#: pkg/networkmanager/interfaces.js:2619
+msgid "Parent $parent"
+msgstr "Parent $parent"
+
+#: pkg/networkmanager/interfaces.js:1372
+msgid "Part of "
+msgstr "Fait partie de "
+
+#: pkg/kubernetes/views/volume-body.html:8
+#: pkg/kubernetes/views/volume-body.html:18
+msgid "Partition"
+msgstr "Partition"
+
+#: pkg/storaged/details.js:346
+msgid "Partitioning"
+msgstr "Partitionnement"
+
+#: pkg/networkmanager/interfaces.js:1848
+msgid "Passive"
 msgstr ""
-"Impossible de rejoindre un domaine car reamld n'est pas disponible sur ce "
-"système"
 
-#: pkg/realmd/operation.js:436
-msgid "The user <b>$0</b> is not permitted to modify realms"
-msgstr "L'utilisateur <b>$0</b> n'a pas le droit de modifier les domaines"
+#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
+msgid "Passphrase"
+msgstr "Phrase de passe"
 
-#: pkg/realmd/operation.js:453
-msgid "Join Domain"
-msgstr "Rejoindre le domaine"
-
-#: pkg/docker/run.js:246 pkg/docker/util.js:102
-#: pkg/networkmanager/interfaces.js:2280 pkg/kubernetes/scripts/volumes.js:992
-#: pkg/docker/index.html.h:46
-msgid "No"
-msgstr "Non"
-
-#: pkg/docker/run.js:261 pkg/docker/console.html.h:1
-#: pkg/kubernetes/views/image-panel.html.h:2
-#: pkg/kubernetes/views/container-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:1
-#: pkg/kubernetes/views/image-page.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:1
-msgid "Container"
-msgstr "Conteneur"
-
-#: pkg/docker/run.js:263 pkg/kubernetes/views/route-modify.html.h:2
-#: pkg/kubernetes/views/route-body.html.h:4
-#: pkg/kubernetes/views/details-page.html.h:12
-msgid "Host"
-msgstr "Hôte"
-
-#: pkg/docker/run.js:283
-msgid "Invalid port"
-msgstr "Port invalide"
-
-#: pkg/docker/run.js:293
-msgid "Duplicate port"
-msgstr "Port dupliqué"
-
-#: pkg/docker/run.js:332
+#: pkg/storaged/details.js:224
 #, fuzzy
-msgid "Command can't be empty"
-msgstr "Le nom ne peut être vide."
+msgid "Passphrase cannot be empty"
+msgstr "La phrase de passe ne peut être vide"
 
-#: pkg/docker/run.js:350
-msgid "No alias specified"
-msgstr "Aucun alias indiqué"
+#: pkg/storaged/details.js:232
+msgid "Passphrases do not match"
+msgstr "Les phrases de passe ne correspondent pas."
 
-#: pkg/docker/run.js:360
-msgid "Duplicate alias"
-msgstr "Alias dupliqué"
+#: pkg/users/index.html:115 pkg/users/index.html:160 pkg/shell/index.html:199
+#: pkg/shell/index.html:212 pkg/kubernetes/views/auth-form.html:105
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+msgid "Password"
+msgstr "Mot de passe"
 
-#: pkg/docker/run.js:384
-msgid "No container specified"
-msgstr "Aucun conteneur indiqué"
+#: pkg/users/local.js:259
+msgid "Password is not acceptable"
+msgstr "Le mot de passe n'est pas acceptable"
 
-#: pkg/docker/details.js:47 pkg/docker/image.js:43
-msgctxt "page-title"
-msgid "Containers"
-msgstr "Conteneurs"
+#: pkg/users/local.js:247
+msgid "Password is too weak"
+msgstr "Le mot de passe est trop faible"
 
-#: pkg/docker/details.js:144
-msgid "${hip}:${hport} -> $cport"
-msgstr "${hip}:${hport} -> $cport"
+#: pkg/lib/credentials.js:278
+msgid "Password not accepted"
+msgstr "Mot de passe refusé"
 
-#: pkg/docker/details.js:272 pkg/docker/containers-view.jsx:167
-msgid "Deleting a container will erase all data in it."
-msgstr "Supprimer un conteneur en supprimera toutes les données"
-
-#: pkg/docker/storage.jsx:156
-#, fuzzy
-msgid "Solid-State Disk"
-msgstr "Disque SSD"
-
-#: pkg/docker/storage.jsx:157
-#, fuzzy
-msgid "Hard Disk"
-msgstr "Disque dur"
-
-#: pkg/docker/storage.jsx:158 pkg/storaged/index.html.h:33
-msgid "Drive"
-msgstr "Disque"
-
-#: pkg/docker/storage.jsx:188
-#, fuzzy
-msgid "Local Disks"
-msgstr "$0 disques"
-
-#: pkg/docker/storage.jsx:194
-msgid "No additional local storage found."
+#: pkg/kubernetes/views/pv-modify.html:126
+#: pkg/kubernetes/views/volume-body.html:37
+#: pkg/kubernetes/views/volume-body.html:49
+#: pkg/kubernetes/views/volume-body.html:101
+msgid "Path"
 msgstr ""
 
-#: pkg/docker/storage.jsx:242
-msgid " (shared with the OS)"
+#: pkg/networkmanager/index.html:259
+msgid "Path cost"
+msgstr "Coût du chemin"
+
+#: pkg/networkmanager/interfaces.js:2601
+msgid "Path cost $path_cost"
+msgstr "Coût du chemin $path_cost"
+
+#: pkg/systemd/services.html:56
+msgid "Paths"
 msgstr ""
 
-#: pkg/docker/storage.jsx:282
-msgid "Information about the Docker storage pool is not available."
+#: pkg/kubernetes/views/volumes-page.html:53
+msgid "Pending Volume Claims"
 msgstr ""
 
-#: pkg/docker/storage.jsx:314
-msgid "Total"
+#: pkg/systemd/index.html:143
+msgid "Performance Profile"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:14
+msgid "Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:16
+msgid "Phase"
+msgstr ""
+
+#: pkg/storaged/index.html:641
+msgid "Physical Volumes"
+msgstr ""
+
+#: pkg/networkmanager/index.html:405
+#, fuzzy
+msgid "Ping Interval"
+msgstr "Intervalle de surveillance"
+
+#: pkg/networkmanager/index.html:414
+#, fuzzy
+msgid "Ping Target"
+msgstr "Effacement de $target"
+
+#: pkg/docker/containers-view.jsx:166 pkg/docker/details.js:271
+#: pkg/docker/image.js:151 pkg/storaged/details.js:625
+#: pkg/storaged/details.js:821 pkg/storaged/details.js:1016
+msgid "Please confirm deletion of $0"
+msgstr "Confirmer la suppression de $0"
+
+#: pkg/docker/util.js:501
+msgid "Please confirm forced deletion of $0"
+msgstr "Merci de confirmer la suppression de $0"
+
+#: pkg/kubernetes/scripts/dashboard.js:441
+msgid "Please create another namespace for $0 \"$1\""
+msgstr "Merci de créer un nouvel espace de nommage pour l'objet $0 « $1 »"
+
+#: pkg/kubernetes/scripts/volumes.js:574
+msgid "Please provide a GlusterFS volume name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:554
+msgid "Please provide a username"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:632
+msgid "Please provide a valid NFS server"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:539
+msgid "Please provide a valid address"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:805
+msgid "Please provide a valid filesystem type"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:813
+msgid "Please provide a valid interface"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:797
+msgid "Please provide a valid logical unit number"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:477
+msgid "Please provide a valid name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:376
+msgid "Please provide a valid namespace."
+msgstr "Merci d'indiquer un espace de nommage valide."
+
+#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
+msgid "Please provide a valid path"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:789
+msgid "Please provide a valid qualified name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:485
+msgid "Please provide a valid storage capacity."
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:781
+msgid "Please provide a valid target"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:469
+msgid "Please select a valid access mode"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:565
+msgid "Please select a valid endpoint"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:493
+msgid "Please select a valid policy option."
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:397
+msgid "Please type an address"
+msgstr "Merci de saisir une adresse"
+
+#: pkg/kubernetes/views/pod-page.html:12
+#: pkg/kubernetes/views/containers-listing.html:12
+#: pkg/kubernetes/views/topology-page.html:14
+msgid "Pod"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:20
+msgid "Pod Address"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:4
+#: pkg/kubernetes/views/service-endpoint.html:9
+msgid "Pod Endpoints"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:4
+msgid "Pod Replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:15
+#: pkg/kubernetes/views/replicationcontroller-pods.html:11
+msgid "Pod Selector"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:17
+#: pkg/kubernetes/views/dashboard-page.html:18
+#: pkg/kubernetes/views/details-page.html:166
+#: pkg/kubernetes/views/pv-claim.html:37
+#: pkg/kubernetes/views/replicationcontroller-panel.html:12
+msgid "Pods"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:15
+msgid ""
+"Pods contain one or more containers that run                together on a "
+"node, containing your application code."
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:60
+msgid "Pool Name"
+msgstr ""
+
+#: pkg/storaged/utils.js:166
+msgid "Pool for Thin Logical Volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:874
+msgid "Pool for thinly provisioned volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:45
+msgid "Populate"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:23
+msgid "Port"
+msgstr ""
+
+#: pkg/docker/index.html:525 pkg/kubernetes/views/service-body.html:13
+#: pkg/kubernetes/views/image-config.html:23
+#: pkg/kubernetes/views/container-body.html:12
+#: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:373
+msgid "Ports"
+msgstr "Ports"
+
+#: pkg/systemd/index.html:123
+msgid "Power Options"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length"
+msgstr "Longueur de préfixe"
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length or Netmask"
+msgstr "Longueur de préfixe ou masque de réseau"
+
+#: pkg/networkmanager/interfaces.js:809
+msgid "Preparing"
+msgstr "Préparation"
+
+#: pkg/systemd/init.js:544
+msgid "Preset"
+msgstr "Préconfigurer"
+
+#: pkg/systemd/init.js:545
+msgid "Preset Forcefully"
+msgstr "Forcer la préconfiguration"
+
+#: pkg/systemd/index.html:310
+msgid "Pretty Host Name"
+msgstr ""
+
+#: pkg/networkmanager/index.html:307
+msgid "Primary"
+msgstr "Primaire"
+
+#: pkg/storaged/details.js:1426
+msgid "Primary Partition"
+msgstr "Partition primaire"
+
+#: pkg/networkmanager/index.html:250 pkg/networkmanager/index.html:446
+#: pkg/networkmanager/index.html:464
+msgid "Priority"
+msgstr "Priorité"
+
+#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
+msgid "Priority $priority"
+msgstr "Priorité $priority"
+
+#: pkg/subscriptions/subscriptions-view.jsx:33
+msgid "Product ID"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:32
+msgid "Product name"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:4
+#: pkg/kubernetes/views/replicationcontroller-body.html:4
+#: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/imagestream-modify.html:21
+#: pkg/kubernetes/views/pod-body.html:4
+#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/details-page.html:35
+#: pkg/kubernetes/views/details-page.html:71
+#: pkg/kubernetes/views/details-page.html:104
+#: pkg/kubernetes/views/details-page.html:138
+#: pkg/kubernetes/views/details-page.html:172
+#: pkg/kubernetes/views/containers-listing.html:13
+#: pkg/kubernetes/views/route-body.html:4
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
+msgid "Project"
+msgstr "Projet"
+
+#: pkg/kubernetes/views/project-body.html:20
+msgid "Project Members"
+msgstr ""
+
+#: pkg/kubernetes/views/filter-project.html:5
+msgid "Project:"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:54 pkg/kubernetes/views/group-delete.html:10
+#: pkg/kubernetes/views/project-listing.html:9
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:84
+msgid "Projects"
+msgstr ""
+
+#: pkg/users/local.js:82
+msgid "Prompting via passwd timed out"
+msgstr "Temps d'attente dépassé sur saisie avec passwd"
+
+#: pkg/lib/credentials.js:251
+msgid "Prompting via ssh-add timed out"
+msgstr "Temps d'attente dépassé sur saisie avec ssh-add"
+
+#: pkg/lib/credentials.js:191
+msgid "Prompting via ssh-keygen timed out"
+msgstr "Temps d'attente dépassé sur saisie via ssh-keygen"
+
+#: pkg/subscriptions/subscriptions-register.jsx:125
+msgid "Proxy"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:25
+msgid "Proxy Version"
+msgstr ""
+
+#: pkg/shell/index.html:198 pkg/lib/machine-auth-failed.html:9
+msgid "Public Key"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:150
+msgid "Pull an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:66
+msgid "Pull from"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:31
+msgid "Pull repository"
+msgstr ""
+
+#: pkg/storaged/details.js:869
+msgid "Purpose"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:140
+msgid "Push an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:147
+#: pkg/kubernetes/views/volume-body.html:77
+msgid "Qualified Name"
+msgstr ""
+
+#: pkg/storaged/details.js:1539
+msgid "RAID ($0)"
+msgstr "RAID ($0)"
+
+#: pkg/storaged/details.js:1533
+msgid "RAID 0"
+msgstr "RAID 0"
+
+#: pkg/storaged/overview.js:422
+msgid "RAID 0 (Stripe)"
+msgstr "RAID 0 (Réparti par bande)"
+
+#: pkg/storaged/details.js:1534
+msgid "RAID 1"
+msgstr "RAID 1"
+
+#: pkg/storaged/overview.js:423
+msgid "RAID 1 (Mirror)"
+msgstr "RAID 1 (Miroir)"
+
+#: pkg/storaged/details.js:1538
+msgid "RAID 10"
+msgstr "RAID 10"
+
+#: pkg/storaged/overview.js:427
+msgid "RAID 10 (Stripe of Mirrors)"
+msgstr ""
+
+#: pkg/storaged/details.js:1535
+msgid "RAID 4"
+msgstr "RAID 4"
+
+#: pkg/storaged/overview.js:424
+msgid "RAID 4 (Dedicated Parity)"
+msgstr "RAID 4 (Parité Dédié)"
+
+#: pkg/storaged/details.js:1536
+msgid "RAID 5"
+msgstr "RAID 5"
+
+#: pkg/storaged/overview.js:425
+msgid "RAID 5 (Distributed Parity)"
+msgstr "RAID 5 (Parité Distribué)"
+
+#: pkg/storaged/details.js:1537
+msgid "RAID 6"
+msgstr "RAID 6"
+
+#: pkg/storaged/overview.js:426
+msgid "RAID 6 (Double Distributed Parity)"
+msgstr "RAID 6 (Parité Doublement Distribué)"
+
+#: pkg/storaged/index.html:537
+msgid "RAID Device"
+msgstr "Périphérique RAID"
+
+#: pkg/storaged/utils.js:233
+msgid "RAID Device $0"
+msgstr "Périphérique RAID $0"
+
+#: pkg/storaged/index.html:65
+msgid "RAID Devices"
+msgstr "Périphériques RAID"
+
+#: pkg/storaged/overview.js:420
+msgid "RAID Level"
+msgstr "Niveau RAID"
+
+#: pkg/storaged/index.html:555
+#, fuzzy
+msgctxt "storage"
+msgid "RAID Level"
+msgstr "Niveau RAID"
+
+#: pkg/storaged/details.js:1228
+msgctxt "storage-id-desc"
+msgid "RAID Member"
+msgstr "Membre de grappe RAID"
+
+#: pkg/kubernetes/scripts/volumes.js:200
+msgid "Rados Block Device"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:194
+#: pkg/kubernetes/views/volume-body.html:10
+#: pkg/kubernetes/views/volume-body.html:20
+#: pkg/kubernetes/views/volume-body.html:44
+#: pkg/kubernetes/views/volume-body.html:51
+#: pkg/kubernetes/views/volume-body.html:71
+#: pkg/kubernetes/views/volume-body.html:85
+#: pkg/kubernetes/views/volume-body.html:93
+#: pkg/kubernetes/views/volume-body.html:110
+#: pkg/kubernetes/views/volume-body.html:122
+#: pkg/kubernetes/views/volume-body.html:136
+#: pkg/kubernetes/views/volume-body.html:143
+msgid "Read Only"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:211
+msgid "Read and write from a single node"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:213
+msgid "Read and write from multiple nodes"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:212
+msgid "Read only from multiple nodes"
+msgstr ""
+
+#: pkg/docker/index.html:385
+msgid "ReadOnly"
+msgstr ""
+
+#: pkg/docker/index.html:384
+msgid "ReadWrite"
+msgstr ""
+
+#: pkg/storaged/index.html:327
+msgid "Reading"
+msgstr "Lecture"
+
+#: pkg/playground/translate.html:20 pkg/playground/translate.html:179
+#: pkg/kubernetes/views/details-page.html:52
+#: pkg/kubernetes/views/node-body.html:41
+msgid "Ready"
+msgstr "Prêt"
+
+#: pkg/playground/translate.html:25
+#, fuzzy
+msgctxt "verb"
+msgid "Ready"
+msgstr "Prêt"
+
+#: pkg/systemd/index.html:319
+msgid "Real Host Name"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:45
+msgid "Reason"
+msgstr ""
+
+#: pkg/lib/journal.js:241
+msgid "Reboot"
+msgstr "Redémarrer"
+
+#: pkg/networkmanager/index.html:75 pkg/networkmanager/index.html:98
+#: pkg/networkmanager/index.html:116 pkg/networkmanager/index.html:521
+#: pkg/networkmanager/index.html:551
+msgid "Receiving"
+msgstr "Réception"
+
+#: pkg/ostree/client.js:56
+msgid "Receiving delta parts"
+msgstr ""
+
+#: pkg/ostree/client.js:58
+msgid "Receiving metadata objects"
+msgstr ""
+
+#: pkg/ostree/client.js:61
+msgid "Receiving objects: $0%"
+msgstr ""
+
+#: pkg/systemd/logs.html:40
+msgid "Recent"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:56 pkg/kubernetes/views/pv-body.html:6
+msgid "Reclaim Policy"
+msgstr ""
+
+#: pkg/shell/simple.html:144 pkg/shell/index.html:327 pkg/shell/stub.html:180
+msgid "Reconnect"
+msgstr "Reconnecter"
+
+#: pkg/storaged/details.js:1594
+msgid "Recovering"
+msgstr "Récupération en cours"
+
+#: pkg/storaged/jobs.js:145
+msgid "Recovering RAID Device $target"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:219
+msgid "Recycle"
 msgstr ""
 
 #: pkg/docker/storage.jsx:348
 msgid "Reformat and add disks"
 msgstr ""
 
-#: pkg/docker/storage.jsx:355
+#: pkg/kubernetes/views/pv-modify.html:205
+msgid "Register"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:12
+msgid "Register New Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:4
+msgid "Register Persistent Volume"
+msgstr ""
+
+#: pkg/subscriptions/main.js:74
+msgid "Register system"
+msgstr ""
+
+#: pkg/ostree/index.html:115
+msgid "Released"
+msgstr ""
+
+#: pkg/systemd/init.js:518
+msgid "Reload"
+msgstr "Recharger"
+
+#: pkg/systemd/init.js:519
+msgid "Reload or Restart"
+msgstr "Recharger ou redémarrer"
+
+#: pkg/systemd/init.js:521
+msgid "Reload or Try Restart"
+msgstr "Recharger ou essayer de redémarrer"
+
+#: pkg/kubernetes/views/imagestream-modify.html:89
+msgid "Remote registry is insecure"
+msgstr ""
+
+#: cockpit.desktop.in.h:3
+msgid "Remote;Administration;"
+msgstr "À distance;Administration;"
+
+#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
+msgctxt "storage"
+msgid "Removable Drive"
+msgstr "Périphérique amovible"
+
+#: pkg/ostree/index.html:123 pkg/ostree/index.html:146
+msgid "Removals"
+msgstr ""
+
+#: pkg/kubernetes/views/user-group-remove.html:10
+#: pkg/kubernetes/views/group-delete.html:21
+#: pkg/kubernetes/views/user-delete.html:25
+#: pkg/kubernetes/views/remove-role-dialog.html:8
+msgid "Remove"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2791
+#, fuzzy
+msgid "Remove $0"
+msgstr "Périphérique RAID $0"
+
+#: pkg/kubernetes/views/group-delete.html:3
+msgid "Remove Group"
+msgstr ""
+
+#: pkg/kubernetes/views/user-group-remove.html:3
+msgid "Remove Member"
+msgstr ""
+
+#: pkg/kubernetes/views/remove-role-dialog.html:3
+msgid "Remove Role"
+msgstr ""
+
+#: pkg/kubernetes/views/user-delete.html:3
+msgid "Remove User"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:3
+msgid "Remove image tag"
+msgstr ""
+
+#: pkg/kubernetes/views/user-remove-membership.html:3
+msgid "Remove membership"
+msgstr ""
+
+#: pkg/storaged/jobs.js:141
+msgid "Removing $target from RAID Device"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2788
+msgid "Removing <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:154
+msgid "Removing physical volume from $target"
+msgstr ""
+
+#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
+#: pkg/storaged/details.js:1775
+msgid "Rename"
+msgstr "Renommer"
+
+#: pkg/storaged/details.js:795
+msgid "Rename Volume Group"
+msgstr "Renommer un groupe de volumes"
+
+#: pkg/storaged/details.js:706
+msgid "Renamee Logical Volume"
+msgstr "Renommer un volume logique"
+
+#: pkg/storaged/jobs.js:157
+msgid "Renaming $target"
+msgstr ""
+
+#: pkg/systemd/services.html:432
+msgid "Repeat Daily"
+msgstr ""
+
+#: pkg/systemd/services.html:431
+msgid "Repeat Hourly"
+msgstr ""
+
+#: pkg/systemd/services.html:434
+msgid "Repeat Monthly"
+msgstr ""
+
+#: pkg/systemd/services.html:433
+msgid "Repeat Weekly"
+msgstr ""
+
+#: pkg/systemd/services.html:435
+msgid "Repeat Yearly"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-body.html:9
+#: pkg/kubernetes/views/details-page.html:141
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
+#: pkg/kubernetes/views/replicationcontroller-modify.html:8
+msgid "Replicas"
+msgstr "Répliques"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:14
+#: pkg/kubernetes/views/replicationcontroller-panel.html:10
+#: pkg/kubernetes/views/topology-page.html:23
+msgid "Replication Controller"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:132
+msgid "Replication Controllers"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:24
 msgid ""
-"The storage pool will be reset to optimize its layout.  All containers will "
-"be erased."
+"Replication controllers dynamically create instances of                pods "
+"from templates, and remove pods when necessary."
 msgstr ""
 
-#: pkg/docker/storage.jsx:360
-msgid "Erase containers, reformat disks, and add them"
+#: pkg/docker/index.html:718
+msgid "Repository"
+msgstr "Dépôt"
+
+#: pkg/kubernetes/views/volume-body.html:24
+msgid "Repository URL"
 msgstr ""
 
-#: pkg/docker/storage.jsx:363
-msgid "Add Additional Storage"
+#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
+msgid "Requested"
 msgstr ""
 
-#: pkg/docker/storage.jsx:366
-msgid ""
-"All data on selected disks will be erased and disks will be added to the "
-"storage pool."
+#: pkg/kubernetes/views/pv-claim.html:13
+msgid "Requests"
 msgstr ""
 
-#: pkg/docker/storage.jsx:404
-msgid "Could not add all disks"
+#: pkg/kubernetes/views/auth-form.html:54
+msgid "Requires Authentication"
+msgstr ""
+
+#: pkg/docker/index.html:323
+msgid "Reset"
 msgstr ""
 
 #: pkg/docker/storage.jsx:417
@@ -2102,382 +4612,596 @@ msgid ""
 "the pool."
 msgstr ""
 
-#: pkg/docker/storage.jsx:423
-msgid "Erase containers and reset storage pool"
+#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
+msgid "Resize"
+msgstr "Redimensionner"
+
+#: pkg/storaged/details.js:673
+msgid "Resize Filesystem"
+msgstr "Redimensionner un système de fichiers"
+
+#: pkg/storaged/details.js:661
+msgid "Resize Logical Volume"
+msgstr "Redimensionner un volume logique"
+
+#: pkg/storaged/jobs.js:158
+msgid "Resizing $target"
 msgstr ""
 
-#: pkg/docker/storage.jsx:446
-msgid "Could not reset the storage pool"
+#: pkg/systemd/index.html:126 pkg/systemd/index.html:133
+msgid "Restart"
+msgstr "Redémarrer"
+
+#: pkg/kubernetes/views/container-body.html:20
+msgid "Restart Count"
 msgstr ""
 
-#: pkg/docker/storage.jsx:482
-msgid "You don't have permission to manage the Docker storage pool."
+#: pkg/docker/index.html:558 pkg/kubernetes/views/pod-body.html:10
+msgid "Restart Policy"
 msgstr ""
 
-#: pkg/docker/storage.jsx:485
-msgid "The Docker storage pool cannot be managed on this system."
+#: pkg/kubernetes/scripts/volumes.js:217
+msgid "Retain"
 msgstr ""
 
-#: pkg/docker/image.js:77
-msgid "Image $0"
-msgstr "Image $0"
-
-#: pkg/docker/image.js:152
-msgid ""
-"Deleting an image will delete it, but you can probably download it again if "
-"you need it later.  Unless this image has never been pushed to a repository, "
-"that is, in which case you probably can't download it again."
-msgstr ""
-"Supprimer une image la supprimera, mais il sera probablement possible de la "
-"récupérer à nouveau plus tard. Si cette image n'a jamais été poussée sur un "
-"dépôt, il ne sera probablement pas possible de la récupérer."
-
-#: pkg/docker/util.js:94
-msgid "Up since $StartedAt"
-msgstr "Allumé depuis $StartedAt"
-
-#: pkg/docker/util.js:96
-msgid "Exited $ExitCode"
-msgstr "Code de sortie $ExitCode"
-
-#: pkg/docker/util.js:104
-msgid "On failure, retry $0 time"
-msgid_plural "On failure, retry $0 times"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/docker/util.js:107 pkg/docker/index.html.h:48
-msgid "Always"
+#: pkg/docker/index.html:574
+msgid "Retries:"
 msgstr ""
 
-#: pkg/docker/util.js:109 pkg/docker/index.html.h:49
-msgid "Unless Stopped"
+#: pkg/subscriptions/subscriptions-view.jsx:188
+msgid "Retrieving subscription status..."
 msgstr ""
 
-#: pkg/docker/util.js:123
-msgid "default"
-msgstr "par défaut"
+#: pkg/kubernetes/views/volume-body.html:26
+msgid "Revision"
+msgstr ""
 
-#: pkg/docker/util.js:124
-msgid "$0 shares"
-msgstr "$0 partages"
+#: pkg/users/index.html:94 pkg/kubernetes/views/add-member-role-dialog.html:39
+#: pkg/kubernetes/views/project-body.html:21
+msgid "Roles"
+msgstr ""
 
-#: pkg/docker/util.js:231
-msgid "Stopped"
-msgstr "Arrêté"
+#: pkg/ostree/index.html:73
+msgid "Roll back and reboot"
+msgstr ""
 
-#: pkg/docker/util.js:488
-msgid "Container is currently running."
-msgstr "Le conteneur est en cours d'exécution"
+#: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
+msgid "Round Robin"
+msgstr "Round Robin"
 
-#: pkg/docker/util.js:490
-msgid ""
-"Container is currently marked as not running, but regular stopping failed."
-msgstr "Le conteneur est marqué comme arrêté, mais l'arrêt normal a échoué."
+#: pkg/kubernetes/views/route-page.html:14
+#: pkg/kubernetes/views/route-panel.html:9
+msgid "Route"
+msgstr ""
 
-#: pkg/docker/util.js:491
-msgid "Error message from Docker:"
-msgstr "Message d'erreur de Docker :"
+#: pkg/kubernetes/views/details-page.html:65
+msgid "Routes"
+msgstr "Routes"
 
-#: pkg/docker/util.js:501
-msgid "Please confirm forced deletion of $0"
-msgstr "Merci de confirmer la suppression de $0"
-
-#: pkg/docker/util.js:503
-msgid "Force Delete"
-msgstr "Forcer la suppression"
-
-#: pkg/docker/util.js:544
-msgid "Failed to stop Docker scope: $0"
-msgstr "Échec de l'arrêt de la portée Docker : $0"
-
-#: pkg/docker/containers-view.jsx:239
+#: pkg/systemd/services.html:384
 #, fuzzy
-msgid "Commit"
-msgstr "Commande"
+msgid "Run"
+msgstr "En fonctionnement"
 
-#: pkg/docker/containers.js:64
-msgid "Failed to start Docker: $0"
-msgstr "Échec du démarrage de Docker : $0"
-
-#: pkg/users/authorized-keys.js:103
-msgid "Validating key"
-msgstr "Validation de la clé"
-
-#: pkg/users/authorized-keys.js:108
-msgid "Adding key"
-msgstr "Ajout de la clé"
-
-#: pkg/users/authorized-keys.js:115
-msgid "Error saving authorized keys: "
-msgstr "Erreur pendant l'enregistrement du fichier authorized_keys :"
-
-#: pkg/users/authorized-keys.js:118
-msgid "The key you provided was not valid."
-msgstr "La clé fournie est invalide."
-
-#: pkg/users/local.js:40
-msgid "The user <b>$0</b> is not permitted to modify accounts"
-msgstr "L'utilisateur <b>$0</b> n'a pas le droit de modifier les comptes"
-
-#: pkg/users/local.js:57
-msgid "Unable to delete root account"
-msgstr "Impossible de supprimer le compte root"
-
-#: pkg/users/local.js:59
-msgid "Unable to rename root account"
-msgstr "Impossible de renommer le compte root"
-
-#: pkg/users/local.js:82
-msgid "Prompting via passwd timed out"
-msgstr "Temps d'attente dépassé sur saisie avec passwd"
-
-#: pkg/users/local.js:247
-msgid "Password is too weak"
-msgstr "Le mot de passe est trop faible"
-
-#: pkg/users/local.js:259
-msgid "Password is not acceptable"
-msgstr "Le mot de passe n'est pas acceptable"
-
-#: pkg/users/local.js:284 pkg/users/local.js:594
-msgctxt "page-title"
-msgid "Accounts"
-msgstr "Comptes"
-
-#: pkg/users/local.js:395 pkg/users/local.js:1082
-msgid "The passwords do not match"
-msgstr "Les mots de passe ne correspondent pas."
-
-#: pkg/users/local.js:400
-msgid "No user name specified"
-msgstr "Aucun nom d'utilisateur indiqué."
-
-#: pkg/users/local.js:405
-msgid "No real name specified"
-msgstr "Aucun nom réel indiqué."
-
-#: pkg/users/local.js:429 pkg/users/local.js:1104
-msgid "Excellent password"
-msgstr "Mot de passe excellent"
-
-#: pkg/users/local.js:501
-msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
+#: pkg/kubernetes/views/image-config.html:4
+msgid "Run as"
 msgstr ""
 
-#: pkg/users/local.js:509
-msgid "This user name already exists"
+#: pkg/networkmanager/index.html:381
+#, fuzzy
+msgid "Runner"
+msgstr "En fonctionnement"
+
+#: pkg/ostree/index.html:83
+msgid "Running"
+msgstr "En fonctionnement"
+
+#: pkg/selinux/setroubleshoot-view.jsx:478
+msgid "SELinux Access Control Errors"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:330
+msgid "SELinux Policy"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot.html:23
+msgid "SELinux Troubleshoot"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:317
+msgid "SELinux is disabled on the system."
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:309
+msgid "SELinux system status is unknown."
+msgstr ""
+
+#: pkg/storaged/jobs.js:119
+msgid "SMART self-test of $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:218
+msgid "STP Forward delay"
+msgstr "Délai de réacheminement STP"
+
+#: pkg/networkmanager/index.html:227
+msgid "STP Hello time"
+msgstr "Durée Hello STP"
+
+#: pkg/networkmanager/index.html:236
+msgid "STP Maximum message age"
+msgstr "Âge maximal de message STP"
+
+#: pkg/networkmanager/index.html:209
+msgid "STP Priority"
+msgstr "Priorité STP"
+
+#: pkg/systemd/services.html:466
+msgid "Save"
+msgstr ""
+
+#: pkg/ostree/client.js:66
+msgid "Scanning metadata"
+msgstr ""
+
+#: pkg/kubernetes/views/node-capacity.html:9
+msgid "Scheduled Pods"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:322
+msgid "Scheduling Disabled"
+msgstr ""
+
+#: pkg/systemd/services.html:402 pkg/systemd/services.html:406
+msgid "Seconds"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:195
+msgid "Secret"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:106
+msgid "Secret File"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:141
+msgid "Secret Name"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:69
+#: pkg/kubernetes/views/volume-body.html:108
+#: pkg/kubernetes/views/volume-body.html:134
+msgid "Secret Volume"
+msgstr ""
+
+#: pkg/systemd/index.html:93
+msgid "Secure Shell Keys"
+msgstr ""
+
+#: pkg/storaged/jobs.js:136
+msgid "Securely erasing $target"
+msgstr ""
+
+#: pkg/kubernetes/views/file-button.html:4
+msgid "Select Manifest File..."
+msgstr "Sélectionner le fichier de manifeste..."
+
+#: pkg/kubernetes/views/topology-page.html:7
+msgid "Select an object to see more details."
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:8
+msgid ""
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
+msgstr ""
+
+#: pkg/networkmanager/index.html:69 pkg/networkmanager/index.html:97
+#: pkg/networkmanager/index.html:115 pkg/networkmanager/index.html:515
+#: pkg/networkmanager/index.html:550
+msgid "Sending"
+msgstr "Envoi"
+
+#: pkg/storaged/index.html:432
+msgctxt "storage"
+msgid "Serial Number"
+msgstr "Numéro de série"
+
+#: pkg/kubernetes/views/pv-modify.html:82
+#: pkg/kubernetes/views/volume-body.html:47
+msgid "Server"
+msgstr ""
+
+#: pkg/storaged/overview.js:518
+msgid "Server Address"
 msgstr ""
 
 #: pkg/users/local.js:682 pkg/users/local.js:683
 msgid "Server Administrator"
 msgstr "Administrateur de serveurs"
 
-#: pkg/users/local.js:684
-msgid "Container Administrator"
-msgstr "Administrateur de conteneurs"
+#: pkg/storaged/overview.js:521
+#, fuzzy
+msgid "Server address cannot be empty."
+msgstr "Le nom ne peut être vide."
 
-#: pkg/users/local.js:839
-msgid "Logged In"
-msgstr "Connecté"
-
-#: pkg/users/local.js:841
-msgid "Never"
-msgstr "Jamais"
-
-#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
-msgid "Delete $0"
-msgstr "Supprimer $0"
-
-#: pkg/sosreport/index.js:49 pkg/sosreport/index.js:113
-#: pkg/systemd/services.html.h:13 pkg/lib/machine-invalid-hostkey.html.h:4
-#: pkg/lib/machine-auth-failed.html.h:7
-#: pkg/lib/machine-unknown-hostkey.html.h:4
-#: pkg/lib/machine-change-port.html.h:8 pkg/lib/machine-not-supported.html.h:3
-#: pkg/shell/index.html.h:37
-msgid "Close"
-msgstr "Fermer"
-
-#: pkg/sosreport/index.js:115
-msgid "No archive has been created."
+#: src/base1/cockpit.js:3709
+msgid "Server has closed the connection."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:598 pkg/networkmanager/interfaces.js:1051
-#: pkg/networkmanager/interfaces.js:2255 pkg/networkmanager/interfaces.js:2257
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:753 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/kubernetes/views/node-body.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:6
-#: pkg/kubernetes/views/pv-claim.html.h:7
-#: pkg/kubernetes/views/image-body.html.h:6
-#: pkg/kubernetes/views/pv-body.html.h:5
-msgid "Unknown"
-msgstr "Inconnu"
-
-#: pkg/networkmanager/interfaces.js:805
-msgid "Not available"
-msgstr "Indisponible"
-
-#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
-#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
-msgid "Inactive"
-msgstr "Inactif"
-
-#: pkg/networkmanager/interfaces.js:809
-msgid "Preparing"
-msgstr "Préparation"
-
-#: pkg/networkmanager/interfaces.js:811
-msgid "Configuring"
-msgstr "Configuration"
-
-#: pkg/networkmanager/interfaces.js:813
-msgid "Authenticating"
-msgstr "Authentification"
-
-#: pkg/networkmanager/interfaces.js:815
-msgid "Configuring IP"
-msgstr "Configuration IP"
-
-#: pkg/networkmanager/interfaces.js:817
-msgid "Checking IP"
-msgstr "Vérification IP"
-
-#: pkg/networkmanager/interfaces.js:819
-msgid "Waiting"
-msgstr "Attente"
-
-#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
-msgid "Active"
-msgstr "Actif"
-
-#: pkg/networkmanager/interfaces.js:823
-msgid "Deactivating"
-msgstr "Désactivation"
-
-#: pkg/networkmanager/interfaces.js:825 pkg/ostree/index.html.h:14
-msgid "Failed"
-msgstr "Échec"
-
-#: pkg/networkmanager/interfaces.js:1326
-msgid "No carrier"
-msgstr "Pas de porteuse"
-
-#: pkg/networkmanager/interfaces.js:1372
-msgid "Part of "
-msgstr "Fait partie de "
-
-#: pkg/networkmanager/interfaces.js:1420
-msgid "The user <b>$0</b> is not permitted to modify network settings"
+#: pkg/kubernetes/views/service-page.html:12
+#: pkg/kubernetes/views/service-panel.html:8
+#: pkg/kubernetes/views/topology-page.html:32
+msgid "Service"
 msgstr ""
-"L'utilisateur <b>$0</b> n'a pas le droit de modifier les réglages réseau"
 
-#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
-msgctxt "page-title"
-msgid "Networking"
-msgstr "Réseau"
+#: pkg/kubernetes/views/pod-body.html:12
+msgid "Service Account"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1804
-msgid "Automatic (DHCP)"
-msgstr "Automatique (DHCP)"
+#: pkg/systemd/services.html:279
+msgid "Service Logs"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
-msgid "Link local"
-msgstr "Lien local"
+#: pkg/systemd/services.html:342
+msgid "Service name"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
-msgid "Manual"
-msgstr "Manuel"
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:272
+#: pkg/kubernetes/views/dashboard-page.html:134
+#: pkg/kubernetes/views/details-page.html:29
+msgid "Services"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:33
+msgid ""
+"Services group pods and provide a common DNS                name and an "
+"optional, load-balanced IP address to access them."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:20
+msgid "Session Affinity"
+msgstr ""
+
+#: pkg/dashboard/index.html:190
+msgid "Set"
+msgstr ""
+
+#: pkg/systemd/host.js:559
+msgid "Set Host name"
+msgstr "Définir le nom d'hôte"
+
+#: pkg/users/index.html:117 pkg/users/index.html:221
+msgid "Set Password"
+msgstr ""
+
+#: pkg/systemd/index.html:395
+msgid "Set Time"
+msgstr ""
+
+#: pkg/docker/index.html:551
+msgid "Set container environment variables"
+msgstr ""
+
+#: pkg/networkmanager/index.html:172
+msgid "Set to"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:326
+msgid ""
+"Setting deviates from the configured state and will revert on the next boot."
+msgstr ""
+
+#: pkg/storaged/jobs.js:131
+msgid "Setting up loop device $target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:139
+msgid "Share Name"
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:1807
 msgid "Shared"
 msgstr "Partagé"
 
-#: pkg/networkmanager/interfaces.js:1813 pkg/networkmanager/interfaces.js:2475
-#: pkg/networkmanager/interfaces.js:3019 pkg/networkmanager/interfaces.js:3023
-#: pkg/networkmanager/interfaces.js:3029 pkg/networkmanager/index.html.h:22
-msgid "Automatic"
-msgstr "Automatique"
+#: pkg/kubernetes/views/container-panel.html:9
+#: pkg/kubernetes/views/container-page-inline.html:14
+msgid "Shell"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1814
-msgid "Automatic (DHCP only)"
-msgstr "Automatique (DHCP uniquement)"
+#: pkg/kubernetes/views/container-page.html:4
+msgid "Show all Containers"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1817
-msgid "Ignore"
-msgstr "Ignorer"
+#: pkg/kubernetes/views/deploymentconfig-page.html:8
+msgid "Show all Deployment Configs"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
-msgid "Round Robin"
-msgstr "Round Robin"
+#: pkg/kubernetes/views/node-page.html:8
+msgid "Show all Nodes"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
-msgid "Active Backup"
-msgstr "Active Backup"
+#: pkg/kubernetes/views/pv-page.html:9
+msgid "Show all Persistent Volumes"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1824
-msgid "XOR"
-msgstr "XOR"
+#: pkg/kubernetes/views/pod-container.html:4
+msgid "Show all Pod Containers"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
-msgid "Broadcast"
-msgstr "Broadcast"
+#: pkg/kubernetes/views/pod-page.html:8
+msgid "Show all Pods"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1826
-msgid "802.3ad"
-msgstr "802.3ad"
+#: pkg/kubernetes/views/user-page.html:16
+#: pkg/kubernetes/views/group-page.html:14
+#: pkg/kubernetes/views/project-page.html:23
+msgid "Show all Projects"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1827
-msgid "Adaptive transmit load balancing"
-msgstr "Adaptive transmit load balancing"
+#: pkg/kubernetes/views/replicationcontroller-page.html:10
+msgid "Show all Replication Controllers"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1828
-msgid "Adaptive load balancing"
-msgstr "Adaptive load balancing"
+#: pkg/kubernetes/views/route-page.html:10
+msgid "Show all Routes"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1833
-msgid "MII (Recommended)"
-msgstr "MII (Recommandé)"
+#: pkg/kubernetes/views/service-page.html:8
+msgid "Show all Services"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1834
-msgid "ARP"
-msgstr "ARP"
-
-#: pkg/networkmanager/interfaces.js:1841
+#: pkg/docker/index.html:127
 #, fuzzy
-msgid "Load Balancing"
-msgstr "Adaptive load balancing"
+msgid "Show all containers"
+msgstr "Conteneurs"
 
-#: pkg/networkmanager/interfaces.js:1843
+#: pkg/kubernetes/views/imagestream-page.html:12
+msgid "Show all image streams"
+msgstr ""
+
+#: pkg/docker/index.html:241 pkg/kubernetes/views/image-page.html:11
+msgid "Show all images"
+msgstr ""
+
+#: pkg/systemd/index.html:94
+msgid "Show fingerprints"
+msgstr ""
+
+#: pkg/systemd/index.html:136
+msgid "Shutdown"
+msgstr "Éteindre"
+
+#: pkg/kubernetes/views/container-body.html:18
+msgid "Since"
+msgstr ""
+
+#: pkg/systemd/init.js:621
+msgid "Since $0"
+msgstr "Depuis $0"
+
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/storaged/index.html:232
+msgid "Size"
+msgstr "Taille"
+
+#: pkg/storaged/dialog.js:271
 #, fuzzy
-msgid "802.3ad LACP"
-msgstr "802.3ad"
+msgid "Size cannot be negative"
+msgstr "Le nom ne peut être vide."
 
-#: pkg/networkmanager/interfaces.js:1848
-msgid "Passive"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1854
-msgid "Ethtool"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1855
+#: pkg/storaged/dialog.js:269
 #, fuzzy
-msgid "ARP Ping"
-msgstr "Supervision ARP"
+msgid "Size cannot be zero"
+msgstr "Le nom ne peut être vide."
 
-#: pkg/networkmanager/interfaces.js:1856
-msgid "NSNA Ping"
+#: pkg/storaged/dialog.js:273
+msgid "Size is too large"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2156
-msgid "Deleting <b>$0</b> will break the connection to the server, "
+#: pkg/storaged/dialog.js:267
+msgid "Size must be a number"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2188
-msgid "Switching on <b>$0</b>  will break the connection to the server, "
+#: pkg/kubernetes/views/auth-form.html:43
+#: pkg/kubernetes/views/auth-rejected-cert.html:11
+msgid "Skip Certificate Verification"
+msgstr ""
+
+#: pkg/systemd/services.html:54
+msgid "Sockets"
+msgstr ""
+
+#: pkg/ostree/index.html:23
+msgid "Software Updates"
+msgstr ""
+
+#: pkg/docker/storage.jsx:156
+#, fuzzy
+msgid "Solid-State Disk"
+msgstr "Disque SSD"
+
+#: pkg/storaged/overview.js:182
+msgctxt "storage"
+msgid "Solid-State Disk"
+msgstr "Disque SSD"
+
+#: pkg/selinux/setroubleshoot-view.jsx:90
+msgid "Solution applied successfully"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:97
+msgid "Solution failed"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:908
+msgid "Sorry, I don't know how to modify this volume"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:8
+msgid "Source URL"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2573
+msgid "Spanning Tree Protocol"
+msgstr "Spanning Tree Protocol"
+
+#: pkg/networkmanager/index.html:200
+msgid "Spanning Tree Protocol (STP)"
+msgstr "Spanning Tree Protocol (STP)"
+
+#: pkg/storaged/details.js:1594
+msgid "Spare"
+msgstr "Rechange"
+
+#: pkg/systemd/index.html:470
+msgid "Specific Time"
+msgstr ""
+
+#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
+msgid "Start"
+msgstr "Démarrer"
+
+#: pkg/docker/index.html:68
+msgid "Start Docker"
+msgstr "Démarrer docker"
+
+#: pkg/storaged/index.html:49
+msgid "Start Multipath"
+msgstr ""
+
+#: pkg/storaged/details.js:1614
+msgid "Start Scrubbing"
+msgstr "Démarrer la scrutation"
+
+#: pkg/storaged/jobs.js:139
+msgid "Starting RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:124
+msgid "Starting swapspace $target"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:37
+#, fuzzy
+msgid "Starts"
+msgstr "Démarrer"
+
+#: pkg/kubernetes/views/container-body.html:16
+#: pkg/kubernetes/views/details-page.html:38
+#: pkg/kubernetes/views/details-page.html:175
+msgid "State"
+msgstr ""
+
+#: pkg/storaged/index.html:571
+#, fuzzy
+msgctxt "storage"
+msgid "State"
+msgstr "Statique"
+
+#: pkg/systemd/init.js:303
+msgid "Static"
+msgstr "Statique"
+
+#: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/containers-listing.html:16
+#: pkg/kubernetes/views/nodes-page.html:44
+#: pkg/kubernetes/views/pvc-body.html:13 pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/pv-body.html:24
+msgid "Status"
+msgstr "État"
+
+#: pkg/subscriptions/subscriptions-view.jsx:146
+#, fuzzy
+msgid "Status: $0"
+msgstr "État"
+
+#: pkg/subscriptions/subscriptions-view.jsx:141
+msgid "Status: System isn't registered"
+msgstr ""
+
+#: pkg/networkmanager/index.html:455
+msgid "Sticky"
+msgstr ""
+
+#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
+msgid "Stop"
+msgstr "Arrêter"
+
+#: pkg/storaged/details.js:1615
+msgid "Stop Scrubbing"
+msgstr "Arrêter la scrutation"
+
+#: pkg/kubernetes/views/image-config.html:10
+msgid "Stop with"
+msgstr ""
+
+#: pkg/docker/util.js:231
+msgid "Stopped"
+msgstr "Arrêté"
+
+#: pkg/storaged/jobs.js:138
+msgid "Stopping RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:125
+msgid "Stopping swapspace $target"
+msgstr ""
+
+#: pkg/storaged/index.html:23 pkg/storaged/index.html:672
+msgid "Storage"
+msgstr ""
+
+#: pkg/storaged/index.html:686
+msgid "Storage Log"
+msgstr ""
+
+#: pkg/storaged/index.html:342
+msgid "Storage Logs"
+msgstr "Logs de stockage"
+
+#: pkg/docker/index.html:324
+msgid "Storage pool"
+msgstr ""
+
+#: pkg/systemd/index.html:148
+msgid "Store Performance Data"
+msgstr ""
+
+#: pkg/storaged/details.js:237
+msgid "Store passphrase"
+msgstr "Enregistrer la phrase de passe"
+
+#: pkg/storaged/details.js:527
+msgid "Stored Passphrase"
+msgstr "Phrase de passe enregistrée"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:12
+msgid ""
+"Strategy            {{item.spec.strategy.type}}            Latest "
+"Version            {{ item.status.latestVersion }}            Not "
+"deployed        "
+msgstr ""
+
+#: pkg/subscriptions/index.html:22
+msgid "Subscriptions"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:4
+msgid "Summary"
+msgstr ""
+
+#: pkg/storaged/details.js:1251
+msgctxt "storage-id-desc"
+msgid "Swap Space"
+msgstr "Espace d'échange"
+
+#: pkg/systemd/index.html:243
+msgid "Swap Used"
+msgstr "Échange utilisé"
+
+#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
+msgid "Switch off $0"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2191 pkg/networkmanager/interfaces.js:2765
@@ -2488,356 +5212,619 @@ msgstr ""
 msgid "Switching off <b>$0</b>  will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
-msgid "Switch off $0"
+#: pkg/networkmanager/interfaces.js:2773
+msgid "Switching off <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
-#: pkg/networkmanager/interfaces.js:2507
-msgid "Bond"
-msgstr "Bond"
+#: pkg/networkmanager/interfaces.js:2188
+msgid "Switching on <b>$0</b>  will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2762
+msgid "Switching on <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:75
+msgid "Synchronize"
+msgstr ""
+
+#: pkg/dashboard/index.html:188 pkg/lib/machine-sync-users.html:4
+msgid "Synchronize users"
+msgstr ""
+
+#: pkg/systemd/index.html:54
+msgid "Synchronized"
+msgstr ""
+
+#: pkg/systemd/index.html:51
+msgid "Synchronized with {{Server}}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:146
+msgid "Synchronizing RAID Device $target"
+msgstr ""
+
+#: pkg/systemd/index.html:4
+msgid "System"
+msgstr ""
+
+#: pkg/systemd/services.html:53
+msgid "System Services"
+msgstr ""
+
+#: pkg/systemd/index.html:112
+msgid "System Time"
+msgstr ""
+
+#: pkg/docker/index.html:349
+msgid "TCP"
+msgstr "TCP"
+
+#: pkg/kubernetes/views/route-body.html:12
+msgid "TLS Termination"
+msgstr ""
+
+#: pkg/docker/index.html:724
+msgid "Tag"
+msgstr "Balise"
+
+#: pkg/kubernetes/views/image-body.html:27
+#: pkg/kubernetes/views/imagestream-modify.html:76
+#: pkg/kubernetes/views/image-listing.html:14
+msgid "Tags"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:136
+msgid "Target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:75
+msgid "Target Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:114
+msgid "Target World Wide Names"
+msgstr ""
+
+#: pkg/systemd/services.html:52
+msgid "Targets"
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2235 pkg/networkmanager/interfaces.js:2247
 #: pkg/networkmanager/interfaces.js:2530
 msgid "Team"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
-#: pkg/networkmanager/interfaces.js:2622
-msgid "VLAN"
-msgstr "VLAN"
+#: pkg/networkmanager/interfaces.js:2558
+msgid "Team Port"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
-#: pkg/networkmanager/interfaces.js:2584
-msgid "Bridge"
-msgstr "Pont"
+#: pkg/networkmanager/index.html:652
+#, fuzzy
+msgid "Team Port Settings"
+msgstr "Réglages de port du pont"
 
-#: pkg/networkmanager/interfaces.js:2276
-msgid "Carrier"
-msgstr "Porteuse"
+#: pkg/networkmanager/index.html:624
+#, fuzzy
+msgid "Team Settings"
+msgstr "Paramétrage IP"
 
-#: pkg/networkmanager/interfaces.js:2279 pkg/kubernetes/scripts/volumes.js:990
-msgid "Yes"
-msgstr "Oui"
+#: pkg/kubernetes/views/replicationcontroller-page.html:20
+#: pkg/kubernetes/views/deploymentconfig-panel.html:10
+#: pkg/kubernetes/views/deploymentconfig-page.html:15
+#: pkg/kubernetes/views/replicationcontroller-panel.html:14
+msgid "Template"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2299
-#: pkg/subscriptions/subscriptions-view.jsx:36
-#: pkg/kubernetes/views/node-body.html.h:14
-#: pkg/kubernetes/views/containers-listing.html.h:7
-#: pkg/kubernetes/views/volumes-page.html.h:5
-#: pkg/kubernetes/views/pv-claim.html.h:6
-#: pkg/kubernetes/views/nodes-page.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:5 pkg/kubernetes/views/pv-body.html.h:4
-msgid "Status"
-msgstr "État"
+#: pkg/systemd/terminal.html:4
+msgid "Terminal"
+msgstr ""
+
+#: pkg/users/index.html:78
+msgid "Terminate Session"
+msgstr ""
+
+#: pkg/networkmanager/index.html:38
+msgid "Testing connection"
+msgstr ""
+
+#: pkg/storaged/index.html:40
+msgid "The \"storaged\" API is not available on this system."
+msgstr ""
+
+#: pkg/docker/storage.jsx:485
+msgid "The Docker storage pool cannot be managed on this system."
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:386
+msgid "The IP address or host name cannot contain whitespace."
+msgstr "L'adresse IP ou nom d'hôte ne peut pas contenir d'espace."
+
+#: pkg/storaged/index.html:532
+msgid "The RAID Array is in a degraded state"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:399
+msgid "The address contains invalid characters"
+msgstr "L'adresse contient des caractères invalides"
+
+#: pkg/lib/machine-unknown-hostkey.html:6
+msgid ""
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:324
+msgid "The configured state is unknown, it might change on the next boot."
+msgstr ""
+
+#: pkg/kubernetes/views/container-page-inline.html:22
+msgid "The container '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:192
+msgid "The current user isn't allowed to access system subscription status."
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:25
+msgid "The deployment config '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:47
+msgid "The group '{{ groupName }}' does not exist."
+msgstr ""
+
+#: pkg/shell/base_index.js:673
+msgid "The javascript console contains details about this error "
+msgstr ""
+"La console Javascript contient des informations au sujet de cette erreur."
+
+#: pkg/lib/machine-invalid-hostkey.html:8
+msgid ""
+"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
+"in use. Unless this machine was recently replaced, it is likely that someone "
+"is trying to attack your connection to this machine."
+msgstr ""
+
+#: pkg/users/authorized-keys.js:118
+msgid "The key you provided was not valid."
+msgstr "La clé fournie est invalide."
+
+#: pkg/storaged/details.js:1751
+msgid "The last physical volume of a volume group cannot be removed."
+msgstr ""
+
+#: pkg/shell/indexes.js:314
+msgid "The machine is restarting"
+msgstr "Cette machine redémarre"
+
+#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
+msgid "The maximum number of replicas is 128"
+msgstr "Le nombre maximal de répliques est 128"
+
+#: pkg/kubernetes/scripts/nodes.js:407
+msgid "The name contains invalid characters"
+msgstr ""
+
+#: pkg/kubernetes/views/node-page.html:23
+msgid "The node '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/node-alerts.html:7
+msgid "The node doesn't have enough disk space"
+msgstr ""
+
+#: pkg/kubernetes/views/node-alerts.html:11
+msgid "The node doesn't have enough free memory"
+msgstr ""
+
+#: pkg/users/local.js:395 pkg/users/local.js:1082
+msgid "The passwords do not match"
+msgstr "Les mots de passe ne correspondent pas."
+
+#: pkg/lib/credentials.js:186
+msgid "The passwords do not match."
+msgstr "Les mots de passe ne correspondent pas."
+
+#: pkg/kubernetes/views/pv-page.html:21
+msgid "The persistent volume '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:40
+msgid "The pod '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/project-page.html:34
+msgid "The project '{{ projName }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:30
+msgid "The replication controller '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:19
+msgid "The route '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:386
+msgid "The selected file is not a valid Kubernetes application manifest."
+msgstr ""
+"Le fichier sélectionné n'est pas un manifeste d'application kubernetes "
+"valide."
+
+#: src/base1/cockpit.js:3695
+msgid "The server refused to authenticate using any supported methods."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:2
+msgid "The server uses a certificate signed by an unknown authority."
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:19
+msgid "The service '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/docker/storage.jsx:355
+msgid ""
+"The storage pool will be reset to optimize its layout.  All containers will "
+"be erased."
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:29
+msgid "The user '{{ userName }}' does not exist."
+msgstr ""
+
+#: pkg/systemd/init.js:834
+#, fuzzy
+msgid "The user <b>$0</b> does not have permissions for creating timers"
+msgstr "L'utilisateur <b>$0</b> n'a pas le droit de gérer des serveurs"
+
+#: pkg/dashboard/list.js:209
+msgid "The user <b>$0</b> is not permitted to manage servers"
+msgstr "L'utilisateur <b>$0</b> n'a pas le droit de gérer des serveurs"
+
+#: pkg/storaged/permissions.js:61
+msgid "The user <b>$0</b> is not permitted to manage storage"
+msgstr ""
+
+#: pkg/users/local.js:40
+msgid "The user <b>$0</b> is not permitted to modify accounts"
+msgstr "L'utilisateur <b>$0</b> n'a pas le droit de modifier les comptes"
+
+#: pkg/systemd/host.js:43
+msgid "The user <b>$0</b> is not permitted to modify hostnames"
+msgstr "L'utilisateur <b>$0</b> n'a pas le droit de modifier les noms d'hôtes"
+
+#: pkg/networkmanager/interfaces.js:1420
+msgid "The user <b>$0</b> is not permitted to modify network settings"
+msgstr ""
+"L'utilisateur <b>$0</b> n'a pas le droit de modifier les réglages réseau"
+
+#: pkg/realmd/operation.js:436
+msgid "The user <b>$0</b> is not permitted to modify realms"
+msgstr "L'utilisateur <b>$0</b> n'a pas le droit de modifier les domaines"
+
+#: pkg/users/local.js:501
+msgid ""
+"The user name can only consist of letters from a-z, digits, dots, dashes and "
+"underscores."
+msgstr ""
+
+#: pkg/users/index.html:332
+msgid "There are no authorized public keys for this account."
+msgstr ""
+
+#: pkg/storaged/details.js:1756
+msgid ""
+"There is not enough free space elsewhere to remove this physical volume.  At "
+"least $0 more free space is needed."
+msgstr ""
+
+#: pkg/storaged/utils.js:168
+msgid "Thin Logical Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:8
+msgid ""
+"This claim is in use. Deleting it may cause issues with the following pod:"
+msgstr ""
+
+#: pkg/systemd/init.js:1222
+msgid ""
+"This day doesn't exist in all months.<br> The timer will only be executed in "
+"months that have 31st."
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2310
 msgid "This device cannot be managed here."
+msgstr ""
+
+#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
+#, fuzzy
+msgid "This field cannot be empty."
+msgstr "Le nom ne peut être vide."
+
+#: pkg/storaged/details.js:690
+msgid "This logical volume cannot be made smaller."
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:364
+msgid "This machine has already been added."
+msgstr "Cette machine a été déjà été ajoutée."
+
+#: pkg/realmd/operation.html:89
+msgid "This may take a while"
+msgstr "Cela peut prendre un certain temps"
+
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid ""
+"This option is for single node testing only – local storage will not work in "
+"a multi-node cluster"
+msgstr ""
+
+#: src/bridge/cockpitpackages.c:470
+msgid "This package is not compatible with this version of Cockpit"
+msgstr ""
+
+#: src/bridge/cockpitpackages.c:459
+#, c-format
+msgid "This package requires Cockpit version %s or later"
+msgstr ""
+
+#: pkg/tuned/dialog.js:102
+msgid "This system is using a custom profile"
+msgstr "Ce système utilise un profil personnalisé"
+
+#: pkg/tuned/dialog.js:100
+msgid "This system is using the recommended profile"
+msgstr "Ce système utilise le profil recommandé"
+
+#: pkg/systemd/init.js:639
+msgid "This unit is an instance of the $0 template."
+msgstr "Cette unité est une instance du modèle $0."
+
+#: pkg/systemd/services.html:302
+msgid "This unit is not designed to be enabled explicitly.          "
+msgstr ""
+
+#: pkg/users/local.js:509
+msgid "This user name already exists"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:380
+msgid ""
+"This version of cockpit-ws does not support connecting to a host with an "
+"alternate user or port"
+msgstr ""
+"Cette version de cockpit-ws ne prend pas en charge la connexion à un hôte "
+"avec un autre utilisateur ou un port différent"
+
+#: pkg/kubernetes/views/pv-delete.html:7
+msgid ""
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:23
+msgid "This volume has not been claimed"
+msgstr ""
+
+#: pkg/systemd/index.html:379
+msgid "Time Zone"
+msgstr ""
+
+#: pkg/systemd/services.html:55
+msgid "Timers"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:33
+msgid "To pull this image:"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:39
+msgid "To push to an image to this image stream:"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:11
+msgid ""
+"To try a different port you will need to upgrade cockpit-ws to a newer "
+"version."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:116
+msgid "Token"
+msgstr ""
+
+#: pkg/kubernetes/index.html:57
+msgid "Topology"
+msgstr ""
+
+#: pkg/docker/storage.jsx:314
+msgid "Total"
+msgstr ""
+
+#: pkg/ostree/index.html:99
+msgid "Tree"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:32
+msgid "Triggers"
+msgstr ""
+
+#: pkg/shell/index.html:328 pkg/shell/stub.html:181
+msgid "Troubleshoot"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:21
+msgid "Trust this certificate for this connection"
+msgstr ""
+
+#: pkg/systemd/init.js:520
+msgid "Try Restart"
+msgstr "Essayer de redémarrer"
+
+#: pkg/docker/index.html:71 pkg/docker/index.html:74
+msgid "Try again"
+msgstr "Réessayer"
+
+#: pkg/systemd/index.html:59
+msgid "Trying to synchronize with {{Server}}"
+msgstr ""
+
+#: pkg/tuned/dialog.js:262
+msgid "Tuned has failed to start"
+msgstr "Échec du démarrage de tuned"
+
+#: pkg/tuned/dialog.js:94
+msgid "Tuned is not available"
+msgstr "Tuned n'est pas disponible"
+
+#: pkg/tuned/dialog.js:96
+msgid "Tuned is not running"
+msgstr "Tuned n'est pas en cours d'exécution"
+
+#: pkg/tuned/dialog.js:98
+msgid "Tuned is off"
+msgstr "Tuned est désactivé"
+
+#: pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/pv-modify.html:10
+#: pkg/kubernetes/views/volumes-page.html:20 pkg/kubernetes/views/deploy.html:9
+msgid "Type"
+msgstr "Type"
+
+#: pkg/kubernetes/views/details-page.html:7
+msgid "Type:"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:110
+msgid "URL"
+msgstr ""
+
+#: pkg/storaged/index.html:547 pkg/storaged/index.html:626
+msgctxt "storage"
+msgid "UUID"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:114
+msgid "Unable to apply this solution automatically"
+msgstr ""
+
+#: pkg/ostree/index.html:219
+msgid "Unable to communicate with OSTree"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:195
+#, fuzzy
+msgid "Unable to connect"
+msgstr "Impossible d'obtenir l'alerte"
+
+#: pkg/kubernetes/scripts/dashboard.js:413
+msgid "Unable to decode Kubernetes application manifest."
+msgstr ""
+
+#: pkg/users/local.js:57
+msgid "Unable to delete root account"
+msgstr "Impossible de supprimer le compte root"
+
+#: pkg/selinux/setroubleshoot-client.js:157
+msgid "Unable to get alert"
+msgstr "Impossible d'obtenir l'alerte"
+
+#: pkg/storaged/overview.js:586
+msgid "Unable to reach server"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:401
+msgid "Unable to read the Kubernetes application manifest. Code $0."
+msgstr "Impossible de lire le manifeste d'application kubernetes. Code $0."
+
+#: pkg/users/local.js:59
+msgid "Unable to rename root account"
+msgstr "Impossible de renommer le compte root"
+
+#: pkg/selinux/setroubleshoot-client.js:172
+msgid "Unable to run fix"
+msgstr "Impossible d'exécutif l'action de correction"
+
+#: pkg/selinux/setroubleshoot-client.js:52
+msgid "Unable to start setroubleshootd"
+msgstr "Impossible de démarrer setroubleshootd"
+
+#: pkg/playground/translate.html:35 pkg/playground/translate.html:40
+msgid "Unavailable"
+msgstr ""
+
+#: pkg/docker/index.html:763 pkg/networkmanager/index.html:792
+msgid "Unexpected error"
+msgstr "Erreur inattendue"
+
+#: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/image-body.html:15
+#: pkg/kubernetes/views/pv-claim.html:31 pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
+msgid "Unknown"
+msgstr "Inconnu"
+
+#: pkg/storaged/details.js:1597
+msgid "Unknown ($0)"
+msgstr "Inconnu ($0)"
+
+#: pkg/lib/machine-unknown-hostkey.html:2
+msgid "Unknown Host Key"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2342
 msgid "Unknown configuration"
 msgstr "Configuration inconnue"
 
-#: pkg/networkmanager/interfaces.js:2441
-msgid "Configure"
-msgstr "Configurer"
-
-#: pkg/networkmanager/interfaces.js:2473
-msgid "$mtu"
+#: pkg/storaged/overview.js:582
+msgid "Unknown host name"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2477
-msgid "MTU"
+#: pkg/docker/index.html:570
+msgid "Unless Stopped"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2483
-msgid "Master"
-msgstr "Maître"
+#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
+#: pkg/storaged/details.js:1110
+msgid "Unlock"
+msgstr "Déverrouiller"
 
-#: pkg/networkmanager/interfaces.js:2502
-msgid "ARP Monitoring"
-msgstr "Supervision ARP"
+#: pkg/shell/index.html:220
+msgid "Unlock Key"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#: pkg/storaged/jobs.js:121
+msgid "Unlocking $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:108
 #, fuzzy
-msgid "Broken configuration"
-msgstr "Configuration inconnue"
+msgid "Unmanaged Interfaces"
+msgstr "Interfaces"
 
-#: pkg/networkmanager/interfaces.js:2558
-msgid "Team Port"
+#: pkg/systemd/init.js:548
+msgid "Unmask"
+msgstr "Démasquer"
+
+#: pkg/storaged/details.js:1100
+msgid "Unmount"
+msgstr "Démonter"
+
+#: pkg/storaged/jobs.js:127
+msgid "Unmounting $target"
+msgstr "Démontage de $target"
+
+#: pkg/users/index.html:315
+msgid "Unnamed"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2573
-msgid "Spanning Tree Protocol"
-msgstr "Spanning Tree Protocol"
-
-#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
-msgid "Priority $priority"
-msgstr "Priorité $priority"
-
-#: pkg/networkmanager/interfaces.js:2577
-#, fuzzy
-msgid "Forward delay $forward_delay"
-msgstr "Forward delay $forward_delay"
-
-#: pkg/networkmanager/interfaces.js:2579
-msgid "Hello time $hello_time"
-msgstr "Hello time $hello_time"
-
-#: pkg/networkmanager/interfaces.js:2581
-msgid "Maximum message age $max_age"
-msgstr "Âge maximal de message $max_age"
-
-#: pkg/networkmanager/interfaces.js:2601
-msgid "Path cost $path_cost"
-msgstr "Coût du chemin $path_cost"
-
-#: pkg/networkmanager/interfaces.js:2603
-msgid "Hairpin mode"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2605
-msgid "Bridge port"
-msgstr "Port de pont"
-
-#: pkg/networkmanager/interfaces.js:2619
-msgid "Parent $parent"
-msgstr "Parent $parent"
-
-#: pkg/networkmanager/interfaces.js:2620
-msgid "Id $id"
-msgstr "Id $id"
-
-#: pkg/networkmanager/interfaces.js:2628
-msgid "General"
-msgstr "Général"
-
-#: pkg/networkmanager/interfaces.js:2637
-msgid "Connect automatically"
-msgstr "Connexion automatique"
-
-#: pkg/networkmanager/interfaces.js:2641
-msgid "IPv4"
-msgstr "IPv4"
-
-#: pkg/networkmanager/interfaces.js:2642
-msgid "IPv6"
-msgstr "IPv6"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/networkmanager/index.html.h:33
-#: pkg/kubernetes/views/project-listing.html.h:5
-msgid "Members"
-msgstr "Membres"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/docker/index.html.h:39
-#: pkg/networkmanager/index.html.h:24
-#: pkg/kubernetes/views/service-body.html.h:6
-#: pkg/kubernetes/views/image-config.html.h:7
-#: pkg/kubernetes/views/container-body.html.h:5
-msgid "Ports"
-msgstr "Ports"
-
-#: pkg/networkmanager/interfaces.js:2762
-msgid "Switching on <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2773
-msgid "Switching off <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2788
-msgid "Removing <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2791
-#, fuzzy
-msgid "Remove $0"
-msgstr "Périphérique RAID $0"
-
-#: pkg/networkmanager/interfaces.js:2833
-msgid "Adding <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2836
-msgid "Add $0"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2870
-msgid "Changing the settings will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2872
-#, fuzzy
-msgid "Change the settings"
-msgstr "Réglages de port du pont"
-
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length or Netmask"
-msgstr "Longueur de préfixe ou masque de réseau"
-
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length"
-msgstr "Longueur de préfixe"
-
-#: pkg/networkmanager/interfaces.js:3011
-#: pkg/kubernetes/views/details-page.html.h:7
-msgid "Addresses"
-msgstr "Adresses"
-
-#: pkg/networkmanager/interfaces.js:3018
-msgid "DNS"
-msgstr "DNS"
-
-#: pkg/networkmanager/interfaces.js:3022
-msgid "DNS Search Domains"
-msgstr "Domaines de recherche DNS"
-
-#: pkg/networkmanager/interfaces.js:3027
-#: pkg/kubernetes/views/details-page.html.h:11
-msgid "Routes"
-msgstr "Routes"
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv4 Settings"
-msgstr "Réglages IPv4"
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv6 Settings"
-msgstr "Réglages IPv6"
-
-#: pkg/networkmanager/interfaces.js:3436
-msgid "Creating this bond will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
-#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
-#, fuzzy
-msgid "Create it"
-msgstr "Créer"
-
-#: pkg/networkmanager/interfaces.js:3611
-msgid "Creating this team will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3842
-msgid "Creating this bridge will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4064
-msgid "Creating this VLAN will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4139
-msgid "MTU must be a positive number"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:196
-#, fuzzy
-msgid "Invalid credentials"
-msgstr "Port invalide"
-
-#: pkg/subscriptions/subscriptions-client.js:198
-msgid "'Organization' required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:200
-msgid "Login/password or activation key required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:202
-msgid "'Organization' required when using activation keys."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:64
-#: pkg/kubernetes/views/volume-body.html.h:16
-#: pkg/kubernetes/views/pv-modify.html.h:11
-msgid "Server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:88
-#: pkg/subscriptions/subscriptions-register.jsx:152
-#: pkg/lib/machine-auth-failed.html.h:3 pkg/lib/machine-sync-users.html.h:6
-#: pkg/lib/machine-change-auth.html.h:6 pkg/shell/index.html.h:31
-#: pkg/users/index.html.h:16 pkg/kubernetes/views/auth-form.html.h:11
-msgid "Password"
-msgstr "Mot de passe"
-
-#: pkg/subscriptions/subscriptions-register.jsx:102
-#, fuzzy
-msgid "Custom URL"
-msgstr "Personnalisé"
-
-#: pkg/subscriptions/subscriptions-register.jsx:110
-msgid "URL"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:125
-msgid "Proxy"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:132
-msgid "Use proxy server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:140
-msgid "Login"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:164
-#, fuzzy
-msgid "Activation Key"
-msgstr "Activer"
-
-#: pkg/subscriptions/subscriptions-register.jsx:176
-msgid "Organization"
-msgstr ""
-
-#: pkg/subscriptions/main.js:45 pkg/subscriptions/subscriptions-view.jsx:143
-#: pkg/kubernetes/views/pv-modify.html.h:23
-msgid "Register"
-msgstr ""
-
-#: pkg/subscriptions/main.js:74
-msgid "Register system"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:32
-msgid "Product name"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product ID"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/index.html.h:13
-#: pkg/shell/index.html.h:14 pkg/shell/stub.html.h:9 pkg/shell/simple.html.h:9
-#: pkg/ostree/index.html.h:19
-msgid "Version"
-msgstr "Version"
-
-#: pkg/subscriptions/subscriptions-view.jsx:35
-#: pkg/kubernetes/views/image-config.html.h:5
-msgid "Architecture"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:37
-#, fuzzy
-msgid "Starts"
-msgstr "Démarrer"
-
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Ends"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:141
-msgid "Status: System isn't registered"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:146
-#, fuzzy
-msgid "Status: $0"
-msgstr "État"
+#: pkg/storaged/details.js:1256
+msgctxt "storage-id-desc"
+msgid "Unrecognized Data"
+msgstr "Données non reconnues"
 
 #: pkg/subscriptions/subscriptions-view.jsx:148
 msgid "Unregister"
@@ -2847,348 +5834,215 @@ msgstr ""
 msgid "Unregistering system..."
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:161
-#: pkg/subscriptions/index.html.h:1
-msgid "Subscriptions"
+#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
+#: src/bridge/cockpitdbussetup.c:625
+#, fuzzy
+msgid "Unsupported setup mechanism"
+msgstr "Mécanisme de configuration non pris en charge : %s"
+
+#: src/base1/cockpit.js:3697
+msgid "Untrusted host"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/ostree/index.html.h:15
+#: pkg/docker/util.js:94
+msgid "Up since $StartedAt"
+msgstr "Allumé depuis $StartedAt"
+
+#: pkg/lib/machine-change-port.html:41
+msgid "Update"
+msgstr ""
+
+#: pkg/ostree/index.html:125 pkg/ostree/index.html:152
+msgid "Updates"
+msgstr ""
+
+#: pkg/ostree/index.html:96
 msgid "Updating"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:188
-msgid "Retrieving subscription status..."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:191
-msgid "Access denied"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:192
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:195
-#, fuzzy
-msgid "Unable to connect"
-msgstr "Impossible d'obtenir l'alerte"
-
-#: pkg/subscriptions/subscriptions-view.jsx:196
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:222
-msgid "Installed products"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:223
-#, fuzzy
-msgid "No installed products on the system."
-msgstr "Docker n'est pas installé ou activé sur le système"
-
-#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "Nombre de répliques invalide"
-
-#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "Le nombre maximal de répliques est 128"
-
-#: pkg/kubernetes/scripts/details.js:546
-msgid "Not a valid value for Host"
 msgstr ""
 
 #: pkg/kubernetes/scripts/details.js:655
 msgid "Updating $0..."
 msgstr "Mise à jour de $0..."
 
-#: pkg/kubernetes/scripts/graphs.js:601 pkg/kubernetes/scripts/nodes.js:711
-#: pkg/kubernetes/scripts/nodes.js:817 pkg/dashboard/index.html.h:2
-msgid "CPU"
-msgstr "CPU"
-
-#: pkg/kubernetes/scripts/graphs.js:606 pkg/kubernetes/scripts/nodes.js:715
-#: pkg/kubernetes/scripts/nodes.js:826 pkg/dashboard/index.html.h:3
-msgid "Memory"
-msgstr "Mémoire"
-
-#: pkg/kubernetes/scripts/graphs.js:611 pkg/dashboard/index.html.h:4
-msgid "Network"
-msgstr "Réseau"
-
-#: pkg/kubernetes/scripts/nodes.js:319 pkg/kubernetes/views/node-body.html.h:16
-#: pkg/kubernetes/views/details-page.html.h:10
-msgid "Not Ready"
-msgstr "Pas prêt"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
+#: pkg/shell/index.html:165
+msgid "Use my password for privileged tasks and to connect to other machines"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:324 pkg/kubernetes/views/node-body.html.h:15
-#: pkg/kubernetes/views/details-page.html.h:9
-msgid "Ready"
-msgstr "Prêt"
-
-#: pkg/kubernetes/scripts/nodes.js:397
-msgid "Please type an address"
-msgstr "Merci de saisir une adresse"
-
-#: pkg/kubernetes/scripts/nodes.js:399
-msgid "The address contains invalid characters"
-msgstr "L'adresse contient des caractères invalides"
-
-#: pkg/kubernetes/scripts/nodes.js:407
-msgid "The name contains invalid characters"
+#: pkg/subscriptions/subscriptions-register.jsx:132
+msgid "Use proxy server"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
+#: pkg/shell/index.html:172
+msgid "Use the following keys to authenticate against other systems"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
+#: pkg/systemd/index.html:251
+msgid "Used"
+msgstr "Utilisé(e)"
+
+#: pkg/systemd/index.html:229 pkg/dashboard/index.html:158
+#: pkg/playground/translate.html:86 pkg/playground/translate.html:106
+#: pkg/kubernetes/views/user-panel.html:9
+#: pkg/kubernetes/views/auth-form.html:61
+#: pkg/kubernetes/views/volume-body.html:64
+#: pkg/kubernetes/views/volume-body.html:103
+msgid "User"
+msgstr "Utilisateur"
+
+#: pkg/users/index.html:90 pkg/users/index.html:154
+#: pkg/realmd/operation.html:47
+msgid "User Name"
+msgstr "Nom d'utilisateur"
+
+#: pkg/realmd/operation.html:53
+msgid "User Password"
+msgstr "Mot de passe utilisateur"
+
+#: pkg/lib/machine-change-auth.html:18
+msgid "User name"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
-msgid "Disk"
+#: pkg/kubernetes/views/add-member-role-dialog.html:15
+msgid "User or Group"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
+#: pkg/kubernetes/views/auth-form.html:94
+msgid "Username"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:870
-#, c-format
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/kubernetes/scripts/nodes.js:872
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/kubernetes/scripts/connection.js:88
-msgid "Error writing kubectl config"
+#: pkg/kubernetes/views/project-listing.html:85
+msgid "Users"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:514
-msgid "Couldn't find running API server"
+#: pkg/storaged/details.js:181
+msgid "VFAT - Compatible with all systems and devices"
+msgstr "VFAT - Compatible avec tous les systèmes et appareils"
+
+#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
+#: pkg/networkmanager/interfaces.js:2622
+msgid "VLAN"
+msgstr "VLAN"
+
+#: pkg/networkmanager/index.html:141
+msgid "VLAN Id"
+msgstr "Identifiant de VLAN"
+
+#: pkg/networkmanager/index.html:736
+msgid "VLAN Settings"
+msgstr "Réglages VLAN"
+
+#: pkg/users/authorized-keys.js:103
+msgid "Validating key"
+msgstr "Validation de la clé"
+
+#: pkg/systemd/index.html:98 pkg/ostree/index.html:113 pkg/shell/simple.html:77
+#: pkg/shell/index.html:90 pkg/shell/stub.html:83
+msgid "Version"
+msgstr "Version"
+
+#: pkg/storaged/jobs.js:137
+msgid "Very securely erasing $target"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:516
-msgid "Connection Error: $0"
+#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
+#: pkg/kubernetes/views/pvc-body.html:6
+msgid "Volume"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:539
-msgid "Please provide a valid address"
+#: pkg/storaged/index.html:620
+msgid "Volume Group"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:554
-msgid "Please provide a username"
+#: pkg/storaged/utils.js:239
+msgid "Volume Group $0"
+msgstr "Groupe de volumes $0"
+
+#: pkg/storaged/index.html:98
+msgid "Volume Groups"
+msgstr "Groupes de volumes"
+
+#: pkg/kubernetes/views/volume-body.html:14
+#: pkg/kubernetes/views/volume-body.html:89
+msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:650
-msgid "Error getting certificate details: $0"
+#: pkg/kubernetes/views/pv-modify.html:115
+#: pkg/kubernetes/views/volume-body.html:42
+msgid "Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
+#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
+msgid "Volume Type"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
+#: pkg/docker/index.html:536 pkg/kubernetes/views/pod-page.html:18
+#: pkg/kubernetes/views/image-config.html:28
+#: pkg/kubernetes/views/dashboard-page.html:47 pkg/kubernetes/index.html:70
+msgid "Volumes"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
+#: pkg/networkmanager/interfaces.js:819
+msgid "Waiting"
+msgstr "Attente"
+
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid "Warning:"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
+#: pkg/systemd/logs.html:48
+msgid "Warnings"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
+#: pkg/systemd/services.html:409
+msgid "Weeks"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
-msgid "Host Path"
+#: pkg/kubernetes/views/registry-dashboard-page.html:5
+msgid "Welcome to the Image Registry"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
+#: pkg/kubernetes/views/volumes-page.html:61
+msgid "When"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:199
-msgid "NFS Mount"
+#: pkg/docker/index.html:507
+msgid "With terminal"
+msgstr "Avec le terminal"
+
+#: pkg/storaged/index.html:438
+msgctxt "storage"
+msgid "World Wide Name"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
+#: pkg/storaged/details.js:1595
+msgid "Write-mostly"
+msgstr "Écriture favorisée"
+
+#: pkg/storaged/index.html:333
+msgid "Writing"
+msgstr "Ecriture"
+
+#: pkg/ostree/client.js:64
+msgid "Writing objects"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
-msgid "ISCSI"
-msgstr ""
+#: pkg/storaged/details.js:177
+msgid "XFS - Red Hat Enterprise Linux 7 default"
+msgstr "XFS - Système de fichier par défaut de Red Hat Enterprise Linux 7"
 
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr ""
+#: pkg/networkmanager/interfaces.js:1824
+msgid "XOR"
+msgstr "XOR"
 
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr ""
+#: pkg/kubernetes/scripts/volumes.js:990 pkg/networkmanager/interfaces.js:2279
+msgid "Yes"
+msgstr "Oui"
 
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:469
-msgid "Please select a valid access mode"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:477
-msgid "Please provide a valid name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:485
-msgid "Please provide a valid storage capacity."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:493
-msgid "Please select a valid policy option."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:565
-msgid "Please select a valid endpoint"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:574
-msgid "Please provide a GlusterFS volume name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:632
-msgid "Please provide a valid NFS server"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
-msgid "Please provide a valid path"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:781
-msgid "Please provide a valid target"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:789
-msgid "Please provide a valid qualified name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:797
-msgid "Please provide a valid logical unit number"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:805
-msgid "Please provide a valid filesystem type"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:813
-msgid "Please provide a valid interface"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:860
-msgid "NFS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:872
-msgid "GlusterFS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:908
-msgid "Sorry, I don't know how to modify this volume"
-msgstr ""
-
-#: pkg/kubernetes/scripts/charts.js:113
-msgid "Unavailable"
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "L'espace de nommage ne peut être vide."
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "Merci d'indiquer un espace de nommage valide."
-
-#: pkg/kubernetes/scripts/dashboard.js:384
+#: pkg/lib/machine-sync-users.html:47
 msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
+"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
+"synchronize users, a user with superuser privileges is required."
 msgstr ""
-"Aucun fichier de metadonnées sélectionné. Merci de sélectionner un fichier "
-"de metadonnées Kubernetes."
-
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr ""
-"Le fichier sélectionné n'est pas un manifeste d'application kubernetes "
-"valide."
-
-#: pkg/kubernetes/scripts/dashboard.js:401
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr "Impossible de lire le manifeste d'application kubernetes. Code $0."
-
-#: pkg/kubernetes/scripts/dashboard.js:413
-msgid "Unable to decode Kubernetes application manifest."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:441
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "Merci de créer un nouvel espace de nommage pour l'objet $0 « $1 »"
-
-#: pkg/kubernetes/scripts/dashboard.js:460
-msgid "Manifest"
-msgstr ""
-
-#: pkg/dashboard/list.js:209
-msgid "The user <b>$0</b> is not permitted to manage servers"
-msgstr "L'utilisateur <b>$0</b> n'a pas le droit de gérer des serveurs"
 
 #: pkg/dashboard/list.js:394
 msgid ""
@@ -3197,2985 +6051,208 @@ msgstr ""
 "Vous êtes actuellement connecté directement à ce serveur. Vous ne pouvez pas "
 "le supprimer."
 
-#: cockpit.appdata.xml.in.h:1
-msgid ""
-"Cockpit is a server manager that makes it easy to administer your Linux "
-"servers via a web browser. Jumping between the terminal and the web tool is "
-"no problem. A service started via Cockpit can be stopped via the terminal. "
-"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
-"journal interface."
-msgstr ""
-
-#: cockpit.appdata.xml.in.h:2
-msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
-"stopping services. You can monitor and administer several servers at the "
-"same time. Just add them with a single click and your machines will look "
-"after its buddies."
-msgstr ""
-
-#: cockpit.desktop.in.h:1 pkg/shell/index.html.h:1 pkg/shell/stub.html.h:1
-#: pkg/shell/simple.html.h:1
-msgid "Cockpit"
-msgstr "Cockpit"
-
-#: cockpit.desktop.in.h:2
-msgid "A user interface for GNU/Linux servers"
-msgstr "Une interface utilisateur pour serveurs GNU/Linux"
-
-#: cockpit.desktop.in.h:3
-msgid "Remote;Administration;"
-msgstr "À distance;Administration;"
-
-#: pkg/systemd/index.html.h:1
-msgid "System"
-msgstr ""
-
-#: pkg/systemd/index.html.h:2
-msgid "No host keys found."
-msgstr ""
-
-#: pkg/systemd/index.html.h:3
-msgid "Synchronized with {{Server}}"
-msgstr ""
-
-#: pkg/systemd/index.html.h:4
-msgid "Synchronized"
-msgstr ""
-
-#: pkg/systemd/index.html.h:5
-msgid "Trying to synchronize with {{Server}}"
-msgstr ""
-
-#: pkg/systemd/index.html.h:6
-msgid "Not synchronized"
-msgstr ""
-
-#: pkg/systemd/index.html.h:7
-msgid "Hardware"
-msgstr ""
-
-#: pkg/systemd/index.html.h:8
-msgid "Asset Tag"
-msgstr ""
-
-#: pkg/systemd/index.html.h:9 pkg/kubernetes/views/node-body.html.h:6
-msgid "Machine ID"
-msgstr ""
-
-#: pkg/systemd/index.html.h:10 pkg/ostree/index.html.h:18
-#: pkg/kubernetes/views/nodes-page.html.h:6
-msgid "Operating System"
-msgstr ""
-
-#: pkg/systemd/index.html.h:11
-msgid "Secure Shell Keys"
-msgstr ""
-
-#: pkg/systemd/index.html.h:12
-msgid "Show fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:14 pkg/dashboard/index.html.h:7
-msgid "Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:15
-msgid "Domain"
-msgstr ""
-
-#: pkg/systemd/index.html.h:16
-msgid "System Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:17
-msgid "Power Options"
-msgstr ""
-
-#: pkg/systemd/index.html.h:20
-msgid "Performance Profile"
-msgstr ""
-
-#: pkg/systemd/index.html.h:21
-msgid "Store Performance Data"
-msgstr ""
-
-#: pkg/systemd/index.html.h:32
-msgid "Machine SSH Key Fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:33
-msgid "Pretty Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:34
-msgid "Real Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:35
-msgid "Time Zone"
-msgstr ""
-
-#: pkg/systemd/index.html.h:36
-msgid ""
-"\n"
-"                                    Invalid time zone\n"
-"                                "
-msgstr ""
-
-#: pkg/systemd/index.html.h:39
-msgid "Set Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:40
-msgid "Manually"
-msgstr ""
-
-#: pkg/systemd/index.html.h:41
-msgid "Automatically using NTP"
-msgstr ""
-
-#: pkg/systemd/index.html.h:42
-msgid "Automatically using specific NTP servers"
-msgstr ""
-
-#: pkg/systemd/index.html.h:43
-msgid "Delay"
-msgstr ""
-
-#: pkg/systemd/index.html.h:44
-msgid "1 Minute"
-msgstr ""
-
-#: pkg/systemd/index.html.h:45
-msgid "5 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:46
-msgid "20 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:47
-msgid "40 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:48
-msgid "60 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:49
-msgid "No Delay"
-msgstr ""
-
-#: pkg/systemd/index.html.h:50
-msgid "Specific Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:51
-msgid ""
-"\n"
-"                        Cancel\n"
-"                    "
-msgstr ""
-
-#: pkg/systemd/logs.html.h:1
-msgid "Journal"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:2
-msgid "Recent"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:3
-msgid "Current boot"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:4
-msgid "Last 24 hours"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:5
-msgid "Last 7 days"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:6
-msgid "Errors"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:7
-msgid "Warnings"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:8
-msgid "Notices"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:9
-msgid "All"
-msgstr "Tout"
-
-#: pkg/systemd/logs.html.h:10 pkg/kubernetes/views/container-panel.html.h:2
-#: pkg/kubernetes/views/container-page-inline.html.h:2
-msgid "Logs"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:11
-msgid "Entry"
-msgstr ""
-
-#: pkg/systemd/services.html.h:1 pkg/kubernetes/views/dashboard-page.html.h:12
-#: pkg/kubernetes/views/details-page.html.h:3
-msgid "Services"
-msgstr ""
-
-#: pkg/systemd/services.html.h:3
-msgid "System Services"
-msgstr ""
-
-#: pkg/systemd/services.html.h:4
-msgid "Sockets"
-msgstr ""
-
-#: pkg/systemd/services.html.h:5
-msgid "Timers"
-msgstr ""
-
-#: pkg/systemd/services.html.h:6
-msgid "Paths"
-msgstr ""
-
-#: pkg/systemd/services.html.h:7
-msgid "Instantiate"
-msgstr ""
-
-#: pkg/systemd/services.html.h:8
-msgid "{{days_text}}"
-msgstr ""
-
-#: pkg/systemd/services.html.h:9
-msgid "Service Logs"
-msgstr ""
-
-#: pkg/systemd/services.html.h:10
-msgid "Note"
-msgstr ""
-
-#: pkg/systemd/services.html.h:11
-msgid ""
-"This unit is not designed to be enabled explicitly.\n"
-"          "
-msgstr ""
-
-#: pkg/systemd/services.html.h:15
-#, fuzzy
-msgid "Create Timers"
-msgstr "Créer"
-
-#: pkg/systemd/services.html.h:16
-msgid "Service name"
-msgstr ""
-
-#: pkg/systemd/services.html.h:18 pkg/docker/index.html.h:32
-msgid "Command"
-msgstr "Commande"
-
-#: pkg/systemd/services.html.h:19
-#, fuzzy
-msgid "Run"
-msgstr "En fonctionnement"
-
-#: pkg/systemd/services.html.h:20
-msgid "After system boot"
-msgstr ""
-
-#: pkg/systemd/services.html.h:21
-msgid "At specific time"
-msgstr ""
-
-#: pkg/systemd/services.html.h:22
-msgid "Seconds"
-msgstr ""
-
-#: pkg/systemd/services.html.h:23
-#, fuzzy
-msgid "Minutes"
-msgstr "5 minutes"
-
-#: pkg/systemd/services.html.h:24
-#, fuzzy
-msgid "Hours"
-msgstr "6 heures"
-
-#: pkg/systemd/services.html.h:25
-msgid "Weeks"
-msgstr ""
-
-#: pkg/systemd/services.html.h:26
-msgid "Don't Repeat"
-msgstr ""
-
-#: pkg/systemd/services.html.h:27
-msgid "Repeat Hourly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:28
-msgid "Repeat Daily"
-msgstr ""
-
-#: pkg/systemd/services.html.h:29
-msgid "Repeat Weekly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:30
-msgid "Repeat Monthly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:31
-msgid "Repeat Yearly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:32
-msgid "Hour : Minute"
-msgstr ""
-
-#: pkg/systemd/services.html.h:33
-msgid ":"
-msgstr ""
-
-#: pkg/systemd/services.html.h:35
-msgid "Save"
-msgstr ""
-
-#: pkg/systemd/terminal.html.h:1
-msgid "Terminal"
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:1
-msgid "Incorrect Host Key"
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:2
-msgid ""
-"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
-"in use. Unless this machine was recently replaced, it is likely that someone "
-"is trying to attack your connection to this machine."
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:3
-msgid ""
-"You can remove the previously stored key by running the following command"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:1
-msgid "Authentication Failed"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:2
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
-"machine with cockpit you will need to enable one of the following "
-"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:4 pkg/shell/index.html.h:30
-msgid "Public Key"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:5
-msgid "Kerberos Based SSO"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:6
-msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:1 pkg/dashboard/index.html.h:11
-msgid "Synchronize users"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:2
-msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:3
-msgid "Error loading users: {{perm_failed}}"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:4
-msgid ""
-"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
-"synchronize users, a user with superuser privileges is required."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:5 pkg/lib/machine-change-auth.html.h:4
-msgid "User name"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:8
-msgid "Synchronize"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:1
-msgid "Unknown Host Key"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:2
-msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:3 pkg/shell/index.html.h:4
-msgid "Fingerprint"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:5
-#: pkg/kubernetes/views/auth-form.html.h:14
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:6
-msgid "Connect"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:1
-msgid "Add Machine to Dashboard"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:3 pkg/dashboard/index.html.h:9
-msgid "Color"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:4
-msgid ""
-"Connecting simultaneously to more than {{ limit }} machines is unsupported."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:1
-msgid "Could not contact {{host}}"
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:2
-msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:3
-msgid ""
-"To try a different port you will need to upgrade cockpit-ws to a newer "
-"version."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:4
-msgid "Is sshd running on a different port?"
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:7
-msgid "Update"
-msgstr ""
-
-#: pkg/lib/machine-not-supported.html.h:1
-msgid "Cockpit is not installed"
-msgstr ""
-
-#: pkg/lib/machine-not-supported.html.h:2
-msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:1
-msgid "Log in to {{host}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:2
-msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:3
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:5 pkg/shell/index.html.h:9
-#: pkg/realmd/operation.html.h:3 pkg/kubernetes/views/auth-form.html.h:8
-msgid "Authentication"
-msgstr "Authentification"
-
-#: pkg/lib/machine-change-auth.html.h:7
-msgid "Available"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:8
-msgid "Login Password"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:9
-msgid "Kerberos Ticket"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:10
-msgid "Checking for public keys"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:12
-msgid "Log In"
-msgstr ""
-
-#: pkg/shell/shell.html.h:1
-msgid "Things have moved"
-msgstr ""
-
-#: pkg/shell/index.html.h:2
-msgid "Comment"
-msgstr ""
-
-#: pkg/shell/index.html.h:5 pkg/shell/stub.html.h:2 pkg/shell/simple.html.h:2
-msgid "Ooops!"
-msgstr "Oups !"
-
-#: pkg/shell/index.html.h:6 pkg/shell/stub.html.h:3 pkg/shell/simple.html.h:3
-msgid "Display Language"
-msgstr "Langue d'affichage"
-
-#: pkg/shell/index.html.h:7 pkg/shell/stub.html.h:4 pkg/shell/simple.html.h:4
-msgid "About Cockpit"
-msgstr "À propos de Cockpit"
-
-#: pkg/shell/index.html.h:8
-msgid "Account Settings"
-msgstr "Paramètres de compte"
-
-#: pkg/shell/index.html.h:10 pkg/shell/stub.html.h:5 pkg/shell/simple.html.h:5
-msgid "Log out"
-msgstr "Déconnexion"
-
-#: pkg/shell/index.html.h:11 pkg/shell/stub.html.h:6 pkg/shell/simple.html.h:6
-msgid ""
-"\n"
-"              Cockpit is an interactive Linux server admin interface.\n"
-"            "
-msgstr ""
-"\n"
-"              Cockpit est une interface d'administration Linux interactive.\n"
-"            "
-
-#: pkg/shell/index.html.h:15 pkg/shell/stub.html.h:10
-#: pkg/shell/simple.html.h:10
-msgid "Choose the language to be used in the application"
-msgstr "Choisir la langue à utiliser dans l'application"
-
-#: pkg/shell/index.html.h:16 pkg/shell/stub.html.h:11
-#: pkg/shell/simple.html.h:11 pkg/storaged/index.html.h:59
-msgid ""
-"\n"
-"              Cancel\n"
-"            "
-msgstr ""
-"\n"
-"              Annuler\n"
-"            "
-
-#: pkg/shell/index.html.h:19 pkg/shell/stub.html.h:14
-#: pkg/shell/simple.html.h:14
-msgid ""
-"\n"
-"              Select\n"
-"            "
-msgstr ""
-"\n"
-"              Sélectionner\n"
-"            "
-
-#: pkg/shell/index.html.h:22 pkg/shell/stub.html.h:17
-msgid ""
-"\n"
-"              Close\n"
-"            "
-msgstr ""
-"\n"
-"              Fermer\n"
-"            "
-
-#: pkg/shell/index.html.h:25
-msgid "Use my password for privileged tasks and to connect to other machines"
-msgstr ""
-
-#: pkg/shell/index.html.h:26
-msgid "Use the following keys to authenticate against other systems"
-msgstr ""
-
-#: pkg/shell/index.html.h:29 pkg/kubernetes/index.html.h:6
-msgid "Details"
-msgstr ""
-
-#: pkg/shell/index.html.h:32
-msgid "Unlock Key"
-msgstr ""
-
-#: pkg/shell/index.html.h:33 pkg/users/index.html.h:23
-msgid "Old Password"
-msgstr ""
-
-#: pkg/shell/index.html.h:34 pkg/users/index.html.h:24
-msgid "New Password"
-msgstr ""
-
-#: pkg/shell/index.html.h:35 pkg/users/index.html.h:19
-msgid "Confirm"
-msgstr ""
-
-#: pkg/shell/index.html.h:36
-msgid "Change Password"
-msgstr ""
-
-#: pkg/shell/index.html.h:38 pkg/shell/stub.html.h:20
-msgid ""
-"\n"
-"                Tools\n"
-"              "
-msgstr ""
-"\n"
-"                Outils\n"
-"              "
-
-#: pkg/shell/index.html.h:41 pkg/shell/stub.html.h:23
-#: pkg/shell/simple.html.h:24
-msgid "Reconnect"
-msgstr "Reconnecter"
-
-#: pkg/shell/index.html.h:42 pkg/shell/stub.html.h:24
-msgid "Troubleshoot"
-msgstr ""
-
-#: pkg/shell/simple.html.h:18
-msgid ""
-"\n"
-"              Try to reconnect\n"
-"            "
-msgstr ""
-"\n"
-"              Tenter de se reconnecter\n"
-"            "
-
-#: pkg/shell/simple.html.h:21
-msgid ""
-"\n"
-"              Log in again\n"
-"            "
-msgstr ""
-"\n"
-"              Se reconnecter\n"
-"            "
-
-#: pkg/ostree/index.html.h:1
-msgid "Software Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:2
-msgid "Check for updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:3
-msgid ""
-"\n"
-"                    Update and reboot\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:6
-msgid "Roll back and reboot"
-msgstr ""
-
-#: pkg/ostree/index.html.h:8
-msgid ""
-"\n"
-"                    Default\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:11
-msgid ""
-"\n"
-"                    Available\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:16
-msgid "Tree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:17
-msgid "Packages"
-msgstr ""
-
-#: pkg/ostree/index.html.h:20
-msgid "Released"
-msgstr ""
-
-#: pkg/ostree/index.html.h:21
-msgid "Additions"
-msgstr ""
-
-#: pkg/ostree/index.html.h:22
-msgid "Removals"
-msgstr ""
-
-#: pkg/ostree/index.html.h:23
-msgid "Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:24
-msgid "Downgrades"
-msgstr ""
-
-#: pkg/ostree/index.html.h:25
-msgid ""
-"\n"
-"                    This deployment contains the same packages as your "
-"currently booted system\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:28
-msgid "Operating System Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:29
-msgid "Connecting"
-msgstr ""
-
-#: pkg/ostree/index.html.h:30
-msgid "Unable to communicate with OSTree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:31
-msgid "No Deployments"
-msgstr ""
-
-#: pkg/ostree/index.html.h:32
-msgid ""
-"\n"
-"                    Reconnect\n"
-"                "
-msgstr ""
-
-#: pkg/selinux/setroubleshoot.html.h:1
-msgid "SELinux Troubleshoot"
-msgstr ""
-
-#: pkg/machines/index.html.h:1
-msgid "Virtual Machines Management"
-msgstr ""
-
-#: pkg/storaged/index.html.h:1
-msgid "Storage"
-msgstr ""
-
-#: pkg/storaged/index.html.h:2
-msgid "The \"storaged\" API is not available on this system."
-msgstr ""
-
-#: pkg/storaged/index.html.h:3
-msgid "Start Multipath"
-msgstr ""
-
-#: pkg/storaged/index.html.h:4
-msgid ""
-"\n"
-"        There are devices with multiple paths on the system, but the "
-"multipath service is not running.\n"
-"      "
-msgstr ""
-
-#: pkg/storaged/index.html.h:7
-msgid "RAID Devices"
-msgstr "Périphériques RAID"
-
-#: pkg/storaged/index.html.h:8
-msgid "No storage set up as RAID"
-msgstr ""
-
-#: pkg/storaged/index.html.h:9
-msgid "Volume Groups"
-msgstr "Groupes de volumes"
-
-#: pkg/storaged/index.html.h:10
-msgid "No volume groups created"
-msgstr ""
-
-#: pkg/storaged/index.html.h:11
-msgid "iSCSI Targets"
-msgstr ""
-
-#: pkg/storaged/index.html.h:12
-msgid "{{Address}}:{{Port}}"
-msgstr ""
-
-#: pkg/storaged/index.html.h:13
-msgid "No iSCSI targets set up"
-msgstr ""
-
-#: pkg/storaged/index.html.h:14
-msgid "Drives"
-msgstr "Disques"
-
-#: pkg/storaged/index.html.h:15
-msgid "No drives attached"
-msgstr ""
-
-#: pkg/storaged/index.html.h:16
-msgid "Other Devices"
-msgstr "Autres Périphériques"
-
-#: pkg/storaged/index.html.h:17
-msgid "Filesystems"
-msgstr "Systèmes de fichiers"
-
-#: pkg/storaged/index.html.h:21
-msgid "Jobs"
-msgstr "Tâches"
-
-#: pkg/storaged/index.html.h:23 pkg/networkmanager/index.html.h:3
-msgid "Go to now"
-msgstr "Aller à maintenant"
-
-#: pkg/storaged/index.html.h:24 pkg/networkmanager/index.html.h:4
-msgid "5 minutes"
-msgstr "5 minutes"
-
-#: pkg/storaged/index.html.h:25 pkg/networkmanager/index.html.h:5
-msgid "1 hour"
-msgstr "1 heure"
-
-#: pkg/storaged/index.html.h:26 pkg/networkmanager/index.html.h:6
-msgid "6 hours"
-msgstr "6 heures"
-
-#: pkg/storaged/index.html.h:27 pkg/networkmanager/index.html.h:7
-msgid "1 day"
-msgstr "1 jour"
-
-#: pkg/storaged/index.html.h:28 pkg/networkmanager/index.html.h:8
-msgid "1 week"
-msgstr "1 semaine"
-
-#: pkg/storaged/index.html.h:29
-msgid "Reading"
-msgstr "Lecture"
-
-#: pkg/storaged/index.html.h:30
-msgid "Writing"
-msgstr "Ecriture"
-
-#: pkg/storaged/index.html.h:31
-msgid "Storage Logs"
-msgstr "Logs de stockage"
-
-#: pkg/storaged/index.html.h:32
-msgid "Create partition table"
-msgstr ""
-
-#: pkg/storaged/index.html.h:34
-msgid "Block Device"
-msgstr ""
-
-#: pkg/storaged/index.html.h:40
-msgid "No media inserted"
-msgstr "Aucun média inséré"
-
-#: pkg/storaged/index.html.h:42
-msgid "DISK IS FAILING"
-msgstr ""
-
-#: pkg/storaged/index.html.h:43
-msgid "Disk is OK"
-msgstr "Le disque est OK"
-
-#: pkg/storaged/index.html.h:46
-msgid "The RAID Array is in a degraded state"
-msgstr ""
-
-#: pkg/storaged/index.html.h:47
-msgid "RAID Device"
-msgstr "Périphérique RAID"
-
-#: pkg/storaged/index.html.h:56
-msgid "Volume Group"
-msgstr ""
-
-#: pkg/storaged/index.html.h:57
-msgid "Physical Volumes"
-msgstr ""
-
-#: pkg/storaged/index.html.h:58
-msgid "Storage Log"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:1
-msgid "Domain Address"
-msgstr "Adresse de domaine"
-
-#: pkg/realmd/operation.html.h:2
-msgid "Computer OU"
-msgstr "OU Computer"
-
-#: pkg/realmd/operation.html.h:4 pkg/users/index.html.h:11
-msgid "User Name"
-msgstr "Nom d'utilisateur"
-
-#: pkg/realmd/operation.html.h:5
-msgid "User Password"
-msgstr "Mot de passe utilisateur"
-
-#: pkg/realmd/operation.html.h:6
-msgid "Domain Administrator Name"
-msgstr "Nom de l'administrateur du domaine"
-
-#: pkg/realmd/operation.html.h:7
-msgid "Domain Administrator Password"
-msgstr "Mot de passe de l'administrateur du domaine"
-
-#: pkg/realmd/operation.html.h:8
-msgid "One Time Password"
-msgstr "Mot de passe à usage unique"
-
-#: pkg/realmd/operation.html.h:9
-msgid "This may take a while"
-msgstr "Cela peut prendre un certain temps"
-
-#: pkg/docker/index.html.h:1 pkg/kubernetes/index.html.h:4
-#: pkg/kubernetes/views/containers-listing.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:6
-#: pkg/kubernetes/views/dashboard-page.html.h:17
-msgid "Containers"
-msgstr "Conteneurs"
-
-#: pkg/docker/index.html.h:2
-msgid "Connecting to Docker"
-msgstr "Connexion à Docker"
-
-#: pkg/docker/index.html.h:3
-msgid "Not authorized to access Docker on this system"
-msgstr "Vous n'êtes pas autorisé à accéder à Docker sur ce système"
-
-#: pkg/docker/index.html.h:4
-msgid "Docker is not installed or activated on the system"
-msgstr "Docker n'est pas installé ou activé sur le système"
-
-#: pkg/docker/index.html.h:5
-msgid "Can&rsquo;t connect to Docker"
-msgstr ""
-
-#: pkg/docker/index.html.h:6
-msgid "Start Docker"
-msgstr "Démarrer docker"
-
-#: pkg/docker/index.html.h:7
-msgid "Try again"
-msgstr "Réessayer"
-
-#: pkg/docker/index.html.h:8
-msgid "Combined CPU usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:9
-msgid "Combined memory usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:10
-#, fuzzy
-msgid "Show all containers"
-msgstr "Conteneurs"
-
-#: pkg/docker/index.html.h:11
-msgid "IP Address:"
-msgstr ""
-
-#: pkg/docker/index.html.h:12
-msgid "IP Prefix Length:"
-msgstr ""
-
-#: pkg/docker/index.html.h:13
-msgid "Gateway:"
-msgstr ""
-
-#: pkg/docker/index.html.h:14
-msgid "MAC Address:"
-msgstr ""
-
-#: pkg/docker/index.html.h:15 pkg/kubernetes/views/image-page.html.h:1
-msgid "Show all images"
-msgstr ""
-
-#: pkg/docker/index.html.h:16 pkg/kubernetes/index.html.h:2
-#: pkg/kubernetes/registry.html.h:2
-msgid "Overview"
-msgstr ""
-
-#: pkg/docker/index.html.h:17
-msgid "Reset"
-msgstr ""
-
-#: pkg/docker/index.html.h:18
-msgid "Storage pool"
-msgstr ""
-
-#: pkg/docker/index.html.h:19
-msgid "Additional Storage"
-msgstr ""
-
-#: pkg/docker/index.html.h:20
-msgid "TCP"
-msgstr "TCP"
-
-#: pkg/docker/index.html.h:21
-msgid "{{host_port_label}}"
-msgstr "{{host_port_label}}"
-
-#: pkg/docker/index.html.h:22
-msgid "{{host_volume_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:24
-msgid "ReadWrite"
-msgstr ""
-
-#: pkg/docker/index.html.h:25
-msgid "ReadOnly"
-msgstr ""
-
-#: pkg/docker/index.html.h:26
-msgid "{{envvar_key_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:27
-msgid "{{envvar_value_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:28
-msgid "select container"
-msgstr ""
-
-#: pkg/docker/index.html.h:29
-msgid "{{alias_label}}"
-msgstr "{{alias_label}}"
-
-#: pkg/docker/index.html.h:30 pkg/kubernetes/views/image-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:2
-#: pkg/kubernetes/views/image-page.html.h:2
-msgid "Image"
-msgstr "Image"
-
-#: pkg/docker/index.html.h:31
-msgid "Container Name"
-msgstr "Nom du conteneur"
-
-#: pkg/docker/index.html.h:33
-msgid "Memory limit"
-msgstr "Limite en mémoire"
-
-#: pkg/docker/index.html.h:34
-msgid "MiB"
-msgstr ""
-
-#: pkg/docker/index.html.h:35
-msgid "CPU priority"
-msgstr "Priorité en CPU"
-
-#: pkg/docker/index.html.h:36
-msgid "shares"
-msgstr ""
-
-#: pkg/docker/index.html.h:37
-msgid "With terminal"
-msgstr "Avec le terminal"
-
-#: pkg/docker/index.html.h:38
-msgid "Links"
-msgstr "Liens"
-
-#: pkg/docker/index.html.h:40
-msgid "Expose container ports"
-msgstr ""
-
-#: pkg/docker/index.html.h:41 pkg/kubernetes/index.html.h:7
-#: pkg/kubernetes/views/image-config.html.h:9
-#: pkg/kubernetes/views/pod-page.html.h:3
-#: pkg/kubernetes/views/dashboard-page.html.h:4
-msgid "Volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:42
-msgid "Mount container volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:43 pkg/kubernetes/views/image-config.html.h:6
-#: pkg/kubernetes/views/container-body.html.h:9
-msgid "Environment"
-msgstr ""
-
-#: pkg/docker/index.html.h:44
-msgid "Set container environment variables"
-msgstr ""
-
-#: pkg/docker/index.html.h:45 pkg/kubernetes/views/pod-body.html.h:4
-msgid "Restart Policy"
-msgstr ""
-
-#: pkg/docker/index.html.h:47
-msgid "On Failure"
-msgstr ""
-
-#: pkg/docker/index.html.h:50
-msgid "Retries:"
-msgstr ""
-
-#: pkg/docker/index.html.h:51 pkg/users/index.html.h:26
-#: pkg/networkmanager/index.html.h:52
-msgid ""
-"\n"
-"            Cancel\n"
-"          "
-msgstr ""
-"\n"
-"            Annuler\n"
-"           "
-
-#: pkg/docker/index.html.h:54
-msgid ""
-"\n"
-"            Run\n"
-"          "
-msgstr ""
-"\n"
-"            Lancer\n"
-"           "
-
-#: pkg/docker/index.html.h:57
-msgid ""
-"\n"
-"            Download\n"
-"          "
-msgstr ""
-"\n"
-"            Télécharger\n"
-"           "
-
-#: pkg/docker/index.html.h:60
-msgid ""
-"\n"
-"            Change\n"
-"          "
-msgstr ""
-"\n"
-"            Changer\n"
-"           "
-
-#: pkg/docker/index.html.h:63
-msgid "Repository"
-msgstr "Dépôt"
-
-#: pkg/docker/index.html.h:64
-msgid "Tag"
-msgstr "Balise"
-
-#: pkg/docker/index.html.h:65 pkg/kubernetes/views/image-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:5
-msgid "Author"
-msgstr "Auteur"
-
-#: pkg/docker/index.html.h:66
-msgid ""
-"\n"
-"            Commit\n"
-"          "
-msgstr ""
-"\n"
-"            Valider\n"
-"           "
-
-#: pkg/users/index.html.h:1
-msgid "Local Accounts"
-msgstr ""
-
-#: pkg/users/index.html.h:2
-msgid ""
-"\n"
-"            Close\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:5
-msgid "Create New Account"
-msgstr ""
-
-#: pkg/users/index.html.h:6
-msgid "Account not available or cannot be edited."
-msgstr ""
-
-#: pkg/users/index.html.h:7
-msgid "Accounts"
-msgstr ""
-
-#: pkg/users/index.html.h:8
-msgid "Terminate Session"
-msgstr ""
-
-#: pkg/users/index.html.h:10
-msgid "Full Name"
-msgstr ""
-
-#: pkg/users/index.html.h:12
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:3
-#: pkg/kubernetes/views/project-body.html.h:2
-msgid "Roles"
-msgstr ""
-
-#: pkg/users/index.html.h:13
-msgid "Last Login"
-msgstr ""
-
-#: pkg/users/index.html.h:14
-msgid "Access"
-msgstr ""
-
-#: pkg/users/index.html.h:15
-msgid "Lock Account"
-msgstr ""
-
-#: pkg/users/index.html.h:17
-msgid "Set Password"
-msgstr ""
-
-#: pkg/users/index.html.h:18
-msgid "Authorized Public SSH Keys"
-msgstr ""
-
-#: pkg/users/index.html.h:20
-msgid ""
-"\n"
-"            Create\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:25
-msgid "Confirm New Password"
-msgstr ""
-
-#: pkg/users/index.html.h:29
-msgid ""
-"\n"
-"            Set\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:32
-msgid "Delete Files"
-msgstr ""
-
-#: pkg/users/index.html.h:33 pkg/networkmanager/index.html.h:48
-msgid ""
-"\n"
-"            Delete\n"
-"          "
-msgstr ""
-"\n"
-"            Supprimer\n"
-"          "
-
-#: pkg/users/index.html.h:36
-msgid "Unnamed"
-msgstr ""
-
-#: pkg/users/index.html.h:37
-msgid "Invalid key"
-msgstr ""
-
-#: pkg/users/index.html.h:38
-msgid "There are no authorized public keys for this account."
-msgstr ""
-
-#: pkg/users/index.html.h:39
-msgid ""
-"You do not have permission to view the authorized public keys for this "
-"account."
-msgstr ""
-
-#: pkg/users/index.html.h:40
-msgid "Failed to load authorized keys."
-msgstr ""
-
-#: pkg/users/index.html.h:41
-msgid "Add public key"
-msgstr ""
-
-#: pkg/users/index.html.h:42
-msgid ""
-"\n"
-"            Add key\n"
-"          "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:1
-msgid "Diagnostic reports"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:2
-msgid ""
-"\n"
-"        This tool will collect system configuration and diagnostic\n"
-"        information from this system for use with diagnosing problems\n"
-"        with the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:7
-msgid ""
-"\n"
-"        The collected information will be stored locally on the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:10
-msgid "Create report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:11
-msgid "Create diagnostic report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:12
-msgid ""
-"\n"
-"                The generated archive contains data considered\n"
-"                sensitive and its content should be reviewed by the\n"
-"                originating organization before being passed to any\n"
-"                third party.\n"
-"              "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:18
-msgid "Generating report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:19
-msgid "Done!"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:1
-msgid "Networking"
-msgstr "Réseau"
-
-#: pkg/networkmanager/index.html.h:2
-msgid "Testing connection"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:9
-msgid "Sending"
-msgstr "Envoi"
-
-#: pkg/networkmanager/index.html.h:10
-msgid "Receiving"
-msgstr "Réception"
-
-#: pkg/networkmanager/index.html.h:11
-msgid "Interfaces"
-msgstr "Interfaces"
-
-#: pkg/networkmanager/index.html.h:12
-msgid "Add Bond"
-msgstr "Ajouter une liaison d'interfaces réseau"
-
-#: pkg/networkmanager/index.html.h:13
-msgid "Add Team"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:14
-msgid "Add Bridge"
-msgstr "Ajouter un pont"
-
-#: pkg/networkmanager/index.html.h:15
-msgid "Add VLAN"
-msgstr "Ajouter un VLAN"
-
-#: pkg/networkmanager/index.html.h:17
-msgid "IP Address"
-msgstr "Adresse IP"
-
-#: pkg/networkmanager/index.html.h:18
-#, fuzzy
-msgid "Unmanaged Interfaces"
-msgstr "Interfaces"
-
-#: pkg/networkmanager/index.html.h:19
-msgid "Networking Logs"
-msgstr "Journaux réseau"
-
-#: pkg/networkmanager/index.html.h:20
-msgid "Parent"
-msgstr "Parent"
-
-#: pkg/networkmanager/index.html.h:21
-msgid "VLAN Id"
-msgstr "Identifiant de VLAN"
-
-#: pkg/networkmanager/index.html.h:23
-msgid "Set to"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:25
-msgid "Spanning Tree Protocol (STP)"
-msgstr "Spanning Tree Protocol (STP)"
-
-#: pkg/networkmanager/index.html.h:26
-msgid "STP Priority"
-msgstr "Priorité STP"
-
-#: pkg/networkmanager/index.html.h:27
-msgid "STP Forward delay"
-msgstr "Délai de réacheminement STP"
-
-#: pkg/networkmanager/index.html.h:28
-msgid "STP Hello time"
-msgstr "Durée Hello STP"
-
-#: pkg/networkmanager/index.html.h:29
-msgid "STP Maximum message age"
-msgstr "Âge maximal de message STP"
-
-#: pkg/networkmanager/index.html.h:30
-msgid "Priority"
-msgstr "Priorité"
-
-#: pkg/networkmanager/index.html.h:31
-msgid "Path cost"
-msgstr "Coût du chemin"
-
-#: pkg/networkmanager/index.html.h:32
-msgid "Hair Pin mode"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:34
-msgid "Mode"
-msgstr "Mode"
-
-#: pkg/networkmanager/index.html.h:35
-msgid "Primary"
-msgstr "Primaire"
-
-#: pkg/networkmanager/index.html.h:36
-msgid "Link Monitoring"
-msgstr "Surveillance du lien"
-
-#: pkg/networkmanager/index.html.h:37
-msgid "Monitoring Interval"
-msgstr "Intervalle de surveillance"
-
-#: pkg/networkmanager/index.html.h:38
-msgid "Monitoring Targets"
-msgstr "Cibles à surveiller"
-
-#: pkg/networkmanager/index.html.h:39
-msgid "Link up delay"
-msgstr "Délai de montée de lien"
-
-#: pkg/networkmanager/index.html.h:40
-msgid "Link down delay"
-msgstr "Délai de chute de lien"
-
-#: pkg/networkmanager/index.html.h:41
-#, fuzzy
-msgid "Runner"
-msgstr "En fonctionnement"
-
-#: pkg/networkmanager/index.html.h:42
-msgid "Balancer"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:43
-#, fuzzy
-msgid "Link Watch"
-msgstr "Lien local"
-
-#: pkg/networkmanager/index.html.h:44
-#, fuzzy
-msgid "Ping Interval"
-msgstr "Intervalle de surveillance"
-
-#: pkg/networkmanager/index.html.h:45
-#, fuzzy
-msgid "Ping Target"
-msgstr "Effacement de $target"
-
-#: pkg/networkmanager/index.html.h:46
-msgid "Sticky"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:47
-msgid "LACP Key"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:51
-msgid "IP Settings"
-msgstr "Paramétrage IP"
-
-#: pkg/networkmanager/index.html.h:55
-msgid ""
-"\n"
-"            Apply\n"
-"          "
-msgstr ""
-"\n"
-"            Appliquer\n"
-"          "
-
-#: pkg/networkmanager/index.html.h:58
-msgid "Bond Settings"
-msgstr "Réglages de la liaison d'interfaces"
-
-#: pkg/networkmanager/index.html.h:59
-#, fuzzy
-msgid "Team Settings"
-msgstr "Paramétrage IP"
-
-#: pkg/networkmanager/index.html.h:60
-#, fuzzy
-msgid "Team Port Settings"
-msgstr "Réglages de port du pont"
-
-#: pkg/networkmanager/index.html.h:61
-msgid "Bridge Settings"
-msgstr "Réglages du pont"
-
-#: pkg/networkmanager/index.html.h:62
-msgid "Bridge Port Settings"
-msgstr "Réglages de port du pont"
-
-#: pkg/networkmanager/index.html.h:63
-msgid "VLAN Settings"
-msgstr "Réglages VLAN"
-
-#: pkg/networkmanager/index.html.h:64
-msgid "Ethernet MTU"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:66
-msgid "Connection will be lost"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:1
-msgid "Kubernetes Cluster"
-msgstr "Grappe Kubernetes"
-
-#: pkg/kubernetes/index.html.h:3 pkg/kubernetes/views/dashboard-page.html.h:8
-#: pkg/kubernetes/views/nodes-page.html.h:4
-msgid "Nodes"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:5
-msgid "Topology"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:8 pkg/kubernetes/registry.html.h:3
-#: pkg/kubernetes/views/image-listing.html.h:2
-#: pkg/kubernetes/views/imagestream-page.html.h:3
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:5
-msgid "Images"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:9 pkg/kubernetes/registry.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:2
-#: pkg/kubernetes/views/project-listing.html.h:2
-#: pkg/kubernetes/views/user-delete.html.h:2
-msgid "Projects"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:11 pkg/kubernetes/registry.html.h:6
-msgid "Couldn't connect to server"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:12 pkg/kubernetes/registry.html.h:7
-msgid ""
-"\n"
-"                Reconnect\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:15
-msgid ""
-"\n"
-"                Troubleshoot\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/registry.html.h:1
-msgid "Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:1
-#: pkg/kubernetes/views/service-body.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:1
-#: pkg/kubernetes/views/containers-listing.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:9
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:18
-#: pkg/kubernetes/views/route-body.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:5
-#: pkg/kubernetes/views/imagestream-modify.html.h:4
-msgid "Project"
-msgstr "Projet"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:2
-#: pkg/kubernetes/views/service-body.html.h:2
-#: pkg/kubernetes/views/pod-body.html.h:2
-#: pkg/kubernetes/views/containers-listing.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:10
-#: pkg/kubernetes/views/pv-claim.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:19
-#: pkg/kubernetes/views/route-body.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:6
-msgid "Namespace"
-msgstr "Espace de nommage"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:3
-#: pkg/kubernetes/views/pod-body.html.h:3
-#: pkg/kubernetes/views/node-body.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:3
-#: pkg/kubernetes/views/route-body.html.h:3
-msgid "Created"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:4
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:17
-msgid "Replicas"
-msgstr "Répliques"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:5
-#: pkg/kubernetes/views/service-body.html.h:9
-#: pkg/kubernetes/views/pod-body.html.h:10
-#: pkg/kubernetes/views/node-body.html.h:12
-#: pkg/kubernetes/views/image-meta.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:8
-#: pkg/kubernetes/views/route-body.html.h:8
-msgid "Labels"
-msgstr ""
-
-#: pkg/kubernetes/views/service-body.html.h:4
-#: pkg/kubernetes/views/node-body.html.h:3
-msgid "IP"
-msgstr ""
-
-#: pkg/kubernetes/views/service-body.html.h:8
-msgid "Session Affinity"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:1
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:10
-msgid "New image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:3
-#: pkg/kubernetes/views/image-body.html.h:10
-#: pkg/kubernetes/views/imagestream-modify.html.h:7
-msgid "Tags"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:5
-msgid "Last Updated"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:6
-msgid "No image streams are present."
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:1
-msgid "Delete Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:2
-msgid "Do you want to delete this Node?"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:3
-msgid " 1\">Do you want to delete the following Nodes?"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-container.html.h:1
-msgid "Show all Pod Containers"
-msgstr ""
-
-#: pkg/kubernetes/views/image-panel.html.h:3
-#: pkg/kubernetes/views/imagestream-page.html.h:4
-#: pkg/kubernetes/views/image-page.html.h:4
-msgid "Metadata"
-msgstr ""
-
-#: pkg/kubernetes/views/node-panel.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:8
-#: pkg/kubernetes/views/containers-listing.html.h:6
-#: pkg/kubernetes/views/node-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:11
-msgid "Node"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:1
-msgid "Show all Replication Controllers"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:2
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:5
-msgid "Replication Controller"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:2
-#: pkg/kubernetes/views/pv-claim.html.h:9
-#: pkg/kubernetes/views/dashboard-page.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:18
-msgid "Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:2
-msgid "Template"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:5
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/group-delete.html.h:1
-msgid "Remove Group"
-msgstr ""
-
-#: pkg/kubernetes/views/group-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:5
-#: pkg/kubernetes/views/user-group-remove.html.h:3
-msgid "Remove"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:1
-msgid "Delete Persistent Volume Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:2
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:3
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:5
-msgid "Service Account"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:6
-msgid "DNS Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:7
-msgid "Phase"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:9
-msgid "Pod Address"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:5
-msgid "OS"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:7
-msgid "Boot ID"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:8
-msgid "Kernel Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:9
-msgid "Container Runtime Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:10
-msgid "Kubelet Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:11
-msgid "Proxy Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:13
-#: pkg/kubernetes/views/route-body.html.h:9
-msgid "none"
-msgstr "aucun"
-
-#: pkg/kubernetes/views/node-body.html.h:17
-msgid "Reason"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:18
-#: pkg/kubernetes/views/pv-claim.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:6 pkg/kubernetes/views/pv-body.html.h:6
-msgid "Message"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:19
-msgid "Last Heartbeat"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:20
-msgid "Last Status Change"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:21
-#: pkg/kubernetes/views/image-meta.html.h:3
-#: pkg/kubernetes/views/imagestream-meta.html.h:1
-#: pkg/kubernetes/views/route-body.html.h:10
-msgid "Annotations"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:1
-msgid "Remove Role"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:2
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member "
-"{{ fields.member.metadata.name }}?"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:1
-msgid "New Project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:6
-msgid "No projects are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:7
-msgid "New Group"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:8
-#: pkg/kubernetes/views/user-delete.html.h:3
-msgid "Groups"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:9
-msgid "No groups are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:10
-#: pkg/kubernetes/views/add-user-dialog.html.h:1
-msgid "Add User"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:11
-msgid "Users"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:12
-msgid "Identity"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:13
-msgid "Member of"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:14
-msgid "No users are present."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:1
-msgid "Cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:2
-msgid "Add New Cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:4
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:3
-msgid "Skip Certificate Verification"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:5
-msgid "Requires Authentication"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:7
-msgid "Add New User"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:9
-msgid "Client Certificate"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:10
-msgid "Username"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:12
-msgid "Token"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:1
-msgid "Add Cluster Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:4
-msgid "Configuration"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:5
-msgid "Configure Kubelet and Proxy"
-msgstr "Configurer le Kubelet et le mandataire"
-
-#: pkg/kubernetes/views/node-add.html.h:6
-msgid "Configure Flannel networking"
-msgstr "Configurer le réseau Flannel"
-
-#: pkg/kubernetes/views/volume-body.html.h:1
-#: pkg/kubernetes/views/pvc-body.html.h:1
-msgid "Volume Type"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:2
-msgid "{{ volume | formatVolumeType }}"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:3
-msgid "PD Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:19
-msgid "Filesystem Type"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:6
-#: pkg/kubernetes/views/pv-modify.html.h:20
-msgid "Read Only"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:7
-msgid "Volume ID"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:8
-msgid "Repository URL"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:9
-msgid "Revision"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:10
-#: pkg/kubernetes/views/image-config.html.h:3
-msgid "Directory"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:12
-msgid "Medium"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:13
-#: pkg/kubernetes/views/pv-modify.html.h:14
-msgid "Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:14
-msgid "Endpoint Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:15
-#: pkg/kubernetes/views/pv-modify.html.h:13
-msgid "Volume Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:17
-msgid "Monitors"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:18
-msgid "Image Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:19
-msgid "Pool Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:21
-msgid "Key Ring Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:22
-msgid "Secret Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:23
-msgid "Target Portal"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:24
-#: pkg/kubernetes/views/pv-modify.html.h:16
-msgid "Qualified Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:25
-#: pkg/kubernetes/views/pv-modify.html.h:17
-msgid "Logical Unit Number"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:26
-#: pkg/kubernetes/views/pv-modify.html.h:18
-msgid "Interface"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:27
-msgid "Ceph Monitors"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:28
-msgid "Secret File"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:29
-msgid "Target World Wide Names"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:30
-msgid "Flocker Dataset Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:31
-msgid "Driver"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:33
-msgid "Share Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:34
-msgid "Secret Name"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:2
-msgid "On Build"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:4
-msgid "Docker Version"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:5
-msgid "Image Layers"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:1
-#: pkg/kubernetes/views/user-page.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:1
-msgid "Show all Projects"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:2
-#: pkg/kubernetes/views/group-panel.html.h:1
-msgid "Group Members"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:3
-#: pkg/kubernetes/views/user-group-add.html.h:1
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:1
-#: pkg/kubernetes/views/group-panel.html.h:2
-#: pkg/kubernetes/views/project-body.html.h:10
-msgid "Add Member"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:4
-msgid "The group '{{ groupName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/containers-listing.html.h:3
-#: pkg/kubernetes/views/pod-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:2
-msgid "Pod"
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:2
-msgid "Membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:2
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:5
-#: pkg/kubernetes/views/user-panel.html.h:7
-msgid "Add Membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-group-add.html.h:2
-msgid ""
-"\n"
-"                        User\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:2
-msgid "User or Group"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-panel.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:4
-msgid "Mount Location"
-msgstr ""
-
-#: pkg/kubernetes/views/route-modify.html.h:1
-msgid "Adjust Route"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:1
-msgid "Show all Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:2 pkg/kubernetes/views/pvc-body.html.h:3
-#: pkg/kubernetes/views/pv-panel.html.h:1
-msgid "Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:3 pkg/kubernetes/views/pv-panel.html.h:2
-msgid "Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:4
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:1
-msgid "Remove image tag"
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:2
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:1
-msgid "Run as"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:4
-msgid "Stop with"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:1
-msgid "Delete Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:2
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:3
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
-"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
-"may cause issues with any pods depending on it."
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:3
-msgid "Identities"
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:3
-msgid "The user '{{ userName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:1
-msgid "Show all Deployment Configs"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:1
-msgid "Deployment Config"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:4
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/route-panel.html.h:1
-#: pkg/kubernetes/views/route-page.html.h:2
-msgid "Route"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:1
-msgid "Register New Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:2
-msgid "Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:7
-msgid "No volumes are present."
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:8
-msgid "Pending Volume Claims"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:12
-msgid "When"
-msgstr ""
-
-#: pkg/kubernetes/views/user-delete.html.h:1
-msgid "Remove User"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:3
-#: pkg/kubernetes/views/pv-modify.html.h:10
-#: pkg/kubernetes/views/pvc-body.html.h:7 pkg/kubernetes/views/pv-body.html.h:2
-msgid "Access Modes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:4
-msgid "Requests"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:5
-msgid "This volume has not been claimed"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:10
-msgid "No Pods are using this claim"
-msgstr ""
-
-#: pkg/kubernetes/views/filter-project.html.h:1
-msgid "All Projects"
-msgstr ""
-
-#: pkg/kubernetes/views/filter-project.html.h:2
-msgid "Project:"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:5
-#: pkg/kubernetes/views/details-page.html.h:14
-msgid "Latest Version"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:6
-msgid "Deployment Causes"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:7
-msgid "Triggers"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:1
-msgid "Delete {{ item.kind }}"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:2
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:3
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:2
-#: pkg/kubernetes/views/user-modify.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:2
-msgid ""
-"\n"
-"                        Name\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:5
-#: pkg/kubernetes/views/user-modify.html.h:5
-msgid ""
-"\n"
-"                        Identity\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:1
-msgid "Project Members"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:3
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:6
-msgid "Admin"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:7
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/container-panel.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:3
-msgid "Shell"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:1
-msgid "Pod Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:2
-msgid "No pods selected"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:3
-msgid "Pod Selector"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:1
-msgid "Add membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:2
-msgid ""
-"\n"
-"                        Group or Project\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:5
-msgid ""
-"\n"
-"                        Role\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:1
-msgid "Deploy Application"
-msgstr "Déployer l'application"
-
-#: pkg/kubernetes/views/deploy.html.h:3
-msgid "{{ selected.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:5
-#: pkg/kubernetes/views/dashboard-page.html.h:11
-msgid "Deploy"
-msgstr ""
-
-#: pkg/kubernetes/views/user-modify.html.h:1
-msgid "Change User"
-msgstr ""
-
-#: pkg/kubernetes/views/user-modify.html.h:9
-msgid "Modify"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:1
-#: pkg/kubernetes/views/project-modify.html.h:6
-msgid "Access Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:2
-msgid ""
-"\n"
-"          Images may be pulled by anonymous users\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:5
-msgid ""
-"\n"
-"          Images may be pulled by any authenticated user or group\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:8
-msgid ""
-"\n"
-"          Images may only be pulled by specific users or groups\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:11
-msgid "Pull repository"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:13
-msgid "Image count"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:14
-msgid "{{stream.status.tags.length}}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:15
-msgid "To push to an image to this image stream:"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:1
-msgid "The node doesn't have enough disk space"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:2
-msgid "The node doesn't have enough free memory"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:1
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:2
-msgid "Register Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:4
-msgid "Warning:"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:5
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:7
-#: pkg/kubernetes/views/node-page.html.h:3
-#: pkg/kubernetes/views/pvc-body.html.h:10
-#: pkg/kubernetes/views/pv-body.html.h:3
-msgid "Capacity"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:8
-#: pkg/kubernetes/views/pv-body.html.h:1
-msgid "Reclaim Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:9
-msgid "{{ value }}"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:12
-msgid "Endpoint"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:15
-msgid "Target"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-dialog.html.h:1
-msgid "Connection Settings"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-dialog.html.h:2
-msgid "Connection Error"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:2
-msgid "Summary"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:4
-msgid "Source URL"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:7
-msgid "Built"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:8
-msgid "Digest"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:9
-msgid "Identifier"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:11
-msgid "To pull this image:"
-msgstr ""
-
-#: pkg/kubernetes/views/service-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:8
-#: pkg/kubernetes/views/service-page.html.h:2
-msgid "Service"
-msgstr ""
-
-#: pkg/kubernetes/views/service-panel.html.h:2
-#: pkg/kubernetes/views/service-page.html.h:3
-msgid "Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:1
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:2
+#: pkg/kubernetes/views/auth-rejected-cert.html:3
 msgid ""
 "You can bypass the certificate check, but any data you send to the server "
 "could be intercepted by others."
 msgstr ""
 
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:4
-msgid "Trust this certificate for this connection"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:1
-msgid "Show all Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:7
-msgid "The pod '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:1
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:1
-msgid "Delete image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:2
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:2
-msgid "All running"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:3
-msgid "No pods deployed"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:5
-msgid "All in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:6
-msgid "No volumes in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:7
-msgid "pending volume claims"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:9
-msgid "All healthy"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:10
-msgid "No nodes in cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:13
-msgid "Could not list services"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:14
+#: pkg/kubernetes/views/dashboard-page.html:150
 msgid "You can deploy an application to your cluster."
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-page.html.h:1
-msgid "Show all image streams"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-page.html.h:2
-msgid "Image Stream"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:3
-msgid "Image ID"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:4
-msgid "Container ID"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:7
-msgid "Since"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:8
-msgid "Restart Count"
-msgstr ""
-
-#: pkg/kubernetes/views/user-remove-membership.html.h:1
-msgid "Remove membership"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:1
-msgid "Delete Selected"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:2
-msgid "OS Versions"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:3
-msgid "Add Kubernetes Node"
-msgstr ""
-
-#: pkg/kubernetes/views/project-page.html.h:3
-msgid "The project '{{ projName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/user-panel.html.h:4
+#: pkg/lib/machine-invalid-hostkey.html:11
 msgid ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
+"You can remove the previously stored key by running the following command"
 msgstr ""
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:1
-msgid "Pod Replicated"
+#: pkg/shell/base_index.js:672
+msgid "You can try restarting Cockpit by pressing refresh in your browser. "
 msgstr ""
+"Vous pouvez tenter de redémarrer Cockpit en rafraichissant la page dans "
+"votre navigateur."
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:2
-msgid "No pods replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/container-page.html.h:1
-msgid "Show all Containers"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:1
-msgid "Welcome to the Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:2
+#: pkg/users/index.html:335
 msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
+"You do not have permission to view the authorized public keys for this "
+"account."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:1
-msgid "New project"
+#: pkg/docker/storage.jsx:482
+msgid "You don't have permission to manage the Docker storage pool."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:4
-msgid "Images by project"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:6
-msgid "Images pushed recently"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:7
-msgid "All images"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:8
-msgid "No images pushed"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:9
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:11
-msgid "Login commands"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:12
-msgid "Log into the registry:"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:13
+#: pkg/kubernetes/views/registry-dashboard-page.html:112
 msgid ""
 "Your login credentials do not give you access to use the docker registry "
 "from the command line."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:14
-msgid "Log into OpenShift command line tools:"
+#: src/base1/cockpit.js:3687
+msgid "Your session has been terminated."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:15
-msgid "Image commands"
+#: src/base1/cockpit.js:3689
+msgid "Your session has expired. Please log in again."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:16
-msgid "Push an image:"
+#: pkg/lib/journal.js:213
+msgid "[$0 bytes of binary data]"
+msgstr "[$0 octets de données binaires]"
+
+#: pkg/lib/journal.js:215
+msgid "[binary data]"
+msgstr "[données binaires]"
+
+#: pkg/lib/journal.js:209
+msgid "[no data]"
+msgstr "[aucune donnée]"
+
+#: pkg/storaged/details.js:1692
+msgid "active, but unsupported"
+msgstr "actif, mais non pris en charge"
+
+#: pkg/storaged/utils.js:88
+msgctxt "format-bytes"
+msgid "bytes"
+msgstr "octets"
+
+#: pkg/docker/util.js:123
+msgid "default"
+msgstr "par défaut"
+
+#: pkg/storaged/details.js:178
+msgid "ext4 - Red Hat Enterprise Linux 6 default"
+msgstr "ext4 - Système de fichier par défaut de Red Hat Enterprise Linux 6"
+
+#: pkg/systemd/host.js:661
+msgid "failed to list ssh host keys: $0"
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:17
-msgid "Pull an image:"
+#: pkg/storaged/index.html:135
+msgid "iSCSI Targets"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html.h:1
-msgid "Show all Nodes"
-msgstr ""
+#: pkg/storaged/details.js:1692
+msgid "inactive"
+msgstr "inactif"
 
-#: pkg/kubernetes/views/node-page.html.h:4
-msgid "The node '{{ target }}' does not exist."
-msgstr ""
+#: pkg/storaged/details.js:1286
+msgid "locked"
+msgstr "verrouillé"
 
-#: pkg/kubernetes/views/route-page.html.h:1
-msgid "Show all Routes"
-msgstr ""
+#: pkg/storaged/details.js:1278
+msgid "mounted on $0"
+msgstr "monté sur $0"
 
-#: pkg/kubernetes/views/route-page.html.h:3
-msgid "The route '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:1
-msgid "Select an object to see more details."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:3
-msgid ""
-"Pods contain one or more containers that run\n"
-"                together on a node, containing your application code."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:6
-msgid ""
-"Replication controllers dynamically create instances of\n"
-"                pods from templates, and remove pods when necessary."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:9
-msgid ""
-"Services group pods and provide a common DNS\n"
-"                name and an optional, load-balanced IP address to access "
-"them."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:12
-msgid "Nodes are the machines that run your containers."
-msgstr ""
-
-#: pkg/kubernetes/views/add-group-dialog.html.h:1
-msgid "Add Group"
-msgstr ""
-
-#: pkg/kubernetes/views/file-button.html.h:1
-msgid "Select Manifest File..."
-msgstr "Sélectionner le fichier de manifeste..."
-
-#: pkg/kubernetes/views/project-modify.html.h:2
-msgid "Change project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-modify.html.h:4
-msgid "Display name"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:5
-msgid "TLS Termination"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:6
-msgid "yes"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:7
+#: pkg/kubernetes/views/route-body.html:14
 msgid "no"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:1
-msgid "Add Role"
+#: pkg/kubernetes/views/route-body.html:24
+#: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
+msgid "none"
+msgstr "aucun"
+
+#: pkg/storaged/details.js:1280
+msgid "not mounted"
+msgstr "non monté"
+
+#: pkg/kubernetes/views/dashboard-page.html:83
+msgid "pending volume claims"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:2
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#: pkg/tuned/change-profile.jsx:52
+#, fuzzy
+msgid "recommended"
+msgstr "MII (Recommandé)"
+
+#: pkg/docker/index.html:426
+msgid "select container"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:1
-msgid "All Types"
+#: pkg/docker/index.html:504 pkg/docker/index.html:683
+msgid "shares"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:2
-msgid "Type:"
+#: pkg/selinux/setroubleshoot-view.jsx:118
+msgid "solution details"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:13
-msgid "Deployment Configs"
+#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
+msgid "unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:15
-msgid "Not deployed"
+#: pkg/storaged/jobs.js:180
+msgid "unknown target"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:16
-msgid "Replication Controllers"
+#: pkg/storaged/details.js:1284
+msgid "unlocked"
+msgstr "déverrouillé"
+
+#: pkg/kubernetes/views/route-body.html:13
+msgid "yes"
 msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:1
-msgid "Adjust Service"
-msgstr "Ajuster le service"
-
-#: pkg/kubernetes/views/service-modify.html.h:3
+#: pkg/kubernetes/views/service-modify.html:16
 msgid "{{ item.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:5
-msgid "Adjust"
-msgstr "Ajuster"
-
-#: pkg/kubernetes/views/project-delete.html.h:1
-msgid "Delete Project"
+#: pkg/kubernetes/views/deploy.html:27
+msgid "{{ selected.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:2
-msgid "Claim Name"
+#: pkg/kubernetes/views/pv-modify.html:61
+#: pkg/kubernetes/views/pv-modify.html:74
+msgid "{{ value }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:4
-msgid "No Volume Bound"
+#: pkg/kubernetes/views/volume-body.html:2
+msgid "{{ volume | formatVolumeType }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:8
-msgid "Requested"
+#: pkg/storaged/index.html:147
+msgid "{{Address}}:{{Port}}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:9
-msgid "Actual"
+#: pkg/docker/index.html:435
+msgid "{{alias_label}}"
+msgstr "{{alias_label}}"
+
+#: pkg/systemd/services.html:173 pkg/systemd/services.html:202
+msgid "{{days_text}}"
 msgstr ""
 
-#: pkg/kubernetes/views/node-capacity.html.h:1
-msgid "Scheduled Pods"
+#: pkg/docker/index.html:403
+msgid "{{envvar_key_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/node-capacity.html.h:2
-msgid "No pods scheduled"
+#: pkg/docker/index.html:407
+msgid "{{envvar_value_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/container-page-inline.html.h:4
-msgid "The container '{{ target }}' does not exist."
+#: pkg/docker/index.html:359
+msgid "{{host_port_label}}"
+msgstr "{{host_port_label}}"
+
+#: pkg/docker/index.html:373
+msgid "{{host_volume_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:1
-msgid "Create image stream"
+#: pkg/kubernetes/views/imagestream-body.html:35
+msgid "{{stream.status.tags.length}}"
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:2
-msgid "Change image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:5
-msgid "Populate"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:6
-msgid "Pull from"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:8
-msgid "Remote registry is insecure"
-msgstr ""
-
-#: pkg/kubernetes/views/user-group-remove.html.h:1
-msgid "Remove Member"
-msgstr ""
-
-#: pkg/kubernetes/views/service-page.html.h:1
-msgid "Show all Services"
-msgstr ""
-
-#: pkg/kubernetes/views/service-page.html.h:4
-msgid "The service '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/scripts/frob-layers.html.h:1
-msgid "Image Layers Example"
-msgstr ""
-
-#: pkg/playground/service.html.h:1
-msgid "Cockpit Generic Service Monitor"
-msgstr ""
-
-#: pkg/playground/jquery-patterns.html.h:1
-msgid "Cockpit Pattern Usage"
-msgstr ""
-
-#: pkg/playground/metrics.html.h:1
 #, fuzzy
-msgid "Cockpit Monitoring"
-msgstr "Surveillance du lien"
+#~ msgid "Cockpit Monitoring"
+#~ msgstr "Surveillance du lien"
 
-#: pkg/playground/test.html.h:1 pkg/playground/translate.html.h:1
-msgid "Cockpit playground"
-msgstr ""
-
-#: pkg/playground/react-patterns.html.h:1
-msgid "Cockpit React Patterns Usage"
-msgstr ""
-
-#: pkg/playground/speed.html.h:1
-msgid "Cockpit Speed Tests"
-msgstr ""
-
-#: pkg/playground/plot.html.h:1
 #, fuzzy
-msgid "Cockpit Plots"
-msgstr "Cockpit"
-
-#: pkg/dashboard/index.html.h:1
-msgid "Dashboard"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:5
-#, fuzzy
-msgid "Disk I/O"
-msgstr "Le disque est OK"
-
-#: pkg/dashboard/index.html.h:6
-msgid "Lost connection. Trying to reconnect"
-msgstr "Connexion perdue. Tentative de reconnexion."
-
-#: pkg/dashboard/index.html.h:10
-msgid "Avatar"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:13
-msgid "Set"
-msgstr ""
+#~ msgid "Cockpit Plots"
+#~ msgstr "Cockpit"
 
 #~ msgid "No addresses found"
 #~ msgstr "Adresse introuvable"
@@ -6230,15 +6307,3 @@ msgstr ""
 #~ "\n"
 #~ "              Obtenir une nouvelle image\n"
 #~ "            "
-
-#~ msgctxt "storage"
-#~ msgid "Serial Number"
-#~ msgstr "Numéro de série"
-
-#~ msgctxt "storage"
-#~ msgid "Capacity"
-#~ msgstr "Capacité"
-
-#~ msgctxt "storage"
-#~ msgid "Device"
-#~ msgstr "Périphérique"

--- a/po/hr.po
+++ b/po/hr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-17 19:28+0100\n"
+"POT-Creation-Date: 2016-11-18 06:44+0100\n"
 "PO-Revision-Date: 2016-02-27 03:52-0500\n"
 "Last-Translator: Goran <goransocemo@gmail.com>\n"
 "Language-Team: Croatian\n"
@@ -15,175 +15,312 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
-#: src/ws/cockpitcertificate.c:359
-msgid "Cannot decrypt PEM-encoded private key"
+#: pkg/shell/index.html:227
+msgid "                                                Comment                                            "
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:364
-msgid "No PEM-encoded private key found"
+#: pkg/shell/index.html:235
+msgid "                                                Fingerprint                                            "
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:374
-msgid "Could not parse PEM-encoded private key"
+#: pkg/shell/index.html:231
+msgid "                                                Type                                            "
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:398
-msgid "No PEM-encoded certificate found"
+#: pkg/systemd/index.html:389
+msgid ""
+"                                    Invalid time "
+"zone                                "
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:407
-msgid "Could not parse PEM-encoded certificate"
+#: pkg/kubernetes/views/project-body.html:80
+msgid ""
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}                                "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
-#: src/bridge/cockpitdbussetup.c:625
-msgid "Unsupported setup mechanism"
+#: pkg/kubernetes/views/user-body.html:22
+msgid ""
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}                                "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:236
-msgid "Couldn't list users"
+#: pkg/kubernetes/views/user-panel.html:39
+msgid ""
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}                            "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
-msgid "Bad data passed for passwd1 mechanism"
+#: pkg/kubernetes/views/project-body.html:37
+msgid ""
+"                                {{ getRegistryRoles(user, project())."
+"join() }}                            "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:382
-msgid "Couldn't load user data"
+#: pkg/systemd/index.html:485 pkg/systemd/index.html:504
+msgid "                        Cancel                    "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:467
-msgid "Couldn't change user groups"
+#: pkg/kubernetes/views/user-add-membership.html:9
+msgid "                        Group or Project                    "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:520
-msgid "Couldn't change user password"
+#: pkg/kubernetes/views/add-user-dialog.html:19
+#: pkg/kubernetes/views/user-modify.html:19
+msgid "                        Identity                    "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:544
-msgid "Couldn't create new users"
+#: pkg/kubernetes/views/add-user-dialog.html:9
+#: pkg/kubernetes/views/user-modify.html:9
+#: pkg/kubernetes/views/add-group-dialog.html:9
+msgid "                        Name                    "
 msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:642
-msgid "Couldn't list local users"
+#: pkg/kubernetes/views/user-add-membership.html:30
+msgid "                        Role                    "
 msgstr ""
 
-#: src/bridge/cockpitpackages.c:459
-#, c-format
-msgid "This package requires Cockpit version %s or later"
+#: pkg/kubernetes/views/user-group-add.html:9
+msgid "                        User                    "
 msgstr ""
 
-#: src/bridge/cockpitpackages.c:470
-msgid "This package is not compatible with this version of Cockpit"
+#: pkg/ostree/index.html:88
+msgid "                    Available                  "
 msgstr ""
 
-#: src/base1/cockpit.js:2586
-msgid "$0 killed with signal $1"
+#: pkg/ostree/index.html:85
+msgid "                    Default                  "
 msgstr ""
 
-#: src/base1/cockpit.js:2588
-msgid "$0 exited with code $1"
+#: pkg/ostree/index.html:223
+msgid "                    Reconnect                "
 msgstr ""
 
-#: src/base1/cockpit.js:2590
-msgid "$0 failed"
+#: pkg/ostree/index.html:135
+msgid ""
+"                    This deployment contains the same packages as your "
+"currently booted system                "
 msgstr ""
 
-#: src/base1/cockpit.js:3667
-msgid "Your session has been terminated."
+#: pkg/ostree/index.html:67
+msgid "                    Update and reboot                "
 msgstr ""
 
-#: src/base1/cockpit.js:3669
-msgid "Your session has expired. Please log in again."
+#: pkg/kubernetes/registry.html:74 pkg/kubernetes/index.html:104
+msgid "                Reconnect            "
 msgstr ""
 
-#: src/base1/cockpit.js:3671
-msgid "Not permitted to perform this action."
+#: pkg/sosreport/index.html:57
+msgid ""
+"                The generated archive contains data "
+"considered                sensitive and its content should be reviewed by "
+"the                originating organization before being passed to "
+"any                third party.              "
 msgstr ""
 
-#: src/base1/cockpit.js:3673
-msgid "Login failed"
+#: pkg/shell/index.html:304 pkg/shell/stub.html:157
+msgid "                Tools              "
 msgstr ""
 
-#: src/base1/cockpit.js:3675
-msgid "The server refused to authenticate using any supported methods."
+#: pkg/kubernetes/index.html:107
+msgid "                Troubleshoot            "
 msgstr ""
 
-#: src/base1/cockpit.js:3677
-msgid "Untrusted host"
+#: pkg/shell/simple.html:105 pkg/shell/index.html:126 pkg/shell/stub.html:119
+#: pkg/storaged/index.html:862
+msgid "              Cancel            "
 msgstr ""
 
-#: src/base1/cockpit.js:3679
-msgid "Host key is incorrect"
+#: pkg/shell/index.html:147 pkg/shell/stub.html:140
+msgid "              Close            "
 msgstr ""
 
-#: src/base1/cockpit.js:3681
-msgid "Internal error"
+#: pkg/shell/simple.html:70 pkg/shell/index.html:83 pkg/shell/stub.html:76
+msgid ""
+"              Cockpit is an interactive Linux server admin "
+"interface.            "
 msgstr ""
 
-#: src/base1/cockpit.js:3683
-msgid "Connection has timed out."
+#: pkg/shell/simple.html:79 pkg/shell/index.html:92 pkg/shell/stub.html:85
+msgid "              Licensed under the GNU LGPL version 2.1            "
 msgstr ""
 
-#: src/base1/cockpit.js:3685
-msgid "Cockpit is not installed on the system."
+#: pkg/shell/simple.html:129
+msgid "              Log in again            "
 msgstr ""
 
-#: src/base1/cockpit.js:3687
-msgid "Cannot forward login credentials"
+#: pkg/shell/simple.html:73 pkg/shell/index.html:86 pkg/shell/stub.html:79
+msgid "              Project website            "
 msgstr ""
 
-#: src/base1/cockpit.js:3689
-msgid "Server has closed the connection."
+#: pkg/shell/simple.html:108 pkg/shell/index.html:129 pkg/shell/stub.html:122
+msgid "              Select            "
 msgstr ""
 
-#: src/base1/cockpit.js:3691
-msgid "Cockpit is not compatible with the software on the system."
+#: pkg/shell/simple.html:126
+msgid "              Try to reconnect            "
 msgstr ""
 
-#: src/base1/cockpit.js:3693
-msgid "Cockpit could not contact the given host."
+#: pkg/users/index.html:361
+msgid "            Add key          "
 msgstr ""
 
-#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:19
-#, fuzzy
-msgid "Control"
-msgstr "Spremnik"
-
-#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
-#: pkg/playground/translate.js:22
-#, fuzzy
-msgctxt "key"
-msgid "Control"
-msgstr "Spremnik"
-
-#: src/base1/test-locale.js:46 src/base1/test-locale.js:56
-#: pkg/playground/translate.js:10
-msgid "Empty"
+#: pkg/networkmanager/index.html:582 pkg/networkmanager/index.html:610
+#: pkg/networkmanager/index.html:638 pkg/networkmanager/index.html:666
+#: pkg/networkmanager/index.html:694 pkg/networkmanager/index.html:722
+#: pkg/networkmanager/index.html:750 pkg/networkmanager/index.html:778
+msgid "            Apply          "
 msgstr ""
 
-#: src/base1/test-locale.js:47 src/base1/test-locale.js:58
-#: pkg/playground/translate.js:16
-msgctxt "verb"
-msgid "Empty"
+#: pkg/users/index.html:269 pkg/users/index.html:297 pkg/users/index.html:358
+#: pkg/docker/index.html:584 pkg/docker/index.html:622
+#: pkg/docker/index.html:688 pkg/docker/index.html:744
+#: pkg/docker/index.html:790 pkg/networkmanager/index.html:579
+#: pkg/networkmanager/index.html:607 pkg/networkmanager/index.html:635
+#: pkg/networkmanager/index.html:663 pkg/networkmanager/index.html:691
+#: pkg/networkmanager/index.html:719 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:775
+msgid "            Cancel          "
 msgstr ""
 
-#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
-#: src/base1/test-locale.js:66 pkg/storaged/details.js:1557
-#: pkg/playground/translate.js:25 pkg/playground/translate.js:28
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+#: pkg/docker/index.html:691
+msgid "            Change          "
+msgstr ""
 
-#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
-#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
-#: pkg/playground/translate.js:34
-msgctxt "disk-non-rotational"
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
+#: pkg/users/index.html:45
+msgid "            Close          "
+msgstr ""
+
+#: pkg/docker/index.html:747
+msgid "            Commit          "
+msgstr ""
+
+#: pkg/users/index.html:207
+msgid "            Create          "
+msgstr ""
+
+#: pkg/users/index.html:300 pkg/networkmanager/index.html:533
+msgid "            Delete          "
+msgstr ""
+
+#: pkg/docker/index.html:625
+msgid "            Download          "
+msgstr ""
+
+#: pkg/docker/index.html:587
+msgid "            Run          "
+msgstr ""
+
+#: pkg/users/index.html:272
+msgid "            Set          "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:14
+msgid "          Images may be pulled by anonymous users        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:20
+msgid ""
+"          Images may be pulled by any authenticated user or group        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:26
+msgid "          Images may only be pulled by specific users or groups        "
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:9
+msgid "         {{ labels.url }}    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:2
+msgid ""
+"        Project access policy allows anonymous users to pull images. Grant "
+"additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:7
+msgid ""
+"        Project access policy allows any authenticated user to pull images. "
+"Grant additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:12
+msgid ""
+"        Project access policy only allows specific members to access images. "
+"Grant access to specific members below.    "
+msgstr ""
+
+#: pkg/sosreport/index.html:39
+msgid ""
+"        The collected information will be stored locally on the system.      "
+msgstr ""
+
+#: pkg/storaged/index.html:51
+msgid ""
+"        There are devices with multiple paths on the system, but the "
+"multipath service is not running.      "
+msgstr ""
+
+#: pkg/sosreport/index.html:34
+msgid ""
+"        This tool will collect system configuration and diagnostic        "
+"information from this system for use with diagnosing problems        with "
+"the system.      "
+msgstr ""
+
+#: pkg/docker/storage.jsx:242
+msgid " (shared with the OS)"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:8
+msgid " 1\"Do you want to delete the following Nodes?"
+msgstr ""
+
+#: pkg/storaged/overview.js:253
+msgid "$0 Block Device"
+msgstr "$0 Blok uređaj"
+
+#: pkg/storaged/details.js:1546
+msgid "$0 Chunk Size"
+msgstr ""
+
+#: pkg/storaged/details.js:1544
+msgid "$0 Disks"
+msgstr ""
+
+#: pkg/storaged/details.js:1387
+msgid "$0 Extended Partition"
+msgstr ""
+
+#: pkg/storaged/details.js:1221
+msgctxt "storage-id-desc"
+msgid "$0 File System"
+msgstr ""
+
+#: pkg/storaged/details.js:1375
+msgid "$0 Free Space"
+msgstr ""
+
+#: pkg/storaged/details.js:1367
+msgid "$0 Free Space for Logical Partitions"
+msgstr ""
+
+#: pkg/storaged/details.js:1711
+msgid "$0 Free Space for Logical Volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:1370
+msgid "$0 Free Space for Primary Partitions"
+msgstr ""
+
+#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
+msgid "$0 Template"
+msgstr ""
+
+#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+msgid "$0 bit"
+msgid_plural "$0 bits"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -206,668 +343,35 @@ msgstr[0] "bajtova"
 msgstr[1] "bajtova"
 msgstr[2] "bajtova"
 
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
-msgid "$0 bit"
-msgid_plural "$0 bits"
+#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
+#: src/base1/test-locale.js:66 pkg/playground/translate.js:25
+#: pkg/playground/translate.js:28 pkg/storaged/details.js:1557
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: pkg/systemd/host.js:43
-msgid "The user <b>$0</b> is not permitted to modify hostnames"
-msgstr ""
-
-#: pkg/systemd/host.js:559
-msgid "Set Host name"
-msgstr ""
-
-#: pkg/systemd/host.js:661
-#, fuzzy
-msgid "failed to list ssh host keys: $0"
-msgstr "Pokretanje Docker-a neuspjelo: $0"
-
-#: pkg/systemd/host.js:1113
-msgid "Need at least one NTP server"
-msgstr ""
-
-#: pkg/systemd/host.js:1190
-msgid "Invalid date format and invalid time format"
-msgstr ""
-
-#: pkg/systemd/host.js:1192
-msgid "Invalid time format"
-msgstr ""
-
-#: pkg/systemd/host.js:1194
-msgid "Invalid date format"
-msgstr ""
-
-#: pkg/systemd/host.js:1250
-msgid "NTP Server"
-msgstr ""
-
-#: pkg/systemd/host.js:1300
-msgid "Message to logged in users"
-msgstr ""
-
-#: pkg/systemd/host.js:1307 pkg/systemd/host.js:1309
-#: pkg/systemd/index.html.h:19
-msgid "Shutdown"
-msgstr ""
-
-#: pkg/systemd/host.js:1311 pkg/systemd/host.js:1313 pkg/systemd/init.js:517
-#: pkg/systemd/index.html.h:18
-msgid "Restart"
-msgstr ""
-
-#: pkg/systemd/host.js:1381
-msgctxt "page-title"
-msgid "CPU Status"
-msgstr ""
-
-#: pkg/systemd/host.js:1413 pkg/systemd/index.html.h:24
-msgid "I/O Wait"
-msgstr ""
-
-#: pkg/systemd/host.js:1414 pkg/systemd/index.html.h:25
-msgid "Kernel"
-msgstr ""
-
-#: pkg/systemd/host.js:1415 pkg/subscriptions/subscriptions-register.jsx:76
-#: pkg/systemd/index.html.h:26 pkg/kubernetes/views/auth-form.html.h:6
-#: pkg/kubernetes/views/volume-body.html.h:20
-#: pkg/kubernetes/views/user-panel.html.h:1 pkg/playground/translate.html.h:3
-#: pkg/dashboard/index.html.h:8
-msgid "User"
-msgstr ""
-
-#: pkg/systemd/host.js:1416 pkg/systemd/index.html.h:27
-msgid "Nice"
-msgstr ""
-
-#: pkg/systemd/host.js:1466
-msgctxt "page-title"
-msgid "Memory"
-msgstr ""
-
-#: pkg/systemd/host.js:1499 pkg/systemd/index.html.h:28
-msgid "Swap Used"
-msgstr ""
-
-#: pkg/systemd/host.js:1500 pkg/systemd/index.html.h:29
-msgid "Cached"
-msgstr ""
-
-#: pkg/systemd/host.js:1501 pkg/docker/storage.jsx:313
-#: pkg/kubernetes/scripts/nodes.js:828 pkg/kubernetes/scripts/nodes.js:837
-#: pkg/systemd/index.html.h:30
-msgid "Used"
-msgstr ""
-
-#: pkg/systemd/host.js:1502 pkg/docker/storage.jsx:298
-#: pkg/docker/storage.jsx:320 pkg/systemd/index.html.h:31
-msgid "Free"
-msgstr ""
-
-#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
-#, fuzzy
-msgid "unknown"
-msgstr "Nepoznato"
-
-#: pkg/systemd/init.js:269 pkg/systemd/services.html.h:17
-#: pkg/kubernetes/views/project-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:5
-msgid "Description"
-msgstr ""
-
-#: pkg/systemd/init.js:270
-msgid "Id"
-msgstr ""
-
-#: pkg/systemd/init.js:272
-#, fuzzy
-msgid "Next Run"
-msgstr "Sljedeće"
-
-#: pkg/systemd/init.js:273
-msgid "Last Trigger"
-msgstr ""
-
-#: pkg/systemd/init.js:274 pkg/kubernetes/views/container-body.html.h:6
-#: pkg/kubernetes/views/details-page.html.h:8
-msgid "State"
-msgstr ""
-
-#: pkg/systemd/init.js:301
-msgid "Enabled"
-msgstr ""
-
-#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
-msgid "Disabled"
-msgstr "Onemogućen"
-
-#: pkg/systemd/init.js:303
-msgid "Static"
-msgstr ""
-
-#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
-msgid "$0 Template"
-msgstr ""
-
-#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
-msgid "Start"
-msgstr ""
-
-#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
-msgid "Stop"
-msgstr ""
-
-#: pkg/systemd/init.js:518
-msgid "Reload"
-msgstr ""
-
-#: pkg/systemd/init.js:519
-msgid "Reload or Restart"
-msgstr ""
-
-#: pkg/systemd/init.js:520
-msgid "Try Restart"
-msgstr ""
-
-#: pkg/systemd/init.js:521
-msgid "Reload or Try Restart"
-msgstr ""
-
-#: pkg/systemd/init.js:522
-msgid "Isolate"
-msgstr ""
-
-#: pkg/systemd/init.js:541
-msgid "Enable"
-msgstr ""
-
-#: pkg/systemd/init.js:542
-msgid "Enable Forcefully"
-msgstr ""
-
-#: pkg/systemd/init.js:543
-msgid "Disable"
-msgstr ""
-
-#: pkg/systemd/init.js:544
-msgid "Preset"
-msgstr ""
-
-#: pkg/systemd/init.js:545
-msgid "Preset Forcefully"
-msgstr ""
-
-#: pkg/systemd/init.js:546
-msgid "Mask"
-msgstr ""
-
-#: pkg/systemd/init.js:547
-msgid "Mask Forcefully"
-msgstr ""
-
-#: pkg/systemd/init.js:548
-msgid "Unmask"
-msgstr ""
-
-#: pkg/systemd/init.js:621
-msgid "Since $0"
-msgstr ""
-
-#: pkg/systemd/init.js:639
-msgid "This unit is an instance of the $0 template."
-msgstr ""
-
-#: pkg/systemd/init.js:834
-#, fuzzy
-msgid "The user <b>$0</b> does not have permissions for creating timers"
-msgstr "Korisniku <b>$0</b> nije dozvoljeno da upravlja poslužiteljima"
-
-#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
-#, fuzzy
-msgid "This field cannot be empty."
-msgstr "Lozinka(fraza) ne može biti prazna"
-
-#: pkg/systemd/init.js:1147
-msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
-msgstr ""
-
-#: pkg/systemd/init.js:1169
-#, fuzzy
-msgid "Invalid number."
-msgstr "Nepravilan port"
-
-#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
-msgid "Hour needs to be a number between 0-23"
-msgstr ""
-
-#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
-msgid "Minute needs to be a number between 0-59"
-msgstr ""
-
-#: pkg/systemd/init.js:1218
-#, fuzzy
-msgid "Invalid date format."
-msgstr "Nepravilan port"
-
-#: pkg/systemd/init.js:1222
-msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
-msgstr ""
-
-#: pkg/systemd/logs.js:69
-msgid "Load earlier entries"
-msgstr ""
-
-#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
-#: pkg/systemd/logs.js:175
-msgid "Loading..."
-msgstr ""
-
-#: pkg/systemd/logs.js:130
-msgid "Go to"
-msgstr ""
-
-#: pkg/systemd/logs.js:257
-msgid "Journal entry"
-msgstr ""
-
-#: pkg/systemd/logs.js:284
-msgid "Journal entry not found"
-msgstr ""
-
-#: pkg/tuned/dialog.js:94
-msgid "Tuned is not available"
-msgstr ""
-
-#: pkg/tuned/dialog.js:96
-msgid "Tuned is not running"
-msgstr ""
-
-#: pkg/tuned/dialog.js:98
-msgid "Tuned is off"
-msgstr ""
-
-#: pkg/tuned/dialog.js:100
-msgid "This system is using the recommended profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:102
-msgid "This system is using a custom profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:114
-msgid "Communication with tuned has failed"
-msgstr ""
-
-#: pkg/tuned/dialog.js:133
-#, fuzzy
-msgid "Failed to disable tuned profile"
-msgstr "Pokretanje Docker-a neuspjelo: $0"
-
-#: pkg/tuned/dialog.js:145
-#, fuzzy
-msgid "Failed to switch profile"
-msgstr "Pokretanje Docker-a neuspjelo: $0"
-
-#: pkg/tuned/dialog.js:169
-msgid "Failed to enable tuned"
-msgstr ""
-
-#: pkg/tuned/dialog.js:171
-#, fuzzy
-msgid "Failed to disable tuned"
-msgstr "Pokretanje Docker-a neuspjelo: $0"
-
-#: pkg/tuned/dialog.js:191
-msgid "Change Performance Profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:200
-msgid "Change Profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:233 pkg/kubernetes/views/service-body.html.h:7
-#: pkg/kubernetes/views/pod-panel.html.h:2
-#: pkg/kubernetes/views/image-config.html.h:8
-#: pkg/kubernetes/views/imagestream-body.html.h:12
-#: pkg/kubernetes/views/pod-page.html.h:5
-msgid "None"
-msgstr ""
-
-#: pkg/tuned/dialog.js:234
-msgid "Disable tuned"
-msgstr ""
-
-#: pkg/tuned/dialog.js:262
-msgid "Tuned has failed to start"
-msgstr ""
-
-#: pkg/tuned/change-profile.jsx:52
-msgid "recommended"
-msgstr ""
-
-#: pkg/lib/journal.js:209
-msgid "[no data]"
-msgstr ""
-
-#: pkg/lib/journal.js:213
-msgid "[$0 bytes of binary data]"
-msgstr ""
-
-#: pkg/lib/journal.js:215
-msgid "[binary data]"
-msgstr ""
-
-#: pkg/lib/journal.js:241
-msgid "Reboot"
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:364
-msgid "This machine has already been added."
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:380
-msgid ""
-"This version of cockpit-ws does not support connecting to a host with an "
-"alternate user or port"
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:386
-msgid "The IP address or host name cannot contain whitespace."
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:412
-msgid "Failed to add machine: $0"
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:429
-msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:447
-msgid "Enter IP address or host name"
-msgstr "Unesite IP adresu ili ime računala"
-
-#: pkg/lib/machine-dialogs.js:494
-msgid "Failed to edit machine: $0"
-msgstr ""
-
-#: pkg/lib/cockpit-components-dialog.jsx:136 pkg/sosreport/index.js:55
-#: pkg/systemd/services.html.h:34 pkg/lib/machine-sync-users.html.h:7
-#: pkg/lib/machine-add.html.h:5 pkg/lib/machine-change-port.html.h:6
-#: pkg/lib/machine-change-auth.html.h:11 pkg/storaged/index.html.h:22
-#: pkg/realmd/operation.html.h:10 pkg/kubernetes/views/node-delete.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:3
-#: pkg/kubernetes/views/pvc-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:3
-#: pkg/kubernetes/views/auth-form.html.h:13
-#: pkg/kubernetes/views/node-add.html.h:7
-#: pkg/kubernetes/views/user-group-add.html.h:5
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:4
-#: pkg/kubernetes/views/route-modify.html.h:3
-#: pkg/kubernetes/views/image-delete.html.h:3
-#: pkg/kubernetes/views/pv-delete.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:4
-#: pkg/kubernetes/views/item-delete.html.h:4
-#: pkg/kubernetes/views/add-user-dialog.html.h:8
-#: pkg/kubernetes/views/user-add-membership.html.h:8
-#: pkg/kubernetes/views/deploy.html.h:4
-#: pkg/kubernetes/views/user-modify.html.h:8
-#: pkg/kubernetes/views/pv-modify.html.h:21
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:5
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:3
-#: pkg/kubernetes/views/imagestream-delete.html.h:3
-#: pkg/kubernetes/views/user-remove-membership.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:7
-#: pkg/kubernetes/views/add-role-dialog.html.h:3
-#: pkg/kubernetes/views/service-modify.html.h:4
-#: pkg/kubernetes/views/project-delete.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:9
-#: pkg/kubernetes/views/user-group-remove.html.h:2
-#: pkg/playground/translate.html.h:2 pkg/dashboard/index.html.h:12
-msgid "Cancel"
-msgstr "Odustani"
-
-#: pkg/lib/cockpit-components-dialog.jsx:155
-msgid "Ok"
-msgstr ""
-
-#: pkg/lib/credentials.js:182
-msgid "No such file or directory"
-msgstr ""
-
-#: pkg/lib/credentials.js:186
-msgid "The passwords do not match."
-msgstr ""
-
-#: pkg/lib/credentials.js:191
-msgid "Prompting via ssh-keygen timed out"
-msgstr ""
-
-#: pkg/lib/credentials.js:213 pkg/users/local.js:78
-msgid "Old password not accepted"
-msgstr ""
-
-#: pkg/lib/credentials.js:223 pkg/users/local.js:112 pkg/users/local.js:144
-msgid "Failed to change password"
-msgstr ""
-
-#: pkg/lib/credentials.js:231 pkg/users/local.js:120
-msgid "New password was not accepted"
-msgstr ""
-
-#: pkg/lib/credentials.js:248
-msgid "Not a valid private key"
-msgstr ""
-
-#: pkg/lib/credentials.js:251
-msgid "Prompting via ssh-add timed out"
-msgstr ""
-
-#: pkg/lib/credentials.js:274
-msgid "Invalid file permissions"
-msgstr ""
-
-#: pkg/lib/credentials.js:278
-msgid "Password not accepted"
-msgstr ""
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:22
-#: pkg/shell/index.html.h:27 pkg/storaged/index.html.h:52
-#: pkg/playground/jquery-patterns.html.h:2
-msgid "On"
-msgstr "Uključi"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:23
-#: pkg/shell/index.html.h:28 pkg/storaged/index.html.h:53
-#: pkg/playground/jquery-patterns.html.h:3
-msgid "Off"
-msgstr "Isključi"
-
-#: pkg/shell/base_index.js:670 pkg/users/local.js:1164
-#: pkg/docker/index.html.h:69 pkg/networkmanager/index.html.h:65
-msgid "Unexpected error"
-msgstr "Neočekivana pogreška"
-
-#: pkg/shell/base_index.js:671
-msgid "Cockpit had an unexpected internal error. <br/><br/>"
-msgstr "Neočekivana interna greška <br/><br/>"
-
-#: pkg/shell/base_index.js:672
-msgid "You can try restarting Cockpit by pressing refresh in your browser. "
-msgstr ""
-
-#: pkg/shell/base_index.js:673
-msgid "The javascript console contains details about this error "
-msgstr "Javascript konzola sadrži detalje ove greške"
-
-#: pkg/shell/base_index.js:674
-msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
-msgstr "(<b>Ctrl-Shift-J</b> u većini preglednika)."
-
-#: pkg/shell/indexes.js:126 pkg/shell/indexes.js:497 pkg/shell/simple.html.h:17
-msgid "Disconnected"
-msgstr "Nepovezan"
-
-#: pkg/shell/indexes.js:253
-msgid "Machines"
-msgstr ""
-
-#: pkg/shell/indexes.js:314
-msgid "The machine is restarting"
-msgstr "Uređaj se ponovo pokreće"
-
-#: pkg/shell/indexes.js:317
-msgid "Connecting to the machine"
-msgstr "Spajanje na uređaj"
-
-#: pkg/shell/indexes.js:320
-msgid "Couldn't connect to the machine"
-msgstr "Spajanje na uređaj neuspjelo"
-
-#: pkg/shell/indexes.js:322
-msgid "Cannot connect to an unknown machine"
-msgstr ""
-
-#: pkg/ostree/client.js:56
-msgid "Receiving delta parts"
-msgstr ""
-
-#: pkg/ostree/client.js:58
-msgid "Receiving metadata objects"
-msgstr ""
-
-#: pkg/ostree/client.js:61
-msgid "Receiving objects: $0%"
-msgstr ""
-
-#: pkg/ostree/client.js:64
-msgid "Writing objects"
-msgstr ""
-
-#: pkg/ostree/client.js:66
-msgid "Scanning metadata"
-msgstr ""
-
-#: pkg/ostree/client.js:500
-msgid "OS $0 not found"
-msgstr ""
-
-#: pkg/ostree/app.js:81
-msgid "Not authorized to update software on this system"
-msgstr ""
-
-#: pkg/ostree/app.js:83
-msgid "OSTree is not available on this system"
-msgstr ""
-
-#: pkg/ostree/app.js:101
-msgid "No OSTree deployments found"
-msgstr ""
-
-#: pkg/ostree/app.js:219
-msgid "Checking for updates"
-msgstr ""
-
-#: pkg/ostree/app.js:307
-msgid "$0 package"
-msgstr ""
-
-#: pkg/ostree/app.js:307
-msgid "$0 packages"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot.js:65
-msgid "Error while setting SELinux mode: '$0'"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot.js:238
-#, fuzzy
-msgid "Not connected"
-msgstr "Nepovezan"
-
-#: pkg/selinux/setroubleshoot.js:275
-#, fuzzy
-msgid "Error while connecting."
-msgstr "Greška prilikom preuzimanja"
-
-#: pkg/selinux/setroubleshoot-view.jsx:82
-msgid "Applying solution..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:90
-msgid "Solution applied successfully"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:97
-msgid "Solution failed"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:107
-msgid "Apply this solution"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:114
-msgid "Unable to apply this solution automatically"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:118
-msgid "solution details"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:309
-msgid "SELinux system status is unknown."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:317
-msgid "SELinux is disabled on the system."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:324
-msgid "The configured state is unknown, it might change on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:326
-msgid ""
-"Setting deviates from the configured state and will revert on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:330
-msgid "SELinux Policy"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:332
-msgid "Enforce policy:"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:382 pkg/kubernetes/index.html.h:10
-#: pkg/kubernetes/registry.html.h:5
-msgid "Connecting..."
-msgstr ""
+#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
+#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
+#: pkg/playground/translate.js:34
+msgctxt "disk-non-rotational"
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:385
-msgid ""
-"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
-"server is installed."
+#: src/base1/cockpit.js:2588
+msgid "$0 exited with code $1"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:400
-msgid "Occurred between $0 and $1"
+#: src/base1/cockpit.js:2590
+msgid "$0 failed"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:405
-msgid "Occurred $0"
+#: src/base1/cockpit.js:2586
+msgid "$0 killed with signal $1"
 msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:440
@@ -877,599 +381,43 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:478
-msgid "SELinux Access Control Errors"
+#: pkg/ostree/app.js:307
+msgid "$0 package"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:479
-msgid "No SELinux alerts."
+#: pkg/ostree/app.js:307
+msgid "$0 packages"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-client.js:52
-msgid "Unable to start setroubleshootd"
+#: pkg/docker/util.js:124
+msgid "$0 shares"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-client.js:157
-msgid "Unable to get alert"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:172
-msgid "Unable to run fix"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:187
-msgid "Failed to delete alert"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:192
-msgid "Error while deleting alert"
-msgstr ""
-
-#: pkg/storaged/dialog.js:267
-#, fuzzy
-msgid "Size must be a number"
-msgstr "Veličina mora biti specificirana."
-
-#: pkg/storaged/dialog.js:269
-#, fuzzy
-msgid "Size cannot be zero"
-msgstr "Veličina mora biti specificirana."
-
-#: pkg/storaged/dialog.js:271
-msgid "Size cannot be negative"
-msgstr ""
-
-#: pkg/storaged/dialog.js:273
-msgid "Size is too large"
-msgstr ""
-
-#: pkg/storaged/details.js:85
-msgid "Device $0 is mounted on $1"
-msgstr ""
-
-#: pkg/storaged/details.js:91
-msgid "Device $0 is a member of RAID Array $1"
-msgstr "Uređaj $0 je član RAID niza $1"
-
-#: pkg/storaged/details.js:97
-msgid "Device $0 is a physical volume of $1"
-msgstr ""
-
-#: pkg/storaged/details.js:113
-msgid "Create partition on $0"
-msgstr ""
-
-#: pkg/storaged/details.js:115
-msgid "Format $0"
-msgstr "Format $0"
-
-#: pkg/storaged/details.js:177
-msgid "XFS - Red Hat Enterprise Linux 7 default"
-msgstr ""
-
-#: pkg/storaged/details.js:178
-msgid "ext4 - Red Hat Enterprise Linux 6 default"
-msgstr ""
-
-#: pkg/storaged/details.js:179
-msgid "Encrypted XFS (LUKS)"
-msgstr "Šifrirani XFS (LUKS)"
-
-#: pkg/storaged/details.js:180
-msgid "Encrypted EXT4 (LUKS)"
-msgstr "Šifrirani EXT4 (LUKS)"
-
-#: pkg/storaged/details.js:181
-msgid "VFAT - Compatible with all systems and devices"
-msgstr "VFAT - Kompatibilan sa svim sistemima i uređajima"
-
-#: pkg/storaged/details.js:182
-msgid "NTFS - Compatible with most systems"
-msgstr "NTFS - Kompatibilan sa većinom sistema"
-
-#: pkg/storaged/details.js:183
-msgid "Extended Partition"
-msgstr "Proširena particija"
-
-#: pkg/storaged/details.js:185
-msgid "No Filesystem"
-msgstr ""
-
-#: pkg/storaged/details.js:186
-msgid "Custom (Enter filesystem type)"
-msgstr ""
-
-#: pkg/storaged/details.js:192 pkg/storaged/details.js:664
-#: pkg/storaged/details.js:735 pkg/storaged/details.js:773
-#: pkg/storaged/details.js:909 pkg/storaged/index.html.h:20
-#: pkg/kubernetes/views/volumes-page.html.h:11
-msgid "Size"
-msgstr "Veličina"
-
-#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
-msgid "Erase"
-msgstr "Izbriši"
-
-#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
-msgid "Don't overwrite existing data"
-msgstr "Ne piši preko postojećih podataka"
-
-#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
-msgid "Overwrite existing data with zeros"
-msgstr ""
-
-#: pkg/storaged/details.js:207 pkg/shell/index.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:4
-#: pkg/kubernetes/views/deploy.html.h:2 pkg/kubernetes/views/pv-modify.html.h:3
-msgid "Type"
-msgstr "Tip"
-
-#: pkg/storaged/details.js:211 pkg/storaged/details.js:429
-#: pkg/storaged/details.js:709 pkg/storaged/details.js:731
-#: pkg/storaged/details.js:769 pkg/storaged/details.js:798
-#: pkg/storaged/details.js:864 pkg/storaged/overview.js:417
-#: pkg/storaged/overview.js:490 pkg/storaged/overview.js:624
-#: pkg/storaged/overview.js:702 pkg/storaged/index.html.h:18
-#: pkg/networkmanager/index.html.h:16
-#: pkg/kubernetes/views/project-listing.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:3
-#: pkg/kubernetes/views/volume-body.html.h:11
-#: pkg/kubernetes/views/containers-listing.html.h:2
-#: pkg/kubernetes/views/volumes-page.html.h:3
-#: pkg/kubernetes/views/pv-claim.html.h:1
-#: pkg/kubernetes/views/pv-modify.html.h:6
-#: pkg/kubernetes/views/image-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:15
-#: pkg/kubernetes/views/nodes-page.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:3
-#: pkg/kubernetes/views/details-page.html.h:4
-#: pkg/kubernetes/views/service-modify.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:3
-msgid "Name"
-msgstr "Naziv"
-
-#: pkg/storaged/details.js:215
-msgid "Filesystem type"
-msgstr ""
-
-#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
-msgid "Passphrase"
-msgstr "Lozinka(fraza)"
-
-#: pkg/storaged/details.js:224
-#, fuzzy
-msgid "Passphrase cannot be empty"
-msgstr "Lozinka(fraza) ne može biti prazna"
-
-#: pkg/storaged/details.js:229
-msgid "Confirm passphrase"
-msgstr "Potvrdi lozinku(frazu)"
-
-#: pkg/storaged/details.js:232
-msgid "Passphrases do not match"
-msgstr "Lozinke(fraze) se ne podudaraju"
-
-#: pkg/storaged/details.js:237
-msgid "Store passphrase"
-msgstr "Spremi lozinku(frazu)"
-
-#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
-#: pkg/storaged/details.js:1115
-msgid "Encryption Options"
-msgstr "Opcije šifriranja"
-
-#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
-msgid "Mounting"
-msgstr "Montiranje"
-
-#: pkg/storaged/details.js:247 pkg/storaged/details.js:435
-#: pkg/subscriptions/subscriptions-register.jsx:101 pkg/docker/index.html.h:23
-#: pkg/kubernetes/views/image-config.html.h:2
-msgid "Default"
-msgstr "Zadano"
-
-#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
-msgid "Custom"
-msgstr "Prilagođeno"
-
-#: pkg/storaged/details.js:253 pkg/storaged/details.js:440
-#: pkg/storaged/index.html.h:19
-msgid "Mount Point"
-msgstr "Točka pristupa"
-
-#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
-msgid "Mount Options"
-msgstr ""
-
-#: pkg/storaged/details.js:266
-msgid "Create partition"
-msgstr "Načini particiju"
-
-#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
-#: pkg/storaged/details.js:1142
-msgid "Format"
-msgstr ""
-
-#: pkg/storaged/details.js:268
-msgid "Formatting a storage device will erase all data on it."
-msgstr ""
-
-#: pkg/storaged/details.js:335
-msgid "Format Disk $0"
-msgstr ""
-
-#: pkg/storaged/details.js:346
-msgid "Partitioning"
-msgstr ""
-
-#: pkg/storaged/details.js:348
-msgid "Compatible with all systems and devices (MBR)"
-msgstr ""
-
-#: pkg/storaged/details.js:349
-msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr ""
-
-#: pkg/storaged/details.js:352
-msgid "No partitioning"
-msgstr ""
-
-#: pkg/storaged/details.js:358
-msgid "Formatting a disk will erase all data on it."
-msgstr ""
-
-#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
-msgid "Filesystem Options"
-msgstr ""
-
-#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
-msgid "Apply"
-msgstr ""
-
-#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
-#: pkg/storaged/details.js:1110
-msgid "Unlock"
-msgstr ""
-
-#: pkg/storaged/details.js:527
-msgid "Stored Passphrase"
-msgstr ""
-
-#: pkg/storaged/details.js:531 pkg/kubernetes/views/volume-body.html.h:32
-msgid "Options"
-msgstr ""
-
-#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
-msgid "Add Disks"
-msgstr ""
-
-#: pkg/storaged/details.js:567 pkg/storaged/details.js:933
-#: pkg/storaged/overview.js:448 pkg/storaged/overview.js:495
-#: pkg/storaged/index.html.h:55
-msgid "Disks"
-msgstr ""
-
-#: pkg/storaged/details.js:579 pkg/storaged/details.js:948
-#: pkg/storaged/overview.js:501
-msgid "At least one disk is needed."
-msgstr ""
-
-#: pkg/storaged/details.js:584 pkg/storaged/details.js:953
-#: pkg/storaged/overview.js:629 pkg/storaged/overview.js:657
-#: pkg/lib/machine-add.html.h:6 pkg/kubernetes/views/node-add.html.h:8
-#: pkg/kubernetes/views/user-group-add.html.h:6
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:5
-#: pkg/kubernetes/views/add-user-dialog.html.h:9
-#: pkg/kubernetes/views/user-add-membership.html.h:9
-#: pkg/kubernetes/views/add-role-dialog.html.h:4
-msgid "Add"
-msgstr "Dodaj"
-
-#: pkg/storaged/details.js:625 pkg/storaged/details.js:821
-#: pkg/storaged/details.js:1016 pkg/docker/details.js:271
-#: pkg/docker/image.js:151 pkg/docker/containers-view.jsx:166
-msgid "Please confirm deletion of $0"
-msgstr "Potvrdite brisanje $0"
-
-#: pkg/storaged/details.js:630 pkg/storaged/details.js:827
-#: pkg/storaged/details.js:1022 pkg/storaged/details.js:1151
-#: pkg/storaged/details.js:1616 pkg/storaged/details.js:1776
-#: pkg/docker/details.js:273 pkg/docker/image.js:153
-#: pkg/docker/containers-view.jsx:168 pkg/kubernetes/scripts/volumes.js:218
-#: pkg/users/index.html.h:9 pkg/kubernetes/views/node-delete.html.h:5
-#: pkg/kubernetes/views/pvc-delete.html.h:5
-#: pkg/kubernetes/views/image-delete.html.h:4
-#: pkg/kubernetes/views/pv-delete.html.h:5
-#: pkg/kubernetes/views/item-delete.html.h:5
-#: pkg/kubernetes/views/imagestream-delete.html.h:4
-#: pkg/kubernetes/views/user-remove-membership.html.h:3
-#: pkg/kubernetes/views/project-delete.html.h:3
-msgid "Delete"
-msgstr "Izbriši"
-
-#: pkg/storaged/details.js:631
-msgid "Deleting a RAID device will erase all data on it."
-msgstr ""
-
-#: pkg/storaged/details.js:661
-msgid "Resize Logical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:673
-msgid "Resize Filesystem"
-msgstr ""
-
-#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
-msgid "Resize"
-msgstr ""
-
-#: pkg/storaged/details.js:690
-msgid "This logical volume cannot be made smaller."
-msgstr ""
-
-#: pkg/storaged/details.js:706
-msgid "Renamee Logical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
-#: pkg/storaged/details.js:1775
-msgid "Rename"
-msgstr ""
-
-#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
-msgid "Create Snapshot"
-msgstr ""
-
-#: pkg/storaged/details.js:745 pkg/storaged/details.js:781
-#: pkg/storaged/details.js:804 pkg/storaged/details.js:915
-#: pkg/storaged/overview.js:461 pkg/storaged/overview.js:506
-#: pkg/kubernetes/views/add-group-dialog.html.h:6
-#: pkg/kubernetes/views/project-modify.html.h:8
-msgid "Create"
-msgstr "Izradi"
+#: pkg/kubernetes/scripts/nodes.js:870
+#, c-format
+msgid "$0% Free"
+msgid_plural "$0% Free"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
-#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
-msgid "Create Thin Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:795
-msgid "Rename Volume Group"
-msgstr ""
-
-#: pkg/storaged/details.js:826
-msgid "Deleting a volume group will erase all data on it."
-msgstr ""
-
-#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
-msgid "Create Logical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:869
-msgid "Purpose"
-msgstr ""
-
-#: pkg/storaged/details.js:871
-msgid "Block device for filesystems"
-msgstr ""
-
-#: pkg/storaged/details.js:874
-msgid "Pool for thinly provisioned volumes"
-msgstr ""
-
-#: pkg/storaged/details.js:1009
-msgid "Deleting a logical volume will delete all data in it."
-msgstr ""
-
-#: pkg/storaged/details.js:1012
-msgid "Deleting a partition will delete all data in it."
-msgstr ""
-
-#: pkg/storaged/details.js:1053 pkg/storaged/overview.js:689
-#: pkg/storaged/devices.js:119 pkg/users/local.js:1155
-#: pkg/systemd/services.html.h:14
-msgid "Error"
-msgstr ""
-
-#: pkg/storaged/details.js:1099
-msgid "Mount"
-msgstr ""
-
-#: pkg/storaged/details.js:1100
-msgid "Unmount"
-msgstr ""
-
-#: pkg/storaged/details.js:1109
-msgid "Lock"
-msgstr ""
-
-#: pkg/storaged/details.js:1127
-msgid "Activate"
-msgstr ""
-
-#: pkg/storaged/details.js:1130
-msgid "Deactivate"
-msgstr ""
-
-#: pkg/storaged/details.js:1221
-msgctxt "storage-id-desc"
-msgid "$0 File System"
-msgstr ""
-
-#: pkg/storaged/details.js:1224
-msgctxt "storage-id-desc"
-msgid "Linux MD-RAID Component"
-msgstr ""
-
-#: pkg/storaged/details.js:1226
-msgctxt "storage-id-desc"
-msgid "LVM2 Physical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:1228
-msgctxt "storage-id-desc"
-msgid "RAID Member"
-msgstr ""
-
-#: pkg/storaged/details.js:1245
-msgctxt "storage-id-desc"
-msgid "LUKS Encrypted"
-msgstr ""
-
-#: pkg/storaged/details.js:1247
-msgctxt "storage-id-desc"
-msgid "Encrypted"
-msgstr ""
-
-#: pkg/storaged/details.js:1251
-msgctxt "storage-id-desc"
-msgid "Swap Space"
-msgstr ""
-
-#: pkg/storaged/details.js:1253
-msgctxt "storage-id-desc"
-msgid "Other Data"
-msgstr ""
-
-#: pkg/storaged/details.js:1256
-msgctxt "storage-id-desc"
-msgid "Unrecognized Data"
-msgstr ""
-
-#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
-msgid "$size $partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1278
-msgid "mounted on $0"
-msgstr ""
-
-#: pkg/storaged/details.js:1280
-msgid "not mounted"
-msgstr ""
-
-#: pkg/storaged/details.js:1284
-msgid "unlocked"
-msgstr ""
-
-#: pkg/storaged/details.js:1286
-msgid "locked"
-msgstr ""
-
-#: pkg/storaged/details.js:1367
-msgid "$0 Free Space for Logical Partitions"
-msgstr ""
-
-#: pkg/storaged/details.js:1370
-msgid "$0 Free Space for Primary Partitions"
-msgstr ""
-
-#: pkg/storaged/details.js:1375
-msgid "$0 Free Space"
-msgstr ""
-
-#: pkg/storaged/details.js:1379
-msgid "Create Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1387
-msgid "$0 Extended Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1424
-msgid "Logical Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1426
-msgid "Primary Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1428 pkg/kubernetes/views/volume-body.html.h:5
-msgid "Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
-msgid "Content"
-msgstr ""
-
-#: pkg/storaged/details.js:1533
-msgid "RAID 0"
-msgstr ""
-
-#: pkg/storaged/details.js:1534
-msgid "RAID 1"
-msgstr ""
-
-#: pkg/storaged/details.js:1535
-msgid "RAID 4"
-msgstr ""
-
-#: pkg/storaged/details.js:1536
-msgid "RAID 5"
-msgstr ""
-
-#: pkg/storaged/details.js:1537
-msgid "RAID 6"
-msgstr ""
-
-#: pkg/storaged/details.js:1538
-msgid "RAID 10"
-msgstr ""
-
-#: pkg/storaged/details.js:1539
-msgid "RAID ($0)"
-msgstr ""
-
-#: pkg/storaged/details.js:1544
-msgid "$0 Disks"
-msgstr ""
-
-#: pkg/storaged/details.js:1546
-msgid "$0 Chunk Size"
-msgstr ""
-
-#: pkg/storaged/details.js:1574 pkg/ostree/index.html.h:7
-msgid "Running"
-msgstr "Pokrenuto"
-
-#: pkg/storaged/details.js:1574
-msgid "Not running"
-msgstr ""
-
-#: pkg/storaged/details.js:1592
-msgid "FAILED"
-msgstr ""
-
-#: pkg/storaged/details.js:1593
-msgid "In Sync"
-msgstr ""
-
-#: pkg/storaged/details.js:1594
-msgid "Spare"
-msgstr ""
-
-#: pkg/storaged/details.js:1594
-msgid "Recovering"
-msgstr ""
-
-#: pkg/storaged/details.js:1595
-msgid "Write-mostly"
-msgstr ""
-
-#: pkg/storaged/details.js:1596
-msgid "Blocked"
-msgstr ""
+#: pkg/kubernetes/scripts/nodes.js:872
+msgid "$0% Used"
+msgid_plural "$0% Used"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
-#: pkg/storaged/details.js:1597
-msgid "Unknown ($0)"
+#: pkg/storaged/details.js:1765
+msgid "$0, $1 free"
 msgstr ""
 
-#: pkg/storaged/details.js:1614
-msgid "Start Scrubbing"
+#: pkg/networkmanager/interfaces.js:2473
+msgid "$mtu"
 msgstr ""
 
-#: pkg/storaged/details.js:1615
-msgid "Stop Scrubbing"
+#: pkg/storaged/utils.js:157
+msgid "$name (from $host)"
 msgstr ""
 
 #: pkg/storaged/details.js:1653
@@ -1485,253 +433,129 @@ msgstr ""
 msgid "$size $desc<br/>($state)"
 msgstr ""
 
-#: pkg/storaged/details.js:1692
-msgid "active, but unsupported"
+#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
+msgid "$size $partition"
 msgstr ""
 
-#: pkg/storaged/details.js:1692
-msgid "inactive"
+#: pkg/docker/details.js:144
+msgid "${hip}:${hport} -> $cport"
+msgstr "${hip}:${hport} -> $cport"
+
+#: pkg/subscriptions/subscriptions-client.js:198
+msgid "'Organization' required to register."
 msgstr ""
 
-#: pkg/storaged/details.js:1711
-msgid "$0 Free Space for Logical Volumes"
+#: pkg/subscriptions/subscriptions-client.js:202
+msgid "'Organization' required when using activation keys."
 msgstr ""
 
-#: pkg/storaged/details.js:1751
-msgid "The last physical volume of a volume group cannot be removed."
+#: pkg/shell/base_index.js:674
+msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
+msgstr "(<b>Ctrl-Shift-J</b> u većini preglednika)."
+
+#: pkg/storaged/overview.js:440
+msgid "1 MiB"
 msgstr ""
 
-#: pkg/storaged/details.js:1756
-msgid ""
-"There is not enough free space elsewhere to remove this physical volume.  At "
-"least $0 more free space is needed."
+#: pkg/systemd/index.html:459 pkg/systemd/index.html:463
+msgid "1 Minute"
 msgstr ""
 
-#: pkg/storaged/details.js:1765
-msgid "$0, $1 free"
-msgstr ""
+#: pkg/storaged/index.html:312 pkg/networkmanager/index.html:55
+#: pkg/networkmanager/index.html:501
+msgid "1 day"
+msgstr "1 dan"
 
-#: pkg/storaged/details.js:1792
-msgid "Logical Volumes"
-msgstr ""
+#: pkg/storaged/index.html:310 pkg/networkmanager/index.html:53
+#: pkg/networkmanager/index.html:499
+msgid "1 hour"
+msgstr "1 sat"
 
-#: pkg/storaged/details.js:1822 pkg/docker/details.js:177
-#: pkg/docker/image.js:112
-msgid "Not found"
-msgstr "Nije pronađeno"
+#: pkg/storaged/index.html:313 pkg/networkmanager/index.html:56
+#: pkg/networkmanager/index.html:502
+msgid "1 week"
+msgstr "1 tjedan"
 
-#: pkg/storaged/overview.js:180
-msgctxt "storage"
-msgid "Hard Disk"
-msgstr "Tvrdi disk"
+#: pkg/playground/translate.html:190
+msgid "1% Free"
+msgid_plural "{{$count}}% Free"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
-#: pkg/storaged/overview.js:182
-msgctxt "storage"
-msgid "Solid-State Disk"
-msgstr "SSD disk"
-
-#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
-msgctxt "storage"
-msgid "Removable Drive"
-msgstr ""
-
-#: pkg/storaged/overview.js:189
-msgctxt "storage"
-msgid "Optical Drive"
-msgstr "Optički pogon"
-
-#: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
-msgctxt "storage"
-msgid "Drive"
-msgstr "Pogon"
-
-#: pkg/storaged/overview.js:253
-msgid "$0 Block Device"
-msgstr "$0 Blok uređaj"
-
-#: pkg/storaged/overview.js:414
-msgid "Create RAID Device"
-msgstr "Stvori RAID uređaj"
-
-#: pkg/storaged/overview.js:420
-msgid "RAID Level"
-msgstr "RAID razina"
-
-#: pkg/storaged/overview.js:422
-msgid "RAID 0 (Stripe)"
-msgstr "RAID 0 (Stripe)"
-
-#: pkg/storaged/overview.js:423
-msgid "RAID 1 (Mirror)"
-msgstr "RAID 1 (Mirror)"
-
-#: pkg/storaged/overview.js:424
-msgid "RAID 4 (Dedicated Parity)"
-msgstr "RAID 4 (Dedicated Parity)"
-
-#: pkg/storaged/overview.js:425
-msgid "RAID 5 (Distributed Parity)"
-msgstr "RAID 5 (Distributed Parity)"
-
-#: pkg/storaged/overview.js:426
-msgid "RAID 6 (Double Distributed Parity)"
-msgstr "RAID 6 (Double Distributed Parity)"
-
-#: pkg/storaged/overview.js:427
-msgid "RAID 10 (Stripe of Mirrors)"
-msgstr ""
-
-#: pkg/storaged/overview.js:431
-msgid "Chunk Size"
-msgstr ""
-
-#: pkg/storaged/overview.js:433
-msgid "4 KiB"
-msgstr ""
-
-#: pkg/storaged/overview.js:434
-msgid "8 KiB"
+#: pkg/storaged/overview.js:438
+msgid "128 KiB"
 msgstr ""
 
 #: pkg/storaged/overview.js:435
 msgid "16 KiB"
 msgstr ""
 
+#: pkg/storaged/overview.js:441
+msgid "2 MiB"
+msgstr ""
+
+#: pkg/systemd/index.html:465
+msgid "20 Minutes"
+msgstr ""
+
 #: pkg/storaged/overview.js:436
 msgid "32 KiB"
+msgstr ""
+
+#: pkg/storaged/overview.js:433
+msgid "4 KiB"
+msgstr ""
+
+#: pkg/systemd/index.html:466
+msgid "40 Minutes"
+msgstr ""
+
+#: pkg/systemd/index.html:464
+msgid "5 Minutes"
+msgstr ""
+
+#: pkg/storaged/index.html:309 pkg/networkmanager/index.html:52
+#: pkg/networkmanager/index.html:498
+msgid "5 minutes"
+msgstr "5 minuta"
+
+#: pkg/storaged/overview.js:439
+msgid "512 KiB"
+msgstr ""
+
+#: pkg/storaged/index.html:311 pkg/networkmanager/index.html:54
+#: pkg/networkmanager/index.html:500
+msgid "6 hours"
+msgstr "6 sati"
+
+#: pkg/systemd/index.html:467
+msgid "60 Minutes"
 msgstr ""
 
 #: pkg/storaged/overview.js:437
 msgid "64 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:438
-msgid "128 KiB"
+#: pkg/storaged/overview.js:434
+msgid "8 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:439
-msgid "512 KiB"
-msgstr ""
+#: pkg/networkmanager/interfaces.js:1826
+msgid "802.3ad"
+msgstr "802.3ad"
 
-#: pkg/storaged/overview.js:440
-msgid "1 MiB"
-msgstr ""
-
-#: pkg/storaged/overview.js:441
-msgid "2 MiB"
-msgstr ""
-
-#: pkg/storaged/overview.js:455
-msgid "At least $0 disks are needed."
-msgstr "Najmanje $0 diskova  je potrebno."
-
-#: pkg/storaged/overview.js:487
-msgid "Create Volume Group"
-msgstr ""
-
-#: pkg/storaged/overview.js:515
-msgid "Add iSCSI Portal"
-msgstr ""
-
-#: pkg/storaged/overview.js:518
-msgid "Server Address"
-msgstr ""
-
-#: pkg/storaged/overview.js:521
+#: pkg/networkmanager/interfaces.js:1843
 #, fuzzy
-msgid "Server address cannot be empty."
-msgstr "Lozinka(fraza) ne može biti prazna"
+msgid "802.3ad LACP"
+msgstr "802.3ad"
 
-#: pkg/storaged/overview.js:533 pkg/realmd/operation.html.h:11
-msgid "Next"
-msgstr "Sljedeće"
-
-#: pkg/storaged/overview.js:577 pkg/storaged/overview.js:668
-#: pkg/subscriptions/subscriptions-client.js:194
-msgid "Invalid username or password"
+#: pkg/systemd/services.html:446
+msgid ":"
 msgstr ""
 
-#: pkg/storaged/overview.js:582
-msgid "Unknown host name"
-msgstr ""
-
-#: pkg/storaged/overview.js:586
-msgid "Unable to reach server"
-msgstr ""
-
-#: pkg/storaged/overview.js:619
-msgid "Available targets on $0"
-msgstr ""
-
-#: pkg/storaged/overview.js:623 pkg/systemd/services.html.h:2
-msgid "Targets"
-msgstr ""
-
-#: pkg/storaged/overview.js:624 pkg/lib/machine-add.html.h:2
-#: pkg/kubernetes/views/node-body.html.h:2
-#: pkg/kubernetes/views/auth-form.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:16
-#: pkg/kubernetes/views/nodes-page.html.h:7
-#: pkg/kubernetes/views/details-page.html.h:19
-msgid "Address"
-msgstr "Adresa"
-
-#: pkg/storaged/overview.js:624 pkg/lib/machine-change-port.html.h:5
-msgid "Port"
-msgstr ""
-
-#: pkg/storaged/overview.js:699
-msgid "Change iSCSI Initiator Name"
-msgstr ""
-
-#: pkg/storaged/overview.js:707 pkg/kubernetes/views/route-modify.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:22
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:4
-#: pkg/kubernetes/views/project-modify.html.h:9
-msgid "Change"
-msgstr ""
-
-#: pkg/storaged/utils.js:88
-msgctxt "format-bytes"
-msgid "bytes"
-msgstr "bajtova"
-
-#: pkg/storaged/utils.js:129
-#, fuzzy
-msgid "Name cannot be empty."
-msgstr "Lozinka(fraza) ne može biti prazna"
-
-#: pkg/storaged/utils.js:131
-msgid "Name cannot be longer than 127 characters."
-msgstr ""
-
-#: pkg/storaged/utils.js:135
-msgid "Name cannot contain the character '$0'."
-msgstr ""
-
-#: pkg/storaged/utils.js:137
-msgid "Name cannot contain whitespace."
-msgstr ""
-
-#: pkg/storaged/utils.js:157
-msgid "$name (from $host)"
-msgstr ""
-
-#: pkg/storaged/utils.js:166
-msgid "Pool for Thin Logical Volumes"
-msgstr ""
-
-#: pkg/storaged/utils.js:168
-msgid "Thin Logical Volume"
-msgstr ""
-
-#: pkg/storaged/utils.js:170
-msgid "Logical Volume (Snapshot)"
-msgstr ""
-
-#: pkg/storaged/utils.js:172
-msgid "Logical Volume"
+#: pkg/storaged/utils.js:220
+msgid "<span>Encrypted $0</span>"
 msgstr ""
 
 #: pkg/storaged/utils.js:212
@@ -1750,105 +574,632 @@ msgstr ""
 msgid "<span>Partition of $0</span>"
 msgstr ""
 
-#: pkg/storaged/utils.js:220
-msgid "<span>Encrypted $0</span>"
+#: pkg/lib/machine-not-supported.html:5
+msgid ""
+"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
+"strong}}."
 msgstr ""
 
-#: pkg/storaged/utils.js:233
-msgid "RAID Device $0"
-msgstr "RAID uređaj $0"
-
-#: pkg/storaged/utils.js:239
-msgid "Volume Group $0"
+#: cockpit.desktop.in.h:2
+msgid "A user interface for GNU/Linux servers"
 msgstr ""
 
-#: pkg/storaged/jobs.js:119
-msgid "SMART self-test of $target"
+#: pkg/networkmanager/interfaces.js:1834
+msgid "ARP"
+msgstr "ARP"
+
+#: pkg/networkmanager/interfaces.js:2502
+msgid "ARP Monitoring"
+msgstr "ARP nadziranje"
+
+#: pkg/networkmanager/interfaces.js:1855
+#, fuzzy
+msgid "ARP Ping"
+msgstr "ARP nadziranje"
+
+#: pkg/kubernetes/scripts/volumes.js:193
+msgid "AWS Elastic Block Store"
 msgstr ""
 
-#: pkg/storaged/jobs.js:120
-msgid "Ejecting $target"
+#: pkg/shell/simple.html:41 pkg/shell/simple.html:67 pkg/shell/index.html:41
+#: pkg/shell/index.html:80 pkg/shell/stub.html:41 pkg/shell/stub.html:73
+msgid "About Cockpit"
+msgstr "O Cockpit-u"
+
+#: pkg/users/index.html:105 pkg/users/index.html:191
+msgid "Access"
 msgstr ""
 
-#: pkg/storaged/jobs.js:121
-msgid "Unlocking $target"
+#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pv-claim.html:9
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-body.html:9
+msgid "Access Modes"
 msgstr ""
 
-#: pkg/storaged/jobs.js:122
-msgid "Locking $target"
+#: pkg/kubernetes/views/project-modify.html:49
+#: pkg/kubernetes/views/imagestream-body.html:11
+msgid "Access Policy"
 msgstr ""
 
-#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
-msgid "Modifying $target"
+#: pkg/subscriptions/subscriptions-view.jsx:191
+msgid "Access denied"
 msgstr ""
 
-#: pkg/storaged/jobs.js:124
-msgid "Starting swapspace $target"
+#: pkg/shell/index.html:45
+msgid "Account Settings"
+msgstr "Postavke Računa"
+
+#: pkg/users/index.html:63
+msgid "Account not available or cannot be edited."
 msgstr ""
 
-#: pkg/storaged/jobs.js:125
-msgid "Stopping swapspace $target"
+#: pkg/users/index.html:71
+msgid "Accounts"
 msgstr ""
 
-#: pkg/storaged/jobs.js:126
-msgid "Mounting $target"
+#: pkg/users/local.js:284 pkg/users/local.js:594
+msgctxt "page-title"
+msgid "Accounts"
 msgstr ""
 
-#: pkg/storaged/jobs.js:127
-msgid "Unmounting $target"
+#: pkg/storaged/details.js:1127
+msgid "Activate"
 msgstr ""
 
-#: pkg/storaged/jobs.js:129
-msgid "Erasing $target"
+#: pkg/storaged/jobs.js:148
+msgid "Activating $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:130
-msgid "Creating filesystem on $target"
+#: pkg/subscriptions/subscriptions-register.jsx:164
+#, fuzzy
+msgid "Activation Key"
+msgstr "Deaktiviram"
+
+#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
+msgid "Active"
+msgstr "Aktivno"
+
+#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
+msgid "Active Backup"
 msgstr ""
 
-#: pkg/storaged/jobs.js:131
-msgid "Setting up loop device $target"
+#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
+msgid "Actual"
 msgstr ""
 
-#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
-msgid "Deleting $target"
+#: pkg/networkmanager/interfaces.js:1828
+msgid "Adaptive load balancing"
 msgstr ""
 
-#: pkg/storaged/jobs.js:134
-msgid "Creating partition $target"
+#: pkg/networkmanager/interfaces.js:1827
+msgid "Adaptive transmit load balancing"
 msgstr ""
 
-#: pkg/storaged/jobs.js:135
-msgid "Cleaning up for $target"
+#: pkg/kubernetes/views/add-user-dialog.html:31
+#: pkg/kubernetes/views/node-add.html:50
+#: pkg/kubernetes/views/user-add-membership.html:53
+#: pkg/kubernetes/views/add-member-role-dialog.html:61
+#: pkg/kubernetes/views/user-group-add.html:32
+#: pkg/kubernetes/views/add-role-dialog.html:8 pkg/lib/machine-add.html:43
+msgid "Add"
+msgstr "Dodaj"
+
+#: pkg/networkmanager/interfaces.js:2836
+msgid "Add $0"
 msgstr ""
 
-#: pkg/storaged/jobs.js:136
-msgid "Securely erasing $target"
+#: pkg/docker/storage.jsx:363
+msgid "Add Additional Storage"
 msgstr ""
 
-#: pkg/storaged/jobs.js:137
-msgid "Very securely erasing $target"
+#: pkg/networkmanager/index.html:86
+msgid "Add Bond"
+msgstr "Dodaj Bond"
+
+#: pkg/networkmanager/index.html:88
+msgid "Add Bridge"
+msgstr "Dodaj Bridge"
+
+#: pkg/kubernetes/views/node-add.html:3
+msgid "Add Cluster Node"
 msgstr ""
 
-#: pkg/storaged/jobs.js:138
-msgid "Stopping RAID Device $target"
+#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
+msgid "Add Disks"
 msgstr ""
 
-#: pkg/storaged/jobs.js:139
-msgid "Starting RAID Device $target"
+#: pkg/kubernetes/views/add-group-dialog.html:3
+msgid "Add Group"
 msgstr ""
 
-#: pkg/storaged/jobs.js:140
-msgid "Marking $target as faulty"
+#: pkg/kubernetes/views/nodes-page.html:34
+msgid "Add Kubernetes Node"
 msgstr ""
 
-#: pkg/storaged/jobs.js:141
-msgid "Removing $target from RAID Device"
+#: pkg/lib/machine-add.html:4
+msgid "Add Machine to Dashboard"
 msgstr ""
 
-#: pkg/storaged/jobs.js:142
-msgid "Creating RAID Device $target"
+#: pkg/kubernetes/views/group-page.html:38
+#: pkg/kubernetes/views/add-member-role-dialog.html:4
+#: pkg/kubernetes/views/group-panel.html:29
+#: pkg/kubernetes/views/user-group-add.html:3
+#: pkg/kubernetes/views/project-body.html:108
+msgid "Add Member"
 msgstr ""
+
+#: pkg/kubernetes/views/user-panel.html:76
+#: pkg/kubernetes/views/user-body.html:67
+#, fuzzy
+msgid "Add Membership"
+msgstr "Članovi"
+
+#: pkg/kubernetes/views/auth-form.html:11
+#: pkg/kubernetes/views/auth-form.html:20
+msgid "Add New Cluster"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:67
+#: pkg/kubernetes/views/auth-form.html:76
+msgid "Add New User"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:3
+#, fuzzy
+msgid "Add Role"
+msgstr "Dodaj Bond"
+
+#: pkg/networkmanager/index.html:87
+#, fuzzy
+msgid "Add Team"
+msgstr "Dodaj Bond"
+
+#: pkg/kubernetes/views/add-user-dialog.html:3
+#: pkg/kubernetes/views/project-listing.html:83
+msgid "Add User"
+msgstr ""
+
+#: pkg/networkmanager/index.html:89
+msgid "Add VLAN"
+msgstr "Dodaj VLAN"
+
+#: pkg/storaged/overview.js:515
+msgid "Add iSCSI Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/user-add-membership.html:3
+msgid "Add membership"
+msgstr ""
+
+#: pkg/users/index.html:351
+msgid "Add public key"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2833
+msgid "Adding <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/users/authorized-keys.js:108
+msgid "Adding key"
+msgstr ""
+
+#: pkg/storaged/jobs.js:153
+msgid "Adding physical volume to $target"
+msgstr ""
+
+#: pkg/docker/index.html:329
+msgid "Additional Storage"
+msgstr ""
+
+#: pkg/ostree/index.html:121 pkg/ostree/index.html:140
+msgid "Additions"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:8
+#: pkg/kubernetes/views/dashboard-page.html:157
+#: pkg/kubernetes/views/details-page.html:174
+#: pkg/kubernetes/views/nodes-page.html:43
+#: pkg/kubernetes/views/auth-form.html:29 pkg/kubernetes/views/node-body.html:5
+#: pkg/lib/machine-add.html:11
+msgid "Address"
+msgstr "Adresa"
+
+#: pkg/kubernetes/views/details-page.html:37
+msgid "Addresses"
+msgstr "Adresa"
+
+#: pkg/kubernetes/views/service-modify.html:25
+msgid "Adjust"
+msgstr "Prilagodi"
+
+#: pkg/kubernetes/views/pv-modify.html:3
+msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-modify.html:3
+msgid "Adjust Replication Controller {{ item.metadata.name }}"
+msgstr ""
+
+#: pkg/kubernetes/views/route-modify.html:3
+msgid "Adjust Route"
+msgstr ""
+
+#: pkg/kubernetes/views/service-modify.html:3
+msgid "Adjust Service"
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:56
+msgid "Admin"
+msgstr ""
+
+#: pkg/systemd/services.html:389 pkg/systemd/services.html:393
+msgid "After system boot"
+msgstr ""
+
+#: pkg/systemd/logs.html:50
+msgid "All"
+msgstr "Sve"
+
+#: pkg/kubernetes/views/filter-project.html:4
+msgid "All Projects"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:6
+#, fuzzy
+msgid "All Types"
+msgstr "Tip"
+
+#: pkg/docker/storage.jsx:366
+msgid ""
+"All data on selected disks will be erased and disks will be added to the "
+"storage pool."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:112
+msgid "All healthy"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:74
+msgid "All images"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:69
+msgid "All in use"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:37
+#, fuzzy
+msgid "All running"
+msgstr "Pokrenuto"
+
+#: pkg/docker/index.html:569
+msgid "Always"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-meta.html:2
+#: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/image-meta.html:9
+#: pkg/kubernetes/views/node-body.html:57
+msgid "Annotations"
+msgstr ""
+
+#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
+msgid "Apply"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:107
+msgid "Apply this solution"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:82
+msgid "Applying solution..."
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:12
+msgid "Architecture"
+msgstr ""
+
+#: pkg/storaged/index.html:451
+msgctxt "storage"
+msgid "Assessment"
+msgstr ""
+
+#: pkg/systemd/index.html:81
+msgid "Asset Tag"
+msgstr ""
+
+#: pkg/storaged/overview.js:455
+msgid "At least $0 disks are needed."
+msgstr "Najmanje $0 diskova  je potrebno."
+
+#: pkg/storaged/overview.js:501 pkg/storaged/details.js:579
+#: pkg/storaged/details.js:948
+msgid "At least one disk is needed."
+msgstr ""
+
+#: pkg/systemd/services.html:394
+msgid "At specific time"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:813
+msgid "Authenticating"
+msgstr "Autoriziranje"
+
+#: pkg/realmd/operation.html:34 pkg/shell/index.html:48
+#: pkg/shell/index.html:159 pkg/kubernetes/views/auth-form.html:85
+#: pkg/lib/machine-change-auth.html:32
+msgid "Authentication"
+msgstr "Autentifikacija"
+
+#: pkg/lib/machine-auth-failed.html:2
+msgid "Authentication Failed"
+msgstr ""
+
+#: pkg/docker/index.html:730 pkg/kubernetes/views/image-body.html:12
+#: pkg/kubernetes/views/image-listing.html:15
+msgid "Author"
+msgstr "Autor"
+
+#: pkg/users/index.html:130
+msgid "Authorized Public SSH Keys"
+msgstr ""
+
+#: pkg/networkmanager/index.html:165
+msgid "Automatic"
+msgstr "Automatski"
+
+#: pkg/networkmanager/interfaces.js:1814
+msgid "Automatic (DHCP only)"
+msgstr "Automatski (samo DHCP)"
+
+#: pkg/networkmanager/interfaces.js:1804
+msgid "Automatic (DHCP)"
+msgstr "Automatski (DHCP)"
+
+#: pkg/systemd/index.html:406
+msgid "Automatically using NTP"
+msgstr ""
+
+#: pkg/systemd/index.html:407
+msgid "Automatically using specific NTP servers"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:66
+msgid "Available"
+msgstr ""
+
+#: pkg/storaged/overview.js:619
+msgid "Available targets on $0"
+msgstr ""
+
+#: pkg/dashboard/index.html:177
+msgid "Avatar"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:207
+msgid "Azure"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
+msgid "Bad data passed for passwd1 mechanism"
+msgstr ""
+
+#: pkg/networkmanager/index.html:389
+msgid "Balancer"
+msgstr ""
+
+#: pkg/storaged/index.html:560
+msgctxt "storage"
+msgid "Bitmap"
+msgstr ""
+
+#: pkg/storaged/index.html:414
+msgid "Block Device"
+msgstr ""
+
+#: pkg/storaged/details.js:871
+msgid "Block device for filesystems"
+msgstr ""
+
+#: pkg/storaged/details.js:1596
+msgid "Blocked"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
+#: pkg/networkmanager/interfaces.js:2507
+msgid "Bond"
+msgstr ""
+
+#: pkg/networkmanager/index.html:596
+msgid "Bond Settings"
+msgstr "Bond Postavke"
+
+#: pkg/kubernetes/views/node-body.html:17
+msgid "Boot ID"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
+#: pkg/networkmanager/interfaces.js:2584
+msgid "Bridge"
+msgstr ""
+
+#: pkg/networkmanager/index.html:708
+msgid "Bridge Port Settings"
+msgstr "Bridge Port Postavke"
+
+#: pkg/networkmanager/index.html:680
+msgid "Bridge Settings"
+msgstr "Bridge Postavke"
+
+#: pkg/networkmanager/interfaces.js:2605
+msgid "Bridge port"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
+msgid "Broadcast"
+msgstr "Emitiranje"
+
+#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#, fuzzy
+msgid "Broken configuration"
+msgstr "Nepoznata konfiguracija"
+
+#: pkg/kubernetes/views/image-body.html:16
+msgid "Built"
+msgstr ""
+
+#: pkg/dashboard/index.html:70
+msgid "CPU"
+msgstr "CPU"
+
+#: pkg/systemd/host.js:1381
+msgctxt "page-title"
+msgid "CPU Status"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:712
+msgid "CPU Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:490 pkg/docker/index.html:669
+msgid "CPU priority"
+msgstr "CPU prioritet"
+
+#: pkg/systemd/index.html:247
+msgid "Cached"
+msgstr ""
+
+#: pkg/docker/index.html:63
+#, fuzzy
+msgid "Can&rsquo;t connect to Docker"
+msgstr "Uspostavljanje veze sa Docker-om nije moguće"
+
+#: pkg/systemd/services.html:465 pkg/dashboard/index.html:189
+#: pkg/playground/translate.html:40 pkg/playground/translate.html:174
+#: pkg/realmd/operation.html:90 pkg/kubernetes/views/pv-modify.html:202
+#: pkg/kubernetes/views/item-delete.html:10
+#: pkg/kubernetes/views/add-user-dialog.html:30
+#: pkg/kubernetes/views/project-modify.html:71
+#: pkg/kubernetes/views/node-add.html:49
+#: pkg/kubernetes/views/pvc-delete.html:14
+#: pkg/kubernetes/views/node-delete.html:14
+#: pkg/kubernetes/views/imagestream-modify.html:96
+#: pkg/kubernetes/views/imagestream-delete.html:7
+#: pkg/kubernetes/views/user-modify.html:30
+#: pkg/kubernetes/views/add-group-dialog.html:20
+#: pkg/kubernetes/views/project-delete.html:8
+#: pkg/kubernetes/views/service-modify.html:24
+#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/kubernetes/views/user-group-remove.html:9
+#: pkg/kubernetes/views/user-add-membership.html:52
+#: pkg/kubernetes/views/add-member-role-dialog.html:60
+#: pkg/kubernetes/views/group-delete.html:20
+#: pkg/kubernetes/views/image-delete.html:7 pkg/kubernetes/views/deploy.html:61
+#: pkg/kubernetes/views/user-group-add.html:31
+#: pkg/kubernetes/views/auth-form.html:128
+#: pkg/kubernetes/views/auth-rejected-cert.html:31
+#: pkg/kubernetes/views/replicationcontroller-modify.html:16
+#: pkg/kubernetes/views/pv-delete.html:10
+#: pkg/kubernetes/views/add-role-dialog.html:7
+#: pkg/kubernetes/views/route-modify.html:16
+#: pkg/kubernetes/views/user-delete.html:24
+#: pkg/kubernetes/views/remove-role-dialog.html:7 pkg/storaged/index.html:289
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:79
+msgid "Cancel"
+msgstr "Odustani"
+
+#: pkg/shell/indexes.js:322
+msgid "Cannot connect to an unknown machine"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:359
+msgid "Cannot decrypt PEM-encoded private key"
+msgstr ""
+
+#: src/base1/cockpit.js:3707
+msgid "Cannot forward login credentials"
+msgstr ""
+
+#: pkg/realmd/operation.js:417
+msgid "Cannot join a domain because realmd is not available on this system"
+msgstr "Nije moguće pristupiti domeni jer realmd nije dostupan na ovom sustavu"
+
+#: pkg/kubernetes/views/pv-modify.html:44
+#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pv-body.html:13
+msgid "Capacity"
+msgstr ""
+
+#: pkg/storaged/index.html:443 pkg/storaged/index.html:519
+#: pkg/storaged/index.html:551 pkg/storaged/index.html:630
+msgctxt "storage"
+msgid "Capacity"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2276
+msgid "Carrier"
+msgstr "Nosioc"
+
+#: pkg/kubernetes/scripts/volumes.js:203
+msgid "Ceph Filesystem Mount"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:97
+#, fuzzy
+msgid "Ceph Monitors"
+msgstr "Repozitorij"
+
+#: pkg/kubernetes/views/pv-modify.html:204
+#: pkg/kubernetes/views/project-modify.html:74
+#: pkg/kubernetes/views/replicationcontroller-modify.html:17
+#: pkg/kubernetes/views/route-modify.html:17
+msgid "Change"
+msgstr ""
+
+#: pkg/shell/index.html:278
+msgid "Change Password"
+msgstr ""
+
+#: pkg/tuned/dialog.js:191
+msgid "Change Performance Profile"
+msgstr ""
+
+#: pkg/tuned/dialog.js:200
+msgid "Change Profile"
+msgstr ""
+
+#: pkg/kubernetes/views/user-modify.html:3
+msgid "Change User"
+msgstr ""
+
+#: pkg/storaged/overview.js:699
+msgid "Change iSCSI Initiator Name"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:4
+msgid "Change image stream"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:10
+msgid "Change project"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2872
+#, fuzzy
+msgid "Change the settings"
+msgstr "Bond Postavke"
+
+#: pkg/networkmanager/interfaces.js:2870
+msgid "Changing the settings will break the connection to the server, "
+msgstr ""
+
+#: pkg/ostree/index.html:48
+msgid "Check for updates"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:817
+msgid "Checking IP"
+msgstr "Provjera IP"
 
 #: pkg/storaged/jobs.js:143
 #, fuzzy
@@ -1859,77 +1210,840 @@ msgstr "RAID uređaj $0"
 msgid "Checking and Repairing RAID Device $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:145
-msgid "Recovering RAID Device $target"
+#: pkg/lib/machine-change-auth.html:70
+msgid "Checking for public keys"
 msgstr ""
 
-#: pkg/storaged/jobs.js:146
-msgid "Synchronizing RAID Device $target"
+#: pkg/ostree/app.js:219
+msgid "Checking for updates"
 msgstr ""
 
-#: pkg/storaged/jobs.js:148
-msgid "Activating $target"
+#: pkg/shell/simple.html:100 pkg/shell/index.html:121 pkg/shell/stub.html:114
+msgid "Choose the language to be used in the application"
+msgstr "Odaberite jezik koji će se koristiti u aplikaciji"
+
+#: pkg/storaged/overview.js:431
+msgid "Chunk Size"
 msgstr ""
 
-#: pkg/storaged/jobs.js:149
-msgid "Deactivating $target"
+#: pkg/kubernetes/scripts/volumes.js:202
+msgid "Cinder"
 msgstr ""
 
-#: pkg/storaged/jobs.js:150
-msgid "Creating snapshot of $target"
+#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
+msgid "Claim"
 msgstr ""
 
-#: pkg/storaged/jobs.js:151
-msgid "Creating volume group $target"
+#: pkg/kubernetes/views/pvc-body.html:4
+#, fuzzy
+msgid "Claim Name"
+msgstr "Ime spremnika"
+
+#: pkg/storaged/jobs.js:135
+msgid "Cleaning up for $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:152
-msgid "Deleting volume group $target"
+#: pkg/kubernetes/views/auth-form.html:88
+msgid "Client Certificate"
 msgstr ""
 
-#: pkg/storaged/jobs.js:153
-msgid "Adding physical volume to $target"
+#: pkg/systemd/services.html:306 pkg/systemd/services.html:324
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-invalid-hostkey.html:19
+msgid "Close"
+msgstr "Zatvori"
+
+#: pkg/kubernetes/views/auth-form.html:5
+#, fuzzy
+msgid "Cluster"
+msgstr "Glavni"
+
+#: cockpit.desktop.in.h:1
+msgid "Cockpit"
+msgstr "Cockpit"
+
+#: pkg/lib/machine-dialogs.js:429
+msgid ""
+"Cockpit could not contact the given host $0. Make sure it has ssh running on "
+"port $1, or specify another port in the address."
 msgstr ""
 
-#: pkg/storaged/jobs.js:154
-msgid "Removing physical volume from $target"
+#: src/base1/cockpit.js:3713
+msgid "Cockpit could not contact the given host."
 msgstr ""
 
-#: pkg/storaged/jobs.js:155
-msgid "Emptying $target"
+#: pkg/shell/base_index.js:671
+msgid "Cockpit had an unexpected internal error. <br/><br/>"
+msgstr "Neočekivana interna greška <br/><br/>"
+
+#: cockpit.appdata.xml.in.h:1
+msgid ""
+"Cockpit is a server manager that makes it easy to administer your Linux "
+"servers via a web browser. Jumping between the terminal and the web tool is "
+"no problem. A service started via Cockpit can be stopped via the terminal. "
+"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
+"journal interface."
+msgstr ""
+
+#: src/base1/cockpit.js:3711
+msgid "Cockpit is not compatible with the software on the system."
+msgstr ""
+
+#: pkg/lib/machine-not-supported.html:2
+msgid "Cockpit is not installed"
+msgstr ""
+
+#: src/base1/cockpit.js:3705
+msgid "Cockpit is not installed on the system."
+msgstr ""
+
+#: cockpit.appdata.xml.in.h:2
+msgid ""
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
+"tasks such as storage administration, inspecting journals and starting and "
+"stopping services. You can monitor and administer several servers at the "
+"same time. Just add them with a single click and your machines will look "
+"after its buddies."
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:9
+msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:15
+msgid ""
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:9
+msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:6
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
+"machine with cockpit you will need to enable one of the following "
+"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:13
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
+"change your authentication credentials below. {{#can_sync}}You may prefer to "
+"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+msgstr ""
+
+#: pkg/dashboard/index.html:171 pkg/lib/machine-add.html:27
+msgid "Color"
+msgstr ""
+
+#: pkg/docker/index.html:95
+msgid "Combined CPU usage"
+msgstr ""
+
+#: pkg/docker/index.html:101
+msgid "Combined memory usage"
+msgstr ""
+
+#: pkg/systemd/services.html:370 pkg/docker/index.html:466
+#: pkg/docker/index.html:736
+msgid "Command"
+msgstr "Naredba"
+
+#: pkg/docker/run.js:332
+#, fuzzy
+msgid "Command can't be empty"
+msgstr "Lozinka(fraza) ne može biti prazna"
+
+#: pkg/docker/containers-view.jsx:239
+#, fuzzy
+msgid "Commit"
+msgstr "Naredba"
+
+#: pkg/tuned/dialog.js:114
+msgid "Communication with tuned has failed"
+msgstr ""
+
+#: pkg/storaged/details.js:348
+msgid "Compatible with all systems and devices (MBR)"
+msgstr ""
+
+#: pkg/storaged/details.js:349
+msgid "Compatible with modern system and hard disks > 2TB (GPT)"
+msgstr ""
+
+#: pkg/realmd/operation.html:28
+msgid "Computer OU"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:24
+msgid "Configuration"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2441
+msgid "Configure"
+msgstr "Konfiguriranje"
+
+#: pkg/kubernetes/views/node-add.html:42
+msgid "Configure Flannel networking"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:32
+msgid "Configure Kubelet and Proxy"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:811
+msgid "Configuring"
+msgstr "Podešavanje"
+
+#: pkg/networkmanager/interfaces.js:815
+msgid "Configuring IP"
+msgstr "Podešavanje IP"
+
+#: pkg/users/index.html:171 pkg/shell/index.html:262
+msgid "Confirm"
+msgstr ""
+
+#: pkg/users/index.html:247
+msgid "Confirm New Password"
+msgstr ""
+
+#: pkg/storaged/details.js:229
+msgid "Confirm passphrase"
+msgstr "Potvrdi lozinku(frazu)"
+
+#: pkg/kubernetes/views/auth-form.html:130
+#: pkg/kubernetes/views/auth-rejected-cert.html:33
+#: pkg/lib/machine-unknown-hostkey.html:22
+msgid "Connect"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2637
+msgid "Connect automatically"
+msgstr "Automatski uspostavi vezu"
+
+#: pkg/ostree/index.html:218
+msgid "Connecting"
+msgstr ""
+
+#: pkg/lib/machine-add.html:39
+msgid ""
+"Connecting simultaneously to more than {{ limit }} machines is unsupported."
+msgstr ""
+
+#: pkg/docker/index.html:54
+msgid "Connecting to Docker"
+msgstr "Povezujem se na Docker"
+
+#: pkg/shell/indexes.js:317
+msgid "Connecting to the machine"
+msgstr "Spajanje na uređaj"
+
+#: pkg/kubernetes/registry.html:70 pkg/kubernetes/index.html:100
+msgid "Connecting..."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-dialog.html:4
+#, fuzzy
+msgid "Connection Error"
+msgstr "Povezujem se na Docker"
+
+#: pkg/kubernetes/scripts/connection.js:516
+#, fuzzy
+msgid "Connection Error: $0"
+msgstr "Povezujem se na Docker"
+
+#: pkg/kubernetes/views/auth-dialog.html:3
+#, fuzzy
+msgid "Connection Settings"
+msgstr "Bond Postavke"
+
+#: src/base1/cockpit.js:3703
+msgid "Connection has timed out."
+msgstr ""
+
+#: pkg/networkmanager/index.html:812
+#, fuzzy
+msgid "Connection will be lost"
+msgstr "Bond Postavke"
+
+#: pkg/docker/console.html:4 pkg/kubernetes/views/container-panel.html:4
+#: pkg/kubernetes/views/image-panel.html:12
+#: pkg/kubernetes/views/container-body.html:4
+#: pkg/kubernetes/views/container-page-inline.html:2
+#: pkg/kubernetes/views/image-page.html:19
+msgid "Container"
+msgstr "Spremnik"
+
+#: pkg/users/local.js:684
+msgid "Container Administrator"
+msgstr ""
+
+#: pkg/kubernetes/views/container-body.html:10
+msgid "Container ID"
+msgstr ""
+
+#: pkg/docker/index.html:459 pkg/docker/index.html:646
+#: pkg/docker/index.html:712
+msgid "Container Name"
+msgstr "Ime spremnika"
+
+#: pkg/kubernetes/views/node-body.html:21
+msgid "Container Runtime Version"
+msgstr ""
+
+#: pkg/docker/util.js:490
+msgid ""
+"Container is currently marked as not running, but regular stopping failed."
+msgstr ""
+"Spremnik trenutno nije u pogonu, ali uredno zaustavljanje nije uspjelo."
+
+#: pkg/docker/util.js:488
+msgid "Container is currently running."
+msgstr "Spremnik je pokrenut."
+
+#: pkg/docker/index.html:23 pkg/docker/index.html:309
+#: pkg/kubernetes/views/pod-page.html:36
+#: pkg/kubernetes/views/dashboard-page.html:158
+#: pkg/kubernetes/views/dashboard-page.html:199
+#: pkg/kubernetes/views/containers-listing.html:5 pkg/kubernetes/index.html:51
+msgid "Containers"
+msgstr "Spremnici"
+
+#: pkg/docker/details.js:47 pkg/docker/image.js:43
+msgctxt "page-title"
+msgid "Containers"
+msgstr "Spremnici"
+
+#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
+msgid "Content"
+msgstr ""
+
+#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
+#: pkg/playground/translate.js:19
+#, fuzzy
+msgid "Control"
+msgstr "Spremnik"
+
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
+#: pkg/playground/translate.js:22
+#, fuzzy
+msgctxt "key"
+msgid "Control"
+msgstr "Spremnik"
+
+#: pkg/docker/storage.jsx:404
+msgid "Could not add all disks"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:4
+msgid "Could not contact {{host}}"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:142
+msgid "Could not list services"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:407
+msgid "Could not parse PEM-encoded certificate"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:374
+msgid "Could not parse PEM-encoded private key"
+msgstr ""
+
+#: pkg/docker/storage.jsx:446
+msgid "Could not reset the storage pool"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:467
+msgid "Couldn't change user groups"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:520
+msgid "Couldn't change user password"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:385
+msgid ""
+"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
+"server is installed."
+msgstr ""
+
+#: pkg/kubernetes/registry.html:71 pkg/kubernetes/index.html:101
+msgid "Couldn't connect to server"
+msgstr ""
+
+#: pkg/shell/indexes.js:320
+msgid "Couldn't connect to the machine"
+msgstr "Spajanje na uređaj neuspjelo"
+
+#: src/bridge/cockpitdbussetup.c:544
+msgid "Couldn't create new users"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:514
+msgid "Couldn't find running API server"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:196
+msgid ""
+"Couldn't get system subscription status. Please ensure subscription-manager "
+"is installed."
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:642
+msgid "Couldn't list local users"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:236
+msgid "Couldn't list users"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:382
+msgid "Couldn't load user data"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:72
+#: pkg/kubernetes/views/add-group-dialog.html:21
+msgid "Create"
+msgstr "Izradi"
+
+#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
+msgid "Create Logical Volume"
+msgstr ""
+
+#: pkg/users/index.html:54 pkg/users/index.html:143
+msgid "Create New Account"
+msgstr ""
+
+#: pkg/storaged/details.js:1379
+msgid "Create Partition"
+msgstr ""
+
+#: pkg/storaged/overview.js:414
+msgid "Create RAID Device"
+msgstr "Stvori RAID uređaj"
+
+#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
+msgid "Create Snapshot"
+msgstr ""
+
+#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
+msgid "Create Thin Volume"
+msgstr ""
+
+#: pkg/systemd/services.html:336
+#, fuzzy
+msgid "Create Timers"
+msgstr "Izradi"
+
+#: pkg/storaged/overview.js:487
+msgid "Create Volume Group"
+msgstr ""
+
+#: pkg/sosreport/index.html:50
+msgid "Create diagnostic report"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:3
+msgid "Create image stream"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
+#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
+#, fuzzy
+msgid "Create it"
+msgstr "Izradi"
+
+#: pkg/storaged/details.js:266
+msgid "Create partition"
+msgstr "Načini particiju"
+
+#: pkg/storaged/details.js:113
+msgid "Create partition on $0"
+msgstr ""
+
+#: pkg/storaged/index.html:381
+msgid "Create partition table"
+msgstr ""
+
+#: pkg/sosreport/index.html:42
+msgid "Create report"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/replicationcontroller-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7 pkg/kubernetes/views/route-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3
+msgid "Created"
+msgstr ""
+
+#: pkg/storaged/jobs.js:142
+msgid "Creating RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:130
+msgid "Creating filesystem on $target"
 msgstr ""
 
 #: pkg/storaged/jobs.js:156
 msgid "Creating logical volume $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:157
-msgid "Renaming $target"
+#: pkg/storaged/jobs.js:134
+msgid "Creating partition $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:158
-msgid "Resizing $target"
+#: pkg/storaged/jobs.js:150
+msgid "Creating snapshot of $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:166
-msgid "Operation '$operation' on $target"
+#: pkg/networkmanager/interfaces.js:4064
+msgid "Creating this VLAN will break the connection to the server, "
 msgstr ""
 
-#: pkg/storaged/jobs.js:180
-msgid "unknown target"
+#: pkg/networkmanager/interfaces.js:3436
+msgid "Creating this bond will break the connection to the server, "
 msgstr ""
 
-#: pkg/storaged/permissions.js:61
-msgid "The user <b>$0</b> is not permitted to manage storage"
+#: pkg/networkmanager/interfaces.js:3842
+msgid "Creating this bridge will break the connection to the server, "
 msgstr ""
 
-#: pkg/realmd/operation.js:96
-msgid "Join"
-msgstr "Pridruživanje"
+#: pkg/networkmanager/interfaces.js:3611
+msgid "Creating this team will break the connection to the server, "
+msgstr ""
 
-#: pkg/realmd/operation.js:101
-msgid "Leave"
-msgstr "Napusti"
+#: pkg/storaged/jobs.js:151
+msgid "Creating volume group $target"
+msgstr ""
+
+#: pkg/systemd/logs.html:41
+msgid "Current boot"
+msgstr ""
+
+#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
+msgid "Custom"
+msgstr "Prilagođeno"
+
+#: pkg/storaged/details.js:186
+msgid "Custom (Enter filesystem type)"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:102
+#, fuzzy
+msgid "Custom URL"
+msgstr "Prilagođeno"
+
+#: pkg/storaged/index.html:454
+msgid "DISK IS FAILING"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3018
+msgid "DNS"
+msgstr "DNS"
+
+#: pkg/kubernetes/views/pod-body.html:14
+msgid "DNS Policy"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3022
+msgid "DNS Search Domains"
+msgstr "DNS traži domene"
+
+#: pkg/dashboard/index.html:22
+msgid "Dashboard"
+msgstr ""
+
+#: pkg/storaged/details.js:1130
+msgid "Deactivate"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:823
+msgid "Deactivating"
+msgstr "Deaktiviram"
+
+#: pkg/storaged/jobs.js:149
+msgid "Deactivating $target"
+msgstr ""
+
+#: pkg/docker/index.html:379 pkg/docker/index.html:383
+#: pkg/kubernetes/views/image-config.html:6
+msgid "Default"
+msgstr "Zadano"
+
+#: pkg/systemd/index.html:454
+msgid "Delay"
+msgstr ""
+
+#: pkg/users/index.html:79 pkg/kubernetes/views/item-delete.html:11
+#: pkg/kubernetes/views/pvc-delete.html:15
+#: pkg/kubernetes/views/node-delete.html:15
+#: pkg/kubernetes/views/imagestream-delete.html:8
+#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/kubernetes/views/image-delete.html:8
+#: pkg/kubernetes/views/pv-delete.html:11
+msgid "Delete"
+msgstr "Izbriši"
+
+#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
+msgid "Delete $0"
+msgstr ""
+
+#: pkg/users/index.html:292
+msgid "Delete Files"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:4
+#, fuzzy
+msgid "Delete Node"
+msgstr "Izbriši"
+
+#: pkg/kubernetes/views/pv-delete.html:3
+msgid "Delete Persistent Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:3
+msgid "Delete Persistent Volume Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/project-delete.html:3
+#, fuzzy
+msgid "Delete Project"
+msgstr "Projekt"
+
+#: pkg/kubernetes/views/nodes-page.html:3
+msgid "Delete Selected"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:3
+msgid "Delete image stream"
+msgstr ""
+
+#: pkg/playground/translate.html:184 pkg/kubernetes/views/item-delete.html:3
+msgid "Delete {{ item.kind }}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
+msgid "Deleting $target"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2156
+msgid "Deleting <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:7
+msgid ""
+"Deleting a Pod will kill all associated containers. Pods may be "
+"automatically created again in some cases."
+msgstr ""
+
+#: pkg/storaged/details.js:631
+msgid "Deleting a RAID device will erase all data on it."
+msgstr ""
+
+#: pkg/docker/containers-view.jsx:167 pkg/docker/details.js:272
+msgid "Deleting a container will erase all data in it."
+msgstr "Brisanjem svih spremnika ćete izbrisati sve podatke u njima."
+
+#: pkg/storaged/details.js:1009
+msgid "Deleting a logical volume will delete all data in it."
+msgstr ""
+
+#: pkg/storaged/details.js:1012
+msgid "Deleting a partition will delete all data in it."
+msgstr ""
+
+#: pkg/storaged/details.js:826
+msgid "Deleting a volume group will erase all data on it."
+msgstr ""
+
+#: pkg/docker/image.js:152
+msgid ""
+"Deleting an image will delete it, but you can probably download it again if "
+"you need it later.  Unless this image has never been pushed to a repository, "
+"that is, in which case you probably can't download it again."
+msgstr ""
+
+#: pkg/storaged/jobs.js:152
+msgid "Deleting volume group $target"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:131
+#: pkg/kubernetes/views/deploy.html:62
+msgid "Deploy"
+msgstr ""
+
+#: pkg/kubernetes/views/deploy.html:3
+msgid "Deploy Application"
+msgstr "Stavi aplikaciju u pogon"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:22
+msgid "Deployment Causes"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-panel.html:8
+#: pkg/kubernetes/views/deploymentconfig-page.html:12
+msgid "Deployment Config"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:98
+msgid "Deployment Configs"
+msgstr ""
+
+#: pkg/systemd/services.html:356 pkg/kubernetes/views/project-modify.html:40
+#: pkg/kubernetes/views/image-body.html:6
+#: pkg/kubernetes/views/project-listing.html:15
+#: pkg/kubernetes/views/project-listing.html:54
+msgid "Description"
+msgstr ""
+
+#: pkg/shell/index.html:197 pkg/kubernetes/index.html:63
+msgid "Details"
+msgstr ""
+
+#: pkg/storaged/index.html:543
+#, fuzzy
+msgctxt "storage"
+msgid "Device"
+msgstr "RAID uređaj $0"
+
+#: pkg/storaged/details.js:91
+msgid "Device $0 is a member of RAID Array $1"
+msgstr "Uređaj $0 je član RAID niza $1"
+
+#: pkg/storaged/details.js:97
+msgid "Device $0 is a physical volume of $1"
+msgstr ""
+
+#: pkg/storaged/details.js:85
+msgid "Device $0 is mounted on $1"
+msgstr ""
+
+#: pkg/storaged/index.html:467 pkg/storaged/index.html:473
+#: pkg/storaged/index.html:515
+#, fuzzy
+msgctxt "storage"
+msgid "Device File"
+msgstr "Korisničko ime"
+
+#: pkg/sosreport/index.html:22
+msgid "Diagnostic reports"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:20
+msgid "Digest"
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:7
+#: pkg/kubernetes/views/volume-body.html:28
+msgid "Directory"
+msgstr ""
+
+#: pkg/systemd/init.js:543
+msgid "Disable"
+msgstr ""
+
+#: pkg/tuned/dialog.js:234
+msgid "Disable tuned"
+msgstr ""
+
+#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
+msgid "Disabled"
+msgstr "Onemogućen"
+
+#: pkg/shell/simple.html:120
+msgid "Disconnected"
+msgstr "Nepovezan"
+
+#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+#, fuzzy
+msgid "Disk"
+msgstr "Tvrdi disk"
+
+#: pkg/dashboard/index.html:73
+#, fuzzy
+msgid "Disk I/O"
+msgstr "Tvrdi disk"
+
+#: pkg/kubernetes/scripts/nodes.js:720
+msgid "Disk Utilization: $0%"
+msgstr ""
+
+#: pkg/storaged/index.html:457
+msgid "Disk is OK"
+msgstr ""
+
+#: pkg/storaged/index.html:584
+msgid "Disks"
+msgstr ""
+
+#: pkg/shell/simple.html:37 pkg/shell/simple.html:97 pkg/shell/index.html:37
+#: pkg/shell/index.html:118 pkg/shell/stub.html:37 pkg/shell/stub.html:111
+msgid "Display Language"
+msgstr "Jezik Prikaza"
+
+#: pkg/kubernetes/views/project-modify.html:31
+msgid "Display name"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:5
+msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:5
+msgid ""
+"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}' image stream?"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:6
+msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:6
+msgid ""
+"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:6
+msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:7
+msgid "Do you want to delete this Node?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:5
+msgid ""
+"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+"{{stream.metadata.name}}:{{tag.tag}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/remove-role-dialog.html:5
+msgid ""
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:11
+msgid "Docker Version"
+msgstr ""
+
+#: pkg/docker/index.html:60
+msgid "Docker is not installed or activated on the system"
+msgstr "Docker nije instaliran ili pokrenut na sustavu"
+
+#: pkg/systemd/index.html:107
+msgid "Domain"
+msgstr ""
 
 #: pkg/realmd/operation.js:148
 msgid "Domain $0 could not be contacted"
@@ -1939,145 +2053,2457 @@ msgstr "Domenu $0 nije moguće kontaktirati"
 msgid "Domain $0 is not supported"
 msgstr ""
 
-#: pkg/realmd/operation.js:347
-msgid "Joining this domain is not supported"
+#: pkg/realmd/operation.html:11
+msgid "Domain Address"
+msgstr "Domenska Adresa"
+
+#: pkg/realmd/operation.html:59
+msgid "Domain Administrator Name"
+msgstr "Naziv Domenskog Administratora"
+
+#: pkg/realmd/operation.html:65
+msgid "Domain Administrator Password"
+msgstr "Lozinka Domenskog Administratora"
+
+#: pkg/systemd/services.html:426 pkg/systemd/services.html:430
+msgid "Don't Repeat"
 msgstr ""
 
-#: pkg/realmd/operation.js:366
-msgid "More"
-msgstr "Više"
+#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
+msgid "Don't overwrite existing data"
+msgstr "Ne piši preko postojećih podataka"
 
-#: pkg/realmd/operation.js:417
-msgid "Cannot join a domain because realmd is not available on this system"
-msgstr "Nije moguće pristupiti domeni jer realmd nije dostupan na ovom sustavu"
-
-#: pkg/realmd/operation.js:436
-msgid "The user <b>$0</b> is not permitted to modify realms"
-msgstr "Korisniku <b>$0</b> nije dozvoljeno da preinači oblasti"
-
-#: pkg/realmd/operation.js:453
-msgid "Join Domain"
-msgstr "Pridruživanje domeni"
-
-#: pkg/docker/run.js:246 pkg/docker/util.js:102
-#: pkg/networkmanager/interfaces.js:2280 pkg/kubernetes/scripts/volumes.js:992
-#: pkg/docker/index.html.h:46
-msgid "No"
-msgstr "Ne"
-
-#: pkg/docker/run.js:261 pkg/docker/console.html.h:1
-#: pkg/kubernetes/views/image-panel.html.h:2
-#: pkg/kubernetes/views/container-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:1
-#: pkg/kubernetes/views/image-page.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:1
-msgid "Container"
-msgstr "Spremnik"
-
-#: pkg/docker/run.js:263 pkg/kubernetes/views/route-modify.html.h:2
-#: pkg/kubernetes/views/route-body.html.h:4
-#: pkg/kubernetes/views/details-page.html.h:12
-msgid "Host"
+#: pkg/sosreport/index.html:74
+msgid "Done!"
 msgstr ""
 
-#: pkg/docker/run.js:283
-msgid "Invalid port"
-msgstr "Nepravilan port"
+#: pkg/ostree/index.html:127 pkg/ostree/index.html:158
+msgid "Downgrades"
+msgstr ""
 
-#: pkg/docker/run.js:293
-msgid "Duplicate port"
-msgstr "Dupliciran port"
+#: pkg/storaged/index.html:411
+msgid "Drive"
+msgstr ""
 
-#: pkg/docker/run.js:332
+#: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
+msgctxt "storage"
+msgid "Drive"
+msgstr "Pogon"
+
+#: pkg/kubernetes/views/volume-body.html:128
 #, fuzzy
-msgid "Command can't be empty"
-msgstr "Lozinka(fraza) ne može biti prazna"
+msgid "Driver"
+msgstr "Pogon"
 
-#: pkg/docker/run.js:350
-msgid "No alias specified"
-msgstr "Alias nije naveden"
+#: pkg/storaged/index.html:166
+msgid "Drives"
+msgstr ""
 
 #: pkg/docker/run.js:360
 msgid "Duplicate alias"
 msgstr ""
 
-#: pkg/docker/run.js:384
-msgid "No container specified"
-msgstr "Nijedan spremnik nije naveden"
+#: pkg/docker/run.js:293
+msgid "Duplicate port"
+msgstr "Dupliciran port"
 
-#: pkg/docker/details.js:47 pkg/docker/image.js:43
-msgctxt "page-title"
-msgid "Containers"
-msgstr "Spremnici"
-
-#: pkg/docker/details.js:144
-msgid "${hip}:${hport} -> $cport"
-msgstr "${hip}:${hport} -> $cport"
-
-#: pkg/docker/details.js:272 pkg/docker/containers-view.jsx:167
-msgid "Deleting a container will erase all data in it."
-msgstr "Brisanjem svih spremnika ćete izbrisati sve podatke u njima."
-
-#: pkg/docker/storage.jsx:156
-#, fuzzy
-msgid "Solid-State Disk"
-msgstr "SSD disk"
-
-#: pkg/docker/storage.jsx:157
-#, fuzzy
-msgid "Hard Disk"
-msgstr "Tvrdi disk"
-
-#: pkg/docker/storage.jsx:158 pkg/storaged/index.html.h:33
-msgid "Drive"
+#: pkg/storaged/jobs.js:120
+msgid "Ejecting $target"
 msgstr ""
 
-#: pkg/docker/storage.jsx:188
-msgid "Local Disks"
+#: pkg/playground/translate.html:58
+msgid "Empty"
 msgstr ""
 
-#: pkg/docker/storage.jsx:194
-msgid "No additional local storage found."
+#: pkg/playground/translate.html:63
+msgctxt "verb"
+msgid "Empty"
 msgstr ""
 
-#: pkg/docker/storage.jsx:242
-msgid " (shared with the OS)"
+#: pkg/kubernetes/scripts/volumes.js:196
+msgid "Empty Directory"
 msgstr ""
 
-#: pkg/docker/storage.jsx:282
-msgid "Information about the Docker storage pool is not available."
+#: pkg/storaged/jobs.js:155
+msgid "Emptying $target"
 msgstr ""
 
-#: pkg/docker/storage.jsx:314
-msgid "Total"
+#: pkg/systemd/init.js:541
+msgid "Enable"
 msgstr ""
 
-#: pkg/docker/storage.jsx:348
-msgid "Reformat and add disks"
+#: pkg/systemd/init.js:542
+msgid "Enable Forcefully"
 msgstr ""
 
-#: pkg/docker/storage.jsx:355
-msgid ""
-"The storage pool will be reset to optimize its layout.  All containers will "
-"be erased."
+#: pkg/systemd/init.js:301
+msgid "Enabled"
+msgstr ""
+
+#: pkg/storaged/details.js:1247
+msgctxt "storage-id-desc"
+msgid "Encrypted"
+msgstr ""
+
+#: pkg/storaged/details.js:180
+msgid "Encrypted EXT4 (LUKS)"
+msgstr "Šifrirani EXT4 (LUKS)"
+
+#: pkg/storaged/details.js:179
+msgid "Encrypted XFS (LUKS)"
+msgstr "Šifrirani XFS (LUKS)"
+
+#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
+#: pkg/storaged/details.js:1115
+msgid "Encryption Options"
+msgstr "Opcije šifriranja"
+
+#: pkg/kubernetes/views/pv-modify.html:93
+msgid "Endpoint"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:40
+msgid "Endpoint Name"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:14
+#: pkg/kubernetes/views/service-panel.html:9
+msgid "Endpoints"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:38
+msgid "Ends"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:332
+msgid "Enforce policy:"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:447
+msgid "Enter IP address or host name"
+msgstr "Unesite IP adresu ili ime računala"
+
+#: pkg/systemd/logs.html:60
+msgid "Entry"
+msgstr ""
+
+#: pkg/docker/index.html:547 pkg/kubernetes/views/image-config.html:17
+#: pkg/kubernetes/views/container-body.html:26
+msgid "Environment"
+msgstr ""
+
+#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
+msgid "Erase"
+msgstr "Izbriši"
+
+#: pkg/docker/storage.jsx:423
+msgid "Erase containers and reset storage pool"
 msgstr ""
 
 #: pkg/docker/storage.jsx:360
 msgid "Erase containers, reformat disks, and add them"
 msgstr ""
 
-#: pkg/docker/storage.jsx:363
-msgid "Add Additional Storage"
+#: pkg/storaged/jobs.js:129
+msgid "Erasing $target"
 msgstr ""
 
-#: pkg/docker/storage.jsx:366
+#: pkg/systemd/services.html:318 pkg/playground/translate.html:101
+#: pkg/playground/translate.html:106
+msgid "Error"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:650
+msgid "Error getting certificate details: $0"
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:13
+msgid "Error loading users: {{perm_failed}}"
+msgstr ""
+
+#: pkg/docker/util.js:491
+msgid "Error message from Docker:"
+msgstr "Poruka greške od Docker-a:"
+
+#: pkg/users/authorized-keys.js:115
+msgid "Error saving authorized keys: "
+msgstr ""
+
+#: pkg/selinux/setroubleshoot.js:275
+#, fuzzy
+msgid "Error while connecting."
+msgstr "Greška prilikom preuzimanja"
+
+#: pkg/selinux/setroubleshoot-client.js:192
+msgid "Error while deleting alert"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot.js:65
+msgid "Error while setting SELinux mode: '$0'"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:88
+msgid "Error writing kubectl config"
+msgstr ""
+
+#: pkg/systemd/logs.html:47
+msgid "Errors"
+msgstr ""
+
+#: pkg/networkmanager/index.html:764
+msgid "Ethernet MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1854
+msgid "Ethtool"
+msgstr ""
+
+#: pkg/users/local.js:429 pkg/users/local.js:1104
+msgid "Excellent password"
+msgstr ""
+
+#: pkg/docker/util.js:96
+msgid "Exited $ExitCode"
+msgstr ""
+
+#: pkg/docker/index.html:529
+msgid "Expose container ports"
+msgstr ""
+
+#: pkg/storaged/details.js:183
+msgid "Extended Partition"
+msgstr "Proširena particija"
+
+#: pkg/storaged/details.js:1592
+msgid "FAILED"
+msgstr ""
+
+#: pkg/ostree/index.html:92
+msgid "Failed"
+msgstr "Neuspjelo"
+
+#: pkg/lib/machine-dialogs.js:412
+msgid "Failed to add machine: $0"
+msgstr ""
+
+#: pkg/users/local.js:112 pkg/users/local.js:144 pkg/lib/credentials.js:223
+msgid "Failed to change password"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:187
+msgid "Failed to delete alert"
+msgstr ""
+
+#: pkg/tuned/dialog.js:171
+#, fuzzy
+msgid "Failed to disable tuned"
+msgstr "Pokretanje Docker-a neuspjelo: $0"
+
+#: pkg/tuned/dialog.js:133
+#, fuzzy
+msgid "Failed to disable tuned profile"
+msgstr "Pokretanje Docker-a neuspjelo: $0"
+
+#: pkg/lib/machine-dialogs.js:494
+msgid "Failed to edit machine: $0"
+msgstr ""
+
+#: pkg/tuned/dialog.js:169
+msgid "Failed to enable tuned"
+msgstr ""
+
+#: pkg/users/index.html:338
+msgid "Failed to load authorized keys."
+msgstr ""
+
+#: pkg/docker/containers.js:64
+msgid "Failed to start Docker: $0"
+msgstr "Pokretanje Docker-a neuspjelo: $0"
+
+#: pkg/docker/util.js:544
+msgid "Failed to stop Docker scope: $0"
+msgstr ""
+
+#: pkg/tuned/dialog.js:145
+#, fuzzy
+msgid "Failed to switch profile"
+msgstr "Pokretanje Docker-a neuspjelo: $0"
+
+#: pkg/kubernetes/scripts/volumes.js:204
+msgid "Fibre Channel"
+msgstr ""
+
+#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
+msgid "Filesystem Options"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:180
+#: pkg/kubernetes/views/volume-body.html:6
+#: pkg/kubernetes/views/volume-body.html:16
+#: pkg/kubernetes/views/volume-body.html:62
+#: pkg/kubernetes/views/volume-body.html:83
+#: pkg/kubernetes/views/volume-body.html:91
+#: pkg/kubernetes/views/volume-body.html:120
+#: pkg/kubernetes/views/volume-body.html:132
+msgid "Filesystem Type"
+msgstr ""
+
+#: pkg/storaged/details.js:215
+msgid "Filesystem type"
+msgstr ""
+
+#: pkg/storaged/index.html:225
+msgid "Filesystems"
+msgstr ""
+
+#: pkg/lib/machine-unknown-hostkey.html:10
+msgid "Fingerprint"
+msgstr ""
+
+#: pkg/storaged/index.html:426
+#, fuzzy
+msgctxt "storage"
+msgid "Firmware Version"
+msgstr "Inačica"
+
+#: pkg/kubernetes/scripts/volumes.js:206
+msgid "Flex"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:205
+msgid "Flocker"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:125
+msgid "Flocker Dataset Name"
+msgstr ""
+
+#: pkg/docker/util.js:503
+msgid "Force Delete"
+msgstr "Prisilno brisanje"
+
+#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
+#: pkg/storaged/details.js:1142
+msgid "Format"
+msgstr ""
+
+#: pkg/storaged/details.js:115
+msgid "Format $0"
+msgstr "Format $0"
+
+#: pkg/storaged/details.js:335
+msgid "Format Disk $0"
+msgstr ""
+
+#: pkg/storaged/details.js:358
+msgid "Formatting a disk will erase all data on it."
+msgstr ""
+
+#: pkg/storaged/details.js:268
+msgid "Formatting a storage device will erase all data on it."
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2577
+msgid "Forward delay $forward_delay"
+msgstr "Odgoda prosljeđivanja $forward_delay"
+
+#: pkg/systemd/index.html:255
+msgid "Free"
+msgstr ""
+
+#: pkg/users/index.html:86 pkg/users/index.html:148
+msgid "Full Name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:192
+msgid "GCE Persistent Disk"
+msgstr ""
+
+#: pkg/docker/index.html:180
+msgid "Gateway:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2628
+msgid "General"
+msgstr "Općenito"
+
+#: pkg/sosreport/index.html:66
+msgid "Generating report"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:194
+#, fuzzy
+msgid "Git Repository"
+msgstr "Repozitorij"
+
+#: pkg/kubernetes/scripts/volumes.js:198
+msgid "Gluster FS"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:872
+msgid "GlusterFS"
+msgstr ""
+
+#: pkg/systemd/logs.js:130
+msgid "Go to"
+msgstr ""
+
+#: pkg/storaged/index.html:307 pkg/networkmanager/index.html:50
+#: pkg/networkmanager/index.html:496
+msgid "Go to now"
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:21
+#: pkg/kubernetes/views/group-panel.html:12
+#, fuzzy
+msgid "Group Members"
+msgstr "Članovi"
+
+#: pkg/kubernetes/views/project-listing.html:48
+#: pkg/kubernetes/views/user-delete.html:14
+msgid "Groups"
+msgstr ""
+
+#: pkg/networkmanager/index.html:268
+msgid "Hair Pin mode"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2603
+msgid "Hairpin mode"
+msgstr ""
+
+#: pkg/docker/storage.jsx:157
+#, fuzzy
+msgid "Hard Disk"
+msgstr "Tvrdi disk"
+
+#: pkg/storaged/overview.js:180
+msgctxt "storage"
+msgid "Hard Disk"
+msgstr "Tvrdi disk"
+
+#: pkg/systemd/index.html:77
+msgid "Hardware"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2579
+msgid "Hello time $hello_time"
+msgstr "Hello vrijeme $hello_time"
+
+#: pkg/kubernetes/views/details-page.html:73
+#: pkg/kubernetes/views/route-body.html:9
+#: pkg/kubernetes/views/route-modify.html:8
+msgid "Host"
+msgstr ""
+
+#: pkg/systemd/index.html:102 pkg/dashboard/index.html:151
+msgid "Host Name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
+msgid "Host Path"
+msgstr ""
+
+#: src/base1/cockpit.js:3699
+msgid "Host key is incorrect"
+msgstr ""
+
+#: pkg/systemd/services.html:442
+msgid "Hour : Minute"
+msgstr ""
+
+#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
+msgid "Hour needs to be a number between 0-23"
+msgstr ""
+
+#: pkg/systemd/services.html:408
+#, fuzzy
+msgid "Hours"
+msgstr "6 sati"
+
+#: pkg/systemd/index.html:221
+msgid "I/O Wait"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
+msgid "IP"
+msgstr ""
+
+#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
+msgid "IP Address"
+msgstr "IP adresa"
+
+#: pkg/docker/index.html:172
+#, fuzzy
+msgid "IP Address:"
+msgstr "IP adresa"
+
+#: pkg/docker/index.html:176
+#, fuzzy
+msgid "IP Prefix Length:"
+msgstr "Prefiks"
+
+#: pkg/networkmanager/index.html:568
+msgid "IP Settings"
+msgstr "IP postavke"
+
+#: pkg/networkmanager/interfaces.js:2641
+msgid "IPv4"
+msgstr "IPv4"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv4 Settings"
+msgstr "IPv4 Postavke"
+
+#: pkg/networkmanager/interfaces.js:2642
+msgid "IPv6"
+msgstr "IPv6"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv6 Settings"
+msgstr "IPv6 Postavke"
+
+#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
+msgid "ISCSI"
+msgstr ""
+
+#: pkg/systemd/init.js:270
+msgid "Id"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2620
+msgid "Id $id"
+msgstr "Id $id"
+
+#: pkg/kubernetes/views/image-body.html:22
+msgid "Identifier"
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:23
+#: pkg/kubernetes/views/user-panel.html:18
+msgid "Identities"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:91
+msgid "Identity"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1817
+msgid "Ignore"
+msgstr "Ignoriraj"
+
+#: pkg/docker/index.html:452 pkg/kubernetes/views/image-panel.html:9
+#: pkg/kubernetes/views/container-body.html:6
+#: pkg/kubernetes/views/image-page.html:16
+msgid "Image"
+msgstr ""
+
+#: pkg/docker/image.js:77
+msgid "Image $0"
+msgstr "Preslika $0"
+
+#: pkg/kubernetes/views/container-body.html:8
+msgid "Image ID"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:16
+#, fuzzy
+msgid "Image Layers"
+msgstr "Preslika $0"
+
+#: pkg/kubernetes/views/volume-body.html:58
+#, fuzzy
+msgid "Image Name"
+msgstr "Preslika $0"
+
+#: pkg/kubernetes/registry.html:23
+msgid "Image Registry"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-page.html:16
+msgid "Image Stream"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:135
+#, fuzzy
+msgid "Image commands"
+msgstr "Preslika $0"
+
+#: pkg/kubernetes/views/imagestream-body.html:34
+msgid "Image count"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:48
+#: pkg/kubernetes/views/registry-dashboard-page.html:19
+#: pkg/kubernetes/views/imagestream-page.html:18
+#: pkg/kubernetes/views/image-listing.html:9 pkg/kubernetes/index.html:77
+msgid "Images"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:17
+msgid "Images by project"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:54
+msgid "Images pushed recently"
+msgstr ""
+
+#: pkg/storaged/details.js:1593
+msgid "In Sync"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:81
 msgid ""
-"All data on selected disks will be erased and disks will be added to the "
-"storage pool."
+"In order to begin pushing images to the registry, use the commands below."
 msgstr ""
 
-#: pkg/docker/storage.jsx:404
-msgid "Could not add all disks"
+#: pkg/kubernetes/views/registry-dashboard-page.html:6
+msgid ""
+"In order to begin pushing images to the registry, you need to create a "
+"project."
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:50
+msgid ""
+"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
+"strong}}.        {{/needs_root}}                                    User "
+"name                                                                            "
+"{{#allows_password}}                            "
+"Password                                                                            "
+"{{/allows_password}}            "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
+#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
+msgid "Inactive"
+msgstr "Neaktivan"
+
+#: pkg/lib/machine-invalid-hostkey.html:2
+msgid "Incorrect Host Key"
+msgstr ""
+
+#: pkg/docker/storage.jsx:282
+msgid "Information about the Docker storage pool is not available."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:222
+msgid "Installed products"
+msgstr ""
+
+#: pkg/systemd/services.html:135
+msgid "Instantiate"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:169
+#: pkg/kubernetes/views/volume-body.html:81
+#, fuzzy
+msgid "Interface"
+msgstr "Sučelja"
+
+#: pkg/networkmanager/index.html:84
+msgid "Interfaces"
+msgstr "Sučelja"
+
+#: src/base1/cockpit.js:3701
+msgid "Internal error"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:196
+#, fuzzy
+msgid "Invalid credentials"
+msgstr "Nepravilan port"
+
+#: pkg/systemd/host.js:1194
+msgid "Invalid date format"
+msgstr ""
+
+#: pkg/systemd/host.js:1190
+msgid "Invalid date format and invalid time format"
+msgstr ""
+
+#: pkg/systemd/init.js:1218
+#, fuzzy
+msgid "Invalid date format."
+msgstr "Nepravilan port"
+
+#: pkg/lib/credentials.js:274
+msgid "Invalid file permissions"
+msgstr ""
+
+#: pkg/users/index.html:322
+msgid "Invalid key"
+msgstr ""
+
+#: pkg/systemd/init.js:1169
+#, fuzzy
+msgid "Invalid number."
+msgstr "Nepravilan port"
+
+#: pkg/docker/run.js:283
+msgid "Invalid port"
+msgstr "Nepravilan port"
+
+#: pkg/systemd/host.js:1192
+msgid "Invalid time format"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:194 pkg/storaged/overview.js:577
+#: pkg/storaged/overview.js:668
+msgid "Invalid username or password"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:15
+msgid "Is sshd running on a different port?"
+msgstr ""
+
+#: pkg/systemd/init.js:522
+msgid "Isolate"
+msgstr ""
+
+#: pkg/storaged/index.html:280
+msgid "Jobs"
+msgstr ""
+
+#: pkg/realmd/operation.js:96
+msgid "Join"
+msgstr "Pridruživanje"
+
+#: pkg/realmd/operation.js:453
+msgid "Join Domain"
+msgstr "Pridruživanje domeni"
+
+#: pkg/realmd/operation.js:347
+msgid "Joining this domain is not supported"
+msgstr ""
+
+#: pkg/systemd/logs.js:257
+msgid "Journal entry"
+msgstr ""
+
+#: pkg/systemd/logs.js:284
+msgid "Journal entry not found"
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:10
+msgid "Kerberos Based SSO"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:69
+msgid "Kerberos Ticket"
+msgstr ""
+
+#: pkg/systemd/index.html:225
+msgid "Kernel"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:19
+#, fuzzy
+msgid "Kernel Version"
+msgstr "Inačica"
+
+#: pkg/kubernetes/views/volume-body.html:67
+msgid "Key Ring Path"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:23
+msgid "Kubelet Version"
+msgstr ""
+
+#: pkg/kubernetes/index.html:23
+msgid "Kubernetes Cluster"
+msgstr ""
+
+#: pkg/networkmanager/index.html:473
+msgid "LACP Key"
+msgstr ""
+
+#: pkg/storaged/details.js:1245
+msgctxt "storage-id-desc"
+msgid "LUKS Encrypted"
+msgstr ""
+
+#: pkg/storaged/details.js:1226
+msgctxt "storage-id-desc"
+msgid "LVM2 Physical Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/replicationcontroller-body.html:17
+#: pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/route-body.html:22
+#: pkg/kubernetes/views/image-meta.html:3
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
+msgid "Labels"
+msgstr ""
+
+#: pkg/systemd/logs.html:42
+msgid "Last 24 hours"
+msgstr ""
+
+#: pkg/systemd/logs.html:43
+msgid "Last 7 days"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:49
+msgid "Last Heartbeat"
+msgstr ""
+
+#: pkg/users/index.html:100
+msgid "Last Login"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:51
+msgid "Last Status Change"
+msgstr ""
+
+#: pkg/systemd/init.js:273
+msgid "Last Trigger"
+msgstr ""
+
+#: pkg/kubernetes/views/image-listing.html:16
+msgid "Last Updated"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:107
+msgid "Latest Version"
+msgstr ""
+
+#: pkg/realmd/operation.js:101
+msgid "Leave"
+msgstr "Napusti"
+
+#: pkg/networkmanager/index.html:315
+msgid "Link Monitoring"
+msgstr "Nadziranje veze"
+
+#: pkg/networkmanager/index.html:397
+msgid "Link Watch"
+msgstr ""
+
+#: pkg/networkmanager/index.html:350 pkg/networkmanager/index.html:432
+msgid "Link down delay"
+msgstr "Odgoda gašenja linka"
+
+#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
+msgid "Link local"
+msgstr ""
+
+#: pkg/networkmanager/index.html:341 pkg/networkmanager/index.html:423
+msgid "Link up delay"
+msgstr "Odgoda podizanja linka"
+
+#: pkg/docker/index.html:514
+msgid "Links"
+msgstr "Linkovi"
+
+#: pkg/storaged/details.js:1224
+msgctxt "storage-id-desc"
+msgid "Linux MD-RAID Component"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1841
+msgid "Load Balancing"
+msgstr ""
+
+#: pkg/systemd/logs.js:69
+msgid "Load earlier entries"
+msgstr ""
+
+#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
+#: pkg/systemd/logs.js:175
+msgid "Loading..."
+msgstr ""
+
+#: pkg/users/index.html:23
+msgid "Local Accounts"
+msgstr ""
+
+#: pkg/docker/storage.jsx:188
+msgid "Local Disks"
+msgstr ""
+
+#: pkg/storaged/details.js:1109
+msgid "Lock"
+msgstr ""
+
+#: pkg/users/index.html:109 pkg/users/index.html:196
+msgid "Lock Account"
+msgstr ""
+
+#: pkg/storaged/jobs.js:122
+msgid "Locking $target"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:80
+msgid "Log In"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:4
+msgid "Log in to {{host}}"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:116
+msgid "Log into OpenShift command line tools:"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:101
+msgid "Log into the registry:"
+msgstr ""
+
+#: pkg/shell/simple.html:45 pkg/shell/index.html:52 pkg/shell/stub.html:45
+msgid "Log out"
+msgstr "Odjavi se"
+
+#: pkg/users/local.js:839
+msgid "Logged In"
+msgstr ""
+
+#: pkg/storaged/details.js:1424
+msgid "Logical Partition"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:158
+#: pkg/kubernetes/views/volume-body.html:79
+#: pkg/kubernetes/views/volume-body.html:118
+msgid "Logical Unit Number"
+msgstr ""
+
+#: pkg/storaged/utils.js:172
+msgid "Logical Volume"
+msgstr ""
+
+#: pkg/storaged/utils.js:170
+msgid "Logical Volume (Snapshot)"
+msgstr ""
+
+#: pkg/storaged/details.js:1792
+msgid "Logical Volumes"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:140
+msgid "Login"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:68
+msgid "Login Password"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:96
+msgid "Login commands"
+msgstr ""
+
+#: src/base1/cockpit.js:3693
+msgid "Login failed"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:200
+msgid "Login/password or activation key required to register."
+msgstr ""
+
+#: pkg/systemd/logs.html:59 pkg/kubernetes/views/container-panel.html:6
+#: pkg/kubernetes/views/container-page-inline.html:8
+msgid "Logs"
+msgstr ""
+
+#: pkg/dashboard/index.html:110
+msgid "Lost connection. Trying to reconnect"
+msgstr "Veza prekinuta.  Pokušavam ponovo uspostaviti vezu"
+
+#: pkg/docker/index.html:184
+#, fuzzy
+msgid "MAC Address:"
+msgstr "Adresa"
+
+#: pkg/networkmanager/interfaces.js:1833
+msgid "MII (Recommended)"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2477
+msgid "MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:4139
+#, fuzzy
+msgid "MTU must be a positive number"
+msgstr "Veličina mora biti specificirana."
+
+#: pkg/systemd/index.html:85 pkg/kubernetes/views/node-body.html:15
+msgid "Machine ID"
+msgstr ""
+
+#: pkg/systemd/index.html:282
+msgid "Machine SSH Key Fingerprints"
+msgstr ""
+
+#: pkg/shell/indexes.js:253
+msgid "Machines"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:460
+msgid "Manifest"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
+msgid "Manual"
+msgstr "Ručno"
+
+#: pkg/systemd/index.html:401 pkg/systemd/index.html:405
+#, fuzzy
+msgid "Manually"
+msgstr "Ručno"
+
+#: pkg/storaged/jobs.js:140
+msgid "Marking $target as faulty"
+msgstr ""
+
+#: pkg/systemd/init.js:546
+msgid "Mask"
+msgstr ""
+
+#: pkg/systemd/init.js:547
+msgid "Mask Forcefully"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2483
+msgid "Master"
+msgstr "Glavni"
+
+#: pkg/networkmanager/interfaces.js:2581
+msgid "Maximum message age $max_age"
+msgstr "Maksimalna starost poruke $max_age"
+
+#: pkg/kubernetes/views/volume-body.html:34
+msgid "Medium"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:92
+msgid "Member of"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:16
+#: pkg/kubernetes/views/project-listing.html:55
+#: pkg/networkmanager/index.html:291
+msgid "Members"
+msgstr "Članovi"
+
+#: pkg/kubernetes/views/project-page.html:29
+#: pkg/kubernetes/views/user-panel.html:11
+#: pkg/kubernetes/views/user-panel.html:27
+#: pkg/kubernetes/views/user-body.html:4
+msgid "Membership"
+msgstr ""
+
+#: pkg/dashboard/index.html:71 pkg/playground/translate.html:91
+msgid "Memory"
+msgstr "Memorija"
+
+#: pkg/systemd/host.js:1466
+msgctxt "page-title"
+msgid "Memory"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:716
+msgid "Memory Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:473 pkg/docker/index.html:652
+msgid "Memory limit"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
+msgid "Message"
+msgstr ""
+
+#: pkg/systemd/host.js:1300
+msgid "Message to logged in users"
+msgstr ""
+
+#: pkg/kubernetes/views/image-panel.html:15
+#: pkg/kubernetes/views/imagestream-page.html:21
+#: pkg/kubernetes/views/image-page.html:22
+msgid "Metadata"
+msgstr ""
+
+#: pkg/docker/index.html:487 pkg/docker/index.html:666
+msgid "MiB"
+msgstr ""
+
+#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
+msgid "Minute needs to be a number between 0-59"
+msgstr ""
+
+#: pkg/systemd/services.html:407
+#, fuzzy
+msgid "Minutes"
+msgstr "5 minuta"
+
+#: pkg/networkmanager/index.html:299
+msgid "Mode"
+msgstr "Način"
+
+#: pkg/storaged/index.html:421
+#, fuzzy
+msgctxt "storage"
+msgid "Model"
+msgstr "Način"
+
+#: pkg/kubernetes/views/user-modify.html:31
+msgid "Modify"
+msgstr ""
+
+#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
+msgid "Modifying $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:323
+msgid "Monitoring Interval"
+msgstr "Interval nadziranja"
+
+#: pkg/networkmanager/index.html:332
+msgid "Monitoring Targets"
+msgstr "Mete nadziranja"
+
+#: pkg/kubernetes/views/volume-body.html:54
+#, fuzzy
+msgid "Monitors"
+msgstr "ARP nadziranje"
+
+#: pkg/realmd/operation.js:366
+msgid "More"
+msgstr "Više"
+
+#: pkg/storaged/details.js:1099
+msgid "Mount"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
+#, fuzzy
+msgid "Mount Location"
+msgstr "Točka pristupa"
+
+#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
+msgid "Mount Options"
+msgstr ""
+
+#: pkg/storaged/index.html:231
+msgid "Mount Point"
+msgstr "Točka pristupa"
+
+#: pkg/docker/index.html:540
+msgid "Mount container volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
+msgid "Mounting"
+msgstr "Montiranje"
+
+#: pkg/storaged/jobs.js:126
+msgid "Mounting $target"
+msgstr ""
+
+#: pkg/storaged/index.html:508
+msgctxt "storage"
+msgid "Multipathed Devices"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:860
+#, fuzzy
+msgid "NFS"
+msgstr "DNS"
+
+#: pkg/kubernetes/scripts/volumes.js:199
+msgid "NFS Mount"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1856
+msgid "NSNA Ping"
+msgstr ""
+
+#: pkg/storaged/details.js:182
+msgid "NTFS - Compatible with most systems"
+msgstr "NTFS - Kompatibilan sa većinom sistema"
+
+#: pkg/systemd/host.js:1250
+msgid "NTP Server"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/project-modify.html:16
+#: pkg/kubernetes/views/node-add.html:16
+#: pkg/kubernetes/views/volumes-page.html:19
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/image-body.html:2
+#: pkg/kubernetes/views/imagestream-modify.html:10
+#: pkg/kubernetes/views/service-modify.html:9
+#: pkg/kubernetes/views/dashboard-page.html:156
+#: pkg/kubernetes/views/dashboard-page.html:198
+#: pkg/kubernetes/views/details-page.html:34
+#: pkg/kubernetes/views/details-page.html:70
+#: pkg/kubernetes/views/details-page.html:103
+#: pkg/kubernetes/views/details-page.html:137
+#: pkg/kubernetes/views/details-page.html:171
+#: pkg/kubernetes/views/pv-claim.html:4
+#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/kubernetes/views/project-listing.html:14
+#: pkg/kubernetes/views/project-listing.html:53
+#: pkg/kubernetes/views/project-listing.html:90
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/volume-body.html:31 pkg/storaged/index.html:230
+#: pkg/networkmanager/index.html:95 pkg/networkmanager/index.html:113
+#: pkg/networkmanager/index.html:150 pkg/networkmanager/index.html:183
+#: pkg/networkmanager/index.html:282 pkg/networkmanager/index.html:364
+msgid "Name"
+msgstr "Naziv"
+
+#: pkg/storaged/utils.js:129
+#, fuzzy
+msgid "Name cannot be empty."
+msgstr "Lozinka(fraza) ne može biti prazna"
+
+#: pkg/storaged/utils.js:131
+msgid "Name cannot be longer than 127 characters."
+msgstr ""
+
+#: pkg/storaged/utils.js:135
+msgid "Name cannot contain the character '$0'."
+msgstr ""
+
+#: pkg/storaged/utils.js:137
+msgid "Name cannot contain whitespace."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:5
+#: pkg/kubernetes/views/replicationcontroller-body.html:5
+#: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/pod-body.html:5
+#: pkg/kubernetes/views/dashboard-page.html:160
+#: pkg/kubernetes/views/details-page.html:36
+#: pkg/kubernetes/views/details-page.html:72
+#: pkg/kubernetes/views/details-page.html:105
+#: pkg/kubernetes/views/details-page.html:139
+#: pkg/kubernetes/views/details-page.html:173
+#: pkg/kubernetes/views/pv-claim.html:6
+#: pkg/kubernetes/views/containers-listing.html:14
+#: pkg/kubernetes/views/route-body.html:5
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
+msgid "Namespace"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:374
+msgid "Namespace cannot be empty."
+msgstr ""
+
+#: pkg/systemd/host.js:1113
+msgid "Need at least one NTP server"
+msgstr ""
+
+#: pkg/dashboard/index.html:72 pkg/playground/translate.html:96
+msgid "Network"
+msgstr "Mreža"
+
+#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:485
+msgid "Networking"
+msgstr "Mreža"
+
+#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
+msgctxt "page-title"
+msgid "Networking"
+msgstr "Mreža"
+
+#: pkg/networkmanager/index.html:124
+msgid "Networking Logs"
+msgstr "Mrežni Logovi"
+
+#: pkg/users/local.js:841
+msgid "Never"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:46
+msgid "New Group"
+msgstr ""
+
+#: pkg/users/index.html:236 pkg/shell/index.html:255
+msgid "New Password"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:7
+msgid "New Project"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/image-listing.html:7
+msgid "New image stream"
+msgstr ""
+
+#: pkg/users/local.js:120 pkg/lib/credentials.js:231
+msgid "New password was not accepted"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:4
+#: pkg/kubernetes/views/registry-dashboard-page.html:9
+#: pkg/kubernetes/views/registry-dashboard-page.html:48
+msgid "New project"
+msgstr ""
+
+#: pkg/realmd/operation.html:91
+msgid "Next"
+msgstr "Sljedeće"
+
+#: pkg/systemd/init.js:272
+#, fuzzy
+msgid "Next Run"
+msgstr "Sljedeće"
+
+#: pkg/systemd/index.html:233
+msgid "Nice"
+msgstr ""
+
+#: pkg/docker/index.html:563 pkg/docker/index.html:567
+msgid "No"
+msgstr "Ne"
+
+#: pkg/systemd/index.html:469
+msgid "No Delay"
+msgstr ""
+
+#: pkg/ostree/index.html:220
+msgid "No Deployments"
+msgstr ""
+
+#: pkg/storaged/details.js:185
+msgid "No Filesystem"
+msgstr ""
+
+#: pkg/ostree/app.js:101
+msgid "No OSTree deployments found"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:398
+msgid "No PEM-encoded certificate found"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:364
+msgid "No PEM-encoded private key found"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:39
+msgid "No Pods are using this claim"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:479
+msgid "No SELinux alerts."
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:10
+msgid "No Volume Bound"
+msgstr ""
+
+#: pkg/docker/storage.jsx:194
+msgid "No additional local storage found."
+msgstr ""
+
+#: pkg/docker/run.js:350
+msgid "No alias specified"
+msgstr "Alias nije naveden"
+
+#: pkg/sosreport/index.js:115
+msgid "No archive has been created."
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1326
+msgid "No carrier"
+msgstr ""
+
+#: pkg/docker/run.js:384
+msgid "No container specified"
+msgstr "Nijedan spremnik nije naveden"
+
+#: pkg/storaged/index.html:193
+msgid "No drives attached"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:74
+msgid "No groups are present."
+msgstr ""
+
+#: pkg/systemd/index.html:28
+#, fuzzy
+msgid "No host keys found."
+msgstr "Nije pronađeno"
+
+#: pkg/storaged/index.html:158
+msgid "No iSCSI targets set up"
+msgstr ""
+
+#: pkg/kubernetes/views/image-listing.html:70
+msgid "No image streams are present."
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:80
+msgid "No images pushed"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:223
+#, fuzzy
+msgid "No installed products on the system."
+msgstr "Docker nije instaliran ili pokrenut na sustavu"
+
+#: pkg/storaged/index.html:446
+msgid "No media inserted"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:384
+msgid ""
+"No metadata file was selected. Please select a Kubernetes metadata file."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:117
+msgid "No nodes in cluster"
+msgstr ""
+
+#: pkg/storaged/details.js:352
+msgid "No partitioning"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:40
+msgid "No pods deployed"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:6
+msgid "No pods replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/node-capacity.html:11
+msgid "No pods scheduled"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:10
+msgid "No pods selected"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:37
+msgid "No projects are present."
+msgstr ""
+
+#: pkg/users/local.js:405
+msgid "No real name specified"
+msgstr ""
+
+#: pkg/storaged/index.html:87
+msgid "No storage set up as RAID"
+msgstr ""
+
+#: pkg/lib/credentials.js:182
+msgid "No such file or directory"
+msgstr ""
+
+#: pkg/users/local.js:400
+msgid "No user name specified"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:112
+msgid "No users are present."
+msgstr ""
+
+#: pkg/storaged/index.html:120
+msgid "No volume groups created"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:44
+msgid "No volumes are present."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:73
+msgid "No volumes in use"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:18 pkg/kubernetes/views/node-panel.html:7
+#: pkg/kubernetes/views/containers-listing.html:15
+#: pkg/kubernetes/views/node-page.html:14
+#: pkg/kubernetes/views/topology-page.html:41
+msgid "Node"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:192
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:45
+msgid "Nodes"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:42
+msgid "Nodes are the machines that run your containers."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:15
+#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
+#: pkg/kubernetes/views/image-config.html:25
+#: pkg/kubernetes/views/imagestream-body.html:33
+msgid "None"
+msgstr ""
+
+#: pkg/playground/translate.html:30 pkg/kubernetes/views/details-page.html:53
+#: pkg/kubernetes/views/node-body.html:42
+msgid "Not Ready"
+msgstr ""
+
+#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
+msgid "Not a valid number of replicas"
+msgstr ""
+
+#: pkg/lib/credentials.js:248
+msgid "Not a valid private key"
+msgstr ""
+
+#: pkg/kubernetes/scripts/details.js:546
+msgid "Not a valid value for Host"
+msgstr ""
+
+#: pkg/docker/index.html:57
+msgid "Not authorized to access Docker on this system"
+msgstr "Nemate dopuštenje da pristupite Docker-u na ovom sustavu"
+
+#: pkg/ostree/app.js:81
+msgid "Not authorized to update software on this system"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:805
+msgid "Not available"
+msgstr "Nije dostupno"
+
+#: pkg/selinux/setroubleshoot.js:238
+#, fuzzy
+msgid "Not connected"
+msgstr "Nepovezan"
+
+#: pkg/kubernetes/views/details-page.html:122
+msgid "Not deployed"
+msgstr ""
+
+#: pkg/docker/details.js:177 pkg/docker/image.js:112
+#: pkg/storaged/details.js:1822
+msgid "Not found"
+msgstr "Nije pronađeno"
+
+#: src/base1/cockpit.js:3691
+msgid "Not permitted to perform this action."
+msgstr ""
+
+#: pkg/storaged/details.js:1574
+msgid "Not running"
+msgstr ""
+
+#: pkg/systemd/index.html:62
+msgid "Not synchronized"
+msgstr ""
+
+#: pkg/systemd/services.html:299
+msgid "Note"
+msgstr ""
+
+#: pkg/systemd/logs.html:49
+msgid "Notices"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:13
+msgid "OS"
+msgstr ""
+
+#: pkg/ostree/client.js:500
+msgid "OS $0 not found"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:19
+#, fuzzy
+msgid "OS Versions"
+msgstr "Inačica"
+
+#: pkg/ostree/app.js:83
+msgid "OSTree is not available on this system"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:405
+msgid "Occurred $0"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:400
+msgid "Occurred between $0 and $1"
+msgstr ""
+
+#: pkg/systemd/index.html:157 pkg/playground/jquery-patterns.html:95
+#: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:189
+#: pkg/storaged/index.html:565
+msgid "Off"
+msgstr "Isključi"
+
+#: pkg/lib/cockpit-components-dialog.jsx:155
+msgid "Ok"
+msgstr ""
+
+#: pkg/users/index.html:226 pkg/shell/index.html:248
+msgid "Old Password"
+msgstr ""
+
+#: pkg/users/local.js:78 pkg/lib/credentials.js:213
+msgid "Old password not accepted"
+msgstr ""
+
+#: pkg/systemd/index.html:153 pkg/playground/jquery-patterns.html:91
+#: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:185
+#: pkg/storaged/index.html:564
+msgid "On"
+msgstr "Uključi"
+
+#: pkg/kubernetes/views/image-meta.html:7
+msgid "On Build"
+msgstr ""
+
+#: pkg/docker/index.html:568
+#, fuzzy
+msgid "On Failure"
+msgstr "Neuspjelo"
+
+#: pkg/docker/util.js:104
+msgid "On failure, retry $0 time"
+msgid_plural "On failure, retry $0 times"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: pkg/realmd/operation.html:71
+msgid "One Time Password"
+msgstr "Jednokratna Lozinka"
+
+#: pkg/systemd/init.js:1147
+msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
+msgstr ""
+
+#: pkg/shell/simple.html:28 pkg/shell/index.html:28 pkg/shell/stub.html:28
+msgid "Ooops!"
+msgstr "Uuups!"
+
+#: pkg/systemd/index.html:89 pkg/ostree/index.html:111
+#: pkg/kubernetes/views/nodes-page.html:42
+msgid "Operating System"
+msgstr ""
+
+#: pkg/ostree/index.html:186
+msgid "Operating System Updates"
+msgstr ""
+
+#: pkg/storaged/jobs.js:166
+msgid "Operation '$operation' on $target"
+msgstr ""
+
+#: pkg/storaged/overview.js:189
+msgctxt "storage"
+msgid "Optical Drive"
+msgstr "Optički pogon"
+
+#: pkg/kubernetes/views/volume-body.html:130
+msgid "Options"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:176
+msgid "Organization"
+msgstr ""
+
+#: pkg/storaged/details.js:1253
+msgctxt "storage-id-desc"
+msgid "Other Data"
+msgstr ""
+
+#: pkg/storaged/index.html:202
+msgid "Other Devices"
+msgstr ""
+
+#: pkg/docker/index.html:319 pkg/kubernetes/registry.html:42
+#: pkg/kubernetes/index.html:39
+msgid "Overview"
+msgstr ""
+
+#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
+msgid "Overwrite existing data with zeros"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:4
+#, fuzzy
+msgid "PD Name"
+msgstr "Naziv"
+
+#: pkg/ostree/index.html:100
+msgid "Packages"
+msgstr ""
+
+#: pkg/networkmanager/index.html:133
+msgid "Parent"
+msgstr "Roditelj"
+
+#: pkg/networkmanager/interfaces.js:2619
+msgid "Parent $parent"
+msgstr "Roditelj $parent"
+
+#: pkg/networkmanager/interfaces.js:1372
+msgid "Part of "
+msgstr "Dio"
+
+#: pkg/kubernetes/views/volume-body.html:8
+#: pkg/kubernetes/views/volume-body.html:18
+msgid "Partition"
+msgstr ""
+
+#: pkg/storaged/details.js:346
+msgid "Partitioning"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1848
+msgid "Passive"
+msgstr ""
+
+#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
+msgid "Passphrase"
+msgstr "Lozinka(fraza)"
+
+#: pkg/storaged/details.js:224
+#, fuzzy
+msgid "Passphrase cannot be empty"
+msgstr "Lozinka(fraza) ne može biti prazna"
+
+#: pkg/storaged/details.js:232
+msgid "Passphrases do not match"
+msgstr "Lozinke(fraze) se ne podudaraju"
+
+#: pkg/users/index.html:115 pkg/users/index.html:160 pkg/shell/index.html:199
+#: pkg/shell/index.html:212 pkg/kubernetes/views/auth-form.html:105
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+msgid "Password"
+msgstr "Lozinka"
+
+#: pkg/users/local.js:259
+msgid "Password is not acceptable"
+msgstr ""
+
+#: pkg/users/local.js:247
+msgid "Password is too weak"
+msgstr ""
+
+#: pkg/lib/credentials.js:278
+msgid "Password not accepted"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:126
+#: pkg/kubernetes/views/volume-body.html:37
+#: pkg/kubernetes/views/volume-body.html:49
+#: pkg/kubernetes/views/volume-body.html:101
+#, fuzzy
+msgid "Path"
+msgstr "Trošak putanje"
+
+#: pkg/networkmanager/index.html:259
+msgid "Path cost"
+msgstr "Trošak putanje"
+
+#: pkg/networkmanager/interfaces.js:2601
+msgid "Path cost $path_cost"
+msgstr "Trošak putanje $path_cost"
+
+#: pkg/systemd/services.html:56
+msgid "Paths"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:53
+msgid "Pending Volume Claims"
+msgstr ""
+
+#: pkg/systemd/index.html:143
+msgid "Performance Profile"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:14
+msgid "Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:16
+msgid "Phase"
+msgstr ""
+
+#: pkg/storaged/index.html:641
+msgid "Physical Volumes"
+msgstr ""
+
+#: pkg/networkmanager/index.html:405
+#, fuzzy
+msgid "Ping Interval"
+msgstr "Interval nadziranja"
+
+#: pkg/networkmanager/index.html:414
+#, fuzzy
+msgid "Ping Target"
+msgstr "Mete nadziranja"
+
+#: pkg/docker/containers-view.jsx:166 pkg/docker/details.js:271
+#: pkg/docker/image.js:151 pkg/storaged/details.js:625
+#: pkg/storaged/details.js:821 pkg/storaged/details.js:1016
+msgid "Please confirm deletion of $0"
+msgstr "Potvrdite brisanje $0"
+
+#: pkg/docker/util.js:501
+msgid "Please confirm forced deletion of $0"
+msgstr "Potvrdite prisilno brisanje $0"
+
+#: pkg/kubernetes/scripts/dashboard.js:441
+msgid "Please create another namespace for $0 \"$1\""
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:574
+msgid "Please provide a GlusterFS volume name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:554
+msgid "Please provide a username"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:632
+msgid "Please provide a valid NFS server"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:539
+#, fuzzy
+msgid "Please provide a valid address"
+msgstr "Unesite adresu"
+
+#: pkg/kubernetes/scripts/volumes.js:805
+msgid "Please provide a valid filesystem type"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:813
+msgid "Please provide a valid interface"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:797
+msgid "Please provide a valid logical unit number"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:477
+#, fuzzy
+msgid "Please provide a valid name"
+msgstr "Unesite adresu"
+
+#: pkg/kubernetes/scripts/dashboard.js:376
+msgid "Please provide a valid namespace."
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
+msgid "Please provide a valid path"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:789
+msgid "Please provide a valid qualified name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:485
+msgid "Please provide a valid storage capacity."
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:781
+#, fuzzy
+msgid "Please provide a valid target"
+msgstr "Unesite adresu"
+
+#: pkg/kubernetes/scripts/volumes.js:469
+msgid "Please select a valid access mode"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:565
+msgid "Please select a valid endpoint"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:493
+msgid "Please select a valid policy option."
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:397
+msgid "Please type an address"
+msgstr "Unesite adresu"
+
+#: pkg/kubernetes/views/pod-page.html:12
+#: pkg/kubernetes/views/containers-listing.html:12
+#: pkg/kubernetes/views/topology-page.html:14
+msgid "Pod"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:20
+msgid "Pod Address"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:4
+#: pkg/kubernetes/views/service-endpoint.html:9
+msgid "Pod Endpoints"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:4
+msgid "Pod Replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:15
+#: pkg/kubernetes/views/replicationcontroller-pods.html:11
+msgid "Pod Selector"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:17
+#: pkg/kubernetes/views/dashboard-page.html:18
+#: pkg/kubernetes/views/details-page.html:166
+#: pkg/kubernetes/views/pv-claim.html:37
+#: pkg/kubernetes/views/replicationcontroller-panel.html:12
+msgid "Pods"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:15
+msgid ""
+"Pods contain one or more containers that run                together on a "
+"node, containing your application code."
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:60
+#, fuzzy
+msgid "Pool Name"
+msgstr "Naziv"
+
+#: pkg/storaged/utils.js:166
+msgid "Pool for Thin Logical Volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:874
+msgid "Pool for thinly provisioned volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:45
+msgid "Populate"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:23
+msgid "Port"
+msgstr ""
+
+#: pkg/docker/index.html:525 pkg/kubernetes/views/service-body.html:13
+#: pkg/kubernetes/views/image-config.html:23
+#: pkg/kubernetes/views/container-body.html:12
+#: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:373
+msgid "Ports"
+msgstr "Portovi"
+
+#: pkg/systemd/index.html:123
+msgid "Power Options"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length"
+msgstr "Prefiks"
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length or Netmask"
+msgstr "Prefiks ili mrežna maska"
+
+#: pkg/networkmanager/interfaces.js:809
+msgid "Preparing"
+msgstr "Pripremanje"
+
+#: pkg/systemd/init.js:544
+msgid "Preset"
+msgstr ""
+
+#: pkg/systemd/init.js:545
+msgid "Preset Forcefully"
+msgstr ""
+
+#: pkg/systemd/index.html:310
+msgid "Pretty Host Name"
+msgstr ""
+
+#: pkg/networkmanager/index.html:307
+msgid "Primary"
+msgstr "Primarni"
+
+#: pkg/storaged/details.js:1426
+msgid "Primary Partition"
+msgstr ""
+
+#: pkg/networkmanager/index.html:250 pkg/networkmanager/index.html:446
+#: pkg/networkmanager/index.html:464
+msgid "Priority"
+msgstr "Prioritet"
+
+#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
+msgid "Priority $priority"
+msgstr "Prioritet $priority"
+
+#: pkg/subscriptions/subscriptions-view.jsx:33
+msgid "Product ID"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:32
+msgid "Product name"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:4
+#: pkg/kubernetes/views/replicationcontroller-body.html:4
+#: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/imagestream-modify.html:21
+#: pkg/kubernetes/views/pod-body.html:4
+#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/details-page.html:35
+#: pkg/kubernetes/views/details-page.html:71
+#: pkg/kubernetes/views/details-page.html:104
+#: pkg/kubernetes/views/details-page.html:138
+#: pkg/kubernetes/views/details-page.html:172
+#: pkg/kubernetes/views/containers-listing.html:13
+#: pkg/kubernetes/views/route-body.html:4
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
+msgid "Project"
+msgstr "Projekt"
+
+#: pkg/kubernetes/views/project-body.html:20
+msgid "Project Members"
+msgstr ""
+
+#: pkg/kubernetes/views/filter-project.html:5
+msgid "Project:"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:54 pkg/kubernetes/views/group-delete.html:10
+#: pkg/kubernetes/views/project-listing.html:9
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:84
+msgid "Projects"
+msgstr ""
+
+#: pkg/users/local.js:82
+msgid "Prompting via passwd timed out"
+msgstr ""
+
+#: pkg/lib/credentials.js:251
+msgid "Prompting via ssh-add timed out"
+msgstr ""
+
+#: pkg/lib/credentials.js:191
+msgid "Prompting via ssh-keygen timed out"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:125
+msgid "Proxy"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:25
+msgid "Proxy Version"
+msgstr ""
+
+#: pkg/shell/index.html:198 pkg/lib/machine-auth-failed.html:9
+msgid "Public Key"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:150
+msgid "Pull an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:66
+msgid "Pull from"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:31
+msgid "Pull repository"
+msgstr ""
+
+#: pkg/storaged/details.js:869
+msgid "Purpose"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:140
+msgid "Push an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:147
+#: pkg/kubernetes/views/volume-body.html:77
+msgid "Qualified Name"
+msgstr ""
+
+#: pkg/storaged/details.js:1539
+msgid "RAID ($0)"
+msgstr ""
+
+#: pkg/storaged/details.js:1533
+msgid "RAID 0"
+msgstr ""
+
+#: pkg/storaged/overview.js:422
+msgid "RAID 0 (Stripe)"
+msgstr "RAID 0 (Stripe)"
+
+#: pkg/storaged/details.js:1534
+msgid "RAID 1"
+msgstr ""
+
+#: pkg/storaged/overview.js:423
+msgid "RAID 1 (Mirror)"
+msgstr "RAID 1 (Mirror)"
+
+#: pkg/storaged/details.js:1538
+msgid "RAID 10"
+msgstr ""
+
+#: pkg/storaged/overview.js:427
+msgid "RAID 10 (Stripe of Mirrors)"
+msgstr ""
+
+#: pkg/storaged/details.js:1535
+msgid "RAID 4"
+msgstr ""
+
+#: pkg/storaged/overview.js:424
+msgid "RAID 4 (Dedicated Parity)"
+msgstr "RAID 4 (Dedicated Parity)"
+
+#: pkg/storaged/details.js:1536
+msgid "RAID 5"
+msgstr ""
+
+#: pkg/storaged/overview.js:425
+msgid "RAID 5 (Distributed Parity)"
+msgstr "RAID 5 (Distributed Parity)"
+
+#: pkg/storaged/details.js:1537
+msgid "RAID 6"
+msgstr ""
+
+#: pkg/storaged/overview.js:426
+msgid "RAID 6 (Double Distributed Parity)"
+msgstr "RAID 6 (Double Distributed Parity)"
+
+#: pkg/storaged/index.html:537
+msgid "RAID Device"
+msgstr ""
+
+#: pkg/storaged/utils.js:233
+msgid "RAID Device $0"
+msgstr "RAID uređaj $0"
+
+#: pkg/storaged/index.html:65
+msgid "RAID Devices"
+msgstr ""
+
+#: pkg/storaged/overview.js:420
+msgid "RAID Level"
+msgstr "RAID razina"
+
+#: pkg/storaged/index.html:555
+#, fuzzy
+msgctxt "storage"
+msgid "RAID Level"
+msgstr "RAID razina"
+
+#: pkg/storaged/details.js:1228
+msgctxt "storage-id-desc"
+msgid "RAID Member"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:200
+#, fuzzy
+msgid "Rados Block Device"
+msgstr "$0 Blok uređaj"
+
+#: pkg/kubernetes/views/pv-modify.html:194
+#: pkg/kubernetes/views/volume-body.html:10
+#: pkg/kubernetes/views/volume-body.html:20
+#: pkg/kubernetes/views/volume-body.html:44
+#: pkg/kubernetes/views/volume-body.html:51
+#: pkg/kubernetes/views/volume-body.html:71
+#: pkg/kubernetes/views/volume-body.html:85
+#: pkg/kubernetes/views/volume-body.html:93
+#: pkg/kubernetes/views/volume-body.html:110
+#: pkg/kubernetes/views/volume-body.html:122
+#: pkg/kubernetes/views/volume-body.html:136
+#: pkg/kubernetes/views/volume-body.html:143
+#, fuzzy
+msgid "Read Only"
+msgstr "Spreman"
+
+#: pkg/kubernetes/scripts/volumes.js:211
+msgid "Read and write from a single node"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:213
+msgid "Read and write from multiple nodes"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:212
+msgid "Read only from multiple nodes"
+msgstr ""
+
+#: pkg/docker/index.html:385
+#, fuzzy
+msgid "ReadOnly"
+msgstr "Spreman"
+
+#: pkg/docker/index.html:384
+msgid "ReadWrite"
+msgstr ""
+
+#: pkg/storaged/index.html:327
+msgid "Reading"
+msgstr ""
+
+#: pkg/playground/translate.html:20 pkg/playground/translate.html:179
+#: pkg/kubernetes/views/details-page.html:52
+#: pkg/kubernetes/views/node-body.html:41
+msgid "Ready"
+msgstr "Spreman"
+
+#: pkg/playground/translate.html:25
+#, fuzzy
+msgctxt "verb"
+msgid "Ready"
+msgstr "Spreman"
+
+#: pkg/systemd/index.html:319
+msgid "Real Host Name"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:45
+msgid "Reason"
+msgstr ""
+
+#: pkg/lib/journal.js:241
+msgid "Reboot"
+msgstr ""
+
+#: pkg/networkmanager/index.html:75 pkg/networkmanager/index.html:98
+#: pkg/networkmanager/index.html:116 pkg/networkmanager/index.html:521
+#: pkg/networkmanager/index.html:551
+msgid "Receiving"
+msgstr "Primanje"
+
+#: pkg/ostree/client.js:56
+msgid "Receiving delta parts"
+msgstr ""
+
+#: pkg/ostree/client.js:58
+msgid "Receiving metadata objects"
+msgstr ""
+
+#: pkg/ostree/client.js:61
+msgid "Receiving objects: $0%"
+msgstr ""
+
+#: pkg/systemd/logs.html:40
+msgid "Recent"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:56 pkg/kubernetes/views/pv-body.html:6
+msgid "Reclaim Policy"
+msgstr ""
+
+#: pkg/shell/simple.html:144 pkg/shell/index.html:327 pkg/shell/stub.html:180
+msgid "Reconnect"
+msgstr ""
+
+#: pkg/storaged/details.js:1594
+msgid "Recovering"
+msgstr ""
+
+#: pkg/storaged/jobs.js:145
+msgid "Recovering RAID Device $target"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:219
+msgid "Recycle"
+msgstr ""
+
+#: pkg/docker/storage.jsx:348
+msgid "Reformat and add disks"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:205
+msgid "Register"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:12
+msgid "Register New Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:4
+msgid "Register Persistent Volume"
+msgstr ""
+
+#: pkg/subscriptions/main.js:74
+msgid "Register system"
+msgstr ""
+
+#: pkg/ostree/index.html:115
+msgid "Released"
+msgstr ""
+
+#: pkg/systemd/init.js:518
+msgid "Reload"
+msgstr ""
+
+#: pkg/systemd/init.js:519
+msgid "Reload or Restart"
+msgstr ""
+
+#: pkg/systemd/init.js:521
+msgid "Reload or Try Restart"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:89
+msgid "Remote registry is insecure"
+msgstr ""
+
+#: cockpit.desktop.in.h:3
+msgid "Remote;Administration;"
+msgstr ""
+
+#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
+msgctxt "storage"
+msgid "Removable Drive"
+msgstr ""
+
+#: pkg/ostree/index.html:123 pkg/ostree/index.html:146
+msgid "Removals"
+msgstr ""
+
+#: pkg/kubernetes/views/user-group-remove.html:10
+#: pkg/kubernetes/views/group-delete.html:21
+#: pkg/kubernetes/views/user-delete.html:25
+#: pkg/kubernetes/views/remove-role-dialog.html:8
+msgid "Remove"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2791
+#, fuzzy
+msgid "Remove $0"
+msgstr "Članovi"
+
+#: pkg/kubernetes/views/group-delete.html:3
+msgid "Remove Group"
+msgstr ""
+
+#: pkg/kubernetes/views/user-group-remove.html:3
+#, fuzzy
+msgid "Remove Member"
+msgstr "Članovi"
+
+#: pkg/kubernetes/views/remove-role-dialog.html:3
+msgid "Remove Role"
+msgstr ""
+
+#: pkg/kubernetes/views/user-delete.html:3
+msgid "Remove User"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:3
+msgid "Remove image tag"
+msgstr ""
+
+#: pkg/kubernetes/views/user-remove-membership.html:3
+msgid "Remove membership"
+msgstr ""
+
+#: pkg/storaged/jobs.js:141
+msgid "Removing $target from RAID Device"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2788
+msgid "Removing <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:154
+msgid "Removing physical volume from $target"
+msgstr ""
+
+#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
+#: pkg/storaged/details.js:1775
+msgid "Rename"
+msgstr ""
+
+#: pkg/storaged/details.js:795
+msgid "Rename Volume Group"
+msgstr ""
+
+#: pkg/storaged/details.js:706
+msgid "Renamee Logical Volume"
+msgstr ""
+
+#: pkg/storaged/jobs.js:157
+msgid "Renaming $target"
+msgstr ""
+
+#: pkg/systemd/services.html:432
+msgid "Repeat Daily"
+msgstr ""
+
+#: pkg/systemd/services.html:431
+msgid "Repeat Hourly"
+msgstr ""
+
+#: pkg/systemd/services.html:434
+msgid "Repeat Monthly"
+msgstr ""
+
+#: pkg/systemd/services.html:433
+msgid "Repeat Weekly"
+msgstr ""
+
+#: pkg/systemd/services.html:435
+msgid "Repeat Yearly"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-body.html:9
+#: pkg/kubernetes/views/details-page.html:141
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
+#: pkg/kubernetes/views/replicationcontroller-modify.html:8
+msgid "Replicas"
+msgstr "Replike"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:14
+#: pkg/kubernetes/views/replicationcontroller-panel.html:10
+#: pkg/kubernetes/views/topology-page.html:23
+msgid "Replication Controller"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:132
+msgid "Replication Controllers"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:24
+msgid ""
+"Replication controllers dynamically create instances of                pods "
+"from templates, and remove pods when necessary."
+msgstr ""
+
+#: pkg/docker/index.html:718
+msgid "Repository"
+msgstr "Repozitorij"
+
+#: pkg/kubernetes/views/volume-body.html:24
+#, fuzzy
+msgid "Repository URL"
+msgstr "Repozitorij"
+
+#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
+msgid "Requested"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:13
+msgid "Requests"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:54
+#, fuzzy
+msgid "Requires Authentication"
+msgstr "Autentifikacija"
+
+#: pkg/docker/index.html:323
+msgid "Reset"
 msgstr ""
 
 #: pkg/docker/storage.jsx:417
@@ -2090,380 +4516,602 @@ msgid ""
 "the pool."
 msgstr ""
 
-#: pkg/docker/storage.jsx:423
-msgid "Erase containers and reset storage pool"
+#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
+msgid "Resize"
 msgstr ""
 
-#: pkg/docker/storage.jsx:446
-msgid "Could not reset the storage pool"
+#: pkg/storaged/details.js:673
+msgid "Resize Filesystem"
 msgstr ""
 
-#: pkg/docker/storage.jsx:482
-msgid "You don't have permission to manage the Docker storage pool."
+#: pkg/storaged/details.js:661
+msgid "Resize Logical Volume"
 msgstr ""
 
-#: pkg/docker/storage.jsx:485
-msgid "The Docker storage pool cannot be managed on this system."
+#: pkg/storaged/jobs.js:158
+msgid "Resizing $target"
 msgstr ""
 
-#: pkg/docker/image.js:77
-msgid "Image $0"
-msgstr "Preslika $0"
-
-#: pkg/docker/image.js:152
-msgid ""
-"Deleting an image will delete it, but you can probably download it again if "
-"you need it later.  Unless this image has never been pushed to a repository, "
-"that is, in which case you probably can't download it again."
+#: pkg/systemd/index.html:126 pkg/systemd/index.html:133
+msgid "Restart"
 msgstr ""
 
-#: pkg/docker/util.js:94
-msgid "Up since $StartedAt"
-msgstr "Pokrenut od $StartedAt"
-
-#: pkg/docker/util.js:96
-msgid "Exited $ExitCode"
+#: pkg/kubernetes/views/container-body.html:20
+msgid "Restart Count"
 msgstr ""
 
-#: pkg/docker/util.js:104
-msgid "On failure, retry $0 time"
-msgid_plural "On failure, retry $0 times"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: pkg/docker/util.js:107 pkg/docker/index.html.h:48
-msgid "Always"
+#: pkg/docker/index.html:558 pkg/kubernetes/views/pod-body.html:10
+msgid "Restart Policy"
 msgstr ""
 
-#: pkg/docker/util.js:109 pkg/docker/index.html.h:49
+#: pkg/kubernetes/scripts/volumes.js:217
+msgid "Retain"
+msgstr ""
+
+#: pkg/docker/index.html:574
+msgid "Retries:"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:188
+msgid "Retrieving subscription status..."
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:26
 #, fuzzy
-msgid "Unless Stopped"
-msgstr "Zaustavljeno "
+msgid "Revision"
+msgstr "Inačica"
 
-#: pkg/docker/util.js:123
-msgid "default"
-msgstr "zadano"
-
-#: pkg/docker/util.js:124
-msgid "$0 shares"
+#: pkg/users/index.html:94 pkg/kubernetes/views/add-member-role-dialog.html:39
+#: pkg/kubernetes/views/project-body.html:21
+msgid "Roles"
 msgstr ""
 
-#: pkg/docker/util.js:231
-msgid "Stopped"
-msgstr "Zaustavljeno "
-
-#: pkg/docker/util.js:488
-msgid "Container is currently running."
-msgstr "Spremnik je pokrenut."
-
-#: pkg/docker/util.js:490
-msgid ""
-"Container is currently marked as not running, but regular stopping failed."
-msgstr ""
-"Spremnik trenutno nije u pogonu, ali uredno zaustavljanje nije uspjelo."
-
-#: pkg/docker/util.js:491
-msgid "Error message from Docker:"
-msgstr "Poruka greške od Docker-a:"
-
-#: pkg/docker/util.js:501
-msgid "Please confirm forced deletion of $0"
-msgstr "Potvrdite prisilno brisanje $0"
-
-#: pkg/docker/util.js:503
-msgid "Force Delete"
-msgstr "Prisilno brisanje"
-
-#: pkg/docker/util.js:544
-msgid "Failed to stop Docker scope: $0"
+#: pkg/ostree/index.html:73
+msgid "Roll back and reboot"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:239
+#: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
+msgid "Round Robin"
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:14
+#: pkg/kubernetes/views/route-panel.html:9
 #, fuzzy
-msgid "Commit"
-msgstr "Naredba"
+msgid "Route"
+msgstr "Putanje"
 
-#: pkg/docker/containers.js:64
-msgid "Failed to start Docker: $0"
-msgstr "Pokretanje Docker-a neuspjelo: $0"
+#: pkg/kubernetes/views/details-page.html:65
+msgid "Routes"
+msgstr "Putanje"
 
-#: pkg/users/authorized-keys.js:103
-msgid "Validating key"
+#: pkg/systemd/services.html:384
+#, fuzzy
+msgid "Run"
+msgstr "Pokrenuto"
+
+#: pkg/kubernetes/views/image-config.html:4
+msgid "Run as"
 msgstr ""
 
-#: pkg/users/authorized-keys.js:108
-msgid "Adding key"
+#: pkg/networkmanager/index.html:381
+#, fuzzy
+msgid "Runner"
+msgstr "Pokrenuto"
+
+#: pkg/ostree/index.html:83
+msgid "Running"
+msgstr "Pokrenuto"
+
+#: pkg/selinux/setroubleshoot-view.jsx:478
+msgid "SELinux Access Control Errors"
 msgstr ""
 
-#: pkg/users/authorized-keys.js:115
-msgid "Error saving authorized keys: "
+#: pkg/selinux/setroubleshoot-view.jsx:330
+msgid "SELinux Policy"
 msgstr ""
 
-#: pkg/users/authorized-keys.js:118
-msgid "The key you provided was not valid."
+#: pkg/selinux/setroubleshoot.html:23
+msgid "SELinux Troubleshoot"
 msgstr ""
 
-#: pkg/users/local.js:40
-msgid "The user <b>$0</b> is not permitted to modify accounts"
+#: pkg/selinux/setroubleshoot-view.jsx:317
+msgid "SELinux is disabled on the system."
 msgstr ""
 
-#: pkg/users/local.js:57
-msgid "Unable to delete root account"
+#: pkg/selinux/setroubleshoot-view.jsx:309
+msgid "SELinux system status is unknown."
 msgstr ""
 
-#: pkg/users/local.js:59
-msgid "Unable to rename root account"
+#: pkg/storaged/jobs.js:119
+msgid "SMART self-test of $target"
 msgstr ""
 
-#: pkg/users/local.js:82
-msgid "Prompting via passwd timed out"
+#: pkg/networkmanager/index.html:218
+msgid "STP Forward delay"
+msgstr "STP odgoda prosljeđivanja"
+
+#: pkg/networkmanager/index.html:227
+msgid "STP Hello time"
+msgstr "STP hello vrijeme"
+
+#: pkg/networkmanager/index.html:236
+msgid "STP Maximum message age"
+msgstr "STP maksimalna starost poruke"
+
+#: pkg/networkmanager/index.html:209
+msgid "STP Priority"
+msgstr "STP Prioritet"
+
+#: pkg/systemd/services.html:466
+msgid "Save"
 msgstr ""
 
-#: pkg/users/local.js:247
-msgid "Password is too weak"
+#: pkg/ostree/client.js:66
+msgid "Scanning metadata"
 msgstr ""
 
-#: pkg/users/local.js:259
-msgid "Password is not acceptable"
+#: pkg/kubernetes/views/node-capacity.html:9
+msgid "Scheduled Pods"
 msgstr ""
 
-#: pkg/users/local.js:284 pkg/users/local.js:594
-msgctxt "page-title"
-msgid "Accounts"
+#: pkg/kubernetes/scripts/nodes.js:322
+msgid "Scheduling Disabled"
 msgstr ""
 
-#: pkg/users/local.js:395 pkg/users/local.js:1082
-msgid "The passwords do not match"
+#: pkg/systemd/services.html:402 pkg/systemd/services.html:406
+msgid "Seconds"
 msgstr ""
 
-#: pkg/users/local.js:400
-msgid "No user name specified"
+#: pkg/kubernetes/scripts/volumes.js:195
+msgid "Secret"
 msgstr ""
 
-#: pkg/users/local.js:405
-msgid "No real name specified"
+#: pkg/kubernetes/views/volume-body.html:106
+msgid "Secret File"
 msgstr ""
 
-#: pkg/users/local.js:429 pkg/users/local.js:1104
-msgid "Excellent password"
+#: pkg/kubernetes/views/volume-body.html:141
+#, fuzzy
+msgid "Secret Name"
+msgstr "Korisničko ime"
+
+#: pkg/kubernetes/views/volume-body.html:69
+#: pkg/kubernetes/views/volume-body.html:108
+#: pkg/kubernetes/views/volume-body.html:134
+msgid "Secret Volume"
 msgstr ""
 
-#: pkg/users/local.js:501
+#: pkg/systemd/index.html:93
+msgid "Secure Shell Keys"
+msgstr ""
+
+#: pkg/storaged/jobs.js:136
+msgid "Securely erasing $target"
+msgstr ""
+
+#: pkg/kubernetes/views/file-button.html:4
+msgid "Select Manifest File..."
+msgstr "Odaberite manifest datoteku..."
+
+#: pkg/kubernetes/views/topology-page.html:7
+msgid "Select an object to see more details."
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:8
 msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
-#: pkg/users/local.js:509
-msgid "This user name already exists"
+#: pkg/networkmanager/index.html:69 pkg/networkmanager/index.html:97
+#: pkg/networkmanager/index.html:115 pkg/networkmanager/index.html:515
+#: pkg/networkmanager/index.html:550
+msgid "Sending"
+msgstr "Slanje"
+
+#: pkg/storaged/index.html:432
+msgctxt "storage"
+msgid "Serial Number"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:82
+#: pkg/kubernetes/views/volume-body.html:47
+msgid "Server"
+msgstr ""
+
+#: pkg/storaged/overview.js:518
+msgid "Server Address"
 msgstr ""
 
 #: pkg/users/local.js:682 pkg/users/local.js:683
 msgid "Server Administrator"
 msgstr ""
 
-#: pkg/users/local.js:684
-msgid "Container Administrator"
+#: pkg/storaged/overview.js:521
+#, fuzzy
+msgid "Server address cannot be empty."
+msgstr "Lozinka(fraza) ne može biti prazna"
+
+#: src/base1/cockpit.js:3709
+msgid "Server has closed the connection."
 msgstr ""
 
-#: pkg/users/local.js:839
-msgid "Logged In"
+#: pkg/kubernetes/views/service-page.html:12
+#: pkg/kubernetes/views/service-panel.html:8
+#: pkg/kubernetes/views/topology-page.html:32
+msgid "Service"
 msgstr ""
 
-#: pkg/users/local.js:841
-msgid "Never"
+#: pkg/kubernetes/views/pod-body.html:12
+msgid "Service Account"
 msgstr ""
 
-#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
-msgid "Delete $0"
+#: pkg/systemd/services.html:279
+msgid "Service Logs"
 msgstr ""
 
-#: pkg/sosreport/index.js:49 pkg/sosreport/index.js:113
-#: pkg/systemd/services.html.h:13 pkg/lib/machine-invalid-hostkey.html.h:4
-#: pkg/lib/machine-auth-failed.html.h:7
-#: pkg/lib/machine-unknown-hostkey.html.h:4
-#: pkg/lib/machine-change-port.html.h:8 pkg/lib/machine-not-supported.html.h:3
-#: pkg/shell/index.html.h:37
-msgid "Close"
-msgstr "Zatvori"
+#: pkg/systemd/services.html:342
+#, fuzzy
+msgid "Service name"
+msgstr "Korisničko ime"
 
-#: pkg/sosreport/index.js:115
-msgid "No archive has been created."
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:272
+#: pkg/kubernetes/views/dashboard-page.html:134
+#: pkg/kubernetes/views/details-page.html:29
+msgid "Services"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:598 pkg/networkmanager/interfaces.js:1051
-#: pkg/networkmanager/interfaces.js:2255 pkg/networkmanager/interfaces.js:2257
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:753 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/kubernetes/views/node-body.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:6
-#: pkg/kubernetes/views/pv-claim.html.h:7
-#: pkg/kubernetes/views/image-body.html.h:6
-#: pkg/kubernetes/views/pv-body.html.h:5
-msgid "Unknown"
-msgstr "Nepoznato"
-
-#: pkg/networkmanager/interfaces.js:805
-msgid "Not available"
-msgstr "Nije dostupno"
-
-#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
-#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
-msgid "Inactive"
-msgstr "Neaktivan"
-
-#: pkg/networkmanager/interfaces.js:809
-msgid "Preparing"
-msgstr "Pripremanje"
-
-#: pkg/networkmanager/interfaces.js:811
-msgid "Configuring"
-msgstr "Podešavanje"
-
-#: pkg/networkmanager/interfaces.js:813
-msgid "Authenticating"
-msgstr "Autoriziranje"
-
-#: pkg/networkmanager/interfaces.js:815
-msgid "Configuring IP"
-msgstr "Podešavanje IP"
-
-#: pkg/networkmanager/interfaces.js:817
-msgid "Checking IP"
-msgstr "Provjera IP"
-
-#: pkg/networkmanager/interfaces.js:819
-msgid "Waiting"
-msgstr "Čekanje"
-
-#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
-msgid "Active"
-msgstr "Aktivno"
-
-#: pkg/networkmanager/interfaces.js:823
-msgid "Deactivating"
-msgstr "Deaktiviram"
-
-#: pkg/networkmanager/interfaces.js:825 pkg/ostree/index.html.h:14
-msgid "Failed"
-msgstr "Neuspjelo"
-
-#: pkg/networkmanager/interfaces.js:1326
-msgid "No carrier"
+#: pkg/kubernetes/views/topology-page.html:33
+msgid ""
+"Services group pods and provide a common DNS                name and an "
+"optional, load-balanced IP address to access them."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1372
-msgid "Part of "
-msgstr "Dio"
-
-#: pkg/networkmanager/interfaces.js:1420
-msgid "The user <b>$0</b> is not permitted to modify network settings"
+#: pkg/kubernetes/views/service-body.html:20
+msgid "Session Affinity"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
-msgctxt "page-title"
-msgid "Networking"
-msgstr "Mreža"
-
-#: pkg/networkmanager/interfaces.js:1804
-msgid "Automatic (DHCP)"
-msgstr "Automatski (DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
-msgid "Link local"
+#: pkg/dashboard/index.html:190
+msgid "Set"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
-msgid "Manual"
-msgstr "Ručno"
+#: pkg/systemd/host.js:559
+msgid "Set Host name"
+msgstr ""
+
+#: pkg/users/index.html:117 pkg/users/index.html:221
+msgid "Set Password"
+msgstr ""
+
+#: pkg/systemd/index.html:395
+msgid "Set Time"
+msgstr ""
+
+#: pkg/docker/index.html:551
+msgid "Set container environment variables"
+msgstr ""
+
+#: pkg/networkmanager/index.html:172
+msgid "Set to"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:326
+msgid ""
+"Setting deviates from the configured state and will revert on the next boot."
+msgstr ""
+
+#: pkg/storaged/jobs.js:131
+msgid "Setting up loop device $target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:139
+#, fuzzy
+msgid "Share Name"
+msgstr "Korisničko ime"
 
 #: pkg/networkmanager/interfaces.js:1807
 msgid "Shared"
 msgstr "Dijeljenje"
 
-#: pkg/networkmanager/interfaces.js:1813 pkg/networkmanager/interfaces.js:2475
-#: pkg/networkmanager/interfaces.js:3019 pkg/networkmanager/interfaces.js:3023
-#: pkg/networkmanager/interfaces.js:3029 pkg/networkmanager/index.html.h:22
-msgid "Automatic"
-msgstr "Automatski"
-
-#: pkg/networkmanager/interfaces.js:1814
-msgid "Automatic (DHCP only)"
-msgstr "Automatski (samo DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1817
-msgid "Ignore"
-msgstr "Ignoriraj"
-
-#: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
-msgid "Round Robin"
+#: pkg/kubernetes/views/container-panel.html:9
+#: pkg/kubernetes/views/container-page-inline.html:14
+msgid "Shell"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
-msgid "Active Backup"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1824
-msgid "XOR"
-msgstr "XILI"
-
-#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
-msgid "Broadcast"
-msgstr "Emitiranje"
-
-#: pkg/networkmanager/interfaces.js:1826
-msgid "802.3ad"
-msgstr "802.3ad"
-
-#: pkg/networkmanager/interfaces.js:1827
-msgid "Adaptive transmit load balancing"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1828
-msgid "Adaptive load balancing"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1833
-msgid "MII (Recommended)"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1834
-msgid "ARP"
-msgstr "ARP"
-
-#: pkg/networkmanager/interfaces.js:1841
-msgid "Load Balancing"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1843
+#: pkg/kubernetes/views/container-page.html:4
 #, fuzzy
-msgid "802.3ad LACP"
-msgstr "802.3ad"
+msgid "Show all Containers"
+msgstr "Spremnici"
 
-#: pkg/networkmanager/interfaces.js:1848
-msgid "Passive"
+#: pkg/kubernetes/views/deploymentconfig-page.html:8
+msgid "Show all Deployment Configs"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1854
-msgid "Ethtool"
+#: pkg/kubernetes/views/node-page.html:8
+msgid "Show all Nodes"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1855
+#: pkg/kubernetes/views/pv-page.html:9
+msgid "Show all Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-container.html:4
 #, fuzzy
-msgid "ARP Ping"
-msgstr "ARP nadziranje"
+msgid "Show all Pod Containers"
+msgstr "Spremnici"
 
-#: pkg/networkmanager/interfaces.js:1856
-msgid "NSNA Ping"
+#: pkg/kubernetes/views/pod-page.html:8
+msgid "Show all Pods"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2156
-msgid "Deleting <b>$0</b> will break the connection to the server, "
+#: pkg/kubernetes/views/user-page.html:16
+#: pkg/kubernetes/views/group-page.html:14
+#: pkg/kubernetes/views/project-page.html:23
+msgid "Show all Projects"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2188
-msgid "Switching on <b>$0</b>  will break the connection to the server, "
+#: pkg/kubernetes/views/replicationcontroller-page.html:10
+msgid "Show all Replication Controllers"
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:10
+msgid "Show all Routes"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:8
+msgid "Show all Services"
+msgstr ""
+
+#: pkg/docker/index.html:127
+#, fuzzy
+msgid "Show all containers"
+msgstr "Spremnici"
+
+#: pkg/kubernetes/views/imagestream-page.html:12
+msgid "Show all image streams"
+msgstr ""
+
+#: pkg/docker/index.html:241 pkg/kubernetes/views/image-page.html:11
+msgid "Show all images"
+msgstr ""
+
+#: pkg/systemd/index.html:94
+msgid "Show fingerprints"
+msgstr ""
+
+#: pkg/systemd/index.html:136
+msgid "Shutdown"
+msgstr ""
+
+#: pkg/kubernetes/views/container-body.html:18
+msgid "Since"
+msgstr ""
+
+#: pkg/systemd/init.js:621
+msgid "Since $0"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/storaged/index.html:232
+msgid "Size"
+msgstr "Veličina"
+
+#: pkg/storaged/dialog.js:271
+msgid "Size cannot be negative"
+msgstr ""
+
+#: pkg/storaged/dialog.js:269
+#, fuzzy
+msgid "Size cannot be zero"
+msgstr "Veličina mora biti specificirana."
+
+#: pkg/storaged/dialog.js:273
+msgid "Size is too large"
+msgstr ""
+
+#: pkg/storaged/dialog.js:267
+#, fuzzy
+msgid "Size must be a number"
+msgstr "Veličina mora biti specificirana."
+
+#: pkg/kubernetes/views/auth-form.html:43
+#: pkg/kubernetes/views/auth-rejected-cert.html:11
+msgid "Skip Certificate Verification"
+msgstr ""
+
+#: pkg/systemd/services.html:54
+msgid "Sockets"
+msgstr ""
+
+#: pkg/ostree/index.html:23
+msgid "Software Updates"
+msgstr ""
+
+#: pkg/docker/storage.jsx:156
+#, fuzzy
+msgid "Solid-State Disk"
+msgstr "SSD disk"
+
+#: pkg/storaged/overview.js:182
+msgctxt "storage"
+msgid "Solid-State Disk"
+msgstr "SSD disk"
+
+#: pkg/selinux/setroubleshoot-view.jsx:90
+msgid "Solution applied successfully"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:97
+msgid "Solution failed"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:908
+msgid "Sorry, I don't know how to modify this volume"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:8
+msgid "Source URL"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2573
+msgid "Spanning Tree Protocol"
+msgstr "Spanning Tree Protokol"
+
+#: pkg/networkmanager/index.html:200
+msgid "Spanning Tree Protocol (STP)"
+msgstr "Spanning Tree Protocol (STP)"
+
+#: pkg/storaged/details.js:1594
+msgid "Spare"
+msgstr ""
+
+#: pkg/systemd/index.html:470
+msgid "Specific Time"
+msgstr ""
+
+#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
+msgid "Start"
+msgstr ""
+
+#: pkg/docker/index.html:68
+msgid "Start Docker"
+msgstr "Pokreni Docker"
+
+#: pkg/storaged/index.html:49
+msgid "Start Multipath"
+msgstr ""
+
+#: pkg/storaged/details.js:1614
+msgid "Start Scrubbing"
+msgstr ""
+
+#: pkg/storaged/jobs.js:139
+msgid "Starting RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:124
+msgid "Starting swapspace $target"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:37
+msgid "Starts"
+msgstr ""
+
+#: pkg/kubernetes/views/container-body.html:16
+#: pkg/kubernetes/views/details-page.html:38
+#: pkg/kubernetes/views/details-page.html:175
+msgid "State"
+msgstr ""
+
+#: pkg/storaged/index.html:571
+#, fuzzy
+msgctxt "storage"
+msgid "State"
+msgstr "Stanje"
+
+#: pkg/systemd/init.js:303
+msgid "Static"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/containers-listing.html:16
+#: pkg/kubernetes/views/nodes-page.html:44
+#: pkg/kubernetes/views/pvc-body.html:13 pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/pv-body.html:24
+msgid "Status"
+msgstr "Stanje"
+
+#: pkg/subscriptions/subscriptions-view.jsx:146
+#, fuzzy
+msgid "Status: $0"
+msgstr "Stanje"
+
+#: pkg/subscriptions/subscriptions-view.jsx:141
+msgid "Status: System isn't registered"
+msgstr ""
+
+#: pkg/networkmanager/index.html:455
+msgid "Sticky"
+msgstr ""
+
+#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
+msgid "Stop"
+msgstr ""
+
+#: pkg/storaged/details.js:1615
+msgid "Stop Scrubbing"
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:10
+msgid "Stop with"
+msgstr ""
+
+#: pkg/docker/util.js:231
+msgid "Stopped"
+msgstr "Zaustavljeno "
+
+#: pkg/storaged/jobs.js:138
+msgid "Stopping RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:125
+msgid "Stopping swapspace $target"
+msgstr ""
+
+#: pkg/storaged/index.html:23 pkg/storaged/index.html:672
+msgid "Storage"
+msgstr ""
+
+#: pkg/storaged/index.html:686
+msgid "Storage Log"
+msgstr ""
+
+#: pkg/storaged/index.html:342
+msgid "Storage Logs"
+msgstr ""
+
+#: pkg/docker/index.html:324
+msgid "Storage pool"
+msgstr ""
+
+#: pkg/systemd/index.html:148
+msgid "Store Performance Data"
+msgstr ""
+
+#: pkg/storaged/details.js:237
+msgid "Store passphrase"
+msgstr "Spremi lozinku(frazu)"
+
+#: pkg/storaged/details.js:527
+msgid "Stored Passphrase"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:12
+msgid ""
+"Strategy            {{item.spec.strategy.type}}            Latest "
+"Version            {{ item.status.latestVersion }}            Not "
+"deployed        "
+msgstr ""
+
+#: pkg/subscriptions/index.html:22
+msgid "Subscriptions"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:4
+msgid "Summary"
+msgstr ""
+
+#: pkg/storaged/details.js:1251
+msgctxt "storage-id-desc"
+msgid "Swap Space"
+msgstr ""
+
+#: pkg/systemd/index.html:243
+msgid "Swap Used"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
+msgid "Switch off $0"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2191 pkg/networkmanager/interfaces.js:2765
@@ -2474,13 +5122,82 @@ msgstr ""
 msgid "Switching off <b>$0</b>  will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
-msgid "Switch off $0"
+#: pkg/networkmanager/interfaces.js:2773
+msgid "Switching off <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
-#: pkg/networkmanager/interfaces.js:2507
-msgid "Bond"
+#: pkg/networkmanager/interfaces.js:2188
+msgid "Switching on <b>$0</b>  will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2762
+msgid "Switching on <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:75
+msgid "Synchronize"
+msgstr ""
+
+#: pkg/dashboard/index.html:188 pkg/lib/machine-sync-users.html:4
+msgid "Synchronize users"
+msgstr ""
+
+#: pkg/systemd/index.html:54
+msgid "Synchronized"
+msgstr ""
+
+#: pkg/systemd/index.html:51
+msgid "Synchronized with {{Server}}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:146
+msgid "Synchronizing RAID Device $target"
+msgstr ""
+
+#: pkg/systemd/index.html:4
+msgid "System"
+msgstr ""
+
+#: pkg/systemd/services.html:53
+msgid "System Services"
+msgstr ""
+
+#: pkg/systemd/index.html:112
+msgid "System Time"
+msgstr ""
+
+#: pkg/docker/index.html:349
+msgid "TCP"
+msgstr "TCP"
+
+#: pkg/kubernetes/views/route-body.html:12
+msgid "TLS Termination"
+msgstr ""
+
+#: pkg/docker/index.html:724
+msgid "Tag"
+msgstr "Oznaka"
+
+#: pkg/kubernetes/views/image-body.html:27
+#: pkg/kubernetes/views/imagestream-modify.html:76
+#: pkg/kubernetes/views/image-listing.html:14
+msgid "Tags"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:136
+msgid "Target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:75
+msgid "Target Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:114
+msgid "Target World Wide Names"
+msgstr ""
+
+#: pkg/systemd/services.html:52
+msgid "Targets"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2235 pkg/networkmanager/interfaces.js:2247
@@ -2488,341 +5205,533 @@ msgstr ""
 msgid "Team"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
-#: pkg/networkmanager/interfaces.js:2622
-msgid "VLAN"
-msgstr "VLAN"
-
-#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
-#: pkg/networkmanager/interfaces.js:2584
-msgid "Bridge"
+#: pkg/networkmanager/interfaces.js:2558
+msgid "Team Port"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2276
-msgid "Carrier"
-msgstr "Nosioc"
+#: pkg/networkmanager/index.html:652
+#, fuzzy
+msgid "Team Port Settings"
+msgstr "Bridge Port Postavke"
 
-#: pkg/networkmanager/interfaces.js:2279 pkg/kubernetes/scripts/volumes.js:990
-msgid "Yes"
-msgstr "Da"
+#: pkg/networkmanager/index.html:624
+#, fuzzy
+msgid "Team Settings"
+msgstr "IP postavke"
 
-#: pkg/networkmanager/interfaces.js:2299
-#: pkg/subscriptions/subscriptions-view.jsx:36
-#: pkg/kubernetes/views/node-body.html.h:14
-#: pkg/kubernetes/views/containers-listing.html.h:7
-#: pkg/kubernetes/views/volumes-page.html.h:5
-#: pkg/kubernetes/views/pv-claim.html.h:6
-#: pkg/kubernetes/views/nodes-page.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:5 pkg/kubernetes/views/pv-body.html.h:4
-msgid "Status"
-msgstr "Stanje"
+#: pkg/kubernetes/views/replicationcontroller-page.html:20
+#: pkg/kubernetes/views/deploymentconfig-panel.html:10
+#: pkg/kubernetes/views/deploymentconfig-page.html:15
+#: pkg/kubernetes/views/replicationcontroller-panel.html:14
+msgid "Template"
+msgstr ""
+
+#: pkg/systemd/terminal.html:4
+msgid "Terminal"
+msgstr ""
+
+#: pkg/users/index.html:78
+msgid "Terminate Session"
+msgstr ""
+
+#: pkg/networkmanager/index.html:38
+msgid "Testing connection"
+msgstr ""
+
+#: pkg/storaged/index.html:40
+msgid "The \"storaged\" API is not available on this system."
+msgstr ""
+
+#: pkg/docker/storage.jsx:485
+msgid "The Docker storage pool cannot be managed on this system."
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:386
+msgid "The IP address or host name cannot contain whitespace."
+msgstr ""
+
+#: pkg/storaged/index.html:532
+msgid "The RAID Array is in a degraded state"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:399
+msgid "The address contains invalid characters"
+msgstr "Adresa sadrži neispravne znakove"
+
+#: pkg/lib/machine-unknown-hostkey.html:6
+msgid ""
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:324
+msgid "The configured state is unknown, it might change on the next boot."
+msgstr ""
+
+#: pkg/kubernetes/views/container-page-inline.html:22
+msgid "The container '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:192
+msgid "The current user isn't allowed to access system subscription status."
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:25
+msgid "The deployment config '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:47
+msgid "The group '{{ groupName }}' does not exist."
+msgstr ""
+
+#: pkg/shell/base_index.js:673
+msgid "The javascript console contains details about this error "
+msgstr "Javascript konzola sadrži detalje ove greške"
+
+#: pkg/lib/machine-invalid-hostkey.html:8
+msgid ""
+"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
+"in use. Unless this machine was recently replaced, it is likely that someone "
+"is trying to attack your connection to this machine."
+msgstr ""
+
+#: pkg/users/authorized-keys.js:118
+msgid "The key you provided was not valid."
+msgstr ""
+
+#: pkg/storaged/details.js:1751
+msgid "The last physical volume of a volume group cannot be removed."
+msgstr ""
+
+#: pkg/shell/indexes.js:314
+msgid "The machine is restarting"
+msgstr "Uređaj se ponovo pokreće"
+
+#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
+msgid "The maximum number of replicas is 128"
+msgstr "Maksimalan broj replika je 128"
+
+#: pkg/kubernetes/scripts/nodes.js:407
+msgid "The name contains invalid characters"
+msgstr ""
+
+#: pkg/kubernetes/views/node-page.html:23
+msgid "The node '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/node-alerts.html:7
+msgid "The node doesn't have enough disk space"
+msgstr ""
+
+#: pkg/kubernetes/views/node-alerts.html:11
+msgid "The node doesn't have enough free memory"
+msgstr ""
+
+#: pkg/users/local.js:395 pkg/users/local.js:1082
+msgid "The passwords do not match"
+msgstr ""
+
+#: pkg/lib/credentials.js:186
+msgid "The passwords do not match."
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:21
+msgid "The persistent volume '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:40
+msgid "The pod '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/project-page.html:34
+msgid "The project '{{ projName }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:30
+msgid "The replication controller '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:19
+msgid "The route '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:386
+msgid "The selected file is not a valid Kubernetes application manifest."
+msgstr ""
+
+#: src/base1/cockpit.js:3695
+msgid "The server refused to authenticate using any supported methods."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:2
+msgid "The server uses a certificate signed by an unknown authority."
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:19
+msgid "The service '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/docker/storage.jsx:355
+msgid ""
+"The storage pool will be reset to optimize its layout.  All containers will "
+"be erased."
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:29
+msgid "The user '{{ userName }}' does not exist."
+msgstr ""
+
+#: pkg/systemd/init.js:834
+#, fuzzy
+msgid "The user <b>$0</b> does not have permissions for creating timers"
+msgstr "Korisniku <b>$0</b> nije dozvoljeno da upravlja poslužiteljima"
+
+#: pkg/dashboard/list.js:209
+msgid "The user <b>$0</b> is not permitted to manage servers"
+msgstr "Korisniku <b>$0</b> nije dozvoljeno da upravlja poslužiteljima"
+
+#: pkg/storaged/permissions.js:61
+msgid "The user <b>$0</b> is not permitted to manage storage"
+msgstr ""
+
+#: pkg/users/local.js:40
+msgid "The user <b>$0</b> is not permitted to modify accounts"
+msgstr ""
+
+#: pkg/systemd/host.js:43
+msgid "The user <b>$0</b> is not permitted to modify hostnames"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1420
+msgid "The user <b>$0</b> is not permitted to modify network settings"
+msgstr ""
+
+#: pkg/realmd/operation.js:436
+msgid "The user <b>$0</b> is not permitted to modify realms"
+msgstr "Korisniku <b>$0</b> nije dozvoljeno da preinači oblasti"
+
+#: pkg/users/local.js:501
+msgid ""
+"The user name can only consist of letters from a-z, digits, dots, dashes and "
+"underscores."
+msgstr ""
+
+#: pkg/users/index.html:332
+msgid "There are no authorized public keys for this account."
+msgstr ""
+
+#: pkg/storaged/details.js:1756
+msgid ""
+"There is not enough free space elsewhere to remove this physical volume.  At "
+"least $0 more free space is needed."
+msgstr ""
+
+#: pkg/storaged/utils.js:168
+msgid "Thin Logical Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:8
+msgid ""
+"This claim is in use. Deleting it may cause issues with the following pod:"
+msgstr ""
+
+#: pkg/systemd/init.js:1222
+msgid ""
+"This day doesn't exist in all months.<br> The timer will only be executed in "
+"months that have 31st."
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2310
 msgid "This device cannot be managed here."
+msgstr ""
+
+#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
+#, fuzzy
+msgid "This field cannot be empty."
+msgstr "Lozinka(fraza) ne može biti prazna"
+
+#: pkg/storaged/details.js:690
+msgid "This logical volume cannot be made smaller."
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:364
+msgid "This machine has already been added."
+msgstr ""
+
+#: pkg/realmd/operation.html:89
+msgid "This may take a while"
+msgstr "Ovo bi moglo potrajati"
+
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid ""
+"This option is for single node testing only – local storage will not work in "
+"a multi-node cluster"
+msgstr ""
+
+#: src/bridge/cockpitpackages.c:470
+msgid "This package is not compatible with this version of Cockpit"
+msgstr ""
+
+#: src/bridge/cockpitpackages.c:459
+#, c-format
+msgid "This package requires Cockpit version %s or later"
+msgstr ""
+
+#: pkg/tuned/dialog.js:102
+msgid "This system is using a custom profile"
+msgstr ""
+
+#: pkg/tuned/dialog.js:100
+msgid "This system is using the recommended profile"
+msgstr ""
+
+#: pkg/systemd/init.js:639
+msgid "This unit is an instance of the $0 template."
+msgstr ""
+
+#: pkg/systemd/services.html:302
+msgid "This unit is not designed to be enabled explicitly.          "
+msgstr ""
+
+#: pkg/users/local.js:509
+msgid "This user name already exists"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:380
+msgid ""
+"This version of cockpit-ws does not support connecting to a host with an "
+"alternate user or port"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:7
+msgid ""
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:23
+msgid "This volume has not been claimed"
+msgstr ""
+
+#: pkg/systemd/index.html:379
+msgid "Time Zone"
+msgstr ""
+
+#: pkg/systemd/services.html:55
+msgid "Timers"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:33
+msgid "To pull this image:"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:39
+msgid "To push to an image to this image stream:"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:11
+msgid ""
+"To try a different port you will need to upgrade cockpit-ws to a newer "
+"version."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:116
+msgid "Token"
+msgstr ""
+
+#: pkg/kubernetes/index.html:57
+msgid "Topology"
+msgstr ""
+
+#: pkg/docker/storage.jsx:314
+msgid "Total"
+msgstr ""
+
+#: pkg/ostree/index.html:99
+msgid "Tree"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:32
+msgid "Triggers"
+msgstr ""
+
+#: pkg/shell/index.html:328 pkg/shell/stub.html:181
+msgid "Troubleshoot"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:21
+msgid "Trust this certificate for this connection"
+msgstr ""
+
+#: pkg/systemd/init.js:520
+msgid "Try Restart"
+msgstr ""
+
+#: pkg/docker/index.html:71 pkg/docker/index.html:74
+msgid "Try again"
+msgstr "Pokušaj ponovo"
+
+#: pkg/systemd/index.html:59
+msgid "Trying to synchronize with {{Server}}"
+msgstr ""
+
+#: pkg/tuned/dialog.js:262
+msgid "Tuned has failed to start"
+msgstr ""
+
+#: pkg/tuned/dialog.js:94
+msgid "Tuned is not available"
+msgstr ""
+
+#: pkg/tuned/dialog.js:96
+msgid "Tuned is not running"
+msgstr ""
+
+#: pkg/tuned/dialog.js:98
+msgid "Tuned is off"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/pv-modify.html:10
+#: pkg/kubernetes/views/volumes-page.html:20 pkg/kubernetes/views/deploy.html:9
+msgid "Type"
+msgstr "Tip"
+
+#: pkg/kubernetes/views/details-page.html:7
+#, fuzzy
+msgid "Type:"
+msgstr "Tip"
+
+#: pkg/subscriptions/subscriptions-register.jsx:110
+msgid "URL"
+msgstr ""
+
+#: pkg/storaged/index.html:547 pkg/storaged/index.html:626
+msgctxt "storage"
+msgid "UUID"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:114
+msgid "Unable to apply this solution automatically"
+msgstr ""
+
+#: pkg/ostree/index.html:219
+msgid "Unable to communicate with OSTree"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:195
+#, fuzzy
+msgid "Unable to connect"
+msgstr "Nepovezan"
+
+#: pkg/kubernetes/scripts/dashboard.js:413
+msgid "Unable to decode Kubernetes application manifest."
+msgstr ""
+
+#: pkg/users/local.js:57
+msgid "Unable to delete root account"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:157
+msgid "Unable to get alert"
+msgstr ""
+
+#: pkg/storaged/overview.js:586
+msgid "Unable to reach server"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:401
+msgid "Unable to read the Kubernetes application manifest. Code $0."
+msgstr ""
+
+#: pkg/users/local.js:59
+msgid "Unable to rename root account"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:172
+msgid "Unable to run fix"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:52
+msgid "Unable to start setroubleshootd"
+msgstr ""
+
+#: pkg/playground/translate.html:35 pkg/playground/translate.html:40
+#, fuzzy
+msgid "Unavailable"
+msgstr "Nije dostupno"
+
+#: pkg/docker/index.html:763 pkg/networkmanager/index.html:792
+msgid "Unexpected error"
+msgstr "Neočekivana pogreška"
+
+#: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/image-body.html:15
+#: pkg/kubernetes/views/pv-claim.html:31 pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
+msgid "Unknown"
+msgstr "Nepoznato"
+
+#: pkg/storaged/details.js:1597
+msgid "Unknown ($0)"
+msgstr ""
+
+#: pkg/lib/machine-unknown-hostkey.html:2
+msgid "Unknown Host Key"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2342
 msgid "Unknown configuration"
 msgstr "Nepoznata konfiguracija"
 
-#: pkg/networkmanager/interfaces.js:2441
-msgid "Configure"
-msgstr "Konfiguriranje"
-
-#: pkg/networkmanager/interfaces.js:2473
-msgid "$mtu"
+#: pkg/storaged/overview.js:582
+msgid "Unknown host name"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2477
-msgid "MTU"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2483
-msgid "Master"
-msgstr "Glavni"
-
-#: pkg/networkmanager/interfaces.js:2502
-msgid "ARP Monitoring"
-msgstr "ARP nadziranje"
-
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#: pkg/docker/index.html:570
 #, fuzzy
-msgid "Broken configuration"
-msgstr "Nepoznata konfiguracija"
+msgid "Unless Stopped"
+msgstr "Zaustavljeno "
 
-#: pkg/networkmanager/interfaces.js:2558
-msgid "Team Port"
+#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
+#: pkg/storaged/details.js:1110
+msgid "Unlock"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2573
-msgid "Spanning Tree Protocol"
-msgstr "Spanning Tree Protokol"
-
-#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
-msgid "Priority $priority"
-msgstr "Prioritet $priority"
-
-#: pkg/networkmanager/interfaces.js:2577
-msgid "Forward delay $forward_delay"
-msgstr "Odgoda prosljeđivanja $forward_delay"
-
-#: pkg/networkmanager/interfaces.js:2579
-msgid "Hello time $hello_time"
-msgstr "Hello vrijeme $hello_time"
-
-#: pkg/networkmanager/interfaces.js:2581
-msgid "Maximum message age $max_age"
-msgstr "Maksimalna starost poruke $max_age"
-
-#: pkg/networkmanager/interfaces.js:2601
-msgid "Path cost $path_cost"
-msgstr "Trošak putanje $path_cost"
-
-#: pkg/networkmanager/interfaces.js:2603
-msgid "Hairpin mode"
+#: pkg/shell/index.html:220
+msgid "Unlock Key"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2605
-msgid "Bridge port"
+#: pkg/storaged/jobs.js:121
+msgid "Unlocking $target"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2619
-msgid "Parent $parent"
-msgstr "Roditelj $parent"
-
-#: pkg/networkmanager/interfaces.js:2620
-msgid "Id $id"
-msgstr "Id $id"
-
-#: pkg/networkmanager/interfaces.js:2628
-msgid "General"
-msgstr "Općenito"
-
-#: pkg/networkmanager/interfaces.js:2637
-msgid "Connect automatically"
-msgstr "Automatski uspostavi vezu"
-
-#: pkg/networkmanager/interfaces.js:2641
-msgid "IPv4"
-msgstr "IPv4"
-
-#: pkg/networkmanager/interfaces.js:2642
-msgid "IPv6"
-msgstr "IPv6"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/networkmanager/index.html.h:33
-#: pkg/kubernetes/views/project-listing.html.h:5
-msgid "Members"
-msgstr "Članovi"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/docker/index.html.h:39
-#: pkg/networkmanager/index.html.h:24
-#: pkg/kubernetes/views/service-body.html.h:6
-#: pkg/kubernetes/views/image-config.html.h:7
-#: pkg/kubernetes/views/container-body.html.h:5
-msgid "Ports"
-msgstr "Portovi"
-
-#: pkg/networkmanager/interfaces.js:2762
-msgid "Switching on <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2773
-msgid "Switching off <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2788
-msgid "Removing <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2791
+#: pkg/networkmanager/index.html:108
 #, fuzzy
-msgid "Remove $0"
-msgstr "Članovi"
+msgid "Unmanaged Interfaces"
+msgstr "Sučelja"
 
-#: pkg/networkmanager/interfaces.js:2833
-msgid "Adding <b>$0</b> will break the connection to the server, "
+#: pkg/systemd/init.js:548
+msgid "Unmask"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2836
-msgid "Add $0"
+#: pkg/storaged/details.js:1100
+msgid "Unmount"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2870
-msgid "Changing the settings will break the connection to the server, "
+#: pkg/storaged/jobs.js:127
+msgid "Unmounting $target"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2872
-#, fuzzy
-msgid "Change the settings"
-msgstr "Bond Postavke"
-
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length or Netmask"
-msgstr "Prefiks ili mrežna maska"
-
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length"
-msgstr "Prefiks"
-
-#: pkg/networkmanager/interfaces.js:3011
-#: pkg/kubernetes/views/details-page.html.h:7
-msgid "Addresses"
-msgstr "Adresa"
-
-#: pkg/networkmanager/interfaces.js:3018
-msgid "DNS"
-msgstr "DNS"
-
-#: pkg/networkmanager/interfaces.js:3022
-msgid "DNS Search Domains"
-msgstr "DNS traži domene"
-
-#: pkg/networkmanager/interfaces.js:3027
-#: pkg/kubernetes/views/details-page.html.h:11
-msgid "Routes"
-msgstr "Putanje"
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv4 Settings"
-msgstr "IPv4 Postavke"
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv6 Settings"
-msgstr "IPv6 Postavke"
-
-#: pkg/networkmanager/interfaces.js:3436
-msgid "Creating this bond will break the connection to the server, "
+#: pkg/users/index.html:315
+msgid "Unnamed"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
-#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
-#, fuzzy
-msgid "Create it"
-msgstr "Izradi"
-
-#: pkg/networkmanager/interfaces.js:3611
-msgid "Creating this team will break the connection to the server, "
+#: pkg/storaged/details.js:1256
+msgctxt "storage-id-desc"
+msgid "Unrecognized Data"
 msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3842
-msgid "Creating this bridge will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4064
-msgid "Creating this VLAN will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4139
-#, fuzzy
-msgid "MTU must be a positive number"
-msgstr "Veličina mora biti specificirana."
-
-#: pkg/subscriptions/subscriptions-client.js:196
-#, fuzzy
-msgid "Invalid credentials"
-msgstr "Nepravilan port"
-
-#: pkg/subscriptions/subscriptions-client.js:198
-msgid "'Organization' required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:200
-msgid "Login/password or activation key required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:202
-msgid "'Organization' required when using activation keys."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:64
-#: pkg/kubernetes/views/volume-body.html.h:16
-#: pkg/kubernetes/views/pv-modify.html.h:11
-msgid "Server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:88
-#: pkg/subscriptions/subscriptions-register.jsx:152
-#: pkg/lib/machine-auth-failed.html.h:3 pkg/lib/machine-sync-users.html.h:6
-#: pkg/lib/machine-change-auth.html.h:6 pkg/shell/index.html.h:31
-#: pkg/users/index.html.h:16 pkg/kubernetes/views/auth-form.html.h:11
-msgid "Password"
-msgstr "Lozinka"
-
-#: pkg/subscriptions/subscriptions-register.jsx:102
-#, fuzzy
-msgid "Custom URL"
-msgstr "Prilagođeno"
-
-#: pkg/subscriptions/subscriptions-register.jsx:110
-msgid "URL"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:125
-msgid "Proxy"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:132
-msgid "Use proxy server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:140
-msgid "Login"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:164
-#, fuzzy
-msgid "Activation Key"
-msgstr "Deaktiviram"
-
-#: pkg/subscriptions/subscriptions-register.jsx:176
-msgid "Organization"
-msgstr ""
-
-#: pkg/subscriptions/main.js:45 pkg/subscriptions/subscriptions-view.jsx:143
-#: pkg/kubernetes/views/pv-modify.html.h:23
-msgid "Register"
-msgstr ""
-
-#: pkg/subscriptions/main.js:74
-msgid "Register system"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:32
-msgid "Product name"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product ID"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/index.html.h:13
-#: pkg/shell/index.html.h:14 pkg/shell/stub.html.h:9 pkg/shell/simple.html.h:9
-#: pkg/ostree/index.html.h:19
-msgid "Version"
-msgstr "Inačica"
-
-#: pkg/subscriptions/subscriptions-view.jsx:35
-#: pkg/kubernetes/views/image-config.html.h:5
-msgid "Architecture"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:37
-msgid "Starts"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Ends"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:141
-msgid "Status: System isn't registered"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:146
-#, fuzzy
-msgid "Status: $0"
-msgstr "Stanje"
 
 #: pkg/subscriptions/subscriptions-view.jsx:148
 msgid "Unregister"
@@ -2832,3347 +5741,429 @@ msgstr ""
 msgid "Unregistering system..."
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:161
-#: pkg/subscriptions/index.html.h:1
-msgid "Subscriptions"
+#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
+#: src/bridge/cockpitdbussetup.c:625
+msgid "Unsupported setup mechanism"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/ostree/index.html.h:15
+#: src/base1/cockpit.js:3697
+msgid "Untrusted host"
+msgstr ""
+
+#: pkg/docker/util.js:94
+msgid "Up since $StartedAt"
+msgstr "Pokrenut od $StartedAt"
+
+#: pkg/lib/machine-change-port.html:41
+msgid "Update"
+msgstr ""
+
+#: pkg/ostree/index.html:125 pkg/ostree/index.html:152
+msgid "Updates"
+msgstr ""
+
+#: pkg/ostree/index.html:96
 msgid "Updating"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:188
-msgid "Retrieving subscription status..."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:191
-msgid "Access denied"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:192
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:195
-#, fuzzy
-msgid "Unable to connect"
-msgstr "Nepovezan"
-
-#: pkg/subscriptions/subscriptions-view.jsx:196
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:222
-msgid "Installed products"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:223
-#, fuzzy
-msgid "No installed products on the system."
-msgstr "Docker nije instaliran ili pokrenut na sustavu"
-
-#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr ""
-
-#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "Maksimalan broj replika je 128"
-
-#: pkg/kubernetes/scripts/details.js:546
-msgid "Not a valid value for Host"
 msgstr ""
 
 #: pkg/kubernetes/scripts/details.js:655
 msgid "Updating $0..."
 msgstr "Ažuriranje $0..."
 
-#: pkg/kubernetes/scripts/graphs.js:601 pkg/kubernetes/scripts/nodes.js:711
-#: pkg/kubernetes/scripts/nodes.js:817 pkg/dashboard/index.html.h:2
-msgid "CPU"
-msgstr "CPU"
-
-#: pkg/kubernetes/scripts/graphs.js:606 pkg/kubernetes/scripts/nodes.js:715
-#: pkg/kubernetes/scripts/nodes.js:826 pkg/dashboard/index.html.h:3
-msgid "Memory"
-msgstr "Memorija"
-
-#: pkg/kubernetes/scripts/graphs.js:611 pkg/dashboard/index.html.h:4
-msgid "Network"
-msgstr "Mreža"
-
-#: pkg/kubernetes/scripts/nodes.js:319 pkg/kubernetes/views/node-body.html.h:16
-#: pkg/kubernetes/views/details-page.html.h:10
-msgid "Not Ready"
+#: pkg/shell/index.html:165
+msgid "Use my password for privileged tasks and to connect to other machines"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
+#: pkg/subscriptions/subscriptions-register.jsx:132
+msgid "Use proxy server"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:324 pkg/kubernetes/views/node-body.html.h:15
-#: pkg/kubernetes/views/details-page.html.h:9
-msgid "Ready"
-msgstr "Spreman"
-
-#: pkg/kubernetes/scripts/nodes.js:397
-msgid "Please type an address"
-msgstr "Unesite adresu"
-
-#: pkg/kubernetes/scripts/nodes.js:399
-msgid "The address contains invalid characters"
-msgstr "Adresa sadrži neispravne znakove"
-
-#: pkg/kubernetes/scripts/nodes.js:407
-msgid "The name contains invalid characters"
+#: pkg/shell/index.html:172
+msgid "Use the following keys to authenticate against other systems"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
+#: pkg/systemd/index.html:251
+msgid "Used"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
+#: pkg/systemd/index.html:229 pkg/dashboard/index.html:158
+#: pkg/playground/translate.html:86 pkg/playground/translate.html:106
+#: pkg/kubernetes/views/user-panel.html:9
+#: pkg/kubernetes/views/auth-form.html:61
+#: pkg/kubernetes/views/volume-body.html:64
+#: pkg/kubernetes/views/volume-body.html:103
+msgid "User"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+#: pkg/users/index.html:90 pkg/users/index.html:154
+#: pkg/realmd/operation.html:47
+msgid "User Name"
+msgstr "Korisničko ime"
+
+#: pkg/realmd/operation.html:53
+msgid "User Password"
+msgstr "Korisnička Lozinka"
+
+#: pkg/lib/machine-change-auth.html:18
+msgid "User name"
+msgstr ""
+
+#: pkg/kubernetes/views/add-member-role-dialog.html:15
+msgid "User or Group"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:94
 #, fuzzy
-msgid "Disk"
-msgstr "Tvrdi disk"
+msgid "Username"
+msgstr "Korisničko ime"
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
+#: pkg/kubernetes/views/project-listing.html:85
+msgid "Users"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:870
-#, c-format
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+#: pkg/storaged/details.js:181
+msgid "VFAT - Compatible with all systems and devices"
+msgstr "VFAT - Kompatibilan sa svim sistemima i uređajima"
 
-#: pkg/kubernetes/scripts/nodes.js:872
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
+#: pkg/networkmanager/interfaces.js:2622
+msgid "VLAN"
+msgstr "VLAN"
 
-#: pkg/kubernetes/scripts/connection.js:88
-msgid "Error writing kubectl config"
+#: pkg/networkmanager/index.html:141
+msgid "VLAN Id"
+msgstr "VLAN id"
+
+#: pkg/networkmanager/index.html:736
+msgid "VLAN Settings"
+msgstr "VLAN Postavke"
+
+#: pkg/users/authorized-keys.js:103
+msgid "Validating key"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:514
-msgid "Couldn't find running API server"
+#: pkg/systemd/index.html:98 pkg/ostree/index.html:113 pkg/shell/simple.html:77
+#: pkg/shell/index.html:90 pkg/shell/stub.html:83
+msgid "Version"
+msgstr "Inačica"
+
+#: pkg/storaged/jobs.js:137
+msgid "Very securely erasing $target"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:516
+#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
+#: pkg/kubernetes/views/pvc-body.html:6
+msgid "Volume"
+msgstr ""
+
+#: pkg/storaged/index.html:620
+msgid "Volume Group"
+msgstr ""
+
+#: pkg/storaged/utils.js:239
+msgid "Volume Group $0"
+msgstr ""
+
+#: pkg/storaged/index.html:98
+msgid "Volume Groups"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:14
+#: pkg/kubernetes/views/volume-body.html:89
+msgid "Volume ID"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:115
+#: pkg/kubernetes/views/volume-body.html:42
 #, fuzzy
-msgid "Connection Error: $0"
-msgstr "Povezujem se na Docker"
+msgid "Volume Name"
+msgstr "Korisničko ime"
 
-#: pkg/kubernetes/scripts/connection.js:539
+#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
+msgid "Volume Type"
+msgstr ""
+
+#: pkg/docker/index.html:536 pkg/kubernetes/views/pod-page.html:18
+#: pkg/kubernetes/views/image-config.html:28
+#: pkg/kubernetes/views/dashboard-page.html:47 pkg/kubernetes/index.html:70
+msgid "Volumes"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:819
+msgid "Waiting"
+msgstr "Čekanje"
+
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid "Warning:"
+msgstr ""
+
+#: pkg/systemd/logs.html:48
+msgid "Warnings"
+msgstr ""
+
+#: pkg/systemd/services.html:409
+msgid "Weeks"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:5
+msgid "Welcome to the Image Registry"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:61
+msgid "When"
+msgstr ""
+
+#: pkg/docker/index.html:507
+msgid "With terminal"
+msgstr ""
+
+#: pkg/storaged/index.html:438
 #, fuzzy
-msgid "Please provide a valid address"
-msgstr "Unesite adresu"
+msgctxt "storage"
+msgid "World Wide Name"
+msgstr "Korisničko ime"
 
-#: pkg/kubernetes/scripts/connection.js:554
-msgid "Please provide a username"
+#: pkg/storaged/details.js:1595
+msgid "Write-mostly"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:650
-msgid "Error getting certificate details: $0"
+#: pkg/storaged/index.html:333
+msgid "Writing"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
+#: pkg/ostree/client.js:64
+msgid "Writing objects"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
+#: pkg/storaged/details.js:177
+msgid "XFS - Red Hat Enterprise Linux 7 default"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:194
-#, fuzzy
-msgid "Git Repository"
-msgstr "Repozitorij"
+#: pkg/networkmanager/interfaces.js:1824
+msgid "XOR"
+msgstr "XILI"
 
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr ""
+#: pkg/kubernetes/scripts/volumes.js:990 pkg/networkmanager/interfaces.js:2279
+msgid "Yes"
+msgstr "Da"
 
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
-msgid "Host Path"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:199
-msgid "NFS Mount"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:200
-#, fuzzy
-msgid "Rados Block Device"
-msgstr "$0 Blok uređaj"
-
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
-msgid "ISCSI"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:469
-msgid "Please select a valid access mode"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:477
-#, fuzzy
-msgid "Please provide a valid name"
-msgstr "Unesite adresu"
-
-#: pkg/kubernetes/scripts/volumes.js:485
-msgid "Please provide a valid storage capacity."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:493
-msgid "Please select a valid policy option."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:565
-msgid "Please select a valid endpoint"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:574
-msgid "Please provide a GlusterFS volume name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:632
-msgid "Please provide a valid NFS server"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
-msgid "Please provide a valid path"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:781
-#, fuzzy
-msgid "Please provide a valid target"
-msgstr "Unesite adresu"
-
-#: pkg/kubernetes/scripts/volumes.js:789
-msgid "Please provide a valid qualified name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:797
-msgid "Please provide a valid logical unit number"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:805
-msgid "Please provide a valid filesystem type"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:813
-msgid "Please provide a valid interface"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:860
-#, fuzzy
-msgid "NFS"
-msgstr "DNS"
-
-#: pkg/kubernetes/scripts/volumes.js:872
-msgid "GlusterFS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:908
-msgid "Sorry, I don't know how to modify this volume"
-msgstr ""
-
-#: pkg/kubernetes/scripts/charts.js:113
-#, fuzzy
-msgid "Unavailable"
-msgstr "Nije dostupno"
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:384
+#: pkg/lib/machine-sync-users.html:47
 msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
+"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
+"synchronize users, a user with superuser privileges is required."
 msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:401
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:413
-msgid "Unable to decode Kubernetes application manifest."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:441
-msgid "Please create another namespace for $0 \"$1\""
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:460
-msgid "Manifest"
-msgstr ""
-
-#: pkg/dashboard/list.js:209
-msgid "The user <b>$0</b> is not permitted to manage servers"
-msgstr "Korisniku <b>$0</b> nije dozvoljeno da upravlja poslužiteljima"
 
 #: pkg/dashboard/list.js:394
 msgid ""
 "You are currently connected directly to this server. You cannot delete it."
 msgstr "Trenutno ste izravno spojeni na ovaj server. Ne možete ga izbrisati."
 
-#: cockpit.appdata.xml.in.h:1
-msgid ""
-"Cockpit is a server manager that makes it easy to administer your Linux "
-"servers via a web browser. Jumping between the terminal and the web tool is "
-"no problem. A service started via Cockpit can be stopped via the terminal. "
-"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
-"journal interface."
-msgstr ""
-
-#: cockpit.appdata.xml.in.h:2
-msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
-"stopping services. You can monitor and administer several servers at the "
-"same time. Just add them with a single click and your machines will look "
-"after its buddies."
-msgstr ""
-
-#: cockpit.desktop.in.h:1 pkg/shell/index.html.h:1 pkg/shell/stub.html.h:1
-#: pkg/shell/simple.html.h:1
-msgid "Cockpit"
-msgstr "Cockpit"
-
-#: cockpit.desktop.in.h:2
-msgid "A user interface for GNU/Linux servers"
-msgstr ""
-
-#: cockpit.desktop.in.h:3
-msgid "Remote;Administration;"
-msgstr ""
-
-#: pkg/systemd/index.html.h:1
-msgid "System"
-msgstr ""
-
-#: pkg/systemd/index.html.h:2
-#, fuzzy
-msgid "No host keys found."
-msgstr "Nije pronađeno"
-
-#: pkg/systemd/index.html.h:3
-msgid "Synchronized with {{Server}}"
-msgstr ""
-
-#: pkg/systemd/index.html.h:4
-msgid "Synchronized"
-msgstr ""
-
-#: pkg/systemd/index.html.h:5
-msgid "Trying to synchronize with {{Server}}"
-msgstr ""
-
-#: pkg/systemd/index.html.h:6
-msgid "Not synchronized"
-msgstr ""
-
-#: pkg/systemd/index.html.h:7
-msgid "Hardware"
-msgstr ""
-
-#: pkg/systemd/index.html.h:8
-msgid "Asset Tag"
-msgstr ""
-
-#: pkg/systemd/index.html.h:9 pkg/kubernetes/views/node-body.html.h:6
-msgid "Machine ID"
-msgstr ""
-
-#: pkg/systemd/index.html.h:10 pkg/ostree/index.html.h:18
-#: pkg/kubernetes/views/nodes-page.html.h:6
-msgid "Operating System"
-msgstr ""
-
-#: pkg/systemd/index.html.h:11
-msgid "Secure Shell Keys"
-msgstr ""
-
-#: pkg/systemd/index.html.h:12
-msgid "Show fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:14 pkg/dashboard/index.html.h:7
-msgid "Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:15
-msgid "Domain"
-msgstr ""
-
-#: pkg/systemd/index.html.h:16
-msgid "System Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:17
-msgid "Power Options"
-msgstr ""
-
-#: pkg/systemd/index.html.h:20
-msgid "Performance Profile"
-msgstr ""
-
-#: pkg/systemd/index.html.h:21
-msgid "Store Performance Data"
-msgstr ""
-
-#: pkg/systemd/index.html.h:32
-msgid "Machine SSH Key Fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:33
-msgid "Pretty Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:34
-msgid "Real Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:35
-msgid "Time Zone"
-msgstr ""
-
-#: pkg/systemd/index.html.h:36
-msgid ""
-"\n"
-"                                    Invalid time zone\n"
-"                                "
-msgstr ""
-
-#: pkg/systemd/index.html.h:39
-msgid "Set Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:40
-#, fuzzy
-msgid "Manually"
-msgstr "Ručno"
-
-#: pkg/systemd/index.html.h:41
-msgid "Automatically using NTP"
-msgstr ""
-
-#: pkg/systemd/index.html.h:42
-msgid "Automatically using specific NTP servers"
-msgstr ""
-
-#: pkg/systemd/index.html.h:43
-msgid "Delay"
-msgstr ""
-
-#: pkg/systemd/index.html.h:44
-msgid "1 Minute"
-msgstr ""
-
-#: pkg/systemd/index.html.h:45
-msgid "5 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:46
-msgid "20 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:47
-msgid "40 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:48
-msgid "60 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:49
-msgid "No Delay"
-msgstr ""
-
-#: pkg/systemd/index.html.h:50
-msgid "Specific Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:51
-msgid ""
-"\n"
-"                        Cancel\n"
-"                    "
-msgstr ""
-
-#: pkg/systemd/logs.html.h:1
-msgid "Journal"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:2
-msgid "Recent"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:3
-msgid "Current boot"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:4
-msgid "Last 24 hours"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:5
-msgid "Last 7 days"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:6
-msgid "Errors"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:7
-msgid "Warnings"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:8
-msgid "Notices"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:9
-msgid "All"
-msgstr "Sve"
-
-#: pkg/systemd/logs.html.h:10 pkg/kubernetes/views/container-panel.html.h:2
-#: pkg/kubernetes/views/container-page-inline.html.h:2
-msgid "Logs"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:11
-msgid "Entry"
-msgstr ""
-
-#: pkg/systemd/services.html.h:1 pkg/kubernetes/views/dashboard-page.html.h:12
-#: pkg/kubernetes/views/details-page.html.h:3
-msgid "Services"
-msgstr ""
-
-#: pkg/systemd/services.html.h:3
-msgid "System Services"
-msgstr ""
-
-#: pkg/systemd/services.html.h:4
-msgid "Sockets"
-msgstr ""
-
-#: pkg/systemd/services.html.h:5
-msgid "Timers"
-msgstr ""
-
-#: pkg/systemd/services.html.h:6
-msgid "Paths"
-msgstr ""
-
-#: pkg/systemd/services.html.h:7
-msgid "Instantiate"
-msgstr ""
-
-#: pkg/systemd/services.html.h:8
-msgid "{{days_text}}"
-msgstr ""
-
-#: pkg/systemd/services.html.h:9
-msgid "Service Logs"
-msgstr ""
-
-#: pkg/systemd/services.html.h:10
-msgid "Note"
-msgstr ""
-
-#: pkg/systemd/services.html.h:11
-msgid ""
-"This unit is not designed to be enabled explicitly.\n"
-"          "
-msgstr ""
-
-#: pkg/systemd/services.html.h:15
-#, fuzzy
-msgid "Create Timers"
-msgstr "Izradi"
-
-#: pkg/systemd/services.html.h:16
-#, fuzzy
-msgid "Service name"
-msgstr "Korisničko ime"
-
-#: pkg/systemd/services.html.h:18 pkg/docker/index.html.h:32
-msgid "Command"
-msgstr "Naredba"
-
-#: pkg/systemd/services.html.h:19
-#, fuzzy
-msgid "Run"
-msgstr "Pokrenuto"
-
-#: pkg/systemd/services.html.h:20
-msgid "After system boot"
-msgstr ""
-
-#: pkg/systemd/services.html.h:21
-msgid "At specific time"
-msgstr ""
-
-#: pkg/systemd/services.html.h:22
-msgid "Seconds"
-msgstr ""
-
-#: pkg/systemd/services.html.h:23
-#, fuzzy
-msgid "Minutes"
-msgstr "5 minuta"
-
-#: pkg/systemd/services.html.h:24
-#, fuzzy
-msgid "Hours"
-msgstr "6 sati"
-
-#: pkg/systemd/services.html.h:25
-msgid "Weeks"
-msgstr ""
-
-#: pkg/systemd/services.html.h:26
-msgid "Don't Repeat"
-msgstr ""
-
-#: pkg/systemd/services.html.h:27
-msgid "Repeat Hourly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:28
-msgid "Repeat Daily"
-msgstr ""
-
-#: pkg/systemd/services.html.h:29
-msgid "Repeat Weekly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:30
-msgid "Repeat Monthly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:31
-msgid "Repeat Yearly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:32
-msgid "Hour : Minute"
-msgstr ""
-
-#: pkg/systemd/services.html.h:33
-msgid ":"
-msgstr ""
-
-#: pkg/systemd/services.html.h:35
-msgid "Save"
-msgstr ""
-
-#: pkg/systemd/terminal.html.h:1
-msgid "Terminal"
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:1
-msgid "Incorrect Host Key"
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:2
-msgid ""
-"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
-"in use. Unless this machine was recently replaced, it is likely that someone "
-"is trying to attack your connection to this machine."
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:3
-msgid ""
-"You can remove the previously stored key by running the following command"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:1
-msgid "Authentication Failed"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:2
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
-"machine with cockpit you will need to enable one of the following "
-"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:4 pkg/shell/index.html.h:30
-msgid "Public Key"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:5
-msgid "Kerberos Based SSO"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:6
-msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:1 pkg/dashboard/index.html.h:11
-msgid "Synchronize users"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:2
-msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:3
-msgid "Error loading users: {{perm_failed}}"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:4
-msgid ""
-"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
-"synchronize users, a user with superuser privileges is required."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:5 pkg/lib/machine-change-auth.html.h:4
-msgid "User name"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:8
-msgid "Synchronize"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:1
-msgid "Unknown Host Key"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:2
-msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:3 pkg/shell/index.html.h:4
-msgid "Fingerprint"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:5
-#: pkg/kubernetes/views/auth-form.html.h:14
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:6
-msgid "Connect"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:1
-msgid "Add Machine to Dashboard"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:3 pkg/dashboard/index.html.h:9
-msgid "Color"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:4
-msgid ""
-"Connecting simultaneously to more than {{ limit }} machines is unsupported."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:1
-msgid "Could not contact {{host}}"
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:2
-msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:3
-msgid ""
-"To try a different port you will need to upgrade cockpit-ws to a newer "
-"version."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:4
-msgid "Is sshd running on a different port?"
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:7
-msgid "Update"
-msgstr ""
-
-#: pkg/lib/machine-not-supported.html.h:1
-msgid "Cockpit is not installed"
-msgstr ""
-
-#: pkg/lib/machine-not-supported.html.h:2
-msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:1
-msgid "Log in to {{host}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:2
-msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:3
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:5 pkg/shell/index.html.h:9
-#: pkg/realmd/operation.html.h:3 pkg/kubernetes/views/auth-form.html.h:8
-msgid "Authentication"
-msgstr "Autentifikacija"
-
-#: pkg/lib/machine-change-auth.html.h:7
-msgid "Available"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:8
-msgid "Login Password"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:9
-msgid "Kerberos Ticket"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:10
-msgid "Checking for public keys"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:12
-msgid "Log In"
-msgstr ""
-
-#: pkg/shell/shell.html.h:1
-msgid "Things have moved"
-msgstr ""
-
-#: pkg/shell/index.html.h:2
-msgid "Comment"
-msgstr ""
-
-#: pkg/shell/index.html.h:5 pkg/shell/stub.html.h:2 pkg/shell/simple.html.h:2
-msgid "Ooops!"
-msgstr "Uuups!"
-
-#: pkg/shell/index.html.h:6 pkg/shell/stub.html.h:3 pkg/shell/simple.html.h:3
-msgid "Display Language"
-msgstr "Jezik Prikaza"
-
-#: pkg/shell/index.html.h:7 pkg/shell/stub.html.h:4 pkg/shell/simple.html.h:4
-msgid "About Cockpit"
-msgstr "O Cockpit-u"
-
-#: pkg/shell/index.html.h:8
-msgid "Account Settings"
-msgstr "Postavke Računa"
-
-#: pkg/shell/index.html.h:10 pkg/shell/stub.html.h:5 pkg/shell/simple.html.h:5
-msgid "Log out"
-msgstr "Odjavi se"
-
-#: pkg/shell/index.html.h:11 pkg/shell/stub.html.h:6 pkg/shell/simple.html.h:6
-msgid ""
-"\n"
-"              Cockpit is an interactive Linux server admin interface.\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:15 pkg/shell/stub.html.h:10
-#: pkg/shell/simple.html.h:10
-msgid "Choose the language to be used in the application"
-msgstr "Odaberite jezik koji će se koristiti u aplikaciji"
-
-#: pkg/shell/index.html.h:16 pkg/shell/stub.html.h:11
-#: pkg/shell/simple.html.h:11 pkg/storaged/index.html.h:59
-msgid ""
-"\n"
-"              Cancel\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:19 pkg/shell/stub.html.h:14
-#: pkg/shell/simple.html.h:14
-msgid ""
-"\n"
-"              Select\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:22 pkg/shell/stub.html.h:17
-msgid ""
-"\n"
-"              Close\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:25
-msgid "Use my password for privileged tasks and to connect to other machines"
-msgstr ""
-
-#: pkg/shell/index.html.h:26
-msgid "Use the following keys to authenticate against other systems"
-msgstr ""
-
-#: pkg/shell/index.html.h:29 pkg/kubernetes/index.html.h:6
-msgid "Details"
-msgstr ""
-
-#: pkg/shell/index.html.h:32
-msgid "Unlock Key"
-msgstr ""
-
-#: pkg/shell/index.html.h:33 pkg/users/index.html.h:23
-msgid "Old Password"
-msgstr ""
-
-#: pkg/shell/index.html.h:34 pkg/users/index.html.h:24
-msgid "New Password"
-msgstr ""
-
-#: pkg/shell/index.html.h:35 pkg/users/index.html.h:19
-msgid "Confirm"
-msgstr ""
-
-#: pkg/shell/index.html.h:36
-msgid "Change Password"
-msgstr ""
-
-#: pkg/shell/index.html.h:38 pkg/shell/stub.html.h:20
-msgid ""
-"\n"
-"                Tools\n"
-"              "
-msgstr ""
-
-#: pkg/shell/index.html.h:41 pkg/shell/stub.html.h:23
-#: pkg/shell/simple.html.h:24
-msgid "Reconnect"
-msgstr ""
-
-#: pkg/shell/index.html.h:42 pkg/shell/stub.html.h:24
-msgid "Troubleshoot"
-msgstr ""
-
-#: pkg/shell/simple.html.h:18
-msgid ""
-"\n"
-"              Try to reconnect\n"
-"            "
-msgstr ""
-
-#: pkg/shell/simple.html.h:21
-msgid ""
-"\n"
-"              Log in again\n"
-"            "
-msgstr ""
-
-#: pkg/ostree/index.html.h:1
-msgid "Software Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:2
-msgid "Check for updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:3
-msgid ""
-"\n"
-"                    Update and reboot\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:6
-msgid "Roll back and reboot"
-msgstr ""
-
-#: pkg/ostree/index.html.h:8
-msgid ""
-"\n"
-"                    Default\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:11
-msgid ""
-"\n"
-"                    Available\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:16
-msgid "Tree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:17
-msgid "Packages"
-msgstr ""
-
-#: pkg/ostree/index.html.h:20
-msgid "Released"
-msgstr ""
-
-#: pkg/ostree/index.html.h:21
-msgid "Additions"
-msgstr ""
-
-#: pkg/ostree/index.html.h:22
-msgid "Removals"
-msgstr ""
-
-#: pkg/ostree/index.html.h:23
-msgid "Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:24
-msgid "Downgrades"
-msgstr ""
-
-#: pkg/ostree/index.html.h:25
-msgid ""
-"\n"
-"                    This deployment contains the same packages as your "
-"currently booted system\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:28
-msgid "Operating System Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:29
-msgid "Connecting"
-msgstr ""
-
-#: pkg/ostree/index.html.h:30
-msgid "Unable to communicate with OSTree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:31
-msgid "No Deployments"
-msgstr ""
-
-#: pkg/ostree/index.html.h:32
-msgid ""
-"\n"
-"                    Reconnect\n"
-"                "
-msgstr ""
-
-#: pkg/selinux/setroubleshoot.html.h:1
-msgid "SELinux Troubleshoot"
-msgstr ""
-
-#: pkg/machines/index.html.h:1
-msgid "Virtual Machines Management"
-msgstr ""
-
-#: pkg/storaged/index.html.h:1
-msgid "Storage"
-msgstr ""
-
-#: pkg/storaged/index.html.h:2
-msgid "The \"storaged\" API is not available on this system."
-msgstr ""
-
-#: pkg/storaged/index.html.h:3
-msgid "Start Multipath"
-msgstr ""
-
-#: pkg/storaged/index.html.h:4
-msgid ""
-"\n"
-"        There are devices with multiple paths on the system, but the "
-"multipath service is not running.\n"
-"      "
-msgstr ""
-
-#: pkg/storaged/index.html.h:7
-msgid "RAID Devices"
-msgstr ""
-
-#: pkg/storaged/index.html.h:8
-msgid "No storage set up as RAID"
-msgstr ""
-
-#: pkg/storaged/index.html.h:9
-msgid "Volume Groups"
-msgstr ""
-
-#: pkg/storaged/index.html.h:10
-msgid "No volume groups created"
-msgstr ""
-
-#: pkg/storaged/index.html.h:11
-msgid "iSCSI Targets"
-msgstr ""
-
-#: pkg/storaged/index.html.h:12
-msgid "{{Address}}:{{Port}}"
-msgstr ""
-
-#: pkg/storaged/index.html.h:13
-msgid "No iSCSI targets set up"
-msgstr ""
-
-#: pkg/storaged/index.html.h:14
-msgid "Drives"
-msgstr ""
-
-#: pkg/storaged/index.html.h:15
-msgid "No drives attached"
-msgstr ""
-
-#: pkg/storaged/index.html.h:16
-msgid "Other Devices"
-msgstr ""
-
-#: pkg/storaged/index.html.h:17
-msgid "Filesystems"
-msgstr ""
-
-#: pkg/storaged/index.html.h:21
-msgid "Jobs"
-msgstr ""
-
-#: pkg/storaged/index.html.h:23 pkg/networkmanager/index.html.h:3
-msgid "Go to now"
-msgstr ""
-
-#: pkg/storaged/index.html.h:24 pkg/networkmanager/index.html.h:4
-msgid "5 minutes"
-msgstr "5 minuta"
-
-#: pkg/storaged/index.html.h:25 pkg/networkmanager/index.html.h:5
-msgid "1 hour"
-msgstr "1 sat"
-
-#: pkg/storaged/index.html.h:26 pkg/networkmanager/index.html.h:6
-msgid "6 hours"
-msgstr "6 sati"
-
-#: pkg/storaged/index.html.h:27 pkg/networkmanager/index.html.h:7
-msgid "1 day"
-msgstr "1 dan"
-
-#: pkg/storaged/index.html.h:28 pkg/networkmanager/index.html.h:8
-msgid "1 week"
-msgstr "1 tjedan"
-
-#: pkg/storaged/index.html.h:29
-msgid "Reading"
-msgstr ""
-
-#: pkg/storaged/index.html.h:30
-msgid "Writing"
-msgstr ""
-
-#: pkg/storaged/index.html.h:31
-msgid "Storage Logs"
-msgstr ""
-
-#: pkg/storaged/index.html.h:32
-msgid "Create partition table"
-msgstr ""
-
-#: pkg/storaged/index.html.h:34
-msgid "Block Device"
-msgstr ""
-
-#: pkg/storaged/index.html.h:40
-msgid "No media inserted"
-msgstr ""
-
-#: pkg/storaged/index.html.h:42
-msgid "DISK IS FAILING"
-msgstr ""
-
-#: pkg/storaged/index.html.h:43
-msgid "Disk is OK"
-msgstr ""
-
-#: pkg/storaged/index.html.h:46
-msgid "The RAID Array is in a degraded state"
-msgstr ""
-
-#: pkg/storaged/index.html.h:47
-msgid "RAID Device"
-msgstr ""
-
-#: pkg/storaged/index.html.h:56
-msgid "Volume Group"
-msgstr ""
-
-#: pkg/storaged/index.html.h:57
-msgid "Physical Volumes"
-msgstr ""
-
-#: pkg/storaged/index.html.h:58
-msgid "Storage Log"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:1
-msgid "Domain Address"
-msgstr "Domenska Adresa"
-
-#: pkg/realmd/operation.html.h:2
-msgid "Computer OU"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:4 pkg/users/index.html.h:11
-msgid "User Name"
-msgstr "Korisničko ime"
-
-#: pkg/realmd/operation.html.h:5
-msgid "User Password"
-msgstr "Korisnička Lozinka"
-
-#: pkg/realmd/operation.html.h:6
-msgid "Domain Administrator Name"
-msgstr "Naziv Domenskog Administratora"
-
-#: pkg/realmd/operation.html.h:7
-msgid "Domain Administrator Password"
-msgstr "Lozinka Domenskog Administratora"
-
-#: pkg/realmd/operation.html.h:8
-msgid "One Time Password"
-msgstr "Jednokratna Lozinka"
-
-#: pkg/realmd/operation.html.h:9
-msgid "This may take a while"
-msgstr "Ovo bi moglo potrajati"
-
-#: pkg/docker/index.html.h:1 pkg/kubernetes/index.html.h:4
-#: pkg/kubernetes/views/containers-listing.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:6
-#: pkg/kubernetes/views/dashboard-page.html.h:17
-msgid "Containers"
-msgstr "Spremnici"
-
-#: pkg/docker/index.html.h:2
-msgid "Connecting to Docker"
-msgstr "Povezujem se na Docker"
-
-#: pkg/docker/index.html.h:3
-msgid "Not authorized to access Docker on this system"
-msgstr "Nemate dopuštenje da pristupite Docker-u na ovom sustavu"
-
-#: pkg/docker/index.html.h:4
-msgid "Docker is not installed or activated on the system"
-msgstr "Docker nije instaliran ili pokrenut na sustavu"
-
-#: pkg/docker/index.html.h:5
-#, fuzzy
-msgid "Can&rsquo;t connect to Docker"
-msgstr "Uspostavljanje veze sa Docker-om nije moguće"
-
-#: pkg/docker/index.html.h:6
-msgid "Start Docker"
-msgstr "Pokreni Docker"
-
-#: pkg/docker/index.html.h:7
-msgid "Try again"
-msgstr "Pokušaj ponovo"
-
-#: pkg/docker/index.html.h:8
-msgid "Combined CPU usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:9
-msgid "Combined memory usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:10
-#, fuzzy
-msgid "Show all containers"
-msgstr "Spremnici"
-
-#: pkg/docker/index.html.h:11
-#, fuzzy
-msgid "IP Address:"
-msgstr "IP adresa"
-
-#: pkg/docker/index.html.h:12
-#, fuzzy
-msgid "IP Prefix Length:"
-msgstr "Prefiks"
-
-#: pkg/docker/index.html.h:13
-msgid "Gateway:"
-msgstr ""
-
-#: pkg/docker/index.html.h:14
-#, fuzzy
-msgid "MAC Address:"
-msgstr "Adresa"
-
-#: pkg/docker/index.html.h:15 pkg/kubernetes/views/image-page.html.h:1
-msgid "Show all images"
-msgstr ""
-
-#: pkg/docker/index.html.h:16 pkg/kubernetes/index.html.h:2
-#: pkg/kubernetes/registry.html.h:2
-msgid "Overview"
-msgstr ""
-
-#: pkg/docker/index.html.h:17
-msgid "Reset"
-msgstr ""
-
-#: pkg/docker/index.html.h:18
-msgid "Storage pool"
-msgstr ""
-
-#: pkg/docker/index.html.h:19
-msgid "Additional Storage"
-msgstr ""
-
-#: pkg/docker/index.html.h:20
-msgid "TCP"
-msgstr "TCP"
-
-#: pkg/docker/index.html.h:21
-msgid "{{host_port_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:22
-msgid "{{host_volume_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:24
-msgid "ReadWrite"
-msgstr ""
-
-#: pkg/docker/index.html.h:25
-#, fuzzy
-msgid "ReadOnly"
-msgstr "Spreman"
-
-#: pkg/docker/index.html.h:26
-msgid "{{envvar_key_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:27
-msgid "{{envvar_value_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:28
-msgid "select container"
-msgstr ""
-
-#: pkg/docker/index.html.h:29
-msgid "{{alias_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:30 pkg/kubernetes/views/image-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:2
-#: pkg/kubernetes/views/image-page.html.h:2
-msgid "Image"
-msgstr ""
-
-#: pkg/docker/index.html.h:31
-msgid "Container Name"
-msgstr "Ime spremnika"
-
-#: pkg/docker/index.html.h:33
-msgid "Memory limit"
-msgstr ""
-
-#: pkg/docker/index.html.h:34
-msgid "MiB"
-msgstr ""
-
-#: pkg/docker/index.html.h:35
-msgid "CPU priority"
-msgstr "CPU prioritet"
-
-#: pkg/docker/index.html.h:36
-#, fuzzy
-msgid "shares"
-msgstr "Dijeljenje"
-
-#: pkg/docker/index.html.h:37
-msgid "With terminal"
-msgstr ""
-
-#: pkg/docker/index.html.h:38
-msgid "Links"
-msgstr "Linkovi"
-
-#: pkg/docker/index.html.h:40
-msgid "Expose container ports"
-msgstr ""
-
-#: pkg/docker/index.html.h:41 pkg/kubernetes/index.html.h:7
-#: pkg/kubernetes/views/image-config.html.h:9
-#: pkg/kubernetes/views/pod-page.html.h:3
-#: pkg/kubernetes/views/dashboard-page.html.h:4
-msgid "Volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:42
-msgid "Mount container volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:43 pkg/kubernetes/views/image-config.html.h:6
-#: pkg/kubernetes/views/container-body.html.h:9
-msgid "Environment"
-msgstr ""
-
-#: pkg/docker/index.html.h:44
-msgid "Set container environment variables"
-msgstr ""
-
-#: pkg/docker/index.html.h:45 pkg/kubernetes/views/pod-body.html.h:4
-msgid "Restart Policy"
-msgstr ""
-
-#: pkg/docker/index.html.h:47
-#, fuzzy
-msgid "On Failure"
-msgstr "Neuspjelo"
-
-#: pkg/docker/index.html.h:50
-msgid "Retries:"
-msgstr ""
-
-#: pkg/docker/index.html.h:51 pkg/users/index.html.h:26
-#: pkg/networkmanager/index.html.h:52
-msgid ""
-"\n"
-"            Cancel\n"
-"          "
-msgstr ""
-
-#: pkg/docker/index.html.h:54
-msgid ""
-"\n"
-"            Run\n"
-"          "
-msgstr ""
-
-#: pkg/docker/index.html.h:57
-msgid ""
-"\n"
-"            Download\n"
-"          "
-msgstr ""
-
-#: pkg/docker/index.html.h:60
-msgid ""
-"\n"
-"            Change\n"
-"          "
-msgstr ""
-
-#: pkg/docker/index.html.h:63
-msgid "Repository"
-msgstr "Repozitorij"
-
-#: pkg/docker/index.html.h:64
-msgid "Tag"
-msgstr "Oznaka"
-
-#: pkg/docker/index.html.h:65 pkg/kubernetes/views/image-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:5
-msgid "Author"
-msgstr "Autor"
-
-#: pkg/docker/index.html.h:66
-msgid ""
-"\n"
-"            Commit\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:1
-msgid "Local Accounts"
-msgstr ""
-
-#: pkg/users/index.html.h:2
-msgid ""
-"\n"
-"            Close\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:5
-msgid "Create New Account"
-msgstr ""
-
-#: pkg/users/index.html.h:6
-msgid "Account not available or cannot be edited."
-msgstr ""
-
-#: pkg/users/index.html.h:7
-msgid "Accounts"
-msgstr ""
-
-#: pkg/users/index.html.h:8
-msgid "Terminate Session"
-msgstr ""
-
-#: pkg/users/index.html.h:10
-msgid "Full Name"
-msgstr ""
-
-#: pkg/users/index.html.h:12
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:3
-#: pkg/kubernetes/views/project-body.html.h:2
-msgid "Roles"
-msgstr ""
-
-#: pkg/users/index.html.h:13
-msgid "Last Login"
-msgstr ""
-
-#: pkg/users/index.html.h:14
-msgid "Access"
-msgstr ""
-
-#: pkg/users/index.html.h:15
-msgid "Lock Account"
-msgstr ""
-
-#: pkg/users/index.html.h:17
-msgid "Set Password"
-msgstr ""
-
-#: pkg/users/index.html.h:18
-msgid "Authorized Public SSH Keys"
-msgstr ""
-
-#: pkg/users/index.html.h:20
-msgid ""
-"\n"
-"            Create\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:25
-msgid "Confirm New Password"
-msgstr ""
-
-#: pkg/users/index.html.h:29
-msgid ""
-"\n"
-"            Set\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:32
-msgid "Delete Files"
-msgstr ""
-
-#: pkg/users/index.html.h:33 pkg/networkmanager/index.html.h:48
-msgid ""
-"\n"
-"            Delete\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:36
-msgid "Unnamed"
-msgstr ""
-
-#: pkg/users/index.html.h:37
-msgid "Invalid key"
-msgstr ""
-
-#: pkg/users/index.html.h:38
-msgid "There are no authorized public keys for this account."
-msgstr ""
-
-#: pkg/users/index.html.h:39
-msgid ""
-"You do not have permission to view the authorized public keys for this "
-"account."
-msgstr ""
-
-#: pkg/users/index.html.h:40
-msgid "Failed to load authorized keys."
-msgstr ""
-
-#: pkg/users/index.html.h:41
-msgid "Add public key"
-msgstr ""
-
-#: pkg/users/index.html.h:42
-msgid ""
-"\n"
-"            Add key\n"
-"          "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:1
-msgid "Diagnostic reports"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:2
-msgid ""
-"\n"
-"        This tool will collect system configuration and diagnostic\n"
-"        information from this system for use with diagnosing problems\n"
-"        with the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:7
-msgid ""
-"\n"
-"        The collected information will be stored locally on the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:10
-msgid "Create report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:11
-msgid "Create diagnostic report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:12
-msgid ""
-"\n"
-"                The generated archive contains data considered\n"
-"                sensitive and its content should be reviewed by the\n"
-"                originating organization before being passed to any\n"
-"                third party.\n"
-"              "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:18
-msgid "Generating report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:19
-msgid "Done!"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:1
-msgid "Networking"
-msgstr "Mreža"
-
-#: pkg/networkmanager/index.html.h:2
-msgid "Testing connection"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:9
-msgid "Sending"
-msgstr "Slanje"
-
-#: pkg/networkmanager/index.html.h:10
-msgid "Receiving"
-msgstr "Primanje"
-
-#: pkg/networkmanager/index.html.h:11
-msgid "Interfaces"
-msgstr "Sučelja"
-
-#: pkg/networkmanager/index.html.h:12
-msgid "Add Bond"
-msgstr "Dodaj Bond"
-
-#: pkg/networkmanager/index.html.h:13
-#, fuzzy
-msgid "Add Team"
-msgstr "Dodaj Bond"
-
-#: pkg/networkmanager/index.html.h:14
-msgid "Add Bridge"
-msgstr "Dodaj Bridge"
-
-#: pkg/networkmanager/index.html.h:15
-msgid "Add VLAN"
-msgstr "Dodaj VLAN"
-
-#: pkg/networkmanager/index.html.h:17
-msgid "IP Address"
-msgstr "IP adresa"
-
-#: pkg/networkmanager/index.html.h:18
-#, fuzzy
-msgid "Unmanaged Interfaces"
-msgstr "Sučelja"
-
-#: pkg/networkmanager/index.html.h:19
-msgid "Networking Logs"
-msgstr "Mrežni Logovi"
-
-#: pkg/networkmanager/index.html.h:20
-msgid "Parent"
-msgstr "Roditelj"
-
-#: pkg/networkmanager/index.html.h:21
-msgid "VLAN Id"
-msgstr "VLAN id"
-
-#: pkg/networkmanager/index.html.h:23
-msgid "Set to"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:25
-msgid "Spanning Tree Protocol (STP)"
-msgstr "Spanning Tree Protocol (STP)"
-
-#: pkg/networkmanager/index.html.h:26
-msgid "STP Priority"
-msgstr "STP Prioritet"
-
-#: pkg/networkmanager/index.html.h:27
-msgid "STP Forward delay"
-msgstr "STP odgoda prosljeđivanja"
-
-#: pkg/networkmanager/index.html.h:28
-msgid "STP Hello time"
-msgstr "STP hello vrijeme"
-
-#: pkg/networkmanager/index.html.h:29
-msgid "STP Maximum message age"
-msgstr "STP maksimalna starost poruke"
-
-#: pkg/networkmanager/index.html.h:30
-msgid "Priority"
-msgstr "Prioritet"
-
-#: pkg/networkmanager/index.html.h:31
-msgid "Path cost"
-msgstr "Trošak putanje"
-
-#: pkg/networkmanager/index.html.h:32
-msgid "Hair Pin mode"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:34
-msgid "Mode"
-msgstr "Način"
-
-#: pkg/networkmanager/index.html.h:35
-msgid "Primary"
-msgstr "Primarni"
-
-#: pkg/networkmanager/index.html.h:36
-msgid "Link Monitoring"
-msgstr "Nadziranje veze"
-
-#: pkg/networkmanager/index.html.h:37
-msgid "Monitoring Interval"
-msgstr "Interval nadziranja"
-
-#: pkg/networkmanager/index.html.h:38
-msgid "Monitoring Targets"
-msgstr "Mete nadziranja"
-
-#: pkg/networkmanager/index.html.h:39
-msgid "Link up delay"
-msgstr "Odgoda podizanja linka"
-
-#: pkg/networkmanager/index.html.h:40
-msgid "Link down delay"
-msgstr "Odgoda gašenja linka"
-
-#: pkg/networkmanager/index.html.h:41
-#, fuzzy
-msgid "Runner"
-msgstr "Pokrenuto"
-
-#: pkg/networkmanager/index.html.h:42
-msgid "Balancer"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:43
-msgid "Link Watch"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:44
-#, fuzzy
-msgid "Ping Interval"
-msgstr "Interval nadziranja"
-
-#: pkg/networkmanager/index.html.h:45
-#, fuzzy
-msgid "Ping Target"
-msgstr "Mete nadziranja"
-
-#: pkg/networkmanager/index.html.h:46
-msgid "Sticky"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:47
-msgid "LACP Key"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:51
-msgid "IP Settings"
-msgstr "IP postavke"
-
-#: pkg/networkmanager/index.html.h:55
-msgid ""
-"\n"
-"            Apply\n"
-"          "
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:58
-msgid "Bond Settings"
-msgstr "Bond Postavke"
-
-#: pkg/networkmanager/index.html.h:59
-#, fuzzy
-msgid "Team Settings"
-msgstr "IP postavke"
-
-#: pkg/networkmanager/index.html.h:60
-#, fuzzy
-msgid "Team Port Settings"
-msgstr "Bridge Port Postavke"
-
-#: pkg/networkmanager/index.html.h:61
-msgid "Bridge Settings"
-msgstr "Bridge Postavke"
-
-#: pkg/networkmanager/index.html.h:62
-msgid "Bridge Port Settings"
-msgstr "Bridge Port Postavke"
-
-#: pkg/networkmanager/index.html.h:63
-msgid "VLAN Settings"
-msgstr "VLAN Postavke"
-
-#: pkg/networkmanager/index.html.h:64
-msgid "Ethernet MTU"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:66
-#, fuzzy
-msgid "Connection will be lost"
-msgstr "Bond Postavke"
-
-#: pkg/kubernetes/index.html.h:1
-msgid "Kubernetes Cluster"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:3 pkg/kubernetes/views/dashboard-page.html.h:8
-#: pkg/kubernetes/views/nodes-page.html.h:4
-msgid "Nodes"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:5
-msgid "Topology"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:8 pkg/kubernetes/registry.html.h:3
-#: pkg/kubernetes/views/image-listing.html.h:2
-#: pkg/kubernetes/views/imagestream-page.html.h:3
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:5
-msgid "Images"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:9 pkg/kubernetes/registry.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:2
-#: pkg/kubernetes/views/project-listing.html.h:2
-#: pkg/kubernetes/views/user-delete.html.h:2
-msgid "Projects"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:11 pkg/kubernetes/registry.html.h:6
-msgid "Couldn't connect to server"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:12 pkg/kubernetes/registry.html.h:7
-msgid ""
-"\n"
-"                Reconnect\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:15
-msgid ""
-"\n"
-"                Troubleshoot\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/registry.html.h:1
-msgid "Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:1
-#: pkg/kubernetes/views/service-body.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:1
-#: pkg/kubernetes/views/containers-listing.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:9
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:18
-#: pkg/kubernetes/views/route-body.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:5
-#: pkg/kubernetes/views/imagestream-modify.html.h:4
-msgid "Project"
-msgstr "Projekt"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:2
-#: pkg/kubernetes/views/service-body.html.h:2
-#: pkg/kubernetes/views/pod-body.html.h:2
-#: pkg/kubernetes/views/containers-listing.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:10
-#: pkg/kubernetes/views/pv-claim.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:19
-#: pkg/kubernetes/views/route-body.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:6
-msgid "Namespace"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:3
-#: pkg/kubernetes/views/pod-body.html.h:3
-#: pkg/kubernetes/views/node-body.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:3
-#: pkg/kubernetes/views/route-body.html.h:3
-msgid "Created"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:4
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:17
-msgid "Replicas"
-msgstr "Replike"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:5
-#: pkg/kubernetes/views/service-body.html.h:9
-#: pkg/kubernetes/views/pod-body.html.h:10
-#: pkg/kubernetes/views/node-body.html.h:12
-#: pkg/kubernetes/views/image-meta.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:8
-#: pkg/kubernetes/views/route-body.html.h:8
-msgid "Labels"
-msgstr ""
-
-#: pkg/kubernetes/views/service-body.html.h:4
-#: pkg/kubernetes/views/node-body.html.h:3
-msgid "IP"
-msgstr ""
-
-#: pkg/kubernetes/views/service-body.html.h:8
-msgid "Session Affinity"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:1
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:10
-msgid "New image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:3
-#: pkg/kubernetes/views/image-body.html.h:10
-#: pkg/kubernetes/views/imagestream-modify.html.h:7
-msgid "Tags"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:5
-msgid "Last Updated"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:6
-msgid "No image streams are present."
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:1
-#, fuzzy
-msgid "Delete Node"
-msgstr "Izbriši"
-
-#: pkg/kubernetes/views/node-delete.html.h:2
-msgid "Do you want to delete this Node?"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:3
-msgid " 1\">Do you want to delete the following Nodes?"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-container.html.h:1
-#, fuzzy
-msgid "Show all Pod Containers"
-msgstr "Spremnici"
-
-#: pkg/kubernetes/views/image-panel.html.h:3
-#: pkg/kubernetes/views/imagestream-page.html.h:4
-#: pkg/kubernetes/views/image-page.html.h:4
-msgid "Metadata"
-msgstr ""
-
-#: pkg/kubernetes/views/node-panel.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:8
-#: pkg/kubernetes/views/containers-listing.html.h:6
-#: pkg/kubernetes/views/node-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:11
-msgid "Node"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:1
-msgid "Show all Replication Controllers"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:2
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:5
-msgid "Replication Controller"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:2
-#: pkg/kubernetes/views/pv-claim.html.h:9
-#: pkg/kubernetes/views/dashboard-page.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:18
-msgid "Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:2
-msgid "Template"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:5
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/group-delete.html.h:1
-msgid "Remove Group"
-msgstr ""
-
-#: pkg/kubernetes/views/group-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:5
-#: pkg/kubernetes/views/user-group-remove.html.h:3
-msgid "Remove"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:1
-msgid "Delete Persistent Volume Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:2
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:3
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:5
-msgid "Service Account"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:6
-msgid "DNS Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:7
-msgid "Phase"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:9
-msgid "Pod Address"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:5
-msgid "OS"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:7
-msgid "Boot ID"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:8
-#, fuzzy
-msgid "Kernel Version"
-msgstr "Inačica"
-
-#: pkg/kubernetes/views/node-body.html.h:9
-msgid "Container Runtime Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:10
-msgid "Kubelet Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:11
-msgid "Proxy Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:13
-#: pkg/kubernetes/views/route-body.html.h:9
-msgid "none"
-msgstr "nijedan"
-
-#: pkg/kubernetes/views/node-body.html.h:17
-msgid "Reason"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:18
-#: pkg/kubernetes/views/pv-claim.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:6 pkg/kubernetes/views/pv-body.html.h:6
-msgid "Message"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:19
-msgid "Last Heartbeat"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:20
-msgid "Last Status Change"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:21
-#: pkg/kubernetes/views/image-meta.html.h:3
-#: pkg/kubernetes/views/imagestream-meta.html.h:1
-#: pkg/kubernetes/views/route-body.html.h:10
-msgid "Annotations"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:1
-msgid "Remove Role"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:2
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member "
-"{{ fields.member.metadata.name }}?"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:1
-msgid "New Project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:6
-msgid "No projects are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:7
-msgid "New Group"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:8
-#: pkg/kubernetes/views/user-delete.html.h:3
-msgid "Groups"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:9
-msgid "No groups are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:10
-#: pkg/kubernetes/views/add-user-dialog.html.h:1
-msgid "Add User"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:11
-msgid "Users"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:12
-msgid "Identity"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:13
-msgid "Member of"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:14
-msgid "No users are present."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:1
-#, fuzzy
-msgid "Cluster"
-msgstr "Glavni"
-
-#: pkg/kubernetes/views/auth-form.html.h:2
-msgid "Add New Cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:4
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:3
-msgid "Skip Certificate Verification"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:5
-#, fuzzy
-msgid "Requires Authentication"
-msgstr "Autentifikacija"
-
-#: pkg/kubernetes/views/auth-form.html.h:7
-msgid "Add New User"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:9
-msgid "Client Certificate"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:10
-#, fuzzy
-msgid "Username"
-msgstr "Korisničko ime"
-
-#: pkg/kubernetes/views/auth-form.html.h:12
-msgid "Token"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:1
-msgid "Add Cluster Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:4
-msgid "Configuration"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:5
-msgid "Configure Kubelet and Proxy"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:6
-msgid "Configure Flannel networking"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:1
-#: pkg/kubernetes/views/pvc-body.html.h:1
-msgid "Volume Type"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:2
-msgid "{{ volume | formatVolumeType }}"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:3
-#, fuzzy
-msgid "PD Name"
-msgstr "Naziv"
-
-#: pkg/kubernetes/views/volume-body.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:19
-msgid "Filesystem Type"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:6
-#: pkg/kubernetes/views/pv-modify.html.h:20
-#, fuzzy
-msgid "Read Only"
-msgstr "Spreman"
-
-#: pkg/kubernetes/views/volume-body.html.h:7
-msgid "Volume ID"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:8
-#, fuzzy
-msgid "Repository URL"
-msgstr "Repozitorij"
-
-#: pkg/kubernetes/views/volume-body.html.h:9
-#, fuzzy
-msgid "Revision"
-msgstr "Inačica"
-
-#: pkg/kubernetes/views/volume-body.html.h:10
-#: pkg/kubernetes/views/image-config.html.h:3
-msgid "Directory"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:12
-msgid "Medium"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:13
-#: pkg/kubernetes/views/pv-modify.html.h:14
-#, fuzzy
-msgid "Path"
-msgstr "Trošak putanje"
-
-#: pkg/kubernetes/views/volume-body.html.h:14
-msgid "Endpoint Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:15
-#: pkg/kubernetes/views/pv-modify.html.h:13
-#, fuzzy
-msgid "Volume Name"
-msgstr "Korisničko ime"
-
-#: pkg/kubernetes/views/volume-body.html.h:17
-#, fuzzy
-msgid "Monitors"
-msgstr "ARP nadziranje"
-
-#: pkg/kubernetes/views/volume-body.html.h:18
-#, fuzzy
-msgid "Image Name"
-msgstr "Preslika $0"
-
-#: pkg/kubernetes/views/volume-body.html.h:19
-#, fuzzy
-msgid "Pool Name"
-msgstr "Naziv"
-
-#: pkg/kubernetes/views/volume-body.html.h:21
-msgid "Key Ring Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:22
-msgid "Secret Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:23
-msgid "Target Portal"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:24
-#: pkg/kubernetes/views/pv-modify.html.h:16
-msgid "Qualified Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:25
-#: pkg/kubernetes/views/pv-modify.html.h:17
-msgid "Logical Unit Number"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:26
-#: pkg/kubernetes/views/pv-modify.html.h:18
-#, fuzzy
-msgid "Interface"
-msgstr "Sučelja"
-
-#: pkg/kubernetes/views/volume-body.html.h:27
-#, fuzzy
-msgid "Ceph Monitors"
-msgstr "Repozitorij"
-
-#: pkg/kubernetes/views/volume-body.html.h:28
-msgid "Secret File"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:29
-msgid "Target World Wide Names"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:30
-msgid "Flocker Dataset Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:31
-#, fuzzy
-msgid "Driver"
-msgstr "Pogon"
-
-#: pkg/kubernetes/views/volume-body.html.h:33
-#, fuzzy
-msgid "Share Name"
-msgstr "Korisničko ime"
-
-#: pkg/kubernetes/views/volume-body.html.h:34
-#, fuzzy
-msgid "Secret Name"
-msgstr "Korisničko ime"
-
-#: pkg/kubernetes/views/image-meta.html.h:2
-msgid "On Build"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:4
-msgid "Docker Version"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:5
-#, fuzzy
-msgid "Image Layers"
-msgstr "Preslika $0"
-
-#: pkg/kubernetes/views/group-page.html.h:1
-#: pkg/kubernetes/views/user-page.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:1
-msgid "Show all Projects"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:2
-#: pkg/kubernetes/views/group-panel.html.h:1
-#, fuzzy
-msgid "Group Members"
-msgstr "Članovi"
-
-#: pkg/kubernetes/views/group-page.html.h:3
-#: pkg/kubernetes/views/user-group-add.html.h:1
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:1
-#: pkg/kubernetes/views/group-panel.html.h:2
-#: pkg/kubernetes/views/project-body.html.h:10
-msgid "Add Member"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:4
-msgid "The group '{{ groupName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/containers-listing.html.h:3
-#: pkg/kubernetes/views/pod-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:2
-msgid "Pod"
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:2
-msgid "Membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:2
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:5
-#: pkg/kubernetes/views/user-panel.html.h:7
-#, fuzzy
-msgid "Add Membership"
-msgstr "Članovi"
-
-#: pkg/kubernetes/views/user-group-add.html.h:2
-msgid ""
-"\n"
-"                        User\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:2
-msgid "User or Group"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-panel.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:4
-#, fuzzy
-msgid "Mount Location"
-msgstr "Točka pristupa"
-
-#: pkg/kubernetes/views/route-modify.html.h:1
-msgid "Adjust Route"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:1
-msgid "Show all Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:2 pkg/kubernetes/views/pvc-body.html.h:3
-#: pkg/kubernetes/views/pv-panel.html.h:1
-msgid "Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:3 pkg/kubernetes/views/pv-panel.html.h:2
-msgid "Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:4
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:1
-msgid "Remove image tag"
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:2
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:1
-msgid "Run as"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:4
-msgid "Stop with"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:1
-msgid "Delete Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:2
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:3
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
-"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
-"may cause issues with any pods depending on it."
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:3
-msgid "Identities"
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:3
-msgid "The user '{{ userName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:1
-msgid "Show all Deployment Configs"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:1
-msgid "Deployment Config"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:4
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/route-panel.html.h:1
-#: pkg/kubernetes/views/route-page.html.h:2
-#, fuzzy
-msgid "Route"
-msgstr "Putanje"
-
-#: pkg/kubernetes/views/volumes-page.html.h:1
-msgid "Register New Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:2
-msgid "Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:7
-msgid "No volumes are present."
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:8
-msgid "Pending Volume Claims"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:12
-msgid "When"
-msgstr ""
-
-#: pkg/kubernetes/views/user-delete.html.h:1
-msgid "Remove User"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:3
-#: pkg/kubernetes/views/pv-modify.html.h:10
-#: pkg/kubernetes/views/pvc-body.html.h:7 pkg/kubernetes/views/pv-body.html.h:2
-msgid "Access Modes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:4
-msgid "Requests"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:5
-msgid "This volume has not been claimed"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:10
-msgid "No Pods are using this claim"
-msgstr ""
-
-#: pkg/kubernetes/views/filter-project.html.h:1
-msgid "All Projects"
-msgstr ""
-
-#: pkg/kubernetes/views/filter-project.html.h:2
-msgid "Project:"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:5
-#: pkg/kubernetes/views/details-page.html.h:14
-msgid "Latest Version"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:6
-msgid "Deployment Causes"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:7
-msgid "Triggers"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:1
-msgid "Delete {{ item.kind }}"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:2
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:3
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:2
-#: pkg/kubernetes/views/user-modify.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:2
-msgid ""
-"\n"
-"                        Name\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:5
-#: pkg/kubernetes/views/user-modify.html.h:5
-msgid ""
-"\n"
-"                        Identity\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:1
-msgid "Project Members"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:3
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:6
-msgid "Admin"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:7
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/container-panel.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:3
-msgid "Shell"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:1
-msgid "Pod Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:2
-msgid "No pods selected"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:3
-msgid "Pod Selector"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:1
-msgid "Add membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:2
-msgid ""
-"\n"
-"                        Group or Project\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:5
-msgid ""
-"\n"
-"                        Role\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:1
-msgid "Deploy Application"
-msgstr "Stavi aplikaciju u pogon"
-
-#: pkg/kubernetes/views/deploy.html.h:3
-msgid "{{ selected.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:5
-#: pkg/kubernetes/views/dashboard-page.html.h:11
-msgid "Deploy"
-msgstr ""
-
-#: pkg/kubernetes/views/user-modify.html.h:1
-msgid "Change User"
-msgstr ""
-
-#: pkg/kubernetes/views/user-modify.html.h:9
-msgid "Modify"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:1
-#: pkg/kubernetes/views/project-modify.html.h:6
-msgid "Access Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:2
-msgid ""
-"\n"
-"          Images may be pulled by anonymous users\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:5
-msgid ""
-"\n"
-"          Images may be pulled by any authenticated user or group\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:8
-msgid ""
-"\n"
-"          Images may only be pulled by specific users or groups\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:11
-msgid "Pull repository"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:13
-msgid "Image count"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:14
-msgid "{{stream.status.tags.length}}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:15
-msgid "To push to an image to this image stream:"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:1
-msgid "The node doesn't have enough disk space"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:2
-msgid "The node doesn't have enough free memory"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:1
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:2
-msgid "Register Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:4
-msgid "Warning:"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:5
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:7
-#: pkg/kubernetes/views/node-page.html.h:3
-#: pkg/kubernetes/views/pvc-body.html.h:10
-#: pkg/kubernetes/views/pv-body.html.h:3
-msgid "Capacity"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:8
-#: pkg/kubernetes/views/pv-body.html.h:1
-msgid "Reclaim Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:9
-msgid "{{ value }}"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:12
-msgid "Endpoint"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:15
-msgid "Target"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-dialog.html.h:1
-#, fuzzy
-msgid "Connection Settings"
-msgstr "Bond Postavke"
-
-#: pkg/kubernetes/views/auth-dialog.html.h:2
-#, fuzzy
-msgid "Connection Error"
-msgstr "Povezujem se na Docker"
-
-#: pkg/kubernetes/views/image-body.html.h:2
-msgid "Summary"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:4
-msgid "Source URL"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:7
-msgid "Built"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:8
-msgid "Digest"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:9
-msgid "Identifier"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:11
-msgid "To pull this image:"
-msgstr ""
-
-#: pkg/kubernetes/views/service-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:8
-#: pkg/kubernetes/views/service-page.html.h:2
-msgid "Service"
-msgstr ""
-
-#: pkg/kubernetes/views/service-panel.html.h:2
-#: pkg/kubernetes/views/service-page.html.h:3
-msgid "Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:1
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:2
+#: pkg/kubernetes/views/auth-rejected-cert.html:3
 msgid ""
 "You can bypass the certificate check, but any data you send to the server "
 "could be intercepted by others."
 msgstr ""
 
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:4
-msgid "Trust this certificate for this connection"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:1
-msgid "Show all Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:7
-msgid "The pod '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:1
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:1
-msgid "Delete image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:2
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:2
-#, fuzzy
-msgid "All running"
-msgstr "Pokrenuto"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:3
-msgid "No pods deployed"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:5
-msgid "All in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:6
-msgid "No volumes in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:7
-msgid "pending volume claims"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:9
-msgid "All healthy"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:10
-msgid "No nodes in cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:13
-msgid "Could not list services"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:14
+#: pkg/kubernetes/views/dashboard-page.html:150
 msgid "You can deploy an application to your cluster."
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-page.html.h:1
-msgid "Show all image streams"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-page.html.h:2
-msgid "Image Stream"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:3
-msgid "Image ID"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:4
-msgid "Container ID"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:7
-msgid "Since"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:8
-msgid "Restart Count"
-msgstr ""
-
-#: pkg/kubernetes/views/user-remove-membership.html.h:1
-msgid "Remove membership"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:1
-msgid "Delete Selected"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:2
-#, fuzzy
-msgid "OS Versions"
-msgstr "Inačica"
-
-#: pkg/kubernetes/views/nodes-page.html.h:3
-msgid "Add Kubernetes Node"
-msgstr ""
-
-#: pkg/kubernetes/views/project-page.html.h:3
-msgid "The project '{{ projName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/user-panel.html.h:4
+#: pkg/lib/machine-invalid-hostkey.html:11
 msgid ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
+"You can remove the previously stored key by running the following command"
 msgstr ""
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:1
-msgid "Pod Replicated"
+#: pkg/shell/base_index.js:672
+msgid "You can try restarting Cockpit by pressing refresh in your browser. "
 msgstr ""
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:2
-msgid "No pods replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/container-page.html.h:1
-#, fuzzy
-msgid "Show all Containers"
-msgstr "Spremnici"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:1
-msgid "Welcome to the Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:2
+#: pkg/users/index.html:335
 msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
+"You do not have permission to view the authorized public keys for this "
+"account."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:1
-msgid "New project"
+#: pkg/docker/storage.jsx:482
+msgid "You don't have permission to manage the Docker storage pool."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:4
-msgid "Images by project"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:6
-msgid "Images pushed recently"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:7
-msgid "All images"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:8
-msgid "No images pushed"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:9
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:11
-msgid "Login commands"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:12
-msgid "Log into the registry:"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:13
+#: pkg/kubernetes/views/registry-dashboard-page.html:112
 msgid ""
 "Your login credentials do not give you access to use the docker registry "
 "from the command line."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:14
-msgid "Log into OpenShift command line tools:"
+#: src/base1/cockpit.js:3687
+msgid "Your session has been terminated."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:15
+#: src/base1/cockpit.js:3689
+msgid "Your session has expired. Please log in again."
+msgstr ""
+
+#: pkg/lib/journal.js:213
+msgid "[$0 bytes of binary data]"
+msgstr ""
+
+#: pkg/lib/journal.js:215
+msgid "[binary data]"
+msgstr ""
+
+#: pkg/lib/journal.js:209
+msgid "[no data]"
+msgstr ""
+
+#: pkg/storaged/details.js:1692
+msgid "active, but unsupported"
+msgstr ""
+
+#: pkg/storaged/utils.js:88
+msgctxt "format-bytes"
+msgid "bytes"
+msgstr "bajtova"
+
+#: pkg/docker/util.js:123
+msgid "default"
+msgstr "zadano"
+
+#: pkg/storaged/details.js:178
+msgid "ext4 - Red Hat Enterprise Linux 6 default"
+msgstr ""
+
+#: pkg/systemd/host.js:661
 #, fuzzy
-msgid "Image commands"
-msgstr "Preslika $0"
+msgid "failed to list ssh host keys: $0"
+msgstr "Pokretanje Docker-a neuspjelo: $0"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:16
-msgid "Push an image:"
+#: pkg/storaged/index.html:135
+msgid "iSCSI Targets"
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:17
-msgid "Pull an image:"
+#: pkg/storaged/details.js:1692
+msgid "inactive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html.h:1
-msgid "Show all Nodes"
+#: pkg/storaged/details.js:1286
+msgid "locked"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html.h:4
-msgid "The node '{{ target }}' does not exist."
+#: pkg/storaged/details.js:1278
+msgid "mounted on $0"
 msgstr ""
 
-#: pkg/kubernetes/views/route-page.html.h:1
-msgid "Show all Routes"
-msgstr ""
-
-#: pkg/kubernetes/views/route-page.html.h:3
-msgid "The route '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:1
-msgid "Select an object to see more details."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:3
-msgid ""
-"Pods contain one or more containers that run\n"
-"                together on a node, containing your application code."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:6
-msgid ""
-"Replication controllers dynamically create instances of\n"
-"                pods from templates, and remove pods when necessary."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:9
-msgid ""
-"Services group pods and provide a common DNS\n"
-"                name and an optional, load-balanced IP address to access "
-"them."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:12
-msgid "Nodes are the machines that run your containers."
-msgstr ""
-
-#: pkg/kubernetes/views/add-group-dialog.html.h:1
-msgid "Add Group"
-msgstr ""
-
-#: pkg/kubernetes/views/file-button.html.h:1
-msgid "Select Manifest File..."
-msgstr "Odaberite manifest datoteku..."
-
-#: pkg/kubernetes/views/project-modify.html.h:2
-msgid "Change project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-modify.html.h:4
-msgid "Display name"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:5
-msgid "TLS Termination"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:6
-msgid "yes"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:7
+#: pkg/kubernetes/views/route-body.html:14
 msgid "no"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:1
+#: pkg/kubernetes/views/route-body.html:24
+#: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
+msgid "none"
+msgstr "nijedan"
+
+#: pkg/storaged/details.js:1280
+msgid "not mounted"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:83
+msgid "pending volume claims"
+msgstr ""
+
+#: pkg/tuned/change-profile.jsx:52
+msgid "recommended"
+msgstr ""
+
+#: pkg/docker/index.html:426
+msgid "select container"
+msgstr ""
+
+#: pkg/docker/index.html:504 pkg/docker/index.html:683
 #, fuzzy
-msgid "Add Role"
-msgstr "Dodaj Bond"
+msgid "shares"
+msgstr "Dijeljenje"
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:2
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#: pkg/selinux/setroubleshoot-view.jsx:118
+msgid "solution details"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:1
+#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
 #, fuzzy
-msgid "All Types"
-msgstr "Tip"
+msgid "unknown"
+msgstr "Nepoznato"
 
-#: pkg/kubernetes/views/details-page.html.h:2
-#, fuzzy
-msgid "Type:"
-msgstr "Tip"
-
-#: pkg/kubernetes/views/details-page.html.h:13
-msgid "Deployment Configs"
+#: pkg/storaged/jobs.js:180
+msgid "unknown target"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:15
-msgid "Not deployed"
+#: pkg/storaged/details.js:1284
+msgid "unlocked"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:16
-msgid "Replication Controllers"
+#: pkg/kubernetes/views/route-body.html:13
+msgid "yes"
 msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:1
-msgid "Adjust Service"
-msgstr ""
-
-#: pkg/kubernetes/views/service-modify.html.h:3
+#: pkg/kubernetes/views/service-modify.html:16
 msgid "{{ item.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:5
-msgid "Adjust"
-msgstr "Prilagodi"
+#: pkg/kubernetes/views/deploy.html:27
+msgid "{{ selected.name }}"
+msgstr ""
 
-#: pkg/kubernetes/views/project-delete.html.h:1
+#: pkg/kubernetes/views/pv-modify.html:61
+#: pkg/kubernetes/views/pv-modify.html:74
+msgid "{{ value }}"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:2
+msgid "{{ volume | formatVolumeType }}"
+msgstr ""
+
+#: pkg/storaged/index.html:147
+msgid "{{Address}}:{{Port}}"
+msgstr ""
+
+#: pkg/docker/index.html:435
+msgid "{{alias_label}}"
+msgstr ""
+
+#: pkg/systemd/services.html:173 pkg/systemd/services.html:202
+msgid "{{days_text}}"
+msgstr ""
+
+#: pkg/docker/index.html:403
+msgid "{{envvar_key_label}}"
+msgstr ""
+
+#: pkg/docker/index.html:407
+msgid "{{envvar_value_label}}"
+msgstr ""
+
+#: pkg/docker/index.html:359
+msgid "{{host_port_label}}"
+msgstr ""
+
+#: pkg/docker/index.html:373
+msgid "{{host_volume_label}}"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:35
+msgid "{{stream.status.tags.length}}"
+msgstr ""
+
 #, fuzzy
-msgid "Delete Project"
-msgstr "Projekt"
+#~ msgid "Image Layers Example"
+#~ msgstr "Preslika $0"
 
-#: pkg/kubernetes/views/pvc-body.html.h:2
 #, fuzzy
-msgid "Claim Name"
-msgstr "Ime spremnika"
+#~ msgid "Cockpit Monitoring"
+#~ msgstr "Nadziranje veze"
 
-#: pkg/kubernetes/views/pvc-body.html.h:4
-msgid "No Volume Bound"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-body.html.h:8
-msgid "Requested"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-body.html.h:9
-msgid "Actual"
-msgstr ""
-
-#: pkg/kubernetes/views/node-capacity.html.h:1
-msgid "Scheduled Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/node-capacity.html.h:2
-msgid "No pods scheduled"
-msgstr ""
-
-#: pkg/kubernetes/views/container-page-inline.html.h:4
-msgid "The container '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:1
-msgid "Create image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:2
-msgid "Change image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:5
-msgid "Populate"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:6
-msgid "Pull from"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:8
-msgid "Remote registry is insecure"
-msgstr ""
-
-#: pkg/kubernetes/views/user-group-remove.html.h:1
 #, fuzzy
-msgid "Remove Member"
-msgstr "Članovi"
-
-#: pkg/kubernetes/views/service-page.html.h:1
-msgid "Show all Services"
-msgstr ""
-
-#: pkg/kubernetes/views/service-page.html.h:4
-msgid "The service '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/scripts/frob-layers.html.h:1
-#, fuzzy
-msgid "Image Layers Example"
-msgstr "Preslika $0"
-
-#: pkg/playground/service.html.h:1
-msgid "Cockpit Generic Service Monitor"
-msgstr ""
-
-#: pkg/playground/jquery-patterns.html.h:1
-msgid "Cockpit Pattern Usage"
-msgstr ""
-
-#: pkg/playground/metrics.html.h:1
-#, fuzzy
-msgid "Cockpit Monitoring"
-msgstr "Nadziranje veze"
-
-#: pkg/playground/test.html.h:1 pkg/playground/translate.html.h:1
-msgid "Cockpit playground"
-msgstr ""
-
-#: pkg/playground/react-patterns.html.h:1
-msgid "Cockpit React Patterns Usage"
-msgstr ""
-
-#: pkg/playground/speed.html.h:1
-msgid "Cockpit Speed Tests"
-msgstr ""
-
-#: pkg/playground/plot.html.h:1
-#, fuzzy
-msgid "Cockpit Plots"
-msgstr "Cockpit"
-
-#: pkg/dashboard/index.html.h:1
-msgid "Dashboard"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:5
-#, fuzzy
-msgid "Disk I/O"
-msgstr "Tvrdi disk"
-
-#: pkg/dashboard/index.html.h:6
-msgid "Lost connection. Trying to reconnect"
-msgstr "Veza prekinuta.  Pokušavam ponovo uspostaviti vezu"
-
-#: pkg/dashboard/index.html.h:10
-msgid "Avatar"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:13
-msgid "Set"
-msgstr ""
+#~ msgid "Cockpit Plots"
+#~ msgstr "Cockpit"
 
 #~ msgid "page-title"
 #~ msgstr "naslov-stranice"

--- a/po/html2po
+++ b/po/html2po
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+
+/*
+ * Extracts translatable strings from HTML files in the following forms:
+ *
+ * <tag translate>String</tag>
+ * <tag translate context="value">String</tag>
+ * <tag translate="...">String</tag>
+ * <tag translate-attr attr="String"></tag>
+ *
+ * Supports the following Glade compatible forms:
+ *
+ * <tag translatable="yes">String</tag>
+ * <tag translatable="yes" context="value">String</tag>
+ *
+ * Supports the following angular-gettext compatible forms:
+ *
+ * <translate>String</translate>
+ * <tag translate-plural="Plural">Singular</tag>
+ *
+ * Note that some of the use of the translated may not support all the strings
+ * depending on the code actually using these strings to translate the HTML.
+ */
+
+
+function fatal(message, code) {
+    console.log((filename || "html2po") + ": " + message);
+    process.exit(code || 1);
+}
+
+function usage() {
+    console.log("usage: html2po input output");
+    process.exit(2);
+}
+
+var fs, htmlparser, path, stdio;
+
+try {
+    fs = require('fs');
+    path = require('path');
+    htmlparser = require('htmlparser');
+    stdio = require('stdio');
+} catch (ex) {
+    fatal(ex.message, 127); /* missing looks for this */
+}
+
+var opts = stdio.getopt({
+    directory: { key: "d", args: 1, description: "Base directory for input files" },
+    output: { key: "o", args: 1, description: "Output file" },
+    from: { key: "f", args: 1, description: "File containing list of input files" },
+});
+
+if (!opts.from && opts.args.length < 1) {
+    usage();
+}
+
+var input = opts.args;
+var entries = { };
+
+/* Filename being parsed and offset of line number */
+var filename = null;
+var offsets = 0;
+
+/* The HTML parser we're using */
+var handler = new htmlparser.DefaultHandler(function(error, dom) {
+    if (error)
+        fatal(error);
+    else
+        walk(dom);
+});
+
+prepare();
+
+/* Decide what input files to process */
+function prepare() {
+    if (opts.from) {
+        fs.readFile(opts.from, { encoding: "utf-8"}, function(err, data) {
+            if (err)
+                fatal(err.message);
+            input = data.split("\n").filter(function(value) {
+                return !!value;
+            }).concat(input);
+            step();
+        });
+    } else {
+        step();
+    }
+}
+
+/* Now process each file in turn */
+function step() {
+    filename = input.shift();
+    if (filename === undefined) {
+        finish();
+        return;
+    }
+
+    /* Qualify the filename if necessary */
+    var full = filename;
+    if (opts.directory)
+        full = path.join(opts.directory, filename);
+
+    fs.readFile(full, { encoding: "utf-8"}, function(err, data) {
+        if (err)
+            fatal(err.message);
+
+        var parser = new htmlparser.Parser(handler, { includeLocation: true });
+        parser.parseComplete(data);
+        step();
+    });
+}
+
+/* Process an array of nodes */
+function walk(children) {
+    if (!children)
+        return;
+
+    children.forEach(function(child) {
+        var line = (child.location || { }).line || 0;
+        var offset = line - 1;
+
+        /* Scripts get their text processed as HTML */
+        if (child.type == 'script' && child.children) {
+            var parser = new htmlparser.Parser(handler, { includeLocation: true });
+
+            /* Make note of how far into the outer HTML file we are */
+            offsets += offset;
+
+            child.children.forEach(function(node) {
+                parser.parseChunk(node.raw);
+            });
+            parser.done();
+
+            offsets -= offset;
+
+        /* Tags get extracted as usual */
+        } else if (child.type == 'tag') {
+            tag(child);
+        }
+    });
+}
+
+/* Process a single loaded tag */
+function tag(node) {
+
+    var tasks, line, entry;
+    var attrs = node.attribs || { };
+    var nest = true;
+
+    /* Extract translate strings */
+    if (node.name == "translate" || "translate" in attrs || "translatable" in attrs) {
+        tasks = (attrs["translate"] || attrs["translatable"] || "yes").split(" ");
+
+        /* Calculate the line location taking into account nested parsing */
+        line = (node.location || { })["line"] || 0;
+        line += offsets;
+
+        entry = {
+            msgctxt: attrs['translate-context'] || attrs['context'],
+            msgid_plural: attrs['translate-plural'],
+            locations: [ filename + ":" + line ]
+        };
+
+        /* For each thing listed */
+        tasks.forEach(function(task) {
+            var copy = Object.assign({}, entry);
+
+            /* The element text itself */
+            if (task == "yes" || task == "translate") {
+                copy.msgid = extract(node.children);
+                nest = false;
+
+            /* An attribute */
+            } else if (task) {
+                copy.msgid = attrs[task];
+            }
+
+            if (copy.msgid)
+                push(copy);
+        });
+    }
+
+    /* Walk through all the children */
+    if (nest)
+        walk(node.children);
+}
+
+/* Push an entry onto the list */
+function push(entry) {
+    var key = entry.msgid + "\0" + entry.msgid_plural + + "\0" + entry.msgctxt;
+    var prev = entries[key];
+    if (prev) {
+        prev.locations = prev.locations.concat(entry.locations);
+    } else {
+        entries[key] = entry;
+    }
+}
+
+/* Extract the given text */
+function extract(children) {
+    if (!children)
+        return null;
+
+    var i, len, node, str = [];
+    children.forEach(function(node) {
+        if (node.type == 'tag' && node.children)
+            str.push(extract(node.children))
+        else if (node.type == 'text' && node.data)
+            str.push(node.data);
+    });
+
+    return str.join("");
+}
+
+/* Escape a string for inclusion in po file */
+function escape(string) {
+    var bs = string.split('\\').join('\\\\').split('"').join('\\"');
+    return bs.split("\n").map(function(line) {
+        return '"' + line + '"';
+    }).join("\n");
+}
+
+/* Finish by writing out the strings */
+function finish() {
+    var result = [
+        'msgid ""',
+        'msgstr ""',
+        '"Project-Id-Version: PACKAGE_VERSION\\n"',
+        '"MIME-Version: 1.0\\n"',
+        '"Content-Type: text/plain; charset=UTF-8\\n"',
+        '"Content-Transfer-Encoding: 8bit\\n"',
+        '"X-Generator: Cockpit html2po\\n"',
+        '',
+    ];
+
+    var msgid, entry;
+    for (msgid in entries) {
+        entry = entries[msgid];
+        result.push('#: ' + entry.locations.join(" "));
+        if (entry.msgctxt)
+            result.push('msgctxt ' + escape(entry.msgctxt));
+        result.push('msgid ' + escape(entry.msgid));
+        if (entry.msgid_plural) {
+            result.push('msgid_plural ' + escape(entry.msgid_plural));
+            result.push('msgstr[0] ""');
+            result.push('msgstr[1] ""');
+        } else {
+            result.push('msgstr ""');
+        }
+        result.push('');
+    }
+
+    var data = result.join('\n');
+    if (!opts.output) {
+        process.stdout.write(data);
+        process.exit(0);
+    } else {
+        fs.writeFile(opts.output, data, function(err) {
+            if (err)
+                fatal(err.message);
+            process.exit(0);
+        });
+    }
+}

--- a/po/html2po
+++ b/po/html2po
@@ -148,7 +148,7 @@ function tag(node) {
     var nest = true;
 
     /* Extract translate strings */
-    if (node.name == "translate" || "translate" in attrs || "translatable" in attrs) {
+    if ("translate" in attrs || "translatable" in attrs) {
         tasks = (attrs["translate"] || attrs["translatable"] || "yes").split(" ");
 
         /* Calculate the line location taking into account nested parsing */

--- a/po/ko.po
+++ b/po/ko.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-17 19:28+0100\n"
+"POT-Creation-Date: 2016-11-18 06:44+0100\n"
 "PO-Revision-Date: 2016-01-13 03:30-0500\n"
 "Last-Translator: MinWoo Joh <igtzhsou@naver.com>\n"
 "Language-Team: Korean\n"
@@ -15,173 +15,472 @@ msgstr ""
 "X-Generator: Zanata 3.8.4\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 
-#: src/ws/cockpitcertificate.c:359
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr ""
-
-#: src/ws/cockpitcertificate.c:364
-msgid "No PEM-encoded private key found"
-msgstr ""
-
-#: src/ws/cockpitcertificate.c:374
-msgid "Could not parse PEM-encoded private key"
-msgstr ""
-
-#: src/ws/cockpitcertificate.c:398
-msgid "No PEM-encoded certificate found"
-msgstr ""
-
-#: src/ws/cockpitcertificate.c:407
-msgid "Could not parse PEM-encoded certificate"
-msgstr ""
-
-#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
-#: src/bridge/cockpitdbussetup.c:625
-msgid "Unsupported setup mechanism"
-msgstr ""
-
-#: src/bridge/cockpitdbussetup.c:236
-msgid "Couldn't list users"
-msgstr ""
-
-#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
-msgid "Bad data passed for passwd1 mechanism"
-msgstr ""
-
-#: src/bridge/cockpitdbussetup.c:382
-msgid "Couldn't load user data"
-msgstr ""
-
-#: src/bridge/cockpitdbussetup.c:467
-msgid "Couldn't change user groups"
-msgstr ""
-
-#: src/bridge/cockpitdbussetup.c:520
-msgid "Couldn't change user password"
-msgstr ""
-
-#: src/bridge/cockpitdbussetup.c:544
-msgid "Couldn't create new users"
-msgstr ""
-
-#: src/bridge/cockpitdbussetup.c:642
-msgid "Couldn't list local users"
-msgstr ""
-
-#: src/bridge/cockpitpackages.c:459
-#, c-format
-msgid "This package requires Cockpit version %s or later"
-msgstr ""
-
-#: src/bridge/cockpitpackages.c:470
-msgid "This package is not compatible with this version of Cockpit"
-msgstr ""
-
-#: src/base1/cockpit.js:2586
-msgid "$0 killed with signal $1"
-msgstr ""
-
-#: src/base1/cockpit.js:2588
-msgid "$0 exited with code $1"
-msgstr ""
-
-#: src/base1/cockpit.js:2590
-msgid "$0 failed"
-msgstr ""
-
-#: src/base1/cockpit.js:3667
-msgid "Your session has been terminated."
-msgstr ""
-
-#: src/base1/cockpit.js:3669
-msgid "Your session has expired. Please log in again."
-msgstr ""
-
-#: src/base1/cockpit.js:3671
-msgid "Not permitted to perform this action."
-msgstr ""
-
-#: src/base1/cockpit.js:3673
-msgid "Login failed"
-msgstr ""
-
-#: src/base1/cockpit.js:3675
-msgid "The server refused to authenticate using any supported methods."
-msgstr ""
-
-#: src/base1/cockpit.js:3677
-msgid "Untrusted host"
-msgstr ""
-
-#: src/base1/cockpit.js:3679
-msgid "Host key is incorrect"
-msgstr ""
-
-#: src/base1/cockpit.js:3681
-msgid "Internal error"
-msgstr ""
-
-#: src/base1/cockpit.js:3683
-msgid "Connection has timed out."
-msgstr ""
-
-#: src/base1/cockpit.js:3685
-msgid "Cockpit is not installed on the system."
-msgstr ""
-
-#: src/base1/cockpit.js:3687
-msgid "Cannot forward login credentials"
-msgstr ""
-
-#: src/base1/cockpit.js:3689
-msgid "Server has closed the connection."
-msgstr ""
-
-#: src/base1/cockpit.js:3691
-msgid "Cockpit is not compatible with the software on the system."
-msgstr ""
-
-#: src/base1/cockpit.js:3693
-msgid "Cockpit could not contact the given host."
-msgstr ""
-
-#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:19
+#: pkg/shell/index.html:227
 #, fuzzy
-msgid "Control"
-msgstr "컨테이너 "
+msgid "                                                Comment                                            "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
 
-#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
-#: pkg/playground/translate.js:22
+#: pkg/shell/index.html:235
 #, fuzzy
-msgctxt "key"
-msgid "Control"
-msgstr "컨테이너 "
+msgid "                                                Fingerprint                                            "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
 
-#: src/base1/test-locale.js:46 src/base1/test-locale.js:56
-#: pkg/playground/translate.js:10
-msgid "Empty"
+#: pkg/shell/index.html:231
+#, fuzzy
+msgid "                                                Type                                            "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
+
+#: pkg/systemd/index.html:389
+#, fuzzy
+msgid ""
+"                                    Invalid time "
+"zone                                "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
+
+#: pkg/kubernetes/views/project-body.html:80
+#, fuzzy
+msgid ""
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}                                "
+msgstr ""
+"\n"
+"              재연결 시도\n"
+"            "
+
+#: pkg/kubernetes/views/user-body.html:22
+msgid ""
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}                                "
 msgstr ""
 
-#: src/base1/test-locale.js:47 src/base1/test-locale.js:58
-#: pkg/playground/translate.js:16
-msgctxt "verb"
-msgid "Empty"
+#: pkg/kubernetes/views/user-panel.html:39
+#, fuzzy
+msgid ""
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}                            "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
+
+#: pkg/kubernetes/views/project-body.html:37
+#, fuzzy
+msgid ""
+"                                {{ getRegistryRoles(user, project())."
+"join() }}                            "
+msgstr ""
+"\n"
+"              재연결 시도\n"
+"            "
+
+#: pkg/systemd/index.html:485 pkg/systemd/index.html:504
+#, fuzzy
+msgid "                        Cancel                    "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
+
+#: pkg/kubernetes/views/user-add-membership.html:9
+#, fuzzy
+msgid "                        Group or Project                    "
+msgstr ""
+"\n"
+"              재연결 시도\n"
+"            "
+
+#: pkg/kubernetes/views/add-user-dialog.html:19
+#: pkg/kubernetes/views/user-modify.html:19
+#, fuzzy
+msgid "                        Identity                    "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
+
+#: pkg/kubernetes/views/add-user-dialog.html:9
+#: pkg/kubernetes/views/user-modify.html:9
+#: pkg/kubernetes/views/add-group-dialog.html:9
+#, fuzzy
+msgid "                        Name                    "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
+
+#: pkg/kubernetes/views/user-add-membership.html:30
+#, fuzzy
+msgid "                        Role                    "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
+
+#: pkg/kubernetes/views/user-group-add.html:9
+#, fuzzy
+msgid "                        User                    "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
+
+#: pkg/ostree/index.html:88
+#, fuzzy
+msgid "                    Available                  "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
+
+#: pkg/ostree/index.html:85
+#, fuzzy
+msgid "                    Default                  "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
+
+#: pkg/ostree/index.html:223
+#, fuzzy
+msgid "                    Reconnect                "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
+
+#: pkg/ostree/index.html:135
+msgid ""
+"                    This deployment contains the same packages as your "
+"currently booted system                "
 msgstr ""
 
-#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
-#: src/base1/test-locale.js:66 pkg/storaged/details.js:1557
-#: pkg/playground/translate.js:25 pkg/playground/translate.js:28
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] ""
+#: pkg/ostree/index.html:67
+#, fuzzy
+msgid "                    Update and reboot                "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
 
-#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
-#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
-#: pkg/playground/translate.js:34
-msgctxt "disk-non-rotational"
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
+#: pkg/kubernetes/registry.html:74 pkg/kubernetes/index.html:104
+#, fuzzy
+msgid "                Reconnect            "
+msgstr ""
+"\n"
+"              재연결 시도\n"
+"            "
+
+#: pkg/sosreport/index.html:57
+msgid ""
+"                The generated archive contains data "
+"considered                sensitive and its content should be reviewed by "
+"the                originating organization before being passed to "
+"any                third party.              "
+msgstr ""
+
+#: pkg/shell/index.html:304 pkg/shell/stub.html:157
+#, fuzzy
+msgid "                Tools              "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
+
+#: pkg/kubernetes/index.html:107
+#, fuzzy
+msgid "                Troubleshoot            "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
+
+#: pkg/shell/simple.html:105 pkg/shell/index.html:126 pkg/shell/stub.html:119
+#: pkg/storaged/index.html:862
+#, fuzzy
+msgid "              Cancel            "
+msgstr ""
+"\n"
+"              취소\n"
+"            "
+
+#: pkg/shell/index.html:147 pkg/shell/stub.html:140
+#, fuzzy
+msgid "              Close            "
+msgstr ""
+"\n"
+"              종료\n"
+"            "
+
+#: pkg/shell/simple.html:70 pkg/shell/index.html:83 pkg/shell/stub.html:76
+#, fuzzy
+msgid ""
+"              Cockpit is an interactive Linux server admin "
+"interface.            "
+msgstr ""
+"\n"
+"              Cockpit은 반응형 리눅스 서버 관리 인터페이스입니다.\n"
+"            "
+
+#: pkg/shell/simple.html:79 pkg/shell/index.html:92 pkg/shell/stub.html:85
+#, fuzzy
+msgid "              Licensed under the GNU LGPL version 2.1            "
+msgstr ""
+"\n"
+"                도구\n"
+"              "
+
+#: pkg/shell/simple.html:129
+#, fuzzy
+msgid "              Log in again            "
+msgstr ""
+"\n"
+"              다시 로그인\n"
+"            "
+
+#: pkg/shell/simple.html:73 pkg/shell/index.html:86 pkg/shell/stub.html:79
+#, fuzzy
+msgid "              Project website            "
+msgstr ""
+"\n"
+"              종료\n"
+"            "
+
+#: pkg/shell/simple.html:108 pkg/shell/index.html:129 pkg/shell/stub.html:122
+#, fuzzy
+msgid "              Select            "
+msgstr ""
+"\n"
+"              선택\n"
+"            "
+
+#: pkg/shell/simple.html:126
+#, fuzzy
+msgid "              Try to reconnect            "
+msgstr ""
+"\n"
+"              재연결 시도\n"
+"            "
+
+#: pkg/users/index.html:361
+#, fuzzy
+msgid "            Add key          "
+msgstr ""
+"\n"
+"            적용\n"
+"          "
+
+#: pkg/networkmanager/index.html:582 pkg/networkmanager/index.html:610
+#: pkg/networkmanager/index.html:638 pkg/networkmanager/index.html:666
+#: pkg/networkmanager/index.html:694 pkg/networkmanager/index.html:722
+#: pkg/networkmanager/index.html:750 pkg/networkmanager/index.html:778
+#, fuzzy
+msgid "            Apply          "
+msgstr ""
+"\n"
+"            적용\n"
+"          "
+
+#: pkg/users/index.html:269 pkg/users/index.html:297 pkg/users/index.html:358
+#: pkg/docker/index.html:584 pkg/docker/index.html:622
+#: pkg/docker/index.html:688 pkg/docker/index.html:744
+#: pkg/docker/index.html:790 pkg/networkmanager/index.html:579
+#: pkg/networkmanager/index.html:607 pkg/networkmanager/index.html:635
+#: pkg/networkmanager/index.html:663 pkg/networkmanager/index.html:691
+#: pkg/networkmanager/index.html:719 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:775
+#, fuzzy
+msgid "            Cancel          "
+msgstr ""
+"\n"
+"            취소\n"
+"          "
+
+#: pkg/docker/index.html:691
+#, fuzzy
+msgid "            Change          "
+msgstr ""
+"\n"
+"            변경\n"
+"          "
+
+#: pkg/users/index.html:45
+#, fuzzy
+msgid "            Close          "
+msgstr ""
+"\n"
+"              종료\n"
+"            "
+
+#: pkg/docker/index.html:747
+#, fuzzy
+msgid "            Commit          "
+msgstr ""
+"\n"
+"            커밋\n"
+"          "
+
+#: pkg/users/index.html:207
+#, fuzzy
+msgid "            Create          "
+msgstr ""
+"\n"
+"            취소\n"
+"          "
+
+#: pkg/users/index.html:300 pkg/networkmanager/index.html:533
+#, fuzzy
+msgid "            Delete          "
+msgstr ""
+"\n"
+"            삭제\n"
+"          "
+
+#: pkg/docker/index.html:625
+#, fuzzy
+msgid "            Download          "
+msgstr ""
+"\n"
+"            다운로드\n"
+"          "
+
+#: pkg/docker/index.html:587
+#, fuzzy
+msgid "            Run          "
+msgstr ""
+"\n"
+"            실행\n"
+"          "
+
+#: pkg/users/index.html:272
+#, fuzzy
+msgid "            Set          "
+msgstr ""
+"\n"
+"            삭제\n"
+"          "
+
+#: pkg/kubernetes/views/imagestream-body.html:14
+msgid "          Images may be pulled by anonymous users        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:20
+msgid ""
+"          Images may be pulled by any authenticated user or group        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:26
+msgid "          Images may only be pulled by specific users or groups        "
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:9
+#, fuzzy
+msgid "         {{ labels.url }}    "
+msgstr ""
+"\n"
+"            취소\n"
+"          "
+
+#: pkg/kubernetes/views/project-body.html:2
+msgid ""
+"        Project access policy allows anonymous users to pull images. Grant "
+"additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:7
+msgid ""
+"        Project access policy allows any authenticated user to pull images. "
+"Grant additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:12
+msgid ""
+"        Project access policy only allows specific members to access images. "
+"Grant access to specific members below.    "
+msgstr ""
+
+#: pkg/sosreport/index.html:39
+msgid ""
+"        The collected information will be stored locally on the system.      "
+msgstr ""
+
+#: pkg/storaged/index.html:51
+msgid ""
+"        There are devices with multiple paths on the system, but the "
+"multipath service is not running.      "
+msgstr ""
+
+#: pkg/sosreport/index.html:34
+msgid ""
+"        This tool will collect system configuration and diagnostic        "
+"information from this system for use with diagnosing problems        with "
+"the system.      "
+msgstr ""
+
+#: pkg/docker/storage.jsx:242
+msgid " (shared with the OS)"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:8
+msgid " 1\"Do you want to delete the following Nodes?"
+msgstr ""
+
+#: pkg/storaged/overview.js:253
+msgid "$0 Block Device"
+msgstr ""
+
+#: pkg/storaged/details.js:1546
+msgid "$0 Chunk Size"
+msgstr ""
+
+#: pkg/storaged/details.js:1544
+msgid "$0 Disks"
+msgstr ""
+
+#: pkg/storaged/details.js:1387
+msgid "$0 Extended Partition"
+msgstr ""
+
+#: pkg/storaged/details.js:1221
+msgctxt "storage-id-desc"
+msgid "$0 File System"
+msgstr ""
+
+#: pkg/storaged/details.js:1375
+msgid "$0 Free Space"
+msgstr ""
+
+#: pkg/storaged/details.js:1367
+msgid "$0 Free Space for Logical Partitions"
+msgstr ""
+
+#: pkg/storaged/details.js:1711
+msgid "$0 Free Space for Logical Volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:1370
+msgid "$0 Free Space for Primary Partitions"
+msgstr ""
+
+#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
+msgid "$0 Template"
+msgstr ""
+
+#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+msgid "$0 bit"
+msgid_plural "$0 bits"
 msgstr[0] ""
 
 #: src/base1/test-locale.js:73 src/base1/test-locale.js:74
@@ -198,578 +497,37 @@ msgid "$0 byte"
 msgid_plural "$0 bytes"
 msgstr[0] "바이트"
 
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
-msgid "$0 bit"
-msgid_plural "$0 bits"
+#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
+#: src/base1/test-locale.js:66 pkg/playground/translate.js:25
+#: pkg/playground/translate.js:28 pkg/storaged/details.js:1557
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
 msgstr[0] ""
 
-#: pkg/systemd/host.js:43
-msgid "The user <b>$0</b> is not permitted to modify hostnames"
-msgstr ""
-
-#: pkg/systemd/host.js:559
-msgid "Set Host name"
-msgstr ""
-
-#: pkg/systemd/host.js:661
-#, fuzzy
-msgid "failed to list ssh host keys: $0"
-msgstr " Docker 실행을 실패하였습니다: $0"
-
-#: pkg/systemd/host.js:1113
-msgid "Need at least one NTP server"
-msgstr ""
-
-#: pkg/systemd/host.js:1190
-msgid "Invalid date format and invalid time format"
-msgstr ""
-
-#: pkg/systemd/host.js:1192
-msgid "Invalid time format"
-msgstr ""
-
-#: pkg/systemd/host.js:1194
-msgid "Invalid date format"
-msgstr ""
-
-#: pkg/systemd/host.js:1250
-msgid "NTP Server"
-msgstr ""
-
-#: pkg/systemd/host.js:1300
-msgid "Message to logged in users"
-msgstr ""
-
-#: pkg/systemd/host.js:1307 pkg/systemd/host.js:1309
-#: pkg/systemd/index.html.h:19
-msgid "Shutdown"
-msgstr ""
-
-#: pkg/systemd/host.js:1311 pkg/systemd/host.js:1313 pkg/systemd/init.js:517
-#: pkg/systemd/index.html.h:18
-msgid "Restart"
-msgstr ""
-
-#: pkg/systemd/host.js:1381
-msgctxt "page-title"
-msgid "CPU Status"
-msgstr ""
-
-#: pkg/systemd/host.js:1413 pkg/systemd/index.html.h:24
-msgid "I/O Wait"
-msgstr ""
-
-#: pkg/systemd/host.js:1414 pkg/systemd/index.html.h:25
-msgid "Kernel"
-msgstr ""
-
-#: pkg/systemd/host.js:1415 pkg/subscriptions/subscriptions-register.jsx:76
-#: pkg/systemd/index.html.h:26 pkg/kubernetes/views/auth-form.html.h:6
-#: pkg/kubernetes/views/volume-body.html.h:20
-#: pkg/kubernetes/views/user-panel.html.h:1 pkg/playground/translate.html.h:3
-#: pkg/dashboard/index.html.h:8
-msgid "User"
-msgstr ""
-
-#: pkg/systemd/host.js:1416 pkg/systemd/index.html.h:27
-msgid "Nice"
-msgstr ""
-
-#: pkg/systemd/host.js:1466
-msgctxt "page-title"
-msgid "Memory"
-msgstr ""
-
-#: pkg/systemd/host.js:1499 pkg/systemd/index.html.h:28
-msgid "Swap Used"
-msgstr ""
-
-#: pkg/systemd/host.js:1500 pkg/systemd/index.html.h:29
-msgid "Cached"
-msgstr ""
-
-#: pkg/systemd/host.js:1501 pkg/docker/storage.jsx:313
-#: pkg/kubernetes/scripts/nodes.js:828 pkg/kubernetes/scripts/nodes.js:837
-#: pkg/systemd/index.html.h:30
-msgid "Used"
-msgstr ""
-
-#: pkg/systemd/host.js:1502 pkg/docker/storage.jsx:298
-#: pkg/docker/storage.jsx:320 pkg/systemd/index.html.h:31
-msgid "Free"
-msgstr ""
-
-#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
-#, fuzzy
-msgid "unknown"
-msgstr "알 수 없음"
-
-#: pkg/systemd/init.js:269 pkg/systemd/services.html.h:17
-#: pkg/kubernetes/views/project-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:5
-msgid "Description"
-msgstr ""
-
-#: pkg/systemd/init.js:270
-msgid "Id"
-msgstr ""
-
-#: pkg/systemd/init.js:272
-#, fuzzy
-msgid "Next Run"
-msgstr "다음"
-
-#: pkg/systemd/init.js:273
-msgid "Last Trigger"
-msgstr ""
-
-#: pkg/systemd/init.js:274 pkg/kubernetes/views/container-body.html.h:6
-#: pkg/kubernetes/views/details-page.html.h:8
-msgid "State"
-msgstr ""
-
-#: pkg/systemd/init.js:301
-msgid "Enabled"
-msgstr ""
-
-#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
-msgid "Disabled"
-msgstr "사용 안함"
-
-#: pkg/systemd/init.js:303
-msgid "Static"
-msgstr ""
-
-#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
-msgid "$0 Template"
-msgstr ""
-
-#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
-msgid "Start"
-msgstr ""
-
-#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
-msgid "Stop"
-msgstr ""
-
-#: pkg/systemd/init.js:518
-msgid "Reload"
-msgstr ""
-
-#: pkg/systemd/init.js:519
-msgid "Reload or Restart"
-msgstr ""
-
-#: pkg/systemd/init.js:520
-msgid "Try Restart"
-msgstr ""
-
-#: pkg/systemd/init.js:521
-msgid "Reload or Try Restart"
-msgstr ""
-
-#: pkg/systemd/init.js:522
-msgid "Isolate"
-msgstr ""
-
-#: pkg/systemd/init.js:541
-msgid "Enable"
-msgstr ""
-
-#: pkg/systemd/init.js:542
-msgid "Enable Forcefully"
-msgstr ""
-
-#: pkg/systemd/init.js:543
-msgid "Disable"
-msgstr ""
-
-#: pkg/systemd/init.js:544
-msgid "Preset"
-msgstr ""
-
-#: pkg/systemd/init.js:545
-msgid "Preset Forcefully"
-msgstr ""
-
-#: pkg/systemd/init.js:546
-msgid "Mask"
-msgstr ""
-
-#: pkg/systemd/init.js:547
-msgid "Mask Forcefully"
-msgstr ""
-
-#: pkg/systemd/init.js:548
-msgid "Unmask"
-msgstr ""
-
-#: pkg/systemd/init.js:621
-msgid "Since $0"
-msgstr ""
-
-#: pkg/systemd/init.js:639
-msgid "This unit is an instance of the $0 template."
-msgstr ""
-
-#: pkg/systemd/init.js:834
-#, fuzzy
-msgid "The user <b>$0</b> does not have permissions for creating timers"
-msgstr "사용자 <b>$0</b> 는 서버 관리 권한이 없습니다."
-
-#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
-#, fuzzy
-msgid "This field cannot be empty."
-msgstr "이름을 입력하셔야 합니다."
-
-#: pkg/systemd/init.js:1147
-msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
-msgstr ""
-
-#: pkg/systemd/init.js:1169
-#, fuzzy
-msgid "Invalid number."
-msgstr "잘못된 포트"
-
-#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
-msgid "Hour needs to be a number between 0-23"
-msgstr ""
-
-#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
-msgid "Minute needs to be a number between 0-59"
-msgstr ""
-
-#: pkg/systemd/init.js:1218
-#, fuzzy
-msgid "Invalid date format."
-msgstr "잘못된 포트"
-
-#: pkg/systemd/init.js:1222
-msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
-msgstr ""
-
-#: pkg/systemd/logs.js:69
-msgid "Load earlier entries"
-msgstr ""
-
-#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
-#: pkg/systemd/logs.js:175
-msgid "Loading..."
-msgstr ""
-
-#: pkg/systemd/logs.js:130
-msgid "Go to"
-msgstr ""
-
-#: pkg/systemd/logs.js:257
-msgid "Journal entry"
-msgstr ""
-
-#: pkg/systemd/logs.js:284
-msgid "Journal entry not found"
-msgstr ""
-
-#: pkg/tuned/dialog.js:94
-msgid "Tuned is not available"
-msgstr ""
-
-#: pkg/tuned/dialog.js:96
-msgid "Tuned is not running"
-msgstr ""
-
-#: pkg/tuned/dialog.js:98
-msgid "Tuned is off"
-msgstr ""
-
-#: pkg/tuned/dialog.js:100
-msgid "This system is using the recommended profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:102
-msgid "This system is using a custom profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:114
-msgid "Communication with tuned has failed"
-msgstr ""
-
-#: pkg/tuned/dialog.js:133
-#, fuzzy
-msgid "Failed to disable tuned profile"
-msgstr " Docker 실행을 실패하였습니다: $0"
-
-#: pkg/tuned/dialog.js:145
-#, fuzzy
-msgid "Failed to switch profile"
-msgstr " Docker 실행을 실패하였습니다: $0"
-
-#: pkg/tuned/dialog.js:169
-msgid "Failed to enable tuned"
-msgstr ""
-
-#: pkg/tuned/dialog.js:171
-#, fuzzy
-msgid "Failed to disable tuned"
-msgstr " Docker 실행을 실패하였습니다: $0"
-
-#: pkg/tuned/dialog.js:191
-msgid "Change Performance Profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:200
-msgid "Change Profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:233 pkg/kubernetes/views/service-body.html.h:7
-#: pkg/kubernetes/views/pod-panel.html.h:2
-#: pkg/kubernetes/views/image-config.html.h:8
-#: pkg/kubernetes/views/imagestream-body.html.h:12
-#: pkg/kubernetes/views/pod-page.html.h:5
-msgid "None"
-msgstr ""
-
-#: pkg/tuned/dialog.js:234
-msgid "Disable tuned"
-msgstr ""
-
-#: pkg/tuned/dialog.js:262
-msgid "Tuned has failed to start"
-msgstr ""
-
-#: pkg/tuned/change-profile.jsx:52
-#, fuzzy
-msgid "recommended"
-msgstr "MII (권장 사항)"
-
-#: pkg/lib/journal.js:209
-msgid "[no data]"
-msgstr ""
-
-#: pkg/lib/journal.js:213
-msgid "[$0 bytes of binary data]"
-msgstr ""
-
-#: pkg/lib/journal.js:215
-msgid "[binary data]"
-msgstr ""
-
-#: pkg/lib/journal.js:241
-msgid "Reboot"
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:364
-msgid "This machine has already been added."
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:380
-msgid ""
-"This version of cockpit-ws does not support connecting to a host with an "
-"alternate user or port"
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:386
-msgid "The IP address or host name cannot contain whitespace."
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:412
-msgid "Failed to add machine: $0"
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:429
-msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
-msgstr ""
+#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
+#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
+#: pkg/playground/translate.js:34
+msgctxt "disk-non-rotational"
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] ""
 
-#: pkg/lib/machine-dialogs.js:447
-msgid "Enter IP address or host name"
-msgstr "IP 주소 또는 호스트 명을 입력하세요"
-
-#: pkg/lib/machine-dialogs.js:494
-msgid "Failed to edit machine: $0"
-msgstr ""
-
-#: pkg/lib/cockpit-components-dialog.jsx:136 pkg/sosreport/index.js:55
-#: pkg/systemd/services.html.h:34 pkg/lib/machine-sync-users.html.h:7
-#: pkg/lib/machine-add.html.h:5 pkg/lib/machine-change-port.html.h:6
-#: pkg/lib/machine-change-auth.html.h:11 pkg/storaged/index.html.h:22
-#: pkg/realmd/operation.html.h:10 pkg/kubernetes/views/node-delete.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:3
-#: pkg/kubernetes/views/pvc-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:3
-#: pkg/kubernetes/views/auth-form.html.h:13
-#: pkg/kubernetes/views/node-add.html.h:7
-#: pkg/kubernetes/views/user-group-add.html.h:5
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:4
-#: pkg/kubernetes/views/route-modify.html.h:3
-#: pkg/kubernetes/views/image-delete.html.h:3
-#: pkg/kubernetes/views/pv-delete.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:4
-#: pkg/kubernetes/views/item-delete.html.h:4
-#: pkg/kubernetes/views/add-user-dialog.html.h:8
-#: pkg/kubernetes/views/user-add-membership.html.h:8
-#: pkg/kubernetes/views/deploy.html.h:4
-#: pkg/kubernetes/views/user-modify.html.h:8
-#: pkg/kubernetes/views/pv-modify.html.h:21
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:5
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:3
-#: pkg/kubernetes/views/imagestream-delete.html.h:3
-#: pkg/kubernetes/views/user-remove-membership.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:7
-#: pkg/kubernetes/views/add-role-dialog.html.h:3
-#: pkg/kubernetes/views/service-modify.html.h:4
-#: pkg/kubernetes/views/project-delete.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:9
-#: pkg/kubernetes/views/user-group-remove.html.h:2
-#: pkg/playground/translate.html.h:2 pkg/dashboard/index.html.h:12
-msgid "Cancel"
-msgstr "취소"
-
-#: pkg/lib/cockpit-components-dialog.jsx:155
-msgid "Ok"
-msgstr ""
-
-#: pkg/lib/credentials.js:182
-msgid "No such file or directory"
-msgstr ""
-
-#: pkg/lib/credentials.js:186
-msgid "The passwords do not match."
-msgstr ""
-
-#: pkg/lib/credentials.js:191
-msgid "Prompting via ssh-keygen timed out"
-msgstr ""
-
-#: pkg/lib/credentials.js:213 pkg/users/local.js:78
-msgid "Old password not accepted"
-msgstr ""
-
-#: pkg/lib/credentials.js:223 pkg/users/local.js:112 pkg/users/local.js:144
-msgid "Failed to change password"
-msgstr ""
-
-#: pkg/lib/credentials.js:231 pkg/users/local.js:120
-msgid "New password was not accepted"
-msgstr ""
-
-#: pkg/lib/credentials.js:248
-msgid "Not a valid private key"
-msgstr ""
-
-#: pkg/lib/credentials.js:251
-msgid "Prompting via ssh-add timed out"
-msgstr ""
-
-#: pkg/lib/credentials.js:274
-msgid "Invalid file permissions"
-msgstr ""
-
-#: pkg/lib/credentials.js:278
-msgid "Password not accepted"
-msgstr ""
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:22
-#: pkg/shell/index.html.h:27 pkg/storaged/index.html.h:52
-#: pkg/playground/jquery-patterns.html.h:2
-msgid "On"
-msgstr "활성"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:23
-#: pkg/shell/index.html.h:28 pkg/storaged/index.html.h:53
-#: pkg/playground/jquery-patterns.html.h:3
-msgid "Off"
-msgstr "비활성"
-
-#: pkg/shell/base_index.js:670 pkg/users/local.js:1164
-#: pkg/docker/index.html.h:69 pkg/networkmanager/index.html.h:65
-msgid "Unexpected error"
-msgstr "예상치 못한 오류"
-
-#: pkg/shell/base_index.js:671
-msgid "Cockpit had an unexpected internal error. <br/><br/>"
-msgstr "Cockpit 내부에서 예상치 못한 오류가 발생하였습니다. <br/><br/>"
-
-#: pkg/shell/base_index.js:672
-msgid "You can try restarting Cockpit by pressing refresh in your browser. "
-msgstr "브라우저의 새로고침을 눌러 Cockpit을 다시 시작하실 수 있습니다."
-
-#: pkg/shell/base_index.js:673
-msgid "The javascript console contains details about this error "
-msgstr "자바스크립트 콘솔에서 오류에 대한 데이터를 확인하실 수 있습니다."
-
-#: pkg/shell/base_index.js:674
-msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
-msgstr "(대부분의 브라우저에서 <b>Ctrl-Shift-J</b> )."
-
-#: pkg/shell/indexes.js:126 pkg/shell/indexes.js:497 pkg/shell/simple.html.h:17
-msgid "Disconnected"
-msgstr "연결 해제됨"
-
-#: pkg/shell/indexes.js:253
-msgid "Machines"
-msgstr "장치들"
-
-#: pkg/shell/indexes.js:314
-msgid "The machine is restarting"
-msgstr "장치가 재시동되고 있습니다"
-
-#: pkg/shell/indexes.js:317
-msgid "Connecting to the machine"
-msgstr "장치에 연결 중입니다"
-
-#: pkg/shell/indexes.js:320
-msgid "Couldn't connect to the machine"
-msgstr "장치에 연결할 수 없습니다"
-
-#: pkg/shell/indexes.js:322
-msgid "Cannot connect to an unknown machine"
-msgstr ""
-
-#: pkg/ostree/client.js:56
-msgid "Receiving delta parts"
-msgstr ""
-
-#: pkg/ostree/client.js:58
-msgid "Receiving metadata objects"
-msgstr ""
-
-#: pkg/ostree/client.js:61
-msgid "Receiving objects: $0%"
-msgstr ""
-
-#: pkg/ostree/client.js:64
-msgid "Writing objects"
+#: src/base1/cockpit.js:2588
+msgid "$0 exited with code $1"
 msgstr ""
 
-#: pkg/ostree/client.js:66
-msgid "Scanning metadata"
+#: src/base1/cockpit.js:2590
+msgid "$0 failed"
 msgstr ""
 
-#: pkg/ostree/client.js:500
-msgid "OS $0 not found"
+#: src/base1/cockpit.js:2586
+msgid "$0 killed with signal $1"
 msgstr ""
 
-#: pkg/ostree/app.js:81
-msgid "Not authorized to update software on this system"
-msgstr ""
-
-#: pkg/ostree/app.js:83
-msgid "OSTree is not available on this system"
-msgstr ""
-
-#: pkg/ostree/app.js:101
-msgid "No OSTree deployments found"
-msgstr ""
-
-#: pkg/ostree/app.js:219
-msgid "Checking for updates"
-msgstr ""
+#: pkg/selinux/setroubleshoot-view.jsx:440
+msgid "$0 occurrence"
+msgid_plural "$1 occurrences"
+msgstr[0] ""
 
 #: pkg/ostree/app.js:307
 msgid "$0 package"
@@ -779,689 +537,32 @@ msgstr ""
 msgid "$0 packages"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot.js:65
-msgid "Error while setting SELinux mode: '$0'"
-msgstr ""
+#: pkg/docker/util.js:124
+msgid "$0 shares"
+msgstr "$0 공유"
 
-#: pkg/selinux/setroubleshoot.js:238
-#, fuzzy
-msgid "Not connected"
-msgstr "연결 해제됨"
-
-#: pkg/selinux/setroubleshoot.js:275
-#, fuzzy
-msgid "Error while connecting."
-msgstr "다운로드 중 오류 발생"
-
-#: pkg/selinux/setroubleshoot-view.jsx:82
-msgid "Applying solution..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:90
-msgid "Solution applied successfully"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:97
-msgid "Solution failed"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:107
-msgid "Apply this solution"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:114
-msgid "Unable to apply this solution automatically"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:118
-msgid "solution details"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:309
-msgid "SELinux system status is unknown."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:317
-msgid "SELinux is disabled on the system."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:324
-msgid "The configured state is unknown, it might change on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:326
-msgid ""
-"Setting deviates from the configured state and will revert on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:330
-msgid "SELinux Policy"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:332
-msgid "Enforce policy:"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:382 pkg/kubernetes/index.html.h:10
-#: pkg/kubernetes/registry.html.h:5
-msgid "Connecting..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:385
-msgid ""
-"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
-"server is installed."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:400
-msgid "Occurred between $0 and $1"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:405
-msgid "Occurred $0"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:440
-msgid "$0 occurrence"
-msgid_plural "$1 occurrences"
+#: pkg/kubernetes/scripts/nodes.js:870
+#, c-format
+msgid "$0% Free"
+msgid_plural "$0% Free"
 msgstr[0] ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:478
-msgid "SELinux Access Control Errors"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:479
-msgid "No SELinux alerts."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:52
-msgid "Unable to start setroubleshootd"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:157
-msgid "Unable to get alert"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:172
-msgid "Unable to run fix"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:187
-msgid "Failed to delete alert"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:192
-msgid "Error while deleting alert"
-msgstr ""
-
-#: pkg/storaged/dialog.js:267
-msgid "Size must be a number"
-msgstr ""
-
-#: pkg/storaged/dialog.js:269
-#, fuzzy
-msgid "Size cannot be zero"
-msgstr "이름을 입력하셔야 합니다."
-
-#: pkg/storaged/dialog.js:271
-#, fuzzy
-msgid "Size cannot be negative"
-msgstr "이름을 입력하셔야 합니다."
-
-#: pkg/storaged/dialog.js:273
-msgid "Size is too large"
-msgstr ""
-
-#: pkg/storaged/details.js:85
-msgid "Device $0 is mounted on $1"
-msgstr "장치 $0는 $1에 마운트되어 있습니다"
-
-#: pkg/storaged/details.js:91
-msgid "Device $0 is a member of RAID Array $1"
-msgstr "장치 $0는 RAID 어레이 $1에 속해 있습니다"
-
-#: pkg/storaged/details.js:97
-msgid "Device $0 is a physical volume of $1"
-msgstr "장치 $0는  $1의 물리 볼륨입니다"
-
-#: pkg/storaged/details.js:113
-msgid "Create partition on $0"
-msgstr "$0에 파티션 만들기"
-
-#: pkg/storaged/details.js:115
-msgid "Format $0"
-msgstr ""
-
-#: pkg/storaged/details.js:177
-msgid "XFS - Red Hat Enterprise Linux 7 default"
-msgstr ""
-
-#: pkg/storaged/details.js:178
-msgid "ext4 - Red Hat Enterprise Linux 6 default"
-msgstr ""
-
-#: pkg/storaged/details.js:179
-msgid "Encrypted XFS (LUKS)"
-msgstr ""
-
-#: pkg/storaged/details.js:180
-msgid "Encrypted EXT4 (LUKS)"
-msgstr ""
-
-#: pkg/storaged/details.js:181
-msgid "VFAT - Compatible with all systems and devices"
-msgstr ""
-
-#: pkg/storaged/details.js:182
-msgid "NTFS - Compatible with most systems"
-msgstr ""
-
-#: pkg/storaged/details.js:183
-msgid "Extended Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:185
-msgid "No Filesystem"
-msgstr ""
-
-#: pkg/storaged/details.js:186
-msgid "Custom (Enter filesystem type)"
-msgstr ""
-
-#: pkg/storaged/details.js:192 pkg/storaged/details.js:664
-#: pkg/storaged/details.js:735 pkg/storaged/details.js:773
-#: pkg/storaged/details.js:909 pkg/storaged/index.html.h:20
-#: pkg/kubernetes/views/volumes-page.html.h:11
-msgid "Size"
-msgstr ""
-
-#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
-msgid "Erase"
-msgstr ""
-
-#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
-msgid "Don't overwrite existing data"
-msgstr ""
-
-#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
-msgid "Overwrite existing data with zeros"
-msgstr ""
-
-#: pkg/storaged/details.js:207 pkg/shell/index.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:4
-#: pkg/kubernetes/views/deploy.html.h:2 pkg/kubernetes/views/pv-modify.html.h:3
-msgid "Type"
-msgstr ""
-
-#: pkg/storaged/details.js:211 pkg/storaged/details.js:429
-#: pkg/storaged/details.js:709 pkg/storaged/details.js:731
-#: pkg/storaged/details.js:769 pkg/storaged/details.js:798
-#: pkg/storaged/details.js:864 pkg/storaged/overview.js:417
-#: pkg/storaged/overview.js:490 pkg/storaged/overview.js:624
-#: pkg/storaged/overview.js:702 pkg/storaged/index.html.h:18
-#: pkg/networkmanager/index.html.h:16
-#: pkg/kubernetes/views/project-listing.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:3
-#: pkg/kubernetes/views/volume-body.html.h:11
-#: pkg/kubernetes/views/containers-listing.html.h:2
-#: pkg/kubernetes/views/volumes-page.html.h:3
-#: pkg/kubernetes/views/pv-claim.html.h:1
-#: pkg/kubernetes/views/pv-modify.html.h:6
-#: pkg/kubernetes/views/image-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:15
-#: pkg/kubernetes/views/nodes-page.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:3
-#: pkg/kubernetes/views/details-page.html.h:4
-#: pkg/kubernetes/views/service-modify.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:3
-msgid "Name"
-msgstr "이름"
-
-#: pkg/storaged/details.js:215
-msgid "Filesystem type"
-msgstr ""
-
-#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
-msgid "Passphrase"
-msgstr ""
-
-#: pkg/storaged/details.js:224
-#, fuzzy
-msgid "Passphrase cannot be empty"
-msgstr "네임스페이스를 입력하셔야 합니다."
-
-#: pkg/storaged/details.js:229
-msgid "Confirm passphrase"
-msgstr ""
-
-#: pkg/storaged/details.js:232
-msgid "Passphrases do not match"
-msgstr ""
-
-#: pkg/storaged/details.js:237
-msgid "Store passphrase"
-msgstr ""
-
-#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
-#: pkg/storaged/details.js:1115
-msgid "Encryption Options"
-msgstr ""
-
-#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
-msgid "Mounting"
-msgstr "마운트"
-
-#: pkg/storaged/details.js:247 pkg/storaged/details.js:435
-#: pkg/subscriptions/subscriptions-register.jsx:101 pkg/docker/index.html.h:23
-#: pkg/kubernetes/views/image-config.html.h:2
-msgid "Default"
-msgstr "기본"
-
-#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
-msgid "Custom"
-msgstr "사용자 지정"
-
-#: pkg/storaged/details.js:253 pkg/storaged/details.js:440
-#: pkg/storaged/index.html.h:19
-msgid "Mount Point"
-msgstr "마운트 포인트"
-
-#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
-msgid "Mount Options"
-msgstr "마운트 옵션"
-
-#: pkg/storaged/details.js:266
-msgid "Create partition"
-msgstr "파티션 생성"
-
-#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
-#: pkg/storaged/details.js:1142
-msgid "Format"
-msgstr "포멧"
-
-#: pkg/storaged/details.js:268
-msgid "Formatting a storage device will erase all data on it."
-msgstr "장치를 포멧하면 내부의 모든 데이터를 지우게 됩니다."
-
-#: pkg/storaged/details.js:335
-msgid "Format Disk $0"
-msgstr "디스크 $0 포멧"
-
-#: pkg/storaged/details.js:346
-msgid "Partitioning"
-msgstr "파티션"
-
-#: pkg/storaged/details.js:348
-msgid "Compatible with all systems and devices (MBR)"
-msgstr "모든 시스템과 장치와 호환됩니다 (MBR)"
-
-#: pkg/storaged/details.js:349
-msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr "최신 시스템과 2TB 이상의 하드 디스크와 호환됩니다 (GPT)"
-
-#: pkg/storaged/details.js:352
-msgid "No partitioning"
-msgstr "파티션 설정하지 않음"
-
-#: pkg/storaged/details.js:358
-msgid "Formatting a disk will erase all data on it."
-msgstr "디스크를 포멧하면 내부의 모든 데이터를 지우게 됩니다."
-
-#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
-msgid "Filesystem Options"
-msgstr "파일 시스템 옵션"
-
-#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
-msgid "Apply"
-msgstr "적용"
-
-#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
-#: pkg/storaged/details.js:1110
-msgid "Unlock"
-msgstr "잠금 해제"
-
-#: pkg/storaged/details.js:527
-msgid "Stored Passphrase"
-msgstr "저장된 암호"
-
-#: pkg/storaged/details.js:531 pkg/kubernetes/views/volume-body.html.h:32
-msgid "Options"
-msgstr "옵션"
-
-#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
-msgid "Add Disks"
-msgstr "디스크 추가"
-
-#: pkg/storaged/details.js:567 pkg/storaged/details.js:933
-#: pkg/storaged/overview.js:448 pkg/storaged/overview.js:495
-#: pkg/storaged/index.html.h:55
-msgid "Disks"
-msgstr ""
-
-#: pkg/storaged/details.js:579 pkg/storaged/details.js:948
-#: pkg/storaged/overview.js:501
-msgid "At least one disk is needed."
-msgstr "최소 1개의 디스크가 필요합니다."
-
-#: pkg/storaged/details.js:584 pkg/storaged/details.js:953
-#: pkg/storaged/overview.js:629 pkg/storaged/overview.js:657
-#: pkg/lib/machine-add.html.h:6 pkg/kubernetes/views/node-add.html.h:8
-#: pkg/kubernetes/views/user-group-add.html.h:6
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:5
-#: pkg/kubernetes/views/add-user-dialog.html.h:9
-#: pkg/kubernetes/views/user-add-membership.html.h:9
-#: pkg/kubernetes/views/add-role-dialog.html.h:4
-msgid "Add"
-msgstr "추가"
-
-#: pkg/storaged/details.js:625 pkg/storaged/details.js:821
-#: pkg/storaged/details.js:1016 pkg/docker/details.js:271
-#: pkg/docker/image.js:151 pkg/docker/containers-view.jsx:166
-msgid "Please confirm deletion of $0"
-msgstr "$0 삭제를 확인해주세요"
-
-#: pkg/storaged/details.js:630 pkg/storaged/details.js:827
-#: pkg/storaged/details.js:1022 pkg/storaged/details.js:1151
-#: pkg/storaged/details.js:1616 pkg/storaged/details.js:1776
-#: pkg/docker/details.js:273 pkg/docker/image.js:153
-#: pkg/docker/containers-view.jsx:168 pkg/kubernetes/scripts/volumes.js:218
-#: pkg/users/index.html.h:9 pkg/kubernetes/views/node-delete.html.h:5
-#: pkg/kubernetes/views/pvc-delete.html.h:5
-#: pkg/kubernetes/views/image-delete.html.h:4
-#: pkg/kubernetes/views/pv-delete.html.h:5
-#: pkg/kubernetes/views/item-delete.html.h:5
-#: pkg/kubernetes/views/imagestream-delete.html.h:4
-#: pkg/kubernetes/views/user-remove-membership.html.h:3
-#: pkg/kubernetes/views/project-delete.html.h:3
-msgid "Delete"
-msgstr "삭제"
-
-#: pkg/storaged/details.js:631
-msgid "Deleting a RAID device will erase all data on it."
-msgstr "RAID 장치를 제거하면 내부의 모든 데이터를 지우게 됩니다."
-
-#: pkg/storaged/details.js:661
-msgid "Resize Logical Volume"
-msgstr "논리 볼륨 크기 조정"
-
-#: pkg/storaged/details.js:673
-msgid "Resize Filesystem"
-msgstr ""
-
-#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
-msgid "Resize"
-msgstr "크기 조정"
-
-#: pkg/storaged/details.js:690
-msgid "This logical volume cannot be made smaller."
-msgstr ""
-
-#: pkg/storaged/details.js:706
-msgid "Renamee Logical Volume"
-msgstr "논리 볼륨 이름 바꾸기"
-
-#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
-#: pkg/storaged/details.js:1775
-msgid "Rename"
-msgstr ""
-
-#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
-msgid "Create Snapshot"
-msgstr ""
-
-#: pkg/storaged/details.js:745 pkg/storaged/details.js:781
-#: pkg/storaged/details.js:804 pkg/storaged/details.js:915
-#: pkg/storaged/overview.js:461 pkg/storaged/overview.js:506
-#: pkg/kubernetes/views/add-group-dialog.html.h:6
-#: pkg/kubernetes/views/project-modify.html.h:8
-msgid "Create"
-msgstr "생성"
-
-#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
-msgid "Create Thin Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:795
-msgid "Rename Volume Group"
-msgstr ""
-
-#: pkg/storaged/details.js:826
-msgid "Deleting a volume group will erase all data on it."
-msgstr ""
-
-#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
-#, fuzzy
-msgid "Create Logical Volume"
-msgstr "논리 볼륨 이름 바꾸기"
-
-#: pkg/storaged/details.js:869
-msgid "Purpose"
-msgstr ""
-
-#: pkg/storaged/details.js:871
-msgid "Block device for filesystems"
-msgstr ""
-
-#: pkg/storaged/details.js:874
-#, fuzzy
-msgid "Pool for thinly provisioned volumes"
-msgstr "Thin 논리 볼륨을 위한 풀"
-
-#: pkg/storaged/details.js:1009
-msgid "Deleting a logical volume will delete all data in it."
-msgstr ""
-
-#: pkg/storaged/details.js:1012
-msgid "Deleting a partition will delete all data in it."
-msgstr ""
-
-#: pkg/storaged/details.js:1053 pkg/storaged/overview.js:689
-#: pkg/storaged/devices.js:119 pkg/users/local.js:1155
-#: pkg/systemd/services.html.h:14
-msgid "Error"
-msgstr ""
-
-#: pkg/storaged/details.js:1099
-msgid "Mount"
-msgstr ""
-
-#: pkg/storaged/details.js:1100
-msgid "Unmount"
-msgstr ""
-
-#: pkg/storaged/details.js:1109
-msgid "Lock"
-msgstr ""
-
-#: pkg/storaged/details.js:1127
-msgid "Activate"
-msgstr ""
-
-#: pkg/storaged/details.js:1130
-msgid "Deactivate"
-msgstr ""
-
-#: pkg/storaged/details.js:1221
-msgctxt "storage-id-desc"
-msgid "$0 File System"
-msgstr ""
-
-#: pkg/storaged/details.js:1224
-msgctxt "storage-id-desc"
-msgid "Linux MD-RAID Component"
-msgstr ""
-
-#: pkg/storaged/details.js:1226
-msgctxt "storage-id-desc"
-msgid "LVM2 Physical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:1228
-msgctxt "storage-id-desc"
-msgid "RAID Member"
-msgstr ""
-
-#: pkg/storaged/details.js:1245
-msgctxt "storage-id-desc"
-msgid "LUKS Encrypted"
-msgstr ""
-
-#: pkg/storaged/details.js:1247
-msgctxt "storage-id-desc"
-msgid "Encrypted"
-msgstr ""
-
-#: pkg/storaged/details.js:1251
-msgctxt "storage-id-desc"
-msgid "Swap Space"
-msgstr ""
-
-#: pkg/storaged/details.js:1253
-msgctxt "storage-id-desc"
-msgid "Other Data"
-msgstr ""
-
-#: pkg/storaged/details.js:1256
-msgctxt "storage-id-desc"
-msgid "Unrecognized Data"
-msgstr ""
-
-#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
-msgid "$size $partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1278
-msgid "mounted on $0"
-msgstr ""
-
-#: pkg/storaged/details.js:1280
-msgid "not mounted"
-msgstr ""
-
-#: pkg/storaged/details.js:1284
-msgid "unlocked"
-msgstr ""
+#: pkg/kubernetes/scripts/nodes.js:872
+msgid "$0% Used"
+msgid_plural "$0% Used"
+msgstr[0] ""
 
-#: pkg/storaged/details.js:1286
-msgid "locked"
+#: pkg/storaged/details.js:1765
+msgid "$0, $1 free"
 msgstr ""
 
-#: pkg/storaged/details.js:1367
-msgid "$0 Free Space for Logical Partitions"
+#: pkg/networkmanager/interfaces.js:2473
+msgid "$mtu"
 msgstr ""
 
-#: pkg/storaged/details.js:1370
-msgid "$0 Free Space for Primary Partitions"
-msgstr ""
-
-#: pkg/storaged/details.js:1375
-msgid "$0 Free Space"
-msgstr ""
-
-#: pkg/storaged/details.js:1379
-msgid "Create Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1387
-msgid "$0 Extended Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1424
-msgid "Logical Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1426
-msgid "Primary Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1428 pkg/kubernetes/views/volume-body.html.h:5
-msgid "Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
-msgid "Content"
-msgstr ""
-
-#: pkg/storaged/details.js:1533
-msgid "RAID 0"
-msgstr ""
-
-#: pkg/storaged/details.js:1534
-msgid "RAID 1"
-msgstr ""
-
-#: pkg/storaged/details.js:1535
-msgid "RAID 4"
-msgstr ""
-
-#: pkg/storaged/details.js:1536
-msgid "RAID 5"
-msgstr ""
-
-#: pkg/storaged/details.js:1537
-msgid "RAID 6"
-msgstr ""
-
-#: pkg/storaged/details.js:1538
-msgid "RAID 10"
-msgstr ""
-
-#: pkg/storaged/details.js:1539
-msgid "RAID ($0)"
-msgstr ""
-
-#: pkg/storaged/details.js:1544
-msgid "$0 Disks"
-msgstr ""
-
-#: pkg/storaged/details.js:1546
-msgid "$0 Chunk Size"
-msgstr ""
-
-#: pkg/storaged/details.js:1574 pkg/ostree/index.html.h:7
-msgid "Running"
-msgstr "작동중"
-
-#: pkg/storaged/details.js:1574
-msgid "Not running"
-msgstr ""
-
-#: pkg/storaged/details.js:1592
-msgid "FAILED"
-msgstr ""
-
-#: pkg/storaged/details.js:1593
-msgid "In Sync"
-msgstr ""
-
-#: pkg/storaged/details.js:1594
-msgid "Spare"
-msgstr ""
-
-#: pkg/storaged/details.js:1594
-msgid "Recovering"
-msgstr ""
-
-#: pkg/storaged/details.js:1595
-msgid "Write-mostly"
-msgstr ""
-
-#: pkg/storaged/details.js:1596
-msgid "Blocked"
-msgstr ""
-
-#: pkg/storaged/details.js:1597
-msgid "Unknown ($0)"
-msgstr ""
-
-#: pkg/storaged/details.js:1614
-msgid "Start Scrubbing"
-msgstr ""
-
-#: pkg/storaged/details.js:1615
-msgid "Stop Scrubbing"
-msgstr ""
+#: pkg/storaged/utils.js:157
+msgid "$name (from $host)"
+msgstr "$name ($host에서)"
 
 #: pkg/storaged/details.js:1653
 msgid "$size $desc"
@@ -1476,59 +577,1660 @@ msgstr ""
 msgid "$size $desc<br/>($state)"
 msgstr ""
 
-#: pkg/storaged/details.js:1692
-msgid "active, but unsupported"
+#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
+msgid "$size $partition"
 msgstr ""
 
-#: pkg/storaged/details.js:1692
-msgid "inactive"
+#: pkg/docker/details.js:144
+msgid "${hip}:${hport} -> $cport"
+msgstr "${hip}:${hport} -> $cport"
+
+#: pkg/subscriptions/subscriptions-client.js:198
+msgid "'Organization' required to register."
 msgstr ""
 
-#: pkg/storaged/details.js:1711
-msgid "$0 Free Space for Logical Volumes"
+#: pkg/subscriptions/subscriptions-client.js:202
+msgid "'Organization' required when using activation keys."
 msgstr ""
 
-#: pkg/storaged/details.js:1751
-msgid "The last physical volume of a volume group cannot be removed."
+#: pkg/shell/base_index.js:674
+msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
+msgstr "(대부분의 브라우저에서 <b>Ctrl-Shift-J</b> )."
+
+#: pkg/storaged/overview.js:440
+msgid "1 MiB"
 msgstr ""
 
-#: pkg/storaged/details.js:1756
+#: pkg/systemd/index.html:459 pkg/systemd/index.html:463
+msgid "1 Minute"
+msgstr ""
+
+#: pkg/storaged/index.html:312 pkg/networkmanager/index.html:55
+#: pkg/networkmanager/index.html:501
+msgid "1 day"
+msgstr "1 일"
+
+#: pkg/storaged/index.html:310 pkg/networkmanager/index.html:53
+#: pkg/networkmanager/index.html:499
+msgid "1 hour"
+msgstr "1 시간"
+
+#: pkg/storaged/index.html:313 pkg/networkmanager/index.html:56
+#: pkg/networkmanager/index.html:502
+msgid "1 week"
+msgstr "1 주"
+
+#: pkg/playground/translate.html:190
+msgid "1% Free"
+msgid_plural "{{$count}}% Free"
+msgstr[0] ""
+
+#: pkg/storaged/overview.js:438
+msgid "128 KiB"
+msgstr ""
+
+#: pkg/storaged/overview.js:435
+msgid "16 KiB"
+msgstr ""
+
+#: pkg/storaged/overview.js:441
+msgid "2 MiB"
+msgstr ""
+
+#: pkg/systemd/index.html:465
+msgid "20 Minutes"
+msgstr ""
+
+#: pkg/storaged/overview.js:436
+msgid "32 KiB"
+msgstr ""
+
+#: pkg/storaged/overview.js:433
+msgid "4 KiB"
+msgstr ""
+
+#: pkg/systemd/index.html:466
+msgid "40 Minutes"
+msgstr ""
+
+#: pkg/systemd/index.html:464
+msgid "5 Minutes"
+msgstr ""
+
+#: pkg/storaged/index.html:309 pkg/networkmanager/index.html:52
+#: pkg/networkmanager/index.html:498
+msgid "5 minutes"
+msgstr "5분"
+
+#: pkg/storaged/overview.js:439
+msgid "512 KiB"
+msgstr ""
+
+#: pkg/storaged/index.html:311 pkg/networkmanager/index.html:54
+#: pkg/networkmanager/index.html:500
+msgid "6 hours"
+msgstr "6 시간"
+
+#: pkg/systemd/index.html:467
+msgid "60 Minutes"
+msgstr ""
+
+#: pkg/storaged/overview.js:437
+msgid "64 KiB"
+msgstr ""
+
+#: pkg/storaged/overview.js:434
+msgid "8 KiB"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1826
+msgid "802.3ad"
+msgstr "802.3ad"
+
+#: pkg/networkmanager/interfaces.js:1843
+#, fuzzy
+msgid "802.3ad LACP"
+msgstr "802.3ad"
+
+#: pkg/systemd/services.html:446
+msgid ":"
+msgstr ""
+
+#: pkg/storaged/utils.js:220
+msgid "<span>Encrypted $0</span>"
+msgstr "<span>암호화 된 $0</span>"
+
+#: pkg/storaged/utils.js:212
+msgid "<span>Encrypted Logical Volume of $0</span>"
+msgstr "<span>$0의 암호화 된 논리 볼륨</span>"
+
+#: pkg/storaged/utils.js:214
+msgid "<span>Encrypted Partition of $0</span>"
+msgstr "<span>$0의 암호화 된 파티션</span>"
+
+#: pkg/storaged/utils.js:216
+msgid "<span>Logical Volume of $0</span>"
+msgstr "<span>$0의 논리 볼륨</span>"
+
+#: pkg/storaged/utils.js:218
+msgid "<span>Partition of $0</span>"
+msgstr "<span>$0의 파티션</span>"
+
+#: pkg/lib/machine-not-supported.html:5
 msgid ""
-"There is not enough free space elsewhere to remove this physical volume.  At "
-"least $0 more free space is needed."
+"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
+"strong}}."
 msgstr ""
 
-#: pkg/storaged/details.js:1765
-msgid "$0, $1 free"
+#: cockpit.desktop.in.h:2
+msgid "A user interface for GNU/Linux servers"
 msgstr ""
 
-#: pkg/storaged/details.js:1792
-msgid "Logical Volumes"
+#: pkg/networkmanager/interfaces.js:1834
+msgid "ARP"
+msgstr "ARP"
+
+#: pkg/networkmanager/interfaces.js:2502
+msgid "ARP Monitoring"
+msgstr "ARP 모니터링"
+
+#: pkg/networkmanager/interfaces.js:1855
+#, fuzzy
+msgid "ARP Ping"
+msgstr "ARP 모니터링"
+
+#: pkg/kubernetes/scripts/volumes.js:193
+msgid "AWS Elastic Block Store"
 msgstr ""
 
-#: pkg/storaged/details.js:1822 pkg/docker/details.js:177
-#: pkg/docker/image.js:112
-msgid "Not found"
-msgstr "찾을 수 없습니다."
+#: pkg/shell/simple.html:41 pkg/shell/simple.html:67 pkg/shell/index.html:41
+#: pkg/shell/index.html:80 pkg/shell/stub.html:41 pkg/shell/stub.html:73
+msgid "About Cockpit"
+msgstr "Cockpit에 대하여"
 
-#: pkg/storaged/overview.js:180
+#: pkg/users/index.html:105 pkg/users/index.html:191
+msgid "Access"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pv-claim.html:9
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-body.html:9
+msgid "Access Modes"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:49
+#: pkg/kubernetes/views/imagestream-body.html:11
+msgid "Access Policy"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:191
+msgid "Access denied"
+msgstr ""
+
+#: pkg/shell/index.html:45
+msgid "Account Settings"
+msgstr "계정 설정"
+
+#: pkg/users/index.html:63
+msgid "Account not available or cannot be edited."
+msgstr ""
+
+#: pkg/users/index.html:71
+msgid "Accounts"
+msgstr ""
+
+#: pkg/users/local.js:284 pkg/users/local.js:594
+msgctxt "page-title"
+msgid "Accounts"
+msgstr ""
+
+#: pkg/storaged/details.js:1127
+msgid "Activate"
+msgstr ""
+
+#: pkg/storaged/jobs.js:148
+msgid "Activating $target"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:164
+#, fuzzy
+msgid "Activation Key"
+msgstr "비활성화 중 입니다"
+
+#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
+msgid "Active"
+msgstr "활성"
+
+#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
+msgid "Active Backup"
+msgstr "활성화된 백업"
+
+#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
+msgid "Actual"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1828
+msgid "Adaptive load balancing"
+msgstr "적응형 로드 밸런싱"
+
+#: pkg/networkmanager/interfaces.js:1827
+msgid "Adaptive transmit load balancing"
+msgstr "적응형 전송 로드 밸런싱"
+
+#: pkg/kubernetes/views/add-user-dialog.html:31
+#: pkg/kubernetes/views/node-add.html:50
+#: pkg/kubernetes/views/user-add-membership.html:53
+#: pkg/kubernetes/views/add-member-role-dialog.html:61
+#: pkg/kubernetes/views/user-group-add.html:32
+#: pkg/kubernetes/views/add-role-dialog.html:8 pkg/lib/machine-add.html:43
+msgid "Add"
+msgstr "추가"
+
+#: pkg/networkmanager/interfaces.js:2836
+msgid "Add $0"
+msgstr ""
+
+#: pkg/docker/storage.jsx:363
+msgid "Add Additional Storage"
+msgstr ""
+
+#: pkg/networkmanager/index.html:86
+msgid "Add Bond"
+msgstr "본드 추가"
+
+#: pkg/networkmanager/index.html:88
+msgid "Add Bridge"
+msgstr "브릿지 추가"
+
+#: pkg/kubernetes/views/node-add.html:3
+msgid "Add Cluster Node"
+msgstr ""
+
+#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
+msgid "Add Disks"
+msgstr "디스크 추가"
+
+#: pkg/kubernetes/views/add-group-dialog.html:3
+msgid "Add Group"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:34
+#, fuzzy
+msgid "Add Kubernetes Node"
+msgstr "Kubernetes 클러스터"
+
+#: pkg/lib/machine-add.html:4
+msgid "Add Machine to Dashboard"
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:38
+#: pkg/kubernetes/views/add-member-role-dialog.html:4
+#: pkg/kubernetes/views/group-panel.html:29
+#: pkg/kubernetes/views/user-group-add.html:3
+#: pkg/kubernetes/views/project-body.html:108
+msgid "Add Member"
+msgstr ""
+
+#: pkg/kubernetes/views/user-panel.html:76
+#: pkg/kubernetes/views/user-body.html:67
+#, fuzzy
+msgid "Add Membership"
+msgstr "맴버"
+
+#: pkg/kubernetes/views/auth-form.html:11
+#: pkg/kubernetes/views/auth-form.html:20
+msgid "Add New Cluster"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:67
+#: pkg/kubernetes/views/auth-form.html:76
+msgid "Add New User"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:3
+#, fuzzy
+msgid "Add Role"
+msgstr "본드 추가"
+
+#: pkg/networkmanager/index.html:87
+#, fuzzy
+msgid "Add Team"
+msgstr "본드 추가"
+
+#: pkg/kubernetes/views/add-user-dialog.html:3
+#: pkg/kubernetes/views/project-listing.html:83
+msgid "Add User"
+msgstr ""
+
+#: pkg/networkmanager/index.html:89
+msgid "Add VLAN"
+msgstr "VLAN 추가"
+
+#: pkg/storaged/overview.js:515
+msgid "Add iSCSI Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/user-add-membership.html:3
+msgid "Add membership"
+msgstr ""
+
+#: pkg/users/index.html:351
+msgid "Add public key"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2833
+msgid "Adding <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/users/authorized-keys.js:108
+msgid "Adding key"
+msgstr ""
+
+#: pkg/storaged/jobs.js:153
+msgid "Adding physical volume to $target"
+msgstr ""
+
+#: pkg/docker/index.html:329
+msgid "Additional Storage"
+msgstr ""
+
+#: pkg/ostree/index.html:121 pkg/ostree/index.html:140
+msgid "Additions"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:8
+#: pkg/kubernetes/views/dashboard-page.html:157
+#: pkg/kubernetes/views/details-page.html:174
+#: pkg/kubernetes/views/nodes-page.html:43
+#: pkg/kubernetes/views/auth-form.html:29 pkg/kubernetes/views/node-body.html:5
+#: pkg/lib/machine-add.html:11
+msgid "Address"
+msgstr "주소"
+
+#: pkg/kubernetes/views/details-page.html:37
+msgid "Addresses"
+msgstr ""
+
+#: pkg/kubernetes/views/service-modify.html:25
+msgid "Adjust"
+msgstr "조정"
+
+#: pkg/kubernetes/views/pv-modify.html:3
+msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-modify.html:3
+msgid "Adjust Replication Controller {{ item.metadata.name }}"
+msgstr ""
+
+#: pkg/kubernetes/views/route-modify.html:3
+msgid "Adjust Route"
+msgstr ""
+
+#: pkg/kubernetes/views/service-modify.html:3
+msgid "Adjust Service"
+msgstr "서비스 조정"
+
+#: pkg/kubernetes/views/project-body.html:56
+msgid "Admin"
+msgstr ""
+
+#: pkg/systemd/services.html:389 pkg/systemd/services.html:393
+msgid "After system boot"
+msgstr ""
+
+#: pkg/systemd/logs.html:50
+msgid "All"
+msgstr "모두"
+
+#: pkg/kubernetes/views/filter-project.html:4
+msgid "All Projects"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:6
+msgid "All Types"
+msgstr ""
+
+#: pkg/docker/storage.jsx:366
+msgid ""
+"All data on selected disks will be erased and disks will be added to the "
+"storage pool."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:112
+msgid "All healthy"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:74
+msgid "All images"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:69
+msgid "All in use"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:37
+#, fuzzy
+msgid "All running"
+msgstr "작동중"
+
+#: pkg/docker/index.html:569
+msgid "Always"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-meta.html:2
+#: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/image-meta.html:9
+#: pkg/kubernetes/views/node-body.html:57
+msgid "Annotations"
+msgstr ""
+
+#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
+msgid "Apply"
+msgstr "적용"
+
+#: pkg/selinux/setroubleshoot-view.jsx:107
+msgid "Apply this solution"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:82
+msgid "Applying solution..."
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:12
+msgid "Architecture"
+msgstr ""
+
+#: pkg/storaged/index.html:451
 msgctxt "storage"
-msgid "Hard Disk"
+msgid "Assessment"
 msgstr ""
 
-#: pkg/storaged/overview.js:182
-msgctxt "storage"
-msgid "Solid-State Disk"
+#: pkg/systemd/index.html:81
+msgid "Asset Tag"
 msgstr ""
 
-#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
-msgctxt "storage"
-msgid "Removable Drive"
+#: pkg/storaged/overview.js:455
+msgid "At least $0 disks are needed."
+msgstr "최소 $0 개의 디스크가 필요합니다."
+
+#: pkg/storaged/overview.js:501 pkg/storaged/details.js:579
+#: pkg/storaged/details.js:948
+msgid "At least one disk is needed."
+msgstr "최소 1개의 디스크가 필요합니다."
+
+#: pkg/systemd/services.html:394
+msgid "At specific time"
 msgstr ""
 
-#: pkg/storaged/overview.js:189
+#: pkg/networkmanager/interfaces.js:813
+msgid "Authenticating"
+msgstr "인증 중입니다"
+
+#: pkg/realmd/operation.html:34 pkg/shell/index.html:48
+#: pkg/shell/index.html:159 pkg/kubernetes/views/auth-form.html:85
+#: pkg/lib/machine-change-auth.html:32
+msgid "Authentication"
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:2
+msgid "Authentication Failed"
+msgstr ""
+
+#: pkg/docker/index.html:730 pkg/kubernetes/views/image-body.html:12
+#: pkg/kubernetes/views/image-listing.html:15
+msgid "Author"
+msgstr "작성자"
+
+#: pkg/users/index.html:130
+msgid "Authorized Public SSH Keys"
+msgstr ""
+
+#: pkg/networkmanager/index.html:165
+msgid "Automatic"
+msgstr "자동"
+
+#: pkg/networkmanager/interfaces.js:1814
+msgid "Automatic (DHCP only)"
+msgstr "자동(DHCP only)"
+
+#: pkg/networkmanager/interfaces.js:1804
+msgid "Automatic (DHCP)"
+msgstr "자동(DHCP)"
+
+#: pkg/systemd/index.html:406
+msgid "Automatically using NTP"
+msgstr ""
+
+#: pkg/systemd/index.html:407
+msgid "Automatically using specific NTP servers"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:66
+msgid "Available"
+msgstr ""
+
+#: pkg/storaged/overview.js:619
+msgid "Available targets on $0"
+msgstr ""
+
+#: pkg/dashboard/index.html:177
+msgid "Avatar"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:207
+msgid "Azure"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
+msgid "Bad data passed for passwd1 mechanism"
+msgstr ""
+
+#: pkg/networkmanager/index.html:389
+msgid "Balancer"
+msgstr ""
+
+#: pkg/storaged/index.html:560
 msgctxt "storage"
-msgid "Optical Drive"
+msgid "Bitmap"
+msgstr ""
+
+#: pkg/storaged/index.html:414
+msgid "Block Device"
+msgstr ""
+
+#: pkg/storaged/details.js:871
+msgid "Block device for filesystems"
+msgstr ""
+
+#: pkg/storaged/details.js:1596
+msgid "Blocked"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
+#: pkg/networkmanager/interfaces.js:2507
+msgid "Bond"
+msgstr "본드"
+
+#: pkg/networkmanager/index.html:596
+msgid "Bond Settings"
+msgstr "본드 설정"
+
+#: pkg/kubernetes/views/node-body.html:17
+msgid "Boot ID"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
+#: pkg/networkmanager/interfaces.js:2584
+msgid "Bridge"
+msgstr "브릿지"
+
+#: pkg/networkmanager/index.html:708
+msgid "Bridge Port Settings"
+msgstr "브릿지 포트 설정"
+
+#: pkg/networkmanager/index.html:680
+msgid "Bridge Settings"
+msgstr "브릿지 설정"
+
+#: pkg/networkmanager/interfaces.js:2605
+msgid "Bridge port"
+msgstr "브릿지 포트"
+
+#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
+msgid "Broadcast"
+msgstr "브로트캐스트"
+
+#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#, fuzzy
+msgid "Broken configuration"
+msgstr "알 수 없는 설정"
+
+#: pkg/kubernetes/views/image-body.html:16
+msgid "Built"
+msgstr ""
+
+#: pkg/dashboard/index.html:70
+msgid "CPU"
+msgstr "CPU"
+
+#: pkg/systemd/host.js:1381
+msgctxt "page-title"
+msgid "CPU Status"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:712
+msgid "CPU Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:490 pkg/docker/index.html:669
+msgid "CPU priority"
+msgstr "CPU 우선순위"
+
+#: pkg/systemd/index.html:247
+msgid "Cached"
+msgstr ""
+
+#: pkg/docker/index.html:63
+#, fuzzy
+msgid "Can&rsquo;t connect to Docker"
+msgstr "Docker에 연결할 수 없습니다."
+
+#: pkg/systemd/services.html:465 pkg/dashboard/index.html:189
+#: pkg/playground/translate.html:40 pkg/playground/translate.html:174
+#: pkg/realmd/operation.html:90 pkg/kubernetes/views/pv-modify.html:202
+#: pkg/kubernetes/views/item-delete.html:10
+#: pkg/kubernetes/views/add-user-dialog.html:30
+#: pkg/kubernetes/views/project-modify.html:71
+#: pkg/kubernetes/views/node-add.html:49
+#: pkg/kubernetes/views/pvc-delete.html:14
+#: pkg/kubernetes/views/node-delete.html:14
+#: pkg/kubernetes/views/imagestream-modify.html:96
+#: pkg/kubernetes/views/imagestream-delete.html:7
+#: pkg/kubernetes/views/user-modify.html:30
+#: pkg/kubernetes/views/add-group-dialog.html:20
+#: pkg/kubernetes/views/project-delete.html:8
+#: pkg/kubernetes/views/service-modify.html:24
+#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/kubernetes/views/user-group-remove.html:9
+#: pkg/kubernetes/views/user-add-membership.html:52
+#: pkg/kubernetes/views/add-member-role-dialog.html:60
+#: pkg/kubernetes/views/group-delete.html:20
+#: pkg/kubernetes/views/image-delete.html:7 pkg/kubernetes/views/deploy.html:61
+#: pkg/kubernetes/views/user-group-add.html:31
+#: pkg/kubernetes/views/auth-form.html:128
+#: pkg/kubernetes/views/auth-rejected-cert.html:31
+#: pkg/kubernetes/views/replicationcontroller-modify.html:16
+#: pkg/kubernetes/views/pv-delete.html:10
+#: pkg/kubernetes/views/add-role-dialog.html:7
+#: pkg/kubernetes/views/route-modify.html:16
+#: pkg/kubernetes/views/user-delete.html:24
+#: pkg/kubernetes/views/remove-role-dialog.html:7 pkg/storaged/index.html:289
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:79
+msgid "Cancel"
+msgstr "취소"
+
+#: pkg/shell/indexes.js:322
+msgid "Cannot connect to an unknown machine"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:359
+msgid "Cannot decrypt PEM-encoded private key"
+msgstr ""
+
+#: src/base1/cockpit.js:3707
+msgid "Cannot forward login credentials"
+msgstr ""
+
+#: pkg/realmd/operation.js:417
+msgid "Cannot join a domain because realmd is not available on this system"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:44
+#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pv-body.html:13
+msgid "Capacity"
+msgstr ""
+
+#: pkg/storaged/index.html:443 pkg/storaged/index.html:519
+#: pkg/storaged/index.html:551 pkg/storaged/index.html:630
+msgctxt "storage"
+msgid "Capacity"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2276
+msgid "Carrier"
+msgstr "캐리어"
+
+#: pkg/kubernetes/scripts/volumes.js:203
+#, fuzzy
+msgid "Ceph Filesystem Mount"
+msgstr "파일 시스템 옵션"
+
+#: pkg/kubernetes/views/volume-body.html:97
+#, fuzzy
+msgid "Ceph Monitors"
+msgstr "리포지터리 "
+
+#: pkg/kubernetes/views/pv-modify.html:204
+#: pkg/kubernetes/views/project-modify.html:74
+#: pkg/kubernetes/views/replicationcontroller-modify.html:17
+#: pkg/kubernetes/views/route-modify.html:17
+msgid "Change"
+msgstr ""
+
+#: pkg/shell/index.html:278
+msgid "Change Password"
+msgstr ""
+
+#: pkg/tuned/dialog.js:191
+msgid "Change Performance Profile"
+msgstr ""
+
+#: pkg/tuned/dialog.js:200
+msgid "Change Profile"
+msgstr ""
+
+#: pkg/kubernetes/views/user-modify.html:3
+msgid "Change User"
+msgstr ""
+
+#: pkg/storaged/overview.js:699
+msgid "Change iSCSI Initiator Name"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:4
+msgid "Change image stream"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:10
+msgid "Change project"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2872
+#, fuzzy
+msgid "Change the settings"
+msgstr "본드 설정"
+
+#: pkg/networkmanager/interfaces.js:2870
+msgid "Changing the settings will break the connection to the server, "
+msgstr ""
+
+#: pkg/ostree/index.html:48
+msgid "Check for updates"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:817
+msgid "Checking IP"
+msgstr "IP확인 중입니다"
+
+#: pkg/storaged/jobs.js:143
+#, fuzzy
+msgid "Checking RAID Device $target"
+msgstr "RAID 장치 $0"
+
+#: pkg/storaged/jobs.js:144
+msgid "Checking and Repairing RAID Device $target"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:70
+msgid "Checking for public keys"
+msgstr ""
+
+#: pkg/ostree/app.js:219
+msgid "Checking for updates"
+msgstr ""
+
+#: pkg/shell/simple.html:100 pkg/shell/index.html:121 pkg/shell/stub.html:114
+msgid "Choose the language to be used in the application"
+msgstr "사용하실 언어를 선택해주세요"
+
+#: pkg/storaged/overview.js:431
+msgid "Chunk Size"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:202
+msgid "Cinder"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
+msgid "Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:4
+#, fuzzy
+msgid "Claim Name"
+msgstr "컨테이너 이름"
+
+#: pkg/storaged/jobs.js:135
+msgid "Cleaning up for $target"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:88
+msgid "Client Certificate"
+msgstr ""
+
+#: pkg/systemd/services.html:306 pkg/systemd/services.html:324
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-invalid-hostkey.html:19
+msgid "Close"
+msgstr "닫기"
+
+#: pkg/kubernetes/views/auth-form.html:5
+#, fuzzy
+msgid "Cluster"
+msgstr "마스터"
+
+#: cockpit.desktop.in.h:1
+msgid "Cockpit"
+msgstr "Cockpit"
+
+#: pkg/lib/machine-dialogs.js:429
+msgid ""
+"Cockpit could not contact the given host $0. Make sure it has ssh running on "
+"port $1, or specify another port in the address."
+msgstr ""
+
+#: src/base1/cockpit.js:3713
+msgid "Cockpit could not contact the given host."
+msgstr ""
+
+#: pkg/shell/base_index.js:671
+msgid "Cockpit had an unexpected internal error. <br/><br/>"
+msgstr "Cockpit 내부에서 예상치 못한 오류가 발생하였습니다. <br/><br/>"
+
+#: cockpit.appdata.xml.in.h:1
+msgid ""
+"Cockpit is a server manager that makes it easy to administer your Linux "
+"servers via a web browser. Jumping between the terminal and the web tool is "
+"no problem. A service started via Cockpit can be stopped via the terminal. "
+"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
+"journal interface."
+msgstr ""
+
+#: src/base1/cockpit.js:3711
+msgid "Cockpit is not compatible with the software on the system."
+msgstr ""
+
+#: pkg/lib/machine-not-supported.html:2
+msgid "Cockpit is not installed"
+msgstr ""
+
+#: src/base1/cockpit.js:3705
+msgid "Cockpit is not installed on the system."
+msgstr ""
+
+#: cockpit.appdata.xml.in.h:2
+msgid ""
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
+"tasks such as storage administration, inspecting journals and starting and "
+"stopping services. You can monitor and administer several servers at the "
+"same time. Just add them with a single click and your machines will look "
+"after its buddies."
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:9
+msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:15
+msgid ""
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:9
+msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:6
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
+"machine with cockpit you will need to enable one of the following "
+"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:13
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
+"change your authentication credentials below. {{#can_sync}}You may prefer to "
+"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+msgstr ""
+
+#: pkg/dashboard/index.html:171 pkg/lib/machine-add.html:27
+msgid "Color"
+msgstr ""
+
+#: pkg/docker/index.html:95
+msgid "Combined CPU usage"
+msgstr ""
+
+#: pkg/docker/index.html:101
+msgid "Combined memory usage"
+msgstr ""
+
+#: pkg/systemd/services.html:370 pkg/docker/index.html:466
+#: pkg/docker/index.html:736
+msgid "Command"
+msgstr "명령"
+
+#: pkg/docker/run.js:332
+#, fuzzy
+msgid "Command can't be empty"
+msgstr "이름을 입력하셔야 합니다."
+
+#: pkg/docker/containers-view.jsx:239
+#, fuzzy
+msgid "Commit"
+msgstr "명령"
+
+#: pkg/tuned/dialog.js:114
+msgid "Communication with tuned has failed"
+msgstr ""
+
+#: pkg/storaged/details.js:348
+msgid "Compatible with all systems and devices (MBR)"
+msgstr "모든 시스템과 장치와 호환됩니다 (MBR)"
+
+#: pkg/storaged/details.js:349
+msgid "Compatible with modern system and hard disks > 2TB (GPT)"
+msgstr "최신 시스템과 2TB 이상의 하드 디스크와 호환됩니다 (GPT)"
+
+#: pkg/realmd/operation.html:28
+msgid "Computer OU"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:24
+msgid "Configuration"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2441
+msgid "Configure"
+msgstr "설정"
+
+#: pkg/kubernetes/views/node-add.html:42
+msgid "Configure Flannel networking"
+msgstr "Flannel 네트워킹 설정"
+
+#: pkg/kubernetes/views/node-add.html:32
+msgid "Configure Kubelet and Proxy"
+msgstr "Kubelet 과 프록시 설정"
+
+#: pkg/networkmanager/interfaces.js:811
+msgid "Configuring"
+msgstr "설정 중입니다"
+
+#: pkg/networkmanager/interfaces.js:815
+msgid "Configuring IP"
+msgstr "IP 인증 중입니다"
+
+#: pkg/users/index.html:171 pkg/shell/index.html:262
+msgid "Confirm"
+msgstr ""
+
+#: pkg/users/index.html:247
+msgid "Confirm New Password"
+msgstr ""
+
+#: pkg/storaged/details.js:229
+msgid "Confirm passphrase"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:130
+#: pkg/kubernetes/views/auth-rejected-cert.html:33
+#: pkg/lib/machine-unknown-hostkey.html:22
+msgid "Connect"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2637
+msgid "Connect automatically"
+msgstr "자동으로 연결"
+
+#: pkg/ostree/index.html:218
+msgid "Connecting"
+msgstr ""
+
+#: pkg/lib/machine-add.html:39
+msgid ""
+"Connecting simultaneously to more than {{ limit }} machines is unsupported."
+msgstr ""
+
+#: pkg/docker/index.html:54
+msgid "Connecting to Docker"
+msgstr "Docker에 연결중입니다."
+
+#: pkg/shell/indexes.js:317
+msgid "Connecting to the machine"
+msgstr "장치에 연결 중입니다"
+
+#: pkg/kubernetes/registry.html:70 pkg/kubernetes/index.html:100
+msgid "Connecting..."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-dialog.html:4
+#, fuzzy
+msgid "Connection Error"
+msgstr "Docker에 연결중입니다."
+
+#: pkg/kubernetes/scripts/connection.js:516
+#, fuzzy
+msgid "Connection Error: $0"
+msgstr "Docker에 연결중입니다."
+
+#: pkg/kubernetes/views/auth-dialog.html:3
+#, fuzzy
+msgid "Connection Settings"
+msgstr "본드 설정"
+
+#: src/base1/cockpit.js:3703
+msgid "Connection has timed out."
+msgstr ""
+
+#: pkg/networkmanager/index.html:812
+#, fuzzy
+msgid "Connection will be lost"
+msgstr "본드 설정"
+
+#: pkg/docker/console.html:4 pkg/kubernetes/views/container-panel.html:4
+#: pkg/kubernetes/views/image-panel.html:12
+#: pkg/kubernetes/views/container-body.html:4
+#: pkg/kubernetes/views/container-page-inline.html:2
+#: pkg/kubernetes/views/image-page.html:19
+msgid "Container"
+msgstr "컨테이너 "
+
+#: pkg/users/local.js:684
+msgid "Container Administrator"
+msgstr ""
+
+#: pkg/kubernetes/views/container-body.html:10
+msgid "Container ID"
+msgstr ""
+
+#: pkg/docker/index.html:459 pkg/docker/index.html:646
+#: pkg/docker/index.html:712
+msgid "Container Name"
+msgstr "컨테이너 이름"
+
+#: pkg/kubernetes/views/node-body.html:21
+msgid "Container Runtime Version"
+msgstr ""
+
+#: pkg/docker/util.js:490
+msgid ""
+"Container is currently marked as not running, but regular stopping failed."
+msgstr ""
+"컨테이너는 현재 실행중이지 않은 것으로 보이지만, 정상적인 종료가 되지 않았습"
+"니다."
+
+#: pkg/docker/util.js:488
+msgid "Container is currently running."
+msgstr "컨테이너가 현재 실행중입니다."
+
+#: pkg/docker/index.html:23 pkg/docker/index.html:309
+#: pkg/kubernetes/views/pod-page.html:36
+#: pkg/kubernetes/views/dashboard-page.html:158
+#: pkg/kubernetes/views/dashboard-page.html:199
+#: pkg/kubernetes/views/containers-listing.html:5 pkg/kubernetes/index.html:51
+msgid "Containers"
+msgstr "컨테이너들"
+
+#: pkg/docker/details.js:47 pkg/docker/image.js:43
+msgctxt "page-title"
+msgid "Containers"
+msgstr "컨테이너"
+
+#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
+msgid "Content"
+msgstr ""
+
+#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
+#: pkg/playground/translate.js:19
+#, fuzzy
+msgid "Control"
+msgstr "컨테이너 "
+
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
+#: pkg/playground/translate.js:22
+#, fuzzy
+msgctxt "key"
+msgid "Control"
+msgstr "컨테이너 "
+
+#: pkg/docker/storage.jsx:404
+msgid "Could not add all disks"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:4
+msgid "Could not contact {{host}}"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:142
+msgid "Could not list services"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:407
+msgid "Could not parse PEM-encoded certificate"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:374
+msgid "Could not parse PEM-encoded private key"
+msgstr ""
+
+#: pkg/docker/storage.jsx:446
+msgid "Could not reset the storage pool"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:467
+msgid "Couldn't change user groups"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:520
+msgid "Couldn't change user password"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:385
+msgid ""
+"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
+"server is installed."
+msgstr ""
+
+#: pkg/kubernetes/registry.html:71 pkg/kubernetes/index.html:101
+msgid "Couldn't connect to server"
+msgstr ""
+
+#: pkg/shell/indexes.js:320
+msgid "Couldn't connect to the machine"
+msgstr "장치에 연결할 수 없습니다"
+
+#: src/bridge/cockpitdbussetup.c:544
+msgid "Couldn't create new users"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:514
+msgid "Couldn't find running API server"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:196
+msgid ""
+"Couldn't get system subscription status. Please ensure subscription-manager "
+"is installed."
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:642
+msgid "Couldn't list local users"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:236
+msgid "Couldn't list users"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:382
+msgid "Couldn't load user data"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:72
+#: pkg/kubernetes/views/add-group-dialog.html:21
+msgid "Create"
+msgstr "생성"
+
+#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
+#, fuzzy
+msgid "Create Logical Volume"
+msgstr "논리 볼륨 이름 바꾸기"
+
+#: pkg/users/index.html:54 pkg/users/index.html:143
+msgid "Create New Account"
+msgstr ""
+
+#: pkg/storaged/details.js:1379
+msgid "Create Partition"
+msgstr ""
+
+#: pkg/storaged/overview.js:414
+msgid "Create RAID Device"
+msgstr ""
+
+#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
+msgid "Create Snapshot"
+msgstr ""
+
+#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
+msgid "Create Thin Volume"
+msgstr ""
+
+#: pkg/systemd/services.html:336
+#, fuzzy
+msgid "Create Timers"
+msgstr "생성"
+
+#: pkg/storaged/overview.js:487
+msgid "Create Volume Group"
+msgstr "볼륨 그룹 생성"
+
+#: pkg/sosreport/index.html:50
+msgid "Create diagnostic report"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:3
+msgid "Create image stream"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
+#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
+#, fuzzy
+msgid "Create it"
+msgstr "생성"
+
+#: pkg/storaged/details.js:266
+msgid "Create partition"
+msgstr "파티션 생성"
+
+#: pkg/storaged/details.js:113
+msgid "Create partition on $0"
+msgstr "$0에 파티션 만들기"
+
+#: pkg/storaged/index.html:381
+msgid "Create partition table"
+msgstr ""
+
+#: pkg/sosreport/index.html:42
+msgid "Create report"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/replicationcontroller-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7 pkg/kubernetes/views/route-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3
+msgid "Created"
+msgstr ""
+
+#: pkg/storaged/jobs.js:142
+msgid "Creating RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:130
+msgid "Creating filesystem on $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:156
+msgid "Creating logical volume $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:134
+msgid "Creating partition $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:150
+msgid "Creating snapshot of $target"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:4064
+msgid "Creating this VLAN will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3436
+msgid "Creating this bond will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3842
+msgid "Creating this bridge will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3611
+msgid "Creating this team will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:151
+msgid "Creating volume group $target"
+msgstr ""
+
+#: pkg/systemd/logs.html:41
+msgid "Current boot"
+msgstr ""
+
+#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
+msgid "Custom"
+msgstr "사용자 지정"
+
+#: pkg/storaged/details.js:186
+msgid "Custom (Enter filesystem type)"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:102
+#, fuzzy
+msgid "Custom URL"
+msgstr "사용자 지정"
+
+#: pkg/storaged/index.html:454
+msgid "DISK IS FAILING"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3018
+msgid "DNS"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:14
+msgid "DNS Policy"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3022
+msgid "DNS Search Domains"
+msgstr ""
+
+#: pkg/dashboard/index.html:22
+msgid "Dashboard"
+msgstr ""
+
+#: pkg/storaged/details.js:1130
+msgid "Deactivate"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:823
+msgid "Deactivating"
+msgstr "비활성화 중 입니다"
+
+#: pkg/storaged/jobs.js:149
+msgid "Deactivating $target"
+msgstr ""
+
+#: pkg/docker/index.html:379 pkg/docker/index.html:383
+#: pkg/kubernetes/views/image-config.html:6
+msgid "Default"
+msgstr "기본"
+
+#: pkg/systemd/index.html:454
+msgid "Delay"
+msgstr ""
+
+#: pkg/users/index.html:79 pkg/kubernetes/views/item-delete.html:11
+#: pkg/kubernetes/views/pvc-delete.html:15
+#: pkg/kubernetes/views/node-delete.html:15
+#: pkg/kubernetes/views/imagestream-delete.html:8
+#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/kubernetes/views/image-delete.html:8
+#: pkg/kubernetes/views/pv-delete.html:11
+msgid "Delete"
+msgstr "삭제"
+
+#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
+msgid "Delete $0"
+msgstr ""
+
+#: pkg/users/index.html:292
+msgid "Delete Files"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:4
+#, fuzzy
+msgid "Delete Node"
+msgstr "삭제"
+
+#: pkg/kubernetes/views/pv-delete.html:3
+msgid "Delete Persistent Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:3
+msgid "Delete Persistent Volume Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/project-delete.html:3
+#, fuzzy
+msgid "Delete Project"
+msgstr "프로젝트"
+
+#: pkg/kubernetes/views/nodes-page.html:3
+msgid "Delete Selected"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:3
+msgid "Delete image stream"
+msgstr ""
+
+#: pkg/playground/translate.html:184 pkg/kubernetes/views/item-delete.html:3
+msgid "Delete {{ item.kind }}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
+msgid "Deleting $target"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2156
+msgid "Deleting <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:7
+msgid ""
+"Deleting a Pod will kill all associated containers. Pods may be "
+"automatically created again in some cases."
+msgstr ""
+
+#: pkg/storaged/details.js:631
+msgid "Deleting a RAID device will erase all data on it."
+msgstr "RAID 장치를 제거하면 내부의 모든 데이터를 지우게 됩니다."
+
+#: pkg/docker/containers-view.jsx:167 pkg/docker/details.js:272
+msgid "Deleting a container will erase all data in it."
+msgstr "컨테이너를 삭제하시면, 내부의 모든 데이터도 함께 삭제됩니다. "
+
+#: pkg/storaged/details.js:1009
+msgid "Deleting a logical volume will delete all data in it."
+msgstr ""
+
+#: pkg/storaged/details.js:1012
+msgid "Deleting a partition will delete all data in it."
+msgstr ""
+
+#: pkg/storaged/details.js:826
+msgid "Deleting a volume group will erase all data on it."
+msgstr ""
+
+#: pkg/docker/image.js:152
+msgid ""
+"Deleting an image will delete it, but you can probably download it again if "
+"you need it later.  Unless this image has never been pushed to a repository, "
+"that is, in which case you probably can't download it again."
+msgstr ""
+"이미지를 삭제하시면 실제 파일이 삭제되지만, 필요할 때 다시 다운로드 하실 수 "
+"있습니다. 만일 이미지가 리포지터리에 한번도 푸쉬되지 않았다면, 다시 다운로드 "
+"하실 수 없습니다."
+
+#: pkg/storaged/jobs.js:152
+msgid "Deleting volume group $target"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:131
+#: pkg/kubernetes/views/deploy.html:62
+msgid "Deploy"
+msgstr ""
+
+#: pkg/kubernetes/views/deploy.html:3
+msgid "Deploy Application"
+msgstr "어플리케이션 사용"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:22
+msgid "Deployment Causes"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-panel.html:8
+#: pkg/kubernetes/views/deploymentconfig-page.html:12
+msgid "Deployment Config"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:98
+msgid "Deployment Configs"
+msgstr ""
+
+#: pkg/systemd/services.html:356 pkg/kubernetes/views/project-modify.html:40
+#: pkg/kubernetes/views/image-body.html:6
+#: pkg/kubernetes/views/project-listing.html:15
+#: pkg/kubernetes/views/project-listing.html:54
+msgid "Description"
+msgstr ""
+
+#: pkg/shell/index.html:197 pkg/kubernetes/index.html:63
+msgid "Details"
+msgstr ""
+
+#: pkg/storaged/index.html:543
+#, fuzzy
+msgctxt "storage"
+msgid "Device"
+msgstr "RAID 장치 $0"
+
+#: pkg/storaged/details.js:91
+msgid "Device $0 is a member of RAID Array $1"
+msgstr "장치 $0는 RAID 어레이 $1에 속해 있습니다"
+
+#: pkg/storaged/details.js:97
+msgid "Device $0 is a physical volume of $1"
+msgstr "장치 $0는  $1의 물리 볼륨입니다"
+
+#: pkg/storaged/details.js:85
+msgid "Device $0 is mounted on $1"
+msgstr "장치 $0는 $1에 마운트되어 있습니다"
+
+#: pkg/storaged/index.html:467 pkg/storaged/index.html:473
+#: pkg/storaged/index.html:515
+#, fuzzy
+msgctxt "storage"
+msgid "Device File"
+msgstr "사용자 이름"
+
+#: pkg/sosreport/index.html:22
+msgid "Diagnostic reports"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:20
+msgid "Digest"
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:7
+#: pkg/kubernetes/views/volume-body.html:28
+msgid "Directory"
+msgstr ""
+
+#: pkg/systemd/init.js:543
+msgid "Disable"
+msgstr ""
+
+#: pkg/tuned/dialog.js:234
+msgid "Disable tuned"
+msgstr ""
+
+#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
+msgid "Disabled"
+msgstr "사용 안함"
+
+#: pkg/shell/simple.html:120
+msgid "Disconnected"
+msgstr "연결 해제됨"
+
+#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+#, fuzzy
+msgid "Disk"
+msgstr "디스크 추가"
+
+#: pkg/dashboard/index.html:73
+#, fuzzy
+msgid "Disk I/O"
+msgstr "디스크 추가"
+
+#: pkg/kubernetes/scripts/nodes.js:720
+msgid "Disk Utilization: $0%"
+msgstr ""
+
+#: pkg/storaged/index.html:457
+msgid "Disk is OK"
+msgstr ""
+
+#: pkg/storaged/index.html:584
+msgid "Disks"
+msgstr ""
+
+#: pkg/shell/simple.html:37 pkg/shell/simple.html:97 pkg/shell/index.html:37
+#: pkg/shell/index.html:118 pkg/shell/stub.html:37 pkg/shell/stub.html:111
+msgid "Display Language"
+msgstr "표시 언어"
+
+#: pkg/kubernetes/views/project-modify.html:31
+msgid "Display name"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:5
+msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:5
+msgid ""
+"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}' image stream?"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:6
+msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:6
+msgid ""
+"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:6
+msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:7
+msgid "Do you want to delete this Node?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:5
+msgid ""
+"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+"{{stream.metadata.name}}:{{tag.tag}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/remove-role-dialog.html:5
+msgid ""
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:11
+msgid "Docker Version"
+msgstr ""
+
+#: pkg/docker/index.html:60
+msgid "Docker is not installed or activated on the system"
+msgstr "본 시스템에 Docker가 설치되어 있지 않거나 활성화되어 있지 않습니다."
+
+#: pkg/systemd/index.html:107
+msgid "Domain"
+msgstr ""
+
+#: pkg/realmd/operation.js:148
+msgid "Domain $0 could not be contacted"
+msgstr ""
+
+#: pkg/realmd/operation.js:220
+msgid "Domain $0 is not supported"
+msgstr ""
+
+#: pkg/realmd/operation.html:11
+msgid "Domain Address"
+msgstr ""
+
+#: pkg/realmd/operation.html:59
+msgid "Domain Administrator Name"
+msgstr ""
+
+#: pkg/realmd/operation.html:65
+msgid "Domain Administrator Password"
+msgstr ""
+
+#: pkg/systemd/services.html:426 pkg/systemd/services.html:430
+msgid "Don't Repeat"
+msgstr ""
+
+#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
+msgid "Don't overwrite existing data"
+msgstr ""
+
+#: pkg/sosreport/index.html:74
+msgid "Done!"
+msgstr ""
+
+#: pkg/ostree/index.html:127 pkg/ostree/index.html:158
+msgid "Downgrades"
+msgstr ""
+
+#: pkg/storaged/index.html:411
+msgid "Drive"
 msgstr ""
 
 #: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
@@ -1536,157 +2238,1177 @@ msgctxt "storage"
 msgid "Drive"
 msgstr ""
 
-#: pkg/storaged/overview.js:253
-msgid "$0 Block Device"
+#: pkg/kubernetes/views/volume-body.html:128
+msgid "Driver"
 msgstr ""
 
-#: pkg/storaged/overview.js:414
-msgid "Create RAID Device"
+#: pkg/storaged/index.html:166
+msgid "Drives"
 msgstr ""
 
-#: pkg/storaged/overview.js:420
-msgid "RAID Level"
+#: pkg/docker/run.js:360
+msgid "Duplicate alias"
+msgstr "alias 복제"
+
+#: pkg/docker/run.js:293
+msgid "Duplicate port"
+msgstr "포트 복제"
+
+#: pkg/storaged/jobs.js:120
+msgid "Ejecting $target"
 msgstr ""
 
-#: pkg/storaged/overview.js:422
-msgid "RAID 0 (Stripe)"
+#: pkg/playground/translate.html:58
+msgid "Empty"
 msgstr ""
 
-#: pkg/storaged/overview.js:423
-msgid "RAID 1 (Mirror)"
+#: pkg/playground/translate.html:63
+msgctxt "verb"
+msgid "Empty"
 msgstr ""
 
-#: pkg/storaged/overview.js:424
-msgid "RAID 4 (Dedicated Parity)"
+#: pkg/kubernetes/scripts/volumes.js:196
+msgid "Empty Directory"
 msgstr ""
 
-#: pkg/storaged/overview.js:425
-msgid "RAID 5 (Distributed Parity)"
+#: pkg/storaged/jobs.js:155
+msgid "Emptying $target"
 msgstr ""
 
-#: pkg/storaged/overview.js:426
-msgid "RAID 6 (Double Distributed Parity)"
+#: pkg/systemd/init.js:541
+msgid "Enable"
 msgstr ""
 
-#: pkg/storaged/overview.js:427
-msgid "RAID 10 (Stripe of Mirrors)"
+#: pkg/systemd/init.js:542
+msgid "Enable Forcefully"
 msgstr ""
 
-#: pkg/storaged/overview.js:431
-msgid "Chunk Size"
+#: pkg/systemd/init.js:301
+msgid "Enabled"
 msgstr ""
 
-#: pkg/storaged/overview.js:433
-msgid "4 KiB"
+#: pkg/storaged/details.js:1247
+msgctxt "storage-id-desc"
+msgid "Encrypted"
 msgstr ""
 
-#: pkg/storaged/overview.js:434
-msgid "8 KiB"
+#: pkg/storaged/details.js:180
+msgid "Encrypted EXT4 (LUKS)"
 msgstr ""
 
-#: pkg/storaged/overview.js:435
-msgid "16 KiB"
+#: pkg/storaged/details.js:179
+msgid "Encrypted XFS (LUKS)"
 msgstr ""
 
-#: pkg/storaged/overview.js:436
-msgid "32 KiB"
+#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
+#: pkg/storaged/details.js:1115
+msgid "Encryption Options"
 msgstr ""
 
-#: pkg/storaged/overview.js:437
-msgid "64 KiB"
+#: pkg/kubernetes/views/pv-modify.html:93
+msgid "Endpoint"
 msgstr ""
 
-#: pkg/storaged/overview.js:438
-msgid "128 KiB"
+#: pkg/kubernetes/views/volume-body.html:40
+msgid "Endpoint Name"
 msgstr ""
 
-#: pkg/storaged/overview.js:439
-msgid "512 KiB"
+#: pkg/kubernetes/views/service-page.html:14
+#: pkg/kubernetes/views/service-panel.html:9
+msgid "Endpoints"
 msgstr ""
 
-#: pkg/storaged/overview.js:440
-msgid "1 MiB"
+#: pkg/subscriptions/subscriptions-view.jsx:38
+msgid "Ends"
 msgstr ""
 
-#: pkg/storaged/overview.js:441
-msgid "2 MiB"
+#: pkg/selinux/setroubleshoot-view.jsx:332
+msgid "Enforce policy:"
 msgstr ""
 
-#: pkg/storaged/overview.js:455
-msgid "At least $0 disks are needed."
-msgstr "최소 $0 개의 디스크가 필요합니다."
+#: pkg/lib/machine-dialogs.js:447
+msgid "Enter IP address or host name"
+msgstr "IP 주소 또는 호스트 명을 입력하세요"
 
-#: pkg/storaged/overview.js:487
-msgid "Create Volume Group"
-msgstr "볼륨 그룹 생성"
-
-#: pkg/storaged/overview.js:515
-msgid "Add iSCSI Portal"
+#: pkg/systemd/logs.html:60
+msgid "Entry"
 msgstr ""
 
-#: pkg/storaged/overview.js:518
-msgid "Server Address"
+#: pkg/docker/index.html:547 pkg/kubernetes/views/image-config.html:17
+#: pkg/kubernetes/views/container-body.html:26
+msgid "Environment"
 msgstr ""
 
-#: pkg/storaged/overview.js:521
+#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
+msgid "Erase"
+msgstr ""
+
+#: pkg/docker/storage.jsx:423
+msgid "Erase containers and reset storage pool"
+msgstr ""
+
+#: pkg/docker/storage.jsx:360
+msgid "Erase containers, reformat disks, and add them"
+msgstr ""
+
+#: pkg/storaged/jobs.js:129
+msgid "Erasing $target"
+msgstr ""
+
+#: pkg/systemd/services.html:318 pkg/playground/translate.html:101
+#: pkg/playground/translate.html:106
+msgid "Error"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:650
+msgid "Error getting certificate details: $0"
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:13
+msgid "Error loading users: {{perm_failed}}"
+msgstr ""
+
+#: pkg/docker/util.js:491
+msgid "Error message from Docker:"
+msgstr "Docker로 부터의 오류 메세지:"
+
+#: pkg/users/authorized-keys.js:115
+msgid "Error saving authorized keys: "
+msgstr ""
+
+#: pkg/selinux/setroubleshoot.js:275
 #, fuzzy
-msgid "Server address cannot be empty."
-msgstr "이름을 입력하셔야 합니다."
+msgid "Error while connecting."
+msgstr "다운로드 중 오류 발생"
 
-#: pkg/storaged/overview.js:533 pkg/realmd/operation.html.h:11
-msgid "Next"
-msgstr "다음"
+#: pkg/selinux/setroubleshoot-client.js:192
+msgid "Error while deleting alert"
+msgstr ""
 
-#: pkg/storaged/overview.js:577 pkg/storaged/overview.js:668
-#: pkg/subscriptions/subscriptions-client.js:194
+#: pkg/selinux/setroubleshoot.js:65
+msgid "Error while setting SELinux mode: '$0'"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:88
+msgid "Error writing kubectl config"
+msgstr ""
+
+#: pkg/systemd/logs.html:47
+msgid "Errors"
+msgstr ""
+
+#: pkg/networkmanager/index.html:764
+msgid "Ethernet MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1854
+msgid "Ethtool"
+msgstr ""
+
+#: pkg/users/local.js:429 pkg/users/local.js:1104
+msgid "Excellent password"
+msgstr ""
+
+#: pkg/docker/util.js:96
+msgid "Exited $ExitCode"
+msgstr "$ExitCode 로 종료"
+
+#: pkg/docker/index.html:529
+msgid "Expose container ports"
+msgstr ""
+
+#: pkg/storaged/details.js:183
+msgid "Extended Partition"
+msgstr ""
+
+#: pkg/storaged/details.js:1592
+msgid "FAILED"
+msgstr ""
+
+#: pkg/ostree/index.html:92
+msgid "Failed"
+msgstr "실패하였습니다"
+
+#: pkg/lib/machine-dialogs.js:412
+msgid "Failed to add machine: $0"
+msgstr ""
+
+#: pkg/users/local.js:112 pkg/users/local.js:144 pkg/lib/credentials.js:223
+msgid "Failed to change password"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:187
+msgid "Failed to delete alert"
+msgstr ""
+
+#: pkg/tuned/dialog.js:171
+#, fuzzy
+msgid "Failed to disable tuned"
+msgstr " Docker 실행을 실패하였습니다: $0"
+
+#: pkg/tuned/dialog.js:133
+#, fuzzy
+msgid "Failed to disable tuned profile"
+msgstr " Docker 실행을 실패하였습니다: $0"
+
+#: pkg/lib/machine-dialogs.js:494
+msgid "Failed to edit machine: $0"
+msgstr ""
+
+#: pkg/tuned/dialog.js:169
+msgid "Failed to enable tuned"
+msgstr ""
+
+#: pkg/users/index.html:338
+msgid "Failed to load authorized keys."
+msgstr ""
+
+#: pkg/docker/containers.js:64
+msgid "Failed to start Docker: $0"
+msgstr " Docker 실행을 실패하였습니다: $0"
+
+#: pkg/docker/util.js:544
+msgid "Failed to stop Docker scope: $0"
+msgstr "Docker Scope를 정지하지 못했습니다: $0"
+
+#: pkg/tuned/dialog.js:145
+#, fuzzy
+msgid "Failed to switch profile"
+msgstr " Docker 실행을 실패하였습니다: $0"
+
+#: pkg/kubernetes/scripts/volumes.js:204
+msgid "Fibre Channel"
+msgstr ""
+
+#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
+msgid "Filesystem Options"
+msgstr "파일 시스템 옵션"
+
+#: pkg/kubernetes/views/pv-modify.html:180
+#: pkg/kubernetes/views/volume-body.html:6
+#: pkg/kubernetes/views/volume-body.html:16
+#: pkg/kubernetes/views/volume-body.html:62
+#: pkg/kubernetes/views/volume-body.html:83
+#: pkg/kubernetes/views/volume-body.html:91
+#: pkg/kubernetes/views/volume-body.html:120
+#: pkg/kubernetes/views/volume-body.html:132
+#, fuzzy
+msgid "Filesystem Type"
+msgstr "파일 시스템 옵션"
+
+#: pkg/storaged/details.js:215
+msgid "Filesystem type"
+msgstr ""
+
+#: pkg/storaged/index.html:225
+msgid "Filesystems"
+msgstr ""
+
+#: pkg/lib/machine-unknown-hostkey.html:10
+msgid "Fingerprint"
+msgstr ""
+
+#: pkg/storaged/index.html:426
+#, fuzzy
+msgctxt "storage"
+msgid "Firmware Version"
+msgstr "버전"
+
+#: pkg/kubernetes/scripts/volumes.js:206
+msgid "Flex"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:205
+#, fuzzy
+msgid "Flocker"
+msgstr "잠금 해제"
+
+#: pkg/kubernetes/views/volume-body.html:125
+msgid "Flocker Dataset Name"
+msgstr ""
+
+#: pkg/docker/util.js:503
+msgid "Force Delete"
+msgstr "강제 삭제"
+
+#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
+#: pkg/storaged/details.js:1142
+msgid "Format"
+msgstr "포멧"
+
+#: pkg/storaged/details.js:115
+msgid "Format $0"
+msgstr ""
+
+#: pkg/storaged/details.js:335
+msgid "Format Disk $0"
+msgstr "디스크 $0 포멧"
+
+#: pkg/storaged/details.js:358
+msgid "Formatting a disk will erase all data on it."
+msgstr "디스크를 포멧하면 내부의 모든 데이터를 지우게 됩니다."
+
+#: pkg/storaged/details.js:268
+msgid "Formatting a storage device will erase all data on it."
+msgstr "장치를 포멧하면 내부의 모든 데이터를 지우게 됩니다."
+
+#: pkg/networkmanager/interfaces.js:2577
+msgid "Forward delay $forward_delay"
+msgstr "포워드 딜레이 $forward_delay"
+
+#: pkg/systemd/index.html:255
+msgid "Free"
+msgstr ""
+
+#: pkg/users/index.html:86 pkg/users/index.html:148
+msgid "Full Name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:192
+msgid "GCE Persistent Disk"
+msgstr ""
+
+#: pkg/docker/index.html:180
+msgid "Gateway:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2628
+msgid "General"
+msgstr "일반"
+
+#: pkg/sosreport/index.html:66
+msgid "Generating report"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:194
+#, fuzzy
+msgid "Git Repository"
+msgstr "리포지터리 "
+
+#: pkg/kubernetes/scripts/volumes.js:198
+msgid "Gluster FS"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:872
+msgid "GlusterFS"
+msgstr ""
+
+#: pkg/systemd/logs.js:130
+msgid "Go to"
+msgstr ""
+
+#: pkg/storaged/index.html:307 pkg/networkmanager/index.html:50
+#: pkg/networkmanager/index.html:496
+msgid "Go to now"
+msgstr "지금 바로 가기"
+
+#: pkg/kubernetes/views/group-page.html:21
+#: pkg/kubernetes/views/group-panel.html:12
+#, fuzzy
+msgid "Group Members"
+msgstr "맴버"
+
+#: pkg/kubernetes/views/project-listing.html:48
+#: pkg/kubernetes/views/user-delete.html:14
+msgid "Groups"
+msgstr ""
+
+#: pkg/networkmanager/index.html:268
+msgid "Hair Pin mode"
+msgstr "Hair Pin 모드"
+
+#: pkg/networkmanager/interfaces.js:2603
+msgid "Hairpin mode"
+msgstr "Hairpin 모드"
+
+#: pkg/docker/storage.jsx:157
+#, fuzzy
+msgid "Hard Disk"
+msgstr "디스크 추가"
+
+#: pkg/storaged/overview.js:180
+msgctxt "storage"
+msgid "Hard Disk"
+msgstr ""
+
+#: pkg/systemd/index.html:77
+msgid "Hardware"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2579
+msgid "Hello time $hello_time"
+msgstr "Hello 시간 $hello_time"
+
+#: pkg/kubernetes/views/details-page.html:73
+#: pkg/kubernetes/views/route-body.html:9
+#: pkg/kubernetes/views/route-modify.html:8
+msgid "Host"
+msgstr "호스트"
+
+#: pkg/systemd/index.html:102 pkg/dashboard/index.html:151
+msgid "Host Name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
+#, fuzzy
+msgid "Host Path"
+msgstr "호스트"
+
+#: src/base1/cockpit.js:3699
+msgid "Host key is incorrect"
+msgstr ""
+
+#: pkg/systemd/services.html:442
+msgid "Hour : Minute"
+msgstr ""
+
+#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
+msgid "Hour needs to be a number between 0-23"
+msgstr ""
+
+#: pkg/systemd/services.html:408
+#, fuzzy
+msgid "Hours"
+msgstr "6 시간"
+
+#: pkg/systemd/index.html:221
+msgid "I/O Wait"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
+msgid "IP"
+msgstr ""
+
+#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
+msgid "IP Address"
+msgstr "IP 주소"
+
+#: pkg/docker/index.html:172
+#, fuzzy
+msgid "IP Address:"
+msgstr "IP 주소"
+
+#: pkg/docker/index.html:176
+#, fuzzy
+msgid "IP Prefix Length:"
+msgstr "접두 길이"
+
+#: pkg/networkmanager/index.html:568
+msgid "IP Settings"
+msgstr "IP 설정"
+
+#: pkg/networkmanager/interfaces.js:2641
+msgid "IPv4"
+msgstr "IPv4"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv4 Settings"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2642
+msgid "IPv6"
+msgstr "IPv6"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv6 Settings"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
+msgid "ISCSI"
+msgstr ""
+
+#: pkg/systemd/init.js:270
+msgid "Id"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2620
+msgid "Id $id"
+msgstr "Id $id"
+
+#: pkg/kubernetes/views/image-body.html:22
+msgid "Identifier"
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:23
+#: pkg/kubernetes/views/user-panel.html:18
+msgid "Identities"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:91
+msgid "Identity"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1817
+msgid "Ignore"
+msgstr "무시"
+
+#: pkg/docker/index.html:452 pkg/kubernetes/views/image-panel.html:9
+#: pkg/kubernetes/views/container-body.html:6
+#: pkg/kubernetes/views/image-page.html:16
+msgid "Image"
+msgstr "이미지"
+
+#: pkg/docker/image.js:77
+msgid "Image $0"
+msgstr "이미지 $0"
+
+#: pkg/kubernetes/views/container-body.html:8
+msgid "Image ID"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:16
+#, fuzzy
+msgid "Image Layers"
+msgstr "이미지 $0"
+
+#: pkg/kubernetes/views/volume-body.html:58
+#, fuzzy
+msgid "Image Name"
+msgstr "이미지 $0"
+
+#: pkg/kubernetes/registry.html:23
+msgid "Image Registry"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-page.html:16
+msgid "Image Stream"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:135
+#, fuzzy
+msgid "Image commands"
+msgstr "이미지 $0"
+
+#: pkg/kubernetes/views/imagestream-body.html:34
+msgid "Image count"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:48
+#: pkg/kubernetes/views/registry-dashboard-page.html:19
+#: pkg/kubernetes/views/imagestream-page.html:18
+#: pkg/kubernetes/views/image-listing.html:9 pkg/kubernetes/index.html:77
+msgid "Images"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:17
+msgid "Images by project"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:54
+msgid "Images pushed recently"
+msgstr ""
+
+#: pkg/storaged/details.js:1593
+msgid "In Sync"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:81
+msgid ""
+"In order to begin pushing images to the registry, use the commands below."
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:6
+msgid ""
+"In order to begin pushing images to the registry, you need to create a "
+"project."
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:50
+msgid ""
+"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
+"strong}}.        {{/needs_root}}                                    User "
+"name                                                                            "
+"{{#allows_password}}                            "
+"Password                                                                            "
+"{{/allows_password}}            "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
+#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
+msgid "Inactive"
+msgstr "비활성"
+
+#: pkg/lib/machine-invalid-hostkey.html:2
+msgid "Incorrect Host Key"
+msgstr ""
+
+#: pkg/docker/storage.jsx:282
+msgid "Information about the Docker storage pool is not available."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:222
+msgid "Installed products"
+msgstr ""
+
+#: pkg/systemd/services.html:135
+msgid "Instantiate"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:169
+#: pkg/kubernetes/views/volume-body.html:81
+#, fuzzy
+msgid "Interface"
+msgstr "인터페이스"
+
+#: pkg/networkmanager/index.html:84
+msgid "Interfaces"
+msgstr "인터페이스"
+
+#: src/base1/cockpit.js:3701
+msgid "Internal error"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:196
+#, fuzzy
+msgid "Invalid credentials"
+msgstr "잘못된 포트"
+
+#: pkg/systemd/host.js:1194
+msgid "Invalid date format"
+msgstr ""
+
+#: pkg/systemd/host.js:1190
+msgid "Invalid date format and invalid time format"
+msgstr ""
+
+#: pkg/systemd/init.js:1218
+#, fuzzy
+msgid "Invalid date format."
+msgstr "잘못된 포트"
+
+#: pkg/lib/credentials.js:274
+msgid "Invalid file permissions"
+msgstr ""
+
+#: pkg/users/index.html:322
+msgid "Invalid key"
+msgstr ""
+
+#: pkg/systemd/init.js:1169
+#, fuzzy
+msgid "Invalid number."
+msgstr "잘못된 포트"
+
+#: pkg/docker/run.js:283
+msgid "Invalid port"
+msgstr "잘못된 포트"
+
+#: pkg/systemd/host.js:1192
+msgid "Invalid time format"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:194 pkg/storaged/overview.js:577
+#: pkg/storaged/overview.js:668
 msgid "Invalid username or password"
 msgstr ""
 
-#: pkg/storaged/overview.js:582
-msgid "Unknown host name"
+#: pkg/lib/machine-change-port.html:15
+msgid "Is sshd running on a different port?"
 msgstr ""
 
-#: pkg/storaged/overview.js:586
-msgid "Unable to reach server"
+#: pkg/systemd/init.js:522
+msgid "Isolate"
 msgstr ""
 
-#: pkg/storaged/overview.js:619
-msgid "Available targets on $0"
+#: pkg/storaged/index.html:280
+msgid "Jobs"
 msgstr ""
 
-#: pkg/storaged/overview.js:623 pkg/systemd/services.html.h:2
-msgid "Targets"
+#: pkg/realmd/operation.js:96
+msgid "Join"
 msgstr ""
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-add.html.h:2
-#: pkg/kubernetes/views/node-body.html.h:2
-#: pkg/kubernetes/views/auth-form.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:16
-#: pkg/kubernetes/views/nodes-page.html.h:7
-#: pkg/kubernetes/views/details-page.html.h:19
-msgid "Address"
+#: pkg/realmd/operation.js:453
+msgid "Join Domain"
+msgstr ""
+
+#: pkg/realmd/operation.js:347
+msgid "Joining this domain is not supported"
+msgstr ""
+
+#: pkg/systemd/logs.js:257
+msgid "Journal entry"
+msgstr ""
+
+#: pkg/systemd/logs.js:284
+msgid "Journal entry not found"
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:10
+msgid "Kerberos Based SSO"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:69
+msgid "Kerberos Ticket"
+msgstr ""
+
+#: pkg/systemd/index.html:225
+msgid "Kernel"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:19
+#, fuzzy
+msgid "Kernel Version"
+msgstr "버전"
+
+#: pkg/kubernetes/views/volume-body.html:67
+msgid "Key Ring Path"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:23
+msgid "Kubelet Version"
+msgstr ""
+
+#: pkg/kubernetes/index.html:23
+msgid "Kubernetes Cluster"
+msgstr "Kubernetes 클러스터"
+
+#: pkg/networkmanager/index.html:473
+msgid "LACP Key"
+msgstr ""
+
+#: pkg/storaged/details.js:1245
+msgctxt "storage-id-desc"
+msgid "LUKS Encrypted"
+msgstr ""
+
+#: pkg/storaged/details.js:1226
+msgctxt "storage-id-desc"
+msgid "LVM2 Physical Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/replicationcontroller-body.html:17
+#: pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/route-body.html:22
+#: pkg/kubernetes/views/image-meta.html:3
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
+msgid "Labels"
+msgstr ""
+
+#: pkg/systemd/logs.html:42
+msgid "Last 24 hours"
+msgstr ""
+
+#: pkg/systemd/logs.html:43
+msgid "Last 7 days"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:49
+msgid "Last Heartbeat"
+msgstr ""
+
+#: pkg/users/index.html:100
+msgid "Last Login"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:51
+msgid "Last Status Change"
+msgstr ""
+
+#: pkg/systemd/init.js:273
+msgid "Last Trigger"
+msgstr ""
+
+#: pkg/kubernetes/views/image-listing.html:16
+msgid "Last Updated"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:107
+msgid "Latest Version"
+msgstr ""
+
+#: pkg/realmd/operation.js:101
+msgid "Leave"
+msgstr ""
+
+#: pkg/networkmanager/index.html:315
+msgid "Link Monitoring"
+msgstr "링크 모니터링"
+
+#: pkg/networkmanager/index.html:397
+#, fuzzy
+msgid "Link Watch"
+msgstr "로컬 링크"
+
+#: pkg/networkmanager/index.html:350 pkg/networkmanager/index.html:432
+msgid "Link down delay"
+msgstr "링크 다운 딜레이"
+
+#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
+msgid "Link local"
+msgstr "로컬 링크"
+
+#: pkg/networkmanager/index.html:341 pkg/networkmanager/index.html:423
+msgid "Link up delay"
+msgstr "링크 업 딜레이"
+
+#: pkg/docker/index.html:514
+msgid "Links"
+msgstr "링크"
+
+#: pkg/storaged/details.js:1224
+msgctxt "storage-id-desc"
+msgid "Linux MD-RAID Component"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1841
+#, fuzzy
+msgid "Load Balancing"
+msgstr "적응형 로드 밸런싱"
+
+#: pkg/systemd/logs.js:69
+msgid "Load earlier entries"
+msgstr ""
+
+#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
+#: pkg/systemd/logs.js:175
+msgid "Loading..."
+msgstr ""
+
+#: pkg/users/index.html:23
+msgid "Local Accounts"
+msgstr ""
+
+#: pkg/docker/storage.jsx:188
+#, fuzzy
+msgid "Local Disks"
+msgstr "디스크 추가"
+
+#: pkg/storaged/details.js:1109
+msgid "Lock"
+msgstr ""
+
+#: pkg/users/index.html:109 pkg/users/index.html:196
+msgid "Lock Account"
+msgstr ""
+
+#: pkg/storaged/jobs.js:122
+msgid "Locking $target"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:80
+msgid "Log In"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:4
+msgid "Log in to {{host}}"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:116
+msgid "Log into OpenShift command line tools:"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:101
+msgid "Log into the registry:"
+msgstr ""
+
+#: pkg/shell/simple.html:45 pkg/shell/index.html:52 pkg/shell/stub.html:45
+msgid "Log out"
+msgstr "로그아웃"
+
+#: pkg/users/local.js:839
+msgid "Logged In"
+msgstr ""
+
+#: pkg/storaged/details.js:1424
+msgid "Logical Partition"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:158
+#: pkg/kubernetes/views/volume-body.html:79
+#: pkg/kubernetes/views/volume-body.html:118
+#, fuzzy
+msgid "Logical Unit Number"
+msgstr "논리 볼륨"
+
+#: pkg/storaged/utils.js:172
+msgid "Logical Volume"
+msgstr "논리 볼륨"
+
+#: pkg/storaged/utils.js:170
+msgid "Logical Volume (Snapshot)"
+msgstr "논리 볼륨 (스냅샷)"
+
+#: pkg/storaged/details.js:1792
+msgid "Logical Volumes"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:140
+msgid "Login"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:68
+msgid "Login Password"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:96
+msgid "Login commands"
+msgstr ""
+
+#: src/base1/cockpit.js:3693
+msgid "Login failed"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:200
+msgid "Login/password or activation key required to register."
+msgstr ""
+
+#: pkg/systemd/logs.html:59 pkg/kubernetes/views/container-panel.html:6
+#: pkg/kubernetes/views/container-page-inline.html:8
+msgid "Logs"
+msgstr ""
+
+#: pkg/dashboard/index.html:110
+msgid "Lost connection. Trying to reconnect"
+msgstr "연결이 끓어졌습니다. 다시 시도 하는 중입니다."
+
+#: pkg/docker/index.html:184
+#, fuzzy
+msgid "MAC Address:"
 msgstr "주소"
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-change-port.html.h:5
-msgid "Port"
+#: pkg/networkmanager/interfaces.js:1833
+msgid "MII (Recommended)"
+msgstr "MII (권장 사항)"
+
+#: pkg/networkmanager/interfaces.js:2477
+msgid "MTU"
 msgstr ""
 
-#: pkg/storaged/overview.js:699
-msgid "Change iSCSI Initiator Name"
+#: pkg/networkmanager/interfaces.js:4139
+msgid "MTU must be a positive number"
 msgstr ""
 
-#: pkg/storaged/overview.js:707 pkg/kubernetes/views/route-modify.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:22
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:4
-#: pkg/kubernetes/views/project-modify.html.h:9
-msgid "Change"
+#: pkg/systemd/index.html:85 pkg/kubernetes/views/node-body.html:15
+msgid "Machine ID"
 msgstr ""
 
-#: pkg/storaged/utils.js:88
-msgctxt "format-bytes"
-msgid "bytes"
-msgstr "바이트"
+#: pkg/systemd/index.html:282
+msgid "Machine SSH Key Fingerprints"
+msgstr ""
+
+#: pkg/shell/indexes.js:253
+msgid "Machines"
+msgstr "장치들"
+
+#: pkg/kubernetes/scripts/dashboard.js:460
+msgid "Manifest"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
+msgid "Manual"
+msgstr "수동"
+
+#: pkg/systemd/index.html:401 pkg/systemd/index.html:405
+#, fuzzy
+msgid "Manually"
+msgstr "수동"
+
+#: pkg/storaged/jobs.js:140
+msgid "Marking $target as faulty"
+msgstr ""
+
+#: pkg/systemd/init.js:546
+msgid "Mask"
+msgstr ""
+
+#: pkg/systemd/init.js:547
+msgid "Mask Forcefully"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2483
+msgid "Master"
+msgstr "마스터"
+
+#: pkg/networkmanager/interfaces.js:2581
+msgid "Maximum message age $max_age"
+msgstr "최대 메세지 수명 $max_age"
+
+#: pkg/kubernetes/views/volume-body.html:34
+msgid "Medium"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:92
+msgid "Member of"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:16
+#: pkg/kubernetes/views/project-listing.html:55
+#: pkg/networkmanager/index.html:291
+msgid "Members"
+msgstr "맴버"
+
+#: pkg/kubernetes/views/project-page.html:29
+#: pkg/kubernetes/views/user-panel.html:11
+#: pkg/kubernetes/views/user-panel.html:27
+#: pkg/kubernetes/views/user-body.html:4
+msgid "Membership"
+msgstr ""
+
+#: pkg/dashboard/index.html:71 pkg/playground/translate.html:91
+msgid "Memory"
+msgstr "메모리"
+
+#: pkg/systemd/host.js:1466
+msgctxt "page-title"
+msgid "Memory"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:716
+msgid "Memory Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:473 pkg/docker/index.html:652
+msgid "Memory limit"
+msgstr "메모리 제한"
+
+#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
+msgid "Message"
+msgstr ""
+
+#: pkg/systemd/host.js:1300
+msgid "Message to logged in users"
+msgstr ""
+
+#: pkg/kubernetes/views/image-panel.html:15
+#: pkg/kubernetes/views/imagestream-page.html:21
+#: pkg/kubernetes/views/image-page.html:22
+msgid "Metadata"
+msgstr ""
+
+#: pkg/docker/index.html:487 pkg/docker/index.html:666
+msgid "MiB"
+msgstr ""
+
+#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
+msgid "Minute needs to be a number between 0-59"
+msgstr ""
+
+#: pkg/systemd/services.html:407
+#, fuzzy
+msgid "Minutes"
+msgstr "5분"
+
+#: pkg/networkmanager/index.html:299
+msgid "Mode"
+msgstr "모드"
+
+#: pkg/storaged/index.html:421
+#, fuzzy
+msgctxt "storage"
+msgid "Model"
+msgstr "모드"
+
+#: pkg/kubernetes/views/user-modify.html:31
+msgid "Modify"
+msgstr ""
+
+#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
+msgid "Modifying $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:323
+msgid "Monitoring Interval"
+msgstr "모니터링 주기"
+
+#: pkg/networkmanager/index.html:332
+msgid "Monitoring Targets"
+msgstr "모니터링 대상"
+
+#: pkg/kubernetes/views/volume-body.html:54
+#, fuzzy
+msgid "Monitors"
+msgstr "ARP 모니터링"
+
+#: pkg/realmd/operation.js:366
+msgid "More"
+msgstr ""
+
+#: pkg/storaged/details.js:1099
+msgid "Mount"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
+#, fuzzy
+msgid "Mount Location"
+msgstr "마운트 옵션"
+
+#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
+msgid "Mount Options"
+msgstr "마운트 옵션"
+
+#: pkg/storaged/index.html:231
+msgid "Mount Point"
+msgstr "마운트 포인트"
+
+#: pkg/docker/index.html:540
+msgid "Mount container volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
+msgid "Mounting"
+msgstr "마운트"
+
+#: pkg/storaged/jobs.js:126
+msgid "Mounting $target"
+msgstr ""
+
+#: pkg/storaged/index.html:508
+msgctxt "storage"
+msgid "Multipathed Devices"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:860
+msgid "NFS"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:199
+msgid "NFS Mount"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1856
+msgid "NSNA Ping"
+msgstr ""
+
+#: pkg/storaged/details.js:182
+msgid "NTFS - Compatible with most systems"
+msgstr ""
+
+#: pkg/systemd/host.js:1250
+msgid "NTP Server"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/project-modify.html:16
+#: pkg/kubernetes/views/node-add.html:16
+#: pkg/kubernetes/views/volumes-page.html:19
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/image-body.html:2
+#: pkg/kubernetes/views/imagestream-modify.html:10
+#: pkg/kubernetes/views/service-modify.html:9
+#: pkg/kubernetes/views/dashboard-page.html:156
+#: pkg/kubernetes/views/dashboard-page.html:198
+#: pkg/kubernetes/views/details-page.html:34
+#: pkg/kubernetes/views/details-page.html:70
+#: pkg/kubernetes/views/details-page.html:103
+#: pkg/kubernetes/views/details-page.html:137
+#: pkg/kubernetes/views/details-page.html:171
+#: pkg/kubernetes/views/pv-claim.html:4
+#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/kubernetes/views/project-listing.html:14
+#: pkg/kubernetes/views/project-listing.html:53
+#: pkg/kubernetes/views/project-listing.html:90
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/volume-body.html:31 pkg/storaged/index.html:230
+#: pkg/networkmanager/index.html:95 pkg/networkmanager/index.html:113
+#: pkg/networkmanager/index.html:150 pkg/networkmanager/index.html:183
+#: pkg/networkmanager/index.html:282 pkg/networkmanager/index.html:364
+msgid "Name"
+msgstr "이름"
 
 #: pkg/storaged/utils.js:129
 #, fuzzy
@@ -1708,1160 +3430,176 @@ msgstr "이름은 문자 '$0'를 포함할 수 없습니다."
 msgid "Name cannot contain whitespace."
 msgstr "이름은 공백이 없어야 합니다."
 
-#: pkg/storaged/utils.js:157
-msgid "$name (from $host)"
-msgstr "$name ($host에서)"
-
-#: pkg/storaged/utils.js:166
-msgid "Pool for Thin Logical Volumes"
-msgstr "Thin 논리 볼륨을 위한 풀"
-
-#: pkg/storaged/utils.js:168
-msgid "Thin Logical Volume"
-msgstr "Thin 논리 볼륨"
-
-#: pkg/storaged/utils.js:170
-msgid "Logical Volume (Snapshot)"
-msgstr "논리 볼륨 (스냅샷)"
-
-#: pkg/storaged/utils.js:172
-msgid "Logical Volume"
-msgstr "논리 볼륨"
-
-#: pkg/storaged/utils.js:212
-msgid "<span>Encrypted Logical Volume of $0</span>"
-msgstr "<span>$0의 암호화 된 논리 볼륨</span>"
-
-#: pkg/storaged/utils.js:214
-msgid "<span>Encrypted Partition of $0</span>"
-msgstr "<span>$0의 암호화 된 파티션</span>"
-
-#: pkg/storaged/utils.js:216
-msgid "<span>Logical Volume of $0</span>"
-msgstr "<span>$0의 논리 볼륨</span>"
-
-#: pkg/storaged/utils.js:218
-msgid "<span>Partition of $0</span>"
-msgstr "<span>$0의 파티션</span>"
-
-#: pkg/storaged/utils.js:220
-msgid "<span>Encrypted $0</span>"
-msgstr "<span>암호화 된 $0</span>"
-
-#: pkg/storaged/utils.js:233
-msgid "RAID Device $0"
-msgstr "RAID 장치 $0"
-
-#: pkg/storaged/utils.js:239
-msgid "Volume Group $0"
-msgstr "볼륨 그룹 $0"
-
-#: pkg/storaged/jobs.js:119
-msgid "SMART self-test of $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:120
-msgid "Ejecting $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:121
-msgid "Unlocking $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:122
-msgid "Locking $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
-msgid "Modifying $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:124
-msgid "Starting swapspace $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:125
-msgid "Stopping swapspace $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:126
-msgid "Mounting $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:127
-msgid "Unmounting $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:129
-msgid "Erasing $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:130
-msgid "Creating filesystem on $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:131
-msgid "Setting up loop device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
-msgid "Deleting $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:134
-msgid "Creating partition $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:135
-msgid "Cleaning up for $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:136
-msgid "Securely erasing $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:137
-msgid "Very securely erasing $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:138
-msgid "Stopping RAID Device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:139
-msgid "Starting RAID Device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:140
-msgid "Marking $target as faulty"
-msgstr ""
-
-#: pkg/storaged/jobs.js:141
-msgid "Removing $target from RAID Device"
-msgstr ""
-
-#: pkg/storaged/jobs.js:142
-msgid "Creating RAID Device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:143
-#, fuzzy
-msgid "Checking RAID Device $target"
-msgstr "RAID 장치 $0"
-
-#: pkg/storaged/jobs.js:144
-msgid "Checking and Repairing RAID Device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:145
-msgid "Recovering RAID Device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:146
-msgid "Synchronizing RAID Device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:148
-msgid "Activating $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:149
-msgid "Deactivating $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:150
-msgid "Creating snapshot of $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:151
-msgid "Creating volume group $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:152
-msgid "Deleting volume group $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:153
-msgid "Adding physical volume to $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:154
-msgid "Removing physical volume from $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:155
-msgid "Emptying $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:156
-msgid "Creating logical volume $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:157
-msgid "Renaming $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:158
-msgid "Resizing $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:166
-msgid "Operation '$operation' on $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:180
-msgid "unknown target"
-msgstr ""
-
-#: pkg/storaged/permissions.js:61
-msgid "The user <b>$0</b> is not permitted to manage storage"
-msgstr ""
-
-#: pkg/realmd/operation.js:96
-msgid "Join"
-msgstr ""
-
-#: pkg/realmd/operation.js:101
-msgid "Leave"
-msgstr ""
-
-#: pkg/realmd/operation.js:148
-msgid "Domain $0 could not be contacted"
-msgstr ""
-
-#: pkg/realmd/operation.js:220
-msgid "Domain $0 is not supported"
-msgstr ""
-
-#: pkg/realmd/operation.js:347
-msgid "Joining this domain is not supported"
-msgstr ""
-
-#: pkg/realmd/operation.js:366
-msgid "More"
-msgstr ""
-
-#: pkg/realmd/operation.js:417
-msgid "Cannot join a domain because realmd is not available on this system"
-msgstr ""
-
-#: pkg/realmd/operation.js:436
-msgid "The user <b>$0</b> is not permitted to modify realms"
-msgstr ""
-
-#: pkg/realmd/operation.js:453
-msgid "Join Domain"
-msgstr ""
-
-#: pkg/docker/run.js:246 pkg/docker/util.js:102
-#: pkg/networkmanager/interfaces.js:2280 pkg/kubernetes/scripts/volumes.js:992
-#: pkg/docker/index.html.h:46
-msgid "No"
-msgstr "아니오"
-
-#: pkg/docker/run.js:261 pkg/docker/console.html.h:1
-#: pkg/kubernetes/views/image-panel.html.h:2
-#: pkg/kubernetes/views/container-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:1
-#: pkg/kubernetes/views/image-page.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:1
-msgid "Container"
-msgstr "컨테이너 "
-
-#: pkg/docker/run.js:263 pkg/kubernetes/views/route-modify.html.h:2
-#: pkg/kubernetes/views/route-body.html.h:4
-#: pkg/kubernetes/views/details-page.html.h:12
-msgid "Host"
-msgstr "호스트"
-
-#: pkg/docker/run.js:283
-msgid "Invalid port"
-msgstr "잘못된 포트"
-
-#: pkg/docker/run.js:293
-msgid "Duplicate port"
-msgstr "포트 복제"
-
-#: pkg/docker/run.js:332
-#, fuzzy
-msgid "Command can't be empty"
-msgstr "이름을 입력하셔야 합니다."
-
-#: pkg/docker/run.js:350
-msgid "No alias specified"
-msgstr "alias가 지정되지 않았습니다"
-
-#: pkg/docker/run.js:360
-msgid "Duplicate alias"
-msgstr "alias 복제"
-
-#: pkg/docker/run.js:384
-msgid "No container specified"
-msgstr "컨테이너가 지정되지 않았습니다."
-
-#: pkg/docker/details.js:47 pkg/docker/image.js:43
-msgctxt "page-title"
-msgid "Containers"
-msgstr "컨테이너"
-
-#: pkg/docker/details.js:144
-msgid "${hip}:${hport} -> $cport"
-msgstr "${hip}:${hport} -> $cport"
-
-#: pkg/docker/details.js:272 pkg/docker/containers-view.jsx:167
-msgid "Deleting a container will erase all data in it."
-msgstr "컨테이너를 삭제하시면, 내부의 모든 데이터도 함께 삭제됩니다. "
-
-#: pkg/docker/storage.jsx:156
-msgid "Solid-State Disk"
-msgstr ""
-
-#: pkg/docker/storage.jsx:157
-#, fuzzy
-msgid "Hard Disk"
-msgstr "디스크 추가"
-
-#: pkg/docker/storage.jsx:158 pkg/storaged/index.html.h:33
-msgid "Drive"
-msgstr ""
-
-#: pkg/docker/storage.jsx:188
-#, fuzzy
-msgid "Local Disks"
-msgstr "디스크 추가"
-
-#: pkg/docker/storage.jsx:194
-msgid "No additional local storage found."
-msgstr ""
-
-#: pkg/docker/storage.jsx:242
-msgid " (shared with the OS)"
-msgstr ""
-
-#: pkg/docker/storage.jsx:282
-msgid "Information about the Docker storage pool is not available."
-msgstr ""
-
-#: pkg/docker/storage.jsx:314
-msgid "Total"
-msgstr ""
-
-#: pkg/docker/storage.jsx:348
-msgid "Reformat and add disks"
-msgstr ""
-
-#: pkg/docker/storage.jsx:355
-msgid ""
-"The storage pool will be reset to optimize its layout.  All containers will "
-"be erased."
-msgstr ""
-
-#: pkg/docker/storage.jsx:360
-msgid "Erase containers, reformat disks, and add them"
-msgstr ""
-
-#: pkg/docker/storage.jsx:363
-msgid "Add Additional Storage"
-msgstr ""
-
-#: pkg/docker/storage.jsx:366
-msgid ""
-"All data on selected disks will be erased and disks will be added to the "
-"storage pool."
-msgstr ""
-
-#: pkg/docker/storage.jsx:404
-msgid "Could not add all disks"
-msgstr ""
-
-#: pkg/docker/storage.jsx:417
-msgid "Reset Storage Pool"
-msgstr ""
-
-#: pkg/docker/storage.jsx:420
-msgid ""
-"Resetting the storage pool will erase all containers and release disks in "
-"the pool."
-msgstr ""
-
-#: pkg/docker/storage.jsx:423
-msgid "Erase containers and reset storage pool"
-msgstr ""
-
-#: pkg/docker/storage.jsx:446
-msgid "Could not reset the storage pool"
-msgstr ""
-
-#: pkg/docker/storage.jsx:482
-msgid "You don't have permission to manage the Docker storage pool."
-msgstr ""
-
-#: pkg/docker/storage.jsx:485
-msgid "The Docker storage pool cannot be managed on this system."
-msgstr ""
-
-#: pkg/docker/image.js:77
-msgid "Image $0"
-msgstr "이미지 $0"
-
-#: pkg/docker/image.js:152
-msgid ""
-"Deleting an image will delete it, but you can probably download it again if "
-"you need it later.  Unless this image has never been pushed to a repository, "
-"that is, in which case you probably can't download it again."
-msgstr ""
-"이미지를 삭제하시면 실제 파일이 삭제되지만, 필요할 때 다시 다운로드 하실 수 "
-"있습니다. 만일 이미지가 리포지터리에 한번도 푸쉬되지 않았다면, 다시 다운로드 "
-"하실 수 없습니다."
-
-#: pkg/docker/util.js:94
-msgid "Up since $StartedAt"
-msgstr "$StartedAt 부터 켜져있음"
-
-#: pkg/docker/util.js:96
-msgid "Exited $ExitCode"
-msgstr "$ExitCode 로 종료"
-
-#: pkg/docker/util.js:104
-msgid "On failure, retry $0 time"
-msgid_plural "On failure, retry $0 times"
-msgstr[0] ""
-
-#: pkg/docker/util.js:107 pkg/docker/index.html.h:48
-msgid "Always"
-msgstr ""
-
-#: pkg/docker/util.js:109 pkg/docker/index.html.h:49
-#, fuzzy
-msgid "Unless Stopped"
-msgstr "정지됨"
-
-#: pkg/docker/util.js:123
-msgid "default"
-msgstr "기본"
-
-#: pkg/docker/util.js:124
-msgid "$0 shares"
-msgstr "$0 공유"
-
-#: pkg/docker/util.js:231
-msgid "Stopped"
-msgstr "정지됨"
-
-#: pkg/docker/util.js:488
-msgid "Container is currently running."
-msgstr "컨테이너가 현재 실행중입니다."
-
-#: pkg/docker/util.js:490
-msgid ""
-"Container is currently marked as not running, but regular stopping failed."
-msgstr ""
-"컨테이너는 현재 실행중이지 않은 것으로 보이지만, 정상적인 종료가 되지 않았습"
-"니다."
-
-#: pkg/docker/util.js:491
-msgid "Error message from Docker:"
-msgstr "Docker로 부터의 오류 메세지:"
-
-#: pkg/docker/util.js:501
-msgid "Please confirm forced deletion of $0"
-msgstr "$0 강제 삭제를 확인해주세요"
-
-#: pkg/docker/util.js:503
-msgid "Force Delete"
-msgstr "강제 삭제"
-
-#: pkg/docker/util.js:544
-msgid "Failed to stop Docker scope: $0"
-msgstr "Docker Scope를 정지하지 못했습니다: $0"
-
-#: pkg/docker/containers-view.jsx:239
-#, fuzzy
-msgid "Commit"
-msgstr "명령"
-
-#: pkg/docker/containers.js:64
-msgid "Failed to start Docker: $0"
-msgstr " Docker 실행을 실패하였습니다: $0"
-
-#: pkg/users/authorized-keys.js:103
-msgid "Validating key"
-msgstr ""
-
-#: pkg/users/authorized-keys.js:108
-msgid "Adding key"
-msgstr ""
-
-#: pkg/users/authorized-keys.js:115
-msgid "Error saving authorized keys: "
-msgstr ""
-
-#: pkg/users/authorized-keys.js:118
-msgid "The key you provided was not valid."
-msgstr ""
-
-#: pkg/users/local.js:40
-msgid "The user <b>$0</b> is not permitted to modify accounts"
-msgstr ""
-
-#: pkg/users/local.js:57
-msgid "Unable to delete root account"
-msgstr ""
-
-#: pkg/users/local.js:59
-msgid "Unable to rename root account"
-msgstr ""
-
-#: pkg/users/local.js:82
-msgid "Prompting via passwd timed out"
-msgstr ""
-
-#: pkg/users/local.js:247
-msgid "Password is too weak"
-msgstr ""
-
-#: pkg/users/local.js:259
-msgid "Password is not acceptable"
-msgstr ""
-
-#: pkg/users/local.js:284 pkg/users/local.js:594
-msgctxt "page-title"
-msgid "Accounts"
-msgstr ""
-
-#: pkg/users/local.js:395 pkg/users/local.js:1082
-msgid "The passwords do not match"
-msgstr ""
-
-#: pkg/users/local.js:400
-msgid "No user name specified"
-msgstr ""
-
-#: pkg/users/local.js:405
-msgid "No real name specified"
-msgstr ""
-
-#: pkg/users/local.js:429 pkg/users/local.js:1104
-msgid "Excellent password"
-msgstr ""
-
-#: pkg/users/local.js:501
-msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
-msgstr ""
-
-#: pkg/users/local.js:509
-msgid "This user name already exists"
-msgstr ""
-
-#: pkg/users/local.js:682 pkg/users/local.js:683
-msgid "Server Administrator"
-msgstr ""
-
-#: pkg/users/local.js:684
-msgid "Container Administrator"
-msgstr ""
-
-#: pkg/users/local.js:839
-msgid "Logged In"
-msgstr ""
-
-#: pkg/users/local.js:841
-msgid "Never"
-msgstr ""
-
-#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
-msgid "Delete $0"
-msgstr ""
-
-#: pkg/sosreport/index.js:49 pkg/sosreport/index.js:113
-#: pkg/systemd/services.html.h:13 pkg/lib/machine-invalid-hostkey.html.h:4
-#: pkg/lib/machine-auth-failed.html.h:7
-#: pkg/lib/machine-unknown-hostkey.html.h:4
-#: pkg/lib/machine-change-port.html.h:8 pkg/lib/machine-not-supported.html.h:3
-#: pkg/shell/index.html.h:37
-msgid "Close"
-msgstr "닫기"
-
-#: pkg/sosreport/index.js:115
-msgid "No archive has been created."
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:598 pkg/networkmanager/interfaces.js:1051
-#: pkg/networkmanager/interfaces.js:2255 pkg/networkmanager/interfaces.js:2257
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:753 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/kubernetes/views/node-body.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:6
-#: pkg/kubernetes/views/pv-claim.html.h:7
-#: pkg/kubernetes/views/image-body.html.h:6
-#: pkg/kubernetes/views/pv-body.html.h:5
-msgid "Unknown"
-msgstr "알 수 없음"
-
-#: pkg/networkmanager/interfaces.js:805
-msgid "Not available"
-msgstr "사용할 수 없습니다"
-
-#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
-#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
-msgid "Inactive"
-msgstr "비활성"
-
-#: pkg/networkmanager/interfaces.js:809
-msgid "Preparing"
-msgstr "준비 중입니다"
-
-#: pkg/networkmanager/interfaces.js:811
-msgid "Configuring"
-msgstr "설정 중입니다"
-
-#: pkg/networkmanager/interfaces.js:813
-msgid "Authenticating"
-msgstr "인증 중입니다"
-
-#: pkg/networkmanager/interfaces.js:815
-msgid "Configuring IP"
-msgstr "IP 인증 중입니다"
-
-#: pkg/networkmanager/interfaces.js:817
-msgid "Checking IP"
-msgstr "IP확인 중입니다"
-
-#: pkg/networkmanager/interfaces.js:819
-msgid "Waiting"
-msgstr "대기 중입니다"
-
-#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
-msgid "Active"
-msgstr "활성"
-
-#: pkg/networkmanager/interfaces.js:823
-msgid "Deactivating"
-msgstr "비활성화 중 입니다"
-
-#: pkg/networkmanager/interfaces.js:825 pkg/ostree/index.html.h:14
-msgid "Failed"
-msgstr "실패하였습니다"
-
-#: pkg/networkmanager/interfaces.js:1326
-msgid "No carrier"
-msgstr "캐리어가 없습니다"
-
-#: pkg/networkmanager/interfaces.js:1372
-msgid "Part of "
-msgstr "일부분"
-
-#: pkg/networkmanager/interfaces.js:1420
-msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr "사용자 <b>$0</b> 는 네트워크 설정 권한이 없습니다"
+#: pkg/kubernetes/views/service-body.html:5
+#: pkg/kubernetes/views/replicationcontroller-body.html:5
+#: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/pod-body.html:5
+#: pkg/kubernetes/views/dashboard-page.html:160
+#: pkg/kubernetes/views/details-page.html:36
+#: pkg/kubernetes/views/details-page.html:72
+#: pkg/kubernetes/views/details-page.html:105
+#: pkg/kubernetes/views/details-page.html:139
+#: pkg/kubernetes/views/details-page.html:173
+#: pkg/kubernetes/views/pv-claim.html:6
+#: pkg/kubernetes/views/containers-listing.html:14
+#: pkg/kubernetes/views/route-body.html:5
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
+msgid "Namespace"
+msgstr "네임스페이스"
+
+#: pkg/kubernetes/scripts/dashboard.js:374
+msgid "Namespace cannot be empty."
+msgstr "네임스페이스를 입력하셔야 합니다."
+
+#: pkg/systemd/host.js:1113
+msgid "Need at least one NTP server"
+msgstr ""
+
+#: pkg/dashboard/index.html:72 pkg/playground/translate.html:96
+msgid "Network"
+msgstr "네트워크"
+
+#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:485
+msgid "Networking"
+msgstr "네트워킹"
 
 #: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
 msgctxt "page-title"
 msgid "Networking"
 msgstr "네트워킹"
 
-#: pkg/networkmanager/interfaces.js:1804
-msgid "Automatic (DHCP)"
-msgstr "자동(DHCP)"
+#: pkg/networkmanager/index.html:124
+msgid "Networking Logs"
+msgstr "네트워킹 로그"
 
-#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
-msgid "Link local"
-msgstr "로컬 링크"
+#: pkg/users/local.js:841
+msgid "Never"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
-msgid "Manual"
-msgstr "수동"
+#: pkg/kubernetes/views/project-listing.html:46
+msgid "New Group"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1807
-msgid "Shared"
-msgstr "공유됨"
+#: pkg/users/index.html:236 pkg/shell/index.html:255
+msgid "New Password"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1813 pkg/networkmanager/interfaces.js:2475
-#: pkg/networkmanager/interfaces.js:3019 pkg/networkmanager/interfaces.js:3023
-#: pkg/networkmanager/interfaces.js:3029 pkg/networkmanager/index.html.h:22
-msgid "Automatic"
-msgstr "자동"
+#: pkg/kubernetes/views/project-listing.html:7
+msgid "New Project"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1814
-msgid "Automatic (DHCP only)"
-msgstr "자동(DHCP only)"
+#: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/image-listing.html:7
+msgid "New image stream"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1817
-msgid "Ignore"
-msgstr "무시"
+#: pkg/users/local.js:120 pkg/lib/credentials.js:231
+msgid "New password was not accepted"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
-msgid "Round Robin"
-msgstr "Round Robin"
+#: pkg/kubernetes/views/project-modify.html:4
+#: pkg/kubernetes/views/registry-dashboard-page.html:9
+#: pkg/kubernetes/views/registry-dashboard-page.html:48
+msgid "New project"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
-msgid "Active Backup"
-msgstr "활성화된 백업"
+#: pkg/realmd/operation.html:91
+msgid "Next"
+msgstr "다음"
 
-#: pkg/networkmanager/interfaces.js:1824
-msgid "XOR"
-msgstr "XOR"
-
-#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
-msgid "Broadcast"
-msgstr "브로트캐스트"
-
-#: pkg/networkmanager/interfaces.js:1826
-msgid "802.3ad"
-msgstr "802.3ad"
-
-#: pkg/networkmanager/interfaces.js:1827
-msgid "Adaptive transmit load balancing"
-msgstr "적응형 전송 로드 밸런싱"
-
-#: pkg/networkmanager/interfaces.js:1828
-msgid "Adaptive load balancing"
-msgstr "적응형 로드 밸런싱"
-
-#: pkg/networkmanager/interfaces.js:1833
-msgid "MII (Recommended)"
-msgstr "MII (권장 사항)"
-
-#: pkg/networkmanager/interfaces.js:1834
-msgid "ARP"
-msgstr "ARP"
-
-#: pkg/networkmanager/interfaces.js:1841
+#: pkg/systemd/init.js:272
 #, fuzzy
-msgid "Load Balancing"
-msgstr "적응형 로드 밸런싱"
+msgid "Next Run"
+msgstr "다음"
 
-#: pkg/networkmanager/interfaces.js:1843
+#: pkg/systemd/index.html:233
+msgid "Nice"
+msgstr ""
+
+#: pkg/docker/index.html:563 pkg/docker/index.html:567
+msgid "No"
+msgstr "아니오"
+
+#: pkg/systemd/index.html:469
+msgid "No Delay"
+msgstr ""
+
+#: pkg/ostree/index.html:220
+msgid "No Deployments"
+msgstr ""
+
+#: pkg/storaged/details.js:185
+msgid "No Filesystem"
+msgstr ""
+
+#: pkg/ostree/app.js:101
+msgid "No OSTree deployments found"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:398
+msgid "No PEM-encoded certificate found"
+msgstr ""
+
+#: src/ws/cockpitcertificate.c:364
+msgid "No PEM-encoded private key found"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:39
+msgid "No Pods are using this claim"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:479
+msgid "No SELinux alerts."
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:10
 #, fuzzy
-msgid "802.3ad LACP"
-msgstr "802.3ad"
+msgid "No Volume Bound"
+msgstr "볼륨 그룹 $0"
 
-#: pkg/networkmanager/interfaces.js:1848
-msgid "Passive"
+#: pkg/docker/storage.jsx:194
+msgid "No additional local storage found."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1854
-msgid "Ethtool"
+#: pkg/docker/run.js:350
+msgid "No alias specified"
+msgstr "alias가 지정되지 않았습니다"
+
+#: pkg/sosreport/index.js:115
+msgid "No archive has been created."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1855
+#: pkg/networkmanager/interfaces.js:1326
+msgid "No carrier"
+msgstr "캐리어가 없습니다"
+
+#: pkg/docker/run.js:384
+msgid "No container specified"
+msgstr "컨테이너가 지정되지 않았습니다."
+
+#: pkg/storaged/index.html:193
+msgid "No drives attached"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:74
+msgid "No groups are present."
+msgstr ""
+
+#: pkg/systemd/index.html:28
 #, fuzzy
-msgid "ARP Ping"
-msgstr "ARP 모니터링"
+msgid "No host keys found."
+msgstr "찾을 수 없습니다."
 
-#: pkg/networkmanager/interfaces.js:1856
-msgid "NSNA Ping"
+#: pkg/storaged/index.html:158
+msgid "No iSCSI targets set up"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2156
-msgid "Deleting <b>$0</b> will break the connection to the server, "
+#: pkg/kubernetes/views/image-listing.html:70
+msgid "No image streams are present."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2188
-msgid "Switching on <b>$0</b>  will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2191 pkg/networkmanager/interfaces.js:2765
-msgid "Switch on $0"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2213
-msgid "Switching off <b>$0</b>  will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
-msgid "Switch off $0"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
-#: pkg/networkmanager/interfaces.js:2507
-msgid "Bond"
-msgstr "본드"
-
-#: pkg/networkmanager/interfaces.js:2235 pkg/networkmanager/interfaces.js:2247
-#: pkg/networkmanager/interfaces.js:2530
-msgid "Team"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
-#: pkg/networkmanager/interfaces.js:2622
-msgid "VLAN"
-msgstr "VLAN"
-
-#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
-#: pkg/networkmanager/interfaces.js:2584
-msgid "Bridge"
-msgstr "브릿지"
-
-#: pkg/networkmanager/interfaces.js:2276
-msgid "Carrier"
-msgstr "캐리어"
-
-#: pkg/networkmanager/interfaces.js:2279 pkg/kubernetes/scripts/volumes.js:990
-msgid "Yes"
-msgstr "네"
-
-#: pkg/networkmanager/interfaces.js:2299
-#: pkg/subscriptions/subscriptions-view.jsx:36
-#: pkg/kubernetes/views/node-body.html.h:14
-#: pkg/kubernetes/views/containers-listing.html.h:7
-#: pkg/kubernetes/views/volumes-page.html.h:5
-#: pkg/kubernetes/views/pv-claim.html.h:6
-#: pkg/kubernetes/views/nodes-page.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:5 pkg/kubernetes/views/pv-body.html.h:4
-msgid "Status"
-msgstr "상태"
-
-#: pkg/networkmanager/interfaces.js:2310
-msgid "This device cannot be managed here."
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2342
-msgid "Unknown configuration"
-msgstr "알 수 없는 설정"
-
-#: pkg/networkmanager/interfaces.js:2441
-msgid "Configure"
-msgstr "설정"
-
-#: pkg/networkmanager/interfaces.js:2473
-msgid "$mtu"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2477
-msgid "MTU"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2483
-msgid "Master"
-msgstr "마스터"
-
-#: pkg/networkmanager/interfaces.js:2502
-msgid "ARP Monitoring"
-msgstr "ARP 모니터링"
-
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
-#, fuzzy
-msgid "Broken configuration"
-msgstr "알 수 없는 설정"
-
-#: pkg/networkmanager/interfaces.js:2558
-msgid "Team Port"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2573
-msgid "Spanning Tree Protocol"
-msgstr "Spanning Tree Protocol"
-
-#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
-msgid "Priority $priority"
-msgstr "우선순위 $priority"
-
-#: pkg/networkmanager/interfaces.js:2577
-msgid "Forward delay $forward_delay"
-msgstr "포워드 딜레이 $forward_delay"
-
-#: pkg/networkmanager/interfaces.js:2579
-msgid "Hello time $hello_time"
-msgstr "Hello 시간 $hello_time"
-
-#: pkg/networkmanager/interfaces.js:2581
-msgid "Maximum message age $max_age"
-msgstr "최대 메세지 수명 $max_age"
-
-#: pkg/networkmanager/interfaces.js:2601
-msgid "Path cost $path_cost"
-msgstr "Path cost $path_cost"
-
-#: pkg/networkmanager/interfaces.js:2603
-msgid "Hairpin mode"
-msgstr "Hairpin 모드"
-
-#: pkg/networkmanager/interfaces.js:2605
-msgid "Bridge port"
-msgstr "브릿지 포트"
-
-#: pkg/networkmanager/interfaces.js:2619
-msgid "Parent $parent"
-msgstr "부모 $parent"
-
-#: pkg/networkmanager/interfaces.js:2620
-msgid "Id $id"
-msgstr "Id $id"
-
-#: pkg/networkmanager/interfaces.js:2628
-msgid "General"
-msgstr "일반"
-
-#: pkg/networkmanager/interfaces.js:2637
-msgid "Connect automatically"
-msgstr "자동으로 연결"
-
-#: pkg/networkmanager/interfaces.js:2641
-msgid "IPv4"
-msgstr "IPv4"
-
-#: pkg/networkmanager/interfaces.js:2642
-msgid "IPv6"
-msgstr "IPv6"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/networkmanager/index.html.h:33
-#: pkg/kubernetes/views/project-listing.html.h:5
-msgid "Members"
-msgstr "맴버"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/docker/index.html.h:39
-#: pkg/networkmanager/index.html.h:24
-#: pkg/kubernetes/views/service-body.html.h:6
-#: pkg/kubernetes/views/image-config.html.h:7
-#: pkg/kubernetes/views/container-body.html.h:5
-msgid "Ports"
-msgstr "포트"
-
-#: pkg/networkmanager/interfaces.js:2762
-msgid "Switching on <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2773
-msgid "Switching off <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2788
-msgid "Removing <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2791
-#, fuzzy
-msgid "Remove $0"
-msgstr "맴버"
-
-#: pkg/networkmanager/interfaces.js:2833
-msgid "Adding <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2836
-msgid "Add $0"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2870
-msgid "Changing the settings will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2872
-#, fuzzy
-msgid "Change the settings"
-msgstr "본드 설정"
-
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length or Netmask"
-msgstr "접두 길이 또는 넷마스크"
-
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length"
-msgstr "접두 길이"
-
-#: pkg/networkmanager/interfaces.js:3011
-#: pkg/kubernetes/views/details-page.html.h:7
-msgid "Addresses"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3018
-msgid "DNS"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3022
-msgid "DNS Search Domains"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3027
-#: pkg/kubernetes/views/details-page.html.h:11
-msgid "Routes"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv4 Settings"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv6 Settings"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3436
-msgid "Creating this bond will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
-#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
-#, fuzzy
-msgid "Create it"
-msgstr "생성"
-
-#: pkg/networkmanager/interfaces.js:3611
-msgid "Creating this team will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3842
-msgid "Creating this bridge will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4064
-msgid "Creating this VLAN will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4139
-msgid "MTU must be a positive number"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:196
-#, fuzzy
-msgid "Invalid credentials"
-msgstr "잘못된 포트"
-
-#: pkg/subscriptions/subscriptions-client.js:198
-msgid "'Organization' required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:200
-msgid "Login/password or activation key required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:202
-msgid "'Organization' required when using activation keys."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:64
-#: pkg/kubernetes/views/volume-body.html.h:16
-#: pkg/kubernetes/views/pv-modify.html.h:11
-msgid "Server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:88
-#: pkg/subscriptions/subscriptions-register.jsx:152
-#: pkg/lib/machine-auth-failed.html.h:3 pkg/lib/machine-sync-users.html.h:6
-#: pkg/lib/machine-change-auth.html.h:6 pkg/shell/index.html.h:31
-#: pkg/users/index.html.h:16 pkg/kubernetes/views/auth-form.html.h:11
-msgid "Password"
-msgstr "암호"
-
-#: pkg/subscriptions/subscriptions-register.jsx:102
-#, fuzzy
-msgid "Custom URL"
-msgstr "사용자 지정"
-
-#: pkg/subscriptions/subscriptions-register.jsx:110
-msgid "URL"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:125
-msgid "Proxy"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:132
-msgid "Use proxy server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:140
-msgid "Login"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:164
-#, fuzzy
-msgid "Activation Key"
-msgstr "비활성화 중 입니다"
-
-#: pkg/subscriptions/subscriptions-register.jsx:176
-msgid "Organization"
-msgstr ""
-
-#: pkg/subscriptions/main.js:45 pkg/subscriptions/subscriptions-view.jsx:143
-#: pkg/kubernetes/views/pv-modify.html.h:23
-msgid "Register"
-msgstr ""
-
-#: pkg/subscriptions/main.js:74
-msgid "Register system"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:32
-msgid "Product name"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product ID"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/index.html.h:13
-#: pkg/shell/index.html.h:14 pkg/shell/stub.html.h:9 pkg/shell/simple.html.h:9
-#: pkg/ostree/index.html.h:19
-msgid "Version"
-msgstr "버전"
-
-#: pkg/subscriptions/subscriptions-view.jsx:35
-#: pkg/kubernetes/views/image-config.html.h:5
-msgid "Architecture"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:37
-msgid "Starts"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Ends"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:141
-msgid "Status: System isn't registered"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:146
-#, fuzzy
-msgid "Status: $0"
-msgstr "상태"
-
-#: pkg/subscriptions/subscriptions-view.jsx:148
-msgid "Unregister"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:154
-msgid "Unregistering system..."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:161
-#: pkg/subscriptions/index.html.h:1
-msgid "Subscriptions"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/ostree/index.html.h:15
-msgid "Updating"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:188
-msgid "Retrieving subscription status..."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:191
-msgid "Access denied"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:192
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:195
-#, fuzzy
-msgid "Unable to connect"
-msgstr "재연결"
-
-#: pkg/subscriptions/subscriptions-view.jsx:196
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:222
-msgid "Installed products"
+#: pkg/kubernetes/views/registry-dashboard-page.html:80
+msgid "No images pushed"
 msgstr ""
 
 #: pkg/subscriptions/subscriptions-view.jsx:223
@@ -2869,106 +3607,415 @@ msgstr ""
 msgid "No installed products on the system."
 msgstr "본 시스템에 Docker가 설치되어 있지 않거나 활성화되어 있지 않습니다."
 
+#: pkg/storaged/index.html:446
+msgid "No media inserted"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:384
+msgid ""
+"No metadata file was selected. Please select a Kubernetes metadata file."
+msgstr ""
+"메타데이터 파일이 선택되지 않았습니다. Kubernetes 메타데이터 파일을 선택하세"
+"요."
+
+#: pkg/kubernetes/views/dashboard-page.html:117
+msgid "No nodes in cluster"
+msgstr ""
+
+#: pkg/storaged/details.js:352
+msgid "No partitioning"
+msgstr "파티션 설정하지 않음"
+
+#: pkg/kubernetes/views/dashboard-page.html:40
+msgid "No pods deployed"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:6
+msgid "No pods replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/node-capacity.html:11
+msgid "No pods scheduled"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:10
+msgid "No pods selected"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:37
+msgid "No projects are present."
+msgstr ""
+
+#: pkg/users/local.js:405
+msgid "No real name specified"
+msgstr ""
+
+#: pkg/storaged/index.html:87
+msgid "No storage set up as RAID"
+msgstr ""
+
+#: pkg/lib/credentials.js:182
+msgid "No such file or directory"
+msgstr ""
+
+#: pkg/users/local.js:400
+msgid "No user name specified"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:112
+msgid "No users are present."
+msgstr ""
+
+#: pkg/storaged/index.html:120
+msgid "No volume groups created"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:44
+msgid "No volumes are present."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:73
+msgid "No volumes in use"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:18 pkg/kubernetes/views/node-panel.html:7
+#: pkg/kubernetes/views/containers-listing.html:15
+#: pkg/kubernetes/views/node-page.html:14
+#: pkg/kubernetes/views/topology-page.html:41
+msgid "Node"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:192
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:45
+msgid "Nodes"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:42
+msgid "Nodes are the machines that run your containers."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:15
+#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
+#: pkg/kubernetes/views/image-config.html:25
+#: pkg/kubernetes/views/imagestream-body.html:33
+msgid "None"
+msgstr ""
+
+#: pkg/playground/translate.html:30 pkg/kubernetes/views/details-page.html:53
+#: pkg/kubernetes/views/node-body.html:42
+msgid "Not Ready"
+msgstr "준비되지 않음"
+
 #: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
 msgid "Not a valid number of replicas"
 msgstr "올바른 replica 숫자가 아닙니다."
 
-#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "replica의 최대 수는 128개입니다."
+#: pkg/lib/credentials.js:248
+msgid "Not a valid private key"
+msgstr ""
 
 #: pkg/kubernetes/scripts/details.js:546
 msgid "Not a valid value for Host"
 msgstr ""
 
-#: pkg/kubernetes/scripts/details.js:655
-msgid "Updating $0..."
-msgstr "$0 업데이트 중..."
+#: pkg/docker/index.html:57
+msgid "Not authorized to access Docker on this system"
+msgstr "본 시스템 상의 Docker에 대한 접근 권한이 없습니다."
 
-#: pkg/kubernetes/scripts/graphs.js:601 pkg/kubernetes/scripts/nodes.js:711
-#: pkg/kubernetes/scripts/nodes.js:817 pkg/dashboard/index.html.h:2
-msgid "CPU"
-msgstr "CPU"
-
-#: pkg/kubernetes/scripts/graphs.js:606 pkg/kubernetes/scripts/nodes.js:715
-#: pkg/kubernetes/scripts/nodes.js:826 pkg/dashboard/index.html.h:3
-msgid "Memory"
-msgstr "메모리"
-
-#: pkg/kubernetes/scripts/graphs.js:611 pkg/dashboard/index.html.h:4
-msgid "Network"
-msgstr "네트워크"
-
-#: pkg/kubernetes/scripts/nodes.js:319 pkg/kubernetes/views/node-body.html.h:16
-#: pkg/kubernetes/views/details-page.html.h:10
-msgid "Not Ready"
-msgstr "준비되지 않음"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
+#: pkg/ostree/app.js:81
+msgid "Not authorized to update software on this system"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:324 pkg/kubernetes/views/node-body.html.h:15
-#: pkg/kubernetes/views/details-page.html.h:9
-msgid "Ready"
-msgstr "준비됨"
+#: pkg/networkmanager/interfaces.js:805
+msgid "Not available"
+msgstr "사용할 수 없습니다"
 
-#: pkg/kubernetes/scripts/nodes.js:397
-msgid "Please type an address"
-msgstr "주소를 입력해주세요"
-
-#: pkg/kubernetes/scripts/nodes.js:399
-msgid "The address contains invalid characters"
-msgstr "주소에 잘못된 문자가 있습니다 "
-
-#: pkg/kubernetes/scripts/nodes.js:407
-msgid "The name contains invalid characters"
-msgstr ""
-
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
-msgstr ""
-
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
-msgstr ""
-
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+#: pkg/selinux/setroubleshoot.js:238
 #, fuzzy
-msgid "Disk"
-msgstr "디스크 추가"
+msgid "Not connected"
+msgstr "연결 해제됨"
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
+#: pkg/kubernetes/views/details-page.html:122
+msgid "Not deployed"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:870
-#, c-format
-msgid "$0% Free"
-msgid_plural "$0% Free"
+#: pkg/docker/details.js:177 pkg/docker/image.js:112
+#: pkg/storaged/details.js:1822
+msgid "Not found"
+msgstr "찾을 수 없습니다."
+
+#: src/base1/cockpit.js:3691
+msgid "Not permitted to perform this action."
+msgstr ""
+
+#: pkg/storaged/details.js:1574
+msgid "Not running"
+msgstr ""
+
+#: pkg/systemd/index.html:62
+msgid "Not synchronized"
+msgstr ""
+
+#: pkg/systemd/services.html:299
+msgid "Note"
+msgstr ""
+
+#: pkg/systemd/logs.html:49
+msgid "Notices"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:13
+msgid "OS"
+msgstr ""
+
+#: pkg/ostree/client.js:500
+msgid "OS $0 not found"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:19
+#, fuzzy
+msgid "OS Versions"
+msgstr "버전"
+
+#: pkg/ostree/app.js:83
+msgid "OSTree is not available on this system"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:405
+msgid "Occurred $0"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:400
+msgid "Occurred between $0 and $1"
+msgstr ""
+
+#: pkg/systemd/index.html:157 pkg/playground/jquery-patterns.html:95
+#: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:189
+#: pkg/storaged/index.html:565
+msgid "Off"
+msgstr "비활성"
+
+#: pkg/lib/cockpit-components-dialog.jsx:155
+msgid "Ok"
+msgstr ""
+
+#: pkg/users/index.html:226 pkg/shell/index.html:248
+msgid "Old Password"
+msgstr ""
+
+#: pkg/users/local.js:78 pkg/lib/credentials.js:213
+msgid "Old password not accepted"
+msgstr ""
+
+#: pkg/systemd/index.html:153 pkg/playground/jquery-patterns.html:91
+#: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:185
+#: pkg/storaged/index.html:564
+msgid "On"
+msgstr "활성"
+
+#: pkg/kubernetes/views/image-meta.html:7
+msgid "On Build"
+msgstr ""
+
+#: pkg/docker/index.html:568
+#, fuzzy
+msgid "On Failure"
+msgstr "실패하였습니다"
+
+#: pkg/docker/util.js:104
+msgid "On failure, retry $0 time"
+msgid_plural "On failure, retry $0 times"
 msgstr[0] ""
 
-#: pkg/kubernetes/scripts/nodes.js:872
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] ""
-
-#: pkg/kubernetes/scripts/connection.js:88
-msgid "Error writing kubectl config"
+#: pkg/realmd/operation.html:71
+msgid "One Time Password"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:514
-msgid "Couldn't find running API server"
+#: pkg/systemd/init.js:1147
+msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:516
-#, fuzzy
-msgid "Connection Error: $0"
-msgstr "Docker에 연결중입니다."
+#: pkg/shell/simple.html:28 pkg/shell/index.html:28 pkg/shell/stub.html:28
+msgid "Ooops!"
+msgstr "어머나!"
 
-#: pkg/kubernetes/scripts/connection.js:539
+#: pkg/systemd/index.html:89 pkg/ostree/index.html:111
+#: pkg/kubernetes/views/nodes-page.html:42
+msgid "Operating System"
+msgstr ""
+
+#: pkg/ostree/index.html:186
+msgid "Operating System Updates"
+msgstr ""
+
+#: pkg/storaged/jobs.js:166
+msgid "Operation '$operation' on $target"
+msgstr ""
+
+#: pkg/storaged/overview.js:189
+msgctxt "storage"
+msgid "Optical Drive"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:130
+msgid "Options"
+msgstr "옵션"
+
+#: pkg/subscriptions/subscriptions-register.jsx:176
+msgid "Organization"
+msgstr ""
+
+#: pkg/storaged/details.js:1253
+msgctxt "storage-id-desc"
+msgid "Other Data"
+msgstr ""
+
+#: pkg/storaged/index.html:202
+msgid "Other Devices"
+msgstr ""
+
+#: pkg/docker/index.html:319 pkg/kubernetes/registry.html:42
+#: pkg/kubernetes/index.html:39
+msgid "Overview"
+msgstr ""
+
+#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
+msgid "Overwrite existing data with zeros"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:4
 #, fuzzy
-msgid "Please provide a valid address"
+msgid "PD Name"
+msgstr "이름"
+
+#: pkg/ostree/index.html:100
+msgid "Packages"
+msgstr ""
+
+#: pkg/networkmanager/index.html:133
+msgid "Parent"
+msgstr "부모"
+
+#: pkg/networkmanager/interfaces.js:2619
+msgid "Parent $parent"
+msgstr "부모 $parent"
+
+#: pkg/networkmanager/interfaces.js:1372
+msgid "Part of "
+msgstr "일부분"
+
+#: pkg/kubernetes/views/volume-body.html:8
+#: pkg/kubernetes/views/volume-body.html:18
+msgid "Partition"
+msgstr ""
+
+#: pkg/storaged/details.js:346
+msgid "Partitioning"
+msgstr "파티션"
+
+#: pkg/networkmanager/interfaces.js:1848
+msgid "Passive"
+msgstr ""
+
+#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
+msgid "Passphrase"
+msgstr ""
+
+#: pkg/storaged/details.js:224
+#, fuzzy
+msgid "Passphrase cannot be empty"
+msgstr "네임스페이스를 입력하셔야 합니다."
+
+#: pkg/storaged/details.js:232
+msgid "Passphrases do not match"
+msgstr ""
+
+#: pkg/users/index.html:115 pkg/users/index.html:160 pkg/shell/index.html:199
+#: pkg/shell/index.html:212 pkg/kubernetes/views/auth-form.html:105
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+msgid "Password"
+msgstr "암호"
+
+#: pkg/users/local.js:259
+msgid "Password is not acceptable"
+msgstr ""
+
+#: pkg/users/local.js:247
+msgid "Password is too weak"
+msgstr ""
+
+#: pkg/lib/credentials.js:278
+msgid "Password not accepted"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:126
+#: pkg/kubernetes/views/volume-body.html:37
+#: pkg/kubernetes/views/volume-body.html:49
+#: pkg/kubernetes/views/volume-body.html:101
+#, fuzzy
+msgid "Path"
+msgstr "Path cost"
+
+#: pkg/networkmanager/index.html:259
+msgid "Path cost"
+msgstr "Path cost"
+
+#: pkg/networkmanager/interfaces.js:2601
+msgid "Path cost $path_cost"
+msgstr "Path cost $path_cost"
+
+#: pkg/systemd/services.html:56
+msgid "Paths"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:53
+msgid "Pending Volume Claims"
+msgstr ""
+
+#: pkg/systemd/index.html:143
+msgid "Performance Profile"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:14
+msgid "Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:16
+msgid "Phase"
+msgstr ""
+
+#: pkg/storaged/index.html:641
+msgid "Physical Volumes"
+msgstr ""
+
+#: pkg/networkmanager/index.html:405
+#, fuzzy
+msgid "Ping Interval"
+msgstr "모니터링 주기"
+
+#: pkg/networkmanager/index.html:414
+#, fuzzy
+msgid "Ping Target"
+msgstr "모니터링 대상"
+
+#: pkg/docker/containers-view.jsx:166 pkg/docker/details.js:271
+#: pkg/docker/image.js:151 pkg/storaged/details.js:625
+#: pkg/storaged/details.js:821 pkg/storaged/details.js:1016
+msgid "Please confirm deletion of $0"
+msgstr "$0 삭제를 확인해주세요"
+
+#: pkg/docker/util.js:501
+msgid "Please confirm forced deletion of $0"
+msgstr "$0 강제 삭제를 확인해주세요"
+
+#: pkg/kubernetes/scripts/dashboard.js:441
+msgid "Please create another namespace for $0 \"$1\""
+msgstr " $0 \"$1\"을 위한 다른 네임스페이스를 생성하세요"
+
+#: pkg/kubernetes/scripts/volumes.js:574
+#, fuzzy
+msgid "Please provide a GlusterFS volume name"
 msgstr "올바른 네임스페이스를 입력하세요."
 
 #: pkg/kubernetes/scripts/connection.js:554
@@ -2976,150 +4023,14 @@ msgstr "올바른 네임스페이스를 입력하세요."
 msgid "Please provide a username"
 msgstr "올바른 네임스페이스를 입력하세요."
 
-#: pkg/kubernetes/scripts/connection.js:650
-msgid "Error getting certificate details: $0"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:194
-#, fuzzy
-msgid "Git Repository"
-msgstr "리포지터리 "
-
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
-#, fuzzy
-msgid "Host Path"
-msgstr "호스트"
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:199
-msgid "NFS Mount"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
-msgid "ISCSI"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:203
-#, fuzzy
-msgid "Ceph Filesystem Mount"
-msgstr "파일 시스템 옵션"
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:205
-#, fuzzy
-msgid "Flocker"
-msgstr "잠금 해제"
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:469
-#, fuzzy
-msgid "Please select a valid access mode"
-msgstr "올바른 네임스페이스를 입력하세요."
-
-#: pkg/kubernetes/scripts/volumes.js:477
-#, fuzzy
-msgid "Please provide a valid name"
-msgstr "올바른 네임스페이스를 입력하세요."
-
-#: pkg/kubernetes/scripts/volumes.js:485
-#, fuzzy
-msgid "Please provide a valid storage capacity."
-msgstr "올바른 네임스페이스를 입력하세요."
-
-#: pkg/kubernetes/scripts/volumes.js:493
-msgid "Please select a valid policy option."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:565
-#, fuzzy
-msgid "Please select a valid endpoint"
-msgstr "올바른 네임스페이스를 입력하세요."
-
-#: pkg/kubernetes/scripts/volumes.js:574
-#, fuzzy
-msgid "Please provide a GlusterFS volume name"
-msgstr "올바른 네임스페이스를 입력하세요."
-
 #: pkg/kubernetes/scripts/volumes.js:632
 #, fuzzy
 msgid "Please provide a valid NFS server"
 msgstr "올바른 네임스페이스를 입력하세요."
 
-#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
+#: pkg/kubernetes/scripts/connection.js:539
 #, fuzzy
-msgid "Please provide a valid path"
-msgstr "올바른 네임스페이스를 입력하세요."
-
-#: pkg/kubernetes/scripts/volumes.js:781
-#, fuzzy
-msgid "Please provide a valid target"
-msgstr "올바른 네임스페이스를 입력하세요."
-
-#: pkg/kubernetes/scripts/volumes.js:789
-#, fuzzy
-msgid "Please provide a valid qualified name"
-msgstr "올바른 네임스페이스를 입력하세요."
-
-#: pkg/kubernetes/scripts/volumes.js:797
-#, fuzzy
-msgid "Please provide a valid logical unit number"
+msgid "Please provide a valid address"
 msgstr "올바른 네임스페이스를 입력하세요."
 
 #: pkg/kubernetes/scripts/volumes.js:805
@@ -3132,3124 +4043,2301 @@ msgstr "올바른 네임스페이스를 입력하세요."
 msgid "Please provide a valid interface"
 msgstr "올바른 네임스페이스를 입력하세요."
 
-#: pkg/kubernetes/scripts/volumes.js:860
-msgid "NFS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:872
-msgid "GlusterFS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:908
-msgid "Sorry, I don't know how to modify this volume"
-msgstr ""
-
-#: pkg/kubernetes/scripts/charts.js:113
+#: pkg/kubernetes/scripts/volumes.js:797
 #, fuzzy
-msgid "Unavailable"
-msgstr "사용할 수 없습니다"
+msgid "Please provide a valid logical unit number"
+msgstr "올바른 네임스페이스를 입력하세요."
 
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "네임스페이스를 입력하셔야 합니다."
+#: pkg/kubernetes/scripts/volumes.js:477
+#, fuzzy
+msgid "Please provide a valid name"
+msgstr "올바른 네임스페이스를 입력하세요."
 
 #: pkg/kubernetes/scripts/dashboard.js:376
 msgid "Please provide a valid namespace."
 msgstr "올바른 네임스페이스를 입력하세요."
 
-#: pkg/kubernetes/scripts/dashboard.js:384
+#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
+#, fuzzy
+msgid "Please provide a valid path"
+msgstr "올바른 네임스페이스를 입력하세요."
+
+#: pkg/kubernetes/scripts/volumes.js:789
+#, fuzzy
+msgid "Please provide a valid qualified name"
+msgstr "올바른 네임스페이스를 입력하세요."
+
+#: pkg/kubernetes/scripts/volumes.js:485
+#, fuzzy
+msgid "Please provide a valid storage capacity."
+msgstr "올바른 네임스페이스를 입력하세요."
+
+#: pkg/kubernetes/scripts/volumes.js:781
+#, fuzzy
+msgid "Please provide a valid target"
+msgstr "올바른 네임스페이스를 입력하세요."
+
+#: pkg/kubernetes/scripts/volumes.js:469
+#, fuzzy
+msgid "Please select a valid access mode"
+msgstr "올바른 네임스페이스를 입력하세요."
+
+#: pkg/kubernetes/scripts/volumes.js:565
+#, fuzzy
+msgid "Please select a valid endpoint"
+msgstr "올바른 네임스페이스를 입력하세요."
+
+#: pkg/kubernetes/scripts/volumes.js:493
+msgid "Please select a valid policy option."
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:397
+msgid "Please type an address"
+msgstr "주소를 입력해주세요"
+
+#: pkg/kubernetes/views/pod-page.html:12
+#: pkg/kubernetes/views/containers-listing.html:12
+#: pkg/kubernetes/views/topology-page.html:14
+msgid "Pod"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:20
+msgid "Pod Address"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:4
+#: pkg/kubernetes/views/service-endpoint.html:9
+msgid "Pod Endpoints"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:4
+msgid "Pod Replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:15
+#: pkg/kubernetes/views/replicationcontroller-pods.html:11
+msgid "Pod Selector"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:17
+#: pkg/kubernetes/views/dashboard-page.html:18
+#: pkg/kubernetes/views/details-page.html:166
+#: pkg/kubernetes/views/pv-claim.html:37
+#: pkg/kubernetes/views/replicationcontroller-panel.html:12
+msgid "Pods"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:15
 msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr ""
-"메타데이터 파일이 선택되지 않았습니다. Kubernetes 메타데이터 파일을 선택하세"
-"요."
-
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr "선택한 파일은 올바른 Kubernetes 메타데이터 파일이 아닙니다."
-
-#: pkg/kubernetes/scripts/dashboard.js:401
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr "Kubernetes 어플리케이션  manifest를 읽을 수 없습니다. 코드 $0."
-
-#: pkg/kubernetes/scripts/dashboard.js:413
-msgid "Unable to decode Kubernetes application manifest."
+"Pods contain one or more containers that run                together on a "
+"node, containing your application code."
 msgstr ""
 
-#: pkg/kubernetes/scripts/dashboard.js:441
-msgid "Please create another namespace for $0 \"$1\""
-msgstr " $0 \"$1\"을 위한 다른 네임스페이스를 생성하세요"
+#: pkg/kubernetes/views/volume-body.html:60
+#, fuzzy
+msgid "Pool Name"
+msgstr "이름"
 
-#: pkg/kubernetes/scripts/dashboard.js:460
-msgid "Manifest"
+#: pkg/storaged/utils.js:166
+msgid "Pool for Thin Logical Volumes"
+msgstr "Thin 논리 볼륨을 위한 풀"
+
+#: pkg/storaged/details.js:874
+#, fuzzy
+msgid "Pool for thinly provisioned volumes"
+msgstr "Thin 논리 볼륨을 위한 풀"
+
+#: pkg/kubernetes/views/imagestream-modify.html:45
+msgid "Populate"
 msgstr ""
 
-#: pkg/dashboard/list.js:209
-msgid "The user <b>$0</b> is not permitted to manage servers"
-msgstr "사용자 <b>$0</b> 는 서버 관리 권한이 없습니다."
-
-#: pkg/dashboard/list.js:394
-msgid ""
-"You are currently connected directly to this server. You cannot delete it."
-msgstr "현재 직접적으로 이 서버에 연결되어 있습니다. 삭제하실 수 없습니다."
-
-#: cockpit.appdata.xml.in.h:1
-msgid ""
-"Cockpit is a server manager that makes it easy to administer your Linux "
-"servers via a web browser. Jumping between the terminal and the web tool is "
-"no problem. A service started via Cockpit can be stopped via the terminal. "
-"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
-"journal interface."
+#: pkg/lib/machine-change-port.html:23
+msgid "Port"
 msgstr ""
 
-#: cockpit.appdata.xml.in.h:2
-msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
-"stopping services. You can monitor and administer several servers at the "
-"same time. Just add them with a single click and your machines will look "
-"after its buddies."
+#: pkg/docker/index.html:525 pkg/kubernetes/views/service-body.html:13
+#: pkg/kubernetes/views/image-config.html:23
+#: pkg/kubernetes/views/container-body.html:12
+#: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:373
+msgid "Ports"
+msgstr "포트"
+
+#: pkg/systemd/index.html:123
+msgid "Power Options"
 msgstr ""
 
-#: cockpit.desktop.in.h:1 pkg/shell/index.html.h:1 pkg/shell/stub.html.h:1
-#: pkg/shell/simple.html.h:1
-msgid "Cockpit"
-msgstr "Cockpit"
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length"
+msgstr "접두 길이"
 
-#: cockpit.desktop.in.h:2
-msgid "A user interface for GNU/Linux servers"
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length or Netmask"
+msgstr "접두 길이 또는 넷마스크"
+
+#: pkg/networkmanager/interfaces.js:809
+msgid "Preparing"
+msgstr "준비 중입니다"
+
+#: pkg/systemd/init.js:544
+msgid "Preset"
+msgstr ""
+
+#: pkg/systemd/init.js:545
+msgid "Preset Forcefully"
+msgstr ""
+
+#: pkg/systemd/index.html:310
+msgid "Pretty Host Name"
+msgstr ""
+
+#: pkg/networkmanager/index.html:307
+msgid "Primary"
+msgstr "주"
+
+#: pkg/storaged/details.js:1426
+msgid "Primary Partition"
+msgstr ""
+
+#: pkg/networkmanager/index.html:250 pkg/networkmanager/index.html:446
+#: pkg/networkmanager/index.html:464
+msgid "Priority"
+msgstr "우선순위"
+
+#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
+msgid "Priority $priority"
+msgstr "우선순위 $priority"
+
+#: pkg/subscriptions/subscriptions-view.jsx:33
+msgid "Product ID"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:32
+msgid "Product name"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:4
+#: pkg/kubernetes/views/replicationcontroller-body.html:4
+#: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/imagestream-modify.html:21
+#: pkg/kubernetes/views/pod-body.html:4
+#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/details-page.html:35
+#: pkg/kubernetes/views/details-page.html:71
+#: pkg/kubernetes/views/details-page.html:104
+#: pkg/kubernetes/views/details-page.html:138
+#: pkg/kubernetes/views/details-page.html:172
+#: pkg/kubernetes/views/containers-listing.html:13
+#: pkg/kubernetes/views/route-body.html:4
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
+msgid "Project"
+msgstr "프로젝트"
+
+#: pkg/kubernetes/views/project-body.html:20
+msgid "Project Members"
+msgstr ""
+
+#: pkg/kubernetes/views/filter-project.html:5
+msgid "Project:"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:54 pkg/kubernetes/views/group-delete.html:10
+#: pkg/kubernetes/views/project-listing.html:9
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:84
+msgid "Projects"
+msgstr ""
+
+#: pkg/users/local.js:82
+msgid "Prompting via passwd timed out"
+msgstr ""
+
+#: pkg/lib/credentials.js:251
+msgid "Prompting via ssh-add timed out"
+msgstr ""
+
+#: pkg/lib/credentials.js:191
+msgid "Prompting via ssh-keygen timed out"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:125
+msgid "Proxy"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:25
+msgid "Proxy Version"
+msgstr ""
+
+#: pkg/shell/index.html:198 pkg/lib/machine-auth-failed.html:9
+msgid "Public Key"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:150
+msgid "Pull an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:66
+msgid "Pull from"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:31
+msgid "Pull repository"
+msgstr ""
+
+#: pkg/storaged/details.js:869
+msgid "Purpose"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:140
+msgid "Push an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:147
+#: pkg/kubernetes/views/volume-body.html:77
+msgid "Qualified Name"
+msgstr ""
+
+#: pkg/storaged/details.js:1539
+msgid "RAID ($0)"
+msgstr ""
+
+#: pkg/storaged/details.js:1533
+msgid "RAID 0"
+msgstr ""
+
+#: pkg/storaged/overview.js:422
+msgid "RAID 0 (Stripe)"
+msgstr ""
+
+#: pkg/storaged/details.js:1534
+msgid "RAID 1"
+msgstr ""
+
+#: pkg/storaged/overview.js:423
+msgid "RAID 1 (Mirror)"
+msgstr ""
+
+#: pkg/storaged/details.js:1538
+msgid "RAID 10"
+msgstr ""
+
+#: pkg/storaged/overview.js:427
+msgid "RAID 10 (Stripe of Mirrors)"
+msgstr ""
+
+#: pkg/storaged/details.js:1535
+msgid "RAID 4"
+msgstr ""
+
+#: pkg/storaged/overview.js:424
+msgid "RAID 4 (Dedicated Parity)"
+msgstr ""
+
+#: pkg/storaged/details.js:1536
+msgid "RAID 5"
+msgstr ""
+
+#: pkg/storaged/overview.js:425
+msgid "RAID 5 (Distributed Parity)"
+msgstr ""
+
+#: pkg/storaged/details.js:1537
+msgid "RAID 6"
+msgstr ""
+
+#: pkg/storaged/overview.js:426
+msgid "RAID 6 (Double Distributed Parity)"
+msgstr ""
+
+#: pkg/storaged/index.html:537
+msgid "RAID Device"
+msgstr ""
+
+#: pkg/storaged/utils.js:233
+msgid "RAID Device $0"
+msgstr "RAID 장치 $0"
+
+#: pkg/storaged/index.html:65
+msgid "RAID Devices"
+msgstr ""
+
+#: pkg/storaged/overview.js:420
+msgid "RAID Level"
+msgstr ""
+
+#: pkg/storaged/index.html:555
+#, fuzzy
+msgctxt "storage"
+msgid "RAID Level"
+msgstr "RAID 장치 $0"
+
+#: pkg/storaged/details.js:1228
+msgctxt "storage-id-desc"
+msgid "RAID Member"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:200
+msgid "Rados Block Device"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:194
+#: pkg/kubernetes/views/volume-body.html:10
+#: pkg/kubernetes/views/volume-body.html:20
+#: pkg/kubernetes/views/volume-body.html:44
+#: pkg/kubernetes/views/volume-body.html:51
+#: pkg/kubernetes/views/volume-body.html:71
+#: pkg/kubernetes/views/volume-body.html:85
+#: pkg/kubernetes/views/volume-body.html:93
+#: pkg/kubernetes/views/volume-body.html:110
+#: pkg/kubernetes/views/volume-body.html:122
+#: pkg/kubernetes/views/volume-body.html:136
+#: pkg/kubernetes/views/volume-body.html:143
+#, fuzzy
+msgid "Read Only"
+msgstr "준비됨"
+
+#: pkg/kubernetes/scripts/volumes.js:211
+msgid "Read and write from a single node"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:213
+msgid "Read and write from multiple nodes"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:212
+msgid "Read only from multiple nodes"
+msgstr ""
+
+#: pkg/docker/index.html:385
+#, fuzzy
+msgid "ReadOnly"
+msgstr "준비됨"
+
+#: pkg/docker/index.html:384
+msgid "ReadWrite"
+msgstr ""
+
+#: pkg/storaged/index.html:327
+msgid "Reading"
+msgstr ""
+
+#: pkg/playground/translate.html:20 pkg/playground/translate.html:179
+#: pkg/kubernetes/views/details-page.html:52
+#: pkg/kubernetes/views/node-body.html:41
+msgid "Ready"
+msgstr "준비됨"
+
+#: pkg/playground/translate.html:25
+#, fuzzy
+msgctxt "verb"
+msgid "Ready"
+msgstr "준비됨"
+
+#: pkg/systemd/index.html:319
+msgid "Real Host Name"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:45
+msgid "Reason"
+msgstr ""
+
+#: pkg/lib/journal.js:241
+msgid "Reboot"
+msgstr ""
+
+#: pkg/networkmanager/index.html:75 pkg/networkmanager/index.html:98
+#: pkg/networkmanager/index.html:116 pkg/networkmanager/index.html:521
+#: pkg/networkmanager/index.html:551
+msgid "Receiving"
+msgstr "수신 중입니다"
+
+#: pkg/ostree/client.js:56
+msgid "Receiving delta parts"
+msgstr ""
+
+#: pkg/ostree/client.js:58
+msgid "Receiving metadata objects"
+msgstr ""
+
+#: pkg/ostree/client.js:61
+msgid "Receiving objects: $0%"
+msgstr ""
+
+#: pkg/systemd/logs.html:40
+msgid "Recent"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:56 pkg/kubernetes/views/pv-body.html:6
+msgid "Reclaim Policy"
+msgstr ""
+
+#: pkg/shell/simple.html:144 pkg/shell/index.html:327 pkg/shell/stub.html:180
+msgid "Reconnect"
+msgstr "재연결"
+
+#: pkg/storaged/details.js:1594
+msgid "Recovering"
+msgstr ""
+
+#: pkg/storaged/jobs.js:145
+msgid "Recovering RAID Device $target"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:219
+msgid "Recycle"
+msgstr ""
+
+#: pkg/docker/storage.jsx:348
+msgid "Reformat and add disks"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:205
+msgid "Register"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:12
+#, fuzzy
+msgid "Register New Volume"
+msgstr "논리 볼륨 크기 조정"
+
+#: pkg/kubernetes/views/pv-modify.html:4
+msgid "Register Persistent Volume"
+msgstr ""
+
+#: pkg/subscriptions/main.js:74
+msgid "Register system"
+msgstr ""
+
+#: pkg/ostree/index.html:115
+msgid "Released"
+msgstr ""
+
+#: pkg/systemd/init.js:518
+msgid "Reload"
+msgstr ""
+
+#: pkg/systemd/init.js:519
+msgid "Reload or Restart"
+msgstr ""
+
+#: pkg/systemd/init.js:521
+msgid "Reload or Try Restart"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:89
+msgid "Remote registry is insecure"
 msgstr ""
 
 #: cockpit.desktop.in.h:3
 msgid "Remote;Administration;"
 msgstr ""
 
-#: pkg/systemd/index.html.h:1
-msgid "System"
+#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
+msgctxt "storage"
+msgid "Removable Drive"
 msgstr ""
 
-#: pkg/systemd/index.html.h:2
+#: pkg/ostree/index.html:123 pkg/ostree/index.html:146
+msgid "Removals"
+msgstr ""
+
+#: pkg/kubernetes/views/user-group-remove.html:10
+#: pkg/kubernetes/views/group-delete.html:21
+#: pkg/kubernetes/views/user-delete.html:25
+#: pkg/kubernetes/views/remove-role-dialog.html:8
+msgid "Remove"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2791
 #, fuzzy
-msgid "No host keys found."
-msgstr "찾을 수 없습니다."
+msgid "Remove $0"
+msgstr "맴버"
 
-#: pkg/systemd/index.html.h:3
-msgid "Synchronized with {{Server}}"
+#: pkg/kubernetes/views/group-delete.html:3
+msgid "Remove Group"
 msgstr ""
 
-#: pkg/systemd/index.html.h:4
-msgid "Synchronized"
+#: pkg/kubernetes/views/user-group-remove.html:3
+#, fuzzy
+msgid "Remove Member"
+msgstr "맴버"
+
+#: pkg/kubernetes/views/remove-role-dialog.html:3
+msgid "Remove Role"
 msgstr ""
 
-#: pkg/systemd/index.html.h:5
-msgid "Trying to synchronize with {{Server}}"
+#: pkg/kubernetes/views/user-delete.html:3
+msgid "Remove User"
 msgstr ""
 
-#: pkg/systemd/index.html.h:6
-msgid "Not synchronized"
+#: pkg/kubernetes/views/image-delete.html:3
+msgid "Remove image tag"
 msgstr ""
 
-#: pkg/systemd/index.html.h:7
-msgid "Hardware"
+#: pkg/kubernetes/views/user-remove-membership.html:3
+msgid "Remove membership"
 msgstr ""
 
-#: pkg/systemd/index.html.h:8
-msgid "Asset Tag"
+#: pkg/storaged/jobs.js:141
+msgid "Removing $target from RAID Device"
 msgstr ""
 
-#: pkg/systemd/index.html.h:9 pkg/kubernetes/views/node-body.html.h:6
-msgid "Machine ID"
+#: pkg/networkmanager/interfaces.js:2788
+msgid "Removing <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/systemd/index.html.h:10 pkg/ostree/index.html.h:18
-#: pkg/kubernetes/views/nodes-page.html.h:6
-msgid "Operating System"
+#: pkg/storaged/jobs.js:154
+msgid "Removing physical volume from $target"
 msgstr ""
 
-#: pkg/systemd/index.html.h:11
-msgid "Secure Shell Keys"
+#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
+#: pkg/storaged/details.js:1775
+msgid "Rename"
 msgstr ""
 
-#: pkg/systemd/index.html.h:12
-msgid "Show fingerprints"
+#: pkg/storaged/details.js:795
+msgid "Rename Volume Group"
 msgstr ""
 
-#: pkg/systemd/index.html.h:14 pkg/dashboard/index.html.h:7
-msgid "Host Name"
+#: pkg/storaged/details.js:706
+msgid "Renamee Logical Volume"
+msgstr "논리 볼륨 이름 바꾸기"
+
+#: pkg/storaged/jobs.js:157
+msgid "Renaming $target"
 msgstr ""
 
-#: pkg/systemd/index.html.h:15
-msgid "Domain"
+#: pkg/systemd/services.html:432
+msgid "Repeat Daily"
 msgstr ""
 
-#: pkg/systemd/index.html.h:16
-msgid "System Time"
+#: pkg/systemd/services.html:431
+msgid "Repeat Hourly"
 msgstr ""
 
-#: pkg/systemd/index.html.h:17
-msgid "Power Options"
+#: pkg/systemd/services.html:434
+msgid "Repeat Monthly"
 msgstr ""
 
-#: pkg/systemd/index.html.h:20
-msgid "Performance Profile"
+#: pkg/systemd/services.html:433
+msgid "Repeat Weekly"
 msgstr ""
 
-#: pkg/systemd/index.html.h:21
-msgid "Store Performance Data"
+#: pkg/systemd/services.html:435
+msgid "Repeat Yearly"
 msgstr ""
 
-#: pkg/systemd/index.html.h:32
-msgid "Machine SSH Key Fingerprints"
+#: pkg/kubernetes/views/replicationcontroller-body.html:9
+#: pkg/kubernetes/views/details-page.html:141
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
+#: pkg/kubernetes/views/replicationcontroller-modify.html:8
+msgid "Replicas"
+msgstr "Replicas"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:14
+#: pkg/kubernetes/views/replicationcontroller-panel.html:10
+#: pkg/kubernetes/views/topology-page.html:23
+msgid "Replication Controller"
 msgstr ""
 
-#: pkg/systemd/index.html.h:33
-msgid "Pretty Host Name"
+#: pkg/kubernetes/views/details-page.html:132
+msgid "Replication Controllers"
 msgstr ""
 
-#: pkg/systemd/index.html.h:34
-msgid "Real Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:35
-msgid "Time Zone"
-msgstr ""
-
-#: pkg/systemd/index.html.h:36
+#: pkg/kubernetes/views/topology-page.html:24
 msgid ""
-"\n"
-"                                    Invalid time zone\n"
-"                                "
+"Replication controllers dynamically create instances of                pods "
+"from templates, and remove pods when necessary."
 msgstr ""
 
-#: pkg/systemd/index.html.h:39
-msgid "Set Time"
-msgstr ""
+#: pkg/docker/index.html:718
+msgid "Repository"
+msgstr "리포지터리 "
 
-#: pkg/systemd/index.html.h:40
+#: pkg/kubernetes/views/volume-body.html:24
 #, fuzzy
-msgid "Manually"
-msgstr "수동"
+msgid "Repository URL"
+msgstr "리포지터리 "
 
-#: pkg/systemd/index.html.h:41
-msgid "Automatically using NTP"
+#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
+msgid "Requested"
 msgstr ""
 
-#: pkg/systemd/index.html.h:42
-msgid "Automatically using specific NTP servers"
+#: pkg/kubernetes/views/pv-claim.html:13
+msgid "Requests"
 msgstr ""
 
-#: pkg/systemd/index.html.h:43
-msgid "Delay"
+#: pkg/kubernetes/views/auth-form.html:54
+#, fuzzy
+msgid "Requires Authentication"
+msgstr "인증 중입니다"
+
+#: pkg/docker/index.html:323
+msgid "Reset"
 msgstr ""
 
-#: pkg/systemd/index.html.h:44
-msgid "1 Minute"
+#: pkg/docker/storage.jsx:417
+msgid "Reset Storage Pool"
 msgstr ""
 
-#: pkg/systemd/index.html.h:45
-msgid "5 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:46
-msgid "20 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:47
-msgid "40 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:48
-msgid "60 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:49
-msgid "No Delay"
-msgstr ""
-
-#: pkg/systemd/index.html.h:50
-msgid "Specific Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:51
+#: pkg/docker/storage.jsx:420
 msgid ""
-"\n"
-"                        Cancel\n"
-"                    "
+"Resetting the storage pool will erase all containers and release disks in "
+"the pool."
 msgstr ""
 
-#: pkg/systemd/logs.html.h:1
-msgid "Journal"
+#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
+msgid "Resize"
+msgstr "크기 조정"
+
+#: pkg/storaged/details.js:673
+msgid "Resize Filesystem"
 msgstr ""
 
-#: pkg/systemd/logs.html.h:2
-msgid "Recent"
+#: pkg/storaged/details.js:661
+msgid "Resize Logical Volume"
+msgstr "논리 볼륨 크기 조정"
+
+#: pkg/storaged/jobs.js:158
+msgid "Resizing $target"
 msgstr ""
 
-#: pkg/systemd/logs.html.h:3
-msgid "Current boot"
+#: pkg/systemd/index.html:126 pkg/systemd/index.html:133
+msgid "Restart"
 msgstr ""
 
-#: pkg/systemd/logs.html.h:4
-msgid "Last 24 hours"
+#: pkg/kubernetes/views/container-body.html:20
+msgid "Restart Count"
 msgstr ""
 
-#: pkg/systemd/logs.html.h:5
-msgid "Last 7 days"
+#: pkg/docker/index.html:558 pkg/kubernetes/views/pod-body.html:10
+msgid "Restart Policy"
 msgstr ""
 
-#: pkg/systemd/logs.html.h:6
-msgid "Errors"
+#: pkg/kubernetes/scripts/volumes.js:217
+msgid "Retain"
 msgstr ""
 
-#: pkg/systemd/logs.html.h:7
-msgid "Warnings"
+#: pkg/docker/index.html:574
+msgid "Retries:"
 msgstr ""
 
-#: pkg/systemd/logs.html.h:8
-msgid "Notices"
+#: pkg/subscriptions/subscriptions-view.jsx:188
+msgid "Retrieving subscription status..."
 msgstr ""
 
-#: pkg/systemd/logs.html.h:9
-msgid "All"
-msgstr "모두"
-
-#: pkg/systemd/logs.html.h:10 pkg/kubernetes/views/container-panel.html.h:2
-#: pkg/kubernetes/views/container-page-inline.html.h:2
-msgid "Logs"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:11
-msgid "Entry"
-msgstr ""
-
-#: pkg/systemd/services.html.h:1 pkg/kubernetes/views/dashboard-page.html.h:12
-#: pkg/kubernetes/views/details-page.html.h:3
-msgid "Services"
-msgstr ""
-
-#: pkg/systemd/services.html.h:3
-msgid "System Services"
-msgstr ""
-
-#: pkg/systemd/services.html.h:4
-msgid "Sockets"
-msgstr ""
-
-#: pkg/systemd/services.html.h:5
-msgid "Timers"
-msgstr ""
-
-#: pkg/systemd/services.html.h:6
-msgid "Paths"
-msgstr ""
-
-#: pkg/systemd/services.html.h:7
-msgid "Instantiate"
-msgstr ""
-
-#: pkg/systemd/services.html.h:8
-msgid "{{days_text}}"
-msgstr ""
-
-#: pkg/systemd/services.html.h:9
-msgid "Service Logs"
-msgstr ""
-
-#: pkg/systemd/services.html.h:10
-msgid "Note"
-msgstr ""
-
-#: pkg/systemd/services.html.h:11
-msgid ""
-"This unit is not designed to be enabled explicitly.\n"
-"          "
-msgstr ""
-
-#: pkg/systemd/services.html.h:15
+#: pkg/kubernetes/views/volume-body.html:26
 #, fuzzy
-msgid "Create Timers"
-msgstr "생성"
+msgid "Revision"
+msgstr "버전"
 
-#: pkg/systemd/services.html.h:16
-#, fuzzy
-msgid "Service name"
-msgstr "사용자 이름"
+#: pkg/users/index.html:94 pkg/kubernetes/views/add-member-role-dialog.html:39
+#: pkg/kubernetes/views/project-body.html:21
+msgid "Roles"
+msgstr ""
 
-#: pkg/systemd/services.html.h:18 pkg/docker/index.html.h:32
-msgid "Command"
-msgstr "명령"
+#: pkg/ostree/index.html:73
+msgid "Roll back and reboot"
+msgstr ""
 
-#: pkg/systemd/services.html.h:19
+#: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
+msgid "Round Robin"
+msgstr "Round Robin"
+
+#: pkg/kubernetes/views/route-page.html:14
+#: pkg/kubernetes/views/route-panel.html:9
+msgid "Route"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:65
+msgid "Routes"
+msgstr ""
+
+#: pkg/systemd/services.html:384
 #, fuzzy
 msgid "Run"
 msgstr "작동중"
 
-#: pkg/systemd/services.html.h:20
-msgid "After system boot"
+#: pkg/kubernetes/views/image-config.html:4
+msgid "Run as"
 msgstr ""
 
-#: pkg/systemd/services.html.h:21
-msgid "At specific time"
-msgstr ""
-
-#: pkg/systemd/services.html.h:22
-msgid "Seconds"
-msgstr ""
-
-#: pkg/systemd/services.html.h:23
+#: pkg/networkmanager/index.html:381
 #, fuzzy
-msgid "Minutes"
-msgstr "5분"
+msgid "Runner"
+msgstr "작동중"
 
-#: pkg/systemd/services.html.h:24
-#, fuzzy
-msgid "Hours"
-msgstr "6 시간"
+#: pkg/ostree/index.html:83
+msgid "Running"
+msgstr "작동중"
 
-#: pkg/systemd/services.html.h:25
-msgid "Weeks"
+#: pkg/selinux/setroubleshoot-view.jsx:478
+msgid "SELinux Access Control Errors"
 msgstr ""
 
-#: pkg/systemd/services.html.h:26
-msgid "Don't Repeat"
+#: pkg/selinux/setroubleshoot-view.jsx:330
+msgid "SELinux Policy"
 msgstr ""
 
-#: pkg/systemd/services.html.h:27
-msgid "Repeat Hourly"
+#: pkg/selinux/setroubleshoot.html:23
+msgid "SELinux Troubleshoot"
 msgstr ""
 
-#: pkg/systemd/services.html.h:28
-msgid "Repeat Daily"
+#: pkg/selinux/setroubleshoot-view.jsx:317
+msgid "SELinux is disabled on the system."
 msgstr ""
 
-#: pkg/systemd/services.html.h:29
-msgid "Repeat Weekly"
+#: pkg/selinux/setroubleshoot-view.jsx:309
+msgid "SELinux system status is unknown."
 msgstr ""
 
-#: pkg/systemd/services.html.h:30
-msgid "Repeat Monthly"
+#: pkg/storaged/jobs.js:119
+msgid "SMART self-test of $target"
 msgstr ""
 
-#: pkg/systemd/services.html.h:31
-msgid "Repeat Yearly"
-msgstr ""
+#: pkg/networkmanager/index.html:218
+msgid "STP Forward delay"
+msgstr "STP Forward delay"
 
-#: pkg/systemd/services.html.h:32
-msgid "Hour : Minute"
-msgstr ""
+#: pkg/networkmanager/index.html:227
+msgid "STP Hello time"
+msgstr "STP Hello time"
 
-#: pkg/systemd/services.html.h:33
-msgid ":"
-msgstr ""
+#: pkg/networkmanager/index.html:236
+msgid "STP Maximum message age"
+msgstr "STP Maximum message age"
 
-#: pkg/systemd/services.html.h:35
+#: pkg/networkmanager/index.html:209
+msgid "STP Priority"
+msgstr "STP 우선순위"
+
+#: pkg/systemd/services.html:466
 msgid "Save"
 msgstr ""
 
-#: pkg/systemd/terminal.html.h:1
+#: pkg/ostree/client.js:66
+msgid "Scanning metadata"
+msgstr ""
+
+#: pkg/kubernetes/views/node-capacity.html:9
+msgid "Scheduled Pods"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:322
+msgid "Scheduling Disabled"
+msgstr ""
+
+#: pkg/systemd/services.html:402 pkg/systemd/services.html:406
+msgid "Seconds"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:195
+msgid "Secret"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:106
+msgid "Secret File"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:141
+#, fuzzy
+msgid "Secret Name"
+msgstr "사용자 이름"
+
+#: pkg/kubernetes/views/volume-body.html:69
+#: pkg/kubernetes/views/volume-body.html:108
+#: pkg/kubernetes/views/volume-body.html:134
+#, fuzzy
+msgid "Secret Volume"
+msgstr "볼륨 그룹 생성"
+
+#: pkg/systemd/index.html:93
+msgid "Secure Shell Keys"
+msgstr ""
+
+#: pkg/storaged/jobs.js:136
+msgid "Securely erasing $target"
+msgstr ""
+
+#: pkg/kubernetes/views/file-button.html:4
+msgid "Select Manifest File..."
+msgstr "manifest을 선택하세요..."
+
+#: pkg/kubernetes/views/topology-page.html:7
+msgid "Select an object to see more details."
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:8
+msgid ""
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
+msgstr ""
+
+#: pkg/networkmanager/index.html:69 pkg/networkmanager/index.html:97
+#: pkg/networkmanager/index.html:115 pkg/networkmanager/index.html:515
+#: pkg/networkmanager/index.html:550
+msgid "Sending"
+msgstr "전송 중입니다"
+
+#: pkg/storaged/index.html:432
+#, fuzzy
+msgctxt "storage"
+msgid "Serial Number"
+msgstr "논리 볼륨"
+
+#: pkg/kubernetes/views/pv-modify.html:82
+#: pkg/kubernetes/views/volume-body.html:47
+msgid "Server"
+msgstr ""
+
+#: pkg/storaged/overview.js:518
+msgid "Server Address"
+msgstr ""
+
+#: pkg/users/local.js:682 pkg/users/local.js:683
+msgid "Server Administrator"
+msgstr ""
+
+#: pkg/storaged/overview.js:521
+#, fuzzy
+msgid "Server address cannot be empty."
+msgstr "이름을 입력하셔야 합니다."
+
+#: src/base1/cockpit.js:3709
+msgid "Server has closed the connection."
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:12
+#: pkg/kubernetes/views/service-panel.html:8
+#: pkg/kubernetes/views/topology-page.html:32
+msgid "Service"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:12
+msgid "Service Account"
+msgstr ""
+
+#: pkg/systemd/services.html:279
+msgid "Service Logs"
+msgstr ""
+
+#: pkg/systemd/services.html:342
+#, fuzzy
+msgid "Service name"
+msgstr "사용자 이름"
+
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:272
+#: pkg/kubernetes/views/dashboard-page.html:134
+#: pkg/kubernetes/views/details-page.html:29
+msgid "Services"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:33
+msgid ""
+"Services group pods and provide a common DNS                name and an "
+"optional, load-balanced IP address to access them."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:20
+msgid "Session Affinity"
+msgstr ""
+
+#: pkg/dashboard/index.html:190
+msgid "Set"
+msgstr ""
+
+#: pkg/systemd/host.js:559
+msgid "Set Host name"
+msgstr ""
+
+#: pkg/users/index.html:117 pkg/users/index.html:221
+msgid "Set Password"
+msgstr ""
+
+#: pkg/systemd/index.html:395
+msgid "Set Time"
+msgstr ""
+
+#: pkg/docker/index.html:551
+msgid "Set container environment variables"
+msgstr ""
+
+#: pkg/networkmanager/index.html:172
+msgid "Set to"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:326
+msgid ""
+"Setting deviates from the configured state and will revert on the next boot."
+msgstr ""
+
+#: pkg/storaged/jobs.js:131
+msgid "Setting up loop device $target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:139
+#, fuzzy
+msgid "Share Name"
+msgstr "사용자 이름"
+
+#: pkg/networkmanager/interfaces.js:1807
+msgid "Shared"
+msgstr "공유됨"
+
+#: pkg/kubernetes/views/container-panel.html:9
+#: pkg/kubernetes/views/container-page-inline.html:14
+msgid "Shell"
+msgstr ""
+
+#: pkg/kubernetes/views/container-page.html:4
+#, fuzzy
+msgid "Show all Containers"
+msgstr "컨테이너들"
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:8
+msgid "Show all Deployment Configs"
+msgstr ""
+
+#: pkg/kubernetes/views/node-page.html:8
+msgid "Show all Nodes"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:9
+msgid "Show all Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-container.html:4
+#, fuzzy
+msgid "Show all Pod Containers"
+msgstr "컨테이너들"
+
+#: pkg/kubernetes/views/pod-page.html:8
+msgid "Show all Pods"
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:16
+#: pkg/kubernetes/views/group-page.html:14
+#: pkg/kubernetes/views/project-page.html:23
+msgid "Show all Projects"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:10
+msgid "Show all Replication Controllers"
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:10
+msgid "Show all Routes"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:8
+msgid "Show all Services"
+msgstr ""
+
+#: pkg/docker/index.html:127
+#, fuzzy
+msgid "Show all containers"
+msgstr "컨테이너들"
+
+#: pkg/kubernetes/views/imagestream-page.html:12
+msgid "Show all image streams"
+msgstr ""
+
+#: pkg/docker/index.html:241 pkg/kubernetes/views/image-page.html:11
+msgid "Show all images"
+msgstr ""
+
+#: pkg/systemd/index.html:94
+msgid "Show fingerprints"
+msgstr ""
+
+#: pkg/systemd/index.html:136
+msgid "Shutdown"
+msgstr ""
+
+#: pkg/kubernetes/views/container-body.html:18
+msgid "Since"
+msgstr ""
+
+#: pkg/systemd/init.js:621
+msgid "Since $0"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/storaged/index.html:232
+msgid "Size"
+msgstr ""
+
+#: pkg/storaged/dialog.js:271
+#, fuzzy
+msgid "Size cannot be negative"
+msgstr "이름을 입력하셔야 합니다."
+
+#: pkg/storaged/dialog.js:269
+#, fuzzy
+msgid "Size cannot be zero"
+msgstr "이름을 입력하셔야 합니다."
+
+#: pkg/storaged/dialog.js:273
+msgid "Size is too large"
+msgstr ""
+
+#: pkg/storaged/dialog.js:267
+msgid "Size must be a number"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:43
+#: pkg/kubernetes/views/auth-rejected-cert.html:11
+msgid "Skip Certificate Verification"
+msgstr ""
+
+#: pkg/systemd/services.html:54
+msgid "Sockets"
+msgstr ""
+
+#: pkg/ostree/index.html:23
+msgid "Software Updates"
+msgstr ""
+
+#: pkg/docker/storage.jsx:156
+msgid "Solid-State Disk"
+msgstr ""
+
+#: pkg/storaged/overview.js:182
+msgctxt "storage"
+msgid "Solid-State Disk"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:90
+msgid "Solution applied successfully"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:97
+msgid "Solution failed"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:908
+msgid "Sorry, I don't know how to modify this volume"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:8
+msgid "Source URL"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2573
+msgid "Spanning Tree Protocol"
+msgstr "Spanning Tree Protocol"
+
+#: pkg/networkmanager/index.html:200
+msgid "Spanning Tree Protocol (STP)"
+msgstr "Spanning Tree Protocol (STP)"
+
+#: pkg/storaged/details.js:1594
+msgid "Spare"
+msgstr ""
+
+#: pkg/systemd/index.html:470
+msgid "Specific Time"
+msgstr ""
+
+#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
+msgid "Start"
+msgstr ""
+
+#: pkg/docker/index.html:68
+msgid "Start Docker"
+msgstr "Docker 시작"
+
+#: pkg/storaged/index.html:49
+msgid "Start Multipath"
+msgstr ""
+
+#: pkg/storaged/details.js:1614
+msgid "Start Scrubbing"
+msgstr ""
+
+#: pkg/storaged/jobs.js:139
+msgid "Starting RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:124
+msgid "Starting swapspace $target"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:37
+msgid "Starts"
+msgstr ""
+
+#: pkg/kubernetes/views/container-body.html:16
+#: pkg/kubernetes/views/details-page.html:38
+#: pkg/kubernetes/views/details-page.html:175
+msgid "State"
+msgstr ""
+
+#: pkg/storaged/index.html:571
+#, fuzzy
+msgctxt "storage"
+msgid "State"
+msgstr "상태"
+
+#: pkg/systemd/init.js:303
+msgid "Static"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/containers-listing.html:16
+#: pkg/kubernetes/views/nodes-page.html:44
+#: pkg/kubernetes/views/pvc-body.html:13 pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/pv-body.html:24
+msgid "Status"
+msgstr "상태"
+
+#: pkg/subscriptions/subscriptions-view.jsx:146
+#, fuzzy
+msgid "Status: $0"
+msgstr "상태"
+
+#: pkg/subscriptions/subscriptions-view.jsx:141
+msgid "Status: System isn't registered"
+msgstr ""
+
+#: pkg/networkmanager/index.html:455
+msgid "Sticky"
+msgstr ""
+
+#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
+msgid "Stop"
+msgstr ""
+
+#: pkg/storaged/details.js:1615
+msgid "Stop Scrubbing"
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:10
+msgid "Stop with"
+msgstr ""
+
+#: pkg/docker/util.js:231
+msgid "Stopped"
+msgstr "정지됨"
+
+#: pkg/storaged/jobs.js:138
+msgid "Stopping RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:125
+msgid "Stopping swapspace $target"
+msgstr ""
+
+#: pkg/storaged/index.html:23 pkg/storaged/index.html:672
+msgid "Storage"
+msgstr ""
+
+#: pkg/storaged/index.html:686
+msgid "Storage Log"
+msgstr ""
+
+#: pkg/storaged/index.html:342
+msgid "Storage Logs"
+msgstr ""
+
+#: pkg/docker/index.html:324
+msgid "Storage pool"
+msgstr ""
+
+#: pkg/systemd/index.html:148
+msgid "Store Performance Data"
+msgstr ""
+
+#: pkg/storaged/details.js:237
+msgid "Store passphrase"
+msgstr ""
+
+#: pkg/storaged/details.js:527
+msgid "Stored Passphrase"
+msgstr "저장된 암호"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:12
+msgid ""
+"Strategy            {{item.spec.strategy.type}}            Latest "
+"Version            {{ item.status.latestVersion }}            Not "
+"deployed        "
+msgstr ""
+
+#: pkg/subscriptions/index.html:22
+msgid "Subscriptions"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:4
+msgid "Summary"
+msgstr ""
+
+#: pkg/storaged/details.js:1251
+msgctxt "storage-id-desc"
+msgid "Swap Space"
+msgstr ""
+
+#: pkg/systemd/index.html:243
+msgid "Swap Used"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
+msgid "Switch off $0"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2191 pkg/networkmanager/interfaces.js:2765
+msgid "Switch on $0"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2213
+msgid "Switching off <b>$0</b>  will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2773
+msgid "Switching off <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2188
+msgid "Switching on <b>$0</b>  will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2762
+msgid "Switching on <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:75
+msgid "Synchronize"
+msgstr ""
+
+#: pkg/dashboard/index.html:188 pkg/lib/machine-sync-users.html:4
+msgid "Synchronize users"
+msgstr ""
+
+#: pkg/systemd/index.html:54
+msgid "Synchronized"
+msgstr ""
+
+#: pkg/systemd/index.html:51
+msgid "Synchronized with {{Server}}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:146
+msgid "Synchronizing RAID Device $target"
+msgstr ""
+
+#: pkg/systemd/index.html:4
+msgid "System"
+msgstr ""
+
+#: pkg/systemd/services.html:53
+msgid "System Services"
+msgstr ""
+
+#: pkg/systemd/index.html:112
+msgid "System Time"
+msgstr ""
+
+#: pkg/docker/index.html:349
+msgid "TCP"
+msgstr "TCP"
+
+#: pkg/kubernetes/views/route-body.html:12
+msgid "TLS Termination"
+msgstr ""
+
+#: pkg/docker/index.html:724
+msgid "Tag"
+msgstr "태그"
+
+#: pkg/kubernetes/views/image-body.html:27
+#: pkg/kubernetes/views/imagestream-modify.html:76
+#: pkg/kubernetes/views/image-listing.html:14
+msgid "Tags"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:136
+msgid "Target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:75
+msgid "Target Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:114
+msgid "Target World Wide Names"
+msgstr ""
+
+#: pkg/systemd/services.html:52
+msgid "Targets"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2235 pkg/networkmanager/interfaces.js:2247
+#: pkg/networkmanager/interfaces.js:2530
+msgid "Team"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2558
+msgid "Team Port"
+msgstr ""
+
+#: pkg/networkmanager/index.html:652
+#, fuzzy
+msgid "Team Port Settings"
+msgstr "브릿지 포트 설정"
+
+#: pkg/networkmanager/index.html:624
+#, fuzzy
+msgid "Team Settings"
+msgstr "IP 설정"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:20
+#: pkg/kubernetes/views/deploymentconfig-panel.html:10
+#: pkg/kubernetes/views/deploymentconfig-page.html:15
+#: pkg/kubernetes/views/replicationcontroller-panel.html:14
+msgid "Template"
+msgstr ""
+
+#: pkg/systemd/terminal.html:4
 msgid "Terminal"
 msgstr ""
 
-#: pkg/lib/machine-invalid-hostkey.html.h:1
-msgid "Incorrect Host Key"
+#: pkg/users/index.html:78
+msgid "Terminate Session"
 msgstr ""
 
-#: pkg/lib/machine-invalid-hostkey.html.h:2
+#: pkg/networkmanager/index.html:38
+msgid "Testing connection"
+msgstr ""
+
+#: pkg/storaged/index.html:40
+msgid "The \"storaged\" API is not available on this system."
+msgstr ""
+
+#: pkg/docker/storage.jsx:485
+msgid "The Docker storage pool cannot be managed on this system."
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:386
+msgid "The IP address or host name cannot contain whitespace."
+msgstr ""
+
+#: pkg/storaged/index.html:532
+msgid "The RAID Array is in a degraded state"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:399
+msgid "The address contains invalid characters"
+msgstr "주소에 잘못된 문자가 있습니다 "
+
+#: pkg/lib/machine-unknown-hostkey.html:6
+msgid ""
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:324
+msgid "The configured state is unknown, it might change on the next boot."
+msgstr ""
+
+#: pkg/kubernetes/views/container-page-inline.html:22
+msgid "The container '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:192
+msgid "The current user isn't allowed to access system subscription status."
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:25
+msgid "The deployment config '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:47
+msgid "The group '{{ groupName }}' does not exist."
+msgstr ""
+
+#: pkg/shell/base_index.js:673
+msgid "The javascript console contains details about this error "
+msgstr "자바스크립트 콘솔에서 오류에 대한 데이터를 확인하실 수 있습니다."
+
+#: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
 "The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
 "in use. Unless this machine was recently replaced, it is likely that someone "
 "is trying to attack your connection to this machine."
 msgstr ""
 
-#: pkg/lib/machine-invalid-hostkey.html.h:3
-msgid ""
-"You can remove the previously stored key by running the following command"
+#: pkg/users/authorized-keys.js:118
+msgid "The key you provided was not valid."
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html.h:1
-msgid "Authentication Failed"
+#: pkg/storaged/details.js:1751
+msgid "The last physical volume of a volume group cannot be removed."
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html.h:2
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
-"machine with cockpit you will need to enable one of the following "
-"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:4 pkg/shell/index.html.h:30
-msgid "Public Key"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:5
-msgid "Kerberos Based SSO"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:6
-msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:1 pkg/dashboard/index.html.h:11
-msgid "Synchronize users"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:2
-msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:3
-msgid "Error loading users: {{perm_failed}}"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:4
-msgid ""
-"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
-"synchronize users, a user with superuser privileges is required."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:5 pkg/lib/machine-change-auth.html.h:4
-msgid "User name"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:8
-msgid "Synchronize"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:1
-msgid "Unknown Host Key"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:2
-msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:3 pkg/shell/index.html.h:4
-msgid "Fingerprint"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:5
-#: pkg/kubernetes/views/auth-form.html.h:14
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:6
-msgid "Connect"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:1
-msgid "Add Machine to Dashboard"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:3 pkg/dashboard/index.html.h:9
-msgid "Color"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:4
-msgid ""
-"Connecting simultaneously to more than {{ limit }} machines is unsupported."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:1
-msgid "Could not contact {{host}}"
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:2
-msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:3
-msgid ""
-"To try a different port you will need to upgrade cockpit-ws to a newer "
-"version."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:4
-msgid "Is sshd running on a different port?"
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:7
-msgid "Update"
-msgstr ""
-
-#: pkg/lib/machine-not-supported.html.h:1
-msgid "Cockpit is not installed"
-msgstr ""
-
-#: pkg/lib/machine-not-supported.html.h:2
-msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:1
-msgid "Log in to {{host}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:2
-msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:3
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:5 pkg/shell/index.html.h:9
-#: pkg/realmd/operation.html.h:3 pkg/kubernetes/views/auth-form.html.h:8
-msgid "Authentication"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:7
-msgid "Available"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:8
-msgid "Login Password"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:9
-msgid "Kerberos Ticket"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:10
-msgid "Checking for public keys"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:12
-msgid "Log In"
-msgstr ""
-
-#: pkg/shell/shell.html.h:1
-msgid "Things have moved"
-msgstr ""
-
-#: pkg/shell/index.html.h:2
-msgid "Comment"
-msgstr ""
-
-#: pkg/shell/index.html.h:5 pkg/shell/stub.html.h:2 pkg/shell/simple.html.h:2
-msgid "Ooops!"
-msgstr "어머나!"
-
-#: pkg/shell/index.html.h:6 pkg/shell/stub.html.h:3 pkg/shell/simple.html.h:3
-msgid "Display Language"
-msgstr "표시 언어"
-
-#: pkg/shell/index.html.h:7 pkg/shell/stub.html.h:4 pkg/shell/simple.html.h:4
-msgid "About Cockpit"
-msgstr "Cockpit에 대하여"
-
-#: pkg/shell/index.html.h:8
-msgid "Account Settings"
-msgstr "계정 설정"
-
-#: pkg/shell/index.html.h:10 pkg/shell/stub.html.h:5 pkg/shell/simple.html.h:5
-msgid "Log out"
-msgstr "로그아웃"
-
-#: pkg/shell/index.html.h:11 pkg/shell/stub.html.h:6 pkg/shell/simple.html.h:6
-msgid ""
-"\n"
-"              Cockpit is an interactive Linux server admin interface.\n"
-"            "
-msgstr ""
-"\n"
-"              Cockpit은 반응형 리눅스 서버 관리 인터페이스입니다.\n"
-"            "
-
-#: pkg/shell/index.html.h:15 pkg/shell/stub.html.h:10
-#: pkg/shell/simple.html.h:10
-msgid "Choose the language to be used in the application"
-msgstr "사용하실 언어를 선택해주세요"
-
-#: pkg/shell/index.html.h:16 pkg/shell/stub.html.h:11
-#: pkg/shell/simple.html.h:11 pkg/storaged/index.html.h:59
-msgid ""
-"\n"
-"              Cancel\n"
-"            "
-msgstr ""
-"\n"
-"              취소\n"
-"            "
-
-#: pkg/shell/index.html.h:19 pkg/shell/stub.html.h:14
-#: pkg/shell/simple.html.h:14
-msgid ""
-"\n"
-"              Select\n"
-"            "
-msgstr ""
-"\n"
-"              선택\n"
-"            "
-
-#: pkg/shell/index.html.h:22 pkg/shell/stub.html.h:17
-msgid ""
-"\n"
-"              Close\n"
-"            "
-msgstr ""
-"\n"
-"              종료\n"
-"            "
-
-#: pkg/shell/index.html.h:25
-msgid "Use my password for privileged tasks and to connect to other machines"
-msgstr ""
-
-#: pkg/shell/index.html.h:26
-msgid "Use the following keys to authenticate against other systems"
-msgstr ""
-
-#: pkg/shell/index.html.h:29 pkg/kubernetes/index.html.h:6
-msgid "Details"
-msgstr ""
-
-#: pkg/shell/index.html.h:32
-msgid "Unlock Key"
-msgstr ""
-
-#: pkg/shell/index.html.h:33 pkg/users/index.html.h:23
-msgid "Old Password"
-msgstr ""
-
-#: pkg/shell/index.html.h:34 pkg/users/index.html.h:24
-msgid "New Password"
-msgstr ""
-
-#: pkg/shell/index.html.h:35 pkg/users/index.html.h:19
-msgid "Confirm"
-msgstr ""
-
-#: pkg/shell/index.html.h:36
-msgid "Change Password"
-msgstr ""
-
-#: pkg/shell/index.html.h:38 pkg/shell/stub.html.h:20
-msgid ""
-"\n"
-"                Tools\n"
-"              "
-msgstr ""
-"\n"
-"                도구\n"
-"              "
-
-#: pkg/shell/index.html.h:41 pkg/shell/stub.html.h:23
-#: pkg/shell/simple.html.h:24
-msgid "Reconnect"
-msgstr "재연결"
-
-#: pkg/shell/index.html.h:42 pkg/shell/stub.html.h:24
-msgid "Troubleshoot"
-msgstr ""
-
-#: pkg/shell/simple.html.h:18
-msgid ""
-"\n"
-"              Try to reconnect\n"
-"            "
-msgstr ""
-"\n"
-"              재연결 시도\n"
-"            "
-
-#: pkg/shell/simple.html.h:21
-msgid ""
-"\n"
-"              Log in again\n"
-"            "
-msgstr ""
-"\n"
-"              다시 로그인\n"
-"            "
-
-#: pkg/ostree/index.html.h:1
-msgid "Software Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:2
-msgid "Check for updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:3
-msgid ""
-"\n"
-"                    Update and reboot\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:6
-msgid "Roll back and reboot"
-msgstr ""
-
-#: pkg/ostree/index.html.h:8
-msgid ""
-"\n"
-"                    Default\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:11
-msgid ""
-"\n"
-"                    Available\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:16
-msgid "Tree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:17
-msgid "Packages"
-msgstr ""
-
-#: pkg/ostree/index.html.h:20
-msgid "Released"
-msgstr ""
-
-#: pkg/ostree/index.html.h:21
-msgid "Additions"
-msgstr ""
-
-#: pkg/ostree/index.html.h:22
-msgid "Removals"
-msgstr ""
-
-#: pkg/ostree/index.html.h:23
-msgid "Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:24
-msgid "Downgrades"
-msgstr ""
-
-#: pkg/ostree/index.html.h:25
-msgid ""
-"\n"
-"                    This deployment contains the same packages as your "
-"currently booted system\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:28
-msgid "Operating System Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:29
-msgid "Connecting"
-msgstr ""
-
-#: pkg/ostree/index.html.h:30
-msgid "Unable to communicate with OSTree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:31
-msgid "No Deployments"
-msgstr ""
-
-#: pkg/ostree/index.html.h:32
-msgid ""
-"\n"
-"                    Reconnect\n"
-"                "
-msgstr ""
-
-#: pkg/selinux/setroubleshoot.html.h:1
-msgid "SELinux Troubleshoot"
-msgstr ""
-
-#: pkg/machines/index.html.h:1
-msgid "Virtual Machines Management"
-msgstr ""
-
-#: pkg/storaged/index.html.h:1
-msgid "Storage"
-msgstr ""
-
-#: pkg/storaged/index.html.h:2
-msgid "The \"storaged\" API is not available on this system."
-msgstr ""
-
-#: pkg/storaged/index.html.h:3
-msgid "Start Multipath"
-msgstr ""
-
-#: pkg/storaged/index.html.h:4
-msgid ""
-"\n"
-"        There are devices with multiple paths on the system, but the "
-"multipath service is not running.\n"
-"      "
-msgstr ""
-
-#: pkg/storaged/index.html.h:7
-msgid "RAID Devices"
-msgstr ""
-
-#: pkg/storaged/index.html.h:8
-msgid "No storage set up as RAID"
-msgstr ""
-
-#: pkg/storaged/index.html.h:9
-msgid "Volume Groups"
-msgstr ""
-
-#: pkg/storaged/index.html.h:10
-msgid "No volume groups created"
-msgstr ""
-
-#: pkg/storaged/index.html.h:11
-msgid "iSCSI Targets"
-msgstr ""
-
-#: pkg/storaged/index.html.h:12
-msgid "{{Address}}:{{Port}}"
-msgstr ""
-
-#: pkg/storaged/index.html.h:13
-msgid "No iSCSI targets set up"
-msgstr ""
-
-#: pkg/storaged/index.html.h:14
-msgid "Drives"
-msgstr ""
-
-#: pkg/storaged/index.html.h:15
-msgid "No drives attached"
-msgstr ""
-
-#: pkg/storaged/index.html.h:16
-msgid "Other Devices"
-msgstr ""
-
-#: pkg/storaged/index.html.h:17
-msgid "Filesystems"
-msgstr ""
-
-#: pkg/storaged/index.html.h:21
-msgid "Jobs"
-msgstr ""
-
-#: pkg/storaged/index.html.h:23 pkg/networkmanager/index.html.h:3
-msgid "Go to now"
-msgstr "지금 바로 가기"
-
-#: pkg/storaged/index.html.h:24 pkg/networkmanager/index.html.h:4
-msgid "5 minutes"
-msgstr "5분"
-
-#: pkg/storaged/index.html.h:25 pkg/networkmanager/index.html.h:5
-msgid "1 hour"
-msgstr "1 시간"
-
-#: pkg/storaged/index.html.h:26 pkg/networkmanager/index.html.h:6
-msgid "6 hours"
-msgstr "6 시간"
-
-#: pkg/storaged/index.html.h:27 pkg/networkmanager/index.html.h:7
-msgid "1 day"
-msgstr "1 일"
-
-#: pkg/storaged/index.html.h:28 pkg/networkmanager/index.html.h:8
-msgid "1 week"
-msgstr "1 주"
-
-#: pkg/storaged/index.html.h:29
-msgid "Reading"
-msgstr ""
-
-#: pkg/storaged/index.html.h:30
-msgid "Writing"
-msgstr ""
-
-#: pkg/storaged/index.html.h:31
-msgid "Storage Logs"
-msgstr ""
-
-#: pkg/storaged/index.html.h:32
-msgid "Create partition table"
-msgstr ""
-
-#: pkg/storaged/index.html.h:34
-msgid "Block Device"
-msgstr ""
-
-#: pkg/storaged/index.html.h:40
-msgid "No media inserted"
-msgstr ""
-
-#: pkg/storaged/index.html.h:42
-msgid "DISK IS FAILING"
-msgstr ""
-
-#: pkg/storaged/index.html.h:43
-msgid "Disk is OK"
-msgstr ""
-
-#: pkg/storaged/index.html.h:46
-msgid "The RAID Array is in a degraded state"
-msgstr ""
-
-#: pkg/storaged/index.html.h:47
-msgid "RAID Device"
-msgstr ""
-
-#: pkg/storaged/index.html.h:56
-msgid "Volume Group"
-msgstr ""
-
-#: pkg/storaged/index.html.h:57
-msgid "Physical Volumes"
-msgstr ""
-
-#: pkg/storaged/index.html.h:58
-msgid "Storage Log"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:1
-msgid "Domain Address"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:2
-msgid "Computer OU"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:4 pkg/users/index.html.h:11
-msgid "User Name"
-msgstr "사용자 이름"
-
-#: pkg/realmd/operation.html.h:5
-msgid "User Password"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:6
-msgid "Domain Administrator Name"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:7
-msgid "Domain Administrator Password"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:8
-msgid "One Time Password"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:9
-msgid "This may take a while"
-msgstr ""
+#: pkg/shell/indexes.js:314
+msgid "The machine is restarting"
+msgstr "장치가 재시동되고 있습니다"
 
-#: pkg/docker/index.html.h:1 pkg/kubernetes/index.html.h:4
-#: pkg/kubernetes/views/containers-listing.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:6
-#: pkg/kubernetes/views/dashboard-page.html.h:17
-msgid "Containers"
-msgstr "컨테이너들"
+#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
+msgid "The maximum number of replicas is 128"
+msgstr "replica의 최대 수는 128개입니다."
 
-#: pkg/docker/index.html.h:2
-msgid "Connecting to Docker"
-msgstr "Docker에 연결중입니다."
-
-#: pkg/docker/index.html.h:3
-msgid "Not authorized to access Docker on this system"
-msgstr "본 시스템 상의 Docker에 대한 접근 권한이 없습니다."
-
-#: pkg/docker/index.html.h:4
-msgid "Docker is not installed or activated on the system"
-msgstr "본 시스템에 Docker가 설치되어 있지 않거나 활성화되어 있지 않습니다."
-
-#: pkg/docker/index.html.h:5
-#, fuzzy
-msgid "Can&rsquo;t connect to Docker"
-msgstr "Docker에 연결할 수 없습니다."
-
-#: pkg/docker/index.html.h:6
-msgid "Start Docker"
-msgstr "Docker 시작"
-
-#: pkg/docker/index.html.h:7
-msgid "Try again"
-msgstr "다시 시도"
-
-#: pkg/docker/index.html.h:8
-msgid "Combined CPU usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:9
-msgid "Combined memory usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:10
-#, fuzzy
-msgid "Show all containers"
-msgstr "컨테이너들"
-
-#: pkg/docker/index.html.h:11
-#, fuzzy
-msgid "IP Address:"
-msgstr "IP 주소"
-
-#: pkg/docker/index.html.h:12
-#, fuzzy
-msgid "IP Prefix Length:"
-msgstr "접두 길이"
-
-#: pkg/docker/index.html.h:13
-msgid "Gateway:"
-msgstr ""
-
-#: pkg/docker/index.html.h:14
-#, fuzzy
-msgid "MAC Address:"
-msgstr "주소"
-
-#: pkg/docker/index.html.h:15 pkg/kubernetes/views/image-page.html.h:1
-msgid "Show all images"
-msgstr ""
-
-#: pkg/docker/index.html.h:16 pkg/kubernetes/index.html.h:2
-#: pkg/kubernetes/registry.html.h:2
-msgid "Overview"
-msgstr ""
-
-#: pkg/docker/index.html.h:17
-msgid "Reset"
-msgstr ""
-
-#: pkg/docker/index.html.h:18
-msgid "Storage pool"
-msgstr ""
-
-#: pkg/docker/index.html.h:19
-msgid "Additional Storage"
-msgstr ""
-
-#: pkg/docker/index.html.h:20
-msgid "TCP"
-msgstr "TCP"
-
-#: pkg/docker/index.html.h:21
-msgid "{{host_port_label}}"
-msgstr "{{host_port_label}}"
-
-#: pkg/docker/index.html.h:22
-#, fuzzy
-msgid "{{host_volume_label}}"
-msgstr "{{host_port_label}}"
-
-#: pkg/docker/index.html.h:24
-msgid "ReadWrite"
-msgstr ""
-
-#: pkg/docker/index.html.h:25
-#, fuzzy
-msgid "ReadOnly"
-msgstr "준비됨"
-
-#: pkg/docker/index.html.h:26
-#, fuzzy
-msgid "{{envvar_key_label}}"
-msgstr "{{alias_label}}"
-
-#: pkg/docker/index.html.h:27
-#, fuzzy
-msgid "{{envvar_value_label}}"
-msgstr "{{alias_label}}"
-
-#: pkg/docker/index.html.h:28
-msgid "select container"
-msgstr ""
-
-#: pkg/docker/index.html.h:29
-msgid "{{alias_label}}"
-msgstr "{{alias_label}}"
-
-#: pkg/docker/index.html.h:30 pkg/kubernetes/views/image-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:2
-#: pkg/kubernetes/views/image-page.html.h:2
-msgid "Image"
-msgstr "이미지"
-
-#: pkg/docker/index.html.h:31
-msgid "Container Name"
-msgstr "컨테이너 이름"
-
-#: pkg/docker/index.html.h:33
-msgid "Memory limit"
-msgstr "메모리 제한"
-
-#: pkg/docker/index.html.h:34
-msgid "MiB"
-msgstr ""
-
-#: pkg/docker/index.html.h:35
-msgid "CPU priority"
-msgstr "CPU 우선순위"
-
-#: pkg/docker/index.html.h:36
-#, fuzzy
-msgid "shares"
-msgstr "$0 공유"
-
-#: pkg/docker/index.html.h:37
-msgid "With terminal"
-msgstr "터미널 실행"
-
-#: pkg/docker/index.html.h:38
-msgid "Links"
-msgstr "링크"
-
-#: pkg/docker/index.html.h:40
-msgid "Expose container ports"
-msgstr ""
-
-#: pkg/docker/index.html.h:41 pkg/kubernetes/index.html.h:7
-#: pkg/kubernetes/views/image-config.html.h:9
-#: pkg/kubernetes/views/pod-page.html.h:3
-#: pkg/kubernetes/views/dashboard-page.html.h:4
-msgid "Volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:42
-msgid "Mount container volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:43 pkg/kubernetes/views/image-config.html.h:6
-#: pkg/kubernetes/views/container-body.html.h:9
-msgid "Environment"
-msgstr ""
-
-#: pkg/docker/index.html.h:44
-msgid "Set container environment variables"
-msgstr ""
-
-#: pkg/docker/index.html.h:45 pkg/kubernetes/views/pod-body.html.h:4
-msgid "Restart Policy"
-msgstr ""
-
-#: pkg/docker/index.html.h:47
-#, fuzzy
-msgid "On Failure"
-msgstr "실패하였습니다"
-
-#: pkg/docker/index.html.h:50
-msgid "Retries:"
-msgstr ""
-
-#: pkg/docker/index.html.h:51 pkg/users/index.html.h:26
-#: pkg/networkmanager/index.html.h:52
-msgid ""
-"\n"
-"            Cancel\n"
-"          "
-msgstr ""
-"\n"
-"            취소\n"
-"          "
-
-#: pkg/docker/index.html.h:54
-msgid ""
-"\n"
-"            Run\n"
-"          "
-msgstr ""
-"\n"
-"            실행\n"
-"          "
-
-#: pkg/docker/index.html.h:57
-msgid ""
-"\n"
-"            Download\n"
-"          "
-msgstr ""
-"\n"
-"            다운로드\n"
-"          "
-
-#: pkg/docker/index.html.h:60
-msgid ""
-"\n"
-"            Change\n"
-"          "
-msgstr ""
-"\n"
-"            변경\n"
-"          "
-
-#: pkg/docker/index.html.h:63
-msgid "Repository"
-msgstr "리포지터리 "
-
-#: pkg/docker/index.html.h:64
-msgid "Tag"
-msgstr "태그"
-
-#: pkg/docker/index.html.h:65 pkg/kubernetes/views/image-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:5
-msgid "Author"
-msgstr "작성자"
-
-#: pkg/docker/index.html.h:66
-msgid ""
-"\n"
-"            Commit\n"
-"          "
-msgstr ""
-"\n"
-"            커밋\n"
-"          "
-
-#: pkg/users/index.html.h:1
-msgid "Local Accounts"
-msgstr ""
-
-#: pkg/users/index.html.h:2
-#, fuzzy
-msgid ""
-"\n"
-"            Close\n"
-"          "
-msgstr ""
-"\n"
-"              종료\n"
-"            "
-
-#: pkg/users/index.html.h:5
-msgid "Create New Account"
-msgstr ""
-
-#: pkg/users/index.html.h:6
-msgid "Account not available or cannot be edited."
-msgstr ""
-
-#: pkg/users/index.html.h:7
-msgid "Accounts"
-msgstr ""
-
-#: pkg/users/index.html.h:8
-msgid "Terminate Session"
-msgstr ""
-
-#: pkg/users/index.html.h:10
-msgid "Full Name"
-msgstr ""
-
-#: pkg/users/index.html.h:12
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:3
-#: pkg/kubernetes/views/project-body.html.h:2
-msgid "Roles"
-msgstr ""
-
-#: pkg/users/index.html.h:13
-msgid "Last Login"
-msgstr ""
-
-#: pkg/users/index.html.h:14
-msgid "Access"
-msgstr ""
-
-#: pkg/users/index.html.h:15
-msgid "Lock Account"
-msgstr ""
-
-#: pkg/users/index.html.h:17
-msgid "Set Password"
-msgstr ""
-
-#: pkg/users/index.html.h:18
-msgid "Authorized Public SSH Keys"
-msgstr ""
-
-#: pkg/users/index.html.h:20
-msgid ""
-"\n"
-"            Create\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:25
-msgid "Confirm New Password"
-msgstr ""
-
-#: pkg/users/index.html.h:29
-msgid ""
-"\n"
-"            Set\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:32
-msgid "Delete Files"
-msgstr ""
-
-#: pkg/users/index.html.h:33 pkg/networkmanager/index.html.h:48
-msgid ""
-"\n"
-"            Delete\n"
-"          "
-msgstr ""
-"\n"
-"            삭제\n"
-"          "
-
-#: pkg/users/index.html.h:36
-msgid "Unnamed"
-msgstr ""
-
-#: pkg/users/index.html.h:37
-msgid "Invalid key"
-msgstr ""
-
-#: pkg/users/index.html.h:38
-msgid "There are no authorized public keys for this account."
-msgstr ""
-
-#: pkg/users/index.html.h:39
-msgid ""
-"You do not have permission to view the authorized public keys for this "
-"account."
-msgstr ""
-
-#: pkg/users/index.html.h:40
-msgid "Failed to load authorized keys."
-msgstr ""
-
-#: pkg/users/index.html.h:41
-msgid "Add public key"
-msgstr ""
-
-#: pkg/users/index.html.h:42
-msgid ""
-"\n"
-"            Add key\n"
-"          "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:1
-msgid "Diagnostic reports"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:2
-msgid ""
-"\n"
-"        This tool will collect system configuration and diagnostic\n"
-"        information from this system for use with diagnosing problems\n"
-"        with the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:7
-msgid ""
-"\n"
-"        The collected information will be stored locally on the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:10
-msgid "Create report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:11
-msgid "Create diagnostic report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:12
-msgid ""
-"\n"
-"                The generated archive contains data considered\n"
-"                sensitive and its content should be reviewed by the\n"
-"                originating organization before being passed to any\n"
-"                third party.\n"
-"              "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:18
-msgid "Generating report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:19
-msgid "Done!"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:1
-msgid "Networking"
-msgstr "네트워킹"
-
-#: pkg/networkmanager/index.html.h:2
-msgid "Testing connection"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:9
-msgid "Sending"
-msgstr "전송 중입니다"
-
-#: pkg/networkmanager/index.html.h:10
-msgid "Receiving"
-msgstr "수신 중입니다"
-
-#: pkg/networkmanager/index.html.h:11
-msgid "Interfaces"
-msgstr "인터페이스"
-
-#: pkg/networkmanager/index.html.h:12
-msgid "Add Bond"
-msgstr "본드 추가"
-
-#: pkg/networkmanager/index.html.h:13
-#, fuzzy
-msgid "Add Team"
-msgstr "본드 추가"
-
-#: pkg/networkmanager/index.html.h:14
-msgid "Add Bridge"
-msgstr "브릿지 추가"
-
-#: pkg/networkmanager/index.html.h:15
-msgid "Add VLAN"
-msgstr "VLAN 추가"
-
-#: pkg/networkmanager/index.html.h:17
-msgid "IP Address"
-msgstr "IP 주소"
-
-#: pkg/networkmanager/index.html.h:18
-#, fuzzy
-msgid "Unmanaged Interfaces"
-msgstr "인터페이스"
-
-#: pkg/networkmanager/index.html.h:19
-msgid "Networking Logs"
-msgstr "네트워킹 로그"
-
-#: pkg/networkmanager/index.html.h:20
-msgid "Parent"
-msgstr "부모"
-
-#: pkg/networkmanager/index.html.h:21
-msgid "VLAN Id"
-msgstr "VLAN ID"
-
-#: pkg/networkmanager/index.html.h:23
-msgid "Set to"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:25
-msgid "Spanning Tree Protocol (STP)"
-msgstr "Spanning Tree Protocol (STP)"
-
-#: pkg/networkmanager/index.html.h:26
-msgid "STP Priority"
-msgstr "STP 우선순위"
-
-#: pkg/networkmanager/index.html.h:27
-msgid "STP Forward delay"
-msgstr "STP Forward delay"
-
-#: pkg/networkmanager/index.html.h:28
-msgid "STP Hello time"
-msgstr "STP Hello time"
-
-#: pkg/networkmanager/index.html.h:29
-msgid "STP Maximum message age"
-msgstr "STP Maximum message age"
-
-#: pkg/networkmanager/index.html.h:30
-msgid "Priority"
-msgstr "우선순위"
-
-#: pkg/networkmanager/index.html.h:31
-msgid "Path cost"
-msgstr "Path cost"
-
-#: pkg/networkmanager/index.html.h:32
-msgid "Hair Pin mode"
-msgstr "Hair Pin 모드"
-
-#: pkg/networkmanager/index.html.h:34
-msgid "Mode"
-msgstr "모드"
-
-#: pkg/networkmanager/index.html.h:35
-msgid "Primary"
-msgstr "주"
-
-#: pkg/networkmanager/index.html.h:36
-msgid "Link Monitoring"
-msgstr "링크 모니터링"
-
-#: pkg/networkmanager/index.html.h:37
-msgid "Monitoring Interval"
-msgstr "모니터링 주기"
-
-#: pkg/networkmanager/index.html.h:38
-msgid "Monitoring Targets"
-msgstr "모니터링 대상"
-
-#: pkg/networkmanager/index.html.h:39
-msgid "Link up delay"
-msgstr "링크 업 딜레이"
-
-#: pkg/networkmanager/index.html.h:40
-msgid "Link down delay"
-msgstr "링크 다운 딜레이"
-
-#: pkg/networkmanager/index.html.h:41
-#, fuzzy
-msgid "Runner"
-msgstr "작동중"
-
-#: pkg/networkmanager/index.html.h:42
-msgid "Balancer"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:43
-#, fuzzy
-msgid "Link Watch"
-msgstr "로컬 링크"
-
-#: pkg/networkmanager/index.html.h:44
-#, fuzzy
-msgid "Ping Interval"
-msgstr "모니터링 주기"
-
-#: pkg/networkmanager/index.html.h:45
-#, fuzzy
-msgid "Ping Target"
-msgstr "모니터링 대상"
-
-#: pkg/networkmanager/index.html.h:46
-msgid "Sticky"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:47
-msgid "LACP Key"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:51
-msgid "IP Settings"
-msgstr "IP 설정"
-
-#: pkg/networkmanager/index.html.h:55
-msgid ""
-"\n"
-"            Apply\n"
-"          "
-msgstr ""
-"\n"
-"            적용\n"
-"          "
-
-#: pkg/networkmanager/index.html.h:58
-msgid "Bond Settings"
-msgstr "본드 설정"
-
-#: pkg/networkmanager/index.html.h:59
-#, fuzzy
-msgid "Team Settings"
-msgstr "IP 설정"
-
-#: pkg/networkmanager/index.html.h:60
-#, fuzzy
-msgid "Team Port Settings"
-msgstr "브릿지 포트 설정"
-
-#: pkg/networkmanager/index.html.h:61
-msgid "Bridge Settings"
-msgstr "브릿지 설정"
-
-#: pkg/networkmanager/index.html.h:62
-msgid "Bridge Port Settings"
-msgstr "브릿지 포트 설정"
-
-#: pkg/networkmanager/index.html.h:63
-msgid "VLAN Settings"
-msgstr "VLAN 설정"
-
-#: pkg/networkmanager/index.html.h:64
-msgid "Ethernet MTU"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:66
-#, fuzzy
-msgid "Connection will be lost"
-msgstr "본드 설정"
-
-#: pkg/kubernetes/index.html.h:1
-msgid "Kubernetes Cluster"
-msgstr "Kubernetes 클러스터"
-
-#: pkg/kubernetes/index.html.h:3 pkg/kubernetes/views/dashboard-page.html.h:8
-#: pkg/kubernetes/views/nodes-page.html.h:4
-msgid "Nodes"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:5
-msgid "Topology"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:8 pkg/kubernetes/registry.html.h:3
-#: pkg/kubernetes/views/image-listing.html.h:2
-#: pkg/kubernetes/views/imagestream-page.html.h:3
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:5
-msgid "Images"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:9 pkg/kubernetes/registry.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:2
-#: pkg/kubernetes/views/project-listing.html.h:2
-#: pkg/kubernetes/views/user-delete.html.h:2
-msgid "Projects"
+#: pkg/kubernetes/scripts/nodes.js:407
+msgid "The name contains invalid characters"
 msgstr ""
 
-#: pkg/kubernetes/index.html.h:11 pkg/kubernetes/registry.html.h:6
-msgid "Couldn't connect to server"
+#: pkg/kubernetes/views/node-page.html:23
+msgid "The node '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/kubernetes/index.html.h:12 pkg/kubernetes/registry.html.h:7
-msgid ""
-"\n"
-"                Reconnect\n"
-"            "
+#: pkg/kubernetes/views/node-alerts.html:7
+msgid "The node doesn't have enough disk space"
 msgstr ""
-
-#: pkg/kubernetes/index.html.h:15
-#, fuzzy
-msgid ""
-"\n"
-"                Troubleshoot\n"
-"            "
-msgstr ""
-"\n"
-"                도구\n"
-"              "
-
-#: pkg/kubernetes/registry.html.h:1
-msgid "Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:1
-#: pkg/kubernetes/views/service-body.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:1
-#: pkg/kubernetes/views/containers-listing.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:9
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:18
-#: pkg/kubernetes/views/route-body.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:5
-#: pkg/kubernetes/views/imagestream-modify.html.h:4
-msgid "Project"
-msgstr "프로젝트"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:2
-#: pkg/kubernetes/views/service-body.html.h:2
-#: pkg/kubernetes/views/pod-body.html.h:2
-#: pkg/kubernetes/views/containers-listing.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:10
-#: pkg/kubernetes/views/pv-claim.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:19
-#: pkg/kubernetes/views/route-body.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:6
-msgid "Namespace"
-msgstr "네임스페이스"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:3
-#: pkg/kubernetes/views/pod-body.html.h:3
-#: pkg/kubernetes/views/node-body.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:3
-#: pkg/kubernetes/views/route-body.html.h:3
-msgid "Created"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:4
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:17
-msgid "Replicas"
-msgstr "Replicas"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:5
-#: pkg/kubernetes/views/service-body.html.h:9
-#: pkg/kubernetes/views/pod-body.html.h:10
-#: pkg/kubernetes/views/node-body.html.h:12
-#: pkg/kubernetes/views/image-meta.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:8
-#: pkg/kubernetes/views/route-body.html.h:8
-msgid "Labels"
-msgstr ""
-
-#: pkg/kubernetes/views/service-body.html.h:4
-#: pkg/kubernetes/views/node-body.html.h:3
-msgid "IP"
-msgstr ""
-
-#: pkg/kubernetes/views/service-body.html.h:8
-msgid "Session Affinity"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:1
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:10
-msgid "New image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:3
-#: pkg/kubernetes/views/image-body.html.h:10
-#: pkg/kubernetes/views/imagestream-modify.html.h:7
-msgid "Tags"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:5
-msgid "Last Updated"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:6
-msgid "No image streams are present."
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:1
-#, fuzzy
-msgid "Delete Node"
-msgstr "삭제"
-
-#: pkg/kubernetes/views/node-delete.html.h:2
-msgid "Do you want to delete this Node?"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:3
-msgid " 1\">Do you want to delete the following Nodes?"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-container.html.h:1
-#, fuzzy
-msgid "Show all Pod Containers"
-msgstr "컨테이너들"
 
-#: pkg/kubernetes/views/image-panel.html.h:3
-#: pkg/kubernetes/views/imagestream-page.html.h:4
-#: pkg/kubernetes/views/image-page.html.h:4
-msgid "Metadata"
+#: pkg/kubernetes/views/node-alerts.html:11
+msgid "The node doesn't have enough free memory"
 msgstr ""
 
-#: pkg/kubernetes/views/node-panel.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:8
-#: pkg/kubernetes/views/containers-listing.html.h:6
-#: pkg/kubernetes/views/node-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:11
-msgid "Node"
+#: pkg/users/local.js:395 pkg/users/local.js:1082
+msgid "The passwords do not match"
 msgstr ""
 
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:1
-msgid "Show all Replication Controllers"
+#: pkg/lib/credentials.js:186
+msgid "The passwords do not match."
 msgstr ""
 
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:2
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:5
-msgid "Replication Controller"
+#: pkg/kubernetes/views/pv-page.html:21
+msgid "The persistent volume '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:2
-#: pkg/kubernetes/views/pv-claim.html.h:9
-#: pkg/kubernetes/views/dashboard-page.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:18
-msgid "Pods"
+#: pkg/kubernetes/views/pod-page.html:40
+msgid "The pod '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:2
-msgid "Template"
+#: pkg/kubernetes/views/project-page.html:34
+msgid "The project '{{ projName }}' does not exist."
 msgstr ""
 
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:5
+#: pkg/kubernetes/views/replicationcontroller-page.html:30
 msgid "The replication controller '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/kubernetes/views/group-delete.html.h:1
-msgid "Remove Group"
+#: pkg/kubernetes/views/route-page.html:19
+msgid "The route '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/kubernetes/views/group-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:5
-#: pkg/kubernetes/views/user-group-remove.html.h:3
-msgid "Remove"
+#: pkg/kubernetes/scripts/dashboard.js:386
+msgid "The selected file is not a valid Kubernetes application manifest."
+msgstr "선택한 파일은 올바른 Kubernetes 메타데이터 파일이 아닙니다."
+
+#: src/base1/cockpit.js:3695
+msgid "The server refused to authenticate using any supported methods."
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-delete.html.h:1
-msgid "Delete Persistent Volume Claim"
+#: pkg/kubernetes/views/auth-rejected-cert.html:2
+msgid "The server uses a certificate signed by an unknown authority."
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-delete.html.h:2
+#: pkg/kubernetes/views/service-page.html:19
+msgid "The service '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/docker/storage.jsx:355
 msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
+"The storage pool will be reset to optimize its layout.  All containers will "
+"be erased."
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-delete.html.h:3
+#: pkg/kubernetes/views/user-page.html:29
+msgid "The user '{{ userName }}' does not exist."
+msgstr ""
+
+#: pkg/systemd/init.js:834
+#, fuzzy
+msgid "The user <b>$0</b> does not have permissions for creating timers"
+msgstr "사용자 <b>$0</b> 는 서버 관리 권한이 없습니다."
+
+#: pkg/dashboard/list.js:209
+msgid "The user <b>$0</b> is not permitted to manage servers"
+msgstr "사용자 <b>$0</b> 는 서버 관리 권한이 없습니다."
+
+#: pkg/storaged/permissions.js:61
+msgid "The user <b>$0</b> is not permitted to manage storage"
+msgstr ""
+
+#: pkg/users/local.js:40
+msgid "The user <b>$0</b> is not permitted to modify accounts"
+msgstr ""
+
+#: pkg/systemd/host.js:43
+msgid "The user <b>$0</b> is not permitted to modify hostnames"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1420
+msgid "The user <b>$0</b> is not permitted to modify network settings"
+msgstr "사용자 <b>$0</b> 는 네트워크 설정 권한이 없습니다"
+
+#: pkg/realmd/operation.js:436
+msgid "The user <b>$0</b> is not permitted to modify realms"
+msgstr ""
+
+#: pkg/users/local.js:501
+msgid ""
+"The user name can only consist of letters from a-z, digits, dots, dashes and "
+"underscores."
+msgstr ""
+
+#: pkg/users/index.html:332
+msgid "There are no authorized public keys for this account."
+msgstr ""
+
+#: pkg/storaged/details.js:1756
+msgid ""
+"There is not enough free space elsewhere to remove this physical volume.  At "
+"least $0 more free space is needed."
+msgstr ""
+
+#: pkg/storaged/utils.js:168
+msgid "Thin Logical Volume"
+msgstr "Thin 논리 볼륨"
+
+#: pkg/kubernetes/views/pvc-delete.html:8
 msgid ""
 "This claim is in use. Deleting it may cause issues with the following pod:"
 msgstr ""
 
-#: pkg/kubernetes/views/pod-body.html.h:5
-msgid "Service Account"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:6
-msgid "DNS Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:7
-msgid "Phase"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:9
-msgid "Pod Address"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:5
-msgid "OS"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:7
-msgid "Boot ID"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:8
-#, fuzzy
-msgid "Kernel Version"
-msgstr "버전"
-
-#: pkg/kubernetes/views/node-body.html.h:9
-msgid "Container Runtime Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:10
-msgid "Kubelet Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:11
-msgid "Proxy Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:13
-#: pkg/kubernetes/views/route-body.html.h:9
-msgid "none"
-msgstr "없음"
-
-#: pkg/kubernetes/views/node-body.html.h:17
-msgid "Reason"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:18
-#: pkg/kubernetes/views/pv-claim.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:6 pkg/kubernetes/views/pv-body.html.h:6
-msgid "Message"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:19
-msgid "Last Heartbeat"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:20
-msgid "Last Status Change"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:21
-#: pkg/kubernetes/views/image-meta.html.h:3
-#: pkg/kubernetes/views/imagestream-meta.html.h:1
-#: pkg/kubernetes/views/route-body.html.h:10
-msgid "Annotations"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:1
-msgid "Remove Role"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:2
+#: pkg/systemd/init.js:1222
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member "
-"{{ fields.member.metadata.name }}?"
+"This day doesn't exist in all months.<br> The timer will only be executed in "
+"months that have 31st."
 msgstr ""
 
-#: pkg/kubernetes/views/project-listing.html.h:1
-msgid "New Project"
+#: pkg/networkmanager/interfaces.js:2310
+msgid "This device cannot be managed here."
 msgstr ""
 
-#: pkg/kubernetes/views/project-listing.html.h:6
-msgid "No projects are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:7
-msgid "New Group"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:8
-#: pkg/kubernetes/views/user-delete.html.h:3
-msgid "Groups"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:9
-msgid "No groups are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:10
-#: pkg/kubernetes/views/add-user-dialog.html.h:1
-msgid "Add User"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:11
-msgid "Users"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:12
-msgid "Identity"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:13
-msgid "Member of"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:14
-msgid "No users are present."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:1
+#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
 #, fuzzy
-msgid "Cluster"
-msgstr "마스터"
+msgid "This field cannot be empty."
+msgstr "이름을 입력하셔야 합니다."
 
-#: pkg/kubernetes/views/auth-form.html.h:2
-msgid "Add New Cluster"
+#: pkg/storaged/details.js:690
+msgid "This logical volume cannot be made smaller."
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html.h:4
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:3
-msgid "Skip Certificate Verification"
+#: pkg/lib/machine-dialogs.js:364
+msgid "This machine has already been added."
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html.h:5
-#, fuzzy
-msgid "Requires Authentication"
-msgstr "인증 중입니다"
-
-#: pkg/kubernetes/views/auth-form.html.h:7
-msgid "Add New User"
+#: pkg/realmd/operation.html:89
+msgid "This may take a while"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html.h:9
-msgid "Client Certificate"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:10
-#, fuzzy
-msgid "Username"
-msgstr "사용자 이름"
-
-#: pkg/kubernetes/views/auth-form.html.h:12
-msgid "Token"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:1
-msgid "Add Cluster Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:4
-msgid "Configuration"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:5
-msgid "Configure Kubelet and Proxy"
-msgstr "Kubelet 과 프록시 설정"
-
-#: pkg/kubernetes/views/node-add.html.h:6
-msgid "Configure Flannel networking"
-msgstr "Flannel 네트워킹 설정"
-
-#: pkg/kubernetes/views/volume-body.html.h:1
-#: pkg/kubernetes/views/pvc-body.html.h:1
-#, fuzzy
-msgid "Volume Type"
-msgstr "볼륨 그룹 $0"
-
-#: pkg/kubernetes/views/volume-body.html.h:2
-msgid "{{ volume | formatVolumeType }}"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:3
-#, fuzzy
-msgid "PD Name"
-msgstr "이름"
-
-#: pkg/kubernetes/views/volume-body.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:19
-#, fuzzy
-msgid "Filesystem Type"
-msgstr "파일 시스템 옵션"
-
-#: pkg/kubernetes/views/volume-body.html.h:6
-#: pkg/kubernetes/views/pv-modify.html.h:20
-#, fuzzy
-msgid "Read Only"
-msgstr "준비됨"
-
-#: pkg/kubernetes/views/volume-body.html.h:7
-msgid "Volume ID"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:8
-#, fuzzy
-msgid "Repository URL"
-msgstr "리포지터리 "
-
-#: pkg/kubernetes/views/volume-body.html.h:9
-#, fuzzy
-msgid "Revision"
-msgstr "버전"
-
-#: pkg/kubernetes/views/volume-body.html.h:10
-#: pkg/kubernetes/views/image-config.html.h:3
-msgid "Directory"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:12
-msgid "Medium"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:13
-#: pkg/kubernetes/views/pv-modify.html.h:14
-#, fuzzy
-msgid "Path"
-msgstr "Path cost"
-
-#: pkg/kubernetes/views/volume-body.html.h:14
-msgid "Endpoint Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:15
-#: pkg/kubernetes/views/pv-modify.html.h:13
-#, fuzzy
-msgid "Volume Name"
-msgstr "사용자 이름"
-
-#: pkg/kubernetes/views/volume-body.html.h:17
-#, fuzzy
-msgid "Monitors"
-msgstr "ARP 모니터링"
-
-#: pkg/kubernetes/views/volume-body.html.h:18
-#, fuzzy
-msgid "Image Name"
-msgstr "이미지 $0"
-
-#: pkg/kubernetes/views/volume-body.html.h:19
-#, fuzzy
-msgid "Pool Name"
-msgstr "이름"
-
-#: pkg/kubernetes/views/volume-body.html.h:21
-msgid "Key Ring Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:22
-#, fuzzy
-msgid "Secret Volume"
-msgstr "볼륨 그룹 생성"
-
-#: pkg/kubernetes/views/volume-body.html.h:23
-msgid "Target Portal"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:24
-#: pkg/kubernetes/views/pv-modify.html.h:16
-msgid "Qualified Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:25
-#: pkg/kubernetes/views/pv-modify.html.h:17
-#, fuzzy
-msgid "Logical Unit Number"
-msgstr "논리 볼륨"
-
-#: pkg/kubernetes/views/volume-body.html.h:26
-#: pkg/kubernetes/views/pv-modify.html.h:18
-#, fuzzy
-msgid "Interface"
-msgstr "인터페이스"
-
-#: pkg/kubernetes/views/volume-body.html.h:27
-#, fuzzy
-msgid "Ceph Monitors"
-msgstr "리포지터리 "
-
-#: pkg/kubernetes/views/volume-body.html.h:28
-msgid "Secret File"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:29
-msgid "Target World Wide Names"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:30
-msgid "Flocker Dataset Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:31
-msgid "Driver"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:33
-#, fuzzy
-msgid "Share Name"
-msgstr "사용자 이름"
-
-#: pkg/kubernetes/views/volume-body.html.h:34
-#, fuzzy
-msgid "Secret Name"
-msgstr "사용자 이름"
-
-#: pkg/kubernetes/views/image-meta.html.h:2
-msgid "On Build"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:4
-msgid "Docker Version"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:5
-#, fuzzy
-msgid "Image Layers"
-msgstr "이미지 $0"
-
-#: pkg/kubernetes/views/group-page.html.h:1
-#: pkg/kubernetes/views/user-page.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:1
-msgid "Show all Projects"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:2
-#: pkg/kubernetes/views/group-panel.html.h:1
-#, fuzzy
-msgid "Group Members"
-msgstr "맴버"
-
-#: pkg/kubernetes/views/group-page.html.h:3
-#: pkg/kubernetes/views/user-group-add.html.h:1
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:1
-#: pkg/kubernetes/views/group-panel.html.h:2
-#: pkg/kubernetes/views/project-body.html.h:10
-msgid "Add Member"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:4
-msgid "The group '{{ groupName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/containers-listing.html.h:3
-#: pkg/kubernetes/views/pod-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:2
-msgid "Pod"
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:2
-msgid "Membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:2
+#: pkg/kubernetes/views/pv-modify.html:24
 msgid ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
+"This option is for single node testing only – local storage will not work in "
+"a multi-node cluster"
 msgstr ""
 
-#: pkg/kubernetes/views/user-body.html.h:5
-#: pkg/kubernetes/views/user-panel.html.h:7
-#, fuzzy
-msgid "Add Membership"
-msgstr "맴버"
+#: src/bridge/cockpitpackages.c:470
+msgid "This package is not compatible with this version of Cockpit"
+msgstr ""
 
-#: pkg/kubernetes/views/user-group-add.html.h:2
-#, fuzzy
+#: src/bridge/cockpitpackages.c:459
+#, c-format
+msgid "This package requires Cockpit version %s or later"
+msgstr ""
+
+#: pkg/tuned/dialog.js:102
+msgid "This system is using a custom profile"
+msgstr ""
+
+#: pkg/tuned/dialog.js:100
+msgid "This system is using the recommended profile"
+msgstr ""
+
+#: pkg/systemd/init.js:639
+msgid "This unit is an instance of the $0 template."
+msgstr ""
+
+#: pkg/systemd/services.html:302
+msgid "This unit is not designed to be enabled explicitly.          "
+msgstr ""
+
+#: pkg/users/local.js:509
+msgid "This user name already exists"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:380
 msgid ""
-"\n"
-"                        User\n"
-"                    "
-msgstr ""
-"\n"
-"                도구\n"
-"              "
-
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:2
-msgid "User or Group"
+"This version of cockpit-ws does not support connecting to a host with an "
+"alternate user or port"
 msgstr ""
 
-#: pkg/kubernetes/views/pod-panel.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:4
-#, fuzzy
-msgid "Mount Location"
-msgstr "마운트 옵션"
-
-#: pkg/kubernetes/views/route-modify.html.h:1
-msgid "Adjust Route"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:1
-msgid "Show all Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:2 pkg/kubernetes/views/pvc-body.html.h:3
-#: pkg/kubernetes/views/pv-panel.html.h:1
-#, fuzzy
-msgid "Volume"
-msgstr "논리 볼륨"
-
-#: pkg/kubernetes/views/pv-page.html.h:3 pkg/kubernetes/views/pv-panel.html.h:2
-msgid "Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:4
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:1
-msgid "Remove image tag"
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:2
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:1
-msgid "Run as"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:4
-msgid "Stop with"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:1
-msgid "Delete Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:2
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:3
+#: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
 "This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
 "{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
 "may cause issues with any pods depending on it."
 msgstr ""
 
-#: pkg/kubernetes/views/user-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:3
-msgid "Identities"
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:3
-msgid "The user '{{ userName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:1
-msgid "Show all Deployment Configs"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:1
-msgid "Deployment Config"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:4
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/route-panel.html.h:1
-#: pkg/kubernetes/views/route-page.html.h:2
-msgid "Route"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:1
-#, fuzzy
-msgid "Register New Volume"
-msgstr "논리 볼륨 크기 조정"
-
-#: pkg/kubernetes/views/volumes-page.html.h:2
-msgid "Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:7
-msgid "No volumes are present."
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:8
-msgid "Pending Volume Claims"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:12
-msgid "When"
-msgstr ""
-
-#: pkg/kubernetes/views/user-delete.html.h:1
-msgid "Remove User"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:3
-#: pkg/kubernetes/views/pv-modify.html.h:10
-#: pkg/kubernetes/views/pvc-body.html.h:7 pkg/kubernetes/views/pv-body.html.h:2
-msgid "Access Modes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:4
-msgid "Requests"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:5
+#: pkg/kubernetes/views/pv-claim.html:23
 msgid "This volume has not been claimed"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-claim.html.h:10
-msgid "No Pods are using this claim"
+#: pkg/systemd/index.html:379
+msgid "Time Zone"
 msgstr ""
 
-#: pkg/kubernetes/views/filter-project.html.h:1
-msgid "All Projects"
+#: pkg/systemd/services.html:55
+msgid "Timers"
 msgstr ""
 
-#: pkg/kubernetes/views/filter-project.html.h:2
-msgid "Project:"
+#: pkg/kubernetes/views/image-body.html:33
+msgid "To pull this image:"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:5
-#: pkg/kubernetes/views/details-page.html.h:14
-msgid "Latest Version"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:6
-msgid "Deployment Causes"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:7
-msgid "Triggers"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:1
-msgid "Delete {{ item.kind }}"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:2
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:3
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:2
-#: pkg/kubernetes/views/user-modify.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:2
-msgid ""
-"\n"
-"                        Name\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:5
-#: pkg/kubernetes/views/user-modify.html.h:5
-msgid ""
-"\n"
-"                        Identity\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:1
-msgid "Project Members"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:3
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:6
-msgid "Admin"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:7
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/container-panel.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:3
-msgid "Shell"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:1
-msgid "Pod Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:2
-msgid "No pods selected"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:3
-msgid "Pod Selector"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:1
-msgid "Add membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:2
-#, fuzzy
-msgid ""
-"\n"
-"                        Group or Project\n"
-"                    "
-msgstr ""
-"\n"
-"              재연결 시도\n"
-"            "
-
-#: pkg/kubernetes/views/user-add-membership.html.h:5
-#, fuzzy
-msgid ""
-"\n"
-"                        Role\n"
-"                    "
-msgstr ""
-"\n"
-"                도구\n"
-"              "
-
-#: pkg/kubernetes/views/deploy.html.h:1
-msgid "Deploy Application"
-msgstr "어플리케이션 사용"
-
-#: pkg/kubernetes/views/deploy.html.h:3
-msgid "{{ selected.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:5
-#: pkg/kubernetes/views/dashboard-page.html.h:11
-msgid "Deploy"
-msgstr ""
-
-#: pkg/kubernetes/views/user-modify.html.h:1
-msgid "Change User"
-msgstr ""
-
-#: pkg/kubernetes/views/user-modify.html.h:9
-msgid "Modify"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:1
-#: pkg/kubernetes/views/project-modify.html.h:6
-msgid "Access Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:2
-msgid ""
-"\n"
-"          Images may be pulled by anonymous users\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:5
-msgid ""
-"\n"
-"          Images may be pulled by any authenticated user or group\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:8
-msgid ""
-"\n"
-"          Images may only be pulled by specific users or groups\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:11
-msgid "Pull repository"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:13
-msgid "Image count"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:14
-msgid "{{stream.status.tags.length}}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:15
+#: pkg/kubernetes/views/imagestream-body.html:39
 msgid "To push to an image to this image stream:"
 msgstr ""
 
-#: pkg/kubernetes/views/node-alerts.html.h:1
-msgid "The node doesn't have enough disk space"
+#: pkg/lib/machine-change-port.html:11
+msgid ""
+"To try a different port you will need to upgrade cockpit-ws to a newer "
+"version."
 msgstr ""
 
-#: pkg/kubernetes/views/node-alerts.html.h:2
-msgid "The node doesn't have enough free memory"
+#: pkg/kubernetes/views/auth-form.html:116
+msgid "Token"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html.h:1
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+#: pkg/kubernetes/index.html:57
+msgid "Topology"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html.h:2
-msgid "Register Persistent Volume"
+#: pkg/docker/storage.jsx:314
+msgid "Total"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html.h:4
+#: pkg/ostree/index.html:99
+msgid "Tree"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:32
+msgid "Triggers"
+msgstr ""
+
+#: pkg/shell/index.html:328 pkg/shell/stub.html:181
+msgid "Troubleshoot"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:21
+msgid "Trust this certificate for this connection"
+msgstr ""
+
+#: pkg/systemd/init.js:520
+msgid "Try Restart"
+msgstr ""
+
+#: pkg/docker/index.html:71 pkg/docker/index.html:74
+msgid "Try again"
+msgstr "다시 시도"
+
+#: pkg/systemd/index.html:59
+msgid "Trying to synchronize with {{Server}}"
+msgstr ""
+
+#: pkg/tuned/dialog.js:262
+msgid "Tuned has failed to start"
+msgstr ""
+
+#: pkg/tuned/dialog.js:94
+msgid "Tuned is not available"
+msgstr ""
+
+#: pkg/tuned/dialog.js:96
+msgid "Tuned is not running"
+msgstr ""
+
+#: pkg/tuned/dialog.js:98
+msgid "Tuned is off"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/pv-modify.html:10
+#: pkg/kubernetes/views/volumes-page.html:20 pkg/kubernetes/views/deploy.html:9
+msgid "Type"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:7
+msgid "Type:"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:110
+msgid "URL"
+msgstr ""
+
+#: pkg/storaged/index.html:547 pkg/storaged/index.html:626
+msgctxt "storage"
+msgid "UUID"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:114
+msgid "Unable to apply this solution automatically"
+msgstr ""
+
+#: pkg/ostree/index.html:219
+msgid "Unable to communicate with OSTree"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:195
+#, fuzzy
+msgid "Unable to connect"
+msgstr "재연결"
+
+#: pkg/kubernetes/scripts/dashboard.js:413
+msgid "Unable to decode Kubernetes application manifest."
+msgstr ""
+
+#: pkg/users/local.js:57
+msgid "Unable to delete root account"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:157
+msgid "Unable to get alert"
+msgstr ""
+
+#: pkg/storaged/overview.js:586
+msgid "Unable to reach server"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:401
+msgid "Unable to read the Kubernetes application manifest. Code $0."
+msgstr "Kubernetes 어플리케이션  manifest를 읽을 수 없습니다. 코드 $0."
+
+#: pkg/users/local.js:59
+msgid "Unable to rename root account"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:172
+msgid "Unable to run fix"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:52
+msgid "Unable to start setroubleshootd"
+msgstr ""
+
+#: pkg/playground/translate.html:35 pkg/playground/translate.html:40
+#, fuzzy
+msgid "Unavailable"
+msgstr "사용할 수 없습니다"
+
+#: pkg/docker/index.html:763 pkg/networkmanager/index.html:792
+msgid "Unexpected error"
+msgstr "예상치 못한 오류"
+
+#: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/image-body.html:15
+#: pkg/kubernetes/views/pv-claim.html:31 pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
+msgid "Unknown"
+msgstr "알 수 없음"
+
+#: pkg/storaged/details.js:1597
+msgid "Unknown ($0)"
+msgstr ""
+
+#: pkg/lib/machine-unknown-hostkey.html:2
+msgid "Unknown Host Key"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2342
+msgid "Unknown configuration"
+msgstr "알 수 없는 설정"
+
+#: pkg/storaged/overview.js:582
+msgid "Unknown host name"
+msgstr ""
+
+#: pkg/docker/index.html:570
+#, fuzzy
+msgid "Unless Stopped"
+msgstr "정지됨"
+
+#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
+#: pkg/storaged/details.js:1110
+msgid "Unlock"
+msgstr "잠금 해제"
+
+#: pkg/shell/index.html:220
+msgid "Unlock Key"
+msgstr ""
+
+#: pkg/storaged/jobs.js:121
+msgid "Unlocking $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:108
+#, fuzzy
+msgid "Unmanaged Interfaces"
+msgstr "인터페이스"
+
+#: pkg/systemd/init.js:548
+msgid "Unmask"
+msgstr ""
+
+#: pkg/storaged/details.js:1100
+msgid "Unmount"
+msgstr ""
+
+#: pkg/storaged/jobs.js:127
+msgid "Unmounting $target"
+msgstr ""
+
+#: pkg/users/index.html:315
+msgid "Unnamed"
+msgstr ""
+
+#: pkg/storaged/details.js:1256
+msgctxt "storage-id-desc"
+msgid "Unrecognized Data"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:148
+msgid "Unregister"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:154
+msgid "Unregistering system..."
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
+#: src/bridge/cockpitdbussetup.c:625
+msgid "Unsupported setup mechanism"
+msgstr ""
+
+#: src/base1/cockpit.js:3697
+msgid "Untrusted host"
+msgstr ""
+
+#: pkg/docker/util.js:94
+msgid "Up since $StartedAt"
+msgstr "$StartedAt 부터 켜져있음"
+
+#: pkg/lib/machine-change-port.html:41
+msgid "Update"
+msgstr ""
+
+#: pkg/ostree/index.html:125 pkg/ostree/index.html:152
+msgid "Updates"
+msgstr ""
+
+#: pkg/ostree/index.html:96
+msgid "Updating"
+msgstr ""
+
+#: pkg/kubernetes/scripts/details.js:655
+msgid "Updating $0..."
+msgstr "$0 업데이트 중..."
+
+#: pkg/shell/index.html:165
+msgid "Use my password for privileged tasks and to connect to other machines"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:132
+msgid "Use proxy server"
+msgstr ""
+
+#: pkg/shell/index.html:172
+msgid "Use the following keys to authenticate against other systems"
+msgstr ""
+
+#: pkg/systemd/index.html:251
+msgid "Used"
+msgstr ""
+
+#: pkg/systemd/index.html:229 pkg/dashboard/index.html:158
+#: pkg/playground/translate.html:86 pkg/playground/translate.html:106
+#: pkg/kubernetes/views/user-panel.html:9
+#: pkg/kubernetes/views/auth-form.html:61
+#: pkg/kubernetes/views/volume-body.html:64
+#: pkg/kubernetes/views/volume-body.html:103
+msgid "User"
+msgstr ""
+
+#: pkg/users/index.html:90 pkg/users/index.html:154
+#: pkg/realmd/operation.html:47
+msgid "User Name"
+msgstr "사용자 이름"
+
+#: pkg/realmd/operation.html:53
+msgid "User Password"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:18
+msgid "User name"
+msgstr ""
+
+#: pkg/kubernetes/views/add-member-role-dialog.html:15
+msgid "User or Group"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:94
+#, fuzzy
+msgid "Username"
+msgstr "사용자 이름"
+
+#: pkg/kubernetes/views/project-listing.html:85
+msgid "Users"
+msgstr ""
+
+#: pkg/storaged/details.js:181
+msgid "VFAT - Compatible with all systems and devices"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
+#: pkg/networkmanager/interfaces.js:2622
+msgid "VLAN"
+msgstr "VLAN"
+
+#: pkg/networkmanager/index.html:141
+msgid "VLAN Id"
+msgstr "VLAN ID"
+
+#: pkg/networkmanager/index.html:736
+msgid "VLAN Settings"
+msgstr "VLAN 설정"
+
+#: pkg/users/authorized-keys.js:103
+msgid "Validating key"
+msgstr ""
+
+#: pkg/systemd/index.html:98 pkg/ostree/index.html:113 pkg/shell/simple.html:77
+#: pkg/shell/index.html:90 pkg/shell/stub.html:83
+msgid "Version"
+msgstr "버전"
+
+#: pkg/storaged/jobs.js:137
+msgid "Very securely erasing $target"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
+#: pkg/kubernetes/views/pvc-body.html:6
+#, fuzzy
+msgid "Volume"
+msgstr "논리 볼륨"
+
+#: pkg/storaged/index.html:620
+msgid "Volume Group"
+msgstr ""
+
+#: pkg/storaged/utils.js:239
+msgid "Volume Group $0"
+msgstr "볼륨 그룹 $0"
+
+#: pkg/storaged/index.html:98
+msgid "Volume Groups"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:14
+#: pkg/kubernetes/views/volume-body.html:89
+msgid "Volume ID"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:115
+#: pkg/kubernetes/views/volume-body.html:42
+#, fuzzy
+msgid "Volume Name"
+msgstr "사용자 이름"
+
+#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
+#, fuzzy
+msgid "Volume Type"
+msgstr "볼륨 그룹 $0"
+
+#: pkg/docker/index.html:536 pkg/kubernetes/views/pod-page.html:18
+#: pkg/kubernetes/views/image-config.html:28
+#: pkg/kubernetes/views/dashboard-page.html:47 pkg/kubernetes/index.html:70
+msgid "Volumes"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:819
+msgid "Waiting"
+msgstr "대기 중입니다"
+
+#: pkg/kubernetes/views/pv-modify.html:24
 #, fuzzy
 msgid "Warning:"
 msgstr "파티션"
 
-#: pkg/kubernetes/views/pv-modify.html.h:5
+#: pkg/systemd/logs.html:48
+msgid "Warnings"
+msgstr ""
+
+#: pkg/systemd/services.html:409
+msgid "Weeks"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:5
+msgid "Welcome to the Image Registry"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:61
+msgid "When"
+msgstr ""
+
+#: pkg/docker/index.html:507
+msgid "With terminal"
+msgstr "터미널 실행"
+
+#: pkg/storaged/index.html:438
+#, fuzzy
+msgctxt "storage"
+msgid "World Wide Name"
+msgstr "사용자 이름"
+
+#: pkg/storaged/details.js:1595
+msgid "Write-mostly"
+msgstr ""
+
+#: pkg/storaged/index.html:333
+msgid "Writing"
+msgstr ""
+
+#: pkg/ostree/client.js:64
+msgid "Writing objects"
+msgstr ""
+
+#: pkg/storaged/details.js:177
+msgid "XFS - Red Hat Enterprise Linux 7 default"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1824
+msgid "XOR"
+msgstr "XOR"
+
+#: pkg/kubernetes/scripts/volumes.js:990 pkg/networkmanager/interfaces.js:2279
+msgid "Yes"
+msgstr "네"
+
+#: pkg/lib/machine-sync-users.html:47
 msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
+"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
+"synchronize users, a user with superuser privileges is required."
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html.h:7
-#: pkg/kubernetes/views/node-page.html.h:3
-#: pkg/kubernetes/views/pvc-body.html.h:10
-#: pkg/kubernetes/views/pv-body.html.h:3
-msgid "Capacity"
-msgstr ""
+#: pkg/dashboard/list.js:394
+msgid ""
+"You are currently connected directly to this server. You cannot delete it."
+msgstr "현재 직접적으로 이 서버에 연결되어 있습니다. 삭제하실 수 없습니다."
 
-#: pkg/kubernetes/views/pv-modify.html.h:8
-#: pkg/kubernetes/views/pv-body.html.h:1
-msgid "Reclaim Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:9
-msgid "{{ value }}"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:12
-msgid "Endpoint"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:15
-msgid "Target"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-dialog.html.h:1
-#, fuzzy
-msgid "Connection Settings"
-msgstr "본드 설정"
-
-#: pkg/kubernetes/views/auth-dialog.html.h:2
-#, fuzzy
-msgid "Connection Error"
-msgstr "Docker에 연결중입니다."
-
-#: pkg/kubernetes/views/image-body.html.h:2
-msgid "Summary"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:4
-msgid "Source URL"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:7
-msgid "Built"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:8
-msgid "Digest"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:9
-msgid "Identifier"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:11
-msgid "To pull this image:"
-msgstr ""
-
-#: pkg/kubernetes/views/service-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:8
-#: pkg/kubernetes/views/service-page.html.h:2
-msgid "Service"
-msgstr ""
-
-#: pkg/kubernetes/views/service-panel.html.h:2
-#: pkg/kubernetes/views/service-page.html.h:3
-msgid "Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:1
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:2
+#: pkg/kubernetes/views/auth-rejected-cert.html:3
 msgid ""
 "You can bypass the certificate check, but any data you send to the server "
 "could be intercepted by others."
 msgstr ""
 
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:4
-msgid "Trust this certificate for this connection"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:1
-msgid "Show all Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:7
-msgid "The pod '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:1
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:1
-msgid "Delete image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:2
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:2
-#, fuzzy
-msgid "All running"
-msgstr "작동중"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:3
-msgid "No pods deployed"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:5
-msgid "All in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:6
-msgid "No volumes in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:7
-msgid "pending volume claims"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:9
-msgid "All healthy"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:10
-msgid "No nodes in cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:13
-msgid "Could not list services"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:14
+#: pkg/kubernetes/views/dashboard-page.html:150
 msgid "You can deploy an application to your cluster."
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-page.html.h:1
-msgid "Show all image streams"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-page.html.h:2
-msgid "Image Stream"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:3
-msgid "Image ID"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:4
-msgid "Container ID"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:7
-msgid "Since"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:8
-msgid "Restart Count"
-msgstr ""
-
-#: pkg/kubernetes/views/user-remove-membership.html.h:1
-msgid "Remove membership"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:1
-msgid "Delete Selected"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:2
-#, fuzzy
-msgid "OS Versions"
-msgstr "버전"
-
-#: pkg/kubernetes/views/nodes-page.html.h:3
-#, fuzzy
-msgid "Add Kubernetes Node"
-msgstr "Kubernetes 클러스터"
-
-#: pkg/kubernetes/views/project-page.html.h:3
-msgid "The project '{{ projName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/user-panel.html.h:4
+#: pkg/lib/machine-invalid-hostkey.html:11
 msgid ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
+"You can remove the previously stored key by running the following command"
 msgstr ""
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:1
-msgid "Pod Replicated"
-msgstr ""
+#: pkg/shell/base_index.js:672
+msgid "You can try restarting Cockpit by pressing refresh in your browser. "
+msgstr "브라우저의 새로고침을 눌러 Cockpit을 다시 시작하실 수 있습니다."
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:2
-msgid "No pods replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/container-page.html.h:1
-#, fuzzy
-msgid "Show all Containers"
-msgstr "컨테이너들"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:1
-msgid "Welcome to the Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:2
+#: pkg/users/index.html:335
 msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
+"You do not have permission to view the authorized public keys for this "
+"account."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:1
-msgid "New project"
+#: pkg/docker/storage.jsx:482
+msgid "You don't have permission to manage the Docker storage pool."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:4
-msgid "Images by project"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:6
-msgid "Images pushed recently"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:7
-msgid "All images"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:8
-msgid "No images pushed"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:9
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:11
-msgid "Login commands"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:12
-msgid "Log into the registry:"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:13
+#: pkg/kubernetes/views/registry-dashboard-page.html:112
 msgid ""
 "Your login credentials do not give you access to use the docker registry "
 "from the command line."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:14
-msgid "Log into OpenShift command line tools:"
+#: src/base1/cockpit.js:3687
+msgid "Your session has been terminated."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:15
+#: src/base1/cockpit.js:3689
+msgid "Your session has expired. Please log in again."
+msgstr ""
+
+#: pkg/lib/journal.js:213
+msgid "[$0 bytes of binary data]"
+msgstr ""
+
+#: pkg/lib/journal.js:215
+msgid "[binary data]"
+msgstr ""
+
+#: pkg/lib/journal.js:209
+msgid "[no data]"
+msgstr ""
+
+#: pkg/storaged/details.js:1692
+msgid "active, but unsupported"
+msgstr ""
+
+#: pkg/storaged/utils.js:88
+msgctxt "format-bytes"
+msgid "bytes"
+msgstr "바이트"
+
+#: pkg/docker/util.js:123
+msgid "default"
+msgstr "기본"
+
+#: pkg/storaged/details.js:178
+msgid "ext4 - Red Hat Enterprise Linux 6 default"
+msgstr ""
+
+#: pkg/systemd/host.js:661
 #, fuzzy
-msgid "Image commands"
-msgstr "이미지 $0"
+msgid "failed to list ssh host keys: $0"
+msgstr " Docker 실행을 실패하였습니다: $0"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:16
-msgid "Push an image:"
+#: pkg/storaged/index.html:135
+msgid "iSCSI Targets"
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:17
-msgid "Pull an image:"
+#: pkg/storaged/details.js:1692
+msgid "inactive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html.h:1
-msgid "Show all Nodes"
+#: pkg/storaged/details.js:1286
+msgid "locked"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html.h:4
-msgid "The node '{{ target }}' does not exist."
+#: pkg/storaged/details.js:1278
+msgid "mounted on $0"
 msgstr ""
 
-#: pkg/kubernetes/views/route-page.html.h:1
-msgid "Show all Routes"
-msgstr ""
-
-#: pkg/kubernetes/views/route-page.html.h:3
-msgid "The route '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:1
-msgid "Select an object to see more details."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:3
-msgid ""
-"Pods contain one or more containers that run\n"
-"                together on a node, containing your application code."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:6
-msgid ""
-"Replication controllers dynamically create instances of\n"
-"                pods from templates, and remove pods when necessary."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:9
-msgid ""
-"Services group pods and provide a common DNS\n"
-"                name and an optional, load-balanced IP address to access "
-"them."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:12
-msgid "Nodes are the machines that run your containers."
-msgstr ""
-
-#: pkg/kubernetes/views/add-group-dialog.html.h:1
-msgid "Add Group"
-msgstr ""
-
-#: pkg/kubernetes/views/file-button.html.h:1
-msgid "Select Manifest File..."
-msgstr "manifest을 선택하세요..."
-
-#: pkg/kubernetes/views/project-modify.html.h:2
-msgid "Change project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-modify.html.h:4
-msgid "Display name"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:5
-msgid "TLS Termination"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:6
-msgid "yes"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:7
+#: pkg/kubernetes/views/route-body.html:14
 msgid "no"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:1
+#: pkg/kubernetes/views/route-body.html:24
+#: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
+msgid "none"
+msgstr "없음"
+
+#: pkg/storaged/details.js:1280
+msgid "not mounted"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:83
+msgid "pending volume claims"
+msgstr ""
+
+#: pkg/tuned/change-profile.jsx:52
 #, fuzzy
-msgid "Add Role"
-msgstr "본드 추가"
+msgid "recommended"
+msgstr "MII (권장 사항)"
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:2
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#: pkg/docker/index.html:426
+msgid "select container"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:1
-msgid "All Types"
+#: pkg/docker/index.html:504 pkg/docker/index.html:683
+#, fuzzy
+msgid "shares"
+msgstr "$0 공유"
+
+#: pkg/selinux/setroubleshoot-view.jsx:118
+msgid "solution details"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:2
-msgid "Type:"
+#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
+#, fuzzy
+msgid "unknown"
+msgstr "알 수 없음"
+
+#: pkg/storaged/jobs.js:180
+msgid "unknown target"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:13
-msgid "Deployment Configs"
+#: pkg/storaged/details.js:1284
+msgid "unlocked"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:15
-msgid "Not deployed"
+#: pkg/kubernetes/views/route-body.html:13
+msgid "yes"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:16
-msgid "Replication Controllers"
-msgstr ""
-
-#: pkg/kubernetes/views/service-modify.html.h:1
-msgid "Adjust Service"
-msgstr "서비스 조정"
-
-#: pkg/kubernetes/views/service-modify.html.h:3
+#: pkg/kubernetes/views/service-modify.html:16
 msgid "{{ item.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:5
-msgid "Adjust"
-msgstr "조정"
+#: pkg/kubernetes/views/deploy.html:27
+msgid "{{ selected.name }}"
+msgstr ""
 
-#: pkg/kubernetes/views/project-delete.html.h:1
+#: pkg/kubernetes/views/pv-modify.html:61
+#: pkg/kubernetes/views/pv-modify.html:74
+msgid "{{ value }}"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:2
+msgid "{{ volume | formatVolumeType }}"
+msgstr ""
+
+#: pkg/storaged/index.html:147
+msgid "{{Address}}:{{Port}}"
+msgstr ""
+
+#: pkg/docker/index.html:435
+msgid "{{alias_label}}"
+msgstr "{{alias_label}}"
+
+#: pkg/systemd/services.html:173 pkg/systemd/services.html:202
+msgid "{{days_text}}"
+msgstr ""
+
+#: pkg/docker/index.html:403
 #, fuzzy
-msgid "Delete Project"
-msgstr "프로젝트"
+msgid "{{envvar_key_label}}"
+msgstr "{{alias_label}}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:2
+#: pkg/docker/index.html:407
 #, fuzzy
-msgid "Claim Name"
-msgstr "컨테이너 이름"
+msgid "{{envvar_value_label}}"
+msgstr "{{alias_label}}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:4
+#: pkg/docker/index.html:359
+msgid "{{host_port_label}}"
+msgstr "{{host_port_label}}"
+
+#: pkg/docker/index.html:373
 #, fuzzy
-msgid "No Volume Bound"
-msgstr "볼륨 그룹 $0"
+msgid "{{host_volume_label}}"
+msgstr "{{host_port_label}}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:8
-msgid "Requested"
+#: pkg/kubernetes/views/imagestream-body.html:35
+msgid "{{stream.status.tags.length}}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:9
-msgid "Actual"
-msgstr ""
-
-#: pkg/kubernetes/views/node-capacity.html.h:1
-msgid "Scheduled Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/node-capacity.html.h:2
-msgid "No pods scheduled"
-msgstr ""
-
-#: pkg/kubernetes/views/container-page-inline.html.h:4
-msgid "The container '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:1
-msgid "Create image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:2
-msgid "Change image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:5
-msgid "Populate"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:6
-msgid "Pull from"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:8
-msgid "Remote registry is insecure"
-msgstr ""
-
-#: pkg/kubernetes/views/user-group-remove.html.h:1
 #, fuzzy
-msgid "Remove Member"
-msgstr "맴버"
+#~ msgid "Image Layers Example"
+#~ msgstr "이미지 $0"
 
-#: pkg/kubernetes/views/service-page.html.h:1
-msgid "Show all Services"
-msgstr ""
-
-#: pkg/kubernetes/views/service-page.html.h:4
-msgid "The service '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/scripts/frob-layers.html.h:1
 #, fuzzy
-msgid "Image Layers Example"
-msgstr "이미지 $0"
+#~ msgid "Cockpit Monitoring"
+#~ msgstr "링크 모니터링"
 
-#: pkg/playground/service.html.h:1
-msgid "Cockpit Generic Service Monitor"
-msgstr ""
-
-#: pkg/playground/jquery-patterns.html.h:1
-msgid "Cockpit Pattern Usage"
-msgstr ""
-
-#: pkg/playground/metrics.html.h:1
 #, fuzzy
-msgid "Cockpit Monitoring"
-msgstr "링크 모니터링"
-
-#: pkg/playground/test.html.h:1 pkg/playground/translate.html.h:1
-msgid "Cockpit playground"
-msgstr ""
-
-#: pkg/playground/react-patterns.html.h:1
-msgid "Cockpit React Patterns Usage"
-msgstr ""
-
-#: pkg/playground/speed.html.h:1
-msgid "Cockpit Speed Tests"
-msgstr ""
-
-#: pkg/playground/plot.html.h:1
-#, fuzzy
-msgid "Cockpit Plots"
-msgstr "Cockpit"
-
-#: pkg/dashboard/index.html.h:1
-msgid "Dashboard"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:5
-#, fuzzy
-msgid "Disk I/O"
-msgstr "디스크 추가"
-
-#: pkg/dashboard/index.html.h:6
-msgid "Lost connection. Trying to reconnect"
-msgstr "연결이 끓어졌습니다. 다시 시도 하는 중입니다."
-
-#: pkg/dashboard/index.html.h:10
-msgid "Avatar"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:13
-msgid "Set"
-msgstr ""
+#~ msgid "Cockpit Plots"
+#~ msgstr "Cockpit"
 
 #~ msgid "Run image"
 #~ msgstr "이미지 실행"
@@ -6279,26 +6367,6 @@ msgstr ""
 #~ "\n"
 #~ "              새로운 이미지 구하기\n"
 #~ "            "
-
-#, fuzzy
-#~ msgid ""
-#~ "\n"
-#~ "                    Activation Key\n"
-#~ "                  "
-#~ msgstr ""
-#~ "\n"
-#~ "                도구\n"
-#~ "              "
-
-#, fuzzy
-#~ msgid ""
-#~ "\n"
-#~ "                    Organization\n"
-#~ "                  "
-#~ msgstr ""
-#~ "\n"
-#~ "                도구\n"
-#~ "              "
 
 #~ msgid ""
 #~ "WARNING: Docker may be reporting the size it has allocated to it's "

--- a/po/pl.po
+++ b/po/pl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-17 19:28+0100\n"
+"POT-Creation-Date: 2016-11-18 06:44+0100\n"
 "PO-Revision-Date: 2016-09-05 12:46-0400\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,182 +21,527 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Zanata 3.9.6\n"
 
-#: src/ws/cockpitcertificate.c:359
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr "Nie można odszyfrować klucza prywatnego zakodowanego jako PEM"
-
-#: src/ws/cockpitcertificate.c:364
-msgid "No PEM-encoded private key found"
-msgstr "Nie odnaleziono klucza prywatnego zakodowanego jako PEM"
-
-#: src/ws/cockpitcertificate.c:374
-msgid "Could not parse PEM-encoded private key"
-msgstr "Nie można przetworzyć klucza prywatnego zakodowanego jako PEM"
-
-#: src/ws/cockpitcertificate.c:398
-msgid "No PEM-encoded certificate found"
-msgstr "Nie odnaleziono certyfikatu zakodowanego jako PEM"
-
-#: src/ws/cockpitcertificate.c:407
-msgid "Could not parse PEM-encoded certificate"
-msgstr "Nie można przetworzyć certyfikatu zakodowanego jako PEM"
-
-#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
-#: src/bridge/cockpitdbussetup.c:625
+#: pkg/shell/index.html:227
 #, fuzzy
-msgid "Unsupported setup mechanism"
-msgstr "Nieobsługiwany mechanizm ustawiania: %s"
+msgid "                                                Comment                                            "
+msgstr ""
+"\n"
+"                                    Nieprawidłowa strefa czasowa\n"
+"                                "
 
-#: src/bridge/cockpitdbussetup.c:236
-msgid "Couldn't list users"
-msgstr "Nie można wyświetlić listy użytkowników"
+#: pkg/shell/index.html:235
+#, fuzzy
+msgid "                                                Fingerprint                                            "
+msgstr ""
+"\n"
+"                                    Nieprawidłowa strefa czasowa\n"
+"                                "
 
-#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
-msgid "Bad data passed for passwd1 mechanism"
-msgstr "Przekazano błędne dane dla mechanizmu passwd1"
+#: pkg/shell/index.html:231
+#, fuzzy
+msgid "                                                Type                                            "
+msgstr ""
+"\n"
+"                                    Nieprawidłowa strefa czasowa\n"
+"                                "
 
-#: src/bridge/cockpitdbussetup.c:382
-msgid "Couldn't load user data"
-msgstr "Nie można wczytać danych użytkownika"
+#: pkg/systemd/index.html:389
+#, fuzzy
+msgid ""
+"                                    Invalid time "
+"zone                                "
+msgstr ""
+"\n"
+"                                    Nieprawidłowa strefa czasowa\n"
+"                                "
 
-#: src/bridge/cockpitdbussetup.c:467
-msgid "Couldn't change user groups"
-msgstr "Nie można zmienić grup użytkownika"
+#: pkg/kubernetes/views/project-body.html:80
+#, fuzzy
+msgid ""
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}                                "
+msgstr ""
+"\n"
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}\n"
+"                                "
 
-#: src/bridge/cockpitdbussetup.c:520
-msgid "Couldn't change user password"
-msgstr "Nie można zmienić hasła użytkownika"
+#: pkg/kubernetes/views/user-body.html:22
+#, fuzzy
+msgid ""
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}                                "
+msgstr ""
+"\n"
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}\n"
+"                                "
 
-#: src/bridge/cockpitdbussetup.c:544
-msgid "Couldn't create new users"
-msgstr "Nie można utworzyć nowych użytkowników"
+#: pkg/kubernetes/views/user-panel.html:39
+#, fuzzy
+msgid ""
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}                            "
+msgstr ""
+"\n"
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}\n"
+"                            "
 
-#: src/bridge/cockpitdbussetup.c:642
-msgid "Couldn't list local users"
-msgstr "Nie można wyświetlić listy lokalnych użytkowników"
+#: pkg/kubernetes/views/project-body.html:37
+#, fuzzy
+msgid ""
+"                                {{ getRegistryRoles(user, project())."
+"join() }}                            "
+msgstr ""
+"\n"
+"                                {{ getRegistryRoles(user, project())."
+"join() }}\n"
+"                            "
 
-#: src/bridge/cockpitpackages.c:459
-#, c-format
-msgid "This package requires Cockpit version %s or later"
+#: pkg/systemd/index.html:485 pkg/systemd/index.html:504
+#, fuzzy
+msgid "                        Cancel                    "
+msgstr ""
+"\n"
+"                        Anuluj\n"
+"                    "
+
+#: pkg/kubernetes/views/user-add-membership.html:9
+#, fuzzy
+msgid "                        Group or Project                    "
+msgstr ""
+"\n"
+"                        Grupa lub projekt\n"
+"                    "
+
+#: pkg/kubernetes/views/add-user-dialog.html:19
+#: pkg/kubernetes/views/user-modify.html:19
+#, fuzzy
+msgid "                        Identity                    "
+msgstr ""
+"\n"
+"                        Tożsamość\n"
+"                    "
+
+#: pkg/kubernetes/views/add-user-dialog.html:9
+#: pkg/kubernetes/views/user-modify.html:9
+#: pkg/kubernetes/views/add-group-dialog.html:9
+#, fuzzy
+msgid "                        Name                    "
+msgstr ""
+"\n"
+"                        Nazwa\n"
+"                    "
+
+#: pkg/kubernetes/views/user-add-membership.html:30
+#, fuzzy
+msgid "                        Role                    "
+msgstr ""
+"\n"
+"                        Rola\n"
+"                    "
+
+#: pkg/kubernetes/views/user-group-add.html:9
+#, fuzzy
+msgid "                        User                    "
+msgstr ""
+"\n"
+"                        Użytkownik\n"
+"                    "
+
+#: pkg/ostree/index.html:88
+#, fuzzy
+msgid "                    Available                  "
+msgstr ""
+"\n"
+"                    Dostępne\n"
+"                  "
+
+#: pkg/ostree/index.html:85
+#, fuzzy
+msgid "                    Default                  "
+msgstr ""
+"\n"
+"                    Domyślne\n"
+"                  "
+
+#: pkg/ostree/index.html:223
+#, fuzzy
+msgid "                    Reconnect                "
+msgstr ""
+"\n"
+"                    Połącz ponownie\n"
+"                "
+
+#: pkg/ostree/index.html:135
+#, fuzzy
+msgid ""
+"                    This deployment contains the same packages as your "
+"currently booted system                "
+msgstr ""
+"\n"
+"                    To wdrożenie zawiera takie same pakiety, co obecnie "
+"uruchomiony system\n"
+"                "
+
+#: pkg/ostree/index.html:67
+#, fuzzy
+msgid "                    Update and reboot                "
+msgstr ""
+"\n"
+"                    Zaktualizuj i uruchom ponownie\n"
+"                "
+
+#: pkg/kubernetes/registry.html:74 pkg/kubernetes/index.html:104
+#, fuzzy
+msgid "                Reconnect            "
+msgstr ""
+"\n"
+"                Połącz ponownie\n"
+"            "
+
+#: pkg/sosreport/index.html:57
+#, fuzzy
+msgid ""
+"                The generated archive contains data "
+"considered                sensitive and its content should be reviewed by "
+"the                originating organization before being passed to "
+"any                third party.              "
+msgstr ""
+"\n"
+"                Utworzone archiwum zawiera dane uważane za\n"
+"                prywatne, więc jego zawartość powinna zostać przejrzana\n"
+"                przez pierwotną organizację, zanim zostanie ono przekazane\n"
+"                jakiejkolwiek stronie trzeciej.\n"
+"              "
+
+#: pkg/shell/index.html:304 pkg/shell/stub.html:157
+#, fuzzy
+msgid "                Tools              "
+msgstr ""
+"\n"
+"                Narzędzia\n"
+"              "
+
+#: pkg/kubernetes/index.html:107
+#, fuzzy
+msgid "                Troubleshoot            "
+msgstr ""
+"\n"
+"                Rozwiąż problem\n"
+"            "
+
+#: pkg/shell/simple.html:105 pkg/shell/index.html:126 pkg/shell/stub.html:119
+#: pkg/storaged/index.html:862
+#, fuzzy
+msgid "              Cancel            "
+msgstr ""
+"\n"
+"              Anuluj\n"
+"            "
+
+#: pkg/shell/index.html:147 pkg/shell/stub.html:140
+#, fuzzy
+msgid "              Close            "
+msgstr ""
+"\n"
+"              Zamknij\n"
+"            "
+
+#: pkg/shell/simple.html:70 pkg/shell/index.html:83 pkg/shell/stub.html:76
+#, fuzzy
+msgid ""
+"              Cockpit is an interactive Linux server admin "
+"interface.            "
+msgstr ""
+"\n"
+"              Cockpit to interaktywny interfejs do administrowania serwerami "
+"Linux.\n"
+"            "
+
+#: pkg/shell/simple.html:79 pkg/shell/index.html:92 pkg/shell/stub.html:85
+#, fuzzy
+msgid "              Licensed under the GNU LGPL version 2.1            "
+msgstr ""
+"\n"
+"                    Login\n"
+"                  "
+
+#: pkg/shell/simple.html:129
+#, fuzzy
+msgid "              Log in again            "
+msgstr ""
+"\n"
+"              Zaloguj ponownie\n"
+"            "
+
+#: pkg/shell/simple.html:73 pkg/shell/index.html:86 pkg/shell/stub.html:79
+#, fuzzy
+msgid "              Project website            "
+msgstr ""
+"\n"
+"              Zamknij\n"
+"            "
+
+#: pkg/shell/simple.html:108 pkg/shell/index.html:129 pkg/shell/stub.html:122
+#, fuzzy
+msgid "              Select            "
+msgstr ""
+"\n"
+"              Wybierz\n"
+"            "
+
+#: pkg/shell/simple.html:126
+#, fuzzy
+msgid "              Try to reconnect            "
+msgstr ""
+"\n"
+"              Spróbuj połączyć ponownie\n"
+"            "
+
+#: pkg/users/index.html:361
+#, fuzzy
+msgid "            Add key          "
+msgstr ""
+"\n"
+"            Dodaj klucz\n"
+"          "
+
+#: pkg/networkmanager/index.html:582 pkg/networkmanager/index.html:610
+#: pkg/networkmanager/index.html:638 pkg/networkmanager/index.html:666
+#: pkg/networkmanager/index.html:694 pkg/networkmanager/index.html:722
+#: pkg/networkmanager/index.html:750 pkg/networkmanager/index.html:778
+#, fuzzy
+msgid "            Apply          "
+msgstr ""
+"\n"
+"            Zastosuj\n"
+"          "
+
+#: pkg/users/index.html:269 pkg/users/index.html:297 pkg/users/index.html:358
+#: pkg/docker/index.html:584 pkg/docker/index.html:622
+#: pkg/docker/index.html:688 pkg/docker/index.html:744
+#: pkg/docker/index.html:790 pkg/networkmanager/index.html:579
+#: pkg/networkmanager/index.html:607 pkg/networkmanager/index.html:635
+#: pkg/networkmanager/index.html:663 pkg/networkmanager/index.html:691
+#: pkg/networkmanager/index.html:719 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:775
+#, fuzzy
+msgid "            Cancel          "
+msgstr ""
+"\n"
+"            Anuluj\n"
+"          "
+
+#: pkg/docker/index.html:691
+#, fuzzy
+msgid "            Change          "
+msgstr ""
+"\n"
+"            Zmień\n"
+"          "
+
+#: pkg/users/index.html:45
+#, fuzzy
+msgid "            Close          "
+msgstr ""
+"\n"
+"            Zamknij\n"
+"          "
+
+#: pkg/docker/index.html:747
+#, fuzzy
+msgid "            Commit          "
+msgstr ""
+"\n"
+"            Zatwierdzenie\n"
+"          "
+
+#: pkg/users/index.html:207
+#, fuzzy
+msgid "            Create          "
+msgstr ""
+"\n"
+"            Utwórz\n"
+"          "
+
+#: pkg/users/index.html:300 pkg/networkmanager/index.html:533
+#, fuzzy
+msgid "            Delete          "
+msgstr ""
+"\n"
+"            Usuń\n"
+"          "
+
+#: pkg/docker/index.html:625
+#, fuzzy
+msgid "            Download          "
+msgstr ""
+"\n"
+"            Pobierz\n"
+"          "
+
+#: pkg/docker/index.html:587
+#, fuzzy
+msgid "            Run          "
+msgstr ""
+"\n"
+"            Uruchom\n"
+"          "
+
+#: pkg/users/index.html:272
+#, fuzzy
+msgid "            Set          "
+msgstr ""
+"\n"
+"            Ustaw\n"
+"          "
+
+#: pkg/kubernetes/views/imagestream-body.html:14
+#, fuzzy
+msgid "          Images may be pulled by anonymous users        "
+msgstr ""
+"\n"
+"          Obrazy mogą być pobierane przez wszystkich uwierzytelnionych "
+"użytkowników i grupy\n"
+"        "
+
+#: pkg/kubernetes/views/imagestream-body.html:20
+#, fuzzy
+msgid ""
+"          Images may be pulled by any authenticated user or group        "
+msgstr ""
+"\n"
+"          Obrazy mogą być pobierane przez wszystkich uwierzytelnionych "
+"użytkowników i grupy\n"
+"        "
+
+#: pkg/kubernetes/views/imagestream-body.html:26
+#, fuzzy
+msgid "          Images may only be pulled by specific users or groups        "
+msgstr ""
+"\n"
+"          Obrazy mogą być pobierane tylko przez podanych użytkowników "
+"i grupy\n"
+"        "
+
+#: pkg/kubernetes/views/image-body.html:9
+#, fuzzy
+msgid "         {{ labels.url }}    "
+msgstr ""
+"\n"
+"            Anuluj\n"
+"          "
+
+#: pkg/kubernetes/views/project-body.html:2
+msgid ""
+"        Project access policy allows anonymous users to pull images. Grant "
+"additional push or admin access to specific members below.    "
 msgstr ""
 
-#: src/bridge/cockpitpackages.c:470
-msgid "This package is not compatible with this version of Cockpit"
+#: pkg/kubernetes/views/project-body.html:7
+msgid ""
+"        Project access policy allows any authenticated user to pull images. "
+"Grant additional push or admin access to specific members below.    "
 msgstr ""
 
-#: src/base1/cockpit.js:2586
-msgid "$0 killed with signal $1"
-msgstr "$0 zostało zakończone z sygnałem $1"
-
-#: src/base1/cockpit.js:2588
-msgid "$0 exited with code $1"
-msgstr "$0 zakończyło działanie z kodem $1"
-
-#: src/base1/cockpit.js:2590
-msgid "$0 failed"
-msgstr "$0 się nie powiodło"
-
-#: src/base1/cockpit.js:3667
-msgid "Your session has been terminated."
-msgstr "Sesja została zakończona."
-
-#: src/base1/cockpit.js:3669
-msgid "Your session has expired. Please log in again."
-msgstr "Sesja wygasła. Proszę zalogować się ponownie."
-
-#: src/base1/cockpit.js:3671
-msgid "Not permitted to perform this action."
-msgstr "Brak uprawnień do wykonania tego działania."
-
-#: src/base1/cockpit.js:3673
-msgid "Login failed"
-msgstr "Logowanie się nie powiodło"
-
-#: src/base1/cockpit.js:3675
-msgid "The server refused to authenticate using any supported methods."
+#: pkg/kubernetes/views/project-body.html:12
+msgid ""
+"        Project access policy only allows specific members to access images. "
+"Grant access to specific members below.    "
 msgstr ""
-"Serwer odmówił uwierzytelnienia za pomocą wszystkich obsługiwanych metod."
 
-#: src/base1/cockpit.js:3677
-msgid "Untrusted host"
-msgstr "Niezaufany komputer"
-
-#: src/base1/cockpit.js:3679
-msgid "Host key is incorrect"
-msgstr "Klucz komputera jest niepoprawny"
-
-#: src/base1/cockpit.js:3681
-msgid "Internal error"
-msgstr "Wewnętrzny błąd"
-
-#: src/base1/cockpit.js:3683
-msgid "Connection has timed out."
-msgstr "Połączenie przekroczyło czas oczekiwania."
-
-#: src/base1/cockpit.js:3685
-msgid "Cockpit is not installed on the system."
-msgstr "Cockpit nie jest zainstalowany w systemie."
-
-#: src/base1/cockpit.js:3687
-msgid "Cannot forward login credentials"
-msgstr "Nie można przekazać danych uwierzytelniania logowania"
-
-#: src/base1/cockpit.js:3689
-msgid "Server has closed the connection."
-msgstr "Serwer zamknął połączenie."
-
-#: src/base1/cockpit.js:3691
-msgid "Cockpit is not compatible with the software on the system."
-msgstr "Cockpit nie jest zgodny z oprogramowaniem w systemie."
-
-#: src/base1/cockpit.js:3693
-msgid "Cockpit could not contact the given host."
-msgstr "Cockpit nie może skontaktować się z podanym komputerem."
-
-#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:19
+#: pkg/sosreport/index.html:39
 #, fuzzy
-msgid "Control"
-msgstr "Kontener"
+msgid ""
+"        The collected information will be stored locally on the system.      "
+msgstr ""
+"\n"
+"        Zebrane informacje będą przechowywane lokalnie w systemie.\n"
+"      "
 
-#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
-#: pkg/playground/translate.js:22
+#: pkg/storaged/index.html:51
 #, fuzzy
-msgctxt "key"
-msgid "Control"
-msgstr "Kontener"
+msgid ""
+"        There are devices with multiple paths on the system, but the "
+"multipath service is not running.      "
+msgstr ""
+"\n"
+"        W systemie obecne są urządzenia z wieloma ścieżkami, ale usługa "
+"urządzeń wielościeżkowych nie jest uruchomiona.\n"
+"      "
 
-#: src/base1/test-locale.js:46 src/base1/test-locale.js:56
-#: pkg/playground/translate.js:10
-msgid "Empty"
-msgstr "Puste"
-
-#: src/base1/test-locale.js:47 src/base1/test-locale.js:58
-#: pkg/playground/translate.js:16
+#: pkg/sosreport/index.html:34
 #, fuzzy
-msgctxt "verb"
-msgid "Empty"
-msgstr "Puste"
+msgid ""
+"        This tool will collect system configuration and diagnostic        "
+"information from this system for use with diagnosing problems        with "
+"the system.      "
+msgstr ""
+"\n"
+"        To narzędzie zbierze konfigurację systemu i informacje\n"
+"        diagnostyczne z tego systemu do użycia w diagnozowaniu problemów\n"
+"        z systemem.\n"
+"      "
 
-#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
-#: src/base1/test-locale.js:66 pkg/storaged/details.js:1557
-#: pkg/playground/translate.js:25 pkg/playground/translate.js:28
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] "Brak $0 dysku"
-msgstr[1] "Brak $0 dysków"
-msgstr[2] "Brak $0 dysków"
+#: pkg/docker/storage.jsx:242
+msgid " (shared with the OS)"
+msgstr ""
 
-#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
-#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
-#: pkg/playground/translate.js:34
+#: pkg/kubernetes/views/node-delete.html:8
 #, fuzzy
-msgctxt "disk-non-rotational"
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] "Brak $0 dysku"
-msgstr[1] "Brak $0 dysków"
-msgstr[2] "Brak $0 dysków"
+msgid " 1\"Do you want to delete the following Nodes?"
+msgstr " 1\">Usunąć poniższe węzły?"
+
+#: pkg/storaged/overview.js:253
+msgid "$0 Block Device"
+msgstr "Urządzenie blokowe $0"
+
+#: pkg/storaged/details.js:1546
+msgid "$0 Chunk Size"
+msgstr "Rozmiar bloku: $0"
+
+#: pkg/storaged/details.js:1544
+msgid "$0 Disks"
+msgstr "Dyski: $0"
+
+#: pkg/storaged/details.js:1387
+msgid "$0 Extended Partition"
+msgstr "Rozszerzona partycja $0"
+
+#: pkg/storaged/details.js:1221
+msgctxt "storage-id-desc"
+msgid "$0 File System"
+msgstr "System plików $0"
+
+#: pkg/storaged/details.js:1375
+msgid "$0 Free Space"
+msgstr "Wolne miejsce: $0"
+
+#: pkg/storaged/details.js:1367
+msgid "$0 Free Space for Logical Partitions"
+msgstr "Wolne miejsce dla partycji logicznych: $0"
+
+#: pkg/storaged/details.js:1711
+msgid "$0 Free Space for Logical Volumes"
+msgstr "Wolne miejsce dla woluminów logicznych: $0"
+
+#: pkg/storaged/details.js:1370
+msgid "$0 Free Space for Primary Partitions"
+msgstr "Wolne miejsce dla głównych partycji: $0"
+
+#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
+msgid "$0 Template"
+msgstr "Szablon $0"
+
+#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+msgid "$0 bit"
+msgid_plural "$0 bits"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/base1/test-locale.js:73 src/base1/test-locale.js:74
 #: src/base1/test-locale.js:86 src/base1/test-locale.js:87
@@ -216,582 +561,44 @@ msgstr[0] "bajtów"
 msgstr[1] "bajtów"
 msgstr[2] "bajtów"
 
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
-msgid "$0 bit"
-msgid_plural "$0 bits"
+#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
+#: src/base1/test-locale.js:66 pkg/playground/translate.js:25
+#: pkg/playground/translate.js:28 pkg/storaged/details.js:1557
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] "Brak $0 dysku"
+msgstr[1] "Brak $0 dysków"
+msgstr[2] "Brak $0 dysków"
+
+#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
+#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
+#: pkg/playground/translate.js:34
+#, fuzzy
+msgctxt "disk-non-rotational"
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] "Brak $0 dysku"
+msgstr[1] "Brak $0 dysków"
+msgstr[2] "Brak $0 dysków"
+
+#: src/base1/cockpit.js:2588
+msgid "$0 exited with code $1"
+msgstr "$0 zakończyło działanie z kodem $1"
+
+#: src/base1/cockpit.js:2590
+msgid "$0 failed"
+msgstr "$0 się nie powiodło"
+
+#: src/base1/cockpit.js:2586
+msgid "$0 killed with signal $1"
+msgstr "$0 zostało zakończone z sygnałem $1"
+
+#: pkg/selinux/setroubleshoot-view.jsx:440
+msgid "$0 occurrence"
+msgid_plural "$1 occurrences"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
-
-#: pkg/systemd/host.js:43
-msgid "The user <b>$0</b> is not permitted to modify hostnames"
-msgstr ""
-"Użytkownik <b>$0</b> nie posiada zezwolenia na modyfikowanie nazw komputerów"
-
-#: pkg/systemd/host.js:559
-msgid "Set Host name"
-msgstr "Ustaw nazwę komputera"
-
-#: pkg/systemd/host.js:661
-msgid "failed to list ssh host keys: $0"
-msgstr "wyświetlenie listy kluczy SSH komputera się nie powiodło: $0"
-
-#: pkg/systemd/host.js:1113
-msgid "Need at least one NTP server"
-msgstr "Wymagany jest co najmniej jeden serwer NTP"
-
-#: pkg/systemd/host.js:1190
-msgid "Invalid date format and invalid time format"
-msgstr "Nieprawidłowy format daty i nieprawidłowy format czasu"
-
-#: pkg/systemd/host.js:1192
-msgid "Invalid time format"
-msgstr "Nieprawidłowy format czasu"
-
-#: pkg/systemd/host.js:1194
-msgid "Invalid date format"
-msgstr "Nieprawidłowy format daty"
-
-#: pkg/systemd/host.js:1250
-msgid "NTP Server"
-msgstr "Serwer NTP"
-
-#: pkg/systemd/host.js:1300
-msgid "Message to logged in users"
-msgstr "Wiadomość do zalogowanych użytkowników"
-
-#: pkg/systemd/host.js:1307 pkg/systemd/host.js:1309
-#: pkg/systemd/index.html.h:19
-msgid "Shutdown"
-msgstr "Wyłącz"
-
-#: pkg/systemd/host.js:1311 pkg/systemd/host.js:1313 pkg/systemd/init.js:517
-#: pkg/systemd/index.html.h:18
-msgid "Restart"
-msgstr "Uruchom ponownie"
-
-#: pkg/systemd/host.js:1381
-msgctxt "page-title"
-msgid "CPU Status"
-msgstr "Stan procesora"
-
-#: pkg/systemd/host.js:1413 pkg/systemd/index.html.h:24
-msgid "I/O Wait"
-msgstr "Oczekiwanie wejścia/wyjścia"
-
-#: pkg/systemd/host.js:1414 pkg/systemd/index.html.h:25
-msgid "Kernel"
-msgstr "Jądro"
-
-#: pkg/systemd/host.js:1415 pkg/subscriptions/subscriptions-register.jsx:76
-#: pkg/systemd/index.html.h:26 pkg/kubernetes/views/auth-form.html.h:6
-#: pkg/kubernetes/views/volume-body.html.h:20
-#: pkg/kubernetes/views/user-panel.html.h:1 pkg/playground/translate.html.h:3
-#: pkg/dashboard/index.html.h:8
-msgid "User"
-msgstr "Użytkownik"
-
-#: pkg/systemd/host.js:1416 pkg/systemd/index.html.h:27
-msgid "Nice"
-msgstr "Nice"
-
-#: pkg/systemd/host.js:1466
-msgctxt "page-title"
-msgid "Memory"
-msgstr "Pamięć"
-
-#: pkg/systemd/host.js:1499 pkg/systemd/index.html.h:28
-msgid "Swap Used"
-msgstr "Używana przestrzeń wymiany"
-
-#: pkg/systemd/host.js:1500 pkg/systemd/index.html.h:29
-msgid "Cached"
-msgstr "W pamięci podręcznej"
-
-#: pkg/systemd/host.js:1501 pkg/docker/storage.jsx:313
-#: pkg/kubernetes/scripts/nodes.js:828 pkg/kubernetes/scripts/nodes.js:837
-#: pkg/systemd/index.html.h:30
-msgid "Used"
-msgstr "Używane"
-
-#: pkg/systemd/host.js:1502 pkg/docker/storage.jsx:298
-#: pkg/docker/storage.jsx:320 pkg/systemd/index.html.h:31
-msgid "Free"
-msgstr "Wolne"
-
-#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
-msgid "unknown"
-msgstr "nieznane"
-
-#: pkg/systemd/init.js:269 pkg/systemd/services.html.h:17
-#: pkg/kubernetes/views/project-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:5
-msgid "Description"
-msgstr "Opis"
-
-#: pkg/systemd/init.js:270
-msgid "Id"
-msgstr "Identyfikator"
-
-#: pkg/systemd/init.js:272
-msgid "Next Run"
-msgstr "Następne uruchomienie"
-
-#: pkg/systemd/init.js:273
-msgid "Last Trigger"
-msgstr "Ostatnio wyzwolono"
-
-#: pkg/systemd/init.js:274 pkg/kubernetes/views/container-body.html.h:6
-#: pkg/kubernetes/views/details-page.html.h:8
-msgid "State"
-msgstr "Stan"
-
-#: pkg/systemd/init.js:301
-msgid "Enabled"
-msgstr "Włączone"
-
-#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
-msgid "Disabled"
-msgstr "Wyłączone"
-
-#: pkg/systemd/init.js:303
-msgid "Static"
-msgstr "Statyczne"
-
-#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
-msgid "$0 Template"
-msgstr "Szablon $0"
-
-#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
-msgid "Start"
-msgstr "Rozpocznij"
-
-#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
-msgid "Stop"
-msgstr "Zatrzymaj"
-
-#: pkg/systemd/init.js:518
-msgid "Reload"
-msgstr "Wczytaj ponownie"
-
-#: pkg/systemd/init.js:519
-msgid "Reload or Restart"
-msgstr "Wczytaj lub uruchom ponownie"
-
-#: pkg/systemd/init.js:520
-msgid "Try Restart"
-msgstr "Spróbuj uruchomić ponownie"
-
-#: pkg/systemd/init.js:521
-msgid "Reload or Try Restart"
-msgstr "Wczytaj ponownie lub spróbuj uruchomić ponownie"
-
-#: pkg/systemd/init.js:522
-msgid "Isolate"
-msgstr "Izoluj"
-
-#: pkg/systemd/init.js:541
-msgid "Enable"
-msgstr "Włącz"
-
-#: pkg/systemd/init.js:542
-msgid "Enable Forcefully"
-msgstr "Wymuś włączenie"
-
-#: pkg/systemd/init.js:543
-msgid "Disable"
-msgstr "Wyłącz"
-
-#: pkg/systemd/init.js:544
-msgid "Preset"
-msgstr "Ustaw wstępnie"
-
-#: pkg/systemd/init.js:545
-msgid "Preset Forcefully"
-msgstr "Wymuś ustawienie wstępne"
-
-#: pkg/systemd/init.js:546
-msgid "Mask"
-msgstr "Maskuj"
-
-#: pkg/systemd/init.js:547
-msgid "Mask Forcefully"
-msgstr "Wymuś maskowanie"
-
-#: pkg/systemd/init.js:548
-msgid "Unmask"
-msgstr "Anuluj maskowanie"
-
-#: pkg/systemd/init.js:621
-msgid "Since $0"
-msgstr "Od $0"
-
-#: pkg/systemd/init.js:639
-msgid "This unit is an instance of the $0 template."
-msgstr "Ta jednostka jest wystąpieniem szablonu $0."
-
-#: pkg/systemd/init.js:834
-#, fuzzy
-msgid "The user <b>$0</b> does not have permissions for creating timers"
-msgstr "Użytkownik <b>$0</b> nie posiada zezwolenia na zarządzanie serwerami"
-
-#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
-#, fuzzy
-msgid "This field cannot be empty."
-msgstr "Nazwa nie może być pusta."
-
-#: pkg/systemd/init.js:1147
-msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
-msgstr ""
-
-#: pkg/systemd/init.js:1169
-#, fuzzy
-msgid "Invalid number."
-msgstr "Nieprawidłowy klucz"
-
-#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
-msgid "Hour needs to be a number between 0-23"
-msgstr ""
-
-#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
-msgid "Minute needs to be a number between 0-59"
-msgstr ""
-
-#: pkg/systemd/init.js:1218
-#, fuzzy
-msgid "Invalid date format."
-msgstr "Nieprawidłowy format daty"
-
-#: pkg/systemd/init.js:1222
-msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
-msgstr ""
-
-#: pkg/systemd/logs.js:69
-msgid "Load earlier entries"
-msgstr "Wczytaj wcześniejsze wpisy"
-
-#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
-#: pkg/systemd/logs.js:175
-msgid "Loading..."
-msgstr "Wczytywanie…"
-
-#: pkg/systemd/logs.js:130
-msgid "Go to"
-msgstr "Przejdź do"
-
-#: pkg/systemd/logs.js:257
-msgid "Journal entry"
-msgstr "Wpis dziennika"
-
-#: pkg/systemd/logs.js:284
-msgid "Journal entry not found"
-msgstr "Nie odnaleziono wpisu dziennika"
-
-#: pkg/tuned/dialog.js:94
-msgid "Tuned is not available"
-msgstr "tuned jest niedostępne"
-
-#: pkg/tuned/dialog.js:96
-msgid "Tuned is not running"
-msgstr "tuned nie jest uruchomione"
-
-#: pkg/tuned/dialog.js:98
-msgid "Tuned is off"
-msgstr "tuned jest wyłączone"
-
-#: pkg/tuned/dialog.js:100
-msgid "This system is using the recommended profile"
-msgstr "Ten system używa zalecanego profilu"
-
-#: pkg/tuned/dialog.js:102
-msgid "This system is using a custom profile"
-msgstr "Ten system używa niestandardowego profilu"
-
-#: pkg/tuned/dialog.js:114
-msgid "Communication with tuned has failed"
-msgstr "Komunikacja z tuned się nie powiodła"
-
-#: pkg/tuned/dialog.js:133
-msgid "Failed to disable tuned profile"
-msgstr "Wyłączenie profilu tuned się nie powiodło"
-
-#: pkg/tuned/dialog.js:145
-msgid "Failed to switch profile"
-msgstr "Przełączenie profilu się nie powiodło"
-
-#: pkg/tuned/dialog.js:169
-msgid "Failed to enable tuned"
-msgstr "Włączenie tuned się nie powiodło"
-
-#: pkg/tuned/dialog.js:171
-msgid "Failed to disable tuned"
-msgstr "Wyłączenie tuned się nie powiodło"
-
-#: pkg/tuned/dialog.js:191
-msgid "Change Performance Profile"
-msgstr "Zmień profil wydajności"
-
-#: pkg/tuned/dialog.js:200
-msgid "Change Profile"
-msgstr "Zmień profil"
-
-#: pkg/tuned/dialog.js:233 pkg/kubernetes/views/service-body.html.h:7
-#: pkg/kubernetes/views/pod-panel.html.h:2
-#: pkg/kubernetes/views/image-config.html.h:8
-#: pkg/kubernetes/views/imagestream-body.html.h:12
-#: pkg/kubernetes/views/pod-page.html.h:5
-msgid "None"
-msgstr "Brak"
-
-#: pkg/tuned/dialog.js:234
-msgid "Disable tuned"
-msgstr "Wyłącz tuned"
-
-#: pkg/tuned/dialog.js:262
-msgid "Tuned has failed to start"
-msgstr "Uruchomienie tuned się nie powiodło"
-
-#: pkg/tuned/change-profile.jsx:52
-#, fuzzy
-msgid "recommended"
-msgstr "MII (zalecane)"
-
-#: pkg/lib/journal.js:209
-msgid "[no data]"
-msgstr "[brak danych]"
-
-#: pkg/lib/journal.js:213
-msgid "[$0 bytes of binary data]"
-msgstr "[$0 bajtów danych binarnych]"
-
-#: pkg/lib/journal.js:215
-msgid "[binary data]"
-msgstr "[dane binarne]"
-
-#: pkg/lib/journal.js:241
-msgid "Reboot"
-msgstr "Uruchom ponownie"
-
-#: pkg/lib/machine-dialogs.js:364
-msgid "This machine has already been added."
-msgstr "Ten komputer został już dodany."
-
-#: pkg/lib/machine-dialogs.js:380
-msgid ""
-"This version of cockpit-ws does not support connecting to a host with an "
-"alternate user or port"
-msgstr ""
-"Ta wersja cockpit-ws nie obsługuje łączenia z komputerem z alternatywnym "
-"użytkownikiem lub portem"
-
-#: pkg/lib/machine-dialogs.js:386
-msgid "The IP address or host name cannot contain whitespace."
-msgstr "Adres IP lub nazwa komputera nie może zawierać spacji."
-
-#: pkg/lib/machine-dialogs.js:412
-msgid "Failed to add machine: $0"
-msgstr "Dodanie komputera się nie powiodło: $0"
-
-#: pkg/lib/machine-dialogs.js:429
-msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
-msgstr ""
-"Cockpit nie może skontaktować się z podanym komputerem $0. Proszę się "
-"upewnić, że ma on uruchomioną usługę ssh na porcie $1 lub podać inny port "
-"w adresie."
-
-#: pkg/lib/machine-dialogs.js:447
-msgid "Enter IP address or host name"
-msgstr "Proszę podać adres IP lub nazwę komputera"
-
-#: pkg/lib/machine-dialogs.js:494
-msgid "Failed to edit machine: $0"
-msgstr "Modyfikacja komputera się nie powiodła: $0"
-
-#: pkg/lib/cockpit-components-dialog.jsx:136 pkg/sosreport/index.js:55
-#: pkg/systemd/services.html.h:34 pkg/lib/machine-sync-users.html.h:7
-#: pkg/lib/machine-add.html.h:5 pkg/lib/machine-change-port.html.h:6
-#: pkg/lib/machine-change-auth.html.h:11 pkg/storaged/index.html.h:22
-#: pkg/realmd/operation.html.h:10 pkg/kubernetes/views/node-delete.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:3
-#: pkg/kubernetes/views/pvc-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:3
-#: pkg/kubernetes/views/auth-form.html.h:13
-#: pkg/kubernetes/views/node-add.html.h:7
-#: pkg/kubernetes/views/user-group-add.html.h:5
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:4
-#: pkg/kubernetes/views/route-modify.html.h:3
-#: pkg/kubernetes/views/image-delete.html.h:3
-#: pkg/kubernetes/views/pv-delete.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:4
-#: pkg/kubernetes/views/item-delete.html.h:4
-#: pkg/kubernetes/views/add-user-dialog.html.h:8
-#: pkg/kubernetes/views/user-add-membership.html.h:8
-#: pkg/kubernetes/views/deploy.html.h:4
-#: pkg/kubernetes/views/user-modify.html.h:8
-#: pkg/kubernetes/views/pv-modify.html.h:21
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:5
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:3
-#: pkg/kubernetes/views/imagestream-delete.html.h:3
-#: pkg/kubernetes/views/user-remove-membership.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:7
-#: pkg/kubernetes/views/add-role-dialog.html.h:3
-#: pkg/kubernetes/views/service-modify.html.h:4
-#: pkg/kubernetes/views/project-delete.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:9
-#: pkg/kubernetes/views/user-group-remove.html.h:2
-#: pkg/playground/translate.html.h:2 pkg/dashboard/index.html.h:12
-msgid "Cancel"
-msgstr "Anuluj"
-
-#: pkg/lib/cockpit-components-dialog.jsx:155
-msgid "Ok"
-msgstr ""
-
-#: pkg/lib/credentials.js:182
-msgid "No such file or directory"
-msgstr "Nie ma takiego pliku lub katalogu"
-
-#: pkg/lib/credentials.js:186
-msgid "The passwords do not match."
-msgstr "Hasła się nie zgadzają."
-
-#: pkg/lib/credentials.js:191
-msgid "Prompting via ssh-keygen timed out"
-msgstr "Pytanie przez ssh-keygen przekroczyło czas oczekiwania"
-
-#: pkg/lib/credentials.js:213 pkg/users/local.js:78
-msgid "Old password not accepted"
-msgstr "Nie przyjęto poprzedniego hasła"
-
-#: pkg/lib/credentials.js:223 pkg/users/local.js:112 pkg/users/local.js:144
-msgid "Failed to change password"
-msgstr "Zmiana hasła się nie powiodła"
-
-#: pkg/lib/credentials.js:231 pkg/users/local.js:120
-msgid "New password was not accepted"
-msgstr "Nie przyjęto nowego hasła"
-
-#: pkg/lib/credentials.js:248
-msgid "Not a valid private key"
-msgstr "Nieprawidłowy klucz prywatny"
-
-#: pkg/lib/credentials.js:251
-msgid "Prompting via ssh-add timed out"
-msgstr "Pytanie przez ssh-add przekroczyło czas oczekiwania"
-
-#: pkg/lib/credentials.js:274
-msgid "Invalid file permissions"
-msgstr "Nieprawidłowe uprawnienia pliku"
-
-#: pkg/lib/credentials.js:278
-msgid "Password not accepted"
-msgstr "Nie przyjęto hasła"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:22
-#: pkg/shell/index.html.h:27 pkg/storaged/index.html.h:52
-#: pkg/playground/jquery-patterns.html.h:2
-msgid "On"
-msgstr "Włączone"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:23
-#: pkg/shell/index.html.h:28 pkg/storaged/index.html.h:53
-#: pkg/playground/jquery-patterns.html.h:3
-msgid "Off"
-msgstr "Wyłączone"
-
-#: pkg/shell/base_index.js:670 pkg/users/local.js:1164
-#: pkg/docker/index.html.h:69 pkg/networkmanager/index.html.h:65
-msgid "Unexpected error"
-msgstr "Nieoczekiwany błąd"
-
-#: pkg/shell/base_index.js:671
-msgid "Cockpit had an unexpected internal error. <br/><br/>"
-msgstr "Wystąpił nieoczekiwany wewnętrzny błąd w programie Cockpit. <br/><br/>"
-
-#: pkg/shell/base_index.js:672
-msgid "You can try restarting Cockpit by pressing refresh in your browser. "
-msgstr ""
-"Można spróbować ponownie uruchomić program Cockpit przez odświeżenie strony "
-"w przeglądarce. "
-
-#: pkg/shell/base_index.js:673
-msgid "The javascript console contains details about this error "
-msgstr "Konsola języka JavaScript zawiera informacje o tym błędzie "
-
-#: pkg/shell/base_index.js:674
-msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
-msgstr "(<b>Ctrl-Shift-J</b> w większości przeglądarek)."
-
-#: pkg/shell/indexes.js:126 pkg/shell/indexes.js:497 pkg/shell/simple.html.h:17
-msgid "Disconnected"
-msgstr "Rozłączono"
-
-#: pkg/shell/indexes.js:253
-msgid "Machines"
-msgstr "Komputery"
-
-#: pkg/shell/indexes.js:314
-msgid "The machine is restarting"
-msgstr "Komputer jest ponownie uruchamiany"
-
-#: pkg/shell/indexes.js:317
-msgid "Connecting to the machine"
-msgstr "Łączenie z komputerem"
-
-#: pkg/shell/indexes.js:320
-msgid "Couldn't connect to the machine"
-msgstr "Nie można połączyć z komputerem"
-
-#: pkg/shell/indexes.js:322
-msgid "Cannot connect to an unknown machine"
-msgstr "Nie można połączyć z nieznanym komputerem"
-
-#: pkg/ostree/client.js:56
-msgid "Receiving delta parts"
-msgstr "Pobieranie części delta"
-
-#: pkg/ostree/client.js:58
-msgid "Receiving metadata objects"
-msgstr "Pobieranie obiektów metadanych"
-
-#: pkg/ostree/client.js:61
-msgid "Receiving objects: $0%"
-msgstr "Pobieranie obiektów: $0%"
-
-#: pkg/ostree/client.js:64
-msgid "Writing objects"
-msgstr "Zapisywanie obiektów"
-
-#: pkg/ostree/client.js:66
-msgid "Scanning metadata"
-msgstr "Skanowanie metadanych"
-
-#: pkg/ostree/client.js:500
-msgid "OS $0 not found"
-msgstr "Nie odnaleziono systemu operacyjnego $0"
-
-#: pkg/ostree/app.js:81
-msgid "Not authorized to update software on this system"
-msgstr "Brak upoważnienia do aktualizowania oprogramowania w tym systemie"
-
-#: pkg/ostree/app.js:83
-msgid "OSTree is not available on this system"
-msgstr "OSTree jest niedostępne w tym systemie"
-
-#: pkg/ostree/app.js:101
-msgid "No OSTree deployments found"
-msgstr "Nie odnaleziono wdrożeń OSTree"
-
-#: pkg/ostree/app.js:219
-msgid "Checking for updates"
-msgstr "Wyszukiwanie aktualizacji"
 
 #: pkg/ostree/app.js:307
 msgid "$0 package"
@@ -801,694 +608,36 @@ msgstr "$0 pakiet"
 msgid "$0 packages"
 msgstr "$0 pakiety"
 
-#: pkg/selinux/setroubleshoot.js:65
-msgid "Error while setting SELinux mode: '$0'"
-msgstr "Błąd podczas ustawiania trybu SELinuksa: „$0”"
-
-#: pkg/selinux/setroubleshoot.js:238
-msgid "Not connected"
-msgstr "Nie połączono"
-
-#: pkg/selinux/setroubleshoot.js:275
-msgid "Error while connecting."
-msgstr "Błąd podczas łączenia."
-
-#: pkg/selinux/setroubleshoot-view.jsx:82
-msgid "Applying solution..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:90
-msgid "Solution applied successfully"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:97
-#, fuzzy
-msgid "Solution failed"
-msgstr "Logowanie się nie powiodło"
-
-#: pkg/selinux/setroubleshoot-view.jsx:107
-msgid "Apply this solution"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:114
-msgid "Unable to apply this solution automatically"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:118
-msgid "solution details"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:309
-msgid "SELinux system status is unknown."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:317
-#, fuzzy
-msgid "SELinux is disabled on the system."
-msgstr "Cockpit nie jest zainstalowany w systemie."
-
-#: pkg/selinux/setroubleshoot-view.jsx:324
-msgid "The configured state is unknown, it might change on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:326
-msgid ""
-"Setting deviates from the configured state and will revert on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:330
-#, fuzzy
-msgid "SELinux Policy"
-msgstr "Polityka DNS"
-
-#: pkg/selinux/setroubleshoot-view.jsx:332
-msgid "Enforce policy:"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:382 pkg/kubernetes/index.html.h:10
-#: pkg/kubernetes/registry.html.h:5
-msgid "Connecting..."
-msgstr "Łączenie…"
-
-#: pkg/selinux/setroubleshoot-view.jsx:385
-msgid ""
-"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
-"server is installed."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:400
-msgid "Occurred between $0 and $1"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:405
-msgid "Occurred $0"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:440
-msgid "$0 occurrence"
-msgid_plural "$1 occurrences"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:478
-msgid "SELinux Access Control Errors"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:479
-msgid "No SELinux alerts."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:52
-msgid "Unable to start setroubleshootd"
-msgstr "Nie można uruchomić usługi setroubleshootd"
-
-#: pkg/selinux/setroubleshoot-client.js:157
-msgid "Unable to get alert"
-msgstr "Nie można uzyskać alarmu"
-
-#: pkg/selinux/setroubleshoot-client.js:172
-msgid "Unable to run fix"
-msgstr "Nie można wykonać poprawki"
-
-#: pkg/selinux/setroubleshoot-client.js:187
-msgid "Failed to delete alert"
-msgstr "Usunięcie alarmu się nie powiodło"
-
-#: pkg/selinux/setroubleshoot-client.js:192
-msgid "Error while deleting alert"
-msgstr "Błąd podczas usuwania alarmu"
-
-#: pkg/storaged/dialog.js:267
-msgid "Size must be a number"
-msgstr "Rozmiar musi być liczbą"
-
-#: pkg/storaged/dialog.js:269
-#, fuzzy
-msgid "Size cannot be zero"
-msgstr "Rozmiar nie może wynosić zero"
-
-#: pkg/storaged/dialog.js:271
-#, fuzzy
-msgid "Size cannot be negative"
-msgstr "Rozmiar nie może być ujemny"
-
-#: pkg/storaged/dialog.js:273
-msgid "Size is too large"
-msgstr "Rozmiar jest za duży"
-
-#: pkg/storaged/details.js:85
-msgid "Device $0 is mounted on $1"
-msgstr "Urządzenie $0 jest zamontowane w $1"
-
-#: pkg/storaged/details.js:91
-msgid "Device $0 is a member of RAID Array $1"
-msgstr "Urządzenie $0 jest elementem macierzy RAID $1"
-
-#: pkg/storaged/details.js:97
-msgid "Device $0 is a physical volume of $1"
-msgstr "Urządzenie $0 jest fizycznym woluminem $1"
-
-#: pkg/storaged/details.js:113
-msgid "Create partition on $0"
-msgstr "Utwórz partycję w $0"
-
-#: pkg/storaged/details.js:115
-msgid "Format $0"
-msgstr "Sformatuj $0"
-
-#: pkg/storaged/details.js:177
-msgid "XFS - Red Hat Enterprise Linux 7 default"
-msgstr "XFS — domyślne w systemie Red Hat Enterprise Linux 7"
-
-#: pkg/storaged/details.js:178
-msgid "ext4 - Red Hat Enterprise Linux 6 default"
-msgstr "ext4 — domyślne w systemie Red Hat Enterprise Linux 6"
-
-#: pkg/storaged/details.js:179
-msgid "Encrypted XFS (LUKS)"
-msgstr "Szyfrowane XFS (LUKS)"
-
-#: pkg/storaged/details.js:180
-msgid "Encrypted EXT4 (LUKS)"
-msgstr "Szyfrowane EXT4 (LUKS)"
-
-#: pkg/storaged/details.js:181
-msgid "VFAT - Compatible with all systems and devices"
-msgstr "VFAT — zgodne ze wszystkimi systemami i urządzeniami"
-
-#: pkg/storaged/details.js:182
-msgid "NTFS - Compatible with most systems"
-msgstr "NTFS — zgodne z większością systemów"
-
-#: pkg/storaged/details.js:183
-msgid "Extended Partition"
-msgstr "Rozszerzona partycja"
-
-#: pkg/storaged/details.js:185
-msgid "No Filesystem"
-msgstr "Brak systemu plików"
-
-#: pkg/storaged/details.js:186
-msgid "Custom (Enter filesystem type)"
-msgstr "Własne (proszę podać typ systemu plików)"
-
-#: pkg/storaged/details.js:192 pkg/storaged/details.js:664
-#: pkg/storaged/details.js:735 pkg/storaged/details.js:773
-#: pkg/storaged/details.js:909 pkg/storaged/index.html.h:20
-#: pkg/kubernetes/views/volumes-page.html.h:11
-msgid "Size"
-msgstr "Rozmiar"
-
-#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
-msgid "Erase"
-msgstr "Wymaż"
-
-#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
-msgid "Don't overwrite existing data"
-msgstr "Nie zastępuj istniejących danych"
-
-#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
-msgid "Overwrite existing data with zeros"
-msgstr "Zastąp istniejące dane zerami"
-
-#: pkg/storaged/details.js:207 pkg/shell/index.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:4
-#: pkg/kubernetes/views/deploy.html.h:2 pkg/kubernetes/views/pv-modify.html.h:3
-msgid "Type"
-msgstr "Typ"
-
-#: pkg/storaged/details.js:211 pkg/storaged/details.js:429
-#: pkg/storaged/details.js:709 pkg/storaged/details.js:731
-#: pkg/storaged/details.js:769 pkg/storaged/details.js:798
-#: pkg/storaged/details.js:864 pkg/storaged/overview.js:417
-#: pkg/storaged/overview.js:490 pkg/storaged/overview.js:624
-#: pkg/storaged/overview.js:702 pkg/storaged/index.html.h:18
-#: pkg/networkmanager/index.html.h:16
-#: pkg/kubernetes/views/project-listing.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:3
-#: pkg/kubernetes/views/volume-body.html.h:11
-#: pkg/kubernetes/views/containers-listing.html.h:2
-#: pkg/kubernetes/views/volumes-page.html.h:3
-#: pkg/kubernetes/views/pv-claim.html.h:1
-#: pkg/kubernetes/views/pv-modify.html.h:6
-#: pkg/kubernetes/views/image-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:15
-#: pkg/kubernetes/views/nodes-page.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:3
-#: pkg/kubernetes/views/details-page.html.h:4
-#: pkg/kubernetes/views/service-modify.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:3
-msgid "Name"
-msgstr "Nazwa"
-
-#: pkg/storaged/details.js:215
-msgid "Filesystem type"
-msgstr "Typ systemu plików"
-
-#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
-msgid "Passphrase"
-msgstr "Hasło"
-
-#: pkg/storaged/details.js:224
-#, fuzzy
-msgid "Passphrase cannot be empty"
-msgstr "Hasło nie może być puste"
-
-#: pkg/storaged/details.js:229
-msgid "Confirm passphrase"
-msgstr "Potwierdź hasło"
-
-#: pkg/storaged/details.js:232
-msgid "Passphrases do not match"
-msgstr "Hasła się nie zgadzają"
-
-#: pkg/storaged/details.js:237
-msgid "Store passphrase"
-msgstr "Przechowaj hasło"
-
-#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
-#: pkg/storaged/details.js:1115
-msgid "Encryption Options"
-msgstr "Opcje szyfrowania"
-
-#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
-msgid "Mounting"
-msgstr "Montowanie"
-
-#: pkg/storaged/details.js:247 pkg/storaged/details.js:435
-#: pkg/subscriptions/subscriptions-register.jsx:101 pkg/docker/index.html.h:23
-#: pkg/kubernetes/views/image-config.html.h:2
-msgid "Default"
-msgstr "Domyślne"
-
-#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
-msgid "Custom"
-msgstr "Własne"
-
-#: pkg/storaged/details.js:253 pkg/storaged/details.js:440
-#: pkg/storaged/index.html.h:19
-msgid "Mount Point"
-msgstr "Punkt montowania"
-
-#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
-msgid "Mount Options"
-msgstr "Opcje montowania"
-
-#: pkg/storaged/details.js:266
-msgid "Create partition"
-msgstr "Utwórz partycję"
-
-#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
-#: pkg/storaged/details.js:1142
-msgid "Format"
-msgstr "Sformatuj"
-
-#: pkg/storaged/details.js:268
-msgid "Formatting a storage device will erase all data on it."
-msgstr ""
-"Sformatowanie urządzenia do przechowywania danych usunie wszystkie "
-"znajdujące się na nim dane."
-
-#: pkg/storaged/details.js:335
-msgid "Format Disk $0"
-msgstr "Sformatuj dysk $0"
-
-#: pkg/storaged/details.js:346
-msgid "Partitioning"
-msgstr "Partycjonowanie"
-
-#: pkg/storaged/details.js:348
-msgid "Compatible with all systems and devices (MBR)"
-msgstr "Zgodne ze wszystkimi systemami i urządzeniami (MBR)"
-
-#: pkg/storaged/details.js:349
-msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr "Zgodne z nowoczesnymi systemami i dyskami twardymi > 2 TB (GPT)"
-
-#: pkg/storaged/details.js:352
-msgid "No partitioning"
-msgstr "Brak partycjonowania"
-
-#: pkg/storaged/details.js:358
-msgid "Formatting a disk will erase all data on it."
-msgstr "Sformatowanie dysku usunie wszystkie znajdujące się na nim dane."
-
-#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
-msgid "Filesystem Options"
-msgstr "Opcje systemu plików"
-
-#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
-msgid "Apply"
-msgstr "Zastosuj"
-
-#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
-#: pkg/storaged/details.js:1110
-msgid "Unlock"
-msgstr "Odblokuj"
-
-#: pkg/storaged/details.js:527
-msgid "Stored Passphrase"
-msgstr "Zachowane hasło"
-
-#: pkg/storaged/details.js:531 pkg/kubernetes/views/volume-body.html.h:32
-msgid "Options"
-msgstr "Opcje"
-
-#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
-msgid "Add Disks"
-msgstr "Dodaj dyski"
-
-#: pkg/storaged/details.js:567 pkg/storaged/details.js:933
-#: pkg/storaged/overview.js:448 pkg/storaged/overview.js:495
-#: pkg/storaged/index.html.h:55
-msgid "Disks"
-msgstr "Dyski"
-
-#: pkg/storaged/details.js:579 pkg/storaged/details.js:948
-#: pkg/storaged/overview.js:501
-msgid "At least one disk is needed."
-msgstr "Wymagany jest co najmniej jeden dysk."
-
-#: pkg/storaged/details.js:584 pkg/storaged/details.js:953
-#: pkg/storaged/overview.js:629 pkg/storaged/overview.js:657
-#: pkg/lib/machine-add.html.h:6 pkg/kubernetes/views/node-add.html.h:8
-#: pkg/kubernetes/views/user-group-add.html.h:6
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:5
-#: pkg/kubernetes/views/add-user-dialog.html.h:9
-#: pkg/kubernetes/views/user-add-membership.html.h:9
-#: pkg/kubernetes/views/add-role-dialog.html.h:4
-msgid "Add"
-msgstr "Dodaj"
-
-#: pkg/storaged/details.js:625 pkg/storaged/details.js:821
-#: pkg/storaged/details.js:1016 pkg/docker/details.js:271
-#: pkg/docker/image.js:151 pkg/docker/containers-view.jsx:166
-msgid "Please confirm deletion of $0"
-msgstr "Proszę potwierdzić usunięcie $0"
-
-#: pkg/storaged/details.js:630 pkg/storaged/details.js:827
-#: pkg/storaged/details.js:1022 pkg/storaged/details.js:1151
-#: pkg/storaged/details.js:1616 pkg/storaged/details.js:1776
-#: pkg/docker/details.js:273 pkg/docker/image.js:153
-#: pkg/docker/containers-view.jsx:168 pkg/kubernetes/scripts/volumes.js:218
-#: pkg/users/index.html.h:9 pkg/kubernetes/views/node-delete.html.h:5
-#: pkg/kubernetes/views/pvc-delete.html.h:5
-#: pkg/kubernetes/views/image-delete.html.h:4
-#: pkg/kubernetes/views/pv-delete.html.h:5
-#: pkg/kubernetes/views/item-delete.html.h:5
-#: pkg/kubernetes/views/imagestream-delete.html.h:4
-#: pkg/kubernetes/views/user-remove-membership.html.h:3
-#: pkg/kubernetes/views/project-delete.html.h:3
-msgid "Delete"
-msgstr "Usuń"
-
-#: pkg/storaged/details.js:631
-msgid "Deleting a RAID device will erase all data on it."
-msgstr "Usunięcie urządzenia RAID usunie wszystkie znajdujące się na nim dane."
-
-#: pkg/storaged/details.js:661
-msgid "Resize Logical Volume"
-msgstr "Zmień rozmiar woluminu logicznego"
-
-#: pkg/storaged/details.js:673
-msgid "Resize Filesystem"
-msgstr "Zmień rozmiar systemu plików"
-
-#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
-msgid "Resize"
-msgstr "Zmień rozmiar"
-
-#: pkg/storaged/details.js:690
-#, fuzzy
-msgid "This logical volume cannot be made smaller."
-msgstr "Ten wolumin logiczny nie może zostać zmniejszony."
-
-#: pkg/storaged/details.js:706
-msgid "Renamee Logical Volume"
-msgstr "Zmień nazwę woluminu logicznego"
-
-#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
-#: pkg/storaged/details.js:1775
-msgid "Rename"
-msgstr "Zmień nazwę"
-
-#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
-msgid "Create Snapshot"
-msgstr "Utwórz migawkę"
-
-#: pkg/storaged/details.js:745 pkg/storaged/details.js:781
-#: pkg/storaged/details.js:804 pkg/storaged/details.js:915
-#: pkg/storaged/overview.js:461 pkg/storaged/overview.js:506
-#: pkg/kubernetes/views/add-group-dialog.html.h:6
-#: pkg/kubernetes/views/project-modify.html.h:8
-msgid "Create"
-msgstr "Utwórz"
-
-#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
-msgid "Create Thin Volume"
-msgstr "Utwórz cienki wolumin"
-
-#: pkg/storaged/details.js:795
-msgid "Rename Volume Group"
-msgstr "Zmień nazwę grupy woluminów"
-
-#: pkg/storaged/details.js:826
-msgid "Deleting a volume group will erase all data on it."
-msgstr "Usunięcie grupy woluminów usunie wszystkie znajdujące się w niej dane."
-
-#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
-msgid "Create Logical Volume"
-msgstr "Utwórz wolumin logiczny"
-
-#: pkg/storaged/details.js:869
-msgid "Purpose"
-msgstr "Zastosowanie"
-
-#: pkg/storaged/details.js:871
-msgid "Block device for filesystems"
-msgstr "Urządzenie blokowe dla systemów plików"
-
-#: pkg/storaged/details.js:874
-msgid "Pool for thinly provisioned volumes"
-msgstr "Pula dla cienko nadzorowanych woluminów"
-
-#: pkg/storaged/details.js:1009
-msgid "Deleting a logical volume will delete all data in it."
-msgstr ""
-"Usunięcie woluminu logicznego usunie wszystkie znajdujące się na nim dane."
-
-#: pkg/storaged/details.js:1012
-msgid "Deleting a partition will delete all data in it."
-msgstr "Usunięcie partycji usunie wszystkie znajdujące się na niej dane."
-
-#: pkg/storaged/details.js:1053 pkg/storaged/overview.js:689
-#: pkg/storaged/devices.js:119 pkg/users/local.js:1155
-#: pkg/systemd/services.html.h:14
-msgid "Error"
-msgstr "Błąd"
-
-#: pkg/storaged/details.js:1099
-msgid "Mount"
-msgstr "Zamontuj"
-
-#: pkg/storaged/details.js:1100
-msgid "Unmount"
-msgstr "Odmontuj"
-
-#: pkg/storaged/details.js:1109
-msgid "Lock"
-msgstr "Zablokuj"
-
-#: pkg/storaged/details.js:1127
-msgid "Activate"
-msgstr "Aktywuj"
-
-#: pkg/storaged/details.js:1130
-msgid "Deactivate"
-msgstr "Dezaktywuj"
-
-#: pkg/storaged/details.js:1221
-msgctxt "storage-id-desc"
-msgid "$0 File System"
-msgstr "System plików $0"
-
-#: pkg/storaged/details.js:1224
-msgctxt "storage-id-desc"
-msgid "Linux MD-RAID Component"
-msgstr "Składnik MD-RAID systemu Linux"
-
-#: pkg/storaged/details.js:1226
-msgctxt "storage-id-desc"
-msgid "LVM2 Physical Volume"
-msgstr "Wolumin fizyczny LVM2"
-
-#: pkg/storaged/details.js:1228
-msgctxt "storage-id-desc"
-msgid "RAID Member"
-msgstr "Element macierzy RAID"
-
-#: pkg/storaged/details.js:1245
-msgctxt "storage-id-desc"
-msgid "LUKS Encrypted"
-msgstr "Zaszyfrowane LUKS"
-
-#: pkg/storaged/details.js:1247
-msgctxt "storage-id-desc"
-msgid "Encrypted"
-msgstr "Zaszyfrowane"
-
-#: pkg/storaged/details.js:1251
-msgctxt "storage-id-desc"
-msgid "Swap Space"
-msgstr "Przestrzeń wymiany"
-
-#: pkg/storaged/details.js:1253
-msgctxt "storage-id-desc"
-msgid "Other Data"
-msgstr "Inne dane"
-
-#: pkg/storaged/details.js:1256
-msgctxt "storage-id-desc"
-msgid "Unrecognized Data"
-msgstr "Nierozpoznane dane"
-
-#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
-msgid "$size $partition"
-msgstr "$partition o rozmiarze $size"
-
-#: pkg/storaged/details.js:1278
-msgid "mounted on $0"
-msgstr "zamontowane w $0"
-
-#: pkg/storaged/details.js:1280
-msgid "not mounted"
-msgstr "niezamontowane"
-
-#: pkg/storaged/details.js:1284
-msgid "unlocked"
-msgstr "odblokowane"
-
-#: pkg/storaged/details.js:1286
-msgid "locked"
-msgstr "zablokowane"
-
-#: pkg/storaged/details.js:1367
-msgid "$0 Free Space for Logical Partitions"
-msgstr "Wolne miejsce dla partycji logicznych: $0"
-
-#: pkg/storaged/details.js:1370
-msgid "$0 Free Space for Primary Partitions"
-msgstr "Wolne miejsce dla głównych partycji: $0"
-
-#: pkg/storaged/details.js:1375
-msgid "$0 Free Space"
-msgstr "Wolne miejsce: $0"
-
-#: pkg/storaged/details.js:1379
-msgid "Create Partition"
-msgstr "Utwórz partycję"
-
-#: pkg/storaged/details.js:1387
-msgid "$0 Extended Partition"
-msgstr "Rozszerzona partycja $0"
-
-#: pkg/storaged/details.js:1424
-msgid "Logical Partition"
-msgstr "Partycja logiczna"
-
-#: pkg/storaged/details.js:1426
-msgid "Primary Partition"
-msgstr "Partycja główna"
-
-#: pkg/storaged/details.js:1428 pkg/kubernetes/views/volume-body.html.h:5
-msgid "Partition"
-msgstr "Partycja"
-
-#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
-msgid "Content"
-msgstr "Zawartość"
-
-#: pkg/storaged/details.js:1533
-msgid "RAID 0"
-msgstr "RAID 0"
-
-#: pkg/storaged/details.js:1534
-msgid "RAID 1"
-msgstr "RAID 1"
-
-#: pkg/storaged/details.js:1535
-msgid "RAID 4"
-msgstr "RAID 4"
-
-#: pkg/storaged/details.js:1536
-msgid "RAID 5"
-msgstr "RAID 5"
-
-#: pkg/storaged/details.js:1537
-msgid "RAID 6"
-msgstr "RAID 6"
-
-#: pkg/storaged/details.js:1538
-msgid "RAID 10"
-msgstr "RAID 10"
-
-#: pkg/storaged/details.js:1539
-msgid "RAID ($0)"
-msgstr "RAID ($0)"
-
-#: pkg/storaged/details.js:1544
-msgid "$0 Disks"
-msgstr "Dyski: $0"
-
-#: pkg/storaged/details.js:1546
-msgid "$0 Chunk Size"
-msgstr "Rozmiar bloku: $0"
-
-#: pkg/storaged/details.js:1574 pkg/ostree/index.html.h:7
-msgid "Running"
-msgstr "Działające"
-
-#: pkg/storaged/details.js:1574
-msgid "Not running"
-msgstr "Niedziałające"
-
-#: pkg/storaged/details.js:1592
-msgid "FAILED"
-msgstr "NIEPOWODZENIE"
-
-#: pkg/storaged/details.js:1593
-msgid "In Sync"
-msgstr "Zsynchronizowane"
-
-#: pkg/storaged/details.js:1594
-msgid "Spare"
-msgstr "Zapasowe"
-
-#: pkg/storaged/details.js:1594
-msgid "Recovering"
-msgstr "Odzyskiwanie"
-
-#: pkg/storaged/details.js:1595
-msgid "Write-mostly"
-msgstr "Głównie zapisywane"
-
-#: pkg/storaged/details.js:1596
-msgid "Blocked"
-msgstr "Zablokowane"
-
-#: pkg/storaged/details.js:1597
-msgid "Unknown ($0)"
-msgstr "Nieznane ($0)"
-
-#: pkg/storaged/details.js:1614
-msgid "Start Scrubbing"
-msgstr "Rozpocznij kontrolę"
-
-#: pkg/storaged/details.js:1615
-msgid "Stop Scrubbing"
-msgstr "Zatrzymaj kontrolę"
+#: pkg/docker/util.js:124
+msgid "$0 shares"
+msgstr "Udziały: $0"
+
+#: pkg/kubernetes/scripts/nodes.js:870
+#, fuzzy, c-format
+msgid "$0% Free"
+msgid_plural "$0% Free"
+msgstr[0] "$0% wolny"
+msgstr[1] "$0% wolne"
+msgstr[2] "$0% wolnych"
+
+#: pkg/kubernetes/scripts/nodes.js:872
+msgid "$0% Used"
+msgid_plural "$0% Used"
+msgstr[0] "$0% używany"
+msgstr[1] "$0% używane"
+msgstr[2] "$0% używanych"
+
+#: pkg/storaged/details.js:1765
+msgid "$0, $1 free"
+msgstr "$0, wolne: $1"
+
+#: pkg/networkmanager/interfaces.js:2473
+msgid "$mtu"
+msgstr "$mtu"
+
+#: pkg/storaged/utils.js:157
+msgid "$name (from $host)"
+msgstr "$name (z $host)"
 
 #: pkg/storaged/details.js:1653
 msgid "$size $desc"
@@ -1503,217 +652,2859 @@ msgstr "$desc o rozmiarze $size<br/>${percent}% pełne"
 msgid "$size $desc<br/>($state)"
 msgstr "$desc o rozmiarze $size<br/>($state)"
 
-#: pkg/storaged/details.js:1692
-msgid "active, but unsupported"
-msgstr "aktywne, ale nieobsługiwane"
+#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
+msgid "$size $partition"
+msgstr "$partition o rozmiarze $size"
 
-#: pkg/storaged/details.js:1692
-msgid "inactive"
-msgstr "nieaktywne"
+#: pkg/docker/details.js:144
+msgid "${hip}:${hport} -> $cport"
+msgstr "${hip}:${hport} → $cport"
 
-#: pkg/storaged/details.js:1711
-msgid "$0 Free Space for Logical Volumes"
-msgstr "Wolne miejsce dla woluminów logicznych: $0"
-
-#: pkg/storaged/details.js:1751
-msgid "The last physical volume of a volume group cannot be removed."
+#: pkg/subscriptions/subscriptions-client.js:198
+msgid "'Organization' required to register."
 msgstr ""
 
-#: pkg/storaged/details.js:1756
+#: pkg/subscriptions/subscriptions-client.js:202
+msgid "'Organization' required when using activation keys."
+msgstr ""
+
+#: pkg/shell/base_index.js:674
+msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
+msgstr "(<b>Ctrl-Shift-J</b> w większości przeglądarek)."
+
+#: pkg/storaged/overview.js:440
+msgid "1 MiB"
+msgstr "1 MiB"
+
+#: pkg/systemd/index.html:459 pkg/systemd/index.html:463
+msgid "1 Minute"
+msgstr "1 minuta"
+
+#: pkg/storaged/index.html:312 pkg/networkmanager/index.html:55
+#: pkg/networkmanager/index.html:501
+msgid "1 day"
+msgstr "1 dzień"
+
+#: pkg/storaged/index.html:310 pkg/networkmanager/index.html:53
+#: pkg/networkmanager/index.html:499
+msgid "1 hour"
+msgstr "1 godzina"
+
+#: pkg/storaged/index.html:313 pkg/networkmanager/index.html:56
+#: pkg/networkmanager/index.html:502
+msgid "1 week"
+msgstr "1 tydzień"
+
+#: pkg/playground/translate.html:190
+#, fuzzy
+msgid "1% Free"
+msgid_plural "{{$count}}% Free"
+msgstr[0] "$0% wolny"
+msgstr[1] "$0% wolne"
+msgstr[2] "$0% wolnych"
+
+#: pkg/storaged/overview.js:438
+msgid "128 KiB"
+msgstr "128 KiB"
+
+#: pkg/storaged/overview.js:435
+msgid "16 KiB"
+msgstr "16 KiB"
+
+#: pkg/storaged/overview.js:441
+msgid "2 MiB"
+msgstr "2 MiB"
+
+#: pkg/systemd/index.html:465
+msgid "20 Minutes"
+msgstr "20 minut"
+
+#: pkg/storaged/overview.js:436
+msgid "32 KiB"
+msgstr "32 KiB"
+
+#: pkg/storaged/overview.js:433
+msgid "4 KiB"
+msgstr "4 KiB"
+
+#: pkg/systemd/index.html:466
+msgid "40 Minutes"
+msgstr "40 minut"
+
+#: pkg/systemd/index.html:464
+msgid "5 Minutes"
+msgstr "5 minut"
+
+#: pkg/storaged/index.html:309 pkg/networkmanager/index.html:52
+#: pkg/networkmanager/index.html:498
+msgid "5 minutes"
+msgstr "5 minut"
+
+#: pkg/storaged/overview.js:439
+msgid "512 KiB"
+msgstr "512 KiB"
+
+#: pkg/storaged/index.html:311 pkg/networkmanager/index.html:54
+#: pkg/networkmanager/index.html:500
+msgid "6 hours"
+msgstr "6 godzin"
+
+#: pkg/systemd/index.html:467
+msgid "60 Minutes"
+msgstr "Godzina"
+
+#: pkg/storaged/overview.js:437
+msgid "64 KiB"
+msgstr "64 KiB"
+
+#: pkg/storaged/overview.js:434
+msgid "8 KiB"
+msgstr "8 KiB"
+
+#: pkg/networkmanager/interfaces.js:1826
+msgid "802.3ad"
+msgstr "802.3ad"
+
+#: pkg/networkmanager/interfaces.js:1843
+#, fuzzy
+msgid "802.3ad LACP"
+msgstr "802.3ad"
+
+#: pkg/systemd/services.html:446
+msgid ":"
+msgstr ""
+
+#: pkg/storaged/utils.js:220
+msgid "<span>Encrypted $0</span>"
+msgstr "<span>Zaszyfrowane $0</span>"
+
+#: pkg/storaged/utils.js:212
+msgid "<span>Encrypted Logical Volume of $0</span>"
+msgstr "<span>Zaszyfrowany wolumin logiczny $0</span>"
+
+#: pkg/storaged/utils.js:214
+msgid "<span>Encrypted Partition of $0</span>"
+msgstr "<span>Zaszyfrowana partycja $0</span>"
+
+#: pkg/storaged/utils.js:216
+msgid "<span>Logical Volume of $0</span>"
+msgstr "<span>Wolumin logiczny $0</span>"
+
+#: pkg/storaged/utils.js:218
+msgid "<span>Partition of $0</span>"
+msgstr "<span>Partycja $0</span>"
+
+#: pkg/lib/machine-not-supported.html:5
 msgid ""
-"There is not enough free space elsewhere to remove this physical volume.  At "
-"least $0 more free space is needed."
+"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
+"strong}}."
+msgstr ""
+"Na {{#strong}}{{host}}{{/strong}} nie zainstalowano zgodnej wersji Cockpit."
+
+#: cockpit.desktop.in.h:2
+msgid "A user interface for GNU/Linux servers"
+msgstr "Interfejs użytkownika dla serwerów GNU/Linux"
+
+#: pkg/networkmanager/interfaces.js:1834
+msgid "ARP"
+msgstr "ARP"
+
+#: pkg/networkmanager/interfaces.js:2502
+msgid "ARP Monitoring"
+msgstr "Monitorowanie ARP"
+
+#: pkg/networkmanager/interfaces.js:1855
+#, fuzzy
+msgid "ARP Ping"
+msgstr "Monitorowanie ARP"
+
+#: pkg/kubernetes/scripts/volumes.js:193
+msgid "AWS Elastic Block Store"
+msgstr "Elastyczna przechowalnia blokowa AWS"
+
+#: pkg/shell/simple.html:41 pkg/shell/simple.html:67 pkg/shell/index.html:41
+#: pkg/shell/index.html:80 pkg/shell/stub.html:41 pkg/shell/stub.html:73
+msgid "About Cockpit"
+msgstr "O programie Cockpit"
+
+#: pkg/users/index.html:105 pkg/users/index.html:191
+msgid "Access"
+msgstr "Dostęp"
+
+#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pv-claim.html:9
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-body.html:9
+msgid "Access Modes"
+msgstr "Tryby dostępu"
+
+#: pkg/kubernetes/views/project-modify.html:49
+#: pkg/kubernetes/views/imagestream-body.html:11
+msgid "Access Policy"
+msgstr "Polityka dostępu"
+
+#: pkg/subscriptions/subscriptions-view.jsx:191
+#, fuzzy
+msgid "Access denied"
+msgstr "Tryby dostępu"
+
+#: pkg/shell/index.html:45
+msgid "Account Settings"
+msgstr "Ustawienia konta"
+
+#: pkg/users/index.html:63
+msgid "Account not available or cannot be edited."
+msgstr "Konto jest niedostępne lub nie może być modyfikowane."
+
+#: pkg/users/index.html:71
+msgid "Accounts"
+msgstr "Konta"
+
+#: pkg/users/local.js:284 pkg/users/local.js:594
+msgctxt "page-title"
+msgid "Accounts"
+msgstr "Konta"
+
+#: pkg/storaged/details.js:1127
+msgid "Activate"
+msgstr "Aktywuj"
+
+#: pkg/storaged/jobs.js:148
+msgid "Activating $target"
+msgstr "Aktywowanie $target"
+
+#: pkg/subscriptions/subscriptions-register.jsx:164
+#, fuzzy
+msgid "Activation Key"
+msgstr "Aktywuj"
+
+#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
+msgid "Active"
+msgstr "Aktywne"
+
+#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
+msgid "Active Backup"
+msgstr "Aktywna kopia zapasowa"
+
+#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
+msgid "Actual"
+msgstr "Rzeczywisty"
+
+#: pkg/networkmanager/interfaces.js:1828
+msgid "Adaptive load balancing"
+msgstr "Adaptacyjne równoważenie obciążenia"
+
+#: pkg/networkmanager/interfaces.js:1827
+msgid "Adaptive transmit load balancing"
+msgstr "Adaptacyjne równoważenie obciążenia przesyłu"
+
+#: pkg/kubernetes/views/add-user-dialog.html:31
+#: pkg/kubernetes/views/node-add.html:50
+#: pkg/kubernetes/views/user-add-membership.html:53
+#: pkg/kubernetes/views/add-member-role-dialog.html:61
+#: pkg/kubernetes/views/user-group-add.html:32
+#: pkg/kubernetes/views/add-role-dialog.html:8 pkg/lib/machine-add.html:43
+msgid "Add"
+msgstr "Dodaj"
+
+#: pkg/networkmanager/interfaces.js:2836
+msgid "Add $0"
 msgstr ""
 
-#: pkg/storaged/details.js:1765
-msgid "$0, $1 free"
-msgstr "$0, wolne: $1"
+#: pkg/docker/storage.jsx:363
+#, fuzzy
+msgid "Add Additional Storage"
+msgstr "Dodatkowe urządzenia do przechowywania danych"
 
-#: pkg/storaged/details.js:1792
-msgid "Logical Volumes"
-msgstr "Woluminy logiczne"
+#: pkg/networkmanager/index.html:86
+msgid "Add Bond"
+msgstr "Dodaj węzeł"
 
-#: pkg/storaged/details.js:1822 pkg/docker/details.js:177
-#: pkg/docker/image.js:112
-msgid "Not found"
-msgstr "Nie odnaleziono"
+#: pkg/networkmanager/index.html:88
+msgid "Add Bridge"
+msgstr "Dodaj mostek"
 
-#: pkg/storaged/overview.js:180
+#: pkg/kubernetes/views/node-add.html:3
+msgid "Add Cluster Node"
+msgstr "Dodaj węzeł klastra"
+
+#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
+msgid "Add Disks"
+msgstr "Dodaj dyski"
+
+#: pkg/kubernetes/views/add-group-dialog.html:3
+msgid "Add Group"
+msgstr "Dodaj grupę"
+
+#: pkg/kubernetes/views/nodes-page.html:34
+msgid "Add Kubernetes Node"
+msgstr "Dodaj węzeł Kubernetes"
+
+#: pkg/lib/machine-add.html:4
+msgid "Add Machine to Dashboard"
+msgstr "Dodaj komputer do panelu kontrolnego"
+
+#: pkg/kubernetes/views/group-page.html:38
+#: pkg/kubernetes/views/add-member-role-dialog.html:4
+#: pkg/kubernetes/views/group-panel.html:29
+#: pkg/kubernetes/views/user-group-add.html:3
+#: pkg/kubernetes/views/project-body.html:108
+msgid "Add Member"
+msgstr "Dodaj element"
+
+#: pkg/kubernetes/views/user-panel.html:76
+#: pkg/kubernetes/views/user-body.html:67
+msgid "Add Membership"
+msgstr "Dodaj członkostwo"
+
+#: pkg/kubernetes/views/auth-form.html:11
+#: pkg/kubernetes/views/auth-form.html:20
+msgid "Add New Cluster"
+msgstr "Dodaj nowy klaster"
+
+#: pkg/kubernetes/views/auth-form.html:67
+#: pkg/kubernetes/views/auth-form.html:76
+msgid "Add New User"
+msgstr "Dodaj nowego użytkownika"
+
+#: pkg/kubernetes/views/add-role-dialog.html:3
+msgid "Add Role"
+msgstr "Dodaj rolę"
+
+#: pkg/networkmanager/index.html:87
+#, fuzzy
+msgid "Add Team"
+msgstr "Dodaj element"
+
+#: pkg/kubernetes/views/add-user-dialog.html:3
+#: pkg/kubernetes/views/project-listing.html:83
+msgid "Add User"
+msgstr "Dodaj użytkownika"
+
+#: pkg/networkmanager/index.html:89
+msgid "Add VLAN"
+msgstr "Dodaj VLAN"
+
+#: pkg/storaged/overview.js:515
+msgid "Add iSCSI Portal"
+msgstr "Dodaj portal iSCSI"
+
+#: pkg/kubernetes/views/user-add-membership.html:3
+msgid "Add membership"
+msgstr "Dodaj członkostwo"
+
+#: pkg/users/index.html:351
+msgid "Add public key"
+msgstr "Dodaj klucz publiczny"
+
+#: pkg/networkmanager/interfaces.js:2833
+msgid "Adding <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/users/authorized-keys.js:108
+msgid "Adding key"
+msgstr "Dodawanie klucza"
+
+#: pkg/storaged/jobs.js:153
+msgid "Adding physical volume to $target"
+msgstr "Dodawanie woluminu fizycznego do $target"
+
+#: pkg/docker/index.html:329
+msgid "Additional Storage"
+msgstr "Dodatkowe urządzenia do przechowywania danych"
+
+#: pkg/ostree/index.html:121 pkg/ostree/index.html:140
+msgid "Additions"
+msgstr "Dodane"
+
+#: pkg/kubernetes/views/node-add.html:8
+#: pkg/kubernetes/views/dashboard-page.html:157
+#: pkg/kubernetes/views/details-page.html:174
+#: pkg/kubernetes/views/nodes-page.html:43
+#: pkg/kubernetes/views/auth-form.html:29 pkg/kubernetes/views/node-body.html:5
+#: pkg/lib/machine-add.html:11
+msgid "Address"
+msgstr "Adres"
+
+#: pkg/kubernetes/views/details-page.html:37
+msgid "Addresses"
+msgstr "Adresy"
+
+#: pkg/kubernetes/views/service-modify.html:25
+msgid "Adjust"
+msgstr "Dostosuj"
+
+#: pkg/kubernetes/views/pv-modify.html:3
+msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+msgstr "Dostosuj trwały wolumin „{{ item.metadata.name }}”"
+
+#: pkg/kubernetes/views/replicationcontroller-modify.html:3
+msgid "Adjust Replication Controller {{ item.metadata.name }}"
+msgstr "Dostosuj kontroler replikacji {{ item.metadata.name }}"
+
+#: pkg/kubernetes/views/route-modify.html:3
+msgid "Adjust Route"
+msgstr "Dostosuj trasę"
+
+#: pkg/kubernetes/views/service-modify.html:3
+msgid "Adjust Service"
+msgstr "Dostosuj usługę"
+
+#: pkg/kubernetes/views/project-body.html:56
+msgid "Admin"
+msgstr "Administrator"
+
+#: pkg/systemd/services.html:389 pkg/systemd/services.html:393
+#, fuzzy
+msgid "After system boot"
+msgstr "Zarejestruj system"
+
+#: pkg/systemd/logs.html:50
+msgid "All"
+msgstr "Wszystkie"
+
+#: pkg/kubernetes/views/filter-project.html:4
+msgid "All Projects"
+msgstr "Wszystkie projekty"
+
+#: pkg/kubernetes/views/details-page.html:6
+msgid "All Types"
+msgstr "Wszystkie typy"
+
+#: pkg/docker/storage.jsx:366
+msgid ""
+"All data on selected disks will be erased and disks will be added to the "
+"storage pool."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:112
+msgid "All healthy"
+msgstr "Wszystko jest zdrowe"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:74
+msgid "All images"
+msgstr "Wszystkie obrazy"
+
+#: pkg/kubernetes/views/dashboard-page.html:69
+msgid "All in use"
+msgstr "Wszystko jest używane"
+
+#: pkg/kubernetes/views/dashboard-page.html:37
+msgid "All running"
+msgstr "Wszystko działa"
+
+#: pkg/docker/index.html:569
+msgid "Always"
+msgstr "Zawsze"
+
+#: pkg/kubernetes/views/imagestream-meta.html:2
+#: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/image-meta.html:9
+#: pkg/kubernetes/views/node-body.html:57
+msgid "Annotations"
+msgstr "Adnotacje"
+
+#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
+msgid "Apply"
+msgstr "Zastosuj"
+
+#: pkg/selinux/setroubleshoot-view.jsx:107
+msgid "Apply this solution"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:82
+msgid "Applying solution..."
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:12
+msgid "Architecture"
+msgstr "Architektura"
+
+#: pkg/storaged/index.html:451
 msgctxt "storage"
-msgid "Hard Disk"
-msgstr "Dysk twardy"
+msgid "Assessment"
+msgstr "Ocena"
 
-#: pkg/storaged/overview.js:182
-msgctxt "storage"
-msgid "Solid-State Disk"
-msgstr "Dysk SSD"
+#: pkg/systemd/index.html:81
+msgid "Asset Tag"
+msgstr "Etykieta zasobu"
 
-#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
-msgctxt "storage"
-msgid "Removable Drive"
-msgstr "Dysk wymienny"
+#: pkg/storaged/overview.js:455
+msgid "At least $0 disks are needed."
+msgstr "Wymagane są co najmniej $0 dyski."
 
-#: pkg/storaged/overview.js:189
+#: pkg/storaged/overview.js:501 pkg/storaged/details.js:579
+#: pkg/storaged/details.js:948
+msgid "At least one disk is needed."
+msgstr "Wymagany jest co najmniej jeden dysk."
+
+#: pkg/systemd/services.html:394
+#, fuzzy
+msgid "At specific time"
+msgstr "Podany czas"
+
+#: pkg/networkmanager/interfaces.js:813
+msgid "Authenticating"
+msgstr "Uwierzytelnianie"
+
+#: pkg/realmd/operation.html:34 pkg/shell/index.html:48
+#: pkg/shell/index.html:159 pkg/kubernetes/views/auth-form.html:85
+#: pkg/lib/machine-change-auth.html:32
+msgid "Authentication"
+msgstr "Uwierzytelnienie"
+
+#: pkg/lib/machine-auth-failed.html:2
+msgid "Authentication Failed"
+msgstr "Uwierzytelnienie się nie powiodło"
+
+#: pkg/docker/index.html:730 pkg/kubernetes/views/image-body.html:12
+#: pkg/kubernetes/views/image-listing.html:15
+msgid "Author"
+msgstr "Autor"
+
+#: pkg/users/index.html:130
+msgid "Authorized Public SSH Keys"
+msgstr "Upoważnione publiczne klucze SSH"
+
+#: pkg/networkmanager/index.html:165
+msgid "Automatic"
+msgstr "Automatyczne"
+
+#: pkg/networkmanager/interfaces.js:1814
+msgid "Automatic (DHCP only)"
+msgstr "Automatyczne (tylko DHCP)"
+
+#: pkg/networkmanager/interfaces.js:1804
+msgid "Automatic (DHCP)"
+msgstr "Automatyczne (DHCP)"
+
+#: pkg/systemd/index.html:406
+msgid "Automatically using NTP"
+msgstr "Automatycznie za pomocą NTP"
+
+#: pkg/systemd/index.html:407
+msgid "Automatically using specific NTP servers"
+msgstr "Automatycznie za pomocą podanych serwerów NTP"
+
+#: pkg/lib/machine-change-auth.html:66
+msgid "Available"
+msgstr "Dostępne"
+
+#: pkg/storaged/overview.js:619
+msgid "Available targets on $0"
+msgstr "Dostępne cele w $0"
+
+#: pkg/dashboard/index.html:177
+msgid "Avatar"
+msgstr "Awatar"
+
+#: pkg/kubernetes/scripts/volumes.js:207
+msgid "Azure"
+msgstr "Azure"
+
+#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
+msgid "Bad data passed for passwd1 mechanism"
+msgstr "Przekazano błędne dane dla mechanizmu passwd1"
+
+#: pkg/networkmanager/index.html:389
+msgid "Balancer"
+msgstr ""
+
+#: pkg/storaged/index.html:560
 msgctxt "storage"
-msgid "Optical Drive"
-msgstr "Napęd optyczny"
+msgid "Bitmap"
+msgstr "Bitmapa"
+
+#: pkg/storaged/index.html:414
+msgid "Block Device"
+msgstr "Urządzenie blokowe"
+
+#: pkg/storaged/details.js:871
+msgid "Block device for filesystems"
+msgstr "Urządzenie blokowe dla systemów plików"
+
+#: pkg/storaged/details.js:1596
+msgid "Blocked"
+msgstr "Zablokowane"
+
+#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
+#: pkg/networkmanager/interfaces.js:2507
+msgid "Bond"
+msgstr "Wiązanie"
+
+#: pkg/networkmanager/index.html:596
+msgid "Bond Settings"
+msgstr "Ustawienia węzła"
+
+#: pkg/kubernetes/views/node-body.html:17
+msgid "Boot ID"
+msgstr "Identyfikator uruchomienia"
+
+#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
+#: pkg/networkmanager/interfaces.js:2584
+msgid "Bridge"
+msgstr "Mostek"
+
+#: pkg/networkmanager/index.html:708
+msgid "Bridge Port Settings"
+msgstr "Ustawienia portu mostku"
+
+#: pkg/networkmanager/index.html:680
+msgid "Bridge Settings"
+msgstr "Ustawienia mostka"
+
+#: pkg/networkmanager/interfaces.js:2605
+msgid "Bridge port"
+msgstr "Port mostku"
+
+#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
+msgid "Broadcast"
+msgstr "Broadcast"
+
+#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#, fuzzy
+msgid "Broken configuration"
+msgstr "Nieznana konfiguracja"
+
+#: pkg/kubernetes/views/image-body.html:16
+msgid "Built"
+msgstr "Zbudowane"
+
+#: pkg/dashboard/index.html:70
+msgid "CPU"
+msgstr "Procesor"
+
+#: pkg/systemd/host.js:1381
+msgctxt "page-title"
+msgid "CPU Status"
+msgstr "Stan procesora"
+
+#: pkg/kubernetes/scripts/nodes.js:712
+msgid "CPU Utilization: $0%"
+msgstr "Użycie procesora: $0%"
+
+#: pkg/docker/index.html:490 pkg/docker/index.html:669
+msgid "CPU priority"
+msgstr "Priorytet procesora"
+
+#: pkg/systemd/index.html:247
+msgid "Cached"
+msgstr "W pamięci podręcznej"
+
+#: pkg/docker/index.html:63
+msgid "Can&rsquo;t connect to Docker"
+msgstr "Nie można połączyć z Dockerem"
+
+#: pkg/systemd/services.html:465 pkg/dashboard/index.html:189
+#: pkg/playground/translate.html:40 pkg/playground/translate.html:174
+#: pkg/realmd/operation.html:90 pkg/kubernetes/views/pv-modify.html:202
+#: pkg/kubernetes/views/item-delete.html:10
+#: pkg/kubernetes/views/add-user-dialog.html:30
+#: pkg/kubernetes/views/project-modify.html:71
+#: pkg/kubernetes/views/node-add.html:49
+#: pkg/kubernetes/views/pvc-delete.html:14
+#: pkg/kubernetes/views/node-delete.html:14
+#: pkg/kubernetes/views/imagestream-modify.html:96
+#: pkg/kubernetes/views/imagestream-delete.html:7
+#: pkg/kubernetes/views/user-modify.html:30
+#: pkg/kubernetes/views/add-group-dialog.html:20
+#: pkg/kubernetes/views/project-delete.html:8
+#: pkg/kubernetes/views/service-modify.html:24
+#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/kubernetes/views/user-group-remove.html:9
+#: pkg/kubernetes/views/user-add-membership.html:52
+#: pkg/kubernetes/views/add-member-role-dialog.html:60
+#: pkg/kubernetes/views/group-delete.html:20
+#: pkg/kubernetes/views/image-delete.html:7 pkg/kubernetes/views/deploy.html:61
+#: pkg/kubernetes/views/user-group-add.html:31
+#: pkg/kubernetes/views/auth-form.html:128
+#: pkg/kubernetes/views/auth-rejected-cert.html:31
+#: pkg/kubernetes/views/replicationcontroller-modify.html:16
+#: pkg/kubernetes/views/pv-delete.html:10
+#: pkg/kubernetes/views/add-role-dialog.html:7
+#: pkg/kubernetes/views/route-modify.html:16
+#: pkg/kubernetes/views/user-delete.html:24
+#: pkg/kubernetes/views/remove-role-dialog.html:7 pkg/storaged/index.html:289
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:79
+msgid "Cancel"
+msgstr "Anuluj"
+
+#: pkg/shell/indexes.js:322
+msgid "Cannot connect to an unknown machine"
+msgstr "Nie można połączyć z nieznanym komputerem"
+
+#: src/ws/cockpitcertificate.c:359
+msgid "Cannot decrypt PEM-encoded private key"
+msgstr "Nie można odszyfrować klucza prywatnego zakodowanego jako PEM"
+
+#: src/base1/cockpit.js:3707
+msgid "Cannot forward login credentials"
+msgstr "Nie można przekazać danych uwierzytelniania logowania"
+
+#: pkg/realmd/operation.js:417
+msgid "Cannot join a domain because realmd is not available on this system"
+msgstr ""
+"Nie można dołączyć do domeny, ponieważ usługa realmd nie jest dostępna "
+"w systemie"
+
+#: pkg/kubernetes/views/pv-modify.html:44
+#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pv-body.html:13
+msgid "Capacity"
+msgstr "Pojemność"
+
+#: pkg/storaged/index.html:443 pkg/storaged/index.html:519
+#: pkg/storaged/index.html:551 pkg/storaged/index.html:630
+msgctxt "storage"
+msgid "Capacity"
+msgstr "Pojemność"
+
+#: pkg/networkmanager/interfaces.js:2276
+msgid "Carrier"
+msgstr "Operator"
+
+#: pkg/kubernetes/scripts/volumes.js:203
+msgid "Ceph Filesystem Mount"
+msgstr "Punkt montowania systemu plików Ceph"
+
+#: pkg/kubernetes/views/volume-body.html:97
+msgid "Ceph Monitors"
+msgstr "Monitory Ceph"
+
+#: pkg/kubernetes/views/pv-modify.html:204
+#: pkg/kubernetes/views/project-modify.html:74
+#: pkg/kubernetes/views/replicationcontroller-modify.html:17
+#: pkg/kubernetes/views/route-modify.html:17
+msgid "Change"
+msgstr "Zmień"
+
+#: pkg/shell/index.html:278
+msgid "Change Password"
+msgstr "Zmień hasło"
+
+#: pkg/tuned/dialog.js:191
+msgid "Change Performance Profile"
+msgstr "Zmień profil wydajności"
+
+#: pkg/tuned/dialog.js:200
+msgid "Change Profile"
+msgstr "Zmień profil"
+
+#: pkg/kubernetes/views/user-modify.html:3
+msgid "Change User"
+msgstr "Zmień użytkownika"
+
+#: pkg/storaged/overview.js:699
+msgid "Change iSCSI Initiator Name"
+msgstr "Zmień nazwę inicjatora iSCSI"
+
+#: pkg/kubernetes/views/imagestream-modify.html:4
+msgid "Change image stream"
+msgstr "Zmień potok obrazu"
+
+#: pkg/kubernetes/views/project-modify.html:10
+msgid "Change project"
+msgstr "Zmień projekt"
+
+#: pkg/networkmanager/interfaces.js:2872
+#, fuzzy
+msgid "Change the settings"
+msgstr "Ustawienia połączenia"
+
+#: pkg/networkmanager/interfaces.js:2870
+msgid "Changing the settings will break the connection to the server, "
+msgstr ""
+
+#: pkg/ostree/index.html:48
+msgid "Check for updates"
+msgstr "Wyszukaj aktualizacje"
+
+#: pkg/networkmanager/interfaces.js:817
+msgid "Checking IP"
+msgstr "Sprawdzanie IP"
+
+#: pkg/storaged/jobs.js:143
+#, fuzzy
+msgid "Checking RAID Device $target"
+msgstr "Tworzenie urządzenia RAID $target"
+
+#: pkg/storaged/jobs.js:144
+#, fuzzy
+msgid "Checking and Repairing RAID Device $target"
+msgstr "Tworzenie urządzenia RAID $target"
+
+#: pkg/lib/machine-change-auth.html:70
+msgid "Checking for public keys"
+msgstr "Wyszukiwanie kluczy publicznych"
+
+#: pkg/ostree/app.js:219
+msgid "Checking for updates"
+msgstr "Wyszukiwanie aktualizacji"
+
+#: pkg/shell/simple.html:100 pkg/shell/index.html:121 pkg/shell/stub.html:114
+msgid "Choose the language to be used in the application"
+msgstr "Proszę wybrać język używany w aplikacji"
+
+#: pkg/storaged/overview.js:431
+msgid "Chunk Size"
+msgstr "Rozmiar bloku"
+
+#: pkg/kubernetes/scripts/volumes.js:202
+msgid "Cinder"
+msgstr "Cinder"
+
+#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
+msgid "Claim"
+msgstr "Zadeklaruj"
+
+#: pkg/kubernetes/views/pvc-body.html:4
+msgid "Claim Name"
+msgstr "Nazwa deklaracji"
+
+#: pkg/storaged/jobs.js:135
+msgid "Cleaning up for $target"
+msgstr "Czyszczenie dla $target"
+
+#: pkg/kubernetes/views/auth-form.html:88
+msgid "Client Certificate"
+msgstr "Certyfikat klienta"
+
+#: pkg/systemd/services.html:306 pkg/systemd/services.html:324
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-invalid-hostkey.html:19
+msgid "Close"
+msgstr "Zamknij"
+
+#: pkg/kubernetes/views/auth-form.html:5
+msgid "Cluster"
+msgstr "Klaster"
+
+#: cockpit.desktop.in.h:1
+msgid "Cockpit"
+msgstr "Cockpit"
+
+#: pkg/lib/machine-dialogs.js:429
+msgid ""
+"Cockpit could not contact the given host $0. Make sure it has ssh running on "
+"port $1, or specify another port in the address."
+msgstr ""
+"Cockpit nie może skontaktować się z podanym komputerem $0. Proszę się "
+"upewnić, że ma on uruchomioną usługę ssh na porcie $1 lub podać inny port "
+"w adresie."
+
+#: src/base1/cockpit.js:3713
+msgid "Cockpit could not contact the given host."
+msgstr "Cockpit nie może skontaktować się z podanym komputerem."
+
+#: pkg/shell/base_index.js:671
+msgid "Cockpit had an unexpected internal error. <br/><br/>"
+msgstr "Wystąpił nieoczekiwany wewnętrzny błąd w programie Cockpit. <br/><br/>"
+
+#: cockpit.appdata.xml.in.h:1
+msgid ""
+"Cockpit is a server manager that makes it easy to administer your Linux "
+"servers via a web browser. Jumping between the terminal and the web tool is "
+"no problem. A service started via Cockpit can be stopped via the terminal. "
+"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
+"journal interface."
+msgstr ""
+"Cockpit to menedżer serwerów ułatwiający administrowanie serwerów Linux "
+"przez przeglądarkę WWW. Można z łatwością przechodzić między terminalem "
+"a narzędziami WWW. Usługa uruchomiona za pomocą Cockpit może zostać "
+"zatrzymana za pomocą terminala. Jeśli błąd wystąpi w terminalu, to można go "
+"zobaczyć w interfejsie dziennika Cockpit."
+
+#: src/base1/cockpit.js:3711
+msgid "Cockpit is not compatible with the software on the system."
+msgstr "Cockpit nie jest zgodny z oprogramowaniem w systemie."
+
+#: pkg/lib/machine-not-supported.html:2
+msgid "Cockpit is not installed"
+msgstr "Cockpit nie jest zainstalowany"
+
+#: src/base1/cockpit.js:3705
+msgid "Cockpit is not installed on the system."
+msgstr "Cockpit nie jest zainstalowany w systemie."
+
+#: cockpit.appdata.xml.in.h:2
+msgid ""
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
+"tasks such as storage administration, inspecting journals and starting and "
+"stopping services. You can monitor and administer several servers at the "
+"same time. Just add them with a single click and your machines will look "
+"after its buddies."
+msgstr ""
+"Cockpit jest idealny dla nowych administratorów, umożliwiając łatwe "
+"wykonywanie prostych zadań, takich jak administracja urządzeniami do "
+"przechowywania danych, badanie dzienników oraz uruchamianie i zatrzymywanie "
+"usług. Można monitorować i administrować wiele serwerów w tym samym czasie. "
+"Wystarczy dodać je pojedynczym kliknięciem."
+
+#: pkg/lib/machine-change-port.html:9
+msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
+msgstr "Cockpit nie może skontaktować się z {{#strong}}{{host}}{{/strong}}."
+
+#: pkg/lib/machine-auth-failed.html:15
+msgid ""
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
+msgstr ""
+"Cockpit nie może zalogować do {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"Można spróbować {{#sync_link}}synchronizować użytkowników{{/sync_link}}.{{/"
+"can_sync}} Zaktualizowanie cockpit-ws do nowszej wersji udostępni więcej "
+"opcji uwierzytelniania i pomocy w rozwiązywaniu problemów."
+
+#: pkg/lib/machine-change-auth.html:9
+msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
+msgstr "Cockpit nie może zalogować się do {{#strong}}{{host}}{{/strong}}."
+
+#: pkg/lib/machine-auth-failed.html:6
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
+"machine with cockpit you will need to enable one of the following "
+"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
+msgstr ""
+"Cockpit nie może zalogować się do {{#strong}}{{host}}{{/strong}}. Aby używać "
+"tego komputera za pomocą programu Cockpit, należy włączyć jedną z poniższych "
+"metod uwierzytelniania w konfiguracji usługi sshd w {{#strong}}{{host}}{{/"
+"strong}}:"
+
+#: pkg/lib/machine-change-auth.html:13
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
+"change your authentication credentials below. {{#can_sync}}You may prefer to "
+"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+msgstr ""
+"Cockpit nie może zalogować się do {{#strong}}{{host}}{{/strong}}. Poniżej "
+"można zmienić dane uwierzytelniające. {{#can_sync}}Można też {{#sync_link}}"
+"synchronizować konta i hasła{{/sync_link}}.{{/can_sync}}"
+
+#: pkg/dashboard/index.html:171 pkg/lib/machine-add.html:27
+msgid "Color"
+msgstr "Kolor"
+
+#: pkg/docker/index.html:95
+msgid "Combined CPU usage"
+msgstr "Łączne użycie procesora"
+
+#: pkg/docker/index.html:101
+msgid "Combined memory usage"
+msgstr "Łączne użycie pamięci"
+
+#: pkg/systemd/services.html:370 pkg/docker/index.html:466
+#: pkg/docker/index.html:736
+msgid "Command"
+msgstr "Polecenie"
+
+#: pkg/docker/run.js:332
+#, fuzzy
+msgid "Command can't be empty"
+msgstr "Nazwa nie może być pusta."
+
+#: pkg/docker/containers-view.jsx:239
+#, fuzzy
+msgid "Commit"
+msgstr "Komentarz"
+
+#: pkg/tuned/dialog.js:114
+msgid "Communication with tuned has failed"
+msgstr "Komunikacja z tuned się nie powiodła"
+
+#: pkg/storaged/details.js:348
+msgid "Compatible with all systems and devices (MBR)"
+msgstr "Zgodne ze wszystkimi systemami i urządzeniami (MBR)"
+
+#: pkg/storaged/details.js:349
+msgid "Compatible with modern system and hard disks > 2TB (GPT)"
+msgstr "Zgodne z nowoczesnymi systemami i dyskami twardymi > 2 TB (GPT)"
+
+#: pkg/realmd/operation.html:28
+msgid "Computer OU"
+msgstr "OU komputera"
+
+#: pkg/kubernetes/views/node-add.html:24
+msgid "Configuration"
+msgstr "Konfiguracja"
+
+#: pkg/networkmanager/interfaces.js:2441
+msgid "Configure"
+msgstr "Skonfiguruj"
+
+#: pkg/kubernetes/views/node-add.html:42
+msgid "Configure Flannel networking"
+msgstr "Skonfiguruj sieć Flannel"
+
+#: pkg/kubernetes/views/node-add.html:32
+msgid "Configure Kubelet and Proxy"
+msgstr "Skonfiguruj Kubernetes i pośrednika"
+
+#: pkg/networkmanager/interfaces.js:811
+msgid "Configuring"
+msgstr "Konfigurowanie"
+
+#: pkg/networkmanager/interfaces.js:815
+msgid "Configuring IP"
+msgstr "Konfigurowanie IP"
+
+#: pkg/users/index.html:171 pkg/shell/index.html:262
+msgid "Confirm"
+msgstr "Potwierdź"
+
+#: pkg/users/index.html:247
+msgid "Confirm New Password"
+msgstr "Potwierdź nowe hasło"
+
+#: pkg/storaged/details.js:229
+msgid "Confirm passphrase"
+msgstr "Potwierdź hasło"
+
+#: pkg/kubernetes/views/auth-form.html:130
+#: pkg/kubernetes/views/auth-rejected-cert.html:33
+#: pkg/lib/machine-unknown-hostkey.html:22
+msgid "Connect"
+msgstr "Połącz"
+
+#: pkg/networkmanager/interfaces.js:2637
+msgid "Connect automatically"
+msgstr "Łączenie automatyczne"
+
+#: pkg/ostree/index.html:218
+msgid "Connecting"
+msgstr "Łączenie"
+
+#: pkg/lib/machine-add.html:39
+msgid ""
+"Connecting simultaneously to more than {{ limit }} machines is unsupported."
+msgstr ""
+"Jednoczesne łączenie z więcej niż {{ limit }} komputerami jest "
+"nieobsługiwane."
+
+#: pkg/docker/index.html:54
+msgid "Connecting to Docker"
+msgstr "Łączenie z Dockerem"
+
+#: pkg/shell/indexes.js:317
+msgid "Connecting to the machine"
+msgstr "Łączenie z komputerem"
+
+#: pkg/kubernetes/registry.html:70 pkg/kubernetes/index.html:100
+msgid "Connecting..."
+msgstr "Łączenie…"
+
+#: pkg/kubernetes/views/auth-dialog.html:4
+msgid "Connection Error"
+msgstr "Błąd połączenia"
+
+#: pkg/kubernetes/scripts/connection.js:516
+msgid "Connection Error: $0"
+msgstr "Błąd połączenia: $0"
+
+#: pkg/kubernetes/views/auth-dialog.html:3
+msgid "Connection Settings"
+msgstr "Ustawienia połączenia"
+
+#: src/base1/cockpit.js:3703
+msgid "Connection has timed out."
+msgstr "Połączenie przekroczyło czas oczekiwania."
+
+#: pkg/networkmanager/index.html:812
+#, fuzzy
+msgid "Connection will be lost"
+msgstr "Połączenie przekroczyło czas oczekiwania."
+
+#: pkg/docker/console.html:4 pkg/kubernetes/views/container-panel.html:4
+#: pkg/kubernetes/views/image-panel.html:12
+#: pkg/kubernetes/views/container-body.html:4
+#: pkg/kubernetes/views/container-page-inline.html:2
+#: pkg/kubernetes/views/image-page.html:19
+msgid "Container"
+msgstr "Kontener"
+
+#: pkg/users/local.js:684
+msgid "Container Administrator"
+msgstr "Administrator kontenera"
+
+#: pkg/kubernetes/views/container-body.html:10
+msgid "Container ID"
+msgstr "Identyfikator kontenera"
+
+#: pkg/docker/index.html:459 pkg/docker/index.html:646
+#: pkg/docker/index.html:712
+msgid "Container Name"
+msgstr "Nazwa kontenera"
+
+#: pkg/kubernetes/views/node-body.html:21
+msgid "Container Runtime Version"
+msgstr "Wersja środowiska wykonawczego kontenera"
+
+#: pkg/docker/util.js:490
+msgid ""
+"Container is currently marked as not running, but regular stopping failed."
+msgstr ""
+"Kontener jest obecnie oznaczony jako działający, ale zwykłe zatrzymanie się "
+"nie powiodło."
+
+#: pkg/docker/util.js:488
+msgid "Container is currently running."
+msgstr "Kontener jest obecnie uruchomiony."
+
+#: pkg/docker/index.html:23 pkg/docker/index.html:309
+#: pkg/kubernetes/views/pod-page.html:36
+#: pkg/kubernetes/views/dashboard-page.html:158
+#: pkg/kubernetes/views/dashboard-page.html:199
+#: pkg/kubernetes/views/containers-listing.html:5 pkg/kubernetes/index.html:51
+msgid "Containers"
+msgstr "Kontenery"
+
+#: pkg/docker/details.js:47 pkg/docker/image.js:43
+msgctxt "page-title"
+msgid "Containers"
+msgstr "Kontenery"
+
+#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
+msgid "Content"
+msgstr "Zawartość"
+
+#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
+#: pkg/playground/translate.js:19
+#, fuzzy
+msgid "Control"
+msgstr "Kontener"
+
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
+#: pkg/playground/translate.js:22
+#, fuzzy
+msgctxt "key"
+msgid "Control"
+msgstr "Kontener"
+
+#: pkg/docker/storage.jsx:404
+#, fuzzy
+msgid "Could not add all disks"
+msgstr "Nie można wyświetlić listy usług"
+
+#: pkg/lib/machine-change-port.html:4
+msgid "Could not contact {{host}}"
+msgstr "Nie można skontaktować się z {{host}}"
+
+#: pkg/kubernetes/views/dashboard-page.html:142
+msgid "Could not list services"
+msgstr "Nie można wyświetlić listy usług"
+
+#: src/ws/cockpitcertificate.c:407
+msgid "Could not parse PEM-encoded certificate"
+msgstr "Nie można przetworzyć certyfikatu zakodowanego jako PEM"
+
+#: src/ws/cockpitcertificate.c:374
+msgid "Could not parse PEM-encoded private key"
+msgstr "Nie można przetworzyć klucza prywatnego zakodowanego jako PEM"
+
+#: pkg/docker/storage.jsx:446
+msgid "Could not reset the storage pool"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:467
+msgid "Couldn't change user groups"
+msgstr "Nie można zmienić grup użytkownika"
+
+#: src/bridge/cockpitdbussetup.c:520
+msgid "Couldn't change user password"
+msgstr "Nie można zmienić hasła użytkownika"
+
+#: pkg/selinux/setroubleshoot-view.jsx:385
+msgid ""
+"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
+"server is installed."
+msgstr ""
+
+#: pkg/kubernetes/registry.html:71 pkg/kubernetes/index.html:101
+msgid "Couldn't connect to server"
+msgstr "Nie można połączyć z serwerem"
+
+#: pkg/shell/indexes.js:320
+msgid "Couldn't connect to the machine"
+msgstr "Nie można połączyć z komputerem"
+
+#: src/bridge/cockpitdbussetup.c:544
+msgid "Couldn't create new users"
+msgstr "Nie można utworzyć nowych użytkowników"
+
+#: pkg/kubernetes/scripts/connection.js:514
+msgid "Couldn't find running API server"
+msgstr "Nie można odnaleźć uruchomionego serwera API"
+
+#: pkg/subscriptions/subscriptions-view.jsx:196
+#, fuzzy
+msgid ""
+"Couldn't get system subscription status. Please ensure subscription-manager "
+"is installed."
+msgstr ""
+"\n"
+"        Proszę upewnić się, że program subscription-manager jest "
+"zainstalowany, aby zarządzać subskrypcjami systemu.\n"
+"      "
+
+#: src/bridge/cockpitdbussetup.c:642
+msgid "Couldn't list local users"
+msgstr "Nie można wyświetlić listy lokalnych użytkowników"
+
+#: src/bridge/cockpitdbussetup.c:236
+msgid "Couldn't list users"
+msgstr "Nie można wyświetlić listy użytkowników"
+
+#: src/bridge/cockpitdbussetup.c:382
+msgid "Couldn't load user data"
+msgstr "Nie można wczytać danych użytkownika"
+
+#: pkg/kubernetes/views/project-modify.html:72
+#: pkg/kubernetes/views/add-group-dialog.html:21
+msgid "Create"
+msgstr "Utwórz"
+
+#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
+msgid "Create Logical Volume"
+msgstr "Utwórz wolumin logiczny"
+
+#: pkg/users/index.html:54 pkg/users/index.html:143
+msgid "Create New Account"
+msgstr "Utwórz nowe konto"
+
+#: pkg/storaged/details.js:1379
+msgid "Create Partition"
+msgstr "Utwórz partycję"
+
+#: pkg/storaged/overview.js:414
+msgid "Create RAID Device"
+msgstr "Utwórz urządzenie RAID"
+
+#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
+msgid "Create Snapshot"
+msgstr "Utwórz migawkę"
+
+#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
+msgid "Create Thin Volume"
+msgstr "Utwórz cienki wolumin"
+
+#: pkg/systemd/services.html:336
+#, fuzzy
+msgid "Create Timers"
+msgstr "Utwórz cienki wolumin"
+
+#: pkg/storaged/overview.js:487
+msgid "Create Volume Group"
+msgstr "Utwórz grupę woluminów"
+
+#: pkg/sosreport/index.html:50
+msgid "Create diagnostic report"
+msgstr "Utwórz raport diagnostyczny"
+
+#: pkg/kubernetes/views/imagestream-modify.html:3
+msgid "Create image stream"
+msgstr "Utwórz potok obrazu"
+
+#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
+#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
+#, fuzzy
+msgid "Create it"
+msgstr "Utwórz"
+
+#: pkg/storaged/details.js:266
+msgid "Create partition"
+msgstr "Utwórz partycję"
+
+#: pkg/storaged/details.js:113
+msgid "Create partition on $0"
+msgstr "Utwórz partycję w $0"
+
+#: pkg/storaged/index.html:381
+msgid "Create partition table"
+msgstr "Utwórz tablicę partycji"
+
+#: pkg/sosreport/index.html:42
+msgid "Create report"
+msgstr "Utwórz raport"
+
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/replicationcontroller-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7 pkg/kubernetes/views/route-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3
+msgid "Created"
+msgstr "Utworzono"
+
+#: pkg/storaged/jobs.js:142
+msgid "Creating RAID Device $target"
+msgstr "Tworzenie urządzenia RAID $target"
+
+#: pkg/storaged/jobs.js:130
+msgid "Creating filesystem on $target"
+msgstr "Tworzenie systemu plików w $target"
+
+#: pkg/storaged/jobs.js:156
+msgid "Creating logical volume $target"
+msgstr "Tworzenie woluminu logicznego $target"
+
+#: pkg/storaged/jobs.js:134
+msgid "Creating partition $target"
+msgstr "Tworzenie partycji $target"
+
+#: pkg/storaged/jobs.js:150
+msgid "Creating snapshot of $target"
+msgstr "Tworzenie migawki $target"
+
+#: pkg/networkmanager/interfaces.js:4064
+msgid "Creating this VLAN will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3436
+msgid "Creating this bond will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3842
+msgid "Creating this bridge will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3611
+msgid "Creating this team will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:151
+msgid "Creating volume group $target"
+msgstr "Tworzenie grupy woluminów $target"
+
+#: pkg/systemd/logs.html:41
+msgid "Current boot"
+msgstr "Obecne uruchomienie"
+
+#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
+msgid "Custom"
+msgstr "Własne"
+
+#: pkg/storaged/details.js:186
+msgid "Custom (Enter filesystem type)"
+msgstr "Własne (proszę podać typ systemu plików)"
+
+#: pkg/subscriptions/subscriptions-register.jsx:102
+#, fuzzy
+msgid "Custom URL"
+msgstr "Własne"
+
+#: pkg/storaged/index.html:454
+msgid "DISK IS FAILING"
+msgstr "NA DYSKU WYSTĘPUJĄ BŁĘDY"
+
+#: pkg/networkmanager/interfaces.js:3018
+msgid "DNS"
+msgstr "DNS"
+
+#: pkg/kubernetes/views/pod-body.html:14
+msgid "DNS Policy"
+msgstr "Polityka DNS"
+
+#: pkg/networkmanager/interfaces.js:3022
+msgid "DNS Search Domains"
+msgstr "Domeny wyszukiwania DNS"
+
+#: pkg/dashboard/index.html:22
+msgid "Dashboard"
+msgstr ""
+
+#: pkg/storaged/details.js:1130
+msgid "Deactivate"
+msgstr "Dezaktywuj"
+
+#: pkg/networkmanager/interfaces.js:823
+msgid "Deactivating"
+msgstr "Dezaktywowanie"
+
+#: pkg/storaged/jobs.js:149
+msgid "Deactivating $target"
+msgstr "Dezaktywowanie $target"
+
+#: pkg/docker/index.html:379 pkg/docker/index.html:383
+#: pkg/kubernetes/views/image-config.html:6
+msgid "Default"
+msgstr "Domyślne"
+
+#: pkg/systemd/index.html:454
+msgid "Delay"
+msgstr "Opóźnienie"
+
+#: pkg/users/index.html:79 pkg/kubernetes/views/item-delete.html:11
+#: pkg/kubernetes/views/pvc-delete.html:15
+#: pkg/kubernetes/views/node-delete.html:15
+#: pkg/kubernetes/views/imagestream-delete.html:8
+#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/kubernetes/views/image-delete.html:8
+#: pkg/kubernetes/views/pv-delete.html:11
+msgid "Delete"
+msgstr "Usuń"
+
+#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
+msgid "Delete $0"
+msgstr "Usuń $0"
+
+#: pkg/users/index.html:292
+msgid "Delete Files"
+msgstr "Usuń pliki"
+
+#: pkg/kubernetes/views/node-delete.html:4
+msgid "Delete Node"
+msgstr "Usuń węzeł"
+
+#: pkg/kubernetes/views/pv-delete.html:3
+msgid "Delete Persistent Volume"
+msgstr "Usuń trwały wolumin"
+
+#: pkg/kubernetes/views/pvc-delete.html:3
+msgid "Delete Persistent Volume Claim"
+msgstr "Usuń deklarację trwałego woluminu"
+
+#: pkg/kubernetes/views/project-delete.html:3
+msgid "Delete Project"
+msgstr "Usuń projekt"
+
+#: pkg/kubernetes/views/nodes-page.html:3
+msgid "Delete Selected"
+msgstr "Usuń zaznaczone"
+
+#: pkg/kubernetes/views/imagestream-delete.html:3
+msgid "Delete image stream"
+msgstr "Usuń potok obrazu"
+
+#: pkg/playground/translate.html:184 pkg/kubernetes/views/item-delete.html:3
+msgid "Delete {{ item.kind }}"
+msgstr "Usuń {{ item.kind }}"
+
+#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
+msgid "Deleting $target"
+msgstr "Usuwanie $target"
+
+#: pkg/networkmanager/interfaces.js:2156
+msgid "Deleting <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:7
+msgid ""
+"Deleting a Pod will kill all associated containers. Pods may be "
+"automatically created again in some cases."
+msgstr ""
+"Usunięcie pojemnika zakończy wszystkie powiązane kontenery. W niektórych "
+"przypadkach pojemniki mogą być automatycznie tworzone ponownie.\n"
+"          "
+
+#: pkg/storaged/details.js:631
+msgid "Deleting a RAID device will erase all data on it."
+msgstr "Usunięcie urządzenia RAID usunie wszystkie znajdujące się na nim dane."
+
+#: pkg/docker/containers-view.jsx:167 pkg/docker/details.js:272
+msgid "Deleting a container will erase all data in it."
+msgstr "Usunięcie kontenera usunie wszystkie znajdujące się w nim dane."
+
+#: pkg/storaged/details.js:1009
+msgid "Deleting a logical volume will delete all data in it."
+msgstr ""
+"Usunięcie woluminu logicznego usunie wszystkie znajdujące się na nim dane."
+
+#: pkg/storaged/details.js:1012
+msgid "Deleting a partition will delete all data in it."
+msgstr "Usunięcie partycji usunie wszystkie znajdujące się na niej dane."
+
+#: pkg/storaged/details.js:826
+msgid "Deleting a volume group will erase all data on it."
+msgstr "Usunięcie grupy woluminów usunie wszystkie znajdujące się w niej dane."
+
+#: pkg/docker/image.js:152
+msgid ""
+"Deleting an image will delete it, but you can probably download it again if "
+"you need it later.  Unless this image has never been pushed to a repository, "
+"that is, in which case you probably can't download it again."
+msgstr ""
+"Usunięcie obrazu spowoduje jego usunięcie, ale prawdopodobnie można go "
+"pobrać ponownie w razie potrzeby. Wyjątkiem jest sytuacja, w której tego "
+"obrazu nigdy nie wysłano do repozytorium."
+
+#: pkg/storaged/jobs.js:152
+msgid "Deleting volume group $target"
+msgstr "Usuwanie grupy woluminów $target"
+
+#: pkg/kubernetes/views/dashboard-page.html:131
+#: pkg/kubernetes/views/deploy.html:62
+msgid "Deploy"
+msgstr "Wdroż"
+
+#: pkg/kubernetes/views/deploy.html:3
+msgid "Deploy Application"
+msgstr "Wdroż aplikację"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:22
+msgid "Deployment Causes"
+msgstr "Przyczyny wdrażania"
+
+#: pkg/kubernetes/views/deploymentconfig-panel.html:8
+#: pkg/kubernetes/views/deploymentconfig-page.html:12
+msgid "Deployment Config"
+msgstr "Konfiguracja wdrażania"
+
+#: pkg/kubernetes/views/details-page.html:98
+msgid "Deployment Configs"
+msgstr "Konfiguracje wdrożeń"
+
+#: pkg/systemd/services.html:356 pkg/kubernetes/views/project-modify.html:40
+#: pkg/kubernetes/views/image-body.html:6
+#: pkg/kubernetes/views/project-listing.html:15
+#: pkg/kubernetes/views/project-listing.html:54
+msgid "Description"
+msgstr "Opis"
+
+#: pkg/shell/index.html:197 pkg/kubernetes/index.html:63
+msgid "Details"
+msgstr "Szczegóły"
+
+#: pkg/storaged/index.html:543
+msgctxt "storage"
+msgid "Device"
+msgstr "Urządzenie"
+
+#: pkg/storaged/details.js:91
+msgid "Device $0 is a member of RAID Array $1"
+msgstr "Urządzenie $0 jest elementem macierzy RAID $1"
+
+#: pkg/storaged/details.js:97
+msgid "Device $0 is a physical volume of $1"
+msgstr "Urządzenie $0 jest fizycznym woluminem $1"
+
+#: pkg/storaged/details.js:85
+msgid "Device $0 is mounted on $1"
+msgstr "Urządzenie $0 jest zamontowane w $1"
+
+#: pkg/storaged/index.html:467 pkg/storaged/index.html:473
+#: pkg/storaged/index.html:515
+msgctxt "storage"
+msgid "Device File"
+msgstr "Plik urządzenia"
+
+#: pkg/sosreport/index.html:22
+msgid "Diagnostic reports"
+msgstr "Raporty diagnostyczne"
+
+#: pkg/kubernetes/views/image-body.html:20
+msgid "Digest"
+msgstr "Przegląd"
+
+#: pkg/kubernetes/views/image-config.html:7
+#: pkg/kubernetes/views/volume-body.html:28
+msgid "Directory"
+msgstr "Katalog"
+
+#: pkg/systemd/init.js:543
+msgid "Disable"
+msgstr "Wyłącz"
+
+#: pkg/tuned/dialog.js:234
+msgid "Disable tuned"
+msgstr "Wyłącz tuned"
+
+#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
+msgid "Disabled"
+msgstr "Wyłączone"
+
+#: pkg/shell/simple.html:120
+msgid "Disconnected"
+msgstr "Rozłączono"
+
+#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+msgid "Disk"
+msgstr "Dysk"
+
+#: pkg/dashboard/index.html:73
+#, fuzzy
+msgid "Disk I/O"
+msgstr "Dysk jest OK"
+
+#: pkg/kubernetes/scripts/nodes.js:720
+msgid "Disk Utilization: $0%"
+msgstr "Użycie dysku: $0%"
+
+#: pkg/storaged/index.html:457
+msgid "Disk is OK"
+msgstr "Dysk jest OK"
+
+#: pkg/storaged/index.html:584
+msgid "Disks"
+msgstr "Dyski"
+
+#: pkg/shell/simple.html:37 pkg/shell/simple.html:97 pkg/shell/index.html:37
+#: pkg/shell/index.html:118 pkg/shell/stub.html:37 pkg/shell/stub.html:111
+msgid "Display Language"
+msgstr "Wyświetl język"
+
+#: pkg/kubernetes/views/project-modify.html:31
+msgid "Display name"
+msgstr "Wyświetlana nazwa"
+
+#: pkg/kubernetes/views/add-role-dialog.html:5
+msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+msgstr "Dodać rolę „{{ fields.displayRole }}”?"
+
+#: pkg/kubernetes/views/imagestream-delete.html:5
+msgid ""
+"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}' image stream?"
+msgstr ""
+"Usunąć potok obrazu „{{stream.metadata.namespace}}/{{stream.metadata.name}}”?"
+
+#: pkg/kubernetes/views/pv-delete.html:6
+msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+msgstr "Usunąć trwały wolumin „{{item.metadata.name}}”?"
+
+#: pkg/kubernetes/views/pvc-delete.html:6
+msgid ""
+"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
+msgstr "Usunąć deklarację trwałego woluminu „{{item.metadata.name}}”?"
+
+#: pkg/kubernetes/views/item-delete.html:6
+msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+msgstr "Usunąć {{ item.kind }} „{{item.metadata.name}}”?"
+
+#: pkg/kubernetes/views/node-delete.html:7
+msgid "Do you want to delete this Node?"
+msgstr "Usunąć ten węzeł?"
+
+#: pkg/kubernetes/views/image-delete.html:5
+msgid ""
+"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+"{{stream.metadata.name}}:{{tag.tag}}'?"
+msgstr ""
+"Usunąć obraz z etykietą „{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}:{{tag.tag}}”?"
+
+#: pkg/kubernetes/views/remove-role-dialog.html:5
+msgid ""
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
+msgstr ""
+"Usunąć rolę „{{ fields.displayRole }}” z elementu {{ fields.member.metadata."
+"name }}?"
+
+#: pkg/kubernetes/views/image-meta.html:11
+msgid "Docker Version"
+msgstr "Wersja Dockera"
+
+#: pkg/docker/index.html:60
+msgid "Docker is not installed or activated on the system"
+msgstr "Docker nie jest zainstalowany lub aktywowany w tym systemie"
+
+#: pkg/systemd/index.html:107
+msgid "Domain"
+msgstr "Domena"
+
+#: pkg/realmd/operation.js:148
+msgid "Domain $0 could not be contacted"
+msgstr "Nie można skontaktować się z domeną $0"
+
+#: pkg/realmd/operation.js:220
+msgid "Domain $0 is not supported"
+msgstr "Domena $0 jest nieobsługiwana"
+
+#: pkg/realmd/operation.html:11
+msgid "Domain Address"
+msgstr "Adres domeny"
+
+#: pkg/realmd/operation.html:59
+msgid "Domain Administrator Name"
+msgstr "Nazwa administratora domeny"
+
+#: pkg/realmd/operation.html:65
+msgid "Domain Administrator Password"
+msgstr "Hasło administratora domeny"
+
+#: pkg/systemd/services.html:426 pkg/systemd/services.html:430
+msgid "Don't Repeat"
+msgstr ""
+
+#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
+msgid "Don't overwrite existing data"
+msgstr "Nie zastępuj istniejących danych"
+
+#: pkg/sosreport/index.html:74
+msgid "Done!"
+msgstr "Gotowe."
+
+#: pkg/ostree/index.html:127 pkg/ostree/index.html:158
+msgid "Downgrades"
+msgstr "Zainstalowane w starszej wersji"
+
+#: pkg/storaged/index.html:411
+msgid "Drive"
+msgstr "Napęd"
 
 #: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
 msgctxt "storage"
 msgid "Drive"
 msgstr "Napęd"
 
-#: pkg/storaged/overview.js:253
-msgid "$0 Block Device"
-msgstr "Urządzenie blokowe $0"
+#: pkg/kubernetes/views/volume-body.html:128
+msgid "Driver"
+msgstr "Sterownik"
 
-#: pkg/storaged/overview.js:414
-msgid "Create RAID Device"
-msgstr "Utwórz urządzenie RAID"
+#: pkg/storaged/index.html:166
+msgid "Drives"
+msgstr "Napędy"
 
-#: pkg/storaged/overview.js:420
-msgid "RAID Level"
-msgstr "Poziom macierzy RAID"
+#: pkg/docker/run.js:360
+msgid "Duplicate alias"
+msgstr "Podwójny alias"
 
-#: pkg/storaged/overview.js:422
-msgid "RAID 0 (Stripe)"
-msgstr "RAID 0 (Striping)"
+#: pkg/docker/run.js:293
+msgid "Duplicate port"
+msgstr "Podwójny port"
 
-#: pkg/storaged/overview.js:423
-msgid "RAID 1 (Mirror)"
-msgstr "RAID 1 (Lustrzany)"
+#: pkg/storaged/jobs.js:120
+msgid "Ejecting $target"
+msgstr "Wysuwanie $target"
 
-#: pkg/storaged/overview.js:424
-msgid "RAID 4 (Dedicated Parity)"
-msgstr "RAID 4 (Dedykowana parzystość)"
+#: pkg/playground/translate.html:58
+msgid "Empty"
+msgstr "Puste"
 
-#: pkg/storaged/overview.js:425
-msgid "RAID 5 (Distributed Parity)"
-msgstr "RAID 5 (Rozproszona parzystość)"
-
-#: pkg/storaged/overview.js:426
-msgid "RAID 6 (Double Distributed Parity)"
-msgstr "RAID 6 (Podwójna rozproszona parzystość)"
-
-#: pkg/storaged/overview.js:427
-msgid "RAID 10 (Stripe of Mirrors)"
-msgstr "RID 10 (Striping lustrzany)"
-
-#: pkg/storaged/overview.js:431
-msgid "Chunk Size"
-msgstr "Rozmiar bloku"
-
-#: pkg/storaged/overview.js:433
-msgid "4 KiB"
-msgstr "4 KiB"
-
-#: pkg/storaged/overview.js:434
-msgid "8 KiB"
-msgstr "8 KiB"
-
-#: pkg/storaged/overview.js:435
-msgid "16 KiB"
-msgstr "16 KiB"
-
-#: pkg/storaged/overview.js:436
-msgid "32 KiB"
-msgstr "32 KiB"
-
-#: pkg/storaged/overview.js:437
-msgid "64 KiB"
-msgstr "64 KiB"
-
-#: pkg/storaged/overview.js:438
-msgid "128 KiB"
-msgstr "128 KiB"
-
-#: pkg/storaged/overview.js:439
-msgid "512 KiB"
-msgstr "512 KiB"
-
-#: pkg/storaged/overview.js:440
-msgid "1 MiB"
-msgstr "1 MiB"
-
-#: pkg/storaged/overview.js:441
-msgid "2 MiB"
-msgstr "2 MiB"
-
-#: pkg/storaged/overview.js:455
-msgid "At least $0 disks are needed."
-msgstr "Wymagane są co najmniej $0 dyski."
-
-#: pkg/storaged/overview.js:487
-msgid "Create Volume Group"
-msgstr "Utwórz grupę woluminów"
-
-#: pkg/storaged/overview.js:515
-msgid "Add iSCSI Portal"
-msgstr "Dodaj portal iSCSI"
-
-#: pkg/storaged/overview.js:518
-msgid "Server Address"
-msgstr "Adres serwera"
-
-#: pkg/storaged/overview.js:521
+#: pkg/playground/translate.html:63
 #, fuzzy
-msgid "Server address cannot be empty."
-msgstr "Adres serwera nie może być pusty."
+msgctxt "verb"
+msgid "Empty"
+msgstr "Puste"
 
-#: pkg/storaged/overview.js:533 pkg/realmd/operation.html.h:11
-msgid "Next"
-msgstr "Dalej"
+#: pkg/kubernetes/scripts/volumes.js:196
+msgid "Empty Directory"
+msgstr "Pusty katalog"
 
-#: pkg/storaged/overview.js:577 pkg/storaged/overview.js:668
-#: pkg/subscriptions/subscriptions-client.js:194
+#: pkg/storaged/jobs.js:155
+msgid "Emptying $target"
+msgstr "Opróżnianie $target"
+
+#: pkg/systemd/init.js:541
+msgid "Enable"
+msgstr "Włącz"
+
+#: pkg/systemd/init.js:542
+msgid "Enable Forcefully"
+msgstr "Wymuś włączenie"
+
+#: pkg/systemd/init.js:301
+msgid "Enabled"
+msgstr "Włączone"
+
+#: pkg/storaged/details.js:1247
+msgctxt "storage-id-desc"
+msgid "Encrypted"
+msgstr "Zaszyfrowane"
+
+#: pkg/storaged/details.js:180
+msgid "Encrypted EXT4 (LUKS)"
+msgstr "Szyfrowane EXT4 (LUKS)"
+
+#: pkg/storaged/details.js:179
+msgid "Encrypted XFS (LUKS)"
+msgstr "Szyfrowane XFS (LUKS)"
+
+#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
+#: pkg/storaged/details.js:1115
+msgid "Encryption Options"
+msgstr "Opcje szyfrowania"
+
+#: pkg/kubernetes/views/pv-modify.html:93
+msgid "Endpoint"
+msgstr "Punkt końcowy"
+
+#: pkg/kubernetes/views/volume-body.html:40
+msgid "Endpoint Name"
+msgstr "Nazwa punktu końcowego"
+
+#: pkg/kubernetes/views/service-page.html:14
+#: pkg/kubernetes/views/service-panel.html:9
+msgid "Endpoints"
+msgstr "Punkty końcowe"
+
+#: pkg/subscriptions/subscriptions-view.jsx:38
+msgid "Ends"
+msgstr "Kończy się"
+
+#: pkg/selinux/setroubleshoot-view.jsx:332
+msgid "Enforce policy:"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:447
+msgid "Enter IP address or host name"
+msgstr "Proszę podać adres IP lub nazwę komputera"
+
+#: pkg/systemd/logs.html:60
+msgid "Entry"
+msgstr "Wpis"
+
+#: pkg/docker/index.html:547 pkg/kubernetes/views/image-config.html:17
+#: pkg/kubernetes/views/container-body.html:26
+msgid "Environment"
+msgstr "Środowisko"
+
+#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
+msgid "Erase"
+msgstr "Wymaż"
+
+#: pkg/docker/storage.jsx:423
+msgid "Erase containers and reset storage pool"
+msgstr ""
+
+#: pkg/docker/storage.jsx:360
+msgid "Erase containers, reformat disks, and add them"
+msgstr ""
+
+#: pkg/storaged/jobs.js:129
+msgid "Erasing $target"
+msgstr "Czyszczenie $target"
+
+#: pkg/systemd/services.html:318 pkg/playground/translate.html:101
+#: pkg/playground/translate.html:106
+msgid "Error"
+msgstr "Błąd"
+
+#: pkg/kubernetes/scripts/connection.js:650
+msgid "Error getting certificate details: $0"
+msgstr "Błąd podczas uzyskiwania informacji o certyfikacie: $0"
+
+#: pkg/lib/machine-sync-users.html:13
+msgid "Error loading users: {{perm_failed}}"
+msgstr "Błąd podczas wczytywania użytkowników: {{perm_failed}}"
+
+#: pkg/docker/util.js:491
+msgid "Error message from Docker:"
+msgstr "Komunikat o błędzie Dockera:"
+
+#: pkg/users/authorized-keys.js:115
+msgid "Error saving authorized keys: "
+msgstr "Błąd podczas zapisywania upoważnionych kluczy: "
+
+#: pkg/selinux/setroubleshoot.js:275
+msgid "Error while connecting."
+msgstr "Błąd podczas łączenia."
+
+#: pkg/selinux/setroubleshoot-client.js:192
+msgid "Error while deleting alert"
+msgstr "Błąd podczas usuwania alarmu"
+
+#: pkg/selinux/setroubleshoot.js:65
+msgid "Error while setting SELinux mode: '$0'"
+msgstr "Błąd podczas ustawiania trybu SELinuksa: „$0”"
+
+#: pkg/kubernetes/scripts/connection.js:88
+msgid "Error writing kubectl config"
+msgstr "Błąd podczas zapisywania konfiguracji kubectl"
+
+#: pkg/systemd/logs.html:47
+msgid "Errors"
+msgstr "Błędy"
+
+#: pkg/networkmanager/index.html:764
+msgid "Ethernet MTU"
+msgstr "MTU ethernetu"
+
+#: pkg/networkmanager/interfaces.js:1854
+msgid "Ethtool"
+msgstr ""
+
+#: pkg/users/local.js:429 pkg/users/local.js:1104
+msgid "Excellent password"
+msgstr "Doskonałe hasło"
+
+#: pkg/docker/util.js:96
+msgid "Exited $ExitCode"
+msgstr "Zakończono $ExitCode"
+
+#: pkg/docker/index.html:529
+msgid "Expose container ports"
+msgstr "Uwidocznij porty kontenera"
+
+#: pkg/storaged/details.js:183
+msgid "Extended Partition"
+msgstr "Rozszerzona partycja"
+
+#: pkg/storaged/details.js:1592
+msgid "FAILED"
+msgstr "NIEPOWODZENIE"
+
+#: pkg/ostree/index.html:92
+msgid "Failed"
+msgstr "Niepowodzenie"
+
+#: pkg/lib/machine-dialogs.js:412
+msgid "Failed to add machine: $0"
+msgstr "Dodanie komputera się nie powiodło: $0"
+
+#: pkg/users/local.js:112 pkg/users/local.js:144 pkg/lib/credentials.js:223
+msgid "Failed to change password"
+msgstr "Zmiana hasła się nie powiodła"
+
+#: pkg/selinux/setroubleshoot-client.js:187
+msgid "Failed to delete alert"
+msgstr "Usunięcie alarmu się nie powiodło"
+
+#: pkg/tuned/dialog.js:171
+msgid "Failed to disable tuned"
+msgstr "Wyłączenie tuned się nie powiodło"
+
+#: pkg/tuned/dialog.js:133
+msgid "Failed to disable tuned profile"
+msgstr "Wyłączenie profilu tuned się nie powiodło"
+
+#: pkg/lib/machine-dialogs.js:494
+msgid "Failed to edit machine: $0"
+msgstr "Modyfikacja komputera się nie powiodła: $0"
+
+#: pkg/tuned/dialog.js:169
+msgid "Failed to enable tuned"
+msgstr "Włączenie tuned się nie powiodło"
+
+#: pkg/users/index.html:338
+msgid "Failed to load authorized keys."
+msgstr "Wczytanie upoważnionych kluczy się nie powiodło."
+
+#: pkg/docker/containers.js:64
+msgid "Failed to start Docker: $0"
+msgstr "Uruchomienie Dockera się nie powiodło: $0"
+
+#: pkg/docker/util.js:544
+msgid "Failed to stop Docker scope: $0"
+msgstr "Zatrzymanie zakresu Dockera się nie powiodło: $0"
+
+#: pkg/tuned/dialog.js:145
+msgid "Failed to switch profile"
+msgstr "Przełączenie profilu się nie powiodło"
+
+#: pkg/kubernetes/scripts/volumes.js:204
+msgid "Fibre Channel"
+msgstr "Fibre Channel"
+
+#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
+msgid "Filesystem Options"
+msgstr "Opcje systemu plików"
+
+#: pkg/kubernetes/views/pv-modify.html:180
+#: pkg/kubernetes/views/volume-body.html:6
+#: pkg/kubernetes/views/volume-body.html:16
+#: pkg/kubernetes/views/volume-body.html:62
+#: pkg/kubernetes/views/volume-body.html:83
+#: pkg/kubernetes/views/volume-body.html:91
+#: pkg/kubernetes/views/volume-body.html:120
+#: pkg/kubernetes/views/volume-body.html:132
+msgid "Filesystem Type"
+msgstr "Typ systemu plików"
+
+#: pkg/storaged/details.js:215
+msgid "Filesystem type"
+msgstr "Typ systemu plików"
+
+#: pkg/storaged/index.html:225
+msgid "Filesystems"
+msgstr "Systemy plików"
+
+#: pkg/lib/machine-unknown-hostkey.html:10
+msgid "Fingerprint"
+msgstr "Odcisk"
+
+#: pkg/storaged/index.html:426
+msgctxt "storage"
+msgid "Firmware Version"
+msgstr "Wersja oprogramowania sprzętowego"
+
+#: pkg/kubernetes/scripts/volumes.js:206
+msgid "Flex"
+msgstr "Flex"
+
+#: pkg/kubernetes/scripts/volumes.js:205
+msgid "Flocker"
+msgstr "Flocker"
+
+#: pkg/kubernetes/views/volume-body.html:125
+msgid "Flocker Dataset Name"
+msgstr "Nazwa zestawu danych Flocker"
+
+#: pkg/docker/util.js:503
+msgid "Force Delete"
+msgstr "Wymuś usunięcie"
+
+#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
+#: pkg/storaged/details.js:1142
+msgid "Format"
+msgstr "Sformatuj"
+
+#: pkg/storaged/details.js:115
+msgid "Format $0"
+msgstr "Sformatuj $0"
+
+#: pkg/storaged/details.js:335
+msgid "Format Disk $0"
+msgstr "Sformatuj dysk $0"
+
+#: pkg/storaged/details.js:358
+msgid "Formatting a disk will erase all data on it."
+msgstr "Sformatowanie dysku usunie wszystkie znajdujące się na nim dane."
+
+#: pkg/storaged/details.js:268
+msgid "Formatting a storage device will erase all data on it."
+msgstr ""
+"Sformatowanie urządzenia do przechowywania danych usunie wszystkie "
+"znajdujące się na nim dane."
+
+#: pkg/networkmanager/interfaces.js:2577
+msgid "Forward delay $forward_delay"
+msgstr "Opóźnienie w przód $forward_delay"
+
+#: pkg/systemd/index.html:255
+msgid "Free"
+msgstr "Wolne"
+
+#: pkg/users/index.html:86 pkg/users/index.html:148
+msgid "Full Name"
+msgstr "Imię i nazwisko"
+
+#: pkg/kubernetes/scripts/volumes.js:192
+msgid "GCE Persistent Disk"
+msgstr "Trwały dysk GCE"
+
+#: pkg/docker/index.html:180
+msgid "Gateway:"
+msgstr "Brama:"
+
+#: pkg/networkmanager/interfaces.js:2628
+msgid "General"
+msgstr "Ogólne"
+
+#: pkg/sosreport/index.html:66
+msgid "Generating report"
+msgstr "Tworzenie raportu"
+
+#: pkg/kubernetes/scripts/volumes.js:194
+msgid "Git Repository"
+msgstr "Repozytorium git"
+
+#: pkg/kubernetes/scripts/volumes.js:198
+msgid "Gluster FS"
+msgstr "GlusterFS"
+
+#: pkg/kubernetes/scripts/volumes.js:872
+msgid "GlusterFS"
+msgstr "GlusterFS"
+
+#: pkg/systemd/logs.js:130
+msgid "Go to"
+msgstr "Przejdź do"
+
+#: pkg/storaged/index.html:307 pkg/networkmanager/index.html:50
+#: pkg/networkmanager/index.html:496
+msgid "Go to now"
+msgstr "Przejdź teraz"
+
+#: pkg/kubernetes/views/group-page.html:21
+#: pkg/kubernetes/views/group-panel.html:12
+msgid "Group Members"
+msgstr "Elementy grupy"
+
+#: pkg/kubernetes/views/project-listing.html:48
+#: pkg/kubernetes/views/user-delete.html:14
+msgid "Groups"
+msgstr "Grupy"
+
+#: pkg/networkmanager/index.html:268
+msgid "Hair Pin mode"
+msgstr "Tryb Hairpin"
+
+#: pkg/networkmanager/interfaces.js:2603
+msgid "Hairpin mode"
+msgstr "Tryb Hairpin"
+
+#: pkg/docker/storage.jsx:157
+#, fuzzy
+msgid "Hard Disk"
+msgstr "Dysk twardy"
+
+#: pkg/storaged/overview.js:180
+msgctxt "storage"
+msgid "Hard Disk"
+msgstr "Dysk twardy"
+
+#: pkg/systemd/index.html:77
+msgid "Hardware"
+msgstr "Sprzęt"
+
+#: pkg/networkmanager/interfaces.js:2579
+msgid "Hello time $hello_time"
+msgstr "Czas powitania $hello_time"
+
+#: pkg/kubernetes/views/details-page.html:73
+#: pkg/kubernetes/views/route-body.html:9
+#: pkg/kubernetes/views/route-modify.html:8
+msgid "Host"
+msgstr "Gospodarz"
+
+#: pkg/systemd/index.html:102 pkg/dashboard/index.html:151
+msgid "Host Name"
+msgstr "Nazwa komputera"
+
+#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
+msgid "Host Path"
+msgstr "Ścieżka gospodarza"
+
+#: src/base1/cockpit.js:3699
+msgid "Host key is incorrect"
+msgstr "Klucz komputera jest niepoprawny"
+
+#: pkg/systemd/services.html:442
+#, fuzzy
+msgid "Hour : Minute"
+msgstr "1 minuta"
+
+#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
+msgid "Hour needs to be a number between 0-23"
+msgstr ""
+
+#: pkg/systemd/services.html:408
+#, fuzzy
+msgid "Hours"
+msgstr "6 godzin"
+
+#: pkg/systemd/index.html:221
+msgid "I/O Wait"
+msgstr "Oczekiwanie wejścia/wyjścia"
+
+#: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
+msgid "IP"
+msgstr "IP"
+
+#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
+msgid "IP Address"
+msgstr "Adres IP"
+
+#: pkg/docker/index.html:172
+msgid "IP Address:"
+msgstr "Adres IP:"
+
+#: pkg/docker/index.html:176
+msgid "IP Prefix Length:"
+msgstr "Długość przedrostka IP:"
+
+#: pkg/networkmanager/index.html:568
+msgid "IP Settings"
+msgstr "Ustawienia IP"
+
+#: pkg/networkmanager/interfaces.js:2641
+msgid "IPv4"
+msgstr "IPv4"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv4 Settings"
+msgstr "Ustawienia IPv4"
+
+#: pkg/networkmanager/interfaces.js:2642
+msgid "IPv6"
+msgstr "IPv6"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv6 Settings"
+msgstr "Ustawienia IPv6"
+
+#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
+msgid "ISCSI"
+msgstr "iSCSI"
+
+#: pkg/systemd/init.js:270
+msgid "Id"
+msgstr "Identyfikator"
+
+#: pkg/networkmanager/interfaces.js:2620
+msgid "Id $id"
+msgstr "Identyfikator $id"
+
+#: pkg/kubernetes/views/image-body.html:22
+msgid "Identifier"
+msgstr "Identyfikator"
+
+#: pkg/kubernetes/views/user-page.html:23
+#: pkg/kubernetes/views/user-panel.html:18
+msgid "Identities"
+msgstr "Tożsamości"
+
+#: pkg/kubernetes/views/project-listing.html:91
+msgid "Identity"
+msgstr "Tożsamość"
+
+#: pkg/networkmanager/interfaces.js:1817
+msgid "Ignore"
+msgstr "Ignorowanie"
+
+#: pkg/docker/index.html:452 pkg/kubernetes/views/image-panel.html:9
+#: pkg/kubernetes/views/container-body.html:6
+#: pkg/kubernetes/views/image-page.html:16
+msgid "Image"
+msgstr "Obraz"
+
+#: pkg/docker/image.js:77
+msgid "Image $0"
+msgstr "Obraz $0"
+
+#: pkg/kubernetes/views/container-body.html:8
+msgid "Image ID"
+msgstr "Identyfikator obrazu"
+
+#: pkg/kubernetes/views/image-meta.html:16
+msgid "Image Layers"
+msgstr "Warstwy obrazu"
+
+#: pkg/kubernetes/views/volume-body.html:58
+msgid "Image Name"
+msgstr "Nazwa obrazu"
+
+#: pkg/kubernetes/registry.html:23
+msgid "Image Registry"
+msgstr "Rejestr obrazów"
+
+#: pkg/kubernetes/views/imagestream-page.html:16
+msgid "Image Stream"
+msgstr "Potok obrazu"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:135
+#, fuzzy
+msgid "Image commands"
+msgstr "Liczba obrazów"
+
+#: pkg/kubernetes/views/imagestream-body.html:34
+msgid "Image count"
+msgstr "Liczba obrazów"
+
+#: pkg/kubernetes/registry.html:48
+#: pkg/kubernetes/views/registry-dashboard-page.html:19
+#: pkg/kubernetes/views/imagestream-page.html:18
+#: pkg/kubernetes/views/image-listing.html:9 pkg/kubernetes/index.html:77
+msgid "Images"
+msgstr "Obrazy"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:17
+msgid "Images by project"
+msgstr "Obrazy według projektu"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:54
+msgid "Images pushed recently"
+msgstr "Ostatnio wysłane obrazy"
+
+#: pkg/storaged/details.js:1593
+msgid "In Sync"
+msgstr "Zsynchronizowane"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:81
+msgid ""
+"In order to begin pushing images to the registry, use the commands below."
+msgstr "Aby zacząć wysyłać obrazy do rejestru, należy użyć poniższych poleceń."
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:6
+msgid ""
+"In order to begin pushing images to the registry, you need to create a "
+"project."
+msgstr "Aby zacząć wysyłać obrazy do rejestru, należy utworzyć projekt."
+
+#: pkg/lib/machine-sync-users.html:50
+msgid ""
+"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
+"strong}}.        {{/needs_root}}                                    User "
+"name                                                                            "
+"{{#allows_password}}                            "
+"Password                                                                            "
+"{{/allows_password}}            "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
+#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
+msgid "Inactive"
+msgstr "Nieaktywne"
+
+#: pkg/lib/machine-invalid-hostkey.html:2
+msgid "Incorrect Host Key"
+msgstr "Niepoprawny klucz komputera"
+
+#: pkg/docker/storage.jsx:282
+msgid "Information about the Docker storage pool is not available."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:222
+#, fuzzy
+msgid "Installed products"
+msgstr "Zainstalowane produkty"
+
+#: pkg/systemd/services.html:135
+msgid "Instantiate"
+msgstr "Wystąpienie"
+
+#: pkg/kubernetes/views/pv-modify.html:169
+#: pkg/kubernetes/views/volume-body.html:81
+msgid "Interface"
+msgstr "Interfejs"
+
+#: pkg/networkmanager/index.html:84
+msgid "Interfaces"
+msgstr "Interfejsy"
+
+#: src/base1/cockpit.js:3701
+msgid "Internal error"
+msgstr "Wewnętrzny błąd"
+
+#: pkg/subscriptions/subscriptions-client.js:196
+#, fuzzy
+msgid "Invalid credentials"
+msgstr "Nieprawidłowy port"
+
+#: pkg/systemd/host.js:1194
+msgid "Invalid date format"
+msgstr "Nieprawidłowy format daty"
+
+#: pkg/systemd/host.js:1190
+msgid "Invalid date format and invalid time format"
+msgstr "Nieprawidłowy format daty i nieprawidłowy format czasu"
+
+#: pkg/systemd/init.js:1218
+#, fuzzy
+msgid "Invalid date format."
+msgstr "Nieprawidłowy format daty"
+
+#: pkg/lib/credentials.js:274
+msgid "Invalid file permissions"
+msgstr "Nieprawidłowe uprawnienia pliku"
+
+#: pkg/users/index.html:322
+msgid "Invalid key"
+msgstr "Nieprawidłowy klucz"
+
+#: pkg/systemd/init.js:1169
+#, fuzzy
+msgid "Invalid number."
+msgstr "Nieprawidłowy klucz"
+
+#: pkg/docker/run.js:283
+msgid "Invalid port"
+msgstr "Nieprawidłowy port"
+
+#: pkg/systemd/host.js:1192
+msgid "Invalid time format"
+msgstr "Nieprawidłowy format czasu"
+
+#: pkg/subscriptions/subscriptions-client.js:194 pkg/storaged/overview.js:577
+#: pkg/storaged/overview.js:668
 msgid "Invalid username or password"
 msgstr "Nieprawidłowa nazwa użytkownika lub hasło"
 
-#: pkg/storaged/overview.js:582
-msgid "Unknown host name"
-msgstr "Nieznana nazwa komputera"
+#: pkg/lib/machine-change-port.html:15
+msgid "Is sshd running on a different port?"
+msgstr "Czy sshd jest uruchomione na innym porcie?"
 
-#: pkg/storaged/overview.js:586
-msgid "Unable to reach server"
-msgstr "Nie można połączyć się z serwerem"
+#: pkg/systemd/init.js:522
+msgid "Isolate"
+msgstr "Izoluj"
 
-#: pkg/storaged/overview.js:619
-msgid "Available targets on $0"
-msgstr "Dostępne cele w $0"
+#: pkg/storaged/index.html:280
+msgid "Jobs"
+msgstr "Zadania"
 
-#: pkg/storaged/overview.js:623 pkg/systemd/services.html.h:2
-msgid "Targets"
-msgstr "Cele"
+#: pkg/realmd/operation.js:96
+msgid "Join"
+msgstr "Dołącz"
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-add.html.h:2
-#: pkg/kubernetes/views/node-body.html.h:2
-#: pkg/kubernetes/views/auth-form.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:16
-#: pkg/kubernetes/views/nodes-page.html.h:7
-#: pkg/kubernetes/views/details-page.html.h:19
-msgid "Address"
-msgstr "Adres"
+#: pkg/realmd/operation.js:453
+msgid "Join Domain"
+msgstr "Dołącz do domeny"
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-change-port.html.h:5
-msgid "Port"
-msgstr "Port"
+#: pkg/realmd/operation.js:347
+msgid "Joining this domain is not supported"
+msgstr "Dołączenie do tej domeny jest nieobsługiwane"
 
-#: pkg/storaged/overview.js:699
-msgid "Change iSCSI Initiator Name"
-msgstr "Zmień nazwę inicjatora iSCSI"
+#: pkg/systemd/logs.js:257
+msgid "Journal entry"
+msgstr "Wpis dziennika"
 
-#: pkg/storaged/overview.js:707 pkg/kubernetes/views/route-modify.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:22
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:4
-#: pkg/kubernetes/views/project-modify.html.h:9
-msgid "Change"
-msgstr "Zmień"
+#: pkg/systemd/logs.js:284
+msgid "Journal entry not found"
+msgstr "Nie odnaleziono wpisu dziennika"
 
-#: pkg/storaged/utils.js:88
-msgctxt "format-bytes"
-msgid "bytes"
-msgstr "bajtów"
+#: pkg/lib/machine-auth-failed.html:10
+msgid "Kerberos Based SSO"
+msgstr "SSO oparte na Kerberos"
+
+#: pkg/lib/machine-change-auth.html:69
+msgid "Kerberos Ticket"
+msgstr "Zgłoszenie Kerberos"
+
+#: pkg/systemd/index.html:225
+msgid "Kernel"
+msgstr "Jądro"
+
+#: pkg/kubernetes/views/node-body.html:19
+msgid "Kernel Version"
+msgstr "Wersja jądra"
+
+#: pkg/kubernetes/views/volume-body.html:67
+msgid "Key Ring Path"
+msgstr "Ścieżka do bazy kluczy"
+
+#: pkg/kubernetes/views/node-body.html:23
+msgid "Kubelet Version"
+msgstr "Wersja Kubelet"
+
+#: pkg/kubernetes/index.html:23
+msgid "Kubernetes Cluster"
+msgstr "Klaster Kubernetes"
+
+#: pkg/networkmanager/index.html:473
+msgid "LACP Key"
+msgstr ""
+
+#: pkg/storaged/details.js:1245
+msgctxt "storage-id-desc"
+msgid "LUKS Encrypted"
+msgstr "Zaszyfrowane LUKS"
+
+#: pkg/storaged/details.js:1226
+msgctxt "storage-id-desc"
+msgid "LVM2 Physical Volume"
+msgstr "Wolumin fizyczny LVM2"
+
+#: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/replicationcontroller-body.html:17
+#: pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/route-body.html:22
+#: pkg/kubernetes/views/image-meta.html:3
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
+msgid "Labels"
+msgstr "Etykiety"
+
+#: pkg/systemd/logs.html:42
+msgid "Last 24 hours"
+msgstr "Ostatni dzień"
+
+#: pkg/systemd/logs.html:43
+msgid "Last 7 days"
+msgstr "Ostatni tydzień"
+
+#: pkg/kubernetes/views/node-body.html:49
+msgid "Last Heartbeat"
+msgstr "Ostatnie bicie serca"
+
+#: pkg/users/index.html:100
+msgid "Last Login"
+msgstr "Ostatnie logowanie"
+
+#: pkg/kubernetes/views/node-body.html:51
+msgid "Last Status Change"
+msgstr "Ostatnia zmiana stanu"
+
+#: pkg/systemd/init.js:273
+msgid "Last Trigger"
+msgstr "Ostatnio wyzwolono"
+
+#: pkg/kubernetes/views/image-listing.html:16
+msgid "Last Updated"
+msgstr "Ostatnio zaktualizowano"
+
+#: pkg/kubernetes/views/details-page.html:107
+msgid "Latest Version"
+msgstr "Najnowsza wersja"
+
+#: pkg/realmd/operation.js:101
+msgid "Leave"
+msgstr "Opuść"
+
+#: pkg/networkmanager/index.html:315
+msgid "Link Monitoring"
+msgstr "Monitorowanie łącza"
+
+#: pkg/networkmanager/index.html:397
+#, fuzzy
+msgid "Link Watch"
+msgstr "Link-local"
+
+#: pkg/networkmanager/index.html:350 pkg/networkmanager/index.html:432
+msgid "Link down delay"
+msgstr "Opóźnienie łącza w dół"
+
+#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
+msgid "Link local"
+msgstr "Link-local"
+
+#: pkg/networkmanager/index.html:341 pkg/networkmanager/index.html:423
+msgid "Link up delay"
+msgstr "Opóźnienie łącza w górę"
+
+#: pkg/docker/index.html:514
+msgid "Links"
+msgstr "Łącza"
+
+#: pkg/storaged/details.js:1224
+msgctxt "storage-id-desc"
+msgid "Linux MD-RAID Component"
+msgstr "Składnik MD-RAID systemu Linux"
+
+#: pkg/networkmanager/interfaces.js:1841
+#, fuzzy
+msgid "Load Balancing"
+msgstr "Adaptacyjne równoważenie obciążenia"
+
+#: pkg/systemd/logs.js:69
+msgid "Load earlier entries"
+msgstr "Wczytaj wcześniejsze wpisy"
+
+#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
+#: pkg/systemd/logs.js:175
+msgid "Loading..."
+msgstr "Wczytywanie…"
+
+#: pkg/users/index.html:23
+msgid "Local Accounts"
+msgstr "Lokalne konta"
+
+#: pkg/docker/storage.jsx:188
+#, fuzzy
+msgid "Local Disks"
+msgstr "Dyski: $0"
+
+#: pkg/storaged/details.js:1109
+msgid "Lock"
+msgstr "Zablokuj"
+
+#: pkg/users/index.html:109 pkg/users/index.html:196
+msgid "Lock Account"
+msgstr "Zablokuj konto"
+
+#: pkg/storaged/jobs.js:122
+msgid "Locking $target"
+msgstr "Blokowanie $target"
+
+#: pkg/lib/machine-change-auth.html:80
+msgid "Log In"
+msgstr "Zaloguj"
+
+#: pkg/lib/machine-change-auth.html:4
+msgid "Log in to {{host}}"
+msgstr "Zaloguj do {{host}}"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:116
+msgid "Log into OpenShift command line tools:"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:101
+#, fuzzy
+msgid "Log into the registry:"
+msgstr "Witamy w rejestrze obrazów"
+
+#: pkg/shell/simple.html:45 pkg/shell/index.html:52 pkg/shell/stub.html:45
+msgid "Log out"
+msgstr "Wyloguj"
+
+#: pkg/users/local.js:839
+msgid "Logged In"
+msgstr "Zalogowano"
+
+#: pkg/storaged/details.js:1424
+msgid "Logical Partition"
+msgstr "Partycja logiczna"
+
+#: pkg/kubernetes/views/pv-modify.html:158
+#: pkg/kubernetes/views/volume-body.html:79
+#: pkg/kubernetes/views/volume-body.html:118
+msgid "Logical Unit Number"
+msgstr "Numer jednostki logicznej"
+
+#: pkg/storaged/utils.js:172
+msgid "Logical Volume"
+msgstr "Wolumin logiczny"
+
+#: pkg/storaged/utils.js:170
+msgid "Logical Volume (Snapshot)"
+msgstr "Wolumin logiczny (migawka)"
+
+#: pkg/storaged/details.js:1792
+msgid "Logical Volumes"
+msgstr "Woluminy logiczne"
+
+#: pkg/subscriptions/subscriptions-register.jsx:140
+#, fuzzy
+msgid "Login"
+msgstr "Ostatnie logowanie"
+
+#: pkg/lib/machine-change-auth.html:68
+msgid "Login Password"
+msgstr "Hasło logowania"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:96
+#, fuzzy
+msgid "Login commands"
+msgstr "Polecenia Dockera"
+
+#: src/base1/cockpit.js:3693
+msgid "Login failed"
+msgstr "Logowanie się nie powiodło"
+
+#: pkg/subscriptions/subscriptions-client.js:200
+#, fuzzy
+msgid "Login/password or activation key required to register."
+msgstr "Wymagana jest nazwa użytkownika/hasło lub klucz aktywacji"
+
+#: pkg/systemd/logs.html:59 pkg/kubernetes/views/container-panel.html:6
+#: pkg/kubernetes/views/container-page-inline.html:8
+msgid "Logs"
+msgstr "Dzienniki"
+
+#: pkg/dashboard/index.html:110
+msgid "Lost connection. Trying to reconnect"
+msgstr "Utracono połączenie. Próbowanie ponownego połączenia"
+
+#: pkg/docker/index.html:184
+msgid "MAC Address:"
+msgstr "Adres MAC:"
+
+#: pkg/networkmanager/interfaces.js:1833
+msgid "MII (Recommended)"
+msgstr "MII (zalecane)"
+
+#: pkg/networkmanager/interfaces.js:2477
+msgid "MTU"
+msgstr "MTU"
+
+#: pkg/networkmanager/interfaces.js:4139
+msgid "MTU must be a positive number"
+msgstr "MTU musi być liczbą dodatnią"
+
+#: pkg/systemd/index.html:85 pkg/kubernetes/views/node-body.html:15
+msgid "Machine ID"
+msgstr "Identyfikator komputera"
+
+#: pkg/systemd/index.html:282
+msgid "Machine SSH Key Fingerprints"
+msgstr "Odciski kluczy SSH komputera"
+
+#: pkg/shell/indexes.js:253
+msgid "Machines"
+msgstr "Komputery"
+
+#: pkg/kubernetes/scripts/dashboard.js:460
+msgid "Manifest"
+msgstr "Manifest"
+
+#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
+msgid "Manual"
+msgstr "Ręczne"
+
+#: pkg/systemd/index.html:401 pkg/systemd/index.html:405
+msgid "Manually"
+msgstr "Ręcznie"
+
+#: pkg/storaged/jobs.js:140
+msgid "Marking $target as faulty"
+msgstr "Oznaczanie $target jako wadliwe"
+
+#: pkg/systemd/init.js:546
+msgid "Mask"
+msgstr "Maskuj"
+
+#: pkg/systemd/init.js:547
+msgid "Mask Forcefully"
+msgstr "Wymuś maskowanie"
+
+#: pkg/networkmanager/interfaces.js:2483
+msgid "Master"
+msgstr "Główne"
+
+#: pkg/networkmanager/interfaces.js:2581
+msgid "Maximum message age $max_age"
+msgstr "Maksymalny wiek komunikatu $max_age"
+
+#: pkg/kubernetes/views/volume-body.html:34
+msgid "Medium"
+msgstr "Nośnik"
+
+#: pkg/kubernetes/views/project-listing.html:92
+msgid "Member of"
+msgstr "Element"
+
+#: pkg/kubernetes/views/project-listing.html:16
+#: pkg/kubernetes/views/project-listing.html:55
+#: pkg/networkmanager/index.html:291
+msgid "Members"
+msgstr "Elementy"
+
+#: pkg/kubernetes/views/project-page.html:29
+#: pkg/kubernetes/views/user-panel.html:11
+#: pkg/kubernetes/views/user-panel.html:27
+#: pkg/kubernetes/views/user-body.html:4
+msgid "Membership"
+msgstr "Członkostwo"
+
+#: pkg/dashboard/index.html:71 pkg/playground/translate.html:91
+msgid "Memory"
+msgstr "Pamięć"
+
+#: pkg/systemd/host.js:1466
+msgctxt "page-title"
+msgid "Memory"
+msgstr "Pamięć"
+
+#: pkg/kubernetes/scripts/nodes.js:716
+msgid "Memory Utilization: $0%"
+msgstr "Użycie pamięci: $0%"
+
+#: pkg/docker/index.html:473 pkg/docker/index.html:652
+msgid "Memory limit"
+msgstr "Ograniczenie pamięci"
+
+#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
+msgid "Message"
+msgstr "Komunikat"
+
+#: pkg/systemd/host.js:1300
+msgid "Message to logged in users"
+msgstr "Wiadomość do zalogowanych użytkowników"
+
+#: pkg/kubernetes/views/image-panel.html:15
+#: pkg/kubernetes/views/imagestream-page.html:21
+#: pkg/kubernetes/views/image-page.html:22
+msgid "Metadata"
+msgstr "Metadane"
+
+#: pkg/docker/index.html:487 pkg/docker/index.html:666
+msgid "MiB"
+msgstr "MiB"
+
+#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
+msgid "Minute needs to be a number between 0-59"
+msgstr ""
+
+#: pkg/systemd/services.html:407
+#, fuzzy
+msgid "Minutes"
+msgstr "5 minut"
+
+#: pkg/networkmanager/index.html:299
+msgid "Mode"
+msgstr "Tryb"
+
+#: pkg/storaged/index.html:421
+msgctxt "storage"
+msgid "Model"
+msgstr "Model"
+
+#: pkg/kubernetes/views/user-modify.html:31
+msgid "Modify"
+msgstr "Modyfikuj"
+
+#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
+msgid "Modifying $target"
+msgstr "Modyfikowanie $target"
+
+#: pkg/networkmanager/index.html:323
+msgid "Monitoring Interval"
+msgstr "Odstęp monitorowania"
+
+#: pkg/networkmanager/index.html:332
+msgid "Monitoring Targets"
+msgstr "Cele monitorowania"
+
+#: pkg/kubernetes/views/volume-body.html:54
+msgid "Monitors"
+msgstr "Monitory"
+
+#: pkg/realmd/operation.js:366
+msgid "More"
+msgstr "Więcej"
+
+#: pkg/storaged/details.js:1099
+msgid "Mount"
+msgstr "Zamontuj"
+
+#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
+msgid "Mount Location"
+msgstr "Położenie punktu montowania"
+
+#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
+msgid "Mount Options"
+msgstr "Opcje montowania"
+
+#: pkg/storaged/index.html:231
+msgid "Mount Point"
+msgstr "Punkt montowania"
+
+#: pkg/docker/index.html:540
+msgid "Mount container volumes"
+msgstr "Zamontuj woluminy kontenera"
+
+#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
+msgid "Mounting"
+msgstr "Montowanie"
+
+#: pkg/storaged/jobs.js:126
+msgid "Mounting $target"
+msgstr "Montowanie $target"
+
+#: pkg/storaged/index.html:508
+msgctxt "storage"
+msgid "Multipathed Devices"
+msgstr "Urządzenia wielościeżkowe"
+
+#: pkg/kubernetes/scripts/volumes.js:860
+msgid "NFS"
+msgstr "NFS"
+
+#: pkg/kubernetes/scripts/volumes.js:199
+msgid "NFS Mount"
+msgstr "Punkt montowania NFS"
+
+#: pkg/networkmanager/interfaces.js:1856
+msgid "NSNA Ping"
+msgstr ""
+
+#: pkg/storaged/details.js:182
+msgid "NTFS - Compatible with most systems"
+msgstr "NTFS — zgodne z większością systemów"
+
+#: pkg/systemd/host.js:1250
+msgid "NTP Server"
+msgstr "Serwer NTP"
+
+#: pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/project-modify.html:16
+#: pkg/kubernetes/views/node-add.html:16
+#: pkg/kubernetes/views/volumes-page.html:19
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/image-body.html:2
+#: pkg/kubernetes/views/imagestream-modify.html:10
+#: pkg/kubernetes/views/service-modify.html:9
+#: pkg/kubernetes/views/dashboard-page.html:156
+#: pkg/kubernetes/views/dashboard-page.html:198
+#: pkg/kubernetes/views/details-page.html:34
+#: pkg/kubernetes/views/details-page.html:70
+#: pkg/kubernetes/views/details-page.html:103
+#: pkg/kubernetes/views/details-page.html:137
+#: pkg/kubernetes/views/details-page.html:171
+#: pkg/kubernetes/views/pv-claim.html:4
+#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/kubernetes/views/project-listing.html:14
+#: pkg/kubernetes/views/project-listing.html:53
+#: pkg/kubernetes/views/project-listing.html:90
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/volume-body.html:31 pkg/storaged/index.html:230
+#: pkg/networkmanager/index.html:95 pkg/networkmanager/index.html:113
+#: pkg/networkmanager/index.html:150 pkg/networkmanager/index.html:183
+#: pkg/networkmanager/index.html:282 pkg/networkmanager/index.html:364
+msgid "Name"
+msgstr "Nazwa"
 
 #: pkg/storaged/utils.js:129
 #, fuzzy
@@ -1735,381 +3526,1229 @@ msgstr "Nazwa nie może zawierać znaku „$0”."
 msgid "Name cannot contain whitespace."
 msgstr "Nazwa nie może zawierać spacji."
 
-#: pkg/storaged/utils.js:157
-msgid "$name (from $host)"
-msgstr "$name (z $host)"
+#: pkg/kubernetes/views/service-body.html:5
+#: pkg/kubernetes/views/replicationcontroller-body.html:5
+#: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/pod-body.html:5
+#: pkg/kubernetes/views/dashboard-page.html:160
+#: pkg/kubernetes/views/details-page.html:36
+#: pkg/kubernetes/views/details-page.html:72
+#: pkg/kubernetes/views/details-page.html:105
+#: pkg/kubernetes/views/details-page.html:139
+#: pkg/kubernetes/views/details-page.html:173
+#: pkg/kubernetes/views/pv-claim.html:6
+#: pkg/kubernetes/views/containers-listing.html:14
+#: pkg/kubernetes/views/route-body.html:5
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
+msgid "Namespace"
+msgstr "Przestrzeń nazw"
 
-#: pkg/storaged/utils.js:166
-msgid "Pool for Thin Logical Volumes"
-msgstr "Pula dla cienkich woluminów logicznych"
+#: pkg/kubernetes/scripts/dashboard.js:374
+msgid "Namespace cannot be empty."
+msgstr "Przestrzeń nazw nie może być pusta."
 
-#: pkg/storaged/utils.js:168
-msgid "Thin Logical Volume"
-msgstr "Cienki wolumin logiczny"
+#: pkg/systemd/host.js:1113
+msgid "Need at least one NTP server"
+msgstr "Wymagany jest co najmniej jeden serwer NTP"
 
-#: pkg/storaged/utils.js:170
-msgid "Logical Volume (Snapshot)"
-msgstr "Wolumin logiczny (migawka)"
+#: pkg/dashboard/index.html:72 pkg/playground/translate.html:96
+msgid "Network"
+msgstr "Sieć"
 
-#: pkg/storaged/utils.js:172
-msgid "Logical Volume"
-msgstr "Wolumin logiczny"
+#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:485
+msgid "Networking"
+msgstr "Sieć"
 
-#: pkg/storaged/utils.js:212
-msgid "<span>Encrypted Logical Volume of $0</span>"
-msgstr "<span>Zaszyfrowany wolumin logiczny $0</span>"
+#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
+msgctxt "page-title"
+msgid "Networking"
+msgstr "Sieć"
 
-#: pkg/storaged/utils.js:214
-msgid "<span>Encrypted Partition of $0</span>"
-msgstr "<span>Zaszyfrowana partycja $0</span>"
+#: pkg/networkmanager/index.html:124
+msgid "Networking Logs"
+msgstr "Dzienniki sieci"
 
-#: pkg/storaged/utils.js:216
-msgid "<span>Logical Volume of $0</span>"
-msgstr "<span>Wolumin logiczny $0</span>"
+#: pkg/users/local.js:841
+msgid "Never"
+msgstr "Nigdy"
 
-#: pkg/storaged/utils.js:218
-msgid "<span>Partition of $0</span>"
-msgstr "<span>Partycja $0</span>"
+#: pkg/kubernetes/views/project-listing.html:46
+msgid "New Group"
+msgstr "Nowa grupa"
 
-#: pkg/storaged/utils.js:220
-msgid "<span>Encrypted $0</span>"
-msgstr "<span>Zaszyfrowane $0</span>"
+#: pkg/users/index.html:236 pkg/shell/index.html:255
+msgid "New Password"
+msgstr "Nowe hasło"
 
-#: pkg/storaged/utils.js:233
-msgid "RAID Device $0"
-msgstr "Urządzenie RAID $0"
+#: pkg/kubernetes/views/project-listing.html:7
+msgid "New Project"
+msgstr "Nowy projekt"
 
-#: pkg/storaged/utils.js:239
-msgid "Volume Group $0"
-msgstr "Grupa woluminów $0"
+#: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/image-listing.html:7
+msgid "New image stream"
+msgstr "Nowy potok obrazu"
 
-#: pkg/storaged/jobs.js:119
-msgid "SMART self-test of $target"
-msgstr "Test SMART $target"
+#: pkg/users/local.js:120 pkg/lib/credentials.js:231
+msgid "New password was not accepted"
+msgstr "Nie przyjęto nowego hasła"
 
-#: pkg/storaged/jobs.js:120
-msgid "Ejecting $target"
-msgstr "Wysuwanie $target"
+#: pkg/kubernetes/views/project-modify.html:4
+#: pkg/kubernetes/views/registry-dashboard-page.html:9
+#: pkg/kubernetes/views/registry-dashboard-page.html:48
+msgid "New project"
+msgstr "Nowy projekt"
 
-#: pkg/storaged/jobs.js:121
-msgid "Unlocking $target"
-msgstr "Odblokowywanie $target"
+#: pkg/realmd/operation.html:91
+msgid "Next"
+msgstr "Dalej"
 
-#: pkg/storaged/jobs.js:122
-msgid "Locking $target"
-msgstr "Blokowanie $target"
+#: pkg/systemd/init.js:272
+msgid "Next Run"
+msgstr "Następne uruchomienie"
 
-#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
-msgid "Modifying $target"
-msgstr "Modyfikowanie $target"
+#: pkg/systemd/index.html:233
+msgid "Nice"
+msgstr "Nice"
 
-#: pkg/storaged/jobs.js:124
-msgid "Starting swapspace $target"
-msgstr "Uruchamianie przestrzeni wymiany $target"
-
-#: pkg/storaged/jobs.js:125
-msgid "Stopping swapspace $target"
-msgstr "Zatrzymywanie przestrzeni wymiany $target"
-
-#: pkg/storaged/jobs.js:126
-msgid "Mounting $target"
-msgstr "Montowanie $target"
-
-#: pkg/storaged/jobs.js:127
-msgid "Unmounting $target"
-msgstr "Odmontowywanie $target"
-
-#: pkg/storaged/jobs.js:129
-msgid "Erasing $target"
-msgstr "Czyszczenie $target"
-
-#: pkg/storaged/jobs.js:130
-msgid "Creating filesystem on $target"
-msgstr "Tworzenie systemu plików w $target"
-
-#: pkg/storaged/jobs.js:131
-msgid "Setting up loop device $target"
-msgstr "Ustawianie urządzenia zwrotnego $target"
-
-#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
-msgid "Deleting $target"
-msgstr "Usuwanie $target"
-
-#: pkg/storaged/jobs.js:134
-msgid "Creating partition $target"
-msgstr "Tworzenie partycji $target"
-
-#: pkg/storaged/jobs.js:135
-msgid "Cleaning up for $target"
-msgstr "Czyszczenie dla $target"
-
-#: pkg/storaged/jobs.js:136
-msgid "Securely erasing $target"
-msgstr "Bezpieczne usuwanie zawartości $target"
-
-#: pkg/storaged/jobs.js:137
-msgid "Very securely erasing $target"
-msgstr "Bardzo bezpieczne usuwanie zawartości $target"
-
-#: pkg/storaged/jobs.js:138
-msgid "Stopping RAID Device $target"
-msgstr "Zatrzymywanie urządzenia RAID $target"
-
-#: pkg/storaged/jobs.js:139
-msgid "Starting RAID Device $target"
-msgstr "Uruchamianie urządzenia RAID $target"
-
-#: pkg/storaged/jobs.js:140
-msgid "Marking $target as faulty"
-msgstr "Oznaczanie $target jako wadliwe"
-
-#: pkg/storaged/jobs.js:141
-msgid "Removing $target from RAID Device"
-msgstr "Usuwanie $target z urządzenia RAID"
-
-#: pkg/storaged/jobs.js:142
-msgid "Creating RAID Device $target"
-msgstr "Tworzenie urządzenia RAID $target"
-
-#: pkg/storaged/jobs.js:143
-#, fuzzy
-msgid "Checking RAID Device $target"
-msgstr "Tworzenie urządzenia RAID $target"
-
-#: pkg/storaged/jobs.js:144
-#, fuzzy
-msgid "Checking and Repairing RAID Device $target"
-msgstr "Tworzenie urządzenia RAID $target"
-
-#: pkg/storaged/jobs.js:145
-#, fuzzy
-msgid "Recovering RAID Device $target"
-msgstr "Zatrzymywanie urządzenia RAID $target"
-
-#: pkg/storaged/jobs.js:146
-msgid "Synchronizing RAID Device $target"
-msgstr "Synchronizowanie urządzenia RAID $target"
-
-#: pkg/storaged/jobs.js:148
-msgid "Activating $target"
-msgstr "Aktywowanie $target"
-
-#: pkg/storaged/jobs.js:149
-msgid "Deactivating $target"
-msgstr "Dezaktywowanie $target"
-
-#: pkg/storaged/jobs.js:150
-msgid "Creating snapshot of $target"
-msgstr "Tworzenie migawki $target"
-
-#: pkg/storaged/jobs.js:151
-msgid "Creating volume group $target"
-msgstr "Tworzenie grupy woluminów $target"
-
-#: pkg/storaged/jobs.js:152
-msgid "Deleting volume group $target"
-msgstr "Usuwanie grupy woluminów $target"
-
-#: pkg/storaged/jobs.js:153
-msgid "Adding physical volume to $target"
-msgstr "Dodawanie woluminu fizycznego do $target"
-
-#: pkg/storaged/jobs.js:154
-msgid "Removing physical volume from $target"
-msgstr "Usuwanie woluminu fizycznego z $target"
-
-#: pkg/storaged/jobs.js:155
-msgid "Emptying $target"
-msgstr "Opróżnianie $target"
-
-#: pkg/storaged/jobs.js:156
-msgid "Creating logical volume $target"
-msgstr "Tworzenie woluminu logicznego $target"
-
-#: pkg/storaged/jobs.js:157
-msgid "Renaming $target"
-msgstr "Zmienianie nazwy $target"
-
-#: pkg/storaged/jobs.js:158
-msgid "Resizing $target"
-msgstr "Zmienianie rozmiaru $target"
-
-#: pkg/storaged/jobs.js:166
-msgid "Operation '$operation' on $target"
-msgstr "Działanie „$operation” na $target"
-
-#: pkg/storaged/jobs.js:180
-msgid "unknown target"
-msgstr "nieznany cel"
-
-#: pkg/storaged/permissions.js:61
-msgid "The user <b>$0</b> is not permitted to manage storage"
-msgstr ""
-"Użytkownik <b>$0</b> nie posiada zezwolenia na zarządzanie urządzeniami do "
-"przechowywania danych"
-
-#: pkg/realmd/operation.js:96
-msgid "Join"
-msgstr "Dołącz"
-
-#: pkg/realmd/operation.js:101
-msgid "Leave"
-msgstr "Opuść"
-
-#: pkg/realmd/operation.js:148
-msgid "Domain $0 could not be contacted"
-msgstr "Nie można skontaktować się z domeną $0"
-
-#: pkg/realmd/operation.js:220
-msgid "Domain $0 is not supported"
-msgstr "Domena $0 jest nieobsługiwana"
-
-#: pkg/realmd/operation.js:347
-msgid "Joining this domain is not supported"
-msgstr "Dołączenie do tej domeny jest nieobsługiwane"
-
-#: pkg/realmd/operation.js:366
-msgid "More"
-msgstr "Więcej"
-
-#: pkg/realmd/operation.js:417
-msgid "Cannot join a domain because realmd is not available on this system"
-msgstr ""
-"Nie można dołączyć do domeny, ponieważ usługa realmd nie jest dostępna "
-"w systemie"
-
-#: pkg/realmd/operation.js:436
-msgid "The user <b>$0</b> is not permitted to modify realms"
-msgstr "Użytkownik <b>$0</b> nie posiada zezwolenia na modyfikowanie obszarów"
-
-#: pkg/realmd/operation.js:453
-msgid "Join Domain"
-msgstr "Dołącz do domeny"
-
-#: pkg/docker/run.js:246 pkg/docker/util.js:102
-#: pkg/networkmanager/interfaces.js:2280 pkg/kubernetes/scripts/volumes.js:992
-#: pkg/docker/index.html.h:46
+#: pkg/docker/index.html:563 pkg/docker/index.html:567
 msgid "No"
 msgstr "Nie"
 
-#: pkg/docker/run.js:261 pkg/docker/console.html.h:1
-#: pkg/kubernetes/views/image-panel.html.h:2
-#: pkg/kubernetes/views/container-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:1
-#: pkg/kubernetes/views/image-page.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:1
-msgid "Container"
-msgstr "Kontener"
+#: pkg/systemd/index.html:469
+msgid "No Delay"
+msgstr "Brak opóźnienia"
 
-#: pkg/docker/run.js:263 pkg/kubernetes/views/route-modify.html.h:2
-#: pkg/kubernetes/views/route-body.html.h:4
-#: pkg/kubernetes/views/details-page.html.h:12
-msgid "Host"
-msgstr "Gospodarz"
+#: pkg/ostree/index.html:220
+msgid "No Deployments"
+msgstr "Brak wdrożeń"
 
-#: pkg/docker/run.js:283
-msgid "Invalid port"
-msgstr "Nieprawidłowy port"
+#: pkg/storaged/details.js:185
+msgid "No Filesystem"
+msgstr "Brak systemu plików"
 
-#: pkg/docker/run.js:293
-msgid "Duplicate port"
-msgstr "Podwójny port"
+#: pkg/ostree/app.js:101
+msgid "No OSTree deployments found"
+msgstr "Nie odnaleziono wdrożeń OSTree"
 
-#: pkg/docker/run.js:332
-#, fuzzy
-msgid "Command can't be empty"
-msgstr "Nazwa nie może być pusta."
+#: src/ws/cockpitcertificate.c:398
+msgid "No PEM-encoded certificate found"
+msgstr "Nie odnaleziono certyfikatu zakodowanego jako PEM"
 
-#: pkg/docker/run.js:350
-msgid "No alias specified"
-msgstr "Nie podano aliasu"
+#: src/ws/cockpitcertificate.c:364
+msgid "No PEM-encoded private key found"
+msgstr "Nie odnaleziono klucza prywatnego zakodowanego jako PEM"
 
-#: pkg/docker/run.js:360
-msgid "Duplicate alias"
-msgstr "Podwójny alias"
+#: pkg/kubernetes/views/pv-claim.html:39
+msgid "No Pods are using this claim"
+msgstr "Żaden pojemnik nie używa tej deklaracji"
 
-#: pkg/docker/run.js:384
-msgid "No container specified"
-msgstr "Nie podano kontenera"
+#: pkg/selinux/setroubleshoot-view.jsx:479
+msgid "No SELinux alerts."
+msgstr ""
 
-#: pkg/docker/details.js:47 pkg/docker/image.js:43
-msgctxt "page-title"
-msgid "Containers"
-msgstr "Kontenery"
-
-#: pkg/docker/details.js:144
-msgid "${hip}:${hport} -> $cport"
-msgstr "${hip}:${hport} → $cport"
-
-#: pkg/docker/details.js:272 pkg/docker/containers-view.jsx:167
-msgid "Deleting a container will erase all data in it."
-msgstr "Usunięcie kontenera usunie wszystkie znajdujące się w nim dane."
-
-#: pkg/docker/storage.jsx:156
-#, fuzzy
-msgid "Solid-State Disk"
-msgstr "Dysk SSD"
-
-#: pkg/docker/storage.jsx:157
-#, fuzzy
-msgid "Hard Disk"
-msgstr "Dysk twardy"
-
-#: pkg/docker/storage.jsx:158 pkg/storaged/index.html.h:33
-msgid "Drive"
-msgstr "Napęd"
-
-#: pkg/docker/storage.jsx:188
-#, fuzzy
-msgid "Local Disks"
-msgstr "Dyski: $0"
+#: pkg/kubernetes/views/pvc-body.html:10
+msgid "No Volume Bound"
+msgstr "Żaden wolumin nie został przypisany"
 
 #: pkg/docker/storage.jsx:194
 #, fuzzy
 msgid "No additional local storage found."
 msgstr "Dodatkowe urządzenia do przechowywania danych"
 
-#: pkg/docker/storage.jsx:242
-msgid " (shared with the OS)"
+#: pkg/docker/run.js:350
+msgid "No alias specified"
+msgstr "Nie podano aliasu"
+
+#: pkg/sosreport/index.js:115
+msgid "No archive has been created."
+msgstr "Nie utworzono archiwum."
+
+#: pkg/networkmanager/interfaces.js:1326
+msgid "No carrier"
+msgstr "Brak operatora"
+
+#: pkg/docker/run.js:384
+msgid "No container specified"
+msgstr "Nie podano kontenera"
+
+#: pkg/storaged/index.html:193
+msgid "No drives attached"
+msgstr "Nie dołączono dysków"
+
+#: pkg/kubernetes/views/project-listing.html:74
+msgid "No groups are present."
+msgstr "Brak grup."
+
+#: pkg/systemd/index.html:28
+msgid "No host keys found."
+msgstr "Nie odnaleziono kluczy komputera."
+
+#: pkg/storaged/index.html:158
+msgid "No iSCSI targets set up"
+msgstr "Nie ustawiono żadnych celów iSCSI"
+
+#: pkg/kubernetes/views/image-listing.html:70
+msgid "No image streams are present."
+msgstr "Żadne potoki obrazów nie są obecne."
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:80
+msgid "No images pushed"
+msgstr "Nie wysłano obrazów"
+
+#: pkg/subscriptions/subscriptions-view.jsx:223
+#, fuzzy
+msgid "No installed products on the system."
+msgstr "Cockpit nie jest zainstalowany w systemie."
+
+#: pkg/storaged/index.html:446
+msgid "No media inserted"
+msgstr "Nie włożono żadnego nośnika"
+
+#: pkg/kubernetes/scripts/dashboard.js:384
+msgid ""
+"No metadata file was selected. Please select a Kubernetes metadata file."
+msgstr ""
+"Nie wybrano żadnego pliku metadanych. Proszę wybrać plik metadanych "
+"Kubernetes."
+
+#: pkg/kubernetes/views/dashboard-page.html:117
+msgid "No nodes in cluster"
+msgstr "Brak węzłów w klastrze"
+
+#: pkg/storaged/details.js:352
+msgid "No partitioning"
+msgstr "Brak partycjonowania"
+
+#: pkg/kubernetes/views/dashboard-page.html:40
+msgid "No pods deployed"
+msgstr "Brak wdrożonych pojemników"
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:6
+msgid "No pods replicated"
+msgstr "Nie utworzono kopii żadnych pojemników"
+
+#: pkg/kubernetes/views/node-capacity.html:11
+msgid "No pods scheduled"
+msgstr "Nie zaplanowano żadnych pojemników"
+
+#: pkg/kubernetes/views/service-endpoint.html:10
+msgid "No pods selected"
+msgstr "Nie wybrano żadnego pojemnika"
+
+#: pkg/kubernetes/views/project-listing.html:37
+msgid "No projects are present."
+msgstr "Brak projektów."
+
+#: pkg/users/local.js:405
+msgid "No real name specified"
+msgstr "Nie podano nazwy obszaru"
+
+#: pkg/storaged/index.html:87
+msgid "No storage set up as RAID"
+msgstr "Nie ustawiono żadnego urządzenia do przechowywania danych jako RAID"
+
+#: pkg/lib/credentials.js:182
+msgid "No such file or directory"
+msgstr "Nie ma takiego pliku lub katalogu"
+
+#: pkg/users/local.js:400
+msgid "No user name specified"
+msgstr "Nie podano nazwy użytkownika"
+
+#: pkg/kubernetes/views/project-listing.html:112
+msgid "No users are present."
+msgstr "Brak użytkowników."
+
+#: pkg/storaged/index.html:120
+msgid "No volume groups created"
+msgstr "Nie utworzono grup woluminów"
+
+#: pkg/kubernetes/views/volumes-page.html:44
+msgid "No volumes are present."
+msgstr "Brak woluminów."
+
+#: pkg/kubernetes/views/dashboard-page.html:73
+msgid "No volumes in use"
+msgstr "Żadne woluminy nie są używane"
+
+#: pkg/kubernetes/views/pod-body.html:18 pkg/kubernetes/views/node-panel.html:7
+#: pkg/kubernetes/views/containers-listing.html:15
+#: pkg/kubernetes/views/node-page.html:14
+#: pkg/kubernetes/views/topology-page.html:41
+msgid "Node"
+msgstr "Węzeł"
+
+#: pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:192
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:45
+msgid "Nodes"
+msgstr "Węzły"
+
+#: pkg/kubernetes/views/topology-page.html:42
+msgid "Nodes are the machines that run your containers."
+msgstr "Węzły to komputery, na których działają kontenery."
+
+#: pkg/kubernetes/views/service-body.html:15
+#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
+#: pkg/kubernetes/views/image-config.html:25
+#: pkg/kubernetes/views/imagestream-body.html:33
+msgid "None"
+msgstr "Brak"
+
+#: pkg/playground/translate.html:30 pkg/kubernetes/views/details-page.html:53
+#: pkg/kubernetes/views/node-body.html:42
+msgid "Not Ready"
+msgstr "Niegotowe"
+
+#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
+msgid "Not a valid number of replicas"
+msgstr "Nie jest prawidłowym liczbą replik"
+
+#: pkg/lib/credentials.js:248
+msgid "Not a valid private key"
+msgstr "Nieprawidłowy klucz prywatny"
+
+#: pkg/kubernetes/scripts/details.js:546
+msgid "Not a valid value for Host"
+msgstr "Nieprawidłowa wartość dla gospodarza"
+
+#: pkg/docker/index.html:57
+msgid "Not authorized to access Docker on this system"
+msgstr "Brak upoważnienia do łączenia z Dockerem w tym systemie"
+
+#: pkg/ostree/app.js:81
+msgid "Not authorized to update software on this system"
+msgstr "Brak upoważnienia do aktualizowania oprogramowania w tym systemie"
+
+#: pkg/networkmanager/interfaces.js:805
+msgid "Not available"
+msgstr "Niedostępne"
+
+#: pkg/selinux/setroubleshoot.js:238
+msgid "Not connected"
+msgstr "Nie połączono"
+
+#: pkg/kubernetes/views/details-page.html:122
+msgid "Not deployed"
+msgstr "Nie wdrożono"
+
+#: pkg/docker/details.js:177 pkg/docker/image.js:112
+#: pkg/storaged/details.js:1822
+msgid "Not found"
+msgstr "Nie odnaleziono"
+
+#: src/base1/cockpit.js:3691
+msgid "Not permitted to perform this action."
+msgstr "Brak uprawnień do wykonania tego działania."
+
+#: pkg/storaged/details.js:1574
+msgid "Not running"
+msgstr "Niedziałające"
+
+#: pkg/systemd/index.html:62
+msgid "Not synchronized"
+msgstr "Niesynchronizowane"
+
+#: pkg/systemd/services.html:299
+msgid "Note"
+msgstr "Uwaga"
+
+#: pkg/systemd/logs.html:49
+msgid "Notices"
+msgstr "Uwagi"
+
+#: pkg/kubernetes/views/node-body.html:13
+msgid "OS"
+msgstr "System operacyjny"
+
+#: pkg/ostree/client.js:500
+msgid "OS $0 not found"
+msgstr "Nie odnaleziono systemu operacyjnego $0"
+
+#: pkg/kubernetes/views/nodes-page.html:19
+msgid "OS Versions"
+msgstr "Wersje systemu operacyjnego"
+
+#: pkg/ostree/app.js:83
+msgid "OSTree is not available on this system"
+msgstr "OSTree jest niedostępne w tym systemie"
+
+#: pkg/selinux/setroubleshoot-view.jsx:405
+msgid "Occurred $0"
 msgstr ""
 
-#: pkg/docker/storage.jsx:282
-msgid "Information about the Docker storage pool is not available."
+#: pkg/selinux/setroubleshoot-view.jsx:400
+msgid "Occurred between $0 and $1"
 msgstr ""
 
-#: pkg/docker/storage.jsx:314
-msgid "Total"
+#: pkg/systemd/index.html:157 pkg/playground/jquery-patterns.html:95
+#: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:189
+#: pkg/storaged/index.html:565
+msgid "Off"
+msgstr "Wyłączone"
+
+#: pkg/lib/cockpit-components-dialog.jsx:155
+msgid "Ok"
 msgstr ""
+
+#: pkg/users/index.html:226 pkg/shell/index.html:248
+msgid "Old Password"
+msgstr "Poprzednie hasło"
+
+#: pkg/users/local.js:78 pkg/lib/credentials.js:213
+msgid "Old password not accepted"
+msgstr "Nie przyjęto poprzedniego hasła"
+
+#: pkg/systemd/index.html:153 pkg/playground/jquery-patterns.html:91
+#: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:185
+#: pkg/storaged/index.html:564
+msgid "On"
+msgstr "Włączone"
+
+#: pkg/kubernetes/views/image-meta.html:7
+msgid "On Build"
+msgstr "Podczas budowania"
+
+#: pkg/docker/index.html:568
+msgid "On Failure"
+msgstr "Podczas niepowodzenia"
+
+#: pkg/docker/util.js:104
+msgid "On failure, retry $0 time"
+msgid_plural "On failure, retry $0 times"
+msgstr[0] "Po niepowodzeniu próbowanie ponownie $0 raz"
+msgstr[1] "Po niepowodzeniu próbowanie ponownie $0 razy"
+msgstr[2] "Po niepowodzeniu próbowanie ponownie $0 razy"
+
+#: pkg/realmd/operation.html:71
+msgid "One Time Password"
+msgstr "Hasło jednorazowe"
+
+#: pkg/systemd/init.js:1147
+msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
+msgstr ""
+
+#: pkg/shell/simple.html:28 pkg/shell/index.html:28 pkg/shell/stub.html:28
+msgid "Ooops!"
+msgstr "Ups!"
+
+#: pkg/systemd/index.html:89 pkg/ostree/index.html:111
+#: pkg/kubernetes/views/nodes-page.html:42
+msgid "Operating System"
+msgstr "System operacyjny"
+
+#: pkg/ostree/index.html:186
+msgid "Operating System Updates"
+msgstr "Aktualizacje systemu operacyjnego"
+
+#: pkg/storaged/jobs.js:166
+msgid "Operation '$operation' on $target"
+msgstr "Działanie „$operation” na $target"
+
+#: pkg/storaged/overview.js:189
+msgctxt "storage"
+msgid "Optical Drive"
+msgstr "Napęd optyczny"
+
+#: pkg/kubernetes/views/volume-body.html:130
+msgid "Options"
+msgstr "Opcje"
+
+#: pkg/subscriptions/subscriptions-register.jsx:176
+#, fuzzy
+msgid "Organization"
+msgstr "Tłumaczenie"
+
+#: pkg/storaged/details.js:1253
+msgctxt "storage-id-desc"
+msgid "Other Data"
+msgstr "Inne dane"
+
+#: pkg/storaged/index.html:202
+msgid "Other Devices"
+msgstr "Inne urządzenia"
+
+#: pkg/docker/index.html:319 pkg/kubernetes/registry.html:42
+#: pkg/kubernetes/index.html:39
+msgid "Overview"
+msgstr "Przegląd"
+
+#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
+msgid "Overwrite existing data with zeros"
+msgstr "Zastąp istniejące dane zerami"
+
+#: pkg/kubernetes/views/volume-body.html:4
+msgid "PD Name"
+msgstr "Nazwa PD"
+
+#: pkg/ostree/index.html:100
+msgid "Packages"
+msgstr "Pakiety"
+
+#: pkg/networkmanager/index.html:133
+msgid "Parent"
+msgstr "Nadrzędne"
+
+#: pkg/networkmanager/interfaces.js:2619
+msgid "Parent $parent"
+msgstr "Nadrzędne $parent"
+
+#: pkg/networkmanager/interfaces.js:1372
+msgid "Part of "
+msgstr "Część "
+
+#: pkg/kubernetes/views/volume-body.html:8
+#: pkg/kubernetes/views/volume-body.html:18
+msgid "Partition"
+msgstr "Partycja"
+
+#: pkg/storaged/details.js:346
+msgid "Partitioning"
+msgstr "Partycjonowanie"
+
+#: pkg/networkmanager/interfaces.js:1848
+msgid "Passive"
+msgstr ""
+
+#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
+msgid "Passphrase"
+msgstr "Hasło"
+
+#: pkg/storaged/details.js:224
+#, fuzzy
+msgid "Passphrase cannot be empty"
+msgstr "Hasło nie może być puste"
+
+#: pkg/storaged/details.js:232
+msgid "Passphrases do not match"
+msgstr "Hasła się nie zgadzają"
+
+#: pkg/users/index.html:115 pkg/users/index.html:160 pkg/shell/index.html:199
+#: pkg/shell/index.html:212 pkg/kubernetes/views/auth-form.html:105
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+msgid "Password"
+msgstr "Hasło"
+
+#: pkg/users/local.js:259
+msgid "Password is not acceptable"
+msgstr "Hasło jest do przyjęcia"
+
+#: pkg/users/local.js:247
+msgid "Password is too weak"
+msgstr "Hasło jest za słabe"
+
+#: pkg/lib/credentials.js:278
+msgid "Password not accepted"
+msgstr "Nie przyjęto hasła"
+
+#: pkg/kubernetes/views/pv-modify.html:126
+#: pkg/kubernetes/views/volume-body.html:37
+#: pkg/kubernetes/views/volume-body.html:49
+#: pkg/kubernetes/views/volume-body.html:101
+msgid "Path"
+msgstr "Ścieżka"
+
+#: pkg/networkmanager/index.html:259
+msgid "Path cost"
+msgstr "Koszt ścieżki"
+
+#: pkg/networkmanager/interfaces.js:2601
+msgid "Path cost $path_cost"
+msgstr "Koszt ścieżki $path_cost"
+
+#: pkg/systemd/services.html:56
+msgid "Paths"
+msgstr "Ścieżki"
+
+#: pkg/kubernetes/views/volumes-page.html:53
+msgid "Pending Volume Claims"
+msgstr "Oczekujące deklaracje woluminów"
+
+#: pkg/systemd/index.html:143
+msgid "Performance Profile"
+msgstr "Profil wydajności"
+
+#: pkg/kubernetes/views/volumes-page.html:14
+msgid "Persistent Volumes"
+msgstr "Trwałe woluminy"
+
+#: pkg/kubernetes/views/pod-body.html:16
+msgid "Phase"
+msgstr "Faza"
+
+#: pkg/storaged/index.html:641
+msgid "Physical Volumes"
+msgstr "Woluminy fizyczne"
+
+#: pkg/networkmanager/index.html:405
+#, fuzzy
+msgid "Ping Interval"
+msgstr "Odstęp monitorowania"
+
+#: pkg/networkmanager/index.html:414
+#, fuzzy
+msgid "Ping Target"
+msgstr "Cel"
+
+#: pkg/docker/containers-view.jsx:166 pkg/docker/details.js:271
+#: pkg/docker/image.js:151 pkg/storaged/details.js:625
+#: pkg/storaged/details.js:821 pkg/storaged/details.js:1016
+msgid "Please confirm deletion of $0"
+msgstr "Proszę potwierdzić usunięcie $0"
+
+#: pkg/docker/util.js:501
+msgid "Please confirm forced deletion of $0"
+msgstr "Proszę potwierdzić wymuszenie usunięcia $0"
+
+#: pkg/kubernetes/scripts/dashboard.js:441
+msgid "Please create another namespace for $0 \"$1\""
+msgstr "Proszę dodać następną przestrzeń nazw dla $0 „$1”"
+
+#: pkg/kubernetes/scripts/volumes.js:574
+msgid "Please provide a GlusterFS volume name"
+msgstr "Proszę podać prawidłową nazwę woluminu GlusterFS"
+
+#: pkg/kubernetes/scripts/connection.js:554
+msgid "Please provide a username"
+msgstr "Proszę podać nazwę użytkownika"
+
+#: pkg/kubernetes/scripts/volumes.js:632
+msgid "Please provide a valid NFS server"
+msgstr "Proszę podać prawidłowy serwer NFS"
+
+#: pkg/kubernetes/scripts/connection.js:539
+msgid "Please provide a valid address"
+msgstr "Proszę podać prawidłowy adres"
+
+#: pkg/kubernetes/scripts/volumes.js:805
+msgid "Please provide a valid filesystem type"
+msgstr "Proszę podać prawidłowy typ systemu plików"
+
+#: pkg/kubernetes/scripts/volumes.js:813
+msgid "Please provide a valid interface"
+msgstr "Proszę podać prawidłowy interfejs"
+
+#: pkg/kubernetes/scripts/volumes.js:797
+msgid "Please provide a valid logical unit number"
+msgstr "Proszę podać prawidłowy numer jednostki logicznej"
+
+#: pkg/kubernetes/scripts/volumes.js:477
+msgid "Please provide a valid name"
+msgstr "Proszę podać prawidłową nazwę"
+
+#: pkg/kubernetes/scripts/dashboard.js:376
+msgid "Please provide a valid namespace."
+msgstr "Proszę podać prawidłową przestrzeń nazw."
+
+#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
+msgid "Please provide a valid path"
+msgstr "Proszę podać prawidłową ścieżkę"
+
+#: pkg/kubernetes/scripts/volumes.js:789
+msgid "Please provide a valid qualified name"
+msgstr "Proszę podać prawidłową nazwę kwalifikowaną"
+
+#: pkg/kubernetes/scripts/volumes.js:485
+msgid "Please provide a valid storage capacity."
+msgstr "Proszę podać prawidłową pojemność urządzenia do przechowywania danych."
+
+#: pkg/kubernetes/scripts/volumes.js:781
+msgid "Please provide a valid target"
+msgstr "Proszę podać prawidłowy cel"
+
+#: pkg/kubernetes/scripts/volumes.js:469
+msgid "Please select a valid access mode"
+msgstr "Proszę wybrać prawidłowy tryb dostępu"
+
+#: pkg/kubernetes/scripts/volumes.js:565
+msgid "Please select a valid endpoint"
+msgstr "Proszę wybrać prawidłowy punkt końcowy"
+
+#: pkg/kubernetes/scripts/volumes.js:493
+msgid "Please select a valid policy option."
+msgstr "Proszę wybrać prawidłową opcję polityki."
+
+#: pkg/kubernetes/scripts/nodes.js:397
+msgid "Please type an address"
+msgstr "Proszę wpisać adres"
+
+#: pkg/kubernetes/views/pod-page.html:12
+#: pkg/kubernetes/views/containers-listing.html:12
+#: pkg/kubernetes/views/topology-page.html:14
+msgid "Pod"
+msgstr "Pojemnik"
+
+#: pkg/kubernetes/views/pod-body.html:20
+msgid "Pod Address"
+msgstr "Adres pojemnika"
+
+#: pkg/kubernetes/views/service-endpoint.html:4
+#: pkg/kubernetes/views/service-endpoint.html:9
+msgid "Pod Endpoints"
+msgstr "Punkty końcowe pojemnika"
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:4
+msgid "Pod Replicated"
+msgstr "Utworzono kopię pojemnika"
+
+#: pkg/kubernetes/views/service-endpoint.html:15
+#: pkg/kubernetes/views/replicationcontroller-pods.html:11
+msgid "Pod Selector"
+msgstr "Wybór pojemnika"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:17
+#: pkg/kubernetes/views/dashboard-page.html:18
+#: pkg/kubernetes/views/details-page.html:166
+#: pkg/kubernetes/views/pv-claim.html:37
+#: pkg/kubernetes/views/replicationcontroller-panel.html:12
+msgid "Pods"
+msgstr "Pojemniki"
+
+#: pkg/kubernetes/views/topology-page.html:15
+#, fuzzy
+msgid ""
+"Pods contain one or more containers that run                together on a "
+"node, containing your application code."
+msgstr ""
+"Pojemniki zawierają jeden lub więcej kontenerów działających\n"
+"               razem na węźle, zawierających kod aplikacji."
+
+#: pkg/kubernetes/views/volume-body.html:60
+msgid "Pool Name"
+msgstr "Nazwa puli"
+
+#: pkg/storaged/utils.js:166
+msgid "Pool for Thin Logical Volumes"
+msgstr "Pula dla cienkich woluminów logicznych"
+
+#: pkg/storaged/details.js:874
+msgid "Pool for thinly provisioned volumes"
+msgstr "Pula dla cienko nadzorowanych woluminów"
+
+#: pkg/kubernetes/views/imagestream-modify.html:45
+msgid "Populate"
+msgstr "Wypełnij"
+
+#: pkg/lib/machine-change-port.html:23
+msgid "Port"
+msgstr "Port"
+
+#: pkg/docker/index.html:525 pkg/kubernetes/views/service-body.html:13
+#: pkg/kubernetes/views/image-config.html:23
+#: pkg/kubernetes/views/container-body.html:12
+#: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:373
+msgid "Ports"
+msgstr "Porty"
+
+#: pkg/systemd/index.html:123
+msgid "Power Options"
+msgstr "Opcje zasilania"
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length"
+msgstr "Długość przedrostka"
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length or Netmask"
+msgstr "Długość przedrostka lub maska sieci"
+
+#: pkg/networkmanager/interfaces.js:809
+msgid "Preparing"
+msgstr "Przygotowywanie"
+
+#: pkg/systemd/init.js:544
+msgid "Preset"
+msgstr "Ustaw wstępnie"
+
+#: pkg/systemd/init.js:545
+msgid "Preset Forcefully"
+msgstr "Wymuś ustawienie wstępne"
+
+#: pkg/systemd/index.html:310
+msgid "Pretty Host Name"
+msgstr "Czytelna nazwa komputera"
+
+#: pkg/networkmanager/index.html:307
+msgid "Primary"
+msgstr "Główne"
+
+#: pkg/storaged/details.js:1426
+msgid "Primary Partition"
+msgstr "Partycja główna"
+
+#: pkg/networkmanager/index.html:250 pkg/networkmanager/index.html:446
+#: pkg/networkmanager/index.html:464
+msgid "Priority"
+msgstr "Priorytet"
+
+#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
+msgid "Priority $priority"
+msgstr "Priorytet $priority"
+
+#: pkg/subscriptions/subscriptions-view.jsx:33
+msgid "Product ID"
+msgstr "Identyfikator produktu"
+
+#: pkg/subscriptions/subscriptions-view.jsx:32
+msgid "Product name"
+msgstr "Nazwa produktu"
+
+#: pkg/kubernetes/views/service-body.html:4
+#: pkg/kubernetes/views/replicationcontroller-body.html:4
+#: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/imagestream-modify.html:21
+#: pkg/kubernetes/views/pod-body.html:4
+#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/details-page.html:35
+#: pkg/kubernetes/views/details-page.html:71
+#: pkg/kubernetes/views/details-page.html:104
+#: pkg/kubernetes/views/details-page.html:138
+#: pkg/kubernetes/views/details-page.html:172
+#: pkg/kubernetes/views/containers-listing.html:13
+#: pkg/kubernetes/views/route-body.html:4
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
+msgid "Project"
+msgstr "Projekt"
+
+#: pkg/kubernetes/views/project-body.html:20
+msgid "Project Members"
+msgstr "Elementy projektu"
+
+#: pkg/kubernetes/views/filter-project.html:5
+msgid "Project:"
+msgstr "Projekt:"
+
+#: pkg/kubernetes/registry.html:54 pkg/kubernetes/views/group-delete.html:10
+#: pkg/kubernetes/views/project-listing.html:9
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:84
+msgid "Projects"
+msgstr "Projekty"
+
+#: pkg/users/local.js:82
+msgid "Prompting via passwd timed out"
+msgstr "Pytanie przez passwd przekroczyło czas oczekiwania"
+
+#: pkg/lib/credentials.js:251
+msgid "Prompting via ssh-add timed out"
+msgstr "Pytanie przez ssh-add przekroczyło czas oczekiwania"
+
+#: pkg/lib/credentials.js:191
+msgid "Prompting via ssh-keygen timed out"
+msgstr "Pytanie przez ssh-keygen przekroczyło czas oczekiwania"
+
+#: pkg/subscriptions/subscriptions-register.jsx:125
+msgid "Proxy"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:25
+msgid "Proxy Version"
+msgstr "Wersja pośrednika"
+
+#: pkg/shell/index.html:198 pkg/lib/machine-auth-failed.html:9
+msgid "Public Key"
+msgstr "Klucz publiczny"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:150
+msgid "Pull an image:"
+msgstr "Pobranie obrazu:"
+
+#: pkg/kubernetes/views/imagestream-modify.html:66
+msgid "Pull from"
+msgstr "Pobierz z"
+
+#: pkg/kubernetes/views/imagestream-body.html:31
+msgid "Pull repository"
+msgstr "Repozytorium pobierania"
+
+#: pkg/storaged/details.js:869
+msgid "Purpose"
+msgstr "Zastosowanie"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:140
+msgid "Push an image:"
+msgstr "Wysłanie obrazu:"
+
+#: pkg/kubernetes/views/pv-modify.html:147
+#: pkg/kubernetes/views/volume-body.html:77
+msgid "Qualified Name"
+msgstr "Nazwa kwalifikowana"
+
+#: pkg/storaged/details.js:1539
+msgid "RAID ($0)"
+msgstr "RAID ($0)"
+
+#: pkg/storaged/details.js:1533
+msgid "RAID 0"
+msgstr "RAID 0"
+
+#: pkg/storaged/overview.js:422
+msgid "RAID 0 (Stripe)"
+msgstr "RAID 0 (Striping)"
+
+#: pkg/storaged/details.js:1534
+msgid "RAID 1"
+msgstr "RAID 1"
+
+#: pkg/storaged/overview.js:423
+msgid "RAID 1 (Mirror)"
+msgstr "RAID 1 (Lustrzany)"
+
+#: pkg/storaged/details.js:1538
+msgid "RAID 10"
+msgstr "RAID 10"
+
+#: pkg/storaged/overview.js:427
+msgid "RAID 10 (Stripe of Mirrors)"
+msgstr "RID 10 (Striping lustrzany)"
+
+#: pkg/storaged/details.js:1535
+msgid "RAID 4"
+msgstr "RAID 4"
+
+#: pkg/storaged/overview.js:424
+msgid "RAID 4 (Dedicated Parity)"
+msgstr "RAID 4 (Dedykowana parzystość)"
+
+#: pkg/storaged/details.js:1536
+msgid "RAID 5"
+msgstr "RAID 5"
+
+#: pkg/storaged/overview.js:425
+msgid "RAID 5 (Distributed Parity)"
+msgstr "RAID 5 (Rozproszona parzystość)"
+
+#: pkg/storaged/details.js:1537
+msgid "RAID 6"
+msgstr "RAID 6"
+
+#: pkg/storaged/overview.js:426
+msgid "RAID 6 (Double Distributed Parity)"
+msgstr "RAID 6 (Podwójna rozproszona parzystość)"
+
+#: pkg/storaged/index.html:537
+msgid "RAID Device"
+msgstr "Urządzenie RAID"
+
+#: pkg/storaged/utils.js:233
+msgid "RAID Device $0"
+msgstr "Urządzenie RAID $0"
+
+#: pkg/storaged/index.html:65
+msgid "RAID Devices"
+msgstr "Urządzenia RAID"
+
+#: pkg/storaged/overview.js:420
+msgid "RAID Level"
+msgstr "Poziom macierzy RAID"
+
+#: pkg/storaged/index.html:555
+msgctxt "storage"
+msgid "RAID Level"
+msgstr "Poziom macierzy RAID"
+
+#: pkg/storaged/details.js:1228
+msgctxt "storage-id-desc"
+msgid "RAID Member"
+msgstr "Element macierzy RAID"
+
+#: pkg/kubernetes/scripts/volumes.js:200
+msgid "Rados Block Device"
+msgstr "Urządzenie blokowe Rados"
+
+#: pkg/kubernetes/views/pv-modify.html:194
+#: pkg/kubernetes/views/volume-body.html:10
+#: pkg/kubernetes/views/volume-body.html:20
+#: pkg/kubernetes/views/volume-body.html:44
+#: pkg/kubernetes/views/volume-body.html:51
+#: pkg/kubernetes/views/volume-body.html:71
+#: pkg/kubernetes/views/volume-body.html:85
+#: pkg/kubernetes/views/volume-body.html:93
+#: pkg/kubernetes/views/volume-body.html:110
+#: pkg/kubernetes/views/volume-body.html:122
+#: pkg/kubernetes/views/volume-body.html:136
+#: pkg/kubernetes/views/volume-body.html:143
+msgid "Read Only"
+msgstr "Tylko do odczytu"
+
+#: pkg/kubernetes/scripts/volumes.js:211
+msgid "Read and write from a single node"
+msgstr "Odczyt i zapis z jednego węzła"
+
+#: pkg/kubernetes/scripts/volumes.js:213
+msgid "Read and write from multiple nodes"
+msgstr "Odczyt i zapis z wielu węzłów"
+
+#: pkg/kubernetes/scripts/volumes.js:212
+msgid "Read only from multiple nodes"
+msgstr "Tylko odczyt z wielu węzłów"
+
+#: pkg/docker/index.html:385
+msgid "ReadOnly"
+msgstr "Tylko do odczytu"
+
+#: pkg/docker/index.html:384
+msgid "ReadWrite"
+msgstr "Odczyt i zapis"
+
+#: pkg/storaged/index.html:327
+msgid "Reading"
+msgstr "Odczytywanie"
+
+#: pkg/playground/translate.html:20 pkg/playground/translate.html:179
+#: pkg/kubernetes/views/details-page.html:52
+#: pkg/kubernetes/views/node-body.html:41
+msgid "Ready"
+msgstr "Gotowe"
+
+#: pkg/playground/translate.html:25
+#, fuzzy
+msgctxt "verb"
+msgid "Ready"
+msgstr "Gotowe"
+
+#: pkg/systemd/index.html:319
+msgid "Real Host Name"
+msgstr "Prawdziwa nazwa komputera"
+
+#: pkg/kubernetes/views/node-body.html:45
+msgid "Reason"
+msgstr "Przyczyna"
+
+#: pkg/lib/journal.js:241
+msgid "Reboot"
+msgstr "Uruchom ponownie"
+
+#: pkg/networkmanager/index.html:75 pkg/networkmanager/index.html:98
+#: pkg/networkmanager/index.html:116 pkg/networkmanager/index.html:521
+#: pkg/networkmanager/index.html:551
+msgid "Receiving"
+msgstr "Odbieranie"
+
+#: pkg/ostree/client.js:56
+msgid "Receiving delta parts"
+msgstr "Pobieranie części delta"
+
+#: pkg/ostree/client.js:58
+msgid "Receiving metadata objects"
+msgstr "Pobieranie obiektów metadanych"
+
+#: pkg/ostree/client.js:61
+msgid "Receiving objects: $0%"
+msgstr "Pobieranie obiektów: $0%"
+
+#: pkg/systemd/logs.html:40
+msgid "Recent"
+msgstr "Ostatnie"
+
+#: pkg/kubernetes/views/pv-modify.html:56 pkg/kubernetes/views/pv-body.html:6
+msgid "Reclaim Policy"
+msgstr "Polityka odzyskiwania"
+
+#: pkg/shell/simple.html:144 pkg/shell/index.html:327 pkg/shell/stub.html:180
+msgid "Reconnect"
+msgstr "Połącz ponownie"
+
+#: pkg/storaged/details.js:1594
+msgid "Recovering"
+msgstr "Odzyskiwanie"
+
+#: pkg/storaged/jobs.js:145
+#, fuzzy
+msgid "Recovering RAID Device $target"
+msgstr "Zatrzymywanie urządzenia RAID $target"
+
+#: pkg/kubernetes/scripts/volumes.js:219
+msgid "Recycle"
+msgstr "Użyj ponownie"
 
 #: pkg/docker/storage.jsx:348
 msgid "Reformat and add disks"
 msgstr ""
 
-#: pkg/docker/storage.jsx:355
-msgid ""
-"The storage pool will be reset to optimize its layout.  All containers will "
-"be erased."
-msgstr ""
+#: pkg/kubernetes/views/pv-modify.html:205
+msgid "Register"
+msgstr "Zarejestruj"
 
-#: pkg/docker/storage.jsx:360
-msgid "Erase containers, reformat disks, and add them"
-msgstr ""
+#: pkg/kubernetes/views/volumes-page.html:12
+msgid "Register New Volume"
+msgstr "Zarejestruj nowy wolumin"
 
-#: pkg/docker/storage.jsx:363
+#: pkg/kubernetes/views/pv-modify.html:4
+msgid "Register Persistent Volume"
+msgstr "Zarejestruj trwały wolumin"
+
+#: pkg/subscriptions/main.js:74
+msgid "Register system"
+msgstr "Zarejestruj system"
+
+#: pkg/ostree/index.html:115
+msgid "Released"
+msgstr "Wydano"
+
+#: pkg/systemd/init.js:518
+msgid "Reload"
+msgstr "Wczytaj ponownie"
+
+#: pkg/systemd/init.js:519
+msgid "Reload or Restart"
+msgstr "Wczytaj lub uruchom ponownie"
+
+#: pkg/systemd/init.js:521
+msgid "Reload or Try Restart"
+msgstr "Wczytaj ponownie lub spróbuj uruchomić ponownie"
+
+#: pkg/kubernetes/views/imagestream-modify.html:89
+msgid "Remote registry is insecure"
+msgstr "Zdalny rejestr jest niezabezpieczony"
+
+#: cockpit.desktop.in.h:3
+msgid "Remote;Administration;"
+msgstr "Zdalna;Administracja;"
+
+#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
+msgctxt "storage"
+msgid "Removable Drive"
+msgstr "Dysk wymienny"
+
+#: pkg/ostree/index.html:123 pkg/ostree/index.html:146
+msgid "Removals"
+msgstr "Usunięte"
+
+#: pkg/kubernetes/views/user-group-remove.html:10
+#: pkg/kubernetes/views/group-delete.html:21
+#: pkg/kubernetes/views/user-delete.html:25
+#: pkg/kubernetes/views/remove-role-dialog.html:8
+msgid "Remove"
+msgstr "Usuń"
+
+#: pkg/networkmanager/interfaces.js:2791
 #, fuzzy
-msgid "Add Additional Storage"
-msgstr "Dodatkowe urządzenia do przechowywania danych"
+msgid "Remove $0"
+msgstr "Usuń"
 
-#: pkg/docker/storage.jsx:366
-msgid ""
-"All data on selected disks will be erased and disks will be added to the "
-"storage pool."
+#: pkg/kubernetes/views/group-delete.html:3
+msgid "Remove Group"
+msgstr "Usuń grupę"
+
+#: pkg/kubernetes/views/user-group-remove.html:3
+msgid "Remove Member"
+msgstr "Usuń element"
+
+#: pkg/kubernetes/views/remove-role-dialog.html:3
+msgid "Remove Role"
+msgstr "Usuń rolę"
+
+#: pkg/kubernetes/views/user-delete.html:3
+msgid "Remove User"
+msgstr "Usuń użytkownika"
+
+#: pkg/kubernetes/views/image-delete.html:3
+msgid "Remove image tag"
+msgstr "Usuń etykietę obrazu"
+
+#: pkg/kubernetes/views/user-remove-membership.html:3
+msgid "Remove membership"
+msgstr "Usuń członkostwo"
+
+#: pkg/storaged/jobs.js:141
+msgid "Removing $target from RAID Device"
+msgstr "Usuwanie $target z urządzenia RAID"
+
+#: pkg/networkmanager/interfaces.js:2788
+msgid "Removing <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/docker/storage.jsx:404
+#: pkg/storaged/jobs.js:154
+msgid "Removing physical volume from $target"
+msgstr "Usuwanie woluminu fizycznego z $target"
+
+#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
+#: pkg/storaged/details.js:1775
+msgid "Rename"
+msgstr "Zmień nazwę"
+
+#: pkg/storaged/details.js:795
+msgid "Rename Volume Group"
+msgstr "Zmień nazwę grupy woluminów"
+
+#: pkg/storaged/details.js:706
+msgid "Renamee Logical Volume"
+msgstr "Zmień nazwę woluminu logicznego"
+
+#: pkg/storaged/jobs.js:157
+msgid "Renaming $target"
+msgstr "Zmienianie nazwy $target"
+
+#: pkg/systemd/services.html:432
+msgid "Repeat Daily"
+msgstr ""
+
+#: pkg/systemd/services.html:431
+msgid "Repeat Hourly"
+msgstr ""
+
+#: pkg/systemd/services.html:434
+msgid "Repeat Monthly"
+msgstr ""
+
+#: pkg/systemd/services.html:433
+msgid "Repeat Weekly"
+msgstr ""
+
+#: pkg/systemd/services.html:435
+msgid "Repeat Yearly"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-body.html:9
+#: pkg/kubernetes/views/details-page.html:141
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
+#: pkg/kubernetes/views/replicationcontroller-modify.html:8
+msgid "Replicas"
+msgstr "Repliki"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:14
+#: pkg/kubernetes/views/replicationcontroller-panel.html:10
+#: pkg/kubernetes/views/topology-page.html:23
+msgid "Replication Controller"
+msgstr "Kontroler replikacji"
+
+#: pkg/kubernetes/views/details-page.html:132
+msgid "Replication Controllers"
+msgstr "Kontrolery replikacji"
+
+#: pkg/kubernetes/views/topology-page.html:24
 #, fuzzy
-msgid "Could not add all disks"
-msgstr "Nie można wyświetlić listy usług"
+msgid ""
+"Replication controllers dynamically create instances of                pods "
+"from templates, and remove pods when necessary."
+msgstr ""
+"Kontrolery replikacji dynamicznie tworzą wystąpienia\n"
+"                pojemników z szablonów, i usuwają je w razie potrzeby."
+
+#: pkg/docker/index.html:718
+msgid "Repository"
+msgstr "Repozytorium"
+
+#: pkg/kubernetes/views/volume-body.html:24
+msgid "Repository URL"
+msgstr "Adres URL repozytorium"
+
+#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
+msgid "Requested"
+msgstr "Żądany"
+
+#: pkg/kubernetes/views/pv-claim.html:13
+msgid "Requests"
+msgstr "Żądania"
+
+#: pkg/kubernetes/views/auth-form.html:54
+msgid "Requires Authentication"
+msgstr "Wymaga uwierzytelnienia"
+
+#: pkg/docker/index.html:323
+msgid "Reset"
+msgstr "Przywróć"
 
 #: pkg/docker/storage.jsx:417
 #, fuzzy
@@ -2122,391 +4761,603 @@ msgid ""
 "the pool."
 msgstr ""
 
-#: pkg/docker/storage.jsx:423
-msgid "Erase containers and reset storage pool"
+#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
+msgid "Resize"
+msgstr "Zmień rozmiar"
+
+#: pkg/storaged/details.js:673
+msgid "Resize Filesystem"
+msgstr "Zmień rozmiar systemu plików"
+
+#: pkg/storaged/details.js:661
+msgid "Resize Logical Volume"
+msgstr "Zmień rozmiar woluminu logicznego"
+
+#: pkg/storaged/jobs.js:158
+msgid "Resizing $target"
+msgstr "Zmienianie rozmiaru $target"
+
+#: pkg/systemd/index.html:126 pkg/systemd/index.html:133
+msgid "Restart"
+msgstr "Uruchom ponownie"
+
+#: pkg/kubernetes/views/container-body.html:20
+msgid "Restart Count"
+msgstr "Liczba ponownych uruchomień"
+
+#: pkg/docker/index.html:558 pkg/kubernetes/views/pod-body.html:10
+msgid "Restart Policy"
+msgstr "Polityka ponownego uruchamiania"
+
+#: pkg/kubernetes/scripts/volumes.js:217
+msgid "Retain"
+msgstr "Zachowaj"
+
+#: pkg/docker/index.html:574
+msgid "Retries:"
+msgstr "Próby:"
+
+#: pkg/subscriptions/subscriptions-view.jsx:188
+msgid "Retrieving subscription status..."
 msgstr ""
 
-#: pkg/docker/storage.jsx:446
-msgid "Could not reset the storage pool"
-msgstr ""
-
-#: pkg/docker/storage.jsx:482
-#, fuzzy
-msgid "You don't have permission to manage the Docker storage pool."
-msgstr ""
-"Brak uprawnienia do wyświetlania upoważnionych publicznych kluczy dla tego "
-"konta."
-
-#: pkg/docker/storage.jsx:485
-#, fuzzy
-msgid "The Docker storage pool cannot be managed on this system."
-msgstr "API „storaged” nie jest dostępne w tym systemie."
-
-#: pkg/docker/image.js:77
-msgid "Image $0"
-msgstr "Obraz $0"
-
-#: pkg/docker/image.js:152
-msgid ""
-"Deleting an image will delete it, but you can probably download it again if "
-"you need it later.  Unless this image has never been pushed to a repository, "
-"that is, in which case you probably can't download it again."
-msgstr ""
-"Usunięcie obrazu spowoduje jego usunięcie, ale prawdopodobnie można go "
-"pobrać ponownie w razie potrzeby. Wyjątkiem jest sytuacja, w której tego "
-"obrazu nigdy nie wysłano do repozytorium."
-
-#: pkg/docker/util.js:94
-msgid "Up since $StartedAt"
-msgstr "Działa od $StartedAt"
-
-#: pkg/docker/util.js:96
-msgid "Exited $ExitCode"
-msgstr "Zakończono $ExitCode"
-
-#: pkg/docker/util.js:104
-msgid "On failure, retry $0 time"
-msgid_plural "On failure, retry $0 times"
-msgstr[0] "Po niepowodzeniu próbowanie ponownie $0 raz"
-msgstr[1] "Po niepowodzeniu próbowanie ponownie $0 razy"
-msgstr[2] "Po niepowodzeniu próbowanie ponownie $0 razy"
-
-#: pkg/docker/util.js:107 pkg/docker/index.html.h:48
-msgid "Always"
-msgstr "Zawsze"
-
-#: pkg/docker/util.js:109 pkg/docker/index.html.h:49
-msgid "Unless Stopped"
-msgstr "Do zatrzymania"
-
-#: pkg/docker/util.js:123
-msgid "default"
-msgstr "domyślnie"
-
-#: pkg/docker/util.js:124
-msgid "$0 shares"
-msgstr "Udziały: $0"
-
-#: pkg/docker/util.js:231
-msgid "Stopped"
-msgstr "Zatrzymano"
-
-#: pkg/docker/util.js:488
-msgid "Container is currently running."
-msgstr "Kontener jest obecnie uruchomiony."
-
-#: pkg/docker/util.js:490
-msgid ""
-"Container is currently marked as not running, but regular stopping failed."
-msgstr ""
-"Kontener jest obecnie oznaczony jako działający, ale zwykłe zatrzymanie się "
-"nie powiodło."
-
-#: pkg/docker/util.js:491
-msgid "Error message from Docker:"
-msgstr "Komunikat o błędzie Dockera:"
-
-#: pkg/docker/util.js:501
-msgid "Please confirm forced deletion of $0"
-msgstr "Proszę potwierdzić wymuszenie usunięcia $0"
-
-#: pkg/docker/util.js:503
-msgid "Force Delete"
-msgstr "Wymuś usunięcie"
-
-#: pkg/docker/util.js:544
-msgid "Failed to stop Docker scope: $0"
-msgstr "Zatrzymanie zakresu Dockera się nie powiodło: $0"
-
-#: pkg/docker/containers-view.jsx:239
-#, fuzzy
-msgid "Commit"
-msgstr "Komentarz"
-
-#: pkg/docker/containers.js:64
-msgid "Failed to start Docker: $0"
-msgstr "Uruchomienie Dockera się nie powiodło: $0"
-
-#: pkg/users/authorized-keys.js:103
-msgid "Validating key"
-msgstr "Sprawdzanie poprawności klucza"
-
-#: pkg/users/authorized-keys.js:108
-msgid "Adding key"
-msgstr "Dodawanie klucza"
-
-#: pkg/users/authorized-keys.js:115
-msgid "Error saving authorized keys: "
-msgstr "Błąd podczas zapisywania upoważnionych kluczy: "
-
-#: pkg/users/authorized-keys.js:118
-msgid "The key you provided was not valid."
-msgstr "Podany klucz jest nieprawidłowy."
-
-#: pkg/users/local.js:40
-msgid "The user <b>$0</b> is not permitted to modify accounts"
-msgstr "Użytkownik <b>$0</b> nie posiada zezwolenia na modyfikowanie kont"
-
-#: pkg/users/local.js:57
-msgid "Unable to delete root account"
-msgstr "Nie można usunąć konta roota"
-
-#: pkg/users/local.js:59
-msgid "Unable to rename root account"
-msgstr "Nie można zmienić nazwy konta roota"
-
-#: pkg/users/local.js:82
-msgid "Prompting via passwd timed out"
-msgstr "Pytanie przez passwd przekroczyło czas oczekiwania"
-
-#: pkg/users/local.js:247
-msgid "Password is too weak"
-msgstr "Hasło jest za słabe"
-
-#: pkg/users/local.js:259
-msgid "Password is not acceptable"
-msgstr "Hasło jest do przyjęcia"
-
-#: pkg/users/local.js:284 pkg/users/local.js:594
-msgctxt "page-title"
-msgid "Accounts"
-msgstr "Konta"
-
-#: pkg/users/local.js:395 pkg/users/local.js:1082
-msgid "The passwords do not match"
-msgstr "Hasła się nie zgadzają"
-
-#: pkg/users/local.js:400
-msgid "No user name specified"
-msgstr "Nie podano nazwy użytkownika"
-
-#: pkg/users/local.js:405
-msgid "No real name specified"
-msgstr "Nie podano nazwy obszaru"
-
-#: pkg/users/local.js:429 pkg/users/local.js:1104
-msgid "Excellent password"
-msgstr "Doskonałe hasło"
-
-#: pkg/users/local.js:501
-msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
-msgstr ""
-"Nazwa użytkownika może składać się tylko z liter od A do Z, cyfr, kropek, "
-"myślników i podkreślników."
-
-#: pkg/users/local.js:509
-msgid "This user name already exists"
-msgstr "Ta nazwa użytkownika już istnieje"
-
-#: pkg/users/local.js:682 pkg/users/local.js:683
-msgid "Server Administrator"
-msgstr "Administrator serwera"
-
-#: pkg/users/local.js:684
-msgid "Container Administrator"
-msgstr "Administrator kontenera"
-
-#: pkg/users/local.js:839
-msgid "Logged In"
-msgstr "Zalogowano"
-
-#: pkg/users/local.js:841
-msgid "Never"
-msgstr "Nigdy"
-
-#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
-msgid "Delete $0"
-msgstr "Usuń $0"
-
-#: pkg/sosreport/index.js:49 pkg/sosreport/index.js:113
-#: pkg/systemd/services.html.h:13 pkg/lib/machine-invalid-hostkey.html.h:4
-#: pkg/lib/machine-auth-failed.html.h:7
-#: pkg/lib/machine-unknown-hostkey.html.h:4
-#: pkg/lib/machine-change-port.html.h:8 pkg/lib/machine-not-supported.html.h:3
-#: pkg/shell/index.html.h:37
-msgid "Close"
-msgstr "Zamknij"
-
-#: pkg/sosreport/index.js:115
-msgid "No archive has been created."
-msgstr "Nie utworzono archiwum."
-
-#: pkg/networkmanager/interfaces.js:598 pkg/networkmanager/interfaces.js:1051
-#: pkg/networkmanager/interfaces.js:2255 pkg/networkmanager/interfaces.js:2257
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:753 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/kubernetes/views/node-body.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:6
-#: pkg/kubernetes/views/pv-claim.html.h:7
-#: pkg/kubernetes/views/image-body.html.h:6
-#: pkg/kubernetes/views/pv-body.html.h:5
-msgid "Unknown"
-msgstr "Nieznane"
-
-#: pkg/networkmanager/interfaces.js:805
-msgid "Not available"
-msgstr "Niedostępne"
-
-#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
-#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
-msgid "Inactive"
-msgstr "Nieaktywne"
-
-#: pkg/networkmanager/interfaces.js:809
-msgid "Preparing"
-msgstr "Przygotowywanie"
-
-#: pkg/networkmanager/interfaces.js:811
-msgid "Configuring"
-msgstr "Konfigurowanie"
-
-#: pkg/networkmanager/interfaces.js:813
-msgid "Authenticating"
-msgstr "Uwierzytelnianie"
-
-#: pkg/networkmanager/interfaces.js:815
-msgid "Configuring IP"
-msgstr "Konfigurowanie IP"
-
-#: pkg/networkmanager/interfaces.js:817
-msgid "Checking IP"
-msgstr "Sprawdzanie IP"
-
-#: pkg/networkmanager/interfaces.js:819
-msgid "Waiting"
-msgstr "Oczekiwanie"
-
-#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
-msgid "Active"
-msgstr "Aktywne"
-
-#: pkg/networkmanager/interfaces.js:823
-msgid "Deactivating"
-msgstr "Dezaktywowanie"
-
-#: pkg/networkmanager/interfaces.js:825 pkg/ostree/index.html.h:14
-msgid "Failed"
-msgstr "Niepowodzenie"
-
-#: pkg/networkmanager/interfaces.js:1326
-msgid "No carrier"
-msgstr "Brak operatora"
-
-#: pkg/networkmanager/interfaces.js:1372
-msgid "Part of "
-msgstr "Część "
-
-#: pkg/networkmanager/interfaces.js:1420
-msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr ""
-"Użytkownik <b>$0</b> nie posiada zezwolenia na modyfikowanie ustawień sieci"
-
-#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
-msgctxt "page-title"
-msgid "Networking"
-msgstr "Sieć"
-
-#: pkg/networkmanager/interfaces.js:1804
-msgid "Automatic (DHCP)"
-msgstr "Automatyczne (DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
-msgid "Link local"
-msgstr "Link-local"
-
-#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
-msgid "Manual"
-msgstr "Ręczne"
-
-#: pkg/networkmanager/interfaces.js:1807
-msgid "Shared"
-msgstr "Współdzielone"
-
-#: pkg/networkmanager/interfaces.js:1813 pkg/networkmanager/interfaces.js:2475
-#: pkg/networkmanager/interfaces.js:3019 pkg/networkmanager/interfaces.js:3023
-#: pkg/networkmanager/interfaces.js:3029 pkg/networkmanager/index.html.h:22
-msgid "Automatic"
-msgstr "Automatyczne"
-
-#: pkg/networkmanager/interfaces.js:1814
-msgid "Automatic (DHCP only)"
-msgstr "Automatyczne (tylko DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1817
-msgid "Ignore"
-msgstr "Ignorowanie"
+#: pkg/kubernetes/views/volume-body.html:26
+msgid "Revision"
+msgstr "Wersja"
+
+#: pkg/users/index.html:94 pkg/kubernetes/views/add-member-role-dialog.html:39
+#: pkg/kubernetes/views/project-body.html:21
+msgid "Roles"
+msgstr "Role"
+
+#: pkg/ostree/index.html:73
+msgid "Roll back and reboot"
+msgstr "Przywróć i uruchom ponownie"
 
 #: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
 msgid "Round Robin"
 msgstr "Round Robin"
 
-#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
-msgid "Active Backup"
-msgstr "Aktywna kopia zapasowa"
+#: pkg/kubernetes/views/route-page.html:14
+#: pkg/kubernetes/views/route-panel.html:9
+msgid "Route"
+msgstr "Trasa"
 
-#: pkg/networkmanager/interfaces.js:1824
-msgid "XOR"
-msgstr "XOR"
+#: pkg/kubernetes/views/details-page.html:65
+msgid "Routes"
+msgstr "Trasy"
 
-#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
-msgid "Broadcast"
-msgstr "Broadcast"
-
-#: pkg/networkmanager/interfaces.js:1826
-msgid "802.3ad"
-msgstr "802.3ad"
-
-#: pkg/networkmanager/interfaces.js:1827
-msgid "Adaptive transmit load balancing"
-msgstr "Adaptacyjne równoważenie obciążenia przesyłu"
-
-#: pkg/networkmanager/interfaces.js:1828
-msgid "Adaptive load balancing"
-msgstr "Adaptacyjne równoważenie obciążenia"
-
-#: pkg/networkmanager/interfaces.js:1833
-msgid "MII (Recommended)"
-msgstr "MII (zalecane)"
-
-#: pkg/networkmanager/interfaces.js:1834
-msgid "ARP"
-msgstr "ARP"
-
-#: pkg/networkmanager/interfaces.js:1841
+#: pkg/systemd/services.html:384
 #, fuzzy
-msgid "Load Balancing"
-msgstr "Adaptacyjne równoważenie obciążenia"
+msgid "Run"
+msgstr "Działanie jako"
 
-#: pkg/networkmanager/interfaces.js:1843
+#: pkg/kubernetes/views/image-config.html:4
+msgid "Run as"
+msgstr "Działanie jako"
+
+#: pkg/networkmanager/index.html:381
 #, fuzzy
-msgid "802.3ad LACP"
-msgstr "802.3ad"
+msgid "Runner"
+msgstr "Działające"
 
-#: pkg/networkmanager/interfaces.js:1848
-msgid "Passive"
+#: pkg/ostree/index.html:83
+msgid "Running"
+msgstr "Działające"
+
+#: pkg/selinux/setroubleshoot-view.jsx:478
+msgid "SELinux Access Control Errors"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1854
-msgid "Ethtool"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1855
+#: pkg/selinux/setroubleshoot-view.jsx:330
 #, fuzzy
-msgid "ARP Ping"
-msgstr "Monitorowanie ARP"
+msgid "SELinux Policy"
+msgstr "Polityka DNS"
 
-#: pkg/networkmanager/interfaces.js:1856
-msgid "NSNA Ping"
+#: pkg/selinux/setroubleshoot.html:23
+msgid "SELinux Troubleshoot"
+msgstr "Rozwiązywanie problemów z SELinuksem"
+
+#: pkg/selinux/setroubleshoot-view.jsx:317
+#, fuzzy
+msgid "SELinux is disabled on the system."
+msgstr "Cockpit nie jest zainstalowany w systemie."
+
+#: pkg/selinux/setroubleshoot-view.jsx:309
+msgid "SELinux system status is unknown."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2156
-msgid "Deleting <b>$0</b> will break the connection to the server, "
+#: pkg/storaged/jobs.js:119
+msgid "SMART self-test of $target"
+msgstr "Test SMART $target"
+
+#: pkg/networkmanager/index.html:218
+msgid "STP Forward delay"
+msgstr "Opóźnienie w przód STP"
+
+#: pkg/networkmanager/index.html:227
+msgid "STP Hello time"
+msgstr "Czas powitania STP"
+
+#: pkg/networkmanager/index.html:236
+msgid "STP Maximum message age"
+msgstr "Maksymalny wiek komunikatu STP"
+
+#: pkg/networkmanager/index.html:209
+msgid "STP Priority"
+msgstr "Priorytet STP"
+
+#: pkg/systemd/services.html:466
+msgid "Save"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2188
-msgid "Switching on <b>$0</b>  will break the connection to the server, "
+#: pkg/ostree/client.js:66
+msgid "Scanning metadata"
+msgstr "Skanowanie metadanych"
+
+#: pkg/kubernetes/views/node-capacity.html:9
+msgid "Scheduled Pods"
+msgstr "Zaplanowane pojemniki"
+
+#: pkg/kubernetes/scripts/nodes.js:322
+msgid "Scheduling Disabled"
+msgstr "Wyłączono planowanie"
+
+#: pkg/systemd/services.html:402 pkg/systemd/services.html:406
+msgid "Seconds"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:195
+msgid "Secret"
+msgstr "Sekret"
+
+#: pkg/kubernetes/views/volume-body.html:106
+msgid "Secret File"
+msgstr "Tajny plik"
+
+#: pkg/kubernetes/views/volume-body.html:141
+msgid "Secret Name"
+msgstr "Tajna nazwa"
+
+#: pkg/kubernetes/views/volume-body.html:69
+#: pkg/kubernetes/views/volume-body.html:108
+#: pkg/kubernetes/views/volume-body.html:134
+msgid "Secret Volume"
+msgstr "Tajny wolumin"
+
+#: pkg/systemd/index.html:93
+msgid "Secure Shell Keys"
+msgstr "Klucze SSH"
+
+#: pkg/storaged/jobs.js:136
+msgid "Securely erasing $target"
+msgstr "Bezpieczne usuwanie zawartości $target"
+
+#: pkg/kubernetes/views/file-button.html:4
+msgid "Select Manifest File..."
+msgstr "Wybierz plik manifestu…"
+
+#: pkg/kubernetes/views/topology-page.html:7
+msgid "Select an object to see more details."
+msgstr "Proszę wybrać obiekt, aby wyświetlić więcej informacji."
+
+#: pkg/lib/machine-sync-users.html:8
+msgid ""
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
+msgstr ""
+"Proszę wybrać użytkowników do synchronizacji z {{#strong}}{{host}}{{/strong}}"
+
+#: pkg/networkmanager/index.html:69 pkg/networkmanager/index.html:97
+#: pkg/networkmanager/index.html:115 pkg/networkmanager/index.html:515
+#: pkg/networkmanager/index.html:550
+msgid "Sending"
+msgstr "Wysyłanie"
+
+#: pkg/storaged/index.html:432
+msgctxt "storage"
+msgid "Serial Number"
+msgstr "Numer seryjny"
+
+#: pkg/kubernetes/views/pv-modify.html:82
+#: pkg/kubernetes/views/volume-body.html:47
+msgid "Server"
+msgstr "Serwer"
+
+#: pkg/storaged/overview.js:518
+msgid "Server Address"
+msgstr "Adres serwera"
+
+#: pkg/users/local.js:682 pkg/users/local.js:683
+msgid "Server Administrator"
+msgstr "Administrator serwera"
+
+#: pkg/storaged/overview.js:521
+#, fuzzy
+msgid "Server address cannot be empty."
+msgstr "Adres serwera nie może być pusty."
+
+#: src/base1/cockpit.js:3709
+msgid "Server has closed the connection."
+msgstr "Serwer zamknął połączenie."
+
+#: pkg/kubernetes/views/service-page.html:12
+#: pkg/kubernetes/views/service-panel.html:8
+#: pkg/kubernetes/views/topology-page.html:32
+msgid "Service"
+msgstr "Usługa"
+
+#: pkg/kubernetes/views/pod-body.html:12
+msgid "Service Account"
+msgstr "Konto usługi"
+
+#: pkg/systemd/services.html:279
+msgid "Service Logs"
+msgstr "Dzienniki serwera"
+
+#: pkg/systemd/services.html:342
+#, fuzzy
+msgid "Service name"
+msgstr "Usługa"
+
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:272
+#: pkg/kubernetes/views/dashboard-page.html:134
+#: pkg/kubernetes/views/details-page.html:29
+msgid "Services"
+msgstr "Usługi"
+
+#: pkg/kubernetes/views/topology-page.html:33
+#, fuzzy
+msgid ""
+"Services group pods and provide a common DNS                name and an "
+"optional, load-balanced IP address to access them."
+msgstr ""
+"Usługi grupują pojemniki i dostarczają wspólną nazwę\n"
+"                DNS oraz opcjonalny, zrównoważony adres IP do uzyskiwania do "
+"nich dostępu."
+
+#: pkg/kubernetes/views/service-body.html:20
+msgid "Session Affinity"
+msgstr "Pokrewieństwo procesora"
+
+#: pkg/dashboard/index.html:190
+msgid "Set"
+msgstr "Ustaw"
+
+#: pkg/systemd/host.js:559
+msgid "Set Host name"
+msgstr "Ustaw nazwę komputera"
+
+#: pkg/users/index.html:117 pkg/users/index.html:221
+msgid "Set Password"
+msgstr "Ustaw hasło"
+
+#: pkg/systemd/index.html:395
+msgid "Set Time"
+msgstr "Ustaw czas"
+
+#: pkg/docker/index.html:551
+msgid "Set container environment variables"
+msgstr "Ustaw zmienne środowiskowe kontenera"
+
+#: pkg/networkmanager/index.html:172
+msgid "Set to"
+msgstr "Ustaw na"
+
+#: pkg/selinux/setroubleshoot-view.jsx:326
+msgid ""
+"Setting deviates from the configured state and will revert on the next boot."
+msgstr ""
+
+#: pkg/storaged/jobs.js:131
+msgid "Setting up loop device $target"
+msgstr "Ustawianie urządzenia zwrotnego $target"
+
+#: pkg/kubernetes/views/volume-body.html:139
+msgid "Share Name"
+msgstr "Współdzielona nazwa"
+
+#: pkg/networkmanager/interfaces.js:1807
+msgid "Shared"
+msgstr "Współdzielone"
+
+#: pkg/kubernetes/views/container-panel.html:9
+#: pkg/kubernetes/views/container-page-inline.html:14
+msgid "Shell"
+msgstr "Powłoka"
+
+#: pkg/kubernetes/views/container-page.html:4
+msgid "Show all Containers"
+msgstr "Wyświetl wszystkie kontenery"
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:8
+msgid "Show all Deployment Configs"
+msgstr "Wyświetl wszystkie konfiguracje wdrożeń"
+
+#: pkg/kubernetes/views/node-page.html:8
+msgid "Show all Nodes"
+msgstr "Wyświetl wszystkie węzły"
+
+#: pkg/kubernetes/views/pv-page.html:9
+msgid "Show all Persistent Volumes"
+msgstr "Wyświetl wszystkie trwałe woluminy"
+
+#: pkg/kubernetes/views/pod-container.html:4
+msgid "Show all Pod Containers"
+msgstr "Wyświetl wszystkie kontenery pojemników"
+
+#: pkg/kubernetes/views/pod-page.html:8
+msgid "Show all Pods"
+msgstr "Wyświetl wszystkie pojemniki"
+
+#: pkg/kubernetes/views/user-page.html:16
+#: pkg/kubernetes/views/group-page.html:14
+#: pkg/kubernetes/views/project-page.html:23
+msgid "Show all Projects"
+msgstr "Wyświetl wszystkie projekty"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:10
+msgid "Show all Replication Controllers"
+msgstr "Wyświetl wszystkie kontrolery replikacji"
+
+#: pkg/kubernetes/views/route-page.html:10
+msgid "Show all Routes"
+msgstr "Wyświetl wszystkie trasy"
+
+#: pkg/kubernetes/views/service-page.html:8
+msgid "Show all Services"
+msgstr "Wyświetl wszystkie usługi"
+
+#: pkg/docker/index.html:127
+#, fuzzy
+msgid "Show all containers"
+msgstr "Wyświetl wszystkie kontenery"
+
+#: pkg/kubernetes/views/imagestream-page.html:12
+msgid "Show all image streams"
+msgstr "Wyświetl wszystkie potoki obrazów"
+
+#: pkg/docker/index.html:241 pkg/kubernetes/views/image-page.html:11
+msgid "Show all images"
+msgstr "Wyświetl wszystkie obrazy"
+
+#: pkg/systemd/index.html:94
+msgid "Show fingerprints"
+msgstr "Wyświetl odciski"
+
+#: pkg/systemd/index.html:136
+msgid "Shutdown"
+msgstr "Wyłącz"
+
+#: pkg/kubernetes/views/container-body.html:18
+msgid "Since"
+msgstr "Od"
+
+#: pkg/systemd/init.js:621
+msgid "Since $0"
+msgstr "Od $0"
+
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/storaged/index.html:232
+msgid "Size"
+msgstr "Rozmiar"
+
+#: pkg/storaged/dialog.js:271
+#, fuzzy
+msgid "Size cannot be negative"
+msgstr "Rozmiar nie może być ujemny"
+
+#: pkg/storaged/dialog.js:269
+#, fuzzy
+msgid "Size cannot be zero"
+msgstr "Rozmiar nie może wynosić zero"
+
+#: pkg/storaged/dialog.js:273
+msgid "Size is too large"
+msgstr "Rozmiar jest za duży"
+
+#: pkg/storaged/dialog.js:267
+msgid "Size must be a number"
+msgstr "Rozmiar musi być liczbą"
+
+#: pkg/kubernetes/views/auth-form.html:43
+#: pkg/kubernetes/views/auth-rejected-cert.html:11
+msgid "Skip Certificate Verification"
+msgstr "Pomiń sprawdzanie poprawności certyfikatu"
+
+#: pkg/systemd/services.html:54
+msgid "Sockets"
+msgstr "Gniazda"
+
+#: pkg/ostree/index.html:23
+msgid "Software Updates"
+msgstr "Aktualizacje oprogramowania"
+
+#: pkg/docker/storage.jsx:156
+#, fuzzy
+msgid "Solid-State Disk"
+msgstr "Dysk SSD"
+
+#: pkg/storaged/overview.js:182
+msgctxt "storage"
+msgid "Solid-State Disk"
+msgstr "Dysk SSD"
+
+#: pkg/selinux/setroubleshoot-view.jsx:90
+msgid "Solution applied successfully"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:97
+#, fuzzy
+msgid "Solution failed"
+msgstr "Logowanie się nie powiodło"
+
+#: pkg/kubernetes/scripts/volumes.js:908
+msgid "Sorry, I don't know how to modify this volume"
+msgstr "Nie wiadomo, jak zmodyfikować ten wolumin"
+
+#: pkg/kubernetes/views/image-body.html:8
+msgid "Source URL"
+msgstr "Źródłowy adres URL"
+
+#: pkg/networkmanager/interfaces.js:2573
+msgid "Spanning Tree Protocol"
+msgstr "Protokół STP"
+
+#: pkg/networkmanager/index.html:200
+msgid "Spanning Tree Protocol (STP)"
+msgstr "Protokół STP"
+
+#: pkg/storaged/details.js:1594
+msgid "Spare"
+msgstr "Zapasowe"
+
+#: pkg/systemd/index.html:470
+msgid "Specific Time"
+msgstr "Podany czas"
+
+#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
+msgid "Start"
+msgstr "Rozpocznij"
+
+#: pkg/docker/index.html:68
+msgid "Start Docker"
+msgstr "Uruchom Dockera"
+
+#: pkg/storaged/index.html:49
+msgid "Start Multipath"
+msgstr "Uruchom urządzenie wielościeżkowe"
+
+#: pkg/storaged/details.js:1614
+msgid "Start Scrubbing"
+msgstr "Rozpocznij kontrolę"
+
+#: pkg/storaged/jobs.js:139
+msgid "Starting RAID Device $target"
+msgstr "Uruchamianie urządzenia RAID $target"
+
+#: pkg/storaged/jobs.js:124
+msgid "Starting swapspace $target"
+msgstr "Uruchamianie przestrzeni wymiany $target"
+
+#: pkg/subscriptions/subscriptions-view.jsx:37
+msgid "Starts"
+msgstr "Zaczyna się"
+
+#: pkg/kubernetes/views/container-body.html:16
+#: pkg/kubernetes/views/details-page.html:38
+#: pkg/kubernetes/views/details-page.html:175
+msgid "State"
+msgstr "Stan"
+
+#: pkg/storaged/index.html:571
+msgctxt "storage"
+msgid "State"
+msgstr "Stan"
+
+#: pkg/systemd/init.js:303
+msgid "Static"
+msgstr "Statyczne"
+
+#: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/containers-listing.html:16
+#: pkg/kubernetes/views/nodes-page.html:44
+#: pkg/kubernetes/views/pvc-body.html:13 pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/pv-body.html:24
+msgid "Status"
+msgstr "Stan"
+
+#: pkg/subscriptions/subscriptions-view.jsx:146
+#, fuzzy
+msgid "Status: $0"
+msgstr "Stan"
+
+#: pkg/subscriptions/subscriptions-view.jsx:141
+msgid "Status: System isn't registered"
+msgstr ""
+
+#: pkg/networkmanager/index.html:455
+msgid "Sticky"
+msgstr ""
+
+#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
+msgid "Stop"
+msgstr "Zatrzymaj"
+
+#: pkg/storaged/details.js:1615
+msgid "Stop Scrubbing"
+msgstr "Zatrzymaj kontrolę"
+
+#: pkg/kubernetes/views/image-config.html:10
+msgid "Stop with"
+msgstr "Zatrzymanie za pomocą"
+
+#: pkg/docker/util.js:231
+msgid "Stopped"
+msgstr "Zatrzymano"
+
+#: pkg/storaged/jobs.js:138
+msgid "Stopping RAID Device $target"
+msgstr "Zatrzymywanie urządzenia RAID $target"
+
+#: pkg/storaged/jobs.js:125
+msgid "Stopping swapspace $target"
+msgstr "Zatrzymywanie przestrzeni wymiany $target"
+
+#: pkg/storaged/index.html:23 pkg/storaged/index.html:672
+msgid "Storage"
+msgstr "Urządzenia do przechowywania danych"
+
+#: pkg/storaged/index.html:686
+msgid "Storage Log"
+msgstr "Dziennik urządzeń do przechowywania danych"
+
+#: pkg/storaged/index.html:342
+msgid "Storage Logs"
+msgstr "Dzienniki urządzeń do przechowywania danych"
+
+#: pkg/docker/index.html:324
+msgid "Storage pool"
+msgstr "Pula urządzeń do przechowywania danych"
+
+#: pkg/systemd/index.html:148
+msgid "Store Performance Data"
+msgstr "Przechowywanie danych wydajności"
+
+#: pkg/storaged/details.js:237
+msgid "Store passphrase"
+msgstr "Przechowaj hasło"
+
+#: pkg/storaged/details.js:527
+msgid "Stored Passphrase"
+msgstr "Zachowane hasło"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:12
+msgid ""
+"Strategy            {{item.spec.strategy.type}}            Latest "
+"Version            {{ item.status.latestVersion }}            Not "
+"deployed        "
+msgstr ""
+
+#: pkg/subscriptions/index.html:22
+msgid "Subscriptions"
+msgstr "Subskrypcje"
+
+#: pkg/kubernetes/views/image-body.html:4
+msgid "Summary"
+msgstr "Podsumowanie"
+
+#: pkg/storaged/details.js:1251
+msgctxt "storage-id-desc"
+msgid "Swap Space"
+msgstr "Przestrzeń wymiany"
+
+#: pkg/systemd/index.html:243
+msgid "Swap Used"
+msgstr "Używana przestrzeń wymiany"
+
+#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
+msgid "Switch off $0"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2191 pkg/networkmanager/interfaces.js:2765
@@ -2517,359 +5368,649 @@ msgstr ""
 msgid "Switching off <b>$0</b>  will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
-msgid "Switch off $0"
+#: pkg/networkmanager/interfaces.js:2773
+msgid "Switching off <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
-#: pkg/networkmanager/interfaces.js:2507
-msgid "Bond"
-msgstr "Wiązanie"
+#: pkg/networkmanager/interfaces.js:2188
+msgid "Switching on <b>$0</b>  will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2762
+msgid "Switching on <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:75
+msgid "Synchronize"
+msgstr "Zsynchronizuj"
+
+#: pkg/dashboard/index.html:188 pkg/lib/machine-sync-users.html:4
+msgid "Synchronize users"
+msgstr "Zsynchronizuj użytkowników"
+
+#: pkg/systemd/index.html:54
+msgid "Synchronized"
+msgstr "Synchronizowane"
+
+#: pkg/systemd/index.html:51
+msgid "Synchronized with {{Server}}"
+msgstr "Synchronizowane z {{Server}}"
+
+#: pkg/storaged/jobs.js:146
+msgid "Synchronizing RAID Device $target"
+msgstr "Synchronizowanie urządzenia RAID $target"
+
+#: pkg/systemd/index.html:4
+#, fuzzy
+msgid "System"
+msgstr "Czas systemowy"
+
+#: pkg/systemd/services.html:53
+msgid "System Services"
+msgstr "Usługi systemowe"
+
+#: pkg/systemd/index.html:112
+msgid "System Time"
+msgstr "Czas systemowy"
+
+#: pkg/docker/index.html:349
+msgid "TCP"
+msgstr "TCP"
+
+#: pkg/kubernetes/views/route-body.html:12
+msgid "TLS Termination"
+msgstr "Zakończenie TLS"
+
+#: pkg/docker/index.html:724
+msgid "Tag"
+msgstr "Etykieta"
+
+#: pkg/kubernetes/views/image-body.html:27
+#: pkg/kubernetes/views/imagestream-modify.html:76
+#: pkg/kubernetes/views/image-listing.html:14
+msgid "Tags"
+msgstr "Etykiety"
+
+#: pkg/kubernetes/views/pv-modify.html:136
+msgid "Target"
+msgstr "Cel"
+
+#: pkg/kubernetes/views/volume-body.html:75
+msgid "Target Portal"
+msgstr "Portal docelowy"
+
+#: pkg/kubernetes/views/volume-body.html:114
+msgid "Target World Wide Names"
+msgstr "Docelowe WWN"
+
+#: pkg/systemd/services.html:52
+msgid "Targets"
+msgstr "Cele"
 
 #: pkg/networkmanager/interfaces.js:2235 pkg/networkmanager/interfaces.js:2247
 #: pkg/networkmanager/interfaces.js:2530
 msgid "Team"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
-#: pkg/networkmanager/interfaces.js:2622
-msgid "VLAN"
-msgstr "VLAN"
+#: pkg/networkmanager/interfaces.js:2558
+#, fuzzy
+msgid "Team Port"
+msgstr "Portal docelowy"
 
-#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
-#: pkg/networkmanager/interfaces.js:2584
-msgid "Bridge"
-msgstr "Mostek"
+#: pkg/networkmanager/index.html:652
+#, fuzzy
+msgid "Team Port Settings"
+msgstr "Ustawienia portu mostku"
 
-#: pkg/networkmanager/interfaces.js:2276
-msgid "Carrier"
-msgstr "Operator"
+#: pkg/networkmanager/index.html:624
+#, fuzzy
+msgid "Team Settings"
+msgstr "Ustawienia IP"
 
-#: pkg/networkmanager/interfaces.js:2279 pkg/kubernetes/scripts/volumes.js:990
-msgid "Yes"
-msgstr "Tak"
+#: pkg/kubernetes/views/replicationcontroller-page.html:20
+#: pkg/kubernetes/views/deploymentconfig-panel.html:10
+#: pkg/kubernetes/views/deploymentconfig-page.html:15
+#: pkg/kubernetes/views/replicationcontroller-panel.html:14
+msgid "Template"
+msgstr "Szablon"
 
-#: pkg/networkmanager/interfaces.js:2299
-#: pkg/subscriptions/subscriptions-view.jsx:36
-#: pkg/kubernetes/views/node-body.html.h:14
-#: pkg/kubernetes/views/containers-listing.html.h:7
-#: pkg/kubernetes/views/volumes-page.html.h:5
-#: pkg/kubernetes/views/pv-claim.html.h:6
-#: pkg/kubernetes/views/nodes-page.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:5 pkg/kubernetes/views/pv-body.html.h:4
-msgid "Status"
-msgstr "Stan"
+#: pkg/systemd/terminal.html:4
+msgid "Terminal"
+msgstr "Terminal"
+
+#: pkg/users/index.html:78
+msgid "Terminate Session"
+msgstr "Zakończ sesję"
+
+#: pkg/networkmanager/index.html:38
+msgid "Testing connection"
+msgstr ""
+
+#: pkg/storaged/index.html:40
+msgid "The \"storaged\" API is not available on this system."
+msgstr "API „storaged” nie jest dostępne w tym systemie."
+
+#: pkg/docker/storage.jsx:485
+#, fuzzy
+msgid "The Docker storage pool cannot be managed on this system."
+msgstr "API „storaged” nie jest dostępne w tym systemie."
+
+#: pkg/lib/machine-dialogs.js:386
+msgid "The IP address or host name cannot contain whitespace."
+msgstr "Adres IP lub nazwa komputera nie może zawierać spacji."
+
+#: pkg/storaged/index.html:532
+msgid "The RAID Array is in a degraded state"
+msgstr "Macierz RAID jest w stanie zdegradowanym"
+
+#: pkg/kubernetes/scripts/nodes.js:399
+msgid "The address contains invalid characters"
+msgstr "Adres zawiera nieprawidłowe znaki"
+
+#: pkg/lib/machine-unknown-hostkey.html:6
+msgid ""
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
+msgstr ""
+"Nie można ustalić autentyczności komputera {{#strong}}{{host}}{{/strong}}. "
+"Na pewno kontynuować łączenie?"
+
+#: pkg/selinux/setroubleshoot-view.jsx:324
+msgid "The configured state is unknown, it might change on the next boot."
+msgstr ""
+
+#: pkg/kubernetes/views/container-page-inline.html:22
+msgid "The container '{{ target }}' does not exist."
+msgstr "Kontener „{{ target }}” nie istnieje."
+
+#: pkg/subscriptions/subscriptions-view.jsx:192
+#, fuzzy
+msgid "The current user isn't allowed to access system subscription status."
+msgstr ""
+"\n"
+"        Obecny użytkownik nie jest upoważniony do zarządzania subskrypcjami "
+"w tym systemie.\n"
+"      "
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:25
+msgid "The deployment config '{{ target }}' does not exist."
+msgstr "Konfiguracja wdrożenia „{{ target }}” nie istnieje."
+
+#: pkg/kubernetes/views/group-page.html:47
+msgid "The group '{{ groupName }}' does not exist."
+msgstr "Grupa „{{ groupName }}” nie istnieje."
+
+#: pkg/shell/base_index.js:673
+msgid "The javascript console contains details about this error "
+msgstr "Konsola języka JavaScript zawiera informacje o tym błędzie "
+
+#: pkg/lib/machine-invalid-hostkey.html:8
+msgid ""
+"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
+"in use. Unless this machine was recently replaced, it is likely that someone "
+"is trying to attack your connection to this machine."
+msgstr ""
+"Klucz {{#strong}}{{host}}{{/strong}} nie pasuje do poprzednio używanego "
+"klucza. Jeśli ten komputer nie został niedawno wymieniany, może to oznaczać "
+"próbę ataku na połączenie z tym komputerem."
+
+#: pkg/users/authorized-keys.js:118
+msgid "The key you provided was not valid."
+msgstr "Podany klucz jest nieprawidłowy."
+
+#: pkg/storaged/details.js:1751
+msgid "The last physical volume of a volume group cannot be removed."
+msgstr ""
+
+#: pkg/shell/indexes.js:314
+msgid "The machine is restarting"
+msgstr "Komputer jest ponownie uruchamiany"
+
+#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
+msgid "The maximum number of replicas is 128"
+msgstr "Maksymalna liczna replik to 128"
+
+#: pkg/kubernetes/scripts/nodes.js:407
+msgid "The name contains invalid characters"
+msgstr "Nazwa zawiera nieprawidłowe znaki"
+
+#: pkg/kubernetes/views/node-page.html:23
+msgid "The node '{{ target }}' does not exist."
+msgstr "Węzeł „{{ target }}” nie istnieje."
+
+#: pkg/kubernetes/views/node-alerts.html:7
+msgid "The node doesn't have enough disk space"
+msgstr "Węzeł ma za mało miejsca na dysku"
+
+#: pkg/kubernetes/views/node-alerts.html:11
+msgid "The node doesn't have enough free memory"
+msgstr "Węzeł ma za mało wolnej pamięci"
+
+#: pkg/users/local.js:395 pkg/users/local.js:1082
+msgid "The passwords do not match"
+msgstr "Hasła się nie zgadzają"
+
+#: pkg/lib/credentials.js:186
+msgid "The passwords do not match."
+msgstr "Hasła się nie zgadzają."
+
+#: pkg/kubernetes/views/pv-page.html:21
+msgid "The persistent volume '{{ target }}' does not exist."
+msgstr "Trwały wolumin „{{ target }}” nie istnieje."
+
+#: pkg/kubernetes/views/pod-page.html:40
+msgid "The pod '{{ target }}' does not exist."
+msgstr "Pojemnik „{{ target }}” nie istnieje."
+
+#: pkg/kubernetes/views/project-page.html:34
+msgid "The project '{{ projName }}' does not exist."
+msgstr "Projekt „{{ projName }}” nie istnieje."
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:30
+msgid "The replication controller '{{ target }}' does not exist."
+msgstr "Kontroler replikacji „{{ target }}” nie istnieje."
+
+#: pkg/kubernetes/views/route-page.html:19
+msgid "The route '{{ target }}' does not exist."
+msgstr "Trasa „{{ target }}” nie istnieje."
+
+#: pkg/kubernetes/scripts/dashboard.js:386
+msgid "The selected file is not a valid Kubernetes application manifest."
+msgstr "Wybrany plik nie jest prawidłowym manifestem aplikacji Kubernetes."
+
+#: src/base1/cockpit.js:3695
+msgid "The server refused to authenticate using any supported methods."
+msgstr ""
+"Serwer odmówił uwierzytelnienia za pomocą wszystkich obsługiwanych metod."
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:2
+msgid "The server uses a certificate signed by an unknown authority."
+msgstr "Serwer używa certyfikatu podpisanego przez nieznany ośrodek."
+
+#: pkg/kubernetes/views/service-page.html:19
+msgid "The service '{{ target }}' does not exist."
+msgstr "Usługa „{{ target }}” nie istnieje."
+
+#: pkg/docker/storage.jsx:355
+msgid ""
+"The storage pool will be reset to optimize its layout.  All containers will "
+"be erased."
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:29
+msgid "The user '{{ userName }}' does not exist."
+msgstr "Użytkownik „{{ userName }}” nie istnieje."
+
+#: pkg/systemd/init.js:834
+#, fuzzy
+msgid "The user <b>$0</b> does not have permissions for creating timers"
+msgstr "Użytkownik <b>$0</b> nie posiada zezwolenia na zarządzanie serwerami"
+
+#: pkg/dashboard/list.js:209
+msgid "The user <b>$0</b> is not permitted to manage servers"
+msgstr "Użytkownik <b>$0</b> nie posiada zezwolenia na zarządzanie serwerami"
+
+#: pkg/storaged/permissions.js:61
+msgid "The user <b>$0</b> is not permitted to manage storage"
+msgstr ""
+"Użytkownik <b>$0</b> nie posiada zezwolenia na zarządzanie urządzeniami do "
+"przechowywania danych"
+
+#: pkg/users/local.js:40
+msgid "The user <b>$0</b> is not permitted to modify accounts"
+msgstr "Użytkownik <b>$0</b> nie posiada zezwolenia na modyfikowanie kont"
+
+#: pkg/systemd/host.js:43
+msgid "The user <b>$0</b> is not permitted to modify hostnames"
+msgstr ""
+"Użytkownik <b>$0</b> nie posiada zezwolenia na modyfikowanie nazw komputerów"
+
+#: pkg/networkmanager/interfaces.js:1420
+msgid "The user <b>$0</b> is not permitted to modify network settings"
+msgstr ""
+"Użytkownik <b>$0</b> nie posiada zezwolenia na modyfikowanie ustawień sieci"
+
+#: pkg/realmd/operation.js:436
+msgid "The user <b>$0</b> is not permitted to modify realms"
+msgstr "Użytkownik <b>$0</b> nie posiada zezwolenia na modyfikowanie obszarów"
+
+#: pkg/users/local.js:501
+msgid ""
+"The user name can only consist of letters from a-z, digits, dots, dashes and "
+"underscores."
+msgstr ""
+"Nazwa użytkownika może składać się tylko z liter od A do Z, cyfr, kropek, "
+"myślników i podkreślników."
+
+#: pkg/users/index.html:332
+msgid "There are no authorized public keys for this account."
+msgstr "Brak upoważnionych publicznych kluczy dla tego konta."
+
+#: pkg/storaged/details.js:1756
+msgid ""
+"There is not enough free space elsewhere to remove this physical volume.  At "
+"least $0 more free space is needed."
+msgstr ""
+
+#: pkg/storaged/utils.js:168
+msgid "Thin Logical Volume"
+msgstr "Cienki wolumin logiczny"
+
+#: pkg/kubernetes/views/pvc-delete.html:8
+msgid ""
+"This claim is in use. Deleting it may cause issues with the following pod:"
+msgstr ""
+"Ta deklaracja jest używana. Usunięcie może spowodować problemy z poniższym "
+"pojemnikiem:"
+
+#: pkg/systemd/init.js:1222
+msgid ""
+"This day doesn't exist in all months.<br> The timer will only be executed in "
+"months that have 31st."
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2310
 #, fuzzy
 msgid "This device cannot be managed here."
 msgstr "Ten wolumin logiczny nie może zostać zmniejszony."
 
-#: pkg/networkmanager/interfaces.js:2342
-msgid "Unknown configuration"
-msgstr "Nieznana konfiguracja"
-
-#: pkg/networkmanager/interfaces.js:2441
-msgid "Configure"
-msgstr "Skonfiguruj"
-
-#: pkg/networkmanager/interfaces.js:2473
-msgid "$mtu"
-msgstr "$mtu"
-
-#: pkg/networkmanager/interfaces.js:2477
-msgid "MTU"
-msgstr "MTU"
-
-#: pkg/networkmanager/interfaces.js:2483
-msgid "Master"
-msgstr "Główne"
-
-#: pkg/networkmanager/interfaces.js:2502
-msgid "ARP Monitoring"
-msgstr "Monitorowanie ARP"
-
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
 #, fuzzy
-msgid "Broken configuration"
-msgstr "Nieznana konfiguracja"
+msgid "This field cannot be empty."
+msgstr "Nazwa nie może być pusta."
 
-#: pkg/networkmanager/interfaces.js:2558
+#: pkg/storaged/details.js:690
 #, fuzzy
-msgid "Team Port"
-msgstr "Portal docelowy"
+msgid "This logical volume cannot be made smaller."
+msgstr "Ten wolumin logiczny nie może zostać zmniejszony."
 
-#: pkg/networkmanager/interfaces.js:2573
-msgid "Spanning Tree Protocol"
-msgstr "Protokół STP"
+#: pkg/lib/machine-dialogs.js:364
+msgid "This machine has already been added."
+msgstr "Ten komputer został już dodany."
 
-#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
-msgid "Priority $priority"
-msgstr "Priorytet $priority"
+#: pkg/realmd/operation.html:89
+msgid "This may take a while"
+msgstr "Może to chwilę zająć"
 
-#: pkg/networkmanager/interfaces.js:2577
-msgid "Forward delay $forward_delay"
-msgstr "Opóźnienie w przód $forward_delay"
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid ""
+"This option is for single node testing only – local storage will not work in "
+"a multi-node cluster"
+msgstr ""
+"Ta opcja jest tylko do testowania jednego węzła — lokalne urządzenia do "
+"przechowywania danych nie będą działały w klastrze wielowęzłowym"
 
-#: pkg/networkmanager/interfaces.js:2579
-msgid "Hello time $hello_time"
-msgstr "Czas powitania $hello_time"
-
-#: pkg/networkmanager/interfaces.js:2581
-msgid "Maximum message age $max_age"
-msgstr "Maksymalny wiek komunikatu $max_age"
-
-#: pkg/networkmanager/interfaces.js:2601
-msgid "Path cost $path_cost"
-msgstr "Koszt ścieżki $path_cost"
-
-#: pkg/networkmanager/interfaces.js:2603
-msgid "Hairpin mode"
-msgstr "Tryb Hairpin"
-
-#: pkg/networkmanager/interfaces.js:2605
-msgid "Bridge port"
-msgstr "Port mostku"
-
-#: pkg/networkmanager/interfaces.js:2619
-msgid "Parent $parent"
-msgstr "Nadrzędne $parent"
-
-#: pkg/networkmanager/interfaces.js:2620
-msgid "Id $id"
-msgstr "Identyfikator $id"
-
-#: pkg/networkmanager/interfaces.js:2628
-msgid "General"
-msgstr "Ogólne"
-
-#: pkg/networkmanager/interfaces.js:2637
-msgid "Connect automatically"
-msgstr "Łączenie automatyczne"
-
-#: pkg/networkmanager/interfaces.js:2641
-msgid "IPv4"
-msgstr "IPv4"
-
-#: pkg/networkmanager/interfaces.js:2642
-msgid "IPv6"
-msgstr "IPv6"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/networkmanager/index.html.h:33
-#: pkg/kubernetes/views/project-listing.html.h:5
-msgid "Members"
-msgstr "Elementy"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/docker/index.html.h:39
-#: pkg/networkmanager/index.html.h:24
-#: pkg/kubernetes/views/service-body.html.h:6
-#: pkg/kubernetes/views/image-config.html.h:7
-#: pkg/kubernetes/views/container-body.html.h:5
-msgid "Ports"
-msgstr "Porty"
-
-#: pkg/networkmanager/interfaces.js:2762
-msgid "Switching on <b>$0</b> will break the connection to the server, "
+#: src/bridge/cockpitpackages.c:470
+msgid "This package is not compatible with this version of Cockpit"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2773
-msgid "Switching off <b>$0</b> will break the connection to the server, "
+#: src/bridge/cockpitpackages.c:459
+#, c-format
+msgid "This package requires Cockpit version %s or later"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2788
-msgid "Removing <b>$0</b> will break the connection to the server, "
-msgstr ""
+#: pkg/tuned/dialog.js:102
+msgid "This system is using a custom profile"
+msgstr "Ten system używa niestandardowego profilu"
 
-#: pkg/networkmanager/interfaces.js:2791
+#: pkg/tuned/dialog.js:100
+msgid "This system is using the recommended profile"
+msgstr "Ten system używa zalecanego profilu"
+
+#: pkg/systemd/init.js:639
+msgid "This unit is an instance of the $0 template."
+msgstr "Ta jednostka jest wystąpieniem szablonu $0."
+
+#: pkg/systemd/services.html:302
 #, fuzzy
-msgid "Remove $0"
-msgstr "Usuń"
+msgid "This unit is not designed to be enabled explicitly.          "
+msgstr ""
+"Ta jednostka nie została zaprojektowana do bezpośredniego włączania.\n"
+"          "
 
-#: pkg/networkmanager/interfaces.js:2833
-msgid "Adding <b>$0</b> will break the connection to the server, "
+#: pkg/users/local.js:509
+msgid "This user name already exists"
+msgstr "Ta nazwa użytkownika już istnieje"
+
+#: pkg/lib/machine-dialogs.js:380
+msgid ""
+"This version of cockpit-ws does not support connecting to a host with an "
+"alternate user or port"
+msgstr ""
+"Ta wersja cockpit-ws nie obsługuje łączenia z komputerem z alternatywnym "
+"użytkownikiem lub portem"
+
+#: pkg/kubernetes/views/pv-delete.html:7
+msgid ""
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
+msgstr ""
+"Ten wolumin został zadeklarowany przez {{ item.item.spec.claimRef."
+"namespace }}/{{ item.item.spec.claimRef.name }}. Usunięcie uszkodzi tę "
+"deklarację i może spowodować problemy z pojemnikami od niej zależnymi."
+
+#: pkg/kubernetes/views/pv-claim.html:23
+msgid "This volume has not been claimed"
+msgstr "Ten wolumin nie został zadeklarowany"
+
+#: pkg/systemd/index.html:379
+msgid "Time Zone"
+msgstr "Strefa czasowa"
+
+#: pkg/systemd/services.html:55
+msgid "Timers"
+msgstr "Liczniki"
+
+#: pkg/kubernetes/views/image-body.html:33
+msgid "To pull this image:"
+msgstr "Aby pobrać ten obraz:"
+
+#: pkg/kubernetes/views/imagestream-body.html:39
+msgid "To push to an image to this image stream:"
+msgstr "Aby wysłać obraz do tego potoku obrazów:"
+
+#: pkg/lib/machine-change-port.html:11
+msgid ""
+"To try a different port you will need to upgrade cockpit-ws to a newer "
+"version."
+msgstr ""
+"Należy zaktualizować cockpit-ws do nowszej wersji, aby spróbować innego "
+"portu."
+
+#: pkg/kubernetes/views/auth-form.html:116
+msgid "Token"
+msgstr "Token"
+
+#: pkg/kubernetes/index.html:57
+msgid "Topology"
+msgstr "Topologia"
+
+#: pkg/docker/storage.jsx:314
+msgid "Total"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2836
-msgid "Add $0"
-msgstr ""
+#: pkg/ostree/index.html:99
+msgid "Tree"
+msgstr "Drzewo"
 
-#: pkg/networkmanager/interfaces.js:2870
-msgid "Changing the settings will break the connection to the server, "
-msgstr ""
+#: pkg/kubernetes/views/deploymentconfig-body.html:32
+msgid "Triggers"
+msgstr "Wyzwalacze"
 
-#: pkg/networkmanager/interfaces.js:2872
-#, fuzzy
-msgid "Change the settings"
-msgstr "Ustawienia połączenia"
+#: pkg/shell/index.html:328 pkg/shell/stub.html:181
+msgid "Troubleshoot"
+msgstr "Rozwiązywanie problemów"
 
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length or Netmask"
-msgstr "Długość przedrostka lub maska sieci"
+#: pkg/kubernetes/views/auth-rejected-cert.html:21
+msgid "Trust this certificate for this connection"
+msgstr "Zaufaj temu certyfikatowi w tym połączeniu"
 
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length"
-msgstr "Długość przedrostka"
+#: pkg/systemd/init.js:520
+msgid "Try Restart"
+msgstr "Spróbuj uruchomić ponownie"
 
-#: pkg/networkmanager/interfaces.js:3011
-#: pkg/kubernetes/views/details-page.html.h:7
-msgid "Addresses"
-msgstr "Adresy"
+#: pkg/docker/index.html:71 pkg/docker/index.html:74
+msgid "Try again"
+msgstr "Spróbuj ponownie"
 
-#: pkg/networkmanager/interfaces.js:3018
-msgid "DNS"
-msgstr "DNS"
+#: pkg/systemd/index.html:59
+msgid "Trying to synchronize with {{Server}}"
+msgstr "Próbowanie synchronizacji z {{Server}}"
 
-#: pkg/networkmanager/interfaces.js:3022
-msgid "DNS Search Domains"
-msgstr "Domeny wyszukiwania DNS"
+#: pkg/tuned/dialog.js:262
+msgid "Tuned has failed to start"
+msgstr "Uruchomienie tuned się nie powiodło"
 
-#: pkg/networkmanager/interfaces.js:3027
-#: pkg/kubernetes/views/details-page.html.h:11
-msgid "Routes"
-msgstr "Trasy"
+#: pkg/tuned/dialog.js:94
+msgid "Tuned is not available"
+msgstr "tuned jest niedostępne"
 
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv4 Settings"
-msgstr "Ustawienia IPv4"
+#: pkg/tuned/dialog.js:96
+msgid "Tuned is not running"
+msgstr "tuned nie jest uruchomione"
 
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv6 Settings"
-msgstr "Ustawienia IPv6"
+#: pkg/tuned/dialog.js:98
+msgid "Tuned is off"
+msgstr "tuned jest wyłączone"
 
-#: pkg/networkmanager/interfaces.js:3436
-msgid "Creating this bond will break the connection to the server, "
-msgstr ""
+#: pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/pv-modify.html:10
+#: pkg/kubernetes/views/volumes-page.html:20 pkg/kubernetes/views/deploy.html:9
+msgid "Type"
+msgstr "Typ"
 
-#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
-#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
-#, fuzzy
-msgid "Create it"
-msgstr "Utwórz"
-
-#: pkg/networkmanager/interfaces.js:3611
-msgid "Creating this team will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3842
-msgid "Creating this bridge will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4064
-msgid "Creating this VLAN will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4139
-msgid "MTU must be a positive number"
-msgstr "MTU musi być liczbą dodatnią"
-
-#: pkg/subscriptions/subscriptions-client.js:196
-#, fuzzy
-msgid "Invalid credentials"
-msgstr "Nieprawidłowy port"
-
-#: pkg/subscriptions/subscriptions-client.js:198
-msgid "'Organization' required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:200
-#, fuzzy
-msgid "Login/password or activation key required to register."
-msgstr "Wymagana jest nazwa użytkownika/hasło lub klucz aktywacji"
-
-#: pkg/subscriptions/subscriptions-client.js:202
-msgid "'Organization' required when using activation keys."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:64
-#: pkg/kubernetes/views/volume-body.html.h:16
-#: pkg/kubernetes/views/pv-modify.html.h:11
-msgid "Server"
-msgstr "Serwer"
-
-#: pkg/subscriptions/subscriptions-register.jsx:88
-#: pkg/subscriptions/subscriptions-register.jsx:152
-#: pkg/lib/machine-auth-failed.html.h:3 pkg/lib/machine-sync-users.html.h:6
-#: pkg/lib/machine-change-auth.html.h:6 pkg/shell/index.html.h:31
-#: pkg/users/index.html.h:16 pkg/kubernetes/views/auth-form.html.h:11
-msgid "Password"
-msgstr "Hasło"
-
-#: pkg/subscriptions/subscriptions-register.jsx:102
-#, fuzzy
-msgid "Custom URL"
-msgstr "Własne"
+#: pkg/kubernetes/views/details-page.html:7
+msgid "Type:"
+msgstr "Typ:"
 
 #: pkg/subscriptions/subscriptions-register.jsx:110
 msgid "URL"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-register.jsx:125
-msgid "Proxy"
+#: pkg/storaged/index.html:547 pkg/storaged/index.html:626
+msgctxt "storage"
+msgid "UUID"
+msgstr "UUID"
+
+#: pkg/selinux/setroubleshoot-view.jsx:114
+msgid "Unable to apply this solution automatically"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-register.jsx:132
-msgid "Use proxy server"
-msgstr ""
+#: pkg/ostree/index.html:219
+msgid "Unable to communicate with OSTree"
+msgstr "Nie można komunikować się OSTree"
 
-#: pkg/subscriptions/subscriptions-register.jsx:140
+#: pkg/subscriptions/subscriptions-view.jsx:195
 #, fuzzy
-msgid "Login"
-msgstr "Ostatnie logowanie"
+msgid "Unable to connect"
+msgstr "Nie można uzyskać alarmu"
 
-#: pkg/subscriptions/subscriptions-register.jsx:164
+#: pkg/kubernetes/scripts/dashboard.js:413
+msgid "Unable to decode Kubernetes application manifest."
+msgstr "Nie można dekodować manifestu aplikacji Kubernetes."
+
+#: pkg/users/local.js:57
+msgid "Unable to delete root account"
+msgstr "Nie można usunąć konta roota"
+
+#: pkg/selinux/setroubleshoot-client.js:157
+msgid "Unable to get alert"
+msgstr "Nie można uzyskać alarmu"
+
+#: pkg/storaged/overview.js:586
+msgid "Unable to reach server"
+msgstr "Nie można połączyć się z serwerem"
+
+#: pkg/kubernetes/scripts/dashboard.js:401
+msgid "Unable to read the Kubernetes application manifest. Code $0."
+msgstr "Nie można odczytać manifestu aplikacji Kubernetes. Kod $0."
+
+#: pkg/users/local.js:59
+msgid "Unable to rename root account"
+msgstr "Nie można zmienić nazwy konta roota"
+
+#: pkg/selinux/setroubleshoot-client.js:172
+msgid "Unable to run fix"
+msgstr "Nie można wykonać poprawki"
+
+#: pkg/selinux/setroubleshoot-client.js:52
+msgid "Unable to start setroubleshootd"
+msgstr "Nie można uruchomić usługi setroubleshootd"
+
+#: pkg/playground/translate.html:35 pkg/playground/translate.html:40
+msgid "Unavailable"
+msgstr "Niedostępne"
+
+#: pkg/docker/index.html:763 pkg/networkmanager/index.html:792
+msgid "Unexpected error"
+msgstr "Nieoczekiwany błąd"
+
+#: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/image-body.html:15
+#: pkg/kubernetes/views/pv-claim.html:31 pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
+msgid "Unknown"
+msgstr "Nieznane"
+
+#: pkg/storaged/details.js:1597
+msgid "Unknown ($0)"
+msgstr "Nieznane ($0)"
+
+#: pkg/lib/machine-unknown-hostkey.html:2
+msgid "Unknown Host Key"
+msgstr "Nieznany klucz komputera"
+
+#: pkg/networkmanager/interfaces.js:2342
+msgid "Unknown configuration"
+msgstr "Nieznana konfiguracja"
+
+#: pkg/storaged/overview.js:582
+msgid "Unknown host name"
+msgstr "Nieznana nazwa komputera"
+
+#: pkg/docker/index.html:570
+msgid "Unless Stopped"
+msgstr "Do zatrzymania"
+
+#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
+#: pkg/storaged/details.js:1110
+msgid "Unlock"
+msgstr "Odblokuj"
+
+#: pkg/shell/index.html:220
+msgid "Unlock Key"
+msgstr "Odblokuj klucz"
+
+#: pkg/storaged/jobs.js:121
+msgid "Unlocking $target"
+msgstr "Odblokowywanie $target"
+
+#: pkg/networkmanager/index.html:108
 #, fuzzy
-msgid "Activation Key"
-msgstr "Aktywuj"
+msgid "Unmanaged Interfaces"
+msgstr "Interfejsy"
 
-#: pkg/subscriptions/subscriptions-register.jsx:176
-#, fuzzy
-msgid "Organization"
-msgstr "Tłumaczenie"
+#: pkg/systemd/init.js:548
+msgid "Unmask"
+msgstr "Anuluj maskowanie"
 
-#: pkg/subscriptions/main.js:45 pkg/subscriptions/subscriptions-view.jsx:143
-#: pkg/kubernetes/views/pv-modify.html.h:23
-msgid "Register"
-msgstr "Zarejestruj"
+#: pkg/storaged/details.js:1100
+msgid "Unmount"
+msgstr "Odmontuj"
 
-#: pkg/subscriptions/main.js:74
-msgid "Register system"
-msgstr "Zarejestruj system"
+#: pkg/storaged/jobs.js:127
+msgid "Unmounting $target"
+msgstr "Odmontowywanie $target"
 
-#: pkg/subscriptions/subscriptions-view.jsx:32
-msgid "Product name"
-msgstr "Nazwa produktu"
+#: pkg/users/index.html:315
+msgid "Unnamed"
+msgstr "Bez nazwy"
 
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product ID"
-msgstr "Identyfikator produktu"
-
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/index.html.h:13
-#: pkg/shell/index.html.h:14 pkg/shell/stub.html.h:9 pkg/shell/simple.html.h:9
-#: pkg/ostree/index.html.h:19
-msgid "Version"
-msgstr "Wersja"
-
-#: pkg/subscriptions/subscriptions-view.jsx:35
-#: pkg/kubernetes/views/image-config.html.h:5
-msgid "Architecture"
-msgstr "Architektura"
-
-#: pkg/subscriptions/subscriptions-view.jsx:37
-msgid "Starts"
-msgstr "Zaczyna się"
-
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Ends"
-msgstr "Kończy się"
-
-#: pkg/subscriptions/subscriptions-view.jsx:141
-msgid "Status: System isn't registered"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:146
-#, fuzzy
-msgid "Status: $0"
-msgstr "Stan"
+#: pkg/storaged/details.js:1256
+msgctxt "storage-id-desc"
+msgid "Unrecognized Data"
+msgstr "Nierozpoznane dane"
 
 #: pkg/subscriptions/subscriptions-view.jsx:148
 #, fuzzy
@@ -2881,814 +6022,212 @@ msgstr "Zarejestruj"
 msgid "Unregistering system..."
 msgstr "Rejestrowanie systemu…"
 
-#: pkg/subscriptions/subscriptions-view.jsx:161
-#: pkg/subscriptions/index.html.h:1
-msgid "Subscriptions"
-msgstr "Subskrypcje"
+#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
+#: src/bridge/cockpitdbussetup.c:625
+#, fuzzy
+msgid "Unsupported setup mechanism"
+msgstr "Nieobsługiwany mechanizm ustawiania: %s"
 
-#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/ostree/index.html.h:15
+#: src/base1/cockpit.js:3697
+msgid "Untrusted host"
+msgstr "Niezaufany komputer"
+
+#: pkg/docker/util.js:94
+msgid "Up since $StartedAt"
+msgstr "Działa od $StartedAt"
+
+#: pkg/lib/machine-change-port.html:41
+msgid "Update"
+msgstr "Zaktualizuj"
+
+#: pkg/ostree/index.html:125 pkg/ostree/index.html:152
+msgid "Updates"
+msgstr "Zaktualizowane"
+
+#: pkg/ostree/index.html:96
 msgid "Updating"
 msgstr "Aktualizowanie"
-
-#: pkg/subscriptions/subscriptions-view.jsx:188
-msgid "Retrieving subscription status..."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:191
-#, fuzzy
-msgid "Access denied"
-msgstr "Tryby dostępu"
-
-#: pkg/subscriptions/subscriptions-view.jsx:192
-#, fuzzy
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-"\n"
-"        Obecny użytkownik nie jest upoważniony do zarządzania subskrypcjami "
-"w tym systemie.\n"
-"      "
-
-#: pkg/subscriptions/subscriptions-view.jsx:195
-#, fuzzy
-msgid "Unable to connect"
-msgstr "Nie można uzyskać alarmu"
-
-#: pkg/subscriptions/subscriptions-view.jsx:196
-#, fuzzy
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-"\n"
-"        Proszę upewnić się, że program subscription-manager jest "
-"zainstalowany, aby zarządzać subskrypcjami systemu.\n"
-"      "
-
-#: pkg/subscriptions/subscriptions-view.jsx:222
-#, fuzzy
-msgid "Installed products"
-msgstr "Zainstalowane produkty"
-
-#: pkg/subscriptions/subscriptions-view.jsx:223
-#, fuzzy
-msgid "No installed products on the system."
-msgstr "Cockpit nie jest zainstalowany w systemie."
-
-#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "Nie jest prawidłowym liczbą replik"
-
-#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "Maksymalna liczna replik to 128"
-
-#: pkg/kubernetes/scripts/details.js:546
-msgid "Not a valid value for Host"
-msgstr "Nieprawidłowa wartość dla gospodarza"
 
 #: pkg/kubernetes/scripts/details.js:655
 msgid "Updating $0..."
 msgstr "Aktualizowanie $0…"
 
-#: pkg/kubernetes/scripts/graphs.js:601 pkg/kubernetes/scripts/nodes.js:711
-#: pkg/kubernetes/scripts/nodes.js:817 pkg/dashboard/index.html.h:2
-msgid "CPU"
-msgstr "Procesor"
-
-#: pkg/kubernetes/scripts/graphs.js:606 pkg/kubernetes/scripts/nodes.js:715
-#: pkg/kubernetes/scripts/nodes.js:826 pkg/dashboard/index.html.h:3
-msgid "Memory"
-msgstr "Pamięć"
-
-#: pkg/kubernetes/scripts/graphs.js:611 pkg/dashboard/index.html.h:4
-msgid "Network"
-msgstr "Sieć"
-
-#: pkg/kubernetes/scripts/nodes.js:319 pkg/kubernetes/views/node-body.html.h:16
-#: pkg/kubernetes/views/details-page.html.h:10
-msgid "Not Ready"
-msgstr "Niegotowe"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
-msgstr "Wyłączono planowanie"
-
-#: pkg/kubernetes/scripts/nodes.js:324 pkg/kubernetes/views/node-body.html.h:15
-#: pkg/kubernetes/views/details-page.html.h:9
-msgid "Ready"
-msgstr "Gotowe"
-
-#: pkg/kubernetes/scripts/nodes.js:397
-msgid "Please type an address"
-msgstr "Proszę wpisać adres"
-
-#: pkg/kubernetes/scripts/nodes.js:399
-msgid "The address contains invalid characters"
-msgstr "Adres zawiera nieprawidłowe znaki"
-
-#: pkg/kubernetes/scripts/nodes.js:407
-msgid "The name contains invalid characters"
-msgstr "Nazwa zawiera nieprawidłowe znaki"
-
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
-msgstr "Użycie procesora: $0%"
-
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
-msgstr "Użycie pamięci: $0%"
-
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
-msgid "Disk"
-msgstr "Dysk"
-
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
-msgstr "Użycie dysku: $0%"
-
-#: pkg/kubernetes/scripts/nodes.js:870
-#, fuzzy, c-format
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] "$0% wolny"
-msgstr[1] "$0% wolne"
-msgstr[2] "$0% wolnych"
-
-#: pkg/kubernetes/scripts/nodes.js:872
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] "$0% używany"
-msgstr[1] "$0% używane"
-msgstr[2] "$0% używanych"
-
-#: pkg/kubernetes/scripts/connection.js:88
-msgid "Error writing kubectl config"
-msgstr "Błąd podczas zapisywania konfiguracji kubectl"
-
-#: pkg/kubernetes/scripts/connection.js:514
-msgid "Couldn't find running API server"
-msgstr "Nie można odnaleźć uruchomionego serwera API"
-
-#: pkg/kubernetes/scripts/connection.js:516
-msgid "Connection Error: $0"
-msgstr "Błąd połączenia: $0"
-
-#: pkg/kubernetes/scripts/connection.js:539
-msgid "Please provide a valid address"
-msgstr "Proszę podać prawidłowy adres"
-
-#: pkg/kubernetes/scripts/connection.js:554
-msgid "Please provide a username"
-msgstr "Proszę podać nazwę użytkownika"
-
-#: pkg/kubernetes/scripts/connection.js:650
-msgid "Error getting certificate details: $0"
-msgstr "Błąd podczas uzyskiwania informacji o certyfikacie: $0"
-
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr "Trwały dysk GCE"
-
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr "Elastyczna przechowalnia blokowa AWS"
-
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
-msgstr "Repozytorium git"
-
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr "Sekret"
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr "Pusty katalog"
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
-msgid "Host Path"
-msgstr "Ścieżka gospodarza"
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr "GlusterFS"
-
-#: pkg/kubernetes/scripts/volumes.js:199
-msgid "NFS Mount"
-msgstr "Punkt montowania NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr "Urządzenie blokowe Rados"
-
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
-msgid "ISCSI"
-msgstr "iSCSI"
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr "Cinder"
-
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr "Punkt montowania systemu plików Ceph"
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr "Fibre Channel"
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr "Flocker"
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr "Flex"
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr "Azure"
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr "Odczyt i zapis z jednego węzła"
-
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr "Tylko odczyt z wielu węzłów"
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr "Odczyt i zapis z wielu węzłów"
-
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr "Zachowaj"
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr "Użyj ponownie"
-
-#: pkg/kubernetes/scripts/volumes.js:469
-msgid "Please select a valid access mode"
-msgstr "Proszę wybrać prawidłowy tryb dostępu"
-
-#: pkg/kubernetes/scripts/volumes.js:477
-msgid "Please provide a valid name"
-msgstr "Proszę podać prawidłową nazwę"
-
-#: pkg/kubernetes/scripts/volumes.js:485
-msgid "Please provide a valid storage capacity."
-msgstr "Proszę podać prawidłową pojemność urządzenia do przechowywania danych."
-
-#: pkg/kubernetes/scripts/volumes.js:493
-msgid "Please select a valid policy option."
-msgstr "Proszę wybrać prawidłową opcję polityki."
-
-#: pkg/kubernetes/scripts/volumes.js:565
-msgid "Please select a valid endpoint"
-msgstr "Proszę wybrać prawidłowy punkt końcowy"
-
-#: pkg/kubernetes/scripts/volumes.js:574
-msgid "Please provide a GlusterFS volume name"
-msgstr "Proszę podać prawidłową nazwę woluminu GlusterFS"
-
-#: pkg/kubernetes/scripts/volumes.js:632
-msgid "Please provide a valid NFS server"
-msgstr "Proszę podać prawidłowy serwer NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
-msgid "Please provide a valid path"
-msgstr "Proszę podać prawidłową ścieżkę"
-
-#: pkg/kubernetes/scripts/volumes.js:781
-msgid "Please provide a valid target"
-msgstr "Proszę podać prawidłowy cel"
-
-#: pkg/kubernetes/scripts/volumes.js:789
-msgid "Please provide a valid qualified name"
-msgstr "Proszę podać prawidłową nazwę kwalifikowaną"
-
-#: pkg/kubernetes/scripts/volumes.js:797
-msgid "Please provide a valid logical unit number"
-msgstr "Proszę podać prawidłowy numer jednostki logicznej"
-
-#: pkg/kubernetes/scripts/volumes.js:805
-msgid "Please provide a valid filesystem type"
-msgstr "Proszę podać prawidłowy typ systemu plików"
-
-#: pkg/kubernetes/scripts/volumes.js:813
-msgid "Please provide a valid interface"
-msgstr "Proszę podać prawidłowy interfejs"
-
-#: pkg/kubernetes/scripts/volumes.js:860
-msgid "NFS"
-msgstr "NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:872
-msgid "GlusterFS"
-msgstr "GlusterFS"
-
-#: pkg/kubernetes/scripts/volumes.js:908
-msgid "Sorry, I don't know how to modify this volume"
-msgstr "Nie wiadomo, jak zmodyfikować ten wolumin"
-
-#: pkg/kubernetes/scripts/charts.js:113
-msgid "Unavailable"
-msgstr "Niedostępne"
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "Przestrzeń nazw nie może być pusta."
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "Proszę podać prawidłową przestrzeń nazw."
-
-#: pkg/kubernetes/scripts/dashboard.js:384
-msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
+#: pkg/shell/index.html:165
+msgid "Use my password for privileged tasks and to connect to other machines"
 msgstr ""
-"Nie wybrano żadnego pliku metadanych. Proszę wybrać plik metadanych "
-"Kubernetes."
+"Użycie hasła do zadań wymagających uprawnień i łączenia z innymi komputerami"
 
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr "Wybrany plik nie jest prawidłowym manifestem aplikacji Kubernetes."
-
-#: pkg/kubernetes/scripts/dashboard.js:401
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr "Nie można odczytać manifestu aplikacji Kubernetes. Kod $0."
-
-#: pkg/kubernetes/scripts/dashboard.js:413
-msgid "Unable to decode Kubernetes application manifest."
-msgstr "Nie można dekodować manifestu aplikacji Kubernetes."
-
-#: pkg/kubernetes/scripts/dashboard.js:441
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "Proszę dodać następną przestrzeń nazw dla $0 „$1”"
-
-#: pkg/kubernetes/scripts/dashboard.js:460
-msgid "Manifest"
-msgstr "Manifest"
-
-#: pkg/dashboard/list.js:209
-msgid "The user <b>$0</b> is not permitted to manage servers"
-msgstr "Użytkownik <b>$0</b> nie posiada zezwolenia na zarządzanie serwerami"
-
-#: pkg/dashboard/list.js:394
-msgid ""
-"You are currently connected directly to this server. You cannot delete it."
-msgstr "Obecnie połączono bezpośrednio z tym serwerem. Nie można go usunąć."
-
-#: cockpit.appdata.xml.in.h:1
-msgid ""
-"Cockpit is a server manager that makes it easy to administer your Linux "
-"servers via a web browser. Jumping between the terminal and the web tool is "
-"no problem. A service started via Cockpit can be stopped via the terminal. "
-"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
-"journal interface."
+#: pkg/subscriptions/subscriptions-register.jsx:132
+msgid "Use proxy server"
 msgstr ""
-"Cockpit to menedżer serwerów ułatwiający administrowanie serwerów Linux "
-"przez przeglądarkę WWW. Można z łatwością przechodzić między terminalem "
-"a narzędziami WWW. Usługa uruchomiona za pomocą Cockpit może zostać "
-"zatrzymana za pomocą terminala. Jeśli błąd wystąpi w terminalu, to można go "
-"zobaczyć w interfejsie dziennika Cockpit."
 
-#: cockpit.appdata.xml.in.h:2
-msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
-"stopping services. You can monitor and administer several servers at the "
-"same time. Just add them with a single click and your machines will look "
-"after its buddies."
-msgstr ""
-"Cockpit jest idealny dla nowych administratorów, umożliwiając łatwe "
-"wykonywanie prostych zadań, takich jak administracja urządzeniami do "
-"przechowywania danych, badanie dzienników oraz uruchamianie i zatrzymywanie "
-"usług. Można monitorować i administrować wiele serwerów w tym samym czasie. "
-"Wystarczy dodać je pojedynczym kliknięciem."
+#: pkg/shell/index.html:172
+msgid "Use the following keys to authenticate against other systems"
+msgstr "Użycie poniższych kluczy do uwierzytelniania w innych systemach"
 
-#: cockpit.desktop.in.h:1 pkg/shell/index.html.h:1 pkg/shell/stub.html.h:1
-#: pkg/shell/simple.html.h:1
-msgid "Cockpit"
-msgstr "Cockpit"
+#: pkg/systemd/index.html:251
+msgid "Used"
+msgstr "Używane"
 
-#: cockpit.desktop.in.h:2
-msgid "A user interface for GNU/Linux servers"
-msgstr "Interfejs użytkownika dla serwerów GNU/Linux"
+#: pkg/systemd/index.html:229 pkg/dashboard/index.html:158
+#: pkg/playground/translate.html:86 pkg/playground/translate.html:106
+#: pkg/kubernetes/views/user-panel.html:9
+#: pkg/kubernetes/views/auth-form.html:61
+#: pkg/kubernetes/views/volume-body.html:64
+#: pkg/kubernetes/views/volume-body.html:103
+msgid "User"
+msgstr "Użytkownik"
 
-#: cockpit.desktop.in.h:3
-msgid "Remote;Administration;"
-msgstr "Zdalna;Administracja;"
+#: pkg/users/index.html:90 pkg/users/index.html:154
+#: pkg/realmd/operation.html:47
+msgid "User Name"
+msgstr "Nazwa użytkownika"
 
-#: pkg/systemd/index.html.h:1
-#, fuzzy
-msgid "System"
-msgstr "Czas systemowy"
+#: pkg/realmd/operation.html:53
+msgid "User Password"
+msgstr "Hasło użytkownika"
 
-#: pkg/systemd/index.html.h:2
-msgid "No host keys found."
-msgstr "Nie odnaleziono kluczy komputera."
+#: pkg/lib/machine-change-auth.html:18
+msgid "User name"
+msgstr "Nazwa użytkownika"
 
-#: pkg/systemd/index.html.h:3
-msgid "Synchronized with {{Server}}"
-msgstr "Synchronizowane z {{Server}}"
+#: pkg/kubernetes/views/add-member-role-dialog.html:15
+msgid "User or Group"
+msgstr "Użytkownik lub grupa"
 
-#: pkg/systemd/index.html.h:4
-msgid "Synchronized"
-msgstr "Synchronizowane"
+#: pkg/kubernetes/views/auth-form.html:94
+msgid "Username"
+msgstr "Nazwa użytkownika"
 
-#: pkg/systemd/index.html.h:5
-msgid "Trying to synchronize with {{Server}}"
-msgstr "Próbowanie synchronizacji z {{Server}}"
+#: pkg/kubernetes/views/project-listing.html:85
+msgid "Users"
+msgstr "Użytkownicy"
 
-#: pkg/systemd/index.html.h:6
-msgid "Not synchronized"
-msgstr "Niesynchronizowane"
+#: pkg/storaged/details.js:181
+msgid "VFAT - Compatible with all systems and devices"
+msgstr "VFAT — zgodne ze wszystkimi systemami i urządzeniami"
 
-#: pkg/systemd/index.html.h:7
-msgid "Hardware"
-msgstr "Sprzęt"
+#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
+#: pkg/networkmanager/interfaces.js:2622
+msgid "VLAN"
+msgstr "VLAN"
 
-#: pkg/systemd/index.html.h:8
-msgid "Asset Tag"
-msgstr "Etykieta zasobu"
+#: pkg/networkmanager/index.html:141
+msgid "VLAN Id"
+msgstr "Identyfikator VLAN"
 
-#: pkg/systemd/index.html.h:9 pkg/kubernetes/views/node-body.html.h:6
-msgid "Machine ID"
-msgstr "Identyfikator komputera"
+#: pkg/networkmanager/index.html:736
+msgid "VLAN Settings"
+msgstr "Ustawienia VLAN"
 
-#: pkg/systemd/index.html.h:10 pkg/ostree/index.html.h:18
-#: pkg/kubernetes/views/nodes-page.html.h:6
-msgid "Operating System"
-msgstr "System operacyjny"
+#: pkg/users/authorized-keys.js:103
+msgid "Validating key"
+msgstr "Sprawdzanie poprawności klucza"
 
-#: pkg/systemd/index.html.h:11
-msgid "Secure Shell Keys"
-msgstr "Klucze SSH"
+#: pkg/systemd/index.html:98 pkg/ostree/index.html:113 pkg/shell/simple.html:77
+#: pkg/shell/index.html:90 pkg/shell/stub.html:83
+msgid "Version"
+msgstr "Wersja"
 
-#: pkg/systemd/index.html.h:12
-msgid "Show fingerprints"
-msgstr "Wyświetl odciski"
+#: pkg/storaged/jobs.js:137
+msgid "Very securely erasing $target"
+msgstr "Bardzo bezpieczne usuwanie zawartości $target"
 
-#: pkg/systemd/index.html.h:14 pkg/dashboard/index.html.h:7
-msgid "Host Name"
-msgstr "Nazwa komputera"
+#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
+#: pkg/kubernetes/views/pvc-body.html:6
+msgid "Volume"
+msgstr "Wolumin"
 
-#: pkg/systemd/index.html.h:15
-msgid "Domain"
-msgstr "Domena"
+#: pkg/storaged/index.html:620
+msgid "Volume Group"
+msgstr "Grupa woluminów"
 
-#: pkg/systemd/index.html.h:16
-msgid "System Time"
-msgstr "Czas systemowy"
+#: pkg/storaged/utils.js:239
+msgid "Volume Group $0"
+msgstr "Grupa woluminów $0"
 
-#: pkg/systemd/index.html.h:17
-msgid "Power Options"
-msgstr "Opcje zasilania"
+#: pkg/storaged/index.html:98
+msgid "Volume Groups"
+msgstr "Grupy woluminów"
 
-#: pkg/systemd/index.html.h:20
-msgid "Performance Profile"
-msgstr "Profil wydajności"
+#: pkg/kubernetes/views/volume-body.html:14
+#: pkg/kubernetes/views/volume-body.html:89
+msgid "Volume ID"
+msgstr "Identyfikator woluminu"
 
-#: pkg/systemd/index.html.h:21
-msgid "Store Performance Data"
-msgstr "Przechowywanie danych wydajności"
+#: pkg/kubernetes/views/pv-modify.html:115
+#: pkg/kubernetes/views/volume-body.html:42
+msgid "Volume Name"
+msgstr "Nazwa woluminu"
 
-#: pkg/systemd/index.html.h:32
-msgid "Machine SSH Key Fingerprints"
-msgstr "Odciski kluczy SSH komputera"
+#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
+msgid "Volume Type"
+msgstr "Typ woluminu"
 
-#: pkg/systemd/index.html.h:33
-msgid "Pretty Host Name"
-msgstr "Czytelna nazwa komputera"
+#: pkg/docker/index.html:536 pkg/kubernetes/views/pod-page.html:18
+#: pkg/kubernetes/views/image-config.html:28
+#: pkg/kubernetes/views/dashboard-page.html:47 pkg/kubernetes/index.html:70
+msgid "Volumes"
+msgstr "Woluminy"
 
-#: pkg/systemd/index.html.h:34
-msgid "Real Host Name"
-msgstr "Prawdziwa nazwa komputera"
+#: pkg/networkmanager/interfaces.js:819
+msgid "Waiting"
+msgstr "Oczekiwanie"
 
-#: pkg/systemd/index.html.h:35
-msgid "Time Zone"
-msgstr "Strefa czasowa"
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid "Warning:"
+msgstr "Ostrzeżenie:"
 
-#: pkg/systemd/index.html.h:36
-msgid ""
-"\n"
-"                                    Invalid time zone\n"
-"                                "
-msgstr ""
-"\n"
-"                                    Nieprawidłowa strefa czasowa\n"
-"                                "
-
-#: pkg/systemd/index.html.h:39
-msgid "Set Time"
-msgstr "Ustaw czas"
-
-#: pkg/systemd/index.html.h:40
-msgid "Manually"
-msgstr "Ręcznie"
-
-#: pkg/systemd/index.html.h:41
-msgid "Automatically using NTP"
-msgstr "Automatycznie za pomocą NTP"
-
-#: pkg/systemd/index.html.h:42
-msgid "Automatically using specific NTP servers"
-msgstr "Automatycznie za pomocą podanych serwerów NTP"
-
-#: pkg/systemd/index.html.h:43
-msgid "Delay"
-msgstr "Opóźnienie"
-
-#: pkg/systemd/index.html.h:44
-msgid "1 Minute"
-msgstr "1 minuta"
-
-#: pkg/systemd/index.html.h:45
-msgid "5 Minutes"
-msgstr "5 minut"
-
-#: pkg/systemd/index.html.h:46
-msgid "20 Minutes"
-msgstr "20 minut"
-
-#: pkg/systemd/index.html.h:47
-msgid "40 Minutes"
-msgstr "40 minut"
-
-#: pkg/systemd/index.html.h:48
-msgid "60 Minutes"
-msgstr "Godzina"
-
-#: pkg/systemd/index.html.h:49
-msgid "No Delay"
-msgstr "Brak opóźnienia"
-
-#: pkg/systemd/index.html.h:50
-msgid "Specific Time"
-msgstr "Podany czas"
-
-#: pkg/systemd/index.html.h:51
-msgid ""
-"\n"
-"                        Cancel\n"
-"                    "
-msgstr ""
-"\n"
-"                        Anuluj\n"
-"                    "
-
-#: pkg/systemd/logs.html.h:1
-msgid "Journal"
-msgstr "Dziennik"
-
-#: pkg/systemd/logs.html.h:2
-msgid "Recent"
-msgstr "Ostatnie"
-
-#: pkg/systemd/logs.html.h:3
-msgid "Current boot"
-msgstr "Obecne uruchomienie"
-
-#: pkg/systemd/logs.html.h:4
-msgid "Last 24 hours"
-msgstr "Ostatni dzień"
-
-#: pkg/systemd/logs.html.h:5
-msgid "Last 7 days"
-msgstr "Ostatni tydzień"
-
-#: pkg/systemd/logs.html.h:6
-msgid "Errors"
-msgstr "Błędy"
-
-#: pkg/systemd/logs.html.h:7
+#: pkg/systemd/logs.html:48
 msgid "Warnings"
 msgstr "Ostrzeżenia"
 
-#: pkg/systemd/logs.html.h:8
-msgid "Notices"
-msgstr "Uwagi"
-
-#: pkg/systemd/logs.html.h:9
-msgid "All"
-msgstr "Wszystkie"
-
-#: pkg/systemd/logs.html.h:10 pkg/kubernetes/views/container-panel.html.h:2
-#: pkg/kubernetes/views/container-page-inline.html.h:2
-msgid "Logs"
-msgstr "Dzienniki"
-
-#: pkg/systemd/logs.html.h:11
-msgid "Entry"
-msgstr "Wpis"
-
-#: pkg/systemd/services.html.h:1 pkg/kubernetes/views/dashboard-page.html.h:12
-#: pkg/kubernetes/views/details-page.html.h:3
-msgid "Services"
-msgstr "Usługi"
-
-#: pkg/systemd/services.html.h:3
-msgid "System Services"
-msgstr "Usługi systemowe"
-
-#: pkg/systemd/services.html.h:4
-msgid "Sockets"
-msgstr "Gniazda"
-
-#: pkg/systemd/services.html.h:5
-msgid "Timers"
-msgstr "Liczniki"
-
-#: pkg/systemd/services.html.h:6
-msgid "Paths"
-msgstr "Ścieżki"
-
-#: pkg/systemd/services.html.h:7
-msgid "Instantiate"
-msgstr "Wystąpienie"
-
-#: pkg/systemd/services.html.h:8
-msgid "{{days_text}}"
-msgstr ""
-
-#: pkg/systemd/services.html.h:9
-msgid "Service Logs"
-msgstr "Dzienniki serwera"
-
-#: pkg/systemd/services.html.h:10
-msgid "Note"
-msgstr "Uwaga"
-
-#: pkg/systemd/services.html.h:11
-msgid ""
-"This unit is not designed to be enabled explicitly.\n"
-"          "
-msgstr ""
-"Ta jednostka nie została zaprojektowana do bezpośredniego włączania.\n"
-"          "
-
-#: pkg/systemd/services.html.h:15
-#, fuzzy
-msgid "Create Timers"
-msgstr "Utwórz cienki wolumin"
-
-#: pkg/systemd/services.html.h:16
-#, fuzzy
-msgid "Service name"
-msgstr "Usługa"
-
-#: pkg/systemd/services.html.h:18 pkg/docker/index.html.h:32
-msgid "Command"
-msgstr "Polecenie"
-
-#: pkg/systemd/services.html.h:19
-#, fuzzy
-msgid "Run"
-msgstr "Działanie jako"
-
-#: pkg/systemd/services.html.h:20
-#, fuzzy
-msgid "After system boot"
-msgstr "Zarejestruj system"
-
-#: pkg/systemd/services.html.h:21
-#, fuzzy
-msgid "At specific time"
-msgstr "Podany czas"
-
-#: pkg/systemd/services.html.h:22
-msgid "Seconds"
-msgstr ""
-
-#: pkg/systemd/services.html.h:23
-#, fuzzy
-msgid "Minutes"
-msgstr "5 minut"
-
-#: pkg/systemd/services.html.h:24
-#, fuzzy
-msgid "Hours"
-msgstr "6 godzin"
-
-#: pkg/systemd/services.html.h:25
+#: pkg/systemd/services.html:409
 msgid "Weeks"
 msgstr ""
 
-#: pkg/systemd/services.html.h:26
-msgid "Don't Repeat"
-msgstr ""
+#: pkg/kubernetes/views/registry-dashboard-page.html:5
+msgid "Welcome to the Image Registry"
+msgstr "Witamy w rejestrze obrazów"
 
-#: pkg/systemd/services.html.h:27
-msgid "Repeat Hourly"
-msgstr ""
+#: pkg/kubernetes/views/volumes-page.html:61
+msgid "When"
+msgstr "Kiedy"
 
-#: pkg/systemd/services.html.h:28
-msgid "Repeat Daily"
-msgstr ""
+#: pkg/docker/index.html:507
+msgid "With terminal"
+msgstr "Z terminalem"
 
-#: pkg/systemd/services.html.h:29
-msgid "Repeat Weekly"
-msgstr ""
+#: pkg/storaged/index.html:438
+msgctxt "storage"
+msgid "World Wide Name"
+msgstr "Nazwa WWN"
 
-#: pkg/systemd/services.html.h:30
-msgid "Repeat Monthly"
-msgstr ""
+#: pkg/storaged/details.js:1595
+msgid "Write-mostly"
+msgstr "Głównie zapisywane"
 
-#: pkg/systemd/services.html.h:31
-msgid "Repeat Yearly"
-msgstr ""
+#: pkg/storaged/index.html:333
+msgid "Writing"
+msgstr "Zapisywanie"
 
-#: pkg/systemd/services.html.h:32
-#, fuzzy
-msgid "Hour : Minute"
-msgstr "1 minuta"
+#: pkg/ostree/client.js:64
+msgid "Writing objects"
+msgstr "Zapisywanie obiektów"
 
-#: pkg/systemd/services.html.h:33
-msgid ":"
-msgstr ""
+#: pkg/storaged/details.js:177
+msgid "XFS - Red Hat Enterprise Linux 7 default"
+msgstr "XFS — domyślne w systemie Red Hat Enterprise Linux 7"
 
-#: pkg/systemd/services.html.h:35
-msgid "Save"
-msgstr ""
+#: pkg/networkmanager/interfaces.js:1824
+msgid "XOR"
+msgstr "XOR"
 
-#: pkg/systemd/terminal.html.h:1
-msgid "Terminal"
-msgstr "Terminal"
+#: pkg/kubernetes/scripts/volumes.js:990 pkg/networkmanager/interfaces.js:2279
+msgid "Yes"
+msgstr "Tak"
 
-#: pkg/lib/machine-invalid-hostkey.html.h:1
-msgid "Incorrect Host Key"
-msgstr "Niepoprawny klucz komputera"
-
-#: pkg/lib/machine-invalid-hostkey.html.h:2
-msgid ""
-"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
-"in use. Unless this machine was recently replaced, it is likely that someone "
-"is trying to attack your connection to this machine."
-msgstr ""
-"Klucz {{#strong}}{{host}}{{/strong}} nie pasuje do poprzednio używanego "
-"klucza. Jeśli ten komputer nie został niedawno wymieniany, może to oznaczać "
-"próbę ataku na połączenie z tym komputerem."
-
-#: pkg/lib/machine-invalid-hostkey.html.h:3
-msgid ""
-"You can remove the previously stored key by running the following command"
-msgstr ""
-"Można usunąć poprzednio przechowywany klucz wykonując następujące polecenie"
-
-#: pkg/lib/machine-auth-failed.html.h:1
-msgid "Authentication Failed"
-msgstr "Uwierzytelnienie się nie powiodło"
-
-#: pkg/lib/machine-auth-failed.html.h:2
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
-"machine with cockpit you will need to enable one of the following "
-"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
-msgstr ""
-"Cockpit nie może zalogować się do {{#strong}}{{host}}{{/strong}}. Aby używać "
-"tego komputera za pomocą programu Cockpit, należy włączyć jedną z poniższych "
-"metod uwierzytelniania w konfiguracji usługi sshd w {{#strong}}{{host}}{{/"
-"strong}}:"
-
-#: pkg/lib/machine-auth-failed.html.h:4 pkg/shell/index.html.h:30
-msgid "Public Key"
-msgstr "Klucz publiczny"
-
-#: pkg/lib/machine-auth-failed.html.h:5
-msgid "Kerberos Based SSO"
-msgstr "SSO oparte na Kerberos"
-
-#: pkg/lib/machine-auth-failed.html.h:6
-msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
-msgstr ""
-"Cockpit nie może zalogować do {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"Można spróbować {{#sync_link}}synchronizować użytkowników{{/sync_link}}.{{/"
-"can_sync}} Zaktualizowanie cockpit-ws do nowszej wersji udostępni więcej "
-"opcji uwierzytelniania i pomocy w rozwiązywaniu problemów."
-
-#: pkg/lib/machine-sync-users.html.h:1 pkg/dashboard/index.html.h:11
-msgid "Synchronize users"
-msgstr "Zsynchronizuj użytkowników"
-
-#: pkg/lib/machine-sync-users.html.h:2
-msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
-msgstr ""
-"Proszę wybrać użytkowników do synchronizacji z {{#strong}}{{host}}{{/strong}}"
-
-#: pkg/lib/machine-sync-users.html.h:3
-msgid "Error loading users: {{perm_failed}}"
-msgstr "Błąd podczas wczytywania użytkowników: {{perm_failed}}"
-
-#: pkg/lib/machine-sync-users.html.h:4
+#: pkg/lib/machine-sync-users.html:47
 msgid ""
 "You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
 "synchronize users, a user with superuser privileges is required."
@@ -3696,2264 +6235,12 @@ msgstr ""
 "Połączono z {{#strong}}{{host}}{{/strong}}, jednakże do synchronizacji "
 "użytkowników wymagane są uprawnienia superużytkownika."
 
-#: pkg/lib/machine-sync-users.html.h:5 pkg/lib/machine-change-auth.html.h:4
-msgid "User name"
-msgstr "Nazwa użytkownika"
-
-#: pkg/lib/machine-sync-users.html.h:8
-msgid "Synchronize"
-msgstr "Zsynchronizuj"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:1
-msgid "Unknown Host Key"
-msgstr "Nieznany klucz komputera"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:2
+#: pkg/dashboard/list.js:394
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
-msgstr ""
-"Nie można ustalić autentyczności komputera {{#strong}}{{host}}{{/strong}}. "
-"Na pewno kontynuować łączenie?"
+"You are currently connected directly to this server. You cannot delete it."
+msgstr "Obecnie połączono bezpośrednio z tym serwerem. Nie można go usunąć."
 
-#: pkg/lib/machine-unknown-hostkey.html.h:3 pkg/shell/index.html.h:4
-msgid "Fingerprint"
-msgstr "Odcisk"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:5
-#: pkg/kubernetes/views/auth-form.html.h:14
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:6
-msgid "Connect"
-msgstr "Połącz"
-
-#: pkg/lib/machine-add.html.h:1
-msgid "Add Machine to Dashboard"
-msgstr "Dodaj komputer do panelu kontrolnego"
-
-#: pkg/lib/machine-add.html.h:3 pkg/dashboard/index.html.h:9
-msgid "Color"
-msgstr "Kolor"
-
-#: pkg/lib/machine-add.html.h:4
-msgid ""
-"Connecting simultaneously to more than {{ limit }} machines is unsupported."
-msgstr ""
-"Jednoczesne łączenie z więcej niż {{ limit }} komputerami jest "
-"nieobsługiwane."
-
-#: pkg/lib/machine-change-port.html.h:1
-msgid "Could not contact {{host}}"
-msgstr "Nie można skontaktować się z {{host}}"
-
-#: pkg/lib/machine-change-port.html.h:2
-msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
-msgstr "Cockpit nie może skontaktować się z {{#strong}}{{host}}{{/strong}}."
-
-#: pkg/lib/machine-change-port.html.h:3
-msgid ""
-"To try a different port you will need to upgrade cockpit-ws to a newer "
-"version."
-msgstr ""
-"Należy zaktualizować cockpit-ws do nowszej wersji, aby spróbować innego "
-"portu."
-
-#: pkg/lib/machine-change-port.html.h:4
-msgid "Is sshd running on a different port?"
-msgstr "Czy sshd jest uruchomione na innym porcie?"
-
-#: pkg/lib/machine-change-port.html.h:7
-msgid "Update"
-msgstr "Zaktualizuj"
-
-#: pkg/lib/machine-not-supported.html.h:1
-msgid "Cockpit is not installed"
-msgstr "Cockpit nie jest zainstalowany"
-
-#: pkg/lib/machine-not-supported.html.h:2
-msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
-msgstr ""
-"Na {{#strong}}{{host}}{{/strong}} nie zainstalowano zgodnej wersji Cockpit."
-
-#: pkg/lib/machine-change-auth.html.h:1
-msgid "Log in to {{host}}"
-msgstr "Zaloguj do {{host}}"
-
-#: pkg/lib/machine-change-auth.html.h:2
-msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
-msgstr "Cockpit nie może zalogować się do {{#strong}}{{host}}{{/strong}}."
-
-#: pkg/lib/machine-change-auth.html.h:3
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
-msgstr ""
-"Cockpit nie może zalogować się do {{#strong}}{{host}}{{/strong}}. Poniżej "
-"można zmienić dane uwierzytelniające. {{#can_sync}}Można też {{#sync_link}}"
-"synchronizować konta i hasła{{/sync_link}}.{{/can_sync}}"
-
-#: pkg/lib/machine-change-auth.html.h:5 pkg/shell/index.html.h:9
-#: pkg/realmd/operation.html.h:3 pkg/kubernetes/views/auth-form.html.h:8
-msgid "Authentication"
-msgstr "Uwierzytelnienie"
-
-#: pkg/lib/machine-change-auth.html.h:7
-msgid "Available"
-msgstr "Dostępne"
-
-#: pkg/lib/machine-change-auth.html.h:8
-msgid "Login Password"
-msgstr "Hasło logowania"
-
-#: pkg/lib/machine-change-auth.html.h:9
-msgid "Kerberos Ticket"
-msgstr "Zgłoszenie Kerberos"
-
-#: pkg/lib/machine-change-auth.html.h:10
-msgid "Checking for public keys"
-msgstr "Wyszukiwanie kluczy publicznych"
-
-#: pkg/lib/machine-change-auth.html.h:12
-msgid "Log In"
-msgstr "Zaloguj"
-
-#: pkg/shell/shell.html.h:1
-msgid "Things have moved"
-msgstr ""
-
-#: pkg/shell/index.html.h:2
-msgid "Comment"
-msgstr "Komentarz"
-
-#: pkg/shell/index.html.h:5 pkg/shell/stub.html.h:2 pkg/shell/simple.html.h:2
-msgid "Ooops!"
-msgstr "Ups!"
-
-#: pkg/shell/index.html.h:6 pkg/shell/stub.html.h:3 pkg/shell/simple.html.h:3
-msgid "Display Language"
-msgstr "Wyświetl język"
-
-#: pkg/shell/index.html.h:7 pkg/shell/stub.html.h:4 pkg/shell/simple.html.h:4
-msgid "About Cockpit"
-msgstr "O programie Cockpit"
-
-#: pkg/shell/index.html.h:8
-msgid "Account Settings"
-msgstr "Ustawienia konta"
-
-#: pkg/shell/index.html.h:10 pkg/shell/stub.html.h:5 pkg/shell/simple.html.h:5
-msgid "Log out"
-msgstr "Wyloguj"
-
-#: pkg/shell/index.html.h:11 pkg/shell/stub.html.h:6 pkg/shell/simple.html.h:6
-msgid ""
-"\n"
-"              Cockpit is an interactive Linux server admin interface.\n"
-"            "
-msgstr ""
-"\n"
-"              Cockpit to interaktywny interfejs do administrowania serwerami "
-"Linux.\n"
-"            "
-
-#: pkg/shell/index.html.h:15 pkg/shell/stub.html.h:10
-#: pkg/shell/simple.html.h:10
-msgid "Choose the language to be used in the application"
-msgstr "Proszę wybrać język używany w aplikacji"
-
-#: pkg/shell/index.html.h:16 pkg/shell/stub.html.h:11
-#: pkg/shell/simple.html.h:11 pkg/storaged/index.html.h:59
-msgid ""
-"\n"
-"              Cancel\n"
-"            "
-msgstr ""
-"\n"
-"              Anuluj\n"
-"            "
-
-#: pkg/shell/index.html.h:19 pkg/shell/stub.html.h:14
-#: pkg/shell/simple.html.h:14
-msgid ""
-"\n"
-"              Select\n"
-"            "
-msgstr ""
-"\n"
-"              Wybierz\n"
-"            "
-
-#: pkg/shell/index.html.h:22 pkg/shell/stub.html.h:17
-msgid ""
-"\n"
-"              Close\n"
-"            "
-msgstr ""
-"\n"
-"              Zamknij\n"
-"            "
-
-#: pkg/shell/index.html.h:25
-msgid "Use my password for privileged tasks and to connect to other machines"
-msgstr ""
-"Użycie hasła do zadań wymagających uprawnień i łączenia z innymi komputerami"
-
-#: pkg/shell/index.html.h:26
-msgid "Use the following keys to authenticate against other systems"
-msgstr "Użycie poniższych kluczy do uwierzytelniania w innych systemach"
-
-#: pkg/shell/index.html.h:29 pkg/kubernetes/index.html.h:6
-msgid "Details"
-msgstr "Szczegóły"
-
-#: pkg/shell/index.html.h:32
-msgid "Unlock Key"
-msgstr "Odblokuj klucz"
-
-#: pkg/shell/index.html.h:33 pkg/users/index.html.h:23
-msgid "Old Password"
-msgstr "Poprzednie hasło"
-
-#: pkg/shell/index.html.h:34 pkg/users/index.html.h:24
-msgid "New Password"
-msgstr "Nowe hasło"
-
-#: pkg/shell/index.html.h:35 pkg/users/index.html.h:19
-msgid "Confirm"
-msgstr "Potwierdź"
-
-#: pkg/shell/index.html.h:36
-msgid "Change Password"
-msgstr "Zmień hasło"
-
-#: pkg/shell/index.html.h:38 pkg/shell/stub.html.h:20
-msgid ""
-"\n"
-"                Tools\n"
-"              "
-msgstr ""
-"\n"
-"                Narzędzia\n"
-"              "
-
-#: pkg/shell/index.html.h:41 pkg/shell/stub.html.h:23
-#: pkg/shell/simple.html.h:24
-msgid "Reconnect"
-msgstr "Połącz ponownie"
-
-#: pkg/shell/index.html.h:42 pkg/shell/stub.html.h:24
-msgid "Troubleshoot"
-msgstr "Rozwiązywanie problemów"
-
-#: pkg/shell/simple.html.h:18
-msgid ""
-"\n"
-"              Try to reconnect\n"
-"            "
-msgstr ""
-"\n"
-"              Spróbuj połączyć ponownie\n"
-"            "
-
-#: pkg/shell/simple.html.h:21
-msgid ""
-"\n"
-"              Log in again\n"
-"            "
-msgstr ""
-"\n"
-"              Zaloguj ponownie\n"
-"            "
-
-#: pkg/ostree/index.html.h:1
-msgid "Software Updates"
-msgstr "Aktualizacje oprogramowania"
-
-#: pkg/ostree/index.html.h:2
-msgid "Check for updates"
-msgstr "Wyszukaj aktualizacje"
-
-#: pkg/ostree/index.html.h:3
-msgid ""
-"\n"
-"                    Update and reboot\n"
-"                "
-msgstr ""
-"\n"
-"                    Zaktualizuj i uruchom ponownie\n"
-"                "
-
-#: pkg/ostree/index.html.h:6
-msgid "Roll back and reboot"
-msgstr "Przywróć i uruchom ponownie"
-
-#: pkg/ostree/index.html.h:8
-msgid ""
-"\n"
-"                    Default\n"
-"                  "
-msgstr ""
-"\n"
-"                    Domyślne\n"
-"                  "
-
-#: pkg/ostree/index.html.h:11
-msgid ""
-"\n"
-"                    Available\n"
-"                  "
-msgstr ""
-"\n"
-"                    Dostępne\n"
-"                  "
-
-#: pkg/ostree/index.html.h:16
-msgid "Tree"
-msgstr "Drzewo"
-
-#: pkg/ostree/index.html.h:17
-msgid "Packages"
-msgstr "Pakiety"
-
-#: pkg/ostree/index.html.h:20
-msgid "Released"
-msgstr "Wydano"
-
-#: pkg/ostree/index.html.h:21
-msgid "Additions"
-msgstr "Dodane"
-
-#: pkg/ostree/index.html.h:22
-msgid "Removals"
-msgstr "Usunięte"
-
-#: pkg/ostree/index.html.h:23
-msgid "Updates"
-msgstr "Zaktualizowane"
-
-#: pkg/ostree/index.html.h:24
-msgid "Downgrades"
-msgstr "Zainstalowane w starszej wersji"
-
-#: pkg/ostree/index.html.h:25
-msgid ""
-"\n"
-"                    This deployment contains the same packages as your "
-"currently booted system\n"
-"                "
-msgstr ""
-"\n"
-"                    To wdrożenie zawiera takie same pakiety, co obecnie "
-"uruchomiony system\n"
-"                "
-
-#: pkg/ostree/index.html.h:28
-msgid "Operating System Updates"
-msgstr "Aktualizacje systemu operacyjnego"
-
-#: pkg/ostree/index.html.h:29
-msgid "Connecting"
-msgstr "Łączenie"
-
-#: pkg/ostree/index.html.h:30
-msgid "Unable to communicate with OSTree"
-msgstr "Nie można komunikować się OSTree"
-
-#: pkg/ostree/index.html.h:31
-msgid "No Deployments"
-msgstr "Brak wdrożeń"
-
-#: pkg/ostree/index.html.h:32
-msgid ""
-"\n"
-"                    Reconnect\n"
-"                "
-msgstr ""
-"\n"
-"                    Połącz ponownie\n"
-"                "
-
-#: pkg/selinux/setroubleshoot.html.h:1
-msgid "SELinux Troubleshoot"
-msgstr "Rozwiązywanie problemów z SELinuksem"
-
-#: pkg/machines/index.html.h:1
-msgid "Virtual Machines Management"
-msgstr ""
-
-#: pkg/storaged/index.html.h:1
-msgid "Storage"
-msgstr "Urządzenia do przechowywania danych"
-
-#: pkg/storaged/index.html.h:2
-msgid "The \"storaged\" API is not available on this system."
-msgstr "API „storaged” nie jest dostępne w tym systemie."
-
-#: pkg/storaged/index.html.h:3
-msgid "Start Multipath"
-msgstr "Uruchom urządzenie wielościeżkowe"
-
-#: pkg/storaged/index.html.h:4
-msgid ""
-"\n"
-"        There are devices with multiple paths on the system, but the "
-"multipath service is not running.\n"
-"      "
-msgstr ""
-"\n"
-"        W systemie obecne są urządzenia z wieloma ścieżkami, ale usługa "
-"urządzeń wielościeżkowych nie jest uruchomiona.\n"
-"      "
-
-#: pkg/storaged/index.html.h:7
-msgid "RAID Devices"
-msgstr "Urządzenia RAID"
-
-#: pkg/storaged/index.html.h:8
-msgid "No storage set up as RAID"
-msgstr "Nie ustawiono żadnego urządzenia do przechowywania danych jako RAID"
-
-#: pkg/storaged/index.html.h:9
-msgid "Volume Groups"
-msgstr "Grupy woluminów"
-
-#: pkg/storaged/index.html.h:10
-msgid "No volume groups created"
-msgstr "Nie utworzono grup woluminów"
-
-#: pkg/storaged/index.html.h:11
-msgid "iSCSI Targets"
-msgstr "Cele iSCSI"
-
-#: pkg/storaged/index.html.h:12
-msgid "{{Address}}:{{Port}}"
-msgstr "{{Address}}:{{Port}}"
-
-#: pkg/storaged/index.html.h:13
-msgid "No iSCSI targets set up"
-msgstr "Nie ustawiono żadnych celów iSCSI"
-
-#: pkg/storaged/index.html.h:14
-msgid "Drives"
-msgstr "Napędy"
-
-#: pkg/storaged/index.html.h:15
-msgid "No drives attached"
-msgstr "Nie dołączono dysków"
-
-#: pkg/storaged/index.html.h:16
-msgid "Other Devices"
-msgstr "Inne urządzenia"
-
-#: pkg/storaged/index.html.h:17
-msgid "Filesystems"
-msgstr "Systemy plików"
-
-#: pkg/storaged/index.html.h:21
-msgid "Jobs"
-msgstr "Zadania"
-
-#: pkg/storaged/index.html.h:23 pkg/networkmanager/index.html.h:3
-msgid "Go to now"
-msgstr "Przejdź teraz"
-
-#: pkg/storaged/index.html.h:24 pkg/networkmanager/index.html.h:4
-msgid "5 minutes"
-msgstr "5 minut"
-
-#: pkg/storaged/index.html.h:25 pkg/networkmanager/index.html.h:5
-msgid "1 hour"
-msgstr "1 godzina"
-
-#: pkg/storaged/index.html.h:26 pkg/networkmanager/index.html.h:6
-msgid "6 hours"
-msgstr "6 godzin"
-
-#: pkg/storaged/index.html.h:27 pkg/networkmanager/index.html.h:7
-msgid "1 day"
-msgstr "1 dzień"
-
-#: pkg/storaged/index.html.h:28 pkg/networkmanager/index.html.h:8
-msgid "1 week"
-msgstr "1 tydzień"
-
-#: pkg/storaged/index.html.h:29
-msgid "Reading"
-msgstr "Odczytywanie"
-
-#: pkg/storaged/index.html.h:30
-msgid "Writing"
-msgstr "Zapisywanie"
-
-#: pkg/storaged/index.html.h:31
-msgid "Storage Logs"
-msgstr "Dzienniki urządzeń do przechowywania danych"
-
-#: pkg/storaged/index.html.h:32
-msgid "Create partition table"
-msgstr "Utwórz tablicę partycji"
-
-#: pkg/storaged/index.html.h:34
-msgid "Block Device"
-msgstr "Urządzenie blokowe"
-
-#: pkg/storaged/index.html.h:40
-msgid "No media inserted"
-msgstr "Nie włożono żadnego nośnika"
-
-#: pkg/storaged/index.html.h:42
-msgid "DISK IS FAILING"
-msgstr "NA DYSKU WYSTĘPUJĄ BŁĘDY"
-
-#: pkg/storaged/index.html.h:43
-msgid "Disk is OK"
-msgstr "Dysk jest OK"
-
-#: pkg/storaged/index.html.h:46
-msgid "The RAID Array is in a degraded state"
-msgstr "Macierz RAID jest w stanie zdegradowanym"
-
-#: pkg/storaged/index.html.h:47
-msgid "RAID Device"
-msgstr "Urządzenie RAID"
-
-#: pkg/storaged/index.html.h:56
-msgid "Volume Group"
-msgstr "Grupa woluminów"
-
-#: pkg/storaged/index.html.h:57
-msgid "Physical Volumes"
-msgstr "Woluminy fizyczne"
-
-#: pkg/storaged/index.html.h:58
-msgid "Storage Log"
-msgstr "Dziennik urządzeń do przechowywania danych"
-
-#: pkg/realmd/operation.html.h:1
-msgid "Domain Address"
-msgstr "Adres domeny"
-
-#: pkg/realmd/operation.html.h:2
-msgid "Computer OU"
-msgstr "OU komputera"
-
-#: pkg/realmd/operation.html.h:4 pkg/users/index.html.h:11
-msgid "User Name"
-msgstr "Nazwa użytkownika"
-
-#: pkg/realmd/operation.html.h:5
-msgid "User Password"
-msgstr "Hasło użytkownika"
-
-#: pkg/realmd/operation.html.h:6
-msgid "Domain Administrator Name"
-msgstr "Nazwa administratora domeny"
-
-#: pkg/realmd/operation.html.h:7
-msgid "Domain Administrator Password"
-msgstr "Hasło administratora domeny"
-
-#: pkg/realmd/operation.html.h:8
-msgid "One Time Password"
-msgstr "Hasło jednorazowe"
-
-#: pkg/realmd/operation.html.h:9
-msgid "This may take a while"
-msgstr "Może to chwilę zająć"
-
-#: pkg/docker/index.html.h:1 pkg/kubernetes/index.html.h:4
-#: pkg/kubernetes/views/containers-listing.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:6
-#: pkg/kubernetes/views/dashboard-page.html.h:17
-msgid "Containers"
-msgstr "Kontenery"
-
-#: pkg/docker/index.html.h:2
-msgid "Connecting to Docker"
-msgstr "Łączenie z Dockerem"
-
-#: pkg/docker/index.html.h:3
-msgid "Not authorized to access Docker on this system"
-msgstr "Brak upoważnienia do łączenia z Dockerem w tym systemie"
-
-#: pkg/docker/index.html.h:4
-msgid "Docker is not installed or activated on the system"
-msgstr "Docker nie jest zainstalowany lub aktywowany w tym systemie"
-
-#: pkg/docker/index.html.h:5
-msgid "Can&rsquo;t connect to Docker"
-msgstr "Nie można połączyć z Dockerem"
-
-#: pkg/docker/index.html.h:6
-msgid "Start Docker"
-msgstr "Uruchom Dockera"
-
-#: pkg/docker/index.html.h:7
-msgid "Try again"
-msgstr "Spróbuj ponownie"
-
-#: pkg/docker/index.html.h:8
-msgid "Combined CPU usage"
-msgstr "Łączne użycie procesora"
-
-#: pkg/docker/index.html.h:9
-msgid "Combined memory usage"
-msgstr "Łączne użycie pamięci"
-
-#: pkg/docker/index.html.h:10
-#, fuzzy
-msgid "Show all containers"
-msgstr "Wyświetl wszystkie kontenery"
-
-#: pkg/docker/index.html.h:11
-msgid "IP Address:"
-msgstr "Adres IP:"
-
-#: pkg/docker/index.html.h:12
-msgid "IP Prefix Length:"
-msgstr "Długość przedrostka IP:"
-
-#: pkg/docker/index.html.h:13
-msgid "Gateway:"
-msgstr "Brama:"
-
-#: pkg/docker/index.html.h:14
-msgid "MAC Address:"
-msgstr "Adres MAC:"
-
-#: pkg/docker/index.html.h:15 pkg/kubernetes/views/image-page.html.h:1
-msgid "Show all images"
-msgstr "Wyświetl wszystkie obrazy"
-
-#: pkg/docker/index.html.h:16 pkg/kubernetes/index.html.h:2
-#: pkg/kubernetes/registry.html.h:2
-msgid "Overview"
-msgstr "Przegląd"
-
-#: pkg/docker/index.html.h:17
-msgid "Reset"
-msgstr "Przywróć"
-
-#: pkg/docker/index.html.h:18
-msgid "Storage pool"
-msgstr "Pula urządzeń do przechowywania danych"
-
-#: pkg/docker/index.html.h:19
-msgid "Additional Storage"
-msgstr "Dodatkowe urządzenia do przechowywania danych"
-
-#: pkg/docker/index.html.h:20
-msgid "TCP"
-msgstr "TCP"
-
-#: pkg/docker/index.html.h:21
-msgid "{{host_port_label}}"
-msgstr "{{host_port_label}}"
-
-#: pkg/docker/index.html.h:22
-msgid "{{host_volume_label}}"
-msgstr "{{host_volume_label}}"
-
-#: pkg/docker/index.html.h:24
-msgid "ReadWrite"
-msgstr "Odczyt i zapis"
-
-#: pkg/docker/index.html.h:25
-msgid "ReadOnly"
-msgstr "Tylko do odczytu"
-
-#: pkg/docker/index.html.h:26
-msgid "{{envvar_key_label}}"
-msgstr "{{envvar_key_label}}"
-
-#: pkg/docker/index.html.h:27
-msgid "{{envvar_value_label}}"
-msgstr "{{envvar_value_label}}"
-
-#: pkg/docker/index.html.h:28
-msgid "select container"
-msgstr "wybierz kontener"
-
-#: pkg/docker/index.html.h:29
-msgid "{{alias_label}}"
-msgstr "{{alias_label}}"
-
-#: pkg/docker/index.html.h:30 pkg/kubernetes/views/image-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:2
-#: pkg/kubernetes/views/image-page.html.h:2
-msgid "Image"
-msgstr "Obraz"
-
-#: pkg/docker/index.html.h:31
-msgid "Container Name"
-msgstr "Nazwa kontenera"
-
-#: pkg/docker/index.html.h:33
-msgid "Memory limit"
-msgstr "Ograniczenie pamięci"
-
-#: pkg/docker/index.html.h:34
-msgid "MiB"
-msgstr "MiB"
-
-#: pkg/docker/index.html.h:35
-msgid "CPU priority"
-msgstr "Priorytet procesora"
-
-#: pkg/docker/index.html.h:36
-msgid "shares"
-msgstr "udziały"
-
-#: pkg/docker/index.html.h:37
-msgid "With terminal"
-msgstr "Z terminalem"
-
-#: pkg/docker/index.html.h:38
-msgid "Links"
-msgstr "Łącza"
-
-#: pkg/docker/index.html.h:40
-msgid "Expose container ports"
-msgstr "Uwidocznij porty kontenera"
-
-#: pkg/docker/index.html.h:41 pkg/kubernetes/index.html.h:7
-#: pkg/kubernetes/views/image-config.html.h:9
-#: pkg/kubernetes/views/pod-page.html.h:3
-#: pkg/kubernetes/views/dashboard-page.html.h:4
-msgid "Volumes"
-msgstr "Woluminy"
-
-#: pkg/docker/index.html.h:42
-msgid "Mount container volumes"
-msgstr "Zamontuj woluminy kontenera"
-
-#: pkg/docker/index.html.h:43 pkg/kubernetes/views/image-config.html.h:6
-#: pkg/kubernetes/views/container-body.html.h:9
-msgid "Environment"
-msgstr "Środowisko"
-
-#: pkg/docker/index.html.h:44
-msgid "Set container environment variables"
-msgstr "Ustaw zmienne środowiskowe kontenera"
-
-#: pkg/docker/index.html.h:45 pkg/kubernetes/views/pod-body.html.h:4
-msgid "Restart Policy"
-msgstr "Polityka ponownego uruchamiania"
-
-#: pkg/docker/index.html.h:47
-msgid "On Failure"
-msgstr "Podczas niepowodzenia"
-
-#: pkg/docker/index.html.h:50
-msgid "Retries:"
-msgstr "Próby:"
-
-#: pkg/docker/index.html.h:51 pkg/users/index.html.h:26
-#: pkg/networkmanager/index.html.h:52
-msgid ""
-"\n"
-"            Cancel\n"
-"          "
-msgstr ""
-"\n"
-"            Anuluj\n"
-"          "
-
-#: pkg/docker/index.html.h:54
-msgid ""
-"\n"
-"            Run\n"
-"          "
-msgstr ""
-"\n"
-"            Uruchom\n"
-"          "
-
-#: pkg/docker/index.html.h:57
-msgid ""
-"\n"
-"            Download\n"
-"          "
-msgstr ""
-"\n"
-"            Pobierz\n"
-"          "
-
-#: pkg/docker/index.html.h:60
-msgid ""
-"\n"
-"            Change\n"
-"          "
-msgstr ""
-"\n"
-"            Zmień\n"
-"          "
-
-#: pkg/docker/index.html.h:63
-msgid "Repository"
-msgstr "Repozytorium"
-
-#: pkg/docker/index.html.h:64
-msgid "Tag"
-msgstr "Etykieta"
-
-#: pkg/docker/index.html.h:65 pkg/kubernetes/views/image-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:5
-msgid "Author"
-msgstr "Autor"
-
-#: pkg/docker/index.html.h:66
-msgid ""
-"\n"
-"            Commit\n"
-"          "
-msgstr ""
-"\n"
-"            Zatwierdzenie\n"
-"          "
-
-#: pkg/users/index.html.h:1
-msgid "Local Accounts"
-msgstr "Lokalne konta"
-
-#: pkg/users/index.html.h:2
-msgid ""
-"\n"
-"            Close\n"
-"          "
-msgstr ""
-"\n"
-"            Zamknij\n"
-"          "
-
-#: pkg/users/index.html.h:5
-msgid "Create New Account"
-msgstr "Utwórz nowe konto"
-
-#: pkg/users/index.html.h:6
-msgid "Account not available or cannot be edited."
-msgstr "Konto jest niedostępne lub nie może być modyfikowane."
-
-#: pkg/users/index.html.h:7
-msgid "Accounts"
-msgstr "Konta"
-
-#: pkg/users/index.html.h:8
-msgid "Terminate Session"
-msgstr "Zakończ sesję"
-
-#: pkg/users/index.html.h:10
-msgid "Full Name"
-msgstr "Imię i nazwisko"
-
-#: pkg/users/index.html.h:12
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:3
-#: pkg/kubernetes/views/project-body.html.h:2
-msgid "Roles"
-msgstr "Role"
-
-#: pkg/users/index.html.h:13
-msgid "Last Login"
-msgstr "Ostatnie logowanie"
-
-#: pkg/users/index.html.h:14
-msgid "Access"
-msgstr "Dostęp"
-
-#: pkg/users/index.html.h:15
-msgid "Lock Account"
-msgstr "Zablokuj konto"
-
-#: pkg/users/index.html.h:17
-msgid "Set Password"
-msgstr "Ustaw hasło"
-
-#: pkg/users/index.html.h:18
-msgid "Authorized Public SSH Keys"
-msgstr "Upoważnione publiczne klucze SSH"
-
-#: pkg/users/index.html.h:20
-msgid ""
-"\n"
-"            Create\n"
-"          "
-msgstr ""
-"\n"
-"            Utwórz\n"
-"          "
-
-#: pkg/users/index.html.h:25
-msgid "Confirm New Password"
-msgstr "Potwierdź nowe hasło"
-
-#: pkg/users/index.html.h:29
-msgid ""
-"\n"
-"            Set\n"
-"          "
-msgstr ""
-"\n"
-"            Ustaw\n"
-"          "
-
-#: pkg/users/index.html.h:32
-msgid "Delete Files"
-msgstr "Usuń pliki"
-
-#: pkg/users/index.html.h:33 pkg/networkmanager/index.html.h:48
-msgid ""
-"\n"
-"            Delete\n"
-"          "
-msgstr ""
-"\n"
-"            Usuń\n"
-"          "
-
-#: pkg/users/index.html.h:36
-msgid "Unnamed"
-msgstr "Bez nazwy"
-
-#: pkg/users/index.html.h:37
-msgid "Invalid key"
-msgstr "Nieprawidłowy klucz"
-
-#: pkg/users/index.html.h:38
-msgid "There are no authorized public keys for this account."
-msgstr "Brak upoważnionych publicznych kluczy dla tego konta."
-
-#: pkg/users/index.html.h:39
-msgid ""
-"You do not have permission to view the authorized public keys for this "
-"account."
-msgstr ""
-"Brak uprawnienia do wyświetlania upoważnionych publicznych kluczy dla tego "
-"konta."
-
-#: pkg/users/index.html.h:40
-msgid "Failed to load authorized keys."
-msgstr "Wczytanie upoważnionych kluczy się nie powiodło."
-
-#: pkg/users/index.html.h:41
-msgid "Add public key"
-msgstr "Dodaj klucz publiczny"
-
-#: pkg/users/index.html.h:42
-msgid ""
-"\n"
-"            Add key\n"
-"          "
-msgstr ""
-"\n"
-"            Dodaj klucz\n"
-"          "
-
-#: pkg/sosreport/index.html.h:1
-msgid "Diagnostic reports"
-msgstr "Raporty diagnostyczne"
-
-#: pkg/sosreport/index.html.h:2
-msgid ""
-"\n"
-"        This tool will collect system configuration and diagnostic\n"
-"        information from this system for use with diagnosing problems\n"
-"        with the system.\n"
-"      "
-msgstr ""
-"\n"
-"        To narzędzie zbierze konfigurację systemu i informacje\n"
-"        diagnostyczne z tego systemu do użycia w diagnozowaniu problemów\n"
-"        z systemem.\n"
-"      "
-
-#: pkg/sosreport/index.html.h:7
-msgid ""
-"\n"
-"        The collected information will be stored locally on the system.\n"
-"      "
-msgstr ""
-"\n"
-"        Zebrane informacje będą przechowywane lokalnie w systemie.\n"
-"      "
-
-#: pkg/sosreport/index.html.h:10
-msgid "Create report"
-msgstr "Utwórz raport"
-
-#: pkg/sosreport/index.html.h:11
-msgid "Create diagnostic report"
-msgstr "Utwórz raport diagnostyczny"
-
-#: pkg/sosreport/index.html.h:12
-msgid ""
-"\n"
-"                The generated archive contains data considered\n"
-"                sensitive and its content should be reviewed by the\n"
-"                originating organization before being passed to any\n"
-"                third party.\n"
-"              "
-msgstr ""
-"\n"
-"                Utworzone archiwum zawiera dane uważane za\n"
-"                prywatne, więc jego zawartość powinna zostać przejrzana\n"
-"                przez pierwotną organizację, zanim zostanie ono przekazane\n"
-"                jakiejkolwiek stronie trzeciej.\n"
-"              "
-
-#: pkg/sosreport/index.html.h:18
-msgid "Generating report"
-msgstr "Tworzenie raportu"
-
-#: pkg/sosreport/index.html.h:19
-msgid "Done!"
-msgstr "Gotowe."
-
-#: pkg/networkmanager/index.html.h:1
-msgid "Networking"
-msgstr "Sieć"
-
-#: pkg/networkmanager/index.html.h:2
-msgid "Testing connection"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:9
-msgid "Sending"
-msgstr "Wysyłanie"
-
-#: pkg/networkmanager/index.html.h:10
-msgid "Receiving"
-msgstr "Odbieranie"
-
-#: pkg/networkmanager/index.html.h:11
-msgid "Interfaces"
-msgstr "Interfejsy"
-
-#: pkg/networkmanager/index.html.h:12
-msgid "Add Bond"
-msgstr "Dodaj węzeł"
-
-#: pkg/networkmanager/index.html.h:13
-#, fuzzy
-msgid "Add Team"
-msgstr "Dodaj element"
-
-#: pkg/networkmanager/index.html.h:14
-msgid "Add Bridge"
-msgstr "Dodaj mostek"
-
-#: pkg/networkmanager/index.html.h:15
-msgid "Add VLAN"
-msgstr "Dodaj VLAN"
-
-#: pkg/networkmanager/index.html.h:17
-msgid "IP Address"
-msgstr "Adres IP"
-
-#: pkg/networkmanager/index.html.h:18
-#, fuzzy
-msgid "Unmanaged Interfaces"
-msgstr "Interfejsy"
-
-#: pkg/networkmanager/index.html.h:19
-msgid "Networking Logs"
-msgstr "Dzienniki sieci"
-
-#: pkg/networkmanager/index.html.h:20
-msgid "Parent"
-msgstr "Nadrzędne"
-
-#: pkg/networkmanager/index.html.h:21
-msgid "VLAN Id"
-msgstr "Identyfikator VLAN"
-
-#: pkg/networkmanager/index.html.h:23
-msgid "Set to"
-msgstr "Ustaw na"
-
-#: pkg/networkmanager/index.html.h:25
-msgid "Spanning Tree Protocol (STP)"
-msgstr "Protokół STP"
-
-#: pkg/networkmanager/index.html.h:26
-msgid "STP Priority"
-msgstr "Priorytet STP"
-
-#: pkg/networkmanager/index.html.h:27
-msgid "STP Forward delay"
-msgstr "Opóźnienie w przód STP"
-
-#: pkg/networkmanager/index.html.h:28
-msgid "STP Hello time"
-msgstr "Czas powitania STP"
-
-#: pkg/networkmanager/index.html.h:29
-msgid "STP Maximum message age"
-msgstr "Maksymalny wiek komunikatu STP"
-
-#: pkg/networkmanager/index.html.h:30
-msgid "Priority"
-msgstr "Priorytet"
-
-#: pkg/networkmanager/index.html.h:31
-msgid "Path cost"
-msgstr "Koszt ścieżki"
-
-#: pkg/networkmanager/index.html.h:32
-msgid "Hair Pin mode"
-msgstr "Tryb Hairpin"
-
-#: pkg/networkmanager/index.html.h:34
-msgid "Mode"
-msgstr "Tryb"
-
-#: pkg/networkmanager/index.html.h:35
-msgid "Primary"
-msgstr "Główne"
-
-#: pkg/networkmanager/index.html.h:36
-msgid "Link Monitoring"
-msgstr "Monitorowanie łącza"
-
-#: pkg/networkmanager/index.html.h:37
-msgid "Monitoring Interval"
-msgstr "Odstęp monitorowania"
-
-#: pkg/networkmanager/index.html.h:38
-msgid "Monitoring Targets"
-msgstr "Cele monitorowania"
-
-#: pkg/networkmanager/index.html.h:39
-msgid "Link up delay"
-msgstr "Opóźnienie łącza w górę"
-
-#: pkg/networkmanager/index.html.h:40
-msgid "Link down delay"
-msgstr "Opóźnienie łącza w dół"
-
-#: pkg/networkmanager/index.html.h:41
-#, fuzzy
-msgid "Runner"
-msgstr "Działające"
-
-#: pkg/networkmanager/index.html.h:42
-msgid "Balancer"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:43
-#, fuzzy
-msgid "Link Watch"
-msgstr "Link-local"
-
-#: pkg/networkmanager/index.html.h:44
-#, fuzzy
-msgid "Ping Interval"
-msgstr "Odstęp monitorowania"
-
-#: pkg/networkmanager/index.html.h:45
-#, fuzzy
-msgid "Ping Target"
-msgstr "Cel"
-
-#: pkg/networkmanager/index.html.h:46
-msgid "Sticky"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:47
-msgid "LACP Key"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:51
-msgid "IP Settings"
-msgstr "Ustawienia IP"
-
-#: pkg/networkmanager/index.html.h:55
-msgid ""
-"\n"
-"            Apply\n"
-"          "
-msgstr ""
-"\n"
-"            Zastosuj\n"
-"          "
-
-#: pkg/networkmanager/index.html.h:58
-msgid "Bond Settings"
-msgstr "Ustawienia węzła"
-
-#: pkg/networkmanager/index.html.h:59
-#, fuzzy
-msgid "Team Settings"
-msgstr "Ustawienia IP"
-
-#: pkg/networkmanager/index.html.h:60
-#, fuzzy
-msgid "Team Port Settings"
-msgstr "Ustawienia portu mostku"
-
-#: pkg/networkmanager/index.html.h:61
-msgid "Bridge Settings"
-msgstr "Ustawienia mostka"
-
-#: pkg/networkmanager/index.html.h:62
-msgid "Bridge Port Settings"
-msgstr "Ustawienia portu mostku"
-
-#: pkg/networkmanager/index.html.h:63
-msgid "VLAN Settings"
-msgstr "Ustawienia VLAN"
-
-#: pkg/networkmanager/index.html.h:64
-msgid "Ethernet MTU"
-msgstr "MTU ethernetu"
-
-#: pkg/networkmanager/index.html.h:66
-#, fuzzy
-msgid "Connection will be lost"
-msgstr "Połączenie przekroczyło czas oczekiwania."
-
-#: pkg/kubernetes/index.html.h:1
-msgid "Kubernetes Cluster"
-msgstr "Klaster Kubernetes"
-
-#: pkg/kubernetes/index.html.h:3 pkg/kubernetes/views/dashboard-page.html.h:8
-#: pkg/kubernetes/views/nodes-page.html.h:4
-msgid "Nodes"
-msgstr "Węzły"
-
-#: pkg/kubernetes/index.html.h:5
-msgid "Topology"
-msgstr "Topologia"
-
-#: pkg/kubernetes/index.html.h:8 pkg/kubernetes/registry.html.h:3
-#: pkg/kubernetes/views/image-listing.html.h:2
-#: pkg/kubernetes/views/imagestream-page.html.h:3
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:5
-msgid "Images"
-msgstr "Obrazy"
-
-#: pkg/kubernetes/index.html.h:9 pkg/kubernetes/registry.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:2
-#: pkg/kubernetes/views/project-listing.html.h:2
-#: pkg/kubernetes/views/user-delete.html.h:2
-msgid "Projects"
-msgstr "Projekty"
-
-#: pkg/kubernetes/index.html.h:11 pkg/kubernetes/registry.html.h:6
-msgid "Couldn't connect to server"
-msgstr "Nie można połączyć z serwerem"
-
-#: pkg/kubernetes/index.html.h:12 pkg/kubernetes/registry.html.h:7
-msgid ""
-"\n"
-"                Reconnect\n"
-"            "
-msgstr ""
-"\n"
-"                Połącz ponownie\n"
-"            "
-
-#: pkg/kubernetes/index.html.h:15
-msgid ""
-"\n"
-"                Troubleshoot\n"
-"            "
-msgstr ""
-"\n"
-"                Rozwiąż problem\n"
-"            "
-
-#: pkg/kubernetes/registry.html.h:1
-msgid "Image Registry"
-msgstr "Rejestr obrazów"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:1
-#: pkg/kubernetes/views/service-body.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:1
-#: pkg/kubernetes/views/containers-listing.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:9
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:18
-#: pkg/kubernetes/views/route-body.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:5
-#: pkg/kubernetes/views/imagestream-modify.html.h:4
-msgid "Project"
-msgstr "Projekt"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:2
-#: pkg/kubernetes/views/service-body.html.h:2
-#: pkg/kubernetes/views/pod-body.html.h:2
-#: pkg/kubernetes/views/containers-listing.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:10
-#: pkg/kubernetes/views/pv-claim.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:19
-#: pkg/kubernetes/views/route-body.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:6
-msgid "Namespace"
-msgstr "Przestrzeń nazw"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:3
-#: pkg/kubernetes/views/pod-body.html.h:3
-#: pkg/kubernetes/views/node-body.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:3
-#: pkg/kubernetes/views/route-body.html.h:3
-msgid "Created"
-msgstr "Utworzono"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:4
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:17
-msgid "Replicas"
-msgstr "Repliki"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:5
-#: pkg/kubernetes/views/service-body.html.h:9
-#: pkg/kubernetes/views/pod-body.html.h:10
-#: pkg/kubernetes/views/node-body.html.h:12
-#: pkg/kubernetes/views/image-meta.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:8
-#: pkg/kubernetes/views/route-body.html.h:8
-msgid "Labels"
-msgstr "Etykiety"
-
-#: pkg/kubernetes/views/service-body.html.h:4
-#: pkg/kubernetes/views/node-body.html.h:3
-msgid "IP"
-msgstr "IP"
-
-#: pkg/kubernetes/views/service-body.html.h:8
-msgid "Session Affinity"
-msgstr "Pokrewieństwo procesora"
-
-#: pkg/kubernetes/views/image-listing.html.h:1
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:10
-msgid "New image stream"
-msgstr "Nowy potok obrazu"
-
-#: pkg/kubernetes/views/image-listing.html.h:3
-#: pkg/kubernetes/views/image-body.html.h:10
-#: pkg/kubernetes/views/imagestream-modify.html.h:7
-msgid "Tags"
-msgstr "Etykiety"
-
-#: pkg/kubernetes/views/image-listing.html.h:5
-msgid "Last Updated"
-msgstr "Ostatnio zaktualizowano"
-
-#: pkg/kubernetes/views/image-listing.html.h:6
-msgid "No image streams are present."
-msgstr "Żadne potoki obrazów nie są obecne."
-
-#: pkg/kubernetes/views/node-delete.html.h:1
-msgid "Delete Node"
-msgstr "Usuń węzeł"
-
-#: pkg/kubernetes/views/node-delete.html.h:2
-msgid "Do you want to delete this Node?"
-msgstr "Usunąć ten węzeł?"
-
-#: pkg/kubernetes/views/node-delete.html.h:3
-msgid " 1\">Do you want to delete the following Nodes?"
-msgstr " 1\">Usunąć poniższe węzły?"
-
-#: pkg/kubernetes/views/pod-container.html.h:1
-msgid "Show all Pod Containers"
-msgstr "Wyświetl wszystkie kontenery pojemników"
-
-#: pkg/kubernetes/views/image-panel.html.h:3
-#: pkg/kubernetes/views/imagestream-page.html.h:4
-#: pkg/kubernetes/views/image-page.html.h:4
-msgid "Metadata"
-msgstr "Metadane"
-
-#: pkg/kubernetes/views/node-panel.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:8
-#: pkg/kubernetes/views/containers-listing.html.h:6
-#: pkg/kubernetes/views/node-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:11
-msgid "Node"
-msgstr "Węzeł"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:1
-msgid "Show all Replication Controllers"
-msgstr "Wyświetl wszystkie kontrolery replikacji"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:2
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:5
-msgid "Replication Controller"
-msgstr "Kontroler replikacji"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:2
-#: pkg/kubernetes/views/pv-claim.html.h:9
-#: pkg/kubernetes/views/dashboard-page.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:18
-msgid "Pods"
-msgstr "Pojemniki"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:2
-msgid "Template"
-msgstr "Szablon"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:5
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr "Kontroler replikacji „{{ target }}” nie istnieje."
-
-#: pkg/kubernetes/views/group-delete.html.h:1
-msgid "Remove Group"
-msgstr "Usuń grupę"
-
-#: pkg/kubernetes/views/group-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:5
-#: pkg/kubernetes/views/user-group-remove.html.h:3
-msgid "Remove"
-msgstr "Usuń"
-
-#: pkg/kubernetes/views/pvc-delete.html.h:1
-msgid "Delete Persistent Volume Claim"
-msgstr "Usuń deklarację trwałego woluminu"
-
-#: pkg/kubernetes/views/pvc-delete.html.h:2
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr "Usunąć deklarację trwałego woluminu „{{item.metadata.name}}”?"
-
-#: pkg/kubernetes/views/pvc-delete.html.h:3
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-"Ta deklaracja jest używana. Usunięcie może spowodować problemy z poniższym "
-"pojemnikiem:"
-
-#: pkg/kubernetes/views/pod-body.html.h:5
-msgid "Service Account"
-msgstr "Konto usługi"
-
-#: pkg/kubernetes/views/pod-body.html.h:6
-msgid "DNS Policy"
-msgstr "Polityka DNS"
-
-#: pkg/kubernetes/views/pod-body.html.h:7
-msgid "Phase"
-msgstr "Faza"
-
-#: pkg/kubernetes/views/pod-body.html.h:9
-msgid "Pod Address"
-msgstr "Adres pojemnika"
-
-#: pkg/kubernetes/views/node-body.html.h:5
-msgid "OS"
-msgstr "System operacyjny"
-
-#: pkg/kubernetes/views/node-body.html.h:7
-msgid "Boot ID"
-msgstr "Identyfikator uruchomienia"
-
-#: pkg/kubernetes/views/node-body.html.h:8
-msgid "Kernel Version"
-msgstr "Wersja jądra"
-
-#: pkg/kubernetes/views/node-body.html.h:9
-msgid "Container Runtime Version"
-msgstr "Wersja środowiska wykonawczego kontenera"
-
-#: pkg/kubernetes/views/node-body.html.h:10
-msgid "Kubelet Version"
-msgstr "Wersja Kubelet"
-
-#: pkg/kubernetes/views/node-body.html.h:11
-msgid "Proxy Version"
-msgstr "Wersja pośrednika"
-
-#: pkg/kubernetes/views/node-body.html.h:13
-#: pkg/kubernetes/views/route-body.html.h:9
-msgid "none"
-msgstr "brak"
-
-#: pkg/kubernetes/views/node-body.html.h:17
-msgid "Reason"
-msgstr "Przyczyna"
-
-#: pkg/kubernetes/views/node-body.html.h:18
-#: pkg/kubernetes/views/pv-claim.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:6 pkg/kubernetes/views/pv-body.html.h:6
-msgid "Message"
-msgstr "Komunikat"
-
-#: pkg/kubernetes/views/node-body.html.h:19
-msgid "Last Heartbeat"
-msgstr "Ostatnie bicie serca"
-
-#: pkg/kubernetes/views/node-body.html.h:20
-msgid "Last Status Change"
-msgstr "Ostatnia zmiana stanu"
-
-#: pkg/kubernetes/views/node-body.html.h:21
-#: pkg/kubernetes/views/image-meta.html.h:3
-#: pkg/kubernetes/views/imagestream-meta.html.h:1
-#: pkg/kubernetes/views/route-body.html.h:10
-msgid "Annotations"
-msgstr "Adnotacje"
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:1
-msgid "Remove Role"
-msgstr "Usuń rolę"
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:2
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member "
-"{{ fields.member.metadata.name }}?"
-msgstr ""
-"Usunąć rolę „{{ fields.displayRole }}” z elementu {{ fields.member.metadata."
-"name }}?"
-
-#: pkg/kubernetes/views/project-listing.html.h:1
-msgid "New Project"
-msgstr "Nowy projekt"
-
-#: pkg/kubernetes/views/project-listing.html.h:6
-msgid "No projects are present."
-msgstr "Brak projektów."
-
-#: pkg/kubernetes/views/project-listing.html.h:7
-msgid "New Group"
-msgstr "Nowa grupa"
-
-#: pkg/kubernetes/views/project-listing.html.h:8
-#: pkg/kubernetes/views/user-delete.html.h:3
-msgid "Groups"
-msgstr "Grupy"
-
-#: pkg/kubernetes/views/project-listing.html.h:9
-msgid "No groups are present."
-msgstr "Brak grup."
-
-#: pkg/kubernetes/views/project-listing.html.h:10
-#: pkg/kubernetes/views/add-user-dialog.html.h:1
-msgid "Add User"
-msgstr "Dodaj użytkownika"
-
-#: pkg/kubernetes/views/project-listing.html.h:11
-msgid "Users"
-msgstr "Użytkownicy"
-
-#: pkg/kubernetes/views/project-listing.html.h:12
-msgid "Identity"
-msgstr "Tożsamość"
-
-#: pkg/kubernetes/views/project-listing.html.h:13
-msgid "Member of"
-msgstr "Element"
-
-#: pkg/kubernetes/views/project-listing.html.h:14
-msgid "No users are present."
-msgstr "Brak użytkowników."
-
-#: pkg/kubernetes/views/auth-form.html.h:1
-msgid "Cluster"
-msgstr "Klaster"
-
-#: pkg/kubernetes/views/auth-form.html.h:2
-msgid "Add New Cluster"
-msgstr "Dodaj nowy klaster"
-
-#: pkg/kubernetes/views/auth-form.html.h:4
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:3
-msgid "Skip Certificate Verification"
-msgstr "Pomiń sprawdzanie poprawności certyfikatu"
-
-#: pkg/kubernetes/views/auth-form.html.h:5
-msgid "Requires Authentication"
-msgstr "Wymaga uwierzytelnienia"
-
-#: pkg/kubernetes/views/auth-form.html.h:7
-msgid "Add New User"
-msgstr "Dodaj nowego użytkownika"
-
-#: pkg/kubernetes/views/auth-form.html.h:9
-msgid "Client Certificate"
-msgstr "Certyfikat klienta"
-
-#: pkg/kubernetes/views/auth-form.html.h:10
-msgid "Username"
-msgstr "Nazwa użytkownika"
-
-#: pkg/kubernetes/views/auth-form.html.h:12
-msgid "Token"
-msgstr "Token"
-
-#: pkg/kubernetes/views/node-add.html.h:1
-msgid "Add Cluster Node"
-msgstr "Dodaj węzeł klastra"
-
-#: pkg/kubernetes/views/node-add.html.h:4
-msgid "Configuration"
-msgstr "Konfiguracja"
-
-#: pkg/kubernetes/views/node-add.html.h:5
-msgid "Configure Kubelet and Proxy"
-msgstr "Skonfiguruj Kubernetes i pośrednika"
-
-#: pkg/kubernetes/views/node-add.html.h:6
-msgid "Configure Flannel networking"
-msgstr "Skonfiguruj sieć Flannel"
-
-#: pkg/kubernetes/views/volume-body.html.h:1
-#: pkg/kubernetes/views/pvc-body.html.h:1
-msgid "Volume Type"
-msgstr "Typ woluminu"
-
-#: pkg/kubernetes/views/volume-body.html.h:2
-msgid "{{ volume | formatVolumeType }}"
-msgstr "{{ volume | formatVolumeType }}"
-
-#: pkg/kubernetes/views/volume-body.html.h:3
-msgid "PD Name"
-msgstr "Nazwa PD"
-
-#: pkg/kubernetes/views/volume-body.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:19
-msgid "Filesystem Type"
-msgstr "Typ systemu plików"
-
-#: pkg/kubernetes/views/volume-body.html.h:6
-#: pkg/kubernetes/views/pv-modify.html.h:20
-msgid "Read Only"
-msgstr "Tylko do odczytu"
-
-#: pkg/kubernetes/views/volume-body.html.h:7
-msgid "Volume ID"
-msgstr "Identyfikator woluminu"
-
-#: pkg/kubernetes/views/volume-body.html.h:8
-msgid "Repository URL"
-msgstr "Adres URL repozytorium"
-
-#: pkg/kubernetes/views/volume-body.html.h:9
-msgid "Revision"
-msgstr "Wersja"
-
-#: pkg/kubernetes/views/volume-body.html.h:10
-#: pkg/kubernetes/views/image-config.html.h:3
-msgid "Directory"
-msgstr "Katalog"
-
-#: pkg/kubernetes/views/volume-body.html.h:12
-msgid "Medium"
-msgstr "Nośnik"
-
-#: pkg/kubernetes/views/volume-body.html.h:13
-#: pkg/kubernetes/views/pv-modify.html.h:14
-msgid "Path"
-msgstr "Ścieżka"
-
-#: pkg/kubernetes/views/volume-body.html.h:14
-msgid "Endpoint Name"
-msgstr "Nazwa punktu końcowego"
-
-#: pkg/kubernetes/views/volume-body.html.h:15
-#: pkg/kubernetes/views/pv-modify.html.h:13
-msgid "Volume Name"
-msgstr "Nazwa woluminu"
-
-#: pkg/kubernetes/views/volume-body.html.h:17
-msgid "Monitors"
-msgstr "Monitory"
-
-#: pkg/kubernetes/views/volume-body.html.h:18
-msgid "Image Name"
-msgstr "Nazwa obrazu"
-
-#: pkg/kubernetes/views/volume-body.html.h:19
-msgid "Pool Name"
-msgstr "Nazwa puli"
-
-#: pkg/kubernetes/views/volume-body.html.h:21
-msgid "Key Ring Path"
-msgstr "Ścieżka do bazy kluczy"
-
-#: pkg/kubernetes/views/volume-body.html.h:22
-msgid "Secret Volume"
-msgstr "Tajny wolumin"
-
-#: pkg/kubernetes/views/volume-body.html.h:23
-msgid "Target Portal"
-msgstr "Portal docelowy"
-
-#: pkg/kubernetes/views/volume-body.html.h:24
-#: pkg/kubernetes/views/pv-modify.html.h:16
-msgid "Qualified Name"
-msgstr "Nazwa kwalifikowana"
-
-#: pkg/kubernetes/views/volume-body.html.h:25
-#: pkg/kubernetes/views/pv-modify.html.h:17
-msgid "Logical Unit Number"
-msgstr "Numer jednostki logicznej"
-
-#: pkg/kubernetes/views/volume-body.html.h:26
-#: pkg/kubernetes/views/pv-modify.html.h:18
-msgid "Interface"
-msgstr "Interfejs"
-
-#: pkg/kubernetes/views/volume-body.html.h:27
-msgid "Ceph Monitors"
-msgstr "Monitory Ceph"
-
-#: pkg/kubernetes/views/volume-body.html.h:28
-msgid "Secret File"
-msgstr "Tajny plik"
-
-#: pkg/kubernetes/views/volume-body.html.h:29
-msgid "Target World Wide Names"
-msgstr "Docelowe WWN"
-
-#: pkg/kubernetes/views/volume-body.html.h:30
-msgid "Flocker Dataset Name"
-msgstr "Nazwa zestawu danych Flocker"
-
-#: pkg/kubernetes/views/volume-body.html.h:31
-msgid "Driver"
-msgstr "Sterownik"
-
-#: pkg/kubernetes/views/volume-body.html.h:33
-msgid "Share Name"
-msgstr "Współdzielona nazwa"
-
-#: pkg/kubernetes/views/volume-body.html.h:34
-msgid "Secret Name"
-msgstr "Tajna nazwa"
-
-#: pkg/kubernetes/views/image-meta.html.h:2
-msgid "On Build"
-msgstr "Podczas budowania"
-
-#: pkg/kubernetes/views/image-meta.html.h:4
-msgid "Docker Version"
-msgstr "Wersja Dockera"
-
-#: pkg/kubernetes/views/image-meta.html.h:5
-msgid "Image Layers"
-msgstr "Warstwy obrazu"
-
-#: pkg/kubernetes/views/group-page.html.h:1
-#: pkg/kubernetes/views/user-page.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:1
-msgid "Show all Projects"
-msgstr "Wyświetl wszystkie projekty"
-
-#: pkg/kubernetes/views/group-page.html.h:2
-#: pkg/kubernetes/views/group-panel.html.h:1
-msgid "Group Members"
-msgstr "Elementy grupy"
-
-#: pkg/kubernetes/views/group-page.html.h:3
-#: pkg/kubernetes/views/user-group-add.html.h:1
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:1
-#: pkg/kubernetes/views/group-panel.html.h:2
-#: pkg/kubernetes/views/project-body.html.h:10
-msgid "Add Member"
-msgstr "Dodaj element"
-
-#: pkg/kubernetes/views/group-page.html.h:4
-msgid "The group '{{ groupName }}' does not exist."
-msgstr "Grupa „{{ groupName }}” nie istnieje."
-
-#: pkg/kubernetes/views/containers-listing.html.h:3
-#: pkg/kubernetes/views/pod-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:2
-msgid "Pod"
-msgstr "Pojemnik"
-
-#: pkg/kubernetes/views/user-body.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:2
-msgid "Membership"
-msgstr "Członkostwo"
-
-#: pkg/kubernetes/views/user-body.html.h:2
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
-msgstr ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
-
-#: pkg/kubernetes/views/user-body.html.h:5
-#: pkg/kubernetes/views/user-panel.html.h:7
-msgid "Add Membership"
-msgstr "Dodaj członkostwo"
-
-#: pkg/kubernetes/views/user-group-add.html.h:2
-msgid ""
-"\n"
-"                        User\n"
-"                    "
-msgstr ""
-"\n"
-"                        Użytkownik\n"
-"                    "
-
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:2
-msgid "User or Group"
-msgstr "Użytkownik lub grupa"
-
-#: pkg/kubernetes/views/pod-panel.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:4
-msgid "Mount Location"
-msgstr "Położenie punktu montowania"
-
-#: pkg/kubernetes/views/route-modify.html.h:1
-msgid "Adjust Route"
-msgstr "Dostosuj trasę"
-
-#: pkg/kubernetes/views/pv-page.html.h:1
-msgid "Show all Persistent Volumes"
-msgstr "Wyświetl wszystkie trwałe woluminy"
-
-#: pkg/kubernetes/views/pv-page.html.h:2 pkg/kubernetes/views/pvc-body.html.h:3
-#: pkg/kubernetes/views/pv-panel.html.h:1
-msgid "Volume"
-msgstr "Wolumin"
-
-#: pkg/kubernetes/views/pv-page.html.h:3 pkg/kubernetes/views/pv-panel.html.h:2
-msgid "Claim"
-msgstr "Zadeklaruj"
-
-#: pkg/kubernetes/views/pv-page.html.h:4
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr "Trwały wolumin „{{ target }}” nie istnieje."
-
-#: pkg/kubernetes/views/image-delete.html.h:1
-msgid "Remove image tag"
-msgstr "Usuń etykietę obrazu"
-
-#: pkg/kubernetes/views/image-delete.html.h:2
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-"Usunąć obraz z etykietą „{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}:{{tag.tag}}”?"
-
-#: pkg/kubernetes/views/image-config.html.h:1
-msgid "Run as"
-msgstr "Działanie jako"
-
-#: pkg/kubernetes/views/image-config.html.h:4
-msgid "Stop with"
-msgstr "Zatrzymanie za pomocą"
-
-#: pkg/kubernetes/views/pv-delete.html.h:1
-msgid "Delete Persistent Volume"
-msgstr "Usuń trwały wolumin"
-
-#: pkg/kubernetes/views/pv-delete.html.h:2
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr "Usunąć trwały wolumin „{{item.metadata.name}}”?"
-
-#: pkg/kubernetes/views/pv-delete.html.h:3
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
-"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
-"may cause issues with any pods depending on it."
-msgstr ""
-"Ten wolumin został zadeklarowany przez {{ item.item.spec.claimRef."
-"namespace }}/{{ item.item.spec.claimRef.name }}. Usunięcie uszkodzi tę "
-"deklarację i może spowodować problemy z pojemnikami od niej zależnymi."
-
-#: pkg/kubernetes/views/user-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:3
-msgid "Identities"
-msgstr "Tożsamości"
-
-#: pkg/kubernetes/views/user-page.html.h:3
-msgid "The user '{{ userName }}' does not exist."
-msgstr "Użytkownik „{{ userName }}” nie istnieje."
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:1
-msgid "Show all Deployment Configs"
-msgstr "Wyświetl wszystkie konfiguracje wdrożeń"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:1
-msgid "Deployment Config"
-msgstr "Konfiguracja wdrażania"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:4
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr "Konfiguracja wdrożenia „{{ target }}” nie istnieje."
-
-#: pkg/kubernetes/views/route-panel.html.h:1
-#: pkg/kubernetes/views/route-page.html.h:2
-msgid "Route"
-msgstr "Trasa"
-
-#: pkg/kubernetes/views/volumes-page.html.h:1
-msgid "Register New Volume"
-msgstr "Zarejestruj nowy wolumin"
-
-#: pkg/kubernetes/views/volumes-page.html.h:2
-msgid "Persistent Volumes"
-msgstr "Trwałe woluminy"
-
-#: pkg/kubernetes/views/volumes-page.html.h:7
-msgid "No volumes are present."
-msgstr "Brak woluminów."
-
-#: pkg/kubernetes/views/volumes-page.html.h:8
-msgid "Pending Volume Claims"
-msgstr "Oczekujące deklaracje woluminów"
-
-#: pkg/kubernetes/views/volumes-page.html.h:12
-msgid "When"
-msgstr "Kiedy"
-
-#: pkg/kubernetes/views/user-delete.html.h:1
-msgid "Remove User"
-msgstr "Usuń użytkownika"
-
-#: pkg/kubernetes/views/pv-claim.html.h:3
-#: pkg/kubernetes/views/pv-modify.html.h:10
-#: pkg/kubernetes/views/pvc-body.html.h:7 pkg/kubernetes/views/pv-body.html.h:2
-msgid "Access Modes"
-msgstr "Tryby dostępu"
-
-#: pkg/kubernetes/views/pv-claim.html.h:4
-msgid "Requests"
-msgstr "Żądania"
-
-#: pkg/kubernetes/views/pv-claim.html.h:5
-msgid "This volume has not been claimed"
-msgstr "Ten wolumin nie został zadeklarowany"
-
-#: pkg/kubernetes/views/pv-claim.html.h:10
-msgid "No Pods are using this claim"
-msgstr "Żaden pojemnik nie używa tej deklaracji"
-
-#: pkg/kubernetes/views/filter-project.html.h:1
-msgid "All Projects"
-msgstr "Wszystkie projekty"
-
-#: pkg/kubernetes/views/filter-project.html.h:2
-msgid "Project:"
-msgstr "Projekt:"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:5
-#: pkg/kubernetes/views/details-page.html.h:14
-msgid "Latest Version"
-msgstr "Najnowsza wersja"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:6
-msgid "Deployment Causes"
-msgstr "Przyczyny wdrażania"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:7
-msgid "Triggers"
-msgstr "Wyzwalacze"
-
-#: pkg/kubernetes/views/item-delete.html.h:1
-msgid "Delete {{ item.kind }}"
-msgstr "Usuń {{ item.kind }}"
-
-#: pkg/kubernetes/views/item-delete.html.h:2
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr "Usunąć {{ item.kind }} „{{item.metadata.name}}”?"
-
-#: pkg/kubernetes/views/item-delete.html.h:3
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-"Usunięcie pojemnika zakończy wszystkie powiązane kontenery. W niektórych "
-"przypadkach pojemniki mogą być automatycznie tworzone ponownie.\n"
-"          "
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:2
-#: pkg/kubernetes/views/user-modify.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:2
-msgid ""
-"\n"
-"                        Name\n"
-"                    "
-msgstr ""
-"\n"
-"                        Nazwa\n"
-"                    "
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:5
-#: pkg/kubernetes/views/user-modify.html.h:5
-msgid ""
-"\n"
-"                        Identity\n"
-"                    "
-msgstr ""
-"\n"
-"                        Tożsamość\n"
-"                    "
-
-#: pkg/kubernetes/views/project-body.html.h:1
-msgid "Project Members"
-msgstr "Elementy projektu"
-
-#: pkg/kubernetes/views/project-body.html.h:3
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-msgstr ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-
-#: pkg/kubernetes/views/project-body.html.h:6
-msgid "Admin"
-msgstr "Administrator"
-
-#: pkg/kubernetes/views/project-body.html.h:7
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-msgstr ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-
-#: pkg/kubernetes/views/container-panel.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:3
-msgid "Shell"
-msgstr "Powłoka"
-
-#: pkg/kubernetes/views/service-endpoint.html.h:1
-msgid "Pod Endpoints"
-msgstr "Punkty końcowe pojemnika"
-
-#: pkg/kubernetes/views/service-endpoint.html.h:2
-msgid "No pods selected"
-msgstr "Nie wybrano żadnego pojemnika"
-
-#: pkg/kubernetes/views/service-endpoint.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:3
-msgid "Pod Selector"
-msgstr "Wybór pojemnika"
-
-#: pkg/kubernetes/views/user-add-membership.html.h:1
-msgid "Add membership"
-msgstr "Dodaj członkostwo"
-
-#: pkg/kubernetes/views/user-add-membership.html.h:2
-msgid ""
-"\n"
-"                        Group or Project\n"
-"                    "
-msgstr ""
-"\n"
-"                        Grupa lub projekt\n"
-"                    "
-
-#: pkg/kubernetes/views/user-add-membership.html.h:5
-msgid ""
-"\n"
-"                        Role\n"
-"                    "
-msgstr ""
-"\n"
-"                        Rola\n"
-"                    "
-
-#: pkg/kubernetes/views/deploy.html.h:1
-msgid "Deploy Application"
-msgstr "Wdroż aplikację"
-
-#: pkg/kubernetes/views/deploy.html.h:3
-msgid "{{ selected.name }}"
-msgstr "{{ selected.name }}"
-
-#: pkg/kubernetes/views/deploy.html.h:5
-#: pkg/kubernetes/views/dashboard-page.html.h:11
-msgid "Deploy"
-msgstr "Wdroż"
-
-#: pkg/kubernetes/views/user-modify.html.h:1
-msgid "Change User"
-msgstr "Zmień użytkownika"
-
-#: pkg/kubernetes/views/user-modify.html.h:9
-msgid "Modify"
-msgstr "Modyfikuj"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:1
-#: pkg/kubernetes/views/project-modify.html.h:6
-msgid "Access Policy"
-msgstr "Polityka dostępu"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:2
-#, fuzzy
-msgid ""
-"\n"
-"          Images may be pulled by anonymous users\n"
-"        "
-msgstr ""
-"\n"
-"          Obrazy mogą być pobierane przez wszystkich uwierzytelnionych "
-"użytkowników i grupy\n"
-"        "
-
-#: pkg/kubernetes/views/imagestream-body.html.h:5
-msgid ""
-"\n"
-"          Images may be pulled by any authenticated user or group\n"
-"        "
-msgstr ""
-"\n"
-"          Obrazy mogą być pobierane przez wszystkich uwierzytelnionych "
-"użytkowników i grupy\n"
-"        "
-
-#: pkg/kubernetes/views/imagestream-body.html.h:8
-msgid ""
-"\n"
-"          Images may only be pulled by specific users or groups\n"
-"        "
-msgstr ""
-"\n"
-"          Obrazy mogą być pobierane tylko przez podanych użytkowników "
-"i grupy\n"
-"        "
-
-#: pkg/kubernetes/views/imagestream-body.html.h:11
-msgid "Pull repository"
-msgstr "Repozytorium pobierania"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:13
-msgid "Image count"
-msgstr "Liczba obrazów"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:14
-msgid "{{stream.status.tags.length}}"
-msgstr "{{stream.status.tags.length}}"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:15
-msgid "To push to an image to this image stream:"
-msgstr "Aby wysłać obraz do tego potoku obrazów:"
-
-#: pkg/kubernetes/views/node-alerts.html.h:1
-msgid "The node doesn't have enough disk space"
-msgstr "Węzeł ma za mało miejsca na dysku"
-
-#: pkg/kubernetes/views/node-alerts.html.h:2
-msgid "The node doesn't have enough free memory"
-msgstr "Węzeł ma za mało wolnej pamięci"
-
-#: pkg/kubernetes/views/pv-modify.html.h:1
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr "Dostosuj trwały wolumin „{{ item.metadata.name }}”"
-
-#: pkg/kubernetes/views/pv-modify.html.h:2
-msgid "Register Persistent Volume"
-msgstr "Zarejestruj trwały wolumin"
-
-#: pkg/kubernetes/views/pv-modify.html.h:4
-msgid "Warning:"
-msgstr "Ostrzeżenie:"
-
-#: pkg/kubernetes/views/pv-modify.html.h:5
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-"Ta opcja jest tylko do testowania jednego węzła — lokalne urządzenia do "
-"przechowywania danych nie będą działały w klastrze wielowęzłowym"
-
-#: pkg/kubernetes/views/pv-modify.html.h:7
-#: pkg/kubernetes/views/node-page.html.h:3
-#: pkg/kubernetes/views/pvc-body.html.h:10
-#: pkg/kubernetes/views/pv-body.html.h:3
-msgid "Capacity"
-msgstr "Pojemność"
-
-#: pkg/kubernetes/views/pv-modify.html.h:8
-#: pkg/kubernetes/views/pv-body.html.h:1
-msgid "Reclaim Policy"
-msgstr "Polityka odzyskiwania"
-
-#: pkg/kubernetes/views/pv-modify.html.h:9
-msgid "{{ value }}"
-msgstr "{{ value }}"
-
-#: pkg/kubernetes/views/pv-modify.html.h:12
-msgid "Endpoint"
-msgstr "Punkt końcowy"
-
-#: pkg/kubernetes/views/pv-modify.html.h:15
-msgid "Target"
-msgstr "Cel"
-
-#: pkg/kubernetes/views/auth-dialog.html.h:1
-msgid "Connection Settings"
-msgstr "Ustawienia połączenia"
-
-#: pkg/kubernetes/views/auth-dialog.html.h:2
-msgid "Connection Error"
-msgstr "Błąd połączenia"
-
-#: pkg/kubernetes/views/image-body.html.h:2
-msgid "Summary"
-msgstr "Podsumowanie"
-
-#: pkg/kubernetes/views/image-body.html.h:4
-msgid "Source URL"
-msgstr "Źródłowy adres URL"
-
-#: pkg/kubernetes/views/image-body.html.h:7
-msgid "Built"
-msgstr "Zbudowane"
-
-#: pkg/kubernetes/views/image-body.html.h:8
-msgid "Digest"
-msgstr "Przegląd"
-
-#: pkg/kubernetes/views/image-body.html.h:9
-msgid "Identifier"
-msgstr "Identyfikator"
-
-#: pkg/kubernetes/views/image-body.html.h:11
-msgid "To pull this image:"
-msgstr "Aby pobrać ten obraz:"
-
-#: pkg/kubernetes/views/service-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:8
-#: pkg/kubernetes/views/service-page.html.h:2
-msgid "Service"
-msgstr "Usługa"
-
-#: pkg/kubernetes/views/service-panel.html.h:2
-#: pkg/kubernetes/views/service-page.html.h:3
-msgid "Endpoints"
-msgstr "Punkty końcowe"
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:1
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr "Serwer używa certyfikatu podpisanego przez nieznany ośrodek."
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:2
+#: pkg/kubernetes/views/auth-rejected-cert.html:3
 msgid ""
 "You can bypass the certificate check, but any data you send to the server "
 "could be intercepted by others."
@@ -5961,184 +6248,38 @@ msgstr ""
 "Można obejść sprawdzanie certyfikatu, ale wszystkie dane przesyłane do "
 "serwera mogą zostać przechwycone przez innych."
 
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:4
-msgid "Trust this certificate for this connection"
-msgstr "Zaufaj temu certyfikatowi w tym połączeniu"
-
-#: pkg/kubernetes/views/pod-page.html.h:1
-msgid "Show all Pods"
-msgstr "Wyświetl wszystkie pojemniki"
-
-#: pkg/kubernetes/views/pod-page.html.h:7
-msgid "The pod '{{ target }}' does not exist."
-msgstr "Pojemnik „{{ target }}” nie istnieje."
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:1
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr "Dostosuj kontroler replikacji {{ item.metadata.name }}"
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:1
-msgid "Delete image stream"
-msgstr "Usuń potok obrazu"
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:2
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-"Usunąć potok obrazu „{{stream.metadata.namespace}}/{{stream.metadata.name}}”?"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:2
-msgid "All running"
-msgstr "Wszystko działa"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:3
-msgid "No pods deployed"
-msgstr "Brak wdrożonych pojemników"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:5
-msgid "All in use"
-msgstr "Wszystko jest używane"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:6
-msgid "No volumes in use"
-msgstr "Żadne woluminy nie są używane"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:7
-msgid "pending volume claims"
-msgstr "oczekujące deklaracje woluminów"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:9
-msgid "All healthy"
-msgstr "Wszystko jest zdrowe"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:10
-msgid "No nodes in cluster"
-msgstr "Brak węzłów w klastrze"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:13
-msgid "Could not list services"
-msgstr "Nie można wyświetlić listy usług"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:14
+#: pkg/kubernetes/views/dashboard-page.html:150
 msgid "You can deploy an application to your cluster."
 msgstr "Można wdrożyć aplikację w klastrze."
 
-#: pkg/kubernetes/views/imagestream-page.html.h:1
-msgid "Show all image streams"
-msgstr "Wyświetl wszystkie potoki obrazów"
-
-#: pkg/kubernetes/views/imagestream-page.html.h:2
-msgid "Image Stream"
-msgstr "Potok obrazu"
-
-#: pkg/kubernetes/views/container-body.html.h:3
-msgid "Image ID"
-msgstr "Identyfikator obrazu"
-
-#: pkg/kubernetes/views/container-body.html.h:4
-msgid "Container ID"
-msgstr "Identyfikator kontenera"
-
-#: pkg/kubernetes/views/container-body.html.h:7
-msgid "Since"
-msgstr "Od"
-
-#: pkg/kubernetes/views/container-body.html.h:8
-msgid "Restart Count"
-msgstr "Liczba ponownych uruchomień"
-
-#: pkg/kubernetes/views/user-remove-membership.html.h:1
-msgid "Remove membership"
-msgstr "Usuń członkostwo"
-
-#: pkg/kubernetes/views/nodes-page.html.h:1
-msgid "Delete Selected"
-msgstr "Usuń zaznaczone"
-
-#: pkg/kubernetes/views/nodes-page.html.h:2
-msgid "OS Versions"
-msgstr "Wersje systemu operacyjnego"
-
-#: pkg/kubernetes/views/nodes-page.html.h:3
-msgid "Add Kubernetes Node"
-msgstr "Dodaj węzeł Kubernetes"
-
-#: pkg/kubernetes/views/project-page.html.h:3
-msgid "The project '{{ projName }}' does not exist."
-msgstr "Projekt „{{ projName }}” nie istnieje."
-
-#: pkg/kubernetes/views/user-panel.html.h:4
+#: pkg/lib/machine-invalid-hostkey.html:11
 msgid ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
+"You can remove the previously stored key by running the following command"
 msgstr ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
+"Można usunąć poprzednio przechowywany klucz wykonując następujące polecenie"
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:1
-msgid "Pod Replicated"
-msgstr "Utworzono kopię pojemnika"
+#: pkg/shell/base_index.js:672
+msgid "You can try restarting Cockpit by pressing refresh in your browser. "
+msgstr ""
+"Można spróbować ponownie uruchomić program Cockpit przez odświeżenie strony "
+"w przeglądarce. "
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:2
-msgid "No pods replicated"
-msgstr "Nie utworzono kopii żadnych pojemników"
-
-#: pkg/kubernetes/views/container-page.html.h:1
-msgid "Show all Containers"
-msgstr "Wyświetl wszystkie kontenery"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:1
-msgid "Welcome to the Image Registry"
-msgstr "Witamy w rejestrze obrazów"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:2
+#: pkg/users/index.html:335
 msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
-msgstr "Aby zacząć wysyłać obrazy do rejestru, należy utworzyć projekt."
+"You do not have permission to view the authorized public keys for this "
+"account."
+msgstr ""
+"Brak uprawnienia do wyświetlania upoważnionych publicznych kluczy dla tego "
+"konta."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:1
-msgid "New project"
-msgstr "Nowy projekt"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:4
-msgid "Images by project"
-msgstr "Obrazy według projektu"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:6
-msgid "Images pushed recently"
-msgstr "Ostatnio wysłane obrazy"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:7
-msgid "All images"
-msgstr "Wszystkie obrazy"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:8
-msgid "No images pushed"
-msgstr "Nie wysłano obrazów"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:9
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr "Aby zacząć wysyłać obrazy do rejestru, należy użyć poniższych poleceń."
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:11
+#: pkg/docker/storage.jsx:482
 #, fuzzy
-msgid "Login commands"
-msgstr "Polecenia Dockera"
+msgid "You don't have permission to manage the Docker storage pool."
+msgstr ""
+"Brak uprawnienia do wyświetlania upoważnionych publicznych kluczy dla tego "
+"konta."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:12
-#, fuzzy
-msgid "Log into the registry:"
-msgstr "Witamy w rejestrze obrazów"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:13
+#: pkg/kubernetes/views/registry-dashboard-page.html:112
 msgid ""
 "Your login credentials do not give you access to use the docker registry "
 "from the command line."
@@ -6146,260 +6287,187 @@ msgstr ""
 "Dane uwierzytelniające logowania nie daję dostępu do używania rejestru "
 "Dockera z wiersza poleceń."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:14
-msgid "Log into OpenShift command line tools:"
-msgstr ""
+#: src/base1/cockpit.js:3687
+msgid "Your session has been terminated."
+msgstr "Sesja została zakończona."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:15
-#, fuzzy
-msgid "Image commands"
-msgstr "Liczba obrazów"
+#: src/base1/cockpit.js:3689
+msgid "Your session has expired. Please log in again."
+msgstr "Sesja wygasła. Proszę zalogować się ponownie."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:16
-msgid "Push an image:"
-msgstr "Wysłanie obrazu:"
+#: pkg/lib/journal.js:213
+msgid "[$0 bytes of binary data]"
+msgstr "[$0 bajtów danych binarnych]"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:17
-msgid "Pull an image:"
-msgstr "Pobranie obrazu:"
+#: pkg/lib/journal.js:215
+msgid "[binary data]"
+msgstr "[dane binarne]"
 
-#: pkg/kubernetes/views/node-page.html.h:1
-msgid "Show all Nodes"
-msgstr "Wyświetl wszystkie węzły"
+#: pkg/lib/journal.js:209
+msgid "[no data]"
+msgstr "[brak danych]"
 
-#: pkg/kubernetes/views/node-page.html.h:4
-msgid "The node '{{ target }}' does not exist."
-msgstr "Węzeł „{{ target }}” nie istnieje."
+#: pkg/storaged/details.js:1692
+msgid "active, but unsupported"
+msgstr "aktywne, ale nieobsługiwane"
 
-#: pkg/kubernetes/views/route-page.html.h:1
-msgid "Show all Routes"
-msgstr "Wyświetl wszystkie trasy"
+#: pkg/storaged/utils.js:88
+msgctxt "format-bytes"
+msgid "bytes"
+msgstr "bajtów"
 
-#: pkg/kubernetes/views/route-page.html.h:3
-msgid "The route '{{ target }}' does not exist."
-msgstr "Trasa „{{ target }}” nie istnieje."
+#: pkg/docker/util.js:123
+msgid "default"
+msgstr "domyślnie"
 
-#: pkg/kubernetes/views/topology-page.html.h:1
-msgid "Select an object to see more details."
-msgstr "Proszę wybrać obiekt, aby wyświetlić więcej informacji."
+#: pkg/storaged/details.js:178
+msgid "ext4 - Red Hat Enterprise Linux 6 default"
+msgstr "ext4 — domyślne w systemie Red Hat Enterprise Linux 6"
 
-#: pkg/kubernetes/views/topology-page.html.h:3
-msgid ""
-"Pods contain one or more containers that run\n"
-"                together on a node, containing your application code."
-msgstr ""
-"Pojemniki zawierają jeden lub więcej kontenerów działających\n"
-"               razem na węźle, zawierających kod aplikacji."
+#: pkg/systemd/host.js:661
+msgid "failed to list ssh host keys: $0"
+msgstr "wyświetlenie listy kluczy SSH komputera się nie powiodło: $0"
 
-#: pkg/kubernetes/views/topology-page.html.h:6
-msgid ""
-"Replication controllers dynamically create instances of\n"
-"                pods from templates, and remove pods when necessary."
-msgstr ""
-"Kontrolery replikacji dynamicznie tworzą wystąpienia\n"
-"                pojemników z szablonów, i usuwają je w razie potrzeby."
+#: pkg/storaged/index.html:135
+msgid "iSCSI Targets"
+msgstr "Cele iSCSI"
 
-#: pkg/kubernetes/views/topology-page.html.h:9
-msgid ""
-"Services group pods and provide a common DNS\n"
-"                name and an optional, load-balanced IP address to access "
-"them."
-msgstr ""
-"Usługi grupują pojemniki i dostarczają wspólną nazwę\n"
-"                DNS oraz opcjonalny, zrównoważony adres IP do uzyskiwania do "
-"nich dostępu."
+#: pkg/storaged/details.js:1692
+msgid "inactive"
+msgstr "nieaktywne"
 
-#: pkg/kubernetes/views/topology-page.html.h:12
-msgid "Nodes are the machines that run your containers."
-msgstr "Węzły to komputery, na których działają kontenery."
+#: pkg/storaged/details.js:1286
+msgid "locked"
+msgstr "zablokowane"
 
-#: pkg/kubernetes/views/add-group-dialog.html.h:1
-msgid "Add Group"
-msgstr "Dodaj grupę"
+#: pkg/storaged/details.js:1278
+msgid "mounted on $0"
+msgstr "zamontowane w $0"
 
-#: pkg/kubernetes/views/file-button.html.h:1
-msgid "Select Manifest File..."
-msgstr "Wybierz plik manifestu…"
-
-#: pkg/kubernetes/views/project-modify.html.h:2
-msgid "Change project"
-msgstr "Zmień projekt"
-
-#: pkg/kubernetes/views/project-modify.html.h:4
-msgid "Display name"
-msgstr "Wyświetlana nazwa"
-
-#: pkg/kubernetes/views/route-body.html.h:5
-msgid "TLS Termination"
-msgstr "Zakończenie TLS"
-
-#: pkg/kubernetes/views/route-body.html.h:6
-msgid "yes"
-msgstr "tak"
-
-#: pkg/kubernetes/views/route-body.html.h:7
+#: pkg/kubernetes/views/route-body.html:14
 msgid "no"
 msgstr "nie"
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:1
-msgid "Add Role"
-msgstr "Dodaj rolę"
+#: pkg/kubernetes/views/route-body.html:24
+#: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
+msgid "none"
+msgstr "brak"
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:2
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
-msgstr "Dodać rolę „{{ fields.displayRole }}”?"
+#: pkg/storaged/details.js:1280
+msgid "not mounted"
+msgstr "niezamontowane"
 
-#: pkg/kubernetes/views/details-page.html.h:1
-msgid "All Types"
-msgstr "Wszystkie typy"
+#: pkg/kubernetes/views/dashboard-page.html:83
+msgid "pending volume claims"
+msgstr "oczekujące deklaracje woluminów"
 
-#: pkg/kubernetes/views/details-page.html.h:2
-msgid "Type:"
-msgstr "Typ:"
+#: pkg/tuned/change-profile.jsx:52
+#, fuzzy
+msgid "recommended"
+msgstr "MII (zalecane)"
 
-#: pkg/kubernetes/views/details-page.html.h:13
-msgid "Deployment Configs"
-msgstr "Konfiguracje wdrożeń"
+#: pkg/docker/index.html:426
+msgid "select container"
+msgstr "wybierz kontener"
 
-#: pkg/kubernetes/views/details-page.html.h:15
-msgid "Not deployed"
-msgstr "Nie wdrożono"
+#: pkg/docker/index.html:504 pkg/docker/index.html:683
+msgid "shares"
+msgstr "udziały"
 
-#: pkg/kubernetes/views/details-page.html.h:16
-msgid "Replication Controllers"
-msgstr "Kontrolery replikacji"
+#: pkg/selinux/setroubleshoot-view.jsx:118
+msgid "solution details"
+msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:1
-msgid "Adjust Service"
-msgstr "Dostosuj usługę"
+#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
+msgid "unknown"
+msgstr "nieznane"
 
-#: pkg/kubernetes/views/service-modify.html.h:3
+#: pkg/storaged/jobs.js:180
+msgid "unknown target"
+msgstr "nieznany cel"
+
+#: pkg/storaged/details.js:1284
+msgid "unlocked"
+msgstr "odblokowane"
+
+#: pkg/kubernetes/views/route-body.html:13
+msgid "yes"
+msgstr "tak"
+
+#: pkg/kubernetes/views/service-modify.html:16
 msgid "{{ item.name }}"
 msgstr "{{ item.name }}"
 
-#: pkg/kubernetes/views/service-modify.html.h:5
-msgid "Adjust"
-msgstr "Dostosuj"
+#: pkg/kubernetes/views/deploy.html:27
+msgid "{{ selected.name }}"
+msgstr "{{ selected.name }}"
 
-#: pkg/kubernetes/views/project-delete.html.h:1
-msgid "Delete Project"
-msgstr "Usuń projekt"
+#: pkg/kubernetes/views/pv-modify.html:61
+#: pkg/kubernetes/views/pv-modify.html:74
+msgid "{{ value }}"
+msgstr "{{ value }}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:2
-msgid "Claim Name"
-msgstr "Nazwa deklaracji"
+#: pkg/kubernetes/views/volume-body.html:2
+msgid "{{ volume | formatVolumeType }}"
+msgstr "{{ volume | formatVolumeType }}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:4
-msgid "No Volume Bound"
-msgstr "Żaden wolumin nie został przypisany"
+#: pkg/storaged/index.html:147
+msgid "{{Address}}:{{Port}}"
+msgstr "{{Address}}:{{Port}}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:8
-msgid "Requested"
-msgstr "Żądany"
+#: pkg/docker/index.html:435
+msgid "{{alias_label}}"
+msgstr "{{alias_label}}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:9
-msgid "Actual"
-msgstr "Rzeczywisty"
-
-#: pkg/kubernetes/views/node-capacity.html.h:1
-msgid "Scheduled Pods"
-msgstr "Zaplanowane pojemniki"
-
-#: pkg/kubernetes/views/node-capacity.html.h:2
-msgid "No pods scheduled"
-msgstr "Nie zaplanowano żadnych pojemników"
-
-#: pkg/kubernetes/views/container-page-inline.html.h:4
-msgid "The container '{{ target }}' does not exist."
-msgstr "Kontener „{{ target }}” nie istnieje."
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:1
-msgid "Create image stream"
-msgstr "Utwórz potok obrazu"
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:2
-msgid "Change image stream"
-msgstr "Zmień potok obrazu"
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:5
-msgid "Populate"
-msgstr "Wypełnij"
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:6
-msgid "Pull from"
-msgstr "Pobierz z"
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:8
-msgid "Remote registry is insecure"
-msgstr "Zdalny rejestr jest niezabezpieczony"
-
-#: pkg/kubernetes/views/user-group-remove.html.h:1
-msgid "Remove Member"
-msgstr "Usuń element"
-
-#: pkg/kubernetes/views/service-page.html.h:1
-msgid "Show all Services"
-msgstr "Wyświetl wszystkie usługi"
-
-#: pkg/kubernetes/views/service-page.html.h:4
-msgid "The service '{{ target }}' does not exist."
-msgstr "Usługa „{{ target }}” nie istnieje."
-
-#: pkg/kubernetes/scripts/frob-layers.html.h:1
-#, fuzzy
-msgid "Image Layers Example"
-msgstr "Warstwy obrazu"
-
-#: pkg/playground/service.html.h:1
-msgid "Cockpit Generic Service Monitor"
+#: pkg/systemd/services.html:173 pkg/systemd/services.html:202
+msgid "{{days_text}}"
 msgstr ""
 
-#: pkg/playground/jquery-patterns.html.h:1
-msgid "Cockpit Pattern Usage"
-msgstr "Wzór użycia Cockpit"
+#: pkg/docker/index.html:403
+msgid "{{envvar_key_label}}"
+msgstr "{{envvar_key_label}}"
 
-#: pkg/playground/metrics.html.h:1
+#: pkg/docker/index.html:407
+msgid "{{envvar_value_label}}"
+msgstr "{{envvar_value_label}}"
+
+#: pkg/docker/index.html:359
+msgid "{{host_port_label}}"
+msgstr "{{host_port_label}}"
+
+#: pkg/docker/index.html:373
+msgid "{{host_volume_label}}"
+msgstr "{{host_volume_label}}"
+
+#: pkg/kubernetes/views/imagestream-body.html:35
+msgid "{{stream.status.tags.length}}"
+msgstr "{{stream.status.tags.length}}"
+
+#~ msgid "Journal"
+#~ msgstr "Dziennik"
+
+#~ msgid "Comment"
+#~ msgstr "Komentarz"
+
 #, fuzzy
-msgid "Cockpit Monitoring"
-msgstr "Monitorowanie łącza"
+#~ msgid "Image Layers Example"
+#~ msgstr "Warstwy obrazu"
 
-#: pkg/playground/test.html.h:1 pkg/playground/translate.html.h:1
-msgid "Cockpit playground"
-msgstr ""
+#~ msgid "Cockpit Pattern Usage"
+#~ msgstr "Wzór użycia Cockpit"
 
-#: pkg/playground/react-patterns.html.h:1
-msgid "Cockpit React Patterns Usage"
-msgstr "Wzór użycia Cockpit React"
-
-#: pkg/playground/speed.html.h:1
-msgid "Cockpit Speed Tests"
-msgstr ""
-
-#: pkg/playground/plot.html.h:1
 #, fuzzy
-msgid "Cockpit Plots"
-msgstr "Cockpit"
+#~ msgid "Cockpit Monitoring"
+#~ msgstr "Monitorowanie łącza"
 
-#: pkg/dashboard/index.html.h:1
-msgid "Dashboard"
-msgstr ""
+#~ msgid "Cockpit React Patterns Usage"
+#~ msgstr "Wzór użycia Cockpit React"
 
-#: pkg/dashboard/index.html.h:5
 #, fuzzy
-msgid "Disk I/O"
-msgstr "Dysk jest OK"
-
-#: pkg/dashboard/index.html.h:6
-msgid "Lost connection. Trying to reconnect"
-msgstr "Utracono połączenie. Próbowanie ponownego połączenia"
-
-#: pkg/dashboard/index.html.h:10
-msgid "Avatar"
-msgstr "Awatar"
-
-#: pkg/dashboard/index.html.h:13
-msgid "Set"
-msgstr "Ustaw"
+#~ msgid "Cockpit Plots"
+#~ msgstr "Cockpit"
 
 #~ msgid "No addresses found"
 #~ msgstr "Nie odnaleziono adresów"
@@ -6596,60 +6664,8 @@ msgstr "Ustaw"
 #~ msgstr "Wyświetl okno błędu"
 
 #~ msgctxt "storage"
-#~ msgid "Model"
-#~ msgstr "Model"
-
-#~ msgctxt "storage"
-#~ msgid "Firmware Version"
-#~ msgstr "Wersja oprogramowania sprzętowego"
-
-#~ msgctxt "storage"
-#~ msgid "Serial Number"
-#~ msgstr "Numer seryjny"
-
-#~ msgctxt "storage"
-#~ msgid "World Wide Name"
-#~ msgstr "Nazwa WWN"
-
-#~ msgctxt "storage"
-#~ msgid "Capacity"
-#~ msgstr "Pojemność"
-
-#~ msgctxt "storage"
-#~ msgid "Assessment"
-#~ msgstr "Ocena"
-
-#~ msgctxt "storage"
-#~ msgid "Device File"
-#~ msgstr "Plik urządzenia"
-
-#~ msgctxt "storage"
-#~ msgid "Multipathed Devices"
-#~ msgstr "Urządzenia wielościeżkowe"
-
-#~ msgctxt "storage"
-#~ msgid "Device"
-#~ msgstr "Urządzenie"
-
-#~ msgctxt "storage"
 #~ msgid "Name"
 #~ msgstr "Nazwa"
-
-#~ msgctxt "storage"
-#~ msgid "UUID"
-#~ msgstr "UUID"
-
-#~ msgctxt "storage"
-#~ msgid "RAID Level"
-#~ msgstr "Poziom macierzy RAID"
-
-#~ msgctxt "storage"
-#~ msgid "Bitmap"
-#~ msgstr "Bitmapa"
-
-#~ msgctxt "storage"
-#~ msgid "State"
-#~ msgstr "Stan"
 
 #~ msgid ""
 #~ "\n"
@@ -6704,15 +6720,6 @@ msgstr "Ustaw"
 #~ msgstr ""
 #~ "\n"
 #~ "                    Adres URL\n"
-#~ "                  "
-
-#~ msgid ""
-#~ "\n"
-#~ "                    Login\n"
-#~ "                  "
-#~ msgstr ""
-#~ "\n"
-#~ "                    Login\n"
 #~ "                  "
 
 #~ msgid ""

--- a/po/po.js
+++ b/po/po.js
@@ -1,9 +1,60 @@
 (function (root, data) {
+    var loaded, module;
+
+    /* Load into AMD if desired */
     if (typeof define === 'function' && define.amd) {
         define(data);
-    } else if (typeof cockpit === 'object') {
-        cockpit.locale(data);
-    } else {
-        root.po = data;
+        loaded = true;
     }
-}(this, {"": { "language": "en" }}));
+
+    /* Load into Cockpit locale */
+    if (typeof cockpit === 'object') {
+        cockpit.locale(data)
+        loaded = true;
+    }
+
+    function transformAngular(data) {
+        var key, context, parts, value, result = { };
+        for (key in data) {
+            if (key === "")
+                continue;
+            parts = key.split("\u0004");
+            value = data[key];
+            if (parts[1]) {
+                context = parts[0];
+                key = parts[1];
+            } else {
+                context = "$$noContext";
+                key = parts[0];
+            }
+            if (value[0] === null)
+                value = value[1];
+            else
+                value = value.slice(1);
+            if (!(key in result))
+                result[key] = { };
+            result[key][context] = value;
+        }
+        return result;
+    }
+
+    /* Load into angular here */
+    if (typeof angular === 'object') {
+        try {
+            module = angular.module(["gettext"]);
+        } catch(ex) { console.log(ex); /* Either no angular or angular-gettext */ };
+        if (module) {
+            loaded = true;
+            module.run(['gettextCatalog', function(gettextCatalog) {
+                var lang = data[""]["language"];
+                gettextCatalog.setStrings(lang, transformAngular(data));
+                gettextCatalog.setCurrentLanguage(lang);
+            }]);
+        }
+    }
+
+    if (!loaded)
+        root.po = data;
+
+/* The syntax of this line is important  by po2json */
+}(this, {"":{"language":"en"}}));

--- a/po/po2json
+++ b/po/po2json
@@ -1,42 +1,41 @@
 #!/usr/bin/env node
 
-var fs, po2json, Jed;
-
 function fatal(message, code) {
-    console.log("po2json: " + message);
+    console.log((filename || "html2po") + ": " + message);
     process.exit(code || 1);
 }
 
 function usage() {
-    console.log("usage: po2json [--module] input output");
+    console.log("usage: po2json [--module=template.js] input output");
     process.exit(2);
 }
 
+var fs, po2json, Jed, stdio;
 
 try {
     fs = require('fs');
     po2json = require('po2json');
     Jed = require('jed');
+    stdio = require('stdio');
 } catch(ex) {
     fatal(ex.message, 127); /* missing looks for this */
 }
 
 var argi = 2;
-var module = false;
+var filename = null;
 
-if (process.argv[argi] == "--module") {
-    module = true;
-    argi++;
-}
+var opts = stdio.getopt({
+    module: { key: "m", args: 1, description: "Module template to include" },
+    output: { key: "o", args: 1, description: "Output file" },
+});
 
-if (process.argv.length != argi + 2) {
+if (opts.args.length != 1) {
     usage();
 }
 
-var input = process.argv[argi];
-var output = process.argv[argi + 1];
+parse();
 
-function prepare_header(header) {
+function prepareHeader(header) {
     var body, statement, plurals = header["plural-forms"], ret = null;
     if (plurals) {
         try {
@@ -70,29 +69,56 @@ function prepare_header(header) {
     return ret;
 }
 
-po2json.parseFile(input, { "fuzzy": true }, function(err, jsonData) {
-    var plurals, pos;
+/* Parse and process the po data */
+function parse() {
+    filename = opts.args[0];
+    po2json.parseFile(opts.args[0], { "fuzzy": true }, function(err, jsonData) {
+        var plurals, pos;
 
-    if (err)
-        fatal(err.message);
-
-    var header = jsonData[""];
-    if (header)
-        plurals = prepare_header(header);
-
-    var data = JSON.stringify(jsonData, null, 1);
-
-    /* We know the brace in is the location to insert our function */
-    if (plurals) {
-        pos = data.indexOf('{', 1);
-        data = data.substr(0, pos + 1) + "'plural-forms':" + String(plurals) + "," + data.substr(pos + 1);
-    }
-
-    if (module)
-	data = "(function (root, data) { if (typeof define === 'function' && define.amd) { define(data); } else if(typeof cockpit === 'object') { cockpit.locale(data); } else { root.po = data; } }(this, " + data + "));";
-
-    fs.writeFile(output, data, function(err) {
         if (err)
-	    fatal(err.message);
+            fatal(err.message);
+
+        var header = jsonData[""];
+        if (header)
+            plurals = prepareHeader(header);
+
+        var data = JSON.stringify(jsonData, null, 1);
+
+        /* We know the brace in is the location to insert our function */
+        if (plurals) {
+            pos = data.indexOf('{', 1);
+            data = data.substr(0, pos + 1) + "'plural-forms':" + String(plurals) + "," + data.substr(pos + 1);
+        }
+
+        wrap(data);
     });
-});
+}
+
+/* Wrap the data if desired */
+function wrap(data) {
+    if (opts.module) {
+        filename = opts.module;
+        fs.readFile(opts.module, { encoding: "utf-8" }, function(err, template) {
+            if (err)
+                fatal(err.message);
+            data = template.replace('{"":{"language":"en"}}', data);
+            finish(data);
+        });
+    } else {
+        finish(data);
+    }
+}
+
+/* Write it out */
+function finish(data) {
+    if (opts.output) {
+        fs.writeFile(opts.output, data, function(err) {
+            if (err)
+	        fatal(err.message);
+            process.exit(0);
+        });
+    } else {
+        process.stdout.write(data);
+        process.exit(0);
+    }
+}

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-17 19:28+0100\n"
+"POT-Creation-Date: 2016-11-18 06:44+0100\n"
 "PO-Revision-Date: 2016-09-03 06:49-0400\n"
 "Last-Translator: Lucas Landim Pinheiro <detona.headmetal@gmail.com>\n"
 "Language-Team: Portuguese (Brazil)\n"
@@ -18,176 +18,440 @@ msgstr ""
 "X-Generator: Zanata 3.9.6\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
-#: src/ws/cockpitcertificate.c:359
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr "Não é possível decifrar a chave privada codificado em PEM"
+#: pkg/shell/index.html:227
+msgid "                                                Comment                                            "
+msgstr ""
 
-#: src/ws/cockpitcertificate.c:364
-msgid "No PEM-encoded private key found"
-msgstr "Nenhuma chave privada codificado em PEM encontrados"
+#: pkg/shell/index.html:235
+msgid "                                                Fingerprint                                            "
+msgstr ""
 
-#: src/ws/cockpitcertificate.c:374
-msgid "Could not parse PEM-encoded private key"
-msgstr "Não foi possível analisar chave privada codificado em PEM"
+#: pkg/shell/index.html:231
+msgid "                                                Type                                            "
+msgstr ""
 
-#: src/ws/cockpitcertificate.c:398
-msgid "No PEM-encoded certificate found"
-msgstr "Nenhum certificado codificado em PEM encontrados"
+#: pkg/systemd/index.html:389
+msgid ""
+"                                    Invalid time "
+"zone                                "
+msgstr ""
 
-#: src/ws/cockpitcertificate.c:407
-msgid "Could not parse PEM-encoded certificate"
-msgstr "Não foi possível analisar certificado PEM-codificado"
+#: pkg/kubernetes/views/project-body.html:80
+msgid ""
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}                                "
+msgstr ""
 
-#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
-#: src/bridge/cockpitdbussetup.c:625
+#: pkg/kubernetes/views/user-body.html:22
+msgid ""
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}                                "
+msgstr ""
+
+#: pkg/kubernetes/views/user-panel.html:39
+msgid ""
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}                            "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:37
+msgid ""
+"                                {{ getRegistryRoles(user, project())."
+"join() }}                            "
+msgstr ""
+
+#: pkg/systemd/index.html:485 pkg/systemd/index.html:504
 #, fuzzy
-msgid "Unsupported setup mechanism"
-msgstr "Mecanismo de ajuste não suportado: %s"
-
-#: src/bridge/cockpitdbussetup.c:236
-msgid "Couldn't list users"
-msgstr "Não foi possível listar os usuários"
-
-#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
-msgid "Bad data passed for passwd1 mechanism"
-msgstr "Dados corrompidos passaram por passwd1 mecanismo"
-
-#: src/bridge/cockpitdbussetup.c:382
-msgid "Couldn't load user data"
-msgstr "Não foi possível carregar os dados do usuário"
-
-#: src/bridge/cockpitdbussetup.c:467
-msgid "Couldn't change user groups"
-msgstr "Não foi possível alterar os grupos de usuários"
-
-#: src/bridge/cockpitdbussetup.c:520
-msgid "Couldn't change user password"
-msgstr "Não foi possível alterar a senha do usuário"
-
-#: src/bridge/cockpitdbussetup.c:544
-msgid "Couldn't create new users"
-msgstr "Não foi possível criar novos usuários"
-
-#: src/bridge/cockpitdbussetup.c:642
-msgid "Couldn't list local users"
-msgstr "Não foi possível listar os usuários locais"
-
-#: src/bridge/cockpitpackages.c:459
-#, c-format
-msgid "This package requires Cockpit version %s or later"
+msgid "                        Cancel                    "
 msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
 
-#: src/bridge/cockpitpackages.c:470
-msgid "This package is not compatible with this version of Cockpit"
-msgstr ""
-
-#: src/base1/cockpit.js:2586
-msgid "$0 killed with signal $1"
-msgstr ""
-
-#: src/base1/cockpit.js:2588
-msgid "$0 exited with code $1"
-msgstr ""
-
-#: src/base1/cockpit.js:2590
-msgid "$0 failed"
-msgstr ""
-
-#: src/base1/cockpit.js:3667
-msgid "Your session has been terminated."
-msgstr ""
-
-#: src/base1/cockpit.js:3669
-msgid "Your session has expired. Please log in again."
-msgstr ""
-
-#: src/base1/cockpit.js:3671
-msgid "Not permitted to perform this action."
-msgstr ""
-
-#: src/base1/cockpit.js:3673
-msgid "Login failed"
-msgstr ""
-
-#: src/base1/cockpit.js:3675
-msgid "The server refused to authenticate using any supported methods."
-msgstr ""
-
-#: src/base1/cockpit.js:3677
-msgid "Untrusted host"
-msgstr ""
-
-#: src/base1/cockpit.js:3679
-msgid "Host key is incorrect"
-msgstr ""
-
-#: src/base1/cockpit.js:3681
-msgid "Internal error"
-msgstr ""
-
-#: src/base1/cockpit.js:3683
-msgid "Connection has timed out."
-msgstr ""
-
-#: src/base1/cockpit.js:3685
-msgid "Cockpit is not installed on the system."
-msgstr ""
-
-#: src/base1/cockpit.js:3687
-msgid "Cannot forward login credentials"
-msgstr ""
-
-#: src/base1/cockpit.js:3689
-msgid "Server has closed the connection."
-msgstr ""
-
-#: src/base1/cockpit.js:3691
-msgid "Cockpit is not compatible with the software on the system."
-msgstr ""
-
-#: src/base1/cockpit.js:3693
-msgid "Cockpit could not contact the given host."
-msgstr ""
-
-#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:19
+#: pkg/kubernetes/views/user-add-membership.html:9
 #, fuzzy
-msgid "Control"
-msgstr "Container"
+msgid "                        Group or Project                    "
+msgstr ""
+"\n"
+"              Obter nova imagem\n"
+"            "
 
-#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
-#: pkg/playground/translate.js:22
+#: pkg/kubernetes/views/add-user-dialog.html:19
+#: pkg/kubernetes/views/user-modify.html:19
 #, fuzzy
-msgctxt "key"
-msgid "Control"
-msgstr "Container"
+msgid "                        Identity                    "
+msgstr ""
+"\n"
+"              Obter nova imagem\n"
+"            "
 
-#: src/base1/test-locale.js:46 src/base1/test-locale.js:56
-#: pkg/playground/translate.js:10
-msgid "Empty"
-msgstr "Vazio"
-
-#: src/base1/test-locale.js:47 src/base1/test-locale.js:58
-#: pkg/playground/translate.js:16
+#: pkg/kubernetes/views/add-user-dialog.html:9
+#: pkg/kubernetes/views/user-modify.html:9
+#: pkg/kubernetes/views/add-group-dialog.html:9
 #, fuzzy
-msgctxt "verb"
-msgid "Empty"
-msgstr "Vazio"
+msgid "                        Name                    "
+msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
 
-#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
-#: src/base1/test-locale.js:66 pkg/storaged/details.js:1557
-#: pkg/playground/translate.js:25 pkg/playground/translate.js:28
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] ""
-msgstr[1] ""
+#: pkg/kubernetes/views/user-add-membership.html:30
+#, fuzzy
+msgid "                        Role                    "
+msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
 
-#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
-#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
-#: pkg/playground/translate.js:34
-msgctxt "disk-non-rotational"
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
+#: pkg/kubernetes/views/user-group-add.html:9
+#, fuzzy
+msgid "                        User                    "
+msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
+
+#: pkg/ostree/index.html:88
+#, fuzzy
+msgid "                    Available                  "
+msgstr ""
+"\n"
+"              Obter nova imagem\n"
+"            "
+
+#: pkg/ostree/index.html:85
+#, fuzzy
+msgid "                    Default                  "
+msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
+
+#: pkg/ostree/index.html:223
+#, fuzzy
+msgid "                    Reconnect                "
+msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
+
+#: pkg/ostree/index.html:135
+msgid ""
+"                    This deployment contains the same packages as your "
+"currently booted system                "
+msgstr ""
+
+#: pkg/ostree/index.html:67
+#, fuzzy
+msgid "                    Update and reboot                "
+msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
+
+#: pkg/kubernetes/registry.html:74 pkg/kubernetes/index.html:104
+#, fuzzy
+msgid "                Reconnect            "
+msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
+
+#: pkg/sosreport/index.html:57
+msgid ""
+"                The generated archive contains data "
+"considered                sensitive and its content should be reviewed by "
+"the                originating organization before being passed to "
+"any                third party.              "
+msgstr ""
+
+#: pkg/shell/index.html:304 pkg/shell/stub.html:157
+#, fuzzy
+msgid "                Tools              "
+msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
+
+#: pkg/kubernetes/index.html:107
+#, fuzzy
+msgid "                Troubleshoot            "
+msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
+
+#: pkg/shell/simple.html:105 pkg/shell/index.html:126 pkg/shell/stub.html:119
+#: pkg/storaged/index.html:862
+#, fuzzy
+msgid "              Cancel            "
+msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
+
+#: pkg/shell/index.html:147 pkg/shell/stub.html:140
+#, fuzzy
+msgid "              Close            "
+msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
+
+#: pkg/shell/simple.html:70 pkg/shell/index.html:83 pkg/shell/stub.html:76
+msgid ""
+"              Cockpit is an interactive Linux server admin "
+"interface.            "
+msgstr ""
+
+#: pkg/shell/simple.html:79 pkg/shell/index.html:92 pkg/shell/stub.html:85
+#, fuzzy
+msgid "              Licensed under the GNU LGPL version 2.1            "
+msgstr ""
+"\n"
+"              Obter nova imagem\n"
+"            "
+
+#: pkg/shell/simple.html:129
+#, fuzzy
+msgid "              Log in again            "
+msgstr ""
+"\n"
+"              Obter nova imagem\n"
+"            "
+
+#: pkg/shell/simple.html:73 pkg/shell/index.html:86 pkg/shell/stub.html:79
+#, fuzzy
+msgid "              Project website            "
+msgstr ""
+"\n"
+"              Obter nova imagem\n"
+"            "
+
+#: pkg/shell/simple.html:108 pkg/shell/index.html:129 pkg/shell/stub.html:122
+#, fuzzy
+msgid "              Select            "
+msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
+
+#: pkg/shell/simple.html:126
+#, fuzzy
+msgid "              Try to reconnect            "
+msgstr ""
+"\n"
+"              Cancelar\n"
+"            "
+
+#: pkg/users/index.html:361
+#, fuzzy
+msgid "            Add key          "
+msgstr ""
+"\n"
+"            Executar\n"
+"          "
+
+#: pkg/networkmanager/index.html:582 pkg/networkmanager/index.html:610
+#: pkg/networkmanager/index.html:638 pkg/networkmanager/index.html:666
+#: pkg/networkmanager/index.html:694 pkg/networkmanager/index.html:722
+#: pkg/networkmanager/index.html:750 pkg/networkmanager/index.html:778
+#, fuzzy
+msgid "            Apply          "
+msgstr ""
+"\n"
+"            Executar\n"
+"          "
+
+#: pkg/users/index.html:269 pkg/users/index.html:297 pkg/users/index.html:358
+#: pkg/docker/index.html:584 pkg/docker/index.html:622
+#: pkg/docker/index.html:688 pkg/docker/index.html:744
+#: pkg/docker/index.html:790 pkg/networkmanager/index.html:579
+#: pkg/networkmanager/index.html:607 pkg/networkmanager/index.html:635
+#: pkg/networkmanager/index.html:663 pkg/networkmanager/index.html:691
+#: pkg/networkmanager/index.html:719 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:775
+#, fuzzy
+msgid "            Cancel          "
+msgstr ""
+"\n"
+"            Cancelar\n"
+"          "
+
+#: pkg/docker/index.html:691
+#, fuzzy
+msgid "            Change          "
+msgstr ""
+"\n"
+"            Modificar\n"
+"          "
+
+#: pkg/users/index.html:45
+#, fuzzy
+msgid "            Close          "
+msgstr ""
+"\n"
+"            Cancelar\n"
+"          "
+
+#: pkg/docker/index.html:747
+#, fuzzy
+msgid "            Commit          "
+msgstr ""
+"\n"
+"            Commit\n"
+"          "
+
+#: pkg/users/index.html:207
+#, fuzzy
+msgid "            Create          "
+msgstr ""
+"\n"
+"            Cancelar\n"
+"          "
+
+#: pkg/users/index.html:300 pkg/networkmanager/index.html:533
+#, fuzzy
+msgid "            Delete          "
+msgstr ""
+"\n"
+"            Cancelar\n"
+"          "
+
+#: pkg/docker/index.html:625
+#, fuzzy
+msgid "            Download          "
+msgstr ""
+"\n"
+"            Baixar\n"
+"          "
+
+#: pkg/docker/index.html:587
+#, fuzzy
+msgid "            Run          "
+msgstr ""
+"\n"
+"            Executar\n"
+"          "
+
+#: pkg/users/index.html:272
+#, fuzzy
+msgid "            Set          "
+msgstr ""
+"\n"
+"            Executar\n"
+"          "
+
+#: pkg/kubernetes/views/imagestream-body.html:14
+msgid "          Images may be pulled by anonymous users        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:20
+msgid ""
+"          Images may be pulled by any authenticated user or group        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:26
+msgid "          Images may only be pulled by specific users or groups        "
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:9
+#, fuzzy
+msgid "         {{ labels.url }}    "
+msgstr ""
+"\n"
+"            Cancelar\n"
+"          "
+
+#: pkg/kubernetes/views/project-body.html:2
+msgid ""
+"        Project access policy allows anonymous users to pull images. Grant "
+"additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:7
+msgid ""
+"        Project access policy allows any authenticated user to pull images. "
+"Grant additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:12
+msgid ""
+"        Project access policy only allows specific members to access images. "
+"Grant access to specific members below.    "
+msgstr ""
+
+#: pkg/sosreport/index.html:39
+msgid ""
+"        The collected information will be stored locally on the system.      "
+msgstr ""
+
+#: pkg/storaged/index.html:51
+msgid ""
+"        There are devices with multiple paths on the system, but the "
+"multipath service is not running.      "
+msgstr ""
+
+#: pkg/sosreport/index.html:34
+msgid ""
+"        This tool will collect system configuration and diagnostic        "
+"information from this system for use with diagnosing problems        with "
+"the system.      "
+msgstr ""
+
+#: pkg/docker/storage.jsx:242
+msgid " (shared with the OS)"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:8
+msgid " 1\"Do you want to delete the following Nodes?"
+msgstr ""
+
+#: pkg/storaged/overview.js:253
+msgid "$0 Block Device"
+msgstr ""
+
+#: pkg/storaged/details.js:1546
+msgid "$0 Chunk Size"
+msgstr ""
+
+#: pkg/storaged/details.js:1544
+msgid "$0 Disks"
+msgstr "$0 Discos"
+
+#: pkg/storaged/details.js:1387
+msgid "$0 Extended Partition"
+msgstr "$0 Partição Extendida"
+
+#: pkg/storaged/details.js:1221
+msgctxt "storage-id-desc"
+msgid "$0 File System"
+msgstr "$0 Sistema de Arquivos"
+
+#: pkg/storaged/details.js:1375
+msgid "$0 Free Space"
+msgstr "$0 Espaço Livre"
+
+#: pkg/storaged/details.js:1367
+msgid "$0 Free Space for Logical Partitions"
+msgstr "$0 Espaço Livre para Partições Lógicas"
+
+#: pkg/storaged/details.js:1711
+msgid "$0 Free Space for Logical Volumes"
+msgstr "$0 Espaço Livres Para Volumes Lógicos"
+
+#: pkg/storaged/details.js:1370
+msgid "$0 Free Space for Primary Partitions"
+msgstr "$0 Espaço Livre para Partições Primarias"
+
+#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
+msgid "$0 Template"
+msgstr "Modelo $0 "
+
+#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+msgid "$0 bit"
+msgid_plural "$0 bits"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -207,582 +471,40 @@ msgid_plural "$0 bytes"
 msgstr[0] "bytes"
 msgstr[1] "bytes"
 
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
-msgid "$0 bit"
-msgid_plural "$0 bits"
+#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
+#: src/base1/test-locale.js:66 pkg/playground/translate.js:25
+#: pkg/playground/translate.js:28 pkg/storaged/details.js:1557
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/systemd/host.js:43
-msgid "The user <b>$0</b> is not permitted to modify hostnames"
+#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
+#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
+#: pkg/playground/translate.js:34
+msgctxt "disk-non-rotational"
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/base1/cockpit.js:2588
+msgid "$0 exited with code $1"
 msgstr ""
 
-#: pkg/systemd/host.js:559
-msgid "Set Host name"
+#: src/base1/cockpit.js:2590
+msgid "$0 failed"
 msgstr ""
 
-#: pkg/systemd/host.js:661
-msgid "failed to list ssh host keys: $0"
+#: src/base1/cockpit.js:2586
+msgid "$0 killed with signal $1"
 msgstr ""
 
-#: pkg/systemd/host.js:1113
-msgid "Need at least one NTP server"
-msgstr ""
-
-#: pkg/systemd/host.js:1190
-msgid "Invalid date format and invalid time format"
-msgstr ""
-
-#: pkg/systemd/host.js:1192
-msgid "Invalid time format"
-msgstr ""
-
-#: pkg/systemd/host.js:1194
-msgid "Invalid date format"
-msgstr ""
-
-#: pkg/systemd/host.js:1250
-msgid "NTP Server"
-msgstr ""
-
-#: pkg/systemd/host.js:1300
-msgid "Message to logged in users"
-msgstr ""
-
-#: pkg/systemd/host.js:1307 pkg/systemd/host.js:1309
-#: pkg/systemd/index.html.h:19
-msgid "Shutdown"
-msgstr ""
-
-#: pkg/systemd/host.js:1311 pkg/systemd/host.js:1313 pkg/systemd/init.js:517
-#: pkg/systemd/index.html.h:18
-msgid "Restart"
-msgstr "Reiniciar"
-
-#: pkg/systemd/host.js:1381
-msgctxt "page-title"
-msgid "CPU Status"
-msgstr "Status de CPU"
-
-#: pkg/systemd/host.js:1413 pkg/systemd/index.html.h:24
-msgid "I/O Wait"
-msgstr ""
-
-#: pkg/systemd/host.js:1414 pkg/systemd/index.html.h:25
-msgid "Kernel"
-msgstr ""
-
-#: pkg/systemd/host.js:1415 pkg/subscriptions/subscriptions-register.jsx:76
-#: pkg/systemd/index.html.h:26 pkg/kubernetes/views/auth-form.html.h:6
-#: pkg/kubernetes/views/volume-body.html.h:20
-#: pkg/kubernetes/views/user-panel.html.h:1 pkg/playground/translate.html.h:3
-#: pkg/dashboard/index.html.h:8
-msgid "User"
-msgstr ""
-
-#: pkg/systemd/host.js:1416 pkg/systemd/index.html.h:27
-msgid "Nice"
-msgstr ""
-
-#: pkg/systemd/host.js:1466
-msgctxt "page-title"
-msgid "Memory"
-msgstr "Memória"
-
-#: pkg/systemd/host.js:1499 pkg/systemd/index.html.h:28
-msgid "Swap Used"
-msgstr ""
-
-#: pkg/systemd/host.js:1500 pkg/systemd/index.html.h:29
-msgid "Cached"
-msgstr ""
-
-#: pkg/systemd/host.js:1501 pkg/docker/storage.jsx:313
-#: pkg/kubernetes/scripts/nodes.js:828 pkg/kubernetes/scripts/nodes.js:837
-#: pkg/systemd/index.html.h:30
-msgid "Used"
-msgstr ""
-
-#: pkg/systemd/host.js:1502 pkg/docker/storage.jsx:298
-#: pkg/docker/storage.jsx:320 pkg/systemd/index.html.h:31
-msgid "Free"
-msgstr ""
-
-#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
-msgid "unknown"
-msgstr ""
-
-#: pkg/systemd/init.js:269 pkg/systemd/services.html.h:17
-#: pkg/kubernetes/views/project-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:5
-msgid "Description"
-msgstr ""
-
-#: pkg/systemd/init.js:270
-msgid "Id"
-msgstr ""
-
-#: pkg/systemd/init.js:272
-msgid "Next Run"
-msgstr ""
-
-#: pkg/systemd/init.js:273
-msgid "Last Trigger"
-msgstr ""
-
-#: pkg/systemd/init.js:274 pkg/kubernetes/views/container-body.html.h:6
-#: pkg/kubernetes/views/details-page.html.h:8
-msgid "State"
-msgstr ""
-
-#: pkg/systemd/init.js:301
-msgid "Enabled"
-msgstr "Habilitado"
-
-#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
-msgid "Disabled"
-msgstr "Desabilitado"
-
-#: pkg/systemd/init.js:303
-msgid "Static"
-msgstr "Estático"
-
-#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
-msgid "$0 Template"
-msgstr "Modelo $0 "
-
-#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
-msgid "Start"
-msgstr "Iniciar"
-
-#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
-msgid "Stop"
-msgstr "Pare"
-
-#: pkg/systemd/init.js:518
-msgid "Reload"
-msgstr "Recarregar"
-
-#: pkg/systemd/init.js:519
-msgid "Reload or Restart"
-msgstr "Recarregar ou Reiniciar"
-
-#: pkg/systemd/init.js:520
-msgid "Try Restart"
-msgstr "Tente Reiniciar"
-
-#: pkg/systemd/init.js:521
-msgid "Reload or Try Restart"
-msgstr "Recarregue ou Tente Reiniciar"
-
-#: pkg/systemd/init.js:522
-msgid "Isolate"
-msgstr "Isolar"
-
-#: pkg/systemd/init.js:541
-msgid "Enable"
-msgstr "Habilitar"
-
-#: pkg/systemd/init.js:542
-msgid "Enable Forcefully"
-msgstr "Habilite Forçosamente"
-
-#: pkg/systemd/init.js:543
-msgid "Disable"
-msgstr "Desabilitar"
-
-#: pkg/systemd/init.js:544
-msgid "Preset"
-msgstr "Preset"
-
-#: pkg/systemd/init.js:545
-msgid "Preset Forcefully"
-msgstr "Preset Forçado"
-
-#: pkg/systemd/init.js:546
-msgid "Mask"
-msgstr "Máscara"
-
-#: pkg/systemd/init.js:547
-msgid "Mask Forcefully"
-msgstr "Máscara forçada"
-
-#: pkg/systemd/init.js:548
-msgid "Unmask"
-msgstr "Sem Máscara"
-
-#: pkg/systemd/init.js:621
-msgid "Since $0"
-msgstr "Desde $0"
-
-#: pkg/systemd/init.js:639
-msgid "This unit is an instance of the $0 template."
-msgstr "Esta unidade é uma instância do modelo $0."
-
-#: pkg/systemd/init.js:834
-#, fuzzy
-msgid "The user <b>$0</b> does not have permissions for creating timers"
-msgstr "Ao usuário <b>$0</b> não é permitido gerenciar servidores"
-
-#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
-#, fuzzy
-msgid "This field cannot be empty."
-msgstr "Namespace não pode estar vazio ."
-
-#: pkg/systemd/init.js:1147
-msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
-msgstr ""
-
-#: pkg/systemd/init.js:1169
-#, fuzzy
-msgid "Invalid number."
-msgstr "Porta inválida"
-
-#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
-msgid "Hour needs to be a number between 0-23"
-msgstr ""
-
-#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
-msgid "Minute needs to be a number between 0-59"
-msgstr ""
-
-#: pkg/systemd/init.js:1218
-#, fuzzy
-msgid "Invalid date format."
-msgstr "Porta inválida"
-
-#: pkg/systemd/init.js:1222
-msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
-msgstr ""
-
-#: pkg/systemd/logs.js:69
-msgid "Load earlier entries"
-msgstr "Carregar logs anteriores"
-
-#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
-#: pkg/systemd/logs.js:175
-msgid "Loading..."
-msgstr "Carregando..."
-
-#: pkg/systemd/logs.js:130
-msgid "Go to"
-msgstr "Ir para"
-
-#: pkg/systemd/logs.js:257
-msgid "Journal entry"
-msgstr ""
-
-#: pkg/systemd/logs.js:284
-msgid "Journal entry not found"
-msgstr ""
-
-#: pkg/tuned/dialog.js:94
-msgid "Tuned is not available"
-msgstr "Tuned não está disponível"
-
-#: pkg/tuned/dialog.js:96
-msgid "Tuned is not running"
-msgstr "Tuned não está em execução"
-
-#: pkg/tuned/dialog.js:98
-msgid "Tuned is off"
-msgstr "Tuned está fora"
-
-#: pkg/tuned/dialog.js:100
-msgid "This system is using the recommended profile"
-msgstr "Este sistema está usando o perfil recomendado"
-
-#: pkg/tuned/dialog.js:102
-msgid "This system is using a custom profile"
-msgstr "Este sistema está usando um perfil personalizado"
-
-#: pkg/tuned/dialog.js:114
-msgid "Communication with tuned has failed"
-msgstr "A comunicação com sintonizado falhou"
-
-#: pkg/tuned/dialog.js:133
-#, fuzzy
-msgid "Failed to disable tuned profile"
-msgstr "Falha para desabilitar perfil tuned"
-
-#: pkg/tuned/dialog.js:145
-msgid "Failed to switch profile"
-msgstr "Falha ao mudar de perfil"
-
-#: pkg/tuned/dialog.js:169
-msgid "Failed to enable tuned"
-msgstr "Falha ao habilitar tuned"
-
-#: pkg/tuned/dialog.js:171
-msgid "Failed to disable tuned"
-msgstr "Falha ao desabilitar tuned"
-
-#: pkg/tuned/dialog.js:191
-msgid "Change Performance Profile"
-msgstr "Perfil alterar o desempenho"
-
-#: pkg/tuned/dialog.js:200
-msgid "Change Profile"
-msgstr "Alterar o perfil"
-
-#: pkg/tuned/dialog.js:233 pkg/kubernetes/views/service-body.html.h:7
-#: pkg/kubernetes/views/pod-panel.html.h:2
-#: pkg/kubernetes/views/image-config.html.h:8
-#: pkg/kubernetes/views/imagestream-body.html.h:12
-#: pkg/kubernetes/views/pod-page.html.h:5
-msgid "None"
-msgstr "Nenhum"
-
-#: pkg/tuned/dialog.js:234
-msgid "Disable tuned"
-msgstr "Desabilitar tuned"
-
-#: pkg/tuned/dialog.js:262
-msgid "Tuned has failed to start"
-msgstr "Falhou ao iniciar Tuned"
-
-#: pkg/tuned/change-profile.jsx:52
-#, fuzzy
-msgid "recommended"
-msgstr "MII (Recomendado)"
-
-#: pkg/lib/journal.js:209
-msgid "[no data]"
-msgstr ""
-
-#: pkg/lib/journal.js:213
-msgid "[$0 bytes of binary data]"
-msgstr ""
-
-#: pkg/lib/journal.js:215
-msgid "[binary data]"
-msgstr ""
-
-#: pkg/lib/journal.js:241
-msgid "Reboot"
-msgstr "Reiniciar"
-
-#: pkg/lib/machine-dialogs.js:364
-msgid "This machine has already been added."
-msgstr "Esta máquina já foi adicionada"
-
-#: pkg/lib/machine-dialogs.js:380
-msgid ""
-"This version of cockpit-ws does not support connecting to a host with an "
-"alternate user or port"
-msgstr ""
-"Esta versão do cockpit-ws não suporta conectar a um host com um usuário ou "
-"porta alternativa"
-
-#: pkg/lib/machine-dialogs.js:386
-msgid "The IP address or host name cannot contain whitespace."
-msgstr "O enderço IP ou hostname não podem conter espações."
-
-#: pkg/lib/machine-dialogs.js:412
-msgid "Failed to add machine: $0"
-msgstr "Falha ao adicionar a máquina: $0"
-
-#: pkg/lib/machine-dialogs.js:429
-msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
-msgstr ""
-"Cockpit não pode contactar o host $0. Tenha certeza que o ssh  esteja "
-"rodando na porta $1, ou especifique outra porta no endereço."
-
-#: pkg/lib/machine-dialogs.js:447
-msgid "Enter IP address or host name"
-msgstr "Digite o endereço IP ou nome de host"
-
-#: pkg/lib/machine-dialogs.js:494
-msgid "Failed to edit machine: $0"
-msgstr "Falha ao editar a máquina: $0"
-
-#: pkg/lib/cockpit-components-dialog.jsx:136 pkg/sosreport/index.js:55
-#: pkg/systemd/services.html.h:34 pkg/lib/machine-sync-users.html.h:7
-#: pkg/lib/machine-add.html.h:5 pkg/lib/machine-change-port.html.h:6
-#: pkg/lib/machine-change-auth.html.h:11 pkg/storaged/index.html.h:22
-#: pkg/realmd/operation.html.h:10 pkg/kubernetes/views/node-delete.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:3
-#: pkg/kubernetes/views/pvc-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:3
-#: pkg/kubernetes/views/auth-form.html.h:13
-#: pkg/kubernetes/views/node-add.html.h:7
-#: pkg/kubernetes/views/user-group-add.html.h:5
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:4
-#: pkg/kubernetes/views/route-modify.html.h:3
-#: pkg/kubernetes/views/image-delete.html.h:3
-#: pkg/kubernetes/views/pv-delete.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:4
-#: pkg/kubernetes/views/item-delete.html.h:4
-#: pkg/kubernetes/views/add-user-dialog.html.h:8
-#: pkg/kubernetes/views/user-add-membership.html.h:8
-#: pkg/kubernetes/views/deploy.html.h:4
-#: pkg/kubernetes/views/user-modify.html.h:8
-#: pkg/kubernetes/views/pv-modify.html.h:21
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:5
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:3
-#: pkg/kubernetes/views/imagestream-delete.html.h:3
-#: pkg/kubernetes/views/user-remove-membership.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:7
-#: pkg/kubernetes/views/add-role-dialog.html.h:3
-#: pkg/kubernetes/views/service-modify.html.h:4
-#: pkg/kubernetes/views/project-delete.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:9
-#: pkg/kubernetes/views/user-group-remove.html.h:2
-#: pkg/playground/translate.html.h:2 pkg/dashboard/index.html.h:12
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: pkg/lib/cockpit-components-dialog.jsx:155
-msgid "Ok"
-msgstr ""
-
-#: pkg/lib/credentials.js:182
-msgid "No such file or directory"
-msgstr "Diretório ou arquivo não encontrado"
-
-#: pkg/lib/credentials.js:186
-msgid "The passwords do not match."
-msgstr "As senhas não batem."
-
-#: pkg/lib/credentials.js:191
-#, fuzzy
-msgid "Prompting via ssh-keygen timed out"
-msgstr "tempo excedido na tentativa via chave ssh"
-
-#: pkg/lib/credentials.js:213 pkg/users/local.js:78
-#, fuzzy
-msgid "Old password not accepted"
-msgstr "Senha antida não aceita"
-
-#: pkg/lib/credentials.js:223 pkg/users/local.js:112 pkg/users/local.js:144
-msgid "Failed to change password"
-msgstr "Falha ao mudar senha"
-
-#: pkg/lib/credentials.js:231 pkg/users/local.js:120
-msgid "New password was not accepted"
-msgstr "Nova senha não foi aceita"
-
-#: pkg/lib/credentials.js:248
-msgid "Not a valid private key"
-msgstr "Chave privada não válida"
-
-#: pkg/lib/credentials.js:251
-msgid "Prompting via ssh-add timed out"
-msgstr ""
-
-#: pkg/lib/credentials.js:274
-msgid "Invalid file permissions"
-msgstr "Permissão de arquivos inválida"
-
-#: pkg/lib/credentials.js:278
-msgid "Password not accepted"
-msgstr "Senha não aceita"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:22
-#: pkg/shell/index.html.h:27 pkg/storaged/index.html.h:52
-#: pkg/playground/jquery-patterns.html.h:2
-msgid "On"
-msgstr "Ligado"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:23
-#: pkg/shell/index.html.h:28 pkg/storaged/index.html.h:53
-#: pkg/playground/jquery-patterns.html.h:3
-msgid "Off"
-msgstr "Desligado"
-
-#: pkg/shell/base_index.js:670 pkg/users/local.js:1164
-#: pkg/docker/index.html.h:69 pkg/networkmanager/index.html.h:65
-msgid "Unexpected error"
-msgstr "Erro inesperado"
-
-#: pkg/shell/base_index.js:671
-msgid "Cockpit had an unexpected internal error. <br/><br/>"
-msgstr "Cockpit teve um erro inesperado. <br/><br/>"
-
-#: pkg/shell/base_index.js:672
-msgid "You can try restarting Cockpit by pressing refresh in your browser. "
-msgstr ""
-"Você pode tentar reiniciar o Cockpit pressionado o botão atualizar do seu "
-"browser."
-
-#: pkg/shell/base_index.js:673
-msgid "The javascript console contains details about this error "
-msgstr "A console Javascript contém detalhes sobre este erro."
-
-#: pkg/shell/base_index.js:674
-msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
-msgstr "(<b>Ctrl-Shift-J</b> na maioria dos browsers)."
-
-#: pkg/shell/indexes.js:126 pkg/shell/indexes.js:497 pkg/shell/simple.html.h:17
-msgid "Disconnected"
-msgstr "Desconectado"
-
-#: pkg/shell/indexes.js:253
-msgid "Machines"
-msgstr "Máquinas"
-
-#: pkg/shell/indexes.js:314
-msgid "The machine is restarting"
-msgstr "A máquina esta reiniciando"
-
-#: pkg/shell/indexes.js:317
-msgid "Connecting to the machine"
-msgstr "Conectando a máquina"
-
-#: pkg/shell/indexes.js:320
-msgid "Couldn't connect to the machine"
-msgstr "Não pode conectar a máquina"
-
-#: pkg/shell/indexes.js:322
-msgid "Cannot connect to an unknown machine"
-msgstr "Não pode conectar a uma máquina desconhecida"
-
-#: pkg/ostree/client.js:56
-msgid "Receiving delta parts"
-msgstr ""
-
-#: pkg/ostree/client.js:58
-msgid "Receiving metadata objects"
-msgstr ""
-
-#: pkg/ostree/client.js:61
-msgid "Receiving objects: $0%"
-msgstr ""
-
-#: pkg/ostree/client.js:64
-msgid "Writing objects"
-msgstr ""
-
-#: pkg/ostree/client.js:66
-msgid "Scanning metadata"
-msgstr ""
-
-#: pkg/ostree/client.js:500
-msgid "OS $0 not found"
-msgstr ""
-
-#: pkg/ostree/app.js:81
-msgid "Not authorized to update software on this system"
-msgstr ""
-
-#: pkg/ostree/app.js:83
-msgid "OSTree is not available on this system"
-msgstr ""
-
-#: pkg/ostree/app.js:101
-msgid "No OSTree deployments found"
-msgstr ""
-
-#: pkg/ostree/app.js:219
-msgid "Checking for updates"
-msgstr ""
+#: pkg/selinux/setroubleshoot-view.jsx:440
+msgid "$0 occurrence"
+msgid_plural "$1 occurrences"
+msgstr[0] ""
+msgstr[1] ""
 
 #: pkg/ostree/app.js:307
 msgid "$0 package"
@@ -792,686 +514,34 @@ msgstr ""
 msgid "$0 packages"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot.js:65
-msgid "Error while setting SELinux mode: '$0'"
-msgstr "Erro ao definir o modo de SELinux: '$0'"
+#: pkg/docker/util.js:124
+msgid "$0 shares"
+msgstr "$0 compartilhamentos"
 
-#: pkg/selinux/setroubleshoot.js:238
-msgid "Not connected"
-msgstr "Não conectado"
-
-#: pkg/selinux/setroubleshoot.js:275
-msgid "Error while connecting."
-msgstr "Erro ao se conectar."
-
-#: pkg/selinux/setroubleshoot-view.jsx:82
-msgid "Applying solution..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:90
-msgid "Solution applied successfully"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:97
-msgid "Solution failed"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:107
-msgid "Apply this solution"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:114
-msgid "Unable to apply this solution automatically"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:118
-msgid "solution details"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:309
-msgid "SELinux system status is unknown."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:317
-msgid "SELinux is disabled on the system."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:324
-msgid "The configured state is unknown, it might change on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:326
-msgid ""
-"Setting deviates from the configured state and will revert on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:330
-msgid "SELinux Policy"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:332
-msgid "Enforce policy:"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:382 pkg/kubernetes/index.html.h:10
-#: pkg/kubernetes/registry.html.h:5
-msgid "Connecting..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:385
-msgid ""
-"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
-"server is installed."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:400
-msgid "Occurred between $0 and $1"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:405
-msgid "Occurred $0"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:440
-msgid "$0 occurrence"
-msgid_plural "$1 occurrences"
+#: pkg/kubernetes/scripts/nodes.js:870
+#, c-format
+msgid "$0% Free"
+msgid_plural "$0% Free"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:478
-msgid "SELinux Access Control Errors"
+#: pkg/kubernetes/scripts/nodes.js:872
+msgid "$0% Used"
+msgid_plural "$0% Used"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/storaged/details.js:1765
+msgid "$0, $1 free"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:479
-msgid "No SELinux alerts."
+#: pkg/networkmanager/interfaces.js:2473
+msgid "$mtu"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-client.js:52
-msgid "Unable to start setroubleshootd"
-msgstr "Incapaz de iniciar setroubleshootd"
-
-#: pkg/selinux/setroubleshoot-client.js:157
-#, fuzzy
-msgid "Unable to get alert"
-msgstr "Incapaz de pegar o alerta"
-
-#: pkg/selinux/setroubleshoot-client.js:172
-msgid "Unable to run fix"
-msgstr "Incapaz de rodar a correção"
-
-#: pkg/selinux/setroubleshoot-client.js:187
-msgid "Failed to delete alert"
-msgstr "Falha ao deletar o alerta"
-
-#: pkg/selinux/setroubleshoot-client.js:192
-msgid "Error while deleting alert"
-msgstr "Erro ao deletar o alerta"
-
-#: pkg/storaged/dialog.js:267
-msgid "Size must be a number"
-msgstr ""
-
-#: pkg/storaged/dialog.js:269
-msgid "Size cannot be zero"
-msgstr ""
-
-#: pkg/storaged/dialog.js:271
-msgid "Size cannot be negative"
-msgstr ""
-
-#: pkg/storaged/dialog.js:273
-msgid "Size is too large"
-msgstr ""
-
-#: pkg/storaged/details.js:85
-msgid "Device $0 is mounted on $1"
-msgstr ""
-
-#: pkg/storaged/details.js:91
-msgid "Device $0 is a member of RAID Array $1"
-msgstr ""
-
-#: pkg/storaged/details.js:97
-msgid "Device $0 is a physical volume of $1"
-msgstr ""
-
-#: pkg/storaged/details.js:113
-msgid "Create partition on $0"
-msgstr ""
-
-#: pkg/storaged/details.js:115
-msgid "Format $0"
-msgstr "Formate $0"
-
-#: pkg/storaged/details.js:177
-msgid "XFS - Red Hat Enterprise Linux 7 default"
-msgstr ""
-
-#: pkg/storaged/details.js:178
-msgid "ext4 - Red Hat Enterprise Linux 6 default"
-msgstr ""
-
-#: pkg/storaged/details.js:179
-msgid "Encrypted XFS (LUKS)"
-msgstr "Encriptado XFS (LUKS)"
-
-#: pkg/storaged/details.js:180
-msgid "Encrypted EXT4 (LUKS)"
-msgstr "Encriptado EXT4 (LUKS)"
-
-#: pkg/storaged/details.js:181
-msgid "VFAT - Compatible with all systems and devices"
-msgstr ""
-
-#: pkg/storaged/details.js:182
-msgid "NTFS - Compatible with most systems"
-msgstr ""
-
-#: pkg/storaged/details.js:183
-msgid "Extended Partition"
-msgstr "Partição Extendida"
-
-#: pkg/storaged/details.js:185
-msgid "No Filesystem"
-msgstr "Nenhum Sistema de Arquivos"
-
-#: pkg/storaged/details.js:186
-msgid "Custom (Enter filesystem type)"
-msgstr ""
-
-#: pkg/storaged/details.js:192 pkg/storaged/details.js:664
-#: pkg/storaged/details.js:735 pkg/storaged/details.js:773
-#: pkg/storaged/details.js:909 pkg/storaged/index.html.h:20
-#: pkg/kubernetes/views/volumes-page.html.h:11
-msgid "Size"
-msgstr ""
-
-#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
-msgid "Erase"
-msgstr "Apagar"
-
-#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
-msgid "Don't overwrite existing data"
-msgstr ""
-
-#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
-msgid "Overwrite existing data with zeros"
-msgstr ""
-
-#: pkg/storaged/details.js:207 pkg/shell/index.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:4
-#: pkg/kubernetes/views/deploy.html.h:2 pkg/kubernetes/views/pv-modify.html.h:3
-msgid "Type"
-msgstr "Tipo"
-
-#: pkg/storaged/details.js:211 pkg/storaged/details.js:429
-#: pkg/storaged/details.js:709 pkg/storaged/details.js:731
-#: pkg/storaged/details.js:769 pkg/storaged/details.js:798
-#: pkg/storaged/details.js:864 pkg/storaged/overview.js:417
-#: pkg/storaged/overview.js:490 pkg/storaged/overview.js:624
-#: pkg/storaged/overview.js:702 pkg/storaged/index.html.h:18
-#: pkg/networkmanager/index.html.h:16
-#: pkg/kubernetes/views/project-listing.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:3
-#: pkg/kubernetes/views/volume-body.html.h:11
-#: pkg/kubernetes/views/containers-listing.html.h:2
-#: pkg/kubernetes/views/volumes-page.html.h:3
-#: pkg/kubernetes/views/pv-claim.html.h:1
-#: pkg/kubernetes/views/pv-modify.html.h:6
-#: pkg/kubernetes/views/image-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:15
-#: pkg/kubernetes/views/nodes-page.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:3
-#: pkg/kubernetes/views/details-page.html.h:4
-#: pkg/kubernetes/views/service-modify.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:3
-msgid "Name"
-msgstr "Nome"
-
-#: pkg/storaged/details.js:215
-msgid "Filesystem type"
-msgstr ""
-
-#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
-msgid "Passphrase"
-msgstr "Frase-senha"
-
-#: pkg/storaged/details.js:224
-#, fuzzy
-msgid "Passphrase cannot be empty"
-msgstr "Namespace não pode estar vazio ."
-
-#: pkg/storaged/details.js:229
-msgid "Confirm passphrase"
-msgstr ""
-
-#: pkg/storaged/details.js:232
-msgid "Passphrases do not match"
-msgstr ""
-
-#: pkg/storaged/details.js:237
-msgid "Store passphrase"
-msgstr ""
-
-#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
-#: pkg/storaged/details.js:1115
-msgid "Encryption Options"
-msgstr "Opções de Criptografia"
-
-#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
-msgid "Mounting"
-msgstr ""
-
-#: pkg/storaged/details.js:247 pkg/storaged/details.js:435
-#: pkg/subscriptions/subscriptions-register.jsx:101 pkg/docker/index.html.h:23
-#: pkg/kubernetes/views/image-config.html.h:2
-msgid "Default"
-msgstr "Padrão"
-
-#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
-msgid "Custom"
-msgstr "Personalizado"
-
-#: pkg/storaged/details.js:253 pkg/storaged/details.js:440
-#: pkg/storaged/index.html.h:19
-msgid "Mount Point"
-msgstr "Ponto de Montagem"
-
-#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
-msgid "Mount Options"
-msgstr "Opções de Montagem"
-
-#: pkg/storaged/details.js:266
-msgid "Create partition"
-msgstr "Criar partição"
-
-#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
-#: pkg/storaged/details.js:1142
-msgid "Format"
-msgstr "Formate"
-
-#: pkg/storaged/details.js:268
-msgid "Formatting a storage device will erase all data on it."
-msgstr "Formatar esse dispositivo apagará todos os dados contidos nele."
-
-#: pkg/storaged/details.js:335
-msgid "Format Disk $0"
-msgstr "Formate Disco $0"
-
-#: pkg/storaged/details.js:346
-msgid "Partitioning"
-msgstr "Particionamento"
-
-#: pkg/storaged/details.js:348
-msgid "Compatible with all systems and devices (MBR)"
-msgstr ""
-
-#: pkg/storaged/details.js:349
-msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr ""
-
-#: pkg/storaged/details.js:352
-msgid "No partitioning"
-msgstr ""
-
-#: pkg/storaged/details.js:358
-msgid "Formatting a disk will erase all data on it."
-msgstr "A formatação de um disco apaga todos os dados do mesmo."
-
-#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
-msgid "Filesystem Options"
-msgstr "Opções do Sistema de Arquivos"
-
-#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
-msgid "Apply"
-msgstr ""
-
-#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
-#: pkg/storaged/details.js:1110
-msgid "Unlock"
-msgstr "Destravar"
-
-#: pkg/storaged/details.js:527
-msgid "Stored Passphrase"
-msgstr "Frase-senha armazenada"
-
-#: pkg/storaged/details.js:531 pkg/kubernetes/views/volume-body.html.h:32
-msgid "Options"
-msgstr "Opções"
-
-#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
-msgid "Add Disks"
-msgstr ""
-
-#: pkg/storaged/details.js:567 pkg/storaged/details.js:933
-#: pkg/storaged/overview.js:448 pkg/storaged/overview.js:495
-#: pkg/storaged/index.html.h:55
-msgid "Disks"
-msgstr "Discos"
-
-#: pkg/storaged/details.js:579 pkg/storaged/details.js:948
-#: pkg/storaged/overview.js:501
-msgid "At least one disk is needed."
-msgstr ""
-
-#: pkg/storaged/details.js:584 pkg/storaged/details.js:953
-#: pkg/storaged/overview.js:629 pkg/storaged/overview.js:657
-#: pkg/lib/machine-add.html.h:6 pkg/kubernetes/views/node-add.html.h:8
-#: pkg/kubernetes/views/user-group-add.html.h:6
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:5
-#: pkg/kubernetes/views/add-user-dialog.html.h:9
-#: pkg/kubernetes/views/user-add-membership.html.h:9
-#: pkg/kubernetes/views/add-role-dialog.html.h:4
-msgid "Add"
-msgstr "Adicionar"
-
-#: pkg/storaged/details.js:625 pkg/storaged/details.js:821
-#: pkg/storaged/details.js:1016 pkg/docker/details.js:271
-#: pkg/docker/image.js:151 pkg/docker/containers-view.jsx:166
-msgid "Please confirm deletion of $0"
-msgstr "Por favor, confirme a remoção de $0"
-
-#: pkg/storaged/details.js:630 pkg/storaged/details.js:827
-#: pkg/storaged/details.js:1022 pkg/storaged/details.js:1151
-#: pkg/storaged/details.js:1616 pkg/storaged/details.js:1776
-#: pkg/docker/details.js:273 pkg/docker/image.js:153
-#: pkg/docker/containers-view.jsx:168 pkg/kubernetes/scripts/volumes.js:218
-#: pkg/users/index.html.h:9 pkg/kubernetes/views/node-delete.html.h:5
-#: pkg/kubernetes/views/pvc-delete.html.h:5
-#: pkg/kubernetes/views/image-delete.html.h:4
-#: pkg/kubernetes/views/pv-delete.html.h:5
-#: pkg/kubernetes/views/item-delete.html.h:5
-#: pkg/kubernetes/views/imagestream-delete.html.h:4
-#: pkg/kubernetes/views/user-remove-membership.html.h:3
-#: pkg/kubernetes/views/project-delete.html.h:3
-msgid "Delete"
-msgstr "Excluir"
-
-#: pkg/storaged/details.js:631
-msgid "Deleting a RAID device will erase all data on it."
-msgstr ""
-
-#: pkg/storaged/details.js:661
-msgid "Resize Logical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:673
-msgid "Resize Filesystem"
-msgstr ""
-
-#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
-msgid "Resize"
-msgstr "Re-dimensionar"
-
-#: pkg/storaged/details.js:690
-msgid "This logical volume cannot be made smaller."
-msgstr ""
-
-#: pkg/storaged/details.js:706
-msgid "Renamee Logical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
-#: pkg/storaged/details.js:1775
-msgid "Rename"
-msgstr "Renomear"
-
-#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
-msgid "Create Snapshot"
-msgstr "Criar Snapshot"
-
-#: pkg/storaged/details.js:745 pkg/storaged/details.js:781
-#: pkg/storaged/details.js:804 pkg/storaged/details.js:915
-#: pkg/storaged/overview.js:461 pkg/storaged/overview.js:506
-#: pkg/kubernetes/views/add-group-dialog.html.h:6
-#: pkg/kubernetes/views/project-modify.html.h:8
-msgid "Create"
-msgstr ""
-
-#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
-msgid "Create Thin Volume"
-msgstr "Criar Thin Volume"
-
-#: pkg/storaged/details.js:795
-msgid "Rename Volume Group"
-msgstr ""
-
-#: pkg/storaged/details.js:826
-msgid "Deleting a volume group will erase all data on it."
-msgstr "A exclusão de um grupo de volumes apaga todos os dados do mesmo."
-
-#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
-msgid "Create Logical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:869
-msgid "Purpose"
-msgstr ""
-
-#: pkg/storaged/details.js:871
-msgid "Block device for filesystems"
-msgstr ""
-
-#: pkg/storaged/details.js:874
-msgid "Pool for thinly provisioned volumes"
-msgstr ""
-
-#: pkg/storaged/details.js:1009
-msgid "Deleting a logical volume will delete all data in it."
-msgstr ""
-
-#: pkg/storaged/details.js:1012
-msgid "Deleting a partition will delete all data in it."
-msgstr "A exclusão de uma partição apaga todos os dados da mesma."
-
-#: pkg/storaged/details.js:1053 pkg/storaged/overview.js:689
-#: pkg/storaged/devices.js:119 pkg/users/local.js:1155
-#: pkg/systemd/services.html.h:14
-msgid "Error"
-msgstr "Erro"
-
-#: pkg/storaged/details.js:1099
-msgid "Mount"
-msgstr "Montar"
-
-#: pkg/storaged/details.js:1100
-msgid "Unmount"
-msgstr "Desmontar"
-
-#: pkg/storaged/details.js:1109
-msgid "Lock"
-msgstr "Travar"
-
-#: pkg/storaged/details.js:1127
-msgid "Activate"
-msgstr "Ativar"
-
-#: pkg/storaged/details.js:1130
-msgid "Deactivate"
-msgstr "Desativar"
-
-#: pkg/storaged/details.js:1221
-msgctxt "storage-id-desc"
-msgid "$0 File System"
-msgstr "$0 Sistema de Arquivos"
-
-#: pkg/storaged/details.js:1224
-msgctxt "storage-id-desc"
-msgid "Linux MD-RAID Component"
-msgstr "Linux MD-RAID Componente"
-
-#: pkg/storaged/details.js:1226
-msgctxt "storage-id-desc"
-msgid "LVM2 Physical Volume"
-msgstr "LVM2 Volume Físico"
-
-#: pkg/storaged/details.js:1228
-msgctxt "storage-id-desc"
-msgid "RAID Member"
-msgstr "RAID Membro"
-
-#: pkg/storaged/details.js:1245
-msgctxt "storage-id-desc"
-msgid "LUKS Encrypted"
-msgstr "LUKS Encriptado"
-
-#: pkg/storaged/details.js:1247
-msgctxt "storage-id-desc"
-msgid "Encrypted"
-msgstr "Encriptado"
-
-#: pkg/storaged/details.js:1251
-msgctxt "storage-id-desc"
-msgid "Swap Space"
-msgstr "Swap Espaço"
-
-#: pkg/storaged/details.js:1253
-msgctxt "storage-id-desc"
-msgid "Other Data"
-msgstr "Outros Dados"
-
-#: pkg/storaged/details.js:1256
-msgctxt "storage-id-desc"
-msgid "Unrecognized Data"
-msgstr "Dados não reconhecidos"
-
-#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
-msgid "$size $partition"
-msgstr "$tamanho $partição"
-
-#: pkg/storaged/details.js:1278
-msgid "mounted on $0"
-msgstr "montado em $0"
-
-#: pkg/storaged/details.js:1280
-msgid "not mounted"
-msgstr "não montado"
-
-#: pkg/storaged/details.js:1284
-msgid "unlocked"
-msgstr "desbloqueado"
-
-#: pkg/storaged/details.js:1286
-msgid "locked"
-msgstr "bloqueado"
-
-#: pkg/storaged/details.js:1367
-msgid "$0 Free Space for Logical Partitions"
-msgstr "$0 Espaço Livre para Partições Lógicas"
-
-#: pkg/storaged/details.js:1370
-msgid "$0 Free Space for Primary Partitions"
-msgstr "$0 Espaço Livre para Partições Primarias"
-
-#: pkg/storaged/details.js:1375
-msgid "$0 Free Space"
-msgstr "$0 Espaço Livre"
-
-#: pkg/storaged/details.js:1379
-msgid "Create Partition"
-msgstr "Criar Partição"
-
-#: pkg/storaged/details.js:1387
-msgid "$0 Extended Partition"
-msgstr "$0 Partição Extendida"
-
-#: pkg/storaged/details.js:1424
-msgid "Logical Partition"
-msgstr "Partição Lógica"
-
-#: pkg/storaged/details.js:1426
-msgid "Primary Partition"
-msgstr "Partição Primária"
-
-#: pkg/storaged/details.js:1428 pkg/kubernetes/views/volume-body.html.h:5
-msgid "Partition"
-msgstr "Partição"
-
-#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
-msgid "Content"
-msgstr "Conteúdo"
-
-#: pkg/storaged/details.js:1533
-msgid "RAID 0"
-msgstr "RAID 0"
-
-#: pkg/storaged/details.js:1534
-msgid "RAID 1"
-msgstr "RAID 1"
-
-#: pkg/storaged/details.js:1535
-msgid "RAID 4"
-msgstr "RAID 4"
-
-#: pkg/storaged/details.js:1536
-msgid "RAID 5"
-msgstr "RAID 5"
-
-#: pkg/storaged/details.js:1537
-msgid "RAID 6"
-msgstr "RAID 6"
-
-#: pkg/storaged/details.js:1538
-msgid "RAID 10"
-msgstr "RAID 10"
-
-#: pkg/storaged/details.js:1539
-msgid "RAID ($0)"
-msgstr ""
-
-#: pkg/storaged/details.js:1544
-msgid "$0 Disks"
-msgstr "$0 Discos"
-
-#: pkg/storaged/details.js:1546
-msgid "$0 Chunk Size"
-msgstr ""
-
-#: pkg/storaged/details.js:1574 pkg/ostree/index.html.h:7
-msgid "Running"
-msgstr "Executando"
-
-#: pkg/storaged/details.js:1574
-msgid "Not running"
-msgstr "Não está rodando"
-
-#: pkg/storaged/details.js:1592
-msgid "FAILED"
-msgstr "FALHOU"
-
-#: pkg/storaged/details.js:1593
-msgid "In Sync"
-msgstr "Em Sincronização"
-
-#: pkg/storaged/details.js:1594
-#, fuzzy
-msgid "Spare"
-msgstr "Disponível"
-
-#: pkg/storaged/details.js:1594
-msgid "Recovering"
-msgstr "Recuperação"
-
-#: pkg/storaged/details.js:1595
-msgid "Write-mostly"
-msgstr "Maioria-Escrita"
-
-#: pkg/storaged/details.js:1596
-msgid "Blocked"
-msgstr "Bloqueado"
-
-#: pkg/storaged/details.js:1597
-msgid "Unknown ($0)"
-msgstr "Desconhecido ($0)"
-
-#: pkg/storaged/details.js:1614
-msgid "Start Scrubbing"
-msgstr "Iniciando Scrubbing"
-
-#: pkg/storaged/details.js:1615
-msgid "Stop Scrubbing"
-msgstr "Parando Scrubbing"
+#: pkg/storaged/utils.js:157
+msgid "$name (from $host)"
+msgstr "$nome(vindo de $host)"
 
 #: pkg/storaged/details.js:1653
 msgid "$size $desc"
@@ -1486,217 +556,2812 @@ msgstr "$size $desc<br/>${percent}% cheio"
 msgid "$size $desc<br/>($state)"
 msgstr "$size $desc<br/>($state)"
 
-#: pkg/storaged/details.js:1692
-msgid "active, but unsupported"
-msgstr "ativo, mas não suportado"
+#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
+msgid "$size $partition"
+msgstr "$tamanho $partição"
 
-#: pkg/storaged/details.js:1692
-msgid "inactive"
-msgstr "inativo"
+#: pkg/docker/details.js:144
+msgid "${hip}:${hport} -> $cport"
+msgstr "${hip}:${hport} -> $cport"
 
-#: pkg/storaged/details.js:1711
-msgid "$0 Free Space for Logical Volumes"
-msgstr "$0 Espaço Livres Para Volumes Lógicos"
-
-#: pkg/storaged/details.js:1751
-msgid "The last physical volume of a volume group cannot be removed."
+#: pkg/subscriptions/subscriptions-client.js:198
+msgid "'Organization' required to register."
 msgstr ""
 
-#: pkg/storaged/details.js:1756
-msgid ""
-"There is not enough free space elsewhere to remove this physical volume.  At "
-"least $0 more free space is needed."
+#: pkg/subscriptions/subscriptions-client.js:202
+msgid "'Organization' required when using activation keys."
 msgstr ""
 
-#: pkg/storaged/details.js:1765
-msgid "$0, $1 free"
+#: pkg/shell/base_index.js:674
+msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
+msgstr "(<b>Ctrl-Shift-J</b> na maioria dos browsers)."
+
+#: pkg/storaged/overview.js:440
+msgid "1 MiB"
 msgstr ""
 
-#: pkg/storaged/details.js:1792
-msgid "Logical Volumes"
-msgstr "Volumes Lógicos"
-
-#: pkg/storaged/details.js:1822 pkg/docker/details.js:177
-#: pkg/docker/image.js:112
-msgid "Not found"
-msgstr "Não encontrado"
-
-#: pkg/storaged/overview.js:180
-msgctxt "storage"
-msgid "Hard Disk"
-msgstr "Hard Disk"
-
-#: pkg/storaged/overview.js:182
-msgctxt "storage"
-msgid "Solid-State Disk"
-msgstr "Solid-State Disk"
-
-#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
-msgctxt "storage"
-msgid "Removable Drive"
-msgstr "Removable Drive"
-
-#: pkg/storaged/overview.js:189
-msgctxt "storage"
-msgid "Optical Drive"
-msgstr "Optical Drive"
-
-#: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
-msgctxt "storage"
-msgid "Drive"
-msgstr "Drive"
-
-#: pkg/storaged/overview.js:253
-msgid "$0 Block Device"
+#: pkg/systemd/index.html:459 pkg/systemd/index.html:463
+msgid "1 Minute"
 msgstr ""
 
-#: pkg/storaged/overview.js:414
-msgid "Create RAID Device"
-msgstr "Criar dispositivo RAID"
-
-#: pkg/storaged/overview.js:420
-msgid "RAID Level"
-msgstr "Nível de RAID"
-
-#: pkg/storaged/overview.js:422
-msgid "RAID 0 (Stripe)"
-msgstr "RAID 0 (Distribuição)"
-
-#: pkg/storaged/overview.js:423
-msgid "RAID 1 (Mirror)"
-msgstr "RAID 1 (Espelhamento)"
-
-#: pkg/storaged/overview.js:424
-msgid "RAID 4 (Dedicated Parity)"
-msgstr "RAID 4 (Paridade Dedicada)"
-
-#: pkg/storaged/overview.js:425
-msgid "RAID 5 (Distributed Parity)"
-msgstr "RAID 5 (Paridade Distribuída)"
-
-#: pkg/storaged/overview.js:426
-msgid "RAID 6 (Double Distributed Parity)"
-msgstr "RAID 6 (Paridade Duplamente Distribuída)"
-
-#: pkg/storaged/overview.js:427
-msgid "RAID 10 (Stripe of Mirrors)"
-msgstr "RAID 10 (Distribuição de Espelhos)"
-
-#: pkg/storaged/overview.js:431
-msgid "Chunk Size"
-msgstr "Tamanho do Bloco"
-
-#: pkg/storaged/overview.js:433
-msgid "4 KiB"
+#: pkg/storaged/index.html:312 pkg/networkmanager/index.html:55
+#: pkg/networkmanager/index.html:501
+msgid "1 day"
 msgstr ""
 
-#: pkg/storaged/overview.js:434
-msgid "8 KiB"
+#: pkg/storaged/index.html:310 pkg/networkmanager/index.html:53
+#: pkg/networkmanager/index.html:499
+msgid "1 hour"
+msgstr ""
+
+#: pkg/storaged/index.html:313 pkg/networkmanager/index.html:56
+#: pkg/networkmanager/index.html:502
+msgid "1 week"
+msgstr ""
+
+#: pkg/playground/translate.html:190
+msgid "1% Free"
+msgid_plural "{{$count}}% Free"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/storaged/overview.js:438
+msgid "128 KiB"
 msgstr ""
 
 #: pkg/storaged/overview.js:435
 msgid "16 KiB"
 msgstr ""
 
+#: pkg/storaged/overview.js:441
+msgid "2 MiB"
+msgstr ""
+
+#: pkg/systemd/index.html:465
+msgid "20 Minutes"
+msgstr ""
+
 #: pkg/storaged/overview.js:436
 msgid "32 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:437
-msgid "64 KiB"
+#: pkg/storaged/overview.js:433
+msgid "4 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:438
-msgid "128 KiB"
+#: pkg/systemd/index.html:466
+msgid "40 Minutes"
+msgstr ""
+
+#: pkg/systemd/index.html:464
+msgid "5 Minutes"
+msgstr ""
+
+#: pkg/storaged/index.html:309 pkg/networkmanager/index.html:52
+#: pkg/networkmanager/index.html:498
+msgid "5 minutes"
 msgstr ""
 
 #: pkg/storaged/overview.js:439
 msgid "512 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:440
-msgid "1 MiB"
+#: pkg/storaged/index.html:311 pkg/networkmanager/index.html:54
+#: pkg/networkmanager/index.html:500
+msgid "6 hours"
 msgstr ""
 
-#: pkg/storaged/overview.js:441
-msgid "2 MiB"
+#: pkg/systemd/index.html:467
+msgid "60 Minutes"
+msgstr ""
+
+#: pkg/storaged/overview.js:437
+msgid "64 KiB"
+msgstr ""
+
+#: pkg/storaged/overview.js:434
+msgid "8 KiB"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1826
+msgid "802.3ad"
+msgstr "802.3ad"
+
+#: pkg/networkmanager/interfaces.js:1843
+#, fuzzy
+msgid "802.3ad LACP"
+msgstr "802.3ad"
+
+#: pkg/systemd/services.html:446
+msgid ":"
+msgstr ""
+
+#: pkg/storaged/utils.js:220
+msgid "<span>Encrypted $0</span>"
+msgstr ""
+
+#: pkg/storaged/utils.js:212
+msgid "<span>Encrypted Logical Volume of $0</span>"
+msgstr ""
+
+#: pkg/storaged/utils.js:214
+msgid "<span>Encrypted Partition of $0</span>"
+msgstr ""
+
+#: pkg/storaged/utils.js:216
+msgid "<span>Logical Volume of $0</span>"
+msgstr ""
+
+#: pkg/storaged/utils.js:218
+msgid "<span>Partition of $0</span>"
+msgstr ""
+
+#: pkg/lib/machine-not-supported.html:5
+msgid ""
+"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
+"strong}}."
+msgstr ""
+
+#: cockpit.desktop.in.h:2
+msgid "A user interface for GNU/Linux servers"
+msgstr "A interface de usuário para servidores GNU/Linux"
+
+#: pkg/networkmanager/interfaces.js:1834
+msgid "ARP"
+msgstr "ARP"
+
+#: pkg/networkmanager/interfaces.js:2502
+msgid "ARP Monitoring"
+msgstr "ARP Monitoramento"
+
+#: pkg/networkmanager/interfaces.js:1855
+#, fuzzy
+msgid "ARP Ping"
+msgstr "ARP Monitoramento"
+
+#: pkg/kubernetes/scripts/volumes.js:193
+msgid "AWS Elastic Block Store"
+msgstr ""
+
+#: pkg/shell/simple.html:41 pkg/shell/simple.html:67 pkg/shell/index.html:41
+#: pkg/shell/index.html:80 pkg/shell/stub.html:41 pkg/shell/stub.html:73
+msgid "About Cockpit"
+msgstr ""
+
+#: pkg/users/index.html:105 pkg/users/index.html:191
+msgid "Access"
+msgstr "Acesso"
+
+#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pv-claim.html:9
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-body.html:9
+msgid "Access Modes"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:49
+#: pkg/kubernetes/views/imagestream-body.html:11
+msgid "Access Policy"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:191
+#, fuzzy
+msgid "Access denied"
+msgstr "Acesso"
+
+#: pkg/shell/index.html:45
+msgid "Account Settings"
+msgstr ""
+
+#: pkg/users/index.html:63
+msgid "Account not available or cannot be edited."
+msgstr ""
+
+#: pkg/users/index.html:71
+msgid "Accounts"
+msgstr ""
+
+#: pkg/users/local.js:284 pkg/users/local.js:594
+msgctxt "page-title"
+msgid "Accounts"
+msgstr "Contas"
+
+#: pkg/storaged/details.js:1127
+msgid "Activate"
+msgstr "Ativar"
+
+#: pkg/storaged/jobs.js:148
+msgid "Activating $target"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:164
+#, fuzzy
+msgid "Activation Key"
+msgstr "Ativar"
+
+#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
+msgid "Active"
+msgstr "Ativo"
+
+#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
+msgid "Active Backup"
+msgstr "Backup Ativo"
+
+#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
+msgid "Actual"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1828
+msgid "Adaptive load balancing"
+msgstr "Balanceamento de carga dinâmico"
+
+#: pkg/networkmanager/interfaces.js:1827
+msgid "Adaptive transmit load balancing"
+msgstr "Transmissão dinâmica de balanceamento de carga"
+
+#: pkg/kubernetes/views/add-user-dialog.html:31
+#: pkg/kubernetes/views/node-add.html:50
+#: pkg/kubernetes/views/user-add-membership.html:53
+#: pkg/kubernetes/views/add-member-role-dialog.html:61
+#: pkg/kubernetes/views/user-group-add.html:32
+#: pkg/kubernetes/views/add-role-dialog.html:8 pkg/lib/machine-add.html:43
+msgid "Add"
+msgstr "Adicionar"
+
+#: pkg/networkmanager/interfaces.js:2836
+msgid "Add $0"
+msgstr ""
+
+#: pkg/docker/storage.jsx:363
+msgid "Add Additional Storage"
+msgstr ""
+
+#: pkg/networkmanager/index.html:86
+msgid "Add Bond"
+msgstr ""
+
+#: pkg/networkmanager/index.html:88
+msgid "Add Bridge"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:3
+msgid "Add Cluster Node"
+msgstr ""
+
+#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
+msgid "Add Disks"
+msgstr ""
+
+#: pkg/kubernetes/views/add-group-dialog.html:3
+msgid "Add Group"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:34
+msgid "Add Kubernetes Node"
+msgstr ""
+
+#: pkg/lib/machine-add.html:4
+msgid "Add Machine to Dashboard"
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:38
+#: pkg/kubernetes/views/add-member-role-dialog.html:4
+#: pkg/kubernetes/views/group-panel.html:29
+#: pkg/kubernetes/views/user-group-add.html:3
+#: pkg/kubernetes/views/project-body.html:108
+msgid "Add Member"
+msgstr ""
+
+#: pkg/kubernetes/views/user-panel.html:76
+#: pkg/kubernetes/views/user-body.html:67
+msgid "Add Membership"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:11
+#: pkg/kubernetes/views/auth-form.html:20
+msgid "Add New Cluster"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:67
+#: pkg/kubernetes/views/auth-form.html:76
+msgid "Add New User"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:3
+msgid "Add Role"
+msgstr ""
+
+#: pkg/networkmanager/index.html:87
+msgid "Add Team"
+msgstr ""
+
+#: pkg/kubernetes/views/add-user-dialog.html:3
+#: pkg/kubernetes/views/project-listing.html:83
+msgid "Add User"
+msgstr ""
+
+#: pkg/networkmanager/index.html:89
+msgid "Add VLAN"
+msgstr ""
+
+#: pkg/storaged/overview.js:515
+msgid "Add iSCSI Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/user-add-membership.html:3
+msgid "Add membership"
+msgstr ""
+
+#: pkg/users/index.html:351
+msgid "Add public key"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2833
+msgid "Adding <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/users/authorized-keys.js:108
+msgid "Adding key"
+msgstr ""
+
+#: pkg/storaged/jobs.js:153
+msgid "Adding physical volume to $target"
+msgstr ""
+
+#: pkg/docker/index.html:329
+msgid "Additional Storage"
+msgstr ""
+
+#: pkg/ostree/index.html:121 pkg/ostree/index.html:140
+msgid "Additions"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:8
+#: pkg/kubernetes/views/dashboard-page.html:157
+#: pkg/kubernetes/views/details-page.html:174
+#: pkg/kubernetes/views/nodes-page.html:43
+#: pkg/kubernetes/views/auth-form.html:29 pkg/kubernetes/views/node-body.html:5
+#: pkg/lib/machine-add.html:11
+msgid "Address"
+msgstr "Endereço"
+
+#: pkg/kubernetes/views/details-page.html:37
+msgid "Addresses"
+msgstr "Endereços"
+
+#: pkg/kubernetes/views/service-modify.html:25
+msgid "Adjust"
+msgstr "Ajustar"
+
+#: pkg/kubernetes/views/pv-modify.html:3
+msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-modify.html:3
+msgid "Adjust Replication Controller {{ item.metadata.name }}"
+msgstr ""
+
+#: pkg/kubernetes/views/route-modify.html:3
+msgid "Adjust Route"
+msgstr ""
+
+#: pkg/kubernetes/views/service-modify.html:3
+msgid "Adjust Service"
+msgstr "Ajuste de serviço"
+
+#: pkg/kubernetes/views/project-body.html:56
+msgid "Admin"
+msgstr ""
+
+#: pkg/systemd/services.html:389 pkg/systemd/services.html:393
+msgid "After system boot"
+msgstr ""
+
+#: pkg/systemd/logs.html:50
+msgid "All"
+msgstr "Todos"
+
+#: pkg/kubernetes/views/filter-project.html:4
+msgid "All Projects"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:6
+msgid "All Types"
+msgstr ""
+
+#: pkg/docker/storage.jsx:366
+msgid ""
+"All data on selected disks will be erased and disks will be added to the "
+"storage pool."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:112
+msgid "All healthy"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:74
+msgid "All images"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:69
+msgid "All in use"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:37
+msgid "All running"
+msgstr ""
+
+#: pkg/docker/index.html:569
+msgid "Always"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-meta.html:2
+#: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/image-meta.html:9
+#: pkg/kubernetes/views/node-body.html:57
+msgid "Annotations"
+msgstr ""
+
+#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
+msgid "Apply"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:107
+msgid "Apply this solution"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:82
+msgid "Applying solution..."
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:12
+msgid "Architecture"
+msgstr ""
+
+#: pkg/storaged/index.html:451
+msgctxt "storage"
+msgid "Assessment"
+msgstr "Avaliação"
+
+#: pkg/systemd/index.html:81
+msgid "Asset Tag"
 msgstr ""
 
 #: pkg/storaged/overview.js:455
 msgid "At least $0 disks are needed."
 msgstr ""
 
-#: pkg/storaged/overview.js:487
-msgid "Create Volume Group"
-msgstr "Criar Grupo de Volumes"
-
-#: pkg/storaged/overview.js:515
-msgid "Add iSCSI Portal"
+#: pkg/storaged/overview.js:501 pkg/storaged/details.js:579
+#: pkg/storaged/details.js:948
+msgid "At least one disk is needed."
 msgstr ""
 
-#: pkg/storaged/overview.js:518
-msgid "Server Address"
+#: pkg/systemd/services.html:394
+msgid "At specific time"
 msgstr ""
 
-#: pkg/storaged/overview.js:521
-#, fuzzy
-msgid "Server address cannot be empty."
-msgstr "Namespace não pode estar vazio ."
+#: pkg/networkmanager/interfaces.js:813
+msgid "Authenticating"
+msgstr "Autenticando"
 
-#: pkg/storaged/overview.js:533 pkg/realmd/operation.html.h:11
-msgid "Next"
-msgstr "Próximo"
-
-#: pkg/storaged/overview.js:577 pkg/storaged/overview.js:668
-#: pkg/subscriptions/subscriptions-client.js:194
-msgid "Invalid username or password"
+#: pkg/realmd/operation.html:34 pkg/shell/index.html:48
+#: pkg/shell/index.html:159 pkg/kubernetes/views/auth-form.html:85
+#: pkg/lib/machine-change-auth.html:32
+msgid "Authentication"
 msgstr ""
 
-#: pkg/storaged/overview.js:582
-msgid "Unknown host name"
+#: pkg/lib/machine-auth-failed.html:2
+msgid "Authentication Failed"
 msgstr ""
 
-#: pkg/storaged/overview.js:586
-msgid "Unable to reach server"
+#: pkg/docker/index.html:730 pkg/kubernetes/views/image-body.html:12
+#: pkg/kubernetes/views/image-listing.html:15
+msgid "Author"
+msgstr "Autor"
+
+#: pkg/users/index.html:130
+msgid "Authorized Public SSH Keys"
+msgstr ""
+
+#: pkg/networkmanager/index.html:165
+msgid "Automatic"
+msgstr "Automático"
+
+#: pkg/networkmanager/interfaces.js:1814
+msgid "Automatic (DHCP only)"
+msgstr "Automático (apenas DHCP)"
+
+#: pkg/networkmanager/interfaces.js:1804
+msgid "Automatic (DHCP)"
+msgstr "Automático (DHCP)"
+
+#: pkg/systemd/index.html:406
+msgid "Automatically using NTP"
+msgstr ""
+
+#: pkg/systemd/index.html:407
+msgid "Automatically using specific NTP servers"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:66
+msgid "Available"
 msgstr ""
 
 #: pkg/storaged/overview.js:619
 msgid "Available targets on $0"
 msgstr ""
 
-#: pkg/storaged/overview.js:623 pkg/systemd/services.html.h:2
-msgid "Targets"
-msgstr "Alvos"
+#: pkg/dashboard/index.html:177
+msgid "Avatar"
+msgstr ""
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-add.html.h:2
-#: pkg/kubernetes/views/node-body.html.h:2
-#: pkg/kubernetes/views/auth-form.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:16
-#: pkg/kubernetes/views/nodes-page.html.h:7
-#: pkg/kubernetes/views/details-page.html.h:19
-msgid "Address"
-msgstr "Endereço"
+#: pkg/kubernetes/scripts/volumes.js:207
+msgid "Azure"
+msgstr ""
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-change-port.html.h:5
-msgid "Port"
+#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
+msgid "Bad data passed for passwd1 mechanism"
+msgstr "Dados corrompidos passaram por passwd1 mecanismo"
+
+#: pkg/networkmanager/index.html:389
+msgid "Balancer"
+msgstr ""
+
+#: pkg/storaged/index.html:560
+msgctxt "storage"
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: pkg/storaged/index.html:414
+msgid "Block Device"
+msgstr "Dispositivos de Bloco"
+
+#: pkg/storaged/details.js:871
+msgid "Block device for filesystems"
+msgstr ""
+
+#: pkg/storaged/details.js:1596
+msgid "Blocked"
+msgstr "Bloqueado"
+
+#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
+#: pkg/networkmanager/interfaces.js:2507
+msgid "Bond"
+msgstr "Bond"
+
+#: pkg/networkmanager/index.html:596
+msgid "Bond Settings"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:17
+msgid "Boot ID"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
+#: pkg/networkmanager/interfaces.js:2584
+msgid "Bridge"
+msgstr "Bridge"
+
+#: pkg/networkmanager/index.html:708
+msgid "Bridge Port Settings"
+msgstr ""
+
+#: pkg/networkmanager/index.html:680
+msgid "Bridge Settings"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2605
+msgid "Bridge port"
+msgstr "Bridge porta"
+
+#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
+msgid "Broadcast"
+msgstr "Broadcast"
+
+#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#, fuzzy
+msgid "Broken configuration"
+msgstr "Configuração desconhecida"
+
+#: pkg/kubernetes/views/image-body.html:16
+msgid "Built"
+msgstr ""
+
+#: pkg/dashboard/index.html:70
+msgid "CPU"
+msgstr ""
+
+#: pkg/systemd/host.js:1381
+msgctxt "page-title"
+msgid "CPU Status"
+msgstr "Status de CPU"
+
+#: pkg/kubernetes/scripts/nodes.js:712
+msgid "CPU Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:490 pkg/docker/index.html:669
+msgid "CPU priority"
+msgstr "Prioridade de CPU"
+
+#: pkg/systemd/index.html:247
+msgid "Cached"
+msgstr ""
+
+#: pkg/docker/index.html:63
+msgid "Can&rsquo;t connect to Docker"
+msgstr ""
+
+#: pkg/systemd/services.html:465 pkg/dashboard/index.html:189
+#: pkg/playground/translate.html:40 pkg/playground/translate.html:174
+#: pkg/realmd/operation.html:90 pkg/kubernetes/views/pv-modify.html:202
+#: pkg/kubernetes/views/item-delete.html:10
+#: pkg/kubernetes/views/add-user-dialog.html:30
+#: pkg/kubernetes/views/project-modify.html:71
+#: pkg/kubernetes/views/node-add.html:49
+#: pkg/kubernetes/views/pvc-delete.html:14
+#: pkg/kubernetes/views/node-delete.html:14
+#: pkg/kubernetes/views/imagestream-modify.html:96
+#: pkg/kubernetes/views/imagestream-delete.html:7
+#: pkg/kubernetes/views/user-modify.html:30
+#: pkg/kubernetes/views/add-group-dialog.html:20
+#: pkg/kubernetes/views/project-delete.html:8
+#: pkg/kubernetes/views/service-modify.html:24
+#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/kubernetes/views/user-group-remove.html:9
+#: pkg/kubernetes/views/user-add-membership.html:52
+#: pkg/kubernetes/views/add-member-role-dialog.html:60
+#: pkg/kubernetes/views/group-delete.html:20
+#: pkg/kubernetes/views/image-delete.html:7 pkg/kubernetes/views/deploy.html:61
+#: pkg/kubernetes/views/user-group-add.html:31
+#: pkg/kubernetes/views/auth-form.html:128
+#: pkg/kubernetes/views/auth-rejected-cert.html:31
+#: pkg/kubernetes/views/replicationcontroller-modify.html:16
+#: pkg/kubernetes/views/pv-delete.html:10
+#: pkg/kubernetes/views/add-role-dialog.html:7
+#: pkg/kubernetes/views/route-modify.html:16
+#: pkg/kubernetes/views/user-delete.html:24
+#: pkg/kubernetes/views/remove-role-dialog.html:7 pkg/storaged/index.html:289
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:79
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: pkg/shell/indexes.js:322
+msgid "Cannot connect to an unknown machine"
+msgstr "Não pode conectar a uma máquina desconhecida"
+
+#: src/ws/cockpitcertificate.c:359
+msgid "Cannot decrypt PEM-encoded private key"
+msgstr "Não é possível decifrar a chave privada codificado em PEM"
+
+#: src/base1/cockpit.js:3707
+msgid "Cannot forward login credentials"
+msgstr ""
+
+#: pkg/realmd/operation.js:417
+msgid "Cannot join a domain because realmd is not available on this system"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:44
+#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pv-body.html:13
+msgid "Capacity"
+msgstr ""
+
+#: pkg/storaged/index.html:443 pkg/storaged/index.html:519
+#: pkg/storaged/index.html:551 pkg/storaged/index.html:630
+msgctxt "storage"
+msgid "Capacity"
+msgstr "Capacidade"
+
+#: pkg/networkmanager/interfaces.js:2276
+msgid "Carrier"
+msgstr "Sinal"
+
+#: pkg/kubernetes/scripts/volumes.js:203
+msgid "Ceph Filesystem Mount"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:97
+msgid "Ceph Monitors"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:204
+#: pkg/kubernetes/views/project-modify.html:74
+#: pkg/kubernetes/views/replicationcontroller-modify.html:17
+#: pkg/kubernetes/views/route-modify.html:17
+msgid "Change"
+msgstr ""
+
+#: pkg/shell/index.html:278
+msgid "Change Password"
+msgstr ""
+
+#: pkg/tuned/dialog.js:191
+msgid "Change Performance Profile"
+msgstr "Perfil alterar o desempenho"
+
+#: pkg/tuned/dialog.js:200
+msgid "Change Profile"
+msgstr "Alterar o perfil"
+
+#: pkg/kubernetes/views/user-modify.html:3
+msgid "Change User"
 msgstr ""
 
 #: pkg/storaged/overview.js:699
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
-#: pkg/storaged/overview.js:707 pkg/kubernetes/views/route-modify.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:22
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:4
-#: pkg/kubernetes/views/project-modify.html.h:9
-msgid "Change"
+#: pkg/kubernetes/views/imagestream-modify.html:4
+msgid "Change image stream"
 msgstr ""
 
-#: pkg/storaged/utils.js:88
-msgctxt "format-bytes"
-msgid "bytes"
-msgstr "bytes"
+#: pkg/kubernetes/views/project-modify.html:10
+msgid "Change project"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2872
+msgid "Change the settings"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2870
+msgid "Changing the settings will break the connection to the server, "
+msgstr ""
+
+#: pkg/ostree/index.html:48
+msgid "Check for updates"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:817
+msgid "Checking IP"
+msgstr "Checando IP"
+
+#: pkg/storaged/jobs.js:143
+#, fuzzy
+msgid "Checking RAID Device $target"
+msgstr "Criar dispositivo RAID"
+
+#: pkg/storaged/jobs.js:144
+msgid "Checking and Repairing RAID Device $target"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:70
+msgid "Checking for public keys"
+msgstr ""
+
+#: pkg/ostree/app.js:219
+msgid "Checking for updates"
+msgstr ""
+
+#: pkg/shell/simple.html:100 pkg/shell/index.html:121 pkg/shell/stub.html:114
+msgid "Choose the language to be used in the application"
+msgstr ""
+
+#: pkg/storaged/overview.js:431
+msgid "Chunk Size"
+msgstr "Tamanho do Bloco"
+
+#: pkg/kubernetes/scripts/volumes.js:202
+msgid "Cinder"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
+msgid "Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:4
+msgid "Claim Name"
+msgstr ""
+
+#: pkg/storaged/jobs.js:135
+msgid "Cleaning up for $target"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:88
+msgid "Client Certificate"
+msgstr ""
+
+#: pkg/systemd/services.html:306 pkg/systemd/services.html:324
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-invalid-hostkey.html:19
+msgid "Close"
+msgstr "Fechar"
+
+#: pkg/kubernetes/views/auth-form.html:5
+msgid "Cluster"
+msgstr ""
+
+#: cockpit.desktop.in.h:1
+msgid "Cockpit"
+msgstr "Cockpit"
+
+#: pkg/lib/machine-dialogs.js:429
+msgid ""
+"Cockpit could not contact the given host $0. Make sure it has ssh running on "
+"port $1, or specify another port in the address."
+msgstr ""
+"Cockpit não pode contactar o host $0. Tenha certeza que o ssh  esteja "
+"rodando na porta $1, ou especifique outra porta no endereço."
+
+#: src/base1/cockpit.js:3713
+msgid "Cockpit could not contact the given host."
+msgstr ""
+
+#: pkg/shell/base_index.js:671
+msgid "Cockpit had an unexpected internal error. <br/><br/>"
+msgstr "Cockpit teve um erro inesperado. <br/><br/>"
+
+#: cockpit.appdata.xml.in.h:1
+msgid ""
+"Cockpit is a server manager that makes it easy to administer your Linux "
+"servers via a web browser. Jumping between the terminal and the web tool is "
+"no problem. A service started via Cockpit can be stopped via the terminal. "
+"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
+"journal interface."
+msgstr ""
+"Cockpit é um gerenciador de Servidores que facilita a tarefa de administrar "
+"seu servidor Linux via navegador web. Alternar entre o terminal e a "
+"ferramenta web, não é dif[icil. Um serviço pode ser iniciado pelo Cockpit e "
+"finalizado pelo Terminal. Da mesma forma, se um erro ocorrer no terminal, "
+"este pode ser detectado via interface do Cockpit."
+
+#: src/base1/cockpit.js:3711
+msgid "Cockpit is not compatible with the software on the system."
+msgstr ""
+
+#: pkg/lib/machine-not-supported.html:2
+msgid "Cockpit is not installed"
+msgstr ""
+
+#: src/base1/cockpit.js:3705
+msgid "Cockpit is not installed on the system."
+msgstr ""
+
+#: cockpit.appdata.xml.in.h:2
+msgid ""
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
+"tasks such as storage administration, inspecting journals and starting and "
+"stopping services. You can monitor and administer several servers at the "
+"same time. Just add them with a single click and your machines will look "
+"after its buddies."
+msgstr ""
+"Cockpit é perfeito para novos administradores de sistemas, permitindo-lhes "
+"facilmente realizar tarefas simples, como a administração de armazenamento, "
+"inspecionando logs e iniciar/parar serviços. É possível monitorar e "
+"administrar vários servidores ao mesmo tempo. Basta adicioná-los com um "
+"único clique e suas máquinas vão cuidar de seus companheiros."
+
+#: pkg/lib/machine-change-port.html:9
+msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:15
+msgid ""
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:9
+msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:6
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
+"machine with cockpit you will need to enable one of the following "
+"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:13
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
+"change your authentication credentials below. {{#can_sync}}You may prefer to "
+"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+msgstr ""
+
+#: pkg/dashboard/index.html:171 pkg/lib/machine-add.html:27
+msgid "Color"
+msgstr ""
+
+#: pkg/docker/index.html:95
+msgid "Combined CPU usage"
+msgstr ""
+
+#: pkg/docker/index.html:101
+msgid "Combined memory usage"
+msgstr ""
+
+#: pkg/systemd/services.html:370 pkg/docker/index.html:466
+#: pkg/docker/index.html:736
+msgid "Command"
+msgstr "Comando"
+
+#: pkg/docker/run.js:332
+#, fuzzy
+msgid "Command can't be empty"
+msgstr "Namespace não pode estar vazio ."
+
+#: pkg/docker/containers-view.jsx:239
+#, fuzzy
+msgid "Commit"
+msgstr "Comando"
+
+#: pkg/tuned/dialog.js:114
+msgid "Communication with tuned has failed"
+msgstr "A comunicação com sintonizado falhou"
+
+#: pkg/storaged/details.js:348
+msgid "Compatible with all systems and devices (MBR)"
+msgstr ""
+
+#: pkg/storaged/details.js:349
+msgid "Compatible with modern system and hard disks > 2TB (GPT)"
+msgstr ""
+
+#: pkg/realmd/operation.html:28
+msgid "Computer OU"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:24
+msgid "Configuration"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2441
+msgid "Configure"
+msgstr "Configurar"
+
+#: pkg/kubernetes/views/node-add.html:42
+msgid "Configure Flannel networking"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:32
+msgid "Configure Kubelet and Proxy"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:811
+msgid "Configuring"
+msgstr "Configurando"
+
+#: pkg/networkmanager/interfaces.js:815
+msgid "Configuring IP"
+msgstr "Configurando IP"
+
+#: pkg/users/index.html:171 pkg/shell/index.html:262
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: pkg/users/index.html:247
+msgid "Confirm New Password"
+msgstr "Confirmar Nova Senha"
+
+#: pkg/storaged/details.js:229
+msgid "Confirm passphrase"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:130
+#: pkg/kubernetes/views/auth-rejected-cert.html:33
+#: pkg/lib/machine-unknown-hostkey.html:22
+msgid "Connect"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2637
+msgid "Connect automatically"
+msgstr "Conecte automaticamente"
+
+#: pkg/ostree/index.html:218
+msgid "Connecting"
+msgstr ""
+
+#: pkg/lib/machine-add.html:39
+msgid ""
+"Connecting simultaneously to more than {{ limit }} machines is unsupported."
+msgstr ""
+
+#: pkg/docker/index.html:54
+msgid "Connecting to Docker"
+msgstr "Conectando ao Docker"
+
+#: pkg/shell/indexes.js:317
+msgid "Connecting to the machine"
+msgstr "Conectando a máquina"
+
+#: pkg/kubernetes/registry.html:70 pkg/kubernetes/index.html:100
+msgid "Connecting..."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-dialog.html:4
+msgid "Connection Error"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:516
+msgid "Connection Error: $0"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-dialog.html:3
+msgid "Connection Settings"
+msgstr ""
+
+#: src/base1/cockpit.js:3703
+msgid "Connection has timed out."
+msgstr ""
+
+#: pkg/networkmanager/index.html:812
+msgid "Connection will be lost"
+msgstr ""
+
+#: pkg/docker/console.html:4 pkg/kubernetes/views/container-panel.html:4
+#: pkg/kubernetes/views/image-panel.html:12
+#: pkg/kubernetes/views/container-body.html:4
+#: pkg/kubernetes/views/container-page-inline.html:2
+#: pkg/kubernetes/views/image-page.html:19
+msgid "Container"
+msgstr "Container"
+
+#: pkg/users/local.js:684
+msgid "Container Administrator"
+msgstr ""
+
+#: pkg/kubernetes/views/container-body.html:10
+msgid "Container ID"
+msgstr ""
+
+#: pkg/docker/index.html:459 pkg/docker/index.html:646
+#: pkg/docker/index.html:712
+msgid "Container Name"
+msgstr "Nome do Container"
+
+#: pkg/kubernetes/views/node-body.html:21
+msgid "Container Runtime Version"
+msgstr ""
+
+#: pkg/docker/util.js:490
+msgid ""
+"Container is currently marked as not running, but regular stopping failed."
+msgstr ""
+"Container está atualmente marcado como parado, mas parada normal falhou."
+
+#: pkg/docker/util.js:488
+msgid "Container is currently running."
+msgstr "Container está em execução."
+
+#: pkg/docker/index.html:23 pkg/docker/index.html:309
+#: pkg/kubernetes/views/pod-page.html:36
+#: pkg/kubernetes/views/dashboard-page.html:158
+#: pkg/kubernetes/views/dashboard-page.html:199
+#: pkg/kubernetes/views/containers-listing.html:5 pkg/kubernetes/index.html:51
+msgid "Containers"
+msgstr "Containers"
+
+#: pkg/docker/details.js:47 pkg/docker/image.js:43
+msgctxt "page-title"
+msgid "Containers"
+msgstr "Containers"
+
+#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
+msgid "Content"
+msgstr "Conteúdo"
+
+#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
+#: pkg/playground/translate.js:19
+#, fuzzy
+msgid "Control"
+msgstr "Container"
+
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
+#: pkg/playground/translate.js:22
+#, fuzzy
+msgctxt "key"
+msgid "Control"
+msgstr "Container"
+
+#: pkg/docker/storage.jsx:404
+#, fuzzy
+msgid "Could not add all disks"
+msgstr "Não foi possível listar serviços"
+
+#: pkg/lib/machine-change-port.html:4
+msgid "Could not contact {{host}}"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:142
+msgid "Could not list services"
+msgstr "Não foi possível listar serviços"
+
+#: src/ws/cockpitcertificate.c:407
+msgid "Could not parse PEM-encoded certificate"
+msgstr "Não foi possível analisar certificado PEM-codificado"
+
+#: src/ws/cockpitcertificate.c:374
+msgid "Could not parse PEM-encoded private key"
+msgstr "Não foi possível analisar chave privada codificado em PEM"
+
+#: pkg/docker/storage.jsx:446
+msgid "Could not reset the storage pool"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:467
+msgid "Couldn't change user groups"
+msgstr "Não foi possível alterar os grupos de usuários"
+
+#: src/bridge/cockpitdbussetup.c:520
+msgid "Couldn't change user password"
+msgstr "Não foi possível alterar a senha do usuário"
+
+#: pkg/selinux/setroubleshoot-view.jsx:385
+msgid ""
+"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
+"server is installed."
+msgstr ""
+
+#: pkg/kubernetes/registry.html:71 pkg/kubernetes/index.html:101
+msgid "Couldn't connect to server"
+msgstr ""
+
+#: pkg/shell/indexes.js:320
+msgid "Couldn't connect to the machine"
+msgstr "Não pode conectar a máquina"
+
+#: src/bridge/cockpitdbussetup.c:544
+msgid "Couldn't create new users"
+msgstr "Não foi possível criar novos usuários"
+
+#: pkg/kubernetes/scripts/connection.js:514
+msgid "Couldn't find running API server"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:196
+msgid ""
+"Couldn't get system subscription status. Please ensure subscription-manager "
+"is installed."
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:642
+msgid "Couldn't list local users"
+msgstr "Não foi possível listar os usuários locais"
+
+#: src/bridge/cockpitdbussetup.c:236
+msgid "Couldn't list users"
+msgstr "Não foi possível listar os usuários"
+
+#: src/bridge/cockpitdbussetup.c:382
+msgid "Couldn't load user data"
+msgstr "Não foi possível carregar os dados do usuário"
+
+#: pkg/kubernetes/views/project-modify.html:72
+#: pkg/kubernetes/views/add-group-dialog.html:21
+msgid "Create"
+msgstr ""
+
+#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
+msgid "Create Logical Volume"
+msgstr ""
+
+#: pkg/users/index.html:54 pkg/users/index.html:143
+msgid "Create New Account"
+msgstr "Criar Nova Conta"
+
+#: pkg/storaged/details.js:1379
+msgid "Create Partition"
+msgstr "Criar Partição"
+
+#: pkg/storaged/overview.js:414
+msgid "Create RAID Device"
+msgstr "Criar dispositivo RAID"
+
+#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
+msgid "Create Snapshot"
+msgstr "Criar Snapshot"
+
+#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
+msgid "Create Thin Volume"
+msgstr "Criar Thin Volume"
+
+#: pkg/systemd/services.html:336
+#, fuzzy
+msgid "Create Timers"
+msgstr "Criar Thin Volume"
+
+#: pkg/storaged/overview.js:487
+msgid "Create Volume Group"
+msgstr "Criar Grupo de Volumes"
+
+#: pkg/sosreport/index.html:50
+msgid "Create diagnostic report"
+msgstr "Criar um relatório de diagnostico"
+
+#: pkg/kubernetes/views/imagestream-modify.html:3
+msgid "Create image stream"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
+#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
+#, fuzzy
+msgid "Create it"
+msgstr "Criar relatório"
+
+#: pkg/storaged/details.js:266
+msgid "Create partition"
+msgstr "Criar partição"
+
+#: pkg/storaged/details.js:113
+msgid "Create partition on $0"
+msgstr ""
+
+#: pkg/storaged/index.html:381
+msgid "Create partition table"
+msgstr ""
+
+#: pkg/sosreport/index.html:42
+msgid "Create report"
+msgstr "Criar relatório"
+
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/replicationcontroller-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7 pkg/kubernetes/views/route-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3
+msgid "Created"
+msgstr ""
+
+#: pkg/storaged/jobs.js:142
+msgid "Creating RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:130
+msgid "Creating filesystem on $target"
+msgstr "Criando sistema de arquivos em $target"
+
+#: pkg/storaged/jobs.js:156
+msgid "Creating logical volume $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:134
+msgid "Creating partition $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:150
+msgid "Creating snapshot of $target"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:4064
+msgid "Creating this VLAN will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3436
+msgid "Creating this bond will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3842
+msgid "Creating this bridge will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3611
+msgid "Creating this team will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:151
+msgid "Creating volume group $target"
+msgstr ""
+
+#: pkg/systemd/logs.html:41
+msgid "Current boot"
+msgstr "Inicialização atual"
+
+#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
+msgid "Custom"
+msgstr "Personalizado"
+
+#: pkg/storaged/details.js:186
+msgid "Custom (Enter filesystem type)"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:102
+#, fuzzy
+msgid "Custom URL"
+msgstr "Personalizado"
+
+#: pkg/storaged/index.html:454
+msgid "DISK IS FAILING"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3018
+msgid "DNS"
+msgstr "DNS"
+
+#: pkg/kubernetes/views/pod-body.html:14
+msgid "DNS Policy"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3022
+msgid "DNS Search Domains"
+msgstr "DNS Busca de Domínios"
+
+#: pkg/dashboard/index.html:22
+msgid "Dashboard"
+msgstr ""
+
+#: pkg/storaged/details.js:1130
+msgid "Deactivate"
+msgstr "Desativar"
+
+#: pkg/networkmanager/interfaces.js:823
+msgid "Deactivating"
+msgstr "Desativando"
+
+#: pkg/storaged/jobs.js:149
+msgid "Deactivating $target"
+msgstr ""
+
+#: pkg/docker/index.html:379 pkg/docker/index.html:383
+#: pkg/kubernetes/views/image-config.html:6
+msgid "Default"
+msgstr "Padrão"
+
+#: pkg/systemd/index.html:454
+msgid "Delay"
+msgstr "Atraso"
+
+#: pkg/users/index.html:79 pkg/kubernetes/views/item-delete.html:11
+#: pkg/kubernetes/views/pvc-delete.html:15
+#: pkg/kubernetes/views/node-delete.html:15
+#: pkg/kubernetes/views/imagestream-delete.html:8
+#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/kubernetes/views/image-delete.html:8
+#: pkg/kubernetes/views/pv-delete.html:11
+msgid "Delete"
+msgstr "Excluir"
+
+#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
+msgid "Delete $0"
+msgstr ""
+
+#: pkg/users/index.html:292
+msgid "Delete Files"
+msgstr "Excluir Arquivos"
+
+#: pkg/kubernetes/views/node-delete.html:4
+msgid "Delete Node"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:3
+msgid "Delete Persistent Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:3
+msgid "Delete Persistent Volume Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/project-delete.html:3
+msgid "Delete Project"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:3
+msgid "Delete Selected"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:3
+msgid "Delete image stream"
+msgstr ""
+
+#: pkg/playground/translate.html:184 pkg/kubernetes/views/item-delete.html:3
+msgid "Delete {{ item.kind }}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
+msgid "Deleting $target"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2156
+msgid "Deleting <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:7
+msgid ""
+"Deleting a Pod will kill all associated containers. Pods may be "
+"automatically created again in some cases."
+msgstr ""
+
+#: pkg/storaged/details.js:631
+msgid "Deleting a RAID device will erase all data on it."
+msgstr ""
+
+#: pkg/docker/containers-view.jsx:167 pkg/docker/details.js:272
+msgid "Deleting a container will erase all data in it."
+msgstr "A exclusão de um container irá apagar todos os dados nele."
+
+#: pkg/storaged/details.js:1009
+msgid "Deleting a logical volume will delete all data in it."
+msgstr ""
+
+#: pkg/storaged/details.js:1012
+msgid "Deleting a partition will delete all data in it."
+msgstr "A exclusão de uma partição apaga todos os dados da mesma."
+
+#: pkg/storaged/details.js:826
+msgid "Deleting a volume group will erase all data on it."
+msgstr "A exclusão de um grupo de volumes apaga todos os dados do mesmo."
+
+#: pkg/docker/image.js:152
+msgid ""
+"Deleting an image will delete it, but you can probably download it again if "
+"you need it later.  Unless this image has never been pushed to a repository, "
+"that is, in which case you probably can't download it again."
+msgstr ""
+"Apagar uma imagem irá excluí-la, mas provavelmente você pode baixá-la "
+"novamente se você precisar dela mais tarde. A menos que essa imagem nunca "
+"tem sido enviada para um repositório, ou seja, caso em que você "
+"provavelmente não pode baixá-la novamente."
+
+#: pkg/storaged/jobs.js:152
+msgid "Deleting volume group $target"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:131
+#: pkg/kubernetes/views/deploy.html:62
+msgid "Deploy"
+msgstr "Implantar"
+
+#: pkg/kubernetes/views/deploy.html:3
+msgid "Deploy Application"
+msgstr "Implantar aplicativo"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:22
+msgid "Deployment Causes"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-panel.html:8
+#: pkg/kubernetes/views/deploymentconfig-page.html:12
+msgid "Deployment Config"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:98
+msgid "Deployment Configs"
+msgstr ""
+
+#: pkg/systemd/services.html:356 pkg/kubernetes/views/project-modify.html:40
+#: pkg/kubernetes/views/image-body.html:6
+#: pkg/kubernetes/views/project-listing.html:15
+#: pkg/kubernetes/views/project-listing.html:54
+msgid "Description"
+msgstr ""
+
+#: pkg/shell/index.html:197 pkg/kubernetes/index.html:63
+msgid "Details"
+msgstr ""
+
+#: pkg/storaged/index.html:543
+msgctxt "storage"
+msgid "Device"
+msgstr "Dispositivo"
+
+#: pkg/storaged/details.js:91
+msgid "Device $0 is a member of RAID Array $1"
+msgstr ""
+
+#: pkg/storaged/details.js:97
+msgid "Device $0 is a physical volume of $1"
+msgstr ""
+
+#: pkg/storaged/details.js:85
+msgid "Device $0 is mounted on $1"
+msgstr ""
+
+#: pkg/storaged/index.html:467 pkg/storaged/index.html:473
+#: pkg/storaged/index.html:515
+msgctxt "storage"
+msgid "Device File"
+msgstr "Arquivo de Dispositivo"
+
+#: pkg/sosreport/index.html:22
+msgid "Diagnostic reports"
+msgstr "Relatório de diagnostico"
+
+#: pkg/kubernetes/views/image-body.html:20
+msgid "Digest"
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:7
+#: pkg/kubernetes/views/volume-body.html:28
+msgid "Directory"
+msgstr ""
+
+#: pkg/systemd/init.js:543
+msgid "Disable"
+msgstr "Desabilitar"
+
+#: pkg/tuned/dialog.js:234
+msgid "Disable tuned"
+msgstr "Desabilitar tuned"
+
+#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
+msgid "Disabled"
+msgstr "Desabilitado"
+
+#: pkg/shell/simple.html:120
+msgid "Disconnected"
+msgstr "Desconectado"
+
+#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+msgid "Disk"
+msgstr ""
+
+#: pkg/dashboard/index.html:73
+#, fuzzy
+msgid "Disk I/O"
+msgstr "Discos"
+
+#: pkg/kubernetes/scripts/nodes.js:720
+msgid "Disk Utilization: $0%"
+msgstr ""
+
+#: pkg/storaged/index.html:457
+msgid "Disk is OK"
+msgstr ""
+
+#: pkg/storaged/index.html:584
+msgid "Disks"
+msgstr "Discos"
+
+#: pkg/shell/simple.html:37 pkg/shell/simple.html:97 pkg/shell/index.html:37
+#: pkg/shell/index.html:118 pkg/shell/stub.html:37 pkg/shell/stub.html:111
+msgid "Display Language"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:31
+msgid "Display name"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:5
+msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:5
+msgid ""
+"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}' image stream?"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:6
+msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:6
+msgid ""
+"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:6
+msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:7
+msgid "Do you want to delete this Node?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:5
+msgid ""
+"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+"{{stream.metadata.name}}:{{tag.tag}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/remove-role-dialog.html:5
+msgid ""
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:11
+msgid "Docker Version"
+msgstr ""
+
+#: pkg/docker/index.html:60
+msgid "Docker is not installed or activated on the system"
+msgstr "Docker não está instalado ou ativado no sistema"
+
+#: pkg/systemd/index.html:107
+msgid "Domain"
+msgstr ""
+
+#: pkg/realmd/operation.js:148
+msgid "Domain $0 could not be contacted"
+msgstr ""
+
+#: pkg/realmd/operation.js:220
+msgid "Domain $0 is not supported"
+msgstr ""
+
+#: pkg/realmd/operation.html:11
+msgid "Domain Address"
+msgstr ""
+
+#: pkg/realmd/operation.html:59
+msgid "Domain Administrator Name"
+msgstr ""
+
+#: pkg/realmd/operation.html:65
+msgid "Domain Administrator Password"
+msgstr ""
+
+#: pkg/systemd/services.html:426 pkg/systemd/services.html:430
+msgid "Don't Repeat"
+msgstr ""
+
+#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
+msgid "Don't overwrite existing data"
+msgstr ""
+
+#: pkg/sosreport/index.html:74
+msgid "Done!"
+msgstr "Feito!"
+
+#: pkg/ostree/index.html:127 pkg/ostree/index.html:158
+msgid "Downgrades"
+msgstr ""
+
+#: pkg/storaged/index.html:411
+msgid "Drive"
+msgstr "Unidade"
+
+#: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
+msgctxt "storage"
+msgid "Drive"
+msgstr "Drive"
+
+#: pkg/kubernetes/views/volume-body.html:128
+msgid "Driver"
+msgstr ""
+
+#: pkg/storaged/index.html:166
+msgid "Drives"
+msgstr "Unidades"
+
+#: pkg/docker/run.js:360
+msgid "Duplicate alias"
+msgstr "Apelido duplicado"
+
+#: pkg/docker/run.js:293
+msgid "Duplicate port"
+msgstr "Porta duplicada"
+
+#: pkg/storaged/jobs.js:120
+msgid "Ejecting $target"
+msgstr ""
+
+#: pkg/playground/translate.html:58
+msgid "Empty"
+msgstr "Vazio"
+
+#: pkg/playground/translate.html:63
+#, fuzzy
+msgctxt "verb"
+msgid "Empty"
+msgstr "Vazio"
+
+#: pkg/kubernetes/scripts/volumes.js:196
+msgid "Empty Directory"
+msgstr ""
+
+#: pkg/storaged/jobs.js:155
+msgid "Emptying $target"
+msgstr "Esvaziando $target"
+
+#: pkg/systemd/init.js:541
+msgid "Enable"
+msgstr "Habilitar"
+
+#: pkg/systemd/init.js:542
+msgid "Enable Forcefully"
+msgstr "Habilite Forçosamente"
+
+#: pkg/systemd/init.js:301
+msgid "Enabled"
+msgstr "Habilitado"
+
+#: pkg/storaged/details.js:1247
+msgctxt "storage-id-desc"
+msgid "Encrypted"
+msgstr "Encriptado"
+
+#: pkg/storaged/details.js:180
+msgid "Encrypted EXT4 (LUKS)"
+msgstr "Encriptado EXT4 (LUKS)"
+
+#: pkg/storaged/details.js:179
+msgid "Encrypted XFS (LUKS)"
+msgstr "Encriptado XFS (LUKS)"
+
+#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
+#: pkg/storaged/details.js:1115
+msgid "Encryption Options"
+msgstr "Opções de Criptografia"
+
+#: pkg/kubernetes/views/pv-modify.html:93
+msgid "Endpoint"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:40
+msgid "Endpoint Name"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:14
+#: pkg/kubernetes/views/service-panel.html:9
+msgid "Endpoints"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:38
+msgid "Ends"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:332
+msgid "Enforce policy:"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:447
+msgid "Enter IP address or host name"
+msgstr "Digite o endereço IP ou nome de host"
+
+#: pkg/systemd/logs.html:60
+msgid "Entry"
+msgstr ""
+
+#: pkg/docker/index.html:547 pkg/kubernetes/views/image-config.html:17
+#: pkg/kubernetes/views/container-body.html:26
+msgid "Environment"
+msgstr ""
+
+#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
+msgid "Erase"
+msgstr "Apagar"
+
+#: pkg/docker/storage.jsx:423
+msgid "Erase containers and reset storage pool"
+msgstr ""
+
+#: pkg/docker/storage.jsx:360
+msgid "Erase containers, reformat disks, and add them"
+msgstr ""
+
+#: pkg/storaged/jobs.js:129
+msgid "Erasing $target"
+msgstr "Apagando $target"
+
+#: pkg/systemd/services.html:318 pkg/playground/translate.html:101
+#: pkg/playground/translate.html:106
+msgid "Error"
+msgstr "Erro"
+
+#: pkg/kubernetes/scripts/connection.js:650
+msgid "Error getting certificate details: $0"
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:13
+msgid "Error loading users: {{perm_failed}}"
+msgstr ""
+
+#: pkg/docker/util.js:491
+msgid "Error message from Docker:"
+msgstr "Mensagem de erro do Docker:"
+
+#: pkg/users/authorized-keys.js:115
+msgid "Error saving authorized keys: "
+msgstr ""
+
+#: pkg/selinux/setroubleshoot.js:275
+msgid "Error while connecting."
+msgstr "Erro ao se conectar."
+
+#: pkg/selinux/setroubleshoot-client.js:192
+msgid "Error while deleting alert"
+msgstr "Erro ao deletar o alerta"
+
+#: pkg/selinux/setroubleshoot.js:65
+msgid "Error while setting SELinux mode: '$0'"
+msgstr "Erro ao definir o modo de SELinux: '$0'"
+
+#: pkg/kubernetes/scripts/connection.js:88
+msgid "Error writing kubectl config"
+msgstr ""
+
+#: pkg/systemd/logs.html:47
+msgid "Errors"
+msgstr "Erros"
+
+#: pkg/networkmanager/index.html:764
+msgid "Ethernet MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1854
+msgid "Ethtool"
+msgstr ""
+
+#: pkg/users/local.js:429 pkg/users/local.js:1104
+msgid "Excellent password"
+msgstr "Senha excelente"
+
+#: pkg/docker/util.js:96
+msgid "Exited $ExitCode"
+msgstr "Encerrado $ExitCode"
+
+#: pkg/docker/index.html:529
+msgid "Expose container ports"
+msgstr ""
+
+#: pkg/storaged/details.js:183
+msgid "Extended Partition"
+msgstr "Partição Extendida"
+
+#: pkg/storaged/details.js:1592
+msgid "FAILED"
+msgstr "FALHOU"
+
+#: pkg/ostree/index.html:92
+msgid "Failed"
+msgstr "Falhou"
+
+#: pkg/lib/machine-dialogs.js:412
+msgid "Failed to add machine: $0"
+msgstr "Falha ao adicionar a máquina: $0"
+
+#: pkg/users/local.js:112 pkg/users/local.js:144 pkg/lib/credentials.js:223
+msgid "Failed to change password"
+msgstr "Falha ao mudar senha"
+
+#: pkg/selinux/setroubleshoot-client.js:187
+msgid "Failed to delete alert"
+msgstr "Falha ao deletar o alerta"
+
+#: pkg/tuned/dialog.js:171
+msgid "Failed to disable tuned"
+msgstr "Falha ao desabilitar tuned"
+
+#: pkg/tuned/dialog.js:133
+#, fuzzy
+msgid "Failed to disable tuned profile"
+msgstr "Falha para desabilitar perfil tuned"
+
+#: pkg/lib/machine-dialogs.js:494
+msgid "Failed to edit machine: $0"
+msgstr "Falha ao editar a máquina: $0"
+
+#: pkg/tuned/dialog.js:169
+msgid "Failed to enable tuned"
+msgstr "Falha ao habilitar tuned"
+
+#: pkg/users/index.html:338
+msgid "Failed to load authorized keys."
+msgstr ""
+
+#: pkg/docker/containers.js:64
+msgid "Failed to start Docker: $0"
+msgstr "Falha ao iniciar Docker: $0"
+
+#: pkg/docker/util.js:544
+msgid "Failed to stop Docker scope: $0"
+msgstr "Falha ao parar Docker escopo: $0"
+
+#: pkg/tuned/dialog.js:145
+msgid "Failed to switch profile"
+msgstr "Falha ao mudar de perfil"
+
+#: pkg/kubernetes/scripts/volumes.js:204
+msgid "Fibre Channel"
+msgstr ""
+
+#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
+msgid "Filesystem Options"
+msgstr "Opções do Sistema de Arquivos"
+
+#: pkg/kubernetes/views/pv-modify.html:180
+#: pkg/kubernetes/views/volume-body.html:6
+#: pkg/kubernetes/views/volume-body.html:16
+#: pkg/kubernetes/views/volume-body.html:62
+#: pkg/kubernetes/views/volume-body.html:83
+#: pkg/kubernetes/views/volume-body.html:91
+#: pkg/kubernetes/views/volume-body.html:120
+#: pkg/kubernetes/views/volume-body.html:132
+msgid "Filesystem Type"
+msgstr ""
+
+#: pkg/storaged/details.js:215
+msgid "Filesystem type"
+msgstr ""
+
+#: pkg/storaged/index.html:225
+msgid "Filesystems"
+msgstr "Sistema de Arquivos"
+
+#: pkg/lib/machine-unknown-hostkey.html:10
+msgid "Fingerprint"
+msgstr ""
+
+#: pkg/storaged/index.html:426
+msgctxt "storage"
+msgid "Firmware Version"
+msgstr "Versão do Firmware"
+
+#: pkg/kubernetes/scripts/volumes.js:206
+msgid "Flex"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:205
+msgid "Flocker"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:125
+msgid "Flocker Dataset Name"
+msgstr ""
+
+#: pkg/docker/util.js:503
+msgid "Force Delete"
+msgstr "Remoção forçada"
+
+#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
+#: pkg/storaged/details.js:1142
+msgid "Format"
+msgstr "Formate"
+
+#: pkg/storaged/details.js:115
+msgid "Format $0"
+msgstr "Formate $0"
+
+#: pkg/storaged/details.js:335
+msgid "Format Disk $0"
+msgstr "Formate Disco $0"
+
+#: pkg/storaged/details.js:358
+msgid "Formatting a disk will erase all data on it."
+msgstr "A formatação de um disco apaga todos os dados do mesmo."
+
+#: pkg/storaged/details.js:268
+msgid "Formatting a storage device will erase all data on it."
+msgstr "Formatar esse dispositivo apagará todos os dados contidos nele."
+
+#: pkg/networkmanager/interfaces.js:2577
+msgid "Forward delay $forward_delay"
+msgstr "Encaminhado Atraso $forward_delay"
+
+#: pkg/systemd/index.html:255
+msgid "Free"
+msgstr ""
+
+#: pkg/users/index.html:86 pkg/users/index.html:148
+msgid "Full Name"
+msgstr "Nome Completo"
+
+#: pkg/kubernetes/scripts/volumes.js:192
+msgid "GCE Persistent Disk"
+msgstr ""
+
+#: pkg/docker/index.html:180
+msgid "Gateway:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2628
+msgid "General"
+msgstr "Geral"
+
+#: pkg/sosreport/index.html:66
+msgid "Generating report"
+msgstr "Gerando relatório"
+
+#: pkg/kubernetes/scripts/volumes.js:194
+msgid "Git Repository"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:198
+msgid "Gluster FS"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:872
+msgid "GlusterFS"
+msgstr ""
+
+#: pkg/systemd/logs.js:130
+msgid "Go to"
+msgstr "Ir para"
+
+#: pkg/storaged/index.html:307 pkg/networkmanager/index.html:50
+#: pkg/networkmanager/index.html:496
+msgid "Go to now"
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:21
+#: pkg/kubernetes/views/group-panel.html:12
+msgid "Group Members"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:48
+#: pkg/kubernetes/views/user-delete.html:14
+msgid "Groups"
+msgstr ""
+
+#: pkg/networkmanager/index.html:268
+msgid "Hair Pin mode"
+msgstr "Hair Pin modo"
+
+#: pkg/networkmanager/interfaces.js:2603
+msgid "Hairpin mode"
+msgstr "Hairpin modo"
+
+#: pkg/docker/storage.jsx:157
+#, fuzzy
+msgid "Hard Disk"
+msgstr "Hard Disk"
+
+#: pkg/storaged/overview.js:180
+msgctxt "storage"
+msgid "Hard Disk"
+msgstr "Hard Disk"
+
+#: pkg/systemd/index.html:77
+msgid "Hardware"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2579
+msgid "Hello time $hello_time"
+msgstr "Hello time $hello_time"
+
+#: pkg/kubernetes/views/details-page.html:73
+#: pkg/kubernetes/views/route-body.html:9
+#: pkg/kubernetes/views/route-modify.html:8
+msgid "Host"
+msgstr "Máquina"
+
+#: pkg/systemd/index.html:102 pkg/dashboard/index.html:151
+msgid "Host Name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
+msgid "Host Path"
+msgstr ""
+
+#: src/base1/cockpit.js:3699
+msgid "Host key is incorrect"
+msgstr ""
+
+#: pkg/systemd/services.html:442
+msgid "Hour : Minute"
+msgstr ""
+
+#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
+msgid "Hour needs to be a number between 0-23"
+msgstr ""
+
+#: pkg/systemd/services.html:408
+msgid "Hours"
+msgstr ""
+
+#: pkg/systemd/index.html:221
+msgid "I/O Wait"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
+msgid "IP"
+msgstr ""
+
+#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
+msgid "IP Address"
+msgstr ""
+
+#: pkg/docker/index.html:172
+msgid "IP Address:"
+msgstr ""
+
+#: pkg/docker/index.html:176
+msgid "IP Prefix Length:"
+msgstr ""
+
+#: pkg/networkmanager/index.html:568
+msgid "IP Settings"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2641
+msgid "IPv4"
+msgstr "IPv4"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv4 Settings"
+msgstr "IPv4 Ajustes"
+
+#: pkg/networkmanager/interfaces.js:2642
+msgid "IPv6"
+msgstr "IPv6"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv6 Settings"
+msgstr "IPv6 Ajustes"
+
+#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
+msgid "ISCSI"
+msgstr ""
+
+#: pkg/systemd/init.js:270
+msgid "Id"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2620
+msgid "Id $id"
+msgstr "Id $id"
+
+#: pkg/kubernetes/views/image-body.html:22
+msgid "Identifier"
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:23
+#: pkg/kubernetes/views/user-panel.html:18
+msgid "Identities"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:91
+msgid "Identity"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1817
+msgid "Ignore"
+msgstr "Ignorar"
+
+#: pkg/docker/index.html:452 pkg/kubernetes/views/image-panel.html:9
+#: pkg/kubernetes/views/container-body.html:6
+#: pkg/kubernetes/views/image-page.html:16
+msgid "Image"
+msgstr "Imagem"
+
+#: pkg/docker/image.js:77
+msgid "Image $0"
+msgstr "Imagem $0"
+
+#: pkg/kubernetes/views/container-body.html:8
+msgid "Image ID"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:16
+msgid "Image Layers"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:58
+msgid "Image Name"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:23
+msgid "Image Registry"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-page.html:16
+msgid "Image Stream"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:135
+msgid "Image commands"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:34
+msgid "Image count"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:48
+#: pkg/kubernetes/views/registry-dashboard-page.html:19
+#: pkg/kubernetes/views/imagestream-page.html:18
+#: pkg/kubernetes/views/image-listing.html:9 pkg/kubernetes/index.html:77
+msgid "Images"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:17
+msgid "Images by project"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:54
+msgid "Images pushed recently"
+msgstr ""
+
+#: pkg/storaged/details.js:1593
+msgid "In Sync"
+msgstr "Em Sincronização"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:81
+msgid ""
+"In order to begin pushing images to the registry, use the commands below."
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:6
+msgid ""
+"In order to begin pushing images to the registry, you need to create a "
+"project."
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:50
+msgid ""
+"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
+"strong}}.        {{/needs_root}}                                    User "
+"name                                                                            "
+"{{#allows_password}}                            "
+"Password                                                                            "
+"{{/allows_password}}            "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
+#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
+msgid "Inactive"
+msgstr "Inativo"
+
+#: pkg/lib/machine-invalid-hostkey.html:2
+msgid "Incorrect Host Key"
+msgstr ""
+
+#: pkg/docker/storage.jsx:282
+msgid "Information about the Docker storage pool is not available."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:222
+msgid "Installed products"
+msgstr ""
+
+#: pkg/systemd/services.html:135
+msgid "Instantiate"
+msgstr "Instanciar"
+
+#: pkg/kubernetes/views/pv-modify.html:169
+#: pkg/kubernetes/views/volume-body.html:81
+msgid "Interface"
+msgstr ""
+
+#: pkg/networkmanager/index.html:84
+msgid "Interfaces"
+msgstr "Interfaces"
+
+#: src/base1/cockpit.js:3701
+msgid "Internal error"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:196
+#, fuzzy
+msgid "Invalid credentials"
+msgstr "Porta inválida"
+
+#: pkg/systemd/host.js:1194
+msgid "Invalid date format"
+msgstr ""
+
+#: pkg/systemd/host.js:1190
+msgid "Invalid date format and invalid time format"
+msgstr ""
+
+#: pkg/systemd/init.js:1218
+#, fuzzy
+msgid "Invalid date format."
+msgstr "Porta inválida"
+
+#: pkg/lib/credentials.js:274
+msgid "Invalid file permissions"
+msgstr "Permissão de arquivos inválida"
+
+#: pkg/users/index.html:322
+msgid "Invalid key"
+msgstr ""
+
+#: pkg/systemd/init.js:1169
+#, fuzzy
+msgid "Invalid number."
+msgstr "Porta inválida"
+
+#: pkg/docker/run.js:283
+msgid "Invalid port"
+msgstr "Porta inválida"
+
+#: pkg/systemd/host.js:1192
+msgid "Invalid time format"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:194 pkg/storaged/overview.js:577
+#: pkg/storaged/overview.js:668
+msgid "Invalid username or password"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:15
+msgid "Is sshd running on a different port?"
+msgstr ""
+
+#: pkg/systemd/init.js:522
+msgid "Isolate"
+msgstr "Isolar"
+
+#: pkg/storaged/index.html:280
+msgid "Jobs"
+msgstr ""
+
+#: pkg/realmd/operation.js:96
+msgid "Join"
+msgstr ""
+
+#: pkg/realmd/operation.js:453
+msgid "Join Domain"
+msgstr ""
+
+#: pkg/realmd/operation.js:347
+msgid "Joining this domain is not supported"
+msgstr ""
+
+#: pkg/systemd/logs.js:257
+msgid "Journal entry"
+msgstr ""
+
+#: pkg/systemd/logs.js:284
+msgid "Journal entry not found"
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:10
+msgid "Kerberos Based SSO"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:69
+msgid "Kerberos Ticket"
+msgstr ""
+
+#: pkg/systemd/index.html:225
+msgid "Kernel"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:19
+msgid "Kernel Version"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:67
+msgid "Key Ring Path"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:23
+msgid "Kubelet Version"
+msgstr ""
+
+#: pkg/kubernetes/index.html:23
+msgid "Kubernetes Cluster"
+msgstr "Kubernetes Cluster"
+
+#: pkg/networkmanager/index.html:473
+msgid "LACP Key"
+msgstr ""
+
+#: pkg/storaged/details.js:1245
+msgctxt "storage-id-desc"
+msgid "LUKS Encrypted"
+msgstr "LUKS Encriptado"
+
+#: pkg/storaged/details.js:1226
+msgctxt "storage-id-desc"
+msgid "LVM2 Physical Volume"
+msgstr "LVM2 Volume Físico"
+
+#: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/replicationcontroller-body.html:17
+#: pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/route-body.html:22
+#: pkg/kubernetes/views/image-meta.html:3
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
+msgid "Labels"
+msgstr "Rótulos"
+
+#: pkg/systemd/logs.html:42
+msgid "Last 24 hours"
+msgstr "Últimas 24 horas"
+
+#: pkg/systemd/logs.html:43
+msgid "Last 7 days"
+msgstr "Últimos 7 dias"
+
+#: pkg/kubernetes/views/node-body.html:49
+msgid "Last Heartbeat"
+msgstr ""
+
+#: pkg/users/index.html:100
+msgid "Last Login"
+msgstr "Último Login"
+
+#: pkg/kubernetes/views/node-body.html:51
+msgid "Last Status Change"
+msgstr ""
+
+#: pkg/systemd/init.js:273
+msgid "Last Trigger"
+msgstr ""
+
+#: pkg/kubernetes/views/image-listing.html:16
+msgid "Last Updated"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:107
+msgid "Latest Version"
+msgstr ""
+
+#: pkg/realmd/operation.js:101
+msgid "Leave"
+msgstr ""
+
+#: pkg/networkmanager/index.html:315
+msgid "Link Monitoring"
+msgstr "Monitoramento de Link"
+
+#: pkg/networkmanager/index.html:397
+#, fuzzy
+msgid "Link Watch"
+msgstr "Link Local"
+
+#: pkg/networkmanager/index.html:350 pkg/networkmanager/index.html:432
+msgid "Link down delay"
+msgstr "Link down atraso"
+
+#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
+msgid "Link local"
+msgstr "Link Local"
+
+#: pkg/networkmanager/index.html:341 pkg/networkmanager/index.html:423
+msgid "Link up delay"
+msgstr "Link up atraso"
+
+#: pkg/docker/index.html:514
+msgid "Links"
+msgstr "Links"
+
+#: pkg/storaged/details.js:1224
+msgctxt "storage-id-desc"
+msgid "Linux MD-RAID Component"
+msgstr "Linux MD-RAID Componente"
+
+#: pkg/networkmanager/interfaces.js:1841
+#, fuzzy
+msgid "Load Balancing"
+msgstr "Balanceamento de carga dinâmico"
+
+#: pkg/systemd/logs.js:69
+msgid "Load earlier entries"
+msgstr "Carregar logs anteriores"
+
+#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
+#: pkg/systemd/logs.js:175
+msgid "Loading..."
+msgstr "Carregando..."
+
+#: pkg/users/index.html:23
+msgid "Local Accounts"
+msgstr ""
+
+#: pkg/docker/storage.jsx:188
+#, fuzzy
+msgid "Local Disks"
+msgstr "$0 Discos"
+
+#: pkg/storaged/details.js:1109
+msgid "Lock"
+msgstr "Travar"
+
+#: pkg/users/index.html:109 pkg/users/index.html:196
+msgid "Lock Account"
+msgstr "Bloquear Conta"
+
+#: pkg/storaged/jobs.js:122
+msgid "Locking $target"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:80
+msgid "Log In"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:4
+msgid "Log in to {{host}}"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:116
+msgid "Log into OpenShift command line tools:"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:101
+msgid "Log into the registry:"
+msgstr ""
+
+#: pkg/shell/simple.html:45 pkg/shell/index.html:52 pkg/shell/stub.html:45
+msgid "Log out"
+msgstr ""
+
+#: pkg/users/local.js:839
+msgid "Logged In"
+msgstr ""
+
+#: pkg/storaged/details.js:1424
+msgid "Logical Partition"
+msgstr "Partição Lógica"
+
+#: pkg/kubernetes/views/pv-modify.html:158
+#: pkg/kubernetes/views/volume-body.html:79
+#: pkg/kubernetes/views/volume-body.html:118
+msgid "Logical Unit Number"
+msgstr ""
+
+#: pkg/storaged/utils.js:172
+msgid "Logical Volume"
+msgstr "Volume Lógico"
+
+#: pkg/storaged/utils.js:170
+msgid "Logical Volume (Snapshot)"
+msgstr "Volume Lógico (Snapshot)"
+
+#: pkg/storaged/details.js:1792
+msgid "Logical Volumes"
+msgstr "Volumes Lógicos"
+
+#: pkg/subscriptions/subscriptions-register.jsx:140
+#, fuzzy
+msgid "Login"
+msgstr "Último Login"
+
+#: pkg/lib/machine-change-auth.html:68
+msgid "Login Password"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:96
+msgid "Login commands"
+msgstr ""
+
+#: src/base1/cockpit.js:3693
+msgid "Login failed"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:200
+msgid "Login/password or activation key required to register."
+msgstr ""
+
+#: pkg/systemd/logs.html:59 pkg/kubernetes/views/container-panel.html:6
+#: pkg/kubernetes/views/container-page-inline.html:8
+msgid "Logs"
+msgstr ""
+
+#: pkg/dashboard/index.html:110
+msgid "Lost connection. Trying to reconnect"
+msgstr "Conexão Perdida. Tentando reconectar."
+
+#: pkg/docker/index.html:184
+msgid "MAC Address:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1833
+msgid "MII (Recommended)"
+msgstr "MII (Recomendado)"
+
+#: pkg/networkmanager/interfaces.js:2477
+msgid "MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:4139
+msgid "MTU must be a positive number"
+msgstr ""
+
+#: pkg/systemd/index.html:85 pkg/kubernetes/views/node-body.html:15
+msgid "Machine ID"
+msgstr ""
+
+#: pkg/systemd/index.html:282
+msgid "Machine SSH Key Fingerprints"
+msgstr ""
+
+#: pkg/shell/indexes.js:253
+msgid "Machines"
+msgstr "Máquinas"
+
+#: pkg/kubernetes/scripts/dashboard.js:460
+msgid "Manifest"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
+msgid "Manual"
+msgstr "Manual"
+
+#: pkg/systemd/index.html:401 pkg/systemd/index.html:405
+msgid "Manually"
+msgstr ""
+
+#: pkg/storaged/jobs.js:140
+msgid "Marking $target as faulty"
+msgstr ""
+
+#: pkg/systemd/init.js:546
+msgid "Mask"
+msgstr "Máscara"
+
+#: pkg/systemd/init.js:547
+msgid "Mask Forcefully"
+msgstr "Máscara forçada"
+
+#: pkg/networkmanager/interfaces.js:2483
+msgid "Master"
+msgstr "Mestre"
+
+#: pkg/networkmanager/interfaces.js:2581
+msgid "Maximum message age $max_age"
+msgstr "Máxima permanência da mensagem $max_age"
+
+#: pkg/kubernetes/views/volume-body.html:34
+msgid "Medium"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:92
+msgid "Member of"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:16
+#: pkg/kubernetes/views/project-listing.html:55
+#: pkg/networkmanager/index.html:291
+msgid "Members"
+msgstr "Membros"
+
+#: pkg/kubernetes/views/project-page.html:29
+#: pkg/kubernetes/views/user-panel.html:11
+#: pkg/kubernetes/views/user-panel.html:27
+#: pkg/kubernetes/views/user-body.html:4
+msgid "Membership"
+msgstr ""
+
+#: pkg/dashboard/index.html:71 pkg/playground/translate.html:91
+msgid "Memory"
+msgstr ""
+
+#: pkg/systemd/host.js:1466
+msgctxt "page-title"
+msgid "Memory"
+msgstr "Memória"
+
+#: pkg/kubernetes/scripts/nodes.js:716
+msgid "Memory Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:473 pkg/docker/index.html:652
+msgid "Memory limit"
+msgstr "Limite de Memória"
+
+#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
+msgid "Message"
+msgstr ""
+
+#: pkg/systemd/host.js:1300
+msgid "Message to logged in users"
+msgstr ""
+
+#: pkg/kubernetes/views/image-panel.html:15
+#: pkg/kubernetes/views/imagestream-page.html:21
+#: pkg/kubernetes/views/image-page.html:22
+msgid "Metadata"
+msgstr ""
+
+#: pkg/docker/index.html:487 pkg/docker/index.html:666
+msgid "MiB"
+msgstr ""
+
+#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
+msgid "Minute needs to be a number between 0-59"
+msgstr ""
+
+#: pkg/systemd/services.html:407
+#, fuzzy
+msgid "Minutes"
+msgstr "Rotas"
+
+#: pkg/networkmanager/index.html:299
+msgid "Mode"
+msgstr "Modo"
+
+#: pkg/storaged/index.html:421
+msgctxt "storage"
+msgid "Model"
+msgstr "Modelo"
+
+#: pkg/kubernetes/views/user-modify.html:31
+msgid "Modify"
+msgstr ""
+
+#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
+msgid "Modifying $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:323
+msgid "Monitoring Interval"
+msgstr "Monitorando Intervalo"
+
+#: pkg/networkmanager/index.html:332
+msgid "Monitoring Targets"
+msgstr "Alvod e Monitoramento"
+
+#: pkg/kubernetes/views/volume-body.html:54
+msgid "Monitors"
+msgstr ""
+
+#: pkg/realmd/operation.js:366
+msgid "More"
+msgstr ""
+
+#: pkg/storaged/details.js:1099
+msgid "Mount"
+msgstr "Montar"
+
+#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
+msgid "Mount Location"
+msgstr ""
+
+#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
+msgid "Mount Options"
+msgstr "Opções de Montagem"
+
+#: pkg/storaged/index.html:231
+msgid "Mount Point"
+msgstr "Ponto de Montagem"
+
+#: pkg/docker/index.html:540
+msgid "Mount container volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
+msgid "Mounting"
+msgstr ""
+
+#: pkg/storaged/jobs.js:126
+msgid "Mounting $target"
+msgstr ""
+
+#: pkg/storaged/index.html:508
+#, fuzzy
+msgctxt "storage"
+msgid "Multipathed Devices"
+msgstr "Outros dispositivos"
+
+#: pkg/kubernetes/scripts/volumes.js:860
+msgid "NFS"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:199
+msgid "NFS Mount"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1856
+msgid "NSNA Ping"
+msgstr ""
+
+#: pkg/storaged/details.js:182
+msgid "NTFS - Compatible with most systems"
+msgstr ""
+
+#: pkg/systemd/host.js:1250
+msgid "NTP Server"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/project-modify.html:16
+#: pkg/kubernetes/views/node-add.html:16
+#: pkg/kubernetes/views/volumes-page.html:19
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/image-body.html:2
+#: pkg/kubernetes/views/imagestream-modify.html:10
+#: pkg/kubernetes/views/service-modify.html:9
+#: pkg/kubernetes/views/dashboard-page.html:156
+#: pkg/kubernetes/views/dashboard-page.html:198
+#: pkg/kubernetes/views/details-page.html:34
+#: pkg/kubernetes/views/details-page.html:70
+#: pkg/kubernetes/views/details-page.html:103
+#: pkg/kubernetes/views/details-page.html:137
+#: pkg/kubernetes/views/details-page.html:171
+#: pkg/kubernetes/views/pv-claim.html:4
+#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/kubernetes/views/project-listing.html:14
+#: pkg/kubernetes/views/project-listing.html:53
+#: pkg/kubernetes/views/project-listing.html:90
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/volume-body.html:31 pkg/storaged/index.html:230
+#: pkg/networkmanager/index.html:95 pkg/networkmanager/index.html:113
+#: pkg/networkmanager/index.html:150 pkg/networkmanager/index.html:183
+#: pkg/networkmanager/index.html:282 pkg/networkmanager/index.html:364
+msgid "Name"
+msgstr "Nome"
 
 #: pkg/storaged/utils.js:129
 #, fuzzy
@@ -1716,373 +3381,1223 @@ msgstr ""
 msgid "Name cannot contain whitespace."
 msgstr "O enderço IP ou hostname não podem conter espações."
 
-#: pkg/storaged/utils.js:157
-msgid "$name (from $host)"
-msgstr "$nome(vindo de $host)"
+#: pkg/kubernetes/views/service-body.html:5
+#: pkg/kubernetes/views/replicationcontroller-body.html:5
+#: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/pod-body.html:5
+#: pkg/kubernetes/views/dashboard-page.html:160
+#: pkg/kubernetes/views/details-page.html:36
+#: pkg/kubernetes/views/details-page.html:72
+#: pkg/kubernetes/views/details-page.html:105
+#: pkg/kubernetes/views/details-page.html:139
+#: pkg/kubernetes/views/details-page.html:173
+#: pkg/kubernetes/views/pv-claim.html:6
+#: pkg/kubernetes/views/containers-listing.html:14
+#: pkg/kubernetes/views/route-body.html:5
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
+msgid "Namespace"
+msgstr "Namespace"
 
-#: pkg/storaged/utils.js:166
-msgid "Pool for Thin Logical Volumes"
-msgstr "Buscando por  Thin Logical Volumes"
+#: pkg/kubernetes/scripts/dashboard.js:374
+msgid "Namespace cannot be empty."
+msgstr "Namespace não pode estar vazio ."
 
-#: pkg/storaged/utils.js:168
-msgid "Thin Logical Volume"
-msgstr "Thin Logical Volume"
-
-#: pkg/storaged/utils.js:170
-msgid "Logical Volume (Snapshot)"
-msgstr "Volume Lógico (Snapshot)"
-
-#: pkg/storaged/utils.js:172
-msgid "Logical Volume"
-msgstr "Volume Lógico"
-
-#: pkg/storaged/utils.js:212
-msgid "<span>Encrypted Logical Volume of $0</span>"
+#: pkg/systemd/host.js:1113
+msgid "Need at least one NTP server"
 msgstr ""
 
-#: pkg/storaged/utils.js:214
-msgid "<span>Encrypted Partition of $0</span>"
+#: pkg/dashboard/index.html:72 pkg/playground/translate.html:96
+msgid "Network"
 msgstr ""
 
-#: pkg/storaged/utils.js:216
-msgid "<span>Logical Volume of $0</span>"
+#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:485
+msgid "Networking"
 msgstr ""
 
-#: pkg/storaged/utils.js:218
-msgid "<span>Partition of $0</span>"
+#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
+msgctxt "page-title"
+msgid "Networking"
+msgstr "Networking"
+
+#: pkg/networkmanager/index.html:124
+msgid "Networking Logs"
 msgstr ""
 
-#: pkg/storaged/utils.js:220
-msgid "<span>Encrypted $0</span>"
+#: pkg/users/local.js:841
+msgid "Never"
 msgstr ""
 
-#: pkg/storaged/utils.js:233
-msgid "RAID Device $0"
+#: pkg/kubernetes/views/project-listing.html:46
+msgid "New Group"
 msgstr ""
 
-#: pkg/storaged/utils.js:239
-msgid "Volume Group $0"
+#: pkg/users/index.html:236 pkg/shell/index.html:255
+msgid "New Password"
+msgstr "Nova Senha"
+
+#: pkg/kubernetes/views/project-listing.html:7
+msgid "New Project"
 msgstr ""
 
-#: pkg/storaged/jobs.js:119
-msgid "SMART self-test of $target"
+#: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/image-listing.html:7
+msgid "New image stream"
 msgstr ""
 
-#: pkg/storaged/jobs.js:120
-msgid "Ejecting $target"
+#: pkg/users/local.js:120 pkg/lib/credentials.js:231
+msgid "New password was not accepted"
+msgstr "Nova senha não foi aceita"
+
+#: pkg/kubernetes/views/project-modify.html:4
+#: pkg/kubernetes/views/registry-dashboard-page.html:9
+#: pkg/kubernetes/views/registry-dashboard-page.html:48
+msgid "New project"
 msgstr ""
 
-#: pkg/storaged/jobs.js:121
-msgid "Unlocking $target"
+#: pkg/realmd/operation.html:91
+msgid "Next"
+msgstr "Próximo"
+
+#: pkg/systemd/init.js:272
+msgid "Next Run"
 msgstr ""
 
-#: pkg/storaged/jobs.js:122
-msgid "Locking $target"
+#: pkg/systemd/index.html:233
+msgid "Nice"
 msgstr ""
 
-#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
-msgid "Modifying $target"
+#: pkg/docker/index.html:563 pkg/docker/index.html:567
+msgid "No"
+msgstr "Não"
+
+#: pkg/systemd/index.html:469
+msgid "No Delay"
 msgstr ""
 
-#: pkg/storaged/jobs.js:124
-msgid "Starting swapspace $target"
+#: pkg/ostree/index.html:220
+msgid "No Deployments"
 msgstr ""
 
-#: pkg/storaged/jobs.js:125
-msgid "Stopping swapspace $target"
+#: pkg/storaged/details.js:185
+msgid "No Filesystem"
+msgstr "Nenhum Sistema de Arquivos"
+
+#: pkg/ostree/app.js:101
+msgid "No OSTree deployments found"
 msgstr ""
 
-#: pkg/storaged/jobs.js:126
-msgid "Mounting $target"
+#: src/ws/cockpitcertificate.c:398
+msgid "No PEM-encoded certificate found"
+msgstr "Nenhum certificado codificado em PEM encontrados"
+
+#: src/ws/cockpitcertificate.c:364
+msgid "No PEM-encoded private key found"
+msgstr "Nenhuma chave privada codificado em PEM encontrados"
+
+#: pkg/kubernetes/views/pv-claim.html:39
+msgid "No Pods are using this claim"
 msgstr ""
 
-#: pkg/storaged/jobs.js:127
-msgid "Unmounting $target"
+#: pkg/selinux/setroubleshoot-view.jsx:479
+msgid "No SELinux alerts."
 msgstr ""
 
-#: pkg/storaged/jobs.js:129
-msgid "Erasing $target"
-msgstr "Apagando $target"
-
-#: pkg/storaged/jobs.js:130
-msgid "Creating filesystem on $target"
-msgstr "Criando sistema de arquivos em $target"
-
-#: pkg/storaged/jobs.js:131
-msgid "Setting up loop device $target"
+#: pkg/kubernetes/views/pvc-body.html:10
+msgid "No Volume Bound"
 msgstr ""
 
-#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
-msgid "Deleting $target"
+#: pkg/docker/storage.jsx:194
+msgid "No additional local storage found."
 msgstr ""
 
-#: pkg/storaged/jobs.js:134
-msgid "Creating partition $target"
+#: pkg/docker/run.js:350
+msgid "No alias specified"
+msgstr "Nenhum apelido especificado"
+
+#: pkg/sosreport/index.js:115
+msgid "No archive has been created."
 msgstr ""
 
-#: pkg/storaged/jobs.js:135
-msgid "Cleaning up for $target"
+#: pkg/networkmanager/interfaces.js:1326
+msgid "No carrier"
+msgstr "Sem sinal"
+
+#: pkg/docker/run.js:384
+msgid "No container specified"
+msgstr "Nenhum container especificado"
+
+#: pkg/storaged/index.html:193
+msgid "No drives attached"
 msgstr ""
 
-#: pkg/storaged/jobs.js:136
-msgid "Securely erasing $target"
+#: pkg/kubernetes/views/project-listing.html:74
+msgid "No groups are present."
 msgstr ""
 
-#: pkg/storaged/jobs.js:137
-msgid "Very securely erasing $target"
+#: pkg/systemd/index.html:28
+msgid "No host keys found."
 msgstr ""
 
-#: pkg/storaged/jobs.js:138
-msgid "Stopping RAID Device $target"
+#: pkg/storaged/index.html:158
+msgid "No iSCSI targets set up"
 msgstr ""
 
-#: pkg/storaged/jobs.js:139
-msgid "Starting RAID Device $target"
+#: pkg/kubernetes/views/image-listing.html:70
+msgid "No image streams are present."
 msgstr ""
 
-#: pkg/storaged/jobs.js:140
-msgid "Marking $target as faulty"
+#: pkg/kubernetes/views/registry-dashboard-page.html:80
+msgid "No images pushed"
 msgstr ""
 
-#: pkg/storaged/jobs.js:141
-msgid "Removing $target from RAID Device"
-msgstr ""
-
-#: pkg/storaged/jobs.js:142
-msgid "Creating RAID Device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:143
+#: pkg/subscriptions/subscriptions-view.jsx:223
 #, fuzzy
-msgid "Checking RAID Device $target"
-msgstr "Criar dispositivo RAID"
+msgid "No installed products on the system."
+msgstr "Docker não está instalado ou ativado no sistema"
 
-#: pkg/storaged/jobs.js:144
-msgid "Checking and Repairing RAID Device $target"
+#: pkg/storaged/index.html:446
+msgid "No media inserted"
 msgstr ""
 
-#: pkg/storaged/jobs.js:145
-msgid "Recovering RAID Device $target"
+#: pkg/kubernetes/scripts/dashboard.js:384
+msgid ""
+"No metadata file was selected. Please select a Kubernetes metadata file."
+msgstr ""
+"Nenhum arquivo de metadados foi selecionado. Por favor, selecione um arquivo "
+"de metadados Kubernetes ."
+
+#: pkg/kubernetes/views/dashboard-page.html:117
+msgid "No nodes in cluster"
 msgstr ""
 
-#: pkg/storaged/jobs.js:146
-msgid "Synchronizing RAID Device $target"
+#: pkg/storaged/details.js:352
+msgid "No partitioning"
 msgstr ""
 
-#: pkg/storaged/jobs.js:148
-msgid "Activating $target"
+#: pkg/kubernetes/views/dashboard-page.html:40
+msgid "No pods deployed"
 msgstr ""
 
-#: pkg/storaged/jobs.js:149
-msgid "Deactivating $target"
+#: pkg/kubernetes/views/replicationcontroller-pods.html:6
+msgid "No pods replicated"
 msgstr ""
 
-#: pkg/storaged/jobs.js:150
-msgid "Creating snapshot of $target"
+#: pkg/kubernetes/views/node-capacity.html:11
+msgid "No pods scheduled"
 msgstr ""
 
-#: pkg/storaged/jobs.js:151
-msgid "Creating volume group $target"
+#: pkg/kubernetes/views/service-endpoint.html:10
+msgid "No pods selected"
 msgstr ""
 
-#: pkg/storaged/jobs.js:152
-msgid "Deleting volume group $target"
+#: pkg/kubernetes/views/project-listing.html:37
+msgid "No projects are present."
 msgstr ""
 
-#: pkg/storaged/jobs.js:153
-msgid "Adding physical volume to $target"
+#: pkg/users/local.js:405
+#, fuzzy
+msgid "No real name specified"
+msgstr "Nenhum nome real  foi especificado"
+
+#: pkg/storaged/index.html:87
+msgid "No storage set up as RAID"
 msgstr ""
 
-#: pkg/storaged/jobs.js:154
-msgid "Removing physical volume from $target"
+#: pkg/lib/credentials.js:182
+msgid "No such file or directory"
+msgstr "Diretório ou arquivo não encontrado"
+
+#: pkg/users/local.js:400
+msgid "No user name specified"
+msgstr "Nenhum nome de usuário foi especificado"
+
+#: pkg/kubernetes/views/project-listing.html:112
+msgid "No users are present."
 msgstr ""
 
-#: pkg/storaged/jobs.js:155
-msgid "Emptying $target"
-msgstr "Esvaziando $target"
-
-#: pkg/storaged/jobs.js:156
-msgid "Creating logical volume $target"
+#: pkg/storaged/index.html:120
+msgid "No volume groups created"
 msgstr ""
 
-#: pkg/storaged/jobs.js:157
-msgid "Renaming $target"
+#: pkg/kubernetes/views/volumes-page.html:44
+msgid "No volumes are present."
 msgstr ""
 
-#: pkg/storaged/jobs.js:158
-msgid "Resizing $target"
+#: pkg/kubernetes/views/dashboard-page.html:73
+msgid "No volumes in use"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:18 pkg/kubernetes/views/node-panel.html:7
+#: pkg/kubernetes/views/containers-listing.html:15
+#: pkg/kubernetes/views/node-page.html:14
+#: pkg/kubernetes/views/topology-page.html:41
+msgid "Node"
+msgstr "Nó"
+
+#: pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:192
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:45
+msgid "Nodes"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:42
+msgid "Nodes are the machines that run your containers."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:15
+#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
+#: pkg/kubernetes/views/image-config.html:25
+#: pkg/kubernetes/views/imagestream-body.html:33
+msgid "None"
+msgstr "Nenhum"
+
+#: pkg/playground/translate.html:30 pkg/kubernetes/views/details-page.html:53
+#: pkg/kubernetes/views/node-body.html:42
+msgid "Not Ready"
+msgstr "Não está pronto"
+
+#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
+msgid "Not a valid number of replicas"
+msgstr "Não é um número válido de réplicas"
+
+#: pkg/lib/credentials.js:248
+msgid "Not a valid private key"
+msgstr "Chave privada não válida"
+
+#: pkg/kubernetes/scripts/details.js:546
+msgid "Not a valid value for Host"
+msgstr ""
+
+#: pkg/docker/index.html:57
+msgid "Not authorized to access Docker on this system"
+msgstr "Não autorizado para acessar Docker neste sistema"
+
+#: pkg/ostree/app.js:81
+msgid "Not authorized to update software on this system"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:805
+msgid "Not available"
+msgstr "Indisponível"
+
+#: pkg/selinux/setroubleshoot.js:238
+msgid "Not connected"
+msgstr "Não conectado"
+
+#: pkg/kubernetes/views/details-page.html:122
+msgid "Not deployed"
+msgstr ""
+
+#: pkg/docker/details.js:177 pkg/docker/image.js:112
+#: pkg/storaged/details.js:1822
+msgid "Not found"
+msgstr "Não encontrado"
+
+#: src/base1/cockpit.js:3691
+msgid "Not permitted to perform this action."
+msgstr ""
+
+#: pkg/storaged/details.js:1574
+msgid "Not running"
+msgstr "Não está rodando"
+
+#: pkg/systemd/index.html:62
+msgid "Not synchronized"
+msgstr ""
+
+#: pkg/systemd/services.html:299
+msgid "Note"
+msgstr "Nota"
+
+#: pkg/systemd/logs.html:49
+msgid "Notices"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:13
+msgid "OS"
+msgstr ""
+
+#: pkg/ostree/client.js:500
+msgid "OS $0 not found"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:19
+msgid "OS Versions"
+msgstr ""
+
+#: pkg/ostree/app.js:83
+msgid "OSTree is not available on this system"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:405
+msgid "Occurred $0"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:400
+msgid "Occurred between $0 and $1"
+msgstr ""
+
+#: pkg/systemd/index.html:157 pkg/playground/jquery-patterns.html:95
+#: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:189
+#: pkg/storaged/index.html:565
+msgid "Off"
+msgstr "Desligado"
+
+#: pkg/lib/cockpit-components-dialog.jsx:155
+msgid "Ok"
+msgstr ""
+
+#: pkg/users/index.html:226 pkg/shell/index.html:248
+msgid "Old Password"
+msgstr "Senha Atual"
+
+#: pkg/users/local.js:78 pkg/lib/credentials.js:213
+#, fuzzy
+msgid "Old password not accepted"
+msgstr "Senha antida não aceita"
+
+#: pkg/systemd/index.html:153 pkg/playground/jquery-patterns.html:91
+#: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:185
+#: pkg/storaged/index.html:564
+msgid "On"
+msgstr "Ligado"
+
+#: pkg/kubernetes/views/image-meta.html:7
+msgid "On Build"
+msgstr ""
+
+#: pkg/docker/index.html:568
+msgid "On Failure"
+msgstr ""
+
+#: pkg/docker/util.js:104
+msgid "On failure, retry $0 time"
+msgid_plural "On failure, retry $0 times"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/realmd/operation.html:71
+msgid "One Time Password"
+msgstr ""
+
+#: pkg/systemd/init.js:1147
+msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
+msgstr ""
+
+#: pkg/shell/simple.html:28 pkg/shell/index.html:28 pkg/shell/stub.html:28
+msgid "Ooops!"
+msgstr ""
+
+#: pkg/systemd/index.html:89 pkg/ostree/index.html:111
+#: pkg/kubernetes/views/nodes-page.html:42
+msgid "Operating System"
+msgstr ""
+
+#: pkg/ostree/index.html:186
+msgid "Operating System Updates"
 msgstr ""
 
 #: pkg/storaged/jobs.js:166
 msgid "Operation '$operation' on $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:180
-msgid "unknown target"
+#: pkg/storaged/overview.js:189
+msgctxt "storage"
+msgid "Optical Drive"
+msgstr "Optical Drive"
+
+#: pkg/kubernetes/views/volume-body.html:130
+msgid "Options"
+msgstr "Opções"
+
+#: pkg/subscriptions/subscriptions-register.jsx:176
+msgid "Organization"
 msgstr ""
 
-#: pkg/storaged/permissions.js:61
-msgid "The user <b>$0</b> is not permitted to manage storage"
-msgstr "Ao usuário <b>$0</b> não é permitido gerenciar o armazaenamento"
+#: pkg/storaged/details.js:1253
+msgctxt "storage-id-desc"
+msgid "Other Data"
+msgstr "Outros Dados"
 
-#: pkg/realmd/operation.js:96
-msgid "Join"
+#: pkg/storaged/index.html:202
+msgid "Other Devices"
+msgstr "Outros dispositivos"
+
+#: pkg/docker/index.html:319 pkg/kubernetes/registry.html:42
+#: pkg/kubernetes/index.html:39
+msgid "Overview"
 msgstr ""
 
-#: pkg/realmd/operation.js:101
-msgid "Leave"
+#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
+msgid "Overwrite existing data with zeros"
 msgstr ""
 
-#: pkg/realmd/operation.js:148
-msgid "Domain $0 could not be contacted"
+#: pkg/kubernetes/views/volume-body.html:4
+msgid "PD Name"
 msgstr ""
 
-#: pkg/realmd/operation.js:220
-msgid "Domain $0 is not supported"
+#: pkg/ostree/index.html:100
+msgid "Packages"
 msgstr ""
 
-#: pkg/realmd/operation.js:347
-msgid "Joining this domain is not supported"
+#: pkg/networkmanager/index.html:133
+msgid "Parent"
+msgstr "Parente"
+
+#: pkg/networkmanager/interfaces.js:2619
+msgid "Parent $parent"
+msgstr "Parent $parent"
+
+#: pkg/networkmanager/interfaces.js:1372
+msgid "Part of "
+msgstr "Parte de"
+
+#: pkg/kubernetes/views/volume-body.html:8
+#: pkg/kubernetes/views/volume-body.html:18
+msgid "Partition"
+msgstr "Partição"
+
+#: pkg/storaged/details.js:346
+msgid "Partitioning"
+msgstr "Particionamento"
+
+#: pkg/networkmanager/interfaces.js:1848
+msgid "Passive"
 msgstr ""
 
-#: pkg/realmd/operation.js:366
-msgid "More"
-msgstr ""
+#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
+msgid "Passphrase"
+msgstr "Frase-senha"
 
-#: pkg/realmd/operation.js:417
-msgid "Cannot join a domain because realmd is not available on this system"
-msgstr ""
-
-#: pkg/realmd/operation.js:436
-msgid "The user <b>$0</b> is not permitted to modify realms"
-msgstr ""
-
-#: pkg/realmd/operation.js:453
-msgid "Join Domain"
-msgstr ""
-
-#: pkg/docker/run.js:246 pkg/docker/util.js:102
-#: pkg/networkmanager/interfaces.js:2280 pkg/kubernetes/scripts/volumes.js:992
-#: pkg/docker/index.html.h:46
-msgid "No"
-msgstr "Não"
-
-#: pkg/docker/run.js:261 pkg/docker/console.html.h:1
-#: pkg/kubernetes/views/image-panel.html.h:2
-#: pkg/kubernetes/views/container-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:1
-#: pkg/kubernetes/views/image-page.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:1
-msgid "Container"
-msgstr "Container"
-
-#: pkg/docker/run.js:263 pkg/kubernetes/views/route-modify.html.h:2
-#: pkg/kubernetes/views/route-body.html.h:4
-#: pkg/kubernetes/views/details-page.html.h:12
-msgid "Host"
-msgstr "Máquina"
-
-#: pkg/docker/run.js:283
-msgid "Invalid port"
-msgstr "Porta inválida"
-
-#: pkg/docker/run.js:293
-msgid "Duplicate port"
-msgstr "Porta duplicada"
-
-#: pkg/docker/run.js:332
+#: pkg/storaged/details.js:224
 #, fuzzy
-msgid "Command can't be empty"
+msgid "Passphrase cannot be empty"
 msgstr "Namespace não pode estar vazio ."
 
-#: pkg/docker/run.js:350
-msgid "No alias specified"
-msgstr "Nenhum apelido especificado"
-
-#: pkg/docker/run.js:360
-msgid "Duplicate alias"
-msgstr "Apelido duplicado"
-
-#: pkg/docker/run.js:384
-msgid "No container specified"
-msgstr "Nenhum container especificado"
-
-#: pkg/docker/details.js:47 pkg/docker/image.js:43
-msgctxt "page-title"
-msgid "Containers"
-msgstr "Containers"
-
-#: pkg/docker/details.js:144
-msgid "${hip}:${hport} -> $cport"
-msgstr "${hip}:${hport} -> $cport"
-
-#: pkg/docker/details.js:272 pkg/docker/containers-view.jsx:167
-msgid "Deleting a container will erase all data in it."
-msgstr "A exclusão de um container irá apagar todos os dados nele."
-
-#: pkg/docker/storage.jsx:156
-#, fuzzy
-msgid "Solid-State Disk"
-msgstr "Solid-State Disk"
-
-#: pkg/docker/storage.jsx:157
-#, fuzzy
-msgid "Hard Disk"
-msgstr "Hard Disk"
-
-#: pkg/docker/storage.jsx:158 pkg/storaged/index.html.h:33
-msgid "Drive"
-msgstr "Unidade"
-
-#: pkg/docker/storage.jsx:188
-#, fuzzy
-msgid "Local Disks"
-msgstr "$0 Discos"
-
-#: pkg/docker/storage.jsx:194
-msgid "No additional local storage found."
+#: pkg/storaged/details.js:232
+msgid "Passphrases do not match"
 msgstr ""
 
-#: pkg/docker/storage.jsx:242
-msgid " (shared with the OS)"
+#: pkg/users/index.html:115 pkg/users/index.html:160 pkg/shell/index.html:199
+#: pkg/shell/index.html:212 pkg/kubernetes/views/auth-form.html:105
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+msgid "Password"
+msgstr "Senha"
+
+#: pkg/users/local.js:259
+msgid "Password is not acceptable"
+msgstr "Senha não é aceitavél"
+
+#: pkg/users/local.js:247
+msgid "Password is too weak"
+msgstr "Senha é muito fraca"
+
+#: pkg/lib/credentials.js:278
+msgid "Password not accepted"
+msgstr "Senha não aceita"
+
+#: pkg/kubernetes/views/pv-modify.html:126
+#: pkg/kubernetes/views/volume-body.html:37
+#: pkg/kubernetes/views/volume-body.html:49
+#: pkg/kubernetes/views/volume-body.html:101
+msgid "Path"
 msgstr ""
 
-#: pkg/docker/storage.jsx:282
-msgid "Information about the Docker storage pool is not available."
+#: pkg/networkmanager/index.html:259
+msgid "Path cost"
+msgstr "Custo do Caminho"
+
+#: pkg/networkmanager/interfaces.js:2601
+msgid "Path cost $path_cost"
+msgstr "Path cost $path_cost"
+
+#: pkg/systemd/services.html:56
+msgid "Paths"
+msgstr "Caminhos"
+
+#: pkg/kubernetes/views/volumes-page.html:53
+msgid "Pending Volume Claims"
 msgstr ""
 
-#: pkg/docker/storage.jsx:314
-msgid "Total"
+#: pkg/systemd/index.html:143
+msgid "Performance Profile"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:14
+msgid "Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:16
+msgid "Phase"
+msgstr ""
+
+#: pkg/storaged/index.html:641
+msgid "Physical Volumes"
+msgstr "Volumes Físicos"
+
+#: pkg/networkmanager/index.html:405
+#, fuzzy
+msgid "Ping Interval"
+msgstr "Monitorando Intervalo"
+
+#: pkg/networkmanager/index.html:414
+#, fuzzy
+msgid "Ping Target"
+msgstr "Apagando $target"
+
+#: pkg/docker/containers-view.jsx:166 pkg/docker/details.js:271
+#: pkg/docker/image.js:151 pkg/storaged/details.js:625
+#: pkg/storaged/details.js:821 pkg/storaged/details.js:1016
+msgid "Please confirm deletion of $0"
+msgstr "Por favor, confirme a remoção de $0"
+
+#: pkg/docker/util.js:501
+msgid "Please confirm forced deletion of $0"
+msgstr "Por favor, confirme a exclusão forçada de $0"
+
+#: pkg/kubernetes/scripts/dashboard.js:441
+msgid "Please create another namespace for $0 \"$1\""
+msgstr "Por favor, crie outro namespace para $0 \"$1\""
+
+#: pkg/kubernetes/scripts/volumes.js:574
+msgid "Please provide a GlusterFS volume name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:554
+msgid "Please provide a username"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:632
+msgid "Please provide a valid NFS server"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:539
+msgid "Please provide a valid address"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:805
+msgid "Please provide a valid filesystem type"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:813
+msgid "Please provide a valid interface"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:797
+msgid "Please provide a valid logical unit number"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:477
+msgid "Please provide a valid name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:376
+msgid "Please provide a valid namespace."
+msgstr "Por favor, forneça um namespace válido."
+
+#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
+msgid "Please provide a valid path"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:789
+msgid "Please provide a valid qualified name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:485
+msgid "Please provide a valid storage capacity."
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:781
+msgid "Please provide a valid target"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:469
+msgid "Please select a valid access mode"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:565
+msgid "Please select a valid endpoint"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:493
+msgid "Please select a valid policy option."
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:397
+msgid "Please type an address"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:12
+#: pkg/kubernetes/views/containers-listing.html:12
+#: pkg/kubernetes/views/topology-page.html:14
+msgid "Pod"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:20
+msgid "Pod Address"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:4
+#: pkg/kubernetes/views/service-endpoint.html:9
+msgid "Pod Endpoints"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:4
+msgid "Pod Replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:15
+#: pkg/kubernetes/views/replicationcontroller-pods.html:11
+msgid "Pod Selector"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:17
+#: pkg/kubernetes/views/dashboard-page.html:18
+#: pkg/kubernetes/views/details-page.html:166
+#: pkg/kubernetes/views/pv-claim.html:37
+#: pkg/kubernetes/views/replicationcontroller-panel.html:12
+msgid "Pods"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:15
+msgid ""
+"Pods contain one or more containers that run                together on a "
+"node, containing your application code."
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:60
+msgid "Pool Name"
+msgstr ""
+
+#: pkg/storaged/utils.js:166
+msgid "Pool for Thin Logical Volumes"
+msgstr "Buscando por  Thin Logical Volumes"
+
+#: pkg/storaged/details.js:874
+msgid "Pool for thinly provisioned volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:45
+msgid "Populate"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:23
+msgid "Port"
+msgstr ""
+
+#: pkg/docker/index.html:525 pkg/kubernetes/views/service-body.html:13
+#: pkg/kubernetes/views/image-config.html:23
+#: pkg/kubernetes/views/container-body.html:12
+#: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:373
+msgid "Ports"
+msgstr "Portas"
+
+#: pkg/systemd/index.html:123
+msgid "Power Options"
+msgstr "Opções de Energia"
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length"
+msgstr "Comprimento do prefixo"
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length or Netmask"
+msgstr "Comprimento do prefixo ou máscara de rede"
+
+#: pkg/networkmanager/interfaces.js:809
+msgid "Preparing"
+msgstr "Preparando"
+
+#: pkg/systemd/init.js:544
+msgid "Preset"
+msgstr "Preset"
+
+#: pkg/systemd/init.js:545
+msgid "Preset Forcefully"
+msgstr "Preset Forçado"
+
+#: pkg/systemd/index.html:310
+msgid "Pretty Host Name"
+msgstr ""
+
+#: pkg/networkmanager/index.html:307
+msgid "Primary"
+msgstr "Primário"
+
+#: pkg/storaged/details.js:1426
+msgid "Primary Partition"
+msgstr "Partição Primária"
+
+#: pkg/networkmanager/index.html:250 pkg/networkmanager/index.html:446
+#: pkg/networkmanager/index.html:464
+msgid "Priority"
+msgstr "Prioridade"
+
+#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
+msgid "Priority $priority"
+msgstr "Prioridade $priority"
+
+#: pkg/subscriptions/subscriptions-view.jsx:33
+msgid "Product ID"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:32
+msgid "Product name"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:4
+#: pkg/kubernetes/views/replicationcontroller-body.html:4
+#: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/imagestream-modify.html:21
+#: pkg/kubernetes/views/pod-body.html:4
+#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/details-page.html:35
+#: pkg/kubernetes/views/details-page.html:71
+#: pkg/kubernetes/views/details-page.html:104
+#: pkg/kubernetes/views/details-page.html:138
+#: pkg/kubernetes/views/details-page.html:172
+#: pkg/kubernetes/views/containers-listing.html:13
+#: pkg/kubernetes/views/route-body.html:4
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
+msgid "Project"
+msgstr "Projeto"
+
+#: pkg/kubernetes/views/project-body.html:20
+msgid "Project Members"
+msgstr ""
+
+#: pkg/kubernetes/views/filter-project.html:5
+msgid "Project:"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:54 pkg/kubernetes/views/group-delete.html:10
+#: pkg/kubernetes/views/project-listing.html:9
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:84
+msgid "Projects"
+msgstr ""
+
+#: pkg/users/local.js:82
+#, fuzzy
+msgid "Prompting via passwd timed out"
+msgstr "Tempo excedido na tentativa via senha"
+
+#: pkg/lib/credentials.js:251
+msgid "Prompting via ssh-add timed out"
+msgstr ""
+
+#: pkg/lib/credentials.js:191
+#, fuzzy
+msgid "Prompting via ssh-keygen timed out"
+msgstr "tempo excedido na tentativa via chave ssh"
+
+#: pkg/subscriptions/subscriptions-register.jsx:125
+msgid "Proxy"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:25
+msgid "Proxy Version"
+msgstr ""
+
+#: pkg/shell/index.html:198 pkg/lib/machine-auth-failed.html:9
+msgid "Public Key"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:150
+msgid "Pull an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:66
+msgid "Pull from"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:31
+msgid "Pull repository"
+msgstr ""
+
+#: pkg/storaged/details.js:869
+msgid "Purpose"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:140
+msgid "Push an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:147
+#: pkg/kubernetes/views/volume-body.html:77
+msgid "Qualified Name"
+msgstr ""
+
+#: pkg/storaged/details.js:1539
+msgid "RAID ($0)"
+msgstr ""
+
+#: pkg/storaged/details.js:1533
+msgid "RAID 0"
+msgstr "RAID 0"
+
+#: pkg/storaged/overview.js:422
+msgid "RAID 0 (Stripe)"
+msgstr "RAID 0 (Distribuição)"
+
+#: pkg/storaged/details.js:1534
+msgid "RAID 1"
+msgstr "RAID 1"
+
+#: pkg/storaged/overview.js:423
+msgid "RAID 1 (Mirror)"
+msgstr "RAID 1 (Espelhamento)"
+
+#: pkg/storaged/details.js:1538
+msgid "RAID 10"
+msgstr "RAID 10"
+
+#: pkg/storaged/overview.js:427
+msgid "RAID 10 (Stripe of Mirrors)"
+msgstr "RAID 10 (Distribuição de Espelhos)"
+
+#: pkg/storaged/details.js:1535
+msgid "RAID 4"
+msgstr "RAID 4"
+
+#: pkg/storaged/overview.js:424
+msgid "RAID 4 (Dedicated Parity)"
+msgstr "RAID 4 (Paridade Dedicada)"
+
+#: pkg/storaged/details.js:1536
+msgid "RAID 5"
+msgstr "RAID 5"
+
+#: pkg/storaged/overview.js:425
+msgid "RAID 5 (Distributed Parity)"
+msgstr "RAID 5 (Paridade Distribuída)"
+
+#: pkg/storaged/details.js:1537
+msgid "RAID 6"
+msgstr "RAID 6"
+
+#: pkg/storaged/overview.js:426
+msgid "RAID 6 (Double Distributed Parity)"
+msgstr "RAID 6 (Paridade Duplamente Distribuída)"
+
+#: pkg/storaged/index.html:537
+msgid "RAID Device"
+msgstr "Dispositivo RAID"
+
+#: pkg/storaged/utils.js:233
+msgid "RAID Device $0"
+msgstr ""
+
+#: pkg/storaged/index.html:65
+msgid "RAID Devices"
+msgstr ""
+
+#: pkg/storaged/overview.js:420
+msgid "RAID Level"
+msgstr "Nível de RAID"
+
+#: pkg/storaged/index.html:555
+msgctxt "storage"
+msgid "RAID Level"
+msgstr "Nível de RAID"
+
+#: pkg/storaged/details.js:1228
+msgctxt "storage-id-desc"
+msgid "RAID Member"
+msgstr "RAID Membro"
+
+#: pkg/kubernetes/scripts/volumes.js:200
+msgid "Rados Block Device"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:194
+#: pkg/kubernetes/views/volume-body.html:10
+#: pkg/kubernetes/views/volume-body.html:20
+#: pkg/kubernetes/views/volume-body.html:44
+#: pkg/kubernetes/views/volume-body.html:51
+#: pkg/kubernetes/views/volume-body.html:71
+#: pkg/kubernetes/views/volume-body.html:85
+#: pkg/kubernetes/views/volume-body.html:93
+#: pkg/kubernetes/views/volume-body.html:110
+#: pkg/kubernetes/views/volume-body.html:122
+#: pkg/kubernetes/views/volume-body.html:136
+#: pkg/kubernetes/views/volume-body.html:143
+msgid "Read Only"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:211
+msgid "Read and write from a single node"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:213
+msgid "Read and write from multiple nodes"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:212
+msgid "Read only from multiple nodes"
+msgstr ""
+
+#: pkg/docker/index.html:385
+msgid "ReadOnly"
+msgstr ""
+
+#: pkg/docker/index.html:384
+msgid "ReadWrite"
+msgstr ""
+
+#: pkg/storaged/index.html:327
+msgid "Reading"
+msgstr ""
+
+#: pkg/playground/translate.html:20 pkg/playground/translate.html:179
+#: pkg/kubernetes/views/details-page.html:52
+#: pkg/kubernetes/views/node-body.html:41
+msgid "Ready"
+msgstr "Pronto"
+
+#: pkg/playground/translate.html:25
+#, fuzzy
+msgctxt "verb"
+msgid "Ready"
+msgstr "Pronto"
+
+#: pkg/systemd/index.html:319
+msgid "Real Host Name"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:45
+msgid "Reason"
+msgstr ""
+
+#: pkg/lib/journal.js:241
+msgid "Reboot"
+msgstr "Reiniciar"
+
+#: pkg/networkmanager/index.html:75 pkg/networkmanager/index.html:98
+#: pkg/networkmanager/index.html:116 pkg/networkmanager/index.html:521
+#: pkg/networkmanager/index.html:551
+msgid "Receiving"
+msgstr ""
+
+#: pkg/ostree/client.js:56
+msgid "Receiving delta parts"
+msgstr ""
+
+#: pkg/ostree/client.js:58
+msgid "Receiving metadata objects"
+msgstr ""
+
+#: pkg/ostree/client.js:61
+msgid "Receiving objects: $0%"
+msgstr ""
+
+#: pkg/systemd/logs.html:40
+msgid "Recent"
+msgstr "Recente"
+
+#: pkg/kubernetes/views/pv-modify.html:56 pkg/kubernetes/views/pv-body.html:6
+msgid "Reclaim Policy"
+msgstr ""
+
+#: pkg/shell/simple.html:144 pkg/shell/index.html:327 pkg/shell/stub.html:180
+msgid "Reconnect"
+msgstr ""
+
+#: pkg/storaged/details.js:1594
+msgid "Recovering"
+msgstr "Recuperação"
+
+#: pkg/storaged/jobs.js:145
+msgid "Recovering RAID Device $target"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:219
+msgid "Recycle"
 msgstr ""
 
 #: pkg/docker/storage.jsx:348
 msgid "Reformat and add disks"
 msgstr ""
 
-#: pkg/docker/storage.jsx:355
-msgid ""
-"The storage pool will be reset to optimize its layout.  All containers will "
-"be erased."
+#: pkg/kubernetes/views/pv-modify.html:205
+msgid "Register"
 msgstr ""
 
-#: pkg/docker/storage.jsx:360
-msgid "Erase containers, reformat disks, and add them"
+#: pkg/kubernetes/views/volumes-page.html:12
+msgid "Register New Volume"
 msgstr ""
 
-#: pkg/docker/storage.jsx:363
-msgid "Add Additional Storage"
+#: pkg/kubernetes/views/pv-modify.html:4
+msgid "Register Persistent Volume"
 msgstr ""
 
-#: pkg/docker/storage.jsx:366
-msgid ""
-"All data on selected disks will be erased and disks will be added to the "
-"storage pool."
+#: pkg/subscriptions/main.js:74
+msgid "Register system"
 msgstr ""
 
-#: pkg/docker/storage.jsx:404
+#: pkg/ostree/index.html:115
+msgid "Released"
+msgstr ""
+
+#: pkg/systemd/init.js:518
+msgid "Reload"
+msgstr "Recarregar"
+
+#: pkg/systemd/init.js:519
+msgid "Reload or Restart"
+msgstr "Recarregar ou Reiniciar"
+
+#: pkg/systemd/init.js:521
+msgid "Reload or Try Restart"
+msgstr "Recarregue ou Tente Reiniciar"
+
+#: pkg/kubernetes/views/imagestream-modify.html:89
+msgid "Remote registry is insecure"
+msgstr ""
+
+#: cockpit.desktop.in.h:3
+msgid "Remote;Administration;"
+msgstr "Remoto; Administração;"
+
+#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
+msgctxt "storage"
+msgid "Removable Drive"
+msgstr "Removable Drive"
+
+#: pkg/ostree/index.html:123 pkg/ostree/index.html:146
+msgid "Removals"
+msgstr ""
+
+#: pkg/kubernetes/views/user-group-remove.html:10
+#: pkg/kubernetes/views/group-delete.html:21
+#: pkg/kubernetes/views/user-delete.html:25
+#: pkg/kubernetes/views/remove-role-dialog.html:8
+msgid "Remove"
+msgstr "Remover"
+
+#: pkg/networkmanager/interfaces.js:2791
 #, fuzzy
-msgid "Could not add all disks"
-msgstr "Não foi possível listar serviços"
+msgid "Remove $0"
+msgstr "Remover"
+
+#: pkg/kubernetes/views/group-delete.html:3
+msgid "Remove Group"
+msgstr ""
+
+#: pkg/kubernetes/views/user-group-remove.html:3
+msgid "Remove Member"
+msgstr ""
+
+#: pkg/kubernetes/views/remove-role-dialog.html:3
+msgid "Remove Role"
+msgstr ""
+
+#: pkg/kubernetes/views/user-delete.html:3
+msgid "Remove User"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:3
+msgid "Remove image tag"
+msgstr ""
+
+#: pkg/kubernetes/views/user-remove-membership.html:3
+msgid "Remove membership"
+msgstr ""
+
+#: pkg/storaged/jobs.js:141
+msgid "Removing $target from RAID Device"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2788
+msgid "Removing <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:154
+msgid "Removing physical volume from $target"
+msgstr ""
+
+#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
+#: pkg/storaged/details.js:1775
+msgid "Rename"
+msgstr "Renomear"
+
+#: pkg/storaged/details.js:795
+msgid "Rename Volume Group"
+msgstr ""
+
+#: pkg/storaged/details.js:706
+msgid "Renamee Logical Volume"
+msgstr ""
+
+#: pkg/storaged/jobs.js:157
+msgid "Renaming $target"
+msgstr ""
+
+#: pkg/systemd/services.html:432
+msgid "Repeat Daily"
+msgstr ""
+
+#: pkg/systemd/services.html:431
+msgid "Repeat Hourly"
+msgstr ""
+
+#: pkg/systemd/services.html:434
+msgid "Repeat Monthly"
+msgstr ""
+
+#: pkg/systemd/services.html:433
+msgid "Repeat Weekly"
+msgstr ""
+
+#: pkg/systemd/services.html:435
+msgid "Repeat Yearly"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-body.html:9
+#: pkg/kubernetes/views/details-page.html:141
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
+#: pkg/kubernetes/views/replicationcontroller-modify.html:8
+msgid "Replicas"
+msgstr "Réplicas"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:14
+#: pkg/kubernetes/views/replicationcontroller-panel.html:10
+#: pkg/kubernetes/views/topology-page.html:23
+msgid "Replication Controller"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:132
+msgid "Replication Controllers"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:24
+msgid ""
+"Replication controllers dynamically create instances of                pods "
+"from templates, and remove pods when necessary."
+msgstr ""
+
+#: pkg/docker/index.html:718
+msgid "Repository"
+msgstr "Repositório"
+
+#: pkg/kubernetes/views/volume-body.html:24
+msgid "Repository URL"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
+msgid "Requested"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:13
+msgid "Requests"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:54
+msgid "Requires Authentication"
+msgstr ""
+
+#: pkg/docker/index.html:323
+msgid "Reset"
+msgstr "Redefinir"
 
 #: pkg/docker/storage.jsx:417
 #, fuzzy
@@ -2095,388 +4610,595 @@ msgid ""
 "the pool."
 msgstr ""
 
-#: pkg/docker/storage.jsx:423
-msgid "Erase containers and reset storage pool"
+#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
+msgid "Resize"
+msgstr "Re-dimensionar"
+
+#: pkg/storaged/details.js:673
+msgid "Resize Filesystem"
 msgstr ""
 
-#: pkg/docker/storage.jsx:446
-msgid "Could not reset the storage pool"
+#: pkg/storaged/details.js:661
+msgid "Resize Logical Volume"
 msgstr ""
 
-#: pkg/docker/storage.jsx:482
-msgid "You don't have permission to manage the Docker storage pool."
+#: pkg/storaged/jobs.js:158
+msgid "Resizing $target"
 msgstr ""
 
-#: pkg/docker/storage.jsx:485
-msgid "The Docker storage pool cannot be managed on this system."
+#: pkg/systemd/index.html:126 pkg/systemd/index.html:133
+msgid "Restart"
+msgstr "Reiniciar"
+
+#: pkg/kubernetes/views/container-body.html:20
+msgid "Restart Count"
 msgstr ""
 
-#: pkg/docker/image.js:77
-msgid "Image $0"
-msgstr "Imagem $0"
-
-#: pkg/docker/image.js:152
-msgid ""
-"Deleting an image will delete it, but you can probably download it again if "
-"you need it later.  Unless this image has never been pushed to a repository, "
-"that is, in which case you probably can't download it again."
-msgstr ""
-"Apagar uma imagem irá excluí-la, mas provavelmente você pode baixá-la "
-"novamente se você precisar dela mais tarde. A menos que essa imagem nunca "
-"tem sido enviada para um repositório, ou seja, caso em que você "
-"provavelmente não pode baixá-la novamente."
-
-#: pkg/docker/util.js:94
-msgid "Up since $StartedAt"
-msgstr "Ativo desde $StartedAt"
-
-#: pkg/docker/util.js:96
-msgid "Exited $ExitCode"
-msgstr "Encerrado $ExitCode"
-
-#: pkg/docker/util.js:104
-msgid "On failure, retry $0 time"
-msgid_plural "On failure, retry $0 times"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/docker/util.js:107 pkg/docker/index.html.h:48
-msgid "Always"
+#: pkg/docker/index.html:558 pkg/kubernetes/views/pod-body.html:10
+msgid "Restart Policy"
 msgstr ""
 
-#: pkg/docker/util.js:109 pkg/docker/index.html.h:49
-msgid "Unless Stopped"
+#: pkg/kubernetes/scripts/volumes.js:217
+msgid "Retain"
 msgstr ""
 
-#: pkg/docker/util.js:123
-msgid "default"
-msgstr "padrão"
-
-#: pkg/docker/util.js:124
-msgid "$0 shares"
-msgstr "$0 compartilhamentos"
-
-#: pkg/docker/util.js:231
-msgid "Stopped"
-msgstr "Parado"
-
-#: pkg/docker/util.js:488
-msgid "Container is currently running."
-msgstr "Container está em execução."
-
-#: pkg/docker/util.js:490
-msgid ""
-"Container is currently marked as not running, but regular stopping failed."
-msgstr ""
-"Container está atualmente marcado como parado, mas parada normal falhou."
-
-#: pkg/docker/util.js:491
-msgid "Error message from Docker:"
-msgstr "Mensagem de erro do Docker:"
-
-#: pkg/docker/util.js:501
-msgid "Please confirm forced deletion of $0"
-msgstr "Por favor, confirme a exclusão forçada de $0"
-
-#: pkg/docker/util.js:503
-msgid "Force Delete"
-msgstr "Remoção forçada"
-
-#: pkg/docker/util.js:544
-msgid "Failed to stop Docker scope: $0"
-msgstr "Falha ao parar Docker escopo: $0"
-
-#: pkg/docker/containers-view.jsx:239
-#, fuzzy
-msgid "Commit"
-msgstr "Comando"
-
-#: pkg/docker/containers.js:64
-msgid "Failed to start Docker: $0"
-msgstr "Falha ao iniciar Docker: $0"
-
-#: pkg/users/authorized-keys.js:103
-msgid "Validating key"
+#: pkg/docker/index.html:574
+msgid "Retries:"
 msgstr ""
 
-#: pkg/users/authorized-keys.js:108
-msgid "Adding key"
+#: pkg/subscriptions/subscriptions-view.jsx:188
+msgid "Retrieving subscription status..."
 msgstr ""
 
-#: pkg/users/authorized-keys.js:115
-msgid "Error saving authorized keys: "
+#: pkg/kubernetes/views/volume-body.html:26
+msgid "Revision"
 msgstr ""
 
-#: pkg/users/authorized-keys.js:118
-msgid "The key you provided was not valid."
+#: pkg/users/index.html:94 pkg/kubernetes/views/add-member-role-dialog.html:39
+#: pkg/kubernetes/views/project-body.html:21
+msgid "Roles"
+msgstr "Papéis"
+
+#: pkg/ostree/index.html:73
+msgid "Roll back and reboot"
 msgstr ""
-
-#: pkg/users/local.js:40
-msgid "The user <b>$0</b> is not permitted to modify accounts"
-msgstr "O usuário <b>$0</b> não tem permissões para odificar contas"
-
-#: pkg/users/local.js:57
-msgid "Unable to delete root account"
-msgstr "Incapaz de deletar a conta root"
-
-#: pkg/users/local.js:59
-msgid "Unable to rename root account"
-msgstr "Incapaz de renomear a conta root"
-
-#: pkg/users/local.js:82
-#, fuzzy
-msgid "Prompting via passwd timed out"
-msgstr "Tempo excedido na tentativa via senha"
-
-#: pkg/users/local.js:247
-msgid "Password is too weak"
-msgstr "Senha é muito fraca"
-
-#: pkg/users/local.js:259
-msgid "Password is not acceptable"
-msgstr "Senha não é aceitavél"
-
-#: pkg/users/local.js:284 pkg/users/local.js:594
-msgctxt "page-title"
-msgid "Accounts"
-msgstr "Contas"
-
-#: pkg/users/local.js:395 pkg/users/local.js:1082
-msgid "The passwords do not match"
-msgstr "As senhas não batem"
-
-#: pkg/users/local.js:400
-msgid "No user name specified"
-msgstr "Nenhum nome de usuário foi especificado"
-
-#: pkg/users/local.js:405
-#, fuzzy
-msgid "No real name specified"
-msgstr "Nenhum nome real  foi especificado"
-
-#: pkg/users/local.js:429 pkg/users/local.js:1104
-msgid "Excellent password"
-msgstr "Senha excelente"
-
-#: pkg/users/local.js:501
-msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
-msgstr ""
-"O nome de usuário coniste em letas de  a-z, digitos, pontos, barras e "
-"underline."
-
-#: pkg/users/local.js:509
-msgid "This user name already exists"
-msgstr "Este usuário já existe"
-
-#: pkg/users/local.js:682 pkg/users/local.js:683
-msgid "Server Administrator"
-msgstr "Administrador do servidor"
-
-#: pkg/users/local.js:684
-msgid "Container Administrator"
-msgstr ""
-
-#: pkg/users/local.js:839
-msgid "Logged In"
-msgstr ""
-
-#: pkg/users/local.js:841
-msgid "Never"
-msgstr ""
-
-#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
-msgid "Delete $0"
-msgstr ""
-
-#: pkg/sosreport/index.js:49 pkg/sosreport/index.js:113
-#: pkg/systemd/services.html.h:13 pkg/lib/machine-invalid-hostkey.html.h:4
-#: pkg/lib/machine-auth-failed.html.h:7
-#: pkg/lib/machine-unknown-hostkey.html.h:4
-#: pkg/lib/machine-change-port.html.h:8 pkg/lib/machine-not-supported.html.h:3
-#: pkg/shell/index.html.h:37
-msgid "Close"
-msgstr "Fechar"
-
-#: pkg/sosreport/index.js:115
-msgid "No archive has been created."
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:598 pkg/networkmanager/interfaces.js:1051
-#: pkg/networkmanager/interfaces.js:2255 pkg/networkmanager/interfaces.js:2257
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:753 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/kubernetes/views/node-body.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:6
-#: pkg/kubernetes/views/pv-claim.html.h:7
-#: pkg/kubernetes/views/image-body.html.h:6
-#: pkg/kubernetes/views/pv-body.html.h:5
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#: pkg/networkmanager/interfaces.js:805
-msgid "Not available"
-msgstr "Indisponível"
-
-#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
-#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
-msgid "Inactive"
-msgstr "Inativo"
-
-#: pkg/networkmanager/interfaces.js:809
-msgid "Preparing"
-msgstr "Preparando"
-
-#: pkg/networkmanager/interfaces.js:811
-msgid "Configuring"
-msgstr "Configurando"
-
-#: pkg/networkmanager/interfaces.js:813
-msgid "Authenticating"
-msgstr "Autenticando"
-
-#: pkg/networkmanager/interfaces.js:815
-msgid "Configuring IP"
-msgstr "Configurando IP"
-
-#: pkg/networkmanager/interfaces.js:817
-msgid "Checking IP"
-msgstr "Checando IP"
-
-#: pkg/networkmanager/interfaces.js:819
-msgid "Waiting"
-msgstr "Aguardando"
-
-#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
-msgid "Active"
-msgstr "Ativo"
-
-#: pkg/networkmanager/interfaces.js:823
-msgid "Deactivating"
-msgstr "Desativando"
-
-#: pkg/networkmanager/interfaces.js:825 pkg/ostree/index.html.h:14
-msgid "Failed"
-msgstr "Falhou"
-
-#: pkg/networkmanager/interfaces.js:1326
-msgid "No carrier"
-msgstr "Sem sinal"
-
-#: pkg/networkmanager/interfaces.js:1372
-msgid "Part of "
-msgstr "Parte de"
-
-#: pkg/networkmanager/interfaces.js:1420
-msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr ""
-"O usuário <b>$0</b> não tem permissão para modificar as configurações de rede"
-
-#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
-msgctxt "page-title"
-msgid "Networking"
-msgstr "Networking"
-
-#: pkg/networkmanager/interfaces.js:1804
-msgid "Automatic (DHCP)"
-msgstr "Automático (DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
-msgid "Link local"
-msgstr "Link Local"
-
-#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
-msgid "Manual"
-msgstr "Manual"
-
-#: pkg/networkmanager/interfaces.js:1807
-msgid "Shared"
-msgstr "Compartilhado"
-
-#: pkg/networkmanager/interfaces.js:1813 pkg/networkmanager/interfaces.js:2475
-#: pkg/networkmanager/interfaces.js:3019 pkg/networkmanager/interfaces.js:3023
-#: pkg/networkmanager/interfaces.js:3029 pkg/networkmanager/index.html.h:22
-msgid "Automatic"
-msgstr "Automático"
-
-#: pkg/networkmanager/interfaces.js:1814
-msgid "Automatic (DHCP only)"
-msgstr "Automático (apenas DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1817
-msgid "Ignore"
-msgstr "Ignorar"
 
 #: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
 msgid "Round Robin"
 msgstr "Round Robin"
 
-#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
-msgid "Active Backup"
-msgstr "Backup Ativo"
+#: pkg/kubernetes/views/route-page.html:14
+#: pkg/kubernetes/views/route-panel.html:9
+msgid "Route"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1824
-msgid "XOR"
-msgstr "XOR"
+#: pkg/kubernetes/views/details-page.html:65
+msgid "Routes"
+msgstr "Rotas"
 
-#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
-msgid "Broadcast"
-msgstr "Broadcast"
-
-#: pkg/networkmanager/interfaces.js:1826
-msgid "802.3ad"
-msgstr "802.3ad"
-
-#: pkg/networkmanager/interfaces.js:1827
-msgid "Adaptive transmit load balancing"
-msgstr "Transmissão dinâmica de balanceamento de carga"
-
-#: pkg/networkmanager/interfaces.js:1828
-msgid "Adaptive load balancing"
-msgstr "Balanceamento de carga dinâmico"
-
-#: pkg/networkmanager/interfaces.js:1833
-msgid "MII (Recommended)"
-msgstr "MII (Recomendado)"
-
-#: pkg/networkmanager/interfaces.js:1834
-msgid "ARP"
-msgstr "ARP"
-
-#: pkg/networkmanager/interfaces.js:1841
+#: pkg/systemd/services.html:384
 #, fuzzy
-msgid "Load Balancing"
-msgstr "Balanceamento de carga dinâmico"
+msgid "Run"
+msgstr "Executando"
 
-#: pkg/networkmanager/interfaces.js:1843
+#: pkg/kubernetes/views/image-config.html:4
+msgid "Run as"
+msgstr ""
+
+#: pkg/networkmanager/index.html:381
 #, fuzzy
-msgid "802.3ad LACP"
-msgstr "802.3ad"
+msgid "Runner"
+msgstr "Executando"
 
-#: pkg/networkmanager/interfaces.js:1848
-msgid "Passive"
+#: pkg/ostree/index.html:83
+msgid "Running"
+msgstr "Executando"
+
+#: pkg/selinux/setroubleshoot-view.jsx:478
+msgid "SELinux Access Control Errors"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1854
-msgid "Ethtool"
+#: pkg/selinux/setroubleshoot-view.jsx:330
+msgid "SELinux Policy"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1855
+#: pkg/selinux/setroubleshoot.html:23
+msgid "SELinux Troubleshoot"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:317
+msgid "SELinux is disabled on the system."
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:309
+msgid "SELinux system status is unknown."
+msgstr ""
+
+#: pkg/storaged/jobs.js:119
+msgid "SMART self-test of $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:218
+msgid "STP Forward delay"
+msgstr "STP Atraso de Redirecionamento "
+
+#: pkg/networkmanager/index.html:227
+msgid "STP Hello time"
+msgstr "STP Hello time"
+
+#: pkg/networkmanager/index.html:236
+msgid "STP Maximum message age"
+msgstr "STP Máxima permanência de mensagem"
+
+#: pkg/networkmanager/index.html:209
+msgid "STP Priority"
+msgstr "STP Prioridade"
+
+#: pkg/systemd/services.html:466
+msgid "Save"
+msgstr ""
+
+#: pkg/ostree/client.js:66
+msgid "Scanning metadata"
+msgstr ""
+
+#: pkg/kubernetes/views/node-capacity.html:9
+msgid "Scheduled Pods"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:322
+msgid "Scheduling Disabled"
+msgstr ""
+
+#: pkg/systemd/services.html:402 pkg/systemd/services.html:406
+msgid "Seconds"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:195
+msgid "Secret"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:106
+msgid "Secret File"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:141
+msgid "Secret Name"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:69
+#: pkg/kubernetes/views/volume-body.html:108
+#: pkg/kubernetes/views/volume-body.html:134
+msgid "Secret Volume"
+msgstr ""
+
+#: pkg/systemd/index.html:93
+msgid "Secure Shell Keys"
+msgstr ""
+
+#: pkg/storaged/jobs.js:136
+msgid "Securely erasing $target"
+msgstr ""
+
+#: pkg/kubernetes/views/file-button.html:4
+msgid "Select Manifest File..."
+msgstr "Selecione Arquivo Manifest ..."
+
+#: pkg/kubernetes/views/topology-page.html:7
+msgid "Select an object to see more details."
+msgstr "Selecione um objeto para ver mais detalhes."
+
+#: pkg/lib/machine-sync-users.html:8
+msgid ""
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
+msgstr ""
+
+#: pkg/networkmanager/index.html:69 pkg/networkmanager/index.html:97
+#: pkg/networkmanager/index.html:115 pkg/networkmanager/index.html:515
+#: pkg/networkmanager/index.html:550
+msgid "Sending"
+msgstr ""
+
+#: pkg/storaged/index.html:432
+msgctxt "storage"
+msgid "Serial Number"
+msgstr "Número de Série"
+
+#: pkg/kubernetes/views/pv-modify.html:82
+#: pkg/kubernetes/views/volume-body.html:47
+msgid "Server"
+msgstr ""
+
+#: pkg/storaged/overview.js:518
+msgid "Server Address"
+msgstr ""
+
+#: pkg/users/local.js:682 pkg/users/local.js:683
+msgid "Server Administrator"
+msgstr "Administrador do servidor"
+
+#: pkg/storaged/overview.js:521
 #, fuzzy
-msgid "ARP Ping"
-msgstr "ARP Monitoramento"
+msgid "Server address cannot be empty."
+msgstr "Namespace não pode estar vazio ."
 
-#: pkg/networkmanager/interfaces.js:1856
-msgid "NSNA Ping"
+#: src/base1/cockpit.js:3709
+msgid "Server has closed the connection."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2156
-msgid "Deleting <b>$0</b> will break the connection to the server, "
+#: pkg/kubernetes/views/service-page.html:12
+#: pkg/kubernetes/views/service-panel.html:8
+#: pkg/kubernetes/views/topology-page.html:32
+msgid "Service"
+msgstr "Serviço"
+
+#: pkg/kubernetes/views/pod-body.html:12
+msgid "Service Account"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2188
-msgid "Switching on <b>$0</b>  will break the connection to the server, "
+#: pkg/systemd/services.html:279
+msgid "Service Logs"
+msgstr ""
+
+#: pkg/systemd/services.html:342
+#, fuzzy
+msgid "Service name"
+msgstr "Serviço"
+
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:272
+#: pkg/kubernetes/views/dashboard-page.html:134
+#: pkg/kubernetes/views/details-page.html:29
+msgid "Services"
+msgstr "Serviços"
+
+#: pkg/kubernetes/views/topology-page.html:33
+msgid ""
+"Services group pods and provide a common DNS                name and an "
+"optional, load-balanced IP address to access them."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:20
+msgid "Session Affinity"
+msgstr ""
+
+#: pkg/dashboard/index.html:190
+msgid "Set"
+msgstr ""
+
+#: pkg/systemd/host.js:559
+msgid "Set Host name"
+msgstr ""
+
+#: pkg/users/index.html:117 pkg/users/index.html:221
+msgid "Set Password"
+msgstr ""
+
+#: pkg/systemd/index.html:395
+msgid "Set Time"
+msgstr ""
+
+#: pkg/docker/index.html:551
+msgid "Set container environment variables"
+msgstr ""
+
+#: pkg/networkmanager/index.html:172
+msgid "Set to"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:326
+msgid ""
+"Setting deviates from the configured state and will revert on the next boot."
+msgstr ""
+
+#: pkg/storaged/jobs.js:131
+msgid "Setting up loop device $target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:139
+msgid "Share Name"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1807
+msgid "Shared"
+msgstr "Compartilhado"
+
+#: pkg/kubernetes/views/container-panel.html:9
+#: pkg/kubernetes/views/container-page-inline.html:14
+msgid "Shell"
+msgstr ""
+
+#: pkg/kubernetes/views/container-page.html:4
+msgid "Show all Containers"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:8
+msgid "Show all Deployment Configs"
+msgstr ""
+
+#: pkg/kubernetes/views/node-page.html:8
+msgid "Show all Nodes"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:9
+msgid "Show all Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-container.html:4
+msgid "Show all Pod Containers"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:8
+msgid "Show all Pods"
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:16
+#: pkg/kubernetes/views/group-page.html:14
+#: pkg/kubernetes/views/project-page.html:23
+msgid "Show all Projects"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:10
+msgid "Show all Replication Controllers"
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:10
+msgid "Show all Routes"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:8
+msgid "Show all Services"
+msgstr ""
+
+#: pkg/docker/index.html:127
+#, fuzzy
+msgid "Show all containers"
+msgstr "Containers"
+
+#: pkg/kubernetes/views/imagestream-page.html:12
+msgid "Show all image streams"
+msgstr ""
+
+#: pkg/docker/index.html:241 pkg/kubernetes/views/image-page.html:11
+msgid "Show all images"
+msgstr ""
+
+#: pkg/systemd/index.html:94
+msgid "Show fingerprints"
+msgstr ""
+
+#: pkg/systemd/index.html:136
+msgid "Shutdown"
+msgstr ""
+
+#: pkg/kubernetes/views/container-body.html:18
+msgid "Since"
+msgstr "Desde"
+
+#: pkg/systemd/init.js:621
+msgid "Since $0"
+msgstr "Desde $0"
+
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/storaged/index.html:232
+msgid "Size"
+msgstr ""
+
+#: pkg/storaged/dialog.js:271
+msgid "Size cannot be negative"
+msgstr ""
+
+#: pkg/storaged/dialog.js:269
+msgid "Size cannot be zero"
+msgstr ""
+
+#: pkg/storaged/dialog.js:273
+msgid "Size is too large"
+msgstr ""
+
+#: pkg/storaged/dialog.js:267
+msgid "Size must be a number"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:43
+#: pkg/kubernetes/views/auth-rejected-cert.html:11
+msgid "Skip Certificate Verification"
+msgstr ""
+
+#: pkg/systemd/services.html:54
+msgid "Sockets"
+msgstr "Sockets"
+
+#: pkg/ostree/index.html:23
+msgid "Software Updates"
+msgstr ""
+
+#: pkg/docker/storage.jsx:156
+#, fuzzy
+msgid "Solid-State Disk"
+msgstr "Solid-State Disk"
+
+#: pkg/storaged/overview.js:182
+msgctxt "storage"
+msgid "Solid-State Disk"
+msgstr "Solid-State Disk"
+
+#: pkg/selinux/setroubleshoot-view.jsx:90
+msgid "Solution applied successfully"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:97
+msgid "Solution failed"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:908
+msgid "Sorry, I don't know how to modify this volume"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:8
+msgid "Source URL"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2573
+msgid "Spanning Tree Protocol"
+msgstr "Spanning Tree Protocol (STP)"
+
+#: pkg/networkmanager/index.html:200
+msgid "Spanning Tree Protocol (STP)"
+msgstr "Spanning Tree Protocol (STP)"
+
+#: pkg/storaged/details.js:1594
+#, fuzzy
+msgid "Spare"
+msgstr "Disponível"
+
+#: pkg/systemd/index.html:470
+msgid "Specific Time"
+msgstr ""
+
+#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
+msgid "Start"
+msgstr "Iniciar"
+
+#: pkg/docker/index.html:68
+msgid "Start Docker"
+msgstr "Iniciar Docker"
+
+#: pkg/storaged/index.html:49
+msgid "Start Multipath"
+msgstr ""
+
+#: pkg/storaged/details.js:1614
+msgid "Start Scrubbing"
+msgstr "Iniciando Scrubbing"
+
+#: pkg/storaged/jobs.js:139
+msgid "Starting RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:124
+msgid "Starting swapspace $target"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:37
+#, fuzzy
+msgid "Starts"
+msgstr "Iniciar"
+
+#: pkg/kubernetes/views/container-body.html:16
+#: pkg/kubernetes/views/details-page.html:38
+#: pkg/kubernetes/views/details-page.html:175
+msgid "State"
+msgstr ""
+
+#: pkg/storaged/index.html:571
+msgctxt "storage"
+msgid "State"
+msgstr "Estado"
+
+#: pkg/systemd/init.js:303
+msgid "Static"
+msgstr "Estático"
+
+#: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/containers-listing.html:16
+#: pkg/kubernetes/views/nodes-page.html:44
+#: pkg/kubernetes/views/pvc-body.html:13 pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/pv-body.html:24
+msgid "Status"
+msgstr "Estado"
+
+#: pkg/subscriptions/subscriptions-view.jsx:146
+#, fuzzy
+msgid "Status: $0"
+msgstr "Estado"
+
+#: pkg/subscriptions/subscriptions-view.jsx:141
+msgid "Status: System isn't registered"
+msgstr ""
+
+#: pkg/networkmanager/index.html:455
+msgid "Sticky"
+msgstr ""
+
+#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
+msgid "Stop"
+msgstr "Pare"
+
+#: pkg/storaged/details.js:1615
+msgid "Stop Scrubbing"
+msgstr "Parando Scrubbing"
+
+#: pkg/kubernetes/views/image-config.html:10
+msgid "Stop with"
+msgstr ""
+
+#: pkg/docker/util.js:231
+msgid "Stopped"
+msgstr "Parado"
+
+#: pkg/storaged/jobs.js:138
+msgid "Stopping RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:125
+msgid "Stopping swapspace $target"
+msgstr ""
+
+#: pkg/storaged/index.html:23 pkg/storaged/index.html:672
+msgid "Storage"
+msgstr ""
+
+#: pkg/storaged/index.html:686
+msgid "Storage Log"
+msgstr "Log de armazenamento"
+
+#: pkg/storaged/index.html:342
+msgid "Storage Logs"
+msgstr ""
+
+#: pkg/docker/index.html:324
+msgid "Storage pool"
+msgstr ""
+
+#: pkg/systemd/index.html:148
+msgid "Store Performance Data"
+msgstr ""
+
+#: pkg/storaged/details.js:237
+msgid "Store passphrase"
+msgstr ""
+
+#: pkg/storaged/details.js:527
+msgid "Stored Passphrase"
+msgstr "Frase-senha armazenada"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:12
+msgid ""
+"Strategy            {{item.spec.strategy.type}}            Latest "
+"Version            {{ item.status.latestVersion }}            Not "
+"deployed        "
+msgstr ""
+
+#: pkg/subscriptions/index.html:22
+msgid "Subscriptions"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:4
+msgid "Summary"
+msgstr ""
+
+#: pkg/storaged/details.js:1251
+msgctxt "storage-id-desc"
+msgid "Swap Space"
+msgstr "Swap Espaço"
+
+#: pkg/systemd/index.html:243
+msgid "Swap Used"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
+msgid "Switch off $0"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2191 pkg/networkmanager/interfaces.js:2765
@@ -2487,355 +5209,623 @@ msgstr ""
 msgid "Switching off <b>$0</b>  will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
-msgid "Switch off $0"
+#: pkg/networkmanager/interfaces.js:2773
+msgid "Switching off <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
-#: pkg/networkmanager/interfaces.js:2507
-msgid "Bond"
-msgstr "Bond"
+#: pkg/networkmanager/interfaces.js:2188
+msgid "Switching on <b>$0</b>  will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2762
+msgid "Switching on <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:75
+msgid "Synchronize"
+msgstr ""
+
+#: pkg/dashboard/index.html:188 pkg/lib/machine-sync-users.html:4
+msgid "Synchronize users"
+msgstr ""
+
+#: pkg/systemd/index.html:54
+msgid "Synchronized"
+msgstr ""
+
+#: pkg/systemd/index.html:51
+msgid "Synchronized with {{Server}}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:146
+msgid "Synchronizing RAID Device $target"
+msgstr ""
+
+#: pkg/systemd/index.html:4
+msgid "System"
+msgstr ""
+
+#: pkg/systemd/services.html:53
+msgid "System Services"
+msgstr "Serviços do Sistema"
+
+#: pkg/systemd/index.html:112
+msgid "System Time"
+msgstr ""
+
+#: pkg/docker/index.html:349
+msgid "TCP"
+msgstr "TCP"
+
+#: pkg/kubernetes/views/route-body.html:12
+msgid "TLS Termination"
+msgstr ""
+
+#: pkg/docker/index.html:724
+msgid "Tag"
+msgstr "Marca"
+
+#: pkg/kubernetes/views/image-body.html:27
+#: pkg/kubernetes/views/imagestream-modify.html:76
+#: pkg/kubernetes/views/image-listing.html:14
+msgid "Tags"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:136
+msgid "Target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:75
+msgid "Target Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:114
+msgid "Target World Wide Names"
+msgstr ""
+
+#: pkg/systemd/services.html:52
+msgid "Targets"
+msgstr "Alvos"
 
 #: pkg/networkmanager/interfaces.js:2235 pkg/networkmanager/interfaces.js:2247
 #: pkg/networkmanager/interfaces.js:2530
 msgid "Team"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
-#: pkg/networkmanager/interfaces.js:2622
-msgid "VLAN"
-msgstr "VLAN"
+#: pkg/networkmanager/interfaces.js:2558
+msgid "Team Port"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
-#: pkg/networkmanager/interfaces.js:2584
-msgid "Bridge"
-msgstr "Bridge"
+#: pkg/networkmanager/index.html:652
+#, fuzzy
+msgid "Team Port Settings"
+msgstr "IPv4 Ajustes"
 
-#: pkg/networkmanager/interfaces.js:2276
-msgid "Carrier"
-msgstr "Sinal"
+#: pkg/networkmanager/index.html:624
+#, fuzzy
+msgid "Team Settings"
+msgstr "IPv4 Ajustes"
 
-#: pkg/networkmanager/interfaces.js:2279 pkg/kubernetes/scripts/volumes.js:990
-msgid "Yes"
-msgstr "Sim"
+#: pkg/kubernetes/views/replicationcontroller-page.html:20
+#: pkg/kubernetes/views/deploymentconfig-panel.html:10
+#: pkg/kubernetes/views/deploymentconfig-page.html:15
+#: pkg/kubernetes/views/replicationcontroller-panel.html:14
+msgid "Template"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2299
-#: pkg/subscriptions/subscriptions-view.jsx:36
-#: pkg/kubernetes/views/node-body.html.h:14
-#: pkg/kubernetes/views/containers-listing.html.h:7
-#: pkg/kubernetes/views/volumes-page.html.h:5
-#: pkg/kubernetes/views/pv-claim.html.h:6
-#: pkg/kubernetes/views/nodes-page.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:5 pkg/kubernetes/views/pv-body.html.h:4
-msgid "Status"
-msgstr "Estado"
+#: pkg/systemd/terminal.html:4
+msgid "Terminal"
+msgstr "Terminal"
+
+#: pkg/users/index.html:78
+msgid "Terminate Session"
+msgstr ""
+
+#: pkg/networkmanager/index.html:38
+msgid "Testing connection"
+msgstr ""
+
+#: pkg/storaged/index.html:40
+msgid "The \"storaged\" API is not available on this system."
+msgstr ""
+
+#: pkg/docker/storage.jsx:485
+msgid "The Docker storage pool cannot be managed on this system."
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:386
+msgid "The IP address or host name cannot contain whitespace."
+msgstr "O enderço IP ou hostname não podem conter espações."
+
+#: pkg/storaged/index.html:532
+msgid "The RAID Array is in a degraded state"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:399
+msgid "The address contains invalid characters"
+msgstr ""
+
+#: pkg/lib/machine-unknown-hostkey.html:6
+msgid ""
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:324
+msgid "The configured state is unknown, it might change on the next boot."
+msgstr ""
+
+#: pkg/kubernetes/views/container-page-inline.html:22
+msgid "The container '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:192
+msgid "The current user isn't allowed to access system subscription status."
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:25
+msgid "The deployment config '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:47
+msgid "The group '{{ groupName }}' does not exist."
+msgstr ""
+
+#: pkg/shell/base_index.js:673
+msgid "The javascript console contains details about this error "
+msgstr "A console Javascript contém detalhes sobre este erro."
+
+#: pkg/lib/machine-invalid-hostkey.html:8
+msgid ""
+"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
+"in use. Unless this machine was recently replaced, it is likely that someone "
+"is trying to attack your connection to this machine."
+msgstr ""
+
+#: pkg/users/authorized-keys.js:118
+msgid "The key you provided was not valid."
+msgstr ""
+
+#: pkg/storaged/details.js:1751
+msgid "The last physical volume of a volume group cannot be removed."
+msgstr ""
+
+#: pkg/shell/indexes.js:314
+msgid "The machine is restarting"
+msgstr "A máquina esta reiniciando"
+
+#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
+msgid "The maximum number of replicas is 128"
+msgstr "O número máximo de réplicas é 128"
+
+#: pkg/kubernetes/scripts/nodes.js:407
+msgid "The name contains invalid characters"
+msgstr ""
+
+#: pkg/kubernetes/views/node-page.html:23
+msgid "The node '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/node-alerts.html:7
+msgid "The node doesn't have enough disk space"
+msgstr ""
+
+#: pkg/kubernetes/views/node-alerts.html:11
+msgid "The node doesn't have enough free memory"
+msgstr ""
+
+#: pkg/users/local.js:395 pkg/users/local.js:1082
+msgid "The passwords do not match"
+msgstr "As senhas não batem"
+
+#: pkg/lib/credentials.js:186
+msgid "The passwords do not match."
+msgstr "As senhas não batem."
+
+#: pkg/kubernetes/views/pv-page.html:21
+msgid "The persistent volume '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:40
+msgid "The pod '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/project-page.html:34
+msgid "The project '{{ projName }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:30
+msgid "The replication controller '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:19
+msgid "The route '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:386
+msgid "The selected file is not a valid Kubernetes application manifest."
+msgstr ""
+"O arquivo selecionado não é um manifesto do aplicativo Kubernetes válido."
+
+#: src/base1/cockpit.js:3695
+msgid "The server refused to authenticate using any supported methods."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:2
+msgid "The server uses a certificate signed by an unknown authority."
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:19
+msgid "The service '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/docker/storage.jsx:355
+msgid ""
+"The storage pool will be reset to optimize its layout.  All containers will "
+"be erased."
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:29
+msgid "The user '{{ userName }}' does not exist."
+msgstr ""
+
+#: pkg/systemd/init.js:834
+#, fuzzy
+msgid "The user <b>$0</b> does not have permissions for creating timers"
+msgstr "Ao usuário <b>$0</b> não é permitido gerenciar servidores"
+
+#: pkg/dashboard/list.js:209
+msgid "The user <b>$0</b> is not permitted to manage servers"
+msgstr "Ao usuário <b>$0</b> não é permitido gerenciar servidores"
+
+#: pkg/storaged/permissions.js:61
+msgid "The user <b>$0</b> is not permitted to manage storage"
+msgstr "Ao usuário <b>$0</b> não é permitido gerenciar o armazaenamento"
+
+#: pkg/users/local.js:40
+msgid "The user <b>$0</b> is not permitted to modify accounts"
+msgstr "O usuário <b>$0</b> não tem permissões para odificar contas"
+
+#: pkg/systemd/host.js:43
+msgid "The user <b>$0</b> is not permitted to modify hostnames"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1420
+msgid "The user <b>$0</b> is not permitted to modify network settings"
+msgstr ""
+"O usuário <b>$0</b> não tem permissão para modificar as configurações de rede"
+
+#: pkg/realmd/operation.js:436
+msgid "The user <b>$0</b> is not permitted to modify realms"
+msgstr ""
+
+#: pkg/users/local.js:501
+msgid ""
+"The user name can only consist of letters from a-z, digits, dots, dashes and "
+"underscores."
+msgstr ""
+"O nome de usuário coniste em letas de  a-z, digitos, pontos, barras e "
+"underline."
+
+#: pkg/users/index.html:332
+msgid "There are no authorized public keys for this account."
+msgstr ""
+
+#: pkg/storaged/details.js:1756
+msgid ""
+"There is not enough free space elsewhere to remove this physical volume.  At "
+"least $0 more free space is needed."
+msgstr ""
+
+#: pkg/storaged/utils.js:168
+msgid "Thin Logical Volume"
+msgstr "Thin Logical Volume"
+
+#: pkg/kubernetes/views/pvc-delete.html:8
+msgid ""
+"This claim is in use. Deleting it may cause issues with the following pod:"
+msgstr ""
+
+#: pkg/systemd/init.js:1222
+msgid ""
+"This day doesn't exist in all months.<br> The timer will only be executed in "
+"months that have 31st."
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2310
 msgid "This device cannot be managed here."
+msgstr ""
+
+#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
+#, fuzzy
+msgid "This field cannot be empty."
+msgstr "Namespace não pode estar vazio ."
+
+#: pkg/storaged/details.js:690
+msgid "This logical volume cannot be made smaller."
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:364
+msgid "This machine has already been added."
+msgstr "Esta máquina já foi adicionada"
+
+#: pkg/realmd/operation.html:89
+msgid "This may take a while"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid ""
+"This option is for single node testing only – local storage will not work in "
+"a multi-node cluster"
+msgstr ""
+
+#: src/bridge/cockpitpackages.c:470
+msgid "This package is not compatible with this version of Cockpit"
+msgstr ""
+
+#: src/bridge/cockpitpackages.c:459
+#, c-format
+msgid "This package requires Cockpit version %s or later"
+msgstr ""
+
+#: pkg/tuned/dialog.js:102
+msgid "This system is using a custom profile"
+msgstr "Este sistema está usando um perfil personalizado"
+
+#: pkg/tuned/dialog.js:100
+msgid "This system is using the recommended profile"
+msgstr "Este sistema está usando o perfil recomendado"
+
+#: pkg/systemd/init.js:639
+msgid "This unit is an instance of the $0 template."
+msgstr "Esta unidade é uma instância do modelo $0."
+
+#: pkg/systemd/services.html:302
+#, fuzzy
+msgid "This unit is not designed to be enabled explicitly.          "
+msgstr ""
+"Esta unidade não foi projetada para ser habilitada explicitamente.\n"
+"          "
+
+#: pkg/users/local.js:509
+msgid "This user name already exists"
+msgstr "Este usuário já existe"
+
+#: pkg/lib/machine-dialogs.js:380
+msgid ""
+"This version of cockpit-ws does not support connecting to a host with an "
+"alternate user or port"
+msgstr ""
+"Esta versão do cockpit-ws não suporta conectar a um host com um usuário ou "
+"porta alternativa"
+
+#: pkg/kubernetes/views/pv-delete.html:7
+msgid ""
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:23
+msgid "This volume has not been claimed"
+msgstr ""
+
+#: pkg/systemd/index.html:379
+msgid "Time Zone"
+msgstr ""
+
+#: pkg/systemd/services.html:55
+msgid "Timers"
+msgstr "Temporizadores"
+
+#: pkg/kubernetes/views/image-body.html:33
+msgid "To pull this image:"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:39
+msgid "To push to an image to this image stream:"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:11
+msgid ""
+"To try a different port you will need to upgrade cockpit-ws to a newer "
+"version."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:116
+msgid "Token"
+msgstr ""
+
+#: pkg/kubernetes/index.html:57
+msgid "Topology"
+msgstr ""
+
+#: pkg/docker/storage.jsx:314
+msgid "Total"
+msgstr ""
+
+#: pkg/ostree/index.html:99
+msgid "Tree"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:32
+msgid "Triggers"
+msgstr ""
+
+#: pkg/shell/index.html:328 pkg/shell/stub.html:181
+msgid "Troubleshoot"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:21
+msgid "Trust this certificate for this connection"
+msgstr ""
+
+#: pkg/systemd/init.js:520
+msgid "Try Restart"
+msgstr "Tente Reiniciar"
+
+#: pkg/docker/index.html:71 pkg/docker/index.html:74
+msgid "Try again"
+msgstr "Tente novamente"
+
+#: pkg/systemd/index.html:59
+msgid "Trying to synchronize with {{Server}}"
+msgstr ""
+
+#: pkg/tuned/dialog.js:262
+msgid "Tuned has failed to start"
+msgstr "Falhou ao iniciar Tuned"
+
+#: pkg/tuned/dialog.js:94
+msgid "Tuned is not available"
+msgstr "Tuned não está disponível"
+
+#: pkg/tuned/dialog.js:96
+msgid "Tuned is not running"
+msgstr "Tuned não está em execução"
+
+#: pkg/tuned/dialog.js:98
+msgid "Tuned is off"
+msgstr "Tuned está fora"
+
+#: pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/pv-modify.html:10
+#: pkg/kubernetes/views/volumes-page.html:20 pkg/kubernetes/views/deploy.html:9
+msgid "Type"
+msgstr "Tipo"
+
+#: pkg/kubernetes/views/details-page.html:7
+msgid "Type:"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:110
+msgid "URL"
+msgstr ""
+
+#: pkg/storaged/index.html:547 pkg/storaged/index.html:626
+msgctxt "storage"
+msgid "UUID"
+msgstr "UUID"
+
+#: pkg/selinux/setroubleshoot-view.jsx:114
+msgid "Unable to apply this solution automatically"
+msgstr ""
+
+#: pkg/ostree/index.html:219
+msgid "Unable to communicate with OSTree"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:195
+#, fuzzy
+msgid "Unable to connect"
+msgstr "Incapaz de pegar o alerta"
+
+#: pkg/kubernetes/scripts/dashboard.js:413
+msgid "Unable to decode Kubernetes application manifest."
+msgstr ""
+
+#: pkg/users/local.js:57
+msgid "Unable to delete root account"
+msgstr "Incapaz de deletar a conta root"
+
+#: pkg/selinux/setroubleshoot-client.js:157
+#, fuzzy
+msgid "Unable to get alert"
+msgstr "Incapaz de pegar o alerta"
+
+#: pkg/storaged/overview.js:586
+msgid "Unable to reach server"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:401
+msgid "Unable to read the Kubernetes application manifest. Code $0."
+msgstr "Não é possível ler o manifesto do aplicativo Kubernetes . Código $0."
+
+#: pkg/users/local.js:59
+msgid "Unable to rename root account"
+msgstr "Incapaz de renomear a conta root"
+
+#: pkg/selinux/setroubleshoot-client.js:172
+msgid "Unable to run fix"
+msgstr "Incapaz de rodar a correção"
+
+#: pkg/selinux/setroubleshoot-client.js:52
+msgid "Unable to start setroubleshootd"
+msgstr "Incapaz de iniciar setroubleshootd"
+
+#: pkg/playground/translate.html:35 pkg/playground/translate.html:40
+msgid "Unavailable"
+msgstr ""
+
+#: pkg/docker/index.html:763 pkg/networkmanager/index.html:792
+msgid "Unexpected error"
+msgstr "Erro inesperado"
+
+#: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/image-body.html:15
+#: pkg/kubernetes/views/pv-claim.html:31 pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: pkg/storaged/details.js:1597
+msgid "Unknown ($0)"
+msgstr "Desconhecido ($0)"
+
+#: pkg/lib/machine-unknown-hostkey.html:2
+msgid "Unknown Host Key"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2342
 msgid "Unknown configuration"
 msgstr "Configuração desconhecida"
 
-#: pkg/networkmanager/interfaces.js:2441
-msgid "Configure"
-msgstr "Configurar"
-
-#: pkg/networkmanager/interfaces.js:2473
-msgid "$mtu"
+#: pkg/storaged/overview.js:582
+msgid "Unknown host name"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2477
-msgid "MTU"
+#: pkg/docker/index.html:570
+msgid "Unless Stopped"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2483
-msgid "Master"
-msgstr "Mestre"
+#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
+#: pkg/storaged/details.js:1110
+msgid "Unlock"
+msgstr "Destravar"
 
-#: pkg/networkmanager/interfaces.js:2502
-msgid "ARP Monitoring"
-msgstr "ARP Monitoramento"
+#: pkg/shell/index.html:220
+msgid "Unlock Key"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#: pkg/storaged/jobs.js:121
+msgid "Unlocking $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:108
 #, fuzzy
-msgid "Broken configuration"
-msgstr "Configuração desconhecida"
+msgid "Unmanaged Interfaces"
+msgstr "Interfaces"
 
-#: pkg/networkmanager/interfaces.js:2558
-msgid "Team Port"
+#: pkg/systemd/init.js:548
+msgid "Unmask"
+msgstr "Sem Máscara"
+
+#: pkg/storaged/details.js:1100
+msgid "Unmount"
+msgstr "Desmontar"
+
+#: pkg/storaged/jobs.js:127
+msgid "Unmounting $target"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2573
-msgid "Spanning Tree Protocol"
-msgstr "Spanning Tree Protocol (STP)"
-
-#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
-msgid "Priority $priority"
-msgstr "Prioridade $priority"
-
-#: pkg/networkmanager/interfaces.js:2577
-msgid "Forward delay $forward_delay"
-msgstr "Encaminhado Atraso $forward_delay"
-
-#: pkg/networkmanager/interfaces.js:2579
-msgid "Hello time $hello_time"
-msgstr "Hello time $hello_time"
-
-#: pkg/networkmanager/interfaces.js:2581
-msgid "Maximum message age $max_age"
-msgstr "Máxima permanência da mensagem $max_age"
-
-#: pkg/networkmanager/interfaces.js:2601
-msgid "Path cost $path_cost"
-msgstr "Path cost $path_cost"
-
-#: pkg/networkmanager/interfaces.js:2603
-msgid "Hairpin mode"
-msgstr "Hairpin modo"
-
-#: pkg/networkmanager/interfaces.js:2605
-msgid "Bridge port"
-msgstr "Bridge porta"
-
-#: pkg/networkmanager/interfaces.js:2619
-msgid "Parent $parent"
-msgstr "Parent $parent"
-
-#: pkg/networkmanager/interfaces.js:2620
-msgid "Id $id"
-msgstr "Id $id"
-
-#: pkg/networkmanager/interfaces.js:2628
-msgid "General"
-msgstr "Geral"
-
-#: pkg/networkmanager/interfaces.js:2637
-msgid "Connect automatically"
-msgstr "Conecte automaticamente"
-
-#: pkg/networkmanager/interfaces.js:2641
-msgid "IPv4"
-msgstr "IPv4"
-
-#: pkg/networkmanager/interfaces.js:2642
-msgid "IPv6"
-msgstr "IPv6"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/networkmanager/index.html.h:33
-#: pkg/kubernetes/views/project-listing.html.h:5
-msgid "Members"
-msgstr "Membros"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/docker/index.html.h:39
-#: pkg/networkmanager/index.html.h:24
-#: pkg/kubernetes/views/service-body.html.h:6
-#: pkg/kubernetes/views/image-config.html.h:7
-#: pkg/kubernetes/views/container-body.html.h:5
-msgid "Ports"
-msgstr "Portas"
-
-#: pkg/networkmanager/interfaces.js:2762
-msgid "Switching on <b>$0</b> will break the connection to the server, "
+#: pkg/users/index.html:315
+msgid "Unnamed"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2773
-msgid "Switching off <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2788
-msgid "Removing <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2791
-#, fuzzy
-msgid "Remove $0"
-msgstr "Remover"
-
-#: pkg/networkmanager/interfaces.js:2833
-msgid "Adding <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2836
-msgid "Add $0"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2870
-msgid "Changing the settings will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2872
-msgid "Change the settings"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length or Netmask"
-msgstr "Comprimento do prefixo ou máscara de rede"
-
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length"
-msgstr "Comprimento do prefixo"
-
-#: pkg/networkmanager/interfaces.js:3011
-#: pkg/kubernetes/views/details-page.html.h:7
-msgid "Addresses"
-msgstr "Endereços"
-
-#: pkg/networkmanager/interfaces.js:3018
-msgid "DNS"
-msgstr "DNS"
-
-#: pkg/networkmanager/interfaces.js:3022
-msgid "DNS Search Domains"
-msgstr "DNS Busca de Domínios"
-
-#: pkg/networkmanager/interfaces.js:3027
-#: pkg/kubernetes/views/details-page.html.h:11
-msgid "Routes"
-msgstr "Rotas"
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv4 Settings"
-msgstr "IPv4 Ajustes"
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv6 Settings"
-msgstr "IPv6 Ajustes"
-
-#: pkg/networkmanager/interfaces.js:3436
-msgid "Creating this bond will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
-#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
-#, fuzzy
-msgid "Create it"
-msgstr "Criar relatório"
-
-#: pkg/networkmanager/interfaces.js:3611
-msgid "Creating this team will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3842
-msgid "Creating this bridge will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4064
-msgid "Creating this VLAN will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4139
-msgid "MTU must be a positive number"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:196
-#, fuzzy
-msgid "Invalid credentials"
-msgstr "Porta inválida"
-
-#: pkg/subscriptions/subscriptions-client.js:198
-msgid "'Organization' required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:200
-msgid "Login/password or activation key required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:202
-msgid "'Organization' required when using activation keys."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:64
-#: pkg/kubernetes/views/volume-body.html.h:16
-#: pkg/kubernetes/views/pv-modify.html.h:11
-msgid "Server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:88
-#: pkg/subscriptions/subscriptions-register.jsx:152
-#: pkg/lib/machine-auth-failed.html.h:3 pkg/lib/machine-sync-users.html.h:6
-#: pkg/lib/machine-change-auth.html.h:6 pkg/shell/index.html.h:31
-#: pkg/users/index.html.h:16 pkg/kubernetes/views/auth-form.html.h:11
-msgid "Password"
-msgstr "Senha"
-
-#: pkg/subscriptions/subscriptions-register.jsx:102
-#, fuzzy
-msgid "Custom URL"
-msgstr "Personalizado"
-
-#: pkg/subscriptions/subscriptions-register.jsx:110
-msgid "URL"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:125
-msgid "Proxy"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:132
-msgid "Use proxy server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:140
-#, fuzzy
-msgid "Login"
-msgstr "Último Login"
-
-#: pkg/subscriptions/subscriptions-register.jsx:164
-#, fuzzy
-msgid "Activation Key"
-msgstr "Ativar"
-
-#: pkg/subscriptions/subscriptions-register.jsx:176
-msgid "Organization"
-msgstr ""
-
-#: pkg/subscriptions/main.js:45 pkg/subscriptions/subscriptions-view.jsx:143
-#: pkg/kubernetes/views/pv-modify.html.h:23
-msgid "Register"
-msgstr ""
-
-#: pkg/subscriptions/main.js:74
-msgid "Register system"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:32
-msgid "Product name"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product ID"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/index.html.h:13
-#: pkg/shell/index.html.h:14 pkg/shell/stub.html.h:9 pkg/shell/simple.html.h:9
-#: pkg/ostree/index.html.h:19
-msgid "Version"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:35
-#: pkg/kubernetes/views/image-config.html.h:5
-msgid "Architecture"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:37
-#, fuzzy
-msgid "Starts"
-msgstr "Iniciar"
-
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Ends"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:141
-msgid "Status: System isn't registered"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:146
-#, fuzzy
-msgid "Status: $0"
-msgstr "Estado"
+#: pkg/storaged/details.js:1256
+msgctxt "storage-id-desc"
+msgid "Unrecognized Data"
+msgstr "Dados não reconhecidos"
 
 #: pkg/subscriptions/subscriptions-view.jsx:148
 msgid "Unregister"
@@ -2845,348 +5835,215 @@ msgstr ""
 msgid "Unregistering system..."
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:161
-#: pkg/subscriptions/index.html.h:1
-msgid "Subscriptions"
+#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
+#: src/bridge/cockpitdbussetup.c:625
+#, fuzzy
+msgid "Unsupported setup mechanism"
+msgstr "Mecanismo de ajuste não suportado: %s"
+
+#: src/base1/cockpit.js:3697
+msgid "Untrusted host"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/ostree/index.html.h:15
+#: pkg/docker/util.js:94
+msgid "Up since $StartedAt"
+msgstr "Ativo desde $StartedAt"
+
+#: pkg/lib/machine-change-port.html:41
+msgid "Update"
+msgstr ""
+
+#: pkg/ostree/index.html:125 pkg/ostree/index.html:152
+msgid "Updates"
+msgstr ""
+
+#: pkg/ostree/index.html:96
 msgid "Updating"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:188
-msgid "Retrieving subscription status..."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:191
-#, fuzzy
-msgid "Access denied"
-msgstr "Acesso"
-
-#: pkg/subscriptions/subscriptions-view.jsx:192
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:195
-#, fuzzy
-msgid "Unable to connect"
-msgstr "Incapaz de pegar o alerta"
-
-#: pkg/subscriptions/subscriptions-view.jsx:196
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:222
-msgid "Installed products"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:223
-#, fuzzy
-msgid "No installed products on the system."
-msgstr "Docker não está instalado ou ativado no sistema"
-
-#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "Não é um número válido de réplicas"
-
-#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "O número máximo de réplicas é 128"
-
-#: pkg/kubernetes/scripts/details.js:546
-msgid "Not a valid value for Host"
 msgstr ""
 
 #: pkg/kubernetes/scripts/details.js:655
 msgid "Updating $0..."
 msgstr "Atualizando $0..."
 
-#: pkg/kubernetes/scripts/graphs.js:601 pkg/kubernetes/scripts/nodes.js:711
-#: pkg/kubernetes/scripts/nodes.js:817 pkg/dashboard/index.html.h:2
-msgid "CPU"
+#: pkg/shell/index.html:165
+msgid "Use my password for privileged tasks and to connect to other machines"
 msgstr ""
 
-#: pkg/kubernetes/scripts/graphs.js:606 pkg/kubernetes/scripts/nodes.js:715
-#: pkg/kubernetes/scripts/nodes.js:826 pkg/dashboard/index.html.h:3
-msgid "Memory"
+#: pkg/subscriptions/subscriptions-register.jsx:132
+msgid "Use proxy server"
 msgstr ""
 
-#: pkg/kubernetes/scripts/graphs.js:611 pkg/dashboard/index.html.h:4
-msgid "Network"
+#: pkg/shell/index.html:172
+msgid "Use the following keys to authenticate against other systems"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:319 pkg/kubernetes/views/node-body.html.h:16
-#: pkg/kubernetes/views/details-page.html.h:10
-msgid "Not Ready"
-msgstr "Não está pronto"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
+#: pkg/systemd/index.html:251
+msgid "Used"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:324 pkg/kubernetes/views/node-body.html.h:15
-#: pkg/kubernetes/views/details-page.html.h:9
-msgid "Ready"
-msgstr "Pronto"
-
-#: pkg/kubernetes/scripts/nodes.js:397
-msgid "Please type an address"
+#: pkg/systemd/index.html:229 pkg/dashboard/index.html:158
+#: pkg/playground/translate.html:86 pkg/playground/translate.html:106
+#: pkg/kubernetes/views/user-panel.html:9
+#: pkg/kubernetes/views/auth-form.html:61
+#: pkg/kubernetes/views/volume-body.html:64
+#: pkg/kubernetes/views/volume-body.html:103
+msgid "User"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:399
-msgid "The address contains invalid characters"
+#: pkg/users/index.html:90 pkg/users/index.html:154
+#: pkg/realmd/operation.html:47
+msgid "User Name"
+msgstr "Nome de Usuário"
+
+#: pkg/realmd/operation.html:53
+msgid "User Password"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:407
-msgid "The name contains invalid characters"
+#: pkg/lib/machine-change-auth.html:18
+msgid "User name"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
+#: pkg/kubernetes/views/add-member-role-dialog.html:15
+msgid "User or Group"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
+#: pkg/kubernetes/views/auth-form.html:94
+msgid "Username"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
-msgid "Disk"
+#: pkg/kubernetes/views/project-listing.html:85
+msgid "Users"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
+#: pkg/storaged/details.js:181
+msgid "VFAT - Compatible with all systems and devices"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:870
-#, c-format
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] ""
-msgstr[1] ""
+#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
+#: pkg/networkmanager/interfaces.js:2622
+msgid "VLAN"
+msgstr "VLAN"
 
-#: pkg/kubernetes/scripts/nodes.js:872
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] ""
-msgstr[1] ""
+#: pkg/networkmanager/index.html:141
+msgid "VLAN Id"
+msgstr "VLAN Id"
 
-#: pkg/kubernetes/scripts/connection.js:88
-msgid "Error writing kubectl config"
+#: pkg/networkmanager/index.html:736
+msgid "VLAN Settings"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:514
-msgid "Couldn't find running API server"
+#: pkg/users/authorized-keys.js:103
+msgid "Validating key"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:516
-msgid "Connection Error: $0"
+#: pkg/systemd/index.html:98 pkg/ostree/index.html:113 pkg/shell/simple.html:77
+#: pkg/shell/index.html:90 pkg/shell/stub.html:83
+msgid "Version"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:539
-msgid "Please provide a valid address"
+#: pkg/storaged/jobs.js:137
+msgid "Very securely erasing $target"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:554
-msgid "Please provide a username"
+#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
+#: pkg/kubernetes/views/pvc-body.html:6
+msgid "Volume"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:650
-msgid "Error getting certificate details: $0"
+#: pkg/storaged/index.html:620
+msgid "Volume Group"
+msgstr "Grupo de volumes"
+
+#: pkg/storaged/utils.js:239
+msgid "Volume Group $0"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
+#: pkg/storaged/index.html:98
+msgid "Volume Groups"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
+#: pkg/kubernetes/views/volume-body.html:14
+#: pkg/kubernetes/views/volume-body.html:89
+msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
+#: pkg/kubernetes/views/pv-modify.html:115
+#: pkg/kubernetes/views/volume-body.html:42
+msgid "Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
+#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
+msgid "Volume Type"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
+#: pkg/docker/index.html:536 pkg/kubernetes/views/pod-page.html:18
+#: pkg/kubernetes/views/image-config.html:28
+#: pkg/kubernetes/views/dashboard-page.html:47 pkg/kubernetes/index.html:70
+msgid "Volumes"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
-msgid "Host Path"
+#: pkg/networkmanager/interfaces.js:819
+msgid "Waiting"
+msgstr "Aguardando"
+
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid "Warning:"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
+#: pkg/systemd/logs.html:48
+msgid "Warnings"
+msgstr "Avisos"
+
+#: pkg/systemd/services.html:409
+msgid "Weeks"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:199
-msgid "NFS Mount"
+#: pkg/kubernetes/views/registry-dashboard-page.html:5
+msgid "Welcome to the Image Registry"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
+#: pkg/kubernetes/views/volumes-page.html:61
+msgid "When"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
-msgid "ISCSI"
+#: pkg/docker/index.html:507
+msgid "With terminal"
+msgstr "Com o terminal"
+
+#: pkg/storaged/index.html:438
+msgctxt "storage"
+msgid "World Wide Name"
+msgstr "Nome Global"
+
+#: pkg/storaged/details.js:1595
+msgid "Write-mostly"
+msgstr "Maioria-Escrita"
+
+#: pkg/storaged/index.html:333
+msgid "Writing"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
+#: pkg/ostree/client.js:64
+msgid "Writing objects"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
+#: pkg/storaged/details.js:177
+msgid "XFS - Red Hat Enterprise Linux 7 default"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr ""
+#: pkg/networkmanager/interfaces.js:1824
+msgid "XOR"
+msgstr "XOR"
 
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr ""
+#: pkg/kubernetes/scripts/volumes.js:990 pkg/networkmanager/interfaces.js:2279
+msgid "Yes"
+msgstr "Sim"
 
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:469
-msgid "Please select a valid access mode"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:477
-msgid "Please provide a valid name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:485
-msgid "Please provide a valid storage capacity."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:493
-msgid "Please select a valid policy option."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:565
-msgid "Please select a valid endpoint"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:574
-msgid "Please provide a GlusterFS volume name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:632
-msgid "Please provide a valid NFS server"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
-msgid "Please provide a valid path"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:781
-msgid "Please provide a valid target"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:789
-msgid "Please provide a valid qualified name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:797
-msgid "Please provide a valid logical unit number"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:805
-msgid "Please provide a valid filesystem type"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:813
-msgid "Please provide a valid interface"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:860
-msgid "NFS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:872
-msgid "GlusterFS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:908
-msgid "Sorry, I don't know how to modify this volume"
-msgstr ""
-
-#: pkg/kubernetes/scripts/charts.js:113
-msgid "Unavailable"
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "Namespace não pode estar vazio ."
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "Por favor, forneça um namespace válido."
-
-#: pkg/kubernetes/scripts/dashboard.js:384
+#: pkg/lib/machine-sync-users.html:47
 msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
+"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
+"synchronize users, a user with superuser privileges is required."
 msgstr ""
-"Nenhum arquivo de metadados foi selecionado. Por favor, selecione um arquivo "
-"de metadados Kubernetes ."
-
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr ""
-"O arquivo selecionado não é um manifesto do aplicativo Kubernetes válido."
-
-#: pkg/kubernetes/scripts/dashboard.js:401
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr "Não é possível ler o manifesto do aplicativo Kubernetes . Código $0."
-
-#: pkg/kubernetes/scripts/dashboard.js:413
-msgid "Unable to decode Kubernetes application manifest."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:441
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "Por favor, crie outro namespace para $0 \"$1\""
-
-#: pkg/kubernetes/scripts/dashboard.js:460
-msgid "Manifest"
-msgstr ""
-
-#: pkg/dashboard/list.js:209
-msgid "The user <b>$0</b> is not permitted to manage servers"
-msgstr "Ao usuário <b>$0</b> não é permitido gerenciar servidores"
 
 #: pkg/dashboard/list.js:394
 msgid ""
@@ -3194,2973 +6051,208 @@ msgid ""
 msgstr ""
 "Você está conectado diretamente a este servidor. Você não pode excluí-lo."
 
-#: cockpit.appdata.xml.in.h:1
-msgid ""
-"Cockpit is a server manager that makes it easy to administer your Linux "
-"servers via a web browser. Jumping between the terminal and the web tool is "
-"no problem. A service started via Cockpit can be stopped via the terminal. "
-"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
-"journal interface."
-msgstr ""
-"Cockpit é um gerenciador de Servidores que facilita a tarefa de administrar "
-"seu servidor Linux via navegador web. Alternar entre o terminal e a "
-"ferramenta web, não é dif[icil. Um serviço pode ser iniciado pelo Cockpit e "
-"finalizado pelo Terminal. Da mesma forma, se um erro ocorrer no terminal, "
-"este pode ser detectado via interface do Cockpit."
-
-#: cockpit.appdata.xml.in.h:2
-msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
-"stopping services. You can monitor and administer several servers at the "
-"same time. Just add them with a single click and your machines will look "
-"after its buddies."
-msgstr ""
-"Cockpit é perfeito para novos administradores de sistemas, permitindo-lhes "
-"facilmente realizar tarefas simples, como a administração de armazenamento, "
-"inspecionando logs e iniciar/parar serviços. É possível monitorar e "
-"administrar vários servidores ao mesmo tempo. Basta adicioná-los com um "
-"único clique e suas máquinas vão cuidar de seus companheiros."
-
-#: cockpit.desktop.in.h:1 pkg/shell/index.html.h:1 pkg/shell/stub.html.h:1
-#: pkg/shell/simple.html.h:1
-msgid "Cockpit"
-msgstr "Cockpit"
-
-#: cockpit.desktop.in.h:2
-msgid "A user interface for GNU/Linux servers"
-msgstr "A interface de usuário para servidores GNU/Linux"
-
-#: cockpit.desktop.in.h:3
-msgid "Remote;Administration;"
-msgstr "Remoto; Administração;"
-
-#: pkg/systemd/index.html.h:1
-msgid "System"
-msgstr ""
-
-#: pkg/systemd/index.html.h:2
-msgid "No host keys found."
-msgstr ""
-
-#: pkg/systemd/index.html.h:3
-msgid "Synchronized with {{Server}}"
-msgstr ""
-
-#: pkg/systemd/index.html.h:4
-msgid "Synchronized"
-msgstr ""
-
-#: pkg/systemd/index.html.h:5
-msgid "Trying to synchronize with {{Server}}"
-msgstr ""
-
-#: pkg/systemd/index.html.h:6
-msgid "Not synchronized"
-msgstr ""
-
-#: pkg/systemd/index.html.h:7
-msgid "Hardware"
-msgstr ""
-
-#: pkg/systemd/index.html.h:8
-msgid "Asset Tag"
-msgstr ""
-
-#: pkg/systemd/index.html.h:9 pkg/kubernetes/views/node-body.html.h:6
-msgid "Machine ID"
-msgstr ""
-
-#: pkg/systemd/index.html.h:10 pkg/ostree/index.html.h:18
-#: pkg/kubernetes/views/nodes-page.html.h:6
-msgid "Operating System"
-msgstr ""
-
-#: pkg/systemd/index.html.h:11
-msgid "Secure Shell Keys"
-msgstr ""
-
-#: pkg/systemd/index.html.h:12
-msgid "Show fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:14 pkg/dashboard/index.html.h:7
-msgid "Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:15
-msgid "Domain"
-msgstr ""
-
-#: pkg/systemd/index.html.h:16
-msgid "System Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:17
-msgid "Power Options"
-msgstr "Opções de Energia"
-
-#: pkg/systemd/index.html.h:20
-msgid "Performance Profile"
-msgstr ""
-
-#: pkg/systemd/index.html.h:21
-msgid "Store Performance Data"
-msgstr ""
-
-#: pkg/systemd/index.html.h:32
-msgid "Machine SSH Key Fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:33
-msgid "Pretty Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:34
-msgid "Real Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:35
-msgid "Time Zone"
-msgstr ""
-
-#: pkg/systemd/index.html.h:36
-msgid ""
-"\n"
-"                                    Invalid time zone\n"
-"                                "
-msgstr ""
-
-#: pkg/systemd/index.html.h:39
-msgid "Set Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:40
-msgid "Manually"
-msgstr ""
-
-#: pkg/systemd/index.html.h:41
-msgid "Automatically using NTP"
-msgstr ""
-
-#: pkg/systemd/index.html.h:42
-msgid "Automatically using specific NTP servers"
-msgstr ""
-
-#: pkg/systemd/index.html.h:43
-msgid "Delay"
-msgstr "Atraso"
-
-#: pkg/systemd/index.html.h:44
-msgid "1 Minute"
-msgstr ""
-
-#: pkg/systemd/index.html.h:45
-msgid "5 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:46
-msgid "20 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:47
-msgid "40 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:48
-msgid "60 Minutes"
-msgstr ""
-
-#: pkg/systemd/index.html.h:49
-msgid "No Delay"
-msgstr ""
-
-#: pkg/systemd/index.html.h:50
-msgid "Specific Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:51
-msgid ""
-"\n"
-"                        Cancel\n"
-"                    "
-msgstr ""
-
-#: pkg/systemd/logs.html.h:1
-msgid "Journal"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:2
-msgid "Recent"
-msgstr "Recente"
-
-#: pkg/systemd/logs.html.h:3
-msgid "Current boot"
-msgstr "Inicialização atual"
-
-#: pkg/systemd/logs.html.h:4
-msgid "Last 24 hours"
-msgstr "Últimas 24 horas"
-
-#: pkg/systemd/logs.html.h:5
-msgid "Last 7 days"
-msgstr "Últimos 7 dias"
-
-#: pkg/systemd/logs.html.h:6
-msgid "Errors"
-msgstr "Erros"
-
-#: pkg/systemd/logs.html.h:7
-msgid "Warnings"
-msgstr "Avisos"
-
-#: pkg/systemd/logs.html.h:8
-msgid "Notices"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:9
-msgid "All"
-msgstr "Todos"
-
-#: pkg/systemd/logs.html.h:10 pkg/kubernetes/views/container-panel.html.h:2
-#: pkg/kubernetes/views/container-page-inline.html.h:2
-msgid "Logs"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:11
-msgid "Entry"
-msgstr ""
-
-#: pkg/systemd/services.html.h:1 pkg/kubernetes/views/dashboard-page.html.h:12
-#: pkg/kubernetes/views/details-page.html.h:3
-msgid "Services"
-msgstr "Serviços"
-
-#: pkg/systemd/services.html.h:3
-msgid "System Services"
-msgstr "Serviços do Sistema"
-
-#: pkg/systemd/services.html.h:4
-msgid "Sockets"
-msgstr "Sockets"
-
-#: pkg/systemd/services.html.h:5
-msgid "Timers"
-msgstr "Temporizadores"
-
-#: pkg/systemd/services.html.h:6
-msgid "Paths"
-msgstr "Caminhos"
-
-#: pkg/systemd/services.html.h:7
-msgid "Instantiate"
-msgstr "Instanciar"
-
-#: pkg/systemd/services.html.h:8
-msgid "{{days_text}}"
-msgstr ""
-
-#: pkg/systemd/services.html.h:9
-msgid "Service Logs"
-msgstr ""
-
-#: pkg/systemd/services.html.h:10
-msgid "Note"
-msgstr "Nota"
-
-#: pkg/systemd/services.html.h:11
-msgid ""
-"This unit is not designed to be enabled explicitly.\n"
-"          "
-msgstr ""
-"Esta unidade não foi projetada para ser habilitada explicitamente.\n"
-"          "
-
-#: pkg/systemd/services.html.h:15
-#, fuzzy
-msgid "Create Timers"
-msgstr "Criar Thin Volume"
-
-#: pkg/systemd/services.html.h:16
-#, fuzzy
-msgid "Service name"
-msgstr "Serviço"
-
-#: pkg/systemd/services.html.h:18 pkg/docker/index.html.h:32
-msgid "Command"
-msgstr "Comando"
-
-#: pkg/systemd/services.html.h:19
-#, fuzzy
-msgid "Run"
-msgstr "Executando"
-
-#: pkg/systemd/services.html.h:20
-msgid "After system boot"
-msgstr ""
-
-#: pkg/systemd/services.html.h:21
-msgid "At specific time"
-msgstr ""
-
-#: pkg/systemd/services.html.h:22
-msgid "Seconds"
-msgstr ""
-
-#: pkg/systemd/services.html.h:23
-#, fuzzy
-msgid "Minutes"
-msgstr "Rotas"
-
-#: pkg/systemd/services.html.h:24
-msgid "Hours"
-msgstr ""
-
-#: pkg/systemd/services.html.h:25
-msgid "Weeks"
-msgstr ""
-
-#: pkg/systemd/services.html.h:26
-msgid "Don't Repeat"
-msgstr ""
-
-#: pkg/systemd/services.html.h:27
-msgid "Repeat Hourly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:28
-msgid "Repeat Daily"
-msgstr ""
-
-#: pkg/systemd/services.html.h:29
-msgid "Repeat Weekly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:30
-msgid "Repeat Monthly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:31
-msgid "Repeat Yearly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:32
-msgid "Hour : Minute"
-msgstr ""
-
-#: pkg/systemd/services.html.h:33
-msgid ":"
-msgstr ""
-
-#: pkg/systemd/services.html.h:35
-msgid "Save"
-msgstr ""
-
-#: pkg/systemd/terminal.html.h:1
-msgid "Terminal"
-msgstr "Terminal"
-
-#: pkg/lib/machine-invalid-hostkey.html.h:1
-msgid "Incorrect Host Key"
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:2
-msgid ""
-"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
-"in use. Unless this machine was recently replaced, it is likely that someone "
-"is trying to attack your connection to this machine."
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:3
-msgid ""
-"You can remove the previously stored key by running the following command"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:1
-msgid "Authentication Failed"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:2
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
-"machine with cockpit you will need to enable one of the following "
-"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:4 pkg/shell/index.html.h:30
-msgid "Public Key"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:5
-msgid "Kerberos Based SSO"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:6
-msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:1 pkg/dashboard/index.html.h:11
-msgid "Synchronize users"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:2
-msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:3
-msgid "Error loading users: {{perm_failed}}"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:4
-msgid ""
-"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
-"synchronize users, a user with superuser privileges is required."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:5 pkg/lib/machine-change-auth.html.h:4
-msgid "User name"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:8
-msgid "Synchronize"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:1
-msgid "Unknown Host Key"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:2
-msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:3 pkg/shell/index.html.h:4
-msgid "Fingerprint"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:5
-#: pkg/kubernetes/views/auth-form.html.h:14
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:6
-msgid "Connect"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:1
-msgid "Add Machine to Dashboard"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:3 pkg/dashboard/index.html.h:9
-msgid "Color"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:4
-msgid ""
-"Connecting simultaneously to more than {{ limit }} machines is unsupported."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:1
-msgid "Could not contact {{host}}"
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:2
-msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:3
-msgid ""
-"To try a different port you will need to upgrade cockpit-ws to a newer "
-"version."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:4
-msgid "Is sshd running on a different port?"
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:7
-msgid "Update"
-msgstr ""
-
-#: pkg/lib/machine-not-supported.html.h:1
-msgid "Cockpit is not installed"
-msgstr ""
-
-#: pkg/lib/machine-not-supported.html.h:2
-msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:1
-msgid "Log in to {{host}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:2
-msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:3
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:5 pkg/shell/index.html.h:9
-#: pkg/realmd/operation.html.h:3 pkg/kubernetes/views/auth-form.html.h:8
-msgid "Authentication"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:7
-msgid "Available"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:8
-msgid "Login Password"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:9
-msgid "Kerberos Ticket"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:10
-msgid "Checking for public keys"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:12
-msgid "Log In"
-msgstr ""
-
-#: pkg/shell/shell.html.h:1
-msgid "Things have moved"
-msgstr ""
-
-#: pkg/shell/index.html.h:2
-msgid "Comment"
-msgstr ""
-
-#: pkg/shell/index.html.h:5 pkg/shell/stub.html.h:2 pkg/shell/simple.html.h:2
-msgid "Ooops!"
-msgstr ""
-
-#: pkg/shell/index.html.h:6 pkg/shell/stub.html.h:3 pkg/shell/simple.html.h:3
-msgid "Display Language"
-msgstr ""
-
-#: pkg/shell/index.html.h:7 pkg/shell/stub.html.h:4 pkg/shell/simple.html.h:4
-msgid "About Cockpit"
-msgstr ""
-
-#: pkg/shell/index.html.h:8
-msgid "Account Settings"
-msgstr ""
-
-#: pkg/shell/index.html.h:10 pkg/shell/stub.html.h:5 pkg/shell/simple.html.h:5
-msgid "Log out"
-msgstr ""
-
-#: pkg/shell/index.html.h:11 pkg/shell/stub.html.h:6 pkg/shell/simple.html.h:6
-msgid ""
-"\n"
-"              Cockpit is an interactive Linux server admin interface.\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:15 pkg/shell/stub.html.h:10
-#: pkg/shell/simple.html.h:10
-msgid "Choose the language to be used in the application"
-msgstr ""
-
-#: pkg/shell/index.html.h:16 pkg/shell/stub.html.h:11
-#: pkg/shell/simple.html.h:11 pkg/storaged/index.html.h:59
-msgid ""
-"\n"
-"              Cancel\n"
-"            "
-msgstr ""
-"\n"
-"              Cancelar\n"
-"            "
-
-#: pkg/shell/index.html.h:19 pkg/shell/stub.html.h:14
-#: pkg/shell/simple.html.h:14
-msgid ""
-"\n"
-"              Select\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:22 pkg/shell/stub.html.h:17
-msgid ""
-"\n"
-"              Close\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:25
-msgid "Use my password for privileged tasks and to connect to other machines"
-msgstr ""
-
-#: pkg/shell/index.html.h:26
-msgid "Use the following keys to authenticate against other systems"
-msgstr ""
-
-#: pkg/shell/index.html.h:29 pkg/kubernetes/index.html.h:6
-msgid "Details"
-msgstr ""
-
-#: pkg/shell/index.html.h:32
-msgid "Unlock Key"
-msgstr ""
-
-#: pkg/shell/index.html.h:33 pkg/users/index.html.h:23
-msgid "Old Password"
-msgstr "Senha Atual"
-
-#: pkg/shell/index.html.h:34 pkg/users/index.html.h:24
-msgid "New Password"
-msgstr "Nova Senha"
-
-#: pkg/shell/index.html.h:35 pkg/users/index.html.h:19
-msgid "Confirm"
-msgstr "Confirmar"
-
-#: pkg/shell/index.html.h:36
-msgid "Change Password"
-msgstr ""
-
-#: pkg/shell/index.html.h:38 pkg/shell/stub.html.h:20
-msgid ""
-"\n"
-"                Tools\n"
-"              "
-msgstr ""
-
-#: pkg/shell/index.html.h:41 pkg/shell/stub.html.h:23
-#: pkg/shell/simple.html.h:24
-msgid "Reconnect"
-msgstr ""
-
-#: pkg/shell/index.html.h:42 pkg/shell/stub.html.h:24
-msgid "Troubleshoot"
-msgstr ""
-
-#: pkg/shell/simple.html.h:18
-msgid ""
-"\n"
-"              Try to reconnect\n"
-"            "
-msgstr ""
-
-#: pkg/shell/simple.html.h:21
-msgid ""
-"\n"
-"              Log in again\n"
-"            "
-msgstr ""
-
-#: pkg/ostree/index.html.h:1
-msgid "Software Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:2
-msgid "Check for updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:3
-msgid ""
-"\n"
-"                    Update and reboot\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:6
-msgid "Roll back and reboot"
-msgstr ""
-
-#: pkg/ostree/index.html.h:8
-msgid ""
-"\n"
-"                    Default\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:11
-msgid ""
-"\n"
-"                    Available\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:16
-msgid "Tree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:17
-msgid "Packages"
-msgstr ""
-
-#: pkg/ostree/index.html.h:20
-msgid "Released"
-msgstr ""
-
-#: pkg/ostree/index.html.h:21
-msgid "Additions"
-msgstr ""
-
-#: pkg/ostree/index.html.h:22
-msgid "Removals"
-msgstr ""
-
-#: pkg/ostree/index.html.h:23
-msgid "Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:24
-msgid "Downgrades"
-msgstr ""
-
-#: pkg/ostree/index.html.h:25
-msgid ""
-"\n"
-"                    This deployment contains the same packages as your "
-"currently booted system\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:28
-msgid "Operating System Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:29
-msgid "Connecting"
-msgstr ""
-
-#: pkg/ostree/index.html.h:30
-msgid "Unable to communicate with OSTree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:31
-msgid "No Deployments"
-msgstr ""
-
-#: pkg/ostree/index.html.h:32
-msgid ""
-"\n"
-"                    Reconnect\n"
-"                "
-msgstr ""
-
-#: pkg/selinux/setroubleshoot.html.h:1
-msgid "SELinux Troubleshoot"
-msgstr ""
-
-#: pkg/machines/index.html.h:1
-msgid "Virtual Machines Management"
-msgstr ""
-
-#: pkg/storaged/index.html.h:1
-msgid "Storage"
-msgstr ""
-
-#: pkg/storaged/index.html.h:2
-msgid "The \"storaged\" API is not available on this system."
-msgstr ""
-
-#: pkg/storaged/index.html.h:3
-msgid "Start Multipath"
-msgstr ""
-
-#: pkg/storaged/index.html.h:4
-msgid ""
-"\n"
-"        There are devices with multiple paths on the system, but the "
-"multipath service is not running.\n"
-"      "
-msgstr ""
-
-#: pkg/storaged/index.html.h:7
-msgid "RAID Devices"
-msgstr ""
-
-#: pkg/storaged/index.html.h:8
-msgid "No storage set up as RAID"
-msgstr ""
-
-#: pkg/storaged/index.html.h:9
-msgid "Volume Groups"
-msgstr ""
-
-#: pkg/storaged/index.html.h:10
-msgid "No volume groups created"
-msgstr ""
-
-#: pkg/storaged/index.html.h:11
-msgid "iSCSI Targets"
-msgstr ""
-
-#: pkg/storaged/index.html.h:12
-msgid "{{Address}}:{{Port}}"
-msgstr ""
-
-#: pkg/storaged/index.html.h:13
-msgid "No iSCSI targets set up"
-msgstr ""
-
-#: pkg/storaged/index.html.h:14
-msgid "Drives"
-msgstr "Unidades"
-
-#: pkg/storaged/index.html.h:15
-msgid "No drives attached"
-msgstr ""
-
-#: pkg/storaged/index.html.h:16
-msgid "Other Devices"
-msgstr "Outros dispositivos"
-
-#: pkg/storaged/index.html.h:17
-msgid "Filesystems"
-msgstr "Sistema de Arquivos"
-
-#: pkg/storaged/index.html.h:21
-msgid "Jobs"
-msgstr ""
-
-#: pkg/storaged/index.html.h:23 pkg/networkmanager/index.html.h:3
-msgid "Go to now"
-msgstr ""
-
-#: pkg/storaged/index.html.h:24 pkg/networkmanager/index.html.h:4
-msgid "5 minutes"
-msgstr ""
-
-#: pkg/storaged/index.html.h:25 pkg/networkmanager/index.html.h:5
-msgid "1 hour"
-msgstr ""
-
-#: pkg/storaged/index.html.h:26 pkg/networkmanager/index.html.h:6
-msgid "6 hours"
-msgstr ""
-
-#: pkg/storaged/index.html.h:27 pkg/networkmanager/index.html.h:7
-msgid "1 day"
-msgstr ""
-
-#: pkg/storaged/index.html.h:28 pkg/networkmanager/index.html.h:8
-msgid "1 week"
-msgstr ""
-
-#: pkg/storaged/index.html.h:29
-msgid "Reading"
-msgstr ""
-
-#: pkg/storaged/index.html.h:30
-msgid "Writing"
-msgstr ""
-
-#: pkg/storaged/index.html.h:31
-msgid "Storage Logs"
-msgstr ""
-
-#: pkg/storaged/index.html.h:32
-msgid "Create partition table"
-msgstr ""
-
-#: pkg/storaged/index.html.h:34
-msgid "Block Device"
-msgstr "Dispositivos de Bloco"
-
-#: pkg/storaged/index.html.h:40
-msgid "No media inserted"
-msgstr ""
-
-#: pkg/storaged/index.html.h:42
-msgid "DISK IS FAILING"
-msgstr ""
-
-#: pkg/storaged/index.html.h:43
-msgid "Disk is OK"
-msgstr ""
-
-#: pkg/storaged/index.html.h:46
-msgid "The RAID Array is in a degraded state"
-msgstr ""
-
-#: pkg/storaged/index.html.h:47
-msgid "RAID Device"
-msgstr "Dispositivo RAID"
-
-#: pkg/storaged/index.html.h:56
-msgid "Volume Group"
-msgstr "Grupo de volumes"
-
-#: pkg/storaged/index.html.h:57
-msgid "Physical Volumes"
-msgstr "Volumes Físicos"
-
-#: pkg/storaged/index.html.h:58
-msgid "Storage Log"
-msgstr "Log de armazenamento"
-
-#: pkg/realmd/operation.html.h:1
-msgid "Domain Address"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:2
-msgid "Computer OU"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:4 pkg/users/index.html.h:11
-msgid "User Name"
-msgstr "Nome de Usuário"
-
-#: pkg/realmd/operation.html.h:5
-msgid "User Password"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:6
-msgid "Domain Administrator Name"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:7
-msgid "Domain Administrator Password"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:8
-msgid "One Time Password"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:9
-msgid "This may take a while"
-msgstr ""
-
-#: pkg/docker/index.html.h:1 pkg/kubernetes/index.html.h:4
-#: pkg/kubernetes/views/containers-listing.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:6
-#: pkg/kubernetes/views/dashboard-page.html.h:17
-msgid "Containers"
-msgstr "Containers"
-
-#: pkg/docker/index.html.h:2
-msgid "Connecting to Docker"
-msgstr "Conectando ao Docker"
-
-#: pkg/docker/index.html.h:3
-msgid "Not authorized to access Docker on this system"
-msgstr "Não autorizado para acessar Docker neste sistema"
-
-#: pkg/docker/index.html.h:4
-msgid "Docker is not installed or activated on the system"
-msgstr "Docker não está instalado ou ativado no sistema"
-
-#: pkg/docker/index.html.h:5
-msgid "Can&rsquo;t connect to Docker"
-msgstr ""
-
-#: pkg/docker/index.html.h:6
-msgid "Start Docker"
-msgstr "Iniciar Docker"
-
-#: pkg/docker/index.html.h:7
-msgid "Try again"
-msgstr "Tente novamente"
-
-#: pkg/docker/index.html.h:8
-msgid "Combined CPU usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:9
-msgid "Combined memory usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:10
-#, fuzzy
-msgid "Show all containers"
-msgstr "Containers"
-
-#: pkg/docker/index.html.h:11
-msgid "IP Address:"
-msgstr ""
-
-#: pkg/docker/index.html.h:12
-msgid "IP Prefix Length:"
-msgstr ""
-
-#: pkg/docker/index.html.h:13
-msgid "Gateway:"
-msgstr ""
-
-#: pkg/docker/index.html.h:14
-msgid "MAC Address:"
-msgstr ""
-
-#: pkg/docker/index.html.h:15 pkg/kubernetes/views/image-page.html.h:1
-msgid "Show all images"
-msgstr ""
-
-#: pkg/docker/index.html.h:16 pkg/kubernetes/index.html.h:2
-#: pkg/kubernetes/registry.html.h:2
-msgid "Overview"
-msgstr ""
-
-#: pkg/docker/index.html.h:17
-msgid "Reset"
-msgstr "Redefinir"
-
-#: pkg/docker/index.html.h:18
-msgid "Storage pool"
-msgstr ""
-
-#: pkg/docker/index.html.h:19
-msgid "Additional Storage"
-msgstr ""
-
-#: pkg/docker/index.html.h:20
-msgid "TCP"
-msgstr "TCP"
-
-#: pkg/docker/index.html.h:21
-msgid "{{host_port_label}}"
-msgstr "{{host_port_label}}"
-
-#: pkg/docker/index.html.h:22
-msgid "{{host_volume_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:24
-msgid "ReadWrite"
-msgstr ""
-
-#: pkg/docker/index.html.h:25
-msgid "ReadOnly"
-msgstr ""
-
-#: pkg/docker/index.html.h:26
-msgid "{{envvar_key_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:27
-msgid "{{envvar_value_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:28
-msgid "select container"
-msgstr ""
-
-#: pkg/docker/index.html.h:29
-msgid "{{alias_label}}"
-msgstr "{{alias_label}}"
-
-#: pkg/docker/index.html.h:30 pkg/kubernetes/views/image-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:2
-#: pkg/kubernetes/views/image-page.html.h:2
-msgid "Image"
-msgstr "Imagem"
-
-#: pkg/docker/index.html.h:31
-msgid "Container Name"
-msgstr "Nome do Container"
-
-#: pkg/docker/index.html.h:33
-msgid "Memory limit"
-msgstr "Limite de Memória"
-
-#: pkg/docker/index.html.h:34
-msgid "MiB"
-msgstr ""
-
-#: pkg/docker/index.html.h:35
-msgid "CPU priority"
-msgstr "Prioridade de CPU"
-
-#: pkg/docker/index.html.h:36
-msgid "shares"
-msgstr ""
-
-#: pkg/docker/index.html.h:37
-msgid "With terminal"
-msgstr "Com o terminal"
-
-#: pkg/docker/index.html.h:38
-msgid "Links"
-msgstr "Links"
-
-#: pkg/docker/index.html.h:40
-msgid "Expose container ports"
-msgstr ""
-
-#: pkg/docker/index.html.h:41 pkg/kubernetes/index.html.h:7
-#: pkg/kubernetes/views/image-config.html.h:9
-#: pkg/kubernetes/views/pod-page.html.h:3
-#: pkg/kubernetes/views/dashboard-page.html.h:4
-msgid "Volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:42
-msgid "Mount container volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:43 pkg/kubernetes/views/image-config.html.h:6
-#: pkg/kubernetes/views/container-body.html.h:9
-msgid "Environment"
-msgstr ""
-
-#: pkg/docker/index.html.h:44
-msgid "Set container environment variables"
-msgstr ""
-
-#: pkg/docker/index.html.h:45 pkg/kubernetes/views/pod-body.html.h:4
-msgid "Restart Policy"
-msgstr ""
-
-#: pkg/docker/index.html.h:47
-msgid "On Failure"
-msgstr ""
-
-#: pkg/docker/index.html.h:50
-msgid "Retries:"
-msgstr ""
-
-#: pkg/docker/index.html.h:51 pkg/users/index.html.h:26
-#: pkg/networkmanager/index.html.h:52
-msgid ""
-"\n"
-"            Cancel\n"
-"          "
-msgstr ""
-"\n"
-"            Cancelar\n"
-"          "
-
-#: pkg/docker/index.html.h:54
-msgid ""
-"\n"
-"            Run\n"
-"          "
-msgstr ""
-"\n"
-"            Executar\n"
-"          "
-
-#: pkg/docker/index.html.h:57
-msgid ""
-"\n"
-"            Download\n"
-"          "
-msgstr ""
-"\n"
-"            Baixar\n"
-"          "
-
-#: pkg/docker/index.html.h:60
-msgid ""
-"\n"
-"            Change\n"
-"          "
-msgstr ""
-"\n"
-"            Modificar\n"
-"          "
-
-#: pkg/docker/index.html.h:63
-msgid "Repository"
-msgstr "Repositório"
-
-#: pkg/docker/index.html.h:64
-msgid "Tag"
-msgstr "Marca"
-
-#: pkg/docker/index.html.h:65 pkg/kubernetes/views/image-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:5
-msgid "Author"
-msgstr "Autor"
-
-#: pkg/docker/index.html.h:66
-msgid ""
-"\n"
-"            Commit\n"
-"          "
-msgstr ""
-"\n"
-"            Commit\n"
-"          "
-
-#: pkg/users/index.html.h:1
-msgid "Local Accounts"
-msgstr ""
-
-#: pkg/users/index.html.h:2
-msgid ""
-"\n"
-"            Close\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:5
-msgid "Create New Account"
-msgstr "Criar Nova Conta"
-
-#: pkg/users/index.html.h:6
-msgid "Account not available or cannot be edited."
-msgstr ""
-
-#: pkg/users/index.html.h:7
-msgid "Accounts"
-msgstr ""
-
-#: pkg/users/index.html.h:8
-msgid "Terminate Session"
-msgstr ""
-
-#: pkg/users/index.html.h:10
-msgid "Full Name"
-msgstr "Nome Completo"
-
-#: pkg/users/index.html.h:12
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:3
-#: pkg/kubernetes/views/project-body.html.h:2
-msgid "Roles"
-msgstr "Papéis"
-
-#: pkg/users/index.html.h:13
-msgid "Last Login"
-msgstr "Último Login"
-
-#: pkg/users/index.html.h:14
-msgid "Access"
-msgstr "Acesso"
-
-#: pkg/users/index.html.h:15
-msgid "Lock Account"
-msgstr "Bloquear Conta"
-
-#: pkg/users/index.html.h:17
-msgid "Set Password"
-msgstr ""
-
-#: pkg/users/index.html.h:18
-msgid "Authorized Public SSH Keys"
-msgstr ""
-
-#: pkg/users/index.html.h:20
-msgid ""
-"\n"
-"            Create\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:25
-msgid "Confirm New Password"
-msgstr "Confirmar Nova Senha"
-
-#: pkg/users/index.html.h:29
-msgid ""
-"\n"
-"            Set\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:32
-msgid "Delete Files"
-msgstr "Excluir Arquivos"
-
-#: pkg/users/index.html.h:33 pkg/networkmanager/index.html.h:48
-msgid ""
-"\n"
-"            Delete\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:36
-msgid "Unnamed"
-msgstr ""
-
-#: pkg/users/index.html.h:37
-msgid "Invalid key"
-msgstr ""
-
-#: pkg/users/index.html.h:38
-msgid "There are no authorized public keys for this account."
-msgstr ""
-
-#: pkg/users/index.html.h:39
-msgid ""
-"You do not have permission to view the authorized public keys for this "
-"account."
-msgstr ""
-
-#: pkg/users/index.html.h:40
-msgid "Failed to load authorized keys."
-msgstr ""
-
-#: pkg/users/index.html.h:41
-msgid "Add public key"
-msgstr ""
-
-#: pkg/users/index.html.h:42
-msgid ""
-"\n"
-"            Add key\n"
-"          "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:1
-msgid "Diagnostic reports"
-msgstr "Relatório de diagnostico"
-
-#: pkg/sosreport/index.html.h:2
-msgid ""
-"\n"
-"        This tool will collect system configuration and diagnostic\n"
-"        information from this system for use with diagnosing problems\n"
-"        with the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:7
-msgid ""
-"\n"
-"        The collected information will be stored locally on the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:10
-msgid "Create report"
-msgstr "Criar relatório"
-
-#: pkg/sosreport/index.html.h:11
-msgid "Create diagnostic report"
-msgstr "Criar um relatório de diagnostico"
-
-#: pkg/sosreport/index.html.h:12
-msgid ""
-"\n"
-"                The generated archive contains data considered\n"
-"                sensitive and its content should be reviewed by the\n"
-"                originating organization before being passed to any\n"
-"                third party.\n"
-"              "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:18
-msgid "Generating report"
-msgstr "Gerando relatório"
-
-#: pkg/sosreport/index.html.h:19
-msgid "Done!"
-msgstr "Feito!"
-
-#: pkg/networkmanager/index.html.h:1
-msgid "Networking"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:2
-msgid "Testing connection"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:9
-msgid "Sending"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:10
-msgid "Receiving"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:11
-msgid "Interfaces"
-msgstr "Interfaces"
-
-#: pkg/networkmanager/index.html.h:12
-msgid "Add Bond"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:13
-msgid "Add Team"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:14
-msgid "Add Bridge"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:15
-msgid "Add VLAN"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:17
-msgid "IP Address"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:18
-#, fuzzy
-msgid "Unmanaged Interfaces"
-msgstr "Interfaces"
-
-#: pkg/networkmanager/index.html.h:19
-msgid "Networking Logs"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:20
-msgid "Parent"
-msgstr "Parente"
-
-#: pkg/networkmanager/index.html.h:21
-msgid "VLAN Id"
-msgstr "VLAN Id"
-
-#: pkg/networkmanager/index.html.h:23
-msgid "Set to"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:25
-msgid "Spanning Tree Protocol (STP)"
-msgstr "Spanning Tree Protocol (STP)"
-
-#: pkg/networkmanager/index.html.h:26
-msgid "STP Priority"
-msgstr "STP Prioridade"
-
-#: pkg/networkmanager/index.html.h:27
-msgid "STP Forward delay"
-msgstr "STP Atraso de Redirecionamento "
-
-#: pkg/networkmanager/index.html.h:28
-msgid "STP Hello time"
-msgstr "STP Hello time"
-
-#: pkg/networkmanager/index.html.h:29
-msgid "STP Maximum message age"
-msgstr "STP Máxima permanência de mensagem"
-
-#: pkg/networkmanager/index.html.h:30
-msgid "Priority"
-msgstr "Prioridade"
-
-#: pkg/networkmanager/index.html.h:31
-msgid "Path cost"
-msgstr "Custo do Caminho"
-
-#: pkg/networkmanager/index.html.h:32
-msgid "Hair Pin mode"
-msgstr "Hair Pin modo"
-
-#: pkg/networkmanager/index.html.h:34
-msgid "Mode"
-msgstr "Modo"
-
-#: pkg/networkmanager/index.html.h:35
-msgid "Primary"
-msgstr "Primário"
-
-#: pkg/networkmanager/index.html.h:36
-msgid "Link Monitoring"
-msgstr "Monitoramento de Link"
-
-#: pkg/networkmanager/index.html.h:37
-msgid "Monitoring Interval"
-msgstr "Monitorando Intervalo"
-
-#: pkg/networkmanager/index.html.h:38
-msgid "Monitoring Targets"
-msgstr "Alvod e Monitoramento"
-
-#: pkg/networkmanager/index.html.h:39
-msgid "Link up delay"
-msgstr "Link up atraso"
-
-#: pkg/networkmanager/index.html.h:40
-msgid "Link down delay"
-msgstr "Link down atraso"
-
-#: pkg/networkmanager/index.html.h:41
-#, fuzzy
-msgid "Runner"
-msgstr "Executando"
-
-#: pkg/networkmanager/index.html.h:42
-msgid "Balancer"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:43
-#, fuzzy
-msgid "Link Watch"
-msgstr "Link Local"
-
-#: pkg/networkmanager/index.html.h:44
-#, fuzzy
-msgid "Ping Interval"
-msgstr "Monitorando Intervalo"
-
-#: pkg/networkmanager/index.html.h:45
-#, fuzzy
-msgid "Ping Target"
-msgstr "Apagando $target"
-
-#: pkg/networkmanager/index.html.h:46
-msgid "Sticky"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:47
-msgid "LACP Key"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:51
-msgid "IP Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:55
-msgid ""
-"\n"
-"            Apply\n"
-"          "
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:58
-msgid "Bond Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:59
-#, fuzzy
-msgid "Team Settings"
-msgstr "IPv4 Ajustes"
-
-#: pkg/networkmanager/index.html.h:60
-#, fuzzy
-msgid "Team Port Settings"
-msgstr "IPv4 Ajustes"
-
-#: pkg/networkmanager/index.html.h:61
-msgid "Bridge Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:62
-msgid "Bridge Port Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:63
-msgid "VLAN Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:64
-msgid "Ethernet MTU"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:66
-msgid "Connection will be lost"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:1
-msgid "Kubernetes Cluster"
-msgstr "Kubernetes Cluster"
-
-#: pkg/kubernetes/index.html.h:3 pkg/kubernetes/views/dashboard-page.html.h:8
-#: pkg/kubernetes/views/nodes-page.html.h:4
-msgid "Nodes"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:5
-msgid "Topology"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:8 pkg/kubernetes/registry.html.h:3
-#: pkg/kubernetes/views/image-listing.html.h:2
-#: pkg/kubernetes/views/imagestream-page.html.h:3
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:5
-msgid "Images"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:9 pkg/kubernetes/registry.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:2
-#: pkg/kubernetes/views/project-listing.html.h:2
-#: pkg/kubernetes/views/user-delete.html.h:2
-msgid "Projects"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:11 pkg/kubernetes/registry.html.h:6
-msgid "Couldn't connect to server"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:12 pkg/kubernetes/registry.html.h:7
-msgid ""
-"\n"
-"                Reconnect\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:15
-msgid ""
-"\n"
-"                Troubleshoot\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/registry.html.h:1
-msgid "Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:1
-#: pkg/kubernetes/views/service-body.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:1
-#: pkg/kubernetes/views/containers-listing.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:9
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:18
-#: pkg/kubernetes/views/route-body.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:5
-#: pkg/kubernetes/views/imagestream-modify.html.h:4
-msgid "Project"
-msgstr "Projeto"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:2
-#: pkg/kubernetes/views/service-body.html.h:2
-#: pkg/kubernetes/views/pod-body.html.h:2
-#: pkg/kubernetes/views/containers-listing.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:10
-#: pkg/kubernetes/views/pv-claim.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:19
-#: pkg/kubernetes/views/route-body.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:6
-msgid "Namespace"
-msgstr "Namespace"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:3
-#: pkg/kubernetes/views/pod-body.html.h:3
-#: pkg/kubernetes/views/node-body.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:3
-#: pkg/kubernetes/views/route-body.html.h:3
-msgid "Created"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:4
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:17
-msgid "Replicas"
-msgstr "Réplicas"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:5
-#: pkg/kubernetes/views/service-body.html.h:9
-#: pkg/kubernetes/views/pod-body.html.h:10
-#: pkg/kubernetes/views/node-body.html.h:12
-#: pkg/kubernetes/views/image-meta.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:8
-#: pkg/kubernetes/views/route-body.html.h:8
-msgid "Labels"
-msgstr "Rótulos"
-
-#: pkg/kubernetes/views/service-body.html.h:4
-#: pkg/kubernetes/views/node-body.html.h:3
-msgid "IP"
-msgstr ""
-
-#: pkg/kubernetes/views/service-body.html.h:8
-msgid "Session Affinity"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:1
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:10
-msgid "New image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:3
-#: pkg/kubernetes/views/image-body.html.h:10
-#: pkg/kubernetes/views/imagestream-modify.html.h:7
-msgid "Tags"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:5
-msgid "Last Updated"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:6
-msgid "No image streams are present."
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:1
-msgid "Delete Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:2
-msgid "Do you want to delete this Node?"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:3
-msgid " 1\">Do you want to delete the following Nodes?"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-container.html.h:1
-msgid "Show all Pod Containers"
-msgstr ""
-
-#: pkg/kubernetes/views/image-panel.html.h:3
-#: pkg/kubernetes/views/imagestream-page.html.h:4
-#: pkg/kubernetes/views/image-page.html.h:4
-msgid "Metadata"
-msgstr ""
-
-#: pkg/kubernetes/views/node-panel.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:8
-#: pkg/kubernetes/views/containers-listing.html.h:6
-#: pkg/kubernetes/views/node-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:11
-msgid "Node"
-msgstr "Nó"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:1
-msgid "Show all Replication Controllers"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:2
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:5
-msgid "Replication Controller"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:2
-#: pkg/kubernetes/views/pv-claim.html.h:9
-#: pkg/kubernetes/views/dashboard-page.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:18
-msgid "Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:2
-msgid "Template"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:5
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/group-delete.html.h:1
-msgid "Remove Group"
-msgstr ""
-
-#: pkg/kubernetes/views/group-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:5
-#: pkg/kubernetes/views/user-group-remove.html.h:3
-msgid "Remove"
-msgstr "Remover"
-
-#: pkg/kubernetes/views/pvc-delete.html.h:1
-msgid "Delete Persistent Volume Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:2
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:3
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:5
-msgid "Service Account"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:6
-msgid "DNS Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:7
-msgid "Phase"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:9
-msgid "Pod Address"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:5
-msgid "OS"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:7
-msgid "Boot ID"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:8
-msgid "Kernel Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:9
-msgid "Container Runtime Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:10
-msgid "Kubelet Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:11
-msgid "Proxy Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:13
-#: pkg/kubernetes/views/route-body.html.h:9
-msgid "none"
-msgstr "Nenhum"
-
-#: pkg/kubernetes/views/node-body.html.h:17
-msgid "Reason"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:18
-#: pkg/kubernetes/views/pv-claim.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:6 pkg/kubernetes/views/pv-body.html.h:6
-msgid "Message"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:19
-msgid "Last Heartbeat"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:20
-msgid "Last Status Change"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:21
-#: pkg/kubernetes/views/image-meta.html.h:3
-#: pkg/kubernetes/views/imagestream-meta.html.h:1
-#: pkg/kubernetes/views/route-body.html.h:10
-msgid "Annotations"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:1
-msgid "Remove Role"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:2
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member "
-"{{ fields.member.metadata.name }}?"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:1
-msgid "New Project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:6
-msgid "No projects are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:7
-msgid "New Group"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:8
-#: pkg/kubernetes/views/user-delete.html.h:3
-msgid "Groups"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:9
-msgid "No groups are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:10
-#: pkg/kubernetes/views/add-user-dialog.html.h:1
-msgid "Add User"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:11
-msgid "Users"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:12
-msgid "Identity"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:13
-msgid "Member of"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:14
-msgid "No users are present."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:1
-msgid "Cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:2
-msgid "Add New Cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:4
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:3
-msgid "Skip Certificate Verification"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:5
-msgid "Requires Authentication"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:7
-msgid "Add New User"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:9
-msgid "Client Certificate"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:10
-msgid "Username"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:12
-msgid "Token"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:1
-msgid "Add Cluster Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:4
-msgid "Configuration"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:5
-msgid "Configure Kubelet and Proxy"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:6
-msgid "Configure Flannel networking"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:1
-#: pkg/kubernetes/views/pvc-body.html.h:1
-msgid "Volume Type"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:2
-msgid "{{ volume | formatVolumeType }}"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:3
-msgid "PD Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:19
-msgid "Filesystem Type"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:6
-#: pkg/kubernetes/views/pv-modify.html.h:20
-msgid "Read Only"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:7
-msgid "Volume ID"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:8
-msgid "Repository URL"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:9
-msgid "Revision"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:10
-#: pkg/kubernetes/views/image-config.html.h:3
-msgid "Directory"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:12
-msgid "Medium"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:13
-#: pkg/kubernetes/views/pv-modify.html.h:14
-msgid "Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:14
-msgid "Endpoint Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:15
-#: pkg/kubernetes/views/pv-modify.html.h:13
-msgid "Volume Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:17
-msgid "Monitors"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:18
-msgid "Image Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:19
-msgid "Pool Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:21
-msgid "Key Ring Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:22
-msgid "Secret Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:23
-msgid "Target Portal"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:24
-#: pkg/kubernetes/views/pv-modify.html.h:16
-msgid "Qualified Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:25
-#: pkg/kubernetes/views/pv-modify.html.h:17
-msgid "Logical Unit Number"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:26
-#: pkg/kubernetes/views/pv-modify.html.h:18
-msgid "Interface"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:27
-msgid "Ceph Monitors"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:28
-msgid "Secret File"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:29
-msgid "Target World Wide Names"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:30
-msgid "Flocker Dataset Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:31
-msgid "Driver"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:33
-msgid "Share Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:34
-msgid "Secret Name"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:2
-msgid "On Build"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:4
-msgid "Docker Version"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:5
-msgid "Image Layers"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:1
-#: pkg/kubernetes/views/user-page.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:1
-msgid "Show all Projects"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:2
-#: pkg/kubernetes/views/group-panel.html.h:1
-msgid "Group Members"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:3
-#: pkg/kubernetes/views/user-group-add.html.h:1
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:1
-#: pkg/kubernetes/views/group-panel.html.h:2
-#: pkg/kubernetes/views/project-body.html.h:10
-msgid "Add Member"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:4
-msgid "The group '{{ groupName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/containers-listing.html.h:3
-#: pkg/kubernetes/views/pod-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:2
-msgid "Pod"
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:2
-msgid "Membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:2
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:5
-#: pkg/kubernetes/views/user-panel.html.h:7
-msgid "Add Membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-group-add.html.h:2
-msgid ""
-"\n"
-"                        User\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:2
-msgid "User or Group"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-panel.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:4
-msgid "Mount Location"
-msgstr ""
-
-#: pkg/kubernetes/views/route-modify.html.h:1
-msgid "Adjust Route"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:1
-msgid "Show all Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:2 pkg/kubernetes/views/pvc-body.html.h:3
-#: pkg/kubernetes/views/pv-panel.html.h:1
-msgid "Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:3 pkg/kubernetes/views/pv-panel.html.h:2
-msgid "Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:4
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:1
-msgid "Remove image tag"
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:2
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:1
-msgid "Run as"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:4
-msgid "Stop with"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:1
-msgid "Delete Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:2
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:3
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
-"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
-"may cause issues with any pods depending on it."
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:3
-msgid "Identities"
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:3
-msgid "The user '{{ userName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:1
-msgid "Show all Deployment Configs"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:1
-msgid "Deployment Config"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:4
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/route-panel.html.h:1
-#: pkg/kubernetes/views/route-page.html.h:2
-msgid "Route"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:1
-msgid "Register New Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:2
-msgid "Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:7
-msgid "No volumes are present."
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:8
-msgid "Pending Volume Claims"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:12
-msgid "When"
-msgstr ""
-
-#: pkg/kubernetes/views/user-delete.html.h:1
-msgid "Remove User"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:3
-#: pkg/kubernetes/views/pv-modify.html.h:10
-#: pkg/kubernetes/views/pvc-body.html.h:7 pkg/kubernetes/views/pv-body.html.h:2
-msgid "Access Modes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:4
-msgid "Requests"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:5
-msgid "This volume has not been claimed"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:10
-msgid "No Pods are using this claim"
-msgstr ""
-
-#: pkg/kubernetes/views/filter-project.html.h:1
-msgid "All Projects"
-msgstr ""
-
-#: pkg/kubernetes/views/filter-project.html.h:2
-msgid "Project:"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:5
-#: pkg/kubernetes/views/details-page.html.h:14
-msgid "Latest Version"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:6
-msgid "Deployment Causes"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:7
-msgid "Triggers"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:1
-msgid "Delete {{ item.kind }}"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:2
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:3
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:2
-#: pkg/kubernetes/views/user-modify.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:2
-msgid ""
-"\n"
-"                        Name\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:5
-#: pkg/kubernetes/views/user-modify.html.h:5
-msgid ""
-"\n"
-"                        Identity\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:1
-msgid "Project Members"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:3
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:6
-msgid "Admin"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:7
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/container-panel.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:3
-msgid "Shell"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:1
-msgid "Pod Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:2
-msgid "No pods selected"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:3
-msgid "Pod Selector"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:1
-msgid "Add membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:2
-msgid ""
-"\n"
-"                        Group or Project\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:5
-msgid ""
-"\n"
-"                        Role\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:1
-msgid "Deploy Application"
-msgstr "Implantar aplicativo"
-
-#: pkg/kubernetes/views/deploy.html.h:3
-msgid "{{ selected.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:5
-#: pkg/kubernetes/views/dashboard-page.html.h:11
-msgid "Deploy"
-msgstr "Implantar"
-
-#: pkg/kubernetes/views/user-modify.html.h:1
-msgid "Change User"
-msgstr ""
-
-#: pkg/kubernetes/views/user-modify.html.h:9
-msgid "Modify"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:1
-#: pkg/kubernetes/views/project-modify.html.h:6
-msgid "Access Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:2
-msgid ""
-"\n"
-"          Images may be pulled by anonymous users\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:5
-msgid ""
-"\n"
-"          Images may be pulled by any authenticated user or group\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:8
-msgid ""
-"\n"
-"          Images may only be pulled by specific users or groups\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:11
-msgid "Pull repository"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:13
-msgid "Image count"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:14
-msgid "{{stream.status.tags.length}}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:15
-msgid "To push to an image to this image stream:"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:1
-msgid "The node doesn't have enough disk space"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:2
-msgid "The node doesn't have enough free memory"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:1
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:2
-msgid "Register Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:4
-msgid "Warning:"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:5
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:7
-#: pkg/kubernetes/views/node-page.html.h:3
-#: pkg/kubernetes/views/pvc-body.html.h:10
-#: pkg/kubernetes/views/pv-body.html.h:3
-msgid "Capacity"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:8
-#: pkg/kubernetes/views/pv-body.html.h:1
-msgid "Reclaim Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:9
-msgid "{{ value }}"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:12
-msgid "Endpoint"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:15
-msgid "Target"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-dialog.html.h:1
-msgid "Connection Settings"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-dialog.html.h:2
-msgid "Connection Error"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:2
-msgid "Summary"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:4
-msgid "Source URL"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:7
-msgid "Built"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:8
-msgid "Digest"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:9
-msgid "Identifier"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:11
-msgid "To pull this image:"
-msgstr ""
-
-#: pkg/kubernetes/views/service-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:8
-#: pkg/kubernetes/views/service-page.html.h:2
-msgid "Service"
-msgstr "Serviço"
-
-#: pkg/kubernetes/views/service-panel.html.h:2
-#: pkg/kubernetes/views/service-page.html.h:3
-msgid "Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:1
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:2
+#: pkg/kubernetes/views/auth-rejected-cert.html:3
 msgid ""
 "You can bypass the certificate check, but any data you send to the server "
 "could be intercepted by others."
 msgstr ""
 
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:4
-msgid "Trust this certificate for this connection"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:1
-msgid "Show all Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:7
-msgid "The pod '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:1
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:1
-msgid "Delete image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:2
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:2
-msgid "All running"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:3
-msgid "No pods deployed"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:5
-msgid "All in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:6
-msgid "No volumes in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:7
-msgid "pending volume claims"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:9
-msgid "All healthy"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:10
-msgid "No nodes in cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:13
-msgid "Could not list services"
-msgstr "Não foi possível listar serviços"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:14
+#: pkg/kubernetes/views/dashboard-page.html:150
 msgid "You can deploy an application to your cluster."
 msgstr "Você pode implantar um aplicativo para o seu cluster."
 
-#: pkg/kubernetes/views/imagestream-page.html.h:1
-msgid "Show all image streams"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-page.html.h:2
-msgid "Image Stream"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:3
-msgid "Image ID"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:4
-msgid "Container ID"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:7
-msgid "Since"
-msgstr "Desde"
-
-#: pkg/kubernetes/views/container-body.html.h:8
-msgid "Restart Count"
-msgstr ""
-
-#: pkg/kubernetes/views/user-remove-membership.html.h:1
-msgid "Remove membership"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:1
-msgid "Delete Selected"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:2
-msgid "OS Versions"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:3
-msgid "Add Kubernetes Node"
-msgstr ""
-
-#: pkg/kubernetes/views/project-page.html.h:3
-msgid "The project '{{ projName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/user-panel.html.h:4
+#: pkg/lib/machine-invalid-hostkey.html:11
 msgid ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
+"You can remove the previously stored key by running the following command"
 msgstr ""
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:1
-msgid "Pod Replicated"
+#: pkg/shell/base_index.js:672
+msgid "You can try restarting Cockpit by pressing refresh in your browser. "
 msgstr ""
+"Você pode tentar reiniciar o Cockpit pressionado o botão atualizar do seu "
+"browser."
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:2
-msgid "No pods replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/container-page.html.h:1
-msgid "Show all Containers"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:1
-msgid "Welcome to the Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:2
+#: pkg/users/index.html:335
 msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
+"You do not have permission to view the authorized public keys for this "
+"account."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:1
-msgid "New project"
+#: pkg/docker/storage.jsx:482
+msgid "You don't have permission to manage the Docker storage pool."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:4
-msgid "Images by project"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:6
-msgid "Images pushed recently"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:7
-msgid "All images"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:8
-msgid "No images pushed"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:9
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:11
-msgid "Login commands"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:12
-msgid "Log into the registry:"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:13
+#: pkg/kubernetes/views/registry-dashboard-page.html:112
 msgid ""
 "Your login credentials do not give you access to use the docker registry "
 "from the command line."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:14
-msgid "Log into OpenShift command line tools:"
+#: src/base1/cockpit.js:3687
+msgid "Your session has been terminated."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:15
-msgid "Image commands"
+#: src/base1/cockpit.js:3689
+msgid "Your session has expired. Please log in again."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:16
-msgid "Push an image:"
+#: pkg/lib/journal.js:213
+msgid "[$0 bytes of binary data]"
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:17
-msgid "Pull an image:"
+#: pkg/lib/journal.js:215
+msgid "[binary data]"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html.h:1
-msgid "Show all Nodes"
+#: pkg/lib/journal.js:209
+msgid "[no data]"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html.h:4
-msgid "The node '{{ target }}' does not exist."
+#: pkg/storaged/details.js:1692
+msgid "active, but unsupported"
+msgstr "ativo, mas não suportado"
+
+#: pkg/storaged/utils.js:88
+msgctxt "format-bytes"
+msgid "bytes"
+msgstr "bytes"
+
+#: pkg/docker/util.js:123
+msgid "default"
+msgstr "padrão"
+
+#: pkg/storaged/details.js:178
+msgid "ext4 - Red Hat Enterprise Linux 6 default"
 msgstr ""
 
-#: pkg/kubernetes/views/route-page.html.h:1
-msgid "Show all Routes"
+#: pkg/systemd/host.js:661
+msgid "failed to list ssh host keys: $0"
 msgstr ""
 
-#: pkg/kubernetes/views/route-page.html.h:3
-msgid "The route '{{ target }}' does not exist."
+#: pkg/storaged/index.html:135
+msgid "iSCSI Targets"
 msgstr ""
 
-#: pkg/kubernetes/views/topology-page.html.h:1
-msgid "Select an object to see more details."
-msgstr "Selecione um objeto para ver mais detalhes."
+#: pkg/storaged/details.js:1692
+msgid "inactive"
+msgstr "inativo"
 
-#: pkg/kubernetes/views/topology-page.html.h:3
-msgid ""
-"Pods contain one or more containers that run\n"
-"                together on a node, containing your application code."
-msgstr ""
+#: pkg/storaged/details.js:1286
+msgid "locked"
+msgstr "bloqueado"
 
-#: pkg/kubernetes/views/topology-page.html.h:6
-msgid ""
-"Replication controllers dynamically create instances of\n"
-"                pods from templates, and remove pods when necessary."
-msgstr ""
+#: pkg/storaged/details.js:1278
+msgid "mounted on $0"
+msgstr "montado em $0"
 
-#: pkg/kubernetes/views/topology-page.html.h:9
-msgid ""
-"Services group pods and provide a common DNS\n"
-"                name and an optional, load-balanced IP address to access "
-"them."
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html.h:12
-msgid "Nodes are the machines that run your containers."
-msgstr ""
-
-#: pkg/kubernetes/views/add-group-dialog.html.h:1
-msgid "Add Group"
-msgstr ""
-
-#: pkg/kubernetes/views/file-button.html.h:1
-msgid "Select Manifest File..."
-msgstr "Selecione Arquivo Manifest ..."
-
-#: pkg/kubernetes/views/project-modify.html.h:2
-msgid "Change project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-modify.html.h:4
-msgid "Display name"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:5
-msgid "TLS Termination"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:6
-msgid "yes"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:7
+#: pkg/kubernetes/views/route-body.html:14
 msgid "no"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:1
-msgid "Add Role"
+#: pkg/kubernetes/views/route-body.html:24
+#: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
+msgid "none"
+msgstr "Nenhum"
+
+#: pkg/storaged/details.js:1280
+msgid "not mounted"
+msgstr "não montado"
+
+#: pkg/kubernetes/views/dashboard-page.html:83
+msgid "pending volume claims"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:2
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#: pkg/tuned/change-profile.jsx:52
+#, fuzzy
+msgid "recommended"
+msgstr "MII (Recomendado)"
+
+#: pkg/docker/index.html:426
+msgid "select container"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:1
-msgid "All Types"
+#: pkg/docker/index.html:504 pkg/docker/index.html:683
+msgid "shares"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:2
-msgid "Type:"
+#: pkg/selinux/setroubleshoot-view.jsx:118
+msgid "solution details"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:13
-msgid "Deployment Configs"
+#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
+msgid "unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:15
-msgid "Not deployed"
+#: pkg/storaged/jobs.js:180
+msgid "unknown target"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:16
-msgid "Replication Controllers"
+#: pkg/storaged/details.js:1284
+msgid "unlocked"
+msgstr "desbloqueado"
+
+#: pkg/kubernetes/views/route-body.html:13
+msgid "yes"
 msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:1
-msgid "Adjust Service"
-msgstr "Ajuste de serviço"
-
-#: pkg/kubernetes/views/service-modify.html.h:3
+#: pkg/kubernetes/views/service-modify.html:16
 msgid "{{ item.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:5
-msgid "Adjust"
-msgstr "Ajustar"
-
-#: pkg/kubernetes/views/project-delete.html.h:1
-msgid "Delete Project"
+#: pkg/kubernetes/views/deploy.html:27
+msgid "{{ selected.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:2
-msgid "Claim Name"
+#: pkg/kubernetes/views/pv-modify.html:61
+#: pkg/kubernetes/views/pv-modify.html:74
+msgid "{{ value }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:4
-msgid "No Volume Bound"
+#: pkg/kubernetes/views/volume-body.html:2
+msgid "{{ volume | formatVolumeType }}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:8
-msgid "Requested"
+#: pkg/storaged/index.html:147
+msgid "{{Address}}:{{Port}}"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html.h:9
-msgid "Actual"
+#: pkg/docker/index.html:435
+msgid "{{alias_label}}"
+msgstr "{{alias_label}}"
+
+#: pkg/systemd/services.html:173 pkg/systemd/services.html:202
+msgid "{{days_text}}"
 msgstr ""
 
-#: pkg/kubernetes/views/node-capacity.html.h:1
-msgid "Scheduled Pods"
+#: pkg/docker/index.html:403
+msgid "{{envvar_key_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/node-capacity.html.h:2
-msgid "No pods scheduled"
+#: pkg/docker/index.html:407
+msgid "{{envvar_value_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/container-page-inline.html.h:4
-msgid "The container '{{ target }}' does not exist."
+#: pkg/docker/index.html:359
+msgid "{{host_port_label}}"
+msgstr "{{host_port_label}}"
+
+#: pkg/docker/index.html:373
+msgid "{{host_volume_label}}"
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:1
-msgid "Create image stream"
+#: pkg/kubernetes/views/imagestream-body.html:35
+msgid "{{stream.status.tags.length}}"
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-modify.html.h:2
-msgid "Change image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:5
-msgid "Populate"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:6
-msgid "Pull from"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:8
-msgid "Remote registry is insecure"
-msgstr ""
-
-#: pkg/kubernetes/views/user-group-remove.html.h:1
-msgid "Remove Member"
-msgstr ""
-
-#: pkg/kubernetes/views/service-page.html.h:1
-msgid "Show all Services"
-msgstr ""
-
-#: pkg/kubernetes/views/service-page.html.h:4
-msgid "The service '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/scripts/frob-layers.html.h:1
-msgid "Image Layers Example"
-msgstr ""
-
-#: pkg/playground/service.html.h:1
-msgid "Cockpit Generic Service Monitor"
-msgstr ""
-
-#: pkg/playground/jquery-patterns.html.h:1
-msgid "Cockpit Pattern Usage"
-msgstr ""
-
-#: pkg/playground/metrics.html.h:1
 #, fuzzy
-msgid "Cockpit Monitoring"
-msgstr "Monitoramento de Link"
+#~ msgid "Cockpit Monitoring"
+#~ msgstr "Monitoramento de Link"
 
-#: pkg/playground/test.html.h:1 pkg/playground/translate.html.h:1
-msgid "Cockpit playground"
-msgstr ""
-
-#: pkg/playground/react-patterns.html.h:1
-msgid "Cockpit React Patterns Usage"
-msgstr ""
-
-#: pkg/playground/speed.html.h:1
-msgid "Cockpit Speed Tests"
-msgstr ""
-
-#: pkg/playground/plot.html.h:1
 #, fuzzy
-msgid "Cockpit Plots"
-msgstr "Cockpit"
-
-#: pkg/dashboard/index.html.h:1
-msgid "Dashboard"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:5
-#, fuzzy
-msgid "Disk I/O"
-msgstr "Discos"
-
-#: pkg/dashboard/index.html.h:6
-msgid "Lost connection. Trying to reconnect"
-msgstr "Conexão Perdida. Tentando reconectar."
-
-#: pkg/dashboard/index.html.h:10
-msgid "Avatar"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:13
-msgid "Set"
-msgstr ""
+#~ msgid "Cockpit Plots"
+#~ msgstr "Cockpit"
 
 #~ msgid "No addresses found"
 #~ msgstr "Nenhum endereço encontrado"
@@ -6195,63 +6287,6 @@ msgstr ""
 #~ msgid "Invalid login or password."
 #~ msgstr "Usuário ou senha inválido."
 
-#~ msgid ""
-#~ "\n"
-#~ "              Get new image\n"
-#~ "            "
-#~ msgstr ""
-#~ "\n"
-#~ "              Obter nova imagem\n"
-#~ "            "
-
-#~ msgctxt "storage"
-#~ msgid "Model"
-#~ msgstr "Modelo"
-
-#~ msgctxt "storage"
-#~ msgid "Firmware Version"
-#~ msgstr "Versão do Firmware"
-
-#~ msgctxt "storage"
-#~ msgid "Serial Number"
-#~ msgstr "Número de Série"
-
-#~ msgctxt "storage"
-#~ msgid "World Wide Name"
-#~ msgstr "Nome Global"
-
-#~ msgctxt "storage"
-#~ msgid "Capacity"
-#~ msgstr "Capacidade"
-
-#~ msgctxt "storage"
-#~ msgid "Assessment"
-#~ msgstr "Avaliação"
-
-#~ msgctxt "storage"
-#~ msgid "Device File"
-#~ msgstr "Arquivo de Dispositivo"
-
-#~ msgctxt "storage"
-#~ msgid "Device"
-#~ msgstr "Dispositivo"
-
 #~ msgctxt "storage"
 #~ msgid "Name"
 #~ msgstr "Nome"
-
-#~ msgctxt "storage"
-#~ msgid "UUID"
-#~ msgstr "UUID"
-
-#~ msgctxt "storage"
-#~ msgid "RAID Level"
-#~ msgstr "Nível de RAID"
-
-#~ msgctxt "storage"
-#~ msgid "Bitmap"
-#~ msgstr "Bitmap"
-
-#~ msgctxt "storage"
-#~ msgid "State"
-#~ msgstr "Estado"

--- a/po/tr.po
+++ b/po/tr.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-17 19:28+0100\n"
+"POT-Creation-Date: 2016-11-18 06:44+0100\n"
 "PO-Revision-Date: 2016-11-07 10:35-0500\n"
 "Last-Translator: Emin Tufan Çetin <etcetin@gmail.com>\n"
 "Language-Team: Turkish\n"
@@ -16,176 +16,312 @@ msgstr ""
 "X-Generator: Zanata 3.9.6\n"
 "Plural-Forms: nplurals=2; plural=(n>1)\n"
 
-#: src/ws/cockpitcertificate.c:359
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr "PEM-şifreli özel anahtar çözülemiyor"
-
-#: src/ws/cockpitcertificate.c:364
-msgid "No PEM-encoded private key found"
-msgstr "PEM-şifreli özel anahtar bulunamadı"
-
-#: src/ws/cockpitcertificate.c:374
-msgid "Could not parse PEM-encoded private key"
-msgstr "PEM-şifreli özel anahtar ayrıştırılamıyor"
-
-#: src/ws/cockpitcertificate.c:398
-msgid "No PEM-encoded certificate found"
-msgstr "PEM-şifreli sertifika bulunamadı"
-
-#: src/ws/cockpitcertificate.c:407
-msgid "Could not parse PEM-encoded certificate"
-msgstr "PEM-şifreli sertifika ayrıştırılamadı"
-
-#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
-#: src/bridge/cockpitdbussetup.c:625
-#, fuzzy
-msgid "Unsupported setup mechanism"
-msgstr "Desteklenmeyen kurulum düzeneği: %s"
-
-#: src/bridge/cockpitdbussetup.c:236
-msgid "Couldn't list users"
-msgstr "Kullanıcılar listelenemedi"
-
-#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
-msgid "Bad data passed for passwd1 mechanism"
-msgstr "passwd1 düzeneği için kötü veri geçti"
-
-#: src/bridge/cockpitdbussetup.c:382
-msgid "Couldn't load user data"
-msgstr "Kullanıcı verisi yüklenemedi"
-
-#: src/bridge/cockpitdbussetup.c:467
-msgid "Couldn't change user groups"
-msgstr "Kullanıcı kümeleri değiştirilemedi"
-
-#: src/bridge/cockpitdbussetup.c:520
-msgid "Couldn't change user password"
-msgstr "Kullanıcı parolası değiştirilemedi"
-
-#: src/bridge/cockpitdbussetup.c:544
-msgid "Couldn't create new users"
-msgstr "Yeni kullanıcılar oluşturulamadı"
-
-#: src/bridge/cockpitdbussetup.c:642
-msgid "Couldn't list local users"
-msgstr "Yerel kullanıcılar listelenemedi"
-
-#: src/bridge/cockpitpackages.c:459
-#, c-format
-msgid "This package requires Cockpit version %s or later"
+#: pkg/shell/index.html:227
+msgid "                                                Comment                                            "
 msgstr ""
 
-#: src/bridge/cockpitpackages.c:470
-msgid "This package is not compatible with this version of Cockpit"
+#: pkg/shell/index.html:235
+msgid "                                                Fingerprint                                            "
 msgstr ""
 
-#: src/base1/cockpit.js:2586
-msgid "$0 killed with signal $1"
+#: pkg/shell/index.html:231
+msgid "                                                Type                                            "
 msgstr ""
 
-#: src/base1/cockpit.js:2588
-msgid "$0 exited with code $1"
+#: pkg/systemd/index.html:389
+msgid ""
+"                                    Invalid time "
+"zone                                "
 msgstr ""
 
-#: src/base1/cockpit.js:2590
-msgid "$0 failed"
+#: pkg/kubernetes/views/project-body.html:80
+msgid ""
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}                                "
 msgstr ""
 
-#: src/base1/cockpit.js:3667
-msgid "Your session has been terminated."
+#: pkg/kubernetes/views/user-body.html:22
+msgid ""
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}                                "
 msgstr ""
 
-#: src/base1/cockpit.js:3669
-msgid "Your session has expired. Please log in again."
+#: pkg/kubernetes/views/user-panel.html:39
+msgid ""
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}                            "
 msgstr ""
 
-#: src/base1/cockpit.js:3671
-msgid "Not permitted to perform this action."
+#: pkg/kubernetes/views/project-body.html:37
+msgid ""
+"                                {{ getRegistryRoles(user, project())."
+"join() }}                            "
 msgstr ""
 
-#: src/base1/cockpit.js:3673
-msgid "Login failed"
+#: pkg/systemd/index.html:485 pkg/systemd/index.html:504
+msgid "                        Cancel                    "
 msgstr ""
 
-#: src/base1/cockpit.js:3675
-msgid "The server refused to authenticate using any supported methods."
+#: pkg/kubernetes/views/user-add-membership.html:9
+msgid "                        Group or Project                    "
 msgstr ""
 
-#: src/base1/cockpit.js:3677
-msgid "Untrusted host"
+#: pkg/kubernetes/views/add-user-dialog.html:19
+#: pkg/kubernetes/views/user-modify.html:19
+msgid "                        Identity                    "
 msgstr ""
 
-#: src/base1/cockpit.js:3679
-msgid "Host key is incorrect"
+#: pkg/kubernetes/views/add-user-dialog.html:9
+#: pkg/kubernetes/views/user-modify.html:9
+#: pkg/kubernetes/views/add-group-dialog.html:9
+msgid "                        Name                    "
 msgstr ""
 
-#: src/base1/cockpit.js:3681
-msgid "Internal error"
+#: pkg/kubernetes/views/user-add-membership.html:30
+msgid "                        Role                    "
 msgstr ""
 
-#: src/base1/cockpit.js:3683
-msgid "Connection has timed out."
+#: pkg/kubernetes/views/user-group-add.html:9
+msgid "                        User                    "
 msgstr ""
 
-#: src/base1/cockpit.js:3685
-msgid "Cockpit is not installed on the system."
+#: pkg/ostree/index.html:88
+msgid "                    Available                  "
 msgstr ""
 
-#: src/base1/cockpit.js:3687
-msgid "Cannot forward login credentials"
+#: pkg/ostree/index.html:85
+msgid "                    Default                  "
 msgstr ""
 
-#: src/base1/cockpit.js:3689
-msgid "Server has closed the connection."
+#: pkg/ostree/index.html:223
+msgid "                    Reconnect                "
 msgstr ""
 
-#: src/base1/cockpit.js:3691
-msgid "Cockpit is not compatible with the software on the system."
+#: pkg/ostree/index.html:135
+msgid ""
+"                    This deployment contains the same packages as your "
+"currently booted system                "
 msgstr ""
 
-#: src/base1/cockpit.js:3693
-msgid "Cockpit could not contact the given host."
+#: pkg/ostree/index.html:67
+msgid "                    Update and reboot                "
 msgstr ""
 
-#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:19
-#, fuzzy
-msgid "Control"
-msgstr "Konteyner"
+#: pkg/kubernetes/registry.html:74 pkg/kubernetes/index.html:104
+msgid "                Reconnect            "
+msgstr ""
 
-#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
-#: pkg/playground/translate.js:22
-#, fuzzy
-msgctxt "key"
-msgid "Control"
-msgstr "Konteyner"
+#: pkg/sosreport/index.html:57
+msgid ""
+"                The generated archive contains data "
+"considered                sensitive and its content should be reviewed by "
+"the                originating organization before being passed to "
+"any                third party.              "
+msgstr ""
 
-#: src/base1/test-locale.js:46 src/base1/test-locale.js:56
-#: pkg/playground/translate.js:10
-msgid "Empty"
-msgstr "Boş"
+#: pkg/shell/index.html:304 pkg/shell/stub.html:157
+msgid "                Tools              "
+msgstr ""
 
-#: src/base1/test-locale.js:47 src/base1/test-locale.js:58
-#: pkg/playground/translate.js:16
-#, fuzzy
-msgctxt "verb"
-msgid "Empty"
-msgstr "Boş"
+#: pkg/kubernetes/index.html:107
+msgid "                Troubleshoot            "
+msgstr ""
 
-#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
-#: src/base1/test-locale.js:66 pkg/storaged/details.js:1557
-#: pkg/playground/translate.js:25 pkg/playground/translate.js:28
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] ""
-msgstr[1] ""
+#: pkg/shell/simple.html:105 pkg/shell/index.html:126 pkg/shell/stub.html:119
+#: pkg/storaged/index.html:862
+msgid "              Cancel            "
+msgstr ""
 
-#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
-#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
-#: pkg/playground/translate.js:34
-msgctxt "disk-non-rotational"
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
+#: pkg/shell/index.html:147 pkg/shell/stub.html:140
+msgid "              Close            "
+msgstr ""
+
+#: pkg/shell/simple.html:70 pkg/shell/index.html:83 pkg/shell/stub.html:76
+msgid ""
+"              Cockpit is an interactive Linux server admin "
+"interface.            "
+msgstr ""
+
+#: pkg/shell/simple.html:79 pkg/shell/index.html:92 pkg/shell/stub.html:85
+msgid "              Licensed under the GNU LGPL version 2.1            "
+msgstr ""
+
+#: pkg/shell/simple.html:129
+msgid "              Log in again            "
+msgstr ""
+
+#: pkg/shell/simple.html:73 pkg/shell/index.html:86 pkg/shell/stub.html:79
+msgid "              Project website            "
+msgstr ""
+
+#: pkg/shell/simple.html:108 pkg/shell/index.html:129 pkg/shell/stub.html:122
+msgid "              Select            "
+msgstr ""
+
+#: pkg/shell/simple.html:126
+msgid "              Try to reconnect            "
+msgstr ""
+
+#: pkg/users/index.html:361
+msgid "            Add key          "
+msgstr ""
+
+#: pkg/networkmanager/index.html:582 pkg/networkmanager/index.html:610
+#: pkg/networkmanager/index.html:638 pkg/networkmanager/index.html:666
+#: pkg/networkmanager/index.html:694 pkg/networkmanager/index.html:722
+#: pkg/networkmanager/index.html:750 pkg/networkmanager/index.html:778
+msgid "            Apply          "
+msgstr ""
+
+#: pkg/users/index.html:269 pkg/users/index.html:297 pkg/users/index.html:358
+#: pkg/docker/index.html:584 pkg/docker/index.html:622
+#: pkg/docker/index.html:688 pkg/docker/index.html:744
+#: pkg/docker/index.html:790 pkg/networkmanager/index.html:579
+#: pkg/networkmanager/index.html:607 pkg/networkmanager/index.html:635
+#: pkg/networkmanager/index.html:663 pkg/networkmanager/index.html:691
+#: pkg/networkmanager/index.html:719 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:775
+msgid "            Cancel          "
+msgstr ""
+
+#: pkg/docker/index.html:691
+msgid "            Change          "
+msgstr ""
+
+#: pkg/users/index.html:45
+msgid "            Close          "
+msgstr ""
+
+#: pkg/docker/index.html:747
+msgid "            Commit          "
+msgstr ""
+
+#: pkg/users/index.html:207
+msgid "            Create          "
+msgstr ""
+
+#: pkg/users/index.html:300 pkg/networkmanager/index.html:533
+msgid "            Delete          "
+msgstr ""
+
+#: pkg/docker/index.html:625
+msgid "            Download          "
+msgstr ""
+
+#: pkg/docker/index.html:587
+msgid "            Run          "
+msgstr ""
+
+#: pkg/users/index.html:272
+msgid "            Set          "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:14
+msgid "          Images may be pulled by anonymous users        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:20
+msgid ""
+"          Images may be pulled by any authenticated user or group        "
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:26
+msgid "          Images may only be pulled by specific users or groups        "
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:9
+msgid "         {{ labels.url }}    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:2
+msgid ""
+"        Project access policy allows anonymous users to pull images. Grant "
+"additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:7
+msgid ""
+"        Project access policy allows any authenticated user to pull images. "
+"Grant additional push or admin access to specific members below.    "
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:12
+msgid ""
+"        Project access policy only allows specific members to access images. "
+"Grant access to specific members below.    "
+msgstr ""
+
+#: pkg/sosreport/index.html:39
+msgid ""
+"        The collected information will be stored locally on the system.      "
+msgstr ""
+
+#: pkg/storaged/index.html:51
+msgid ""
+"        There are devices with multiple paths on the system, but the "
+"multipath service is not running.      "
+msgstr ""
+
+#: pkg/sosreport/index.html:34
+msgid ""
+"        This tool will collect system configuration and diagnostic        "
+"information from this system for use with diagnosing problems        with "
+"the system.      "
+msgstr ""
+
+#: pkg/docker/storage.jsx:242
+msgid " (shared with the OS)"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:8
+msgid " 1\"Do you want to delete the following Nodes?"
+msgstr ""
+
+#: pkg/storaged/overview.js:253
+msgid "$0 Block Device"
+msgstr "$0 Blok Device"
+
+#: pkg/storaged/details.js:1546
+msgid "$0 Chunk Size"
+msgstr ""
+
+#: pkg/storaged/details.js:1544
+msgid "$0 Disks"
+msgstr ""
+
+#: pkg/storaged/details.js:1387
+msgid "$0 Extended Partition"
+msgstr ""
+
+#: pkg/storaged/details.js:1221
+msgctxt "storage-id-desc"
+msgid "$0 File System"
+msgstr ""
+
+#: pkg/storaged/details.js:1375
+msgid "$0 Free Space"
+msgstr ""
+
+#: pkg/storaged/details.js:1367
+msgid "$0 Free Space for Logical Partitions"
+msgstr ""
+
+#: pkg/storaged/details.js:1711
+msgid "$0 Free Space for Logical Volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:1370
+msgid "$0 Free Space for Primary Partitions"
+msgstr ""
+
+#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
+msgid "$0 Template"
+msgstr ""
+
+#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+msgid "$0 bit"
+msgid_plural "$0 bits"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -203,575 +339,40 @@ msgid_plural "$0 bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
-msgid "$0 bit"
-msgid_plural "$0 bits"
+#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
+#: src/base1/test-locale.js:66 pkg/playground/translate.js:25
+#: pkg/playground/translate.js:28 pkg/storaged/details.js:1557
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/systemd/host.js:43
-msgid "The user <b>$0</b> is not permitted to modify hostnames"
+#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
+#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
+#: pkg/playground/translate.js:34
+msgctxt "disk-non-rotational"
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/base1/cockpit.js:2588
+msgid "$0 exited with code $1"
 msgstr ""
 
-#: pkg/systemd/host.js:559
-msgid "Set Host name"
-msgstr "Host ismi ayarla"
-
-#: pkg/systemd/host.js:661
-msgid "failed to list ssh host keys: $0"
+#: src/base1/cockpit.js:2590
+msgid "$0 failed"
 msgstr ""
 
-#: pkg/systemd/host.js:1113
-msgid "Need at least one NTP server"
+#: src/base1/cockpit.js:2586
+msgid "$0 killed with signal $1"
 msgstr ""
 
-#: pkg/systemd/host.js:1190
-msgid "Invalid date format and invalid time format"
-msgstr "Geçersiz tarih ve geçersiz zaman biçimi"
-
-#: pkg/systemd/host.js:1192
-msgid "Invalid time format"
-msgstr "Geçersiz zaman biçimi"
-
-#: pkg/systemd/host.js:1194
-msgid "Invalid date format"
-msgstr "Geçersiz tarih biçimi"
-
-#: pkg/systemd/host.js:1250
-msgid "NTP Server"
-msgstr ""
-
-#: pkg/systemd/host.js:1300
-msgid "Message to logged in users"
-msgstr "Giriş yapmış kullanıcılara mesaj"
-
-#: pkg/systemd/host.js:1307 pkg/systemd/host.js:1309
-#: pkg/systemd/index.html.h:19
-msgid "Shutdown"
-msgstr "Kapat"
-
-#: pkg/systemd/host.js:1311 pkg/systemd/host.js:1313 pkg/systemd/init.js:517
-#: pkg/systemd/index.html.h:18
-msgid "Restart"
-msgstr "Yeniden başlat"
-
-#: pkg/systemd/host.js:1381
-msgctxt "page-title"
-msgid "CPU Status"
-msgstr "CPU Durumu"
-
-#: pkg/systemd/host.js:1413 pkg/systemd/index.html.h:24
-msgid "I/O Wait"
-msgstr "I/O Beklemesi"
-
-#: pkg/systemd/host.js:1414 pkg/systemd/index.html.h:25
-msgid "Kernel"
-msgstr "Çekirdek"
-
-#: pkg/systemd/host.js:1415 pkg/subscriptions/subscriptions-register.jsx:76
-#: pkg/systemd/index.html.h:26 pkg/kubernetes/views/auth-form.html.h:6
-#: pkg/kubernetes/views/volume-body.html.h:20
-#: pkg/kubernetes/views/user-panel.html.h:1 pkg/playground/translate.html.h:3
-#: pkg/dashboard/index.html.h:8
-msgid "User"
-msgstr "Kullanıcı"
-
-#: pkg/systemd/host.js:1416 pkg/systemd/index.html.h:27
-msgid "Nice"
-msgstr "Nice"
-
-#: pkg/systemd/host.js:1466
-msgctxt "page-title"
-msgid "Memory"
-msgstr "Bellek"
-
-#: pkg/systemd/host.js:1499 pkg/systemd/index.html.h:28
-msgid "Swap Used"
-msgstr "Kullanılan Swap"
-
-#: pkg/systemd/host.js:1500 pkg/systemd/index.html.h:29
-msgid "Cached"
-msgstr "Belleklenmiş"
-
-#: pkg/systemd/host.js:1501 pkg/docker/storage.jsx:313
-#: pkg/kubernetes/scripts/nodes.js:828 pkg/kubernetes/scripts/nodes.js:837
-#: pkg/systemd/index.html.h:30
-msgid "Used"
-msgstr "Kullanılmış"
-
-#: pkg/systemd/host.js:1502 pkg/docker/storage.jsx:298
-#: pkg/docker/storage.jsx:320 pkg/systemd/index.html.h:31
-msgid "Free"
-msgstr "Boş"
-
-#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
-#, fuzzy
-msgid "unknown"
-msgstr "Bilinmiyor"
-
-#: pkg/systemd/init.js:269 pkg/systemd/services.html.h:17
-#: pkg/kubernetes/views/project-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:5
-msgid "Description"
-msgstr ""
-
-#: pkg/systemd/init.js:270
-msgid "Id"
-msgstr ""
-
-#: pkg/systemd/init.js:272
-#, fuzzy
-msgid "Next Run"
-msgstr "Sonraki"
-
-#: pkg/systemd/init.js:273
-msgid "Last Trigger"
-msgstr ""
-
-#: pkg/systemd/init.js:274 pkg/kubernetes/views/container-body.html.h:6
-#: pkg/kubernetes/views/details-page.html.h:8
-msgid "State"
-msgstr ""
-
-#: pkg/systemd/init.js:301
-msgid "Enabled"
-msgstr ""
-
-#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
-msgid "Disabled"
-msgstr "Etkin değil"
-
-#: pkg/systemd/init.js:303
-msgid "Static"
-msgstr ""
-
-#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
-msgid "$0 Template"
-msgstr ""
-
-#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
-msgid "Start"
-msgstr "Başlat"
-
-#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
-msgid "Stop"
-msgstr "Durdur"
-
-#: pkg/systemd/init.js:518
-msgid "Reload"
-msgstr ""
-
-#: pkg/systemd/init.js:519
-msgid "Reload or Restart"
-msgstr ""
-
-#: pkg/systemd/init.js:520
-msgid "Try Restart"
-msgstr ""
-
-#: pkg/systemd/init.js:521
-msgid "Reload or Try Restart"
-msgstr ""
-
-#: pkg/systemd/init.js:522
-msgid "Isolate"
-msgstr ""
-
-#: pkg/systemd/init.js:541
-msgid "Enable"
-msgstr ""
-
-#: pkg/systemd/init.js:542
-msgid "Enable Forcefully"
-msgstr ""
-
-#: pkg/systemd/init.js:543
-msgid "Disable"
-msgstr ""
-
-#: pkg/systemd/init.js:544
-msgid "Preset"
-msgstr ""
-
-#: pkg/systemd/init.js:545
-msgid "Preset Forcefully"
-msgstr ""
-
-#: pkg/systemd/init.js:546
-msgid "Mask"
-msgstr ""
-
-#: pkg/systemd/init.js:547
-msgid "Mask Forcefully"
-msgstr ""
-
-#: pkg/systemd/init.js:548
-msgid "Unmask"
-msgstr ""
-
-#: pkg/systemd/init.js:621
-msgid "Since $0"
-msgstr ""
-
-#: pkg/systemd/init.js:639
-msgid "This unit is an instance of the $0 template."
-msgstr ""
-
-#: pkg/systemd/init.js:834
-#, fuzzy
-msgid "The user <b>$0</b> does not have permissions for creating timers"
-msgstr "<b>$0</b> kullanıcısı hesapları düzenlemek için yetkili değil"
-
-#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
-#, fuzzy
-msgid "This field cannot be empty."
-msgstr "İsim boş olamaz"
-
-#: pkg/systemd/init.js:1147
-msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
-msgstr ""
-
-#: pkg/systemd/init.js:1169
-#, fuzzy
-msgid "Invalid number."
-msgstr "Geçersiz anahtar"
-
-#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
-msgid "Hour needs to be a number between 0-23"
-msgstr ""
-
-#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
-msgid "Minute needs to be a number between 0-59"
-msgstr ""
-
-#: pkg/systemd/init.js:1218
-#, fuzzy
-msgid "Invalid date format."
-msgstr "Geçersiz tarih biçimi"
-
-#: pkg/systemd/init.js:1222
-msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
-msgstr ""
-
-#: pkg/systemd/logs.js:69
-msgid "Load earlier entries"
-msgstr ""
-
-#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
-#: pkg/systemd/logs.js:175
-msgid "Loading..."
-msgstr ""
-
-#: pkg/systemd/logs.js:130
-msgid "Go to"
-msgstr ""
-
-#: pkg/systemd/logs.js:257
-msgid "Journal entry"
-msgstr ""
-
-#: pkg/systemd/logs.js:284
-msgid "Journal entry not found"
-msgstr ""
-
-#: pkg/tuned/dialog.js:94
-msgid "Tuned is not available"
-msgstr "Tuned uygun değil"
-
-#: pkg/tuned/dialog.js:96
-msgid "Tuned is not running"
-msgstr "Tuned çalışmıyor"
-
-#: pkg/tuned/dialog.js:98
-msgid "Tuned is off"
-msgstr "Tuned kapalı"
-
-#: pkg/tuned/dialog.js:100
-msgid "This system is using the recommended profile"
-msgstr "Bu sistem önerilen profili kullanıyor"
-
-#: pkg/tuned/dialog.js:102
-msgid "This system is using a custom profile"
-msgstr "Bu sistem özel profil kullanıyor"
-
-#: pkg/tuned/dialog.js:114
-msgid "Communication with tuned has failed"
-msgstr "tuned ile iletişim başarısız"
-
-#: pkg/tuned/dialog.js:133
-msgid "Failed to disable tuned profile"
-msgstr "tuned profilini devre dışı bırakma başarısız"
-
-#: pkg/tuned/dialog.js:145
-msgid "Failed to switch profile"
-msgstr ""
-
-#: pkg/tuned/dialog.js:169
-msgid "Failed to enable tuned"
-msgstr "tuned'i etkinleştirme başarısız"
-
-#: pkg/tuned/dialog.js:171
-msgid "Failed to disable tuned"
-msgstr "tuned'i devre dışı bırakma başarısız"
-
-#: pkg/tuned/dialog.js:191
-msgid "Change Performance Profile"
-msgstr "Başarım Profilini Değiştir"
-
-#: pkg/tuned/dialog.js:200
-msgid "Change Profile"
-msgstr "Profil Değiştir"
-
-#: pkg/tuned/dialog.js:233 pkg/kubernetes/views/service-body.html.h:7
-#: pkg/kubernetes/views/pod-panel.html.h:2
-#: pkg/kubernetes/views/image-config.html.h:8
-#: pkg/kubernetes/views/imagestream-body.html.h:12
-#: pkg/kubernetes/views/pod-page.html.h:5
-msgid "None"
-msgstr "Hiçbiri"
-
-#: pkg/tuned/dialog.js:234
-msgid "Disable tuned"
-msgstr "tuned'i devre dışı bırak"
-
-#: pkg/tuned/dialog.js:262
-msgid "Tuned has failed to start"
-msgstr "Tuned başlatılırken başarısız oldu"
-
-#: pkg/tuned/change-profile.jsx:52
-msgid "recommended"
-msgstr ""
-
-#: pkg/lib/journal.js:209
-msgid "[no data]"
-msgstr ""
-
-#: pkg/lib/journal.js:213
-msgid "[$0 bytes of binary data]"
-msgstr ""
-
-#: pkg/lib/journal.js:215
-msgid "[binary data]"
-msgstr ""
-
-#: pkg/lib/journal.js:241
-msgid "Reboot"
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:364
-msgid "This machine has already been added."
-msgstr "Bu makine zaten eklenmiş."
-
-#: pkg/lib/machine-dialogs.js:380
-msgid ""
-"This version of cockpit-ws does not support connecting to a host with an "
-"alternate user or port"
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:386
-msgid "The IP address or host name cannot contain whitespace."
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:412
-msgid "Failed to add machine: $0"
-msgstr "Makine ekleme başarısız: $0"
-
-#: pkg/lib/machine-dialogs.js:429
-msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:447
-msgid "Enter IP address or host name"
-msgstr "IP adresi ya da ana makine adı gir"
-
-#: pkg/lib/machine-dialogs.js:494
-msgid "Failed to edit machine: $0"
-msgstr "Makine düzenleme başarısız:  $0"
-
-#: pkg/lib/cockpit-components-dialog.jsx:136 pkg/sosreport/index.js:55
-#: pkg/systemd/services.html.h:34 pkg/lib/machine-sync-users.html.h:7
-#: pkg/lib/machine-add.html.h:5 pkg/lib/machine-change-port.html.h:6
-#: pkg/lib/machine-change-auth.html.h:11 pkg/storaged/index.html.h:22
-#: pkg/realmd/operation.html.h:10 pkg/kubernetes/views/node-delete.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:3
-#: pkg/kubernetes/views/pvc-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:3
-#: pkg/kubernetes/views/auth-form.html.h:13
-#: pkg/kubernetes/views/node-add.html.h:7
-#: pkg/kubernetes/views/user-group-add.html.h:5
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:4
-#: pkg/kubernetes/views/route-modify.html.h:3
-#: pkg/kubernetes/views/image-delete.html.h:3
-#: pkg/kubernetes/views/pv-delete.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:4
-#: pkg/kubernetes/views/item-delete.html.h:4
-#: pkg/kubernetes/views/add-user-dialog.html.h:8
-#: pkg/kubernetes/views/user-add-membership.html.h:8
-#: pkg/kubernetes/views/deploy.html.h:4
-#: pkg/kubernetes/views/user-modify.html.h:8
-#: pkg/kubernetes/views/pv-modify.html.h:21
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:5
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:3
-#: pkg/kubernetes/views/imagestream-delete.html.h:3
-#: pkg/kubernetes/views/user-remove-membership.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:7
-#: pkg/kubernetes/views/add-role-dialog.html.h:3
-#: pkg/kubernetes/views/service-modify.html.h:4
-#: pkg/kubernetes/views/project-delete.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:9
-#: pkg/kubernetes/views/user-group-remove.html.h:2
-#: pkg/playground/translate.html.h:2 pkg/dashboard/index.html.h:12
-msgid "Cancel"
-msgstr "İptal"
-
-#: pkg/lib/cockpit-components-dialog.jsx:155
-msgid "Ok"
-msgstr ""
-
-#: pkg/lib/credentials.js:182
-msgid "No such file or directory"
-msgstr "Böyle bir dosya ya da dizin yok"
-
-#: pkg/lib/credentials.js:186
-msgid "The passwords do not match."
-msgstr "Parolalar uyuşmuyor."
-
-#: pkg/lib/credentials.js:191
-msgid "Prompting via ssh-keygen timed out"
-msgstr ""
-
-#: pkg/lib/credentials.js:213 pkg/users/local.js:78
-msgid "Old password not accepted"
-msgstr "Eski parola kabul edilmedi"
-
-#: pkg/lib/credentials.js:223 pkg/users/local.js:112 pkg/users/local.js:144
-msgid "Failed to change password"
-msgstr "Parola değişimi başarısız oldu"
-
-#: pkg/lib/credentials.js:231 pkg/users/local.js:120
-msgid "New password was not accepted"
-msgstr "Yeni parola kabul edilmedi"
-
-#: pkg/lib/credentials.js:248
-msgid "Not a valid private key"
-msgstr "Geçerli bir özel anahtar değil"
-
-#: pkg/lib/credentials.js:251
-msgid "Prompting via ssh-add timed out"
-msgstr ""
-
-#: pkg/lib/credentials.js:274
-msgid "Invalid file permissions"
-msgstr "Geçersiz dosya izinleri"
-
-#: pkg/lib/credentials.js:278
-msgid "Password not accepted"
-msgstr "Parola kabul edilmedi"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:22
-#: pkg/shell/index.html.h:27 pkg/storaged/index.html.h:52
-#: pkg/playground/jquery-patterns.html.h:2
-msgid "On"
-msgstr "Açık"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:23
-#: pkg/shell/index.html.h:28 pkg/storaged/index.html.h:53
-#: pkg/playground/jquery-patterns.html.h:3
-msgid "Off"
-msgstr "Kapalı"
-
-#: pkg/shell/base_index.js:670 pkg/users/local.js:1164
-#: pkg/docker/index.html.h:69 pkg/networkmanager/index.html.h:65
-msgid "Unexpected error"
-msgstr "Beklenmeyen hata"
-
-#: pkg/shell/base_index.js:671
-msgid "Cockpit had an unexpected internal error. <br/><br/>"
-msgstr "Cockpit'te beklenmedik bir iç hata var. <br/><br/>"
-
-#: pkg/shell/base_index.js:672
-msgid "You can try restarting Cockpit by pressing refresh in your browser. "
-msgstr ""
-"Tarayıcınızda yenileye basarak Cockpit'i yeniden başlatmayı deneyebilirsiniz."
-
-#: pkg/shell/base_index.js:673
-msgid "The javascript console contains details about this error "
-msgstr "Javascript uçbirimi bu hatayla ilgili ayrıntıları içeriyor"
-
-#: pkg/shell/base_index.js:674
-msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
-msgstr "(Çoğu tarayıcıda <b>Ctrl-Shift-J</b>)."
-
-#: pkg/shell/indexes.js:126 pkg/shell/indexes.js:497 pkg/shell/simple.html.h:17
-msgid "Disconnected"
-msgstr "Bağlantı kesildi"
-
-#: pkg/shell/indexes.js:253
-msgid "Machines"
-msgstr "Makineler"
-
-#: pkg/shell/indexes.js:314
-msgid "The machine is restarting"
-msgstr "Makine yeniden başlatılıyor"
-
-#: pkg/shell/indexes.js:317
-msgid "Connecting to the machine"
-msgstr "Makineye bağlanılıyor"
-
-#: pkg/shell/indexes.js:320
-msgid "Couldn't connect to the machine"
-msgstr "Makineye bağlanılamadı"
-
-#: pkg/shell/indexes.js:322
-msgid "Cannot connect to an unknown machine"
-msgstr "Bilinmeyen bir makineye bağlanılamıyor"
-
-#: pkg/ostree/client.js:56
-msgid "Receiving delta parts"
-msgstr ""
-
-#: pkg/ostree/client.js:58
-msgid "Receiving metadata objects"
-msgstr ""
-
-#: pkg/ostree/client.js:61
-msgid "Receiving objects: $0%"
-msgstr ""
-
-#: pkg/ostree/client.js:64
-msgid "Writing objects"
-msgstr ""
-
-#: pkg/ostree/client.js:66
-msgid "Scanning metadata"
-msgstr ""
-
-#: pkg/ostree/client.js:500
-msgid "OS $0 not found"
-msgstr ""
-
-#: pkg/ostree/app.js:81
-msgid "Not authorized to update software on this system"
-msgstr ""
-
-#: pkg/ostree/app.js:83
-msgid "OSTree is not available on this system"
-msgstr ""
-
-#: pkg/ostree/app.js:101
-msgid "No OSTree deployments found"
-msgstr ""
-
-#: pkg/ostree/app.js:219
-msgid "Checking for updates"
-msgstr ""
+#: pkg/selinux/setroubleshoot-view.jsx:440
+msgid "$0 occurrence"
+msgid_plural "$1 occurrences"
+msgstr[0] ""
+msgstr[1] ""
 
 #: pkg/ostree/app.js:307
 msgid "$0 package"
@@ -781,687 +382,34 @@ msgstr ""
 msgid "$0 packages"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot.js:65
-msgid "Error while setting SELinux mode: '$0'"
-msgstr "SELinux kipi belirlenirken hata: '$0'"
-
-#: pkg/selinux/setroubleshoot.js:238
-msgid "Not connected"
-msgstr "Bağlı değil"
-
-#: pkg/selinux/setroubleshoot.js:275
-msgid "Error while connecting."
-msgstr "Bağlanırken hata."
-
-#: pkg/selinux/setroubleshoot-view.jsx:82
-msgid "Applying solution..."
+#: pkg/docker/util.js:124
+msgid "$0 shares"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:90
-msgid "Solution applied successfully"
-msgstr ""
+#: pkg/kubernetes/scripts/nodes.js:870
+#, fuzzy, c-format
+msgid "$0% Free"
+msgid_plural "$0% Free"
+msgstr[0] "Boş"
+msgstr[1] "Boş"
 
-#: pkg/selinux/setroubleshoot-view.jsx:97
-msgid "Solution failed"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:107
-msgid "Apply this solution"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:114
-msgid "Unable to apply this solution automatically"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:118
-msgid "solution details"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:309
-msgid "SELinux system status is unknown."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:317
-msgid "SELinux is disabled on the system."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:324
-msgid "The configured state is unknown, it might change on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:326
-msgid ""
-"Setting deviates from the configured state and will revert on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:330
-msgid "SELinux Policy"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:332
-msgid "Enforce policy:"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:382 pkg/kubernetes/index.html.h:10
-#: pkg/kubernetes/registry.html.h:5
-msgid "Connecting..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:385
-msgid ""
-"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
-"server is installed."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:400
-msgid "Occurred between $0 and $1"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:405
-msgid "Occurred $0"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:440
-msgid "$0 occurrence"
-msgid_plural "$1 occurrences"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:478
-msgid "SELinux Access Control Errors"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:479
-msgid "No SELinux alerts."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:52
-msgid "Unable to start setroubleshootd"
-msgstr "setroubleshootd başlatılamıyor"
-
-#: pkg/selinux/setroubleshoot-client.js:157
-msgid "Unable to get alert"
-msgstr "Uyarı alınamıyor"
-
-#: pkg/selinux/setroubleshoot-client.js:172
-msgid "Unable to run fix"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:187
-msgid "Failed to delete alert"
-msgstr "Uyarı silme başarısız"
-
-#: pkg/selinux/setroubleshoot-client.js:192
-msgid "Error while deleting alert"
-msgstr "Uyarıyı silerken hata"
-
-#: pkg/storaged/dialog.js:267
+#: pkg/kubernetes/scripts/nodes.js:872
 #, fuzzy
-msgid "Size must be a number"
-msgstr "Boyut belirtilmeli"
+msgid "$0% Used"
+msgid_plural "$0% Used"
+msgstr[0] "Kullanılmış"
+msgstr[1] "Kullanılmış"
 
-#: pkg/storaged/dialog.js:269
-#, fuzzy
-msgid "Size cannot be zero"
-msgstr "İsim boş olamaz"
-
-#: pkg/storaged/dialog.js:271
-#, fuzzy
-msgid "Size cannot be negative"
-msgstr "İsim boş olamaz"
-
-#: pkg/storaged/dialog.js:273
-msgid "Size is too large"
+#: pkg/storaged/details.js:1765
+msgid "$0, $1 free"
 msgstr ""
 
-#: pkg/storaged/details.js:85
-msgid "Device $0 is mounted on $1"
+#: pkg/networkmanager/interfaces.js:2473
+msgid "$mtu"
 msgstr ""
 
-#: pkg/storaged/details.js:91
-msgid "Device $0 is a member of RAID Array $1"
-msgstr ""
-
-#: pkg/storaged/details.js:97
-msgid "Device $0 is a physical volume of $1"
-msgstr ""
-
-#: pkg/storaged/details.js:113
-msgid "Create partition on $0"
-msgstr ""
-
-#: pkg/storaged/details.js:115
-msgid "Format $0"
-msgstr ""
-
-#: pkg/storaged/details.js:177
-msgid "XFS - Red Hat Enterprise Linux 7 default"
-msgstr "XFS - Red Hat Enterprise Linux 7 ön tanımlı"
-
-#: pkg/storaged/details.js:178
-msgid "ext4 - Red Hat Enterprise Linux 6 default"
-msgstr "ext4 - Red Hat Enterprise Linux 6 ön tanımlı"
-
-#: pkg/storaged/details.js:179
-msgid "Encrypted XFS (LUKS)"
-msgstr "Şifreli XFS (LUKS)"
-
-#: pkg/storaged/details.js:180
-msgid "Encrypted EXT4 (LUKS)"
-msgstr "Şifreli EXT4 (LUKS)"
-
-#: pkg/storaged/details.js:181
-msgid "VFAT - Compatible with all systems and devices"
-msgstr "VFAT - Tüm sistemler ve cihazlarla uyumlu"
-
-#: pkg/storaged/details.js:182
-msgid "NTFS - Compatible with most systems"
-msgstr "NTFS - Çoğu sistemle uyumlu"
-
-#: pkg/storaged/details.js:183
-msgid "Extended Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:185
-msgid "No Filesystem"
-msgstr "Dosya sistemi yok"
-
-#: pkg/storaged/details.js:186
-msgid "Custom (Enter filesystem type)"
-msgstr "Özel (Dosya sistemi tipi girin)"
-
-#: pkg/storaged/details.js:192 pkg/storaged/details.js:664
-#: pkg/storaged/details.js:735 pkg/storaged/details.js:773
-#: pkg/storaged/details.js:909 pkg/storaged/index.html.h:20
-#: pkg/kubernetes/views/volumes-page.html.h:11
-msgid "Size"
-msgstr "Boyut"
-
-#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
-msgid "Erase"
-msgstr "Sil"
-
-#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
-msgid "Don't overwrite existing data"
-msgstr "Mevcut verinin üstüne yazma"
-
-#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
-msgid "Overwrite existing data with zeros"
-msgstr "Mevcut veriyi sıfırlarla tekrar yaz"
-
-#: pkg/storaged/details.js:207 pkg/shell/index.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:4
-#: pkg/kubernetes/views/deploy.html.h:2 pkg/kubernetes/views/pv-modify.html.h:3
-msgid "Type"
-msgstr "Tip"
-
-#: pkg/storaged/details.js:211 pkg/storaged/details.js:429
-#: pkg/storaged/details.js:709 pkg/storaged/details.js:731
-#: pkg/storaged/details.js:769 pkg/storaged/details.js:798
-#: pkg/storaged/details.js:864 pkg/storaged/overview.js:417
-#: pkg/storaged/overview.js:490 pkg/storaged/overview.js:624
-#: pkg/storaged/overview.js:702 pkg/storaged/index.html.h:18
-#: pkg/networkmanager/index.html.h:16
-#: pkg/kubernetes/views/project-listing.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:3
-#: pkg/kubernetes/views/volume-body.html.h:11
-#: pkg/kubernetes/views/containers-listing.html.h:2
-#: pkg/kubernetes/views/volumes-page.html.h:3
-#: pkg/kubernetes/views/pv-claim.html.h:1
-#: pkg/kubernetes/views/pv-modify.html.h:6
-#: pkg/kubernetes/views/image-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:15
-#: pkg/kubernetes/views/nodes-page.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:3
-#: pkg/kubernetes/views/details-page.html.h:4
-#: pkg/kubernetes/views/service-modify.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:3
-msgid "Name"
-msgstr "İsim"
-
-#: pkg/storaged/details.js:215
-msgid "Filesystem type"
-msgstr "Dosya sistemi tipi"
-
-#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
-msgid "Passphrase"
-msgstr "Parola"
-
-#: pkg/storaged/details.js:224
-#, fuzzy
-msgid "Passphrase cannot be empty"
-msgstr "Parola boş olamaz"
-
-#: pkg/storaged/details.js:229
-msgid "Confirm passphrase"
-msgstr "Parolayı onayla"
-
-#: pkg/storaged/details.js:232
-msgid "Passphrases do not match"
-msgstr "Parolalar eşleşmiyor"
-
-#: pkg/storaged/details.js:237
-msgid "Store passphrase"
-msgstr "Parolayı sakla"
-
-#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
-#: pkg/storaged/details.js:1115
-msgid "Encryption Options"
-msgstr "Şifreleme seçenekleri"
-
-#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
-msgid "Mounting"
-msgstr ""
-
-#: pkg/storaged/details.js:247 pkg/storaged/details.js:435
-#: pkg/subscriptions/subscriptions-register.jsx:101 pkg/docker/index.html.h:23
-#: pkg/kubernetes/views/image-config.html.h:2
-msgid "Default"
-msgstr "Ön tanımlı"
-
-#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
-msgid "Custom"
-msgstr "Özel"
-
-#: pkg/storaged/details.js:253 pkg/storaged/details.js:440
-#: pkg/storaged/index.html.h:19
-msgid "Mount Point"
-msgstr "Bağlama Noktası"
-
-#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
-msgid "Mount Options"
-msgstr "Bağlama Seçenekleri"
-
-#: pkg/storaged/details.js:266
-msgid "Create partition"
-msgstr ""
-
-#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
-#: pkg/storaged/details.js:1142
-msgid "Format"
-msgstr "Biçimlendir"
-
-#: pkg/storaged/details.js:268
-msgid "Formatting a storage device will erase all data on it."
-msgstr ""
-
-#: pkg/storaged/details.js:335
-msgid "Format Disk $0"
-msgstr ""
-
-#: pkg/storaged/details.js:346
-msgid "Partitioning"
-msgstr ""
-
-#: pkg/storaged/details.js:348
-msgid "Compatible with all systems and devices (MBR)"
-msgstr ""
-
-#: pkg/storaged/details.js:349
-msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr ""
-
-#: pkg/storaged/details.js:352
-msgid "No partitioning"
-msgstr ""
-
-#: pkg/storaged/details.js:358
-msgid "Formatting a disk will erase all data on it."
-msgstr "Bir diski biçimlendirmek üstünde yer alan veriyi silecektir."
-
-#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
-msgid "Filesystem Options"
-msgstr "Dosya Sistemi Seçenekleri"
-
-#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
-msgid "Apply"
-msgstr "Uygula"
-
-#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
-#: pkg/storaged/details.js:1110
-msgid "Unlock"
-msgstr "Kilidi Aç"
-
-#: pkg/storaged/details.js:527
-msgid "Stored Passphrase"
-msgstr "Saklı Parolalar"
-
-#: pkg/storaged/details.js:531 pkg/kubernetes/views/volume-body.html.h:32
-msgid "Options"
-msgstr "Seçenekler"
-
-#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
-msgid "Add Disks"
-msgstr "Disk Ekle"
-
-#: pkg/storaged/details.js:567 pkg/storaged/details.js:933
-#: pkg/storaged/overview.js:448 pkg/storaged/overview.js:495
-#: pkg/storaged/index.html.h:55
-msgid "Disks"
-msgstr "Diskler"
-
-#: pkg/storaged/details.js:579 pkg/storaged/details.js:948
-#: pkg/storaged/overview.js:501
-msgid "At least one disk is needed."
-msgstr "En azından bir disk gerekli"
-
-#: pkg/storaged/details.js:584 pkg/storaged/details.js:953
-#: pkg/storaged/overview.js:629 pkg/storaged/overview.js:657
-#: pkg/lib/machine-add.html.h:6 pkg/kubernetes/views/node-add.html.h:8
-#: pkg/kubernetes/views/user-group-add.html.h:6
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:5
-#: pkg/kubernetes/views/add-user-dialog.html.h:9
-#: pkg/kubernetes/views/user-add-membership.html.h:9
-#: pkg/kubernetes/views/add-role-dialog.html.h:4
-msgid "Add"
-msgstr "Ekle"
-
-#: pkg/storaged/details.js:625 pkg/storaged/details.js:821
-#: pkg/storaged/details.js:1016 pkg/docker/details.js:271
-#: pkg/docker/image.js:151 pkg/docker/containers-view.jsx:166
-msgid "Please confirm deletion of $0"
-msgstr ""
-
-#: pkg/storaged/details.js:630 pkg/storaged/details.js:827
-#: pkg/storaged/details.js:1022 pkg/storaged/details.js:1151
-#: pkg/storaged/details.js:1616 pkg/storaged/details.js:1776
-#: pkg/docker/details.js:273 pkg/docker/image.js:153
-#: pkg/docker/containers-view.jsx:168 pkg/kubernetes/scripts/volumes.js:218
-#: pkg/users/index.html.h:9 pkg/kubernetes/views/node-delete.html.h:5
-#: pkg/kubernetes/views/pvc-delete.html.h:5
-#: pkg/kubernetes/views/image-delete.html.h:4
-#: pkg/kubernetes/views/pv-delete.html.h:5
-#: pkg/kubernetes/views/item-delete.html.h:5
-#: pkg/kubernetes/views/imagestream-delete.html.h:4
-#: pkg/kubernetes/views/user-remove-membership.html.h:3
-#: pkg/kubernetes/views/project-delete.html.h:3
-msgid "Delete"
-msgstr "Sil"
-
-#: pkg/storaged/details.js:631
-msgid "Deleting a RAID device will erase all data on it."
-msgstr "Bir RAID cihazını silmek üstündeki tüm veriyi silecektir."
-
-#: pkg/storaged/details.js:661
-msgid "Resize Logical Volume"
-msgstr "Mantıksal Bölümü Yeniden Boyurlandır"
-
-#: pkg/storaged/details.js:673
-msgid "Resize Filesystem"
-msgstr "Dosya Sistemini Yeniden Boyutlandır"
-
-#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
-msgid "Resize"
-msgstr "Yeniden Boyutlandır"
-
-#: pkg/storaged/details.js:690
-msgid "This logical volume cannot be made smaller."
-msgstr ""
-
-#: pkg/storaged/details.js:706
-msgid "Renamee Logical Volume"
-msgstr "Mantıksal Bölümü Yeniden İsimlendir"
-
-#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
-#: pkg/storaged/details.js:1775
-msgid "Rename"
-msgstr "Yeniden İsimlendir"
-
-#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
-msgid "Create Snapshot"
-msgstr ""
-
-#: pkg/storaged/details.js:745 pkg/storaged/details.js:781
-#: pkg/storaged/details.js:804 pkg/storaged/details.js:915
-#: pkg/storaged/overview.js:461 pkg/storaged/overview.js:506
-#: pkg/kubernetes/views/add-group-dialog.html.h:6
-#: pkg/kubernetes/views/project-modify.html.h:8
-msgid "Create"
-msgstr "Yarat"
-
-#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
-msgid "Create Thin Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:795
-msgid "Rename Volume Group"
-msgstr ""
-
-#: pkg/storaged/details.js:826
-msgid "Deleting a volume group will erase all data on it."
-msgstr ""
-
-#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
-#, fuzzy
-msgid "Create Logical Volume"
-msgstr "Mantıksal Bölümü Yeniden İsimlendir"
-
-#: pkg/storaged/details.js:869
-msgid "Purpose"
-msgstr ""
-
-#: pkg/storaged/details.js:871
-msgid "Block device for filesystems"
-msgstr ""
-
-#: pkg/storaged/details.js:874
-msgid "Pool for thinly provisioned volumes"
-msgstr ""
-
-#: pkg/storaged/details.js:1009
-msgid "Deleting a logical volume will delete all data in it."
-msgstr ""
-
-#: pkg/storaged/details.js:1012
-msgid "Deleting a partition will delete all data in it."
-msgstr ""
-
-#: pkg/storaged/details.js:1053 pkg/storaged/overview.js:689
-#: pkg/storaged/devices.js:119 pkg/users/local.js:1155
-#: pkg/systemd/services.html.h:14
-msgid "Error"
-msgstr "Hata"
-
-#: pkg/storaged/details.js:1099
-msgid "Mount"
-msgstr "Bağla"
-
-#: pkg/storaged/details.js:1100
-msgid "Unmount"
-msgstr "Çöz"
-
-#: pkg/storaged/details.js:1109
-msgid "Lock"
-msgstr "Kilitle"
-
-#: pkg/storaged/details.js:1127
-msgid "Activate"
-msgstr "Aktifleştir"
-
-#: pkg/storaged/details.js:1130
-msgid "Deactivate"
-msgstr "Deaktifleştir"
-
-#: pkg/storaged/details.js:1221
-msgctxt "storage-id-desc"
-msgid "$0 File System"
-msgstr ""
-
-#: pkg/storaged/details.js:1224
-msgctxt "storage-id-desc"
-msgid "Linux MD-RAID Component"
-msgstr ""
-
-#: pkg/storaged/details.js:1226
-msgctxt "storage-id-desc"
-msgid "LVM2 Physical Volume"
-msgstr ""
-
-#: pkg/storaged/details.js:1228
-msgctxt "storage-id-desc"
-msgid "RAID Member"
-msgstr "RAID Üyesi"
-
-#: pkg/storaged/details.js:1245
-msgctxt "storage-id-desc"
-msgid "LUKS Encrypted"
-msgstr "LUKS Şifreli"
-
-#: pkg/storaged/details.js:1247
-msgctxt "storage-id-desc"
-msgid "Encrypted"
-msgstr "Şifreli"
-
-#: pkg/storaged/details.js:1251
-msgctxt "storage-id-desc"
-msgid "Swap Space"
-msgstr "Swap Alanı"
-
-#: pkg/storaged/details.js:1253
-msgctxt "storage-id-desc"
-msgid "Other Data"
-msgstr "Diğer Veri"
-
-#: pkg/storaged/details.js:1256
-msgctxt "storage-id-desc"
-msgid "Unrecognized Data"
-msgstr "Tanımlanamayan Veri"
-
-#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
-msgid "$size $partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1278
-msgid "mounted on $0"
-msgstr "$0 noktasında bağlı"
-
-#: pkg/storaged/details.js:1280
-msgid "not mounted"
-msgstr "bağlı değil"
-
-#: pkg/storaged/details.js:1284
-msgid "unlocked"
-msgstr "kilidi açıldı"
-
-#: pkg/storaged/details.js:1286
-msgid "locked"
-msgstr "kilitlendi"
-
-#: pkg/storaged/details.js:1367
-msgid "$0 Free Space for Logical Partitions"
-msgstr ""
-
-#: pkg/storaged/details.js:1370
-msgid "$0 Free Space for Primary Partitions"
-msgstr ""
-
-#: pkg/storaged/details.js:1375
-msgid "$0 Free Space"
-msgstr ""
-
-#: pkg/storaged/details.js:1379
-msgid "Create Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1387
-msgid "$0 Extended Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1424
-msgid "Logical Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1426
-msgid "Primary Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1428 pkg/kubernetes/views/volume-body.html.h:5
-msgid "Partition"
-msgstr ""
-
-#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
-msgid "Content"
-msgstr "İçerik"
-
-#: pkg/storaged/details.js:1533
-msgid "RAID 0"
-msgstr "RAID 0"
-
-#: pkg/storaged/details.js:1534
-msgid "RAID 1"
-msgstr "RAID 1"
-
-#: pkg/storaged/details.js:1535
-msgid "RAID 4"
-msgstr "RAID 4"
-
-#: pkg/storaged/details.js:1536
-msgid "RAID 5"
-msgstr "RAID 5"
-
-#: pkg/storaged/details.js:1537
-msgid "RAID 6"
-msgstr "RAID 6"
-
-#: pkg/storaged/details.js:1538
-msgid "RAID 10"
-msgstr "RAID 10"
-
-#: pkg/storaged/details.js:1539
-msgid "RAID ($0)"
-msgstr "RAID ($0)"
-
-#: pkg/storaged/details.js:1544
-msgid "$0 Disks"
-msgstr ""
-
-#: pkg/storaged/details.js:1546
-msgid "$0 Chunk Size"
-msgstr ""
-
-#: pkg/storaged/details.js:1574 pkg/ostree/index.html.h:7
-msgid "Running"
-msgstr "Çalışıyor"
-
-#: pkg/storaged/details.js:1574
-msgid "Not running"
-msgstr "Çalışmıyor"
-
-#: pkg/storaged/details.js:1592
-msgid "FAILED"
-msgstr "OLMADI"
-
-#: pkg/storaged/details.js:1593
-msgid "In Sync"
-msgstr "Eş zamanlanıyor"
-
-#: pkg/storaged/details.js:1594
-msgid "Spare"
-msgstr "Yedek"
-
-#: pkg/storaged/details.js:1594
-msgid "Recovering"
-msgstr ""
-
-#: pkg/storaged/details.js:1595
-msgid "Write-mostly"
-msgstr ""
-
-#: pkg/storaged/details.js:1596
-msgid "Blocked"
-msgstr "Bloklanmış"
-
-#: pkg/storaged/details.js:1597
-msgid "Unknown ($0)"
-msgstr "Bilinmiyor ($)"
-
-#: pkg/storaged/details.js:1614
-msgid "Start Scrubbing"
-msgstr ""
-
-#: pkg/storaged/details.js:1615
-msgid "Stop Scrubbing"
+#: pkg/storaged/utils.js:157
+msgid "$name (from $host)"
 msgstr ""
 
 #: pkg/storaged/details.js:1653
@@ -1477,217 +425,2840 @@ msgstr ""
 msgid "$size $desc<br/>($state)"
 msgstr ""
 
-#: pkg/storaged/details.js:1692
-msgid "active, but unsupported"
+#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
+msgid "$size $partition"
 msgstr ""
 
-#: pkg/storaged/details.js:1692
-msgid "inactive"
+#: pkg/docker/details.js:144
+msgid "${hip}:${hport} -> $cport"
 msgstr ""
 
-#: pkg/storaged/details.js:1711
-msgid "$0 Free Space for Logical Volumes"
+#: pkg/subscriptions/subscriptions-client.js:198
+msgid "'Organization' required to register."
 msgstr ""
 
-#: pkg/storaged/details.js:1751
-msgid "The last physical volume of a volume group cannot be removed."
+#: pkg/subscriptions/subscriptions-client.js:202
+msgid "'Organization' required when using activation keys."
 msgstr ""
 
-#: pkg/storaged/details.js:1756
-msgid ""
-"There is not enough free space elsewhere to remove this physical volume.  At "
-"least $0 more free space is needed."
+#: pkg/shell/base_index.js:674
+msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
+msgstr "(Çoğu tarayıcıda <b>Ctrl-Shift-J</b>)."
+
+#: pkg/storaged/overview.js:440
+msgid "1 MiB"
 msgstr ""
 
-#: pkg/storaged/details.js:1765
-msgid "$0, $1 free"
-msgstr ""
+#: pkg/systemd/index.html:459 pkg/systemd/index.html:463
+msgid "1 Minute"
+msgstr "1 dakika"
 
-#: pkg/storaged/details.js:1792
-msgid "Logical Volumes"
-msgstr "Mantıksal Bölümler"
+#: pkg/storaged/index.html:312 pkg/networkmanager/index.html:55
+#: pkg/networkmanager/index.html:501
+msgid "1 day"
+msgstr "1 gün"
 
-#: pkg/storaged/details.js:1822 pkg/docker/details.js:177
-#: pkg/docker/image.js:112
-msgid "Not found"
-msgstr "Bulunamadı"
+#: pkg/storaged/index.html:310 pkg/networkmanager/index.html:53
+#: pkg/networkmanager/index.html:499
+msgid "1 hour"
+msgstr "1 saat "
 
-#: pkg/storaged/overview.js:180
-msgctxt "storage"
-msgid "Hard Disk"
-msgstr "Sabit Disk"
+#: pkg/storaged/index.html:313 pkg/networkmanager/index.html:56
+#: pkg/networkmanager/index.html:502
+msgid "1 week"
+msgstr "1 hafta"
 
-#: pkg/storaged/overview.js:182
-msgctxt "storage"
-msgid "Solid-State Disk"
-msgstr "SSD Disk"
+#: pkg/playground/translate.html:190
+#, fuzzy
+msgid "1% Free"
+msgid_plural "{{$count}}% Free"
+msgstr[0] "Boş"
+msgstr[1] "Boş"
 
-#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
-msgctxt "storage"
-msgid "Removable Drive"
-msgstr "Çıkarılabilir Disk"
-
-#: pkg/storaged/overview.js:189
-msgctxt "storage"
-msgid "Optical Drive"
-msgstr "Optik Sürücü"
-
-#: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
-msgctxt "storage"
-msgid "Drive"
-msgstr "Sürücü"
-
-#: pkg/storaged/overview.js:253
-msgid "$0 Block Device"
-msgstr "$0 Blok Device"
-
-#: pkg/storaged/overview.js:414
-msgid "Create RAID Device"
-msgstr "RAID Yarat"
-
-#: pkg/storaged/overview.js:420
-msgid "RAID Level"
-msgstr "RAID Level"
-
-#: pkg/storaged/overview.js:422
-msgid "RAID 0 (Stripe)"
-msgstr ""
-
-#: pkg/storaged/overview.js:423
-msgid "RAID 1 (Mirror)"
-msgstr ""
-
-#: pkg/storaged/overview.js:424
-msgid "RAID 4 (Dedicated Parity)"
-msgstr ""
-
-#: pkg/storaged/overview.js:425
-msgid "RAID 5 (Distributed Parity)"
-msgstr ""
-
-#: pkg/storaged/overview.js:426
-msgid "RAID 6 (Double Distributed Parity)"
-msgstr ""
-
-#: pkg/storaged/overview.js:427
-msgid "RAID 10 (Stripe of Mirrors)"
-msgstr ""
-
-#: pkg/storaged/overview.js:431
-msgid "Chunk Size"
-msgstr ""
-
-#: pkg/storaged/overview.js:433
-msgid "4 KiB"
-msgstr ""
-
-#: pkg/storaged/overview.js:434
-msgid "8 KiB"
+#: pkg/storaged/overview.js:438
+msgid "128 KiB"
 msgstr ""
 
 #: pkg/storaged/overview.js:435
 msgid "16 KiB"
 msgstr ""
 
+#: pkg/storaged/overview.js:441
+msgid "2 MiB"
+msgstr ""
+
+#: pkg/systemd/index.html:465
+msgid "20 Minutes"
+msgstr "20 dakika"
+
 #: pkg/storaged/overview.js:436
 msgid "32 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:437
-msgid "64 KiB"
+#: pkg/storaged/overview.js:433
+msgid "4 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:438
-msgid "128 KiB"
-msgstr ""
+#: pkg/systemd/index.html:466
+msgid "40 Minutes"
+msgstr "40 dakika"
+
+#: pkg/systemd/index.html:464
+msgid "5 Minutes"
+msgstr "5 dakika"
+
+#: pkg/storaged/index.html:309 pkg/networkmanager/index.html:52
+#: pkg/networkmanager/index.html:498
+msgid "5 minutes"
+msgstr "5 dakika"
 
 #: pkg/storaged/overview.js:439
 msgid "512 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:440
-msgid "1 MiB"
+#: pkg/storaged/index.html:311 pkg/networkmanager/index.html:54
+#: pkg/networkmanager/index.html:500
+msgid "6 hours"
+msgstr "6 saat"
+
+#: pkg/systemd/index.html:467
+msgid "60 Minutes"
+msgstr "60 dakika"
+
+#: pkg/storaged/overview.js:437
+msgid "64 KiB"
 msgstr ""
 
-#: pkg/storaged/overview.js:441
-msgid "2 MiB"
+#: pkg/storaged/overview.js:434
+msgid "8 KiB"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1826
+msgid "802.3ad"
+msgstr "802.3ad"
+
+#: pkg/networkmanager/interfaces.js:1843
+#, fuzzy
+msgid "802.3ad LACP"
+msgstr "802.3ad"
+
+#: pkg/systemd/services.html:446
+msgid ":"
+msgstr ""
+
+#: pkg/storaged/utils.js:220
+msgid "<span>Encrypted $0</span>"
+msgstr ""
+
+#: pkg/storaged/utils.js:212
+msgid "<span>Encrypted Logical Volume of $0</span>"
+msgstr ""
+
+#: pkg/storaged/utils.js:214
+msgid "<span>Encrypted Partition of $0</span>"
+msgstr ""
+
+#: pkg/storaged/utils.js:216
+msgid "<span>Logical Volume of $0</span>"
+msgstr ""
+
+#: pkg/storaged/utils.js:218
+msgid "<span>Partition of $0</span>"
+msgstr ""
+
+#: pkg/lib/machine-not-supported.html:5
+msgid ""
+"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
+"strong}}."
+msgstr ""
+
+#: cockpit.desktop.in.h:2
+msgid "A user interface for GNU/Linux servers"
+msgstr "GNU/Linux sunucular için bir kullanıcı arayüzü"
+
+#: pkg/networkmanager/interfaces.js:1834
+msgid "ARP"
+msgstr "ARP"
+
+#: pkg/networkmanager/interfaces.js:2502
+msgid "ARP Monitoring"
+msgstr "ARP İzleme"
+
+#: pkg/networkmanager/interfaces.js:1855
+#, fuzzy
+msgid "ARP Ping"
+msgstr "ARP İzleme"
+
+#: pkg/kubernetes/scripts/volumes.js:193
+msgid "AWS Elastic Block Store"
+msgstr ""
+
+#: pkg/shell/simple.html:41 pkg/shell/simple.html:67 pkg/shell/index.html:41
+#: pkg/shell/index.html:80 pkg/shell/stub.html:41 pkg/shell/stub.html:73
+msgid "About Cockpit"
+msgstr "Kokpit Hakkında"
+
+#: pkg/users/index.html:105 pkg/users/index.html:191
+msgid "Access"
+msgstr "Erişim"
+
+#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pv-claim.html:9
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-body.html:9
+#, fuzzy
+msgid "Access Modes"
+msgstr "Erişim"
+
+#: pkg/kubernetes/views/project-modify.html:49
+#: pkg/kubernetes/views/imagestream-body.html:11
+msgid "Access Policy"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:191
+#, fuzzy
+msgid "Access denied"
+msgstr "Erişim"
+
+#: pkg/shell/index.html:45
+msgid "Account Settings"
+msgstr "Hesap Ayarları"
+
+#: pkg/users/index.html:63
+msgid "Account not available or cannot be edited."
+msgstr ""
+
+#: pkg/users/index.html:71
+msgid "Accounts"
+msgstr ""
+
+#: pkg/users/local.js:284 pkg/users/local.js:594
+msgctxt "page-title"
+msgid "Accounts"
+msgstr "Hesaplar"
+
+#: pkg/storaged/details.js:1127
+msgid "Activate"
+msgstr "Aktifleştir"
+
+#: pkg/storaged/jobs.js:148
+msgid "Activating $target"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:164
+#, fuzzy
+msgid "Activation Key"
+msgstr "Aktifleştir"
+
+#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
+msgid "Active"
+msgstr "Aktif"
+
+#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
+msgid "Active Backup"
+msgstr "Aktif Yedekleme"
+
+#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
+msgid "Actual"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1828
+msgid "Adaptive load balancing"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1827
+msgid "Adaptive transmit load balancing"
+msgstr ""
+
+#: pkg/kubernetes/views/add-user-dialog.html:31
+#: pkg/kubernetes/views/node-add.html:50
+#: pkg/kubernetes/views/user-add-membership.html:53
+#: pkg/kubernetes/views/add-member-role-dialog.html:61
+#: pkg/kubernetes/views/user-group-add.html:32
+#: pkg/kubernetes/views/add-role-dialog.html:8 pkg/lib/machine-add.html:43
+msgid "Add"
+msgstr "Ekle"
+
+#: pkg/networkmanager/interfaces.js:2836
+msgid "Add $0"
+msgstr ""
+
+#: pkg/docker/storage.jsx:363
+msgid "Add Additional Storage"
+msgstr ""
+
+#: pkg/networkmanager/index.html:86
+msgid "Add Bond"
+msgstr ""
+
+#: pkg/networkmanager/index.html:88
+msgid "Add Bridge"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:3
+msgid "Add Cluster Node"
+msgstr ""
+
+#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
+msgid "Add Disks"
+msgstr "Disk Ekle"
+
+#: pkg/kubernetes/views/add-group-dialog.html:3
+msgid "Add Group"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:34
+#, fuzzy
+msgid "Add Kubernetes Node"
+msgstr "Kubernetes Düğümleri"
+
+#: pkg/lib/machine-add.html:4
+msgid "Add Machine to Dashboard"
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:38
+#: pkg/kubernetes/views/add-member-role-dialog.html:4
+#: pkg/kubernetes/views/group-panel.html:29
+#: pkg/kubernetes/views/user-group-add.html:3
+#: pkg/kubernetes/views/project-body.html:108
+msgid "Add Member"
+msgstr ""
+
+#: pkg/kubernetes/views/user-panel.html:76
+#: pkg/kubernetes/views/user-body.html:67
+#, fuzzy
+msgid "Add Membership"
+msgstr "Üyeler"
+
+#: pkg/kubernetes/views/auth-form.html:11
+#: pkg/kubernetes/views/auth-form.html:20
+msgid "Add New Cluster"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:67
+#: pkg/kubernetes/views/auth-form.html:76
+msgid "Add New User"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:3
+#, fuzzy
+msgid "Add Role"
+msgstr "Roller"
+
+#: pkg/networkmanager/index.html:87
+#, fuzzy
+msgid "Add Team"
+msgstr "Roller"
+
+#: pkg/kubernetes/views/add-user-dialog.html:3
+#: pkg/kubernetes/views/project-listing.html:83
+msgid "Add User"
+msgstr ""
+
+#: pkg/networkmanager/index.html:89
+msgid "Add VLAN"
+msgstr ""
+
+#: pkg/storaged/overview.js:515
+msgid "Add iSCSI Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/user-add-membership.html:3
+msgid "Add membership"
+msgstr ""
+
+#: pkg/users/index.html:351
+msgid "Add public key"
+msgstr "Açık anahtar ekle"
+
+#: pkg/networkmanager/interfaces.js:2833
+msgid "Adding <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/users/authorized-keys.js:108
+msgid "Adding key"
+msgstr "Anahtar ekleniyor"
+
+#: pkg/storaged/jobs.js:153
+msgid "Adding physical volume to $target"
+msgstr ""
+
+#: pkg/docker/index.html:329
+msgid "Additional Storage"
+msgstr ""
+
+#: pkg/ostree/index.html:121 pkg/ostree/index.html:140
+msgid "Additions"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:8
+#: pkg/kubernetes/views/dashboard-page.html:157
+#: pkg/kubernetes/views/details-page.html:174
+#: pkg/kubernetes/views/nodes-page.html:43
+#: pkg/kubernetes/views/auth-form.html:29 pkg/kubernetes/views/node-body.html:5
+#: pkg/lib/machine-add.html:11
+msgid "Address"
+msgstr "Adres"
+
+#: pkg/kubernetes/views/details-page.html:37
+msgid "Addresses"
+msgstr "Adresler"
+
+#: pkg/kubernetes/views/service-modify.html:25
+msgid "Adjust"
+msgstr "Ayarla"
+
+#: pkg/kubernetes/views/pv-modify.html:3
+msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-modify.html:3
+msgid "Adjust Replication Controller {{ item.metadata.name }}"
+msgstr ""
+
+#: pkg/kubernetes/views/route-modify.html:3
+msgid "Adjust Route"
+msgstr ""
+
+#: pkg/kubernetes/views/service-modify.html:3
+msgid "Adjust Service"
+msgstr "Servisi Ayarla"
+
+#: pkg/kubernetes/views/project-body.html:56
+msgid "Admin"
+msgstr ""
+
+#: pkg/systemd/services.html:389 pkg/systemd/services.html:393
+msgid "After system boot"
+msgstr ""
+
+#: pkg/systemd/logs.html:50
+msgid "All"
+msgstr "Hepsi"
+
+#: pkg/kubernetes/views/filter-project.html:4
+msgid "All Projects"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:6
+#, fuzzy
+msgid "All Types"
+msgstr "Tip"
+
+#: pkg/docker/storage.jsx:366
+msgid ""
+"All data on selected disks will be erased and disks will be added to the "
+"storage pool."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:112
+msgid "All healthy"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:74
+msgid "All images"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:69
+msgid "All in use"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:37
+#, fuzzy
+msgid "All running"
+msgstr "Çalışmıyor"
+
+#: pkg/docker/index.html:569
+msgid "Always"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-meta.html:2
+#: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/image-meta.html:9
+#: pkg/kubernetes/views/node-body.html:57
+msgid "Annotations"
+msgstr ""
+
+#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
+msgid "Apply"
+msgstr "Uygula"
+
+#: pkg/selinux/setroubleshoot-view.jsx:107
+msgid "Apply this solution"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:82
+msgid "Applying solution..."
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:12
+msgid "Architecture"
+msgstr ""
+
+#: pkg/storaged/index.html:451
+msgctxt "storage"
+msgid "Assessment"
+msgstr ""
+
+#: pkg/systemd/index.html:81
+msgid "Asset Tag"
 msgstr ""
 
 #: pkg/storaged/overview.js:455
 msgid "At least $0 disks are needed."
 msgstr ""
 
-#: pkg/storaged/overview.js:487
-msgid "Create Volume Group"
-msgstr "Volume Grubu Yarat"
+#: pkg/storaged/overview.js:501 pkg/storaged/details.js:579
+#: pkg/storaged/details.js:948
+msgid "At least one disk is needed."
+msgstr "En azından bir disk gerekli"
 
-#: pkg/storaged/overview.js:515
-msgid "Add iSCSI Portal"
-msgstr ""
-
-#: pkg/storaged/overview.js:518
-msgid "Server Address"
-msgstr ""
-
-#: pkg/storaged/overview.js:521
+#: pkg/systemd/services.html:394
 #, fuzzy
-msgid "Server address cannot be empty."
-msgstr "İsim boş olamaz"
+msgid "At specific time"
+msgstr "Özel Bir Zamanda"
 
-#: pkg/storaged/overview.js:533 pkg/realmd/operation.html.h:11
-msgid "Next"
-msgstr "Sonraki"
+#: pkg/networkmanager/interfaces.js:813
+msgid "Authenticating"
+msgstr "Yetkilendiriliyor"
 
-#: pkg/storaged/overview.js:577 pkg/storaged/overview.js:668
-#: pkg/subscriptions/subscriptions-client.js:194
-msgid "Invalid username or password"
+#: pkg/realmd/operation.html:34 pkg/shell/index.html:48
+#: pkg/shell/index.html:159 pkg/kubernetes/views/auth-form.html:85
+#: pkg/lib/machine-change-auth.html:32
+msgid "Authentication"
+msgstr "Yetkilendirme"
+
+#: pkg/lib/machine-auth-failed.html:2
+msgid "Authentication Failed"
 msgstr ""
 
-#: pkg/storaged/overview.js:582
-msgid "Unknown host name"
+#: pkg/docker/index.html:730 pkg/kubernetes/views/image-body.html:12
+#: pkg/kubernetes/views/image-listing.html:15
+msgid "Author"
+msgstr "Yazar"
+
+#: pkg/users/index.html:130
+msgid "Authorized Public SSH Keys"
+msgstr "Yetkilendirilmiş Açık SSH Anahtarları"
+
+#: pkg/networkmanager/index.html:165
+msgid "Automatic"
+msgstr "Otomatik"
+
+#: pkg/networkmanager/interfaces.js:1814
+msgid "Automatic (DHCP only)"
+msgstr "Otomatik (Sadece DHCP)"
+
+#: pkg/networkmanager/interfaces.js:1804
+msgid "Automatic (DHCP)"
+msgstr "Otomatik (DHCP)"
+
+#: pkg/systemd/index.html:406
+msgid "Automatically using NTP"
 msgstr ""
 
-#: pkg/storaged/overview.js:586
-msgid "Unable to reach server"
+#: pkg/systemd/index.html:407
+msgid "Automatically using specific NTP servers"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:66
+msgid "Available"
 msgstr ""
 
 #: pkg/storaged/overview.js:619
 msgid "Available targets on $0"
 msgstr ""
 
-#: pkg/storaged/overview.js:623 pkg/systemd/services.html.h:2
-msgid "Targets"
+#: pkg/dashboard/index.html:177
+msgid "Avatar"
 msgstr ""
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-add.html.h:2
-#: pkg/kubernetes/views/node-body.html.h:2
-#: pkg/kubernetes/views/auth-form.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:16
-#: pkg/kubernetes/views/nodes-page.html.h:7
-#: pkg/kubernetes/views/details-page.html.h:19
-msgid "Address"
-msgstr "Adres"
+#: pkg/kubernetes/scripts/volumes.js:207
+msgid "Azure"
+msgstr ""
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-change-port.html.h:5
-msgid "Port"
+#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
+msgid "Bad data passed for passwd1 mechanism"
+msgstr "passwd1 düzeneği için kötü veri geçti"
+
+#: pkg/networkmanager/index.html:389
+msgid "Balancer"
+msgstr ""
+
+#: pkg/storaged/index.html:560
+msgctxt "storage"
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: pkg/storaged/index.html:414
+msgid "Block Device"
+msgstr "Blok Aygıtı"
+
+#: pkg/storaged/details.js:871
+msgid "Block device for filesystems"
+msgstr ""
+
+#: pkg/storaged/details.js:1596
+msgid "Blocked"
+msgstr "Bloklanmış"
+
+#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
+#: pkg/networkmanager/interfaces.js:2507
+msgid "Bond"
+msgstr "Bond"
+
+#: pkg/networkmanager/index.html:596
+msgid "Bond Settings"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:17
+msgid "Boot ID"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
+#: pkg/networkmanager/interfaces.js:2584
+msgid "Bridge"
+msgstr "Köprü"
+
+#: pkg/networkmanager/index.html:708
+msgid "Bridge Port Settings"
+msgstr ""
+
+#: pkg/networkmanager/index.html:680
+msgid "Bridge Settings"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2605
+msgid "Bridge port"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
+msgid "Broadcast"
+msgstr "Broadcast"
+
+#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#, fuzzy
+msgid "Broken configuration"
+msgstr "Bilinmeyen konfigrasyon"
+
+#: pkg/kubernetes/views/image-body.html:16
+msgid "Built"
+msgstr ""
+
+#: pkg/dashboard/index.html:70
+msgid "CPU"
+msgstr "CPU"
+
+#: pkg/systemd/host.js:1381
+msgctxt "page-title"
+msgid "CPU Status"
+msgstr "CPU Durumu"
+
+#: pkg/kubernetes/scripts/nodes.js:712
+msgid "CPU Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:490 pkg/docker/index.html:669
+msgid "CPU priority"
+msgstr "CPU önceliği"
+
+#: pkg/systemd/index.html:247
+msgid "Cached"
+msgstr "Belleklenmiş"
+
+#: pkg/docker/index.html:63
+#, fuzzy
+msgid "Can&rsquo;t connect to Docker"
+msgstr "Docker'a bağlanılamadı"
+
+#: pkg/systemd/services.html:465 pkg/dashboard/index.html:189
+#: pkg/playground/translate.html:40 pkg/playground/translate.html:174
+#: pkg/realmd/operation.html:90 pkg/kubernetes/views/pv-modify.html:202
+#: pkg/kubernetes/views/item-delete.html:10
+#: pkg/kubernetes/views/add-user-dialog.html:30
+#: pkg/kubernetes/views/project-modify.html:71
+#: pkg/kubernetes/views/node-add.html:49
+#: pkg/kubernetes/views/pvc-delete.html:14
+#: pkg/kubernetes/views/node-delete.html:14
+#: pkg/kubernetes/views/imagestream-modify.html:96
+#: pkg/kubernetes/views/imagestream-delete.html:7
+#: pkg/kubernetes/views/user-modify.html:30
+#: pkg/kubernetes/views/add-group-dialog.html:20
+#: pkg/kubernetes/views/project-delete.html:8
+#: pkg/kubernetes/views/service-modify.html:24
+#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/kubernetes/views/user-group-remove.html:9
+#: pkg/kubernetes/views/user-add-membership.html:52
+#: pkg/kubernetes/views/add-member-role-dialog.html:60
+#: pkg/kubernetes/views/group-delete.html:20
+#: pkg/kubernetes/views/image-delete.html:7 pkg/kubernetes/views/deploy.html:61
+#: pkg/kubernetes/views/user-group-add.html:31
+#: pkg/kubernetes/views/auth-form.html:128
+#: pkg/kubernetes/views/auth-rejected-cert.html:31
+#: pkg/kubernetes/views/replicationcontroller-modify.html:16
+#: pkg/kubernetes/views/pv-delete.html:10
+#: pkg/kubernetes/views/add-role-dialog.html:7
+#: pkg/kubernetes/views/route-modify.html:16
+#: pkg/kubernetes/views/user-delete.html:24
+#: pkg/kubernetes/views/remove-role-dialog.html:7 pkg/storaged/index.html:289
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:79
+msgid "Cancel"
+msgstr "İptal"
+
+#: pkg/shell/indexes.js:322
+msgid "Cannot connect to an unknown machine"
+msgstr "Bilinmeyen bir makineye bağlanılamıyor"
+
+#: src/ws/cockpitcertificate.c:359
+msgid "Cannot decrypt PEM-encoded private key"
+msgstr "PEM-şifreli özel anahtar çözülemiyor"
+
+#: src/base1/cockpit.js:3707
+msgid "Cannot forward login credentials"
+msgstr ""
+
+#: pkg/realmd/operation.js:417
+msgid "Cannot join a domain because realmd is not available on this system"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:44
+#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pv-body.html:13
+#, fuzzy
+msgid "Capacity"
+msgstr "Kapasite"
+
+#: pkg/storaged/index.html:443 pkg/storaged/index.html:519
+#: pkg/storaged/index.html:551 pkg/storaged/index.html:630
+msgctxt "storage"
+msgid "Capacity"
+msgstr "Kapasite"
+
+#: pkg/networkmanager/interfaces.js:2276
+msgid "Carrier"
+msgstr "Taşıyıcı"
+
+#: pkg/kubernetes/scripts/volumes.js:203
+#, fuzzy
+msgid "Ceph Filesystem Mount"
+msgstr "Dosya sistemi tipi"
+
+#: pkg/kubernetes/views/volume-body.html:97
+#, fuzzy
+msgid "Ceph Monitors"
+msgstr "Depo"
+
+#: pkg/kubernetes/views/pv-modify.html:204
+#: pkg/kubernetes/views/project-modify.html:74
+#: pkg/kubernetes/views/replicationcontroller-modify.html:17
+#: pkg/kubernetes/views/route-modify.html:17
+msgid "Change"
+msgstr ""
+
+#: pkg/shell/index.html:278
+msgid "Change Password"
+msgstr ""
+
+#: pkg/tuned/dialog.js:191
+msgid "Change Performance Profile"
+msgstr "Başarım Profilini Değiştir"
+
+#: pkg/tuned/dialog.js:200
+msgid "Change Profile"
+msgstr "Profil Değiştir"
+
+#: pkg/kubernetes/views/user-modify.html:3
+msgid "Change User"
 msgstr ""
 
 #: pkg/storaged/overview.js:699
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
-#: pkg/storaged/overview.js:707 pkg/kubernetes/views/route-modify.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:22
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:4
-#: pkg/kubernetes/views/project-modify.html.h:9
-msgid "Change"
+#: pkg/kubernetes/views/imagestream-modify.html:4
+msgid "Change image stream"
 msgstr ""
 
-#: pkg/storaged/utils.js:88
-msgctxt "format-bytes"
-msgid "bytes"
+#: pkg/kubernetes/views/project-modify.html:10
+msgid "Change project"
 msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2872
+#, fuzzy
+msgid "Change the settings"
+msgstr "Hesap Ayarları"
+
+#: pkg/networkmanager/interfaces.js:2870
+msgid "Changing the settings will break the connection to the server, "
+msgstr ""
+
+#: pkg/ostree/index.html:48
+msgid "Check for updates"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:817
+msgid "Checking IP"
+msgstr "IP kontrol ediliyor"
+
+#: pkg/storaged/jobs.js:143
+#, fuzzy
+msgid "Checking RAID Device $target"
+msgstr "RAID Yarat"
+
+#: pkg/storaged/jobs.js:144
+msgid "Checking and Repairing RAID Device $target"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:70
+msgid "Checking for public keys"
+msgstr ""
+
+#: pkg/ostree/app.js:219
+msgid "Checking for updates"
+msgstr ""
+
+#: pkg/shell/simple.html:100 pkg/shell/index.html:121 pkg/shell/stub.html:114
+msgid "Choose the language to be used in the application"
+msgstr ""
+
+#: pkg/storaged/overview.js:431
+msgid "Chunk Size"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:202
+msgid "Cinder"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
+msgid "Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-body.html:4
+#, fuzzy
+msgid "Claim Name"
+msgstr "Konteyner İsmi"
+
+#: pkg/storaged/jobs.js:135
+msgid "Cleaning up for $target"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:88
+msgid "Client Certificate"
+msgstr ""
+
+#: pkg/systemd/services.html:306 pkg/systemd/services.html:324
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-invalid-hostkey.html:19
+msgid "Close"
+msgstr "Kapat"
+
+#: pkg/kubernetes/views/auth-form.html:5
+#, fuzzy
+msgid "Cluster"
+msgstr "Ana"
+
+#: cockpit.desktop.in.h:1
+msgid "Cockpit"
+msgstr "Kokpit"
+
+#: pkg/lib/machine-dialogs.js:429
+msgid ""
+"Cockpit could not contact the given host $0. Make sure it has ssh running on "
+"port $1, or specify another port in the address."
+msgstr ""
+
+#: src/base1/cockpit.js:3713
+msgid "Cockpit could not contact the given host."
+msgstr ""
+
+#: pkg/shell/base_index.js:671
+msgid "Cockpit had an unexpected internal error. <br/><br/>"
+msgstr "Cockpit'te beklenmedik bir iç hata var. <br/><br/>"
+
+#: cockpit.appdata.xml.in.h:1
+msgid ""
+"Cockpit is a server manager that makes it easy to administer your Linux "
+"servers via a web browser. Jumping between the terminal and the web tool is "
+"no problem. A service started via Cockpit can be stopped via the terminal. "
+"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
+"journal interface."
+msgstr ""
+
+#: src/base1/cockpit.js:3711
+msgid "Cockpit is not compatible with the software on the system."
+msgstr ""
+
+#: pkg/lib/machine-not-supported.html:2
+msgid "Cockpit is not installed"
+msgstr ""
+
+#: src/base1/cockpit.js:3705
+msgid "Cockpit is not installed on the system."
+msgstr ""
+
+#: cockpit.appdata.xml.in.h:2
+msgid ""
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
+"tasks such as storage administration, inspecting journals and starting and "
+"stopping services. You can monitor and administer several servers at the "
+"same time. Just add them with a single click and your machines will look "
+"after its buddies."
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:9
+msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:15
+msgid ""
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:9
+msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:6
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
+"machine with cockpit you will need to enable one of the following "
+"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:13
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
+"change your authentication credentials below. {{#can_sync}}You may prefer to "
+"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+msgstr ""
+
+#: pkg/dashboard/index.html:171 pkg/lib/machine-add.html:27
+msgid "Color"
+msgstr ""
+
+#: pkg/docker/index.html:95
+msgid "Combined CPU usage"
+msgstr ""
+
+#: pkg/docker/index.html:101
+msgid "Combined memory usage"
+msgstr ""
+
+#: pkg/systemd/services.html:370 pkg/docker/index.html:466
+#: pkg/docker/index.html:736
+msgid "Command"
+msgstr "Komut"
+
+#: pkg/docker/run.js:332
+#, fuzzy
+msgid "Command can't be empty"
+msgstr "İsim boş olamaz"
+
+#: pkg/docker/containers-view.jsx:239
+#, fuzzy
+msgid "Commit"
+msgstr "Komut"
+
+#: pkg/tuned/dialog.js:114
+msgid "Communication with tuned has failed"
+msgstr "tuned ile iletişim başarısız"
+
+#: pkg/storaged/details.js:348
+msgid "Compatible with all systems and devices (MBR)"
+msgstr ""
+
+#: pkg/storaged/details.js:349
+msgid "Compatible with modern system and hard disks > 2TB (GPT)"
+msgstr ""
+
+#: pkg/realmd/operation.html:28
+msgid "Computer OU"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:24
+msgid "Configuration"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2441
+msgid "Configure"
+msgstr "Ayarla"
+
+#: pkg/kubernetes/views/node-add.html:42
+msgid "Configure Flannel networking"
+msgstr ""
+
+#: pkg/kubernetes/views/node-add.html:32
+msgid "Configure Kubelet and Proxy"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:811
+msgid "Configuring"
+msgstr "Ayarlanıyor"
+
+#: pkg/networkmanager/interfaces.js:815
+msgid "Configuring IP"
+msgstr "IP ayarlanıyor"
+
+#: pkg/users/index.html:171 pkg/shell/index.html:262
+msgid "Confirm"
+msgstr "Onayla"
+
+#: pkg/users/index.html:247
+msgid "Confirm New Password"
+msgstr "Yeni Parolayı Onayla"
+
+#: pkg/storaged/details.js:229
+msgid "Confirm passphrase"
+msgstr "Parolayı onayla"
+
+#: pkg/kubernetes/views/auth-form.html:130
+#: pkg/kubernetes/views/auth-rejected-cert.html:33
+#: pkg/lib/machine-unknown-hostkey.html:22
+msgid "Connect"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2637
+msgid "Connect automatically"
+msgstr "Otomatik bağlan"
+
+#: pkg/ostree/index.html:218
+msgid "Connecting"
+msgstr ""
+
+#: pkg/lib/machine-add.html:39
+msgid ""
+"Connecting simultaneously to more than {{ limit }} machines is unsupported."
+msgstr ""
+
+#: pkg/docker/index.html:54
+msgid "Connecting to Docker"
+msgstr "Docker'a bağlanılıyor"
+
+#: pkg/shell/indexes.js:317
+msgid "Connecting to the machine"
+msgstr "Makineye bağlanılıyor"
+
+#: pkg/kubernetes/registry.html:70 pkg/kubernetes/index.html:100
+msgid "Connecting..."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-dialog.html:4
+#, fuzzy
+msgid "Connection Error"
+msgstr "Docker'a bağlanılıyor"
+
+#: pkg/kubernetes/scripts/connection.js:516
+#, fuzzy
+msgid "Connection Error: $0"
+msgstr "Docker'a bağlanılıyor"
+
+#: pkg/kubernetes/views/auth-dialog.html:3
+#, fuzzy
+msgid "Connection Settings"
+msgstr "Hesap Ayarları"
+
+#: src/base1/cockpit.js:3703
+msgid "Connection has timed out."
+msgstr ""
+
+#: pkg/networkmanager/index.html:812
+#, fuzzy
+msgid "Connection will be lost"
+msgstr "Hesap Ayarları"
+
+#: pkg/docker/console.html:4 pkg/kubernetes/views/container-panel.html:4
+#: pkg/kubernetes/views/image-panel.html:12
+#: pkg/kubernetes/views/container-body.html:4
+#: pkg/kubernetes/views/container-page-inline.html:2
+#: pkg/kubernetes/views/image-page.html:19
+msgid "Container"
+msgstr "Konteyner"
+
+#: pkg/users/local.js:684
+msgid "Container Administrator"
+msgstr "Konteyner Yöneticisi"
+
+#: pkg/kubernetes/views/container-body.html:10
+msgid "Container ID"
+msgstr ""
+
+#: pkg/docker/index.html:459 pkg/docker/index.html:646
+#: pkg/docker/index.html:712
+msgid "Container Name"
+msgstr "Konteyner İsmi"
+
+#: pkg/kubernetes/views/node-body.html:21
+msgid "Container Runtime Version"
+msgstr ""
+
+#: pkg/docker/util.js:490
+msgid ""
+"Container is currently marked as not running, but regular stopping failed."
+msgstr ""
+
+#: pkg/docker/util.js:488
+msgid "Container is currently running."
+msgstr "Konteyner şu an çalışıyor."
+
+#: pkg/docker/index.html:23 pkg/docker/index.html:309
+#: pkg/kubernetes/views/pod-page.html:36
+#: pkg/kubernetes/views/dashboard-page.html:158
+#: pkg/kubernetes/views/dashboard-page.html:199
+#: pkg/kubernetes/views/containers-listing.html:5 pkg/kubernetes/index.html:51
+msgid "Containers"
+msgstr "Konteynerler"
+
+#: pkg/docker/details.js:47 pkg/docker/image.js:43
+msgctxt "page-title"
+msgid "Containers"
+msgstr "Konteynerler"
+
+#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
+msgid "Content"
+msgstr "İçerik"
+
+#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
+#: pkg/playground/translate.js:19
+#, fuzzy
+msgid "Control"
+msgstr "Konteyner"
+
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
+#: pkg/playground/translate.js:22
+#, fuzzy
+msgctxt "key"
+msgid "Control"
+msgstr "Konteyner"
+
+#: pkg/docker/storage.jsx:404
+#, fuzzy
+msgid "Could not add all disks"
+msgstr "Servisler listelenemedi"
+
+#: pkg/lib/machine-change-port.html:4
+msgid "Could not contact {{host}}"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:142
+msgid "Could not list services"
+msgstr "Servisler listelenemedi"
+
+#: src/ws/cockpitcertificate.c:407
+msgid "Could not parse PEM-encoded certificate"
+msgstr "PEM-şifreli sertifika ayrıştırılamadı"
+
+#: src/ws/cockpitcertificate.c:374
+msgid "Could not parse PEM-encoded private key"
+msgstr "PEM-şifreli özel anahtar ayrıştırılamıyor"
+
+#: pkg/docker/storage.jsx:446
+msgid "Could not reset the storage pool"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:467
+msgid "Couldn't change user groups"
+msgstr "Kullanıcı kümeleri değiştirilemedi"
+
+#: src/bridge/cockpitdbussetup.c:520
+msgid "Couldn't change user password"
+msgstr "Kullanıcı parolası değiştirilemedi"
+
+#: pkg/selinux/setroubleshoot-view.jsx:385
+msgid ""
+"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
+"server is installed."
+msgstr ""
+
+#: pkg/kubernetes/registry.html:71 pkg/kubernetes/index.html:101
+msgid "Couldn't connect to server"
+msgstr ""
+
+#: pkg/shell/indexes.js:320
+msgid "Couldn't connect to the machine"
+msgstr "Makineye bağlanılamadı"
+
+#: src/bridge/cockpitdbussetup.c:544
+msgid "Couldn't create new users"
+msgstr "Yeni kullanıcılar oluşturulamadı"
+
+#: pkg/kubernetes/scripts/connection.js:514
+msgid "Couldn't find running API server"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:196
+msgid ""
+"Couldn't get system subscription status. Please ensure subscription-manager "
+"is installed."
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:642
+msgid "Couldn't list local users"
+msgstr "Yerel kullanıcılar listelenemedi"
+
+#: src/bridge/cockpitdbussetup.c:236
+msgid "Couldn't list users"
+msgstr "Kullanıcılar listelenemedi"
+
+#: src/bridge/cockpitdbussetup.c:382
+msgid "Couldn't load user data"
+msgstr "Kullanıcı verisi yüklenemedi"
+
+#: pkg/kubernetes/views/project-modify.html:72
+#: pkg/kubernetes/views/add-group-dialog.html:21
+msgid "Create"
+msgstr "Yarat"
+
+#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
+#, fuzzy
+msgid "Create Logical Volume"
+msgstr "Mantıksal Bölümü Yeniden İsimlendir"
+
+#: pkg/users/index.html:54 pkg/users/index.html:143
+msgid "Create New Account"
+msgstr "Yeni Hesap Yarat"
+
+#: pkg/storaged/details.js:1379
+msgid "Create Partition"
+msgstr ""
+
+#: pkg/storaged/overview.js:414
+msgid "Create RAID Device"
+msgstr "RAID Yarat"
+
+#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
+msgid "Create Snapshot"
+msgstr ""
+
+#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
+msgid "Create Thin Volume"
+msgstr ""
+
+#: pkg/systemd/services.html:336
+#, fuzzy
+msgid "Create Timers"
+msgstr "Zamanı Ayarla"
+
+#: pkg/storaged/overview.js:487
+msgid "Create Volume Group"
+msgstr "Volume Grubu Yarat"
+
+#: pkg/sosreport/index.html:50
+msgid "Create diagnostic report"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:3
+msgid "Create image stream"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
+#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
+#, fuzzy
+msgid "Create it"
+msgstr "Yarat"
+
+#: pkg/storaged/details.js:266
+msgid "Create partition"
+msgstr ""
+
+#: pkg/storaged/details.js:113
+msgid "Create partition on $0"
+msgstr ""
+
+#: pkg/storaged/index.html:381
+msgid "Create partition table"
+msgstr ""
+
+#: pkg/sosreport/index.html:42
+msgid "Create report"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/replicationcontroller-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7 pkg/kubernetes/views/route-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3
+msgid "Created"
+msgstr ""
+
+#: pkg/storaged/jobs.js:142
+msgid "Creating RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:130
+msgid "Creating filesystem on $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:156
+msgid "Creating logical volume $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:134
+msgid "Creating partition $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:150
+msgid "Creating snapshot of $target"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:4064
+msgid "Creating this VLAN will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3436
+msgid "Creating this bond will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3842
+msgid "Creating this bridge will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3611
+msgid "Creating this team will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:151
+msgid "Creating volume group $target"
+msgstr ""
+
+#: pkg/systemd/logs.html:41
+msgid "Current boot"
+msgstr ""
+
+#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
+msgid "Custom"
+msgstr "Özel"
+
+#: pkg/storaged/details.js:186
+msgid "Custom (Enter filesystem type)"
+msgstr "Özel (Dosya sistemi tipi girin)"
+
+#: pkg/subscriptions/subscriptions-register.jsx:102
+#, fuzzy
+msgid "Custom URL"
+msgstr "Özel"
+
+#: pkg/storaged/index.html:454
+msgid "DISK IS FAILING"
+msgstr "DİSK BOZULUYOR"
+
+#: pkg/networkmanager/interfaces.js:3018
+msgid "DNS"
+msgstr "DNS"
+
+#: pkg/kubernetes/views/pod-body.html:14
+msgid "DNS Policy"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3022
+msgid "DNS Search Domains"
+msgstr "DNS Search Domains"
+
+#: pkg/dashboard/index.html:22
+msgid "Dashboard"
+msgstr ""
+
+#: pkg/storaged/details.js:1130
+msgid "Deactivate"
+msgstr "Deaktifleştir"
+
+#: pkg/networkmanager/interfaces.js:823
+msgid "Deactivating"
+msgstr "Deaktif ediliyor"
+
+#: pkg/storaged/jobs.js:149
+msgid "Deactivating $target"
+msgstr ""
+
+#: pkg/docker/index.html:379 pkg/docker/index.html:383
+#: pkg/kubernetes/views/image-config.html:6
+msgid "Default"
+msgstr "Ön tanımlı"
+
+#: pkg/systemd/index.html:454
+msgid "Delay"
+msgstr "Gecikme"
+
+#: pkg/users/index.html:79 pkg/kubernetes/views/item-delete.html:11
+#: pkg/kubernetes/views/pvc-delete.html:15
+#: pkg/kubernetes/views/node-delete.html:15
+#: pkg/kubernetes/views/imagestream-delete.html:8
+#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/kubernetes/views/image-delete.html:8
+#: pkg/kubernetes/views/pv-delete.html:11
+msgid "Delete"
+msgstr "Sil"
+
+#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
+msgid "Delete $0"
+msgstr "Sil: $0"
+
+#: pkg/users/index.html:292
+msgid "Delete Files"
+msgstr "Dosyaları Sil"
+
+#: pkg/kubernetes/views/node-delete.html:4
+#, fuzzy
+msgid "Delete Node"
+msgstr "Sil"
+
+#: pkg/kubernetes/views/pv-delete.html:3
+msgid "Delete Persistent Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:3
+msgid "Delete Persistent Volume Claim"
+msgstr ""
+
+#: pkg/kubernetes/views/project-delete.html:3
+#, fuzzy
+msgid "Delete Project"
+msgstr "Dosyaları Sil"
+
+#: pkg/kubernetes/views/nodes-page.html:3
+#, fuzzy
+msgid "Delete Selected"
+msgstr "Dosyaları Sil"
+
+#: pkg/kubernetes/views/imagestream-delete.html:3
+msgid "Delete image stream"
+msgstr ""
+
+#: pkg/playground/translate.html:184 pkg/kubernetes/views/item-delete.html:3
+msgid "Delete {{ item.kind }}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
+msgid "Deleting $target"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2156
+msgid "Deleting <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:7
+msgid ""
+"Deleting a Pod will kill all associated containers. Pods may be "
+"automatically created again in some cases."
+msgstr ""
+
+#: pkg/storaged/details.js:631
+msgid "Deleting a RAID device will erase all data on it."
+msgstr "Bir RAID cihazını silmek üstündeki tüm veriyi silecektir."
+
+#: pkg/docker/containers-view.jsx:167 pkg/docker/details.js:272
+msgid "Deleting a container will erase all data in it."
+msgstr "Bir konteyneri silmek içindeki veriyi de silecektir."
+
+#: pkg/storaged/details.js:1009
+msgid "Deleting a logical volume will delete all data in it."
+msgstr ""
+
+#: pkg/storaged/details.js:1012
+msgid "Deleting a partition will delete all data in it."
+msgstr ""
+
+#: pkg/storaged/details.js:826
+msgid "Deleting a volume group will erase all data on it."
+msgstr ""
+
+#: pkg/docker/image.js:152
+msgid ""
+"Deleting an image will delete it, but you can probably download it again if "
+"you need it later.  Unless this image has never been pushed to a repository, "
+"that is, in which case you probably can't download it again."
+msgstr ""
+
+#: pkg/storaged/jobs.js:152
+msgid "Deleting volume group $target"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:131
+#: pkg/kubernetes/views/deploy.html:62
+msgid "Deploy"
+msgstr "Devreye Al"
+
+#: pkg/kubernetes/views/deploy.html:3
+msgid "Deploy Application"
+msgstr "Uygulamayı Devreye Al"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:22
+msgid "Deployment Causes"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-panel.html:8
+#: pkg/kubernetes/views/deploymentconfig-page.html:12
+msgid "Deployment Config"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:98
+msgid "Deployment Configs"
+msgstr ""
+
+#: pkg/systemd/services.html:356 pkg/kubernetes/views/project-modify.html:40
+#: pkg/kubernetes/views/image-body.html:6
+#: pkg/kubernetes/views/project-listing.html:15
+#: pkg/kubernetes/views/project-listing.html:54
+msgid "Description"
+msgstr ""
+
+#: pkg/shell/index.html:197 pkg/kubernetes/index.html:63
+msgid "Details"
+msgstr ""
+
+#: pkg/storaged/index.html:543
+msgctxt "storage"
+msgid "Device"
+msgstr "Aygıt"
+
+#: pkg/storaged/details.js:91
+msgid "Device $0 is a member of RAID Array $1"
+msgstr ""
+
+#: pkg/storaged/details.js:97
+msgid "Device $0 is a physical volume of $1"
+msgstr ""
+
+#: pkg/storaged/details.js:85
+msgid "Device $0 is mounted on $1"
+msgstr ""
+
+#: pkg/storaged/index.html:467 pkg/storaged/index.html:473
+#: pkg/storaged/index.html:515
+msgctxt "storage"
+msgid "Device File"
+msgstr "Aygıt dosyası"
+
+#: pkg/sosreport/index.html:22
+msgid "Diagnostic reports"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:20
+msgid "Digest"
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:7
+#: pkg/kubernetes/views/volume-body.html:28
+msgid "Directory"
+msgstr ""
+
+#: pkg/systemd/init.js:543
+msgid "Disable"
+msgstr ""
+
+#: pkg/tuned/dialog.js:234
+msgid "Disable tuned"
+msgstr "tuned'i devre dışı bırak"
+
+#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
+msgid "Disabled"
+msgstr "Etkin değil"
+
+#: pkg/shell/simple.html:120
+msgid "Disconnected"
+msgstr "Bağlantı kesildi"
+
+#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+#, fuzzy
+msgid "Disk"
+msgstr "Diskler"
+
+#: pkg/dashboard/index.html:73
+#, fuzzy
+msgid "Disk I/O"
+msgstr "Disk durumu iyi"
+
+#: pkg/kubernetes/scripts/nodes.js:720
+msgid "Disk Utilization: $0%"
+msgstr ""
+
+#: pkg/storaged/index.html:457
+msgid "Disk is OK"
+msgstr "Disk durumu iyi"
+
+#: pkg/storaged/index.html:584
+msgid "Disks"
+msgstr "Diskler"
+
+#: pkg/shell/simple.html:37 pkg/shell/simple.html:97 pkg/shell/index.html:37
+#: pkg/shell/index.html:118 pkg/shell/stub.html:37 pkg/shell/stub.html:111
+msgid "Display Language"
+msgstr ""
+
+#: pkg/kubernetes/views/project-modify.html:31
+msgid "Display name"
+msgstr ""
+
+#: pkg/kubernetes/views/add-role-dialog.html:5
+msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-delete.html:5
+msgid ""
+"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}' image stream?"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:6
+msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:6
+msgid ""
+"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:6
+msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/node-delete.html:7
+msgid "Do you want to delete this Node?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-delete.html:5
+msgid ""
+"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+"{{stream.metadata.name}}:{{tag.tag}}'?"
+msgstr ""
+
+#: pkg/kubernetes/views/remove-role-dialog.html:5
+msgid ""
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:11
+msgid "Docker Version"
+msgstr ""
+
+#: pkg/docker/index.html:60
+msgid "Docker is not installed or activated on the system"
+msgstr "Docker sistemde yüklü ya da aktif değil"
+
+#: pkg/systemd/index.html:107
+msgid "Domain"
+msgstr ""
+
+#: pkg/realmd/operation.js:148
+msgid "Domain $0 could not be contacted"
+msgstr ""
+
+#: pkg/realmd/operation.js:220
+msgid "Domain $0 is not supported"
+msgstr ""
+
+#: pkg/realmd/operation.html:11
+msgid "Domain Address"
+msgstr ""
+
+#: pkg/realmd/operation.html:59
+msgid "Domain Administrator Name"
+msgstr ""
+
+#: pkg/realmd/operation.html:65
+msgid "Domain Administrator Password"
+msgstr ""
+
+#: pkg/systemd/services.html:426 pkg/systemd/services.html:430
+msgid "Don't Repeat"
+msgstr ""
+
+#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
+msgid "Don't overwrite existing data"
+msgstr "Mevcut verinin üstüne yazma"
+
+#: pkg/sosreport/index.html:74
+msgid "Done!"
+msgstr ""
+
+#: pkg/ostree/index.html:127 pkg/ostree/index.html:158
+msgid "Downgrades"
+msgstr ""
+
+#: pkg/storaged/index.html:411
+msgid "Drive"
+msgstr "Sürücü"
+
+#: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
+msgctxt "storage"
+msgid "Drive"
+msgstr "Sürücü"
+
+#: pkg/kubernetes/views/volume-body.html:128
+#, fuzzy
+msgid "Driver"
+msgstr "Sürücü"
+
+#: pkg/storaged/index.html:166
+msgid "Drives"
+msgstr ""
+
+#: pkg/docker/run.js:360
+msgid "Duplicate alias"
+msgstr ""
+
+#: pkg/docker/run.js:293
+msgid "Duplicate port"
+msgstr ""
+
+#: pkg/storaged/jobs.js:120
+msgid "Ejecting $target"
+msgstr ""
+
+#: pkg/playground/translate.html:58
+msgid "Empty"
+msgstr "Boş"
+
+#: pkg/playground/translate.html:63
+#, fuzzy
+msgctxt "verb"
+msgid "Empty"
+msgstr "Boş"
+
+#: pkg/kubernetes/scripts/volumes.js:196
+msgid "Empty Directory"
+msgstr ""
+
+#: pkg/storaged/jobs.js:155
+msgid "Emptying $target"
+msgstr ""
+
+#: pkg/systemd/init.js:541
+msgid "Enable"
+msgstr ""
+
+#: pkg/systemd/init.js:542
+msgid "Enable Forcefully"
+msgstr ""
+
+#: pkg/systemd/init.js:301
+msgid "Enabled"
+msgstr ""
+
+#: pkg/storaged/details.js:1247
+msgctxt "storage-id-desc"
+msgid "Encrypted"
+msgstr "Şifreli"
+
+#: pkg/storaged/details.js:180
+msgid "Encrypted EXT4 (LUKS)"
+msgstr "Şifreli EXT4 (LUKS)"
+
+#: pkg/storaged/details.js:179
+msgid "Encrypted XFS (LUKS)"
+msgstr "Şifreli XFS (LUKS)"
+
+#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
+#: pkg/storaged/details.js:1115
+msgid "Encryption Options"
+msgstr "Şifreleme seçenekleri"
+
+#: pkg/kubernetes/views/pv-modify.html:93
+msgid "Endpoint"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:40
+msgid "Endpoint Name"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:14
+#: pkg/kubernetes/views/service-panel.html:9
+msgid "Endpoints"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:38
+msgid "Ends"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:332
+msgid "Enforce policy:"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:447
+msgid "Enter IP address or host name"
+msgstr "IP adresi ya da ana makine adı gir"
+
+#: pkg/systemd/logs.html:60
+msgid "Entry"
+msgstr ""
+
+#: pkg/docker/index.html:547 pkg/kubernetes/views/image-config.html:17
+#: pkg/kubernetes/views/container-body.html:26
+msgid "Environment"
+msgstr ""
+
+#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
+msgid "Erase"
+msgstr "Sil"
+
+#: pkg/docker/storage.jsx:423
+msgid "Erase containers and reset storage pool"
+msgstr ""
+
+#: pkg/docker/storage.jsx:360
+msgid "Erase containers, reformat disks, and add them"
+msgstr ""
+
+#: pkg/storaged/jobs.js:129
+msgid "Erasing $target"
+msgstr ""
+
+#: pkg/systemd/services.html:318 pkg/playground/translate.html:101
+#: pkg/playground/translate.html:106
+msgid "Error"
+msgstr "Hata"
+
+#: pkg/kubernetes/scripts/connection.js:650
+msgid "Error getting certificate details: $0"
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:13
+msgid "Error loading users: {{perm_failed}}"
+msgstr ""
+
+#: pkg/docker/util.js:491
+msgid "Error message from Docker:"
+msgstr "Docker'dan hata mesajı:"
+
+#: pkg/users/authorized-keys.js:115
+msgid "Error saving authorized keys: "
+msgstr "Yetkilendirilmiş anahtarın kaydedilmesinde hata:"
+
+#: pkg/selinux/setroubleshoot.js:275
+msgid "Error while connecting."
+msgstr "Bağlanırken hata."
+
+#: pkg/selinux/setroubleshoot-client.js:192
+msgid "Error while deleting alert"
+msgstr "Uyarıyı silerken hata"
+
+#: pkg/selinux/setroubleshoot.js:65
+msgid "Error while setting SELinux mode: '$0'"
+msgstr "SELinux kipi belirlenirken hata: '$0'"
+
+#: pkg/kubernetes/scripts/connection.js:88
+msgid "Error writing kubectl config"
+msgstr ""
+
+#: pkg/systemd/logs.html:47
+msgid "Errors"
+msgstr ""
+
+#: pkg/networkmanager/index.html:764
+msgid "Ethernet MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1854
+msgid "Ethtool"
+msgstr ""
+
+#: pkg/users/local.js:429 pkg/users/local.js:1104
+msgid "Excellent password"
+msgstr "Mükemmel Parola"
+
+#: pkg/docker/util.js:96
+msgid "Exited $ExitCode"
+msgstr ""
+
+#: pkg/docker/index.html:529
+msgid "Expose container ports"
+msgstr ""
+
+#: pkg/storaged/details.js:183
+msgid "Extended Partition"
+msgstr ""
+
+#: pkg/storaged/details.js:1592
+msgid "FAILED"
+msgstr "OLMADI"
+
+#: pkg/ostree/index.html:92
+msgid "Failed"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:412
+msgid "Failed to add machine: $0"
+msgstr "Makine ekleme başarısız: $0"
+
+#: pkg/users/local.js:112 pkg/users/local.js:144 pkg/lib/credentials.js:223
+msgid "Failed to change password"
+msgstr "Parola değişimi başarısız oldu"
+
+#: pkg/selinux/setroubleshoot-client.js:187
+msgid "Failed to delete alert"
+msgstr "Uyarı silme başarısız"
+
+#: pkg/tuned/dialog.js:171
+msgid "Failed to disable tuned"
+msgstr "tuned'i devre dışı bırakma başarısız"
+
+#: pkg/tuned/dialog.js:133
+msgid "Failed to disable tuned profile"
+msgstr "tuned profilini devre dışı bırakma başarısız"
+
+#: pkg/lib/machine-dialogs.js:494
+msgid "Failed to edit machine: $0"
+msgstr "Makine düzenleme başarısız:  $0"
+
+#: pkg/tuned/dialog.js:169
+msgid "Failed to enable tuned"
+msgstr "tuned'i etkinleştirme başarısız"
+
+#: pkg/users/index.html:338
+msgid "Failed to load authorized keys."
+msgstr "Yetkilendirilmiş anahtarların yüklemesi başarısız oldu."
+
+#: pkg/docker/containers.js:64
+msgid "Failed to start Docker: $0"
+msgstr ""
+
+#: pkg/docker/util.js:544
+msgid "Failed to stop Docker scope: $0"
+msgstr ""
+
+#: pkg/tuned/dialog.js:145
+msgid "Failed to switch profile"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:204
+msgid "Fibre Channel"
+msgstr ""
+
+#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
+msgid "Filesystem Options"
+msgstr "Dosya Sistemi Seçenekleri"
+
+#: pkg/kubernetes/views/pv-modify.html:180
+#: pkg/kubernetes/views/volume-body.html:6
+#: pkg/kubernetes/views/volume-body.html:16
+#: pkg/kubernetes/views/volume-body.html:62
+#: pkg/kubernetes/views/volume-body.html:83
+#: pkg/kubernetes/views/volume-body.html:91
+#: pkg/kubernetes/views/volume-body.html:120
+#: pkg/kubernetes/views/volume-body.html:132
+#, fuzzy
+msgid "Filesystem Type"
+msgstr "Dosya sistemi tipi"
+
+#: pkg/storaged/details.js:215
+msgid "Filesystem type"
+msgstr "Dosya sistemi tipi"
+
+#: pkg/storaged/index.html:225
+msgid "Filesystems"
+msgstr "Dosya Sistemleri"
+
+#: pkg/lib/machine-unknown-hostkey.html:10
+msgid "Fingerprint"
+msgstr ""
+
+#: pkg/storaged/index.html:426
+msgctxt "storage"
+msgid "Firmware Version"
+msgstr "Firmware Sürümü"
+
+#: pkg/kubernetes/scripts/volumes.js:206
+msgid "Flex"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:205
+#, fuzzy
+msgid "Flocker"
+msgstr "kilitlendi"
+
+#: pkg/kubernetes/views/volume-body.html:125
+msgid "Flocker Dataset Name"
+msgstr ""
+
+#: pkg/docker/util.js:503
+msgid "Force Delete"
+msgstr "Zorla Sil"
+
+#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
+#: pkg/storaged/details.js:1142
+msgid "Format"
+msgstr "Biçimlendir"
+
+#: pkg/storaged/details.js:115
+msgid "Format $0"
+msgstr ""
+
+#: pkg/storaged/details.js:335
+msgid "Format Disk $0"
+msgstr ""
+
+#: pkg/storaged/details.js:358
+msgid "Formatting a disk will erase all data on it."
+msgstr "Bir diski biçimlendirmek üstünde yer alan veriyi silecektir."
+
+#: pkg/storaged/details.js:268
+msgid "Formatting a storage device will erase all data on it."
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2577
+msgid "Forward delay $forward_delay"
+msgstr ""
+
+#: pkg/systemd/index.html:255
+msgid "Free"
+msgstr "Boş"
+
+#: pkg/users/index.html:86 pkg/users/index.html:148
+msgid "Full Name"
+msgstr "Tam İsim"
+
+#: pkg/kubernetes/scripts/volumes.js:192
+msgid "GCE Persistent Disk"
+msgstr ""
+
+#: pkg/docker/index.html:180
+msgid "Gateway:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2628
+msgid "General"
+msgstr "Genel"
+
+#: pkg/sosreport/index.html:66
+msgid "Generating report"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:194
+#, fuzzy
+msgid "Git Repository"
+msgstr "Depo"
+
+#: pkg/kubernetes/scripts/volumes.js:198
+msgid "Gluster FS"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:872
+msgid "GlusterFS"
+msgstr ""
+
+#: pkg/systemd/logs.js:130
+msgid "Go to"
+msgstr ""
+
+#: pkg/storaged/index.html:307 pkg/networkmanager/index.html:50
+#: pkg/networkmanager/index.html:496
+msgid "Go to now"
+msgstr "Şimdiye git"
+
+#: pkg/kubernetes/views/group-page.html:21
+#: pkg/kubernetes/views/group-panel.html:12
+#, fuzzy
+msgid "Group Members"
+msgstr "Üyeler"
+
+#: pkg/kubernetes/views/project-listing.html:48
+#: pkg/kubernetes/views/user-delete.html:14
+msgid "Groups"
+msgstr ""
+
+#: pkg/networkmanager/index.html:268
+msgid "Hair Pin mode"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2603
+msgid "Hairpin mode"
+msgstr ""
+
+#: pkg/docker/storage.jsx:157
+#, fuzzy
+msgid "Hard Disk"
+msgstr "Sabit Disk"
+
+#: pkg/storaged/overview.js:180
+msgctxt "storage"
+msgid "Hard Disk"
+msgstr "Sabit Disk"
+
+#: pkg/systemd/index.html:77
+msgid "Hardware"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2579
+msgid "Hello time $hello_time"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:73
+#: pkg/kubernetes/views/route-body.html:9
+#: pkg/kubernetes/views/route-modify.html:8
+msgid "Host"
+msgstr "Host"
+
+#: pkg/systemd/index.html:102 pkg/dashboard/index.html:151
+msgid "Host Name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
+#, fuzzy
+msgid "Host Path"
+msgstr "Host"
+
+#: src/base1/cockpit.js:3699
+msgid "Host key is incorrect"
+msgstr ""
+
+#: pkg/systemd/services.html:442
+#, fuzzy
+msgid "Hour : Minute"
+msgstr "1 dakika"
+
+#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
+msgid "Hour needs to be a number between 0-23"
+msgstr ""
+
+#: pkg/systemd/services.html:408
+#, fuzzy
+msgid "Hours"
+msgstr "6 saat"
+
+#: pkg/systemd/index.html:221
+msgid "I/O Wait"
+msgstr "I/O Beklemesi"
+
+#: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
+msgid "IP"
+msgstr ""
+
+#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
+msgid "IP Address"
+msgstr ""
+
+#: pkg/docker/index.html:172
+#, fuzzy
+msgid "IP Address:"
+msgstr "Adres"
+
+#: pkg/docker/index.html:176
+#, fuzzy
+msgid "IP Prefix Length:"
+msgstr "Ön ek uzunluğu"
+
+#: pkg/networkmanager/index.html:568
+msgid "IP Settings"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2641
+msgid "IPv4"
+msgstr "IPv4"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv4 Settings"
+msgstr "IPv4 Ayarları"
+
+#: pkg/networkmanager/interfaces.js:2642
+msgid "IPv6"
+msgstr "IPv6"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv6 Settings"
+msgstr "IPv6 Ayarları"
+
+#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
+msgid "ISCSI"
+msgstr ""
+
+#: pkg/systemd/init.js:270
+msgid "Id"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2620
+msgid "Id $id"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:22
+msgid "Identifier"
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:23
+#: pkg/kubernetes/views/user-panel.html:18
+msgid "Identities"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:91
+msgid "Identity"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1817
+msgid "Ignore"
+msgstr "Yoksay"
+
+#: pkg/docker/index.html:452 pkg/kubernetes/views/image-panel.html:9
+#: pkg/kubernetes/views/container-body.html:6
+#: pkg/kubernetes/views/image-page.html:16
+msgid "Image"
+msgstr "Kalıp"
+
+#: pkg/docker/image.js:77
+msgid "Image $0"
+msgstr "Kalıp $0"
+
+#: pkg/kubernetes/views/container-body.html:8
+msgid "Image ID"
+msgstr ""
+
+#: pkg/kubernetes/views/image-meta.html:16
+#, fuzzy
+msgid "Image Layers"
+msgstr "Kalıp $0"
+
+#: pkg/kubernetes/views/volume-body.html:58
+#, fuzzy
+msgid "Image Name"
+msgstr "Kalıp $0"
+
+#: pkg/kubernetes/registry.html:23
+msgid "Image Registry"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-page.html:16
+msgid "Image Stream"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:135
+#, fuzzy
+msgid "Image commands"
+msgstr "Kalıp $0"
+
+#: pkg/kubernetes/views/imagestream-body.html:34
+msgid "Image count"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:48
+#: pkg/kubernetes/views/registry-dashboard-page.html:19
+#: pkg/kubernetes/views/imagestream-page.html:18
+#: pkg/kubernetes/views/image-listing.html:9 pkg/kubernetes/index.html:77
+msgid "Images"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:17
+msgid "Images by project"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:54
+msgid "Images pushed recently"
+msgstr ""
+
+#: pkg/storaged/details.js:1593
+msgid "In Sync"
+msgstr "Eş zamanlanıyor"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:81
+msgid ""
+"In order to begin pushing images to the registry, use the commands below."
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:6
+msgid ""
+"In order to begin pushing images to the registry, you need to create a "
+"project."
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:50
+msgid ""
+"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
+"strong}}.        {{/needs_root}}                                    User "
+"name                                                                            "
+"{{#allows_password}}                            "
+"Password                                                                            "
+"{{/allows_password}}            "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
+#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
+msgid "Inactive"
+msgstr "Aktif değil"
+
+#: pkg/lib/machine-invalid-hostkey.html:2
+msgid "Incorrect Host Key"
+msgstr ""
+
+#: pkg/docker/storage.jsx:282
+msgid "Information about the Docker storage pool is not available."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:222
+msgid "Installed products"
+msgstr ""
+
+#: pkg/systemd/services.html:135
+msgid "Instantiate"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:169
+#: pkg/kubernetes/views/volume-body.html:81
+#, fuzzy
+msgid "Interface"
+msgstr "Arayüzler"
+
+#: pkg/networkmanager/index.html:84
+msgid "Interfaces"
+msgstr "Arayüzler"
+
+#: src/base1/cockpit.js:3701
+msgid "Internal error"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:196
+#, fuzzy
+msgid "Invalid credentials"
+msgstr "Geçersiz port"
+
+#: pkg/systemd/host.js:1194
+msgid "Invalid date format"
+msgstr "Geçersiz tarih biçimi"
+
+#: pkg/systemd/host.js:1190
+msgid "Invalid date format and invalid time format"
+msgstr "Geçersiz tarih ve geçersiz zaman biçimi"
+
+#: pkg/systemd/init.js:1218
+#, fuzzy
+msgid "Invalid date format."
+msgstr "Geçersiz tarih biçimi"
+
+#: pkg/lib/credentials.js:274
+msgid "Invalid file permissions"
+msgstr "Geçersiz dosya izinleri"
+
+#: pkg/users/index.html:322
+msgid "Invalid key"
+msgstr "Geçersiz anahtar"
+
+#: pkg/systemd/init.js:1169
+#, fuzzy
+msgid "Invalid number."
+msgstr "Geçersiz anahtar"
+
+#: pkg/docker/run.js:283
+msgid "Invalid port"
+msgstr "Geçersiz port"
+
+#: pkg/systemd/host.js:1192
+msgid "Invalid time format"
+msgstr "Geçersiz zaman biçimi"
+
+#: pkg/subscriptions/subscriptions-client.js:194 pkg/storaged/overview.js:577
+#: pkg/storaged/overview.js:668
+msgid "Invalid username or password"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:15
+msgid "Is sshd running on a different port?"
+msgstr ""
+
+#: pkg/systemd/init.js:522
+msgid "Isolate"
+msgstr ""
+
+#: pkg/storaged/index.html:280
+msgid "Jobs"
+msgstr "İşler"
+
+#: pkg/realmd/operation.js:96
+msgid "Join"
+msgstr "Katıl"
+
+#: pkg/realmd/operation.js:453
+msgid "Join Domain"
+msgstr ""
+
+#: pkg/realmd/operation.js:347
+msgid "Joining this domain is not supported"
+msgstr ""
+
+#: pkg/systemd/logs.js:257
+msgid "Journal entry"
+msgstr ""
+
+#: pkg/systemd/logs.js:284
+msgid "Journal entry not found"
+msgstr ""
+
+#: pkg/lib/machine-auth-failed.html:10
+msgid "Kerberos Based SSO"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:69
+msgid "Kerberos Ticket"
+msgstr ""
+
+#: pkg/systemd/index.html:225
+msgid "Kernel"
+msgstr "Çekirdek"
+
+#: pkg/kubernetes/views/node-body.html:19
+#, fuzzy
+msgid "Kernel Version"
+msgstr "Sürüm"
+
+#: pkg/kubernetes/views/volume-body.html:67
+msgid "Key Ring Path"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:23
+msgid "Kubelet Version"
+msgstr ""
+
+#: pkg/kubernetes/index.html:23
+msgid "Kubernetes Cluster"
+msgstr "Kubernetes kümesi"
+
+#: pkg/networkmanager/index.html:473
+msgid "LACP Key"
+msgstr ""
+
+#: pkg/storaged/details.js:1245
+msgctxt "storage-id-desc"
+msgid "LUKS Encrypted"
+msgstr "LUKS Şifreli"
+
+#: pkg/storaged/details.js:1226
+msgctxt "storage-id-desc"
+msgid "LVM2 Physical Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/replicationcontroller-body.html:17
+#: pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/route-body.html:22
+#: pkg/kubernetes/views/image-meta.html:3
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
+msgid "Labels"
+msgstr "Etiketler"
+
+#: pkg/systemd/logs.html:42
+msgid "Last 24 hours"
+msgstr ""
+
+#: pkg/systemd/logs.html:43
+msgid "Last 7 days"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:49
+msgid "Last Heartbeat"
+msgstr ""
+
+#: pkg/users/index.html:100
+msgid "Last Login"
+msgstr "Son Giriş"
+
+#: pkg/kubernetes/views/node-body.html:51
+msgid "Last Status Change"
+msgstr ""
+
+#: pkg/systemd/init.js:273
+msgid "Last Trigger"
+msgstr ""
+
+#: pkg/kubernetes/views/image-listing.html:16
+msgid "Last Updated"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:107
+msgid "Latest Version"
+msgstr ""
+
+#: pkg/realmd/operation.js:101
+msgid "Leave"
+msgstr "Ayrıl"
+
+#: pkg/networkmanager/index.html:315
+msgid "Link Monitoring"
+msgstr ""
+
+#: pkg/networkmanager/index.html:397
+msgid "Link Watch"
+msgstr ""
+
+#: pkg/networkmanager/index.html:350 pkg/networkmanager/index.html:432
+msgid "Link down delay"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
+msgid "Link local"
+msgstr ""
+
+#: pkg/networkmanager/index.html:341 pkg/networkmanager/index.html:423
+msgid "Link up delay"
+msgstr ""
+
+#: pkg/docker/index.html:514
+msgid "Links"
+msgstr "Linkler"
+
+#: pkg/storaged/details.js:1224
+msgctxt "storage-id-desc"
+msgid "Linux MD-RAID Component"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1841
+msgid "Load Balancing"
+msgstr ""
+
+#: pkg/systemd/logs.js:69
+msgid "Load earlier entries"
+msgstr ""
+
+#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
+#: pkg/systemd/logs.js:175
+msgid "Loading..."
+msgstr ""
+
+#: pkg/users/index.html:23
+msgid "Local Accounts"
+msgstr ""
+
+#: pkg/docker/storage.jsx:188
+#, fuzzy
+msgid "Local Disks"
+msgstr "Diskler"
+
+#: pkg/storaged/details.js:1109
+msgid "Lock"
+msgstr "Kilitle"
+
+#: pkg/users/index.html:109 pkg/users/index.html:196
+msgid "Lock Account"
+msgstr "Hesabı Kilitle"
+
+#: pkg/storaged/jobs.js:122
+msgid "Locking $target"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:80
+msgid "Log In"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:4
+msgid "Log in to {{host}}"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:116
+msgid "Log into OpenShift command line tools:"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:101
+msgid "Log into the registry:"
+msgstr ""
+
+#: pkg/shell/simple.html:45 pkg/shell/index.html:52 pkg/shell/stub.html:45
+msgid "Log out"
+msgstr "Çıkış Yap"
+
+#: pkg/users/local.js:839
+msgid "Logged In"
+msgstr "Giriş Yapıldı"
+
+#: pkg/storaged/details.js:1424
+msgid "Logical Partition"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:158
+#: pkg/kubernetes/views/volume-body.html:79
+#: pkg/kubernetes/views/volume-body.html:118
+#, fuzzy
+msgid "Logical Unit Number"
+msgstr "Mantıksal Bölüm"
+
+#: pkg/storaged/utils.js:172
+msgid "Logical Volume"
+msgstr "Mantıksal Bölüm"
+
+#: pkg/storaged/utils.js:170
+msgid "Logical Volume (Snapshot)"
+msgstr ""
+
+#: pkg/storaged/details.js:1792
+msgid "Logical Volumes"
+msgstr "Mantıksal Bölümler"
+
+#: pkg/subscriptions/subscriptions-register.jsx:140
+#, fuzzy
+msgid "Login"
+msgstr "Son Giriş"
+
+#: pkg/lib/machine-change-auth.html:68
+msgid "Login Password"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:96
+msgid "Login commands"
+msgstr ""
+
+#: src/base1/cockpit.js:3693
+msgid "Login failed"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:200
+msgid "Login/password or activation key required to register."
+msgstr ""
+
+#: pkg/systemd/logs.html:59 pkg/kubernetes/views/container-panel.html:6
+#: pkg/kubernetes/views/container-page-inline.html:8
+msgid "Logs"
+msgstr ""
+
+#: pkg/dashboard/index.html:110
+msgid "Lost connection. Trying to reconnect"
+msgstr "Bağlantı koptu. Tekrar bağlanmaya çalışıyor"
+
+#: pkg/docker/index.html:184
+#, fuzzy
+msgid "MAC Address:"
+msgstr "Adres"
+
+#: pkg/networkmanager/interfaces.js:1833
+msgid "MII (Recommended)"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2477
+msgid "MTU"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:4139
+#, fuzzy
+msgid "MTU must be a positive number"
+msgstr "Boyut belirtilmeli"
+
+#: pkg/systemd/index.html:85 pkg/kubernetes/views/node-body.html:15
+msgid "Machine ID"
+msgstr ""
+
+#: pkg/systemd/index.html:282
+msgid "Machine SSH Key Fingerprints"
+msgstr ""
+
+#: pkg/shell/indexes.js:253
+msgid "Machines"
+msgstr "Makineler"
+
+#: pkg/kubernetes/scripts/dashboard.js:460
+msgid "Manifest"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
+msgid "Manual"
+msgstr "Elle"
+
+#: pkg/systemd/index.html:401 pkg/systemd/index.html:405
+#, fuzzy
+msgid "Manually"
+msgstr "Elle"
+
+#: pkg/storaged/jobs.js:140
+msgid "Marking $target as faulty"
+msgstr ""
+
+#: pkg/systemd/init.js:546
+msgid "Mask"
+msgstr ""
+
+#: pkg/systemd/init.js:547
+msgid "Mask Forcefully"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2483
+msgid "Master"
+msgstr "Ana"
+
+#: pkg/networkmanager/interfaces.js:2581
+msgid "Maximum message age $max_age"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:34
+msgid "Medium"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:92
+msgid "Member of"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:16
+#: pkg/kubernetes/views/project-listing.html:55
+#: pkg/networkmanager/index.html:291
+msgid "Members"
+msgstr "Üyeler"
+
+#: pkg/kubernetes/views/project-page.html:29
+#: pkg/kubernetes/views/user-panel.html:11
+#: pkg/kubernetes/views/user-panel.html:27
+#: pkg/kubernetes/views/user-body.html:4
+msgid "Membership"
+msgstr ""
+
+#: pkg/dashboard/index.html:71 pkg/playground/translate.html:91
+msgid "Memory"
+msgstr "Bellek"
+
+#: pkg/systemd/host.js:1466
+msgctxt "page-title"
+msgid "Memory"
+msgstr "Bellek"
+
+#: pkg/kubernetes/scripts/nodes.js:716
+msgid "Memory Utilization: $0%"
+msgstr ""
+
+#: pkg/docker/index.html:473 pkg/docker/index.html:652
+msgid "Memory limit"
+msgstr "Bellek limiti"
+
+#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
+msgid "Message"
+msgstr ""
+
+#: pkg/systemd/host.js:1300
+msgid "Message to logged in users"
+msgstr "Giriş yapmış kullanıcılara mesaj"
+
+#: pkg/kubernetes/views/image-panel.html:15
+#: pkg/kubernetes/views/imagestream-page.html:21
+#: pkg/kubernetes/views/image-page.html:22
+msgid "Metadata"
+msgstr ""
+
+#: pkg/docker/index.html:487 pkg/docker/index.html:666
+msgid "MiB"
+msgstr ""
+
+#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
+msgid "Minute needs to be a number between 0-59"
+msgstr ""
+
+#: pkg/systemd/services.html:407
+#, fuzzy
+msgid "Minutes"
+msgstr "5 dakika"
+
+#: pkg/networkmanager/index.html:299
+msgid "Mode"
+msgstr "Mod"
+
+#: pkg/storaged/index.html:421
+msgctxt "storage"
+msgid "Model"
+msgstr "Model"
+
+#: pkg/kubernetes/views/user-modify.html:31
+msgid "Modify"
+msgstr ""
+
+#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
+msgid "Modifying $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:323
+msgid "Monitoring Interval"
+msgstr "İzleme Sıklığı"
+
+#: pkg/networkmanager/index.html:332
+msgid "Monitoring Targets"
+msgstr "İzleme Hedefleri"
+
+#: pkg/kubernetes/views/volume-body.html:54
+#, fuzzy
+msgid "Monitors"
+msgstr "ARP İzleme"
+
+#: pkg/realmd/operation.js:366
+msgid "More"
+msgstr "Daha fazla"
+
+#: pkg/storaged/details.js:1099
+msgid "Mount"
+msgstr "Bağla"
+
+#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
+#, fuzzy
+msgid "Mount Location"
+msgstr "Bağlama Seçenekleri"
+
+#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
+msgid "Mount Options"
+msgstr "Bağlama Seçenekleri"
+
+#: pkg/storaged/index.html:231
+msgid "Mount Point"
+msgstr "Bağlama Noktası"
+
+#: pkg/docker/index.html:540
+msgid "Mount container volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
+msgid "Mounting"
+msgstr ""
+
+#: pkg/storaged/jobs.js:126
+msgid "Mounting $target"
+msgstr ""
+
+#: pkg/storaged/index.html:508
+#, fuzzy
+msgctxt "storage"
+msgid "Multipathed Devices"
+msgstr "Diğer Aygıtlar"
+
+#: pkg/kubernetes/scripts/volumes.js:860
+#, fuzzy
+msgid "NFS"
+msgstr "DNS"
+
+#: pkg/kubernetes/scripts/volumes.js:199
+#, fuzzy
+msgid "NFS Mount"
+msgstr "Bağla"
+
+#: pkg/networkmanager/interfaces.js:1856
+msgid "NSNA Ping"
+msgstr ""
+
+#: pkg/storaged/details.js:182
+msgid "NTFS - Compatible with most systems"
+msgstr "NTFS - Çoğu sistemle uyumlu"
+
+#: pkg/systemd/host.js:1250
+msgid "NTP Server"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/project-modify.html:16
+#: pkg/kubernetes/views/node-add.html:16
+#: pkg/kubernetes/views/volumes-page.html:19
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/image-body.html:2
+#: pkg/kubernetes/views/imagestream-modify.html:10
+#: pkg/kubernetes/views/service-modify.html:9
+#: pkg/kubernetes/views/dashboard-page.html:156
+#: pkg/kubernetes/views/dashboard-page.html:198
+#: pkg/kubernetes/views/details-page.html:34
+#: pkg/kubernetes/views/details-page.html:70
+#: pkg/kubernetes/views/details-page.html:103
+#: pkg/kubernetes/views/details-page.html:137
+#: pkg/kubernetes/views/details-page.html:171
+#: pkg/kubernetes/views/pv-claim.html:4
+#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/kubernetes/views/project-listing.html:14
+#: pkg/kubernetes/views/project-listing.html:53
+#: pkg/kubernetes/views/project-listing.html:90
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/volume-body.html:31 pkg/storaged/index.html:230
+#: pkg/networkmanager/index.html:95 pkg/networkmanager/index.html:113
+#: pkg/networkmanager/index.html:150 pkg/networkmanager/index.html:183
+#: pkg/networkmanager/index.html:282 pkg/networkmanager/index.html:364
+msgid "Name"
+msgstr "İsim"
 
 #: pkg/storaged/utils.js:129
 #, fuzzy
@@ -1709,373 +3280,1239 @@ msgstr "İsim 127 karakterden uzun olamaz"
 msgid "Name cannot contain whitespace."
 msgstr "İsim 127 karakterden uzun olamaz"
 
-#: pkg/storaged/utils.js:157
-msgid "$name (from $host)"
+#: pkg/kubernetes/views/service-body.html:5
+#: pkg/kubernetes/views/replicationcontroller-body.html:5
+#: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/pod-body.html:5
+#: pkg/kubernetes/views/dashboard-page.html:160
+#: pkg/kubernetes/views/details-page.html:36
+#: pkg/kubernetes/views/details-page.html:72
+#: pkg/kubernetes/views/details-page.html:105
+#: pkg/kubernetes/views/details-page.html:139
+#: pkg/kubernetes/views/details-page.html:173
+#: pkg/kubernetes/views/pv-claim.html:6
+#: pkg/kubernetes/views/containers-listing.html:14
+#: pkg/kubernetes/views/route-body.html:5
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
+msgid "Namespace"
 msgstr ""
 
-#: pkg/storaged/utils.js:166
-msgid "Pool for Thin Logical Volumes"
+#: pkg/kubernetes/scripts/dashboard.js:374
+msgid "Namespace cannot be empty."
 msgstr ""
 
-#: pkg/storaged/utils.js:168
-msgid "Thin Logical Volume"
+#: pkg/systemd/host.js:1113
+msgid "Need at least one NTP server"
 msgstr ""
 
-#: pkg/storaged/utils.js:170
-msgid "Logical Volume (Snapshot)"
+#: pkg/dashboard/index.html:72 pkg/playground/translate.html:96
+msgid "Network"
+msgstr "Ağ"
+
+#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:485
+msgid "Networking"
 msgstr ""
 
-#: pkg/storaged/utils.js:172
-msgid "Logical Volume"
-msgstr "Mantıksal Bölüm"
-
-#: pkg/storaged/utils.js:212
-msgid "<span>Encrypted Logical Volume of $0</span>"
+#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
+msgctxt "page-title"
+msgid "Networking"
 msgstr ""
 
-#: pkg/storaged/utils.js:214
-msgid "<span>Encrypted Partition of $0</span>"
+#: pkg/networkmanager/index.html:124
+msgid "Networking Logs"
 msgstr ""
 
-#: pkg/storaged/utils.js:216
-msgid "<span>Logical Volume of $0</span>"
+#: pkg/users/local.js:841
+msgid "Never"
+msgstr "Asla"
+
+#: pkg/kubernetes/views/project-listing.html:46
+msgid "New Group"
 msgstr ""
 
-#: pkg/storaged/utils.js:218
-msgid "<span>Partition of $0</span>"
+#: pkg/users/index.html:236 pkg/shell/index.html:255
+msgid "New Password"
+msgstr "Yeni Parola"
+
+#: pkg/kubernetes/views/project-listing.html:7
+msgid "New Project"
 msgstr ""
 
-#: pkg/storaged/utils.js:220
-msgid "<span>Encrypted $0</span>"
+#: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/image-listing.html:7
+msgid "New image stream"
 msgstr ""
 
-#: pkg/storaged/utils.js:233
-msgid "RAID Device $0"
+#: pkg/users/local.js:120 pkg/lib/credentials.js:231
+msgid "New password was not accepted"
+msgstr "Yeni parola kabul edilmedi"
+
+#: pkg/kubernetes/views/project-modify.html:4
+#: pkg/kubernetes/views/registry-dashboard-page.html:9
+#: pkg/kubernetes/views/registry-dashboard-page.html:48
+msgid "New project"
 msgstr ""
 
-#: pkg/storaged/utils.js:239
-msgid "Volume Group $0"
-msgstr ""
+#: pkg/realmd/operation.html:91
+msgid "Next"
+msgstr "Sonraki"
 
-#: pkg/storaged/jobs.js:119
-msgid "SMART self-test of $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:120
-msgid "Ejecting $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:121
-msgid "Unlocking $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:122
-msgid "Locking $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
-msgid "Modifying $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:124
-msgid "Starting swapspace $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:125
-msgid "Stopping swapspace $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:126
-msgid "Mounting $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:127
-msgid "Unmounting $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:129
-msgid "Erasing $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:130
-msgid "Creating filesystem on $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:131
-msgid "Setting up loop device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
-msgid "Deleting $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:134
-msgid "Creating partition $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:135
-msgid "Cleaning up for $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:136
-msgid "Securely erasing $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:137
-msgid "Very securely erasing $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:138
-msgid "Stopping RAID Device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:139
-msgid "Starting RAID Device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:140
-msgid "Marking $target as faulty"
-msgstr ""
-
-#: pkg/storaged/jobs.js:141
-msgid "Removing $target from RAID Device"
-msgstr ""
-
-#: pkg/storaged/jobs.js:142
-msgid "Creating RAID Device $target"
-msgstr ""
-
-#: pkg/storaged/jobs.js:143
+#: pkg/systemd/init.js:272
 #, fuzzy
-msgid "Checking RAID Device $target"
-msgstr "RAID Yarat"
+msgid "Next Run"
+msgstr "Sonraki"
 
-#: pkg/storaged/jobs.js:144
-msgid "Checking and Repairing RAID Device $target"
+#: pkg/systemd/index.html:233
+msgid "Nice"
+msgstr "Nice"
+
+#: pkg/docker/index.html:563 pkg/docker/index.html:567
+msgid "No"
+msgstr "Hayır"
+
+#: pkg/systemd/index.html:469
+msgid "No Delay"
+msgstr "Gecikme yok"
+
+#: pkg/ostree/index.html:220
+msgid "No Deployments"
 msgstr ""
 
-#: pkg/storaged/jobs.js:145
-msgid "Recovering RAID Device $target"
+#: pkg/storaged/details.js:185
+msgid "No Filesystem"
+msgstr "Dosya sistemi yok"
+
+#: pkg/ostree/app.js:101
+msgid "No OSTree deployments found"
 msgstr ""
 
-#: pkg/storaged/jobs.js:146
-msgid "Synchronizing RAID Device $target"
+#: src/ws/cockpitcertificate.c:398
+msgid "No PEM-encoded certificate found"
+msgstr "PEM-şifreli sertifika bulunamadı"
+
+#: src/ws/cockpitcertificate.c:364
+msgid "No PEM-encoded private key found"
+msgstr "PEM-şifreli özel anahtar bulunamadı"
+
+#: pkg/kubernetes/views/pv-claim.html:39
+msgid "No Pods are using this claim"
 msgstr ""
 
-#: pkg/storaged/jobs.js:148
-msgid "Activating $target"
+#: pkg/selinux/setroubleshoot-view.jsx:479
+msgid "No SELinux alerts."
 msgstr ""
 
-#: pkg/storaged/jobs.js:149
-msgid "Deactivating $target"
+#: pkg/kubernetes/views/pvc-body.html:10
+msgid "No Volume Bound"
 msgstr ""
 
-#: pkg/storaged/jobs.js:150
-msgid "Creating snapshot of $target"
+#: pkg/docker/storage.jsx:194
+msgid "No additional local storage found."
 msgstr ""
 
-#: pkg/storaged/jobs.js:151
-msgid "Creating volume group $target"
+#: pkg/docker/run.js:350
+msgid "No alias specified"
 msgstr ""
 
-#: pkg/storaged/jobs.js:152
-msgid "Deleting volume group $target"
+#: pkg/sosreport/index.js:115
+msgid "No archive has been created."
 msgstr ""
 
-#: pkg/storaged/jobs.js:153
-msgid "Adding physical volume to $target"
+#: pkg/networkmanager/interfaces.js:1326
+msgid "No carrier"
+msgstr "Taşıyıcı yok"
+
+#: pkg/docker/run.js:384
+msgid "No container specified"
 msgstr ""
 
-#: pkg/storaged/jobs.js:154
-msgid "Removing physical volume from $target"
+#: pkg/storaged/index.html:193
+msgid "No drives attached"
 msgstr ""
 
-#: pkg/storaged/jobs.js:155
-msgid "Emptying $target"
+#: pkg/kubernetes/views/project-listing.html:74
+msgid "No groups are present."
 msgstr ""
 
-#: pkg/storaged/jobs.js:156
-msgid "Creating logical volume $target"
+#: pkg/systemd/index.html:28
+#, fuzzy
+msgid "No host keys found."
+msgstr "Bulunamadı"
+
+#: pkg/storaged/index.html:158
+msgid "No iSCSI targets set up"
 msgstr ""
 
-#: pkg/storaged/jobs.js:157
-msgid "Renaming $target"
+#: pkg/kubernetes/views/image-listing.html:70
+msgid "No image streams are present."
 msgstr ""
 
-#: pkg/storaged/jobs.js:158
-msgid "Resizing $target"
+#: pkg/kubernetes/views/registry-dashboard-page.html:80
+msgid "No images pushed"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:223
+#, fuzzy
+msgid "No installed products on the system."
+msgstr "Docker sistemde yüklü ya da aktif değil"
+
+#: pkg/storaged/index.html:446
+msgid "No media inserted"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:384
+msgid ""
+"No metadata file was selected. Please select a Kubernetes metadata file."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:117
+msgid "No nodes in cluster"
+msgstr ""
+
+#: pkg/storaged/details.js:352
+msgid "No partitioning"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:40
+msgid "No pods deployed"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:6
+msgid "No pods replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/node-capacity.html:11
+msgid "No pods scheduled"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:10
+msgid "No pods selected"
+msgstr ""
+
+#: pkg/kubernetes/views/project-listing.html:37
+msgid "No projects are present."
+msgstr ""
+
+#: pkg/users/local.js:405
+msgid "No real name specified"
+msgstr "Gerçek ad belirtilmedi"
+
+#: pkg/storaged/index.html:87
+msgid "No storage set up as RAID"
+msgstr ""
+
+#: pkg/lib/credentials.js:182
+msgid "No such file or directory"
+msgstr "Böyle bir dosya ya da dizin yok"
+
+#: pkg/users/local.js:400
+msgid "No user name specified"
+msgstr "Kullanıcı adı belirtilmedi"
+
+#: pkg/kubernetes/views/project-listing.html:112
+#, fuzzy
+msgid "No users are present."
+msgstr "Kullanıcı adı belirtilmedi"
+
+#: pkg/storaged/index.html:120
+msgid "No volume groups created"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:44
+msgid "No volumes are present."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:73
+msgid "No volumes in use"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:18 pkg/kubernetes/views/node-panel.html:7
+#: pkg/kubernetes/views/containers-listing.html:15
+#: pkg/kubernetes/views/node-page.html:14
+#: pkg/kubernetes/views/topology-page.html:41
+msgid "Node"
+msgstr "Düğüm"
+
+#: pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:192
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:45
+msgid "Nodes"
+msgstr "Düğümler"
+
+#: pkg/kubernetes/views/topology-page.html:42
+msgid "Nodes are the machines that run your containers."
+msgstr "Düğümler, konteynerlerinizi çalıştıran makinelerdir."
+
+#: pkg/kubernetes/views/service-body.html:15
+#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
+#: pkg/kubernetes/views/image-config.html:25
+#: pkg/kubernetes/views/imagestream-body.html:33
+msgid "None"
+msgstr "Hiçbiri"
+
+#: pkg/playground/translate.html:30 pkg/kubernetes/views/details-page.html:53
+#: pkg/kubernetes/views/node-body.html:42
+msgid "Not Ready"
+msgstr "Hazır değil"
+
+#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
+msgid "Not a valid number of replicas"
+msgstr ""
+
+#: pkg/lib/credentials.js:248
+msgid "Not a valid private key"
+msgstr "Geçerli bir özel anahtar değil"
+
+#: pkg/kubernetes/scripts/details.js:546
+msgid "Not a valid value for Host"
+msgstr ""
+
+#: pkg/docker/index.html:57
+msgid "Not authorized to access Docker on this system"
+msgstr "Bu sistem üzerinde Docker'e erişim yetkisi yok"
+
+#: pkg/ostree/app.js:81
+msgid "Not authorized to update software on this system"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:805
+msgid "Not available"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot.js:238
+msgid "Not connected"
+msgstr "Bağlı değil"
+
+#: pkg/kubernetes/views/details-page.html:122
+msgid "Not deployed"
+msgstr ""
+
+#: pkg/docker/details.js:177 pkg/docker/image.js:112
+#: pkg/storaged/details.js:1822
+msgid "Not found"
+msgstr "Bulunamadı"
+
+#: src/base1/cockpit.js:3691
+msgid "Not permitted to perform this action."
+msgstr ""
+
+#: pkg/storaged/details.js:1574
+msgid "Not running"
+msgstr "Çalışmıyor"
+
+#: pkg/systemd/index.html:62
+msgid "Not synchronized"
+msgstr ""
+
+#: pkg/systemd/services.html:299
+msgid "Note"
+msgstr ""
+
+#: pkg/systemd/logs.html:49
+msgid "Notices"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:13
+msgid "OS"
+msgstr ""
+
+#: pkg/ostree/client.js:500
+msgid "OS $0 not found"
+msgstr ""
+
+#: pkg/kubernetes/views/nodes-page.html:19
+#, fuzzy
+msgid "OS Versions"
+msgstr "Sürüm"
+
+#: pkg/ostree/app.js:83
+msgid "OSTree is not available on this system"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:405
+msgid "Occurred $0"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:400
+msgid "Occurred between $0 and $1"
+msgstr ""
+
+#: pkg/systemd/index.html:157 pkg/playground/jquery-patterns.html:95
+#: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:189
+#: pkg/storaged/index.html:565
+msgid "Off"
+msgstr "Kapalı"
+
+#: pkg/lib/cockpit-components-dialog.jsx:155
+msgid "Ok"
+msgstr ""
+
+#: pkg/users/index.html:226 pkg/shell/index.html:248
+msgid "Old Password"
+msgstr "Eski Parola"
+
+#: pkg/users/local.js:78 pkg/lib/credentials.js:213
+msgid "Old password not accepted"
+msgstr "Eski parola kabul edilmedi"
+
+#: pkg/systemd/index.html:153 pkg/playground/jquery-patterns.html:91
+#: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:185
+#: pkg/storaged/index.html:564
+msgid "On"
+msgstr "Açık"
+
+#: pkg/kubernetes/views/image-meta.html:7
+msgid "On Build"
+msgstr ""
+
+#: pkg/docker/index.html:568
+msgid "On Failure"
+msgstr ""
+
+#: pkg/docker/util.js:104
+msgid "On failure, retry $0 time"
+msgid_plural "On failure, retry $0 times"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/realmd/operation.html:71
+msgid "One Time Password"
+msgstr "Tek Seferlik Parola"
+
+#: pkg/systemd/init.js:1147
+msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
+msgstr ""
+
+#: pkg/shell/simple.html:28 pkg/shell/index.html:28 pkg/shell/stub.html:28
+msgid "Ooops!"
+msgstr "Tüh!"
+
+#: pkg/systemd/index.html:89 pkg/ostree/index.html:111
+#: pkg/kubernetes/views/nodes-page.html:42
+msgid "Operating System"
+msgstr ""
+
+#: pkg/ostree/index.html:186
+msgid "Operating System Updates"
 msgstr ""
 
 #: pkg/storaged/jobs.js:166
 msgid "Operation '$operation' on $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:180
-msgid "unknown target"
+#: pkg/storaged/overview.js:189
+msgctxt "storage"
+msgid "Optical Drive"
+msgstr "Optik Sürücü"
+
+#: pkg/kubernetes/views/volume-body.html:130
+msgid "Options"
+msgstr "Seçenekler"
+
+#: pkg/subscriptions/subscriptions-register.jsx:176
+msgid "Organization"
 msgstr ""
 
-#: pkg/storaged/permissions.js:61
-msgid "The user <b>$0</b> is not permitted to manage storage"
-msgstr ""
+#: pkg/storaged/details.js:1253
+msgctxt "storage-id-desc"
+msgid "Other Data"
+msgstr "Diğer Veri"
 
-#: pkg/realmd/operation.js:96
-msgid "Join"
-msgstr "Katıl"
+#: pkg/storaged/index.html:202
+msgid "Other Devices"
+msgstr "Diğer Aygıtlar"
 
-#: pkg/realmd/operation.js:101
-msgid "Leave"
-msgstr "Ayrıl"
-
-#: pkg/realmd/operation.js:148
-msgid "Domain $0 could not be contacted"
-msgstr ""
-
-#: pkg/realmd/operation.js:220
-msgid "Domain $0 is not supported"
-msgstr ""
-
-#: pkg/realmd/operation.js:347
-msgid "Joining this domain is not supported"
-msgstr ""
-
-#: pkg/realmd/operation.js:366
-msgid "More"
-msgstr "Daha fazla"
-
-#: pkg/realmd/operation.js:417
-msgid "Cannot join a domain because realmd is not available on this system"
-msgstr ""
-
-#: pkg/realmd/operation.js:436
-msgid "The user <b>$0</b> is not permitted to modify realms"
-msgstr ""
-
-#: pkg/realmd/operation.js:453
-msgid "Join Domain"
-msgstr ""
-
-#: pkg/docker/run.js:246 pkg/docker/util.js:102
-#: pkg/networkmanager/interfaces.js:2280 pkg/kubernetes/scripts/volumes.js:992
-#: pkg/docker/index.html.h:46
-msgid "No"
-msgstr "Hayır"
-
-#: pkg/docker/run.js:261 pkg/docker/console.html.h:1
-#: pkg/kubernetes/views/image-panel.html.h:2
-#: pkg/kubernetes/views/container-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:1
-#: pkg/kubernetes/views/image-page.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:1
-msgid "Container"
-msgstr "Konteyner"
-
-#: pkg/docker/run.js:263 pkg/kubernetes/views/route-modify.html.h:2
-#: pkg/kubernetes/views/route-body.html.h:4
-#: pkg/kubernetes/views/details-page.html.h:12
-msgid "Host"
-msgstr "Host"
-
-#: pkg/docker/run.js:283
-msgid "Invalid port"
-msgstr "Geçersiz port"
-
-#: pkg/docker/run.js:293
-msgid "Duplicate port"
-msgstr ""
-
-#: pkg/docker/run.js:332
+#: pkg/docker/index.html:319 pkg/kubernetes/registry.html:42
+#: pkg/kubernetes/index.html:39
 #, fuzzy
-msgid "Command can't be empty"
-msgstr "İsim boş olamaz"
+msgid "Overview"
+msgstr "Servis"
 
-#: pkg/docker/run.js:350
-msgid "No alias specified"
-msgstr ""
+#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
+msgid "Overwrite existing data with zeros"
+msgstr "Mevcut veriyi sıfırlarla tekrar yaz"
 
-#: pkg/docker/run.js:360
-msgid "Duplicate alias"
-msgstr ""
-
-#: pkg/docker/run.js:384
-msgid "No container specified"
-msgstr ""
-
-#: pkg/docker/details.js:47 pkg/docker/image.js:43
-msgctxt "page-title"
-msgid "Containers"
-msgstr "Konteynerler"
-
-#: pkg/docker/details.js:144
-msgid "${hip}:${hport} -> $cport"
-msgstr ""
-
-#: pkg/docker/details.js:272 pkg/docker/containers-view.jsx:167
-msgid "Deleting a container will erase all data in it."
-msgstr "Bir konteyneri silmek içindeki veriyi de silecektir."
-
-#: pkg/docker/storage.jsx:156
+#: pkg/kubernetes/views/volume-body.html:4
 #, fuzzy
-msgid "Solid-State Disk"
-msgstr "SSD Disk"
+msgid "PD Name"
+msgstr "İsim"
 
-#: pkg/docker/storage.jsx:157
+#: pkg/ostree/index.html:100
+msgid "Packages"
+msgstr ""
+
+#: pkg/networkmanager/index.html:133
+msgid "Parent"
+msgstr "Ana"
+
+#: pkg/networkmanager/interfaces.js:2619
+msgid "Parent $parent"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1372
+msgid "Part of "
+msgstr "Parçası: "
+
+#: pkg/kubernetes/views/volume-body.html:8
+#: pkg/kubernetes/views/volume-body.html:18
+msgid "Partition"
+msgstr ""
+
+#: pkg/storaged/details.js:346
+msgid "Partitioning"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1848
+msgid "Passive"
+msgstr ""
+
+#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
+msgid "Passphrase"
+msgstr "Parola"
+
+#: pkg/storaged/details.js:224
 #, fuzzy
-msgid "Hard Disk"
-msgstr "Sabit Disk"
+msgid "Passphrase cannot be empty"
+msgstr "Parola boş olamaz"
 
-#: pkg/docker/storage.jsx:158 pkg/storaged/index.html.h:33
-msgid "Drive"
-msgstr "Sürücü"
+#: pkg/storaged/details.js:232
+msgid "Passphrases do not match"
+msgstr "Parolalar eşleşmiyor"
 
-#: pkg/docker/storage.jsx:188
+#: pkg/users/index.html:115 pkg/users/index.html:160 pkg/shell/index.html:199
+#: pkg/shell/index.html:212 pkg/kubernetes/views/auth-form.html:105
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+msgid "Password"
+msgstr "Parola"
+
+#: pkg/users/local.js:259
+msgid "Password is not acceptable"
+msgstr "Parola kabul edilebilir değil"
+
+#: pkg/users/local.js:247
+msgid "Password is too weak"
+msgstr "Parola çok güçsüz"
+
+#: pkg/lib/credentials.js:278
+msgid "Password not accepted"
+msgstr "Parola kabul edilmedi"
+
+#: pkg/kubernetes/views/pv-modify.html:126
+#: pkg/kubernetes/views/volume-body.html:37
+#: pkg/kubernetes/views/volume-body.html:49
+#: pkg/kubernetes/views/volume-body.html:101
+msgid "Path"
+msgstr ""
+
+#: pkg/networkmanager/index.html:259
+msgid "Path cost"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2601
+msgid "Path cost $path_cost"
+msgstr ""
+
+#: pkg/systemd/services.html:56
+msgid "Paths"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:53
+msgid "Pending Volume Claims"
+msgstr ""
+
+#: pkg/systemd/index.html:143
+msgid "Performance Profile"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:14
+msgid "Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-body.html:16
+msgid "Phase"
+msgstr ""
+
+#: pkg/storaged/index.html:641
+msgid "Physical Volumes"
+msgstr ""
+
+#: pkg/networkmanager/index.html:405
 #, fuzzy
-msgid "Local Disks"
-msgstr "Diskler"
+msgid "Ping Interval"
+msgstr "İzleme Sıklığı"
 
-#: pkg/docker/storage.jsx:194
-msgid "No additional local storage found."
+#: pkg/networkmanager/index.html:414
+#, fuzzy
+msgid "Ping Target"
+msgstr "İzleme Hedefleri"
+
+#: pkg/docker/containers-view.jsx:166 pkg/docker/details.js:271
+#: pkg/docker/image.js:151 pkg/storaged/details.js:625
+#: pkg/storaged/details.js:821 pkg/storaged/details.js:1016
+msgid "Please confirm deletion of $0"
 msgstr ""
 
-#: pkg/docker/storage.jsx:242
-msgid " (shared with the OS)"
+#: pkg/docker/util.js:501
+msgid "Please confirm forced deletion of $0"
 msgstr ""
 
-#: pkg/docker/storage.jsx:282
-msgid "Information about the Docker storage pool is not available."
+#: pkg/kubernetes/scripts/dashboard.js:441
+msgid "Please create another namespace for $0 \"$1\""
 msgstr ""
 
-#: pkg/docker/storage.jsx:314
-msgid "Total"
+#: pkg/kubernetes/scripts/volumes.js:574
+msgid "Please provide a GlusterFS volume name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:554
+msgid "Please provide a username"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:632
+msgid "Please provide a valid NFS server"
+msgstr ""
+
+#: pkg/kubernetes/scripts/connection.js:539
+#, fuzzy
+msgid "Please provide a valid address"
+msgstr "Bir adres girin"
+
+#: pkg/kubernetes/scripts/volumes.js:805
+msgid "Please provide a valid filesystem type"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:813
+msgid "Please provide a valid interface"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:797
+msgid "Please provide a valid logical unit number"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:477
+#, fuzzy
+msgid "Please provide a valid name"
+msgstr "Bir adres girin"
+
+#: pkg/kubernetes/scripts/dashboard.js:376
+msgid "Please provide a valid namespace."
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
+msgid "Please provide a valid path"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:789
+msgid "Please provide a valid qualified name"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:485
+msgid "Please provide a valid storage capacity."
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:781
+#, fuzzy
+msgid "Please provide a valid target"
+msgstr "Bir adres girin"
+
+#: pkg/kubernetes/scripts/volumes.js:469
+msgid "Please select a valid access mode"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:565
+msgid "Please select a valid endpoint"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:493
+msgid "Please select a valid policy option."
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:397
+msgid "Please type an address"
+msgstr "Bir adres girin"
+
+#: pkg/kubernetes/views/pod-page.html:12
+#: pkg/kubernetes/views/containers-listing.html:12
+#: pkg/kubernetes/views/topology-page.html:14
+msgid "Pod"
+msgstr "Pod"
+
+#: pkg/kubernetes/views/pod-body.html:20
+msgid "Pod Address"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:4
+#: pkg/kubernetes/views/service-endpoint.html:9
+msgid "Pod Endpoints"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:4
+msgid "Pod Replicated"
+msgstr ""
+
+#: pkg/kubernetes/views/service-endpoint.html:15
+#: pkg/kubernetes/views/replicationcontroller-pods.html:11
+msgid "Pod Selector"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:17
+#: pkg/kubernetes/views/dashboard-page.html:18
+#: pkg/kubernetes/views/details-page.html:166
+#: pkg/kubernetes/views/pv-claim.html:37
+#: pkg/kubernetes/views/replicationcontroller-panel.html:12
+msgid "Pods"
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:15
+msgid ""
+"Pods contain one or more containers that run                together on a "
+"node, containing your application code."
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:60
+#, fuzzy
+msgid "Pool Name"
+msgstr "Tam İsim"
+
+#: pkg/storaged/utils.js:166
+msgid "Pool for Thin Logical Volumes"
+msgstr ""
+
+#: pkg/storaged/details.js:874
+msgid "Pool for thinly provisioned volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:45
+msgid "Populate"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:23
+msgid "Port"
+msgstr ""
+
+#: pkg/docker/index.html:525 pkg/kubernetes/views/service-body.html:13
+#: pkg/kubernetes/views/image-config.html:23
+#: pkg/kubernetes/views/container-body.html:12
+#: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:373
+msgid "Ports"
+msgstr "Portlar"
+
+#: pkg/systemd/index.html:123
+msgid "Power Options"
+msgstr "Güç Seçenekleri"
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length"
+msgstr "Ön ek uzunluğu"
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length or Netmask"
+msgstr "Ön ek uzunluğu ya da ağ maskesi"
+
+#: pkg/networkmanager/interfaces.js:809
+msgid "Preparing"
+msgstr "Hazırlanıyor"
+
+#: pkg/systemd/init.js:544
+msgid "Preset"
+msgstr ""
+
+#: pkg/systemd/init.js:545
+msgid "Preset Forcefully"
+msgstr ""
+
+#: pkg/systemd/index.html:310
+msgid "Pretty Host Name"
+msgstr ""
+
+#: pkg/networkmanager/index.html:307
+msgid "Primary"
+msgstr "Öncelikli"
+
+#: pkg/storaged/details.js:1426
+msgid "Primary Partition"
+msgstr ""
+
+#: pkg/networkmanager/index.html:250 pkg/networkmanager/index.html:446
+#: pkg/networkmanager/index.html:464
+msgid "Priority"
+msgstr "Öncelik"
+
+#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
+msgid "Priority $priority"
+msgstr "Öncelik $priority"
+
+#: pkg/subscriptions/subscriptions-view.jsx:33
+msgid "Product ID"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:32
+msgid "Product name"
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:4
+#: pkg/kubernetes/views/replicationcontroller-body.html:4
+#: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/imagestream-modify.html:21
+#: pkg/kubernetes/views/pod-body.html:4
+#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/details-page.html:35
+#: pkg/kubernetes/views/details-page.html:71
+#: pkg/kubernetes/views/details-page.html:104
+#: pkg/kubernetes/views/details-page.html:138
+#: pkg/kubernetes/views/details-page.html:172
+#: pkg/kubernetes/views/containers-listing.html:13
+#: pkg/kubernetes/views/route-body.html:4
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
+msgid "Project"
+msgstr ""
+
+#: pkg/kubernetes/views/project-body.html:20
+msgid "Project Members"
+msgstr ""
+
+#: pkg/kubernetes/views/filter-project.html:5
+msgid "Project:"
+msgstr ""
+
+#: pkg/kubernetes/registry.html:54 pkg/kubernetes/views/group-delete.html:10
+#: pkg/kubernetes/views/project-listing.html:9
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:84
+msgid "Projects"
+msgstr ""
+
+#: pkg/users/local.js:82
+msgid "Prompting via passwd timed out"
+msgstr ""
+
+#: pkg/lib/credentials.js:251
+msgid "Prompting via ssh-add timed out"
+msgstr ""
+
+#: pkg/lib/credentials.js:191
+msgid "Prompting via ssh-keygen timed out"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-register.jsx:125
+msgid "Proxy"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:25
+msgid "Proxy Version"
+msgstr ""
+
+#: pkg/shell/index.html:198 pkg/lib/machine-auth-failed.html:9
+msgid "Public Key"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:150
+msgid "Pull an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:66
+msgid "Pull from"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:31
+msgid "Pull repository"
+msgstr ""
+
+#: pkg/storaged/details.js:869
+msgid "Purpose"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:140
+msgid "Push an image:"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:147
+#: pkg/kubernetes/views/volume-body.html:77
+#, fuzzy
+msgid "Qualified Name"
+msgstr "Tam İsim"
+
+#: pkg/storaged/details.js:1539
+msgid "RAID ($0)"
+msgstr "RAID ($0)"
+
+#: pkg/storaged/details.js:1533
+msgid "RAID 0"
+msgstr "RAID 0"
+
+#: pkg/storaged/overview.js:422
+msgid "RAID 0 (Stripe)"
+msgstr ""
+
+#: pkg/storaged/details.js:1534
+msgid "RAID 1"
+msgstr "RAID 1"
+
+#: pkg/storaged/overview.js:423
+msgid "RAID 1 (Mirror)"
+msgstr ""
+
+#: pkg/storaged/details.js:1538
+msgid "RAID 10"
+msgstr "RAID 10"
+
+#: pkg/storaged/overview.js:427
+msgid "RAID 10 (Stripe of Mirrors)"
+msgstr ""
+
+#: pkg/storaged/details.js:1535
+msgid "RAID 4"
+msgstr "RAID 4"
+
+#: pkg/storaged/overview.js:424
+msgid "RAID 4 (Dedicated Parity)"
+msgstr ""
+
+#: pkg/storaged/details.js:1536
+msgid "RAID 5"
+msgstr "RAID 5"
+
+#: pkg/storaged/overview.js:425
+msgid "RAID 5 (Distributed Parity)"
+msgstr ""
+
+#: pkg/storaged/details.js:1537
+msgid "RAID 6"
+msgstr "RAID 6"
+
+#: pkg/storaged/overview.js:426
+msgid "RAID 6 (Double Distributed Parity)"
+msgstr ""
+
+#: pkg/storaged/index.html:537
+msgid "RAID Device"
+msgstr "RAID Aygıtı"
+
+#: pkg/storaged/utils.js:233
+msgid "RAID Device $0"
+msgstr ""
+
+#: pkg/storaged/index.html:65
+msgid "RAID Devices"
+msgstr "RAID Aygıtları"
+
+#: pkg/storaged/overview.js:420
+msgid "RAID Level"
+msgstr "RAID Level"
+
+#: pkg/storaged/index.html:555
+msgctxt "storage"
+msgid "RAID Level"
+msgstr "RAID Seviyesi"
+
+#: pkg/storaged/details.js:1228
+msgctxt "storage-id-desc"
+msgid "RAID Member"
+msgstr "RAID Üyesi"
+
+#: pkg/kubernetes/scripts/volumes.js:200
+#, fuzzy
+msgid "Rados Block Device"
+msgstr "Blok Aygıtı"
+
+#: pkg/kubernetes/views/pv-modify.html:194
+#: pkg/kubernetes/views/volume-body.html:10
+#: pkg/kubernetes/views/volume-body.html:20
+#: pkg/kubernetes/views/volume-body.html:44
+#: pkg/kubernetes/views/volume-body.html:51
+#: pkg/kubernetes/views/volume-body.html:71
+#: pkg/kubernetes/views/volume-body.html:85
+#: pkg/kubernetes/views/volume-body.html:93
+#: pkg/kubernetes/views/volume-body.html:110
+#: pkg/kubernetes/views/volume-body.html:122
+#: pkg/kubernetes/views/volume-body.html:136
+#: pkg/kubernetes/views/volume-body.html:143
+#, fuzzy
+msgid "Read Only"
+msgstr "Hazır"
+
+#: pkg/kubernetes/scripts/volumes.js:211
+msgid "Read and write from a single node"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:213
+msgid "Read and write from multiple nodes"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:212
+msgid "Read only from multiple nodes"
+msgstr ""
+
+#: pkg/docker/index.html:385
+#, fuzzy
+msgid "ReadOnly"
+msgstr "Hazır"
+
+#: pkg/docker/index.html:384
+#, fuzzy
+msgid "ReadWrite"
+msgstr "Okunuyor"
+
+#: pkg/storaged/index.html:327
+msgid "Reading"
+msgstr "Okunuyor"
+
+#: pkg/playground/translate.html:20 pkg/playground/translate.html:179
+#: pkg/kubernetes/views/details-page.html:52
+#: pkg/kubernetes/views/node-body.html:41
+msgid "Ready"
+msgstr "Hazır"
+
+#: pkg/playground/translate.html:25
+#, fuzzy
+msgctxt "verb"
+msgid "Ready"
+msgstr "Hazır"
+
+#: pkg/systemd/index.html:319
+msgid "Real Host Name"
+msgstr "Gerçek Host İsmi"
+
+#: pkg/kubernetes/views/node-body.html:45
+msgid "Reason"
+msgstr ""
+
+#: pkg/lib/journal.js:241
+msgid "Reboot"
+msgstr ""
+
+#: pkg/networkmanager/index.html:75 pkg/networkmanager/index.html:98
+#: pkg/networkmanager/index.html:116 pkg/networkmanager/index.html:521
+#: pkg/networkmanager/index.html:551
+msgid "Receiving"
+msgstr ""
+
+#: pkg/ostree/client.js:56
+msgid "Receiving delta parts"
+msgstr ""
+
+#: pkg/ostree/client.js:58
+msgid "Receiving metadata objects"
+msgstr ""
+
+#: pkg/ostree/client.js:61
+msgid "Receiving objects: $0%"
+msgstr ""
+
+#: pkg/systemd/logs.html:40
+msgid "Recent"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:56 pkg/kubernetes/views/pv-body.html:6
+msgid "Reclaim Policy"
+msgstr ""
+
+#: pkg/shell/simple.html:144 pkg/shell/index.html:327 pkg/shell/stub.html:180
+msgid "Reconnect"
+msgstr ""
+
+#: pkg/storaged/details.js:1594
+msgid "Recovering"
+msgstr ""
+
+#: pkg/storaged/jobs.js:145
+msgid "Recovering RAID Device $target"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:219
+msgid "Recycle"
 msgstr ""
 
 #: pkg/docker/storage.jsx:348
 msgid "Reformat and add disks"
 msgstr ""
 
-#: pkg/docker/storage.jsx:355
-msgid ""
-"The storage pool will be reset to optimize its layout.  All containers will "
-"be erased."
+#: pkg/kubernetes/views/pv-modify.html:205
+msgid "Register"
 msgstr ""
 
-#: pkg/docker/storage.jsx:360
-msgid "Erase containers, reformat disks, and add them"
-msgstr ""
-
-#: pkg/docker/storage.jsx:363
-msgid "Add Additional Storage"
-msgstr ""
-
-#: pkg/docker/storage.jsx:366
-msgid ""
-"All data on selected disks will be erased and disks will be added to the "
-"storage pool."
-msgstr ""
-
-#: pkg/docker/storage.jsx:404
+#: pkg/kubernetes/views/volumes-page.html:12
 #, fuzzy
-msgid "Could not add all disks"
-msgstr "Servisler listelenemedi"
+msgid "Register New Volume"
+msgstr "Mantıksal Bölümü Yeniden Boyurlandır"
+
+#: pkg/kubernetes/views/pv-modify.html:4
+msgid "Register Persistent Volume"
+msgstr ""
+
+#: pkg/subscriptions/main.js:74
+msgid "Register system"
+msgstr ""
+
+#: pkg/ostree/index.html:115
+msgid "Released"
+msgstr ""
+
+#: pkg/systemd/init.js:518
+msgid "Reload"
+msgstr ""
+
+#: pkg/systemd/init.js:519
+msgid "Reload or Restart"
+msgstr ""
+
+#: pkg/systemd/init.js:521
+msgid "Reload or Try Restart"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-modify.html:89
+msgid "Remote registry is insecure"
+msgstr ""
+
+#: cockpit.desktop.in.h:3
+msgid "Remote;Administration;"
+msgstr "Uzak;Yönetim;"
+
+#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
+msgctxt "storage"
+msgid "Removable Drive"
+msgstr "Çıkarılabilir Disk"
+
+#: pkg/ostree/index.html:123 pkg/ostree/index.html:146
+msgid "Removals"
+msgstr ""
+
+#: pkg/kubernetes/views/user-group-remove.html:10
+#: pkg/kubernetes/views/group-delete.html:21
+#: pkg/kubernetes/views/user-delete.html:25
+#: pkg/kubernetes/views/remove-role-dialog.html:8
+msgid "Remove"
+msgstr "Kaldır"
+
+#: pkg/networkmanager/interfaces.js:2791
+#, fuzzy
+msgid "Remove $0"
+msgstr "Kaldır"
+
+#: pkg/kubernetes/views/group-delete.html:3
+#, fuzzy
+msgid "Remove Group"
+msgstr "Kaldır"
+
+#: pkg/kubernetes/views/user-group-remove.html:3
+#, fuzzy
+msgid "Remove Member"
+msgstr "RAID Üyesi"
+
+#: pkg/kubernetes/views/remove-role-dialog.html:3
+#, fuzzy
+msgid "Remove Role"
+msgstr "Kaldır"
+
+#: pkg/kubernetes/views/user-delete.html:3
+#, fuzzy
+msgid "Remove User"
+msgstr "Kaldır"
+
+#: pkg/kubernetes/views/image-delete.html:3
+msgid "Remove image tag"
+msgstr ""
+
+#: pkg/kubernetes/views/user-remove-membership.html:3
+msgid "Remove membership"
+msgstr ""
+
+#: pkg/storaged/jobs.js:141
+msgid "Removing $target from RAID Device"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2788
+msgid "Removing <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:154
+msgid "Removing physical volume from $target"
+msgstr ""
+
+#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
+#: pkg/storaged/details.js:1775
+msgid "Rename"
+msgstr "Yeniden İsimlendir"
+
+#: pkg/storaged/details.js:795
+msgid "Rename Volume Group"
+msgstr ""
+
+#: pkg/storaged/details.js:706
+msgid "Renamee Logical Volume"
+msgstr "Mantıksal Bölümü Yeniden İsimlendir"
+
+#: pkg/storaged/jobs.js:157
+msgid "Renaming $target"
+msgstr ""
+
+#: pkg/systemd/services.html:432
+msgid "Repeat Daily"
+msgstr ""
+
+#: pkg/systemd/services.html:431
+msgid "Repeat Hourly"
+msgstr ""
+
+#: pkg/systemd/services.html:434
+msgid "Repeat Monthly"
+msgstr ""
+
+#: pkg/systemd/services.html:433
+msgid "Repeat Weekly"
+msgstr ""
+
+#: pkg/systemd/services.html:435
+msgid "Repeat Yearly"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-body.html:9
+#: pkg/kubernetes/views/details-page.html:141
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
+#: pkg/kubernetes/views/replicationcontroller-modify.html:8
+msgid "Replicas"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:14
+#: pkg/kubernetes/views/replicationcontroller-panel.html:10
+#: pkg/kubernetes/views/topology-page.html:23
+msgid "Replication Controller"
+msgstr "Replikasyon Kontrolörü"
+
+#: pkg/kubernetes/views/details-page.html:132
+msgid "Replication Controllers"
+msgstr "Replikasyon Kontrolörleri"
+
+#: pkg/kubernetes/views/topology-page.html:24
+msgid ""
+"Replication controllers dynamically create instances of                pods "
+"from templates, and remove pods when necessary."
+msgstr ""
+
+#: pkg/docker/index.html:718
+msgid "Repository"
+msgstr "Depo"
+
+#: pkg/kubernetes/views/volume-body.html:24
+#, fuzzy
+msgid "Repository URL"
+msgstr "Depo"
+
+#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
+msgid "Requested"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:13
+msgid "Requests"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:54
+#, fuzzy
+msgid "Requires Authentication"
+msgstr "Yetkilendirme"
+
+#: pkg/docker/index.html:323
+msgid "Reset"
+msgstr ""
 
 #: pkg/docker/storage.jsx:417
 #, fuzzy
@@ -2088,380 +4525,611 @@ msgid ""
 "the pool."
 msgstr ""
 
-#: pkg/docker/storage.jsx:423
-msgid "Erase containers and reset storage pool"
+#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
+msgid "Resize"
+msgstr "Yeniden Boyutlandır"
+
+#: pkg/storaged/details.js:673
+msgid "Resize Filesystem"
+msgstr "Dosya Sistemini Yeniden Boyutlandır"
+
+#: pkg/storaged/details.js:661
+msgid "Resize Logical Volume"
+msgstr "Mantıksal Bölümü Yeniden Boyurlandır"
+
+#: pkg/storaged/jobs.js:158
+msgid "Resizing $target"
 msgstr ""
 
-#: pkg/docker/storage.jsx:446
-msgid "Could not reset the storage pool"
+#: pkg/systemd/index.html:126 pkg/systemd/index.html:133
+msgid "Restart"
+msgstr "Yeniden başlat"
+
+#: pkg/kubernetes/views/container-body.html:20
+msgid "Restart Count"
 msgstr ""
 
-#: pkg/docker/storage.jsx:482
+#: pkg/docker/index.html:558 pkg/kubernetes/views/pod-body.html:10
+msgid "Restart Policy"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:217
+msgid "Retain"
+msgstr ""
+
+#: pkg/docker/index.html:574
+msgid "Retries:"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:188
+msgid "Retrieving subscription status..."
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:26
 #, fuzzy
-msgid "You don't have permission to manage the Docker storage pool."
+msgid "Revision"
+msgstr "Sürüm"
+
+#: pkg/users/index.html:94 pkg/kubernetes/views/add-member-role-dialog.html:39
+#: pkg/kubernetes/views/project-body.html:21
+msgid "Roles"
+msgstr "Roller"
+
+#: pkg/ostree/index.html:73
+msgid "Roll back and reboot"
 msgstr ""
-"Bu hesabın yetkilendirilmiş açık anahtarlarını görmeniz için izniniz yok."
 
-#: pkg/docker/storage.jsx:485
-msgid "The Docker storage pool cannot be managed on this system."
+#: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
+msgid "Round Robin"
+msgstr "Round Robin"
+
+#: pkg/kubernetes/views/route-page.html:14
+#: pkg/kubernetes/views/route-panel.html:9
+#, fuzzy
+msgid "Route"
+msgstr "Yönlendirmeler"
+
+#: pkg/kubernetes/views/details-page.html:65
+msgid "Routes"
+msgstr "Yönlendirmeler"
+
+#: pkg/systemd/services.html:384
+#, fuzzy
+msgid "Run"
+msgstr "Çalışıyor"
+
+#: pkg/kubernetes/views/image-config.html:4
+msgid "Run as"
 msgstr ""
 
-#: pkg/docker/image.js:77
-msgid "Image $0"
-msgstr "Kalıp $0"
+#: pkg/networkmanager/index.html:381
+#, fuzzy
+msgid "Runner"
+msgstr "Çalışıyor"
 
-#: pkg/docker/image.js:152
+#: pkg/ostree/index.html:83
+msgid "Running"
+msgstr "Çalışıyor"
+
+#: pkg/selinux/setroubleshoot-view.jsx:478
+msgid "SELinux Access Control Errors"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:330
+msgid "SELinux Policy"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot.html:23
+msgid "SELinux Troubleshoot"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:317
+msgid "SELinux is disabled on the system."
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:309
+msgid "SELinux system status is unknown."
+msgstr ""
+
+#: pkg/storaged/jobs.js:119
+msgid "SMART self-test of $target"
+msgstr ""
+
+#: pkg/networkmanager/index.html:218
+msgid "STP Forward delay"
+msgstr ""
+
+#: pkg/networkmanager/index.html:227
+msgid "STP Hello time"
+msgstr ""
+
+#: pkg/networkmanager/index.html:236
+msgid "STP Maximum message age"
+msgstr ""
+
+#: pkg/networkmanager/index.html:209
+msgid "STP Priority"
+msgstr "STP Önceliği"
+
+#: pkg/systemd/services.html:466
+msgid "Save"
+msgstr ""
+
+#: pkg/ostree/client.js:66
+msgid "Scanning metadata"
+msgstr ""
+
+#: pkg/kubernetes/views/node-capacity.html:9
+msgid "Scheduled Pods"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:322
+msgid "Scheduling Disabled"
+msgstr ""
+
+#: pkg/systemd/services.html:402 pkg/systemd/services.html:406
+msgid "Seconds"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:195
+msgid "Secret"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:106
+#, fuzzy
+msgid "Secret File"
+msgstr "Aygıt dosyası"
+
+#: pkg/kubernetes/views/volume-body.html:141
+#, fuzzy
+msgid "Secret Name"
+msgstr "Kullanıcı Adı"
+
+#: pkg/kubernetes/views/volume-body.html:69
+#: pkg/kubernetes/views/volume-body.html:108
+#: pkg/kubernetes/views/volume-body.html:134
+#, fuzzy
+msgid "Secret Volume"
+msgstr "Volume Grubu Yarat"
+
+#: pkg/systemd/index.html:93
+msgid "Secure Shell Keys"
+msgstr ""
+
+#: pkg/storaged/jobs.js:136
+msgid "Securely erasing $target"
+msgstr ""
+
+#: pkg/kubernetes/views/file-button.html:4
+msgid "Select Manifest File..."
+msgstr ""
+
+#: pkg/kubernetes/views/topology-page.html:7
+msgid "Select an object to see more details."
+msgstr "Daha fazla ayrıntı için bir obje seçin."
+
+#: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Deleting an image will delete it, but you can probably download it again if "
-"you need it later.  Unless this image has never been pushed to a repository, "
-"that is, in which case you probably can't download it again."
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
-#: pkg/docker/util.js:94
-msgid "Up since $StartedAt"
+#: pkg/networkmanager/index.html:69 pkg/networkmanager/index.html:97
+#: pkg/networkmanager/index.html:115 pkg/networkmanager/index.html:515
+#: pkg/networkmanager/index.html:550
+msgid "Sending"
 msgstr ""
 
-#: pkg/docker/util.js:96
-msgid "Exited $ExitCode"
-msgstr ""
+#: pkg/storaged/index.html:432
+msgctxt "storage"
+msgid "Serial Number"
+msgstr "Seri Numarası"
 
-#: pkg/docker/util.js:104
-msgid "On failure, retry $0 time"
-msgid_plural "On failure, retry $0 times"
-msgstr[0] ""
-msgstr[1] ""
-
-#: pkg/docker/util.js:107 pkg/docker/index.html.h:48
-msgid "Always"
-msgstr ""
-
-#: pkg/docker/util.js:109 pkg/docker/index.html.h:49
+#: pkg/kubernetes/views/pv-modify.html:82
+#: pkg/kubernetes/views/volume-body.html:47
 #, fuzzy
-msgid "Unless Stopped"
-msgstr "Durduruldu"
+msgid "Server"
+msgstr "Servis"
 
-#: pkg/docker/util.js:123
-msgid "default"
-msgstr "ön tanımlı"
+#: pkg/storaged/overview.js:518
+msgid "Server Address"
+msgstr ""
 
-#: pkg/docker/util.js:124
-msgid "$0 shares"
+#: pkg/users/local.js:682 pkg/users/local.js:683
+msgid "Server Administrator"
+msgstr "Sunucu Yöneticisi"
+
+#: pkg/storaged/overview.js:521
+#, fuzzy
+msgid "Server address cannot be empty."
+msgstr "İsim boş olamaz"
+
+#: src/base1/cockpit.js:3709
+msgid "Server has closed the connection."
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:12
+#: pkg/kubernetes/views/service-panel.html:8
+#: pkg/kubernetes/views/topology-page.html:32
+msgid "Service"
+msgstr "Servis"
+
+#: pkg/kubernetes/views/pod-body.html:12
+msgid "Service Account"
+msgstr ""
+
+#: pkg/systemd/services.html:279
+msgid "Service Logs"
+msgstr ""
+
+#: pkg/systemd/services.html:342
+#, fuzzy
+msgid "Service name"
+msgstr "Servis"
+
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:272
+#: pkg/kubernetes/views/dashboard-page.html:134
+#: pkg/kubernetes/views/details-page.html:29
+msgid "Services"
+msgstr "Servisler"
+
+#: pkg/kubernetes/views/topology-page.html:33
+msgid ""
+"Services group pods and provide a common DNS                name and an "
+"optional, load-balanced IP address to access them."
+msgstr ""
+
+#: pkg/kubernetes/views/service-body.html:20
+msgid "Session Affinity"
+msgstr ""
+
+#: pkg/dashboard/index.html:190
+msgid "Set"
+msgstr ""
+
+#: pkg/systemd/host.js:559
+msgid "Set Host name"
+msgstr "Host ismi ayarla"
+
+#: pkg/users/index.html:117 pkg/users/index.html:221
+msgid "Set Password"
+msgstr "Parola Belirle"
+
+#: pkg/systemd/index.html:395
+#, fuzzy
+msgid "Set Time"
+msgstr "Zamanı Ayarla"
+
+#: pkg/docker/index.html:551
+msgid "Set container environment variables"
+msgstr ""
+
+#: pkg/networkmanager/index.html:172
+#, fuzzy
+msgid "Set to"
+msgstr "Zamanı Ayarla"
+
+#: pkg/selinux/setroubleshoot-view.jsx:326
+msgid ""
+"Setting deviates from the configured state and will revert on the next boot."
+msgstr ""
+
+#: pkg/storaged/jobs.js:131
+msgid "Setting up loop device $target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:139
+#, fuzzy
+msgid "Share Name"
+msgstr "Kullanıcı Adı"
+
+#: pkg/networkmanager/interfaces.js:1807
+msgid "Shared"
+msgstr "Paylaşılan"
+
+#: pkg/kubernetes/views/container-panel.html:9
+#: pkg/kubernetes/views/container-page-inline.html:14
+msgid "Shell"
+msgstr ""
+
+#: pkg/kubernetes/views/container-page.html:4
+#, fuzzy
+msgid "Show all Containers"
+msgstr "Konteynerler"
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:8
+msgid "Show all Deployment Configs"
+msgstr ""
+
+#: pkg/kubernetes/views/node-page.html:8
+msgid "Show all Nodes"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:9
+msgid "Show all Persistent Volumes"
+msgstr ""
+
+#: pkg/kubernetes/views/pod-container.html:4
+#, fuzzy
+msgid "Show all Pod Containers"
+msgstr "Konteynerler"
+
+#: pkg/kubernetes/views/pod-page.html:8
+msgid "Show all Pods"
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:16
+#: pkg/kubernetes/views/group-page.html:14
+#: pkg/kubernetes/views/project-page.html:23
+msgid "Show all Projects"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:10
+#, fuzzy
+msgid "Show all Replication Controllers"
+msgstr "Replikasyon Kontrolörleri"
+
+#: pkg/kubernetes/views/route-page.html:10
+msgid "Show all Routes"
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:8
+#, fuzzy
+msgid "Show all Services"
+msgstr "Servisler"
+
+#: pkg/docker/index.html:127
+#, fuzzy
+msgid "Show all containers"
+msgstr "Konteynerler"
+
+#: pkg/kubernetes/views/imagestream-page.html:12
+msgid "Show all image streams"
+msgstr ""
+
+#: pkg/docker/index.html:241 pkg/kubernetes/views/image-page.html:11
+msgid "Show all images"
+msgstr ""
+
+#: pkg/systemd/index.html:94
+msgid "Show fingerprints"
+msgstr ""
+
+#: pkg/systemd/index.html:136
+msgid "Shutdown"
+msgstr "Kapat"
+
+#: pkg/kubernetes/views/container-body.html:18
+msgid "Since"
+msgstr ""
+
+#: pkg/systemd/init.js:621
+msgid "Since $0"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/storaged/index.html:232
+msgid "Size"
+msgstr "Boyut"
+
+#: pkg/storaged/dialog.js:271
+#, fuzzy
+msgid "Size cannot be negative"
+msgstr "İsim boş olamaz"
+
+#: pkg/storaged/dialog.js:269
+#, fuzzy
+msgid "Size cannot be zero"
+msgstr "İsim boş olamaz"
+
+#: pkg/storaged/dialog.js:273
+msgid "Size is too large"
+msgstr ""
+
+#: pkg/storaged/dialog.js:267
+#, fuzzy
+msgid "Size must be a number"
+msgstr "Boyut belirtilmeli"
+
+#: pkg/kubernetes/views/auth-form.html:43
+#: pkg/kubernetes/views/auth-rejected-cert.html:11
+msgid "Skip Certificate Verification"
+msgstr ""
+
+#: pkg/systemd/services.html:54
+msgid "Sockets"
+msgstr ""
+
+#: pkg/ostree/index.html:23
+msgid "Software Updates"
+msgstr ""
+
+#: pkg/docker/storage.jsx:156
+#, fuzzy
+msgid "Solid-State Disk"
+msgstr "SSD Disk"
+
+#: pkg/storaged/overview.js:182
+msgctxt "storage"
+msgid "Solid-State Disk"
+msgstr "SSD Disk"
+
+#: pkg/selinux/setroubleshoot-view.jsx:90
+msgid "Solution applied successfully"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:97
+msgid "Solution failed"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:908
+msgid "Sorry, I don't know how to modify this volume"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:8
+msgid "Source URL"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2573
+msgid "Spanning Tree Protocol"
+msgstr "Spanning Tree Protocol"
+
+#: pkg/networkmanager/index.html:200
+msgid "Spanning Tree Protocol (STP)"
+msgstr "Spanning Tree Protocol (STP)"
+
+#: pkg/storaged/details.js:1594
+msgid "Spare"
+msgstr "Yedek"
+
+#: pkg/systemd/index.html:470
+msgid "Specific Time"
+msgstr "Özel Bir Zamanda"
+
+#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
+msgid "Start"
+msgstr "Başlat"
+
+#: pkg/docker/index.html:68
+msgid "Start Docker"
+msgstr "Docker'ı Başlat"
+
+#: pkg/storaged/index.html:49
+msgid "Start Multipath"
+msgstr ""
+
+#: pkg/storaged/details.js:1614
+msgid "Start Scrubbing"
+msgstr ""
+
+#: pkg/storaged/jobs.js:139
+msgid "Starting RAID Device $target"
+msgstr ""
+
+#: pkg/storaged/jobs.js:124
+msgid "Starting swapspace $target"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:37
+#, fuzzy
+msgid "Starts"
+msgstr "Başlat"
+
+#: pkg/kubernetes/views/container-body.html:16
+#: pkg/kubernetes/views/details-page.html:38
+#: pkg/kubernetes/views/details-page.html:175
+msgid "State"
+msgstr ""
+
+#: pkg/storaged/index.html:571
+msgctxt "storage"
+msgid "State"
+msgstr "Durum"
+
+#: pkg/systemd/init.js:303
+msgid "Static"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/containers-listing.html:16
+#: pkg/kubernetes/views/nodes-page.html:44
+#: pkg/kubernetes/views/pvc-body.html:13 pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/pv-body.html:24
+msgid "Status"
+msgstr "Durum"
+
+#: pkg/subscriptions/subscriptions-view.jsx:146
+#, fuzzy
+msgid "Status: $0"
+msgstr "Durum"
+
+#: pkg/subscriptions/subscriptions-view.jsx:141
+msgid "Status: System isn't registered"
+msgstr ""
+
+#: pkg/networkmanager/index.html:455
+msgid "Sticky"
+msgstr ""
+
+#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
+msgid "Stop"
+msgstr "Durdur"
+
+#: pkg/storaged/details.js:1615
+msgid "Stop Scrubbing"
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:10
+msgid "Stop with"
 msgstr ""
 
 #: pkg/docker/util.js:231
 msgid "Stopped"
 msgstr "Durduruldu"
 
-#: pkg/docker/util.js:488
-msgid "Container is currently running."
-msgstr "Konteyner şu an çalışıyor."
+#: pkg/storaged/jobs.js:138
+msgid "Stopping RAID Device $target"
+msgstr ""
 
-#: pkg/docker/util.js:490
+#: pkg/storaged/jobs.js:125
+msgid "Stopping swapspace $target"
+msgstr ""
+
+#: pkg/storaged/index.html:23 pkg/storaged/index.html:672
+msgid "Storage"
+msgstr "Depolama"
+
+#: pkg/storaged/index.html:686
+msgid "Storage Log"
+msgstr ""
+
+#: pkg/storaged/index.html:342
+msgid "Storage Logs"
+msgstr ""
+
+#: pkg/docker/index.html:324
+#, fuzzy
+msgid "Storage pool"
+msgstr "Depolama"
+
+#: pkg/systemd/index.html:148
+msgid "Store Performance Data"
+msgstr ""
+
+#: pkg/storaged/details.js:237
+msgid "Store passphrase"
+msgstr "Parolayı sakla"
+
+#: pkg/storaged/details.js:527
+msgid "Stored Passphrase"
+msgstr "Saklı Parolalar"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:12
 msgid ""
-"Container is currently marked as not running, but regular stopping failed."
+"Strategy            {{item.spec.strategy.type}}            Latest "
+"Version            {{ item.status.latestVersion }}            Not "
+"deployed        "
 msgstr ""
 
-#: pkg/docker/util.js:491
-msgid "Error message from Docker:"
-msgstr "Docker'dan hata mesajı:"
-
-#: pkg/docker/util.js:501
-msgid "Please confirm forced deletion of $0"
+#: pkg/subscriptions/index.html:22
+msgid "Subscriptions"
 msgstr ""
 
-#: pkg/docker/util.js:503
-msgid "Force Delete"
-msgstr "Zorla Sil"
-
-#: pkg/docker/util.js:544
-msgid "Failed to stop Docker scope: $0"
+#: pkg/kubernetes/views/image-body.html:4
+msgid "Summary"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:239
-#, fuzzy
-msgid "Commit"
-msgstr "Komut"
-
-#: pkg/docker/containers.js:64
-msgid "Failed to start Docker: $0"
-msgstr ""
-
-#: pkg/users/authorized-keys.js:103
-msgid "Validating key"
-msgstr "Anahtar doğrulanıyor"
-
-#: pkg/users/authorized-keys.js:108
-msgid "Adding key"
-msgstr "Anahtar ekleniyor"
-
-#: pkg/users/authorized-keys.js:115
-msgid "Error saving authorized keys: "
-msgstr "Yetkilendirilmiş anahtarın kaydedilmesinde hata:"
-
-#: pkg/users/authorized-keys.js:118
-msgid "The key you provided was not valid."
-msgstr "Sağladığınız anahtar geçerli değil."
-
-#: pkg/users/local.js:40
-msgid "The user <b>$0</b> is not permitted to modify accounts"
-msgstr "<b>$0</b> kullanıcısı hesapları düzenlemek için yetkili değil"
-
-#: pkg/users/local.js:57
-msgid "Unable to delete root account"
-msgstr "Kök hesabı silinemiyor"
-
-#: pkg/users/local.js:59
-msgid "Unable to rename root account"
-msgstr "Kök hesabı yeniden adlandırılamıyor"
-
-#: pkg/users/local.js:82
-msgid "Prompting via passwd timed out"
-msgstr ""
-
-#: pkg/users/local.js:247
-msgid "Password is too weak"
-msgstr "Parola çok güçsüz"
-
-#: pkg/users/local.js:259
-msgid "Password is not acceptable"
-msgstr "Parola kabul edilebilir değil"
-
-#: pkg/users/local.js:284 pkg/users/local.js:594
-msgctxt "page-title"
-msgid "Accounts"
-msgstr "Hesaplar"
-
-#: pkg/users/local.js:395 pkg/users/local.js:1082
-msgid "The passwords do not match"
-msgstr "Parolalar eşleşmişyor"
-
-#: pkg/users/local.js:400
-msgid "No user name specified"
-msgstr "Kullanıcı adı belirtilmedi"
-
-#: pkg/users/local.js:405
-msgid "No real name specified"
-msgstr "Gerçek ad belirtilmedi"
-
-#: pkg/users/local.js:429 pkg/users/local.js:1104
-msgid "Excellent password"
-msgstr "Mükemmel Parola"
-
-#: pkg/users/local.js:501
-msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
-msgstr ""
-
-#: pkg/users/local.js:509
-msgid "This user name already exists"
-msgstr "Böyle bir kullanıcı adı zaten var"
-
-#: pkg/users/local.js:682 pkg/users/local.js:683
-msgid "Server Administrator"
-msgstr "Sunucu Yöneticisi"
-
-#: pkg/users/local.js:684
-msgid "Container Administrator"
-msgstr "Konteyner Yöneticisi"
-
-#: pkg/users/local.js:839
-msgid "Logged In"
-msgstr "Giriş Yapıldı"
-
-#: pkg/users/local.js:841
-msgid "Never"
-msgstr "Asla"
-
-#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
-msgid "Delete $0"
-msgstr "Sil: $0"
-
-#: pkg/sosreport/index.js:49 pkg/sosreport/index.js:113
-#: pkg/systemd/services.html.h:13 pkg/lib/machine-invalid-hostkey.html.h:4
-#: pkg/lib/machine-auth-failed.html.h:7
-#: pkg/lib/machine-unknown-hostkey.html.h:4
-#: pkg/lib/machine-change-port.html.h:8 pkg/lib/machine-not-supported.html.h:3
-#: pkg/shell/index.html.h:37
-msgid "Close"
-msgstr "Kapat"
-
-#: pkg/sosreport/index.js:115
-msgid "No archive has been created."
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:598 pkg/networkmanager/interfaces.js:1051
-#: pkg/networkmanager/interfaces.js:2255 pkg/networkmanager/interfaces.js:2257
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:753 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/kubernetes/views/node-body.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:6
-#: pkg/kubernetes/views/pv-claim.html.h:7
-#: pkg/kubernetes/views/image-body.html.h:6
-#: pkg/kubernetes/views/pv-body.html.h:5
-msgid "Unknown"
-msgstr "Bilinmiyor"
-
-#: pkg/networkmanager/interfaces.js:805
-msgid "Not available"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
-#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
-msgid "Inactive"
-msgstr "Aktif değil"
-
-#: pkg/networkmanager/interfaces.js:809
-msgid "Preparing"
-msgstr "Hazırlanıyor"
-
-#: pkg/networkmanager/interfaces.js:811
-msgid "Configuring"
-msgstr "Ayarlanıyor"
-
-#: pkg/networkmanager/interfaces.js:813
-msgid "Authenticating"
-msgstr "Yetkilendiriliyor"
-
-#: pkg/networkmanager/interfaces.js:815
-msgid "Configuring IP"
-msgstr "IP ayarlanıyor"
-
-#: pkg/networkmanager/interfaces.js:817
-msgid "Checking IP"
-msgstr "IP kontrol ediliyor"
-
-#: pkg/networkmanager/interfaces.js:819
-msgid "Waiting"
-msgstr "Bekleniyor"
-
-#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
-msgid "Active"
-msgstr "Aktif"
-
-#: pkg/networkmanager/interfaces.js:823
-msgid "Deactivating"
-msgstr "Deaktif ediliyor"
-
-#: pkg/networkmanager/interfaces.js:825 pkg/ostree/index.html.h:14
-msgid "Failed"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1326
-msgid "No carrier"
-msgstr "Taşıyıcı yok"
-
-#: pkg/networkmanager/interfaces.js:1372
-msgid "Part of "
-msgstr "Parçası: "
-
-#: pkg/networkmanager/interfaces.js:1420
-msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
-msgctxt "page-title"
-msgid "Networking"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1804
-msgid "Automatic (DHCP)"
-msgstr "Otomatik (DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
-msgid "Link local"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
-msgid "Manual"
-msgstr "Elle"
-
-#: pkg/networkmanager/interfaces.js:1807
-msgid "Shared"
-msgstr "Paylaşılan"
-
-#: pkg/networkmanager/interfaces.js:1813 pkg/networkmanager/interfaces.js:2475
-#: pkg/networkmanager/interfaces.js:3019 pkg/networkmanager/interfaces.js:3023
-#: pkg/networkmanager/interfaces.js:3029 pkg/networkmanager/index.html.h:22
-msgid "Automatic"
-msgstr "Otomatik"
-
-#: pkg/networkmanager/interfaces.js:1814
-msgid "Automatic (DHCP only)"
-msgstr "Otomatik (Sadece DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1817
-msgid "Ignore"
-msgstr "Yoksay"
-
-#: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
-msgid "Round Robin"
-msgstr "Round Robin"
-
-#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
-msgid "Active Backup"
-msgstr "Aktif Yedekleme"
-
-#: pkg/networkmanager/interfaces.js:1824
-msgid "XOR"
-msgstr "XOR"
-
-#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
-msgid "Broadcast"
-msgstr "Broadcast"
-
-#: pkg/networkmanager/interfaces.js:1826
-msgid "802.3ad"
-msgstr "802.3ad"
-
-#: pkg/networkmanager/interfaces.js:1827
-msgid "Adaptive transmit load balancing"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1828
-msgid "Adaptive load balancing"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1833
-msgid "MII (Recommended)"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1834
-msgid "ARP"
-msgstr "ARP"
-
-#: pkg/networkmanager/interfaces.js:1841
-msgid "Load Balancing"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1843
-#, fuzzy
-msgid "802.3ad LACP"
-msgstr "802.3ad"
-
-#: pkg/networkmanager/interfaces.js:1848
-msgid "Passive"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1854
-msgid "Ethtool"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1855
-#, fuzzy
-msgid "ARP Ping"
-msgstr "ARP İzleme"
-
-#: pkg/networkmanager/interfaces.js:1856
-msgid "NSNA Ping"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2156
-msgid "Deleting <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2188
-msgid "Switching on <b>$0</b>  will break the connection to the server, "
+#: pkg/storaged/details.js:1251
+msgctxt "storage-id-desc"
+msgid "Swap Space"
+msgstr "Swap Alanı"
+
+#: pkg/systemd/index.html:243
+msgid "Swap Used"
+msgstr "Kullanılan Swap"
+
+#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
+msgid "Switch off $0"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2191 pkg/networkmanager/interfaces.js:2765
@@ -2472,358 +5140,615 @@ msgstr ""
 msgid "Switching off <b>$0</b>  will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
-msgid "Switch off $0"
+#: pkg/networkmanager/interfaces.js:2773
+msgid "Switching off <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
-#: pkg/networkmanager/interfaces.js:2507
-msgid "Bond"
-msgstr "Bond"
+#: pkg/networkmanager/interfaces.js:2188
+msgid "Switching on <b>$0</b>  will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2762
+msgid "Switching on <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:75
+msgid "Synchronize"
+msgstr ""
+
+#: pkg/dashboard/index.html:188 pkg/lib/machine-sync-users.html:4
+msgid "Synchronize users"
+msgstr ""
+
+#: pkg/systemd/index.html:54
+msgid "Synchronized"
+msgstr ""
+
+#: pkg/systemd/index.html:51
+msgid "Synchronized with {{Server}}"
+msgstr ""
+
+#: pkg/storaged/jobs.js:146
+msgid "Synchronizing RAID Device $target"
+msgstr ""
+
+#: pkg/systemd/index.html:4
+msgid "System"
+msgstr ""
+
+#: pkg/systemd/services.html:53
+msgid "System Services"
+msgstr ""
+
+#: pkg/systemd/index.html:112
+msgid "System Time"
+msgstr ""
+
+#: pkg/docker/index.html:349
+msgid "TCP"
+msgstr "TCP"
+
+#: pkg/kubernetes/views/route-body.html:12
+msgid "TLS Termination"
+msgstr ""
+
+#: pkg/docker/index.html:724
+msgid "Tag"
+msgstr "Etiket"
+
+#: pkg/kubernetes/views/image-body.html:27
+#: pkg/kubernetes/views/imagestream-modify.html:76
+#: pkg/kubernetes/views/image-listing.html:14
+msgid "Tags"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:136
+msgid "Target"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:75
+msgid "Target Portal"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:114
+msgid "Target World Wide Names"
+msgstr ""
+
+#: pkg/systemd/services.html:52
+msgid "Targets"
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2235 pkg/networkmanager/interfaces.js:2247
 #: pkg/networkmanager/interfaces.js:2530
 msgid "Team"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
-#: pkg/networkmanager/interfaces.js:2622
-msgid "VLAN"
-msgstr "VLAN"
+#: pkg/networkmanager/interfaces.js:2558
+msgid "Team Port"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
-#: pkg/networkmanager/interfaces.js:2584
-msgid "Bridge"
-msgstr "Köprü"
+#: pkg/networkmanager/index.html:652
+#, fuzzy
+msgid "Team Port Settings"
+msgstr "Hesap Ayarları"
 
-#: pkg/networkmanager/interfaces.js:2276
-msgid "Carrier"
-msgstr "Taşıyıcı"
+#: pkg/networkmanager/index.html:624
+#, fuzzy
+msgid "Team Settings"
+msgstr "IPv4 Ayarları"
 
-#: pkg/networkmanager/interfaces.js:2279 pkg/kubernetes/scripts/volumes.js:990
-msgid "Yes"
-msgstr "Evet"
+#: pkg/kubernetes/views/replicationcontroller-page.html:20
+#: pkg/kubernetes/views/deploymentconfig-panel.html:10
+#: pkg/kubernetes/views/deploymentconfig-page.html:15
+#: pkg/kubernetes/views/replicationcontroller-panel.html:14
+msgid "Template"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2299
-#: pkg/subscriptions/subscriptions-view.jsx:36
-#: pkg/kubernetes/views/node-body.html.h:14
-#: pkg/kubernetes/views/containers-listing.html.h:7
-#: pkg/kubernetes/views/volumes-page.html.h:5
-#: pkg/kubernetes/views/pv-claim.html.h:6
-#: pkg/kubernetes/views/nodes-page.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:5 pkg/kubernetes/views/pv-body.html.h:4
-msgid "Status"
-msgstr "Durum"
+#: pkg/systemd/terminal.html:4
+msgid "Terminal"
+msgstr ""
+
+#: pkg/users/index.html:78
+msgid "Terminate Session"
+msgstr ""
+
+#: pkg/networkmanager/index.html:38
+msgid "Testing connection"
+msgstr ""
+
+#: pkg/storaged/index.html:40
+msgid "The \"storaged\" API is not available on this system."
+msgstr ""
+
+#: pkg/docker/storage.jsx:485
+msgid "The Docker storage pool cannot be managed on this system."
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:386
+msgid "The IP address or host name cannot contain whitespace."
+msgstr ""
+
+#: pkg/storaged/index.html:532
+msgid "The RAID Array is in a degraded state"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:399
+msgid "The address contains invalid characters"
+msgstr "Adres geçersiz karakterler içeriyor"
+
+#: pkg/lib/machine-unknown-hostkey.html:6
+msgid ""
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:324
+msgid "The configured state is unknown, it might change on the next boot."
+msgstr ""
+
+#: pkg/kubernetes/views/container-page-inline.html:22
+msgid "The container '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:192
+msgid "The current user isn't allowed to access system subscription status."
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:25
+msgid "The deployment config '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/group-page.html:47
+msgid "The group '{{ groupName }}' does not exist."
+msgstr ""
+
+#: pkg/shell/base_index.js:673
+msgid "The javascript console contains details about this error "
+msgstr "Javascript uçbirimi bu hatayla ilgili ayrıntıları içeriyor"
+
+#: pkg/lib/machine-invalid-hostkey.html:8
+msgid ""
+"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
+"in use. Unless this machine was recently replaced, it is likely that someone "
+"is trying to attack your connection to this machine."
+msgstr ""
+
+#: pkg/users/authorized-keys.js:118
+msgid "The key you provided was not valid."
+msgstr "Sağladığınız anahtar geçerli değil."
+
+#: pkg/storaged/details.js:1751
+msgid "The last physical volume of a volume group cannot be removed."
+msgstr ""
+
+#: pkg/shell/indexes.js:314
+msgid "The machine is restarting"
+msgstr "Makine yeniden başlatılıyor"
+
+#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
+msgid "The maximum number of replicas is 128"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:407
+msgid "The name contains invalid characters"
+msgstr ""
+
+#: pkg/kubernetes/views/node-page.html:23
+msgid "The node '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/node-alerts.html:7
+msgid "The node doesn't have enough disk space"
+msgstr ""
+
+#: pkg/kubernetes/views/node-alerts.html:11
+msgid "The node doesn't have enough free memory"
+msgstr ""
+
+#: pkg/users/local.js:395 pkg/users/local.js:1082
+msgid "The passwords do not match"
+msgstr "Parolalar eşleşmişyor"
+
+#: pkg/lib/credentials.js:186
+msgid "The passwords do not match."
+msgstr "Parolalar uyuşmuyor."
+
+#: pkg/kubernetes/views/pv-page.html:21
+msgid "The persistent volume '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/pod-page.html:40
+msgid "The pod '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/project-page.html:34
+msgid "The project '{{ projName }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:30
+msgid "The replication controller '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/views/route-page.html:19
+msgid "The route '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:386
+msgid "The selected file is not a valid Kubernetes application manifest."
+msgstr ""
+
+#: src/base1/cockpit.js:3695
+msgid "The server refused to authenticate using any supported methods."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:2
+msgid "The server uses a certificate signed by an unknown authority."
+msgstr ""
+
+#: pkg/kubernetes/views/service-page.html:19
+msgid "The service '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/docker/storage.jsx:355
+msgid ""
+"The storage pool will be reset to optimize its layout.  All containers will "
+"be erased."
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:29
+msgid "The user '{{ userName }}' does not exist."
+msgstr ""
+
+#: pkg/systemd/init.js:834
+#, fuzzy
+msgid "The user <b>$0</b> does not have permissions for creating timers"
+msgstr "<b>$0</b> kullanıcısı hesapları düzenlemek için yetkili değil"
+
+#: pkg/dashboard/list.js:209
+msgid "The user <b>$0</b> is not permitted to manage servers"
+msgstr ""
+
+#: pkg/storaged/permissions.js:61
+msgid "The user <b>$0</b> is not permitted to manage storage"
+msgstr ""
+
+#: pkg/users/local.js:40
+msgid "The user <b>$0</b> is not permitted to modify accounts"
+msgstr "<b>$0</b> kullanıcısı hesapları düzenlemek için yetkili değil"
+
+#: pkg/systemd/host.js:43
+msgid "The user <b>$0</b> is not permitted to modify hostnames"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1420
+msgid "The user <b>$0</b> is not permitted to modify network settings"
+msgstr ""
+
+#: pkg/realmd/operation.js:436
+msgid "The user <b>$0</b> is not permitted to modify realms"
+msgstr ""
+
+#: pkg/users/local.js:501
+msgid ""
+"The user name can only consist of letters from a-z, digits, dots, dashes and "
+"underscores."
+msgstr ""
+
+#: pkg/users/index.html:332
+msgid "There are no authorized public keys for this account."
+msgstr "Bu hesap için yetkilendirilmiş açık anahtar yok."
+
+#: pkg/storaged/details.js:1756
+msgid ""
+"There is not enough free space elsewhere to remove this physical volume.  At "
+"least $0 more free space is needed."
+msgstr ""
+
+#: pkg/storaged/utils.js:168
+msgid "Thin Logical Volume"
+msgstr ""
+
+#: pkg/kubernetes/views/pvc-delete.html:8
+msgid ""
+"This claim is in use. Deleting it may cause issues with the following pod:"
+msgstr ""
+
+#: pkg/systemd/init.js:1222
+msgid ""
+"This day doesn't exist in all months.<br> The timer will only be executed in "
+"months that have 31st."
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2310
 msgid "This device cannot be managed here."
+msgstr ""
+
+#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
+#, fuzzy
+msgid "This field cannot be empty."
+msgstr "İsim boş olamaz"
+
+#: pkg/storaged/details.js:690
+msgid "This logical volume cannot be made smaller."
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:364
+msgid "This machine has already been added."
+msgstr "Bu makine zaten eklenmiş."
+
+#: pkg/realmd/operation.html:89
+msgid "This may take a while"
+msgstr "Bu biraz zaman alabilir"
+
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid ""
+"This option is for single node testing only – local storage will not work in "
+"a multi-node cluster"
+msgstr ""
+
+#: src/bridge/cockpitpackages.c:470
+msgid "This package is not compatible with this version of Cockpit"
+msgstr ""
+
+#: src/bridge/cockpitpackages.c:459
+#, c-format
+msgid "This package requires Cockpit version %s or later"
+msgstr ""
+
+#: pkg/tuned/dialog.js:102
+msgid "This system is using a custom profile"
+msgstr "Bu sistem özel profil kullanıyor"
+
+#: pkg/tuned/dialog.js:100
+msgid "This system is using the recommended profile"
+msgstr "Bu sistem önerilen profili kullanıyor"
+
+#: pkg/systemd/init.js:639
+msgid "This unit is an instance of the $0 template."
+msgstr ""
+
+#: pkg/systemd/services.html:302
+msgid "This unit is not designed to be enabled explicitly.          "
+msgstr ""
+
+#: pkg/users/local.js:509
+msgid "This user name already exists"
+msgstr "Böyle bir kullanıcı adı zaten var"
+
+#: pkg/lib/machine-dialogs.js:380
+msgid ""
+"This version of cockpit-ws does not support connecting to a host with an "
+"alternate user or port"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-delete.html:7
+msgid ""
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
+msgstr ""
+
+#: pkg/kubernetes/views/pv-claim.html:23
+msgid "This volume has not been claimed"
+msgstr ""
+
+#: pkg/systemd/index.html:379
+msgid "Time Zone"
+msgstr "Zaman Dilimi"
+
+#: pkg/systemd/services.html:55
+msgid "Timers"
+msgstr ""
+
+#: pkg/kubernetes/views/image-body.html:33
+msgid "To pull this image:"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:39
+msgid "To push to an image to this image stream:"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:11
+msgid ""
+"To try a different port you will need to upgrade cockpit-ws to a newer "
+"version."
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:116
+msgid "Token"
+msgstr ""
+
+#: pkg/kubernetes/index.html:57
+msgid "Topology"
+msgstr ""
+
+#: pkg/docker/storage.jsx:314
+msgid "Total"
+msgstr ""
+
+#: pkg/ostree/index.html:99
+msgid "Tree"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:32
+msgid "Triggers"
+msgstr ""
+
+#: pkg/shell/index.html:328 pkg/shell/stub.html:181
+msgid "Troubleshoot"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:21
+msgid "Trust this certificate for this connection"
+msgstr ""
+
+#: pkg/systemd/init.js:520
+msgid "Try Restart"
+msgstr ""
+
+#: pkg/docker/index.html:71 pkg/docker/index.html:74
+msgid "Try again"
+msgstr "Tekrar Dene"
+
+#: pkg/systemd/index.html:59
+msgid "Trying to synchronize with {{Server}}"
+msgstr ""
+
+#: pkg/tuned/dialog.js:262
+msgid "Tuned has failed to start"
+msgstr "Tuned başlatılırken başarısız oldu"
+
+#: pkg/tuned/dialog.js:94
+msgid "Tuned is not available"
+msgstr "Tuned uygun değil"
+
+#: pkg/tuned/dialog.js:96
+msgid "Tuned is not running"
+msgstr "Tuned çalışmıyor"
+
+#: pkg/tuned/dialog.js:98
+msgid "Tuned is off"
+msgstr "Tuned kapalı"
+
+#: pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/pv-modify.html:10
+#: pkg/kubernetes/views/volumes-page.html:20 pkg/kubernetes/views/deploy.html:9
+msgid "Type"
+msgstr "Tip"
+
+#: pkg/kubernetes/views/details-page.html:7
+#, fuzzy
+msgid "Type:"
+msgstr "Tip"
+
+#: pkg/subscriptions/subscriptions-register.jsx:110
+msgid "URL"
+msgstr ""
+
+#: pkg/storaged/index.html:547 pkg/storaged/index.html:626
+msgctxt "storage"
+msgid "UUID"
+msgstr "UUID"
+
+#: pkg/selinux/setroubleshoot-view.jsx:114
+msgid "Unable to apply this solution automatically"
+msgstr ""
+
+#: pkg/ostree/index.html:219
+msgid "Unable to communicate with OSTree"
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:195
+#, fuzzy
+msgid "Unable to connect"
+msgstr "Uyarı alınamıyor"
+
+#: pkg/kubernetes/scripts/dashboard.js:413
+msgid "Unable to decode Kubernetes application manifest."
+msgstr ""
+
+#: pkg/users/local.js:57
+msgid "Unable to delete root account"
+msgstr "Kök hesabı silinemiyor"
+
+#: pkg/selinux/setroubleshoot-client.js:157
+msgid "Unable to get alert"
+msgstr "Uyarı alınamıyor"
+
+#: pkg/storaged/overview.js:586
+msgid "Unable to reach server"
+msgstr ""
+
+#: pkg/kubernetes/scripts/dashboard.js:401
+msgid "Unable to read the Kubernetes application manifest. Code $0."
+msgstr ""
+
+#: pkg/users/local.js:59
+msgid "Unable to rename root account"
+msgstr "Kök hesabı yeniden adlandırılamıyor"
+
+#: pkg/selinux/setroubleshoot-client.js:172
+msgid "Unable to run fix"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:52
+msgid "Unable to start setroubleshootd"
+msgstr "setroubleshootd başlatılamıyor"
+
+#: pkg/playground/translate.html:35 pkg/playground/translate.html:40
+msgid "Unavailable"
+msgstr ""
+
+#: pkg/docker/index.html:763 pkg/networkmanager/index.html:792
+msgid "Unexpected error"
+msgstr "Beklenmeyen hata"
+
+#: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/image-body.html:15
+#: pkg/kubernetes/views/pv-claim.html:31 pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
+msgid "Unknown"
+msgstr "Bilinmiyor"
+
+#: pkg/storaged/details.js:1597
+msgid "Unknown ($0)"
+msgstr "Bilinmiyor ($)"
+
+#: pkg/lib/machine-unknown-hostkey.html:2
+msgid "Unknown Host Key"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2342
 msgid "Unknown configuration"
 msgstr "Bilinmeyen konfigrasyon"
 
-#: pkg/networkmanager/interfaces.js:2441
-msgid "Configure"
-msgstr "Ayarla"
-
-#: pkg/networkmanager/interfaces.js:2473
-msgid "$mtu"
+#: pkg/storaged/overview.js:582
+msgid "Unknown host name"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2477
-msgid "MTU"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2483
-msgid "Master"
-msgstr "Ana"
-
-#: pkg/networkmanager/interfaces.js:2502
-msgid "ARP Monitoring"
-msgstr "ARP İzleme"
-
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#: pkg/docker/index.html:570
 #, fuzzy
-msgid "Broken configuration"
-msgstr "Bilinmeyen konfigrasyon"
+msgid "Unless Stopped"
+msgstr "Durduruldu"
 
-#: pkg/networkmanager/interfaces.js:2558
-msgid "Team Port"
+#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
+#: pkg/storaged/details.js:1110
+msgid "Unlock"
+msgstr "Kilidi Aç"
+
+#: pkg/shell/index.html:220
+msgid "Unlock Key"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2573
-msgid "Spanning Tree Protocol"
-msgstr "Spanning Tree Protocol"
-
-#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
-msgid "Priority $priority"
-msgstr "Öncelik $priority"
-
-#: pkg/networkmanager/interfaces.js:2577
-msgid "Forward delay $forward_delay"
+#: pkg/storaged/jobs.js:121
+msgid "Unlocking $target"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2579
-msgid "Hello time $hello_time"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2581
-msgid "Maximum message age $max_age"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2601
-msgid "Path cost $path_cost"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2603
-msgid "Hairpin mode"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2605
-msgid "Bridge port"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2619
-msgid "Parent $parent"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2620
-msgid "Id $id"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2628
-msgid "General"
-msgstr "Genel"
-
-#: pkg/networkmanager/interfaces.js:2637
-msgid "Connect automatically"
-msgstr "Otomatik bağlan"
-
-#: pkg/networkmanager/interfaces.js:2641
-msgid "IPv4"
-msgstr "IPv4"
-
-#: pkg/networkmanager/interfaces.js:2642
-msgid "IPv6"
-msgstr "IPv6"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/networkmanager/index.html.h:33
-#: pkg/kubernetes/views/project-listing.html.h:5
-msgid "Members"
-msgstr "Üyeler"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/docker/index.html.h:39
-#: pkg/networkmanager/index.html.h:24
-#: pkg/kubernetes/views/service-body.html.h:6
-#: pkg/kubernetes/views/image-config.html.h:7
-#: pkg/kubernetes/views/container-body.html.h:5
-msgid "Ports"
-msgstr "Portlar"
-
-#: pkg/networkmanager/interfaces.js:2762
-msgid "Switching on <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2773
-msgid "Switching off <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2788
-msgid "Removing <b>$0</b> will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2791
+#: pkg/networkmanager/index.html:108
 #, fuzzy
-msgid "Remove $0"
-msgstr "Kaldır"
+msgid "Unmanaged Interfaces"
+msgstr "Arayüzler"
 
-#: pkg/networkmanager/interfaces.js:2833
-msgid "Adding <b>$0</b> will break the connection to the server, "
+#: pkg/systemd/init.js:548
+msgid "Unmask"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2836
-msgid "Add $0"
+#: pkg/storaged/details.js:1100
+msgid "Unmount"
+msgstr "Çöz"
+
+#: pkg/storaged/jobs.js:127
+msgid "Unmounting $target"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2870
-msgid "Changing the settings will break the connection to the server, "
-msgstr ""
+#: pkg/users/index.html:315
+msgid "Unnamed"
+msgstr "İsimsiz"
 
-#: pkg/networkmanager/interfaces.js:2872
-#, fuzzy
-msgid "Change the settings"
-msgstr "Hesap Ayarları"
-
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length or Netmask"
-msgstr "Ön ek uzunluğu ya da ağ maskesi"
-
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length"
-msgstr "Ön ek uzunluğu"
-
-#: pkg/networkmanager/interfaces.js:3011
-#: pkg/kubernetes/views/details-page.html.h:7
-msgid "Addresses"
-msgstr "Adresler"
-
-#: pkg/networkmanager/interfaces.js:3018
-msgid "DNS"
-msgstr "DNS"
-
-#: pkg/networkmanager/interfaces.js:3022
-msgid "DNS Search Domains"
-msgstr "DNS Search Domains"
-
-#: pkg/networkmanager/interfaces.js:3027
-#: pkg/kubernetes/views/details-page.html.h:11
-msgid "Routes"
-msgstr "Yönlendirmeler"
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv4 Settings"
-msgstr "IPv4 Ayarları"
-
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv6 Settings"
-msgstr "IPv6 Ayarları"
-
-#: pkg/networkmanager/interfaces.js:3436
-msgid "Creating this bond will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
-#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
-#, fuzzy
-msgid "Create it"
-msgstr "Yarat"
-
-#: pkg/networkmanager/interfaces.js:3611
-msgid "Creating this team will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3842
-msgid "Creating this bridge will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4064
-msgid "Creating this VLAN will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4139
-#, fuzzy
-msgid "MTU must be a positive number"
-msgstr "Boyut belirtilmeli"
-
-#: pkg/subscriptions/subscriptions-client.js:196
-#, fuzzy
-msgid "Invalid credentials"
-msgstr "Geçersiz port"
-
-#: pkg/subscriptions/subscriptions-client.js:198
-msgid "'Organization' required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:200
-msgid "Login/password or activation key required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:202
-msgid "'Organization' required when using activation keys."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:64
-#: pkg/kubernetes/views/volume-body.html.h:16
-#: pkg/kubernetes/views/pv-modify.html.h:11
-#, fuzzy
-msgid "Server"
-msgstr "Servis"
-
-#: pkg/subscriptions/subscriptions-register.jsx:88
-#: pkg/subscriptions/subscriptions-register.jsx:152
-#: pkg/lib/machine-auth-failed.html.h:3 pkg/lib/machine-sync-users.html.h:6
-#: pkg/lib/machine-change-auth.html.h:6 pkg/shell/index.html.h:31
-#: pkg/users/index.html.h:16 pkg/kubernetes/views/auth-form.html.h:11
-msgid "Password"
-msgstr "Parola"
-
-#: pkg/subscriptions/subscriptions-register.jsx:102
-#, fuzzy
-msgid "Custom URL"
-msgstr "Özel"
-
-#: pkg/subscriptions/subscriptions-register.jsx:110
-msgid "URL"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:125
-msgid "Proxy"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:132
-msgid "Use proxy server"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:140
-#, fuzzy
-msgid "Login"
-msgstr "Son Giriş"
-
-#: pkg/subscriptions/subscriptions-register.jsx:164
-#, fuzzy
-msgid "Activation Key"
-msgstr "Aktifleştir"
-
-#: pkg/subscriptions/subscriptions-register.jsx:176
-msgid "Organization"
-msgstr ""
-
-#: pkg/subscriptions/main.js:45 pkg/subscriptions/subscriptions-view.jsx:143
-#: pkg/kubernetes/views/pv-modify.html.h:23
-msgid "Register"
-msgstr ""
-
-#: pkg/subscriptions/main.js:74
-msgid "Register system"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:32
-msgid "Product name"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product ID"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/index.html.h:13
-#: pkg/shell/index.html.h:14 pkg/shell/stub.html.h:9 pkg/shell/simple.html.h:9
-#: pkg/ostree/index.html.h:19
-msgid "Version"
-msgstr "Sürüm"
-
-#: pkg/subscriptions/subscriptions-view.jsx:35
-#: pkg/kubernetes/views/image-config.html.h:5
-msgid "Architecture"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:37
-#, fuzzy
-msgid "Starts"
-msgstr "Başlat"
-
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Ends"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:141
-msgid "Status: System isn't registered"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:146
-#, fuzzy
-msgid "Status: $0"
-msgstr "Durum"
+#: pkg/storaged/details.js:1256
+msgctxt "storage-id-desc"
+msgid "Unrecognized Data"
+msgstr "Tanımlanamayan Veri"
 
 #: pkg/subscriptions/subscriptions-view.jsx:148
 msgid "Unregister"
@@ -2833,357 +5758,218 @@ msgstr ""
 msgid "Unregistering system..."
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:161
-#: pkg/subscriptions/index.html.h:1
-msgid "Subscriptions"
+#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
+#: src/bridge/cockpitdbussetup.c:625
+#, fuzzy
+msgid "Unsupported setup mechanism"
+msgstr "Desteklenmeyen kurulum düzeneği: %s"
+
+#: src/base1/cockpit.js:3697
+msgid "Untrusted host"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/ostree/index.html.h:15
+#: pkg/docker/util.js:94
+msgid "Up since $StartedAt"
+msgstr ""
+
+#: pkg/lib/machine-change-port.html:41
+msgid "Update"
+msgstr ""
+
+#: pkg/ostree/index.html:125 pkg/ostree/index.html:152
+msgid "Updates"
+msgstr ""
+
+#: pkg/ostree/index.html:96
 msgid "Updating"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:188
-msgid "Retrieving subscription status..."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:191
-#, fuzzy
-msgid "Access denied"
-msgstr "Erişim"
-
-#: pkg/subscriptions/subscriptions-view.jsx:192
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:195
-#, fuzzy
-msgid "Unable to connect"
-msgstr "Uyarı alınamıyor"
-
-#: pkg/subscriptions/subscriptions-view.jsx:196
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:222
-msgid "Installed products"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:223
-#, fuzzy
-msgid "No installed products on the system."
-msgstr "Docker sistemde yüklü ya da aktif değil"
-
-#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr ""
-
-#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr ""
-
-#: pkg/kubernetes/scripts/details.js:546
-msgid "Not a valid value for Host"
 msgstr ""
 
 #: pkg/kubernetes/scripts/details.js:655
 msgid "Updating $0..."
 msgstr ""
 
-#: pkg/kubernetes/scripts/graphs.js:601 pkg/kubernetes/scripts/nodes.js:711
-#: pkg/kubernetes/scripts/nodes.js:817 pkg/dashboard/index.html.h:2
-msgid "CPU"
-msgstr "CPU"
-
-#: pkg/kubernetes/scripts/graphs.js:606 pkg/kubernetes/scripts/nodes.js:715
-#: pkg/kubernetes/scripts/nodes.js:826 pkg/dashboard/index.html.h:3
-msgid "Memory"
-msgstr "Bellek"
-
-#: pkg/kubernetes/scripts/graphs.js:611 pkg/dashboard/index.html.h:4
-msgid "Network"
-msgstr "Ağ"
-
-#: pkg/kubernetes/scripts/nodes.js:319 pkg/kubernetes/views/node-body.html.h:16
-#: pkg/kubernetes/views/details-page.html.h:10
-msgid "Not Ready"
-msgstr "Hazır değil"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
+#: pkg/shell/index.html:165
+msgid "Use my password for privileged tasks and to connect to other machines"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:324 pkg/kubernetes/views/node-body.html.h:15
-#: pkg/kubernetes/views/details-page.html.h:9
-msgid "Ready"
-msgstr "Hazır"
-
-#: pkg/kubernetes/scripts/nodes.js:397
-msgid "Please type an address"
-msgstr "Bir adres girin"
-
-#: pkg/kubernetes/scripts/nodes.js:399
-msgid "The address contains invalid characters"
-msgstr "Adres geçersiz karakterler içeriyor"
-
-#: pkg/kubernetes/scripts/nodes.js:407
-msgid "The name contains invalid characters"
+#: pkg/subscriptions/subscriptions-register.jsx:132
+msgid "Use proxy server"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
+#: pkg/shell/index.html:172
+msgid "Use the following keys to authenticate against other systems"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
+#: pkg/systemd/index.html:251
+msgid "Used"
+msgstr "Kullanılmış"
+
+#: pkg/systemd/index.html:229 pkg/dashboard/index.html:158
+#: pkg/playground/translate.html:86 pkg/playground/translate.html:106
+#: pkg/kubernetes/views/user-panel.html:9
+#: pkg/kubernetes/views/auth-form.html:61
+#: pkg/kubernetes/views/volume-body.html:64
+#: pkg/kubernetes/views/volume-body.html:103
+msgid "User"
+msgstr "Kullanıcı"
+
+#: pkg/users/index.html:90 pkg/users/index.html:154
+#: pkg/realmd/operation.html:47
+msgid "User Name"
+msgstr "Kullanıcı Adı"
+
+#: pkg/realmd/operation.html:53
+msgid "User Password"
+msgstr "Kullanıcı Parolası"
+
+#: pkg/lib/machine-change-auth.html:18
+msgid "User name"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+#: pkg/kubernetes/views/add-member-role-dialog.html:15
+msgid "User or Group"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:94
 #, fuzzy
-msgid "Disk"
-msgstr "Diskler"
+msgid "Username"
+msgstr "Kullanıcı Adı"
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
+#: pkg/kubernetes/views/project-listing.html:85
+msgid "Users"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:870
-#, fuzzy, c-format
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] "Boş"
-msgstr[1] "Boş"
+#: pkg/storaged/details.js:181
+msgid "VFAT - Compatible with all systems and devices"
+msgstr "VFAT - Tüm sistemler ve cihazlarla uyumlu"
 
-#: pkg/kubernetes/scripts/nodes.js:872
+#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
+#: pkg/networkmanager/interfaces.js:2622
+msgid "VLAN"
+msgstr "VLAN"
+
+#: pkg/networkmanager/index.html:141
+msgid "VLAN Id"
+msgstr "VLAN id"
+
+#: pkg/networkmanager/index.html:736
+msgid "VLAN Settings"
+msgstr ""
+
+#: pkg/users/authorized-keys.js:103
+msgid "Validating key"
+msgstr "Anahtar doğrulanıyor"
+
+#: pkg/systemd/index.html:98 pkg/ostree/index.html:113 pkg/shell/simple.html:77
+#: pkg/shell/index.html:90 pkg/shell/stub.html:83
+msgid "Version"
+msgstr "Sürüm"
+
+#: pkg/storaged/jobs.js:137
+msgid "Very securely erasing $target"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
+#: pkg/kubernetes/views/pvc-body.html:6
 #, fuzzy
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] "Kullanılmış"
-msgstr[1] "Kullanılmış"
+msgid "Volume"
+msgstr "Mantıksal Bölüm"
 
-#: pkg/kubernetes/scripts/connection.js:88
-msgid "Error writing kubectl config"
+#: pkg/storaged/index.html:620
+msgid "Volume Group"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:514
-msgid "Couldn't find running API server"
+#: pkg/storaged/utils.js:239
+msgid "Volume Group $0"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:516
+#: pkg/storaged/index.html:98
+msgid "Volume Groups"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:14
+#: pkg/kubernetes/views/volume-body.html:89
+msgid "Volume ID"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:115
+#: pkg/kubernetes/views/volume-body.html:42
 #, fuzzy
-msgid "Connection Error: $0"
-msgstr "Docker'a bağlanılıyor"
+msgid "Volume Name"
+msgstr "Tam İsim"
 
-#: pkg/kubernetes/scripts/connection.js:539
+#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
+msgid "Volume Type"
+msgstr ""
+
+#: pkg/docker/index.html:536 pkg/kubernetes/views/pod-page.html:18
+#: pkg/kubernetes/views/image-config.html:28
+#: pkg/kubernetes/views/dashboard-page.html:47 pkg/kubernetes/index.html:70
+msgid "Volumes"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:819
+msgid "Waiting"
+msgstr "Bekleniyor"
+
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid "Warning:"
+msgstr ""
+
+#: pkg/systemd/logs.html:48
+msgid "Warnings"
+msgstr ""
+
+#: pkg/systemd/services.html:409
+msgid "Weeks"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:5
+msgid "Welcome to the Image Registry"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:61
+msgid "When"
+msgstr ""
+
+#: pkg/docker/index.html:507
+msgid "With terminal"
+msgstr "Terminal ile"
+
+#: pkg/storaged/index.html:438
 #, fuzzy
-msgid "Please provide a valid address"
-msgstr "Bir adres girin"
+msgctxt "storage"
+msgid "World Wide Name"
+msgstr "Tam İsim"
 
-#: pkg/kubernetes/scripts/connection.js:554
-msgid "Please provide a username"
+#: pkg/storaged/details.js:1595
+msgid "Write-mostly"
 msgstr ""
 
-#: pkg/kubernetes/scripts/connection.js:650
-msgid "Error getting certificate details: $0"
+#: pkg/storaged/index.html:333
+msgid "Writing"
+msgstr "Yazılıyor"
+
+#: pkg/ostree/client.js:64
+msgid "Writing objects"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr ""
+#: pkg/storaged/details.js:177
+msgid "XFS - Red Hat Enterprise Linux 7 default"
+msgstr "XFS - Red Hat Enterprise Linux 7 ön tanımlı"
 
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr ""
+#: pkg/networkmanager/interfaces.js:1824
+msgid "XOR"
+msgstr "XOR"
 
-#: pkg/kubernetes/scripts/volumes.js:194
-#, fuzzy
-msgid "Git Repository"
-msgstr "Depo"
+#: pkg/kubernetes/scripts/volumes.js:990 pkg/networkmanager/interfaces.js:2279
+msgid "Yes"
+msgstr "Evet"
 
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
-#, fuzzy
-msgid "Host Path"
-msgstr "Host"
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:199
-#, fuzzy
-msgid "NFS Mount"
-msgstr "Bağla"
-
-#: pkg/kubernetes/scripts/volumes.js:200
-#, fuzzy
-msgid "Rados Block Device"
-msgstr "Blok Aygıtı"
-
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
-msgid "ISCSI"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:203
-#, fuzzy
-msgid "Ceph Filesystem Mount"
-msgstr "Dosya sistemi tipi"
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:205
-#, fuzzy
-msgid "Flocker"
-msgstr "kilitlendi"
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:469
-msgid "Please select a valid access mode"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:477
-#, fuzzy
-msgid "Please provide a valid name"
-msgstr "Bir adres girin"
-
-#: pkg/kubernetes/scripts/volumes.js:485
-msgid "Please provide a valid storage capacity."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:493
-msgid "Please select a valid policy option."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:565
-msgid "Please select a valid endpoint"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:574
-msgid "Please provide a GlusterFS volume name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:632
-msgid "Please provide a valid NFS server"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
-msgid "Please provide a valid path"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:781
-#, fuzzy
-msgid "Please provide a valid target"
-msgstr "Bir adres girin"
-
-#: pkg/kubernetes/scripts/volumes.js:789
-msgid "Please provide a valid qualified name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:797
-msgid "Please provide a valid logical unit number"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:805
-msgid "Please provide a valid filesystem type"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:813
-msgid "Please provide a valid interface"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:860
-#, fuzzy
-msgid "NFS"
-msgstr "DNS"
-
-#: pkg/kubernetes/scripts/volumes.js:872
-msgid "GlusterFS"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:908
-msgid "Sorry, I don't know how to modify this volume"
-msgstr ""
-
-#: pkg/kubernetes/scripts/charts.js:113
-msgid "Unavailable"
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:384
+#: pkg/lib/machine-sync-users.html:47
 msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:401
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:413
-msgid "Unable to decode Kubernetes application manifest."
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:441
-msgid "Please create another namespace for $0 \"$1\""
-msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:460
-msgid "Manifest"
-msgstr ""
-
-#: pkg/dashboard/list.js:209
-msgid "The user <b>$0</b> is not permitted to manage servers"
+"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
+"synchronize users, a user with superuser privileges is required."
 msgstr ""
 
 #: pkg/dashboard/list.js:394
@@ -3191,3015 +5977,215 @@ msgid ""
 "You are currently connected directly to this server. You cannot delete it."
 msgstr "Şu an bu sunucuya doğrudan bağlısınız. Silme işlemi yapamazsınız."
 
-#: cockpit.appdata.xml.in.h:1
+#: pkg/kubernetes/views/auth-rejected-cert.html:3
 msgid ""
-"Cockpit is a server manager that makes it easy to administer your Linux "
-"servers via a web browser. Jumping between the terminal and the web tool is "
-"no problem. A service started via Cockpit can be stopped via the terminal. "
-"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
-"journal interface."
+"You can bypass the certificate check, but any data you send to the server "
+"could be intercepted by others."
 msgstr ""
 
-#: cockpit.appdata.xml.in.h:2
-msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
-"stopping services. You can monitor and administer several servers at the "
-"same time. Just add them with a single click and your machines will look "
-"after its buddies."
+#: pkg/kubernetes/views/dashboard-page.html:150
+msgid "You can deploy an application to your cluster."
 msgstr ""
 
-#: cockpit.desktop.in.h:1 pkg/shell/index.html.h:1 pkg/shell/stub.html.h:1
-#: pkg/shell/simple.html.h:1
-msgid "Cockpit"
-msgstr "Kokpit"
-
-#: cockpit.desktop.in.h:2
-msgid "A user interface for GNU/Linux servers"
-msgstr "GNU/Linux sunucular için bir kullanıcı arayüzü"
-
-#: cockpit.desktop.in.h:3
-msgid "Remote;Administration;"
-msgstr "Uzak;Yönetim;"
-
-#: pkg/systemd/index.html.h:1
-msgid "System"
-msgstr ""
-
-#: pkg/systemd/index.html.h:2
-#, fuzzy
-msgid "No host keys found."
-msgstr "Bulunamadı"
-
-#: pkg/systemd/index.html.h:3
-msgid "Synchronized with {{Server}}"
-msgstr ""
-
-#: pkg/systemd/index.html.h:4
-msgid "Synchronized"
-msgstr ""
-
-#: pkg/systemd/index.html.h:5
-msgid "Trying to synchronize with {{Server}}"
-msgstr ""
-
-#: pkg/systemd/index.html.h:6
-msgid "Not synchronized"
-msgstr ""
-
-#: pkg/systemd/index.html.h:7
-msgid "Hardware"
-msgstr ""
-
-#: pkg/systemd/index.html.h:8
-msgid "Asset Tag"
-msgstr ""
-
-#: pkg/systemd/index.html.h:9 pkg/kubernetes/views/node-body.html.h:6
-msgid "Machine ID"
-msgstr ""
-
-#: pkg/systemd/index.html.h:10 pkg/ostree/index.html.h:18
-#: pkg/kubernetes/views/nodes-page.html.h:6
-msgid "Operating System"
-msgstr ""
-
-#: pkg/systemd/index.html.h:11
-msgid "Secure Shell Keys"
-msgstr ""
-
-#: pkg/systemd/index.html.h:12
-msgid "Show fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:14 pkg/dashboard/index.html.h:7
-msgid "Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:15
-msgid "Domain"
-msgstr ""
-
-#: pkg/systemd/index.html.h:16
-msgid "System Time"
-msgstr ""
-
-#: pkg/systemd/index.html.h:17
-msgid "Power Options"
-msgstr "Güç Seçenekleri"
-
-#: pkg/systemd/index.html.h:20
-msgid "Performance Profile"
-msgstr ""
-
-#: pkg/systemd/index.html.h:21
-msgid "Store Performance Data"
-msgstr ""
-
-#: pkg/systemd/index.html.h:32
-msgid "Machine SSH Key Fingerprints"
-msgstr ""
-
-#: pkg/systemd/index.html.h:33
-msgid "Pretty Host Name"
-msgstr ""
-
-#: pkg/systemd/index.html.h:34
-msgid "Real Host Name"
-msgstr "Gerçek Host İsmi"
-
-#: pkg/systemd/index.html.h:35
-msgid "Time Zone"
-msgstr "Zaman Dilimi"
-
-#: pkg/systemd/index.html.h:36
-msgid ""
-"\n"
-"                                    Invalid time zone\n"
-"                                "
-msgstr ""
-
-#: pkg/systemd/index.html.h:39
-#, fuzzy
-msgid "Set Time"
-msgstr "Zamanı Ayarla"
-
-#: pkg/systemd/index.html.h:40
-#, fuzzy
-msgid "Manually"
-msgstr "Elle"
-
-#: pkg/systemd/index.html.h:41
-msgid "Automatically using NTP"
-msgstr ""
-
-#: pkg/systemd/index.html.h:42
-msgid "Automatically using specific NTP servers"
-msgstr ""
-
-#: pkg/systemd/index.html.h:43
-msgid "Delay"
-msgstr "Gecikme"
-
-#: pkg/systemd/index.html.h:44
-msgid "1 Minute"
-msgstr "1 dakika"
-
-#: pkg/systemd/index.html.h:45
-msgid "5 Minutes"
-msgstr "5 dakika"
-
-#: pkg/systemd/index.html.h:46
-msgid "20 Minutes"
-msgstr "20 dakika"
-
-#: pkg/systemd/index.html.h:47
-msgid "40 Minutes"
-msgstr "40 dakika"
-
-#: pkg/systemd/index.html.h:48
-msgid "60 Minutes"
-msgstr "60 dakika"
-
-#: pkg/systemd/index.html.h:49
-msgid "No Delay"
-msgstr "Gecikme yok"
-
-#: pkg/systemd/index.html.h:50
-msgid "Specific Time"
-msgstr "Özel Bir Zamanda"
-
-#: pkg/systemd/index.html.h:51
-msgid ""
-"\n"
-"                        Cancel\n"
-"                    "
-msgstr ""
-
-#: pkg/systemd/logs.html.h:1
-msgid "Journal"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:2
-msgid "Recent"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:3
-msgid "Current boot"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:4
-msgid "Last 24 hours"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:5
-msgid "Last 7 days"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:6
-msgid "Errors"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:7
-msgid "Warnings"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:8
-msgid "Notices"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:9
-msgid "All"
-msgstr "Hepsi"
-
-#: pkg/systemd/logs.html.h:10 pkg/kubernetes/views/container-panel.html.h:2
-#: pkg/kubernetes/views/container-page-inline.html.h:2
-msgid "Logs"
-msgstr ""
-
-#: pkg/systemd/logs.html.h:11
-msgid "Entry"
-msgstr ""
-
-#: pkg/systemd/services.html.h:1 pkg/kubernetes/views/dashboard-page.html.h:12
-#: pkg/kubernetes/views/details-page.html.h:3
-msgid "Services"
-msgstr "Servisler"
-
-#: pkg/systemd/services.html.h:3
-msgid "System Services"
-msgstr ""
-
-#: pkg/systemd/services.html.h:4
-msgid "Sockets"
-msgstr ""
-
-#: pkg/systemd/services.html.h:5
-msgid "Timers"
-msgstr ""
-
-#: pkg/systemd/services.html.h:6
-msgid "Paths"
-msgstr ""
-
-#: pkg/systemd/services.html.h:7
-msgid "Instantiate"
-msgstr ""
-
-#: pkg/systemd/services.html.h:8
-msgid "{{days_text}}"
-msgstr ""
-
-#: pkg/systemd/services.html.h:9
-msgid "Service Logs"
-msgstr ""
-
-#: pkg/systemd/services.html.h:10
-msgid "Note"
-msgstr ""
-
-#: pkg/systemd/services.html.h:11
-msgid ""
-"This unit is not designed to be enabled explicitly.\n"
-"          "
-msgstr ""
-
-#: pkg/systemd/services.html.h:15
-#, fuzzy
-msgid "Create Timers"
-msgstr "Zamanı Ayarla"
-
-#: pkg/systemd/services.html.h:16
-#, fuzzy
-msgid "Service name"
-msgstr "Servis"
-
-#: pkg/systemd/services.html.h:18 pkg/docker/index.html.h:32
-msgid "Command"
-msgstr "Komut"
-
-#: pkg/systemd/services.html.h:19
-#, fuzzy
-msgid "Run"
-msgstr "Çalışıyor"
-
-#: pkg/systemd/services.html.h:20
-msgid "After system boot"
-msgstr ""
-
-#: pkg/systemd/services.html.h:21
-#, fuzzy
-msgid "At specific time"
-msgstr "Özel Bir Zamanda"
-
-#: pkg/systemd/services.html.h:22
-msgid "Seconds"
-msgstr ""
-
-#: pkg/systemd/services.html.h:23
-#, fuzzy
-msgid "Minutes"
-msgstr "5 dakika"
-
-#: pkg/systemd/services.html.h:24
-#, fuzzy
-msgid "Hours"
-msgstr "6 saat"
-
-#: pkg/systemd/services.html.h:25
-msgid "Weeks"
-msgstr ""
-
-#: pkg/systemd/services.html.h:26
-msgid "Don't Repeat"
-msgstr ""
-
-#: pkg/systemd/services.html.h:27
-msgid "Repeat Hourly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:28
-msgid "Repeat Daily"
-msgstr ""
-
-#: pkg/systemd/services.html.h:29
-msgid "Repeat Weekly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:30
-msgid "Repeat Monthly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:31
-msgid "Repeat Yearly"
-msgstr ""
-
-#: pkg/systemd/services.html.h:32
-#, fuzzy
-msgid "Hour : Minute"
-msgstr "1 dakika"
-
-#: pkg/systemd/services.html.h:33
-msgid ":"
-msgstr ""
-
-#: pkg/systemd/services.html.h:35
-msgid "Save"
-msgstr ""
-
-#: pkg/systemd/terminal.html.h:1
-msgid "Terminal"
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:1
-msgid "Incorrect Host Key"
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:2
-msgid ""
-"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
-"in use. Unless this machine was recently replaced, it is likely that someone "
-"is trying to attack your connection to this machine."
-msgstr ""
-
-#: pkg/lib/machine-invalid-hostkey.html.h:3
+#: pkg/lib/machine-invalid-hostkey.html:11
 msgid ""
 "You can remove the previously stored key by running the following command"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html.h:1
-msgid "Authentication Failed"
+#: pkg/shell/base_index.js:672
+msgid "You can try restarting Cockpit by pressing refresh in your browser. "
 msgstr ""
+"Tarayıcınızda yenileye basarak Cockpit'i yeniden başlatmayı deneyebilirsiniz."
 
-#: pkg/lib/machine-auth-failed.html.h:2
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
-"machine with cockpit you will need to enable one of the following "
-"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:4 pkg/shell/index.html.h:30
-msgid "Public Key"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:5
-msgid "Kerberos Based SSO"
-msgstr ""
-
-#: pkg/lib/machine-auth-failed.html.h:6
-msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:1 pkg/dashboard/index.html.h:11
-msgid "Synchronize users"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:2
-msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:3
-msgid "Error loading users: {{perm_failed}}"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:4
-msgid ""
-"You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
-"synchronize users, a user with superuser privileges is required."
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:5 pkg/lib/machine-change-auth.html.h:4
-msgid "User name"
-msgstr ""
-
-#: pkg/lib/machine-sync-users.html.h:8
-msgid "Synchronize"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:1
-msgid "Unknown Host Key"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:2
-msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:3 pkg/shell/index.html.h:4
-msgid "Fingerprint"
-msgstr ""
-
-#: pkg/lib/machine-unknown-hostkey.html.h:5
-#: pkg/kubernetes/views/auth-form.html.h:14
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:6
-msgid "Connect"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:1
-msgid "Add Machine to Dashboard"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:3 pkg/dashboard/index.html.h:9
-msgid "Color"
-msgstr ""
-
-#: pkg/lib/machine-add.html.h:4
-msgid ""
-"Connecting simultaneously to more than {{ limit }} machines is unsupported."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:1
-msgid "Could not contact {{host}}"
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:2
-msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:3
-msgid ""
-"To try a different port you will need to upgrade cockpit-ws to a newer "
-"version."
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:4
-msgid "Is sshd running on a different port?"
-msgstr ""
-
-#: pkg/lib/machine-change-port.html.h:7
-msgid "Update"
-msgstr ""
-
-#: pkg/lib/machine-not-supported.html.h:1
-msgid "Cockpit is not installed"
-msgstr ""
-
-#: pkg/lib/machine-not-supported.html.h:2
-msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:1
-msgid "Log in to {{host}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:2
-msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:3
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:5 pkg/shell/index.html.h:9
-#: pkg/realmd/operation.html.h:3 pkg/kubernetes/views/auth-form.html.h:8
-msgid "Authentication"
-msgstr "Yetkilendirme"
-
-#: pkg/lib/machine-change-auth.html.h:7
-msgid "Available"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:8
-msgid "Login Password"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:9
-msgid "Kerberos Ticket"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:10
-msgid "Checking for public keys"
-msgstr ""
-
-#: pkg/lib/machine-change-auth.html.h:12
-msgid "Log In"
-msgstr ""
-
-#: pkg/shell/shell.html.h:1
-msgid "Things have moved"
-msgstr ""
-
-#: pkg/shell/index.html.h:2
-msgid "Comment"
-msgstr ""
-
-#: pkg/shell/index.html.h:5 pkg/shell/stub.html.h:2 pkg/shell/simple.html.h:2
-msgid "Ooops!"
-msgstr "Tüh!"
-
-#: pkg/shell/index.html.h:6 pkg/shell/stub.html.h:3 pkg/shell/simple.html.h:3
-msgid "Display Language"
-msgstr ""
-
-#: pkg/shell/index.html.h:7 pkg/shell/stub.html.h:4 pkg/shell/simple.html.h:4
-msgid "About Cockpit"
-msgstr "Kokpit Hakkında"
-
-#: pkg/shell/index.html.h:8
-msgid "Account Settings"
-msgstr "Hesap Ayarları"
-
-#: pkg/shell/index.html.h:10 pkg/shell/stub.html.h:5 pkg/shell/simple.html.h:5
-msgid "Log out"
-msgstr "Çıkış Yap"
-
-#: pkg/shell/index.html.h:11 pkg/shell/stub.html.h:6 pkg/shell/simple.html.h:6
-msgid ""
-"\n"
-"              Cockpit is an interactive Linux server admin interface.\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:15 pkg/shell/stub.html.h:10
-#: pkg/shell/simple.html.h:10
-msgid "Choose the language to be used in the application"
-msgstr ""
-
-#: pkg/shell/index.html.h:16 pkg/shell/stub.html.h:11
-#: pkg/shell/simple.html.h:11 pkg/storaged/index.html.h:59
-msgid ""
-"\n"
-"              Cancel\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:19 pkg/shell/stub.html.h:14
-#: pkg/shell/simple.html.h:14
-msgid ""
-"\n"
-"              Select\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:22 pkg/shell/stub.html.h:17
-msgid ""
-"\n"
-"              Close\n"
-"            "
-msgstr ""
-
-#: pkg/shell/index.html.h:25
-msgid "Use my password for privileged tasks and to connect to other machines"
-msgstr ""
-
-#: pkg/shell/index.html.h:26
-msgid "Use the following keys to authenticate against other systems"
-msgstr ""
-
-#: pkg/shell/index.html.h:29 pkg/kubernetes/index.html.h:6
-msgid "Details"
-msgstr ""
-
-#: pkg/shell/index.html.h:32
-msgid "Unlock Key"
-msgstr ""
-
-#: pkg/shell/index.html.h:33 pkg/users/index.html.h:23
-msgid "Old Password"
-msgstr "Eski Parola"
-
-#: pkg/shell/index.html.h:34 pkg/users/index.html.h:24
-msgid "New Password"
-msgstr "Yeni Parola"
-
-#: pkg/shell/index.html.h:35 pkg/users/index.html.h:19
-msgid "Confirm"
-msgstr "Onayla"
-
-#: pkg/shell/index.html.h:36
-msgid "Change Password"
-msgstr ""
-
-#: pkg/shell/index.html.h:38 pkg/shell/stub.html.h:20
-msgid ""
-"\n"
-"                Tools\n"
-"              "
-msgstr ""
-
-#: pkg/shell/index.html.h:41 pkg/shell/stub.html.h:23
-#: pkg/shell/simple.html.h:24
-msgid "Reconnect"
-msgstr ""
-
-#: pkg/shell/index.html.h:42 pkg/shell/stub.html.h:24
-msgid "Troubleshoot"
-msgstr ""
-
-#: pkg/shell/simple.html.h:18
-msgid ""
-"\n"
-"              Try to reconnect\n"
-"            "
-msgstr ""
-
-#: pkg/shell/simple.html.h:21
-msgid ""
-"\n"
-"              Log in again\n"
-"            "
-msgstr ""
-
-#: pkg/ostree/index.html.h:1
-msgid "Software Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:2
-msgid "Check for updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:3
-msgid ""
-"\n"
-"                    Update and reboot\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:6
-msgid "Roll back and reboot"
-msgstr ""
-
-#: pkg/ostree/index.html.h:8
-msgid ""
-"\n"
-"                    Default\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:11
-msgid ""
-"\n"
-"                    Available\n"
-"                  "
-msgstr ""
-
-#: pkg/ostree/index.html.h:16
-msgid "Tree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:17
-msgid "Packages"
-msgstr ""
-
-#: pkg/ostree/index.html.h:20
-msgid "Released"
-msgstr ""
-
-#: pkg/ostree/index.html.h:21
-msgid "Additions"
-msgstr ""
-
-#: pkg/ostree/index.html.h:22
-msgid "Removals"
-msgstr ""
-
-#: pkg/ostree/index.html.h:23
-msgid "Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:24
-msgid "Downgrades"
-msgstr ""
-
-#: pkg/ostree/index.html.h:25
-msgid ""
-"\n"
-"                    This deployment contains the same packages as your "
-"currently booted system\n"
-"                "
-msgstr ""
-
-#: pkg/ostree/index.html.h:28
-msgid "Operating System Updates"
-msgstr ""
-
-#: pkg/ostree/index.html.h:29
-msgid "Connecting"
-msgstr ""
-
-#: pkg/ostree/index.html.h:30
-msgid "Unable to communicate with OSTree"
-msgstr ""
-
-#: pkg/ostree/index.html.h:31
-msgid "No Deployments"
-msgstr ""
-
-#: pkg/ostree/index.html.h:32
-msgid ""
-"\n"
-"                    Reconnect\n"
-"                "
-msgstr ""
-
-#: pkg/selinux/setroubleshoot.html.h:1
-msgid "SELinux Troubleshoot"
-msgstr ""
-
-#: pkg/machines/index.html.h:1
-msgid "Virtual Machines Management"
-msgstr ""
-
-#: pkg/storaged/index.html.h:1
-msgid "Storage"
-msgstr "Depolama"
-
-#: pkg/storaged/index.html.h:2
-msgid "The \"storaged\" API is not available on this system."
-msgstr ""
-
-#: pkg/storaged/index.html.h:3
-msgid "Start Multipath"
-msgstr ""
-
-#: pkg/storaged/index.html.h:4
-msgid ""
-"\n"
-"        There are devices with multiple paths on the system, but the "
-"multipath service is not running.\n"
-"      "
-msgstr ""
-
-#: pkg/storaged/index.html.h:7
-msgid "RAID Devices"
-msgstr "RAID Aygıtları"
-
-#: pkg/storaged/index.html.h:8
-msgid "No storage set up as RAID"
-msgstr ""
-
-#: pkg/storaged/index.html.h:9
-msgid "Volume Groups"
-msgstr ""
-
-#: pkg/storaged/index.html.h:10
-msgid "No volume groups created"
-msgstr ""
-
-#: pkg/storaged/index.html.h:11
-msgid "iSCSI Targets"
-msgstr ""
-
-#: pkg/storaged/index.html.h:12
-msgid "{{Address}}:{{Port}}"
-msgstr ""
-
-#: pkg/storaged/index.html.h:13
-msgid "No iSCSI targets set up"
-msgstr ""
-
-#: pkg/storaged/index.html.h:14
-msgid "Drives"
-msgstr ""
-
-#: pkg/storaged/index.html.h:15
-msgid "No drives attached"
-msgstr ""
-
-#: pkg/storaged/index.html.h:16
-msgid "Other Devices"
-msgstr "Diğer Aygıtlar"
-
-#: pkg/storaged/index.html.h:17
-msgid "Filesystems"
-msgstr "Dosya Sistemleri"
-
-#: pkg/storaged/index.html.h:21
-msgid "Jobs"
-msgstr "İşler"
-
-#: pkg/storaged/index.html.h:23 pkg/networkmanager/index.html.h:3
-msgid "Go to now"
-msgstr "Şimdiye git"
-
-#: pkg/storaged/index.html.h:24 pkg/networkmanager/index.html.h:4
-msgid "5 minutes"
-msgstr "5 dakika"
-
-#: pkg/storaged/index.html.h:25 pkg/networkmanager/index.html.h:5
-msgid "1 hour"
-msgstr "1 saat "
-
-#: pkg/storaged/index.html.h:26 pkg/networkmanager/index.html.h:6
-msgid "6 hours"
-msgstr "6 saat"
-
-#: pkg/storaged/index.html.h:27 pkg/networkmanager/index.html.h:7
-msgid "1 day"
-msgstr "1 gün"
-
-#: pkg/storaged/index.html.h:28 pkg/networkmanager/index.html.h:8
-msgid "1 week"
-msgstr "1 hafta"
-
-#: pkg/storaged/index.html.h:29
-msgid "Reading"
-msgstr "Okunuyor"
-
-#: pkg/storaged/index.html.h:30
-msgid "Writing"
-msgstr "Yazılıyor"
-
-#: pkg/storaged/index.html.h:31
-msgid "Storage Logs"
-msgstr ""
-
-#: pkg/storaged/index.html.h:32
-msgid "Create partition table"
-msgstr ""
-
-#: pkg/storaged/index.html.h:34
-msgid "Block Device"
-msgstr "Blok Aygıtı"
-
-#: pkg/storaged/index.html.h:40
-msgid "No media inserted"
-msgstr ""
-
-#: pkg/storaged/index.html.h:42
-msgid "DISK IS FAILING"
-msgstr "DİSK BOZULUYOR"
-
-#: pkg/storaged/index.html.h:43
-msgid "Disk is OK"
-msgstr "Disk durumu iyi"
-
-#: pkg/storaged/index.html.h:46
-msgid "The RAID Array is in a degraded state"
-msgstr ""
-
-#: pkg/storaged/index.html.h:47
-msgid "RAID Device"
-msgstr "RAID Aygıtı"
-
-#: pkg/storaged/index.html.h:56
-msgid "Volume Group"
-msgstr ""
-
-#: pkg/storaged/index.html.h:57
-msgid "Physical Volumes"
-msgstr ""
-
-#: pkg/storaged/index.html.h:58
-msgid "Storage Log"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:1
-msgid "Domain Address"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:2
-msgid "Computer OU"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:4 pkg/users/index.html.h:11
-msgid "User Name"
-msgstr "Kullanıcı Adı"
-
-#: pkg/realmd/operation.html.h:5
-msgid "User Password"
-msgstr "Kullanıcı Parolası"
-
-#: pkg/realmd/operation.html.h:6
-msgid "Domain Administrator Name"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:7
-msgid "Domain Administrator Password"
-msgstr ""
-
-#: pkg/realmd/operation.html.h:8
-msgid "One Time Password"
-msgstr "Tek Seferlik Parola"
-
-#: pkg/realmd/operation.html.h:9
-msgid "This may take a while"
-msgstr "Bu biraz zaman alabilir"
-
-#: pkg/docker/index.html.h:1 pkg/kubernetes/index.html.h:4
-#: pkg/kubernetes/views/containers-listing.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:6
-#: pkg/kubernetes/views/dashboard-page.html.h:17
-msgid "Containers"
-msgstr "Konteynerler"
-
-#: pkg/docker/index.html.h:2
-msgid "Connecting to Docker"
-msgstr "Docker'a bağlanılıyor"
-
-#: pkg/docker/index.html.h:3
-msgid "Not authorized to access Docker on this system"
-msgstr "Bu sistem üzerinde Docker'e erişim yetkisi yok"
-
-#: pkg/docker/index.html.h:4
-msgid "Docker is not installed or activated on the system"
-msgstr "Docker sistemde yüklü ya da aktif değil"
-
-#: pkg/docker/index.html.h:5
-#, fuzzy
-msgid "Can&rsquo;t connect to Docker"
-msgstr "Docker'a bağlanılamadı"
-
-#: pkg/docker/index.html.h:6
-msgid "Start Docker"
-msgstr "Docker'ı Başlat"
-
-#: pkg/docker/index.html.h:7
-msgid "Try again"
-msgstr "Tekrar Dene"
-
-#: pkg/docker/index.html.h:8
-msgid "Combined CPU usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:9
-msgid "Combined memory usage"
-msgstr ""
-
-#: pkg/docker/index.html.h:10
-#, fuzzy
-msgid "Show all containers"
-msgstr "Konteynerler"
-
-#: pkg/docker/index.html.h:11
-#, fuzzy
-msgid "IP Address:"
-msgstr "Adres"
-
-#: pkg/docker/index.html.h:12
-#, fuzzy
-msgid "IP Prefix Length:"
-msgstr "Ön ek uzunluğu"
-
-#: pkg/docker/index.html.h:13
-msgid "Gateway:"
-msgstr ""
-
-#: pkg/docker/index.html.h:14
-#, fuzzy
-msgid "MAC Address:"
-msgstr "Adres"
-
-#: pkg/docker/index.html.h:15 pkg/kubernetes/views/image-page.html.h:1
-msgid "Show all images"
-msgstr ""
-
-#: pkg/docker/index.html.h:16 pkg/kubernetes/index.html.h:2
-#: pkg/kubernetes/registry.html.h:2
-#, fuzzy
-msgid "Overview"
-msgstr "Servis"
-
-#: pkg/docker/index.html.h:17
-msgid "Reset"
-msgstr ""
-
-#: pkg/docker/index.html.h:18
-#, fuzzy
-msgid "Storage pool"
-msgstr "Depolama"
-
-#: pkg/docker/index.html.h:19
-msgid "Additional Storage"
-msgstr ""
-
-#: pkg/docker/index.html.h:20
-msgid "TCP"
-msgstr "TCP"
-
-#: pkg/docker/index.html.h:21
-msgid "{{host_port_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:22
-msgid "{{host_volume_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:24
-#, fuzzy
-msgid "ReadWrite"
-msgstr "Okunuyor"
-
-#: pkg/docker/index.html.h:25
-#, fuzzy
-msgid "ReadOnly"
-msgstr "Hazır"
-
-#: pkg/docker/index.html.h:26
-msgid "{{envvar_key_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:27
-msgid "{{envvar_value_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:28
-msgid "select container"
-msgstr ""
-
-#: pkg/docker/index.html.h:29
-msgid "{{alias_label}}"
-msgstr ""
-
-#: pkg/docker/index.html.h:30 pkg/kubernetes/views/image-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:2
-#: pkg/kubernetes/views/image-page.html.h:2
-msgid "Image"
-msgstr "Kalıp"
-
-#: pkg/docker/index.html.h:31
-msgid "Container Name"
-msgstr "Konteyner İsmi"
-
-#: pkg/docker/index.html.h:33
-msgid "Memory limit"
-msgstr "Bellek limiti"
-
-#: pkg/docker/index.html.h:34
-msgid "MiB"
-msgstr ""
-
-#: pkg/docker/index.html.h:35
-msgid "CPU priority"
-msgstr "CPU önceliği"
-
-#: pkg/docker/index.html.h:36
-#, fuzzy
-msgid "shares"
-msgstr "Paylaşılan"
-
-#: pkg/docker/index.html.h:37
-msgid "With terminal"
-msgstr "Terminal ile"
-
-#: pkg/docker/index.html.h:38
-msgid "Links"
-msgstr "Linkler"
-
-#: pkg/docker/index.html.h:40
-msgid "Expose container ports"
-msgstr ""
-
-#: pkg/docker/index.html.h:41 pkg/kubernetes/index.html.h:7
-#: pkg/kubernetes/views/image-config.html.h:9
-#: pkg/kubernetes/views/pod-page.html.h:3
-#: pkg/kubernetes/views/dashboard-page.html.h:4
-msgid "Volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:42
-msgid "Mount container volumes"
-msgstr ""
-
-#: pkg/docker/index.html.h:43 pkg/kubernetes/views/image-config.html.h:6
-#: pkg/kubernetes/views/container-body.html.h:9
-msgid "Environment"
-msgstr ""
-
-#: pkg/docker/index.html.h:44
-msgid "Set container environment variables"
-msgstr ""
-
-#: pkg/docker/index.html.h:45 pkg/kubernetes/views/pod-body.html.h:4
-msgid "Restart Policy"
-msgstr ""
-
-#: pkg/docker/index.html.h:47
-msgid "On Failure"
-msgstr ""
-
-#: pkg/docker/index.html.h:50
-msgid "Retries:"
-msgstr ""
-
-#: pkg/docker/index.html.h:51 pkg/users/index.html.h:26
-#: pkg/networkmanager/index.html.h:52
-msgid ""
-"\n"
-"            Cancel\n"
-"          "
-msgstr ""
-
-#: pkg/docker/index.html.h:54
-msgid ""
-"\n"
-"            Run\n"
-"          "
-msgstr ""
-
-#: pkg/docker/index.html.h:57
-msgid ""
-"\n"
-"            Download\n"
-"          "
-msgstr ""
-
-#: pkg/docker/index.html.h:60
-msgid ""
-"\n"
-"            Change\n"
-"          "
-msgstr ""
-
-#: pkg/docker/index.html.h:63
-msgid "Repository"
-msgstr "Depo"
-
-#: pkg/docker/index.html.h:64
-msgid "Tag"
-msgstr "Etiket"
-
-#: pkg/docker/index.html.h:65 pkg/kubernetes/views/image-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:5
-msgid "Author"
-msgstr "Yazar"
-
-#: pkg/docker/index.html.h:66
-msgid ""
-"\n"
-"            Commit\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:1
-msgid "Local Accounts"
-msgstr ""
-
-#: pkg/users/index.html.h:2
-msgid ""
-"\n"
-"            Close\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:5
-msgid "Create New Account"
-msgstr "Yeni Hesap Yarat"
-
-#: pkg/users/index.html.h:6
-msgid "Account not available or cannot be edited."
-msgstr ""
-
-#: pkg/users/index.html.h:7
-msgid "Accounts"
-msgstr ""
-
-#: pkg/users/index.html.h:8
-msgid "Terminate Session"
-msgstr ""
-
-#: pkg/users/index.html.h:10
-msgid "Full Name"
-msgstr "Tam İsim"
-
-#: pkg/users/index.html.h:12
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:3
-#: pkg/kubernetes/views/project-body.html.h:2
-msgid "Roles"
-msgstr "Roller"
-
-#: pkg/users/index.html.h:13
-msgid "Last Login"
-msgstr "Son Giriş"
-
-#: pkg/users/index.html.h:14
-msgid "Access"
-msgstr "Erişim"
-
-#: pkg/users/index.html.h:15
-msgid "Lock Account"
-msgstr "Hesabı Kilitle"
-
-#: pkg/users/index.html.h:17
-msgid "Set Password"
-msgstr "Parola Belirle"
-
-#: pkg/users/index.html.h:18
-msgid "Authorized Public SSH Keys"
-msgstr "Yetkilendirilmiş Açık SSH Anahtarları"
-
-#: pkg/users/index.html.h:20
-msgid ""
-"\n"
-"            Create\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:25
-msgid "Confirm New Password"
-msgstr "Yeni Parolayı Onayla"
-
-#: pkg/users/index.html.h:29
-msgid ""
-"\n"
-"            Set\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:32
-msgid "Delete Files"
-msgstr "Dosyaları Sil"
-
-#: pkg/users/index.html.h:33 pkg/networkmanager/index.html.h:48
-msgid ""
-"\n"
-"            Delete\n"
-"          "
-msgstr ""
-
-#: pkg/users/index.html.h:36
-msgid "Unnamed"
-msgstr "İsimsiz"
-
-#: pkg/users/index.html.h:37
-msgid "Invalid key"
-msgstr "Geçersiz anahtar"
-
-#: pkg/users/index.html.h:38
-msgid "There are no authorized public keys for this account."
-msgstr "Bu hesap için yetkilendirilmiş açık anahtar yok."
-
-#: pkg/users/index.html.h:39
+#: pkg/users/index.html:335
 msgid ""
 "You do not have permission to view the authorized public keys for this "
 "account."
 msgstr ""
 "Bu hesabın yetkilendirilmiş açık anahtarlarını görmeniz için izniniz yok."
 
-#: pkg/users/index.html.h:40
-msgid "Failed to load authorized keys."
-msgstr "Yetkilendirilmiş anahtarların yüklemesi başarısız oldu."
-
-#: pkg/users/index.html.h:41
-msgid "Add public key"
-msgstr "Açık anahtar ekle"
-
-#: pkg/users/index.html.h:42
-msgid ""
-"\n"
-"            Add key\n"
-"          "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:1
-msgid "Diagnostic reports"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:2
-msgid ""
-"\n"
-"        This tool will collect system configuration and diagnostic\n"
-"        information from this system for use with diagnosing problems\n"
-"        with the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:7
-msgid ""
-"\n"
-"        The collected information will be stored locally on the system.\n"
-"      "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:10
-msgid "Create report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:11
-msgid "Create diagnostic report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:12
-msgid ""
-"\n"
-"                The generated archive contains data considered\n"
-"                sensitive and its content should be reviewed by the\n"
-"                originating organization before being passed to any\n"
-"                third party.\n"
-"              "
-msgstr ""
-
-#: pkg/sosreport/index.html.h:18
-msgid "Generating report"
-msgstr ""
-
-#: pkg/sosreport/index.html.h:19
-msgid "Done!"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:1
-msgid "Networking"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:2
-msgid "Testing connection"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:9
-msgid "Sending"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:10
-msgid "Receiving"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:11
-msgid "Interfaces"
-msgstr "Arayüzler"
-
-#: pkg/networkmanager/index.html.h:12
-msgid "Add Bond"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:13
+#: pkg/docker/storage.jsx:482
 #, fuzzy
-msgid "Add Team"
-msgstr "Roller"
-
-#: pkg/networkmanager/index.html.h:14
-msgid "Add Bridge"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:15
-msgid "Add VLAN"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:17
-msgid "IP Address"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:18
-#, fuzzy
-msgid "Unmanaged Interfaces"
-msgstr "Arayüzler"
-
-#: pkg/networkmanager/index.html.h:19
-msgid "Networking Logs"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:20
-msgid "Parent"
-msgstr "Ana"
-
-#: pkg/networkmanager/index.html.h:21
-msgid "VLAN Id"
-msgstr "VLAN id"
-
-#: pkg/networkmanager/index.html.h:23
-#, fuzzy
-msgid "Set to"
-msgstr "Zamanı Ayarla"
-
-#: pkg/networkmanager/index.html.h:25
-msgid "Spanning Tree Protocol (STP)"
-msgstr "Spanning Tree Protocol (STP)"
-
-#: pkg/networkmanager/index.html.h:26
-msgid "STP Priority"
-msgstr "STP Önceliği"
-
-#: pkg/networkmanager/index.html.h:27
-msgid "STP Forward delay"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:28
-msgid "STP Hello time"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:29
-msgid "STP Maximum message age"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:30
-msgid "Priority"
-msgstr "Öncelik"
-
-#: pkg/networkmanager/index.html.h:31
-msgid "Path cost"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:32
-msgid "Hair Pin mode"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:34
-msgid "Mode"
-msgstr "Mod"
-
-#: pkg/networkmanager/index.html.h:35
-msgid "Primary"
-msgstr "Öncelikli"
-
-#: pkg/networkmanager/index.html.h:36
-msgid "Link Monitoring"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:37
-msgid "Monitoring Interval"
-msgstr "İzleme Sıklığı"
-
-#: pkg/networkmanager/index.html.h:38
-msgid "Monitoring Targets"
-msgstr "İzleme Hedefleri"
-
-#: pkg/networkmanager/index.html.h:39
-msgid "Link up delay"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:40
-msgid "Link down delay"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:41
-#, fuzzy
-msgid "Runner"
-msgstr "Çalışıyor"
-
-#: pkg/networkmanager/index.html.h:42
-msgid "Balancer"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:43
-msgid "Link Watch"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:44
-#, fuzzy
-msgid "Ping Interval"
-msgstr "İzleme Sıklığı"
-
-#: pkg/networkmanager/index.html.h:45
-#, fuzzy
-msgid "Ping Target"
-msgstr "İzleme Hedefleri"
-
-#: pkg/networkmanager/index.html.h:46
-msgid "Sticky"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:47
-msgid "LACP Key"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:51
-msgid "IP Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:55
-msgid ""
-"\n"
-"            Apply\n"
-"          "
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:58
-msgid "Bond Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:59
-#, fuzzy
-msgid "Team Settings"
-msgstr "IPv4 Ayarları"
-
-#: pkg/networkmanager/index.html.h:60
-#, fuzzy
-msgid "Team Port Settings"
-msgstr "Hesap Ayarları"
-
-#: pkg/networkmanager/index.html.h:61
-msgid "Bridge Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:62
-msgid "Bridge Port Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:63
-msgid "VLAN Settings"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:64
-msgid "Ethernet MTU"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:66
-#, fuzzy
-msgid "Connection will be lost"
-msgstr "Hesap Ayarları"
-
-#: pkg/kubernetes/index.html.h:1
-msgid "Kubernetes Cluster"
-msgstr "Kubernetes kümesi"
-
-#: pkg/kubernetes/index.html.h:3 pkg/kubernetes/views/dashboard-page.html.h:8
-#: pkg/kubernetes/views/nodes-page.html.h:4
-msgid "Nodes"
-msgstr "Düğümler"
-
-#: pkg/kubernetes/index.html.h:5
-msgid "Topology"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:8 pkg/kubernetes/registry.html.h:3
-#: pkg/kubernetes/views/image-listing.html.h:2
-#: pkg/kubernetes/views/imagestream-page.html.h:3
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:5
-msgid "Images"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:9 pkg/kubernetes/registry.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:2
-#: pkg/kubernetes/views/project-listing.html.h:2
-#: pkg/kubernetes/views/user-delete.html.h:2
-msgid "Projects"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:11 pkg/kubernetes/registry.html.h:6
-msgid "Couldn't connect to server"
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:12 pkg/kubernetes/registry.html.h:7
-msgid ""
-"\n"
-"                Reconnect\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/index.html.h:15
-msgid ""
-"\n"
-"                Troubleshoot\n"
-"            "
-msgstr ""
-
-#: pkg/kubernetes/registry.html.h:1
-msgid "Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:1
-#: pkg/kubernetes/views/service-body.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:1
-#: pkg/kubernetes/views/containers-listing.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:9
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:18
-#: pkg/kubernetes/views/route-body.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:5
-#: pkg/kubernetes/views/imagestream-modify.html.h:4
-msgid "Project"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:2
-#: pkg/kubernetes/views/service-body.html.h:2
-#: pkg/kubernetes/views/pod-body.html.h:2
-#: pkg/kubernetes/views/containers-listing.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:10
-#: pkg/kubernetes/views/pv-claim.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:19
-#: pkg/kubernetes/views/route-body.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:6
-msgid "Namespace"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:3
-#: pkg/kubernetes/views/pod-body.html.h:3
-#: pkg/kubernetes/views/node-body.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:3
-#: pkg/kubernetes/views/route-body.html.h:3
-msgid "Created"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:4
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:17
-msgid "Replicas"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:5
-#: pkg/kubernetes/views/service-body.html.h:9
-#: pkg/kubernetes/views/pod-body.html.h:10
-#: pkg/kubernetes/views/node-body.html.h:12
-#: pkg/kubernetes/views/image-meta.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:8
-#: pkg/kubernetes/views/route-body.html.h:8
-msgid "Labels"
-msgstr "Etiketler"
-
-#: pkg/kubernetes/views/service-body.html.h:4
-#: pkg/kubernetes/views/node-body.html.h:3
-msgid "IP"
-msgstr ""
-
-#: pkg/kubernetes/views/service-body.html.h:8
-msgid "Session Affinity"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:1
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:10
-msgid "New image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:3
-#: pkg/kubernetes/views/image-body.html.h:10
-#: pkg/kubernetes/views/imagestream-modify.html.h:7
-msgid "Tags"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:5
-msgid "Last Updated"
-msgstr ""
-
-#: pkg/kubernetes/views/image-listing.html.h:6
-msgid "No image streams are present."
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:1
-#, fuzzy
-msgid "Delete Node"
-msgstr "Sil"
-
-#: pkg/kubernetes/views/node-delete.html.h:2
-msgid "Do you want to delete this Node?"
-msgstr ""
-
-#: pkg/kubernetes/views/node-delete.html.h:3
-msgid " 1\">Do you want to delete the following Nodes?"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-container.html.h:1
-#, fuzzy
-msgid "Show all Pod Containers"
-msgstr "Konteynerler"
-
-#: pkg/kubernetes/views/image-panel.html.h:3
-#: pkg/kubernetes/views/imagestream-page.html.h:4
-#: pkg/kubernetes/views/image-page.html.h:4
-msgid "Metadata"
-msgstr ""
-
-#: pkg/kubernetes/views/node-panel.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:8
-#: pkg/kubernetes/views/containers-listing.html.h:6
-#: pkg/kubernetes/views/node-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:11
-msgid "Node"
-msgstr "Düğüm"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:1
-#, fuzzy
-msgid "Show all Replication Controllers"
-msgstr "Replikasyon Kontrolörleri"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:2
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:5
-msgid "Replication Controller"
-msgstr "Replikasyon Kontrolörü"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:2
-#: pkg/kubernetes/views/pv-claim.html.h:9
-#: pkg/kubernetes/views/dashboard-page.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:18
-msgid "Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:2
-msgid "Template"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:5
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/group-delete.html.h:1
-#, fuzzy
-msgid "Remove Group"
-msgstr "Kaldır"
-
-#: pkg/kubernetes/views/group-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:5
-#: pkg/kubernetes/views/user-group-remove.html.h:3
-msgid "Remove"
-msgstr "Kaldır"
-
-#: pkg/kubernetes/views/pvc-delete.html.h:1
-msgid "Delete Persistent Volume Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:2
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html.h:3
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:5
-msgid "Service Account"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:6
-msgid "DNS Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:7
-msgid "Phase"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-body.html.h:9
-msgid "Pod Address"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:5
-msgid "OS"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:7
-msgid "Boot ID"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:8
-#, fuzzy
-msgid "Kernel Version"
-msgstr "Sürüm"
-
-#: pkg/kubernetes/views/node-body.html.h:9
-msgid "Container Runtime Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:10
-msgid "Kubelet Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:11
-msgid "Proxy Version"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:13
-#: pkg/kubernetes/views/route-body.html.h:9
-msgid "none"
-msgstr "hiç biri"
-
-#: pkg/kubernetes/views/node-body.html.h:17
-msgid "Reason"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:18
-#: pkg/kubernetes/views/pv-claim.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:6 pkg/kubernetes/views/pv-body.html.h:6
-msgid "Message"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:19
-msgid "Last Heartbeat"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:20
-msgid "Last Status Change"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html.h:21
-#: pkg/kubernetes/views/image-meta.html.h:3
-#: pkg/kubernetes/views/imagestream-meta.html.h:1
-#: pkg/kubernetes/views/route-body.html.h:10
-msgid "Annotations"
-msgstr ""
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:1
-#, fuzzy
-msgid "Remove Role"
-msgstr "Kaldır"
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:2
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member "
-"{{ fields.member.metadata.name }}?"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:1
-msgid "New Project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:6
-msgid "No projects are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:7
-msgid "New Group"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:8
-#: pkg/kubernetes/views/user-delete.html.h:3
-msgid "Groups"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:9
-msgid "No groups are present."
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:10
-#: pkg/kubernetes/views/add-user-dialog.html.h:1
-msgid "Add User"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:11
-msgid "Users"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:12
-msgid "Identity"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:13
-msgid "Member of"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html.h:14
-#, fuzzy
-msgid "No users are present."
-msgstr "Kullanıcı adı belirtilmedi"
-
-#: pkg/kubernetes/views/auth-form.html.h:1
-#, fuzzy
-msgid "Cluster"
-msgstr "Ana"
-
-#: pkg/kubernetes/views/auth-form.html.h:2
-msgid "Add New Cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:4
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:3
-msgid "Skip Certificate Verification"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:5
-#, fuzzy
-msgid "Requires Authentication"
-msgstr "Yetkilendirme"
-
-#: pkg/kubernetes/views/auth-form.html.h:7
-msgid "Add New User"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:9
-msgid "Client Certificate"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html.h:10
-#, fuzzy
-msgid "Username"
-msgstr "Kullanıcı Adı"
-
-#: pkg/kubernetes/views/auth-form.html.h:12
-msgid "Token"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:1
-msgid "Add Cluster Node"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:4
-msgid "Configuration"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:5
-msgid "Configure Kubelet and Proxy"
-msgstr ""
-
-#: pkg/kubernetes/views/node-add.html.h:6
-msgid "Configure Flannel networking"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:1
-#: pkg/kubernetes/views/pvc-body.html.h:1
-msgid "Volume Type"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:2
-msgid "{{ volume | formatVolumeType }}"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:3
-#, fuzzy
-msgid "PD Name"
-msgstr "İsim"
-
-#: pkg/kubernetes/views/volume-body.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:19
-#, fuzzy
-msgid "Filesystem Type"
-msgstr "Dosya sistemi tipi"
-
-#: pkg/kubernetes/views/volume-body.html.h:6
-#: pkg/kubernetes/views/pv-modify.html.h:20
-#, fuzzy
-msgid "Read Only"
-msgstr "Hazır"
-
-#: pkg/kubernetes/views/volume-body.html.h:7
-msgid "Volume ID"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:8
-#, fuzzy
-msgid "Repository URL"
-msgstr "Depo"
-
-#: pkg/kubernetes/views/volume-body.html.h:9
-#, fuzzy
-msgid "Revision"
-msgstr "Sürüm"
-
-#: pkg/kubernetes/views/volume-body.html.h:10
-#: pkg/kubernetes/views/image-config.html.h:3
-msgid "Directory"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:12
-msgid "Medium"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:13
-#: pkg/kubernetes/views/pv-modify.html.h:14
-msgid "Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:14
-msgid "Endpoint Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:15
-#: pkg/kubernetes/views/pv-modify.html.h:13
-#, fuzzy
-msgid "Volume Name"
-msgstr "Tam İsim"
-
-#: pkg/kubernetes/views/volume-body.html.h:17
-#, fuzzy
-msgid "Monitors"
-msgstr "ARP İzleme"
-
-#: pkg/kubernetes/views/volume-body.html.h:18
-#, fuzzy
-msgid "Image Name"
-msgstr "Kalıp $0"
-
-#: pkg/kubernetes/views/volume-body.html.h:19
-#, fuzzy
-msgid "Pool Name"
-msgstr "Tam İsim"
-
-#: pkg/kubernetes/views/volume-body.html.h:21
-msgid "Key Ring Path"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:22
-#, fuzzy
-msgid "Secret Volume"
-msgstr "Volume Grubu Yarat"
-
-#: pkg/kubernetes/views/volume-body.html.h:23
-msgid "Target Portal"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:24
-#: pkg/kubernetes/views/pv-modify.html.h:16
-#, fuzzy
-msgid "Qualified Name"
-msgstr "Tam İsim"
-
-#: pkg/kubernetes/views/volume-body.html.h:25
-#: pkg/kubernetes/views/pv-modify.html.h:17
-#, fuzzy
-msgid "Logical Unit Number"
-msgstr "Mantıksal Bölüm"
-
-#: pkg/kubernetes/views/volume-body.html.h:26
-#: pkg/kubernetes/views/pv-modify.html.h:18
-#, fuzzy
-msgid "Interface"
-msgstr "Arayüzler"
-
-#: pkg/kubernetes/views/volume-body.html.h:27
-#, fuzzy
-msgid "Ceph Monitors"
-msgstr "Depo"
-
-#: pkg/kubernetes/views/volume-body.html.h:28
-#, fuzzy
-msgid "Secret File"
-msgstr "Aygıt dosyası"
-
-#: pkg/kubernetes/views/volume-body.html.h:29
-msgid "Target World Wide Names"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:30
-msgid "Flocker Dataset Name"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html.h:31
-#, fuzzy
-msgid "Driver"
-msgstr "Sürücü"
-
-#: pkg/kubernetes/views/volume-body.html.h:33
-#, fuzzy
-msgid "Share Name"
-msgstr "Kullanıcı Adı"
-
-#: pkg/kubernetes/views/volume-body.html.h:34
-#, fuzzy
-msgid "Secret Name"
-msgstr "Kullanıcı Adı"
-
-#: pkg/kubernetes/views/image-meta.html.h:2
-msgid "On Build"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:4
-msgid "Docker Version"
-msgstr ""
-
-#: pkg/kubernetes/views/image-meta.html.h:5
-#, fuzzy
-msgid "Image Layers"
-msgstr "Kalıp $0"
-
-#: pkg/kubernetes/views/group-page.html.h:1
-#: pkg/kubernetes/views/user-page.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:1
-msgid "Show all Projects"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:2
-#: pkg/kubernetes/views/group-panel.html.h:1
-#, fuzzy
-msgid "Group Members"
-msgstr "Üyeler"
-
-#: pkg/kubernetes/views/group-page.html.h:3
-#: pkg/kubernetes/views/user-group-add.html.h:1
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:1
-#: pkg/kubernetes/views/group-panel.html.h:2
-#: pkg/kubernetes/views/project-body.html.h:10
-msgid "Add Member"
-msgstr ""
-
-#: pkg/kubernetes/views/group-page.html.h:4
-msgid "The group '{{ groupName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/containers-listing.html.h:3
-#: pkg/kubernetes/views/pod-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:2
-msgid "Pod"
-msgstr "Pod"
-
-#: pkg/kubernetes/views/user-body.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:2
-msgid "Membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:2
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/user-body.html.h:5
-#: pkg/kubernetes/views/user-panel.html.h:7
-#, fuzzy
-msgid "Add Membership"
-msgstr "Üyeler"
-
-#: pkg/kubernetes/views/user-group-add.html.h:2
-msgid ""
-"\n"
-"                        User\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:2
-msgid "User or Group"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-panel.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:4
-#, fuzzy
-msgid "Mount Location"
-msgstr "Bağlama Seçenekleri"
-
-#: pkg/kubernetes/views/route-modify.html.h:1
-msgid "Adjust Route"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:1
-msgid "Show all Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:2 pkg/kubernetes/views/pvc-body.html.h:3
-#: pkg/kubernetes/views/pv-panel.html.h:1
-#, fuzzy
-msgid "Volume"
-msgstr "Mantıksal Bölüm"
-
-#: pkg/kubernetes/views/pv-page.html.h:3 pkg/kubernetes/views/pv-panel.html.h:2
-msgid "Claim"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html.h:4
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:1
-msgid "Remove image tag"
-msgstr ""
-
-#: pkg/kubernetes/views/image-delete.html.h:2
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:1
-msgid "Run as"
-msgstr ""
-
-#: pkg/kubernetes/views/image-config.html.h:4
-msgid "Stop with"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:1
-msgid "Delete Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:2
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-delete.html.h:3
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
-"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
-"may cause issues with any pods depending on it."
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:3
-msgid "Identities"
-msgstr ""
-
-#: pkg/kubernetes/views/user-page.html.h:3
-msgid "The user '{{ userName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:1
-msgid "Show all Deployment Configs"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:1
-msgid "Deployment Config"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:4
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/route-panel.html.h:1
-#: pkg/kubernetes/views/route-page.html.h:2
-#, fuzzy
-msgid "Route"
-msgstr "Yönlendirmeler"
-
-#: pkg/kubernetes/views/volumes-page.html.h:1
-#, fuzzy
-msgid "Register New Volume"
-msgstr "Mantıksal Bölümü Yeniden Boyurlandır"
-
-#: pkg/kubernetes/views/volumes-page.html.h:2
-msgid "Persistent Volumes"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:7
-msgid "No volumes are present."
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:8
-msgid "Pending Volume Claims"
-msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html.h:12
-msgid "When"
-msgstr ""
-
-#: pkg/kubernetes/views/user-delete.html.h:1
-#, fuzzy
-msgid "Remove User"
-msgstr "Kaldır"
-
-#: pkg/kubernetes/views/pv-claim.html.h:3
-#: pkg/kubernetes/views/pv-modify.html.h:10
-#: pkg/kubernetes/views/pvc-body.html.h:7 pkg/kubernetes/views/pv-body.html.h:2
-#, fuzzy
-msgid "Access Modes"
-msgstr "Erişim"
-
-#: pkg/kubernetes/views/pv-claim.html.h:4
-msgid "Requests"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:5
-msgid "This volume has not been claimed"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html.h:10
-msgid "No Pods are using this claim"
-msgstr ""
-
-#: pkg/kubernetes/views/filter-project.html.h:1
-msgid "All Projects"
-msgstr ""
-
-#: pkg/kubernetes/views/filter-project.html.h:2
-msgid "Project:"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:5
-#: pkg/kubernetes/views/details-page.html.h:14
-msgid "Latest Version"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:6
-msgid "Deployment Causes"
-msgstr ""
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:7
-msgid "Triggers"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:1
-msgid "Delete {{ item.kind }}"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:2
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html.h:3
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:2
-#: pkg/kubernetes/views/user-modify.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:2
-msgid ""
-"\n"
-"                        Name\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:5
-#: pkg/kubernetes/views/user-modify.html.h:5
-msgid ""
-"\n"
-"                        Identity\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:1
-msgid "Project Members"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:3
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:6
-msgid "Admin"
-msgstr ""
-
-#: pkg/kubernetes/views/project-body.html.h:7
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-msgstr ""
-
-#: pkg/kubernetes/views/container-panel.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:3
-msgid "Shell"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:1
-msgid "Pod Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:2
-msgid "No pods selected"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:3
-msgid "Pod Selector"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:1
-msgid "Add membership"
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:2
-msgid ""
-"\n"
-"                        Group or Project\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/user-add-membership.html.h:5
-msgid ""
-"\n"
-"                        Role\n"
-"                    "
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:1
-msgid "Deploy Application"
-msgstr "Uygulamayı Devreye Al"
-
-#: pkg/kubernetes/views/deploy.html.h:3
-msgid "{{ selected.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/deploy.html.h:5
-#: pkg/kubernetes/views/dashboard-page.html.h:11
-msgid "Deploy"
-msgstr "Devreye Al"
-
-#: pkg/kubernetes/views/user-modify.html.h:1
-msgid "Change User"
-msgstr ""
-
-#: pkg/kubernetes/views/user-modify.html.h:9
-msgid "Modify"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:1
-#: pkg/kubernetes/views/project-modify.html.h:6
-msgid "Access Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:2
-msgid ""
-"\n"
-"          Images may be pulled by anonymous users\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:5
-msgid ""
-"\n"
-"          Images may be pulled by any authenticated user or group\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:8
-msgid ""
-"\n"
-"          Images may only be pulled by specific users or groups\n"
-"        "
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:11
-msgid "Pull repository"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:13
-msgid "Image count"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:14
-msgid "{{stream.status.tags.length}}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-body.html.h:15
-msgid "To push to an image to this image stream:"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:1
-msgid "The node doesn't have enough disk space"
-msgstr ""
-
-#: pkg/kubernetes/views/node-alerts.html.h:2
-msgid "The node doesn't have enough free memory"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:1
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:2
-msgid "Register Persistent Volume"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:4
-msgid "Warning:"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:5
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:7
-#: pkg/kubernetes/views/node-page.html.h:3
-#: pkg/kubernetes/views/pvc-body.html.h:10
-#: pkg/kubernetes/views/pv-body.html.h:3
-#, fuzzy
-msgid "Capacity"
-msgstr "Kapasite"
-
-#: pkg/kubernetes/views/pv-modify.html.h:8
-#: pkg/kubernetes/views/pv-body.html.h:1
-msgid "Reclaim Policy"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:9
-msgid "{{ value }}"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:12
-msgid "Endpoint"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-modify.html.h:15
-msgid "Target"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-dialog.html.h:1
-#, fuzzy
-msgid "Connection Settings"
-msgstr "Hesap Ayarları"
-
-#: pkg/kubernetes/views/auth-dialog.html.h:2
-#, fuzzy
-msgid "Connection Error"
-msgstr "Docker'a bağlanılıyor"
-
-#: pkg/kubernetes/views/image-body.html.h:2
-msgid "Summary"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:4
-msgid "Source URL"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:7
-msgid "Built"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:8
-msgid "Digest"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:9
-msgid "Identifier"
-msgstr ""
-
-#: pkg/kubernetes/views/image-body.html.h:11
-msgid "To pull this image:"
-msgstr ""
-
-#: pkg/kubernetes/views/service-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:8
-#: pkg/kubernetes/views/service-page.html.h:2
-msgid "Service"
-msgstr "Servis"
-
-#: pkg/kubernetes/views/service-panel.html.h:2
-#: pkg/kubernetes/views/service-page.html.h:3
-msgid "Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:1
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:2
-msgid ""
-"You can bypass the certificate check, but any data you send to the server "
-"could be intercepted by others."
-msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:4
-msgid "Trust this certificate for this connection"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:1
-msgid "Show all Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html.h:7
-msgid "The pod '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:1
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:1
-msgid "Delete image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:2
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:2
-#, fuzzy
-msgid "All running"
-msgstr "Çalışmıyor"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:3
-msgid "No pods deployed"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:5
-msgid "All in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:6
-msgid "No volumes in use"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:7
-msgid "pending volume claims"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:9
-msgid "All healthy"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:10
-msgid "No nodes in cluster"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html.h:13
-msgid "Could not list services"
-msgstr "Servisler listelenemedi"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:14
-msgid "You can deploy an application to your cluster."
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-page.html.h:1
-msgid "Show all image streams"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-page.html.h:2
-msgid "Image Stream"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:3
-msgid "Image ID"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:4
-msgid "Container ID"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:7
-msgid "Since"
-msgstr ""
-
-#: pkg/kubernetes/views/container-body.html.h:8
-msgid "Restart Count"
-msgstr ""
-
-#: pkg/kubernetes/views/user-remove-membership.html.h:1
-msgid "Remove membership"
-msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html.h:1
-#, fuzzy
-msgid "Delete Selected"
-msgstr "Dosyaları Sil"
-
-#: pkg/kubernetes/views/nodes-page.html.h:2
-#, fuzzy
-msgid "OS Versions"
-msgstr "Sürüm"
-
-#: pkg/kubernetes/views/nodes-page.html.h:3
-#, fuzzy
-msgid "Add Kubernetes Node"
-msgstr "Kubernetes Düğümleri"
-
-#: pkg/kubernetes/views/project-page.html.h:3
-msgid "The project '{{ projName }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/user-panel.html.h:4
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:1
-msgid "Pod Replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:2
-msgid "No pods replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/container-page.html.h:1
-#, fuzzy
-msgid "Show all Containers"
-msgstr "Konteynerler"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:1
-msgid "Welcome to the Image Registry"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:2
-msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:1
-msgid "New project"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:4
-msgid "Images by project"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:6
-msgid "Images pushed recently"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:7
-msgid "All images"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:8
-msgid "No images pushed"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:9
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:11
-msgid "Login commands"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:12
-msgid "Log into the registry:"
+msgid "You don't have permission to manage the Docker storage pool."
 msgstr ""
+"Bu hesabın yetkilendirilmiş açık anahtarlarını görmeniz için izniniz yok."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:13
+#: pkg/kubernetes/views/registry-dashboard-page.html:112
 msgid ""
 "Your login credentials do not give you access to use the docker registry "
 "from the command line."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:14
-msgid "Log into OpenShift command line tools:"
+#: src/base1/cockpit.js:3687
+msgid "Your session has been terminated."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:15
-#, fuzzy
-msgid "Image commands"
-msgstr "Kalıp $0"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:16
-msgid "Push an image:"
+#: src/base1/cockpit.js:3689
+msgid "Your session has expired. Please log in again."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:17
-msgid "Pull an image:"
+#: pkg/lib/journal.js:213
+msgid "[$0 bytes of binary data]"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html.h:1
-msgid "Show all Nodes"
+#: pkg/lib/journal.js:215
+msgid "[binary data]"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html.h:4
-msgid "The node '{{ target }}' does not exist."
+#: pkg/lib/journal.js:209
+msgid "[no data]"
 msgstr ""
 
-#: pkg/kubernetes/views/route-page.html.h:1
-msgid "Show all Routes"
+#: pkg/storaged/details.js:1692
+msgid "active, but unsupported"
 msgstr ""
 
-#: pkg/kubernetes/views/route-page.html.h:3
-msgid "The route '{{ target }}' does not exist."
+#: pkg/storaged/utils.js:88
+msgctxt "format-bytes"
+msgid "bytes"
 msgstr ""
 
-#: pkg/kubernetes/views/topology-page.html.h:1
-msgid "Select an object to see more details."
-msgstr "Daha fazla ayrıntı için bir obje seçin."
+#: pkg/docker/util.js:123
+msgid "default"
+msgstr "ön tanımlı"
 
-#: pkg/kubernetes/views/topology-page.html.h:3
-msgid ""
-"Pods contain one or more containers that run\n"
-"                together on a node, containing your application code."
+#: pkg/storaged/details.js:178
+msgid "ext4 - Red Hat Enterprise Linux 6 default"
+msgstr "ext4 - Red Hat Enterprise Linux 6 ön tanımlı"
+
+#: pkg/systemd/host.js:661
+msgid "failed to list ssh host keys: $0"
 msgstr ""
 
-#: pkg/kubernetes/views/topology-page.html.h:6
-msgid ""
-"Replication controllers dynamically create instances of\n"
-"                pods from templates, and remove pods when necessary."
+#: pkg/storaged/index.html:135
+msgid "iSCSI Targets"
 msgstr ""
 
-#: pkg/kubernetes/views/topology-page.html.h:9
-msgid ""
-"Services group pods and provide a common DNS\n"
-"                name and an optional, load-balanced IP address to access "
-"them."
+#: pkg/storaged/details.js:1692
+msgid "inactive"
 msgstr ""
 
-#: pkg/kubernetes/views/topology-page.html.h:12
-msgid "Nodes are the machines that run your containers."
-msgstr "Düğümler, konteynerlerinizi çalıştıran makinelerdir."
+#: pkg/storaged/details.js:1286
+msgid "locked"
+msgstr "kilitlendi"
 
-#: pkg/kubernetes/views/add-group-dialog.html.h:1
-msgid "Add Group"
-msgstr ""
+#: pkg/storaged/details.js:1278
+msgid "mounted on $0"
+msgstr "$0 noktasında bağlı"
 
-#: pkg/kubernetes/views/file-button.html.h:1
-msgid "Select Manifest File..."
-msgstr ""
-
-#: pkg/kubernetes/views/project-modify.html.h:2
-msgid "Change project"
-msgstr ""
-
-#: pkg/kubernetes/views/project-modify.html.h:4
-msgid "Display name"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:5
-msgid "TLS Termination"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:6
-msgid "yes"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html.h:7
+#: pkg/kubernetes/views/route-body.html:14
 msgid "no"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:1
-#, fuzzy
-msgid "Add Role"
-msgstr "Roller"
+#: pkg/kubernetes/views/route-body.html:24
+#: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
+msgid "none"
+msgstr "hiç biri"
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:2
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#: pkg/storaged/details.js:1280
+msgid "not mounted"
+msgstr "bağlı değil"
+
+#: pkg/kubernetes/views/dashboard-page.html:83
+msgid "pending volume claims"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:1
-#, fuzzy
-msgid "All Types"
-msgstr "Tip"
-
-#: pkg/kubernetes/views/details-page.html.h:2
-#, fuzzy
-msgid "Type:"
-msgstr "Tip"
-
-#: pkg/kubernetes/views/details-page.html.h:13
-msgid "Deployment Configs"
+#: pkg/tuned/change-profile.jsx:52
+msgid "recommended"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:15
-msgid "Not deployed"
+#: pkg/docker/index.html:426
+msgid "select container"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html.h:16
-msgid "Replication Controllers"
-msgstr "Replikasyon Kontrolörleri"
+#: pkg/docker/index.html:504 pkg/docker/index.html:683
+#, fuzzy
+msgid "shares"
+msgstr "Paylaşılan"
 
-#: pkg/kubernetes/views/service-modify.html.h:1
-msgid "Adjust Service"
-msgstr "Servisi Ayarla"
+#: pkg/selinux/setroubleshoot-view.jsx:118
+msgid "solution details"
+msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:3
+#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
+#, fuzzy
+msgid "unknown"
+msgstr "Bilinmiyor"
+
+#: pkg/storaged/jobs.js:180
+msgid "unknown target"
+msgstr ""
+
+#: pkg/storaged/details.js:1284
+msgid "unlocked"
+msgstr "kilidi açıldı"
+
+#: pkg/kubernetes/views/route-body.html:13
+msgid "yes"
+msgstr ""
+
+#: pkg/kubernetes/views/service-modify.html:16
 msgid "{{ item.name }}"
 msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:5
-msgid "Adjust"
-msgstr "Ayarla"
+#: pkg/kubernetes/views/deploy.html:27
+msgid "{{ selected.name }}"
+msgstr ""
 
-#: pkg/kubernetes/views/project-delete.html.h:1
+#: pkg/kubernetes/views/pv-modify.html:61
+#: pkg/kubernetes/views/pv-modify.html:74
+msgid "{{ value }}"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:2
+msgid "{{ volume | formatVolumeType }}"
+msgstr ""
+
+#: pkg/storaged/index.html:147
+msgid "{{Address}}:{{Port}}"
+msgstr ""
+
+#: pkg/docker/index.html:435
+msgid "{{alias_label}}"
+msgstr ""
+
+#: pkg/systemd/services.html:173 pkg/systemd/services.html:202
+msgid "{{days_text}}"
+msgstr ""
+
+#: pkg/docker/index.html:403
+msgid "{{envvar_key_label}}"
+msgstr ""
+
+#: pkg/docker/index.html:407
+msgid "{{envvar_value_label}}"
+msgstr ""
+
+#: pkg/docker/index.html:359
+msgid "{{host_port_label}}"
+msgstr ""
+
+#: pkg/docker/index.html:373
+msgid "{{host_volume_label}}"
+msgstr ""
+
+#: pkg/kubernetes/views/imagestream-body.html:35
+msgid "{{stream.status.tags.length}}"
+msgstr ""
+
 #, fuzzy
-msgid "Delete Project"
-msgstr "Dosyaları Sil"
+#~ msgid "Image Layers Example"
+#~ msgstr "Kalıp $0"
 
-#: pkg/kubernetes/views/pvc-body.html.h:2
 #, fuzzy
-msgid "Claim Name"
-msgstr "Konteyner İsmi"
+#~ msgid "Cockpit Monitoring"
+#~ msgstr "ARP İzleme"
 
-#: pkg/kubernetes/views/pvc-body.html.h:4
-msgid "No Volume Bound"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-body.html.h:8
-msgid "Requested"
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-body.html.h:9
-msgid "Actual"
-msgstr ""
-
-#: pkg/kubernetes/views/node-capacity.html.h:1
-msgid "Scheduled Pods"
-msgstr ""
-
-#: pkg/kubernetes/views/node-capacity.html.h:2
-msgid "No pods scheduled"
-msgstr ""
-
-#: pkg/kubernetes/views/container-page-inline.html.h:4
-msgid "The container '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:1
-msgid "Create image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:2
-msgid "Change image stream"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:5
-msgid "Populate"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:6
-msgid "Pull from"
-msgstr ""
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:8
-msgid "Remote registry is insecure"
-msgstr ""
-
-#: pkg/kubernetes/views/user-group-remove.html.h:1
 #, fuzzy
-msgid "Remove Member"
-msgstr "RAID Üyesi"
-
-#: pkg/kubernetes/views/service-page.html.h:1
-#, fuzzy
-msgid "Show all Services"
-msgstr "Servisler"
-
-#: pkg/kubernetes/views/service-page.html.h:4
-msgid "The service '{{ target }}' does not exist."
-msgstr ""
-
-#: pkg/kubernetes/scripts/frob-layers.html.h:1
-#, fuzzy
-msgid "Image Layers Example"
-msgstr "Kalıp $0"
-
-#: pkg/playground/service.html.h:1
-msgid "Cockpit Generic Service Monitor"
-msgstr ""
-
-#: pkg/playground/jquery-patterns.html.h:1
-msgid "Cockpit Pattern Usage"
-msgstr ""
-
-#: pkg/playground/metrics.html.h:1
-#, fuzzy
-msgid "Cockpit Monitoring"
-msgstr "ARP İzleme"
-
-#: pkg/playground/test.html.h:1 pkg/playground/translate.html.h:1
-msgid "Cockpit playground"
-msgstr ""
-
-#: pkg/playground/react-patterns.html.h:1
-msgid "Cockpit React Patterns Usage"
-msgstr ""
-
-#: pkg/playground/speed.html.h:1
-msgid "Cockpit Speed Tests"
-msgstr ""
-
-#: pkg/playground/plot.html.h:1
-#, fuzzy
-msgid "Cockpit Plots"
-msgstr "Kokpit"
-
-#: pkg/dashboard/index.html.h:1
-msgid "Dashboard"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:5
-#, fuzzy
-msgid "Disk I/O"
-msgstr "Disk durumu iyi"
-
-#: pkg/dashboard/index.html.h:6
-msgid "Lost connection. Trying to reconnect"
-msgstr "Bağlantı koptu. Tekrar bağlanmaya çalışıyor"
-
-#: pkg/dashboard/index.html.h:10
-msgid "Avatar"
-msgstr ""
-
-#: pkg/dashboard/index.html.h:13
-msgid "Set"
-msgstr ""
+#~ msgid "Cockpit Plots"
+#~ msgstr "Kokpit"
 
 #~ msgid "No addresses found"
 #~ msgstr "Adresler bulunamadı"
@@ -6225,45 +6211,5 @@ msgstr ""
 #~ msgstr "Dondurulmuş"
 
 #~ msgctxt "storage"
-#~ msgid "Model"
-#~ msgstr "Model"
-
-#~ msgctxt "storage"
-#~ msgid "Firmware Version"
-#~ msgstr "Firmware Sürümü"
-
-#~ msgctxt "storage"
-#~ msgid "Serial Number"
-#~ msgstr "Seri Numarası"
-
-#~ msgctxt "storage"
-#~ msgid "Capacity"
-#~ msgstr "Kapasite"
-
-#~ msgctxt "storage"
-#~ msgid "Device File"
-#~ msgstr "Aygıt dosyası"
-
-#~ msgctxt "storage"
-#~ msgid "Device"
-#~ msgstr "Aygıt"
-
-#~ msgctxt "storage"
 #~ msgid "Name"
 #~ msgstr "İsim"
-
-#~ msgctxt "storage"
-#~ msgid "UUID"
-#~ msgstr "UUID"
-
-#~ msgctxt "storage"
-#~ msgid "RAID Level"
-#~ msgstr "RAID Seviyesi"
-
-#~ msgctxt "storage"
-#~ msgid "Bitmap"
-#~ msgstr "Bitmap"
-
-#~ msgctxt "storage"
-#~ msgid "State"
-#~ msgstr "Durum"

--- a/po/uk.po
+++ b/po/uk.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-17 19:28+0100\n"
+"POT-Creation-Date: 2016-11-18 06:44+0100\n"
 "PO-Revision-Date: 2016-08-02 02:44-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Ukrainian <kde-i18n-uk@kde.org>\n"
@@ -17,185 +17,526 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
-#: src/ws/cockpitcertificate.c:359
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr "Не вдалося розшифрувати зашифрований PEM закритий ключ"
-
-#: src/ws/cockpitcertificate.c:364
-msgid "No PEM-encoded private key found"
-msgstr "Не знайдено зашифрованого PEM закритого ключа"
-
-#: src/ws/cockpitcertificate.c:374
-msgid "Could not parse PEM-encoded private key"
-msgstr "Не вдалося обробити зашифрований PEM закритий ключ"
-
-#: src/ws/cockpitcertificate.c:398
-msgid "No PEM-encoded certificate found"
-msgstr "Не знайдено зашифрованого PEM сертифіката"
-
-#: src/ws/cockpitcertificate.c:407
-msgid "Could not parse PEM-encoded certificate"
-msgstr "Не вдалося обробити зашифрований PEM сертифікат"
-
-#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
-#: src/bridge/cockpitdbussetup.c:625
+#: pkg/shell/index.html:227
 #, fuzzy
-msgid "Unsupported setup mechanism"
-msgstr "Непідтримуваний механізм налаштовування: %s"
+msgid "                                                Comment                                            "
+msgstr ""
+"\n"
+"                           Некоректний часовий пояс\n"
+"                      "
 
-#: src/bridge/cockpitdbussetup.c:236
-msgid "Couldn't list users"
-msgstr "Не вдалося побудувати список користувачів"
+#: pkg/shell/index.html:235
+#, fuzzy
+msgid "                                                Fingerprint                                            "
+msgstr ""
+"\n"
+"                           Некоректний часовий пояс\n"
+"                      "
 
-#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
-msgid "Bad data passed for passwd1 mechanism"
-msgstr "Механізму passwd1 передано помилкові дані"
+#: pkg/shell/index.html:231
+#, fuzzy
+msgid "                                                Type                                            "
+msgstr ""
+"\n"
+"                           Некоректний часовий пояс\n"
+"                      "
 
-#: src/bridge/cockpitdbussetup.c:382
-msgid "Couldn't load user data"
-msgstr "Не вдалося завантажити дані користувача"
+#: pkg/systemd/index.html:389
+#, fuzzy
+msgid ""
+"                                    Invalid time "
+"zone                                "
+msgstr ""
+"\n"
+"                           Некоректний часовий пояс\n"
+"                      "
 
-#: src/bridge/cockpitdbussetup.c:467
-msgid "Couldn't change user groups"
-msgstr "Не вдалося змінити групи користувачів"
+#: pkg/kubernetes/views/project-body.html:80
+#, fuzzy
+msgid ""
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}                                "
+msgstr ""
+"\n"
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}\n"
+"                                "
 
-#: src/bridge/cockpitdbussetup.c:520
-msgid "Couldn't change user password"
-msgstr "Не вдалося змінити пароль користувача"
+#: pkg/kubernetes/views/user-body.html:22
+#, fuzzy
+msgid ""
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}                                "
+msgstr ""
+"\n"
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}\n"
+"                                "
 
-#: src/bridge/cockpitdbussetup.c:544
-msgid "Couldn't create new users"
-msgstr "Не вдалося створити записи користувачів"
+#: pkg/kubernetes/views/user-panel.html:39
+#, fuzzy
+msgid ""
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}                            "
+msgstr ""
+"\n"
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}\n"
+"                            "
 
-#: src/bridge/cockpitdbussetup.c:642
-msgid "Couldn't list local users"
-msgstr "Не вдалося побудувати список локальних користувачів"
+#: pkg/kubernetes/views/project-body.html:37
+#, fuzzy
+msgid ""
+"                                {{ getRegistryRoles(user, project())."
+"join() }}                            "
+msgstr ""
+"\n"
+"                                {{ getRegistryRoles(user, project())."
+"join() }}\n"
+"                            "
 
-#: src/bridge/cockpitpackages.c:459
-#, c-format
-msgid "This package requires Cockpit version %s or later"
+#: pkg/systemd/index.html:485 pkg/systemd/index.html:504
+#, fuzzy
+msgid "                        Cancel                    "
+msgstr ""
+"\n"
+"              Скасувати\n"
+"            "
+
+#: pkg/kubernetes/views/user-add-membership.html:9
+#, fuzzy
+msgid "                        Group or Project                    "
+msgstr ""
+"\n"
+"                        Група або проект\n"
+"                    "
+
+#: pkg/kubernetes/views/add-user-dialog.html:19
+#: pkg/kubernetes/views/user-modify.html:19
+#, fuzzy
+msgid "                        Identity                    "
+msgstr ""
+"\n"
+"                        Профіль\n"
+"                    "
+
+#: pkg/kubernetes/views/add-user-dialog.html:9
+#: pkg/kubernetes/views/user-modify.html:9
+#: pkg/kubernetes/views/add-group-dialog.html:9
+#, fuzzy
+msgid "                        Name                    "
+msgstr ""
+"\n"
+"                        Назва\n"
+"                    "
+
+#: pkg/kubernetes/views/user-add-membership.html:30
+#, fuzzy
+msgid "                        Role                    "
+msgstr ""
+"\n"
+"                        Роль\n"
+"                    "
+
+#: pkg/kubernetes/views/user-group-add.html:9
+#, fuzzy
+msgid "                        User                    "
+msgstr ""
+"\n"
+"                        Користувач\n"
+"                    "
+
+#: pkg/ostree/index.html:88
+#, fuzzy
+msgid "                    Available                  "
+msgstr ""
+"\n"
+"                    Доступний\n"
+"                  "
+
+#: pkg/ostree/index.html:85
+#, fuzzy
+msgid "                    Default                  "
+msgstr ""
+"\n"
+"                    Типовий\n"
+"                  "
+
+#: pkg/ostree/index.html:223
+#, fuzzy
+msgid "                    Reconnect                "
+msgstr ""
+"\n"
+"                    Повторно з’єднатися\n"
+"                "
+
+#: pkg/ostree/index.html:135
+#, fuzzy
+msgid ""
+"                    This deployment contains the same packages as your "
+"currently booted system                "
+msgstr ""
+"\n"
+"                    У цьому розгортанні містяться деякі пакунки, які є у "
+"поточній завантаженій системі\n"
+"                "
+
+#: pkg/ostree/index.html:67
+#, fuzzy
+msgid "                    Update and reboot                "
+msgstr ""
+"\n"
+"                    Оновити і перезавантажити\n"
+"                "
+
+#: pkg/kubernetes/registry.html:74 pkg/kubernetes/index.html:104
+#, fuzzy
+msgid "                Reconnect            "
+msgstr ""
+"\n"
+"             Повторно з’єднатися\n"
+"          "
+
+#: pkg/sosreport/index.html:57
+#, fuzzy
+msgid ""
+"                The generated archive contains data "
+"considered                sensitive and its content should be reviewed by "
+"the                originating organization before being passed to "
+"any                third party.              "
+msgstr ""
+"\n"
+"                У створеному архіві містяться дані, які є конфіденційними.\n"
+"                Його вміст має бути переглянути організацією походження,\n"
+"                перш ніж архів буде передано стороннім особам.\n"
+"              "
+
+#: pkg/shell/index.html:304 pkg/shell/stub.html:157
+#, fuzzy
+msgid "                Tools              "
+msgstr ""
+"\n"
+"                Інструменти\n"
+"              "
+
+#: pkg/kubernetes/index.html:107
+#, fuzzy
+msgid "                Troubleshoot            "
+msgstr ""
+"\n"
+"                Усування вад\n"
+"            "
+
+#: pkg/shell/simple.html:105 pkg/shell/index.html:126 pkg/shell/stub.html:119
+#: pkg/storaged/index.html:862
+#, fuzzy
+msgid "              Cancel            "
+msgstr ""
+"\n"
+"              Скасувати\n"
+"            "
+
+#: pkg/shell/index.html:147 pkg/shell/stub.html:140
+#, fuzzy
+msgid "              Close            "
+msgstr ""
+"\n"
+"              Закрити\n"
+"            "
+
+#: pkg/shell/simple.html:70 pkg/shell/index.html:83 pkg/shell/stub.html:76
+#, fuzzy
+msgid ""
+"              Cockpit is an interactive Linux server admin "
+"interface.            "
+msgstr ""
+"\n"
+"              Cockpit — інтерактивний інтерфейс адміністратора сервера "
+"Linux.\n"
+"            "
+
+#: pkg/shell/simple.html:79 pkg/shell/index.html:92 pkg/shell/stub.html:85
+#, fuzzy
+msgid "              Licensed under the GNU LGPL version 2.1            "
+msgstr ""
+"\n"
+"                    Користувач\n"
+"                  "
+
+#: pkg/shell/simple.html:129
+#, fuzzy
+msgid "              Log in again            "
+msgstr ""
+"\n"
+"              Увійти знову\n"
+"            "
+
+#: pkg/shell/simple.html:73 pkg/shell/index.html:86 pkg/shell/stub.html:79
+#, fuzzy
+msgid "              Project website            "
+msgstr ""
+"\n"
+"              Закрити\n"
+"            "
+
+#: pkg/shell/simple.html:108 pkg/shell/index.html:129 pkg/shell/stub.html:122
+#, fuzzy
+msgid "              Select            "
+msgstr ""
+"\n"
+"              Вибрати\n"
+"            "
+
+#: pkg/shell/simple.html:126
+#, fuzzy
+msgid "              Try to reconnect            "
+msgstr ""
+"\n"
+"              Спробувати з’єднатися знову\n"
+"            "
+
+#: pkg/users/index.html:361
+#, fuzzy
+msgid "            Add key          "
+msgstr ""
+"\n"
+"              Додати ключ\n"
+"            "
+
+#: pkg/networkmanager/index.html:582 pkg/networkmanager/index.html:610
+#: pkg/networkmanager/index.html:638 pkg/networkmanager/index.html:666
+#: pkg/networkmanager/index.html:694 pkg/networkmanager/index.html:722
+#: pkg/networkmanager/index.html:750 pkg/networkmanager/index.html:778
+#, fuzzy
+msgid "            Apply          "
+msgstr ""
+"\n"
+"              Застосувати\n"
+"            "
+
+#: pkg/users/index.html:269 pkg/users/index.html:297 pkg/users/index.html:358
+#: pkg/docker/index.html:584 pkg/docker/index.html:622
+#: pkg/docker/index.html:688 pkg/docker/index.html:744
+#: pkg/docker/index.html:790 pkg/networkmanager/index.html:579
+#: pkg/networkmanager/index.html:607 pkg/networkmanager/index.html:635
+#: pkg/networkmanager/index.html:663 pkg/networkmanager/index.html:691
+#: pkg/networkmanager/index.html:719 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:775
+#, fuzzy
+msgid "            Cancel          "
+msgstr ""
+"\n"
+"              Скасувати\n"
+"            "
+
+#: pkg/docker/index.html:691
+#, fuzzy
+msgid "            Change          "
+msgstr ""
+"\n"
+"              Змінити\n"
+"            "
+
+#: pkg/users/index.html:45
+#, fuzzy
+msgid "            Close          "
+msgstr ""
+"\n"
+"              Закрити\n"
+"            "
+
+#: pkg/docker/index.html:747
+#, fuzzy
+msgid "            Commit          "
+msgstr ""
+"\n"
+"              Надіслати\n"
+"            "
+
+#: pkg/users/index.html:207
+#, fuzzy
+msgid "            Create          "
+msgstr ""
+"\n"
+"              Створити\n"
+"            "
+
+#: pkg/users/index.html:300 pkg/networkmanager/index.html:533
+#, fuzzy
+msgid "            Delete          "
+msgstr ""
+"\n"
+"              Вилучити\n"
+"            "
+
+#: pkg/docker/index.html:625
+#, fuzzy
+msgid "            Download          "
+msgstr ""
+"\n"
+"              Отримати\n"
+"            "
+
+#: pkg/docker/index.html:587
+#, fuzzy
+msgid "            Run          "
+msgstr ""
+"\n"
+"              Виконати\n"
+"            "
+
+#: pkg/users/index.html:272
+#, fuzzy
+msgid "            Set          "
+msgstr ""
+"\n"
+"              Встановити\n"
+"            "
+
+#: pkg/kubernetes/views/imagestream-body.html:14
+#, fuzzy
+msgid "          Images may be pulled by anonymous users        "
+msgstr ""
+"\n"
+"          Образи може бути отримати будь-яким розпізнаним користувачем або "
+"учасником групи\n"
+"        "
+
+#: pkg/kubernetes/views/imagestream-body.html:20
+#, fuzzy
+msgid ""
+"          Images may be pulled by any authenticated user or group        "
+msgstr ""
+"\n"
+"          Образи може бути отримати будь-яким розпізнаним користувачем або "
+"учасником групи\n"
+"        "
+
+#: pkg/kubernetes/views/imagestream-body.html:26
+#, fuzzy
+msgid "          Images may only be pulled by specific users or groups        "
+msgstr ""
+"\n"
+"          Образи може бути отримано лише вказаними користувачами або "
+"учасниками груп\n"
+"        "
+
+#: pkg/kubernetes/views/image-body.html:9
+#, fuzzy
+msgid "         {{ labels.url }}    "
+msgstr ""
+"\n"
+"              Скасувати\n"
+"            "
+
+#: pkg/kubernetes/views/project-body.html:2
+msgid ""
+"        Project access policy allows anonymous users to pull images. Grant "
+"additional push or admin access to specific members below.    "
 msgstr ""
 
-#: src/bridge/cockpitpackages.c:470
-msgid "This package is not compatible with this version of Cockpit"
+#: pkg/kubernetes/views/project-body.html:7
+msgid ""
+"        Project access policy allows any authenticated user to pull images. "
+"Grant additional push or admin access to specific members below.    "
 msgstr ""
 
-#: src/base1/cockpit.js:2586
-msgid "$0 killed with signal $1"
-msgstr "$0 завершено з сигналом $1"
-
-#: src/base1/cockpit.js:2588
-msgid "$0 exited with code $1"
-msgstr "$0 завершено роботу з кодом $1"
-
-#: src/base1/cockpit.js:2590
-msgid "$0 failed"
-msgstr "Помилка $0"
-
-#: src/base1/cockpit.js:3667
-msgid "Your session has been terminated."
-msgstr "Ваш сеанс перервано."
-
-#: src/base1/cockpit.js:3669
-msgid "Your session has expired. Please log in again."
+#: pkg/kubernetes/views/project-body.html:12
+msgid ""
+"        Project access policy only allows specific members to access images. "
+"Grant access to specific members below.    "
 msgstr ""
-"Строк роботи у вашому сеансі вичерпано. Будь ласка, увійдіть до системи ще "
-"раз."
 
-#: src/base1/cockpit.js:3671
-msgid "Not permitted to perform this action."
-msgstr "Немає дозволу на виконання цієї дії."
-
-#: src/base1/cockpit.js:3673
-msgid "Login failed"
-msgstr "Невдала спроба увійти"
-
-#: src/base1/cockpit.js:3675
-msgid "The server refused to authenticate using any supported methods."
+#: pkg/sosreport/index.html:39
+#, fuzzy
+msgid ""
+"        The collected information will be stored locally on the system.      "
 msgstr ""
-"Сервер відмовився розпізнавати користувача за допомогою будь-якого з "
-"підтримуваних методів."
+"\n"
+"        Зібрані дані буде збережено локально у операційній системі.\n"
+"      "
 
-#: src/base1/cockpit.js:3677
-msgid "Untrusted host"
-msgstr "Ненадійний вузол"
-
-#: src/base1/cockpit.js:3679
-msgid "Host key is incorrect"
-msgstr "Ключ вузла є неправильним"
-
-#: src/base1/cockpit.js:3681
-msgid "Internal error"
-msgstr "Внутрішня помилка"
-
-#: src/base1/cockpit.js:3683
-msgid "Connection has timed out."
-msgstr "Вичерпано час очікування на з’єднання."
-
-#: src/base1/cockpit.js:3685
-msgid "Cockpit is not installed on the system."
-msgstr "Cockpit у цій системі не встановлено."
-
-#: src/base1/cockpit.js:3687
-msgid "Cannot forward login credentials"
-msgstr "Не вдалося переспрямувати реєстраційні дані для входу"
-
-#: src/base1/cockpit.js:3689
-msgid "Server has closed the connection."
-msgstr "З’єднання розірвано сервером."
-
-#: src/base1/cockpit.js:3691
-msgid "Cockpit is not compatible with the software on the system."
-msgstr "Cockpit є несумісним із програмним забезпеченням цієї системи."
-
-#: src/base1/cockpit.js:3693
-msgid "Cockpit could not contact the given host."
-msgstr "Cockpit не вдалося встановити зв’язок із вказаним вузлом."
-
-#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:19
+#: pkg/storaged/index.html:51
 #, fuzzy
-msgid "Control"
-msgstr "Контейнер"
+msgid ""
+"        There are devices with multiple paths on the system, but the "
+"multipath service is not running.      "
+msgstr ""
+"\n"
+"        У системі є пристрої із декількома шляхами доступу, але службу "
+"multipath не запущено.\n"
+"      "
 
-#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
-#: pkg/playground/translate.js:22
+#: pkg/sosreport/index.html:34
 #, fuzzy
-msgctxt "key"
-msgid "Control"
-msgstr "Контейнер"
+msgid ""
+"        This tool will collect system configuration and diagnostic        "
+"information from this system for use with diagnosing problems        with "
+"the system.      "
+msgstr ""
+"\n"
+"        Ця програма збере дані щодо налаштувань системи і діагностичні\n"
+"        дані з цієї системи для виявлення причин проблем\n"
+"        у системі.\n"
+"      "
 
-#: src/base1/test-locale.js:46 src/base1/test-locale.js:56
-#: pkg/playground/translate.js:10
-msgid "Empty"
-msgstr "Порожній"
+#: pkg/docker/storage.jsx:242
+msgid " (shared with the OS)"
+msgstr ""
 
-#: src/base1/test-locale.js:47 src/base1/test-locale.js:58
-#: pkg/playground/translate.js:16
+#: pkg/kubernetes/views/node-delete.html:8
 #, fuzzy
-msgctxt "verb"
-msgid "Empty"
-msgstr "Порожній"
+msgid " 1\"Do you want to delete the following Nodes?"
+msgstr " 1\">Хочете вилучити вказані нижче вузли?"
 
-#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
-#: src/base1/test-locale.js:66 pkg/storaged/details.js:1557
-#: pkg/playground/translate.js:25 pkg/playground/translate.js:28
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] "Не вистачає $0 диска"
-msgstr[1] "Не вистачає $0 дисків"
-msgstr[2] "Не вистачає $0 дисків"
+#: pkg/storaged/overview.js:253
+msgid "$0 Block Device"
+msgstr "$0, блоковий пристрій"
 
-#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
-#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
-#: pkg/playground/translate.js:34
-#, fuzzy
-msgctxt "disk-non-rotational"
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] "Не вистачає $0 диска"
-msgstr[1] "Не вистачає $0 дисків"
-msgstr[2] "Не вистачає $0 дисків"
+#: pkg/storaged/details.js:1546
+msgid "$0 Chunk Size"
+msgstr "Розмір фрагмента $0"
+
+#: pkg/storaged/details.js:1544
+msgid "$0 Disks"
+msgstr "Диски $0"
+
+#: pkg/storaged/details.js:1387
+msgid "$0 Extended Partition"
+msgstr "Розширений розділ $0"
+
+#: pkg/storaged/details.js:1221
+msgctxt "storage-id-desc"
+msgid "$0 File System"
+msgstr "Файлова система $0"
+
+#: pkg/storaged/details.js:1375
+msgid "$0 Free Space"
+msgstr "Вільного місця: $0"
+
+#: pkg/storaged/details.js:1367
+msgid "$0 Free Space for Logical Partitions"
+msgstr "$0 вільного простору для логічних розділів"
+
+#: pkg/storaged/details.js:1711
+msgid "$0 Free Space for Logical Volumes"
+msgstr "$0 вільного простору для логічних томів"
+
+#: pkg/storaged/details.js:1370
+msgid "$0 Free Space for Primary Partitions"
+msgstr "$0 вільного простору для основних розділів"
+
+#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
+msgid "$0 Template"
+msgstr "Шаблон $0"
+
+#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+msgid "$0 bit"
+msgid_plural "$0 bits"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/base1/test-locale.js:73 src/base1/test-locale.js:74
 #: src/base1/test-locale.js:86 src/base1/test-locale.js:87
@@ -215,580 +556,44 @@ msgstr[0] "байтів"
 msgstr[1] "байтів"
 msgstr[2] "байтів"
 
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
-msgid "$0 bit"
-msgid_plural "$0 bits"
+#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
+#: src/base1/test-locale.js:66 pkg/playground/translate.js:25
+#: pkg/playground/translate.js:28 pkg/storaged/details.js:1557
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] "Не вистачає $0 диска"
+msgstr[1] "Не вистачає $0 дисків"
+msgstr[2] "Не вистачає $0 дисків"
+
+#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
+#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
+#: pkg/playground/translate.js:34
+#, fuzzy
+msgctxt "disk-non-rotational"
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] "Не вистачає $0 диска"
+msgstr[1] "Не вистачає $0 дисків"
+msgstr[2] "Не вистачає $0 дисків"
+
+#: src/base1/cockpit.js:2588
+msgid "$0 exited with code $1"
+msgstr "$0 завершено роботу з кодом $1"
+
+#: src/base1/cockpit.js:2590
+msgid "$0 failed"
+msgstr "Помилка $0"
+
+#: src/base1/cockpit.js:2586
+msgid "$0 killed with signal $1"
+msgstr "$0 завершено з сигналом $1"
+
+#: pkg/selinux/setroubleshoot-view.jsx:440
+msgid "$0 occurrence"
+msgid_plural "$1 occurrences"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
-
-#: pkg/systemd/host.js:43
-msgid "The user <b>$0</b> is not permitted to modify hostnames"
-msgstr "Користувачу <b>$0</b> не дозволено змінювати назви вузлів"
-
-#: pkg/systemd/host.js:559
-msgid "Set Host name"
-msgstr "Встановити назву вузла"
-
-#: pkg/systemd/host.js:661
-msgid "failed to list ssh host keys: $0"
-msgstr "не вдалося побудувати список ключів SSH вузла: $0"
-
-#: pkg/systemd/host.js:1113
-msgid "Need at least one NTP server"
-msgstr "Потрібен принаймні один сервер NTP"
-
-#: pkg/systemd/host.js:1190
-msgid "Invalid date format and invalid time format"
-msgstr "Некоректний формат дати і часу"
-
-#: pkg/systemd/host.js:1192
-msgid "Invalid time format"
-msgstr "Некоректний формат визначення часу"
-
-#: pkg/systemd/host.js:1194
-msgid "Invalid date format"
-msgstr "Некоректний формат дати"
-
-#: pkg/systemd/host.js:1250
-msgid "NTP Server"
-msgstr "Сервер NTP"
-
-#: pkg/systemd/host.js:1300
-msgid "Message to logged in users"
-msgstr "Повідомлення користувачам, які увійшли"
-
-#: pkg/systemd/host.js:1307 pkg/systemd/host.js:1309
-#: pkg/systemd/index.html.h:19
-msgid "Shutdown"
-msgstr "Вимкнути"
-
-#: pkg/systemd/host.js:1311 pkg/systemd/host.js:1313 pkg/systemd/init.js:517
-#: pkg/systemd/index.html.h:18
-msgid "Restart"
-msgstr "Перезапустити"
-
-#: pkg/systemd/host.js:1381
-msgctxt "page-title"
-msgid "CPU Status"
-msgstr "Стан процесора"
-
-#: pkg/systemd/host.js:1413 pkg/systemd/index.html.h:24
-msgid "I/O Wait"
-msgstr "Очікування В-В"
-
-#: pkg/systemd/host.js:1414 pkg/systemd/index.html.h:25
-msgid "Kernel"
-msgstr "Ядро"
-
-#: pkg/systemd/host.js:1415 pkg/subscriptions/subscriptions-register.jsx:76
-#: pkg/systemd/index.html.h:26 pkg/kubernetes/views/auth-form.html.h:6
-#: pkg/kubernetes/views/volume-body.html.h:20
-#: pkg/kubernetes/views/user-panel.html.h:1 pkg/playground/translate.html.h:3
-#: pkg/dashboard/index.html.h:8
-msgid "User"
-msgstr "Користувач"
-
-#: pkg/systemd/host.js:1416 pkg/systemd/index.html.h:27
-msgid "Nice"
-msgstr "Пріоритетність"
-
-#: pkg/systemd/host.js:1466
-msgctxt "page-title"
-msgid "Memory"
-msgstr "Пам'ять"
-
-#: pkg/systemd/host.js:1499 pkg/systemd/index.html.h:28
-msgid "Swap Used"
-msgstr "Використано резерву"
-
-#: pkg/systemd/host.js:1500 pkg/systemd/index.html.h:29
-msgid "Cached"
-msgstr "Кеш"
-
-#: pkg/systemd/host.js:1501 pkg/docker/storage.jsx:313
-#: pkg/kubernetes/scripts/nodes.js:828 pkg/kubernetes/scripts/nodes.js:837
-#: pkg/systemd/index.html.h:30
-msgid "Used"
-msgstr "Використано"
-
-#: pkg/systemd/host.js:1502 pkg/docker/storage.jsx:298
-#: pkg/docker/storage.jsx:320 pkg/systemd/index.html.h:31
-msgid "Free"
-msgstr "Вільно"
-
-#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
-msgid "unknown"
-msgstr "невідомо"
-
-#: pkg/systemd/init.js:269 pkg/systemd/services.html.h:17
-#: pkg/kubernetes/views/project-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:5
-msgid "Description"
-msgstr "Опис"
-
-#: pkg/systemd/init.js:270
-msgid "Id"
-msgstr "Ід."
-
-#: pkg/systemd/init.js:272
-msgid "Next Run"
-msgstr "Наступний запуск"
-
-#: pkg/systemd/init.js:273
-msgid "Last Trigger"
-msgstr "Останній перемикач"
-
-#: pkg/systemd/init.js:274 pkg/kubernetes/views/container-body.html.h:6
-#: pkg/kubernetes/views/details-page.html.h:8
-msgid "State"
-msgstr "Стан"
-
-#: pkg/systemd/init.js:301
-msgid "Enabled"
-msgstr "Увімкнено"
-
-#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
-msgid "Disabled"
-msgstr "Вимкнено"
-
-#: pkg/systemd/init.js:303
-msgid "Static"
-msgstr "Статичний"
-
-#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
-msgid "$0 Template"
-msgstr "Шаблон $0"
-
-#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
-msgid "Start"
-msgstr "Почати"
-
-#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
-msgid "Stop"
-msgstr "Зупинити"
-
-#: pkg/systemd/init.js:518
-msgid "Reload"
-msgstr "Перезавантажити"
-
-#: pkg/systemd/init.js:519
-msgid "Reload or Restart"
-msgstr "Перезавантажити або перезапустити"
-
-#: pkg/systemd/init.js:520
-msgid "Try Restart"
-msgstr "Спробувати перезапустити"
-
-#: pkg/systemd/init.js:521
-msgid "Reload or Try Restart"
-msgstr "Перезавантажити або спробувати перезапустити"
-
-#: pkg/systemd/init.js:522
-msgid "Isolate"
-msgstr "Ізолювати"
-
-#: pkg/systemd/init.js:541
-msgid "Enable"
-msgstr "Увімкнути"
-
-#: pkg/systemd/init.js:542
-msgid "Enable Forcefully"
-msgstr "Примусово увімкнути"
-
-#: pkg/systemd/init.js:543
-msgid "Disable"
-msgstr "Вимкнути"
-
-#: pkg/systemd/init.js:544
-msgid "Preset"
-msgstr "Шаблон"
-
-#: pkg/systemd/init.js:545
-msgid "Preset Forcefully"
-msgstr "Примусово початкові налаштування"
-
-#: pkg/systemd/init.js:546
-msgid "Mask"
-msgstr "Маска"
-
-#: pkg/systemd/init.js:547
-msgid "Mask Forcefully"
-msgstr "Примусово замаскувати"
-
-#: pkg/systemd/init.js:548
-msgid "Unmask"
-msgstr "Розмаскувати"
-
-#: pkg/systemd/init.js:621
-msgid "Since $0"
-msgstr "З $0"
-
-#: pkg/systemd/init.js:639
-msgid "This unit is an instance of the $0 template."
-msgstr "Цей модуль є екземпляром шаблона $0."
-
-#: pkg/systemd/init.js:834
-#, fuzzy
-msgid "The user <b>$0</b> does not have permissions for creating timers"
-msgstr "Користувачу <b>$0</b> заборонено керувати серверами"
-
-#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
-#, fuzzy
-msgid "This field cannot be empty."
-msgstr "Назва не повинна бути порожньою."
-
-#: pkg/systemd/init.js:1147
-msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
-msgstr ""
-
-#: pkg/systemd/init.js:1169
-#, fuzzy
-msgid "Invalid number."
-msgstr "Некоректний ключ"
-
-#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
-msgid "Hour needs to be a number between 0-23"
-msgstr ""
-
-#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
-msgid "Minute needs to be a number between 0-59"
-msgstr ""
-
-#: pkg/systemd/init.js:1218
-#, fuzzy
-msgid "Invalid date format."
-msgstr "Некоректний формат дати"
-
-#: pkg/systemd/init.js:1222
-msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
-msgstr ""
-
-#: pkg/systemd/logs.js:69
-msgid "Load earlier entries"
-msgstr "Завантажити попередні записи"
-
-#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
-#: pkg/systemd/logs.js:175
-msgid "Loading..."
-msgstr "Завантаження…"
-
-#: pkg/systemd/logs.js:130
-msgid "Go to"
-msgstr "Перейти до"
-
-#: pkg/systemd/logs.js:257
-msgid "Journal entry"
-msgstr "Запис журналу"
-
-#: pkg/systemd/logs.js:284
-msgid "Journal entry not found"
-msgstr "Не знайдено запису журналу"
-
-#: pkg/tuned/dialog.js:94
-msgid "Tuned is not available"
-msgstr "Tuned недоступна"
-
-#: pkg/tuned/dialog.js:96
-msgid "Tuned is not running"
-msgstr "Tuned не запущено"
-
-#: pkg/tuned/dialog.js:98
-msgid "Tuned is off"
-msgstr "Tuned вимкнено"
-
-#: pkg/tuned/dialog.js:100
-msgid "This system is using the recommended profile"
-msgstr "Ця система використовує рекомендований профіль"
-
-#: pkg/tuned/dialog.js:102
-msgid "This system is using a custom profile"
-msgstr "Ця система використовує нетиповий профіль"
-
-#: pkg/tuned/dialog.js:114
-msgid "Communication with tuned has failed"
-msgstr "Не вдалося обмінятися даними з tuned"
-
-#: pkg/tuned/dialog.js:133
-msgid "Failed to disable tuned profile"
-msgstr "Невдалося вимкнути профіль tuned"
-
-#: pkg/tuned/dialog.js:145
-msgid "Failed to switch profile"
-msgstr "Не вдалося перемкнути профіль"
-
-#: pkg/tuned/dialog.js:169
-msgid "Failed to enable tuned"
-msgstr "Не вдалося увімкнути tuned"
-
-#: pkg/tuned/dialog.js:171
-msgid "Failed to disable tuned"
-msgstr "Не вдалося вимкнути tuned"
-
-#: pkg/tuned/dialog.js:191
-msgid "Change Performance Profile"
-msgstr "Зміна профілю швидкодії"
-
-#: pkg/tuned/dialog.js:200
-msgid "Change Profile"
-msgstr "Змінити профіль"
-
-#: pkg/tuned/dialog.js:233 pkg/kubernetes/views/service-body.html.h:7
-#: pkg/kubernetes/views/pod-panel.html.h:2
-#: pkg/kubernetes/views/image-config.html.h:8
-#: pkg/kubernetes/views/imagestream-body.html.h:12
-#: pkg/kubernetes/views/pod-page.html.h:5
-msgid "None"
-msgstr "Немає"
-
-#: pkg/tuned/dialog.js:234
-msgid "Disable tuned"
-msgstr "Вимкнути tuned"
-
-#: pkg/tuned/dialog.js:262
-msgid "Tuned has failed to start"
-msgstr "Tuned не вдалося запустити"
-
-#: pkg/tuned/change-profile.jsx:52
-#, fuzzy
-msgid "recommended"
-msgstr "MII (рекомендоване)"
-
-#: pkg/lib/journal.js:209
-msgid "[no data]"
-msgstr "[немає даних]"
-
-#: pkg/lib/journal.js:213
-msgid "[$0 bytes of binary data]"
-msgstr "[$0 байтів двійкових даних]"
-
-#: pkg/lib/journal.js:215
-msgid "[binary data]"
-msgstr "[двійкові дані]"
-
-#: pkg/lib/journal.js:241
-msgid "Reboot"
-msgstr "Перезавантажити"
-
-#: pkg/lib/machine-dialogs.js:364
-msgid "This machine has already been added."
-msgstr "Цей комп’ютер вже було додано."
-
-#: pkg/lib/machine-dialogs.js:380
-msgid ""
-"This version of cockpit-ws does not support connecting to a host with an "
-"alternate user or port"
-msgstr ""
-"У цій версії cockpit-ws не передбачено підтримки встановлення з’єднання із "
-"вузлом від альтернативного користувача або на альтернативному порті."
-
-#: pkg/lib/machine-dialogs.js:386
-msgid "The IP address or host name cannot contain whitespace."
-msgstr "У IP-адресі або назві вузла не повинно бути пробілів."
-
-#: pkg/lib/machine-dialogs.js:412
-msgid "Failed to add machine: $0"
-msgstr "Не вдалося додати комп’ютер: $0"
-
-#: pkg/lib/machine-dialogs.js:429
-msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
-msgstr ""
-"Cockpit не вдалося встановити зв’язок із вказаним вузлом $0. Переконайтеся, "
-"що ssh запущено на порту $1 або вкажіть інший порт у адресі."
-
-#: pkg/lib/machine-dialogs.js:447
-msgid "Enter IP address or host name"
-msgstr "Введіть IP-адресу або назву вузла"
-
-#: pkg/lib/machine-dialogs.js:494
-msgid "Failed to edit machine: $0"
-msgstr "Не вдалося змінити запис комп’ютера: $0"
-
-#: pkg/lib/cockpit-components-dialog.jsx:136 pkg/sosreport/index.js:55
-#: pkg/systemd/services.html.h:34 pkg/lib/machine-sync-users.html.h:7
-#: pkg/lib/machine-add.html.h:5 pkg/lib/machine-change-port.html.h:6
-#: pkg/lib/machine-change-auth.html.h:11 pkg/storaged/index.html.h:22
-#: pkg/realmd/operation.html.h:10 pkg/kubernetes/views/node-delete.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:3
-#: pkg/kubernetes/views/pvc-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:3
-#: pkg/kubernetes/views/auth-form.html.h:13
-#: pkg/kubernetes/views/node-add.html.h:7
-#: pkg/kubernetes/views/user-group-add.html.h:5
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:4
-#: pkg/kubernetes/views/route-modify.html.h:3
-#: pkg/kubernetes/views/image-delete.html.h:3
-#: pkg/kubernetes/views/pv-delete.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:4
-#: pkg/kubernetes/views/item-delete.html.h:4
-#: pkg/kubernetes/views/add-user-dialog.html.h:8
-#: pkg/kubernetes/views/user-add-membership.html.h:8
-#: pkg/kubernetes/views/deploy.html.h:4
-#: pkg/kubernetes/views/user-modify.html.h:8
-#: pkg/kubernetes/views/pv-modify.html.h:21
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:5
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:3
-#: pkg/kubernetes/views/imagestream-delete.html.h:3
-#: pkg/kubernetes/views/user-remove-membership.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:7
-#: pkg/kubernetes/views/add-role-dialog.html.h:3
-#: pkg/kubernetes/views/service-modify.html.h:4
-#: pkg/kubernetes/views/project-delete.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:9
-#: pkg/kubernetes/views/user-group-remove.html.h:2
-#: pkg/playground/translate.html.h:2 pkg/dashboard/index.html.h:12
-msgid "Cancel"
-msgstr "Скасувати"
-
-#: pkg/lib/cockpit-components-dialog.jsx:155
-msgid "Ok"
-msgstr ""
-
-#: pkg/lib/credentials.js:182
-msgid "No such file or directory"
-msgstr "Немає такого файла або каталогу"
-
-#: pkg/lib/credentials.js:186
-msgid "The passwords do not match."
-msgstr "Паролі не збігаються."
-
-#: pkg/lib/credentials.js:191
-msgid "Prompting via ssh-keygen timed out"
-msgstr "Час очікування відповіді на запит за допомогою ssh-keygen вичерпано"
-
-#: pkg/lib/credentials.js:213 pkg/users/local.js:78
-msgid "Old password not accepted"
-msgstr "Старий пароль не прийнято"
-
-#: pkg/lib/credentials.js:223 pkg/users/local.js:112 pkg/users/local.js:144
-msgid "Failed to change password"
-msgstr "Не вдалося змінити пароль"
-
-#: pkg/lib/credentials.js:231 pkg/users/local.js:120
-msgid "New password was not accepted"
-msgstr "Новий пароль не прийнято"
-
-#: pkg/lib/credentials.js:248
-msgid "Not a valid private key"
-msgstr "Некоректний закритий ключ"
-
-#: pkg/lib/credentials.js:251
-msgid "Prompting via ssh-add timed out"
-msgstr "Час очікування відповіді на запит за допомогою ssh-add вичерпано"
-
-#: pkg/lib/credentials.js:274
-msgid "Invalid file permissions"
-msgstr "Некоректні права доступу до файла"
-
-#: pkg/lib/credentials.js:278
-msgid "Password not accepted"
-msgstr "Пароль не прийнято"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:22
-#: pkg/shell/index.html.h:27 pkg/storaged/index.html.h:52
-#: pkg/playground/jquery-patterns.html.h:2
-msgid "On"
-msgstr "Увімкнено"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:23
-#: pkg/shell/index.html.h:28 pkg/storaged/index.html.h:53
-#: pkg/playground/jquery-patterns.html.h:3
-msgid "Off"
-msgstr "Вимкнено"
-
-#: pkg/shell/base_index.js:670 pkg/users/local.js:1164
-#: pkg/docker/index.html.h:69 pkg/networkmanager/index.html.h:65
-msgid "Unexpected error"
-msgstr "Неочікувана помилка"
-
-#: pkg/shell/base_index.js:671
-msgid "Cockpit had an unexpected internal error. <br/><br/>"
-msgstr "У Cockpit сталася неочікувана внутрішня помилка. <br/><br/>"
-
-#: pkg/shell/base_index.js:672
-msgid "You can try restarting Cockpit by pressing refresh in your browser. "
-msgstr ""
-"Ви можете спробувати перезапустити Cockpit натисканням кнопки оновлення "
-"сторінки у вашому браузері. "
-
-#: pkg/shell/base_index.js:673
-msgid "The javascript console contains details about this error "
-msgstr "У консолі javascript наведено подробиці щодо цієї помилки "
-
-#: pkg/shell/base_index.js:674
-msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
-msgstr "(<b>Ctrl-Shift-J</b> у більшості браузерів)."
-
-#: pkg/shell/indexes.js:126 pkg/shell/indexes.js:497 pkg/shell/simple.html.h:17
-msgid "Disconnected"
-msgstr "Роз'єднано"
-
-#: pkg/shell/indexes.js:253
-msgid "Machines"
-msgstr "Машини"
-
-#: pkg/shell/indexes.js:314
-msgid "The machine is restarting"
-msgstr "Комп’ютер перезавантажується"
-
-#: pkg/shell/indexes.js:317
-msgid "Connecting to the machine"
-msgstr "Встановлюємо з’єднання із комп’ютером"
-
-#: pkg/shell/indexes.js:320
-msgid "Couldn't connect to the machine"
-msgstr "Не вдалося встановити з’єднання із комп’ютером"
-
-#: pkg/shell/indexes.js:322
-msgid "Cannot connect to an unknown machine"
-msgstr "Неможливо встановити з’єднання із невідомим комп’ютером"
-
-#: pkg/ostree/client.js:56
-msgid "Receiving delta parts"
-msgstr "Отримуємо частини відмінностей"
-
-#: pkg/ostree/client.js:58
-msgid "Receiving metadata objects"
-msgstr "Отримуємо об’єкти метаданих"
-
-#: pkg/ostree/client.js:61
-msgid "Receiving objects: $0%"
-msgstr "Отримуємо об’єкти: $0%"
-
-#: pkg/ostree/client.js:64
-msgid "Writing objects"
-msgstr "Записуємо об’єкти"
-
-#: pkg/ostree/client.js:66
-msgid "Scanning metadata"
-msgstr "Скануємо метадані"
-
-#: pkg/ostree/client.js:500
-msgid "OS $0 not found"
-msgstr "ОС $0 не знайдено"
-
-#: pkg/ostree/app.js:81
-msgid "Not authorized to update software on this system"
-msgstr "Не уповноважено на оновлення програмного забезпечення у цій системі"
-
-#: pkg/ostree/app.js:83
-msgid "OSTree is not available on this system"
-msgstr "OSTree у цій системі недоступна"
-
-#: pkg/ostree/app.js:101
-msgid "No OSTree deployments found"
-msgstr "Не знайдено розгорнутих OSTree"
-
-#: pkg/ostree/app.js:219
-msgid "Checking for updates"
-msgstr "Шукаємо оновлення"
 
 #: pkg/ostree/app.js:307
 msgid "$0 package"
@@ -798,699 +603,36 @@ msgstr "$0 пакунок"
 msgid "$0 packages"
 msgstr "$0 пакунків"
 
-#: pkg/selinux/setroubleshoot.js:65
-msgid "Error while setting SELinux mode: '$0'"
-msgstr "Помилка під час спроби встановити режим SELinux: «$0»"
-
-#: pkg/selinux/setroubleshoot.js:238
-msgid "Not connected"
-msgstr "Не з’єднано"
-
-#: pkg/selinux/setroubleshoot.js:275
-msgid "Error while connecting."
-msgstr "Помилка під час спроби з’єднатися."
-
-#: pkg/selinux/setroubleshoot-view.jsx:82
-msgid "Applying solution..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:90
-msgid "Solution applied successfully"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:97
-#, fuzzy
-msgid "Solution failed"
-msgstr "Невдала спроба увійти"
-
-#: pkg/selinux/setroubleshoot-view.jsx:107
-msgid "Apply this solution"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:114
-msgid "Unable to apply this solution automatically"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:118
-msgid "solution details"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:309
-msgid "SELinux system status is unknown."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:317
-#, fuzzy
-msgid "SELinux is disabled on the system."
-msgstr "Cockpit у цій системі не встановлено."
-
-#: pkg/selinux/setroubleshoot-view.jsx:324
-msgid "The configured state is unknown, it might change on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:326
-msgid ""
-"Setting deviates from the configured state and will revert on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:330
-#, fuzzy
-msgid "SELinux Policy"
-msgstr "Правило DNS"
-
-#: pkg/selinux/setroubleshoot-view.jsx:332
-msgid "Enforce policy:"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:382 pkg/kubernetes/index.html.h:10
-#: pkg/kubernetes/registry.html.h:5
-msgid "Connecting..."
-msgstr "Встановлення з’єднання…"
-
-#: pkg/selinux/setroubleshoot-view.jsx:385
-msgid ""
-"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
-"server is installed."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:400
-msgid "Occurred between $0 and $1"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:405
-msgid "Occurred $0"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:440
-msgid "$0 occurrence"
-msgid_plural "$1 occurrences"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:478
-msgid "SELinux Access Control Errors"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:479
-msgid "No SELinux alerts."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:52
-msgid "Unable to start setroubleshootd"
-msgstr "Не вдалося запустити setroubleshootd"
-
-#: pkg/selinux/setroubleshoot-client.js:157
-msgid "Unable to get alert"
-msgstr "Не вдалося отримати нагадування"
-
-#: pkg/selinux/setroubleshoot-client.js:172
-msgid "Unable to run fix"
-msgstr "Не вдалося виконати fix"
-
-#: pkg/selinux/setroubleshoot-client.js:187
-msgid "Failed to delete alert"
-msgstr "Не вдалося вилучити нагадування"
-
-#: pkg/selinux/setroubleshoot-client.js:192
-msgid "Error while deleting alert"
-msgstr "Помилка під час вилучення нагадування"
-
-#: pkg/storaged/dialog.js:267
-msgid "Size must be a number"
-msgstr "Розмір має бути числом"
-
-#: pkg/storaged/dialog.js:269
-#, fuzzy
-msgid "Size cannot be zero"
-msgstr "Розмір не може бути нульовим"
-
-#: pkg/storaged/dialog.js:271
-#, fuzzy
-msgid "Size cannot be negative"
-msgstr "Розмір не може бути від’ємним"
-
-#: pkg/storaged/dialog.js:273
-msgid "Size is too large"
-msgstr "Розмір є надто великим"
-
-#: pkg/storaged/details.js:85
-msgid "Device $0 is mounted on $1"
-msgstr "Пристрій $0 змонтовано до $1"
-
-#: pkg/storaged/details.js:91
-msgid "Device $0 is a member of RAID Array $1"
-msgstr "Пристрій $0 є елементом масиву RAID $1"
-
-#: pkg/storaged/details.js:97
-msgid "Device $0 is a physical volume of $1"
-msgstr "Пристрій $0 є фізичним томом $1"
-
-#: pkg/storaged/details.js:113
-msgid "Create partition on $0"
-msgstr "Створити розділ на $0"
-
-#: pkg/storaged/details.js:115
-msgid "Format $0"
-msgstr "Форматувати $0"
-
-#: pkg/storaged/details.js:177
-msgid "XFS - Red Hat Enterprise Linux 7 default"
-msgstr "XFS - Типова для Red Hat Enterprise Linux 7"
-
-#: pkg/storaged/details.js:178
-msgid "ext4 - Red Hat Enterprise Linux 6 default"
-msgstr "ext4 - Типова для Red Hat Enterprise Linux 6"
-
-#: pkg/storaged/details.js:179
-msgid "Encrypted XFS (LUKS)"
-msgstr "Шифрована XFS (LUKS)"
-
-#: pkg/storaged/details.js:180
-msgid "Encrypted EXT4 (LUKS)"
-msgstr "Шифрована EXT4 (LUKS)"
-
-#: pkg/storaged/details.js:181
-msgid "VFAT - Compatible with all systems and devices"
-msgstr "VFAT - Сумісна із усіма системами та пристроями"
-
-#: pkg/storaged/details.js:182
-msgid "NTFS - Compatible with most systems"
-msgstr "NTFS - Сумісна з більшістю систем"
-
-#: pkg/storaged/details.js:183
-msgid "Extended Partition"
-msgstr "Розширений розділ"
-
-#: pkg/storaged/details.js:185
-msgid "No Filesystem"
-msgstr "Немає файлової системи"
-
-#: pkg/storaged/details.js:186
-msgid "Custom (Enter filesystem type)"
-msgstr "Нетипова (Вкажіть тип файлової системи)"
-
-#: pkg/storaged/details.js:192 pkg/storaged/details.js:664
-#: pkg/storaged/details.js:735 pkg/storaged/details.js:773
-#: pkg/storaged/details.js:909 pkg/storaged/index.html.h:20
-#: pkg/kubernetes/views/volumes-page.html.h:11
-msgid "Size"
-msgstr "Розмір"
-
-#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
-msgid "Erase"
-msgstr "Витерти"
-
-#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
-msgid "Don't overwrite existing data"
-msgstr "Не перезаписувати наявні дані"
-
-#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
-msgid "Overwrite existing data with zeros"
-msgstr "Перезаписати наявні дані нулями"
-
-#: pkg/storaged/details.js:207 pkg/shell/index.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:4
-#: pkg/kubernetes/views/deploy.html.h:2 pkg/kubernetes/views/pv-modify.html.h:3
-msgid "Type"
-msgstr "Тип"
-
-#: pkg/storaged/details.js:211 pkg/storaged/details.js:429
-#: pkg/storaged/details.js:709 pkg/storaged/details.js:731
-#: pkg/storaged/details.js:769 pkg/storaged/details.js:798
-#: pkg/storaged/details.js:864 pkg/storaged/overview.js:417
-#: pkg/storaged/overview.js:490 pkg/storaged/overview.js:624
-#: pkg/storaged/overview.js:702 pkg/storaged/index.html.h:18
-#: pkg/networkmanager/index.html.h:16
-#: pkg/kubernetes/views/project-listing.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:3
-#: pkg/kubernetes/views/volume-body.html.h:11
-#: pkg/kubernetes/views/containers-listing.html.h:2
-#: pkg/kubernetes/views/volumes-page.html.h:3
-#: pkg/kubernetes/views/pv-claim.html.h:1
-#: pkg/kubernetes/views/pv-modify.html.h:6
-#: pkg/kubernetes/views/image-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:15
-#: pkg/kubernetes/views/nodes-page.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:3
-#: pkg/kubernetes/views/details-page.html.h:4
-#: pkg/kubernetes/views/service-modify.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:3
-msgid "Name"
-msgstr "Назва"
-
-#: pkg/storaged/details.js:215
-msgid "Filesystem type"
-msgstr "Тип файлової системи"
-
-#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
-msgid "Passphrase"
-msgstr "Пароль"
-
-#: pkg/storaged/details.js:224
-#, fuzzy
-msgid "Passphrase cannot be empty"
-msgstr "Пароль не може бути порожнім"
-
-#: pkg/storaged/details.js:229
-msgid "Confirm passphrase"
-msgstr "Підтвердить пароль"
-
-#: pkg/storaged/details.js:232
-msgid "Passphrases do not match"
-msgstr "Паролі не збігаються"
-
-#: pkg/storaged/details.js:237
-msgid "Store passphrase"
-msgstr "Зберігати пароль"
-
-#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
-#: pkg/storaged/details.js:1115
-msgid "Encryption Options"
-msgstr "Параметри шифрування"
-
-#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
-msgid "Mounting"
-msgstr "Монтування"
-
-#: pkg/storaged/details.js:247 pkg/storaged/details.js:435
-#: pkg/subscriptions/subscriptions-register.jsx:101 pkg/docker/index.html.h:23
-#: pkg/kubernetes/views/image-config.html.h:2
-msgid "Default"
-msgstr "Типовий"
-
-#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
-msgid "Custom"
-msgstr "Нетиповий"
-
-#: pkg/storaged/details.js:253 pkg/storaged/details.js:440
-#: pkg/storaged/index.html.h:19
-msgid "Mount Point"
-msgstr "Точка монтування"
-
-#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
-msgid "Mount Options"
-msgstr "Параметри монтування"
-
-#: pkg/storaged/details.js:266
-msgid "Create partition"
-msgstr "Створити розділ"
-
-#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
-#: pkg/storaged/details.js:1142
-msgid "Format"
-msgstr "Формат"
-
-#: pkg/storaged/details.js:268
-msgid "Formatting a storage device will erase all data on it."
-msgstr ""
-"Форматування пристрою для зберігання даних призведе до знищення даних, які "
-"на ньому зберігаються."
-
-#: pkg/storaged/details.js:335
-msgid "Format Disk $0"
-msgstr "Форматувати диск $0"
-
-#: pkg/storaged/details.js:346
-msgid "Partitioning"
-msgstr "Розподіл"
-
-#: pkg/storaged/details.js:348
-msgid "Compatible with all systems and devices (MBR)"
-msgstr "Сумісний із усіма системами та пристроями (MBR)"
-
-#: pkg/storaged/details.js:349
-msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr "Сумісний зі сучасними системами та жорсткими дисками > 2 ТБ (GPT)"
-
-#: pkg/storaged/details.js:352
-msgid "No partitioning"
-msgstr "Немає розподілу на розділи"
-
-#: pkg/storaged/details.js:358
-msgid "Formatting a disk will erase all data on it."
-msgstr ""
-"Форматування диска призведе до знищення даних, які на ньому зберігаються."
-
-#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
-msgid "Filesystem Options"
-msgstr "Параметри файлової системи"
-
-#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
-msgid "Apply"
-msgstr "Застосувати"
-
-#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
-#: pkg/storaged/details.js:1110
-msgid "Unlock"
-msgstr "Розблокувати"
-
-#: pkg/storaged/details.js:527
-msgid "Stored Passphrase"
-msgstr "Збережений пароль"
-
-#: pkg/storaged/details.js:531 pkg/kubernetes/views/volume-body.html.h:32
-msgid "Options"
-msgstr "Параметри"
-
-#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
-msgid "Add Disks"
-msgstr "Додати диски"
-
-#: pkg/storaged/details.js:567 pkg/storaged/details.js:933
-#: pkg/storaged/overview.js:448 pkg/storaged/overview.js:495
-#: pkg/storaged/index.html.h:55
-msgid "Disks"
-msgstr "Диски"
-
-#: pkg/storaged/details.js:579 pkg/storaged/details.js:948
-#: pkg/storaged/overview.js:501
-msgid "At least one disk is needed."
-msgstr "Потрібен принаймні один диск."
-
-#: pkg/storaged/details.js:584 pkg/storaged/details.js:953
-#: pkg/storaged/overview.js:629 pkg/storaged/overview.js:657
-#: pkg/lib/machine-add.html.h:6 pkg/kubernetes/views/node-add.html.h:8
-#: pkg/kubernetes/views/user-group-add.html.h:6
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:5
-#: pkg/kubernetes/views/add-user-dialog.html.h:9
-#: pkg/kubernetes/views/user-add-membership.html.h:9
-#: pkg/kubernetes/views/add-role-dialog.html.h:4
-msgid "Add"
-msgstr "Додати"
-
-#: pkg/storaged/details.js:625 pkg/storaged/details.js:821
-#: pkg/storaged/details.js:1016 pkg/docker/details.js:271
-#: pkg/docker/image.js:151 pkg/docker/containers-view.jsx:166
-msgid "Please confirm deletion of $0"
-msgstr "Будь ласка, підтвердьте вилучення $0"
-
-#: pkg/storaged/details.js:630 pkg/storaged/details.js:827
-#: pkg/storaged/details.js:1022 pkg/storaged/details.js:1151
-#: pkg/storaged/details.js:1616 pkg/storaged/details.js:1776
-#: pkg/docker/details.js:273 pkg/docker/image.js:153
-#: pkg/docker/containers-view.jsx:168 pkg/kubernetes/scripts/volumes.js:218
-#: pkg/users/index.html.h:9 pkg/kubernetes/views/node-delete.html.h:5
-#: pkg/kubernetes/views/pvc-delete.html.h:5
-#: pkg/kubernetes/views/image-delete.html.h:4
-#: pkg/kubernetes/views/pv-delete.html.h:5
-#: pkg/kubernetes/views/item-delete.html.h:5
-#: pkg/kubernetes/views/imagestream-delete.html.h:4
-#: pkg/kubernetes/views/user-remove-membership.html.h:3
-#: pkg/kubernetes/views/project-delete.html.h:3
-msgid "Delete"
-msgstr "Вилучити"
-
-#: pkg/storaged/details.js:631
-msgid "Deleting a RAID device will erase all data on it."
-msgstr "Вилучення пристрою RAID призведе до витирання з нього усіх даних."
-
-#: pkg/storaged/details.js:661
-msgid "Resize Logical Volume"
-msgstr "Змінити розмір логічного тому"
-
-#: pkg/storaged/details.js:673
-msgid "Resize Filesystem"
-msgstr "Змінити розмір файлової системи"
-
-#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
-msgid "Resize"
-msgstr "Змінити розмір"
-
-#: pkg/storaged/details.js:690
-#, fuzzy
-msgid "This logical volume cannot be made smaller."
-msgstr "Логічний том не можна зменшувати."
-
-#: pkg/storaged/details.js:706
-msgid "Renamee Logical Volume"
-msgstr "Перейменувати логічний том"
-
-#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
-#: pkg/storaged/details.js:1775
-msgid "Rename"
-msgstr "Перейменувати"
-
-#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
-msgid "Create Snapshot"
-msgstr "Створення знімка"
-
-#: pkg/storaged/details.js:745 pkg/storaged/details.js:781
-#: pkg/storaged/details.js:804 pkg/storaged/details.js:915
-#: pkg/storaged/overview.js:461 pkg/storaged/overview.js:506
-#: pkg/kubernetes/views/add-group-dialog.html.h:6
-#: pkg/kubernetes/views/project-modify.html.h:8
-msgid "Create"
-msgstr "Створити"
-
-#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
-msgid "Create Thin Volume"
-msgstr "Створити тонкий том"
-
-#: pkg/storaged/details.js:795
-msgid "Rename Volume Group"
-msgstr "Перейменувати групу томів"
-
-#: pkg/storaged/details.js:826
-msgid "Deleting a volume group will erase all data on it."
-msgstr ""
-"Вилучення групи томів призведе до витирання усіх даних, що у ній "
-"зберігаються."
-
-#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
-msgid "Create Logical Volume"
-msgstr "Створити логічний том"
-
-#: pkg/storaged/details.js:869
-msgid "Purpose"
-msgstr "Призначення"
-
-#: pkg/storaged/details.js:871
-msgid "Block device for filesystems"
-msgstr "Блоковий пристрій для файлових систем"
-
-#: pkg/storaged/details.js:874
-msgid "Pool for thinly provisioned volumes"
-msgstr "Буфер для тонких резервованих томів"
-
-#: pkg/storaged/details.js:1009
-msgid "Deleting a logical volume will delete all data in it."
-msgstr ""
-"Вилучення логічного тому призведе до витирання усіх даних, що на ньому "
-"зберігаються."
-
-#: pkg/storaged/details.js:1012
-msgid "Deleting a partition will delete all data in it."
-msgstr ""
-"Вилучення розділу призведе до вилучення усіх даних, що на ньому зберігаються."
-
-#: pkg/storaged/details.js:1053 pkg/storaged/overview.js:689
-#: pkg/storaged/devices.js:119 pkg/users/local.js:1155
-#: pkg/systemd/services.html.h:14
-msgid "Error"
-msgstr "Помилка"
-
-#: pkg/storaged/details.js:1099
-msgid "Mount"
-msgstr "Змонтувати"
-
-#: pkg/storaged/details.js:1100
-msgid "Unmount"
-msgstr "Демонтувати"
-
-#: pkg/storaged/details.js:1109
-msgid "Lock"
-msgstr "Заблокувати"
-
-#: pkg/storaged/details.js:1127
-msgid "Activate"
-msgstr "Задіяти"
-
-#: pkg/storaged/details.js:1130
-msgid "Deactivate"
-msgstr "Вимкнути"
-
-#: pkg/storaged/details.js:1221
-msgctxt "storage-id-desc"
-msgid "$0 File System"
-msgstr "Файлова система $0"
-
-#: pkg/storaged/details.js:1224
-msgctxt "storage-id-desc"
-msgid "Linux MD-RAID Component"
-msgstr "Компонент MD-RAID Linux"
-
-#: pkg/storaged/details.js:1226
-msgctxt "storage-id-desc"
-msgid "LVM2 Physical Volume"
-msgstr "Фізичний том LVM2"
-
-#: pkg/storaged/details.js:1228
-msgctxt "storage-id-desc"
-msgid "RAID Member"
-msgstr "Елемент RAID"
-
-#: pkg/storaged/details.js:1245
-msgctxt "storage-id-desc"
-msgid "LUKS Encrypted"
-msgstr "Зашифровано LUKS"
-
-#: pkg/storaged/details.js:1247
-msgctxt "storage-id-desc"
-msgid "Encrypted"
-msgstr "Шифровано"
-
-#: pkg/storaged/details.js:1251
-msgctxt "storage-id-desc"
-msgid "Swap Space"
-msgstr "Резервна пам’ять"
-
-#: pkg/storaged/details.js:1253
-msgctxt "storage-id-desc"
-msgid "Other Data"
-msgstr "Інші дані"
-
-#: pkg/storaged/details.js:1256
-msgctxt "storage-id-desc"
-msgid "Unrecognized Data"
-msgstr "Нерозпізнані дані"
-
-#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
-msgid "$size $partition"
-msgstr "$size $partition"
-
-#: pkg/storaged/details.js:1278
-msgid "mounted on $0"
-msgstr "змонтовано до $0"
-
-#: pkg/storaged/details.js:1280
-msgid "not mounted"
-msgstr "не змонтовано"
-
-#: pkg/storaged/details.js:1284
-msgid "unlocked"
-msgstr "розблоковано"
-
-#: pkg/storaged/details.js:1286
-msgid "locked"
-msgstr "блоковано"
-
-#: pkg/storaged/details.js:1367
-msgid "$0 Free Space for Logical Partitions"
-msgstr "$0 вільного простору для логічних розділів"
-
-#: pkg/storaged/details.js:1370
-msgid "$0 Free Space for Primary Partitions"
-msgstr "$0 вільного простору для основних розділів"
-
-#: pkg/storaged/details.js:1375
-msgid "$0 Free Space"
-msgstr "Вільного місця: $0"
-
-#: pkg/storaged/details.js:1379
-msgid "Create Partition"
-msgstr "Створити розділ"
-
-#: pkg/storaged/details.js:1387
-msgid "$0 Extended Partition"
-msgstr "Розширений розділ $0"
-
-#: pkg/storaged/details.js:1424
-msgid "Logical Partition"
-msgstr "Логічний розділ"
-
-#: pkg/storaged/details.js:1426
-msgid "Primary Partition"
-msgstr "Основний розділ"
-
-#: pkg/storaged/details.js:1428 pkg/kubernetes/views/volume-body.html.h:5
-msgid "Partition"
-msgstr "Розділ"
-
-#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
-msgid "Content"
-msgstr "Вміст"
-
-#: pkg/storaged/details.js:1533
-msgid "RAID 0"
-msgstr "RAID 0"
-
-#: pkg/storaged/details.js:1534
-msgid "RAID 1"
-msgstr "RAID 1"
-
-#: pkg/storaged/details.js:1535
-msgid "RAID 4"
-msgstr "RAID 4"
-
-#: pkg/storaged/details.js:1536
-msgid "RAID 5"
-msgstr "RAID 5"
-
-#: pkg/storaged/details.js:1537
-msgid "RAID 6"
-msgstr "RAID 6"
-
-#: pkg/storaged/details.js:1538
-msgid "RAID 10"
-msgstr "RAID 10"
-
-#: pkg/storaged/details.js:1539
-msgid "RAID ($0)"
-msgstr "RAID ($0)"
-
-#: pkg/storaged/details.js:1544
-msgid "$0 Disks"
-msgstr "Диски $0"
-
-#: pkg/storaged/details.js:1546
-msgid "$0 Chunk Size"
-msgstr "Розмір фрагмента $0"
-
-#: pkg/storaged/details.js:1574 pkg/ostree/index.html.h:7
-msgid "Running"
-msgstr "Працює"
-
-#: pkg/storaged/details.js:1574
-msgid "Not running"
-msgstr "Зупинено"
-
-#: pkg/storaged/details.js:1592
-msgid "FAILED"
-msgstr "ПОМИЛКА"
-
-#: pkg/storaged/details.js:1593
-msgid "In Sync"
-msgstr "Синхронізовано"
-
-#: pkg/storaged/details.js:1594
-msgid "Spare"
-msgstr "Запас"
-
-#: pkg/storaged/details.js:1594
-msgid "Recovering"
-msgstr "Відновлюємо"
-
-#: pkg/storaged/details.js:1595
-msgid "Write-mostly"
-msgstr "Здебільшого запис"
-
-#: pkg/storaged/details.js:1596
-msgid "Blocked"
-msgstr "Заблоковано"
-
-#: pkg/storaged/details.js:1597
-msgid "Unknown ($0)"
-msgstr "Невідомий ($0)"
-
-#: pkg/storaged/details.js:1614
-msgid "Start Scrubbing"
-msgstr "Почати витирання"
-
-#: pkg/storaged/details.js:1615
-msgid "Stop Scrubbing"
-msgstr "Зупинити витирання"
+#: pkg/docker/util.js:124
+msgid "$0 shares"
+msgstr "$0 спільних ресурсів"
+
+#: pkg/kubernetes/scripts/nodes.js:870
+#, fuzzy, c-format
+msgid "$0% Free"
+msgid_plural "$0% Free"
+msgstr[0] "Вільно $0%"
+msgstr[1] "Вільно $0%"
+msgstr[2] "Вільно $0%"
+
+#: pkg/kubernetes/scripts/nodes.js:872
+msgid "$0% Used"
+msgid_plural "$0% Used"
+msgstr[0] "Використано $0%"
+msgstr[1] "Використано $0%"
+msgstr[2] "Використано $0%"
+
+#: pkg/storaged/details.js:1765
+msgid "$0, $1 free"
+msgstr "$0, вільно $1"
+
+#: pkg/networkmanager/interfaces.js:2473
+msgid "$mtu"
+msgstr "$mtu"
+
+#: pkg/storaged/utils.js:157
+msgid "$name (from $host)"
+msgstr "$name (з $host)"
 
 #: pkg/storaged/details.js:1653
 msgid "$size $desc"
@@ -1505,217 +647,2874 @@ msgstr "$size $desc<br/>заповнено на ${percent}%"
 msgid "$size $desc<br/>($state)"
 msgstr "$size $desc<br/>($state)"
 
-#: pkg/storaged/details.js:1692
-msgid "active, but unsupported"
-msgstr "активний, але непідтримуваний"
+#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
+msgid "$size $partition"
+msgstr "$size $partition"
 
-#: pkg/storaged/details.js:1692
-msgid "inactive"
-msgstr "неактивний"
+#: pkg/docker/details.js:144
+msgid "${hip}:${hport} -> $cport"
+msgstr "${hip}:${hport} -> $cport"
 
-#: pkg/storaged/details.js:1711
-msgid "$0 Free Space for Logical Volumes"
-msgstr "$0 вільного простору для логічних томів"
-
-#: pkg/storaged/details.js:1751
-msgid "The last physical volume of a volume group cannot be removed."
+#: pkg/subscriptions/subscriptions-client.js:198
+msgid "'Organization' required to register."
 msgstr ""
 
-#: pkg/storaged/details.js:1756
+#: pkg/subscriptions/subscriptions-client.js:202
+msgid "'Organization' required when using activation keys."
+msgstr ""
+
+#: pkg/shell/base_index.js:674
+msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
+msgstr "(<b>Ctrl-Shift-J</b> у більшості браузерів)."
+
+#: pkg/storaged/overview.js:440
+msgid "1 MiB"
+msgstr "1 МіБ"
+
+#: pkg/systemd/index.html:459 pkg/systemd/index.html:463
+msgid "1 Minute"
+msgstr "1 хвилина"
+
+#: pkg/storaged/index.html:312 pkg/networkmanager/index.html:55
+#: pkg/networkmanager/index.html:501
+msgid "1 day"
+msgstr "1 день"
+
+#: pkg/storaged/index.html:310 pkg/networkmanager/index.html:53
+#: pkg/networkmanager/index.html:499
+msgid "1 hour"
+msgstr "1 година"
+
+#: pkg/storaged/index.html:313 pkg/networkmanager/index.html:56
+#: pkg/networkmanager/index.html:502
+msgid "1 week"
+msgstr "1 тиждень"
+
+#: pkg/playground/translate.html:190
+#, fuzzy
+msgid "1% Free"
+msgid_plural "{{$count}}% Free"
+msgstr[0] "Вільно $0%"
+msgstr[1] "Вільно $0%"
+msgstr[2] "Вільно $0%"
+
+#: pkg/storaged/overview.js:438
+msgid "128 KiB"
+msgstr "128 КіБ"
+
+#: pkg/storaged/overview.js:435
+msgid "16 KiB"
+msgstr "16 КіБ"
+
+#: pkg/storaged/overview.js:441
+msgid "2 MiB"
+msgstr "2 МіБ"
+
+#: pkg/systemd/index.html:465
+msgid "20 Minutes"
+msgstr "20 хвилин"
+
+#: pkg/storaged/overview.js:436
+msgid "32 KiB"
+msgstr "32 КіБ"
+
+#: pkg/storaged/overview.js:433
+msgid "4 KiB"
+msgstr "4 КіБ"
+
+#: pkg/systemd/index.html:466
+msgid "40 Minutes"
+msgstr "40 хвилин"
+
+#: pkg/systemd/index.html:464
+msgid "5 Minutes"
+msgstr "5 хвилин"
+
+#: pkg/storaged/index.html:309 pkg/networkmanager/index.html:52
+#: pkg/networkmanager/index.html:498
+msgid "5 minutes"
+msgstr "5 хвилин"
+
+#: pkg/storaged/overview.js:439
+msgid "512 KiB"
+msgstr "512 КіБ"
+
+#: pkg/storaged/index.html:311 pkg/networkmanager/index.html:54
+#: pkg/networkmanager/index.html:500
+msgid "6 hours"
+msgstr "6 годин"
+
+#: pkg/systemd/index.html:467
+msgid "60 Minutes"
+msgstr "60 хвилин"
+
+#: pkg/storaged/overview.js:437
+msgid "64 KiB"
+msgstr "64 КіБ"
+
+#: pkg/storaged/overview.js:434
+msgid "8 KiB"
+msgstr "8 КіБ"
+
+#: pkg/networkmanager/interfaces.js:1826
+msgid "802.3ad"
+msgstr "802.3ad"
+
+#: pkg/networkmanager/interfaces.js:1843
+#, fuzzy
+msgid "802.3ad LACP"
+msgstr "802.3ad"
+
+#: pkg/systemd/services.html:446
+msgid ":"
+msgstr ""
+
+#: pkg/storaged/utils.js:220
+msgid "<span>Encrypted $0</span>"
+msgstr "<span>Зашифрований $0</span>"
+
+#: pkg/storaged/utils.js:212
+msgid "<span>Encrypted Logical Volume of $0</span>"
+msgstr "<span>Зашифрований логічний том $0</span>"
+
+#: pkg/storaged/utils.js:214
+msgid "<span>Encrypted Partition of $0</span>"
+msgstr "<span>Шифрований розділ $0</span>"
+
+#: pkg/storaged/utils.js:216
+msgid "<span>Logical Volume of $0</span>"
+msgstr "<span>Логічний том $0</span>"
+
+#: pkg/storaged/utils.js:218
+msgid "<span>Partition of $0</span>"
+msgstr "<span>Розділ $0</span>"
+
+#: pkg/lib/machine-not-supported.html:5
 msgid ""
-"There is not enough free space elsewhere to remove this physical volume.  At "
-"least $0 more free space is needed."
+"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
+"strong}}."
+msgstr ""
+"У {{#strong}}{{host}}{{/strong}} не встановлено сумісної версії Cockpit."
+
+#: cockpit.desktop.in.h:2
+msgid "A user interface for GNU/Linux servers"
+msgstr "Інтерфейс користувача для серверів GNU/Linux"
+
+#: pkg/networkmanager/interfaces.js:1834
+msgid "ARP"
+msgstr "ARP"
+
+#: pkg/networkmanager/interfaces.js:2502
+msgid "ARP Monitoring"
+msgstr "Стеження за ARP"
+
+#: pkg/networkmanager/interfaces.js:1855
+#, fuzzy
+msgid "ARP Ping"
+msgstr "Стеження за ARP"
+
+#: pkg/kubernetes/scripts/volumes.js:193
+msgid "AWS Elastic Block Store"
+msgstr "Блокове сховище AWS Elastic"
+
+#: pkg/shell/simple.html:41 pkg/shell/simple.html:67 pkg/shell/index.html:41
+#: pkg/shell/index.html:80 pkg/shell/stub.html:41 pkg/shell/stub.html:73
+msgid "About Cockpit"
+msgstr "Про Cockpit"
+
+#: pkg/users/index.html:105 pkg/users/index.html:191
+msgid "Access"
+msgstr "Доступ"
+
+#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pv-claim.html:9
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-body.html:9
+msgid "Access Modes"
+msgstr "Режими доступу"
+
+#: pkg/kubernetes/views/project-modify.html:49
+#: pkg/kubernetes/views/imagestream-body.html:11
+msgid "Access Policy"
+msgstr "Правила доступу"
+
+#: pkg/subscriptions/subscriptions-view.jsx:191
+#, fuzzy
+msgid "Access denied"
+msgstr "Режими доступу"
+
+#: pkg/shell/index.html:45
+msgid "Account Settings"
+msgstr "Параметри облікового запису"
+
+#: pkg/users/index.html:63
+msgid "Account not available or cannot be edited."
+msgstr "Обліковий запис недоступний або його не можна редагувати."
+
+#: pkg/users/index.html:71
+msgid "Accounts"
+msgstr "Облікові записи"
+
+#: pkg/users/local.js:284 pkg/users/local.js:594
+msgctxt "page-title"
+msgid "Accounts"
+msgstr "Облікові записи"
+
+#: pkg/storaged/details.js:1127
+msgid "Activate"
+msgstr "Задіяти"
+
+#: pkg/storaged/jobs.js:148
+msgid "Activating $target"
+msgstr "Активуємо $target"
+
+#: pkg/subscriptions/subscriptions-register.jsx:164
+#, fuzzy
+msgid "Activation Key"
+msgstr "Задіяти"
+
+#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
+msgid "Active"
+msgstr "Активний"
+
+#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
+msgid "Active Backup"
+msgstr "Активне резервування"
+
+#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
+msgid "Actual"
+msgstr "Поточна"
+
+#: pkg/networkmanager/interfaces.js:1828
+msgid "Adaptive load balancing"
+msgstr "Адаптивне урівноваження навантаження"
+
+#: pkg/networkmanager/interfaces.js:1827
+msgid "Adaptive transmit load balancing"
+msgstr "Адаптивне урівноваження навантаження за передаванням"
+
+#: pkg/kubernetes/views/add-user-dialog.html:31
+#: pkg/kubernetes/views/node-add.html:50
+#: pkg/kubernetes/views/user-add-membership.html:53
+#: pkg/kubernetes/views/add-member-role-dialog.html:61
+#: pkg/kubernetes/views/user-group-add.html:32
+#: pkg/kubernetes/views/add-role-dialog.html:8 pkg/lib/machine-add.html:43
+msgid "Add"
+msgstr "Додати"
+
+#: pkg/networkmanager/interfaces.js:2836
+msgid "Add $0"
 msgstr ""
 
-#: pkg/storaged/details.js:1765
-msgid "$0, $1 free"
-msgstr "$0, вільно $1"
+#: pkg/docker/storage.jsx:363
+#, fuzzy
+msgid "Add Additional Storage"
+msgstr "Додаткове сховище"
 
-#: pkg/storaged/details.js:1792
-msgid "Logical Volumes"
-msgstr "Логічні томи"
+#: pkg/networkmanager/index.html:86
+msgid "Add Bond"
+msgstr "Додати зв’язок"
 
-#: pkg/storaged/details.js:1822 pkg/docker/details.js:177
-#: pkg/docker/image.js:112
-msgid "Not found"
-msgstr "Не знайдено"
+#: pkg/networkmanager/index.html:88
+msgid "Add Bridge"
+msgstr "Додати місток"
 
-#: pkg/storaged/overview.js:180
+#: pkg/kubernetes/views/node-add.html:3
+msgid "Add Cluster Node"
+msgstr "Додати вузол кластера"
+
+#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
+msgid "Add Disks"
+msgstr "Додати диски"
+
+#: pkg/kubernetes/views/add-group-dialog.html:3
+msgid "Add Group"
+msgstr "Додати групу"
+
+#: pkg/kubernetes/views/nodes-page.html:34
+msgid "Add Kubernetes Node"
+msgstr "Додати вузол Kubernetes"
+
+#: pkg/lib/machine-add.html:4
+msgid "Add Machine to Dashboard"
+msgstr "Додати запис комп’ютера на панель"
+
+#: pkg/kubernetes/views/group-page.html:38
+#: pkg/kubernetes/views/add-member-role-dialog.html:4
+#: pkg/kubernetes/views/group-panel.html:29
+#: pkg/kubernetes/views/user-group-add.html:3
+#: pkg/kubernetes/views/project-body.html:108
+msgid "Add Member"
+msgstr "Додати учасника"
+
+#: pkg/kubernetes/views/user-panel.html:76
+#: pkg/kubernetes/views/user-body.html:67
+msgid "Add Membership"
+msgstr "Додати запис участі"
+
+#: pkg/kubernetes/views/auth-form.html:11
+#: pkg/kubernetes/views/auth-form.html:20
+msgid "Add New Cluster"
+msgstr "Додати новий кластер"
+
+#: pkg/kubernetes/views/auth-form.html:67
+#: pkg/kubernetes/views/auth-form.html:76
+msgid "Add New User"
+msgstr "Додати нового користувача"
+
+#: pkg/kubernetes/views/add-role-dialog.html:3
+msgid "Add Role"
+msgstr "Додати роль"
+
+#: pkg/networkmanager/index.html:87
+#, fuzzy
+msgid "Add Team"
+msgstr "Додати учасника"
+
+#: pkg/kubernetes/views/add-user-dialog.html:3
+#: pkg/kubernetes/views/project-listing.html:83
+msgid "Add User"
+msgstr "Додати користувача"
+
+#: pkg/networkmanager/index.html:89
+msgid "Add VLAN"
+msgstr "Додати VLAN"
+
+#: pkg/storaged/overview.js:515
+msgid "Add iSCSI Portal"
+msgstr "Додати портал iSCSI"
+
+#: pkg/kubernetes/views/user-add-membership.html:3
+msgid "Add membership"
+msgstr "Додати запис участі"
+
+#: pkg/users/index.html:351
+msgid "Add public key"
+msgstr "Додати відкритий ключ"
+
+#: pkg/networkmanager/interfaces.js:2833
+msgid "Adding <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/users/authorized-keys.js:108
+msgid "Adding key"
+msgstr "Додавання ключа"
+
+#: pkg/storaged/jobs.js:153
+msgid "Adding physical volume to $target"
+msgstr "Додаємо фізичний том до $target"
+
+#: pkg/docker/index.html:329
+msgid "Additional Storage"
+msgstr "Додаткове сховище"
+
+#: pkg/ostree/index.html:121 pkg/ostree/index.html:140
+msgid "Additions"
+msgstr "Додавання"
+
+#: pkg/kubernetes/views/node-add.html:8
+#: pkg/kubernetes/views/dashboard-page.html:157
+#: pkg/kubernetes/views/details-page.html:174
+#: pkg/kubernetes/views/nodes-page.html:43
+#: pkg/kubernetes/views/auth-form.html:29 pkg/kubernetes/views/node-body.html:5
+#: pkg/lib/machine-add.html:11
+msgid "Address"
+msgstr "Адреса"
+
+#: pkg/kubernetes/views/details-page.html:37
+msgid "Addresses"
+msgstr "Адреси"
+
+#: pkg/kubernetes/views/service-modify.html:25
+msgid "Adjust"
+msgstr "Скоригувати"
+
+#: pkg/kubernetes/views/pv-modify.html:3
+msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+msgstr "Скоригувати сталий том «{{ item.metadata.name }}»"
+
+#: pkg/kubernetes/views/replicationcontroller-modify.html:3
+msgid "Adjust Replication Controller {{ item.metadata.name }}"
+msgstr "Скоригувати контролер реплікації {{ item.metadata.name }}"
+
+#: pkg/kubernetes/views/route-modify.html:3
+msgid "Adjust Route"
+msgstr "Скоригувати маршрут"
+
+#: pkg/kubernetes/views/service-modify.html:3
+msgid "Adjust Service"
+msgstr "Скоригувати службу"
+
+#: pkg/kubernetes/views/project-body.html:56
+msgid "Admin"
+msgstr "Адміністратор"
+
+#: pkg/systemd/services.html:389 pkg/systemd/services.html:393
+#, fuzzy
+msgid "After system boot"
+msgstr "Зареєструвати систему"
+
+#: pkg/systemd/logs.html:50
+msgid "All"
+msgstr "Всі"
+
+#: pkg/kubernetes/views/filter-project.html:4
+msgid "All Projects"
+msgstr "Всі проекти"
+
+#: pkg/kubernetes/views/details-page.html:6
+msgid "All Types"
+msgstr "Всі типи"
+
+#: pkg/docker/storage.jsx:366
+msgid ""
+"All data on selected disks will be erased and disks will be added to the "
+"storage pool."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:112
+msgid "All healthy"
+msgstr "Усі корисні"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:74
+msgid "All images"
+msgstr "Усі образи"
+
+#: pkg/kubernetes/views/dashboard-page.html:69
+msgid "All in use"
+msgstr "Усі використано"
+
+#: pkg/kubernetes/views/dashboard-page.html:37
+msgid "All running"
+msgstr "Усі запущено"
+
+#: pkg/docker/index.html:569
+msgid "Always"
+msgstr "Завжди"
+
+#: pkg/kubernetes/views/imagestream-meta.html:2
+#: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/image-meta.html:9
+#: pkg/kubernetes/views/node-body.html:57
+msgid "Annotations"
+msgstr "Анотації"
+
+#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
+msgid "Apply"
+msgstr "Застосувати"
+
+#: pkg/selinux/setroubleshoot-view.jsx:107
+msgid "Apply this solution"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:82
+msgid "Applying solution..."
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:12
+msgid "Architecture"
+msgstr "Архітектура"
+
+#: pkg/storaged/index.html:451
 msgctxt "storage"
-msgid "Hard Disk"
-msgstr "Жорсткий диск"
+msgid "Assessment"
+msgstr "Оцінка"
 
-#: pkg/storaged/overview.js:182
-msgctxt "storage"
-msgid "Solid-State Disk"
-msgstr "Твердотільний диск"
+#: pkg/systemd/index.html:81
+msgid "Asset Tag"
+msgstr "Мітка активу"
 
-#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
-msgctxt "storage"
-msgid "Removable Drive"
-msgstr "Портативний диск"
+#: pkg/storaged/overview.js:455
+msgid "At least $0 disks are needed."
+msgstr "Потрібно принаймні $0 дисків."
 
-#: pkg/storaged/overview.js:189
+#: pkg/storaged/overview.js:501 pkg/storaged/details.js:579
+#: pkg/storaged/details.js:948
+msgid "At least one disk is needed."
+msgstr "Потрібен принаймні один диск."
+
+#: pkg/systemd/services.html:394
+#, fuzzy
+msgid "At specific time"
+msgstr "У визначений час"
+
+#: pkg/networkmanager/interfaces.js:813
+msgid "Authenticating"
+msgstr "Автентифікація"
+
+#: pkg/realmd/operation.html:34 pkg/shell/index.html:48
+#: pkg/shell/index.html:159 pkg/kubernetes/views/auth-form.html:85
+#: pkg/lib/machine-change-auth.html:32
+msgid "Authentication"
+msgstr "Розпізнавання"
+
+#: pkg/lib/machine-auth-failed.html:2
+msgid "Authentication Failed"
+msgstr "Не вдалося пройти розпізнавання"
+
+#: pkg/docker/index.html:730 pkg/kubernetes/views/image-body.html:12
+#: pkg/kubernetes/views/image-listing.html:15
+msgid "Author"
+msgstr "Автор"
+
+#: pkg/users/index.html:130
+msgid "Authorized Public SSH Keys"
+msgstr "Уповноважені відкриті ключі SSH"
+
+#: pkg/networkmanager/index.html:165
+msgid "Automatic"
+msgstr "Автоматично"
+
+#: pkg/networkmanager/interfaces.js:1814
+msgid "Automatic (DHCP only)"
+msgstr "Автоматично (лише DHCP)"
+
+#: pkg/networkmanager/interfaces.js:1804
+msgid "Automatic (DHCP)"
+msgstr "Автоматично (DHCP)"
+
+#: pkg/systemd/index.html:406
+msgid "Automatically using NTP"
+msgstr "Автоматично на основі NTP"
+
+#: pkg/systemd/index.html:407
+msgid "Automatically using specific NTP servers"
+msgstr "Автоматично за допомогою певних серверів NTP"
+
+#: pkg/lib/machine-change-auth.html:66
+msgid "Available"
+msgstr "Доступні"
+
+#: pkg/storaged/overview.js:619
+msgid "Available targets on $0"
+msgstr "Доступні призначення на $0"
+
+#: pkg/dashboard/index.html:177
+msgid "Avatar"
+msgstr "Аватар"
+
+#: pkg/kubernetes/scripts/volumes.js:207
+msgid "Azure"
+msgstr "Azure"
+
+#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
+msgid "Bad data passed for passwd1 mechanism"
+msgstr "Механізму passwd1 передано помилкові дані"
+
+#: pkg/networkmanager/index.html:389
+msgid "Balancer"
+msgstr ""
+
+#: pkg/storaged/index.html:560
 msgctxt "storage"
-msgid "Optical Drive"
-msgstr "Пристрій читання оптичних дисків"
+msgid "Bitmap"
+msgstr "Растр"
+
+#: pkg/storaged/index.html:414
+msgid "Block Device"
+msgstr "Блоковий пристрій"
+
+#: pkg/storaged/details.js:871
+msgid "Block device for filesystems"
+msgstr "Блоковий пристрій для файлових систем"
+
+#: pkg/storaged/details.js:1596
+msgid "Blocked"
+msgstr "Заблоковано"
+
+#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
+#: pkg/networkmanager/interfaces.js:2507
+msgid "Bond"
+msgstr "Прив’язка"
+
+#: pkg/networkmanager/index.html:596
+msgid "Bond Settings"
+msgstr "Параметри зв’язку"
+
+#: pkg/kubernetes/views/node-body.html:17
+msgid "Boot ID"
+msgstr "Ід. завантаження"
+
+#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
+#: pkg/networkmanager/interfaces.js:2584
+msgid "Bridge"
+msgstr "Міст"
+
+#: pkg/networkmanager/index.html:708
+msgid "Bridge Port Settings"
+msgstr "Параметри порту містка"
+
+#: pkg/networkmanager/index.html:680
+msgid "Bridge Settings"
+msgstr "Параметри містка"
+
+#: pkg/networkmanager/interfaces.js:2605
+msgid "Bridge port"
+msgstr "Порт містка"
+
+#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
+msgid "Broadcast"
+msgstr "Трансляція"
+
+#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#, fuzzy
+msgid "Broken configuration"
+msgstr "Невідомі налаштування"
+
+#: pkg/kubernetes/views/image-body.html:16
+msgid "Built"
+msgstr "Зібрано"
+
+#: pkg/dashboard/index.html:70
+msgid "CPU"
+msgstr "Процесор"
+
+#: pkg/systemd/host.js:1381
+msgctxt "page-title"
+msgid "CPU Status"
+msgstr "Стан процесора"
+
+#: pkg/kubernetes/scripts/nodes.js:712
+msgid "CPU Utilization: $0%"
+msgstr "Використання процесора: $0%"
+
+#: pkg/docker/index.html:490 pkg/docker/index.html:669
+msgid "CPU priority"
+msgstr "Пріоритетність процесора"
+
+#: pkg/systemd/index.html:247
+msgid "Cached"
+msgstr "Кеш"
+
+#: pkg/docker/index.html:63
+msgid "Can&rsquo;t connect to Docker"
+msgstr "Не вдалося зв’язатися із Docker"
+
+#: pkg/systemd/services.html:465 pkg/dashboard/index.html:189
+#: pkg/playground/translate.html:40 pkg/playground/translate.html:174
+#: pkg/realmd/operation.html:90 pkg/kubernetes/views/pv-modify.html:202
+#: pkg/kubernetes/views/item-delete.html:10
+#: pkg/kubernetes/views/add-user-dialog.html:30
+#: pkg/kubernetes/views/project-modify.html:71
+#: pkg/kubernetes/views/node-add.html:49
+#: pkg/kubernetes/views/pvc-delete.html:14
+#: pkg/kubernetes/views/node-delete.html:14
+#: pkg/kubernetes/views/imagestream-modify.html:96
+#: pkg/kubernetes/views/imagestream-delete.html:7
+#: pkg/kubernetes/views/user-modify.html:30
+#: pkg/kubernetes/views/add-group-dialog.html:20
+#: pkg/kubernetes/views/project-delete.html:8
+#: pkg/kubernetes/views/service-modify.html:24
+#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/kubernetes/views/user-group-remove.html:9
+#: pkg/kubernetes/views/user-add-membership.html:52
+#: pkg/kubernetes/views/add-member-role-dialog.html:60
+#: pkg/kubernetes/views/group-delete.html:20
+#: pkg/kubernetes/views/image-delete.html:7 pkg/kubernetes/views/deploy.html:61
+#: pkg/kubernetes/views/user-group-add.html:31
+#: pkg/kubernetes/views/auth-form.html:128
+#: pkg/kubernetes/views/auth-rejected-cert.html:31
+#: pkg/kubernetes/views/replicationcontroller-modify.html:16
+#: pkg/kubernetes/views/pv-delete.html:10
+#: pkg/kubernetes/views/add-role-dialog.html:7
+#: pkg/kubernetes/views/route-modify.html:16
+#: pkg/kubernetes/views/user-delete.html:24
+#: pkg/kubernetes/views/remove-role-dialog.html:7 pkg/storaged/index.html:289
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:79
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: pkg/shell/indexes.js:322
+msgid "Cannot connect to an unknown machine"
+msgstr "Неможливо встановити з’єднання із невідомим комп’ютером"
+
+#: src/ws/cockpitcertificate.c:359
+msgid "Cannot decrypt PEM-encoded private key"
+msgstr "Не вдалося розшифрувати зашифрований PEM закритий ключ"
+
+#: src/base1/cockpit.js:3707
+msgid "Cannot forward login credentials"
+msgstr "Не вдалося переспрямувати реєстраційні дані для входу"
+
+#: pkg/realmd/operation.js:417
+msgid "Cannot join a domain because realmd is not available on this system"
+msgstr ""
+"Не вдалося долучитися до домену, оскільки у цій системі недоступна служба "
+"realmd"
+
+#: pkg/kubernetes/views/pv-modify.html:44
+#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pv-body.html:13
+msgid "Capacity"
+msgstr "Місткість"
+
+#: pkg/storaged/index.html:443 pkg/storaged/index.html:519
+#: pkg/storaged/index.html:551 pkg/storaged/index.html:630
+msgctxt "storage"
+msgid "Capacity"
+msgstr "Місткість"
+
+#: pkg/networkmanager/interfaces.js:2276
+msgid "Carrier"
+msgstr "Носій сигналу"
+
+#: pkg/kubernetes/scripts/volumes.js:203
+msgid "Ceph Filesystem Mount"
+msgstr "Змонтована файлова система Ceph"
+
+#: pkg/kubernetes/views/volume-body.html:97
+msgid "Ceph Monitors"
+msgstr "Монітори Ceph"
+
+#: pkg/kubernetes/views/pv-modify.html:204
+#: pkg/kubernetes/views/project-modify.html:74
+#: pkg/kubernetes/views/replicationcontroller-modify.html:17
+#: pkg/kubernetes/views/route-modify.html:17
+msgid "Change"
+msgstr "Змінити"
+
+#: pkg/shell/index.html:278
+msgid "Change Password"
+msgstr "Змінити пароль"
+
+#: pkg/tuned/dialog.js:191
+msgid "Change Performance Profile"
+msgstr "Зміна профілю швидкодії"
+
+#: pkg/tuned/dialog.js:200
+msgid "Change Profile"
+msgstr "Змінити профіль"
+
+#: pkg/kubernetes/views/user-modify.html:3
+msgid "Change User"
+msgstr "Змінити користувача"
+
+#: pkg/storaged/overview.js:699
+msgid "Change iSCSI Initiator Name"
+msgstr "Змінити назву ініціатора iSCSI"
+
+#: pkg/kubernetes/views/imagestream-modify.html:4
+msgid "Change image stream"
+msgstr "Змінити потік образу"
+
+#: pkg/kubernetes/views/project-modify.html:10
+msgid "Change project"
+msgstr "Змінити проект"
+
+#: pkg/networkmanager/interfaces.js:2872
+#, fuzzy
+msgid "Change the settings"
+msgstr "Параметри з’єднання"
+
+#: pkg/networkmanager/interfaces.js:2870
+msgid "Changing the settings will break the connection to the server, "
+msgstr ""
+
+#: pkg/ostree/index.html:48
+msgid "Check for updates"
+msgstr "Перевірити оновлення"
+
+#: pkg/networkmanager/interfaces.js:817
+msgid "Checking IP"
+msgstr "Перевіряємо IP"
+
+#: pkg/storaged/jobs.js:143
+#, fuzzy
+msgid "Checking RAID Device $target"
+msgstr "Створюємо пристрій RAID $target"
+
+#: pkg/storaged/jobs.js:144
+#, fuzzy
+msgid "Checking and Repairing RAID Device $target"
+msgstr "Створюємо пристрій RAID $target"
+
+#: pkg/lib/machine-change-auth.html:70
+msgid "Checking for public keys"
+msgstr "Шукаємо відкриті ключі"
+
+#: pkg/ostree/app.js:219
+msgid "Checking for updates"
+msgstr "Шукаємо оновлення"
+
+#: pkg/shell/simple.html:100 pkg/shell/index.html:121 pkg/shell/stub.html:114
+msgid "Choose the language to be used in the application"
+msgstr "Виберіть мову перекладу, яку буде використано для інтерфейсу програми"
+
+#: pkg/storaged/overview.js:431
+msgid "Chunk Size"
+msgstr "Розмір фрагмента"
+
+#: pkg/kubernetes/scripts/volumes.js:202
+msgid "Cinder"
+msgstr "Cinder"
+
+#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
+msgid "Claim"
+msgstr "Заявити"
+
+#: pkg/kubernetes/views/pvc-body.html:4
+msgid "Claim Name"
+msgstr "Назва заявки"
+
+#: pkg/storaged/jobs.js:135
+msgid "Cleaning up for $target"
+msgstr "Спорожнюємо для $target"
+
+#: pkg/kubernetes/views/auth-form.html:88
+msgid "Client Certificate"
+msgstr "Сертифікат клієнта"
+
+#: pkg/systemd/services.html:306 pkg/systemd/services.html:324
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-invalid-hostkey.html:19
+msgid "Close"
+msgstr "Закрити"
+
+#: pkg/kubernetes/views/auth-form.html:5
+msgid "Cluster"
+msgstr "Кластер"
+
+#: cockpit.desktop.in.h:1
+msgid "Cockpit"
+msgstr "Cockpit"
+
+#: pkg/lib/machine-dialogs.js:429
+msgid ""
+"Cockpit could not contact the given host $0. Make sure it has ssh running on "
+"port $1, or specify another port in the address."
+msgstr ""
+"Cockpit не вдалося встановити зв’язок із вказаним вузлом $0. Переконайтеся, "
+"що ssh запущено на порту $1 або вкажіть інший порт у адресі."
+
+#: src/base1/cockpit.js:3713
+msgid "Cockpit could not contact the given host."
+msgstr "Cockpit не вдалося встановити зв’язок із вказаним вузлом."
+
+#: pkg/shell/base_index.js:671
+msgid "Cockpit had an unexpected internal error. <br/><br/>"
+msgstr "У Cockpit сталася неочікувана внутрішня помилка. <br/><br/>"
+
+#: cockpit.appdata.xml.in.h:1
+msgid ""
+"Cockpit is a server manager that makes it easy to administer your Linux "
+"servers via a web browser. Jumping between the terminal and the web tool is "
+"no problem. A service started via Cockpit can be stopped via the terminal. "
+"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
+"journal interface."
+msgstr ""
+"Cockpit — програма для керування сервером, яка полегшує адміністрування "
+"ваших серверів під керуванням Linux за допомогою програми для перегляду "
+"сторінок інтернету. Ви зможете одночасно використовувати термінал і "
+"вебінструмент. Службу, яку було запущено за допомогою Cockpit, можна "
+"зупинити за допомогою термінала. І навпаки, якщо трапиться помилка у "
+"терміналі, ви побачите її у інтерфейсі журналу Cockpit."
+
+#: src/base1/cockpit.js:3711
+msgid "Cockpit is not compatible with the software on the system."
+msgstr "Cockpit є несумісним із програмним забезпеченням цієї системи."
+
+#: pkg/lib/machine-not-supported.html:2
+msgid "Cockpit is not installed"
+msgstr "Cockpit не встановлено"
+
+#: src/base1/cockpit.js:3705
+msgid "Cockpit is not installed on the system."
+msgstr "Cockpit у цій системі не встановлено."
+
+#: cockpit.appdata.xml.in.h:2
+msgid ""
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
+"tasks such as storage administration, inspecting journals and starting and "
+"stopping services. You can monitor and administer several servers at the "
+"same time. Just add them with a single click and your machines will look "
+"after its buddies."
+msgstr ""
+"Cockpit — чудовий інструмент для системних адміністраторів-початківців. За "
+"його допомогою вони без проблем впораються із простими завданнями, зокрема "
+"адмініструванням сховищ даних, інспектуванням журналів та запуском і "
+"зупиненням служб. Ви зможете одночасно стежити за роботою декількох серверів "
+"і адмініструвати ці сервери. Просто додайте їх одним клацанням кнопкою миші "
+"і ваш комп’ютер сам нагляне за своїми приятелями."
+
+#: pkg/lib/machine-change-port.html:9
+msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
+msgstr ""
+"Cockpit не вдалося встановити зв’язок ізt {{#strong}}{{host}}{{/strong}}."
+
+#: pkg/lib/machine-auth-failed.html:15
+msgid ""
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
+msgstr ""
+"Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"Вам варто спробувати {{#sync_link}}синхронізувати користувачів{{/sync_link}}."
+"{{/can_sync}} Щоб отримати доступ до ширшого спектра способів розпізнавання "
+"та до підтримки діагностики помилок, будь ласка, оновіть cockpit-ws."
+
+#: pkg/lib/machine-change-auth.html:9
+msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
+msgstr "Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}."
+
+#: pkg/lib/machine-auth-failed.html:6
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
+"machine with cockpit you will need to enable one of the following "
+"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
+msgstr ""
+"Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. Щоб "
+"користуватися цим комп’ютером за допомогою cockpit, вам слід увімкнути "
+"вказані нижче способи розпізнавання у налаштуваннях sshd на {{#strong}}"
+"{{host}}{{/strong}}:"
+
+#: pkg/lib/machine-change-auth.html:13
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
+"change your authentication credentials below. {{#can_sync}}You may prefer to "
+"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+msgstr ""
+"Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. Ви можете "
+"змінити ваші реєстраційні дані для розпізнавання нижче. {{#can_sync}}"
+"Можливо, варто надати перевагу {{#sync_link}}синхронізації облікових записів "
+"і паролів{{/sync_link}}.{{/can_sync}}"
+
+#: pkg/dashboard/index.html:171 pkg/lib/machine-add.html:27
+msgid "Color"
+msgstr "Колір"
+
+#: pkg/docker/index.html:95
+msgid "Combined CPU usage"
+msgstr "Поєднане використання процесора"
+
+#: pkg/docker/index.html:101
+msgid "Combined memory usage"
+msgstr "Поєднане використання пам’яті"
+
+#: pkg/systemd/services.html:370 pkg/docker/index.html:466
+#: pkg/docker/index.html:736
+msgid "Command"
+msgstr "Команда"
+
+#: pkg/docker/run.js:332
+#, fuzzy
+msgid "Command can't be empty"
+msgstr "Назва не повинна бути порожньою."
+
+#: pkg/docker/containers-view.jsx:239
+#, fuzzy
+msgid "Commit"
+msgstr "Коментар"
+
+#: pkg/tuned/dialog.js:114
+msgid "Communication with tuned has failed"
+msgstr "Не вдалося обмінятися даними з tuned"
+
+#: pkg/storaged/details.js:348
+msgid "Compatible with all systems and devices (MBR)"
+msgstr "Сумісний із усіма системами та пристроями (MBR)"
+
+#: pkg/storaged/details.js:349
+msgid "Compatible with modern system and hard disks > 2TB (GPT)"
+msgstr "Сумісний зі сучасними системами та жорсткими дисками > 2 ТБ (GPT)"
+
+#: pkg/realmd/operation.html:28
+msgid "Computer OU"
+msgstr "OU комп’ютера"
+
+#: pkg/kubernetes/views/node-add.html:24
+msgid "Configuration"
+msgstr "Налаштування"
+
+#: pkg/networkmanager/interfaces.js:2441
+msgid "Configure"
+msgstr "Налаштувати"
+
+#: pkg/kubernetes/views/node-add.html:42
+msgid "Configure Flannel networking"
+msgstr "Налаштувати роботу у мережі Flannel"
+
+#: pkg/kubernetes/views/node-add.html:32
+msgid "Configure Kubelet and Proxy"
+msgstr "Налаштувати Kubelet і проксі"
+
+#: pkg/networkmanager/interfaces.js:811
+msgid "Configuring"
+msgstr "Налаштовування"
+
+#: pkg/networkmanager/interfaces.js:815
+msgid "Configuring IP"
+msgstr "Налаштовуємо IP"
+
+#: pkg/users/index.html:171 pkg/shell/index.html:262
+msgid "Confirm"
+msgstr "Підтвердити"
+
+#: pkg/users/index.html:247
+msgid "Confirm New Password"
+msgstr "Підтвердження нового пароля"
+
+#: pkg/storaged/details.js:229
+msgid "Confirm passphrase"
+msgstr "Підтвердить пароль"
+
+#: pkg/kubernetes/views/auth-form.html:130
+#: pkg/kubernetes/views/auth-rejected-cert.html:33
+#: pkg/lib/machine-unknown-hostkey.html:22
+msgid "Connect"
+msgstr "З'єднатися"
+
+#: pkg/networkmanager/interfaces.js:2637
+msgid "Connect automatically"
+msgstr "З’єднуватися автоматично"
+
+#: pkg/ostree/index.html:218
+msgid "Connecting"
+msgstr "Встановлюємо з’єднання"
+
+#: pkg/lib/machine-add.html:39
+msgid ""
+"Connecting simultaneously to more than {{ limit }} machines is unsupported."
+msgstr ""
+"Підтримки одночасного з’єднання із понад {{ limit }} комп’ютерами не "
+"передбачено."
+
+#: pkg/docker/index.html:54
+msgid "Connecting to Docker"
+msgstr "Встановлюємо з’єднання із Docker"
+
+#: pkg/shell/indexes.js:317
+msgid "Connecting to the machine"
+msgstr "Встановлюємо з’єднання із комп’ютером"
+
+#: pkg/kubernetes/registry.html:70 pkg/kubernetes/index.html:100
+msgid "Connecting..."
+msgstr "Встановлення з’єднання…"
+
+#: pkg/kubernetes/views/auth-dialog.html:4
+msgid "Connection Error"
+msgstr "Помилка з'єднання"
+
+#: pkg/kubernetes/scripts/connection.js:516
+msgid "Connection Error: $0"
+msgstr "Помилка з’єднання: $0"
+
+#: pkg/kubernetes/views/auth-dialog.html:3
+msgid "Connection Settings"
+msgstr "Параметри з’єднання"
+
+#: src/base1/cockpit.js:3703
+msgid "Connection has timed out."
+msgstr "Вичерпано час очікування на з’єднання."
+
+#: pkg/networkmanager/index.html:812
+#, fuzzy
+msgid "Connection will be lost"
+msgstr "Вичерпано час очікування на з’єднання."
+
+#: pkg/docker/console.html:4 pkg/kubernetes/views/container-panel.html:4
+#: pkg/kubernetes/views/image-panel.html:12
+#: pkg/kubernetes/views/container-body.html:4
+#: pkg/kubernetes/views/container-page-inline.html:2
+#: pkg/kubernetes/views/image-page.html:19
+msgid "Container"
+msgstr "Контейнер"
+
+#: pkg/users/local.js:684
+msgid "Container Administrator"
+msgstr "Адміністратор контейнера"
+
+#: pkg/kubernetes/views/container-body.html:10
+msgid "Container ID"
+msgstr "Ід. контейнера"
+
+#: pkg/docker/index.html:459 pkg/docker/index.html:646
+#: pkg/docker/index.html:712
+msgid "Container Name"
+msgstr "Назва контейнера"
+
+#: pkg/kubernetes/views/node-body.html:21
+msgid "Container Runtime Version"
+msgstr "Версія середовища контейнера"
+
+#: pkg/docker/util.js:490
+msgid ""
+"Container is currently marked as not running, but regular stopping failed."
+msgstr ""
+"Зараз контейнер позначено як такий, що працює, але звичайна спроба зупинити "
+"роботу зазнала невдачі."
+
+#: pkg/docker/util.js:488
+msgid "Container is currently running."
+msgstr "Контейнер працює."
+
+#: pkg/docker/index.html:23 pkg/docker/index.html:309
+#: pkg/kubernetes/views/pod-page.html:36
+#: pkg/kubernetes/views/dashboard-page.html:158
+#: pkg/kubernetes/views/dashboard-page.html:199
+#: pkg/kubernetes/views/containers-listing.html:5 pkg/kubernetes/index.html:51
+msgid "Containers"
+msgstr "Контейнери"
+
+#: pkg/docker/details.js:47 pkg/docker/image.js:43
+msgctxt "page-title"
+msgid "Containers"
+msgstr "Контейнери"
+
+#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
+msgid "Content"
+msgstr "Вміст"
+
+#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
+#: pkg/playground/translate.js:19
+#, fuzzy
+msgid "Control"
+msgstr "Контейнер"
+
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
+#: pkg/playground/translate.js:22
+#, fuzzy
+msgctxt "key"
+msgid "Control"
+msgstr "Контейнер"
+
+#: pkg/docker/storage.jsx:404
+#, fuzzy
+msgid "Could not add all disks"
+msgstr "Не вдалося побудувати список служб"
+
+#: pkg/lib/machine-change-port.html:4
+msgid "Could not contact {{host}}"
+msgstr "Не вдалося встановити зв’язок із {{host}}"
+
+#: pkg/kubernetes/views/dashboard-page.html:142
+msgid "Could not list services"
+msgstr "Не вдалося побудувати список служб"
+
+#: src/ws/cockpitcertificate.c:407
+msgid "Could not parse PEM-encoded certificate"
+msgstr "Не вдалося обробити зашифрований PEM сертифікат"
+
+#: src/ws/cockpitcertificate.c:374
+msgid "Could not parse PEM-encoded private key"
+msgstr "Не вдалося обробити зашифрований PEM закритий ключ"
+
+#: pkg/docker/storage.jsx:446
+msgid "Could not reset the storage pool"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:467
+msgid "Couldn't change user groups"
+msgstr "Не вдалося змінити групи користувачів"
+
+#: src/bridge/cockpitdbussetup.c:520
+msgid "Couldn't change user password"
+msgstr "Не вдалося змінити пароль користувача"
+
+#: pkg/selinux/setroubleshoot-view.jsx:385
+msgid ""
+"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
+"server is installed."
+msgstr ""
+
+#: pkg/kubernetes/registry.html:71 pkg/kubernetes/index.html:101
+msgid "Couldn't connect to server"
+msgstr "Не вдалося встановити з’єднання із сервером"
+
+#: pkg/shell/indexes.js:320
+msgid "Couldn't connect to the machine"
+msgstr "Не вдалося встановити з’єднання із комп’ютером"
+
+#: src/bridge/cockpitdbussetup.c:544
+msgid "Couldn't create new users"
+msgstr "Не вдалося створити записи користувачів"
+
+#: pkg/kubernetes/scripts/connection.js:514
+msgid "Couldn't find running API server"
+msgstr "Не вдалося знайти запущений сервер API"
+
+#: pkg/subscriptions/subscriptions-view.jsx:196
+#, fuzzy
+msgid ""
+"Couldn't get system subscription status. Please ensure subscription-manager "
+"is installed."
+msgstr ""
+"\n"
+"        Для керування передплатами цієї системи, будь ласка, перевірте, чи "
+"встановлено subscription-manager.\n"
+"      "
+
+#: src/bridge/cockpitdbussetup.c:642
+msgid "Couldn't list local users"
+msgstr "Не вдалося побудувати список локальних користувачів"
+
+#: src/bridge/cockpitdbussetup.c:236
+msgid "Couldn't list users"
+msgstr "Не вдалося побудувати список користувачів"
+
+#: src/bridge/cockpitdbussetup.c:382
+msgid "Couldn't load user data"
+msgstr "Не вдалося завантажити дані користувача"
+
+#: pkg/kubernetes/views/project-modify.html:72
+#: pkg/kubernetes/views/add-group-dialog.html:21
+msgid "Create"
+msgstr "Створити"
+
+#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
+msgid "Create Logical Volume"
+msgstr "Створити логічний том"
+
+#: pkg/users/index.html:54 pkg/users/index.html:143
+msgid "Create New Account"
+msgstr "Створити новий рахунок"
+
+#: pkg/storaged/details.js:1379
+msgid "Create Partition"
+msgstr "Створити розділ"
+
+#: pkg/storaged/overview.js:414
+msgid "Create RAID Device"
+msgstr "Створити пристрій RAID"
+
+#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
+msgid "Create Snapshot"
+msgstr "Створення знімка"
+
+#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
+msgid "Create Thin Volume"
+msgstr "Створити тонкий том"
+
+#: pkg/systemd/services.html:336
+#, fuzzy
+msgid "Create Timers"
+msgstr "Створити тонкий том"
+
+#: pkg/storaged/overview.js:487
+msgid "Create Volume Group"
+msgstr "Створити групу томів"
+
+#: pkg/sosreport/index.html:50
+msgid "Create diagnostic report"
+msgstr "Створити діагностичний звіт"
+
+#: pkg/kubernetes/views/imagestream-modify.html:3
+msgid "Create image stream"
+msgstr "Створити потік образу"
+
+#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
+#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
+#, fuzzy
+msgid "Create it"
+msgstr "Створити"
+
+#: pkg/storaged/details.js:266
+msgid "Create partition"
+msgstr "Створити розділ"
+
+#: pkg/storaged/details.js:113
+msgid "Create partition on $0"
+msgstr "Створити розділ на $0"
+
+#: pkg/storaged/index.html:381
+msgid "Create partition table"
+msgstr "Створити таблицю розділів"
+
+#: pkg/sosreport/index.html:42
+msgid "Create report"
+msgstr "Створити звіт"
+
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/replicationcontroller-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7 pkg/kubernetes/views/route-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3
+msgid "Created"
+msgstr "Створено"
+
+#: pkg/storaged/jobs.js:142
+msgid "Creating RAID Device $target"
+msgstr "Створюємо пристрій RAID $target"
+
+#: pkg/storaged/jobs.js:130
+msgid "Creating filesystem on $target"
+msgstr "Створюємо файлову систему на $target"
+
+#: pkg/storaged/jobs.js:156
+msgid "Creating logical volume $target"
+msgstr "Створюємо логічний том $target"
+
+#: pkg/storaged/jobs.js:134
+msgid "Creating partition $target"
+msgstr "Створюємо розділ $target"
+
+#: pkg/storaged/jobs.js:150
+msgid "Creating snapshot of $target"
+msgstr "Створюємо знімок $target"
+
+#: pkg/networkmanager/interfaces.js:4064
+msgid "Creating this VLAN will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3436
+msgid "Creating this bond will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3842
+msgid "Creating this bridge will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3611
+msgid "Creating this team will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:151
+msgid "Creating volume group $target"
+msgstr "Створюємо групу томів $target"
+
+#: pkg/systemd/logs.html:41
+msgid "Current boot"
+msgstr "Поточне завантаження"
+
+#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
+msgid "Custom"
+msgstr "Нетиповий"
+
+#: pkg/storaged/details.js:186
+msgid "Custom (Enter filesystem type)"
+msgstr "Нетипова (Вкажіть тип файлової системи)"
+
+#: pkg/subscriptions/subscriptions-register.jsx:102
+#, fuzzy
+msgid "Custom URL"
+msgstr "Нетиповий"
+
+#: pkg/storaged/index.html:454
+msgid "DISK IS FAILING"
+msgstr "ДИСК НЕПРАЦЕЗДАТНИЙ"
+
+#: pkg/networkmanager/interfaces.js:3018
+msgid "DNS"
+msgstr "DNS"
+
+#: pkg/kubernetes/views/pod-body.html:14
+msgid "DNS Policy"
+msgstr "Правило DNS"
+
+#: pkg/networkmanager/interfaces.js:3022
+msgid "DNS Search Domains"
+msgstr "Домени пошуку DNS"
+
+#: pkg/dashboard/index.html:22
+msgid "Dashboard"
+msgstr ""
+
+#: pkg/storaged/details.js:1130
+msgid "Deactivate"
+msgstr "Вимкнути"
+
+#: pkg/networkmanager/interfaces.js:823
+msgid "Deactivating"
+msgstr "Деактивація"
+
+#: pkg/storaged/jobs.js:149
+msgid "Deactivating $target"
+msgstr "Деактивуємо $target"
+
+#: pkg/docker/index.html:379 pkg/docker/index.html:383
+#: pkg/kubernetes/views/image-config.html:6
+msgid "Default"
+msgstr "Типовий"
+
+#: pkg/systemd/index.html:454
+msgid "Delay"
+msgstr "Затримка"
+
+#: pkg/users/index.html:79 pkg/kubernetes/views/item-delete.html:11
+#: pkg/kubernetes/views/pvc-delete.html:15
+#: pkg/kubernetes/views/node-delete.html:15
+#: pkg/kubernetes/views/imagestream-delete.html:8
+#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/kubernetes/views/image-delete.html:8
+#: pkg/kubernetes/views/pv-delete.html:11
+msgid "Delete"
+msgstr "Вилучити"
+
+#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
+msgid "Delete $0"
+msgstr "Вилучити $0"
+
+#: pkg/users/index.html:292
+msgid "Delete Files"
+msgstr "Вилучити файли"
+
+#: pkg/kubernetes/views/node-delete.html:4
+msgid "Delete Node"
+msgstr "Вилучити вузол"
+
+#: pkg/kubernetes/views/pv-delete.html:3
+msgid "Delete Persistent Volume"
+msgstr "Вилучити сталий том"
+
+#: pkg/kubernetes/views/pvc-delete.html:3
+msgid "Delete Persistent Volume Claim"
+msgstr "Вилучити заявку на сталий том"
+
+#: pkg/kubernetes/views/project-delete.html:3
+msgid "Delete Project"
+msgstr "Вилучення проекту"
+
+#: pkg/kubernetes/views/nodes-page.html:3
+msgid "Delete Selected"
+msgstr "Вилучити позначене"
+
+#: pkg/kubernetes/views/imagestream-delete.html:3
+msgid "Delete image stream"
+msgstr "Вилучити потік образу"
+
+#: pkg/playground/translate.html:184 pkg/kubernetes/views/item-delete.html:3
+msgid "Delete {{ item.kind }}"
+msgstr "Вилучити {{ item.kind }}"
+
+#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
+msgid "Deleting $target"
+msgstr "Вилучаємо $target"
+
+#: pkg/networkmanager/interfaces.js:2156
+msgid "Deleting <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/kubernetes/views/item-delete.html:7
+msgid ""
+"Deleting a Pod will kill all associated containers. Pods may be "
+"automatically created again in some cases."
+msgstr ""
+"Вилучення кокона призведе до завершення роботи усіх пов’язаних із ним "
+"контейнерів. У певних випадках кокон може бути повторно створено "
+"автоматично.\n"
+"          "
+
+#: pkg/storaged/details.js:631
+msgid "Deleting a RAID device will erase all data on it."
+msgstr "Вилучення пристрою RAID призведе до витирання з нього усіх даних."
+
+#: pkg/docker/containers-view.jsx:167 pkg/docker/details.js:272
+msgid "Deleting a container will erase all data in it."
+msgstr ""
+"Вилучення контейнера призведе до витирання усіх даних, що на ньому "
+"зберігаються."
+
+#: pkg/storaged/details.js:1009
+msgid "Deleting a logical volume will delete all data in it."
+msgstr ""
+"Вилучення логічного тому призведе до витирання усіх даних, що на ньому "
+"зберігаються."
+
+#: pkg/storaged/details.js:1012
+msgid "Deleting a partition will delete all data in it."
+msgstr ""
+"Вилучення розділу призведе до вилучення усіх даних, що на ньому зберігаються."
+
+#: pkg/storaged/details.js:826
+msgid "Deleting a volume group will erase all data on it."
+msgstr ""
+"Вилучення групи томів призведе до витирання усіх даних, що у ній "
+"зберігаються."
+
+#: pkg/docker/image.js:152
+msgid ""
+"Deleting an image will delete it, but you can probably download it again if "
+"you need it later.  Unless this image has never been pushed to a repository, "
+"that is, in which case you probably can't download it again."
+msgstr ""
+"Вилучення образу призведе до його вилучення, але ви, ймовірно, зможете "
+"отримати його знову, якщо виникне потреба. Виключенням є випадок, коли образ "
+"ніколи не було записано до сховища. У цьому випадку ви, ймовірно, не зможете "
+"отримати образ знову."
+
+#: pkg/storaged/jobs.js:152
+msgid "Deleting volume group $target"
+msgstr "Вилучаємо групу томів $target"
+
+#: pkg/kubernetes/views/dashboard-page.html:131
+#: pkg/kubernetes/views/deploy.html:62
+msgid "Deploy"
+msgstr "Розгорнути"
+
+#: pkg/kubernetes/views/deploy.html:3
+msgid "Deploy Application"
+msgstr "Розгорнути програму"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:22
+msgid "Deployment Causes"
+msgstr "Причини розгортання"
+
+#: pkg/kubernetes/views/deploymentconfig-panel.html:8
+#: pkg/kubernetes/views/deploymentconfig-page.html:12
+msgid "Deployment Config"
+msgstr "Налаштування розгортання"
+
+#: pkg/kubernetes/views/details-page.html:98
+msgid "Deployment Configs"
+msgstr "Налаштування розгортання"
+
+#: pkg/systemd/services.html:356 pkg/kubernetes/views/project-modify.html:40
+#: pkg/kubernetes/views/image-body.html:6
+#: pkg/kubernetes/views/project-listing.html:15
+#: pkg/kubernetes/views/project-listing.html:54
+msgid "Description"
+msgstr "Опис"
+
+#: pkg/shell/index.html:197 pkg/kubernetes/index.html:63
+msgid "Details"
+msgstr "Подробиці"
+
+#: pkg/storaged/index.html:543
+msgctxt "storage"
+msgid "Device"
+msgstr "Пристрій"
+
+#: pkg/storaged/details.js:91
+msgid "Device $0 is a member of RAID Array $1"
+msgstr "Пристрій $0 є елементом масиву RAID $1"
+
+#: pkg/storaged/details.js:97
+msgid "Device $0 is a physical volume of $1"
+msgstr "Пристрій $0 є фізичним томом $1"
+
+#: pkg/storaged/details.js:85
+msgid "Device $0 is mounted on $1"
+msgstr "Пристрій $0 змонтовано до $1"
+
+#: pkg/storaged/index.html:467 pkg/storaged/index.html:473
+#: pkg/storaged/index.html:515
+msgctxt "storage"
+msgid "Device File"
+msgstr "Файл пристрою"
+
+#: pkg/sosreport/index.html:22
+msgid "Diagnostic reports"
+msgstr "Діагностичні звіти"
+
+#: pkg/kubernetes/views/image-body.html:20
+msgid "Digest"
+msgstr "Контрольна сума"
+
+#: pkg/kubernetes/views/image-config.html:7
+#: pkg/kubernetes/views/volume-body.html:28
+msgid "Directory"
+msgstr "Каталог"
+
+#: pkg/systemd/init.js:543
+msgid "Disable"
+msgstr "Вимкнути"
+
+#: pkg/tuned/dialog.js:234
+msgid "Disable tuned"
+msgstr "Вимкнути tuned"
+
+#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
+msgid "Disabled"
+msgstr "Вимкнено"
+
+#: pkg/shell/simple.html:120
+msgid "Disconnected"
+msgstr "Роз'єднано"
+
+#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+msgid "Disk"
+msgstr "Диск"
+
+#: pkg/dashboard/index.html:73
+#, fuzzy
+msgid "Disk I/O"
+msgstr "З диском усе гаразд"
+
+#: pkg/kubernetes/scripts/nodes.js:720
+msgid "Disk Utilization: $0%"
+msgstr "Використання диска: $0%"
+
+#: pkg/storaged/index.html:457
+msgid "Disk is OK"
+msgstr "З диском усе гаразд"
+
+#: pkg/storaged/index.html:584
+msgid "Disks"
+msgstr "Диски"
+
+#: pkg/shell/simple.html:37 pkg/shell/simple.html:97 pkg/shell/index.html:37
+#: pkg/shell/index.html:118 pkg/shell/stub.html:37 pkg/shell/stub.html:111
+msgid "Display Language"
+msgstr "Мова перекладу"
+
+#: pkg/kubernetes/views/project-modify.html:31
+msgid "Display name"
+msgstr "Показана назва"
+
+#: pkg/kubernetes/views/add-role-dialog.html:5
+msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+msgstr "Хочете додати роль «{{ fields.displayRole }}»?"
+
+#: pkg/kubernetes/views/imagestream-delete.html:5
+msgid ""
+"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}' image stream?"
+msgstr ""
+"Хочете вилучити потік образу «{{stream.metadata.namespace}}/{{stream."
+"metadata.name}}»?"
+
+#: pkg/kubernetes/views/pv-delete.html:6
+msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+msgstr "Ви хочете вилучити сталий том «{{item.metadata.name}}»?"
+
+#: pkg/kubernetes/views/pvc-delete.html:6
+msgid ""
+"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
+msgstr "Ви хочете вилучити заявку на сталий том «{{item.metadata.name}}»?"
+
+#: pkg/kubernetes/views/item-delete.html:6
+msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+msgstr "Хочете вилучити {{ item.kind }} «{{item.metadata.name}}»?"
+
+#: pkg/kubernetes/views/node-delete.html:7
+msgid "Do you want to delete this Node?"
+msgstr "Хочете вилучити цей вузол?"
+
+#: pkg/kubernetes/views/image-delete.html:5
+msgid ""
+"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+"{{stream.metadata.name}}:{{tag.tag}}'?"
+msgstr ""
+"Хочете вилучити образ із мітками «{{stream.metadata.namespace}}/{{stream."
+"metadata.name}}:{{tag.tag}}»?"
+
+#: pkg/kubernetes/views/remove-role-dialog.html:5
+msgid ""
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
+msgstr ""
+"Хочете вилучити роль «{{ fields.displayRole }}» із запису учасника {{ fields."
+"member.metadata.name }}?"
+
+#: pkg/kubernetes/views/image-meta.html:11
+msgid "Docker Version"
+msgstr "Версія Docker"
+
+#: pkg/docker/index.html:60
+msgid "Docker is not installed or activated on the system"
+msgstr "Docker не встановлено або не активовано у цій системі"
+
+#: pkg/systemd/index.html:107
+msgid "Domain"
+msgstr "Домен"
+
+#: pkg/realmd/operation.js:148
+msgid "Domain $0 could not be contacted"
+msgstr "Не вдалося встановити зв’язок із доменом $0"
+
+#: pkg/realmd/operation.js:220
+msgid "Domain $0 is not supported"
+msgstr "Підтримки домену $0 не передбачено"
+
+#: pkg/realmd/operation.html:11
+msgid "Domain Address"
+msgstr "Адреса домену"
+
+#: pkg/realmd/operation.html:59
+msgid "Domain Administrator Name"
+msgstr "Ім’я адміністратора домену"
+
+#: pkg/realmd/operation.html:65
+msgid "Domain Administrator Password"
+msgstr "Пароль адміністратора домену"
+
+#: pkg/systemd/services.html:426 pkg/systemd/services.html:430
+msgid "Don't Repeat"
+msgstr ""
+
+#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
+msgid "Don't overwrite existing data"
+msgstr "Не перезаписувати наявні дані"
+
+#: pkg/sosreport/index.html:74
+msgid "Done!"
+msgstr "Готово!"
+
+#: pkg/ostree/index.html:127 pkg/ostree/index.html:158
+msgid "Downgrades"
+msgstr "Зниження"
+
+#: pkg/storaged/index.html:411
+msgid "Drive"
+msgstr "Диск"
 
 #: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
 msgctxt "storage"
 msgid "Drive"
 msgstr "Диск"
 
-#: pkg/storaged/overview.js:253
-msgid "$0 Block Device"
-msgstr "$0, блоковий пристрій"
+#: pkg/kubernetes/views/volume-body.html:128
+msgid "Driver"
+msgstr "Драйвер"
 
-#: pkg/storaged/overview.js:414
-msgid "Create RAID Device"
-msgstr "Створити пристрій RAID"
+#: pkg/storaged/index.html:166
+msgid "Drives"
+msgstr "Диски"
 
-#: pkg/storaged/overview.js:420
-msgid "RAID Level"
-msgstr "Рівень RAID"
+#: pkg/docker/run.js:360
+msgid "Duplicate alias"
+msgstr "Дублювання псевдоніма"
 
-#: pkg/storaged/overview.js:422
-msgid "RAID 0 (Stripe)"
-msgstr "RAID 0 (Стрічка)"
+#: pkg/docker/run.js:293
+msgid "Duplicate port"
+msgstr "Дублювання порту"
 
-#: pkg/storaged/overview.js:423
-msgid "RAID 1 (Mirror)"
-msgstr "RAID 1 (Дзеркало)"
+#: pkg/storaged/jobs.js:120
+msgid "Ejecting $target"
+msgstr "Видобуваємо $target"
 
-#: pkg/storaged/overview.js:424
-msgid "RAID 4 (Dedicated Parity)"
-msgstr "RAID 4 (Пов’язана парність)"
+#: pkg/playground/translate.html:58
+msgid "Empty"
+msgstr "Порожній"
 
-#: pkg/storaged/overview.js:425
-msgid "RAID 5 (Distributed Parity)"
-msgstr "RAID 5 (Розподілена парність)"
-
-#: pkg/storaged/overview.js:426
-msgid "RAID 6 (Double Distributed Parity)"
-msgstr "RAID 6 (Подвійна розподілена парність)"
-
-#: pkg/storaged/overview.js:427
-msgid "RAID 10 (Stripe of Mirrors)"
-msgstr "RAID 10 (Стрічка дзеркал)"
-
-#: pkg/storaged/overview.js:431
-msgid "Chunk Size"
-msgstr "Розмір фрагмента"
-
-#: pkg/storaged/overview.js:433
-msgid "4 KiB"
-msgstr "4 КіБ"
-
-#: pkg/storaged/overview.js:434
-msgid "8 KiB"
-msgstr "8 КіБ"
-
-#: pkg/storaged/overview.js:435
-msgid "16 KiB"
-msgstr "16 КіБ"
-
-#: pkg/storaged/overview.js:436
-msgid "32 KiB"
-msgstr "32 КіБ"
-
-#: pkg/storaged/overview.js:437
-msgid "64 KiB"
-msgstr "64 КіБ"
-
-#: pkg/storaged/overview.js:438
-msgid "128 KiB"
-msgstr "128 КіБ"
-
-#: pkg/storaged/overview.js:439
-msgid "512 KiB"
-msgstr "512 КіБ"
-
-#: pkg/storaged/overview.js:440
-msgid "1 MiB"
-msgstr "1 МіБ"
-
-#: pkg/storaged/overview.js:441
-msgid "2 MiB"
-msgstr "2 МіБ"
-
-#: pkg/storaged/overview.js:455
-msgid "At least $0 disks are needed."
-msgstr "Потрібно принаймні $0 дисків."
-
-#: pkg/storaged/overview.js:487
-msgid "Create Volume Group"
-msgstr "Створити групу томів"
-
-#: pkg/storaged/overview.js:515
-msgid "Add iSCSI Portal"
-msgstr "Додати портал iSCSI"
-
-#: pkg/storaged/overview.js:518
-msgid "Server Address"
-msgstr "Адреса сервера"
-
-#: pkg/storaged/overview.js:521
+#: pkg/playground/translate.html:63
 #, fuzzy
-msgid "Server address cannot be empty."
-msgstr "Адреса сервера не може бути порожньою."
+msgctxt "verb"
+msgid "Empty"
+msgstr "Порожній"
 
-#: pkg/storaged/overview.js:533 pkg/realmd/operation.html.h:11
-msgid "Next"
-msgstr "Далі"
+#: pkg/kubernetes/scripts/volumes.js:196
+msgid "Empty Directory"
+msgstr "Порожній каталог"
 
-#: pkg/storaged/overview.js:577 pkg/storaged/overview.js:668
-#: pkg/subscriptions/subscriptions-client.js:194
+#: pkg/storaged/jobs.js:155
+msgid "Emptying $target"
+msgstr "Спорожняємо $target"
+
+#: pkg/systemd/init.js:541
+msgid "Enable"
+msgstr "Увімкнути"
+
+#: pkg/systemd/init.js:542
+msgid "Enable Forcefully"
+msgstr "Примусово увімкнути"
+
+#: pkg/systemd/init.js:301
+msgid "Enabled"
+msgstr "Увімкнено"
+
+#: pkg/storaged/details.js:1247
+msgctxt "storage-id-desc"
+msgid "Encrypted"
+msgstr "Шифровано"
+
+#: pkg/storaged/details.js:180
+msgid "Encrypted EXT4 (LUKS)"
+msgstr "Шифрована EXT4 (LUKS)"
+
+#: pkg/storaged/details.js:179
+msgid "Encrypted XFS (LUKS)"
+msgstr "Шифрована XFS (LUKS)"
+
+#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
+#: pkg/storaged/details.js:1115
+msgid "Encryption Options"
+msgstr "Параметри шифрування"
+
+#: pkg/kubernetes/views/pv-modify.html:93
+msgid "Endpoint"
+msgstr "Кінцевий пункт"
+
+#: pkg/kubernetes/views/volume-body.html:40
+msgid "Endpoint Name"
+msgstr "Назва кінцевої точки"
+
+#: pkg/kubernetes/views/service-page.html:14
+#: pkg/kubernetes/views/service-panel.html:9
+msgid "Endpoints"
+msgstr "Кінцеві точки"
+
+#: pkg/subscriptions/subscriptions-view.jsx:38
+msgid "Ends"
+msgstr "Завершується"
+
+#: pkg/selinux/setroubleshoot-view.jsx:332
+msgid "Enforce policy:"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:447
+msgid "Enter IP address or host name"
+msgstr "Введіть IP-адресу або назву вузла"
+
+#: pkg/systemd/logs.html:60
+msgid "Entry"
+msgstr "Запис"
+
+#: pkg/docker/index.html:547 pkg/kubernetes/views/image-config.html:17
+#: pkg/kubernetes/views/container-body.html:26
+msgid "Environment"
+msgstr "Середовище"
+
+#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
+msgid "Erase"
+msgstr "Витерти"
+
+#: pkg/docker/storage.jsx:423
+msgid "Erase containers and reset storage pool"
+msgstr ""
+
+#: pkg/docker/storage.jsx:360
+msgid "Erase containers, reformat disks, and add them"
+msgstr ""
+
+#: pkg/storaged/jobs.js:129
+msgid "Erasing $target"
+msgstr "Витираємо $target"
+
+#: pkg/systemd/services.html:318 pkg/playground/translate.html:101
+#: pkg/playground/translate.html:106
+msgid "Error"
+msgstr "Помилка"
+
+#: pkg/kubernetes/scripts/connection.js:650
+msgid "Error getting certificate details: $0"
+msgstr "Помилка під час спроби отримати параметри сертифіката: $0"
+
+#: pkg/lib/machine-sync-users.html:13
+msgid "Error loading users: {{perm_failed}}"
+msgstr "Помилка під час завантаження списку користувачів: {{perm_failed}}"
+
+#: pkg/docker/util.js:491
+msgid "Error message from Docker:"
+msgstr "Повідомлення щодо помилки від Docker:"
+
+#: pkg/users/authorized-keys.js:115
+msgid "Error saving authorized keys: "
+msgstr "Помилка під час спроби зберегти уповноважені ключі: "
+
+#: pkg/selinux/setroubleshoot.js:275
+msgid "Error while connecting."
+msgstr "Помилка під час спроби з’єднатися."
+
+#: pkg/selinux/setroubleshoot-client.js:192
+msgid "Error while deleting alert"
+msgstr "Помилка під час вилучення нагадування"
+
+#: pkg/selinux/setroubleshoot.js:65
+msgid "Error while setting SELinux mode: '$0'"
+msgstr "Помилка під час спроби встановити режим SELinux: «$0»"
+
+#: pkg/kubernetes/scripts/connection.js:88
+msgid "Error writing kubectl config"
+msgstr "Помилка під час спроби записати налаштування kubectl"
+
+#: pkg/systemd/logs.html:47
+msgid "Errors"
+msgstr "Помилки"
+
+#: pkg/networkmanager/index.html:764
+msgid "Ethernet MTU"
+msgstr "MTU Ethernet"
+
+#: pkg/networkmanager/interfaces.js:1854
+msgid "Ethtool"
+msgstr ""
+
+#: pkg/users/local.js:429 pkg/users/local.js:1104
+msgid "Excellent password"
+msgstr "Чудовий пароль"
+
+#: pkg/docker/util.js:96
+msgid "Exited $ExitCode"
+msgstr "Завершено $ExitCode"
+
+#: pkg/docker/index.html:529
+msgid "Expose container ports"
+msgstr "Відкрити порти контейнера"
+
+#: pkg/storaged/details.js:183
+msgid "Extended Partition"
+msgstr "Розширений розділ"
+
+#: pkg/storaged/details.js:1592
+msgid "FAILED"
+msgstr "ПОМИЛКА"
+
+#: pkg/ostree/index.html:92
+msgid "Failed"
+msgstr "Помилка"
+
+#: pkg/lib/machine-dialogs.js:412
+msgid "Failed to add machine: $0"
+msgstr "Не вдалося додати комп’ютер: $0"
+
+#: pkg/users/local.js:112 pkg/users/local.js:144 pkg/lib/credentials.js:223
+msgid "Failed to change password"
+msgstr "Не вдалося змінити пароль"
+
+#: pkg/selinux/setroubleshoot-client.js:187
+msgid "Failed to delete alert"
+msgstr "Не вдалося вилучити нагадування"
+
+#: pkg/tuned/dialog.js:171
+msgid "Failed to disable tuned"
+msgstr "Не вдалося вимкнути tuned"
+
+#: pkg/tuned/dialog.js:133
+msgid "Failed to disable tuned profile"
+msgstr "Невдалося вимкнути профіль tuned"
+
+#: pkg/lib/machine-dialogs.js:494
+msgid "Failed to edit machine: $0"
+msgstr "Не вдалося змінити запис комп’ютера: $0"
+
+#: pkg/tuned/dialog.js:169
+msgid "Failed to enable tuned"
+msgstr "Не вдалося увімкнути tuned"
+
+#: pkg/users/index.html:338
+msgid "Failed to load authorized keys."
+msgstr "Не вдалося завантажити уповноважені ключі."
+
+#: pkg/docker/containers.js:64
+msgid "Failed to start Docker: $0"
+msgstr "Не вдалося запустити Docker: $0"
+
+#: pkg/docker/util.js:544
+msgid "Failed to stop Docker scope: $0"
+msgstr "Не вдалося зупинити область Docker: $0"
+
+#: pkg/tuned/dialog.js:145
+msgid "Failed to switch profile"
+msgstr "Не вдалося перемкнути профіль"
+
+#: pkg/kubernetes/scripts/volumes.js:204
+msgid "Fibre Channel"
+msgstr "Оптоволоконний канал"
+
+#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
+msgid "Filesystem Options"
+msgstr "Параметри файлової системи"
+
+#: pkg/kubernetes/views/pv-modify.html:180
+#: pkg/kubernetes/views/volume-body.html:6
+#: pkg/kubernetes/views/volume-body.html:16
+#: pkg/kubernetes/views/volume-body.html:62
+#: pkg/kubernetes/views/volume-body.html:83
+#: pkg/kubernetes/views/volume-body.html:91
+#: pkg/kubernetes/views/volume-body.html:120
+#: pkg/kubernetes/views/volume-body.html:132
+msgid "Filesystem Type"
+msgstr "Тип файлової системи"
+
+#: pkg/storaged/details.js:215
+msgid "Filesystem type"
+msgstr "Тип файлової системи"
+
+#: pkg/storaged/index.html:225
+msgid "Filesystems"
+msgstr "Файлові системи"
+
+#: pkg/lib/machine-unknown-hostkey.html:10
+msgid "Fingerprint"
+msgstr "Відбиток"
+
+#: pkg/storaged/index.html:426
+msgctxt "storage"
+msgid "Firmware Version"
+msgstr "Версія мікропрограми"
+
+#: pkg/kubernetes/scripts/volumes.js:206
+msgid "Flex"
+msgstr "Flex"
+
+#: pkg/kubernetes/scripts/volumes.js:205
+msgid "Flocker"
+msgstr "Flocker"
+
+#: pkg/kubernetes/views/volume-body.html:125
+msgid "Flocker Dataset Name"
+msgstr "Назва набору даних Flocker"
+
+#: pkg/docker/util.js:503
+msgid "Force Delete"
+msgstr "Примусове вилучення"
+
+#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
+#: pkg/storaged/details.js:1142
+msgid "Format"
+msgstr "Формат"
+
+#: pkg/storaged/details.js:115
+msgid "Format $0"
+msgstr "Форматувати $0"
+
+#: pkg/storaged/details.js:335
+msgid "Format Disk $0"
+msgstr "Форматувати диск $0"
+
+#: pkg/storaged/details.js:358
+msgid "Formatting a disk will erase all data on it."
+msgstr ""
+"Форматування диска призведе до знищення даних, які на ньому зберігаються."
+
+#: pkg/storaged/details.js:268
+msgid "Formatting a storage device will erase all data on it."
+msgstr ""
+"Форматування пристрою для зберігання даних призведе до знищення даних, які "
+"на ньому зберігаються."
+
+#: pkg/networkmanager/interfaces.js:2577
+msgid "Forward delay $forward_delay"
+msgstr "Затримка переспрямування $forward_delay"
+
+#: pkg/systemd/index.html:255
+msgid "Free"
+msgstr "Вільно"
+
+#: pkg/users/index.html:86 pkg/users/index.html:148
+msgid "Full Name"
+msgstr "Повне ім'я"
+
+#: pkg/kubernetes/scripts/volumes.js:192
+msgid "GCE Persistent Disk"
+msgstr "Сталий диск GCE"
+
+#: pkg/docker/index.html:180
+msgid "Gateway:"
+msgstr "Шлюз:"
+
+#: pkg/networkmanager/interfaces.js:2628
+msgid "General"
+msgstr "Загальний"
+
+#: pkg/sosreport/index.html:66
+msgid "Generating report"
+msgstr "Створюємо звіт"
+
+#: pkg/kubernetes/scripts/volumes.js:194
+msgid "Git Repository"
+msgstr "Сховище Git"
+
+#: pkg/kubernetes/scripts/volumes.js:198
+msgid "Gluster FS"
+msgstr "ФС Gluster"
+
+#: pkg/kubernetes/scripts/volumes.js:872
+msgid "GlusterFS"
+msgstr "GlusterFS"
+
+#: pkg/systemd/logs.js:130
+msgid "Go to"
+msgstr "Перейти до"
+
+#: pkg/storaged/index.html:307 pkg/networkmanager/index.html:50
+#: pkg/networkmanager/index.html:496
+msgid "Go to now"
+msgstr "Перейти зараз"
+
+#: pkg/kubernetes/views/group-page.html:21
+#: pkg/kubernetes/views/group-panel.html:12
+msgid "Group Members"
+msgstr "Учасники групи"
+
+#: pkg/kubernetes/views/project-listing.html:48
+#: pkg/kubernetes/views/user-delete.html:14
+msgid "Groups"
+msgstr "Групи"
+
+#: pkg/networkmanager/index.html:268
+msgid "Hair Pin mode"
+msgstr "Режим початкової зони"
+
+#: pkg/networkmanager/interfaces.js:2603
+msgid "Hairpin mode"
+msgstr "Режим початкової зони (hairpin)"
+
+#: pkg/docker/storage.jsx:157
+#, fuzzy
+msgid "Hard Disk"
+msgstr "Жорсткий диск"
+
+#: pkg/storaged/overview.js:180
+msgctxt "storage"
+msgid "Hard Disk"
+msgstr "Жорсткий диск"
+
+#: pkg/systemd/index.html:77
+msgid "Hardware"
+msgstr "Обладнання"
+
+#: pkg/networkmanager/interfaces.js:2579
+msgid "Hello time $hello_time"
+msgstr "Час вітання $hello_time"
+
+#: pkg/kubernetes/views/details-page.html:73
+#: pkg/kubernetes/views/route-body.html:9
+#: pkg/kubernetes/views/route-modify.html:8
+msgid "Host"
+msgstr "Вузол"
+
+#: pkg/systemd/index.html:102 pkg/dashboard/index.html:151
+msgid "Host Name"
+msgstr "Назва вузла"
+
+#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
+msgid "Host Path"
+msgstr "Шлях на вузлі"
+
+#: src/base1/cockpit.js:3699
+msgid "Host key is incorrect"
+msgstr "Ключ вузла є неправильним"
+
+#: pkg/systemd/services.html:442
+#, fuzzy
+msgid "Hour : Minute"
+msgstr "1 хвилина"
+
+#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
+msgid "Hour needs to be a number between 0-23"
+msgstr ""
+
+#: pkg/systemd/services.html:408
+#, fuzzy
+msgid "Hours"
+msgstr "6 годин"
+
+#: pkg/systemd/index.html:221
+msgid "I/O Wait"
+msgstr "Очікування В-В"
+
+#: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
+msgid "IP"
+msgstr "IP"
+
+#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
+msgid "IP Address"
+msgstr "IP-адреса"
+
+#: pkg/docker/index.html:172
+msgid "IP Address:"
+msgstr "IP-адреса:"
+
+#: pkg/docker/index.html:176
+msgid "IP Prefix Length:"
+msgstr "Довжина префікса IP:"
+
+#: pkg/networkmanager/index.html:568
+msgid "IP Settings"
+msgstr "Параметри IP"
+
+#: pkg/networkmanager/interfaces.js:2641
+msgid "IPv4"
+msgstr "IPv4"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv4 Settings"
+msgstr "Параметри IPv4"
+
+#: pkg/networkmanager/interfaces.js:2642
+msgid "IPv6"
+msgstr "IPv6"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv6 Settings"
+msgstr "Параметри IPv6"
+
+#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
+msgid "ISCSI"
+msgstr "ISCSI"
+
+#: pkg/systemd/init.js:270
+msgid "Id"
+msgstr "Ід."
+
+#: pkg/networkmanager/interfaces.js:2620
+msgid "Id $id"
+msgstr "Ід. $id"
+
+#: pkg/kubernetes/views/image-body.html:22
+msgid "Identifier"
+msgstr "Ідентифікатор"
+
+#: pkg/kubernetes/views/user-page.html:23
+#: pkg/kubernetes/views/user-panel.html:18
+msgid "Identities"
+msgstr "Профілі"
+
+#: pkg/kubernetes/views/project-listing.html:91
+msgid "Identity"
+msgstr "Профіль"
+
+#: pkg/networkmanager/interfaces.js:1817
+msgid "Ignore"
+msgstr "Ігнорувати"
+
+#: pkg/docker/index.html:452 pkg/kubernetes/views/image-panel.html:9
+#: pkg/kubernetes/views/container-body.html:6
+#: pkg/kubernetes/views/image-page.html:16
+msgid "Image"
+msgstr "Образ"
+
+#: pkg/docker/image.js:77
+msgid "Image $0"
+msgstr "Зображення $0"
+
+#: pkg/kubernetes/views/container-body.html:8
+msgid "Image ID"
+msgstr "Ід. образу"
+
+#: pkg/kubernetes/views/image-meta.html:16
+msgid "Image Layers"
+msgstr "Шари образу"
+
+#: pkg/kubernetes/views/volume-body.html:58
+msgid "Image Name"
+msgstr "Назви предметів"
+
+#: pkg/kubernetes/registry.html:23
+msgid "Image Registry"
+msgstr "Реєстр образів"
+
+#: pkg/kubernetes/views/imagestream-page.html:16
+msgid "Image Stream"
+msgstr "Потік образу"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:135
+#, fuzzy
+msgid "Image commands"
+msgstr "Кількість образів"
+
+#: pkg/kubernetes/views/imagestream-body.html:34
+msgid "Image count"
+msgstr "Кількість образів"
+
+#: pkg/kubernetes/registry.html:48
+#: pkg/kubernetes/views/registry-dashboard-page.html:19
+#: pkg/kubernetes/views/imagestream-page.html:18
+#: pkg/kubernetes/views/image-listing.html:9 pkg/kubernetes/index.html:77
+msgid "Images"
+msgstr "Зображення"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:17
+msgid "Images by project"
+msgstr "Образи за проектом"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:54
+msgid "Images pushed recently"
+msgstr "Нещодавно вивантажені образи"
+
+#: pkg/storaged/details.js:1593
+msgid "In Sync"
+msgstr "Синхронізовано"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:81
+msgid ""
+"In order to begin pushing images to the registry, use the commands below."
+msgstr ""
+"З метою розпочати надсилання образів до реєстру скористайтеся наведеними "
+"нижче командами."
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:6
+msgid ""
+"In order to begin pushing images to the registry, you need to create a "
+"project."
+msgstr "Щоб розпочати надсилання образів до реєстру, вам слід створити проект."
+
+#: pkg/lib/machine-sync-users.html:50
+msgid ""
+"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
+"strong}}.        {{/needs_root}}                                    User "
+"name                                                                            "
+"{{#allows_password}}                            "
+"Password                                                                            "
+"{{/allows_password}}            "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
+#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
+msgid "Inactive"
+msgstr "Неактивний"
+
+#: pkg/lib/machine-invalid-hostkey.html:2
+msgid "Incorrect Host Key"
+msgstr "Неправильний ключ вузла"
+
+#: pkg/docker/storage.jsx:282
+msgid "Information about the Docker storage pool is not available."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:222
+#, fuzzy
+msgid "Installed products"
+msgstr "Встановлені продукти"
+
+#: pkg/systemd/services.html:135
+msgid "Instantiate"
+msgstr "Створити екземпляр"
+
+#: pkg/kubernetes/views/pv-modify.html:169
+#: pkg/kubernetes/views/volume-body.html:81
+msgid "Interface"
+msgstr "Інтерфейс"
+
+#: pkg/networkmanager/index.html:84
+msgid "Interfaces"
+msgstr "Інтерфейси"
+
+#: src/base1/cockpit.js:3701
+msgid "Internal error"
+msgstr "Внутрішня помилка"
+
+#: pkg/subscriptions/subscriptions-client.js:196
+#, fuzzy
+msgid "Invalid credentials"
+msgstr "Некоректний порт"
+
+#: pkg/systemd/host.js:1194
+msgid "Invalid date format"
+msgstr "Некоректний формат дати"
+
+#: pkg/systemd/host.js:1190
+msgid "Invalid date format and invalid time format"
+msgstr "Некоректний формат дати і часу"
+
+#: pkg/systemd/init.js:1218
+#, fuzzy
+msgid "Invalid date format."
+msgstr "Некоректний формат дати"
+
+#: pkg/lib/credentials.js:274
+msgid "Invalid file permissions"
+msgstr "Некоректні права доступу до файла"
+
+#: pkg/users/index.html:322
+msgid "Invalid key"
+msgstr "Некоректний ключ"
+
+#: pkg/systemd/init.js:1169
+#, fuzzy
+msgid "Invalid number."
+msgstr "Некоректний ключ"
+
+#: pkg/docker/run.js:283
+msgid "Invalid port"
+msgstr "Некоректний порт"
+
+#: pkg/systemd/host.js:1192
+msgid "Invalid time format"
+msgstr "Некоректний формат визначення часу"
+
+#: pkg/subscriptions/subscriptions-client.js:194 pkg/storaged/overview.js:577
+#: pkg/storaged/overview.js:668
 msgid "Invalid username or password"
 msgstr "Некоректне ім’я користувача чи пароль"
 
-#: pkg/storaged/overview.js:582
-msgid "Unknown host name"
-msgstr "Невідома назва вузла"
+#: pkg/lib/machine-change-port.html:15
+msgid "Is sshd running on a different port?"
+msgstr "sshd працює на іншому порті?"
 
-#: pkg/storaged/overview.js:586
-msgid "Unable to reach server"
-msgstr "Не вдалося досягти сервера"
+#: pkg/systemd/init.js:522
+msgid "Isolate"
+msgstr "Ізолювати"
 
-#: pkg/storaged/overview.js:619
-msgid "Available targets on $0"
-msgstr "Доступні призначення на $0"
+#: pkg/storaged/index.html:280
+msgid "Jobs"
+msgstr "Завдання"
 
-#: pkg/storaged/overview.js:623 pkg/systemd/services.html.h:2
-msgid "Targets"
-msgstr "Призначення"
+#: pkg/realmd/operation.js:96
+msgid "Join"
+msgstr "З'єднати"
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-add.html.h:2
-#: pkg/kubernetes/views/node-body.html.h:2
-#: pkg/kubernetes/views/auth-form.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:16
-#: pkg/kubernetes/views/nodes-page.html.h:7
-#: pkg/kubernetes/views/details-page.html.h:19
-msgid "Address"
-msgstr "Адреса"
+#: pkg/realmd/operation.js:453
+msgid "Join Domain"
+msgstr "Долучитися до домену"
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-change-port.html.h:5
-msgid "Port"
-msgstr "Порт"
+#: pkg/realmd/operation.js:347
+msgid "Joining this domain is not supported"
+msgstr "Підтримки долучення до цього домену не передбачено"
 
-#: pkg/storaged/overview.js:699
-msgid "Change iSCSI Initiator Name"
-msgstr "Змінити назву ініціатора iSCSI"
+#: pkg/systemd/logs.js:257
+msgid "Journal entry"
+msgstr "Запис журналу"
 
-#: pkg/storaged/overview.js:707 pkg/kubernetes/views/route-modify.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:22
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:4
-#: pkg/kubernetes/views/project-modify.html.h:9
-msgid "Change"
+#: pkg/systemd/logs.js:284
+msgid "Journal entry not found"
+msgstr "Не знайдено запису журналу"
+
+#: pkg/lib/machine-auth-failed.html:10
+msgid "Kerberos Based SSO"
+msgstr "SSO на основі Kerberos"
+
+#: pkg/lib/machine-change-auth.html:69
+msgid "Kerberos Ticket"
+msgstr "Квиток Kerberos"
+
+#: pkg/systemd/index.html:225
+msgid "Kernel"
+msgstr "Ядро"
+
+#: pkg/kubernetes/views/node-body.html:19
+msgid "Kernel Version"
+msgstr "Версія ядра"
+
+#: pkg/kubernetes/views/volume-body.html:67
+msgid "Key Ring Path"
+msgstr "Шлях до сховища ключів"
+
+#: pkg/kubernetes/views/node-body.html:23
+msgid "Kubelet Version"
+msgstr "Версія Kubelet"
+
+#: pkg/kubernetes/index.html:23
+msgid "Kubernetes Cluster"
+msgstr "Кластер Kubernetes"
+
+#: pkg/networkmanager/index.html:473
+msgid "LACP Key"
+msgstr ""
+
+#: pkg/storaged/details.js:1245
+msgctxt "storage-id-desc"
+msgid "LUKS Encrypted"
+msgstr "Зашифровано LUKS"
+
+#: pkg/storaged/details.js:1226
+msgctxt "storage-id-desc"
+msgid "LVM2 Physical Volume"
+msgstr "Фізичний том LVM2"
+
+#: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/replicationcontroller-body.html:17
+#: pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/route-body.html:22
+#: pkg/kubernetes/views/image-meta.html:3
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
+msgid "Labels"
+msgstr "Мітки"
+
+#: pkg/systemd/logs.html:42
+msgid "Last 24 hours"
+msgstr "Попередні 24 години"
+
+#: pkg/systemd/logs.html:43
+msgid "Last 7 days"
+msgstr "Попередні 7 днів"
+
+#: pkg/kubernetes/views/node-body.html:49
+msgid "Last Heartbeat"
+msgstr "Останній такт"
+
+#: pkg/users/index.html:100
+msgid "Last Login"
+msgstr "Останній вхід"
+
+#: pkg/kubernetes/views/node-body.html:51
+msgid "Last Status Change"
+msgstr "Остання зміна стану"
+
+#: pkg/systemd/init.js:273
+msgid "Last Trigger"
+msgstr "Останній перемикач"
+
+#: pkg/kubernetes/views/image-listing.html:16
+msgid "Last Updated"
+msgstr "Останнє оновлення"
+
+#: pkg/kubernetes/views/details-page.html:107
+msgid "Latest Version"
+msgstr "Найсвіжіша версія"
+
+#: pkg/realmd/operation.js:101
+msgid "Leave"
+msgstr "Вийти"
+
+#: pkg/networkmanager/index.html:315
+msgid "Link Monitoring"
+msgstr "Спостереження за зв’язком"
+
+#: pkg/networkmanager/index.html:397
+#, fuzzy
+msgid "Link Watch"
+msgstr "Пов’язати локальний"
+
+#: pkg/networkmanager/index.html:350 pkg/networkmanager/index.html:432
+msgid "Link down delay"
+msgstr "Затримка розірвання зв’язку"
+
+#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
+msgid "Link local"
+msgstr "Пов’язати локальний"
+
+#: pkg/networkmanager/index.html:341 pkg/networkmanager/index.html:423
+msgid "Link up delay"
+msgstr "Затримка встановлення зв’язку"
+
+#: pkg/docker/index.html:514
+msgid "Links"
+msgstr "Посилання"
+
+#: pkg/storaged/details.js:1224
+msgctxt "storage-id-desc"
+msgid "Linux MD-RAID Component"
+msgstr "Компонент MD-RAID Linux"
+
+#: pkg/networkmanager/interfaces.js:1841
+#, fuzzy
+msgid "Load Balancing"
+msgstr "Адаптивне урівноваження навантаження"
+
+#: pkg/systemd/logs.js:69
+msgid "Load earlier entries"
+msgstr "Завантажити попередні записи"
+
+#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
+#: pkg/systemd/logs.js:175
+msgid "Loading..."
+msgstr "Завантаження…"
+
+#: pkg/users/index.html:23
+msgid "Local Accounts"
+msgstr "Локальні облікові записи"
+
+#: pkg/docker/storage.jsx:188
+#, fuzzy
+msgid "Local Disks"
+msgstr "Диски $0"
+
+#: pkg/storaged/details.js:1109
+msgid "Lock"
+msgstr "Заблокувати"
+
+#: pkg/users/index.html:109 pkg/users/index.html:196
+msgid "Lock Account"
+msgstr "Заблокувати обліковий запис"
+
+#: pkg/storaged/jobs.js:122
+msgid "Locking $target"
+msgstr "Блокуємо $target"
+
+#: pkg/lib/machine-change-auth.html:80
+msgid "Log In"
+msgstr "Увійти"
+
+#: pkg/lib/machine-change-auth.html:4
+msgid "Log in to {{host}}"
+msgstr "Вхід до {{host}}"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:116
+msgid "Log into OpenShift command line tools:"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:101
+#, fuzzy
+msgid "Log into the registry:"
+msgstr "Вітаємо у реєстрі образів"
+
+#: pkg/shell/simple.html:45 pkg/shell/index.html:52 pkg/shell/stub.html:45
+msgid "Log out"
+msgstr "Вийти"
+
+#: pkg/users/local.js:839
+msgid "Logged In"
+msgstr "Вхід"
+
+#: pkg/storaged/details.js:1424
+msgid "Logical Partition"
+msgstr "Логічний розділ"
+
+#: pkg/kubernetes/views/pv-modify.html:158
+#: pkg/kubernetes/views/volume-body.html:79
+#: pkg/kubernetes/views/volume-body.html:118
+msgid "Logical Unit Number"
+msgstr "Логічний номер модуля"
+
+#: pkg/storaged/utils.js:172
+msgid "Logical Volume"
+msgstr "Логічний том"
+
+#: pkg/storaged/utils.js:170
+msgid "Logical Volume (Snapshot)"
+msgstr "Логічний том (знімок)"
+
+#: pkg/storaged/details.js:1792
+msgid "Logical Volumes"
+msgstr "Логічні томи"
+
+#: pkg/subscriptions/subscriptions-register.jsx:140
+#, fuzzy
+msgid "Login"
+msgstr "Останній вхід"
+
+#: pkg/lib/machine-change-auth.html:68
+msgid "Login Password"
+msgstr "Пароль користувача"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:96
+#, fuzzy
+msgid "Login commands"
+msgstr "Команди Docker"
+
+#: src/base1/cockpit.js:3693
+msgid "Login failed"
+msgstr "Невдала спроба увійти"
+
+#: pkg/subscriptions/subscriptions-client.js:200
+#, fuzzy
+msgid "Login/password or activation key required to register."
+msgstr "Слід вказати ім’я користувача та пароль або ключ активації"
+
+#: pkg/systemd/logs.html:59 pkg/kubernetes/views/container-panel.html:6
+#: pkg/kubernetes/views/container-page-inline.html:8
+msgid "Logs"
+msgstr "Журнали"
+
+#: pkg/dashboard/index.html:110
+msgid "Lost connection. Trying to reconnect"
+msgstr "З’єднання розірвано. Намагаємося його повторно встановити"
+
+#: pkg/docker/index.html:184
+msgid "MAC Address:"
+msgstr "MAC-адреса:"
+
+#: pkg/networkmanager/interfaces.js:1833
+msgid "MII (Recommended)"
+msgstr "MII (рекомендоване)"
+
+#: pkg/networkmanager/interfaces.js:2477
+msgid "MTU"
+msgstr "MTU"
+
+#: pkg/networkmanager/interfaces.js:4139
+msgid "MTU must be a positive number"
+msgstr "MTU має бути додатнім числом"
+
+#: pkg/systemd/index.html:85 pkg/kubernetes/views/node-body.html:15
+msgid "Machine ID"
+msgstr "Ід. комп’ютера"
+
+#: pkg/systemd/index.html:282
+msgid "Machine SSH Key Fingerprints"
+msgstr "Відбитки ключів SSH комп’ютерів"
+
+#: pkg/shell/indexes.js:253
+msgid "Machines"
+msgstr "Машини"
+
+#: pkg/kubernetes/scripts/dashboard.js:460
+msgid "Manifest"
+msgstr "Маніфест"
+
+#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
+msgid "Manual"
+msgstr "Вручну"
+
+#: pkg/systemd/index.html:401 pkg/systemd/index.html:405
+msgid "Manually"
+msgstr "Вручну"
+
+#: pkg/storaged/jobs.js:140
+msgid "Marking $target as faulty"
+msgstr "Позначаємо $target як помилковий"
+
+#: pkg/systemd/init.js:546
+msgid "Mask"
+msgstr "Маска"
+
+#: pkg/systemd/init.js:547
+msgid "Mask Forcefully"
+msgstr "Примусово замаскувати"
+
+#: pkg/networkmanager/interfaces.js:2483
+msgid "Master"
+msgstr "Основний"
+
+#: pkg/networkmanager/interfaces.js:2581
+msgid "Maximum message age $max_age"
+msgstr "Максимальний вік повідомлення $max_age"
+
+#: pkg/kubernetes/views/volume-body.html:34
+msgid "Medium"
+msgstr "Носій"
+
+#: pkg/kubernetes/views/project-listing.html:92
+msgid "Member of"
+msgstr "Учасник"
+
+#: pkg/kubernetes/views/project-listing.html:16
+#: pkg/kubernetes/views/project-listing.html:55
+#: pkg/networkmanager/index.html:291
+msgid "Members"
+msgstr "Учасники"
+
+#: pkg/kubernetes/views/project-page.html:29
+#: pkg/kubernetes/views/user-panel.html:11
+#: pkg/kubernetes/views/user-panel.html:27
+#: pkg/kubernetes/views/user-body.html:4
+msgid "Membership"
+msgstr "Участь"
+
+#: pkg/dashboard/index.html:71 pkg/playground/translate.html:91
+msgid "Memory"
+msgstr "Пам'ять"
+
+#: pkg/systemd/host.js:1466
+msgctxt "page-title"
+msgid "Memory"
+msgstr "Пам'ять"
+
+#: pkg/kubernetes/scripts/nodes.js:716
+msgid "Memory Utilization: $0%"
+msgstr "Використання пам’яті: $0%"
+
+#: pkg/docker/index.html:473 pkg/docker/index.html:652
+msgid "Memory limit"
+msgstr "Обмеження пам’яті"
+
+#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
+msgid "Message"
+msgstr "Повідомлення"
+
+#: pkg/systemd/host.js:1300
+msgid "Message to logged in users"
+msgstr "Повідомлення користувачам, які увійшли"
+
+#: pkg/kubernetes/views/image-panel.html:15
+#: pkg/kubernetes/views/imagestream-page.html:21
+#: pkg/kubernetes/views/image-page.html:22
+msgid "Metadata"
+msgstr "Метадані"
+
+#: pkg/docker/index.html:487 pkg/docker/index.html:666
+msgid "MiB"
+msgstr "МіБ"
+
+#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
+msgid "Minute needs to be a number between 0-59"
+msgstr ""
+
+#: pkg/systemd/services.html:407
+#, fuzzy
+msgid "Minutes"
+msgstr "5 хвилин"
+
+#: pkg/networkmanager/index.html:299
+msgid "Mode"
+msgstr "Режим"
+
+#: pkg/storaged/index.html:421
+msgctxt "storage"
+msgid "Model"
+msgstr "Модель"
+
+#: pkg/kubernetes/views/user-modify.html:31
+msgid "Modify"
 msgstr "Змінити"
 
-#: pkg/storaged/utils.js:88
-msgctxt "format-bytes"
-msgid "bytes"
-msgstr "байтів"
+#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
+msgid "Modifying $target"
+msgstr "Змінюємо $target"
+
+#: pkg/networkmanager/index.html:323
+msgid "Monitoring Interval"
+msgstr "Інтервал оновлення"
+
+#: pkg/networkmanager/index.html:332
+msgid "Monitoring Targets"
+msgstr "Спостерігаємо за цілями"
+
+#: pkg/kubernetes/views/volume-body.html:54
+msgid "Monitors"
+msgstr "Монітори"
+
+#: pkg/realmd/operation.js:366
+msgid "More"
+msgstr "Більше"
+
+#: pkg/storaged/details.js:1099
+msgid "Mount"
+msgstr "Змонтувати"
+
+#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
+msgid "Mount Location"
+msgstr "Місце монтування"
+
+#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
+msgid "Mount Options"
+msgstr "Параметри монтування"
+
+#: pkg/storaged/index.html:231
+msgid "Mount Point"
+msgstr "Точка монтування"
+
+#: pkg/docker/index.html:540
+msgid "Mount container volumes"
+msgstr "Змонтувати томи контейнера"
+
+#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
+msgid "Mounting"
+msgstr "Монтування"
+
+#: pkg/storaged/jobs.js:126
+msgid "Mounting $target"
+msgstr "Монтуємо $target"
+
+#: pkg/storaged/index.html:508
+msgctxt "storage"
+msgid "Multipathed Devices"
+msgstr "Пристрої із багатьма шляхами"
+
+#: pkg/kubernetes/scripts/volumes.js:860
+msgid "NFS"
+msgstr "NFS"
+
+#: pkg/kubernetes/scripts/volumes.js:199
+msgid "NFS Mount"
+msgstr "Змонтована NFS"
+
+#: pkg/networkmanager/interfaces.js:1856
+msgid "NSNA Ping"
+msgstr ""
+
+#: pkg/storaged/details.js:182
+msgid "NTFS - Compatible with most systems"
+msgstr "NTFS - Сумісна з більшістю систем"
+
+#: pkg/systemd/host.js:1250
+msgid "NTP Server"
+msgstr "Сервер NTP"
+
+#: pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/project-modify.html:16
+#: pkg/kubernetes/views/node-add.html:16
+#: pkg/kubernetes/views/volumes-page.html:19
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/image-body.html:2
+#: pkg/kubernetes/views/imagestream-modify.html:10
+#: pkg/kubernetes/views/service-modify.html:9
+#: pkg/kubernetes/views/dashboard-page.html:156
+#: pkg/kubernetes/views/dashboard-page.html:198
+#: pkg/kubernetes/views/details-page.html:34
+#: pkg/kubernetes/views/details-page.html:70
+#: pkg/kubernetes/views/details-page.html:103
+#: pkg/kubernetes/views/details-page.html:137
+#: pkg/kubernetes/views/details-page.html:171
+#: pkg/kubernetes/views/pv-claim.html:4
+#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/kubernetes/views/project-listing.html:14
+#: pkg/kubernetes/views/project-listing.html:53
+#: pkg/kubernetes/views/project-listing.html:90
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/volume-body.html:31 pkg/storaged/index.html:230
+#: pkg/networkmanager/index.html:95 pkg/networkmanager/index.html:113
+#: pkg/networkmanager/index.html:150 pkg/networkmanager/index.html:183
+#: pkg/networkmanager/index.html:282 pkg/networkmanager/index.html:364
+msgid "Name"
+msgstr "Назва"
 
 #: pkg/storaged/utils.js:129
 #, fuzzy
@@ -1737,381 +3536,1228 @@ msgstr "Назва не повинна містити символів «$0»."
 msgid "Name cannot contain whitespace."
 msgstr "У назві не повинно бути пробілів."
 
-#: pkg/storaged/utils.js:157
-msgid "$name (from $host)"
-msgstr "$name (з $host)"
+#: pkg/kubernetes/views/service-body.html:5
+#: pkg/kubernetes/views/replicationcontroller-body.html:5
+#: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/pod-body.html:5
+#: pkg/kubernetes/views/dashboard-page.html:160
+#: pkg/kubernetes/views/details-page.html:36
+#: pkg/kubernetes/views/details-page.html:72
+#: pkg/kubernetes/views/details-page.html:105
+#: pkg/kubernetes/views/details-page.html:139
+#: pkg/kubernetes/views/details-page.html:173
+#: pkg/kubernetes/views/pv-claim.html:6
+#: pkg/kubernetes/views/containers-listing.html:14
+#: pkg/kubernetes/views/route-body.html:5
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
+msgid "Namespace"
+msgstr "Простір назв"
 
-#: pkg/storaged/utils.js:166
-msgid "Pool for Thin Logical Volumes"
-msgstr "Буфер для тонких логічних томів"
+#: pkg/kubernetes/scripts/dashboard.js:374
+msgid "Namespace cannot be empty."
+msgstr "Простір назв не може бути порожнім."
 
-#: pkg/storaged/utils.js:168
-msgid "Thin Logical Volume"
-msgstr "Тонкий логічний том"
+#: pkg/systemd/host.js:1113
+msgid "Need at least one NTP server"
+msgstr "Потрібен принаймні один сервер NTP"
 
-#: pkg/storaged/utils.js:170
-msgid "Logical Volume (Snapshot)"
-msgstr "Логічний том (знімок)"
+#: pkg/dashboard/index.html:72 pkg/playground/translate.html:96
+msgid "Network"
+msgstr "Мережа"
 
-#: pkg/storaged/utils.js:172
-msgid "Logical Volume"
-msgstr "Логічний том"
+#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:485
+msgid "Networking"
+msgstr "Робота у мережі"
 
-#: pkg/storaged/utils.js:212
-msgid "<span>Encrypted Logical Volume of $0</span>"
-msgstr "<span>Зашифрований логічний том $0</span>"
+#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
+msgctxt "page-title"
+msgid "Networking"
+msgstr "Робота у мережі"
 
-#: pkg/storaged/utils.js:214
-msgid "<span>Encrypted Partition of $0</span>"
-msgstr "<span>Шифрований розділ $0</span>"
+#: pkg/networkmanager/index.html:124
+msgid "Networking Logs"
+msgstr "Журнали роботи у мережі"
 
-#: pkg/storaged/utils.js:216
-msgid "<span>Logical Volume of $0</span>"
-msgstr "<span>Логічний том $0</span>"
+#: pkg/users/local.js:841
+msgid "Never"
+msgstr "Ніколи"
 
-#: pkg/storaged/utils.js:218
-msgid "<span>Partition of $0</span>"
-msgstr "<span>Розділ $0</span>"
+#: pkg/kubernetes/views/project-listing.html:46
+msgid "New Group"
+msgstr "Нова група"
 
-#: pkg/storaged/utils.js:220
-msgid "<span>Encrypted $0</span>"
-msgstr "<span>Зашифрований $0</span>"
+#: pkg/users/index.html:236 pkg/shell/index.html:255
+msgid "New Password"
+msgstr "Новий пароль"
 
-#: pkg/storaged/utils.js:233
-msgid "RAID Device $0"
-msgstr "Пристій RAID $0"
+#: pkg/kubernetes/views/project-listing.html:7
+msgid "New Project"
+msgstr "Новий проект"
 
-#: pkg/storaged/utils.js:239
-msgid "Volume Group $0"
-msgstr "Група томів $0"
+#: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/image-listing.html:7
+msgid "New image stream"
+msgstr "Новий потік образу"
 
-#: pkg/storaged/jobs.js:119
-msgid "SMART self-test of $target"
-msgstr "Самоперевірка SMART $target"
+#: pkg/users/local.js:120 pkg/lib/credentials.js:231
+msgid "New password was not accepted"
+msgstr "Новий пароль не прийнято"
 
-#: pkg/storaged/jobs.js:120
-msgid "Ejecting $target"
-msgstr "Видобуваємо $target"
+#: pkg/kubernetes/views/project-modify.html:4
+#: pkg/kubernetes/views/registry-dashboard-page.html:9
+#: pkg/kubernetes/views/registry-dashboard-page.html:48
+msgid "New project"
+msgstr "Новий проект"
 
-#: pkg/storaged/jobs.js:121
-msgid "Unlocking $target"
-msgstr "Розблокуємо $target"
+#: pkg/realmd/operation.html:91
+msgid "Next"
+msgstr "Далі"
 
-#: pkg/storaged/jobs.js:122
-msgid "Locking $target"
-msgstr "Блокуємо $target"
+#: pkg/systemd/init.js:272
+msgid "Next Run"
+msgstr "Наступний запуск"
 
-#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
-msgid "Modifying $target"
-msgstr "Змінюємо $target"
+#: pkg/systemd/index.html:233
+msgid "Nice"
+msgstr "Пріоритетність"
 
-#: pkg/storaged/jobs.js:124
-msgid "Starting swapspace $target"
-msgstr "Запускаємо резервну область пам’яті $target"
-
-#: pkg/storaged/jobs.js:125
-msgid "Stopping swapspace $target"
-msgstr "Зупиняємо резервну область пам’яті $target"
-
-#: pkg/storaged/jobs.js:126
-msgid "Mounting $target"
-msgstr "Монтуємо $target"
-
-#: pkg/storaged/jobs.js:127
-msgid "Unmounting $target"
-msgstr "Демонтуємо $target"
-
-#: pkg/storaged/jobs.js:129
-msgid "Erasing $target"
-msgstr "Витираємо $target"
-
-#: pkg/storaged/jobs.js:130
-msgid "Creating filesystem on $target"
-msgstr "Створюємо файлову систему на $target"
-
-#: pkg/storaged/jobs.js:131
-msgid "Setting up loop device $target"
-msgstr "Налаштовуємо петльовий пристрій $target"
-
-#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
-msgid "Deleting $target"
-msgstr "Вилучаємо $target"
-
-#: pkg/storaged/jobs.js:134
-msgid "Creating partition $target"
-msgstr "Створюємо розділ $target"
-
-#: pkg/storaged/jobs.js:135
-msgid "Cleaning up for $target"
-msgstr "Спорожнюємо для $target"
-
-#: pkg/storaged/jobs.js:136
-msgid "Securely erasing $target"
-msgstr "Безпечно витираємо $target"
-
-#: pkg/storaged/jobs.js:137
-msgid "Very securely erasing $target"
-msgstr "Дуже безпечно витираємо $target"
-
-#: pkg/storaged/jobs.js:138
-msgid "Stopping RAID Device $target"
-msgstr "Зупиняємо пристрій RAID $target"
-
-#: pkg/storaged/jobs.js:139
-msgid "Starting RAID Device $target"
-msgstr "Зупиняємо пристрій RAID $target"
-
-#: pkg/storaged/jobs.js:140
-msgid "Marking $target as faulty"
-msgstr "Позначаємо $target як помилковий"
-
-#: pkg/storaged/jobs.js:141
-msgid "Removing $target from RAID Device"
-msgstr "Вилучаємо $target з пристрою RAID"
-
-#: pkg/storaged/jobs.js:142
-msgid "Creating RAID Device $target"
-msgstr "Створюємо пристрій RAID $target"
-
-#: pkg/storaged/jobs.js:143
-#, fuzzy
-msgid "Checking RAID Device $target"
-msgstr "Створюємо пристрій RAID $target"
-
-#: pkg/storaged/jobs.js:144
-#, fuzzy
-msgid "Checking and Repairing RAID Device $target"
-msgstr "Створюємо пристрій RAID $target"
-
-#: pkg/storaged/jobs.js:145
-#, fuzzy
-msgid "Recovering RAID Device $target"
-msgstr "Зупиняємо пристрій RAID $target"
-
-#: pkg/storaged/jobs.js:146
-msgid "Synchronizing RAID Device $target"
-msgstr "Синхронізуємо пристрій RAID $target"
-
-#: pkg/storaged/jobs.js:148
-msgid "Activating $target"
-msgstr "Активуємо $target"
-
-#: pkg/storaged/jobs.js:149
-msgid "Deactivating $target"
-msgstr "Деактивуємо $target"
-
-#: pkg/storaged/jobs.js:150
-msgid "Creating snapshot of $target"
-msgstr "Створюємо знімок $target"
-
-#: pkg/storaged/jobs.js:151
-msgid "Creating volume group $target"
-msgstr "Створюємо групу томів $target"
-
-#: pkg/storaged/jobs.js:152
-msgid "Deleting volume group $target"
-msgstr "Вилучаємо групу томів $target"
-
-#: pkg/storaged/jobs.js:153
-msgid "Adding physical volume to $target"
-msgstr "Додаємо фізичний том до $target"
-
-#: pkg/storaged/jobs.js:154
-msgid "Removing physical volume from $target"
-msgstr "Вилучаємо фізичний том з $target"
-
-#: pkg/storaged/jobs.js:155
-msgid "Emptying $target"
-msgstr "Спорожняємо $target"
-
-#: pkg/storaged/jobs.js:156
-msgid "Creating logical volume $target"
-msgstr "Створюємо логічний том $target"
-
-#: pkg/storaged/jobs.js:157
-msgid "Renaming $target"
-msgstr "Перейменовуємо $target"
-
-#: pkg/storaged/jobs.js:158
-msgid "Resizing $target"
-msgstr "Зміна розміру $target"
-
-#: pkg/storaged/jobs.js:166
-msgid "Operation '$operation' on $target"
-msgstr "Дія «$operation» над $target"
-
-#: pkg/storaged/jobs.js:180
-msgid "unknown target"
-msgstr "невідоме призначення"
-
-#: pkg/storaged/permissions.js:61
-msgid "The user <b>$0</b> is not permitted to manage storage"
-msgstr "Користувачу <b>$0</b> не дозволено керувати сховищем даних"
-
-#: pkg/realmd/operation.js:96
-msgid "Join"
-msgstr "З'єднати"
-
-#: pkg/realmd/operation.js:101
-msgid "Leave"
-msgstr "Вийти"
-
-#: pkg/realmd/operation.js:148
-msgid "Domain $0 could not be contacted"
-msgstr "Не вдалося встановити зв’язок із доменом $0"
-
-#: pkg/realmd/operation.js:220
-msgid "Domain $0 is not supported"
-msgstr "Підтримки домену $0 не передбачено"
-
-#: pkg/realmd/operation.js:347
-msgid "Joining this domain is not supported"
-msgstr "Підтримки долучення до цього домену не передбачено"
-
-#: pkg/realmd/operation.js:366
-msgid "More"
-msgstr "Більше"
-
-#: pkg/realmd/operation.js:417
-msgid "Cannot join a domain because realmd is not available on this system"
-msgstr ""
-"Не вдалося долучитися до домену, оскільки у цій системі недоступна служба "
-"realmd"
-
-#: pkg/realmd/operation.js:436
-msgid "The user <b>$0</b> is not permitted to modify realms"
-msgstr "Користувачу <b>$0</b> не дозволено вносити зміни до областей"
-
-#: pkg/realmd/operation.js:453
-msgid "Join Domain"
-msgstr "Долучитися до домену"
-
-#: pkg/docker/run.js:246 pkg/docker/util.js:102
-#: pkg/networkmanager/interfaces.js:2280 pkg/kubernetes/scripts/volumes.js:992
-#: pkg/docker/index.html.h:46
+#: pkg/docker/index.html:563 pkg/docker/index.html:567
 msgid "No"
 msgstr "Ні"
 
-#: pkg/docker/run.js:261 pkg/docker/console.html.h:1
-#: pkg/kubernetes/views/image-panel.html.h:2
-#: pkg/kubernetes/views/container-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:1
-#: pkg/kubernetes/views/image-page.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:1
-msgid "Container"
-msgstr "Контейнер"
+#: pkg/systemd/index.html:469
+msgid "No Delay"
+msgstr "Без затримки"
 
-#: pkg/docker/run.js:263 pkg/kubernetes/views/route-modify.html.h:2
-#: pkg/kubernetes/views/route-body.html.h:4
-#: pkg/kubernetes/views/details-page.html.h:12
-msgid "Host"
-msgstr "Вузол"
+#: pkg/ostree/index.html:220
+msgid "No Deployments"
+msgstr "Немає розгортань"
 
-#: pkg/docker/run.js:283
-msgid "Invalid port"
-msgstr "Некоректний порт"
+#: pkg/storaged/details.js:185
+msgid "No Filesystem"
+msgstr "Немає файлової системи"
 
-#: pkg/docker/run.js:293
-msgid "Duplicate port"
-msgstr "Дублювання порту"
+#: pkg/ostree/app.js:101
+msgid "No OSTree deployments found"
+msgstr "Не знайдено розгорнутих OSTree"
 
-#: pkg/docker/run.js:332
-#, fuzzy
-msgid "Command can't be empty"
-msgstr "Назва не повинна бути порожньою."
+#: src/ws/cockpitcertificate.c:398
+msgid "No PEM-encoded certificate found"
+msgstr "Не знайдено зашифрованого PEM сертифіката"
 
-#: pkg/docker/run.js:350
-msgid "No alias specified"
-msgstr "Альтернативної назви не вказано"
+#: src/ws/cockpitcertificate.c:364
+msgid "No PEM-encoded private key found"
+msgstr "Не знайдено зашифрованого PEM закритого ключа"
 
-#: pkg/docker/run.js:360
-msgid "Duplicate alias"
-msgstr "Дублювання псевдоніма"
+#: pkg/kubernetes/views/pv-claim.html:39
+msgid "No Pods are using this claim"
+msgstr "Цю вимогу не використовує жоден кокон"
 
-#: pkg/docker/run.js:384
-msgid "No container specified"
-msgstr "Контейнер не вказано"
-
-#: pkg/docker/details.js:47 pkg/docker/image.js:43
-msgctxt "page-title"
-msgid "Containers"
-msgstr "Контейнери"
-
-#: pkg/docker/details.js:144
-msgid "${hip}:${hport} -> $cport"
-msgstr "${hip}:${hport} -> $cport"
-
-#: pkg/docker/details.js:272 pkg/docker/containers-view.jsx:167
-msgid "Deleting a container will erase all data in it."
+#: pkg/selinux/setroubleshoot-view.jsx:479
+msgid "No SELinux alerts."
 msgstr ""
-"Вилучення контейнера призведе до витирання усіх даних, що на ньому "
-"зберігаються."
 
-#: pkg/docker/storage.jsx:156
-#, fuzzy
-msgid "Solid-State Disk"
-msgstr "Твердотільний диск"
-
-#: pkg/docker/storage.jsx:157
-#, fuzzy
-msgid "Hard Disk"
-msgstr "Жорсткий диск"
-
-#: pkg/docker/storage.jsx:158 pkg/storaged/index.html.h:33
-msgid "Drive"
-msgstr "Диск"
-
-#: pkg/docker/storage.jsx:188
-#, fuzzy
-msgid "Local Disks"
-msgstr "Диски $0"
+#: pkg/kubernetes/views/pvc-body.html:10
+msgid "No Volume Bound"
+msgstr "Не пов’язано тому"
 
 #: pkg/docker/storage.jsx:194
 #, fuzzy
 msgid "No additional local storage found."
 msgstr "Додаткове сховище"
 
-#: pkg/docker/storage.jsx:242
-msgid " (shared with the OS)"
+#: pkg/docker/run.js:350
+msgid "No alias specified"
+msgstr "Альтернативної назви не вказано"
+
+#: pkg/sosreport/index.js:115
+msgid "No archive has been created."
+msgstr "Архів не було створено."
+
+#: pkg/networkmanager/interfaces.js:1326
+msgid "No carrier"
+msgstr "Немає сигналу"
+
+#: pkg/docker/run.js:384
+msgid "No container specified"
+msgstr "Контейнер не вказано"
+
+#: pkg/storaged/index.html:193
+msgid "No drives attached"
+msgstr "Не долучено жодного диска"
+
+#: pkg/kubernetes/views/project-listing.html:74
+msgid "No groups are present."
+msgstr "Немає груп."
+
+#: pkg/systemd/index.html:28
+msgid "No host keys found."
+msgstr "Не знайдено ключів вузлів."
+
+#: pkg/storaged/index.html:158
+msgid "No iSCSI targets set up"
+msgstr "Призначень iSCSI не налаштовано"
+
+#: pkg/kubernetes/views/image-listing.html:70
+msgid "No image streams are present."
+msgstr "Немає потоків образів."
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:80
+msgid "No images pushed"
+msgstr "Не вивантажено жодного образу"
+
+#: pkg/subscriptions/subscriptions-view.jsx:223
+#, fuzzy
+msgid "No installed products on the system."
+msgstr "Cockpit у цій системі не встановлено."
+
+#: pkg/storaged/index.html:446
+msgid "No media inserted"
+msgstr "Не виявлено носія даних"
+
+#: pkg/kubernetes/scripts/dashboard.js:384
+msgid ""
+"No metadata file was selected. Please select a Kubernetes metadata file."
+msgstr ""
+"Не вибрано файл метаданих. Будь ласка, виберіть файл метаданих Kubernetes."
+
+#: pkg/kubernetes/views/dashboard-page.html:117
+msgid "No nodes in cluster"
+msgstr "У кластері немає вузлів"
+
+#: pkg/storaged/details.js:352
+msgid "No partitioning"
+msgstr "Немає розподілу на розділи"
+
+#: pkg/kubernetes/views/dashboard-page.html:40
+msgid "No pods deployed"
+msgstr "Коконів не розгорнуто"
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:6
+msgid "No pods replicated"
+msgstr "Реплік коконів не створено"
+
+#: pkg/kubernetes/views/node-capacity.html:11
+msgid "No pods scheduled"
+msgstr "Коконів не заплановано"
+
+#: pkg/kubernetes/views/service-endpoint.html:10
+msgid "No pods selected"
+msgstr "Коконів не позначено"
+
+#: pkg/kubernetes/views/project-listing.html:37
+msgid "No projects are present."
+msgstr "Немає проектів."
+
+#: pkg/users/local.js:405
+msgid "No real name specified"
+msgstr "Не вказано справжнього імені"
+
+#: pkg/storaged/index.html:87
+msgid "No storage set up as RAID"
+msgstr "Жодне зі сховищ даних не налаштовано як RAID"
+
+#: pkg/lib/credentials.js:182
+msgid "No such file or directory"
+msgstr "Немає такого файла або каталогу"
+
+#: pkg/users/local.js:400
+msgid "No user name specified"
+msgstr "Не вказано імені користувача"
+
+#: pkg/kubernetes/views/project-listing.html:112
+msgid "No users are present."
+msgstr "Немає користувачів."
+
+#: pkg/storaged/index.html:120
+msgid "No volume groups created"
+msgstr "Груп томів не створено"
+
+#: pkg/kubernetes/views/volumes-page.html:44
+msgid "No volumes are present."
+msgstr "Немає томів."
+
+#: pkg/kubernetes/views/dashboard-page.html:73
+msgid "No volumes in use"
+msgstr "Немає використаних томів"
+
+#: pkg/kubernetes/views/pod-body.html:18 pkg/kubernetes/views/node-panel.html:7
+#: pkg/kubernetes/views/containers-listing.html:15
+#: pkg/kubernetes/views/node-page.html:14
+#: pkg/kubernetes/views/topology-page.html:41
+msgid "Node"
+msgstr "Вузол"
+
+#: pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:192
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:45
+msgid "Nodes"
+msgstr "Вузли"
+
+#: pkg/kubernetes/views/topology-page.html:42
+msgid "Nodes are the machines that run your containers."
+msgstr "Вузли — комп’ютери, на яких запущено ваші контейнери."
+
+#: pkg/kubernetes/views/service-body.html:15
+#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
+#: pkg/kubernetes/views/image-config.html:25
+#: pkg/kubernetes/views/imagestream-body.html:33
+msgid "None"
+msgstr "Немає"
+
+#: pkg/playground/translate.html:30 pkg/kubernetes/views/details-page.html:53
+#: pkg/kubernetes/views/node-body.html:42
+msgid "Not Ready"
+msgstr "Не готовий"
+
+#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
+msgid "Not a valid number of replicas"
+msgstr "Некоректна кількість реплік"
+
+#: pkg/lib/credentials.js:248
+msgid "Not a valid private key"
+msgstr "Некоректний закритий ключ"
+
+#: pkg/kubernetes/scripts/details.js:546
+msgid "Not a valid value for Host"
+msgstr "Некоректне значення вузла"
+
+#: pkg/docker/index.html:57
+msgid "Not authorized to access Docker on this system"
+msgstr "Не уповноважено на доступ до Docker у цій системі"
+
+#: pkg/ostree/app.js:81
+msgid "Not authorized to update software on this system"
+msgstr "Не уповноважено на оновлення програмного забезпечення у цій системі"
+
+#: pkg/networkmanager/interfaces.js:805
+msgid "Not available"
+msgstr "Недоступний"
+
+#: pkg/selinux/setroubleshoot.js:238
+msgid "Not connected"
+msgstr "Не з’єднано"
+
+#: pkg/kubernetes/views/details-page.html:122
+msgid "Not deployed"
+msgstr "Не розгорнуто"
+
+#: pkg/docker/details.js:177 pkg/docker/image.js:112
+#: pkg/storaged/details.js:1822
+msgid "Not found"
+msgstr "Не знайдено"
+
+#: src/base1/cockpit.js:3691
+msgid "Not permitted to perform this action."
+msgstr "Немає дозволу на виконання цієї дії."
+
+#: pkg/storaged/details.js:1574
+msgid "Not running"
+msgstr "Зупинено"
+
+#: pkg/systemd/index.html:62
+msgid "Not synchronized"
+msgstr "Не синхронізовано"
+
+#: pkg/systemd/services.html:299
+msgid "Note"
+msgstr "Примітка"
+
+#: pkg/systemd/logs.html:49
+msgid "Notices"
+msgstr "Примітки"
+
+#: pkg/kubernetes/views/node-body.html:13
+msgid "OS"
+msgstr "ОС"
+
+#: pkg/ostree/client.js:500
+msgid "OS $0 not found"
+msgstr "ОС $0 не знайдено"
+
+#: pkg/kubernetes/views/nodes-page.html:19
+msgid "OS Versions"
+msgstr "Версії ОС"
+
+#: pkg/ostree/app.js:83
+msgid "OSTree is not available on this system"
+msgstr "OSTree у цій системі недоступна"
+
+#: pkg/selinux/setroubleshoot-view.jsx:405
+msgid "Occurred $0"
 msgstr ""
 
-#: pkg/docker/storage.jsx:282
-msgid "Information about the Docker storage pool is not available."
+#: pkg/selinux/setroubleshoot-view.jsx:400
+msgid "Occurred between $0 and $1"
 msgstr ""
 
-#: pkg/docker/storage.jsx:314
-msgid "Total"
+#: pkg/systemd/index.html:157 pkg/playground/jquery-patterns.html:95
+#: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:189
+#: pkg/storaged/index.html:565
+msgid "Off"
+msgstr "Вимкнено"
+
+#: pkg/lib/cockpit-components-dialog.jsx:155
+msgid "Ok"
 msgstr ""
+
+#: pkg/users/index.html:226 pkg/shell/index.html:248
+msgid "Old Password"
+msgstr "Старий пароль"
+
+#: pkg/users/local.js:78 pkg/lib/credentials.js:213
+msgid "Old password not accepted"
+msgstr "Старий пароль не прийнято"
+
+#: pkg/systemd/index.html:153 pkg/playground/jquery-patterns.html:91
+#: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:185
+#: pkg/storaged/index.html:564
+msgid "On"
+msgstr "Увімкнено"
+
+#: pkg/kubernetes/views/image-meta.html:7
+msgid "On Build"
+msgstr "Збирання"
+
+#: pkg/docker/index.html:568
+msgid "On Failure"
+msgstr "Якщо помилка"
+
+#: pkg/docker/util.js:104
+msgid "On failure, retry $0 time"
+msgid_plural "On failure, retry $0 times"
+msgstr[0] "Якщо помилка, повторити $0 раз"
+msgstr[1] "Якщо помилка, повторити $0 рази"
+msgstr[2] "Якщо помилка, повторити $0 разів"
+
+#: pkg/realmd/operation.html:71
+msgid "One Time Password"
+msgstr "Одноразовий пароль"
+
+#: pkg/systemd/init.js:1147
+msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
+msgstr ""
+
+#: pkg/shell/simple.html:28 pkg/shell/index.html:28 pkg/shell/stub.html:28
+msgid "Ooops!"
+msgstr "Вибачте!"
+
+#: pkg/systemd/index.html:89 pkg/ostree/index.html:111
+#: pkg/kubernetes/views/nodes-page.html:42
+msgid "Operating System"
+msgstr "Операційна система"
+
+#: pkg/ostree/index.html:186
+msgid "Operating System Updates"
+msgstr "Оновлення операційної системи"
+
+#: pkg/storaged/jobs.js:166
+msgid "Operation '$operation' on $target"
+msgstr "Дія «$operation» над $target"
+
+#: pkg/storaged/overview.js:189
+msgctxt "storage"
+msgid "Optical Drive"
+msgstr "Пристрій читання оптичних дисків"
+
+#: pkg/kubernetes/views/volume-body.html:130
+msgid "Options"
+msgstr "Параметри"
+
+#: pkg/subscriptions/subscriptions-register.jsx:176
+#, fuzzy
+msgid "Organization"
+msgstr "Переклад"
+
+#: pkg/storaged/details.js:1253
+msgctxt "storage-id-desc"
+msgid "Other Data"
+msgstr "Інші дані"
+
+#: pkg/storaged/index.html:202
+msgid "Other Devices"
+msgstr "Інші пристрої"
+
+#: pkg/docker/index.html:319 pkg/kubernetes/registry.html:42
+#: pkg/kubernetes/index.html:39
+msgid "Overview"
+msgstr "Огляд"
+
+#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
+msgid "Overwrite existing data with zeros"
+msgstr "Перезаписати наявні дані нулями"
+
+#: pkg/kubernetes/views/volume-body.html:4
+msgid "PD Name"
+msgstr "Назва PD"
+
+#: pkg/ostree/index.html:100
+msgid "Packages"
+msgstr "Пакунки"
+
+#: pkg/networkmanager/index.html:133
+msgid "Parent"
+msgstr "Батьківський"
+
+#: pkg/networkmanager/interfaces.js:2619
+msgid "Parent $parent"
+msgstr "Батьківський $parent"
+
+#: pkg/networkmanager/interfaces.js:1372
+msgid "Part of "
+msgstr "Є частиною "
+
+#: pkg/kubernetes/views/volume-body.html:8
+#: pkg/kubernetes/views/volume-body.html:18
+msgid "Partition"
+msgstr "Розділ"
+
+#: pkg/storaged/details.js:346
+msgid "Partitioning"
+msgstr "Розподіл"
+
+#: pkg/networkmanager/interfaces.js:1848
+msgid "Passive"
+msgstr ""
+
+#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
+msgid "Passphrase"
+msgstr "Пароль"
+
+#: pkg/storaged/details.js:224
+#, fuzzy
+msgid "Passphrase cannot be empty"
+msgstr "Пароль не може бути порожнім"
+
+#: pkg/storaged/details.js:232
+msgid "Passphrases do not match"
+msgstr "Паролі не збігаються"
+
+#: pkg/users/index.html:115 pkg/users/index.html:160 pkg/shell/index.html:199
+#: pkg/shell/index.html:212 pkg/kubernetes/views/auth-form.html:105
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+msgid "Password"
+msgstr "Пароль"
+
+#: pkg/users/local.js:259
+msgid "Password is not acceptable"
+msgstr "Пароль є неприйнятним"
+
+#: pkg/users/local.js:247
+msgid "Password is too weak"
+msgstr "Пароль є надто простим"
+
+#: pkg/lib/credentials.js:278
+msgid "Password not accepted"
+msgstr "Пароль не прийнято"
+
+#: pkg/kubernetes/views/pv-modify.html:126
+#: pkg/kubernetes/views/volume-body.html:37
+#: pkg/kubernetes/views/volume-body.html:49
+#: pkg/kubernetes/views/volume-body.html:101
+msgid "Path"
+msgstr "Шлях"
+
+#: pkg/networkmanager/index.html:259
+msgid "Path cost"
+msgstr "Вартість маршруту"
+
+#: pkg/networkmanager/interfaces.js:2601
+msgid "Path cost $path_cost"
+msgstr "Вартість шляху $path_cost"
+
+#: pkg/systemd/services.html:56
+msgid "Paths"
+msgstr "Шляхи"
+
+#: pkg/kubernetes/views/volumes-page.html:53
+msgid "Pending Volume Claims"
+msgstr "Заявки щодо томів у черзі"
+
+#: pkg/systemd/index.html:143
+msgid "Performance Profile"
+msgstr "Профіль швидкодії"
+
+#: pkg/kubernetes/views/volumes-page.html:14
+msgid "Persistent Volumes"
+msgstr "Сталі томи"
+
+#: pkg/kubernetes/views/pod-body.html:16
+msgid "Phase"
+msgstr "Фаза"
+
+#: pkg/storaged/index.html:641
+msgid "Physical Volumes"
+msgstr "Фізичні томи"
+
+#: pkg/networkmanager/index.html:405
+#, fuzzy
+msgid "Ping Interval"
+msgstr "Інтервал оновлення"
+
+#: pkg/networkmanager/index.html:414
+#, fuzzy
+msgid "Ping Target"
+msgstr "Призначення"
+
+#: pkg/docker/containers-view.jsx:166 pkg/docker/details.js:271
+#: pkg/docker/image.js:151 pkg/storaged/details.js:625
+#: pkg/storaged/details.js:821 pkg/storaged/details.js:1016
+msgid "Please confirm deletion of $0"
+msgstr "Будь ласка, підтвердьте вилучення $0"
+
+#: pkg/docker/util.js:501
+msgid "Please confirm forced deletion of $0"
+msgstr "Будь ласка, підтвердьте примусове вилучення $0"
+
+#: pkg/kubernetes/scripts/dashboard.js:441
+msgid "Please create another namespace for $0 \"$1\""
+msgstr "Будь ласка, створіть інший простір назв для $0 «$1»"
+
+#: pkg/kubernetes/scripts/volumes.js:574
+msgid "Please provide a GlusterFS volume name"
+msgstr "Будь ласка, вкажіть назву тому GlusterFS"
+
+#: pkg/kubernetes/scripts/connection.js:554
+msgid "Please provide a username"
+msgstr "Будь ласка, вкажіть ім’я користувача"
+
+#: pkg/kubernetes/scripts/volumes.js:632
+msgid "Please provide a valid NFS server"
+msgstr "Будь ласка, вкажіть коректний сервер NFS"
+
+#: pkg/kubernetes/scripts/connection.js:539
+msgid "Please provide a valid address"
+msgstr "Будь ласка, вкажіть коректну адресу"
+
+#: pkg/kubernetes/scripts/volumes.js:805
+msgid "Please provide a valid filesystem type"
+msgstr "Будь ласка, вкажіть коректний тип файлової системи"
+
+#: pkg/kubernetes/scripts/volumes.js:813
+msgid "Please provide a valid interface"
+msgstr "Будь ласка, вкажіть коректний інтерфейс"
+
+#: pkg/kubernetes/scripts/volumes.js:797
+msgid "Please provide a valid logical unit number"
+msgstr "Будь ласка, вкажіть коректну кількість логічних одиниць"
+
+#: pkg/kubernetes/scripts/volumes.js:477
+msgid "Please provide a valid name"
+msgstr "Будь ласка, вкажіть коректну назву"
+
+#: pkg/kubernetes/scripts/dashboard.js:376
+msgid "Please provide a valid namespace."
+msgstr "Будь ласка, вкажіть коректний простір назв."
+
+#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
+msgid "Please provide a valid path"
+msgstr "Будь ласка, вкажіть коректний шлях"
+
+#: pkg/kubernetes/scripts/volumes.js:789
+msgid "Please provide a valid qualified name"
+msgstr "Будь ласка, вкажіть коректну повну назву"
+
+#: pkg/kubernetes/scripts/volumes.js:485
+msgid "Please provide a valid storage capacity."
+msgstr "Будь ласка, вкажіть коректну місткість сховища."
+
+#: pkg/kubernetes/scripts/volumes.js:781
+msgid "Please provide a valid target"
+msgstr "Будь ласка, вкажіть коректне призначення"
+
+#: pkg/kubernetes/scripts/volumes.js:469
+msgid "Please select a valid access mode"
+msgstr "Будь ласка, виберіть коректний режим доступу"
+
+#: pkg/kubernetes/scripts/volumes.js:565
+msgid "Please select a valid endpoint"
+msgstr "Будь ласка, виберіть коректну кінцеву точку"
+
+#: pkg/kubernetes/scripts/volumes.js:493
+msgid "Please select a valid policy option."
+msgstr "Будь ласка, виберіть коректний варіант правил."
+
+#: pkg/kubernetes/scripts/nodes.js:397
+msgid "Please type an address"
+msgstr "Будь ласка, введіть адресу"
+
+#: pkg/kubernetes/views/pod-page.html:12
+#: pkg/kubernetes/views/containers-listing.html:12
+#: pkg/kubernetes/views/topology-page.html:14
+msgid "Pod"
+msgstr "Кокон"
+
+#: pkg/kubernetes/views/pod-body.html:20
+msgid "Pod Address"
+msgstr "Адреса коконів"
+
+#: pkg/kubernetes/views/service-endpoint.html:4
+#: pkg/kubernetes/views/service-endpoint.html:9
+msgid "Pod Endpoints"
+msgstr "Кінцеві точки коконів"
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:4
+msgid "Pod Replicated"
+msgstr "Створено репліку кокона"
+
+#: pkg/kubernetes/views/service-endpoint.html:15
+#: pkg/kubernetes/views/replicationcontroller-pods.html:11
+msgid "Pod Selector"
+msgstr "Вибір коконів"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:17
+#: pkg/kubernetes/views/dashboard-page.html:18
+#: pkg/kubernetes/views/details-page.html:166
+#: pkg/kubernetes/views/pv-claim.html:37
+#: pkg/kubernetes/views/replicationcontroller-panel.html:12
+msgid "Pods"
+msgstr "Кокони"
+
+#: pkg/kubernetes/views/topology-page.html:15
+#, fuzzy
+msgid ""
+"Pods contain one or more containers that run                together on a "
+"node, containing your application code."
+msgstr ""
+"Кокони містять один або декілька контейнерів, які працюють разом\n"
+"                на вузлі, де міститься код вашої програми."
+
+#: pkg/kubernetes/views/volume-body.html:60
+msgid "Pool Name"
+msgstr "Назва буфера"
+
+#: pkg/storaged/utils.js:166
+msgid "Pool for Thin Logical Volumes"
+msgstr "Буфер для тонких логічних томів"
+
+#: pkg/storaged/details.js:874
+msgid "Pool for thinly provisioned volumes"
+msgstr "Буфер для тонких резервованих томів"
+
+#: pkg/kubernetes/views/imagestream-modify.html:45
+msgid "Populate"
+msgstr "Заповнити"
+
+#: pkg/lib/machine-change-port.html:23
+msgid "Port"
+msgstr "Порт"
+
+#: pkg/docker/index.html:525 pkg/kubernetes/views/service-body.html:13
+#: pkg/kubernetes/views/image-config.html:23
+#: pkg/kubernetes/views/container-body.html:12
+#: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:373
+msgid "Ports"
+msgstr "Порти"
+
+#: pkg/systemd/index.html:123
+msgid "Power Options"
+msgstr "Параметри живлення"
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length"
+msgstr "Довжина префікса"
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length or Netmask"
+msgstr "Довжина префікса або маска мережі"
+
+#: pkg/networkmanager/interfaces.js:809
+msgid "Preparing"
+msgstr "Приготування"
+
+#: pkg/systemd/init.js:544
+msgid "Preset"
+msgstr "Шаблон"
+
+#: pkg/systemd/init.js:545
+msgid "Preset Forcefully"
+msgstr "Примусово початкові налаштування"
+
+#: pkg/systemd/index.html:310
+msgid "Pretty Host Name"
+msgstr "Зручна назва вузла"
+
+#: pkg/networkmanager/index.html:307
+msgid "Primary"
+msgstr "Основний"
+
+#: pkg/storaged/details.js:1426
+msgid "Primary Partition"
+msgstr "Основний розділ"
+
+#: pkg/networkmanager/index.html:250 pkg/networkmanager/index.html:446
+#: pkg/networkmanager/index.html:464
+msgid "Priority"
+msgstr "Пріоритетність"
+
+#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
+msgid "Priority $priority"
+msgstr "Пріоритетність $priority"
+
+#: pkg/subscriptions/subscriptions-view.jsx:33
+msgid "Product ID"
+msgstr "Ід. продукту"
+
+#: pkg/subscriptions/subscriptions-view.jsx:32
+msgid "Product name"
+msgstr "Назва продукту"
+
+#: pkg/kubernetes/views/service-body.html:4
+#: pkg/kubernetes/views/replicationcontroller-body.html:4
+#: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/imagestream-modify.html:21
+#: pkg/kubernetes/views/pod-body.html:4
+#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/details-page.html:35
+#: pkg/kubernetes/views/details-page.html:71
+#: pkg/kubernetes/views/details-page.html:104
+#: pkg/kubernetes/views/details-page.html:138
+#: pkg/kubernetes/views/details-page.html:172
+#: pkg/kubernetes/views/containers-listing.html:13
+#: pkg/kubernetes/views/route-body.html:4
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
+msgid "Project"
+msgstr "Проект"
+
+#: pkg/kubernetes/views/project-body.html:20
+msgid "Project Members"
+msgstr "Учасники проекту"
+
+#: pkg/kubernetes/views/filter-project.html:5
+msgid "Project:"
+msgstr "Проект:"
+
+#: pkg/kubernetes/registry.html:54 pkg/kubernetes/views/group-delete.html:10
+#: pkg/kubernetes/views/project-listing.html:9
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:84
+msgid "Projects"
+msgstr "Проекти"
+
+#: pkg/users/local.js:82
+msgid "Prompting via passwd timed out"
+msgstr "Час очікування відповіді на запит за допомогою passwd вичерпано"
+
+#: pkg/lib/credentials.js:251
+msgid "Prompting via ssh-add timed out"
+msgstr "Час очікування відповіді на запит за допомогою ssh-add вичерпано"
+
+#: pkg/lib/credentials.js:191
+msgid "Prompting via ssh-keygen timed out"
+msgstr "Час очікування відповіді на запит за допомогою ssh-keygen вичерпано"
+
+#: pkg/subscriptions/subscriptions-register.jsx:125
+msgid "Proxy"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:25
+msgid "Proxy Version"
+msgstr "Версія проксі"
+
+#: pkg/shell/index.html:198 pkg/lib/machine-auth-failed.html:9
+msgid "Public Key"
+msgstr "Відкритий ключ"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:150
+msgid "Pull an image:"
+msgstr "Отримати образ:"
+
+#: pkg/kubernetes/views/imagestream-modify.html:66
+msgid "Pull from"
+msgstr "Отримати з"
+
+#: pkg/kubernetes/views/imagestream-body.html:31
+msgid "Pull repository"
+msgstr "Отримати сховище"
+
+#: pkg/storaged/details.js:869
+msgid "Purpose"
+msgstr "Призначення"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:140
+msgid "Push an image:"
+msgstr "Вивантажити образ:"
+
+#: pkg/kubernetes/views/pv-modify.html:147
+#: pkg/kubernetes/views/volume-body.html:77
+msgid "Qualified Name"
+msgstr "Повна назва"
+
+#: pkg/storaged/details.js:1539
+msgid "RAID ($0)"
+msgstr "RAID ($0)"
+
+#: pkg/storaged/details.js:1533
+msgid "RAID 0"
+msgstr "RAID 0"
+
+#: pkg/storaged/overview.js:422
+msgid "RAID 0 (Stripe)"
+msgstr "RAID 0 (Стрічка)"
+
+#: pkg/storaged/details.js:1534
+msgid "RAID 1"
+msgstr "RAID 1"
+
+#: pkg/storaged/overview.js:423
+msgid "RAID 1 (Mirror)"
+msgstr "RAID 1 (Дзеркало)"
+
+#: pkg/storaged/details.js:1538
+msgid "RAID 10"
+msgstr "RAID 10"
+
+#: pkg/storaged/overview.js:427
+msgid "RAID 10 (Stripe of Mirrors)"
+msgstr "RAID 10 (Стрічка дзеркал)"
+
+#: pkg/storaged/details.js:1535
+msgid "RAID 4"
+msgstr "RAID 4"
+
+#: pkg/storaged/overview.js:424
+msgid "RAID 4 (Dedicated Parity)"
+msgstr "RAID 4 (Пов’язана парність)"
+
+#: pkg/storaged/details.js:1536
+msgid "RAID 5"
+msgstr "RAID 5"
+
+#: pkg/storaged/overview.js:425
+msgid "RAID 5 (Distributed Parity)"
+msgstr "RAID 5 (Розподілена парність)"
+
+#: pkg/storaged/details.js:1537
+msgid "RAID 6"
+msgstr "RAID 6"
+
+#: pkg/storaged/overview.js:426
+msgid "RAID 6 (Double Distributed Parity)"
+msgstr "RAID 6 (Подвійна розподілена парність)"
+
+#: pkg/storaged/index.html:537
+msgid "RAID Device"
+msgstr "пристрій RAID"
+
+#: pkg/storaged/utils.js:233
+msgid "RAID Device $0"
+msgstr "Пристій RAID $0"
+
+#: pkg/storaged/index.html:65
+msgid "RAID Devices"
+msgstr "Пристрої RAID"
+
+#: pkg/storaged/overview.js:420
+msgid "RAID Level"
+msgstr "Рівень RAID"
+
+#: pkg/storaged/index.html:555
+msgctxt "storage"
+msgid "RAID Level"
+msgstr "Рівень RAID:"
+
+#: pkg/storaged/details.js:1228
+msgctxt "storage-id-desc"
+msgid "RAID Member"
+msgstr "Елемент RAID"
+
+#: pkg/kubernetes/scripts/volumes.js:200
+msgid "Rados Block Device"
+msgstr "Блоковий пристрій Rados"
+
+#: pkg/kubernetes/views/pv-modify.html:194
+#: pkg/kubernetes/views/volume-body.html:10
+#: pkg/kubernetes/views/volume-body.html:20
+#: pkg/kubernetes/views/volume-body.html:44
+#: pkg/kubernetes/views/volume-body.html:51
+#: pkg/kubernetes/views/volume-body.html:71
+#: pkg/kubernetes/views/volume-body.html:85
+#: pkg/kubernetes/views/volume-body.html:93
+#: pkg/kubernetes/views/volume-body.html:110
+#: pkg/kubernetes/views/volume-body.html:122
+#: pkg/kubernetes/views/volume-body.html:136
+#: pkg/kubernetes/views/volume-body.html:143
+msgid "Read Only"
+msgstr "Лише читання"
+
+#: pkg/kubernetes/scripts/volumes.js:211
+msgid "Read and write from a single node"
+msgstr "Читання і запис із одного вузла"
+
+#: pkg/kubernetes/scripts/volumes.js:213
+msgid "Read and write from multiple nodes"
+msgstr "Читання і запис із декількох вузлів"
+
+#: pkg/kubernetes/scripts/volumes.js:212
+msgid "Read only from multiple nodes"
+msgstr "Читання лише з декількох вузлів"
+
+#: pkg/docker/index.html:385
+msgid "ReadOnly"
+msgstr "Лише запис"
+
+#: pkg/docker/index.html:384
+msgid "ReadWrite"
+msgstr "Запис-читання"
+
+#: pkg/storaged/index.html:327
+msgid "Reading"
+msgstr "Читання"
+
+#: pkg/playground/translate.html:20 pkg/playground/translate.html:179
+#: pkg/kubernetes/views/details-page.html:52
+#: pkg/kubernetes/views/node-body.html:41
+msgid "Ready"
+msgstr "Готовий"
+
+#: pkg/playground/translate.html:25
+#, fuzzy
+msgctxt "verb"
+msgid "Ready"
+msgstr "Готовий"
+
+#: pkg/systemd/index.html:319
+msgid "Real Host Name"
+msgstr "Справжня назва вузла"
+
+#: pkg/kubernetes/views/node-body.html:45
+msgid "Reason"
+msgstr "Підстава"
+
+#: pkg/lib/journal.js:241
+msgid "Reboot"
+msgstr "Перезавантажити"
+
+#: pkg/networkmanager/index.html:75 pkg/networkmanager/index.html:98
+#: pkg/networkmanager/index.html:116 pkg/networkmanager/index.html:521
+#: pkg/networkmanager/index.html:551
+msgid "Receiving"
+msgstr "Отримання"
+
+#: pkg/ostree/client.js:56
+msgid "Receiving delta parts"
+msgstr "Отримуємо частини відмінностей"
+
+#: pkg/ostree/client.js:58
+msgid "Receiving metadata objects"
+msgstr "Отримуємо об’єкти метаданих"
+
+#: pkg/ostree/client.js:61
+msgid "Receiving objects: $0%"
+msgstr "Отримуємо об’єкти: $0%"
+
+#: pkg/systemd/logs.html:40
+msgid "Recent"
+msgstr "Нещодавні"
+
+#: pkg/kubernetes/views/pv-modify.html:56 pkg/kubernetes/views/pv-body.html:6
+msgid "Reclaim Policy"
+msgstr "Правила повторного заявлення"
+
+#: pkg/shell/simple.html:144 pkg/shell/index.html:327 pkg/shell/stub.html:180
+msgid "Reconnect"
+msgstr "Повторно з’єднатися"
+
+#: pkg/storaged/details.js:1594
+msgid "Recovering"
+msgstr "Відновлюємо"
+
+#: pkg/storaged/jobs.js:145
+#, fuzzy
+msgid "Recovering RAID Device $target"
+msgstr "Зупиняємо пристрій RAID $target"
+
+#: pkg/kubernetes/scripts/volumes.js:219
+msgid "Recycle"
+msgstr "Повторний цикл"
 
 #: pkg/docker/storage.jsx:348
 msgid "Reformat and add disks"
 msgstr ""
 
-#: pkg/docker/storage.jsx:355
-msgid ""
-"The storage pool will be reset to optimize its layout.  All containers will "
-"be erased."
-msgstr ""
+#: pkg/kubernetes/views/pv-modify.html:205
+msgid "Register"
+msgstr "Зареєструвати"
 
-#: pkg/docker/storage.jsx:360
-msgid "Erase containers, reformat disks, and add them"
-msgstr ""
+#: pkg/kubernetes/views/volumes-page.html:12
+msgid "Register New Volume"
+msgstr "Зареєструвати новий том"
 
-#: pkg/docker/storage.jsx:363
+#: pkg/kubernetes/views/pv-modify.html:4
+msgid "Register Persistent Volume"
+msgstr "Зареєструвати сталий том"
+
+#: pkg/subscriptions/main.js:74
+msgid "Register system"
+msgstr "Зареєструвати систему"
+
+#: pkg/ostree/index.html:115
+msgid "Released"
+msgstr "Випущено"
+
+#: pkg/systemd/init.js:518
+msgid "Reload"
+msgstr "Перезавантажити"
+
+#: pkg/systemd/init.js:519
+msgid "Reload or Restart"
+msgstr "Перезавантажити або перезапустити"
+
+#: pkg/systemd/init.js:521
+msgid "Reload or Try Restart"
+msgstr "Перезавантажити або спробувати перезапустити"
+
+#: pkg/kubernetes/views/imagestream-modify.html:89
+msgid "Remote registry is insecure"
+msgstr "Віддалений реєстр є незахищеним"
+
+#: cockpit.desktop.in.h:3
+msgid "Remote;Administration;"
+msgstr "віддалене;адміністрування;"
+
+#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
+msgctxt "storage"
+msgid "Removable Drive"
+msgstr "Портативний диск"
+
+#: pkg/ostree/index.html:123 pkg/ostree/index.html:146
+msgid "Removals"
+msgstr "Вилучення"
+
+#: pkg/kubernetes/views/user-group-remove.html:10
+#: pkg/kubernetes/views/group-delete.html:21
+#: pkg/kubernetes/views/user-delete.html:25
+#: pkg/kubernetes/views/remove-role-dialog.html:8
+msgid "Remove"
+msgstr "Вилучити"
+
+#: pkg/networkmanager/interfaces.js:2791
 #, fuzzy
-msgid "Add Additional Storage"
-msgstr "Додаткове сховище"
+msgid "Remove $0"
+msgstr "Вилучити"
 
-#: pkg/docker/storage.jsx:366
-msgid ""
-"All data on selected disks will be erased and disks will be added to the "
-"storage pool."
+#: pkg/kubernetes/views/group-delete.html:3
+msgid "Remove Group"
+msgstr "Вилучити групу"
+
+#: pkg/kubernetes/views/user-group-remove.html:3
+msgid "Remove Member"
+msgstr "Вилучити члена"
+
+#: pkg/kubernetes/views/remove-role-dialog.html:3
+msgid "Remove Role"
+msgstr "Вилучити роль"
+
+#: pkg/kubernetes/views/user-delete.html:3
+msgid "Remove User"
+msgstr "Вилучити користувача"
+
+#: pkg/kubernetes/views/image-delete.html:3
+msgid "Remove image tag"
+msgstr "Вилучити мітку образу"
+
+#: pkg/kubernetes/views/user-remove-membership.html:3
+msgid "Remove membership"
+msgstr "Вилучити запис участі"
+
+#: pkg/storaged/jobs.js:141
+msgid "Removing $target from RAID Device"
+msgstr "Вилучаємо $target з пристрою RAID"
+
+#: pkg/networkmanager/interfaces.js:2788
+msgid "Removing <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/docker/storage.jsx:404
+#: pkg/storaged/jobs.js:154
+msgid "Removing physical volume from $target"
+msgstr "Вилучаємо фізичний том з $target"
+
+#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
+#: pkg/storaged/details.js:1775
+msgid "Rename"
+msgstr "Перейменувати"
+
+#: pkg/storaged/details.js:795
+msgid "Rename Volume Group"
+msgstr "Перейменувати групу томів"
+
+#: pkg/storaged/details.js:706
+msgid "Renamee Logical Volume"
+msgstr "Перейменувати логічний том"
+
+#: pkg/storaged/jobs.js:157
+msgid "Renaming $target"
+msgstr "Перейменовуємо $target"
+
+#: pkg/systemd/services.html:432
+msgid "Repeat Daily"
+msgstr ""
+
+#: pkg/systemd/services.html:431
+msgid "Repeat Hourly"
+msgstr ""
+
+#: pkg/systemd/services.html:434
+msgid "Repeat Monthly"
+msgstr ""
+
+#: pkg/systemd/services.html:433
+msgid "Repeat Weekly"
+msgstr ""
+
+#: pkg/systemd/services.html:435
+msgid "Repeat Yearly"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-body.html:9
+#: pkg/kubernetes/views/details-page.html:141
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
+#: pkg/kubernetes/views/replicationcontroller-modify.html:8
+msgid "Replicas"
+msgstr "Репліки"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:14
+#: pkg/kubernetes/views/replicationcontroller-panel.html:10
+#: pkg/kubernetes/views/topology-page.html:23
+msgid "Replication Controller"
+msgstr "Контролер реплікації"
+
+#: pkg/kubernetes/views/details-page.html:132
+msgid "Replication Controllers"
+msgstr "Керування реплікацією"
+
+#: pkg/kubernetes/views/topology-page.html:24
 #, fuzzy
-msgid "Could not add all disks"
-msgstr "Не вдалося побудувати список служб"
+msgid ""
+"Replication controllers dynamically create instances of                pods "
+"from templates, and remove pods when necessary."
+msgstr ""
+"Контролери реплікації динамічно створюють екземпляри\n"
+"                коконів із шаблонів і вилучають кокони, якщо потрібно."
+
+#: pkg/docker/index.html:718
+msgid "Repository"
+msgstr "Сховище"
+
+#: pkg/kubernetes/views/volume-body.html:24
+msgid "Repository URL"
+msgstr "Адреса сховища"
+
+#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
+msgid "Requested"
+msgstr "Запитано"
+
+#: pkg/kubernetes/views/pv-claim.html:13
+msgid "Requests"
+msgstr "Запити"
+
+#: pkg/kubernetes/views/auth-form.html:54
+msgid "Requires Authentication"
+msgstr "Потрібне розпізнавання"
+
+#: pkg/docker/index.html:323
+msgid "Reset"
+msgstr "Скинути"
 
 #: pkg/docker/storage.jsx:417
 #, fuzzy
@@ -2124,391 +4770,604 @@ msgid ""
 "the pool."
 msgstr ""
 
-#: pkg/docker/storage.jsx:423
-msgid "Erase containers and reset storage pool"
+#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
+msgid "Resize"
+msgstr "Змінити розмір"
+
+#: pkg/storaged/details.js:673
+msgid "Resize Filesystem"
+msgstr "Змінити розмір файлової системи"
+
+#: pkg/storaged/details.js:661
+msgid "Resize Logical Volume"
+msgstr "Змінити розмір логічного тому"
+
+#: pkg/storaged/jobs.js:158
+msgid "Resizing $target"
+msgstr "Зміна розміру $target"
+
+#: pkg/systemd/index.html:126 pkg/systemd/index.html:133
+msgid "Restart"
+msgstr "Перезапустити"
+
+#: pkg/kubernetes/views/container-body.html:20
+msgid "Restart Count"
+msgstr "Кількість перезапусків"
+
+#: pkg/docker/index.html:558 pkg/kubernetes/views/pod-body.html:10
+msgid "Restart Policy"
+msgstr "Правила перезапуску"
+
+#: pkg/kubernetes/scripts/volumes.js:217
+msgid "Retain"
+msgstr "Зберегти"
+
+#: pkg/docker/index.html:574
+msgid "Retries:"
+msgstr "Кількість спроб:"
+
+#: pkg/subscriptions/subscriptions-view.jsx:188
+msgid "Retrieving subscription status..."
 msgstr ""
 
-#: pkg/docker/storage.jsx:446
-msgid "Could not reset the storage pool"
-msgstr ""
-
-#: pkg/docker/storage.jsx:482
-#, fuzzy
-msgid "You don't have permission to manage the Docker storage pool."
-msgstr ""
-"У вас немає прав доступу для перегляду уповноважених відкритих ключів для "
-"цього облікового запису."
-
-#: pkg/docker/storage.jsx:485
-#, fuzzy
-msgid "The Docker storage pool cannot be managed on this system."
-msgstr "У цій системі програмний інтерфейс «storaged» є недоступним."
-
-#: pkg/docker/image.js:77
-msgid "Image $0"
-msgstr "Зображення $0"
-
-#: pkg/docker/image.js:152
-msgid ""
-"Deleting an image will delete it, but you can probably download it again if "
-"you need it later.  Unless this image has never been pushed to a repository, "
-"that is, in which case you probably can't download it again."
-msgstr ""
-"Вилучення образу призведе до його вилучення, але ви, ймовірно, зможете "
-"отримати його знову, якщо виникне потреба. Виключенням є випадок, коли образ "
-"ніколи не було записано до сховища. У цьому випадку ви, ймовірно, не зможете "
-"отримати образ знову."
-
-#: pkg/docker/util.js:94
-msgid "Up since $StartedAt"
-msgstr "Працює з $StartedAt"
-
-#: pkg/docker/util.js:96
-msgid "Exited $ExitCode"
-msgstr "Завершено $ExitCode"
-
-#: pkg/docker/util.js:104
-msgid "On failure, retry $0 time"
-msgid_plural "On failure, retry $0 times"
-msgstr[0] "Якщо помилка, повторити $0 раз"
-msgstr[1] "Якщо помилка, повторити $0 рази"
-msgstr[2] "Якщо помилка, повторити $0 разів"
-
-#: pkg/docker/util.js:107 pkg/docker/index.html.h:48
-msgid "Always"
-msgstr "Завжди"
-
-#: pkg/docker/util.js:109 pkg/docker/index.html.h:49
-msgid "Unless Stopped"
-msgstr "Якщо не зупинено"
-
-#: pkg/docker/util.js:123
-msgid "default"
-msgstr "типовий"
-
-#: pkg/docker/util.js:124
-msgid "$0 shares"
-msgstr "$0 спільних ресурсів"
-
-#: pkg/docker/util.js:231
-msgid "Stopped"
-msgstr "Зупинено"
-
-#: pkg/docker/util.js:488
-msgid "Container is currently running."
-msgstr "Контейнер працює."
-
-#: pkg/docker/util.js:490
-msgid ""
-"Container is currently marked as not running, but regular stopping failed."
-msgstr ""
-"Зараз контейнер позначено як такий, що працює, але звичайна спроба зупинити "
-"роботу зазнала невдачі."
-
-#: pkg/docker/util.js:491
-msgid "Error message from Docker:"
-msgstr "Повідомлення щодо помилки від Docker:"
-
-#: pkg/docker/util.js:501
-msgid "Please confirm forced deletion of $0"
-msgstr "Будь ласка, підтвердьте примусове вилучення $0"
-
-#: pkg/docker/util.js:503
-msgid "Force Delete"
-msgstr "Примусове вилучення"
-
-#: pkg/docker/util.js:544
-msgid "Failed to stop Docker scope: $0"
-msgstr "Не вдалося зупинити область Docker: $0"
-
-#: pkg/docker/containers-view.jsx:239
-#, fuzzy
-msgid "Commit"
-msgstr "Коментар"
-
-#: pkg/docker/containers.js:64
-msgid "Failed to start Docker: $0"
-msgstr "Не вдалося запустити Docker: $0"
-
-#: pkg/users/authorized-keys.js:103
-msgid "Validating key"
-msgstr "Перевірка ключа"
-
-#: pkg/users/authorized-keys.js:108
-msgid "Adding key"
-msgstr "Додавання ключа"
-
-#: pkg/users/authorized-keys.js:115
-msgid "Error saving authorized keys: "
-msgstr "Помилка під час спроби зберегти уповноважені ключі: "
-
-#: pkg/users/authorized-keys.js:118
-msgid "The key you provided was not valid."
-msgstr "Наданий вами ключ є некоректним."
-
-#: pkg/users/local.js:40
-msgid "The user <b>$0</b> is not permitted to modify accounts"
-msgstr "Користувачу <b>$0</b> заборонено змінювати облікові записи"
-
-#: pkg/users/local.js:57
-msgid "Unable to delete root account"
-msgstr "Неможливо вилучити обліковий запис root"
-
-#: pkg/users/local.js:59
-msgid "Unable to rename root account"
-msgstr "Неможливо перейменувати обліковий запис root"
-
-#: pkg/users/local.js:82
-msgid "Prompting via passwd timed out"
-msgstr "Час очікування відповіді на запит за допомогою passwd вичерпано"
-
-#: pkg/users/local.js:247
-msgid "Password is too weak"
-msgstr "Пароль є надто простим"
-
-#: pkg/users/local.js:259
-msgid "Password is not acceptable"
-msgstr "Пароль є неприйнятним"
-
-#: pkg/users/local.js:284 pkg/users/local.js:594
-msgctxt "page-title"
-msgid "Accounts"
-msgstr "Облікові записи"
-
-#: pkg/users/local.js:395 pkg/users/local.js:1082
-msgid "The passwords do not match"
-msgstr "Паролі не збігаються"
-
-#: pkg/users/local.js:400
-msgid "No user name specified"
-msgstr "Не вказано імені користувача"
-
-#: pkg/users/local.js:405
-msgid "No real name specified"
-msgstr "Не вказано справжнього імені"
-
-#: pkg/users/local.js:429 pkg/users/local.js:1104
-msgid "Excellent password"
-msgstr "Чудовий пароль"
-
-#: pkg/users/local.js:501
-msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
-msgstr ""
-"Ім’я користувача може складатися лише із літер a-z, цифр, крапок, дефісів та "
-"символів підкреслювання."
-
-#: pkg/users/local.js:509
-msgid "This user name already exists"
-msgstr "Запис користувача із таким іменем уже існує"
-
-#: pkg/users/local.js:682 pkg/users/local.js:683
-msgid "Server Administrator"
-msgstr "Адміністратор сервера"
-
-#: pkg/users/local.js:684
-msgid "Container Administrator"
-msgstr "Адміністратор контейнера"
-
-#: pkg/users/local.js:839
-msgid "Logged In"
-msgstr "Вхід"
-
-#: pkg/users/local.js:841
-msgid "Never"
-msgstr "Ніколи"
-
-#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
-msgid "Delete $0"
-msgstr "Вилучити $0"
-
-#: pkg/sosreport/index.js:49 pkg/sosreport/index.js:113
-#: pkg/systemd/services.html.h:13 pkg/lib/machine-invalid-hostkey.html.h:4
-#: pkg/lib/machine-auth-failed.html.h:7
-#: pkg/lib/machine-unknown-hostkey.html.h:4
-#: pkg/lib/machine-change-port.html.h:8 pkg/lib/machine-not-supported.html.h:3
-#: pkg/shell/index.html.h:37
-msgid "Close"
-msgstr "Закрити"
-
-#: pkg/sosreport/index.js:115
-msgid "No archive has been created."
-msgstr "Архів не було створено."
-
-#: pkg/networkmanager/interfaces.js:598 pkg/networkmanager/interfaces.js:1051
-#: pkg/networkmanager/interfaces.js:2255 pkg/networkmanager/interfaces.js:2257
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:753 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/kubernetes/views/node-body.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:6
-#: pkg/kubernetes/views/pv-claim.html.h:7
-#: pkg/kubernetes/views/image-body.html.h:6
-#: pkg/kubernetes/views/pv-body.html.h:5
-msgid "Unknown"
-msgstr "Невідомий"
-
-#: pkg/networkmanager/interfaces.js:805
-msgid "Not available"
-msgstr "Недоступний"
-
-#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
-#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
-msgid "Inactive"
-msgstr "Неактивний"
-
-#: pkg/networkmanager/interfaces.js:809
-msgid "Preparing"
-msgstr "Приготування"
-
-#: pkg/networkmanager/interfaces.js:811
-msgid "Configuring"
-msgstr "Налаштовування"
-
-#: pkg/networkmanager/interfaces.js:813
-msgid "Authenticating"
-msgstr "Автентифікація"
-
-#: pkg/networkmanager/interfaces.js:815
-msgid "Configuring IP"
-msgstr "Налаштовуємо IP"
-
-#: pkg/networkmanager/interfaces.js:817
-msgid "Checking IP"
-msgstr "Перевіряємо IP"
-
-#: pkg/networkmanager/interfaces.js:819
-msgid "Waiting"
-msgstr "Очікування"
-
-#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
-msgid "Active"
-msgstr "Активний"
-
-#: pkg/networkmanager/interfaces.js:823
-msgid "Deactivating"
-msgstr "Деактивація"
-
-#: pkg/networkmanager/interfaces.js:825 pkg/ostree/index.html.h:14
-msgid "Failed"
-msgstr "Помилка"
-
-#: pkg/networkmanager/interfaces.js:1326
-msgid "No carrier"
-msgstr "Немає сигналу"
-
-#: pkg/networkmanager/interfaces.js:1372
-msgid "Part of "
-msgstr "Є частиною "
-
-#: pkg/networkmanager/interfaces.js:1420
-msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr "Користувачу <b>$0</b> заборонено змінювати параметри роботи мережі"
-
-#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
-msgctxt "page-title"
-msgid "Networking"
-msgstr "Робота у мережі"
-
-#: pkg/networkmanager/interfaces.js:1804
-msgid "Automatic (DHCP)"
-msgstr "Автоматично (DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
-msgid "Link local"
-msgstr "Пов’язати локальний"
-
-#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
-msgid "Manual"
-msgstr "Вручну"
-
-#: pkg/networkmanager/interfaces.js:1807
-msgid "Shared"
-msgstr "Спільний"
-
-#: pkg/networkmanager/interfaces.js:1813 pkg/networkmanager/interfaces.js:2475
-#: pkg/networkmanager/interfaces.js:3019 pkg/networkmanager/interfaces.js:3023
-#: pkg/networkmanager/interfaces.js:3029 pkg/networkmanager/index.html.h:22
-msgid "Automatic"
-msgstr "Автоматично"
-
-#: pkg/networkmanager/interfaces.js:1814
-msgid "Automatic (DHCP only)"
-msgstr "Автоматично (лише DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1817
-msgid "Ignore"
-msgstr "Ігнорувати"
+#: pkg/kubernetes/views/volume-body.html:26
+msgid "Revision"
+msgstr "Модифікація"
+
+#: pkg/users/index.html:94 pkg/kubernetes/views/add-member-role-dialog.html:39
+#: pkg/kubernetes/views/project-body.html:21
+msgid "Roles"
+msgstr "Ролі"
+
+#: pkg/ostree/index.html:73
+msgid "Roll back and reboot"
+msgstr "Відкотити і перезавантажити"
 
 #: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
 msgid "Round Robin"
 msgstr "Циклічне"
 
-#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
-msgid "Active Backup"
-msgstr "Активне резервування"
+#: pkg/kubernetes/views/route-page.html:14
+#: pkg/kubernetes/views/route-panel.html:9
+msgid "Route"
+msgstr "Маршрут"
 
-#: pkg/networkmanager/interfaces.js:1824
-msgid "XOR"
-msgstr "XOR"
+#: pkg/kubernetes/views/details-page.html:65
+msgid "Routes"
+msgstr "Маршрути"
 
-#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
-msgid "Broadcast"
-msgstr "Трансляція"
-
-#: pkg/networkmanager/interfaces.js:1826
-msgid "802.3ad"
-msgstr "802.3ad"
-
-#: pkg/networkmanager/interfaces.js:1827
-msgid "Adaptive transmit load balancing"
-msgstr "Адаптивне урівноваження навантаження за передаванням"
-
-#: pkg/networkmanager/interfaces.js:1828
-msgid "Adaptive load balancing"
-msgstr "Адаптивне урівноваження навантаження"
-
-#: pkg/networkmanager/interfaces.js:1833
-msgid "MII (Recommended)"
-msgstr "MII (рекомендоване)"
-
-#: pkg/networkmanager/interfaces.js:1834
-msgid "ARP"
-msgstr "ARP"
-
-#: pkg/networkmanager/interfaces.js:1841
+#: pkg/systemd/services.html:384
 #, fuzzy
-msgid "Load Balancing"
-msgstr "Адаптивне урівноваження навантаження"
+msgid "Run"
+msgstr "Запустити від імені"
 
-#: pkg/networkmanager/interfaces.js:1843
+#: pkg/kubernetes/views/image-config.html:4
+msgid "Run as"
+msgstr "Запустити від імені"
+
+#: pkg/networkmanager/index.html:381
 #, fuzzy
-msgid "802.3ad LACP"
-msgstr "802.3ad"
+msgid "Runner"
+msgstr "Працює"
 
-#: pkg/networkmanager/interfaces.js:1848
-msgid "Passive"
+#: pkg/ostree/index.html:83
+msgid "Running"
+msgstr "Працює"
+
+#: pkg/selinux/setroubleshoot-view.jsx:478
+msgid "SELinux Access Control Errors"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1854
-msgid "Ethtool"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1855
+#: pkg/selinux/setroubleshoot-view.jsx:330
 #, fuzzy
-msgid "ARP Ping"
-msgstr "Стеження за ARP"
+msgid "SELinux Policy"
+msgstr "Правило DNS"
 
-#: pkg/networkmanager/interfaces.js:1856
-msgid "NSNA Ping"
+#: pkg/selinux/setroubleshoot.html:23
+msgid "SELinux Troubleshoot"
+msgstr "Усування вад SELinux"
+
+#: pkg/selinux/setroubleshoot-view.jsx:317
+#, fuzzy
+msgid "SELinux is disabled on the system."
+msgstr "Cockpit у цій системі не встановлено."
+
+#: pkg/selinux/setroubleshoot-view.jsx:309
+msgid "SELinux system status is unknown."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2156
-msgid "Deleting <b>$0</b> will break the connection to the server, "
+#: pkg/storaged/jobs.js:119
+msgid "SMART self-test of $target"
+msgstr "Самоперевірка SMART $target"
+
+#: pkg/networkmanager/index.html:218
+msgid "STP Forward delay"
+msgstr "Затримка переспрямування STP"
+
+#: pkg/networkmanager/index.html:227
+msgid "STP Hello time"
+msgstr "Час вітання STP"
+
+#: pkg/networkmanager/index.html:236
+msgid "STP Maximum message age"
+msgstr "Максимальний вік повідомлення STP"
+
+#: pkg/networkmanager/index.html:209
+msgid "STP Priority"
+msgstr "Пріоритет STP"
+
+#: pkg/systemd/services.html:466
+msgid "Save"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2188
-msgid "Switching on <b>$0</b>  will break the connection to the server, "
+#: pkg/ostree/client.js:66
+msgid "Scanning metadata"
+msgstr "Скануємо метадані"
+
+#: pkg/kubernetes/views/node-capacity.html:9
+msgid "Scheduled Pods"
+msgstr "Заплановані кокони"
+
+#: pkg/kubernetes/scripts/nodes.js:322
+msgid "Scheduling Disabled"
+msgstr "Планування вимкнено"
+
+#: pkg/systemd/services.html:402 pkg/systemd/services.html:406
+msgid "Seconds"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:195
+msgid "Secret"
+msgstr "Секретний"
+
+#: pkg/kubernetes/views/volume-body.html:106
+msgid "Secret File"
+msgstr "Файл ключа"
+
+#: pkg/kubernetes/views/volume-body.html:141
+msgid "Secret Name"
+msgstr "Назва ключа"
+
+#: pkg/kubernetes/views/volume-body.html:69
+#: pkg/kubernetes/views/volume-body.html:108
+#: pkg/kubernetes/views/volume-body.html:134
+msgid "Secret Volume"
+msgstr "Секретний том"
+
+#: pkg/systemd/index.html:93
+msgid "Secure Shell Keys"
+msgstr "Ключі захищеної оболонки (SSH)"
+
+#: pkg/storaged/jobs.js:136
+msgid "Securely erasing $target"
+msgstr "Безпечно витираємо $target"
+
+#: pkg/kubernetes/views/file-button.html:4
+msgid "Select Manifest File..."
+msgstr "Вибір файла маніфесту…"
+
+#: pkg/kubernetes/views/topology-page.html:7
+msgid "Select an object to see more details."
+msgstr "Виберіть об’єкт для перегляду ширшого спектра параметрів."
+
+#: pkg/lib/machine-sync-users.html:8
+msgid ""
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
+msgstr ""
+"Виберіть користувачів, записи яких ви б хотіли синхронізувати з {{#strong}}"
+"{{host}}{{/strong}}"
+
+#: pkg/networkmanager/index.html:69 pkg/networkmanager/index.html:97
+#: pkg/networkmanager/index.html:115 pkg/networkmanager/index.html:515
+#: pkg/networkmanager/index.html:550
+msgid "Sending"
+msgstr "Надсилання"
+
+#: pkg/storaged/index.html:432
+msgctxt "storage"
+msgid "Serial Number"
+msgstr "Серійний номер"
+
+#: pkg/kubernetes/views/pv-modify.html:82
+#: pkg/kubernetes/views/volume-body.html:47
+msgid "Server"
+msgstr "Сервер"
+
+#: pkg/storaged/overview.js:518
+msgid "Server Address"
+msgstr "Адреса сервера"
+
+#: pkg/users/local.js:682 pkg/users/local.js:683
+msgid "Server Administrator"
+msgstr "Адміністратор сервера"
+
+#: pkg/storaged/overview.js:521
+#, fuzzy
+msgid "Server address cannot be empty."
+msgstr "Адреса сервера не може бути порожньою."
+
+#: src/base1/cockpit.js:3709
+msgid "Server has closed the connection."
+msgstr "З’єднання розірвано сервером."
+
+#: pkg/kubernetes/views/service-page.html:12
+#: pkg/kubernetes/views/service-panel.html:8
+#: pkg/kubernetes/views/topology-page.html:32
+msgid "Service"
+msgstr "Служба"
+
+#: pkg/kubernetes/views/pod-body.html:12
+msgid "Service Account"
+msgstr "Обліковий запис служби"
+
+#: pkg/systemd/services.html:279
+msgid "Service Logs"
+msgstr "Журнали служб"
+
+#: pkg/systemd/services.html:342
+#, fuzzy
+msgid "Service name"
+msgstr "Служба"
+
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:272
+#: pkg/kubernetes/views/dashboard-page.html:134
+#: pkg/kubernetes/views/details-page.html:29
+msgid "Services"
+msgstr "Служби"
+
+#: pkg/kubernetes/views/topology-page.html:33
+#, fuzzy
+msgid ""
+"Services group pods and provide a common DNS                name and an "
+"optional, load-balanced IP address to access them."
+msgstr ""
+"Служби збирають у групи кокони і надають загальну назву DNS\n"
+"                та додаткову, збалансовану за навантаженням IP-адресу для "
+"доступу до них."
+
+#: pkg/kubernetes/views/service-body.html:20
+msgid "Session Affinity"
+msgstr "Спорідненість сеансу"
+
+#: pkg/dashboard/index.html:190
+msgid "Set"
+msgstr "Встановити"
+
+#: pkg/systemd/host.js:559
+msgid "Set Host name"
+msgstr "Встановити назву вузла"
+
+#: pkg/users/index.html:117 pkg/users/index.html:221
+msgid "Set Password"
+msgstr "Встановити пароль"
+
+#: pkg/systemd/index.html:395
+msgid "Set Time"
+msgstr "Встановити час"
+
+#: pkg/docker/index.html:551
+msgid "Set container environment variables"
+msgstr "Встановити змінні середовища контейнера"
+
+#: pkg/networkmanager/index.html:172
+msgid "Set to"
+msgstr "Встановити значення"
+
+#: pkg/selinux/setroubleshoot-view.jsx:326
+msgid ""
+"Setting deviates from the configured state and will revert on the next boot."
+msgstr ""
+
+#: pkg/storaged/jobs.js:131
+msgid "Setting up loop device $target"
+msgstr "Налаштовуємо петльовий пристрій $target"
+
+#: pkg/kubernetes/views/volume-body.html:139
+msgid "Share Name"
+msgstr "Назва ресурсу"
+
+#: pkg/networkmanager/interfaces.js:1807
+msgid "Shared"
+msgstr "Спільний"
+
+#: pkg/kubernetes/views/container-panel.html:9
+#: pkg/kubernetes/views/container-page-inline.html:14
+msgid "Shell"
+msgstr "Оболонка"
+
+#: pkg/kubernetes/views/container-page.html:4
+msgid "Show all Containers"
+msgstr "Показати усі контейнери"
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:8
+msgid "Show all Deployment Configs"
+msgstr "Показати усі налаштування розгортання"
+
+#: pkg/kubernetes/views/node-page.html:8
+msgid "Show all Nodes"
+msgstr "Показати усі вузли"
+
+#: pkg/kubernetes/views/pv-page.html:9
+msgid "Show all Persistent Volumes"
+msgstr "Показати усі сталі томи"
+
+#: pkg/kubernetes/views/pod-container.html:4
+msgid "Show all Pod Containers"
+msgstr "Показати усі контейнери коконів"
+
+#: pkg/kubernetes/views/pod-page.html:8
+msgid "Show all Pods"
+msgstr "Показати усі кокони"
+
+#: pkg/kubernetes/views/user-page.html:16
+#: pkg/kubernetes/views/group-page.html:14
+#: pkg/kubernetes/views/project-page.html:23
+msgid "Show all Projects"
+msgstr "Показати усі проекти"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:10
+msgid "Show all Replication Controllers"
+msgstr "Показати усі контролери реплікації"
+
+#: pkg/kubernetes/views/route-page.html:10
+msgid "Show all Routes"
+msgstr "Показати усі маршрути"
+
+#: pkg/kubernetes/views/service-page.html:8
+msgid "Show all Services"
+msgstr "Показувати всі служби"
+
+#: pkg/docker/index.html:127
+#, fuzzy
+msgid "Show all containers"
+msgstr "Показати усі контейнери"
+
+#: pkg/kubernetes/views/imagestream-page.html:12
+msgid "Show all image streams"
+msgstr "Показати усіх потоки образів"
+
+#: pkg/docker/index.html:241 pkg/kubernetes/views/image-page.html:11
+msgid "Show all images"
+msgstr "Показати усі образи"
+
+#: pkg/systemd/index.html:94
+msgid "Show fingerprints"
+msgstr "Показати відбитки"
+
+#: pkg/systemd/index.html:136
+msgid "Shutdown"
+msgstr "Вимкнути"
+
+#: pkg/kubernetes/views/container-body.html:18
+msgid "Since"
+msgstr "З"
+
+#: pkg/systemd/init.js:621
+msgid "Since $0"
+msgstr "З $0"
+
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/storaged/index.html:232
+msgid "Size"
+msgstr "Розмір"
+
+#: pkg/storaged/dialog.js:271
+#, fuzzy
+msgid "Size cannot be negative"
+msgstr "Розмір не може бути від’ємним"
+
+#: pkg/storaged/dialog.js:269
+#, fuzzy
+msgid "Size cannot be zero"
+msgstr "Розмір не може бути нульовим"
+
+#: pkg/storaged/dialog.js:273
+msgid "Size is too large"
+msgstr "Розмір є надто великим"
+
+#: pkg/storaged/dialog.js:267
+msgid "Size must be a number"
+msgstr "Розмір має бути числом"
+
+#: pkg/kubernetes/views/auth-form.html:43
+#: pkg/kubernetes/views/auth-rejected-cert.html:11
+msgid "Skip Certificate Verification"
+msgstr "Пропустити перевірку сертифікатів"
+
+#: pkg/systemd/services.html:54
+msgid "Sockets"
+msgstr "Сокети"
+
+#: pkg/ostree/index.html:23
+msgid "Software Updates"
+msgstr "Оновлення програм"
+
+#: pkg/docker/storage.jsx:156
+#, fuzzy
+msgid "Solid-State Disk"
+msgstr "Твердотільний диск"
+
+#: pkg/storaged/overview.js:182
+msgctxt "storage"
+msgid "Solid-State Disk"
+msgstr "Твердотільний диск"
+
+#: pkg/selinux/setroubleshoot-view.jsx:90
+msgid "Solution applied successfully"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:97
+#, fuzzy
+msgid "Solution failed"
+msgstr "Невдала спроба увійти"
+
+#: pkg/kubernetes/scripts/volumes.js:908
+msgid "Sorry, I don't know how to modify this volume"
+msgstr "Вибачте, спосіб внесення змін до цього тому невідомий"
+
+#: pkg/kubernetes/views/image-body.html:8
+msgid "Source URL"
+msgstr "Початкова адреса"
+
+#: pkg/networkmanager/interfaces.js:2573
+msgid "Spanning Tree Protocol"
+msgstr "Протокол пересування ієрархією"
+
+#: pkg/networkmanager/index.html:200
+msgid "Spanning Tree Protocol (STP)"
+msgstr "Протокол пересування ієрархією (STP)"
+
+#: pkg/storaged/details.js:1594
+msgid "Spare"
+msgstr "Запас"
+
+#: pkg/systemd/index.html:470
+msgid "Specific Time"
+msgstr "У визначений час"
+
+#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
+msgid "Start"
+msgstr "Почати"
+
+#: pkg/docker/index.html:68
+msgid "Start Docker"
+msgstr "Запустити Docker"
+
+#: pkg/storaged/index.html:49
+msgid "Start Multipath"
+msgstr "Запустити Multipath"
+
+#: pkg/storaged/details.js:1614
+msgid "Start Scrubbing"
+msgstr "Почати витирання"
+
+#: pkg/storaged/jobs.js:139
+msgid "Starting RAID Device $target"
+msgstr "Зупиняємо пристрій RAID $target"
+
+#: pkg/storaged/jobs.js:124
+msgid "Starting swapspace $target"
+msgstr "Запускаємо резервну область пам’яті $target"
+
+#: pkg/subscriptions/subscriptions-view.jsx:37
+msgid "Starts"
+msgstr "Починається"
+
+#: pkg/kubernetes/views/container-body.html:16
+#: pkg/kubernetes/views/details-page.html:38
+#: pkg/kubernetes/views/details-page.html:175
+msgid "State"
+msgstr "Стан"
+
+#: pkg/storaged/index.html:571
+msgctxt "storage"
+msgid "State"
+msgstr "Стан"
+
+#: pkg/systemd/init.js:303
+msgid "Static"
+msgstr "Статичний"
+
+#: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/containers-listing.html:16
+#: pkg/kubernetes/views/nodes-page.html:44
+#: pkg/kubernetes/views/pvc-body.html:13 pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/pv-body.html:24
+msgid "Status"
+msgstr "Стан"
+
+#: pkg/subscriptions/subscriptions-view.jsx:146
+#, fuzzy
+msgid "Status: $0"
+msgstr "Стан"
+
+#: pkg/subscriptions/subscriptions-view.jsx:141
+msgid "Status: System isn't registered"
+msgstr ""
+
+#: pkg/networkmanager/index.html:455
+msgid "Sticky"
+msgstr ""
+
+#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
+msgid "Stop"
+msgstr "Зупинити"
+
+#: pkg/storaged/details.js:1615
+msgid "Stop Scrubbing"
+msgstr "Зупинити витирання"
+
+#: pkg/kubernetes/views/image-config.html:10
+msgid "Stop with"
+msgstr "Зупинитися на"
+
+#: pkg/docker/util.js:231
+msgid "Stopped"
+msgstr "Зупинено"
+
+#: pkg/storaged/jobs.js:138
+msgid "Stopping RAID Device $target"
+msgstr "Зупиняємо пристрій RAID $target"
+
+#: pkg/storaged/jobs.js:125
+msgid "Stopping swapspace $target"
+msgstr "Зупиняємо резервну область пам’яті $target"
+
+#: pkg/storaged/index.html:23 pkg/storaged/index.html:672
+msgid "Storage"
+msgstr "Сховище даних"
+
+#: pkg/storaged/index.html:686
+msgid "Storage Log"
+msgstr "Журнал сховища даних"
+
+#: pkg/storaged/index.html:342
+msgid "Storage Logs"
+msgstr "Журнали зберігання"
+
+#: pkg/docker/index.html:324
+msgid "Storage pool"
+msgstr "Буфер сховища"
+
+#: pkg/systemd/index.html:148
+msgid "Store Performance Data"
+msgstr "Зберігати дані щодо швидкодії"
+
+#: pkg/storaged/details.js:237
+msgid "Store passphrase"
+msgstr "Зберігати пароль"
+
+#: pkg/storaged/details.js:527
+msgid "Stored Passphrase"
+msgstr "Збережений пароль"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:12
+msgid ""
+"Strategy            {{item.spec.strategy.type}}            Latest "
+"Version            {{ item.status.latestVersion }}            Not "
+"deployed        "
+msgstr ""
+
+#: pkg/subscriptions/index.html:22
+msgid "Subscriptions"
+msgstr "Передплати"
+
+#: pkg/kubernetes/views/image-body.html:4
+msgid "Summary"
+msgstr "Резюме"
+
+#: pkg/storaged/details.js:1251
+msgctxt "storage-id-desc"
+msgid "Swap Space"
+msgstr "Резервна пам’ять"
+
+#: pkg/systemd/index.html:243
+msgid "Swap Used"
+msgstr "Використано резерву"
+
+#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
+msgid "Switch off $0"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2191 pkg/networkmanager/interfaces.js:2765
@@ -2519,359 +5378,646 @@ msgstr ""
 msgid "Switching off <b>$0</b>  will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
-msgid "Switch off $0"
+#: pkg/networkmanager/interfaces.js:2773
+msgid "Switching off <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
-#: pkg/networkmanager/interfaces.js:2507
-msgid "Bond"
-msgstr "Прив’язка"
+#: pkg/networkmanager/interfaces.js:2188
+msgid "Switching on <b>$0</b>  will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2762
+msgid "Switching on <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:75
+msgid "Synchronize"
+msgstr "Синхронізувати"
+
+#: pkg/dashboard/index.html:188 pkg/lib/machine-sync-users.html:4
+msgid "Synchronize users"
+msgstr "Синхронізувати користувачів"
+
+#: pkg/systemd/index.html:54
+msgid "Synchronized"
+msgstr "Синхронізовано"
+
+#: pkg/systemd/index.html:51
+msgid "Synchronized with {{Server}}"
+msgstr "Синхронізовано із {{Server}}"
+
+#: pkg/storaged/jobs.js:146
+msgid "Synchronizing RAID Device $target"
+msgstr "Синхронізуємо пристрій RAID $target"
+
+#: pkg/systemd/index.html:4
+#, fuzzy
+msgid "System"
+msgstr "Системний час"
+
+#: pkg/systemd/services.html:53
+msgid "System Services"
+msgstr "Служби системи"
+
+#: pkg/systemd/index.html:112
+msgid "System Time"
+msgstr "Системний час"
+
+#: pkg/docker/index.html:349
+msgid "TCP"
+msgstr "TCP"
+
+#: pkg/kubernetes/views/route-body.html:12
+msgid "TLS Termination"
+msgstr "Переривання TLS"
+
+#: pkg/docker/index.html:724
+msgid "Tag"
+msgstr "Мітка"
+
+#: pkg/kubernetes/views/image-body.html:27
+#: pkg/kubernetes/views/imagestream-modify.html:76
+#: pkg/kubernetes/views/image-listing.html:14
+msgid "Tags"
+msgstr "Мітки"
+
+#: pkg/kubernetes/views/pv-modify.html:136
+msgid "Target"
+msgstr "Призначення"
+
+#: pkg/kubernetes/views/volume-body.html:75
+msgid "Target Portal"
+msgstr "Портал призначення"
+
+#: pkg/kubernetes/views/volume-body.html:114
+msgid "Target World Wide Names"
+msgstr "WWN призначень"
+
+#: pkg/systemd/services.html:52
+msgid "Targets"
+msgstr "Призначення"
 
 #: pkg/networkmanager/interfaces.js:2235 pkg/networkmanager/interfaces.js:2247
 #: pkg/networkmanager/interfaces.js:2530
 msgid "Team"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
-#: pkg/networkmanager/interfaces.js:2622
-msgid "VLAN"
-msgstr "VLAN"
+#: pkg/networkmanager/interfaces.js:2558
+#, fuzzy
+msgid "Team Port"
+msgstr "Портал призначення"
 
-#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
-#: pkg/networkmanager/interfaces.js:2584
-msgid "Bridge"
-msgstr "Міст"
+#: pkg/networkmanager/index.html:652
+#, fuzzy
+msgid "Team Port Settings"
+msgstr "Параметри порту містка"
 
-#: pkg/networkmanager/interfaces.js:2276
-msgid "Carrier"
-msgstr "Носій сигналу"
+#: pkg/networkmanager/index.html:624
+#, fuzzy
+msgid "Team Settings"
+msgstr "Параметри IP"
 
-#: pkg/networkmanager/interfaces.js:2279 pkg/kubernetes/scripts/volumes.js:990
-msgid "Yes"
-msgstr "Так"
+#: pkg/kubernetes/views/replicationcontroller-page.html:20
+#: pkg/kubernetes/views/deploymentconfig-panel.html:10
+#: pkg/kubernetes/views/deploymentconfig-page.html:15
+#: pkg/kubernetes/views/replicationcontroller-panel.html:14
+msgid "Template"
+msgstr "Шаблон"
 
-#: pkg/networkmanager/interfaces.js:2299
-#: pkg/subscriptions/subscriptions-view.jsx:36
-#: pkg/kubernetes/views/node-body.html.h:14
-#: pkg/kubernetes/views/containers-listing.html.h:7
-#: pkg/kubernetes/views/volumes-page.html.h:5
-#: pkg/kubernetes/views/pv-claim.html.h:6
-#: pkg/kubernetes/views/nodes-page.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:5 pkg/kubernetes/views/pv-body.html.h:4
-msgid "Status"
-msgstr "Стан"
+#: pkg/systemd/terminal.html:4
+msgid "Terminal"
+msgstr "Термінал"
+
+#: pkg/users/index.html:78
+msgid "Terminate Session"
+msgstr "Перервати сеанс"
+
+#: pkg/networkmanager/index.html:38
+msgid "Testing connection"
+msgstr ""
+
+#: pkg/storaged/index.html:40
+msgid "The \"storaged\" API is not available on this system."
+msgstr "У цій системі програмний інтерфейс «storaged» є недоступним."
+
+#: pkg/docker/storage.jsx:485
+#, fuzzy
+msgid "The Docker storage pool cannot be managed on this system."
+msgstr "У цій системі програмний інтерфейс «storaged» є недоступним."
+
+#: pkg/lib/machine-dialogs.js:386
+msgid "The IP address or host name cannot contain whitespace."
+msgstr "У IP-адресі або назві вузла не повинно бути пробілів."
+
+#: pkg/storaged/index.html:532
+msgid "The RAID Array is in a degraded state"
+msgstr "Масив RAID перебуває у стані із погіршеними властивостями"
+
+#: pkg/kubernetes/scripts/nodes.js:399
+msgid "The address contains invalid characters"
+msgstr "У адресі містяться некоректні символи"
+
+#: pkg/lib/machine-unknown-hostkey.html:6
+msgid ""
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
+msgstr ""
+"Не вдалося встановити ідентичність вузла {{#strong}}{{host}}{{/strong}}. Ви "
+"справді хочете продовжити спробу встановити з’єднання?"
+
+#: pkg/selinux/setroubleshoot-view.jsx:324
+msgid "The configured state is unknown, it might change on the next boot."
+msgstr ""
+
+#: pkg/kubernetes/views/container-page-inline.html:22
+msgid "The container '{{ target }}' does not exist."
+msgstr "Контейнера «{{ target }}» не існує."
+
+#: pkg/subscriptions/subscriptions-view.jsx:192
+#, fuzzy
+msgid "The current user isn't allowed to access system subscription status."
+msgstr ""
+"\n"
+"        Поточного користувача не уповноважено на керування передплатами цієї "
+"системи.\n"
+"      "
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:25
+msgid "The deployment config '{{ target }}' does not exist."
+msgstr "Налаштувань розгортання «{{ target }}» не існує."
+
+#: pkg/kubernetes/views/group-page.html:47
+msgid "The group '{{ groupName }}' does not exist."
+msgstr "Групи «{{ groupName }}» не існує."
+
+#: pkg/shell/base_index.js:673
+msgid "The javascript console contains details about this error "
+msgstr "У консолі javascript наведено подробиці щодо цієї помилки "
+
+#: pkg/lib/machine-invalid-hostkey.html:8
+msgid ""
+"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
+"in use. Unless this machine was recently replaced, it is likely that someone "
+"is trying to attack your connection to this machine."
+msgstr ""
+"Ключ {{#strong}}{{host}}{{/strong}} не відповідає раніше використаному "
+"ключу. Якщо нещодавно ніхто не міняв цього комп’ютера, ймовірною причиною є "
+"спроба атаки на ваше з’єднання із цим комп’ютером."
+
+#: pkg/users/authorized-keys.js:118
+msgid "The key you provided was not valid."
+msgstr "Наданий вами ключ є некоректним."
+
+#: pkg/storaged/details.js:1751
+msgid "The last physical volume of a volume group cannot be removed."
+msgstr ""
+
+#: pkg/shell/indexes.js:314
+msgid "The machine is restarting"
+msgstr "Комп’ютер перезавантажується"
+
+#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
+msgid "The maximum number of replicas is 128"
+msgstr "Максимальною є кількість реплік 128"
+
+#: pkg/kubernetes/scripts/nodes.js:407
+msgid "The name contains invalid characters"
+msgstr "У назві містяться некоректні символи"
+
+#: pkg/kubernetes/views/node-page.html:23
+msgid "The node '{{ target }}' does not exist."
+msgstr "Вузла «{{ target }}» не існує."
+
+#: pkg/kubernetes/views/node-alerts.html:7
+msgid "The node doesn't have enough disk space"
+msgstr "На вузлі недостатньо простору на диску"
+
+#: pkg/kubernetes/views/node-alerts.html:11
+msgid "The node doesn't have enough free memory"
+msgstr "На вузлі недостатньо вільної пам’яті"
+
+#: pkg/users/local.js:395 pkg/users/local.js:1082
+msgid "The passwords do not match"
+msgstr "Паролі не збігаються"
+
+#: pkg/lib/credentials.js:186
+msgid "The passwords do not match."
+msgstr "Паролі не збігаються."
+
+#: pkg/kubernetes/views/pv-page.html:21
+msgid "The persistent volume '{{ target }}' does not exist."
+msgstr "Сталого тому «{{ target }}» не існує."
+
+#: pkg/kubernetes/views/pod-page.html:40
+msgid "The pod '{{ target }}' does not exist."
+msgstr "Кокона «{{ target }}» не існує."
+
+#: pkg/kubernetes/views/project-page.html:34
+msgid "The project '{{ projName }}' does not exist."
+msgstr "Проекту «{{ projName }}» не існує."
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:30
+msgid "The replication controller '{{ target }}' does not exist."
+msgstr "Контролера реплікації «{{ target }}» не існує."
+
+#: pkg/kubernetes/views/route-page.html:19
+msgid "The route '{{ target }}' does not exist."
+msgstr "Маршруту «{{ target }}» не існує."
+
+#: pkg/kubernetes/scripts/dashboard.js:386
+msgid "The selected file is not a valid Kubernetes application manifest."
+msgstr "Вибраний файл не є коректним маніфестом програми Kubernetes."
+
+#: src/base1/cockpit.js:3695
+msgid "The server refused to authenticate using any supported methods."
+msgstr ""
+"Сервер відмовився розпізнавати користувача за допомогою будь-якого з "
+"підтримуваних методів."
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:2
+msgid "The server uses a certificate signed by an unknown authority."
+msgstr ""
+"На сервері використовується сертифікат, підписаний невідомою службою "
+"сертифікації."
+
+#: pkg/kubernetes/views/service-page.html:19
+msgid "The service '{{ target }}' does not exist."
+msgstr "Служби «{{ target }}» не існує."
+
+#: pkg/docker/storage.jsx:355
+msgid ""
+"The storage pool will be reset to optimize its layout.  All containers will "
+"be erased."
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:29
+msgid "The user '{{ userName }}' does not exist."
+msgstr "Запису користувача «{{ userName }}» не існує."
+
+#: pkg/systemd/init.js:834
+#, fuzzy
+msgid "The user <b>$0</b> does not have permissions for creating timers"
+msgstr "Користувачу <b>$0</b> заборонено керувати серверами"
+
+#: pkg/dashboard/list.js:209
+msgid "The user <b>$0</b> is not permitted to manage servers"
+msgstr "Користувачу <b>$0</b> заборонено керувати серверами"
+
+#: pkg/storaged/permissions.js:61
+msgid "The user <b>$0</b> is not permitted to manage storage"
+msgstr "Користувачу <b>$0</b> не дозволено керувати сховищем даних"
+
+#: pkg/users/local.js:40
+msgid "The user <b>$0</b> is not permitted to modify accounts"
+msgstr "Користувачу <b>$0</b> заборонено змінювати облікові записи"
+
+#: pkg/systemd/host.js:43
+msgid "The user <b>$0</b> is not permitted to modify hostnames"
+msgstr "Користувачу <b>$0</b> не дозволено змінювати назви вузлів"
+
+#: pkg/networkmanager/interfaces.js:1420
+msgid "The user <b>$0</b> is not permitted to modify network settings"
+msgstr "Користувачу <b>$0</b> заборонено змінювати параметри роботи мережі"
+
+#: pkg/realmd/operation.js:436
+msgid "The user <b>$0</b> is not permitted to modify realms"
+msgstr "Користувачу <b>$0</b> не дозволено вносити зміни до областей"
+
+#: pkg/users/local.js:501
+msgid ""
+"The user name can only consist of letters from a-z, digits, dots, dashes and "
+"underscores."
+msgstr ""
+"Ім’я користувача може складатися лише із літер a-z, цифр, крапок, дефісів та "
+"символів підкреслювання."
+
+#: pkg/users/index.html:332
+msgid "There are no authorized public keys for this account."
+msgstr "Для цього облікового запису немає уповноважених відкритих ключів."
+
+#: pkg/storaged/details.js:1756
+msgid ""
+"There is not enough free space elsewhere to remove this physical volume.  At "
+"least $0 more free space is needed."
+msgstr ""
+
+#: pkg/storaged/utils.js:168
+msgid "Thin Logical Volume"
+msgstr "Тонкий логічний том"
+
+#: pkg/kubernetes/views/pvc-delete.html:8
+msgid ""
+"This claim is in use. Deleting it may cause issues with the following pod:"
+msgstr ""
+"Ця заявка використовується. Її вилучення може призвести до проблем із цим "
+"коконом:"
+
+#: pkg/systemd/init.js:1222
+msgid ""
+"This day doesn't exist in all months.<br> The timer will only be executed in "
+"months that have 31st."
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2310
 #, fuzzy
 msgid "This device cannot be managed here."
 msgstr "Логічний том не можна зменшувати."
 
-#: pkg/networkmanager/interfaces.js:2342
-msgid "Unknown configuration"
-msgstr "Невідомі налаштування"
-
-#: pkg/networkmanager/interfaces.js:2441
-msgid "Configure"
-msgstr "Налаштувати"
-
-#: pkg/networkmanager/interfaces.js:2473
-msgid "$mtu"
-msgstr "$mtu"
-
-#: pkg/networkmanager/interfaces.js:2477
-msgid "MTU"
-msgstr "MTU"
-
-#: pkg/networkmanager/interfaces.js:2483
-msgid "Master"
-msgstr "Основний"
-
-#: pkg/networkmanager/interfaces.js:2502
-msgid "ARP Monitoring"
-msgstr "Стеження за ARP"
-
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
 #, fuzzy
-msgid "Broken configuration"
-msgstr "Невідомі налаштування"
+msgid "This field cannot be empty."
+msgstr "Назва не повинна бути порожньою."
 
-#: pkg/networkmanager/interfaces.js:2558
+#: pkg/storaged/details.js:690
 #, fuzzy
-msgid "Team Port"
-msgstr "Портал призначення"
+msgid "This logical volume cannot be made smaller."
+msgstr "Логічний том не можна зменшувати."
 
-#: pkg/networkmanager/interfaces.js:2573
-msgid "Spanning Tree Protocol"
-msgstr "Протокол пересування ієрархією"
+#: pkg/lib/machine-dialogs.js:364
+msgid "This machine has already been added."
+msgstr "Цей комп’ютер вже було додано."
 
-#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
-msgid "Priority $priority"
-msgstr "Пріоритетність $priority"
+#: pkg/realmd/operation.html:89
+msgid "This may take a while"
+msgstr "Зачекайте"
 
-#: pkg/networkmanager/interfaces.js:2577
-msgid "Forward delay $forward_delay"
-msgstr "Затримка переспрямування $forward_delay"
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid ""
+"This option is for single node testing only – local storage will not work in "
+"a multi-node cluster"
+msgstr ""
+"Цей параметр призначено лише для тестування окремих вузлів – локальне "
+"сховище не працюватиму у багатовузловому кластері"
 
-#: pkg/networkmanager/interfaces.js:2579
-msgid "Hello time $hello_time"
-msgstr "Час вітання $hello_time"
-
-#: pkg/networkmanager/interfaces.js:2581
-msgid "Maximum message age $max_age"
-msgstr "Максимальний вік повідомлення $max_age"
-
-#: pkg/networkmanager/interfaces.js:2601
-msgid "Path cost $path_cost"
-msgstr "Вартість шляху $path_cost"
-
-#: pkg/networkmanager/interfaces.js:2603
-msgid "Hairpin mode"
-msgstr "Режим початкової зони (hairpin)"
-
-#: pkg/networkmanager/interfaces.js:2605
-msgid "Bridge port"
-msgstr "Порт містка"
-
-#: pkg/networkmanager/interfaces.js:2619
-msgid "Parent $parent"
-msgstr "Батьківський $parent"
-
-#: pkg/networkmanager/interfaces.js:2620
-msgid "Id $id"
-msgstr "Ід. $id"
-
-#: pkg/networkmanager/interfaces.js:2628
-msgid "General"
-msgstr "Загальний"
-
-#: pkg/networkmanager/interfaces.js:2637
-msgid "Connect automatically"
-msgstr "З’єднуватися автоматично"
-
-#: pkg/networkmanager/interfaces.js:2641
-msgid "IPv4"
-msgstr "IPv4"
-
-#: pkg/networkmanager/interfaces.js:2642
-msgid "IPv6"
-msgstr "IPv6"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/networkmanager/index.html.h:33
-#: pkg/kubernetes/views/project-listing.html.h:5
-msgid "Members"
-msgstr "Учасники"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/docker/index.html.h:39
-#: pkg/networkmanager/index.html.h:24
-#: pkg/kubernetes/views/service-body.html.h:6
-#: pkg/kubernetes/views/image-config.html.h:7
-#: pkg/kubernetes/views/container-body.html.h:5
-msgid "Ports"
-msgstr "Порти"
-
-#: pkg/networkmanager/interfaces.js:2762
-msgid "Switching on <b>$0</b> will break the connection to the server, "
+#: src/bridge/cockpitpackages.c:470
+msgid "This package is not compatible with this version of Cockpit"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2773
-msgid "Switching off <b>$0</b> will break the connection to the server, "
+#: src/bridge/cockpitpackages.c:459
+#, c-format
+msgid "This package requires Cockpit version %s or later"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2788
-msgid "Removing <b>$0</b> will break the connection to the server, "
-msgstr ""
+#: pkg/tuned/dialog.js:102
+msgid "This system is using a custom profile"
+msgstr "Ця система використовує нетиповий профіль"
 
-#: pkg/networkmanager/interfaces.js:2791
+#: pkg/tuned/dialog.js:100
+msgid "This system is using the recommended profile"
+msgstr "Ця система використовує рекомендований профіль"
+
+#: pkg/systemd/init.js:639
+msgid "This unit is an instance of the $0 template."
+msgstr "Цей модуль є екземпляром шаблона $0."
+
+#: pkg/systemd/services.html:302
 #, fuzzy
-msgid "Remove $0"
-msgstr "Вилучити"
+msgid "This unit is not designed to be enabled explicitly.          "
+msgstr ""
+"Цей модуль створено для вмикання явним чином.\n"
+"          "
 
-#: pkg/networkmanager/interfaces.js:2833
-msgid "Adding <b>$0</b> will break the connection to the server, "
+#: pkg/users/local.js:509
+msgid "This user name already exists"
+msgstr "Запис користувача із таким іменем уже існує"
+
+#: pkg/lib/machine-dialogs.js:380
+msgid ""
+"This version of cockpit-ws does not support connecting to a host with an "
+"alternate user or port"
+msgstr ""
+"У цій версії cockpit-ws не передбачено підтримки встановлення з’єднання із "
+"вузлом від альтернативного користувача або на альтернативному порті."
+
+#: pkg/kubernetes/views/pv-delete.html:7
+msgid ""
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
+msgstr ""
+"Цей том може бути заявлено для {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Його вилучення порушить цю заявку і може "
+"призвести до проблем із усіма коконами, які від нього залежать."
+
+#: pkg/kubernetes/views/pv-claim.html:23
+msgid "This volume has not been claimed"
+msgstr "Цей том не заявлено"
+
+#: pkg/systemd/index.html:379
+msgid "Time Zone"
+msgstr "Часовий пояс"
+
+#: pkg/systemd/services.html:55
+msgid "Timers"
+msgstr "Таймери"
+
+#: pkg/kubernetes/views/image-body.html:33
+msgid "To pull this image:"
+msgstr "Для отримання цього образу:"
+
+#: pkg/kubernetes/views/imagestream-body.html:39
+msgid "To push to an image to this image stream:"
+msgstr "Для вивантаження образу до цього потоку образу:"
+
+#: pkg/lib/machine-change-port.html:11
+msgid ""
+"To try a different port you will need to upgrade cockpit-ws to a newer "
+"version."
+msgstr "Щоб спробувати інший порт, вам слід оновити cockpit-ws."
+
+#: pkg/kubernetes/views/auth-form.html:116
+msgid "Token"
+msgstr "Елемент"
+
+#: pkg/kubernetes/index.html:57
+msgid "Topology"
+msgstr "Топологія"
+
+#: pkg/docker/storage.jsx:314
+msgid "Total"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2836
-msgid "Add $0"
-msgstr ""
+#: pkg/ostree/index.html:99
+msgid "Tree"
+msgstr "Дерево"
 
-#: pkg/networkmanager/interfaces.js:2870
-msgid "Changing the settings will break the connection to the server, "
-msgstr ""
+#: pkg/kubernetes/views/deploymentconfig-body.html:32
+msgid "Triggers"
+msgstr "Умовні зміни"
 
-#: pkg/networkmanager/interfaces.js:2872
-#, fuzzy
-msgid "Change the settings"
-msgstr "Параметри з’єднання"
+#: pkg/shell/index.html:328 pkg/shell/stub.html:181
+msgid "Troubleshoot"
+msgstr "Діагностика проблем"
 
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length or Netmask"
-msgstr "Довжина префікса або маска мережі"
+#: pkg/kubernetes/views/auth-rejected-cert.html:21
+msgid "Trust this certificate for this connection"
+msgstr "Довіряти цьому сертифікату для цього з’єднання"
 
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length"
-msgstr "Довжина префікса"
+#: pkg/systemd/init.js:520
+msgid "Try Restart"
+msgstr "Спробувати перезапустити"
 
-#: pkg/networkmanager/interfaces.js:3011
-#: pkg/kubernetes/views/details-page.html.h:7
-msgid "Addresses"
-msgstr "Адреси"
+#: pkg/docker/index.html:71 pkg/docker/index.html:74
+msgid "Try again"
+msgstr "Повторити спробу"
 
-#: pkg/networkmanager/interfaces.js:3018
-msgid "DNS"
-msgstr "DNS"
+#: pkg/systemd/index.html:59
+msgid "Trying to synchronize with {{Server}}"
+msgstr "Намагаємося синхронізуватися з {{Server}}"
 
-#: pkg/networkmanager/interfaces.js:3022
-msgid "DNS Search Domains"
-msgstr "Домени пошуку DNS"
+#: pkg/tuned/dialog.js:262
+msgid "Tuned has failed to start"
+msgstr "Tuned не вдалося запустити"
 
-#: pkg/networkmanager/interfaces.js:3027
-#: pkg/kubernetes/views/details-page.html.h:11
-msgid "Routes"
-msgstr "Маршрути"
+#: pkg/tuned/dialog.js:94
+msgid "Tuned is not available"
+msgstr "Tuned недоступна"
 
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv4 Settings"
-msgstr "Параметри IPv4"
+#: pkg/tuned/dialog.js:96
+msgid "Tuned is not running"
+msgstr "Tuned не запущено"
 
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv6 Settings"
-msgstr "Параметри IPv6"
+#: pkg/tuned/dialog.js:98
+msgid "Tuned is off"
+msgstr "Tuned вимкнено"
 
-#: pkg/networkmanager/interfaces.js:3436
-msgid "Creating this bond will break the connection to the server, "
-msgstr ""
+#: pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/pv-modify.html:10
+#: pkg/kubernetes/views/volumes-page.html:20 pkg/kubernetes/views/deploy.html:9
+msgid "Type"
+msgstr "Тип"
 
-#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
-#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
-#, fuzzy
-msgid "Create it"
-msgstr "Створити"
-
-#: pkg/networkmanager/interfaces.js:3611
-msgid "Creating this team will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3842
-msgid "Creating this bridge will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4064
-msgid "Creating this VLAN will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4139
-msgid "MTU must be a positive number"
-msgstr "MTU має бути додатнім числом"
-
-#: pkg/subscriptions/subscriptions-client.js:196
-#, fuzzy
-msgid "Invalid credentials"
-msgstr "Некоректний порт"
-
-#: pkg/subscriptions/subscriptions-client.js:198
-msgid "'Organization' required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:200
-#, fuzzy
-msgid "Login/password or activation key required to register."
-msgstr "Слід вказати ім’я користувача та пароль або ключ активації"
-
-#: pkg/subscriptions/subscriptions-client.js:202
-msgid "'Organization' required when using activation keys."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:64
-#: pkg/kubernetes/views/volume-body.html.h:16
-#: pkg/kubernetes/views/pv-modify.html.h:11
-msgid "Server"
-msgstr "Сервер"
-
-#: pkg/subscriptions/subscriptions-register.jsx:88
-#: pkg/subscriptions/subscriptions-register.jsx:152
-#: pkg/lib/machine-auth-failed.html.h:3 pkg/lib/machine-sync-users.html.h:6
-#: pkg/lib/machine-change-auth.html.h:6 pkg/shell/index.html.h:31
-#: pkg/users/index.html.h:16 pkg/kubernetes/views/auth-form.html.h:11
-msgid "Password"
-msgstr "Пароль"
-
-#: pkg/subscriptions/subscriptions-register.jsx:102
-#, fuzzy
-msgid "Custom URL"
-msgstr "Нетиповий"
+#: pkg/kubernetes/views/details-page.html:7
+msgid "Type:"
+msgstr "Тип:"
 
 #: pkg/subscriptions/subscriptions-register.jsx:110
 msgid "URL"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-register.jsx:125
-msgid "Proxy"
+#: pkg/storaged/index.html:547 pkg/storaged/index.html:626
+msgctxt "storage"
+msgid "UUID"
+msgstr "UUID"
+
+#: pkg/selinux/setroubleshoot-view.jsx:114
+msgid "Unable to apply this solution automatically"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-register.jsx:132
-msgid "Use proxy server"
-msgstr ""
+#: pkg/ostree/index.html:219
+msgid "Unable to communicate with OSTree"
+msgstr "Не вдалося обмінятися даними з OSTree"
 
-#: pkg/subscriptions/subscriptions-register.jsx:140
+#: pkg/subscriptions/subscriptions-view.jsx:195
 #, fuzzy
-msgid "Login"
-msgstr "Останній вхід"
+msgid "Unable to connect"
+msgstr "Не вдалося отримати нагадування"
 
-#: pkg/subscriptions/subscriptions-register.jsx:164
+#: pkg/kubernetes/scripts/dashboard.js:413
+msgid "Unable to decode Kubernetes application manifest."
+msgstr "Не вдалося декодувати маніфест програми Kubernetes."
+
+#: pkg/users/local.js:57
+msgid "Unable to delete root account"
+msgstr "Неможливо вилучити обліковий запис root"
+
+#: pkg/selinux/setroubleshoot-client.js:157
+msgid "Unable to get alert"
+msgstr "Не вдалося отримати нагадування"
+
+#: pkg/storaged/overview.js:586
+msgid "Unable to reach server"
+msgstr "Не вдалося досягти сервера"
+
+#: pkg/kubernetes/scripts/dashboard.js:401
+msgid "Unable to read the Kubernetes application manifest. Code $0."
+msgstr "Не вдалося прочитати маніфест програми Kubernetes. Код $0."
+
+#: pkg/users/local.js:59
+msgid "Unable to rename root account"
+msgstr "Неможливо перейменувати обліковий запис root"
+
+#: pkg/selinux/setroubleshoot-client.js:172
+msgid "Unable to run fix"
+msgstr "Не вдалося виконати fix"
+
+#: pkg/selinux/setroubleshoot-client.js:52
+msgid "Unable to start setroubleshootd"
+msgstr "Не вдалося запустити setroubleshootd"
+
+#: pkg/playground/translate.html:35 pkg/playground/translate.html:40
+msgid "Unavailable"
+msgstr "Недоступний"
+
+#: pkg/docker/index.html:763 pkg/networkmanager/index.html:792
+msgid "Unexpected error"
+msgstr "Неочікувана помилка"
+
+#: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/image-body.html:15
+#: pkg/kubernetes/views/pv-claim.html:31 pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
+msgid "Unknown"
+msgstr "Невідомий"
+
+#: pkg/storaged/details.js:1597
+msgid "Unknown ($0)"
+msgstr "Невідомий ($0)"
+
+#: pkg/lib/machine-unknown-hostkey.html:2
+msgid "Unknown Host Key"
+msgstr "Невідомий ключ вузла"
+
+#: pkg/networkmanager/interfaces.js:2342
+msgid "Unknown configuration"
+msgstr "Невідомі налаштування"
+
+#: pkg/storaged/overview.js:582
+msgid "Unknown host name"
+msgstr "Невідома назва вузла"
+
+#: pkg/docker/index.html:570
+msgid "Unless Stopped"
+msgstr "Якщо не зупинено"
+
+#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
+#: pkg/storaged/details.js:1110
+msgid "Unlock"
+msgstr "Розблокувати"
+
+#: pkg/shell/index.html:220
+msgid "Unlock Key"
+msgstr "Розблокувати ключ"
+
+#: pkg/storaged/jobs.js:121
+msgid "Unlocking $target"
+msgstr "Розблокуємо $target"
+
+#: pkg/networkmanager/index.html:108
 #, fuzzy
-msgid "Activation Key"
-msgstr "Задіяти"
+msgid "Unmanaged Interfaces"
+msgstr "Інтерфейси"
 
-#: pkg/subscriptions/subscriptions-register.jsx:176
-#, fuzzy
-msgid "Organization"
-msgstr "Переклад"
+#: pkg/systemd/init.js:548
+msgid "Unmask"
+msgstr "Розмаскувати"
 
-#: pkg/subscriptions/main.js:45 pkg/subscriptions/subscriptions-view.jsx:143
-#: pkg/kubernetes/views/pv-modify.html.h:23
-msgid "Register"
-msgstr "Зареєструвати"
+#: pkg/storaged/details.js:1100
+msgid "Unmount"
+msgstr "Демонтувати"
 
-#: pkg/subscriptions/main.js:74
-msgid "Register system"
-msgstr "Зареєструвати систему"
+#: pkg/storaged/jobs.js:127
+msgid "Unmounting $target"
+msgstr "Демонтуємо $target"
 
-#: pkg/subscriptions/subscriptions-view.jsx:32
-msgid "Product name"
-msgstr "Назва продукту"
+#: pkg/users/index.html:315
+msgid "Unnamed"
+msgstr "Без назви"
 
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product ID"
-msgstr "Ід. продукту"
-
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/index.html.h:13
-#: pkg/shell/index.html.h:14 pkg/shell/stub.html.h:9 pkg/shell/simple.html.h:9
-#: pkg/ostree/index.html.h:19
-msgid "Version"
-msgstr "Версія"
-
-#: pkg/subscriptions/subscriptions-view.jsx:35
-#: pkg/kubernetes/views/image-config.html.h:5
-msgid "Architecture"
-msgstr "Архітектура"
-
-#: pkg/subscriptions/subscriptions-view.jsx:37
-msgid "Starts"
-msgstr "Починається"
-
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Ends"
-msgstr "Завершується"
-
-#: pkg/subscriptions/subscriptions-view.jsx:141
-msgid "Status: System isn't registered"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:146
-#, fuzzy
-msgid "Status: $0"
-msgstr "Стан"
+#: pkg/storaged/details.js:1256
+msgctxt "storage-id-desc"
+msgid "Unrecognized Data"
+msgstr "Нерозпізнані дані"
 
 #: pkg/subscriptions/subscriptions-view.jsx:148
 #, fuzzy
@@ -2883,817 +6029,213 @@ msgstr "Зареєструвати"
 msgid "Unregistering system..."
 msgstr "Реєструємо систему…"
 
-#: pkg/subscriptions/subscriptions-view.jsx:161
-#: pkg/subscriptions/index.html.h:1
-msgid "Subscriptions"
-msgstr "Передплати"
+#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
+#: src/bridge/cockpitdbussetup.c:625
+#, fuzzy
+msgid "Unsupported setup mechanism"
+msgstr "Непідтримуваний механізм налаштовування: %s"
 
-#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/ostree/index.html.h:15
-msgid "Updating"
+#: src/base1/cockpit.js:3697
+msgid "Untrusted host"
+msgstr "Ненадійний вузол"
+
+#: pkg/docker/util.js:94
+msgid "Up since $StartedAt"
+msgstr "Працює з $StartedAt"
+
+#: pkg/lib/machine-change-port.html:41
+msgid "Update"
+msgstr "Оновити"
+
+#: pkg/ostree/index.html:125 pkg/ostree/index.html:152
+msgid "Updates"
 msgstr "Оновлення"
 
-#: pkg/subscriptions/subscriptions-view.jsx:188
-msgid "Retrieving subscription status..."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:191
-#, fuzzy
-msgid "Access denied"
-msgstr "Режими доступу"
-
-#: pkg/subscriptions/subscriptions-view.jsx:192
-#, fuzzy
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-"\n"
-"        Поточного користувача не уповноважено на керування передплатами цієї "
-"системи.\n"
-"      "
-
-#: pkg/subscriptions/subscriptions-view.jsx:195
-#, fuzzy
-msgid "Unable to connect"
-msgstr "Не вдалося отримати нагадування"
-
-#: pkg/subscriptions/subscriptions-view.jsx:196
-#, fuzzy
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-"\n"
-"        Для керування передплатами цієї системи, будь ласка, перевірте, чи "
-"встановлено subscription-manager.\n"
-"      "
-
-#: pkg/subscriptions/subscriptions-view.jsx:222
-#, fuzzy
-msgid "Installed products"
-msgstr "Встановлені продукти"
-
-#: pkg/subscriptions/subscriptions-view.jsx:223
-#, fuzzy
-msgid "No installed products on the system."
-msgstr "Cockpit у цій системі не встановлено."
-
-#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "Некоректна кількість реплік"
-
-#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "Максимальною є кількість реплік 128"
-
-#: pkg/kubernetes/scripts/details.js:546
-msgid "Not a valid value for Host"
-msgstr "Некоректне значення вузла"
+#: pkg/ostree/index.html:96
+msgid "Updating"
+msgstr "Оновлення"
 
 #: pkg/kubernetes/scripts/details.js:655
 msgid "Updating $0..."
 msgstr "Оновлення $0…"
 
-#: pkg/kubernetes/scripts/graphs.js:601 pkg/kubernetes/scripts/nodes.js:711
-#: pkg/kubernetes/scripts/nodes.js:817 pkg/dashboard/index.html.h:2
-msgid "CPU"
-msgstr "Процесор"
-
-#: pkg/kubernetes/scripts/graphs.js:606 pkg/kubernetes/scripts/nodes.js:715
-#: pkg/kubernetes/scripts/nodes.js:826 pkg/dashboard/index.html.h:3
-msgid "Memory"
-msgstr "Пам'ять"
-
-#: pkg/kubernetes/scripts/graphs.js:611 pkg/dashboard/index.html.h:4
-msgid "Network"
-msgstr "Мережа"
-
-#: pkg/kubernetes/scripts/nodes.js:319 pkg/kubernetes/views/node-body.html.h:16
-#: pkg/kubernetes/views/details-page.html.h:10
-msgid "Not Ready"
-msgstr "Не готовий"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
-msgstr "Планування вимкнено"
-
-#: pkg/kubernetes/scripts/nodes.js:324 pkg/kubernetes/views/node-body.html.h:15
-#: pkg/kubernetes/views/details-page.html.h:9
-msgid "Ready"
-msgstr "Готовий"
-
-#: pkg/kubernetes/scripts/nodes.js:397
-msgid "Please type an address"
-msgstr "Будь ласка, введіть адресу"
-
-#: pkg/kubernetes/scripts/nodes.js:399
-msgid "The address contains invalid characters"
-msgstr "У адресі містяться некоректні символи"
-
-#: pkg/kubernetes/scripts/nodes.js:407
-msgid "The name contains invalid characters"
-msgstr "У назві містяться некоректні символи"
-
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
-msgstr "Використання процесора: $0%"
-
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
-msgstr "Використання пам’яті: $0%"
-
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
-msgid "Disk"
-msgstr "Диск"
-
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
-msgstr "Використання диска: $0%"
-
-#: pkg/kubernetes/scripts/nodes.js:870
-#, fuzzy, c-format
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] "Вільно $0%"
-msgstr[1] "Вільно $0%"
-msgstr[2] "Вільно $0%"
-
-#: pkg/kubernetes/scripts/nodes.js:872
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] "Використано $0%"
-msgstr[1] "Використано $0%"
-msgstr[2] "Використано $0%"
-
-#: pkg/kubernetes/scripts/connection.js:88
-msgid "Error writing kubectl config"
-msgstr "Помилка під час спроби записати налаштування kubectl"
-
-#: pkg/kubernetes/scripts/connection.js:514
-msgid "Couldn't find running API server"
-msgstr "Не вдалося знайти запущений сервер API"
-
-#: pkg/kubernetes/scripts/connection.js:516
-msgid "Connection Error: $0"
-msgstr "Помилка з’єднання: $0"
-
-#: pkg/kubernetes/scripts/connection.js:539
-msgid "Please provide a valid address"
-msgstr "Будь ласка, вкажіть коректну адресу"
-
-#: pkg/kubernetes/scripts/connection.js:554
-msgid "Please provide a username"
-msgstr "Будь ласка, вкажіть ім’я користувача"
-
-#: pkg/kubernetes/scripts/connection.js:650
-msgid "Error getting certificate details: $0"
-msgstr "Помилка під час спроби отримати параметри сертифіката: $0"
-
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr "Сталий диск GCE"
-
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr "Блокове сховище AWS Elastic"
-
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
-msgstr "Сховище Git"
-
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr "Секретний"
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr "Порожній каталог"
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
-msgid "Host Path"
-msgstr "Шлях на вузлі"
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr "ФС Gluster"
-
-#: pkg/kubernetes/scripts/volumes.js:199
-msgid "NFS Mount"
-msgstr "Змонтована NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr "Блоковий пристрій Rados"
-
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
-msgid "ISCSI"
-msgstr "ISCSI"
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr "Cinder"
-
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr "Змонтована файлова система Ceph"
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr "Оптоволоконний канал"
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr "Flocker"
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr "Flex"
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr "Azure"
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr "Читання і запис із одного вузла"
-
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr "Читання лише з декількох вузлів"
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr "Читання і запис із декількох вузлів"
-
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr "Зберегти"
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr "Повторний цикл"
-
-#: pkg/kubernetes/scripts/volumes.js:469
-msgid "Please select a valid access mode"
-msgstr "Будь ласка, виберіть коректний режим доступу"
-
-#: pkg/kubernetes/scripts/volumes.js:477
-msgid "Please provide a valid name"
-msgstr "Будь ласка, вкажіть коректну назву"
-
-#: pkg/kubernetes/scripts/volumes.js:485
-msgid "Please provide a valid storage capacity."
-msgstr "Будь ласка, вкажіть коректну місткість сховища."
-
-#: pkg/kubernetes/scripts/volumes.js:493
-msgid "Please select a valid policy option."
-msgstr "Будь ласка, виберіть коректний варіант правил."
-
-#: pkg/kubernetes/scripts/volumes.js:565
-msgid "Please select a valid endpoint"
-msgstr "Будь ласка, виберіть коректну кінцеву точку"
-
-#: pkg/kubernetes/scripts/volumes.js:574
-msgid "Please provide a GlusterFS volume name"
-msgstr "Будь ласка, вкажіть назву тому GlusterFS"
-
-#: pkg/kubernetes/scripts/volumes.js:632
-msgid "Please provide a valid NFS server"
-msgstr "Будь ласка, вкажіть коректний сервер NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
-msgid "Please provide a valid path"
-msgstr "Будь ласка, вкажіть коректний шлях"
-
-#: pkg/kubernetes/scripts/volumes.js:781
-msgid "Please provide a valid target"
-msgstr "Будь ласка, вкажіть коректне призначення"
-
-#: pkg/kubernetes/scripts/volumes.js:789
-msgid "Please provide a valid qualified name"
-msgstr "Будь ласка, вкажіть коректну повну назву"
-
-#: pkg/kubernetes/scripts/volumes.js:797
-msgid "Please provide a valid logical unit number"
-msgstr "Будь ласка, вкажіть коректну кількість логічних одиниць"
-
-#: pkg/kubernetes/scripts/volumes.js:805
-msgid "Please provide a valid filesystem type"
-msgstr "Будь ласка, вкажіть коректний тип файлової системи"
-
-#: pkg/kubernetes/scripts/volumes.js:813
-msgid "Please provide a valid interface"
-msgstr "Будь ласка, вкажіть коректний інтерфейс"
-
-#: pkg/kubernetes/scripts/volumes.js:860
-msgid "NFS"
-msgstr "NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:872
-msgid "GlusterFS"
-msgstr "GlusterFS"
-
-#: pkg/kubernetes/scripts/volumes.js:908
-msgid "Sorry, I don't know how to modify this volume"
-msgstr "Вибачте, спосіб внесення змін до цього тому невідомий"
-
-#: pkg/kubernetes/scripts/charts.js:113
-msgid "Unavailable"
-msgstr "Недоступний"
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "Простір назв не може бути порожнім."
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "Будь ласка, вкажіть коректний простір назв."
-
-#: pkg/kubernetes/scripts/dashboard.js:384
-msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
+#: pkg/shell/index.html:165
+msgid "Use my password for privileged tasks and to connect to other machines"
 msgstr ""
-"Не вибрано файл метаданих. Будь ласка, виберіть файл метаданих Kubernetes."
+"Використати ваш пароль для привілейованих завдань та з’єднання з іншими "
+"комп’ютерами"
 
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr "Вибраний файл не є коректним маніфестом програми Kubernetes."
-
-#: pkg/kubernetes/scripts/dashboard.js:401
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr "Не вдалося прочитати маніфест програми Kubernetes. Код $0."
-
-#: pkg/kubernetes/scripts/dashboard.js:413
-msgid "Unable to decode Kubernetes application manifest."
-msgstr "Не вдалося декодувати маніфест програми Kubernetes."
-
-#: pkg/kubernetes/scripts/dashboard.js:441
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "Будь ласка, створіть інший простір назв для $0 «$1»"
-
-#: pkg/kubernetes/scripts/dashboard.js:460
-msgid "Manifest"
-msgstr "Маніфест"
-
-#: pkg/dashboard/list.js:209
-msgid "The user <b>$0</b> is not permitted to manage servers"
-msgstr "Користувачу <b>$0</b> заборонено керувати серверами"
-
-#: pkg/dashboard/list.js:394
-msgid ""
-"You are currently connected directly to this server. You cannot delete it."
+#: pkg/subscriptions/subscriptions-register.jsx:132
+msgid "Use proxy server"
 msgstr ""
-"Зараз ваш комп’ютер безпосередньо з’єднано із цим сервером. Ви не можете "
-"його вилучити."
 
-#: cockpit.appdata.xml.in.h:1
-msgid ""
-"Cockpit is a server manager that makes it easy to administer your Linux "
-"servers via a web browser. Jumping between the terminal and the web tool is "
-"no problem. A service started via Cockpit can be stopped via the terminal. "
-"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
-"journal interface."
-msgstr ""
-"Cockpit — програма для керування сервером, яка полегшує адміністрування "
-"ваших серверів під керуванням Linux за допомогою програми для перегляду "
-"сторінок інтернету. Ви зможете одночасно використовувати термінал і "
-"вебінструмент. Службу, яку було запущено за допомогою Cockpit, можна "
-"зупинити за допомогою термінала. І навпаки, якщо трапиться помилка у "
-"терміналі, ви побачите її у інтерфейсі журналу Cockpit."
+#: pkg/shell/index.html:172
+msgid "Use the following keys to authenticate against other systems"
+msgstr "Використати вказані нижче ключі для розпізнавання у інших системах"
 
-#: cockpit.appdata.xml.in.h:2
-msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
-"stopping services. You can monitor and administer several servers at the "
-"same time. Just add them with a single click and your machines will look "
-"after its buddies."
-msgstr ""
-"Cockpit — чудовий інструмент для системних адміністраторів-початківців. За "
-"його допомогою вони без проблем впораються із простими завданнями, зокрема "
-"адмініструванням сховищ даних, інспектуванням журналів та запуском і "
-"зупиненням служб. Ви зможете одночасно стежити за роботою декількох серверів "
-"і адмініструвати ці сервери. Просто додайте їх одним клацанням кнопкою миші "
-"і ваш комп’ютер сам нагляне за своїми приятелями."
+#: pkg/systemd/index.html:251
+msgid "Used"
+msgstr "Використано"
 
-#: cockpit.desktop.in.h:1 pkg/shell/index.html.h:1 pkg/shell/stub.html.h:1
-#: pkg/shell/simple.html.h:1
-msgid "Cockpit"
-msgstr "Cockpit"
+#: pkg/systemd/index.html:229 pkg/dashboard/index.html:158
+#: pkg/playground/translate.html:86 pkg/playground/translate.html:106
+#: pkg/kubernetes/views/user-panel.html:9
+#: pkg/kubernetes/views/auth-form.html:61
+#: pkg/kubernetes/views/volume-body.html:64
+#: pkg/kubernetes/views/volume-body.html:103
+msgid "User"
+msgstr "Користувач"
 
-#: cockpit.desktop.in.h:2
-msgid "A user interface for GNU/Linux servers"
-msgstr "Інтерфейс користувача для серверів GNU/Linux"
+#: pkg/users/index.html:90 pkg/users/index.html:154
+#: pkg/realmd/operation.html:47
+msgid "User Name"
+msgstr "Ім'я користувача"
 
-#: cockpit.desktop.in.h:3
-msgid "Remote;Administration;"
-msgstr "віддалене;адміністрування;"
+#: pkg/realmd/operation.html:53
+msgid "User Password"
+msgstr "Пароль користувача"
 
-#: pkg/systemd/index.html.h:1
-#, fuzzy
-msgid "System"
-msgstr "Системний час"
+#: pkg/lib/machine-change-auth.html:18
+msgid "User name"
+msgstr "Ім'я користувача"
 
-#: pkg/systemd/index.html.h:2
-msgid "No host keys found."
-msgstr "Не знайдено ключів вузлів."
+#: pkg/kubernetes/views/add-member-role-dialog.html:15
+msgid "User or Group"
+msgstr "Користувач або група"
 
-#: pkg/systemd/index.html.h:3
-msgid "Synchronized with {{Server}}"
-msgstr "Синхронізовано із {{Server}}"
+#: pkg/kubernetes/views/auth-form.html:94
+msgid "Username"
+msgstr "Користувач"
 
-#: pkg/systemd/index.html.h:4
-msgid "Synchronized"
-msgstr "Синхронізовано"
+#: pkg/kubernetes/views/project-listing.html:85
+msgid "Users"
+msgstr "Користувачі"
 
-#: pkg/systemd/index.html.h:5
-msgid "Trying to synchronize with {{Server}}"
-msgstr "Намагаємося синхронізуватися з {{Server}}"
+#: pkg/storaged/details.js:181
+msgid "VFAT - Compatible with all systems and devices"
+msgstr "VFAT - Сумісна із усіма системами та пристроями"
 
-#: pkg/systemd/index.html.h:6
-msgid "Not synchronized"
-msgstr "Не синхронізовано"
+#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
+#: pkg/networkmanager/interfaces.js:2622
+msgid "VLAN"
+msgstr "VLAN"
 
-#: pkg/systemd/index.html.h:7
-msgid "Hardware"
-msgstr "Обладнання"
+#: pkg/networkmanager/index.html:141
+msgid "VLAN Id"
+msgstr "Ід. VLAN"
 
-#: pkg/systemd/index.html.h:8
-msgid "Asset Tag"
-msgstr "Мітка активу"
+#: pkg/networkmanager/index.html:736
+msgid "VLAN Settings"
+msgstr "Параметри VLAN"
 
-#: pkg/systemd/index.html.h:9 pkg/kubernetes/views/node-body.html.h:6
-msgid "Machine ID"
-msgstr "Ід. комп’ютера"
+#: pkg/users/authorized-keys.js:103
+msgid "Validating key"
+msgstr "Перевірка ключа"
 
-#: pkg/systemd/index.html.h:10 pkg/ostree/index.html.h:18
-#: pkg/kubernetes/views/nodes-page.html.h:6
-msgid "Operating System"
-msgstr "Операційна система"
+#: pkg/systemd/index.html:98 pkg/ostree/index.html:113 pkg/shell/simple.html:77
+#: pkg/shell/index.html:90 pkg/shell/stub.html:83
+msgid "Version"
+msgstr "Версія"
 
-#: pkg/systemd/index.html.h:11
-msgid "Secure Shell Keys"
-msgstr "Ключі захищеної оболонки (SSH)"
+#: pkg/storaged/jobs.js:137
+msgid "Very securely erasing $target"
+msgstr "Дуже безпечно витираємо $target"
 
-#: pkg/systemd/index.html.h:12
-msgid "Show fingerprints"
-msgstr "Показати відбитки"
+#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
+#: pkg/kubernetes/views/pvc-body.html:6
+msgid "Volume"
+msgstr "Том"
 
-#: pkg/systemd/index.html.h:14 pkg/dashboard/index.html.h:7
-msgid "Host Name"
-msgstr "Назва вузла"
+#: pkg/storaged/index.html:620
+msgid "Volume Group"
+msgstr "Група томів"
 
-#: pkg/systemd/index.html.h:15
-msgid "Domain"
-msgstr "Домен"
+#: pkg/storaged/utils.js:239
+msgid "Volume Group $0"
+msgstr "Група томів $0"
 
-#: pkg/systemd/index.html.h:16
-msgid "System Time"
-msgstr "Системний час"
+#: pkg/storaged/index.html:98
+msgid "Volume Groups"
+msgstr "Групи томів"
 
-#: pkg/systemd/index.html.h:17
-msgid "Power Options"
-msgstr "Параметри живлення"
+#: pkg/kubernetes/views/volume-body.html:14
+#: pkg/kubernetes/views/volume-body.html:89
+msgid "Volume ID"
+msgstr "Ід. тому"
 
-#: pkg/systemd/index.html.h:20
-msgid "Performance Profile"
-msgstr "Профіль швидкодії"
+#: pkg/kubernetes/views/pv-modify.html:115
+#: pkg/kubernetes/views/volume-body.html:42
+msgid "Volume Name"
+msgstr "Назва тому"
 
-#: pkg/systemd/index.html.h:21
-msgid "Store Performance Data"
-msgstr "Зберігати дані щодо швидкодії"
+#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
+msgid "Volume Type"
+msgstr "Тип тому"
 
-#: pkg/systemd/index.html.h:32
-msgid "Machine SSH Key Fingerprints"
-msgstr "Відбитки ключів SSH комп’ютерів"
+#: pkg/docker/index.html:536 pkg/kubernetes/views/pod-page.html:18
+#: pkg/kubernetes/views/image-config.html:28
+#: pkg/kubernetes/views/dashboard-page.html:47 pkg/kubernetes/index.html:70
+msgid "Volumes"
+msgstr "Томи"
 
-#: pkg/systemd/index.html.h:33
-msgid "Pretty Host Name"
-msgstr "Зручна назва вузла"
+#: pkg/networkmanager/interfaces.js:819
+msgid "Waiting"
+msgstr "Очікування"
 
-#: pkg/systemd/index.html.h:34
-msgid "Real Host Name"
-msgstr "Справжня назва вузла"
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid "Warning:"
+msgstr "Попередження:"
 
-#: pkg/systemd/index.html.h:35
-msgid "Time Zone"
-msgstr "Часовий пояс"
-
-#: pkg/systemd/index.html.h:36
-msgid ""
-"\n"
-"                                    Invalid time zone\n"
-"                                "
-msgstr ""
-"\n"
-"                           Некоректний часовий пояс\n"
-"                      "
-
-#: pkg/systemd/index.html.h:39
-msgid "Set Time"
-msgstr "Встановити час"
-
-#: pkg/systemd/index.html.h:40
-msgid "Manually"
-msgstr "Вручну"
-
-#: pkg/systemd/index.html.h:41
-msgid "Automatically using NTP"
-msgstr "Автоматично на основі NTP"
-
-#: pkg/systemd/index.html.h:42
-msgid "Automatically using specific NTP servers"
-msgstr "Автоматично за допомогою певних серверів NTP"
-
-#: pkg/systemd/index.html.h:43
-msgid "Delay"
-msgstr "Затримка"
-
-#: pkg/systemd/index.html.h:44
-msgid "1 Minute"
-msgstr "1 хвилина"
-
-#: pkg/systemd/index.html.h:45
-msgid "5 Minutes"
-msgstr "5 хвилин"
-
-#: pkg/systemd/index.html.h:46
-msgid "20 Minutes"
-msgstr "20 хвилин"
-
-#: pkg/systemd/index.html.h:47
-msgid "40 Minutes"
-msgstr "40 хвилин"
-
-#: pkg/systemd/index.html.h:48
-msgid "60 Minutes"
-msgstr "60 хвилин"
-
-#: pkg/systemd/index.html.h:49
-msgid "No Delay"
-msgstr "Без затримки"
-
-#: pkg/systemd/index.html.h:50
-msgid "Specific Time"
-msgstr "У визначений час"
-
-#: pkg/systemd/index.html.h:51
-msgid ""
-"\n"
-"                        Cancel\n"
-"                    "
-msgstr ""
-"\n"
-"              Скасувати\n"
-"            "
-
-#: pkg/systemd/logs.html.h:1
-msgid "Journal"
-msgstr "Журнал"
-
-#: pkg/systemd/logs.html.h:2
-msgid "Recent"
-msgstr "Нещодавні"
-
-#: pkg/systemd/logs.html.h:3
-msgid "Current boot"
-msgstr "Поточне завантаження"
-
-#: pkg/systemd/logs.html.h:4
-msgid "Last 24 hours"
-msgstr "Попередні 24 години"
-
-#: pkg/systemd/logs.html.h:5
-msgid "Last 7 days"
-msgstr "Попередні 7 днів"
-
-#: pkg/systemd/logs.html.h:6
-msgid "Errors"
-msgstr "Помилки"
-
-#: pkg/systemd/logs.html.h:7
+#: pkg/systemd/logs.html:48
 msgid "Warnings"
 msgstr "Попередження"
 
-#: pkg/systemd/logs.html.h:8
-msgid "Notices"
-msgstr "Примітки"
-
-#: pkg/systemd/logs.html.h:9
-msgid "All"
-msgstr "Всі"
-
-#: pkg/systemd/logs.html.h:10 pkg/kubernetes/views/container-panel.html.h:2
-#: pkg/kubernetes/views/container-page-inline.html.h:2
-msgid "Logs"
-msgstr "Журнали"
-
-#: pkg/systemd/logs.html.h:11
-msgid "Entry"
-msgstr "Запис"
-
-#: pkg/systemd/services.html.h:1 pkg/kubernetes/views/dashboard-page.html.h:12
-#: pkg/kubernetes/views/details-page.html.h:3
-msgid "Services"
-msgstr "Служби"
-
-#: pkg/systemd/services.html.h:3
-msgid "System Services"
-msgstr "Служби системи"
-
-#: pkg/systemd/services.html.h:4
-msgid "Sockets"
-msgstr "Сокети"
-
-#: pkg/systemd/services.html.h:5
-msgid "Timers"
-msgstr "Таймери"
-
-#: pkg/systemd/services.html.h:6
-msgid "Paths"
-msgstr "Шляхи"
-
-#: pkg/systemd/services.html.h:7
-msgid "Instantiate"
-msgstr "Створити екземпляр"
-
-#: pkg/systemd/services.html.h:8
-msgid "{{days_text}}"
-msgstr ""
-
-#: pkg/systemd/services.html.h:9
-msgid "Service Logs"
-msgstr "Журнали служб"
-
-#: pkg/systemd/services.html.h:10
-msgid "Note"
-msgstr "Примітка"
-
-#: pkg/systemd/services.html.h:11
-msgid ""
-"This unit is not designed to be enabled explicitly.\n"
-"          "
-msgstr ""
-"Цей модуль створено для вмикання явним чином.\n"
-"          "
-
-#: pkg/systemd/services.html.h:15
-#, fuzzy
-msgid "Create Timers"
-msgstr "Створити тонкий том"
-
-#: pkg/systemd/services.html.h:16
-#, fuzzy
-msgid "Service name"
-msgstr "Служба"
-
-#: pkg/systemd/services.html.h:18 pkg/docker/index.html.h:32
-msgid "Command"
-msgstr "Команда"
-
-#: pkg/systemd/services.html.h:19
-#, fuzzy
-msgid "Run"
-msgstr "Запустити від імені"
-
-#: pkg/systemd/services.html.h:20
-#, fuzzy
-msgid "After system boot"
-msgstr "Зареєструвати систему"
-
-#: pkg/systemd/services.html.h:21
-#, fuzzy
-msgid "At specific time"
-msgstr "У визначений час"
-
-#: pkg/systemd/services.html.h:22
-msgid "Seconds"
-msgstr ""
-
-#: pkg/systemd/services.html.h:23
-#, fuzzy
-msgid "Minutes"
-msgstr "5 хвилин"
-
-#: pkg/systemd/services.html.h:24
-#, fuzzy
-msgid "Hours"
-msgstr "6 годин"
-
-#: pkg/systemd/services.html.h:25
+#: pkg/systemd/services.html:409
 msgid "Weeks"
 msgstr ""
 
-#: pkg/systemd/services.html.h:26
-msgid "Don't Repeat"
-msgstr ""
+#: pkg/kubernetes/views/registry-dashboard-page.html:5
+msgid "Welcome to the Image Registry"
+msgstr "Вітаємо у реєстрі образів"
 
-#: pkg/systemd/services.html.h:27
-msgid "Repeat Hourly"
-msgstr ""
+#: pkg/kubernetes/views/volumes-page.html:61
+msgid "When"
+msgstr "Умова"
 
-#: pkg/systemd/services.html.h:28
-msgid "Repeat Daily"
-msgstr ""
+#: pkg/docker/index.html:507
+msgid "With terminal"
+msgstr "За допомогою термінала"
 
-#: pkg/systemd/services.html.h:29
-msgid "Repeat Weekly"
-msgstr ""
+#: pkg/storaged/index.html:438
+msgctxt "storage"
+msgid "World Wide Name"
+msgstr "Глобальна назва (WWN)"
 
-#: pkg/systemd/services.html.h:30
-msgid "Repeat Monthly"
-msgstr ""
+#: pkg/storaged/details.js:1595
+msgid "Write-mostly"
+msgstr "Здебільшого запис"
 
-#: pkg/systemd/services.html.h:31
-msgid "Repeat Yearly"
-msgstr ""
+#: pkg/storaged/index.html:333
+msgid "Writing"
+msgstr "Запис"
 
-#: pkg/systemd/services.html.h:32
-#, fuzzy
-msgid "Hour : Minute"
-msgstr "1 хвилина"
+#: pkg/ostree/client.js:64
+msgid "Writing objects"
+msgstr "Записуємо об’єкти"
 
-#: pkg/systemd/services.html.h:33
-msgid ":"
-msgstr ""
+#: pkg/storaged/details.js:177
+msgid "XFS - Red Hat Enterprise Linux 7 default"
+msgstr "XFS - Типова для Red Hat Enterprise Linux 7"
 
-#: pkg/systemd/services.html.h:35
-msgid "Save"
-msgstr ""
+#: pkg/networkmanager/interfaces.js:1824
+msgid "XOR"
+msgstr "XOR"
 
-#: pkg/systemd/terminal.html.h:1
-msgid "Terminal"
-msgstr "Термінал"
+#: pkg/kubernetes/scripts/volumes.js:990 pkg/networkmanager/interfaces.js:2279
+msgid "Yes"
+msgstr "Так"
 
-#: pkg/lib/machine-invalid-hostkey.html.h:1
-msgid "Incorrect Host Key"
-msgstr "Неправильний ключ вузла"
-
-#: pkg/lib/machine-invalid-hostkey.html.h:2
-msgid ""
-"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
-"in use. Unless this machine was recently replaced, it is likely that someone "
-"is trying to attack your connection to this machine."
-msgstr ""
-"Ключ {{#strong}}{{host}}{{/strong}} не відповідає раніше використаному "
-"ключу. Якщо нещодавно ніхто не міняв цього комп’ютера, ймовірною причиною є "
-"спроба атаки на ваше з’єднання із цим комп’ютером."
-
-#: pkg/lib/machine-invalid-hostkey.html.h:3
-msgid ""
-"You can remove the previously stored key by running the following command"
-msgstr "Вилучити раніше збережений ключ можна за допомогою такої команди"
-
-#: pkg/lib/machine-auth-failed.html.h:1
-msgid "Authentication Failed"
-msgstr "Не вдалося пройти розпізнавання"
-
-#: pkg/lib/machine-auth-failed.html.h:2
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
-"machine with cockpit you will need to enable one of the following "
-"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
-msgstr ""
-"Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. Щоб "
-"користуватися цим комп’ютером за допомогою cockpit, вам слід увімкнути "
-"вказані нижче способи розпізнавання у налаштуваннях sshd на {{#strong}}"
-"{{host}}{{/strong}}:"
-
-#: pkg/lib/machine-auth-failed.html.h:4 pkg/shell/index.html.h:30
-msgid "Public Key"
-msgstr "Відкритий ключ"
-
-#: pkg/lib/machine-auth-failed.html.h:5
-msgid "Kerberos Based SSO"
-msgstr "SSO на основі Kerberos"
-
-#: pkg/lib/machine-auth-failed.html.h:6
-msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
-msgstr ""
-"Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"Вам варто спробувати {{#sync_link}}синхронізувати користувачів{{/sync_link}}."
-"{{/can_sync}} Щоб отримати доступ до ширшого спектра способів розпізнавання "
-"та до підтримки діагностики помилок, будь ласка, оновіть cockpit-ws."
-
-#: pkg/lib/machine-sync-users.html.h:1 pkg/dashboard/index.html.h:11
-msgid "Synchronize users"
-msgstr "Синхронізувати користувачів"
-
-#: pkg/lib/machine-sync-users.html.h:2
-msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
-msgstr ""
-"Виберіть користувачів, записи яких ви б хотіли синхронізувати з {{#strong}}"
-"{{host}}{{/strong}}"
-
-#: pkg/lib/machine-sync-users.html.h:3
-msgid "Error loading users: {{perm_failed}}"
-msgstr "Помилка під час завантаження списку користувачів: {{perm_failed}}"
-
-#: pkg/lib/machine-sync-users.html.h:4
+#: pkg/lib/machine-sync-users.html:47
 msgid ""
 "You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
 "synchronize users, a user with superuser privileges is required."
@@ -3702,2267 +6244,14 @@ msgstr ""
 "синхронізації даних користувачів потрібні права доступу адміністративного "
 "користувача."
 
-#: pkg/lib/machine-sync-users.html.h:5 pkg/lib/machine-change-auth.html.h:4
-msgid "User name"
-msgstr "Ім'я користувача"
-
-#: pkg/lib/machine-sync-users.html.h:8
-msgid "Synchronize"
-msgstr "Синхронізувати"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:1
-msgid "Unknown Host Key"
-msgstr "Невідомий ключ вузла"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:2
+#: pkg/dashboard/list.js:394
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
+"You are currently connected directly to this server. You cannot delete it."
 msgstr ""
-"Не вдалося встановити ідентичність вузла {{#strong}}{{host}}{{/strong}}. Ви "
-"справді хочете продовжити спробу встановити з’єднання?"
+"Зараз ваш комп’ютер безпосередньо з’єднано із цим сервером. Ви не можете "
+"його вилучити."
 
-#: pkg/lib/machine-unknown-hostkey.html.h:3 pkg/shell/index.html.h:4
-msgid "Fingerprint"
-msgstr "Відбиток"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:5
-#: pkg/kubernetes/views/auth-form.html.h:14
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:6
-msgid "Connect"
-msgstr "З'єднатися"
-
-#: pkg/lib/machine-add.html.h:1
-msgid "Add Machine to Dashboard"
-msgstr "Додати запис комп’ютера на панель"
-
-#: pkg/lib/machine-add.html.h:3 pkg/dashboard/index.html.h:9
-msgid "Color"
-msgstr "Колір"
-
-#: pkg/lib/machine-add.html.h:4
-msgid ""
-"Connecting simultaneously to more than {{ limit }} machines is unsupported."
-msgstr ""
-"Підтримки одночасного з’єднання із понад {{ limit }} комп’ютерами не "
-"передбачено."
-
-#: pkg/lib/machine-change-port.html.h:1
-msgid "Could not contact {{host}}"
-msgstr "Не вдалося встановити зв’язок із {{host}}"
-
-#: pkg/lib/machine-change-port.html.h:2
-msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
-msgstr ""
-"Cockpit не вдалося встановити зв’язок ізt {{#strong}}{{host}}{{/strong}}."
-
-#: pkg/lib/machine-change-port.html.h:3
-msgid ""
-"To try a different port you will need to upgrade cockpit-ws to a newer "
-"version."
-msgstr "Щоб спробувати інший порт, вам слід оновити cockpit-ws."
-
-#: pkg/lib/machine-change-port.html.h:4
-msgid "Is sshd running on a different port?"
-msgstr "sshd працює на іншому порті?"
-
-#: pkg/lib/machine-change-port.html.h:7
-msgid "Update"
-msgstr "Оновити"
-
-#: pkg/lib/machine-not-supported.html.h:1
-msgid "Cockpit is not installed"
-msgstr "Cockpit не встановлено"
-
-#: pkg/lib/machine-not-supported.html.h:2
-msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
-msgstr ""
-"У {{#strong}}{{host}}{{/strong}} не встановлено сумісної версії Cockpit."
-
-#: pkg/lib/machine-change-auth.html.h:1
-msgid "Log in to {{host}}"
-msgstr "Вхід до {{host}}"
-
-#: pkg/lib/machine-change-auth.html.h:2
-msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
-msgstr "Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}."
-
-#: pkg/lib/machine-change-auth.html.h:3
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
-msgstr ""
-"Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. Ви можете "
-"змінити ваші реєстраційні дані для розпізнавання нижче. {{#can_sync}}"
-"Можливо, варто надати перевагу {{#sync_link}}синхронізації облікових записів "
-"і паролів{{/sync_link}}.{{/can_sync}}"
-
-#: pkg/lib/machine-change-auth.html.h:5 pkg/shell/index.html.h:9
-#: pkg/realmd/operation.html.h:3 pkg/kubernetes/views/auth-form.html.h:8
-msgid "Authentication"
-msgstr "Розпізнавання"
-
-#: pkg/lib/machine-change-auth.html.h:7
-msgid "Available"
-msgstr "Доступні"
-
-#: pkg/lib/machine-change-auth.html.h:8
-msgid "Login Password"
-msgstr "Пароль користувача"
-
-#: pkg/lib/machine-change-auth.html.h:9
-msgid "Kerberos Ticket"
-msgstr "Квиток Kerberos"
-
-#: pkg/lib/machine-change-auth.html.h:10
-msgid "Checking for public keys"
-msgstr "Шукаємо відкриті ключі"
-
-#: pkg/lib/machine-change-auth.html.h:12
-msgid "Log In"
-msgstr "Увійти"
-
-#: pkg/shell/shell.html.h:1
-msgid "Things have moved"
-msgstr ""
-
-#: pkg/shell/index.html.h:2
-msgid "Comment"
-msgstr "Коментар"
-
-#: pkg/shell/index.html.h:5 pkg/shell/stub.html.h:2 pkg/shell/simple.html.h:2
-msgid "Ooops!"
-msgstr "Вибачте!"
-
-#: pkg/shell/index.html.h:6 pkg/shell/stub.html.h:3 pkg/shell/simple.html.h:3
-msgid "Display Language"
-msgstr "Мова перекладу"
-
-#: pkg/shell/index.html.h:7 pkg/shell/stub.html.h:4 pkg/shell/simple.html.h:4
-msgid "About Cockpit"
-msgstr "Про Cockpit"
-
-#: pkg/shell/index.html.h:8
-msgid "Account Settings"
-msgstr "Параметри облікового запису"
-
-#: pkg/shell/index.html.h:10 pkg/shell/stub.html.h:5 pkg/shell/simple.html.h:5
-msgid "Log out"
-msgstr "Вийти"
-
-#: pkg/shell/index.html.h:11 pkg/shell/stub.html.h:6 pkg/shell/simple.html.h:6
-msgid ""
-"\n"
-"              Cockpit is an interactive Linux server admin interface.\n"
-"            "
-msgstr ""
-"\n"
-"              Cockpit — інтерактивний інтерфейс адміністратора сервера "
-"Linux.\n"
-"            "
-
-#: pkg/shell/index.html.h:15 pkg/shell/stub.html.h:10
-#: pkg/shell/simple.html.h:10
-msgid "Choose the language to be used in the application"
-msgstr "Виберіть мову перекладу, яку буде використано для інтерфейсу програми"
-
-#: pkg/shell/index.html.h:16 pkg/shell/stub.html.h:11
-#: pkg/shell/simple.html.h:11 pkg/storaged/index.html.h:59
-msgid ""
-"\n"
-"              Cancel\n"
-"            "
-msgstr ""
-"\n"
-"              Скасувати\n"
-"            "
-
-#: pkg/shell/index.html.h:19 pkg/shell/stub.html.h:14
-#: pkg/shell/simple.html.h:14
-msgid ""
-"\n"
-"              Select\n"
-"            "
-msgstr ""
-"\n"
-"              Вибрати\n"
-"            "
-
-#: pkg/shell/index.html.h:22 pkg/shell/stub.html.h:17
-msgid ""
-"\n"
-"              Close\n"
-"            "
-msgstr ""
-"\n"
-"              Закрити\n"
-"            "
-
-#: pkg/shell/index.html.h:25
-msgid "Use my password for privileged tasks and to connect to other machines"
-msgstr ""
-"Використати ваш пароль для привілейованих завдань та з’єднання з іншими "
-"комп’ютерами"
-
-#: pkg/shell/index.html.h:26
-msgid "Use the following keys to authenticate against other systems"
-msgstr "Використати вказані нижче ключі для розпізнавання у інших системах"
-
-#: pkg/shell/index.html.h:29 pkg/kubernetes/index.html.h:6
-msgid "Details"
-msgstr "Подробиці"
-
-#: pkg/shell/index.html.h:32
-msgid "Unlock Key"
-msgstr "Розблокувати ключ"
-
-#: pkg/shell/index.html.h:33 pkg/users/index.html.h:23
-msgid "Old Password"
-msgstr "Старий пароль"
-
-#: pkg/shell/index.html.h:34 pkg/users/index.html.h:24
-msgid "New Password"
-msgstr "Новий пароль"
-
-#: pkg/shell/index.html.h:35 pkg/users/index.html.h:19
-msgid "Confirm"
-msgstr "Підтвердити"
-
-#: pkg/shell/index.html.h:36
-msgid "Change Password"
-msgstr "Змінити пароль"
-
-#: pkg/shell/index.html.h:38 pkg/shell/stub.html.h:20
-msgid ""
-"\n"
-"                Tools\n"
-"              "
-msgstr ""
-"\n"
-"                Інструменти\n"
-"              "
-
-#: pkg/shell/index.html.h:41 pkg/shell/stub.html.h:23
-#: pkg/shell/simple.html.h:24
-msgid "Reconnect"
-msgstr "Повторно з’єднатися"
-
-#: pkg/shell/index.html.h:42 pkg/shell/stub.html.h:24
-msgid "Troubleshoot"
-msgstr "Діагностика проблем"
-
-#: pkg/shell/simple.html.h:18
-msgid ""
-"\n"
-"              Try to reconnect\n"
-"            "
-msgstr ""
-"\n"
-"              Спробувати з’єднатися знову\n"
-"            "
-
-#: pkg/shell/simple.html.h:21
-msgid ""
-"\n"
-"              Log in again\n"
-"            "
-msgstr ""
-"\n"
-"              Увійти знову\n"
-"            "
-
-#: pkg/ostree/index.html.h:1
-msgid "Software Updates"
-msgstr "Оновлення програм"
-
-#: pkg/ostree/index.html.h:2
-msgid "Check for updates"
-msgstr "Перевірити оновлення"
-
-#: pkg/ostree/index.html.h:3
-msgid ""
-"\n"
-"                    Update and reboot\n"
-"                "
-msgstr ""
-"\n"
-"                    Оновити і перезавантажити\n"
-"                "
-
-#: pkg/ostree/index.html.h:6
-msgid "Roll back and reboot"
-msgstr "Відкотити і перезавантажити"
-
-#: pkg/ostree/index.html.h:8
-msgid ""
-"\n"
-"                    Default\n"
-"                  "
-msgstr ""
-"\n"
-"                    Типовий\n"
-"                  "
-
-#: pkg/ostree/index.html.h:11
-msgid ""
-"\n"
-"                    Available\n"
-"                  "
-msgstr ""
-"\n"
-"                    Доступний\n"
-"                  "
-
-#: pkg/ostree/index.html.h:16
-msgid "Tree"
-msgstr "Дерево"
-
-#: pkg/ostree/index.html.h:17
-msgid "Packages"
-msgstr "Пакунки"
-
-#: pkg/ostree/index.html.h:20
-msgid "Released"
-msgstr "Випущено"
-
-#: pkg/ostree/index.html.h:21
-msgid "Additions"
-msgstr "Додавання"
-
-#: pkg/ostree/index.html.h:22
-msgid "Removals"
-msgstr "Вилучення"
-
-#: pkg/ostree/index.html.h:23
-msgid "Updates"
-msgstr "Оновлення"
-
-#: pkg/ostree/index.html.h:24
-msgid "Downgrades"
-msgstr "Зниження"
-
-#: pkg/ostree/index.html.h:25
-msgid ""
-"\n"
-"                    This deployment contains the same packages as your "
-"currently booted system\n"
-"                "
-msgstr ""
-"\n"
-"                    У цьому розгортанні містяться деякі пакунки, які є у "
-"поточній завантаженій системі\n"
-"                "
-
-#: pkg/ostree/index.html.h:28
-msgid "Operating System Updates"
-msgstr "Оновлення операційної системи"
-
-#: pkg/ostree/index.html.h:29
-msgid "Connecting"
-msgstr "Встановлюємо з’єднання"
-
-#: pkg/ostree/index.html.h:30
-msgid "Unable to communicate with OSTree"
-msgstr "Не вдалося обмінятися даними з OSTree"
-
-#: pkg/ostree/index.html.h:31
-msgid "No Deployments"
-msgstr "Немає розгортань"
-
-#: pkg/ostree/index.html.h:32
-msgid ""
-"\n"
-"                    Reconnect\n"
-"                "
-msgstr ""
-"\n"
-"                    Повторно з’єднатися\n"
-"                "
-
-#: pkg/selinux/setroubleshoot.html.h:1
-msgid "SELinux Troubleshoot"
-msgstr "Усування вад SELinux"
-
-#: pkg/machines/index.html.h:1
-msgid "Virtual Machines Management"
-msgstr ""
-
-#: pkg/storaged/index.html.h:1
-msgid "Storage"
-msgstr "Сховище даних"
-
-#: pkg/storaged/index.html.h:2
-msgid "The \"storaged\" API is not available on this system."
-msgstr "У цій системі програмний інтерфейс «storaged» є недоступним."
-
-#: pkg/storaged/index.html.h:3
-msgid "Start Multipath"
-msgstr "Запустити Multipath"
-
-#: pkg/storaged/index.html.h:4
-msgid ""
-"\n"
-"        There are devices with multiple paths on the system, but the "
-"multipath service is not running.\n"
-"      "
-msgstr ""
-"\n"
-"        У системі є пристрої із декількома шляхами доступу, але службу "
-"multipath не запущено.\n"
-"      "
-
-#: pkg/storaged/index.html.h:7
-msgid "RAID Devices"
-msgstr "Пристрої RAID"
-
-#: pkg/storaged/index.html.h:8
-msgid "No storage set up as RAID"
-msgstr "Жодне зі сховищ даних не налаштовано як RAID"
-
-#: pkg/storaged/index.html.h:9
-msgid "Volume Groups"
-msgstr "Групи томів"
-
-#: pkg/storaged/index.html.h:10
-msgid "No volume groups created"
-msgstr "Груп томів не створено"
-
-#: pkg/storaged/index.html.h:11
-msgid "iSCSI Targets"
-msgstr "Призначення iSCSI"
-
-#: pkg/storaged/index.html.h:12
-msgid "{{Address}}:{{Port}}"
-msgstr "{{Address}}:{{Port}}"
-
-#: pkg/storaged/index.html.h:13
-msgid "No iSCSI targets set up"
-msgstr "Призначень iSCSI не налаштовано"
-
-#: pkg/storaged/index.html.h:14
-msgid "Drives"
-msgstr "Диски"
-
-#: pkg/storaged/index.html.h:15
-msgid "No drives attached"
-msgstr "Не долучено жодного диска"
-
-#: pkg/storaged/index.html.h:16
-msgid "Other Devices"
-msgstr "Інші пристрої"
-
-#: pkg/storaged/index.html.h:17
-msgid "Filesystems"
-msgstr "Файлові системи"
-
-#: pkg/storaged/index.html.h:21
-msgid "Jobs"
-msgstr "Завдання"
-
-#: pkg/storaged/index.html.h:23 pkg/networkmanager/index.html.h:3
-msgid "Go to now"
-msgstr "Перейти зараз"
-
-#: pkg/storaged/index.html.h:24 pkg/networkmanager/index.html.h:4
-msgid "5 minutes"
-msgstr "5 хвилин"
-
-#: pkg/storaged/index.html.h:25 pkg/networkmanager/index.html.h:5
-msgid "1 hour"
-msgstr "1 година"
-
-#: pkg/storaged/index.html.h:26 pkg/networkmanager/index.html.h:6
-msgid "6 hours"
-msgstr "6 годин"
-
-#: pkg/storaged/index.html.h:27 pkg/networkmanager/index.html.h:7
-msgid "1 day"
-msgstr "1 день"
-
-#: pkg/storaged/index.html.h:28 pkg/networkmanager/index.html.h:8
-msgid "1 week"
-msgstr "1 тиждень"
-
-#: pkg/storaged/index.html.h:29
-msgid "Reading"
-msgstr "Читання"
-
-#: pkg/storaged/index.html.h:30
-msgid "Writing"
-msgstr "Запис"
-
-#: pkg/storaged/index.html.h:31
-msgid "Storage Logs"
-msgstr "Журнали зберігання"
-
-#: pkg/storaged/index.html.h:32
-msgid "Create partition table"
-msgstr "Створити таблицю розділів"
-
-#: pkg/storaged/index.html.h:34
-msgid "Block Device"
-msgstr "Блоковий пристрій"
-
-#: pkg/storaged/index.html.h:40
-msgid "No media inserted"
-msgstr "Не виявлено носія даних"
-
-#: pkg/storaged/index.html.h:42
-msgid "DISK IS FAILING"
-msgstr "ДИСК НЕПРАЦЕЗДАТНИЙ"
-
-#: pkg/storaged/index.html.h:43
-msgid "Disk is OK"
-msgstr "З диском усе гаразд"
-
-#: pkg/storaged/index.html.h:46
-msgid "The RAID Array is in a degraded state"
-msgstr "Масив RAID перебуває у стані із погіршеними властивостями"
-
-#: pkg/storaged/index.html.h:47
-msgid "RAID Device"
-msgstr "пристрій RAID"
-
-#: pkg/storaged/index.html.h:56
-msgid "Volume Group"
-msgstr "Група томів"
-
-#: pkg/storaged/index.html.h:57
-msgid "Physical Volumes"
-msgstr "Фізичні томи"
-
-#: pkg/storaged/index.html.h:58
-msgid "Storage Log"
-msgstr "Журнал сховища даних"
-
-#: pkg/realmd/operation.html.h:1
-msgid "Domain Address"
-msgstr "Адреса домену"
-
-#: pkg/realmd/operation.html.h:2
-msgid "Computer OU"
-msgstr "OU комп’ютера"
-
-#: pkg/realmd/operation.html.h:4 pkg/users/index.html.h:11
-msgid "User Name"
-msgstr "Ім'я користувача"
-
-#: pkg/realmd/operation.html.h:5
-msgid "User Password"
-msgstr "Пароль користувача"
-
-#: pkg/realmd/operation.html.h:6
-msgid "Domain Administrator Name"
-msgstr "Ім’я адміністратора домену"
-
-#: pkg/realmd/operation.html.h:7
-msgid "Domain Administrator Password"
-msgstr "Пароль адміністратора домену"
-
-#: pkg/realmd/operation.html.h:8
-msgid "One Time Password"
-msgstr "Одноразовий пароль"
-
-#: pkg/realmd/operation.html.h:9
-msgid "This may take a while"
-msgstr "Зачекайте"
-
-#: pkg/docker/index.html.h:1 pkg/kubernetes/index.html.h:4
-#: pkg/kubernetes/views/containers-listing.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:6
-#: pkg/kubernetes/views/dashboard-page.html.h:17
-msgid "Containers"
-msgstr "Контейнери"
-
-#: pkg/docker/index.html.h:2
-msgid "Connecting to Docker"
-msgstr "Встановлюємо з’єднання із Docker"
-
-#: pkg/docker/index.html.h:3
-msgid "Not authorized to access Docker on this system"
-msgstr "Не уповноважено на доступ до Docker у цій системі"
-
-#: pkg/docker/index.html.h:4
-msgid "Docker is not installed or activated on the system"
-msgstr "Docker не встановлено або не активовано у цій системі"
-
-#: pkg/docker/index.html.h:5
-msgid "Can&rsquo;t connect to Docker"
-msgstr "Не вдалося зв’язатися із Docker"
-
-#: pkg/docker/index.html.h:6
-msgid "Start Docker"
-msgstr "Запустити Docker"
-
-#: pkg/docker/index.html.h:7
-msgid "Try again"
-msgstr "Повторити спробу"
-
-#: pkg/docker/index.html.h:8
-msgid "Combined CPU usage"
-msgstr "Поєднане використання процесора"
-
-#: pkg/docker/index.html.h:9
-msgid "Combined memory usage"
-msgstr "Поєднане використання пам’яті"
-
-#: pkg/docker/index.html.h:10
-#, fuzzy
-msgid "Show all containers"
-msgstr "Показати усі контейнери"
-
-#: pkg/docker/index.html.h:11
-msgid "IP Address:"
-msgstr "IP-адреса:"
-
-#: pkg/docker/index.html.h:12
-msgid "IP Prefix Length:"
-msgstr "Довжина префікса IP:"
-
-#: pkg/docker/index.html.h:13
-msgid "Gateway:"
-msgstr "Шлюз:"
-
-#: pkg/docker/index.html.h:14
-msgid "MAC Address:"
-msgstr "MAC-адреса:"
-
-#: pkg/docker/index.html.h:15 pkg/kubernetes/views/image-page.html.h:1
-msgid "Show all images"
-msgstr "Показати усі образи"
-
-#: pkg/docker/index.html.h:16 pkg/kubernetes/index.html.h:2
-#: pkg/kubernetes/registry.html.h:2
-msgid "Overview"
-msgstr "Огляд"
-
-#: pkg/docker/index.html.h:17
-msgid "Reset"
-msgstr "Скинути"
-
-#: pkg/docker/index.html.h:18
-msgid "Storage pool"
-msgstr "Буфер сховища"
-
-#: pkg/docker/index.html.h:19
-msgid "Additional Storage"
-msgstr "Додаткове сховище"
-
-#: pkg/docker/index.html.h:20
-msgid "TCP"
-msgstr "TCP"
-
-#: pkg/docker/index.html.h:21
-msgid "{{host_port_label}}"
-msgstr "{{host_port_label}}"
-
-#: pkg/docker/index.html.h:22
-msgid "{{host_volume_label}}"
-msgstr "{{host_volume_label}}"
-
-#: pkg/docker/index.html.h:24
-msgid "ReadWrite"
-msgstr "Запис-читання"
-
-#: pkg/docker/index.html.h:25
-msgid "ReadOnly"
-msgstr "Лише запис"
-
-#: pkg/docker/index.html.h:26
-msgid "{{envvar_key_label}}"
-msgstr "{{envvar_key_label}}"
-
-#: pkg/docker/index.html.h:27
-msgid "{{envvar_value_label}}"
-msgstr "{{envvar_value_label}}"
-
-#: pkg/docker/index.html.h:28
-msgid "select container"
-msgstr "вибрати контейнер"
-
-#: pkg/docker/index.html.h:29
-msgid "{{alias_label}}"
-msgstr "{{alias_label}}"
-
-#: pkg/docker/index.html.h:30 pkg/kubernetes/views/image-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:2
-#: pkg/kubernetes/views/image-page.html.h:2
-msgid "Image"
-msgstr "Образ"
-
-#: pkg/docker/index.html.h:31
-msgid "Container Name"
-msgstr "Назва контейнера"
-
-#: pkg/docker/index.html.h:33
-msgid "Memory limit"
-msgstr "Обмеження пам’яті"
-
-#: pkg/docker/index.html.h:34
-msgid "MiB"
-msgstr "МіБ"
-
-#: pkg/docker/index.html.h:35
-msgid "CPU priority"
-msgstr "Пріоритетність процесора"
-
-#: pkg/docker/index.html.h:36
-msgid "shares"
-msgstr "спільний"
-
-#: pkg/docker/index.html.h:37
-msgid "With terminal"
-msgstr "За допомогою термінала"
-
-#: pkg/docker/index.html.h:38
-msgid "Links"
-msgstr "Посилання"
-
-#: pkg/docker/index.html.h:40
-msgid "Expose container ports"
-msgstr "Відкрити порти контейнера"
-
-#: pkg/docker/index.html.h:41 pkg/kubernetes/index.html.h:7
-#: pkg/kubernetes/views/image-config.html.h:9
-#: pkg/kubernetes/views/pod-page.html.h:3
-#: pkg/kubernetes/views/dashboard-page.html.h:4
-msgid "Volumes"
-msgstr "Томи"
-
-#: pkg/docker/index.html.h:42
-msgid "Mount container volumes"
-msgstr "Змонтувати томи контейнера"
-
-#: pkg/docker/index.html.h:43 pkg/kubernetes/views/image-config.html.h:6
-#: pkg/kubernetes/views/container-body.html.h:9
-msgid "Environment"
-msgstr "Середовище"
-
-#: pkg/docker/index.html.h:44
-msgid "Set container environment variables"
-msgstr "Встановити змінні середовища контейнера"
-
-#: pkg/docker/index.html.h:45 pkg/kubernetes/views/pod-body.html.h:4
-msgid "Restart Policy"
-msgstr "Правила перезапуску"
-
-#: pkg/docker/index.html.h:47
-msgid "On Failure"
-msgstr "Якщо помилка"
-
-#: pkg/docker/index.html.h:50
-msgid "Retries:"
-msgstr "Кількість спроб:"
-
-#: pkg/docker/index.html.h:51 pkg/users/index.html.h:26
-#: pkg/networkmanager/index.html.h:52
-msgid ""
-"\n"
-"            Cancel\n"
-"          "
-msgstr ""
-"\n"
-"              Скасувати\n"
-"            "
-
-#: pkg/docker/index.html.h:54
-msgid ""
-"\n"
-"            Run\n"
-"          "
-msgstr ""
-"\n"
-"              Виконати\n"
-"            "
-
-#: pkg/docker/index.html.h:57
-msgid ""
-"\n"
-"            Download\n"
-"          "
-msgstr ""
-"\n"
-"              Отримати\n"
-"            "
-
-#: pkg/docker/index.html.h:60
-msgid ""
-"\n"
-"            Change\n"
-"          "
-msgstr ""
-"\n"
-"              Змінити\n"
-"            "
-
-#: pkg/docker/index.html.h:63
-msgid "Repository"
-msgstr "Сховище"
-
-#: pkg/docker/index.html.h:64
-msgid "Tag"
-msgstr "Мітка"
-
-#: pkg/docker/index.html.h:65 pkg/kubernetes/views/image-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:5
-msgid "Author"
-msgstr "Автор"
-
-#: pkg/docker/index.html.h:66
-msgid ""
-"\n"
-"            Commit\n"
-"          "
-msgstr ""
-"\n"
-"              Надіслати\n"
-"            "
-
-#: pkg/users/index.html.h:1
-msgid "Local Accounts"
-msgstr "Локальні облікові записи"
-
-#: pkg/users/index.html.h:2
-msgid ""
-"\n"
-"            Close\n"
-"          "
-msgstr ""
-"\n"
-"              Закрити\n"
-"            "
-
-#: pkg/users/index.html.h:5
-msgid "Create New Account"
-msgstr "Створити новий рахунок"
-
-#: pkg/users/index.html.h:6
-msgid "Account not available or cannot be edited."
-msgstr "Обліковий запис недоступний або його не можна редагувати."
-
-#: pkg/users/index.html.h:7
-msgid "Accounts"
-msgstr "Облікові записи"
-
-#: pkg/users/index.html.h:8
-msgid "Terminate Session"
-msgstr "Перервати сеанс"
-
-#: pkg/users/index.html.h:10
-msgid "Full Name"
-msgstr "Повне ім'я"
-
-#: pkg/users/index.html.h:12
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:3
-#: pkg/kubernetes/views/project-body.html.h:2
-msgid "Roles"
-msgstr "Ролі"
-
-#: pkg/users/index.html.h:13
-msgid "Last Login"
-msgstr "Останній вхід"
-
-#: pkg/users/index.html.h:14
-msgid "Access"
-msgstr "Доступ"
-
-#: pkg/users/index.html.h:15
-msgid "Lock Account"
-msgstr "Заблокувати обліковий запис"
-
-#: pkg/users/index.html.h:17
-msgid "Set Password"
-msgstr "Встановити пароль"
-
-#: pkg/users/index.html.h:18
-msgid "Authorized Public SSH Keys"
-msgstr "Уповноважені відкриті ключі SSH"
-
-#: pkg/users/index.html.h:20
-msgid ""
-"\n"
-"            Create\n"
-"          "
-msgstr ""
-"\n"
-"              Створити\n"
-"            "
-
-#: pkg/users/index.html.h:25
-msgid "Confirm New Password"
-msgstr "Підтвердження нового пароля"
-
-#: pkg/users/index.html.h:29
-msgid ""
-"\n"
-"            Set\n"
-"          "
-msgstr ""
-"\n"
-"              Встановити\n"
-"            "
-
-#: pkg/users/index.html.h:32
-msgid "Delete Files"
-msgstr "Вилучити файли"
-
-#: pkg/users/index.html.h:33 pkg/networkmanager/index.html.h:48
-msgid ""
-"\n"
-"            Delete\n"
-"          "
-msgstr ""
-"\n"
-"              Вилучити\n"
-"            "
-
-#: pkg/users/index.html.h:36
-msgid "Unnamed"
-msgstr "Без назви"
-
-#: pkg/users/index.html.h:37
-msgid "Invalid key"
-msgstr "Некоректний ключ"
-
-#: pkg/users/index.html.h:38
-msgid "There are no authorized public keys for this account."
-msgstr "Для цього облікового запису немає уповноважених відкритих ключів."
-
-#: pkg/users/index.html.h:39
-msgid ""
-"You do not have permission to view the authorized public keys for this "
-"account."
-msgstr ""
-"У вас немає прав доступу для перегляду уповноважених відкритих ключів для "
-"цього облікового запису."
-
-#: pkg/users/index.html.h:40
-msgid "Failed to load authorized keys."
-msgstr "Не вдалося завантажити уповноважені ключі."
-
-#: pkg/users/index.html.h:41
-msgid "Add public key"
-msgstr "Додати відкритий ключ"
-
-#: pkg/users/index.html.h:42
-msgid ""
-"\n"
-"            Add key\n"
-"          "
-msgstr ""
-"\n"
-"              Додати ключ\n"
-"            "
-
-#: pkg/sosreport/index.html.h:1
-msgid "Diagnostic reports"
-msgstr "Діагностичні звіти"
-
-#: pkg/sosreport/index.html.h:2
-msgid ""
-"\n"
-"        This tool will collect system configuration and diagnostic\n"
-"        information from this system for use with diagnosing problems\n"
-"        with the system.\n"
-"      "
-msgstr ""
-"\n"
-"        Ця програма збере дані щодо налаштувань системи і діагностичні\n"
-"        дані з цієї системи для виявлення причин проблем\n"
-"        у системі.\n"
-"      "
-
-#: pkg/sosreport/index.html.h:7
-msgid ""
-"\n"
-"        The collected information will be stored locally on the system.\n"
-"      "
-msgstr ""
-"\n"
-"        Зібрані дані буде збережено локально у операційній системі.\n"
-"      "
-
-#: pkg/sosreport/index.html.h:10
-msgid "Create report"
-msgstr "Створити звіт"
-
-#: pkg/sosreport/index.html.h:11
-msgid "Create diagnostic report"
-msgstr "Створити діагностичний звіт"
-
-#: pkg/sosreport/index.html.h:12
-msgid ""
-"\n"
-"                The generated archive contains data considered\n"
-"                sensitive and its content should be reviewed by the\n"
-"                originating organization before being passed to any\n"
-"                third party.\n"
-"              "
-msgstr ""
-"\n"
-"                У створеному архіві містяться дані, які є конфіденційними.\n"
-"                Його вміст має бути переглянути організацією походження,\n"
-"                перш ніж архів буде передано стороннім особам.\n"
-"              "
-
-#: pkg/sosreport/index.html.h:18
-msgid "Generating report"
-msgstr "Створюємо звіт"
-
-#: pkg/sosreport/index.html.h:19
-msgid "Done!"
-msgstr "Готово!"
-
-#: pkg/networkmanager/index.html.h:1
-msgid "Networking"
-msgstr "Робота у мережі"
-
-#: pkg/networkmanager/index.html.h:2
-msgid "Testing connection"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:9
-msgid "Sending"
-msgstr "Надсилання"
-
-#: pkg/networkmanager/index.html.h:10
-msgid "Receiving"
-msgstr "Отримання"
-
-#: pkg/networkmanager/index.html.h:11
-msgid "Interfaces"
-msgstr "Інтерфейси"
-
-#: pkg/networkmanager/index.html.h:12
-msgid "Add Bond"
-msgstr "Додати зв’язок"
-
-#: pkg/networkmanager/index.html.h:13
-#, fuzzy
-msgid "Add Team"
-msgstr "Додати учасника"
-
-#: pkg/networkmanager/index.html.h:14
-msgid "Add Bridge"
-msgstr "Додати місток"
-
-#: pkg/networkmanager/index.html.h:15
-msgid "Add VLAN"
-msgstr "Додати VLAN"
-
-#: pkg/networkmanager/index.html.h:17
-msgid "IP Address"
-msgstr "IP-адреса"
-
-#: pkg/networkmanager/index.html.h:18
-#, fuzzy
-msgid "Unmanaged Interfaces"
-msgstr "Інтерфейси"
-
-#: pkg/networkmanager/index.html.h:19
-msgid "Networking Logs"
-msgstr "Журнали роботи у мережі"
-
-#: pkg/networkmanager/index.html.h:20
-msgid "Parent"
-msgstr "Батьківський"
-
-#: pkg/networkmanager/index.html.h:21
-msgid "VLAN Id"
-msgstr "Ід. VLAN"
-
-#: pkg/networkmanager/index.html.h:23
-msgid "Set to"
-msgstr "Встановити значення"
-
-#: pkg/networkmanager/index.html.h:25
-msgid "Spanning Tree Protocol (STP)"
-msgstr "Протокол пересування ієрархією (STP)"
-
-#: pkg/networkmanager/index.html.h:26
-msgid "STP Priority"
-msgstr "Пріоритет STP"
-
-#: pkg/networkmanager/index.html.h:27
-msgid "STP Forward delay"
-msgstr "Затримка переспрямування STP"
-
-#: pkg/networkmanager/index.html.h:28
-msgid "STP Hello time"
-msgstr "Час вітання STP"
-
-#: pkg/networkmanager/index.html.h:29
-msgid "STP Maximum message age"
-msgstr "Максимальний вік повідомлення STP"
-
-#: pkg/networkmanager/index.html.h:30
-msgid "Priority"
-msgstr "Пріоритетність"
-
-#: pkg/networkmanager/index.html.h:31
-msgid "Path cost"
-msgstr "Вартість маршруту"
-
-#: pkg/networkmanager/index.html.h:32
-msgid "Hair Pin mode"
-msgstr "Режим початкової зони"
-
-#: pkg/networkmanager/index.html.h:34
-msgid "Mode"
-msgstr "Режим"
-
-#: pkg/networkmanager/index.html.h:35
-msgid "Primary"
-msgstr "Основний"
-
-#: pkg/networkmanager/index.html.h:36
-msgid "Link Monitoring"
-msgstr "Спостереження за зв’язком"
-
-#: pkg/networkmanager/index.html.h:37
-msgid "Monitoring Interval"
-msgstr "Інтервал оновлення"
-
-#: pkg/networkmanager/index.html.h:38
-msgid "Monitoring Targets"
-msgstr "Спостерігаємо за цілями"
-
-#: pkg/networkmanager/index.html.h:39
-msgid "Link up delay"
-msgstr "Затримка встановлення зв’язку"
-
-#: pkg/networkmanager/index.html.h:40
-msgid "Link down delay"
-msgstr "Затримка розірвання зв’язку"
-
-#: pkg/networkmanager/index.html.h:41
-#, fuzzy
-msgid "Runner"
-msgstr "Працює"
-
-#: pkg/networkmanager/index.html.h:42
-msgid "Balancer"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:43
-#, fuzzy
-msgid "Link Watch"
-msgstr "Пов’язати локальний"
-
-#: pkg/networkmanager/index.html.h:44
-#, fuzzy
-msgid "Ping Interval"
-msgstr "Інтервал оновлення"
-
-#: pkg/networkmanager/index.html.h:45
-#, fuzzy
-msgid "Ping Target"
-msgstr "Призначення"
-
-#: pkg/networkmanager/index.html.h:46
-msgid "Sticky"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:47
-msgid "LACP Key"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:51
-msgid "IP Settings"
-msgstr "Параметри IP"
-
-#: pkg/networkmanager/index.html.h:55
-msgid ""
-"\n"
-"            Apply\n"
-"          "
-msgstr ""
-"\n"
-"              Застосувати\n"
-"            "
-
-#: pkg/networkmanager/index.html.h:58
-msgid "Bond Settings"
-msgstr "Параметри зв’язку"
-
-#: pkg/networkmanager/index.html.h:59
-#, fuzzy
-msgid "Team Settings"
-msgstr "Параметри IP"
-
-#: pkg/networkmanager/index.html.h:60
-#, fuzzy
-msgid "Team Port Settings"
-msgstr "Параметри порту містка"
-
-#: pkg/networkmanager/index.html.h:61
-msgid "Bridge Settings"
-msgstr "Параметри містка"
-
-#: pkg/networkmanager/index.html.h:62
-msgid "Bridge Port Settings"
-msgstr "Параметри порту містка"
-
-#: pkg/networkmanager/index.html.h:63
-msgid "VLAN Settings"
-msgstr "Параметри VLAN"
-
-#: pkg/networkmanager/index.html.h:64
-msgid "Ethernet MTU"
-msgstr "MTU Ethernet"
-
-#: pkg/networkmanager/index.html.h:66
-#, fuzzy
-msgid "Connection will be lost"
-msgstr "Вичерпано час очікування на з’єднання."
-
-#: pkg/kubernetes/index.html.h:1
-msgid "Kubernetes Cluster"
-msgstr "Кластер Kubernetes"
-
-#: pkg/kubernetes/index.html.h:3 pkg/kubernetes/views/dashboard-page.html.h:8
-#: pkg/kubernetes/views/nodes-page.html.h:4
-msgid "Nodes"
-msgstr "Вузли"
-
-#: pkg/kubernetes/index.html.h:5
-msgid "Topology"
-msgstr "Топологія"
-
-#: pkg/kubernetes/index.html.h:8 pkg/kubernetes/registry.html.h:3
-#: pkg/kubernetes/views/image-listing.html.h:2
-#: pkg/kubernetes/views/imagestream-page.html.h:3
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:5
-msgid "Images"
-msgstr "Зображення"
-
-#: pkg/kubernetes/index.html.h:9 pkg/kubernetes/registry.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:2
-#: pkg/kubernetes/views/project-listing.html.h:2
-#: pkg/kubernetes/views/user-delete.html.h:2
-msgid "Projects"
-msgstr "Проекти"
-
-#: pkg/kubernetes/index.html.h:11 pkg/kubernetes/registry.html.h:6
-msgid "Couldn't connect to server"
-msgstr "Не вдалося встановити з’єднання із сервером"
-
-#: pkg/kubernetes/index.html.h:12 pkg/kubernetes/registry.html.h:7
-msgid ""
-"\n"
-"                Reconnect\n"
-"            "
-msgstr ""
-"\n"
-"             Повторно з’єднатися\n"
-"          "
-
-#: pkg/kubernetes/index.html.h:15
-msgid ""
-"\n"
-"                Troubleshoot\n"
-"            "
-msgstr ""
-"\n"
-"                Усування вад\n"
-"            "
-
-#: pkg/kubernetes/registry.html.h:1
-msgid "Image Registry"
-msgstr "Реєстр образів"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:1
-#: pkg/kubernetes/views/service-body.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:1
-#: pkg/kubernetes/views/containers-listing.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:9
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:18
-#: pkg/kubernetes/views/route-body.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:5
-#: pkg/kubernetes/views/imagestream-modify.html.h:4
-msgid "Project"
-msgstr "Проект"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:2
-#: pkg/kubernetes/views/service-body.html.h:2
-#: pkg/kubernetes/views/pod-body.html.h:2
-#: pkg/kubernetes/views/containers-listing.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:10
-#: pkg/kubernetes/views/pv-claim.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:19
-#: pkg/kubernetes/views/route-body.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:6
-msgid "Namespace"
-msgstr "Простір назв"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:3
-#: pkg/kubernetes/views/pod-body.html.h:3
-#: pkg/kubernetes/views/node-body.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:3
-#: pkg/kubernetes/views/route-body.html.h:3
-msgid "Created"
-msgstr "Створено"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:4
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:17
-msgid "Replicas"
-msgstr "Репліки"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:5
-#: pkg/kubernetes/views/service-body.html.h:9
-#: pkg/kubernetes/views/pod-body.html.h:10
-#: pkg/kubernetes/views/node-body.html.h:12
-#: pkg/kubernetes/views/image-meta.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:8
-#: pkg/kubernetes/views/route-body.html.h:8
-msgid "Labels"
-msgstr "Мітки"
-
-#: pkg/kubernetes/views/service-body.html.h:4
-#: pkg/kubernetes/views/node-body.html.h:3
-msgid "IP"
-msgstr "IP"
-
-#: pkg/kubernetes/views/service-body.html.h:8
-msgid "Session Affinity"
-msgstr "Спорідненість сеансу"
-
-#: pkg/kubernetes/views/image-listing.html.h:1
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:10
-msgid "New image stream"
-msgstr "Новий потік образу"
-
-#: pkg/kubernetes/views/image-listing.html.h:3
-#: pkg/kubernetes/views/image-body.html.h:10
-#: pkg/kubernetes/views/imagestream-modify.html.h:7
-msgid "Tags"
-msgstr "Мітки"
-
-#: pkg/kubernetes/views/image-listing.html.h:5
-msgid "Last Updated"
-msgstr "Останнє оновлення"
-
-#: pkg/kubernetes/views/image-listing.html.h:6
-msgid "No image streams are present."
-msgstr "Немає потоків образів."
-
-#: pkg/kubernetes/views/node-delete.html.h:1
-msgid "Delete Node"
-msgstr "Вилучити вузол"
-
-#: pkg/kubernetes/views/node-delete.html.h:2
-msgid "Do you want to delete this Node?"
-msgstr "Хочете вилучити цей вузол?"
-
-#: pkg/kubernetes/views/node-delete.html.h:3
-msgid " 1\">Do you want to delete the following Nodes?"
-msgstr " 1\">Хочете вилучити вказані нижче вузли?"
-
-#: pkg/kubernetes/views/pod-container.html.h:1
-msgid "Show all Pod Containers"
-msgstr "Показати усі контейнери коконів"
-
-#: pkg/kubernetes/views/image-panel.html.h:3
-#: pkg/kubernetes/views/imagestream-page.html.h:4
-#: pkg/kubernetes/views/image-page.html.h:4
-msgid "Metadata"
-msgstr "Метадані"
-
-#: pkg/kubernetes/views/node-panel.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:8
-#: pkg/kubernetes/views/containers-listing.html.h:6
-#: pkg/kubernetes/views/node-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:11
-msgid "Node"
-msgstr "Вузол"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:1
-msgid "Show all Replication Controllers"
-msgstr "Показати усі контролери реплікації"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:2
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:5
-msgid "Replication Controller"
-msgstr "Контролер реплікації"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:2
-#: pkg/kubernetes/views/pv-claim.html.h:9
-#: pkg/kubernetes/views/dashboard-page.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:18
-msgid "Pods"
-msgstr "Кокони"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:2
-msgid "Template"
-msgstr "Шаблон"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:5
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr "Контролера реплікації «{{ target }}» не існує."
-
-#: pkg/kubernetes/views/group-delete.html.h:1
-msgid "Remove Group"
-msgstr "Вилучити групу"
-
-#: pkg/kubernetes/views/group-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:5
-#: pkg/kubernetes/views/user-group-remove.html.h:3
-msgid "Remove"
-msgstr "Вилучити"
-
-#: pkg/kubernetes/views/pvc-delete.html.h:1
-msgid "Delete Persistent Volume Claim"
-msgstr "Вилучити заявку на сталий том"
-
-#: pkg/kubernetes/views/pvc-delete.html.h:2
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr "Ви хочете вилучити заявку на сталий том «{{item.metadata.name}}»?"
-
-#: pkg/kubernetes/views/pvc-delete.html.h:3
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-"Ця заявка використовується. Її вилучення може призвести до проблем із цим "
-"коконом:"
-
-#: pkg/kubernetes/views/pod-body.html.h:5
-msgid "Service Account"
-msgstr "Обліковий запис служби"
-
-#: pkg/kubernetes/views/pod-body.html.h:6
-msgid "DNS Policy"
-msgstr "Правило DNS"
-
-#: pkg/kubernetes/views/pod-body.html.h:7
-msgid "Phase"
-msgstr "Фаза"
-
-#: pkg/kubernetes/views/pod-body.html.h:9
-msgid "Pod Address"
-msgstr "Адреса коконів"
-
-#: pkg/kubernetes/views/node-body.html.h:5
-msgid "OS"
-msgstr "ОС"
-
-#: pkg/kubernetes/views/node-body.html.h:7
-msgid "Boot ID"
-msgstr "Ід. завантаження"
-
-#: pkg/kubernetes/views/node-body.html.h:8
-msgid "Kernel Version"
-msgstr "Версія ядра"
-
-#: pkg/kubernetes/views/node-body.html.h:9
-msgid "Container Runtime Version"
-msgstr "Версія середовища контейнера"
-
-#: pkg/kubernetes/views/node-body.html.h:10
-msgid "Kubelet Version"
-msgstr "Версія Kubelet"
-
-#: pkg/kubernetes/views/node-body.html.h:11
-msgid "Proxy Version"
-msgstr "Версія проксі"
-
-#: pkg/kubernetes/views/node-body.html.h:13
-#: pkg/kubernetes/views/route-body.html.h:9
-msgid "none"
-msgstr "немає"
-
-#: pkg/kubernetes/views/node-body.html.h:17
-msgid "Reason"
-msgstr "Підстава"
-
-#: pkg/kubernetes/views/node-body.html.h:18
-#: pkg/kubernetes/views/pv-claim.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:6 pkg/kubernetes/views/pv-body.html.h:6
-msgid "Message"
-msgstr "Повідомлення"
-
-#: pkg/kubernetes/views/node-body.html.h:19
-msgid "Last Heartbeat"
-msgstr "Останній такт"
-
-#: pkg/kubernetes/views/node-body.html.h:20
-msgid "Last Status Change"
-msgstr "Остання зміна стану"
-
-#: pkg/kubernetes/views/node-body.html.h:21
-#: pkg/kubernetes/views/image-meta.html.h:3
-#: pkg/kubernetes/views/imagestream-meta.html.h:1
-#: pkg/kubernetes/views/route-body.html.h:10
-msgid "Annotations"
-msgstr "Анотації"
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:1
-msgid "Remove Role"
-msgstr "Вилучити роль"
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:2
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member "
-"{{ fields.member.metadata.name }}?"
-msgstr ""
-"Хочете вилучити роль «{{ fields.displayRole }}» із запису учасника {{ fields."
-"member.metadata.name }}?"
-
-#: pkg/kubernetes/views/project-listing.html.h:1
-msgid "New Project"
-msgstr "Новий проект"
-
-#: pkg/kubernetes/views/project-listing.html.h:6
-msgid "No projects are present."
-msgstr "Немає проектів."
-
-#: pkg/kubernetes/views/project-listing.html.h:7
-msgid "New Group"
-msgstr "Нова група"
-
-#: pkg/kubernetes/views/project-listing.html.h:8
-#: pkg/kubernetes/views/user-delete.html.h:3
-msgid "Groups"
-msgstr "Групи"
-
-#: pkg/kubernetes/views/project-listing.html.h:9
-msgid "No groups are present."
-msgstr "Немає груп."
-
-#: pkg/kubernetes/views/project-listing.html.h:10
-#: pkg/kubernetes/views/add-user-dialog.html.h:1
-msgid "Add User"
-msgstr "Додати користувача"
-
-#: pkg/kubernetes/views/project-listing.html.h:11
-msgid "Users"
-msgstr "Користувачі"
-
-#: pkg/kubernetes/views/project-listing.html.h:12
-msgid "Identity"
-msgstr "Профіль"
-
-#: pkg/kubernetes/views/project-listing.html.h:13
-msgid "Member of"
-msgstr "Учасник"
-
-#: pkg/kubernetes/views/project-listing.html.h:14
-msgid "No users are present."
-msgstr "Немає користувачів."
-
-#: pkg/kubernetes/views/auth-form.html.h:1
-msgid "Cluster"
-msgstr "Кластер"
-
-#: pkg/kubernetes/views/auth-form.html.h:2
-msgid "Add New Cluster"
-msgstr "Додати новий кластер"
-
-#: pkg/kubernetes/views/auth-form.html.h:4
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:3
-msgid "Skip Certificate Verification"
-msgstr "Пропустити перевірку сертифікатів"
-
-#: pkg/kubernetes/views/auth-form.html.h:5
-msgid "Requires Authentication"
-msgstr "Потрібне розпізнавання"
-
-#: pkg/kubernetes/views/auth-form.html.h:7
-msgid "Add New User"
-msgstr "Додати нового користувача"
-
-#: pkg/kubernetes/views/auth-form.html.h:9
-msgid "Client Certificate"
-msgstr "Сертифікат клієнта"
-
-#: pkg/kubernetes/views/auth-form.html.h:10
-msgid "Username"
-msgstr "Користувач"
-
-#: pkg/kubernetes/views/auth-form.html.h:12
-msgid "Token"
-msgstr "Елемент"
-
-#: pkg/kubernetes/views/node-add.html.h:1
-msgid "Add Cluster Node"
-msgstr "Додати вузол кластера"
-
-#: pkg/kubernetes/views/node-add.html.h:4
-msgid "Configuration"
-msgstr "Налаштування"
-
-#: pkg/kubernetes/views/node-add.html.h:5
-msgid "Configure Kubelet and Proxy"
-msgstr "Налаштувати Kubelet і проксі"
-
-#: pkg/kubernetes/views/node-add.html.h:6
-msgid "Configure Flannel networking"
-msgstr "Налаштувати роботу у мережі Flannel"
-
-#: pkg/kubernetes/views/volume-body.html.h:1
-#: pkg/kubernetes/views/pvc-body.html.h:1
-msgid "Volume Type"
-msgstr "Тип тому"
-
-#: pkg/kubernetes/views/volume-body.html.h:2
-msgid "{{ volume | formatVolumeType }}"
-msgstr "{{ volume | formatVolumeType }}"
-
-#: pkg/kubernetes/views/volume-body.html.h:3
-msgid "PD Name"
-msgstr "Назва PD"
-
-#: pkg/kubernetes/views/volume-body.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:19
-msgid "Filesystem Type"
-msgstr "Тип файлової системи"
-
-#: pkg/kubernetes/views/volume-body.html.h:6
-#: pkg/kubernetes/views/pv-modify.html.h:20
-msgid "Read Only"
-msgstr "Лише читання"
-
-#: pkg/kubernetes/views/volume-body.html.h:7
-msgid "Volume ID"
-msgstr "Ід. тому"
-
-#: pkg/kubernetes/views/volume-body.html.h:8
-msgid "Repository URL"
-msgstr "Адреса сховища"
-
-#: pkg/kubernetes/views/volume-body.html.h:9
-msgid "Revision"
-msgstr "Модифікація"
-
-#: pkg/kubernetes/views/volume-body.html.h:10
-#: pkg/kubernetes/views/image-config.html.h:3
-msgid "Directory"
-msgstr "Каталог"
-
-#: pkg/kubernetes/views/volume-body.html.h:12
-msgid "Medium"
-msgstr "Носій"
-
-#: pkg/kubernetes/views/volume-body.html.h:13
-#: pkg/kubernetes/views/pv-modify.html.h:14
-msgid "Path"
-msgstr "Шлях"
-
-#: pkg/kubernetes/views/volume-body.html.h:14
-msgid "Endpoint Name"
-msgstr "Назва кінцевої точки"
-
-#: pkg/kubernetes/views/volume-body.html.h:15
-#: pkg/kubernetes/views/pv-modify.html.h:13
-msgid "Volume Name"
-msgstr "Назва тому"
-
-#: pkg/kubernetes/views/volume-body.html.h:17
-msgid "Monitors"
-msgstr "Монітори"
-
-#: pkg/kubernetes/views/volume-body.html.h:18
-msgid "Image Name"
-msgstr "Назви предметів"
-
-#: pkg/kubernetes/views/volume-body.html.h:19
-msgid "Pool Name"
-msgstr "Назва буфера"
-
-#: pkg/kubernetes/views/volume-body.html.h:21
-msgid "Key Ring Path"
-msgstr "Шлях до сховища ключів"
-
-#: pkg/kubernetes/views/volume-body.html.h:22
-msgid "Secret Volume"
-msgstr "Секретний том"
-
-#: pkg/kubernetes/views/volume-body.html.h:23
-msgid "Target Portal"
-msgstr "Портал призначення"
-
-#: pkg/kubernetes/views/volume-body.html.h:24
-#: pkg/kubernetes/views/pv-modify.html.h:16
-msgid "Qualified Name"
-msgstr "Повна назва"
-
-#: pkg/kubernetes/views/volume-body.html.h:25
-#: pkg/kubernetes/views/pv-modify.html.h:17
-msgid "Logical Unit Number"
-msgstr "Логічний номер модуля"
-
-#: pkg/kubernetes/views/volume-body.html.h:26
-#: pkg/kubernetes/views/pv-modify.html.h:18
-msgid "Interface"
-msgstr "Інтерфейс"
-
-#: pkg/kubernetes/views/volume-body.html.h:27
-msgid "Ceph Monitors"
-msgstr "Монітори Ceph"
-
-#: pkg/kubernetes/views/volume-body.html.h:28
-msgid "Secret File"
-msgstr "Файл ключа"
-
-#: pkg/kubernetes/views/volume-body.html.h:29
-msgid "Target World Wide Names"
-msgstr "WWN призначень"
-
-#: pkg/kubernetes/views/volume-body.html.h:30
-msgid "Flocker Dataset Name"
-msgstr "Назва набору даних Flocker"
-
-#: pkg/kubernetes/views/volume-body.html.h:31
-msgid "Driver"
-msgstr "Драйвер"
-
-#: pkg/kubernetes/views/volume-body.html.h:33
-msgid "Share Name"
-msgstr "Назва ресурсу"
-
-#: pkg/kubernetes/views/volume-body.html.h:34
-msgid "Secret Name"
-msgstr "Назва ключа"
-
-#: pkg/kubernetes/views/image-meta.html.h:2
-msgid "On Build"
-msgstr "Збирання"
-
-#: pkg/kubernetes/views/image-meta.html.h:4
-msgid "Docker Version"
-msgstr "Версія Docker"
-
-#: pkg/kubernetes/views/image-meta.html.h:5
-msgid "Image Layers"
-msgstr "Шари образу"
-
-#: pkg/kubernetes/views/group-page.html.h:1
-#: pkg/kubernetes/views/user-page.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:1
-msgid "Show all Projects"
-msgstr "Показати усі проекти"
-
-#: pkg/kubernetes/views/group-page.html.h:2
-#: pkg/kubernetes/views/group-panel.html.h:1
-msgid "Group Members"
-msgstr "Учасники групи"
-
-#: pkg/kubernetes/views/group-page.html.h:3
-#: pkg/kubernetes/views/user-group-add.html.h:1
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:1
-#: pkg/kubernetes/views/group-panel.html.h:2
-#: pkg/kubernetes/views/project-body.html.h:10
-msgid "Add Member"
-msgstr "Додати учасника"
-
-#: pkg/kubernetes/views/group-page.html.h:4
-msgid "The group '{{ groupName }}' does not exist."
-msgstr "Групи «{{ groupName }}» не існує."
-
-#: pkg/kubernetes/views/containers-listing.html.h:3
-#: pkg/kubernetes/views/pod-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:2
-msgid "Pod"
-msgstr "Кокон"
-
-#: pkg/kubernetes/views/user-body.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:2
-msgid "Membership"
-msgstr "Участь"
-
-#: pkg/kubernetes/views/user-body.html.h:2
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
-msgstr ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
-
-#: pkg/kubernetes/views/user-body.html.h:5
-#: pkg/kubernetes/views/user-panel.html.h:7
-msgid "Add Membership"
-msgstr "Додати запис участі"
-
-#: pkg/kubernetes/views/user-group-add.html.h:2
-msgid ""
-"\n"
-"                        User\n"
-"                    "
-msgstr ""
-"\n"
-"                        Користувач\n"
-"                    "
-
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:2
-msgid "User or Group"
-msgstr "Користувач або група"
-
-#: pkg/kubernetes/views/pod-panel.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:4
-msgid "Mount Location"
-msgstr "Місце монтування"
-
-#: pkg/kubernetes/views/route-modify.html.h:1
-msgid "Adjust Route"
-msgstr "Скоригувати маршрут"
-
-#: pkg/kubernetes/views/pv-page.html.h:1
-msgid "Show all Persistent Volumes"
-msgstr "Показати усі сталі томи"
-
-#: pkg/kubernetes/views/pv-page.html.h:2 pkg/kubernetes/views/pvc-body.html.h:3
-#: pkg/kubernetes/views/pv-panel.html.h:1
-msgid "Volume"
-msgstr "Том"
-
-#: pkg/kubernetes/views/pv-page.html.h:3 pkg/kubernetes/views/pv-panel.html.h:2
-msgid "Claim"
-msgstr "Заявити"
-
-#: pkg/kubernetes/views/pv-page.html.h:4
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr "Сталого тому «{{ target }}» не існує."
-
-#: pkg/kubernetes/views/image-delete.html.h:1
-msgid "Remove image tag"
-msgstr "Вилучити мітку образу"
-
-#: pkg/kubernetes/views/image-delete.html.h:2
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-"Хочете вилучити образ із мітками «{{stream.metadata.namespace}}/{{stream."
-"metadata.name}}:{{tag.tag}}»?"
-
-#: pkg/kubernetes/views/image-config.html.h:1
-msgid "Run as"
-msgstr "Запустити від імені"
-
-#: pkg/kubernetes/views/image-config.html.h:4
-msgid "Stop with"
-msgstr "Зупинитися на"
-
-#: pkg/kubernetes/views/pv-delete.html.h:1
-msgid "Delete Persistent Volume"
-msgstr "Вилучити сталий том"
-
-#: pkg/kubernetes/views/pv-delete.html.h:2
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr "Ви хочете вилучити сталий том «{{item.metadata.name}}»?"
-
-#: pkg/kubernetes/views/pv-delete.html.h:3
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
-"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
-"may cause issues with any pods depending on it."
-msgstr ""
-"Цей том може бути заявлено для {{ item.item.spec.claimRef.namespace }} / "
-"{{ item.item.spec.claimRef.name }}. Його вилучення порушить цю заявку і може "
-"призвести до проблем із усіма коконами, які від нього залежать."
-
-#: pkg/kubernetes/views/user-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:3
-msgid "Identities"
-msgstr "Профілі"
-
-#: pkg/kubernetes/views/user-page.html.h:3
-msgid "The user '{{ userName }}' does not exist."
-msgstr "Запису користувача «{{ userName }}» не існує."
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:1
-msgid "Show all Deployment Configs"
-msgstr "Показати усі налаштування розгортання"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:1
-msgid "Deployment Config"
-msgstr "Налаштування розгортання"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:4
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr "Налаштувань розгортання «{{ target }}» не існує."
-
-#: pkg/kubernetes/views/route-panel.html.h:1
-#: pkg/kubernetes/views/route-page.html.h:2
-msgid "Route"
-msgstr "Маршрут"
-
-#: pkg/kubernetes/views/volumes-page.html.h:1
-msgid "Register New Volume"
-msgstr "Зареєструвати новий том"
-
-#: pkg/kubernetes/views/volumes-page.html.h:2
-msgid "Persistent Volumes"
-msgstr "Сталі томи"
-
-#: pkg/kubernetes/views/volumes-page.html.h:7
-msgid "No volumes are present."
-msgstr "Немає томів."
-
-#: pkg/kubernetes/views/volumes-page.html.h:8
-msgid "Pending Volume Claims"
-msgstr "Заявки щодо томів у черзі"
-
-#: pkg/kubernetes/views/volumes-page.html.h:12
-msgid "When"
-msgstr "Умова"
-
-#: pkg/kubernetes/views/user-delete.html.h:1
-msgid "Remove User"
-msgstr "Вилучити користувача"
-
-#: pkg/kubernetes/views/pv-claim.html.h:3
-#: pkg/kubernetes/views/pv-modify.html.h:10
-#: pkg/kubernetes/views/pvc-body.html.h:7 pkg/kubernetes/views/pv-body.html.h:2
-msgid "Access Modes"
-msgstr "Режими доступу"
-
-#: pkg/kubernetes/views/pv-claim.html.h:4
-msgid "Requests"
-msgstr "Запити"
-
-#: pkg/kubernetes/views/pv-claim.html.h:5
-msgid "This volume has not been claimed"
-msgstr "Цей том не заявлено"
-
-#: pkg/kubernetes/views/pv-claim.html.h:10
-msgid "No Pods are using this claim"
-msgstr "Цю вимогу не використовує жоден кокон"
-
-#: pkg/kubernetes/views/filter-project.html.h:1
-msgid "All Projects"
-msgstr "Всі проекти"
-
-#: pkg/kubernetes/views/filter-project.html.h:2
-msgid "Project:"
-msgstr "Проект:"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:5
-#: pkg/kubernetes/views/details-page.html.h:14
-msgid "Latest Version"
-msgstr "Найсвіжіша версія"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:6
-msgid "Deployment Causes"
-msgstr "Причини розгортання"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:7
-msgid "Triggers"
-msgstr "Умовні зміни"
-
-#: pkg/kubernetes/views/item-delete.html.h:1
-msgid "Delete {{ item.kind }}"
-msgstr "Вилучити {{ item.kind }}"
-
-#: pkg/kubernetes/views/item-delete.html.h:2
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr "Хочете вилучити {{ item.kind }} «{{item.metadata.name}}»?"
-
-#: pkg/kubernetes/views/item-delete.html.h:3
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-"Вилучення кокона призведе до завершення роботи усіх пов’язаних із ним "
-"контейнерів. У певних випадках кокон може бути повторно створено "
-"автоматично.\n"
-"          "
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:2
-#: pkg/kubernetes/views/user-modify.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:2
-msgid ""
-"\n"
-"                        Name\n"
-"                    "
-msgstr ""
-"\n"
-"                        Назва\n"
-"                    "
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:5
-#: pkg/kubernetes/views/user-modify.html.h:5
-msgid ""
-"\n"
-"                        Identity\n"
-"                    "
-msgstr ""
-"\n"
-"                        Профіль\n"
-"                    "
-
-#: pkg/kubernetes/views/project-body.html.h:1
-msgid "Project Members"
-msgstr "Учасники проекту"
-
-#: pkg/kubernetes/views/project-body.html.h:3
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-msgstr ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-
-#: pkg/kubernetes/views/project-body.html.h:6
-msgid "Admin"
-msgstr "Адміністратор"
-
-#: pkg/kubernetes/views/project-body.html.h:7
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-msgstr ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-
-#: pkg/kubernetes/views/container-panel.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:3
-msgid "Shell"
-msgstr "Оболонка"
-
-#: pkg/kubernetes/views/service-endpoint.html.h:1
-msgid "Pod Endpoints"
-msgstr "Кінцеві точки коконів"
-
-#: pkg/kubernetes/views/service-endpoint.html.h:2
-msgid "No pods selected"
-msgstr "Коконів не позначено"
-
-#: pkg/kubernetes/views/service-endpoint.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:3
-msgid "Pod Selector"
-msgstr "Вибір коконів"
-
-#: pkg/kubernetes/views/user-add-membership.html.h:1
-msgid "Add membership"
-msgstr "Додати запис участі"
-
-#: pkg/kubernetes/views/user-add-membership.html.h:2
-msgid ""
-"\n"
-"                        Group or Project\n"
-"                    "
-msgstr ""
-"\n"
-"                        Група або проект\n"
-"                    "
-
-#: pkg/kubernetes/views/user-add-membership.html.h:5
-msgid ""
-"\n"
-"                        Role\n"
-"                    "
-msgstr ""
-"\n"
-"                        Роль\n"
-"                    "
-
-#: pkg/kubernetes/views/deploy.html.h:1
-msgid "Deploy Application"
-msgstr "Розгорнути програму"
-
-#: pkg/kubernetes/views/deploy.html.h:3
-msgid "{{ selected.name }}"
-msgstr "{{ selected.name }}"
-
-#: pkg/kubernetes/views/deploy.html.h:5
-#: pkg/kubernetes/views/dashboard-page.html.h:11
-msgid "Deploy"
-msgstr "Розгорнути"
-
-#: pkg/kubernetes/views/user-modify.html.h:1
-msgid "Change User"
-msgstr "Змінити користувача"
-
-#: pkg/kubernetes/views/user-modify.html.h:9
-msgid "Modify"
-msgstr "Змінити"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:1
-#: pkg/kubernetes/views/project-modify.html.h:6
-msgid "Access Policy"
-msgstr "Правила доступу"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:2
-#, fuzzy
-msgid ""
-"\n"
-"          Images may be pulled by anonymous users\n"
-"        "
-msgstr ""
-"\n"
-"          Образи може бути отримати будь-яким розпізнаним користувачем або "
-"учасником групи\n"
-"        "
-
-#: pkg/kubernetes/views/imagestream-body.html.h:5
-msgid ""
-"\n"
-"          Images may be pulled by any authenticated user or group\n"
-"        "
-msgstr ""
-"\n"
-"          Образи може бути отримати будь-яким розпізнаним користувачем або "
-"учасником групи\n"
-"        "
-
-#: pkg/kubernetes/views/imagestream-body.html.h:8
-msgid ""
-"\n"
-"          Images may only be pulled by specific users or groups\n"
-"        "
-msgstr ""
-"\n"
-"          Образи може бути отримано лише вказаними користувачами або "
-"учасниками груп\n"
-"        "
-
-#: pkg/kubernetes/views/imagestream-body.html.h:11
-msgid "Pull repository"
-msgstr "Отримати сховище"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:13
-msgid "Image count"
-msgstr "Кількість образів"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:14
-msgid "{{stream.status.tags.length}}"
-msgstr "{{stream.status.tags.length}}"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:15
-msgid "To push to an image to this image stream:"
-msgstr "Для вивантаження образу до цього потоку образу:"
-
-#: pkg/kubernetes/views/node-alerts.html.h:1
-msgid "The node doesn't have enough disk space"
-msgstr "На вузлі недостатньо простору на диску"
-
-#: pkg/kubernetes/views/node-alerts.html.h:2
-msgid "The node doesn't have enough free memory"
-msgstr "На вузлі недостатньо вільної пам’яті"
-
-#: pkg/kubernetes/views/pv-modify.html.h:1
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr "Скоригувати сталий том «{{ item.metadata.name }}»"
-
-#: pkg/kubernetes/views/pv-modify.html.h:2
-msgid "Register Persistent Volume"
-msgstr "Зареєструвати сталий том"
-
-#: pkg/kubernetes/views/pv-modify.html.h:4
-msgid "Warning:"
-msgstr "Попередження:"
-
-#: pkg/kubernetes/views/pv-modify.html.h:5
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-"Цей параметр призначено лише для тестування окремих вузлів – локальне "
-"сховище не працюватиму у багатовузловому кластері"
-
-#: pkg/kubernetes/views/pv-modify.html.h:7
-#: pkg/kubernetes/views/node-page.html.h:3
-#: pkg/kubernetes/views/pvc-body.html.h:10
-#: pkg/kubernetes/views/pv-body.html.h:3
-msgid "Capacity"
-msgstr "Місткість"
-
-#: pkg/kubernetes/views/pv-modify.html.h:8
-#: pkg/kubernetes/views/pv-body.html.h:1
-msgid "Reclaim Policy"
-msgstr "Правила повторного заявлення"
-
-#: pkg/kubernetes/views/pv-modify.html.h:9
-msgid "{{ value }}"
-msgstr "{{ value }}"
-
-#: pkg/kubernetes/views/pv-modify.html.h:12
-msgid "Endpoint"
-msgstr "Кінцевий пункт"
-
-#: pkg/kubernetes/views/pv-modify.html.h:15
-msgid "Target"
-msgstr "Призначення"
-
-#: pkg/kubernetes/views/auth-dialog.html.h:1
-msgid "Connection Settings"
-msgstr "Параметри з’єднання"
-
-#: pkg/kubernetes/views/auth-dialog.html.h:2
-msgid "Connection Error"
-msgstr "Помилка з'єднання"
-
-#: pkg/kubernetes/views/image-body.html.h:2
-msgid "Summary"
-msgstr "Резюме"
-
-#: pkg/kubernetes/views/image-body.html.h:4
-msgid "Source URL"
-msgstr "Початкова адреса"
-
-#: pkg/kubernetes/views/image-body.html.h:7
-msgid "Built"
-msgstr "Зібрано"
-
-#: pkg/kubernetes/views/image-body.html.h:8
-msgid "Digest"
-msgstr "Контрольна сума"
-
-#: pkg/kubernetes/views/image-body.html.h:9
-msgid "Identifier"
-msgstr "Ідентифікатор"
-
-#: pkg/kubernetes/views/image-body.html.h:11
-msgid "To pull this image:"
-msgstr "Для отримання цього образу:"
-
-#: pkg/kubernetes/views/service-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:8
-#: pkg/kubernetes/views/service-page.html.h:2
-msgid "Service"
-msgstr "Служба"
-
-#: pkg/kubernetes/views/service-panel.html.h:2
-#: pkg/kubernetes/views/service-page.html.h:3
-msgid "Endpoints"
-msgstr "Кінцеві точки"
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:1
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr ""
-"На сервері використовується сертифікат, підписаний невідомою службою "
-"сертифікації."
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:2
+#: pkg/kubernetes/views/auth-rejected-cert.html:3
 msgid ""
 "You can bypass the certificate check, but any data you send to the server "
 "could be intercepted by others."
@@ -5971,187 +6260,37 @@ msgstr ""
 "зроблено, будь-які дані, які надсилатимуться на сервер, може бути "
 "перехоплено сторонніми особами."
 
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:4
-msgid "Trust this certificate for this connection"
-msgstr "Довіряти цьому сертифікату для цього з’єднання"
-
-#: pkg/kubernetes/views/pod-page.html.h:1
-msgid "Show all Pods"
-msgstr "Показати усі кокони"
-
-#: pkg/kubernetes/views/pod-page.html.h:7
-msgid "The pod '{{ target }}' does not exist."
-msgstr "Кокона «{{ target }}» не існує."
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:1
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr "Скоригувати контролер реплікації {{ item.metadata.name }}"
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:1
-msgid "Delete image stream"
-msgstr "Вилучити потік образу"
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:2
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-"Хочете вилучити потік образу «{{stream.metadata.namespace}}/{{stream."
-"metadata.name}}»?"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:2
-msgid "All running"
-msgstr "Усі запущено"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:3
-msgid "No pods deployed"
-msgstr "Коконів не розгорнуто"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:5
-msgid "All in use"
-msgstr "Усі використано"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:6
-msgid "No volumes in use"
-msgstr "Немає використаних томів"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:7
-msgid "pending volume claims"
-msgstr "запити тому у черзі"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:9
-msgid "All healthy"
-msgstr "Усі корисні"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:10
-msgid "No nodes in cluster"
-msgstr "У кластері немає вузлів"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:13
-msgid "Could not list services"
-msgstr "Не вдалося побудувати список служб"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:14
+#: pkg/kubernetes/views/dashboard-page.html:150
 msgid "You can deploy an application to your cluster."
 msgstr "Ви можете розгорнути програму на вашому кластері."
 
-#: pkg/kubernetes/views/imagestream-page.html.h:1
-msgid "Show all image streams"
-msgstr "Показати усіх потоки образів"
-
-#: pkg/kubernetes/views/imagestream-page.html.h:2
-msgid "Image Stream"
-msgstr "Потік образу"
-
-#: pkg/kubernetes/views/container-body.html.h:3
-msgid "Image ID"
-msgstr "Ід. образу"
-
-#: pkg/kubernetes/views/container-body.html.h:4
-msgid "Container ID"
-msgstr "Ід. контейнера"
-
-#: pkg/kubernetes/views/container-body.html.h:7
-msgid "Since"
-msgstr "З"
-
-#: pkg/kubernetes/views/container-body.html.h:8
-msgid "Restart Count"
-msgstr "Кількість перезапусків"
-
-#: pkg/kubernetes/views/user-remove-membership.html.h:1
-msgid "Remove membership"
-msgstr "Вилучити запис участі"
-
-#: pkg/kubernetes/views/nodes-page.html.h:1
-msgid "Delete Selected"
-msgstr "Вилучити позначене"
-
-#: pkg/kubernetes/views/nodes-page.html.h:2
-msgid "OS Versions"
-msgstr "Версії ОС"
-
-#: pkg/kubernetes/views/nodes-page.html.h:3
-msgid "Add Kubernetes Node"
-msgstr "Додати вузол Kubernetes"
-
-#: pkg/kubernetes/views/project-page.html.h:3
-msgid "The project '{{ projName }}' does not exist."
-msgstr "Проекту «{{ projName }}» не існує."
-
-#: pkg/kubernetes/views/user-panel.html.h:4
+#: pkg/lib/machine-invalid-hostkey.html:11
 msgid ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
+"You can remove the previously stored key by running the following command"
+msgstr "Вилучити раніше збережений ключ можна за допомогою такої команди"
+
+#: pkg/shell/base_index.js:672
+msgid "You can try restarting Cockpit by pressing refresh in your browser. "
 msgstr ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
+"Ви можете спробувати перезапустити Cockpit натисканням кнопки оновлення "
+"сторінки у вашому браузері. "
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:1
-msgid "Pod Replicated"
-msgstr "Створено репліку кокона"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:2
-msgid "No pods replicated"
-msgstr "Реплік коконів не створено"
-
-#: pkg/kubernetes/views/container-page.html.h:1
-msgid "Show all Containers"
-msgstr "Показати усі контейнери"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:1
-msgid "Welcome to the Image Registry"
-msgstr "Вітаємо у реєстрі образів"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:2
+#: pkg/users/index.html:335
 msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
-msgstr "Щоб розпочати надсилання образів до реєстру, вам слід створити проект."
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:1
-msgid "New project"
-msgstr "Новий проект"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:4
-msgid "Images by project"
-msgstr "Образи за проектом"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:6
-msgid "Images pushed recently"
-msgstr "Нещодавно вивантажені образи"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:7
-msgid "All images"
-msgstr "Усі образи"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:8
-msgid "No images pushed"
-msgstr "Не вивантажено жодного образу"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:9
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
+"You do not have permission to view the authorized public keys for this "
+"account."
 msgstr ""
-"З метою розпочати надсилання образів до реєстру скористайтеся наведеними "
-"нижче командами."
+"У вас немає прав доступу для перегляду уповноважених відкритих ключів для "
+"цього облікового запису."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:11
+#: pkg/docker/storage.jsx:482
 #, fuzzy
-msgid "Login commands"
-msgstr "Команди Docker"
+msgid "You don't have permission to manage the Docker storage pool."
+msgstr ""
+"У вас немає прав доступу для перегляду уповноважених відкритих ключів для "
+"цього облікового запису."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:12
-#, fuzzy
-msgid "Log into the registry:"
-msgstr "Вітаємо у реєстрі образів"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:13
+#: pkg/kubernetes/views/registry-dashboard-page.html:112
 msgid ""
 "Your login credentials do not give you access to use the docker registry "
 "from the command line."
@@ -6159,260 +6298,189 @@ msgstr ""
 "Ваші реєстраційні дані не дають вам доступу до реєстру docker з командного "
 "рядка."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:14
-msgid "Log into OpenShift command line tools:"
+#: src/base1/cockpit.js:3687
+msgid "Your session has been terminated."
+msgstr "Ваш сеанс перервано."
+
+#: src/base1/cockpit.js:3689
+msgid "Your session has expired. Please log in again."
 msgstr ""
+"Строк роботи у вашому сеансі вичерпано. Будь ласка, увійдіть до системи ще "
+"раз."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:15
-#, fuzzy
-msgid "Image commands"
-msgstr "Кількість образів"
+#: pkg/lib/journal.js:213
+msgid "[$0 bytes of binary data]"
+msgstr "[$0 байтів двійкових даних]"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:16
-msgid "Push an image:"
-msgstr "Вивантажити образ:"
+#: pkg/lib/journal.js:215
+msgid "[binary data]"
+msgstr "[двійкові дані]"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:17
-msgid "Pull an image:"
-msgstr "Отримати образ:"
+#: pkg/lib/journal.js:209
+msgid "[no data]"
+msgstr "[немає даних]"
 
-#: pkg/kubernetes/views/node-page.html.h:1
-msgid "Show all Nodes"
-msgstr "Показати усі вузли"
+#: pkg/storaged/details.js:1692
+msgid "active, but unsupported"
+msgstr "активний, але непідтримуваний"
 
-#: pkg/kubernetes/views/node-page.html.h:4
-msgid "The node '{{ target }}' does not exist."
-msgstr "Вузла «{{ target }}» не існує."
+#: pkg/storaged/utils.js:88
+msgctxt "format-bytes"
+msgid "bytes"
+msgstr "байтів"
 
-#: pkg/kubernetes/views/route-page.html.h:1
-msgid "Show all Routes"
-msgstr "Показати усі маршрути"
+#: pkg/docker/util.js:123
+msgid "default"
+msgstr "типовий"
 
-#: pkg/kubernetes/views/route-page.html.h:3
-msgid "The route '{{ target }}' does not exist."
-msgstr "Маршруту «{{ target }}» не існує."
+#: pkg/storaged/details.js:178
+msgid "ext4 - Red Hat Enterprise Linux 6 default"
+msgstr "ext4 - Типова для Red Hat Enterprise Linux 6"
 
-#: pkg/kubernetes/views/topology-page.html.h:1
-msgid "Select an object to see more details."
-msgstr "Виберіть об’єкт для перегляду ширшого спектра параметрів."
+#: pkg/systemd/host.js:661
+msgid "failed to list ssh host keys: $0"
+msgstr "не вдалося побудувати список ключів SSH вузла: $0"
 
-#: pkg/kubernetes/views/topology-page.html.h:3
-msgid ""
-"Pods contain one or more containers that run\n"
-"                together on a node, containing your application code."
-msgstr ""
-"Кокони містять один або декілька контейнерів, які працюють разом\n"
-"                на вузлі, де міститься код вашої програми."
+#: pkg/storaged/index.html:135
+msgid "iSCSI Targets"
+msgstr "Призначення iSCSI"
 
-#: pkg/kubernetes/views/topology-page.html.h:6
-msgid ""
-"Replication controllers dynamically create instances of\n"
-"                pods from templates, and remove pods when necessary."
-msgstr ""
-"Контролери реплікації динамічно створюють екземпляри\n"
-"                коконів із шаблонів і вилучають кокони, якщо потрібно."
+#: pkg/storaged/details.js:1692
+msgid "inactive"
+msgstr "неактивний"
 
-#: pkg/kubernetes/views/topology-page.html.h:9
-msgid ""
-"Services group pods and provide a common DNS\n"
-"                name and an optional, load-balanced IP address to access "
-"them."
-msgstr ""
-"Служби збирають у групи кокони і надають загальну назву DNS\n"
-"                та додаткову, збалансовану за навантаженням IP-адресу для "
-"доступу до них."
+#: pkg/storaged/details.js:1286
+msgid "locked"
+msgstr "блоковано"
 
-#: pkg/kubernetes/views/topology-page.html.h:12
-msgid "Nodes are the machines that run your containers."
-msgstr "Вузли — комп’ютери, на яких запущено ваші контейнери."
+#: pkg/storaged/details.js:1278
+msgid "mounted on $0"
+msgstr "змонтовано до $0"
 
-#: pkg/kubernetes/views/add-group-dialog.html.h:1
-msgid "Add Group"
-msgstr "Додати групу"
-
-#: pkg/kubernetes/views/file-button.html.h:1
-msgid "Select Manifest File..."
-msgstr "Вибір файла маніфесту…"
-
-#: pkg/kubernetes/views/project-modify.html.h:2
-msgid "Change project"
-msgstr "Змінити проект"
-
-#: pkg/kubernetes/views/project-modify.html.h:4
-msgid "Display name"
-msgstr "Показана назва"
-
-#: pkg/kubernetes/views/route-body.html.h:5
-msgid "TLS Termination"
-msgstr "Переривання TLS"
-
-#: pkg/kubernetes/views/route-body.html.h:6
-msgid "yes"
-msgstr "так"
-
-#: pkg/kubernetes/views/route-body.html.h:7
+#: pkg/kubernetes/views/route-body.html:14
 msgid "no"
 msgstr "ні"
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:1
-msgid "Add Role"
-msgstr "Додати роль"
+#: pkg/kubernetes/views/route-body.html:24
+#: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
+msgid "none"
+msgstr "немає"
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:2
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
-msgstr "Хочете додати роль «{{ fields.displayRole }}»?"
+#: pkg/storaged/details.js:1280
+msgid "not mounted"
+msgstr "не змонтовано"
 
-#: pkg/kubernetes/views/details-page.html.h:1
-msgid "All Types"
-msgstr "Всі типи"
+#: pkg/kubernetes/views/dashboard-page.html:83
+msgid "pending volume claims"
+msgstr "запити тому у черзі"
 
-#: pkg/kubernetes/views/details-page.html.h:2
-msgid "Type:"
-msgstr "Тип:"
+#: pkg/tuned/change-profile.jsx:52
+#, fuzzy
+msgid "recommended"
+msgstr "MII (рекомендоване)"
 
-#: pkg/kubernetes/views/details-page.html.h:13
-msgid "Deployment Configs"
-msgstr "Налаштування розгортання"
+#: pkg/docker/index.html:426
+msgid "select container"
+msgstr "вибрати контейнер"
 
-#: pkg/kubernetes/views/details-page.html.h:15
-msgid "Not deployed"
-msgstr "Не розгорнуто"
+#: pkg/docker/index.html:504 pkg/docker/index.html:683
+msgid "shares"
+msgstr "спільний"
 
-#: pkg/kubernetes/views/details-page.html.h:16
-msgid "Replication Controllers"
-msgstr "Керування реплікацією"
+#: pkg/selinux/setroubleshoot-view.jsx:118
+msgid "solution details"
+msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:1
-msgid "Adjust Service"
-msgstr "Скоригувати службу"
+#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
+msgid "unknown"
+msgstr "невідомо"
 
-#: pkg/kubernetes/views/service-modify.html.h:3
+#: pkg/storaged/jobs.js:180
+msgid "unknown target"
+msgstr "невідоме призначення"
+
+#: pkg/storaged/details.js:1284
+msgid "unlocked"
+msgstr "розблоковано"
+
+#: pkg/kubernetes/views/route-body.html:13
+msgid "yes"
+msgstr "так"
+
+#: pkg/kubernetes/views/service-modify.html:16
 msgid "{{ item.name }}"
 msgstr "{{ item.name }}"
 
-#: pkg/kubernetes/views/service-modify.html.h:5
-msgid "Adjust"
-msgstr "Скоригувати"
+#: pkg/kubernetes/views/deploy.html:27
+msgid "{{ selected.name }}"
+msgstr "{{ selected.name }}"
 
-#: pkg/kubernetes/views/project-delete.html.h:1
-msgid "Delete Project"
-msgstr "Вилучення проекту"
+#: pkg/kubernetes/views/pv-modify.html:61
+#: pkg/kubernetes/views/pv-modify.html:74
+msgid "{{ value }}"
+msgstr "{{ value }}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:2
-msgid "Claim Name"
-msgstr "Назва заявки"
+#: pkg/kubernetes/views/volume-body.html:2
+msgid "{{ volume | formatVolumeType }}"
+msgstr "{{ volume | formatVolumeType }}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:4
-msgid "No Volume Bound"
-msgstr "Не пов’язано тому"
+#: pkg/storaged/index.html:147
+msgid "{{Address}}:{{Port}}"
+msgstr "{{Address}}:{{Port}}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:8
-msgid "Requested"
-msgstr "Запитано"
+#: pkg/docker/index.html:435
+msgid "{{alias_label}}"
+msgstr "{{alias_label}}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:9
-msgid "Actual"
-msgstr "Поточна"
-
-#: pkg/kubernetes/views/node-capacity.html.h:1
-msgid "Scheduled Pods"
-msgstr "Заплановані кокони"
-
-#: pkg/kubernetes/views/node-capacity.html.h:2
-msgid "No pods scheduled"
-msgstr "Коконів не заплановано"
-
-#: pkg/kubernetes/views/container-page-inline.html.h:4
-msgid "The container '{{ target }}' does not exist."
-msgstr "Контейнера «{{ target }}» не існує."
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:1
-msgid "Create image stream"
-msgstr "Створити потік образу"
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:2
-msgid "Change image stream"
-msgstr "Змінити потік образу"
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:5
-msgid "Populate"
-msgstr "Заповнити"
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:6
-msgid "Pull from"
-msgstr "Отримати з"
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:8
-msgid "Remote registry is insecure"
-msgstr "Віддалений реєстр є незахищеним"
-
-#: pkg/kubernetes/views/user-group-remove.html.h:1
-msgid "Remove Member"
-msgstr "Вилучити члена"
-
-#: pkg/kubernetes/views/service-page.html.h:1
-msgid "Show all Services"
-msgstr "Показувати всі служби"
-
-#: pkg/kubernetes/views/service-page.html.h:4
-msgid "The service '{{ target }}' does not exist."
-msgstr "Служби «{{ target }}» не існує."
-
-#: pkg/kubernetes/scripts/frob-layers.html.h:1
-#, fuzzy
-msgid "Image Layers Example"
-msgstr "Шари образу"
-
-#: pkg/playground/service.html.h:1
-msgid "Cockpit Generic Service Monitor"
+#: pkg/systemd/services.html:173 pkg/systemd/services.html:202
+msgid "{{days_text}}"
 msgstr ""
 
-#: pkg/playground/jquery-patterns.html.h:1
-msgid "Cockpit Pattern Usage"
-msgstr "Використання взірців Cockpit"
+#: pkg/docker/index.html:403
+msgid "{{envvar_key_label}}"
+msgstr "{{envvar_key_label}}"
 
-#: pkg/playground/metrics.html.h:1
+#: pkg/docker/index.html:407
+msgid "{{envvar_value_label}}"
+msgstr "{{envvar_value_label}}"
+
+#: pkg/docker/index.html:359
+msgid "{{host_port_label}}"
+msgstr "{{host_port_label}}"
+
+#: pkg/docker/index.html:373
+msgid "{{host_volume_label}}"
+msgstr "{{host_volume_label}}"
+
+#: pkg/kubernetes/views/imagestream-body.html:35
+msgid "{{stream.status.tags.length}}"
+msgstr "{{stream.status.tags.length}}"
+
+#~ msgid "Journal"
+#~ msgstr "Журнал"
+
+#~ msgid "Comment"
+#~ msgstr "Коментар"
+
 #, fuzzy
-msgid "Cockpit Monitoring"
-msgstr "Спостереження за зв’язком"
+#~ msgid "Image Layers Example"
+#~ msgstr "Шари образу"
 
-#: pkg/playground/test.html.h:1 pkg/playground/translate.html.h:1
-msgid "Cockpit playground"
-msgstr ""
+#~ msgid "Cockpit Pattern Usage"
+#~ msgstr "Використання взірців Cockpit"
 
-#: pkg/playground/react-patterns.html.h:1
-msgid "Cockpit React Patterns Usage"
-msgstr "Використання шаблонів реакцій Cockpit"
-
-#: pkg/playground/speed.html.h:1
-msgid "Cockpit Speed Tests"
-msgstr ""
-
-#: pkg/playground/plot.html.h:1
 #, fuzzy
-msgid "Cockpit Plots"
-msgstr "Cockpit"
+#~ msgid "Cockpit Monitoring"
+#~ msgstr "Спостереження за зв’язком"
 
-#: pkg/dashboard/index.html.h:1
-msgid "Dashboard"
-msgstr ""
+#~ msgid "Cockpit React Patterns Usage"
+#~ msgstr "Використання шаблонів реакцій Cockpit"
 
-#: pkg/dashboard/index.html.h:5
 #, fuzzy
-msgid "Disk I/O"
-msgstr "З диском усе гаразд"
-
-#: pkg/dashboard/index.html.h:6
-msgid "Lost connection. Trying to reconnect"
-msgstr "З’єднання розірвано. Намагаємося його повторно встановити"
-
-#: pkg/dashboard/index.html.h:10
-msgid "Avatar"
-msgstr "Аватар"
-
-#: pkg/dashboard/index.html.h:13
-msgid "Set"
-msgstr "Встановити"
+#~ msgid "Cockpit Plots"
+#~ msgstr "Cockpit"
 
 #~ msgid "No addresses found"
 #~ msgstr "Адрес не знайдено"
@@ -6609,60 +6677,8 @@ msgstr "Встановити"
 #~ msgstr "Показати вікно помилки"
 
 #~ msgctxt "storage"
-#~ msgid "Model"
-#~ msgstr "Модель"
-
-#~ msgctxt "storage"
-#~ msgid "Firmware Version"
-#~ msgstr "Версія мікропрограми"
-
-#~ msgctxt "storage"
-#~ msgid "Serial Number"
-#~ msgstr "Серійний номер"
-
-#~ msgctxt "storage"
-#~ msgid "World Wide Name"
-#~ msgstr "Глобальна назва (WWN)"
-
-#~ msgctxt "storage"
-#~ msgid "Capacity"
-#~ msgstr "Місткість"
-
-#~ msgctxt "storage"
-#~ msgid "Assessment"
-#~ msgstr "Оцінка"
-
-#~ msgctxt "storage"
-#~ msgid "Device File"
-#~ msgstr "Файл пристрою"
-
-#~ msgctxt "storage"
-#~ msgid "Multipathed Devices"
-#~ msgstr "Пристрої із багатьма шляхами"
-
-#~ msgctxt "storage"
-#~ msgid "Device"
-#~ msgstr "Пристрій"
-
-#~ msgctxt "storage"
 #~ msgid "Name"
 #~ msgstr "Назва"
-
-#~ msgctxt "storage"
-#~ msgid "UUID"
-#~ msgstr "UUID"
-
-#~ msgctxt "storage"
-#~ msgid "RAID Level"
-#~ msgstr "Рівень RAID:"
-
-#~ msgctxt "storage"
-#~ msgid "Bitmap"
-#~ msgstr "Растр"
-
-#~ msgctxt "storage"
-#~ msgid "State"
-#~ msgstr "Стан"
 
 #~ msgid ""
 #~ "\n"
@@ -6718,15 +6734,6 @@ msgstr "Встановити"
 #~ msgstr ""
 #~ "\n"
 #~ "                    Адреса\n"
-#~ "                  "
-
-#~ msgid ""
-#~ "\n"
-#~ "                    Login\n"
-#~ "                  "
-#~ msgstr ""
-#~ "\n"
-#~ "                    Користувач\n"
 #~ "                  "
 
 #~ msgid ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-17 19:28+0100\n"
+"POT-Creation-Date: 2016-11-18 06:44+0100\n"
 "PO-Revision-Date: 2016-08-20 11:49-0400\n"
 "Last-Translator: vanlos wang <vanloswang@126.com>\n"
 "Language-Team: Chinese (China)\n"
@@ -17,177 +17,520 @@ msgstr ""
 "X-Generator: Zanata 3.9.6\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 
-#: src/ws/cockpitcertificate.c:359
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr "无法解密 PEM 编码的私钥"
-
-#: src/ws/cockpitcertificate.c:364
-msgid "No PEM-encoded private key found"
-msgstr "没有找到 PEM 编码的私钥"
-
-#: src/ws/cockpitcertificate.c:374
-msgid "Could not parse PEM-encoded private key"
-msgstr "无法解析 PEM 编码的私钥"
-
-#: src/ws/cockpitcertificate.c:398
-msgid "No PEM-encoded certificate found"
-msgstr "没有找到 PEM 编码的证书"
-
-#: src/ws/cockpitcertificate.c:407
-msgid "Could not parse PEM-encoded certificate"
-msgstr "无法解析 PEM 编码的证书"
-
-#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
-#: src/bridge/cockpitdbussetup.c:625
+#: pkg/shell/index.html:227
 #, fuzzy
-msgid "Unsupported setup mechanism"
-msgstr "不支持创建机制： %s"
+msgid "                                                Comment                                            "
+msgstr ""
+"\n"
+"                                    无效时区\n"
+"                                "
 
-#: src/bridge/cockpitdbussetup.c:236
-msgid "Couldn't list users"
-msgstr "不能列出用户"
+#: pkg/shell/index.html:235
+#, fuzzy
+msgid "                                                Fingerprint                                            "
+msgstr ""
+"\n"
+"                                    无效时区\n"
+"                                "
 
-#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
-msgid "Bad data passed for passwd1 mechanism"
-msgstr "为 passwd1 机制通过的坏数据"
+#: pkg/shell/index.html:231
+#, fuzzy
+msgid "                                                Type                                            "
+msgstr ""
+"\n"
+"                                    无效时区\n"
+"                                "
 
-#: src/bridge/cockpitdbussetup.c:382
-msgid "Couldn't load user data"
-msgstr "不能载入用户数据"
+#: pkg/systemd/index.html:389
+#, fuzzy
+msgid ""
+"                                    Invalid time "
+"zone                                "
+msgstr ""
+"\n"
+"                                    无效时区\n"
+"                                "
 
-#: src/bridge/cockpitdbussetup.c:467
-msgid "Couldn't change user groups"
-msgstr "不能修改用户组"
+#: pkg/kubernetes/views/project-body.html:80
+#, fuzzy
+msgid ""
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}                                "
+msgstr ""
+"\n"
+"                                    {{ getRegistryRoles(group, project())."
+"join() }}\n"
+"                                "
 
-#: src/bridge/cockpitdbussetup.c:520
-msgid "Couldn't change user password"
-msgstr "不能修改用户密码"
+#: pkg/kubernetes/views/user-body.html:22
+#, fuzzy
+msgid ""
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}                                "
+msgstr ""
+"\n"
+"                                    {{ getRegistryRoles(user(), member)."
+"join() }}\n"
+"                                "
 
-#: src/bridge/cockpitdbussetup.c:544
-msgid "Couldn't create new users"
-msgstr "不能创建新用户"
+#: pkg/kubernetes/views/user-panel.html:39
+#, fuzzy
+msgid ""
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}                            "
+msgstr ""
+"\n"
+"                                {{ getRegistryRoles(user(), member)."
+"join() }}\n"
+"                            "
 
-#: src/bridge/cockpitdbussetup.c:642
-msgid "Couldn't list local users"
-msgstr "不能列出本地用户"
+#: pkg/kubernetes/views/project-body.html:37
+#, fuzzy
+msgid ""
+"                                {{ getRegistryRoles(user, project())."
+"join() }}                            "
+msgstr ""
+"\n"
+"                                {{ getRegistryRoles(user, project())."
+"join() }}\n"
+"                            "
 
-#: src/bridge/cockpitpackages.c:459
-#, c-format
-msgid "This package requires Cockpit version %s or later"
+#: pkg/systemd/index.html:485 pkg/systemd/index.html:504
+#, fuzzy
+msgid "                        Cancel                    "
+msgstr ""
+"\n"
+"                        取消\n"
+"                    "
+
+#: pkg/kubernetes/views/user-add-membership.html:9
+#, fuzzy
+msgid "                        Group or Project                    "
+msgstr ""
+"\n"
+"                       组或项目\n"
+"                    "
+
+#: pkg/kubernetes/views/add-user-dialog.html:19
+#: pkg/kubernetes/views/user-modify.html:19
+#, fuzzy
+msgid "                        Identity                    "
+msgstr ""
+"\n"
+"                        身份\n"
+"                    "
+
+#: pkg/kubernetes/views/add-user-dialog.html:9
+#: pkg/kubernetes/views/user-modify.html:9
+#: pkg/kubernetes/views/add-group-dialog.html:9
+#, fuzzy
+msgid "                        Name                    "
+msgstr ""
+"\n"
+"                        名称\n"
+"                    "
+
+#: pkg/kubernetes/views/user-add-membership.html:30
+#, fuzzy
+msgid "                        Role                    "
+msgstr ""
+"\n"
+"                        角色\n"
+"                    "
+
+#: pkg/kubernetes/views/user-group-add.html:9
+#, fuzzy
+msgid "                        User                    "
+msgstr ""
+"\n"
+"                        用户\n"
+"                    "
+
+#: pkg/ostree/index.html:88
+#, fuzzy
+msgid "                    Available                  "
+msgstr ""
+"\n"
+"                    可用的\n"
+"                  "
+
+#: pkg/ostree/index.html:85
+#, fuzzy
+msgid "                    Default                  "
+msgstr ""
+"\n"
+"                    默认\n"
+"                  "
+
+#: pkg/ostree/index.html:223
+#, fuzzy
+msgid "                    Reconnect                "
+msgstr ""
+"\n"
+"                    重连\n"
+"                "
+
+#: pkg/ostree/index.html:135
+#, fuzzy
+msgid ""
+"                    This deployment contains the same packages as your "
+"currently booted system                "
+msgstr ""
+"\n"
+"                    该部署包含相同的软件包作为当前启动的系统\n"
+"                "
+
+#: pkg/ostree/index.html:67
+#, fuzzy
+msgid "                    Update and reboot                "
+msgstr ""
+"\n"
+"                    更新并重启\n"
+"                "
+
+#: pkg/kubernetes/registry.html:74 pkg/kubernetes/index.html:104
+#, fuzzy
+msgid "                Reconnect            "
+msgstr ""
+"\n"
+"                重连\n"
+"            "
+
+#: pkg/sosreport/index.html:57
+#, fuzzy
+msgid ""
+"                The generated archive contains data "
+"considered                sensitive and its content should be reviewed by "
+"the                originating organization before being passed to "
+"any                third party.              "
+msgstr ""
+"\n"
+"                生成的文档包含被认为敏感的数据，并且在发送给第三方之前其内容"
+"应该被原始组织评审。\n"
+"                \n"
+"                \n"
+"              \n"
+"              "
+
+#: pkg/shell/index.html:304 pkg/shell/stub.html:157
+#, fuzzy
+msgid "                Tools              "
+msgstr ""
+"\n"
+"                工具\n"
+"              "
+
+#: pkg/kubernetes/index.html:107
+#, fuzzy
+msgid "                Troubleshoot            "
+msgstr ""
+"\n"
+"                排错\n"
+"            "
+
+#: pkg/shell/simple.html:105 pkg/shell/index.html:126 pkg/shell/stub.html:119
+#: pkg/storaged/index.html:862
+#, fuzzy
+msgid "              Cancel            "
+msgstr ""
+"\n"
+"              取消\n"
+"            "
+
+#: pkg/shell/index.html:147 pkg/shell/stub.html:140
+#, fuzzy
+msgid "              Close            "
+msgstr ""
+"\n"
+"              关闭\n"
+"            "
+
+#: pkg/shell/simple.html:70 pkg/shell/index.html:83 pkg/shell/stub.html:76
+#, fuzzy
+msgid ""
+"              Cockpit is an interactive Linux server admin "
+"interface.            "
+msgstr ""
+"\n"
+"              Cockpit 是一个交互式 Linux 服务器管理工具。\n"
+"            "
+
+#: pkg/shell/simple.html:79 pkg/shell/index.html:92 pkg/shell/stub.html:85
+#, fuzzy
+msgid "              Licensed under the GNU LGPL version 2.1            "
+msgstr ""
+"\n"
+"                    登陆\n"
+"                  "
+
+#: pkg/shell/simple.html:129
+#, fuzzy
+msgid "              Log in again            "
+msgstr ""
+"\n"
+"              重新登陆\n"
+"            "
+
+#: pkg/shell/simple.html:73 pkg/shell/index.html:86 pkg/shell/stub.html:79
+#, fuzzy
+msgid "              Project website            "
+msgstr ""
+"\n"
+"              关闭\n"
+"            "
+
+#: pkg/shell/simple.html:108 pkg/shell/index.html:129 pkg/shell/stub.html:122
+#, fuzzy
+msgid "              Select            "
+msgstr ""
+"\n"
+"              选择\n"
+"            "
+
+#: pkg/shell/simple.html:126
+#, fuzzy
+msgid "              Try to reconnect            "
+msgstr ""
+"\n"
+"              尝试重新连接\n"
+"            "
+
+#: pkg/users/index.html:361
+#, fuzzy
+msgid "            Add key          "
+msgstr ""
+"\n"
+"            添加 key\n"
+"          "
+
+#: pkg/networkmanager/index.html:582 pkg/networkmanager/index.html:610
+#: pkg/networkmanager/index.html:638 pkg/networkmanager/index.html:666
+#: pkg/networkmanager/index.html:694 pkg/networkmanager/index.html:722
+#: pkg/networkmanager/index.html:750 pkg/networkmanager/index.html:778
+#, fuzzy
+msgid "            Apply          "
+msgstr ""
+"\n"
+"            应用\n"
+"          "
+
+#: pkg/users/index.html:269 pkg/users/index.html:297 pkg/users/index.html:358
+#: pkg/docker/index.html:584 pkg/docker/index.html:622
+#: pkg/docker/index.html:688 pkg/docker/index.html:744
+#: pkg/docker/index.html:790 pkg/networkmanager/index.html:579
+#: pkg/networkmanager/index.html:607 pkg/networkmanager/index.html:635
+#: pkg/networkmanager/index.html:663 pkg/networkmanager/index.html:691
+#: pkg/networkmanager/index.html:719 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:775
+#, fuzzy
+msgid "            Cancel          "
+msgstr ""
+"\n"
+"            取消\n"
+"          "
+
+#: pkg/docker/index.html:691
+#, fuzzy
+msgid "            Change          "
+msgstr ""
+"\n"
+"            修改\n"
+"          "
+
+#: pkg/users/index.html:45
+#, fuzzy
+msgid "            Close          "
+msgstr ""
+"\n"
+"            关闭\n"
+"          "
+
+#: pkg/docker/index.html:747
+#, fuzzy
+msgid "            Commit          "
+msgstr ""
+"\n"
+"            提交\n"
+"          "
+
+#: pkg/users/index.html:207
+#, fuzzy
+msgid "            Create          "
+msgstr ""
+"\n"
+"            创建\n"
+"          "
+
+#: pkg/users/index.html:300 pkg/networkmanager/index.html:533
+#, fuzzy
+msgid "            Delete          "
+msgstr ""
+"\n"
+"            删除\n"
+"          "
+
+#: pkg/docker/index.html:625
+#, fuzzy
+msgid "            Download          "
+msgstr ""
+"\n"
+"            下载\n"
+"          "
+
+#: pkg/docker/index.html:587
+#, fuzzy
+msgid "            Run          "
+msgstr ""
+"\n"
+"            运行\n"
+"          "
+
+#: pkg/users/index.html:272
+#, fuzzy
+msgid "            Set          "
+msgstr ""
+"\n"
+"            设置\n"
+"          "
+
+#: pkg/kubernetes/views/imagestream-body.html:14
+#, fuzzy
+msgid "          Images may be pulled by anonymous users        "
+msgstr ""
+"\n"
+"          镜像可以被任何认证的用户或组拉取\n"
+"        "
+
+#: pkg/kubernetes/views/imagestream-body.html:20
+#, fuzzy
+msgid ""
+"          Images may be pulled by any authenticated user or group        "
+msgstr ""
+"\n"
+"          镜像可以被任何认证的用户或组拉取\n"
+"        "
+
+#: pkg/kubernetes/views/imagestream-body.html:26
+#, fuzzy
+msgid "          Images may only be pulled by specific users or groups        "
+msgstr ""
+"\n"
+"          镜像仅可以被指定的用户或组拉取\n"
+"        "
+
+#: pkg/kubernetes/views/image-body.html:9
+#, fuzzy
+msgid "         {{ labels.url }}    "
+msgstr ""
+"\n"
+"            取消\n"
+"          "
+
+#: pkg/kubernetes/views/project-body.html:2
+msgid ""
+"        Project access policy allows anonymous users to pull images. Grant "
+"additional push or admin access to specific members below.    "
 msgstr ""
 
-#: src/bridge/cockpitpackages.c:470
-msgid "This package is not compatible with this version of Cockpit"
+#: pkg/kubernetes/views/project-body.html:7
+msgid ""
+"        Project access policy allows any authenticated user to pull images. "
+"Grant additional push or admin access to specific members below.    "
 msgstr ""
 
-#: src/base1/cockpit.js:2586
-msgid "$0 killed with signal $1"
-msgstr "$0 被信号 $1 杀掉"
+#: pkg/kubernetes/views/project-body.html:12
+msgid ""
+"        Project access policy only allows specific members to access images. "
+"Grant access to specific members below.    "
+msgstr ""
 
-#: src/base1/cockpit.js:2588
-msgid "$0 exited with code $1"
-msgstr "$0 退出码 $1"
-
-#: src/base1/cockpit.js:2590
-msgid "$0 failed"
-msgstr "$0 失败"
-
-#: src/base1/cockpit.js:3667
-msgid "Your session has been terminated."
-msgstr "会话被终止。"
-
-#: src/base1/cockpit.js:3669
-msgid "Your session has expired. Please log in again."
-msgstr "会话超时。请重新登录。"
-
-#: src/base1/cockpit.js:3671
-msgid "Not permitted to perform this action."
-msgstr "不允许执行该动作。"
-
-#: src/base1/cockpit.js:3673
-msgid "Login failed"
-msgstr "登录失败"
-
-#: src/base1/cockpit.js:3675
-msgid "The server refused to authenticate using any supported methods."
-msgstr "服务器拒绝使用任何支持的方式来认证。"
-
-#: src/base1/cockpit.js:3677
-msgid "Untrusted host"
-msgstr "不可信的主机"
-
-#: src/base1/cockpit.js:3679
-msgid "Host key is incorrect"
-msgstr "主机密钥不正确"
-
-#: src/base1/cockpit.js:3681
-msgid "Internal error"
-msgstr "内部错误"
-
-#: src/base1/cockpit.js:3683
-msgid "Connection has timed out."
-msgstr "连接超时。"
-
-#: src/base1/cockpit.js:3685
-msgid "Cockpit is not installed on the system."
-msgstr "Cockpit 未安装在该系统上。"
-
-#: src/base1/cockpit.js:3687
-msgid "Cannot forward login credentials"
-msgstr "无法转发登录凭证"
-
-#: src/base1/cockpit.js:3689
-msgid "Server has closed the connection."
-msgstr "服务器关闭了连接。"
-
-#: src/base1/cockpit.js:3691
-msgid "Cockpit is not compatible with the software on the system."
-msgstr "Cockpit 与该系统上的软件不兼容。"
-
-#: src/base1/cockpit.js:3693
-msgid "Cockpit could not contact the given host."
-msgstr "Cockpit 无法联系指定的主机。"
-
-#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:19
+#: pkg/sosreport/index.html:39
 #, fuzzy
-msgid "Control"
-msgstr "容器"
+msgid ""
+"        The collected information will be stored locally on the system.      "
+msgstr ""
+"\n"
+"       搜集的信息将会保存在系统本地。\n"
+"      "
 
-#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
-#: pkg/playground/translate.js:22
+#: pkg/storaged/index.html:51
 #, fuzzy
-msgctxt "key"
-msgid "Control"
-msgstr "容器"
+msgid ""
+"        There are devices with multiple paths on the system, but the "
+"multipath service is not running.      "
+msgstr ""
+"\n"
+"        系统中存在多路径设备, 但 multipath 服务未运行.\n"
+"      "
 
-#: src/base1/test-locale.js:46 src/base1/test-locale.js:56
-#: pkg/playground/translate.js:10
-msgid "Empty"
-msgstr "空"
-
-#: src/base1/test-locale.js:47 src/base1/test-locale.js:58
-#: pkg/playground/translate.js:16
+#: pkg/sosreport/index.html:34
 #, fuzzy
-msgctxt "verb"
-msgid "Empty"
-msgstr "空"
+msgid ""
+"        This tool will collect system configuration and diagnostic        "
+"information from this system for use with diagnosing problems        with "
+"the system.      "
+msgstr ""
+"\n"
+"        该工具将会从该系统为有诊断系统问题的用户搜集系统配置和诊断信息。 \n"
+"        \n"
+"       \n"
+"      "
 
-#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
-#: src/base1/test-locale.js:66 pkg/storaged/details.js:1557
-#: pkg/playground/translate.js:25 pkg/playground/translate.js:28
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] "$0 磁盘缺失"
+#: pkg/docker/storage.jsx:242
+msgid " (shared with the OS)"
+msgstr ""
 
-#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
-#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
-#: pkg/playground/translate.js:34
+#: pkg/kubernetes/views/node-delete.html:8
 #, fuzzy
-msgctxt "disk-non-rotational"
-msgid "$0 disk is missing"
-msgid_plural "$0 disks are missing"
-msgstr[0] "$0 磁盘缺失"
+msgid " 1\"Do you want to delete the following Nodes?"
+msgstr " 1\">是否想要删除该节点？"
+
+#: pkg/storaged/overview.js:253
+msgid "$0 Block Device"
+msgstr "$0 块设备"
+
+#: pkg/storaged/details.js:1546
+msgid "$0 Chunk Size"
+msgstr "$0 区块大小"
+
+#: pkg/storaged/details.js:1544
+msgid "$0 Disks"
+msgstr "$0 磁盘"
+
+#: pkg/storaged/details.js:1387
+msgid "$0 Extended Partition"
+msgstr "$0 扩展分区"
+
+#: pkg/storaged/details.js:1221
+msgctxt "storage-id-desc"
+msgid "$0 File System"
+msgstr "$0 文件系统"
+
+#: pkg/storaged/details.js:1375
+msgid "$0 Free Space"
+msgstr "$0 可用空间"
+
+#: pkg/storaged/details.js:1367
+msgid "$0 Free Space for Logical Partitions"
+msgstr "逻辑分区剩余 $0 可用空间"
+
+#: pkg/storaged/details.js:1711
+msgid "$0 Free Space for Logical Volumes"
+msgstr "逻辑卷剩余 $0 可用空间"
+
+#: pkg/storaged/details.js:1370
+msgid "$0 Free Space for Primary Partitions"
+msgstr "主分区剩余 $0 可用空间"
+
+#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
+msgid "$0 Template"
+msgstr "$0 模板"
+
+#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+msgid "$0 bit"
+msgid_plural "$0 bits"
+msgstr[0] ""
 
 #: src/base1/test-locale.js:73 src/base1/test-locale.js:74
 #: src/base1/test-locale.js:86 src/base1/test-locale.js:87
@@ -203,574 +546,38 @@ msgid "$0 byte"
 msgid_plural "$0 bytes"
 msgstr[0] "字节"
 
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
-msgid "$0 bit"
-msgid_plural "$0 bits"
+#: src/base1/test-locale.js:64 src/base1/test-locale.js:65
+#: src/base1/test-locale.js:66 pkg/playground/translate.js:25
+#: pkg/playground/translate.js:28 pkg/storaged/details.js:1557
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] "$0 磁盘缺失"
+
+#: src/base1/test-locale.js:67 src/base1/test-locale.js:69
+#: src/base1/test-locale.js:71 pkg/playground/translate.js:31
+#: pkg/playground/translate.js:34
+#, fuzzy
+msgctxt "disk-non-rotational"
+msgid "$0 disk is missing"
+msgid_plural "$0 disks are missing"
+msgstr[0] "$0 磁盘缺失"
+
+#: src/base1/cockpit.js:2588
+msgid "$0 exited with code $1"
+msgstr "$0 退出码 $1"
+
+#: src/base1/cockpit.js:2590
+msgid "$0 failed"
+msgstr "$0 失败"
+
+#: src/base1/cockpit.js:2586
+msgid "$0 killed with signal $1"
+msgstr "$0 被信号 $1 杀掉"
+
+#: pkg/selinux/setroubleshoot-view.jsx:440
+msgid "$0 occurrence"
+msgid_plural "$1 occurrences"
 msgstr[0] ""
-
-#: pkg/systemd/host.js:43
-msgid "The user <b>$0</b> is not permitted to modify hostnames"
-msgstr "用户 <b>$0</b> 不允许修改的主机名"
-
-#: pkg/systemd/host.js:559
-msgid "Set Host name"
-msgstr "设置主机名"
-
-#: pkg/systemd/host.js:661
-msgid "failed to list ssh host keys: $0"
-msgstr "罗列 SSH 主机密钥失败: $0"
-
-#: pkg/systemd/host.js:1113
-msgid "Need at least one NTP server"
-msgstr "至少需要一个 NTP 服务器"
-
-#: pkg/systemd/host.js:1190
-msgid "Invalid date format and invalid time format"
-msgstr "无效的日期格式和时间格式"
-
-#: pkg/systemd/host.js:1192
-msgid "Invalid time format"
-msgstr "无效的时间格式"
-
-#: pkg/systemd/host.js:1194
-msgid "Invalid date format"
-msgstr "无效的日期格式"
-
-#: pkg/systemd/host.js:1250
-msgid "NTP Server"
-msgstr "NTP 服务器"
-
-#: pkg/systemd/host.js:1300
-msgid "Message to logged in users"
-msgstr "登录用户信息"
-
-#: pkg/systemd/host.js:1307 pkg/systemd/host.js:1309
-#: pkg/systemd/index.html.h:19
-msgid "Shutdown"
-msgstr "关机"
-
-#: pkg/systemd/host.js:1311 pkg/systemd/host.js:1313 pkg/systemd/init.js:517
-#: pkg/systemd/index.html.h:18
-msgid "Restart"
-msgstr "重启"
-
-#: pkg/systemd/host.js:1381
-msgctxt "page-title"
-msgid "CPU Status"
-msgstr "CPU 状态"
-
-#: pkg/systemd/host.js:1413 pkg/systemd/index.html.h:24
-msgid "I/O Wait"
-msgstr "I/O 等待"
-
-#: pkg/systemd/host.js:1414 pkg/systemd/index.html.h:25
-msgid "Kernel"
-msgstr "内核"
-
-#: pkg/systemd/host.js:1415 pkg/subscriptions/subscriptions-register.jsx:76
-#: pkg/systemd/index.html.h:26 pkg/kubernetes/views/auth-form.html.h:6
-#: pkg/kubernetes/views/volume-body.html.h:20
-#: pkg/kubernetes/views/user-panel.html.h:1 pkg/playground/translate.html.h:3
-#: pkg/dashboard/index.html.h:8
-msgid "User"
-msgstr "用户"
-
-#: pkg/systemd/host.js:1416 pkg/systemd/index.html.h:27
-msgid "Nice"
-msgstr "Nice"
-
-#: pkg/systemd/host.js:1466
-msgctxt "page-title"
-msgid "Memory"
-msgstr "内存"
-
-#: pkg/systemd/host.js:1499 pkg/systemd/index.html.h:28
-msgid "Swap Used"
-msgstr "Swap 用量"
-
-#: pkg/systemd/host.js:1500 pkg/systemd/index.html.h:29
-msgid "Cached"
-msgstr "已缓存"
-
-#: pkg/systemd/host.js:1501 pkg/docker/storage.jsx:313
-#: pkg/kubernetes/scripts/nodes.js:828 pkg/kubernetes/scripts/nodes.js:837
-#: pkg/systemd/index.html.h:30
-msgid "Used"
-msgstr "已使用"
-
-#: pkg/systemd/host.js:1502 pkg/docker/storage.jsx:298
-#: pkg/docker/storage.jsx:320 pkg/systemd/index.html.h:31
-msgid "Free"
-msgstr "可用"
-
-#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
-msgid "unknown"
-msgstr "未知"
-
-#: pkg/systemd/init.js:269 pkg/systemd/services.html.h:17
-#: pkg/kubernetes/views/project-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:5
-msgid "Description"
-msgstr "描述"
-
-#: pkg/systemd/init.js:270
-msgid "Id"
-msgstr "ID"
-
-#: pkg/systemd/init.js:272
-msgid "Next Run"
-msgstr "下次运行"
-
-#: pkg/systemd/init.js:273
-msgid "Last Trigger"
-msgstr "最近的触发器"
-
-#: pkg/systemd/init.js:274 pkg/kubernetes/views/container-body.html.h:6
-#: pkg/kubernetes/views/details-page.html.h:8
-msgid "State"
-msgstr "状态"
-
-#: pkg/systemd/init.js:301
-msgid "Enabled"
-msgstr "启用"
-
-#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
-msgid "Disabled"
-msgstr "禁用"
-
-#: pkg/systemd/init.js:303
-msgid "Static"
-msgstr "静态"
-
-#: pkg/systemd/init.js:375 pkg/systemd/init.js:661
-msgid "$0 Template"
-msgstr "$0 模板"
-
-#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
-msgid "Start"
-msgstr "启动"
-
-#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
-msgid "Stop"
-msgstr "停止"
-
-#: pkg/systemd/init.js:518
-msgid "Reload"
-msgstr "重载"
-
-#: pkg/systemd/init.js:519
-msgid "Reload or Restart"
-msgstr "重载或重启"
-
-#: pkg/systemd/init.js:520
-msgid "Try Restart"
-msgstr "尝试重启"
-
-#: pkg/systemd/init.js:521
-msgid "Reload or Try Restart"
-msgstr "重载或尝试重启"
-
-#: pkg/systemd/init.js:522
-msgid "Isolate"
-msgstr "隔离"
-
-#: pkg/systemd/init.js:541
-msgid "Enable"
-msgstr "启用"
-
-#: pkg/systemd/init.js:542
-msgid "Enable Forcefully"
-msgstr "强制启用"
-
-#: pkg/systemd/init.js:543
-msgid "Disable"
-msgstr "禁用"
-
-#: pkg/systemd/init.js:544
-msgid "Preset"
-msgstr "预置"
-
-#: pkg/systemd/init.js:545
-msgid "Preset Forcefully"
-msgstr "强制预设"
-
-#: pkg/systemd/init.js:546
-msgid "Mask"
-msgstr "Mask"
-
-#: pkg/systemd/init.js:547
-msgid "Mask Forcefully"
-msgstr "强制 Mask"
-
-#: pkg/systemd/init.js:548
-msgid "Unmask"
-msgstr "Unmask"
-
-#: pkg/systemd/init.js:621
-msgid "Since $0"
-msgstr "由于 $0"
-
-#: pkg/systemd/init.js:639
-msgid "This unit is an instance of the $0 template."
-msgstr "该单元是模板 $0 的实例."
-
-#: pkg/systemd/init.js:834
-#, fuzzy
-msgid "The user <b>$0</b> does not have permissions for creating timers"
-msgstr "用户 <b>$0</b> 不允许管理服务器"
-
-#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
-#, fuzzy
-msgid "This field cannot be empty."
-msgstr "名称不能为空."
-
-#: pkg/systemd/init.js:1147
-msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
-msgstr ""
-
-#: pkg/systemd/init.js:1169
-#, fuzzy
-msgid "Invalid number."
-msgstr "无效的 key"
-
-#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
-msgid "Hour needs to be a number between 0-23"
-msgstr ""
-
-#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
-msgid "Minute needs to be a number between 0-59"
-msgstr ""
-
-#: pkg/systemd/init.js:1218
-#, fuzzy
-msgid "Invalid date format."
-msgstr "无效的日期格式"
-
-#: pkg/systemd/init.js:1222
-msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
-msgstr ""
-
-#: pkg/systemd/logs.js:69
-msgid "Load earlier entries"
-msgstr "载入更早条目"
-
-#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
-#: pkg/systemd/logs.js:175
-msgid "Loading..."
-msgstr "载入中..."
-
-#: pkg/systemd/logs.js:130
-msgid "Go to"
-msgstr "到"
-
-#: pkg/systemd/logs.js:257
-msgid "Journal entry"
-msgstr "日志条目"
-
-#: pkg/systemd/logs.js:284
-msgid "Journal entry not found"
-msgstr "未找到日志条目"
-
-#: pkg/tuned/dialog.js:94
-msgid "Tuned is not available"
-msgstr "Tuned 不可用"
-
-#: pkg/tuned/dialog.js:96
-msgid "Tuned is not running"
-msgstr "Tuned 未运行"
-
-#: pkg/tuned/dialog.js:98
-msgid "Tuned is off"
-msgstr "Tuned 已关闭"
-
-#: pkg/tuned/dialog.js:100
-msgid "This system is using the recommended profile"
-msgstr "该系统正在使用推荐的配置集"
-
-#: pkg/tuned/dialog.js:102
-msgid "This system is using a custom profile"
-msgstr "该系统正在使用自定义的配置集"
-
-#: pkg/tuned/dialog.js:114
-msgid "Communication with tuned has failed"
-msgstr "与 Tuned 通信失败"
-
-#: pkg/tuned/dialog.js:133
-msgid "Failed to disable tuned profile"
-msgstr "禁用Tuned配置失败"
-
-#: pkg/tuned/dialog.js:145
-msgid "Failed to switch profile"
-msgstr "切换配置集失败"
-
-#: pkg/tuned/dialog.js:169
-msgid "Failed to enable tuned"
-msgstr "启用Tuned失败"
-
-#: pkg/tuned/dialog.js:171
-msgid "Failed to disable tuned"
-msgstr "禁用Tuned失败"
-
-#: pkg/tuned/dialog.js:191
-msgid "Change Performance Profile"
-msgstr "变更性能配置集"
-
-#: pkg/tuned/dialog.js:200
-msgid "Change Profile"
-msgstr "变更配置集"
-
-#: pkg/tuned/dialog.js:233 pkg/kubernetes/views/service-body.html.h:7
-#: pkg/kubernetes/views/pod-panel.html.h:2
-#: pkg/kubernetes/views/image-config.html.h:8
-#: pkg/kubernetes/views/imagestream-body.html.h:12
-#: pkg/kubernetes/views/pod-page.html.h:5
-msgid "None"
-msgstr "无"
-
-#: pkg/tuned/dialog.js:234
-msgid "Disable tuned"
-msgstr "禁用 Tuned"
-
-#: pkg/tuned/dialog.js:262
-msgid "Tuned has failed to start"
-msgstr "Tuned 启动失败"
-
-#: pkg/tuned/change-profile.jsx:52
-#, fuzzy
-msgid "recommended"
-msgstr "MII (推荐)"
-
-#: pkg/lib/journal.js:209
-msgid "[no data]"
-msgstr "[没有数据]"
-
-#: pkg/lib/journal.js:213
-msgid "[$0 bytes of binary data]"
-msgstr "[$0 字节二进制数据]"
-
-#: pkg/lib/journal.js:215
-msgid "[binary data]"
-msgstr "[二进制数据]"
-
-#: pkg/lib/journal.js:241
-msgid "Reboot"
-msgstr "重启"
-
-#: pkg/lib/machine-dialogs.js:364
-msgid "This machine has already been added."
-msgstr "该主机已经被添加。"
-
-#: pkg/lib/machine-dialogs.js:380
-msgid ""
-"This version of cockpit-ws does not support connecting to a host with an "
-"alternate user or port"
-msgstr "该版本的 cockpit-ws 不支持连接到有交替的用户或端口的主机"
-
-#: pkg/lib/machine-dialogs.js:386
-msgid "The IP address or host name cannot contain whitespace."
-msgstr "IP 地址或主机名不能包含空格。"
-
-#: pkg/lib/machine-dialogs.js:412
-msgid "Failed to add machine: $0"
-msgstr "添加主机失败: $0"
-
-#: pkg/lib/machine-dialogs.js:429
-msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
-msgstr ""
-"Cockpit 无法与指定主机 $0 联系。请确认已经在端口 $1 上运行 SSH，或者在该地址"
-"中指定另一个端口。"
-
-#: pkg/lib/machine-dialogs.js:447
-msgid "Enter IP address or host name"
-msgstr "输入 IP 地址或主机名"
-
-#: pkg/lib/machine-dialogs.js:494
-msgid "Failed to edit machine: $0"
-msgstr "编辑主机失败: $0"
-
-#: pkg/lib/cockpit-components-dialog.jsx:136 pkg/sosreport/index.js:55
-#: pkg/systemd/services.html.h:34 pkg/lib/machine-sync-users.html.h:7
-#: pkg/lib/machine-add.html.h:5 pkg/lib/machine-change-port.html.h:6
-#: pkg/lib/machine-change-auth.html.h:11 pkg/storaged/index.html.h:22
-#: pkg/realmd/operation.html.h:10 pkg/kubernetes/views/node-delete.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:3
-#: pkg/kubernetes/views/pvc-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:3
-#: pkg/kubernetes/views/auth-form.html.h:13
-#: pkg/kubernetes/views/node-add.html.h:7
-#: pkg/kubernetes/views/user-group-add.html.h:5
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:4
-#: pkg/kubernetes/views/route-modify.html.h:3
-#: pkg/kubernetes/views/image-delete.html.h:3
-#: pkg/kubernetes/views/pv-delete.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:4
-#: pkg/kubernetes/views/item-delete.html.h:4
-#: pkg/kubernetes/views/add-user-dialog.html.h:8
-#: pkg/kubernetes/views/user-add-membership.html.h:8
-#: pkg/kubernetes/views/deploy.html.h:4
-#: pkg/kubernetes/views/user-modify.html.h:8
-#: pkg/kubernetes/views/pv-modify.html.h:21
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:5
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:3
-#: pkg/kubernetes/views/imagestream-delete.html.h:3
-#: pkg/kubernetes/views/user-remove-membership.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:7
-#: pkg/kubernetes/views/add-role-dialog.html.h:3
-#: pkg/kubernetes/views/service-modify.html.h:4
-#: pkg/kubernetes/views/project-delete.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:9
-#: pkg/kubernetes/views/user-group-remove.html.h:2
-#: pkg/playground/translate.html.h:2 pkg/dashboard/index.html.h:12
-msgid "Cancel"
-msgstr "取消"
-
-#: pkg/lib/cockpit-components-dialog.jsx:155
-msgid "Ok"
-msgstr ""
-
-#: pkg/lib/credentials.js:182
-msgid "No such file or directory"
-msgstr "没有该文件或目录"
-
-#: pkg/lib/credentials.js:186
-msgid "The passwords do not match."
-msgstr "密码不匹配"
-
-#: pkg/lib/credentials.js:191
-msgid "Prompting via ssh-keygen timed out"
-msgstr "通过 ssh-keygen 提示超时"
-
-#: pkg/lib/credentials.js:213 pkg/users/local.js:78
-msgid "Old password not accepted"
-msgstr "旧密码不被接受"
-
-#: pkg/lib/credentials.js:223 pkg/users/local.js:112 pkg/users/local.js:144
-msgid "Failed to change password"
-msgstr "修改密码失败"
-
-#: pkg/lib/credentials.js:231 pkg/users/local.js:120
-msgid "New password was not accepted"
-msgstr "新密码不被接受"
-
-#: pkg/lib/credentials.js:248
-msgid "Not a valid private key"
-msgstr "无效的私钥"
-
-#: pkg/lib/credentials.js:251
-msgid "Prompting via ssh-add timed out"
-msgstr "通过 ssh-add 提示超时"
-
-#: pkg/lib/credentials.js:274
-msgid "Invalid file permissions"
-msgstr "无效的文件权限"
-
-#: pkg/lib/credentials.js:278
-msgid "Password not accepted"
-msgstr "密码未接受"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:22
-#: pkg/shell/index.html.h:27 pkg/storaged/index.html.h:52
-#: pkg/playground/jquery-patterns.html.h:2
-msgid "On"
-msgstr "开"
-
-#: pkg/lib/patterns.js:244 pkg/systemd/index.html.h:23
-#: pkg/shell/index.html.h:28 pkg/storaged/index.html.h:53
-#: pkg/playground/jquery-patterns.html.h:3
-msgid "Off"
-msgstr "关"
-
-#: pkg/shell/base_index.js:670 pkg/users/local.js:1164
-#: pkg/docker/index.html.h:69 pkg/networkmanager/index.html.h:65
-msgid "Unexpected error"
-msgstr "意外的错误"
-
-#: pkg/shell/base_index.js:671
-msgid "Cockpit had an unexpected internal error. <br/><br/>"
-msgstr "Cockpit 发生意外内部错误。<br/><br/>"
-
-#: pkg/shell/base_index.js:672
-msgid "You can try restarting Cockpit by pressing refresh in your browser. "
-msgstr "您可以尝试通过刷新浏览器来重启 Cockpit。"
-
-#: pkg/shell/base_index.js:673
-msgid "The javascript console contains details about this error "
-msgstr "JavaScript 控制台包含有关此错误的详细信息"
-
-#: pkg/shell/base_index.js:674
-msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
-msgstr "(大多数浏览器使用 <b>Ctrl-Shift-J</b>)."
-
-#: pkg/shell/indexes.js:126 pkg/shell/indexes.js:497 pkg/shell/simple.html.h:17
-msgid "Disconnected"
-msgstr "已断开连接"
-
-#: pkg/shell/indexes.js:253
-msgid "Machines"
-msgstr "主机"
-
-#: pkg/shell/indexes.js:314
-msgid "The machine is restarting"
-msgstr "正在重启主机"
-
-#: pkg/shell/indexes.js:317
-msgid "Connecting to the machine"
-msgstr "正在连接至主机"
-
-#: pkg/shell/indexes.js:320
-msgid "Couldn't connect to the machine"
-msgstr "不能连接至主机"
-
-#: pkg/shell/indexes.js:322
-msgid "Cannot connect to an unknown machine"
-msgstr "不能连接至未知主机"
-
-#: pkg/ostree/client.js:56
-msgid "Receiving delta parts"
-msgstr "正在接收增量部分"
-
-#: pkg/ostree/client.js:58
-msgid "Receiving metadata objects"
-msgstr "正在接收元数据对象"
-
-#: pkg/ostree/client.js:61
-msgid "Receiving objects: $0%"
-msgstr "正在接收对象: $0%"
-
-#: pkg/ostree/client.js:64
-msgid "Writing objects"
-msgstr "正在写对象"
-
-#: pkg/ostree/client.js:66
-msgid "Scanning metadata"
-msgstr "正在扫描元数据"
-
-#: pkg/ostree/client.js:500
-msgid "OS $0 not found"
-msgstr "未找到操作系统 $0"
-
-#: pkg/ostree/app.js:81
-msgid "Not authorized to update software on this system"
-msgstr "未授权更新该系统上的软件"
-
-#: pkg/ostree/app.js:83
-msgid "OSTree is not available on this system"
-msgstr "该系统上 OSTree  不可用"
-
-#: pkg/ostree/app.js:101
-msgid "No OSTree deployments found"
-msgstr "没有找到 OSTree  部署"
-
-#: pkg/ostree/app.js:219
-msgid "Checking for updates"
-msgstr "检查升级"
 
 #: pkg/ostree/app.js:307
 msgid "$0 package"
@@ -780,689 +587,32 @@ msgstr "$0 软件包"
 msgid "$0 packages"
 msgstr "$0 软件包"
 
-#: pkg/selinux/setroubleshoot.js:65
-msgid "Error while setting SELinux mode: '$0'"
-msgstr "设置 SELinux 模式时出错: '$0'"
-
-#: pkg/selinux/setroubleshoot.js:238
-msgid "Not connected"
-msgstr "未连接"
-
-#: pkg/selinux/setroubleshoot.js:275
-msgid "Error while connecting."
-msgstr "连接时出错。"
-
-#: pkg/selinux/setroubleshoot-view.jsx:82
-msgid "Applying solution..."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:90
-msgid "Solution applied successfully"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:97
-#, fuzzy
-msgid "Solution failed"
-msgstr "登录失败"
-
-#: pkg/selinux/setroubleshoot-view.jsx:107
-msgid "Apply this solution"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:114
-msgid "Unable to apply this solution automatically"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:118
-msgid "solution details"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:309
-msgid "SELinux system status is unknown."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:317
-#, fuzzy
-msgid "SELinux is disabled on the system."
-msgstr "Cockpit 未安装在该系统上。"
-
-#: pkg/selinux/setroubleshoot-view.jsx:324
-msgid "The configured state is unknown, it might change on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:326
-msgid ""
-"Setting deviates from the configured state and will revert on the next boot."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:330
-#, fuzzy
-msgid "SELinux Policy"
-msgstr "DNS 策略"
-
-#: pkg/selinux/setroubleshoot-view.jsx:332
-msgid "Enforce policy:"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:382 pkg/kubernetes/index.html.h:10
-#: pkg/kubernetes/registry.html.h:5
-msgid "Connecting..."
-msgstr "连接中..."
-
-#: pkg/selinux/setroubleshoot-view.jsx:385
-msgid ""
-"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
-"server is installed."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:400
-msgid "Occurred between $0 and $1"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:405
-msgid "Occurred $0"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:440
-msgid "$0 occurrence"
-msgid_plural "$1 occurrences"
-msgstr[0] ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:478
-msgid "SELinux Access Control Errors"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:479
-msgid "No SELinux alerts."
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-client.js:52
-msgid "Unable to start setroubleshootd"
-msgstr "无法启动 setroubleshootd"
-
-#: pkg/selinux/setroubleshoot-client.js:157
-msgid "Unable to get alert"
-msgstr "无法获取警告"
-
-#: pkg/selinux/setroubleshoot-client.js:172
-msgid "Unable to run fix"
-msgstr "无法运行修复"
-
-#: pkg/selinux/setroubleshoot-client.js:187
-msgid "Failed to delete alert"
-msgstr "无法删除警告"
-
-#: pkg/selinux/setroubleshoot-client.js:192
-msgid "Error while deleting alert"
-msgstr "删除警告时出错"
-
-#: pkg/storaged/dialog.js:267
-msgid "Size must be a number"
-msgstr "大小必须是一个数字"
-
-#: pkg/storaged/dialog.js:269
-#, fuzzy
-msgid "Size cannot be zero"
-msgstr "大小不能为零"
-
-#: pkg/storaged/dialog.js:271
-#, fuzzy
-msgid "Size cannot be negative"
-msgstr "大小不能为负数"
-
-#: pkg/storaged/dialog.js:273
-msgid "Size is too large"
-msgstr "大小太大"
-
-#: pkg/storaged/details.js:85
-msgid "Device $0 is mounted on $1"
-msgstr "设备 $0 已挂载至 $1"
-
-#: pkg/storaged/details.js:91
-msgid "Device $0 is a member of RAID Array $1"
-msgstr "设备 $0 是 RAID 阵列 $1 的成员"
-
-#: pkg/storaged/details.js:97
-msgid "Device $0 is a physical volume of $1"
-msgstr "设备 $0 是 $1 的物理卷"
-
-#: pkg/storaged/details.js:113
-msgid "Create partition on $0"
-msgstr "为 $0 创建分区"
-
-#: pkg/storaged/details.js:115
-msgid "Format $0"
-msgstr "格式 $0"
-
-#: pkg/storaged/details.js:177
-msgid "XFS - Red Hat Enterprise Linux 7 default"
-msgstr "XFS - Red Hat Enterprise Linux 7 默认"
-
-#: pkg/storaged/details.js:178
-msgid "ext4 - Red Hat Enterprise Linux 6 default"
-msgstr "ext4 - Red Hat Enterprise Linux 6 默认"
-
-#: pkg/storaged/details.js:179
-msgid "Encrypted XFS (LUKS)"
-msgstr "加密 XFS (LUKS)"
-
-#: pkg/storaged/details.js:180
-msgid "Encrypted EXT4 (LUKS)"
-msgstr "加密 EXT4 (LUKS)"
-
-#: pkg/storaged/details.js:181
-msgid "VFAT - Compatible with all systems and devices"
-msgstr "VFAT - 兼容所有系统和设备"
-
-#: pkg/storaged/details.js:182
-msgid "NTFS - Compatible with most systems"
-msgstr "NTFS - 兼容多数系统"
-
-#: pkg/storaged/details.js:183
-msgid "Extended Partition"
-msgstr "扩展分区"
-
-#: pkg/storaged/details.js:185
-msgid "No Filesystem"
-msgstr "无文件系统"
-
-#: pkg/storaged/details.js:186
-msgid "Custom (Enter filesystem type)"
-msgstr "自定义 (输入文件系统类型)"
-
-#: pkg/storaged/details.js:192 pkg/storaged/details.js:664
-#: pkg/storaged/details.js:735 pkg/storaged/details.js:773
-#: pkg/storaged/details.js:909 pkg/storaged/index.html.h:20
-#: pkg/kubernetes/views/volumes-page.html.h:11
-msgid "Size"
-msgstr "大小"
-
-#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
-msgid "Erase"
-msgstr "擦除"
-
-#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
-msgid "Don't overwrite existing data"
-msgstr "不覆盖已存在数据"
-
-#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
-msgid "Overwrite existing data with zeros"
-msgstr "使用 0 覆盖已存在数据"
-
-#: pkg/storaged/details.js:207 pkg/shell/index.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:4
-#: pkg/kubernetes/views/deploy.html.h:2 pkg/kubernetes/views/pv-modify.html.h:3
-msgid "Type"
-msgstr "类型"
-
-#: pkg/storaged/details.js:211 pkg/storaged/details.js:429
-#: pkg/storaged/details.js:709 pkg/storaged/details.js:731
-#: pkg/storaged/details.js:769 pkg/storaged/details.js:798
-#: pkg/storaged/details.js:864 pkg/storaged/overview.js:417
-#: pkg/storaged/overview.js:490 pkg/storaged/overview.js:624
-#: pkg/storaged/overview.js:702 pkg/storaged/index.html.h:18
-#: pkg/networkmanager/index.html.h:16
-#: pkg/kubernetes/views/project-listing.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:3
-#: pkg/kubernetes/views/volume-body.html.h:11
-#: pkg/kubernetes/views/containers-listing.html.h:2
-#: pkg/kubernetes/views/volumes-page.html.h:3
-#: pkg/kubernetes/views/pv-claim.html.h:1
-#: pkg/kubernetes/views/pv-modify.html.h:6
-#: pkg/kubernetes/views/image-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:15
-#: pkg/kubernetes/views/nodes-page.html.h:5
-#: pkg/kubernetes/views/project-modify.html.h:3
-#: pkg/kubernetes/views/details-page.html.h:4
-#: pkg/kubernetes/views/service-modify.html.h:2
-#: pkg/kubernetes/views/imagestream-modify.html.h:3
-msgid "Name"
-msgstr "名称"
-
-#: pkg/storaged/details.js:215
-msgid "Filesystem type"
-msgstr "文件系统类型"
-
-#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
-msgid "Passphrase"
-msgstr "口令"
-
-#: pkg/storaged/details.js:224
-#, fuzzy
-msgid "Passphrase cannot be empty"
-msgstr "口令不能为空"
-
-#: pkg/storaged/details.js:229
-msgid "Confirm passphrase"
-msgstr "确认口令"
-
-#: pkg/storaged/details.js:232
-msgid "Passphrases do not match"
-msgstr "口令不匹配"
-
-#: pkg/storaged/details.js:237
-msgid "Store passphrase"
-msgstr "存储口令"
-
-#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
-#: pkg/storaged/details.js:1115
-msgid "Encryption Options"
-msgstr "加密选项"
-
-#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
-msgid "Mounting"
-msgstr "挂载"
-
-#: pkg/storaged/details.js:247 pkg/storaged/details.js:435
-#: pkg/subscriptions/subscriptions-register.jsx:101 pkg/docker/index.html.h:23
-#: pkg/kubernetes/views/image-config.html.h:2
-msgid "Default"
-msgstr "默认"
-
-#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
-msgid "Custom"
-msgstr "自定义"
-
-#: pkg/storaged/details.js:253 pkg/storaged/details.js:440
-#: pkg/storaged/index.html.h:19
-msgid "Mount Point"
-msgstr "挂载点"
-
-#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
-msgid "Mount Options"
-msgstr "挂载选项"
-
-#: pkg/storaged/details.js:266
-msgid "Create partition"
-msgstr "创建分区"
-
-#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
-#: pkg/storaged/details.js:1142
-msgid "Format"
-msgstr "格式化"
-
-#: pkg/storaged/details.js:268
-msgid "Formatting a storage device will erase all data on it."
-msgstr "格式化存储设备将擦除其中的所有数据."
-
-#: pkg/storaged/details.js:335
-msgid "Format Disk $0"
-msgstr "格式化磁盘 $0"
-
-#: pkg/storaged/details.js:346
-msgid "Partitioning"
-msgstr "分区"
-
-#: pkg/storaged/details.js:348
-msgid "Compatible with all systems and devices (MBR)"
-msgstr "兼容所有系统和设备 (MBR)"
-
-#: pkg/storaged/details.js:349
-msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr "兼容现代系统，且支持磁盘 > 2TB (GPT)"
-
-#: pkg/storaged/details.js:352
-msgid "No partitioning"
-msgstr "无分区"
-
-#: pkg/storaged/details.js:358
-msgid "Formatting a disk will erase all data on it."
-msgstr "格式化磁盘将擦除其中的所有数据。"
-
-#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
-msgid "Filesystem Options"
-msgstr "文件系统选项"
-
-#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
-msgid "Apply"
-msgstr "应用"
-
-#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
-#: pkg/storaged/details.js:1110
-msgid "Unlock"
-msgstr "未锁定"
-
-#: pkg/storaged/details.js:527
-msgid "Stored Passphrase"
-msgstr "已存储口令"
-
-#: pkg/storaged/details.js:531 pkg/kubernetes/views/volume-body.html.h:32
-msgid "Options"
-msgstr "选项"
-
-#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
-msgid "Add Disks"
-msgstr "添加磁盘"
-
-#: pkg/storaged/details.js:567 pkg/storaged/details.js:933
-#: pkg/storaged/overview.js:448 pkg/storaged/overview.js:495
-#: pkg/storaged/index.html.h:55
-msgid "Disks"
-msgstr "磁盘"
-
-#: pkg/storaged/details.js:579 pkg/storaged/details.js:948
-#: pkg/storaged/overview.js:501
-msgid "At least one disk is needed."
-msgstr "至少需要 1 块磁盘。"
-
-#: pkg/storaged/details.js:584 pkg/storaged/details.js:953
-#: pkg/storaged/overview.js:629 pkg/storaged/overview.js:657
-#: pkg/lib/machine-add.html.h:6 pkg/kubernetes/views/node-add.html.h:8
-#: pkg/kubernetes/views/user-group-add.html.h:6
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:5
-#: pkg/kubernetes/views/add-user-dialog.html.h:9
-#: pkg/kubernetes/views/user-add-membership.html.h:9
-#: pkg/kubernetes/views/add-role-dialog.html.h:4
-msgid "Add"
-msgstr "添加"
-
-#: pkg/storaged/details.js:625 pkg/storaged/details.js:821
-#: pkg/storaged/details.js:1016 pkg/docker/details.js:271
-#: pkg/docker/image.js:151 pkg/docker/containers-view.jsx:166
-msgid "Please confirm deletion of $0"
-msgstr "请确认删除 $0"
-
-#: pkg/storaged/details.js:630 pkg/storaged/details.js:827
-#: pkg/storaged/details.js:1022 pkg/storaged/details.js:1151
-#: pkg/storaged/details.js:1616 pkg/storaged/details.js:1776
-#: pkg/docker/details.js:273 pkg/docker/image.js:153
-#: pkg/docker/containers-view.jsx:168 pkg/kubernetes/scripts/volumes.js:218
-#: pkg/users/index.html.h:9 pkg/kubernetes/views/node-delete.html.h:5
-#: pkg/kubernetes/views/pvc-delete.html.h:5
-#: pkg/kubernetes/views/image-delete.html.h:4
-#: pkg/kubernetes/views/pv-delete.html.h:5
-#: pkg/kubernetes/views/item-delete.html.h:5
-#: pkg/kubernetes/views/imagestream-delete.html.h:4
-#: pkg/kubernetes/views/user-remove-membership.html.h:3
-#: pkg/kubernetes/views/project-delete.html.h:3
-msgid "Delete"
-msgstr "删除"
-
-#: pkg/storaged/details.js:631
-msgid "Deleting a RAID device will erase all data on it."
-msgstr "删除 RAID 设备将擦除其中的所有数据."
-
-#: pkg/storaged/details.js:661
-msgid "Resize Logical Volume"
-msgstr "调整逻辑卷大小"
-
-#: pkg/storaged/details.js:673
-msgid "Resize Filesystem"
-msgstr "调整文件系统大小"
-
-#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
-msgid "Resize"
-msgstr "调整大小"
-
-#: pkg/storaged/details.js:690
-#, fuzzy
-msgid "This logical volume cannot be made smaller."
-msgstr "该逻辑卷无法变小。"
-
-#: pkg/storaged/details.js:706
-msgid "Renamee Logical Volume"
-msgstr "重命名逻辑卷"
-
-#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
-#: pkg/storaged/details.js:1775
-msgid "Rename"
-msgstr "重命名"
-
-#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
-msgid "Create Snapshot"
-msgstr "创建快照"
-
-#: pkg/storaged/details.js:745 pkg/storaged/details.js:781
-#: pkg/storaged/details.js:804 pkg/storaged/details.js:915
-#: pkg/storaged/overview.js:461 pkg/storaged/overview.js:506
-#: pkg/kubernetes/views/add-group-dialog.html.h:6
-#: pkg/kubernetes/views/project-modify.html.h:8
-msgid "Create"
-msgstr "创建"
-
-#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
-msgid "Create Thin Volume"
-msgstr "创建稀疏卷"
-
-#: pkg/storaged/details.js:795
-msgid "Rename Volume Group"
-msgstr "重命名卷组"
-
-#: pkg/storaged/details.js:826
-msgid "Deleting a volume group will erase all data on it."
-msgstr "删除卷组将擦除其中的所有数据。"
-
-#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
-msgid "Create Logical Volume"
-msgstr "创建逻辑卷"
-
-#: pkg/storaged/details.js:869
-msgid "Purpose"
-msgstr "目的"
-
-#: pkg/storaged/details.js:871
-msgid "Block device for filesystems"
-msgstr "块设备的文件系统"
-
-#: pkg/storaged/details.js:874
-msgid "Pool for thinly provisioned volumes"
-msgstr "池的瘦分配配置卷"
-
-#: pkg/storaged/details.js:1009
-msgid "Deleting a logical volume will delete all data in it."
-msgstr "删除逻辑卷将擦除其中的所有数据。"
-
-#: pkg/storaged/details.js:1012
-msgid "Deleting a partition will delete all data in it."
-msgstr "删除分区将擦除其中的所有数据。"
-
-#: pkg/storaged/details.js:1053 pkg/storaged/overview.js:689
-#: pkg/storaged/devices.js:119 pkg/users/local.js:1155
-#: pkg/systemd/services.html.h:14
-msgid "Error"
-msgstr "错误"
-
-#: pkg/storaged/details.js:1099
-msgid "Mount"
-msgstr "挂载"
-
-#: pkg/storaged/details.js:1100
-msgid "Unmount"
-msgstr "卸载"
-
-#: pkg/storaged/details.js:1109
-msgid "Lock"
-msgstr "锁定"
-
-#: pkg/storaged/details.js:1127
-msgid "Activate"
-msgstr "激活"
-
-#: pkg/storaged/details.js:1130
-msgid "Deactivate"
-msgstr "未激活"
-
-#: pkg/storaged/details.js:1221
-msgctxt "storage-id-desc"
-msgid "$0 File System"
-msgstr "$0 文件系统"
-
-#: pkg/storaged/details.js:1224
-msgctxt "storage-id-desc"
-msgid "Linux MD-RAID Component"
-msgstr "Linux MD-RAID 组件"
-
-#: pkg/storaged/details.js:1226
-msgctxt "storage-id-desc"
-msgid "LVM2 Physical Volume"
-msgstr "LVM2 物理卷"
-
-#: pkg/storaged/details.js:1228
-msgctxt "storage-id-desc"
-msgid "RAID Member"
-msgstr "RAID 成员"
-
-#: pkg/storaged/details.js:1245
-msgctxt "storage-id-desc"
-msgid "LUKS Encrypted"
-msgstr "LUKS 加密"
-
-#: pkg/storaged/details.js:1247
-msgctxt "storage-id-desc"
-msgid "Encrypted"
-msgstr "加密"
-
-#: pkg/storaged/details.js:1251
-msgctxt "storage-id-desc"
-msgid "Swap Space"
-msgstr "Swap 空间"
-
-#: pkg/storaged/details.js:1253
-msgctxt "storage-id-desc"
-msgid "Other Data"
-msgstr "其他数据"
-
-#: pkg/storaged/details.js:1256
-msgctxt "storage-id-desc"
-msgid "Unrecognized Data"
-msgstr "无法识别的数据"
-
-#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
-msgid "$size $partition"
-msgstr "$size $partition"
-
-#: pkg/storaged/details.js:1278
-msgid "mounted on $0"
-msgstr "已挂载至 $0"
-
-#: pkg/storaged/details.js:1280
-msgid "not mounted"
-msgstr "未挂载"
-
-#: pkg/storaged/details.js:1284
-msgid "unlocked"
-msgstr "未锁定"
-
-#: pkg/storaged/details.js:1286
-msgid "locked"
-msgstr "已锁定"
-
-#: pkg/storaged/details.js:1367
-msgid "$0 Free Space for Logical Partitions"
-msgstr "逻辑分区剩余 $0 可用空间"
-
-#: pkg/storaged/details.js:1370
-msgid "$0 Free Space for Primary Partitions"
-msgstr "主分区剩余 $0 可用空间"
-
-#: pkg/storaged/details.js:1375
-msgid "$0 Free Space"
-msgstr "$0 可用空间"
-
-#: pkg/storaged/details.js:1379
-msgid "Create Partition"
-msgstr "创建分区"
-
-#: pkg/storaged/details.js:1387
-msgid "$0 Extended Partition"
-msgstr "$0 扩展分区"
-
-#: pkg/storaged/details.js:1424
-msgid "Logical Partition"
-msgstr "逻辑分区"
-
-#: pkg/storaged/details.js:1426
-msgid "Primary Partition"
-msgstr "主分区"
-
-#: pkg/storaged/details.js:1428 pkg/kubernetes/views/volume-body.html.h:5
-msgid "Partition"
-msgstr "分区"
-
-#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
-msgid "Content"
-msgstr "内容"
-
-#: pkg/storaged/details.js:1533
-msgid "RAID 0"
-msgstr "RAID 0"
-
-#: pkg/storaged/details.js:1534
-msgid "RAID 1"
-msgstr "RAID 1"
-
-#: pkg/storaged/details.js:1535
-msgid "RAID 4"
-msgstr "RAID 4"
-
-#: pkg/storaged/details.js:1536
-msgid "RAID 5"
-msgstr "RAID 5"
-
-#: pkg/storaged/details.js:1537
-msgid "RAID 6"
-msgstr "RAID 6"
-
-#: pkg/storaged/details.js:1538
-msgid "RAID 10"
-msgstr "RAID 10"
-
-#: pkg/storaged/details.js:1539
-msgid "RAID ($0)"
-msgstr "RAID ($0)"
-
-#: pkg/storaged/details.js:1544
-msgid "$0 Disks"
-msgstr "$0 磁盘"
-
-#: pkg/storaged/details.js:1546
-msgid "$0 Chunk Size"
-msgstr "$0 区块大小"
-
-#: pkg/storaged/details.js:1574 pkg/ostree/index.html.h:7
-msgid "Running"
-msgstr "运行中"
-
-#: pkg/storaged/details.js:1574
-msgid "Not running"
-msgstr "未运行"
-
-#: pkg/storaged/details.js:1592
-msgid "FAILED"
-msgstr "失败"
-
-#: pkg/storaged/details.js:1593
-msgid "In Sync"
-msgstr "同步中"
-
-#: pkg/storaged/details.js:1594
-msgid "Spare"
-msgstr "备用"
-
-#: pkg/storaged/details.js:1594
-msgid "Recovering"
-msgstr "恢复"
-
-#: pkg/storaged/details.js:1595
-msgid "Write-mostly"
-msgstr "Write-mostly"
-
-#: pkg/storaged/details.js:1596
-msgid "Blocked"
-msgstr "受阻"
-
-#: pkg/storaged/details.js:1597
-msgid "Unknown ($0)"
-msgstr "未知 ($0)"
-
-#: pkg/storaged/details.js:1614
-msgid "Start Scrubbing"
-msgstr "开始擦除"
-
-#: pkg/storaged/details.js:1615
-msgid "Stop Scrubbing"
-msgstr "停止擦除"
+#: pkg/docker/util.js:124
+msgid "$0 shares"
+msgstr "$0 共享"
+
+#: pkg/kubernetes/scripts/nodes.js:870
+#, fuzzy, c-format
+msgid "$0% Free"
+msgid_plural "$0% Free"
+msgstr[0] "$0% 空闲的"
+
+#: pkg/kubernetes/scripts/nodes.js:872
+msgid "$0% Used"
+msgid_plural "$0% Used"
+msgstr[0] "$0% 已使用的"
+
+#: pkg/storaged/details.js:1765
+msgid "$0, $1 free"
+msgstr "$0, $1 可用"
+
+#: pkg/networkmanager/interfaces.js:2473
+msgid "$mtu"
+msgstr "$mtu"
+
+#: pkg/storaged/utils.js:157
+msgid "$name (from $host)"
+msgstr "$name (从 $host)"
 
 #: pkg/storaged/details.js:1653
 msgid "$size $desc"
@@ -1477,217 +627,2836 @@ msgstr "$size $desc<br/>${percent}% 已满"
 msgid "$size $desc<br/>($state)"
 msgstr "$size $desc<br/>($state)"
 
-#: pkg/storaged/details.js:1692
-msgid "active, but unsupported"
-msgstr "激活，但不支持"
+#: pkg/storaged/details.js:1261 pkg/storaged/details.js:1267
+msgid "$size $partition"
+msgstr "$size $partition"
 
-#: pkg/storaged/details.js:1692
-msgid "inactive"
+#: pkg/docker/details.js:144
+msgid "${hip}:${hport} -> $cport"
+msgstr "${hip}:${hport} -> $cport"
+
+#: pkg/subscriptions/subscriptions-client.js:198
+msgid "'Organization' required to register."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-client.js:202
+msgid "'Organization' required when using activation keys."
+msgstr ""
+
+#: pkg/shell/base_index.js:674
+msgid "(<b>Ctrl-Shift-J</b> in most browsers)."
+msgstr "(大多数浏览器使用 <b>Ctrl-Shift-J</b>)."
+
+#: pkg/storaged/overview.js:440
+msgid "1 MiB"
+msgstr "1 MiB"
+
+#: pkg/systemd/index.html:459 pkg/systemd/index.html:463
+msgid "1 Minute"
+msgstr "1 分钟"
+
+#: pkg/storaged/index.html:312 pkg/networkmanager/index.html:55
+#: pkg/networkmanager/index.html:501
+msgid "1 day"
+msgstr "1 天"
+
+#: pkg/storaged/index.html:310 pkg/networkmanager/index.html:53
+#: pkg/networkmanager/index.html:499
+msgid "1 hour"
+msgstr "1 小时"
+
+#: pkg/storaged/index.html:313 pkg/networkmanager/index.html:56
+#: pkg/networkmanager/index.html:502
+msgid "1 week"
+msgstr "1 周"
+
+#: pkg/playground/translate.html:190
+#, fuzzy
+msgid "1% Free"
+msgid_plural "{{$count}}% Free"
+msgstr[0] "$0% 空闲的"
+
+#: pkg/storaged/overview.js:438
+msgid "128 KiB"
+msgstr "128 KiB"
+
+#: pkg/storaged/overview.js:435
+msgid "16 KiB"
+msgstr "16 KiB"
+
+#: pkg/storaged/overview.js:441
+msgid "2 MiB"
+msgstr "2 MiB"
+
+#: pkg/systemd/index.html:465
+msgid "20 Minutes"
+msgstr "20 分钟"
+
+#: pkg/storaged/overview.js:436
+msgid "32 KiB"
+msgstr "32 KiB"
+
+#: pkg/storaged/overview.js:433
+msgid "4 KiB"
+msgstr "4 KiB"
+
+#: pkg/systemd/index.html:466
+msgid "40 Minutes"
+msgstr "40 分钟"
+
+#: pkg/systemd/index.html:464
+msgid "5 Minutes"
+msgstr "5 分钟"
+
+#: pkg/storaged/index.html:309 pkg/networkmanager/index.html:52
+#: pkg/networkmanager/index.html:498
+msgid "5 minutes"
+msgstr "5 分钟"
+
+#: pkg/storaged/overview.js:439
+msgid "512 KiB"
+msgstr "512 KiB"
+
+#: pkg/storaged/index.html:311 pkg/networkmanager/index.html:54
+#: pkg/networkmanager/index.html:500
+msgid "6 hours"
+msgstr "6 小时"
+
+#: pkg/systemd/index.html:467
+msgid "60 Minutes"
+msgstr "60 分钟"
+
+#: pkg/storaged/overview.js:437
+msgid "64 KiB"
+msgstr "64 KiB"
+
+#: pkg/storaged/overview.js:434
+msgid "8 KiB"
+msgstr "8 KiB"
+
+#: pkg/networkmanager/interfaces.js:1826
+msgid "802.3ad"
+msgstr "802.3ad"
+
+#: pkg/networkmanager/interfaces.js:1843
+#, fuzzy
+msgid "802.3ad LACP"
+msgstr "802.3ad"
+
+#: pkg/systemd/services.html:446
+msgid ":"
+msgstr ""
+
+#: pkg/storaged/utils.js:220
+msgid "<span>Encrypted $0</span>"
+msgstr "<span>已加密 $0</span>"
+
+#: pkg/storaged/utils.js:212
+msgid "<span>Encrypted Logical Volume of $0</span>"
+msgstr "<span>已加密逻辑卷 $0</span>"
+
+#: pkg/storaged/utils.js:214
+msgid "<span>Encrypted Partition of $0</span>"
+msgstr "<span>已加密分区 $0</span>"
+
+#: pkg/storaged/utils.js:216
+msgid "<span>Logical Volume of $0</span>"
+msgstr "<span>逻辑卷 $0</span>"
+
+#: pkg/storaged/utils.js:218
+msgid "<span>Partition of $0</span>"
+msgstr "<span>分区 $0</span>"
+
+#: pkg/lib/machine-not-supported.html:5
+msgid ""
+"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
+"strong}}."
+msgstr "{{#strong}}{{host}}{{/strong}} 上未安装一个兼容版本的 Cockpit。"
+
+#: cockpit.desktop.in.h:2
+msgid "A user interface for GNU/Linux servers"
+msgstr "一个 GNU/Linux 服务器管理界面"
+
+#: pkg/networkmanager/interfaces.js:1834
+msgid "ARP"
+msgstr "ARP"
+
+#: pkg/networkmanager/interfaces.js:2502
+msgid "ARP Monitoring"
+msgstr "ARP 监控"
+
+#: pkg/networkmanager/interfaces.js:1855
+#, fuzzy
+msgid "ARP Ping"
+msgstr "ARP 监控"
+
+#: pkg/kubernetes/scripts/volumes.js:193
+msgid "AWS Elastic Block Store"
+msgstr "AWS 弹性块存储"
+
+#: pkg/shell/simple.html:41 pkg/shell/simple.html:67 pkg/shell/index.html:41
+#: pkg/shell/index.html:80 pkg/shell/stub.html:41 pkg/shell/stub.html:73
+msgid "About Cockpit"
+msgstr "关于 Cockpit"
+
+#: pkg/users/index.html:105 pkg/users/index.html:191
+msgid "Access"
+msgstr "访问"
+
+#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pv-claim.html:9
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-body.html:9
+msgid "Access Modes"
+msgstr "访问模式"
+
+#: pkg/kubernetes/views/project-modify.html:49
+#: pkg/kubernetes/views/imagestream-body.html:11
+msgid "Access Policy"
+msgstr "访问策略"
+
+#: pkg/subscriptions/subscriptions-view.jsx:191
+#, fuzzy
+msgid "Access denied"
+msgstr "访问模式"
+
+#: pkg/shell/index.html:45
+msgid "Account Settings"
+msgstr "账户设置"
+
+#: pkg/users/index.html:63
+msgid "Account not available or cannot be edited."
+msgstr "帐户不可用或不能编辑."
+
+#: pkg/users/index.html:71
+msgid "Accounts"
+msgstr "账户"
+
+#: pkg/users/local.js:284 pkg/users/local.js:594
+msgctxt "page-title"
+msgid "Accounts"
+msgstr "账户"
+
+#: pkg/storaged/details.js:1127
+msgid "Activate"
+msgstr "激活"
+
+#: pkg/storaged/jobs.js:148
+msgid "Activating $target"
+msgstr "激活 $target"
+
+#: pkg/subscriptions/subscriptions-register.jsx:164
+#, fuzzy
+msgid "Activation Key"
+msgstr "激活"
+
+#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
+msgid "Active"
+msgstr "激活"
+
+#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
+msgid "Active Backup"
+msgstr "主备"
+
+#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
+msgid "Actual"
+msgstr "真实的"
+
+#: pkg/networkmanager/interfaces.js:1828
+msgid "Adaptive load balancing"
+msgstr "自适应负载均衡"
+
+#: pkg/networkmanager/interfaces.js:1827
+msgid "Adaptive transmit load balancing"
+msgstr "自适应传输负载均衡"
+
+#: pkg/kubernetes/views/add-user-dialog.html:31
+#: pkg/kubernetes/views/node-add.html:50
+#: pkg/kubernetes/views/user-add-membership.html:53
+#: pkg/kubernetes/views/add-member-role-dialog.html:61
+#: pkg/kubernetes/views/user-group-add.html:32
+#: pkg/kubernetes/views/add-role-dialog.html:8 pkg/lib/machine-add.html:43
+msgid "Add"
+msgstr "添加"
+
+#: pkg/networkmanager/interfaces.js:2836
+msgid "Add $0"
+msgstr ""
+
+#: pkg/docker/storage.jsx:363
+#, fuzzy
+msgid "Add Additional Storage"
+msgstr "额外的存储"
+
+#: pkg/networkmanager/index.html:86
+msgid "Add Bond"
+msgstr "添加绑定"
+
+#: pkg/networkmanager/index.html:88
+msgid "Add Bridge"
+msgstr "添加网桥"
+
+#: pkg/kubernetes/views/node-add.html:3
+msgid "Add Cluster Node"
+msgstr "添加集群节点"
+
+#: pkg/storaged/details.js:564 pkg/storaged/details.js:930
+msgid "Add Disks"
+msgstr "添加磁盘"
+
+#: pkg/kubernetes/views/add-group-dialog.html:3
+msgid "Add Group"
+msgstr "添加组"
+
+#: pkg/kubernetes/views/nodes-page.html:34
+msgid "Add Kubernetes Node"
+msgstr "添加 Kubernetes 节点"
+
+#: pkg/lib/machine-add.html:4
+msgid "Add Machine to Dashboard"
+msgstr "添加主机到仪表板"
+
+#: pkg/kubernetes/views/group-page.html:38
+#: pkg/kubernetes/views/add-member-role-dialog.html:4
+#: pkg/kubernetes/views/group-panel.html:29
+#: pkg/kubernetes/views/user-group-add.html:3
+#: pkg/kubernetes/views/project-body.html:108
+msgid "Add Member"
+msgstr "添加成员"
+
+#: pkg/kubernetes/views/user-panel.html:76
+#: pkg/kubernetes/views/user-body.html:67
+msgid "Add Membership"
+msgstr "添加成员关系"
+
+#: pkg/kubernetes/views/auth-form.html:11
+#: pkg/kubernetes/views/auth-form.html:20
+msgid "Add New Cluster"
+msgstr "添加新集群"
+
+#: pkg/kubernetes/views/auth-form.html:67
+#: pkg/kubernetes/views/auth-form.html:76
+msgid "Add New User"
+msgstr "添加新用户"
+
+#: pkg/kubernetes/views/add-role-dialog.html:3
+msgid "Add Role"
+msgstr "添加角色"
+
+#: pkg/networkmanager/index.html:87
+#, fuzzy
+msgid "Add Team"
+msgstr "添加成员"
+
+#: pkg/kubernetes/views/add-user-dialog.html:3
+#: pkg/kubernetes/views/project-listing.html:83
+msgid "Add User"
+msgstr "添加用户"
+
+#: pkg/networkmanager/index.html:89
+msgid "Add VLAN"
+msgstr "添加 VLAN"
+
+#: pkg/storaged/overview.js:515
+msgid "Add iSCSI Portal"
+msgstr "添加 iSCSI 门户"
+
+#: pkg/kubernetes/views/user-add-membership.html:3
+msgid "Add membership"
+msgstr "添加成员关系"
+
+#: pkg/users/index.html:351
+msgid "Add public key"
+msgstr "添加公钥"
+
+#: pkg/networkmanager/interfaces.js:2833
+msgid "Adding <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/users/authorized-keys.js:108
+msgid "Adding key"
+msgstr "添加 key"
+
+#: pkg/storaged/jobs.js:153
+msgid "Adding physical volume to $target"
+msgstr "添加物理卷至 $target"
+
+#: pkg/docker/index.html:329
+msgid "Additional Storage"
+msgstr "额外的存储"
+
+#: pkg/ostree/index.html:121 pkg/ostree/index.html:140
+msgid "Additions"
+msgstr "添加"
+
+#: pkg/kubernetes/views/node-add.html:8
+#: pkg/kubernetes/views/dashboard-page.html:157
+#: pkg/kubernetes/views/details-page.html:174
+#: pkg/kubernetes/views/nodes-page.html:43
+#: pkg/kubernetes/views/auth-form.html:29 pkg/kubernetes/views/node-body.html:5
+#: pkg/lib/machine-add.html:11
+msgid "Address"
+msgstr "地址"
+
+#: pkg/kubernetes/views/details-page.html:37
+msgid "Addresses"
+msgstr "地址"
+
+#: pkg/kubernetes/views/service-modify.html:25
+msgid "Adjust"
+msgstr "调整"
+
+#: pkg/kubernetes/views/pv-modify.html:3
+msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+msgstr "调整持久卷 '{{ item.metadata.name }}'"
+
+#: pkg/kubernetes/views/replicationcontroller-modify.html:3
+msgid "Adjust Replication Controller {{ item.metadata.name }}"
+msgstr "调整复制控制器 {{ item.metadata.name }}"
+
+#: pkg/kubernetes/views/route-modify.html:3
+msgid "Adjust Route"
+msgstr "调整路由"
+
+#: pkg/kubernetes/views/service-modify.html:3
+msgid "Adjust Service"
+msgstr "调整服务"
+
+#: pkg/kubernetes/views/project-body.html:56
+msgid "Admin"
+msgstr "管理"
+
+#: pkg/systemd/services.html:389 pkg/systemd/services.html:393
+#, fuzzy
+msgid "After system boot"
+msgstr "注册系统"
+
+#: pkg/systemd/logs.html:50
+msgid "All"
+msgstr "所有"
+
+#: pkg/kubernetes/views/filter-project.html:4
+msgid "All Projects"
+msgstr "所有项目"
+
+#: pkg/kubernetes/views/details-page.html:6
+msgid "All Types"
+msgstr "所有类型"
+
+#: pkg/docker/storage.jsx:366
+msgid ""
+"All data on selected disks will be erased and disks will be added to the "
+"storage pool."
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:112
+msgid "All healthy"
+msgstr "所有健康的"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:74
+msgid "All images"
+msgstr "所有镜像"
+
+#: pkg/kubernetes/views/dashboard-page.html:69
+msgid "All in use"
+msgstr "所有正在使用的"
+
+#: pkg/kubernetes/views/dashboard-page.html:37
+msgid "All running"
+msgstr "所有运行的"
+
+#: pkg/docker/index.html:569
+msgid "Always"
+msgstr "通常"
+
+#: pkg/kubernetes/views/imagestream-meta.html:2
+#: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/image-meta.html:9
+#: pkg/kubernetes/views/node-body.html:57
+msgid "Annotations"
+msgstr "注释"
+
+#: pkg/storaged/details.js:455 pkg/storaged/details.js:536
+msgid "Apply"
+msgstr "应用"
+
+#: pkg/selinux/setroubleshoot-view.jsx:107
+msgid "Apply this solution"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:82
+msgid "Applying solution..."
+msgstr ""
+
+#: pkg/kubernetes/views/image-config.html:12
+msgid "Architecture"
+msgstr "架构"
+
+#: pkg/storaged/index.html:451
+msgctxt "storage"
+msgid "Assessment"
+msgstr "评估"
+
+#: pkg/systemd/index.html:81
+msgid "Asset Tag"
+msgstr "资产标记"
+
+#: pkg/storaged/overview.js:455
+msgid "At least $0 disks are needed."
+msgstr "至少需要 $0 块磁盘。"
+
+#: pkg/storaged/overview.js:501 pkg/storaged/details.js:579
+#: pkg/storaged/details.js:948
+msgid "At least one disk is needed."
+msgstr "至少需要 1 块磁盘。"
+
+#: pkg/systemd/services.html:394
+#, fuzzy
+msgid "At specific time"
+msgstr "指定时间"
+
+#: pkg/networkmanager/interfaces.js:813
+msgid "Authenticating"
+msgstr "认证中"
+
+#: pkg/realmd/operation.html:34 pkg/shell/index.html:48
+#: pkg/shell/index.html:159 pkg/kubernetes/views/auth-form.html:85
+#: pkg/lib/machine-change-auth.html:32
+msgid "Authentication"
+msgstr "认证"
+
+#: pkg/lib/machine-auth-failed.html:2
+msgid "Authentication Failed"
+msgstr "认证失败"
+
+#: pkg/docker/index.html:730 pkg/kubernetes/views/image-body.html:12
+#: pkg/kubernetes/views/image-listing.html:15
+msgid "Author"
+msgstr "作者"
+
+#: pkg/users/index.html:130
+msgid "Authorized Public SSH Keys"
+msgstr "授权公共 SSH 密钥"
+
+#: pkg/networkmanager/index.html:165
+msgid "Automatic"
+msgstr "自动"
+
+#: pkg/networkmanager/interfaces.js:1814
+msgid "Automatic (DHCP only)"
+msgstr "自动 (仅 DHCP)"
+
+#: pkg/networkmanager/interfaces.js:1804
+msgid "Automatic (DHCP)"
+msgstr "自动 (DHCP)"
+
+#: pkg/systemd/index.html:406
+msgid "Automatically using NTP"
+msgstr "自动的（使用 NTP）"
+
+#: pkg/systemd/index.html:407
+msgid "Automatically using specific NTP servers"
+msgstr "自动的（使用指定 NTP 服务器）"
+
+#: pkg/lib/machine-change-auth.html:66
+msgid "Available"
+msgstr "可用的"
+
+#: pkg/storaged/overview.js:619
+msgid "Available targets on $0"
+msgstr "$0 上可用的目标"
+
+#: pkg/dashboard/index.html:177
+msgid "Avatar"
+msgstr "替身"
+
+#: pkg/kubernetes/scripts/volumes.js:207
+msgid "Azure"
+msgstr "Azure"
+
+#: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
+msgid "Bad data passed for passwd1 mechanism"
+msgstr "为 passwd1 机制通过的坏数据"
+
+#: pkg/networkmanager/index.html:389
+msgid "Balancer"
+msgstr ""
+
+#: pkg/storaged/index.html:560
+msgctxt "storage"
+msgid "Bitmap"
+msgstr "位图"
+
+#: pkg/storaged/index.html:414
+msgid "Block Device"
+msgstr "块设备"
+
+#: pkg/storaged/details.js:871
+msgid "Block device for filesystems"
+msgstr "块设备的文件系统"
+
+#: pkg/storaged/details.js:1596
+msgid "Blocked"
+msgstr "受阻"
+
+#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
+#: pkg/networkmanager/interfaces.js:2507
+msgid "Bond"
+msgstr "绑定"
+
+#: pkg/networkmanager/index.html:596
+msgid "Bond Settings"
+msgstr "绑定设置"
+
+#: pkg/kubernetes/views/node-body.html:17
+msgid "Boot ID"
+msgstr "启动编号"
+
+#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
+#: pkg/networkmanager/interfaces.js:2584
+msgid "Bridge"
+msgstr "网桥"
+
+#: pkg/networkmanager/index.html:708
+msgid "Bridge Port Settings"
+msgstr "网桥端口设置"
+
+#: pkg/networkmanager/index.html:680
+msgid "Bridge Settings"
+msgstr "网桥设置"
+
+#: pkg/networkmanager/interfaces.js:2605
+msgid "Bridge port"
+msgstr "网桥端口"
+
+#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
+msgid "Broadcast"
+msgstr "广播"
+
+#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#, fuzzy
+msgid "Broken configuration"
+msgstr "未知配置"
+
+#: pkg/kubernetes/views/image-body.html:16
+msgid "Built"
+msgstr "构建于"
+
+#: pkg/dashboard/index.html:70
+msgid "CPU"
+msgstr "CPU"
+
+#: pkg/systemd/host.js:1381
+msgctxt "page-title"
+msgid "CPU Status"
+msgstr "CPU 状态"
+
+#: pkg/kubernetes/scripts/nodes.js:712
+msgid "CPU Utilization: $0%"
+msgstr "CPU 使用率: $0%"
+
+#: pkg/docker/index.html:490 pkg/docker/index.html:669
+msgid "CPU priority"
+msgstr "CPU 优先级"
+
+#: pkg/systemd/index.html:247
+msgid "Cached"
+msgstr "已缓存"
+
+#: pkg/docker/index.html:63
+msgid "Can&rsquo;t connect to Docker"
+msgstr "无法连接到 Docker"
+
+#: pkg/systemd/services.html:465 pkg/dashboard/index.html:189
+#: pkg/playground/translate.html:40 pkg/playground/translate.html:174
+#: pkg/realmd/operation.html:90 pkg/kubernetes/views/pv-modify.html:202
+#: pkg/kubernetes/views/item-delete.html:10
+#: pkg/kubernetes/views/add-user-dialog.html:30
+#: pkg/kubernetes/views/project-modify.html:71
+#: pkg/kubernetes/views/node-add.html:49
+#: pkg/kubernetes/views/pvc-delete.html:14
+#: pkg/kubernetes/views/node-delete.html:14
+#: pkg/kubernetes/views/imagestream-modify.html:96
+#: pkg/kubernetes/views/imagestream-delete.html:7
+#: pkg/kubernetes/views/user-modify.html:30
+#: pkg/kubernetes/views/add-group-dialog.html:20
+#: pkg/kubernetes/views/project-delete.html:8
+#: pkg/kubernetes/views/service-modify.html:24
+#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/kubernetes/views/user-group-remove.html:9
+#: pkg/kubernetes/views/user-add-membership.html:52
+#: pkg/kubernetes/views/add-member-role-dialog.html:60
+#: pkg/kubernetes/views/group-delete.html:20
+#: pkg/kubernetes/views/image-delete.html:7 pkg/kubernetes/views/deploy.html:61
+#: pkg/kubernetes/views/user-group-add.html:31
+#: pkg/kubernetes/views/auth-form.html:128
+#: pkg/kubernetes/views/auth-rejected-cert.html:31
+#: pkg/kubernetes/views/replicationcontroller-modify.html:16
+#: pkg/kubernetes/views/pv-delete.html:10
+#: pkg/kubernetes/views/add-role-dialog.html:7
+#: pkg/kubernetes/views/route-modify.html:16
+#: pkg/kubernetes/views/user-delete.html:24
+#: pkg/kubernetes/views/remove-role-dialog.html:7 pkg/storaged/index.html:289
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:79
+msgid "Cancel"
+msgstr "取消"
+
+#: pkg/shell/indexes.js:322
+msgid "Cannot connect to an unknown machine"
+msgstr "不能连接至未知主机"
+
+#: src/ws/cockpitcertificate.c:359
+msgid "Cannot decrypt PEM-encoded private key"
+msgstr "无法解密 PEM 编码的私钥"
+
+#: src/base1/cockpit.js:3707
+msgid "Cannot forward login credentials"
+msgstr "无法转发登录凭证"
+
+#: pkg/realmd/operation.js:417
+msgid "Cannot join a domain because realmd is not available on this system"
+msgstr "因为该系统的 realmd 不可用, 因此无法加入域"
+
+#: pkg/kubernetes/views/pv-modify.html:44
+#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pv-body.html:13
+msgid "Capacity"
+msgstr "容量"
+
+#: pkg/storaged/index.html:443 pkg/storaged/index.html:519
+#: pkg/storaged/index.html:551 pkg/storaged/index.html:630
+msgctxt "storage"
+msgid "Capacity"
+msgstr "容量"
+
+#: pkg/networkmanager/interfaces.js:2276
+msgid "Carrier"
+msgstr "载体"
+
+#: pkg/kubernetes/scripts/volumes.js:203
+msgid "Ceph Filesystem Mount"
+msgstr "Ceph 文件系统挂载"
+
+#: pkg/kubernetes/views/volume-body.html:97
+msgid "Ceph Monitors"
+msgstr "Ceph 监视器"
+
+#: pkg/kubernetes/views/pv-modify.html:204
+#: pkg/kubernetes/views/project-modify.html:74
+#: pkg/kubernetes/views/replicationcontroller-modify.html:17
+#: pkg/kubernetes/views/route-modify.html:17
+msgid "Change"
+msgstr "变更"
+
+#: pkg/shell/index.html:278
+msgid "Change Password"
+msgstr "变更密码"
+
+#: pkg/tuned/dialog.js:191
+msgid "Change Performance Profile"
+msgstr "变更性能配置集"
+
+#: pkg/tuned/dialog.js:200
+msgid "Change Profile"
+msgstr "变更配置集"
+
+#: pkg/kubernetes/views/user-modify.html:3
+msgid "Change User"
+msgstr "变更用户"
+
+#: pkg/storaged/overview.js:699
+msgid "Change iSCSI Initiator Name"
+msgstr "变更 iSCSI Initiator 名称"
+
+#: pkg/kubernetes/views/imagestream-modify.html:4
+msgid "Change image stream"
+msgstr "变更镜像流"
+
+#: pkg/kubernetes/views/project-modify.html:10
+msgid "Change project"
+msgstr "变更项目"
+
+#: pkg/networkmanager/interfaces.js:2872
+#, fuzzy
+msgid "Change the settings"
+msgstr "连接设置"
+
+#: pkg/networkmanager/interfaces.js:2870
+msgid "Changing the settings will break the connection to the server, "
+msgstr ""
+
+#: pkg/ostree/index.html:48
+msgid "Check for updates"
+msgstr "检查更新"
+
+#: pkg/networkmanager/interfaces.js:817
+msgid "Checking IP"
+msgstr "正在检查 IP"
+
+#: pkg/storaged/jobs.js:143
+#, fuzzy
+msgid "Checking RAID Device $target"
+msgstr "创建 RAID 设备 $target"
+
+#: pkg/storaged/jobs.js:144
+#, fuzzy
+msgid "Checking and Repairing RAID Device $target"
+msgstr "创建 RAID 设备 $target"
+
+#: pkg/lib/machine-change-auth.html:70
+msgid "Checking for public keys"
+msgstr "检查公钥"
+
+#: pkg/ostree/app.js:219
+msgid "Checking for updates"
+msgstr "检查升级"
+
+#: pkg/shell/simple.html:100 pkg/shell/index.html:121 pkg/shell/stub.html:114
+msgid "Choose the language to be used in the application"
+msgstr "选择用于应用程序的语言"
+
+#: pkg/storaged/overview.js:431
+msgid "Chunk Size"
+msgstr "区块大小"
+
+#: pkg/kubernetes/scripts/volumes.js:202
+msgid "Cinder"
+msgstr "Cinder"
+
+#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
+msgid "Claim"
+msgstr "声明"
+
+#: pkg/kubernetes/views/pvc-body.html:4
+msgid "Claim Name"
+msgstr "声明名称"
+
+#: pkg/storaged/jobs.js:135
+msgid "Cleaning up for $target"
+msgstr "清除 $target"
+
+#: pkg/kubernetes/views/auth-form.html:88
+msgid "Client Certificate"
+msgstr "客户端证书"
+
+#: pkg/systemd/services.html:306 pkg/systemd/services.html:324
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-invalid-hostkey.html:19
+msgid "Close"
+msgstr "关闭"
+
+#: pkg/kubernetes/views/auth-form.html:5
+msgid "Cluster"
+msgstr "集群"
+
+#: cockpit.desktop.in.h:1
+msgid "Cockpit"
+msgstr "Cockpit"
+
+#: pkg/lib/machine-dialogs.js:429
+msgid ""
+"Cockpit could not contact the given host $0. Make sure it has ssh running on "
+"port $1, or specify another port in the address."
+msgstr ""
+"Cockpit 无法与指定主机 $0 联系。请确认已经在端口 $1 上运行 SSH，或者在该地址"
+"中指定另一个端口。"
+
+#: src/base1/cockpit.js:3713
+msgid "Cockpit could not contact the given host."
+msgstr "Cockpit 无法联系指定的主机。"
+
+#: pkg/shell/base_index.js:671
+msgid "Cockpit had an unexpected internal error. <br/><br/>"
+msgstr "Cockpit 发生意外内部错误。<br/><br/>"
+
+#: cockpit.appdata.xml.in.h:1
+msgid ""
+"Cockpit is a server manager that makes it easy to administer your Linux "
+"servers via a web browser. Jumping between the terminal and the web tool is "
+"no problem. A service started via Cockpit can be stopped via the terminal. "
+"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
+"journal interface."
+msgstr ""
+"Cockpit 是一个服务器管理器, 可以方便地通过浏览器来管理你的 Linux 服务器.在终"
+"端和 web 工具间切换没有任何问题. 服务可以通过 Cockpit 启动, 通过终端停止.同样"
+"地, 如果在终端中发生错误, 也可以​​在 Cockpit journal 接口中看到."
+
+#: src/base1/cockpit.js:3711
+msgid "Cockpit is not compatible with the software on the system."
+msgstr "Cockpit 与该系统上的软件不兼容。"
+
+#: pkg/lib/machine-not-supported.html:2
+msgid "Cockpit is not installed"
+msgstr "Cockpit 未安装"
+
+#: src/base1/cockpit.js:3705
+msgid "Cockpit is not installed on the system."
+msgstr "Cockpit 未安装在该系统上。"
+
+#: cockpit.appdata.xml.in.h:2
+msgid ""
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
+"tasks such as storage administration, inspecting journals and starting and "
+"stopping services. You can monitor and administer several servers at the "
+"same time. Just add them with a single click and your machines will look "
+"after its buddies."
+msgstr ""
+"Cockpit 是完美的系统管理员工具, 它可以轻松完成简单的任务, 如存储管理, 检查 "
+"journals 和启动/停止服务. 您可以同时监控和管理几个服务器. 只需要逐一添加, 您"
+"的机器就可以看到它们了."
+
+#: pkg/lib/machine-change-port.html:9
+msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
+msgstr "Cockpit 无法联系 {{#strong}}{{host}}{{/strong}}。"
+
+#: pkg/lib/machine-auth-failed.html:15
+msgid ""
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
+msgstr ""
+"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。 {{#can_sync}}也许想要尝"
+"试 {{#sync_link}}同步用户{{/sync_link}}。{{/can_sync}} 更多认证选项和排错支"
+"持，请更新 cockpit-ws 到一个新版本。"
+
+#: pkg/lib/machine-change-auth.html:9
+msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
+msgstr "Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}."
+
+#: pkg/lib/machine-auth-failed.html:6
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
+"machine with cockpit you will need to enable one of the following "
+"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
+msgstr ""
+"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。 To use this machine with "
+"cockpit 需要在 {{#strong}}{{host}}{{/strong}} 上的 sshd 配置中启用以下认证方"
+"式其中之一 来使用该主机的 Cockpit:"
+
+#: pkg/lib/machine-change-auth.html:13
+msgid ""
+"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
+"change your authentication credentials below. {{#can_sync}}You may prefer to "
+"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+msgstr ""
+"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。可以变更以下认证凭证。"
+"{{#can_sync}}也许想要 {{#sync_link}}同步账号和密码{{/sync_link}}.{{/"
+"can_sync}}"
+
+#: pkg/dashboard/index.html:171 pkg/lib/machine-add.html:27
+msgid "Color"
+msgstr "颜色"
+
+#: pkg/docker/index.html:95
+msgid "Combined CPU usage"
+msgstr "结合 CPU 使用率"
+
+#: pkg/docker/index.html:101
+msgid "Combined memory usage"
+msgstr "结合内存使用率"
+
+#: pkg/systemd/services.html:370 pkg/docker/index.html:466
+#: pkg/docker/index.html:736
+msgid "Command"
+msgstr "命令"
+
+#: pkg/docker/run.js:332
+#, fuzzy
+msgid "Command can't be empty"
+msgstr "名称不能为空."
+
+#: pkg/docker/containers-view.jsx:239
+#, fuzzy
+msgid "Commit"
+msgstr "说明"
+
+#: pkg/tuned/dialog.js:114
+msgid "Communication with tuned has failed"
+msgstr "与 Tuned 通信失败"
+
+#: pkg/storaged/details.js:348
+msgid "Compatible with all systems and devices (MBR)"
+msgstr "兼容所有系统和设备 (MBR)"
+
+#: pkg/storaged/details.js:349
+msgid "Compatible with modern system and hard disks > 2TB (GPT)"
+msgstr "兼容现代系统，且支持磁盘 > 2TB (GPT)"
+
+#: pkg/realmd/operation.html:28
+msgid "Computer OU"
+msgstr "计算机 OU"
+
+#: pkg/kubernetes/views/node-add.html:24
+msgid "Configuration"
+msgstr "配置"
+
+#: pkg/networkmanager/interfaces.js:2441
+msgid "Configure"
+msgstr "配置"
+
+#: pkg/kubernetes/views/node-add.html:42
+msgid "Configure Flannel networking"
+msgstr "配置 Flannel 网络"
+
+#: pkg/kubernetes/views/node-add.html:32
+msgid "Configure Kubelet and Proxy"
+msgstr "配置 Kubelet 和代理"
+
+#: pkg/networkmanager/interfaces.js:811
+msgid "Configuring"
+msgstr "配置中"
+
+#: pkg/networkmanager/interfaces.js:815
+msgid "Configuring IP"
+msgstr "正在配置 IP"
+
+#: pkg/users/index.html:171 pkg/shell/index.html:262
+msgid "Confirm"
+msgstr "确认"
+
+#: pkg/users/index.html:247
+msgid "Confirm New Password"
+msgstr "确认新密码"
+
+#: pkg/storaged/details.js:229
+msgid "Confirm passphrase"
+msgstr "确认口令"
+
+#: pkg/kubernetes/views/auth-form.html:130
+#: pkg/kubernetes/views/auth-rejected-cert.html:33
+#: pkg/lib/machine-unknown-hostkey.html:22
+msgid "Connect"
+msgstr "连接"
+
+#: pkg/networkmanager/interfaces.js:2637
+msgid "Connect automatically"
+msgstr "自动连接"
+
+#: pkg/ostree/index.html:218
+msgid "Connecting"
+msgstr "连接"
+
+#: pkg/lib/machine-add.html:39
+msgid ""
+"Connecting simultaneously to more than {{ limit }} machines is unsupported."
+msgstr "不支持同时连接到超过 {{ limit }} 主机。"
+
+#: pkg/docker/index.html:54
+msgid "Connecting to Docker"
+msgstr "正在连接 Docker"
+
+#: pkg/shell/indexes.js:317
+msgid "Connecting to the machine"
+msgstr "正在连接至主机"
+
+#: pkg/kubernetes/registry.html:70 pkg/kubernetes/index.html:100
+msgid "Connecting..."
+msgstr "连接中..."
+
+#: pkg/kubernetes/views/auth-dialog.html:4
+msgid "Connection Error"
+msgstr "连接错误"
+
+#: pkg/kubernetes/scripts/connection.js:516
+msgid "Connection Error: $0"
+msgstr "连接错误: $0"
+
+#: pkg/kubernetes/views/auth-dialog.html:3
+msgid "Connection Settings"
+msgstr "连接设置"
+
+#: src/base1/cockpit.js:3703
+msgid "Connection has timed out."
+msgstr "连接超时。"
+
+#: pkg/networkmanager/index.html:812
+#, fuzzy
+msgid "Connection will be lost"
+msgstr "连接超时。"
+
+#: pkg/docker/console.html:4 pkg/kubernetes/views/container-panel.html:4
+#: pkg/kubernetes/views/image-panel.html:12
+#: pkg/kubernetes/views/container-body.html:4
+#: pkg/kubernetes/views/container-page-inline.html:2
+#: pkg/kubernetes/views/image-page.html:19
+msgid "Container"
+msgstr "容器"
+
+#: pkg/users/local.js:684
+msgid "Container Administrator"
+msgstr "容器管理员"
+
+#: pkg/kubernetes/views/container-body.html:10
+msgid "Container ID"
+msgstr "容器编号"
+
+#: pkg/docker/index.html:459 pkg/docker/index.html:646
+#: pkg/docker/index.html:712
+msgid "Container Name"
+msgstr "容器名称"
+
+#: pkg/kubernetes/views/node-body.html:21
+msgid "Container Runtime Version"
+msgstr "容器运行时版本"
+
+#: pkg/docker/util.js:490
+msgid ""
+"Container is currently marked as not running, but regular stopping failed."
+msgstr "容器当前标记为未运行, 但正常停止失败."
+
+#: pkg/docker/util.js:488
+msgid "Container is currently running."
+msgstr "当前容器正在运行。"
+
+#: pkg/docker/index.html:23 pkg/docker/index.html:309
+#: pkg/kubernetes/views/pod-page.html:36
+#: pkg/kubernetes/views/dashboard-page.html:158
+#: pkg/kubernetes/views/dashboard-page.html:199
+#: pkg/kubernetes/views/containers-listing.html:5 pkg/kubernetes/index.html:51
+msgid "Containers"
+msgstr "容器"
+
+#: pkg/docker/details.js:47 pkg/docker/image.js:43
+msgctxt "page-title"
+msgid "Containers"
+msgstr "容器"
+
+#: pkg/storaged/details.js:1512 pkg/storaged/details.js:1641
+msgid "Content"
+msgstr "内容"
+
+#: src/base1/test-locale.js:44 src/base1/test-locale.js:55
+#: pkg/playground/translate.js:19
+#, fuzzy
+msgid "Control"
+msgstr "容器"
+
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:57
+#: pkg/playground/translate.js:22
+#, fuzzy
+msgctxt "key"
+msgid "Control"
+msgstr "容器"
+
+#: pkg/docker/storage.jsx:404
+#, fuzzy
+msgid "Could not add all disks"
+msgstr "无法罗列服务"
+
+#: pkg/lib/machine-change-port.html:4
+msgid "Could not contact {{host}}"
+msgstr "无法联系 {{host}}"
+
+#: pkg/kubernetes/views/dashboard-page.html:142
+msgid "Could not list services"
+msgstr "无法罗列服务"
+
+#: src/ws/cockpitcertificate.c:407
+msgid "Could not parse PEM-encoded certificate"
+msgstr "无法解析 PEM 编码的证书"
+
+#: src/ws/cockpitcertificate.c:374
+msgid "Could not parse PEM-encoded private key"
+msgstr "无法解析 PEM 编码的私钥"
+
+#: pkg/docker/storage.jsx:446
+msgid "Could not reset the storage pool"
+msgstr ""
+
+#: src/bridge/cockpitdbussetup.c:467
+msgid "Couldn't change user groups"
+msgstr "不能修改用户组"
+
+#: src/bridge/cockpitdbussetup.c:520
+msgid "Couldn't change user password"
+msgstr "不能修改用户密码"
+
+#: pkg/selinux/setroubleshoot-view.jsx:385
+msgid ""
+"Couldn't connect to SETroubleshoot daemon. Please ensure that setroubleshoot-"
+"server is installed."
+msgstr ""
+
+#: pkg/kubernetes/registry.html:71 pkg/kubernetes/index.html:101
+msgid "Couldn't connect to server"
+msgstr "无法连接到服务器"
+
+#: pkg/shell/indexes.js:320
+msgid "Couldn't connect to the machine"
+msgstr "不能连接至主机"
+
+#: src/bridge/cockpitdbussetup.c:544
+msgid "Couldn't create new users"
+msgstr "不能创建新用户"
+
+#: pkg/kubernetes/scripts/connection.js:514
+msgid "Couldn't find running API server"
+msgstr "无法找到运行的 API 服务器"
+
+#: pkg/subscriptions/subscriptions-view.jsx:196
+#, fuzzy
+msgid ""
+"Couldn't get system subscription status. Please ensure subscription-manager "
+"is installed."
+msgstr ""
+"\n"
+"        为了管理该系统的订阅, 请确认已安装 subscription-manager.\n"
+"      "
+
+#: src/bridge/cockpitdbussetup.c:642
+msgid "Couldn't list local users"
+msgstr "不能列出本地用户"
+
+#: src/bridge/cockpitdbussetup.c:236
+msgid "Couldn't list users"
+msgstr "不能列出用户"
+
+#: src/bridge/cockpitdbussetup.c:382
+msgid "Couldn't load user data"
+msgstr "不能载入用户数据"
+
+#: pkg/kubernetes/views/project-modify.html:72
+#: pkg/kubernetes/views/add-group-dialog.html:21
+msgid "Create"
+msgstr "创建"
+
+#: pkg/storaged/details.js:861 pkg/storaged/details.js:1712
+msgid "Create Logical Volume"
+msgstr "创建逻辑卷"
+
+#: pkg/users/index.html:54 pkg/users/index.html:143
+msgid "Create New Account"
+msgstr "创建新账户"
+
+#: pkg/storaged/details.js:1379
+msgid "Create Partition"
+msgstr "创建分区"
+
+#: pkg/storaged/overview.js:414
+msgid "Create RAID Device"
+msgstr "创建 RAID 设备"
+
+#: pkg/storaged/details.js:728 pkg/storaged/details.js:1124
+msgid "Create Snapshot"
+msgstr "创建快照"
+
+#: pkg/storaged/details.js:766 pkg/storaged/details.js:1136
+msgid "Create Thin Volume"
+msgstr "创建稀疏卷"
+
+#: pkg/systemd/services.html:336
+#, fuzzy
+msgid "Create Timers"
+msgstr "创建稀疏卷"
+
+#: pkg/storaged/overview.js:487
+msgid "Create Volume Group"
+msgstr "创建卷组"
+
+#: pkg/sosreport/index.html:50
+msgid "Create diagnostic report"
+msgstr "创建诊断报告"
+
+#: pkg/kubernetes/views/imagestream-modify.html:3
+msgid "Create image stream"
+msgstr "创建镜像流"
+
+#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
+#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
+#, fuzzy
+msgid "Create it"
+msgstr "创建"
+
+#: pkg/storaged/details.js:266
+msgid "Create partition"
+msgstr "创建分区"
+
+#: pkg/storaged/details.js:113
+msgid "Create partition on $0"
+msgstr "为 $0 创建分区"
+
+#: pkg/storaged/index.html:381
+msgid "Create partition table"
+msgstr "创建分区表"
+
+#: pkg/sosreport/index.html:42
+msgid "Create report"
+msgstr "创建报告"
+
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/replicationcontroller-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7 pkg/kubernetes/views/route-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3
+msgid "Created"
+msgstr "创建于"
+
+#: pkg/storaged/jobs.js:142
+msgid "Creating RAID Device $target"
+msgstr "创建 RAID 设备 $target"
+
+#: pkg/storaged/jobs.js:130
+msgid "Creating filesystem on $target"
+msgstr "为 $target 创建文件系统"
+
+#: pkg/storaged/jobs.js:156
+msgid "Creating logical volume $target"
+msgstr "创建逻辑卷 $target"
+
+#: pkg/storaged/jobs.js:134
+msgid "Creating partition $target"
+msgstr "创建分区 $target"
+
+#: pkg/storaged/jobs.js:150
+msgid "Creating snapshot of $target"
+msgstr "创建快照 $target "
+
+#: pkg/networkmanager/interfaces.js:4064
+msgid "Creating this VLAN will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3436
+msgid "Creating this bond will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3842
+msgid "Creating this bridge will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3611
+msgid "Creating this team will break the connection to the server, "
+msgstr ""
+
+#: pkg/storaged/jobs.js:151
+msgid "Creating volume group $target"
+msgstr "创建卷组 $target"
+
+#: pkg/systemd/logs.html:41
+msgid "Current boot"
+msgstr "当前启动"
+
+#: pkg/storaged/details.js:248 pkg/storaged/details.js:436
+msgid "Custom"
+msgstr "自定义"
+
+#: pkg/storaged/details.js:186
+msgid "Custom (Enter filesystem type)"
+msgstr "自定义 (输入文件系统类型)"
+
+#: pkg/subscriptions/subscriptions-register.jsx:102
+#, fuzzy
+msgid "Custom URL"
+msgstr "自定义"
+
+#: pkg/storaged/index.html:454
+msgid "DISK IS FAILING"
+msgstr "磁盘错误"
+
+#: pkg/networkmanager/interfaces.js:3018
+msgid "DNS"
+msgstr "DNS"
+
+#: pkg/kubernetes/views/pod-body.html:14
+msgid "DNS Policy"
+msgstr "DNS 策略"
+
+#: pkg/networkmanager/interfaces.js:3022
+msgid "DNS Search Domains"
+msgstr "DNS 搜索域"
+
+#: pkg/dashboard/index.html:22
+msgid "Dashboard"
+msgstr ""
+
+#: pkg/storaged/details.js:1130
+msgid "Deactivate"
 msgstr "未激活"
 
-#: pkg/storaged/details.js:1711
-msgid "$0 Free Space for Logical Volumes"
-msgstr "逻辑卷剩余 $0 可用空间"
+#: pkg/networkmanager/interfaces.js:823
+msgid "Deactivating"
+msgstr "停用中"
 
-#: pkg/storaged/details.js:1751
-msgid "The last physical volume of a volume group cannot be removed."
+#: pkg/storaged/jobs.js:149
+msgid "Deactivating $target"
+msgstr "停用 $target"
+
+#: pkg/docker/index.html:379 pkg/docker/index.html:383
+#: pkg/kubernetes/views/image-config.html:6
+msgid "Default"
+msgstr "默认"
+
+#: pkg/systemd/index.html:454
+msgid "Delay"
+msgstr "延时"
+
+#: pkg/users/index.html:79 pkg/kubernetes/views/item-delete.html:11
+#: pkg/kubernetes/views/pvc-delete.html:15
+#: pkg/kubernetes/views/node-delete.html:15
+#: pkg/kubernetes/views/imagestream-delete.html:8
+#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/kubernetes/views/image-delete.html:8
+#: pkg/kubernetes/views/pv-delete.html:11
+msgid "Delete"
+msgstr "删除"
+
+#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
+msgid "Delete $0"
+msgstr "删除 $0"
+
+#: pkg/users/index.html:292
+msgid "Delete Files"
+msgstr "删除文件"
+
+#: pkg/kubernetes/views/node-delete.html:4
+msgid "Delete Node"
+msgstr "删除节点"
+
+#: pkg/kubernetes/views/pv-delete.html:3
+msgid "Delete Persistent Volume"
+msgstr "删除持久卷"
+
+#: pkg/kubernetes/views/pvc-delete.html:3
+msgid "Delete Persistent Volume Claim"
+msgstr "删除持久卷声明"
+
+#: pkg/kubernetes/views/project-delete.html:3
+msgid "Delete Project"
+msgstr "删除项目"
+
+#: pkg/kubernetes/views/nodes-page.html:3
+msgid "Delete Selected"
+msgstr "删除所选的"
+
+#: pkg/kubernetes/views/imagestream-delete.html:3
+msgid "Delete image stream"
+msgstr "删除镜像流"
+
+#: pkg/playground/translate.html:184 pkg/kubernetes/views/item-delete.html:3
+msgid "Delete {{ item.kind }}"
+msgstr "删除 {{ item.kind }}"
+
+#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
+msgid "Deleting $target"
+msgstr "删除 $target"
+
+#: pkg/networkmanager/interfaces.js:2156
+msgid "Deleting <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/storaged/details.js:1756
+#: pkg/kubernetes/views/item-delete.html:7
 msgid ""
-"There is not enough free space elsewhere to remove this physical volume.  At "
-"least $0 more free space is needed."
+"Deleting a Pod will kill all associated containers. Pods may be "
+"automatically created again in some cases."
+msgstr "删除容器舱将会杀掉所有相关的容器。容器舱也许会在某些情况下被自动创建。"
+
+#: pkg/storaged/details.js:631
+msgid "Deleting a RAID device will erase all data on it."
+msgstr "删除 RAID 设备将擦除其中的所有数据."
+
+#: pkg/docker/containers-view.jsx:167 pkg/docker/details.js:272
+msgid "Deleting a container will erase all data in it."
+msgstr "删除容器将清除其中的所有数据。"
+
+#: pkg/storaged/details.js:1009
+msgid "Deleting a logical volume will delete all data in it."
+msgstr "删除逻辑卷将擦除其中的所有数据。"
+
+#: pkg/storaged/details.js:1012
+msgid "Deleting a partition will delete all data in it."
+msgstr "删除分区将擦除其中的所有数据。"
+
+#: pkg/storaged/details.js:826
+msgid "Deleting a volume group will erase all data on it."
+msgstr "删除卷组将擦除其中的所有数据。"
+
+#: pkg/docker/image.js:152
+msgid ""
+"Deleting an image will delete it, but you can probably download it again if "
+"you need it later.  Unless this image has never been pushed to a repository, "
+"that is, in which case you probably can't download it again."
+msgstr ""
+"这将删除镜像, 如果以后需要, 可以重新下载.除非该镜像未推送至镜像库, 镜像库未包"
+"含的镜像, 无法再次下载."
+
+#: pkg/storaged/jobs.js:152
+msgid "Deleting volume group $target"
+msgstr "删除卷组 $target"
+
+#: pkg/kubernetes/views/dashboard-page.html:131
+#: pkg/kubernetes/views/deploy.html:62
+msgid "Deploy"
+msgstr "部署"
+
+#: pkg/kubernetes/views/deploy.html:3
+msgid "Deploy Application"
+msgstr "部署应用"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:22
+msgid "Deployment Causes"
+msgstr "部署原因"
+
+#: pkg/kubernetes/views/deploymentconfig-panel.html:8
+#: pkg/kubernetes/views/deploymentconfig-page.html:12
+msgid "Deployment Config"
+msgstr "部署配置"
+
+#: pkg/kubernetes/views/details-page.html:98
+msgid "Deployment Configs"
+msgstr "部署配置"
+
+#: pkg/systemd/services.html:356 pkg/kubernetes/views/project-modify.html:40
+#: pkg/kubernetes/views/image-body.html:6
+#: pkg/kubernetes/views/project-listing.html:15
+#: pkg/kubernetes/views/project-listing.html:54
+msgid "Description"
+msgstr "描述"
+
+#: pkg/shell/index.html:197 pkg/kubernetes/index.html:63
+msgid "Details"
+msgstr "详情"
+
+#: pkg/storaged/index.html:543
+msgctxt "storage"
+msgid "Device"
+msgstr "设备"
+
+#: pkg/storaged/details.js:91
+msgid "Device $0 is a member of RAID Array $1"
+msgstr "设备 $0 是 RAID 阵列 $1 的成员"
+
+#: pkg/storaged/details.js:97
+msgid "Device $0 is a physical volume of $1"
+msgstr "设备 $0 是 $1 的物理卷"
+
+#: pkg/storaged/details.js:85
+msgid "Device $0 is mounted on $1"
+msgstr "设备 $0 已挂载至 $1"
+
+#: pkg/storaged/index.html:467 pkg/storaged/index.html:473
+#: pkg/storaged/index.html:515
+msgctxt "storage"
+msgid "Device File"
+msgstr "设备文件"
+
+#: pkg/sosreport/index.html:22
+msgid "Diagnostic reports"
+msgstr "诊断报告"
+
+#: pkg/kubernetes/views/image-body.html:20
+msgid "Digest"
+msgstr "摘要"
+
+#: pkg/kubernetes/views/image-config.html:7
+#: pkg/kubernetes/views/volume-body.html:28
+msgid "Directory"
+msgstr "目录"
+
+#: pkg/systemd/init.js:543
+msgid "Disable"
+msgstr "禁用"
+
+#: pkg/tuned/dialog.js:234
+msgid "Disable tuned"
+msgstr "禁用 Tuned"
+
+#: pkg/systemd/init.js:302 pkg/networkmanager/interfaces.js:1808
+msgid "Disabled"
+msgstr "禁用"
+
+#: pkg/shell/simple.html:120
+msgid "Disconnected"
+msgstr "已断开连接"
+
+#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+msgid "Disk"
+msgstr "磁盘"
+
+#: pkg/dashboard/index.html:73
+#, fuzzy
+msgid "Disk I/O"
+msgstr "磁盘良好"
+
+#: pkg/kubernetes/scripts/nodes.js:720
+msgid "Disk Utilization: $0%"
+msgstr "磁盘使用率: $0%"
+
+#: pkg/storaged/index.html:457
+msgid "Disk is OK"
+msgstr "磁盘良好"
+
+#: pkg/storaged/index.html:584
+msgid "Disks"
+msgstr "磁盘"
+
+#: pkg/shell/simple.html:37 pkg/shell/simple.html:97 pkg/shell/index.html:37
+#: pkg/shell/index.html:118 pkg/shell/stub.html:37 pkg/shell/stub.html:111
+msgid "Display Language"
+msgstr "显示语言"
+
+#: pkg/kubernetes/views/project-modify.html:31
+msgid "Display name"
+msgstr "显示名称"
+
+#: pkg/kubernetes/views/add-role-dialog.html:5
+msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+msgstr "是否想要添加角色 '{{ fields.displayRole }}'？"
+
+#: pkg/kubernetes/views/imagestream-delete.html:5
+msgid ""
+"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}' image stream?"
+msgstr ""
+"是否想要删除镜像流 '{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}' ？"
+
+#: pkg/kubernetes/views/pv-delete.html:6
+msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+msgstr "是否想要删除持久卷 '{{item.metadata.name}}'？"
+
+#: pkg/kubernetes/views/pvc-delete.html:6
+msgid ""
+"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
+msgstr "是否想要删除持久卷声明 '{{item.metadata.name}}'？"
+
+#: pkg/kubernetes/views/item-delete.html:6
+msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+msgstr "是否想要删除 {{ item.kind }} '{{item.metadata.name}}'？"
+
+#: pkg/kubernetes/views/node-delete.html:7
+msgid "Do you want to delete this Node?"
+msgstr "是否想要删除该节点？"
+
+#: pkg/kubernetes/views/image-delete.html:5
+msgid ""
+"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+"{{stream.metadata.name}}:{{tag.tag}}'?"
+msgstr ""
+"是否想要移除镜像标记 '{{stream.metadata.namespace}}/{{stream.metadata.name}}:"
+"{{tag.tag}}'？"
+
+#: pkg/kubernetes/views/remove-role-dialog.html:5
+msgid ""
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
+msgstr ""
+"是否想要从成员 {{ fields.member.metadata.name }} 移除角色 '{{ fields."
+"displayRole }}'？"
+
+#: pkg/kubernetes/views/image-meta.html:11
+msgid "Docker Version"
+msgstr "Docker 版本"
+
+#: pkg/docker/index.html:60
+msgid "Docker is not installed or activated on the system"
+msgstr "系统中的 Docker 未安装或未启动"
+
+#: pkg/systemd/index.html:107
+msgid "Domain"
+msgstr "域"
+
+#: pkg/realmd/operation.js:148
+msgid "Domain $0 could not be contacted"
+msgstr "域名 $0 无法联系"
+
+#: pkg/realmd/operation.js:220
+msgid "Domain $0 is not supported"
+msgstr "不支持域 $0"
+
+#: pkg/realmd/operation.html:11
+msgid "Domain Address"
+msgstr "域地址"
+
+#: pkg/realmd/operation.html:59
+msgid "Domain Administrator Name"
+msgstr "域管理员用户名"
+
+#: pkg/realmd/operation.html:65
+msgid "Domain Administrator Password"
+msgstr "域管理员密码"
+
+#: pkg/systemd/services.html:426 pkg/systemd/services.html:430
+msgid "Don't Repeat"
 msgstr ""
 
-#: pkg/storaged/details.js:1765
-msgid "$0, $1 free"
-msgstr "$0, $1 可用"
+#: pkg/storaged/details.js:202 pkg/storaged/details.js:341
+msgid "Don't overwrite existing data"
+msgstr "不覆盖已存在数据"
 
-#: pkg/storaged/details.js:1792
-msgid "Logical Volumes"
-msgstr "逻辑卷"
+#: pkg/sosreport/index.html:74
+msgid "Done!"
+msgstr "已完成！"
 
-#: pkg/storaged/details.js:1822 pkg/docker/details.js:177
-#: pkg/docker/image.js:112
-msgid "Not found"
-msgstr "未找到"
+#: pkg/ostree/index.html:127 pkg/ostree/index.html:158
+msgid "Downgrades"
+msgstr "降级"
 
-#: pkg/storaged/overview.js:180
-msgctxt "storage"
-msgid "Hard Disk"
-msgstr "机械硬盘"
-
-#: pkg/storaged/overview.js:182
-msgctxt "storage"
-msgid "Solid-State Disk"
-msgstr "固态硬盘"
-
-#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
-msgctxt "storage"
-msgid "Removable Drive"
-msgstr "可移动驱动器"
-
-#: pkg/storaged/overview.js:189
-msgctxt "storage"
-msgid "Optical Drive"
-msgstr "光盘驱动器"
+#: pkg/storaged/index.html:411
+msgid "Drive"
+msgstr "驱动器"
 
 #: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
 msgctxt "storage"
 msgid "Drive"
 msgstr "驱动器"
 
-#: pkg/storaged/overview.js:253
-msgid "$0 Block Device"
-msgstr "$0 块设备"
+#: pkg/kubernetes/views/volume-body.html:128
+msgid "Driver"
+msgstr "驱动器"
 
-#: pkg/storaged/overview.js:414
-msgid "Create RAID Device"
-msgstr "创建 RAID 设备"
+#: pkg/storaged/index.html:166
+msgid "Drives"
+msgstr "驱动器"
 
-#: pkg/storaged/overview.js:420
-msgid "RAID Level"
-msgstr "RAID 级别"
+#: pkg/docker/run.js:360
+msgid "Duplicate alias"
+msgstr "重复别名"
 
-#: pkg/storaged/overview.js:422
-msgid "RAID 0 (Stripe)"
-msgstr "RAID 0 (条带)"
+#: pkg/docker/run.js:293
+msgid "Duplicate port"
+msgstr "重复端口"
 
-#: pkg/storaged/overview.js:423
-msgid "RAID 1 (Mirror)"
-msgstr "RAID 1 (镜像)"
+#: pkg/storaged/jobs.js:120
+msgid "Ejecting $target"
+msgstr "弹出 $target"
 
-#: pkg/storaged/overview.js:424
-msgid "RAID 4 (Dedicated Parity)"
-msgstr "RAID 4 (奇偶校验)"
+#: pkg/playground/translate.html:58
+msgid "Empty"
+msgstr "空"
 
-#: pkg/storaged/overview.js:425
-msgid "RAID 5 (Distributed Parity)"
-msgstr "RAID 5 (奇偶校验)"
-
-#: pkg/storaged/overview.js:426
-msgid "RAID 6 (Double Distributed Parity)"
-msgstr "RAID 6 (双倍奇偶校验)"
-
-#: pkg/storaged/overview.js:427
-msgid "RAID 10 (Stripe of Mirrors)"
-msgstr "RAID 10 (条带镜像)"
-
-#: pkg/storaged/overview.js:431
-msgid "Chunk Size"
-msgstr "区块大小"
-
-#: pkg/storaged/overview.js:433
-msgid "4 KiB"
-msgstr "4 KiB"
-
-#: pkg/storaged/overview.js:434
-msgid "8 KiB"
-msgstr "8 KiB"
-
-#: pkg/storaged/overview.js:435
-msgid "16 KiB"
-msgstr "16 KiB"
-
-#: pkg/storaged/overview.js:436
-msgid "32 KiB"
-msgstr "32 KiB"
-
-#: pkg/storaged/overview.js:437
-msgid "64 KiB"
-msgstr "64 KiB"
-
-#: pkg/storaged/overview.js:438
-msgid "128 KiB"
-msgstr "128 KiB"
-
-#: pkg/storaged/overview.js:439
-msgid "512 KiB"
-msgstr "512 KiB"
-
-#: pkg/storaged/overview.js:440
-msgid "1 MiB"
-msgstr "1 MiB"
-
-#: pkg/storaged/overview.js:441
-msgid "2 MiB"
-msgstr "2 MiB"
-
-#: pkg/storaged/overview.js:455
-msgid "At least $0 disks are needed."
-msgstr "至少需要 $0 块磁盘。"
-
-#: pkg/storaged/overview.js:487
-msgid "Create Volume Group"
-msgstr "创建卷组"
-
-#: pkg/storaged/overview.js:515
-msgid "Add iSCSI Portal"
-msgstr "添加 iSCSI 门户"
-
-#: pkg/storaged/overview.js:518
-msgid "Server Address"
-msgstr "服务器地址"
-
-#: pkg/storaged/overview.js:521
+#: pkg/playground/translate.html:63
 #, fuzzy
-msgid "Server address cannot be empty."
-msgstr "服务器地址不能为空。"
+msgctxt "verb"
+msgid "Empty"
+msgstr "空"
 
-#: pkg/storaged/overview.js:533 pkg/realmd/operation.html.h:11
-msgid "Next"
-msgstr "下一步"
+#: pkg/kubernetes/scripts/volumes.js:196
+msgid "Empty Directory"
+msgstr "空目录"
 
-#: pkg/storaged/overview.js:577 pkg/storaged/overview.js:668
-#: pkg/subscriptions/subscriptions-client.js:194
+#: pkg/storaged/jobs.js:155
+msgid "Emptying $target"
+msgstr "清空 $target"
+
+#: pkg/systemd/init.js:541
+msgid "Enable"
+msgstr "启用"
+
+#: pkg/systemd/init.js:542
+msgid "Enable Forcefully"
+msgstr "强制启用"
+
+#: pkg/systemd/init.js:301
+msgid "Enabled"
+msgstr "启用"
+
+#: pkg/storaged/details.js:1247
+msgctxt "storage-id-desc"
+msgid "Encrypted"
+msgstr "加密"
+
+#: pkg/storaged/details.js:180
+msgid "Encrypted EXT4 (LUKS)"
+msgstr "加密 EXT4 (LUKS)"
+
+#: pkg/storaged/details.js:179
+msgid "Encrypted XFS (LUKS)"
+msgstr "加密 XFS (LUKS)"
+
+#: pkg/storaged/details.js:241 pkg/storaged/details.js:524
+#: pkg/storaged/details.js:1115
+msgid "Encryption Options"
+msgstr "加密选项"
+
+#: pkg/kubernetes/views/pv-modify.html:93
+msgid "Endpoint"
+msgstr "端点"
+
+#: pkg/kubernetes/views/volume-body.html:40
+msgid "Endpoint Name"
+msgstr "端点名称"
+
+#: pkg/kubernetes/views/service-page.html:14
+#: pkg/kubernetes/views/service-panel.html:9
+msgid "Endpoints"
+msgstr "端点"
+
+#: pkg/subscriptions/subscriptions-view.jsx:38
+msgid "Ends"
+msgstr "结尾"
+
+#: pkg/selinux/setroubleshoot-view.jsx:332
+msgid "Enforce policy:"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:447
+msgid "Enter IP address or host name"
+msgstr "输入 IP 地址或主机名"
+
+#: pkg/systemd/logs.html:60
+msgid "Entry"
+msgstr "条目"
+
+#: pkg/docker/index.html:547 pkg/kubernetes/views/image-config.html:17
+#: pkg/kubernetes/views/container-body.html:26
+msgid "Environment"
+msgstr "环境变量"
+
+#: pkg/storaged/details.js:200 pkg/storaged/details.js:339
+msgid "Erase"
+msgstr "擦除"
+
+#: pkg/docker/storage.jsx:423
+msgid "Erase containers and reset storage pool"
+msgstr ""
+
+#: pkg/docker/storage.jsx:360
+msgid "Erase containers, reformat disks, and add them"
+msgstr ""
+
+#: pkg/storaged/jobs.js:129
+msgid "Erasing $target"
+msgstr "擦除 $target"
+
+#: pkg/systemd/services.html:318 pkg/playground/translate.html:101
+#: pkg/playground/translate.html:106
+msgid "Error"
+msgstr "错误"
+
+#: pkg/kubernetes/scripts/connection.js:650
+msgid "Error getting certificate details: $0"
+msgstr "获取证书详情出错: $0"
+
+#: pkg/lib/machine-sync-users.html:13
+msgid "Error loading users: {{perm_failed}}"
+msgstr "加载用户: {{perm_failed}} 出错"
+
+#: pkg/docker/util.js:491
+msgid "Error message from Docker:"
+msgstr "来自 Docker 的错误消息："
+
+#: pkg/users/authorized-keys.js:115
+msgid "Error saving authorized keys: "
+msgstr "保存授权密钥时出错: "
+
+#: pkg/selinux/setroubleshoot.js:275
+msgid "Error while connecting."
+msgstr "连接时出错。"
+
+#: pkg/selinux/setroubleshoot-client.js:192
+msgid "Error while deleting alert"
+msgstr "删除警告时出错"
+
+#: pkg/selinux/setroubleshoot.js:65
+msgid "Error while setting SELinux mode: '$0'"
+msgstr "设置 SELinux 模式时出错: '$0'"
+
+#: pkg/kubernetes/scripts/connection.js:88
+msgid "Error writing kubectl config"
+msgstr "写 kubectl 配置时出错"
+
+#: pkg/systemd/logs.html:47
+msgid "Errors"
+msgstr "错误"
+
+#: pkg/networkmanager/index.html:764
+msgid "Ethernet MTU"
+msgstr "以太网 MTU"
+
+#: pkg/networkmanager/interfaces.js:1854
+msgid "Ethtool"
+msgstr ""
+
+#: pkg/users/local.js:429 pkg/users/local.js:1104
+msgid "Excellent password"
+msgstr "密码强度良好"
+
+#: pkg/docker/util.js:96
+msgid "Exited $ExitCode"
+msgstr "已退出 $ExitCode"
+
+#: pkg/docker/index.html:529
+msgid "Expose container ports"
+msgstr "暴露容器端口"
+
+#: pkg/storaged/details.js:183
+msgid "Extended Partition"
+msgstr "扩展分区"
+
+#: pkg/storaged/details.js:1592
+msgid "FAILED"
+msgstr "失败"
+
+#: pkg/ostree/index.html:92
+msgid "Failed"
+msgstr "已失败"
+
+#: pkg/lib/machine-dialogs.js:412
+msgid "Failed to add machine: $0"
+msgstr "添加主机失败: $0"
+
+#: pkg/users/local.js:112 pkg/users/local.js:144 pkg/lib/credentials.js:223
+msgid "Failed to change password"
+msgstr "修改密码失败"
+
+#: pkg/selinux/setroubleshoot-client.js:187
+msgid "Failed to delete alert"
+msgstr "无法删除警告"
+
+#: pkg/tuned/dialog.js:171
+msgid "Failed to disable tuned"
+msgstr "禁用Tuned失败"
+
+#: pkg/tuned/dialog.js:133
+msgid "Failed to disable tuned profile"
+msgstr "禁用Tuned配置失败"
+
+#: pkg/lib/machine-dialogs.js:494
+msgid "Failed to edit machine: $0"
+msgstr "编辑主机失败: $0"
+
+#: pkg/tuned/dialog.js:169
+msgid "Failed to enable tuned"
+msgstr "启用Tuned失败"
+
+#: pkg/users/index.html:338
+msgid "Failed to load authorized keys."
+msgstr "载入 authorized key 失败。"
+
+#: pkg/docker/containers.js:64
+msgid "Failed to start Docker: $0"
+msgstr "启动 Docker 失败： $0"
+
+#: pkg/docker/util.js:544
+msgid "Failed to stop Docker scope: $0"
+msgstr "无法停止 Docker 范围: $0"
+
+#: pkg/tuned/dialog.js:145
+msgid "Failed to switch profile"
+msgstr "切换配置集失败"
+
+#: pkg/kubernetes/scripts/volumes.js:204
+msgid "Fibre Channel"
+msgstr "光纤通道"
+
+#: pkg/storaged/details.js:426 pkg/storaged/details.js:1105
+msgid "Filesystem Options"
+msgstr "文件系统选项"
+
+#: pkg/kubernetes/views/pv-modify.html:180
+#: pkg/kubernetes/views/volume-body.html:6
+#: pkg/kubernetes/views/volume-body.html:16
+#: pkg/kubernetes/views/volume-body.html:62
+#: pkg/kubernetes/views/volume-body.html:83
+#: pkg/kubernetes/views/volume-body.html:91
+#: pkg/kubernetes/views/volume-body.html:120
+#: pkg/kubernetes/views/volume-body.html:132
+msgid "Filesystem Type"
+msgstr "文件系统类型"
+
+#: pkg/storaged/details.js:215
+msgid "Filesystem type"
+msgstr "文件系统类型"
+
+#: pkg/storaged/index.html:225
+msgid "Filesystems"
+msgstr "文件系统"
+
+#: pkg/lib/machine-unknown-hostkey.html:10
+msgid "Fingerprint"
+msgstr "指印"
+
+#: pkg/storaged/index.html:426
+msgctxt "storage"
+msgid "Firmware Version"
+msgstr "固件版本"
+
+#: pkg/kubernetes/scripts/volumes.js:206
+msgid "Flex"
+msgstr "收缩"
+
+#: pkg/kubernetes/scripts/volumes.js:205
+msgid "Flocker"
+msgstr "Flocker"
+
+#: pkg/kubernetes/views/volume-body.html:125
+msgid "Flocker Dataset Name"
+msgstr "Flocker 数据集名称"
+
+#: pkg/docker/util.js:503
+msgid "Force Delete"
+msgstr "强制删除"
+
+#: pkg/storaged/details.js:266 pkg/storaged/details.js:357
+#: pkg/storaged/details.js:1142
+msgid "Format"
+msgstr "格式化"
+
+#: pkg/storaged/details.js:115
+msgid "Format $0"
+msgstr "格式 $0"
+
+#: pkg/storaged/details.js:335
+msgid "Format Disk $0"
+msgstr "格式化磁盘 $0"
+
+#: pkg/storaged/details.js:358
+msgid "Formatting a disk will erase all data on it."
+msgstr "格式化磁盘将擦除其中的所有数据。"
+
+#: pkg/storaged/details.js:268
+msgid "Formatting a storage device will erase all data on it."
+msgstr "格式化存储设备将擦除其中的所有数据."
+
+#: pkg/networkmanager/interfaces.js:2577
+msgid "Forward delay $forward_delay"
+msgstr "转发延迟 $forward_delay"
+
+#: pkg/systemd/index.html:255
+msgid "Free"
+msgstr "可用"
+
+#: pkg/users/index.html:86 pkg/users/index.html:148
+msgid "Full Name"
+msgstr "全名"
+
+#: pkg/kubernetes/scripts/volumes.js:192
+msgid "GCE Persistent Disk"
+msgstr "GCE 持久盘"
+
+#: pkg/docker/index.html:180
+msgid "Gateway:"
+msgstr "网关:"
+
+#: pkg/networkmanager/interfaces.js:2628
+msgid "General"
+msgstr "通用"
+
+#: pkg/sosreport/index.html:66
+msgid "Generating report"
+msgstr "正在生成报告"
+
+#: pkg/kubernetes/scripts/volumes.js:194
+msgid "Git Repository"
+msgstr "Git 仓库"
+
+#: pkg/kubernetes/scripts/volumes.js:198
+msgid "Gluster FS"
+msgstr "Gluster FS"
+
+#: pkg/kubernetes/scripts/volumes.js:872
+msgid "GlusterFS"
+msgstr "GlusterFS"
+
+#: pkg/systemd/logs.js:130
+msgid "Go to"
+msgstr "到"
+
+#: pkg/storaged/index.html:307 pkg/networkmanager/index.html:50
+#: pkg/networkmanager/index.html:496
+msgid "Go to now"
+msgstr "转到现在"
+
+#: pkg/kubernetes/views/group-page.html:21
+#: pkg/kubernetes/views/group-panel.html:12
+msgid "Group Members"
+msgstr "组成员"
+
+#: pkg/kubernetes/views/project-listing.html:48
+#: pkg/kubernetes/views/user-delete.html:14
+msgid "Groups"
+msgstr "组"
+
+#: pkg/networkmanager/index.html:268
+msgid "Hair Pin mode"
+msgstr "发夹模式"
+
+#: pkg/networkmanager/interfaces.js:2603
+msgid "Hairpin mode"
+msgstr "发夹模式"
+
+#: pkg/docker/storage.jsx:157
+#, fuzzy
+msgid "Hard Disk"
+msgstr "机械硬盘"
+
+#: pkg/storaged/overview.js:180
+msgctxt "storage"
+msgid "Hard Disk"
+msgstr "机械硬盘"
+
+#: pkg/systemd/index.html:77
+msgid "Hardware"
+msgstr "硬件"
+
+#: pkg/networkmanager/interfaces.js:2579
+msgid "Hello time $hello_time"
+msgstr "Hello 时间 $hello_time"
+
+#: pkg/kubernetes/views/details-page.html:73
+#: pkg/kubernetes/views/route-body.html:9
+#: pkg/kubernetes/views/route-modify.html:8
+msgid "Host"
+msgstr "主机"
+
+#: pkg/systemd/index.html:102 pkg/dashboard/index.html:151
+msgid "Host Name"
+msgstr "主机名"
+
+#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
+msgid "Host Path"
+msgstr "主机路径"
+
+#: src/base1/cockpit.js:3699
+msgid "Host key is incorrect"
+msgstr "主机密钥不正确"
+
+#: pkg/systemd/services.html:442
+#, fuzzy
+msgid "Hour : Minute"
+msgstr "1 分钟"
+
+#: pkg/systemd/init.js:1183 pkg/systemd/init.js:1212
+msgid "Hour needs to be a number between 0-23"
+msgstr ""
+
+#: pkg/systemd/services.html:408
+#, fuzzy
+msgid "Hours"
+msgstr "6 小时"
+
+#: pkg/systemd/index.html:221
+msgid "I/O Wait"
+msgstr "I/O 等待"
+
+#: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
+msgid "IP"
+msgstr "IP"
+
+#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
+msgid "IP Address"
+msgstr "IP 地址"
+
+#: pkg/docker/index.html:172
+msgid "IP Address:"
+msgstr "IP 地址:"
+
+#: pkg/docker/index.html:176
+msgid "IP Prefix Length:"
+msgstr "IP 前缀长度:"
+
+#: pkg/networkmanager/index.html:568
+msgid "IP Settings"
+msgstr "IP 设置"
+
+#: pkg/networkmanager/interfaces.js:2641
+msgid "IPv4"
+msgstr "IPv4"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv4 Settings"
+msgstr "IPv4 设置"
+
+#: pkg/networkmanager/interfaces.js:2642
+msgid "IPv6"
+msgstr "IPv6"
+
+#: pkg/networkmanager/interfaces.js:3061
+msgid "IPv6 Settings"
+msgstr "IPv6 设置"
+
+#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
+msgid "ISCSI"
+msgstr "ISCSI"
+
+#: pkg/systemd/init.js:270
+msgid "Id"
+msgstr "ID"
+
+#: pkg/networkmanager/interfaces.js:2620
+msgid "Id $id"
+msgstr "Id $id"
+
+#: pkg/kubernetes/views/image-body.html:22
+msgid "Identifier"
+msgstr "身份标识"
+
+#: pkg/kubernetes/views/user-page.html:23
+#: pkg/kubernetes/views/user-panel.html:18
+msgid "Identities"
+msgstr "身份"
+
+#: pkg/kubernetes/views/project-listing.html:91
+msgid "Identity"
+msgstr "身份"
+
+#: pkg/networkmanager/interfaces.js:1817
+msgid "Ignore"
+msgstr "忽略"
+
+#: pkg/docker/index.html:452 pkg/kubernetes/views/image-panel.html:9
+#: pkg/kubernetes/views/container-body.html:6
+#: pkg/kubernetes/views/image-page.html:16
+msgid "Image"
+msgstr "镜像"
+
+#: pkg/docker/image.js:77
+msgid "Image $0"
+msgstr "镜像 $0"
+
+#: pkg/kubernetes/views/container-body.html:8
+msgid "Image ID"
+msgstr "镜像编号"
+
+#: pkg/kubernetes/views/image-meta.html:16
+msgid "Image Layers"
+msgstr "镜像层"
+
+#: pkg/kubernetes/views/volume-body.html:58
+msgid "Image Name"
+msgstr "镜像名称"
+
+#: pkg/kubernetes/registry.html:23
+msgid "Image Registry"
+msgstr "镜像注册表"
+
+#: pkg/kubernetes/views/imagestream-page.html:16
+msgid "Image Stream"
+msgstr "镜像流"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:135
+#, fuzzy
+msgid "Image commands"
+msgstr "镜像计数"
+
+#: pkg/kubernetes/views/imagestream-body.html:34
+msgid "Image count"
+msgstr "镜像计数"
+
+#: pkg/kubernetes/registry.html:48
+#: pkg/kubernetes/views/registry-dashboard-page.html:19
+#: pkg/kubernetes/views/imagestream-page.html:18
+#: pkg/kubernetes/views/image-listing.html:9 pkg/kubernetes/index.html:77
+msgid "Images"
+msgstr "镜像"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:17
+msgid "Images by project"
+msgstr "镜像（按项目）"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:54
+msgid "Images pushed recently"
+msgstr "最近推送的镜像"
+
+#: pkg/storaged/details.js:1593
+msgid "In Sync"
+msgstr "同步中"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:81
+msgid ""
+"In order to begin pushing images to the registry, use the commands below."
+msgstr "为了开始推送镜像到注册表，使用以下命令。"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:6
+msgid ""
+"In order to begin pushing images to the registry, you need to create a "
+"project."
+msgstr "为了开始推送镜像到注册表，需要创建一个项目。"
+
+#: pkg/lib/machine-sync-users.html:50
+msgid ""
+"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
+"strong}}.        {{/needs_root}}                                    User "
+"name                                                                            "
+"{{#allows_password}}                            "
+"Password                                                                            "
+"{{/allows_password}}            "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
+#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
+msgid "Inactive"
+msgstr "未激活"
+
+#: pkg/lib/machine-invalid-hostkey.html:2
+msgid "Incorrect Host Key"
+msgstr "不正确的主机密钥"
+
+#: pkg/docker/storage.jsx:282
+msgid "Information about the Docker storage pool is not available."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:222
+#, fuzzy
+msgid "Installed products"
+msgstr "已安装产品"
+
+#: pkg/systemd/services.html:135
+msgid "Instantiate"
+msgstr "实例"
+
+#: pkg/kubernetes/views/pv-modify.html:169
+#: pkg/kubernetes/views/volume-body.html:81
+msgid "Interface"
+msgstr "接口"
+
+#: pkg/networkmanager/index.html:84
+msgid "Interfaces"
+msgstr "接口"
+
+#: src/base1/cockpit.js:3701
+msgid "Internal error"
+msgstr "内部错误"
+
+#: pkg/subscriptions/subscriptions-client.js:196
+#, fuzzy
+msgid "Invalid credentials"
+msgstr "无效端口"
+
+#: pkg/systemd/host.js:1194
+msgid "Invalid date format"
+msgstr "无效的日期格式"
+
+#: pkg/systemd/host.js:1190
+msgid "Invalid date format and invalid time format"
+msgstr "无效的日期格式和时间格式"
+
+#: pkg/systemd/init.js:1218
+#, fuzzy
+msgid "Invalid date format."
+msgstr "无效的日期格式"
+
+#: pkg/lib/credentials.js:274
+msgid "Invalid file permissions"
+msgstr "无效的文件权限"
+
+#: pkg/users/index.html:322
+msgid "Invalid key"
+msgstr "无效的 key"
+
+#: pkg/systemd/init.js:1169
+#, fuzzy
+msgid "Invalid number."
+msgstr "无效的 key"
+
+#: pkg/docker/run.js:283
+msgid "Invalid port"
+msgstr "无效端口"
+
+#: pkg/systemd/host.js:1192
+msgid "Invalid time format"
+msgstr "无效的时间格式"
+
+#: pkg/subscriptions/subscriptions-client.js:194 pkg/storaged/overview.js:577
+#: pkg/storaged/overview.js:668
 msgid "Invalid username or password"
 msgstr "无效的用户名或密码"
 
-#: pkg/storaged/overview.js:582
-msgid "Unknown host name"
-msgstr "未知主机名"
+#: pkg/lib/machine-change-port.html:15
+msgid "Is sshd running on a different port?"
+msgstr "sshd 是否在一个不同的端口上运行？"
 
-#: pkg/storaged/overview.js:586
-msgid "Unable to reach server"
-msgstr "无法到达服务器"
+#: pkg/systemd/init.js:522
+msgid "Isolate"
+msgstr "隔离"
 
-#: pkg/storaged/overview.js:619
-msgid "Available targets on $0"
-msgstr "$0 上可用的目标"
+#: pkg/storaged/index.html:280
+msgid "Jobs"
+msgstr "任务"
 
-#: pkg/storaged/overview.js:623 pkg/systemd/services.html.h:2
-msgid "Targets"
-msgstr "目标"
+#: pkg/realmd/operation.js:96
+msgid "Join"
+msgstr "加入"
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-add.html.h:2
-#: pkg/kubernetes/views/node-body.html.h:2
-#: pkg/kubernetes/views/auth-form.html.h:3
-#: pkg/kubernetes/views/node-add.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:16
-#: pkg/kubernetes/views/nodes-page.html.h:7
-#: pkg/kubernetes/views/details-page.html.h:19
-msgid "Address"
-msgstr "地址"
+#: pkg/realmd/operation.js:453
+msgid "Join Domain"
+msgstr "加入域"
 
-#: pkg/storaged/overview.js:624 pkg/lib/machine-change-port.html.h:5
-msgid "Port"
-msgstr "端口"
+#: pkg/realmd/operation.js:347
+msgid "Joining this domain is not supported"
+msgstr "不支持加入该域"
 
-#: pkg/storaged/overview.js:699
-msgid "Change iSCSI Initiator Name"
-msgstr "变更 iSCSI Initiator 名称"
+#: pkg/systemd/logs.js:257
+msgid "Journal entry"
+msgstr "日志条目"
 
-#: pkg/storaged/overview.js:707 pkg/kubernetes/views/route-modify.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:22
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:4
-#: pkg/kubernetes/views/project-modify.html.h:9
-msgid "Change"
-msgstr "变更"
+#: pkg/systemd/logs.js:284
+msgid "Journal entry not found"
+msgstr "未找到日志条目"
 
-#: pkg/storaged/utils.js:88
-msgctxt "format-bytes"
-msgid "bytes"
-msgstr "字节"
+#: pkg/lib/machine-auth-failed.html:10
+msgid "Kerberos Based SSO"
+msgstr "基于 Kerberos 的 SSO"
+
+#: pkg/lib/machine-change-auth.html:69
+msgid "Kerberos Ticket"
+msgstr "Kerberos 权证"
+
+#: pkg/systemd/index.html:225
+msgid "Kernel"
+msgstr "内核"
+
+#: pkg/kubernetes/views/node-body.html:19
+msgid "Kernel Version"
+msgstr "内核版本"
+
+#: pkg/kubernetes/views/volume-body.html:67
+msgid "Key Ring Path"
+msgstr "密匙环路径"
+
+#: pkg/kubernetes/views/node-body.html:23
+msgid "Kubelet Version"
+msgstr "Kubelet 版本"
+
+#: pkg/kubernetes/index.html:23
+msgid "Kubernetes Cluster"
+msgstr "Kubernetes 集群"
+
+#: pkg/networkmanager/index.html:473
+msgid "LACP Key"
+msgstr ""
+
+#: pkg/storaged/details.js:1245
+msgctxt "storage-id-desc"
+msgid "LUKS Encrypted"
+msgstr "LUKS 加密"
+
+#: pkg/storaged/details.js:1226
+msgctxt "storage-id-desc"
+msgid "LVM2 Physical Volume"
+msgstr "LVM2 物理卷"
+
+#: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/replicationcontroller-body.html:17
+#: pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/route-body.html:22
+#: pkg/kubernetes/views/image-meta.html:3
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
+msgid "Labels"
+msgstr "标签"
+
+#: pkg/systemd/logs.html:42
+msgid "Last 24 hours"
+msgstr "最近 24 小时"
+
+#: pkg/systemd/logs.html:43
+msgid "Last 7 days"
+msgstr "最近 7 天"
+
+#: pkg/kubernetes/views/node-body.html:49
+msgid "Last Heartbeat"
+msgstr "最近的保活心跳"
+
+#: pkg/users/index.html:100
+msgid "Last Login"
+msgstr "最近登陆"
+
+#: pkg/kubernetes/views/node-body.html:51
+msgid "Last Status Change"
+msgstr "最近的状态变更"
+
+#: pkg/systemd/init.js:273
+msgid "Last Trigger"
+msgstr "最近的触发器"
+
+#: pkg/kubernetes/views/image-listing.html:16
+msgid "Last Updated"
+msgstr "最近更新时间"
+
+#: pkg/kubernetes/views/details-page.html:107
+msgid "Latest Version"
+msgstr "最近的版本"
+
+#: pkg/realmd/operation.js:101
+msgid "Leave"
+msgstr "离开"
+
+#: pkg/networkmanager/index.html:315
+msgid "Link Monitoring"
+msgstr "链路监控"
+
+#: pkg/networkmanager/index.html:397
+#, fuzzy
+msgid "Link Watch"
+msgstr "本地链路"
+
+#: pkg/networkmanager/index.html:350 pkg/networkmanager/index.html:432
+msgid "Link down delay"
+msgstr "链路断开延时"
+
+#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
+msgid "Link local"
+msgstr "本地链路"
+
+#: pkg/networkmanager/index.html:341 pkg/networkmanager/index.html:423
+msgid "Link up delay"
+msgstr "链路启用延时"
+
+#: pkg/docker/index.html:514
+msgid "Links"
+msgstr "连接"
+
+#: pkg/storaged/details.js:1224
+msgctxt "storage-id-desc"
+msgid "Linux MD-RAID Component"
+msgstr "Linux MD-RAID 组件"
+
+#: pkg/networkmanager/interfaces.js:1841
+#, fuzzy
+msgid "Load Balancing"
+msgstr "自适应负载均衡"
+
+#: pkg/systemd/logs.js:69
+msgid "Load earlier entries"
+msgstr "载入更早条目"
+
+#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
+#: pkg/systemd/logs.js:175
+msgid "Loading..."
+msgstr "载入中..."
+
+#: pkg/users/index.html:23
+msgid "Local Accounts"
+msgstr "本地账户"
+
+#: pkg/docker/storage.jsx:188
+#, fuzzy
+msgid "Local Disks"
+msgstr "$0 磁盘"
+
+#: pkg/storaged/details.js:1109
+msgid "Lock"
+msgstr "锁定"
+
+#: pkg/users/index.html:109 pkg/users/index.html:196
+msgid "Lock Account"
+msgstr "锁定账户"
+
+#: pkg/storaged/jobs.js:122
+msgid "Locking $target"
+msgstr "锁定 $target"
+
+#: pkg/lib/machine-change-auth.html:80
+msgid "Log In"
+msgstr "登录"
+
+#: pkg/lib/machine-change-auth.html:4
+msgid "Log in to {{host}}"
+msgstr "登录到 {{host}}"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:116
+msgid "Log into OpenShift command line tools:"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:101
+#, fuzzy
+msgid "Log into the registry:"
+msgstr "欢迎使用镜像注册表"
+
+#: pkg/shell/simple.html:45 pkg/shell/index.html:52 pkg/shell/stub.html:45
+msgid "Log out"
+msgstr "登出"
+
+#: pkg/users/local.js:839
+msgid "Logged In"
+msgstr "登录"
+
+#: pkg/storaged/details.js:1424
+msgid "Logical Partition"
+msgstr "逻辑分区"
+
+#: pkg/kubernetes/views/pv-modify.html:158
+#: pkg/kubernetes/views/volume-body.html:79
+#: pkg/kubernetes/views/volume-body.html:118
+msgid "Logical Unit Number"
+msgstr "逻辑单元编号"
+
+#: pkg/storaged/utils.js:172
+msgid "Logical Volume"
+msgstr "逻辑卷"
+
+#: pkg/storaged/utils.js:170
+msgid "Logical Volume (Snapshot)"
+msgstr "逻辑卷 (快照)"
+
+#: pkg/storaged/details.js:1792
+msgid "Logical Volumes"
+msgstr "逻辑卷"
+
+#: pkg/subscriptions/subscriptions-register.jsx:140
+#, fuzzy
+msgid "Login"
+msgstr "最近登陆"
+
+#: pkg/lib/machine-change-auth.html:68
+msgid "Login Password"
+msgstr "登录密码"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:96
+#, fuzzy
+msgid "Login commands"
+msgstr "Docker 命令"
+
+#: src/base1/cockpit.js:3693
+msgid "Login failed"
+msgstr "登录失败"
+
+#: pkg/subscriptions/subscriptions-client.js:200
+#, fuzzy
+msgid "Login/password or activation key required to register."
+msgstr "需要 用户名/密码 或 激活密钥"
+
+#: pkg/systemd/logs.html:59 pkg/kubernetes/views/container-panel.html:6
+#: pkg/kubernetes/views/container-page-inline.html:8
+msgid "Logs"
+msgstr "日志"
+
+#: pkg/dashboard/index.html:110
+msgid "Lost connection. Trying to reconnect"
+msgstr "连接失败。请重新连接"
+
+#: pkg/docker/index.html:184
+msgid "MAC Address:"
+msgstr "MAC 地址:"
+
+#: pkg/networkmanager/interfaces.js:1833
+msgid "MII (Recommended)"
+msgstr "MII (推荐)"
+
+#: pkg/networkmanager/interfaces.js:2477
+msgid "MTU"
+msgstr "MTU"
+
+#: pkg/networkmanager/interfaces.js:4139
+msgid "MTU must be a positive number"
+msgstr "MTU 必须是正整数"
+
+#: pkg/systemd/index.html:85 pkg/kubernetes/views/node-body.html:15
+msgid "Machine ID"
+msgstr "机器编号"
+
+#: pkg/systemd/index.html:282
+msgid "Machine SSH Key Fingerprints"
+msgstr "主机 SSH 密钥指纹"
+
+#: pkg/shell/indexes.js:253
+msgid "Machines"
+msgstr "主机"
+
+#: pkg/kubernetes/scripts/dashboard.js:460
+msgid "Manifest"
+msgstr "清单"
+
+#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
+msgid "Manual"
+msgstr "手动"
+
+#: pkg/systemd/index.html:401 pkg/systemd/index.html:405
+msgid "Manually"
+msgstr "手动的"
+
+#: pkg/storaged/jobs.js:140
+msgid "Marking $target as faulty"
+msgstr "标记 $target 出现故障"
+
+#: pkg/systemd/init.js:546
+msgid "Mask"
+msgstr "Mask"
+
+#: pkg/systemd/init.js:547
+msgid "Mask Forcefully"
+msgstr "强制 Mask"
+
+#: pkg/networkmanager/interfaces.js:2483
+msgid "Master"
+msgstr "主"
+
+#: pkg/networkmanager/interfaces.js:2581
+msgid "Maximum message age $max_age"
+msgstr "最大消息有效期 $max_age"
+
+#: pkg/kubernetes/views/volume-body.html:34
+msgid "Medium"
+msgstr "媒介"
+
+#: pkg/kubernetes/views/project-listing.html:92
+msgid "Member of"
+msgstr "属于"
+
+#: pkg/kubernetes/views/project-listing.html:16
+#: pkg/kubernetes/views/project-listing.html:55
+#: pkg/networkmanager/index.html:291
+msgid "Members"
+msgstr "成员"
+
+#: pkg/kubernetes/views/project-page.html:29
+#: pkg/kubernetes/views/user-panel.html:11
+#: pkg/kubernetes/views/user-panel.html:27
+#: pkg/kubernetes/views/user-body.html:4
+msgid "Membership"
+msgstr "成员关系"
+
+#: pkg/dashboard/index.html:71 pkg/playground/translate.html:91
+msgid "Memory"
+msgstr "内存"
+
+#: pkg/systemd/host.js:1466
+msgctxt "page-title"
+msgid "Memory"
+msgstr "内存"
+
+#: pkg/kubernetes/scripts/nodes.js:716
+msgid "Memory Utilization: $0%"
+msgstr "Memory 使用率: $0%"
+
+#: pkg/docker/index.html:473 pkg/docker/index.html:652
+msgid "Memory limit"
+msgstr "内存限制"
+
+#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
+msgid "Message"
+msgstr "消息"
+
+#: pkg/systemd/host.js:1300
+msgid "Message to logged in users"
+msgstr "登录用户信息"
+
+#: pkg/kubernetes/views/image-panel.html:15
+#: pkg/kubernetes/views/imagestream-page.html:21
+#: pkg/kubernetes/views/image-page.html:22
+msgid "Metadata"
+msgstr "元数据"
+
+#: pkg/docker/index.html:487 pkg/docker/index.html:666
+msgid "MiB"
+msgstr "MiB"
+
+#: pkg/systemd/init.js:1189 pkg/systemd/init.js:1198 pkg/systemd/init.js:1207
+msgid "Minute needs to be a number between 0-59"
+msgstr ""
+
+#: pkg/systemd/services.html:407
+#, fuzzy
+msgid "Minutes"
+msgstr "5 分钟"
+
+#: pkg/networkmanager/index.html:299
+msgid "Mode"
+msgstr "模式"
+
+#: pkg/storaged/index.html:421
+msgctxt "storage"
+msgid "Model"
+msgstr "模型"
+
+#: pkg/kubernetes/views/user-modify.html:31
+msgid "Modify"
+msgstr "修改"
+
+#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
+msgid "Modifying $target"
+msgstr "修改 $target"
+
+#: pkg/networkmanager/index.html:323
+msgid "Monitoring Interval"
+msgstr "监控间隔"
+
+#: pkg/networkmanager/index.html:332
+msgid "Monitoring Targets"
+msgstr "监控目标"
+
+#: pkg/kubernetes/views/volume-body.html:54
+msgid "Monitors"
+msgstr "监视器"
+
+#: pkg/realmd/operation.js:366
+msgid "More"
+msgstr "更多"
+
+#: pkg/storaged/details.js:1099
+msgid "Mount"
+msgstr "挂载"
+
+#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
+msgid "Mount Location"
+msgstr "挂载位置"
+
+#: pkg/storaged/details.js:259 pkg/storaged/details.js:447
+msgid "Mount Options"
+msgstr "挂载选项"
+
+#: pkg/storaged/index.html:231
+msgid "Mount Point"
+msgstr "挂载点"
+
+#: pkg/docker/index.html:540
+msgid "Mount container volumes"
+msgstr "挂载容器卷"
+
+#: pkg/storaged/details.js:245 pkg/storaged/details.js:433
+msgid "Mounting"
+msgstr "挂载"
+
+#: pkg/storaged/jobs.js:126
+msgid "Mounting $target"
+msgstr "挂载 $target"
+
+#: pkg/storaged/index.html:508
+msgctxt "storage"
+msgid "Multipathed Devices"
+msgstr "多路径设备"
+
+#: pkg/kubernetes/scripts/volumes.js:860
+msgid "NFS"
+msgstr "NFS"
+
+#: pkg/kubernetes/scripts/volumes.js:199
+msgid "NFS Mount"
+msgstr "NFS 挂载"
+
+#: pkg/networkmanager/interfaces.js:1856
+msgid "NSNA Ping"
+msgstr ""
+
+#: pkg/storaged/details.js:182
+msgid "NTFS - Compatible with most systems"
+msgstr "NTFS - 兼容多数系统"
+
+#: pkg/systemd/host.js:1250
+msgid "NTP Server"
+msgstr "NTP 服务器"
+
+#: pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/project-modify.html:16
+#: pkg/kubernetes/views/node-add.html:16
+#: pkg/kubernetes/views/volumes-page.html:19
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/image-body.html:2
+#: pkg/kubernetes/views/imagestream-modify.html:10
+#: pkg/kubernetes/views/service-modify.html:9
+#: pkg/kubernetes/views/dashboard-page.html:156
+#: pkg/kubernetes/views/dashboard-page.html:198
+#: pkg/kubernetes/views/details-page.html:34
+#: pkg/kubernetes/views/details-page.html:70
+#: pkg/kubernetes/views/details-page.html:103
+#: pkg/kubernetes/views/details-page.html:137
+#: pkg/kubernetes/views/details-page.html:171
+#: pkg/kubernetes/views/pv-claim.html:4
+#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/kubernetes/views/project-listing.html:14
+#: pkg/kubernetes/views/project-listing.html:53
+#: pkg/kubernetes/views/project-listing.html:90
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/volume-body.html:31 pkg/storaged/index.html:230
+#: pkg/networkmanager/index.html:95 pkg/networkmanager/index.html:113
+#: pkg/networkmanager/index.html:150 pkg/networkmanager/index.html:183
+#: pkg/networkmanager/index.html:282 pkg/networkmanager/index.html:364
+msgid "Name"
+msgstr "名称"
 
 #: pkg/storaged/utils.js:129
 #, fuzzy
@@ -1709,377 +3478,1225 @@ msgstr "名称不能包含字符 '$0'."
 msgid "Name cannot contain whitespace."
 msgstr "名称不能包含空格."
 
-#: pkg/storaged/utils.js:157
-msgid "$name (from $host)"
-msgstr "$name (从 $host)"
+#: pkg/kubernetes/views/service-body.html:5
+#: pkg/kubernetes/views/replicationcontroller-body.html:5
+#: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/pod-body.html:5
+#: pkg/kubernetes/views/dashboard-page.html:160
+#: pkg/kubernetes/views/details-page.html:36
+#: pkg/kubernetes/views/details-page.html:72
+#: pkg/kubernetes/views/details-page.html:105
+#: pkg/kubernetes/views/details-page.html:139
+#: pkg/kubernetes/views/details-page.html:173
+#: pkg/kubernetes/views/pv-claim.html:6
+#: pkg/kubernetes/views/containers-listing.html:14
+#: pkg/kubernetes/views/route-body.html:5
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
+msgid "Namespace"
+msgstr "名称空间"
 
-#: pkg/storaged/utils.js:166
-msgid "Pool for Thin Logical Volumes"
-msgstr "稀疏逻辑卷池"
+#: pkg/kubernetes/scripts/dashboard.js:374
+msgid "Namespace cannot be empty."
+msgstr "命名空间不能为空."
 
-#: pkg/storaged/utils.js:168
-msgid "Thin Logical Volume"
-msgstr "稀疏逻辑卷"
+#: pkg/systemd/host.js:1113
+msgid "Need at least one NTP server"
+msgstr "至少需要一个 NTP 服务器"
 
-#: pkg/storaged/utils.js:170
-msgid "Logical Volume (Snapshot)"
-msgstr "逻辑卷 (快照)"
+#: pkg/dashboard/index.html:72 pkg/playground/translate.html:96
+msgid "Network"
+msgstr "网络"
 
-#: pkg/storaged/utils.js:172
-msgid "Logical Volume"
-msgstr "逻辑卷"
+#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:485
+msgid "Networking"
+msgstr "网络"
 
-#: pkg/storaged/utils.js:212
-msgid "<span>Encrypted Logical Volume of $0</span>"
-msgstr "<span>已加密逻辑卷 $0</span>"
+#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
+msgctxt "page-title"
+msgid "Networking"
+msgstr "联网"
 
-#: pkg/storaged/utils.js:214
-msgid "<span>Encrypted Partition of $0</span>"
-msgstr "<span>已加密分区 $0</span>"
+#: pkg/networkmanager/index.html:124
+msgid "Networking Logs"
+msgstr "联网日志"
 
-#: pkg/storaged/utils.js:216
-msgid "<span>Logical Volume of $0</span>"
-msgstr "<span>逻辑卷 $0</span>"
+#: pkg/users/local.js:841
+msgid "Never"
+msgstr "从不"
 
-#: pkg/storaged/utils.js:218
-msgid "<span>Partition of $0</span>"
-msgstr "<span>分区 $0</span>"
+#: pkg/kubernetes/views/project-listing.html:46
+msgid "New Group"
+msgstr "新建组"
 
-#: pkg/storaged/utils.js:220
-msgid "<span>Encrypted $0</span>"
-msgstr "<span>已加密 $0</span>"
+#: pkg/users/index.html:236 pkg/shell/index.html:255
+msgid "New Password"
+msgstr "新密码"
 
-#: pkg/storaged/utils.js:233
-msgid "RAID Device $0"
-msgstr "RAID 设备 $0"
+#: pkg/kubernetes/views/project-listing.html:7
+msgid "New Project"
+msgstr "新建项目"
 
-#: pkg/storaged/utils.js:239
-msgid "Volume Group $0"
-msgstr "卷组 $0"
+#: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/image-listing.html:7
+msgid "New image stream"
+msgstr "新建镜像流"
 
-#: pkg/storaged/jobs.js:119
-msgid "SMART self-test of $target"
-msgstr "$target SMART 自检"
+#: pkg/users/local.js:120 pkg/lib/credentials.js:231
+msgid "New password was not accepted"
+msgstr "新密码不被接受"
 
-#: pkg/storaged/jobs.js:120
-msgid "Ejecting $target"
-msgstr "弹出 $target"
+#: pkg/kubernetes/views/project-modify.html:4
+#: pkg/kubernetes/views/registry-dashboard-page.html:9
+#: pkg/kubernetes/views/registry-dashboard-page.html:48
+msgid "New project"
+msgstr "新建项目"
 
-#: pkg/storaged/jobs.js:121
-msgid "Unlocking $target"
-msgstr "解锁 $target"
+#: pkg/realmd/operation.html:91
+msgid "Next"
+msgstr "下一步"
 
-#: pkg/storaged/jobs.js:122
-msgid "Locking $target"
-msgstr "锁定 $target"
+#: pkg/systemd/init.js:272
+msgid "Next Run"
+msgstr "下次运行"
 
-#: pkg/storaged/jobs.js:123 pkg/storaged/jobs.js:128 pkg/storaged/jobs.js:132
-msgid "Modifying $target"
-msgstr "修改 $target"
+#: pkg/systemd/index.html:233
+msgid "Nice"
+msgstr "Nice"
 
-#: pkg/storaged/jobs.js:124
-msgid "Starting swapspace $target"
-msgstr "启动 swapspace $target"
-
-#: pkg/storaged/jobs.js:125
-msgid "Stopping swapspace $target"
-msgstr "停止 swapspace $target"
-
-#: pkg/storaged/jobs.js:126
-msgid "Mounting $target"
-msgstr "挂载 $target"
-
-#: pkg/storaged/jobs.js:127
-msgid "Unmounting $target"
-msgstr "卸载 $target"
-
-#: pkg/storaged/jobs.js:129
-msgid "Erasing $target"
-msgstr "擦除 $target"
-
-#: pkg/storaged/jobs.js:130
-msgid "Creating filesystem on $target"
-msgstr "为 $target 创建文件系统"
-
-#: pkg/storaged/jobs.js:131
-msgid "Setting up loop device $target"
-msgstr "创建 loop 设备 $target"
-
-#: pkg/storaged/jobs.js:133 pkg/storaged/jobs.js:147
-msgid "Deleting $target"
-msgstr "删除 $target"
-
-#: pkg/storaged/jobs.js:134
-msgid "Creating partition $target"
-msgstr "创建分区 $target"
-
-#: pkg/storaged/jobs.js:135
-msgid "Cleaning up for $target"
-msgstr "清除 $target"
-
-#: pkg/storaged/jobs.js:136
-msgid "Securely erasing $target"
-msgstr "安全擦除 $target"
-
-#: pkg/storaged/jobs.js:137
-msgid "Very securely erasing $target"
-msgstr "多重安全擦除 $target"
-
-#: pkg/storaged/jobs.js:138
-msgid "Stopping RAID Device $target"
-msgstr "停止 RAID 设备 $target"
-
-#: pkg/storaged/jobs.js:139
-msgid "Starting RAID Device $target"
-msgstr "启动 RAID 设备 $target"
-
-#: pkg/storaged/jobs.js:140
-msgid "Marking $target as faulty"
-msgstr "标记 $target 出现故障"
-
-#: pkg/storaged/jobs.js:141
-msgid "Removing $target from RAID Device"
-msgstr "从 RAID 设备中删除 $target"
-
-#: pkg/storaged/jobs.js:142
-msgid "Creating RAID Device $target"
-msgstr "创建 RAID 设备 $target"
-
-#: pkg/storaged/jobs.js:143
-#, fuzzy
-msgid "Checking RAID Device $target"
-msgstr "创建 RAID 设备 $target"
-
-#: pkg/storaged/jobs.js:144
-#, fuzzy
-msgid "Checking and Repairing RAID Device $target"
-msgstr "创建 RAID 设备 $target"
-
-#: pkg/storaged/jobs.js:145
-#, fuzzy
-msgid "Recovering RAID Device $target"
-msgstr "停止 RAID 设备 $target"
-
-#: pkg/storaged/jobs.js:146
-msgid "Synchronizing RAID Device $target"
-msgstr "同步 RAID 设备 $target"
-
-#: pkg/storaged/jobs.js:148
-msgid "Activating $target"
-msgstr "激活 $target"
-
-#: pkg/storaged/jobs.js:149
-msgid "Deactivating $target"
-msgstr "停用 $target"
-
-#: pkg/storaged/jobs.js:150
-msgid "Creating snapshot of $target"
-msgstr "创建快照 $target "
-
-#: pkg/storaged/jobs.js:151
-msgid "Creating volume group $target"
-msgstr "创建卷组 $target"
-
-#: pkg/storaged/jobs.js:152
-msgid "Deleting volume group $target"
-msgstr "删除卷组 $target"
-
-#: pkg/storaged/jobs.js:153
-msgid "Adding physical volume to $target"
-msgstr "添加物理卷至 $target"
-
-#: pkg/storaged/jobs.js:154
-msgid "Removing physical volume from $target"
-msgstr "从 $target 删除物理卷"
-
-#: pkg/storaged/jobs.js:155
-msgid "Emptying $target"
-msgstr "清空 $target"
-
-#: pkg/storaged/jobs.js:156
-msgid "Creating logical volume $target"
-msgstr "创建逻辑卷 $target"
-
-#: pkg/storaged/jobs.js:157
-msgid "Renaming $target"
-msgstr "重命名 $target"
-
-#: pkg/storaged/jobs.js:158
-msgid "Resizing $target"
-msgstr "调整大小 $target"
-
-#: pkg/storaged/jobs.js:166
-msgid "Operation '$operation' on $target"
-msgstr "在 $target 操作 '$operation'"
-
-#: pkg/storaged/jobs.js:180
-msgid "unknown target"
-msgstr "未知目标"
-
-#: pkg/storaged/permissions.js:61
-msgid "The user <b>$0</b> is not permitted to manage storage"
-msgstr "用户 <b>$0</b> 不允许管理存储"
-
-#: pkg/realmd/operation.js:96
-msgid "Join"
-msgstr "加入"
-
-#: pkg/realmd/operation.js:101
-msgid "Leave"
-msgstr "离开"
-
-#: pkg/realmd/operation.js:148
-msgid "Domain $0 could not be contacted"
-msgstr "域名 $0 无法联系"
-
-#: pkg/realmd/operation.js:220
-msgid "Domain $0 is not supported"
-msgstr "不支持域 $0"
-
-#: pkg/realmd/operation.js:347
-msgid "Joining this domain is not supported"
-msgstr "不支持加入该域"
-
-#: pkg/realmd/operation.js:366
-msgid "More"
-msgstr "更多"
-
-#: pkg/realmd/operation.js:417
-msgid "Cannot join a domain because realmd is not available on this system"
-msgstr "因为该系统的 realmd 不可用, 因此无法加入域"
-
-#: pkg/realmd/operation.js:436
-msgid "The user <b>$0</b> is not permitted to modify realms"
-msgstr "用户 <b>$0</b> 不允许修改 realms"
-
-#: pkg/realmd/operation.js:453
-msgid "Join Domain"
-msgstr "加入域"
-
-#: pkg/docker/run.js:246 pkg/docker/util.js:102
-#: pkg/networkmanager/interfaces.js:2280 pkg/kubernetes/scripts/volumes.js:992
-#: pkg/docker/index.html.h:46
+#: pkg/docker/index.html:563 pkg/docker/index.html:567
 msgid "No"
 msgstr "否"
 
-#: pkg/docker/run.js:261 pkg/docker/console.html.h:1
-#: pkg/kubernetes/views/image-panel.html.h:2
-#: pkg/kubernetes/views/container-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:1
-#: pkg/kubernetes/views/image-page.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:1
-msgid "Container"
-msgstr "容器"
+#: pkg/systemd/index.html:469
+msgid "No Delay"
+msgstr "无延时"
 
-#: pkg/docker/run.js:263 pkg/kubernetes/views/route-modify.html.h:2
-#: pkg/kubernetes/views/route-body.html.h:4
-#: pkg/kubernetes/views/details-page.html.h:12
-msgid "Host"
-msgstr "主机"
+#: pkg/ostree/index.html:220
+msgid "No Deployments"
+msgstr "没有部署"
 
-#: pkg/docker/run.js:283
-msgid "Invalid port"
-msgstr "无效端口"
+#: pkg/storaged/details.js:185
+msgid "No Filesystem"
+msgstr "无文件系统"
 
-#: pkg/docker/run.js:293
-msgid "Duplicate port"
-msgstr "重复端口"
+#: pkg/ostree/app.js:101
+msgid "No OSTree deployments found"
+msgstr "没有找到 OSTree  部署"
 
-#: pkg/docker/run.js:332
-#, fuzzy
-msgid "Command can't be empty"
-msgstr "名称不能为空."
+#: src/ws/cockpitcertificate.c:398
+msgid "No PEM-encoded certificate found"
+msgstr "没有找到 PEM 编码的证书"
 
-#: pkg/docker/run.js:350
-msgid "No alias specified"
-msgstr "未指定别名"
+#: src/ws/cockpitcertificate.c:364
+msgid "No PEM-encoded private key found"
+msgstr "没有找到 PEM 编码的私钥"
 
-#: pkg/docker/run.js:360
-msgid "Duplicate alias"
-msgstr "重复别名"
+#: pkg/kubernetes/views/pv-claim.html:39
+msgid "No Pods are using this claim"
+msgstr "没有容器舱使用该声明"
 
-#: pkg/docker/run.js:384
-msgid "No container specified"
-msgstr "未指定容器"
+#: pkg/selinux/setroubleshoot-view.jsx:479
+msgid "No SELinux alerts."
+msgstr ""
 
-#: pkg/docker/details.js:47 pkg/docker/image.js:43
-msgctxt "page-title"
-msgid "Containers"
-msgstr "容器"
-
-#: pkg/docker/details.js:144
-msgid "${hip}:${hport} -> $cport"
-msgstr "${hip}:${hport} -> $cport"
-
-#: pkg/docker/details.js:272 pkg/docker/containers-view.jsx:167
-msgid "Deleting a container will erase all data in it."
-msgstr "删除容器将清除其中的所有数据。"
-
-#: pkg/docker/storage.jsx:156
-#, fuzzy
-msgid "Solid-State Disk"
-msgstr "固态硬盘"
-
-#: pkg/docker/storage.jsx:157
-#, fuzzy
-msgid "Hard Disk"
-msgstr "机械硬盘"
-
-#: pkg/docker/storage.jsx:158 pkg/storaged/index.html.h:33
-msgid "Drive"
-msgstr "驱动器"
-
-#: pkg/docker/storage.jsx:188
-#, fuzzy
-msgid "Local Disks"
-msgstr "$0 磁盘"
+#: pkg/kubernetes/views/pvc-body.html:10
+msgid "No Volume Bound"
+msgstr "未绑定卷"
 
 #: pkg/docker/storage.jsx:194
 #, fuzzy
 msgid "No additional local storage found."
 msgstr "额外的存储"
 
-#: pkg/docker/storage.jsx:242
-msgid " (shared with the OS)"
+#: pkg/docker/run.js:350
+msgid "No alias specified"
+msgstr "未指定别名"
+
+#: pkg/sosreport/index.js:115
+msgid "No archive has been created."
+msgstr "没有档案被创建"
+
+#: pkg/networkmanager/interfaces.js:1326
+msgid "No carrier"
+msgstr "无载体"
+
+#: pkg/docker/run.js:384
+msgid "No container specified"
+msgstr "未指定容器"
+
+#: pkg/storaged/index.html:193
+msgid "No drives attached"
+msgstr "没有附件的驱动器"
+
+#: pkg/kubernetes/views/project-listing.html:74
+msgid "No groups are present."
+msgstr "没有组用于显示。"
+
+#: pkg/systemd/index.html:28
+msgid "No host keys found."
+msgstr "没有找到主机密钥。"
+
+#: pkg/storaged/index.html:158
+msgid "No iSCSI targets set up"
+msgstr "没有设置 iSCSI 目标"
+
+#: pkg/kubernetes/views/image-listing.html:70
+msgid "No image streams are present."
+msgstr "没有镜像流用于显示。"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:80
+msgid "No images pushed"
+msgstr "没有推送的镜像"
+
+#: pkg/subscriptions/subscriptions-view.jsx:223
+#, fuzzy
+msgid "No installed products on the system."
+msgstr "Cockpit 未安装在该系统上。"
+
+#: pkg/storaged/index.html:446
+msgid "No media inserted"
+msgstr "没有插入媒体"
+
+#: pkg/kubernetes/scripts/dashboard.js:384
+msgid ""
+"No metadata file was selected. Please select a Kubernetes metadata file."
+msgstr "未选择元数据文件. 请选择一个 Kubernetes 元数据文件."
+
+#: pkg/kubernetes/views/dashboard-page.html:117
+msgid "No nodes in cluster"
+msgstr "集群中没有节点"
+
+#: pkg/storaged/details.js:352
+msgid "No partitioning"
+msgstr "无分区"
+
+#: pkg/kubernetes/views/dashboard-page.html:40
+msgid "No pods deployed"
+msgstr "没有部署的容器舱"
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:6
+msgid "No pods replicated"
+msgstr "没有复制的容器舱"
+
+#: pkg/kubernetes/views/node-capacity.html:11
+msgid "No pods scheduled"
+msgstr "没有被调度的容器舱"
+
+#: pkg/kubernetes/views/service-endpoint.html:10
+msgid "No pods selected"
+msgstr "没有选中的容器舱"
+
+#: pkg/kubernetes/views/project-listing.html:37
+msgid "No projects are present."
+msgstr "没有项目用于显示。"
+
+#: pkg/users/local.js:405
+msgid "No real name specified"
+msgstr "未指定真实姓名"
+
+#: pkg/storaged/index.html:87
+msgid "No storage set up as RAID"
+msgstr "没有存储设置为 RAID"
+
+#: pkg/lib/credentials.js:182
+msgid "No such file or directory"
+msgstr "没有该文件或目录"
+
+#: pkg/users/local.js:400
+msgid "No user name specified"
+msgstr "未指定用户名"
+
+#: pkg/kubernetes/views/project-listing.html:112
+msgid "No users are present."
+msgstr "没有用户用于显示。"
+
+#: pkg/storaged/index.html:120
+msgid "No volume groups created"
+msgstr "没有创建的卷组"
+
+#: pkg/kubernetes/views/volumes-page.html:44
+msgid "No volumes are present."
+msgstr "没有卷用于显示。"
+
+#: pkg/kubernetes/views/dashboard-page.html:73
+msgid "No volumes in use"
+msgstr "没有正在使用的卷"
+
+#: pkg/kubernetes/views/pod-body.html:18 pkg/kubernetes/views/node-panel.html:7
+#: pkg/kubernetes/views/containers-listing.html:15
+#: pkg/kubernetes/views/node-page.html:14
+#: pkg/kubernetes/views/topology-page.html:41
+msgid "Node"
+msgstr "节点"
+
+#: pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:192
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:45
+msgid "Nodes"
+msgstr "节点"
+
+#: pkg/kubernetes/views/topology-page.html:42
+msgid "Nodes are the machines that run your containers."
+msgstr "节点是运行容器的主机。"
+
+#: pkg/kubernetes/views/service-body.html:15
+#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
+#: pkg/kubernetes/views/image-config.html:25
+#: pkg/kubernetes/views/imagestream-body.html:33
+msgid "None"
+msgstr "无"
+
+#: pkg/playground/translate.html:30 pkg/kubernetes/views/details-page.html:53
+#: pkg/kubernetes/views/node-body.html:42
+msgid "Not Ready"
+msgstr "未就绪"
+
+#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
+msgid "Not a valid number of replicas"
+msgstr "副本不是一个有效数字"
+
+#: pkg/lib/credentials.js:248
+msgid "Not a valid private key"
+msgstr "无效的私钥"
+
+#: pkg/kubernetes/scripts/details.js:546
+msgid "Not a valid value for Host"
+msgstr "无效的主机值"
+
+#: pkg/docker/index.html:57
+msgid "Not authorized to access Docker on this system"
+msgstr "未授权访问该系统的 Docker"
+
+#: pkg/ostree/app.js:81
+msgid "Not authorized to update software on this system"
+msgstr "未授权更新该系统上的软件"
+
+#: pkg/networkmanager/interfaces.js:805
+msgid "Not available"
+msgstr "不可用"
+
+#: pkg/selinux/setroubleshoot.js:238
+msgid "Not connected"
+msgstr "未连接"
+
+#: pkg/kubernetes/views/details-page.html:122
+msgid "Not deployed"
+msgstr "未部署"
+
+#: pkg/docker/details.js:177 pkg/docker/image.js:112
+#: pkg/storaged/details.js:1822
+msgid "Not found"
+msgstr "未找到"
+
+#: src/base1/cockpit.js:3691
+msgid "Not permitted to perform this action."
+msgstr "不允许执行该动作。"
+
+#: pkg/storaged/details.js:1574
+msgid "Not running"
+msgstr "未运行"
+
+#: pkg/systemd/index.html:62
+msgid "Not synchronized"
+msgstr "未同步"
+
+#: pkg/systemd/services.html:299
+msgid "Note"
+msgstr "注意"
+
+#: pkg/systemd/logs.html:49
+msgid "Notices"
+msgstr "通知"
+
+#: pkg/kubernetes/views/node-body.html:13
+msgid "OS"
+msgstr "操作系统"
+
+#: pkg/ostree/client.js:500
+msgid "OS $0 not found"
+msgstr "未找到操作系统 $0"
+
+#: pkg/kubernetes/views/nodes-page.html:19
+msgid "OS Versions"
+msgstr "操作系统版本"
+
+#: pkg/ostree/app.js:83
+msgid "OSTree is not available on this system"
+msgstr "该系统上 OSTree  不可用"
+
+#: pkg/selinux/setroubleshoot-view.jsx:405
+msgid "Occurred $0"
 msgstr ""
 
-#: pkg/docker/storage.jsx:282
-msgid "Information about the Docker storage pool is not available."
+#: pkg/selinux/setroubleshoot-view.jsx:400
+msgid "Occurred between $0 and $1"
 msgstr ""
 
-#: pkg/docker/storage.jsx:314
-msgid "Total"
+#: pkg/systemd/index.html:157 pkg/playground/jquery-patterns.html:95
+#: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:189
+#: pkg/storaged/index.html:565
+msgid "Off"
+msgstr "关"
+
+#: pkg/lib/cockpit-components-dialog.jsx:155
+msgid "Ok"
 msgstr ""
+
+#: pkg/users/index.html:226 pkg/shell/index.html:248
+msgid "Old Password"
+msgstr "旧密码"
+
+#: pkg/users/local.js:78 pkg/lib/credentials.js:213
+msgid "Old password not accepted"
+msgstr "旧密码不被接受"
+
+#: pkg/systemd/index.html:153 pkg/playground/jquery-patterns.html:91
+#: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:185
+#: pkg/storaged/index.html:564
+msgid "On"
+msgstr "开"
+
+#: pkg/kubernetes/views/image-meta.html:7
+msgid "On Build"
+msgstr "构建中"
+
+#: pkg/docker/index.html:568
+msgid "On Failure"
+msgstr "失败时"
+
+#: pkg/docker/util.js:104
+msgid "On failure, retry $0 time"
+msgid_plural "On failure, retry $0 times"
+msgstr[0] "失败时, 重试 $0 次"
+
+#: pkg/realmd/operation.html:71
+msgid "One Time Password"
+msgstr "一次性密码"
+
+#: pkg/systemd/init.js:1147
+msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
+msgstr ""
+
+#: pkg/shell/simple.html:28 pkg/shell/index.html:28 pkg/shell/stub.html:28
+msgid "Ooops!"
+msgstr "糟糕！"
+
+#: pkg/systemd/index.html:89 pkg/ostree/index.html:111
+#: pkg/kubernetes/views/nodes-page.html:42
+msgid "Operating System"
+msgstr "操作系统"
+
+#: pkg/ostree/index.html:186
+msgid "Operating System Updates"
+msgstr "操作系统更新"
+
+#: pkg/storaged/jobs.js:166
+msgid "Operation '$operation' on $target"
+msgstr "在 $target 操作 '$operation'"
+
+#: pkg/storaged/overview.js:189
+msgctxt "storage"
+msgid "Optical Drive"
+msgstr "光盘驱动器"
+
+#: pkg/kubernetes/views/volume-body.html:130
+msgid "Options"
+msgstr "选项"
+
+#: pkg/subscriptions/subscriptions-register.jsx:176
+#, fuzzy
+msgid "Organization"
+msgstr "转换"
+
+#: pkg/storaged/details.js:1253
+msgctxt "storage-id-desc"
+msgid "Other Data"
+msgstr "其他数据"
+
+#: pkg/storaged/index.html:202
+msgid "Other Devices"
+msgstr "其他设备"
+
+#: pkg/docker/index.html:319 pkg/kubernetes/registry.html:42
+#: pkg/kubernetes/index.html:39
+msgid "Overview"
+msgstr "概览"
+
+#: pkg/storaged/details.js:203 pkg/storaged/details.js:342
+msgid "Overwrite existing data with zeros"
+msgstr "使用 0 覆盖已存在数据"
+
+#: pkg/kubernetes/views/volume-body.html:4
+msgid "PD Name"
+msgstr "持久盘名称"
+
+#: pkg/ostree/index.html:100
+msgid "Packages"
+msgstr "软件包"
+
+#: pkg/networkmanager/index.html:133
+msgid "Parent"
+msgstr "父接口"
+
+#: pkg/networkmanager/interfaces.js:2619
+msgid "Parent $parent"
+msgstr "父接口 $parent"
+
+#: pkg/networkmanager/interfaces.js:1372
+msgid "Part of "
+msgstr "部分"
+
+#: pkg/kubernetes/views/volume-body.html:8
+#: pkg/kubernetes/views/volume-body.html:18
+msgid "Partition"
+msgstr "分区"
+
+#: pkg/storaged/details.js:346
+msgid "Partitioning"
+msgstr "分区"
+
+#: pkg/networkmanager/interfaces.js:1848
+msgid "Passive"
+msgstr ""
+
+#: pkg/storaged/details.js:221 pkg/storaged/details.js:476
+msgid "Passphrase"
+msgstr "口令"
+
+#: pkg/storaged/details.js:224
+#, fuzzy
+msgid "Passphrase cannot be empty"
+msgstr "口令不能为空"
+
+#: pkg/storaged/details.js:232
+msgid "Passphrases do not match"
+msgstr "口令不匹配"
+
+#: pkg/users/index.html:115 pkg/users/index.html:160 pkg/shell/index.html:199
+#: pkg/shell/index.html:212 pkg/kubernetes/views/auth-form.html:105
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+msgid "Password"
+msgstr "密码"
+
+#: pkg/users/local.js:259
+msgid "Password is not acceptable"
+msgstr "不接受该密码"
+
+#: pkg/users/local.js:247
+msgid "Password is too weak"
+msgstr "密码太弱"
+
+#: pkg/lib/credentials.js:278
+msgid "Password not accepted"
+msgstr "密码未接受"
+
+#: pkg/kubernetes/views/pv-modify.html:126
+#: pkg/kubernetes/views/volume-body.html:37
+#: pkg/kubernetes/views/volume-body.html:49
+#: pkg/kubernetes/views/volume-body.html:101
+msgid "Path"
+msgstr "路径"
+
+#: pkg/networkmanager/index.html:259
+msgid "Path cost"
+msgstr "路径开销"
+
+#: pkg/networkmanager/interfaces.js:2601
+msgid "Path cost $path_cost"
+msgstr "路径开销 $path_cost"
+
+#: pkg/systemd/services.html:56
+msgid "Paths"
+msgstr "路径"
+
+#: pkg/kubernetes/views/volumes-page.html:53
+msgid "Pending Volume Claims"
+msgstr "挂起的卷声明"
+
+#: pkg/systemd/index.html:143
+msgid "Performance Profile"
+msgstr "性能配置集"
+
+#: pkg/kubernetes/views/volumes-page.html:14
+msgid "Persistent Volumes"
+msgstr "持久卷"
+
+#: pkg/kubernetes/views/pod-body.html:16
+msgid "Phase"
+msgstr "阶段"
+
+#: pkg/storaged/index.html:641
+msgid "Physical Volumes"
+msgstr "物理卷"
+
+#: pkg/networkmanager/index.html:405
+#, fuzzy
+msgid "Ping Interval"
+msgstr "监控间隔"
+
+#: pkg/networkmanager/index.html:414
+#, fuzzy
+msgid "Ping Target"
+msgstr "目标"
+
+#: pkg/docker/containers-view.jsx:166 pkg/docker/details.js:271
+#: pkg/docker/image.js:151 pkg/storaged/details.js:625
+#: pkg/storaged/details.js:821 pkg/storaged/details.js:1016
+msgid "Please confirm deletion of $0"
+msgstr "请确认删除 $0"
+
+#: pkg/docker/util.js:501
+msgid "Please confirm forced deletion of $0"
+msgstr "请确认强制删除 $0"
+
+#: pkg/kubernetes/scripts/dashboard.js:441
+msgid "Please create another namespace for $0 \"$1\""
+msgstr "请重新为 $0 创建一个命名空间 \"$1\""
+
+#: pkg/kubernetes/scripts/volumes.js:574
+msgid "Please provide a GlusterFS volume name"
+msgstr "请提供一个 GlusterFS 卷名称"
+
+#: pkg/kubernetes/scripts/connection.js:554
+msgid "Please provide a username"
+msgstr "请提供一个用户名"
+
+#: pkg/kubernetes/scripts/volumes.js:632
+msgid "Please provide a valid NFS server"
+msgstr "请提供一个有效的 NFS 服务器"
+
+#: pkg/kubernetes/scripts/connection.js:539
+msgid "Please provide a valid address"
+msgstr "请提供一个有效的地址"
+
+#: pkg/kubernetes/scripts/volumes.js:805
+msgid "Please provide a valid filesystem type"
+msgstr "请提供一个有效的文件系统类型"
+
+#: pkg/kubernetes/scripts/volumes.js:813
+msgid "Please provide a valid interface"
+msgstr "请提供一个有效的接口"
+
+#: pkg/kubernetes/scripts/volumes.js:797
+msgid "Please provide a valid logical unit number"
+msgstr "请提供一个有效的逻辑单元编号"
+
+#: pkg/kubernetes/scripts/volumes.js:477
+msgid "Please provide a valid name"
+msgstr "请提供有效的名称"
+
+#: pkg/kubernetes/scripts/dashboard.js:376
+msgid "Please provide a valid namespace."
+msgstr "请提供有效的命名空间."
+
+#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
+msgid "Please provide a valid path"
+msgstr "请提供一个有效的路径"
+
+#: pkg/kubernetes/scripts/volumes.js:789
+msgid "Please provide a valid qualified name"
+msgstr "请提供一个有效的限定名"
+
+#: pkg/kubernetes/scripts/volumes.js:485
+msgid "Please provide a valid storage capacity."
+msgstr "请提供有效的存储容量。"
+
+#: pkg/kubernetes/scripts/volumes.js:781
+msgid "Please provide a valid target"
+msgstr "请提供一个有效的目标"
+
+#: pkg/kubernetes/scripts/volumes.js:469
+msgid "Please select a valid access mode"
+msgstr "请选择有效的访问模式"
+
+#: pkg/kubernetes/scripts/volumes.js:565
+msgid "Please select a valid endpoint"
+msgstr "请选择有效的端点"
+
+#: pkg/kubernetes/scripts/volumes.js:493
+msgid "Please select a valid policy option."
+msgstr "请选择有效的策略选项。"
+
+#: pkg/kubernetes/scripts/nodes.js:397
+msgid "Please type an address"
+msgstr "请输入一个地址"
+
+#: pkg/kubernetes/views/pod-page.html:12
+#: pkg/kubernetes/views/containers-listing.html:12
+#: pkg/kubernetes/views/topology-page.html:14
+msgid "Pod"
+msgstr "容器舱"
+
+#: pkg/kubernetes/views/pod-body.html:20
+msgid "Pod Address"
+msgstr "容器舱地址"
+
+#: pkg/kubernetes/views/service-endpoint.html:4
+#: pkg/kubernetes/views/service-endpoint.html:9
+msgid "Pod Endpoints"
+msgstr "容器舱端点"
+
+#: pkg/kubernetes/views/replicationcontroller-pods.html:4
+msgid "Pod Replicated"
+msgstr "复制的容器舱"
+
+#: pkg/kubernetes/views/service-endpoint.html:15
+#: pkg/kubernetes/views/replicationcontroller-pods.html:11
+msgid "Pod Selector"
+msgstr "容器舱选择器"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:17
+#: pkg/kubernetes/views/dashboard-page.html:18
+#: pkg/kubernetes/views/details-page.html:166
+#: pkg/kubernetes/views/pv-claim.html:37
+#: pkg/kubernetes/views/replicationcontroller-panel.html:12
+msgid "Pods"
+msgstr "容器舱"
+
+#: pkg/kubernetes/views/topology-page.html:15
+#, fuzzy
+msgid ""
+"Pods contain one or more containers that run                together on a "
+"node, containing your application code."
+msgstr ""
+"容器舱包含运行在一个节点上的一个或多个容器，\n"
+"                包含应用代码。"
+
+#: pkg/kubernetes/views/volume-body.html:60
+msgid "Pool Name"
+msgstr "池名称"
+
+#: pkg/storaged/utils.js:166
+msgid "Pool for Thin Logical Volumes"
+msgstr "稀疏逻辑卷池"
+
+#: pkg/storaged/details.js:874
+msgid "Pool for thinly provisioned volumes"
+msgstr "池的瘦分配配置卷"
+
+#: pkg/kubernetes/views/imagestream-modify.html:45
+msgid "Populate"
+msgstr "填入"
+
+#: pkg/lib/machine-change-port.html:23
+msgid "Port"
+msgstr "端口"
+
+#: pkg/docker/index.html:525 pkg/kubernetes/views/service-body.html:13
+#: pkg/kubernetes/views/image-config.html:23
+#: pkg/kubernetes/views/container-body.html:12
+#: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:373
+msgid "Ports"
+msgstr "端口"
+
+#: pkg/systemd/index.html:123
+msgid "Power Options"
+msgstr "电源选项"
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length"
+msgstr "前缀长度"
+
+#: pkg/networkmanager/interfaces.js:3008
+msgid "Prefix length or Netmask"
+msgstr "前缀长度或网络掩码"
+
+#: pkg/networkmanager/interfaces.js:809
+msgid "Preparing"
+msgstr "准备中"
+
+#: pkg/systemd/init.js:544
+msgid "Preset"
+msgstr "预置"
+
+#: pkg/systemd/init.js:545
+msgid "Preset Forcefully"
+msgstr "强制预设"
+
+#: pkg/systemd/index.html:310
+msgid "Pretty Host Name"
+msgstr "短主机名"
+
+#: pkg/networkmanager/index.html:307
+msgid "Primary"
+msgstr "主"
+
+#: pkg/storaged/details.js:1426
+msgid "Primary Partition"
+msgstr "主分区"
+
+#: pkg/networkmanager/index.html:250 pkg/networkmanager/index.html:446
+#: pkg/networkmanager/index.html:464
+msgid "Priority"
+msgstr "优先级"
+
+#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
+msgid "Priority $priority"
+msgstr "优先级 $priority"
+
+#: pkg/subscriptions/subscriptions-view.jsx:33
+msgid "Product ID"
+msgstr "产品 ID"
+
+#: pkg/subscriptions/subscriptions-view.jsx:32
+msgid "Product name"
+msgstr "产品名"
+
+#: pkg/kubernetes/views/service-body.html:4
+#: pkg/kubernetes/views/replicationcontroller-body.html:4
+#: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/imagestream-modify.html:21
+#: pkg/kubernetes/views/pod-body.html:4
+#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/details-page.html:35
+#: pkg/kubernetes/views/details-page.html:71
+#: pkg/kubernetes/views/details-page.html:104
+#: pkg/kubernetes/views/details-page.html:138
+#: pkg/kubernetes/views/details-page.html:172
+#: pkg/kubernetes/views/containers-listing.html:13
+#: pkg/kubernetes/views/route-body.html:4
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
+msgid "Project"
+msgstr "项目"
+
+#: pkg/kubernetes/views/project-body.html:20
+msgid "Project Members"
+msgstr "项目成员"
+
+#: pkg/kubernetes/views/filter-project.html:5
+msgid "Project:"
+msgstr "项目:"
+
+#: pkg/kubernetes/registry.html:54 pkg/kubernetes/views/group-delete.html:10
+#: pkg/kubernetes/views/project-listing.html:9
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:84
+msgid "Projects"
+msgstr "项目"
+
+#: pkg/users/local.js:82
+msgid "Prompting via passwd timed out"
+msgstr "passwd 提示已超时"
+
+#: pkg/lib/credentials.js:251
+msgid "Prompting via ssh-add timed out"
+msgstr "通过 ssh-add 提示超时"
+
+#: pkg/lib/credentials.js:191
+msgid "Prompting via ssh-keygen timed out"
+msgstr "通过 ssh-keygen 提示超时"
+
+#: pkg/subscriptions/subscriptions-register.jsx:125
+msgid "Proxy"
+msgstr ""
+
+#: pkg/kubernetes/views/node-body.html:25
+msgid "Proxy Version"
+msgstr "代理版本"
+
+#: pkg/shell/index.html:198 pkg/lib/machine-auth-failed.html:9
+msgid "Public Key"
+msgstr "公钥"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:150
+msgid "Pull an image:"
+msgstr "拉取镜像:"
+
+#: pkg/kubernetes/views/imagestream-modify.html:66
+msgid "Pull from"
+msgstr "拉取自"
+
+#: pkg/kubernetes/views/imagestream-body.html:31
+msgid "Pull repository"
+msgstr "拉取仓库"
+
+#: pkg/storaged/details.js:869
+msgid "Purpose"
+msgstr "目的"
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:140
+msgid "Push an image:"
+msgstr "推送镜像:"
+
+#: pkg/kubernetes/views/pv-modify.html:147
+#: pkg/kubernetes/views/volume-body.html:77
+msgid "Qualified Name"
+msgstr "限定名"
+
+#: pkg/storaged/details.js:1539
+msgid "RAID ($0)"
+msgstr "RAID ($0)"
+
+#: pkg/storaged/details.js:1533
+msgid "RAID 0"
+msgstr "RAID 0"
+
+#: pkg/storaged/overview.js:422
+msgid "RAID 0 (Stripe)"
+msgstr "RAID 0 (条带)"
+
+#: pkg/storaged/details.js:1534
+msgid "RAID 1"
+msgstr "RAID 1"
+
+#: pkg/storaged/overview.js:423
+msgid "RAID 1 (Mirror)"
+msgstr "RAID 1 (镜像)"
+
+#: pkg/storaged/details.js:1538
+msgid "RAID 10"
+msgstr "RAID 10"
+
+#: pkg/storaged/overview.js:427
+msgid "RAID 10 (Stripe of Mirrors)"
+msgstr "RAID 10 (条带镜像)"
+
+#: pkg/storaged/details.js:1535
+msgid "RAID 4"
+msgstr "RAID 4"
+
+#: pkg/storaged/overview.js:424
+msgid "RAID 4 (Dedicated Parity)"
+msgstr "RAID 4 (奇偶校验)"
+
+#: pkg/storaged/details.js:1536
+msgid "RAID 5"
+msgstr "RAID 5"
+
+#: pkg/storaged/overview.js:425
+msgid "RAID 5 (Distributed Parity)"
+msgstr "RAID 5 (奇偶校验)"
+
+#: pkg/storaged/details.js:1537
+msgid "RAID 6"
+msgstr "RAID 6"
+
+#: pkg/storaged/overview.js:426
+msgid "RAID 6 (Double Distributed Parity)"
+msgstr "RAID 6 (双倍奇偶校验)"
+
+#: pkg/storaged/index.html:537
+msgid "RAID Device"
+msgstr "RAID 设备"
+
+#: pkg/storaged/utils.js:233
+msgid "RAID Device $0"
+msgstr "RAID 设备 $0"
+
+#: pkg/storaged/index.html:65
+msgid "RAID Devices"
+msgstr "RAID 设备"
+
+#: pkg/storaged/overview.js:420
+msgid "RAID Level"
+msgstr "RAID 级别"
+
+#: pkg/storaged/index.html:555
+msgctxt "storage"
+msgid "RAID Level"
+msgstr "RAID 级别"
+
+#: pkg/storaged/details.js:1228
+msgctxt "storage-id-desc"
+msgid "RAID Member"
+msgstr "RAID 成员"
+
+#: pkg/kubernetes/scripts/volumes.js:200
+msgid "Rados Block Device"
+msgstr "Rados 块设备"
+
+#: pkg/kubernetes/views/pv-modify.html:194
+#: pkg/kubernetes/views/volume-body.html:10
+#: pkg/kubernetes/views/volume-body.html:20
+#: pkg/kubernetes/views/volume-body.html:44
+#: pkg/kubernetes/views/volume-body.html:51
+#: pkg/kubernetes/views/volume-body.html:71
+#: pkg/kubernetes/views/volume-body.html:85
+#: pkg/kubernetes/views/volume-body.html:93
+#: pkg/kubernetes/views/volume-body.html:110
+#: pkg/kubernetes/views/volume-body.html:122
+#: pkg/kubernetes/views/volume-body.html:136
+#: pkg/kubernetes/views/volume-body.html:143
+msgid "Read Only"
+msgstr "只读"
+
+#: pkg/kubernetes/scripts/volumes.js:211
+msgid "Read and write from a single node"
+msgstr "从单节点读和写"
+
+#: pkg/kubernetes/scripts/volumes.js:213
+msgid "Read and write from multiple nodes"
+msgstr "从多节点读和写"
+
+#: pkg/kubernetes/scripts/volumes.js:212
+msgid "Read only from multiple nodes"
+msgstr "仅从多节点读"
+
+#: pkg/docker/index.html:385
+msgid "ReadOnly"
+msgstr "只读"
+
+#: pkg/docker/index.html:384
+msgid "ReadWrite"
+msgstr "读写"
+
+#: pkg/storaged/index.html:327
+msgid "Reading"
+msgstr "读取中"
+
+#: pkg/playground/translate.html:20 pkg/playground/translate.html:179
+#: pkg/kubernetes/views/details-page.html:52
+#: pkg/kubernetes/views/node-body.html:41
+msgid "Ready"
+msgstr "就绪"
+
+#: pkg/playground/translate.html:25
+#, fuzzy
+msgctxt "verb"
+msgid "Ready"
+msgstr "就绪"
+
+#: pkg/systemd/index.html:319
+msgid "Real Host Name"
+msgstr "实际主机名"
+
+#: pkg/kubernetes/views/node-body.html:45
+msgid "Reason"
+msgstr "原因"
+
+#: pkg/lib/journal.js:241
+msgid "Reboot"
+msgstr "重启"
+
+#: pkg/networkmanager/index.html:75 pkg/networkmanager/index.html:98
+#: pkg/networkmanager/index.html:116 pkg/networkmanager/index.html:521
+#: pkg/networkmanager/index.html:551
+msgid "Receiving"
+msgstr "接收中"
+
+#: pkg/ostree/client.js:56
+msgid "Receiving delta parts"
+msgstr "正在接收增量部分"
+
+#: pkg/ostree/client.js:58
+msgid "Receiving metadata objects"
+msgstr "正在接收元数据对象"
+
+#: pkg/ostree/client.js:61
+msgid "Receiving objects: $0%"
+msgstr "正在接收对象: $0%"
+
+#: pkg/systemd/logs.html:40
+msgid "Recent"
+msgstr "最近"
+
+#: pkg/kubernetes/views/pv-modify.html:56 pkg/kubernetes/views/pv-body.html:6
+msgid "Reclaim Policy"
+msgstr "重新声明策略"
+
+#: pkg/shell/simple.html:144 pkg/shell/index.html:327 pkg/shell/stub.html:180
+msgid "Reconnect"
+msgstr "重新连接"
+
+#: pkg/storaged/details.js:1594
+msgid "Recovering"
+msgstr "恢复"
+
+#: pkg/storaged/jobs.js:145
+#, fuzzy
+msgid "Recovering RAID Device $target"
+msgstr "停止 RAID 设备 $target"
+
+#: pkg/kubernetes/scripts/volumes.js:219
+msgid "Recycle"
+msgstr "回收"
 
 #: pkg/docker/storage.jsx:348
 msgid "Reformat and add disks"
 msgstr ""
 
-#: pkg/docker/storage.jsx:355
-msgid ""
-"The storage pool will be reset to optimize its layout.  All containers will "
-"be erased."
-msgstr ""
+#: pkg/kubernetes/views/pv-modify.html:205
+msgid "Register"
+msgstr "注册"
 
-#: pkg/docker/storage.jsx:360
-msgid "Erase containers, reformat disks, and add them"
-msgstr ""
+#: pkg/kubernetes/views/volumes-page.html:12
+msgid "Register New Volume"
+msgstr "注册新卷"
 
-#: pkg/docker/storage.jsx:363
+#: pkg/kubernetes/views/pv-modify.html:4
+msgid "Register Persistent Volume"
+msgstr "注册持久卷"
+
+#: pkg/subscriptions/main.js:74
+msgid "Register system"
+msgstr "注册系统"
+
+#: pkg/ostree/index.html:115
+msgid "Released"
+msgstr "发布于"
+
+#: pkg/systemd/init.js:518
+msgid "Reload"
+msgstr "重载"
+
+#: pkg/systemd/init.js:519
+msgid "Reload or Restart"
+msgstr "重载或重启"
+
+#: pkg/systemd/init.js:521
+msgid "Reload or Try Restart"
+msgstr "重载或尝试重启"
+
+#: pkg/kubernetes/views/imagestream-modify.html:89
+msgid "Remote registry is insecure"
+msgstr "远程注册表不安全"
+
+#: cockpit.desktop.in.h:3
+msgid "Remote;Administration;"
+msgstr "Remote;Administration;"
+
+#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
+msgctxt "storage"
+msgid "Removable Drive"
+msgstr "可移动驱动器"
+
+#: pkg/ostree/index.html:123 pkg/ostree/index.html:146
+msgid "Removals"
+msgstr "移除"
+
+#: pkg/kubernetes/views/user-group-remove.html:10
+#: pkg/kubernetes/views/group-delete.html:21
+#: pkg/kubernetes/views/user-delete.html:25
+#: pkg/kubernetes/views/remove-role-dialog.html:8
+msgid "Remove"
+msgstr "删除"
+
+#: pkg/networkmanager/interfaces.js:2791
 #, fuzzy
-msgid "Add Additional Storage"
-msgstr "额外的存储"
+msgid "Remove $0"
+msgstr "删除"
 
-#: pkg/docker/storage.jsx:366
-msgid ""
-"All data on selected disks will be erased and disks will be added to the "
-"storage pool."
+#: pkg/kubernetes/views/group-delete.html:3
+msgid "Remove Group"
+msgstr "移除组"
+
+#: pkg/kubernetes/views/user-group-remove.html:3
+msgid "Remove Member"
+msgstr "移除成员"
+
+#: pkg/kubernetes/views/remove-role-dialog.html:3
+msgid "Remove Role"
+msgstr "移除角色"
+
+#: pkg/kubernetes/views/user-delete.html:3
+msgid "Remove User"
+msgstr "移除用户"
+
+#: pkg/kubernetes/views/image-delete.html:3
+msgid "Remove image tag"
+msgstr "移除镜像标记"
+
+#: pkg/kubernetes/views/user-remove-membership.html:3
+msgid "Remove membership"
+msgstr "移除成员关系"
+
+#: pkg/storaged/jobs.js:141
+msgid "Removing $target from RAID Device"
+msgstr "从 RAID 设备中删除 $target"
+
+#: pkg/networkmanager/interfaces.js:2788
+msgid "Removing <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/docker/storage.jsx:404
+#: pkg/storaged/jobs.js:154
+msgid "Removing physical volume from $target"
+msgstr "从 $target 删除物理卷"
+
+#: pkg/storaged/details.js:714 pkg/storaged/details.js:1120
+#: pkg/storaged/details.js:1775
+msgid "Rename"
+msgstr "重命名"
+
+#: pkg/storaged/details.js:795
+msgid "Rename Volume Group"
+msgstr "重命名卷组"
+
+#: pkg/storaged/details.js:706
+msgid "Renamee Logical Volume"
+msgstr "重命名逻辑卷"
+
+#: pkg/storaged/jobs.js:157
+msgid "Renaming $target"
+msgstr "重命名 $target"
+
+#: pkg/systemd/services.html:432
+msgid "Repeat Daily"
+msgstr ""
+
+#: pkg/systemd/services.html:431
+msgid "Repeat Hourly"
+msgstr ""
+
+#: pkg/systemd/services.html:434
+msgid "Repeat Monthly"
+msgstr ""
+
+#: pkg/systemd/services.html:433
+msgid "Repeat Weekly"
+msgstr ""
+
+#: pkg/systemd/services.html:435
+msgid "Repeat Yearly"
+msgstr ""
+
+#: pkg/kubernetes/views/replicationcontroller-body.html:9
+#: pkg/kubernetes/views/details-page.html:141
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
+#: pkg/kubernetes/views/replicationcontroller-modify.html:8
+msgid "Replicas"
+msgstr "复用"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:14
+#: pkg/kubernetes/views/replicationcontroller-panel.html:10
+#: pkg/kubernetes/views/topology-page.html:23
+msgid "Replication Controller"
+msgstr "复制控制器"
+
+#: pkg/kubernetes/views/details-page.html:132
+msgid "Replication Controllers"
+msgstr "复制控制器"
+
+#: pkg/kubernetes/views/topology-page.html:24
 #, fuzzy
-msgid "Could not add all disks"
-msgstr "无法罗列服务"
+msgid ""
+"Replication controllers dynamically create instances of                pods "
+"from templates, and remove pods when necessary."
+msgstr ""
+"复制控制器动态从模板创建容器舱实例，\n"
+"                并在必要的时候移除容器舱。"
+
+#: pkg/docker/index.html:718
+msgid "Repository"
+msgstr "存储库"
+
+#: pkg/kubernetes/views/volume-body.html:24
+msgid "Repository URL"
+msgstr "仓库网址"
+
+#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
+msgid "Requested"
+msgstr "请求的"
+
+#: pkg/kubernetes/views/pv-claim.html:13
+msgid "Requests"
+msgstr "请求"
+
+#: pkg/kubernetes/views/auth-form.html:54
+msgid "Requires Authentication"
+msgstr "需要认证"
+
+#: pkg/docker/index.html:323
+msgid "Reset"
+msgstr "重置"
 
 #: pkg/docker/storage.jsx:417
 #, fuzzy
@@ -2092,381 +4709,601 @@ msgid ""
 "the pool."
 msgstr ""
 
-#: pkg/docker/storage.jsx:423
-msgid "Erase containers and reset storage pool"
+#: pkg/storaged/details.js:681 pkg/storaged/details.js:1119
+msgid "Resize"
+msgstr "调整大小"
+
+#: pkg/storaged/details.js:673
+msgid "Resize Filesystem"
+msgstr "调整文件系统大小"
+
+#: pkg/storaged/details.js:661
+msgid "Resize Logical Volume"
+msgstr "调整逻辑卷大小"
+
+#: pkg/storaged/jobs.js:158
+msgid "Resizing $target"
+msgstr "调整大小 $target"
+
+#: pkg/systemd/index.html:126 pkg/systemd/index.html:133
+msgid "Restart"
+msgstr "重启"
+
+#: pkg/kubernetes/views/container-body.html:20
+msgid "Restart Count"
+msgstr "重启次数"
+
+#: pkg/docker/index.html:558 pkg/kubernetes/views/pod-body.html:10
+msgid "Restart Policy"
+msgstr "重启策略"
+
+#: pkg/kubernetes/scripts/volumes.js:217
+msgid "Retain"
+msgstr "留存"
+
+#: pkg/docker/index.html:574
+msgid "Retries:"
+msgstr "重试次数:"
+
+#: pkg/subscriptions/subscriptions-view.jsx:188
+msgid "Retrieving subscription status..."
 msgstr ""
 
-#: pkg/docker/storage.jsx:446
-msgid "Could not reset the storage pool"
-msgstr ""
-
-#: pkg/docker/storage.jsx:482
-#, fuzzy
-msgid "You don't have permission to manage the Docker storage pool."
-msgstr "您没有权限查看此帐户的授权公钥."
-
-#: pkg/docker/storage.jsx:485
-#, fuzzy
-msgid "The Docker storage pool cannot be managed on this system."
-msgstr "在此系统中, \"storaged\" API 不可用."
-
-#: pkg/docker/image.js:77
-msgid "Image $0"
-msgstr "镜像 $0"
-
-#: pkg/docker/image.js:152
-msgid ""
-"Deleting an image will delete it, but you can probably download it again if "
-"you need it later.  Unless this image has never been pushed to a repository, "
-"that is, in which case you probably can't download it again."
-msgstr ""
-"这将删除镜像, 如果以后需要, 可以重新下载.除非该镜像未推送至镜像库, 镜像库未包"
-"含的镜像, 无法再次下载."
-
-#: pkg/docker/util.js:94
-msgid "Up since $StartedAt"
-msgstr "运行自 $StartedAt"
-
-#: pkg/docker/util.js:96
-msgid "Exited $ExitCode"
-msgstr "已退出 $ExitCode"
-
-#: pkg/docker/util.js:104
-msgid "On failure, retry $0 time"
-msgid_plural "On failure, retry $0 times"
-msgstr[0] "失败时, 重试 $0 次"
-
-#: pkg/docker/util.js:107 pkg/docker/index.html.h:48
-msgid "Always"
-msgstr "通常"
-
-#: pkg/docker/util.js:109 pkg/docker/index.html.h:49
-msgid "Unless Stopped"
-msgstr "直到被停止"
-
-#: pkg/docker/util.js:123
-msgid "default"
-msgstr "默认"
-
-#: pkg/docker/util.js:124
-msgid "$0 shares"
-msgstr "$0 共享"
-
-#: pkg/docker/util.js:231
-msgid "Stopped"
-msgstr "已停止"
-
-#: pkg/docker/util.js:488
-msgid "Container is currently running."
-msgstr "当前容器正在运行。"
-
-#: pkg/docker/util.js:490
-msgid ""
-"Container is currently marked as not running, but regular stopping failed."
-msgstr "容器当前标记为未运行, 但正常停止失败."
-
-#: pkg/docker/util.js:491
-msgid "Error message from Docker:"
-msgstr "来自 Docker 的错误消息："
-
-#: pkg/docker/util.js:501
-msgid "Please confirm forced deletion of $0"
-msgstr "请确认强制删除 $0"
-
-#: pkg/docker/util.js:503
-msgid "Force Delete"
-msgstr "强制删除"
-
-#: pkg/docker/util.js:544
-msgid "Failed to stop Docker scope: $0"
-msgstr "无法停止 Docker 范围: $0"
-
-#: pkg/docker/containers-view.jsx:239
-#, fuzzy
-msgid "Commit"
-msgstr "说明"
-
-#: pkg/docker/containers.js:64
-msgid "Failed to start Docker: $0"
-msgstr "启动 Docker 失败： $0"
-
-#: pkg/users/authorized-keys.js:103
-msgid "Validating key"
-msgstr "验证 key"
-
-#: pkg/users/authorized-keys.js:108
-msgid "Adding key"
-msgstr "添加 key"
-
-#: pkg/users/authorized-keys.js:115
-msgid "Error saving authorized keys: "
-msgstr "保存授权密钥时出错: "
-
-#: pkg/users/authorized-keys.js:118
-msgid "The key you provided was not valid."
-msgstr "您提供的 key 是无效的."
-
-#: pkg/users/local.js:40
-msgid "The user <b>$0</b> is not permitted to modify accounts"
-msgstr "用户 <b>$0</b> 不允许修改账户"
-
-#: pkg/users/local.js:57
-msgid "Unable to delete root account"
-msgstr "不能删除 root 账户"
-
-#: pkg/users/local.js:59
-msgid "Unable to rename root account"
-msgstr "不能重命名 root 账户"
-
-#: pkg/users/local.js:82
-msgid "Prompting via passwd timed out"
-msgstr "passwd 提示已超时"
-
-#: pkg/users/local.js:247
-msgid "Password is too weak"
-msgstr "密码太弱"
-
-#: pkg/users/local.js:259
-msgid "Password is not acceptable"
-msgstr "不接受该密码"
-
-#: pkg/users/local.js:284 pkg/users/local.js:594
-msgctxt "page-title"
-msgid "Accounts"
-msgstr "账户"
-
-#: pkg/users/local.js:395 pkg/users/local.js:1082
-msgid "The passwords do not match"
-msgstr "密码不匹配"
-
-#: pkg/users/local.js:400
-msgid "No user name specified"
-msgstr "未指定用户名"
-
-#: pkg/users/local.js:405
-msgid "No real name specified"
-msgstr "未指定真实姓名"
-
-#: pkg/users/local.js:429 pkg/users/local.js:1104
-msgid "Excellent password"
-msgstr "密码强度良好"
-
-#: pkg/users/local.js:501
-msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
-msgstr "用户名仅能包含 a-z、数字、点、破折号和下划线的字母。"
-
-#: pkg/users/local.js:509
-msgid "This user name already exists"
-msgstr "用户名已存在"
-
-#: pkg/users/local.js:682 pkg/users/local.js:683
-msgid "Server Administrator"
-msgstr "服务器管理员"
-
-#: pkg/users/local.js:684
-msgid "Container Administrator"
-msgstr "容器管理员"
-
-#: pkg/users/local.js:839
-msgid "Logged In"
-msgstr "登录"
-
-#: pkg/users/local.js:841
-msgid "Never"
-msgstr "从不"
-
-#: pkg/users/local.js:1019 pkg/networkmanager/interfaces.js:2159
-msgid "Delete $0"
-msgstr "删除 $0"
-
-#: pkg/sosreport/index.js:49 pkg/sosreport/index.js:113
-#: pkg/systemd/services.html.h:13 pkg/lib/machine-invalid-hostkey.html.h:4
-#: pkg/lib/machine-auth-failed.html.h:7
-#: pkg/lib/machine-unknown-hostkey.html.h:4
-#: pkg/lib/machine-change-port.html.h:8 pkg/lib/machine-not-supported.html.h:3
-#: pkg/shell/index.html.h:37
-msgid "Close"
-msgstr "关闭"
-
-#: pkg/sosreport/index.js:115
-msgid "No archive has been created."
-msgstr "没有档案被创建"
-
-#: pkg/networkmanager/interfaces.js:598 pkg/networkmanager/interfaces.js:1051
-#: pkg/networkmanager/interfaces.js:2255 pkg/networkmanager/interfaces.js:2257
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:753 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/kubernetes/views/node-body.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:6
-#: pkg/kubernetes/views/pv-claim.html.h:7
-#: pkg/kubernetes/views/image-body.html.h:6
-#: pkg/kubernetes/views/pv-body.html.h:5
-msgid "Unknown"
-msgstr "未知"
-
-#: pkg/networkmanager/interfaces.js:805
-msgid "Not available"
-msgstr "不可用"
-
-#: pkg/networkmanager/interfaces.js:807 pkg/networkmanager/interfaces.js:1324
-#: pkg/networkmanager/interfaces.js:1331 pkg/networkmanager/interfaces.js:2292
-msgid "Inactive"
-msgstr "未激活"
-
-#: pkg/networkmanager/interfaces.js:809
-msgid "Preparing"
-msgstr "准备中"
-
-#: pkg/networkmanager/interfaces.js:811
-msgid "Configuring"
-msgstr "配置中"
-
-#: pkg/networkmanager/interfaces.js:813
-msgid "Authenticating"
-msgstr "认证中"
-
-#: pkg/networkmanager/interfaces.js:815
-msgid "Configuring IP"
-msgstr "正在配置 IP"
-
-#: pkg/networkmanager/interfaces.js:817
-msgid "Checking IP"
-msgstr "正在检查 IP"
-
-#: pkg/networkmanager/interfaces.js:819
-msgid "Waiting"
-msgstr "等待中"
-
-#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1849
-msgid "Active"
-msgstr "激活"
-
-#: pkg/networkmanager/interfaces.js:823
-msgid "Deactivating"
-msgstr "停用中"
-
-#: pkg/networkmanager/interfaces.js:825 pkg/ostree/index.html.h:14
-msgid "Failed"
-msgstr "已失败"
-
-#: pkg/networkmanager/interfaces.js:1326
-msgid "No carrier"
-msgstr "无载体"
-
-#: pkg/networkmanager/interfaces.js:1372
-msgid "Part of "
-msgstr "部分"
-
-#: pkg/networkmanager/interfaces.js:1420
-msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr "用户 <b>$0</b> 不允许修改网络设置"
-
-#: pkg/networkmanager/interfaces.js:1481 pkg/networkmanager/interfaces.js:1993
-msgctxt "page-title"
-msgid "Networking"
-msgstr "联网"
-
-#: pkg/networkmanager/interfaces.js:1804
-msgid "Automatic (DHCP)"
-msgstr "自动 (DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1805 pkg/networkmanager/interfaces.js:1815
-msgid "Link local"
-msgstr "本地链路"
-
-#: pkg/networkmanager/interfaces.js:1806 pkg/networkmanager/interfaces.js:1816
-msgid "Manual"
-msgstr "手动"
-
-#: pkg/networkmanager/interfaces.js:1807
-msgid "Shared"
-msgstr "共享"
-
-#: pkg/networkmanager/interfaces.js:1813 pkg/networkmanager/interfaces.js:2475
-#: pkg/networkmanager/interfaces.js:3019 pkg/networkmanager/interfaces.js:3023
-#: pkg/networkmanager/interfaces.js:3029 pkg/networkmanager/index.html.h:22
-msgid "Automatic"
-msgstr "自动"
-
-#: pkg/networkmanager/interfaces.js:1814
-msgid "Automatic (DHCP only)"
-msgstr "自动 (仅 DHCP)"
-
-#: pkg/networkmanager/interfaces.js:1817
-msgid "Ignore"
-msgstr "忽略"
+#: pkg/kubernetes/views/volume-body.html:26
+msgid "Revision"
+msgstr "修订"
+
+#: pkg/users/index.html:94 pkg/kubernetes/views/add-member-role-dialog.html:39
+#: pkg/kubernetes/views/project-body.html:21
+msgid "Roles"
+msgstr "角色"
+
+#: pkg/ostree/index.html:73
+msgid "Roll back and reboot"
+msgstr "回滚并重启"
 
 #: pkg/networkmanager/interfaces.js:1822 pkg/networkmanager/interfaces.js:1839
 msgid "Round Robin"
 msgstr "轮循"
 
-#: pkg/networkmanager/interfaces.js:1823 pkg/networkmanager/interfaces.js:1840
-msgid "Active Backup"
-msgstr "主备"
+#: pkg/kubernetes/views/route-page.html:14
+#: pkg/kubernetes/views/route-panel.html:9
+msgid "Route"
+msgstr "路由"
 
-#: pkg/networkmanager/interfaces.js:1824
-msgid "XOR"
-msgstr "XOR"
+#: pkg/kubernetes/views/details-page.html:65
+msgid "Routes"
+msgstr "路由"
 
-#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1842
-msgid "Broadcast"
-msgstr "广播"
-
-#: pkg/networkmanager/interfaces.js:1826
-msgid "802.3ad"
-msgstr "802.3ad"
-
-#: pkg/networkmanager/interfaces.js:1827
-msgid "Adaptive transmit load balancing"
-msgstr "自适应传输负载均衡"
-
-#: pkg/networkmanager/interfaces.js:1828
-msgid "Adaptive load balancing"
-msgstr "自适应负载均衡"
-
-#: pkg/networkmanager/interfaces.js:1833
-msgid "MII (Recommended)"
-msgstr "MII (推荐)"
-
-#: pkg/networkmanager/interfaces.js:1834
-msgid "ARP"
-msgstr "ARP"
-
-#: pkg/networkmanager/interfaces.js:1841
+#: pkg/systemd/services.html:384
 #, fuzzy
-msgid "Load Balancing"
-msgstr "自适应负载均衡"
+msgid "Run"
+msgstr "运行为"
 
-#: pkg/networkmanager/interfaces.js:1843
+#: pkg/kubernetes/views/image-config.html:4
+msgid "Run as"
+msgstr "运行为"
+
+#: pkg/networkmanager/index.html:381
 #, fuzzy
-msgid "802.3ad LACP"
-msgstr "802.3ad"
+msgid "Runner"
+msgstr "运行中"
 
-#: pkg/networkmanager/interfaces.js:1848
-msgid "Passive"
+#: pkg/ostree/index.html:83
+msgid "Running"
+msgstr "运行中"
+
+#: pkg/selinux/setroubleshoot-view.jsx:478
+msgid "SELinux Access Control Errors"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1854
-msgid "Ethtool"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1855
+#: pkg/selinux/setroubleshoot-view.jsx:330
 #, fuzzy
-msgid "ARP Ping"
-msgstr "ARP 监控"
+msgid "SELinux Policy"
+msgstr "DNS 策略"
 
-#: pkg/networkmanager/interfaces.js:1856
-msgid "NSNA Ping"
+#: pkg/selinux/setroubleshoot.html:23
+msgid "SELinux Troubleshoot"
+msgstr "SELinux 排错"
+
+#: pkg/selinux/setroubleshoot-view.jsx:317
+#, fuzzy
+msgid "SELinux is disabled on the system."
+msgstr "Cockpit 未安装在该系统上。"
+
+#: pkg/selinux/setroubleshoot-view.jsx:309
+msgid "SELinux system status is unknown."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2156
-msgid "Deleting <b>$0</b> will break the connection to the server, "
+#: pkg/storaged/jobs.js:119
+msgid "SMART self-test of $target"
+msgstr "$target SMART 自检"
+
+#: pkg/networkmanager/index.html:218
+msgid "STP Forward delay"
+msgstr "STP 转发延迟"
+
+#: pkg/networkmanager/index.html:227
+msgid "STP Hello time"
+msgstr "STP Hello 时间"
+
+#: pkg/networkmanager/index.html:236
+msgid "STP Maximum message age"
+msgstr "STP 最大消息有效期"
+
+#: pkg/networkmanager/index.html:209
+msgid "STP Priority"
+msgstr "STP 优先级"
+
+#: pkg/systemd/services.html:466
+msgid "Save"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2188
-msgid "Switching on <b>$0</b>  will break the connection to the server, "
+#: pkg/ostree/client.js:66
+msgid "Scanning metadata"
+msgstr "正在扫描元数据"
+
+#: pkg/kubernetes/views/node-capacity.html:9
+msgid "Scheduled Pods"
+msgstr "被调度的容器舱"
+
+#: pkg/kubernetes/scripts/nodes.js:322
+msgid "Scheduling Disabled"
+msgstr "调度被禁用"
+
+#: pkg/systemd/services.html:402 pkg/systemd/services.html:406
+msgid "Seconds"
+msgstr ""
+
+#: pkg/kubernetes/scripts/volumes.js:195
+msgid "Secret"
+msgstr "口令"
+
+#: pkg/kubernetes/views/volume-body.html:106
+msgid "Secret File"
+msgstr "口令文件"
+
+#: pkg/kubernetes/views/volume-body.html:141
+msgid "Secret Name"
+msgstr "口令名称"
+
+#: pkg/kubernetes/views/volume-body.html:69
+#: pkg/kubernetes/views/volume-body.html:108
+#: pkg/kubernetes/views/volume-body.html:134
+msgid "Secret Volume"
+msgstr "口令卷"
+
+#: pkg/systemd/index.html:93
+msgid "Secure Shell Keys"
+msgstr "安全 Shell  密钥"
+
+#: pkg/storaged/jobs.js:136
+msgid "Securely erasing $target"
+msgstr "安全擦除 $target"
+
+#: pkg/kubernetes/views/file-button.html:4
+msgid "Select Manifest File..."
+msgstr "选择 Manifest 文件..."
+
+#: pkg/kubernetes/views/topology-page.html:7
+msgid "Select an object to see more details."
+msgstr "选择一个对象来查看更多详情。"
+
+#: pkg/lib/machine-sync-users.html:8
+msgid ""
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
+msgstr "选择你想要与 {{#strong}}{{host}}{{/strong}} 同步的用户"
+
+#: pkg/networkmanager/index.html:69 pkg/networkmanager/index.html:97
+#: pkg/networkmanager/index.html:115 pkg/networkmanager/index.html:515
+#: pkg/networkmanager/index.html:550
+msgid "Sending"
+msgstr "发送中"
+
+#: pkg/storaged/index.html:432
+msgctxt "storage"
+msgid "Serial Number"
+msgstr "串口号"
+
+#: pkg/kubernetes/views/pv-modify.html:82
+#: pkg/kubernetes/views/volume-body.html:47
+msgid "Server"
+msgstr "服务器"
+
+#: pkg/storaged/overview.js:518
+msgid "Server Address"
+msgstr "服务器地址"
+
+#: pkg/users/local.js:682 pkg/users/local.js:683
+msgid "Server Administrator"
+msgstr "服务器管理员"
+
+#: pkg/storaged/overview.js:521
+#, fuzzy
+msgid "Server address cannot be empty."
+msgstr "服务器地址不能为空。"
+
+#: src/base1/cockpit.js:3709
+msgid "Server has closed the connection."
+msgstr "服务器关闭了连接。"
+
+#: pkg/kubernetes/views/service-page.html:12
+#: pkg/kubernetes/views/service-panel.html:8
+#: pkg/kubernetes/views/topology-page.html:32
+msgid "Service"
+msgstr "服务"
+
+#: pkg/kubernetes/views/pod-body.html:12
+msgid "Service Account"
+msgstr "服务账号"
+
+#: pkg/systemd/services.html:279
+msgid "Service Logs"
+msgstr "服务日志"
+
+#: pkg/systemd/services.html:342
+#, fuzzy
+msgid "Service name"
+msgstr "服务"
+
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:272
+#: pkg/kubernetes/views/dashboard-page.html:134
+#: pkg/kubernetes/views/details-page.html:29
+msgid "Services"
+msgstr "服务"
+
+#: pkg/kubernetes/views/topology-page.html:33
+#, fuzzy
+msgid ""
+"Services group pods and provide a common DNS                name and an "
+"optional, load-balanced IP address to access them."
+msgstr ""
+"服务组织容器舱并提供一个通用 DNS\n"
+"                名称和一个可选的负载均衡的 IP 地址来访问它们。"
+
+#: pkg/kubernetes/views/service-body.html:20
+msgid "Session Affinity"
+msgstr "会话关联"
+
+#: pkg/dashboard/index.html:190
+msgid "Set"
+msgstr "设置"
+
+#: pkg/systemd/host.js:559
+msgid "Set Host name"
+msgstr "设置主机名"
+
+#: pkg/users/index.html:117 pkg/users/index.html:221
+msgid "Set Password"
+msgstr "设置密码"
+
+#: pkg/systemd/index.html:395
+msgid "Set Time"
+msgstr "设置时间"
+
+#: pkg/docker/index.html:551
+msgid "Set container environment variables"
+msgstr "设置容器环境变量"
+
+#: pkg/networkmanager/index.html:172
+msgid "Set to"
+msgstr "设置为"
+
+#: pkg/selinux/setroubleshoot-view.jsx:326
+msgid ""
+"Setting deviates from the configured state and will revert on the next boot."
+msgstr ""
+
+#: pkg/storaged/jobs.js:131
+msgid "Setting up loop device $target"
+msgstr "创建 loop 设备 $target"
+
+#: pkg/kubernetes/views/volume-body.html:139
+msgid "Share Name"
+msgstr "共享名称"
+
+#: pkg/networkmanager/interfaces.js:1807
+msgid "Shared"
+msgstr "共享"
+
+#: pkg/kubernetes/views/container-panel.html:9
+#: pkg/kubernetes/views/container-page-inline.html:14
+msgid "Shell"
+msgstr "Shell"
+
+#: pkg/kubernetes/views/container-page.html:4
+msgid "Show all Containers"
+msgstr "显示所有容器"
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:8
+msgid "Show all Deployment Configs"
+msgstr "显示所有部署配置"
+
+#: pkg/kubernetes/views/node-page.html:8
+msgid "Show all Nodes"
+msgstr "显示所有节点"
+
+#: pkg/kubernetes/views/pv-page.html:9
+msgid "Show all Persistent Volumes"
+msgstr "显示所有持久卷"
+
+#: pkg/kubernetes/views/pod-container.html:4
+msgid "Show all Pod Containers"
+msgstr "显示所有容器舱容器"
+
+#: pkg/kubernetes/views/pod-page.html:8
+msgid "Show all Pods"
+msgstr "显示所有容器舱"
+
+#: pkg/kubernetes/views/user-page.html:16
+#: pkg/kubernetes/views/group-page.html:14
+#: pkg/kubernetes/views/project-page.html:23
+msgid "Show all Projects"
+msgstr "显示所有项目"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:10
+msgid "Show all Replication Controllers"
+msgstr "显示所有复制控制器"
+
+#: pkg/kubernetes/views/route-page.html:10
+msgid "Show all Routes"
+msgstr "显示所有路由"
+
+#: pkg/kubernetes/views/service-page.html:8
+msgid "Show all Services"
+msgstr "显示所有服务"
+
+#: pkg/docker/index.html:127
+#, fuzzy
+msgid "Show all containers"
+msgstr "显示所有容器"
+
+#: pkg/kubernetes/views/imagestream-page.html:12
+msgid "Show all image streams"
+msgstr "显示所有镜像流"
+
+#: pkg/docker/index.html:241 pkg/kubernetes/views/image-page.html:11
+msgid "Show all images"
+msgstr "显示所有镜像"
+
+#: pkg/systemd/index.html:94
+msgid "Show fingerprints"
+msgstr "显示指印"
+
+#: pkg/systemd/index.html:136
+msgid "Shutdown"
+msgstr "关机"
+
+#: pkg/kubernetes/views/container-body.html:18
+msgid "Since"
+msgstr "自从"
+
+#: pkg/systemd/init.js:621
+msgid "Since $0"
+msgstr "由于 $0"
+
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/storaged/index.html:232
+msgid "Size"
+msgstr "大小"
+
+#: pkg/storaged/dialog.js:271
+#, fuzzy
+msgid "Size cannot be negative"
+msgstr "大小不能为负数"
+
+#: pkg/storaged/dialog.js:269
+#, fuzzy
+msgid "Size cannot be zero"
+msgstr "大小不能为零"
+
+#: pkg/storaged/dialog.js:273
+msgid "Size is too large"
+msgstr "大小太大"
+
+#: pkg/storaged/dialog.js:267
+msgid "Size must be a number"
+msgstr "大小必须是一个数字"
+
+#: pkg/kubernetes/views/auth-form.html:43
+#: pkg/kubernetes/views/auth-rejected-cert.html:11
+msgid "Skip Certificate Verification"
+msgstr "跳过证书验证"
+
+#: pkg/systemd/services.html:54
+msgid "Sockets"
+msgstr "套接字"
+
+#: pkg/ostree/index.html:23
+msgid "Software Updates"
+msgstr "软件更新"
+
+#: pkg/docker/storage.jsx:156
+#, fuzzy
+msgid "Solid-State Disk"
+msgstr "固态硬盘"
+
+#: pkg/storaged/overview.js:182
+msgctxt "storage"
+msgid "Solid-State Disk"
+msgstr "固态硬盘"
+
+#: pkg/selinux/setroubleshoot-view.jsx:90
+msgid "Solution applied successfully"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:97
+#, fuzzy
+msgid "Solution failed"
+msgstr "登录失败"
+
+#: pkg/kubernetes/scripts/volumes.js:908
+msgid "Sorry, I don't know how to modify this volume"
+msgstr "抱歉，不知道如何修改该卷"
+
+#: pkg/kubernetes/views/image-body.html:8
+msgid "Source URL"
+msgstr "源网址"
+
+#: pkg/networkmanager/interfaces.js:2573
+msgid "Spanning Tree Protocol"
+msgstr "生成树协议"
+
+#: pkg/networkmanager/index.html:200
+msgid "Spanning Tree Protocol (STP)"
+msgstr "生成树协议 (STP)"
+
+#: pkg/storaged/details.js:1594
+msgid "Spare"
+msgstr "备用"
+
+#: pkg/systemd/index.html:470
+msgid "Specific Time"
+msgstr "指定时间"
+
+#: pkg/systemd/init.js:515 pkg/storaged/details.js:1612
+msgid "Start"
+msgstr "启动"
+
+#: pkg/docker/index.html:68
+msgid "Start Docker"
+msgstr "启动 Docker"
+
+#: pkg/storaged/index.html:49
+msgid "Start Multipath"
+msgstr "启用多路径"
+
+#: pkg/storaged/details.js:1614
+msgid "Start Scrubbing"
+msgstr "开始擦除"
+
+#: pkg/storaged/jobs.js:139
+msgid "Starting RAID Device $target"
+msgstr "启动 RAID 设备 $target"
+
+#: pkg/storaged/jobs.js:124
+msgid "Starting swapspace $target"
+msgstr "启动 swapspace $target"
+
+#: pkg/subscriptions/subscriptions-view.jsx:37
+msgid "Starts"
+msgstr "开头"
+
+#: pkg/kubernetes/views/container-body.html:16
+#: pkg/kubernetes/views/details-page.html:38
+#: pkg/kubernetes/views/details-page.html:175
+msgid "State"
+msgstr "状态"
+
+#: pkg/storaged/index.html:571
+msgctxt "storage"
+msgid "State"
+msgstr "状态"
+
+#: pkg/systemd/init.js:303
+msgid "Static"
+msgstr "静态"
+
+#: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/containers-listing.html:16
+#: pkg/kubernetes/views/nodes-page.html:44
+#: pkg/kubernetes/views/pvc-body.html:13 pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/pv-body.html:24
+msgid "Status"
+msgstr "状态"
+
+#: pkg/subscriptions/subscriptions-view.jsx:146
+#, fuzzy
+msgid "Status: $0"
+msgstr "状态"
+
+#: pkg/subscriptions/subscriptions-view.jsx:141
+msgid "Status: System isn't registered"
+msgstr ""
+
+#: pkg/networkmanager/index.html:455
+msgid "Sticky"
+msgstr ""
+
+#: pkg/systemd/init.js:516 pkg/storaged/details.js:1613
+msgid "Stop"
+msgstr "停止"
+
+#: pkg/storaged/details.js:1615
+msgid "Stop Scrubbing"
+msgstr "停止擦除"
+
+#: pkg/kubernetes/views/image-config.html:10
+msgid "Stop with"
+msgstr "停止为"
+
+#: pkg/docker/util.js:231
+msgid "Stopped"
+msgstr "已停止"
+
+#: pkg/storaged/jobs.js:138
+msgid "Stopping RAID Device $target"
+msgstr "停止 RAID 设备 $target"
+
+#: pkg/storaged/jobs.js:125
+msgid "Stopping swapspace $target"
+msgstr "停止 swapspace $target"
+
+#: pkg/storaged/index.html:23 pkg/storaged/index.html:672
+msgid "Storage"
+msgstr "存储"
+
+#: pkg/storaged/index.html:686
+msgid "Storage Log"
+msgstr "存储日志"
+
+#: pkg/storaged/index.html:342
+msgid "Storage Logs"
+msgstr "存储日志"
+
+#: pkg/docker/index.html:324
+msgid "Storage pool"
+msgstr "存储池"
+
+#: pkg/systemd/index.html:148
+msgid "Store Performance Data"
+msgstr "保存性能数据"
+
+#: pkg/storaged/details.js:237
+msgid "Store passphrase"
+msgstr "存储口令"
+
+#: pkg/storaged/details.js:527
+msgid "Stored Passphrase"
+msgstr "已存储口令"
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:12
+msgid ""
+"Strategy            {{item.spec.strategy.type}}            Latest "
+"Version            {{ item.status.latestVersion }}            Not "
+"deployed        "
+msgstr ""
+
+#: pkg/subscriptions/index.html:22
+msgid "Subscriptions"
+msgstr "订阅"
+
+#: pkg/kubernetes/views/image-body.html:4
+msgid "Summary"
+msgstr "汇总"
+
+#: pkg/storaged/details.js:1251
+msgctxt "storage-id-desc"
+msgid "Swap Space"
+msgstr "Swap 空间"
+
+#: pkg/systemd/index.html:243
+msgid "Swap Used"
+msgstr "Swap 用量"
+
+#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
+msgid "Switch off $0"
 msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2191 pkg/networkmanager/interfaces.js:2765
@@ -2477,359 +5314,630 @@ msgstr ""
 msgid "Switching off <b>$0</b>  will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2216 pkg/networkmanager/interfaces.js:2776
-msgid "Switch off $0"
+#: pkg/networkmanager/interfaces.js:2773
+msgid "Switching off <b>$0</b> will break the connection to the server, "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2233 pkg/networkmanager/interfaces.js:2245
-#: pkg/networkmanager/interfaces.js:2507
-msgid "Bond"
-msgstr "绑定"
+#: pkg/networkmanager/interfaces.js:2188
+msgid "Switching on <b>$0</b>  will break the connection to the server, "
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2762
+msgid "Switching on <b>$0</b> will break the connection to the server, "
+msgstr ""
+
+#: pkg/lib/machine-sync-users.html:75
+msgid "Synchronize"
+msgstr "同步"
+
+#: pkg/dashboard/index.html:188 pkg/lib/machine-sync-users.html:4
+msgid "Synchronize users"
+msgstr "同步用户"
+
+#: pkg/systemd/index.html:54
+msgid "Synchronized"
+msgstr "已同步"
+
+#: pkg/systemd/index.html:51
+msgid "Synchronized with {{Server}}"
+msgstr "与 {{Server}} 同步"
+
+#: pkg/storaged/jobs.js:146
+msgid "Synchronizing RAID Device $target"
+msgstr "同步 RAID 设备 $target"
+
+#: pkg/systemd/index.html:4
+#, fuzzy
+msgid "System"
+msgstr "系统时间"
+
+#: pkg/systemd/services.html:53
+msgid "System Services"
+msgstr "系统服务"
+
+#: pkg/systemd/index.html:112
+msgid "System Time"
+msgstr "系统时间"
+
+#: pkg/docker/index.html:349
+msgid "TCP"
+msgstr "TCP"
+
+#: pkg/kubernetes/views/route-body.html:12
+msgid "TLS Termination"
+msgstr "TLS 终止协议"
+
+#: pkg/docker/index.html:724
+msgid "Tag"
+msgstr "标签"
+
+#: pkg/kubernetes/views/image-body.html:27
+#: pkg/kubernetes/views/imagestream-modify.html:76
+#: pkg/kubernetes/views/image-listing.html:14
+msgid "Tags"
+msgstr "标记"
+
+#: pkg/kubernetes/views/pv-modify.html:136
+msgid "Target"
+msgstr "目标"
+
+#: pkg/kubernetes/views/volume-body.html:75
+msgid "Target Portal"
+msgstr "目标门户"
+
+#: pkg/kubernetes/views/volume-body.html:114
+msgid "Target World Wide Names"
+msgstr "目标全球通用名称"
+
+#: pkg/systemd/services.html:52
+msgid "Targets"
+msgstr "目标"
 
 #: pkg/networkmanager/interfaces.js:2235 pkg/networkmanager/interfaces.js:2247
 #: pkg/networkmanager/interfaces.js:2530
 msgid "Team"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
-#: pkg/networkmanager/interfaces.js:2622
-msgid "VLAN"
-msgstr "VLAN"
+#: pkg/networkmanager/interfaces.js:2558
+#, fuzzy
+msgid "Team Port"
+msgstr "目标门户"
 
-#: pkg/networkmanager/interfaces.js:2239 pkg/networkmanager/interfaces.js:2251
-#: pkg/networkmanager/interfaces.js:2584
-msgid "Bridge"
-msgstr "网桥"
+#: pkg/networkmanager/index.html:652
+#, fuzzy
+msgid "Team Port Settings"
+msgstr "网桥端口设置"
 
-#: pkg/networkmanager/interfaces.js:2276
-msgid "Carrier"
-msgstr "载体"
+#: pkg/networkmanager/index.html:624
+#, fuzzy
+msgid "Team Settings"
+msgstr "IP 设置"
 
-#: pkg/networkmanager/interfaces.js:2279 pkg/kubernetes/scripts/volumes.js:990
-msgid "Yes"
-msgstr "是"
+#: pkg/kubernetes/views/replicationcontroller-page.html:20
+#: pkg/kubernetes/views/deploymentconfig-panel.html:10
+#: pkg/kubernetes/views/deploymentconfig-page.html:15
+#: pkg/kubernetes/views/replicationcontroller-panel.html:14
+msgid "Template"
+msgstr "模板"
 
-#: pkg/networkmanager/interfaces.js:2299
-#: pkg/subscriptions/subscriptions-view.jsx:36
-#: pkg/kubernetes/views/node-body.html.h:14
-#: pkg/kubernetes/views/containers-listing.html.h:7
-#: pkg/kubernetes/views/volumes-page.html.h:5
-#: pkg/kubernetes/views/pv-claim.html.h:6
-#: pkg/kubernetes/views/nodes-page.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:5 pkg/kubernetes/views/pv-body.html.h:4
-msgid "Status"
-msgstr "状态"
+#: pkg/systemd/terminal.html:4
+msgid "Terminal"
+msgstr "终端"
+
+#: pkg/users/index.html:78
+msgid "Terminate Session"
+msgstr "终止会话"
+
+#: pkg/networkmanager/index.html:38
+msgid "Testing connection"
+msgstr ""
+
+#: pkg/storaged/index.html:40
+msgid "The \"storaged\" API is not available on this system."
+msgstr "在此系统中, \"storaged\" API 不可用."
+
+#: pkg/docker/storage.jsx:485
+#, fuzzy
+msgid "The Docker storage pool cannot be managed on this system."
+msgstr "在此系统中, \"storaged\" API 不可用."
+
+#: pkg/lib/machine-dialogs.js:386
+msgid "The IP address or host name cannot contain whitespace."
+msgstr "IP 地址或主机名不能包含空格。"
+
+#: pkg/storaged/index.html:532
+msgid "The RAID Array is in a degraded state"
+msgstr "RAID 阵列处于降级状态"
+
+#: pkg/kubernetes/scripts/nodes.js:399
+msgid "The address contains invalid characters"
+msgstr "地址包含无效字符"
+
+#: pkg/lib/machine-unknown-hostkey.html:6
+msgid ""
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
+msgstr "主机 {{#strong}}{{host}}{{/strong}} 的认证无法完成。确认想要继续连接？"
+
+#: pkg/selinux/setroubleshoot-view.jsx:324
+msgid "The configured state is unknown, it might change on the next boot."
+msgstr ""
+
+#: pkg/kubernetes/views/container-page-inline.html:22
+msgid "The container '{{ target }}' does not exist."
+msgstr "容器 '{{ target }}' 不存在。"
+
+#: pkg/subscriptions/subscriptions-view.jsx:192
+#, fuzzy
+msgid "The current user isn't allowed to access system subscription status."
+msgstr ""
+"\n"
+"        当前用户无权管理该系统的订阅.\n"
+"      "
+
+#: pkg/kubernetes/views/deploymentconfig-page.html:25
+msgid "The deployment config '{{ target }}' does not exist."
+msgstr "部署配置 '{{ target }}' 不存在。"
+
+#: pkg/kubernetes/views/group-page.html:47
+msgid "The group '{{ groupName }}' does not exist."
+msgstr "组 '{{ groupName }}' 不存在。"
+
+#: pkg/shell/base_index.js:673
+msgid "The javascript console contains details about this error "
+msgstr "JavaScript 控制台包含有关此错误的详细信息"
+
+#: pkg/lib/machine-invalid-hostkey.html:8
+msgid ""
+"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
+"in use. Unless this machine was recently replaced, it is likely that someone "
+"is trying to attack your connection to this machine."
+msgstr ""
+"{{#strong}}{{host}}{{/strong}} 的密钥与之前使用的不匹配。除非该主机最近被替"
+"换，否则可能有人正在攻击与该主机的连接。"
+
+#: pkg/users/authorized-keys.js:118
+msgid "The key you provided was not valid."
+msgstr "您提供的 key 是无效的."
+
+#: pkg/storaged/details.js:1751
+msgid "The last physical volume of a volume group cannot be removed."
+msgstr ""
+
+#: pkg/shell/indexes.js:314
+msgid "The machine is restarting"
+msgstr "正在重启主机"
+
+#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
+msgid "The maximum number of replicas is 128"
+msgstr "副本最大数量为 128"
+
+#: pkg/kubernetes/scripts/nodes.js:407
+msgid "The name contains invalid characters"
+msgstr "名称包含无效的字符"
+
+#: pkg/kubernetes/views/node-page.html:23
+msgid "The node '{{ target }}' does not exist."
+msgstr "节点 '{{ target }}' 不存在。"
+
+#: pkg/kubernetes/views/node-alerts.html:7
+msgid "The node doesn't have enough disk space"
+msgstr "节点没有足够的磁盘空间"
+
+#: pkg/kubernetes/views/node-alerts.html:11
+msgid "The node doesn't have enough free memory"
+msgstr "节点没有足够的空闲内存"
+
+#: pkg/users/local.js:395 pkg/users/local.js:1082
+msgid "The passwords do not match"
+msgstr "密码不匹配"
+
+#: pkg/lib/credentials.js:186
+msgid "The passwords do not match."
+msgstr "密码不匹配"
+
+#: pkg/kubernetes/views/pv-page.html:21
+msgid "The persistent volume '{{ target }}' does not exist."
+msgstr "持久卷 '{{ target }}' 不存在。"
+
+#: pkg/kubernetes/views/pod-page.html:40
+msgid "The pod '{{ target }}' does not exist."
+msgstr "容器舱 '{{ target }}' 不存在。"
+
+#: pkg/kubernetes/views/project-page.html:34
+msgid "The project '{{ projName }}' does not exist."
+msgstr "项目 '{{ projName }}' 不存在。"
+
+#: pkg/kubernetes/views/replicationcontroller-page.html:30
+msgid "The replication controller '{{ target }}' does not exist."
+msgstr "复制控制器 '{{ target }}' 不存在。"
+
+#: pkg/kubernetes/views/route-page.html:19
+msgid "The route '{{ target }}' does not exist."
+msgstr "路由 '{{ target }}' 不存在。"
+
+#: pkg/kubernetes/scripts/dashboard.js:386
+msgid "The selected file is not a valid Kubernetes application manifest."
+msgstr "所选的文件不是有效的 Kubernetes 应用程序清单."
+
+#: src/base1/cockpit.js:3695
+msgid "The server refused to authenticate using any supported methods."
+msgstr "服务器拒绝使用任何支持的方式来认证。"
+
+#: pkg/kubernetes/views/auth-rejected-cert.html:2
+msgid "The server uses a certificate signed by an unknown authority."
+msgstr "服务器使用率一个通过未知机构签名的证书。"
+
+#: pkg/kubernetes/views/service-page.html:19
+msgid "The service '{{ target }}' does not exist."
+msgstr "服务 '{{ target }}' 不存在。"
+
+#: pkg/docker/storage.jsx:355
+msgid ""
+"The storage pool will be reset to optimize its layout.  All containers will "
+"be erased."
+msgstr ""
+
+#: pkg/kubernetes/views/user-page.html:29
+msgid "The user '{{ userName }}' does not exist."
+msgstr "用户 '{{ userName }}' 不存在。"
+
+#: pkg/systemd/init.js:834
+#, fuzzy
+msgid "The user <b>$0</b> does not have permissions for creating timers"
+msgstr "用户 <b>$0</b> 不允许管理服务器"
+
+#: pkg/dashboard/list.js:209
+msgid "The user <b>$0</b> is not permitted to manage servers"
+msgstr "用户 <b>$0</b> 不允许管理服务器"
+
+#: pkg/storaged/permissions.js:61
+msgid "The user <b>$0</b> is not permitted to manage storage"
+msgstr "用户 <b>$0</b> 不允许管理存储"
+
+#: pkg/users/local.js:40
+msgid "The user <b>$0</b> is not permitted to modify accounts"
+msgstr "用户 <b>$0</b> 不允许修改账户"
+
+#: pkg/systemd/host.js:43
+msgid "The user <b>$0</b> is not permitted to modify hostnames"
+msgstr "用户 <b>$0</b> 不允许修改的主机名"
+
+#: pkg/networkmanager/interfaces.js:1420
+msgid "The user <b>$0</b> is not permitted to modify network settings"
+msgstr "用户 <b>$0</b> 不允许修改网络设置"
+
+#: pkg/realmd/operation.js:436
+msgid "The user <b>$0</b> is not permitted to modify realms"
+msgstr "用户 <b>$0</b> 不允许修改 realms"
+
+#: pkg/users/local.js:501
+msgid ""
+"The user name can only consist of letters from a-z, digits, dots, dashes and "
+"underscores."
+msgstr "用户名仅能包含 a-z、数字、点、破折号和下划线的字母。"
+
+#: pkg/users/index.html:332
+msgid "There are no authorized public keys for this account."
+msgstr "存在未被该帐户授权的公钥."
+
+#: pkg/storaged/details.js:1756
+msgid ""
+"There is not enough free space elsewhere to remove this physical volume.  At "
+"least $0 more free space is needed."
+msgstr ""
+
+#: pkg/storaged/utils.js:168
+msgid "Thin Logical Volume"
+msgstr "稀疏逻辑卷"
+
+#: pkg/kubernetes/views/pvc-delete.html:8
+msgid ""
+"This claim is in use. Deleting it may cause issues with the following pod:"
+msgstr "该声明正在使用。删除它也许会对以下容器舱产生影响:"
+
+#: pkg/systemd/init.js:1222
+msgid ""
+"This day doesn't exist in all months.<br> The timer will only be executed in "
+"months that have 31st."
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2310
 #, fuzzy
 msgid "This device cannot be managed here."
 msgstr "该逻辑卷无法变小。"
 
-#: pkg/networkmanager/interfaces.js:2342
-msgid "Unknown configuration"
-msgstr "未知配置"
-
-#: pkg/networkmanager/interfaces.js:2441
-msgid "Configure"
-msgstr "配置"
-
-#: pkg/networkmanager/interfaces.js:2473
-msgid "$mtu"
-msgstr "$mtu"
-
-#: pkg/networkmanager/interfaces.js:2477
-msgid "MTU"
-msgstr "MTU"
-
-#: pkg/networkmanager/interfaces.js:2483
-msgid "Master"
-msgstr "主"
-
-#: pkg/networkmanager/interfaces.js:2502
-msgid "ARP Monitoring"
-msgstr "ARP 监控"
-
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2554
+#: pkg/systemd/init.js:1142 pkg/systemd/init.js:1154 pkg/systemd/init.js:1161
 #, fuzzy
-msgid "Broken configuration"
-msgstr "未知配置"
+msgid "This field cannot be empty."
+msgstr "名称不能为空."
 
-#: pkg/networkmanager/interfaces.js:2558
+#: pkg/storaged/details.js:690
 #, fuzzy
-msgid "Team Port"
-msgstr "目标门户"
+msgid "This logical volume cannot be made smaller."
+msgstr "该逻辑卷无法变小。"
 
-#: pkg/networkmanager/interfaces.js:2573
-msgid "Spanning Tree Protocol"
-msgstr "生成树协议"
+#: pkg/lib/machine-dialogs.js:364
+msgid "This machine has already been added."
+msgstr "该主机已经被添加。"
 
-#: pkg/networkmanager/interfaces.js:2575 pkg/networkmanager/interfaces.js:2599
-msgid "Priority $priority"
-msgstr "优先级 $priority"
+#: pkg/realmd/operation.html:89
+msgid "This may take a while"
+msgstr "这可能需要一些时间"
 
-#: pkg/networkmanager/interfaces.js:2577
-msgid "Forward delay $forward_delay"
-msgstr "转发延迟 $forward_delay"
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid ""
+"This option is for single node testing only – local storage will not work in "
+"a multi-node cluster"
+msgstr "该选项是仅为单节点测试 – 本地存储，将在多节点集群中不工作"
 
-#: pkg/networkmanager/interfaces.js:2579
-msgid "Hello time $hello_time"
-msgstr "Hello 时间 $hello_time"
-
-#: pkg/networkmanager/interfaces.js:2581
-msgid "Maximum message age $max_age"
-msgstr "最大消息有效期 $max_age"
-
-#: pkg/networkmanager/interfaces.js:2601
-msgid "Path cost $path_cost"
-msgstr "路径开销 $path_cost"
-
-#: pkg/networkmanager/interfaces.js:2603
-msgid "Hairpin mode"
-msgstr "发夹模式"
-
-#: pkg/networkmanager/interfaces.js:2605
-msgid "Bridge port"
-msgstr "网桥端口"
-
-#: pkg/networkmanager/interfaces.js:2619
-msgid "Parent $parent"
-msgstr "父接口 $parent"
-
-#: pkg/networkmanager/interfaces.js:2620
-msgid "Id $id"
-msgstr "Id $id"
-
-#: pkg/networkmanager/interfaces.js:2628
-msgid "General"
-msgstr "通用"
-
-#: pkg/networkmanager/interfaces.js:2637
-msgid "Connect automatically"
-msgstr "自动连接"
-
-#: pkg/networkmanager/interfaces.js:2641
-msgid "IPv4"
-msgstr "IPv4"
-
-#: pkg/networkmanager/interfaces.js:2642
-msgid "IPv6"
-msgstr "IPv6"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/networkmanager/index.html.h:33
-#: pkg/kubernetes/views/project-listing.html.h:5
-msgid "Members"
-msgstr "成员"
-
-#: pkg/networkmanager/interfaces.js:2727 pkg/docker/index.html.h:39
-#: pkg/networkmanager/index.html.h:24
-#: pkg/kubernetes/views/service-body.html.h:6
-#: pkg/kubernetes/views/image-config.html.h:7
-#: pkg/kubernetes/views/container-body.html.h:5
-msgid "Ports"
-msgstr "端口"
-
-#: pkg/networkmanager/interfaces.js:2762
-msgid "Switching on <b>$0</b> will break the connection to the server, "
+#: src/bridge/cockpitpackages.c:470
+msgid "This package is not compatible with this version of Cockpit"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2773
-msgid "Switching off <b>$0</b> will break the connection to the server, "
+#: src/bridge/cockpitpackages.c:459
+#, c-format
+msgid "This package requires Cockpit version %s or later"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2788
-msgid "Removing <b>$0</b> will break the connection to the server, "
-msgstr ""
+#: pkg/tuned/dialog.js:102
+msgid "This system is using a custom profile"
+msgstr "该系统正在使用自定义的配置集"
 
-#: pkg/networkmanager/interfaces.js:2791
+#: pkg/tuned/dialog.js:100
+msgid "This system is using the recommended profile"
+msgstr "该系统正在使用推荐的配置集"
+
+#: pkg/systemd/init.js:639
+msgid "This unit is an instance of the $0 template."
+msgstr "该单元是模板 $0 的实例."
+
+#: pkg/systemd/services.html:302
 #, fuzzy
-msgid "Remove $0"
-msgstr "删除"
+msgid "This unit is not designed to be enabled explicitly.          "
+msgstr ""
+"该单元未设计为明确启用.\n"
+"          "
 
-#: pkg/networkmanager/interfaces.js:2833
-msgid "Adding <b>$0</b> will break the connection to the server, "
+#: pkg/users/local.js:509
+msgid "This user name already exists"
+msgstr "用户名已存在"
+
+#: pkg/lib/machine-dialogs.js:380
+msgid ""
+"This version of cockpit-ws does not support connecting to a host with an "
+"alternate user or port"
+msgstr "该版本的 cockpit-ws 不支持连接到有交替的用户或端口的主机"
+
+#: pkg/kubernetes/views/pv-delete.html:7
+msgid ""
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
+msgstr ""
+"该卷已经被 {{ item.item.spec.claimRef.namespace }} / {{ item.item.spec."
+"claimRef.name }} 声明。删除它将会损坏该声明并且也许会对依赖于它的容器舱尝试影"
+"响。"
+
+#: pkg/kubernetes/views/pv-claim.html:23
+msgid "This volume has not been claimed"
+msgstr "该卷未被声明"
+
+#: pkg/systemd/index.html:379
+msgid "Time Zone"
+msgstr "时区"
+
+#: pkg/systemd/services.html:55
+msgid "Timers"
+msgstr "计时器"
+
+#: pkg/kubernetes/views/image-body.html:33
+msgid "To pull this image:"
+msgstr "拉取该镜像:"
+
+#: pkg/kubernetes/views/imagestream-body.html:39
+msgid "To push to an image to this image stream:"
+msgstr "推送镜像到该镜像流:"
+
+#: pkg/lib/machine-change-port.html:11
+msgid ""
+"To try a different port you will need to upgrade cockpit-ws to a newer "
+"version."
+msgstr "需要更新 cockpit-ws 到一个新版本来尝试一个不同的端口。"
+
+#: pkg/kubernetes/views/auth-form.html:116
+msgid "Token"
+msgstr "令牌"
+
+#: pkg/kubernetes/index.html:57
+msgid "Topology"
+msgstr "拓扑"
+
+#: pkg/docker/storage.jsx:314
+msgid "Total"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2836
-msgid "Add $0"
-msgstr ""
+#: pkg/ostree/index.html:99
+msgid "Tree"
+msgstr "Tree"
 
-#: pkg/networkmanager/interfaces.js:2870
-msgid "Changing the settings will break the connection to the server, "
-msgstr ""
+#: pkg/kubernetes/views/deploymentconfig-body.html:32
+msgid "Triggers"
+msgstr "触发器"
 
-#: pkg/networkmanager/interfaces.js:2872
-#, fuzzy
-msgid "Change the settings"
-msgstr "连接设置"
+#: pkg/shell/index.html:328 pkg/shell/stub.html:181
+msgid "Troubleshoot"
+msgstr "排错"
 
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length or Netmask"
-msgstr "前缀长度或网络掩码"
+#: pkg/kubernetes/views/auth-rejected-cert.html:21
+msgid "Trust this certificate for this connection"
+msgstr "为该连接信任该证书"
 
-#: pkg/networkmanager/interfaces.js:3008
-msgid "Prefix length"
-msgstr "前缀长度"
+#: pkg/systemd/init.js:520
+msgid "Try Restart"
+msgstr "尝试重启"
 
-#: pkg/networkmanager/interfaces.js:3011
-#: pkg/kubernetes/views/details-page.html.h:7
-msgid "Addresses"
-msgstr "地址"
+#: pkg/docker/index.html:71 pkg/docker/index.html:74
+msgid "Try again"
+msgstr "重试"
 
-#: pkg/networkmanager/interfaces.js:3018
-msgid "DNS"
-msgstr "DNS"
+#: pkg/systemd/index.html:59
+msgid "Trying to synchronize with {{Server}}"
+msgstr "正在尝试与 {{Server}} 同步"
 
-#: pkg/networkmanager/interfaces.js:3022
-msgid "DNS Search Domains"
-msgstr "DNS 搜索域"
+#: pkg/tuned/dialog.js:262
+msgid "Tuned has failed to start"
+msgstr "Tuned 启动失败"
 
-#: pkg/networkmanager/interfaces.js:3027
-#: pkg/kubernetes/views/details-page.html.h:11
-msgid "Routes"
-msgstr "路由"
+#: pkg/tuned/dialog.js:94
+msgid "Tuned is not available"
+msgstr "Tuned 不可用"
 
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv4 Settings"
-msgstr "IPv4 设置"
+#: pkg/tuned/dialog.js:96
+msgid "Tuned is not running"
+msgstr "Tuned 未运行"
 
-#: pkg/networkmanager/interfaces.js:3061
-msgid "IPv6 Settings"
-msgstr "IPv6 设置"
+#: pkg/tuned/dialog.js:98
+msgid "Tuned is off"
+msgstr "Tuned 已关闭"
 
-#: pkg/networkmanager/interfaces.js:3436
-msgid "Creating this bond will break the connection to the server, "
-msgstr ""
+#: pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/pv-modify.html:10
+#: pkg/kubernetes/views/volumes-page.html:20 pkg/kubernetes/views/deploy.html:9
+msgid "Type"
+msgstr "类型"
 
-#: pkg/networkmanager/interfaces.js:3438 pkg/networkmanager/interfaces.js:3613
-#: pkg/networkmanager/interfaces.js:3844 pkg/networkmanager/interfaces.js:4066
-#, fuzzy
-msgid "Create it"
-msgstr "创建"
-
-#: pkg/networkmanager/interfaces.js:3611
-msgid "Creating this team will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:3842
-msgid "Creating this bridge will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4064
-msgid "Creating this VLAN will break the connection to the server, "
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:4139
-msgid "MTU must be a positive number"
-msgstr "MTU 必须是正整数"
-
-#: pkg/subscriptions/subscriptions-client.js:196
-#, fuzzy
-msgid "Invalid credentials"
-msgstr "无效端口"
-
-#: pkg/subscriptions/subscriptions-client.js:198
-msgid "'Organization' required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:200
-#, fuzzy
-msgid "Login/password or activation key required to register."
-msgstr "需要 用户名/密码 或 激活密钥"
-
-#: pkg/subscriptions/subscriptions-client.js:202
-msgid "'Organization' required when using activation keys."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:64
-#: pkg/kubernetes/views/volume-body.html.h:16
-#: pkg/kubernetes/views/pv-modify.html.h:11
-msgid "Server"
-msgstr "服务器"
-
-#: pkg/subscriptions/subscriptions-register.jsx:88
-#: pkg/subscriptions/subscriptions-register.jsx:152
-#: pkg/lib/machine-auth-failed.html.h:3 pkg/lib/machine-sync-users.html.h:6
-#: pkg/lib/machine-change-auth.html.h:6 pkg/shell/index.html.h:31
-#: pkg/users/index.html.h:16 pkg/kubernetes/views/auth-form.html.h:11
-msgid "Password"
-msgstr "密码"
-
-#: pkg/subscriptions/subscriptions-register.jsx:102
-#, fuzzy
-msgid "Custom URL"
-msgstr "自定义"
+#: pkg/kubernetes/views/details-page.html:7
+msgid "Type:"
+msgstr "类型:"
 
 #: pkg/subscriptions/subscriptions-register.jsx:110
 msgid "URL"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-register.jsx:125
-msgid "Proxy"
+#: pkg/storaged/index.html:547 pkg/storaged/index.html:626
+msgctxt "storage"
+msgid "UUID"
+msgstr "UUID"
+
+#: pkg/selinux/setroubleshoot-view.jsx:114
+msgid "Unable to apply this solution automatically"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-register.jsx:132
-msgid "Use proxy server"
-msgstr ""
+#: pkg/ostree/index.html:219
+msgid "Unable to communicate with OSTree"
+msgstr "无法与 OSTree 通信"
 
-#: pkg/subscriptions/subscriptions-register.jsx:140
+#: pkg/subscriptions/subscriptions-view.jsx:195
 #, fuzzy
-msgid "Login"
-msgstr "最近登陆"
+msgid "Unable to connect"
+msgstr "无法获取警告"
 
-#: pkg/subscriptions/subscriptions-register.jsx:164
+#: pkg/kubernetes/scripts/dashboard.js:413
+msgid "Unable to decode Kubernetes application manifest."
+msgstr "无法解码 Kubernetes 应用清单。"
+
+#: pkg/users/local.js:57
+msgid "Unable to delete root account"
+msgstr "不能删除 root 账户"
+
+#: pkg/selinux/setroubleshoot-client.js:157
+msgid "Unable to get alert"
+msgstr "无法获取警告"
+
+#: pkg/storaged/overview.js:586
+msgid "Unable to reach server"
+msgstr "无法到达服务器"
+
+#: pkg/kubernetes/scripts/dashboard.js:401
+msgid "Unable to read the Kubernetes application manifest. Code $0."
+msgstr "无法读取 Kubernetes 应用程序清单. 代码 $0."
+
+#: pkg/users/local.js:59
+msgid "Unable to rename root account"
+msgstr "不能重命名 root 账户"
+
+#: pkg/selinux/setroubleshoot-client.js:172
+msgid "Unable to run fix"
+msgstr "无法运行修复"
+
+#: pkg/selinux/setroubleshoot-client.js:52
+msgid "Unable to start setroubleshootd"
+msgstr "无法启动 setroubleshootd"
+
+#: pkg/playground/translate.html:35 pkg/playground/translate.html:40
+msgid "Unavailable"
+msgstr "不可用"
+
+#: pkg/docker/index.html:763 pkg/networkmanager/index.html:792
+msgid "Unexpected error"
+msgstr "意外的错误"
+
+#: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/image-body.html:15
+#: pkg/kubernetes/views/pv-claim.html:31 pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
+msgid "Unknown"
+msgstr "未知"
+
+#: pkg/storaged/details.js:1597
+msgid "Unknown ($0)"
+msgstr "未知 ($0)"
+
+#: pkg/lib/machine-unknown-hostkey.html:2
+msgid "Unknown Host Key"
+msgstr "未知主机密钥"
+
+#: pkg/networkmanager/interfaces.js:2342
+msgid "Unknown configuration"
+msgstr "未知配置"
+
+#: pkg/storaged/overview.js:582
+msgid "Unknown host name"
+msgstr "未知主机名"
+
+#: pkg/docker/index.html:570
+msgid "Unless Stopped"
+msgstr "直到被停止"
+
+#: pkg/storaged/details.js:473 pkg/storaged/details.js:480
+#: pkg/storaged/details.js:1110
+msgid "Unlock"
+msgstr "未锁定"
+
+#: pkg/shell/index.html:220
+msgid "Unlock Key"
+msgstr "解锁密钥"
+
+#: pkg/storaged/jobs.js:121
+msgid "Unlocking $target"
+msgstr "解锁 $target"
+
+#: pkg/networkmanager/index.html:108
 #, fuzzy
-msgid "Activation Key"
-msgstr "激活"
+msgid "Unmanaged Interfaces"
+msgstr "接口"
 
-#: pkg/subscriptions/subscriptions-register.jsx:176
-#, fuzzy
-msgid "Organization"
-msgstr "转换"
+#: pkg/systemd/init.js:548
+msgid "Unmask"
+msgstr "Unmask"
 
-#: pkg/subscriptions/main.js:45 pkg/subscriptions/subscriptions-view.jsx:143
-#: pkg/kubernetes/views/pv-modify.html.h:23
-msgid "Register"
-msgstr "注册"
+#: pkg/storaged/details.js:1100
+msgid "Unmount"
+msgstr "卸载"
 
-#: pkg/subscriptions/main.js:74
-msgid "Register system"
-msgstr "注册系统"
+#: pkg/storaged/jobs.js:127
+msgid "Unmounting $target"
+msgstr "卸载 $target"
 
-#: pkg/subscriptions/subscriptions-view.jsx:32
-msgid "Product name"
-msgstr "产品名"
+#: pkg/users/index.html:315
+msgid "Unnamed"
+msgstr "未命名"
 
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product ID"
-msgstr "产品 ID"
-
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/index.html.h:13
-#: pkg/shell/index.html.h:14 pkg/shell/stub.html.h:9 pkg/shell/simple.html.h:9
-#: pkg/ostree/index.html.h:19
-msgid "Version"
-msgstr "版本"
-
-#: pkg/subscriptions/subscriptions-view.jsx:35
-#: pkg/kubernetes/views/image-config.html.h:5
-msgid "Architecture"
-msgstr "架构"
-
-#: pkg/subscriptions/subscriptions-view.jsx:37
-msgid "Starts"
-msgstr "开头"
-
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Ends"
-msgstr "结尾"
-
-#: pkg/subscriptions/subscriptions-view.jsx:141
-msgid "Status: System isn't registered"
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:146
-#, fuzzy
-msgid "Status: $0"
-msgstr "状态"
+#: pkg/storaged/details.js:1256
+msgctxt "storage-id-desc"
+msgid "Unrecognized Data"
+msgstr "无法识别的数据"
 
 #: pkg/subscriptions/subscriptions-view.jsx:148
 #, fuzzy
@@ -2841,797 +5949,211 @@ msgstr "注册"
 msgid "Unregistering system..."
 msgstr "注册系统中..."
 
-#: pkg/subscriptions/subscriptions-view.jsx:161
-#: pkg/subscriptions/index.html.h:1
-msgid "Subscriptions"
-msgstr "订阅"
+#: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
+#: src/bridge/cockpitdbussetup.c:625
+#, fuzzy
+msgid "Unsupported setup mechanism"
+msgstr "不支持创建机制： %s"
 
-#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/ostree/index.html.h:15
-msgid "Updating"
+#: src/base1/cockpit.js:3697
+msgid "Untrusted host"
+msgstr "不可信的主机"
+
+#: pkg/docker/util.js:94
+msgid "Up since $StartedAt"
+msgstr "运行自 $StartedAt"
+
+#: pkg/lib/machine-change-port.html:41
+msgid "Update"
 msgstr "更新"
 
-#: pkg/subscriptions/subscriptions-view.jsx:188
-msgid "Retrieving subscription status..."
-msgstr ""
+#: pkg/ostree/index.html:125 pkg/ostree/index.html:152
+msgid "Updates"
+msgstr "更新"
 
-#: pkg/subscriptions/subscriptions-view.jsx:191
-#, fuzzy
-msgid "Access denied"
-msgstr "访问模式"
-
-#: pkg/subscriptions/subscriptions-view.jsx:192
-#, fuzzy
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-"\n"
-"        当前用户无权管理该系统的订阅.\n"
-"      "
-
-#: pkg/subscriptions/subscriptions-view.jsx:195
-#, fuzzy
-msgid "Unable to connect"
-msgstr "无法获取警告"
-
-#: pkg/subscriptions/subscriptions-view.jsx:196
-#, fuzzy
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-"\n"
-"        为了管理该系统的订阅, 请确认已安装 subscription-manager.\n"
-"      "
-
-#: pkg/subscriptions/subscriptions-view.jsx:222
-#, fuzzy
-msgid "Installed products"
-msgstr "已安装产品"
-
-#: pkg/subscriptions/subscriptions-view.jsx:223
-#, fuzzy
-msgid "No installed products on the system."
-msgstr "Cockpit 未安装在该系统上。"
-
-#: pkg/kubernetes/scripts/details.js:495 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "副本不是一个有效数字"
-
-#: pkg/kubernetes/scripts/details.js:497 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "副本最大数量为 128"
-
-#: pkg/kubernetes/scripts/details.js:546
-msgid "Not a valid value for Host"
-msgstr "无效的主机值"
+#: pkg/ostree/index.html:96
+msgid "Updating"
+msgstr "更新"
 
 #: pkg/kubernetes/scripts/details.js:655
 msgid "Updating $0..."
 msgstr "更新 $0..."
 
-#: pkg/kubernetes/scripts/graphs.js:601 pkg/kubernetes/scripts/nodes.js:711
-#: pkg/kubernetes/scripts/nodes.js:817 pkg/dashboard/index.html.h:2
-msgid "CPU"
-msgstr "CPU"
-
-#: pkg/kubernetes/scripts/graphs.js:606 pkg/kubernetes/scripts/nodes.js:715
-#: pkg/kubernetes/scripts/nodes.js:826 pkg/dashboard/index.html.h:3
-msgid "Memory"
-msgstr "内存"
-
-#: pkg/kubernetes/scripts/graphs.js:611 pkg/dashboard/index.html.h:4
-msgid "Network"
-msgstr "网络"
-
-#: pkg/kubernetes/scripts/nodes.js:319 pkg/kubernetes/views/node-body.html.h:16
-#: pkg/kubernetes/views/details-page.html.h:10
-msgid "Not Ready"
-msgstr "未就绪"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
-msgstr "调度被禁用"
-
-#: pkg/kubernetes/scripts/nodes.js:324 pkg/kubernetes/views/node-body.html.h:15
-#: pkg/kubernetes/views/details-page.html.h:9
-msgid "Ready"
-msgstr "就绪"
-
-#: pkg/kubernetes/scripts/nodes.js:397
-msgid "Please type an address"
-msgstr "请输入一个地址"
-
-#: pkg/kubernetes/scripts/nodes.js:399
-msgid "The address contains invalid characters"
-msgstr "地址包含无效字符"
-
-#: pkg/kubernetes/scripts/nodes.js:407
-msgid "The name contains invalid characters"
-msgstr "名称包含无效的字符"
-
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
-msgstr "CPU 使用率: $0%"
-
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
-msgstr "Memory 使用率: $0%"
-
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
-msgid "Disk"
-msgstr "磁盘"
-
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
-msgstr "磁盘使用率: $0%"
-
-#: pkg/kubernetes/scripts/nodes.js:870
-#, fuzzy, c-format
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] "$0% 空闲的"
-
-#: pkg/kubernetes/scripts/nodes.js:872
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] "$0% 已使用的"
-
-#: pkg/kubernetes/scripts/connection.js:88
-msgid "Error writing kubectl config"
-msgstr "写 kubectl 配置时出错"
-
-#: pkg/kubernetes/scripts/connection.js:514
-msgid "Couldn't find running API server"
-msgstr "无法找到运行的 API 服务器"
-
-#: pkg/kubernetes/scripts/connection.js:516
-msgid "Connection Error: $0"
-msgstr "连接错误: $0"
-
-#: pkg/kubernetes/scripts/connection.js:539
-msgid "Please provide a valid address"
-msgstr "请提供一个有效的地址"
-
-#: pkg/kubernetes/scripts/connection.js:554
-msgid "Please provide a username"
-msgstr "请提供一个用户名"
-
-#: pkg/kubernetes/scripts/connection.js:650
-msgid "Error getting certificate details: $0"
-msgstr "获取证书详情出错: $0"
-
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr "GCE 持久盘"
-
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr "AWS 弹性块存储"
-
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
-msgstr "Git 仓库"
-
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr "口令"
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr "空目录"
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:864
-msgid "Host Path"
-msgstr "主机路径"
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr "Gluster FS"
-
-#: pkg/kubernetes/scripts/volumes.js:199
-msgid "NFS Mount"
-msgstr "NFS 挂载"
-
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr "Rados 块设备"
-
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:868
-msgid "ISCSI"
-msgstr "ISCSI"
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr "Cinder"
-
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr "Ceph 文件系统挂载"
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr "光纤通道"
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr "Flocker"
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr "收缩"
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr "Azure"
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr "从单节点读和写"
-
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr "仅从多节点读"
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr "从多节点读和写"
-
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr "留存"
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr "回收"
-
-#: pkg/kubernetes/scripts/volumes.js:469
-msgid "Please select a valid access mode"
-msgstr "请选择有效的访问模式"
-
-#: pkg/kubernetes/scripts/volumes.js:477
-msgid "Please provide a valid name"
-msgstr "请提供有效的名称"
-
-#: pkg/kubernetes/scripts/volumes.js:485
-msgid "Please provide a valid storage capacity."
-msgstr "请提供有效的存储容量。"
-
-#: pkg/kubernetes/scripts/volumes.js:493
-msgid "Please select a valid policy option."
-msgstr "请选择有效的策略选项。"
-
-#: pkg/kubernetes/scripts/volumes.js:565
-msgid "Please select a valid endpoint"
-msgstr "请选择有效的端点"
-
-#: pkg/kubernetes/scripts/volumes.js:574
-msgid "Please provide a GlusterFS volume name"
-msgstr "请提供一个 GlusterFS 卷名称"
-
-#: pkg/kubernetes/scripts/volumes.js:632
-msgid "Please provide a valid NFS server"
-msgstr "请提供一个有效的 NFS 服务器"
-
-#: pkg/kubernetes/scripts/volumes.js:640 pkg/kubernetes/scripts/volumes.js:697
-msgid "Please provide a valid path"
-msgstr "请提供一个有效的路径"
-
-#: pkg/kubernetes/scripts/volumes.js:781
-msgid "Please provide a valid target"
-msgstr "请提供一个有效的目标"
-
-#: pkg/kubernetes/scripts/volumes.js:789
-msgid "Please provide a valid qualified name"
-msgstr "请提供一个有效的限定名"
-
-#: pkg/kubernetes/scripts/volumes.js:797
-msgid "Please provide a valid logical unit number"
-msgstr "请提供一个有效的逻辑单元编号"
-
-#: pkg/kubernetes/scripts/volumes.js:805
-msgid "Please provide a valid filesystem type"
-msgstr "请提供一个有效的文件系统类型"
-
-#: pkg/kubernetes/scripts/volumes.js:813
-msgid "Please provide a valid interface"
-msgstr "请提供一个有效的接口"
-
-#: pkg/kubernetes/scripts/volumes.js:860
-msgid "NFS"
-msgstr "NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:872
-msgid "GlusterFS"
-msgstr "GlusterFS"
-
-#: pkg/kubernetes/scripts/volumes.js:908
-msgid "Sorry, I don't know how to modify this volume"
-msgstr "抱歉，不知道如何修改该卷"
-
-#: pkg/kubernetes/scripts/charts.js:113
-msgid "Unavailable"
-msgstr "不可用"
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "命名空间不能为空."
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "请提供有效的命名空间."
-
-#: pkg/kubernetes/scripts/dashboard.js:384
-msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr "未选择元数据文件. 请选择一个 Kubernetes 元数据文件."
-
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr "所选的文件不是有效的 Kubernetes 应用程序清单."
-
-#: pkg/kubernetes/scripts/dashboard.js:401
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr "无法读取 Kubernetes 应用程序清单. 代码 $0."
-
-#: pkg/kubernetes/scripts/dashboard.js:413
-msgid "Unable to decode Kubernetes application manifest."
-msgstr "无法解码 Kubernetes 应用清单。"
-
-#: pkg/kubernetes/scripts/dashboard.js:441
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "请重新为 $0 创建一个命名空间 \"$1\""
-
-#: pkg/kubernetes/scripts/dashboard.js:460
-msgid "Manifest"
-msgstr "清单"
-
-#: pkg/dashboard/list.js:209
-msgid "The user <b>$0</b> is not permitted to manage servers"
-msgstr "用户 <b>$0</b> 不允许管理服务器"
-
-#: pkg/dashboard/list.js:394
-msgid ""
-"You are currently connected directly to this server. You cannot delete it."
-msgstr "您当前已直接连接到该服务器。您不能删除它。"
-
-#: cockpit.appdata.xml.in.h:1
-msgid ""
-"Cockpit is a server manager that makes it easy to administer your Linux "
-"servers via a web browser. Jumping between the terminal and the web tool is "
-"no problem. A service started via Cockpit can be stopped via the terminal. "
-"Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
-"journal interface."
+#: pkg/shell/index.html:165
+msgid "Use my password for privileged tasks and to connect to other machines"
+msgstr "为特权任务使用密码并连接到其他主机"
+
+#: pkg/subscriptions/subscriptions-register.jsx:132
+msgid "Use proxy server"
 msgstr ""
-"Cockpit 是一个服务器管理器, 可以方便地通过浏览器来管理你的 Linux 服务器.在终"
-"端和 web 工具间切换没有任何问题. 服务可以通过 Cockpit 启动, 通过终端停止.同样"
-"地, 如果在终端中发生错误, 也可以​​在 Cockpit journal 接口中看到."
 
-#: cockpit.appdata.xml.in.h:2
-msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
-"stopping services. You can monitor and administer several servers at the "
-"same time. Just add them with a single click and your machines will look "
-"after its buddies."
-msgstr ""
-"Cockpit 是完美的系统管理员工具, 它可以轻松完成简单的任务, 如存储管理, 检查 "
-"journals 和启动/停止服务. 您可以同时监控和管理几个服务器. 只需要逐一添加, 您"
-"的机器就可以看到它们了."
+#: pkg/shell/index.html:172
+msgid "Use the following keys to authenticate against other systems"
+msgstr "使用以下密钥来认证其他系统"
 
-#: cockpit.desktop.in.h:1 pkg/shell/index.html.h:1 pkg/shell/stub.html.h:1
-#: pkg/shell/simple.html.h:1
-msgid "Cockpit"
-msgstr "Cockpit"
+#: pkg/systemd/index.html:251
+msgid "Used"
+msgstr "已使用"
 
-#: cockpit.desktop.in.h:2
-msgid "A user interface for GNU/Linux servers"
-msgstr "一个 GNU/Linux 服务器管理界面"
+#: pkg/systemd/index.html:229 pkg/dashboard/index.html:158
+#: pkg/playground/translate.html:86 pkg/playground/translate.html:106
+#: pkg/kubernetes/views/user-panel.html:9
+#: pkg/kubernetes/views/auth-form.html:61
+#: pkg/kubernetes/views/volume-body.html:64
+#: pkg/kubernetes/views/volume-body.html:103
+msgid "User"
+msgstr "用户"
 
-#: cockpit.desktop.in.h:3
-msgid "Remote;Administration;"
-msgstr "Remote;Administration;"
+#: pkg/users/index.html:90 pkg/users/index.html:154
+#: pkg/realmd/operation.html:47
+msgid "User Name"
+msgstr "用户名"
 
-#: pkg/systemd/index.html.h:1
-#, fuzzy
-msgid "System"
-msgstr "系统时间"
+#: pkg/realmd/operation.html:53
+msgid "User Password"
+msgstr "用户密码"
 
-#: pkg/systemd/index.html.h:2
-msgid "No host keys found."
-msgstr "没有找到主机密钥。"
+#: pkg/lib/machine-change-auth.html:18
+msgid "User name"
+msgstr "用户名"
 
-#: pkg/systemd/index.html.h:3
-msgid "Synchronized with {{Server}}"
-msgstr "与 {{Server}} 同步"
+#: pkg/kubernetes/views/add-member-role-dialog.html:15
+msgid "User or Group"
+msgstr "用户或组"
 
-#: pkg/systemd/index.html.h:4
-msgid "Synchronized"
-msgstr "已同步"
+#: pkg/kubernetes/views/auth-form.html:94
+msgid "Username"
+msgstr "用户名"
 
-#: pkg/systemd/index.html.h:5
-msgid "Trying to synchronize with {{Server}}"
-msgstr "正在尝试与 {{Server}} 同步"
+#: pkg/kubernetes/views/project-listing.html:85
+msgid "Users"
+msgstr "用户"
 
-#: pkg/systemd/index.html.h:6
-msgid "Not synchronized"
-msgstr "未同步"
+#: pkg/storaged/details.js:181
+msgid "VFAT - Compatible with all systems and devices"
+msgstr "VFAT - 兼容所有系统和设备"
 
-#: pkg/systemd/index.html.h:7
-msgid "Hardware"
-msgstr "硬件"
+#: pkg/networkmanager/interfaces.js:2237 pkg/networkmanager/interfaces.js:2249
+#: pkg/networkmanager/interfaces.js:2622
+msgid "VLAN"
+msgstr "VLAN"
 
-#: pkg/systemd/index.html.h:8
-msgid "Asset Tag"
-msgstr "资产标记"
+#: pkg/networkmanager/index.html:141
+msgid "VLAN Id"
+msgstr "VLAN Id"
 
-#: pkg/systemd/index.html.h:9 pkg/kubernetes/views/node-body.html.h:6
-msgid "Machine ID"
-msgstr "机器编号"
+#: pkg/networkmanager/index.html:736
+msgid "VLAN Settings"
+msgstr "VLAN 设置"
 
-#: pkg/systemd/index.html.h:10 pkg/ostree/index.html.h:18
-#: pkg/kubernetes/views/nodes-page.html.h:6
-msgid "Operating System"
-msgstr "操作系统"
+#: pkg/users/authorized-keys.js:103
+msgid "Validating key"
+msgstr "验证 key"
 
-#: pkg/systemd/index.html.h:11
-msgid "Secure Shell Keys"
-msgstr "安全 Shell  密钥"
+#: pkg/systemd/index.html:98 pkg/ostree/index.html:113 pkg/shell/simple.html:77
+#: pkg/shell/index.html:90 pkg/shell/stub.html:83
+msgid "Version"
+msgstr "版本"
 
-#: pkg/systemd/index.html.h:12
-msgid "Show fingerprints"
-msgstr "显示指印"
+#: pkg/storaged/jobs.js:137
+msgid "Very securely erasing $target"
+msgstr "多重安全擦除 $target"
 
-#: pkg/systemd/index.html.h:14 pkg/dashboard/index.html.h:7
-msgid "Host Name"
-msgstr "主机名"
+#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
+#: pkg/kubernetes/views/pvc-body.html:6
+msgid "Volume"
+msgstr "卷"
 
-#: pkg/systemd/index.html.h:15
-msgid "Domain"
-msgstr "域"
+#: pkg/storaged/index.html:620
+msgid "Volume Group"
+msgstr "卷组"
 
-#: pkg/systemd/index.html.h:16
-msgid "System Time"
-msgstr "系统时间"
+#: pkg/storaged/utils.js:239
+msgid "Volume Group $0"
+msgstr "卷组 $0"
 
-#: pkg/systemd/index.html.h:17
-msgid "Power Options"
-msgstr "电源选项"
+#: pkg/storaged/index.html:98
+msgid "Volume Groups"
+msgstr "卷组"
 
-#: pkg/systemd/index.html.h:20
-msgid "Performance Profile"
-msgstr "性能配置集"
+#: pkg/kubernetes/views/volume-body.html:14
+#: pkg/kubernetes/views/volume-body.html:89
+msgid "Volume ID"
+msgstr "卷编号"
 
-#: pkg/systemd/index.html.h:21
-msgid "Store Performance Data"
-msgstr "保存性能数据"
+#: pkg/kubernetes/views/pv-modify.html:115
+#: pkg/kubernetes/views/volume-body.html:42
+msgid "Volume Name"
+msgstr "卷名称"
 
-#: pkg/systemd/index.html.h:32
-msgid "Machine SSH Key Fingerprints"
-msgstr "主机 SSH 密钥指纹"
+#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
+msgid "Volume Type"
+msgstr "卷类型"
 
-#: pkg/systemd/index.html.h:33
-msgid "Pretty Host Name"
-msgstr "短主机名"
+#: pkg/docker/index.html:536 pkg/kubernetes/views/pod-page.html:18
+#: pkg/kubernetes/views/image-config.html:28
+#: pkg/kubernetes/views/dashboard-page.html:47 pkg/kubernetes/index.html:70
+msgid "Volumes"
+msgstr "卷"
 
-#: pkg/systemd/index.html.h:34
-msgid "Real Host Name"
-msgstr "实际主机名"
+#: pkg/networkmanager/interfaces.js:819
+msgid "Waiting"
+msgstr "等待中"
 
-#: pkg/systemd/index.html.h:35
-msgid "Time Zone"
-msgstr "时区"
+#: pkg/kubernetes/views/pv-modify.html:24
+msgid "Warning:"
+msgstr "警告:"
 
-#: pkg/systemd/index.html.h:36
-msgid ""
-"\n"
-"                                    Invalid time zone\n"
-"                                "
-msgstr ""
-"\n"
-"                                    无效时区\n"
-"                                "
-
-#: pkg/systemd/index.html.h:39
-msgid "Set Time"
-msgstr "设置时间"
-
-#: pkg/systemd/index.html.h:40
-msgid "Manually"
-msgstr "手动的"
-
-#: pkg/systemd/index.html.h:41
-msgid "Automatically using NTP"
-msgstr "自动的（使用 NTP）"
-
-#: pkg/systemd/index.html.h:42
-msgid "Automatically using specific NTP servers"
-msgstr "自动的（使用指定 NTP 服务器）"
-
-#: pkg/systemd/index.html.h:43
-msgid "Delay"
-msgstr "延时"
-
-#: pkg/systemd/index.html.h:44
-msgid "1 Minute"
-msgstr "1 分钟"
-
-#: pkg/systemd/index.html.h:45
-msgid "5 Minutes"
-msgstr "5 分钟"
-
-#: pkg/systemd/index.html.h:46
-msgid "20 Minutes"
-msgstr "20 分钟"
-
-#: pkg/systemd/index.html.h:47
-msgid "40 Minutes"
-msgstr "40 分钟"
-
-#: pkg/systemd/index.html.h:48
-msgid "60 Minutes"
-msgstr "60 分钟"
-
-#: pkg/systemd/index.html.h:49
-msgid "No Delay"
-msgstr "无延时"
-
-#: pkg/systemd/index.html.h:50
-msgid "Specific Time"
-msgstr "指定时间"
-
-#: pkg/systemd/index.html.h:51
-msgid ""
-"\n"
-"                        Cancel\n"
-"                    "
-msgstr ""
-"\n"
-"                        取消\n"
-"                    "
-
-#: pkg/systemd/logs.html.h:1
-msgid "Journal"
-msgstr "日志"
-
-#: pkg/systemd/logs.html.h:2
-msgid "Recent"
-msgstr "最近"
-
-#: pkg/systemd/logs.html.h:3
-msgid "Current boot"
-msgstr "当前启动"
-
-#: pkg/systemd/logs.html.h:4
-msgid "Last 24 hours"
-msgstr "最近 24 小时"
-
-#: pkg/systemd/logs.html.h:5
-msgid "Last 7 days"
-msgstr "最近 7 天"
-
-#: pkg/systemd/logs.html.h:6
-msgid "Errors"
-msgstr "错误"
-
-#: pkg/systemd/logs.html.h:7
+#: pkg/systemd/logs.html:48
 msgid "Warnings"
 msgstr "警告"
 
-#: pkg/systemd/logs.html.h:8
-msgid "Notices"
-msgstr "通知"
-
-#: pkg/systemd/logs.html.h:9
-msgid "All"
-msgstr "所有"
-
-#: pkg/systemd/logs.html.h:10 pkg/kubernetes/views/container-panel.html.h:2
-#: pkg/kubernetes/views/container-page-inline.html.h:2
-msgid "Logs"
-msgstr "日志"
-
-#: pkg/systemd/logs.html.h:11
-msgid "Entry"
-msgstr "条目"
-
-#: pkg/systemd/services.html.h:1 pkg/kubernetes/views/dashboard-page.html.h:12
-#: pkg/kubernetes/views/details-page.html.h:3
-msgid "Services"
-msgstr "服务"
-
-#: pkg/systemd/services.html.h:3
-msgid "System Services"
-msgstr "系统服务"
-
-#: pkg/systemd/services.html.h:4
-msgid "Sockets"
-msgstr "套接字"
-
-#: pkg/systemd/services.html.h:5
-msgid "Timers"
-msgstr "计时器"
-
-#: pkg/systemd/services.html.h:6
-msgid "Paths"
-msgstr "路径"
-
-#: pkg/systemd/services.html.h:7
-msgid "Instantiate"
-msgstr "实例"
-
-#: pkg/systemd/services.html.h:8
-msgid "{{days_text}}"
-msgstr ""
-
-#: pkg/systemd/services.html.h:9
-msgid "Service Logs"
-msgstr "服务日志"
-
-#: pkg/systemd/services.html.h:10
-msgid "Note"
-msgstr "注意"
-
-#: pkg/systemd/services.html.h:11
-msgid ""
-"This unit is not designed to be enabled explicitly.\n"
-"          "
-msgstr ""
-"该单元未设计为明确启用.\n"
-"          "
-
-#: pkg/systemd/services.html.h:15
-#, fuzzy
-msgid "Create Timers"
-msgstr "创建稀疏卷"
-
-#: pkg/systemd/services.html.h:16
-#, fuzzy
-msgid "Service name"
-msgstr "服务"
-
-#: pkg/systemd/services.html.h:18 pkg/docker/index.html.h:32
-msgid "Command"
-msgstr "命令"
-
-#: pkg/systemd/services.html.h:19
-#, fuzzy
-msgid "Run"
-msgstr "运行为"
-
-#: pkg/systemd/services.html.h:20
-#, fuzzy
-msgid "After system boot"
-msgstr "注册系统"
-
-#: pkg/systemd/services.html.h:21
-#, fuzzy
-msgid "At specific time"
-msgstr "指定时间"
-
-#: pkg/systemd/services.html.h:22
-msgid "Seconds"
-msgstr ""
-
-#: pkg/systemd/services.html.h:23
-#, fuzzy
-msgid "Minutes"
-msgstr "5 分钟"
-
-#: pkg/systemd/services.html.h:24
-#, fuzzy
-msgid "Hours"
-msgstr "6 小时"
-
-#: pkg/systemd/services.html.h:25
+#: pkg/systemd/services.html:409
 msgid "Weeks"
 msgstr ""
 
-#: pkg/systemd/services.html.h:26
-msgid "Don't Repeat"
-msgstr ""
+#: pkg/kubernetes/views/registry-dashboard-page.html:5
+msgid "Welcome to the Image Registry"
+msgstr "欢迎使用镜像注册表"
 
-#: pkg/systemd/services.html.h:27
-msgid "Repeat Hourly"
-msgstr ""
+#: pkg/kubernetes/views/volumes-page.html:61
+msgid "When"
+msgstr "当"
 
-#: pkg/systemd/services.html.h:28
-msgid "Repeat Daily"
-msgstr ""
+#: pkg/docker/index.html:507
+msgid "With terminal"
+msgstr "跟随终端"
 
-#: pkg/systemd/services.html.h:29
-msgid "Repeat Weekly"
-msgstr ""
+#: pkg/storaged/index.html:438
+msgctxt "storage"
+msgid "World Wide Name"
+msgstr "全局名称"
 
-#: pkg/systemd/services.html.h:30
-msgid "Repeat Monthly"
-msgstr ""
+#: pkg/storaged/details.js:1595
+msgid "Write-mostly"
+msgstr "Write-mostly"
 
-#: pkg/systemd/services.html.h:31
-msgid "Repeat Yearly"
-msgstr ""
+#: pkg/storaged/index.html:333
+msgid "Writing"
+msgstr "写入中"
 
-#: pkg/systemd/services.html.h:32
-#, fuzzy
-msgid "Hour : Minute"
-msgstr "1 分钟"
+#: pkg/ostree/client.js:64
+msgid "Writing objects"
+msgstr "正在写对象"
 
-#: pkg/systemd/services.html.h:33
-msgid ":"
-msgstr ""
+#: pkg/storaged/details.js:177
+msgid "XFS - Red Hat Enterprise Linux 7 default"
+msgstr "XFS - Red Hat Enterprise Linux 7 默认"
 
-#: pkg/systemd/services.html.h:35
-msgid "Save"
-msgstr ""
+#: pkg/networkmanager/interfaces.js:1824
+msgid "XOR"
+msgstr "XOR"
 
-#: pkg/systemd/terminal.html.h:1
-msgid "Terminal"
-msgstr "终端"
+#: pkg/kubernetes/scripts/volumes.js:990 pkg/networkmanager/interfaces.js:2279
+msgid "Yes"
+msgstr "是"
 
-#: pkg/lib/machine-invalid-hostkey.html.h:1
-msgid "Incorrect Host Key"
-msgstr "不正确的主机密钥"
-
-#: pkg/lib/machine-invalid-hostkey.html.h:2
-msgid ""
-"The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
-"in use. Unless this machine was recently replaced, it is likely that someone "
-"is trying to attack your connection to this machine."
-msgstr ""
-"{{#strong}}{{host}}{{/strong}} 的密钥与之前使用的不匹配。除非该主机最近被替"
-"换，否则可能有人正在攻击与该主机的连接。"
-
-#: pkg/lib/machine-invalid-hostkey.html.h:3
-msgid ""
-"You can remove the previously stored key by running the following command"
-msgstr "可以通过使用以下命令来移除之前保存的密钥"
-
-#: pkg/lib/machine-auth-failed.html.h:1
-msgid "Authentication Failed"
-msgstr "认证失败"
-
-#: pkg/lib/machine-auth-failed.html.h:2
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. To use this "
-"machine with cockpit you will need to enable one of the following "
-"authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
-msgstr ""
-"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。 To use this machine with "
-"cockpit 需要在 {{#strong}}{{host}}{{/strong}} 上的 sshd 配置中启用以下认证方"
-"式其中之一 来使用该主机的 Cockpit:"
-
-#: pkg/lib/machine-auth-failed.html.h:4 pkg/shell/index.html.h:30
-msgid "Public Key"
-msgstr "公钥"
-
-#: pkg/lib/machine-auth-failed.html.h:5
-msgid "Kerberos Based SSO"
-msgstr "基于 Kerberos 的 SSO"
-
-#: pkg/lib/machine-auth-failed.html.h:6
-msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
-msgstr ""
-"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。 {{#can_sync}}也许想要尝"
-"试 {{#sync_link}}同步用户{{/sync_link}}。{{/can_sync}} 更多认证选项和排错支"
-"持，请更新 cockpit-ws 到一个新版本。"
-
-#: pkg/lib/machine-sync-users.html.h:1 pkg/dashboard/index.html.h:11
-msgid "Synchronize users"
-msgstr "同步用户"
-
-#: pkg/lib/machine-sync-users.html.h:2
-msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
-msgstr "选择你想要与 {{#strong}}{{host}}{{/strong}} 同步的用户"
-
-#: pkg/lib/machine-sync-users.html.h:3
-msgid "Error loading users: {{perm_failed}}"
-msgstr "加载用户: {{perm_failed}} 出错"
-
-#: pkg/lib/machine-sync-users.html.h:4
+#: pkg/lib/machine-sync-users.html:47
 msgid ""
 "You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
 "synchronize users, a user with superuser privileges is required."
@@ -3639,2684 +6161,228 @@ msgstr ""
 "已经连接到 {{#strong}}{{host}}{{/strong}}，然而为了同步用户，需要一个特权用"
 "户。"
 
-#: pkg/lib/machine-sync-users.html.h:5 pkg/lib/machine-change-auth.html.h:4
-msgid "User name"
-msgstr "用户名"
-
-#: pkg/lib/machine-sync-users.html.h:8
-msgid "Synchronize"
-msgstr "同步"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:1
-msgid "Unknown Host Key"
-msgstr "未知主机密钥"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:2
+#: pkg/dashboard/list.js:394
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
-msgstr "主机 {{#strong}}{{host}}{{/strong}} 的认证无法完成。确认想要继续连接？"
+"You are currently connected directly to this server. You cannot delete it."
+msgstr "您当前已直接连接到该服务器。您不能删除它。"
 
-#: pkg/lib/machine-unknown-hostkey.html.h:3 pkg/shell/index.html.h:4
-msgid "Fingerprint"
-msgstr "指印"
-
-#: pkg/lib/machine-unknown-hostkey.html.h:5
-#: pkg/kubernetes/views/auth-form.html.h:14
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:6
-msgid "Connect"
-msgstr "连接"
-
-#: pkg/lib/machine-add.html.h:1
-msgid "Add Machine to Dashboard"
-msgstr "添加主机到仪表板"
-
-#: pkg/lib/machine-add.html.h:3 pkg/dashboard/index.html.h:9
-msgid "Color"
-msgstr "颜色"
-
-#: pkg/lib/machine-add.html.h:4
-msgid ""
-"Connecting simultaneously to more than {{ limit }} machines is unsupported."
-msgstr "不支持同时连接到超过 {{ limit }} 主机。"
-
-#: pkg/lib/machine-change-port.html.h:1
-msgid "Could not contact {{host}}"
-msgstr "无法联系 {{host}}"
-
-#: pkg/lib/machine-change-port.html.h:2
-msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
-msgstr "Cockpit 无法联系 {{#strong}}{{host}}{{/strong}}。"
-
-#: pkg/lib/machine-change-port.html.h:3
-msgid ""
-"To try a different port you will need to upgrade cockpit-ws to a newer "
-"version."
-msgstr "需要更新 cockpit-ws 到一个新版本来尝试一个不同的端口。"
-
-#: pkg/lib/machine-change-port.html.h:4
-msgid "Is sshd running on a different port?"
-msgstr "sshd 是否在一个不同的端口上运行？"
-
-#: pkg/lib/machine-change-port.html.h:7
-msgid "Update"
-msgstr "更新"
-
-#: pkg/lib/machine-not-supported.html.h:1
-msgid "Cockpit is not installed"
-msgstr "Cockpit 未安装"
-
-#: pkg/lib/machine-not-supported.html.h:2
-msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
-msgstr "{{#strong}}{{host}}{{/strong}} 上未安装一个兼容版本的 Cockpit。"
-
-#: pkg/lib/machine-change-auth.html.h:1
-msgid "Log in to {{host}}"
-msgstr "登录到 {{host}}"
-
-#: pkg/lib/machine-change-auth.html.h:2
-msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
-msgstr "Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}."
-
-#: pkg/lib/machine-change-auth.html.h:3
-msgid ""
-"Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
-msgstr ""
-"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。可以变更以下认证凭证。"
-"{{#can_sync}}也许想要 {{#sync_link}}同步账号和密码{{/sync_link}}.{{/"
-"can_sync}}"
-
-#: pkg/lib/machine-change-auth.html.h:5 pkg/shell/index.html.h:9
-#: pkg/realmd/operation.html.h:3 pkg/kubernetes/views/auth-form.html.h:8
-msgid "Authentication"
-msgstr "认证"
-
-#: pkg/lib/machine-change-auth.html.h:7
-msgid "Available"
-msgstr "可用的"
-
-#: pkg/lib/machine-change-auth.html.h:8
-msgid "Login Password"
-msgstr "登录密码"
-
-#: pkg/lib/machine-change-auth.html.h:9
-msgid "Kerberos Ticket"
-msgstr "Kerberos 权证"
-
-#: pkg/lib/machine-change-auth.html.h:10
-msgid "Checking for public keys"
-msgstr "检查公钥"
-
-#: pkg/lib/machine-change-auth.html.h:12
-msgid "Log In"
-msgstr "登录"
-
-#: pkg/shell/shell.html.h:1
-msgid "Things have moved"
-msgstr ""
-
-#: pkg/shell/index.html.h:2
-msgid "Comment"
-msgstr "说明"
-
-#: pkg/shell/index.html.h:5 pkg/shell/stub.html.h:2 pkg/shell/simple.html.h:2
-msgid "Ooops!"
-msgstr "糟糕！"
-
-#: pkg/shell/index.html.h:6 pkg/shell/stub.html.h:3 pkg/shell/simple.html.h:3
-msgid "Display Language"
-msgstr "显示语言"
-
-#: pkg/shell/index.html.h:7 pkg/shell/stub.html.h:4 pkg/shell/simple.html.h:4
-msgid "About Cockpit"
-msgstr "关于 Cockpit"
-
-#: pkg/shell/index.html.h:8
-msgid "Account Settings"
-msgstr "账户设置"
-
-#: pkg/shell/index.html.h:10 pkg/shell/stub.html.h:5 pkg/shell/simple.html.h:5
-msgid "Log out"
-msgstr "登出"
-
-#: pkg/shell/index.html.h:11 pkg/shell/stub.html.h:6 pkg/shell/simple.html.h:6
-msgid ""
-"\n"
-"              Cockpit is an interactive Linux server admin interface.\n"
-"            "
-msgstr ""
-"\n"
-"              Cockpit 是一个交互式 Linux 服务器管理工具。\n"
-"            "
-
-#: pkg/shell/index.html.h:15 pkg/shell/stub.html.h:10
-#: pkg/shell/simple.html.h:10
-msgid "Choose the language to be used in the application"
-msgstr "选择用于应用程序的语言"
-
-#: pkg/shell/index.html.h:16 pkg/shell/stub.html.h:11
-#: pkg/shell/simple.html.h:11 pkg/storaged/index.html.h:59
-msgid ""
-"\n"
-"              Cancel\n"
-"            "
-msgstr ""
-"\n"
-"              取消\n"
-"            "
-
-#: pkg/shell/index.html.h:19 pkg/shell/stub.html.h:14
-#: pkg/shell/simple.html.h:14
-msgid ""
-"\n"
-"              Select\n"
-"            "
-msgstr ""
-"\n"
-"              选择\n"
-"            "
-
-#: pkg/shell/index.html.h:22 pkg/shell/stub.html.h:17
-msgid ""
-"\n"
-"              Close\n"
-"            "
-msgstr ""
-"\n"
-"              关闭\n"
-"            "
-
-#: pkg/shell/index.html.h:25
-msgid "Use my password for privileged tasks and to connect to other machines"
-msgstr "为特权任务使用密码并连接到其他主机"
-
-#: pkg/shell/index.html.h:26
-msgid "Use the following keys to authenticate against other systems"
-msgstr "使用以下密钥来认证其他系统"
-
-#: pkg/shell/index.html.h:29 pkg/kubernetes/index.html.h:6
-msgid "Details"
-msgstr "详情"
-
-#: pkg/shell/index.html.h:32
-msgid "Unlock Key"
-msgstr "解锁密钥"
-
-#: pkg/shell/index.html.h:33 pkg/users/index.html.h:23
-msgid "Old Password"
-msgstr "旧密码"
-
-#: pkg/shell/index.html.h:34 pkg/users/index.html.h:24
-msgid "New Password"
-msgstr "新密码"
-
-#: pkg/shell/index.html.h:35 pkg/users/index.html.h:19
-msgid "Confirm"
-msgstr "确认"
-
-#: pkg/shell/index.html.h:36
-msgid "Change Password"
-msgstr "变更密码"
-
-#: pkg/shell/index.html.h:38 pkg/shell/stub.html.h:20
-msgid ""
-"\n"
-"                Tools\n"
-"              "
-msgstr ""
-"\n"
-"                工具\n"
-"              "
-
-#: pkg/shell/index.html.h:41 pkg/shell/stub.html.h:23
-#: pkg/shell/simple.html.h:24
-msgid "Reconnect"
-msgstr "重新连接"
-
-#: pkg/shell/index.html.h:42 pkg/shell/stub.html.h:24
-msgid "Troubleshoot"
-msgstr "排错"
-
-#: pkg/shell/simple.html.h:18
-msgid ""
-"\n"
-"              Try to reconnect\n"
-"            "
-msgstr ""
-"\n"
-"              尝试重新连接\n"
-"            "
-
-#: pkg/shell/simple.html.h:21
-msgid ""
-"\n"
-"              Log in again\n"
-"            "
-msgstr ""
-"\n"
-"              重新登陆\n"
-"            "
-
-#: pkg/ostree/index.html.h:1
-msgid "Software Updates"
-msgstr "软件更新"
-
-#: pkg/ostree/index.html.h:2
-msgid "Check for updates"
-msgstr "检查更新"
-
-#: pkg/ostree/index.html.h:3
-msgid ""
-"\n"
-"                    Update and reboot\n"
-"                "
-msgstr ""
-"\n"
-"                    更新并重启\n"
-"                "
-
-#: pkg/ostree/index.html.h:6
-msgid "Roll back and reboot"
-msgstr "回滚并重启"
-
-#: pkg/ostree/index.html.h:8
-msgid ""
-"\n"
-"                    Default\n"
-"                  "
-msgstr ""
-"\n"
-"                    默认\n"
-"                  "
-
-#: pkg/ostree/index.html.h:11
-msgid ""
-"\n"
-"                    Available\n"
-"                  "
-msgstr ""
-"\n"
-"                    可用的\n"
-"                  "
-
-#: pkg/ostree/index.html.h:16
-msgid "Tree"
-msgstr "Tree"
-
-#: pkg/ostree/index.html.h:17
-msgid "Packages"
-msgstr "软件包"
-
-#: pkg/ostree/index.html.h:20
-msgid "Released"
-msgstr "发布于"
-
-#: pkg/ostree/index.html.h:21
-msgid "Additions"
-msgstr "添加"
-
-#: pkg/ostree/index.html.h:22
-msgid "Removals"
-msgstr "移除"
-
-#: pkg/ostree/index.html.h:23
-msgid "Updates"
-msgstr "更新"
-
-#: pkg/ostree/index.html.h:24
-msgid "Downgrades"
-msgstr "降级"
-
-#: pkg/ostree/index.html.h:25
-msgid ""
-"\n"
-"                    This deployment contains the same packages as your "
-"currently booted system\n"
-"                "
-msgstr ""
-"\n"
-"                    该部署包含相同的软件包作为当前启动的系统\n"
-"                "
-
-#: pkg/ostree/index.html.h:28
-msgid "Operating System Updates"
-msgstr "操作系统更新"
-
-#: pkg/ostree/index.html.h:29
-msgid "Connecting"
-msgstr "连接"
-
-#: pkg/ostree/index.html.h:30
-msgid "Unable to communicate with OSTree"
-msgstr "无法与 OSTree 通信"
-
-#: pkg/ostree/index.html.h:31
-msgid "No Deployments"
-msgstr "没有部署"
-
-#: pkg/ostree/index.html.h:32
-msgid ""
-"\n"
-"                    Reconnect\n"
-"                "
-msgstr ""
-"\n"
-"                    重连\n"
-"                "
-
-#: pkg/selinux/setroubleshoot.html.h:1
-msgid "SELinux Troubleshoot"
-msgstr "SELinux 排错"
-
-#: pkg/machines/index.html.h:1
-msgid "Virtual Machines Management"
-msgstr ""
-
-#: pkg/storaged/index.html.h:1
-msgid "Storage"
-msgstr "存储"
-
-#: pkg/storaged/index.html.h:2
-msgid "The \"storaged\" API is not available on this system."
-msgstr "在此系统中, \"storaged\" API 不可用."
-
-#: pkg/storaged/index.html.h:3
-msgid "Start Multipath"
-msgstr "启用多路径"
-
-#: pkg/storaged/index.html.h:4
-msgid ""
-"\n"
-"        There are devices with multiple paths on the system, but the "
-"multipath service is not running.\n"
-"      "
-msgstr ""
-"\n"
-"        系统中存在多路径设备, 但 multipath 服务未运行.\n"
-"      "
-
-#: pkg/storaged/index.html.h:7
-msgid "RAID Devices"
-msgstr "RAID 设备"
-
-#: pkg/storaged/index.html.h:8
-msgid "No storage set up as RAID"
-msgstr "没有存储设置为 RAID"
-
-#: pkg/storaged/index.html.h:9
-msgid "Volume Groups"
-msgstr "卷组"
-
-#: pkg/storaged/index.html.h:10
-msgid "No volume groups created"
-msgstr "没有创建的卷组"
-
-#: pkg/storaged/index.html.h:11
-msgid "iSCSI Targets"
-msgstr "iSCSI 目标"
-
-#: pkg/storaged/index.html.h:12
-msgid "{{Address}}:{{Port}}"
-msgstr "{{Address}}:{{Port}}"
-
-#: pkg/storaged/index.html.h:13
-msgid "No iSCSI targets set up"
-msgstr "没有设置 iSCSI 目标"
-
-#: pkg/storaged/index.html.h:14
-msgid "Drives"
-msgstr "驱动器"
-
-#: pkg/storaged/index.html.h:15
-msgid "No drives attached"
-msgstr "没有附件的驱动器"
-
-#: pkg/storaged/index.html.h:16
-msgid "Other Devices"
-msgstr "其他设备"
-
-#: pkg/storaged/index.html.h:17
-msgid "Filesystems"
-msgstr "文件系统"
-
-#: pkg/storaged/index.html.h:21
-msgid "Jobs"
-msgstr "任务"
-
-#: pkg/storaged/index.html.h:23 pkg/networkmanager/index.html.h:3
-msgid "Go to now"
-msgstr "转到现在"
-
-#: pkg/storaged/index.html.h:24 pkg/networkmanager/index.html.h:4
-msgid "5 minutes"
-msgstr "5 分钟"
-
-#: pkg/storaged/index.html.h:25 pkg/networkmanager/index.html.h:5
-msgid "1 hour"
-msgstr "1 小时"
-
-#: pkg/storaged/index.html.h:26 pkg/networkmanager/index.html.h:6
-msgid "6 hours"
-msgstr "6 小时"
-
-#: pkg/storaged/index.html.h:27 pkg/networkmanager/index.html.h:7
-msgid "1 day"
-msgstr "1 天"
-
-#: pkg/storaged/index.html.h:28 pkg/networkmanager/index.html.h:8
-msgid "1 week"
-msgstr "1 周"
-
-#: pkg/storaged/index.html.h:29
-msgid "Reading"
-msgstr "读取中"
-
-#: pkg/storaged/index.html.h:30
-msgid "Writing"
-msgstr "写入中"
-
-#: pkg/storaged/index.html.h:31
-msgid "Storage Logs"
-msgstr "存储日志"
-
-#: pkg/storaged/index.html.h:32
-msgid "Create partition table"
-msgstr "创建分区表"
-
-#: pkg/storaged/index.html.h:34
-msgid "Block Device"
-msgstr "块设备"
-
-#: pkg/storaged/index.html.h:40
-msgid "No media inserted"
-msgstr "没有插入媒体"
-
-#: pkg/storaged/index.html.h:42
-msgid "DISK IS FAILING"
-msgstr "磁盘错误"
-
-#: pkg/storaged/index.html.h:43
-msgid "Disk is OK"
-msgstr "磁盘良好"
-
-#: pkg/storaged/index.html.h:46
-msgid "The RAID Array is in a degraded state"
-msgstr "RAID 阵列处于降级状态"
-
-#: pkg/storaged/index.html.h:47
-msgid "RAID Device"
-msgstr "RAID 设备"
-
-#: pkg/storaged/index.html.h:56
-msgid "Volume Group"
-msgstr "卷组"
-
-#: pkg/storaged/index.html.h:57
-msgid "Physical Volumes"
-msgstr "物理卷"
-
-#: pkg/storaged/index.html.h:58
-msgid "Storage Log"
-msgstr "存储日志"
-
-#: pkg/realmd/operation.html.h:1
-msgid "Domain Address"
-msgstr "域地址"
-
-#: pkg/realmd/operation.html.h:2
-msgid "Computer OU"
-msgstr "计算机 OU"
-
-#: pkg/realmd/operation.html.h:4 pkg/users/index.html.h:11
-msgid "User Name"
-msgstr "用户名"
-
-#: pkg/realmd/operation.html.h:5
-msgid "User Password"
-msgstr "用户密码"
-
-#: pkg/realmd/operation.html.h:6
-msgid "Domain Administrator Name"
-msgstr "域管理员用户名"
-
-#: pkg/realmd/operation.html.h:7
-msgid "Domain Administrator Password"
-msgstr "域管理员密码"
-
-#: pkg/realmd/operation.html.h:8
-msgid "One Time Password"
-msgstr "一次性密码"
-
-#: pkg/realmd/operation.html.h:9
-msgid "This may take a while"
-msgstr "这可能需要一些时间"
-
-#: pkg/docker/index.html.h:1 pkg/kubernetes/index.html.h:4
-#: pkg/kubernetes/views/containers-listing.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:6
-#: pkg/kubernetes/views/dashboard-page.html.h:17
-msgid "Containers"
-msgstr "容器"
-
-#: pkg/docker/index.html.h:2
-msgid "Connecting to Docker"
-msgstr "正在连接 Docker"
-
-#: pkg/docker/index.html.h:3
-msgid "Not authorized to access Docker on this system"
-msgstr "未授权访问该系统的 Docker"
-
-#: pkg/docker/index.html.h:4
-msgid "Docker is not installed or activated on the system"
-msgstr "系统中的 Docker 未安装或未启动"
-
-#: pkg/docker/index.html.h:5
-msgid "Can&rsquo;t connect to Docker"
-msgstr "无法连接到 Docker"
-
-#: pkg/docker/index.html.h:6
-msgid "Start Docker"
-msgstr "启动 Docker"
-
-#: pkg/docker/index.html.h:7
-msgid "Try again"
-msgstr "重试"
-
-#: pkg/docker/index.html.h:8
-msgid "Combined CPU usage"
-msgstr "结合 CPU 使用率"
-
-#: pkg/docker/index.html.h:9
-msgid "Combined memory usage"
-msgstr "结合内存使用率"
-
-#: pkg/docker/index.html.h:10
-#, fuzzy
-msgid "Show all containers"
-msgstr "显示所有容器"
-
-#: pkg/docker/index.html.h:11
-msgid "IP Address:"
-msgstr "IP 地址:"
-
-#: pkg/docker/index.html.h:12
-msgid "IP Prefix Length:"
-msgstr "IP 前缀长度:"
-
-#: pkg/docker/index.html.h:13
-msgid "Gateway:"
-msgstr "网关:"
-
-#: pkg/docker/index.html.h:14
-msgid "MAC Address:"
-msgstr "MAC 地址:"
-
-#: pkg/docker/index.html.h:15 pkg/kubernetes/views/image-page.html.h:1
-msgid "Show all images"
-msgstr "显示所有镜像"
-
-#: pkg/docker/index.html.h:16 pkg/kubernetes/index.html.h:2
-#: pkg/kubernetes/registry.html.h:2
-msgid "Overview"
-msgstr "概览"
-
-#: pkg/docker/index.html.h:17
-msgid "Reset"
-msgstr "重置"
-
-#: pkg/docker/index.html.h:18
-msgid "Storage pool"
-msgstr "存储池"
-
-#: pkg/docker/index.html.h:19
-msgid "Additional Storage"
-msgstr "额外的存储"
-
-#: pkg/docker/index.html.h:20
-msgid "TCP"
-msgstr "TCP"
-
-#: pkg/docker/index.html.h:21
-msgid "{{host_port_label}}"
-msgstr "{{host_port_label}}"
-
-#: pkg/docker/index.html.h:22
-msgid "{{host_volume_label}}"
-msgstr "{{host_volume_label}}"
-
-#: pkg/docker/index.html.h:24
-msgid "ReadWrite"
-msgstr "读写"
-
-#: pkg/docker/index.html.h:25
-msgid "ReadOnly"
-msgstr "只读"
-
-#: pkg/docker/index.html.h:26
-msgid "{{envvar_key_label}}"
-msgstr "{{envvar_key_label}}"
-
-#: pkg/docker/index.html.h:27
-msgid "{{envvar_value_label}}"
-msgstr "{{envvar_value_label}}"
-
-#: pkg/docker/index.html.h:28
-msgid "select container"
-msgstr "选择容器"
-
-#: pkg/docker/index.html.h:29
-msgid "{{alias_label}}"
-msgstr "{{alias_label}}"
-
-#: pkg/docker/index.html.h:30 pkg/kubernetes/views/image-panel.html.h:1
-#: pkg/kubernetes/views/container-body.html.h:2
-#: pkg/kubernetes/views/image-page.html.h:2
-msgid "Image"
-msgstr "镜像"
-
-#: pkg/docker/index.html.h:31
-msgid "Container Name"
-msgstr "容器名称"
-
-#: pkg/docker/index.html.h:33
-msgid "Memory limit"
-msgstr "内存限制"
-
-#: pkg/docker/index.html.h:34
-msgid "MiB"
-msgstr "MiB"
-
-#: pkg/docker/index.html.h:35
-msgid "CPU priority"
-msgstr "CPU 优先级"
-
-#: pkg/docker/index.html.h:36
-msgid "shares"
-msgstr "共享"
-
-#: pkg/docker/index.html.h:37
-msgid "With terminal"
-msgstr "跟随终端"
-
-#: pkg/docker/index.html.h:38
-msgid "Links"
-msgstr "连接"
-
-#: pkg/docker/index.html.h:40
-msgid "Expose container ports"
-msgstr "暴露容器端口"
-
-#: pkg/docker/index.html.h:41 pkg/kubernetes/index.html.h:7
-#: pkg/kubernetes/views/image-config.html.h:9
-#: pkg/kubernetes/views/pod-page.html.h:3
-#: pkg/kubernetes/views/dashboard-page.html.h:4
-msgid "Volumes"
-msgstr "卷"
-
-#: pkg/docker/index.html.h:42
-msgid "Mount container volumes"
-msgstr "挂载容器卷"
-
-#: pkg/docker/index.html.h:43 pkg/kubernetes/views/image-config.html.h:6
-#: pkg/kubernetes/views/container-body.html.h:9
-msgid "Environment"
-msgstr "环境变量"
-
-#: pkg/docker/index.html.h:44
-msgid "Set container environment variables"
-msgstr "设置容器环境变量"
-
-#: pkg/docker/index.html.h:45 pkg/kubernetes/views/pod-body.html.h:4
-msgid "Restart Policy"
-msgstr "重启策略"
-
-#: pkg/docker/index.html.h:47
-msgid "On Failure"
-msgstr "失败时"
-
-#: pkg/docker/index.html.h:50
-msgid "Retries:"
-msgstr "重试次数:"
-
-#: pkg/docker/index.html.h:51 pkg/users/index.html.h:26
-#: pkg/networkmanager/index.html.h:52
-msgid ""
-"\n"
-"            Cancel\n"
-"          "
-msgstr ""
-"\n"
-"            取消\n"
-"          "
-
-#: pkg/docker/index.html.h:54
-msgid ""
-"\n"
-"            Run\n"
-"          "
-msgstr ""
-"\n"
-"            运行\n"
-"          "
-
-#: pkg/docker/index.html.h:57
-msgid ""
-"\n"
-"            Download\n"
-"          "
-msgstr ""
-"\n"
-"            下载\n"
-"          "
-
-#: pkg/docker/index.html.h:60
-msgid ""
-"\n"
-"            Change\n"
-"          "
-msgstr ""
-"\n"
-"            修改\n"
-"          "
-
-#: pkg/docker/index.html.h:63
-msgid "Repository"
-msgstr "存储库"
-
-#: pkg/docker/index.html.h:64
-msgid "Tag"
-msgstr "标签"
-
-#: pkg/docker/index.html.h:65 pkg/kubernetes/views/image-listing.html.h:4
-#: pkg/kubernetes/views/image-body.html.h:5
-msgid "Author"
-msgstr "作者"
-
-#: pkg/docker/index.html.h:66
-msgid ""
-"\n"
-"            Commit\n"
-"          "
-msgstr ""
-"\n"
-"            提交\n"
-"          "
-
-#: pkg/users/index.html.h:1
-msgid "Local Accounts"
-msgstr "本地账户"
-
-#: pkg/users/index.html.h:2
-msgid ""
-"\n"
-"            Close\n"
-"          "
-msgstr ""
-"\n"
-"            关闭\n"
-"          "
-
-#: pkg/users/index.html.h:5
-msgid "Create New Account"
-msgstr "创建新账户"
-
-#: pkg/users/index.html.h:6
-msgid "Account not available or cannot be edited."
-msgstr "帐户不可用或不能编辑."
-
-#: pkg/users/index.html.h:7
-msgid "Accounts"
-msgstr "账户"
-
-#: pkg/users/index.html.h:8
-msgid "Terminate Session"
-msgstr "终止会话"
-
-#: pkg/users/index.html.h:10
-msgid "Full Name"
-msgstr "全名"
-
-#: pkg/users/index.html.h:12
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:3
-#: pkg/kubernetes/views/project-body.html.h:2
-msgid "Roles"
-msgstr "角色"
-
-#: pkg/users/index.html.h:13
-msgid "Last Login"
-msgstr "最近登陆"
-
-#: pkg/users/index.html.h:14
-msgid "Access"
-msgstr "访问"
-
-#: pkg/users/index.html.h:15
-msgid "Lock Account"
-msgstr "锁定账户"
-
-#: pkg/users/index.html.h:17
-msgid "Set Password"
-msgstr "设置密码"
-
-#: pkg/users/index.html.h:18
-msgid "Authorized Public SSH Keys"
-msgstr "授权公共 SSH 密钥"
-
-#: pkg/users/index.html.h:20
-msgid ""
-"\n"
-"            Create\n"
-"          "
-msgstr ""
-"\n"
-"            创建\n"
-"          "
-
-#: pkg/users/index.html.h:25
-msgid "Confirm New Password"
-msgstr "确认新密码"
-
-#: pkg/users/index.html.h:29
-msgid ""
-"\n"
-"            Set\n"
-"          "
-msgstr ""
-"\n"
-"            设置\n"
-"          "
-
-#: pkg/users/index.html.h:32
-msgid "Delete Files"
-msgstr "删除文件"
-
-#: pkg/users/index.html.h:33 pkg/networkmanager/index.html.h:48
-msgid ""
-"\n"
-"            Delete\n"
-"          "
-msgstr ""
-"\n"
-"            删除\n"
-"          "
-
-#: pkg/users/index.html.h:36
-msgid "Unnamed"
-msgstr "未命名"
-
-#: pkg/users/index.html.h:37
-msgid "Invalid key"
-msgstr "无效的 key"
-
-#: pkg/users/index.html.h:38
-msgid "There are no authorized public keys for this account."
-msgstr "存在未被该帐户授权的公钥."
-
-#: pkg/users/index.html.h:39
-msgid ""
-"You do not have permission to view the authorized public keys for this "
-"account."
-msgstr "您没有权限查看此帐户的授权公钥."
-
-#: pkg/users/index.html.h:40
-msgid "Failed to load authorized keys."
-msgstr "载入 authorized key 失败。"
-
-#: pkg/users/index.html.h:41
-msgid "Add public key"
-msgstr "添加公钥"
-
-#: pkg/users/index.html.h:42
-msgid ""
-"\n"
-"            Add key\n"
-"          "
-msgstr ""
-"\n"
-"            添加 key\n"
-"          "
-
-#: pkg/sosreport/index.html.h:1
-msgid "Diagnostic reports"
-msgstr "诊断报告"
-
-#: pkg/sosreport/index.html.h:2
-msgid ""
-"\n"
-"        This tool will collect system configuration and diagnostic\n"
-"        information from this system for use with diagnosing problems\n"
-"        with the system.\n"
-"      "
-msgstr ""
-"\n"
-"        该工具将会从该系统为有诊断系统问题的用户搜集系统配置和诊断信息。 \n"
-"        \n"
-"       \n"
-"      "
-
-#: pkg/sosreport/index.html.h:7
-msgid ""
-"\n"
-"        The collected information will be stored locally on the system.\n"
-"      "
-msgstr ""
-"\n"
-"       搜集的信息将会保存在系统本地。\n"
-"      "
-
-#: pkg/sosreport/index.html.h:10
-msgid "Create report"
-msgstr "创建报告"
-
-#: pkg/sosreport/index.html.h:11
-msgid "Create diagnostic report"
-msgstr "创建诊断报告"
-
-#: pkg/sosreport/index.html.h:12
-msgid ""
-"\n"
-"                The generated archive contains data considered\n"
-"                sensitive and its content should be reviewed by the\n"
-"                originating organization before being passed to any\n"
-"                third party.\n"
-"              "
-msgstr ""
-"\n"
-"                生成的文档包含被认为敏感的数据，并且在发送给第三方之前其内容"
-"应该被原始组织评审。\n"
-"                \n"
-"                \n"
-"              \n"
-"              "
-
-#: pkg/sosreport/index.html.h:18
-msgid "Generating report"
-msgstr "正在生成报告"
-
-#: pkg/sosreport/index.html.h:19
-msgid "Done!"
-msgstr "已完成！"
-
-#: pkg/networkmanager/index.html.h:1
-msgid "Networking"
-msgstr "网络"
-
-#: pkg/networkmanager/index.html.h:2
-msgid "Testing connection"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:9
-msgid "Sending"
-msgstr "发送中"
-
-#: pkg/networkmanager/index.html.h:10
-msgid "Receiving"
-msgstr "接收中"
-
-#: pkg/networkmanager/index.html.h:11
-msgid "Interfaces"
-msgstr "接口"
-
-#: pkg/networkmanager/index.html.h:12
-msgid "Add Bond"
-msgstr "添加绑定"
-
-#: pkg/networkmanager/index.html.h:13
-#, fuzzy
-msgid "Add Team"
-msgstr "添加成员"
-
-#: pkg/networkmanager/index.html.h:14
-msgid "Add Bridge"
-msgstr "添加网桥"
-
-#: pkg/networkmanager/index.html.h:15
-msgid "Add VLAN"
-msgstr "添加 VLAN"
-
-#: pkg/networkmanager/index.html.h:17
-msgid "IP Address"
-msgstr "IP 地址"
-
-#: pkg/networkmanager/index.html.h:18
-#, fuzzy
-msgid "Unmanaged Interfaces"
-msgstr "接口"
-
-#: pkg/networkmanager/index.html.h:19
-msgid "Networking Logs"
-msgstr "联网日志"
-
-#: pkg/networkmanager/index.html.h:20
-msgid "Parent"
-msgstr "父接口"
-
-#: pkg/networkmanager/index.html.h:21
-msgid "VLAN Id"
-msgstr "VLAN Id"
-
-#: pkg/networkmanager/index.html.h:23
-msgid "Set to"
-msgstr "设置为"
-
-#: pkg/networkmanager/index.html.h:25
-msgid "Spanning Tree Protocol (STP)"
-msgstr "生成树协议 (STP)"
-
-#: pkg/networkmanager/index.html.h:26
-msgid "STP Priority"
-msgstr "STP 优先级"
-
-#: pkg/networkmanager/index.html.h:27
-msgid "STP Forward delay"
-msgstr "STP 转发延迟"
-
-#: pkg/networkmanager/index.html.h:28
-msgid "STP Hello time"
-msgstr "STP Hello 时间"
-
-#: pkg/networkmanager/index.html.h:29
-msgid "STP Maximum message age"
-msgstr "STP 最大消息有效期"
-
-#: pkg/networkmanager/index.html.h:30
-msgid "Priority"
-msgstr "优先级"
-
-#: pkg/networkmanager/index.html.h:31
-msgid "Path cost"
-msgstr "路径开销"
-
-#: pkg/networkmanager/index.html.h:32
-msgid "Hair Pin mode"
-msgstr "发夹模式"
-
-#: pkg/networkmanager/index.html.h:34
-msgid "Mode"
-msgstr "模式"
-
-#: pkg/networkmanager/index.html.h:35
-msgid "Primary"
-msgstr "主"
-
-#: pkg/networkmanager/index.html.h:36
-msgid "Link Monitoring"
-msgstr "链路监控"
-
-#: pkg/networkmanager/index.html.h:37
-msgid "Monitoring Interval"
-msgstr "监控间隔"
-
-#: pkg/networkmanager/index.html.h:38
-msgid "Monitoring Targets"
-msgstr "监控目标"
-
-#: pkg/networkmanager/index.html.h:39
-msgid "Link up delay"
-msgstr "链路启用延时"
-
-#: pkg/networkmanager/index.html.h:40
-msgid "Link down delay"
-msgstr "链路断开延时"
-
-#: pkg/networkmanager/index.html.h:41
-#, fuzzy
-msgid "Runner"
-msgstr "运行中"
-
-#: pkg/networkmanager/index.html.h:42
-msgid "Balancer"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:43
-#, fuzzy
-msgid "Link Watch"
-msgstr "本地链路"
-
-#: pkg/networkmanager/index.html.h:44
-#, fuzzy
-msgid "Ping Interval"
-msgstr "监控间隔"
-
-#: pkg/networkmanager/index.html.h:45
-#, fuzzy
-msgid "Ping Target"
-msgstr "目标"
-
-#: pkg/networkmanager/index.html.h:46
-msgid "Sticky"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:47
-msgid "LACP Key"
-msgstr ""
-
-#: pkg/networkmanager/index.html.h:51
-msgid "IP Settings"
-msgstr "IP 设置"
-
-#: pkg/networkmanager/index.html.h:55
-msgid ""
-"\n"
-"            Apply\n"
-"          "
-msgstr ""
-"\n"
-"            应用\n"
-"          "
-
-#: pkg/networkmanager/index.html.h:58
-msgid "Bond Settings"
-msgstr "绑定设置"
-
-#: pkg/networkmanager/index.html.h:59
-#, fuzzy
-msgid "Team Settings"
-msgstr "IP 设置"
-
-#: pkg/networkmanager/index.html.h:60
-#, fuzzy
-msgid "Team Port Settings"
-msgstr "网桥端口设置"
-
-#: pkg/networkmanager/index.html.h:61
-msgid "Bridge Settings"
-msgstr "网桥设置"
-
-#: pkg/networkmanager/index.html.h:62
-msgid "Bridge Port Settings"
-msgstr "网桥端口设置"
-
-#: pkg/networkmanager/index.html.h:63
-msgid "VLAN Settings"
-msgstr "VLAN 设置"
-
-#: pkg/networkmanager/index.html.h:64
-msgid "Ethernet MTU"
-msgstr "以太网 MTU"
-
-#: pkg/networkmanager/index.html.h:66
-#, fuzzy
-msgid "Connection will be lost"
-msgstr "连接超时。"
-
-#: pkg/kubernetes/index.html.h:1
-msgid "Kubernetes Cluster"
-msgstr "Kubernetes 集群"
-
-#: pkg/kubernetes/index.html.h:3 pkg/kubernetes/views/dashboard-page.html.h:8
-#: pkg/kubernetes/views/nodes-page.html.h:4
-msgid "Nodes"
-msgstr "节点"
-
-#: pkg/kubernetes/index.html.h:5
-msgid "Topology"
-msgstr "拓扑"
-
-#: pkg/kubernetes/index.html.h:8 pkg/kubernetes/registry.html.h:3
-#: pkg/kubernetes/views/image-listing.html.h:2
-#: pkg/kubernetes/views/imagestream-page.html.h:3
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:5
-msgid "Images"
-msgstr "镜像"
-
-#: pkg/kubernetes/index.html.h:9 pkg/kubernetes/registry.html.h:4
-#: pkg/kubernetes/views/group-delete.html.h:2
-#: pkg/kubernetes/views/project-listing.html.h:2
-#: pkg/kubernetes/views/user-delete.html.h:2
-msgid "Projects"
-msgstr "项目"
-
-#: pkg/kubernetes/index.html.h:11 pkg/kubernetes/registry.html.h:6
-msgid "Couldn't connect to server"
-msgstr "无法连接到服务器"
-
-#: pkg/kubernetes/index.html.h:12 pkg/kubernetes/registry.html.h:7
-msgid ""
-"\n"
-"                Reconnect\n"
-"            "
-msgstr ""
-"\n"
-"                重连\n"
-"            "
-
-#: pkg/kubernetes/index.html.h:15
-msgid ""
-"\n"
-"                Troubleshoot\n"
-"            "
-msgstr ""
-"\n"
-"                排错\n"
-"            "
-
-#: pkg/kubernetes/registry.html.h:1
-msgid "Image Registry"
-msgstr "镜像注册表"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:1
-#: pkg/kubernetes/views/service-body.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:1
-#: pkg/kubernetes/views/containers-listing.html.h:4
-#: pkg/kubernetes/views/volumes-page.html.h:9
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:1
-#: pkg/kubernetes/views/dashboard-page.html.h:18
-#: pkg/kubernetes/views/route-body.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:5
-#: pkg/kubernetes/views/imagestream-modify.html.h:4
-msgid "Project"
-msgstr "项目"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:2
-#: pkg/kubernetes/views/service-body.html.h:2
-#: pkg/kubernetes/views/pod-body.html.h:2
-#: pkg/kubernetes/views/containers-listing.html.h:5
-#: pkg/kubernetes/views/volumes-page.html.h:10
-#: pkg/kubernetes/views/pv-claim.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:2
-#: pkg/kubernetes/views/dashboard-page.html.h:19
-#: pkg/kubernetes/views/route-body.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:6
-msgid "Namespace"
-msgstr "名称空间"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:3
-#: pkg/kubernetes/views/service-body.html.h:3
-#: pkg/kubernetes/views/pod-body.html.h:3
-#: pkg/kubernetes/views/node-body.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:3
-#: pkg/kubernetes/views/route-body.html.h:3
-msgid "Created"
-msgstr "创建于"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:4
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:2
-#: pkg/kubernetes/views/details-page.html.h:17
-msgid "Replicas"
-msgstr "复用"
-
-#: pkg/kubernetes/views/replicationcontroller-body.html.h:5
-#: pkg/kubernetes/views/service-body.html.h:9
-#: pkg/kubernetes/views/pod-body.html.h:10
-#: pkg/kubernetes/views/node-body.html.h:12
-#: pkg/kubernetes/views/image-meta.html.h:1
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:8
-#: pkg/kubernetes/views/route-body.html.h:8
-msgid "Labels"
-msgstr "标签"
-
-#: pkg/kubernetes/views/service-body.html.h:4
-#: pkg/kubernetes/views/node-body.html.h:3
-msgid "IP"
-msgstr "IP"
-
-#: pkg/kubernetes/views/service-body.html.h:8
-msgid "Session Affinity"
-msgstr "会话关联"
-
-#: pkg/kubernetes/views/image-listing.html.h:1
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:10
-msgid "New image stream"
-msgstr "新建镜像流"
-
-#: pkg/kubernetes/views/image-listing.html.h:3
-#: pkg/kubernetes/views/image-body.html.h:10
-#: pkg/kubernetes/views/imagestream-modify.html.h:7
-msgid "Tags"
-msgstr "标记"
-
-#: pkg/kubernetes/views/image-listing.html.h:5
-msgid "Last Updated"
-msgstr "最近更新时间"
-
-#: pkg/kubernetes/views/image-listing.html.h:6
-msgid "No image streams are present."
-msgstr "没有镜像流用于显示。"
-
-#: pkg/kubernetes/views/node-delete.html.h:1
-msgid "Delete Node"
-msgstr "删除节点"
-
-#: pkg/kubernetes/views/node-delete.html.h:2
-msgid "Do you want to delete this Node?"
-msgstr "是否想要删除该节点？"
-
-#: pkg/kubernetes/views/node-delete.html.h:3
-msgid " 1\">Do you want to delete the following Nodes?"
-msgstr " 1\">是否想要删除该节点？"
-
-#: pkg/kubernetes/views/pod-container.html.h:1
-msgid "Show all Pod Containers"
-msgstr "显示所有容器舱容器"
-
-#: pkg/kubernetes/views/image-panel.html.h:3
-#: pkg/kubernetes/views/imagestream-page.html.h:4
-#: pkg/kubernetes/views/image-page.html.h:4
-msgid "Metadata"
-msgstr "元数据"
-
-#: pkg/kubernetes/views/node-panel.html.h:1
-#: pkg/kubernetes/views/pod-body.html.h:8
-#: pkg/kubernetes/views/containers-listing.html.h:6
-#: pkg/kubernetes/views/node-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:11
-msgid "Node"
-msgstr "节点"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:1
-msgid "Show all Replication Controllers"
-msgstr "显示所有复制控制器"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:2
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:5
-msgid "Replication Controller"
-msgstr "复制控制器"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:2
-#: pkg/kubernetes/views/pv-claim.html.h:9
-#: pkg/kubernetes/views/dashboard-page.html.h:1
-#: pkg/kubernetes/views/details-page.html.h:18
-msgid "Pods"
-msgstr "容器舱"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:4
-#: pkg/kubernetes/views/replicationcontroller-panel.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:3
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:2
-msgid "Template"
-msgstr "模板"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html.h:5
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr "复制控制器 '{{ target }}' 不存在。"
-
-#: pkg/kubernetes/views/group-delete.html.h:1
-msgid "Remove Group"
-msgstr "移除组"
-
-#: pkg/kubernetes/views/group-delete.html.h:4
-#: pkg/kubernetes/views/remove-role-dialog.html.h:4
-#: pkg/kubernetes/views/user-delete.html.h:5
-#: pkg/kubernetes/views/user-group-remove.html.h:3
-msgid "Remove"
-msgstr "删除"
-
-#: pkg/kubernetes/views/pvc-delete.html.h:1
-msgid "Delete Persistent Volume Claim"
-msgstr "删除持久卷声明"
-
-#: pkg/kubernetes/views/pvc-delete.html.h:2
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr "是否想要删除持久卷声明 '{{item.metadata.name}}'？"
-
-#: pkg/kubernetes/views/pvc-delete.html.h:3
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr "该声明正在使用。删除它也许会对以下容器舱产生影响:"
-
-#: pkg/kubernetes/views/pod-body.html.h:5
-msgid "Service Account"
-msgstr "服务账号"
-
-#: pkg/kubernetes/views/pod-body.html.h:6
-msgid "DNS Policy"
-msgstr "DNS 策略"
-
-#: pkg/kubernetes/views/pod-body.html.h:7
-msgid "Phase"
-msgstr "阶段"
-
-#: pkg/kubernetes/views/pod-body.html.h:9
-msgid "Pod Address"
-msgstr "容器舱地址"
-
-#: pkg/kubernetes/views/node-body.html.h:5
-msgid "OS"
-msgstr "操作系统"
-
-#: pkg/kubernetes/views/node-body.html.h:7
-msgid "Boot ID"
-msgstr "启动编号"
-
-#: pkg/kubernetes/views/node-body.html.h:8
-msgid "Kernel Version"
-msgstr "内核版本"
-
-#: pkg/kubernetes/views/node-body.html.h:9
-msgid "Container Runtime Version"
-msgstr "容器运行时版本"
-
-#: pkg/kubernetes/views/node-body.html.h:10
-msgid "Kubelet Version"
-msgstr "Kubelet 版本"
-
-#: pkg/kubernetes/views/node-body.html.h:11
-msgid "Proxy Version"
-msgstr "代理版本"
-
-#: pkg/kubernetes/views/node-body.html.h:13
-#: pkg/kubernetes/views/route-body.html.h:9
-msgid "none"
-msgstr "空"
-
-#: pkg/kubernetes/views/node-body.html.h:17
-msgid "Reason"
-msgstr "原因"
-
-#: pkg/kubernetes/views/node-body.html.h:18
-#: pkg/kubernetes/views/pv-claim.html.h:8
-#: pkg/kubernetes/views/pvc-body.html.h:6 pkg/kubernetes/views/pv-body.html.h:6
-msgid "Message"
-msgstr "消息"
-
-#: pkg/kubernetes/views/node-body.html.h:19
-msgid "Last Heartbeat"
-msgstr "最近的保活心跳"
-
-#: pkg/kubernetes/views/node-body.html.h:20
-msgid "Last Status Change"
-msgstr "最近的状态变更"
-
-#: pkg/kubernetes/views/node-body.html.h:21
-#: pkg/kubernetes/views/image-meta.html.h:3
-#: pkg/kubernetes/views/imagestream-meta.html.h:1
-#: pkg/kubernetes/views/route-body.html.h:10
-msgid "Annotations"
-msgstr "注释"
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:1
-msgid "Remove Role"
-msgstr "移除角色"
-
-#: pkg/kubernetes/views/remove-role-dialog.html.h:2
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member "
-"{{ fields.member.metadata.name }}?"
-msgstr ""
-"是否想要从成员 {{ fields.member.metadata.name }} 移除角色 '{{ fields."
-"displayRole }}'？"
-
-#: pkg/kubernetes/views/project-listing.html.h:1
-msgid "New Project"
-msgstr "新建项目"
-
-#: pkg/kubernetes/views/project-listing.html.h:6
-msgid "No projects are present."
-msgstr "没有项目用于显示。"
-
-#: pkg/kubernetes/views/project-listing.html.h:7
-msgid "New Group"
-msgstr "新建组"
-
-#: pkg/kubernetes/views/project-listing.html.h:8
-#: pkg/kubernetes/views/user-delete.html.h:3
-msgid "Groups"
-msgstr "组"
-
-#: pkg/kubernetes/views/project-listing.html.h:9
-msgid "No groups are present."
-msgstr "没有组用于显示。"
-
-#: pkg/kubernetes/views/project-listing.html.h:10
-#: pkg/kubernetes/views/add-user-dialog.html.h:1
-msgid "Add User"
-msgstr "添加用户"
-
-#: pkg/kubernetes/views/project-listing.html.h:11
-msgid "Users"
-msgstr "用户"
-
-#: pkg/kubernetes/views/project-listing.html.h:12
-msgid "Identity"
-msgstr "身份"
-
-#: pkg/kubernetes/views/project-listing.html.h:13
-msgid "Member of"
-msgstr "属于"
-
-#: pkg/kubernetes/views/project-listing.html.h:14
-msgid "No users are present."
-msgstr "没有用户用于显示。"
-
-#: pkg/kubernetes/views/auth-form.html.h:1
-msgid "Cluster"
-msgstr "集群"
-
-#: pkg/kubernetes/views/auth-form.html.h:2
-msgid "Add New Cluster"
-msgstr "添加新集群"
-
-#: pkg/kubernetes/views/auth-form.html.h:4
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:3
-msgid "Skip Certificate Verification"
-msgstr "跳过证书验证"
-
-#: pkg/kubernetes/views/auth-form.html.h:5
-msgid "Requires Authentication"
-msgstr "需要认证"
-
-#: pkg/kubernetes/views/auth-form.html.h:7
-msgid "Add New User"
-msgstr "添加新用户"
-
-#: pkg/kubernetes/views/auth-form.html.h:9
-msgid "Client Certificate"
-msgstr "客户端证书"
-
-#: pkg/kubernetes/views/auth-form.html.h:10
-msgid "Username"
-msgstr "用户名"
-
-#: pkg/kubernetes/views/auth-form.html.h:12
-msgid "Token"
-msgstr "令牌"
-
-#: pkg/kubernetes/views/node-add.html.h:1
-msgid "Add Cluster Node"
-msgstr "添加集群节点"
-
-#: pkg/kubernetes/views/node-add.html.h:4
-msgid "Configuration"
-msgstr "配置"
-
-#: pkg/kubernetes/views/node-add.html.h:5
-msgid "Configure Kubelet and Proxy"
-msgstr "配置 Kubelet 和代理"
-
-#: pkg/kubernetes/views/node-add.html.h:6
-msgid "Configure Flannel networking"
-msgstr "配置 Flannel 网络"
-
-#: pkg/kubernetes/views/volume-body.html.h:1
-#: pkg/kubernetes/views/pvc-body.html.h:1
-msgid "Volume Type"
-msgstr "卷类型"
-
-#: pkg/kubernetes/views/volume-body.html.h:2
-msgid "{{ volume | formatVolumeType }}"
-msgstr "{{ volume | formatVolumeType }}"
-
-#: pkg/kubernetes/views/volume-body.html.h:3
-msgid "PD Name"
-msgstr "持久盘名称"
-
-#: pkg/kubernetes/views/volume-body.html.h:4
-#: pkg/kubernetes/views/pv-modify.html.h:19
-msgid "Filesystem Type"
-msgstr "文件系统类型"
-
-#: pkg/kubernetes/views/volume-body.html.h:6
-#: pkg/kubernetes/views/pv-modify.html.h:20
-msgid "Read Only"
-msgstr "只读"
-
-#: pkg/kubernetes/views/volume-body.html.h:7
-msgid "Volume ID"
-msgstr "卷编号"
-
-#: pkg/kubernetes/views/volume-body.html.h:8
-msgid "Repository URL"
-msgstr "仓库网址"
-
-#: pkg/kubernetes/views/volume-body.html.h:9
-msgid "Revision"
-msgstr "修订"
-
-#: pkg/kubernetes/views/volume-body.html.h:10
-#: pkg/kubernetes/views/image-config.html.h:3
-msgid "Directory"
-msgstr "目录"
-
-#: pkg/kubernetes/views/volume-body.html.h:12
-msgid "Medium"
-msgstr "媒介"
-
-#: pkg/kubernetes/views/volume-body.html.h:13
-#: pkg/kubernetes/views/pv-modify.html.h:14
-msgid "Path"
-msgstr "路径"
-
-#: pkg/kubernetes/views/volume-body.html.h:14
-msgid "Endpoint Name"
-msgstr "端点名称"
-
-#: pkg/kubernetes/views/volume-body.html.h:15
-#: pkg/kubernetes/views/pv-modify.html.h:13
-msgid "Volume Name"
-msgstr "卷名称"
-
-#: pkg/kubernetes/views/volume-body.html.h:17
-msgid "Monitors"
-msgstr "监视器"
-
-#: pkg/kubernetes/views/volume-body.html.h:18
-msgid "Image Name"
-msgstr "镜像名称"
-
-#: pkg/kubernetes/views/volume-body.html.h:19
-msgid "Pool Name"
-msgstr "池名称"
-
-#: pkg/kubernetes/views/volume-body.html.h:21
-msgid "Key Ring Path"
-msgstr "密匙环路径"
-
-#: pkg/kubernetes/views/volume-body.html.h:22
-msgid "Secret Volume"
-msgstr "口令卷"
-
-#: pkg/kubernetes/views/volume-body.html.h:23
-msgid "Target Portal"
-msgstr "目标门户"
-
-#: pkg/kubernetes/views/volume-body.html.h:24
-#: pkg/kubernetes/views/pv-modify.html.h:16
-msgid "Qualified Name"
-msgstr "限定名"
-
-#: pkg/kubernetes/views/volume-body.html.h:25
-#: pkg/kubernetes/views/pv-modify.html.h:17
-msgid "Logical Unit Number"
-msgstr "逻辑单元编号"
-
-#: pkg/kubernetes/views/volume-body.html.h:26
-#: pkg/kubernetes/views/pv-modify.html.h:18
-msgid "Interface"
-msgstr "接口"
-
-#: pkg/kubernetes/views/volume-body.html.h:27
-msgid "Ceph Monitors"
-msgstr "Ceph 监视器"
-
-#: pkg/kubernetes/views/volume-body.html.h:28
-msgid "Secret File"
-msgstr "口令文件"
-
-#: pkg/kubernetes/views/volume-body.html.h:29
-msgid "Target World Wide Names"
-msgstr "目标全球通用名称"
-
-#: pkg/kubernetes/views/volume-body.html.h:30
-msgid "Flocker Dataset Name"
-msgstr "Flocker 数据集名称"
-
-#: pkg/kubernetes/views/volume-body.html.h:31
-msgid "Driver"
-msgstr "驱动器"
-
-#: pkg/kubernetes/views/volume-body.html.h:33
-msgid "Share Name"
-msgstr "共享名称"
-
-#: pkg/kubernetes/views/volume-body.html.h:34
-msgid "Secret Name"
-msgstr "口令名称"
-
-#: pkg/kubernetes/views/image-meta.html.h:2
-msgid "On Build"
-msgstr "构建中"
-
-#: pkg/kubernetes/views/image-meta.html.h:4
-msgid "Docker Version"
-msgstr "Docker 版本"
-
-#: pkg/kubernetes/views/image-meta.html.h:5
-msgid "Image Layers"
-msgstr "镜像层"
-
-#: pkg/kubernetes/views/group-page.html.h:1
-#: pkg/kubernetes/views/user-page.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:1
-msgid "Show all Projects"
-msgstr "显示所有项目"
-
-#: pkg/kubernetes/views/group-page.html.h:2
-#: pkg/kubernetes/views/group-panel.html.h:1
-msgid "Group Members"
-msgstr "组成员"
-
-#: pkg/kubernetes/views/group-page.html.h:3
-#: pkg/kubernetes/views/user-group-add.html.h:1
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:1
-#: pkg/kubernetes/views/group-panel.html.h:2
-#: pkg/kubernetes/views/project-body.html.h:10
-msgid "Add Member"
-msgstr "添加成员"
-
-#: pkg/kubernetes/views/group-page.html.h:4
-msgid "The group '{{ groupName }}' does not exist."
-msgstr "组 '{{ groupName }}' 不存在。"
-
-#: pkg/kubernetes/views/containers-listing.html.h:3
-#: pkg/kubernetes/views/pod-page.html.h:2
-#: pkg/kubernetes/views/topology-page.html.h:2
-msgid "Pod"
-msgstr "容器舱"
-
-#: pkg/kubernetes/views/user-body.html.h:1
-#: pkg/kubernetes/views/project-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:2
-msgid "Membership"
-msgstr "成员关系"
-
-#: pkg/kubernetes/views/user-body.html.h:2
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
-msgstr ""
-"\n"
-"                                    {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                                "
-
-#: pkg/kubernetes/views/user-body.html.h:5
-#: pkg/kubernetes/views/user-panel.html.h:7
-msgid "Add Membership"
-msgstr "添加成员关系"
-
-#: pkg/kubernetes/views/user-group-add.html.h:2
-msgid ""
-"\n"
-"                        User\n"
-"                    "
-msgstr ""
-"\n"
-"                        用户\n"
-"                    "
-
-#: pkg/kubernetes/views/add-member-role-dialog.html.h:2
-msgid "User or Group"
-msgstr "用户或组"
-
-#: pkg/kubernetes/views/pod-panel.html.h:1
-#: pkg/kubernetes/views/pod-page.html.h:4
-msgid "Mount Location"
-msgstr "挂载位置"
-
-#: pkg/kubernetes/views/route-modify.html.h:1
-msgid "Adjust Route"
-msgstr "调整路由"
-
-#: pkg/kubernetes/views/pv-page.html.h:1
-msgid "Show all Persistent Volumes"
-msgstr "显示所有持久卷"
-
-#: pkg/kubernetes/views/pv-page.html.h:2 pkg/kubernetes/views/pvc-body.html.h:3
-#: pkg/kubernetes/views/pv-panel.html.h:1
-msgid "Volume"
-msgstr "卷"
-
-#: pkg/kubernetes/views/pv-page.html.h:3 pkg/kubernetes/views/pv-panel.html.h:2
-msgid "Claim"
-msgstr "声明"
-
-#: pkg/kubernetes/views/pv-page.html.h:4
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr "持久卷 '{{ target }}' 不存在。"
-
-#: pkg/kubernetes/views/image-delete.html.h:1
-msgid "Remove image tag"
-msgstr "移除镜像标记"
-
-#: pkg/kubernetes/views/image-delete.html.h:2
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-"是否想要移除镜像标记 '{{stream.metadata.namespace}}/{{stream.metadata.name}}:"
-"{{tag.tag}}'？"
-
-#: pkg/kubernetes/views/image-config.html.h:1
-msgid "Run as"
-msgstr "运行为"
-
-#: pkg/kubernetes/views/image-config.html.h:4
-msgid "Stop with"
-msgstr "停止为"
-
-#: pkg/kubernetes/views/pv-delete.html.h:1
-msgid "Delete Persistent Volume"
-msgstr "删除持久卷"
-
-#: pkg/kubernetes/views/pv-delete.html.h:2
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr "是否想要删除持久卷 '{{item.metadata.name}}'？"
-
-#: pkg/kubernetes/views/pv-delete.html.h:3
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
-"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
-"may cause issues with any pods depending on it."
-msgstr ""
-"该卷已经被 {{ item.item.spec.claimRef.namespace }} / {{ item.item.spec."
-"claimRef.name }} 声明。删除它将会损坏该声明并且也许会对依赖于它的容器舱尝试影"
-"响。"
-
-#: pkg/kubernetes/views/user-page.html.h:2
-#: pkg/kubernetes/views/user-panel.html.h:3
-msgid "Identities"
-msgstr "身份"
-
-#: pkg/kubernetes/views/user-page.html.h:3
-msgid "The user '{{ userName }}' does not exist."
-msgstr "用户 '{{ userName }}' 不存在。"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:1
-msgid "Show all Deployment Configs"
-msgstr "显示所有部署配置"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:2
-#: pkg/kubernetes/views/deploymentconfig-panel.html.h:1
-msgid "Deployment Config"
-msgstr "部署配置"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html.h:4
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr "部署配置 '{{ target }}' 不存在。"
-
-#: pkg/kubernetes/views/route-panel.html.h:1
-#: pkg/kubernetes/views/route-page.html.h:2
-msgid "Route"
-msgstr "路由"
-
-#: pkg/kubernetes/views/volumes-page.html.h:1
-msgid "Register New Volume"
-msgstr "注册新卷"
-
-#: pkg/kubernetes/views/volumes-page.html.h:2
-msgid "Persistent Volumes"
-msgstr "持久卷"
-
-#: pkg/kubernetes/views/volumes-page.html.h:7
-msgid "No volumes are present."
-msgstr "没有卷用于显示。"
-
-#: pkg/kubernetes/views/volumes-page.html.h:8
-msgid "Pending Volume Claims"
-msgstr "挂起的卷声明"
-
-#: pkg/kubernetes/views/volumes-page.html.h:12
-msgid "When"
-msgstr "当"
-
-#: pkg/kubernetes/views/user-delete.html.h:1
-msgid "Remove User"
-msgstr "移除用户"
-
-#: pkg/kubernetes/views/pv-claim.html.h:3
-#: pkg/kubernetes/views/pv-modify.html.h:10
-#: pkg/kubernetes/views/pvc-body.html.h:7 pkg/kubernetes/views/pv-body.html.h:2
-msgid "Access Modes"
-msgstr "访问模式"
-
-#: pkg/kubernetes/views/pv-claim.html.h:4
-msgid "Requests"
-msgstr "请求"
-
-#: pkg/kubernetes/views/pv-claim.html.h:5
-msgid "This volume has not been claimed"
-msgstr "该卷未被声明"
-
-#: pkg/kubernetes/views/pv-claim.html.h:10
-msgid "No Pods are using this claim"
-msgstr "没有容器舱使用该声明"
-
-#: pkg/kubernetes/views/filter-project.html.h:1
-msgid "All Projects"
-msgstr "所有项目"
-
-#: pkg/kubernetes/views/filter-project.html.h:2
-msgid "Project:"
-msgstr "项目:"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:5
-#: pkg/kubernetes/views/details-page.html.h:14
-msgid "Latest Version"
-msgstr "最近的版本"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:6
-msgid "Deployment Causes"
-msgstr "部署原因"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html.h:7
-msgid "Triggers"
-msgstr "触发器"
-
-#: pkg/kubernetes/views/item-delete.html.h:1
-msgid "Delete {{ item.kind }}"
-msgstr "删除 {{ item.kind }}"
-
-#: pkg/kubernetes/views/item-delete.html.h:2
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr "是否想要删除 {{ item.kind }} '{{item.metadata.name}}'？"
-
-#: pkg/kubernetes/views/item-delete.html.h:3
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr "删除容器舱将会杀掉所有相关的容器。容器舱也许会在某些情况下被自动创建。"
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:2
-#: pkg/kubernetes/views/user-modify.html.h:2
-#: pkg/kubernetes/views/add-group-dialog.html.h:2
-msgid ""
-"\n"
-"                        Name\n"
-"                    "
-msgstr ""
-"\n"
-"                        名称\n"
-"                    "
-
-#: pkg/kubernetes/views/add-user-dialog.html.h:5
-#: pkg/kubernetes/views/user-modify.html.h:5
-msgid ""
-"\n"
-"                        Identity\n"
-"                    "
-msgstr ""
-"\n"
-"                        身份\n"
-"                    "
-
-#: pkg/kubernetes/views/project-body.html.h:1
-msgid "Project Members"
-msgstr "项目成员"
-
-#: pkg/kubernetes/views/project-body.html.h:3
-msgid ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-msgstr ""
-"\n"
-"                                {{ getRegistryRoles(user, project())."
-"join() }}\n"
-"                            "
-
-#: pkg/kubernetes/views/project-body.html.h:6
-msgid "Admin"
-msgstr "管理"
-
-#: pkg/kubernetes/views/project-body.html.h:7
-msgid ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-msgstr ""
-"\n"
-"                                    {{ getRegistryRoles(group, project())."
-"join() }}\n"
-"                                "
-
-#: pkg/kubernetes/views/container-panel.html.h:3
-#: pkg/kubernetes/views/container-page-inline.html.h:3
-msgid "Shell"
-msgstr "Shell"
-
-#: pkg/kubernetes/views/service-endpoint.html.h:1
-msgid "Pod Endpoints"
-msgstr "容器舱端点"
-
-#: pkg/kubernetes/views/service-endpoint.html.h:2
-msgid "No pods selected"
-msgstr "没有选中的容器舱"
-
-#: pkg/kubernetes/views/service-endpoint.html.h:3
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:3
-msgid "Pod Selector"
-msgstr "容器舱选择器"
-
-#: pkg/kubernetes/views/user-add-membership.html.h:1
-msgid "Add membership"
-msgstr "添加成员关系"
-
-#: pkg/kubernetes/views/user-add-membership.html.h:2
-msgid ""
-"\n"
-"                        Group or Project\n"
-"                    "
-msgstr ""
-"\n"
-"                       组或项目\n"
-"                    "
-
-#: pkg/kubernetes/views/user-add-membership.html.h:5
-msgid ""
-"\n"
-"                        Role\n"
-"                    "
-msgstr ""
-"\n"
-"                        角色\n"
-"                    "
-
-#: pkg/kubernetes/views/deploy.html.h:1
-msgid "Deploy Application"
-msgstr "部署应用"
-
-#: pkg/kubernetes/views/deploy.html.h:3
-msgid "{{ selected.name }}"
-msgstr "{{ selected.name }}"
-
-#: pkg/kubernetes/views/deploy.html.h:5
-#: pkg/kubernetes/views/dashboard-page.html.h:11
-msgid "Deploy"
-msgstr "部署"
-
-#: pkg/kubernetes/views/user-modify.html.h:1
-msgid "Change User"
-msgstr "变更用户"
-
-#: pkg/kubernetes/views/user-modify.html.h:9
-msgid "Modify"
-msgstr "修改"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:1
-#: pkg/kubernetes/views/project-modify.html.h:6
-msgid "Access Policy"
-msgstr "访问策略"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:2
-#, fuzzy
-msgid ""
-"\n"
-"          Images may be pulled by anonymous users\n"
-"        "
-msgstr ""
-"\n"
-"          镜像可以被任何认证的用户或组拉取\n"
-"        "
-
-#: pkg/kubernetes/views/imagestream-body.html.h:5
-msgid ""
-"\n"
-"          Images may be pulled by any authenticated user or group\n"
-"        "
-msgstr ""
-"\n"
-"          镜像可以被任何认证的用户或组拉取\n"
-"        "
-
-#: pkg/kubernetes/views/imagestream-body.html.h:8
-msgid ""
-"\n"
-"          Images may only be pulled by specific users or groups\n"
-"        "
-msgstr ""
-"\n"
-"          镜像仅可以被指定的用户或组拉取\n"
-"        "
-
-#: pkg/kubernetes/views/imagestream-body.html.h:11
-msgid "Pull repository"
-msgstr "拉取仓库"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:13
-msgid "Image count"
-msgstr "镜像计数"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:14
-msgid "{{stream.status.tags.length}}"
-msgstr "{{stream.status.tags.length}}"
-
-#: pkg/kubernetes/views/imagestream-body.html.h:15
-msgid "To push to an image to this image stream:"
-msgstr "推送镜像到该镜像流:"
-
-#: pkg/kubernetes/views/node-alerts.html.h:1
-msgid "The node doesn't have enough disk space"
-msgstr "节点没有足够的磁盘空间"
-
-#: pkg/kubernetes/views/node-alerts.html.h:2
-msgid "The node doesn't have enough free memory"
-msgstr "节点没有足够的空闲内存"
-
-#: pkg/kubernetes/views/pv-modify.html.h:1
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr "调整持久卷 '{{ item.metadata.name }}'"
-
-#: pkg/kubernetes/views/pv-modify.html.h:2
-msgid "Register Persistent Volume"
-msgstr "注册持久卷"
-
-#: pkg/kubernetes/views/pv-modify.html.h:4
-msgid "Warning:"
-msgstr "警告:"
-
-#: pkg/kubernetes/views/pv-modify.html.h:5
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr "该选项是仅为单节点测试 – 本地存储，将在多节点集群中不工作"
-
-#: pkg/kubernetes/views/pv-modify.html.h:7
-#: pkg/kubernetes/views/node-page.html.h:3
-#: pkg/kubernetes/views/pvc-body.html.h:10
-#: pkg/kubernetes/views/pv-body.html.h:3
-msgid "Capacity"
-msgstr "容量"
-
-#: pkg/kubernetes/views/pv-modify.html.h:8
-#: pkg/kubernetes/views/pv-body.html.h:1
-msgid "Reclaim Policy"
-msgstr "重新声明策略"
-
-#: pkg/kubernetes/views/pv-modify.html.h:9
-msgid "{{ value }}"
-msgstr "{{ value }}"
-
-#: pkg/kubernetes/views/pv-modify.html.h:12
-msgid "Endpoint"
-msgstr "端点"
-
-#: pkg/kubernetes/views/pv-modify.html.h:15
-msgid "Target"
-msgstr "目标"
-
-#: pkg/kubernetes/views/auth-dialog.html.h:1
-msgid "Connection Settings"
-msgstr "连接设置"
-
-#: pkg/kubernetes/views/auth-dialog.html.h:2
-msgid "Connection Error"
-msgstr "连接错误"
-
-#: pkg/kubernetes/views/image-body.html.h:2
-msgid "Summary"
-msgstr "汇总"
-
-#: pkg/kubernetes/views/image-body.html.h:4
-msgid "Source URL"
-msgstr "源网址"
-
-#: pkg/kubernetes/views/image-body.html.h:7
-msgid "Built"
-msgstr "构建于"
-
-#: pkg/kubernetes/views/image-body.html.h:8
-msgid "Digest"
-msgstr "摘要"
-
-#: pkg/kubernetes/views/image-body.html.h:9
-msgid "Identifier"
-msgstr "身份标识"
-
-#: pkg/kubernetes/views/image-body.html.h:11
-msgid "To pull this image:"
-msgstr "拉取该镜像:"
-
-#: pkg/kubernetes/views/service-panel.html.h:1
-#: pkg/kubernetes/views/topology-page.html.h:8
-#: pkg/kubernetes/views/service-page.html.h:2
-msgid "Service"
-msgstr "服务"
-
-#: pkg/kubernetes/views/service-panel.html.h:2
-#: pkg/kubernetes/views/service-page.html.h:3
-msgid "Endpoints"
-msgstr "端点"
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:1
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr "服务器使用率一个通过未知机构签名的证书。"
-
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:2
+#: pkg/kubernetes/views/auth-rejected-cert.html:3
 msgid ""
 "You can bypass the certificate check, but any data you send to the server "
 "could be intercepted by others."
 msgstr "可以通过证书检查，但是发送到服务器的任何数据可能被其他人拦截。"
 
-#: pkg/kubernetes/views/auth-rejected-cert.html.h:4
-msgid "Trust this certificate for this connection"
-msgstr "为该连接信任该证书"
-
-#: pkg/kubernetes/views/pod-page.html.h:1
-msgid "Show all Pods"
-msgstr "显示所有容器舱"
-
-#: pkg/kubernetes/views/pod-page.html.h:7
-msgid "The pod '{{ target }}' does not exist."
-msgstr "容器舱 '{{ target }}' 不存在。"
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html.h:1
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr "调整复制控制器 {{ item.metadata.name }}"
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:1
-msgid "Delete image stream"
-msgstr "删除镜像流"
-
-#: pkg/kubernetes/views/imagestream-delete.html.h:2
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-"是否想要删除镜像流 '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' ？"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:2
-msgid "All running"
-msgstr "所有运行的"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:3
-msgid "No pods deployed"
-msgstr "没有部署的容器舱"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:5
-msgid "All in use"
-msgstr "所有正在使用的"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:6
-msgid "No volumes in use"
-msgstr "没有正在使用的卷"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:7
-msgid "pending volume claims"
-msgstr "挂起的卷声明"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:9
-msgid "All healthy"
-msgstr "所有健康的"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:10
-msgid "No nodes in cluster"
-msgstr "集群中没有节点"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:13
-msgid "Could not list services"
-msgstr "无法罗列服务"
-
-#: pkg/kubernetes/views/dashboard-page.html.h:14
+#: pkg/kubernetes/views/dashboard-page.html:150
 msgid "You can deploy an application to your cluster."
 msgstr "可以部署一个应用到集群中。"
 
-#: pkg/kubernetes/views/imagestream-page.html.h:1
-msgid "Show all image streams"
-msgstr "显示所有镜像流"
-
-#: pkg/kubernetes/views/imagestream-page.html.h:2
-msgid "Image Stream"
-msgstr "镜像流"
-
-#: pkg/kubernetes/views/container-body.html.h:3
-msgid "Image ID"
-msgstr "镜像编号"
-
-#: pkg/kubernetes/views/container-body.html.h:4
-msgid "Container ID"
-msgstr "容器编号"
-
-#: pkg/kubernetes/views/container-body.html.h:7
-msgid "Since"
-msgstr "自从"
-
-#: pkg/kubernetes/views/container-body.html.h:8
-msgid "Restart Count"
-msgstr "重启次数"
-
-#: pkg/kubernetes/views/user-remove-membership.html.h:1
-msgid "Remove membership"
-msgstr "移除成员关系"
-
-#: pkg/kubernetes/views/nodes-page.html.h:1
-msgid "Delete Selected"
-msgstr "删除所选的"
-
-#: pkg/kubernetes/views/nodes-page.html.h:2
-msgid "OS Versions"
-msgstr "操作系统版本"
-
-#: pkg/kubernetes/views/nodes-page.html.h:3
-msgid "Add Kubernetes Node"
-msgstr "添加 Kubernetes 节点"
-
-#: pkg/kubernetes/views/project-page.html.h:3
-msgid "The project '{{ projName }}' does not exist."
-msgstr "项目 '{{ projName }}' 不存在。"
-
-#: pkg/kubernetes/views/user-panel.html.h:4
+#: pkg/lib/machine-invalid-hostkey.html:11
 msgid ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
-msgstr ""
-"\n"
-"                                {{ getRegistryRoles(user(), member)."
-"join() }}\n"
-"                            "
+"You can remove the previously stored key by running the following command"
+msgstr "可以通过使用以下命令来移除之前保存的密钥"
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:1
-msgid "Pod Replicated"
-msgstr "复制的容器舱"
+#: pkg/shell/base_index.js:672
+msgid "You can try restarting Cockpit by pressing refresh in your browser. "
+msgstr "您可以尝试通过刷新浏览器来重启 Cockpit。"
 
-#: pkg/kubernetes/views/replicationcontroller-pods.html.h:2
-msgid "No pods replicated"
-msgstr "没有复制的容器舱"
-
-#: pkg/kubernetes/views/container-page.html.h:1
-msgid "Show all Containers"
-msgstr "显示所有容器"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:1
-msgid "Welcome to the Image Registry"
-msgstr "欢迎使用镜像注册表"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:2
+#: pkg/users/index.html:335
 msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
-msgstr "为了开始推送镜像到注册表，需要创建一个项目。"
+"You do not have permission to view the authorized public keys for this "
+"account."
+msgstr "您没有权限查看此帐户的授权公钥."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:3
-#: pkg/kubernetes/views/project-modify.html.h:1
-msgid "New project"
-msgstr "新建项目"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:4
-msgid "Images by project"
-msgstr "镜像（按项目）"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:6
-msgid "Images pushed recently"
-msgstr "最近推送的镜像"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:7
-msgid "All images"
-msgstr "所有镜像"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:8
-msgid "No images pushed"
-msgstr "没有推送的镜像"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:9
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr "为了开始推送镜像到注册表，使用以下命令。"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:11
+#: pkg/docker/storage.jsx:482
 #, fuzzy
-msgid "Login commands"
-msgstr "Docker 命令"
+msgid "You don't have permission to manage the Docker storage pool."
+msgstr "您没有权限查看此帐户的授权公钥."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:12
-#, fuzzy
-msgid "Log into the registry:"
-msgstr "欢迎使用镜像注册表"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:13
+#: pkg/kubernetes/views/registry-dashboard-page.html:112
 msgid ""
 "Your login credentials do not give you access to use the docker registry "
 "from the command line."
 msgstr "登录凭证没有从命令行使用 Docker 注册表的权限"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:14
-msgid "Log into OpenShift command line tools:"
-msgstr ""
+#: src/base1/cockpit.js:3687
+msgid "Your session has been terminated."
+msgstr "会话被终止。"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:15
-#, fuzzy
-msgid "Image commands"
-msgstr "镜像计数"
+#: src/base1/cockpit.js:3689
+msgid "Your session has expired. Please log in again."
+msgstr "会话超时。请重新登录。"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:16
-msgid "Push an image:"
-msgstr "推送镜像:"
+#: pkg/lib/journal.js:213
+msgid "[$0 bytes of binary data]"
+msgstr "[$0 字节二进制数据]"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html.h:17
-msgid "Pull an image:"
-msgstr "拉取镜像:"
+#: pkg/lib/journal.js:215
+msgid "[binary data]"
+msgstr "[二进制数据]"
 
-#: pkg/kubernetes/views/node-page.html.h:1
-msgid "Show all Nodes"
-msgstr "显示所有节点"
+#: pkg/lib/journal.js:209
+msgid "[no data]"
+msgstr "[没有数据]"
 
-#: pkg/kubernetes/views/node-page.html.h:4
-msgid "The node '{{ target }}' does not exist."
-msgstr "节点 '{{ target }}' 不存在。"
+#: pkg/storaged/details.js:1692
+msgid "active, but unsupported"
+msgstr "激活，但不支持"
 
-#: pkg/kubernetes/views/route-page.html.h:1
-msgid "Show all Routes"
-msgstr "显示所有路由"
+#: pkg/storaged/utils.js:88
+msgctxt "format-bytes"
+msgid "bytes"
+msgstr "字节"
 
-#: pkg/kubernetes/views/route-page.html.h:3
-msgid "The route '{{ target }}' does not exist."
-msgstr "路由 '{{ target }}' 不存在。"
+#: pkg/docker/util.js:123
+msgid "default"
+msgstr "默认"
 
-#: pkg/kubernetes/views/topology-page.html.h:1
-msgid "Select an object to see more details."
-msgstr "选择一个对象来查看更多详情。"
+#: pkg/storaged/details.js:178
+msgid "ext4 - Red Hat Enterprise Linux 6 default"
+msgstr "ext4 - Red Hat Enterprise Linux 6 默认"
 
-#: pkg/kubernetes/views/topology-page.html.h:3
-msgid ""
-"Pods contain one or more containers that run\n"
-"                together on a node, containing your application code."
-msgstr ""
-"容器舱包含运行在一个节点上的一个或多个容器，\n"
-"                包含应用代码。"
+#: pkg/systemd/host.js:661
+msgid "failed to list ssh host keys: $0"
+msgstr "罗列 SSH 主机密钥失败: $0"
 
-#: pkg/kubernetes/views/topology-page.html.h:6
-msgid ""
-"Replication controllers dynamically create instances of\n"
-"                pods from templates, and remove pods when necessary."
-msgstr ""
-"复制控制器动态从模板创建容器舱实例，\n"
-"                并在必要的时候移除容器舱。"
+#: pkg/storaged/index.html:135
+msgid "iSCSI Targets"
+msgstr "iSCSI 目标"
 
-#: pkg/kubernetes/views/topology-page.html.h:9
-msgid ""
-"Services group pods and provide a common DNS\n"
-"                name and an optional, load-balanced IP address to access "
-"them."
-msgstr ""
-"服务组织容器舱并提供一个通用 DNS\n"
-"                名称和一个可选的负载均衡的 IP 地址来访问它们。"
+#: pkg/storaged/details.js:1692
+msgid "inactive"
+msgstr "未激活"
 
-#: pkg/kubernetes/views/topology-page.html.h:12
-msgid "Nodes are the machines that run your containers."
-msgstr "节点是运行容器的主机。"
+#: pkg/storaged/details.js:1286
+msgid "locked"
+msgstr "已锁定"
 
-#: pkg/kubernetes/views/add-group-dialog.html.h:1
-msgid "Add Group"
-msgstr "添加组"
+#: pkg/storaged/details.js:1278
+msgid "mounted on $0"
+msgstr "已挂载至 $0"
 
-#: pkg/kubernetes/views/file-button.html.h:1
-msgid "Select Manifest File..."
-msgstr "选择 Manifest 文件..."
-
-#: pkg/kubernetes/views/project-modify.html.h:2
-msgid "Change project"
-msgstr "变更项目"
-
-#: pkg/kubernetes/views/project-modify.html.h:4
-msgid "Display name"
-msgstr "显示名称"
-
-#: pkg/kubernetes/views/route-body.html.h:5
-msgid "TLS Termination"
-msgstr "TLS 终止协议"
-
-#: pkg/kubernetes/views/route-body.html.h:6
-msgid "yes"
-msgstr "是"
-
-#: pkg/kubernetes/views/route-body.html.h:7
+#: pkg/kubernetes/views/route-body.html:14
 msgid "no"
 msgstr "否"
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:1
-msgid "Add Role"
-msgstr "添加角色"
+#: pkg/kubernetes/views/route-body.html:24
+#: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
+msgid "none"
+msgstr "空"
 
-#: pkg/kubernetes/views/add-role-dialog.html.h:2
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
-msgstr "是否想要添加角色 '{{ fields.displayRole }}'？"
+#: pkg/storaged/details.js:1280
+msgid "not mounted"
+msgstr "未挂载"
 
-#: pkg/kubernetes/views/details-page.html.h:1
-msgid "All Types"
-msgstr "所有类型"
+#: pkg/kubernetes/views/dashboard-page.html:83
+msgid "pending volume claims"
+msgstr "挂起的卷声明"
 
-#: pkg/kubernetes/views/details-page.html.h:2
-msgid "Type:"
-msgstr "类型:"
+#: pkg/tuned/change-profile.jsx:52
+#, fuzzy
+msgid "recommended"
+msgstr "MII (推荐)"
 
-#: pkg/kubernetes/views/details-page.html.h:13
-msgid "Deployment Configs"
-msgstr "部署配置"
+#: pkg/docker/index.html:426
+msgid "select container"
+msgstr "选择容器"
 
-#: pkg/kubernetes/views/details-page.html.h:15
-msgid "Not deployed"
-msgstr "未部署"
+#: pkg/docker/index.html:504 pkg/docker/index.html:683
+msgid "shares"
+msgstr "共享"
 
-#: pkg/kubernetes/views/details-page.html.h:16
-msgid "Replication Controllers"
-msgstr "复制控制器"
+#: pkg/selinux/setroubleshoot-view.jsx:118
+msgid "solution details"
+msgstr ""
 
-#: pkg/kubernetes/views/service-modify.html.h:1
-msgid "Adjust Service"
-msgstr "调整服务"
+#: pkg/systemd/init.js:242 pkg/systemd/init.js:256
+msgid "unknown"
+msgstr "未知"
 
-#: pkg/kubernetes/views/service-modify.html.h:3
+#: pkg/storaged/jobs.js:180
+msgid "unknown target"
+msgstr "未知目标"
+
+#: pkg/storaged/details.js:1284
+msgid "unlocked"
+msgstr "未锁定"
+
+#: pkg/kubernetes/views/route-body.html:13
+msgid "yes"
+msgstr "是"
+
+#: pkg/kubernetes/views/service-modify.html:16
 msgid "{{ item.name }}"
 msgstr "{{ item.name }}"
 
-#: pkg/kubernetes/views/service-modify.html.h:5
-msgid "Adjust"
-msgstr "调整"
+#: pkg/kubernetes/views/deploy.html:27
+msgid "{{ selected.name }}"
+msgstr "{{ selected.name }}"
 
-#: pkg/kubernetes/views/project-delete.html.h:1
-msgid "Delete Project"
-msgstr "删除项目"
+#: pkg/kubernetes/views/pv-modify.html:61
+#: pkg/kubernetes/views/pv-modify.html:74
+msgid "{{ value }}"
+msgstr "{{ value }}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:2
-msgid "Claim Name"
-msgstr "声明名称"
+#: pkg/kubernetes/views/volume-body.html:2
+msgid "{{ volume | formatVolumeType }}"
+msgstr "{{ volume | formatVolumeType }}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:4
-msgid "No Volume Bound"
-msgstr "未绑定卷"
+#: pkg/storaged/index.html:147
+msgid "{{Address}}:{{Port}}"
+msgstr "{{Address}}:{{Port}}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:8
-msgid "Requested"
-msgstr "请求的"
+#: pkg/docker/index.html:435
+msgid "{{alias_label}}"
+msgstr "{{alias_label}}"
 
-#: pkg/kubernetes/views/pvc-body.html.h:9
-msgid "Actual"
-msgstr "真实的"
-
-#: pkg/kubernetes/views/node-capacity.html.h:1
-msgid "Scheduled Pods"
-msgstr "被调度的容器舱"
-
-#: pkg/kubernetes/views/node-capacity.html.h:2
-msgid "No pods scheduled"
-msgstr "没有被调度的容器舱"
-
-#: pkg/kubernetes/views/container-page-inline.html.h:4
-msgid "The container '{{ target }}' does not exist."
-msgstr "容器 '{{ target }}' 不存在。"
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:1
-msgid "Create image stream"
-msgstr "创建镜像流"
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:2
-msgid "Change image stream"
-msgstr "变更镜像流"
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:5
-msgid "Populate"
-msgstr "填入"
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:6
-msgid "Pull from"
-msgstr "拉取自"
-
-#: pkg/kubernetes/views/imagestream-modify.html.h:8
-msgid "Remote registry is insecure"
-msgstr "远程注册表不安全"
-
-#: pkg/kubernetes/views/user-group-remove.html.h:1
-msgid "Remove Member"
-msgstr "移除成员"
-
-#: pkg/kubernetes/views/service-page.html.h:1
-msgid "Show all Services"
-msgstr "显示所有服务"
-
-#: pkg/kubernetes/views/service-page.html.h:4
-msgid "The service '{{ target }}' does not exist."
-msgstr "服务 '{{ target }}' 不存在。"
-
-#: pkg/kubernetes/scripts/frob-layers.html.h:1
-#, fuzzy
-msgid "Image Layers Example"
-msgstr "镜像层"
-
-#: pkg/playground/service.html.h:1
-msgid "Cockpit Generic Service Monitor"
+#: pkg/systemd/services.html:173 pkg/systemd/services.html:202
+msgid "{{days_text}}"
 msgstr ""
 
-#: pkg/playground/jquery-patterns.html.h:1
-msgid "Cockpit Pattern Usage"
-msgstr "Cockpit 模式使用"
+#: pkg/docker/index.html:403
+msgid "{{envvar_key_label}}"
+msgstr "{{envvar_key_label}}"
 
-#: pkg/playground/metrics.html.h:1
+#: pkg/docker/index.html:407
+msgid "{{envvar_value_label}}"
+msgstr "{{envvar_value_label}}"
+
+#: pkg/docker/index.html:359
+msgid "{{host_port_label}}"
+msgstr "{{host_port_label}}"
+
+#: pkg/docker/index.html:373
+msgid "{{host_volume_label}}"
+msgstr "{{host_volume_label}}"
+
+#: pkg/kubernetes/views/imagestream-body.html:35
+msgid "{{stream.status.tags.length}}"
+msgstr "{{stream.status.tags.length}}"
+
+#~ msgid "Journal"
+#~ msgstr "日志"
+
+#~ msgid "Comment"
+#~ msgstr "说明"
+
 #, fuzzy
-msgid "Cockpit Monitoring"
-msgstr "链路监控"
+#~ msgid "Image Layers Example"
+#~ msgstr "镜像层"
 
-#: pkg/playground/test.html.h:1 pkg/playground/translate.html.h:1
-msgid "Cockpit playground"
-msgstr ""
+#~ msgid "Cockpit Pattern Usage"
+#~ msgstr "Cockpit 模式使用"
 
-#: pkg/playground/react-patterns.html.h:1
-msgid "Cockpit React Patterns Usage"
-msgstr "Cockpit React 模式用法"
-
-#: pkg/playground/speed.html.h:1
-msgid "Cockpit Speed Tests"
-msgstr ""
-
-#: pkg/playground/plot.html.h:1
 #, fuzzy
-msgid "Cockpit Plots"
-msgstr "Cockpit"
+#~ msgid "Cockpit Monitoring"
+#~ msgstr "链路监控"
 
-#: pkg/dashboard/index.html.h:1
-msgid "Dashboard"
-msgstr ""
+#~ msgid "Cockpit React Patterns Usage"
+#~ msgstr "Cockpit React 模式用法"
 
-#: pkg/dashboard/index.html.h:5
 #, fuzzy
-msgid "Disk I/O"
-msgstr "磁盘良好"
-
-#: pkg/dashboard/index.html.h:6
-msgid "Lost connection. Trying to reconnect"
-msgstr "连接失败。请重新连接"
-
-#: pkg/dashboard/index.html.h:10
-msgid "Avatar"
-msgstr "替身"
-
-#: pkg/dashboard/index.html.h:13
-msgid "Set"
-msgstr "设置"
+#~ msgid "Cockpit Plots"
+#~ msgstr "Cockpit"
 
 #~ msgid "No addresses found"
 #~ msgstr "没有找到地址"
@@ -6511,60 +6577,8 @@ msgstr "设置"
 #~ msgstr "显示错误-对话框"
 
 #~ msgctxt "storage"
-#~ msgid "Model"
-#~ msgstr "模型"
-
-#~ msgctxt "storage"
-#~ msgid "Firmware Version"
-#~ msgstr "固件版本"
-
-#~ msgctxt "storage"
-#~ msgid "Serial Number"
-#~ msgstr "串口号"
-
-#~ msgctxt "storage"
-#~ msgid "World Wide Name"
-#~ msgstr "全局名称"
-
-#~ msgctxt "storage"
-#~ msgid "Capacity"
-#~ msgstr "容量"
-
-#~ msgctxt "storage"
-#~ msgid "Assessment"
-#~ msgstr "评估"
-
-#~ msgctxt "storage"
-#~ msgid "Device File"
-#~ msgstr "设备文件"
-
-#~ msgctxt "storage"
-#~ msgid "Multipathed Devices"
-#~ msgstr "多路径设备"
-
-#~ msgctxt "storage"
-#~ msgid "Device"
-#~ msgstr "设备"
-
-#~ msgctxt "storage"
 #~ msgid "Name"
 #~ msgstr "名称"
-
-#~ msgctxt "storage"
-#~ msgid "UUID"
-#~ msgstr "UUID"
-
-#~ msgctxt "storage"
-#~ msgid "RAID Level"
-#~ msgstr "RAID 级别"
-
-#~ msgctxt "storage"
-#~ msgid "Bitmap"
-#~ msgstr "位图"
-
-#~ msgctxt "storage"
-#~ msgid "State"
-#~ msgstr "状态"
 
 #~ msgid ""
 #~ "\n"
@@ -6619,15 +6633,6 @@ msgstr "设置"
 #~ msgstr ""
 #~ "\n"
 #~ "                    URL\n"
-#~ "                  "
-
-#~ msgid ""
-#~ "\n"
-#~ "                    Login\n"
-#~ "                  "
-#~ msgstr ""
-#~ "\n"
-#~ "                    登陆\n"
 #~ "                  "
 
 #~ msgid ""

--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -25,8 +25,6 @@ basedebug_DATA = \
 
 CLEAN_CSS = $(srcdir)/node_modules/.bin/cleancss
 
-UGLIFY_JS = $(srcdir)/node_modules/.bin/uglifyjs
-
 MIN_JS_RULE = \
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
 	$(srcdir)/tools/missing $(UGLIFY_JS) $^ --mangle --comments 'preserve' --beautify \

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -3574,7 +3574,7 @@ function basic_scope(cockpit, jquery) {
     };
 
     cockpit.translate = function translate(/* ... */) {
-	var list, el, translated, i, ilen, w, wlen, what;
+	var what;
 
         /* Called without arguments, entire document */
 	if (arguments.length === 0)
@@ -3589,17 +3589,37 @@ function basic_scope(cockpit, jquery) {
             what = arguments;
 
         /* Translate all the things */
+        var w, wlen, val, i, ilen, t, tlen, list, tasks, el;
 	for (w = 0, wlen = what.length; w < wlen; w++) {
+
+            /* The list of things to translate */
             list = null;
             if (what[w].querySelectorAll)
-                list = what[w].querySelectorAll("[translatable=\"yes\"]");
-            if (list) {
-                for (i = 0, ilen = list.length; i < ilen; i++) {
-                    el = list[i];
-                    translated = cockpit.gettext(el.getAttribute("context"), el.textContent);
-                    el.removeAttribute("translatable");
-                    el.textContent = translated;
+                list = what[w].querySelectorAll("[translatable], [translate]");
+            if (!list)
+                continue;
+
+            /* Each element */
+            for (i = 0, ilen = list.length; i < ilen; i++) {
+                el = list[i];
+
+                val = el.getAttribute("translate") || el.getAttribute("translatable") || "yes";
+                if (val == "no")
+                    continue;
+
+                /* Each thing to translate */
+                tasks = val.split(" ");
+                val = el.getAttribute("translate-context") || el.getAttribute("context");
+                for (t = 0, tlen = tasks.length; t < tlen; t++) {
+                    if (tasks[t] == "yes" || tasks[t] == "translate")
+                        el.textContent = cockpit.gettext(val, el.textContent);
+                    else if (tasks[t])
+                        el.setAttribute(tasks[t], cockpit.gettext(val, el.getAttribute(tasks[t]) || ""));
                 }
+
+                /* Mark this thing as translated */
+                el.removeAttribute("translatable");
+                el.removeAttribute("translate");
             }
         }
     };

--- a/src/base1/test-locale.js
+++ b/src/base1/test-locale.js
@@ -93,55 +93,99 @@ QUnit.test("translate document", function() {
 
     $("#translations")
         .empty()
-        .append("<span translatable='yes' id='translatable-html'>Control</span>");
+        .append("<span translate id='translatable-html'>Control</span>");
 
     cockpit.translate();
-    assert.equal($("#translatable-html").text(), "Ontrolcay", "translatable element");
-    assert.strictEqual($("#translatable-html").attr("translatable"), undefined, "translatable element attribute removed");
+    assert.equal($("#translatable-html").text(), "Ontrolcay", "translate element");
+    assert.strictEqual($("#translatable-html").attr("translate"), undefined, "translate element attribute removed");
 });
 
 QUnit.test("translate elements", function() {
     cockpit.locale(null);
     cockpit.locale(pig_latin);
 
-    var div1 = $("<div><span translatable='yes' id='translatable-html'>Control</span>" +
-                 "<span translatable='yes' context='key' id='translatable-context-html'>Control</span></div>");
+    var div1 = $("<div><span translate id='translatable-html'>Control</span>" +
+                 "<span translate translate-context='key' id='translatable-context-html'>Control</span></div>");
 
-    var div2 = $("<div translatable='yes'>User</div>");
+    var div2 = $("<div translate>User</div>");
 
-    var div3 = $("<div><span><i translatable='yes'>Waiting</i></span></div>");
+    var div3 = $("<div><span><i translate>Waiting</i></span></div>");
 
     $("#translations")
         .empty()
         .append(div1, div2, div3);
 
     cockpit.translate(div1[0], div2[0], div3[0]);
-    assert.equal($("#translatable-html").text(), "Ontrolcay", "translatable element");
-    assert.strictEqual($("#translatable-html").attr("translatable"), undefined, "translatable element removed");
-    assert.equal($("#translatable-context-html").text(), "OntrolCAY", "translatable context");
-    assert.strictEqual($("#translatable-context-html").attr("translatable"), undefined, "translatable context attribute removed");
+    assert.equal($("#translatable-html").text(), "Ontrolcay", "translate element");
+    assert.strictEqual($("#translatable-html").attr("translate"), undefined, "translate element removed");
+    assert.equal($("#translatable-context-html").text(), "OntrolCAY", "translate context");
+    assert.strictEqual($("#translatable-context-html").attr("translate"), undefined, "translate context attribute removed");
 });
 
 QUnit.test("translate array", function() {
     cockpit.locale(null);
     cockpit.locale(pig_latin);
 
-    var div1 = $("<div><span translatable='yes' id='translatable-html'>Control</span>" +
-                 "<span translatable='yes' context='key' id='translatable-context-html'>Control</span></div>");
+    var div1 = $("<div><span translate id='translatable-html'>Control</span>" +
+                 "<span translate translate-context='key' id='translatable-context-html'>Control</span></div>");
 
-    var div2 = $("<div translatable='yes'>User</div>");
+    var div2 = $("<div translate>User</div>");
 
-    var div3 = $("<div><span><i translatable='yes'>Waiting</i></span></div>");
+    var div3 = $("<div><span><i translate>Waiting</i></span></div>");
 
     $("#translations")
         .empty()
         .append(div1, div2, div3);
 
     cockpit.translate($("#translations div"));
-    assert.equal($("#translatable-html").text(), "Ontrolcay", "translatable element");
-    assert.strictEqual($("#translatable-html").attr("translatable"), undefined, "translatable element no attribute");
-    assert.equal($("#translatable-context-html").text(), "OntrolCAY", "translatable context");
-    assert.strictEqual($("#translatable-context-html").attr("translatable"), undefined, "translatable context attribute removed");
+    assert.equal($("#translatable-html").text(), "Ontrolcay", "translate element");
+    assert.strictEqual($("#translatable-html").attr("translate"), undefined, "translate element no attribute");
+    assert.equal($("#translatable-context-html").text(), "OntrolCAY", "translate context");
+    assert.strictEqual($("#translatable-context-html").attr("translate"), undefined, "translate context attribute removed");
+});
+
+QUnit.test("translate glade", function() {
+    cockpit.locale(null);
+    cockpit.locale(pig_latin);
+
+    var div = $("<div><span translatable='yes' id='translatable-glade'>Control</span>" +
+                "<span translatable='yes' context='key' id='translatable-glade-context'>Control</span></div>");
+
+    $("#translations").empty().append(div);
+
+    cockpit.translate(div);
+    assert.equal($("#translatable-glade").text(), "Ontrolcay", "translatable element");
+    assert.strictEqual($("#translatable-glade").attr("translatable"), undefined, "translatable element removed");
+    assert.equal($("#translatable-glade-context").text(), "OntrolCAY", "translatable context");
+    assert.strictEqual($("#translatable-glade-context").attr("translatable"), undefined, "translatable context attribute removed");
+});
+
+QUnit.test("translate attributes", function() {
+    cockpit.locale(null);
+    cockpit.locale(pig_latin);
+
+    var div = $("<div><span translate='title' title='Control' id='translatable-attribute'>Waiting</span>" +
+                "<div><span translate='title' translate-context='key' title='Control'" +
+                    "id='translatable-attribute-context'>Waiting</span>" +
+                "<span translate='yes title' title='User' id='translatable-attribute-both'>Waiting</span></div>" +
+                "<span translate='  yes title ' title='User'" +
+                    "id='translatable-attribute-syntax'>Waiting</span></div>");
+
+    $("#translations").empty().append(div);
+
+    cockpit.translate(div);
+    assert.equal($("#translatable-attribute").attr("title"), "Ontrolcay", "translate attribute");
+    assert.equal($("#translatable-attribute").text(), "Waiting", "translate attribute doesn't affect text");
+    assert.strictEqual($("#translatable-attribute").attr("translate"), undefined, "translate removed");
+    assert.equal($("#translatable-attribute-context").attr("title"), "OntrolCAY", "translatable element");
+    assert.equal($("#translatable-attribute-context").text(), "Waiting", "translate context doesn't affect text");
+    assert.strictEqual($("#translatable-attribute-context").attr("translate"), undefined, "translate removed");
+    assert.equal($("#translatable-attribute-both").attr("title"), "Useray", "translate attribute both");
+    assert.equal($("#translatable-attribute-both").text(), "Aitingway", "translate text both");
+    assert.strictEqual($("#translatable-attribute-both").attr("translate"), undefined, "translate removed");
+    assert.equal($("#translatable-attribute-syntax").attr("title"), "Useray", "translate syntax both");
+    assert.equal($("#translatable-attribute-syntax").text(), "Aitingway", "translate syntax both");
+    assert.strictEqual($("#translatable-attribute-syntax").attr("translate"), undefined, "translate removed");
 });
 
 $(function() {

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -159,6 +159,11 @@ WantedBy=default.target
         self.assertEqual(b.text("#ngettext-context-disks-1"), u"$0 Datenträger fehlt")
         self.assertEqual(b.text("#ngettext-context-disks-2"), u"$0 Datenträger fehlen")
 
+        # Angular
+        self.assertEqual(b.text("#angular-translate"), "Bereit")
+        self.assertEqual(b.text("#angular-context"), "Bereiten")
+        self.assertEqual(b.text("#angular-interpolate"), u"'Marmalade' löschen")
+
     def testFrameReload(self):
         b = self.browser
         frame = "cockpit1:localhost/playground/test"

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -125,8 +125,30 @@ WantedBy=default.target
         b.switch_to_top()
         b.go("/playground/translate")
         b.enter_page("/playground/translate")
-        self.assertEqual(b.text("#translatable-html"), "Abbrechen")
+
+        # HTML section
+        self.assertEqual(b.text("#translate-html"), "Bereit")
+        self.assertEqual(b.text("#translate-html-context"), "Bereiten")
+        self.assertEqual(b.text("#translate-html-yes"), "Nicht bereit")
+        self.assertEqual(b.attr("#translate-html-title", "title"), u"Nicht verfügbar")
+        self.assertEqual(b.text("#translate-html-title"), "Cancel")
+        self.assertEqual(b.attr("#translate-html-yes-title", "title"), u"Nicht verfügbar")
+        self.assertEqual(b.text("#translate-html-yes-title"), "Abbrechen")
+
+        # Glade section
+        self.assertEqual(b.text("#translatable-glade"), "Leer")
+        self.assertEqual(b.text("#translatable-glade-context"), "Leeren")
+
+        # Mustache section
         self.assertEqual(b.text("#translatable-mustache"), "Benutzer")
+        self.assertEqual(b.text("#translate-mustache"), "Speicher")
+        self.assertEqual(b.text("#translate-mustache-yes"), "Netzwerk")
+        self.assertEqual(b.attr("#translate-mustache-title", "title"), "Fehler")
+        self.assertEqual(b.text("#translate-mustache-title"), "User")
+        self.assertEqual(b.attr("#translate-mustache-yes-title", "title"), "Fehler")
+        self.assertEqual(b.text("#translate-mustache-yes-title"), "Benutzer")
+
+        # Javascript
         self.assertEqual(b.text("#underscore-empty"), "Leer")
         self.assertEqual(b.text("#underscore-context-empty"), "Leeren")
         self.assertEqual(b.text("#cunderscore-context-empty"), "Leeren")
@@ -136,15 +158,6 @@ WantedBy=default.target
         self.assertEqual(b.text("#ngettext-disks-2"), "$0 Festplatten fehlen")
         self.assertEqual(b.text("#ngettext-context-disks-1"), u"$0 Datenträger fehlt")
         self.assertEqual(b.text("#ngettext-context-disks-2"), u"$0 Datenträger fehlen")
-
-        # TODO: Not yet translated
-        # translate-html
-        # translate-html-yes
-        # translate-html-title
-        # translate-mustache
-        # translate-mustache-yes
-        # translate-mustache-title
-
 
     def testFrameReload(self):
         b = self.browser

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -399,8 +399,9 @@ The Cockpit component for managing storage.  This package uses Storaged.
 
 %package ostree
 Summary: Cockpit user interface for rpm-ostree
-Requires: %{name}-bridge >= %{required_base}
-Requires: %{name}-shell >= %{required_base}
+# Requires: Uses new translations functionality
+Requires: %{name}-bridge > 124
+Requires: %{name}-shell > 124
 %if 0%{?fedora} > 0 && 0%{?fedora} < 24
 Requires: rpm-ostree >= 2015.10-1
 %else


### PR DESCRIPTION
Support extracting the getString() and getPlural() style of javascript strings. Also in our po files support loading into angular-gettext.

Use angular-gettext in the ostree component. And mark everything for transtlation appropriately.

Depends on:

* [x] #5326 
* [x] #5418 
* [x] #5421 
