### PR TITLE
tools: Add another valgrind suppression entry for Semaphore

### DIFF
--- a/tools/glib.supp
+++ b/tools/glib.supp
@@ -519,3 +519,18 @@
    ...
    fun:glib_worker_main
 }
+{
+   g_log__g_convert_with_iconv_1
+   Memcheck:Addr8
+   fun:__gconv_transform_internal_ascii
+   fun:__gconv_transform_utf8_internal
+   fun:__gconv
+   fun:iconv
+   fun:g_convert_with_iconv
+   fun:g_convert
+   fun:g_convert_with_fallback
+   ...
+   fun:g_print
+   ...
+   fun:g_log
+}


### PR DESCRIPTION
This should cover the following valgrind failure:

```
at 0x6982743: __gconv_transform_internal_ascii (skeleton.c:665)
by 0x6983BA8: __gconv_transform_utf8_internal (skeleton.c:674)
by 0x697E599: __gconv (gconv.c:79)
by 0x697DB46: iconv (iconv.c:52)
by 0x5427924: g_convert_with_iconv (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
by 0x5427B67: g_convert (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
by 0x5427CC6: g_convert_with_fallback (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
by 0x544A30D: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
by 0x544B40B: g_print (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
by 0x5466440: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
by 0x5467432: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
by 0x544AAE0: g_logv (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
by 0x544AD71: g_log (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
```