### PR TITLE
bridge: Migrate /var/lib/cockpit/machines.json to /etc

### DIFF
--- a/doc/guide/feature-machines.xml
+++ b/doc/guide/feature-machines.xml
@@ -15,15 +15,95 @@
   <para>Using SSH keys is only supported when the system has the
     necessary APIs in libssh.</para>
 
-  <para>There is currently no command line interface for adding and/or removing
-    machines from the dashboard. The machine data is stored in
-    <filename>/etc/cockpit/machines.d/*.json</filename>. Settings in
+  <para>SSH host keys are stored in
+    <filename>/var/lib/cockpit/known_hosts</filename>.</para>
+
+  <para>The machine data is stored in
+    <filename>/etc/cockpit/machines.d/*.json</filename>.  Settings in
     lexicographically later files amend or override settings in earlier ones.
-    Cockpit itself writes into <filename>99-webui.json</filename>;
-    packages or admins who want to pre-configure machines should ship files
-    like <filename>05-mymachine.json</filename> so that changes from the web
+    Cockpit itself writes into <filename>99-webui.json</filename>; packages or
+    admins who want to pre-configure machines should ship files like
+    <filename>05-mymachine.json</filename> so that changes from the web
     interface override the pre-configured files.</para>
 
-  <para>SSH host keys are stored in
-     <filename>/var/lib/cockpit/known_hosts</filename>.</para>
+  <para>Each JSON file contains an object that maps machine IDs to objects that
+    define the properties of that machine. The ID can be a human readable name
+    or an IP address or any other unique value, and is shown in the web
+    interface until conneting to it the first time, at which point the web
+    interface will show the machine's host name.</para>
+
+  <para>The following properties are recognized:</para>
+
+  <variablelist>
+    <varlistentry>
+      <term><code>"address"</code></term>
+      <listitem><para><emphasis>(string, mandatory)</emphasis> IP address or
+          DNS name of the machine</para></listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <term><code>"visible"</code></term>
+      <listitem><para><emphasis>(boolean, optional)</emphasis> If
+          <code>true</code>, the machine will be displayed and
+          available for managing with Cockpit. If <code>false</code> (the
+          default), it will not be displayed, but still taken into account for
+          type-ahead search when adding new machines in the web
+          interface.</para></listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <term><code>"user"</code></term>
+      <listitem><para><emphasis>(string, optional)</emphasis> User name on the remote machine.
+          When not given, Cockpit will default to the user name that was being
+          used to log into Cockpit itself.</para></listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <term><code>"port"</code></term>
+      <listitem><para><emphasis>(integer, optional)</emphasis> ssh port of the
+          remote machine. When not given, the default port 22 is used.
+          </para></listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <term><code>"color"</code></term>
+      <listitem><para><emphasis>(string, optional)</emphasis> Color to
+          assign to the machine label in the web interface. This can be either given as
+          <code>rgb(r_value, g_value, b_value)</code> with each value being an
+          integer between 0 and 255, or as a color name like <code>yellow</code>.
+          When not given, Cockpit will assign an unused color automatically.
+          </para></listitem>
+    </varlistentry>
+
+    <!-- TODO: This cannot sensibly be used right now, as this neither accepts
+         a full (foreign) URL nor a relative path in the dist/ directory
+    <varlistentry>
+      <term><code>"avatar"</code></term>
+      <listitem><para><emphasis>(string, optional)</emphasis> Path to an image
+          file that will be shown as an icon for that machine in the web
+          interface. If not given, a generic "computer" icon is used.
+          </para></listitem>
+    </varlistentry>
+    -->
+  </variablelist>
+
+  <para>Example:</para>
+  <programlisting>
+{
+    "web server": {
+        "address": "192.168.2.4",
+        "visible": true,
+        "color": "rgb(100, 200, 0)",
+        "user": "admin"
+    },
+    "192.168.2.1": {
+        "address": "192.168.2.1",
+        "port": 2222,
+        "visible": true,
+        "color": "green"
+    }
+}</programlisting>
+
+  <para>There is currently no command line interface for adding and/or removing
+    machines from the dashboard.</para>
 </chapter>

--- a/src/bridge/cockpitdbusmachines.c
+++ b/src/bridge/cockpitdbusmachines.c
@@ -163,8 +163,9 @@ read_machines_json (void)
       return NULL;
     }
 
-  /* also read /var/lib/cockpit/machines.json for backwards compat */
-  conf_glob.gl_pathv[0] = "/var/lib/cockpit/machines.json";
+  /* also read /var/lib/cockpit/machines.json for backwards compat; except when
+   * running unit tests, then disable this (this is covered by an integration test) */
+  conf_glob.gl_pathv[0] = g_getenv ("COCKPIT_TEST_CONFIG_DIR") ? "/dev/null" : "/var/lib/cockpit/machines.json";
 
   /* start with an empty object */
   machines = new_object_node ();

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -274,15 +274,39 @@ class TestDashboardSetup(MachineCase, DashBoardHelpers):
         m2.execute("ps aux | grep cockpit-bridge | grep admin")
         self.allow_hostkey_messages()
 
