### PR TITLE
Image refresh for debian-unstable

### DIFF
--- a/test/images/debian-unstable
+++ b/test/images/debian-unstable
@@ -1,1 +1,0 @@
-debian-unstable-694a895bd2a88a7abe200c808fbfa2a4dc53b66c.qcow2


### PR DESCRIPTION
Image creation for debian-unstable in process on cockpit-11.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-unstable-2016-12-09/