### PR TITLE
doc: Fix regressions that made building guide too noisy

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,6 +63,10 @@ COPY_RULE = \
         $(V_COPY) $(MKDIR_P) $(dir $@) && \
 	cp -L $< $@.tmp && $(MV) $@.tmp $@
 
+CAT_RULE = \
+        $(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
+	cat $^ > $@.tmp && $(MV) $@.tmp $@
+
 GZ_RULE = \
 	$(V_GZIP) $(MKDIR_P) $(dir $@) && \
 	gzip -n -c $< > $@.tmp && $(MV) $@.tmp $@

--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -90,16 +90,14 @@ CLEANFILES += \
 	$(NULL)
 
 dist/guide/html/%.woff: dist/fonts/%.woff
-	$(V_COPY) $(MKDIR_P) $(dir $@)
-	cp -L $^ $@.tmp
-	$(MV) $@.tmp $@
+	$(COPY_RULE)
 
 dist/guide/html/index.html: $(GUIDE_DOCBOOK) $(GUIDE_INCLUDES) $(man_MANS) $(GUIDE_STATIC) $(GUIDE_XSLT) $(GUIDE_FONTS)
-	$(AM_V_GEN) $(MKDIR_P) dist/guide/html/
-	cp $(addprefix $(srcdir)/,$(GUIDE_STATIC)) dist/guide/html/
+	$(AM_V_GEN) $(MKDIR_P) dist/guide/html/ && \
+	cp $(addprefix $(srcdir)/,$(GUIDE_STATIC)) dist/guide/html/ && \
 	LANG=en_US.UTF-8 $(XMLTO) html -m $(srcdir)/doc/guide/gtk-doc.xsl -o dist/guide/html/ \
 		--searchpath $(abs_builddir):$(abs_srcdir):$(abs_builddir)/doc/guide \
-		$(srcdir)/$(GUIDE_DOCBOOK)
+		$(srcdir)/$(GUIDE_DOCBOOK) && \
 	if grep -n -r 'name=\"id' dist/guide/html >&2; then \
 		echo "Unexpected generated id in the documentation" >&2; \
 		rm dist/guide/html/index.html; \
@@ -109,12 +107,12 @@ dist/guide/html/index.html: $(GUIDE_DOCBOOK) $(GUIDE_INCLUDES) $(man_MANS) $(GUI
 dist/guide/html: dist/guide/html/index.html
 
 dist/guide/links.html:
-	$(AM_V_GEN) $(MKDIR_P) $(dir $@)
+	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
 	(git -C $(srcdir) tag -l '[0-9]*' --sort=-version:refname --format \
-		'<a href="./%(refname:strip=2)/">%(refname:strip=2)</a>' | head -n15 || true) > $@.tmp
-	mv $@.tmp $@
+		'<a href="./%(refname:strip=2)/">%(refname:strip=2)</a>' | head -n15 || true) > $@.tmp && \
+	$(MV) $@.tmp $@
 
 dist/guide/index.html: doc/guide/directory.html dist/guide/links.html doc/guide/footer.html
-	$(AM_V_GEN) $(MKDIR_P) $(dir $@)
-	cat $^ > $@.tmp
-	mv $@.tmp $@
+	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
+	cat $^ > $@.tmp && \
+	$(MV) $@.tmp $@

--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -113,6 +113,4 @@ dist/guide/links.html:
 	$(MV) $@.tmp $@
 
 dist/guide/index.html: doc/guide/directory.html dist/guide/links.html doc/guide/footer.html
-	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	cat $^ > $@.tmp && \
-	$(MV) $@.tmp $@
+	$(CAT_RULE)

--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -94,15 +94,10 @@ dist/guide/html/%.woff: dist/fonts/%.woff
 
 dist/guide/html/index.html: $(GUIDE_DOCBOOK) $(GUIDE_INCLUDES) $(man_MANS) $(GUIDE_STATIC) $(GUIDE_XSLT) $(GUIDE_FONTS)
 	$(AM_V_GEN) $(MKDIR_P) dist/guide/html/ && \
-	cp $(addprefix $(srcdir)/,$(GUIDE_STATIC)) dist/guide/html/ && \
-	LANG=en_US.UTF-8 $(XMLTO) html -m $(srcdir)/doc/guide/gtk-doc.xsl -o dist/guide/html/ \
+	cp $(addprefix $(srcdir)/,$(GUIDE_STATIC)) dist/guide/html/
+	$(AM_V_GEN) LANG=en_US.UTF-8 $(XMLTO) html -m $(srcdir)/doc/guide/gtk-doc.xsl -o dist/guide/html/ \
 		--searchpath $(abs_builddir):$(abs_srcdir):$(abs_builddir)/doc/guide \
-		$(srcdir)/$(GUIDE_DOCBOOK) && \
-	if grep -n -r 'name=\"id' dist/guide/html >&2; then \
-		echo "Unexpected generated id in the documentation" >&2; \
-		rm dist/guide/html/index.html; \
-		exit 1; \
-	fi
+		$(srcdir)/$(GUIDE_DOCBOOK)
 
 dist/guide/html: dist/guide/html/index.html
 
@@ -114,3 +109,9 @@ dist/guide/links.html:
 
 dist/guide/index.html: doc/guide/directory.html dist/guide/links.html doc/guide/footer.html
 	$(CAT_RULE)
+
+check-local::
+	if grep -n -r 'name=\"id' dist/guide/html >&2; then \
+		echo "Unexpected generated id in the documentation" >&2; \
+		exit 1; \
+	fi


### PR DESCRIPTION
The Makefile for building the guide respected the V=1 and automake
silent rules. Fix the regression introduced in #5834

CC @dperpeet 