### PR TITLE
less: Import bootstrap variables first and override with patternfly

### DIFF
--- a/pkg/lib/variables.less
+++ b/pkg/lib/variables.less
@@ -1,5 +1,5 @@
-@import (less) "../../bower_components/patternfly/less/variables.less";
 @import (less) "../../bower_components/bootstrap/less/variables.less";
+@import (less) "../../bower_components/patternfly/less/variables.less";
 
 @metadata-color: #888;
 


### PR DESCRIPTION
Patternfly is built on top of bootstrap, so we probably want to override
some variables from there, not the other way around.

The change here makes the listing title caption work again (back to 22px as expected). We should look at the rest of Cockpit though to make sure no breakage creeps in.
![screenshot from 2017-02-13 13-39-48](https://cloud.githubusercontent.com/assets/8711649/22883765/08717062-f1f2-11e6-923e-6336281caf72.png)
