### PR TITLE
Fix install location of mock-pam-conv-mod

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -264,7 +264,7 @@ SED_SUBST = sed \
         -e 's,[@]selinux_config_type[@],$(COCKPIT_SELINUX_CONFIG_TYPE),g' \
         $(NULL)
 
-testassetsdir = $(datadir)/cockpit-test-assets
+testassetsdir = $(prefix)/lib/cockpit-test-assets
 testassets_programs =
 testassets_data =
 testassets_systemdunit_data =

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -257,7 +257,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
     def testConversation(self):
         m = self.machine
         b = self.browser
-        path = "/usr/share/cockpit-test-assets/mock-pam-conv-mod"
+        path = "/usr/lib/cockpit-test-assets/mock-pam-conv-mod"
         conf = "/etc/pam.d/cockpit"
         if ('atomic' in m.image):
             conf = "/etc/pam.d/sshd"

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -555,7 +555,7 @@ pulls in some necessary packages via dependencies.
 
 %files test-assets
 %{_datadir}/%{name}/playground
-%{_datadir}/cockpit-test-assets
+%{_prefix}/lib/cockpit-test-assets
 
 %endif
 

--- a/tools/debian/cockpit-test-assets.install
+++ b/tools/debian/cockpit-test-assets.install
@@ -1,2 +1,2 @@
 usr/share/cockpit/playground
-usr/share/cockpit-test-assets
+usr/lib/cockpit-test-assets


### PR DESCRIPTION
mock-pam-conv-mod is a compiled ELF so it doesn't belong into
/usr/share, so move the test assets into /usr/lib/cockpit-test-assets/.

This is (currently) the only test asset anyway, so there is currently no
need to introduce testassets{bin,data}dir.

Use prefix/lib instead of libdir as the latter usually includes
multi-arch subdirs which are hard to predict from the Python test, and
we don't care about multi-arch for this anyway.