### PR TITLE
build: Build cockpit-kubernetes on more architectures

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -237,6 +237,8 @@ echo '%dir %{_datadir}/%{name}/kubernetes' > kubernetes.list
 find %{buildroot}%{_datadir}/%{name}/kubernetes -type f >> kubernetes.list
 %else
 rm -rf %{buildroot}/%{_datadir}/%{name}/kubernetes
+rm -f %{buildroot}/%{_libexecdir}/cockpit-kube-auth
+rm -f %{buildroot}/%{_libexecdir}/cockpit-kube-launch
 rm %{buildroot}/%{_libexecdir}/cockpit-stub
 touch kubernetes.list
 %endif

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -228,7 +228,7 @@ rm -rf %{buildroot}/%{_datadir}/%{name}/docker
 touch docker.list
 %endif
 
-%ifarch x86_64 ppc64le
+%ifarch aarch64 x86_64 ppc64le s390x
 %if %{defined wip}
 %else
 rm %{buildroot}/%{_datadir}/%{name}/kubernetes/override.json
@@ -579,7 +579,7 @@ This package is not yet complete.
 
 %endif
 
-%ifarch x86_64 ppc64le
+%ifarch aarch64 x86_64 ppc64le s390x
 
 %package kubernetes
 Summary: Cockpit user interface for Kubernetes cluster


### PR DESCRIPTION
Also clean up the build files properly if we don't want the package.