### PR TITLE
networking: Fix regressions re devices without connection settings

### DIFF
--- a/test/verify/check-networking
+++ b/test/verify/check-networking
@@ -519,5 +519,52 @@ NM_CONTROLLED=no
         b.wait_present("#networking-interfaces tr[data-interface='%s']" % iface)
         b.wait_in_text("#networking-interfaces tr[data-interface='%s']" % iface, m.address)
 
+    def testNoConnectionSettings(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/network")
+
+        iface = self.add_iface()
+        self.wait_for_iface(iface)
+
+        b.click("#networking-interfaces tr[data-interface='%s']" % iface)
+        b.wait_visible("#network-interface")
+
+        # Edit and apply the ghost settings
+        b.click("tr:contains('IPv4') a")
+        b.wait_popup("network-ip-settings-dialog")
+        b.click("#network-ip-settings-dialog .btn.dropdown-toggle")
+        b.click("#network-ip-settings-dialog a:contains('Manual')")
+        b.set_val('#network-ip-settings-dialog input[placeholder="Address"]', "1.2.3.4")
+        b.set_val('#network-ip-settings-dialog input[placeholder*="Netmask"]', "24")
+        b.click("#network-ip-settings-dialog button:contains('Apply')")
+        b.wait_popdown("network-ip-settings-dialog")
+        b.wait_in_text("tr:contains('IPv4')", "Address 1.2.3.4/24")
+
+        # Check that we now have connection settings
+        con_id = m.execute("nmcli -m tabular -t -f GENERAL.CONNECTION device show %s" % iface).strip()
+        self.assertEqual(m.execute('nmcli -m tabular -t -f ipv4.method con show "%s"' % con_id).strip(),
+                         "manual")
+
+        # The interface will be activated. Deactivate it.
+        b.wait_in_text("tr:contains('Status')", "1.2.3.4/24")
+        b.click(".panel-heading:contains('%s') .btn:contains('Off')" % iface)
+        b.wait_in_text("tr:contains('Status')", "Inactive")
+
+        # Delete the connection settings again and wait for the ghost
+        # settings to be re-created.
+        m.execute('nmcli con del "%s"' % con_id)
+        b.wait_in_text("tr:contains('IPv4')", "Automatic")
+
+        # Activate with ghost settings
+        b.click(".panel-heading:contains('%s') .btn:contains('On')" % iface)
+        b.wait_in_text("tr:contains('Status')", "10.111.")
+
+        # Check again that we now have connection settings
+        con_id = m.execute("nmcli -m tabular -t -f GENERAL.CONNECTION device show %s" % iface).strip()
+        self.assertEqual(m.execute('nmcli -m tabular -t -f ipv4.method con show "%s"' % con_id).strip(),
+                         "auto")
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
This was broken by

    80102c055a337607917e997c2b3418e8abb43657
    Don't assume unknown devices are ethernet

    1c2d0445dbcaba7c463003205cead8005acb825b
    Don't change settings structure in place

For a device without connection settings, we create "ghost" connection
settings that are added to NM once the device is activated or the
settings are applied via one of the many dialogs.

These settings dialogs didn't get the "ghost" settings anymore and
would thus crash upon being shown.

Also, the "ghost" settings do no longer include the "id" and "type"
fields, which NM usually requires.  We work around this by using the
AddAndActivateConnection method when activating a device or turning a
device into a slave, but the many settings dialogs didn't use it yet.

This is fixed by explicitly providing the ghost settings to the
dialogs, and by routing all settings changes through a common method
that can take care of all the special cases.