### PR TITLE
Fail when variable is used before declaration

### DIFF
--- a/pkg/docker/overview.js
+++ b/pkg/docker/overview.js
@@ -65,6 +65,9 @@
         update_container_list(true, '');
         update_image_list('');
 
+        var cpu_series;
+        var mem_series;
+
         $(client).on('container.containers', function(event, id, container) {
             if (container && container.CGroup) {
                 cpu_series.add_instance(container.CGroup);
@@ -98,7 +101,7 @@
 
         var cpu_plot = plot.plot($("#containers-cpu-graph"), 300);
         cpu_plot.set_options(cpu_options);
-        var cpu_series = cpu_plot.add_metrics_stacked_instances_series(cpu_data, { });
+        cpu_series = cpu_plot.add_metrics_stacked_instances_series(cpu_data, { });
         $(cpu_series).on("value", function(ev, value) {
             $('#containers-cpu-text').text(util.format_cpu_usage(value));
         });
@@ -129,7 +132,7 @@
 
         var mem_plot = plot.plot($("#containers-mem-graph"), 300);
         mem_plot.set_options(mem_options);
-        var mem_series = mem_plot.add_metrics_stacked_instances_series(mem_data, { });
+        mem_series = mem_plot.add_metrics_stacked_instances_series(mem_data, { });
         $(mem_series).on("value", function(ev, value) {
             $('#containers-mem-text').text(cockpit.format_bytes(value, 1024));
         });

--- a/pkg/kubernetes/scripts/app.js
+++ b/pkg/kubernetes/scripts/app.js
@@ -318,7 +318,7 @@
             for (i in items)
                 sorted.push(items[i]);
             if (!angular.isArray(field))
-                field = [ String(criteria) ];
+                field = [ String(field) ];
             var criteria = field.map(function(v) {
                 return v.split('.');
             });

--- a/pkg/kubernetes/scripts/images.js
+++ b/pkg/kubernetes/scripts/images.js
@@ -268,6 +268,7 @@
         'kubeSelect',
         'kubeLoader',
         function(select, loader) {
+            var watching = false;
 
             /* Called when we have to load images via imagestreams */
             loader.listen(function(objects) {
@@ -337,7 +338,6 @@
             }
 
             /* Load images, but fallback to loading individually */
-            var watching = false;
             function watchImages(until) {
                 watching = true;
                 var a = loader.watch("images", until);

--- a/pkg/kubernetes/scripts/kube-client-mock.js
+++ b/pkg/kubernetes/scripts/kube-client-mock.js
@@ -412,6 +412,8 @@ var angular = require("angular");
         return true;
     }
 
+    var unique = 0;
+
     angular.module("kubeClient.mock", [
         "kubeClient",
     ])
@@ -569,7 +571,5 @@ var angular = require("angular");
             };
         }
     ]);
-
-    var unique = 0;
 
 }());

--- a/pkg/kubernetes/scripts/kube-client.js
+++ b/pkg/kubernetes/scripts/kube-client.js
@@ -378,6 +378,8 @@
         "KubeRequest",
         "KUBE_SCHEMA",
         function($q, $timeout, KubeWatch, KubeRequest, KUBE_SCHEMA) {
+            var self;
+
             var callbacks = [];
             var limits = { namespace: null };
 
@@ -660,7 +662,7 @@
                 }
             }
 
