### PR TITLE
test: Handle racy messages in check-connection when not authorized

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -89,7 +89,7 @@ class TestConnection(MachineCase):
         b.enter_page("/system")
 
         # Reauthorization can fail due to disconnects above
-        self.allow_journal_messages("cockpit-polkit: user admin reauthorization failed")
+        self.allow_authorize_journal_messages()
         self.allow_restart_journal_messages()
 
         # Debian 8 doesn't have systemd with coredump support


### PR DESCRIPTION
These messages are produced by the system page. Because we log in
as not authorized for privileged actions. Sometimes these show up.