### PR TITLE
machines: error message for a VM is formated better

### DIFF
--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -191,9 +191,16 @@ const VmLastMessage = ({ vm }) => {
 
     const detail = (vm.lastMessageDetail && vm.lastMessageDetail.exception) ? vm.lastMessageDetail.exception: vm.lastMessage;
     return (
-        <p title={detail} data-toggle='tooltip'>
-            <span className='pficon-warning-triangle-o' />&nbsp;{vm.lastMessage}
-        </p>
+        <tr>
+            <td>
+                <span className='pficon-warning-triangle-o' />
+            </td>
+            <td>
+                <div title={detail} data-toggle='tooltip'>
+                    {vm.lastMessage}
+                </div>
+            </td>
+        </tr>
     );
 };
 VmLastMessage.propTypes = {
@@ -210,6 +217,7 @@ const VmOverviewTab = ({ vm }) => {
                         <VmOverviewTabRecord descr={_("Memory:")}
                                              value={cockpit.format_bytes((vm.currentMemory ? vm.currentMemory : 0) * 1024)}/>
                         <VmOverviewTabRecord id={`${vmId(vm.name)}-vcpus`} descr={_("vCPUs:")} value={vm.vcpus}/>
+                        <VmLastMessage vm={vm} />
                     </table>
                 </td>
 
@@ -222,7 +230,6 @@ const VmOverviewTab = ({ vm }) => {
                 </td>
             </tr>
         </table>
-        <VmLastMessage vm={vm} />
     </div>);
 };
 VmOverviewTab.propTypes = {

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -322,9 +322,13 @@ const Vm = ({ vm, config, onStart, onShutdown, onForceoff, onReboot, onForceRebo
         ));
     }
 
+    const rowName = (vm.lastMessage) ?
+        (<div><span className='pficon-warning-triangle-o' />&nbsp;{vm.name}</div>)
+        : (vm.name);
+
     return (<ListingRow
         columns={[
-            {name: vm.name, 'header': true},
+            {name: rowName, 'header': true},
             rephraseUI('connections', vm.connectionName),
             stateIcon
             ]}

--- a/pkg/machines/libvirt.es6
+++ b/pkg/machines/libvirt.es6
@@ -61,6 +61,14 @@ function getValueFromLine(parsedLines, pattern) {
     return isEmpty(selectedLine) ? undefined : selectedLine.toString().trim().substring(pattern.length).trim();
 }
 
+/**
+ * Returns a function handling VM action failures.
+ */
+function buildFailHandler({ dispatch, name, connectionName, message }) {
+    return ({ exception, data }) =>
+        dispatch(vmActionFailed({name, connectionName, message, detail: {exception, data}}));
+}
+
 let LIBVIRT_PROVIDER = {};
 LIBVIRT_PROVIDER = {
     name: 'Libvirt',
@@ -160,8 +168,7 @@ LIBVIRT_PROVIDER = {
         logDebug(`${this.name}.SHUTDOWN_VM(${name}):`);
         return dispatch => spawnVirsh({connectionName,
             method: 'SHUTDOWN_VM',
-            failHandler: ({exception, data}) => dispatch(vmActionFailed({name, connectionName,
-                message: _("SHUTDOWN_VM action failed"), detail: {exception, data}})),
+            failHandler: buildFailHandler({ dispatch, name, connectionName, message: _("VM SHUT DOWN action failed")}),
             args: ['shutdown', name]
         });
     },
@@ -170,8 +177,7 @@ LIBVIRT_PROVIDER = {
         logDebug(`${this.name}.FORCEOFF_VM(${name}):`);
         return dispatch => spawnVirsh({connectionName,
             method: 'FORCEOFF_VM',
-            failHandler: ({exception, data}) => dispatch(vmActionFailed({name, connectionName,
-                message: _("FORCEOFF_VM action failed"), detail: {exception, data}})),
+            failHandler: buildFailHandler({ dispatch, name, connectionName, message: _("VM FORCE OFF action failed")}),
             args: ['destroy', name]
         });
     },
@@ -180,8 +186,7 @@ LIBVIRT_PROVIDER = {
         logDebug(`${this.name}.REBOOT_VM(${name}):`);
         return dispatch => spawnVirsh({connectionName,
             method: 'REBOOT_VM',
-            failHandler: ({exception, data}) => dispatch(vmActionFailed({name, connectionName,
-                message: _("REBOOT_VM action failed"), detail: {exception, data}})),
+            failHandler: buildFailHandler({ dispatch, name, connectionName, message: _("VM REBOOT action failed")}),
             args: ['reboot', name]
         });
     },
@@ -190,8 +195,7 @@ LIBVIRT_PROVIDER = {
         logDebug(`${this.name}.FORCEREBOOT_VM(${name}):`);
         return dispatch => spawnVirsh({connectionName,
             method: 'FORCEREBOOT_VM',
-            failHandler: ({exception, data}) => dispatch(vmActionFailed({name, connectionName,
-                message: _("FORCEREBOOT_VM action failed"), detail: {exception, data}})),
+            failHandler: buildFailHandler({ dispatch, name, connectionName, message: _("VM FORCE REBOOT action failed")}),
             args: ['reset', name]
         });
     },
@@ -200,8 +204,7 @@ LIBVIRT_PROVIDER = {
         logDebug(`${this.name}.START_VM(${name}):`);
         return dispatch => spawnVirsh({connectionName,
             method: 'START_VM',
-            failHandler: ({exception, data}) => dispatch(vmActionFailed({name, connectionName,
-                message: _("START_VM action failed"), detail: {exception, data}})),
+            failHandler: buildFailHandler({ dispatch, name, connectionName, message: _("VM START action failed")}),
             args: ['start', name]
         });
     }


### PR DESCRIPTION
If an active VM operation fails, the error message is so far rendered in the VM's Overview subtab.

With this fix, the message is better formatted - aligned with the rest of details on the subtab.

In addition, the user is notified by a triangle icon rendered before the VM name in the overall VMs list that something went wrong.
