### PR TITLE
Export DBus objects from Javascript

### DIFF
--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -907,6 +907,35 @@ client.meta(data)
 
   </refsection>
 
+  <refsection id="cockpit-dbus-publish">
+    <title>client.publish()</title>
+<programlisting>
+published = client.publish(path, interface, object, [options])
+</programlisting>
+
+    <para>Publish a DBus <code>interface</code> at the specified object <code>path</code>.
+      Methods on the Javascript <code>object</code> will be invoked when DBus methods on the
+      specified <code>interface</code> are invoked by callers.</para>
+
+    <para>The meta data for the DBus interface must have been populated using the
+      <link linkend="cockpit-dbus-meta"><code>client.meta()</code></link> function. The
+      returned <code>published</code> object is a promise object. It will resolve when the
+      DBus interface has been published on the bus. It is not an error to publish the same
+      interface and path repeatedly: Previously published objects at the interface and
+      path are replaced by those published later.</para>
+  </refsection>
+
+  <refsection id="cockpit-dbus-published">
+    <title>published.remove()</title>
+<programlisting>
+published.remove()
+</programlisting>
+
+    <para>Un-publishes a DBus interface at an object path. This method can be invoked
+      on the <code>published</code> result returned from the
+      <link linkend="cockpit-dbus-publish"><code>client.publish()</code></link> function.</para>
+  </refsection>
+
   <refsection id="cockpit-dbus-variant">
     <title>cockpit.variant()</title>
 <programlisting>

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -397,6 +397,9 @@ invalid.
 An optional "id" field indicates that a response is desired, which will be
 sent back in a "reply" or "error" message with the same "id" field.
 
+If an interface has been exported, then the bridge will send "call" messages
+in its direction for calls received for on that interface.
+
 Method reply messages are JSON objects with a "reply" field whose value is
 an array, the array contains another array of out arguments, or null if
 the DBus reply had no body.
@@ -572,6 +575,25 @@ is unowned.
     {
         "owner": "1:"
     }
+
+A "publish" message can be used to export DBus interfaces on the bus. The bridge
+will then send "call" messages back to the frontend for each method invocation
+on the published interface and object path. The interface must first be described
+with DBus meta information. If a cookie is specified then a reply will be sent
+when the interface is published. If the interface is already published at the given
+path, it will be replaced.
+
+   {
+       "publish": [ "/a/path", "org.Interface" ],
+       "id": "cookie"
+   }
+
+An "unpublish" message will unexport a DBus interface on the bus. It is not an
+error if no such interface has been published.
+
+   {
+       "unpublish": [ "/a/path", "org.Interface" ],
+   }
 
 DBus types are encoded in various places in these messages, such as the
 arguments. These types are encoded as follows:


### PR DESCRIPTION
Export DBus objects from a DBus channel.

 * [x] ```cockpitdbusjson.c``` implementation
 * [x] ```cockpit.js``` implementation
 * [x] Unit tests
 * [x] Documentation

Depends on:
 * [x] #5466 
 * [x] #5465 
 * [x] #5464 
 * [x] #5459 
 * [x] #5492
 * [x] #5491 
 * [x] #5458
 * [x] #5500