### PR TITLE
bridge: Allow CockpitDBusJson to share introspection info

### DIFF
--- a/src/bridge/cockpitdbuscache.c
+++ b/src/bridge/cockpitdbuscache.c
@@ -335,7 +335,7 @@ cockpit_dbus_cache_init (CockpitDBusCache *self)
   self->rules = cockpit_dbus_rules_new ();
 
   self->introspects = g_queue_new ();
-  self->introsent = g_hash_table_new (g_direct_hash, g_direct_equal);
+  self->introsent = g_hash_table_new (g_str_hash, g_str_equal);
 
   self->batches = g_queue_new ();
   self->barriers = g_queue_new ();
@@ -723,6 +723,7 @@ ensure_properties (CockpitDBusCache *self,
 {
   GHashTable *interfaces;
   GHashTable *properties;
+  const gchar *name;
 
   interfaces = ensure_interfaces (self, path);
   properties = g_hash_table_lookup (interfaces, iface->name);
@@ -736,9 +737,10 @@ ensure_properties (CockpitDBusCache *self,
       emit_change (self, path, iface, NULL, NULL);
     }
 
-  if (!g_hash_table_lookup (self->introsent, iface))
+  name = intern_string (self, iface->name);
+  if (!g_hash_table_lookup (self->introsent, name))
     {
-      g_hash_table_add (self->introsent, iface);
+      g_hash_table_add (self->introsent, (gpointer)name);
       g_signal_emit (self, signal_meta, 0, iface);
     }
 

--- a/src/bridge/cockpitdbuscache.h
+++ b/src/bridge/cockpitdbuscache.h
@@ -53,7 +53,8 @@ GType                 cockpit_dbus_cache_get_type          (void) G_GNUC_CONST;
 
 CockpitDBusCache *    cockpit_dbus_cache_new               (GDBusConnection *connection,
                                                             const gchar *name,
-                                                            const gchar *logname);
+                                                            const gchar *logname,
+                                                            GHashTable *interface_info);
 
 void                  cockpit_dbus_cache_barrier           (CockpitDBusCache *self,
                                                             CockpitDBusBarrierFunc callback,
@@ -81,6 +82,14 @@ void                  cockpit_dbus_cache_introspect        (CockpitDBusCache *se
                                                             const gchar *interface,
                                                             CockpitDBusIntrospectFunc callback,
                                                             gpointer user_data);
+
+GHashTable *          cockpit_dbus_interface_info_new      (void);
+
+GDBusInterfaceInfo *  cockpit_dbus_interface_info_lookup   (GHashTable *interface_info,
+                                                            const gchar *interface_name);
+
+void                  cockpit_dbus_interface_info_push     (GHashTable *interface_info,
+                                                            GDBusInterfaceInfo *interface);
 
 G_END_DECLS
 

--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -59,6 +59,7 @@ typedef struct {
   /* Call related */
   GCancellable *cancellable;
   GList *active_calls;
+  GHashTable *interface_info;
 
   /* Signal related */
   CockpitDBusRules *rules;
@@ -1801,6 +1802,7 @@ cockpit_dbus_json_init (CockpitDBusJson *self)
   self->cancellable = g_cancellable_new ();
 
   self->rules = cockpit_dbus_rules_new ();
+  self->interface_info = cockpit_dbus_interface_info_new ();
 }
 
 static void
@@ -1867,7 +1869,8 @@ subscribe_and_cache (CockpitDBusJson *self)
 {
   g_dbus_connection_set_exit_on_close (self->connection, FALSE);
 
-  self->cache = cockpit_dbus_cache_new (self->connection, self->name, self->logname);
+  self->cache = cockpit_dbus_cache_new (self->connection, self->name,
+                                        self->logname, self->interface_info);
   self->meta_sig = g_signal_connect (self->cache, "meta", G_CALLBACK (on_cache_meta), self);
   self->update_sig = g_signal_connect (self->cache, "update",
                                        G_CALLBACK (on_cache_update), self);
@@ -2140,6 +2143,7 @@ cockpit_dbus_json_finalize (GObject *object)
   CockpitDBusJson *self = COCKPIT_DBUS_JSON (object);
 
   g_clear_object (&self->connection);
+  g_hash_table_unref (self->interface_info);
   g_object_unref (self->cancellable);
   cockpit_dbus_rules_free (self->rules);
 


### PR DESCRIPTION
I've split this out into its own commit in order to bisect
digressions that are happening with ordering.