### PR TITLE
kubernetes: Allow email format user names

### DIFF
--- a/pkg/kubernetes/scripts/kube-client.js
+++ b/pkg/kubernetes/scripts/kube-client.js
@@ -64,6 +64,7 @@
     ]);
 
     var NAME_RE = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+    var USER_NAME_RE = /^[a-z0-9_.]([-a-z0-9@._]*[a-z0-9._])?$/;
 
     /* Timeout for non-GET requests */
     var REQ_TIMEOUT = "120s";
@@ -1315,9 +1316,10 @@
                 if (meta) {
                     ex = null;
                     if (meta.name !== undefined) {
+                        var check_re = (resource.kind == "User") ? USER_NAME_RE : NAME_RE;
                         if (!meta.name)
                             ex = new Error("The name cannot be empty");
-                        else if (!NAME_RE.test(meta.name))
+                        else if (!check_re.test(meta.name))
                             ex = new Error("The name contains invalid characters");
                     }
                     if (ex) {

--- a/pkg/kubernetes/scripts/projects.js
+++ b/pkg/kubernetes/scripts/projects.js
@@ -876,7 +876,7 @@
         'fields',
         function($q, $scope, projectData, projectPolicy, kselect, fields) {
             var selectMember = 'Select Member';
-            var NAME_RE = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+            var NAME_RE = /^[a-z0-9_.]([-a-z0-9@._]*[a-z0-9._])?$/;
             var selectRole = 'Select Role';
             $scope.selected = {
                 member: selectMember,

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -608,6 +608,48 @@ class TestRegistry(MachineCase):
         b.click(".btn-primary")
         b.wait_not_present("modal-dialog")
 
+        # try to add user with invalid name from testprojectuserproj page
+        b.go("#/projects/testprojectuserproj")
+        b.wait_present("a i.pficon-add-circle-o")
+        b.click("a i.pficon-add-circle-o")
+        b.wait_present("modal-dialog")
+        b.wait_visible("#add_member_name")
+        b.set_val("#add_member_name", "foo ^ bar")
+        b.wait_visible("#add_role")
+        b.click("#add_role button")
+        b.wait_visible("#add_role .dropdown-menu")
+        b.click("#add_role a[value='Admin']")
+        b.click(".btn-primary")
+        self.assertEqual(b.text(".dialog-error"), "The member name contains invalid characters.")
+
+        # but email-style user name should be accepted
+        b.set_val("#add_member_name", "foo@bar.com")
+        b.click(".btn-primary")
+        b.wait_not_present("modal-dialog")
+        b.wait_present("tbody[data-id='foo@bar.com']")
+        wait(lambda: 'foo@bar.com' in o.execute("oc get rolebinding -n testprojectuserproj"))
+        self.assertNotIn('foo ^ bar', o.execute("oc get rolebinding -n testprojectuserproj"))
+
+        # it appears on the "All projects" page too
+        b.go("#/projects/")
+        b.wait_present("tbody[data-id='foo@bar.com']")
+
+        # try to add user with invalid name from "All projects" page
+        b.click("#add-user")
+        b.wait_present("modal-dialog")
+        b.wait_visible(".modal-body")
+        b.wait_visible("#identities")
+        b.set_val("#user_name", "bar ^ baz")
+        b.set_val("#identities", "anypassword:abc123")
+        b.click(".btn-primary")
+        self.assertEqual(b.text(".dialog-error"), "The name contains invalid characters")
+
+        # email-style user name should be accepted
+        b.set_val("#user_name", "bar@baz.com")
+        b.click(".btn-primary")
+        b.wait_not_present("modal-dialog")
+        b.wait_present("tbody[data-id='bar@baz.com']")
+
     def testProjectPolicy(self):
         o = self.openshift
         b = self.browser


### PR DESCRIPTION
OpenShift itself does not seem to make any restriction on user names,
but let's keep it conservative. Kubernetes explicitly documents
email-format user names: https://kubernetes.io/docs/admin/authentication/

https://bugzilla.redhat.com/show_bug.cgi?id=1383240

~~WIP because this changes the same test as PR #5771 and thus will need rebasing once that lands.~~