### PR TITLE
Issue #5962: only reload loaded KVM modules in vm-prep

### DIFF
--- a/test/vm-prep
+++ b/test/vm-prep
@@ -83,11 +83,11 @@ EOF
   done
 
     # We really want nested virtualization
-    if [ ! -f /etc/modprobe.d/kvm-intel.conf ]; then
+    if [ -d /sys/module/kvm_intel -a ! -f /etc/modprobe.d/kvm-intel.conf ]; then
         echo "options kvm-intel nested=1" > /etc/modprobe.d/kvm-intel.conf
         rmmod kvm-intel && modprobe kvm-intel || true
     fi
-    if [ ! -f /etc/modprobe.d/kvm-amd.conf ]; then
+    if [ -d /sys/module/kvm_amd -a ! -f /etc/modprobe.d/kvm-amd.conf ]; then
         echo "options kvm-amd nested=1" > /etc/modprobe.d/kvm-amd.conf
         rmmod kvm-amd && modprobe kvm-amd || true
     fi


### PR DESCRIPTION
This avoids a spurious warning from rmmod about attempting
to remove a kernel module that wasn't loaded.

It also means only the config snippet relevant to the current
CPU is created in `/etc/modprobe.d`.