### PR TITLE
Implement choice of pre-authorized on login screen

### DIFF
--- a/doc/guide/privileges.xml
+++ b/doc/guide/privileges.xml
@@ -12,8 +12,13 @@
     using <ulink url="http://www.freedesktop.org/wiki/Software/polkit/">Policy Kit</ulink>
     or <ulink url="http://www.sudo.ws/">sudo</ulink>. If the user is able to escalate
     privileges from the command line, then Cockpit will use that same capability to
-    perform certain privileged tasks. Cockpit can use the user's login password internally to
-    escalate privileges unless the user has chosen to prevent that from happening.</para>
+    perform certain privileged tasks.</para>
+
+  <para>Cockpit can use the user's login password internally to escalate privileges
+    in these situations. By selecting the
+    <emphasis>Reuse my password for privileged tasks</emphasis> option on the login screen
+    the login password will be cached internally and passed to <emphasis>Policy Kit</emphasis>
+    when requested in order to escalate privileges.</para>
 
   <para>To test out whether Cockpit can escalate privileges, you can run these commands
     from a the <link linkend="feature-terminal">terminal built into Cockpit</link>.</para>
@@ -28,8 +33,7 @@ $ pkexec cockpit-bridge
   <para>If either of these commands succeed without prompting for a password,
     Cockpit will be able to start a privileged copy of the
     <filename>cockpit-bridge</filename> and use it to perform privileged tasks
-    when necessary. When running these commands from the terminal built into Cockpit
-    neither should prompt for a password.</para>
+    when necessary.</para>
 
   <para>Usually a user needs to be in the <code>wheel</code> Unix user group for the
     user to be able to escalate privileges in this way. However both Policy Kit and

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -252,7 +252,7 @@ Command: authorize
 The "authorize" command is for communication of reauthorization challenges
 and responses between cockpit-bridge and cockpit-ws.
 
-The following fields are defined:
+For challenge/response authorization, the following fields are defined:
 
  * "cookie": an string sent with a challenge, that must be present in
    the corresponding response.
@@ -277,6 +277,14 @@ Example authorize challenge and response messages:
         "cookie": "555",
         "response": "crypt1:$6$r0oetn2039ntoen..."
     }
+
+For credential cache authorization, the following fields are defined:
+
+ * "credential": The word "clear"
+
+When the "credential" is set to "clear", all cached credentials will be
+cleared.
+
 
 Command: kill
 -------------
@@ -311,6 +319,13 @@ Example logout message:
     }
 
 The "logout" command is broadcast to all bridge instances.
+
+
+Command: hint
+-------------
+
+The "hint" command provides hints to other components about the state of things
+or what's going to happen next. The remainder of the fields are extensible.
 
 
 Payload: null

--- a/pkg/lib/credentials.js
+++ b/pkg/lib/credentials.js
@@ -307,7 +307,6 @@
 
         /* The button to deauthorize cockpit */
         $("#credential-authorize button").on("click", function(ev) {
-            $("#credential-authorize").remove();
             cockpit.drop_privileges(false);
             ev.preventDefault();
         });

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -201,6 +201,9 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                 if (control.channel !== undefined) {
                     for (seed in source_by_seed)
                         source_by_seed[seed].window.postMessage(message, origin);
+                } else if (control.command == "hint") {
+                    if (control.credential)
+                        index.authorize_changed(control.credential);
                 }
                 return true; /* still deliver locally */
 
@@ -662,6 +665,10 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
 
         self.expect_restart = function (host) {
             $(self).triggerHandler("expect_restart", host);
+        };
+
+        self.authorize_changed = function(value) {
+            $(self.credential_sel).toggle(value != "clear");
         };
 
         /* Menu items */

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -149,7 +149,7 @@
                 <div class="modal-body modal-scrollable">
                     <table class="listing-ct credential-listing">
                         <thead>
-                            <tr id="credential-authorize">
+                            <tr id="credential-authorize" hidden>
                                 <td translatable="yes" colspan="2">Use my password for privileged tasks and to connect to other machines</td>
                                 <td class="listing-ct-actions">
                                     <button class="btn btn-default pficon pficon-close" id="deauthorize-item">

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -42,6 +42,7 @@
         about_sel: "#about-version",
         account_sel: "#go-account",
         user_sel: "#content-user-name",
+        credential_sel: "#credential-authorize",
         default_title: "Cockpit"
     };
 

--- a/src/ws/login.css
+++ b/src/ws/login.css
@@ -574,6 +574,14 @@ body {
 #option-group:hover svg {
     opacity: 1.0;
 }
+#authorized-input {
+    width: 13px;
+    height: 13px;
+    padding: 0;
+    margin: 0;
+    vertical-align: bottom;
+    margin: 8px 5px 3px 0px;
+}
 #login-button {
     padding: 7px;
 }

