### PR TITLE
machines: Fix the vms reducer to return always state object

### DIFF
--- a/pkg/machines/README.md
+++ b/pkg/machines/README.md
@@ -35,7 +35,7 @@ The external provider script must create global window.EXTERNAL_PROVIDER object 
 
     window.EXTERNAL_PROVIDER = {
         name: 'YOUR PROVIDER NAME',
-        init: function ( providerContext) {return true;}, // return boolean or Promise
+        init: function (providerContext) {return true;}, // return boolean or Promise
 
         GET_VM: function ({ lookupId: name }) { return dispatch => {...}; }, // return Promise
         GET_ALL_VMS: function () {},

--- a/pkg/machines/libvirt.es6
+++ b/pkg/machines/libvirt.es6
@@ -69,14 +69,13 @@ LIBVIRT_PROVIDER = {
      * Initialize the provider.
      * Arguments are used for reference only, they are actually not needed for this Libvirt provider.
      *
-     * @param actionCreators - Map of action creators (functions)
-     * @param nextProvider - Next provider in chain, recently Libvirt. Used for chaining commands or fallbacks.
-     * @returns {boolean} - true, if initialization succeeded
+     * @param providerContext - see `getProviderContext()` in provider.es6
+     * @returns {boolean} - true, if initialization succeeded; or Promise
      */
-    init(actionCreators, nextProvider) {
-        // This is default provider - the Libvirt.
-        // We do not need to use actionCreators or nextProvider
-        return true;
+    init(providerContext) {
+        // This is default provider - the Libvirt, so we do not need to use the providerContext param.
+        // The method is here for reference only.
+        return true; // or Promise
     },
 
     canReset(vmState) {

--- a/pkg/machines/reducers.es6
+++ b/pkg/machines/reducers.es6
@@ -147,7 +147,7 @@ function vms(state, action) {
                 : getFirstIndexOfVm(state, 'name', action.payload.name, connectionName);
             if (index < 0) {
                 logDebug(`VM_ACTION_FAILED reducer(name='${action.payload.name}', connectionName='${connectionName}') not found, skipping`);
-                return ;
+                return state; // VM is (already) missing, do nothing, the failure was at least logged
             }
             const updatedVm = Object.assign({}, state[index],
                 {lastMessage: action.payload.message, lastMessageDetail: action.payload.detail});


### PR DESCRIPTION
Every Redux reducer is required to return a state object.
    
Before this fix, the "vms" reducer returned "undefined" when a VM could not be found.
This can happen i.e. if an action is initiated but the VM is removed before result is received.

A followup patch for https://github.com/cockpit-project/cockpit/pull/5972 is attached to this PR (just cleanup).
