### PR TITLE
Move cockpit-atomic-storage to python 3 on Debian/Ubuntu

### DIFF
--- a/pkg/docker/cockpit-atomic-storage
+++ b/pkg/docker/cockpit-atomic-storage
@@ -72,7 +72,6 @@ import os
 import subprocess
 import json
 import re
-import time
 import select
 
 ## Utils
@@ -169,7 +168,6 @@ def get_driver_info():
             return (None, None)
 
     def get_rootfs_lvol_and_vgroup():
-        root_dev = None
         for l in open("/proc/mounts", "r").readlines():
             fields = l.split()
             if fields[1] == "/" and fields[0].startswith("/dev"):
@@ -312,7 +310,6 @@ def drive_serial(d):
 
 def drive_name(d):
     vendor = drive_vendor(d)
-    model = drive_model(d)
     serial = drive_serial(d)
     wwn = drive_wwn(d)
 
@@ -337,7 +334,8 @@ def drive_class(d):
 
 can_manage = None
 
-def get_info():
+def get_info(got_uevent):
+    # XXX - skip udev/lvm stuff on pure timeouts, i. e. if got_uevent == False (currently unused)
     try:
         drives = { }
         for d in list_block_devices():
@@ -417,7 +415,7 @@ def cmd_monitor():
     except:
         pass
 
-    old_info = get_info()
+    old_info = get_info(True)
     print_info(old_info)
 
     mon = subprocess.Popen([ "stdbuf", "-o", "L", "udevadm", "monitor", "-u", "-s", "block"],
@@ -428,8 +426,9 @@ def cmd_monitor():
         if len(r) > 0:
             if mon.stdout.readline().decode().startswith("UDEV  "):
                 got_event = True
-        # XXX - skip udev/lvm stuff on pure timeouts
-        info = get_info()
+        # we want to periodically call get_info() to update the usage
+        # information even without uevents
+        info = get_info(got_event)
         if info != old_info:
             print_info(info)
             old_info = info
@@ -439,7 +438,6 @@ def cmd_monitor():
 def get_dss_vgroup():
     vgroup = sh_get_var_in_file("/etc/sysconfig/docker-storage-setup", "VG", "")
     if vgroup == "":
-        root_dev = None
         for l in open("/proc/mounts", "r").readlines():
             fields = l.split()
             if fields[1] == "/" and fields[0].startswith("/dev"):

--- a/pkg/docker/cockpit-atomic-storage
+++ b/pkg/docker/cockpit-atomic-storage
@@ -102,8 +102,7 @@ def list_pvs(vgroup):
     return res
 
 def list_lvs(vgroup):
-    return map(lambda s: s.strip(),
-               check_output([ "lvs", "--noheadings", "-o", "name", vgroup ]).splitlines())
+    return [s.strip() for s in check_output([ "lvs", "--noheadings", "-o", "name", vgroup ]).splitlines()]
 
 def list_parents(dev):
     return check_output([ "lsblk", "-snlp", "-o", "NAME", dev ]).splitlines()[1:]

--- a/pkg/docker/storage.jsx
+++ b/pkg/docker/storage.jsx
@@ -26,6 +26,8 @@
     var React = require("react");
     var dialog_view = require("cockpit-components-dialog.jsx");
     var cockpit_atomic_storage = require("raw!./cockpit-atomic-storage");
+    // FIXME: eventually convert all images to python 3
+    const pyinvoke = [ "sh", "-ec", "exec $(which python3 2>/dev/null || which python) $@", "--", "-" ];
 
     var _ = cockpit.gettext;
     var C_ = cockpit.gettext;
@@ -48,7 +50,7 @@
 
         function update() {
             if (!cockpit.hidden && !process) {
-                process = cockpit.spawn([ "python", "-", "monitor" ],
+                process = cockpit.spawn(pyinvoke.concat(["monitor"]),
                                         { err: "ignore",
                                           superuser: true })
                                   .input(cockpit_atomic_storage)
@@ -381,7 +383,7 @@
             var devs = drives.map(function (d) { return d.path; });
             if (docker_will_be_stopped)
                 client.close();
-            var process = cockpit.spawn([ "python", "-", storage_action ].concat(devs),
+            var process = cockpit.spawn(pyinvoke.concat([storage_action]).concat(devs),
                                          { 'err': 'out',
                                            'superuser': true })
                                   .input(cockpit_atomic_storage)
@@ -429,7 +431,7 @@
         function reset() {
             var dfd = $.Deferred();
             client.close();
-            var process = cockpit.spawn([ "python", "-", "reset-and-reduce" ],
+            var process = cockpit.spawn(pyinvoke.concat(["reset-and-reduce"]),
                                         { 'err': 'out',
                                           'superuser': true })
                                   .input(cockpit_atomic_storage)

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -87,7 +87,7 @@ Package: cockpit-docker
 Architecture: all
 Depends: ${misc:Depends},
          docker.io (>= 1.3.0) | docker-engine (>= 1.3.0),
-         python,
+         python3,
          cockpit-bridge (>= ${source:Version}),
          cockpit-bridge (<< ${source:Version}.1~)
 Description: Cockpit user interface for Docker containers

--- a/tools/static-code-tests
+++ b/tools/static-code-tests
@@ -6,6 +6,8 @@ set -e
 # pyflakes
 #
 
+pyflakes pkg/docker/cockpit-atomic-storage
+
 # TODO: there are currently a lot of pyflakes errors like
 #   'parent' imported but unused
 #   'from testlib import *' used; unable to detect undefined names


### PR DESCRIPTION
This makes `cockpit-atomic-storage` bilingual and changes `pkg/docker/storage.jsx` to invoke it with `python3` if available, and otherwise fall back to `python`.

Unfortunately there is no python3 package in rhel-7/centos-7, nor does that OS support alternative RPM dependencies, so keep "python" in cockpit.spec for the time being.

This avoids pulling in the long-deprecated `python` into Debian/Ubuntu. The dependency is hardly necessary anyway as this is only relevant for Atomic which isn't a Debian/Ubuntu thing.

This also fixes some pyflakes-detected issues and a bug.

Fixes #5719