### PR TITLE
tools: Check validity of po files during 'dist check'

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -6104,9 +6104,7 @@ msgstr "Nombre de host desconocido "
 
 #: pkg/docker/index.html:564
 msgid "Unless Stopped"
-msgstr ""
-"\n"
-"A menos que detenido"
+msgstr "A menos que detenido"
 
 #: pkg/storaged/content-views.jsx:170 pkg/storaged/content-views.jsx:177
 #: pkg/storaged/content-views.jsx:190

--- a/tools/check-dist
+++ b/tools/check-dist
@@ -36,3 +36,11 @@ find $1/dist -type f | while read file; do
         fi
     done
 done
+
+# Make sure all po files are valid
+find $1/po -name '*.po' -print | while read file; do
+    if ! msgfmt "$file" -o /dev/null; then
+        echo "Refusing to distribute invalid po file: $file" >&2
+        exit 1
+    fi
+done


### PR DESCRIPTION
This catches various errors found by msgfmt. There was an error in es.po