### PR TITLE
Trivial fixes resulting from coverity scans

### DIFF
--- a/pkg/kubernetes/scripts/test-kube-client.js
+++ b/pkg/kubernetes/scripts/test-kube-client.js
@@ -322,7 +322,7 @@ var FIXTURE_LARGE = require("./fixture-large");
         }
     ]);
 
-    kubeTest("list services", 3, FIXTURE_BASIC, [
+    kubeTest("list services", 4, FIXTURE_BASIC, [
         "kubeLoader",
         "kubeSelect",
         function(loader, select) {
@@ -333,6 +333,7 @@ var FIXTURE_LARGE = require("./fixture-large");
                     svc = services[x];
                     break;
                 }
+                assert.ok(!!svc, "got a service");
                 assert.equal(services.length, 2, "number of services");
                 assert.equal(svc.metadata.name, "kubernetes", "service id");
                 assert.equal(svc.spec.selector.component, "apiserver", "service has label");

--- a/src/base1/test-utf8.js
+++ b/src/base1/test-utf8.js
@@ -87,10 +87,8 @@ QUnit.test("utf8 round trip", function() {
 
         var length = block.length;
         for (var j = 0; j < length; j++) {
-            if (block[j] != decoded[j]) {
+            if (block[j] != decoded[j])
                 assert.deepEqual(block, decoded, "round trip " + block_tag);
-                return;
-            }
         }
     }
 


### PR DESCRIPTION
Most of the coverity scans are false positives, bugs in coverity, or stuff in other projects. But here's a couple minor warnings we can fix.