### PR TITLE
dashboard: Bump cockpit dependency to > 132

### DIFF
--- a/pkg/dashboard/manifest.json.in
+++ b/pkg/dashboard/manifest.json.in
@@ -1,7 +1,7 @@
 {
     "version": "@VERSION@",
     "requires": {
-	"cockpit": "122"
+	"cockpit": "132.x"
     },
 
     "dashboard": {


### PR DESCRIPTION
The dashboard now calls the bridge's new cockpit.Machines D-Bus
interface for managing remote Cockpit machines, so bump its dependency
accordingly. Now that we use per-binary package dependencies for the
RPMs this will not needlessly bump the dependencies for other packages.
In fact it will not even affect cockpit-dashboard.{rpm,deb} as these
doen't use %{required_base}, but let's still provide the correct
information for developers.

----

Note: This is not release critical at all, and in fact it will not affect any actual binary packages. It's mostly just for bookkeeping and may help for manual installs (like @larskarlitski noticed on his system).