### PR TITLE
kdump: Enable testing on continuous-atomic

### DIFF
--- a/bots/images/scripts/fedora-atomic.install
+++ b/bots/images/scripts/fedora-atomic.install
@@ -3,4 +3,4 @@
 
 set -e
 
-/var/lib/testvm/atomic.install "$@"
+/var/lib/testvm/atomic.install --skip cockpit-kdump "$@"

--- a/bots/images/scripts/lib/atomic.install
+++ b/bots/images/scripts/lib/atomic.install
@@ -44,6 +44,7 @@ class AtomicCockpitInstaller:
     # Temporarily force cockpit-system instead of cockpit-shell
     packages_force_install = [ "cockpit-system",
                                "cockpit-docker",
+                               "cockpit-kdump",
                                "cockpit-networkmanager",
                                "cockpit-ostree",
                                "cockpit-sosreport" ]

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -21,7 +21,7 @@
 import parent
 from testlib import *
 
-@skipImage("kexec-tools not installed", "continuous-atomic", "fedora-24", "fedora-atomic", "centos-7", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
+@skipImage("kexec-tools not installed", "fedora-24", "fedora-atomic", "centos-7", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
 class TestKdump(MachineCase):
     def rreplace(self, s, old, new, count):
         li = s.rsplit(old, count)


### PR DESCRIPTION
Let's see what happens there.

 - [x] fix `wait_reboot()` race condition (#7402)