### PR TITLE
Image refresh for debian-8

### DIFF
--- a/test/images/debian-8
+++ b/test/images/debian-8
@@ -1,1 +1,1 @@
-debian-8-6841dfea8ef6d61828142ada93bc3e6b45f2f685.qcow2
+debian-8-0793ae526f689f34f1a5fffc6c8a93f12a0d0d76.qcow2


### PR DESCRIPTION
Image creation for debian-8 in process on cockpit-10.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-8-2017-01-11/