### PR TITLE
test: Don't use String.contains in log.html

### DIFF
--- a/test/common/log.html
+++ b/test/common/log.html
@@ -180,7 +180,7 @@ function extract(text) {
 
         // delete retried segments
         for (s = 0; s < segments.length; s += 1) {
-            if (!segments[s].contains("Retrying due to failure of test harness or framework"))
+            if (segments[s].indexOf("Retrying due to failure of test harness or framework") == -1)
                 continue;
             segments.splice(s, 1);
             retries += 1;


### PR DESCRIPTION
Let's just use the good old indexOf.

String.contains was Firefox-only and is gone since version 40.  See
https://bugzilla.mozilla.org/show_bug.cgi?id=1102219.