### PR TITLE
ws: Add option to remotectl to combine and validate PEM files

### DIFF
--- a/containers/kubernetes/README.md
+++ b/containers/kubernetes/README.md
@@ -55,7 +55,9 @@ Web Certificates
 
 Cockpit looks at ```/etc/cockpit/ws-certs.d/``` to find its SSL certificate. You should create a Kubernetes secret API object to place your PEM encoded certificates and key in a ```.cert``` file in that location.
 
-If there are no certificates present in that location cockpit will generate and use a self-signed certificate. However the CN will be based on the container name so this option should be avoided for most deployments.
+Alternatively if you have a seperate certificate and key file, and you are unable to combine them in advance. You may mount them as ```/var/run/secrets/ws-certs.d/tls.crt``` and ```/var/run/secrets/ws-certs.d/tls.key```. If these are present and valid cockpit will use them.
+
+Otherwise if no certificates could be found cockpit will generate and use a self-signed certificate. However the CN will be based on the container name so this option should be avoided for most deployments.
 
 You can also choose to serve cockpit without SSL by setting the ```COCKPIT_KUBE_INSECURE``` environment variable to ```true```.
 

--- a/doc/man/remotectl.xml
+++ b/doc/man/remotectl.xml
@@ -66,6 +66,16 @@
         <para>
           <option>--group groupname</option> The unix group that should read the certificate. Only takes effect if used with <option>--ensure</option>.
         </para>
+
+        <para>
+          If any additional arguments are given, they are treated as files that should be combined to create a certificate file. If the combined files validate, they will be saved in the appropriate location using the name of the first file given with the extension changed to .cert. For example:
+        </para>
+
+        <para><command>remotectl certificate server.pem chain.pem key.pem</command></para>
+
+        <para>will result in <literal>server.cert</literal>. If <literal>server.cert</literal> already exists it will be overwritten.
+        </para>
+
       </listitem>
       </varlistentry>
     </variablelist>

--- a/pkg/kubernetes/standalone/src/cockpit-kube-launch/main.go
+++ b/pkg/kubernetes/standalone/src/cockpit-kube-launch/main.go
@@ -70,8 +70,12 @@ func setupCertificates() {
 		log.Fatalf("Couldn't create certificate directory %s", dErr)
 	}
 
-	// Setting ownership on the certificate may fail
-	// so execute ensure and the check results without
+	// Finding these certificate files or setting ownership on
+	// the certificate may fail so execute combine and ensure
+	// and the check results without
+	exec.Command("/usr/sbin/remotectl", "certificate",
+		"/var/run/secrets/ws-certs.d/tls.crt",
+		"/var/run/secrets/ws-certs.d/tls.key").CombinedOutput()
 	exec.Command("/usr/sbin/remotectl", "certificate", "--ensure").CombinedOutput()
 	out, rErr := exec.Command("/usr/sbin/remotectl", "certificate").CombinedOutput()
 	if rErr != nil {
@@ -159,10 +163,10 @@ func main() {
 		registry_override := path.Join(*confDir, "registry-dashboard-override.json")
 		linkFiles(registry_override, "/usr/share/cockpit/kubernetes/override.json")
 		linkFiles("/usr/share/cockpit/kubernetes/registry.html.gz",
-				  "/usr/share/cockpit/kubernetes/index.html.gz")
+			"/usr/share/cockpit/kubernetes/index.html.gz")
 	} else {
 		linkFiles("/usr/share/cockpit/kubernetes/original-index.gz",
-				  "/usr/share/cockpit/kubernetes/index.html.gz")
+			"/usr/share/cockpit/kubernetes/index.html.gz")
 	}
 
 	syscall.Exec(args[0], args, os.Environ())

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -219,6 +219,7 @@ WS_CHECKS = \
 	test-channelresponse \
 	test-handlers \
 	test-kerberos \
+	test-remotectlcertificate \
 	$(NULL)
 
 test_auth_CFLAGS = $(cockpit_ws_CFLAGS)
