### PR TITLE
common: Move the logind session lookup into its own function

### DIFF
--- a/src/bridge/cockpitdbusprocess.c
+++ b/src/bridge/cockpitdbusprocess.c
@@ -23,8 +23,6 @@
 
 #include "common/cockpitsystem.h"
 
-#include <systemd/sd-login.h>
-
 #include <errno.h>
 #include <stdlib.h>
 
@@ -53,25 +51,13 @@ build_environment (void)
 static GVariant *
 lookup_session_id (void)
 {
-  GVariant *variant;
   char *session_id;
-  pid_t pid;
-  int res;
+  GVariant *variant;
 
-  pid = getppid ();
-  res = sd_pid_get_session (pid, &session_id);
-  if (res == 0)
-    {
-      variant = g_variant_new_string (session_id);
-      free (session_id);
-      return variant;
-    }
-  else
-    {
-      if (res != -ENODATA && res != -ENXIO)
-        g_message ("could not look up session id for bridge process: %u: %s", pid, g_strerror (-res));
-      return g_variant_new_string ("");
-    }
+  session_id = cockpit_system_session_id ();
+  variant = g_variant_new_string (session_id ? session_id : "");
+  free (session_id);
+  return variant;
 }
 
 static GVariant *

--- a/src/common/cockpitsystem.c
+++ b/src/common/cockpitsystem.c
@@ -21,6 +21,8 @@
 
 #include <glib/gstdio.h>
 
+#include <systemd/sd-login.h>
+
 #include <sys/types.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -214,4 +216,25 @@ out:
   g_free (contents);
 
   return start_time;
+}
+
+char *
+cockpit_system_session_id (void)
+{
+  char *session_id;
+  pid_t pid;
+  int res;
+
+  pid = getppid ();
+  res = sd_pid_get_session (pid, &session_id);
+  if (res == 0)
+    {
+      return session_id;
+    }
+  else
+    {
+      if (res != -ENODATA && res != -ENXIO)
+        g_message ("could not look up session id for bridge process: %u: %s", pid, g_strerror (-res));
+      return NULL;
+    }
 }

--- a/src/common/cockpitsystem.h
+++ b/src/common/cockpitsystem.h
@@ -35,6 +35,8 @@ const gchar **       cockpit_system_os_release_fields          (void);
 
 guint64              cockpit_system_process_start_time         (void);
 
+char *               cockpit_system_session_id                 (void);
+
 G_END_DECLS
 
 #endif /* __COCKPIT_SYSTEM_H__ */


### PR DESCRIPTION
This is so it can be used from multiple places in the code.

This is a remaining commit rescued from #5547 (the otherwise discarded polkit javascript agent).