### PR TITLE
tools: Don't have 'make' fail on file removal

### DIFF
--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -149,6 +149,11 @@ function generateDeps(makefile, stats) {
         lines.push("")
     });
 
+    inputs.forEach(function(name) {
+        lines.push(name + ":");
+        lines.push("")
+    });
+
     lines.push("WEBPACK_INPUTS += $(" + prefix + "_INPUTS)");
     lines.push("WEBPACK_OUTPUTS += $(" + prefix + "_OUTPUTS)");
     lines.push("WEBPACK_INSTALL += $(" + prefix + "_INSTALL)");


### PR DESCRIPTION
Due to the way we listed dependencies in the Makefile inclusion
deps from webpack, make would fail after a file disappeared,
and this would require a 'make clean' to get back into a usable
state.

Here we fix this problem by copying the way that automake handles
its .deps .Po files. We create empty targets for all the inputs
which solves the problem of them not existing until the Makefile
inclusion data can be regenerated.