### PR TITLE
Networking: Smaller Checkpoints

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2042,7 +2042,21 @@ function with_checkpoint(model, modify, options) {
                 }).
                 fail(function () {
                     hide_curtain();
-                    manager.checkpoint_rollback(cp);
+
+                    // HACK
+                    //
+                    // We want to avoid rollbacks for operations that don't actually change anything when they
+                    // fail.  Rollback are always disruptive and always seem to reconnect all the included
+                    // devices, even if nothing has actually changed.  Thus, if you give invalid input to
+                    // NetworkManager and receive an error in a settings dialog, rolling back the checkpoint
+                    // would cause a temporary disconnection on the interface.
+                    //
+                    // https://bugzilla.redhat.com/show_bug.cgi?id=1427187
+
+                    if (options.rollback_on_failure)
+                        manager.checkpoint_rollback(cp);
+                    else
+                        manager.checkpoint_destroy(cp);
                 });
         });
 }
@@ -2248,7 +2262,8 @@ PageNetworkInterface.prototype = {
                             {
                                 fail_text: cockpit.format(_("Deleting <b>$0</b> will break the connection to the server, and will make the administration UI unavailable."), self.dev_name),
                                 anyway_text: cockpit.format(_("Delete $0"), self.dev_name),
-                                hack_does_add_or_remove: true
+                                hack_does_add_or_remove: true,
+                                rollback_on_failure: true
                             });
         }
     },
@@ -3583,7 +3598,9 @@ PageNetworkBondSettings.prototype = {
 
         if (PageNetworkBondSettings.connection)
             with_settings_checkpoint(PageNetworkBondSettings.model, modify,
-                                     { hack_does_add_or_remove: true });
+                                     { hack_does_add_or_remove: true,
+                                       rollback_on_failure: true
+                                     });
         else
             with_checkpoint(
                 PageNetworkBondSettings.model,
@@ -3591,7 +3608,8 @@ PageNetworkBondSettings.prototype = {
                 {
                     fail_text: _("Creating this bond will break the connection to the server, and will make the administration UI unavailable."),
                     anyway_text: _("Create it"),
-                    hack_does_add_or_remove: true
+                    hack_does_add_or_remove: true,
+                    rollback_on_failure: true
                 });
     }
 
@@ -3764,7 +3782,9 @@ PageNetworkTeamSettings.prototype = {
 
         if (PageNetworkTeamSettings.connection)
             with_settings_checkpoint(PageNetworkTeamSettings.model, modify,
-                                     { hack_does_add_or_remove: true });
+                                     { hack_does_add_or_remove: true,
+                                       rollback_on_failure: true
+                                     });
         else
             with_checkpoint(
                 PageNetworkTeamSettings.model,
@@ -3772,7 +3792,8 @@ PageNetworkTeamSettings.prototype = {
                 {
                     fail_text: _("Creating this team will break the connection to the server, and will make the administration UI unavailable."),
                     anyway_text: _("Create it"),
-                    hack_does_add_or_remove: true
+                    hack_does_add_or_remove: true,
+                    rollback_on_failure: true
                 });
     }
 
@@ -3989,7 +4010,9 @@ PageNetworkBridgeSettings.prototype = {
 
         if (PageNetworkBridgeSettings.connection)
             with_settings_checkpoint(PageNetworkBridgeSettings.model, modify,
-                                     { hack_does_add_or_remove: true });
+                                     { hack_does_add_or_remove: true,
+                                       rollback_on_failure: true
+                                     });
         else
             with_checkpoint(
                 PageNetworkBridgeSettings.model,
@@ -3997,7 +4020,8 @@ PageNetworkBridgeSettings.prototype = {
                 {
                     fail_text: _("Creating this bridge will break the connection to the server, and will make the administration UI unavailable."),
                     anyway_text: _("Create it"),
-                    hack_does_add_or_remove: true
+                    hack_does_add_or_remove: true,
+                    rollback_on_failure: true
                 });
     }
 

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -3496,6 +3496,7 @@ PageNetworkBondSettings.prototype = {
             primary_btn = btn;
             select_btn_select(primary_btn, options.primary);
             change_mode();
+            self.slaves_changed = true;
         }
 
         function change_mac() {
@@ -3584,6 +3585,8 @@ PageNetworkBondSettings.prototype = {
         change_mode();
         change_monitoring();
 
+        self.slaves_changed = false;
+
         $('#network-bond-settings-body').html(body);
     },
 
@@ -3613,12 +3616,14 @@ PageNetworkBondSettings.prototype = {
                 });
         }
 
-        if (PageNetworkBondSettings.connection)
+        if (PageNetworkBondSettings.connection) {
             with_settings_checkpoint(PageNetworkBondSettings.model, modify,
-                                     { hack_does_add_or_remove: true,
-                                       rollback_on_failure: true
+                                     { devices: (self.slaves_changed ?
+                                                 [ ] : connection_devices(PageNetworkBondSettings.connection)),
+                                       hack_does_add_or_remove: self.slaves_changed,
+                                       rollback_on_failure: self.slaves_changed
                                      });
-        else
+        } else {
             with_checkpoint(
                 PageNetworkBondSettings.model,
                 modify,
@@ -3628,6 +3633,7 @@ PageNetworkBondSettings.prototype = {
                     hack_does_add_or_remove: true,
                     rollback_on_failure: true
                 });
+        }
     }
 
 };
