### PR TITLE
ws: Fix invalid pointer check in cockpit-ws

### DIFF
--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -559,7 +559,7 @@ parse_host_and_etag (CockpitWebService *service,
     return FALSE;
 
   *host = cockpit_web_service_get_host (service, where + 1);
-  if (!host)
+  if (!*host)
     return FALSE;
 
   /* Top level resources (like the /manifests) are not translatable */


### PR DESCRIPTION
A pointer is not being checked properly in cockpit-ws. The bug
was introduced between version 134 and 135.  This is an important
fix and affects real use.