### PR TITLE
Image refresh for debian-testing

### DIFF
--- a/test/images/debian-testing
+++ b/test/images/debian-testing
@@ -1,1 +1,0 @@
-debian-testing-42ff0db7db474c0aa7d616c43f55110c429e20fd.qcow2


### PR DESCRIPTION
Image creation for debian-testing in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-testing-2017-02-08/