### PR TITLE
kubernetes: Add general timeout parameter to non-GET requests

### DIFF
--- a/pkg/kubernetes/scripts/kube-client.js
+++ b/pkg/kubernetes/scripts/kube-client.js
@@ -1283,6 +1283,8 @@
 
             function generalMethodRequest(method, resource, body, config) {
                 var path = resourcePath([resource]);
+                if (method != "GET")
+                    path += "?timeout=" + REQ_TIMEOUT;
                 var promise = new KubeRequest(method, path, JSON.stringify(body), config);
                 return promise.then(function(response) {
                     var resp = response.data;


### PR DESCRIPTION
We already add the request timeout parameter to a bunch of
requests ... but some were falling through without it, as
intermittent test failures would show:

```
Internal error occurred: Timeout: request did not complete within allowed duration
```

So lets more broadly apply the timeout.