### PR TITLE
test: Fix UnicodeEncodeError failure on Fedora test suite preparation

### DIFF
--- a/test/images/scripts/lib/fedora.install
+++ b/test/images/scripts/lib/fedora.install
@@ -50,7 +50,7 @@ tar=$1
 if [ -n "$do_build" ]; then
     rm -rf build-results
     srpm=$(/var/lib/testvm/make-srpm "$tar")
-    su builder -c "/usr/bin/mock --offline --no-clean --resultdir build-results $mock_opts --rebuild $srpm"
+    LC_ALL=C.UTF-8 su builder -c "/usr/bin/mock --offline --no-clean --resultdir build-results $mock_opts --rebuild $srpm"
 fi
 
 # Install


### PR DESCRIPTION
Under non-English locales (observed under de_DE.UTF-8),
testsuite-prepare failed with
```
DEBUG: Executing command: ['/usr/bin/df', '-H', '/var/lib/mock/fedora-25-x86_64/root'] with env {'HOSTNAME': 'mock', 'HOME': '/builddir', 'LANG': 'de_DE.UTF-8', 'SHELL': '/bin/sh', 'TERM': 'vt100', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin'} and shell False
DEBUG: Dateisystem             Gr\ufffd\ufffd\ufffd\ufffde Benutzt Verf. Verw% Eingeh\ufffd\ufffdngt auf
DEBUG: /dev/mapper/fedora-root  6,7G    4,2G  2,5G   63% /
DEBUG: Child return code was: 0
ERROR: Exception(cockpit-135.x-1.wip.fc25.src.rpm) Config(fedora-25-x86_64) 0 minutes 0 seconds
[..]
Traceback (most recent call last):
  File "/usr/libexec/mock/mock", line 886, in <module>
[...]
UnicodeEncodeError: 'ascii' codec can't encode characters in position 26-29: ordinal not in range(128)
```

Fix that by forcing the C.UTF-8 locale for the mock invocation.