### PR TITLE
common: Fix no locale change case

### DIFF
--- a/src/common/cockpitlocale.c
+++ b/src/common/cockpitlocale.c
@@ -71,27 +71,26 @@ void
 cockpit_locale_set_language (const gchar *value)
 {
   const gchar *encoding = NULL;
-  gchar *locale;
+  gchar *locale = NULL;
+  gint len;
 
   if (value == NULL)
-    {
-      value = "C";
-    }
+    value = "C";
   else
-    {
-      encoding = "UTF-8";
-      if (strlen (value) > sizeof (previous) - 1)
-        {
-          g_printerr ("invalid language: %s\n", value);
-          return;
-        }
-    }
-
-  /* Already set our locale to this language */
-  if (strncmp (value, previous, sizeof (previous)) == 0)
-    return;
+    encoding = "UTF-8";
 
   locale = cockpit_locale_from_language (value, encoding, NULL);
+  len = strlen (locale);
+  if (len > sizeof (previous) - 1)
+    {
+      g_printerr ("invalid language: %s\n", value);
+      goto out;
+    }
+
+  /* Already set our locale to this language? */
+  if (g_strcmp0 (locale, previous) == 0)
+      goto out;
+
   if (setlocale (LC_ALL, locale) == NULL)
     {
       /* Note we use g_printerr directly, since we want no gettext invocations on this line */
@@ -103,6 +102,9 @@ cockpit_locale_set_language (const gchar *value)
       g_setenv ("LANG", locale, TRUE);
     }
 
-  strncpy (previous, locale, sizeof (previous));
+  strncpy (previous, locale, len);
+  previous[len] = '\0';
+
+out:
   g_free (locale);
 }


### PR DESCRIPTION
The no change case wasn't working properly because we were comparing the calculated locale to
the language value passed in. So en-us would not match en_US.

Move the check to after to lang -> locale conversation and explicitly null terminate previous as suggested
by coverity.

Reworked in:

 * [ ] #5501 