### PR TITLE
Add fence channel support

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -105,8 +105,7 @@ The following fields are defined:
  * "host": The destination host for the channel, defaults to "localhost"
  * "user": Optional alternate user for authenticating with host
  * "superuser": Optional. Use "require" to run as root, or "try" to attempt to run as root.
- * "group": A group that can later be used with the "kill" command. You should avoid
-   using group names without punctuation as they can have special meanings.
+ * "group": An optional channel group
  * "capabilities": Optional, array of capability strings required from the bridge
  * "session": Optional, set to "private" or "shared". Defaults to "shared"
 
@@ -143,6 +142,16 @@ WebSocket. In this case the "channel" field must not be present, and an
  * "content-disposition": a Content-Disposition header for GET responses
  * "content-type": a Content-Type header for GET responses
  * "protocols": an array of possible protocols for a WebSocket
+
+Channel "group" fields can be used to group channels into groups. You should
+prefix your groups with a reverse domain name so they don't conflict with
+other or Cockpit's group names. Group names without any punctuation are
+reserved.
+
+One such special group name is the "fence" group. While any channels are
+open in the "fence" group, any channels opened after that point will be
+blocked and wait until all channels in the "fence" group are closed before
+resuming.
 
 Command: close
 --------------

--- a/src/bridge/cockpitchannel.c
+++ b/src/bridge/cockpitchannel.c
@@ -434,8 +434,12 @@ cockpit_channel_set_property (GObject *object,
     case PROP_FROZEN:
       if (g_value_get_boolean (value))
         {
+          if (!self->priv->frozen)
+            self->priv->frozen = g_queue_new ();
+        }
+      else
+        {
           g_assert (self->priv->frozen == NULL);
-          self->priv->frozen = g_queue_new ();
         }
       break;
     default:
@@ -603,7 +607,7 @@ cockpit_channel_class_init (CockpitChannelClass *klass)
    */
   g_object_class_install_property (gobject_class, PROP_FROZEN,
                                    g_param_spec_boolean ("frozen", "frozen", "frozen", FALSE,
-                                                         G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS));
+                                                         G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
 
   /**
    * CockpitChannel::closed:

--- a/src/bridge/cockpitchannel.h
+++ b/src/bridge/cockpitchannel.h
@@ -71,6 +71,8 @@ struct _CockpitChannelClass
 
 GType               cockpit_channel_get_type          (void) G_GNUC_CONST;
 
+void                cockpit_channel_thaw              (CockpitChannel *self);
+
 void                cockpit_channel_close             (CockpitChannel *self,
                                                        const gchar *problem);
 
@@ -82,8 +84,6 @@ void                cockpit_channel_fail              (CockpitChannel *self,
 const gchar *       cockpit_channel_get_id            (CockpitChannel *self);
 
 /* Used by implementations */
-
-void                cockpit_channel_prepare           (CockpitChannel *self);
 
 void                cockpit_channel_control           (CockpitChannel *self,
                                                        const gchar *command,

--- a/src/bridge/test-fs.c
+++ b/src/bridge/test-fs.c
@@ -95,7 +95,7 @@ setup_fsread_channel (TestCase *tc,
   tc->channel = cockpit_fsread_open (COCKPIT_TRANSPORT (tc->transport), "1234", path);
   tc->channel_closed = FALSE;
   g_signal_connect (tc->channel, "closed", G_CALLBACK (on_channel_close), tc);
-  cockpit_channel_prepare (tc->channel);
+  cockpit_channel_thaw (tc->channel);
 }
 
 static void
@@ -106,7 +106,7 @@ setup_fsreplace_channel (TestCase *tc,
   tc->channel = cockpit_fsreplace_open (COCKPIT_TRANSPORT (tc->transport), "1234", path, tag);
   tc->channel_closed = FALSE;
   g_signal_connect (tc->channel, "closed", G_CALLBACK (on_channel_close), tc);
-  cockpit_channel_prepare (tc->channel);
+  cockpit_channel_thaw (tc->channel);
 }
 
 static void
@@ -116,7 +116,7 @@ setup_fswatch_channel (TestCase *tc,
   tc->channel = cockpit_fswatch_open (COCKPIT_TRANSPORT (tc->transport), "1234", path);
   tc->channel_closed = FALSE;
   g_signal_connect (tc->channel, "closed", G_CALLBACK (on_channel_close), tc);
-  cockpit_channel_prepare (tc->channel);
+  cockpit_channel_thaw (tc->channel);
 }
 
 static void

--- a/src/bridge/test-pcp-archives.c
+++ b/src/bridge/test-pcp-archives.c
@@ -136,7 +136,7 @@ setup_metrics_channel_json (TestCase *tc, JsonObject *options)
                               NULL);
   tc->channel_closed = FALSE;
   g_signal_connect (tc->channel, "closed", G_CALLBACK (on_channel_close), tc);
-  cockpit_channel_prepare (tc->channel);
+  cockpit_channel_thaw (tc->channel);
 
   /* Switch off compression by default.  Compression is done by
    * comparing two floating point values for exact equality, and we

--- a/src/bridge/test-pcp.c
+++ b/src/bridge/test-pcp.c
@@ -123,7 +123,7 @@ setup_metrics_channel_json (TestCase *tc, JsonObject *options)
                               NULL);
   tc->channel_closed = FALSE;
   g_signal_connect (tc->channel, "closed", G_CALLBACK (on_channel_close), tc);
-  cockpit_channel_prepare (tc->channel);
+  cockpit_channel_thaw (tc->channel);
 
   /* We work with real timestamps here but we don't want the
      interpolation to change any of our sample values.


### PR DESCRIPTION
A fence channel is required to complete before channels opened after it can proceed. Other channels are frozen and their messages are queued in the bridge. This is required by the polkit agent.

 * [x] Implementation:
 * [x] Unit tests

Depends on:

 * [x] #5669 
 * [x] #5685 
 * [x] #5621 (laziness)