### PR TITLE
machines: Support for external providers

### DIFF
--- a/pkg/machines/README.md
+++ b/pkg/machines/README.md
@@ -35,9 +35,9 @@ The external provider script must create global window.EXTERNAL_PROVIDER object 
 
     window.EXTERNAL_PROVIDER = {
         name: 'YOUR PROVIDER NAME',
-        init: function (actionCreators, nextProvider) {return true;},
+        init: function (actionCreators, nextProvider, React) {return true;}, // return boolean or Promise
 
-        GET_VM: function ({ lookupId: name }) { return dispatch => {...}; },
+        GET_VM: function ({ lookupId: name }) { return dispatch => {...}; }, // return Promise
         GET_ALL_VMS: function () {},
         SHUTDOWN_VM: function ({ name, id }) {},
         FORCEOFF_VM: function ({ name, id }) {},
@@ -45,11 +45,16 @@ The external provider script must create global window.EXTERNAL_PROVIDER object 
         FORCEREBOOT_VM: function ({ name, id }) {},
         START_VM: function ({ name, id }) {},
         
-        canReset: function (state) {return true;},
+        canReset: function (state) {return true;}, // return boolean
         canShutdown: function (state) {return true;},
         isRunning: function (state) {return true;},
         canRun: function (state) {return true;},
-        };
+        
+        vmTabRenderers: [ // optional
+            {name: 'Provider-specific subtab', componentFactory: YOUR_COMPONENT_FACTORY}, // see externalComponent.jsx for more info on componentFactory
+          ],
+
+    };
 
 The provider methods are expected to return a Promise.
 

--- a/pkg/machines/README.md
+++ b/pkg/machines/README.md
@@ -1,7 +1,7 @@
 # Cockpit VM Management
 The 'Virtual Management' plugin provides basic overview of host virtualization by listing defined VMs along with their utilization and basic actions.
 
-The source of data is QEMU/Libvirt.
+The default datasource is QEMU/Libvirt.
 
 ## Nested Virtualization in Vagrant
 To play around with nested VMs in Vagrant on a host with enabled nested virtualization [1]:
@@ -23,5 +23,41 @@ Log into Cockpit as the 'root' user (pwd 'foobar').
 Please note, the created VM is for the plugin testing only, it provides no real OS.
 It's purpose is 'just to be listed by libvirt'.
 
+## External Providers
+By default, the plugin is based on Libvirt, accessed via `virsh`.
+
+The provider can be replaced by deploying `provider/index.js` into the machines installation directory, like
+
+    /usr/share/cockpit/machines/provider/index.js
+
+This script will be dynamically loaded and executed.
+The external provider script must create global window.EXTERNAL_PROVIDER object with following API:
+
+    window.EXTERNAL_PROVIDER = {
+        name: 'YOUR PROVIDER NAME',
+        init: function (actionCreators, nextProvider) {return true;},
+
+        GET_VM: function ({ lookupId: name }) { return dispatch => {...}; },
+        GET_ALL_VMS: function () {},
+        SHUTDOWN_VM: function ({ name, id }) {},
+        FORCEOFF_VM: function ({ name, id }) {},
+        REBOOT_VM: function ({ name, id }) {},
+        FORCEREBOOT_VM: function ({ name, id }) {},
+        START_VM: function ({ name, id }) {},
+        
+        canReset: function (state) {return true;},
+        canShutdown: function (state) {return true;},
+        isRunning: function (state) {return true;},
+        canRun: function (state) {return true;},
+        };
+
+The provider methods are expected to return a Promise.
+
+Please refer libvirt.es6 for current API and more details.
+
+Referential implementation of an external provider is the cockpit-machines-ovirt-provider [2]
+
 ## Links
 \[1\] [How to enable nested virtualization in KVM](https://fedoraproject.org/wiki/How_to_enable_nested_virtualization_in_KVM)
+\[2\] [Cockpit-machines oVirt External Provider](https://github.com/mareklibra/cockpit-machines-ovirt-provider)
+

--- a/pkg/machines/app.jsx
+++ b/pkg/machines/app.jsx
@@ -21,10 +21,10 @@ import React, { PropTypes } from "react";
 import HostVmsList from "./hostvmslist.jsx";
 
 const App = ({ store }) => {
-    const { vms } = store.getState();
+    const { vms, config } = store.getState();
     const dispatch = store.dispatch;
 
-    return (<HostVmsList vms={vms} dispatch={dispatch} />)
+    return (<HostVmsList vms={vms} config={config} dispatch={dispatch} />)
 }
 App.propTypes = {
     store: React.PropTypes.object.isRequired

--- a/pkg/machines/config.es6
+++ b/pkg/machines/config.es6
@@ -34,7 +34,8 @@ const VMS_CONFIG = {
             }
         }
     },
-    isDev: false // TODO: make it configurable based on process.env.NODE_ENV
+    // TODO: make it configurable via config file
+    isDev: false, // Never commit with 'true'
 };
 
 export default VMS_CONFIG;

