### PR TITLE
debian: Lower xdg-utils dependency to suggestion

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -44,12 +44,12 @@ Depends: ${misc:Depends},
          cockpit-ws (>= ${source:Version}),
          cockpit-ws (<< ${source:Version}.1~),
          cockpit-system (= ${binary:Version}),
-         xdg-utils
 Recommends: cockpit-docker (= ${binary:Version}),
             cockpit-storaged (= ${binary:Version}),
             cockpit-networkmanager (= ${binary:Version})
 Suggests: cockpit-doc (= ${binary:Version}),
-          cockpit-pcp (>= ${source:Version})
+          cockpit-pcp (>= ${source:Version}),
+          xdg-utils,
 Description: User interface for Linux servers
  Cockpit runs in a browser and can manage your network of GNU/Linux
  machines.


### PR DESCRIPTION
xdg-utils pulls in a lot of packages through Recommends: like x11-utils
or libwww-perl that are not necessary/desirable on servers. It is only
being used in our desktop file ("Exec=xdg-open http://localhost:9090").

Lower xdg-utils to Suggests:, as we don't need the desktop file on
servers, and xdg-utils is part of Debian/Ubuntu desktop installations.

(Note that the RPM spec file does not pull in xdg-utils at all.)

Fixes #6080