### PR TITLE
ostree: make buttons use headline case instead of sentence case

### DIFF
--- a/pkg/ostree/index.html
+++ b/pkg/ostree/index.html
@@ -45,7 +45,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
                 {{ error }}
             </div>
             <div class="listing-ct-actions">
-                <button class="btn btn-default" ng-class="{ disabled: runningMethod, enabled: !runningMethod }" ng-click="checkForUpgrades()" translatable="yes">Check for updates</button>
+                <button class="btn btn-default" ng-class="{ disabled: runningMethod, enabled: !runningMethod }" ng-click="checkForUpgrades()" translatable="yes">Check for Updates</button>
             </div>
         </div>
     </div>
@@ -68,12 +68,12 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
                         ng-click="doUpgrade(item.osname.v, item.checksum.v)"
                         ng-if="matches('CachedUpdate') && !matches('DefaultDeployment')"
                         class="btn btn-primary" translatable="yes">
-                    Update and reboot
+                    Update and Reboot
                 </button>
                 <button ng-class="{ disabled: runningMethod, enabled: !runningMethod }"
                         ng-click="doRollback(item.osname.v)"
                         ng-if="matches('RollbackDeployment') && !matches('CachedUpdate')"
-                        translatable="yes" class="btn btn-default">Roll back and reboot</button>
+                        translatable="yes" class="btn btn-default">Roll Back and Reboot</button>
             </div>
             <h3>{{ item | releaseName }}</h3>
             <div ng-if="!isRunning" class="listing-ct-status">

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -137,14 +137,14 @@ class OstreeRestartCase(MachineCase):
         b.wait_not_in_text('table.listing-ct tbody:nth-child(4) div.listing-ct-head h3', "cockpit")
         b.wait_present('table.listing-ct tbody:nth-child(4) i.fa-circle')
         b.wait_in_text('table.listing-ct tbody:nth-child(4) div.listing-ct-status', "Available")
-        b.wait_in_text("table.listing-ct tbody:nth-child(4) div.listing-ct-actions button", "Roll back")
+        b.wait_in_text("table.listing-ct tbody:nth-child(4) div.listing-ct-actions button", "Roll Back")
         b.wait_in_text("table.listing-ct tbody:nth-child(4) dd.os", name)
         b.wait_visible("table.listing-ct tbody:nth-child(4) div.tree")
         b.wait_not_visible("table.listing-ct tbody:nth-child(4) div.packages")
 
         # Check for new commit, get error
         b.wait_present('table.listing-ct tbody:nth-child(2) i.fa-caret-up')
-        b.wait_in_text("table.listing-ct tbody:nth-child(2) div.listing-ct-actions button", "Check for updates")
+        b.wait_in_text("table.listing-ct tbody:nth-child(2) div.listing-ct-actions button", "Check for Updates")
         b.wait_not_present('table.listing-ct tbody:nth-child(2) div.alert')
         b.click("table.listing-ct tbody:nth-child(2) div.listing-ct-actions button")
         b.wait_present('table.listing-ct tbody:nth-child(2) div.alert')
@@ -225,7 +225,7 @@ class OstreeRestartCase(MachineCase):
         b.wait_text('table.listing-ct tbody:nth-child(4) div.listing-ct-head h3', name + " cockpit-base.1")
         b.wait_present('table.listing-ct tbody:nth-child(4) i.fa-circle')
         b.wait_in_text('table.listing-ct tbody:nth-child(4) div.listing-ct-status', "Available")
-        b.wait_in_text("table.listing-ct tbody:nth-child(4) div.listing-ct-actions button", "Roll back")
+        b.wait_in_text("table.listing-ct tbody:nth-child(4) div.listing-ct-actions button", "Roll Back")
         b.wait_in_text("table.listing-ct tbody:nth-child(4) dd.os", name)
         self.check_change_counts(b, "table.listing-ct tbody:nth-child(4)")
         self.switch_to_packages(b, "table.listing-ct tbody:nth-child(4)",
@@ -238,7 +238,7 @@ class OstreeRestartCase(MachineCase):
         b.wait_text("table.listing-ct tbody:nth-child(4) dl.removals dd", "empty-1-0.noarch")
 
         # Rollback
-        b.wait_present("button:contains('Roll back')");
+        b.wait_present("button:contains('Roll Back')");
         b.click("table.listing-ct tbody:nth-child(4) div.listing-ct-actions button")
         b.wait_present("table.listing-ct tbody:nth-child(4) div.ostree-progress")
 
@@ -258,7 +258,7 @@ class OstreeRestartCase(MachineCase):
         b.wait_in_text("table.listing-ct tbody:nth-child(3) div.listing-ct-actions button", "Update")
         b.wait_present('table.listing-ct tbody:nth-child(4) i.fa-check-circle-o')
         b.wait_not_present('table.listing-ct tbody:nth-child(5)')
-        b.wait_not_present("button:contains('Roll back')");
+        b.wait_not_present("button:contains('Roll Back')");
 
         self.allow_restart_journal_messages()
 


### PR DESCRIPTION
Patternfly recommends using headline case for buttons

Fixes issue #5413