### PR TITLE
docker: Ignore '500 layer does not exist' errors

### DIFF
--- a/pkg/docker/client.js
+++ b/pkg/docker/client.js
@@ -25,6 +25,14 @@
     var util = require("./util");
     var docker = require("./docker");
 
+    function ignoreException(ex) {
+        if (ex.status == 500 && ex.message && ex.message.indexOf("layer does not exist") === 0) {
+            console.warn(ex);
+            return true;
+        }
+        return false;
+    }
+
     /* DOCKER CLIENT
      */
 
@@ -187,7 +195,7 @@
                     });
                 }).
                 fail(function(ex) {
-                    if (connected) {
+                    if (connected && !ignoreException(ex)) {
                         got_failure = true;
                         $(self).trigger("failure", [ex]);
                     }
@@ -322,7 +330,7 @@
                     });
                 }).
                 fail(function(ex) {
-                    if (connected) {
+                    if (connected && !ignoreException(ex)) {
                         got_failure = true;
                         $(self).trigger("failure", [ex]);
                     }


### PR DESCRIPTION
These errors come from Docker and I've seen them on the command
line too. However we currently show the curtains and completely shut
down the page when such an error occurs. Instead we need to log and
ignore it.