### PR TITLE
ssh: Drop leftover confusing comment

### DIFF
--- a/src/ssh/test-sshtransport.c
+++ b/src/ssh/test-sshtransport.c
@@ -954,8 +954,6 @@ test_close_while_connecting (TestCase *tc,
 {
   gchar *problem = NULL;
 
-  /* exactly which of the two we get depends on how fast cockpit-ssh shuts down its auth pipe underneath us */
-
   g_signal_connect (tc->transport, "closed", G_CALLBACK (on_closed_get_problem), &problem);
   cockpit_transport_close (tc->transport, "special-problem");
 


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/pull/6118 removed the code
that comment applied to, so now it doesn't make sense any more.