### PR TITLE
test: Fix race starting virsh default network

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -39,6 +39,9 @@ class TestMachines(MachineCase):
         b = self.browser
         m = self.machine
 
+        # We race with running the test after boot but before the libvirt network has started
+        m.execute("virsh net-start default 2> /dev/null || true")
+
         self.login_and_go("/machines")
         b.wait_in_text("body", "No VM is running or defined on this host")
 


### PR DESCRIPTION
On some operating systems like debian-8 we seem to race with
starting the virsh 'default' network. Our test runs so fast
after boot that.