### PR TITLE
ws: Use environment variables instead of cmdline options

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -125,3 +125,24 @@ option to the ```WebService``` section of your cockpit configuration.
 Additional connections will be dropped until authentication succeeds or
 the connections are closed. See the man page for cockpit.conf for more
 details. By default the limit is set to 10.
+
+Environment Variables
+================================
+
+The following environment variables are set by cockpit-ws when spawning an auth process
+
+ * **COCKPIT_REMOTE_PEER** Set to the ip address of the connecting user.
+ * **COCKPIT_AUTH_MESSAGE_TYPE** A string representing the type of message that will be sent on the authentication fd. When the message is passed durning login, this will be set to the value of the auth scheme that was included in the the Authorization http header.
+ * **COCKPIT_SUPPORTS_CONVERSATION** Set to ```1``` if conversations are supported.
+
+The following environment variables are used to set options for the ```cockpit-ssh``` process.
+
+ * **COCKPIT_SSH_NO_HOST_KEY**` Set the expected host key to an empty string. This will force the host key check to fail. Used by the frontend to get a valid host key for the given host. Setting this value always allows cockpit-ssh to connect to this host.
+ * **COCKPIT_SSH_HOST_KEY** Expect the given value to match the host key for this server.  Setting this value always allows cockpit-ssh to connect to this host.
+ * **COCKPIT_SSH_IGNORE_HOST_KEY** Set to ```1``` to skip host key validation. Setting this value always allows cockpit-ssh to connect to this host.
+ * **COCKPIT_SSH_ALLOW_UNKNOWN**` Set to ```1``` to  allow connecting to hosts that are not saved in the current knownhosts file. If not set cockpit will only connect to unknown hosts if either the remote_peer is local or if the ```Ssh-Login``` section in ```cockpit.conf``` has a ```allowUnknown``` option set to a truthy value (```1```, ```yes``` or ```true```).
+ * **COCKPIT_SSH_KNOWN_HOSTS_FILE** Path to knownhost files. Defaults to ```PACKAGE_LOCALSTATE_DIR/known_hosts```
+ * **COCKPIT_SSH_BRIDGE_COMMAND** Command to launch after a ssh connection is established. Defaults to ```cockpit-bridge``` if not provided.
+ * **COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT** Set to ```1``` if caller supports prompting users for unknown host keys.
+ * **KRB5CCNAME** Kerberos credentials cache name. Not set when no active kerberos session is active.
+ * **SSH_AUTH_SOCK** When calling process has a cockpit ssh-agent already running this value is set to the FD # of . Otherwise this value is left untouched.

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -17,6 +17,8 @@ libcockpit_ws_a_SOURCES = \
 	src/ws/cockpitws.h				\
 	src/ws/cockpithandlers.h	src/ws/cockpithandlers.c	\
 	src/ws/cockpitauth.h		src/ws/cockpitauth.c		\
+	src/ws/cockpitauthoptions.h \
+	src/ws/cockpitauthoptions.c \
 	src/ws/cockpitauthprocess.h \
 	src/ws/cockpitauthprocess.c \
 	src/ws/cockpitcertificate.c \
@@ -83,6 +85,8 @@ sbin_PROGRAMS += remotectl
 libexec_PROGRAMS += cockpit-ws cockpit-session cockpit-ssh
 
 cockpit_ssh_SOURCES = \
+	src/ws/cockpitauthoptions.h \
+	src/ws/cockpitauthoptions.c \
 	src/ws/ssh.c \
 	$(NULL)
 
@@ -205,6 +209,7 @@ test_server_LDADD = 					\
 WS_CHECKS = \
 	test-creds \
 	test-auth \
+	test-authoptions \
 	test-sshtransport \
 	test-sshagent \
 	test-webservice \
@@ -225,6 +230,12 @@ test_auth_LDADD = \
 	libcockpit-ws.a \
 	$(cockpit_ws_LDADD) \
 	$(NULL)
