### PR TITLE
Fix a couple translation whitespace issues

### DIFF
--- a/pkg/kubernetes/views/deploymentconfig-body.html
+++ b/pkg/kubernetes/views/deploymentconfig-body.html
@@ -14,7 +14,7 @@
 
             <dt translate>Latest Version</dt>
             <dd ng-if="item.status.latestVersion">{{ item.status.latestVersion }}</dd>
-            <dd ng-if="!item.status.latestVersion" translate>Not deployed</td>
+            <dd ng-if="!item.status.latestVersion" translate>Not deployed</dd>
         </dl>
     </div>
     <div class="col-sm-6">

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -256,9 +256,7 @@
                                             <dt>
                                                 <a tabindex="0" role="button" data-toggle="popover"
                                                     data-trigger="focus" data-placement="top"
-                                                    data-content="Tip: Make your key password match
-                                                    your login password to automatically authenticate
-                                                    against other systems." translate="data-content">
+                                                    data-content="Tip: Make your key password match your login password to automatically authenticate against other systems." translate="data-content">
                                                     <span class="fa fa-lg fa-info-circle"></span>
                                                 </a>
                                             </dt>


### PR DESCRIPTION
Translatable strings need to avoid having whitespace in them
in order to be parsed and translated properly.