### PR TITLE
machines: Integration test for ext-provider API

### DIFF
--- a/pkg/machines/README.md
+++ b/pkg/machines/README.md
@@ -64,7 +64,7 @@ The external provider script must create global window.EXTERNAL_PROVIDER object 
           ],
     };
 
-The provider methods are expected to return a Promise.
+The provider methods are expected to return function `(dispatch) => Promise`.
 
 The `providerContext` passed to the `init()` function as an argument consists of:
 
@@ -76,9 +76,11 @@ The `providerContext` passed to the `init()` function as an argument consists of
         exportedReactComponents, // exported React components for reuse in the plugged provider
     }
             
-Please refer the libvirt.es6 for the most current API description and more details.
+Please refer the `libvirt.es6` for the most current API description and more details.
 
-Referential implementation of an external provider is the cockpit-machines-ovirt-provider [2]
+Please refer `cockpit/test/verify/files/cockpitMachinesTestExternalProvider.js` for a "Hello World" implementation in Vanilla JS.
+
+External provider referential implementation is the `cockpit-machines-ovirt-provider` [2] written in ES6 and fully using React/Redux/Webpack.
 
 ## Links
 \[1\] [How to enable nested virtualization in KVM](https://fedoraproject.org/wiki/How_to_enable_nested_virtualization_in_KVM)

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -63,7 +63,11 @@ const VmActions = ({ vmId, state, config, onStart, onReboot, onForceReboot, onSh
         }]
     }) : '';
 
