### PR TITLE
ws: Inject cached password into a channel

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -280,10 +280,15 @@ Example authorize challenge and response messages:
 
 For credential cache authorization, the following fields are defined:
 
- * "credential": The word "clear"
+ * "credential": One of the following words: "inject" or "password"
 
-When the "credential" is set to "clear", all cached credentials will be
-cleared.
+When set to "inject" a channel must be specified a cached password
+credential will be injected as its own payload into the channel. If no
+password is cached, an empty payload will be injected.
+
+When set to "password" then a "password" field should also be present
+which represents a new password to cache, which replaces any current
+passwords. If no password field is present then the passwords are cleared.
 
 
 Command: kill

--- a/src/common/test-transport.c
+++ b/src/common/test-transport.c
@@ -108,6 +108,8 @@ on_recv_get_payload (CockpitTransport *transport,
                      gpointer user_data)
 {
   GBytes **received = user_data;
+  if (channel == NULL)
+    return FALSE;
   g_assert_cmpstr (channel, ==, "546");
   g_assert (*received == NULL);
   *received = g_bytes_ref (message);
@@ -124,6 +126,8 @@ on_recv_multiple (CockpitTransport *transport,
   gint *state = user_data;
   GBytes *check;
 
+  if (channel == NULL)
+    return FALSE;
   g_assert_cmpstr (channel, ==, "9");
 
   if (*state == 0)

--- a/src/ws/cockpitcreds.h
+++ b/src/ws/cockpitcreds.h
@@ -53,7 +53,7 @@ void            cockpit_creds_poison         (CockpitCreds *creds);
 
 const gchar *   cockpit_creds_get_user       (CockpitCreds *creds);
 
-const gchar *   cockpit_creds_get_password   (CockpitCreds *creds);
+GBytes *        cockpit_creds_get_password   (CockpitCreds *creds);
 
 const gchar *   cockpit_creds_get_rhost      (CockpitCreds *creds);
 

--- a/src/ws/cockpitcreds.h
+++ b/src/ws/cockpitcreds.h
@@ -55,6 +55,9 @@ const gchar *   cockpit_creds_get_user       (CockpitCreds *creds);
 
 GBytes *        cockpit_creds_get_password   (CockpitCreds *creds);
 
+void            cockpit_creds_set_password   (CockpitCreds *creds,
+                                              GBytes *password);
+
 const gchar *   cockpit_creds_get_rhost      (CockpitCreds *creds);
 
 const gchar *   cockpit_creds_get_csrf_token (CockpitCreds *creds);

--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -394,7 +394,7 @@ cockpit_ssh_transport_start_process (CockpitSshTransport *self,
   CockpitAuthOptions *options = g_new0 (CockpitAuthOptions, 1);
   CockpitSshOptions *ssh_options = g_new0 (CockpitSshOptions, 1);
 
-  const gchar *password;
+  GBytes *password;
   const gchar *gssapi_creds;
   gchar *host_arg = NULL;
 
@@ -421,7 +421,7 @@ cockpit_ssh_transport_start_process (CockpitSshTransport *self,
   else if (password)
     {
       options->auth_type = "password";
-      input = g_bytes_new_static (password, strlen (password));
+      input = g_bytes_ref (password);
       g_debug ("%s: preparing password creds", self->logname);
     }
 

--- a/src/ws/mock-auth.c
+++ b/src/ws/mock-auth.c
@@ -115,6 +115,7 @@ mock_auth_login_finish (CockpitAuth *auth,
   GSimpleAsyncResult *result = G_SIMPLE_ASYNC_RESULT (async);
   CockpitCreds *creds;
   CockpitPipe *pipe;
+  GBytes *bytes;
   gchar *nonce;
 
   const gchar *argv[] = {
@@ -131,13 +132,15 @@ mock_auth_login_finish (CockpitAuth *auth,
 
   nonce = cockpit_auth_nonce (auth);
 
+  bytes = g_bytes_new_take (g_strdup (self->expect_password), strlen (self->expect_password));
   creds = cockpit_creds_new (self->expect_user,
                              g_object_get_data (G_OBJECT (result), "application"),
-                             COCKPIT_CRED_PASSWORD, self->expect_password,
+                             COCKPIT_CRED_PASSWORD, bytes,
                              COCKPIT_CRED_RHOST, g_object_get_data (G_OBJECT (result), "remote"),
                              COCKPIT_CRED_CSRF_TOKEN, nonce,
                              NULL);
 
+  g_bytes_unref (bytes);
   g_free (nonce);
 
   if (transport)

--- a/src/ws/mock-cat-with-init
+++ b/src/ws/mock-cat-with-init
@@ -2,5 +2,5 @@
 
 # Here we send a init message the exec cat
 
-/usr/bin/printf "22\n{ \"command\" : \"init\" }"
+/usr/bin/printf "37\n\n{ \"command\" : \"init\", \"version\": 1 }"
 exec /bin/cat

--- a/src/ws/mock-echo.c
+++ b/src/ws/mock-echo.c
@@ -34,7 +34,7 @@ main (void)
   gssize count;
   gint i;
 
-  g_print ("22\n{ \"command\" : \"init\" }");
+  g_print ("37\n\n{ \"command\" : \"init\", \"version\": 1 }");
   for (i = 0; TRUE; i++)
     {
       count = read (0, buffer, sizeof (buffer));

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -187,7 +187,7 @@ test_userpass_cookie_check (Test *test,
   creds = cockpit_web_service_get_creds (service);
   g_assert_cmpstr ("me", ==, cockpit_creds_get_user (creds));
   g_assert_cmpstr ("cockpit", ==, cockpit_creds_get_application (creds));
-  g_assert_cmpstr ("this is the password", ==, cockpit_creds_get_password (creds));
+  g_assert_cmpstr ("this is the password", ==, g_bytes_get_data (cockpit_creds_get_password (creds), NULL));
 
   prev_service = service;
   g_object_unref (service);
@@ -205,7 +205,7 @@ test_userpass_cookie_check (Test *test,
   g_assert (prev_creds == creds);
 
   g_assert_cmpstr ("me", ==, cockpit_creds_get_user (creds));
-  g_assert_cmpstr ("this is the password", ==, cockpit_creds_get_password (creds));
+  g_assert_cmpstr ("this is the password", ==, g_bytes_get_data (cockpit_creds_get_password (creds), NULL));
 
   g_hash_table_destroy (headers);
   g_object_unref (service);
@@ -572,9 +572,16 @@ test_custom_success (Test *test,
   g_assert_cmpstr (user, ==, cockpit_creds_get_user (creds));
   g_assert_cmpstr (application, ==, cockpit_creds_get_application (creds));
   if (fix->authorized && g_str_has_prefix (fix->header, "Basic"))
-    g_assert_cmpstr (cockpit_creds_get_password (creds), == , password);
+    {
+      if (password == NULL)
+        g_assert_null (cockpit_creds_get_password (creds));
+      else
+        g_assert_cmpstr (g_bytes_get_data (cockpit_creds_get_password (creds), NULL), ==, password);
+    }
   else
-    g_assert_null (cockpit_creds_get_password (creds));
+    {
+      g_assert_null (cockpit_creds_get_password (creds));
+    }
 
   login_data = cockpit_creds_get_login_data (creds);
   if (fix->data)

--- a/src/ws/test-authssh.c
+++ b/src/ws/test-authssh.c
@@ -192,7 +192,7 @@ test_basic_good (TestCase *test,
   creds = cockpit_web_service_get_creds (service);
   g_assert_cmpstr ("me", ==, cockpit_creds_get_user (creds));
   g_assert_cmpstr (application, ==, cockpit_creds_get_application (creds));
-  g_assert_cmpstr (PASSWORD, ==, cockpit_creds_get_password (creds));
+  g_assert_cmpstr (PASSWORD, ==, g_bytes_get_data (cockpit_creds_get_password (creds), NULL));
 
   g_hash_table_unref (out_headers);
   g_object_unref (service);
@@ -396,7 +396,7 @@ test_key_good (TestCase *test,
   creds = cockpit_web_service_get_creds (service);
   g_assert_cmpstr ("me", ==, cockpit_creds_get_user (creds));
   g_assert_cmpstr (application, ==, cockpit_creds_get_application (creds));
-  g_assert_cmpstr (NULL, ==, cockpit_creds_get_password (creds));
+  g_assert (NULL == cockpit_creds_get_password (creds));
 
   g_hash_table_unref (out_headers);
   g_object_unref (service);

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -72,6 +72,7 @@ setup_resource (TestResourceCase *tc,
   gchar **environ;
   const gchar *user;
   const gchar *home = NULL;
+  GBytes *password;
 
   const gchar *argv[] = {
     BUILDDIR "/cockpit-bridge",
@@ -93,7 +94,9 @@ setup_resource (TestResourceCase *tc,
   g_strfreev (environ);
 
   user = g_get_user_name ();
-  creds = cockpit_creds_new (user, "cockpit", COCKPIT_CRED_PASSWORD, PASSWORD, NULL);
+  password = g_bytes_new_take (g_strdup (PASSWORD), strlen (PASSWORD));
+  creds = cockpit_creds_new (user, "cockpit", COCKPIT_CRED_PASSWORD, password, NULL);
+  g_bytes_unref (password);
 
   transport = cockpit_pipe_transport_new (tc->pipe);
   tc->service = cockpit_web_service_new (creds, transport);

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -327,7 +327,7 @@ test_login_accept (Test *test,
   g_assert (service != NULL);
   creds = cockpit_web_service_get_creds (service);
   g_assert_cmpstr (cockpit_creds_get_user (creds), ==, user);
-  g_assert_cmpstr (cockpit_creds_get_password (creds), ==, PASSWORD);
+  g_assert_cmpstr (g_bytes_get_data (cockpit_creds_get_password (creds), NULL), ==, PASSWORD);
 
   token = cockpit_creds_get_csrf_token (creds);
   g_assert (strstr (output, token));

--- a/src/ws/test-kerberos.c
+++ b/src/ws/test-kerberos.c
@@ -364,7 +364,7 @@ test_authenticate (TestCase *test,
   creds = cockpit_web_service_get_creds (service);
   g_assert_cmpstr (g_get_user_name (), ==, cockpit_creds_get_user (creds));
   g_assert_cmpstr ("cockpit+test", ==, cockpit_creds_get_application (creds));
-  g_assert_cmpstr (NULL, ==, cockpit_creds_get_password (creds));
+  g_assert (NULL == cockpit_creds_get_password (creds));
 
   g_hash_table_unref (out_headers);
   g_object_unref (service);

--- a/src/ws/test-sshtransport.c
+++ b/src/ws/test-sshtransport.c
@@ -318,6 +318,8 @@ on_recv_get_payload (CockpitTransport *transport,
                      gpointer user_data)
 {
   GBytes **received = user_data;
+  if (channel == NULL)
+    return FALSE;
   g_assert_cmpstr (channel, ==, "546");
   g_assert (*received == NULL);
   *received = g_bytes_ref (message);
@@ -332,6 +334,9 @@ on_recv_multiple (CockpitTransport *transport,
 {
   gint *state = user_data;
   GBytes *check;
+
+  if (channel == NULL)
+    return FALSE;
 
   g_assert_cmpstr (channel, ==, "9");
 

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -212,6 +212,7 @@ setup_mock_webserver (TestCase *test,
 {
   GError *error = NULL;
   const gchar *user;
+  GBytes *password;
 
   /* Zero port makes server choose its own */
   test->web_server = cockpit_web_server_new (NULL, 0, NULL, NULL, &error);
@@ -220,10 +221,12 @@ setup_mock_webserver (TestCase *test,
   user = g_get_user_name ();
   test->auth = mock_auth_new (user, PASSWORD);
 
+  password = g_bytes_new_take (g_strdup (PASSWORD), strlen (PASSWORD));
   test->creds = cockpit_creds_new (user, "cockpit",
-                                   COCKPIT_CRED_PASSWORD, PASSWORD,
+                                   COCKPIT_CRED_PASSWORD, password,
                                    COCKPIT_CRED_CSRF_TOKEN, "my-csrf-token",
                                    NULL);
+  g_bytes_unref (password);
 }
 
 static void


### PR DESCRIPTION
This implements support for injecting the cached password into a stream channel. There's a new authorize "credentials": "inject" command.
 
 * [x] Implementation
 * [x] Documentation
 * [x] Unit tests

Depends on: 

 * [x] #5522 
 * [x] #5521 
 * [x] #5510 
