### PR TITLE
ws: Add a private key auth type

### DIFF
--- a/src/ws/test-authssh.c
+++ b/src/ws/test-authssh.c
@@ -247,6 +247,162 @@ test_basic_fail (TestCase *test,
   g_free (application);
 }
 
+/*
+ * These tests exist to test the private key auth function in cockpit-ssh.
+ * They pass a contrived header that includes key data to cockpit_auth_login.
+ * This is not a valid header and not how this is actually meant to be used.
+ * It's just easiest to test like this.
+ */
+
+/* test_rsa */
+static const gchar MOCK_RSA_KEY[] = "-----BEGIN RSA PRIVATE KEY-----\n"
+"MIIEowIBAAKCAQEAvkPEj9GX9I0v/3dxCUB73TgOYjxkXB/m2ecKnUYmYtEwgirA\n"
+"onCgZRMAvB7UaP5e6U/pNCXuZ+UgS0yU6tqEXD7MQ4YZiiNU1RaLe/gQ21NEx27h\n"
+"hCGTZOLKcSfOFv2Z77OUcXSop2PZxQweYaH1+RB7hojOd7ZchN/tIBxvea5JSg/0\n"
+"wLC8Lm65gpCZCxG2TNgfymovnyrYB44HnwEm4jCMU4uP68h0+D297US4oWwcpcqE\n"
+"2S4LOxazjw1Brvntpqwtq624tUb1QVYMxdHpCR7Qu843r3XSpS4BwrnOks7Sbgyg\n"
+"tHiKgogY5Xhu7ZqsTODtzyJ950YD0scnY41qHQIDAQABAoIBAFlQHnkUfixCCoH1\n"
+"Y45gQsS5h6b9im7kWs128ziYsXQ5lnfD8eFO1TwdC39DSZpvrcX/yQy9sYf7uoke\n"
+"Tdlg8jkLEX+w91Qs+al9h8SN0fvivqqPljUcPcBh5X3wnYGVUil/NvN7O6A38wXY\n"
+"hnp2OKzN2+5vUdxIMm39X6ZvMrT/FyQjvdp393G4f0blYl7Npdc+HYPNnhHdgi4I\n"
+"NUa32pG3ypoWkQRAYApaG2RXPTWQXTM2w4CFK5uJx/pB3r5NidU/H0XAl4TAuw9M\n"
+"V9hrIPAOh5zKvHcPv8xOwR0Bt36F+/QATjO9pvlzQO6Rn3x2dyAVdaFMgdYTNpQQ\n"
+"t0ZYsYECgYEA8yAhKUnArEQ4A+AI+pCtZuftzkXmnQ5SHNUtF2GeR5tRZ1PBF/tp\n"
+"zoVRW+5ge1hI2VEx3ziGHEIBr7FfVej7twQ3URv5ILYj6CoNOf+HxkZgkTDGpYdj\n"
+"AVvyjeD5qJEwCSeJ2bxD5LmxS9is8b8rXjVKRuPxwLeWqEjemPb0KNUCgYEAyFcL\n"
+"TdN9cZghuzLZ0vfP4k9Hratunskz5njTFKnJx90riE7VqPH9OHvTeHn1xJ5WACnb\n"
+"mFpAUG1v7BmC+WLEIPnKRKvuzL5C1yr+mntwTZsrwsLDdT/nfTS9hWzk9U6ykhJA\n"
+"De8nNfxHuCoqM++CNvh+rA4W2Zc6WmE0uCwXYCkCgYEA70KMP+Sb3yvXcEDWtTcR\n"
+"3raZ+agitib0ufk0QdFIgbGhH6111lMOIjZjBbSGcHxGXM8h5Ens+PwgSrWkW5hH\n"
+"tylIAuMjfYShu4U+tPf6ty5lNB0rMJUW4qyI/AUNzEztV+T4LTWwHvR7PWgDcniu\n"
+"hiytZyxFqmFBu2TS4vgM+e0CgYAvAL0WNVhpHlhLo1KXvKx5XEBk7qO1fV8/43ki\n"
+"j/NXgPyFrnlSefP/HI4w5exThRKIV0m+JO6R8BsiOZoRCKsbUX+zPON6BemIsf2q\n"
+"IOvoSU+rEibpi2S0a3tLopDVPPGIc9+zZTi94cKx4rKkHL1gSEzv8R5LTr/SFJxZ\n"
+"2X5igQKBgBTkIeB0yI2PGf1drI+YbhDfgIphEeSCPbWxcUzPCcwLqXGo41cr8RXY\n"
+"TgWtKk0gXhJWkMSIIXrfucCvXHTkk8wlqqgAVwrTgq4Q16LfBuucLwSe4TLp4SJZ\n"
+"Lko5CzOq+EIv6DIlZ3tRHeDFatWe+41w27KhrV9yxB6Ay0MalP4i\n"
+"-----END RSA PRIVATE KEY-----";
+
+ /* mock_dsa_key */
+static const gchar MOCK_DSA_KEY[] = "-----BEGIN DSA PRIVATE KEY-----\n"
+"MIIBugIBAAKBgQCCt0UxFgcPqwD3GFDNkKuJBMOfYF6VEP1r5HXmO0AzuuDB2mqK\n"
+"8ko/MbK2jbnZkBYeMW/4uUNRDJzXIThcbYpX1OW1CYHU73rcmRFhS/th8agbPBml\n"
+"kcgdb7UhQMNxjvFVBJ4xfOODd3Tci6HNDV/CL88DSGkIaOik7LnkJRtV/QIVAJdS\n"
+"XhrlS8SUvi2GL/xCXFHk+0R7AoGAajaZeTEwcSkLuY09PlgEmu6QKsE+d6H7+2Uw\n"
+"yBKJGEW+e/58Mw4JHLNX7AUayOnnMyf1ZV1sCm7IJMdjYd2YlmMAvh2ObqkaQ2o9\n"
+"xxEQuizJ+Hc3XJdvX2Hs4hImwm0YyV+ZWRdryGgNRML/Mk9FJbp8h2UYssOFpRIJ\n"
+"ZH/zSEwCgYBxLsdBBXn+8qEYwWK9KT+arRqNXC/lrl0Fp5YyxGNGCv82JcnuOShG\n"
+"GTzhYf8AtTCY1u5oixiW9kea6KXGAKgTjfJShr7n47SZVfOPOrBT3VLhRdGGO3Gb\n"
+"lDUppzfL8wsEdoqXjzrJuxSdrGnkFu8S9QjkPn9dCtScvWEcluHqMwIUUd82Co5T\n"
+"738f4g+9Iuj9G/rNdfg=\n"
+"-----END DSA PRIVATE KEY-----";
+
+typedef struct {
+  const char *key;
+  gint error_code;
+  const char *error_message;
+} TestKeyFixture;
+
+static const TestKeyFixture fixture_invalid_key = {
+  .key = "invalid-key",
+  .error_code = COCKPIT_ERROR_FAILED,
+  .error_message = "Authentication failed: internal-error"
+};
+
+static const TestKeyFixture fixture_wrong_key = {
+  .key = MOCK_DSA_KEY,
+  .error_code = COCKPIT_ERROR_AUTHENTICATION_FAILED,
+  .error_message = "Authentication failed"
+};
+
+static void
+test_key_fail (TestCase *test,
+                 gconstpointer data)
+{
+  GHashTable *headers;
+  GAsyncResult *result = NULL;
+  GError *error = NULL;
+  gchar *path = NULL;
+  gchar *application = NULL;
+  const TestKeyFixture *fix = data;
+  gchar *header_data = g_strdup_printf ("private-key %s", fix->key);
+
+  headers = cockpit_web_server_new_table ();
+  g_hash_table_insert (headers, g_strdup ("Authorization"), header_data);
+
+  application = g_strdup_printf ("cockpit+=me@127.0.0.1:%d", test->ssh_port);
+  path = g_strdup_printf ("/%s", application);
+
+  cockpit_auth_login_async (test->auth, path, NULL, headers, on_ready_get_result, &result);
+  g_hash_table_unref (headers);
+  headers = cockpit_web_server_new_table ();
+
+  while (result == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_assert_null (cockpit_auth_login_finish (test->auth, result, NULL, headers, &error));
+  g_object_unref (result);
+  g_assert_error (error, COCKPIT_ERROR, fix->error_code);
+  g_assert_cmpstr (fix->error_message, ==, error->message);
+
+  g_clear_error (&error);
+  g_hash_table_unref (headers);
+  g_free (path);
+  g_free (application);
+}
+
+static void
+test_key_good (TestCase *test,
+               gconstpointer data)
+{
+  GHashTable *in_headers;
+  GHashTable *out_headers;
+  GAsyncResult *result = NULL;
+  CockpitCreds *creds;
+  CockpitWebService *service;
+  JsonObject *response;
+  GError *error = NULL;
+  gchar *path = NULL;
+  gchar *application = NULL;
+  gchar *cookie = NULL;
+  gchar *header_data = g_strdup_printf ("private-key %s", MOCK_RSA_KEY);
+
+  in_headers = cockpit_web_server_new_table ();
+  out_headers = cockpit_web_server_new_table ();
+  g_hash_table_insert (in_headers, g_strdup ("Authorization"), header_data);
+
+  application = g_strdup_printf ("cockpit+=me@127.0.0.1:%d", test->ssh_port);
+  cookie = g_strdup_printf ("machine-cockpit+me@127.0.0.1:%d", test->ssh_port);
+  path = g_strdup_printf ("/%s", application);
+
+  cockpit_auth_login_async (test->auth, path, NULL, in_headers, on_ready_get_result, &result);
+  g_hash_table_unref (in_headers);
+
+  while (result == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  response = cockpit_auth_login_finish (test->auth, result, NULL, out_headers, &error);
+  g_object_unref (result);
+  g_assert_no_error (error);
+  g_assert (response != NULL);
+  json_object_unref (response);
+
+  mock_auth_include_cookie_as_if_client (out_headers, out_headers, cookie);
+  service = cockpit_auth_check_cookie (test->auth, path, out_headers);
+  g_assert (service != NULL);
+
+  creds = cockpit_web_service_get_creds (service);
+  g_assert_cmpstr ("me", ==, cockpit_creds_get_user (creds));
+  g_assert_cmpstr (application, ==, cockpit_creds_get_application (creds));
+  g_assert_cmpstr (NULL, ==, cockpit_creds_get_password (creds));
+
+  g_hash_table_unref (out_headers);
+  g_object_unref (service);
+  g_free (cookie);
+  g_free (path);
+  g_free (application);
+}
+
 int
 main (int argc,
       char *argv[])
@@ -266,5 +422,11 @@ main (int argc,
               setup, test_basic_fail, teardown);
   g_test_add ("/auth-ssh/basic-empty", TestCase, &fixture_empty,
               setup, test_basic_fail, teardown);
+  g_test_add ("/auth-ssh/key-good", TestCase, NULL,
+              setup, test_key_good, teardown);
+  g_test_add ("/auth-ssh/key-invalid", TestCase, &fixture_invalid_key,
+              setup, test_key_fail, teardown);
+  g_test_add ("/auth-ssh/key-fail", TestCase, &fixture_wrong_key,
+              setup, test_key_fail, teardown);
   return g_test_run ();
 }


### PR DESCRIPTION
This is meant to be used by external callers to cockpit-ssh when passing a private key directly is preferable to running a ssh-agent.