### PR TITLE
test: Make network test setup more robust

### DIFF
--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import subprocess
 from testlib import *
 
 class NetworkCase(MachineCase):
@@ -29,9 +30,18 @@ class NetworkCase(MachineCase):
         # connections that might still be here from the time of
         # creating the image and we prevent NM from automatically
         # creating new connections.
+        # if the command fails, try again
+        failures_allowed = 3
+        while True:
+            try:
+                print m.execute("nmcli con show")
+                m.execute("""nmcli -f UUID,DEVICE connection show | awk '$2 == "--" { print $1 }' | xargs -r nmcli con del""")
+                break
+            except subprocess.CalledProcessError:
+                failures_allowed -= 1
+                if failures_allowed == 0:
+                    raise
 
-        print m.execute("nmcli con show")
-        m.execute("""nmcli -f UUID,DEVICE connection show | awk '$2 == "--" { print $1 }' | xargs -r nmcli con del""")
         m.write("/etc/NetworkManager/conf.d/99-test.conf", "[main]\nno-auto-default=*\n")
         m.execute("systemctl reload-or-restart NetworkManager")
 


### PR DESCRIPTION
Sometimes the nmcli command can fail, but we don't mind trying again.

Happened in https://fedorapeople.org/groups/cockpit/logs/pull-5796-8197835e-verify-centos-7/log.html#34
```
Error: unknown connection '6a76d7cf-7802-411e-9587-56218798a936'.
Error: cannot delete unknown connection(s): '6a76d7cf-7802-411e-9587-56218798a936'.
Wrote TestNetworking-testNonDefaultBondSettings-FAIL.png
Journal extracted to TestNetworking-testNonDefaultBondSettings-10.111.122.152-FAIL.log
not ok 34 testNonDefaultBondSettings (check_networking_bond.TestNetworking) duration: 39s
Traceback (most recent call last):
  File "/build/cockpit/test/verify/netlib.py", line 33, in setUp
    m.execute("""nmcli -f UUID,DEVICE connection show | awk '$2 == "--" { print $1 }' | xargs -r nmcli con del""")
  File "/build/cockpit/test/common/testvm.py", line 412, in execute
    raise subprocess.CalledProcessError(proc.returncode, command, output=output)
CalledProcessError: Command 'nmcli -f UUID,DEVICE connection show | awk '$2 == "--" { print $1 }' | xargs -r nmcli con del' returned non-zero exit status 123
```
