### PR TITLE
containers: Stop downloading externally built rpms

### DIFF
--- a/containers/kubernetes/Dockerfile
+++ b/containers/kubernetes/Dockerfile
@@ -1,13 +1,14 @@
 FROM fedora:25
 
-ARG RELEASE
 ARG VERSION
-ARG COCKPIT_RPM_URL
 ARG INSTALLER
 ARG OFFLINE
-ARG USE_REPO
 
 ADD . /container
+
+RUN echo -e '[group_cockpit-cockpit-preview]\nname=Copr repo for cockpit-preview owned by @cockpit\nbaseurl=https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/fedora-$releasever-$basearch/\ntype=rpm-md\ngpgcheck=1\ngpgkey=https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/pubkey.gpg\nrepo_gpgcheck=0\nenabled=1\nenabled_metadata=1' > /etc/yum.repos.d/cockpit.repo
+
+
 RUN /container/install.sh
 
 CMD ["/usr/libexec/cockpit-kube-launch"]

--- a/containers/kubernetes/Dockerfile.atomic.centos7
+++ b/containers/kubernetes/Dockerfile.atomic.centos7
@@ -1,11 +1,8 @@
 FROM centos
 
-ARG RELEASE
 ARG VERSION
-ARG COCKPIT_RPM_URL
 ARG INSTALLER="yum"
 ARG OFFLINE
-ARG USE_REPO=1
 
 RUN echo -e "[cockpit_test]\nname=Cockpit Test\nbaseurl=http://cbs.centos.org/repos/atomic7-cockpit-preview-testing/x86_64/os/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/cockpit.repo
 

--- a/containers/kubernetes/Dockerfile.centos7
+++ b/containers/kubernetes/Dockerfile.centos7
@@ -1,11 +1,8 @@
 FROM centos
 
-ARG RELEASE
 ARG VERSION
-ARG COCKPIT_RPM_URL
 ARG INSTALLER="yum"
 ARG OFFLINE
-ARG USE_REPO=1
 
 ADD . /container
 RUN /container/install.sh

--- a/containers/kubernetes/Dockerfile.ppc64le
+++ b/containers/kubernetes/Dockerfile.ppc64le
@@ -1,11 +1,8 @@
 FROM ppc64le/fedora:25
 
-ARG RELEASE
 ARG VERSION
-ARG COCKPIT_RPM_URL="http://ppc.koji.fedoraproject.org/packages/cockpit"
 ARG INSTALLER
 ARG OFFLINE
-ARG USE_REPO
 
 ADD . /container
 RUN /container/install.sh

--- a/containers/kubernetes/install.sh
+++ b/containers/kubernetes/install.sh
@@ -6,10 +6,8 @@ if [ -z "$INSTALLER" ]; then
     INSTALLER="dnf"
 fi
 
-if [ -n "$USE_REPO" ]; then
+if [ -z "$OFFLINE" ]; then
     "$INSTALLER" -y update
-elif [ -z "$VERSION" ] && [ -z "$OFFLINE" ]; then
-    eval $(/container/scripts/get-version-env.sh)
 fi
 
 # Install packages without dependencies

