### PR TITLE
Force use of phantomjs 2.1.7

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -246,7 +246,7 @@ SH_LOG_DRIVER = $(top_srcdir)/tools/tap-driver
 HTML_LOG_DRIVER = $(top_srcdir)/tools/tap-driver
 HTML_TEST_SERVER = $(builddir)/test-server
 if WITH_PHANTOMJS
-HTML_LOG_COMPILER = $(top_srcdir)/tools/tap-phantom --strip=$(top_srcdir)/ -- $(HTML_TEST_SERVER)
+HTML_LOG_COMPILER = $(PHANTOMJS) $(top_srcdir)/tools/tap-phantom --strip=$(top_srcdir)/ -- $(HTML_TEST_SERVER)
 else
 HTML_LOG_DRIVER_FLAGS = --missing=phantomjs
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -292,8 +292,9 @@ fi
 
 # phantomjs
 
-AC_PATH_PROG([PHANTOMJS], [phantomjs], [], [$PATH$PATH_SEPARATOR$srcdir/node_modules/.bin/])
+AC_PATH_PROG([PHANTOMJS], [phantomjs], [], [$srcdir/node_modules/.bin$PATH_SEPARATOR$PATH])
 AM_CONDITIONAL([WITH_PHANTOMJS], [test -n "$PHANTOMJS"])
+AC_SUBST([PHANTOMJS])
 
 # go
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "less": "~2.6.0",
     "less-loader": "~2.2.3",
     "ng-cache-loader": "0.0.16",
-    "phantomjs-prebuilt": "~2.1.14",
+    "phantomjs-prebuilt": "2.1.7",
     "po2json": "~0.4.1",
     "promise": "~7.1.1",
     "raw-loader": "~0.5.1",

--- a/test/common/phantom-command
+++ b/test/common/phantom-command
@@ -1,4 +1,4 @@
 #!/bin/sh
 BASE=$(dirname $0)
-PATH="$PATH:$BASE/../../node_modules/.bin"
+PATH="$BASE/../../node_modules/.bin:$PATH"
 exec phantomjs --ignore-ssl-errors=true --ssl-protocol=any $@

--- a/test/common/phantom-driver.js
+++ b/test/common/phantom-driver.js
@@ -42,8 +42,12 @@
  * a screenshot, and "keys" to send key events.
  */
 
-var page = require('webpage').create();
 var sys = require('system');
+
+/* HACK: Figuring out which version of phantomjs we're running */
+sys.stderr.writeLine("phantomjs version: " + JSON.stringify(phantom.version));
+
+var page = require('webpage').create();
 var clearedStorage = false;
 var messages = "";
 var onCheckpoint;


### PR DESCRIPTION
We want to figure out which version of phantomjs avoids the 'Network access is disabled' problems. Lets try 2.1.7

See the commits for the steps that make this work.