### PR TITLE
Makefile: Fix distribution of files in tools/ and tests/

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -350,14 +350,17 @@ COMMITTED_DIST = \
 # Build up the distribution using $COMMITTED_DIST and include node_modules and bower licenses
 # also automatically update minimum base dependency in RPM spec file
 dist-hook::
-	( cd $(srcdir); git ls-tree HEAD --name-only -r $(COMMITTED_DIST) || (echo $(COMMITTED_DIST) | tr ' ' '\n' ) ) | \
-		tar -C $(srcdir) -cf - -T - | tar -C $(distdir) -xf -
+	[ ! -d $(distdir)/tools/debian ] || $(srcdir)/tools/build-debian-copyright $(BOWER) > $(distdir)/tools/debian/copyright
+	[ ! -e $(distdir)/tools/cockpit.spec ] || $(srcdir)/tools/gen-spec-dependencies $(distdir)/tools/cockpit.spec
+	( if [ -d $(srcdir)/.git ]; then \
+		git -C $(srcdir) ls-tree HEAD --name-only -r $(COMMITTED_DIST) | tar -C $(srcdir) -cf - -T -; \
+	else \
+		tar -C $(srcdir) -cf - $(COMMITTED_DIST); \
+	fi ) | tar -C $(distdir) -xf -
 	tar -C $(srcdir) -cf - --exclude='phantomjs*' node_modules/ | tar -C $(distdir) -xf -
 	tar -C $(srcdir) -cf - bower_components/ | tar -C $(distdir) -xf -
 	echo $(VERSION) > $(distdir)/.tarball
 	$(srcdir)/tools/build-copying $(BOWER) > $(distdir)/COPYING.bower
-	[ ! -d $(distdir)/tools/debian ] || $(srcdir)/tools/build-debian-copyright $(BOWER) > $(distdir)/tools/debian/copyright
-	[ ! -e $(distdir)/tools/cockpit.spec ] || $(srcdir)/tools/gen-spec-dependencies $(distdir)/tools/cockpit.spec
 
 DIST_TAR_MAIN = tar --format=posix -cf - --exclude='node_modules' "$(distdir)" "$(distdir)/bower.json" "$(distdir)/.bowerrc"
 DIST_TAR_CACHE = tar --format=posix -cf - "$(distdir)/node_modules" "$(distdir)/package.json"


### PR DESCRIPTION
By default these directories have any contents committed to git distributed. However when creating a tarball without a git checkout ... we just distribute all the files in those directories.
    
This logic was broken. Here we fix it.
