### PR TITLE
branding: Don't warn about instability when non-branded

### DIFF
--- a/src/branding/default/branding.css
+++ b/src/branding/default/branding.css
@@ -1,16 +1,7 @@
 
-/* When showing our own brand, be humble. */
 .login-note {
     color: transparent;
     position: relative;
-}
-
-.login-note:after {
-    content: "Not ready for use on production servers.";
-    color: white;
-    position: absolute;
-    top: 0px;
-    left: 0px;
 }
 
 body.login-pf {


### PR DESCRIPTION
Previously when not branded, we would warn that Cockpit was
not ready for production use. We should no longer do this,
as we've been making stable releases.

While it's true that these releases have not been tested
everywhere the branding isn't really an indication of that.

Fixes #5493