### PR TITLE
machines: Show VM screenshots

### DIFF
--- a/pkg/machines/actions.es6
+++ b/pkg/machines/actions.es6
@@ -162,7 +162,7 @@ export function setRefreshInterval(refreshInterval) {
 }
 
 export function updateOrAddVm({ id, name, state, osType, fqdn, uptime, currentMemory, rssMemory, vcpus, autostart,
-    actualTimeInMs, cpuTime }) {
+    actualTimeInMs, cpuTime, screenshot }) {
     let vm = {};
 
     if (id !== undefined) vm.id = id;
@@ -178,6 +178,7 @@ export function updateOrAddVm({ id, name, state, osType, fqdn, uptime, currentMe
 
     if (actualTimeInMs !== undefined) vm.actualTimeInMs = actualTimeInMs;
     if (cpuTime !== undefined) vm.cpuTime = cpuTime;
+    if (screenshot !== undefined) vm.screenshot = screenshot;
 
     return {
         type: 'UPDATE_ADD_VM',

--- a/pkg/machines/config.es6
+++ b/pkg/machines/config.es6
@@ -25,7 +25,8 @@
 const VMS_CONFIG = {
     DefaultRefreshInterval: 10000, // in ms
     Virsh: {
-        ConnectionParams: ['-c', 'qemu:///system']
+        ConnectionParams: ['-c', 'qemu:///system'],
+        ScreenshotResizeGeometry: 200,
     },
     isDev: false // TODO: make it configurable based on process.env.NODE_ENV
 };

--- a/pkg/machines/helpers.es6
+++ b/pkg/machines/helpers.es6
@@ -108,6 +108,10 @@ export function rephraseUI(key, original) {
     return transform[key][original];
 }
 
+export function random(min, max) {
+    return Math.floor(Math.random()*(max-min+1)+min);
+}
+
 // --- VM state functions --
 export function canReset(vmState) {
     return vmState == 'running' || vmState == 'idle' || vmState == 'paused';

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -182,6 +182,21 @@ VmOverviewTabRecord.propTypes = {
     value: PropTypes.string.isRequired
 }
 
+const VmScreenshot = ({alt, img}) => {
+    if (!img) {
+        return null;
+    }
+
+    const src = `data:image/png;base64,${img}`;
+    return (<td>
+        <img src={src} alt={alt} />
+    </td>);
+};
+VmScreenshot.propTypes = {
+    alt: PropTypes.string,
+    img: PropTypes.string.isRequired,
+};
+
 const VmOverviewTab = ({ vm }) => {
     return (<table className='machines-width-max'>
         <tr className='machines-listing-ct-body-detail'>
@@ -201,6 +216,8 @@ const VmOverviewTab = ({ vm }) => {
                     <VmOverviewTabRecord descr={_("Autostart:")} value={rephraseUI('autostart', vm.autostart)}/>
                 </table>
             </td>
+
+            <VmScreenshot alt={vm.name} img={vm.screenshot} />
         </tr>
     </table>);
 };

--- a/pkg/machines/manifest.json
+++ b/pkg/machines/manifest.json
@@ -8,5 +8,6 @@
         "label": "Virtual Machines",
         "path": "index.html"
      }
-  }
+  },
+  "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval';img-src 'self' data:"
 }

--- a/pkg/machines/services.es6
+++ b/pkg/machines/services.es6
@@ -30,13 +30,18 @@ export function spawnProcess({ cmd, args = [], stdin}) {
             console.error(`spawn '${cmd}' process error: "${JSON.stringify(ex)}", data: "${JSON.stringify(data)}"`));
 }
 
-export function spawnScript({ script }) {
+export function spawnScript({ script, failHandler }) {
     const spawnArgs = [script];
     logDebug(`spawn script args: ${spawnArgs}`);
 
     return spawn(cockpit.script(spawnArgs, [], { err: "message" }))
-        .fail((ex, data) =>
-            console.error(`spawn '${script}' script error: "${JSON.stringify(ex)}", data: "${JSON.stringify(data)}"`));
+        .fail((ex, data) => {
+            if (failHandler) {
+                failHandler(ex, data);
+            } else {
+                console.error(`spawn '${script}' script error: "${JSON.stringify(ex)}", data: "${JSON.stringify(data)}"`);
+            }
+        });
 }
 
 function spawn(command) {

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -285,6 +285,7 @@ Requires: %{name}-bridge >= %{required_base}
 Requires: %{name}-system >= %{required_base}
 Requires: libvirt
 Requires: libvirt-client
+Requires: ImageMagick
 
 %description machines
 The Cockpit components for managing virtual machines.


### PR DESCRIPTION
With this patch, recent screenshot is displayed for a running VM.

The screenshot is taken by 'virsh screenshot'.

New dependency on ImageMagick is introduced since the 'convert'
utility used for resizing of the picture.