### PR TITLE
tools: Require pam_shells for logging in

### DIFF
--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -447,7 +447,7 @@ PageAccountsCreate.prototype = {
     create: function() {
         var tasks = [
             function create_user() {
-                var prog = ["/usr/sbin/useradd"];
+                var prog = ["/usr/sbin/useradd", "-s", "/bin/bash"];
                 if ($('#accounts-create-real-name').val()) {
                     prog.push('-c');
                     prog.push($('#accounts-create-real-name').val());

--- a/test/verify/check-keys
+++ b/test/verify/check-keys
@@ -169,7 +169,7 @@ class TestKeys(MachineCase):
             return b.eval_js("cockpit.spawn([ '/bin/sh', '-c', 'ssh-add -l || true' ])")
 
         # Operating systems where auto loading doesn't work
-        auto_load = "atomic" not in os.environ.get("TEST_OS", "")
+        auto_load = "atomic" not in m.image
 
         # Put all the keys in place
         m.execute("mkdir -p /home/admin/.ssh")

--- a/test/verify/check-keys
+++ b/test/verify/check-keys
@@ -43,7 +43,7 @@ class TestKeys(MachineCase):
         self.allow_journal_messages(".*Failed to create file '/var/lib/cockpit/.*': Permission denied")
 
         # Create a user without any role
-        m.execute("useradd user -m -c 'User' || true")
+        m.execute("useradd user -s /bin/bash -m -c 'User' || true")
         m.execute("echo user:foobar | chpasswd")
 
         m.start_cockpit()

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -75,6 +75,14 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         else:
             b.wait_text("#login-error-message", "Permission denied")
 
+        # Try to login with disabled shell; this does not work on Atomic where
+        # we log in through ssh
+        if m.image not in ["continuous-atomic", "fedora-atomic", "rhel-atomic"]:
+            m.execute("usermod --shell /bin/false admin")
+            login("admin", "foobar")
+            b.wait_text_not("#login-error-message", "")
+            m.execute("usermod --shell /bin/bash admin")
+
         # Login as admin
         b.open("/system")
         login("admin", "foobar")

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -104,7 +104,7 @@ class TestReauthorize(MachineCase):
         m = self.machine
         b = self.browser
 
-        m.execute("useradd user -c 'Barney' || true")
+        m.execute("useradd user -s /bin/bash -c 'Barney' || true")
         m.execute("echo user:foobar | chpasswd")
 
 

--- a/test/verify/check-roles
+++ b/test/verify/check-roles
@@ -27,7 +27,7 @@ class TestRoles(MachineCase):
         b = self.browser
 
         # Create a user without any role
-        m.execute("useradd user -c 'User' || true")
+        m.execute("useradd user -s /bin/bash -c 'User' || true")
         m.execute("echo user:foobar | chpasswd")
 
         m.start_cockpit()

--- a/tools/cockpit.debian.pam
+++ b/tools/cockpit.debian.pam
@@ -4,6 +4,7 @@ auth       substack     common-auth
 auth       optional     pam_reauthorize.so prepare
 auth       optional     pam_ssh_add.so
 account    required     pam_nologin.so
+account    required     pam_shells.so
 account    include      common-account
 password   include      common-password
 # pam_selinux.so close should be the first session rule

--- a/tools/cockpit.pam
+++ b/tools/cockpit.pam
@@ -5,6 +5,7 @@ auth       include      postlogin
 auth       optional     pam_reauthorize.so prepare
 auth       optional     pam_ssh_add.so
 account    required     pam_nologin.so
+account    required     pam_shells.so
 account    include      password-auth
 password   include      password-auth
 # pam_selinux.so close should be the first session rule


### PR DESCRIPTION
Prevent users with /bin/false, /sbin/nologin or similar invalid shells
from logging into Cockpit.

Note: /sbin/nologin is still accepted in Fedora ≤ 25, which is a bug
(https://bugzilla.redhat.com/show_bug.cgi?id=1378893).

Fixes #3798