### PR TITLE
ws: Get packages checksum from headers rather than init

### DIFF
--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -34,6 +34,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+/*
+ * To recalculate the checksums found in this file, do something like:
+ * $ XDG_DATA_DIRS=$PWD/src/bridge/mock-resource/glob/ XDG_DATA_HOME=/nonexistant cockpit-bridge --packages
+ */
+
 extern const gchar **cockpit_bridge_data_dirs;
 extern const gchar *cockpit_bridge_local_address;
 extern gint cockpit_bridge_packages_port;
@@ -529,7 +534,7 @@ test_list_bad_name (TestCase *tc,
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
   cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":"
-                                     "{\"Content-Type\":\"application/json\"}}"
+                                     "{\"X-Cockpit-Pkg-Checksum\":\"524d07b284cda92c86a908c67014ee882a80193b\",\"Content-Type\":\"application/json\",\"ETag\":\"\\\"$524d07b284cda92c86a908c67014ee882a80193b\\\"\"}}"
                                  "{\"ok\":{}}", -1);
   g_assert_cmpuint (count, ==, 2);
   g_bytes_unref (data);
@@ -555,7 +560,7 @@ test_glob (TestCase *tc,
   message = mock_transport_pop_channel (tc->transport, "444");
   object = cockpit_json_parse_bytes (message, &error);
   g_assert_no_error (error);
-  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Content-Type\":\"text/plain\"}}");
+  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-Cockpit-Pkg-Checksum\":\"4f2a5a7bb5bf355776e1fc83831b1d846914182e\",\"Content-Type\":\"text/plain\"}}");
   json_object_unref (object);
 
   message = mock_transport_pop_channel (tc->transport, "444");

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -46,6 +46,8 @@ typedef enum {
   COCKPIT_WEB_RESPONSE_CACHE_PRIVATE,
 } CockpitCacheType;
 
+#define COCKPIT_CHECKSUM_HEADER "X-Cockpit-Pkg-Checksum"
+
 typedef struct _CockpitWebResponse        CockpitWebResponse;
 
 extern const gchar *  cockpit_web_exception_escape_root;

--- a/src/ws/cockpitwebservice.h
+++ b/src/ws/cockpitwebservice.h
@@ -64,15 +64,6 @@ gchar *                 cockpit_web_service_unique_channel   (CockpitWebService 
 CockpitTransport *      cockpit_web_service_ensure_transport (CockpitWebService *self,
                                                               JsonObject *open);
 
-CockpitTransport *      cockpit_web_service_find_transport   (CockpitWebService *self,
-                                                              const gchar *checksum);
-
-const gchar *           cockpit_web_service_get_checksum     (CockpitWebService *self,
-                                                              CockpitTransport *transport);
-
-const gchar *           cockpit_web_service_get_host         (CockpitWebService *self,
-                                                              CockpitTransport *transport);
-
 gboolean                cockpit_web_service_parse_binary     (JsonObject *open,
                                                               WebSocketDataType *type);
 
@@ -80,6 +71,16 @@ gboolean                cockpit_web_service_parse_external   (JsonObject *open,
                                                               const gchar **content_type,
                                                               const gchar **content_disposition,
                                                               gchar ***protocols);
+
+const gchar *           cockpit_web_service_get_host         (CockpitWebService *self,
+                                                              const gchar *checksum);
+
+const gchar *           cockpit_web_service_get_checksum     (CockpitWebService *self,
+                                                              const gchar *host);
+
+void                    cockpit_web_service_set_host_checksum        (CockpitWebService *self,
+                                                                      const gchar *host,
+                                                                      const gchar *checksum);
 
 void           cockpit_web_service_get_transport_init_message_aysnc  (CockpitWebService *self,
                                                                       CockpitTransport *transport,

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -475,7 +475,7 @@ test_resource_redirect_checksum (TestResourceCase *tc,
 
   /* Start the connection up, and poke it a bit */
   response = cockpit_web_response_new (io, "/", "/", NULL, NULL);
-  cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/not-found");
+  cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/test/sub/file.ext");
 
   while (cockpit_web_response_get_state (response) != COCKPIT_WEB_RESPONSE_SENT)
     g_main_context_iteration (NULL, TRUE);

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -504,6 +504,7 @@ class TestMultiMachine(MachineCase):
         b.enter_page("/dashboard")
         # Check the server image
         b.wait_present("#dashboard-hosts a[data-address='%s']" % m2.address)
+        b.wait_present("#dashboard-hosts a[data-address='%s'] img" % m2.address)
         b.wait_attr("#dashboard-hosts a[data-address='%s'] img" % m2.address, 'src', '../shell/images/server-small.png')
         b.switch_to_top()
 


### PR DESCRIPTION
Preparing for the cockpit-ssh move. We can't rely on cockpit-ws getting a init message for each host. So discover and store the host -> checksum mapping differently.