### PR TITLE
machines: Move from direct machines.json manipulation to D-Bus calls, move to /etc/cockpit/machines/*.json

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -265,6 +265,7 @@ VALGRIND_SUPPRESSIONS = \
 	tools/unknown.supp \
 	tools/zlib.supp \
 	tools/libssh.supp \
+	tools/json-glib.supp \
 	$(NULL)
 
 valgrind-suppressions: $(VALGRIND_SUPPRESSIONS)

--- a/containers/ws/atomic-install
+++ b/containers/ws/atomic-install
@@ -34,9 +34,9 @@ set -x
 sed -e '/pam_selinux/d' -e '/pam_sepermit/d' /etc/pam.d/cockpit > /host/etc/pam.d/cockpit
 
 # Make sure that we have required directories in the host
-mkdir -p /host/etc/cockpit/ws-certs.d
-chmod 755 /host/etc/cockpit/ws-certs.d
-chown root:root /host/etc/cockpit/ws-certs.d
+mkdir -p /host/etc/cockpit/ws-certs.d /host/etc/cockpit/machines.d
+chmod 755 /host/etc/cockpit/ws-certs.d /host/etc/cockpit/machines.d
+chown root:root /host/etc/cockpit/ws-certs.d /host/etc/cockpit/machines.d
 
 mkdir -p /host/var/lib/cockpit
 chmod 775 /host/var/lib/cockpit

--- a/doc/guide/feature-machines.xml
+++ b/doc/guide/feature-machines.xml
@@ -17,7 +17,13 @@
 
   <para>There is currently no command line interface for adding and/or removing
     machines from the dashboard. The machine data is stored in
-    <filename>/var/lib/cockpit/machines.json</filename> and SSH host keys are
-    stored in <filename>/var/lib/cockpit/known_hosts</filename>.</para>
+    <filename>/etc/cockpit/machines.d/*.json</filename>. Settings in
+    lexicographically later files amend or override settings in earlier ones.
+    Cockpit itself writes into <filename>99-webui.json</filename>;
+    packages or admins who want to pre-configure machines should ship files
+    like <filename>05-mymachine.json</filename> so that changes from the web
+    interface override the pre-configured files.</para>
 
+  <para>SSH host keys are stored in
+     <filename>/var/lib/cockpit/known_hosts</filename>.</para>
 </chapter>

--- a/pkg/lib/machines.js
+++ b/pkg/lib/machines.js
@@ -180,7 +180,7 @@
 
             // FIXME: investigate re-using the proxy from Loader (runs in different frame/scope)
             var bridge = cockpit.dbus(null, { bus: "internal", "superuser": "try" });
-            var mod = bridge.call("/machines", "cockpit.Machines", "Update", [ host, values_variant ])
+            var mod = bridge.call("/machines", "cockpit.Machines", "Update", [ "99-webui.json", host, values_variant ])
                 .done(function() {
                     var prop, over = { };
                     for (prop in values)

--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -121,6 +121,7 @@ base_QUNIT_TESTS = \
 	dist/base1/test-file.html \
 	dist/base1/test-metrics.html \
 	dist/base1/test-user.html \
+	dist/base1/test-machines.html \
 	dist/base1/test-permissions.html \
 	dist/base1/test-series.html \
 	dist/base1/test-cache.html \

--- a/src/base1/test-machines.js
+++ b/src/base1/test-machines.js
@@ -1,0 +1,133 @@
+/* global cockpit, QUnit */
+
+/* To help with future migration */
+var assert = QUnit;
+
+var dbus = cockpit.dbus(null, { "bus": "internal" });
+var dataDir;
+
+/***
+ * Tests for parsing on-disk JSON configuration
+ */
+
+function machinesParseTest(json, expectedProperty) {
+    assert.expect(3);
+
+    cockpit.file(dataDir + "/machines.json").replace(json).
+        done(function(tag) {
+            dbus.call("/machines", "org.freedesktop.DBus.Properties",
+                      "Get", [ "cockpit.Machines", "Machines" ],
+                      { "type": "ss" })
+                .done(function(reply) {
+                    assert.equal(reply[0].t, "a{sa{sv}}", "expected return type");
+                    assert.deepEqual(reply[0].v, expectedProperty, "expected property value");
+                })
+                .always(function() {
+                    assert.equal(this.state(), "resolved", "finished successfully");
+                    QUnit.start();
+                });
+        });
+}
+
+QUnit.asyncTest("no machine definitions", function() {
+    machinesParseTest(null, {});
+});
+
+QUnit.asyncTest("empty json", function() {
+    machinesParseTest("", {});
+});
+
+QUnit.asyncTest("two definitions", function() {
+    machinesParseTest('{"green": {"visible": true, "address": "1.2.3.4"}, ' +
+                      ' "9.8.7.6": {"visible": false, "address": "9.8.7.6", "user": "admin"}}',
+        { "green": {
+            "address": { "t": "s", "v": "1.2.3.4" },
+            "visible": { "t": "b", "v": true }
+           },
+           "9.8.7.6": {
+               "address": { "t": "s", "v": "9.8.7.6" },
+               "user": { "t": "s", "v": "admin" },
+               "visible": { "t": "b", "v": false }
+           }
+        });
+});
+
+QUnit.asyncTest("invalid json", function() {
+    machinesParseTest('{"green":', {});
+});
+
+QUnit.asyncTest("invalid data types", function() {
+    machinesParseTest('{"green": []}', {});
+});
+
+/***
+ * Tests for Update()
+ */
+
+function machinesUpdateTest(origJson, host, props, expectedJson)
+{
+    assert.expect(3);
+
+    cockpit.file(dataDir + "/machines.json").replace(origJson).
+        done(function(tag) {
+            dbus.call("/machines", "cockpit.Machines", "Update", [ host, props ], { "type": "sa{sv}" })
+                .done(function(reply) {
+                    assert.deepEqual(reply, [], "no expected return value");
+                    cockpit.file(dataDir + "/machines.json", { syntax: JSON }).read().
+                        done(function(content, tag) {
+                            assert.deepEqual(content, expectedJson, "expected file content");
+                        }).
+                        fail(function(err) {
+                            assert.equal(err, undefined, "expected no error");
+                        }).
+                        always(QUnit.start);
+                })
+                .always(function() {
+                    assert.equal(this.state(), "resolved", "finished successfully");
+                });
+        });
+}
+
+QUnit.asyncTest("no config files", function() {
+    machinesUpdateTest(null, "green", { "visible": cockpit.variant('b', true), "address": cockpit.variant('s', "1.2.3.4") },
+        { "green": { "address": "1.2.3.4", "visible": true } });
+});
+
+QUnit.asyncTest("add host to existing map", function() {
+    machinesUpdateTest('{"green": {"visible": true, "address": "1.2.3.4"}}',
+        "blue",
+        { "visible": cockpit.variant('b', false), "address": cockpit.variant('s', "9.8.7.6") },
+        { "green": { "address": "1.2.3.4", "visible": true },
+            "blue":  { "address": "9.8.7.6", "visible": false} });
+});
+
+QUnit.asyncTest("change bool host property", function() {
+    machinesUpdateTest('{"green": {"visible": true, "address": "1.2.3.4"}}',
+        "green",
+        { "visible": cockpit.variant('b', false)},
+        { "green": { "address": "1.2.3.4", "visible": false } });
+});
+
+QUnit.asyncTest("change string host property", function() {
+    machinesUpdateTest('{"green": {"visible": true, "address": "1.2.3.4"}}',
+        "green",
+        { "address": cockpit.variant('s', "fe80::1")},
+        { "green": { "address": "fe80::1", "visible": true } });
+});
+
+QUnit.asyncTest("add host property", function() {
+    machinesUpdateTest('{"green": {"visible": true, "address": "1.2.3.4"}}',
+        "green",
+        { "color": cockpit.variant('s', "pitchblack")},
+        { "green": { "address": "1.2.3.4", "visible": true, "color": "pitchblack" } });
+});
+
+
+/* The test cockpit-bridge gets started with a temp COCKPIT_DATA_DIR  instead
+ * of defaulting to /var/lib/cockpit/. Read it from the bridge so that we can
+ * put our test files into it. */
+var proxy = dbus.proxy("cockpit.Environment", "/environment");
+proxy.wait(function () {
+    dataDir = proxy.Variables["COCKPIT_DATA_DIR"];
+    QUnit.start();
+});

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -59,6 +59,7 @@ libcockpit_bridge_a_SOURCES = \
 	src/bridge/cockpitcpusamples.h \
 	src/bridge/cockpitdbussetup.c \
 	src/bridge/cockpitdbususer.c \