+
+test_authoptions_CFLAGS = $(cockpit_ws_CFLAGS)
+test_authoptions_SOURCES = src/ws/test-authoptions.c
+test_authoptions_LDADD = \
+	libcockpit-ws.a \
+	$(cockpit_ws_LDADD)
 
 test_channelresponse_CFLAGS = $(cockpit_ws_CFLAGS)
 test_channelresponse_SOURCES = src/ws/test-channelresponse.c \

--- a/src/ws/cockpitauth.h
+++ b/src/ws/cockpitauth.h
@@ -32,7 +32,6 @@ G_BEGIN_DECLS
 
 #define MAX_AUTH_TIMEOUT 900
 #define MIN_AUTH_TIMEOUT 1
-#define SSH_SECTION "Ssh-Login"
 
 #define COCKPIT_TYPE_AUTH         (cockpit_auth_get_type ())
 #define COCKPIT_AUTH(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_AUTH, CockpitAuth))

--- a/src/ws/cockpitauthoptions.c
+++ b/src/ws/cockpitauthoptions.c
@@ -1,0 +1,196 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/cockpitconf.h"
+
+#include "cockpitauthoptions.h"
+
+static const gchar *default_knownhosts = PACKAGE_LOCALSTATE_DIR "/known_hosts";
+static const gchar *default_command = "cockpit-bridge";
+
+static gboolean
+has_environment_val (gchar **env,
+                     const gchar *name)
+{
+  const gchar *v = g_environ_getenv (env, name);
+  return v != NULL && v[0] != '\0';
+}
+
+static const gchar *
+get_environment_val (gchar **env,
+                     const gchar *name,
+                     const gchar *defawlt)
+{
+  if (has_environment_val (env, name))
+    return g_environ_getenv (env, name);
+  else
+    return defawlt;
+}
+
+static gchar **
+set_environment_val (gchar **env,
+                     const gchar *name,
+                     const gchar *val)
+{
+  return g_environ_setenv (env, name, val ? val : "", TRUE);
+}
+
+static gboolean
+get_environment_bool (gchar **env,
+                      const gchar *name,
+                      gboolean defawlt)
+{
+  const gchar *value = get_environment_val (env, name, NULL);
+
+  if (!value)
+    return defawlt;
+
+  return g_strcmp0 (value, "yes") == 0 ||
+         g_strcmp0 (value, "true") == 0 ||
+         g_strcmp0 (value, "1") == 0;
+}
+
+static gchar **
+set_environment_bool (gchar **env,
+                      const gchar *name,
+                      gboolean val)
+{
+  return g_environ_setenv (env, name, val ? "1" : "", TRUE);
+}
+
+static const gchar *
+get_expected_hostkey (gchar **env)
+{
+  if (get_environment_bool (env, "COCKPIT_SSH_NO_HOST_KEY", FALSE))
+    return "";
+
+  return get_environment_val (env, "COCKPIT_SSH_HOST_KEY", NULL);
+}
+
+static guint
+get_agent_fd (gchar **env)
+{
+  const gchar *socket;
+  gchar *endptr = NULL;
+  guint agent_fd = 0;
+  socket = g_environ_getenv (env, "SSH_AUTH_SOCK");
+
+  if (socket)
+    agent_fd = g_ascii_strtoull (socket, &endptr, 10);
+
+  if (agent_fd > 3 && agent_fd < G_MAXINT &&
+      (endptr == NULL || endptr[0] == '\0'))
+    return agent_fd;
+
+  return 0;
+}
+
+static gboolean
+get_allow_unknown_hosts (gchar **env)
+{
+  const gchar *remote_peer = g_environ_getenv (env, "COCKPIT_REMOTE_PEER");
+
+  if (g_strcmp0 (remote_peer, "127.0.0.1") == 0 ||
+      g_strcmp0 (remote_peer, "::1") == 0 ||
+      cockpit_conf_bool (SSH_SECTION, "allowUnknown", FALSE))
+    return TRUE;
+
+  return get_environment_bool (env, "COCKPIT_SSH_ALLOW_UNKNOWN", FALSE);
+}
+
+
+CockpitAuthOptions *
+cockpit_auth_options_from_env (gchar **env)
+{
+  CockpitAuthOptions *options = g_new0 (CockpitAuthOptions, 1);
+  options->auth_type = get_environment_val (env, "COCKPIT_AUTH_MESSAGE_TYPE", "none");
+  options->supports_conversations = get_environment_bool (env, "COCKPIT_SUPPORTS_CONVERSATION",
+                                                           FALSE);
+  options->remote_peer = get_environment_val (env, "COCKPIT_REMOTE_PEER", "localhost");
+  return options;
+}
+
+gchar **
+cockpit_auth_options_to_env (CockpitAuthOptions *options,
+                             gchar **env)
+{
+  env = g_environ_setenv (env, "COCKPIT_AUTH_MESSAGE_TYPE",
+                          options->auth_type ? options->auth_type : "none", TRUE);
+  env = set_environment_bool (env, "COCKPIT_SUPPORTS_CONVERSATION",
+                              options->supports_conversations);
+  env = set_environment_val (env, "COCKPIT_REMOTE_PEER",
+                             options->remote_peer);
+  return env;
+}
+
+CockpitSshOptions *
+cockpit_ssh_options_from_env (gchar **env)
+{
+
+  CockpitSshOptions *options = g_new0 (CockpitSshOptions, 1);
+  options->expected_hostkey = get_expected_hostkey (env);
+  options->knownhosts_file = get_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE",
+                                                  default_knownhosts);
+  options->command = get_environment_val (env, "COCKPIT_SSH_BRIDGE_COMMAND", default_command);
+  options->krb5_ccache_name = get_environment_val (env, "KRB5CCNAME", NULL);
+  options->ignore_hostkey = get_environment_bool (env, "COCKPIT_SSH_IGNORE_HOST_KEY", FALSE);
+  options->supports_hostkey_prompt = get_environment_bool (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", FALSE);
+  options->agent_fd = get_agent_fd (env);
+
+  if (options->ignore_hostkey || options->expected_hostkey != NULL)
+    options->allow_unknown_hosts = TRUE;
+  else
+    options->allow_unknown_hosts = get_allow_unknown_hosts (env);
+
+  return options;
+}
+
+gchar **
+cockpit_ssh_options_to_env (CockpitSshOptions *options,
+                            gchar **env)
+{
+  gchar *agent = NULL;
+
+  env = set_environment_bool (env, "COCKPIT_SSH_ALLOW_UNKNOWN",
+                              options->allow_unknown_hosts);
+  env = set_environment_bool (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT",
+                              options->supports_hostkey_prompt);
+  env = set_environment_bool (env, "COCKPIT_SSH_IGNORE_HOST_KEY",
+                              options->ignore_hostkey);
+  env = set_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE",
+                             options->knownhosts_file);
+  env = set_environment_val (env, "COCKPIT_SSH_BRIDGE_COMMAND",
+                             options->command);
+  env = set_environment_val (env, "COCKPIT_SSH_HOST_KEY",
+                             options->expected_hostkey);
+  /* If an empty string we set a different env var */
+  env = set_environment_bool (env, "COCKPIT_SSH_NO_HOST_KEY",
+                              g_strcmp0 (options->expected_hostkey, "") == 0);
+
+  env = set_environment_val (env, "KRB5CCNAME", options->krb5_ccache_name);
+
+  if (options->agent_fd)
+    {
+      agent = g_strdup_printf ("%d", options->agent_fd);
+      env = g_environ_setenv (env, "SSH_AUTH_SOCK", agent, TRUE);
+    }
+
+  g_free (agent);
+  return env;
+}

