### PR TITLE
test: Configure IPA with a DNS forwarder and local DNS lookups

### DIFF
--- a/test/images/ipa
+++ b/test/images/ipa
@@ -1,1 +1,1 @@
-ipa-52c1dd222036c72d73aee8bc0f86a6d7e463ad3d.qcow2
+ipa-4afd875da342bcf439da59321801a885d0c87ff2.qcow2

--- a/test/images/scripts/ipa.setup
+++ b/test/images/scripts/ipa.setup
@@ -23,6 +23,10 @@ ipa-server-install -U -p foobarfoo -a foobarfoo -n cockpit.lan -r COCKPIT.LAN --
 # Make sure any initial password change is overridden
 printf 'foobarfoo\nfoobarfoo\nfoobarfoo\n' | kinit admin@COCKPIT.LAN
 
+ipa dnsconfig-mod --forwarder=8.8.8.8
+nmcli conn modify 'System eth0' ipv4.ignore-auto-dns yes
+nmcli conn modify 'System eth0' ipv4.dns "10.111.112.100"
+
 ln -sf ../selinux/config /etc/sysconfig/selinux
 echo 'SELINUX=permissive' > /etc/selinux/config
 


### PR DESCRIPTION
This makes it much easier to use the test image IPA domain when
developing Cockpit.

 * [x] #6157 
 * [x] Create the image