-    const run = config.provider.canRun(state) ? (<button className="btn btn-default btn-danger" onClick={onStart}>{_("Run")}</button>) : '';
+    const run = config.provider.canRun(state) ?
+        (<button className="btn btn-default btn-danger" onClick={onStart} id={`${vmId}-run`}>
+            {_("Run")}
+        </button>)
+        : '';
 
     return (<div>
         {reset}
@@ -148,7 +152,7 @@ export const DropdownButtons = ({ buttons }) => {
 
     const caretId = buttons[0]['id'] ? `${buttons[0]['id']}-caret` : undefined;
     return (<div className='btn-group'>
-        <button className='btn btn-default btn-danger' onClick={buttons[0].action}>
+        <button className='btn btn-default btn-danger' onClick={buttons[0].action} id={buttons[0]['id']}>
             {buttons[0].title}
         </button>
         <button data-toggle='dropdown' className='btn btn-default dropdown-toggle'>
@@ -190,6 +194,7 @@ const VmLastMessage = ({ vm }) => {
         return null;
     }
 
+    const msgId = `${vmId(vm.name)}-last-message`;
     const detail = (vm.lastMessageDetail && vm.lastMessageDetail.exception) ? vm.lastMessageDetail.exception: vm.lastMessage;
     return (
         <tr>
@@ -197,7 +202,7 @@ const VmLastMessage = ({ vm }) => {
                 <span className='pficon-warning-triangle-o' />
             </td>
             <td>
-                <div title={detail} data-toggle='tooltip'>
+                <div title={detail} data-toggle='tooltip' id={msgId}>
                     {vm.lastMessage}
                 </div>
             </td>
@@ -324,9 +329,10 @@ const Vm = ({ vm, config, onStart, onShutdown, onForceoff, onReboot, onForceRebo
         ));
     }
 
+    const name = (<span id={`${vmId(vm.name)}-row`}>{vm.name}</span>);
     const rowName = (vm.lastMessage) ?
-        (<div><span className='pficon-warning-triangle-o' />&nbsp;{vm.name}</div>)
-        : (vm.name);
+        (<div><span className='pficon-warning-triangle-o' />&nbsp;{name}</div>)
+        : name;
 
     return (<ListingRow
         columns={[

--- a/pkg/machines/provider.es6
+++ b/pkg/machines/provider.es6
@@ -39,7 +39,7 @@ import { StateIcon, DropdownButtons } from './hostvmslist.jsx';
  * @param useProvider - function taking 'provider' as 1st argument and performs provider's registration and init
  * @param defaultProvider - used by default if no external provider is installed
  */
-function loadExternalProvider ({ useProvider, defaultProvider }) {
+function loadExternalProvider({ useProvider, defaultProvider }) {
     const scriptElement = $('<script/>').prop({src: 'provider/index.js', async: true});
     scriptElement.on('load', () => {
         logDebug(`External provider loaded: ${JSON.stringify(window.EXTERNAL_PROVIDER.name)}`);

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -36,11 +36,14 @@ def readFile(name):
 
 @skipImage("Atomic cannot run virtual machines", "fedora-atomic", "rhel-atomic", "continuous-atomic")
 class TestMachines(MachineCase):
-    vm1_name="subVmTest1"
-    vm1_id="#vm-{0}".format(vm1_name)
+    vm1_name = "subVmTest1"
+    vm1_id = "#vm-{0}".format(vm1_name)
     vm1_img = "/var/lib/libvirt/images/{0}.img".format(vm1_name)
     vm1_img2 = "/var/lib/libvirt/images/{0}_2.img".format(vm1_name)
     vm1_img3 = "/var/lib/libvirt/images/{0}_3.img".format(vm1_name)
+
+    providerVm1_name = "vm1"
+    providerVm1_id = "#vm-{0}".format(providerVm1_name)
 
     def envSetup(self):
         b = self.browser
@@ -182,6 +185,35 @@ class TestMachines(MachineCase):
         else:
             print "WARNING: Test VM creation failed, virt-install finished in 'paused' state. Skipping the 'add/remove disk' scenario"
 
+    def testProvider(self):
+        b = self.browser
+        m = self.machine
+
+        # install the provider
+        m.execute("mkdir /usr/share/cockpit/machines/provider")
+        m.upload(["verify/files/cockpitMachinesTestExternalProvider.js"], "/usr/share/cockpit/machines/provider") # do not rename
+        m.execute("mv /usr/share/cockpit/machines/provider/cockpitMachinesTestExternalProvider.js /usr/share/cockpit/machines/provider/index.js")
+
+        self.login_and_go("/machines")
+        b.wait_in_text("body", "Virtual Machines")
+        b.wait_present("{0}-row".format(self.providerVm1_id)) # is VM listed so the provider is correctly loaded, initialized and GET_ALL_VMS() passed??
+
+        b.click("{0}-row".format(self.providerVm1_id)) # click on the row header
+        b.wait_present("{0}-state".format(self.providerVm1_id))
+        b.wait_in_text("{0}-state".format(self.providerVm1_id), "running")
+
+        b.click("{0}-off".format(self.providerVm1_id)) # click the Shut Down button
+        b.wait_in_text("{0}-state".format(self.providerVm1_id), "shut off")
+
+        b.click("a:contains('Test Subtab')") # Click on the subtab injected by the Provider
+        b.wait_visible("#test-subtab-body-vm1") # is subtab rendered?
+        b.wait_in_text("#test-subtab-body-vm1", "Content of subtab")
+
+        b.click("{0}-run".format(self.providerVm1_id)) # click the Run button which intentionally leads to an error, so check it
+        b.click("a:contains('Overview')") # where the error message is rendered
+        b.wait_visible("{0}-state".format(self.providerVm1_id))
+        b.wait_present("{0}-last-message".format(self.providerVm1_id))
+        b.wait_in_text("{0}-last-message".format(self.providerVm1_id), "VM failed to start")
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/files/cockpitMachinesTestExternalProvider.js
+++ b/test/verify/files/cockpitMachinesTestExternalProvider.js
@@ -1,0 +1,375 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The simplest external provider for cockpit:machines.
+ *
+ * Used
+ *   - for Cockpit integration tests
+ *   - as a Hello World example for 3rd party development
+ *
+ * Written in VanillaJS.
+ *
+ * For more complex UI scenarios OR React, please consider ES6/Webpack as used in the `cockpit-machines-ovirt-provider`
+ * referential implementation (see cockpit:machines README.md for most current link to the project).
+ *
+ * Installation prerequisites:
+ *   - Have cockpit-machines package version >=133 installed and running
+ *
+ * Installation steps:
+ *   - # mkdir /usr/share/cockpit/machines/provider
+ *   - # cp [PATH_TO_THIS_JS_FILE] /usr/share/cockpit/machines/provider/index.js
+ *   - refresh/login to cockpit, go to the 'Virtual Machines' package
+ */
+
+(function () {
+  /**
+   * Will be created from init().
+   * In real and more complex provider, consider wrapping into objects as a namespace.
+   * If React is required, consider use of ES6/Webpack.
+   *
+   * For simple UI extensions, JQuery can be used as well but please do not update React-rendered DOM via JQuery.
+   */
+  var TestSubtabReactComponent = null;
+
+  var PROVIDER = {};
+  PROVIDER = {
+    name: 'TEST_PROVIDER',
+
+    actions: {}, // it's expected to be replaced by init()
+    parentReactComponents: {}, // to reuse look&feel, see init()
+    nextProvider: null, // will be default Libvirt provider in the basic scenario
+    vmStateMap: null, // see init()
+
+    /**
+     * Lazily initialize the Provider from the `providerContext`.
+     * Do login to external system if needed.
+     *
+     * Return boolean or Promise.
+     *
+     * See cockpit:machines provider.es6
+     */
+    init: function (providerContext) {
+      console.log("PROVIDER.init() called");
+
+      _checkInitParams(providerContext); // not needed on production, part of integration test
+
+      // The external provider is loaded into context of cockpit:machines plugin
+      // So, JQuery and Cockpit are available
+      if (!window.$) {
+        console.error('JQuery not found! The PROVIDER is not initialized, using default.');
+        return false;
+      }
+      if (!window.cockpit) {
+        console.error('Cockpit not found! The PROVIDER is not initialized, using default.');
+        return false;
+      }
+
+      PROVIDER.actions = providerContext.exportedActionCreators;
+      PROVIDER.parentReactComponents = providerContext.exportedReactComponents;
+      PROVIDER.nextProvider = providerContext.defaultProvider;
+      PROVIDER.vmStateMap = {}; // reuse map for Libvirt (defaultProvider.vmStateMap)
+
+      _lazyCreateReactComponents(providerContext.React);
+
+      return true; // or Promise
+    },
+
+    /**
+     * Manage visibility of VM action buttons or so.
+     *
+     * Recent implementation: redirect state functions back to Libvirt provider.
+     */
+    canReset: function (state) {
+      return PROVIDER.nextProvider.canReset(state);
+    },
+    canShutdown: function (state) {
+      return PROVIDER.nextProvider.canShutdown(state);
+    },
+    isRunning: function (state) {
+      return PROVIDER.nextProvider.isRunning(state);
+    },
+    canRun: function (state) {
+      return PROVIDER.nextProvider.canRun(state);
+    },
+    canConsole: function (state) {
+      return PROVIDER.nextProvider.canConsole(state);
+    },
+
+    /**
+     * Get a single VM
+     *
+     * Not needed for the scope of this minimal PROVIDER.
+     *
+     * See cockpit:machines actions.es6.
+     */
+    GET_VM: function (payload) {
+      console.log('PROVIDER.GET_VM called with params: ' + JSON.stringify(payload));
+      return function (dispatch) {
+        console.log('GET_VM not implemented for this PROVIDER');
+      };
+    },
+
+    /**
+     * Initiate read of all VMs.
+     */
+    GET_ALL_VMS: function (payload) {
+      console.log('PROVIDER.GET_ALL_VMS() called');
+      /* To redirect the call to Libvirt:
+       *    return PROVIDER.nextProvider.GET_ALL_VMS(payload);
+       */
+      return function (dispatch) {
+        // Example of using (Cockpit) Promise for async actions
+        return window.cockpit.spawn(['echo', 'Hello']).then(function (data) {
+          var CONNECTION_NAME = 'testConnection'; // Use whatever suits your needs. In Libvirt, [system | session] is used.
+
+          dispatch(PROVIDER.actions.updateOrAddVm({ // add
+            connectionName: CONNECTION_NAME,
+            name: 'vm1',
+            id: 'id-vm1',
+            osType: '',
+            currentMemory: '1048576', // 1 GB
+            vcpus: 1
+          }));
+          dispatch(PROVIDER.actions.updateOrAddVm({ // update
+            connectionName: CONNECTION_NAME,
+            name: 'vm1',
+            state: 'running',
+            autostart: 'enable'
+          }));
+
+          dispatch(PROVIDER.actions.updateOrAddVm({
+            connectionName: CONNECTION_NAME,
+            name: 'vm2',
+            id: 'id-vm2',
+            osType: '',
+            currentMemory: '2097152', // 2 GB
+            vcpus: 2,
+            state: 'shut off',
+            autostart: 'disable'
+          }));
+
+          // Schedule next GET_ALL_VMS() call if polling is needed, i.e. via dispatch(PROVIDER.actions.delayPolling(getAllVms()))
+        });
+      };
+    },
+
+    /**
+     * Call `shut down` on the VM.
+     */
+    SHUTDOWN_VM: function (payload) {
+      console.log('PROVIDER.SHUTDOWN_VM called with params: ' + JSON.stringify(payload));
+      const vmName = payload.name;
+      const connectionName = payload.connectionName;
+      return function (dispatch) {
+        /*
+         * Do external call, return Promise.
+         *
+         * Dummy implementation to see if it's working follows.
+         *
+         * In real provider, the SHUTDOWN_VM() initiates the operation in "external" system and
+         * then the redux state is updated via polling/events/scheduled focused refresh.
+         */
+
+        var dfd = window.cockpit.defer();
+
+        // mock the external system right here
+        dispatch(PROVIDER.actions.updateOrAddVm({
+          connectionName: connectionName,
+          name: vmName,
+          state: 'shut off',
+        }));
+
+        dfd.resolve();
+        return dfd.promise;
+      };
+    },
+
+
+    /**
+     * Example for VM action error handling.
+     *
+     * The error message will be displayed along the VM.
+     */
+    START_VM: function (payload) {
+      console.log('PROVIDER.REBOOT_VM called with params: ' + JSON.stringify(payload));
+      return function (dispatch) {
+        console.log('START_VM intentionally implemented as failing in this PROVIDER.');
+        const vmName = payload.name;
+        const connectionName = payload.connectionName;
+
+        dispatch(vmActionFailed({
+          name: vmName,
+          connectionName: connectionName,
+          message: 'VM failed to start',
+          detail: 'Detailed description of the failure.',
+        }));
+      };
+    },
+
+    /**
+     * Force shut down on the VM.
+     */
+    FORCEOFF_VM: function (payload) {
+      console.log('PROVIDER.FORCEOFF_VM called with params: ' + JSON.stringify(payload));
+      return function (dispatch) {
+        console.log('FORCEOFF_VM not implemented for this PROVIDER');
+      };
+    },
+
+    REBOOT_VM: function (payload) {
+      console.log('PROVIDER.REBOOT_VM called with params: ' + JSON.stringify(payload));
+      return function (dispatch) {
+        console.log('REBOOT_VM not implemented for this PROVIDER');
+      };
+    },
+
+    FORCEREBOOT_VM: function (payload) {
+      console.log('PROVIDER.FORCEREBOOT_VM called with params: ' + JSON.stringify(payload));
+      return function (dispatch) {
+        console.log('FORCEREBOOT_VM not implemented for this PROVIDER');
+      };
+    },
+
+    CONSOLE_VM: function (payload) {
+      console.log('PROVIDER.CONSOLE_VM called with params: ' + JSON.stringify(payload));
+      return function (dispatch) {
+        console.log('CONSOLE_VM not implemented for this PROVIDER');
+      };
+    },
+
+    /*
+     * Feel free to add additional VM action handlers not even recognized by the Libvirt
+     * as far as your provider's UI extension dispatches the correct actions via `PROVIDER.actions.virtMiddleware()`
+     *
+     * Example: MIGRATE_VM  or CREATE_VM in cockpit-machines-ovirt-provider
+     */
+
+    reducer: undefined, // optional reference to reducer function extending the application Redux state tree, see cockpit-machines-ovirt-provider for more detailed example
+
+    /**
+     * Optional array of
+     * {
+   *  name: 'My Tab Title',
+   *  componentFactory: () => yourReactComponentRenderingSubtabBody
+   *  }
+     *
+     * Please note, the React components have to be created lazily via `providerContext.React` passed to the init() function.
+     */
+    vmTabRenderers: [
+      {
+        name: 'Test Subtab',
+        componentFactory: function () {
+          return TestSubtabReactComponent;
+        }
+      },
+    ],
+
+    vmDisksActionsFactory: undefined, // optional
+    vmDisksColumns: undefined, // optional
+
+    /*
+     * Please note, there are additional methods/properties supported by the cockpit:machines API but out of the scope of this simple test implementation
+     * For full reference see either cockpit:machines sources or the cockpit-machines-ovirt-provider.
+     */
+  };
+
+  window.EXTERNAL_PROVIDER = PROVIDER;
+  console.info('PROVIDER registered');
+
+// ---------------------------------------------------------------------------------------------------------------------
+  /**
+   * Example of Redux action creator.
+   *
+   * Used to dispatch error message, handled in cockpit:machines reducers.es6 to update the Redux state.
+   */
+  function vmActionFailed(details) {
+    return {
+      type: 'VM_ACTION_FAILED',
+      payload: {
+        name: details.name,
+        connectionName: details.connectionName,
+        message: details.message,
+        detail: details.detail,
+      }
+    };
+  }
+
+  /**
+   * Example of lazy React components creation.
+   *
+   * Always reuse React library provided from the calling cockpit:machines context.
+   */
+  function _lazyCreateReactComponents(React) {
+    TestSubtabReactComponent = React.createClass(
+        {
+          propTypes: {
+            vm: React.PropTypes.object.isRequired,
+          },
+          render: function () {
+            var vm = this.props.vm;
+            return React.createElement('div', {id: 'test-subtab-body-' + vm.name}, 'Content of subtab');
+          }
+        }
+    );
+  }
+
+// --- Following functions are for integration tests only, not needed for a production external provider---------------
+  function ProviderException(text, detail) {
+    this.message = text + ': ' + JSON.stringify(detail);
+    this.name = 'ProviderException';
+  }
+
+  function _checkIsFunction(text, obj) {
+    if (!!(obj && obj.constructor && obj.call && obj.apply)) {
+      return true;
+    }
+    throw new ProviderException(text, obj);
+  }
+
+  function _checkEqual(text, objA, objB) {
+    if (objA === objB) {
+      return true;
+    }
+    throw new ProviderException(text, obj);
+  }
+
+  function _checkInitParams(providerContext) {
+    console.log('_checkInitParams called');
+    _checkEqual('The default provider shall be Libvirt', providerContext.defaultProvider.name, 'Libvirt');
+
+    _checkIsFunction('Reference to React shall be provided', providerContext.React.createClass);
+
+    _checkIsFunction('Reference to Redux shall be provided', providerContext.reduxStore.dispatch);
+    _checkIsFunction('Reference to Redux shall be provided', providerContext.reduxStore.subscribe);
+
+
+    var exportedActionCreators = providerContext.exportedActionCreators;
+    _checkIsFunction('exportedActionCreators.virtMiddleware shall be a function', exportedActionCreators.virtMiddleware);
+    _checkIsFunction('exportedActionCreators.delayRefresh shall be a function', exportedActionCreators.delayRefresh);
+    _checkIsFunction('exportedActionCreators.deleteUnlistedVMs shall be a function', exportedActionCreators.deleteUnlistedVMs);
+    _checkIsFunction('exportedActionCreators.updateOrAddVm shall be a function', exportedActionCreators.updateOrAddVm);
+
+    var exportedReactComponents = providerContext.exportedReactComponents;
+    _checkIsFunction('Listing React component shall be provided', exportedReactComponents.Listing);
+    _checkIsFunction('ListingRow React component shall be provided', exportedReactComponents.ListingRow);
+    _checkIsFunction('StateIcon React component shall be provided', exportedReactComponents.StateIcon);
+    _checkIsFunction('DropdownButtons React component shall be provided', exportedReactComponents.DropdownButtons);
+  }
+}());


### PR DESCRIPTION
The `check-machines` is extended for the `testProvider` test case to verify:
  - an external provider can be loaded and initialized as documented
  - ext-provider API conforms implementation

Within this PR, a simplest "Hello World" ext provider is implemented to
  - participate in the integration test
  - farther document the API by an example

Based on https://github.com/cockpit-project/cockpit/pull/6072 due to conflicting changes in `check-machines` there.