### PR TITLE
subscriptions: Print the output we don't recognize

### DIFF
--- a/pkg/subscriptions/subscriptions-client.js
+++ b/pkg/subscriptions/subscriptions-client.js
@@ -210,7 +210,7 @@ client.registerSystem = function(subscriptionDetails) {
                 return;
             } else {
                 // unrecognized output
-                console.log("unrecognized subscription-manager failure output: ", ex);
+                console.log("unrecognized subscription-manager failure output: ", ex, message);
             }
             var error = new Error(message);
             dfd.reject(error);


### PR DESCRIPTION
When we don't recognize subscription-manager output actually print
it in the console log. This gets us much closer to actually figuring
out strange bugs.