### PR TITLE
test: Set resolv.conf SELinux context correctly in test

### DIFF
--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -31,7 +31,7 @@ set -e
 for x in 1 2 3 4 5; do
     hostnamectl set-hostname x0.cockpit.lan
     printf 'domain cockpit.lan\nsearch cockpit.lan\nnameserver {address}\n' >/etc/resolv2.conf
-    chcon -v unconfined_u:object_r:net_conf_t:s0 /etc/resolv.conf || true
+    chcon -v unconfined_u:object_r:net_conf_t:s0 /etc/resolv2.conf || true
     mv /etc/resolv2.conf /etc/resolv.conf
     if chattr +i /etc/resolv.conf; then
         break


### PR DESCRIPTION
The previous fix for this set the wrong file's SELinux context:

commit fce307844fdd429806aeca8a13806b12eb131a0c

Otherwise we get SELinux issues failing the tests that look like this:

```
avc:  denied  { unlink } for  pid=495 comm="NetworkManager" name="resolv.conf" dev="vda3" ino=150316 scontext=system_u:system_r:NetworkManager_t:s0 tcontext=unconfined_u:object_r:etc_t:s0 tclass=file
```