### PR TITLE
build: Make dashboard conflict with old versions

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -344,6 +344,9 @@ Cockpit support for reading PCP metrics and loading PCP archives.
 Summary: Cockpit SSH remoting and dashboard
 Requires: libssh >= %{libssh_version}
 Provides: %{name}-ssh
+# nothing depends on the dashboard, but we can't use it with older versions of the bridge
+Conflicts: %{name}-bridge < 135
+Conflicts: %{name}-ws < 135
 
 %description dashboard
 Cockpit support for remoting to other servers, bastion hosts, and a basic dashboard


### PR DESCRIPTION
This package shouldn't be compatible with old versions
of cockpit-bridge and -ws. We need to do this since otherwise
it won't get upgraded when cockpit-bridge updates.

Blocked on downstream testing:

- [x] rhel