-    def testMachinesJsonVar(self):
+    def testMachinesJsonVarMigration(self):
         b = self.browser
         m = self.machine
 
-        # create obsolete machines.json in /var, which should still be respected
+        # create obsolete machines.json in /var
         blue_conf = '{"blue": {"address": "1.2.3.4", "visible": true}}'
-        m.execute("""echo '%s' > /var/lib/cockpit/machines.json""" % blue_conf)
+        m.execute("echo '%s' > /var/lib/cockpit/machines.json" % blue_conf)
+        # prevent migration due to permission error; should not crash and keep/respect the old file
+        m.execute("""chattr +i /etc/cockpit/machines.d""")
         self.login_and_go("/dashboard")
         self.wait_dashboard_addresses (b, [ "localhost", "1.2.3.4" ])
+        b.logout()
+        # should not have written anything and left the original file untouched
+        m.execute('chattr -i /etc/cockpit/machines.d && [ "$(ls /etc/cockpit/machines.d)" = "" ]')
+        self.assertEqual(m.execute("cat /var/lib/cockpit/machines.json").strip(), blue_conf)
+        self.allow_journal_messages(".*migration of /var/lib/cockpit/machines.json to /etc/cockpit/machines.d/99-webui.json failed:.*")
+
+        # now machines.d/ is writable, should migrate
+        self.login_and_go("/dashboard")
+        self.wait_dashboard_addresses (b, [ "localhost", "1.2.3.4" ])
+        b.logout()
+        m.execute('test ! -e /var/lib/cockpit/machines.json')
+        self.assertEqual(m.execute('cat /etc/cockpit/machines.d/99-webui.json').strip(), blue_conf)
+
+        # old /var file should not clobber existing 99-webui.json but move to 98-migrated.json and merge its data
+        green_conf = '{"green": {"address": "9.8.7.6", "visible": true}}'
+        m.execute("echo '%s' > /var/lib/cockpit/machines.json" % green_conf)
+        self.login_and_go("/dashboard")
+        self.wait_dashboard_addresses (b, [ "localhost", "1.2.3.4", "9.8.7.6" ])
+        b.logout()
+        m.execute('test ! -e /var/lib/cockpit/machines.json')
+        self.assertEqual(m.execute('cat /etc/cockpit/machines.d/99-webui.json').strip(), blue_conf)
+        self.assertEqual(m.execute('cat /etc/cockpit/machines.d/98-migrated.json').strip(), green_conf)
 
 
 @skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")


### PR DESCRIPTION
On startup, migrate the old machines.json file in /var to the new canonical location /etc/cockpit/machines.d/99-webui.json, so that the entire configuration is in the one documented place. Much of the code tries to handle the (rather unlikely) case that *both* the old /var/lib/cockpit/machines.json *and* the new /etc/cockpit/machines.d/99-webui.json already exist; this could happen when upgrading to the new version, the initial migration fails due to some weird permissions error (directory not writable by root), and then the user adds some new hosts. This can never be made fully robust by nature, but the code tries to cope as well as possible. Maybe this is also overengineered and we should simply not support that case, not sure.

We still need to keep reading the file in /var for some time as there is no guarantee that the migration actually works.

The second commit documents the file format. You can see what the generated result looks like at http://piware.de/tmp/feature-machines.html, except that there is a light blue box missing around the example (I didn't want to spend too much time figuring out which CSS to put where).