### PR TITLE
common: Remove the concept of a document root from web server

### DIFF
--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -953,7 +953,7 @@ cockpit_packages_new (void)
 
   packages = g_new0 (CockpitPackages, 1);
 
-  packages->web_server = cockpit_web_server_new (NULL, -1, NULL, NULL, NULL, &error);
+  packages->web_server = cockpit_web_server_new (NULL, -1, NULL, NULL, &error);
   if (!packages->web_server)
     {
       g_warning ("couldn't initialize bridge package server: %s", error->message);

--- a/src/bridge/test-httpstream.c
+++ b/src/bridge/test-httpstream.c
@@ -69,7 +69,7 @@ static void
 setup_general (TestGeneral *tt,
                gconstpointer host_fixture)
 {
-  tt->web_server = cockpit_web_server_new (NULL, 0, NULL, NULL, NULL, NULL);
+  tt->web_server = cockpit_web_server_new (NULL, 0, NULL, NULL, NULL);
   tt->port = cockpit_web_server_get_port (tt->web_server);
   tt->transport = mock_transport_new ();
   tt->host = host_fixture;
@@ -348,8 +348,7 @@ test_http_chunked (void)
   guint count;
   guint port;
 
-  web_server = cockpit_web_server_new (NULL, 0, NULL,
-                                      NULL, NULL, NULL);
+  web_server = cockpit_web_server_new (NULL, 0, NULL, NULL, NULL);
   g_assert (web_server);
   port = cockpit_web_server_get_port (web_server);
   g_signal_connect (web_server, "handle-resource::/",
@@ -482,7 +481,7 @@ setup_tls (TestTls *test,
                                                         SRCDIR "/src/bridge/mock-server.key", &error);
   g_assert_no_error (error);
 
-  test->web_server = cockpit_web_server_new (NULL, 0, test->certificate, NULL, NULL, &error);
+  test->web_server = cockpit_web_server_new (NULL, 0, test->certificate, NULL, &error);
   g_assert_no_error (error);
 
   test->port = cockpit_web_server_get_port (test->web_server);

--- a/src/bridge/test-websocketstream.c
+++ b/src/bridge/test-websocketstream.c
@@ -113,7 +113,7 @@ static void
 setup (TestCase *test,
        gconstpointer data)
 {
-  test->server = cockpit_web_server_new (NULL, 0, NULL, NULL, NULL, NULL);
+  test->server = cockpit_web_server_new (NULL, 0, NULL, NULL, NULL);
   test->port = cockpit_web_server_get_port (test->server);
   test->transport = mock_transport_new ();
   test->ws_closed = FALSE;
@@ -229,7 +229,7 @@ setup_tls (TestTls *test,
   test->certificate = g_tls_certificate_new_from_files (SRCDIR "/src/bridge/mock-server.crt",
                                                         SRCDIR "/src/bridge/mock-server.key", &error);
   g_assert_no_error (error);
-  test->server = cockpit_web_server_new (NULL, 0, test->certificate, NULL, NULL, &error);
+  test->server = cockpit_web_server_new (NULL, 0, test->certificate, NULL, &error);
   g_assert_no_error (error);
 
   test->port = cockpit_web_server_get_port (test->server);

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -1177,6 +1177,26 @@ path_has_prefix (const gchar *path,
   return FALSE;
 }
 
+gchar **
+cockpit_web_response_resolve_roots (const gchar **input)
+{
+  GPtrArray *roots;
+  char *path;
+  gint i;
+
+  roots = g_ptr_array_new ();
+  for (i = 0; input && input[i]; i++)
+    {
+      path = realpath (input[i], NULL);
+      if (path == NULL)
+        g_debug ("couldn't resolve document root: %s: %m", input[i]);
+      else
+        g_ptr_array_add (roots, path);
+    }
+  g_ptr_array_add (roots, NULL);
+  return (gchar **)g_ptr_array_free (roots, FALSE);
+}
+
 static void
 web_response_file (CockpitWebResponse *response,
                    const gchar *escaped,

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -109,6 +109,8 @@ void                  cockpit_web_response_gerror        (CockpitWebResponse *se
                                                           GHashTable *headers,
                                                           GError *error);
 
+gchar **              cockpit_web_response_resolve_roots (const gchar **roots);
+
 void                  cockpit_web_response_file          (CockpitWebResponse *response,
                                                           const gchar *escaped,
                                                           const gchar **roots);

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -38,7 +38,6 @@ GType              cockpit_web_server_get_type      (void) G_GNUC_CONST;
 CockpitWebServer * cockpit_web_server_new           (const gchar *address,
                                                      gint port,
                                                      GTlsCertificate *certificate,
-                                                     const gchar **document_roots,
                                                      GCancellable *cancellable,
                                                      GError **error);
 
@@ -57,13 +56,9 @@ gchar **           cockpit_web_server_parse_languages (GHashTable *headers,
 gboolean           cockpit_web_server_parse_encoding  (GHashTable *headers,
                                                        const gchar *encoding);
 
-gchar **           cockpit_web_server_resolve_roots   (const gchar **roots);
-
 gboolean           cockpit_web_server_get_socket_activated (CockpitWebServer *self);
 
 gint               cockpit_web_server_get_port             (CockpitWebServer *self);
-
-const gchar **     cockpit_web_server_get_document_roots   (CockpitWebServer *self);
 
 void               cockpit_web_server_set_redirect_tls     (CockpitWebServer *self,
                                                             gboolean          redirect_tls);

--- a/src/ws/cockpitbranding.c
+++ b/src/ws/cockpitbranding.c
@@ -79,7 +79,7 @@ cockpit_branding_calculate_static_roots (const gchar *os_id,
   g_ptr_array_add (dirs, g_strdup (DATADIR "/cockpit/static"));
   g_ptr_array_add (dirs, NULL);
 
-  roots = cockpit_web_server_resolve_roots ((const gchar **)dirs->pdata);
+  roots = cockpit_web_response_resolve_roots ((const gchar **)dirs->pdata);
 
   g_ptr_array_free (dirs, TRUE);
   return roots;

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -168,7 +168,6 @@ main (int argc,
                                    opt_port,
                                    certificate,
                                    NULL,
-                                   NULL,
                                    error);
   if (server == NULL)
     {

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -83,12 +83,11 @@ on_web_response_done_set_flag (CockpitWebResponse *response,
 static void
 base_setup (Test *test)
 {
-  const gchar *roots[] = { SRCDIR "/src/ws", NULL };
   const gchar *static_roots[] = { SRCDIR "/src/ws", SRCDIR "/src/branding/default", NULL };
   GError *error = NULL;
   const gchar *user;
 
-  test->server = cockpit_web_server_new (NULL, 0, NULL, roots, NULL, &error);
+  test->server = cockpit_web_server_new (NULL, 0, NULL, NULL, &error);
   g_assert_no_error (error);
 
   /* Other test->data fields are fine NULL */
@@ -96,7 +95,7 @@ base_setup (Test *test)
 
   user = g_get_user_name ();
   test->auth = mock_auth_new (user, PASSWORD);
-  test->roots = cockpit_web_server_resolve_roots (static_roots);
+  test->roots = cockpit_web_response_resolve_roots (static_roots);
 
   test->data.auth = test->auth;
   test->data.static_roots = (const gchar **)test->roots;

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -46,6 +46,7 @@ static gint server_port = 0;
 static gchar **bridge_argv;
 static const gchar *bus_address;
 static const gchar *direct_address;
+static gchar **server_roots;
 
 /* ---------------------------------------------------------------------------------------------------- */
 
@@ -538,7 +539,7 @@ handle_package_file (CockpitWebServer *server,
     }
 
   rebuilt = g_strjoinv ("/", parts);
-  cockpit_web_response_file (response, rebuilt,  cockpit_web_server_get_document_roots (server));
+  cockpit_web_response_file (response, rebuilt, (const gchar **)server_roots);
   g_free (rebuilt);
 }
 
@@ -580,7 +581,7 @@ on_handle_source (CockpitWebServer *server,
       inject_address (response, "bus_address", bus_address);
       inject_address (response, "direct_address", direct_address);
     }
-  cockpit_web_response_file (response, path,  cockpit_web_server_get_document_roots (server));
+  cockpit_web_response_file (response, path, (const gchar **)server_roots);
   return TRUE;
 }
 
@@ -597,9 +598,9 @@ server_ready (void)
   else
     server_port = 8765;
 
+  server_roots = cockpit_web_response_resolve_roots (roots);
   server = cockpit_web_server_new (NULL, server_port, /* TCP port to listen to */
                                    NULL, /* TLS cert */
-                                   roots,/* Where to serve files from */
                                    NULL, /* GCancellable* */
                                    &error);
   if (server == NULL)
@@ -853,6 +854,7 @@ main (int argc,
   g_clear_object (&direct_b);
   g_main_loop_unref (loop);
 
+  g_strfreev (server_roots);
   g_test_dbus_down (bus);
   g_object_unref (bus);
   g_free (bridge_argv);

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -206,13 +206,11 @@ static void
 setup_mock_webserver (TestCase *test,
                       gconstpointer data)
 {
-  const gchar *roots[] = { SRCDIR "/src/ws", NULL };
-
   GError *error = NULL;
   const gchar *user;
 
   /* Zero port makes server choose its own */
-  test->web_server = cockpit_web_server_new (NULL, 0, NULL, roots, NULL, &error);
+  test->web_server = cockpit_web_server_new (NULL, 0, NULL, NULL, &error);
   g_assert_no_error (error);
 
   user = g_get_user_name ();


### PR DESCRIPTION
The webserver itself shouldn't know about any document root
or where to serve files from. Such default behavior is rather
dangerous. Anything serving files should (and already does)
specify its file location or roots to check.