### PR TITLE
test: Retry test if the verify machine returns EAIGIN in fork()

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -475,6 +475,7 @@ class MachineCase(unittest.TestCase):
             except RetryError, ex:
                 assert retry < max_retry_hard_limit
                 sys.stderr.write("{0}\n".format(ex))
+                sleep(retry * 10)
             else:
                 break
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -895,6 +895,11 @@ class Policy(object):
         if "Failure: Unable to reach machine " in trace:
             return True
 
+        # HACK: For when the verify machine runs out of available processes
+        # We should retry this test process
+        if "self.pid = os.fork()\nOSError: [Errno 11] Resource temporarily unavailable" in trace:
+            return True
+
         return False
 
 class TapResult(unittest.TestResult):


### PR DESCRIPTION
See 'man fork' for when this can happen.
