### PR TITLE
test: Ignore dhclient name_bind SELinux failures

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -578,6 +578,9 @@ class MachineCase(unittest.TestCase):
         # https://bugzilla.redhat.com/show_bug.cgi?id=1298171
         "(audit: )?type=1400 .*denied.*comm=\"iptables\".*name=\"xtables.lock\".*",
 
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1386624
+        ".*type=1400 .*denied  { name_bind } for.*dhclient.*",
+
         # https://bugzilla.redhat.com/show_bug.cgi?id=1242656
         "(audit: )?type=1400 .*denied.*comm=\"cockpit-ws\".*name=\"unix\".*dev=\"proc\".*",
         "(audit: )?type=1400 .*denied.*comm=\"ssh-transport-c\".*name=\"unix\".*dev=\"proc\".*",


### PR DESCRIPTION
This is a SELinux policy bug that doesn't seem to affect Cockpit. We should ignore it.

Should fix this sort of error:

```
# testPendingClaim (check_openshift.TestOpenshift)
#
Unexpected journal message 'type=1400 audit(1482141972.672:4): avc:  denied  { name_bind } for  pid=621 comm="dhclient" src=61000 scontext=system_u:system_r:dhcpc_t:s0 tcontext=system_u:object_r:ephemeral_port_t:s0 tclass=udp_socket'
Journal extracted to TestOpenshift-testPendingClaim-10.111.118.188-FAIL.log
Journal extracted to TestOpenshift-testPendingClaim-10.111.112.101-FAIL.log
Wrote TestOpenshift-testPendingClaim-FAIL.png
Journal extracted to TestOpenshift-testPendingClaim-10.111.118.188-FAIL.log
Journal extracted to TestOpenshift-testPendingClaim-10.111.112.101-FAIL.log
not ok 114 testPendingClaim (check_openshift.TestOpenshift) duration: 37s
Traceback (most recent call last):
  File "/build/cockpit/test/common/testlib.py", line 538, in tearDown
    self.check_journal_messages()
  File "/build/cockpit/test/common/testlib.py", line 676, in check_journal_messages
    raise Error(first)
Error: type=1400 audit(1482141972.672:4): avc:  denied  { name_bind } for  pid=621 comm="dhclient" src=61000 scontext=system_u:system_r:dhcpc_t:s0 tcontext=system_u:object_r:ephemeral_port_t:s0 tclass=udp_socket
```