### PR TITLE
test: Wait for the sync-password field to be present

### DIFF
--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -241,6 +241,7 @@ class TestDashboardSetup(MachineCase, DashBoardHelpers):
         b.click('#dashboard_setup_server_dialog .btn-primary')
         b.wait_present("#dashboard_setup_server_dialog .btn-primary:not([disabled])")
         b.wait_text('#dashboard_setup_server_dialog .dialog-error', "Login failed")
+        b.wait_present('#sync-password')
         b.set_val('#sync-password', "foobar")
 
         b.click('#dashboard_setup_server_dialog .btn-primary')


### PR DESCRIPTION
In check-dashboard.