### PR TITLE
base1: Increase timeout in test-framed-cache.js test

### DIFF
--- a/src/base1/test-framed-cache.js
+++ b/src/base1/test-framed-cache.js
@@ -30,7 +30,7 @@
             var timer = window.setTimeout(function() {
                 result({ myobject: "value" });
                 window.clearTimeout(timer);
-            }, 200);
+            }, 1000);
             return {
                 close: function() {}
             };
@@ -67,7 +67,7 @@
             var timer = window.setTimeout(function() {
                 result({ myobject: "value2" });
                 window.clearTimeout(timer);
-            }, 200);
+            }, 1000);
             return {
                 close: function() {}
             };


### PR DESCRIPTION
This fails intermittently on my computer. Increasing the timeout
helps a lot.

```
FAIL: dist/base1/test-framed-cache.html 10 - value2 is not equal to value - child consumer got parent value
```