### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ depcomp
 *.min.html
 /src/ws/cockpit.appdata.xml
 /src/ws/cockpit.desktop
+/src/ws/cockpit.service
 src/common/cockpitassets.c
 src/common/cockpitassets.h
 /po/.intltool-merge-cache
@@ -131,6 +132,7 @@ org.freedesktop.UDisks2.h
 /pkg/*/*.min.js.gz
 /pkg/*/*.min.css.gz
 /pkg/*/*.min.html.gz
+/pkg/*/manifest.json
 /src/base1/*.min.js
 /src/base1/*.min.css
 /src/base1/*.gz


### PR DESCRIPTION
Commit 15dc531e24 moved pkg/*/manifest.json from tracked to built files
(from *.json.in). src/ws/cockpit.service gets built from *.service.in.

---

Now "git status" is clean again in a built tree.