### PR TITLE
storaged: Don't crash when job objects are undefined

### DIFF
--- a/pkg/storaged/jobs.js
+++ b/pkg/storaged/jobs.js
@@ -83,6 +83,8 @@
             }
 
             function show_spinners_for_objects(paths) {
+                if (!paths || !paths.length)
+                    return;
                 for (var i = 0; i < paths.length; i++)
                     show_spinners_for_object(paths[i]);
             }


### PR DESCRIPTION
This happens occasionally.