### PR TITLE
Start moving message router logic into the bridge

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -105,7 +105,8 @@ The following fields are defined:
  * "host": The destination host for the channel, defaults to "localhost"
  * "user": Optional alternate user for authenticating with host
  * "superuser": Optional. Use "require" to run as root, or "try" to attempt to run as root.
- * "group": A group that can later be used with the "kill" command.
+ * "group": A group that can later be used with the "kill" command. You should avoid
+   using group names without punctuation as they can have special meanings.
  * "capabilities": Optional, array of capability strings required from the bridge
  * "session": Optional, set to "private" or "shared". Defaults to "shared"
 
@@ -309,9 +310,7 @@ The following fields are defined:
  * "host": optional string kills channels with the given host
  * "group": optional string to select only channels opened with the given "group"
 
-If no fields are specified then all channels are terminated. The "kill" command
-is not forwarded.
-
+If no fields are specified then all channels are terminated.
 
 Command: logout
 ---------------

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -5,8 +5,6 @@ noinst_LIBRARIES += \
 	$(NULL)
 
 libcockpit_stub_a_SOURCES = \
-	src/bridge/cockpitbridge.c \
-	src/bridge/cockpitbridge.h \
 	src/bridge/cockpitchannel.c \
 	src/bridge/cockpitchannel.h \
 	src/bridge/cockpitconnect.c \
@@ -34,6 +32,8 @@ libcockpit_stub_a_SOURCES = \
 	src/bridge/cockpitpaths.h \
 	src/bridge/cockpitnullchannel.c \
 	src/bridge/cockpitnullchannel.h \
+	src/bridge/cockpitrouter.c \
+	src/bridge/cockpitrouter.h \
 	src/bridge/cockpitstream.c \
 	src/bridge/cockpitstream.h \
 	src/bridge/cockpitwebsocketstream.c \
@@ -278,8 +278,6 @@ libexec_PROGRAMS += cockpit-pcp
 noinst_LIBRARIES += libcockpit-pcp.a
 
 libcockpit_pcp_a_SOURCES = \
-	src/bridge/cockpitbridge.c \
-	src/bridge/cockpitbridge.h \
 	src/bridge/cockpitchannel.c \
 	src/bridge/cockpitchannel.h \
 	src/bridge/cockpitconnect.c \
@@ -288,6 +286,8 @@ libcockpit_pcp_a_SOURCES = \
 	src/bridge/cockpitmetrics.h \
 	src/bridge/cockpitpcpmetrics.c \
 	src/bridge/cockpitpcpmetrics.h \
+	src/bridge/cockpitrouter.c \
+	src/bridge/cockpitrouter.h \
 	$(NULL)
 
 libcockpit_pcp_a_CFLAGS = \

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -18,8 +18,6 @@
  */
 #include "config.h"
 
-#include "cockpitbridge.h"
-
 #include "cockpitchannel.h"
 #include "cockpitdbusinternal.h"
 #include "cockpitdbusjson.h"
@@ -36,6 +34,7 @@
 #include "cockpitinternalmetrics.h"
 #include "cockpitpolkitagent.h"
 #include "cockpitportal.h"
+#include "cockpitrouter.h"
 #include "cockpitwebsocketstream.h"
 
 #include "common/cockpitassets.h"
