### PR TITLE
tests: Stop using ostree trivial-httpd

### DIFF
--- a/test/images/scripts/lib/atomic.install
+++ b/test/images/scripts/lib/atomic.install
@@ -79,8 +79,18 @@ class AtomicCockpitInstaller:
         if self.verbose:
             print "install new ostree commit"
 
-        port = subprocess.check_output(["ostree", "trivial-httpd", self.repo_location,
-                                        "-p", "-", "-d"])
+        newenv = dict(os.environ)
+        newenv['PYTHONUNBUFFERED'] = '1'
+        webserver_proc = subprocess.Popen(['python', '-m', 'SimpleHTTPServer', '0'],
+                                          stdout=subprocess.PIPE,
+                                          cwd=self.repo_location, env=newenv)
+        webserver_status = webserver_proc.stdout.readline()
+        pattern = r'port ([0-9]+)'
+        m = re.search(pattern, webserver_status)
+        if m is None:
+            sys.stderr.write("Failed to find {} in {}\n".format(pattern, webserver_status))
+            sys.exit(1)
+        port = int(m.group(1))
 
         # Not an error if this fails
         subprocess.call(["ostree", "remote", "delete", "local"])

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -40,11 +40,22 @@ KEY_ID = "95A8BA1754D0E95E2B3A98A7EE15015654780CBD"
 def start_trivial_httpd(m):
     remote = m.execute("ostree remote show-url local")
     parts = remote.strip().split(":")
+    port = parts[-1]
 
-    # If ostree supports rpm-ostreed then it support the -P option
-    args = [parts[-1], REPO_LOCATION]
-    m.execute("ostree trivial-httpd -d -P {0} {1} ".format(*args))
-
+    newenv = dict(os.environ)
+    newenv['PYTHONUNBUFFERED'] = '1'
+    webserver_proc = subprocess.Popen(['python', '-m', 'SimpleHTTPServer', port],
+                                      stdout=subprocess.PIPE,
+                                      cwd=REPO_LOCATION, env=newenv)
+    webserver_status = webserver_proc.stdout.readline()
+    pattern = r'port ([0-9]+)'
+    m = re.search(pattern, webserver_status)
+    if m is None:
+        sys.stderr.write("Failed to find {} in {}\n".format(pattern, webserver_status))
+        sys.exit(1)
+    running_port = m.group(1)
+    assert port == running_port
+    return webserver_proc
 
 def generate_new_commit(m, pkg_to_remove):
     # Make one change of each type to a new rpm tree
@@ -180,7 +191,7 @@ class OstreeRestartCase(MachineCase):
         b.wait_present("table.listing-ct tbody:nth-child(2) div.listing-ct-actions button.enabled")
 
         # Serve repo
-        start_trivial_httpd(m)
+        webserver = start_trivial_httpd(m)
 
         # Check for new commit
         b.click("table.listing-ct tbody:nth-child(2) div.listing-ct-actions button")
@@ -232,7 +243,7 @@ class OstreeRestartCase(MachineCase):
         b.wait_present("table.listing-ct tbody:nth-child(3) div.listing-ct-actions button.disabled")
         b.wait_present("table.listing-ct tbody:nth-child(3) div.listing-ct-actions button.enabled")
         b.wait_present('table.listing-ct tbody:nth-child(3) div.listing-ct-error')
-        start_trivial_httpd(m)
+        webserver = start_trivial_httpd(m)
 
         # Apply update
         b.click("table.listing-ct tbody:nth-child(3) div.listing-ct-actions button")


### PR DESCRIPTION
I'm trying to add a libcurl backend to ostree, and I'd like people to stop using
trivial-httpd; it was a mistake to have it be command line API.

Related: https://github.com/ostreedev/ostree/pull/636

(Note I didn't test this commit)