### PR TITLE
test: Check for specific operating systems in tests, not features

### DIFF
--- a/test/verify/check-networking-mac
+++ b/test/verify/check-networking-mac
@@ -78,7 +78,7 @@ class TestNetworking(NetworkCase):
         mac = m.execute("cat /sys/class/net/tbond/address").strip()
         b.wait_text("#network-interface-mac", mac.upper())
 
-        if self.networkmanager_version >= [ 1, 6, 0 ]:
+        if m.image in [ "debian-testing" ]:
             new_mac = m.reserve_macaddr()
             b.click("#network-interface-mac a")
             b.wait_popup("network-mac-settings-dialog")


### PR DESCRIPTION
This is general thing, but we should be checking for specific
operating systems in our tests, not making decisions based
on features. This has bitten us many times in the past where
a feature regressed on an operating system without the tests
telling us about it.

In the actual UI code the opposite is obviously true.