### PR TITLE
DEBUG: Skip all networking tests

### DIFF
--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -23,6 +23,9 @@ from testlib import *
 
 class NetworkCase(MachineCase):
     def setUp(self):
+
+        self.skipTest("let's see if the networking tests actually interfere with the rest")
+
         MachineCase.setUp(self)
 
         m = self.machine


### PR DESCRIPTION
I want to see whether the networking tests actually interfere with the rest, or if the trouble with our
connectivity comes from somewhere else.