@@ -278,6 +279,21 @@ test_handlers_SOURCES = \
 test_handlers_LDADD = \
 	libcockpit-ws.a \
 	$(cockpit_ws_LDADD) \
+	$(NULL)
+
+test_remotectlcertificate_CFLAGS = \
+	$(COCKPIT_CFLAGS) \
+	$(NULL)
+test_remotectlcertificate_SOURCES = \
+	src/ws/test-remotectlcertificate.c \
+	src/ws/cockpitcertificate.c \
+	src/ws/cockpitcertificate.h \
+	src/ws/remotectl-certificate.c \
+	src/ws/remotectl.h \
+	$(NULL)
+test_remotectlcertificate_LDADD = \
+	libcockpit-common.a \
+	$(COCKPIT_LIBS) \
 	$(NULL)
 
 test_sshtransport_SOURCES = \

--- a/src/ws/cockpitcertificate.c
+++ b/src/ws/cockpitcertificate.c
@@ -585,7 +585,7 @@ tls_certificate_new_from_pem  (const gchar *data,
   if (length == -1)
     length = strlen (data);
 
-  key_pem = parse_private_key (data, length, FALSE, &child_error);
+  key_pem = parse_private_key (data, length, TRUE, &child_error);
   if (child_error != NULL)
     {
       g_propagate_error (error, child_error);

--- a/src/ws/test-remotectlcertificate.c
+++ b/src/ws/test-remotectlcertificate.c
@@ -1,0 +1,203 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "remotectl.h"
+
+#include "common/cockpittest.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+const gchar *config_dir = BUILDDIR "/test-configdir";
+
+typedef struct {
+  gint ret;
+  gchar *cert_dir;
+} TestCase;
+
+typedef struct {
+  const gchar **files;
+  const gchar *expected_message;
+} TestFixture;
+
+static void
+delete_all (TestCase *tc)
+{
+  GDir *dir = NULL;
+  GError *error = NULL;
+  gchar *parent = NULL;
+  const gchar *name;
+
+  dir = g_dir_open (tc->cert_dir, 0, &error);
+  if (!dir)
+    goto out;
+
+  while ((name = g_dir_read_name (dir)) != NULL)
+    {
+      gchar *path = g_build_filename (tc->cert_dir, name, NULL);
+      g_unlink (path);
+      g_free (path);
+    }
+
+  parent = g_path_get_dirname (tc->cert_dir);
+  g_rmdir (parent);
+  g_rmdir (tc->cert_dir);
+  g_rmdir (config_dir);
+
+out:
+  if (dir)
+    g_dir_close (dir);
+  g_clear_error (&error);
+  g_free (parent);
+}
+
+static void
+setup (TestCase *tc,
+       gconstpointer data)
+{
+  GPtrArray *ptr = g_ptr_array_new ();
+  const TestFixture *fix = data;
+  const gchar *old_val = g_getenv ("XDG_CONFIG_DIRS");
+  gint i;
+
+  g_setenv ("XDG_CONFIG_DIRS", config_dir, TRUE);
+  tc->cert_dir = g_build_filename (config_dir, "cockpit", "ws-certs.d", NULL);
+
+  /* make sure we start clean */
+  delete_all(tc);
+
+  g_ptr_array_add (ptr, "certificate");
+  g_ptr_array_add (ptr, "--user");
+  g_ptr_array_add (ptr, (gchar *) g_get_user_name ());
+  g_ptr_array_add (ptr, "--group");
+  g_ptr_array_add (ptr, (gchar *) g_get_user_name ());
+
+  for (i = 0; fix->files[i] != NULL; i++)
+    g_ptr_array_add (ptr, (gchar *) fix->files[i]);
+
+  if (fix->expected_message)
+    cockpit_expect_message (fix->expected_message);
+
+  tc->ret = cockpit_remotectl_certificate (ptr->len, (gchar **) ptr->pdata);
+
+  g_ptr_array_free (ptr, TRUE);
+  if (old_val)
+    g_setenv ("XDG_CONFIG_DIRS", old_val, TRUE);
+  else
+    g_unsetenv ("XDG_CONFIG_DIRS");
+}
+
+static void
+teardown (TestCase *tc,
+          gconstpointer data)
+{
+  delete_all(tc);
+  cockpit_assert_expected ();
+  g_free (tc->cert_dir);
+}
+
+
+static void
+test_combine_good (TestCase *test,
+                   gconstpointer data)
+{
+
+  g_assert_cmpint (test->ret, ==, 0);
+
+}
+
+static void
+test_combine_bad (TestCase *test,
+                  gconstpointer data)
+{
+  GDir *dir = NULL;
+  GError *error = NULL;
+
+  g_assert_cmpint (test->ret, ==, 1);
+  dir = g_dir_open (test->cert_dir, 0, &error);
+  g_assert_null (error);
+  g_assert_null (g_dir_read_name (dir));
+  g_dir_close (dir);
+}
+
+const gchar *good_files[3] = { SRCDIR "/src/bridge/mock-server.crt",
+                               SRCDIR "/src/bridge/mock-server.key", NULL };
+const gchar *bad_files[2] = { "bad", NULL };
+const gchar *bad_files2[3] = { SRCDIR "/src/bridge/mock-server.crt", "bad2", NULL };
+const gchar *invalid_files1[3] = { SRCDIR "/src/ws/mock-config/cockpit/cockpit.conf",
+                                   SRCDIR "/src/ws/mock-config/cockpit/cockpit-alt.conf", NULL };
+const gchar *invalid_files2[3] = { SRCDIR "/src/bridge/mock-server.crt",
+                                   SRCDIR "/src/bridge/mock-client.crt", NULL };
+const gchar *invalid_files3[2] = { SRCDIR "/src/bridge/mock-client.key", NULL };
+
+static const TestFixture fixture_good_file = {
+  .expected_message = NULL,
+  .files = good_files
+};
+
+static const TestFixture fixture_bad_file = {
+  .expected_message = "*Failed to open file 'bad': No such file or directory",
+  .files = bad_files
+};
+
+static const TestFixture fixture_bad_file2 = {
+  .expected_message = "*Failed to open file 'bad2': No such file or directory",
+  .files = bad_files2
+};
+
+static const TestFixture fixture_invalid1= {
+  .expected_message = "*: No PEM-encoded private key found",
+  .files = invalid_files1
+};
+
+static const TestFixture fixture_invalid2 = {
+  .expected_message = "*: No PEM-encoded private key found",
+  .files = invalid_files2
+};
+
+static const TestFixture fixture_invalid3 = {
+  .expected_message = "*: No PEM-encoded certificate found",
+  .files = invalid_files3
+};
+int
+main (int argc,
+      char *argv[])
+{
+  cockpit_test_init (&argc, &argv);
+
+  g_test_add ("/remotectl-certificate/combine-good", TestCase, &fixture_good_file,
+              setup, test_combine_good, teardown);
+  g_test_add ("/remotectl-certificate/combine-bad-file", TestCase, &fixture_bad_file,
+              setup, test_combine_bad, teardown);
+  g_test_add ("/remotectl-certificate/combine-bad-file2", TestCase, &fixture_bad_file2,
+              setup, test_combine_bad, teardown);
+  g_test_add ("/remotectl-certificate/combine-not-valid", TestCase, &fixture_invalid1,
+              setup, test_combine_bad, teardown);
+  g_test_add ("/remotectl-certificate/combine-no-key", TestCase, &fixture_invalid2,
+              setup, test_combine_bad, teardown);
+  g_test_add ("/remotectl-certificate/combine-no-cert", TestCase, &fixture_invalid3,
+              setup, test_combine_bad, teardown);
+  return g_test_run ();
+}


### PR DESCRIPTION
Use it to support openshift's automatic certificate generation feature.