### PR TITLE
machines: CPU usage is shown with fixed precision

### DIFF
--- a/pkg/machines/helpers.es6
+++ b/pkg/machines/helpers.es6
@@ -124,3 +124,17 @@ export function rephraseUI(key, original) {
 
     return transform[key][original];
 }
+
+export function toFixedPrecision(value, precision) {
+    precision = precision || 0;
+    const power = Math.pow(10, precision);
+    const absValue = Math.abs(Math.round(value * power));
+    let result = (value < 0 ? '-' : '') + String(Math.floor(absValue / power));
+
+    if (precision > 0) {
+        const fraction = String(absValue % power);
+        const padding = new Array(Math.max(precision - fraction.length, 0) + 1).join('0');
+        result += '.' + padding + fraction;
+    }
+    return result;
+}

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -20,7 +20,7 @@
 import cockpit from 'cockpit';
 import React, { PropTypes } from "react";
 import { shutdownVm, forceVmOff, forceRebootVm, rebootVm, startVm } from "./actions.es6";
-import { rephraseUI, logDebug, toGigaBytes } from "./helpers.es6";
+import { rephraseUI, logDebug, toGigaBytes, toFixedPrecision } from "./helpers.es6";
 import DonutChart from "./c3charts.jsx";
 import { Listing, ListingRow } from "cockpit-components-listing.jsx";
 
@@ -239,6 +239,7 @@ const VmUsageTab = ({ vm }) => {
     // 4 CPU system can have usage 400%, let's keep % between 0..100
     let cpuUsage = vm['cpuUsage'] / (totalCpus > 0 ? totalCpus : 1);
     cpuUsage = isNaN(cpuUsage) ? 0 : cpuUsage;
+    cpuUsage = toFixedPrecision(cpuUsage, 1);
 
     logDebug(`VmUsageTab.render(): rssMem: ${rssMem} KiB, memTotal: ${memTotal} KiB, available: ${available} KiB, totalCpus: ${totalCpus}, cpuUsage: ${cpuUsage}`);
 

--- a/pkg/machines/test-machines.js
+++ b/pkg/machines/test-machines.js
@@ -1,0 +1,38 @@
+var QUnit = require("qunit-tests");
+var assert = QUnit;
+
+var helpers = require("./helpers.es6");
+
+QUnit.test("toFixedPrecision", function() {
+    assert.equal("1.0", helpers.toFixedPrecision("1", 1));
+    assert.equal("1.0", helpers.toFixedPrecision("1.0", 1));
+    assert.equal("1.0", helpers.toFixedPrecision("1.01", 1));
+    assert.equal("1.1", helpers.toFixedPrecision("1.1", 1));
+    assert.equal("1.1", helpers.toFixedPrecision("1.123", 1));
+
+    assert.equal("1", helpers.toFixedPrecision("1", 0));
+    assert.equal("1", helpers.toFixedPrecision("1.0", 0));
+    assert.equal("1", helpers.toFixedPrecision("1.01", 0));
+    assert.equal("1", helpers.toFixedPrecision("1.1", 0));
+    assert.equal("1", helpers.toFixedPrecision("1.123", 0));
+
+    assert.equal("1.00", helpers.toFixedPrecision("1", 2));
+    assert.equal("1.00", helpers.toFixedPrecision("1.0", 2));
+    assert.equal("1.01", helpers.toFixedPrecision("1.01", 2));
+    assert.equal("1.10", helpers.toFixedPrecision("1.1", 2));
+    assert.equal("1.12", helpers.toFixedPrecision("1.123", 2));
+
+    assert.equal("12.0", helpers.toFixedPrecision("12", 1));
+    assert.equal("12.0", helpers.toFixedPrecision("12.0", 1));
+    assert.equal("12.0", helpers.toFixedPrecision("12.01", 1));
+    assert.equal("12.0", helpers.toFixedPrecision("12.010", 1));
+    assert.equal("12.1", helpers.toFixedPrecision("12.123", 1));
+
+    assert.equal("12.00", helpers.toFixedPrecision("12", 2));
+    assert.equal("12.00", helpers.toFixedPrecision("12.0", 2));
+    assert.equal("12.01", helpers.toFixedPrecision("12.01", 2));
+    assert.equal("12.01", helpers.toFixedPrecision("12.010", 2));
+    assert.equal("12.12", helpers.toFixedPrecision("12.123", 2));
+});
+
+QUnit.start();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,6 +151,8 @@ var info = {
         "kubernetes/scripts/test-volumes",
 
         "ostree/test-utils",
+
+        "machines/test-machines",
     ],
 
     files: [


### PR DESCRIPTION
With this fix, the VM's CPU usage is limited one digit in the fractional part ( e.g. `12.3 %` ).
