### PR TITLE
storaged: Ignore block devices with size zero

### DIFF
--- a/pkg/storaged/overview.js
+++ b/pkg/storaged/overview.js
@@ -239,7 +239,8 @@
                         block.CryptoBackingDevice == "/" &&
                         block.MDRaid == "/" &&
                         (!block_lvm2 || block_lvm2.LogicalVolume == "/") &&
-                        !block.HintIgnore);
+                        !block.HintIgnore &&
+                        block.Size > 0);
             }
 
             function make_other(path) {


### PR DESCRIPTION
This removes the inactive loopback devices on Ubuntu.