### PR TITLE
Image refresh for centos-7

### DIFF
--- a/test/images/centos-7
+++ b/test/images/centos-7
@@ -1,1 +1,1 @@
-centos-7-2e7e7313a4c49463ee6a03d91aac9ed1d4f6b49f.qcow2
+centos-7-5b5b59cae452d1faf6901222e74cca163fc42fbf.qcow2


### PR DESCRIPTION
Image creation for centos-7 in process on cockpit-11.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-centos-7-2017-01-21/