### PR TITLE
realmd: Fix failure detected by better handling of error cases

### DIFF
--- a/pkg/realmd/operation.js
+++ b/pkg/realmd/operation.js
@@ -358,7 +358,9 @@
                     call
                         .fail(function(ex) {
                             busy(null);
-                            if (ex.name != "com.redhat.Cockpit.Error.Cancelled") {
+                            if (ex.name == "org.freedesktop.realmd.Error.Cancelled") {
+                                $(dialog).modal("hide");
+                            } else {
                                 console.log("Failed to join domain: " + realm.Name + ": " + ex);
                                 $(".realms-op-error").empty().text(ex + " ").show();
                                 if (diagnostics) {
@@ -385,7 +387,7 @@
 
         function cancel() {
             if (operation) {
-                realmd.call(SERVICE, MANAGER, "Cancel", [ operation ]);
+                realmd.call(MANAGER, SERVICE, "Cancel", [ operation ]);
                 busy(null);
                 return true;
             }


### PR DESCRIPTION
We were passing the arguments the wrong way around here. It's good
to see this get caught during testing because we shored up the
argument parsing in another commit.