--- a/src/ws/cockpitauthoptions.h
+++ b/src/ws/cockpitauthoptions.h
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __COCKPIT_AUTH_OPTIONS_H__
+#define __COCKPIT_AUTH_OPTIONS_H__
+
+#include <gio/gio.h>
+
+#define SSH_SECTION "Ssh-Login"
+
+G_BEGIN_DECLS
+
+typedef struct {
+  const gchar *remote_peer;
+  gboolean supports_conversations;
+  const gchar *auth_type;
+} CockpitAuthOptions;
+
+CockpitAuthOptions * cockpit_auth_options_from_env  (gchar **env);
+
+gchar **             cockpit_auth_options_to_env    (CockpitAuthOptions *options,
+                                                     gchar **env);
+
+typedef struct {
+  const gchar *expected_hostkey;
+  const gchar *knownhosts_file;
+  const gchar *command;
+  const gchar *krb5_ccache_name;
+  gboolean allow_unknown_hosts;
+  gboolean supports_hostkey_prompt;
+  gboolean ignore_hostkey;
+  guint agent_fd;
+} CockpitSshOptions;
+
+CockpitSshOptions * cockpit_ssh_options_from_env   (gchar **env);
+
+gchar **             cockpit_ssh_options_to_env     (CockpitSshOptions *options,
+                                                     gchar **env);
+
+G_END_DECLS
+
+#endif

