### PR TITLE
tools: After version 135 the subpackage interdependency is flexible

### DIFF
--- a/pkg/dashboard/manifest.json.in
+++ b/pkg/dashboard/manifest.json.in
@@ -1,7 +1,7 @@
 {
     "version": "@VERSION@",
     "requires": {
-	"cockpit": "132.x"
+	"cockpit": "134.x"
     },
 
     "dashboard": {

--- a/pkg/pcp/manifest.json.in
+++ b/pkg/pcp/manifest.json.in
@@ -1,4 +1,7 @@
 {
+    "requires": {
+        "cockpit": "134.x"
+    },
     "bridges": [
         {
             "match": { "payload": "metrics1" },

--- a/pkg/shell/manifest.json.in
+++ b/pkg/shell/manifest.json.in
@@ -1,7 +1,7 @@
 {
     "version": "@VERSION@",
     "requires": {
-	"cockpit": "122"
+	"cockpit": "134.x"
     },
 
     "locales": {

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -272,7 +272,6 @@ cat kdump.list subscriptions.list sosreport.list networkmanager.list selinux.lis
 
 %package bridge
 Summary: Cockpit bridge server-side component
-Obsoletes: %{name}-daemon < 0.48-2
 Requires: glib-networking
 Requires: polkit
 
@@ -398,8 +397,6 @@ Requires: shadow-utils
 Requires: grep
 Requires: libpwquality
 Requires: /usr/bin/date
-Provides: %{name}-assets
-Obsoletes: %{name}-assets < 0.32
 Provides: %{name}-realmd = %{version}-%{release}
 Provides: %{name}-shell = %{version}-%{release}
 Obsoletes: %{name}-shell < 127
@@ -448,7 +445,6 @@ Summary: Cockpit Web Service
 Requires: glib-networking
 Requires: openssl
 Requires: glib2 >= 2.37.4
-Obsoletes: cockpit-selinux-policy <= 0.83
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -328,7 +328,7 @@ The Cockpit components for managing software updates for ostree based systems.
 
 %package pcp
 Summary: Cockpit PCP integration
-Requires: %{name}-bridge = %{version}-%{release}
+Requires: %{name}-bridge >= %{required_base}
 Requires: pcp
 
 %description pcp
@@ -348,8 +348,7 @@ Cockpit support for reading PCP metrics and loading PCP archives.
 %package dashboard
 Summary: Cockpit SSH remoting and dashboard
 Requires: libssh >= %{libssh_version}
-Requires: cockpit-ws = %{version}-%{release}
-Provides: cockpit-ssh = %{version}-%{release}
+Provides: %{name}-ssh
 
 %description dashboard
 Cockpit support for remoting to other servers, bastion hosts, and a basic dashboard
@@ -386,7 +385,7 @@ The Cockpit component for managing storage.  This package uses Storaged.
 %package system
 Summary: Cockpit admin interface package for configuring and troubleshooting a system
 BuildArch: noarch
-Requires: %{name}-bridge = %{version}-%{release}
+Requires: %{name}-bridge >= %{version}-%{release}
 Requires: shadow-utils
 Requires: grep
 Requires: libpwquality

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -365,11 +365,6 @@ test -f %{_bindir}/chcon && chcon -t cockpit_ws_exec_t %{_libexecdir}/cockpit-ss
 
 %package storaged
 Summary: Cockpit user interface for storage, using Storaged
-# Lock bridge dependency due to --with-storaged-iscsi-sessions
-# which uses new less stable /manifests.js request path.
-%if 0%{?rhel}
-Requires: %{name}-bridge >= %{version}-%{release}
-%endif
 Requires: %{name}-shell >= %{required_base}
 Requires: storaged >= 2.1.1
 %if 0%{?fedora} >= 24 || 0%{?rhel} >= 8

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -273,7 +273,6 @@ cat kdump.list subscriptions.list sosreport.list networkmanager.list selinux.lis
 %package bridge
 Summary: Cockpit bridge server-side component
 Requires: glib-networking
-Requires: polkit
 
 %description bridge
 The Cockpit bridge component installed server side and runs commands on the

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -420,7 +420,7 @@ This package contains the Cockpit shell and system configuration interfaces.
 %package tests
 Summary: Tests for Cockpit
 Requires: %{name}-bridge >= %{version}-%{release}
-Requires: %{name}-shell >= %{version}-%{release}
+Requires: %{name}-system >= %{version}-%{release}
 Requires: openssh-clients
 Provides: %{name}-test-assets
 Obsoletes: %{name}-test-assets < 132

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -144,6 +144,7 @@ Package: cockpit-tests
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
+         cockpit-system (>= ${source:Version}),
          openssh-client
 Conflicts: cockpit-test-assets
 Replaces: cockpit-test-assets

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -57,8 +57,7 @@ Package: cockpit-bridge
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
-         glib-networking,
-         policykit-1
+         glib-networking
 Description: Cockpit bridge server-side component
  The Cockpit bridge component installed server side and runs commands on
  the system on behalf of the web based user interface.


### PR DESCRIPTION
The cockpit-ws, cockpit-dashboard, cockpit-bridge and cockpit-system subpackages have a more flexible interdependency after the 135 release. The way they call each other is stable and documented.
    
For the cockpit-bridge and cockpit-system packages we still keep a rather tight dependency for pragmatic reasons. Any later version of cockpit-bridge is acceptable to cockpit-system.
