### PR TITLE
Support for D-Bus file descriptors

### DIFF
--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -86,6 +86,14 @@
         <listitem><para>A javascript plain object with the <code>"t"</code> property set to a DBus type string,
             and the <code>"v"</code> property set to a value.</para></listitem>
       </varlistentry>
+      <varlistentry>
+        <term><code>HANDLE 'h'</code></term>
+        <listitem><para>A javascript object that describes a cockpit channel which represents the
+           passed file descriptor. The <code>payload</code> is always set to <code>stream</code>.
+           Pass it to <link linkend="cockpit-channels-channel">cockpit.channel()</link> to create
+           the channel and start reading or writing on it. Handles can only be
+           received, not sent from within cockpit.</para></listitem>
+      </varlistentry>
     </variablelist>
   </refsection>
 

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -22,6 +22,8 @@ libcockpit_stub_a_SOURCES = \
 	src/bridge/cockpitdbusrules.h \
 	src/bridge/cockpitechochannel.c \
 	src/bridge/cockpitechochannel.h \
+	src/bridge/cockpitpipechannel.c \
+	src/bridge/cockpitpipechannel.h \
 	src/bridge/cockpithttpstream.c \
 	src/bridge/cockpithttpstream.h \
 	src/bridge/cockpitinteracttransport.c \
@@ -77,8 +79,6 @@ libcockpit_bridge_a_SOURCES = \
 	src/bridge/cockpitdbussetup.c \
 	src/bridge/cockpitdbususer.c \
 	src/bridge/cockpitdbusmachines.c \
-	src/bridge/cockpitpipechannel.c \
-	src/bridge/cockpitpipechannel.h \
 	src/bridge/cockpitpolkitagent.c \
 	src/bridge/cockpitpolkitagent.h \
 	src/bridge/cockpitfsread.c \

--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -2962,10 +2962,15 @@ cockpit_dbus_json_dispose (GObject *object)
       peer = value;
 
       g_free (peer->name);
-      g_signal_handler_disconnect (peer->cache, peer->meta_sig);
-      g_signal_handler_disconnect (peer->cache, peer->update_sig);
-      g_object_run_dispose (G_OBJECT (peer->cache));
-      g_object_unref (peer->cache);
+
+      if (peer->cache)
+        {
+          g_signal_handler_disconnect (peer->cache, peer->meta_sig);
+          g_signal_handler_disconnect (peer->cache, peer->update_sig);
+          g_object_run_dispose (G_OBJECT (peer->cache));
+          g_object_unref (peer->cache);
+        }
+
       cockpit_dbus_rules_free (peer->rules);
 
       if (self->connection)

--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -22,6 +22,7 @@
 #include "cockpitdbusjson.h"
 
 #include "cockpitchannel.h"
+#include "cockpitpipechannel.h"
 #include "cockpitdbuscache.h"
 #include "cockpitdbusinternal.h"
 #include "cockpitdbusmeta.h"
@@ -30,6 +31,8 @@
 #include "common/cockpitjson.h"
 
 #include <json-glib/json-glib.h>
+
+#include <gio/gunixfdlist.h>
 
 #include <string.h>
 
@@ -41,6 +44,9 @@
  */
 
 gboolean cockpit_dbus_json_allow_external = TRUE;
+
+/* The maximum number of DBus passed fds open without a channel */
+#define MAX_RECEIVED_DBUS_FDS 16
 
 #define COCKPIT_DBUS_JSON(o)    (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_DBUS_JSON, CockpitDBusJson))
 
