### PR TITLE
test: Add known issue for NetworkManager crash on Fedora 25

### DIFF
--- a/test/verify/naughty-fedora-25/5671-network-manager-crash-assertion
+++ b/test/verify/naughty-fedora-25/5671-network-manager-crash-assertion
@@ -1,0 +1,1 @@
+Error: org.freedesktop.NetworkManager: couldn't introspect*GDBus.Error:org.freedesktop.DBus.Error.NoReply: Message recipient disconnected from message bus without replying


### PR DESCRIPTION
NetworkManager crashes due to assertion failure.

https://bugzilla.redhat.com/show_bug.cgi?id=1409896