### PR TITLE
Compute and use minimal version of -bridge subpackage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -345,6 +345,7 @@ COMMITTED_DIST = \
 	$(NULL)
 
 # Build up the distribution using $COMMITTED_DIST and include node_modules and bower licenses
+# also automatically update minimum base dependency in RPM spec file
 dist-hook::
 	( cd $(srcdir); git ls-tree HEAD --name-only -r $(COMMITTED_DIST) || (echo $(COMMITTED_DIST) | tr ' ' '\n' ) ) | \
 		tar -C $(srcdir) -cf - -T - | tar -C $(distdir) -xf -
@@ -352,6 +353,7 @@ dist-hook::
 	tar -C $(srcdir) -cf - bower_components/ | tar -C $(distdir) -xf -
 	echo $(VERSION) > $(distdir)/.tarball
 	$(srcdir)/tools/build-copying $(BOWER) > $(distdir)/COPYING.bower
+	[ ! -e $(distdir)/tools/cockpit.spec ] || sed -ri "s/^(.*%define required_base).*$$/\1 $$($(srcdir)/tools/min-base-version)/" $(distdir)/tools/cockpit.spec
 
 DIST_TAR_MAIN = tar --format=posix -cf - --exclude='node_modules' "$(distdir)" "$(distdir)/bower.json" "$(distdir)/.bowerrc"
 DIST_TAR_CACHE = tar --format=posix -cf - "$(distdir)/node_modules" "$(distdir)/package.json"

--- a/test/images/scripts/lib/debian.install
+++ b/test/images/scripts/lib/debian.install
@@ -39,13 +39,16 @@ if [ -n "$do_build" ]; then
     rm -rf build-results
     mkdir build-results
     resultdir=$PWD/build-results
+    upstream_ver=$(ls cockpit-*.tar.gz | sed 's/^.*-//; s/.tar.gz//' | head -n1)
 