--- a/containers/kubernetes/scripts/get-version-env.sh
+++ b/containers/kubernetes/scripts/get-version-env.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-set -ex
-
-v=$(rpm -q --qf "%{version}" -f /etc/fedora-release)
-OS="f$v-updates-testing"
-
-echo $(curl -s https://bodhi.fedoraproject.org/latest_builds?package=cockpit | python3 -c "import json, sys; obj=json.load(sys.stdin); parts=obj['$OS'].strip('cockpit-').split('-', 1); rparts=parts[1].split('.', 1); print('export VERSION={0} RELEASE={1} OS={2}'.format(parts[0], rparts[0], rparts[1]))")

--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -1,17 +1,14 @@
 FROM fedora:25
 MAINTAINER "Stef Walter" <stefw@redhat.com>
 
-ARG RELEASE
 ARG VERSION
-ARG COCKPIT_RPM_URL=https://kojipkgs.fedoraproject.org/packages/cockpit
-ARG USE_REPO
 
 ADD . /container
 
+RUN echo -e '[group_cockpit-cockpit-preview]\nname=Copr repo for cockpit-preview owned by @cockpit\nbaseurl=https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/fedora-$releasever-$basearch/\ntype=rpm-md\ngpgcheck=1\ngpgkey=https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/pubkey.gpg\nrepo_gpgcheck=0\nenabled=1\nenabled_metadata=1' > /etc/yum.repos.d/cockpit.repo
+
 # Again see above ... we do our branching in shell script
 RUN /container/install-package.sh && /container/prep-container.sh
-
-
 
 LABEL INSTALL /usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-install
 LABEL UNINSTALL /usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-uninstall

--- a/containers/ws/Dockerfile.centos7
+++ b/containers/ws/Dockerfile.centos7
@@ -1,9 +1,7 @@
 FROM registry.centos.org/centos/centos
 MAINTAINER "Stef Walter" <stefw@redhat.com>
 
-ARG RELEASE
 ARG VERSION
-ARG USE_REPO=1
 ARG INSTALLER="yum"
 
 ADD . /container

--- a/containers/ws/Dockerfile.testing.centos7
+++ b/containers/ws/Dockerfile.testing.centos7
@@ -1,9 +1,7 @@
 FROM registry.centos.org/centos/centos
 MAINTAINER "Stef Walter" <stefw@redhat.com>
 
-ARG RELEASE
 ARG VERSION
-ARG USE_REPO=1
 ARG INSTALLER="yum"
 
 ADD . /container

--- a/containers/ws/install-package.sh
+++ b/containers/ws/install-package.sh
@@ -2,6 +2,17 @@
 
 set -ex
 
+package_name()
+{
+    package="$1"
+    if [ -n "$VERSION" ]; then
+        package="$package-$VERSION"
+    fi
+    echo "$package"
+}
+
+OSVER=$(. /etc/os-release && echo "$VERSION_ID")
+
 if [ -z "$INSTALLER" ]; then
     INSTALLER="dnf"
 fi
@@ -9,30 +20,16 @@ fi
 "$INSTALLER" -y update
 "$INSTALLER" install -y sed
 
-OS=$(rpm -q --qf "%{release}" basesystem | sed -n -e 's/^[0-9]*\.\(\S\+\).*/\1/p')
-
-rpm=$(ls /container/rpms/cockpit-ws*.rpm /container/rpms/cockpit-dashboard*.rpm || true)
-
-if [ -z "$RELEASE" ]; then
-    RELEASE=1
-fi
+arch=`uname -p`
+rpm=$(ls /container/rpms/cockpit-ws-*$OSVER.*$arch.rpm /container/rpms/cockpit-dashboard-*$OSVER.*$arch.rpm || true)
 
 # If there are rpm files in the current directory we'll install those
 if [ -n "$rpm" ]; then
-    $INSTALLER -y install /container/rpms/cockpit-ws*.rpm /container/rpms/cockpit-dashboard*.rpm
-
-elif [ -n "$USE_REPO" ]; then
-    "$INSTALLER" -y install cockpit-ws cockpit-dashboard
-
-# If there is a url set, pull the version from there
-# requires the build arg VERSION to be set
-elif [ -n "$COCKPIT_RPM_URL" ]; then
-    "$INSTALLER" -y install "$COCKPIT_RPM_URL/$VERSION/$RELEASE.$OS/x86_64/cockpit-ws-$VERSION-$RELEASE.$OS.x86_64.rpm" "$COCKPIT_RPM_URL/$VERSION/$RELEASE.$OS/x86_64/cockpit-dashboard-$VERSION-$RELEASE.$OS.x86_64.rpm"
-
-# Otherwise just do the standard install
-# requires the build arg VERSION to be set
+    $INSTALLER -y install /container/rpms/cockpit-ws-*$OSVER.*$arch.rpm /container/rpms/cockpit-dashboard-*$OSVER.*$arch.rpm
 else
-    "$INSTALLER" -y install cockpit-ws-$VERSION-$RELEASE.$OS cockpit-dashboard-$VERSION-$RELEASE.$OS
+    ws=$(package_name "cockpit-ws")
+    dashboard=$(package_name "cockpit-dashboard")
+    "$INSTALLER" -y install "$ws" "$dashboard"
 fi
 
 "$INSTALLER" clean all


### PR DESCRIPTION
Many build systems disallow this, and determining the releasever (ei: fc25, el7) was buggy and problematic.

We now default to just using copr for our automatic docker builds. Other dockerfiles can provide their own repos. Install either the latest there, or the version given as a build arg.

Installing from local rpms (ei: make ws-container) still works as expected.

Once this is merged here I'll also update the cockpit-container repo.