### PR TITLE
test: Run unittests with fatal-criticals

### DIFF
--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -23,6 +23,8 @@ basedebug_DATA = \
 	dist/base1/cockpit.min.js.map \
 	$(NULL)
 
+AM_TESTS_ENVIRONMENT = export G_DEBUG=fatal-criticals ;
+
 dist/base1/cockpit.min.css: src/base1/cockpit.css
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
 	$(srcdir)/tools/missing $(CLEAN_CSS) --keep-line-breaks --output=$@ --skip-import --source-map --source-map-inline-sources $^


### PR DESCRIPTION
We don't expect any g_critical()s during our tests (as opposed to
warnings), so let's make sure we fail on future problems/bugs.

----
I ran this locally on Fedora 25/amd64, let's see how it fares on the other targets.