### PR TITLE
Image refresh for debian-testing

### DIFF
--- a/test/images/debian-testing
+++ b/test/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-057f49d4bd221b938e7b91ad87c66e9dc2852631.qcow2
+debian-testing-d20b505579ab4f899b4824f2581a2cac073e4061.qcow2


### PR DESCRIPTION
Image creation for debian-testing in process on cockpit-11.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-testing-2017-01-18/