### PR TITLE
test: Really exit phantomjs on fatal errors

### DIFF
--- a/test/common/phantom-driver.js
+++ b/test/common/phantom-driver.js
@@ -416,6 +416,7 @@ page.onResourceError = function(ex) {
     } else if (ex.errorString.indexOf("Network access is disabled") !== -1) {
         sys.stderr.writeLine("ERROR: fatal problem: " + ex.errorString);
         phantom.exit(1);
+        process.exit(1);
     } else {
         loadFailure = ex.errorString + " " + ex.url;
     }


### PR DESCRIPTION
Calling phantom.exit() doesn't really stop execution, and neither does
process.exit().  But both together seem to work.