### PR TITLE
test: Fix docker storage test on atomic

### DIFF
--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -20,6 +20,7 @@
 
 import parent
 from testlib import *
+from common.vmmanage import get_build_image
 
 # The Docker Storage Setup behaves differently depending on
 # whether the "atomic" utility is recent enough, on whether or not
@@ -84,7 +85,7 @@ class TestDockerStorage(MachineCase):
             b.wait_present("#containers-storage-details a")
 
     def testDevmapper(self, vg=""):
-        b = self.browser
+        m = self.machine
 
         # On the Atomics, we use two machines: one for running
         # cockpit-ws, and one whose docker storage pool is managed.
@@ -92,11 +93,17 @@ class TestDockerStorage(MachineCase):
         # the pool would kill the cockpit-ws container.
 
         if self.machine.atomic_image:
-            m = self.new_machine(machine_key='additional')
-            m.start()
-            m.wait_boot()
+            # We want to use a non-Atomic machine as the login machine
+            # and the build machine that matches the current Atomic is suitable
+            # since we can use the same set of built packages
+            login_machine = self.new_machine(machine_key='login',
+                                             image=get_build_image(self.machine.image))
+            login_machine.start()
+            login_machine.wait_boot()
+            b = self.new_browser(login_machine.address)
         else:
-            m = self.machine
+            login_machine = self.machine
+            b = self.browser
 
         if can_manage(m, vg):
             # Allow docker-storage-setup to be happy with our very small disks
@@ -114,10 +121,11 @@ class TestDockerStorage(MachineCase):
 
         check_loopback(initially_loopbacked(m))
 
-        if m == self.machine:
+        if login_machine == self.machine:
             self.login_and_go("/docker#/storage")
         else:
-            self.login_and_go(None)
+            login_machine.start_cockpit()
+            b.login_and_go(None)
 
             # XXX - This should be simpler.
             #

--- a/test/verify/testsuite-prepare
+++ b/test/verify/testsuite-prepare
@@ -39,17 +39,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     test_os = args.image
-    build_os = test_os
-
-    # The Atomic variants can't build their own packages, so we build in
-    # their non-Atomic siblings.  For example, fedora-atomic is build
-    # in fedora-25
-    if test_os == "fedora-atomic":
-        build_os = "fedora-25"
-    elif test_os == "rhel-atomic":
-        build_os = "rhel-7"
-    elif test_os == "continuous-atomic":
-        build_os = "centos-7"
+    build_os = vmmanage.get_build_image(test_os)
 
     os.system(os.path.join(testinfra.TEST_DIR,"vm-reset"))
     try:


### PR DESCRIPTION
Use the build image as the second machine for
testing docker storage rather than a second atomic
image.

This is because atomic no longer has cockpit-ssh

This squashes three commits from master:

7fd5e0229f1bb068a8178e4673554d901530f672
cc2eaa741e3ffa6b13a135389d8973f883686df2
c499f7f6286f7c72fc2cce6cf2b0a21d4df7d1db

Signed-off-by: petervo <petervo@redhat.com>
Signed-off-by: Marius Vollmer <mvollmer@redhat.com>