### PR TITLE
shell: removed tabindex to fix keyboard tab navigation order

### DIFF
--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -34,21 +34,21 @@
                 <label id="conversation-prompt" for="conversation-input"></label>
               </div>
               <div class="col-sm-12 col-md-12">
-                <input type="password" class="form-control" id="conversation-input" tabindex="1">
+                <input type="password" class="form-control" id="conversation-input">
               </div>
             </div>
 
             <div id="user-group" class="form-group">
               <label for="login-user-input" class="col-sm-2 col-md-2 control-label">User name</label>
               <div class="col-sm-10 col-md-10">
-                <input type="text" class="form-control" id="login-user-input" tabindex="1">
+                <input type="text" class="form-control" id="login-user-input">
               </div>
             </div>
 
             <div id="password-group" class="form-group">
               <label for="login-password-input" class="col-sm-2 col-md-2 control-label">Password</label>
               <div class="col-sm-10 col-md-10">
-                <input type="password" class="form-control" id="login-password-input" tabindex="2">
+                <input type="password" class="form-control" id="login-password-input">
               </div>
               <div class="col-sm-2 col-md-2"></div>
               <div class="col-sm-10 col-md-10">
@@ -74,14 +74,14 @@
             <div id="server-group" class="form-group" hidden>
               <label title="Log in to another system. Leave blank to log in to the local system." for="server-field" class="col-sm-2 col-md-2 control-label">Connect to</label>
               <div class="col-sm-10 col-md-10 server-box">
-                <input type="text" class="form-control" id="server-field" tabindex="2">
+                <input type="text" class="form-control" id="server-field">
                 <span class="cross" id="server-clear" aria-hidden="true">&#x274c;</span>
               </div>
             </div>
 
             <div class="form-group">
               <div class="col-md-3 col-sm-3 login-button-container">
-                <button class="btn btn-primary btn-lg col-xs-12" id="login-button" tabindex="3">
+                <button class="btn btn-primary btn-lg col-xs-12" id="login-button">
                   <div class="spinner"></div>
                   <div id="login-button-text">Log In</div>
                 </button>


### PR DESCRIPTION
Accessibility of the log in screen is broken. Many people who do not even rely on such features still often use accessibility features when typing on the keyboard, as to not have to switch back and forth between a keyboard and mouse.

`tabindex` is generally a misfeature of HTML and gets in the way of natural order of tabbing through elements. Generally one would want to remove all `tabindex` references, unless it is necessary to hardcode the tabbing order of elements which may be activated.

See http://webaim.org/techniques/keyboard/tabindex for proper usage of `tabindex`.

Fixes #5819.