### PR TITLE
cockpit:machines: Display VM graphics console

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -89,7 +89,7 @@ CLEAN_CSS = $(srcdir)/node_modules/.bin/cleancss
 
 MIN_JS_RULE = \
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	$(srcdir)/tools/missing $(UGLIFY_JS) $^ --mangle --comments 'preserve' --beautify \
+	$(srcdir)/tools/missing $(UGLIFY_JS) $(filter-out %.deps, $^) --mangle --comments 'preserve' --beautify \
 		--source-map $@.map --source-map-url $(notdir $@).map --source-map-include-sources > $@.tmp && \
 	$(MV) $@.tmp $@
 

--- a/bots/naughty/ubuntu-1604/6901-apparmor-denied-libvirt-gss
+++ b/bots/naughty/ubuntu-1604/6901-apparmor-denied-libvirt-gss
@@ -1,0 +1,1 @@
+apparmor="DENIED" operation="open" profile="libvirt* name="/etc/gss/mech.d/"

--- a/bots/naughty/ubuntu-stable/6901-apparmor-denied-libvirt-gss
+++ b/bots/naughty/ubuntu-stable/6901-apparmor-denied-libvirt-gss
@@ -1,0 +1,1 @@
+apparmor="DENIED" operation="open" profile="libvirt* name="/etc/gss/mech.d/"

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
         "kubernetes-topology-graph": "0.0.23",
         "momentjs": "2.10.6",
         "mustache": "0.8.1",
+        "no-vnc": "0.6.2",
         "patternfly": "3.4.0",
         "qunit": "1.23.1",
         "qunit-tap": "1.5.1",

--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -13,11 +13,35 @@ playground_DATA = \
 dist/playground/extra.de.po: pkg/playground/extra.de.po
 	$(COPY_RULE)
 
+machinesincludedir = $(pkgdatadir)/machines/include
+machinesinclude_DATA = \
+	$(shell ls -1 $(srcdir)/bower_components/no-vnc/include | grep ".*\.\(js\|css\|ttf\|woff\)" | sed -e 's/^/dist\/machines\/include\//') \
+	$(NULL)
+
+machinesincludechromedir = $(pkgdatadir)/machines/include/chrome-app
+machinesincludechrome_DATA = \
+	$(shell ls -1 $(srcdir)/bower_components/no-vnc/include/chrome-app | grep ".*\.\(js\|css\|ttf\|woff\)" | sed -e 's/^/dist\/machines\/include\/chrome-app\//') \
+	$(NULL)
+
+# preprocess no-vnc's keysymdef.js, logo.js to fix "upatchable file" error
+# preprocessed file needs to go to "dist" package since node_modules with "uglify" are missing in the .tar.gz
+dist/machines/include/keysymdef.js: bower_components/no-vnc/include/keysymdef.js
+	$(MIN_JS_RULE)
+
+# just copy the rest
+dist/machines/include/chrome-app/%: bower_components/no-vnc/include/chrome-app/%
+	$(COPY_RULE)
+
+dist/machines/include/%: bower_components/no-vnc/include/%
+	$(COPY_RULE)
+
 EXTRA_DIST += \
 	dist/playground/extra.de.po \
 	pkg/playground/extra.de.po \
 	pkg/users/mock \
 	pkg/lib/qunit-template.html \
+	$(shell ls -1 $(srcdir)/bower_components/no-vnc/include | grep ".*\.\(js\|css\|ttf\|woff\)" | sed -e 's/^/dist\/machines\/include\//') \
+	$(shell ls -1 $(srcdir)/bower_components/no-vnc/include/chrome-app | grep ".*\.\(js\|css\|ttf\|woff\)" | sed -e 's/^/dist\/machines\/include\/chrome-app\//') \
 	$(playground_DATA) \
 	$(pkg_TESTS)
 

--- a/pkg/machines/actions.es6
+++ b/pkg/machines/actions.es6
@@ -63,6 +63,10 @@ export function startVm(vm) {
     return virt('START_VM', { name: vm.name, id: vm.id, connectionName: vm.connectionName });
 }
 
