### PR TITLE
shell: Add dialog to close active pages

### DIFF
--- a/pkg/shell/active-pages-dialog.jsx
+++ b/pkg/shell/active-pages-dialog.jsx
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+var React = require("react");
+
+var cockpit = require("cockpit");
+var _ = cockpit.gettext;
+
+var listingPattern = require("cockpit-components-listing.jsx");
+var Listing = listingPattern.Listing;
+var ListingRow = listingPattern.ListingRow;
+
+/* Dialog body to show active Cockpit pages
+ * Props:
+ *  - iframes          iframe elements on page to list
+ *  - selectionChanged callback when the select state changed, parameters: frame object, new value
+ */
+var ActivePagesDialogBody = React.createClass({
+    render: function() {
+        var self = this;
+        var frames = self.props.iframes.map(function(frame) {
+            var badge;
+            if (frame.visible)
+                badge = <span className="badge pull-right">{_("active")}</span>;
+            var columns = [
+                { name: frame.displayName, header: frame.visible },
+                badge,
+            ];
+            var selectCallback;
+            if (self.props.selectionChanged)
+                selectCallback = self.props.selectionChanged.bind(self, frame);
+            return (
+                <ListingRow columns={columns}
+                    rowId={frame.name}
+                    selected={frame.selected}
+                    selectChanged={selectCallback}
+                />
+            );
+        });
+
+        return (
+            <div className="modal-body">
+                <Listing emptyCaption={ _("There are currently no active pages") }>
+                    {frames}
+                </Listing>
+            </div>
+        );
+    }
+});
+
+module.exports = ActivePagesDialogBody;

--- a/pkg/shell/active-pages.js
+++ b/pkg/shell/active-pages.js
@@ -1,0 +1,120 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+var cockpit = require("cockpit");
+var _ = cockpit.gettext;
+
+var React = require("react");
+
+var dialogPattern = require("cockpit-components-dialog.jsx");
+var PagesDialog = require("./active-pages-dialog.jsx");
+
+// The argument is a Frames object from base_index.js
+var showDialog = function(frames) {
+    var dataStore = { };
+
+    // we omit the host for all pages on our current system
+    function displayName(address, component) {
+        if (address == "localhost")
+            return "/" + component;
+        return address + ":/" + component;
+    }
+
+    function gatherIframes() {
+        var result = [ ];
+        var address, component, iframe;
+        for (address in frames.iframes) {
+            for (component in frames.iframes[address]) {
+                iframe = frames.iframes[address][component];
+                result.push({
+                    frame: iframe,
+                    component: component,
+                    address: address,
+                    name: iframe.getAttribute("name"),
+                    visible: iframe.style.display.indexOf("block") !== -1,
+                    displayName: displayName(address, component)
+                });
+            }
+        }
+        return result;
+    }
+
+    var selectedFrames = [];
+
+    dataStore.closePage = function() {
+        // the user wants to close the selected pages
+        selectedFrames.forEach(function(element) {
+            frames.remove(element.host, element.component);
+        });
+        return cockpit.resolve();
+    };
+
+    function selectionChanged(frame, selected) {
+        var index = selectedFrames.indexOf(frame);
+        if (selected) {
+            if (index === -1)
+                selectedFrames.push(frame);
+        } else {
+            if (index !== -1)
+                selectedFrames.splice(index, 1);
+        }
+    }
+
+    var iframes = gatherIframes();
+    // by default, select currently active (visible) frame
+    iframes.forEach(function(f, index) {
+        if (f.visible) {
+            if (!(f in selectedFrames))
+                selectedFrames.push(f);
+        }
+        f.selected = f.visible;
+    });
+    // sort the frames by displayName, visible ones first
+    iframes.sort(function(a, b) {
+        return (a.visible ? -2 : 0) + (b.visible ? 2 : 0) +
+               ((a.displayName < b.displayName) ? -1 : 0) + ((b.displayName < a.displayName) ? 1 : 0);
+    });
+    dataStore.dialogProps = {
+        title: _("Active Pages"),
+        id: "active-pages-dialog",
+        body: React.createElement(PagesDialog, { iframes: iframes, selectionChanged: selectionChanged }),
+    };
+
+    dataStore.footerProps = {
+        'actions': [
+              { 'clicked': dataStore.closePage,
+                'caption': _("Close Selected Pages"),
+                'style': 'primary',
+              }
+          ],
+    };
+
+    dataStore.dialogObj = dialogPattern.show_modal_dialog(dataStore.dialogProps, dataStore.footerProps);
+
+    dataStore.update = function() {
+        dataStore.dialogProps.body = React.createElement(PagesDialog, { });
+        dataStore.dialogObj.setProps(dataStore.dialogProps);
+    };
+
+    return dataStore;
+};
+
+module.exports = {
+    showDialog: showDialog
+};

