### PR TITLE
Issue #5962: Testing README clarifications

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -44,22 +44,16 @@ In addition, for testing, the following dependencies are required:
     $ sudo yum install \
         curl \
         expect \
-        firewalld \
-        krb5-workstation \
-        krb5-server \
         libvirt \
         libvirt-client \
         libvirt-daemon \
         libvirt-python \
-        mock \
-        openssl \
         python \
         python-libguestfs \
         python-lxml \
         qemu \
         qemu-kvm \
         rpm-build \
-        selinux-policy-devel \
         rsync \
         xz
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -8,6 +8,8 @@ Here's where to get the code:
 The remainder of the commands assume you're in the top level of the
 Cockpit git repository checkout.
 
+## Getting the development dependencies
+
 Cockpit uses Node.js during development. Node.js is not used at runtime.
 To make changes on Cockpit you'll want to install Node.js, NPM and
 various development dependencies like Webpack.
@@ -26,6 +28,46 @@ And lastly get Webpack and the development dependencies:
     $ npm install
     $ ./node_modules/bower/bin/bower install
 
+When relying on CI to run the test suite, this is all that is
+necessary to work on the JavaScript components of Cockpit.
+
+To actually build the Cockpit binaries themselves from source
+(including to run the integration tests locally), you will need
+additional header files and other components. Check
+`tools/cockpit.spec` for the concrete Fedora build dependencies.
+The following should work in a fresh Git clone:
+
+    $ sudo yum-builddep tools/cockpit.spec
+
+In addition, for testing, the following dependencies are required:
+
+    $ sudo yum install \
+        curl \
+        expect \
+        firewalld \
+        krb5-workstation \
+        krb5-server \
+        libvirt \
+        libvirt-client \
+        libvirt-daemon \
+        libvirt-python \
+        mock \
+        openssl \
+        python \
+        python-libguestfs \
+        python-lxml \
+        qemu \
+        qemu-kvm \
+        rpm-build \
+        selinux-policy-devel \
+        rsync \
+        xz
+
+## Running the integration test suite
+
+Refer to the [testing README](test/README) for details on running
+the Cockpit integration tests locally.
+
 ## Working on Cockpit using Vagrant
 
 It is recommended to use a Vagrant virtual machine to develop Cockpit.
@@ -38,8 +80,8 @@ In some cases you may need to use `sudo` with vagrant commands:
 
     $ vagrant up
 
-Next can edit files in the `pkg/` subdirectory of the Cockpit sources.
-Use the `webpack` command to build the those sources. The changes should
+Now you can edit files in the `pkg/` subdirectory of the Cockpit sources.
+Use the `webpack` command to build those sources. The changes should
 take effect after syncing them to the Vagrant VM. For example:
 
     $ webpack
@@ -165,17 +207,9 @@ build the Cockpit binaries locally and install the relevant dependencies.
 Currently, recent x86_64 architectures of Fedora are most often used for
 development.
 
-Check `tools/cockpit.spec` for the concrete Fedora build dependencies.
-The following should work in a fresh Git clone:
-
-    $ sudo yum-builddep tools/cockpit.spec
-    $ sudo yum install nodejs npm
-
-In addition for testing the following dependencies are required:
-
-    $ sudo yum install python-libguestfs qemu mock qemu-kvm rpm-build \
-         curl libvirt-client libvirt-python libvirt python-lxml \
-         krb5-workstation krb5-server selinux-policy-devel
+Before attempting to build anything, first make sure the relevant
+dependencies are installed as described in "Getting the development
+dependencies" above.
 
 Cockpit uses the autotools and thus there are the familiar `./configure`
 script and the familar Makefile targets.

--- a/HACKING.md
+++ b/HACKING.md
@@ -41,21 +41,10 @@ The following should work in a fresh Git clone:
 
 In addition, for testing, the following dependencies are required:
 
-    $ sudo yum install \
-        curl \
-        expect \
-        libvirt \
-        libvirt-client \
-        libvirt-daemon \
-        libvirt-python \
-        python \
-        python-libguestfs \
-        python-lxml \
-        qemu \
-        qemu-kvm \
-        rpm-build \
-        rsync \
-        xz
+    $ sudo yum install curl expect \
+        libvirt libvirt-client libvirt-daemon libvirt-python \
+        python python-libguestfs python-lxml qemu qemu-kvm \
+        rpm-build rsync xz
 
 ## Running the integration test suite
 

--- a/test/README
+++ b/test/README
@@ -13,10 +13,6 @@ the following command needs to be run as root to setup the libvirt bridged netwo
 
     $ sudo ./test/vm-prep
 
