### PR TITLE
retest: Mark the test failure as non-returning functions

### DIFF
--- a/src/retest/retest.c
+++ b/src/retest/retest.c
@@ -87,7 +87,7 @@ struct {
   int child_status;
 } gl = { NULL, NULL, 0, };
 
-static void
+GNUC_NORETURN static void
 exit_child (int code)
 {
   fflush (stderr);
@@ -152,10 +152,9 @@ re_test_fail (const char *filename,
   abort();
 #endif
 
-  if (gl.am_child)
-    exit_child (67);
-  else
+  if (!gl.am_child)
     longjmp (gl.jump, 1);
+  exit_child (67);
 }
 
 void

--- a/src/retest/retest.h
+++ b/src/retest/retest.h
@@ -43,6 +43,18 @@
 #endif
 #endif
 
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
+#if __has_feature(attribute_analyzer_noreturn) && defined(__clang_analyzer__)
+#define GNUC_NORETURN __attribute__((analyzer_noreturn))
+#elif     __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 4)
+#define GNUC_NORETURN __attribute__((__noreturn__))
+#else
+#define GNUC_NORETURN
+#endif
+
 #include <string.h>
 
 #ifdef assert_not_reached
@@ -113,7 +125,7 @@ void        re_test_fail            (const char *filename,
                                      int line,
                                      const char *function,
                                      const char *message,
-                                     ...) GNUC_PRINTF(4, 5);
+                                     ...) GNUC_PRINTF(4, 5) GNUC_NORETURN;
 
 void        re_test_skip            (const char *reason);
 


### PR DESCRIPTION
These functions shouldn't return and by marking them up we
tell the analyzer about that fact.

This should fix a Coverity error like:

```
src/retest/retest.c:369: error[deallocret]: Returning/dereferencing 'directory' after it is deallocated / released
```