### PR TITLE
bridge: Add support for sending DBus metadata to the bridge

### DIFF
--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -853,23 +853,53 @@ client.onmeta = function(ev, data) { ... }
     <para>The <code>data</code> has the following form:</para>
 
 <programlisting>
-{
+  {
       "org.Interface": {
           "methods": {
-              "Method1": { },
+              "Method1": {
+                  "in": [ "s", "v" ],
+                  "out": [ "i" ]
+              },
               "Method2": { }
           },
+          "signals": {
+              "Signal": {
+                  "in": [ "b", "s" ]
+              }
+          },
           "properties": {
-              "Prop1": { "flags": "rw" },
-              "Prop2": { "flags": "r" }
+              "Prop1": {
+                  "flags": "rw",
+                  "type": "s"
+              },
+              "Prop2": {
+                  "flags": "r",
+                  "type": "b"
+              }
           }
       }
-}
+  }
 </programlisting>
 
     <para>Multiple interfaces may be present, each of which may have methods and properties.
       This is emitted before the first <link linkend="cockpit-dbus-proxy"><code>client.onnotify</code></link>
       event for the relevant interface.</para>
+  </refsection>
+
+  <refsection id="cockpit-dbus-meta">
+    <title>client.meta()</title>
+<programlisting>
+client.meta(data)
+</programlisting>
+    <para>Populate DBus introspection metadata about DBus interfaces. Usually this metadata
+      is automatically introspected from the DBus services called by the <code>client</code>,
+      but in certain cases it is useful to populate this info from javascript code. One such
+      case is when exporting a DBus service from javascript.</para>
+
+    <para>The <link linkend="cockpit-dbus-onmeta"><code>client.onmeta</code></link> event will
+      be emitted by this method call. It's documentation includes information about the form
+      of the <code>data</code>.</para>
+
   </refsection>
 
   <refsection id="cockpit-dbus-variant">

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -542,6 +542,8 @@ will be defined here, but this is it for now.
 
 If the bus name of the sender of the signal does not match the "name" field of
 the "open" message, then a "name" field will be included with the "meta" message.
+Such meta information can also be sent to the bridge, in order to populate the
+cache of introspection data for the channel.
 
 When the owner of the DBus "name" (specified in the open message) changes an "owner"
 message is sent. The owner value will be the id of the owner or null if the name

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -2721,11 +2721,11 @@ function factory() {
             console.debug.apply(console, arguments);
     }
 
-    function DBusError(arg) {
+    function DBusError(arg, arg1) {
         if (typeof(arg) == "string") {
             this.problem = arg;
             this.name = null;
-            this.message = cockpit.message(arg);
+            this.message = arg1 || cockpit.message(arg);
         } else {
             this.problem = null;
             this.name = arg[0];
@@ -3160,7 +3160,7 @@ function factory() {
             var id, outstanding = calls;
             calls = { };
             for (id in outstanding) {
-                outstanding[id].reject(new DBusError(closed));
+                outstanding[id].reject(new DBusError(closed, options.message));
             }
             self.dispatchEvent("close", options);
         }

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -3138,6 +3138,21 @@ function factory() {
             self.dispatchEvent("meta", data);
         }
 
+        self.meta = function(data, options) {
+            if (!channel || !channel.valid)
+                return;
+
+            var message = extend({ }, options, {
+                "meta": data
+            });
+
+            var payload = JSON.stringify(message);
+            dbus_debug("dbus:", payload);
+            channel.send(payload);
+
+            meta(data);
+        };
+
         function notify(data) {
             ensure_cache();
             var path, iface, props;

--- a/src/base1/test-dbus-common.js
+++ b/src/base1/test-dbus-common.js
@@ -377,6 +377,61 @@ function common_dbus_tests(channel_options, bus_name)
             });
     });
 
