### PR TITLE
bridge: Read the "priority" manifest.json field as a double

### DIFF
--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -362,11 +362,11 @@ compar_manifest_priority (JsonObject *manifest1,
                           JsonObject *manifest2,
                           const gchar *name)
 {
-  gint64 priority1 = 1;
-  gint64 priority2 = 1;
+  gdouble priority1 = 1;
+  gdouble priority2 = 1;
 
-  if (!cockpit_json_get_int (manifest1, "priority", 1, &priority1) ||
-      !cockpit_json_get_int (manifest2, "priority", 1, &priority2))
+  if (!cockpit_json_get_double (manifest1, "priority", 1, &priority1) ||
+      !cockpit_json_get_double (manifest2, "priority", 1, &priority2))
     {
       g_message ("%s%sinvalid \"priority\" field in package manifest",
                  name ? name : "", name ? ": " : "");

--- a/src/common/cockpitjson.c
+++ b/src/common/cockpitjson.c
@@ -53,6 +53,34 @@ cockpit_json_get_int (JsonObject *object,
 }
 
 gboolean
+cockpit_json_get_double (JsonObject *object,
+                         const gchar *name,
+                         gdouble defawlt,
+                         gdouble *value)
+{
+  JsonNode *node;
+
+  node = json_object_get_member (object, name);
+  if (!node)
+    {
+      if (value)
+        *value = defawlt;
+      return TRUE;
+    }
+  else if (json_node_get_value_type (node) == G_TYPE_INT64 ||
+           json_node_get_value_type (node) == G_TYPE_DOUBLE)
+    {
+      if (value)
+        *value = json_node_get_double (node);
+      return TRUE;
+    }
+  else
+    {
+      return FALSE;
+    }
+}
+
+gboolean
 cockpit_json_get_bool (JsonObject *object,
                        const gchar *name,
                        gboolean defawlt,

--- a/src/common/cockpitjson.h
+++ b/src/common/cockpitjson.h
@@ -61,6 +61,11 @@ gboolean       cockpit_json_get_int           (JsonObject *object,
                                                gint64 defawlt,
                                                gint64 *value);
 
+gboolean       cockpit_json_get_double        (JsonObject *object,
+                                               const gchar *member,
+                                               gdouble defawlt,
+                                               gdouble *value);
+
 gboolean       cockpit_json_get_bool          (JsonObject *object,
                                                const gchar *member,
                                                gboolean defawlt,

--- a/src/common/test-json.c
+++ b/src/common/test-json.c
@@ -29,7 +29,7 @@
 static const gchar *test_data =
   "{"
   "   \"string\": \"value\","
-  "   \"number\": 55,"
+  "   \"number\": 55.4,"
   "   \"array\": [ \"one\", \"two\", \"three\" ],"
   "   \"object\": { \"test\": \"one\" },"
   "   \"bool\": true,"
@@ -113,6 +113,31 @@ test_get_int (TestCase *tc,
   g_assert (ret == FALSE);
 
   ret = cockpit_json_get_int (tc->root, "string", 66, NULL);
+  g_assert (ret == FALSE);
+}
+
+static void
+test_get_double (TestCase *tc,
+                 gconstpointer data)
+{
+  gboolean ret;
+  gdouble value;
+
+  ret = cockpit_json_get_double (tc->root, "number", 0, &value);
+  g_assert (ret == TRUE);
+  g_assert_cmpfloat (value, ==, 55.4);
+
+  ret = cockpit_json_get_double (tc->root, "number", 0, NULL);
+  g_assert (ret == TRUE);
+
+  ret = cockpit_json_get_double (tc->root, "unknown", 66.4, &value);
+  g_assert (ret == TRUE);
+  g_assert_cmpfloat (value, ==, 66.4);
+
+  ret = cockpit_json_get_double (tc->root, "string", 66.4, &value);
+  g_assert (ret == FALSE);
+
+  ret = cockpit_json_get_double (tc->root, "string", 66.4, NULL);
   g_assert (ret == FALSE);
 }
 
@@ -670,6 +695,8 @@ main (int argc,
               setup, test_get_string, teardown);
   g_test_add ("/json/get-int", TestCase, NULL,
               setup, test_get_int, teardown);
+  g_test_add ("/json/get-double", TestCase, NULL,
+              setup, test_get_double, teardown);
   g_test_add ("/json/get-bool", TestCase, NULL,
               setup, test_get_bool, teardown);
   g_test_add ("/json/get-null", TestCase, NULL,


### PR DESCRIPTION
This allows people to use floating point numbers to prioritize
packages. A corner case, but done for completeness.