### PR TITLE
test: Use core dump workaround also on fedora-testing

### DIFF
--- a/test/images/fedora-testing
+++ b/test/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-c357f63b9117057c3c07bbc566a5d5a1904195f3.qcow2
+fedora-testing-9dcd31ecd7c2d3bb505eb836468ffcb20c6c3407.qcow2

--- a/test/images/scripts/fedora-testing.setup
+++ b/test/images/scripts/fedora-testing.setup
@@ -104,6 +104,11 @@ docker build -t cockpit/base /var/tmp/cockpit-base
 # docker images that we need for integration testing
 /var/lib/testvm/docker-images.setup
 
+# HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1341829
+# SELinux breaks coredumping on fedora-25
+printf '(allow init_t domain (process (rlimitinh)))\n' > domain.cil
+semodule -i domain.cil
+
 # reduce image size
 dnf clean all
 /var/lib/testvm/zero-disk.setup


### PR DESCRIPTION
Because we want that to work for our own benefits.