### PR TITLE
ws: Remove libssh header includes that aren't needed anymore

### DIFF
--- a/src/ws/cockpitsshtransport.c
+++ b/src/ws/cockpitsshtransport.c
@@ -37,9 +37,6 @@
 #include "common/cockpitpipe.h"
 #include "common/cockpitpipetransport.h"
 
-#include <libssh/libssh.h>
-#include <libssh/callbacks.h>
-
 #include <glib/gstdio.h>
 
 #include <errno.h>

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -39,9 +39,6 @@
 #include "common/cockpitsystem.h"
 #include "common/cockpittest.h"
 
-#include <libssh/libssh.h>
-#include <libssh/callbacks.h>
-
 /* ---------------------------------------------------------------------------------------------------- */
 
 static gint      opt_port         = 9090;

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -36,8 +36,6 @@
 
 #include <glib.h>
 
-#include <libssh/libssh.h>
-
 #include <string.h>
 #include <errno.h>
 

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -36,8 +36,6 @@
 
 #include <glib.h>
 
-#include <libssh/libssh.h>
-
 #include <string.h>
 #include <errno.h>
 


### PR DESCRIPTION
The libssh dependency was moved out of ws and these includes are leading to failed builds on systems without libssh.