--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -50,6 +50,13 @@
               <div class="col-sm-10 col-md-10">
                 <input type="password" class="form-control" id="login-password-input" tabindex="2">
               </div>
+              <div class="col-sm-2 col-md-2"></div>
+              <div class="col-sm-10 col-md-10">
+                <label class="control-label">
+                    <input type="checkbox" class="form-control" id="authorized-input">
+                    Reuse my password for privileged tasks
+                </label>
+              </div>
             </div>
 
             <div id="option-group">

--- a/src/ws/test-authssh.c
+++ b/src/ws/test-authssh.c
@@ -166,6 +166,7 @@ test_basic_good (TestCase *test,
   gchar *cookie = NULL;
 
   in_headers = mock_auth_basic_header ("me", PASSWORD);
+  g_hash_table_insert (in_headers, g_strdup ("X-Authorize"), g_strdup ("password"));
   out_headers = cockpit_web_server_new_table ();
 
   application = g_strdup_printf ("cockpit+=127.0.0.1:%d", test->ssh_port);
@@ -225,6 +226,7 @@ test_basic_fail (TestCase *test,
 
   headers = cockpit_web_server_new_table ();
   g_hash_table_insert (headers, g_strdup ("Authorization"), g_strdup (fix->header));
+  g_hash_table_insert (headers, g_strdup ("X-Authorize"), g_strdup ("password"));
 
   application = g_strdup_printf ("cockpit+=127.0.0.1:%d", test->ssh_port);
   path = g_strdup_printf ("/%s", application);

--- a/test/avocado/checklogin-basic.py
+++ b/test/avocado/checklogin-basic.py
@@ -60,6 +60,7 @@ class checklogin_basic(Test):
             b.wait_not_present("#login-button:disabled")
             b.set_val('#login-user-input', user)
             b.set_val('#login-password-input', password)
+            b.set_checked('#authorized-input', True)
             b.click('#login-button')
 
         # Try to login as a non-existing user

--- a/test/avocado/seleniumlib.py
+++ b/test/avocado/seleniumlib.py
@@ -159,6 +159,10 @@ This function is only for internal purposes:
             self.driver.execute_script('var ev = document.createEvent("Event"); ev.initEvent("change", true, false); arguments[0].dispatchEvent(ev);', element)
             self.driver.execute_script('var ev = document.createEvent("Event"); ev.initEvent("keydown", true, false); arguments[0].dispatchEvent(ev);', element)
 
+    def check_box(self, element, checked=True):
+        if element.get_attribute('checked') != checked:
+            element.click()
+
     def wait(self, method, text, baseelement, overridetry, fatal, cond, jscheck):
         """
 This function is low level, tests should prefer to use the wait_* functions:
@@ -247,6 +251,7 @@ parameters:
     def login(self, tmpuser=user, tmppasswd=passwd):
         self.send_keys(self.wait_id('login-user-input'), tmpuser)
         self.send_keys(self.wait_id('login-password-input'), tmppasswd)
+        self.check_box(self.wait_id('authorized-input'))
         self.click(self.wait_id("login-button", cond=clickable))
 
     def logout(self):

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -351,7 +351,7 @@ class Browser:
         else:
             self.click(sel + ' button:first-child');
 
-    def login_and_go(self, path=None, user=None, host=None):
+    def login_and_go(self, path=None, user=None, host=None, authorized=True):
         if user is None:
             user = self.default_user
         href = path
@@ -363,6 +363,8 @@ class Browser:
         self.wait_visible("#login")
         self.set_val('#login-user-input', user)
         self.set_val('#login-password-input', self.password)
+        self.set_checked('#authorized-input', authorized)
+
         self.click('#login-button')
         self.expect_load()
         self.wait_present('#content')
@@ -377,13 +379,15 @@ class Browser:
         self.click('#go-logout')
         self.expect_load()
 
-    def relogin(self, path=None, user=None):
+    def relogin(self, path=None, user=None, authorized=None):
         if user is None:
             user = self.default_user
         self.logout()
         self.wait_visible("#login")
         self.set_val("#login-user-input", user)
         self.set_val("#login-password-input", self.password)
+        if authorized is not None:
+            self.set_checked('#authorized-input', authorized)
         self.click('#login-button')
         self.expect_load()
         self.wait_present('#content')
@@ -534,9 +538,9 @@ class MachineCase(unittest.TestCase):
             self.check_journal_messages()
         shutil.rmtree(self.tmpdir)
 
-    def login_and_go(self, path=None, user=None, host=None):
+    def login_and_go(self, path=None, user=None, host=None, authorized=True):
         self.machine.start_cockpit(host)
-        self.browser.login_and_go(path, user=user, host=host)
+        self.browser.login_and_go(path, user=user, host=host, authorized=authorized)
 
     allowed_messages = [
         # This is a failed login, which happens every time

--- a/test/containers/check-kubernetes-openshift
+++ b/test/containers/check-kubernetes-openshift
@@ -36,7 +36,7 @@ from common.testvm import VirtMachine
 from verify import kubelib
 
 class OCBrowser(Browser):
-    def login_and_go(self, path=None, user=None, host=None):
+    def login_and_go(self, path=None, user=None, host=None, authorized=None):
         if user is None:
             user = self.default_user
         href = path

--- a/test/verify/check-embed
+++ b/test/verify/check-embed
@@ -40,6 +40,7 @@ class TestEmbed(MachineCase):
         b.wait_visible("#login")
         b.set_val('#login-user-input', "admin")
         b.set_val('#login-password-input', "foobar")
+        b.set_checked('#authorized-input', True)
         b.click('#login-button')
         b.expect_load()
 

--- a/test/verify/check-keys
+++ b/test/verify/check-keys
@@ -53,6 +53,7 @@ class TestKeys(MachineCase):
             b.wait_visible("#login")
             b.set_val("#login-user-input", user)
             b.set_val("#login-password-input", password)
+            b.set_checked("#authorized-input", True)
             b.click('#login-button')
             b.expect_load()
             b.enter_page("/system")

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -57,6 +57,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.wait_js_cond("document.activeElement.getAttribute('id') === 'login-user-input'")
             b.set_val('#login-user-input', user)
             b.set_val('#login-password-input', password)
+            b.set_checked('#authorized-input', True)
             b.click('#login-button')
 
         # Try to login as a non-existing user
@@ -245,6 +246,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.wait_visible("#user-group")
             b.set_val('#login-user-input', user)
             b.set_val('#login-password-input', password)
+            b.set_checked('#authorized-input', True)
             b.click('#login-button')
 
         # Try to login as a non-existing user

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -414,6 +414,7 @@ class TestMultiMachine(MachineCase):
         b.wait_visible("#login")
         b.set_val("#login-user-input", "admin")
         b.set_val("#login-password-input", "foobar")
+        b.set_checked("#authorized-input", True)
         b.click('#login-button')
         b.expect_load()
         b.enter_page("/system")

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -29,14 +29,19 @@ class TestReauthorize(MachineCase):
         m = self.machine
         b = self.browser
 
-        self.login_and_go("/playground/test")
-
+        # Log in without being authorized
+        self.login_and_go("/playground/test", authorized=False)
         b.click(".cockpit-internal-reauthorize .btn")
         b.wait_in_text(".cockpit-internal-reauthorize span", 'result:')
+        self.assertEqual(b.text(".cockpit-internal-reauthorize span"), 'result: access-denied')
 
+        # Log in again but be authorized
+        b.relogin("/playground/test", authorized=True)
+        b.click(".cockpit-internal-reauthorize .btn")
+        b.wait_in_text(".cockpit-internal-reauthorize span", 'result:')
         self.assertEqual(b.text(".cockpit-internal-reauthorize span"), 'result: authorized')
 
-        # Deauthorize
+        # Deauthorize from the menu
         b.leave_page()
         b.click("#navbar-dropdown")
         b.click("#credentials-item")
@@ -69,7 +74,7 @@ class TestReauthorize(MachineCase):
         b.click("#navbar-dropdown")
         b.click("#credentials-item")
         b.click("#credential-authorize button")
-        b.wait_not_present("#credential-authorize button")
+        b.wait_not_visible("#credential-authorize button")
         b.click("#credentials-dialog [data-dismiss]")
 
         b.enter_page("/playground/test")

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -40,8 +40,9 @@ class TestReauthorize(MachineCase):
         b.leave_page()
         b.click("#navbar-dropdown")
         b.click("#credentials-item")
+        b.wait_visible("#credential-authorize button")
         b.click("#credential-authorize button")
-        b.wait_not_present("#credential-authorize button")
+        b.wait_not_visible("#credential-authorize button")
         b.click("#credentials-dialog [data-dismiss]")
 
         b.enter_page("/playground/test")

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -54,6 +54,7 @@ class TestSession(MachineCase):
         # Login again
         b.set_val("#login-user-input", "admin")
         b.set_val("#login-password-input", "foobar")
+        b.set_checked("#authorized-input", True)
         b.click('#login-button')
         b.expect_load()
         b.enter_page("/system")


### PR DESCRIPTION
There is now a choice on the login screen which lets users choose whether to pre-authorize and reuse their password for privileged tasks inside Cockpit.
    
This choice will always reflect the setting that is chosen last time. The choice is always displayed as it is a key part of the security profile of Cockpit.

 * [x] Login screen option
 * [x] Make authentication in cockpit-ws respect the setting
 * [x] Display state correctly in shell
 * [x] Add test for unauthorized
 * [x] Update most tests to preauthorize
 * [x] Documentation
 
Depends on:

 * [x] #5520 
 * [x] #5510 
 * [x] #5521