### PR TITLE
ssh: Check machines.d/*.json for host keys

### DIFF
--- a/doc/guide/feature-machines.xml
+++ b/doc/guide/feature-machines.xml
@@ -66,6 +66,18 @@
     </varlistentry>
 
     <varlistentry>
+      <term><code>"hostkey"</code></term>
+      <listitem><para><emphasis>(string or list of strings, optional)</emphasis>
+          Public host key(s) of the remote machine, in the format of
+          <code>/etc/ssh/ssh_host_*_key.pub</code>; for example,
+          <code>"ssh-rsa AAAA1234...eF=="</code>.
+          When not given, Cockpit will check the standard ssh
+          <code>/etc/ssh/ssh_known_hosts</code> file, and if the host is not
+          known in that either, ask the user for confirming the fingerprint.
+          </para></listitem>
+    </varlistentry>
+
+    <varlistentry>
       <term><code>"color"</code></term>
       <listitem><para><emphasis>(string, optional)</emphasis> Color to
           assign to the machine label in the web interface. This can be either given as

--- a/src/common/cockpitmachinesjson.c
+++ b/src/common/cockpitmachinesjson.c
@@ -121,7 +121,16 @@ merge_config (JsonObject *machines,
           const char *propname = p->data;
           JsonNode *prop_node = json_object_get_member (json_node_get_object (delta_props), propname);
 
-          if (!JSON_NODE_HOLDS_VALUE (prop_node))
+          /* "hostkey" can be a list, everything else is a simple value */
+          if (g_strcmp0 (propname, "hostkey") == 0)
+            {
+              if (!JSON_NODE_HOLDS_VALUE (prop_node) && !JSON_NODE_HOLDS_ARRAY (prop_node))
+                {
+                  g_message ("%s: host name definition %s: hostkey does not contain a simple value or list, ignoring", path, hostname);
+                  continue;
+                }
+            }
+          else if (!JSON_NODE_HOLDS_VALUE (prop_node))
             {
               g_message ("%s: host name definition %s: property %s does not contain a simple value, ignoring", path, hostname, propname);
               continue;

--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -329,8 +329,8 @@ static gchar *
 create_knownhosts_temp (void)
 {
   const gchar *directories[] = {
-      PACKAGE_LOCALSTATE_DIR,
       "/tmp",
+      PACKAGE_LOCALSTATE_DIR,
       NULL,
   };
 

--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -27,6 +27,7 @@
 #include "common/cockpittest.h"
 #include "common/cockpitunixfd.h"
 #include "common/cockpitknownhosts.h"
+#include "common/cockpitmachinesjson.h"
 
 #include "ws/cockpitauthoptions.h"
 
@@ -47,7 +48,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
-
 
 #define AUTH_FD 3
 
@@ -456,13 +456,130 @@ out:
   return ret;
 }
 
-static void cleanup_knownhosts_file (void)
+static void
+cleanup_knownhosts_file (void)
 {
   if (tmp_knownhost_file)
     {
       g_unlink (tmp_knownhost_file);
       g_free (tmp_knownhost_file);
     }
+}
+
+/**
+ * machines_d_lookup_hostkey:
+ *
+ * Check if @host/@port is known anywhere in /etc/cockpit/machines.d/
+ *
+ * Returns: (transfer full): host key(s) string, or %NULL if no key was found.
+ * The returned value should be freed with g_free().
+ */
+static gchar*
+machines_d_lookup_hostkey (const gchar* host,
+                           const guint port)
+{
+  JsonNode *machines = read_machines_json ();
+  GList *hosts = json_object_get_members (json_node_get_object (machines));
+  GString *keydata = g_string_new (NULL);
+
+  for (GList *i = g_list_first (hosts); i; i = g_list_next (i))
+    {
+      const char *hostname = i->data;
+
+      /* read_machines_json() guarantees the expected output structure */
+      JsonObject *host_props = json_object_get_object_member (json_node_get_object (machines),  hostname);
+      JsonNode *prop;
+
+      /* address matches? */
+      prop = json_object_get_member (host_props, "address");
+      if (!prop || g_strcmp0 (json_node_get_string (prop), host) != 0)
+        continue;
+      /* port matches? */
+      prop = json_object_get_member (host_props, "port");
+      if (prop)
+        {
+          /* can be int or str */
+          guint prop_port = json_node_get_int (prop);
+          if (prop_port == 0)
+            prop_port = g_ascii_strtoull (json_node_get_string (prop), NULL, 10);
+          if (prop_port != port)
+            continue;
+        }
+      else if (port != 22) /* default to 22 if port property is absent */
+        {
+          continue;
+        }
+
+      /* we have a match */
+      prop = json_object_get_member (host_props, "hostkey");
+      if (prop)
+        {
+          /* can be list of strings or string */
+          if (JSON_NODE_HOLDS_ARRAY (prop))
+            {
+              JsonArray *a = json_node_get_array (prop);
+              for (guint i = 0; i < json_array_get_length (a); ++i)
+                {
+                  JsonNode *element = json_array_get_element (a, i);
+                  if (JSON_NODE_HOLDS_VALUE (element))
+                    {
+                      g_string_append_printf (keydata, "[%s]:%u %s\n", host, port, json_node_get_string (element));
+                      g_debug ("%s:%u: found ssh host key list item: '%s'", host, port, json_node_get_string (element));
+                    }
+                  else
+                    {
+                      g_message ("machines.d json definition for %s:%u contains invalid hostkey entry, ignoring",
+                                 host, port);
+                    }
+                }
+            }
+          else
+            {
+              g_string_append_printf (keydata, "[%s]:%u %s\n", host, port, json_node_get_string (prop));
+              g_debug ("%s:%u: found ssh host key: '%s'", host, port, json_node_get_string (prop));
+            }
+
+          break;
+        }
+    }
+
+  g_list_free (hosts);
+  json_node_free (machines);
+  return g_string_free (keydata, keydata->len == 0);
+}
+
+/**
+ * write_temp_knownhosts:
+ *
+ * Create temporary file with @keydata ssh known hosts data.
+ */
+static gboolean write_temp_knownhosts (CockpitSshData *data,
+                                       const gchar *keydata)
+{
+  FILE *fp = NULL;
+  tmp_knownhost_file = create_knownhosts_temp ();
+  if (!tmp_knownhost_file)
+      return FALSE;
+  atexit (cleanup_knownhosts_file);
+
+  fp = fopen (tmp_knownhost_file, "a");
+  if (fp == NULL)
+    {
+      g_warning ("%s: couldn't open temporary known host file for data: %s",
+                 data->logname, tmp_knownhost_file);
+      return FALSE;
+    }
+
+  if (fputs (keydata, fp) < 0)
+    {
+      g_warning ("%s: couldn't write to data to temporary known host file: %s",
+                 data->logname, g_strerror (errno));
+      fclose (fp);
+      return FALSE;
+    }
+
+  fclose (fp);
+  return TRUE;
 }
 
 /**
@@ -483,29 +600,8 @@ set_knownhosts_file (CockpitSshData *data,
   /* $COCKPIT_SSH_KNOWN_HOSTS_DATA has highest priority */
   if (data->ssh_options->knownhosts_data)
     {
-      FILE *fp = NULL;
-      tmp_knownhost_file = create_knownhosts_temp ();
-      if (!tmp_knownhost_file)
-          return "internal-error";
-      atexit (cleanup_knownhosts_file);
-
-      fp = fopen (tmp_knownhost_file, "a");
-      if (fp == NULL)
-        {
-          g_warning ("%s: couldn't open temporary known host file for data: %s",
-                     data->logname, tmp_knownhost_file);
-          return "internal-error";
-        }
-
-      if (fputs (data->ssh_options->knownhosts_data, fp) < 0)
-        {
-          g_warning ("%s: couldn't write to data to temporary known host file: %s",
-                     data->logname, g_strerror (errno));
-          fclose (fp);
-          return "internal-error";
-        }
-
-      fclose (fp);
+      if (!write_temp_knownhosts (data, data->ssh_options->knownhosts_data))
+        return "internal-error";
       data->ssh_options->knownhosts_file = tmp_knownhost_file;
     }
 
@@ -528,7 +624,27 @@ set_knownhosts_file (CockpitSshData *data,
         }
     }
 
