### PR TITLE
Fix races in cockpit.cache() and related tests

### DIFF
--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -1645,10 +1645,15 @@ function factory() {
         var source;
 
         function callback() {
+            var value;
+
             /* Only run the callback if we have a result */
             if (storage[key] !== undefined) {
-                if (consumer(storage[key], org_key) === false)
-                    self.close();
+                value = storage[key];
+                window.setTimeout(function() {
+                    if (consumer(value, org_key) === false)
+                        self.close();
+                });
             }
         }
 
@@ -1673,8 +1678,18 @@ function factory() {
         }
 
         self.claim = function claim() {
-            if (!source)
-                source = provider(result, org_key);
+            if (source)
+                return;
+
+            /* In case we're unclaimed during the callback */
+            var claiming = { close: function() { } };
+            source = claiming;
+
+            var changed = provider(result, org_key);
+            if (source === claiming)
+                source = changed;
+            else
+                changed.close();
         };
 
         function unclaim() {

--- a/src/base1/test-cache.js
+++ b/src/base1/test-cache.js
@@ -51,13 +51,10 @@ QUnit.asyncTest("multi cache", function() {
         assert.equal(key, "test-key-b", "provider1 got right key");
         assert.equal(typeof result, "function", "provider1 got result function");
 
-        var timer = window.setTimeout(function() {
-            result({ myobject: "value1" });
-        }, 200);
+        result({ myobject: "value1" });
 
         return {
             close: function() {
-                window.clearTimeout(timer);
                 closed1 = true;
             }
         };

--- a/src/base1/test-framed-cache.js
+++ b/src/base1/test-framed-cache.js
@@ -26,11 +26,7 @@
         function provider(result, key) {
             test.equal(key, "cross-frame-cache", "parent provider got right key");
             test.equal(typeof result, "function", "parent provider got result function");
-
-            var timer = window.setTimeout(function() {
-                result({ myobject: "value" });
-                window.clearTimeout(timer);
-            }, 1000);
+            result({ myobject: "value" });
             return {
                 close: function() {}
             };
@@ -41,7 +37,7 @@
             test.equal(key, "cross-frame-cache", "parent consumer got right key");
             if (count === 1) {
                 test.equal(value.myobject, "value", "parent consumer got parent value");
-            } else {
+            } else if (count === 2) {
                 test.equal(value.myobject, "value2", "parent consumer got child value");
             }
         }
@@ -79,7 +75,7 @@
             if (count === 1) {
                 test.equal(value.myobject, "value", "child consumer got parent value");
                 cache.claim();
-            } else {
+            } else if (count == 2) {
                 test.equal(value.myobject, "value2", "child consumer got child value");
                 window.parent.postMessage("child-done", "*");
                 test.done();


### PR DESCRIPTION
There were several races in cockpit.cache() and related tests.

I'd considered removing this functionality, since we don't use
it ... but unfortunately it's now part of stable API.