### PR TITLE
Image refresh for fedora-testing

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -576,6 +576,9 @@ class MachineCase(unittest.TestCase):
         # https://bugzilla.redhat.com/show_bug.cgi?id=1386624
         ".*type=1400 .*denied  { name_bind } for.*dhclient.*",
 
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1419263
+        ".*type=1400 .*denied  { write } for.*firewalld.*__pycache__.*",
+
         # https://bugzilla.redhat.com/show_bug.cgi?id=1242656
         "(audit: )?type=1400 .*denied.*comm=\"cockpit-ws\".*name=\"unix\".*dev=\"proc\".*",
         "(audit: )?type=1400 .*denied.*comm=\"ssh-transport-c\".*name=\"unix\".*dev=\"proc\".*",

--- a/test/images/fedora-testing
+++ b/test/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-92adec270dec3ee1dd322fb70c781d6b50ecf820.qcow2
+fedora-testing-637b4006e6d699e72d926443b487d96c7dabd664.qcow2


### PR DESCRIPTION
Image creation for fedora-testing in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-testing-2017-02-03/