### PR TITLE
Use SSCG for creation of certificates

### DIFF
--- a/doc/guide/https.xml
+++ b/doc/guide/https.xml
@@ -53,9 +53,10 @@ MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCyOJ5garOYw0sm
 -----END PRIVATE KEY-----
 </programlisting>
 
-    <para>If no certificate is found, a self-signed certificate is created. using the
-      <code>openssl</code> command and stored in the
-      <filename>0-self-signed.cert</filename> file.</para>
+    <para>If no certificate is found, a self-signed certificate is created and
+      stored in the <filename>0-self-signed.cert</filename> file. On some
+      platforms, Cockpit will also generate a ca.crt in that directory, which
+      may be safely imported into client browsers.</para>
 
     <para>To check which certificate <code>cockpit-ws</code> will use run
       the following command.</para>

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -86,6 +86,7 @@ Requires: %{name}-system = %{version}-%{release}
 Recommends: %{name}-dashboard = %{version}-%{release}
 Recommends: %{name}-networkmanager = %{version}-%{release}
 Recommends: %{name}-storaged = %{version}-%{release}
+Recommends: sscg >= 2.0.4
 %ifarch x86_64 %{arm} aarch64 ppc64le
 Recommends: %{name}-docker = %{version}-%{release}
 %endif


### PR DESCRIPTION
Last year, I wrote a [blog post](https://sgallagh.wordpress.com/2016/05/02/self-signed-ssltls-certificates-why-they-are-terrible-and-a-better-alternative/) on some of the reasons why self-signed certificates are bad and what we can do to be safer in those environments where their use (or the use of something like them) is unavoidable.

tl;dr version: We create a single-use Certificate Authority with X509v3 restrictions to allow it to sign exactly one certificate, then destroy the private key so it can never be reused.

To that end, I built a tool called SSCG (Simple Signed Certificate Generator) to offer an easy way to generate these safer certificates. This pull request adds support to Cockpit to use the sscg when it needs to generate a certificate (because none is currently present).

The first commit adds all of the logic necessary to fork a request to sscg and generate the certificates. It is also designed in such a way that if sscg does not exist (or fails for some reason), it will fall back to the existing OpenSSL approach for generating self-signed certificates.

The second commit modifies the RPM spec file to build with SSCG support by default and to add Recommends: to it on those platforms where SSCG is available.