### PR TITLE
ws: Add 'LoginTo' cockpit.conf option

### DIFF
--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -84,6 +84,15 @@ ProtocolHeader = X-Forwarded-Proto
         <listitem><para>Set the browser title for the login screen.</para></listitem>
       </varlistentry>
       <varlistentry>
+        <term><option>LoginTo</option></term>
+        <listitem>
+          <para>When set to <literal>true</literal> the <emphasis>Connect to</emphasis> option
+            on the login screen is visible and allows logging into another server. If this
+            option is not specified then it will be automatically detected based on whether
+            the <command>cockpit-ssh</command> process is available or not.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
         <term><option>MaxStartups</option></term>
         <listitem><para>Same as the <command>sshd</command> configuration option by the same name.
             Specifies the maximum number of concurrent login attempts
@@ -122,33 +131,33 @@ ProtocolHeader = X-Forwarded-Proto
   </refsect1>
 
   <refsect1 id="cockpit-conf-oauth">
-	  <title>OAuth</title>
-        <para>Cockpit can be configured to support the <ulink url="https://tools.ietf.org/html/rfc6749#section-4.2">
+    <title>OAuth</title>
+    <para>Cockpit can be configured to support the <ulink url="https://tools.ietf.org/html/rfc6749#section-4.2">
         implicit grant</ulink> OAuth authorization flow. When successful the resulting oauth
         token will be passed to cockpit-ws using the <literal>Bearer</literal> auth-scheme.
         For a login to be successful, cockpit will also need a to be configured to verify
         and allow <literal>Bearer</literal> tokens.</para>
-	<variablelist>
-	  <varlistentry>
-	    <term><option>URL</option></term>
-	    <listitem>
+      <variablelist>
+        <varlistentry>
+          <term><option>URL</option></term>
+          <listitem>
           <para>This is the url that cockpit will redirect the users browser to when it needs
           to obtain an oauth token. Cockpit will add a redirect_uri parameter to the url with
           the location of where the oauth provider should redirect to once a token has been
           obtained.</para>
-        </listitem>
-      </varlistentry>
-	  <varlistentry>
-	    <term><option>ErrorParam</option></term>
-	    <listitem>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+	  <term><option>ErrorParam</option></term>
+	  <listitem>
           <para>When a oauth provider redirects a user back to cockpit, look for this parameter
           in the querystring or fragment portion of the url to find a error message. When not
           provided it will default to <literal>error_description</literal></para>
-        </listitem>
-      </varlistentry>
-	  <varlistentry>
-	    <term><option>TokenParam</option></term>
-	    <listitem>
+          </listitem>
+        </varlistentry>
+	<varlistentry>
+        <term><option>TokenParam</option></term>
+        <listitem>
           <para>When a oauth provider redirects a user back to cockpit, look for this parameter
           in the querystring or fragment portion of the url to find the access token. When not
           provided it will default to <literal>access_token</literal></para>

--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -186,7 +186,7 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
         setup_path_globals (window.location.pathname);
 
         // Setup title
-        var title = environment.title;
+        var title = environment.page.title;
         if (!title)
             title = environment.hostname;
         document.title = title;
@@ -397,21 +397,22 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
     }
 
     function show_form(in_conversation) {
-        var option_state = id("option-group").getAttribute("data-state");
+        var connectable = environment.page.connect;
+        var expanded = id("option-group").getAttribute("data-state");
         id("login-wait-validating").style.display = "none";
         id("login").style.visibility = 'visible';
         id("login").style.display = "block";
         id("user-group").style.display = in_conversation ? "none" : "block";
         id("password-group").style.display = in_conversation ? "none" : "block";
-        id("option-group").style.display = in_conversation ? "none" : "block";
+        id("option-group").style.display = !connectable || in_conversation ? "none" : "block";
         id("conversation-group").style.display = in_conversation ? "block" : "none";
         id("login-button-text").textContent = "Log In";
         id("login-password-input").value = '';
 
-        if (in_conversation) {
+        if (!connectable || in_conversation) {
             id("server-group").style.display = "none";
         } else {
-            id("server-group").style.display = option_state ? "block" : "none";
+            id("server-group").style.display = expanded ? "block" : "none";
         }
 
 

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -99,6 +99,30 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         except subprocess.CalledProcessError:
             pass
 
+        # Change login screen options
+        b.logout()
+        b.wait_visible("#option-group")
+        m.execute("printf '[WebService]\nLoginTo = false\n' > /etc/cockpit/cockpit.conf")
+        m.restart_cockpit()
+        b.open("/system")
+        b.wait_present("#option-group")
+        b.wait_not_visible("#option-group")
+
+        # Default options be to display these options
+        m.execute("rm /etc/cockpit/cockpit.conf")
+        m.restart_cockpit()
+        b.open("/system")
+        b.wait_present("#option-group")
+        b.wait_visible("#option-group")
+
+        # And now we remove cockpit-ssh which affects the default
+        if m.image not in [ "continuous-atomic", "fedora-atomic", "rhel-atomic" ]:
+            m.execute("rm -f /usr/libexec/cockpit-ssh /usr/lib/cockpit/cockpit-ssh")
+            m.restart_cockpit()
+            b.open("/system")
+            b.wait_present("#option-group")
+            b.wait_not_visible("#option-group")
+
         self.allow_journal_messages ("Returning error-response ... with reason .*",
                             "pam_unix\(cockpit:auth\): authentication failure; .*",
                             "pam_unix\(cockpit:auth\): check pass; user unknown",


### PR DESCRIPTION
This option configures whether the 'Connect To' option on
the login page is visible or not.

In addition if the option is not specified, the default comes
from whether cockpit-ssh is present and executable.