### PR TITLE
Fix vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,7 +44,7 @@ Vagrant.configure(2) do |config|
         dnf copr enable -y @cockpit/cockpit-preview
         dnf install -y docker kubernetes atomic subscription-manager etcd pcp realmd \
 		NetworkManager storaged storaged-lvm2 git yum-utils tuned libvirt virt-install qemu
-        dnf install -y cockpit-*
+        dnf install -y cockpit
         debuginfo-install -y cockpit cockpit-pcp
 
         systemctl enable cockpit.socket

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 
 Vagrant.configure(2) do |config|
 
-    config.vm.box = "fedora/24-cloud-base"
+    config.vm.box = "fedora/25-cloud-base"
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder "./dist", "/cockpit/dist", type: "rsync"
     config.vm.network "private_network", ip: "192.168.50.10"


### PR DESCRIPTION
We installed cockpit-* before, which can lead to problems when old, conflicting packages are still around in the copr.

There's no need to install packages, because the point of this file is to use the ones from the source directory.