-  /* TODO: Check more sources of known hosts here if !host_known */
+  /* check if our machines.d json files have a key */
+  if (!host_known)
+    {
+      gchar *keydata = machines_d_lookup_hostkey (host, port);
+      if (keydata)
+        {
+          gboolean write_success = write_temp_knownhosts (data, keydata);
+          if (G_LIKELY (write_success))
+            {
+              host_known = cockpit_is_host_known (tmp_knownhost_file, host, port);
+              if (G_LIKELY (host_known))
+                data->ssh_options->knownhosts_file = tmp_knownhost_file;
+            }
+          g_free (keydata);
+
+          if (!write_success)
+            return "internal-error";
+        }
+    }
+
+  /* TODO: Check ~/.ssh/known_hosts here if !host_known */
 
   g_debug ("%s: using known hosts file %s", data->logname, data->ssh_options->knownhosts_file);
   if (ssh_options_set (data->session, SSH_OPTIONS_KNOWNHOSTS,

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -269,7 +269,20 @@ class TestMultiMachine(MachineCase):
         b.click('#login-button')
         b.expect_load()
         b.logout()
-        m.execute("rm /var/lib/cockpit/known_hosts")
+        # read correct key and clean up
+        key = m.execute("cat /etc/ssh/ssh_known_hosts; rm /var/lib/cockpit/known_hosts /etc/ssh/ssh_known_hosts")
+        key = key.split(None, 1)[1]  # strip off host
+
+        # host key from machines.d json
+        m.execute(("""echo '{ "test": { "address": "%s", "hostkey": "%s", "visible": true }}'"""
+                   "> /etc/cockpit/machines.d/01-test.json") % (m2.address, key))
+        b.wait_visible("#login")
+        b.set_val("#login-user-input", "admin")
+        b.set_val("#login-password-input", "alt-password")
+        b.click('#login-button')
+        b.expect_load()
+        b.logout()
+        m.execute("rm /etc/cockpit/machines.d/01-test.json")
 
         # Bad host key
         m.execute("echo '{} ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDgPMmTosSQ4NxMtq+aL2NKLC+W4I9/jbD1e74cnOKTW' > /etc/ssh/ssh_known_hosts".format(m2.address))


### PR DESCRIPTION
That way administrators, VM management software etc. can provide all
necessary information in one place, and again avoid having to write
/etc/ssh/ssh_known_hosts separately and possibly concurrently.

- [x] Add integration test to ensure it satisfies the SELinux profile