+	src/bridge/cockpitdbusmachines.c \
 	src/bridge/cockpitdisksamples.c \
 	src/bridge/cockpitdisksamples.h \
 	src/bridge/cockpitinternalmetrics.c \

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -530,6 +530,7 @@ run_bridge (const gchar *interactive,
   cockpit_dbus_user_startup (pwd);
   cockpit_dbus_setup_startup ();
   cockpit_dbus_process_startup ();
+  cockpit_dbus_machines_startup ();
 
   g_free (pwd);
   pwd = NULL;
@@ -548,6 +549,7 @@ run_bridge (const gchar *interactive,
   g_object_unref (router);
   g_object_unref (transport);
 
+  cockpit_dbus_machines_cleanup ();
   cockpit_dbus_internal_cleanup ();
   cockpit_packages_free (packages);
   packages = NULL;

--- a/src/bridge/cockpitdbusinternal.h
+++ b/src/bridge/cockpitdbusinternal.h
@@ -41,6 +41,10 @@ void                  cockpit_dbus_setup_startup         (void);
 
 void                  cockpit_dbus_process_startup       (void);
 
+void                  cockpit_dbus_machines_startup      (void);
+
+void                  cockpit_dbus_machines_cleanup      (void);
+
 G_END_DECLS
 
 #endif /* __COCKPIT_DBUS_INTERNAL_H */

--- a/src/bridge/cockpitdbusmachines.c
+++ b/src/bridge/cockpitdbusmachines.c
@@ -1,0 +1,349 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include <json-glib/json-glib.h>
+
+#include "cockpitdbusinternal.h"
+#include "common/cockpitsystem.h"
+
+#define MACHINES_SIG "a{sa{sv}}"
+
+/* counts the number of file change events that have not yet gotten a PropertiesChanged signal */
+static guint pending_updates;
+
+GFileMonitor *machines_monitor;
+
+static const char *
+machines_json_path (void)
+{
+  static gchar *path = NULL;
+  if (path == NULL)
+    path = g_strdup_printf ("%s/machines.json", g_getenv ("COCKPIT_DATA_DIR") ?: "/var/lib/cockpit");
+  return path;
+}
+
+static JsonNode*
+read_machines_json (void)
+{
+  gchar *contents;
+  gboolean res;
+  GError *error = NULL;
+  JsonParser *parser = NULL;
+  JsonNode *result = NULL;
+
+  if (!g_file_get_contents (machines_json_path (), &contents, NULL, &error))
+    {
+      if (error->code == G_FILE_ERROR_NOENT)
+        g_debug ("%s does not exist", machines_json_path ());
+      else
+        g_message ("couldn't read %s: %s", machines_json_path (), error->message);
+      g_error_free (error);
+      goto out;
+    }
+
+  parser = json_parser_new ();
+  res = json_parser_load_from_data (parser, contents, -1, &error);
+  g_free (contents);
+  if (!res)
+    {
+      g_message("%s has invalid JSON: %s", machines_json_path (), error->message);
+      g_error_free (error);
+      goto out;
+    }
+
+  result = json_parser_get_root (parser);
+  if (result != NULL)
+    result = json_node_copy (result);
+
+out:
+  if (parser)
+    g_object_unref (parser);
+
+  /* default to an empty object */
+  if (result == NULL)
+    {
+      result = json_node_new (JSON_NODE_OBJECT);
+      json_node_take_object (result, json_object_new ());
+    }
+
+  return result;
+}
+
+/* returns a floating GVariant */
+static GVariant *
+get_machines (void)
+{
+  JsonNode *machines;
+  GError *error = NULL;
+  GVariant *variant;
+
+  machines = read_machines_json ();
+  variant = json_gvariant_deserialize (machines, MACHINES_SIG, &error);
+  json_node_free (machines);
+  if (!variant)
+    {
+      g_message ("%s is misformatted: %s", machines_json_path (), error->message);
+      g_error_free (error);
+      variant = g_variant_new (MACHINES_SIG, NULL);
+    }
+  return variant;
+}
+
+/* iterator function for update_machine() */
+static void
+update_machine_property (JsonObject *object,
+                         const gchar *member_name,
+                         JsonNode *member_node,
+                         gpointer user_data)
+{
+  json_object_set_member ((JsonObject *) user_data, member_name, json_node_copy (member_node));
+}
+
+static gboolean
+update_machine (const char *hostname,
+                JsonNode *info,
+                GError **error)
+{
+  JsonNode *machines;
+  JsonGenerator *json_gen;
+  JsonObject *machines_obj;
+  JsonNode *cur_props;
+  gboolean res;
+
+  machines = read_machines_json ();
+  g_assert (JSON_NODE_HOLDS_OBJECT (info));
+  machines_obj = json_node_get_object (machines);
+  cur_props = json_object_get_member (machines_obj, hostname);
+
+  if (cur_props)
+    {
+      /* update settings for hostname */
+      JsonObject *cur_props_obj = json_node_get_object (cur_props);
+      g_assert (JSON_NODE_HOLDS_OBJECT (cur_props));
+      json_object_foreach_member (json_node_get_object (info), update_machine_property, cur_props_obj);
+    }
+  else
+    {
+      /* create new entry for host name */
+      json_object_set_member (machines_obj, hostname, json_node_copy (info));
+    }
+
+  /* update machines.json file */
+  json_gen = json_generator_new ();
+  json_generator_set_root (json_gen, machines);
+  json_generator_set_pretty (json_gen, TRUE); /* bikeshed zone */
+  res = json_generator_to_file (json_gen, machines_json_path (), error);
+  g_object_unref (json_gen);
+  json_node_free (machines);
+  return res;
+}
+
+static GVariant *
+machines_get_property (GDBusConnection *connection,
+                       const gchar *sender,
+                       const gchar *object_path,
+                       const gchar *interface_name,
+                       const gchar *property_name,
+                       GError **error,
+                       gpointer user_data)
+{
+  g_return_val_if_fail (property_name != NULL, NULL);
+
+  if (g_str_equal (property_name, "Machines"))
+    return get_machines ();
+  else
+    g_return_val_if_reached (NULL);
+}
+
+static void
+machines_method_call (GDBusConnection *connection,
+                      const gchar *sender,
+                      const gchar *object_path,
+                      const gchar *interface_name,
+                      const gchar *method_name,
+                      GVariant *parameters,
+                      GDBusMethodInvocation *invocation,
+                      gpointer user_data)
+{
+  if (g_str_equal (method_name, "Update"))
+    {
+      const gchar *hostname;
+      GVariant * info_v;
+      JsonNode *info_json = NULL;
+      GError *error = NULL;
+
+      g_variant_get (parameters, "(&s@a{sv})", &hostname, &info_v);
+      info_json = json_gvariant_serialize (info_v);
+      /* g_debug ("Updating info for machine %s: %s", hostname, g_variant_print (info_v, TRUE)); */
+      g_variant_unref (info_v);
+
+      if (update_machine (hostname, info_json, &error))
+        g_dbus_method_invocation_return_value (invocation, NULL);
+      else
+        g_dbus_method_invocation_take_error (invocation, error);
+      json_node_free (info_json);
+    }
+  else
+    g_return_if_reached ();
+}
+
+/**
+ * notify_properties:
+ * @user_data: GDBusConnection to which updates get sent
+ *
+ * Send a PropertiesChanged signal for invalidating the Machines property. This
+ * avoids parsing files and constructing the property when nobody is listening.
+ * This gets called in reaction to changed *.json configuration files.
+ */
+static gboolean
+notify_properties (gpointer user_data)
+{
+  GDBusConnection *connection = user_data;
+  GVariant *signal_value;
+  GVariantBuilder builder;
+  GError *error = NULL;
+
+  /* reset pending counter before we do any actual work, to avoid races */
+  pending_updates = 0;
+  g_variant_builder_init (&builder, G_VARIANT_TYPE ("as"));
+  g_variant_builder_add (&builder, "s", "Machines");
+  signal_value = g_variant_ref_sink (g_variant_new ("(sa{sv}as)", "cockpit.Machines", NULL, &builder));
+
+  g_dbus_connection_emit_signal (connection,
+                                 NULL,
+                                 "/machines",
+                                 "org.freedesktop.DBus.Properties",
+                                 "PropertiesChanged",
+                                 signal_value,
+                                 &error);
+  if (error != NULL)
+    {
+      if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CLOSED))
+        g_critical ("failed to send PropertiesChanged signal: %s", error->message);
+      g_error_free (error);
+    }
+  g_variant_unref (signal_value);
+  return G_SOURCE_REMOVE;
+}
+
+
+static void
+on_machines_changed (GFileMonitor *monitor,
+                     GFile *file,
+                     GFile *other_file,
+                     GFileMonitorEvent event_type,
+                     gpointer user_data)
+{
+  /* ignore uninteresting events; FIXME: adjust once we move to a directory;
+   * https://developer.gnome.org/gio/stable/GFileMonitor.html#GFileMonitorEvent */
+  /* g_debug ("on_machines_changed: event type %i on %s", event_type, g_file_get_path (file)); */
+  if (event_type != G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT)
+    return;
+
+  /* change events tend to come in batches, so slightly delay the re-reading of
+   * files and sending PropertiesChanged; if we already have queued up an
+   * update, don't queue it again */
+  if (pending_updates++ == 0)
+    g_timeout_add (100, notify_properties, user_data);
+}
+
+
+static GDBusInterfaceVTable machines_vtable = {
+  .method_call = machines_method_call,
+  .get_property = machines_get_property,
+};
+
+static GDBusPropertyInfo machines_property = {
+  -1, "Machines", MACHINES_SIG, G_DBUS_PROPERTY_INFO_FLAGS_READABLE, NULL
+};
+
+static GDBusPropertyInfo *machines_properties[] = {
+  &machines_property,
+  NULL
+};
+
+static GDBusArgInfo machines_update_hostname_arg = {
+  -1, "hostname", "s", NULL
+};
+
+static GDBusArgInfo machines_update_info_arg = {
+  -1, "info", "a{sv}", NULL
+};
+
+static GDBusArgInfo *machines_update_args[] = {
+  &machines_update_hostname_arg,
+  &machines_update_info_arg,
+  NULL
+};
+
+static GDBusMethodInfo machines_update_method = {
+  -1, "Update", machines_update_args, NULL, NULL
+};
+
+static GDBusMethodInfo *machines_methods[] = {
+  &machines_update_method,
+  NULL
+};
+
+static GDBusInterfaceInfo machines_interface = {
+  -1, "cockpit.Machines", machines_methods, NULL, machines_properties, NULL
+};
+
+void
+cockpit_dbus_machines_startup (void)
+{
+  GDBusConnection *connection;
+  GFile *machines_monitor_file;
+  GError *error = NULL;
+
+  connection = cockpit_dbus_internal_server ();
+  g_return_if_fail (connection != NULL);
+
+  g_dbus_connection_register_object (connection, "/machines", &machines_interface,
+                                     &machines_vtable, NULL, NULL, &error);
+
+  if (error != NULL)
+    {
+      g_critical ("couldn't register DBus cockpit.Machines object: %s", error->message);
+      g_error_free (error);
+      return;
+    }
+
+  /* watch for file changes and send D-Bus signal for it */
+  machines_monitor_file = g_file_new_for_path (machines_json_path ());
+  machines_monitor = g_file_monitor (machines_monitor_file, G_FILE_MONITOR_NONE, NULL, &error);
+  g_object_unref (machines_monitor_file);
+  if (machines_monitor == NULL)
+    {
+      g_critical ("couldn't set up file watch: %s", error->message);
+      g_error_free (error);
+      return;
+    }
+  g_signal_connect (machines_monitor, "changed", G_CALLBACK (on_machines_changed), connection);
+
+  g_object_unref (connection);
+}
+
+void
+cockpit_dbus_machines_cleanup (void)
+{
+  g_object_unref (machines_monitor);
+}

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -384,8 +384,8 @@ install-tests::
 	$(INSTALL_DATA) $(srcdir)/src/ws/fatal.conf $(DESTDIR)$(testserviceddir)
 
 install-exec-hook::
