### PR TITLE
kubernetes: Don't show "docker push" commands for users with only a pull rule

### DIFF
--- a/pkg/kubernetes/scripts/kube-client.js
+++ b/pkg/kubernetes/scripts/kube-client.js
@@ -60,6 +60,7 @@
         { kind: "ProjectRequest", type: "projectrequests", api: OPENSHIFT, global: true, create: -90 },
         { kind: "ReplicationController", type: "replicationcontrollers", api: KUBE, create: -60 },
         { kind: "Service", type: "services", api: KUBE, create: -80 },
+        { kind: "SubjectAccessReview", type: "subjectaccessreviews", api: OPENSHIFT },
         { kind: "User", type: "users", api: OPENSHIFT, global: true },
     ]);
 

--- a/pkg/kubernetes/views/registry-dashboard-page.html
+++ b/pkg/kubernetes/views/registry-dashboard-page.html
@@ -136,17 +136,19 @@
             </h2>
         </div>
         <div class="card-pf-body">
-            <p>
-                <span translate>Push an image:</span>
-                <a tabindex="0" role="button" popover-trigger="focus"
-                    popover="You must login with docker
-                    to push an image.">
-                    <span class="fa fa-lg fa-info-circle"></span>
-                </a>
-            </p>
+            <div id="docker-push-commands" ng-show="showDockerPushCommands">
+                <p>
+                    <span translate>Push an image:</span>
+                    <a tabindex="0" role="button" popover-trigger="focus"
+                        popover="You must login with docker
+                        to push an image.">
+                        <span class="fa fa-lg fa-info-circle"></span>
+                    </a>
+                </p>
 <code>$ sudo docker tag <em>myimage</em> <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name:tag</em>
 $ sudo docker push <span ng-class="{ placeholder: !settings.registry.host_explicit }">{{settings.registry.host}}</span>/<em>project</em>/<em>name</em></code>
-            <p>
+            </div>
+            <p id="docker-pull-commands">
                 <span translate>Pull an image:</span>
                 <a tabindex="0" role="button" popover-trigger="focus"
                     popover="Depending on project access settings

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -904,5 +904,79 @@ class TestRegistry(MachineCase):
         # Make sure it showed up in the console
         wait_project(o, "llama");
 
+    def testDockerCommandInfo(self):
+        o = self.openshift
+        b = self.browser
+        m = self.machine
+
+        # create push and pull user and login as pushuser
+        o.execute("oadm policy add-role-to-user registry-viewer pulluser -n marmalade")
+        o.execute("oadm policy add-role-to-user registry-editor pushuser -n marmalade")
+        o.execute("oadm policy add-role-to-user registry-viewer pushuser -n pizzazz")
+        tmpfile = os.path.join(self.tmpdir, "kubeconfig")
+        o.execute('printf "pushuser\r\na\r\n" | oc login')
+        o.download("/root/.kube/config", tmpfile)
+        with open(tmpfile, "r") as f:
+            m.execute("mkdir -p /home/admin/.kube && cat > /home/admin/.kube/config", input=f.read())
+
+        self.login_and_go("/kubernetes/registry")
+
+        # always visible on "All projects" page
+        b.wait_in_text("body", "Pull an image")
+        b.wait_visible('#docker-push-commands')
+        b.wait_visible('#docker-pull-commands')
+
+        # push user should not see docker push command on pizzazz overview page (only a viewer there)
+        b.wait_visible(".dashboard-images .namespace-filter")
+        b.click(".dashboard-images .namespace-filter button")
+        b.wait_visible(".dashboard-images .namespace-filter .dropdown-menu")
+        b.wait_present(".dashboard-images .namespace-filter a[value='pizzazz']")
+        b.click(".dashboard-images .namespace-filter a[value='pizzazz']")
+        b.wait_visible('#docker-pull-commands')
+        b.wait_not_visible('#docker-push-commands')
+
+        # push user should see docker push and pull commands on marmalade overview page
+        b.click(".dashboard-images .namespace-filter button")
+        b.wait_visible(".dashboard-images .namespace-filter .dropdown-menu")
+        b.wait_present(".dashboard-images .namespace-filter a[value='marmalade']")
+        b.click(".dashboard-images .namespace-filter a[value='marmalade']")
+        b.wait_visible('#docker-push-commands')
+
+        # .. and also on the image page
+        b.go("#/images/marmalade/origin")
+        b.wait_in_text("body", "push to an image to this image stream")
+        b.wait_in_text("body", "docker tag")
+        b.wait_in_text("body", "docker push")
+        b.wait_visible('.registry-imagestream-push')
+
+        # log in as pulluser
+        b.logout()
+        o.execute('printf "pulluser\r\na\r\n" | oc login')
+        o.download("/root/.kube/config", tmpfile)
+        with open(tmpfile, "r") as f:
+            m.execute("cat > /home/admin/.kube/config", input=f.read())
+        self.login_and_go("/kubernetes/registry")
+
+        # always visible on "All projects" page
+        b.wait_in_text("body", "Pull an image")
+        b.wait_visible('#docker-push-commands')
+        b.wait_visible('#docker-pull-commands')
+
+        # pull user should only see docker pull command, but not push on project specific overview page
+        b.wait_visible(".dashboard-images .namespace-filter")
+        b.click(".dashboard-images .namespace-filter button")
+        b.wait_visible(".dashboard-images .namespace-filter .dropdown-menu")
+        b.wait_present(".dashboard-images .namespace-filter a[value='marmalade']")
+        b.click(".dashboard-images .namespace-filter a[value='marmalade']")
+        b.wait_visible('#docker-pull-commands')
+        b.wait_not_visible('#docker-push-commands')
+
+        # and neither the push command on the image page
+        b.go("#/images/marmalade/origin")
+        b.wait_in_text("body", "Images")
+        # FIXME: known to fail for now, needs fixing in registry-image-widgets
+        # b.wait_not_visible('.registry-imagestream-push')
+
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Use SubjectAccessReview OpenShift API to determine if the currently
logged in user is able to update images. If not (i. e. if the user only
has a "pull" role), hide the "docker push/tag" commands.
    
Note that this also requires a corresponding update in
registry-image-widgets to also hide the commands from the per-image
page.

https://bugzilla.redhat.com/show_bug.cgi?id=1373448

TODO:
- [x] move new function from registry.js to policy.js
- [x] invalidate cache on role changes
- [x] Add/use schema instead of hardcoded "/oapi/v1/..." URL
- [x] Remove console.log() marked with "XXX"
- [ ] ~trigger this from project loading, to avoid running into the "empty project list" situation (optimization, works fine as-is)~ (*obsolete*)
- [x] set/watch for a property instead of doing a global `applyAsync()`
- [x] If no project is given, always show the docker push commands; scope.subjectAccessReview() 