### PR TITLE
Remove use of files.cockpit-project.org from documentation

### DIFF
--- a/pkg/realmd/README.md
+++ b/pkg/realmd/README.md
@@ -50,7 +50,7 @@ above if you do not.
 Use the following guide to configure things, with more troubleshooting advice
 below:
 
-http://files.cockpit-project.org/guide/latest/sso.html
+http://cockpit-project.org/guide/latest/sso.html
 
 **BUG:** The host name of the computer Cockpit is running on should end with
 the domain name. If it does not, then rename the computer Cockpit is running on:

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -99,7 +99,7 @@ function invoke_functions(functions, self, args) {
 /* -------------------------------------------------------------------------
  * Channels
  *
- * Public: https://files.cockpit-project.org/guide/api-cockpit.html
+ * Public: http://cockpit-project.org/guide/latest/api-base1.html
  */
 
 var default_transport = null;
@@ -2641,8 +2641,6 @@ function factory() {
 
     /* ---------------------------------------------------------------------
      * Spawning
-     *
-     * Public: https://files.cockpit-project.org/guide/api-cockpit.html
      */
 
     function ProcessError(options, name) {

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -190,7 +190,7 @@ class TestConnection(MachineCase):
     def testSocketPort(self):
         m = self.machine
 
-        # Change port according to documentation: http://files.cockpit-project.org/guide/latest/listen.html
+        # Change port according to documentation: http://cockpit-project.org/guide/latest/listen.html
         m.execute('! selinuxenabled || semanage port -m -t websm_port_t -p tcp 443')
         m.execute('mkdir -p /etc/systemd/system/cockpit.socket.d/ && printf "[Socket]\nListenStream=\nListenStream=443" > /etc/systemd/system/cockpit.socket.d/listen.conf')
         m.start_cockpit(tls=True)


### PR DESCRIPTION
These links no longer work. Update to cockpit-project.org