### PR TITLE
ssh: Prefer creating temporary known hosts files in /tmp

### DIFF
--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -259,8 +259,8 @@ static gchar *
 create_knownhosts_temp (void)
 {
   const gchar *directories[] = {
-      PACKAGE_LOCALSTATE_DIR,
       "/tmp",
+      PACKAGE_LOCALSTATE_DIR,
       NULL,
   };
 


### PR DESCRIPTION
This is a more appropriate place as it gets automatically cleaned up,
and avoids building clutter in /var/lib/cockpit/ if cockpit-ssh exits
abnormally. Also, the referenced SELinux policy issue was marked as
fixed long ago. Still keep /var/lib/cockpit/ as a fallback path though,
just in case.

----

This was a small part of PR #6132, but as that is a dead end (at least for now), let's land it by itself.