### PR TITLE
networkmanager: Fix "Ethernet MTU" dialog layout

### DIFF
--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -171,7 +171,7 @@ span.inverted-switchbox {
     margin-right: 0.5em;
 }
 
-#network-mtu-settings-mtu-input {
+#network-mtu-settings-input {
     margin-left: 0.5em;
     width: 5em;
     display: inline;


### PR DESCRIPTION
The CSS wasn't correctly updated in

    fdb7237 * networkmanager: Rename "ethernet settings" to just "mtu settings"