### PR TITLE
Don't rebuild webpacks in non-maintainer mode, fix "make clean"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -182,7 +182,7 @@ WEBPACK_DEPS = $(WEBPACK_PACKAGES:%=dist/%/Makefile.deps)
 WEBPACK_MANIFEST_IN = $(WEBPACK_PACKAGES:%=pkg/%/manifest.json.in)
 
 noinst_SCRIPTS += $(WEBPACK_DEPS) $(WEBPACK_INSTALL)
-CLEANFILES += $(WEBPACK_DEPS) $(WEBPACK_OUTPUTS)
+DISTCLEANFILES = $(WEBPACK_DEPS) $(WEBPACK_OUTPUTS)
 EXTRA_DIST += $(WEBPACK_DEPS) $(WEBPACK_MANIFEST_IN) webpack.config.js
 
 # Run webpack if we don't have the include file or if its out of date
@@ -314,7 +314,7 @@ dist/fonts/%.woff:
 
 EXTRA_DIST += $(OPENSANS_FONTS)
 
-CLEANFILES += $(OPENSANS_FONTS)
+DISTCLEANFILES += $(OPENSANS_FONTS)
 
 if ENABLE_DOC
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -168,7 +168,11 @@ V_WEBPACK_0 = @echo "  WEBPACK  $(@:dist/%/Makefile.deps=%)";
 WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(srcdir) BUILDDIR=$(builddir) \
 	       $(srcdir)/tools/missing $(srcdir)/tools/webpack-make
 
+if MAINTAINER_MODE
 WEBPACK_RULE = $(V_WEBPACK) $(WEBPACK_MAKE)
+else
+WEBPACK_RULE = @echo "Skipping webpack update in non-maintainer mode: $(@:dist/%/Makefile.deps=%)"; \#
+endif
 
 WEBPACK_CONFIG = $(srcdir)/webpack.config.js
 WEBPACK_INPUTS =

--- a/autogen.sh
+++ b/autogen.sh
@@ -71,7 +71,7 @@ cd $olddir
 if [ -z "${NOREDIRECTMAKEFILE:-}" ]; then
     rm -f $srcdir/Makefile
 fi
-$srcdir/configure --enable-maintainer-mode ${AUTOGEN_CONFIGURE_ARGS:-} "$@" || exit $?
+$srcdir/configure ${AUTOGEN_CONFIGURE_ARGS:-} "$@" || exit $?
 
 # Put a redirect makefile and dist directory here
 if [ -z "${NOREDIRECTMAKEFILE:-}" ]; then

--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -82,12 +82,13 @@ noinst_DATA += \
 	dist/guide/html/index.html \
 	dist/guide/index.html
 
-CLEANFILES += \
+DISTCLEANFILES += \
 	dist/guide/html/* \
 	dist/guide/links.html \
 	dist/guide/index.html \
-	*.tmp \
 	$(NULL)
+
+CLEANFILES += *.tmp
 
 dist/guide/html/%.woff: dist/fonts/%.woff
 	$(COPY_RULE)

--- a/examples/ocserv/Makefile.am
+++ b/examples/ocserv/Makefile.am
@@ -12,7 +12,7 @@ ocservdebug_DATA = \
 	pkg/ocserv/ocserv.css \
 	$(NULL)
 
-CLEANFILES += \
+DISTCLEANFILES += \
 	pkg/ocserv/ocserv.html \
 	pkg/ocserv/ocserv.min.css \
 	$(NULL)

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -126,12 +126,15 @@ CLEANFILES += \
 	$(MO_FILES) \
 	$(POJS_FILES) \
 	$(nodist_po_DATA) \
-	$(PO_JAVASCRIPT) \
 	po/POTFILES.*.in \
 	dist/shell/*.po \
 	src/ws/*.po \
 	po/cockpit*.pot \
 	po/po.js.gz \
+	$(NULL)
+
+DISTCLEANFILES += \
+	$(PO_JAVASCRIPT) \
 	$(NULL)
 
 EXTRA_DIST += \

--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -235,7 +235,7 @@ EXTRA_DIST += \
 	$(base_TESTS_JAVASCRIPT) \
 	$(NULL)
 
-CLEANFILES += \
+DISTCLEANFILES += \
 	dist/base1/cockpit.js \
 	dist/base1/cockpit.min.css \
 	dist/base1/cockpit.min.css.gz \

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -30,7 +30,7 @@ dist/static/login.min.html: src/ws/login.html dist/static/login.min.js dist/stat
 staticfontsdir = $(staticdir)/fonts
 staticfonts_DATA = $(OPENSANS_FONTS)
 
-CLEANFILES += \
+DISTCLEANFILES += \
 	dist/static/login.html \
 	dist/static/login.min.html \
 	dist/static/login.js \

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -190,7 +190,7 @@ function generateDeps(makefile, stats) {
     lines.push("\trm -rf $(" + prefix + "_OUTPUTS) $(" + prefix + "_INSTALL) " + makefile);
     lines.push("all-local:: " + prefix);
     lines.push("\t@true");
-    lines.push("clean-local:: clean-" + prefix);
+    lines.push("distclean-local:: clean-" + prefix);
     lines.push("\t@true");
 
     data = lines.join("\n");


### PR DESCRIPTION
When applying patches, we assume that they also patch the corresponding
generated files in dist/. Depending on the patch ordering/time stamps
these might still trigger webpack rebuilds, which are likely to fail as
we don't ship all the node build dependencies.

When configured with --disable-maintainer-mode, don't run webpack, just
show for which modules it gets skipped.

----

Demonstration: First build this normally, to get the build system updated (autoreconf and all). In maintainer mode, webpacks get updated:
```sh
$ touch {dist,pkg}/dashboard/index.html  ;  make 
  WEBPACK  dashboard
make  all-am
  GZIP     dist/dashboard/dashboard.css.gz
  GZIP     dist/dashboard/index.html.gz
  GZIP     dist/dashboard/dashboard.js.gz
```
Now switch to non-maintainer mode, webpacks don't get updated any more:
```sh
$ ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --enable-debug --disable-maintainer-mode
$ touch {dist,pkg}/dashboard/index.html; make
Skipping webpack update in non-maintainer mode: dashboard
make  all-am
Skipping webpack update in non-maintainer mode: dashboard
  GZIP     dist/dashboard/index.html.gz
```

I think the `GZIP` rule is still okay, but if you prefer I can change this to get skipped as well.