### PR TITLE
test: Only print about coredumps if we actually downloaded them

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -24,6 +24,7 @@ Tools for writing Cockpit test cases.
 from time import sleep
 
 import argparse
+import errno
 import fnmatch
 import subprocess
 import os
@@ -701,9 +702,10 @@ class MachineCase(unittest.TestCase):
                 m.download_dir("/var/lib/systemd/coredump", dest)
                 try:
                     os.rmdir(dest)
-                except OSError:
-                    print "Core dumps downloaded to %s" % (dest)
-                    attach(dest)
+                except OSError, ex:
+                    if ex.errno == errno.ENOTEMPTY:
+                        print "Core dumps downloaded to %s" % (dest)
+                        attach(dest)
 
 some_failed = False
 


### PR DESCRIPTION
Only print about downloading coredumps to a directory if we actually
downloaded something. Previously we were printing the message
erronuously.