### PR TITLE
common: Unset LANGUAGE before running locale tests

### DIFF
--- a/src/common/test-locale.c
+++ b/src/common/test-locale.c
@@ -158,6 +158,7 @@ main (int argc,
   gchar *name;
   gint i;
 
+  g_unsetenv ("LANGUAGE");
   g_unsetenv ("LANG");
   g_unsetenv ("LC_ALL");
   g_unsetenv ("LC_MESSAGES");


### PR DESCRIPTION
LANGUAGE takes precedence over LANG on debian and
causes the tests to fail.