### PR TITLE
docker: Depend on either docker, docker-latest, or docker-engine in RPMs

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -564,7 +564,12 @@ utility setroubleshoot to diagnose and resolve SELinux issues.
 Summary: Cockpit user interface for Docker containers
 Requires: %{name}-bridge >= %{required_base}
 Requires: %{name}-shell >= %{required_base}
+# Fedora, and upstream Docker 'Provide' docker-engine
+%if 0%{?rhel}%{?centos} == 0
+Requires: docker-engine >= 1.3.0
+%else
 Requires: docker >= 1.3.0
+%endif
 Requires: python
 
 %description docker


### PR DESCRIPTION
This allows alternate packages that provide the same file.

Fixes #5769