### PR TITLE
Order menu items in a way that makes sense

### DIFF
--- a/pkg/dashboard/manifest.json.in
+++ b/pkg/dashboard/manifest.json.in
@@ -7,7 +7,7 @@
     "dashboard": {
         "index": {
             "label": "Dashboard",
-            "order": 0,
+            "order": 10,
             "wants": "multiple-machines"
         }
     }

--- a/pkg/docker/manifest.json.in
+++ b/pkg/docker/manifest.json.in
@@ -7,7 +7,7 @@
     "menu": {
         "index": {
             "label": "Containers",
-            "order": 7
+            "order": 50
         }
     }
 }

--- a/pkg/kubernetes/manifest.json.in
+++ b/pkg/kubernetes/manifest.json.in
@@ -7,7 +7,7 @@
     "dashboard": {
         "index": {
             "label": "Cluster",
-            "order": 1
+            "order": 20
         }
     }
 }

--- a/pkg/kubernetes/override.json
+++ b/pkg/kubernetes/override.json
@@ -2,7 +2,7 @@
     "dashboard": {
         "registry": {
             "label": "Image Registry",
-            "order": 3
+            "order": 30
         }
     }
 }

--- a/pkg/machines/manifest.json.in
+++ b/pkg/machines/manifest.json.in
@@ -6,7 +6,8 @@
   "menu": {
      "vms": {
         "label": "Virtual Machines",
-        "path": "index.html"
+        "path": "index.html",
+        "order": 60
      }
   }
 }

--- a/pkg/networkmanager/manifest.json.in
+++ b/pkg/networkmanager/manifest.json.in
@@ -8,7 +8,7 @@
     "menu": {
         "index": {
             "label": "Networking",
-            "order": 20
+            "order": 40
         }
     },
 

--- a/pkg/selinux/manifest.json.in
+++ b/pkg/selinux/manifest.json.in
@@ -6,8 +6,7 @@
 
     "tools": {
         "setroubleshoot": {
-            "label": "SELinux",
-            "order": 8
+            "label": "SELinux"
         }
     }
 }

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -844,7 +844,12 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                 if (!section || self.items[x].section === section)
                     list.push(self.items[x]);
             }
-            list.sort(function(a, b) { return a.order - b.order; });
+            list.sort(function(a, b) {
+                var ret = a.order - b.order;
+                if (ret === 0)
+                    ret = a.label.localeCompare(b.label);
+                return ret;
+            });
             return list;
         };
 

--- a/pkg/storaged/manifest.json.in
+++ b/pkg/storaged/manifest.json.in
@@ -8,7 +8,7 @@
     "menu": {
         "index": {
             "label": "Storage",
-            "order": 15
+            "order": 30
         }
     },
 

--- a/pkg/systemd/manifest.json.in
+++ b/pkg/systemd/manifest.json.in
@@ -9,15 +9,15 @@
     "menu": {
         "index": {
             "label": "System",
-            "order": 0
+            "order": 10
         },
         "services": {
             "label": "Services",
-            "order": 5
+            "order": 100
         },
         "logs": {
             "label": "Logs",
-            "order": 8
+            "order": 20
         }
     },
 

--- a/pkg/users/manifest.json.in
+++ b/pkg/users/manifest.json.in
@@ -4,9 +4,10 @@
 	"cockpit": "122"
     },
 
-    "tools": {
+    "menu": {
         "index": {
-            "label": "Accounts"
+            "label": "Accounts",
+            "order": 70
         }
     }
 }


### PR DESCRIPTION
Once the redesign lands, this will probably change, but for now
in the main menu we order things by:

 * System info
 * Logs for troubleshooting
 * Configuring major subsystems: Storage, Networking
 * Stuff running on the system: Containers and Virtual Machines
 * Implementation details: Admin accounts, Services/Units

In the tools menu we just order things alphabetically.