### PR TITLE
ws: Refactor spawning authentication processes

### DIFF
--- a/containers/kubernetes/cockpit.conf.tmpl
+++ b/containers/kubernetes/cockpit.conf.tmpl
@@ -11,18 +11,15 @@ LoginTitle = Openshift Cockpit
 LoginTitle = Kubernetes Cockpit
 
 [Negotiate]
-Action = spawn-login-with-decoded
 Command = {{.login_command}}
 {{end}}
 {{end}}
 
 [Basic]
-Action = spawn-login-with-decoded
 Command = {{.login_command}}
 
 {{if .oauth_url }}
 [Bearer]
-Action = spawn-login-with-header
 Command = {{.login_command}}
 
 [OAuth]

--- a/pkg/kubernetes/standalone/src/cockpit-kube-auth/main.go
+++ b/pkg/kubernetes/standalone/src/cockpit-kube-auth/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 const MAX_BUFFER = 64 * 1024
-const AUTH_FD = 3;
+const AUTH_FD = 3
 
 func jsonError(err error) ([]byte, error) {
 	log.Println(err)
@@ -68,17 +68,14 @@ func sendAuthResponse(fd int, response []byte) {
 }
 
 func main() {
-	if len(os.Args) < 2 {
-		log.Fatal("Missing required authentication type")
-	}
-
+	authType := os.Getenv("COCKPIT_AUTH_MESSAGE_TYPE")
 	authData, err := readData(AUTH_FD)
 	if err != nil {
 		log.Fatal("Error reading authentication data ", err)
 	}
 
 	client := helpers.NewClient()
-	response, loginErr := client.Login(string(os.Args[1]), string(authData))
+	response, loginErr := client.Login(authType, string(authData))
 	if loginErr != nil {
 		var respErr error
 		response, respErr = jsonError(loginErr)
@@ -88,8 +85,8 @@ func main() {
 	}
 
 	sendAuthResponse(AUTH_FD, response)
-	e := syscall.Close(AUTH_FD);
-	if (e != nil) {
+	e := syscall.Close(AUTH_FD)
+	if e != nil {
 		log.Fatal("Error closing auth FD ", e)
 	}
 

--- a/src/common/cockpitknownhosts.c
+++ b/src/common/cockpitknownhosts.c
@@ -272,7 +272,7 @@ cockpit_is_host_known (const gchar *known_hosts_file,
       return FALSE;
     }
 
-  hostport = g_strdup_printf ("[%s:%d]", host, port);
+  hostport = g_strdup_printf ("[%s]:%d", host, port);
   while (fgets (buffer, sizeof (buffer), file))
     {
       gchar **tokens = NULL;

--- a/src/common/mock_known_hosts
+++ b/src/common/mock_known_hosts
@@ -13,10 +13,10 @@ single-alone ssh-rsa key-goes-here
 # Single with wildcards
 single-wild* ssh-rsa key-goes-here
 single-?.test ssh-rsa key-goes-here
-[single-portwild:*] ssh-rsa key-goes-here
+[single-portwild]:* ssh-rsa key-goes-here
 
 # Multiple
-multiple1,[multiple2:1111],multiple-?.test,multiple-wild* ssh-rsa key-goes-here
+multiple1,[multiple2]:1111,multiple-?.test,multiple-wild* ssh-rsa key-goes-here
 
 # hashedmachine
 |1|6ipvcCN2lAo9KvNGuSvRKWI2gm4=|nRtFuoyz7Am0MsCzUnmosLd7c5I= ssh-dss key-goes-here

--- a/src/common/mock_known_hosts
+++ b/src/common/mock_known_hosts
@@ -8,7 +8,7 @@ too many and too few
 single-alone ssh-rsa key-goes-here
 
 # Single with ports
-[single-port:1111] ssh-rsa key-goes-here
+[single-port]:1111 ssh-rsa key-goes-here
 
 # Single with wildcards
 single-wild* ssh-rsa key-goes-here
@@ -21,4 +21,4 @@ multiple1,[multiple2]:1111,multiple-?.test,multiple-wild* ssh-rsa key-goes-here
 # hashedmachine
 |1|6ipvcCN2lAo9KvNGuSvRKWI2gm4=|nRtFuoyz7Am0MsCzUnmosLd7c5I= ssh-dss key-goes-here
 # hashedmachine2:2020
-|1|Hja+m2ZcjOLzh0gEESIIA7sN4lY=|E9JyE9szrOt+M0V28rH6tetct+w=  ssh-dss key-goes-here
+|1|Y4ddsGwZSw3EnUiTRy/ez3C7PeI=|d6/ii1bPuqJLxu4OsdL8LUmpXJU= ssh-dss key-goes-here

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -210,6 +210,7 @@ WS_CHECKS = \
 	test-creds \
 	test-auth \
 	test-authoptions \
+	test-authssh \
 	test-sshtransport \
 	test-sshagent \
 	test-webservice \
@@ -234,6 +235,16 @@ test_auth_LDADD = \
 test_authoptions_CFLAGS = $(cockpit_ws_CFLAGS)
 test_authoptions_SOURCES = src/ws/test-authoptions.c
 test_authoptions_LDADD = \
+	libcockpit-ws.a \
+	$(cockpit_ws_LDADD)
+
+test_authssh_CFLAGS = $(cockpit_ws_CFLAGS)
+test_authssh_SOURCES = \
+	src/ws/test-authssh.c \
+	src/ws/mock-auth.c \
+	src/ws/mock-auth.h \
+	$(NULL)
+test_authssh_LDADD = \
 	libcockpit-ws.a \
 	$(cockpit_ws_LDADD)
 

--- a/src/ws/cockpitauth.h
+++ b/src/ws/cockpitauth.h
@@ -38,10 +38,6 @@ G_BEGIN_DECLS
 #define COCKPIT_AUTH_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), COCKPIT_TYPE_AUTH, CockpitAuthClass))
 #define COCKPIT_IS_AUTH_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), COCKPIT_TYPE_AUTH))
 
-typedef enum {
-    COCKPIT_AUTH_COOKIE_INSECURE = 1 << 1
-} CockpitAuthFlags;
-
 typedef struct _CockpitAuth        CockpitAuth;
 typedef struct _CockpitAuthClass   CockpitAuthClass;
 
@@ -68,13 +64,14 @@ struct _CockpitAuthClass
   /* vfunc */
   void           (* login_async)         (CockpitAuth *auth,
                                           const gchar *path,
+                                          GIOStream *connection,
                                           GHashTable *headers,
-                                          const gchar *remote_peer,
                                           GAsyncReadyCallback callback,
                                           gpointer user_data);
 
   CockpitCreds * (* login_finish)        (CockpitAuth *auth,
                                           GAsyncResult *result,
+                                          GIOStream *connection,
                                           GHashTable *out_headers,
                                           JsonObject **prompt_data,
                                           CockpitTransport **transport,
@@ -89,14 +86,14 @@ gchar *         cockpit_auth_nonce           (CockpitAuth *self);
 
 void            cockpit_auth_login_async     (CockpitAuth *self,
                                               const gchar *path,
+                                              GIOStream *connection,
                                               GHashTable *headers,
-                                              const gchar *remote_peer,
                                               GAsyncReadyCallback callback,
                                               gpointer user_data);
 
 JsonObject *    cockpit_auth_login_finish    (CockpitAuth *self,
                                               GAsyncResult *result,
-                                              CockpitAuthFlags flags,
+                                              GIOStream *connection,
                                               GHashTable *out_headers,
                                               GError **error);
 
@@ -106,8 +103,10 @@ CockpitWebService *  cockpit_auth_check_cookie    (CockpitAuth *self,
 
 gchar *         cockpit_auth_parse_application    (const gchar *path);
 
-GBytes *        cockpit_auth_parse_authorization      (GHashTable *headers,
-                                                       gboolean base64_decode);
+GBytes *        cockpit_auth_steal_authorization      (GHashTable *headers,
+                                                       GIOStream *connection,
+                                                       const gchar **ret_type,
+                                                       const gchar **ret_conversation);
 
 gchar *        cockpit_auth_parse_authorization_type  (GHashTable *headers);
 

--- a/src/ws/cockpitauthoptions.c
+++ b/src/ws/cockpitauthoptions.c
@@ -176,9 +176,14 @@ cockpit_ssh_options_to_env (CockpitSshOptions *options,
 
   env = set_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA",
                              knownhosts_data);
-  env = set_environment_val (env, "COCKPIT_SSH_BRIDGE_COMMAND",
-                             options->command);
   env = set_environment_val (env, "KRB5CCNAME", options->krb5_ccache_name);
+
+  /* Don't reset these vars unless we have values for them */
+  if (options->command)
+    {
+      env = set_environment_val (env, "COCKPIT_SSH_BRIDGE_COMMAND",
+                                 options->command);
+    }
 
   if (options->agent_fd)
     {

--- a/src/ws/cockpitauthprocess.c
+++ b/src/ws/cockpitauthprocess.c
@@ -70,7 +70,7 @@ struct  _CockpitAuthProcess {
   gboolean closed;
   gboolean pipe_closed;
 
-  gchar *id;
+  gchar *conversation;
   gchar *logname;
   gchar *name;
 
@@ -96,7 +96,7 @@ enum
   PROP_IDLE_TIMEOUT,
   PROP_PIPE_TIMEOUT,
   PROP_PROCESS_AUTH_FD,
-  PROP_ID,
+  PROP_CONVERSATION,
   PROP_LOGNAME,
   PROP_NAME,
 };
@@ -167,7 +167,7 @@ cockpit_auth_process_finalize (GObject *object)
     close (self->child_data.auth_fd);
   self->child_data.auth_fd = -1;
 
-  g_free (self->id);
+  g_free (self->conversation);
   g_free (self->logname);
   g_free (self->name);
   G_OBJECT_CLASS (cockpit_auth_process_parent_class)->finalize (object);
@@ -377,7 +377,7 @@ cockpit_auth_process_init (CockpitAuthProcess *self)
   self->max_idle = default_timeout;
   self->max_wait_pipe = default_timeout;
   self->send_signal = FALSE;
-  self->id = NULL;
+  self->conversation = NULL;
 }
 
 static void
@@ -445,8 +445,8 @@ cockpit_auth_process_set_property (GObject *object,
   case PROP_PROCESS_AUTH_FD:
     self->child_data.wanted_fd_number = g_value_get_uint (value);
     break;
-  case PROP_ID:
-    self->id = g_value_dup_string (value);
+  case PROP_CONVERSATION:
+    self->conversation = g_value_dup_string (value);
     break;
   case PROP_LOGNAME:
     self->logname = g_value_dup_string (value);
@@ -502,8 +502,8 @@ cockpit_auth_process_class_init (CockpitAuthProcessClass *klass)
                                                       G_PARAM_CONSTRUCT_ONLY |
                                                       G_PARAM_STATIC_STRINGS));
 
-  g_object_class_install_property (gobject_class, PROP_ID,
-                                   g_param_spec_string ("id",
+  g_object_class_install_property (gobject_class, PROP_CONVERSATION,
+                                   g_param_spec_string ("conversation",
                                                         NULL,
                                                         NULL,
                                                         NULL,
@@ -697,10 +697,10 @@ cockpit_auth_process_get_authenticated_user (CockpitAuthProcess *self,
 }
 
 const gchar *
-cockpit_auth_process_get_id (CockpitAuthProcess *self)
+cockpit_auth_process_get_conversation (CockpitAuthProcess *self)
 {
   g_return_val_if_fail (self != NULL, NULL);
-  return self->id;
+  return self->conversation;
 }
 
 /* ----------------------------------------------------------------------------

--- a/src/ws/cockpitauthprocess.h
+++ b/src/ws/cockpitauthprocess.h
@@ -36,8 +36,6 @@ typedef struct      _CockpitAuthProcessClass        CockpitAuthProcessClass;
 
 GType              cockpit_auth_process_get_type    (void) G_GNUC_CONST;
 
-const gchar *      cockpit_auth_process_get_id      (CockpitAuthProcess *self);
-
 gboolean           cockpit_auth_process_start       (CockpitAuthProcess *self,
                                                      const gchar** command_args,
                                                      const gchar** env,
@@ -62,6 +60,7 @@ const gchar *      cockpit_auth_process_get_authenticated_user  (CockpitAuthProc
                                                                  JsonObject **prompt_data,
                                                                  GError **error);
 
+const gchar *      cockpit_auth_process_get_conversation        (CockpitAuthProcess *self);
 G_END_DECLS
 
 #endif

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -57,9 +57,6 @@ const gchar *cockpit_ws_ssh_program =
 
 const gchar *cockpit_ws_bridge_program = NULL;
 
-const gchar *cockpit_ws_known_hosts =
-    PACKAGE_LOCALSTATE_DIR "/known_hosts";
-
 const gchar *cockpit_ws_default_host_header =
     "0.0.0.0:0"; /* Must be something invalid */
 

--- a/src/ws/mock-auth.h
+++ b/src/ws/mock-auth.h
@@ -37,3 +37,7 @@ GHashTable *     mock_auth_basic_header  (const gchar *user,
 
 void             mock_auth_set_failure_data (MockAuth *self,
                                              JsonObject *data);
+
+void            mock_auth_include_cookie_as_if_client (GHashTable *resp_headers,
+                                                       GHashTable *req_headers,
+                                                       const gchar *cookie_name);

--- a/src/ws/mock-config/cockpit/cockpit.conf
+++ b/src/ws/mock-config/cockpit/cockpit.conf
@@ -16,11 +16,9 @@ Shell = /second/test.html
 MaxStartups = 1
 
 [badcommand]
-action = spawn-login-with-header
 command = bad-command
 
 [testscheme]
-action = spawn-login-with-header
 command = mock-auth-command
 response-timeout = 2
 
@@ -34,12 +32,10 @@ action = remote-login-ssh
 command = mock-auth-command
 
 [testscheme-fd-4]
-action = spawn-login-with-header
 command = mock-auth-command
 authFD = 4
 
 [timeout-scheme]
-action = spawn-login-with-header
 command = mock-auth-command
 timeout = 1
 

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -297,7 +297,8 @@ dup_string (const char *str,
 }
 
 static const char *
-gssapi_strerror (OM_uint32 major_status,
+gssapi_strerror (gss_OID mech_type,
+                 OM_uint32 major_status,
                  OM_uint32 minor_status)
 {
   static char buffer[1024];
@@ -344,7 +345,7 @@ gssapi_strerror (OM_uint32 major_status,
    for (;;)
      {
        major = gss_display_status (&minor, minor_status, GSS_C_MECH_CODE,
-                                   GSS_C_NULL_OID, &ctx, &status);
+                                   mech_type, &ctx, &status);
        if (GSS_ERROR (major))
          break;
 
@@ -709,7 +710,7 @@ map_gssapi_to_local (gss_name_t name,
           major = gss_display_name (&minor, name, &display, NULL);
           if (GSS_ERROR (major))
             {
-              warnx ("couldn't get gssapi display name: %s", gssapi_strerror (major, minor));
+              warnx ("couldn't get gssapi display name: %s", gssapi_strerror (mech_type, major, minor));
             }
           else
             {
@@ -728,7 +729,7 @@ map_gssapi_to_local (gss_name_t name,
         }
       else
         {
-          warnx ("couldn't map gssapi name to local user: %s", gssapi_strerror (major, minor));
+          warnx ("couldn't map gssapi name to local user: %s", gssapi_strerror (mech_type, major, minor));
         }
     }
 
@@ -778,7 +779,7 @@ perform_gssapi (void)
   if (GSS_ERROR (major))
     {
       /* This is a routine error message, don't litter */
-      msg = gssapi_strerror (major, minor);
+      msg = gssapi_strerror (mech_type, major, minor);
       if (input.length == 0 && !strstr (msg, "nonexistent or empty"))
         warnx ("couldn't acquire server credentials: %s", msg);
       res = PAM_AUTHINFO_UNAVAIL;
@@ -802,7 +803,7 @@ perform_gssapi (void)
 
       if (GSS_ERROR (major))
         {
-          warnx ("gssapi auth failed: %s", gssapi_strerror (major, minor));
+          warnx ("gssapi auth failed: %s", gssapi_strerror (mech_type, major, minor));
           goto out;
         }
 
@@ -850,7 +851,7 @@ out:
 #ifdef HAVE_GSS_IMPORT_CRED
       major = gss_export_cred (&minor, client, &export);
       if (GSS_ERROR (major))
-        warnx ("couldn't export gssapi credentials: %s", gssapi_strerror (major, minor));
+        warnx ("couldn't export gssapi credentials: %s", gssapi_strerror (mech_type, major, minor));
       else if (export.value)
         write_auth_hex ("gssapi-creds", export.value, export.length);
 #else

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -680,6 +680,7 @@ perform_gssapi (void)
   gss_buffer_desc output = GSS_C_EMPTY_BUFFER;
   gss_buffer_desc local = GSS_C_EMPTY_BUFFER;
   gss_buffer_desc display = GSS_C_EMPTY_BUFFER;
+  gss_buffer_desc export = GSS_C_EMPTY_BUFFER;
   gss_name_t name = GSS_C_NO_NAME;
   gss_ctx_id_t context = GSS_C_NO_CONTEXT;
   gss_OID mech_type = GSS_C_NO_OID;
@@ -801,11 +802,11 @@ out:
   if (caps & GSS_C_DELEG_FLAG && client != GSS_C_NO_CREDENTIAL)
     {
 #ifdef HAVE_GSS_IMPORT_CRED
-      major = gss_export_cred (&minor, client, &output);
+      major = gss_export_cred (&minor, client, &export);
       if (GSS_ERROR (major))
         warnx ("couldn't export gssapi credentials: %s", gssapi_strerror (major, minor));
-      else if (output.value)
-        write_auth_hex ("gssapi-creds", output.value, output.length);
+      else if (export.value)
+        write_auth_hex ("gssapi-creds", export.value, export.length);
 #else
       /* cockpit-ws will complain for us, if they're ever used */
       write_auth_hex ("gssapi-creds", (void *)"", 0);
@@ -818,6 +819,8 @@ out:
     gss_release_buffer (&minor, &display);
   if (output.value)
     gss_release_buffer (&minor, &output);
+  if (export.value)
+    gss_release_buffer (&minor, &export);
   if (local.value)
     gss_release_buffer (&minor, &local);
   if (client != GSS_C_NO_CREDENTIAL)

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -669,6 +669,64 @@ perform_basic (void)
   return pamh;
 }
 
+static char *
+map_gssapi_to_local (gss_name_t name,
+                     gss_OID mech_type)
+{
+  gss_buffer_desc local = GSS_C_EMPTY_BUFFER;
+  gss_buffer_desc display = GSS_C_EMPTY_BUFFER;
+  OM_uint32 major, minor;
+  char *str = NULL;
+
+  major = gss_localname (&minor, name, mech_type, &local);
+  if (major == GSS_S_COMPLETE)
+    {
+      minor = 0;
+      str = dup_string (local.value, local.length);
+      debug ("mapped gssapi name to local user '%s'", str);
+
+      if (!getpwnam (str))
+        {
+          /* If the local user doesn't exist, pretend gss_localname() failed */
+          free (str);
+          str = NULL;
+          major = GSS_S_FAILURE;
+          minor = KRB5_NO_LOCALNAME;
+        }
+    }
+
+  if (!str)
+    {
+      if (minor == (OM_uint32)KRB5_NO_LOCALNAME ||
+          minor == (OM_uint32)KRB5_LNAME_NOTRANS)
+        {
+          major = gss_display_name (&minor, name, &display, NULL);
+          if (GSS_ERROR (major))
+            {
+              warnx ("couldn't get gssapi display name: %s", gssapi_strerror (major, minor));
+            }
+          else
+            {
+              str = dup_string (display.value, display.length);
+              debug ("no local user mapping for gssapi name '%s'", str);
+            }
+        }
+      else
+        {
+          warnx ("major is %d minor is %d", (int)major, (int)minor);
+          warnx ("couldn't map gssapi name to local user: %s", gssapi_strerror (major, minor));
+        }
+    }
+
+  if (display.value)
+    gss_release_buffer (&minor, &display);
+  if (local.value)
+    gss_release_buffer (&minor, &local);
+
+  return str;
+}
+
+
 static pam_handle_t *
 perform_gssapi (void)
 {
@@ -678,8 +736,6 @@ perform_gssapi (void)
   gss_cred_id_t server = GSS_C_NO_CREDENTIAL;
   gss_buffer_desc input = GSS_C_EMPTY_BUFFER;
   gss_buffer_desc output = GSS_C_EMPTY_BUFFER;
-  gss_buffer_desc local = GSS_C_EMPTY_BUFFER;
-  gss_buffer_desc display = GSS_C_EMPTY_BUFFER;
   gss_buffer_desc export = GSS_C_EMPTY_BUFFER;
   gss_name_t name = GSS_C_NO_NAME;
   gss_ctx_id_t context = GSS_C_NO_CONTEXT;
@@ -756,49 +812,11 @@ perform_gssapi (void)
       write_auth_begin ();
     }
 
-  major = gss_localname (&minor, name, mech_type, &local);
-  if (major == GSS_S_COMPLETE)
-    {
-      minor = 0;
-      str = dup_string (local.value, local.length);
-      debug ("mapped gssapi name to local user '%s'", str);
+  str = map_gssapi_to_local (name, mech_type);
+  if (!str)
+    goto out;
 
-      if (getpwnam (str))
-        {
-          res = pam_start ("cockpit", str, &conv, &pamh);
-        }
-      else
-        {
-          /* If the local user doesn't exist, pretend gss_localname() failed */
-          free (str);
-          str = NULL;
-          major = GSS_S_FAILURE;
-          minor = KRB5_NO_LOCALNAME;
-        }
-    }
-
-  if (major != GSS_S_COMPLETE)
-    {
-      if (minor == (OM_uint32)KRB5_NO_LOCALNAME || minor == (OM_uint32)KRB5_LNAME_NOTRANS)
-        {
-          major = gss_display_name (&minor, name, &display, NULL);
-          if (GSS_ERROR (major))
-            {
-              warnx ("couldn't get gssapi display name: %s", gssapi_strerror (major, minor));
-              goto out;
-            }
-
-          str = dup_string (display.value, display.length);
-          debug ("no local user mapping for gssapi name '%s'", str);
-
-          res = pam_start ("cockpit", str, &conv, &pamh);
-        }
-      else
-        {
-          warnx ("couldn't map gssapi name to local user: %s", gssapi_strerror (major, minor));
-          goto out;
-        }
-    }
+  res = pam_start ("cockpit", str, &conv, &pamh);
 
   if (res != PAM_SUCCESS)
     errx (EX, "couldn't start pam: %s", pam_strerror (NULL, res));
@@ -829,14 +847,10 @@ out:
 
   write_auth_end ();
 
-  if (display.value)
-    gss_release_buffer (&minor, &display);
   if (output.value)
     gss_release_buffer (&minor, &output);
   if (export.value)
     gss_release_buffer (&minor, &export);
-  if (local.value)
-    gss_release_buffer (&minor, &local);
   if (client != GSS_C_NO_CREDENTIAL)
     gss_release_cred (&minor, &client);
   if (server != GSS_C_NO_CREDENTIAL)

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -700,6 +700,8 @@ perform_gssapi (void)
   debug ("reading kerberos auth from cockpit-ws");
   input.value = read_seqpacket_message (AUTH_FD, "gssapi data", &input.length);
 
+  write_auth_begin ();
+
   debug ("acquiring server credentials");
   major = gss_acquire_cred (&minor, GSS_C_NO_NAME, GSS_C_INDEFINITE, GSS_C_NO_OID_SET,
                             GSS_C_ACCEPT, &server, NULL, NULL);
@@ -713,26 +715,46 @@ perform_gssapi (void)
       goto out;
     }
 
-  major = gss_accept_sec_context (&minor, &context, server, &input,
-                                  GSS_C_NO_CHANNEL_BINDINGS, &name, &mech_type,
-                                  &output, &flags, &caps, &client);
-
-  if (GSS_ERROR (major))
+  for (;;)
     {
-      warnx ("gssapi auth failed: %s", gssapi_strerror (major, minor));
-      goto out;
-    }
+      debug ("gssapi negotiation");
 
-  /*
-   * In general gssapi mechanisms can require multiple challenge response
-   * iterations keeping &context between each, however Kerberos doesn't
-   * require this, so we don't care :O
-   *
-   * If we ever want this to work with something other than Kerberos, then
-   * we'll have to have some sorta session that holds the context.
-   */
-  if (major & GSS_S_CONTINUE_NEEDED)
-    goto out;
+      if (client != GSS_C_NO_CREDENTIAL)
+        gss_release_cred (&minor, &client);
+      if (name != GSS_C_NO_NAME)
+        gss_release_name (&minor, &name);
+      if (output.value)
+        gss_release_buffer (&minor, &output);
+
+      major = gss_accept_sec_context (&minor, &context, server, &input,
+                                      GSS_C_NO_CHANNEL_BINDINGS, &name, &mech_type,
+                                      &output, &flags, &caps, &client);
+
+      if (GSS_ERROR (major))
+        {
+          warnx ("gssapi auth failed: %s", gssapi_strerror (major, minor));
+          goto out;
+        }
+
+      write_auth_hex ("gssapi-output", output.value, output.length);
+
+      if ((major & GSS_S_CONTINUE_NEEDED) == 0)
+        break;
+
+      debug ("need to continue gssapi negotiation");
+
+      /*
+       * The GSSAPI mechanism can require multiple chanllenge response
+       * iterations ... so do that here.
+       */
+      write_auth_code (PAM_AUTH_ERR);
+      write_auth_end ();
+
+      free (input.value);
+      input.value = read_seqpacket_message (AUTH_FD, "gssapi data", &input.length);
+
+      write_auth_begin ();
+    }
 
   major = gss_localname (&minor, name, mech_type, &local);
   if (major == GSS_S_COMPLETE)
@@ -787,17 +809,9 @@ perform_gssapi (void)
   res = open_session (pamh);
 
 out:
-  write_auth_begin ();
   write_auth_code (res);
   if (pwd)
     write_auth_string ("user", pwd->pw_name);
-  if (output.value)
-    write_auth_hex ("gssapi-output", output.value, output.length);
-
-  if (output.value)
-    gss_release_buffer (&minor, &output);
-  output.value = NULL;
-  output.length = 0;
 
   if (caps & GSS_C_DELEG_FLAG && client != GSS_C_NO_CREDENTIAL)
     {

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -59,7 +59,6 @@
 #define DEFAULT_PATH "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 static struct passwd *pwd;
-const char *rhost;
 static pid_t child;
 static int want_session = 1;
 static char *auth_delimiter = "";
@@ -608,7 +607,7 @@ open_session (pam_handle_t *pamh)
 }
 
 static pam_handle_t *
-perform_basic (void)
+perform_basic (const char *rhost)
 {
   struct pam_conv conv = { pam_conv_func, };
   pam_handle_t *pamh;
@@ -743,7 +742,7 @@ map_gssapi_to_local (gss_name_t name,
 
 
 static pam_handle_t *
-perform_gssapi (void)
+perform_gssapi (const char *rhost)
 {
   struct pam_conv conv = { pam_conv_func, };
   OM_uint32 major, minor;
@@ -886,7 +885,8 @@ out:
 }
 
 static void
-utmp_log (int login)
+utmp_log (int login,
+          const char *rhost)
 {
   char id[UT_LINESIZE + 1];
   struct utmp ut;
@@ -1123,12 +1123,20 @@ save_environment (void)
   env_saved[j] = NULL;
 }
 
+static const char *
+get_environ_var (const char *name,
+                 const char *defawlt)
+{
+  return getenv (name) ? getenv (name) : defawlt;
+}
+
 int
 main (int argc,
       char **argv)
 {
   pam_handle_t *pamh = NULL;
   const char *auth;
+  const char *rhost;
   char **env;
   int status;
   int flags;
@@ -1138,11 +1146,15 @@ main (int argc,
   if (isatty (0))
     errx (2, "this command is not meant to be run from the console");
 
-  if (argc != 3)
+  /* argv[1] is ignored */
+  if (argc != 2)
     errx (2, "invalid arguments to cockpit-session");
 
   /* Cleanup the umask */
   umask (077);
+
+  auth = get_environ_var ("COCKPIT_AUTH_MESSAGE_TYPE", "");
+  rhost = get_environ_var ("COCKPIT_REMOTE_PEER", "");
 
   save_environment ();
 
@@ -1168,9 +1180,6 @@ main (int argc,
   if (flags < 0 || fcntl (AUTH_FD, F_SETFD, flags | FD_CLOEXEC))
     err (1, "couldn't set auth fd flags");
 
-  auth = argv[1];
-  rhost = argv[2];
-
   signal (SIGALRM, SIG_DFL);
   signal (SIGQUIT, SIG_DFL);
   signal (SIGTSTP, SIG_IGN);
@@ -1178,10 +1187,11 @@ main (int argc,
   signal (SIGPIPE, SIG_IGN);
 
   if (strcmp (auth, "basic") == 0)
-    pamh = perform_basic ();
+    pamh = perform_basic (rhost);
   else if (strcmp (auth, "negotiate") == 0)
-    pamh = perform_gssapi ();
-  else
+    pamh = perform_gssapi (rhost);
+
+  if (!pamh)
     errx (2, "unrecognized authentication method: %s", auth);
 
   for (i = 0; env_saved[i] != NULL; i++)
@@ -1202,11 +1212,11 @@ main (int argc,
       signal (SIGINT, pass_to_child);
       signal (SIGQUIT, pass_to_child);
 
-      utmp_log (1);
+      utmp_log (1, rhost);
 
       status = fork_session (env);
 
-      utmp_log (0);
+      utmp_log (0, rhost);
 
       signal (SIGTERM, SIG_DFL);
       signal (SIGINT, SIG_DFL);

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -122,7 +122,10 @@ write_auth_string (const char *field,
   const unsigned char *at;
   char buf[8];
 
-  debug ("Writing %s %s", field, str);
+  if (!str)
+    return;
+
+  debug ("writing %s %s", field, str);
   fprintf (authf, "%s \"%s\": \"", auth_delimiter, field);
   for (at = (const unsigned char *)str; *at; at++)
     {
@@ -148,6 +151,7 @@ write_auth_hex (const char *field,
   static const char hex[] = "0123456789abcdef";
   size_t i;
 
+  debug ("writing %s", field);
   fprintf (authf, "%s \"%s\": \"", auth_delimiter, field);
   for (i = 0; i < len; i++)
     {
@@ -163,9 +167,9 @@ static void
 write_auth_bool (const char *field,
                  int val)
 {
-  fprintf (authf, "%s \"%s\": %s",
-           auth_delimiter, field,
-           val ? "true" : "false");
+  const char *str = val ? "true" : "false";
+  debug ("writing %s %s", field, str);
+  fprintf (authf, "%s \"%s\": %s", auth_delimiter, field, str);
   auth_delimiter = ",";
 }
 
@@ -247,6 +251,7 @@ write_auth_end (void)
         }
     }
 
+  debug ("finished auth response");
   free (auth_msg);
   auth_msg = NULL;
   authf = NULL;

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -683,10 +683,14 @@ map_gssapi_to_local (gss_name_t name,
     {
       minor = 0;
       str = dup_string (local.value, local.length);
-      debug ("mapped gssapi name to local user '%s'", str);
-
-      if (!getpwnam (str))
+      if (getpwnam (str))
         {
+          debug ("mapped gssapi name to local user '%s'", str);
+        }
+      else
+        {
+          debug ("ignoring non-existant gssapi local user '%s'", str);
+
           /* If the local user doesn't exist, pretend gss_localname() failed */
           free (str);
           str = NULL;
@@ -695,10 +699,12 @@ map_gssapi_to_local (gss_name_t name,
         }
     }
 
+  /* Try a more pragmatic approach */
   if (!str)
     {
       if (minor == (OM_uint32)KRB5_NO_LOCALNAME ||
-          minor == (OM_uint32)KRB5_LNAME_NOTRANS)
+          minor == (OM_uint32)KRB5_LNAME_NOTRANS ||
+          minor == (OM_uint32)ENOENT)
         {
           major = gss_display_name (&minor, name, &display, NULL);
           if (GSS_ERROR (major))
@@ -708,12 +714,20 @@ map_gssapi_to_local (gss_name_t name,
           else
             {
               str = dup_string (display.value, display.length);
-              debug ("no local user mapping for gssapi name '%s'", str);
+              if (getpwnam (str))
+                {
+                  debug ("no local user mapping for gssapi name '%s'", str);
+                }
+              else
+                {
+                  warnx ("non-existant local user '%s'", str);
+                  free (str);
+                  str = NULL;
+                }
             }
         }
       else
         {
-          warnx ("major is %d minor is %d", (int)major, (int)minor);
           warnx ("couldn't map gssapi name to local user: %s", gssapi_strerror (major, minor));
         }
     }

--- a/src/ws/test-authssh.c
+++ b/src/ws/test-authssh.c
@@ -1,0 +1,270 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitws.h"
+#include "mock-auth.h"
+
+#include "common/cockpittest.h"
+#include "common/cockpitwebserver.h"
+#include "common/cockpiterror.h"
+
+#include <sys/wait.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define PASSWORD "this is the password"
+
+typedef struct {
+  CockpitAuth *auth;
+
+  /* setup_mock_sshd */
+  GPid mock_sshd;
+  guint16 ssh_port;
+} TestCase;
+
+typedef struct {
+  const char *header;
+} TestFixture;
+
+static GString *
+read_all_into_string (int fd)
+{
+  GString *input = g_string_new ("");
+  gsize len;
+  gssize ret;
+
+  for (;;)
+    {
+      len = input->len;
+      g_string_set_size (input, len + 256);
+      ret = read (fd, input->str + len, 256);
+      if (ret < 0)
+        {
+          if (errno != EAGAIN)
+            {
+              g_critical ("couldn't read from mock input: %s", g_strerror (errno));
+              g_string_free (input, TRUE);
+              return NULL;
+            }
+        }
+      else if (ret == 0)
+        {
+          return input;
+        }
+      else
+        {
+          input->len = len + ret;
+          input->str[input->len] = '\0';
+        }
+    }
+}
+
+static void
+setup_mock_sshd (TestCase *tc)
+{
+  GError *error = NULL;
+  GString *port;
+  gchar *endptr;
+  guint64 value;
+  gint out_fd;
+
+  const gchar *argv[] = {
+      BUILDDIR "/mock-sshd",
+      "--user", "me",
+      "--password", PASSWORD,
+      NULL
+  };
+
+  g_spawn_async_with_pipes (BUILDDIR, (gchar **)argv, NULL, G_SPAWN_DO_NOT_REAP_CHILD, NULL, NULL,
+                            &tc->mock_sshd, NULL, &out_fd, NULL, &error);
+  g_assert_no_error (error);
+
+  /*
+   * mock-sshd prints its port on stdout, and then closes stdout
+   * This also lets us know when it has initialized.
+   */
+
+  port = read_all_into_string (out_fd);
+  g_assert (port != NULL);
+  close (out_fd);
+  g_assert_no_error (error);
+
+  g_strstrip (port->str);
+  value = g_ascii_strtoull (port->str, &endptr, 10);
+  if (!endptr || *endptr != '\0' || value == 0 || value > G_MAXUSHORT)
+      g_critical ("invalid port printed by mock-sshd: %s", port->str);
+
+  tc->ssh_port = (gushort)value;
+  g_string_free (port, TRUE);
+}
+
+static void
+setup (TestCase *tc,
+       gconstpointer data)
+{
+  tc->auth = cockpit_auth_new (TRUE);
+  setup_mock_sshd (tc);
+}
+
+static void
+teardown (TestCase *tc,
+          gconstpointer data)
+{
+  if (tc->mock_sshd)
+    {
+      kill (tc->mock_sshd, SIGTERM);
+      g_assert_cmpint (waitpid (tc->mock_sshd, 0, 0), ==, tc->mock_sshd);
+      g_spawn_close_pid (tc->mock_sshd);
+    }
+
+  g_clear_object (&tc->auth);
+}
+
+static void
+on_ready_get_result (GObject *source,
+                     GAsyncResult *result,
+                     gpointer user_data)
+{
+  GAsyncResult **retval = user_data;
+  g_assert (retval != NULL);
+  g_assert (*retval == NULL);
+  *retval = g_object_ref (result);
+}
+
+static void
+test_basic_good (TestCase *test,
+                 gconstpointer data)
+{
+  GHashTable *in_headers;
+  GHashTable *out_headers;
+  GAsyncResult *result = NULL;
+  CockpitCreds *creds;
+  CockpitWebService *service;
+  JsonObject *response;
+  GError *error = NULL;
+  gchar *path = NULL;
+  gchar *application = NULL;
+  gchar *cookie = NULL;
+
+  in_headers = mock_auth_basic_header ("me", PASSWORD);
+  out_headers = cockpit_web_server_new_table ();
+
+  application = g_strdup_printf ("cockpit+=127.0.0.1:%d", test->ssh_port);
+  cookie = g_strdup_printf ("machine-cockpit+127.0.0.1:%d", test->ssh_port);
+  path = g_strdup_printf ("/%s", application);
+
+  cockpit_auth_login_async (test->auth, path, NULL, in_headers, on_ready_get_result, &result);
+  g_hash_table_unref (in_headers);
+
+  while (result == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  response = cockpit_auth_login_finish (test->auth, result, NULL, out_headers, &error);
+  g_object_unref (result);
+  g_assert_no_error (error);
+  g_assert (response != NULL);
+  json_object_unref (response);
+
+  mock_auth_include_cookie_as_if_client (out_headers, out_headers, cookie);
+  service = cockpit_auth_check_cookie (test->auth, path, out_headers);
+  g_assert (service != NULL);
+
+  creds = cockpit_web_service_get_creds (service);
+  g_assert_cmpstr ("me", ==, cockpit_creds_get_user (creds));
+  g_assert_cmpstr (application, ==, cockpit_creds_get_application (creds));
+  g_assert_cmpstr (PASSWORD, ==, cockpit_creds_get_password (creds));
+
+  g_hash_table_unref (out_headers);
+  g_object_unref (service);
+  g_free (cookie);
+  g_free (path);
+  g_free (application);
+}
+
+static const TestFixture fixture_bad_format = {
+  .header = "Basic d3JvbmctZm9ybWF0Cg=="
+};
+
+static const TestFixture fixture_wrong_pw = {
+  .header = "Basic bWU6d3JvbmcK"
+};
+
+static const TestFixture fixture_empty = {
+  .header = "Basic"
+};
+
+static void
+test_basic_fail (TestCase *test,
+                 gconstpointer data)
+{
+  GHashTable *headers;
+  GAsyncResult *result = NULL;
+  GError *error = NULL;
+  gchar *path = NULL;
+  gchar *application = NULL;
+  const TestFixture *fix = data;
+
+  headers = cockpit_web_server_new_table ();
+  g_hash_table_insert (headers, g_strdup ("Authorization"), g_strdup (fix->header));
+
+  application = g_strdup_printf ("cockpit+=127.0.0.1:%d", test->ssh_port);
+  path = g_strdup_printf ("/%s", application);
+
+  cockpit_auth_login_async (test->auth, path, NULL, headers, on_ready_get_result, &result);
+  g_hash_table_unref (headers);
+  headers = cockpit_web_server_new_table ();
+
+  while (result == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_assert_null (cockpit_auth_login_finish (test->auth, result, NULL, headers, &error));
+  g_object_unref (result);
+  g_assert_error (error, COCKPIT_ERROR, COCKPIT_ERROR_AUTHENTICATION_FAILED);
+  g_assert_cmpstr ("Authentication failed", ==, error->message);
+
+  g_clear_error (&error);
+  g_hash_table_unref (headers);
+  g_free (path);
+  g_free (application);
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+  cockpit_ws_ssh_program = BUILDDIR "/cockpit-ssh";
+  cockpit_ws_known_hosts = SRCDIR "/src/ws/mock_known_hosts";
+
+  g_setenv ("COCKPIT_SSH_BRIDGE_COMMAND", BUILDDIR "/cockpit-bridge", TRUE);
+
+  cockpit_test_init (&argc, &argv);
+
+  g_test_add ("/auth-ssh/basic-good", TestCase, NULL,
+              setup, test_basic_good, teardown);
+  g_test_add ("/auth-ssh/basic-bad-password", TestCase, &fixture_wrong_pw,
+              setup, test_basic_fail, teardown);
+  g_test_add ("/auth-ssh/basic-bad-format", TestCase, &fixture_bad_format,
+              setup, test_basic_fail, teardown);
+  g_test_add ("/auth-ssh/basic-empty", TestCase, &fixture_empty,
+              setup, test_basic_fail, teardown);
+  return g_test_run ();
+}

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -193,11 +193,11 @@ test_login_with_cookie (Test *test,
   user = g_get_user_name ();
   headers = mock_auth_basic_header (user, PASSWORD);
 
-  cockpit_auth_login_async (test->auth, path, headers, NULL, on_ready_get_result, &result);
+  cockpit_auth_login_async (test->auth, path, NULL, headers, on_ready_get_result, &result);
   g_hash_table_unref (headers);
   while (result == NULL)
     g_main_context_iteration (NULL, TRUE);
-  response = cockpit_auth_login_finish (test->auth, result, 0, test->headers, &error);
+  response = cockpit_auth_login_finish (test->auth, result, NULL, test->headers, &error);
   g_object_unref (result);
 
   g_assert_no_error (error);
@@ -410,11 +410,11 @@ setup_default (Test *test,
       user = g_get_user_name ();
       headers = mock_auth_basic_header (user, PASSWORD);
 
-      cockpit_auth_login_async (test->auth, fixture->auth, headers, NULL, on_ready_get_result, &result);
+      cockpit_auth_login_async (test->auth, fixture->auth, NULL, headers, on_ready_get_result, &result);
       g_hash_table_unref (headers);
       while (result == NULL)
         g_main_context_iteration (NULL, TRUE);
-      response = cockpit_auth_login_finish (test->auth, result, 0, test->headers, &error);
+      response = cockpit_auth_login_finish (test->auth, result, NULL, test->headers, &error);
       g_object_unref (result);
 
       g_assert_no_error (error);

--- a/src/ws/test-kerberos.c
+++ b/src/ws/test-kerberos.c
@@ -328,13 +328,13 @@ test_authenticate (TestCase *test,
   build_authorization_header (in_headers, &output);
   gss_release_buffer (&minor, &output);
 
-  cockpit_auth_login_async (test->auth, "/cockpit+test", in_headers, NULL, on_ready_get_result, &result);
+  cockpit_auth_login_async (test->auth, "/cockpit+test", NULL, in_headers, on_ready_get_result, &result);
   g_hash_table_unref (in_headers);
 
   while (result == NULL)
     g_main_context_iteration (NULL, TRUE);
 
-  response = cockpit_auth_login_finish (test->auth, result, TRUE, out_headers, &error);
+  response = cockpit_auth_login_finish (test->auth, result, NULL, out_headers, &error);
   g_object_unref (result);
   g_assert_no_error (error);
   g_assert (response != NULL);

--- a/src/ws/test-sshtransport.c
+++ b/src/ws/test-sshtransport.c
@@ -31,8 +31,6 @@
 #include "common/cockpitpipe.h"
 #include "common/cockpitpipetransport.h"
 
-#include <libssh/libssh.h>
-
 #include <sys/wait.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -61,7 +59,6 @@ typedef struct {
   /* setup_mock_sshd */
   GPid mock_sshd;
   guint16 ssh_port;
-  int old_log_level;
 } TestCase;
 
 
@@ -87,7 +84,6 @@ typedef struct {
     gboolean no_password;
     gboolean ignore_key;
     gboolean prompt_hostkey;
-    int ssh_log_level;
 
     const TestAuthResponse *responses;
     int responses_size;

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -166,7 +166,7 @@ class TestRealms(MachineCase):
         b.wait_text(".realms-op-error", "Joining this domain is not supported")
 
 JOIN_SCRIPT = """
-set -e
+set -ex
 # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1071356#c11
 for x in 1 2 3 4 5 6 7 8 9 10; do
     if nslookup -type=SRV _ldap._tcp.cockpit.lan; then
@@ -175,6 +175,7 @@ for x in 1 2 3 4 5 6 7 8 9 10; do
         sleep $x
     fi
 done
+
 if ! echo '%(password)s' | realm join -U admin cockpit.lan; then
     journalctl -u realmd.service
 fi
@@ -183,6 +184,15 @@ fi
 echo '%(password)s' | kinit admin@COCKPIT.LAN
 curl --insecure -s --negotiate -u : https://f0.cockpit.lan/ipa/json --header 'Referer: https://f0.cockpit.lan/ipa' --header "Content-Type: application/json" --header "Accept: application/json" --data '{"params": [["HTTP/x0.cockpit.lan@COCKPIT.LAN"], {"raw": false, "all": false, "version": "2.101", "force": true, "no_members": false}], "method": "service_add", "id": 0}'
 ipa-getkeytab -q -s f0.cockpit.lan -p HTTP/x0.cockpit.lan -k /etc/krb5.keytab
+
+# HACK: https://bugs.freedesktop.org/show_bug.cgi?id=98479
+if ! grep -q 'services.*nss' /etc/sssd/sssd.conf; then
+    sed -i 's/^services = sudo, ssh$/services = sudo, ssh, nss, pam/' /etc/sssd/sssd.conf
+    systemctl restart sssd
+fi
+
+# This needs to work
+getent passwd admin@cockpit.lan
 """
 
 # This is here because our test framework can't run ipa VM's twice

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -231,9 +231,28 @@ class TestKerberos(MachineCase):
         self.configure_kerberos()
         self.machine.restart_cockpit()
 
-        output = self.machine.execute(['/usr/bin/curl', '-s', '--negotiate', '-u', ':', "-D", "-",
+        output = self.machine.execute(['/usr/bin/curl', '-v', '-s', '--negotiate', '-u', ':', "-D", "-",
                                        '--resolve', 'x0.cockpit.lan:9090:%s' % self.machine.address,
-                                       'http://x0.cockpit.lan:9090/cockpit/login'])
+                                       'http://x0.cockpit.lan:9090/cockpit/login', '2>&1'])
+
+        # So curl on centos-7 is broken here. You can verify this by
+        # checking access from another machine. Just get to this failure
+        # point, and then put this in your other machine /etc/krb5.conf
+        #
+        #   [realms]
+        #    COCKPIT.LAN = {
+        #     kdc = 10.111.112.100
+        #     master_kdc = 10.111.112.100
+        # }
+        #
+        # Now run with password  'foobarfoo'
+        # $ kinit admin@COCKPIT.LAN
+        #
+        # And run the above curl command. It should be successful
+        if "centos" in self.machine.image and "gss_init_sec_context() failed: : Success" in output:
+            self.skipTest("curl with --negotiate is broken on CentOS 7")
+            return
+
         self.assertIn("HTTP/1.1 200 OK", output)
         self.assertIn('"admin@cockpit.lan"', output)
 

--- a/test/verify/naughty/4538-gss-continue-needed
+++ b/test/verify/naughty/4538-gss-continue-needed
@@ -1,2 +1,0 @@
-in testNegotiate
-    self.assertIn("HTTP/1.1 200 OK", output)


### PR DESCRIPTION
 Remove differences between launching cockpit-session and cockpit-ssh. 

     * Both commands take the same arguments.
     * Remote peer and auth type are now environment variables.
     * Base64 decoding is not configurable. Only basic, negotiate
    and prompt conversations are decoded.
     * Negotiate authentications can now resume based on keep-alive.

Also brings in stefs' commits to add support for GSSAPI S_CONTINUE.