### PR TITLE
test: Certain 'Not Authorized' log messages happen during rapid logout

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -539,6 +539,10 @@ class MachineCase(unittest.TestCase):
         '.*user .* was reauthorized.*',
         'cockpit-polkit helper exited with status: 0',
 
+        # Happens when the user logs out during reauthorization
+        "Error executing command as another user: Not authorized",
+        "This incident has been reported.",
+
         # Reboots are ok
         "-- Reboot --",
 
@@ -634,8 +638,6 @@ class MachineCase(unittest.TestCase):
 
     def allow_authorize_journal_messages(self):
         self.allow_journal_messages("cannot reauthorize identity.*:.*unix-user:admin.*",
-                                    "Error executing command as another user: Not authorized",
-                                    "This incident has been reported.",
                                     ".*: a password is required",
                                     "user user was reauthorized",
                                     ".*: sorry, you must have a tty to run sudo",


### PR DESCRIPTION
Certain of the 'Not Authorized' log messages can happen during
rapid logout. For example if we exit the bridge while polkit agent
authentication is taking place.