### PR TITLE
bridge: Send DBus unique name with "ready" message

### DIFF
--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -189,6 +189,12 @@ $(client).on("owner", function(event, owner) { ... })
       the client.</para>
   </refsection>
 
+  <refsection id="cockpit-dbus-unique-name">
+    <title>client.unique_name</title>
+    <para>The unique DBus name of the client. Initially null, and becomes valid once the
+      the client is ready.</para>
+  </refsection>
+
   <refsection id="cockpit-dbus-proxy">
     <title>client.proxy()</title>
 <programlisting>

--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -139,6 +139,16 @@ client = cockpit.dbus(name, [options])
     </variablelist>
   </refsection>
 
+  <refsection id="cockpit-dbus-wait">
+    <title>client.wait()</title>
+<programlisting>
+proxy = client.wait([callback])
+</programlisting>
+
+    <para>Returns a <code>promise</code> that is ready when the client is ready, or fails if the
+      client closes. If a <code>callback</code> is specified, it is attached to the promise.</para>
+  </refsection>
+
   <refsection id="cockpit-dbus-close">
     <title>client.close()</title>
 <programlisting>

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -3023,6 +3023,7 @@ function factory() {
         args.payload = "dbus-json3";
         args.name = name;
         self.options = options;
+        self.unique_name = null;
 
         dbus_debug("dbus open: ", args);
 
@@ -3174,14 +3175,21 @@ function factory() {
                 close_perform(options);
         };
 
+        function on_ready(event, message) {
+            dbus_debug("dbus ready:", options);
+            self.unique_name = message["unique-name"];
+        }
+
         function on_close(event, options) {
             dbus_debug("dbus close:", options);
+            channel.removeEventListener("ready", on_ready);
             channel.removeEventListener("message", on_message);
             channel.removeEventListener("close", on_close);
             channel = null;
             close_perform(options);
         }
 
+        channel.addEventListener("control", on_ready);
         channel.addEventListener("message", on_message);
         channel.addEventListener("close", on_close);
 

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -3036,6 +3036,9 @@ function factory() {
 
         self.constructors = { "*": DBusProxy };
 
+        /* Allows waiting on the channel if necessary */
+        self.wait = channel.wait;
+
         function ensure_cache() {
             if (!cache)
                 cache = new DBusCache();

--- a/src/base1/test-dbus.js
+++ b/src/base1/test-dbus.js
@@ -150,6 +150,32 @@ QUnit.asyncTest("bad dbus bus", function() {
     });
 });
 
+QUnit.asyncTest("wait ready", function() {
+    assert.expect(1);
+
+    var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", { "bus": "session" });
+    dbus.wait().then(function(options) {
+        assert.ok(!!dbus.unique_name, "wait fills unique_name");
+    }, function() {
+        assert.ok(false, "shouldn't fail");
+    }).always(function() {
+        QUnit.start();
+    });
+});
+
+QUnit.asyncTest("wait fail", function() {
+    assert.expect(1);
+
+    var dbus = cockpit.dbus(null, { "bus": "none", "address": "bad" });
+    dbus.wait().then(function(options) {
+        assert.ok(false, "shouldn't succeed");
+    }, function() {
+        assert.ok(true, "should fail");
+    }).always(function() {
+        QUnit.start();
+    });
+});
+
 function internal_test(options) {
     assert.expect(2);
     var dbus = cockpit.dbus(null, options);

--- a/src/bridge/cockpitchannel.c
+++ b/src/bridge/cockpitchannel.c
@@ -719,6 +719,7 @@ cockpit_channel_fail (CockpitChannel *self,
 /**
  * cockpit_channel_ready:
  * @self: a pipe
+ * @message: an optional control message, or NULL
  *
  * Called by channel implementations to signal when they're
  * ready. Any messages received before the channel was ready
@@ -730,7 +731,8 @@ cockpit_channel_fail (CockpitChannel *self,
  * can connect appropriately.
  */
 void
-cockpit_channel_ready (CockpitChannel *self)
+cockpit_channel_ready (CockpitChannel *self,
+                       JsonObject *message)
 {
   CockpitChannelClass *klass;
   GBytes *decoded;
@@ -763,7 +765,7 @@ cockpit_channel_ready (CockpitChannel *self)
       g_queue_free (queue);
     }
 
-  cockpit_channel_control (self, "ready", NULL);
+  cockpit_channel_control (self, "ready", message);
   self->priv->ready = TRUE;
 
   /* No more data coming? */

--- a/src/bridge/cockpitchannel.h
+++ b/src/bridge/cockpitchannel.h
@@ -89,7 +89,8 @@ void                cockpit_channel_control           (CockpitChannel *self,
                                                        const gchar *command,
                                                        JsonObject *message);
 
-void                cockpit_channel_ready             (CockpitChannel *self);
+void                cockpit_channel_ready             (CockpitChannel *self,
+                                                       JsonObject *message);
 
 void                cockpit_channel_send              (CockpitChannel *self,
                                                        GBytes *payload,

--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -1824,7 +1824,7 @@ on_name_appeared (GDBusConnection *connection,
   if (!self->name_appeared)
     {
       self->name_appeared = TRUE;
-      cockpit_channel_ready (COCKPIT_CHANNEL (self));
+      cockpit_channel_ready (COCKPIT_CHANNEL (self), NULL);
     }
 
   send_owned (self, name_owner);
@@ -1904,7 +1904,7 @@ process_connection (CockpitDBusJson *self,
       else
         {
           subscribe_and_cache (self);
-          cockpit_channel_ready (COCKPIT_CHANNEL (self));
+          cockpit_channel_ready (COCKPIT_CHANNEL (self), NULL);
         }
     }
 }
@@ -2018,7 +2018,7 @@ cockpit_dbus_json_prepare (CockpitChannel *channel)
       self->logname = self->name;
 
       subscribe_and_cache (self);
-      cockpit_channel_ready (channel);
+      cockpit_channel_ready (channel, NULL);
     }
   else
     {

--- a/src/bridge/cockpitechochannel.c
+++ b/src/bridge/cockpitechochannel.c
@@ -75,7 +75,7 @@ static void
 cockpit_echo_channel_prepare (CockpitChannel *channel)
 {
   COCKPIT_CHANNEL_CLASS (cockpit_echo_channel_parent_class)->prepare (channel);
-  cockpit_channel_ready (channel);
+  cockpit_channel_ready (channel, NULL);
 }
 
 static void

--- a/src/bridge/cockpitfslist.c
+++ b/src/bridge/cockpitfslist.c
@@ -111,7 +111,7 @@ on_files_listed (GObject *source_object,
       g_clear_object (&self->cancellable);
       g_object_unref (source_object);
 
-      cockpit_channel_ready (COCKPIT_CHANNEL (self));
+      cockpit_channel_ready (COCKPIT_CHANNEL (self), NULL);
 
       if (self->monitor == NULL)
         {

--- a/src/bridge/cockpitfsread.c
+++ b/src/bridge/cockpitfsread.c
@@ -249,7 +249,7 @@ cockpit_fsread_prepare (CockpitChannel *channel)
   self->queue = g_queue_new ();
   push_bytes (self->queue, g_mapped_file_get_bytes (mapped));
   self->idler = g_idle_add (on_idle_send_block, self);
-  cockpit_channel_ready (channel);
+  cockpit_channel_ready (channel, NULL);
   g_mapped_file_unref (mapped);
 }
 

--- a/src/bridge/cockpitfsreplace.c
+++ b/src/bridge/cockpitfsreplace.c
@@ -277,7 +277,7 @@ cockpit_fsreplace_prepare (CockpitChannel *channel)
   if (self->fd < 0)
     close_with_errno (self, "couldn't open unique file", errno);
   else
-    cockpit_channel_ready (channel);
+    cockpit_channel_ready (channel, NULL);
 
 out:
   g_free (actual_tag);

--- a/src/bridge/cockpitfswatch.c
+++ b/src/bridge/cockpitfswatch.c
@@ -206,7 +206,7 @@ cockpit_fswatch_prepare (CockpitChannel *channel)
   self->monitor = monitor;
   self->sig_changed = g_signal_connect (self->monitor, "changed", G_CALLBACK (on_changed), self);
 
-  cockpit_channel_ready (channel);
+  cockpit_channel_ready (channel, NULL);
 
 out:
   g_clear_error (&error);

--- a/src/bridge/cockpithttpstream.c
+++ b/src/bridge/cockpithttpstream.c
@@ -589,7 +589,7 @@ on_stream_open (CockpitStream *stream,
                 gpointer user_data)
 {
   CockpitChannel *channel = user_data;
-  cockpit_channel_ready (channel);
+  cockpit_channel_ready (channel, NULL);
 }
 
 static void
@@ -1058,7 +1058,7 @@ cockpit_http_stream_prepare (CockpitChannel *channel)
 
   /* If not waiting for open */
   if (!self->sig_open)
-    cockpit_channel_ready (channel);
+    cockpit_channel_ready (channel, NULL);
 
 out:
   if (connectable)

--- a/src/bridge/cockpitinternalmetrics.c
+++ b/src/bridge/cockpitinternalmetrics.c
@@ -501,7 +501,7 @@ cockpit_internal_metrics_prepare (CockpitChannel *channel)
   self->need_meta = TRUE;
 
   cockpit_metrics_metronome (COCKPIT_METRICS (self), self->interval);
-  cockpit_channel_ready (channel);
+  cockpit_channel_ready (channel, NULL);
 }
 
 static void

--- a/src/bridge/cockpitnullchannel.c
+++ b/src/bridge/cockpitnullchannel.c
@@ -59,7 +59,7 @@ static void
 cockpit_null_channel_prepare (CockpitChannel *channel)
 {
   COCKPIT_CHANNEL_CLASS (cockpit_null_channel_parent_class)->prepare (channel);
-  cockpit_channel_ready (channel);
+  cockpit_channel_ready (channel, NULL);
 }
 
 static void

--- a/src/bridge/cockpitpcpmetrics.c
+++ b/src/bridge/cockpitpcpmetrics.c
@@ -1038,7 +1038,7 @@ cockpit_pcp_metrics_prepare (CockpitChannel *channel)
 
   if (type != PM_CONTEXT_ARCHIVE)
       cockpit_metrics_metronome (COCKPIT_METRICS (self), self->interval);
-  cockpit_channel_ready (channel);
+  cockpit_channel_ready (channel, NULL);
 
 out:
   g_free (name);

--- a/src/bridge/cockpitpipechannel.c
+++ b/src/bridge/cockpitpipechannel.c
@@ -451,7 +451,7 @@ cockpit_pipe_channel_prepare (CockpitChannel *channel)
   self->sig_read = g_signal_connect (self->pipe, "read", G_CALLBACK (on_pipe_read), self);
   self->sig_close = g_signal_connect (self->pipe, "close", G_CALLBACK (on_pipe_close), self);
   self->open = TRUE;
-  cockpit_channel_ready (channel);
+  cockpit_channel_ready (channel, NULL);
 
 out:
   g_free (argv);

--- a/src/bridge/cockpitwebsocketstream.c
+++ b/src/bridge/cockpitwebsocketstream.c
@@ -171,7 +171,7 @@ on_web_socket_open (WebSocketConnection *connection,
   cockpit_channel_control (channel, "response", object);
   json_object_unref (object);
 
-  cockpit_channel_ready (channel);
+  cockpit_channel_ready (channel, NULL);
 }
 
 static void

--- a/src/bridge/mock-bridge.c
+++ b/src/bridge/mock-bridge.c
@@ -95,7 +95,7 @@ mock_case_channel_constructed (GObject *obj)
   else
     g_assert_not_reached ();
 
-  cockpit_channel_ready (COCKPIT_CHANNEL (self));
+  cockpit_channel_ready (COCKPIT_CHANNEL (self), NULL);
 }
 
 static void

--- a/src/bridge/test-portal.c
+++ b/src/bridge/test-portal.c
@@ -69,7 +69,7 @@ static void
 mock_echo_channel_constructed (GObject *obj)
 {
   G_OBJECT_CLASS (mock_echo_channel_parent_class)->constructed (obj);
-  cockpit_channel_ready (COCKPIT_CHANNEL (obj));
+  cockpit_channel_ready (COCKPIT_CHANNEL (obj), NULL);
 }
 
 static void


### PR DESCRIPTION
Adds support for propagating the DBus unique name to the frontend javascript. Tests included.

Depends on:

* [x] #5441 
* [x] #5458 