--- a/src/ws/cockpitauthprocess.c
+++ b/src/ws/cockpitauthprocess.c
@@ -46,7 +46,6 @@
 /* The amount of time auth pipe will stay open */
 guint default_timeout = 60;
 
-
 typedef struct {
   guint wanted_fd_number;
   gint auth_fd;
@@ -727,6 +726,7 @@ cockpit_auth_process_write_auth_bytes (CockpitAuthProcess *self,
 gboolean
 cockpit_auth_process_start (CockpitAuthProcess *self,
                             const gchar** command_args,
+                            const gchar** env,
                             gint agent_fd,
                             gboolean should_respond,
                             GError **error)
@@ -736,7 +736,7 @@ cockpit_auth_process_start (CockpitAuthProcess *self,
   g_debug ("spawning %s", command_args[0]);
 
   self->child_data.agent_fd = agent_fd;
-  ret = g_spawn_async_with_pipes (NULL, (gchar **) command_args, NULL,
+  ret = g_spawn_async_with_pipes (NULL, (gchar **) command_args, (gchar **) env,
                                   G_SPAWN_DO_NOT_REAP_CHILD | G_SPAWN_LEAVE_DESCRIPTORS_OPEN,
                                   spawn_child_setup, &self->child_data,
                                   &self->process_pid, &self->process_in,

--- a/src/ws/cockpitauthprocess.h
+++ b/src/ws/cockpitauthprocess.h
@@ -40,6 +40,7 @@ const gchar *      cockpit_auth_process_get_id      (CockpitAuthProcess *self);
 
 gboolean           cockpit_auth_process_start       (CockpitAuthProcess *self,
                                                      const gchar** command_args,
+                                                     const gchar** env,
                                                      gint agent_fd,
                                                      gboolean should_respond,
                                                      GError **error);
@@ -60,6 +61,7 @@ const gchar *      cockpit_auth_process_get_authenticated_user  (CockpitAuthProc
                                                                  JsonObject *results,
                                                                  JsonObject **prompt_data,
                                                                  GError **error);
+
 G_END_DECLS
 
 #endif

--- a/src/ws/mock-auth-command.c
+++ b/src/ws/mock-auth-command.c
@@ -125,37 +125,31 @@ main (int argc,
       write_resp (fd, "{\"user\": \"me\" }");
       success = 1;
     }
-  else if (strcmp (data, "ssh-remote-switch") == 0 && argc == 2 && strcmp (argv[1], "machine") == 0)
+  else if (strcmp (data, "ssh-remote-switch") == 0 &&
+           strcmp (argv[1], "machine") == 0 &&
+           strcmp (getenv ("COCKPIT_SSH_IGNORE_HOST_KEY"), "") == 0)
     {
       write_resp (fd, "{\"user\": \"me\" }");
       success = 1;
     }
-  else if (strcmp (data, "ssh-local-peer") == 0 && argc == 3 &&
-           strcmp (argv[1], "--prompt-unknown-hostkey") == 0 &&
-           strcmp (argv[2], "machine") == 0)
+  else if (strcmp (data, "ssh-alt-machine") == 0 &&
+           strcmp (argv[1], "machine") == 0 &&
+           strcmp (getenv ("COCKPIT_SSH_IGNORE_HOST_KEY"), "") == 0)
     {
       write_resp (fd, "{\"user\": \"me\" }");
       success = 1;
     }
-  else if (strcmp (data, "ssh-alt-machine") == 0 && argc == 3 &&
-           strcmp (argv[1], "--prompt-unknown-hostkey") == 0 &&
-           strcmp (argv[2], "machine") == 0)
+  else if (strcmp (data, "ssh-alt-default") == 0 &&
+           strcmp (argv[1], "default-host") == 0 &&
+           strcmp (getenv ("COCKPIT_SSH_IGNORE_HOST_KEY"), "1") == 0)
     {
       write_resp (fd, "{\"user\": \"me\" }");
       success = 1;
     }
-  else if (strcmp (data, "ssh-alt-default") == 0 && argc == 3 &&
-           strcmp (argv[1], "--ignore-hostkey") == 0 &&
-           strcmp (argv[2], "default-host") == 0)
+  else if (strcmp (data, "this is the password") == 0 &&
+           strcmp (getenv ("COCKPIT_SSH_IGNORE_HOST_KEY"), "1") == 0)
     {
-      write_resp (fd, "{\"user\": \"me\" }");
-      success = 1;
-    }
-  else if (strcmp (data, "this is the password") == 0)
-    {
-      if (argc == 4 && strcmp (argv[3], "me") == 0 &&
-          strcmp (argv[2], "localhost") == 0 &&
-          strcmp (argv[1], "--ignore-hostkey") == 0)
+      if (strcmp (argv[1], "me@localhost") == 0)
         {
           write_resp (fd, "{\"user\": \"me\" }");
           success = 1;
@@ -165,10 +159,10 @@ main (int argc,
           write_resp (fd, "{ \"error\": \"authentication-failed\", \"auth-method-results\": { \"password\": \"denied\"} }");
         }
     }
-  else if (strcmp (data, "this is the machine password") == 0)
+  else if (strcmp (data, "this is the machine password") == 0 &&
+           strcmp (getenv ("COCKPIT_SSH_IGNORE_HOST_KEY"), "") == 0)
     {
-      if (argc == 3 && strcmp (argv[2], "remote-user") == 0 &&
-          strcmp (argv[1], "machine") == 0)
+      if (strcmp (argv[1], "remote-user@machine") == 0)
         {
           write_resp (fd, "{\"user\": \"remote-user\" }");
           success = 1;

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -626,15 +626,6 @@ static const SuccessFixture fixture_ssh_remote_switched = {
   .cookie_name = "machine-cockpit+machine"
 };
 
-static const SuccessFixture fixture_ssh_local_peer = {
-  .data = NULL,
-  .header = "testscheme ssh-local-peer",
-  .path = "/cockpit+=machine",
-  .application = "cockpit+=machine",
-  .remote_peer = "127.0.0.1",
-  .cookie_name = "machine-cockpit+machine"
-};
-
 static const SuccessFixture fixture_ssh_alt_default = {
   .data = NULL,
   .header = "testsshscheme ssh-alt-default",
@@ -1243,8 +1234,6 @@ main (int argc,
   g_test_add ("/auth/custom-ssh-remote-basic-success", Test, &fixture_ssh_remote_basic,
               setup_normal, test_custom_success, teardown_normal);
   g_test_add ("/auth/custom-ssh-remote-switched", Test, &fixture_ssh_remote_switched,
-              setup_normal, test_custom_success, teardown_normal);
-  g_test_add ("/auth/custom-ssh-local-peer", Test, &fixture_ssh_local_peer,
               setup_normal, test_custom_success, teardown_normal);
   g_test_add ("/auth/custom-ssh-with-conf-default", Test, &fixture_ssh_alt_default,
               setup_alt_config, test_custom_success, teardown_normal);

--- a/src/ws/test-authoptions.c
+++ b/src/ws/test-authoptions.c
@@ -1,0 +1,217 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "common/cockpitconf.h"
+#include "common/cockpittest.h"
+
+#include "cockpitauthoptions.h"
+
+/* Mock override these from other files */
+extern const gchar *cockpit_config_file;
+
+static void
+test_auth_options (void)
+{
+  gchar **env = NULL;
+  CockpitAuthOptions *options = NULL;
+
+  options = cockpit_auth_options_from_env (env);
+  g_assert_false (options->supports_conversations);
+  g_assert_cmpstr (options->auth_type, ==, "none");
+  g_assert_cmpstr (options->remote_peer, ==, "localhost");
+
+  options->auth_type = "test";
+  options->remote_peer = "other";
+  options->supports_conversations = TRUE;
+
+  env = cockpit_auth_options_to_env (options, NULL);
+
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_REMOTE_PEER"), ==, "other");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_AUTH_MESSAGE_TYPE"), ==, "test");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SUPPORTS_CONVERSATION"), ==, "1");
+
+  g_free (options);
+
+  options = cockpit_auth_options_from_env (env);
+  g_assert_true (options->supports_conversations);
+  g_assert_cmpstr (options->auth_type, ==, "test");
+  g_assert_cmpstr (options->remote_peer, ==, "other");
+
+  g_free (options);
+  g_strfreev (env);
+}
+
+static void
+test_ssh_options (void)
+{
+  gchar **env = NULL;
+  CockpitSshOptions *options = NULL;
+
+  options = cockpit_ssh_options_from_env (env);
+  g_assert_null (options->expected_hostkey);
+  g_assert_null (options->krb5_ccache_name);
+  g_assert_cmpstr (options->knownhosts_file, ==, PACKAGE_LOCALSTATE_DIR "/known_hosts");
+  g_assert_cmpstr (options->command, ==, "cockpit-bridge");
+  g_assert_false (options->allow_unknown_hosts);
+  g_assert_false (options->supports_hostkey_prompt);
+  g_assert_false (options->ignore_hostkey);
+  g_assert_cmpuint (options->agent_fd, ==, 0);
+
+  options->knownhosts_file = "other-known";
+  options->command = "other-command";
+  options->krb5_ccache_name = "";
+  options->ignore_hostkey = TRUE;
+
+  env = cockpit_ssh_options_to_env (options, NULL);
+
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_NO_HOST_KEY"), ==, "");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_HOST_KEY"), ==, "");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_IGNORE_HOST_KEY"), ==, "1");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN"), ==, "");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE"), ==, "other-known");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_BRIDGE_COMMAND"), ==, "other-command");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT"), ==, "");
+  g_assert_cmpstr (g_environ_getenv (env, "KRB5CCNAME"), ==, "");
+  g_assert_null (g_environ_getenv (env, "SSH_AUTH_SOCK"));
+
+  options->expected_hostkey = "";
+  options->agent_fd = 5;
+  options->krb5_ccache_name = "cache";
+  options->allow_unknown_hosts = TRUE;
+  options->supports_hostkey_prompt = TRUE;
+  options->ignore_hostkey = FALSE;
+
+  g_strfreev (env);
+  env = cockpit_ssh_options_to_env (options, NULL);
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_NO_HOST_KEY"), ==, "1");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_HOST_KEY"), ==, "");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_IGNORE_HOST_KEY"), ==, "");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN"), ==, "1");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT"), ==, "1");
+  g_assert_cmpstr (g_environ_getenv (env, "KRB5CCNAME"), ==, "cache");
+  g_assert_cmpstr (g_environ_getenv (env, "SSH_AUTH_SOCK"), ==, "5");
+
+  options->expected_hostkey = "key";
+  g_strfreev (env);
+  env = cockpit_ssh_options_to_env (options, NULL);
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_NO_HOST_KEY"), ==, "");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_HOST_KEY"), ==, "key");
+  g_strfreev (env);
+  g_free (options);
+
+  /* Start with a clean env */
+  env = g_environ_setenv (NULL, "SSH_AUTH_SOCK", "other", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_IGNORE_HOST_KEY", "1", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE", "other-known", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_BRIDGE_COMMAND", "other-command", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_NO_HOST_KEY", "", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_HOST_KEY", "", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN", "", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "", TRUE);
+  env = g_environ_setenv (env, "KRB5CCNAME", "", TRUE);
+
+  options = cockpit_ssh_options_from_env (env);
+  g_assert_cmpuint (options->agent_fd, ==, 0);
+  g_assert_true (options->ignore_hostkey);
+  g_assert_null (options->expected_hostkey);
+  g_assert_null (options->krb5_ccache_name);
+  g_assert_false (options->supports_hostkey_prompt);
+  g_assert_true (options->allow_unknown_hosts);
+  g_assert_cmpstr (options->knownhosts_file, ==, "other-known");
+  g_assert_cmpstr (options->command, ==, "other-command");
+
+  g_free (options);
+  g_strfreev (env);
+
+  env = g_environ_setenv (NULL, "SSH_AUTH_SOCK", "5", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_NO_HOST_KEY", "1", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "1", TRUE);
+  env = g_environ_setenv (env, "KRB5CCNAME", "cache", TRUE);
+  options = cockpit_ssh_options_from_env (env);
+  g_assert_cmpuint (options->agent_fd, ==, 5);
+  g_assert_false (options->ignore_hostkey);
+  g_assert_cmpstr (options->expected_hostkey, ==, "");
+  g_assert_cmpstr (options->krb5_ccache_name, ==, "cache");
+  g_assert_true (options->supports_hostkey_prompt);
+  g_assert_true (options->allow_unknown_hosts);
+  g_free (options);
+  g_strfreev (env);
+
+  env = g_environ_setenv (NULL, "SSH_AUTH_SOCK", "5other", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_NO_HOST_KEY", "key", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "key", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN", "key", TRUE);
+  options = cockpit_ssh_options_from_env (env);
+  g_assert_cmpuint (options->agent_fd, ==, 0);
+  g_assert_false (options->ignore_hostkey);
+  g_assert_false (options->supports_hostkey_prompt);
+  g_assert_false (options->allow_unknown_hosts);
+  g_free (options);
+  g_strfreev (env);
+
+  env = g_environ_setenv (NULL, "COCKPIT_SSH_ALLOW_UNKNOWN", "yes", TRUE);
+  env = g_environ_setenv (env, "SSH_AUTH_SOCK", "5other", TRUE);
+  options = cockpit_ssh_options_from_env (env);
+  g_assert_cmpuint (options->agent_fd, ==, 0);
+  g_assert_false (options->ignore_hostkey);
+  g_assert_false (options->supports_hostkey_prompt);
+  g_assert_true (options->allow_unknown_hosts);
+  g_free (options);
+  g_strfreev (env);
+
+  env = g_environ_setenv (NULL, "COCKPIT_REMOTE_PEER", "127.0.0.1", TRUE);
+  options = cockpit_ssh_options_from_env (env);
+  g_assert_true (options->allow_unknown_hosts);
+  g_free (options);
+  g_strfreev (env);
+
+  env = g_environ_setenv (NULL, "COCKPIT_REMOTE_PEER", "::1", TRUE);
+  options = cockpit_ssh_options_from_env (env);
+  g_assert_true (options->allow_unknown_hosts);
+  g_free (options);
+  g_strfreev (env);
+}
+
+static void
+test_ssh_options_alt_conf (void)
+{
+  CockpitSshOptions *options = NULL;
+
+  cockpit_config_file = SRCDIR "/src/ws/mock-config/cockpit/cockpit-alt.conf";
+  cockpit_conf_cleanup ();
+
+  options = cockpit_ssh_options_from_env (NULL);
+  g_assert_true (options->allow_unknown_hosts);
+  g_free (options);
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+  cockpit_test_init (&argc, &argv);
+
+  g_test_add_func ("/auth-options/auth-options", test_auth_options);
+  g_test_add_func ("/auth-options/ssh-options", test_ssh_options);
+  g_test_add_func ("/auth-options/ssh-options-alt-conf", test_ssh_options_alt_conf);
+
+  return g_test_run ();
+}