+export function vmDesktopConsole(vm, consoleDetail) {
+    return virt('CONSOLE_VM', { name: vm.name, id: vm.id, connectionName: vm.connectionName, consoleDetail });
+}
+
 /**
  * Delay call of polling action.
  *
@@ -108,9 +112,24 @@ export function setRefreshInterval(refreshInterval) {
     };
 }
 
-export function updateOrAddVm({ id, name, connectionName, state, osType, fqdn, uptime, currentMemory, rssMemory, vcpus, autostart,
-    actualTimeInMs, cpuTime, disks, emulatedMachine, cpuModel, bootOrder }) {
-    let vm = {};
+export function updateOrAddVm({ id, name, connectionName,
+    state,
+    osType,
+    fqdn,
+    uptime,
+    currentMemory,
+    rssMemory,
+    vcpus,
+    autostart,
+    actualTimeInMs,
+    cpuTime,
+    disks,
+    emulatedMachine,
+    cpuModel,
+    bootOrder,
+    displays,
+    }) {
+    const vm = {};
 
     if (id !== undefined) vm.id = id;
     if (name !== undefined) vm.name = name;
@@ -127,6 +146,7 @@ export function updateOrAddVm({ id, name, connectionName, state, osType, fqdn, u
     if (emulatedMachine !== undefined) vm.emulatedMachine = emulatedMachine;
     if (cpuModel !== undefined) vm.cpuModel = cpuModel;
     if (bootOrder !== undefined) vm.bootOrder = bootOrder;
+    if (displays !== undefined) vm.displays = displays;
 
     if (actualTimeInMs !== undefined) vm.actualTimeInMs = actualTimeInMs;
     if (cpuTime !== undefined) vm.cpuTime = cpuTime;

--- a/pkg/machines/components/desktopConsole.jsx
+++ b/pkg/machines/components/desktopConsole.jsx
@@ -1,0 +1,220 @@
+/*jshint esversion: 6 */
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from "react";
+import cockpit from 'cockpit';
+import { vmId } from '../helpers.es6';
+
+const _ = cockpit.gettext;
+
+const MoreInformationInstallVariant = ({ os, command, innerHtml }) => {
+    return (
+        <li className='machines-desktop-install-instructs-item'>
+            <div className='machines-desktop-install-instructs-row'>
+                <b>{os}:</b>&nbsp;
+                {innerHtml && <div dangerouslySetInnerHTML={{__html: innerHtml}}/>}
+                {!innerHtml && <div className='machines-desktop-shell-command'>{command}</div>}
+            </div>
+        </li>
+
+    );
+}
+
+const MoreInformationContent = () => {
+    const msg1 = cockpit.format(_("Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."),
+        '<i>Remote Viewer</i>');
+
+    const msg2 = cockpit.format(_("$0 is available for most operating systems. To install it, search for it in GNOME Software or run the following:"),
+        '<i>Remote Viewer</i>');
+
+    const downloadMsg = cockpit.format(_("Download the MSI from $0"),
+        '<a href="https://virt-manager.org/download/" target="_blank">virt-manager.org</a>');
+
+    return (
+        <div>
+            <br />
+            <p className='machines-desktop-more-info-text' dangerouslySetInnerHTML={{__html: msg1}} />
+            <p className='machines-desktop-more-info-text' dangerouslySetInnerHTML={{__html: msg2}} />
+
+            <ul className='machines-desktop-install-instructs'>
+                <MoreInformationInstallVariant os='RHEL, CentOS' command='sudo yum install virt-viewer'/>
+                <MoreInformationInstallVariant os='Fedora' command='sudo dnf install virt-viewer'/>
+                <MoreInformationInstallVariant os='Ubuntu, Debian' command='sudo apt-get install virt-viewer'/>
+                <MoreInformationInstallVariant os='Windows' innerHtml={downloadMsg}/>
+            </ul>
+        </div>
+    );
+}
+
+class MoreInformation extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            expanded: false,
+        };
+
+        this.onClick = this.onClick.bind(this);
+        this.getContent = this.getContent.bind(this);
+    }
+
+    onClick() {
+        this.setState({
+            expanded: !this.state.expanded,
+        });
+    }
+
+    getContent() {
+        const { vm } = this.props;
+        const { provider, providerState } = this.props.config;
+
+        let content = <MoreInformationContent />;
+        if (provider.consoleClientResourcesFactory) {
+            // external provider can have specific instructions for console setup
+            const ProviderConsoleClientResources = provider.consoleClientResourcesFactory(vm, providerState);
+            if (ProviderConsoleClientResources) {
+                content = <ProviderConsoleClientResources displays={vm.displays} />;
+            }
+        }
+
+        return content;
+    }
+
+    render() {
+        if (!this.state.expanded) {
+            return (
+                <a href='#' onClick={this.onClick}>
+                    <span className='fa fa-angle-right'/>&nbsp;
+                    {_("More Information")}
+                </a>);
+        }
+
+        return (
+            <div>
+                <a href='#' onClick={this.onClick}>
+                    <span className='fa fa-angle-down'/>&nbsp;
+                    {_("More Information")}
+                </a>
+                {this.getContent()}
+            </div>);
+    }
+}
+
+const ConnectWithRemoteViewer = ({ vm, config, onDesktopConsole }) => {
+    let display = vm.displays.spice;
+    if (!display) {
+        display = vm.displays.vnc;
+    }
+    const onLaunch = () => onDesktopConsole(display);
+
+    return (
+        <td className='machines-desktop-main-col'>
+            <h2>{_("Connect with Remote Viewer")}</h2>
+            <p className='machines-desktop-viewer-block'>
+                <button onClick={onLaunch} id={`${vmId(vm.name)}-consoles-launch`}>
+                    {_("Launch Remote Viewer")}
+                </button>
+            </p>
+            <p className='machines-desktop-viewer-block'>
+                <MoreInformation vm={vm} config={config} />
+            </p>
+        </td>
+    );
+}
+
+const ManualConnectionDetails = ({ displays, idPrefix }) => {
+    const spiceAddress = displays.spice && displays.spice.address;
+    const spicePort = displays.spice && displays.spice.port;
+    const spiceTlsPort = displays.spice && displays.spice.tlsPort;
+    const vncPort = displays.vnc && displays.vnc.port;
+    const vncTlsPort = displays.vnc && displays.vnc.tlsPort;
+    const vncAddress = displays.vnc && displays.vnc.address;
+
+    // deduplicate the address if possible
+    const singleAddress = vncAddress && spiceAddress ?
+        (vncAddress === spiceAddress && vncAddress)
+        : (spiceAddress || vncAddress);
+
+    return (
+        <dl className='machines-desktop-manual-con-details'>
+            {singleAddress && (<dt>{_("Address:")}</dt>)}
+            {singleAddress && (<dd id={`${idPrefix}-address`}>{singleAddress}</dd>)}
+
+            {(!singleAddress && spiceAddress) && (<dt>{_("SPICE Address:")}</dt>)}
+            {(!singleAddress && spiceAddress) && (<dd id={`${idPrefix}-address-spice`}>{spiceAddress}</dd>)}
+
+            {(!singleAddress && vncAddress) && (<dt>{_("VNC Address:")}</dt>)}
+            {(!singleAddress && vncAddress) && (<dd id={`${idPrefix}-address-vnc`}>{vncAddress}</dd>)}
+
+            {spicePort && (<dt>{_("SPICE Port:")}</dt>)}
+            {spicePort && (<dd id={`${idPrefix}-port-spice`}>{spicePort}</dd>)}
+
+            {spiceTlsPort && (<dt>{_("SPICE TLS Port:")}</dt>)}
+            {spiceTlsPort && (<dd id={`${idPrefix}-port-spice-tls`}>{spiceTlsPort}</dd>)}
+
+            {vncPort && (<dt>{_("VNC Port:")}</dt>)}
+            {vncPort && (<dd id={`${idPrefix}-port-vnc`}>{vncPort}</dd>)}
+
+            {vncTlsPort && (<dt>{_("VNC TLS Port:")}</dt>)}
+            {vncTlsPort && (<dd id={`${idPrefix}-port-vnc-tls`}>{vncTlsPort}</dd>)}
+        </dl>
+    );
+}
+
+const ManualConnection = ({ displays, idPrefix }) => {
+    const isVNC = !!displays.vnc
+    const isSPICE = !!displays.spice
+
+    if (!isVNC && !isSPICE) {
+        return null;
+    }
+
+    let msg = _("Connect with any SPICE or VNC viewer application.");
+    if (!isVNC || !isSPICE) {
+        const protocol = isVNC ? _("VNC") : _("SPICE");
+        msg = cockpit.format(_("Connect with any $0 viewer application."), protocol);
+    }
+
+    return (
+        <td className='machines-desktop-main-col'>
+            <h2>{_("Manual Connection")}</h2>
+            <p className='machines-desktop-manual-block'>{msg}</p>
+            <p className='machines-desktop-manual-block'>
+                <ManualConnectionDetails displays={displays} idPrefix={idPrefix}/>
+            </p>
+        </td>
+    )
+}
+
+const DesktopConsoleDownload = ({ vm, onDesktopConsole, config }) => {
+    return (
+        <div>
+            <br />
+            <hr className='machines-desktop-delimiter'/>
+            <table className='machines-desktop-main'>
+                <tr>
+                    <ConnectWithRemoteViewer config={config} vm={vm} onDesktopConsole={onDesktopConsole} />
+                    <ManualConnection displays={vm.displays} idPrefix={`${vmId(vm.name)}-consoles-manual`}/>
+                </tr>
+            </table>
+        </div>
+    );
+};
+
+export default DesktopConsoleDownload;