-    ln -sf cockpit-*.tar.gz cockpit_0.orig.tar.gz
+    ln -sf cockpit-*.tar.gz cockpit_${upstream_ver}.orig.tar.gz
 
     rm -rf cockpit-*/
     tar -xzf cockpit-*.tar.gz
     ( cd cockpit-*/
       cp -rp tools/debian debian
+      # put proper version into changelog, as we have versioned dependencies
+      sed -i "1 s/(.*)/($upstream_ver-1)/" debian/changelog
       # Hack: Remove PCP build dependencies while pcp is not in testing
       # (https://tracker.debian.org/pcp)
       sed -i '/libpcp.*-dev/d' debian/control
@@ -62,7 +65,7 @@ if [ -n "$do_build" ]; then
 
     pbuilder build --buildresult "$resultdir" \
                    --logfile "$resultdir/build.log" \
-                   cockpit_0-1.dsc >$stdout_dest
+                   cockpit_${upstream_ver}-1.dsc >$stdout_dest
     lintian $resultdir/cockpit_*_$(dpkg --print-architecture).changes >&2
 fi
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -12,7 +12,8 @@
 #  * wip 1
 #
 
-# earliest base that the subpackages work on
+# earliest base that the subpackages work on; this gets computed/updated by
+# tools/min-base-version during "make dist", but keep a hardcoded fallback
 %define required_base 122
 
 %if 0%{?centos}

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -37,8 +37,7 @@ Homepage: http://cockpit-project.org/
 Package: cockpit
 Architecture: all
 Depends: ${misc:Depends},
-         cockpit-bridge (>= ${source:Version}),
-         cockpit-bridge (<< ${source:Version}.1~),
+         cockpit-bridge (>= ${bridge:minversion}),
          cockpit-dashboard (>= ${source:Version}),
          cockpit-dashboard (<< ${source:Version}.1~),
          cockpit-ws (>= ${source:Version}),
@@ -89,8 +88,7 @@ Architecture: all
 Depends: ${misc:Depends},
          docker.io (>= 1.3.0) | docker-engine (>= 1.3.0),
          python3,
-         cockpit-bridge (>= ${source:Version}),
-         cockpit-bridge (<< ${source:Version}.1~)
+         cockpit-bridge (>= ${bridge:minversion}),
 Description: Cockpit user interface for Docker containers
  The Cockpit components for interacting with Docker and user interface.
 
@@ -104,8 +102,7 @@ Description: Cockpit user interface for virtual machines
 Package: cockpit-networkmanager
 Architecture: all
 Depends: ${misc:Depends},
-         cockpit-bridge (>= ${source:Version}),
-         cockpit-bridge (<< ${source:Version}.1~),
+         cockpit-bridge (>= ${bridge:minversion}),
          network-manager
 Description: Cockpit user interface for networking
  The Cockpit components for interacting with networking configuration.
@@ -114,7 +111,7 @@ Package: cockpit-pcp
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
-         cockpit-bridge (= ${binary:Version}),
+         cockpit-bridge (>= ${bridge:minversion}),
          pcp
 Description: Cockpit PCP integration
  Cockpit support for reading PCP metrics and loading PCP archives.
@@ -123,16 +120,14 @@ Package: cockpit-storaged
 Architecture: all
 Depends: ${misc:Depends},
          udisks2 | storaged,
-         cockpit-bridge (>= ${source:Version}),
-         cockpit-bridge (<< ${source:Version}.1~)
+         cockpit-bridge (>= ${bridge:minversion}),
 Description: Cockpit user interface for storage
  The Cockpit components for interacting with storage.
 
 Package: cockpit-system
 Architecture: all
 Depends: ${misc:Depends},
-         cockpit-bridge (>= ${source:Version}),
-         cockpit-bridge (<< ${source:Version}.1~),
+         cockpit-bridge (>= ${bridge:minversion}),
          libpwquality-tools,
          openssl,
 Provides: cockpit-realmd,

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -33,3 +33,6 @@ override_dh_install:
 
 override_dh_fixperms:
 	dh_fixperms -Xcockpit-session -Xcockpit-polkit
+
+override_dh_gencontrol:
+	dh_gencontrol -- -Vbridge:minversion="$(shell tools/min-base-version)"

--- a/tools/min-base-version
+++ b/tools/min-base-version
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+# Compute the maximum required "cockpit" version from all pkg/*/manifest.json
+# for computing rpm/deb package dependencies. This is a bit stricter than
+# absolutely required, as only some subpackages might require a newer cockpit
+# version, but doing this precisely would be much more complicated and error
+# prone.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import os
+import json
+from glob import glob
+
+proj_dir = os.path.dirname(os.path.dirname(os.path.realpath(sys.argv[0])))
+
+max_version = '0'
+for manifest in glob(os.path.join(proj_dir, 'pkg/*/manifest.json')):
+    with open(manifest) as f:
+        requires = json.load(f)['requires']
+    try:
+        v = requires['cockpit']
+        if v > max_version:
+            max_version = v
+    except KeyError:
+        sys.stderr.write('WARNING: %s lacks cockpit dependency' % manifest)
+
+print(max_version)

--- a/tools/semaphore-prepare
+++ b/tools/semaphore-prepare
@@ -2,4 +2,4 @@
 
 change-phantomjs-version 2.1.1
 sudo apt-get update
-sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libgirepository1.0-dev libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-login-dev libsystemd-journal-dev pcp pkg-config valgrind xmlto xsltproc pyflakes
+sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libgirepository1.0-dev libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-login-dev libsystemd-journal-dev libkrb5-dev pcp pkg-config valgrind xmlto xsltproc pyflakes npm nodejs-legacy git libfontconfig1 dbus ssh


### PR DESCRIPTION
Add min-base-version helper script to compute the maximum cockpit module dependency from all pkg manifests. This is a bit stricter than absolutely required, as only some subpackages might require a newer cockpit version, but doing this precisely would be much more complicated and error prone. 

Use that to autogenerate the deb dependencies. Unfortunately the same doesn't work for RPM: `%define` gets expanded before unpacking the source tar, so we can't call `min-base-version` in the spec file. So set it as explicit `--define` in lib/make-srpm instead for our test images, and keep the hardcoded fallback for the time being.

I unfortunately don't have a good idea how to make this fully dynamic in our release process. We don't want to teach cockpituous' `release/release-srpm` about this cockpit specific file, `Requires:` can only use macros (not shell vars or `%()` expansion after the source gets untarred), so at least to my uninitiated eye it seems we need to add some indirection to cockpituous to call a "munge my spec file" script from cockpit? 