### PR TITLE
base1: Add ability to filter outgoing messages

### DIFF
--- a/doc/guide/cockpit-channel.xml
+++ b/doc/guide/cockpit-channel.xml
@@ -253,30 +253,34 @@ cockpit.transport.close([problem])
   <refsection id="cockpit-transport-filter">
     <title>cockpit.transport.filter()</title>
 <programlisting>
-cockpit.transport.filter(function(message, channel, control) { ... })
+cockpit.transport.filter(function(message, channelid, control) { ... }, [out])
 </programlisting>
     <para>Add a filter to the underlying channel transport. All incoming messages will be
-      passed to each of the filter callbacks that are registered.</para>
+      passed to each of the filter callbacks that are registered. If the <code>out</code>
+      argument is equal to <code>true</code> then the filter will receive outgoing messages
+      that being sent on the underlying channel transport.</para>
     <para>This function is rarely used.</para>
     <para>Filter callbacks are called in the order they are registered. If a filter
       callback returns <code>false</code> then the message will not be dispatched
       further, whether to other filters, or to channels, etc.</para>
 
     <para>The <code>message</code> is the string or array with the raw message including,
-      the framing. If <code>channel</code> is set to a string this is a payload
-      message in the specified channel. If <code>control</code> is set then this is
-      a control message, and the <code>control</code> argument contains the parsed
-      JSON object of the control message.</para>
+      the framing. The <code>channelid</code> is the channel identifier or an empty string
+      for control messages. If <code>control</code> is set then this is a control message,d
+      and the <code>control</code> argument contains the parsed JSON object of the
+      control message.</para>
   </refsection>
 
   <refsection id="cockpit-transport-inject">
     <title>cockpit.transport.inject()</title>
 <programlisting>
-cockpit.transport.inject(message)
+cockpit.transport.inject(message, [out])
 </programlisting>
     <para>Inject a message into the underlying channel transport. The <code>message</code>
       should be a <code>string</code> or an array of bytes, and should be valid
-      according to the Cockpit message protocol.</para>
+      according to the Cockpit message protocol. If the <code>out</code> argument is equal
+      to <code>false</code> then the message will be injected as an incoming message as if
+      it was received on the underlying channel transport.</para>
     <para>This function is rarely used. In general you should only <code>inject()</code>
       messages you got from a <code><link linkend="cockpit-transport-filter">filter()</link></code>.</para>
   </refsection>

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -203,7 +203,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                     if (control.credential)
                         index.authorize_changed(control.credential);
                 }
-                return true; /* still deliver locally */
 
             /* Forward message to relevant frame */
             } else if (channel) {
@@ -216,10 +215,11 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                         return false; /* Stop delivery */
                     }
                 }
-                /* Still deliver the message locally */
-                return true;
             }
-        });
+
+            /* Still deliver the message locally */
+            return true;
+        }, false);
 
         function perform_jump(child, control) {
             var current_frame = index.current_frame();
@@ -330,6 +330,7 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                 return;
 
             var source = source_by_name[child.name];
+            var control;
 
             /* Closing the transport */
             if (data.length === 0) {
@@ -340,7 +341,7 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
 
             /* A control message */
             if (data[0] == '\n') {
-                var control = JSON.parse(data.substring(1));
+                control = JSON.parse(data.substring(1));
                 if (control.command === "init") {
                     if (source)
                         unregister(source);
@@ -390,7 +391,7 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             }
 
             /* Everything else gets forwarded */
-            cockpit.transport.inject(data);
+            cockpit.transport.inject(data, true);
         }
 
 


### PR DESCRIPTION
We want to be able to have a cockpit.transport.filter() for
outgoing messages as well as the incoming messages. Ditto
for cockpit.transport.inject() where we want to be able to
inject incoming messages, not just outgoing.