### PR TITLE
test: Reload phantomjs browser when testing frame navigation

### DIFF
--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -545,6 +545,7 @@ class TestMultiMachine(MachineCase):
         m2.execute('passwd -u admin')
 
         # path should reconnect at this point
+        b.reload()
         b.go(m2_path)
         b.enter_page("/playground/test", m2.address, reconnect=True)
         # image is back because it page was reloaded after disconnection


### PR DESCRIPTION
Reload phantomjs browser when testing frame navigation. Otherwise
we have races between cockpit-ws channel response internal state,
and the expectations of the tests.