--- a/pkg/machines/components/graphicsConsole.jsx
+++ b/pkg/machines/components/graphicsConsole.jsx
@@ -1,0 +1,199 @@
+/*jshint esversion: 6 */
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from "react";
+import cockpit from 'cockpit';
+import Vnc from './vnc.jsx';
+import DesktopConsoleDownload from './desktopConsole.jsx';
+import { vmDesktopConsole } from '../actions.es6';
+import { logDebug } from '../helpers.es6';
+
+const _ = cockpit.gettext;
+
+const NoConsole = () => { // TODO: add option to define graphics consoles
+    return (
+        <div>
+            {_("No graphics console is defined for this virtual machine.")}
+        </div>
+    );
+};
+
+// TODO: fix: check the flow
+const VmNotRunning = () => {
+  return (
+      <div>
+          {_("Please start the virtual machine to access its graphics console.")}
+      </div>
+  );
+};
+
+const SwitchConsole = ({ displays, inBrowserConsole, onBrowserVNC, onDesktopConsole }) => {
+    const onSwitchToDesktop = () => {
+        setDefaultBrowserMode(false);
+        onDesktopConsole();
+    };
+    const onSwitchToBrowser = () => {
+        setDefaultBrowserMode(true);
+        onBrowserVNC();
+    };
+
+    if (inBrowserConsole) {
+        return (
+            <div className='top-right-menu'>
+                <a className='left-delimiter' href='#' onClick={onSwitchToDesktop}>
+                    {_("Switch to Desktop Viewer")}
+                </a>
+            </div>
+        );
+    }
+
+    if (displays.vnc) { // the VM has VNC defined
+        return (
+            <div className='top-right-menu'>
+                <a className='left-delimiter' href='#' onClick={onSwitchToBrowser}>
+                    {_("Switch to In-Browser Viewer")}
+                </a>
+            </div>
+        );
+    }
+
+    return null;
+};
+
+const setDefaultBrowserMode = (inBrowser) => {
+    const value = inBrowser ? 'true' : 'false';
+    logDebug('Default Browser Console mode set to: ', value);
+    window.localStorage.setItem('MACHINES_CONSOLE_IN_BROWSER_DEFAULT', value);
+};
+
+const getDefaultBrowserConsole = (displays) => {
+    if (!displays) {
+        return null;
+    }
+
+    // TODO: prefer SPICE over VNC once spice-html5 is implemented
+
+    if (displays.vnc) {
+        const vncInBrowserDefault = window.localStorage.getItem('MACHINES_CONSOLE_IN_BROWSER_DEFAULT') !== 'false';
+        if (vncInBrowserDefault) {
+            return 'vnc';
+        }
+    }
+
+    return null; // no in-browser console is rendered
+};
+
+/**
+ * Please note, this is React functional component.
+ *
+ * In addition to redux store, the GraphicsConsole component state depends on:
+ *   - window.localStorage (browser/desktop default)
+ *   - provider.onConsoleAboutToShow() processing (populating consoleDetails by provider-specifics on the time of opening)
+ *   - internally managed this.setState() manipulations (to handle component-local user actions)
+ */
+class GraphicsConsole extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            inBrowserConsole: null,
+            consoleDetail: null,
+        };
+
+        this.onBrowserVnc = this.onBrowserVnc.bind(this);
+        this.onDesktopConsole = this.onDesktopConsole.bind(this);
+    }
+
+    componentDidMount () {
+        if (getDefaultBrowserConsole(this.props.vm.displays) === 'vnc') {
+            this.onBrowserVnc();
+        } else if (this.props.vm.displays.spice) {
+            this.onDesktopConsole();
+        }
+    }
+
+    onBrowserVnc() {
+        const { vm, config } = this.props;
+        const { provider, providerState } = config;
+
+        if (provider.onConsoleAboutToShow) {
+            // Hook: Give provider chance to update consoleDetail before noVNC is initialized.
+            // This update needs to be performed at the time of console retrieval, since provider-specific console
+            // details might vary over time, like the password (in oVirt: the password is valid for 2 minutes only).
+            provider.onConsoleAboutToShow({ type: 'vnc', vm, providerState }).then( consoleDetail => {
+                if (consoleDetail) {
+                    this.setState({inBrowserConsole: 'vnc', consoleDetail});
+                } else { // vnc console can't be rendered (see provider for the reason)
+                    console.info(`In-Browser VNC console is disabled by external provider`);
+                    this.setState({inBrowserConsole: null, consoleDetail: null});
+                }
+            });
+        } else {
+            this.setState({inBrowserConsole: 'vnc', consoleDetail: vm.displays.vnc});
+        }
+    }
+
+    onDesktopConsole(detail) {
+        const { vm, dispatch } = this.props;
+
+        this.setState({inBrowserConsole: null, consoleDetail: null});
+
+        if (detail) { // fire download of the .vv file
+            dispatch(vmDesktopConsole(vm, detail));
+        }
+    }
+
+    render() {
+        const { vm, config } = this.props;
+        const provider = config.provider;
+        const displays = vm.displays;
+
+        if (!(displays && (displays.spice || displays.vnc))) {
+            return (<NoConsole />);
+        }
+
+        if (!provider.canConsole || !provider.canConsole(vm.state)) {
+            return (<VmNotRunning />);
+        }
+
+        let content = null;
+        switch (this.state.inBrowserConsole) { // TODO: add spice once implemented for in-browser
+            case 'vnc':
+                content = <Vnc vm={vm} consoleDetail={this.state.consoleDetail} />;
+                break;
+            case null: // no in-browser console rendered
+                content = <DesktopConsoleDownload vm={vm} config={config} onDesktopConsole={this.onDesktopConsole} />;
+                break;
+            default:
+                console.error(`Unexpected in-browser console type: ${this.state.inBrowserConsole}`);
+        }
+
+        return (
+            <div>
+                <SwitchConsole displays={displays}
+                               inBrowserConsole={this.state.inBrowserConsole}
+                               onBrowserVNC={this.onBrowserVnc}
+                               onDesktopConsole={this.onDesktopConsole} />
+                {content}
+            </div>
+        );
+    }
+}
+
+export default GraphicsConsole;

