### PR TITLE
Image refresh for centos-7

### DIFF
--- a/test/images/centos-7
+++ b/test/images/centos-7
@@ -1,1 +1,0 @@
-centos-7-512e261ab1d18cbd193eb53ec7c5e6b8dacbe201.qcow2


### PR DESCRIPTION
Image creation for centos-7 in process on cockpit-11.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-centos-7-2016-12-10/