### PR TITLE
test: Pull new kubernetes pause image in verify images

### DIFF
--- a/test/images/fedora-24
+++ b/test/images/fedora-24
@@ -1,1 +1,1 @@
-fedora-24-f4cf77baf7de6a99ed2999aef7c72e9f3240e36f.qcow2
+fedora-24-4785b52adc60b7aea39a221d995f61be9d7bf48a.qcow2

--- a/test/images/fedora-25
+++ b/test/images/fedora-25
@@ -1,1 +1,1 @@
-fedora-25-c6ac0dbaf59ea4ecc5b07aaa0bcd7f307a0c1e31.qcow2
+fedora-25-7875fa1b9601476ad12bdf601ae0421cd0bb749b.qcow2

--- a/test/images/fedora-testing
+++ b/test/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-50b6d318eccbed9d2bc959b3d2ad74254f8e8686.qcow2
+fedora-testing-c0f4bb55b0122cddbf4336efba2267673295f9a1.qcow2

--- a/test/images/scripts/lib/docker-images.setup
+++ b/test/images/scripts/lib/docker-images.setup
@@ -23,6 +23,7 @@ docker pull busybox:buildroot-2014.02
 # docker pull submod/helloapache:0.1.11
 docker pull gcr.io/google_containers/pause:2.0
 docker pull gcr.io/google_containers/pause:0.8.0
+docker pull gcr.io/google_containers/pause-amd64:3.0
 
 # Disable all further pulling from online during the tests
 cat >> /etc/hosts <<EOF

--- a/test/verify/naughty-fedora-25/5027-systemd-coredump-selinux-broken
+++ b/test/verify/naughty-fedora-25/5027-systemd-coredump-selinux-broken
@@ -1,3 +1,3 @@
-Traceback (most recent call last):
   File "./verify/check-connection", line *, in testBasic
-    wait(lambda: m.execute("journalctl -b | grep 'Process.*cron.*of user.*dumped core.'"))
+    self.assertNotEqual(cores, "")
+AssertionError: '' == ''


### PR DESCRIPTION
This adds the following docker image which is needed by the
fedora-testing version of kubernetes. Over time other versions
will need this docker image as they upgrade their kubernetes.

docker pull gcr.io/google_containers/pause-amd64:3.0

I've rebuilt three virtual machines, and others will get this
image as necessary when they are rebuilt.