### PR TITLE
test: Try to fix race in check-networking team test

### DIFF
--- a/test/verify/check-networking
+++ b/test/verify/check-networking
@@ -312,6 +312,8 @@ class TestNetworking(MachineCase):
 
         # Deactivate the team and make sure it is still there after a
         # reload.
+        b.wait_text_not("#network-interface-mac", "")
+        b.wait_present(".panel-heading:contains('tteam') .btn.active:contains('On')")
         b.click(".panel-heading:contains('tteam') .btn:contains('Off')")
         b.wait_in_text("tr:contains('Status')", "Inactive")
         b.reload()


### PR DESCRIPTION
Similar to 908f491292, which did the same thing for bonds.