### PR TITLE
Implement javascript functions to wait on channels

### DIFF
--- a/doc/guide/cockpit-channel.xml
+++ b/doc/guide/cockpit-channel.xml
@@ -110,6 +110,20 @@ channel.control(options)
       options field. To indicate that no further messages will be sent through the channel.</para>
   </refsection>
 
+  <refsection id="cockpit-channels-wait">
+    <title>channel.wait()</title>
+<programlisting>
+promise = channel.wait([callback])
+</programlisting>
+
+    <para>Returns a <code>promise</code> that is ready when the channel is ready, or fails if the
+      client closes. If a <code>callback</code> is specified, it is attached to the promise. The
+      promise will be rejected or resolved with the contents <code>options</code> passed to the
+      <link linkend="cockpit-channels-onready">channel.onready</link> and
+      <link linkend="cockpit-channels-close-ev">channel.onclose</link> events respectively.</para>
+    <para>In general it's not necessary to wait for the channel before starting use the channel.</para>
+  </refsection>
+
   <refsection id="cockpit-channels-close">
     <title>channel.close()</title>
 <programlisting>
@@ -149,6 +163,17 @@ channel.addEventListener("control", function(event, options) { ... })
       <code>"done"</code> then no further messages will be received in the channel.
       The exact form of these messages depend on the <code>"payload"</code> of the
       channel.</para>
+  </refsection>
+
+  <refsection id="cockpit-channels-onready">
+    <title>channel.onready</title>
+<programlisting>
+$(channel).on("ready", function(event, options) { ... })
+channel.addEventListener("ready", function(event, options) { ... })
+</programlisting>
+    <para>An event triggered when the other end of the channel is ready to start processing
+      messages. This indicates the channel is completely open. It is possible to start
+      sending messages on the channel before this point.</para>
   </refsection>
 
   <refsection id="cockpit-channels-close-ev">
@@ -212,6 +237,7 @@ cockpit.transport.wait(callback)
       This will start the initialization if not already in progress or completed. If the
       channel transport is already initialized, then <code>callback</code> will be called
       immediately.</para>
+    <para>In general it's not necessary to wait for the transport before starting to open channels.</para>
   </refsection>
 
   <refsection id="cockpit-transport-close">

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -31,6 +31,9 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
 (function() {
 "use strict";
 
+var cockpit = { };
+event_mixin(cockpit, { });
+
 if (typeof window.debugging === "undefined") {
     try {
         // Sometimes this throws a SecurityError such as during testing
@@ -928,7 +931,7 @@ function resolve_path_dots(parts) {
     return out;
 }
 
-function basic_scope(cockpit, jquery) {
+function factory() {
 
     cockpit.channel = function channel(options) {
         return new Channel(options);
@@ -4271,23 +4274,12 @@ function basic_scope(cockpit, jquery) {
         };
     }
 
+    return cockpit;
 } /* scope end */
 
 /*
  * Register this script as a module and/or with globals
  */
-
-var cockpit = { };
-event_mixin(cockpit, { });
-
-var basics = false;
-function factory() {
-    if (!basics) {
-        basic_scope(cockpit);
-        basics = true;
-    }
-    return cockpit;
-}
 
 var self_module_id;
 

--- a/src/base1/test-chan.js
+++ b/src/base1/test-chan.js
@@ -474,6 +474,56 @@ QUnit.asyncTest("close socket", function() {
     mock_peer.close();
 });
 
+QUnit.asyncTest("wait ready", function() {
+    assert.expect(5);
+
+    var channel = cockpit.channel({ "payload": "echo" });
+    channel.wait().then(function(options) {
+        assert.ok(true, "channel is ready");
+        assert.equal(typeof options, "object", "wait options");
+        assert.ok(!!options, "wait options not null");
+        assert.equal(options.command, "ready", "wait is ready");
+        assert.strictEqual(channel.valid, true, "when valid");
+    }, function() {
+        assert.ok(false, "should not fail");
+    }).always(function() {
+        QUnit.start();
+    });
+});
+
+QUnit.asyncTest("wait close", function() {
+    assert.expect(6);
+
+    var channel = cockpit.channel({ "payload": "unsupported" });
+    channel.wait().then(function() {
+        assert.ok(false, "should not succeed");
+    }, function(options) {
+        assert.ok(true, "channel is closed");
+        assert.equal(typeof options, "object", "wait options");
+        assert.ok(!!options, "wait options not null");
+        assert.equal(options.command, "close", "wait is close");
+        assert.equal(options.problem, "not-supported", "wait options has fields");
+        assert.strictEqual(channel.valid, false, "channel not valid");
+    }).always(function() {
+        QUnit.start();
+    });
+});
+
+QUnit.asyncTest("wait callback", function() {
+    assert.expect(5);
+
+    var channel = cockpit.channel({ "payload": "unsupported" });
+    channel.wait(function(options) {
+        assert.equal(typeof options, "object", "wait options");
+        assert.ok(!!options, "wait options not null");
+        assert.equal(options.command, "close", "wait is close");
+        assert.equal(options.problem, "not-supported", "wait options has fields");
+        assert.strictEqual(channel.valid, false, "channel not valid");
+    }).always(function() {
+        QUnit.start();
+    });
+});
+
 QUnit.asyncTest("logout", function() {
     $(mock_peer).on("recv", function(event, chan, payload) {
         var cmd = JSON.parse(payload);


### PR DESCRIPTION
It should be possible to wait on a channel becoming ready. The bridge already sends "ready" control messages when a channel is completely open and ready.
    
In certain circumstances client code needs or wants to know that a channel is ready. Lets make it easy for the channel to determine that with solid API support and a channel.wait() function.
