### PR TITLE
cockpit-components-listing: new 'initiallyExpanded' attribute

### DIFF
--- a/pkg/lib/cockpit-components-listing.jsx
+++ b/pkg/lib/cockpit-components-listing.jsx
@@ -44,6 +44,7 @@ require('./listing.less');
  * listingActions optional: buttons that are presented as actions for the expanded item
  * selectChanged optional: callback will be used when the "selected" state changes
  * selected optional: true if the item is selected, can't be true if row has navigation or expansion
+ * initiallyExpanded optional: the entry will be initially rendered as expanded, but then behaves normally
  */
 var ListingRow = React.createClass({
     propTypes: {
@@ -54,7 +55,8 @@ var ListingRow = React.createClass({
         listingDetail: React.PropTypes.node,
         listingActions: React.PropTypes.arrayOf(React.PropTypes.node),
         selectChanged: React.PropTypes.func,
-        selected: React.PropTypes.bool
+        selected: React.PropTypes.bool,
+        initiallyExpanded: React.PropTypes.bool
     },
     getDefaultProps: function () {
         return {
@@ -64,7 +66,7 @@ var ListingRow = React.createClass({
     },
     getInitialState: function() {
         return {
-            expanded: false, // show expanded view if true, otherwise one line compact
+            expanded: this.props.initiallyExpanded, // show expanded view if true, otherwise one line compact
             activeTab: 0,    // currently active tab in expanded mode, defaults to first tab
             loadedTabs: {},  // which tabs were already loaded - this is important for 'loadOnDemand' setting
                              // contains tab indices

--- a/pkg/playground/react-demo-listing.jsx
+++ b/pkg/playground/react-demo-listing.jsx
@@ -114,7 +114,10 @@
                  <cockpitListing.ListingRow
                      columns={ [ { name: "with button", 'header': true }, 'aoeuaoeu', '127.30.168.10', rowAction ] }
                      tabRenderers={tabRenderers}/>
-                 <cockpitListing.ListingRow
+                <cockpitListing.ListingRow
+                    columns={ [ { name: "initially expanded", 'header': true }, 'aoeuaoeu', '127.30.168.12', rowAction ] }
+                    tabRenderers={tabRenderers} initiallyExpanded/>
+                <cockpitListing.ListingRow
                      columns={ [ { name: 'nothing to expand', 'header': true }, 'some text', '127.30.168.11', 'some state' ] }/>
              </cockpitListing.Listing>
         );


### PR DESCRIPTION
New boolean 'initiallyExpanded' attribute is introduced for
the <ListingRow> component.

When set, the row is initially rendered as expanded.
Subsequent user expand/collapse actions are still working.

This functionality is needed for 
  - the new 'devices' plugin - https://github.com/cockpit-project/cockpit/pull/5523
  - Create VM dialog - https://github.com/cockpit-project/cockpit/pull/7820