### PR TITLE
Image refresh for debian-testing

### DIFF
--- a/test/images/debian-testing
+++ b/test/images/debian-testing
@@ -1,1 +1,0 @@
-debian-testing-f272d4495e3d91e03c2cea8c4e302e7211fd8480.qcow2


### PR DESCRIPTION
Image creation for debian-testing in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-testing-2017-03-16/