### PR TITLE
selinux: Make basic functionality available without setroubleshootd

### DIFF
--- a/pkg/selinux/manifest.json
+++ b/pkg/selinux/manifest.json
@@ -6,7 +6,7 @@
 
     "tools": {
         "setroubleshoot": {
-            "label": "SELinux Troubleshoot",
+            "label": "SELinux",
             "order": 8
         }
     }

--- a/pkg/selinux/selinux-client.es6
+++ b/pkg/selinux/selinux-client.es6
@@ -48,7 +48,7 @@ var status = {
  */
 export function init(statusChangedCallback) {
     var refreshInfo = function() {
-        cockpit.spawn(statusCommand, { err: 'message', environ: [ "LC_ALL=C" ] }).then(
+        cockpit.spawn(statusCommand, { err: 'message', environ: [ "LC_ALL=C" ], superuser: "try" }).then(
             function(output) {
                 /* parse output that looks like this:
                  *   SELinux status:                 enabled

--- a/pkg/selinux/setroubleshoot-client.js
+++ b/pkg/selinux/setroubleshoot-client.js
@@ -74,7 +74,7 @@ client.init = function(capabilitiesChangedCallback) {
     };
 
     // returns a jquery promise
-      client.getAlerts = function(since) {
+    client.getAlerts = function(since) {
         var dfdResult = cockpit.defer();
         var call;
         if (since !== undefined)

--- a/pkg/selinux/setroubleshoot.js
+++ b/pkg/selinux/setroubleshoot.js
@@ -272,9 +272,7 @@ var initStore = function(rootElement) {
                     dataStore.connected = false;
                     window.clearTimeout(dataStore.connecting);
                     dataStore.connecting = null;
-                    dataStore.error = _("Error while connecting.");
                     render();
-                    // TODO: should we propagate the error message here?
                 });
         }
     };

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -52,8 +52,8 @@ mv -f ~/.ssh/authorized_keys.test-avc ~/.ssh/authorized_keys
 """
 
 @skipImage("DBus API of setroubleshoot too old", "centos-7")
-@skipImage("No setroubleshoot", "continuous-atomic", "debian-8", "debian-testing", "fedora-atomic", "rhel-atomic", "ubuntu-1604")
 class TestSelinux(MachineCase):
+    @skipImage("No setroubleshoot", "continuous-atomic", "debian-8", "debian-testing", "fedora-atomic", "rhel-atomic", "ubuntu-1604")
     def testTroubleshootAlerts(self):
         b = self.browser
 
@@ -144,6 +144,7 @@ class TestSelinux(MachineCase):
 
         #b.wait_in_text("body", "No SELinux alerts.")
 
+    @skipImage("No cockpit-selinux", "debian-8", "debian-testing", "continuous-atomic", "fedora-atomic", "ubuntu-1604")
     def testEnforcingToggle(self):
         b = self.browser
         m = self.machine
@@ -153,13 +154,7 @@ class TestSelinux(MachineCase):
         # as happens in our virt-builder and virt-install usage
         m.execute("chmod ugo+r /etc/selinux/config")
 
-        # fix audit events first
-        m.execute(script=FIX_AUDITD)
-
         self.login_and_go("/selinux/setroubleshoot")
-
-        # at the beginning, there should be no entries
-        b.wait_in_text("body", "No SELinux alerts.")
 
         #########################################################
         # wait for the page to be present


### PR DESCRIPTION
Even if setroubleshootd isn't installed, the user can still read the enforce-mode and toggle it.

Currently on rhel-atomic systems, the cockpit package is available but always shows an error.