### PR TITLE
dashboard, systed: Remove unused error-popup dialog from HTML

### DIFF
--- a/pkg/dashboard/index.html
+++ b/pkg/dashboard/index.html
@@ -113,22 +113,6 @@
         {{/machines}}
     </script>
 
-    <div class="modal" id="error-popup" tabindex="-1" role="dialog" data-backdrop="static">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h4 class="modal-title" id="error-popup-title" translate>Unexpected error</h4>
-                </div>
-                <div class="modal-body">
-                    <p id="error-popup-message"></p>
-                </div>
-                <div class="modal-footer">
-                    <button class="btn btn-primary" data-dismiss="modal" translate>Close</button>
-                </div>
-            </div>
-        </div>
-    </div>
-
     <div class="modal" id="dashboard_setup_server_dialog" tabindex="-1" role="dialog"
         data-backdrop="static">
         <div class="modal-dialog">

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -258,22 +258,6 @@
         <div id="memory_status_graph"></div>
     </div>
 
-    <div class="modal" id="error-popup" tabindex="-1" role="dialog" data-backdrop="static">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h4 class="modal-title" id="error-popup-title" translate>Unexpected error</h4>
-                </div>
-                <div class="modal-body">
-                    <p id="error-popup-message"></p>
-                </div>
-                <div class="modal-footer">
-                    <button class="btn btn-primary" data-dismiss="modal" translate>Close</button>
-                </div>
-            </div>
-        </div>
-    </div>
-
     <div class="modal" id="system_information_ssh_keys" tabindex="-1"
         role="dialog" data-backdrop="static">
         <div class="modal-dialog">


### PR DESCRIPTION
This is old design pattern that we should be moving away from.
We shouldn't be showing dialogs just for errors. This code is
still found in various packages.

This commit removes it from places where it's not used.