### PR TITLE
Image refresh for fedora-atomic, fix chcon invocation

### DIFF
--- a/test/images/fedora-atomic
+++ b/test/images/fedora-atomic
@@ -1,1 +1,1 @@
-fedora-atomic-e24e36592345be0ce947cc20a90808c144b957fa.qcow2
+fedora-atomic-2951a0d3fdb4cedbcbd232c0044384c96fb090ed.qcow2

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -318,7 +318,7 @@ CMD ["/bin/sh"]
         b.set_val("#select-mounted-volumes form:eq(0) input:eq(0)", "/blah")
         b.set_val("#select-mounted-volumes form:eq(0) input:eq(1)", "/mnt")
         if m.image not in [ "debian-8", "debian-testing", "ubuntu-1604" ]:
-            m.execute("chcon -Rt svirt_sandbox_file_t /mnt")
+            m.execute("chcon --dereference -HRt svirt_sandbox_file_t /mnt")
         m.execute("touch /mnt/dripping.txt")
 
         # And run it without a terminal


### PR DESCRIPTION
This replaces PR #6071 (Image refresh for fedora-atomic) with an additional fix for our check-docker test. See commit message and detailled analysis in that PR for details.