### PR TITLE
lib: Add multi select capability to listing pattern

### DIFF
--- a/pkg/lib/listing.less
+++ b/pkg/lib/listing.less
@@ -139,11 +139,16 @@ tr.listing-ct-item .listing-ct-toggle + th {
     padding-left: 0;
 }
 
-td.listing-ct-toggle:hover {
-    color: @listing-ct-active;
-    background-color: @color-pf-black-200;
-}
+tr:not(.listing-ct-selected) {
+    td.listing-ct-toggle:hover {
+        color: @listing-ct-active;
+        background-color: @color-pf-black-200;
 
+        ~ td, ~ th {
+            background-color: @color-pf-black-200;
+        }
+    }
+ }
 td.listing-ct-toggle i {
     font-size: 24px;
     visibility: hidden;
@@ -165,12 +170,6 @@ tbody.open td.listing-ct-toggle i {
 tbody.open td.listing-ct-toggle i:before {
     content: "\f107";
 }
-
-td.listing-ct-toggle:hover ~ td,
-td.listing-ct-toggle:hover ~ th {
-    background-color: @color-pf-black-200;
-}
-
 
 /* Listing items have decent padding ... */
 tr.listing-ct-item td {
@@ -195,6 +194,26 @@ td.listing-ct-actions {
     padding: @listing-ct-padding / 2 @listing-ct-padding;
     text-align: right;
     float: none;
+}
+
+/* if the entire row is selected, highlight */
+tr.listing-ct-item.listing-ct-selected {
+    background-color: @color-pf-blue-400;
+    color: @color-pf-white;
+    border-color: multiply(@color-pf-black-200, @color-pf-blue-400);
+
+    &:hover {
+        background-color: multiply(@color-pf-black-200, @color-pf-blue-400);
+        border-color: multiply(@color-pf-black-200, @color-pf-blue-400);
+    }
+}
+
+tr.listing-ct-item.listing-ct-selected .badge {
+    background-color: multiply(@badge-bg, @color-pf-blue-400);
+
+    &:hover {
+        background-color: multiply(@badge-bg, @color-pf-blue-500);
+    }
 }
 
 .listing-ct-head .listing-ct-actions {

--- a/pkg/playground/react-demo-listing.jsx
+++ b/pkg/playground/react-demo-listing.jsx
@@ -46,7 +46,7 @@
         },
     });
 
-    var showListingDemo = function(rootElement, rootElementEmptyList) {
+    var showListingDemo = function(rootElement, rootElementSelectable, rootElementEmptyList) {
         var navigateToItem = function(msg) {
             window.alert("navigated to item: " + msg);
         };
@@ -99,7 +99,7 @@
             tight: true
         };
 
-        // create the dialog
+        // create the listings
         var listing = (
             <cockpitListing.Listing title="Demo Listing Pattern with expandable rows"
                                     actions={addLink}
@@ -119,6 +119,22 @@
              </cockpitListing.Listing>
         );
         React.render(listing, rootElement);
+
+        listing = (
+            <cockpitListing.Listing title="Demo Listing Pattern with selectable rows"
+                                    actions={addLink}
+                                    columnTitles={['Name', 'Random', 'IP', 'State']}>
+                 <cockpitListing.ListingRow
+                     columns={ [ { name: 'selected by default', 'header': true }, 'aoeuaoeu', '127.30.168.10', 'Running' ] }
+                     selected={true}/>
+                 <cockpitListing.ListingRow
+                     columns={ [ { name: "not selected by default", 'header': true }, 'aoeuaoeu', '127.30.168.11', 'Running' ] }
+                     selected={false}/>
+                 <cockpitListing.ListingRow
+                     columns={ [ { name: "no selected entry", 'header': true }, 'aoeuaoeu', '127.30.168.12', rowAction ] }/>
+             </cockpitListing.Listing>
+        );
+        React.render(listing, rootElementSelectable);
 
         var emptyListing = <cockpitListing.Listing title="Demo Empty Listing Pattern" emptyCaption="No Entries"/>;
         React.render(emptyListing, rootElementEmptyList);

--- a/pkg/playground/react-patterns.html
+++ b/pkg/playground/react-patterns.html
@@ -32,6 +32,7 @@
 <div class="container-fluid">
     <h3>Listing Pattern</h3>
     <div id="demo-listing"></div>
+    <div id="demo-listing-selectable"></div>
     <div id="demo-listing-empty"></div>
 </div>
 

--- a/pkg/playground/react-patterns.js
+++ b/pkg/playground/react-patterns.js
@@ -122,7 +122,9 @@
           -----------------------------------------------------------------------------
          */
         // create the listing
-        demoListing.demo(document.getElementById('demo-listing'), document.getElementById('demo-listing-empty'));
+        demoListing.demo(document.getElementById('demo-listing'),
+            document.getElementById('demo-listing-selectable'),
+            document.getElementById('demo-listing-empty'));
 
         /* Tooltip */
         demoTooltip.demo(document.getElementById('demo-tooltip'), document.getElementById('demo-tooltip-top'));


### PR DESCRIPTION
Sometimes we want to select entries in a list. The [patternfly list pattern](http://www.patternfly.org/pattern-library/content-views/list-view/) is often a bit too cluttered and large for our use cases, we prefer a cleaner look more along the lines of a [multi-select component](https://www.patternfly.org/pattern-library/widgets/).

The rows all have a callback for when the state changes and the `Listing` ensures that if even one child has `selected` set, the rest default to `false`. Items which support navigation or expansion can't be selected.

Screenshot: (first item is selected, second is selected and hovered, third regular)

![screenshot from 2017-03-14 11-45-29](https://cloud.githubusercontent.com/assets/8711649/23897152/4bf6929c-08ac-11e7-8d42-0f3174c5306d.png)
