### PR TITLE
test: Fix networking test timeout

### DIFF
--- a/test/verify/check-networking-basic
+++ b/test/verify/check-networking-basic
@@ -48,7 +48,17 @@ class TestNetworking(NetworkCase):
         b.set_val('#network-ip-settings-dialog input[placeholder*="Netmask"]', "255.255.192.0")
         b.click("#network-ip-settings-dialog button:contains('Apply')")
         b.wait_popdown("network-ip-settings-dialog")
-        b.wait_in_text("#network-interface .panel:contains('%s')" % iface, "1.2.3.4/18")
+        b.wait_present("#network-interface .panel:contains('%s')" % iface)
+        try:
+            b.wait_in_text("#network-interface .panel:contains('%s')" % iface, "1.2.3.4/18")
+        except:
+            # if we are reconnecting, give one more chance to reconnect and wait for text
+            # otherwise this was a valid timeout
+            if not b.is_present("#network-interface .panel:contains('%s')" % iface):
+                b.wait_present("#network-interface .panel:contains('%s')" % iface)
+                b.wait_in_text("#network-interface .panel:contains('%s')" % iface, "1.2.3.4/18")
+            else:
+                raise
 
         con_id = self.iface_con_id(iface)
 


### PR DESCRIPTION
Cockpit may try to reconnect, making the wait_in_text fail.
We want to make sure that the item we're looking for is
actually present before comparing the text.

This happened in https://fedorapeople.org/groups/cockpit/logs/pull-5814-81cf6868-verify-fedora-atomic/backup.yCG2e8/log.html#110
```
Traceback (most recent call last):
  File "./verify/check-networking-basic", line 51, in testBasic
    b.wait_in_text("#network-interface .panel:contains('%s')" % iface, "1.2.3.4/18")
  File "/build/cockpit/test/common/testlib.py", line 242, in wait_in_text
    return self.wait_js_func('ph_in_text', selector, text)
  File "/build/cockpit/test/common/testlib.py", line 209, in wait_js_func
    return self.phantom.wait("%s(%s)" % (func, ','.join(map(jsquote, args))))
  File "/build/cockpit/test/common/testlib.py", line 719, in <lambda>
    return lambda *args: self._invoke(name, *args)
  File "/build/cockpit/test/common/testlib.py", line 742, in _invoke
    raise Error(res['error'])
Error: timeout
```
![testnetworking-testbasic-fail](https://cloud.githubusercontent.com/assets/8711649/22422345/2012cd9e-e6ec-11e6-96e0-3430fbe4cf22.png)
