### PR TITLE
test: Use 'canceled' since phantomjs uses the US spelling

### DIFF
--- a/test/common/phantom-driver.js
+++ b/test/common/phantom-driver.js
@@ -412,7 +412,8 @@ page.onResourceError = function(ex) {
      * cancelled loads, and racy state in phantomjs
      */
     if (ex.errorString === "Network access is disabled." ||
-        ex.errorString === "Operation cancelled") {
+        ex.errorString === "Operation cancelled" ||
+        ex.errorString === "Operation canceled") {
         prefix = "Ignoring Resource Error: ";
     } else {
         loadFailure = ex.errorString + " " + ex.url;


### PR DESCRIPTION
Ignore this error message properly, if in the US locale.

```
Resource Error: Operation canceled
```