### PR TITLE
bridge: Set the bridge LC_ALL locale for user language choice

### DIFF
--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -711,11 +711,11 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
              * separate automatically generated file. Need to see.
              */
             var manifest = cockpit.manifests["shell"] || { };
-            $(".display-language-menu").toggle(!!manifest.linguas);
+            $(".display-language-menu").toggle(!!manifest.locales);
             var language = document.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*\=\s*([^;]*).*$)|^.*$/, "$1");
             if (!language)
-                language = "en";
-            $.each(manifest.linguas || { }, function(code, name) {
+                language = "en-us";
+            $.each(manifest.locales || { }, function(code, name) {
                 var el = $("<option>").text(name).val(code);
                 if (code == language)
                     el.attr("selected", "true");

--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -4,17 +4,17 @@
 	"cockpit": "122"
     },
 
-    "linguas": {
-        "en": "English",
-        "ca": "Catalan",
-        "da": "Dansk",
-        "de": "Deutsch",
-        "es": "Español",
-        "fr": "Français",
-        "pl": "Polski",
+    "locales": {
+        "en-us": "English",
+        "ca-es": "Catalan",
+        "da-dk": "Dansk",
+        "de-de": "Deutsch",
+        "es-es": "Español",
+        "fr-fr": "Français",
+        "pl-pl": "Polski",
         "pt-br": "Portugueses",
-        "tr": "Türkçe",
-        "uk": "Українська",
+        "tr-tr": "Türkçe",
+        "uk-ua": "Українська",
         "zh-cn": "中文"
     }
 }

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -7,28 +7,37 @@ LINGUAS = $(shell cat $(srcdir)/po/LINGUAS)
 # The full list of various input and output file types
 PO_LINGUAS = $(addprefix po/,$(LINGUAS))
 PO_INPUTS = $(addsuffix .po,$(PO_LINGUAS))
-MO_FILES = $(addsuffix .mo,$(PO_LINGUAS))
-PO_JAVASCRIPT = $(addprefix po/po.,$(addsuffix .js,$(LINGUAS)))
+MO_FILES = $(addprefix src/ws/,$(addsuffix .mo,$(LINGUAS)))
+PO_JAVASCRIPT = $(addprefix dist/shell/po.,$(addsuffix .js,$(LINGUAS)))
 
 podir = $(pkgdatadir)/shell
 nodist_po_DATA = po/po.js.gz $(addsuffix .gz,$(PO_JAVASCRIPT))
 
 # Used to list files in src/ws in the po file
-FILTER_PO_SRC_WS = sed -ne 's|.*\(\(\.\.\)\?/src/ws/[^:]\+\).*|-N \1|p' $<
+FILTER_PO_SRC_WS = sed -ne 's|.*\(\(\.\./\)\?src/ws/[^:]\+\).*|-N \1|p' $<
 
-# Include only the stuff in src/ws in the po file
+# A filtered po file with just src/ws
+src/ws/%.po: po/%.po
+	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
+	$(MSGGREP) `$(FILTER_PO_SRC_WS)` $< > $@.tmp && mv $@.tmp $@
+
+# A filtered po file without src/ws
+dist/shell/%.po: po/%.po
+	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
+	$(MSGGREP) --invert-match `$(FILTER_PO_SRC_WS)` $< > $@.tmp && mv $@.tmp $@
+
+# Build a binary mo file from po
 .po.mo:
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-		$(MSGGREP) `$(FILTER_PO_SRC_WS)` $< > $@.tmp && \
-		$(MSGFMT) -o $@ $@.tmp && rm $@.tmp && touch $@
+	cat $<
+	$(MSGFMT) -o $@.tmp $< && mv $@.tmp $@ && touch $@
 
-# Include everything not in src/ws in the javascript file
-po/po.%.js: po/%.po
+# Build a javascript file from a po
+po.%.js: %.po
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	$(MSGGREP) --invert-match `$(FILTER_PO_SRC_WS)` $< > $@.po.tmp && \
-	$(srcdir)/tools/missing $(srcdir)/po/po2json -m $(srcdir)/po/po.js -o $@.js.tmp $@.po.tmp && \
+	$(srcdir)/tools/missing $(srcdir)/po/po2json -m $(srcdir)/po/po.js -o $@.js.tmp $< && \
 	$(srcdir)/tools/missing $(UGLIFY_JS) $@.js.tmp --mangle --beautify > $@.tmp && \
-	rm -f $@.po.tmp $@.js.tmp && mv $@.tmp $@
+	rm -f $@.js.tmp && mv $@.tmp $@
 
 # Always build the binary gettext data
 all-local:: $(MO_FILES) $(PO_JAVASCRIPT)
@@ -37,7 +46,7 @@ all-local:: $(MO_FILES) $(PO_JAVASCRIPT)
 install-data-local:: $(MO_FILES)
 	for lang in $(LINGUAS); do \
 		$(MKDIR_P) $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES; \
-		$(INSTALL_DATA) po/$$lang.mo $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo; \
+		$(INSTALL_DATA) src/ws/$$lang.mo $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo; \
 	done
 
 # Called to ininstall the binary gettext data
@@ -117,6 +126,8 @@ CLEANFILES += \
 	$(nodist_po_DATA) \
 	$(PO_JAVASCRIPT) \
 	po/POTFILES.*.in \
+	dist/shell/*.po /
+	src/ws/*.po /
 	po/cockpit*.pot \
 	po/po.js.gz \
 	$(NULL)

--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -26,6 +26,7 @@
 #include "common/cockpitenums.h"
 #include "common/cockpithex.h"
 #include "common/cockpitjson.h"
+#include "common/cockpitlocale.h"
 #include "common/cockpitsystem.h"
 #include "common/cockpitversion.h"
 #include "common/cockpitwebinject.h"
@@ -47,6 +48,7 @@ struct _CockpitPackages {
   GHashTable *listing;
   gchar *checksum;
   JsonObject *json;
+  gchar *locale;
 };
 
 struct _CockpitPackage {
@@ -838,6 +840,13 @@ handle_packages (CockpitWebServer *server,
     }
 
   languages = cockpit_web_server_parse_languages (headers, NULL);
+
+  /*
+   * This is how we find out about the frontends cockpitlang
+   * environment. We tell this process to update its locale
+   * if it has changed.
+   */
+  cockpit_locale_set_language (languages[0]);
 
   bytes = cockpit_web_response_negotiation (filename, package->paths, languages[0], &chosen, &error);
   if (error)

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -24,6 +24,7 @@ CLEANFILES += $(COCKPIT_ASSETS)
 
 EXTRA_DIST += \
 	src/common/mock-content \
+	src/common/mock-locale \
 	src/common/mock_known_hosts \
 	src/common/com.redhat.Cockpit.DBusTests.xml \
 	src/common/cockpitassets.gresource.xml \
@@ -44,6 +45,8 @@ libcockpit_common_a_SOURCES = \
 	src/common/cockpitknownhosts.c \
 	src/common/cockpitknownhosts.h \
 	src/common/cockpitlog.h src/common/cockpitlog.c \
+	src/common/cockpitlocale.c \
+	src/common/cockpitlocale.h \
 	src/common/cockpitloopback.c \
 	src/common/cockpitloopback.h \
 	src/common/cockpitmemory.c \
@@ -104,6 +107,7 @@ COCKPIT_CHECKS = \
 	test-hash \
 	test-hex \
 	test-json \
+	test-locale \
 	test-knownhosts \
 	test-pipe \
 	test-transport \
@@ -132,6 +136,10 @@ test_json_LDADD = $(libcockpit_common_a_LIBS)
 test_knownhosts_CFLAGS = $(libcockpit_common_a_CFLAGS)
 test_knownhosts_SOURCES = src/common/test-knownhosts.c
 test_knownhosts_LDADD = $(libcockpit_common_a_LIBS)
+
+test_locale_CFLAGS = $(libcockpit_common_a_CFLAGS)
+test_locale_SOURCES = src/common/test-locale.c
+test_locale_LDADD = $(libcockpit_common_a_LIBS)
 
 test_pipe_CFLAGS = $(libcockpit_common_a_CFLAGS)
 test_pipe_SOURCES = src/common/test-pipe.c
@@ -175,6 +183,12 @@ test_config_LDADD = $(libcockpit_common_a_LIBS)
 
 noinst_PROGRAMS += $(COCKPIT_CHECKS)
 TESTS += $(COCKPIT_CHECKS)
+
+# For the test-locale test
+noinst_SCRIPTS += \
+	src/common/mock-locale/de_DE/LC_MESSAGES/test.mo \
+	src/common/mock-locale/zh_CN/LC_MESSAGES/test.mo \
+	$(NULL)
 
 EXTRA_DIST += \
 	src/common/mock-stderr \

--- a/src/common/cockpitlocale.c
+++ b/src/common/cockpitlocale.c
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cockpitlocale.h"
+
+#include <locale.h>
+#include <string.h>
+
+gchar *
+cockpit_locale_from_language (const gchar *value,
+                              const gchar *encoding,
+                              gchar **shorter)
+{
+  const gchar *spot;
+  gchar *country = NULL;
+  gchar *lang = NULL;
+  gchar *result = NULL;
+  const gchar *dot;
+
+  if (value == NULL)
+    value = "C";
+
+  dot = ".";
+  if (!encoding)
+    dot = encoding = "";
+
+  spot = strchr (value, '-');
+  if (spot)
+    {
+      country = g_ascii_strup (spot + 1, -1);
+      lang = g_ascii_strdown (value, spot - value);
+      result = g_strconcat (lang, "_", country, dot, encoding, NULL);
+      if (shorter)
+        {
+          *shorter = lang;
+          lang = NULL;
+        }
+    }
+  else
+    {
+      result = g_strconcat (value, dot, encoding, NULL);
+      if (shorter)
+        *shorter = g_strdup (value);
+    }
+
+  g_free (country);
+  g_free (lang);
+  return result;
+}
+
+/* The most recently set language */
+static gchar previous[32] = { '\0' };
+
+void
+cockpit_locale_set_language (const gchar *value)
+{
+  const gchar *encoding = NULL;
+  gchar *locale;
+
+  if (value == NULL)
+    {
+      value = "C";
+    }
+  else
+    {
+      encoding = "UTF-8";
+      if (strlen (value) > sizeof (previous) - 1)
+        {
+          g_printerr ("invalid language: %s\n", value);
+          return;
+        }
+    }
+
+  /* Already set our locale to this language */
+  if (strncmp (value, previous, sizeof (previous)) == 0)
+    return;
+
+  locale = cockpit_locale_from_language (value, encoding, NULL);
+  if (setlocale (LC_ALL, locale) == NULL)
+    {
+      /* Note we use g_printerr directly, since we want no gettext invocations on this line */
+      g_printerr ("invalid or unusable locale: %s\n", locale);
+    }
+  else
+    {
+      g_debug ("set bridge locale to: %s", locale);
+      g_setenv ("LANG", locale, TRUE);
+    }
+
+  strncpy (previous, locale, sizeof (previous));
+  g_free (locale);
+}

--- a/src/common/cockpitlocale.h
+++ b/src/common/cockpitlocale.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __COCKPIT_LOCALE_H__
+#define __COCKPIT_LOCALE_H__
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+gchar *               cockpit_locale_from_language       (const gchar *language,
+                                                          const gchar *encoding,
+                                                          gchar **shorter);
+
+void                  cockpit_locale_set_language        (const gchar *language);
+
+G_END_DECLS
+
+#endif /* __COCKPIT_LOCALE_H__ */

--- a/src/common/mock-locale/de_DE/LC_MESSAGES/test.po
+++ b/src/common/mock-locale/de_DE/LC_MESSAGES/test.po
@@ -1,0 +1,10 @@
+msgid ""
+msgstr ""
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Unavailable"
+msgstr "Nicht verfügbar"

--- a/src/common/mock-locale/zh_CN/LC_MESSAGES/test.po
+++ b/src/common/mock-locale/zh_CN/LC_MESSAGES/test.po
@@ -1,0 +1,10 @@
+msgid ""
+msgstr ""
+"Language: zh-CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+
+msgid "Unavailable"
+msgstr "不可用"

--- a/src/common/test-locale.c
+++ b/src/common/test-locale.c
@@ -1,0 +1,182 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitlocale.h"
+#include "cockpittest.h"
+
+#include <libintl.h>
+#include <string.h>
+
+typedef struct {
+    const gchar *language;
+    const gchar *encoding;
+    const gchar *locale;
+    const gchar *shorter;
+} FromFixture;
+
+static FromFixture from_fixtures[] = {
+  { "en", NULL, "en", "en" },
+  { "en-us", NULL, "en_US", "en" },
+  { "en-us", "UTF-8", "en_US.UTF-8", "en" },
+  { "zh-cn", NULL, "zh_CN", "zh" },
+  { "zh-cn", "UTF-8", "zh_CN.UTF-8", "zh" },
+  { NULL, NULL, "C", "C" },
+};
+
+static void
+test_from_language (gconstpointer data)
+{
+  const FromFixture *fixture = data;
+  gchar *locale;
+  gchar *shorter;
+
+  locale = cockpit_locale_from_language (fixture->language, fixture->encoding, &shorter);
+  g_assert_cmpstr (locale, ==, fixture->locale);
+  if (locale)
+    g_assert_cmpstr (shorter, ==, fixture->shorter);
+  g_free (locale);
+  g_free (shorter);
+
+  locale = cockpit_locale_from_language (fixture->language, fixture->encoding, NULL);
+  g_assert_cmpstr (locale, ==, fixture->locale);
+  g_free (locale);
+}
+
+typedef struct {
+    const gchar *language;
+    const gchar *lang;
+    const gchar *string;
+} SetFixture;
+
+static SetFixture set_fixtures[] = {
+  { "en-us", "en_US.UTF-8", "Unavailable", },
+  { "de-de", "de_DE.UTF-8", "Nicht verfügbar" },
+  { "zh-cn", "zh_CN.UTF-8", "不可用" },
+  { "__xx;%%%", NULL, NULL },
+  { NULL, "C", "Unavailable" },
+  { "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", NULL, NULL },
+};
+
+static gboolean
+locale_available (const gchar *locale)
+{
+  GError *error = NULL;
+  gchar *dot;
+  gchar *output;
+  gint status;
+  gchar *copy;
+  gboolean ret;
+
+  g_spawn_command_line_sync ("locale -a", &output, NULL, &status, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (status, ==, 0);
+
+  copy = g_strdup_printf ("\n%s", locale);
+  dot = strchr (copy, '.');
+  if (dot)
+    dot[1] = '\0';
+
+  ret = strstr (output, copy) ? TRUE : FALSE;
+
+  g_free (output);
+  g_free (copy);
+
+  return ret;
+}
+
+static void
+test_set_language (const gconstpointer data)
+{
+  const SetFixture *fixture = data;
+  const gchar *old;
+
+  /* Check if the locale is available on the test system */
+  if (fixture->lang && !locale_available (fixture->lang))
+    {
+      cockpit_test_skip ("locale not available");
+      return;
+    }
+
+  old = g_getenv ("LANG");
+
+  cockpit_locale_set_language (fixture->language);
+
+  /* Was supposed to fail */
+  if (fixture->lang == NULL)
+    {
+      g_assert_cmpstr (old, ==, g_getenv ("LANG"));
+    }
+
+  /* Was supposed to succeed */
+  else
+    {
+      g_assert_cmpstr (fixture->lang, ==, g_getenv ("LANG"));
+      g_assert_cmpstr (dgettext ("test", "Unavailable"), ==, fixture->string);
+    }
+
+  /* A second time, excercise cache code */
+  cockpit_locale_set_language (fixture->language);
+
+  /* Was supposed to fail */
+  if (fixture->lang == NULL)
+    {
+      g_assert_cmpstr (old, ==, g_getenv ("LANG"));
+    }
+
+  /* Was supposed to succeed */
+  else
+    {
+      g_assert_cmpstr (fixture->lang, ==, g_getenv ("LANG"));
+      g_assert_cmpstr (dgettext ("test", "Unavailable"), ==, fixture->string);
+    }
+
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+  const gchar *val;
+  gchar *name;
+  gint i;
+
+  bindtextdomain ("test", BUILDDIR "/src/common/mock-locale");
+  cockpit_test_init (&argc, &argv);
+
+  for (i = 0; i < G_N_ELEMENTS (from_fixtures); i++)
+    {
+      name = g_strdup_printf ("/locale/from-language/%s", from_fixtures[i].locale);
+      g_test_add_data_func (name, from_fixtures + i, test_from_language);
+      g_free (name);
+    }
+
+  for (i = 0; i < G_N_ELEMENTS (set_fixtures); i++)
+    {
+      val = set_fixtures[i].language;
+      if (!val)
+        val = "null";
+      name = g_strdup_printf ("/locale/set-language/%s", val);
+      g_test_add_data_func (name, set_fixtures + i, test_set_language);
+      g_free (name);
+    }
+
+  return g_test_run ();
+}

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -40,6 +40,17 @@ WantedBy=default.target
         self.allow_restart_journal_messages()
         self.allow_journal_messages("Failed to get realtime timestamp: Cannot assign requested address")
 
+        # On Debian and Ubuntu we have to generate the other locales :S
+        if m.image in ["debian-8", "debian-unstable" ]:
+            m.execute("echo 'de_DE.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen && update-locale")
+        elif m.image in [ "ubuntu-1604" ]:
+            m.execute("locale-gen de_DE && locale-gen de_DE.UTF-8 && update-locale")
+
+        # On Atomic no locales other than en_US are supported on the host itself
+        # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1186757
+        elif m.image in [ "continuous-atomic", "fedora-atomic", "rhel-atomic" ]:
+            self.allow_journal_messages("invalid or unusable locale: de_DE.UTF-8")
+
         # login so that we have a cookie.
         self.login_and_go("/system/services#/test.service")
 
@@ -110,7 +121,7 @@ WantedBy=default.target
         b.click("#content-user-name")
         b.click(".display-language-menu a")
         b.wait_popup('display-language')
-        b.set_val("#display-language select", "de")
+        b.set_val("#display-language select", "de-de")
         b.click("#display-language-select-button")
         b.expect_load()
         b.wait_present("#content")


### PR DESCRIPTION
The bridge itself doesn't do any translation of strings, but calling setlocale() and setting the LANG environment variable here allows:
    
 * Strings to be translated in libraries.
 * Spawned processes to be translated correctly.
    
Note that we find out about the front end's language choice via the cockpitlang cookie and the Accept-Language HTTP header on package requests.
    
We make sure to track what the language was set to and only change it if we receive a different header here.

Since setlocale() is rather strict about what kind of locales it accepts we have to be more verbose about locales in shell/manifest.json and rather than setting just languages, set entire locales.

Add tests for this functionality.