--- a/pkg/shell/active-pages.less
+++ b/pkg/shell/active-pages.less
@@ -1,0 +1,14 @@
+// we don't want the list of pages to overflow our dialog
+#active-pages-dialog .modal-body {
+    overflow-y: auto;
+    max-height: 340px;
+    padding: 0;
+    margin: @listing-ct-spacing @listing-ct-spacing 0;
+    min-height: @listing-ct-spacing * 15;
+    border: 1px solid @color-pf-black-300;
+}
+
+// don't waste space over the table
+#active-pages-dialog table.listing {
+    margin-top: 0;
+}

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -581,7 +581,7 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             }
 
             return null;
-        };
+        }
 
         /* Jumps to a given navigate state */
         self.jump = function (state, replace) {
@@ -770,6 +770,13 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             }).show();
         }
 
+        function setup_killer(id) {
+            $(id).on("click", function(ev) {
+                if (ev && ev.button === 0)
+                    require("./active-pages").showDialog(self.frames);
+            });
+        }
+
         /* User information */
         function setup_user(id, user) {
             $(id).text(user.full_name || user.name || '???');
@@ -797,6 +804,8 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
 
         if (self.about_sel)
             setup_about(self.about_sel);
+        if (self.killer_sel)
+            setup_killer(self.killer_sel);
 
         if (self.user_sel || self.account_sel) {
             cockpit.user().done(function (user) {

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -543,7 +543,7 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             if (shell_embedded) {
                 navbar.hide();
             } else {
-                var local_compiled = new CompiledComponants();
+                var local_compiled = new CompiledComponents();
                 local_compiled.load(cockpit.manifests, "dashboard");
                 navbar.append(local_compiled.ordered("dashboard").map(links));
             }
@@ -803,7 +803,7 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
         }
     }
 
-    function CompiledComponants() {
+    function CompiledComponents() {
         var self = this;
         self.items = {};
 
@@ -878,7 +878,7 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
         },
 
         new_compiled: function () {
-            return new CompiledComponants();
+            return new CompiledComponents();
         },
     };
 }());

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -40,6 +40,9 @@
               <li>
                 <a data-toggle="modal" data-target="#about" translatable="yes">About Cockpit</a>
               </li>
+              <li>
+                <a id="active-pages" translatable="yes" class="navbar-advanced">Active Pages</a>
+              </li>
               <li class="divider"></li>
               <li id="go-account" hidden>
                 <a translatable="yes">Account Settings</a>

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -32,6 +32,14 @@
 
     credentials.setup();
 
+    /* When Ctrl is held down we display debugging menu items */
+    document.addEventListener("click", function(ev) {
+        var i, visible = !!ev.altKey;
+        var advanced = document.querySelectorAll(".navbar-advanced");
+        for (i = 0; i < advanced.length; i++)
+            advanced[i].style.display = visible ? "block" : "none";
+    }, true);
+
     var options = {
         brand_sel: "#index-brand",
         logout_sel: "#go-logout",
@@ -41,6 +49,7 @@
         account_sel: "#go-account",
         user_sel: "#content-user-name",
         credential_sel: "#credential-authorize",
+        killer_sel: "#active-pages",
         default_title: "Cockpit"
     };
 

