### PR TITLE
Image refresh for debian-8

### DIFF
--- a/test/images/debian-8
+++ b/test/images/debian-8
@@ -1,1 +1,1 @@
-debian-8-4b6b7af59b14996be932b5bbb52321bda9ebfd23.qcow2
+debian-8-883a146788469c5146d378d12e2647db2f2dbbd2.qcow2


### PR DESCRIPTION
Image creation for debian-8 in process on cockpit-9.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-8-2017-02-01/