### PR TITLE
Image refresh for ubuntu-1604

### DIFF
--- a/test/images/ubuntu-1604
+++ b/test/images/ubuntu-1604
@@ -1,1 +1,0 @@
-ubuntu-1604-55881a74acd4fab403d35f8582d26feadaac67df.qcow2


### PR DESCRIPTION
Image creation for ubuntu-1604 in process on cockpit-11.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-ubuntu-1604-2016-12-12/