### PR TITLE
debian: Add missing Conflicts/Replaces for -shell → -system rename

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -114,6 +114,8 @@ Provides: cockpit-realmd,
           cockpit-systemd,
           cockpit-tuned,
           cockpit-users
+Conflicts: cockpit-shell
+Replaces: cockpit-shell
 Description: Cockpit admin interface for a system
  Cockpit admin interface package for configuring and
  troubleshooting a system.


### PR DESCRIPTION
Fixes #5715 