### PR TITLE
test: Add ipa image to refresh schedule

### DIFF
--- a/test/common/testinfra.py
+++ b/test/common/testinfra.py
@@ -118,6 +118,13 @@ DEFAULT_IMAGE_REFRESH = {
                       "verify/fedora-25",
                       "verify/rhel-7" ],
         'refresh-days': 30
+    },
+    'ipa': {
+        'triggers': [ "verify/fedora-25",
+                      "verify/rhel-7",
+                      "verify/ubuntu-1604",
+                      "verify/debian-8" ],
+        'refresh-days': 120
     }
 }
 

--- a/test/common/testinfra.py
+++ b/test/common/testinfra.py
@@ -634,17 +634,9 @@ class GitHub(object):
 
     def scan_for_image_tasks(self):
         results = [ ]
-
-        # Trigger based on how old the youngest issue is
-        for image, wait_time in self.scan_image_wait_times().items():
-            if wait_time <= 0:
-                results.append(GitHub.TaskEntry(BASELINE_PRIORITY, GithubImageTask("refresh-" + image,
-                                                                                   image,
-                                                                                   DEFAULT_IMAGE_REFRESH[image],
-                                                                                   None)))
+        requested = set()
 
         # Trigger on explicit requests
-
         def issue_requests_image_refresh(issue, comments, image):
             request = "bot: " + ISSUE_TITLE_IMAGE_REFRESH.format(image)
             in_process_prefix = "Image creation for {} in process".format(image)
@@ -661,10 +653,19 @@ class GitHub(object):
             comments = self.get(issue['comments_url'])
             for image in DEFAULT_IMAGE_REFRESH:
                 if issue_requests_image_refresh(issue, comments, image):
+                    requested.add(image)
                     results.append(GitHub.TaskEntry(BASELINE_PRIORITY, GithubImageTask("refresh-" + image,
                                                                                        image,
                                                                                        DEFAULT_IMAGE_REFRESH[image],
                                                                                        issue)))
+
+        # Trigger based on how old the youngest issue is
+        for image, wait_time in self.scan_image_wait_times().items():
+            if wait_time <= 0 and image not in requested:
+                results.append(GitHub.TaskEntry(BASELINE_PRIORITY, GithubImageTask("refresh-" + image,
+                                                                                   image,
+                                                                                   DEFAULT_IMAGE_REFRESH[image],
+                                                                                   None)))
 
         return results
 


### PR DESCRIPTION
This image expires once every 180 days due to password expiry anyway. Plus we want to be able to request that it is manually refreshed. So setup a slow schedule for its refresh.
