### PR TITLE
Image refresh for debian-testing

### DIFF
--- a/test/images/debian-testing
+++ b/test/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-900187b6c257bdbcb7c368712f3332a4b3356036.qcow2
+debian-testing-394d140b4adbcffc5d5f43746e062c34c2731e23.qcow2


### PR DESCRIPTION
Image creation for debian-testing in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-testing-2017-02-23/