-Note that this step also attempts to ensure nested virtualization is enabled,
-and may emit a spurious `rmmod: ERROR: Module kvm_amd is not currently loaded`
-warning when running on an Intel CPU (or vice-versa).
-
 If test failures are encountered that look like they may be related to problems
 with nested virtualization, refer to
 [this Fedora guide](https://fedoraproject.org/wiki/How_to_enable_nested_virtualization_in_KVM)

--- a/test/README
+++ b/test/README
@@ -20,14 +20,15 @@ for more details and recommendations on ensuring it is enabled correctly.
 
 ## Introduction
 
-To build Cockpit and run the integration tests run the following (do NOT run
-the integration tests as root):
+Before running the tests, ensure Cockpit has been built where the test suite
+expects to find it (do NOT run the build step as root):
 
-    $ ./test/verify/run-tests --install
+   $ ./test/verify/testsuite-prepare
 
-The `--install` option indicates to (re)build and (re)install Cockpit before
-running the tests. Only code currently committed in the current branch will
-be installed and tested.
+To run the integration tests run the following (do NOT run the integration tests
+as root):
+
+    $ ./test/verify/run-tests
 
 The tests will automatically download the VM images they need, so expect
 that the initial run may take a couple of hours (there are quite a few
@@ -48,6 +49,12 @@ you to log into cockpit and/or the test instance and diagnose the issue. An addr
 will be printed of the test instance.
 
     $ ./verify/check-session --trace --sit
+
+In order to pick up local changes to Cockpit itself prior to running the tests,
+the `--install` option provides a convenient alternative to explicitly running
+`testsuite-prepare` as a separate step:
+
+    $ ./test/verify/run-tests --install
 
 ## Details
 

--- a/test/README
+++ b/test/README
@@ -24,17 +24,14 @@ for more details and recommendations on ensuring it is enabled correctly.
 
 ## Introduction
 
-Before running the tests, ensure Cockpit has been built where the test suite
-expects to find it (do NOT run the build step as root):
+To build Cockpit and run the integration tests run the following (do NOT run
+the integration tests as root):
 
-   $ ./test/verify/testsuite-prepare
+    $ ./test/verify/run-tests --install
 
-Only code currently committed in the current branch will be installed and tested.
-
-To run the integration tests run the following (do NOT run the integration tests
-as root):
-
-    $ ./test/verify/run-tests
+The `--install` option indicates to (re)build and (re)install Cockpit before
+running the tests. Only code currently committed in the current branch will
+be installed and tested.
 
 The tests will automatically download the VM images they need, so expect
 that the initial run may take a couple of hours (there are quite a few

--- a/test/README
+++ b/test/README
@@ -3,32 +3,48 @@
 This directory contains automated integration tests for Cockpit, and the support
 files for them.
 
-To run the tests on Fedora, you need to install the following packages:
-
-    $ sudo yum install npm qemu-kvm python \
-         firewalld libvirt-daemon libvirt-client libvirt-python \
-         openssl expect rsync curl xz
+To run the tests on Fedora, refer to the [HACKING](../HACKING.md) guide for
+installation of all of the necessary build and test dependencies. There's
+no need to trigger a build manually - the test suite preparation step below
+will handle that.
 
 You may need to reboot after installing the above packages. For initialization
 the following command needs to be run as root to setup the libvirt bridged network:
 
     $ sudo ./test/vm-prep
 
+Note that this step also attempts to ensure nested virtualization is enabled,
+and may emit a spurious `rmmod: ERROR: Module kvm_amd is not currently loaded`
+warning when running on an Intel CPU (or vice-versa).
+
+If test failures are encountered that look like they may be related to problems
+with nested virtualization, refer to
+[this Fedora guide](https://fedoraproject.org/wiki/How_to_enable_nested_virtualization_in_KVM)
+for more details and recommendations on ensuring it is enabled correctly.
+
 ## Introduction
 
-To run the integration tests run the following. Don't run the integration tests
-as root:
+Before running the tests, ensure Cockpit has been built where the test suite
+expects to find it (do NOT run the build step as root):
+
+   $ ./test/verify/testsuite-prepare
+
+Only code currently committed in the current branch will be installed and tested.
+
+To run the integration tests run the following (do NOT run the integration tests
+as root):
 
     $ ./test/verify/run-tests
+
+The tests will automatically download the VM images they need, so expect
+that the initial run may take a couple of hours (there are quite a few
+images to retrieve for different scenario tests).
 
 Alternatively you can run an individual test like this:
 
     $ cd test
     $ ./verify/testsuite-prepare
     $ ./verify/check-session
-
-The `./verify/testsuite-prepare` command builds cockpit and puts it into the test. Only
-code currently committed in the current branch will be installed and tested.
 
 To see more verbose output from the test, use the --verbose and/or --trace flags:
 


### PR DESCRIPTION
- consolidate dependency installation instructions to one place
- reference HACKING.md from test/README
- make `testsuite-prepare` more prominent
- note that `rmmod` error is harmless
- reference Fedora wiki for nested virtualization problems