### PR TITLE
doc: Add dependency for guide on index.html

### DIFF
--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -99,6 +99,8 @@ dist/guide/html/index.html: $(GUIDE_DOCBOOK) $(GUIDE_INCLUDES) $(man_MANS) $(GUI
 			--searchpath $(abs_builddir):$(abs_srcdir):$(abs_builddir)/doc/guide \
 			$(srcdir)/$(GUIDE_DOCBOOK)
 
+dist/guide/html: dist/guide/html/index.html
+
 dist/guide/links.html:
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
 	(git -C $(srcdir) tag -l --sort=-version:refname --format \


### PR DESCRIPTION
Becuase we distribute dist/guide/html in some cases there's a
make race where it's not present. We need to be explicit about
which other rule to invoke to generate it.