### PR TITLE
ostree: Don't overflow the 'Check for Updates' button

### DIFF
--- a/pkg/ostree/index.html
+++ b/pkg/ostree/index.html
@@ -49,6 +49,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
                 <button class="btn btn-default" ng-class="{ disabled: runningMethod, enabled: !runningMethod }" ng-click="checkForUpgrades()" translate>Check for Updates</button>
             </div>
         </div>
+        &nbsp;
     </div>
 </div>
 </script>

--- a/pkg/ostree/ostree.css
+++ b/pkg/ostree/ostree.css
@@ -73,3 +73,7 @@ table.listing-ct.listingtop thead h3 {
 .listing-ct-head .display-inline {
     display: inline;
 }
+
+.listing-ct-head .listing-ct-actions {
+    margin-top: -3px;
+}


### PR DESCRIPTION
The wrapping div around the 'Check for Updates' button needs to
have some content. When we're not rendering anything else but
the button there, it overflows the div.