@@ -68,6 +74,9 @@ typedef struct {
   GHashTable *invocations;
   GHashTable *registered;
   guint last_invocation;
+
+  /* File descriptors */
+  GQueue *fd_channel_ids;
 } CockpitDBusJson;
 
 typedef struct {
@@ -588,11 +597,18 @@ parse_json (JsonNode *node,
   return NULL;
 }
 
+typedef struct {
+  GUnixFDList *fdlist;
+  GQueue *fdids;
+} VariantContext;
+
 static JsonNode *
-build_json (GVariant *value);
+build_json (GVariant *value,
+            VariantContext *context);
 
 static JsonObject *
-build_json_variant (GVariant *value)
+build_json_variant (GVariant *value,
+                    VariantContext *context)
 {
   GVariant *child;
   JsonObject *object;
@@ -600,7 +616,7 @@ build_json_variant (GVariant *value)
   child = g_variant_get_variant (value);
   object = json_object_new ();
   json_object_set_string_member (object, "t", g_variant_get_type_string (child));
-  json_object_set_member (object, "v", build_json (child));
+  json_object_set_member (object, "v", build_json (child, context));
 
   g_variant_unref (child);
 
@@ -628,7 +644,8 @@ build_json_byte_array (GVariant *value)
 }
 
 static JsonArray *
-build_json_array_or_tuple (GVariant *value)
+build_json_array_or_tuple (GVariant *value,
+                           VariantContext *context)
 {
   GVariantIter iter;
   GVariant *child;
@@ -639,7 +656,7 @@ build_json_array_or_tuple (GVariant *value)
   g_variant_iter_init (&iter, value);
   while ((child = g_variant_iter_next_value (&iter)) != NULL)
     {
-      json_array_add_element (array, build_json (child));
+      json_array_add_element (array, build_json (child, context));
       g_variant_unref (child);
     }
 
@@ -648,7 +665,8 @@ build_json_array_or_tuple (GVariant *value)
 
 static JsonObject *
 build_json_dictionary (const GVariantType *entry_type,
-                       GVariant *dict)
+                       GVariant *dict,
+                       VariantContext *context)
 {
   const GVariantType *key_type;
   GVariantIter iter;
@@ -674,12 +692,12 @@ build_json_dictionary (const GVariantType *entry_type,
 
       if (is_string)
         {
-          json_object_set_member (object, g_variant_get_string (key, NULL), build_json (value));
+          json_object_set_member (object, g_variant_get_string (key, NULL), build_json (value, context));
         }
       else
         {
           key_string = g_variant_print (key, FALSE);
-          json_object_set_member (object, key_string, build_json (value));
+          json_object_set_member (object, key_string, build_json (value, context));
           g_free (key_string);
         }
 
@@ -691,7 +709,64 @@ build_json_dictionary (const GVariantType *entry_type,
 }
 
 static JsonNode *
-build_json (GVariant *value)
+build_json_fd_channel (GVariant *value,
+                       VariantContext *context)
+{
+  JsonObject *object;
+  GError *error = NULL;
+  JsonNode *node;
+  gint fd = -1;
+  gchar *old;
+  const gchar *id;
+
+  if (context->fdlist)
+    {
+      fd = g_unix_fd_list_get (context->fdlist, g_variant_get_handle (value), &error);
+      if (fd == -1)
+        {
+          g_warning ("couldn't dup file descriptor from DBus message: %s", error->message);
+          g_clear_error (&error);
+        }
+    }
+
+  if (fd < 0)
+    {
+      node = json_node_new (JSON_NODE_NULL);
+    }
+  else
+    {
+      g_assert (context->fdlist != NULL);
+      g_assert (context->fdids != NULL);
+
+      node = json_node_new (JSON_NODE_OBJECT);
+
+      /* Add a new internal channel name for this file descriptor */
+      id = cockpit_pipe_channel_add_internal_fd (fd);
+      g_queue_push_tail (context->fdids, (gpointer) g_strdup (id));
+
+      /* And only keep the last N ready for opening channels */
+      while (g_queue_get_length (context->fdids) > MAX_RECEIVED_DBUS_FDS)
+        {
+          old = (gchar *)g_queue_pop_head (context->fdids);
+          cockpit_pipe_channel_remove_internal_fd (old);
+
+          g_free (old);
+        }
+
+      /* This is sent back as the list of channel options to use */
+      object = json_object_new ();
+      json_object_set_string_member (object, "payload", "stream");
+      json_object_set_string_member (object, "internal", id);
+      json_node_set_object (node, object);
+      json_object_unref (object);
+    }
+
+  return node;
+}
+
+static JsonNode *
+build_json (GVariant *value,
+            VariantContext *context)
 {
   const GVariantType *type;
   const GVariantType *element_type;
@@ -742,8 +817,7 @@ build_json (GVariant *value)
       return node;
 
     case G_VARIANT_CLASS_HANDLE:
-      node = json_node_new (JSON_NODE_VALUE);
-      json_node_set_int (node, g_variant_get_handle (value));
+      node = build_json_fd_channel (value, context);
       return node;
 
     case G_VARIANT_CLASS_DOUBLE:
@@ -759,7 +833,7 @@ build_json (GVariant *value)
       return node;
 
     case G_VARIANT_CLASS_VARIANT:
-      object = build_json_variant (value);
+      object = build_json_variant (value, context);
       node = json_node_new (JSON_NODE_OBJECT);
       json_node_take_object (node, object);
       return node;
@@ -769,7 +843,7 @@ build_json (GVariant *value)
       element_type = g_variant_type_element (type);
       if (g_variant_type_is_dict_entry (element_type))
         {
-          object = build_json_dictionary (element_type, value);
+          object = build_json_dictionary (element_type, value, context);
           node = json_node_new (JSON_NODE_OBJECT);
           json_node_take_object (node, object);
         }
@@ -779,7 +853,7 @@ build_json (GVariant *value)
         }
       else
         {
-          array = build_json_array_or_tuple (value);
+          array = build_json_array_or_tuple (value, context);
           node = json_node_new (JSON_NODE_ARRAY);
           json_node_set_array (node, array);
           json_array_unref (array);
@@ -787,7 +861,7 @@ build_json (GVariant *value)
       return node;
 
     case G_VARIANT_CLASS_TUPLE:
-      array = build_json_array_or_tuple (value);
+      array = build_json_array_or_tuple (value, context);
       node = json_node_new (JSON_NODE_ARRAY);
       json_node_set_array (node, array);
       json_array_unref (array);
@@ -859,13 +933,14 @@ build_signature (GVariant *variant)
 
 static JsonNode *
 build_json_body (GVariant *body,
+                 VariantContext *context,
                  gchar **type)
 {
   if (body)
     {
       if (type)
         *type = build_signature (body);
-      return build_json (body);
+      return build_json (body, context);
     }
   else
     {
@@ -883,13 +958,14 @@ build_json_signal (const gchar *path,
 {
   JsonObject *object;
   JsonArray *signal;
+  VariantContext context = { NULL };
 
   object = json_object_new ();
   signal = json_array_new ();
   json_array_add_string_element (signal, path);
   json_array_add_string_element (signal, interface);
   json_array_add_string_element (signal, member);
-  json_array_add_element (signal, build_json_body (body, NULL));
+  json_array_add_element (signal, build_json_body (body, &context, NULL));
   json_object_set_array_member (object, "signal", signal);
 
   return object;
@@ -982,6 +1058,7 @@ send_dbus_reply (CockpitDBusJson *self,
                  GDBusMessage *message)
 {
   CockpitDBusPeer *peer;
+  VariantContext context = { NULL };
   GVariant *scrape = NULL;
   JsonObject *object;
   GString *flags;
@@ -1006,7 +1083,15 @@ send_dbus_reply (CockpitDBusJson *self,
       scrape = g_dbus_message_get_body (message);
     }
 
-  json_array_add_element (reply, build_json_body (g_dbus_message_get_body (message),
+  context.fdlist = g_dbus_message_get_unix_fd_list (message);
+  if (context.fdlist)
+    {
+      if (!self->fd_channel_ids)
+        self->fd_channel_ids = g_queue_new ();
+      context.fdids = self->fd_channel_ids;
+    }
+
+  json_array_add_element (reply, build_json_body (g_dbus_message_get_body (message), &context,
                                                   call->type != NULL ? &type : NULL));
 
   if (type)
@@ -1919,7 +2004,7 @@ build_json_update (GHashTable *paths)
 
               g_hash_table_iter_init (&k, properties);
               while (g_hash_table_iter_next (&k, (gpointer *)&property, (gpointer *)&value))
-                json_object_set_member (iface, property, build_json (value));
+                json_object_set_member (iface, property, build_json (value, NULL));
 
               json_object_set_object_member (object, interface, iface);
             }
@@ -2243,6 +2328,7 @@ on_method_invocation (GDBusConnection *connection,
   gchar *cookie = NULL;
   JsonObject *object;
   JsonArray *call;
+  VariantContext context = { NULL };
 
   message = g_dbus_method_invocation_get_message (invocation);
   flags = g_dbus_message_get_flags (message);
@@ -2252,7 +2338,7 @@ on_method_invocation (GDBusConnection *connection,
   json_array_add_string_element (call, object_path);
   json_array_add_string_element (call, interface_name);
   json_array_add_string_element (call, method_name);
-  json_array_add_element (call, build_json (parameters));
+  json_array_add_element (call, build_json (parameters, &context));
   json_object_set_array_member (object, "call", call);
 
   if (!(flags & G_DBUS_MESSAGE_FLAGS_NO_REPLY_EXPECTED))
@@ -2910,6 +2996,22 @@ cockpit_dbus_json_dispose (GObject *object)
           g_dbus_method_invocation_return_dbus_error (value, "org.freedesktop.DBus.Error.Failed",
                                                       "The DBus interface for this method has been disconnected");
         }
+    }
+
+  if (self->fd_channel_ids)
+    {
+      while (!g_queue_is_empty (self->fd_channel_ids))
+        {
+          gchar *id;
+
+          id = (gchar *)g_queue_pop_head (self->fd_channel_ids);
+          cockpit_pipe_channel_remove_internal_fd (id);
+
+          g_free (id);
+        }
+
+      g_queue_free (self->fd_channel_ids);
+      self->fd_channel_ids = NULL;
     }
 
   /* Divorce ourselves the outstanding calls */

--- a/src/bridge/cockpitpipechannel.h
+++ b/src/bridge/cockpitpipechannel.h
@@ -34,4 +34,8 @@ CockpitChannel *   cockpit_pipe_channel_open       (CockpitTransport *transport,
                                                     const gchar *channel_id,
                                                     const gchar *unix_path);
 
+const gchar *      cockpit_pipe_channel_add_internal_fd         (gint fd);
+
+gboolean           cockpit_pipe_channel_remove_internal_fd      (const gchar *id);
+
 #endif /* COCKPIT_PIPE_CHANNEL_H__ */

--- a/src/common/com.redhat.Cockpit.DBusTests.xml
+++ b/src/common/com.redhat.Cockpit.DBusTests.xml
@@ -138,6 +138,11 @@
       <arg direction="out" name="name" type="s"/>
     </method>
 
+    <method name="MakeTestFd">
+        <arg direction="in" name="type" type="s"/>
+        <arg direction="out" name="fd" type="h"/>
+    </method>
+
     <property name="y" type="y" access="readwrite"/>
     <property name="b" type="b" access="readwrite"/>
     <property name="n" type="n" access="readwrite"/>

--- a/src/common/mock-dbus-tests.c
+++ b/src/common/mock-dbus-tests.c
@@ -1812,6 +1812,53 @@ static const _ExtendedGDBusMethodInfo _test_frobber_method_info_tell_me_your_nam
   FALSE
 };
 
+static const _ExtendedGDBusArgInfo _test_frobber_method_info_make_test_fd_IN_ARG_type =
+{
+  {
+    -1,
+    (gchar *) "type",
+    (gchar *) "s",
+    NULL
+  },
+  FALSE
+};
+
+static const _ExtendedGDBusArgInfo * const _test_frobber_method_info_make_test_fd_IN_ARG_pointers[] =
+{
+  &_test_frobber_method_info_make_test_fd_IN_ARG_type,
+  NULL
+};
+
+static const _ExtendedGDBusArgInfo _test_frobber_method_info_make_test_fd_OUT_ARG_fd =
+{
+  {
+    -1,
+    (gchar *) "fd",
+    (gchar *) "h",
+    NULL
+  },
+  FALSE
+};
+
+static const _ExtendedGDBusArgInfo * const _test_frobber_method_info_make_test_fd_OUT_ARG_pointers[] =
+{
+  &_test_frobber_method_info_make_test_fd_OUT_ARG_fd,
+  NULL
+};
+
+static const _ExtendedGDBusMethodInfo _test_frobber_method_info_make_test_fd =
+{
+  {
+    -1,
+    (gchar *) "MakeTestFd",
+    (GDBusArgInfo **) &_test_frobber_method_info_make_test_fd_IN_ARG_pointers,
+    (GDBusArgInfo **) &_test_frobber_method_info_make_test_fd_OUT_ARG_pointers,
+    NULL
+  },
+  "handle-make-test-fd",
+  FALSE
+};
+
 static const _ExtendedGDBusMethodInfo * const _test_frobber_method_info_pointers[] =
 {
   &_test_frobber_method_info_hello_world,
@@ -1835,6 +1882,7 @@ static const _ExtendedGDBusMethodInfo * const _test_frobber_method_info_pointers
   &_test_frobber_method_info_claim_other_name,
   &_test_frobber_method_info_release_other_name,
   &_test_frobber_method_info_tell_me_your_name,
+  &_test_frobber_method_info_make_test_fd,
   NULL
 };
 
@@ -2304,6 +2352,7 @@ test_frobber_override_properties (GObjectClass *klass, guint property_id_begin)
  * @handle_delete_object: Handler for the #TestFrobber::handle-delete-object signal.
  * @handle_emit_hidden: Handler for the #TestFrobber::handle-emit-hidden signal.
  * @handle_hello_world: Handler for the #TestFrobber::handle-hello-world signal.
+ * @handle_make_test_fd: Handler for the #TestFrobber::handle-make-test-fd signal.
  * @handle_never_return: Handler for the #TestFrobber::handle-never-return signal.
  * @handle_property_cancellation: Handler for the #TestFrobber::handle-property-cancellation signal.
  * @handle_release_other_name: Handler for the #TestFrobber::handle-release-other-name signal.
@@ -2841,6 +2890,29 @@ test_frobber_default_init (TestFrobberIface *iface)
     G_TYPE_BOOLEAN,
     1,
     G_TYPE_DBUS_METHOD_INVOCATION);
+
+  /**
+   * TestFrobber::handle-make-test-fd:
+   * @object: A #TestFrobber.
+   * @invocation: A #GDBusMethodInvocation.
+   * @arg_type: Argument passed by remote caller.
+   *
+   * Signal emitted when a remote caller is invoking the <link linkend="gdbus-method-com-redhat-Cockpit-DBusTests-Frobber.MakeTestFd">MakeTestFd()</link> D-Bus method.
+   *
+   * If a signal handler returns %TRUE, it means the signal handler will handle the invocation (e.g. take a reference to @invocation and eventually call test_frobber_complete_make_test_fd() or e.g. g_dbus_method_invocation_return_error() on it) and no order signal handlers will run. If no signal handler handles the invocation, the %G_DBUS_ERROR_UNKNOWN_METHOD error is returned.
+   *
+   * Returns: %TRUE if the invocation was handled, %FALSE to let other signal handlers run.
+   */
+  g_signal_new ("handle-make-test-fd",
+    G_TYPE_FROM_INTERFACE (iface),
+    G_SIGNAL_RUN_LAST,
+    G_STRUCT_OFFSET (TestFrobberIface, handle_make_test_fd),
+    g_signal_accumulator_true_handled,
+    NULL,
+    g_cclosure_marshal_generic,
+    G_TYPE_BOOLEAN,
+    2,
+    G_TYPE_DBUS_METHOD_INVOCATION, G_TYPE_STRING);
 
   /* GObject signals for received D-Bus signals: */
   /**
@@ -6164,6 +6236,110 @@ _out:
 }
 
 /**
+ * test_frobber_call_make_test_fd:
+ * @proxy: A #TestFrobberProxy.
+ * @arg_type: Argument to pass with the method invocation.
+ * @cancellable: (allow-none): A #GCancellable or %NULL.
+ * @callback: A #GAsyncReadyCallback to call when the request is satisfied or %NULL.
+ * @user_data: User data to pass to @callback.
+ *
+ * Asynchronously invokes the <link linkend="gdbus-method-com-redhat-Cockpit-DBusTests-Frobber.MakeTestFd">MakeTestFd()</link> D-Bus method on @proxy.
+ * When the operation is finished, @callback will be invoked in the <link linkend="g-main-context-push-thread-default">thread-default main loop</link> of the thread you are calling this method from.
+ * You can then call test_frobber_call_make_test_fd_finish() to get the result of the operation.
+ *
+ * See test_frobber_call_make_test_fd_sync() for the synchronous, blocking version of this method.
+ */
+void
+test_frobber_call_make_test_fd (
+    TestFrobber *proxy,
+    const gchar *arg_type,
+    GCancellable *cancellable,
+    GAsyncReadyCallback callback,
+    gpointer user_data)
+{
+  g_dbus_proxy_call (G_DBUS_PROXY (proxy),
+    "MakeTestFd",
+    g_variant_new ("(s)",
+                   arg_type),
+    G_DBUS_CALL_FLAGS_NONE,
+    -1,
+    cancellable,
+    callback,
+    user_data);
+}
+
+/**
+ * test_frobber_call_make_test_fd_finish:
+ * @proxy: A #TestFrobberProxy.
+ * @out_fd: (out): Return location for return parameter or %NULL to ignore.
+ * @res: The #GAsyncResult obtained from the #GAsyncReadyCallback passed to test_frobber_call_make_test_fd().
+ * @error: Return location for error or %NULL.
+ *
+ * Finishes an operation started with test_frobber_call_make_test_fd().
+ *
+ * Returns: (skip): %TRUE if the call succeded, %FALSE if @error is set.
+ */
+gboolean
+test_frobber_call_make_test_fd_finish (
+    TestFrobber *proxy,
+    GVariant **out_fd,
+    GAsyncResult *res,
+    GError **error)
+{
+  GVariant *_ret;
+  _ret = g_dbus_proxy_call_finish (G_DBUS_PROXY (proxy), res, error);
+  if (_ret == NULL)
+    goto _out;
+  g_variant_get (_ret,
+                 "(@h)",
+                 out_fd);
+  g_variant_unref (_ret);
+_out:
+  return _ret != NULL;
+}
+
+/**
+ * test_frobber_call_make_test_fd_sync:
+ * @proxy: A #TestFrobberProxy.
+ * @arg_type: Argument to pass with the method invocation.
+ * @out_fd: (out): Return location for return parameter or %NULL to ignore.
+ * @cancellable: (allow-none): A #GCancellable or %NULL.
+ * @error: Return location for error or %NULL.
+ *
+ * Synchronously invokes the <link linkend="gdbus-method-com-redhat-Cockpit-DBusTests-Frobber.MakeTestFd">MakeTestFd()</link> D-Bus method on @proxy. The calling thread is blocked until a reply is received.
+ *
+ * See test_frobber_call_make_test_fd() for the asynchronous version of this method.
+ *
+ * Returns: (skip): %TRUE if the call succeded, %FALSE if @error is set.
+ */
+gboolean
+test_frobber_call_make_test_fd_sync (
+    TestFrobber *proxy,
+    const gchar *arg_type,
+    GVariant **out_fd,
+    GCancellable *cancellable,
+    GError **error)
+{
+  GVariant *_ret;
+  _ret = g_dbus_proxy_call_sync (G_DBUS_PROXY (proxy),
+    "MakeTestFd",
+    g_variant_new ("(s)",
+                   arg_type),
+    G_DBUS_CALL_FLAGS_NONE,
+    -1,
+    cancellable,
+    error);
+  if (_ret == NULL)
+    goto _out;
+  g_variant_get (_ret,
+                 "(@h)",
+                 out_fd);
+  g_variant_unref (_ret);
+_out:
+  return _ret != NULL;
+}
+
+/**
  * test_frobber_complete_hello_world:
  * @object: A #TestFrobber.
  * @invocation: (transfer full): A #GDBusMethodInvocation.
@@ -6593,6 +6769,27 @@ test_frobber_complete_tell_me_your_name (
   g_dbus_method_invocation_return_value (invocation,
     g_variant_new ("(s)",
                    name));
+}
+
+/**
+ * test_frobber_complete_make_test_fd:
+ * @object: A #TestFrobber.
+ * @invocation: (transfer full): A #GDBusMethodInvocation.
+ * @fd: Parameter to return.
+ *
+ * Helper function used in service implementations to finish handling invocations of the <link linkend="gdbus-method-com-redhat-Cockpit-DBusTests-Frobber.MakeTestFd">MakeTestFd()</link> D-Bus method. If you instead want to finish handling an invocation by returning an error, use g_dbus_method_invocation_return_error() or similar.
+ *
+ * This method will free @invocation, you cannot use it afterwards.
+ */
+void
+test_frobber_complete_make_test_fd (
+    TestFrobber *object,
+    GDBusMethodInvocation *invocation,
+    GVariant *fd)
+{
+  g_dbus_method_invocation_return_value (invocation,
+    g_variant_new ("(@h)",
+                   fd));
 }
 
 /* ------------------------------------------------------------------------ */

--- a/src/common/mock-dbus-tests.h
+++ b/src/common/mock-dbus-tests.h
@@ -195,6 +195,11 @@ struct _TestFrobberIface
     GDBusMethodInvocation *invocation,
     const gchar *arg_greeting);
 
+  gboolean (*handle_make_test_fd) (
+    TestFrobber *object,
+    GDBusMethodInvocation *invocation,
+    const gchar *arg_type);
+
   gboolean (*handle_never_return) (
     TestFrobber *object,
     GDBusMethodInvocation *invocation);
@@ -432,6 +437,11 @@ void test_frobber_complete_tell_me_your_name (
     TestFrobber *object,
     GDBusMethodInvocation *invocation,
     const gchar *name);
+
+void test_frobber_complete_make_test_fd (
+    TestFrobber *object,
+    GDBusMethodInvocation *invocation,
+    GVariant *fd);
 
 
 
@@ -879,6 +889,26 @@ gboolean test_frobber_call_tell_me_your_name_finish (
 gboolean test_frobber_call_tell_me_your_name_sync (
     TestFrobber *proxy,
     gchar **out_name,
+    GCancellable *cancellable,
+    GError **error);
+
+void test_frobber_call_make_test_fd (
+    TestFrobber *proxy,
+    const gchar *arg_type,
+    GCancellable *cancellable,
+    GAsyncReadyCallback callback,
+    gpointer user_data);
+
+gboolean test_frobber_call_make_test_fd_finish (
+    TestFrobber *proxy,
+    GVariant **out_fd,
+    GAsyncResult *res,
+    GError **error);
+
+gboolean test_frobber_call_make_test_fd_sync (
+    TestFrobber *proxy,
+    const gchar *arg_type,
+    GVariant **out_fd,
     GCancellable *cancellable,
     GError **error);
 

--- a/src/common/mock-service.c
+++ b/src/common/mock-service.c
@@ -21,8 +21,10 @@
 
 #include "mock-service.h"
 #include "mock-dbus-tests.h"
+#include "cockpitunixfd.h"
 
 #include <gio/gio.h>
+#include <gio/gunixfdlist.h>
 #include <glib-unix.h>
 #include <string.h>
 
@@ -454,6 +456,71 @@ on_tell_me_your_name (TestFrobber *frobber,
 
 }
 
+static gboolean
+test_fd_pipe_readable (gint fd,
+                       GIOCondition condition,
+                       gpointer user_data)
+{
+  const char *expected = "Hello, fd";
+  size_t expected_len = strlen (expected);
+  char buffer[100];
+  size_t n;
+
+  g_assert (condition == G_IO_IN);
+
+  n = read (fd, buffer, 100);
+  g_assert (n == expected_len);
+  g_assert (strncmp (buffer, expected, expected_len) == 0);
+
+  close (fd);
+
+  return G_SOURCE_REMOVE;
+}
+
+static gboolean
+on_make_test_fd (TestFrobber *frobber,
+                 GDBusMethodInvocation *invocation,
+                 const char *type,
+                 gpointer user_data)
+{
+  gint fds[2] = { -1, -1 };
+  GUnixFDList *fd_list;
+  const char *data = "Hello, fd";
+  size_t data_size = strlen (data);
+  size_t n;
+  GError *error = NULL;
+
+  g_unix_open_pipe (fds, FD_CLOEXEC, &error);
+  g_assert_no_error (error);
+
+  fd_list = g_unix_fd_list_new ();
+
+  if (g_str_equal (type, "readable"))
+    {
+      g_unix_fd_list_append (fd_list, fds[0], &error);
+      g_assert_no_error (error);
+      close (fds[0]);
+
+      n = write(fds[1], data, data_size);
+      g_assert (n == data_size);
+      close (fds[1]);
+    }
+  else if (g_str_equal (type, "writable"))
+    {
+      g_unix_fd_list_append (fd_list, fds[1], &error);
+      g_assert_no_error (error);
+      close (fds[1]);
+
+      cockpit_unix_fd_add (fds[0], G_IO_IN, test_fd_pipe_readable, NULL);
+    }
+  else
+    g_assert_not_reached ();
+
+  g_dbus_method_invocation_return_value_with_unix_fd_list (invocation, g_variant_new ("(h)", 0), fd_list);
+
+  return TRUE;
+}
+
 /* ------------------------------------------------------------------------
  * Non object manager stuff
  */
@@ -738,6 +805,8 @@ mock_service_create_and_export (GDBusConnection *connection,
                     G_CALLBACK (on_release_other_name), mock_data);
   g_signal_connect (exported_frobber, "handle-tell-me-your-name",
                     G_CALLBACK (on_tell_me_your_name), mock_data);
+  g_signal_connect (exported_frobber, "handle-make-test-fd",
+                    G_CALLBACK (on_make_test_fd), mock_data);
 
   g_object_unref (exported_frobber);
   mock_service_create_introspect_fail (connection);


### PR DESCRIPTION
This is based on @stefwalter's initial implementation at #4883. I've rebased it, fixed compile errors, and started to implement the missing bits. Still very much work in progress, but I'm opening this pull request to start the discussion again.

This is basic support for file descriptors passed over DBus. Several APIs like to include stuff like this in their APIs.
- [x] Initial implementation
- [x] Figure out possible fd exaustion until DBus channel is closed.
- [x] Figure out a test case.
- [ ] An actual use case.
- [x] Documentation
- [x] Unit tests, and fix bugs

Fixes #4380