### PR TITLE
bridge: Close dbus-json1 channel when protocol errors in call

### DIFF
--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -2721,11 +2721,11 @@ function factory() {
             console.debug.apply(console, arguments);
     }
 
-    function DBusError(arg) {
+    function DBusError(arg, arg1) {
         if (typeof(arg) == "string") {
             this.problem = arg;
             this.name = null;
-            this.message = cockpit.message(arg);
+            this.message = arg1 || cockpit.message(arg);
         } else {
             this.problem = null;
             this.name = arg[0];
@@ -3160,7 +3160,7 @@ function factory() {
             var id, outstanding = calls;
             calls = { };
             for (id in outstanding) {
-                outstanding[id].reject(new DBusError(closed));
+                outstanding[id].reject(new DBusError(closed, options.message));
             }
             self.dispatchEvent("close", options);
         }

--- a/src/base1/test-dbus-common.js
+++ b/src/base1/test-dbus-common.js
@@ -377,6 +377,61 @@ function common_dbus_tests(channel_options, bus_name)
             });
     });
 
+    QUnit.asyncTest("bad object path", function() {
+        assert.expect(2);
+
+        var dbus = cockpit.dbus(bus_name, channel_options);
+        dbus.call("invalid/path", "borkety.Bork", "Echo", [ 1 ]).
+            fail(function(ex) {
+                assert.equal(ex.problem, "protocol-error", "error name");
+                assert.equal(ex.message, "object path is invalid in dbus \"call\": invalid/path", "error message");
+            }).
+            always(function() {
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest("bad interface name", function() {
+        assert.expect(2);
+
+        var dbus = cockpit.dbus(bus_name, channel_options);
+        dbus.call("/path", "!invalid!interface!", "Echo", [ 1 ]).
+            fail(function(ex) {
+                assert.equal(ex.problem, "protocol-error", "error name");
+                assert.equal(ex.message, "interface name is invalid in dbus \"call\": !invalid!interface!", "error message");
+            }).
+            always(function() {
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest("bad method name", function() {
+        assert.expect(2);
+
+        var dbus = cockpit.dbus(bus_name, channel_options);
+        dbus.call("/path", "borkety.Bork", "!Invalid!Method!", [ 1 ]).
+            fail(function(ex) {
+                assert.equal(ex.problem, "protocol-error", "error name");
+                assert.equal(ex.message, "member name is invalid in dbus \"call\": !Invalid!Method!", "error message");
+            }).
+            always(function() {
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest("bad flags", function() {
+        assert.expect(2);
+
+        var dbus = cockpit.dbus(bus_name, channel_options);
+        dbus.call("/path", "borkety.Bork", "Method", [ 1 ], { "flags": 5 }).
+            fail(function(ex) {
+                assert.equal(ex.problem, "protocol-error", "error name");
+                assert.equal(ex.message, "the \"flags\" field is invalid in dbus call", "error message");
+            }).
+            always(function() {
+                QUnit.start();
+            });
+    });
 
     QUnit.asyncTest("bad types", function() {
         assert.expect(3);
@@ -385,8 +440,23 @@ function common_dbus_tests(channel_options, bus_name)
         dbus.call("/bork", "borkety.Bork", "Echo", [ 1 ],
                   { type: "!!%%" }).
             fail(function(ex) {
-                assert.equal(ex.name, "org.freedesktop.DBus.Error.InvalidArgs", "error name");
-                assert.equal(ex.message, "Type signature is not valid: !!%%", "error message");
+                assert.equal(ex.problem, "protocol-error", "error name");
+                assert.equal(ex.message, "the \"type\" signature is not valid in dbus call: !!%%", "error message");
+            }).
+            always(function() {
+                assert.equal(this.state(), "rejected", "should fail");
+                QUnit.start();
+            });
+    });
+
+    QUnit.asyncTest("bad type invalid", function() {
+        assert.expect(3);
+
+        var dbus = cockpit.dbus(bus_name, channel_options);
+        dbus.call("/bork", "borkety.Bork", "Echo", [ 1 ], { type: 5 /* invalid */ }).
+            fail(function(ex) {
+                assert.equal(ex.problem, "protocol-error", "error name");
+                assert.equal(ex.message, "the \"type\" field is invalid in call", "error message");
             }).
             always(function() {
                 assert.equal(this.state(), "rejected", "should fail");
@@ -852,6 +922,7 @@ function common_dbus_tests(channel_options, bus_name)
                                             assert.equal(this.state(), "resolved", "removed object");
                                             assert.strictEqual(removed, added, "removed fired");
                                             assert.strictEqual(removed.valid, false, "removed is invalid");
+                                            dbus.close();
                                             $(dbus).off();
                                             QUnit.start();
                                         });

--- a/src/base1/test-dbus.js
+++ b/src/base1/test-dbus.js
@@ -192,7 +192,7 @@ QUnit.asyncTest("no default name", function() {
 });
 
 QUnit.asyncTest("no default name bad", function() {
-    assert.expect(1);
+    assert.expect(2);
 
     var dbus = cockpit.dbus(null, { "bus": "session" });
     dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
@@ -200,14 +200,15 @@ QUnit.asyncTest("no default name bad", function() {
         then(function(reply) {
             assert.ok(false, "shouldn't succeed");
         }, function(ex) {
-            assert.equal(ex.message, "The \"name\" field is invalid in call", "error message");
+            assert.equal(ex.problem, "protocol-error", "error problem");
+            assert.equal(ex.message, "the \"name\" field is invalid in dbus call", "error message");
         }).always(function() {
             QUnit.start();
         });
 });
 
 QUnit.asyncTest("no default name invalid", function() {
-    assert.expect(1);
+    assert.expect(2);
 
     var dbus = cockpit.dbus(null, { "bus": "session" });
     dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
@@ -215,14 +216,15 @@ QUnit.asyncTest("no default name invalid", function() {
         then(function(reply) {
             assert.ok(false, "shouldn't succeed");
         }, function(ex) {
-            assert.equal(ex.message, "The \"name\" field is not a valid bus name", "error message");
+            assert.equal(ex.problem, "protocol-error", "error problem");
+            assert.equal(ex.message, "the \"name\" field in dbus call is not a valid bus name: !invalid!", "error message");
         }).always(function() {
             QUnit.start();
         });
 });
 
 QUnit.asyncTest("no default name missing", function() {
-    assert.expect(1);
+    assert.expect(2);
 
     var dbus = cockpit.dbus(null, { "bus": "session" });
     dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
@@ -230,7 +232,8 @@ QUnit.asyncTest("no default name missing", function() {
         then(function(reply) {
             assert.ok(false, "shouldn't succeed");
         }, function(ex) {
-            assert.equal(ex.message, "The \"name\" field is missing in call", "error message");
+            assert.equal(ex.problem, "protocol-error", "error problem");
+            assert.equal(ex.message, "the \"name\" field is missing in dbus call", "error message");
         }).always(function() {
             QUnit.start();
         });
@@ -304,14 +307,15 @@ QUnit.asyncTest("watch no default name", function() {
 });
 
 QUnit.asyncTest("watch missing name", function() {
-    assert.expect(1);
+    assert.expect(2);
 
     var dbus = cockpit.dbus(null, { "bus": "session" });
     dbus.watch("/otree/frobber")
         .then(function() {
             assert.ok(false, "shouldn't succeed");
         }, function(ex) {
-            assert.equal(ex.message, "protocol-error", "error message");
+            assert.equal(ex.problem, "protocol-error", "error problem");
+            assert.equal(ex.message, "session: no \"name\" specified in match", "error message");
         })
         .always(function() {
             dbus.close();


### PR DESCRIPTION
These are programmer errors, and should be predictable by the caller. Especially now that we have support for logging intelligent messages on channel close back to the javascript console, we should handle these as protocol-error.

I've split this into its own pull request to better diagnose the integration test failures it seems to result in.

Depends on:

 * [x] #5464
 * [x] #5500