### PR TITLE
test: Fix retry accounting in log.html

### DIFF
--- a/test/common/log.html
+++ b/test/common/log.html
@@ -183,6 +183,7 @@ function extract(text) {
             if (segments[s].indexOf("Retrying due to failure of test harness or framework") == -1)
                 continue;
             segments.splice(s, 1);
+            s -= 1;
             retries += 1;
         }
 

--- a/test/common/log.html
+++ b/test/common/log.html
@@ -184,9 +184,6 @@ function extract(text) {
                 continue;
             segments.splice(s, 1);
             retries += 1;
-            // don't count this against the total number of tests
-            total -= 1;
-            last -= 1;
         }
 
         var test_links = {};


### PR DESCRIPTION
We don't need to adjust the total count when a retry happens.  The total
is determined upfront and never changes.  It's not the number of
segments, for example.