### PR TITLE
base: Remove correct event listener

### DIFF
--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -3251,7 +3251,7 @@ function factory() {
             close_perform(options);
         }
 
-        channel.addEventListener("control", on_ready);
+        channel.addEventListener("ready", on_ready);
         channel.addEventListener("message", on_message);
         channel.addEventListener("close", on_close);
 


### PR DESCRIPTION
The cleanup function needs to use the same name for the
listener as the function that adds it.

Original commit: https://github.com/cockpit-project/cockpit/commit/3612172f83f436e311d5981d9e3202f13b0ae540