### PR TITLE
configure: Add a ./configure --disable-ssh option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,8 +63,9 @@ AC_MSG_RESULT($enable_prefix_only)
 
 GLIB_VERSION="2.34"
 LIBSSH_VERSION="0.6.0"
+GIO_VERSION="2.37.4" # For appropriate version of TLS logic
 
-GIO_REQUIREMENT="gio-unix-2.0 >= $GLIB_VERSION"
+GIO_REQUIREMENT="gio-unix-2.0 >= $GIO_VERSION gio-2.0 >= $GIO_VERSION"
 LIBSYSTEMD_REQUIREMENT="libsystemd"
 LIBSYSTEMD_REQUIREMENT_OLD="libsystemd-journal >= 187 libsystemd-daemon libsystemd-login"
 JSON_GLIB_REQUIREMENT="json-glib-1.0 >= 0.14.0"
@@ -117,29 +118,41 @@ COCKPIT_POLKIT_LIBS="$GIO_LIBS $POLKIT_LIBS"
 AC_SUBST(COCKPIT_POLKIT_CFLAGS)
 AC_SUBST(COCKPIT_POLKIT_LIBS)
 
-# whether to build cockpit-ws
-AC_ARG_ENABLE(ws, AC_HELP_STRING([--disable-ws], [Disable cockpit-ws build]))
+COCKPIT_WS_CFLAGS="$COCKPIT_CFLAGS $KRB5_CFLAGS"
+COCKPIT_WS_LIBS="$COCKPIT_LIBS $KRB5_LIBS"
+AC_SUBST(COCKPIT_WS_CFLAGS)
+AC_SUBST(COCKPIT_WS_LIBS)
 
-AC_MSG_CHECKING([build with cockpit-ws])
-if test "$enable_ws" != "no"; then
-  enable_ws="yes"
-  AC_MSG_RESULT([$enable_ws])
-  PKG_CHECK_MODULES(GLIB_TLS, [glib-2.0 >= 2.37.4])
+# whether to build cockpit-ssh
+AC_ARG_ENABLE(ssh, AC_HELP_STRING([--disable-ssh], [Disable cockpit-ssh build and libssh dependency]))
+AC_MSG_CHECKING([build with cockpit-ssh])
+if test "$enable_ssh" != "no"; then
+  enable_ssh="yes"
+  AC_MSG_RESULT([$enable_ssh])
   PKG_CHECK_MODULES(LIBSSH, [libssh >= $LIBSSH_VERSION libssh_threads])
-  COCKPIT_WS_CFLAGS="$COCKPIT_CFLAGS $KRB5_CFLAGS"
-  COCKPIT_WS_LIBS="$COCKPIT_LIBS $KRB5_LIBS"
+
+  AC_CHECK_LIB(ssh, ssh_gssapi_set_creds, [
+    AC_DEFINE_UNQUOTED(HAVE_SSH_GSSAPI_SET_CREDS, 1, Whether ssh_gssapi_set_creds is available)
+  ])
+
+  AC_CHECK_LIB(ssh, ssh_set_agent_socket, [
+    AC_DEFINE_UNQUOTED(HAVE_SSH_SET_AGENT_SOCKET, 1, Whether ssh_set_agent_socket is available)
+    key_auth="yes"
+  ], [key_auth="no"])
+
+  AC_DEFINE_UNQUOTED(WITH_COCKPIT_SSH, 1, [Build cockpit-ssh and include libssh dependency])
+
   COCKPIT_SSH_SESSION_CFLAGS="$COCKPIT_CFLAGS $LIBSSH_CFLAGS $KRB5_CFLAGS"
   COCKPIT_SSH_SESSION_LIBS="$COCKPIT_LIBS $LIBSSH_LIBS $KRB5_LIBS"
-  AC_SUBST(COCKPIT_WS_CFLAGS)
-  AC_SUBST(COCKPIT_WS_LIBS)
   AC_SUBST(COCKPIT_SSH_SESSION_LIBS)
   AC_SUBST(COCKPIT_SSH_SESSION_CFLAGS)
 else