@@ -373,7 +372,7 @@ run_bridge (const gchar *interactive,
             gboolean privileged_slave)
 {
   CockpitTransport *transport;
-  CockpitBridge *bridge;
+  CockpitRouter *router;
   gboolean terminated = FALSE;
   gboolean interupted = FALSE;
   gboolean closed = FALSE;
@@ -418,6 +417,9 @@ run_bridge (const gchar *interactive,
       g_setenv ("HOME", pwd->pw_dir, TRUE);
       g_setenv ("SHELL", pwd->pw_shell, TRUE);
     }
+
+  /* Set a path if nothing is set */
+  g_setenv ("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", 0);
 
   /* Reset the umask, typically this is done in .bashrc for a login shell */
   umask (022);
@@ -475,7 +477,7 @@ run_bridge (const gchar *interactive,
 
   pcp = cockpit_portal_new_pcp (transport);
 
-  bridge = cockpit_bridge_new (transport, payload_types, init_host);
+  router = cockpit_router_new (transport, payload_types, init_host);
   cockpit_dbus_user_startup (pwd);
   cockpit_dbus_setup_startup ();
   cockpit_dbus_process_startup ();
@@ -495,7 +497,7 @@ run_bridge (const gchar *interactive,
     g_object_unref (super);
 
   g_object_unref (pcp);
-  g_object_unref (bridge);
+  g_object_unref (router);
   g_object_unref (transport);
 
   cockpit_dbus_internal_cleanup ();

--- a/src/bridge/cockpitpcp.c
+++ b/src/bridge/cockpitpcp.c
@@ -21,7 +21,7 @@
 
 #include "cockpitchannel.h"
 #include "cockpitpcpmetrics.h"
-#include "cockpitbridge.h"
+#include "cockpitrouter.h"
 
 #include "common/cockpitjson.h"
 #include "common/cockpitlog.h"
@@ -76,7 +76,7 @@ main (int argc,
       char **argv)
 {
   CockpitTransport *transport;
-  CockpitBridge *bridge;
+  CockpitRouter *router;
   gboolean terminated = FALSE;
   gboolean closed = FALSE;
   GOptionContext *context;
@@ -135,14 +135,14 @@ main (int argc,
 
   transport = cockpit_pipe_transport_new_fds ("stdio", 0, outfd);
 
-  bridge = cockpit_bridge_new (transport, payload_types, NULL);
+  router = cockpit_router_new (transport, payload_types, NULL);
   g_signal_connect (transport, "closed", G_CALLBACK (on_closed_set_flag), &closed);
   send_init_command (transport);
 
   while (!closed && !terminated)
     g_main_context_iteration (NULL, TRUE);
 
-  g_object_unref (bridge);
+  g_object_unref (router);
   g_object_unref (transport);
 
   g_source_remove (sig_term);

--- a/src/bridge/cockpitrouter.h
+++ b/src/bridge/cockpitrouter.h
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COCKPIT_BRIDGE_H__
-#define __COCKPIT_BRIDGE_H__
+#ifndef __COCKPIT_ROUTER_H__
+#define __COCKPIT_ROUTER_H__
 
 #include "common/cockpittransport.h"
 
@@ -29,21 +29,18 @@ typedef struct {
   GType (* function) (void);
 } CockpitPayloadType;
 
-#define         COCKPIT_TYPE_BRIDGE           (cockpit_bridge_get_type ())
-#define         COCKPIT_BRIDGE(o)            (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_BRIDGE, CockpitBridge))
-#define         COCKPIT_BRIDGE_GET_CLASS(o)   (G_TYPE_INSTANCE_GET_CLASS ((o), COCKPIT_TYPE_BRIDGE, CockpitAuthClass))
-#define         COCKPIT_IS_BRIDGE_CLASS(k)    (G_TYPE_CHECK_CLASS_TYPE ((k), COCKPIT_TYPE_BRIDGE))
-#define         COCKPIT_IS_BRIDGE(o)          (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_BRIDGE))
+#define         COCKPIT_TYPE_ROUTER           (cockpit_router_get_type ())
+#define         COCKPIT_ROUTER(o)             (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_ROUTER, CockpitRouter))
+#define         COCKPIT_IS_ROUTER(o)          (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_ROUTER))
 
-typedef struct _CockpitBridge        CockpitBridge;
-typedef struct _CockpitBridgeClass   CockpitBridgeClass;
+typedef struct _CockpitRouter        CockpitRouter;
 
-GType           cockpit_bridge_get_type     (void) G_GNUC_CONST;
+GType           cockpit_router_get_type     (void) G_GNUC_CONST;
 
-CockpitBridge * cockpit_bridge_new          (CockpitTransport *transport,
+CockpitRouter * cockpit_router_new          (CockpitTransport *transport,
                                              CockpitPayloadType *supported_payloads,
                                              const gchar *init_host);
 
 G_END_DECLS
 
-#endif /* __COCKPIT_CHANNEL_H__ */
+#endif /* __COCKPIT_ROUTER_H__ */

--- a/src/bridge/stub.c
+++ b/src/bridge/stub.c
@@ -18,7 +18,6 @@
  */
 #include "config.h"
 
-#include "cockpitbridge.h"
 #include "cockpitchannel.h"
 #include "cockpitdbusinternal.h"
 #include "cockpitdbusjson.h"
@@ -27,6 +26,7 @@
 #include "cockpithttpstream.h"
 #include "cockpitnullchannel.h"
 #include "cockpitpackages.h"
+#include "cockpitrouter.h"
 #include "cockpitwebsocketstream.h"
 
 #include "common/cockpittransport.h"
@@ -109,7 +109,7 @@ static int
 run_bridge (const gchar *interactive)
 {
   CockpitTransport *transport;
-  CockpitBridge *bridge;
+  CockpitRouter *router;
   gboolean terminated = FALSE;
   gboolean interupted = FALSE;
   gboolean closed = FALSE;
@@ -157,7 +157,10 @@ run_bridge (const gchar *interactive)
   g_resources_register (cockpitassets_get_resource ());
   cockpit_web_failure_resource = "/org/cockpit-project/Cockpit/fail.html";
 
-  bridge = cockpit_bridge_new (transport, payload_types, init_host);
+  /* Set a path if nothing is set */
+  g_setenv ("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", 0);
+
+  router = cockpit_router_new (transport, payload_types, init_host);
   cockpit_dbus_process_startup ();
 
   g_signal_connect (transport, "closed", G_CALLBACK (on_closed_set_flag), &closed);
@@ -166,7 +169,7 @@ run_bridge (const gchar *interactive)
   while (!terminated && !closed && !interupted)
     g_main_context_iteration (NULL, TRUE);
 
-  g_object_unref (bridge);
+  g_object_unref (router);
   g_object_unref (transport);
   cockpit_packages_free (packages);
   packages = NULL;


### PR DESCRIPTION
This does a class rename and starts moving some of the router logic into the bridge. The first step is moving the kill and group logic over.