### PR TITLE
common: Change 'dropping message' message to debug note

### DIFF
--- a/src/common/cockpitpipe.c
+++ b/src/common/cockpitpipe.c
@@ -1011,7 +1011,7 @@ _cockpit_pipe_write (CockpitPipe *self,
   */
   if (self->priv->closed && self->priv->child && self->priv->pid != 0)
     {
-      g_message ("%s: dropping message while waiting for child to exit", self->priv->name);
+      g_debug ("%s: dropping message while waiting for child to exit", self->priv->name);
       return;
     }
 


### PR DESCRIPTION
This often comes up now that we use the cockpit-bridge to
invoke cockpit-ssh. We have to wait for cockpit-ssh to exit
while shutting down. We see this message:

10.111.126.239: dropping message while waiting for child to exit

This is not an error or particularly informative message. It
just means that we've asked the other side of the pipe to shutdown
but it hasn't yet. If it had already shutdown, then the message
wouldn't have made it anyway.