-            var self = {
+            self = {
                 watch: function watch(what, until) {
                     var ret = ensureWatches(what, 1);
                     connectUntil(ret, until);

--- a/pkg/kubernetes/scripts/test-tags.js
+++ b/pkg/kubernetes/scripts/test-tags.js
@@ -22,6 +22,8 @@ var QUnit = require("qunit-tests");
 
 require("./tags");
 
+var specData;
+
 function suite() {
     "use strict";
 
@@ -86,7 +88,7 @@ function suite() {
     angular.bootstrap(document, ['registry.tags.tests']);
 }
 
-var specData = {
+specData = {
     "dockerImageRepository": "busybox",
     "tags": [
         {

--- a/pkg/lib/credentials.js
+++ b/pkg/lib/credentials.js
@@ -187,12 +187,13 @@
                 return dfd.promise();
             }
 
+            var proc;
             var timeout = window.setTimeout(function() {
                 failure = _("Prompting via ssh-keygen timed out");
                 proc.close("terminated");
             }, 10 * 1000);
 
-            var proc = cockpit.spawn(["ssh-keygen", "-p", "-f", name],
+            proc = cockpit.spawn(["ssh-keygen", "-p", "-f", name],
                     { pty: true, environ: [ "LC_ALL=C" ], err: "out", directory: self.path })
                 .always(function() {
                     window.clearInterval(timeout);
@@ -247,12 +248,13 @@
             var output = "";
             var failure = _("Not a valid private key");
 
+            var proc;
             var timeout = window.setTimeout(function() {
                 failure = _("Prompting via ssh-add timed out");
                 proc.close("terminated");
             }, 10 * 1000);
 
-            var proc = cockpit.spawn(["ssh-add", name],
+            proc = cockpit.spawn(["ssh-add", name],
                     { pty: true, environ: [ "LC_ALL=C" ], err: "out", directory: self.path })
                 .always(function() {
                     window.clearInterval(timeout);

--- a/pkg/lib/plot.js
+++ b/pkg/lib/plot.js
@@ -437,6 +437,9 @@ plotter.plot = function plot(element, x_range_seconds, x_stop_seconds) {
                                });
         }
 
+        var instances = { };
+        var last_instance = null;
+
         function reset_series() {
             if (channel)
                 channel.close();
@@ -459,9 +462,6 @@ plotter.plot = function plot(element, x_range_seconds, x_stop_seconds) {
             sync_suppressed--;
             sync();
         }
-
-        var instances = { };
-        var last_instance = null;
 
         function add_instance(name, selector) {
             if (instances[name])

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -319,6 +319,8 @@ function NetworkManagerModel() {
     }
 
     var interface_types = { };
+    var max_export_phases = 0;
+    var export_pending;
 
     function set_object_types(all_types) {
         all_types.forEach(function (type) {
@@ -355,9 +357,6 @@ function NetworkManagerModel() {
         /* For NetworkManager we can make this assumption */
         drop_object(path);
     }
-
-    var max_export_phases = 0;
-    var export_pending;
 
     function export_model() {
         function doit() {
@@ -808,6 +807,8 @@ function NetworkManagerModel() {
      * code and using the data conversion functions.
      */
 
+    var type_Manager;
+
     var type_Ipv4Config = {
         interfaces: [
             "org.freedesktop.NetworkManager.IP4Config"
@@ -1130,7 +1131,7 @@ function NetworkManagerModel() {
         ]
     };
 
-    var type_Manager = {
+    type_Manager = {
         interfaces: [
             "org.freedesktop.NetworkManager"
         ],

--- a/pkg/ostree/app.js
+++ b/pkg/ostree/app.js
@@ -94,6 +94,7 @@
                                    final: final });
                 }
 
+                var timeout;
                 function check_empty() {
                     window.clearTimeout(timeout);
                     timeout = null;
@@ -109,7 +110,7 @@
                 }
 
                 $scope.curtains = { state: 'silent' };
-                var timeout = window.setTimeout(function() {
+                timeout = window.setTimeout(function() {
                     set_curtains({ state: 'connecting' });
                     document.body.removeAttribute('hidden');
                     timeout = null;

--- a/pkg/storaged/jobs.js
+++ b/pkg/storaged/jobs.js
@@ -34,7 +34,7 @@
 
     function init_jobs(client) {
 
-        jobs_tmpl = $("#jobs-tmpl").html();
+        var jobs_tmpl = $("#jobs-tmpl").html();
         mustache.parse(jobs_tmpl);
 
         /* As a special service, we try to also show UDisks2 jobs.
@@ -102,8 +102,6 @@
         $(client.udisks_jobs).on('added removed changed', function () {
             update_job_spinners('body');
         });
-
-        var jobs_tmpl;
 
         function render_jobs_panel() {
 

--- a/pkg/storaged/overview.js
+++ b/pkg/storaged/overview.js
@@ -37,7 +37,9 @@
     /* OVERVIEW PAGE
      */
 
+
     function init_overview(client, jobs) {
+        var read_series, write_series;
 
         $('#vgroups').toggle(client.features.lvm2);
         $('#iscsi-sessions').toggle(client.features.iscsi);
@@ -360,7 +362,7 @@
         read_plot_options.setup_hook = make_plot_setup("#storage-reading-unit");
         var read_plot = plot.plot($("#storage-reading-graph"), 300);
         read_plot.set_options(read_plot_options);
-        var read_series = read_plot.add_metrics_stacked_instances_series(read_plot_data, { });
+        read_series = read_plot.add_metrics_stacked_instances_series(read_plot_data, { });
         read_plot.start_walking();
         $(read_series).on('hover', highlight_drive);
 
@@ -382,7 +384,7 @@
         write_plot_options.setup_hook = make_plot_setup("#storage-writing-unit");
         var write_plot = plot.plot($("#storage-writing-graph"), 300);
         write_plot.set_options(write_plot_options);
-        var write_series = write_plot.add_metrics_stacked_instances_series(write_plot_data, { });
+        write_series = write_plot.add_metrics_stacked_instances_series(write_plot_data, { });
         write_plot.start_walking();
         $(write_series).on('hover', highlight_drive);
 

--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -146,6 +146,7 @@ $(function() {
      */
 
     var units_initialized = false;
+    var clock_realtime_now, clock_monotonic_now;
 
     function ensure_units() {
         if (!units_initialized) {
@@ -847,7 +848,6 @@ $(function() {
             $("#timer-dialog").modal("toggle");
     });
 
-    var clock_realtime_now, clock_monotonic_now;
     function update_time() {
         cockpit.spawn(["grep", "\\w", "timer_list"],
                       { directory: "/proc" }).

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -78,12 +78,13 @@ function passwd_self(old_pass, new_pass) {
     var failure = _("Old password not accepted");
     var i;
 
+    var proc;
     var timeout = window.setTimeout(function() {
         failure = _("Prompting via passwd timed out");
         proc.close("terminated");
     }, 10 * 1000);
 
-    var proc = cockpit.spawn(["/usr/bin/passwd"], { pty: true, environ: [ "LC_ALL=C" ], err: "out" })
+    proc = cockpit.spawn(["/usr/bin/passwd"], { pty: true, environ: [ "LC_ALL=C" ], err: "out" })
         .always(function() {
             window.clearInterval(timeout);
         })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -403,6 +403,7 @@ module.exports = {
     jshint: {
         emitErrors: false,
         failOnHint: true,
+        latedef: "nofunc",
         sub: true,
         multistr: true,
         undef: true,


### PR DESCRIPTION
Javascript allows variable hosting, where a variable definition anywhere in a function is as if it is declared at the top.
    
This leads to hard to find bugs in certain cases. We've been catching this in review, but lets use jshint to catch it for us.
    
This commit enables detection of variable use before declaration, and fixes all cases where that happened.
