### PR TITLE
test: Add knowledge of debian-testing images

### DIFF
--- a/test/common/testinfra.py
+++ b/test/common/testinfra.py
@@ -60,6 +60,7 @@ DEFAULT_VERIFY = {
     'verify/centos-7': [ 'master', 'pulls' ],
     'verify/continuous-atomic': [ 'master' ],
     'verify/debian-8': [ 'master', 'pulls', ],
+    'verify/debian-testing': [ ],
     'verify/debian-unstable': [ 'master', 'pulls' ],
     'verify/fedora-24': [ ],
     'verify/fedora-25': [ 'master', 'pulls' ],


### PR DESCRIPTION
@martinpitt has suggested for good reason that we should test against Debian testing rather than Debian unstable.

Add knowledge of debian-testing images to the verify machines
test harnesses.