### PR TITLE
Log channel close messages to console.warn()

### DIFF
--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -737,6 +737,8 @@ function Channel(options) {
         self.valid = valid = false;
         if (transport && id)
             transport.unregister(id);
+        if (data.message)
+            console.warn(data.message);
         self.dispatchEvent("close", data);
     }
 

--- a/src/bridge/cockpitchannel.h
+++ b/src/bridge/cockpitchannel.h
@@ -74,6 +74,11 @@ GType               cockpit_channel_get_type          (void) G_GNUC_CONST;
 void                cockpit_channel_close             (CockpitChannel *self,
                                                        const gchar *problem);
 
+void                cockpit_channel_fail              (CockpitChannel *self,
+                                                       const gchar *problem,
+                                                       const gchar *format,
+                                                       ...) G_GNUC_PRINTF(3, 4);
+
 const gchar *       cockpit_channel_get_id            (CockpitChannel *self);
 
 /* Used by implementations */

--- a/src/bridge/cockpithttpstream.c
+++ b/src/bridge/cockpithttpstream.c
@@ -229,6 +229,7 @@ G_DEFINE_TYPE (CockpitHttpStream, cockpit_http_stream, COCKPIT_TYPE_CHANNEL);
 
 static gboolean
 parse_content_length (CockpitHttpStream *self,
+                      CockpitChannel *channel,
                       guint status,
                       GHashTable *headers)
 {
@@ -252,12 +253,14 @@ parse_content_length (CockpitHttpStream *self,
   value = g_ascii_strtoull (header, &end, 10);
   if (end[0] != '\0')
     {
-      g_message ("%s: received invalid Content-Length in HTTP stream response", self->name);
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: received invalid Content-Length in HTTP stream response", self->name);
       return FALSE;
     }
   else if (value > G_MAXSSIZE)
     {
-      g_message ("%s: received Content-Length that was too big", self->name);
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: received Content-Length that was too big", self->name);
       return FALSE;
     }
 
@@ -269,6 +272,7 @@ parse_content_length (CockpitHttpStream *self,
 
 static gboolean
 parse_transfer_encoding (CockpitHttpStream *self,
+                         CockpitChannel *channel,
                          GHashTable *headers)
 {
   const gchar *header;
@@ -282,8 +286,9 @@ parse_transfer_encoding (CockpitHttpStream *self,
 
   if (!g_str_equal (header, "chunked"))
     {
-      g_message ("%s: received unsupported Transfer-Encoding in HTTP response: %s",
-                 self->name, header);
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: received unsupported Transfer-Encoding in HTTP response: %s",
+                            self->name, header);
       return FALSE;
     }
 
@@ -325,6 +330,7 @@ cockpit_http_stream_parse_keep_alive (const gchar *version,
 
 static gboolean
 parse_keep_alive (CockpitHttpStream *self,
+                  CockpitChannel *channel,
                   const gchar *version,
                   GHashTable *headers)
 {
@@ -337,7 +343,6 @@ relay_headers (CockpitHttpStream *self,
                CockpitChannel *channel,
                GByteArray *buffer)
 {
-  const gchar *problem = "protocol-error";
   GHashTable *headers = NULL;
   gchar *version = NULL;
   gchar *reason = NULL;
@@ -362,7 +367,8 @@ relay_headers (CockpitHttpStream *self,
 
   if (offset < 0)
     {
-      g_message ("%s: received response with bad HTTP status line", self->name);
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: received response with bad HTTP status line", self->name);
       goto out;
     }
 
@@ -372,7 +378,8 @@ relay_headers (CockpitHttpStream *self,
 
   if (offset2 < 0)
     {
-      g_message ("%s: received response with bad HTTP headers", self->name);
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: received response with bad HTTP headers", self->name);
       goto out;
     }
 
@@ -381,12 +388,11 @@ relay_headers (CockpitHttpStream *self,
   while (g_hash_table_iter_next (&iter, &key, &value))
     g_debug ("%s: header: %s %s", self->name, (gchar *)key, (gchar *)value);
 
-  if (!parse_transfer_encoding (self, headers) ||
-      !parse_content_length (self, status, headers) ||
-      !parse_keep_alive (self, version, headers))
+  if (!parse_transfer_encoding (self, channel, headers) ||
+      !parse_content_length (self, channel, status, headers) ||
+      !parse_keep_alive (self, channel, version, headers))
     goto out;
 
-  problem = NULL;
   cockpit_pipe_skip (buffer, offset + offset2);
 
   if (!self->binary)
@@ -423,8 +429,6 @@ relay_headers (CockpitHttpStream *self,
   json_object_unref (object);
 
 out:
-  if (problem)
-    cockpit_channel_close (channel, problem);
   if (headers)
     g_hash_table_unref (headers);
   g_free (version);
@@ -489,13 +493,13 @@ relay_chunked (CockpitHttpStream *self,
   size = g_ascii_strtoull (data, &end, 16);
   if (pos[1] != '\n' || end != pos)
     {
-      g_message ("%s: received invalid HTTP chunk", self->name);
-      cockpit_channel_close (channel, "protocol-error");
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: received invalid HTTP chunk", self->name);
     }
   else if (size > G_MAXSSIZE)
     {
-      g_message ("%s: received extremely large HTTP chunk", self->name);
-      cockpit_channel_close (channel, "protocol-error");
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: received extremely large HTTP chunk", self->name);
     }
   else if (length < beg + size + 2)
     {
@@ -503,8 +507,8 @@ relay_chunked (CockpitHttpStream *self,
     }
   else if (data[beg + size] != '\r' || data[beg + size + 1] != '\n')
     {
-      g_message ("%s: received invalid HTTP chunk data", self->name);
-      cockpit_channel_close (channel, "protocol-error");
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: received invalid HTTP chunk data", self->name);
     }
   else if (size == 0)
     {
@@ -604,8 +608,8 @@ on_stream_read (CockpitStream *stream,
     {
       if (buffer->len != 0)
         {
-          g_message ("%s: received data before HTTP request was sent", self->name);
-          cockpit_channel_close (channel, "protocol-error");
+          cockpit_channel_fail (channel, "protocol-error",
+                                "%s: received data before HTTP request was sent", self->name);
         }
     }
   else if (self->state < RELAY_DATA)
@@ -617,8 +621,8 @@ on_stream_read (CockpitStream *stream,
         }
       else if (end_of_data)
         {
-          g_message ("%s: received truncated HTTP response", self->name);
-          cockpit_channel_close (channel, "protocol-error");
+          cockpit_channel_fail (channel, "protocol-error",
+                                "%s: received truncated HTTP response", self->name);
         }
     }
   while (self->state == RELAY_DATA)
@@ -676,8 +680,8 @@ on_stream_close (CockpitStream *stream,
         }
       else
         {
-          g_message ("%s: received truncated HTTP response", self->name);
-          cockpit_channel_close (channel, "protocol-error");
+          cockpit_channel_fail (channel, "protocol-error",
+                                "%s: received truncated HTTP response", self->name);
         }
     }
 }
@@ -738,7 +742,6 @@ static void
 send_http_request (CockpitHttpStream *self)
 {
   CockpitChannel *channel = COCKPIT_CHANNEL (self);
-  const gchar *problem = "protocol-error";
   JsonObject *options;
   gboolean had_host;
   gboolean had_encoding;
@@ -764,33 +767,39 @@ send_http_request (CockpitHttpStream *self)
 
   if (!cockpit_json_get_string (options, "path", NULL, &path))
     {
-      g_warning ("%s: bad \"path\" field in HTTP stream request", self->name);
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: bad \"path\" field in HTTP stream request", self->name);
       goto out;
     }
   else if (path == NULL)
     {
-      g_warning ("%s: missing \"path\" field in HTTP stream request", self->name);
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: missing \"path\" field in HTTP stream request", self->name);
       goto out;
     }
   else if (!cockpit_web_response_is_simple_token (path))
     {
-      g_warning ("%s: invalid \"path\" field in HTTP stream request", self->name);
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: invalid \"path\" field in HTTP stream request", self->name);
       goto out;
     }
 
   if (!cockpit_json_get_string (options, "method", NULL, &method))
     {
-      g_warning ("%s: bad \"method\" field in HTTP stream request", self->name);
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: bad \"method\" field in HTTP stream request", self->name);
       goto out;
     }
   else if (method == NULL)
     {
-      g_warning ("%s: missing \"method\" field in HTTP stream request", self->name);
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: missing \"method\" field in HTTP stream request", self->name);
       goto out;
     }
   else if (!cockpit_web_response_is_simple_token (method))
     {
-      g_warning ("%s: invalid \"method\" field in HTTP stream request", self->name);
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: invalid \"method\" field in HTTP stream request", self->name);
       goto out;
     }
 
@@ -806,7 +815,8 @@ send_http_request (CockpitHttpStream *self)
     {
       if (!JSON_NODE_HOLDS_OBJECT (node))
         {
-          g_warning ("%s: invalid \"headers\" field in HTTP stream request", self->name);
+          cockpit_channel_fail (channel, "protocol-error",
+                                "%s: invalid \"headers\" field in HTTP stream request", self->name);
           goto out;
         }
 
@@ -817,24 +827,28 @@ send_http_request (CockpitHttpStream *self)
           header = l->data;
           if (!cockpit_web_response_is_simple_token (header))
             {
-              g_warning ("%s: invalid header in HTTP stream request: %s", self->name, header);
+              cockpit_channel_fail (channel, "protocol-error",
+                                    "%s: invalid header in HTTP stream request: %s", self->name, header);
               goto out;
             }
           node = json_object_get_member (headers, header);
           if (!node || !JSON_NODE_HOLDS_VALUE (node) || json_node_get_value_type (node) != G_TYPE_STRING)
             {
-              g_warning ("%s: invalid header value in HTTP stream request: %s", self->name, header);
+              cockpit_channel_fail (channel, "protocol-error",
+                                    "%s: invalid header value in HTTP stream request: %s", self->name, header);
               goto out;
             }
           value = json_node_get_string (node);
           if (disallowed_header (header, value, self->binary))
             {
-              g_warning ("%s: disallowed header in HTTP stream request: %s", self->name, header);
+              cockpit_channel_fail (channel, "protocol-error",
+                                    "%s: disallowed header in HTTP stream request: %s", self->name, header);
               goto out;
             }
           if (!cockpit_web_response_is_header_value (value))
             {
-              g_warning ("%s: invalid header value in HTTP stream request: %s", self->name, header);
+              cockpit_channel_fail (channel, "protocol-error",
+                                    "%s: invalid header value in HTTP stream request: %s", self->name, header);
               goto out;
             }
 
@@ -860,7 +874,6 @@ send_http_request (CockpitHttpStream *self)
   if (!self->binary)
     g_string_append (string, "Accept-Charset: UTF-8\r\n");
 
-  problem = NULL;
   request = g_list_reverse (self->request);
   self->request = NULL;
 
@@ -888,8 +901,6 @@ out:
   g_list_free_full (request, (GDestroyNotify)g_bytes_unref);
   if (string)
     g_string_free (string, TRUE);
-  if (problem)
-    cockpit_channel_close (COCKPIT_CHANNEL (self), problem);
 }
 
 static void
@@ -986,15 +997,15 @@ cockpit_http_stream_prepare (CockpitChannel *channel)
   options = cockpit_channel_get_options (channel);
   if (!cockpit_json_get_string (options, "connection", NULL, &connection))
     {
-      g_warning ("bad \"connection\" field in HTTP stream request");
-      cockpit_channel_close (channel, "protocol-error");
+      cockpit_channel_fail (channel, "protocol-error",
+                            "bad \"connection\" field in HTTP stream request");
       goto out;
     }
 
   if (!cockpit_json_get_string (options, "path", "/", &path))
     {
-      g_warning ("bad \"path\" field in HTTP stream request");
-      cockpit_channel_close (channel, "protocol-error");
+      cockpit_channel_fail (channel, "protocol-error",
+                            "bad \"path\" field in HTTP stream request");
       goto out;
     }
 

--- a/src/bridge/cockpitstream.h
+++ b/src/bridge/cockpitstream.h
@@ -24,6 +24,8 @@
 
 #include "cockpitconnect.h"
 
+#include "common/cockpitjson.h"
+
 G_BEGIN_DECLS
 
 #define COCKPIT_TYPE_STREAM         (cockpit_stream_get_type ())
@@ -77,7 +79,7 @@ GByteArray *       cockpit_stream_get_buffer   (CockpitStream *self);
 const gchar *      cockpit_stream_problem      (GError *error,
                                                 const gchar *name,
                                                 const gchar *summary,
-                                                GIOStream *stream);
+                                                JsonObject *object);
 
 G_END_DECLS
 

--- a/src/bridge/cockpitwebsocketstream.c
+++ b/src/bridge/cockpitwebsocketstream.c
@@ -275,7 +275,9 @@ on_socket_connect (GObject *object,
   io = cockpit_connect_stream_finish (result, &error);
   if (error)
     {
-      problem = cockpit_stream_problem (error, self->origin, "couldn't connect", NULL);
+      problem = cockpit_stream_problem (error, self->origin, "couldn't connect",
+                                        cockpit_channel_close_options (channel));
+      cockpit_channel_close (channel, problem);
       goto out;
     }
 
@@ -283,7 +285,8 @@ on_socket_connect (GObject *object,
 
   if (!cockpit_json_get_strv (options, "protocols", NULL, &protocols))
     {
-      g_warning ("%s: invalid \"protocol\" value in WebSocket stream request", self->origin);
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: invalid \"protocol\" value in WebSocket stream request", self->origin);
       goto out;
     }
 
@@ -306,7 +309,8 @@ on_socket_connect (GObject *object,
     {
       if (!JSON_NODE_HOLDS_OBJECT (node))
         {
-          g_warning ("%s: invalid \"headers\" field in WebSocket stream request", self->origin);
+          cockpit_channel_fail (channel, "protocol-error",
+                                "%s: invalid \"headers\" field in WebSocket stream request", self->origin);
           goto out;
         }
 
@@ -317,8 +321,9 @@ on_socket_connect (GObject *object,
           node = json_object_get_member (headers, l->data);
           if (!node || !JSON_NODE_HOLDS_VALUE (node) || json_node_get_value_type (node) != G_TYPE_STRING)
             {
-              g_warning ("%s: invalid header value in WebSocket stream request: %s",
-                         self->origin, (gchar *)l->data);
+              cockpit_channel_fail (channel, "protocol-error",
+                                    "%s: invalid header value in WebSocket stream request: %s",
+                                    self->origin, (gchar *)l->data);
               goto out;
             }
           value = json_node_get_string (node);
@@ -337,8 +342,6 @@ on_socket_connect (GObject *object,
   problem = NULL;
 
 out:
-  if (problem)
-    cockpit_channel_close (channel, problem);
   g_clear_error (&error);
   g_strfreev (protocols);
   if (io)
@@ -353,7 +356,6 @@ cockpit_web_socket_stream_prepare (CockpitChannel *channel)
   CockpitConnectable *connectable = NULL;
   JsonObject *options;
   const gchar *path;
-  gboolean started = FALSE;
 
   COCKPIT_CHANNEL_CLASS (cockpit_web_socket_stream_parent_class)->prepare (channel);
 
@@ -367,12 +369,14 @@ cockpit_web_socket_stream_prepare (CockpitChannel *channel)
   options = cockpit_channel_get_options (channel);
   if (!cockpit_json_get_string (options, "path", NULL, &path))
     {
-      g_warning ("%s: bad \"path\" field in WebSocket stream request", self->origin);
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: bad \"path\" field in WebSocket stream request", self->origin);
       goto out;
     }
   else if (path == NULL || path[0] != '/')
     {
-      g_warning ("%s: invalid or missing \"path\" field in WebSocket stream request", self->origin);
+      cockpit_channel_fail (channel, "protocol-error",
+                            "%s: invalid or missing \"path\" field in WebSocket stream request", self->origin);
       goto out;
     }
 
@@ -383,15 +387,10 @@ cockpit_web_socket_stream_prepare (CockpitChannel *channel)
   self->binary = json_object_has_member (options, "binary");
 
   cockpit_connect_stream_full (connectable, NULL, on_socket_connect, g_object_ref (self));
-  started = TRUE;
 
 out:
   if (connectable)
-    {
-      cockpit_connectable_unref (connectable);
-      if (!started)
-        cockpit_channel_close (channel, "protocol-error");
-    }
+    cockpit_connectable_unref (connectable);
 }
 
 static void

--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -486,7 +486,7 @@ test_bad_receive (TestCase *tc,
 {
   GBytes *bad;
 
-  cockpit_expect_warning ("444: channel received message after done");
+  cockpit_expect_message ("444: channel received message after done");
 
   /* A resource2 channel should never have payload sent to it */
   bad = g_bytes_new_static ("bad", 3);

--- a/src/bridge/test-pcp.c
+++ b/src/bridge/test-pcp.c
@@ -294,7 +294,7 @@ static void
 test_metrics_units_noconv (TestCase *tc,
                            gconstpointer unused)
 {
-  cockpit_expect_warning ("direct: can't convert metric mock.seconds to units byte");
+  cockpit_expect_message ("1234: direct: can't convert metric mock.seconds to units byte");
 
   JsonObject *options = json_obj("{ 'source': 'direct',"
                                  "  'metrics': [ { 'name': 'mock.seconds', 'units': 'byte' } ],"

--- a/src/bridge/test-stream.c
+++ b/src/bridge/test-stream.c
@@ -372,7 +372,6 @@ test_read_error (void)
   out = dup (2);
   g_assert (out >= 0);
 
-  cockpit_expect_warning ("*Bad file descriptor");
   cockpit_expect_message ("*Bad file descriptor");
 
   /* Using wrong end of the pipe */
@@ -414,7 +413,6 @@ test_write_error (void)
   if (pipe (fds) < 0)
     g_assert_not_reached ();
 
-  cockpit_expect_warning ("*Bad file descriptor");
   cockpit_expect_message ("*Bad file descriptor");
 
   io = mock_io_stream_for_fds (fds[0], fds[1]);


### PR DESCRIPTION
We want these messages to be transparent. When we know of a reason that a close for a channel happened, we should be logging it to the browser console. In GTK+ apps it's sufficient to be logging this stuff to the terminal, since that's where developers are debugging, but in our case it needs to go to the javascript console.

And yes, this pull request changes lots of messages from level ```g_warning``` to level ```g_message```. That's intentional ... as we start to have a stable API, we need to start treating these failures as caused by external input.