### PR TITLE
Image refresh for debian-8

### DIFF
--- a/test/images/debian-8
+++ b/test/images/debian-8
@@ -1,1 +1,1 @@
-debian-8-de340dd670cd7db29784421ea0b3deeefbdd90cf.qcow2
+debian-8-1eb7999ea62a2548e86524c0594b424193ebd2eb.qcow2


### PR DESCRIPTION
Image creation for debian-8 in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-8-2017-03-15/