### PR TITLE
shell: Don't display lower navbar if empty or irrelevant

### DIFF
--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -227,14 +227,24 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                 el.toggleClass("active", el.attr("data-component") === state.component);
             });
 
+            /* When no dashboard type components show a minimal navbar */
+            var minimal = Object.keys(compiled.items).every(function(key) {
+                return compiled.items[key].section != "dashboard";
+            });
+
+            /* Unless there are more than one machine */
+            if (machines.list.length > 1)
+                minimal = false;
+
             var hide;
             if (machine && machine.static_hostname) {
                 hide = $(".dashboard-link").length < 2 && machines.list.length < 2;
-                $('#content-navbar').toggleClass("hidden", hide);
+                $('#content-navbar').toggleClass("hidden", hide || minimal);
             } else {
-                $('#content-navbar').toggleClass("hidden", false);
+                $('#content-navbar').toggleClass("hidden", minimal);
             }
 
+            /* When a dashboard no machine or sidebar */
             var item = compiled.items[state.component];
             if (item && item.section == "dashboard") {
                 delete state.sidebar;

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -112,12 +112,17 @@ WantedBy=default.target
         b.switch_to_frame("cockpit1:localhost/playground/test")
         b.wait_text("#hidden", "hidden")
 
+        b.switch_to_top()
+
+        # The top bar should not be visible on fedora-atomic because no dashboards
+        if "fedora-atomic" in m.image:
+            b.wait_not_visible("#content-navbar")
+
         # Lets try changing the language
         # Translations are not ready for RHEL yet
         if "rhel" in m.image:
             return
 
-        b.switch_to_top()
         b.click("#content-user-name")
         b.click(".display-language-menu a")
         b.wait_popup('display-language')


### PR DESCRIPTION
On operating systems like RHEL there will be many cases where there
are no dashboard items and the console is just used as a single
server console. In those cases just hide the navbar.