### PR TITLE
networkmanager: Reset static addresses when switching to DHCP

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -3215,9 +3215,11 @@ PageNetworkIpSettings.prototype = {
         var auto_dns_search_btn, dns_search_table;
         var auto_routes_btn, routes_table;
 
-        function choicebox(p, choices) {
+        function choicebox(p, choices, callback) {
             var btn = select_btn(
                 function (choice) {
+                    if (callback)
+                        callback(choice);
                     params[p] = choice;
                     self.update();
                 },
@@ -3320,8 +3322,13 @@ PageNetworkIpSettings.prototype = {
                 $('<div>').append(
                     addresses_table = tablebox(_("Addresses"), "addresses", [ "Address", prefix_text, "Gateway" ],
                                                [ "", "", "" ],
-                                               choicebox("method", (topic == "ipv4")
-                                                   ? ipv4_method_choices : ipv6_method_choices)
+                                               choicebox("method",
+                                                         (topic == "ipv4") ? ipv4_method_choices : ipv6_method_choices,
+                                                         function (method) {
+                                                             if (method == "auto") {
+                                                                 params.addresses = [ ];
+                                                             }
+                                                         })
                                                        .css('display', 'inline-block')),
                     $('<br>'),
                     dns_table =


### PR DESCRIPTION
This is what people expect.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1401426