### PR TITLE
Image refresh for centos-7

### DIFF
--- a/test/images/centos-7
+++ b/test/images/centos-7
@@ -1,1 +1,1 @@
-centos-7-7827c88179bc6cdaa86ef7da000b3e2164b7fb9f.qcow2
+centos-7-180b27f599f3457a1baee59ce6647d61879e8dbe.qcow2


### PR DESCRIPTION
Image creation for centos-7 in process on cockpit-11.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-centos-7-2017-03-11/