-	mkdir -p $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d
-	chmod 755 $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d
+	mkdir -p $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/machines.d
+	chmod 755 $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/machines.d
 
 update-known-hosts:
 	cat $(srcdir)/src/ws/mock_*.pub | \

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -765,6 +765,8 @@ main (int argc,
   int i;
   gchar *guid = NULL;
   GDBusServer *direct_dbus_server = NULL;
+  gchar *data_dir;
+  gchar *rm_rf_argv[] = {"rm", "-rf", NULL, NULL};
 
   GOptionEntry entries[] = {
     { NULL }
@@ -774,8 +776,13 @@ main (int argc,
   /* avoid gvfs (http://bugzilla.gnome.org/show_bug.cgi?id=526454) */
   g_setenv ("GIO_USE_VFS", "local", TRUE);
 
+  /* playground data directory */
+  data_dir = g_dir_make_tmp ("cockpit.data.XXXXXX", NULL);
+  g_assert (data_dir);
+
   g_setenv ("XDG_DATA_HOME", SRCDIR "/src/bridge/mock-resource/home", TRUE);
   g_setenv ("XDG_DATA_DIRS", SRCDIR "/src/bridge/mock-resource/system", TRUE);
+  g_setenv ("COCKPIT_DATA_DIR", data_dir, TRUE);
 
   setup_path (argv[0]);
 
@@ -874,6 +881,11 @@ main (int argc,
   g_object_unref (bus);
   g_free (bridge_argv);
   g_free (guid);
+
+  /* clean up temporary data dir */
+  rm_rf_argv[2] = data_dir;
+  g_spawn_sync (NULL, rm_rf_argv, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL);
+  g_free (data_dir);
 
   return exit_code;
 }

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -765,8 +765,8 @@ main (int argc,
   int i;
   gchar *guid = NULL;
   GDBusServer *direct_dbus_server = NULL;
-  gchar *data_dir;
-  gchar *rm_rf_argv[] = {"rm", "-rf", NULL, NULL};
+  gchar *config_dir, *machines_dir;
+  gchar *rm_rf_argv[] = {"rm", "-rfv", NULL, NULL};
 
   GOptionEntry entries[] = {
     { NULL }
@@ -776,13 +776,16 @@ main (int argc,
   /* avoid gvfs (http://bugzilla.gnome.org/show_bug.cgi?id=526454) */
   g_setenv ("GIO_USE_VFS", "local", TRUE);
 
-  /* playground data directory */
-  data_dir = g_dir_make_tmp ("cockpit.data.XXXXXX", NULL);
-  g_assert (data_dir);
+  /* playground config directory */
+  config_dir = g_dir_make_tmp ("cockpit.config.XXXXXX", NULL);
+  g_assert (config_dir);
+  machines_dir = g_build_filename (config_dir, "machines.d", NULL);
+  g_assert (g_mkdir (machines_dir, 0755) == 0);
+  g_free (machines_dir);
 
   g_setenv ("XDG_DATA_HOME", SRCDIR "/src/bridge/mock-resource/home", TRUE);
   g_setenv ("XDG_DATA_DIRS", SRCDIR "/src/bridge/mock-resource/system", TRUE);
-  g_setenv ("COCKPIT_DATA_DIR", data_dir, TRUE);
+  g_setenv ("COCKPIT_TEST_CONFIG_DIR", config_dir, TRUE);
 
   setup_path (argv[0]);
 
@@ -882,10 +885,10 @@ main (int argc,
   g_free (bridge_argv);
   g_free (guid);
 
-  /* clean up temporary data dir */
-  rm_rf_argv[2] = data_dir;
+  /* clean up temporary config dir */
+  rm_rf_argv[2] = config_dir;
   g_spawn_sync (NULL, rm_rf_argv, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL);
-  g_free (data_dir);
+  g_free (config_dir);
 
   return exit_code;
 }

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -278,6 +278,18 @@ class TestDashboardSetup(MachineCase, DashBoardHelpers):
         m2.execute("ps aux | grep cockpit-bridge | grep admin")
         self.allow_hostkey_messages()
 
+    def testMachinesJsonVar(self):
+        b = self.browser
+        m = self.machine
+
+        # create obsolete machines.json in /var, which should still be respected
+        blue_conf = '{"blue": {"address": "1.2.3.4", "visible": true}}'
+        m.execute("""echo '%s' > /var/lib/cockpit/machines.json""" % blue_conf)
+        self.login_and_go("/dashboard")
+        self.inject_extras(b)
+        self.wait_dashboard_addresses (b, [ "localhost", "1.2.3.4" ])
+
+
 @skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestDashboardEditLimits(MachineCase, DashBoardHelpers):
     def testEdit(self):
@@ -325,7 +337,7 @@ class TestDashboardEditLimits(MachineCase, DashBoardHelpers):
                 n = "bad{0}".format(i)
                 d[n] = {"visible":True,"address":n}
 
-            m.execute("echo '{0}' > /var/lib/cockpit/machines.json".format(json.dumps(d)))
+            m.execute("echo '{0}' > /etc/cockpit/machines.d/99-webui.json".format(json.dumps(d)))
             return d.keys()
 
         def check_limit(limit):

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -737,7 +737,7 @@ class OpenshiftCommonTests(VolumeTests):
 
         # Nothing was saved
         self.assertFalse(m.execute("grep 10.111.112.101 /var/lib/cockpit/known_hosts || true"))
-        self.assertFalse(m.execute("grep 10.111.112.101 /var/lib/cockpit/machines.json || true"))
+        self.assertFalse(m.execute("grep 10.111.112.101 /etc/cockpit/machines.d/99-webui.json || true"))
 
         self.allow_hostkey_messages()
         self.allow_journal_messages('.* host key for server is not known: .*',

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -162,6 +162,7 @@ echo '{ "linguas": null, "machine-limit": 5 }' > %{buildroot}%{_datadir}/%{name}
 # Build the package lists for resource packages
 echo '%dir %{_datadir}/%{name}/base1' > base.list
 find %{buildroot}%{_datadir}/%{name}/base1 -type f >> base.list
+echo '%{_sysconfdir}/cockpit/machines.d' >> base.list
 
 %if %{defined build_dashboard}
 echo '%dir %{_datadir}/%{name}/dashboard' >> dashboard.list
@@ -459,7 +460,7 @@ The Cockpit Web Service listens on the network, and authenticates users.
 %doc %{_mandir}/man8/cockpit-ws.8.gz
 %doc %{_mandir}/man8/remotectl.8.gz
 %doc %{_mandir}/man8/pam_ssh_add.8.gz
-%config(noreplace) %{_sysconfdir}/%{name}
+%config(noreplace) %{_sysconfdir}/%{name}/ws-certs.d
 %config(noreplace) %{_sysconfdir}/pam.d/cockpit
 %{_unitdir}/cockpit.service
 %{_unitdir}/cockpit.socket

--- a/tools/debian/cockpit-bridge.install
+++ b/tools/debian/cockpit-bridge.install
@@ -1,3 +1,4 @@
+etc/cockpit/machines.d
 usr/bin/cockpit-bridge
 lib/*/security/pam_reauthorize.so
 usr/lib/cockpit/cockpit-polkit

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -1,4 +1,4 @@
-etc/cockpit/
+etc/cockpit/ws-certs.d
 etc/pam.d/cockpit
 lib/systemd/system/cockpit.service
 lib/systemd/system/cockpit.socket

--- a/tools/json-glib.supp
+++ b/tools/json-glib.supp
@@ -1,0 +1,13 @@
+# https://bugzilla.gnome.org/show_bug.cgi?id=778674
+{
+   json_gvariant_deserialize_leak_on_signature_mismatch
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:g_malloc
+   fun:g_slice_alloc
+   fun:g_variant_new_from_bytes
+   ...
+   fun:json_gvariant_deserialize
+   fun:get_machines
+}


### PR DESCRIPTION
The first two commits implement the first item in the [Finalize machines.json format](https://trello.com/c/WSEOANNY/268-finalize-machines-json-format) trello card. I. e. it keeps `/var/lib/machines.json` for now, but moves the parsing/updating of that from the web frontend (cockpit.file) to a D-Bus interface.

The third commit moves the single `/var/lib/machines.json` to `/etc/cockpit/machines/*.json`. I kept that separately as it was historically developed that way, but it also makes it easier to separately review the move to D-Bus and the move to multiple files.

- [x] glib 2.44 is not available on all targets yet, rewrite `g_auto*` stuff to use manual cleanup
- [x] fix integration test regressions
- [x] drop XXX debug messages
- [x] fix memleaks (aside from [leak in json-glib](https://bugzilla.gnome.org/show_bug.cgi?id=778674), added suppression )
- [x] add unit tests for new D-Bus interface
- [x] move to `/etc/cockpit/machines/*.json`
- [x] fix Update() call to only write the delta
- [x] change Update() call to take the destination file name instead of hardcoding it
- [x] tests for multiple machines/*.json files
- [x] update documentation
- [x] try to factorize `merge_config()`, the outer and inner loop are structurally similar
- [x] aggregate bursts of inotify events into one parse/property update callback