--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -23,6 +23,7 @@
 @import (less) "/table.css";
 @import "variables.less";
 @import "switcher.less";
+@import "active-pages.less";
 
 /* Hacks on top for now */
 
@@ -306,6 +307,10 @@ html.index-page body {
 }
 
 #navbar-oops {
+    display: none;
+}
+
+.navbar-advanced {
     display: none;
 }
 

--- a/test/verify/check-active-pages
+++ b/test/verify/check-active-pages
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import parent
+from testlib import *
+
+class TestActivePages(MachineCase):
+    def testBasic(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/system")
+
+        b.wait_present("#server")
+
+        def showPagesAssertCount(count):
+            # check the pages and make sure there is only one page loaded
+            b.switch_to_top()
+            b.click("#navbar-dropdown")
+            # we won't wait for the entry to be visible, since that requires a special key combination
+            # since it's a developer feature and not immediately obvious to everyone
+            # that's also why we force this click event
+            b.click("#active-pages", force=True)
+            b.wait_present("#active-pages-dialog")
+            b.call_js_func("ph_count_check", "#active-pages-dialog tbody",  count)
+
+        showPagesAssertCount(1)
+        b.click("button.cancel")
+        b.wait_not_present("#active-pages-dialog")
+
+        b.go("/users")
+        b.enter_page("/users")
+        b.wait_present("#accounts-list")
+
+        # now we want a second page to be present in the pages menu
+        showPagesAssertCount(2)
+        b.click("button.cancel")
+        b.wait_not_present("#active-pages-dialog")
+
+        # open the terminal page and start a session we can see on the machine
+        b.go("/system/terminal")
+        b.enter_page("/system/terminal")
+
+        b.wait_present(".terminal")
+        b.focus(".terminal")
+
+        def line_sel(i):
+            return '.terminal div:nth-child(%d)' % i
+
+        def line_text(t):
+            return t + u'\xa0'*(80-len(t))
+
+        # wait for prompt in first line
+        b.wait_text_not(line_sel(1), line_text(""))
+
+        # run the sleep command
+        key_presses = list("sleep 999999") + [ "Return" ];
+        b.key_press( key_presses )
+
+        # wait for it to be present in ps
+        wait(lambda: m.execute("ps ax | grep 'sleep 99.*999'"))
+
+        # now close the page
+        showPagesAssertCount(3)
+
+        # click on the other page as well
+        b.click('tr[data-row-id="cockpit1:localhost/system"]')
+        # wait until it's highlighted
+        b.wait_present('tr.listing-ct-selected[data-row-id="cockpit1:localhost/system"]')
+        # close
+        b.click("#active-pages-dialog button.btn-primary")
+        b.wait_not_present("#active-pages-dialog")
+
+        # running shell command should disappear on the system
+        wait(lambda: m.execute("ps ax | grep 'sleep 99.*999'"))
+
+        # there should only be one page left
+        showPagesAssertCount(1)
+
+if __name__ == '__main__':
+    test_main()


### PR DESCRIPTION
I reworked this to use the `MutationObserver` to detect DOM changes and the task "killer" to just remove iframes.
This way the "consumer" (task killer) closes iframes like the browser would and removal of the frames is handled by the same code that also creates them.

Feature page: https://github.com/cockpit-project/cockpit/wiki/Feature:-Task-Killer

TODO:

- [x] listing pattern to support selecting entries #6096
- [x] close selected page instead of last one
- [x] fix style of dialog (max height?)
- [x] add integration test
- [x] remove debug code
- [ ] ~~optional: show blank slate reconnect page when closing current frame~~
- [ ] ~~scroll to the active page when opening the dialog~~