--- a/src/ws/test-sshtransport.c
+++ b/src/ws/test-sshtransport.c
@@ -86,6 +86,7 @@ typedef struct {
 
     gboolean no_password;
     gboolean ignore_key;
+    gboolean prompt_hostkey;
     int ssh_log_level;
 
     const TestAuthResponse *responses;
@@ -218,6 +219,7 @@ setup_transport (TestCase *tc,
   const gchar *command;
   gchar *expect_knownhosts = NULL;
   gboolean ignore_key = FALSE;
+  gboolean prompt_hostkey = FALSE;
 
   /* First time around */
   if (old_process_timeout == 0)
@@ -258,6 +260,7 @@ setup_transport (TestCase *tc,
   if (fixture->expect_key)
     expect_knownhosts = g_strdup_printf ("[127.0.0.1]:%d %s", (int)tc->ssh_port, fixture->expect_key);
   ignore_key = fixture->ignore_key;
+  prompt_hostkey = fixture->prompt_hostkey;
 
   if (tc->agent_transport != NULL)
     agent = cockpit_ssh_agent_new (tc->agent_transport, "ssh-tests", "ssh-agent");
@@ -275,6 +278,7 @@ setup_transport (TestCase *tc,
                               "creds", creds,
                               "host-key", expect_knownhosts,
                               "ignore-key", ignore_key,
+                              "prompt-hostkey", prompt_hostkey,
                               NULL);
 
   cockpit_creds_unref (creds);
@@ -729,6 +733,11 @@ static const TestFixture fixture_unknown_hostkey = {
   .known_hosts = "/dev/null"
 };
 
+static const TestFixture fixture_prompt_hostkey = {
+  .known_hosts = "/dev/null",
+  .prompt_hostkey = TRUE
+};
+
 static void
 test_unknown_hostkey (TestCase *tc,
                       gconstpointer data)
@@ -1144,6 +1153,8 @@ main (int argc,
   g_test_add_func ("/ssh-transport/cannot-connect", test_cannot_connect);
 
   g_test_add ("/ssh-transport/unknown-hostkey", TestCase, &fixture_unknown_hostkey,
+              setup_transport, test_unknown_hostkey, teardown);
+  g_test_add ("/ssh-transport/prompt-hostkey-fail", TestCase, &fixture_prompt_hostkey,
               setup_transport, test_unknown_hostkey, teardown);
   g_test_add ("/ssh-transport/ignore-hostkey", TestCase, &fixture_ignore_hostkey,
               setup_transport, test_ignore_hostkey, teardown);


### PR DESCRIPTION
This is working towards stabilizing cockpit-ssh and standardizing the arguments that auth processes can take.