### PR TITLE
networkmanager: More precise slave detection

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1625,9 +1625,8 @@ PageNetworking.prototype = {
         self.model.list_interfaces().forEach(function (iface) {
 
             function has_master(iface) {
-                var connections =
-                    (iface.Device ? iface.Device.AvailableConnections : iface.Connections);
-                return connections.some(function (c) { return c.Masters && c.Masters.length > 0; });
+                return ((iface.Device && iface.Device.ActiveConnection && iface.Device.ActiveConnection.Master) ||
+                        (iface.MainConnection && iface.MainConnection.Masters.length > 0));
             }
 
             // Skip loopback
@@ -2736,6 +2735,9 @@ PageNetworkInterface.prototype = {
 
             con.Slaves.forEach(function (slave_con) {
                 slave_con.Interfaces.forEach(function(iface) {
+                    if (iface.MainConnection != slave_con)
+                        return;
+
                     var dev = iface.Device;
                     var is_active = (dev && dev.State == 100 && dev.Carrier === true);
 

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1067,6 +1067,16 @@ function NetworkManagerModel() {
                         con.Interfaces.push(obj);
                     });
                 }
+
+                // Explicitly prefer the active connection.  The
+                // active connection should have the most recent
+                // timestamp, but only when the activation was
+                // successful.  Also, there don't seem to be change
+                // notifications when the timestamp changes.
+
+                if (obj.Device && obj.Device.ActiveConnection && obj.Device.ActiveConnection.Connection) {
+                    obj.MainConnection = obj.Device.ActiveConnection.Connection;
+                }
             }
         ]
 

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -216,5 +216,37 @@ class TestNetworking(NetworkCase):
         b.wait_present("#network-interface-slaves tr[data-interface='%s']" % iface)
         b.wait_in_text("#network-interface .panel:contains('tbond')", m.address)
 
+    def testAmbiguousSlave(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/network")
+
+        iface = self.add_iface()
+        self.wait_for_iface(iface)
+
+        # Now 'iface' has a normal connection
+        con_id = self.iface_con_id(iface)
+        self.assertTrue(con_id != None)
+
+        # Manually create a bond and make 'iface' its slave via a
+        # second connection.  Cockpit should ignore that second
+        # connection and still show iface as a normal interface.
+        m.execute("nmcli con add type bond-slave ifname %s  con-name bond0-slave-1 master bond0" % iface)
+        m.execute("nmcli con add type bond ifname bond0 con-name bond0")
+
+        self.wait_for_iface("bond0", state="Configuring")
+        self.wait_for_iface(iface)
+
+        # Now activate 'iface' as a slave.  Cockpit should now ignore
+        # the first connection and show 'iface' as a slave of bond0.
+
+        m.execute("nmcli con up bond0-slave-1")
+        b.wait_not_present("#networking-interfaces tr[data-interface='%s']" % iface)
+
+        b.click("#networking-interfaces tr[data-interface='bond0'] td:first-child")
+        b.wait_visible("#network-interface")
+        b.wait_present("#network-interface-slaves tr[data-interface='%s']" % iface)
+
 if __name__ == '__main__':
     test_main()

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -56,13 +56,20 @@ class NetworkCase(MachineCase):
             m.execute("nmcli dev con %s" % iface)
         return iface
 
-    def wait_for_iface(self, iface, active=True):
+    def wait_for_iface(self, iface, active=True, state=None):
         sel = "#networking-interfaces tr[data-interface='%s']" % iface
+
+        if state:
+            text = state
+        elif active:
+            text = "10.111."
+        else:
+            text = "Inactive"
 
         try:
             self.browser.wait_present(sel)
             self.browser.wait_visible(sel)
-            self.browser.wait_in_text(sel, "10.111." if active else "Inactive")
+            self.browser.wait_in_text(sel, text)
         except:
             print "Interface %s didn't show up." % iface
             print self.browser.eval_js("$('#networking-interfaces').html()")


### PR DESCRIPTION
Only look at the main connection for a interface when determining
whether it is a slave.