### PR TITLE
shell: Forward cockpit.kill and cockpit.logout

### DIFF
--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -324,6 +324,7 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             if (event.origin !== origin)
                 return;
 
+            var forward_command = false;
             var data = event.data;
             var child = event.source;
             if (!child || typeof data !== "string")
@@ -362,6 +363,9 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                     perform_jump(child, control);
                     return;
 
+                } else if (control.command == "logout" || control.command == "kill") {
+                    forward_command = true;
+
                 } else if (control.command === "hint") {
                     if (control.hint == "restart") {
                         /* watchdog handles current host for now */
@@ -375,7 +379,7 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                     return;
 
                 /* Only control messages with a channel are forwardable */
-                } else if (control.channel === undefined) {
+                } else if (control.channel === undefined && !forward_command) {
                     return;
 
                 /* Add the child's group to all open channel messages */


### PR DESCRIPTION
I expected these commands to be forwarded from child frames to the parent transport. However that was not the case. I couldn't think of good reason not to do this, but chances are I'm missing something. If someone thinks of a good reason why this shouldn't be allowed I'll change this PR to document why we don't do this.