--- a/pkg/machines/components/vnc.jsx
+++ b/pkg/machines/components/vnc.jsx
@@ -1,0 +1,55 @@
+/*jshint esversion: 6 */
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from "react";
+import cockpit from 'cockpit';
+
+const _ = cockpit.gettext;
+
+const Frame = ({ url }) => {
+    return (
+        <iframe src={url} className='machines-console-frame-vnc' frameBorder='0'>
+            {_("Your browser does not support iframes.")}
+        </iframe>
+    );
+};
+Frame.propTypes = {
+    url: React.PropTypes.string.isRequired,
+};
+
+const Vnc = ({ consoleDetail }) => {
+    if (!consoleDetail) {
+        return null;
+    }
+
+    const encrypt = window.location.protocol === "https:";
+    const port = consoleDetail.tlsPort || consoleDetail.port;
+
+    let params = `?host=${consoleDetail.address}&port=${port}&encrypt=${encrypt}&true_color=1&resize=true`;
+    params = consoleDetail.password ? params += `&password=${consoleDetail.password}` : params;
+
+    return (
+        <div className='machines-console-frame'>
+            <br />
+            <Frame url={`vnc.html${params}`} />
+        </div>
+    );
+};
+
+export default Vnc;

--- a/pkg/machines/components/vnc.jsx
+++ b/pkg/machines/components/vnc.jsx
@@ -20,34 +20,38 @@
 import React from "react";
 import cockpit from 'cockpit';
 
+import { vmId } from '../helpers.es6';
+
 const _ = cockpit.gettext;
 
