### PR TITLE
containers: remove '-ti' flags from web service container

### DIFF
--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -13,8 +13,8 @@ RUN /container/install-package.sh && /container/prep-container.sh
 
 
 
-LABEL INSTALL /usr/bin/docker run -ti --rm --privileged -v /:/host IMAGE /container/atomic-install
-LABEL UNINSTALL /usr/bin/docker run -ti --rm --privileged -v /:/host IMAGE /container/atomic-uninstall
+LABEL INSTALL /usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-install
+LABEL UNINSTALL /usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-uninstall
 LABEL RUN /usr/bin/docker run -d --privileged --pid=host -v /:/host IMAGE /container/atomic-run --local-ssh
 
 # Look ma, no EXPOSE

--- a/containers/ws/Dockerfile.centos7
+++ b/containers/ws/Dockerfile.centos7
@@ -11,8 +11,8 @@ ADD . /container
 # Again see above ... we do our branching in shell script
 RUN /container/install-package.sh && /container/prep-container.sh
 
-LABEL INSTALL /usr/bin/docker run -ti --rm --privileged -v /:/host IMAGE /container/atomic-install
-LABEL UNINSTALL /usr/bin/docker run -ti --rm --privileged -v /:/host IMAGE /container/atomic-uninstall
+LABEL INSTALL /usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-install
+LABEL UNINSTALL /usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-uninstall
 LABEL RUN /usr/bin/docker run -d --privileged --pid=host -v /:/host IMAGE /container/atomic-run --local-ssh
 
 # Look ma, no EXPOSE

--- a/containers/ws/Dockerfile.testing.centos7
+++ b/containers/ws/Dockerfile.testing.centos7
@@ -13,8 +13,8 @@ RUN echo -e "[cockpit_test]\nname=Cockpit Test\nbaseurl=http://cbs.centos.org/re
 # Again see above ... we do our branching in shell script
 RUN /container/install-package.sh && /container/prep-container.sh
 
-LABEL INSTALL /usr/bin/docker run -ti --rm --privileged -v /:/host IMAGE /container/atomic-install
-LABEL UNINSTALL /usr/bin/docker run -ti --rm --privileged -v /:/host IMAGE /container/atomic-uninstall
+LABEL INSTALL /usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-install
+LABEL UNINSTALL /usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-uninstall
 LABEL RUN /usr/bin/docker run -d --privileged --pid=host -v /:/host IMAGE /container/atomic-run --local-ssh
 
 # Look ma, no EXPOSE


### PR DESCRIPTION
When trying to install/uninstall the `cockpit/ws` container via Ansible,
I found myself doing something like this:

`shell: python -c "import pty; pty.spawn(['atomic', 'install',
'cockpit/ws'])"`

All because the `INSTALL` and `UNINSTALL` labels were using the `-ti`
flags.  I was able to remove those flags and run the raw `docker`
command just fine, so let's just remove them completely.