### PR TITLE
test: Fix race when booting check-services

### DIFF
--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -85,6 +85,7 @@ OnCalendar=*:1/2
 
         # After writing files out tell systemd about them
         m.execute("systemctl daemon-reload")
+        self.machine.execute("systemctl start default.target")
 
         self.login_and_go("/system/services")
 


### PR DESCRIPTION
The boot process of check-services seems to race with test.service
and we see it being restarted unexpectedly:

For example:

```
systemd[1]: Started Test Service.
systemd[1]: Starting Test Service...
sh[12539]: START
systemd[1]: Stopping Test Service...
sh[12539]: STOP
systemd[1]: Stopped Test Service.
systemd[1]: Reloading.
systemd[1]: Started Test Timer.
systemd[1]: Starting Test Timer.
systemd[1]: Started Test Service.
systemd[1]: Starting Test Service...
sh[12575]: START
systemd[1]: Stopped Test Timer.
systemd[1]: Stopping Test Timer.
sh[12575]: WORKING
sh[12575]: WORKING
```