### PR TITLE
Document http-stream2 usage

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -630,13 +630,16 @@ arguments. These types are encoded as follows:
        "t": "s"
    }
 
-Payload: http-stream1
+Payload: http-stream2
 ---------------------
 
-This channel replesents a single HTTP request and response. The first payload
-message in each direction are the HTTP headers. The remaining messages make up
-the HTTP request and response bodies. When the channel is in text mode, the
-response body is automatically coerced to UTF-8.
+This channel replesents a single HTTP request and response. The request
+HTTP headers are sent in the "open" message, and response headers are
+returned in a "response" control message.
+
+The remaining messages make up the HTTP request and response bodies.
+When the channel is in text mode, the response body is automatically
+coerced to UTF-8.
 
 The following HTTP methods are not permitted:
 

--- a/pkg/kubernetes/scripts/kube-client-cockpit.js
+++ b/pkg/kubernetes/scripts/kube-client-cockpit.js
@@ -51,7 +51,7 @@
      *
      * base64(PEM(data))
      *
-     * Since our http-stream1 expects PEM certificates (although they're
+     * Since our http-stream2 expects PEM certificates (although they're
      * nasty, they're better than all the alternatives) so we strip out
      * the outer base64 layer.
      */

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -3977,7 +3977,7 @@ function factory() {
         var self = this;
 
         self.options = options;
-        options.payload = "http-stream1";
+        options.payload = "http-stream2";
 
         var active_requests = [ ];
 
@@ -4055,31 +4055,25 @@ function factory() {
             var streamer = null;
             var responsers = null;
 
-            var count = 0;
             var resp = null;
 
             var buffer = channel.buffer(function(data) {
-                count += 1;
+                /* Fire any streamers */
+                if (resp && resp.status >= 200 && resp.status <= 299 && streamer)
+                    return streamer.call(ret, data);
+                return 0;
+            });
 
-                if (count === 1) {
-                    if (channel.binary)
-                        data = cockpit.utf8_decoder().decode(data);
-                    resp = JSON.parse(data);
-
-                    /* Anyone looking for response details? */
+            function on_control(event, options) {
+                /* Anyone looking for response details? */
+                if (options.command == "response") {
+                    resp = options;
                     if (responsers) {
                         resp.headers = resp.headers || { };
                         invoke_functions(responsers, ret, [resp.status, resp.headers]);
                     }
-                    return true;
                 }
-
-                /* Fire any streamers */
-                if (resp.status >= 200 && resp.status <= 299 && streamer)
-                    return streamer.call(ret, data);
-
-                return 0;
-            });
+            }
 
             function on_close(event, options) {
                 var pos = active_requests.indexOf(ret);
@@ -4110,9 +4104,11 @@ function factory() {
                     }
                 }
 
+                channel.removeEventListener("control", on_control);
                 channel.removeEventListener("close", on_close);
             }
 
+            channel.addEventListener("control", on_control);
             channel.addEventListener("close", on_close);
 
             ret.stream = function(callback) {

--- a/src/bridge/cockpithttpstream.c
+++ b/src/bridge/cockpithttpstream.c
@@ -173,7 +173,7 @@ cockpit_http_client_checkout (CockpitHttpClient *client)
  *
  * A #CockpitChannel that represents a HTTP request/response.
  *
- * The payload type for this channel is 'http-stream1'.
+ * The payload type for this channel is 'http-stream2'.
  */
 
 /*


### PR DESCRIPTION
Back in Cockpit version 0.99 we added a ```http-stream2``` payload which better modeled an HTTP request. This should be documented properly.
    
In addition we should use ```http-stream2``` from ```cockpit.http()```
