### PR TITLE
test: Add another storaged crasher on CentOS 7

### DIFF
--- a/test/verify/naughty-centos-7/5331-storaged-crash-poll-with-variant-5
+++ b/test/verify/naughty-centos-7/5331-storaged-crash-poll-with-variant-5
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+  File "./verify/check-storage-lvm2", line 174, in testLvm
+    self.dialog({ "size": 10 })
+*
+Error: timeout
+No such interface 'org.storaged.Storaged.LogicalVolume' on object at path /org/storaged/Storaged/lvm/vgroup0/lvol0


### PR DESCRIPTION
This is already a known issue, just another instance of it.

See Issue #5331