### PR TITLE
test: Fedora Atomic builds on Fedora 25

### DIFF
--- a/test/common/testinfra.py
+++ b/test/common/testinfra.py
@@ -90,12 +90,12 @@ DEFAULT_IMAGE_REFRESH = {
             "selenium/firefox",
             "selenium/chrome",
             "verify/fedora-24",
-            "verify/fedora-atomic",  # builds in fedora-24
         ]
     },
     'fedora-25': {
         'triggers': [
             "verify/fedora-25",
+            "verify/fedora-atomic",  # builds in fedora-25
         ]
     },
     'fedora-atomic': {

--- a/test/verify/testsuite-prepare
+++ b/test/verify/testsuite-prepare
@@ -43,9 +43,9 @@ if __name__ == "__main__":
 
     # The Atomic variants can't build their own packages, so we build in
     # their non-Atomic siblings.  For example, fedora-atomic is build
-    # in fedora-24
+    # in fedora-25
     if test_os == "fedora-atomic":
-        build_os = "fedora-24"
+        build_os = "fedora-25"
     elif test_os == "rhel-atomic":
         build_os = "rhel-7"
     elif test_os == "continuous-atomic":


### PR DESCRIPTION
We moved the Fedora Atomic verify image to version 25. However
we've still been building the packages for it in Fedora 24.