### PR TITLE
bridge: Move the concept of frozen queued messages into transport

### DIFF
--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -387,8 +387,7 @@ static CockpitChannel *
 pcp_shim (CockpitRouter *router,
           CockpitTransport *transport,
           const gchar *channel_id,
-          JsonObject *options,
-          gboolean frozen)
+          JsonObject *options)
 {
   CockpitChannel *channel = NULL;
   CockpitTransport *shim_transport = NULL;
@@ -414,7 +413,6 @@ pcp_shim (CockpitRouter *router,
                                                  "transport", transport,
                                                  "id", channel_id,
                                                  "options", options,
-                                                 "frozen", frozen,
                                                  "shim-transport", shim_transport,
                                                  NULL));
     }

--- a/src/bridge/cockpitchannel.h
+++ b/src/bridge/cockpitchannel.h
@@ -71,7 +71,7 @@ struct _CockpitChannelClass
 
 GType               cockpit_channel_get_type          (void) G_GNUC_CONST;
 
-void                cockpit_channel_thaw              (CockpitChannel *self);
+void                cockpit_channel_prepare           (CockpitChannel *self);
 
 void                cockpit_channel_close             (CockpitChannel *self,
                                                        const gchar *problem);

--- a/src/bridge/cockpitrouter.h
+++ b/src/bridge/cockpitrouter.h
@@ -42,8 +42,7 @@ GType           cockpit_router_get_type     (void) G_GNUC_CONST;
 typedef         CockpitChannel *   (* CockpitRouterChannelFunc)    (CockpitRouter *router,
                                                                     CockpitTransport *transport,
                                                                     const gchar *channel_id,
-                                                                    JsonObject *options,
-                                                                    gboolean frozen);
+                                                                    JsonObject *options);
 
 void                cockpit_router_add_channel_function            (CockpitRouter *self,
                                                                     CockpitRouterChannelFunc channel_func);

--- a/src/bridge/test-fs.c
+++ b/src/bridge/test-fs.c
@@ -95,7 +95,7 @@ setup_fsread_channel (TestCase *tc,
   tc->channel = cockpit_fsread_open (COCKPIT_TRANSPORT (tc->transport), "1234", path);
   tc->channel_closed = FALSE;
   g_signal_connect (tc->channel, "closed", G_CALLBACK (on_channel_close), tc);
-  cockpit_channel_thaw (tc->channel);
+  cockpit_channel_prepare (tc->channel);
 }
 
 static void
@@ -106,7 +106,7 @@ setup_fsreplace_channel (TestCase *tc,
   tc->channel = cockpit_fsreplace_open (COCKPIT_TRANSPORT (tc->transport), "1234", path, tag);
   tc->channel_closed = FALSE;
   g_signal_connect (tc->channel, "closed", G_CALLBACK (on_channel_close), tc);
-  cockpit_channel_thaw (tc->channel);
+  cockpit_channel_prepare (tc->channel);
 }
 
 static void
@@ -116,7 +116,7 @@ setup_fswatch_channel (TestCase *tc,
   tc->channel = cockpit_fswatch_open (COCKPIT_TRANSPORT (tc->transport), "1234", path);
   tc->channel_closed = FALSE;
   g_signal_connect (tc->channel, "closed", G_CALLBACK (on_channel_close), tc);
-  cockpit_channel_thaw (tc->channel);
+  cockpit_channel_prepare (tc->channel);
 }
 
 static void

--- a/src/bridge/test-pcp-archives.c
+++ b/src/bridge/test-pcp-archives.c
@@ -136,7 +136,7 @@ setup_metrics_channel_json (TestCase *tc, JsonObject *options)
                               NULL);
   tc->channel_closed = FALSE;
   g_signal_connect (tc->channel, "closed", G_CALLBACK (on_channel_close), tc);
-  cockpit_channel_thaw (tc->channel);
+  cockpit_channel_prepare (tc->channel);
 
   /* Switch off compression by default.  Compression is done by
    * comparing two floating point values for exact equality, and we

--- a/src/bridge/test-pcp.c
+++ b/src/bridge/test-pcp.c
@@ -123,7 +123,7 @@ setup_metrics_channel_json (TestCase *tc, JsonObject *options)
                               NULL);
   tc->channel_closed = FALSE;
   g_signal_connect (tc->channel, "closed", G_CALLBACK (on_channel_close), tc);
-  cockpit_channel_thaw (tc->channel);
+  cockpit_channel_prepare (tc->channel);
 
   /* We work with real timestamps here but we don't want the
      interpolation to change any of our sample values.

--- a/src/bridge/test-router.c
+++ b/src/bridge/test-router.c
@@ -63,8 +63,7 @@ static CockpitChannel *
 mock_shim (CockpitRouter *router,
            CockpitTransport *transport,
            const gchar *channel_id,
-           JsonObject *options,
-           gboolean frozen)
+           JsonObject *options)
 {
   CockpitChannel *channel = NULL;
   CockpitTransport *shim_transport = NULL;
@@ -86,7 +85,6 @@ mock_shim (CockpitRouter *router,
                                            "transport", transport,
                                            "id", channel_id,
                                            "options", options,
-                                           "frozen", frozen,
                                            "shim-transport", shim_transport,
                                            NULL));
   g_free (payload_arg);

--- a/src/common/cockpittransport.h
+++ b/src/common/cockpittransport.h
@@ -33,10 +33,11 @@ G_BEGIN_DECLS
 
 typedef struct _CockpitTransport        CockpitTransport;
 typedef struct _CockpitTransportClass   CockpitTransportClass;
+typedef struct _CockpitTransportPrivate CockpitTransportPrivate;
 
-struct _CockpitTransport
-{
+struct _CockpitTransport {
   GObject parent;
+  CockpitTransportPrivate *priv;
 };
 
 struct _CockpitTransportClass
@@ -87,8 +88,20 @@ void        cockpit_transport_emit_recv      (CockpitTransport *transport,
                                               const gchar *channel,
                                               GBytes *data);
 
+void        cockpit_transport_emit_control   (CockpitTransport *transport,
+                                              const gchar *command,
+                                              const gchar *channel,
+                                              JsonObject *options,
+                                              GBytes *data);
+
 void        cockpit_transport_emit_closed    (CockpitTransport *transport,
                                               const gchar *problem);
+
+void        cockpit_transport_freeze         (CockpitTransport *transport,
+                                              const gchar *channel);
+
+void        cockpit_transport_thaw           (CockpitTransport *transport,
+                                              const gchar *channel);
 
 GBytes *    cockpit_transport_parse_frame    (GBytes *message,
                                               gchar **channel);


### PR DESCRIPTION
This needs to be channel independent, and happen at the transport
level. There are two reasons for this:

 * We often don't know what kind of shim/channel will need to
   handle the messages until after the freeze is lifted.
 * This allows us to implement 'shims' in the CockpitRouter
   directly and have configurable behavior for which shims
   match to which channels.

This is part of the work on #5683 but I'm making it a separate pull request for easier testing, and review. The code changes in #5683 are significant and I want to bisect early.