### PR TITLE
ws: Update Makefile to prevent target override

### DIFF
--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -368,7 +368,7 @@ noinst_SCRIPTS += \
 TESTS += $(WS_CHECKS)
 
 mock_pam_conv_mod_so_SOURCES = src/ws/mock-pam-conv-mod.c
-mock-pam-conv-mod.so: $(mock_pam_conv_mod_so_SOURCES)
+mock-pam-conv-mod.so$(EXEEXT): $(mock_pam_conv_mod_so_SOURCES)
 	$(AM_V_CCLD) $(CC) -fPIC -shared $(CFLAGS) -I$(builddir) \
 		-o $@ $^ $(PAM_LIBS) $(LDFLAGS)
 


### PR DESCRIPTION
Previous builds showed this output on my machine:
```
src/ws/Makefile-ws.am:373: warning: deprecated feature: target 'mock-pam-conv-mod.so' overrides 'mock-pam-conv-mod.so$(EXEEXT)'
src/ws/Makefile-ws.am:373: change your target to read 'mock-pam-conv-mod.so$(EXEEXT)'
Makefile.am:397:   'src/ws/Makefile-ws.am' included from here
/usr/share/automake-1.15/am/program.am: target 'mock-pam-conv-mod.so$(EXEEXT)' was defined here
Makefile.am:11:   while processing program 'mock-pam-conv-mod.so'
```
This pull request implements the recommended change.
