### PR TITLE
test: Test git 'master' with known issues enabled

### DIFF
--- a/test/verify/run-tests
+++ b/test/verify/run-tests
@@ -82,10 +82,6 @@ def main():
     if not revision:
         revision = subprocess.check_output([ "git", "rev-parse", "HEAD" ]).strip()
 
-    # Master is always thorough
-    if os.environ.get("TEST_NAME") == "master":
-        opts.thorough = True
-
     # Tell any subprocesses what we are testing
     os.environ["TEST_REVISION"] = revision
     testinfra.DEFAULT_IMAGE = image


### PR DESCRIPTION
We've moved to the point where known issues are about issues
in the underlying operating system, not in Cockpit itself.
They are also marked per operating system.

Therefore we should test master with known issues enabled.