### PR TITLE
test: Run and fix unittests with fatal-warnings

### DIFF
--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -23,7 +23,7 @@ basedebug_DATA = \
 	dist/base1/cockpit.min.js.map \
 	$(NULL)
 
-AM_TESTS_ENVIRONMENT = export G_DEBUG=fatal-criticals ;
+AM_TESTS_ENVIRONMENT = export G_DEBUG=fatal-criticals,fatal-warnings ;
 
 dist/base1/cockpit.min.css: src/base1/cockpit.css
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \

--- a/src/base1/test-dbus-common.js
+++ b/src/base1/test-dbus-common.js
@@ -1204,7 +1204,7 @@ function dbus_track_tests(channel_options, bus_name) {
                 channel.onclose = function (event, options) {
                     assert.equal(options.channel, channel.id);
                     assert.equal(options.command, 'close');
-                    assert.equal(options.problem, 'internal-error');
+                    assert.equal(options.problem, 'protocol-error');
                     QUnit.start();
                 };
             }).

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -260,7 +260,7 @@ start_dbus_daemon (void)
 
   if (address->str[0] == '\0')
     {
-      g_warning ("dbus-daemon didn't send us a dbus address");
+      g_message ("dbus-daemon didn't send us a dbus address; not installed?");
     }
   else
     {

--- a/src/bridge/cockpitpipechannel.c
+++ b/src/bridge/cockpitpipechannel.c
@@ -417,7 +417,7 @@ cockpit_pipe_channel_prepare (CockpitChannel *channel)
     }
   else if (internal && steal_internal_fd (internal, &fd))
     {
-      self->pipe = cockpit_pipe_new (internal, fd, fd);
+      self->pipe = cockpit_pipe_new_user_fd (internal, fd);
     }
   else
     {

--- a/src/bridge/test-bridge.c
+++ b/src/bridge/test-bridge.c
@@ -171,6 +171,10 @@ test_bridge_init_problem (gconstpointer user_data)
     NULL
   };
 
+  /* missing version will spawn an expected warning in subprocess */
+  if (fixture->version == 0)
+    cockpit_test_allow_warnings ();
+
   pipe = cockpit_pipe_spawn (argv, NULL, NULL, COCKPIT_PIPE_FLAGS_NONE);
   transport = cockpit_pipe_transport_new (pipe);
   g_object_unref (pipe);
@@ -192,6 +196,8 @@ test_bridge_init_problem (gconstpointer user_data)
 
   while (!closed)
     g_main_context_iteration (NULL, TRUE);
+
+  cockpit_test_reset_warnings ();
 
   g_signal_handlers_disconnect_by_func (transport, on_closed_set_flag, &closed);
 

--- a/src/common/cockpitpipe.h
+++ b/src/common/cockpitpipe.h
@@ -65,6 +65,9 @@ CockpitPipe *      cockpit_pipe_new          (const gchar *name,
                                               gint in_fd,
                                               gint out_fd);
 
+CockpitPipe *      cockpit_pipe_new_user_fd  (const gchar *name,
+                                              gint fd);
+
 CockpitPipe *      cockpit_pipe_spawn        (const gchar **argv,
                                               const gchar **env,
                                               const gchar *directory,

--- a/src/common/cockpittest.c
+++ b/src/common/cockpittest.c
@@ -220,6 +220,9 @@ cockpit_test_init (int *argc,
   g_assert (g_snprintf (path, sizeof (path), "%s:%s", BUILDDIR, g_getenv ("PATH")) < sizeof (path));
   g_setenv ("PATH", path, TRUE);
 
+  /* For our process (children are handled through $G_DEBUG) */
+  g_log_set_always_fatal (G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL | G_LOG_LEVEL_WARNING);
+
   g_type_init ();
 
   // System cockpit configuration file should not be loaded

--- a/src/common/cockpittest.c
+++ b/src/common/cockpittest.c
@@ -52,6 +52,7 @@
  */
 
 static gboolean cockpit_test_init_was_called = FALSE;
+static const gchar *orig_g_debug;
 
 /* In cockpitconf.c */
 extern const gchar *cockpit_config_file;
@@ -731,4 +732,23 @@ cockpit_test_find_non_loopback_address (void)
 
   freeifaddrs (ifas);
   return inet;
+}
+
+void
+cockpit_test_allow_warnings (void)
+{
+  /* make some noise if this gets called twice */
+  g_return_if_fail (orig_g_debug == NULL);
+  orig_g_debug = g_getenv ("G_DEBUG");
+  g_setenv ("G_DEBUG", "fatal-criticals", TRUE);
+}
+
+void
+cockpit_test_reset_warnings (void)
+{
+  if (orig_g_debug != NULL)
+    {
+      g_setenv ("G_DEBUG", orig_g_debug, TRUE);
+      orig_g_debug = NULL;
+    }
 }

--- a/src/common/cockpittest.h
+++ b/src/common/cockpittest.h
@@ -113,6 +113,9 @@ void            cockpit_test_signal_backtrace          (int sig);
 
 GInetAddress *  cockpit_test_find_non_loopback_address (void);
 
+void             cockpit_test_allow_warnings           (void);
+void             cockpit_test_reset_warnings           (void);
+
 G_END_DECLS
 
 #endif /* __COCKPIT_TEST_H__ */

--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -1153,7 +1153,7 @@ cockpit_ssh_connect (CockpitSshData *data,
       data->username = username_from_basic (data->initial_auth_data);
     }
 
-  if (!data->username)
+  if (!data->username || *data->username == '\0')
     {
       g_message ("%s: No username provided", data->logname);
       problem = "authentication-failed";

--- a/src/ws/test-authssh.c
+++ b/src/ws/test-authssh.c
@@ -241,7 +241,7 @@ test_basic_fail (TestCase *test,
   g_assert_null (cockpit_auth_login_finish (test->auth, result, NULL, headers, &error));
   g_object_unref (result);
   g_assert_error (error, COCKPIT_ERROR, COCKPIT_ERROR_AUTHENTICATION_FAILED);
-  g_assert_cmpstr ("Authentication failed", ==, error->message);
+  g_assert (g_str_has_prefix (error->message, "Authentication failed"));
 
   g_clear_error (&error);
   g_hash_table_unref (headers);


### PR DESCRIPTION
This is a series of changes to run our unit tests with fatal warnings. Please see individual commit logs for details, I kept unrelated changes separate.