### PR TITLE
Image refresh for ubuntu-1604

### DIFF
--- a/test/images/ubuntu-1604
+++ b/test/images/ubuntu-1604
@@ -1,1 +1,1 @@
-ubuntu-1604-8df32e816eebeb1843af82dab7c1313f86e4ea47.qcow2
+ubuntu-1604-2efecf480936bbfd641e15a7009e59b79abc03ee.qcow2


### PR DESCRIPTION
Image creation for ubuntu-1604 in process on cockpit-11.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-ubuntu-1604-2017-03-20/