### PR TITLE
test: Fix race in check-storage-luks

### DIFF
--- a/pkg/storaged/crypto-tab.jsx
+++ b/pkg/storaged/crypto-tab.jsx
@@ -46,7 +46,6 @@ var CryptoTab = React.createClass({
 
             function commit() {
                 new_config[1]["track-parents"] = { t: 'b', v: true };
-                console.log(old_config, new_config);
                 if (old_config)
                     return block.UpdateConfigurationItem(old_config, new_config, { });
                 else

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -95,6 +95,7 @@ class TestStorage(StorageCase):
             self.dialog_with_retry(trigger = lambda: b.click(edit_button),
                                    expect = { "passphrase": "wrong-passphrase" },
                                    values = { "passphrase": "" })
+            self.wait_in_storaged_configuration("'passphrase-path': <b''>")
 
             # Lock it
             self.content_head_action(1, "Lock")


### PR DESCRIPTION
By waiting for the passphrase reset to trickle back into storaged.