### PR TITLE
test: Fix race condition in machines.json migration test

### DIFF
--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -285,6 +285,7 @@ class TestDashboardSetup(MachineCase, DashBoardHelpers):
         # prevent migration due to permission error; should not crash and keep/respect the old file
         m.execute("""chattr +i /etc/cockpit/machines.d""")
         self.login_and_go("/dashboard")
+        wait(lambda: m.execute("journalctl -b | grep 'migration.*machines.json.*failed'"))
         self.wait_dashboard_addresses (b, [ "localhost", "1.2.3.4" ])
         b.logout()
         # should not have written anything and left the original file untouched
@@ -294,18 +295,18 @@ class TestDashboardSetup(MachineCase, DashBoardHelpers):
 
         # now machines.d/ is writable, should migrate
         self.login_and_go("/dashboard")
+        wait(lambda: m.execute("test ! -e /var/lib/cockpit/machines.json && ls /etc/cockpit/machines.d/99-webui.json"))
         self.wait_dashboard_addresses (b, [ "localhost", "1.2.3.4" ])
         b.logout()
-        m.execute('test ! -e /var/lib/cockpit/machines.json')
         self.assertEqual(m.execute('cat /etc/cockpit/machines.d/99-webui.json').strip(), blue_conf)
 
         # old /var file should not clobber existing 99-webui.json but move to 98-migrated.json and merge its data
         green_conf = '{"green": {"address": "9.8.7.6", "visible": true}}'
         m.execute("echo '%s' > /var/lib/cockpit/machines.json" % green_conf)
         self.login_and_go("/dashboard")
+        wait(lambda: m.execute("test ! -e /var/lib/cockpit/machines.json && ls /etc/cockpit/machines.d/98-migrated.json"))
         self.wait_dashboard_addresses (b, [ "localhost", "1.2.3.4", "9.8.7.6" ])
         b.logout()
-        m.execute('test ! -e /var/lib/cockpit/machines.json')
         self.assertEqual(m.execute('cat /etc/cockpit/machines.d/99-webui.json').strip(), blue_conf)
         self.assertEqual(m.execute('cat /etc/cockpit/machines.d/98-migrated.json').strip(), green_conf)
 


### PR DESCRIPTION
The migration happens asynchronously after login in the privileged
bridge; we can't assume it's already done after logging in and the
dashboard shows the expected machines, as these may still have been read
from the old file in /var. Thus wait until the /var file is gone, or for
getting the error about the failed migration in the "nonwritable" case.