### PR TITLE
test: Ignore racy log message in check-multi-machine-key

### DIFF
--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -230,6 +230,7 @@ class TestMultiMachineKeyAuth(MachineCase):
                                     ".*: bridge program failed: Child process exited with code .*",
                                     # Since there is not password,
                                     # reauthorize doesn't work on m2
+                                    "received authorize command for wrong user: user",
                                     ".*: user admin reauthorization failed",
                                     "Error executing command as another user: Not authorized",
                                     "This incident has been reported.",


### PR DESCRIPTION
This test has multiple machines with different users. So it's
to be expected we receive an authorize command for another user.