### PR TITLE
shell: Show a 'Locked' and 'Unlocked' top bar

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -295,7 +295,7 @@ Example authorize challenge and response messages:
 
 For credential cache authorization, the following fields are defined:
 
- * "credential": Empty or one of the following: "password"
+ * "credential": Empty or "password"
 
 When set to "password" then a "password" field should also be present
 which represents a new password to cache, which replaces any current

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -295,11 +295,7 @@ Example authorize challenge and response messages:
 
 For credential cache authorization, the following fields are defined:
 
- * "credential": One of the following words: "inject" or "password"
-
-When set to "inject" a channel must be specified a cached password
-credential will be injected as its own payload into the channel. If no
-password is cached, an empty payload will be injected.
+ * "credential": Empty or one of the following: "password"
 
 When set to "password" then a "password" field should also be present
 which represents a new password to cache, which replaces any current

--- a/pkg/lib/credentials.js
+++ b/pkg/lib/credentials.js
@@ -307,12 +307,6 @@
     function setup() {
         var keys;
 
-        /* The button to deauthorize cockpit */
-        $("#credential-authorize button").on("click", function(ev) {
-            cockpit.drop_privileges(false);
-            ev.preventDefault();
-        });
-
         $("#credentials-dialog")
 
             /* Show and hide panels */

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -188,8 +188,10 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                     for (seed in source_by_seed)
                         source_by_seed[seed].window.postMessage(message, origin);
                 } else if (control.command == "hint") {
-                    if (control.credential)
-                        index.authorize_changed(control.credential);
+                    if (control.credential) {
+                        if (index.privileges)
+                            index.privileges.update(control);
+                    }
                 }
 
             /* Forward message to relevant frame */
@@ -674,10 +676,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             $(self).triggerHandler("expect_restart", host);
         };
 
-        self.authorize_changed = function(value) {
-            $(self.credential_sel).toggle(value != "clear");
-        };
-
         /* Menu items */
         /* The oops bar */
         function setup_oops(id) {
@@ -780,10 +778,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
         /* User information */
         function setup_user(id, user) {
             $(id).text(user.full_name || user.name || '???');
-
-            var is_root = (user.name == "root");
-            var is_not_root = (user.name && !is_root);
-            $('#deauthorize-item').toggle(is_not_root);
         }
 
         if (self.oops_sel)

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -24,7 +24,7 @@
       </div>
       <div class="collapse navbar-collapse navbar-collapse-1">
         <ul class="nav navbar-nav navbar-utility">
-          <li id="navbar-oops">
+          <li id="navbar-oops" hidden>
             <a><span class="oops-status" translatable="yes">Ooops!</span></a>
           </li>
           <li class="dropdown">

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -24,6 +24,18 @@
       </div>
       <div class="collapse navbar-collapse navbar-collapse-1">
         <ul class="nav navbar-nav navbar-utility">
+          <li class="credential-lock">
+            <a data-toggle="tooltip" data-placement="bottom" translate="title"
+                title="Privileged tasks not available">
+              <i class="fa fa-lock"></i>
+              <span translate>Locked</span>
+            </a>
+            <a data-toggle="tooltip" data-placement="bottom" translate="title"
+                title="Lock to prevent privileged tasks" class="credential-clear">
+              <i class="fa fa-unlock-alt"></i>
+              <span translate>Unlocked</span>
+            </a>
+          </li>
           <li id="navbar-oops" hidden>
             <a><span class="oops-status" translatable="yes">Ooops!</span></a>
           </li>
@@ -151,14 +163,20 @@
                 </div>
                 <div class="modal-body modal-scrollable">
                     <table class="listing-ct credential-listing">
-                        <thead>
-                            <tr id="credential-authorize" hidden>
-                                <td translatable="yes" colspan="2">Use my password for privileged tasks and to connect to other machines</td>
+                        <thead class="credential-lock">
+                            <tr>
+                                <td translate colspan="2">Password not usable for privileged tasks or to connect to other machines</td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <td translate colspan="2">Reuse my password for privileged tasks and to connect to other machines</td>
                                 <td class="listing-ct-actions">
-                                    <button class="btn btn-default pficon pficon-close" id="deauthorize-item">
+                                    <button class="btn btn-default pficon pficon-close credential-clear">
                                     </button>
                                 </td>
                             </tr>
+                        </thead>
+                        <thead>
                             <tr id="credential-keys">
                                 <td translatable="yes" colspan="2">Use the following keys to authenticate against other systems</td>
                                 <td class="listing-ct-actions">

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -48,9 +48,9 @@
         about_sel: "#about-version",
         account_sel: "#go-account",
         user_sel: "#content-user-name",
-        credential_sel: "#credential-authorize",
         killer_sel: "#active-pages",
-        default_title: "Cockpit"
+        default_title: "Cockpit",
+        privileges: require("./privileges").instance(),
     };
 
     indexes.machines_index(options, machines, loader, dialogs);