-const Frame = ({ url }) => {
+const Frame = ({ url, containerId }) => {
     return (
-        <iframe src={url} className='machines-console-frame-vnc' frameBorder='0'>
+        <iframe src={url} className='machines-console-frame-vnc' frameBorder='0' data-container-id={containerId}>
             {_("Your browser does not support iframes.")}
         </iframe>
     );
 };
 Frame.propTypes = {
     url: React.PropTypes.string.isRequired,
+    containerId: React.PropTypes.string.isRequired,
 };
 
-const Vnc = ({ consoleDetail }) => {
+const Vnc = ({ vm, consoleDetail }) => {
     if (!consoleDetail) {
         return null;
     }
+    const uniqueFrameContainerId = `${vmId(vm.name)}-novnc-frame-container`;
 
     const encrypt = window.location.protocol === "https:";
     const port = consoleDetail.tlsPort || consoleDetail.port;
 
-    let params = `?host=${consoleDetail.address}&port=${port}&encrypt=${encrypt}&true_color=1&resize=true`;
+    let params = `?host=${consoleDetail.address}&port=${port}&encrypt=${encrypt}&true_color=1&resize=true&containerId=${encodeURIComponent(uniqueFrameContainerId)}`;
     params = consoleDetail.password ? params += `&password=${consoleDetail.password}` : params;
 
     return (
-        <div className='machines-console-frame'>
+        <div id={uniqueFrameContainerId} className='machines-console-frame' style={{ height: '100px;' }}>
             <br />
-            <Frame url={`vnc.html${params}`} />
+            <Frame url={`vnc.html${params}`} containerId={uniqueFrameContainerId} />
         </div>
     );
 };

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -173,7 +173,7 @@ export const DropdownButtons = ({ buttons }) => {
 
         const caretId = buttons[0]['id'] ? `${buttons[0]['id']}-caret` : undefined;
         return (<div className='btn-group'>
-            <button className='btn btn-default btn-danger' onClick={buttons[0].action}>
+            <button className='btn btn-default btn-danger' id={buttons[0].id} onClick={buttons[0].action}>
                 {buttons[0].title}
             </button>
             <button data-toggle='dropdown' className='btn btn-default dropdown-toggle'>

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -20,10 +20,11 @@
 import cockpit from 'cockpit';
 import React, { PropTypes } from "react";
 import { shutdownVm, forceVmOff, forceRebootVm, rebootVm, startVm } from "./actions.es6";
-import { rephraseUI, logDebug, toGigaBytes, toFixedPrecision } from "./helpers.es6";
+import { rephraseUI, logDebug, toGigaBytes, toFixedPrecision, vmId } from "./helpers.es6";
 import DonutChart from "./c3charts.jsx";
 import { Listing, ListingRow } from "cockpit-components-listing.jsx";
 import VmDisksTab from './vmdiskstab.jsx';
+import GraphicsConsole from './components/graphicsConsole.jsx';
 
 const _ = cockpit.gettext;
 
@@ -100,7 +101,7 @@ VmActions.propTypes = {
     onReboot: PropTypes.func.isRequired,
     onForceReboot: PropTypes.func.isRequired,
     onShutdown: PropTypes.func.isRequired,
-    onForceoff: PropTypes.func.isRequired
+    onForceoff: PropTypes.func.isRequired,
 }
 
 const IconElement = ({ onClick, className, title, state }) => {
@@ -159,35 +160,39 @@ StateIcon.propTypes = {
  * @constructor
  */
 export const DropdownButtons = ({ buttons }) => {
-    const buttonsHtml = buttons
-        .filter(button => buttons[0].id === undefined || buttons[0].id !== button.id)
-        .map(button => {
-            return (<li className='presentation'>
-                <a role='menuitem' onClick={button.action} id={button.id}>
-                    {button.title}
-                </a>
-            </li>)
-        });
+    if (buttons.length > 1) { // do not display caret for single option
+        const buttonsHtml = buttons
+            .filter(button => buttons[0].id === undefined || buttons[0].id !== button.id)
+            .map(button => {
+                return (<li className='presentation'>
+                    <a role='menuitem' onClick={button.action} id={button.id}>
+                        {button.title}
+                    </a>
+                </li>)
+            });
 
-    const caretId = buttons[0]['id'] ? `${buttons[0]['id']}-caret` : undefined;
+        const caretId = buttons[0]['id'] ? `${buttons[0]['id']}-caret` : undefined;
+        return (<div className='btn-group'>
+            <button className='btn btn-default btn-danger' onClick={buttons[0].action}>
+                {buttons[0].title}
+            </button>
+            <button data-toggle='dropdown' className='btn btn-default dropdown-toggle'>
+                <span className='caret' id={caretId}/>
+            </button>
+            <ul role='menu' className='dropdown-menu'>
+                {buttonsHtml}
+            </ul>
+        </div>);
+    }
+
     return (<div className='btn-group'>
         <button className='btn btn-default btn-danger' onClick={buttons[0].action} id={buttons[0]['id']}>
             {buttons[0].title}
         </button>
-        <button data-toggle='dropdown' className='btn btn-default dropdown-toggle'>
-            <span className='caret' id={caretId}/>
-        </button>
-        <ul role='menu' className='dropdown-menu'>
-            {buttonsHtml}
-        </ul>
     </div>);
 }
 DropdownButtons.propTypes = {
     buttons: PropTypes.array.isRequired
-}
-
-function vmId(vmName) {
-    return `vm-${vmName}`;
 }
 
 const VmOverviewTabRecord = ({id, descr, value}) => {
@@ -359,10 +364,14 @@ VmUsageTab.propTypes = {
 const Vm = ({ vm, config, onStart, onShutdown, onForceoff, onReboot, onForceReboot, dispatch }) => {
     const stateIcon = (<StateIcon state={vm.state} config={config} valueId={`${vmId(vm.name)}-state`} />);
 
+    const disksTabName = (<div id={`${vmId(vm.name)}-disks`}>{_("Disks")}</div>);
+    const consolesTabName = (<div id={`${vmId(vm.name)}-consoles`}>{_("Console")}</div>);
+
     let tabRenderers = [
         {name: _("Overview"), renderer: VmOverviewTab, data: {vm: vm, config: config }},
         {name: _("Usage"), renderer: VmUsageTab, data: {vm: vm}, presence: 'onlyActive' },
-        {name: (<div id={`${vmId(vm.name)}-disks`}>{_("Disks")}</div>), renderer: VmDisksTab, data: {vm: vm, provider: config.provider}, presence: 'onlyActive' }
+        {name: disksTabName, renderer: VmDisksTab, data: {vm: vm, provider: config.provider}, presence: 'onlyActive' },
+        {name: consolesTabName, renderer: GraphicsConsole, data: { vm, config, dispatch }}
     ];
     if (config.provider.vmTabRenderers) { // External Provider might extend the subtab list
         tabRenderers = tabRenderers.concat(config.provider.vmTabRenderers.map(
@@ -391,13 +400,14 @@ const Vm = ({ vm, config, onStart, onShutdown, onForceoff, onReboot, onForceRebo
             onStart, onReboot, onForceReboot, onShutdown, onForceoff})}/>);
 };
 Vm.propTypes = {
-    vm: React.PropTypes.object.isRequired,
-    config: React.PropTypes.object.isRequired,
-    onStart: React.PropTypes.func.isRequired,
-    onShutdown: React.PropTypes.func.isRequired,
-    onForceoff: React.PropTypes.func.isRequired,
-    onReboot: React.PropTypes.func.isRequired,
-    onForceReboot: React.PropTypes.func.isRequired
+    vm: PropTypes.object.isRequired,
+    config: PropTypes.object.isRequired,
+    onStart: PropTypes.func.isRequired,
+    onShutdown: PropTypes.func.isRequired,
+    onForceoff: PropTypes.func.isRequired,
+    onReboot: PropTypes.func.isRequired,
+    onForceReboot: PropTypes.func.isRequired,
+    dispatch: PropTypes.func.isRequired,
 };
 
 /**

--- a/pkg/machines/machines.less
+++ b/pkg/machines/machines.less
@@ -54,3 +54,86 @@
 .machines-listing-detail-top-column {
     vertical-align: top;
 }
+
+.machines-console-frame {
+    min-height: 555px;
+}
+
+.machines-console-frame-vnc {
+    min-height: 555px;
+    width: 100%;
+}
+
+.left-delimiter {
+    padding: 0 13px 0;
+}
+
+.left-delimiter + .left-delimiter {
+    border-left: 1px solid #d1d1d1;
+    padding-left: 15px;
+}
+
+.top-right-menu {
+    float: right;
+    padding-bottom: 5px;
+    position: absolute;
+    right: 5em;
+}
+
+.blue {
+    color: #4babdc;
+}
+
+.machines-desktop-delimiter {
+    margin-top: 20px;
+    margin-bottom: 0px;
+    border: 0;
+    border-top: 1px solid #cccccc;
+}
+
+.machines-desktop-main {
+    width: 100%;
+}
+
+.machines-desktop-main-col {
+    width: 50%;
+    text-align: center;
+    vertical-align: top;
+}
+
+.machines-desktop-manual-block {
+    margin-top: 1.5em;
+    margin-bottom: 1.5em;
+}
+
+.machines-desktop-viewer-block {
+    margin-top: 3em;
+    margin-bottom: 2.5em;
+}
+
+.machines-desktop-manual-con-details {
+    display: inline-block;
+    text-align: left;
+}
+
+.machines-desktop-shell-command {
+    color: #888;
+}
+
+.machines-desktop-more-info-text {
+    margin-left: 7em;
+    margin-right: 7em;
+    text-align: left;
+}
+
+.machines-desktop-install-instructs {
+    display: inline-block;
+}
+
+.machines-desktop-install-instructs-item {
+    text-align: left;
+}
+
+.machines-desktop-install-instructs-row {
+    display: inline-flex;
+}

--- a/pkg/machines/machines.less
+++ b/pkg/machines/machines.less
@@ -56,12 +56,13 @@
 }
 
 .machines-console-frame {
-    min-height: 555px;
+    height: 1px; /* keep at minimum, down-sizing does not work */
 }
 
 .machines-console-frame-vnc {
-    min-height: 555px;
     width: 100%;
+    height: 100%;
+    margin-top: -2em;
 }
 
 .left-delimiter {

--- a/pkg/machines/manifest.json.in
+++ b/pkg/machines/manifest.json.in
@@ -9,5 +9,6 @@
         "path": "index.html",
         "order": 60
      }
-  }
+  },
+  "content-security-policy": "default-src 'self' 'unsafe-inline' data:"
 }

--- a/pkg/machines/provider.es6
+++ b/pkg/machines/provider.es6
@@ -113,7 +113,7 @@ function getVirtProvider (store) {
 export function virt(method, action) {
     return (dispatch, getState) => getVirtProvider({dispatch, getState}).then(provider => {
         if (method in provider) {
-            logDebug(`Calling ${provider.name}.${method}(${JSON.stringify(action)})`);
+            logDebug(`Calling ${provider.name}.${method}`, action);
             return dispatch(provider[method](action));
         } else {
             console.warn(`method: '${method}' is not supported by provider: '${provider.name}'`);

--- a/pkg/machines/vnc.css
+++ b/pkg/machines/vnc.css
@@ -17,10 +17,11 @@
 
 .vnc-custom-body {
     margin: 0px;
+    overflow-y: hidden;
 }
 
 .vnc-custom-container {
-    height: calc(100% - 2.2em) !important;
+    height: inherit !important;
 }
 
 .vnc-custom-status-bar {

--- a/pkg/machines/vnc.css
+++ b/pkg/machines/vnc.css
@@ -1,0 +1,36 @@
+.vnc-main-menu {
+    background-color: white;
+    padding-bottom: 5px;
+    font-size: 13px;
+}
+
+.vnc-button {
+    background-color: #e7e7e7;
+    color: black;
+    border: none;
+    padding: 5px 15px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+}
+
+.vnc-custom-body {
+    margin: 0px;
+}
+
+.vnc-custom-container {
+    height: calc(100% - 2.2em) !important;
+}
+
+.vnc-custom-status-bar {
+    margin-top: 0px;
+    margin-bottom: 2px;
+}
+
+.vnc-custom-status-bar {
+    position: relative;
+    height: auto;
+}
+
+

--- a/pkg/machines/vnc.html
+++ b/pkg/machines/vnc.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <!--
+        noVNC wrapper based on
+            - https://github.com/novnc/noVNC/blob/master/vnc_auto.html
+            - cockpit/examples/poc-vnc
+
+    Connect parameters are provided in query string:
+        http://example.com/?host=HOST&port=PORT&encrypt=1&true_color=1
+    or the fragment:
+        http://example.com/#host=HOST&port=PORT&encrypt=1&true_color=1
+    -->
+    <title>noVNC</title>
+
+    <meta charset="utf-8">
+
+    <!-- Always force latest IE rendering engine (even in intranet) & Chrome Frame
+                Remove this if you use the .htaccess -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+    <!-- Apple iOS Safari settings -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <!-- App Start Icon  -->
+    <link rel="apple-touch-startup-image" href="images/screen_320x460.png" />
+    <!-- For iOS devices set the icon to use if user bookmarks app on their homescreen -->
+    <link rel="apple-touch-icon" href="images/screen_57x57.png">
+
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="include/base.css" title="plain">
+    <link rel="stylesheet" href="vnc.css">
+
+    <script src="include/util.js"></script>
+    <script src="../base1/jquery.js"></script>
+    <script src="../base1/cockpit.js"></script>
+
+</head>
+
+<body class="vnc-custom-body">
+    <div id="vnc-main-menu" class="vnc-main-menu">
+        Send shortcut: <a href="#" class="vnc-button" onclick="sendCtrlAltDel()">Ctrl+Alt+Del</a>
+    </div>
+
+    <div id="noVNC_container" class="vnc-custom-container">
+        <div id="noVNC_status_bar" class="noVNC_status_bar" class="vnc-custom-status-bar">
+            <table border=0 width="100%">
+                <tr>
+                    <td>
+                        <div id="noVNC_status" class="vnc-custom-status-bar">
+                            Loading
+                        </div>
+                    </td>
+                </tr>
+            </table>
+        </div>
+
+        <canvas id="noVNC_canvas" width="640px" height="20px" tabindex="0">
+           Canvas not supported.
+        </canvas>
+    </div>
+
+    <script>
+        /* global window, $, Util, RFB, */
+        "use strict";
+
+        /*
+            Unresolved issues when trying to bundle no-vnc js files:
+                - sources are not UMD modules (so no "require()")
+                - the "modules" are dynamically loading their dependencies (via "Util.load_scripts" call) but not consistently - "preload" is still required
+                - the "modules" have to be in "include" subdir as the "Util.load_scripts" expects
+        */
+        Util.load_scripts(["webutil.js", "base64.js", "websock.js", "des.js",
+                           "keysymdef.js", "keyboard.js", "input.js", "display.js",
+                           "inflator.js", "rfb.js", "keysym.js"]);
+
+        var rfb;
+        var resizeTimeout;
+
+        function UIresize() {
+            if (WebUtil.getConfigVar('resize', false)) {
+                console.log('Resizing noVNC');
+                var innerW = window.innerWidth;
+                var innerH = window.innerHeight;
+                var controlbarH = $D('noVNC_status_bar').offsetHeight + $D('vnc-main-menu').offsetHeight;
+                var padding = 5;
+                if (innerW !== undefined && innerH !== undefined) {
+                    var h = innerH - controlbarH - padding
+                    console.log('requestDesktopSize: ', innerW, h);
+                    rfb.requestDesktopSize(innerW, h);
+                }
+            }
+        }
+        function FBUComplete(rfb, fbu) {
+            UIresize();
+            rfb.set_onFBUComplete(function() { });
+            console.log('Setting focus');
+            $D('noVNC_canvas').focus();
+        }
+        function passwordRequired(rfb) {
+            var msg;
+            msg = '<form onsubmit="return setPassword();"';
+            msg += '  style="margin-bottom: 0px">';
+            msg += 'Password Required: ';
+            msg += '<input type=password size=10 id="password_input" class="noVNC_status">';
+            msg += '<\/form>';
+            $D('noVNC_status_bar').setAttribute("class", "noVNC_status_warn");
+            $D('noVNC_status').innerHTML = msg;
+        }
+        function setPassword() {
+            rfb.sendPassword($D('password_input').value);
+            return false;
+        }
+        function sendCtrlAltDel() {
+            rfb.sendCtrlAltDel();
+            return false;
+        }
+
+        function updateState(rfb, state, oldstate, msg) {
+            var s, sb, cad, level;
+            s = $D('noVNC_status');
+            sb = $D('noVNC_status_bar');
+            switch (state) {
+                case 'failed':       level = "error";  break;
+                case 'fatal':        level = "error";  break;
+                case 'normal':       level = "normal"; break;
+                case 'disconnected': level = "normal"; break;
+                case 'loaded':       level = "normal"; break;
+                default:             level = "warn";   break;
+            }
+
+            if (typeof(msg) !== 'undefined') {
+                sb.setAttribute("class", "noVNC_status_" + level);
+                s.textContent = msg;
+            }
+        }
+
+        window.onresize = function () {
+            // When the window has been resized, wait until the size remains
+            // the same for 0.5 seconds before sending the request for changing
+            // the resolution of the session
+            clearTimeout(resizeTimeout);
+            resizeTimeout = setTimeout(function(){
+                UIresize();
+            }, 500);
+        };
+
+        function parseParams() {
+            var params = {
+                host: WebUtil.getConfigVar('host', 'host not provided in params'),
+                port: WebUtil.getConfigVar('port', 'port not provided in params'),
+                password: WebUtil.getConfigVar('password', ''),
+                encrypt: WebUtil.getConfigVar('encrypt', (window.location.protocol === "https:")),
+                true_color: WebUtil.getConfigVar('true_color', true),
+                local_cursor: WebUtil.getConfigVar('cursor', true),
+                shared: WebUtil.getConfigVar('shared', true),
+                view_only: WebUtil.getConfigVar('view_only', false),
+                repeaterID: WebUtil.getConfigVar('repeaterID', ''),
+
+                logging: WebUtil.getConfigVar('logging', 'warn'),
+                title: WebUtil.getConfigVar('title', 'noVNC'),
+            };
+
+            if ((!params.host) || (!params.port)) {
+                updateState(null, 'fatal', null, 'Must specify host and port in URL');
+                return;
+            }
+
+            return params;
+        }
+
+        function connect(path, params) {
+            try {
+                rfb = new RFB({
+                    'target':       $D('noVNC_canvas'),
+                    'encrypt':      params.encrypt,
+                    'repeaterID':   params.repeaterID,
+                    'true_color':   params.true_color,
+                    'local_cursor': params.local_cursor,
+                    'shared':       params.shared,
+                    'view_only':    params.view_only,
+
+                    'onUpdateState':  updateState,
+                    'onXvpInit':    function () {},
+                    'onPasswordRequired':  passwordRequired,
+                    'onFBUComplete': FBUComplete});
+            } catch (exc) {
+                updateState(null, 'fatal', null, 'Unable to create RFB client -- ' + exc);
+                return; // don't continue trying to connect
+            }
+
+            rfb.connect(window.location.hostname, window.location.port, params.password, path);
+        }
+
+        window.onscriptsload = function () {
+            var params = parseParams();
+
+            WebUtil.init_logging(params.logging);
+            document.title = unescape(params.title);
+
+            // connect
+            var query = window.btoa(JSON.stringify({
+                payload: "stream",
+                protocol: "binary",
+                address: params.host,
+                port: parseInt(params.port, 10),
+                binary: "raw",
+            }));
+
+            console.log(cockpit, cockpit.transport);
+            console.log("channel", params.port);
+            cockpit.transport.wait(function () {
+                connect("cockpit/channel/" + cockpit.transport.csrf_token + "?" + query, params);
+            });
+        };
+        </script>
+
+    </body>
+</html>

--- a/pkg/machines/vnc.html
+++ b/pkg/machines/vnc.html
@@ -78,18 +78,21 @@
         var rfb;
         var resizeTimeout;
 
-        function UIresize() {
+        function UIresize() { 
+            var containerId = decodeURIComponent(WebUtil.getConfigVar('containerId', ''));
+            if (!containerId) {
+                console.error("containerId not found in no-vnc frame params!");
+                return ;
+            }
+
+            // Normally, the frame/container size shall resize the VM.
+            // Since this is not working, let's do it vice-versa: adapt browser's component height according to inner display's size.
+            // Another workaround is in canvas resizing which effectively leads to scaling. But this seems not look good.
             if (WebUtil.getConfigVar('resize', false)) {
-                console.log('Resizing noVNC');
-                var innerW = window.innerWidth;
-                var innerH = window.innerHeight;
-                var controlbarH = $D('noVNC_status_bar').offsetHeight + $D('vnc-main-menu').offsetHeight;
-                var padding = 5;
-                if (innerW !== undefined && innerH !== undefined) {
-                    var h = innerH - controlbarH - padding
-                    console.log('requestDesktopSize: ', innerW, h);
-                    rfb.requestDesktopSize(innerW, h);
-                }
+                var height = ($D('noVNC_canvas').height + 60)+ "px";
+                console.log('Resizing noVNC, height = ', height);
+                $("#" + containerId, window.parent.document)[0].style.height = height;
+                // no need to resize width - already 100%, potential scrollbar
             }
         }
         function FBUComplete(rfb, fbu) {

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -212,6 +212,9 @@ class TestMachines(MachineCase):
         b.wait_present("#test-vm-action-{0}".format(self.providerVm1_name)) # is provider-specific action button rendered?
         b.wait_in_text("#test-vm-props-{0}".format(self.providerVm1_name), "Test Provider Property") # are provider-specific VM props rendered?
 
+        b.click("{0}-off-caret".format(self.providerVm1_id))
+        b.wait_visible("{0}-off".format(self.providerVm1_id))
+
         b.click("{0}-off".format(self.providerVm1_id)) # click the Shut Down button
         b.wait_in_text("{0}-state".format(self.providerVm1_id), "shut off")
 

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -61,7 +61,7 @@ class TestMachines(MachineCase):
 
         m.execute("qemu-img create -f qcow2 {0} 1G".format(self.vm1_img))
         m.execute("qemu-img create -f qcow2 {0} 2G".format(self.vm1_img2))
-        m.execute("virt-install --cpu host -r 128 --pxe --force --nographics --noautoconsole "
+        m.execute("virt-install --cpu host -r 128 --pxe --force --graphics spice,listen=127.0.0.1 --noautoconsole "
                   "--disk path={0},size=1,format=qcow2 --disk path={1},size=2,format=qcow2 "
                   "--boot hd,network "
                   "-n {2} || true"
@@ -227,6 +227,32 @@ class TestMachines(MachineCase):
         b.wait_visible("{0}-vcpus".format(self.providerVm1_id)) # wait till the tab is fully rendered
         b.wait_present("{0}-last-message".format(self.providerVm1_id))
         b.wait_in_text("{0}-last-message".format(self.providerVm1_id), "VM failed to start")
+
+    def testConsoles(self):
+        state = self.envSetup()
+
+        b = self.browser
+
+        if state == "running":
+            b.click("tbody tr th") # click on the row header
+            b.wait_present("{0}-state".format(self.vm1_id))
+            b.wait_in_text("{0}-state".format(self.vm1_id), state) # running or paused
+
+            b.wait_present("{0}-consoles".format(self.vm1_id)) # wait for the tab
+            b.click("{0}-consoles".format(self.vm1_id)) # open the "Console" subtab
+
+            # since VNC is not defined for this VM, the view for "Desktop Viewer" is rendered by default
+            b.wait_present("{0}-consoles-manual-address".format(self.vm1_id)) # wait for the tab
+            b.wait_in_text("{0}-consoles-manual-address".format(self.vm1_id), "127.0.0.1")
+            b.wait_in_text("{0}-consoles-manual-port-spice".format(self.vm1_id), "5900")
+
+            b.wait_present("{0}-consoles-launch".format(self.vm1_id)) # "Launch Remote Viewer" button
+            b.click("{0}-consoles-launch".format(self.vm1_id))
+            b.wait_present("#dynamically-generated-file") # is .vv file generated for download?
+            self.assertEqual(b.attr("#dynamically-generated-file", "href"), u"data:application/x-virt-viewer,%5Bvirt-viewer%5D%0Atype%3Dspice%0Ahost%3D127.0.0.1%0Aport%3D5900%0Adelete-this-file%3D1%0Afullscreen%3D0%0A")
+        else:
+            print "WARNING: Test VM creation failed, virt-install finished in 'paused' state. Skipping the 'testConsoles' scenario"
+
 
 if __name__ == '__main__':
     test_main()

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -36,19 +36,20 @@ def template_licenses(template):
 def module_license(moddir):
     '''Return License: short name for given module'''
 
-    # First check if bower.json has a "license" field
-    try:
-        with open(os.path.join(moddir, 'bower.json')) as f:
-            l = json.load(f)['license']
-            if 'and MIT' in l:
-                # https://github.com/requirejs/requirejs/issues/1645
-                return 'MIT'
-            if os.path.basename(moddir) == 'qunit' and 'https://' in l:
-                # fixed in 2.1.0 (https://github.com/qunitjs/qunit/commit/6e3f6e8e40c4)
-                return 'MIT'
-            return l
-    except (IOError, KeyError):
-        pass
+    # First check if bower.json or package.json has a "license" field
+    for f in ['bower.json', 'package.json']:
+        try:
+            with open(os.path.join(moddir, f)) as f:
+                l = json.load(f)['license']
+                if 'and MIT' in l:
+                    # https://github.com/requirejs/requirejs/issues/1645
+                    return 'MIT'
+                if os.path.basename(moddir) == 'qunit' and 'https://' in l:
+                    # fixed in 2.1.0 (https://github.com/qunitjs/qunit/commit/6e3f6e8e40c4)
+                    return 'MIT'
+                return l
+        except (IOError, KeyError):
+            pass
 
     # *LICENSE*/COPYING/README
     if os.path.exists(os.path.join(moddir, 'MIT-LICENSE.txt')):

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -47,6 +47,9 @@ def module_license(moddir):
                 if os.path.basename(moddir) == 'qunit' and 'https://' in l:
                     # fixed in 2.1.0 (https://github.com/qunitjs/qunit/commit/6e3f6e8e40c4)
                     return 'MIT'
+                if l == 'MPL 2.0':
+                    # https://github.com/novnc/noVNC/pull/819
+                    return 'MPL-2.0'
                 return l
         except (IOError, KeyError):
             pass

--- a/tools/check-dist
+++ b/tools/check-dist
@@ -10,10 +10,10 @@ done
 
 # Make sure files are patchable
 find $1/dist -type f | while read file; do
-
     # We don't care about these files
     case $file in
-    *.png|*.svg|*.gif|*.map|*.woff)
+    *.png|*.svg|*.gif|*.map|*.woff|*.ttf|*.gz| \
+    *machines/include/logo.js)
         continue
         ;;
     esac

--- a/tools/debian/copyright.template
+++ b/tools/debian/copyright.template
@@ -195,3 +195,8 @@ License: Apache-2.0
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
+
+License: MPL-2.0
+ This Source Code Form is subject to the terms of the Mozilla Public License,
+ v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ obtain one at https://mozilla.org/MPL/2.0/.

--- a/tools/debian/source/lintian-overrides
+++ b/tools/debian/source/lintian-overrides
@@ -4,3 +4,5 @@ cockpit source: source-is-missing bower_components/*
 cockpit source: source-is-missing dist/*.js*
 # false-positive heuristics, this is actual source
 cockpit source: source-is-missing pkg/kubernetes/scripts/test-images.js line length*
+# pkg/machines/include is symlink to bower_compoents/no-vnc/include and content is meant as downloadable resource at runtime
+cockpit source: source-is-missing pkg/machines/include/*

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -131,6 +131,8 @@ function generateDeps(makefile, stats) {
             !endsWith(output, "shell/simple.html") &&
             !endsWith(output, ".png") &&
             !endsWith(output, ".map") &&
+            !endsWith(output, ".ttf") &&
+            !endsWith(output, ".woff") &&
             !endsWith(output, ".gif")) {
             install += ".gz";
         }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -174,6 +174,9 @@ var info = {
 
         "machines/index.html",
         "machines/manifest.json",
+        "machines/vnc.html",
+        "machines/vnc.css",
+	// no-vnc files from machines/include are added dynamically later
 
         "networkmanager/index.html",
         "networkmanager/manifest.json",
@@ -262,6 +265,16 @@ var section = process.env.ONLYDIR || null;
 
 /* A standard nodejs and webpack pattern */
 var production = process.env.NODE_ENV === 'production';
+
+/* Dynamically add no-vnc dependencies to the info.files */
+var noVncIncludes = fs.readdirSync(bowerdir + "/no-vnc/include")
+    .filter(function (fileName) {
+	return fileName.match(/.*(js|css|ttf|woff)$/);
+    })
+    .map(function (fileName) {
+        return "machines/include/" + fileName;
+    });
+Array.prototype.push.apply(info.files, noVncIncludes);
 
 /*
  * Note that we're avoiding the use of path.join as webpack and nodejs


### PR DESCRIPTION
With this patch, graphics console(s) can be retrieved for a VM.

Console connection details are retrieved from VM's domail.xml.
To play around, please be sure the test VM is created with appropriate external IP set for the console.
Example for `virt-install`:
  `virt-install --graphics spice,listen=[external host IP]`

So far tested for:
- VNC (virt-viewer)
- SPICE (virt-viewer)
- in browser console via noVnc

The virt-viewer is invoked by downloading a .vv file of `application/x-virt-viewer` mime type.

Following other projects were taken into consideration for the console-in-browser feature:
- spice-html5
- [broadwayd](https://dummdida.tumblr.com/post/131044606675/view-your-gtk3-app-or-vm-on-the-web)

The `broadwayd` is cool but heavy-weight, requiring a lot of client-side dependencies on server.

The `spice-html5` is working for basic scenarios but has multiple limitations so we can't consider it as a full-feature solution. In addition, community support is very limited.

-----
The cockpit-machines newly sets
    "content-security-policy": "default-src 'self' '**unsafe-inline**' data:"
to make the no-vnc and download of dynamically generated files (the .vv) working.

 - [x] fix or disable inline VNC with plain http://
 - [x] integration tests
 - [ ] get design sign-off from @garrett 
 - [x] make VNC window larger and/or resizable to avoid scrolling inside the widget
 - [x] address `check-machines TestMachines.testBasic failure on ubuntu-*` test failure