### PR TITLE
networkmanager: Watch the ObjectManager

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -395,7 +395,7 @@ function NetworkManagerModel() {
         });
 
     var subscription = client.subscribe({ }, signal_emitted);
-    var watch = client.watch({ });
+    var watch = client.watch({ path_namespace: "/org/freedesktop" });
     $(client).on("notify", function(event, data) {
         $.each(data, function(path, ifaces) {
             $.each(ifaces, function(iface, props) {


### PR DESCRIPTION
Newer versions of NetworkManager have a D-Bus ObjectManager
at /org/freedesktop but we have been watching "/", which
makes our cache use introspection.

Using the ObjectManager is better, and there also seem to be
subtle ordering issues when a ObjectManager is present but
the cache uses introspection, see #5792.