### PR TITLE
test: Ignore authorization failure messages in check-session

### DIFF
--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -27,6 +27,7 @@ class TestSession(MachineCase):
         b = self.browser
 
         self.allow_restart_journal_messages()
+        self.allow_authorize_journal_messages()
         # Might happen when killing the bridge.
         self.allow_journal_messages("localhost: dropping message while waiting for child to exit",
                                     "cockpit-polkit helper was terminated with signal: 15",


### PR DESCRIPTION
This test is run without reuse of the password allowed for
reauthorization. So it shouldn't be a surprise that these
messages show up here.