### PR TITLE
tools: After applying spec file patches reset mtimes

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -117,13 +117,18 @@ machines.
 %prep
 %setup -q
 
-# Apply patches using git
-git init
-git config user.email "unused@example.com" && git config user.name "Unused"
-git config core.autocrlf false && git config core.safecrlf false && git config gc.auto 0
-git add -f . && git commit -a -q -m "Base"
-echo "" | git am --whitespace=nowarn %{patches}
-rm -rf .git
+# Apply patches using git in order to support binary patches. Note that
+# we also reset mtimes since patches should be "complete" and include both
+# generated and source file changes
+if [ -n "%{patches}" ]; then
+	git init
+	git config user.email "unused@example.com" && git config user.name "Unused"
+	git config core.autocrlf false && git config core.safecrlf false && git config gc.auto 0
+	git add -f . && git commit -a -q -m "Base" && git tag -a initial --message="initial"
+	git am --whitespace=nowarn %{patches}
+	touch -r $(git diff --name-only initial..HEAD)
+	rm -rf .git
+fi
 
 %build
 exec 2>&1


### PR DESCRIPTION
All patches applied should be "complete" and apply both to source
and generated files in the tarball. By resetting the mtimes we then
ensure that the build process doesn't try to regenerate files that
cannot be generated again due to missing build dependencies on the
building system.