### PR TITLE
debian: Fix problems building a DSC on Fedora

### DIFF
--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -11,6 +11,9 @@ endif
 %:
 	dh $@ --with=systemd
 
+clean:
+	dh $@
+
 override_dh_auto_configure:
 	dh_auto_configure -- \
 		--with-networkmanager-needs-root=yes \


### PR DESCRIPTION
We use Fedora to stage our building environment and expect to
be able to create a DSC in that environment. Once it comes time
to build the DSC into a DEB file, we use pbuilder.

The catch all %: rule broke building a DSC in Fedora and
the package dh-systemd is not available in Fedora in order
to fix it.