### PR TITLE
Image refresh for ubuntu-1604

### DIFF
--- a/test/images/ubuntu-1604
+++ b/test/images/ubuntu-1604
@@ -1,1 +1,1 @@
-ubuntu-1604-cc5b2c053da4c96ae78a858bbe8d3e3269fa864b.qcow2
+ubuntu-1604-44d58f5bb81092d71a0b582ad301ef9282a1ae9f.qcow2


### PR DESCRIPTION
Image creation for ubuntu-1604 in process on cockpit-11.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-ubuntu-1604-2017-02-06/