### PR TITLE
Remove duplicate line from HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -19,7 +19,6 @@ On Debian or Ubuntu:
 On Fedora:
 
     $ sudo yum install nodejs npm
-    $ sudo npm install -g webpack
 
 And lastly get Webpack and the development dependencies:
 


### PR DESCRIPTION
Installing webpack isn't distro-specific, remove it from the Fedora section (it is already present in the webpack/development dependency section).