### PR TITLE
build: Simplify selinux package dependencies

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -542,7 +542,9 @@ The Cockpit component for managing networking.  This package uses NetworkManager
 Summary: Cockpit SELinux package
 Requires: %{name}-bridge >= %{required_base}
 Requires: %{name}-shell >= %{required_base}
-Requires: setroubleshoot-server >= 3.3.3
+%if 0%{?fedora} >= 24 || 0%{?rhel} >= 8
+Recommends: setroubleshoot-server >= 3.3.3
+%endif
 BuildArch: noarch
 
 %description selinux

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -397,8 +397,9 @@ Requires: NetworkManager
 Provides: %{name}-kdump = %{version}-%{release}
 Requires: kexec-tools
 # Optional components (only when soft deps are supported)
-%if 0%{?fedora} >= 24 || 0%{?rhel} >= 8
+%if 0%{?rhel} >= 8
 Recommends: NetworkManager-team
+Recommends: setroubleshoot-server >= 3.3.3
 %endif
 Provides: %{name}-selinux = %{version}-%{release}
 Provides: %{name}-sosreport = %{version}-%{release}


### PR DESCRIPTION
This doesn't affect rhel-7 based systems since these don't support
weak dependencies.

I also removed the `0%{?fedora} >= 24` condition since the target line is already within a `rhel` block.