### PR TITLE
package.json: Add phantomjs

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -159,8 +159,6 @@ In addition for testing the following dependencies are required:
          curl libvirt-client libvirt-python libvirt python-lxml \
          krb5-workstation krb5-server selinux-policy-devel
 
-    $ npm install phantomjs-prebuilt
-
 Cockpit uses the autotools and thus there are the familiar `./configure`
 script and the familar Makefile targets.
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "less": "~2.6.0",
     "less-loader": "~2.2.3",
     "ng-cache-loader": "0.0.16",
+    "phantomjs-prebuilt": "~2.1.14",
     "po2json": "~0.4.1",
     "promise": "~7.1.1",
     "raw-loader": "~0.5.1",

--- a/test/README
+++ b/test/README
@@ -9,10 +9,6 @@ To run the tests on Fedora, you need to install the following packages:
          libvirt-client openssl libguestfs-tools \
          krb5-workstation expect rsync libvirt-python curl xz
 
-Testing requires phantomjs inside the cockpit package.
-
-    $ npm install phantomjs-prebuilt
-
 ## Introduction
 
 To run the integration tests run the following. Don't run the integration tests


### PR DESCRIPTION
This removes the requirement of installing it manually, and every test
preparation would otherwise remove the local installation again
(autogen.sh calls "npm prune").

Fixes #5676