### PR TITLE
configure: Enable more fatal warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -325,7 +325,8 @@ if test "x$GCC" = "xyes"; then
           -Werror=strict-prototypes -Werror=missing-prototypes \
           -Werror=implicit-function-declaration \
           -Werror=pointer-arith -Werror=init-self \
-          -Werror=format-security \
+          -Werror=format=2 \
+          -Werror=return-type \
           -Werror=missing-include-dirs $CFLAGS"
 fi
 changequote([,])dnl

--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -151,7 +151,7 @@ check_int_type (JsonNode *node,
   if (value < min || value > max)
     {
       g_set_error(error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
-                  "Number '%li' is not in range for the expected type '%.*s'", value,
+                  "Number '%" G_GINT64_FORMAT "' is not in range for the expected type '%.*s'", value,
                   (int) g_variant_type_get_string_length (type),
                   g_variant_type_peek_string (type));
       return FALSE;

--- a/src/bridge/test-httpstream.c
+++ b/src/bridge/test-httpstream.c
@@ -791,7 +791,6 @@ test_tls_authority_bad (TestTls *test,
   JsonObject *resp;
   gchar *expected_pem = NULL;
   gchar *expected_json = NULL;
-  const gchar *expected_fmt;
 
   g_object_get (test->certificate, "certificate-pem", &expected_pem, NULL);
   g_assert_true (expected_pem != NULL);
@@ -832,8 +831,8 @@ test_tls_authority_bad (TestTls *test,
   cockpit_assert_json_eq (resp, "{\"command\":\"ready\",\"channel\":\"444\"}");
 
   resp = mock_transport_pop_control (test->transport);
-  expected_fmt = "{\"command\":\"close\",\"channel\":\"444\",\"problem\":\"unknown-hostkey\", \"rejected-certificate\":\"%s\"}";
-  expected_json = g_strdup_printf (expected_fmt, expected_pem);
+  expected_json = g_strdup_printf ("{\"command\":\"close\",\"channel\":\"444\",\"problem\":\"unknown-hostkey\", "
+                                   " \"rejected-certificate\":\"%s\"}", expected_pem);
   cockpit_assert_json_eq (resp, expected_json);
 
   g_object_add_weak_pointer (G_OBJECT (channel), (gpointer *)&channel);

--- a/src/bridge/test-websocketstream.c
+++ b/src/bridge/test-websocketstream.c
@@ -320,7 +320,6 @@ test_tls_authority_bad (TestTls *test,
   JsonObject *resp;
   gchar *expected_pem = NULL;
   gchar *expected_json = NULL;
-  const gchar *expected_fmt;
 
   g_object_get (test->certificate, "certificate-pem", &expected_pem, NULL);
   g_assert_true (expected_pem != NULL);
@@ -349,8 +348,8 @@ test_tls_authority_bad (TestTls *test,
     g_main_context_iteration (NULL, TRUE);
 
   resp = mock_transport_pop_control (test->transport);
-  expected_fmt = "{\"command\":\"close\",\"channel\":\"444\",\"problem\":\"unknown-hostkey\", \"rejected-certificate\":\"%s\"}";
-  expected_json = g_strdup_printf (expected_fmt, expected_pem);
+  expected_json = g_strdup_printf ("{\"command\":\"close\",\"channel\":\"444\",\"problem\":\"unknown-hostkey\", "
+                                   " \"rejected-certificate\":\"%s\"}", expected_pem);
   cockpit_assert_json_eq (resp, expected_json);
 
   g_object_unref (channel);


### PR DESCRIPTION
Fail on -Wreturn-type and more format string errors (-Wformat=2 includes
-Wformat-security and a few others).

Change printf statements in two tests to be literals so that gcc can
check them.

Fix wrong printf macro in src/bridge/cockpitdbusjson.c.