### PR TITLE
bridge: Increase device name buffer for stats

### DIFF
--- a/src/bridge/cockpitblocksamples.c
+++ b/src/bridge/cockpitblocksamples.c
@@ -45,7 +45,7 @@ cockpit_block_samples (CockpitSamples *samples)
       const gchar *line = lines[n];
       guint num_parsed;
       gint dev_major, dev_minor;
-      gchar dev_name[64]; /* TODO: big enough? */
+      gchar dev_name[128];
       guint64 num_reads,  num_reads_merged,  num_sectors_read,    num_msec_reading;
       guint64 num_writes, num_writes_merged, num_sectors_written, num_msec_writing;
       guint64 num_io_in_progress, num_msec_doing_io, weighted_num_msec_doing_io;
@@ -88,7 +88,7 @@ cockpit_block_samples (CockpitSamples *samples)
        */
 
       num_parsed = sscanf (line,
-                           "%d %d %64s"
+                           "%d %d %127s"
                            " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT
                            " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT
                            " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT,

--- a/src/bridge/cockpitdisksamples.c
+++ b/src/bridge/cockpitdisksamples.c
@@ -56,7 +56,7 @@ cockpit_disk_samples (CockpitSamples *samples)
       const gchar *line = lines[n];
       guint num_parsed;
       gint dev_major, dev_minor;
-      gchar dev_name[64]; /* TODO: big enough? */
+      gchar dev_name[128];
       guint64 num_reads,  num_reads_merged,  num_sectors_read,    num_msec_reading;
       guint64 num_writes, num_writes_merged, num_sectors_written, num_msec_writing;
       guint64 num_io_in_progress, num_msec_doing_io, weighted_num_msec_doing_io;
@@ -99,7 +99,7 @@ cockpit_disk_samples (CockpitSamples *samples)
        */
 
       num_parsed = sscanf (line,
-                           "%d %d %64s"
+                           "%d %d %127s"
                            " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT
                            " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT
                            " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT " %" G_GUINT64_FORMAT,


### PR DESCRIPTION
Also pass correct size (size of buffer - 1) to scanf so that it won't overflow.

The utility sysstat uses a name buffer length of 128:
https://github.com/sysstat/sysstat/blob/e53047284ecf9bac4d1cbd14b7cc0db1e6a9ee64/common.h

So let's also use that instead of 64, just in case.