### PR TITLE
test: Try to fix race in check-networking bond test

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2225,6 +2225,7 @@ PageNetworkInterface.prototype = {
         var self = this;
 
         if (!self.dev) {
+            console.log("Trying to switch off without a device?");
             self.update();
             return;
         }

--- a/test/verify/check-networking
+++ b/test/verify/check-networking
@@ -239,7 +239,7 @@ class TestNetworking(MachineCase):
         # Deactivate the bond and make sure it is still there after a
         # reload.
         b.wait_text_not("#network-interface-mac", "")
-        b.wait_not_in_text("tr:contains('Status')", "Inactive")
+        b.wait_present(".panel-heading:contains('tbond') .btn.active:contains('On')")
         b.click(".panel-heading:contains('tbond') .btn:contains('Off')")
         b.wait_in_text("tr:contains('Status')", "Inactive")
         self.assertNotIn("disabled",


### PR DESCRIPTION
Wait for the button to be "On" before clicking on "Off".

Also, output on the console when a disconnect request is ignored.