### PR TITLE
tools: Don't install tests in packages during 'make install'

### DIFF
--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -122,10 +122,10 @@ function generateDeps(makefile, stats) {
             install += ".gz";
         }
 
-        // Debug output gets installed separately
+        // Debug output and tests gets installed separately
         if (endsWith(install, ".map"))
             debugs[install] = install;
-        else
+        else if (output.indexOf("/test-") === -1)
             installs[install] = install;
     }
 


### PR DESCRIPTION
The tests should not be installed by 'make install'. We had
checks for matching a certain kind of filename pattern produced
by webpack, but then we changed the kinds of files that the
tests produced. So we need to broaden the pattern.

In the future I would like to have 'make install-check' work
correctly and install tests. However this just fixes the
regressiond and goes back to the status quo.