### PR TITLE
ws: Use standard pattern for delegated Kerberos credentials

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,10 +126,6 @@ if test "$enable_ssh" != "no"; then
   AC_MSG_RESULT([$enable_ssh])
   PKG_CHECK_MODULES(LIBSSH, [libssh >= $LIBSSH_VERSION libssh_threads])
 
-  AC_CHECK_LIB(ssh, ssh_gssapi_set_creds, [
-    AC_DEFINE_UNQUOTED(HAVE_SSH_GSSAPI_SET_CREDS, 1, Whether ssh_gssapi_set_creds is available)
-  ])
-
   AC_DEFINE_UNQUOTED(WITH_COCKPIT_SSH, 1, [Build cockpit-ssh and include libssh dependency])
 
   COCKPIT_SSH_SESSION_CFLAGS="$COCKPIT_CFLAGS $LIBSSH_CFLAGS $KRB5_CFLAGS"
@@ -209,8 +205,9 @@ fi
 AM_CONDITIONAL([ENABLE_PCP], [test "$enable_pcp" = "yes"])
 
 # gssapi
-AC_CHECK_LIB(gssapi_krb5, gss_import_cred,
-  [AC_DEFINE_UNQUOTED(HAVE_GSS_IMPORT_CRED, 1, Whether gss_import_cred is available)])
+AC_CHECK_LIB(gssapi_krb5, gss_store_cred, [ true ],
+  [AC_MSG_ERROR([Couldn't find GSSAPI KRB5 library. Try installing krb5-devel])]
+)
 
 # systemd
 AC_ARG_WITH([systemdunitdir], [AC_HELP_STRING([--with-systemdunitdir=DIR],

--- a/doc/guide/sso.xml
+++ b/doc/guide/sso.xml
@@ -55,7 +55,11 @@ $ sudo klist -k
 $ getent passwd user@example.com
 user@example.com:*:381001109:381000513:User Name:/home/user:/bin/sh
 </programlisting>
-      
+
+    <para>If you wish to delegate your kerberos credentials to Cockpit, and allow Cockpit
+      to then connect to other machines using those credentials, you should enable delegation
+      for the hosts running Cockpit, and in some cases the <code>HTTP</code> service as well.</para>
+
   </section>
 
   <section id="sso-client">
@@ -66,7 +70,7 @@ user@example.com:*:381001109:381000513:User Name:/home/user:/bin/sh
 
 <programlisting>
 $ kinit user@EXAMPLE.COM
-Password for user@EXAMPLE.COM:  
+Password for user@EXAMPLE.COM:
 </programlisting>
 
     <para>In addition your browser must be usually be configured to allow kerberos
@@ -101,7 +105,29 @@ Password for user@EXAMPLE.COM:
       Cockpit in your web browser.</para>
 
     <para>If you wish to connect from one server to another in Cockpit using kerberos SSO,
-      then you have to explicitly enable this in your web browsers.</para>
+      then you have to explicitly enable all sorts of things. For starters, make sure that
+      delegated credentials are allowed by your domain (see above). Next when requesting your
+      kerberos ticket make sure that forwardable tickets are requested:</para>
+
+<programlisting>
+$ kinit -f user@EXAMPLE.COM
+Password for user@EXAMPLE.COM:
+</programlisting>
+
+    <para>Make sure that the forwardable flag <code>F</code> is present in your ticket:</para>
+
+<programlisting>
+$ klist -f
+Ticket cache: KEYRING:persistent:1000:1000
+Default principal: user@EXAMPLE.COM
+
+Valid starting       Expires              Service principal
+18.03.2017 05:39:23  19.03.2017 05:39:20  krbtgt/EXAMPLE.COM@EXAMPLE.COM
+	Flags: FIA
+</programlisting>
+
+    <para>Lastly configure your browser to allow delegated, forwardable kerberos
+      credentials to be sent to Cockpit:</para>
 
     <variablelist>
       <varlistentry>

--- a/pkg/realmd/README.md
+++ b/pkg/realmd/README.md
@@ -69,7 +69,7 @@ the computer running Cockpit.
             --header 'Referer: https://f0.cockpit.lan/ipa' \
             --header "Content-Type: application/json" \
             --header "Accept: application/json" \
-            --data '{"params": [["HTTP/my-server.cockpit.lan@COCKPIT.LAN"], {"raw": false, "all": false, "version": "2.101", "force": true, "no_members": false}], "method": "service_add", "id": 0}'
+            --data '{"params": [["HTTP/my-server.cockpit.lan@COCKPIT.LAN"], {"raw": false, "all": false, "version": "2.101", "force": true, "no_members": false, "ipakrbokasdelegate": true}], "method": "service_add", "id": 0}'
     # ipa-getkeytab -q -s f0.cockpit.lan -p HTTP/my-server.cockpit.lan \
             -k /etc/krb5.keytab
 
@@ -85,5 +85,21 @@ with the domain user:
 
 If you thought that was nasty and tiresome, it's because it is at present :S
 
+## Using delegated credentials
 
+Cockpit can delegate forwardable credentials. Make sure to specify you want them
+during kinit:
 
+    $ kinit -f admin@COCKPIT.LAN
+    $ klist -f
+    Default principal: admin@COCKPIT.LAN
+    ...
+	Flags: FIA
+
+Use the IPA GUI to setup "Trusted for delegation" for the host and service that
+Cockpit is running on. Make sure to tell the browser to delegate credentials
+as seen in the guide:
+
+http://cockpit-project.org/guide/latest/sso.html
+
+Ze goggles, zey do nothing!

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -607,7 +607,6 @@ create_creds_for_spawn_authenticated (CockpitAuth *self,
                                       const gchar *raw_data)
 {
   GBytes *password = NULL;
-  const gchar *gssapi_creds = NULL;
   CockpitCreds *creds = NULL;
   gchar *csrf_token;
 
@@ -619,12 +618,6 @@ create_creds_for_spawn_authenticated (CockpitAuth *self,
   if (ad->authorize_password && g_str_equal (ad->auth_type, "basic"))
     password = parse_basic_auth_password (ad->authorization, NULL);
 
-  if (!cockpit_json_get_string (results, "gssapi-creds", NULL, &gssapi_creds))
-    {
-      g_warning ("received bad gssapi-creds");
-      gssapi_creds = NULL;
-    }
-
   csrf_token = cockpit_auth_nonce (self);
 
   creds = cockpit_creds_new (user,
@@ -632,7 +625,6 @@ create_creds_for_spawn_authenticated (CockpitAuth *self,
                              COCKPIT_CRED_LOGIN_DATA, raw_data,
                              COCKPIT_CRED_PASSWORD, password,
                              COCKPIT_CRED_RHOST, ad->remote_peer,
-                             COCKPIT_CRED_GSSAPI, gssapi_creds,
                              COCKPIT_CRED_CSRF_TOKEN, csrf_token,
                              NULL);
 

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -438,7 +438,7 @@ cockpit_auth_steal_authorization (GHashTable *headers,
        * or not, then we ask our session to try to do Negotiate auth
        * but without any input data.
        */
-      if (gssapi_available == -1)
+      if (gssapi_available != 0)
         line = g_strdup ("Negotiate");
       else
         return NULL;

--- a/src/ws/cockpitauthoptions.c
+++ b/src/ws/cockpitauthoptions.c
@@ -123,7 +123,6 @@ cockpit_ssh_options_from_env (gchar **env)
   options->knownhosts_file = get_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE",
                                                   default_knownhosts);
   options->command = get_environment_val (env, "COCKPIT_SSH_BRIDGE_COMMAND", default_command);
-  options->krb5_ccache_name = get_environment_val (env, "KRB5CCNAME", NULL);
   options->supports_hostkey_prompt = get_environment_bool (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", FALSE);
 
   if (options->knownhosts_data != NULL)
@@ -156,7 +155,6 @@ cockpit_ssh_options_to_env (CockpitSshOptions *options,
 
   env = set_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA",
                              knownhosts_data);
-  env = set_environment_val (env, "KRB5CCNAME", options->krb5_ccache_name);
 
   /* Don't reset these vars unless we have values for them */
   if (options->command)

--- a/src/ws/cockpitauthoptions.h
+++ b/src/ws/cockpitauthoptions.h
@@ -40,7 +40,6 @@ typedef struct {
   const gchar *knownhosts_data;
   const gchar *knownhosts_file;
   const gchar *command;
-  const gchar *krb5_ccache_name;
   gboolean allow_unknown_hosts;
   gboolean supports_hostkey_prompt;
   gboolean ignore_hostkey;

--- a/src/ws/cockpitcreds.c
+++ b/src/ws/cockpitcreds.c
@@ -157,8 +157,6 @@ cockpit_creds_new (const gchar *user,
         password = va_arg (va, GBytes *);
       else if (g_str_equal (type, COCKPIT_CRED_RHOST))
         creds->rhost = g_strdup (va_arg (va, const char *));
-      else if (g_str_equal (type, COCKPIT_CRED_GSSAPI))
-        creds->gssapi_creds = g_strdup (va_arg (va, const char *));
       else if (g_str_equal (type, COCKPIT_CRED_CSRF_TOKEN))
         creds->csrf_token = g_strdup (va_arg (va, const char *));
       else if (g_str_equal (type, COCKPIT_CRED_LOGIN_DATA))
@@ -274,24 +272,6 @@ cockpit_creds_set_password (CockpitCreds *creds,
 }
 
 const gchar *
-cockpit_creds_get_gssapi_creds (CockpitCreds *creds)
-{
-  g_return_val_if_fail (creds != NULL, NULL);
-  if (g_atomic_int_get (&creds->poisoned))
-      return NULL;
-  return creds->gssapi_creds;
-}
-
-const gchar *
-cockpit_creds_get_krb5_ccache_name (CockpitCreds *creds)
-{
-  g_return_val_if_fail (creds != NULL, NULL);
-  if (g_atomic_int_get (&creds->poisoned))
-      return NULL;
-  return creds->krb5_ccache_name;
-}
-
-const gchar *
 cockpit_creds_get_csrf_token (CockpitCreds *creds)
 {
   g_return_val_if_fail (creds != NULL, NULL);
@@ -328,24 +308,6 @@ cockpit_creds_get_rhost (CockpitCreds *creds)
 {
   g_return_val_if_fail (creds != NULL, NULL);
   return creds->rhost;
-}
-
-/**
- * cockpit_creds_has_gssapi:
- * @creds: the credentials
- *
- * Returns: true if this credentials instance has gssapi credentials
- * stored. Otherwise false.
- */
-gboolean
-cockpit_creds_has_gssapi (CockpitCreds *creds)
-{
-  g_return_val_if_fail (creds != NULL, FALSE);
-
-  if (!creds->gssapi_creds || !creds->krb5_ccache_name)
-    return FALSE;
-
-  return TRUE;
 }
 
 gboolean

--- a/src/ws/cockpitcreds.h
+++ b/src/ws/cockpitcreds.h
@@ -33,7 +33,6 @@ typedef struct _CockpitCreds       CockpitCreds;
 
 #define COCKPIT_CRED_PASSWORD     "password"
 #define COCKPIT_CRED_RHOST        "rhost"
-#define COCKPIT_CRED_GSSAPI       "gssapi"
 #define COCKPIT_CRED_CSRF_TOKEN   "csrf-token"
 #define COCKPIT_CRED_LOGIN_DATA   "login-data"
 
@@ -67,17 +66,12 @@ gboolean        cockpit_creds_equal          (gconstpointer v1,
 
 guint           cockpit_creds_hash           (gconstpointer v);
 
-gboolean        cockpit_creds_has_gssapi     (CockpitCreds *creds);
-
 const gchar *   cockpit_creds_get_application            (CockpitCreds *creds);
 
 JsonObject *    cockpit_creds_get_login_data             (CockpitCreds *creds);
 
 JsonObject *    cockpit_creds_to_json                    (CockpitCreds *creds);
 
-const gchar *   cockpit_creds_get_krb5_ccache_name       (CockpitCreds *creds);
-
-const gchar *   cockpit_creds_get_gssapi_creds           (CockpitCreds *creds);
 G_END_DECLS
 
 #endif

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -1164,12 +1164,9 @@ main (int argc,
   /* When setuid root, make sure our group is also root */
   if (geteuid () == 0)
     {
-      /* Never trust the environment when running setuid() */
-      if (getuid() != 0)
-        {
-          if (clearenv () != 0)
-            err (1, "couldn't clear environment");
-        }
+      /* Always clear the environment */
+      if (clearenv () != 0)
+        err (1, "couldn't clear environment");
 
       /* set a minimal environment */
       setenv ("PATH", DEFAULT_PATH, 1);

--- a/src/ws/test-authoptions.c
+++ b/src/ws/test-authoptions.c
@@ -63,7 +63,6 @@ test_ssh_options (void)
 
   options = cockpit_ssh_options_from_env (env);
   g_assert_null (options->knownhosts_data);
-  g_assert_null (options->krb5_ccache_name);
   g_assert_cmpstr (options->knownhosts_file, ==, PACKAGE_SYSCONF_DIR "/ssh/ssh_known_hosts");
   g_assert_cmpstr (options->command, ==, "cockpit-bridge");
   g_assert_false (options->allow_unknown_hosts);
@@ -73,7 +72,6 @@ test_ssh_options (void)
   options->knownhosts_data = "";
   options->knownhosts_file = "other-known";
   options->command = "other-command";
-  options->krb5_ccache_name = "";
   options->ignore_hostkey = TRUE;
 
   env = cockpit_ssh_options_to_env (options, NULL);
@@ -83,9 +81,7 @@ test_ssh_options (void)
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA"), ==, "*");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_BRIDGE_COMMAND"), ==, "other-command");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT"), ==, "");
-  g_assert_cmpstr (g_environ_getenv (env, "KRB5CCNAME"), ==, "");
 
-  options->krb5_ccache_name = "cache";
   options->allow_unknown_hosts = TRUE;
   options->supports_hostkey_prompt = TRUE;
   options->ignore_hostkey = FALSE;
@@ -95,7 +91,6 @@ test_ssh_options (void)
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA"), ==, "* invalid key");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN"), ==, "1");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT"), ==, "1");
-  g_assert_cmpstr (g_environ_getenv (env, "KRB5CCNAME"), ==, "cache");
 
   options->knownhosts_data = "key";
   g_strfreev (env);
@@ -110,12 +105,10 @@ test_ssh_options (void)
   env = g_environ_setenv (env, "COCKPIT_SSH_BRIDGE_COMMAND", "other-command", TRUE);
   env = g_environ_setenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN", "", TRUE);
   env = g_environ_setenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "", TRUE);
-  env = g_environ_setenv (env, "KRB5CCNAME", "", TRUE);
 
   options = cockpit_ssh_options_from_env (env);
   g_assert_true (options->ignore_hostkey);
   g_assert_cmpstr (options->knownhosts_data, ==, "*");
-  g_assert_null (options->krb5_ccache_name);
   g_assert_false (options->supports_hostkey_prompt);
   g_assert_true (options->allow_unknown_hosts);
   g_assert_cmpstr (options->knownhosts_file, ==, "other-known");
@@ -126,11 +119,9 @@ test_ssh_options (void)
 
   env = g_environ_setenv (NULL, "COCKPIT_SSH_KNOWN_HOSTS_DATA", "data", TRUE);
   env = g_environ_setenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "1", TRUE);
-  env = g_environ_setenv (env, "KRB5CCNAME", "cache", TRUE);
   options = cockpit_ssh_options_from_env (env);
   g_assert_false (options->ignore_hostkey);
   g_assert_cmpstr (options->knownhosts_data, ==, "data");
-  g_assert_cmpstr (options->krb5_ccache_name, ==, "cache");
   g_assert_true (options->supports_hostkey_prompt);
   g_assert_true (options->allow_unknown_hosts);
   g_free (options);

--- a/src/ws/test-creds.c
+++ b/src/ws/test-creds.c
@@ -43,31 +43,6 @@ test_password (void)
 }
 
 static void
-test_gssapi (void)
-{
-  CockpitCreds *creds;
-  GBytes *password;
-
-  password = g_bytes_new_take (g_strdup ("password"), 8);
-  creds = cockpit_creds_new ("user", "test", COCKPIT_CRED_PASSWORD, password, NULL);
-  g_bytes_unref (password);
-
-  g_assert (creds != NULL);
-
-  g_assert_false (cockpit_creds_has_gssapi (creds));
-
-  cockpit_creds_unref (creds);
-
-  creds = cockpit_creds_new ("user", "test", COCKPIT_CRED_GSSAPI, "bad-but-present", NULL);
-  g_assert (creds != NULL);
-
-  g_assert_true (cockpit_creds_has_gssapi (creds));
-
-  cockpit_creds_unref (creds);
-
-}
-
-static void
 test_set_password (void)
 {
   CockpitCreds *creds;
@@ -299,7 +274,6 @@ main (int argc,
   g_test_add_func ("/creds/multiple", test_multiple);
   g_test_add_func ("/creds/hash", test_hash);
   g_test_add_func ("/creds/equal", test_equal);
-  g_test_add_func ("/creds/has_gssapi", test_gssapi);
   g_test_add_func ("/creds/login-data", test_login_data);
 
   return g_test_run ();

--- a/test/common/phantom-driver.js
+++ b/test/common/phantom-driver.js
@@ -314,7 +314,9 @@ var driver = {
         respond({ result: "pong" });
     },
 
-    cookies: function(respond) {
+    cookies: function(respond, add) {
+        if (add)
+            phantom.addCookie(add);
         respond({ result: phantom.cookies });
     }
 };

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -84,7 +84,7 @@ class Browser:
     def title(self):
         return self.phantom.eval('document.title')
 
-    def open(self, href):
+    def open(self, href, cookie=None):
         """
         Load a page into the browser.
 
@@ -103,6 +103,8 @@ class Browser:
         def tryopen(hard=False):
             try:
                 self.phantom.kill()
+                if cookie is not None:
+                    self.phantom.cookies(cookie)
                 self.phantom.open(href)
                 return True
             except:

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -180,9 +180,10 @@ if ! echo '%(password)s' | realm join -U admin cockpit.lan; then
     journalctl -u realmd.service
 fi
 
+echo '%(password)s' | kinit -f admin@COCKPIT.LAN
+
 # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1144292
-echo '%(password)s' | kinit admin@COCKPIT.LAN
-curl --insecure -s --negotiate -u : https://f0.cockpit.lan/ipa/json --header 'Referer: https://f0.cockpit.lan/ipa' --header "Content-Type: application/json" --header "Accept: application/json" --data '{"params": [["HTTP/x0.cockpit.lan@COCKPIT.LAN"], {"raw": false, "all": false, "version": "2.101", "force": true, "no_members": false}], "method": "service_add", "id": 0}'
+curl --insecure -s --negotiate -u : https://f0.cockpit.lan/ipa/json --header 'Referer: https://f0.cockpit.lan/ipa' --header "Content-Type: application/json" --header "Accept: application/json" --data '{"params": [["HTTP/x0.cockpit.lan@COCKPIT.LAN"], {"raw": false, "all": false, "version": "2.101", "force": true, "no_members": false, "ipakrbokasdelegate": true}], "method": "service_add", "id": 0}'
 ipa-getkeytab -q -s f0.cockpit.lan -p HTTP/x0.cockpit.lan -k /etc/krb5.keytab
 
 # HACK: https://bugs.freedesktop.org/show_bug.cgi?id=98479
@@ -193,6 +194,9 @@ fi
 
 # This needs to work
 getent passwd admin@cockpit.lan
+
+# This directory should be owned by the domain user
+chown -R admin@cockpit.lan /home/admin
 """
 
 # This is here because our test framework can't run ipa VM's twice
@@ -218,7 +222,14 @@ class TestKerberos(MachineCase):
         MachineCase.tearDown(self)
 
     def testNegotiate(self):
+        self.allow_authorize_journal_messages()
+        self.allow_hostkey_messages()
         b = self.browser
+
+        # HACK: There is no operating system where the domain admins are admins by default
+        # This is something that needs to be worked on at an OS level. We use admin level
+        # features below, such as adding a machine to the dashboard
+        self.machine.execute("echo 'admin@cockpit.lan        ALL=(ALL)       NOPASSWD: ALL' >> /etc/sudoers")
 
         # Make sure negotiate auth is not offered first
         self.machine.start_cockpit()
@@ -232,16 +243,54 @@ class TestKerberos(MachineCase):
         self.configure_kerberos()
         self.machine.restart_cockpit()
 
-        output = self.machine.execute(['/usr/bin/curl', '-s', '--negotiate', '-u', ':', "-D", "-",
+        output = self.machine.execute(['/usr/bin/curl', '-s', '--negotiate', '--delegation', 'always', '-u', ':', "-D", "-",
                                        '--resolve', 'x0.cockpit.lan:9090:%s' % self.machine.address,
                                        'http://x0.cockpit.lan:9090/cockpit/login'])
         self.assertIn("HTTP/1.1 200 OK", output)
         self.assertIn('"admin@cockpit.lan"', output)
 
         cookie = re.search("Set-Cookie: cockpit=([^ ;]+)", output).group(1)
-        b.open("/system", cookie={ "name": "cockpit", "value": cookie, "domain": self.machine.address, "path": "/" })
+        b.open("/system/terminal", cookie={ "name": "cockpit", "value": cookie, "domain": self.machine.address, "path": "/" })
         b.wait_present('#content')
         b.wait_visible('#content')
+        b.enter_page("/system/terminal")
+        b.wait_present(".terminal")
+        b.focus(".terminal")
+
+        def line_sel(i):
+            return '.terminal > div:nth-child(%d)' % i
+
+        def line_text(t):
+            return t + u'\xa0'*(80-len(t))
+
+        # wait for prompt in first line
+        b.wait_text_not(line_sel(1), line_text(""))
+
+        # run kinit and see if got forwarded the kerberos ticket into the session
+        b.key_press(list("klist") + [ "Return" ])
+        b.wait_text_not(line_sel(2), line_text(""))
+        text = b.text(line_sel(2)).replace(u"\xa0", " ").strip()
+        self.assertIn("Ticket cache", text)
+
+        # Now connect to another machine
+        self.assertNotIn("admin@cockpit.lan", self.machine.execute("ps -xa | grep sshd"))
+        b.switch_to_top()
+        b.go("/@x0.cockpit.lan/system/terminal")
+        b.wait_visible("#machine-troubleshoot")
+        b.click("#machine-troubleshoot")
+        b.wait_popup('troubleshoot-dialog')
+        b.wait_present("#troubleshoot-dialog .btn-primary:not([disabled])")
+        b.wait_text('#troubleshoot-dialog .btn-primary', "Add")
+        b.click('#troubleshoot-dialog .btn-primary')
+        b.wait_in_text('#troubleshoot-dialog', "Fingerprint")
+        b.click('#troubleshoot-dialog .btn-primary')
+        b.wait_popdown('troubleshoot-dialog')
+        b.enter_page("/system/terminal", host="x0.cockpit.lan")
+        b.wait_present(".terminal")
+        b.wait_visible(".terminal")
+
+        # Make sure we connected via SSH
+        self.assertIn("admin@cockpit.lan", self.machine.execute("ps -xa | grep sshd"))
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -22,6 +22,7 @@ import parent
 from testlib import *
 
 import os
+import re
 
 RESOLV_SCRIPT = """
 set -e
@@ -217,6 +218,7 @@ class TestKerberos(MachineCase):
         MachineCase.tearDown(self)
 
     def testNegotiate(self):
+        b = self.browser
 
         # Make sure negotiate auth is not offered first
         self.machine.start_cockpit()
@@ -235,6 +237,11 @@ class TestKerberos(MachineCase):
                                        'http://x0.cockpit.lan:9090/cockpit/login'])
         self.assertIn("HTTP/1.1 200 OK", output)
         self.assertIn('"admin@cockpit.lan"', output)
+
+        cookie = re.search("Set-Cookie: cockpit=([^ ;]+)", output).group(1)
+        b.open("/system", cookie={ "name": "cockpit", "value": cookie, "domain": self.machine.address, "path": "/" })
+        b.wait_present('#content')
+        b.wait_visible('#content')
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
When we get delegated kerberos credentials from a client, we can
store them into the session, and use them as any other program
would. Because cockpit-ssh is now launched from the bridge, we
no longer need to pass them back through cockpit-ws.

This helps remove a bunch of code. Also adds tests for use of delegated credentials, and update documentation for using them.