### PR TITLE
storaged: Fix flicker of storage-details box

### DIFF
--- a/pkg/storaged/details.js
+++ b/pkg/storaged/details.js
@@ -580,7 +580,7 @@
 
         function hide() {
             name = null;
-            $('#storage-detail').hide();
+            utils.hide("#storage-detail");
         }
 
         function show(t, n) {
@@ -593,28 +593,26 @@
             name = n;
             render();
 
-            React.unmountComponentAtNode($("#detail-content")[0]);
+            var content = document.querySelector("#detail-content");
+            React.unmountComponentAtNode(content);
             if (type == 'block') {
                 React.render(React.createElement(ContentViews.Block,
                                                  { client: client,
                                                    name: name
-                                                 }),
-                             $("#detail-content")[0]);
+                                                 }), content);
             } else if (type == 'mdraid') {
                 React.render(React.createElement(ContentViews.MDRaid,
                                                  { client: client,
                                                    name: name
-                                                 }),
-                             $("#detail-content")[0]);
+                                                 }), content);
             } else if (type == 'vgroup') {
                 React.render(React.createElement(ContentViews.VGroup,
                                                  { client: client,
                                                    name: name
-                                                 }),
-                             $("#detail-content")[0]);
+                                                 }), content);
             }
 
-            $('#storage-detail').show();
+            utils.show_soon("#storage-detail", !!content.firstChild);
         }
 
         return {

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -493,5 +493,27 @@
         return this;
     };
 
+    /* Prevent flicker due to the marriage of jQuery and React here */
+    utils.hide = function hide(selector) {
+        var element = document.querySelector("#storage-detail");
+        element.setAttribute("hidden", "");
+    };
+
+    utils.show_soon = function show_soon(selector, ready) {
+        var element = document.querySelector(selector);
+        if (!element.hasAttribute("hidden"))
+            return;
+        var val = element.getAttribute("hidden");
+        if (ready) {
+            element.removeAttribute("hidden");
+            window.clearTimeout(parseInt(val, 10));
+        } else if (!val) {
+            val = window.setTimeout(function() {
+                show_soon(selector, true);
+            }, 2000);
+            element.setAttribute("hidden", String(val));
+        }
+    };
+
     module.exports = utils;
 }());

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -46,6 +46,7 @@ class TestStorage(StorageCase):
         b.click('tr:contains("%s")' % dev)
         b.wait_visible('#storage-detail')
 
+        b.wait_visible('button:contains(Create partition table)')
         b.click('button:contains(Create partition table)')
         self.dialog({ "type": "gpt" })
         self.content_row_wait_in_col(1, 1, "Free Space")


### PR DESCRIPTION
This box is partially populated from HTML and jQuery and partially populated from React. Wait until React has had a chance to populate it or one second has passed before showing anything.
