### PR TITLE
debian: Relax lintian source overrides

### DIFF
--- a/test/images/scripts/lib/debian.install
+++ b/test/images/scripts/lib/debian.install
@@ -63,7 +63,7 @@ if [ -n "$do_build" ]; then
     pbuilder build --buildresult "$resultdir" \
                    --logfile "$resultdir/build.log" \
                    cockpit_0-1.dsc >$stdout_dest
-    lintian $resultdir/cockpit_*_$(dpkg --print-architecture).changes
+    lintian $resultdir/cockpit_*_$(dpkg --print-architecture).changes >&2
 fi
 
 # Install

--- a/tools/debian/source/lintian-overrides
+++ b/tools/debian/source/lintian-overrides
@@ -1,7 +1,6 @@
 # bower_components ship pre-minified *.min.js alongside *.js
 cockpit source: source-is-missing bower_components/*
 # dist/ is (pre-)built by webpack from pkg/ and bower_components, see webpack.config.js
-cockpit source: source-is-missing dist/*min.js
-cockpit source: source-is-missing dist/shell/po.*.js *
+cockpit source: source-is-missing dist/*.js*
 # false-positive heuristics, this is actual source
 cockpit source: source-is-missing pkg/kubernetes/scripts/test-images.js line length*


### PR DESCRIPTION
Currently testsuite-prepare for debian-testing fails on

    E: cockpit source: source-is-missing dist/kdump/test-config-client.js line length is 566 characters (>512)
    E: cockpit source: source-is-missing dist/sosreport/sosreport.js line length is 687 characters (>512)
    E: cockpit source: source-is-missing dist/kubernetes/scripts/test-images.js line length is 12352 characters (>512)

Relax the override to cover these files too. As the entirety of dist/ is
autogenerated, all *.js files are okay to not be preferred form of
modification.

----
Note: It's not entirely clear why this failure doesn't break CI. E. g. PR #5809 ran recently and lintian succeeds there. But this always happens locally, both for @mvollmer and myself.