### PR TITLE
ws: Avoid dereferencing NULL password

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -387,6 +387,10 @@ parse_basic_auth_password (GBytes *input,
         *user = g_strndup (data, password - data);
       password++;
     }
+  else
+    {
+      return NULL;
+    }
 
   return g_bytes_new_with_free_func (password, strlen (password),
                                      (GDestroyNotify)g_bytes_unref,

--- a/src/ws/test-sshtransport.c
+++ b/src/ws/test-sshtransport.c
@@ -239,7 +239,11 @@ setup_transport (TestCase *tc,
   else
     password = fixture->client_password ? fixture->client_password : PASSWORD;
 
-  bytes = g_bytes_new_take (g_strdup (password), strlen (password));
+  if (password)
+    bytes = g_bytes_new_take (g_strdup (password), strlen (password));
+  else
+    bytes = NULL;
+
   creds = cockpit_creds_new (g_get_user_name (), "cockpit", COCKPIT_CRED_PASSWORD, bytes, NULL);
   g_bytes_unref (bytes);
 


### PR DESCRIPTION
Handle the NULL password case properly in these functions.