### PR TITLE
websocket: Remove support for Hixie76 WebSockets

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -99,7 +99,7 @@ The "open" command opens a new channel for payload.
 
 The following fields are defined:
 
- * "binary": If present, either "base64" or "raw"
+ * "binary": If present set to "raw"
  * "channel": A uniquely chosen channel id
  * "payload": A payload type, see below
  * "host": The destination host for the channel, defaults to "localhost"
@@ -110,9 +110,7 @@ The following fields are defined:
  * "capabilities": Optional, array of capability strings required from the bridge
  * "session": Optional, set to "private" or "shared". Defaults to "shared"
 
-If "binary" is set then this channel transfers binary messages. If "binary"
-is set to "base64" then messages in the channel are encoded using "base64",
-otherwise if it's set to "raw" they are transferred directly.
+If "binary" is set to "raw" then this channel transfers binary messages.
 
 After the command is sent, then the channel is assumed to be open. No response
 is sent. If for some reason the channel shouldn't or cannot be opened, then

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -357,7 +357,7 @@ function ParentWebSocket(parent) {
         if (event.origin !== transport_origin || event.source !== parent)
             return;
         var data = event.data;
-        if (data === undefined || data.length === undefined)
+        if (data === undefined || (data.length === undefined && data.byteLength === undefined))
             return;
         if (data.length === 0) {
             self.readyState = 3;

--- a/src/base1/test-base64.js
+++ b/src/base1/test-base64.js
@@ -24,9 +24,6 @@ QUnit.test("base64 array", function() {
 });
 
 QUnit.test("base64 arraybuffer", function() {
-    if (!window.Uint8Array)
-        return;
-
     var view = new Uint8Array(5);
     for (var i = 0; i < 5; i++)
         view[i] = i;

--- a/src/base1/test-framed.js
+++ b/src/base1/test-framed.js
@@ -21,7 +21,7 @@
                 var message = event.data;
                 if (message.length === 0) {
                     test.done(parent_tests + frame_tests);
-                } else if (message.indexOf('"init"') !== -1) {
+                } else if (message.indexOf && message.indexOf('"init"') !== -1) {
                     initialized = true;
                     frame.postMessage('\n{ "command": "init", "version": 1, \
                                            "a": "b", "host" : "frame_host"  }',

--- a/src/websocket/websocket.h
+++ b/src/websocket/websocket.h
@@ -72,19 +72,6 @@ typedef enum {
   WEB_SOCKET_STATE_CLOSED = 3,
 } WebSocketState;
 
-/*
- * The WebSocket flavors we speak, the only reason we even attempt
- * this silliness is to remain compatible with iPads and so on
- *
- * Note this is different from protocols as in Sec-WebSocket-Protocol
- * which is a protocol spoken over the WebSocket (such as cockpit1, or xmpp)
- */
-typedef enum {
-  WEB_SOCKET_FLAVOR_UNKNOWN = 0,   /* No flavor decided yet */
-  WEB_SOCKET_FLAVOR_RFC6455 = 13,  /* http://tools.ietf.org/html/rfc6455 */
-  WEB_SOCKET_FLAVOR_HIXIE76 = 76,  /* http://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-76 */
-} WebSocketFlavor;
-
 typedef struct _WebSocketConnection       WebSocketConnection;
 typedef struct _WebSocketConnectionClass  WebSocketConnectionClass;
 typedef struct _WebSocketClient           WebSocketClient;

--- a/src/websocket/websocketconnection.h
+++ b/src/websocket/websocketconnection.h
@@ -94,8 +94,6 @@ void            web_socket_connection_close               (WebSocketConnection *
                                                            gushort code,
                                                            const gchar *data);
 
-WebSocketFlavor web_socket_connection_get_flavor          (WebSocketConnection *self);
-
 G_END_DECLS
 
 #endif /* __WEB_SOCKET_CONNECTION_H__ */

--- a/src/websocket/websocketprivate.h
+++ b/src/websocket/websocketprivate.h
@@ -68,18 +68,11 @@ void             _web_socket_connection_take_io_stream    (WebSocketConnection *
 void             _web_socket_connection_take_incoming     (WebSocketConnection *self,
                                                            GByteArray *input_buffer);
 
-void             _web_socket_connection_set_flavor        (WebSocketConnection *self,
-                                                           WebSocketFlavor flavor);
-
 gboolean         _web_socket_connection_choose_protocol   (WebSocketConnection *self,
                                                            const gchar **protocols,
                                                            const gchar *value);
 
 gchar *          _web_socket_complete_accept_key_rfc6455  (const gchar *key);
-
-guint8 *         _web_socket_complete_challenge_hixie76   (guint number_1,
-                                                           guint number_2,
-                                                           guint8 challenge[16]);
 
 G_END_DECLS
 

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -1646,11 +1646,7 @@ on_web_socket_open (WebSocketConnection *connection,
   json_array_add_string_element (capabilities, "auth-method-results");
   json_array_add_string_element (capabilities, "multi");
   json_array_add_string_element (capabilities, "credentials");
-
-  if (web_socket_connection_get_flavor (connection) == WEB_SOCKET_FLAVOR_RFC6455)
-    {
-      json_array_add_string_element (capabilities, "binary");
-    }
+  json_array_add_string_element (capabilities, "binary");
   json_object_set_array_member (object, "capabilities", capabilities);
 
   info = json_object_new ();

--- a/tools/semaphore-prepare
+++ b/tools/semaphore-prepare
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+change-phantomjs-version 2.1.1
 sudo apt-get update
 sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libgirepository1.0-dev libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-login-dev libsystemd-journal-dev pcp pkg-config valgrind xmlto xsltproc


### PR DESCRIPTION
We implemented these to support phantomjs 1.0 and ancient webkit
versions. None of our supported browsers require Hixie76 flavor
websockets. Lets remove this code.