### PR TITLE
bridge: Cancel prompt if zero bytes received by cockpit-askpass

### DIFF
--- a/src/bridge/askpass.c
+++ b/src/bridge/askpass.c
@@ -74,16 +74,16 @@ read_control_message (int fd)
       /* Parse the length if necessary */
       if (length == 0)
         {
-        length = cockpit_pipe_parse_length (buffer, &skip);
-        if (length > 0)
-          cockpit_pipe_skip (buffer, skip);
+          length = cockpit_pipe_parse_length (buffer, &skip);
+          if (length > 0)
+            cockpit_pipe_skip (buffer, skip);
         }
 
       if (length < 0)
         break;
     }
 
-  if (length == buffer->len)
+  if (buffer->len > 0 && length == buffer->len)
     {
       /* This could have a password, so clear it when freeing */
       bytes = g_bytes_new_with_free_func (buffer->data, buffer->len,
@@ -94,7 +94,8 @@ read_control_message (int fd)
 
   if (payload == NULL)
     {
-      g_message ("askpass did not receive valid message");
+      if (buffer->len > 0)
+        g_message ("askpass did not receive valid message");
     }
   else if (channel != NULL)
     {


### PR DESCRIPTION
If no bytes are received by cockpit-askpass when reading back
an "authorize" message, this means that the prompt has been
cancelled due to the session shutting down or similar.