### PR TITLE
test: Test against docker-latest on Fedora 25

### DIFF
--- a/test/images/fedora-25
+++ b/test/images/fedora-25
@@ -1,1 +1,1 @@
-fedora-25-55e43c9221cab6864374ac5ab556a9dacdc9cc18.qcow2
+fedora-25-72af2f835d70af73d8955823c6bf4d226ee77d55.qcow2

--- a/test/images/scripts/fedora-25.setup
+++ b/test/images/scripts/fedora-25.setup
@@ -18,7 +18,6 @@ echo foobar | passwd --stdin root
 COCKPIT_DEPS="\
 atomic \
 device-mapper-multipath \
-docker \
 etcd \
 glib-networking \
 json-glib \
@@ -42,6 +41,10 @@ subscription-manager \
 tuned \
 virt-install \
 "
+
+# On the latest Fedora we mix things up a bit and install docker-latest
+# which Fedora and RHEL package as a more up to date version of docker
+COCKPIT_DEPS="$COCKPIT_DEPS docker-latest"
 
 # We also install the packages necessary to join a FreeIPA domain so
 # that we don't have to go to the network during a test run.


### PR DESCRIPTION
There are now two versions of Docker being shipped by Red Hat
docker and docker-latest. We need to test against both, so test
against the later one in Fedora.