### PR TITLE
tools: Rework the jshint error reporter when used with make

### DIFF
--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -43,6 +43,15 @@ var cwd = process.cwd();
 var config_path = path.resolve(cwd, ops.args[0]);
 var config = require(config_path);
 
+// An alternate jshint reporter when used with make
+config.jshint.reporter = function(errors) {
+    var loader = this;
+    errors.forEach(function(err) {
+        console.log(loader.resource + ":" + err.line + ":" + err.character + ": " + err.reason);
+    });
+    process.exit(1);
+};
+
 // The latest input file time updated and used below
 var latest = fs.statSync(config_path).mtime;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -401,18 +401,12 @@ module.exports = {
     },
 
     jshint: {
-        emitErrors: false,
+        emitErrors: true,
         failOnHint: true,
         sub: true,
         multistr: true,
         undef: true,
         unused: "vars",
         predef: [ "window", "document", "console" ],
-        reporter: function (errors) {
-            var loader = this;
-            errors.forEach(function(err) {
-                console.log(loader.resource + ":" + err.line + ":" + err.character + ": " + err.reason);
-            });
-        }
     },
 };


### PR DESCRIPTION
Use the standard error reporter when webpack is used directly,
and fill in our custom reporter only when we use it via make.

Our custom error reporter makes the errors look more like
gcc failure output lines.