### PR TITLE
Vagrant: Order package dependencies alphabetically

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,8 +42,22 @@ Vagrant.configure(2) do |config|
         ln -snf /cockpit/dist /home/admin/.local/share/cockpit
 
         dnf copr enable -y @cockpit/cockpit-preview
-        dnf install -y docker kubernetes atomic subscription-manager etcd pcp realmd \
-		NetworkManager storaged storaged-lvm2 git yum-utils tuned libvirt virt-install qemu
+        dnf install -y \
+            atomic \
+            docker \
+            etcd \
+            git \
+            kubernetes \
+            NetworkManager \
+            pcp \
+            qemu \
+            realmd \
+            storaged \
+            storaged-lvm2 \
+            subscription-manager \
+            tuned libvirt \
+            virt-install \
+            yum-utils
         dnf install -y cockpit
         debuginfo-install -y cockpit cockpit-pcp
 


### PR DESCRIPTION
This makes it easier to change the list.

I changed this because I thought I needed to add a new dependency on kexec-tools, but it turns out I didn't. Either way, this should make maintaining this list easier in the future.
For the record: I didn't try building the image with the new list.