### PR TITLE
kubernetes: Print out better message when loading image fails

### DIFF
--- a/pkg/kubernetes/scripts/images.js
+++ b/pkg/kubernetes/scripts/images.js
@@ -305,7 +305,8 @@
                                 handle_image(image);
                             }
                         }, function(response) {
-                            console.warn("couldn't load image: " + response.statusText);
+                            var message = response.statusText || response.message || String(response);
+                            console.warn("couldn't load image: " + message);
                             interim.metadata.resourceVersion = "invalid";
                         });
                     });


### PR DESCRIPTION
We're seeing messages like this in the tests:

```
> couldn't load image: undefined
> couldn't load image: undefined
> couldn't load image: undefined
```

So lets fix that by printing out a clearer message.