### PR TITLE
kubernetes: Fix removing push/pull role members

### DIFF
--- a/pkg/kubernetes/scripts/policy.js
+++ b/pkg/kubernetes/scripts/policy.js
@@ -224,7 +224,7 @@
             }
 
             function removeMemberFromPolicyBinding(policyBinding, project, subjectRoleBindings, subject) {
-                var registryRoles = ["registry-admin", "registry-edit", "registry-view"];
+                var registryRoles = ["registry-admin", "registry-editor", "registry-viewer"];
                 var chain = $q.when();
                 var defaultPolicybinding;
                 var roleBindings = [];

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1129,8 +1129,8 @@ def wait(func, msg=None, delay=1, tries=60):
       msg: A error message to use when the timeout occurs.  Defaults
         to a generic message.
       delay: How long to wait between calls to FUNC, in seconds.
-        Defaults to 0.2.
-      tries: How often to call FUNC.  Defaults to 20.
+        Defaults to 1.
+      tries: How often to call FUNC.  Defaults to 60.
 
     Raises:
       Error: When a timeout occurs.

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -25,6 +25,7 @@ import os
 import unittest
 import time
 import sys
+import re
 
 from kubelib import *
 
@@ -600,6 +601,9 @@ class TestRegistry(MachineCase):
         b.wait_visible(".modal-body")
         b.click(".btn-primary")
         b.wait_not_present("modal-dialog")
+        b.wait_present("table.listing-ct")
+        wait(lambda: re.search(r"registry-editor\s+/registry-editor\s+testprojectuser\b",
+                               o.execute("oc get rolebinding -n testprojectuserproj")))
 
         #delete user
         b.wait_in_text(".content-filter h3", "testprojectuser")
@@ -607,6 +611,36 @@ class TestRegistry(MachineCase):
         b.wait_present("modal-dialog")
         b.click(".btn-primary")
         b.wait_not_present("modal-dialog")
+        wait(lambda: not re.search(r"\btestprojectuser\b", o.execute("oc get rolebinding -n testprojectuserproj")))
+
+        #add/remove members for other roles
+        b.go("#/projects/testprojectuserproj")
+        for (role, perm) in [("Push", "editor"), ("Pull", "viewer")]:
+            username = "testprojectuser" + role.lower()
+            b.click("a i.pficon-add-circle-o")
+            b.wait_present("modal-dialog")
+            b.wait_visible("#add_member_name")
+            b.set_val("#add_member_name", username)
+            b.wait_visible("#add_role")
+            b.click("#add_role button")
+            b.wait_visible("#add_role .dropdown-menu")
+            b.click("#add_role a[value='%s']" % role)
+            b.click(".btn-primary")
+            b.wait_not_present("modal-dialog")
+            b.wait_present("tbody[data-id='%s']" % username)
+
+            wait(lambda: username in o.execute("oc get rolebinding -n testprojectuserproj"))
+            output = o.execute("oc get rolebinding -n testprojectuserproj")
+            self.assertRegexpMatches(output, "registry-%s\s+/registry-%s\s.*\\b%s\\b" % (perm, perm, username))
+            self.assertNotRegexpMatches(output, "registry-admin.*%s" % username)
+
+            b.wait_present("tbody[data-id='%s']" % username)
+            b.click("tbody[data-id='%s'] a i.pficon-close" % username)
+            b.wait_present("modal-dialog")
+            b.click(".btn-primary")
+            b.wait_not_present("modal-dialog")
+            b.wait_present("table.listing-ct")
+            wait(lambda: username not in o.execute("oc get rolebinding -n testprojectuserproj"))
 
     def testProjectPolicy(self):
         o = self.openshift


### PR DESCRIPTION
Fix role names in removeMemberFromPolicyBinding() to actually remove
non-admin users which have a pull (registry-viewer) and push
(registry-editor) role.

https://bugzilla.redhat.com/show_bug.cgi?id=1373377

We don't currently have that depth of coverage in `test/verify/check-kubernetes`. Do you want me to create a new test for the registry project management page which reproduces/covers this? (Warning: learning exercise ahead, this will take me a bit) Or do we rely on manual testing for those?