### PR TITLE
build: Simplify dependencies

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -93,14 +93,6 @@ Suggests: %{name}-pcp = %{version}-%{release}
 Suggests: %{name}-kubernetes = %{version}-%{release}
 Suggests: %{name}-selinux = %{version}-%{release}
 
-# Older releases need to have strict requirements
-%else
-Requires: %{name}-networkmanager = %{version}-%{release}
-Requires: %{name}-storaged = %{version}-%{release}
-%ifarch x86_64 armv7hl
-Requires: %{name}-docker = %{version}-%{release}
-%endif
-
 %endif
 
 %description

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -79,13 +79,11 @@ BuildRequires: xmlto
 
 Requires: %{name}-bridge = %{version}-%{release}
 Requires: %{name}-ws = %{version}-%{release}
-%if %{defined build_dashboard}
-Requires: %{name}-dashboard = %{version}-%{release}
-%endif
 Requires: %{name}-system = %{version}-%{release}
 
 # Optional components (for f24 we use soft deps)
 %if 0%{?fedora} >= 24 || 0%{?rhel} >= 8
+Recommends: %{name}-dashboard = %{version}-%{release}
 Recommends: %{name}-networkmanager = %{version}-%{release}
 Recommends: %{name}-storaged = %{version}-%{release}
 %ifarch x86_64 %{arm} aarch64 ppc64le


### PR DESCRIPTION
We don't want the cockpit meta package to have harder requirements than it should. Instead, if the packaging system supports it, use Recommends/Suggests.