### PR TITLE
Image refresh for ubuntu-1604

### DIFF
--- a/test/images/ubuntu-1604
+++ b/test/images/ubuntu-1604
@@ -1,1 +1,1 @@
-ubuntu-1604-4a8a3d90f190b7f2c1166868ce916b0b3545fd0d.qcow2
+ubuntu-1604-b32f41b74ab8f98e06f8cde02cd1ebc11a0b4edf.qcow2


### PR DESCRIPTION
Image creation for ubuntu-1604 in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-ubuntu-1604-2017-01-09/