### PR TITLE
test: Log retries properly

### DIFF
--- a/test/common/log.html
+++ b/test/common/log.html
@@ -135,7 +135,7 @@
         <script>
 
 var tap_range = /^([0-9]+)\.\.([0-9]+)$/m;
-var tap_result = /^(ok|not ok) ([0-9]+) (.*\))(?: duration: ([0-9]+s))?(?: # SKIP .*)?$$/gm;
+var tap_result = /^(ok|not ok) ([0-9]+) (.*)\)(?: duration: ([0-9]+s))?(?: # SKIP .*)?$$/gm;
 var tap_skipped = /^ok [0-9]+ ([^#].*\))(?: duration: ([^#]*))? # SKIP (.*$)/gm;
 var image_file = /([A-Za-z0-9-]+)\.(png)$/gm;
 var journal_file = /(Journal extracted to )([A-Za-z0-9\-\.]+)\.(log)$/gm;
@@ -190,7 +190,7 @@ function extract(text) {
         }
 
         var test_links = {};
-        segments.forEach(function (segment) {
+        segments.forEach(function (segment, segmentIndex) {
             tap_range.lastIndex = 0;
             tap_result.lastIndex = 0;
             tap_skipped.lastIndex = 0;
@@ -232,10 +232,19 @@ function extract(text) {
                     failed += 1;
                 }
             } else {
-                entry.idx = 10000;
-                entry.id = "in-progress";
-                entry.title = "in progress";
-                entry.passed = true;
+                // if this isn't the last segment and we don't have a result, treat it as failed
+                if (segmentIndex+1 < segments.length) {
+                    entry.idx = 8000;
+                    entry.id = segment.split("\n")[1].slice(2);
+                    entry.title = entry.id;
+                    entry.passed = false;
+                    failed += 1;
+                } else {
+                    entry.idx = 10000;
+                    entry.id = "in-progress";
+                    entry.title = "in progress";
+                    entry.passed = true;
+                  }
             }
             while (m = image_file.exec(segment)) {
                 // we have an image link

--- a/test/common/log.html
+++ b/test/common/log.html
@@ -105,7 +105,7 @@
         <script id="TestingOverview" type="text/template">
             <div id="testing">
                 {{total}} tests, {{passed}} passed, {{failed}} failed,
-                {{skipped}} skipped, {{left}} to go.<br>
+                {{skipped}} skipped, {{left}} to go ({{retries}} retries).<br>
 
                 <span>Failed and skipped tests:</span>
                 <ul>
@@ -157,13 +157,14 @@ var journal_template = $("#JournalLink").html();
 Mustache.parse(journal_template);
 
 function extract(text) {
-    var m;
+    var m, s;
     var first, last, total, passed, failed, skipped;
     /* default is to show the text we have, unless we find actual results */
     var altered_text = Mustache.render(text_only_template, {
                     text: text
                 });
     var entries = [];
+    var indices = {};
     if (m = tap_range.exec(text)) {
         first = parseInt(m[1], 10);
         last = parseInt(m[2], 10);
@@ -172,9 +173,21 @@ function extract(text) {
         passed = 0;
         failed = 0;
         skipped = 0;
+        retries = 0;
 
         var segments = text.split(test_header_start);
         $('#test-info').text(text.slice(0, text.indexOf('\n')));
+
+        // delete retried segments
+        for (s = 0; s < segments.length; s += 1) {
+            if (!segments[s].contains("Retrying due to failure of test harness or framework"))
+                continue;
+            segments.splice(s, 1);
+            retries += 1;
+            // don't count this against the total number of tests
+            total -= 1;
+            last -= 1;
+        }
 
         var test_links = {};
         segments.forEach(function (segment) {
@@ -260,6 +273,7 @@ function extract(text) {
                                                                 passed: passed,
                                                                 failed: failed,
                                                                 skipped: skipped,
+                                                                retries: retries,
                                                                 total: total,
                                                                 left: total - passed - failed - skipped
                                                               })


### PR DESCRIPTION
Also treat unknown status as an error, e.g. for
```
python: ../nptl/pthread_mutex_lock.c:81: __pthread_mutex_lock: Assertion `mutex->__data.__owner == 0' failed.
```

The numbering of tests with the retries is currently bugged. I'm not sure if we should work around this in the log.html or fix it in the tests: Some numbers occur multiple times (e.g. test 128).