--- a/pkg/shell/privileges.js
+++ b/pkg/shell/privileges.js
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+var cockpit = require("cockpit");
+
+function Privileges() {
+    var self = this;
+    var locked = null;
+    var lock;
+
+    function clicked(ev) {
+        cockpit.drop_privileges(false);
+        ev.preventDefault();
+    }
+
+    function display(blink) {
+        var i, locks = document.querySelectorAll(".credential-lock");
+        for (i = 0; i < locks.length; i++) {
+            lock = locks[i];
+            if (locked !== true)
+                lock.classList.remove("credential-locked");
+            else if (locked === true)
+                lock.classList.add("credential-locked");
+            if (locked !== false)
+                lock.classList.remove("credential-unlocked");
+            else if (locked === false)
+                lock.classList.add("credential-unlocked");
+
+            if (lock.tagName == "LI" && blink)
+                lock.classList.add("credential-blink");
+            else
+                lock.classList.remove("credential-blink");
+        }
+
+        var clear = document.querySelectorAll(".credential-clear");
+        for (i = 0; i < clear.length; i++)
+            clear[i].onclick = clicked;
+    }
+
+    self.update = function update(hint) {
+        var blink = false;
+        if (hint.credential == "password") {
+            locked = false;
+        } else if (hint.credential == "request") {
+            if (locked === null)
+                locked = true;
+            blink = true;
+        } else if (hint.credential == "none") {
+            locked = null;
+        }
+        display(blink);
+    };
+
+    /* No op authorize command to poke about state */
+    cockpit.authorize();
+}
+
+var privileges = null;
+module.exports = {
+    instance: function() {
+        if (!privileges)
+            privileges = new Privileges();
+        return privileges;
+    }
+};

--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -306,7 +306,7 @@ html.index-page body {
     border-color: transparent;
 }
 
-#navbar-oops {
+.nav > li[hidden] {
     display: none;
 }
 

--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -314,6 +314,57 @@ html.index-page body {
     display: none;
 }
 
+.credential-lock > * {
+    display: none !important;
+}
+
+.credential-lock.credential-locked > *:first-child {
+    display: block !important;
+}
+
+.credential-lock.credential-unlocked > *:last-child {
+    display: block !important;
+}
+
+@-webkit-keyframes blink {
+    0% {
+        opacity: 0;
+    }
+    50% {
+        opacity: 0.5;
+    }
+    100% {
+        opacity: 1;
+    }
+}
+
+@keyframes blink {
+    0% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.5;
+    }
+    100% {
+        opacity: 1;
+    }
+}
+
+.credential-blink {
+    -webkit-animation: blink 1.2s 1 linear;
+    animation: blink 1.2s 1 linear;
+}
+
+li.credential-lock {
+    span { padding-left: 1em; }
+}
+
+/* For now this is not clickable */
+li.credential-lock > a:first-child {
+    cursor: default;
+}
+
+
 /* The server avatar */
 #server-avatar {
     width:       128px;
@@ -503,10 +554,6 @@ table.credential-listing {
 .credential-listing thead td {
     padding-left: 15px;
     padding-bottom: 15px;
-}
-
-#credential-authorize td {
-    padding-bottom: 30px;
 }
 
 .credential-data {

--- a/pkg/shell/stub.html
+++ b/pkg/shell/stub.html
@@ -24,7 +24,7 @@
       </div>
       <div class="collapse navbar-collapse navbar-collapse-1">
         <ul class="nav navbar-nav navbar-utility">
-          <li id="navbar-oops">
+          <li id="navbar-oops" hidden>
             <a><span class="oops-status" translatable="yes">Ooops!</span></a>
           </li>
           <li class="dropdown">

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -1106,6 +1106,17 @@ function factory() {
         });
     };
 
