### PR TITLE
Makefile: Fix up install-tests target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -278,13 +278,6 @@ recheck-memory: valgrind-suppressions
 	        HTML_LOG_FLAGS="valgrind $(VALGRIND_ARGS)" \
 		$(AM_MAKEFLAGS) recheck
 
-testassetsdir = $(prefix)/lib/cockpit-test-assets
-testassets_data =
-
-install-test-assets: $(testassets_data)
-	$(MKDIR_P) $(DESTDIR)$(testassetsdir)
-	cd $(srcdir); for d in $(testassets_data); do $(INSTALL_DATA) -D $$d $(DESTDIR)$(testassetsdir)/$$d; done
-
 install-data-hook::
 	mkdir -p $(DESTDIR)$(localstatedir)/lib/cockpit
 	chgrp wheel $(DESTDIR)$(localstatedir)/lib/cockpit || true

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -209,7 +209,6 @@ EXTRA_DIST += \
 	$(appdata_in) \
 	$(desktop_in) \
 	$(pixmap_DATA) \
-	src/ws/fatal.conf \
 	$(NULL)
 
 # ----------------------------------------------------------------------------------------------------
@@ -372,20 +371,17 @@ mock-pam-conv-mod.so$(EXEEXT): $(mock_pam_conv_mod_so_SOURCES)
 	$(AM_V_CCLD) $(CC) -fPIC -shared $(CFLAGS) -I$(builddir) \
 		-o $@ $^ $(PAM_LIBS) $(LDFLAGS)
 
-noinst_PROGRAMS += \
-	mock-pam-conv-mod.so \
-	$(NULL)
+noinst_PROGRAMS += mock-pam-conv-mod.so
+CLEANFILES += mock-pam-conv-mod.so
+EXTRA_DIST += src/ws/fatal.conf
 
-testassets_data += \
-	mock-pam-conv-mod.so \
-	$(NULL)
+testassetsdir = $(prefix)/lib/cockpit-test-assets
+testserviceddir = $(systemdunitdir)/cockpit.service.d
 
-CLEANFILES += \
-	mock-pam-conv-mod.so \
-	$(NULL)
-
-systemdserviceddir = $(sysconfdir)/systemd/system/cockpit.service.d
-systemdserviced_DATA = src/ws/fatal.conf
+install-tests::
+	$(MKDIR_P) $(DESTDIR)$(testassetsdir) $(DESTDIR)$(testserviceddir)
+	$(INSTALL_DATA) mock-pam-conv-mod.so $(DESTDIR)$(testassetsdir)
+	$(INSTALL_DATA) $(srcdir)/src/ws/fatal.conf $(DESTDIR)$(testserviceddir)
 
 install-exec-hook::
 	mkdir -p $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -148,7 +148,7 @@ make -j4 check
 
 %install
 make install DESTDIR=%{buildroot}
-make install-test-assets DESTDIR=%{buildroot}
+make install-tests DESTDIR=%{buildroot}
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/pam.d
 install -p -m 644 tools/cockpit.pam $RPM_BUILD_ROOT%{_sysconfdir}/pam.d/cockpit
 rm -f %{buildroot}/%{_libdir}/cockpit/*.so
@@ -424,6 +424,23 @@ This package contains the Cockpit shell and system configuration interfaces.
 
 %files system -f system.list
 
+%package tests
+Summary: Tests for Cockpit
+Requires: %{name}-bridge >= %{required_base}
+Requires: %{name}-shell >= %{required_base}
+Requires: openssh-clients
+Provides: %{name}-test-assets
+Obsoletes: %{name}-test-assets < 132
+
+%description tests
+This package contains tests and files used while testing Cockpit.
+These files are not required for running Cockpit.
+
+%files tests
+%{_unitdir}/cockpit.service.d
+%{_datadir}/%{name}/playground
+%{_prefix}/lib/cockpit-test-assets
+
 %package ws
 Summary: Cockpit Web Service
 Requires: glib-networking
@@ -587,23 +604,6 @@ cluster. Installed on the Kubernetes master. This package is not yet complete.
 %{_libexecdir}/cockpit-kube-launch
 
 %endif
-
-%package tests
-Summary: Tests for Cockpit
-Requires: %{name}-bridge >= %{required_base}
-Requires: %{name}-shell >= %{required_base}
-Requires: openssh-clients
-Provides: %{name}-test-assets
-Obsoletes: %{name}-test-assets < 132
-
-%description tests
-This package contains tests and files used while testing Cockpit.
-These files are not required for running Cockpit.
-
-%files tests
-%{_sysconfdir}/systemd/system/cockpit.service.d
-%{_datadir}/%{name}/playground
-%{_prefix}/lib/cockpit-test-assets
 
 # The changelog is automatically generated and merged
 %changelog

--- a/tools/debian/cockpit-tests.install
+++ b/tools/debian/cockpit-tests.install
@@ -1,3 +1,1 @@
-etc/systemd/system/cockpit.service.d
 usr/share/cockpit/playground
-usr/lib/cockpit-test-assets

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -18,7 +18,7 @@ override_dh_auto_configure:
 		--libexecdir=/usr/lib/cockpit $(CONFIG_OPTIONS)
 
 override_dh_auto_install:
-	dh_auto_install -- install-test-assets
+	dh_auto_install
 	mkdir -p debian/tmp/etc/pam.d
 	install -p -m 644 tools/cockpit.debian.pam debian/tmp/etc/pam.d/cockpit
 
@@ -30,6 +30,7 @@ override_dh_systemd_start:
 
 override_dh_install:
 	dh_install --list-missing -Xusr/src/debug
+	make install-tests DESTDIR=debian/cockpit-tests
 
 override_dh_fixperms:
 	dh_fixperms -Xcockpit-session -Xcockpit-polkit


### PR DESCRIPTION
Fix up the install-tests target. And always build the
cockpit-tests RPM subpackage. We want to start shipping
real tests in here.