### PR TITLE
storaged: Better behavior with no available disks

### DIFF
--- a/pkg/storaged/details.js
+++ b/pkg/storaged/details.js
@@ -76,6 +76,7 @@
                                               map(function (b) {
                                                   return { value: b.path, Title: b.Name + " " + b.Description };
                                               })),
+                                    EmptyWarning: _("No disks are available."),
                                     validate: function (disks) {
                                         if (disks.length === 0)
                                             return _("At least one disk is needed.");
@@ -212,6 +213,7 @@
                                               map(function (b) {
                                                   return { value: b.path, Title: b.Name + " " + b.Description };
                                               })),
+                                    EmptyWarning: _("No disks are available."),
                                     validate: function (disks) {
                                         if (disks.length === 0)
                                             return _("At least one disk is needed.");

--- a/pkg/storaged/dialog.js
+++ b/pkg/storaged/dialog.js
@@ -50,6 +50,10 @@
             // Put in the Units for SizeSliders
             if (f.SizeSlider && !f.Units)
                 f.Units = cockpit.get_byte_units(f.Value || f.Max);
+
+            // Help SelectMany with counting
+            if (f.SelectMany)
+                f.HasOptions = (f.Options.length > 0);
         });
 
 

--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -810,6 +810,7 @@
                 {{#SelectMany}}
                 <td class="top">{{Title}}</td>
                 <td>
+                  {{#HasOptions}}
                   <ul class="list-group available-disks-group dialog-list-ct" data-field={{.}}>
                     {{#Options}}
                     <li class="list-group-item">
@@ -819,6 +820,10 @@
                     </li>
                     {{/Options}}
                   </ul>
+                  {{/HasOptions}}
+                  {{^HasOptions}}
+                  <span class="text-danger">{{EmptyWarning}}</span>
+                  {{/HasOptions}}
                 </td>
                 {{/SelectMany}}
                 {{#SelectRow}}

--- a/pkg/storaged/overview.js
+++ b/pkg/storaged/overview.js
@@ -452,6 +452,7 @@
                                 Options: utils.get_free_blockdevs(client).map(function (b) {
                                     return { value: b.path, Title: b.Name + " " + b.Description };
                                 }),
+                                EmptyWarning: _("No disks are available."),
                                 validate: function (disks, vals) {
                                     var disks_needed = vals.level == "raid6"? 4 : 2;
                                     if (disks.length < disks_needed)
@@ -499,6 +500,7 @@
                                 Options: utils.get_free_blockdevs(client).map(function (b) {
                                     return { value: b.path, Title: b.Name + " " + b.Description };
                                 }),
+                                EmptyWarning: _("No disks are available."),
                                 validate: function (disks) {
                                     if (disks.length === 0)
                                         return _("At least one disk is needed.");


### PR DESCRIPTION
Previously, the dialogs would show a empty list when there are no
available disks.  This produced a brokenly looking UI and was
confusing.

Now there is a explanatory text.

Fixes #1031