### PR TITLE
ssh: Fix closing transports when auth pipe is still open

### DIFF
--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -239,7 +239,7 @@ write_to_auth_fd (CockpitSshData *data,
         {
           if (errno != EAGAIN && errno != EINTR)
             {
-              g_warning ("%s: failed to write prompt to auth pipe: %s",
+              g_message ("%s: failed to write prompt to auth pipe: %s",
                          data->logname, g_strerror (errno));
               break;
             }
@@ -247,7 +247,7 @@ write_to_auth_fd (CockpitSshData *data,
       else
         {
           if (r != len)
-            g_warning ("%s: failed to write prompt to auth pipe", data->logname);
+            g_message ("%s: failed to write prompt to auth pipe", data->logname);
           break;
         }
     }

--- a/src/ssh/test-sshtransport.c
+++ b/src/ssh/test-sshtransport.c
@@ -458,10 +458,6 @@ test_close_problem (TestCase *tc,
 {
   gchar *problem = NULL;
 
-  /* exactly which of the two we get depends on how fast cockpit-ssh shuts down its auth pipe underneath us */
-  cockpit_expect_possible_log ("cockpit-ssh", G_LOG_LEVEL_WARNING, "*Auth pipe closed: *");
-  cockpit_expect_possible_log ("cockpit-protocol", G_LOG_LEVEL_WARNING, "*cockpit-ssh: couldn't recv: Connection reset by peer*");
-
   g_signal_connect (tc->transport, "closed", G_CALLBACK (on_closed_get_problem), &problem);
   cockpit_transport_close (tc->transport, "right now");
 
@@ -552,13 +548,13 @@ test_multi_auth_timeout (TestCase *tc,
 {
   gchar *problem = NULL;
 
-  // Ad a prompt handler that does nothing
+  // Add a prompt handler that does nothing
   g_signal_connect (COCKPIT_SSH_TRANSPORT (tc->transport), "prompt",
                     G_CALLBACK (on_prompt_do_nothing),
                     NULL);
 
   cockpit_expect_possible_log ("cockpit-bridge", G_LOG_LEVEL_WARNING,
-                                "*Auth pipe closed: timeout*");
+                               "*Auth pipe closed: timeout*");
   cockpit_expect_possible_log ("cockpit-ssh", G_LOG_LEVEL_WARNING,
                                "*Auth pipe closed: timeout*");
 
@@ -959,8 +955,6 @@ test_close_while_connecting (TestCase *tc,
   gchar *problem = NULL;
 
   /* exactly which of the two we get depends on how fast cockpit-ssh shuts down its auth pipe underneath us */
-  cockpit_expect_possible_log ("cockpit-ssh", G_LOG_LEVEL_WARNING, "*Auth pipe closed: *");
-  cockpit_expect_possible_log ("cockpit-protocol", G_LOG_LEVEL_WARNING, "*cockpit-ssh: couldn't recv: Connection reset by peer*");
 
   g_signal_connect (tc->transport, "closed", G_CALLBACK (on_closed_get_problem), &problem);
   cockpit_transport_close (tc->transport, "special-problem");


### PR DESCRIPTION
This seems to have stopped the flakes for me. Tested on multi-arch f25, 26 and rawhide with koji.