### PR TITLE
Makefile: The webpack.config.js describes whan in pkg/ gets distributed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -339,7 +339,6 @@ dump-dist-gzip:
 
 # Subdirectories to distribute everything that's committed to git
 COMMITTED_DIST = \
-	pkg/ \
 	tools/ \
 	test/ \
 	$(NULL)

--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -30,6 +30,7 @@ EXTRA_DIST += \
 	pkg/playground/de.po \
 	pkg/networkmanager/override.json.in \
 	pkg/storaged/override.json.in \
+	pkg/users/mock \
 	pkg/lib/qunit-template.html \
 	$(playground_DATA) \
 	$(pkg_TESTS)


### PR DESCRIPTION
The webpack.config.js describes whan in pkg/ gets distributed.
This happens in tools/webpack-make, and the files are listed in
webpack.config.js