### PR TITLE
test: Use the version of phantomjs in node_modules by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -246,7 +246,7 @@ SH_LOG_DRIVER = $(top_srcdir)/tools/tap-driver
 HTML_LOG_DRIVER = $(top_srcdir)/tools/tap-driver
 HTML_TEST_SERVER = $(builddir)/test-server
 if WITH_PHANTOMJS
-HTML_LOG_COMPILER = $(top_srcdir)/tools/tap-phantom --strip=$(top_srcdir)/ -- $(HTML_TEST_SERVER)
+HTML_LOG_COMPILER = $(PHANTOMJS) $(top_srcdir)/tools/tap-phantom --strip=$(top_srcdir)/ -- $(HTML_TEST_SERVER)
 else
 HTML_LOG_DRIVER_FLAGS = --missing=phantomjs
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -292,8 +292,9 @@ fi
 
 # phantomjs
 
-AC_PATH_PROG([PHANTOMJS], [phantomjs], [], [$PATH$PATH_SEPARATOR$srcdir/node_modules/.bin/])
+AC_PATH_PROG([PHANTOMJS], [phantomjs], [], [$srcdir/node_modules/.bin$PATH_SEPARATOR$PATH])
 AM_CONDITIONAL([WITH_PHANTOMJS], [test -n "$PHANTOMJS"])
+AC_SUBST([PHANTOMJS])
 
 # go
 

--- a/test/common/phantom-command
+++ b/test/common/phantom-command
@@ -1,4 +1,4 @@
 #!/bin/sh
 BASE=$(dirname $0)
-PATH="$PATH:$BASE/../../node_modules/.bin"
+PATH="$BASE/../../node_modules/.bin:$PATH"
 exec phantomjs --ignore-ssl-errors=true --ssl-protocol=any $@


### PR DESCRIPTION
The tests seem to be sensitive to the version of phantomjs
installed. Lets work out a stable one. First lets control exactly
the version we want in our package.json development dependencies
and run the one downloaded into node_modules.