### PR TITLE
Image refresh for debian-8

### DIFF
--- a/test/images/debian-8
+++ b/test/images/debian-8
@@ -1,1 +1,1 @@
-debian-8-376f9a0d65894bd93a6a8c827fbbf77f54efe7d1.qcow2
+debian-8-4f2eb04c47dfbbdff6cede3becc5121d7b7eabf9.qcow2


### PR DESCRIPTION
Image creation for debian-8 in process on cockpit-9.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-8-2017-03-08/