### PR TITLE
Image refresh for centos-7, with kubernetes regression quirk

### DIFF
--- a/test/images/centos-7
+++ b/test/images/centos-7
@@ -1,1 +1,1 @@
-centos-7-7827c88179bc6cdaa86ef7da000b3e2164b7fb9f.qcow2
+centos-7-180b27f599f3457a1baee59ce6647d61879e8dbe.qcow2

--- a/test/verify/naughty-centos-7/6059-kubernetes-broken-selfLink
+++ b/test/verify/naughty-centos-7/6059-kubernetes-broken-selfLink
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "kubelib.py", line *, in testNodes
+    b.wait_not_present("modal-dialog")
+*
+the server could not find the requested resource

--- a/test/verify/naughty-centos-7/6059-kubernetes-broken-selfLink-2
+++ b/test/verify/naughty-centos-7/6059-kubernetes-broken-selfLink-2
@@ -1,0 +1,4 @@
+Traceback (most recent call last):
+  File "kubelib.py", line *, in testVolumes
+    b.wait_present(".pv-listing")*
+the server could not find the requested resource


### PR DESCRIPTION
Issue #6059 now also crept into centos-7.

Replaces PR #6077 
