### PR TITLE
test: Run IPA with 2GB of memory

### DIFF
--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -48,7 +48,7 @@ def prepare_resolv(machine, address):
 @skipImage("No freeipa available", "debian-8", "debian-testing")
 class TestRealms(MachineCase):
     additional_machines = {
-        'ipa': { 'machine': { 'image': 'ipa' } }
+        'ipa': { 'machine': { 'image': 'ipa' }, 'start': { 'memory_mb': 2048 } }
     }
 
     def testIpa(self):
@@ -199,7 +199,7 @@ getent passwd admin@cockpit.lan
 @skipImage("No freeipa available", "debian-8", "debian-testing")
 class TestKerberos(MachineCase):
     additional_machines = {
-        'ipa': { 'machine': { 'image': 'ipa' } }
+        'ipa': { 'machine': { 'image': 'ipa' }, 'start': { 'memory_mb': 2048 } }
     }
 
     def configure_kerberos(self):


### PR DESCRIPTION
IPA seems to be running out of memory when starting. Lets
see if this fixes the instability we're seeing.