+    QUnit.asyncTest("bad object path", function() {
+        assert.expect(2);
+
+        var dbus = cockpit.dbus(bus_name, channel_options);
+        dbus.call("invalid/path", "borkety.Bork", "Echo", [ 1 ]).
+            fail(function(ex) {
+                assert.equal(ex.problem, "protocol-error", "error name");
+                assert.equal(ex.message, "object path is invalid in dbus \"call\": invalid/path", "error message");
+            }).
+            always(function() {
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest("bad interface name", function() {
+        assert.expect(2);
+
+        var dbus = cockpit.dbus(bus_name, channel_options);
+        dbus.call("/path", "!invalid!interface!", "Echo", [ 1 ]).
+            fail(function(ex) {
+                assert.equal(ex.problem, "protocol-error", "error name");
+                assert.equal(ex.message, "interface name is invalid in dbus \"call\": !invalid!interface!", "error message");
+            }).
+            always(function() {
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest("bad method name", function() {
+        assert.expect(2);
+
+        var dbus = cockpit.dbus(bus_name, channel_options);
+        dbus.call("/path", "borkety.Bork", "!Invalid!Method!", [ 1 ]).
+            fail(function(ex) {
+                assert.equal(ex.problem, "protocol-error", "error name");
+                assert.equal(ex.message, "member name is invalid in dbus \"call\": !Invalid!Method!", "error message");
+            }).
+            always(function() {
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest("bad flags", function() {
+        assert.expect(2);
+
+        var dbus = cockpit.dbus(bus_name, channel_options);
+        dbus.call("/path", "borkety.Bork", "Method", [ 1 ], { "flags": 5 }).
+            fail(function(ex) {
+                assert.equal(ex.problem, "protocol-error", "error name");
+                assert.equal(ex.message, "the \"flags\" field is invalid in dbus call", "error message");
+            }).
+            always(function() {
+                QUnit.start();
+            });
+    });
 
     QUnit.asyncTest("bad types", function() {
         assert.expect(3);
@@ -385,8 +440,23 @@ function common_dbus_tests(channel_options, bus_name)
         dbus.call("/bork", "borkety.Bork", "Echo", [ 1 ],
                   { type: "!!%%" }).
             fail(function(ex) {
-                assert.equal(ex.name, "org.freedesktop.DBus.Error.InvalidArgs", "error name");
-                assert.equal(ex.message, "Type signature is not valid: !!%%", "error message");
+                assert.equal(ex.problem, "protocol-error", "error name");
+                assert.equal(ex.message, "the \"type\" signature is not valid in dbus call: !!%%", "error message");
+            }).
+            always(function() {
+                assert.equal(this.state(), "rejected", "should fail");
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest("bad type invalid", function() {
+        assert.expect(3);
+
+        var dbus = cockpit.dbus(bus_name, channel_options);
+        dbus.call("/bork", "borkety.Bork", "Echo", [ 1 ], { type: 5 /* invalid */ }).
+            fail(function(ex) {
+                assert.equal(ex.problem, "protocol-error", "error name");
+                assert.equal(ex.message, "the \"type\" field is invalid in call", "error message");
             }).
             always(function() {
                 assert.equal(this.state(), "rejected", "should fail");
@@ -852,6 +922,7 @@ function common_dbus_tests(channel_options, bus_name)
                                             assert.equal(this.state(), "resolved", "removed object");
                                             assert.strictEqual(removed, added, "removed fired");
                                             assert.strictEqual(removed.valid, false, "removed is invalid");
+                                            dbus.close();
                                             $(dbus).off();
                                             QUnit.start();
                                         });

--- a/src/base1/test-dbus-common.js
+++ b/src/base1/test-dbus-common.js
@@ -360,6 +360,40 @@ function common_dbus_tests(channel_options, bus_name)
             });
     });
 
+    QUnit.asyncTest("with meta", function() {
+        assert.expect(2);
+
+        var meta = {
+            "borkety.Bork": {
+                "methods": {
+                    "Echo": {
+                        "in": [ "a{ss}", "u", "i", "t" ],
+                        "out": [ "a{ss}", "u", "i", "t" ]
+                    }
+                }
+            }
+        };
+
+        var dbus = cockpit.dbus(bus_name, channel_options);
+        dbus.addEventListener("meta", function(event, data) {
+            assert.deepEqual(data, meta, "got meta data");
+        });
+
+        dbus.meta(meta);
+        dbus.call("/bork", "borkety.Bork", "Echo",
+                  [ {one: "red", two: "blue"}, 55, 66, 32 ])
+            .then(function(reply) {
+                assert.deepEqual(reply, [ {one: "red", two: "blue"}, 55, 66, 32 ], "returned round trip");
+            }, function(ex) {
+                console.log(ex);
+                assert.ok(false, "shouldn't fail");
+            }).
+            always(function() {
+                dbus.close();
+                QUnit.start();
+            });
+    });
+
     QUnit.asyncTest("empty base64", function() {
         assert.expect(3);
 

--- a/src/base1/test-dbus.js
+++ b/src/base1/test-dbus.js
@@ -192,7 +192,7 @@ QUnit.asyncTest("no default name", function() {
 });
 
 QUnit.asyncTest("no default name bad", function() {
-    assert.expect(1);
+    assert.expect(2);
 
     var dbus = cockpit.dbus(null, { "bus": "session" });
     dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
@@ -200,14 +200,15 @@ QUnit.asyncTest("no default name bad", function() {
         then(function(reply) {
             assert.ok(false, "shouldn't succeed");
         }, function(ex) {
-            assert.equal(ex.message, "The \"name\" field is invalid in call", "error message");
+            assert.equal(ex.problem, "protocol-error", "error problem");
+            assert.equal(ex.message, "the \"name\" field is invalid in dbus call", "error message");
         }).always(function() {
             QUnit.start();
         });
 });
 
 QUnit.asyncTest("no default name invalid", function() {
-    assert.expect(1);
+    assert.expect(2);
 
     var dbus = cockpit.dbus(null, { "bus": "session" });
     dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
@@ -215,14 +216,15 @@ QUnit.asyncTest("no default name invalid", function() {
         then(function(reply) {
             assert.ok(false, "shouldn't succeed");
         }, function(ex) {
-            assert.equal(ex.message, "The \"name\" field is not a valid bus name", "error message");
+            assert.equal(ex.problem, "protocol-error", "error problem");
+            assert.equal(ex.message, "the \"name\" field in dbus call is not a valid bus name: !invalid!", "error message");
         }).always(function() {
             QUnit.start();
         });
 });
 
 QUnit.asyncTest("no default name missing", function() {
-    assert.expect(1);
+    assert.expect(2);
 
     var dbus = cockpit.dbus(null, { "bus": "session" });
     dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
@@ -230,7 +232,8 @@ QUnit.asyncTest("no default name missing", function() {
         then(function(reply) {
             assert.ok(false, "shouldn't succeed");
         }, function(ex) {
-            assert.equal(ex.message, "The \"name\" field is missing in call", "error message");
+            assert.equal(ex.problem, "protocol-error", "error problem");
+            assert.equal(ex.message, "the \"name\" field is missing in dbus call", "error message");
         }).always(function() {
             QUnit.start();
         });
@@ -304,14 +307,15 @@ QUnit.asyncTest("watch no default name", function() {
 });
 
 QUnit.asyncTest("watch missing name", function() {
-    assert.expect(1);
+    assert.expect(2);
 
     var dbus = cockpit.dbus(null, { "bus": "session" });
     dbus.watch("/otree/frobber")
         .then(function() {
             assert.ok(false, "shouldn't succeed");
         }, function(ex) {
-            assert.equal(ex.message, "protocol-error", "error message");
+            assert.equal(ex.problem, "protocol-error", "error problem");
+            assert.equal(ex.message, "session: no \"name\" specified in match", "error message");
         })
         .always(function() {
             dbus.close();

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -17,6 +17,8 @@ libcockpit_stub_a_SOURCES = \
 	src/bridge/cockpitdbusinternal.c \
 	src/bridge/cockpitdbusjson.c \
 	src/bridge/cockpitdbusjson.h \
+	src/bridge/cockpitdbusmeta.c \
+	src/bridge/cockpitdbusmeta.h \
 	src/bridge/cockpitdbusrules.c \
 	src/bridge/cockpitdbusrules.h \
 	src/bridge/cockpitdbusenvironment.c \
@@ -154,6 +156,7 @@ BRIDGE_CHECKS = \
 	test-portal \
 	test-pipe-channel \
 	test-packages \
+	test-dbus-meta \
 	test-fs \
 	test-metrics \
 	test-connect \
@@ -185,6 +188,10 @@ test_channel_LDADD = $(libcockpit_bridge_LIBS)
 test_connect_CFLAGS = $(libcockpit_bridge_a_CFLAGS)
 test_connect_SOURCES = src/bridge/test-connect.c
 test_connect_LDADD = $(libcockpit_bridge_LIBS)
+
+test_dbus_meta_CFLAGS = $(libcockpit_bridge_a_CFLAGS)
+test_dbus_meta_SOURCES = src/bridge/test-dbus-meta.c
+test_dbus_meta_LDADD = $(libcockpit_bridge_LIBS)
 
 test_packages_SOURCES = src/bridge/test-packages.c \
 	src/bridge/mock-transport.c src/bridge/mock-transport.h

--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -24,6 +24,7 @@
 #include "cockpitchannel.h"
 #include "cockpitdbuscache.h"
 #include "cockpitdbusinternal.h"
+#include "cockpitdbusmeta.h"
 #include "cockpitdbusrules.h"
 
 #include "common/cockpitjson.h"
@@ -861,80 +862,6 @@ build_json_signal (const gchar *path,
   return object;
 }
 
-static JsonArray *
-build_json_meta_args (GDBusArgInfo **args)
-{
-  JsonArray *array = json_array_new ();
-  while (*args)
-    {
-      json_array_add_string_element (array, (*args)->signature);
-      args++;
-    }
-  return array;
-}
-
-static JsonObject *
-build_json_meta (GDBusInterfaceInfo *iface)
-{
-  JsonObject *object;
-  JsonObject *meta;
-  JsonObject *interface;
-  JsonObject *methods;
-  JsonObject *method;
-  JsonObject *properties;
-  JsonObject *property;
-  GString *flags;
-  guint i;
-
-  interface = json_object_new ();
-
-  if (iface->methods)
-    {
-      methods = json_object_new ();
-      for (i = 0; iface->methods[i] != NULL; i++)
-        {
-          method = json_object_new ();
-          if (iface->methods[i]->in_args)
-            json_object_set_array_member (method, "in", build_json_meta_args (iface->methods[i]->in_args));
-          if (iface->methods[i]->out_args)
-            json_object_set_array_member (method, "out", build_json_meta_args (iface->methods[i]->out_args));
-          json_object_set_object_member (methods, iface->methods[i]->name, method);
-        }
-      json_object_set_object_member (interface, "methods", methods);
-    }
-
-  if (iface->properties)
-    {
-      flags = g_string_new ("");
-      properties = json_object_new ();
-      for (i = 0; iface->properties[i] != NULL; i++)
-        {
-          g_string_set_size (flags, 0);
-          property = json_object_new ();
-          if (iface->properties[i]->flags & G_DBUS_PROPERTY_INFO_FLAGS_READABLE)
-            g_string_append_c (flags, 'r');
-          if (iface->properties[i]->flags & G_DBUS_PROPERTY_INFO_FLAGS_WRITABLE)
-            g_string_append_c (flags, 'w');
-          json_object_set_string_member (property, "flags", flags->str);
-          if (iface->properties[i]->signature)
-            json_object_set_string_member (property, "type", iface->properties[i]->signature);
-          json_object_set_object_member (properties, iface->properties[i]->name, property);
-        }
-      g_string_free (flags, TRUE);
-      json_object_set_object_member (interface, "properties", properties);
-    }
-
-
-  meta = json_object_new ();
-  json_object_set_object_member (meta, iface->name, interface);
-
-  object = json_object_new ();
-  json_object_set_object_member (object, "meta", meta);
-
-  return object;
-}
-
-
 /* ---------------------------------------------------------------------------------------------------- */
 
 typedef struct {
@@ -1677,10 +1604,21 @@ on_cache_meta (CockpitDBusCache *cache,
                gpointer user_data)
 {
   CockpitDBusPeer *peer = user_data;
-  JsonObject *object = build_json_meta (iface);
-  maybe_include_name (peer->dbus_json, object, peer->name);
-  send_json_object (peer->dbus_json, object);
-  json_object_unref (object);
+  JsonObject *interface;
+  JsonObject *meta;
+  JsonObject *message;
+
+  interface = cockpit_dbus_meta_build (iface);
+
+  meta = json_object_new ();
+  json_object_set_object_member (meta, iface->name, interface);
+
+  message = json_object_new ();
+  json_object_set_object_member (message, "meta", meta);
+
+  maybe_include_name (peer->dbus_json, message, peer->name);
+  send_json_object (peer->dbus_json, message);
+  json_object_unref (message);
 }
 
 static JsonObject *

--- a/src/bridge/cockpitdbusmeta.c
+++ b/src/bridge/cockpitdbusmeta.c
@@ -1,0 +1,483 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitdbusmeta.h"
+
+#include "common/cockpitjson.h"
+
+#include <string.h>
+
+static JsonArray *
+build_meta_arguments (GDBusArgInfo **args)
+{
+  JsonArray *arguments = json_array_new ();
+  while (*args)
+    {
+      json_array_add_string_element (arguments, (*args)->signature);
+      args++;
+    }
+  return arguments;
+}
+
+static JsonObject *
+build_meta_method (GDBusMethodInfo *meth)
+{
+  JsonObject *method = json_object_new ();
+  if (meth->in_args)
+    {
+      json_object_set_array_member (method, "in",
+                                    build_meta_arguments (meth->in_args));
+    }
+  if (meth->out_args)
+    {
+      json_object_set_array_member (method, "out",
+                                    build_meta_arguments (meth->out_args));
+    }
+  return method;
+}
+
+static JsonObject *
+build_meta_signal (GDBusSignalInfo *sig)
+{
+  JsonObject *signal = json_object_new ();
+  if (sig->args)
+    {
+      json_object_set_array_member (signal, "in",
+                                    build_meta_arguments (sig->args));
+    }
+  return signal;
+}
+
+static JsonObject *
+build_meta_property (GDBusPropertyInfo *prop)
+{
+  JsonObject *property = json_object_new ();;
+  GString *flags = g_string_new ("");
+
+  if (prop->flags & G_DBUS_PROPERTY_INFO_FLAGS_READABLE)
+    g_string_append_c (flags, 'r');
+  if (prop->flags & G_DBUS_PROPERTY_INFO_FLAGS_WRITABLE)
+    g_string_append_c (flags, 'w');
+  json_object_set_string_member (property, "flags", flags->str);
+  if (prop->signature)
+    json_object_set_string_member (property, "type", prop->signature);
+  g_string_free (flags, TRUE);
+  return property;
+}
+
+JsonObject *
+cockpit_dbus_meta_build (GDBusInterfaceInfo *iface)
+{
+  JsonObject *interface;
+  JsonObject *methods;
+  JsonObject *properties;
+  JsonObject *signals;
+  guint i;
+
+  g_return_val_if_fail (iface != NULL, NULL);
+
+  interface = json_object_new ();
+
+  if (iface->methods)
+    {
+      methods = json_object_new ();
+      for (i = 0; iface->methods[i] != NULL; i++)
+        {
+          json_object_set_object_member (methods, iface->methods[i]->name,
+                                         build_meta_method (iface->methods[i]));
+        }
+      json_object_set_object_member (interface, "methods", methods);
+    }
+
+  if (iface->properties)
+    {
+      properties = json_object_new ();
+      for (i = 0; iface->properties[i] != NULL; i++)
+        {
+          json_object_set_object_member (properties, iface->properties[i]->name,
+                                         build_meta_property (iface->properties[i]));
+        }
+      json_object_set_object_member (interface, "properties", properties);
+    }
+
+  if (iface->signals)
+    {
+      signals = json_object_new ();
+      for (i = 0; iface->signals[i] != NULL; i++)
+        {
+          json_object_set_object_member (signals, iface->signals[i]->name,
+                                         build_meta_signal (iface->signals[i]));
+        }
+      json_object_set_object_member (interface, "signals", signals);
+    }
+
+  return interface;
+}
+
+static GDBusArgInfo **
+parse_meta_arguments (JsonArray *arguments,
+                      GError **error)
+{
+  const gchar *signature;
+  GDBusArgInfo *arg;
+  GPtrArray *args;
+  guint i, length;
+  JsonNode *node;
+
+  args = g_ptr_array_new ();
+  g_ptr_array_set_free_func (args, (GDestroyNotify)g_dbus_arg_info_unref);
+
+  length = json_array_get_length (arguments);
+  for (i = 0; i < length; i++)
+    {
+      node = json_array_get_element (arguments, i);
+      if (!JSON_NODE_HOLDS_VALUE(node) || json_node_get_value_type (node) != G_TYPE_STRING)
+        {
+          g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                       "invalid argument in dbus meta field");
+          break;
+        }
+
+      signature = json_node_get_string (node);
+      if (!g_variant_is_signature (signature))
+        {
+          g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                       "argument in dbus meta field has invalid signature: %s", signature);
+          break;
+        }
+
+      arg = g_new0 (GDBusArgInfo, 1);
+      arg->ref_count = 1;
+      arg->name = g_strdup_printf ("argument_%u", i);
+      arg->signature = g_strdup (signature);
+      g_ptr_array_add (args, arg);
+    }
+
+  if (i != length)
+    {
+      g_ptr_array_free (args, TRUE);
+      return NULL;
+    }
+  else
+    {
+      g_ptr_array_add (args, NULL);
+      return (GDBusArgInfo **)g_ptr_array_free (args, FALSE);
+    }
+}
+
+static GDBusMethodInfo *
+parse_meta_method (const gchar *method_name,
+                   JsonObject *method,
+                   GError **error)
+{
+  GDBusMethodInfo *ret = NULL;
+  GDBusMethodInfo *meth;
+  JsonArray *args;
+
+  meth = g_new0 (GDBusMethodInfo, 1);
+  meth->ref_count = 1;
+  meth->name = g_strdup (method_name);
+
+  if (!cockpit_json_get_array (method, "in", NULL, &args))
+    {
+      g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                   "invalid \"in\" field in dbus meta method: %s", method_name);
+      goto out;
+    }
+
+  if (args && json_array_get_length (args) > 0)
+    {
+      meth->in_args = parse_meta_arguments (args, error);
+      if (!meth->in_args)
+        goto out;
+    }
+
+  if (!cockpit_json_get_array (method, "out", NULL, &args))
+    {
+      g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                   "invalid \"out\" field in dbus meta method: %s", method_name);
+      goto out;
+    }
+
+  if (args && json_array_get_length (args) > 0)
+    {
+      meth->out_args = parse_meta_arguments (args, error);
+      if (!meth->out_args)
+        goto out;
+    }
+
+  ret = meth;
+  meth = NULL;
+
+out:
+  if (meth)
+    g_dbus_method_info_unref (meth);
+  return ret;
+}
+
+static GDBusSignalInfo *
+parse_meta_signal (const gchar *signal_name,
+                   JsonObject *signal,
+                   GError **error)
+{
+  GDBusSignalInfo *ret = NULL;
+  GDBusSignalInfo *sig;
+  JsonArray *args;
+
+  sig = g_new0 (GDBusSignalInfo, 1);
+  sig->ref_count = 1;
+  sig->name = g_strdup (signal_name);
+
+  if (!cockpit_json_get_array (signal, "in", NULL, &args))
+    {
+      g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                   "invalid \"in\" field in dbus meta signal: %s", signal_name);
+      goto out;
+    }
+
+  if (args && json_array_get_length (args) > 0)
+    {
+      sig->args = parse_meta_arguments (args, error);
+      if (!sig->args)
+        goto out;
+    }
+
+  ret = sig;
+  sig = NULL;
+
+out:
+  if (sig)
+    g_dbus_signal_info_unref (sig);
+  return ret;
+}
+
+static GDBusPropertyInfo *
+parse_meta_property (const gchar *property_name,
+                     JsonObject *property,
+                     GError **error)
+{
+  GDBusPropertyInfo *prop;
+  GDBusPropertyInfo *ret = NULL;
+  const gchar *flags;
+  const gchar *type;
+
+  prop = g_new0 (GDBusPropertyInfo, 1);
+  prop->ref_count = 1;
+  prop->name = g_strdup (property_name);
+
+  if (!cockpit_json_get_string (property, "flags", NULL, &flags))
+    {
+      g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                   "invalid \"flags\" field in dbus property: %s", property_name);
+      goto out;
+    }
+
+  if (flags && strchr (flags, 'r'))
+    prop->flags |= G_DBUS_PROPERTY_INFO_FLAGS_READABLE;
+  if (flags && strchr (flags, 'w'))
+    prop->flags |= G_DBUS_PROPERTY_INFO_FLAGS_WRITABLE;
+
+  if (!cockpit_json_get_string (property, "type", NULL, &type))
+    {
+      g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                   "invalid \"type\" field in dbus property: %s", property_name);
+      goto out;
+    }
+  else if (!type)
+    {
+      g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                   "missing \"type\" field in dbus property: %s", property_name);
+      goto out;
+    }
+  else if (!g_variant_is_signature (type))
+    {
+      g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                   "the \"type\" field in dbus property is not a dbus signature: %s", type);
+      goto out;
+    }
+
+  prop->signature = g_strdup (type);
+
+  ret = prop;
+  prop = NULL;
+
+out:
+  if (prop)
+    g_dbus_property_info_unref (prop);
+  return ret;
+}
+
+GDBusInterfaceInfo *
+cockpit_dbus_meta_parse (const gchar *iface_name,
+                         JsonObject *interface,
+                         GError **error)
+{
+  GDBusInterfaceInfo *ret = NULL;
+  GDBusInterfaceInfo *iface;
+  GDBusMethodInfo *meth;
+  GDBusSignalInfo *sig;
+  GDBusPropertyInfo *prop;
+  JsonObject *methods;
+  JsonObject *method;
+  JsonObject *signals;
+  JsonObject *signal;
+  JsonObject *properties;
+  JsonObject *property;
+  GPtrArray *array = NULL;
+  GList *names = NULL, *l;
+
+  g_return_val_if_fail (iface_name != NULL, NULL);
+  g_return_val_if_fail (interface != NULL, NULL);
+  g_return_val_if_fail (!error || !*error, NULL);
+
+  iface = g_new0 (GDBusInterfaceInfo, 1);
+  iface->name = g_strdup (iface_name);
+  iface->ref_count = 1;
+
+  if (!cockpit_json_get_object (interface, "methods", NULL, &methods))
+    {
+      g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                   "invalid \"methods\" field in dbus meta structure");
+      goto out;
+    }
+
+  if (methods)
+    {
+      array = g_ptr_array_new ();
+      g_ptr_array_set_free_func (array, (GDestroyNotify)g_dbus_method_info_unref);
+
+      names = json_object_get_members (methods);
+      for (l = names; l != NULL; l = g_list_next (l))
+        {
+          if (!cockpit_json_get_object (methods, l->data, NULL, &method))
+            {
+              g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                           "invalid method field in dbus meta structure: %s",
+                           (const gchar *)l->data);
+              goto out;
+            }
+
+          g_assert (method != NULL);
+          meth = parse_meta_method (l->data, method, error);
+          if (!meth)
+            goto out;
+
+          g_ptr_array_add (array, meth);
+        }
+
+      g_list_free (names);
+      names = NULL;
+
+      g_ptr_array_add (array, NULL);
+      iface->methods = (GDBusMethodInfo **)g_ptr_array_free (array, FALSE);
+      array = NULL;
+    }
+
+  if (!cockpit_json_get_object (interface, "signals", NULL, &signals))
+    {
+      g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                   "invalid \"signals\" field in dbus meta structure");
+      goto out;
+    }
+
+  if (signals)
+    {
+      array = g_ptr_array_new ();
+      g_ptr_array_set_free_func (array, (GDestroyNotify)g_dbus_signal_info_unref);
+
+      names = json_object_get_members (signals);
+      for (l = names; l != NULL; l = g_list_next (l))
+        {
+          if (!cockpit_json_get_object (signals, l->data, NULL, &signal))
+            {
+              g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                           "invalid signal field in dbus meta structure: %s",
+                           (const gchar *)l->data);
+              goto out;
+            }
+
+          g_assert (signal != NULL);
+          sig = parse_meta_signal (l->data, signal, error);
+          if (!sig)
+            goto out;
+
+          g_ptr_array_add (array, sig);
+        }
+
+      g_list_free (names);
+      names = NULL;
+
+      g_ptr_array_add (array, NULL);
+      iface->signals = (GDBusSignalInfo **)g_ptr_array_free (array, FALSE);
+      array = NULL;
+    }
+
+  if (!cockpit_json_get_object (interface, "properties", NULL, &properties))
+    {
+      g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                   "invalid \"properties\" field in dbus meta structure");
+      goto out;
+    }
+
+  if (properties)
+    {
+      array = g_ptr_array_new ();
+      g_ptr_array_set_free_func (array, (GDestroyNotify)g_dbus_property_info_unref);
+
+      names = json_object_get_members (properties);
+      for (l = names; l != NULL; l = g_list_next (l))
+        {
+          if (!cockpit_json_get_object (properties, l->data, NULL, &property))
+            {
+              g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                           "invalid property field in dbus meta structure: %s",
+                           (const gchar *)l->data);
+              goto out;
+            }
+
+          g_assert (property != NULL);
+          prop = parse_meta_property (l->data, property, error);
+          if (!prop)
+            goto out;
+
+          g_ptr_array_add (array, prop);
+        }
+
+      g_list_free (names);
+      names = NULL;
+
+      g_ptr_array_add (array, NULL);
+      iface->properties = (GDBusPropertyInfo **)g_ptr_array_free (array, FALSE);
+      array = NULL;
+    }
+
+  ret = iface;
+  iface = NULL;
+
+out:
+  if (iface)
+    g_dbus_interface_info_unref (iface);
+  if (array)
+    g_ptr_array_free (array, TRUE);
+  if (names)
+    g_list_free (names);
+  return ret;
+}

--- a/src/bridge/cockpitdbusmeta.h
+++ b/src/bridge/cockpitdbusmeta.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COCKPIT_DBUS_META_H__
+#define COCKPIT_DBUS_META_H__
+
+#include <gio/gio.h>
+#include <json-glib/json-glib.h>
+
+G_BEGIN_DECLS
+
+JsonObject *             cockpit_dbus_meta_build     (GDBusInterfaceInfo *iface);
+
+GDBusInterfaceInfo *     cockpit_dbus_meta_parse     (const gchar *iface_name,
+                                                      JsonObject *interface,
+                                                      GError **error);
+
+G_END_DECLS
+
+#endif /* COCKPIT_DBUS_META_H__ */

--- a/src/bridge/test-dbus-meta.c
+++ b/src/bridge/test-dbus-meta.c
@@ -1,0 +1,760 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitdbusmeta.h"
+
+#include "common/cockpitjson.h"
+#include "common/cockpittest.h"
+
+#include <string.h>
+
+typedef struct {
+  const GDBusInterfaceInfo *iface;
+  const gchar *result;
+} BuildFixture;
+
+static const GDBusArgInfo janitor_method_say_what = {
+    -1, (gchar *)"what", "s"
+};
+
+static const GDBusArgInfo janitor_method_say_how = {
+    -1, (gchar *)"how", "i",
+};
+
+static const GDBusArgInfo *janitor_method_say_in[] = {
+    &janitor_method_say_what,
+    &janitor_method_say_how,
+    NULL,
+};
+
+static const GDBusArgInfo janitor_method_say_said = {
+    -1, (gchar *)"said", "a{sv}",
+};
+
+static const GDBusArgInfo *janitor_method_say_out[] = {
+    &janitor_method_say_said,
+    NULL,
+};
+
+static const GDBusMethodInfo janitor_method_say = {
+    -1, (gchar *)"Say",
+    (GDBusArgInfo **) &janitor_method_say_in,
+    (GDBusArgInfo **) &janitor_method_say_out,
+};
+
+static const GDBusArgInfo janitor_method_mop_mess = {
+    -1, (gchar *)"mess", "sa{sa{sv}}a{sv}a{sv}a{sv}a{sv}a{sv}a{sv}ssa{sv}a{sv}b"
+};
+
+static const GDBusArgInfo *janitor_method_mop_out[] = {
+    &janitor_method_mop_mess,
+    NULL,
+};
+
+static const GDBusMethodInfo janitor_method_mop = {
+    -1, (gchar *)"Mop",
+    (GDBusArgInfo **) NULL,
+    (GDBusArgInfo **) &janitor_method_mop_out,
+};
+
+static const GDBusMethodInfo *janitor_methods[] = {
+    &janitor_method_say,
+    &janitor_method_mop,
+    NULL
+};
+
+static const GDBusArgInfo janitor_signal_oh_oh = {
+    -1, (gchar *)"oh", "v",
+};
+
+static const GDBusArgInfo janitor_signal_oh_marmalade = {
+    -1, (gchar *)"marmalade", "v"
+};
+
+static const GDBusArgInfo *janitor_signal_oh_args[] = {
+    &janitor_signal_oh_oh,
+    &janitor_signal_oh_marmalade,
+    NULL,
+};
+
+static const GDBusSignalInfo janitor_signal_oh = {
+    -1, (gchar *)"Oh",
+    (GDBusArgInfo **)&janitor_signal_oh_args
+};
+
+static const GDBusSignalInfo janitor_signal_boom = {
+    -1, (gchar *)"Oh",
+    (GDBusArgInfo **)&janitor_signal_oh_args
+};
+
+static const GDBusSignalInfo *janitor_signals[] = {
+    &janitor_signal_oh,
+    &janitor_signal_boom,
+    NULL
+};
+
+static const GDBusPropertyInfo janitor_property_name = {
+    -1, (gchar *)"Name", "s", G_DBUS_PROPERTY_INFO_FLAGS_READABLE
+};
+
+static const GDBusPropertyInfo janitor_property_habit = {
+    -1, (gchar *)"Habit", "a{sv}", G_DBUS_PROPERTY_INFO_FLAGS_READABLE | G_DBUS_PROPERTY_INFO_FLAGS_WRITABLE
+};
+
+static const GDBusPropertyInfo janitor_property_hidden = {
+    -1, (gchar *)"Hidden", "b", G_DBUS_PROPERTY_INFO_FLAGS_WRITABLE
+};
+
+static const GDBusPropertyInfo *janitor_properties[] = {
+    &janitor_property_name,
+    &janitor_property_habit,
+    &janitor_property_hidden,
+    NULL
+};
+
+static const GDBusInterfaceInfo janitor_interface = {
+    -1, "planet.express.Janitor",
+    (GDBusMethodInfo **) &janitor_methods,
+    (GDBusSignalInfo **) &janitor_signals,
+    (GDBusPropertyInfo **) &janitor_properties,
+    NULL
+};
+
+static const gchar janitor_json[] = "{"
+  "\"methods\": {"
+    "\"Say\": {"
+      "\"in\": [\"s\",\"i\"],"
+      "\"out\":[\"a{sv}\"]"
+    "},"
+    "\"Mop\": {"
+      "\"out\":[\"sa{sa{sv}}a{sv}a{sv}a{sv}a{sv}a{sv}a{sv}ssa{sv}a{sv}b\"]"
+    "}"
+  "},"
+  "\"properties\": {"
+    "\"Name\": {"
+      "\"flags\": \"r\","
+      "\"type\": \"s\""
+    "},"
+    "\"Habit\": {"
+      "\"flags\": \"rw\","
+      "\"type\": \"a{sv}\""
+    "},"
+    "\"Hidden\": {"
+      "\"flags\": \"w\","
+      "\"type\": \"b\""
+    "}"
+  "},"
+  "\"signals\": {"
+    "\"Oh\": {"
+      "\"in\": [\"v\",\"v\"]"
+    "}"
+  "}"
+"}";
+
+static const GDBusInterfaceInfo no_methods_interface = {
+    -1, "planet.express.NoMethods",
+    (GDBusMethodInfo **) NULL,
+    (GDBusSignalInfo **) &janitor_signals,
+    (GDBusPropertyInfo **) &janitor_properties,
+    NULL
+};
+
+static const gchar no_methods_json[] = "{"
+  "\"properties\": {"
+    "\"Name\": {"
+      "\"flags\": \"r\","
+      "\"type\": \"s\""
+    "},"
+    "\"Habit\": {"
+      "\"flags\": \"rw\","
+      "\"type\": \"a{sv}\""
+    "},"
+    "\"Hidden\": {"
+      "\"flags\": \"w\","
+      "\"type\": \"b\""
+    "}"
+  "},"
+  "\"signals\": {"
+    "\"Oh\": {"
+      "\"in\": [\"v\",\"v\"]"
+    "}"
+  "}"
+"}";
+
+static const GDBusInterfaceInfo no_signals_interface = {
+    -1, "planet.express.NoSignals",
+    (GDBusMethodInfo **) &janitor_methods,
+    (GDBusSignalInfo **) NULL,
+    (GDBusPropertyInfo **) &janitor_properties,
+    NULL
+};
+
+static const gchar no_signals_json[] = "{"
+  "\"methods\": {"
+    "\"Say\": {"
+      "\"in\": [\"s\",\"i\"],"
+      "\"out\":[\"a{sv}\"]"
+    "},"
+    "\"Mop\": {"
+      "\"out\":[\"sa{sa{sv}}a{sv}a{sv}a{sv}a{sv}a{sv}a{sv}ssa{sv}a{sv}b\"]"
+    "}"
+  "},"
+  "\"properties\": {"
+    "\"Name\": {"
+      "\"flags\": \"r\","
+      "\"type\": \"s\""
+    "},"
+    "\"Habit\": {"
+      "\"flags\": \"rw\","
+      "\"type\": \"a{sv}\""
+    "},"
+    "\"Hidden\": {"
+      "\"flags\": \"w\","
+      "\"type\": \"b\""
+    "}"
+  "}"
+"}";
+
+static const GDBusInterfaceInfo no_properties_interface = {
+    -1, "planet.express.NoProperties",
+    (GDBusMethodInfo **) &janitor_methods,
+    (GDBusSignalInfo **) &janitor_signals,
+    (GDBusPropertyInfo **) NULL,
+    NULL
+};
+
+static const gchar no_properties_json[] = "{"
+  "\"methods\": {"
+    "\"Say\": {"
+      "\"in\": [\"s\",\"i\"],"
+      "\"out\":[\"a{sv}\"]"
+    "},"
+    "\"Mop\": {"
+      "\"out\":[\"sa{sa{sv}}a{sv}a{sv}a{sv}a{sv}a{sv}a{sv}ssa{sv}a{sv}b\"]"
+    "}"
+  "},"
+  "\"signals\": {"
+    "\"Oh\": {"
+      "\"in\": [\"v\",\"v\"]"
+    "}"
+  "}"
+"}";
+
+static const BuildFixture build_janitor_fixture = {
+  &janitor_interface,
+  janitor_json
+};
+
+static const BuildFixture build_no_methods_fixture = {
+  &no_methods_interface,
+  no_methods_json
+};
+
+static const BuildFixture build_no_signals_fixture = {
+  &no_signals_interface,
+  no_signals_json
+};
+
+static const BuildFixture build_no_properties_fixture = {
+  &no_properties_interface,
+  no_properties_json
+};
+
+static void
+test_build (gconstpointer data)
+{
+  const BuildFixture *fixture = data;
+  JsonObject *object;
+
+  object = cockpit_dbus_meta_build ((GDBusInterfaceInfo *)fixture->iface);
+  cockpit_assert_json_eq (object, fixture->result);
+  json_object_unref (object);
+}
+
+static void
+assert_equal_arg (GDBusArgInfo *one,
+                  GDBusArgInfo *two)
+{
+  g_assert (one != NULL);
+  g_assert (two != NULL);
+  g_assert_cmpstr (one->signature, ==, two->signature);
+}
+
+static void
+assert_equal_args (GDBusArgInfo **one,
+                   GDBusArgInfo **two)
+{
+  if (one == NULL || two == NULL)
+    {
+      g_assert (one == NULL && two == NULL);
+      return;
+    }
+
+  while (*one != NULL && *two != NULL)
+    {
+      assert_equal_arg (*one, *two);
+      one++;
+      two++;
+    }
+}
+
+static void
+assert_equal_method (GDBusMethodInfo *one,
+                     GDBusMethodInfo *two)
+{
+  g_assert (one != NULL);
+  g_assert (two != NULL);
+  g_assert_cmpstr (one->name, ==, two->name);
+  assert_equal_args (one->in_args, two->in_args);
+  assert_equal_args (one->out_args, two->out_args);
+}
+
+static void
+assert_equal_methods (GDBusMethodInfo **one,
+                      GDBusMethodInfo **two)
+{
+  if (one == NULL || two == NULL)
+    {
+      g_assert (one == NULL && two == NULL);
+      return;
+    }
+
+  while (*one != NULL && *two != NULL)
+    {
+      assert_equal_method (*one, *two);
+      one++;
+      two++;
+    }
+}
+
+static void
+assert_equal_signal (GDBusSignalInfo *one,
+                     GDBusSignalInfo *two)
+{
+  g_assert (one != NULL);
+  g_assert (two != NULL);
+  g_assert_cmpstr (one->name, ==, two->name);
+  assert_equal_args (one->args, two->args);
+}
+
+static void
+assert_equal_signals (GDBusSignalInfo **one,
+                      GDBusSignalInfo **two)
+{
+  if (one == NULL || two == NULL)
+    {
+      g_assert (one == NULL && two == NULL);
+      return;
+    }
+
+  while (*one != NULL && *two != NULL)
+    {
+      assert_equal_signal (*one, *two);
+      one++;
+      two++;
+    }
+}
+
+static void
+assert_equal_property (GDBusPropertyInfo *one,
+                       GDBusPropertyInfo *two)
+{
+  g_assert (one != NULL);
+  g_assert (two != NULL);
+  g_assert_cmpstr (one->name, ==, two->name);
+  g_assert_cmpstr (one->signature, ==, two->signature);
+  g_assert_cmpuint (one->flags, ==, two->flags);
+}
+
+static void
+assert_equal_properties (GDBusPropertyInfo **one,
+                         GDBusPropertyInfo **two)
+{
+  if (one == NULL || two == NULL)
+    {
+      g_assert (one == NULL && two == NULL);
+      return;
+    }
+
+  while (*one != NULL && *two != NULL)
+    {
+      assert_equal_property (*one, *two);
+      one++;
+      two++;
+    }
+}
+
+static void
+assert_equal_interface (GDBusInterfaceInfo *one,
+                        GDBusInterfaceInfo *two)
+{
+  g_assert (one != NULL);
+  g_assert (two != NULL);
+  g_assert_cmpstr (one->name, ==, two->name);
+  assert_equal_methods (one->methods, two->methods);
+  assert_equal_signals (one->signals, two->signals);
+  assert_equal_properties (one->properties, two->properties);
+}
+
+typedef struct {
+  const gchar *name;
+  const gchar *input;
+  const GDBusInterfaceInfo *iface;
+} ParseFixture;
+
+static const ParseFixture parse_janitor_fixture = {
+    "planet.express.Janitor",
+    janitor_json,
+    &janitor_interface
+};
+
+static const ParseFixture parse_no_methods_fixture = {
+    "planet.express.NoMethods",
+    no_methods_json,
+    &no_methods_interface
+};
+
+static const ParseFixture parse_no_signals_fixture = {
+    "planet.express.NoSignals",
+    no_signals_json,
+    &no_signals_interface
+};
+
+static const ParseFixture parse_no_properties_fixture = {
+    "planet.express.NoProperties",
+    no_properties_json,
+    &no_properties_interface
+};
+
+static void
+test_parse (gconstpointer data)
+{
+  const ParseFixture *fixture = data;
+  GDBusInterfaceInfo *iface;
+  GError *error = NULL;
+  JsonObject *object;
+
+  object = cockpit_json_parse_object (fixture->input, -1, &error);
+  g_assert_no_error (error);
+
+  iface = cockpit_dbus_meta_parse (fixture->name, object, &error);
+  g_assert_no_error (error);
+
+  assert_equal_interface (iface, (GDBusInterfaceInfo *)fixture->iface);
+
+  g_dbus_interface_info_unref (iface);
+  json_object_unref (object);
+}
+
+typedef struct {
+  const gchar *input;
+  const gchar *message;
+} ErrorFixture;
+
+static const gchar invalid_in_argument_json[] = "{"
+  "\"methods\": {"
+    "\"BrokenMethod\": {"
+      "\"in\": [ true ]"
+    "}"
+  "}"
+"}";
+
+static const ErrorFixture error_invalid_in_argument = {
+    invalid_in_argument_json,
+    "invalid argument in dbus meta field"
+};
+
+static const gchar invalid_out_argument_json[] = "{"
+  "\"methods\": {"
+    "\"BrokenMethod\": {"
+      "\"out\": [ true ]"
+    "}"
+  "}"
+"}";
+
+static const ErrorFixture error_invalid_out_argument = {
+    invalid_out_argument_json,
+    "invalid argument in dbus meta field"
+};
+
+static const gchar invalid_signal_argument_json[] = "{"
+  "\"signals\": {"
+    "\"BrokenSignal\": {"
+      "\"in\": [ true ]"
+    "}"
+  "}"
+"}";
+
+static const ErrorFixture error_invalid_signal_argument = {
+    invalid_signal_argument_json,
+    "invalid argument in dbus meta field"
+};
+
+static const gchar invalid_signature_argument_json[] = "{"
+  "\"methods\": {"
+    "\"BrokenMethod\": {"
+      "\"in\": [\"s\",\"!!!\"]"
+    "}"
+  "}"
+"}";
+
+static const ErrorFixture error_signature_argument = {
+    invalid_signature_argument_json,
+   "argument in dbus meta field has invalid signature: !!!"
+};
+
+static const gchar invalid_in_method_json[] = "{"
+  "\"methods\": {"
+    "\"BrokenMethod\": {"
+      "\"in\": true,"
+      "\"out\":[\"a{sv}\"]"
+    "}"
+  "}"
+"}";
+
+static const ErrorFixture error_invalid_in_method = {
+    invalid_in_method_json,
+    "invalid \"in\" field in dbus meta method: BrokenMethod"
+};
+
+static const gchar invalid_out_method_json[] = "{"
+  "\"methods\": {"
+    "\"BrokenMethod\": {"
+      "\"in\":[\"a{sv}\"],"
+      "\"out\": 5"
+    "}"
+  "}"
+"}";
+
+static const ErrorFixture error_invalid_out_method = {
+    invalid_out_method_json,
+    "invalid \"out\" field in dbus meta method: BrokenMethod"
+};
+
+static const gchar invalid_in_signal_json[] = "{"
+  "\"signals\": {"
+    "\"BrokenSignal\": {"
+      "\"in\": { }"
+    "}"
+  "}"
+"}";
+
+static const ErrorFixture error_in_signal_fixture = {
+    invalid_in_signal_json,
+    "invalid \"in\" field in dbus meta signal: BrokenSignal"
+};
+
+static const gchar invalid_flags_property_json[] = "{"
+  "\"properties\": {"
+    "\"BrokenProperty\": {"
+      "\"flags\": [ ],"
+      "\"type\": \"s\""
+    "}"
+  "}"
+"}";
+
+static const ErrorFixture error_flags_property_fixture = {
+    invalid_flags_property_json,
+    "invalid \"flags\" field in dbus property: BrokenProperty"
+};
+
+static const gchar invalid_type_property_json[] = "{"
+  "\"properties\": {"
+    "\"BrokenProperty\": {"
+      "\"flags\": \"r\","
+      "\"type\": 555"
+    "}"
+  "}"
+"}";
+
+static const ErrorFixture error_type_property_fixture = {
+    invalid_type_property_json,
+    "invalid \"type\" field in dbus property: BrokenProperty"
+};
+
+static const gchar missing_type_property_json[] = "{"
+  "\"properties\": {"
+    "\"BrokenProperty\": {"
+      "\"flags\": \"r\""
+    "}"
+  "}"
+"}";
+
+static const ErrorFixture error_type_missing_fixture = {
+    missing_type_property_json,
+    "missing \"type\" field in dbus property: BrokenProperty"
+};
+
+static const gchar invalid_signature_property_json[] = "{"
+  "\"properties\": {"
+    "\"BrokenProperty\": {"
+      "\"flags\": \"r\","
+      "\"type\": \"???\""
+    "}"
+  "}"
+"}";
+
+static const ErrorFixture error_signature_property_fixture = {
+    invalid_signature_property_json,
+    "the \"type\" field in dbus property is not a dbus signature: ???"
+};
+
+static const gchar invalid_methods_json[] = "{"
+  "\"methods\": [ ]"
+"}";
+
+static const ErrorFixture error_methods_fixture = {
+    invalid_methods_json,
+    "invalid \"methods\" field in dbus meta structure"
+};
+
+static const gchar invalid_method_json[] = "{"
+  "\"methods\": {"
+    "\"BadMethod\": [ ]"
+  "}"
+"}";
+
+static const ErrorFixture error_method_json = {
+    invalid_method_json,
+    "invalid method field in dbus meta structure: BadMethod",
+};
+
+static const gchar invalid_signals_json[] = "{"
+  "\"signals\": 555"
+"}";
+
+static const ErrorFixture error_signals_json = {
+    invalid_signals_json,
+    "invalid \"signals\" field in dbus meta structure"
+};
+
+static const gchar invalid_signal_json[] = "{"
+  "\"signals\": {"
+    "\"BadSignal\": true"
+  "}"
+"}";
+
+static const ErrorFixture error_signal_json = {
+    invalid_signal_json,
+    "invalid signal field in dbus meta structure: BadSignal",
+};
+
+static const gchar invalid_properties_json[] = "{"
+  "\"properties\": [ ]"
+"}";
+
+static const ErrorFixture error_properties_json = {
+    invalid_properties_json,
+    "invalid \"properties\" field in dbus meta structure"
+};
+
+static const gchar invalid_property_json[] = "{"
+  "\"properties\": {"
+    "\"BadProperty\": true"
+  "}"
+"}";
+
+static const ErrorFixture error_property_json = {
+    invalid_property_json,
+    "invalid property field in dbus meta structure: BadProperty",
+};
+
+static void
+test_error (gconstpointer data)
+{
+  const ErrorFixture *fixture = data;
+  GDBusInterfaceInfo *iface;
+  GError *error = NULL;
+  JsonObject *object;
+
+  object = cockpit_json_parse_object (fixture->input, -1, &error);
+  g_assert_no_error (error);
+
+  iface = cockpit_dbus_meta_parse ("name.not.Important", object, &error);
+  g_assert (iface == NULL);
+  g_assert_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS);
+  g_assert_cmpstr (error->message, ==, fixture->message);
+
+  g_error_free (error);
+  json_object_unref (object);
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+  cockpit_test_init (&argc, &argv);
+
+  g_test_add_data_func ("/dbus-meta/build/basic",
+                        &build_janitor_fixture, test_build);
+  g_test_add_data_func ("/dbus-meta/build/no-methods",
+                        &build_no_methods_fixture, test_build);
+  g_test_add_data_func ("/dbus-meta/build/no-signals",
+                        &build_no_signals_fixture, test_build);
+  g_test_add_data_func ("/dbus-meta/build/no-properties",
+                        &build_no_properties_fixture, test_build);
+
+  g_test_add_data_func ("/dbus-meta/parse/basic",
+                        &parse_janitor_fixture, test_parse);
+  g_test_add_data_func ("/dbus-meta/parse/no-methods",
+                        &parse_no_methods_fixture, test_parse);
+  g_test_add_data_func ("/dbus-meta/parse/no-signals",
+                        &parse_no_signals_fixture, test_parse);
+  g_test_add_data_func ("/dbus-meta/parse/no-properties",
+                        &parse_no_properties_fixture, test_parse);
+
+  g_test_add_data_func ("/dbus-meta/parse/invalid-in-argument",
+                        &error_invalid_in_argument, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-out-argument",
+                        &error_invalid_out_argument, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-signal-argument",
+                        &error_invalid_signal_argument, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-signature-argument",
+                        &error_signature_argument, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-in-arguments",
+                        &error_invalid_in_method, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-out-arguments",
+                        &error_invalid_out_method, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-signal-arguments",
+                        &error_in_signal_fixture, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-property-flags",
+                        &error_flags_property_fixture, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-property-type",
+                        &error_type_property_fixture, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/missing-property-type",
+                        &error_type_missing_fixture, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-property-signature",
+                        &error_signature_property_fixture, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-methods",
+                        &error_methods_fixture, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-method",
+                        &error_method_json, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-signals",
+                        &error_signals_json, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-signal",
+                        &error_signal_json, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-properties",
+                        &error_properties_json, test_error);
+  g_test_add_data_func ("/dbus-meta/parse/invalid-property",
+                        &error_property_json, test_error);
+
+  return g_test_run ();
+}


### PR DESCRIPTION
The javascript code can now send DBus interface introspection metadata to the bridge. This sets the stage for exporting objects, but can also be used to populate information about an interface in a service that has poor or non-existent Introspect() capabilities.
    
This adds a client.meta() method in javascript.

Depends on: 

 * [x] #5464
 * [x] #5492
 * [x] #5500