### PR TITLE
machines: Boot order, cpu type and emulated machine

### DIFF
--- a/pkg/machines/actions.es6
+++ b/pkg/machines/actions.es6
@@ -109,7 +109,7 @@ export function setRefreshInterval(refreshInterval) {
 }
 
 export function updateOrAddVm({ id, name, connectionName, state, osType, fqdn, uptime, currentMemory, rssMemory, vcpus, autostart,
-    actualTimeInMs, cpuTime, disks }) {
+    actualTimeInMs, cpuTime, disks, emulatedMachine, cpuModel, bootOrder }) {
     let vm = {};
 
     if (id !== undefined) vm.id = id;
@@ -124,6 +124,9 @@ export function updateOrAddVm({ id, name, connectionName, state, osType, fqdn, u
     if (uptime !== undefined) vm.uptime = uptime;
     if (autostart !== undefined) vm.autostart = autostart;
     if (disks !== undefined) vm.disks = disks;
+    if (emulatedMachine !== undefined) vm.emulatedMachine = emulatedMachine;
+    if (cpuModel !== undefined) vm.cpuModel = cpuModel;
+    if (bootOrder !== undefined) vm.bootOrder = bootOrder;
 
     if (actualTimeInMs !== undefined) vm.actualTimeInMs = actualTimeInMs;
     if (cpuTime !== undefined) vm.cpuTime = cpuTime;

--- a/pkg/machines/helpers.es6
+++ b/pkg/machines/helpers.es6
@@ -100,15 +100,25 @@ const transform = {
         'session': _("Session"),
     },
     'vmStates': {
-        running: _("running"),
-        idle: _("idle"),
-        paused: _("paused"),
-        shutdown: _("shutdown"),
+        'running': _("running"),
+        'idle': _("idle"),
+        'paused': _("paused"),
+        'shutdown': _("shutdown"),
         'shut off': _("shut off"),
-        crashed: _("crashed"),
-        dying: _("dying"),
-        pmsuspended: _("suspended (PM)"),
-    }
+        'crashed': _("crashed"),
+        'dying': _("dying"),
+        'pmsuspended': _("suspended (PM)"),
+    },
+    'bootableDisk': {
+        'disk': _("disk"),
+        'cdrom': _("cdrom"),
+        'interface': _("network"),
+        'hd': _("disk"),
+    },
+    'cpuMode': {
+        'custom': _("custom"),
+        'host-model': _("host"),
+    },
 };
 
 export function rephraseUI(key, original) {

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -115,7 +115,7 @@ IconElement.propTypes = {
     state: PropTypes.string.isRequired,
 }
 
-export const StateIcon = ({ state, config }) => {
+export const StateIcon = ({ state, config, valueId }) => {
     if (state === undefined) {
         return (<div/>);
     }
@@ -138,7 +138,9 @@ export const StateIcon = ({ state, config }) => {
     if (stateMap[state]) {
         return (
             <span title={stateMap[state].title} data-toggle='tooltip' data-placement='left'>
-                {rephraseUI('vmStates', state)}&nbsp;<i className={stateMap[state].className} />
+                <span id={valueId}>{rephraseUI('vmStates', state)}</span>
+                &nbsp;
+                <i className={stateMap[state].className} />
             </span>);
     }
     return (<small>{state}</small>);
@@ -213,17 +215,14 @@ const VmLastMessage = ({ vm }) => {
 
     const msgId = `${vmId(vm.name)}-last-message`;
     const detail = (vm.lastMessageDetail && vm.lastMessageDetail.exception) ? vm.lastMessageDetail.exception: vm.lastMessage;
+
     return (
-        <tr>
-            <td>
-                <span className='pficon-warning-triangle-o' />
-            </td>
-            <td>
-                <div title={detail} data-toggle='tooltip' id={msgId}>
-                    {vm.lastMessage}
-                </div>
-            </td>
-        </tr>
+        <div>
+            <span className='pficon-warning-triangle-o' />&nbsp;
+            <span title={detail} data-toggle='tooltip' id={msgId}>
+                {vm.lastMessage}
+            </span>
+        </div>
     );
 };
 VmLastMessage.propTypes = {
@@ -255,11 +254,9 @@ const VmOverviewTab = ({ vm, config }) => {
             <tr className='machines-listing-ct-body-detail'>
                 <td className='machines-listing-detail-top-column'>
                     <table className='form-table-ct'>
-                        <VmOverviewTabRecord id={`${vmId(vm.name)}-state`} descr={_("State:")} value={vm.state}/>
                         <VmOverviewTabRecord descr={_("Memory:")}
                                              value={cockpit.format_bytes((vm.currentMemory ? vm.currentMemory : 0) * 1024)}/>
                         <VmOverviewTabRecord id={`${vmId(vm.name)}-vcpus`} descr={_("vCPUs:")} value={vm.vcpus}/>
-                        <VmLastMessage vm={vm} />
                     </table>
                 </td>
 
@@ -269,15 +266,21 @@ const VmOverviewTab = ({ vm, config }) => {
                                              descr={_("Emulated Machine:")} value={vm.emulatedMachine}/>
                         <VmOverviewTabRecord id={`${vmId(vm.name)}-cputype`}
                                              descr={_("CPU Type:")} value={vm.cpuModel}/>
+                    </table>
+                </td>
+
+                <td className='machines-listing-detail-top-column'>
+                    <table className='form-table-ct'>
+                        <VmBootOrder vm={vm} />
                         <VmOverviewTabRecord id={`${vmId(vm.name)}-autostart`}
                                              descr={_("Autostart:")} value={rephraseUI('autostart', vm.autostart)}/>
-                        <VmBootOrder vm={vm} />
                     </table>
                 </td>
 
                 {providerContent}
             </tr>
         </table>
+        <VmLastMessage vm={vm} />
     </div>);
 };
 VmOverviewTab.propTypes = {
@@ -354,7 +357,7 @@ VmUsageTab.propTypes = {
 /** One VM in the list (a row)
  */
 const Vm = ({ vm, config, onStart, onShutdown, onForceoff, onReboot, onForceReboot, dispatch }) => {
-    const stateIcon = (<StateIcon state={vm.state} config={config}/>);
+    const stateIcon = (<StateIcon state={vm.state} config={config} valueId={`${vmId(vm.name)}-state`} />);
 
     let tabRenderers = [
         {name: _("Overview"), renderer: VmOverviewTab, data: {vm: vm, config: config }},

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -82,7 +82,7 @@ const VmActions = ({ vm, config, dispatch, onStart, onReboot, onForceReboot, onS
     let providerActions = null;
     if (config.provider.vmActionsFactory) {
         const ProviderActions = config.provider.vmActionsFactory();
-        providerActions = (<ProviderActions vm={vm} providerState={config.providerState} dispatch={dispatch} />);
+        providerActions = <ProviderActions vm={vm} providerState={config.providerState} dispatch={dispatch} />;
     }
 
     return (<div>
@@ -243,7 +243,13 @@ VmBootOrder.propTypes = {
     vm: PropTypes.object.isRequired
 };
 
-const VmOverviewTab = ({ vm }) => {
+const VmOverviewTab = ({ vm, config }) => {
+    let providerContent = null;
+    if (config.provider.vmOverviewPropsFactory) {
+        const ProviderContent = config.provider.vmOverviewPropsFactory();
+        providerContent = (<ProviderContent vm={vm} providerState={config.providerState}/>);
+    }
+
     return (<div>
         <table className='machines-width-max'>
             <tr className='machines-listing-ct-body-detail'>
@@ -259,18 +265,24 @@ const VmOverviewTab = ({ vm }) => {
 
                 <td className='machines-listing-detail-top-column'>
                     <table className='form-table-ct'>
-                        <VmOverviewTabRecord descr={_("Emulated Machine:")} value={vm.emulatedMachine}/>
-                        <VmOverviewTabRecord descr={_("CPU Type:")} value={vm.cpuModel}/>
-                        <VmOverviewTabRecord descr={_("Autostart:")} value={rephraseUI('autostart', vm.autostart)}/>
+                        <VmOverviewTabRecord id={`${vmId(vm.name)}-emulatedmachine`}
+                                             descr={_("Emulated Machine:")} value={vm.emulatedMachine}/>
+                        <VmOverviewTabRecord id={`${vmId(vm.name)}-cputype`}
+                                             descr={_("CPU Type:")} value={vm.cpuModel}/>
+                        <VmOverviewTabRecord id={`${vmId(vm.name)}-autostart`}
+                                             descr={_("Autostart:")} value={rephraseUI('autostart', vm.autostart)}/>
                         <VmBootOrder vm={vm} />
                     </table>
                 </td>
+
+                {providerContent}
             </tr>
         </table>
     </div>);
 };
 VmOverviewTab.propTypes = {
-    vm: PropTypes.object.isRequired
+    vm: PropTypes.object.isRequired,
+    config: PropTypes.object.isRequired,
 }
 
 const VmUsageTab = ({ vm }) => {
@@ -345,7 +357,7 @@ const Vm = ({ vm, config, onStart, onShutdown, onForceoff, onReboot, onForceRebo
     const stateIcon = (<StateIcon state={vm.state} config={config}/>);
 
     let tabRenderers = [
-        {name: _("Overview"), renderer: VmOverviewTab, data: {vm: vm}},
+        {name: _("Overview"), renderer: VmOverviewTab, data: {vm: vm, config: config }},
         {name: _("Usage"), renderer: VmUsageTab, data: {vm: vm}, presence: 'onlyActive' },
         {name: (<div id={`${vmId(vm.name)}-disks`}>{_("Disks")}</div>), renderer: VmDisksTab, data: {vm: vm, provider: config.provider}, presence: 'onlyActive' }
     ];

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -191,7 +191,7 @@ VmOverviewTabRecord.propTypes = {
 
 const VmLastMessage = ({ vm }) => {
     if (!vm.lastMessage) {
-        return null;
+        return (<tr />); // reserve space to keep rendered structure
     }
 
     const msgId = `${vmId(vm.name)}-last-message`;
@@ -213,11 +213,24 @@ VmLastMessage.propTypes = {
     vm: PropTypes.object.isRequired
 }
 
+const VmBootOrder = ({ vm }) => {
+    let bootOrder = _("No boot device found");
+
+    if (vm.bootOrder && vm.bootOrder.devices && vm.bootOrder.devices.length > 0) {
+        bootOrder = vm.bootOrder.devices.map(bootDevice => bootDevice.type).join(); // Example: network,disk,disk
+    }
+
+    return (<VmOverviewTabRecord id={`${vmId(vm.name)}-bootorder`} descr={_("Boot Order:")} value={bootOrder}/>);
+};
+VmBootOrder.propTypes = {
+    vm: PropTypes.object.isRequired
+};
+
 const VmOverviewTab = ({ vm }) => {
     return (<div>
         <table className='machines-width-max'>
             <tr className='machines-listing-ct-body-detail'>
-                <td>
+                <td className='machines-listing-detail-top-column'>
                     <table className='form-table-ct'>
                         <VmOverviewTabRecord id={`${vmId(vm.name)}-state`} descr={_("State:")} value={vm.state}/>
                         <VmOverviewTabRecord descr={_("Memory:")}
@@ -227,11 +240,12 @@ const VmOverviewTab = ({ vm }) => {
                     </table>
                 </td>
 
-                <td>
+                <td className='machines-listing-detail-top-column'>
                     <table className='form-table-ct'>
-                        <VmOverviewTabRecord descr={_("ID:")} value={vm.id}/>
-                        <VmOverviewTabRecord descr={_("OS Type:")} value={vm.osType}/>
+                        <VmOverviewTabRecord descr={_("Emulated Machine:")} value={vm.emulatedMachine}/>
+                        <VmOverviewTabRecord descr={_("CPU Type:")} value={vm.cpuModel}/>
                         <VmOverviewTabRecord descr={_("Autostart:")} value={rephraseUI('autostart', vm.autostart)}/>
+                        <VmBootOrder vm={vm} />
                     </table>
                 </td>
             </tr>

--- a/pkg/machines/machines.less
+++ b/pkg/machines/machines.less
@@ -50,3 +50,7 @@
 .machines-disks-total-value {
     font-weight: bold;
 }
+
+.machines-listing-detail-top-column {
+    vertical-align: top;
+}

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -63,6 +63,7 @@ class TestMachines(MachineCase):
         m.execute("qemu-img create -f qcow2 {0} 2G".format(self.vm1_img2))
         m.execute("virt-install --cpu host -r 128 --pxe --force --nographics --noautoconsole "
                   "--disk path={0},size=1,format=qcow2 --disk path={1},size=2,format=qcow2 "
+                  "--boot hd,network "
                   "-n {2} || true"
                   .format(self.vm1_img, self.vm1_img2, self.vm1_name))
 
@@ -87,6 +88,12 @@ class TestMachines(MachineCase):
         b.wait_in_text("{0}-state".format(self.vm1_id), state) # running or paused
         b.wait_present("{0}-vcpus".format(self.vm1_id))
         b.wait_in_text("{0}-vcpus".format(self.vm1_id), "1")
+
+        b.wait_in_text("{0}-bootorder".format(self.vm1_id), "disk,network")
+        cpu_type = b.eval_js("$('{0}-cputype').text()".format(self.vm1_id))
+        self.assertTrue(cpu_type == 'host' or cpu_type.startswith('custom')) # should be "host" due to "--cpu host", but debian-8 keeps claiming "custom"
+        emulated_machine = b.eval_js("$('{0}-emulatedmachine').text()".format(self.vm1_id))
+        self.assertTrue(len(emulated_machine) > 0) # emulated machine varies across test machines
 
         if state == "running":
             b.click("{0}-off-caret".format(self.vm1_id))

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -210,6 +210,7 @@ class TestMachines(MachineCase):
         b.wait_in_text("{0}-state".format(self.providerVm1_id), "running")
 
         b.wait_present("#test-vm-action-{0}".format(self.providerVm1_name)) # is provider-specific action button rendered?
+        b.wait_in_text("#test-vm-props-{0}".format(self.providerVm1_name), "Test Provider Property") # are provider-specific VM props rendered?
 
         b.click("{0}-off".format(self.providerVm1_id)) # click the Shut Down button
         b.wait_in_text("{0}-state".format(self.providerVm1_id), "shut off")

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -221,7 +221,7 @@ class TestMachines(MachineCase):
 
         b.click("{0}-run".format(self.providerVm1_id)) # click the Run button which intentionally leads to an error, so check it
         b.click("a:contains('Overview')") # where the error message is rendered
-        b.wait_visible("{0}-state".format(self.providerVm1_id))
+        b.wait_visible("{0}-vcpus".format(self.providerVm1_id)) # wait till the tab is fully rendered
         b.wait_present("{0}-last-message".format(self.providerVm1_id))
         b.wait_in_text("{0}-last-message".format(self.providerVm1_id), "VM failed to start")
 

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -209,6 +209,8 @@ class TestMachines(MachineCase):
         b.wait_present("{0}-state".format(self.providerVm1_id))
         b.wait_in_text("{0}-state".format(self.providerVm1_id), "running")
 
+        b.wait_present("#test-vm-action-{0}".format(self.providerVm1_name)) # is provider-specific action button rendered?
+
         b.click("{0}-off".format(self.providerVm1_id)) # click the Shut Down button
         b.wait_in_text("{0}-state".format(self.providerVm1_id), "shut off")
 

--- a/test/verify/files/cockpitMachinesTestExternalProvider.js
+++ b/test/verify/files/cockpitMachinesTestExternalProvider.js
@@ -48,6 +48,7 @@
    */
   var TestSubtabReactComponent = null;
   var VmActionsComponent = null;
+  var VmOverviewPropsComponent = null;
 
   var PROVIDER = {};
   PROVIDER = {
@@ -274,11 +275,19 @@
     },
 
     /**
+     * Extend the Overview tab for provider-specific properties
+     *
+     */
+    vmOverviewPropsFactory: function () {
+      return VmOverviewPropsComponent;
+    },
+
+    /**
      * Optional array of
      * {
-   *  name: 'My Tab Title',
-   *  componentFactory: () => yourReactComponentRenderingSubtabBody
-   *  }
+     *  name: 'My Tab Title',
+     *  componentFactory: () => yourReactComponentRenderingSubtabBody
+     *  }
      *
      * Please note, the React components have to be created lazily via `providerContext.React` passed to the init() function.
      */
@@ -351,8 +360,22 @@
             return React.createElement('div', {className: 'btn-group'},
                 React.createElement('button', {id: 'test-vm-action-' + vm.name, className: 'btn btn-default'}, 'Provider Action')
             );
+          }
+        }
+    );
 
-            // return React.createElement('button', {id: 'test-vm-action-' + vm.name}, 'Provider Action');
+    VmOverviewPropsComponent = React.createClass(
+        {
+          propTypes: {
+            vm: React.PropTypes.object.isRequired,
+            providerState: React.PropTypes.object.isRequired,
+          },
+          render: function () {
+            var vm = this.props.vm;
+
+            return React.createElement('td', null,
+                React.createElement('div', {id: 'test-vm-props-' + vm.name}, 'Test Provider Property')
+            );
           }
         }
     );

--- a/test/verify/files/cockpitMachinesTestExternalProvider.js
+++ b/test/verify/files/cockpitMachinesTestExternalProvider.js
@@ -47,6 +47,7 @@
    * For simple UI extensions, JQuery can be used as well but please do not update React-rendered DOM via JQuery.
    */
   var TestSubtabReactComponent = null;
+  var VmActionsComponent = null;
 
   var PROVIDER = {};
   PROVIDER = {
@@ -264,6 +265,15 @@
     reducer: undefined, // optional reference to reducer function extending the application Redux state tree, see cockpit-machines-ovirt-provider for more detailed example
 
     /**
+     * Extend list of VM actions (along Shut Down or Run buttons) for provider's specific ones.
+     *
+     * Factory method returning a React component.
+     */
+    vmActionsFactory: function () {
+      return VmActionsComponent; // React is lazily initialized, see the init() function
+    },
+
+    /**
      * Optional array of
      * {
    *  name: 'My Tab Title',
@@ -325,6 +335,24 @@
           render: function () {
             var vm = this.props.vm;
             return React.createElement('div', {id: 'test-subtab-body-' + vm.name}, 'Content of subtab');
+          }
+        }
+    );
+
+    VmActionsComponent = React.createClass(
+        {
+          propTypes: {
+            vm: React.PropTypes.object.isRequired,
+            providerState: React.PropTypes.object.isRequired,
+          },
+          render: function () {
+            var vm = this.props.vm;
+
+            return React.createElement('div', {className: 'btn-group'},
+                React.createElement('button', {id: 'test-vm-action-' + vm.name, className: 'btn btn-default'}, 'Provider Action')
+            );
+
+            // return React.createElement('button', {id: 'test-vm-action-' + vm.name}, 'Provider Action');
           }
         }
     );


### PR DESCRIPTION
The VM Overview tab newly renders:

- CPU Type (like 'Conroe' or 'Haswell')
- Emulated Machine (like 'pc-i440fx-rhel7.3.0')
- Boot Order - (like 'cdrom,disk,network')
    
Following properties are removed from rendering:

- VM ID
- OS Type (Libvirt's support is limitted, so useless)
- Status (duplicated with listing row status icon)

In addition to this change, an external provider can enrich

- the action list for provider-specific buttons (along recent 'Shut down' or 'Run')
- VM properties displayed on the Overview subtab

![reviewedvmprops](https://cloud.githubusercontent.com/assets/17194943/24204856/05f5db12-0f1a-11e7-97b6-f787036978a1.png)
