### PR TITLE
test: Fix timeout in check-openshift rolebinding check

### DIFF
--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -652,7 +652,7 @@ class TestRegistry(MachineCase):
             b.click(".btn-primary")
             b.wait_not_present("modal-dialog")
             b.wait_present("table.listing-ct")
-            wait(lambda: username not in o.execute("oc get rolebinding -n testprojectuserproj"))
+            wait(lambda: username not in o.execute("oc get rolebinding -n testprojectuserproj"), delay=5)
 
         # try to add user with invalid name from testprojectuserproj page
         b.go("#/projects/testprojectuserproj")


### PR DESCRIPTION
This check seems to time out. Increase the amount of time
by far. Sometimes it takes openshift a while to react.