### PR TITLE
dashboard: Don't mark hosts as failed on removal

### DIFF
--- a/pkg/lib/machines.js
+++ b/pkg/lib/machines.js
@@ -591,10 +591,13 @@
                         whirl();
                     })
                 .on("close", function(ev, options) {
-                    problem = options.problem || "disconnected";
-                    open = false;
-                    state(host, "failed", problem);
                     var m = machines.lookup(host);
+                    open = false;
+                    // reset to clean state when removing machine (orderly disconnect), otherwise mark as failed
+                    if (!options.problem && m && !m.visible)
+                        state(host, null, null);
+                    else
+                        state(host, "failed", options.problem || "disconnected");
                     if (m && m.restarting) {
                         window.setTimeout(function() {
                             self.connect(host);

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -97,6 +97,12 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
         self.wait_dashboard_addresses (b, [ "localhost", m2.address ])
         self.wait_dashboard_addresses (b2, [ "localhost", m2.address ])
 
+        # Should show successful state and icon
+        b.wait_present("#dashboard-hosts a.connected[data-address='%s'] img" % m2.address)
+        b.wait_attr("#dashboard-hosts a.connected[data-address='%s'] img" % m2.address, 'src', '../shell/images/server-small.png')
+        b2.wait_present("#dashboard-hosts a.connected[data-address='%s'] img" % m2.address)
+        b2.wait_attr("#dashboard-hosts a.connected[data-address='%s'] img" % m2.address, 'src', '../shell/images/server-small.png')
+
         self.add_machine (b, m3.address)
         self.wait_dashboard_addresses (b, [ "localhost", m3.address, m2.address ])
         self.wait_dashboard_addresses (b2, [ "localhost", m3.address, m2.address ])
@@ -121,6 +127,12 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
         self.wait_dashboard_addresses (b2, [ "localhost", m2.address ])
         self.check_discovered_addresses (b, [ m3.address ])
         self.check_discovered_addresses (b2, [ m3.address ])
+
+        # Should show successful state and icon again
+        b.wait_present("#dashboard-hosts a.connected[data-address='%s'] img" % m2.address)
+        b.wait_attr("#dashboard-hosts a.connected[data-address='%s'] img" % m2.address, 'src', '../shell/images/server-small.png')
+        b2.wait_present("#dashboard-hosts a.connected[data-address='%s'] img" % m2.address)
+        b2.wait_attr("#dashboard-hosts a.connected[data-address='%s'] img" % m2.address, 'src', '../shell/images/server-small.png')
 
         # And the second one, check addresses on both browsers
         self.add_machine (b, m3.address, True)


### PR DESCRIPTION
When closing a host connection because it was removed from the dashboard
(i. e. "visible" set to false), we expect an (orderly) disconnect. Don't
set it to state "failed" and set a problem, just clear the state. This
fixes showing the machine as failed when re-adding it.

https://bugzilla.redhat.com/show_bug.cgi?id=1420242