### PR TITLE
configure: Use a config.json.in file to provide configure settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ install-sh
 /mkinstalldirs
 /config.h
 /config.h.in
+/config.json.in
 /aclocal.m4
 /dist/*
 !/dist/README.md

--- a/config.json.in
+++ b/config.json.in
@@ -1,5 +1,6 @@
 {
     "hacks": {
+        "with_storaged_iscsi_sessions": "@with_storaged_iscsi_sessions@",
         "with_networkmanager_needs_root": "@with_networkmanager_needs_root@"
     }
 }

--- a/configure.ac
+++ b/configure.ac
@@ -558,8 +558,7 @@ AC_DEFINE([MAX_PACKET_SIZE], [65536], [Maximum size of packet messages])
 
 AC_OUTPUT([
 Makefile
-pkg/networkmanager/override.json
-pkg/storaged/override.json
+config.json
 doc/guide/version
 ])
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "jed": "~1.1.0",
     "jshint": "~2.9.1",
     "jshint-loader": "~0.8.3",
+    "json-loader": "~0.5.4",
     "less": "~2.6.0",
     "less-loader": "~2.2.3",
     "ng-cache-loader": "0.0.16",

--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -4,21 +4,7 @@ pkg_TESTS = \
 
 TESTS += $(pkg_TESTS)
 
-# HACK: https://github.com/storaged-project/storaged/pull/68
-storageddir = $(pkgdatadir)/storaged
-nodist_storaged_DATA = \
-       pkg/storaged/override.json \
-       $(NULL)
-
-# HACK: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=808162
-networkmanagerdir = $(pkgdatadir)/networkmanager
-nodist_networkmanager_DATA = \
-       pkg/networkmanager/override.json \
-       $(NULL)
-
 EXTRA_DIST += \
-	pkg/networkmanager/override.json.in \
-	pkg/storaged/override.json.in \
 	pkg/lib/qunit-template.html \
 	$(pkg_TESTS)
 

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -27,7 +27,6 @@
     <link href="network.css" type="text/css" rel="stylesheet">
     <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
-    <script src="../manifests.js"></script>
     <script src="../shell/po.js"></script>
     <script src="network.js"></script>
 </head>

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -23,6 +23,7 @@ var cockpit = require('cockpit');
 var Mustache = require('mustache');
 var plot = require('plot');
 var journal = require('journal');
+var hacks = require('config.json').hacks || { };
 
 /* jQuery extensions */
 require('patterns');
@@ -189,9 +190,6 @@ function NetworkManagerModel() {
     var byteorder = null;
 
     /* HACK: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=808162 */
-    var hacks = { };
-    if (cockpit.manifests["network"] && cockpit.manifests["network"]["hacks"])
-        hacks = cockpit.manifests["network"]["hacks"];
     var options = { };
     if (hacks.with_networkmanager_needs_root)
         options["superuser"] = "try";

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -25,13 +25,11 @@
 
     var utils = require('./utils');
 
+    /* HACK: https://github.com/storaged-project/storaged/pull/68 */
+    var hacks = require('config.json').hacks || { };
+
     /* STORAGED CLIENT
      */
-
-    /* HACK: https://github.com/storaged-project/storaged/pull/68 */
-    var hacks = { };
-    if (cockpit.manifests["storage"] && cockpit.manifests["storage"]["hacks"])
-        hacks = cockpit.manifests["storage"]["hacks"];
 
     var client = { };
 

--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -27,7 +27,6 @@
     <link href="storage.css" type="text/css" rel="stylesheet">
     <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
-    <script src="../manifests.js"></script>
     <script src="../shell/po.js"></script>
     <script src="storage.js"></script>
 </head>

--- a/pkg/storaged/override.json.in
+++ b/pkg/storaged/override.json.in
@@ -1,5 +1,0 @@
-{
-    "hacks": {
-        "with_storaged_iscsi_sessions": "@with_storaged_iscsi_sessions@"
-    }
-}

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -374,11 +374,7 @@ This package contains the Cockpit shell UI assets.
 
 %package storaged
 Summary: Cockpit user interface for storage, using Storaged
-# Lock bridge dependency due to --with-storaged-iscsi-sessions
-# which uses new less stable /manifests.js request path.
-%if 0%{?rhel}
-Requires: %{name}-bridge >= %{version}-%{release}
-%endif
+Requires: %{name}-bridge >= %{required_base}
 Requires: %{name}-shell >= %{required_base}
 Requires: storaged >= 2.1.1
 %if 0%{?fedora} >= 24 || 0%{?rhel} >= 8

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -70,8 +70,6 @@ Description: Cockpit bridge server-side component
 
 Package: cockpit-networkmanager
 Architecture: any
-# Lock bridge dependency due to --with-networkmanager-needs-root
-# which uses new less stable /manifests.js request path.
 depends: ${misc:Depends},
          cockpit-bridge (= ${binary:Version}),
          network-manager

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -229,6 +229,7 @@ var html = require('html-webpack-plugin');
 var extract = require("extract-text-webpack-plugin");
 var extend = require("extend");
 var path = require("path");
+var fs = require("fs");
 
 /* For node 0.10.x we need this defined */
 if (typeof(global.Promise) == "undefined")
@@ -237,7 +238,8 @@ if (typeof(global.Promise) == "undefined")
 /* These can be overridden, typically from the Makefile.am */
 var srcdir = process.env.SRCDIR || __dirname;
 var pkgdir = srcdir + path.sep + "pkg";
-var distdir = (process.env.BUILDDIR || __dirname) + path.sep + "dist";
+var builddir = process.env.BUILDDIR || __dirname;
+var distdir = builddir + path.sep + "dist";
 var libdir = path.resolve(srcdir, "pkg" + path.sep + "lib");
 var bowerdir = path.resolve(srcdir, "bower_components");
 var section = process.env.ONLYDIR || null;
@@ -330,16 +332,26 @@ if (!section || section.indexOf("base1") === 0) {
     });
 }
 
+/* Short hand names for various components */
+var aliases =  {
+    "angular": "angular/angular.js",
+    "angular-route": "angular-route/angular-route.js",
+    "d3": "d3/d3.js",
+    "moment": "momentjs/moment.js",
+    "react": "react-lite-cockpit/dist/react-lite.js",
+    "term": "term.js-cockpit/src/term.js",
+};
+
+/* Mark our generated config.json as in use */
+var config_json = path.resolve(builddir, "config.json");
+if (fs.existsSync(config_json))
+    aliases["config.json"] = config_json;
+else
+    externals["config.json"] = "{ }";
+
 module.exports = {
     resolve: {
-        alias: {
-            "angular": "angular/angular.js",
-            "angular-route": "angular-route/angular-route.js",
-            "d3": "d3/d3.js",
-            "moment": "momentjs/moment.js",
-            "react": "react-lite-cockpit/dist/react-lite.js",
-            "term": "term.js-cockpit/src/term.js",
-        },
+        alias: aliases,
         modulesDirectories: [ libdir, bowerdir ]
     },
     resolveLoader: {
@@ -369,6 +381,10 @@ module.exports = {
                 test: /\.js$/,
                 exclude: /bower_components\/.*\//,
                 loader: 'strict' // Adds "use strict"
+            },
+            {
+                test: /\.json$/,
+                loader: "json-loader"
             },
             {
                 test: /\.css$/,


### PR DESCRIPTION
Instead of using manifest files and overrides, we use a config.json.in
file that is then used by configure to generate a config.json and
then in turn used by webpack to make configure settings available.