### PR TITLE
po: Fix mostly harmless typo in html2po

### DIFF
--- a/po/html2po
+++ b/po/html2po
@@ -187,7 +187,7 @@ function tag(node) {
 
 /* Push an entry onto the list */
 function push(entry) {
-    var key = entry.msgid + "\0" + entry.msgid_plural + + "\0" + entry.msgctxt;
+    var key = entry.msgid + "\0" + entry.msgid_plural + "\0" + entry.msgctxt;
     var prev = entries[key];
     if (prev) {
         prev.locations = prev.locations.concat(entry.locations);


### PR DESCRIPTION
In JavaScript, +"\0" is "NaN".  This is harmless in this context, but
probably not what was intended.