### PR TITLE
shell: Build the default po.js in the dist/shell directory

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -11,7 +11,7 @@ MO_FILES = $(addprefix src/ws/,$(addsuffix .mo,$(LINGUAS)))
 PO_JAVASCRIPT = $(addprefix dist/shell/po.,$(addsuffix .js,$(LINGUAS)))
 
 podir = $(pkgdatadir)/shell
-nodist_po_DATA = po/po.js.gz $(addsuffix .gz,$(PO_JAVASCRIPT))
+nodist_po_DATA = dist/shell/po.js.gz $(addsuffix .gz,$(PO_JAVASCRIPT))
 
 # Used to list files in src/ws in the po file
 FILTER_PO_SRC_WS = sed -ne 's|.*\(\(\.\./\)\?src/ws/[^:]\+\).*|-N \1|p' $<
@@ -20,6 +20,9 @@ FILTER_PO_SRC_WS = sed -ne 's|.*\(\(\.\./\)\?src/ws/[^:]\+\).*|-N \1|p' $<
 src/ws/%.po: po/%.po
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
 	$(MSGGREP) `$(FILTER_PO_SRC_WS)` $< > $@.tmp && mv $@.tmp $@
+
+dist/shell/po.js: po/po.js
+	$(COPY_RULE)
 
 # A filtered po file without src/ws
 dist/shell/%.po: po/%.po

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -324,6 +324,9 @@ if (!section || section.indexOf("base1") === 0) {
     }, {
         from: bowerdir + path.sep + "jquery/dist/jquery.js",
         to: "base1/jquery.js"
+    }, {
+        from: srcdir + path.sep + "po/po.js",
+        to: "shell/po.js"
     });
 }
 


### PR DESCRIPTION
Build the default po.js in the dist/shell directory. This solves
problems with linking the shell directory into ~/.local/share/cockpit