### PR TITLE
tools: Add missing packaging control fields for -test-assets rename

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -586,6 +586,8 @@ Summary: Tests for Cockpit
 Requires: %{name}-bridge >= %{required_base}
 Requires: %{name}-shell >= %{required_base}
 Requires: openssh-clients
+Provides: %{name}-test-assets
+Obsoletes: %{name}-test-assets < 132
 
 %description tests
 This package contains tests and files used while testing Cockpit.

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -146,6 +146,9 @@ Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
          openssh-client
+Conflicts: cockpit-test-assets
+Replaces: cockpit-test-assets
+Provides: cockpit-test-assets
 Description: Tests for Cockpit
  This package contains tests and files used while testing Cockpit.
  These files are not required for running Cockpit.


### PR DESCRIPTION
cockpit-test-assets was renamed to cockpit-tests in commit 93cf8951a99.
Add the corresponding packaging declarations so that package managers
handle this properly.