-  enable_ws="no"
-  AC_MSG_RESULT([$enable_ws])
+  enable_ssh="no"
+  key_auth="no"
+  AC_MSG_RESULT([$enable_ssh])
 fi
 
-AM_CONDITIONAL(WITH_COCKPIT_WS, test "$enable_ws" = "yes")
+AM_CONDITIONAL(WITH_COCKPIT_SSH, test "$enable_ssh" = "yes")
 
 # pam
 AC_CHECK_HEADER([security/pam_appl.h], ,
@@ -220,14 +233,6 @@ AM_CONDITIONAL([ENABLE_PCP], [test "$enable_pcp" = "yes"])
 # gssapi
 AC_CHECK_LIB(gssapi_krb5, gss_import_cred,
   [AC_DEFINE_UNQUOTED(HAVE_GSS_IMPORT_CRED, 1, Whether gss_import_cred is available)])
-AC_CHECK_LIB(ssh, ssh_gssapi_set_creds,
-  [AC_DEFINE_UNQUOTED(HAVE_SSH_GSSAPI_SET_CREDS, 1, Whether ssh_gssapi_set_creds is available)])
-
-# key auth
-AC_CHECK_LIB(ssh, ssh_set_agent_socket,
-  [AC_DEFINE_UNQUOTED(HAVE_SSH_SET_AGENT_SOCKET, 1, Whether ssh_set_agent_socket is available)
-  key_auth="yes"],
-  [key_auth="no"])
 
 # systemd
 AC_ARG_WITH([systemdunitdir], [AC_HELP_STRING([--with-systemdunitdir=DIR],
@@ -586,7 +591,6 @@ echo "
         cflags:                     ${CFLAGS}
         cppflags:                   ${CPPFLAGS}
 
-        cockpit-ws:                 ${enable_ws}
         cockpit-ws user:            ${COCKPIT_USER}
         cockpit-ws group:           ${COCKPIT_GROUP}
         selinux config type:        ${COCKPIT_SELINUX_CONFIG_TYPE}
@@ -598,6 +602,8 @@ echo "
         With address sanitizer:     ${asan_status}
         With PCP:                   ${enable_pcp}
 	Branding:                   ${BRAND}
+
+        cockpit-ssh:                ${enable_ssh}
         Supports key auth:          ${key_auth}
 
         pkexec:                     ${PKEXEC}

--- a/doc/man/Makefile-man.am
+++ b/doc/man/Makefile-man.am
@@ -6,8 +6,6 @@ EXTRA_DIST += \
 	doc/man/cockpit-bridge.xml \
 	$(NULL)
 
-if WITH_COCKPIT_WS
-
 man_MANS += \
 	doc/man/cockpit.1 \
 	doc/man/cockpit-ws.8 \
@@ -23,8 +21,6 @@ EXTRA_DIST += \
 	doc/man/pam_ssh_add.xml \
 	doc/man/remotectl.xml \
 	$(NULL)
-
-endif
 
 MAN_PROC = $(MKDIR_P) doc/man/ && $(XSLTPROC) -nonet --param man.output.quietly 1 --output $@ \
 	http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $<

--- a/src/base1/test-file.js
+++ b/src/base1/test-file.js
@@ -409,14 +409,12 @@ QUnit.asyncTest("closing", function() {
 });
 
 QUnit.asyncTest("channel options", function() {
-    assert.expect(2);
-    var file = cockpit.file(dir + "/foobarbaz", { host: "horst.example" });
-    file.read()
-        .always(function () {
-            assert.equal(this.state(), "rejected", "failed");
-        }).
-        fail(function (error) {
-            assert.equal(error.problem, "no-host", "failed to connect");
+    assert.expect(1);
+    cockpit.file(dir + "/foo", { binary: true }).read()
+        .done(function(data) {
+            assert.ok(data instanceof window.Uint8Array, "options applied, got binary data");
+        })
+        .always(function() {
             QUnit.start();
         });
 });

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -1,6 +1,4 @@
 
-if WITH_COCKPIT_WS
-
 COCKPIT_BUILD_INFO = "Built on $(shell date)"
 
 staticdir = $(datadir)/cockpit/static
@@ -77,10 +75,10 @@ libcockpit_ws_a_SOURCES = \
 	src/ws/cockpitcreds.h src/ws/cockpitcreds.c \
 	src/ws/cockpitwebservice.h \
 	src/ws/cockpitwebservice.c \
-	src/ws/cockpitsshtransport.h \
-	src/ws/cockpitsshtransport.c \
 	src/ws/cockpitsshagent.h \
 	src/ws/cockpitsshagent.c \
+	src/ws/cockpitsshtransport.h \
+	src/ws/cockpitsshtransport.c \
 	$(NULL)
 
 libcockpit_ws_a_CFLAGS = \
@@ -127,22 +125,7 @@ EXTRA_DIST += \
 
 sbin_PROGRAMS += remotectl
 
-libexec_PROGRAMS += cockpit-ws cockpit-session cockpit-ssh
-
-cockpit_ssh_SOURCES = \
-	src/ws/cockpitauthoptions.h \
-	src/ws/cockpitauthoptions.c \
-	src/ws/ssh.c \
-	$(NULL)
-
-cockpit_ssh_LDADD = \
-	libcockpit-common.a \
-	$(COCKPIT_SSH_SESSION_LIBS) \
-	$(NULL)
-
-cockpit_ssh_CFLAGS = \
-	$(COCKPIT_SSH_SESSION_CFLAGS) \
-	$(NULL)
+libexec_PROGRAMS += cockpit-ws cockpit-session
 
 cockpit_session_SOURCES = src/ws/session.c
 cockpit_session_LDADD = $(COCKPIT_SESSION_LIBS)
@@ -255,8 +238,6 @@ WS_CHECKS = \
 	test-creds \
 	test-auth \
 	test-authoptions \
-	test-authssh \
-	test-sshtransport \
 	test-sshagent \
 	test-webservice \
 	test-channelresponse \
@@ -281,16 +262,6 @@ test_auth_LDADD = \
 test_authoptions_CFLAGS = $(cockpit_ws_CFLAGS)
 test_authoptions_SOURCES = src/ws/test-authoptions.c
 test_authoptions_LDADD = \
-	libcockpit-ws.a \
-	$(cockpit_ws_LDADD)
-
-test_authssh_CFLAGS = $(cockpit_ws_CFLAGS)
-test_authssh_SOURCES = \
-	src/ws/test-authssh.c \
-	src/ws/mock-auth.c \
-	src/ws/mock-auth.h \
-	$(NULL)
-test_authssh_LDADD = \
 	libcockpit-ws.a \
 	$(cockpit_ws_LDADD)
 
@@ -339,17 +310,6 @@ test_remotectlcertificate_LDADD = \
 	$(COCKPIT_LIBS) \
 	$(NULL)
 
-test_sshtransport_SOURCES = \
-	src/ws/test-sshtransport.c \
-	$(NULL)
-test_sshtransport_CFLAGS = $(cockpit_ws_CFLAGS)
-test_sshtransport_LDADD = \
-	libwebsocket.a \
-	libcockpit-ws.a \
-	$(cockpit_ws_LDADD) \
-	$(NULL)
-
-
 test_sshagent_CFLAGS = $(cockpit_ws_CFLAGS)
 test_sshagent_SOURCES = src/ws/test-sshagent.c
 
@@ -389,18 +349,6 @@ mock_agent_bridge_LDADD = libcockpit-ws.a \
 	$(cockpit_ws_LDADD) \
 	$(NULL)
 
-mock_sshd_SOURCES = src/ws/mock-sshd.c
-
-mock_sshd_LDADD = \
-	$(COCKPIT_WS_LIBS) \
-	$(COCKPIT_SSH_SESSION_LIBS) \
-	$(NULL)
-
-mock_sshd_CFLAGS = \
-	$(COCKPIT_WS_CFLAGS) \
-	$(COCKPIT_SSH_SESSION_CFLAGS) \
-	$(NULL)
-
 mock_echo_SOURCES = src/ws/mock-echo.c
 mock_echo_CFLAGS = $(COCKPIT_WS_CFLAGS)
 mock_echo_LDADD = $(COCKPIT_WS_LIBS)
@@ -409,7 +357,6 @@ mock_auth_command_SOURCES = src/ws/mock-auth-command.c
 
 noinst_PROGRAMS += \
 	$(WS_CHECKS) \
-	mock-sshd \
 	mock-echo \
 	mock-agent-bridge \
 	mock-auth-command \
@@ -423,7 +370,7 @@ noinst_SCRIPTS += \
 TESTS += $(WS_CHECKS)
 
 mock_pam_conv_mod_SOURCES = src/ws/mock-pam-conv-mod.c
-mock-pam-conv-mod: $(mock_pam_conv_mod_SOURCES)
+mock-pam-conv-mod$(EXEEXT): $(mock_pam_conv_mod_SOURCES)
 	$(AM_V_CCLD) $(CC) -fPIC -shared $(CFLAGS) -I$(builddir) \
 		-o $@ $^ $(PAM_LIBS) $(LDFLAGS)
 
@@ -448,8 +395,68 @@ update-known-hosts:
 		sed -ne 's/\(.*\) [^ ]\+$$/[localhost]:*,[127.0.0.1]:* \1/p' > \
 			$(srcdir)/src/ws/mock_known_hosts
 
-endif
-
 prepare-po::
 	$(INTLTOOL_EXTRACT) -l --type=gettext/xml $(srcdir)/$(appdata_in)
 	$(INTLTOOL_EXTRACT) -l --type=gettext/ini $(srcdir)/$(desktop_in)
+
+# ----------------------------------------------------------------------------------------------------
+
+if WITH_COCKPIT_SSH
+
+libexec_PROGRAMS += cockpit-ssh
+
+cockpit_ssh_SOURCES = \
+	src/ws/cockpitauthoptions.h \
+	src/ws/cockpitauthoptions.c \
+	src/ws/ssh.c \
+	$(NULL)
+
+cockpit_ssh_LDADD = \
+	libcockpit-common.a \
+	$(COCKPIT_SSH_SESSION_LIBS) \
+	$(NULL)
+
+cockpit_ssh_CFLAGS = \
+	$(COCKPIT_SSH_SESSION_CFLAGS) \
+	$(NULL)
+
+noinst_PROGRAMS += mock-sshd
+
+mock_sshd_SOURCES = src/ws/mock-sshd.c
+
+mock_sshd_LDADD = \
+	$(COCKPIT_WS_LIBS) \
+	$(COCKPIT_SSH_SESSION_LIBS) \
+	$(NULL)
+
+mock_sshd_CFLAGS = \
+	$(COCKPIT_WS_CFLAGS) \
+	$(COCKPIT_SSH_SESSION_CFLAGS) \
+	$(NULL)
+
+WS_CHECKS += \
+	test-authssh \
+	test-sshtransport \
+	$(NULL)
+
+test_authssh_CFLAGS = $(cockpit_ws_CFLAGS)
+test_authssh_SOURCES = \
+	src/ws/test-authssh.c \
+	src/ws/mock-auth.c \
+	src/ws/mock-auth.h \
+	$(NULL)
+test_authssh_LDADD = \
+	libcockpit-ws.a \
+	$(cockpit_ws_LDADD)
+
+test_sshtransport_SOURCES = \
+	src/ws/test-sshtransport.c \
+	$(NULL)
+test_sshtransport_CFLAGS = $(cockpit_ws_CFLAGS)
+test_sshtransport_LDADD = \
+	libwebsocket.a \
+	libcockpit-ws.a \
+	$(cockpit_ws_LDADD) \
+	$(NULL)
+
+endif


### PR DESCRIPTION
This option allows the libssh dependency and cockpit-ssh component to be built optionally on operating systems that don't have libssh.
    
The --disable-ws option used to serve the same purpose and has therefore been removed.
