### PR TITLE
networkmanager: Make slave On/Off button consistent with rest

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2750,7 +2750,7 @@ PageNetworkInterface.prototype = {
                                     [ $('<td>').text(""), $('<td>').text("") ] :
                                     $('<td colspan="2">').text(device_state_text(dev))),
                                    $('<td class="networking-row-configure">').append(
-                                       switchbox(is_active, function(val) {
+                                       switchbox(!!(dev && dev.ActiveConnection), function(val) {
                                            if (val) {
                                                with_checkpoint(
                                                    self.model,


### PR DESCRIPTION
For unknown reasons, it was using a different definition of "on",
taking the carrier into account as well.