### PR TITLE
ws: A new 'session' option for 'open' command

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -107,6 +107,7 @@ The following fields are defined:
  * "superuser": Optional. Use "require" to run as root, or "try" to attempt to run as root.
  * "group": A group that can later be used with the "kill" command.
  * "capabilities": Optional, array of capability strings required from the bridge
+ * "session": Optional, set to "private" or "shared". Defaults to "shared"
 
 If "binary" is set then this channel transfers binary messages. If "binary"
 is set to "base64" then messages in the channel are encoded using "base64",
@@ -128,6 +129,12 @@ An example of an open:
     }
 
 This message is sent to the cockpit-bridge.
+
+The caller can control whether to open a new bridge session or not by setting
+the "session" field to "private" or "shared". A "private" session will always
+start another bridge just for this channel. If this option is not specified
+then typically the channel will share an already existing session. There are
+certain heuristics for compatibility, where it defaults to private.
 
 The open fields are also used with external channels. External channels are
 channels that have their payload sent via a separate HTTP request or another

--- a/pkg/lib/machine-dialogs.js
+++ b/pkg/lib/machine-dialogs.js
@@ -144,7 +144,8 @@
 
             var machine = self.machines_ins.lookup(address);
             if (machine && machine.host_key && !machine.on_disk) {
-                conn_options['temp-session'] = false;
+                conn_options['temp-session'] = false; /* Compatiblity option */
+                conn_options['session'] = 'shared';
                 conn_options['host-key'] = machine.host_key;
             }
             var client = cockpit.channel(conn_options);
@@ -646,6 +647,7 @@
 
             if ($("#login-type").val() != 'stored') {
                 options['password'] = $("#login-custom-password").val();
+                options["session"] = 'shared';
                 if (!user) {
                     /* we don't want to save the default user for everyone
                      * so we pass current user as an option, but make sure the
@@ -653,7 +655,7 @@
                      */
                     if (self.user && self.user.name)
                         options["user"] = self.user.name;
-                    options["temp-session"] = false;
+                    options["temp-session"] = false; /* Compatibility option */
                 }
             }
 

--- a/pkg/lib/machines.js
+++ b/pkg/lib/machines.js
@@ -525,7 +525,8 @@
             };
 
             if (!machine.on_disk && machine.host_key) {
-                options['temp-session'] = false;
+                options['temp-session'] = false; /* Compatibility option */
+                options['session'] = 'shared';
                 options['host-key'] = machine.host_key;
             }
 


### PR DESCRIPTION
This session option controls whether a session is shared for the channel or a private session is opened.

This standardizes the various options that were used as heuristics before. Unfortunately we still have to support those options, but the goal is that this becomes predictable and introspectable going forward.