### PR TITLE
WIP: common: Abort for all warnings and criticals in unit tests

### DIFF
--- a/src/common/cockpittest.c
+++ b/src/common/cockpittest.c
@@ -220,6 +220,9 @@ cockpit_test_init (int *argc,
   g_assert (g_snprintf (path, sizeof (path), "%s:%s", BUILDDIR, g_getenv ("PATH")) < sizeof (path));
   g_setenv ("PATH", path, TRUE);
 
+  /* For our process and for children */
+  g_log_set_always_fatal (G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL | G_LOG_LEVEL_WARNING);
+
   g_type_init ();
 
   // System cockpit configuration file should not be loaded


### PR DESCRIPTION
This doesn't (yet) apply to child processes.