### PR TITLE
users: Fix tooltips

### DIFF
--- a/pkg/users/index.html
+++ b/pkg/users/index.html
@@ -49,7 +49,7 @@
   </div>
 
   <div id="accounts" class="container-fluid" hidden>
-    <button class="btn btn-default accounts-privileged" id="accounts-create" translatable="yes" data-container="body">Create New Account</button>
+    <button class="btn btn-default accounts-privileged" id="accounts-create" translatable="yes" data-container="body" data-placement="right">Create New Account</button>
     <div id="accounts-list">
     </div>
   </div>
@@ -74,7 +74,7 @@
       <div class="panel-heading">
         <div class="pull-right">
           <button translatable="yes" class="btn btn-default accounts-privileged" id="account-logout">Terminate Session</button>
-          <button translatable="yes" class="btn btn-danger accounts-privileged" id="account-delete">Delete</button>
+          <button translatable="yes" class="btn btn-danger accounts-privileged" data-placement="left" id="account-delete">Delete</button>
         </div>
         <span id="account-title"></span>
       </div>
@@ -123,7 +123,15 @@
     <div class="panel panel-default" id="account-authorized-keys">
       <div class="panel-heading">
         <div class="pull-right">
-          <button data-toggle="modal" data-target="#add-authorized-key-dialog" data-original-title="Add Public Key" class="btn btn-primary accounts-self-privileged fa fa-plus" id="authorized-key-add" title=""></button>
+          <button data-toggle="modal"
+                  data-target="#add-authorized-key-dialog"
+                  data-original-title="Add Public Key"
+                  data-placement="left"
+                  class="btn btn-primary accounts-self-privileged fa fa-plus"
+                  id="authorized-key-add"
+                  title=""
+                  type="button">
+          </button>
         </div>
         <span translatable="yes">Authorized Public SSH Keys</span>
       </div>

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -39,8 +39,7 @@ function update_accounts_privileged() {
     $(".accounts-privileged:not('.accounts-current-account')").update_privileged(
         permission, cockpit.format(
             _("The user <b>$0</b> is not permitted to modify accounts"),
-            permission.user ? permission.user.name : ''),
-        "right"
+            permission.user ? permission.user.name : '')
     );
     $(".accounts-privileged").find("input")
         .attr('disabled', permission.allowed === false ||


### PR DESCRIPTION
![screenshot from 2017-02-14 11-41-26](https://cloud.githubusercontent.com/assets/8711649/22925931/d3c99cd6-f2aa-11e6-8724-c8cb94be6380.png)
![screenshot from 2017-02-14 11-41-30](https://cloud.githubusercontent.com/assets/8711649/22925928/d3c51120-f2aa-11e6-9f27-e421f885b38c.png)
![screenshot from 2017-02-14 11-41-41](https://cloud.githubusercontent.com/assets/8711649/22925930/d3c69d6a-f2aa-11e6-8b64-f943b0f31775.png)
![screenshot from 2017-02-14 11-41-55](https://cloud.githubusercontent.com/assets/8711649/22925929/d3c6a238-f2aa-11e6-93ff-b7807ef244bd.png)

These tooltips where sometimes off-screen.

The security tooltips were configured to always show on the right, so we need to remove that and allow inheritance of the original tooltip placement.