### PR TITLE
kubernetes: Add further debugging to find delete pod issue

### DIFF
--- a/pkg/kubernetes/scripts/details.js
+++ b/pkg/kubernetes/scripts/details.js
@@ -460,7 +460,10 @@
             angular.extend($scope, dialogData);
 
             $scope.performDelete = function performDelete() {
-                return methods.delete($scope.item);
+                return methods.delete($scope.item).catch(function(ex) {
+                    /* HACK: While debugging delete issues */
+                    console.log(JSON.stringify(ex));
+                });
             };
         }
     ])


### PR DESCRIPTION
There are issues where the deletion of a pod fails during testing
with 'pods "mock-xxxx" not found'. We want to figure out what's
going on here, so we'll include this further log output.