### PR TITLE
bridge: Add support for emitting DBus signals.

### DIFF
--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -3055,7 +3055,7 @@ function factory() {
                 return false;
             if (match.member && signal[2] !== match.member)
                 return false;
-            if (match.arg0 && signal[3] !== match.arg0)
+            if (match.arg0 && (!signal[3] || signal[3][0] !== match.arg0))
                 return false;
             return true;
         }
@@ -3231,6 +3231,19 @@ function factory() {
             }
 
             return dfd.promise;
+        };
+
+        self.signal = function signal(path, iface, member, args, options) {
+            if (!channel || !channel.valid)
+                return;
+
+            var message = extend({ }, options, {
+                "signal": [ path, iface, member, args || [] ]
+            });
+
+            var payload = JSON.stringify(message);
+            dbus_debug("dbus:", payload);
+            channel.send(payload);
         };
 
         this.subscribe = function subscribe(match, callback, rule) {

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -62,25 +62,40 @@ on_filter_func (GDBusConnection *connection,
                 gpointer user_data)
 {
   GError *error = NULL;
-  GDBusMessage *reply;
+  GDBusMessage *reply = NULL;
 
-  if (incoming &&
-      g_dbus_message_get_message_type (message) == G_DBUS_MESSAGE_TYPE_METHOD_CALL &&
-      g_str_equal (g_dbus_message_get_path (message), "/bork") &&
-      g_str_equal (g_dbus_message_get_interface (message), "borkety.Bork") &&
-      g_str_equal (g_dbus_message_get_member (message), "Echo"))
+  if (incoming)
     {
-      reply = g_dbus_message_new_method_reply (message);
-      g_dbus_message_set_body (reply, g_dbus_message_get_body (message));
-      g_dbus_connection_send_message (connection, reply, G_DBUS_SEND_MESSAGE_FLAGS_NONE, NULL, &error);
-      if (error != NULL)
+      if (g_dbus_message_get_message_type (message) == G_DBUS_MESSAGE_TYPE_METHOD_CALL &&
+          g_str_equal (g_dbus_message_get_path (message), "/bork") &&
+          g_str_equal (g_dbus_message_get_interface (message), "borkety.Bork") &&
+          g_str_equal (g_dbus_message_get_member (message), "Echo"))
+      {
+        reply = g_dbus_message_new_method_reply (message);
+        g_dbus_message_set_body (reply, g_dbus_message_get_body (message));
+      }
+
+      if (g_dbus_message_get_message_type (message) == G_DBUS_MESSAGE_TYPE_SIGNAL &&
+          g_str_equal (g_dbus_message_get_path (message), "/bork") &&
+          g_str_equal (g_dbus_message_get_interface (message), "borkety.Bork"))
         {
-          g_warning ("Couldn't send DBus message: %s", error->message);
-          g_error_free (error);
+          reply = g_dbus_message_new_signal ("/bork", "borkety.Bork",
+                                             g_dbus_message_get_member (message));
+          g_dbus_message_set_body (reply, g_dbus_message_get_body (message));
         }
-      g_object_unref (reply);
-      g_object_unref (message);
-      return NULL;
+
+      if (reply)
+        {
+          g_dbus_connection_send_message (connection, reply, G_DBUS_SEND_MESSAGE_FLAGS_NONE, NULL, &error);
+          if (error != NULL)
+            {
+              g_warning ("Couldn't send DBus message: %s", error->message);
+              g_error_free (error);
+            }
+          g_object_unref (reply);
+          g_object_unref (message);
+          return NULL;
+        }
     }
 
   return message;


### PR DESCRIPTION
This adds a new DBus client.signal() javascript method and a "signal" message so we can emit signals from a DBus service implemented in javascript.
    
We use the new "meta" functionality to look up the parameter types for the given signal.

Depends on:

 * [x] #5458 
 * [x] #5459 
 * [x] #5464 
 * [x] #5465 
 * [x] #5492 
 * [x] #5500