### PR TITLE
machines: link updated in README

### DIFF
--- a/pkg/machines/README.md
+++ b/pkg/machines/README.md
@@ -84,4 +84,5 @@ External provider referential implementation is the `cockpit-machines-ovirt-prov
 
 ## Links
 \[1\] [How to enable nested virtualization in KVM](https://fedoraproject.org/wiki/How_to_enable_nested_virtualization_in_KVM)
-\[2\] [Cockpit-machines oVirt External Provider](https://github.com/mareklibra/cockpit-machines-ovirt-provider)
+\[2\] [Cockpit-machines oVirt External Provider](https://github.com/oVirt/cockpit-machines-ovirt-provider)
+


### PR DESCRIPTION
The cockpit-machines-ovirt-provider project was moved under github.com/oVirt.
This patch updates link in the README file.