### PR TITLE
docker: Remove unnecessary bind of this

### DIFF
--- a/pkg/docker/atomic.js
+++ b/pkg/docker/atomic.js
@@ -73,7 +73,7 @@ function updateVulnerableInfo() {
                     atomic.dispatchEvent("vulnerableInfoChanged", detailedInfos);
                 });
             }
-        }.bind(this));
+        });
 }
 
 function visibilityChanged() {


### PR DESCRIPTION
There's no objects in play in this code, so we don't need
to bind any promise handlers.