### PR TITLE
docker: Fix display of containers where an image is in use

### DIFF
--- a/pkg/docker/image.js
+++ b/pkg/docker/image.js
@@ -80,15 +80,15 @@
                     self.update();
             });
 
+            $('#image-details .image-details-used').toggle(false);
+
             $(this.client).on('container.image-details', function(event, id, container) {
-                if (!container || (container.Config && container.Config.Image == self.image_id))
-                    self.render_container(id, container);
+                self.maybe_render_container(id, container);
             });
 
             for (var cid in this.client.containers) {
                 var c = this.client.containers[cid];
-                if (c.Config && c.Config.Image == self.image_id)
-                    self.render_container(c.Id, c);
+                self.maybe_render_container(c.Id, c);
             }
 
             this.update();
@@ -137,9 +137,20 @@
             }
         },
 
-        render_container: function (id, container) {
-            util.render_container(this.client, $('#image-details-containers'), "I",
-                                  id, container, this.danger_enabled);
+        maybe_render_container: function(id, container) {
+
+            /* Does this container match? */
+            if (container &&
+                container.Image != this.image_id &&
+                (container.Config && container.Config.Image != this.image_id)) {
+                container = null;
+            }
+
+            var panel = $('#image-details-containers');
+            util.render_container(this.client, panel, "I", id, container, this.danger_enabled);
+
+            /* Hide the entire block if no containers listed */
+            $('#image-details .image-details-used').toggle(panel.find('table > tbody > tr > td').length > 0);
         },
 
         delete_image: function () {

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -276,7 +276,7 @@
       </div>
     </div>
 
-    <div class="panel panel-default" id="image-details-containers">
+    <div class="panel panel-default image-details-used" id="image-details-containers">
       <div class="panel-heading" translate>Containers</div>
       <table class="table table-hover">
         <thead>

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -172,11 +172,20 @@ class TestDocker(MachineCase):
         b.click("#container-details-stop")
         b.wait_in_text("#container-details-state", "Exited")
 
-        self.del_container_from_details("PROBE1")
-
-        # Delete image
+        # Delete the container from the image-details page
+        b.click("#container-details .content-filter a")
+        b.wait_present('#containers-images tr:contains("busybox:latest")')
+        b.wait_visible('#containers-images tr:contains("busybox:latest")')
         b.click('#containers-images tr:contains("busybox:latest")')
         b.wait_visible("#image-details")
+        b.wait_present(".image-details-used")
+        b.wait_present(".image-details-used tr td")
+        b.wait_visible(".image-details-used tr td:first-child")
+        b.click(".image-details-used .enable-danger")
+        b.click(".image-details-used .btn-delete")
+        b.wait_not_present(".image-details-used tr td")
+
+        # Delete image itself
         b.click("#image-details-delete")
         self.confirm()
         b.wait_visible("#containers")


### PR DESCRIPTION
This is/was broken on at least recent versions of Fedora.
Add tests to verify that this actually works.