--- a/pkg/machines/helpers.es6
+++ b/pkg/machines/helpers.es6
@@ -90,18 +90,28 @@ export function logDebug(msg) {
     }
 }
 
-export function rephraseUI(key, original) {
-    const transform = {
-        'autostart': {
-            'disable': 'disabled',
-            'enable': 'enabled'
-        },
-        'connections': {
-            'system': _("System"),
-            'session': _("Session")
-        }
-    };
+const transform = {
+    'autostart': {
+        'disable': _("disabled"),
+        'enable': _("enabled"),
+    },
+    'connections': {
+        'system': _("System"),
+        'session': _("Session"),
+    },
+    'vmStates': {
+        running: _("running"),
+        idle: _("idle"),
+        paused: _("paused"),
+        shutdown: _("shutdown"),
+        'shut off': _("shut off"),
+        crashed: _("crashed"),
+        dying: _("dying"),
+        pmsuspended: _("suspended (PM)"),
+    }
+};
 
+export function rephraseUI(key, original) {
     if (!(key in transform)) {
         logDebug(`rephraseUI(key='${key}', original='${original}'): unknown key`);
         return original;
@@ -113,21 +123,4 @@ export function rephraseUI(key, original) {
     }
 
     return transform[key][original];
-}
-
-// --- VM state functions --
-export function canReset(vmState) {
-    return vmState == 'running' || vmState == 'idle' || vmState == 'paused';
-}
-
-export function canShutdown(vmState) {
-    return canReset(vmState);
-}
-
-export function isRunning(vmState) {
-    return canReset(vmState);
-}
-
-export function canRun(vmState) {
-    return vmState == 'shut off';
 }

--- a/pkg/machines/index.html
+++ b/pkg/machines/index.html
@@ -10,7 +10,7 @@
 
   <script type="text/javascript" src="../base1/cockpit.js"></script>
   <script type="text/javascript" src="../base1/jquery.js"></script>
-  <script type="text/javascript" src="d3.js"></script>
+<!--  <script type="text/javascript" src="d3.js"></script> -->
   <script type="text/javascript" src="machines.js"></script>
 </head>
 

--- a/pkg/machines/libvirt.es6
+++ b/pkg/machines/libvirt.es6
@@ -25,7 +25,7 @@ import cockpit from 'cockpit';
 import $ from 'jquery';
 import {updateOrAddVm, getVm, getAllVms, delayPolling, deleteUnlistedVMs, vmActionFailed} from './actions.es6';
 import { spawnScript, spawnProcess } from './services.es6';
-import { toKiloBytes, isEmpty, logDebug, isRunning } from './helpers.es6';
+import { toKiloBytes, isEmpty, logDebug } from './helpers.es6';
 import VMS_CONFIG from './config.es6';
 
 const _ = cockpit.gettext;
@@ -61,11 +61,39 @@ function getValueFromLine(parsedLines, pattern) {
     return isEmpty(selectedLine) ? undefined : selectedLine.toString().trim().substring(pattern.length).trim();
 }
 
-export default {
+let LIBVIRT_PROVIDER = {};
+LIBVIRT_PROVIDER = {
     name: 'Libvirt',
 
     /**
-     * read VM properties (virsh)
+     * Initialize the provider.
+     * Arguments are used for reference only, they are actually not needed for this Libvirt provider.
+     *
+     * @param actionCreators - Map of action creators (functions)
+     * @param nextProvider - Next provider in chain, recently Libvirt. Used for chaining commands or fallbacks.
+     * @returns {boolean} - true, if initialization succeeded
+     */
+    init(actionCreators, nextProvider) {
+        // This is default provider - the Libvirt.
+        // We do not need to use actionCreators or nextProvider
+        return true;
+    },
+
+    canReset(vmState) {
+        return vmState == 'running' || vmState == 'idle' || vmState == 'paused';
+    },
+    canShutdown(vmState) {
+        return LIBVIRT_PROVIDER.canReset(vmState);
+    },
+    isRunning(vmState) {
+        return LIBVIRT_PROVIDER.canReset(vmState);
+    },
+    canRun(vmState) {
+        return vmState == 'shut off';
+    },
+
+    /**
+     * Read VM properties of a single VM (virsh)
      *
      * @param VM name
      * @returns {Function}
@@ -83,7 +111,7 @@ export default {
                     parseDumpxml(dispatch, connectionName, domXml);
                     return spawnVirshReadOnly({connectionName, method: 'dominfo', name});
                 }).then(domInfo => {
-                    if (isRunning(parseDominfo(dispatch, connectionName, name, domInfo))) {
+                    if (LIBVIRT_PROVIDER.isRunning(parseDominfo(dispatch, connectionName, name, domInfo))) {
                         return spawnVirshReadOnly({connectionName, method: 'dommemstat', name, failHandler: canFailHandler});
                     }
                 }).then(dommemstat => {
@@ -118,7 +146,7 @@ export default {
                         // The 'root' user does not have its own qemu:///session just qemu:///system
                         // https://bugzilla.redhat.com/show_bug.cgi?id=1045069
                         connectionName => canLoggedUserConnectSession(connectionName, loggedUser))
-                    .map( connectionName => dispatch(getAllVms(connectionName)));
+                    .map(connectionName => dispatch(getAllVms(connectionName)));
 
                 return cockpit.all(promises)
                     .then(() => { // keep polling AFTER all VM details have been read (avoid overlap)
@@ -254,7 +282,7 @@ function parseDominfo(dispatch, connectionName, name, domInfo) {
     const state = getValueFromLine(lines, 'State:');
     const autostart = getValueFromLine(lines, 'Autostart:');
 
-    if (!isRunning(state)) { // clean usage data
+    if (!LIBVIRT_PROVIDER.isRunning(state)) { // clean usage data
         dispatch(updateOrAddVm({connectionName, name, state, autostart, actualTimeInMs: -1}));
     } else {
         dispatch(updateOrAddVm({connectionName, name, state, autostart}));
@@ -285,3 +313,5 @@ function parseDomstats(dispatch, connectionName, name, domstats) {
         dispatch(updateOrAddVm({connectionName, name, actualTimeInMs, cpuTime}));
     }
 }
+
+export default LIBVIRT_PROVIDER;

--- a/pkg/machines/middlewares.es6
+++ b/pkg/machines/middlewares.es6
@@ -34,8 +34,8 @@ export function thunk({ dispatch, getState }) {
     return next => action => {
         if (typeof action === 'function') {
             // cockpit style promise is also typeof 'function'
-            // so we differentiate between those two by the presence of property 'then'
-            return action.then ? action : action(dispatch, getState);
+            // so we differentiate between those two by the presence of property 'then' or 'done'
+            return (action.then || action.done) ? action : action(dispatch, getState);
         }
 
         return next(action);

--- a/pkg/machines/provider.es6
+++ b/pkg/machines/provider.es6
@@ -1,0 +1,126 @@
+/*jshint esversion: 6 */
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+import $ from 'jquery';
+
+import { logDebug } from './helpers.es6';
+import Libvirt from './libvirt.es6';
+import { setProvider, delayPolling, getAllVms, deleteUnlistedVMs, updateOrAddVm } from './actions.es6';
+
+/**
+ * External provider can be optionally installed on: .../cockpit/machines/provider/index.js
+ * The default is Libvirt.
+ *
+ * The external provider needs to meet API stated in libvirt.es6 or the README.md.
+ *
+ * @param useProvider - function taking 'provider' as 1st argument and performs provider's registration and init
+ * @param defaultProvider - used by default if no external provider is installed
+ */
+function loadExternalProvider ({ useProvider, defaultProvider }) {
+    const scriptElement = $('<script/>').prop({src: 'provider/index.js', async: true});
+    scriptElement.on('load', () => {
+        logDebug(`External provider loaded: ${JSON.stringify(window.EXTERNAL_PROVIDER.name)}`);
+        useProvider(window.EXTERNAL_PROVIDER);
+    });
+    scriptElement.on('error', (err) => {
+        logDebug(`No external provider found, using ${defaultProvider.name}.`);
+        useProvider(defaultProvider);
+    });
+    document.head.appendChild(scriptElement[0]);
+}
+
+/**
+ * Action creators to be injected to the provider to share the code.
+ */
+function actionCreators () {
+    return {
+        delayRefresh: () => delayPolling(getAllVms()),
+        deleteUnlistedVMs: deleteUnlistedVMs,
+        updateOrAddVm: updateOrAddVm,
+    };
+}
+
+function getVirtProvider (store) {
+    const state = store.getState();
+    if (state.config.provider) {
+        return cockpit.resolve(state.config.provider);
+    } else {
+        const deferred = cockpit.defer();
+        logDebug('Discovering provider');
+
+        const useProvider = provider => {
+            if (!provider) { //  no provider available
+                deferred.reject();
+            } else {
+                // Skip the initialization if provider does not define the `init` hook.
+                if (!provider.init) {
+                    logDebug('No init() method in the provider');
+                    store.dispatch(setProvider(provider));
+                    deferred.resolve(provider);
+                } else {
+                    const initResult = provider.init(actionCreators(), Libvirt);
+                    if (initResult && initResult.then) { // if Promise or $.jqXHR, the then() is defined
+                        initResult
+                            .done(() => {
+                                logDebug(`Provider's Init() is returning resolved Promise`);
+                                store.dispatch(setProvider(provider));
+                                deferred.resolve(provider);
+                                })
+                            .fail(() => {
+                                logDebug(`Provider's Init() is returning rejected Promise`);
+                                useProvider(Libvirt);
+                                } );
+                    } else { // Promise is not returned, so at least 'true' is expected
+                        if (initResult) {
+                            logDebug(`No Promise returned, but successful init: ${JSON.stringify(initResult)}`);
+                            store.dispatch(setProvider(provider));
+                            deferred.resolve(provider);
+                        } else {
+                            useProvider(Libvirt);
+                        }
+                    }
+                }
+            }
+        };
+
+        loadExternalProvider({ useProvider, defaultProvider: Libvirt });
+
+        return deferred.promise;
+    }
+}
+
+/**
+ * Helper for dispatching virt provider methods.
+ *
+ * Lazily initializes the virt provider and dispatches given method on it.
+ */
+export function virt(method, action) {
+    return (dispatch, getState) => getVirtProvider({dispatch, getState}).then(provider => {
+        if (method in provider) {
+            logDebug(`Calling ${provider.name}.${method}(${JSON.stringify(action)})`);
+            return dispatch(provider[method](action));
+        } else {
+            console.warn(`method: '${method}' is not supported by provider: '${provider.name}'`);
+        }
+    }).catch(err => {
+        console.error('could not detect any virt provider');
+    });
+}

--- a/pkg/machines/provider.es6
+++ b/pkg/machines/provider.es6
@@ -20,6 +20,7 @@
 
 import cockpit from 'cockpit';
 import $ from 'jquery';
+import React from 'react';
 
 import { logDebug } from './helpers.es6';
 import Libvirt from './libvirt.es6';
@@ -52,6 +53,7 @@ function loadExternalProvider ({ useProvider, defaultProvider }) {
  */
 function actionCreators () {
     return {
+        virtMiddleware: virt,
         delayRefresh: () => delayPolling(getAllVms()),
         deleteUnlistedVMs: deleteUnlistedVMs,
         updateOrAddVm: updateOrAddVm,
@@ -76,7 +78,7 @@ function getVirtProvider (store) {
                     store.dispatch(setProvider(provider));
                     deferred.resolve(provider);
                 } else {
-                    const initResult = provider.init(actionCreators(), Libvirt);
+                    const initResult = provider.init(actionCreators(), Libvirt, React);
                     if (initResult && initResult.then) { // if Promise or $.jqXHR, the then() is defined
                         initResult
                             .done(() => {


### PR DESCRIPTION
With this patch, data and actions for the 'machines' package can be
provided by pluggable external providers.

Their use is optional. If none is installed, fails to load or to initialize,
the Libvirt is used by default.

This patch allows reuse of common UI for different virtualization providers while
keeping upstream independent on them. An external providers bring more realistic view
of a virtualization host if the server is used in single-purpose installation.

The providers can be chained - i.e. certain operation can be still performed
via Libvirt instead of external system.

Provider-specific code moved to the Libvirt provider (i.e. VM state manipulation).

The external providers are supposed to be implemented separatly from the cockpit-project code base.

A provider is installed by copy of it's index.js file under /usr/share/cockpit/machines/provider and loaded dynamically.

For provider's API and further details, please refer the machines/README.md .