@@ -3695,6 +3701,10 @@ PageNetworkTeamSettings.prototype = {
         if (config.link_watch.delay_down === undefined)
             config.link_watch.delay_down = 0;
 
+        function change_slaves() {
+            self.slaves_changed = true;
+        }
+
         function change_runner() {
             config.runner.name = select_btn_selected(runner_btn);
             balancer_btn.parents("tr").toggle(config.runner.name == "loadbalance" ||
@@ -3745,7 +3755,7 @@ PageNetworkTeamSettings.prototype = {
                         self.settings.connection.interface_name = val;
                     });
         body.find('#network-team-settings-members').
-            append(render_slave_interface_choices(model, master));
+            append(render_slave_interface_choices(model, master).change(change_slaves));
         body.find('#network-team-settings-runner-select').
             append(runner_btn = select_btn(change_runner, team_runner_choices, "form-control"));
         body.find('#network-team-settings-balancer-select').
@@ -3767,6 +3777,8 @@ PageNetworkTeamSettings.prototype = {
         select_btn_select(watch_btn, config.link_watch.name);
         change_runner();
         change_watch();
+
+        self.slaves_changed = false;
 
         $('#network-team-settings-body').html(body);
     },
@@ -3797,12 +3809,14 @@ PageNetworkTeamSettings.prototype = {
                 });
         }
 
-        if (PageNetworkTeamSettings.connection)
+        if (PageNetworkTeamSettings.connection) {
             with_settings_checkpoint(PageNetworkTeamSettings.model, modify,
-                                     { hack_does_add_or_remove: true,
-                                       rollback_on_failure: true
+                                     { devices: (self.slaves_changed ?
+                                                 [ ] : connection_devices(PageNetworkTeamSettings.connection)),
+                                       hack_does_add_or_remove: self.slaves_changed,
+                                       rollback_on_failure: self.slaves_changed
                                      });
-        else
+        } else {
             with_checkpoint(
                 PageNetworkTeamSettings.model,
                 modify,
@@ -3812,6 +3826,7 @@ PageNetworkTeamSettings.prototype = {
                     hack_does_add_or_remove: true,
                     rollback_on_failure: true
                 });
+        }
     }
 
 };
@@ -3953,6 +3968,10 @@ PageNetworkBridgeSettings.prototype = {
 
         var stp_input, priority_input, forward_delay_input, hello_time_input, max_age_input;
 
+        function change_slaves() {
+            self.slaves_changed = true;
+        }
+
         function change_stp() {
             // XXX - handle parse errors
             options.stp = stp_input.prop('checked');
@@ -3983,8 +4002,8 @@ PageNetworkBridgeSettings.prototype = {
                                 self.settings.connection.interface_name = val;
                             });
         body.find('#network-bridge-settings-slave-interfaces').
-                      append(render_slave_interface_choices(model, con)).
-                      parent().toggle(!con);
+            append(render_slave_interface_choices(model, con).change(change_slaves)).
+            parent().toggle(!con);
         stp_input = body.find('#network-bridge-settings-stp-enabled-input');
         stp_input.change(change_stp);
         priority_input = body.find('#network-bridge-settings-stp-priority-input');
@@ -3997,6 +4016,9 @@ PageNetworkBridgeSettings.prototype = {
         max_age_input.change(change_stp);
 
         change_stp();
+
+        self.slaves_changed = false;
+
         $('#network-bridge-settings-body').html(body);
     },
 
@@ -4026,12 +4048,14 @@ PageNetworkBridgeSettings.prototype = {
                 });
         }
 
-        if (PageNetworkBridgeSettings.connection)
+        if (PageNetworkBridgeSettings.connection) {
             with_settings_checkpoint(PageNetworkBridgeSettings.model, modify,
-                                     { hack_does_add_or_remove: true,
-                                       rollback_on_failure: true
+                                     { devices: (self.slaves_changed ?
+                                                 [ ] : connection_devices(PageNetworkBridgeSettings.connection)),
+                                       hack_does_add_or_remove: self.slaves_changed,
+                                       rollback_on_failure: self.slaves_changed
                                      });
-        else
+        } else {
             with_checkpoint(
                 PageNetworkBridgeSettings.model,
                 modify,
@@ -4041,6 +4065,7 @@ PageNetworkBridgeSettings.prototype = {
                     hack_does_add_or_remove: true,
                     rollback_on_failure: true
                 });
+        }
     }
 
 };

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -869,11 +869,14 @@ function NetworkManagerModel() {
             },
 
             apply_settings: function (settings) {
+                var self = this;
                 try {
-                    set_settings(this, settings);
-                    return call_object_method(this,
+                    return call_object_method(self,
                                               "org.freedesktop.NetworkManager.Settings.Connection", "Update",
-                                              settings_to_nm(settings, priv(this).orig));
+                                              settings_to_nm(settings, priv(self).orig)).
+                        done(function () {
+                            set_settings(self, settings);
+                        });
                 }
                 catch (e) {
                     return cockpit.reject(e);

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -3293,7 +3293,9 @@ function set_slave(model, master_connection, master_settings, slave_type,
                                                            master: master_iface
                                                          }
                                                        });
-        } else if (cs.master != master_settings.connection.uuid) {
+        } else if (cs.master != master_settings.connection.uuid &&
+                   cs.master != master_settings.connection.id &&
+                   cs.master != master_iface) {
             cs.slave_type = slave_type;
             cs.master = master_iface;
             main_connection.Settings.connection.autoconnect = true;


### PR DESCRIPTION
NetworkManager is quite brutal when rolling back a checkpoint and reactivates everything just in case.  This change avoids unnecessary rollbacks and limits the devices that are part of a checkpoint.

This should increase reliability in general, and also for the tests.