### PR TITLE
base1: Consistent this in .stream() and .response() callbacks

### DIFF
--- a/pkg/lib/credentials.js
+++ b/pkg/lib/credentials.js
@@ -212,7 +212,7 @@
                         if (old_exps[i].test(buffer)) {
                             buffer = "";
                             failure = _("Old password not accepted");
-                            proc.input(old_pass + "\n", true);
+                            this.input(old_pass + "\n", true);
                             return;
                         }
                     }
@@ -220,7 +220,7 @@
                     for (i = 0; i < new_exps.length; i++) {
                         if (new_exps[i].test(buffer)) {
                             buffer = "";
-                            proc.input(new_pass + "\n", true);
+                            this.input(new_pass + "\n", true);
                             failure = _("Failed to change password");
                             sent_new = true;
                             return;
@@ -278,10 +278,10 @@
                     } else if (ask_exp.test(buffer)) {
                         buffer = "";
                         failure = _("Password not accepted");
-                        proc.input(password + "\n", true);
+                        this.input(password + "\n", true);
                     } else if (bad_exp.test(buffer)) {
                         buffer = "";
-                        proc.input("\n", true);
+                        this.input("\n", true);
                     }
                 });
 

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -101,7 +101,7 @@ function passwd_self(old_pass, new_pass) {
             for (i = 0; i < old_exps.length; i++) {
                 if (old_exps[i].test(buffer)) {
                     buffer = "";
-                    proc.input(old_pass + "\n", true);
+                    this.input(old_pass + "\n", true);
                     return;
                 }
             }
@@ -109,7 +109,7 @@ function passwd_self(old_pass, new_pass) {
             for (i = 0; i < new_exps.length; i++) {
                 if (new_exps[i].test(buffer)) {
                     buffer = "";
-                    proc.input(new_pass + "\n", true);
+                    this.input(new_pass + "\n", true);
                     failure = _("Failed to change password");
                     sent_new = true;
                     return;

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -2706,7 +2706,7 @@ function factory() {
 
         var ret = dfd.promise;
         ret.stream = function(callback) {
-            buffer.callback = callback;
+            buffer.callback = callback.bind(ret);
             return this;
         };
 
@@ -3995,6 +3995,7 @@ function factory() {
 
         self.request = function request(req) {
             var dfd = cockpit.defer();
+            var ret = dfd.promise;
 
             if (!req.path)
                 req.path = "/";
@@ -4056,14 +4057,14 @@ function factory() {
                     /* Anyone looking for response details? */
                     if (responsers) {
                         resp.headers = resp.headers || { };
-                        invoke_functions(responsers, self, [resp.status, resp.headers]);
+                        invoke_functions(responsers, ret, [resp.status, resp.headers]);
                     }
                     return true;
                 }
 
                 /* Fire any streamers */
                 if (resp.status >= 200 && resp.status <= 299 && streamer)
-                    return streamer(data);
+                    return streamer.call(ret, data);
 
                 return 0;
             });
@@ -4102,7 +4103,6 @@ function factory() {
 
             channel.addEventListener("close", on_close);
 
-            var ret = dfd.promise;
             ret.stream = function(callback) {
                 streamer = callback;
                 return ret;

--- a/src/base1/test-http.js
+++ b/src/base1/test-http.js
@@ -65,12 +65,13 @@ QUnit.asyncTest("with params", function() {
 });
 
 QUnit.asyncTest("not found", function() {
-    assert.expect(6);
+    assert.expect(7);
 
-    cockpit.http({ "internal": "/test-server" })
+    var promise = cockpit.http({ "internal": "/test-server" })
         .get("/not/found")
         .response(function(status, headers) {
             assert.equal(status, 404, "status code");
+            assert.strictEqual(this, promise, "got right this");
         })
         .fail(function(ex, data) {
             assert.strictEqual(ex.problem, null, "mapped to cockpit code");
@@ -85,13 +86,15 @@ QUnit.asyncTest("not found", function() {
 });
 
 QUnit.asyncTest("streaming", function() {
-    assert.expect(2);
+    assert.expect(3);
 
     var at = 0;
     var got = "";
-    cockpit.http({ "internal": "/test-server" })
+    var promise = cockpit.http({ "internal": "/test-server" })
         .get("/mock/stream")
         .stream(function(resp) {
+            if (at === 0)
+                assert.strictEqual(this, promise, "got right this");
             got += resp;
             at++;
         })
@@ -114,7 +117,7 @@ QUnit.asyncTest("close", function() {
     req.stream(function(resp) {
             at += 1;
             assert.equal(resp, "0 ", "first stream part");
-            req.close("bad-boy");
+            this.close("bad-boy");
         })
         .fail(function(ex) {
             assert.equal(ex.problem, "bad-boy", "right problem");

--- a/src/base1/test-spawn-proc.js
+++ b/src/base1/test-spawn-proc.js
@@ -129,7 +129,7 @@ QUnit.asyncTest("stream", function() {
     proc.input("33\n");
 });
 
-QUnit.asyncTest("stream", function() {
+QUnit.asyncTest("stream packets", function() {
     assert.expect(3);
 
     var streamed = "";

--- a/src/base1/test-spawn.js
+++ b/src/base1/test-spawn.js
@@ -192,7 +192,7 @@ QUnit.asyncTest("channel options", function() {
 });
 
 QUnit.asyncTest("streaming", function() {
-    assert.expect(12);
+    assert.expect(15);
 
     var peer = new MockPeer();
     $(peer).on("opened", function(event, channel) {
@@ -202,16 +202,20 @@ QUnit.asyncTest("streaming", function() {
     });
 
     var at = 0;
-    cockpit.spawn(["/unused"]).
+    var promise = cockpit.spawn(["/unused"]).
         stream(function(resp) {
             assert.equal(String(at), resp, "stream got right data");
+            if (at === 0)
+                assert.strictEqual(this, promise, "stream got right this");
             at++;
         }).
         done(function(resp) {
             assert.ok(!resp, "stream didn't send data to done");
+            assert.strictEqual(this, promise, "done got right this");
         }).
         always(function() {
             assert.equal(this.state(), "resolved", "split response didn't fail");
+            assert.strictEqual(this, promise, "always got right this");
             QUnit.start();
         });
 });

--- a/tools/semaphore-prepare
+++ b/tools/semaphore-prepare
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+change-phantomjs-version 2.1.1
 sudo apt-get update
 sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libgirepository1.0-dev libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-login-dev libsystemd-journal-dev pcp pkg-config valgrind xmlto xsltproc


### PR DESCRIPTION
This should have a this equal to the returned promise. This allows
code to operate on the promise without refering to an external
variable and is consistent with the other methods on the promise.