### PR TITLE
Bind-mount /etc/ssh into cockpit/ws container and update container scripts in test suite

### DIFF
--- a/containers/ws/atomic-install
+++ b/containers/ws/atomic-install
@@ -42,6 +42,9 @@ mkdir -p /host/var/lib/cockpit
 chmod 775 /host/var/lib/cockpit
 chown root:wheel /host/var/lib/cockpit
 
+# For sharing ssh's known hosts with container
+mkdir -p /etc/ssh
+
 # Ensure we have certificates
 /bin/mount --bind /host/etc/cockpit /etc/cockpit
 /usr/sbin/remotectl certificate --ensure

--- a/containers/ws/atomic-run
+++ b/containers/ws/atomic-run
@@ -15,6 +15,7 @@ set +x
 
 /bin/mount --bind /host/usr/share/pixmaps /usr/share/pixmaps
 /bin/mount --bind /host/var /var
+/bin/mount --bind /host/etc/ssh /etc/ssh
 
 # And run cockpit-ws
 exec /usr/bin/nsenter --net=/container/target-namespace/ns/net --uts=/container/target-namespace/ns/uts -- /usr/libexec/cockpit-ws "$@"

--- a/test/common/vmmanage.py
+++ b/test/common/vmmanage.py
@@ -27,8 +27,7 @@ def upload_scripts(machine, args):
     machine.execute("rm -rf /var/lib/testvm")
     machine.upload([ os.path.join(testinfra.TEST_DIR, "images", "scripts", "lib") ], "/var/lib/testvm")
     machine.upload([ os.path.join(testinfra.TEST_DIR, "images", "scripts", "%s.install" % machine.image) ], "/var/tmp")
-    if args["containers"]:
-        machine.upload([os.path.join(testinfra.TEST_DIR,"..", "containers")], "/var/tmp")
+    machine.upload([os.path.join(testinfra.TEST_DIR,"..", "containers")], "/var/tmp")
 
 def run_install_script(machine, do_build, do_install, skips, arg, args):
     install = do_install

--- a/test/images/scripts/lib/atomic.install
+++ b/test/images/scripts/lib/atomic.install
@@ -195,6 +195,10 @@ class AtomicCockpitInstaller:
                     print "updating cockpit-ws container"
                 subprocess.check_call(rpm_args)
 
+                # if we update the RPMs, also update the scripts, to keep them in sync
+                subprocess.check_call(["docker", "exec", "build-cockpit", "sh", "-exc",
+                                       "cp /host/var/tmp/containers/ws/atomic-* /container/"])
+
             subprocess.check_call(["docker", "commit", "build-cockpit",
                                    "cockpit/ws"])
             subprocess.check_call(["docker", "kill", "build-cockpit"])


### PR DESCRIPTION
This splits out two preparatory commits from PR #6025 while that is blocked. It's harmless with the current code, and means fewer moving parts with each PR.

Corresponding cockpit-container change: https://github.com/cockpit-project/cockpit-container/pull/8