### PR TITLE
bridge: Handle ECONNRESET in cockpit-askpass

### DIFF
--- a/src/bridge/askpass.c
+++ b/src/bridge/askpass.c
@@ -56,6 +56,9 @@ read_control_message (int fd)
       res = read (fd, &ch, 1);
       if (res < 0)
         {
+          /* A disconnect when nothing has been read is a clean close */
+          if (errno == ECONNRESET && buffer->len == 0)
+            break;
           if (errno != EINTR || errno != EAGAIN)
             {
               g_message ("couldn't read askpass authorize message: %s", g_strerror (errno));


### PR DESCRIPTION
When we get ECONNRESET and nothing has been read yet, it's a clean
close resulting from resetting or shutting down Cockpit.