### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.pyc
 *.typelib
 *.so
+*.mo
 *~
 *.dirstamp
 .deps/
@@ -65,6 +66,7 @@ depcomp
 /test/run
 /test/kdc
 /cockpit-session
+/cockpit-ssh
 /cockpit-stub
 /cockpit-kube-auth
 /cockpit-kube-launch
@@ -140,6 +142,7 @@ po*.js.gz
 /.vagrant
 /test_rsa_key
 /tmp-dist
+/valgrind-suppressions
 
 /pkg/*/cockpit-components-*.js
 /pkg/*/cockpit-components-*.js
@@ -154,8 +157,9 @@ po*.js.gz
 
 # Test output
 Test*.log
-cockpit-wip.tar*
+cockpit-*.tar*
 Test*.png
 
+/pkg/networkmanager/override.json
 /pkg/storaged/override.json
 /pkg/docker/storage.js


### PR DESCRIPTION
"git status" in a built tree has become very noisy and shows tons of untracked files:
```
	cockpit-131.x.tar.gz
	cockpit-cache-131.x.tar.gz
	cockpit-ssh
	pkg/networkmanager/override.json
	src/common/mock-locale/de_DE/LC_MESSAGES/test.mo
	src/common/mock-locale/zh_CN/LC_MESSAGES/test.mo
	src/ws/ca.mo
	src/ws/da.mo
	src/ws/de.mo
	src/ws/es.mo
	src/ws/fr.mo
	src/ws/hr.mo
	src/ws/ko.mo
	src/ws/pl.mo
	src/ws/pt_BR.mo
	src/ws/tr.mo
	src/ws/uk.mo
	src/ws/zh_CN.mo
	valgrind-suppressions
```

This PR updates it to be clean again. I tag it "bot" as there is no build/runtime change, so no need to bother the integration tests. Semaphore should still run of course.