### PR TITLE
Actually finish container image scan display

### DIFF
--- a/pkg/docker/containers-view.jsx
+++ b/pkg/docker/containers-view.jsx
@@ -481,7 +481,6 @@ var ImageList = React.createClass({
                 data: {
                     image: image,
                     info: vulnerableInfo,
-                    atomic: this.atomic
                 }
             });
         }

--- a/pkg/docker/containers-view.jsx
+++ b/pkg/docker/containers-view.jsx
@@ -116,7 +116,7 @@ var ContainerDetails = React.createClass({
     render: function () {
         var container = this.props.container;
         return (
-            <div className='listing-body'>
+            <div className='listing-ct-body'>
                 <dl>
                     <dt>{_("Id")}      </dt> <dd>{ container.Id }</dd>
                     <dt>{_("Created")} </dt> <dd>{ container.Created }</dd>
@@ -295,7 +295,7 @@ var ImageDetails = React.createClass({
         }
 
         return (
-            <div className='listing-body'>
+            <div className='listing-ct-body'>
                 <dl>
                     <dt>{_("Id")}</dt>         <dd title={image.Id}>{ docker.truncate_id(image.Id) }</dd>
                     <dt>{_("Entrypoint")}</dt> <dd>{ util.quote_cmdline(entrypoint) }</dd>

--- a/pkg/docker/containers-view.jsx
+++ b/pkg/docker/containers-view.jsx
@@ -297,12 +297,12 @@ var ImageDetails = React.createClass({
         return (
             <div className='listing-body'>
                 <dl>
-                    <dt>Id         </dt> <dd title={image.Id}>{ docker.truncate_id(image.Id) }</dd>
-                    <dt>Entrypoint </dt> <dd>{ util.quote_cmdline(entrypoint) }</dd>
-                    <dt>Command    </dt> <dd>{ util.quote_cmdline(command) }</dd>
-                    <dt>Created    </dt> <dd title={ created.toLocaleString() }>{ created.fromNow() }</dd>
-                    <dt>Author     </dt> <dd>{ image.Author}</dd>
-                    <dt>Ports      </dt> <dd>{ ports.join(', ')  }</dd>
+                    <dt>{_("Id")}</dt>         <dd title={image.Id}>{ docker.truncate_id(image.Id) }</dd>
+                    <dt>{_("Entrypoint")}</dt> <dd>{ util.quote_cmdline(entrypoint) }</dd>
+                    <dt>{_("Command")}</dt>    <dd>{ util.quote_cmdline(command) }</dd>
+                    <dt>{_("Created")}</dt>    <dd title={ created.toLocaleString() }>{ created.fromNow() }</dd>
+                    <dt>{_("Author")}</dt>     <dd>{ image.Author}</dd>
+                    <dt>{_("Ports")}</dt>      <dd>{ ports.join(', ')  }</dd>
                 </dl>
             </div>
         );

--- a/pkg/docker/containers-view.jsx
+++ b/pkg/docker/containers-view.jsx
@@ -209,13 +209,20 @@ var ContainerList = React.createClass({
         var rows = filtered.map(function (container) {
             var isRunning = !!container.State.Running;
 
+            var state;
+            if (this.props.client.waiting[container.Id]) {
+                state = { element: <div className="spinner"></div>, tight: true }
+            } else {
+                state = util.render_container_status(container.State)
+            }
+
             var columns = [
                 { name: container.Name.replace(/^\//, ''), header: true },
                 docker.truncate_id(container.Image),
                 util.render_container_cmdline(container),
                 util.format_cpu_usage(container.CpuUsage),
                 util.format_memory_and_limit(container.MemoryUsage, container.MemoryLimit),
-                util.render_container_status(container.State)
+                state,
             ];
 
             var startStopActions = [];
@@ -509,16 +516,23 @@ var ImageList = React.createClass({
                 );
         }
 
+        var element;
+        if (this.props.client.waiting[image.Id]) {
+            element = <div className="spinner"></div>
+        } else {
+            element = <button className="btn btn-default btn-control-ct fa fa-play"
+                    onClick={ this.showRunImageDialog.bind(this) }
+                    data-image={image.Id} />
+        }
+
         var columns = [
             { name: image.RepoTags[0], header: true },
             vulnerabilityColumn,
             moment.unix(image.Created).fromNow(),
             cockpit.format_bytes(image.VirtualSize),
             {
-                element: <button className="btn btn-default btn-control-ct fa fa-play"
-                    onClick={ this.showRunImageDialog.bind(this) }
-                    data-image={image.Id} />,
-                    tight: true
+                element: element,
+                tight: true
             }
         ];
 

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -300,13 +300,6 @@
     height: 120px;
 }
 
-/* Display properly when there are several tags */
-#image-details .panel-heading {
-    min-height: 44px;
-    height: auto;
-}
-
-#image-details .panel-heading .pull-right,
 #container-details .panel-heading .pull-right {
     height: 25px;
 }
@@ -608,4 +601,9 @@ table.drive-list td:nth-child(2) img {
     padding-left: 32px;
     padding-top: 1em;
     color: #888;
+}
+
+#image-details .listing-ct-inline {
+    padding-left: 20px;
+    padding-right: 20px;
 }

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -31,6 +31,10 @@
     width: 5px;
 }
 
+div.spinner {
+    display: inline-block;
+}
+
 /*
  * For showing and filtering disabled unimportant rows in a table
  *

--- a/pkg/docker/image.js
+++ b/pkg/docker/image.js
@@ -22,8 +22,10 @@
 
     var $ = require("jquery");
     var cockpit = require("cockpit");
+    var React = require("react");
 
     var util = require("./util");
+    var view = require("./containers-view.jsx");
 
     require("./run");
 
@@ -95,46 +97,23 @@
         },
 
         update: function() {
-            $('#image-details-id').text("");
-            $('#image-details-entrypoint').text("");
-            $('#image-details-command').text("");
-            $('#image-details-created').text("");
-            $('#image-details-author').text("");
-            $('#image-details-ports').text("");
-
             var info = this.client.images[this.image_id];
             util.docker_debug("image-details", this.image_id, info);
 
-            if (!info) {
-                $('#image-details-id').text(_("Not found"));
-                return;
-            }
+            React.render(React.createElement(view.ImageInline, {
+                image: info
+            }), document.querySelector('#image-details .content'));
 
             var waiting = !!(this.client.waiting[this.image_id]);
-            $('#image-details-buttons div.waiting').toggle(waiting);
-            $('#image-details-buttons button').toggle(!waiting);
+            $('#image-details-buttons div.waiting').toggle(info && waiting);
+            $('#image-details-buttons button').toggle(info && !waiting);
 
-            if (info.RepoTags && info.RepoTags.length > 0)
-                this.name = info.RepoTags[0];
-
-            $('#image-details .content-filter h3 span').text(this.name);
-
-            $('#image-details-id').text(info.Id);
-            $('#image-details-tags').html(util.multi_line(info.RepoTags));
-            $('#image-details-created').text(info.Created);
-            $('#image-details-author').text(info.Author);
-
-            var config = info.Config;
-            if (config) {
-                var ports = [ ];
-                for (var p in config.ExposedPorts) {
-                    ports.push(p);
-                }
-
-                $('#image-details-entrypoint').text(util.quote_cmdline(config.Entrypoint));
-                $('#image-details-command').text(util.quote_cmdline(config.Cmd));
-                $('#image-details-ports').text(ports.join(', '));
+            if (info) {
+                if (info.RepoTags && info.RepoTags.length > 0)
+                    this.name = info.RepoTags[0];
             }
+
+            $('#image-details .content-filter h3 span').text(this.name || this.image_id);
         },
 
         maybe_render_container: function(id, container) {

--- a/pkg/docker/image.js
+++ b/pkg/docker/image.js
@@ -105,7 +105,7 @@
             }), document.querySelector('#image-details .content'));
 
             var waiting = !!(this.client.waiting[this.image_id]);
-            $('#image-details-buttons div.waiting').toggle(info && waiting);
+            $('#image-details-buttons div.spinner').toggle(info && waiting);
             $('#image-details-buttons button').toggle(info && !waiting);
 
             if (info) {

--- a/pkg/docker/image.js
+++ b/pkg/docker/image.js
@@ -37,7 +37,7 @@
         },
 
         getTitle: function() {
-            return C_("page-title", "Containers");
+            return C_("page-title", "Images");
         },
 
         toggle_danger: function(val) {

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -228,71 +228,45 @@
 
   <!-- IMAGE DETAILS -->
 
-  <div id="image-details" class="container-fluid" hidden>
+  <div id="image-details" hidden>
     <div class="content-filter">
+      <div class="listing-ct-actions" id="image-details-buttons">
+        <button class="btn btn-default" id="image-details-run"
+            data-toggle="modal" data-target="#containers_run_image_dialog" translate>Run</button>
+        <button  title="Delete" translate="title" id="image-details-delete"
+            class="btn btn-danger btn-delete pficon pficon-delete"></button>
+        <div class="spinner" hidden></div>
+      </div>
       <h3>
         <i class="pficon pficon-image"></i>
         <span></span>
       </h3>
       <a translatable="yes">Show all images</a>
     </div>
-    <div class="panel-default panel">
-      <div class="panel-heading">
-        <div class="pull-right" id="image-details-buttons">
-          <button class="btn btn-default" id="image-details-run"
-              data-toggle="modal" data-target="#containers_run_image_dialog" translate>Run</button>
-          <button class="btn btn-danger" id="image-details-delete" translate>Delete</button>
-          <div class="spinner" hidden></div>
-        </div>
-        <span translate>Image:</span> <span id="image-details-tags"></span>
-      </div>
-      <div class="panel-body">
-        <table class="info-table-ct">
-	  <tr>
-            <td translate>Id:</td>
-            <td id="image-details-id"></td>
-          </tr>
-	  <tr>
-            <td translate>Entrypoint:</td>
-            <td id="image-details-entrypoint"></td>
-          </tr>
-	  <tr>
-            <td translate>Command:</td>
-            <td id="image-details-command"></td>
-          </tr>
-	  <tr>
-            <td translate>Created:</td>
-            <td id="image-details-created"></td>
-          </tr>
-	  <tr>
-            <td translate>Author:</td>
-            <td id="image-details-author"></td>
-          </tr>
-	  <tr>
-            <td translate>Ports:</td>
-            <td id="image-details-ports"></td>
-          </tr>
-        </table>
-      </div>
+
+    <div class="content">
     </div>
 
-    <div class="panel panel-default image-details-used" id="image-details-containers">
-      <div class="panel-heading" translate>Containers</div>
-      <table class="table table-hover">
-        <thead>
-          <tr>
-            <th class="container-column-name" translate>Name</th>
-            <th class="container-column-image" translate>Image</th>
-            <th class="container-column-command" translate>Command</th>
-            <th class="container-column-cpu" translate>CPU</th>
-            <th class="container-column-memory-graph" translate>Memory</th>
-            <th class="container-column-memory-text"></th>
-            <th class="container-column-actions cell-buttons"></th>
-          </tr>
-        </thead>
-        <tbody>
-        </tbody>
-      </table>
+    <div class="listing-ct-inline image-details-used">
+      <div><!-- TODO: This tag is a hack until below code is migrated to React --></div>
+      <h3 translate>Used by Containers</h3>
+      <div class="panel panel-default" id="image-details-containers">
+        <table class="table table-hover">
+          <thead>
+            <tr>
+              <th class="container-column-name" translate>Name</th>
+              <th class="container-column-image" translate>Image</th>
+              <th class="container-column-command" translate>Command</th>
+              <th class="container-column-cpu" translate>CPU</th>
+              <th class="container-column-memory-graph" translate>Memory</th>
+              <th class="container-column-memory-text"></th>
+              <th class="container-column-actions cell-buttons"></th>
+            </tr>
+          </thead>
+          <tbody>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 

--- a/pkg/lib/page.css
+++ b/pkg/lib/page.css
@@ -60,6 +60,7 @@ a {
 /* Well and Blankslate */
 
 .curtains-ct {
+    top: 0px;
     height: 100%;
     width: 100%;
     position: fixed;

--- a/pkg/ostree/ostree.css
+++ b/pkg/ostree/ostree.css
@@ -27,12 +27,6 @@
     display: none !important;
 }
 
-.curtains-ct {
-    height: 100%;
-    width: 100%;
-    position: fixed;
-}
-
 #ostree-software-update {
     max-width: 1000px;
 }

--- a/pkg/shell/shell.css
+++ b/pkg/shell/shell.css
@@ -32,6 +32,10 @@ html.index-page body {
     overflow: hidden;
 }
 
+.curtains-ct {
+    top: auto;
+}
+
 #dashboard-add {
     height: 28px;
     width: 28px;

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -579,6 +579,15 @@ class TestAtomicScan(MachineCase):
         # Security tab should exist
         b.click(row_selector + ' td.listing-ct-toggle')
         b.wait_visible(row_selector + ' + tr a:contains("Security")')
+        b.click(row_selector + ' + tr a:contains("Security")')
+        b.wait_in_text(row_selector + ' + tr', 'Verify and Correct File Permissions with RPM')
+
+        # Collapse the tab and click through to the image
+        b.click(row_selector + ' td.listing-ct-toggle')
+        b.click(row_selector + ' th')
+        b.wait_visible("#image-details")
+        b.wait_in_text("#image-details", "Security")
+        b.wait_in_text("#image-details", "Verify and Correct File Permissions with RPM")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
So the work done on container image scanning and using React to render image details has regressions and is incomplete ... even just to view an image scan. In particular:

 * Missing security information on the image details page
 * Inconsistent display of image details between listing view and details page
 * Broken translations
 * Spinners for deleting images are broken.
 * Various other minor bugs and typos

I was trying to write release notes, and do a release, but unfortunately this just isn't ready.

Depends on:

 * [x] #5689 