+    /* Not a public API ... yet? */
+    cockpit.authorize = function authorize(credential, options) {
+        options = extend({ }, options);
+        options["command"] = "authorize";
+        if (credential)
+            options["credential"] = credential;
+        ensure_transport(function(transport) {
+            transport.send_control(options);
+        });
+    };
+
     cockpit.transport = public_transport = {
         wait: ensure_transport,
         inject: function inject(message, out) {

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -31,9 +31,7 @@
 #include "common/cockpitjson.h"
 #include "common/cockpitlog.h"
 #include "common/cockpitmemory.h"
-#include "common/cockpitpipetransport.h"
 #include "common/cockpitsystem.h"
-#include "common/cockpitwebinject.h"
 #include "common/cockpitwebresponse.h"
 #include "common/cockpitwebserver.h"
 

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -638,7 +638,6 @@ process_socket_authorize (CockpitWebService *self,
                           GBytes *payload)
 {
   const gchar *credential = NULL;
-  CockpitSession *session = NULL;
   const gchar *string = NULL;
   GBytes *password;
   gpointer data;
@@ -681,26 +680,6 @@ process_socket_authorize (CockpitWebService *self,
         {
           data = (gpointer)g_bytes_get_data (payload, &length);
           cockpit_secclear (data, length);
-          g_bytes_unref (password);
-        }
-    }
-  else if (g_str_equal (credential, "inject"))
-    {
-      if (channel)
-        session = cockpit_session_by_channel (&self->sessions, channel);
-      if (!session)
-        {
-          g_debug ("%s: channel to inject password credentials does not exist: %s",
-                   socket->id, channel ? channel : "");
-        }
-      else if (!session->sent_done)
-        {
-          password = cockpit_creds_get_password (self->creds);
-          if (password)
-            g_bytes_ref (password);
-          else
-            password = g_bytes_new_static ("", 0);
-          cockpit_transport_send (session->transport, channel, password);
           g_bytes_unref (password);
         }
     }

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -2072,7 +2072,7 @@ test_hint_credential (TestCase *test,
   /* We should now get a hint that we have no password */
   while (received == NULL)
     g_main_context_iteration (NULL, TRUE);
-  cockpit_assert_json_eq (received, "{\"command\":\"hint\",\"credential\":\"clear\"}");
+  cockpit_assert_json_eq (received, "{\"command\":\"hint\",\"credential\":\"none\"}");
   json_object_unref (received);
 
   close_client_and_stop_web_service (test, ws, service);
@@ -2133,7 +2133,7 @@ test_authorize_password (TestCase *test,
   /* We should now get a hint that we have no password */
   while (control == NULL)
     g_main_context_iteration (NULL, TRUE);
-  cockpit_assert_json_eq (control, "{\"command\":\"hint\",\"credential\":\"clear\"}");
+  cockpit_assert_json_eq (control, "{\"command\":\"hint\",\"credential\":\"none\"}");
   json_object_unref (control);
   control = NULL;
 

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -356,7 +356,7 @@ CMD ["/bin/sh"]
         self.allow_journal_messages(".*Failed to create file '/var/lib/cockpit/.*': Permission denied")
         self.allow_journal_messages("http:///var/run/docker.sock/.*: couldn't connect: .*")
 
-        self.login_and_go("/docker")
+        self.login_and_go("/docker", authorized=False)
 
         # We can not become root, so we can't access docker.
         b.wait_visible("#curtain")
@@ -366,7 +366,7 @@ CMD ["/bin/sh"]
         # Give "admin" access via the admin group and login again
         m.execute("usermod -G %s admin" % m.get_admin_group())
         m.execute("systemctl stop docker")
-        b.relogin("/docker")
+        b.relogin("/docker", authorized=True)
         self.allow_restart_journal_messages()
 
         # Now we can become root and start docker

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -39,13 +39,13 @@ class TestReauthorize(MachineCase):
         b.wait_in_text(".cockpit-internal-reauthorize span", 'result:')
         self.assertEqual(b.text(".cockpit-internal-reauthorize span"), 'result: authorized')
 
-        # Deauthorize from the menu
+        # Deauthorize from the top bar
         b.leave_page()
         b.click("#navbar-dropdown")
         b.click("#credentials-item")
-        b.wait_visible("#credential-authorize button")
-        b.click("#credential-authorize button")
-        b.wait_not_visible("#credential-authorize button")
+        b.wait_visible("a.credential-clear")
+        b.click("a.credential-clear")
+        b.wait_not_visible("a.credential-clear")
         b.click("#credentials-dialog [data-dismiss]")
 
         b.enter_page("/playground/test")
@@ -57,6 +57,8 @@ class TestReauthorize(MachineCase):
 
     def testSuper(self):
         self.allow_authorize_journal_messages()
+        self.allow_journal_messages("Error receiving data: Connection reset by peer")
+        self.allow_journal_messages("connection unexpectedly closed by peer")
         b = self.browser
 
         self.login_and_go("/playground/test")
@@ -70,8 +72,8 @@ class TestReauthorize(MachineCase):
         b.leave_page()
         b.click("#navbar-dropdown")
         b.click("#credentials-item")
-        b.click("#credential-authorize button")
-        b.wait_not_visible("#credential-authorize button")
+        b.click("button.credential-clear")
+        b.wait_not_visible("button.credential-clear")
         b.click("#credentials-dialog [data-dismiss]")
 
         b.enter_page("/playground/test")
@@ -81,9 +83,19 @@ class TestReauthorize(MachineCase):
 
         self.assertEqual(b.text(".super-channel span"), 'result: access-denied')
 
+        # Now log in as root even without password caching
+        b.logout
+        self.login_and_go("/playground/test", authorized=False, user="root")
+        b.click(".super-channel .btn")
+        b.wait_in_text(".super-channel span", 'result: ')
+        self.assertIn('result: uid=0', b.text(".super-channel span"))
+
+        # When root and not authorized, the 'Locked' or 'Unlocked' indicators should not be visible
+        b.leave_page()
+        b.wait_not_visible("li.credential-lock")
+
     def testSudo(self):
         self.allow_authorize_journal_messages()
-        self.allow_journal_messages("@authorize@user:user@authorize@.*")
         m = self.machine
         b = self.browser
 


### PR DESCRIPTION
We don't have time to work through all the implications of unlocking a running session for privileged operations, such as retrying the operations, or retrying display of tasks.
    
However we do implement the parts of this new design that we can, and that is updating the top bar.

 * [x] Blocked on #6081 
 * [x] Basic integration test