### PR TITLE
Refine versioned dependencies on -bridge/-shell RPM binary packages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -355,7 +355,7 @@ dist-hook::
 	tar -C $(srcdir) -cf - bower_components/ | tar -C $(distdir) -xf -
 	echo $(VERSION) > $(distdir)/.tarball
 	$(srcdir)/tools/build-copying $(BOWER) > $(distdir)/COPYING.bower
-	[ ! -e $(distdir)/tools/cockpit.spec ] || sed -ri "s/^(.*%define required_base).*$$/\1 $$($(srcdir)/tools/min-base-version)/" $(distdir)/tools/cockpit.spec
+	[ ! -e $(distdir)/tools/cockpit.spec ] || $(srcdir)/tools/gen-spec-dependencies $(distdir)/tools/cockpit.spec
 
 DIST_TAR_MAIN = tar --format=posix -cf - --exclude='node_modules' "$(distdir)" "$(distdir)/bower.json" "$(distdir)/.bowerrc"
 DIST_TAR_CACHE = tar --format=posix -cf - "$(distdir)/node_modules" "$(distdir)/package.json"

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -317,8 +317,8 @@ The Cockpit components for managing virtual machines.
 %package ostree
 Summary: Cockpit user interface for rpm-ostree
 # Requires: Uses new translations functionality
-Requires: %{name}-bridge > 124
-Requires: %{name}-system > 124
+Requires: %{name}-bridge >= %{required_base}
+Requires: %{name}-system >= %{required_base}
 %if 0%{?fedora} > 0 && 0%{?fedora} < 24
 Requires: rpm-ostree >= 2015.10-1
 %else
@@ -430,8 +430,8 @@ This package contains the Cockpit shell and system configuration interfaces.
 
 %package tests
 Summary: Tests for Cockpit
-Requires: %{name}-bridge >= %{required_base}
-Requires: %{name}-shell >= %{required_base}
+Requires: %{name}-bridge >= %{version}-%{release}
+Requires: %{name}-shell >= %{version}-%{release}
 Requires: openssh-clients
 Provides: %{name}-test-assets
 Obsoletes: %{name}-test-assets < 132
@@ -594,8 +594,8 @@ This package is not yet complete.
 Summary: Cockpit user interface for Kubernetes cluster
 Requires: /usr/bin/kubectl
 # Requires: Needs newer localization support
-Requires: %{name}-bridge > 124
-Requires: %{name}-shell > 124
+Requires: %{name}-bridge >= %{required_base}
+Requires: %{name}-shell >= %{required_base}
 BuildRequires: golang-bin
 BuildRequires: golang-src
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -12,8 +12,8 @@
 #  * wip 1
 #
 
-# earliest base that the subpackages work on; this gets computed/updated by
-# tools/min-base-version during "make dist", but keep a hardcoded fallback
+# earliest base that the subpackages work on; the instances of this get computed/updated
+# by tools/gen-spec-dependencies during "make dist", but keep a hardcoded fallback
 %define required_base 122
 
 %if 0%{?centos}

--- a/tools/gen-spec-dependencies
+++ b/tools/gen-spec-dependencies
@@ -1,0 +1,46 @@
+#!/usr/bin/python
+# Compute dependencies of our cockpit-<module> packages to to -bridge/-shell,
+# by replacing %{required_base} with the requires["cockpit"] version from
+# pkg/<module>/manifest.json.in (this is done by tools/min-base-version).
+# The replacement is done in-place in the spec file given as argument.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import os
+import fileinput
+import subprocess
+
+min_base_version_path = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), "min-base-version")
+
+if len(sys.argv) != 2:
+    sys.stderr.write("Usage: %s <specfile>\n" % sys.argv[0])
+    sys.exit(1)
+
+curpkg = None
+pkg_base_dep = None
+for line in fileinput.input(sys.argv[1], inplace=True):
+    if line.startswith("%package"):
+        curpkg = line.split()[1]
+        pkg_base_dep = None
+    elif "%{required_base}" in line:
+        assert curpkg, "spec file uses %{required_base} outside of %package stanza"
+        # lazily determine this -- some packages don't use %{required_base} and some multiple times
+        if not pkg_base_dep:
+            pkg_base_dep = subprocess.check_output([min_base_version_path, curpkg], universal_newlines=True).strip()
+            sys.stderr.write('base dependency of %s: %s\n' % (curpkg, pkg_base_dep))
+        line = line.replace("%{required_base}", pkg_base_dep)
+    sys.stdout.write(line)  # fileinput redirects that back into the file

--- a/tools/min-base-version
+++ b/tools/min-base-version
@@ -27,15 +27,19 @@ from glob import glob
 
 proj_dir = os.path.dirname(os.path.dirname(os.path.realpath(sys.argv[0])))
 
-max_version = '0'
-for manifest in glob(os.path.join(proj_dir, 'pkg/*/manifest.json')):
+max_version = 0
+for manifest in glob(os.path.join(proj_dir, 'pkg/*/manifest.json.in')):
     with open(manifest) as f:
-        requires = json.load(f)['requires']
+        requires = json.load(f).get('requires', {})
     try:
         v = requires['cockpit']
         if v > max_version:
             max_version = v
     except KeyError:
-        sys.stderr.write('WARNING: %s lacks cockpit dependency' % manifest)
+        sys.stderr.write('WARNING: %s lacks cockpit dependency\n' % manifest)
+
+if max_version == 0:
+    sys.stderr.write('ERROR: Could not determine version\n')
+    sys.exit(1)
 
 print(max_version)

--- a/tools/min-base-version
+++ b/tools/min-base-version
@@ -28,7 +28,14 @@ from glob import glob
 proj_dir = os.path.dirname(os.path.dirname(os.path.realpath(sys.argv[0])))
 
 max_version = 0
+
 for manifest in glob(os.path.join(proj_dir, 'pkg/*/manifest.json.in')):
+    # if pkg names are given on the command line, then only look at those,
+    # otherwise on all of them
+    if len(sys.argv) > 1:
+        pkg = os.path.basename(os.path.dirname(manifest))
+        if pkg not in sys.argv[1:]:
+            continue
     with open(manifest) as f:
         requires = json.load(f).get('requires', {})
     try:


### PR DESCRIPTION
This implements the idea from issue #5997. This completely eliminates the remaining duplication of versions between manifests and the spec file (some of which wer even inconsistent), and now uses dependencies which exactly reflect the manifests, not a global maximum over all of those.

It also robustifies the package build to actually fail (instead of silently creating bogus ">= 0" dependencies) if we ever change the layout of the manifests again (commit 15dc531 silently broke this).