### PR TITLE
Add Windows Internet Explorer selenium image

### DIFF
--- a/bots/image-create
+++ b/bots/image-create
@@ -142,7 +142,7 @@ class MachineBuilder:
         script = os.path.join(BOTS, "images", "scripts", "%s.setup" % (self.machine.image, ))
 
         if not os.path.exists(script):
-            raise testvm.Failure("Unsupported image %s: %s not found." % (self.machine.image, script))
+            return
 
         self.machine.message("Running setup script %s" % (script))
         if args.no_build:

--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -80,7 +80,8 @@ REDHAT_STORE = "https://cockpit-11.e2e.bos.redhat.com:8493"
 STORES = {
     "rhel-7": REDHAT_STORE,
     "rhel-7-4": REDHAT_STORE,
-    "rhel-atomic": REDHAT_STORE
+    "rhel-atomic": REDHAT_STORE,
+    "windows-8": REDHAT_STORE
 }
 
 import argparse

--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -37,6 +37,7 @@ REFRESH = {
     'rhel-7': { },
     'rhel-7-4': { },
     'rhel-atomic': { }
+    'windows-8': { "refresh-days": 30 },
 }
 
 import argparse

--- a/bots/images/scripts/windows-8.bootstrap
+++ b/bots/images/scripts/windows-8.bootstrap
@@ -1,0 +1,66 @@
+#! /bin/bash
+# https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/
+# http://www.microsoft.com/en-us/download/details.aspx?id=44069 - not needed d:\Windows8.1-KB2990999-x86.msu
+
+set -ex
+
+BASE=$(dirname $0)
+
+ORIGIN="$1"
+VM_NAME=win8.1
+
+test -e IE11.Win8.1.For.Windows.VMware.zip || wget https://az412801.vo.msecnd.net/vhd/VMBuild_20141027/VMware/IE11/Windows/IE11.Win8.1.For.Windows.VMware.zip
+test -e selenium.zip || wget http://selenium-release.storage.googleapis.com/2.53/IEDriverServer_Win32_2.53.1.zip -O selenium.zip
+test -e java-installer.exe || wget http://javadl.oracle.com/webapps/download/AutoDL?BundleId=216432 -O java-installer.exe
+test -e selenium.jar || wget https://goo.gl/Lyo36k -O selenium.jar
+
+unzip -o IE11.Win8.1.For.Windows.VMware.zip
+unzip -o selenium.zip
+
+cat <<'EOF' > Autorun.inf
+[autorun]
+open=install.exe
+label=Selenium installer
+EOF
+
+cat <<'EOF' > selenium.bat
+netsh interface ipv4 set address name="Ethernet 3" static 10.111.112.10 255.255.240.0 || netsh interface ipv4 set address name="Ethernet 4" static 10.111.112.10 255.255.240.0
+timeout 20
+START "hub" java -jar C:\selenium\selenium.jar -role hub
+timeout 20
+java -jar C:\selenium\selenium.jar -role node  -hub http://localhost:4444/grid/register -browser browserName="internet explorer"
+timeout 50
+EOF
+
+cat <<'EOF' > install.bat
+net file 1>nul 2>nul && goto :run || powershell -ex unrestricted -Command "Start-Process -Verb RunAs -FilePath '%comspec%' -ArgumentList '/c %~fnx0 %*'"
+goto :eof
+:run
+netsh advfirewall firewall add rule name="Open Port 4444" dir=in action=allow protocol=TCP localport=4444
+netsh advfirewall firewall add rule name="Open Port 5555" dir=in action=allow protocol=TCP localport=5555
+NetSh Advfirewall set allprofiles state off
+d:\java-installer.exe /s
+mkdir c:\selenium
+echo f | xcopy /f /y d:\selenium.jar c:\selenium\selenium.jar
+echo f | xcopy /f /y d:\selenium.bat c:\selenium\selenium.bat
+echo f | xcopy /f /y d:\IEDriverServer.exe c:\selenium\IEDriverServer.exe
+echo f | xcopy /f /y d:\IEDriverServer.exe c:\Windows\system32\IEDriverServer.exe
+REG ADD "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Run" /V "Selenium Hub" /t REG_SZ /F /D "C:\selenium\selenium.bat"
+REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BFCACHE"
+REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BFCACHE" /v iexplore.exe /t REG_DWORD /d 0 /f
+REG ADD HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System /v EnableLUA /t REG_DWORD /d 0 /f
+timeout 5
+shutdown -s -t 0 -f
+EOF
+
+CR=$(printf '\r')
+sed -i "s/\$/$CR/" *.bat Autorun.inf
+genisoimage -output wininit.iso -volid cidata -joliet *.bat *.exe selenium.jar Autorun.inf
+
+echo "Converting vmdk to qcow2..."
+qemu-img convert -f vmdk -O qcow2 *.vmdk $ORIGIN
+echo "MANUAL part of installation, open graphics console and run D:\\install.bat"
+virt-install -n $VM_NAME -r 4000 --vcpus=4 --os-type=windows --disk $ORIGIN,device=disk --network user -c wininit.iso --noautoconsole --wait=-1 --noreboot
+echo "Installation finished"
+# virsh destroy $VM_NAME
+# virsh undefine $VM_NAME

--- a/bots/images/windows-8
+++ b/bots/images/windows-8
@@ -1,0 +1,1 @@
+windows-8-ce3479748791c1fcf511d5a0d0fc62e0ac9ca006caef19d6a7b2081b97c0108a.qcow2

--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -33,9 +33,15 @@ KVM_TASKS = [
     "image-refresh"
 ]
 
+# RHEL tasks have to be done inside Red Hat network
 REDHAT_TASKS = [
     "rhel-7",
     "rhel-atomic"
+]
+
+# Windows tasks have to be done by a human
+WINDOWS_TASKS = [
+    "windows"
 ]
 
 # Server to tell us if we can create Red Hat images
@@ -78,6 +84,8 @@ def main():
         if not kvm and contains_any(result, KVM_TASKS):
             continue
         elif not redhat and contains_any(result, REDHAT_TASKS):
+            continue
+        elif contains_any(result, WINDOWS_TASKS):
             continue
         sys.stdout.write(result + "\n")
 


### PR DESCRIPTION
This is a semiautomated script for creating MS Windows selenium hub with Internet Explorer for testing purposes. It uses the readily available VM images from Microsoft which are designed for testing.
    
Regenerating this image requires a human to perform one task, hence the bots will file issues about it but not refresh themselves.
    
This image should not be shared publicly. 
   
 * [x] Integrated into image-create and image-refresh logic
 * [x] Cleaned up messages
 * [x] Added expected IP address for Selenium hub
 * [x] Use CRNL for new lines in scripts
 * [x] image-refresh fedora-24
 * [x] Upload windows-8 image