### PR TITLE
Abrt support

### DIFF
--- a/pkg/lib/journal.js
+++ b/pkg/lib/journal.js
@@ -230,8 +230,10 @@
                 };
             if (count > 1)
                 parts['count'] = count;
-            if (ident === 'abrt-notification')
+            if (ident === 'abrt-notification') {
                 parts['problem'] = true;
+                parts['service'] = entry['PROBLEM_BINARY'];
+            }
             else if (prio < 4)
                 parts['warning'] = true;
             return Mustache.render(line_template, parts);

--- a/pkg/lib/journal.js
+++ b/pkg/lib/journal.js
@@ -230,7 +230,9 @@
                 };
             if (count > 1)
                 parts['count'] = count;
-            if (prio < 4)
+            if (ident === 'abrt-notification')
+                parts['problem'] = true;
+            else if (prio < 4)
                 parts['warning'] = true;
             return Mustache.render(line_template, parts);
         }

--- a/pkg/lib/journal_line.mustache
+++ b/pkg/lib/journal_line.mustache
@@ -1,7 +1,10 @@
 <div class="cockpit-logline" data-cursor="{{cursor}}">
   <div class="cockpit-log-warning">{{#warning}}
     <i class="fa fa-exclamation-triangle"></i>
-  {{/warning}}</div>
+  {{/warning}}{{#problem}}
+    <i class="fa fa-times-circle-o"></i>
+  {{/problem}}
+  </div>
   <div class="cockpit-log-time">{{time}}</div>
   <span class="cockpit-log-message">{{message}}</span>
   {{! if we have count (repeated messages), show service name and badge - otherwise just the service }}

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -294,8 +294,9 @@ a.disabled {
     top: 0;
 }
 
-.content-header-extra .btn-group:not(:first-child) {
-    padding-left: 20px;
+.content-header-extra .btn-group {
+    padding-left: 5px;
+    padding-right: 30px;
 }
 
 #motd {

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -222,6 +222,11 @@ a.disabled {
     word-break: break-all;
 }
 
+#journal-entry .info-table-ct td:first-child {
+    white-space: normal;
+    word-break: keep-all;
+}
+
 .service-unit-description {
     font-weight: bold;
 }
@@ -274,12 +279,58 @@ a.disabled {
     margin-top: 5em;
 }
 
-#journal-entry-message {
+#journal-entry-message:not(:empty) {
     margin: 10px;
 }
 
 #journal-entry-fields {
     margin-bottom: 10px;
+    width: 100%;
+}
+
+#journal-entry-fields th {
+    font-weight: normal;
+}
+
+#accordion-markup {
+    margin-bottom: 0px;
+}
+
+.nav-tabs-pf > li:first-child > a {
+    padding-left: 20px;
+}
+
+.nav li a {
+    font-size: 13px;
+}
+
+.panel-heading {
+    cursor: pointer;
+}
+
+.detail_table > tbody > tr > td, .detail_table > thead > tr > th {
+    padding-right: 10px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+}
+
+.problem-panel {
+    background: none !important;
+    height: auto;
+}
+
+.problem-panel:hover {
+    background: #EDEDED !important;
+    height: auto;
+}
+
+.other-threads-btn {
+    margin-top: 20px;
+}
+
+.other_threads {
+    clear: both;
 }
 
 /* Extra content header */

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -296,6 +296,13 @@ a.disabled {
     margin-bottom: 0px;
 }
 
+.problem-btn {
+    float: right;
+    padding: 0px 5px 0px 5px;
+    margin-right: 10px;
+    margin-top: 4px;
+}
+
 .nav-tabs-pf > li:first-child > a {
     padding-left: 20px;
 }

--- a/pkg/systemd/logs.html
+++ b/pkg/systemd/logs.html
@@ -44,11 +44,19 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
           <li><a data-op="last-week" translatable="yes">Last 7 days</a></li>
         </ul>
       </div>
-      <div id="journal-prio" class="btn-group">
-        <button class="btn btn-default" data-prio="3" translatable="yes">Errors</button>
-        <button class="btn btn-default" data-prio="4" translatable="yes">Warnings</button>
-        <button class="btn btn-default" data-prio="5" translatable="yes">Notices</button>
-        <button class="btn btn-default" data-prio="*" translatable="yes">All</button>
+      <span class="" translate>Severity</span>
+      <div class="btn-group" id="journal-prio-menu">
+        <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+          <span id="journal-prio"></span>
+          <span class="caret"></span>
+        </button>
+        <ul id="prio-lists" class="dropdown-menu" role="menu">
+          <li><a data-prio="*" translatable="yes">Everything</a></li>
+          <li><a data-prio="5" translatable="yes">Problems, Errors, Warnings, Notices</a></li>
+          <li><a data-prio="4" translatable="yes">Problems, Errors, Warnings</a></li>
+          <li><a data-prio="3" translatable="yes">Problems, Errors</a></li>
+          <li><a data-prio="2" translatable="yes">Only Problems</a></li>
+        </ul>
       </div>
     </div>
 

--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -28,6 +28,71 @@ $(function() {
     cockpit.translate();
     var _ = cockpit.gettext;
 
+    var problems_client = cockpit.dbus('org.freedesktop.problems', { superuser: "try" });
+    var service = problems_client.proxy('org.freedesktop.Problems2', '/org/freedesktop/Problems2');
+    var problems = problems_client.proxies('org.freedesktop.Problems2.Entry', '/org/freedesktop/Problems2/Entry');
+
+    // A map of ABRT's problems items and it's callback for rendering
+    var problem_render_callbacks = {'core_backtrace': render_backtrace,
+                                    'os_info': render_table_eq,
+                                    'environ': render_table_eq,
+                                    'limits': render_limits,
+                                    'cgroup': render_cgroup,
+                                    'namespaces': render_table_co,
+                                    'maps': render_maps,
+                                    'dso_list': render_dso_list,
+                                    'mountinfo': render_mountinfo,
+                                    'proc_pid_status': render_table_co,
+                                    'open_fds': render_open_fds,
+                                    'var_log_messages': render_multiline,
+                                    'not-reportable': render_multiline,
+                                    'exploitable': render_multiline,
+                                    'suspend_stats': render_table_co,
+                                    'dmesg': render_multiline,
+                                    'container_rootfs': render_multiline,
+                                    'docker_inspect': render_multiline
+                                    };
+
+    var problem_info_1 = ['reason', 'cmdline', 'executable', 'package', 'component',
+                          'crash_function', 'pid', 'pwd', 'hostname', 'count',
+                          'type', 'analyzer', 'rootdir', 'duphash', 'exception_type',
+                          'container', 'container_uuid', 'container_cmdline',
+                          'container_id', 'container_image' ];
+
+    var problem_info_2 = ['Directory', 'username', 'abrt_version', 'architecture', 'global_pid', 'kernel',
+                          'last_occurrence', 'os_release', 'pkg_fingerprint', 'pkg_vendor',
+                          'runlevel', 'tid', 'time', 'uid', 'uuid'];
+
+    var displayable_problems = {};
+
+    //Get list of all problems that can be displayed
+    var find_problems = function () {
+        var r = $.Deferred();
+        problems.wait(function() {
+            try {
+                service.GetProblems(0, {})
+                    .done(function(problem_paths, options) {
+                        update_problems(problem_paths);
+                        r.resolve();
+                    });
+            }
+            catch(err) {
+                //ABRT is not installed. Suggest installing?
+                r.resolve();
+            }
+        });
+        return r;
+    };
+
+    function update_problems(problem_paths) {
+        for (var i in problem_paths) {
+            var p = problems[problem_paths[i]];
+            displayable_problems[p.ID] = {'count': p.Count, 'problem_path': p.path};
+            displayable_problems[p.UUID] = {'count': p.Count, 'problem_path': p.path};
+            displayable_problems[p.Duphash] = {'count': p.Count, 'problem_path': p.path};
+        }
+    }
+
     /* Not public API */
     function journalbox(outer, start, match, day_box) {
         var box = $('<div class="panel panel-default cockpit-log-panel">');
@@ -257,8 +322,6 @@ $(function() {
         out.empty();
 
         function show_entry(entry) {
-            $('#journal-entry-message').text(journal.printable(entry["MESSAGE"]));
-
             var d = new Date(entry["__REALTIME_TIMESTAMP"] / 1000);
             $('#journal-entry-date').text(d.toString());
 
@@ -269,18 +332,22 @@ $(function() {
                 id = entry["_SYSTEMD_UNIT"];
             else
                 id = _("Journal entry");
+
+            var is_problem = false;
+            if (id === 'abrt-notification'){
+                is_problem = true;
+                id = entry['PROBLEM_BINARY'];
+            }
+
             $('#journal-entry-id').text(id);
 
-            var keys = Object.keys(entry).sort();
-            $.each(keys, function(i, key) {
-                if (key != "MESSAGE") {
-                    out.append(
-                        $('<tr>').append(
-                            $('<td>').css("text-align", "right").text(key),
-                            $('<td>').css("text-align", "left").
-                                text(journal.printable(entry[key]))));
-                }
-            });
+            if (is_problem) {
+                find_problems().done(function() {
+                    create_problem(out, entry);
+                });
+            } else {
+                create_entry(out, entry);
+            }
         }
 
         function show_error(error) {
@@ -300,6 +367,369 @@ $(function() {
             fail(function (error) {
                 show_error(error);
             });
+    }
+
+    function create_entry(out, entry){
+        $('#journal-entry-message').text(journal.printable(entry['MESSAGE']));
+        var keys = Object.keys(entry).sort();
+        $.each(keys, function (i, key) {
+            if (key !== 'MESSAGE') {
+                out.append(
+                    $('<tr>').append(
+                        $('<td>').css('text-align', 'right').text(key),
+                        $('<td>').css('text-align', 'left')
+                            .text(journal.printable(entry[key]))));
+            }
+        });
+    }
+
+    function create_problem(out, entry) {
+        var problem = null;
+        var all_p = [entry['PROBLEM_DIR'], entry['PROBLEM_DUPHASH'], entry['PROBLEM_UUID']];
+        for (var i = 0; i < all_p.length; i++) {
+            if (all_p[i] in displayable_problems) {
+                problem = problems[displayable_problems[all_p[i]]['problem_path']];
+                break;
+            }
+        }
+
+        //Display unknown problems as standard logs
+        //unknown problem = deleted problem | problem of different user
+        if (problem === null){
+            create_entry(out, entry);
+            return;
+        }
+
+        function switch_tab(new_tab, new_content) {
+            out.find('li').removeClass('active');
+            new_tab.addClass('active');
+            out.find('div').first().replaceWith(new_content);
+        }
+
+        $('#journal-entry-message').text('');
+
+        var ge_t = $('<li class="active">').append($('<a>').append($('<span translatable="yes">').text('General')));
+        var pi_t = $('<li>').append($('<a>').append($('<span translatable="yes">').text('Problem info')));
+        var pd_t = $('<li>').append($('<a>').append($('<span translatable="yes">').text('Problem details')));
+
+        var ge = $('<div>');
+        var pi = $('<div>');
+        var pd = $('<div class="panel-group" id="accordion-markup">');
+        var tab = $('<ul class="nav nav-tabs nav-tabs-pf">');
+
+        ge_t.click(function() {
+            switch_tab(ge_t, ge);
+        });
+
+        pi_t.click(function() {
+            switch_tab(pi_t, pi);
+        });
+
+        pd_t.click(function() {
+            switch_tab(pd_t, pd);
+        });
+
+        // write into general tab non-ABRT related items
+        var keys = Object.keys(entry).sort();
+        $.each(keys, function(i, key) {
+            if (key !== 'MESSAGE' && key.indexOf('PROBLEM_') !== 0) {
+                ge.append(
+                    $('<tr>').append(
+                        $('<td>').css('text-align', 'right').text(key),
+                        $('<td>').css('text-align', 'left').
+                            text(journal.printable(entry[key]))));
+            }
+        });
+
+        tab.html(ge_t);
+        tab.append(pi_t);
+        tab.append(pd_t);
+
+        var body = $('<th>');
+        body.append(tab);
+        body.append(ge);
+
+        out.html($('<tr>').append(body));
+        out.css("margin-bottom", "0px");
+
+        create_problem_details(problem, pi, pd);
+    }
+
+
+    function create_problem_details(problem, pi, pd) {
+        service.GetProblemData(problem.path).done(function(args, options) {
+            var i, elem, val;
+            // Render first column of problem info
+            var c1 = $('<table>').css('display', 'inline-block')
+                               .css('padding-right', '200px')
+                               .css('vertical-align', 'top');
+            pi.append(c1);
+            for (i = 0; i < problem_info_1.length; i++) {
+                elem = problem_info_1[i];
+                if (elem in args){
+                    val = args[elem][2];
+                    c1.append(
+                        $('<tr>').append(
+                            $('<td>').css('text-align', 'right').text(elem),
+                            $('<td>').css('text-align', 'left')
+                                .text(String(val))));
+                }
+            }
+
+            // Render second column of problem info
+            var c2 = $('<table>').css('display', 'inline-block')
+                               .css('vertical-align', 'top');
+            pi.append(c2);
+            for (i = 0; i < problem_info_2.length; i++) {
+                elem = problem_info_2[i];
+                if (elem in args){
+                    val = args[elem][2];
+                    // Display date properly
+                    if (['last_occurrence', 'time'].indexOf(elem) !== -1){
+                        var d = new Date(val / 1000);
+                        val = d.toString();
+                    }
+                    c2.append(
+                        $('<tr>').append(
+                            $('<td>').css('text-align', 'right').text(elem),
+                            $('<td>').css('text-align', 'left')
+                                .text(String(val))));
+                }
+            }
+
+            // Render problem details
+            var problem_details_elems = Object.keys(problem_render_callbacks);
+            $.each(problem_details_elems, function(i, key) {
+                if (key in args){
+                    val = problem_render_callbacks[key](args[key]);
+                    pd.append(
+                        $('<div class="panel panel-default">')
+                            .css("border-width", "0px 0px 2px 0px")
+                            .append(
+                          $('<div class="panel-heading problem-panel">')
+                            .attr('data-toggle', 'collapse')
+                            .attr('data-target', '#' + key)
+                            .attr('data-parent', '#accordion-markup')
+                            .append($('<h4 class="panel-title">')
+                              .append($('<a class="accordion-toggle">')
+                                .text(key))),
+                          $('<div class="panel-collapse collapse">')
+                            .attr('id', key)
+                            .append(
+                              $('<div class="panel-body">')
+                                    .html(val))));
+                }
+            });
+        });
+    }
+
+    function render_table_eq(orig) {
+        return render_table(orig, '=');
+    }
+
+    function render_table_co(orig) {
+        return render_table(orig, ':');
+    }
+
+    function render_table(orig, delimiter) {
+        var lines = orig[2].split('\n');
+        var result;
+
+        for (var i = 0; i < lines.length - 1; i++) {
+            var line = lines[i].split(delimiter);
+            result += '<tr> <td class="text-right">' + line[0];
+            result += '<td class="text-left">' + line[1];
+            result += '</tr>';
+        }
+
+        return result;
+    }
+
+    function render_multiline(orig) {
+        var rendered = orig[2].replace(/\n/g, '<br>');
+        return rendered;
+    }
+
+    function render_multitable(orig, delimiter) {
+        var rendered = orig.replace(RegExp(delimiter, 'g'), '</td><td>');
+        rendered = rendered.replace(/\n/g, '</td></tr><tr><td>');
+        return '<tr><td>' + rendered + '</td></tr>';
+    }
+
+    function render_dso_list(orig) {
+        var rendered = orig[2].replace(/^(\S+\s+)(\S+)(.*)$/gm, '$1<b>$2</b>$3');
+        return render_multitable(rendered, ' ');
+    }
+
+    function render_open_fds(orig) {
+        var lines = orig[2].split('\n');
+        for (var i = 0; i < lines.length - 1; i++) {
+            if (i % 5 !== 0) {
+                lines[i] = ':' + lines[i];
+            }
+        }
+        return render_multitable(lines.join('\n'), ':');
+    }
+
+    function render_cgroup(orig) {
+        return render_multitable(orig[2], ':');
+    }
+
+    function render_mountinfo(orig) {
+        return render_multitable(orig[2].replace(/  +/g, ':'), ' ');
+    }
+
+    function render_maps(orig) {
+        return render_multitable(orig[2].replace(/  +/g, ':'), ' ');
+    }
+
+    function render_limits(orig) {
+        var lines = orig[2].split('\n');
+        lines[0] ='":' + lines[0].replace(/(\S+) (\S+) /g, '$1:$2 ');
+        for (var i = 1; i < lines.length - 1; i++) {
+                lines[i] = lines[i].replace(/  +/g, ':');
+        }
+
+        return render_multitable(lines.join('\n'), ':');
+    }
+
+    function render_backtrace(content) {
+        var content_json = JSON.parse(content[2]);
+
+        var crash_thread = null;
+        var other_threads = [];
+        var other_items = {};
+
+        for (var item in content_json) {
+
+            if (item === 'stacktrace') {
+
+                var threads = content_json[item];
+                for (var thread_key in threads) {
+
+                    var thread = threads[thread_key];
+
+                    if (thread.hasOwnProperty("crash_thread") && thread['crash_thread']) {
+                        if (thread.hasOwnProperty('frames')) {
+                            crash_thread = thread['frames'];
+                        }
+                    }
+                    else {
+                        if (thread.hasOwnProperty('frames')) {
+                            other_threads.push(thread['frames']);
+                        }
+                    }
+                }
+            }
+            else {
+                other_items[item] = content_json[item];
+            }
+        }
+        return create_detail_from_parsed_core_backtrace(crash_thread, other_threads, other_items);
+    }
+
+    function create_detail_from_parsed_core_backtrace(crash_thread, other_threads, other_items) {
+
+        var detail_content = '';
+        for (var item in other_items) {
+            detail_content += item;
+            detail_content += ': ' + other_items[item] + "  ";
+        }
+
+        detail_content += create_table_from_thread(crash_thread);
+
+        if (other_threads.length !== 0) {
+            detail_content += '<div id="other_threads_btn_div"><button class="btn btn-default other-threads-btn" title="">Show all threads</button></div>';
+            detail_content += '<div class="hidden other_threads">';
+
+            var thread_num = 1;
+            for (var thread_key in other_threads) {
+                detail_content += '\n';
+                detail_content += 'thread: ' + thread_num++ + '\n';
+                detail_content += create_table_from_thread(other_threads[thread_key]);
+            }
+            detail_content += '</div>';
+        }
+
+        return detail_content;
+    }
+
+    function create_table_from_thread(thread) {
+        var all_keys = get_all_keys_from_frames(thread);
+
+        /* create table legend */
+        var table = '<table class="detail_table"><thead><tr><th>Fr #</th>';
+        for (var key in all_keys) {
+            table += '<th>';
+            table += all_keys[key].replace(/_/g, ' ');
+            table += '</th>';
+        }
+        table += '</tr></thead><tbody>';
+
+        var frame_num = 1;
+        for (var frame_key in thread) {
+            table += '<tr>';
+            table += '<td>';
+            table += frame_num++;
+            table += '</td>';
+
+            var frame = thread[frame_key];
+            for (var key_key in all_keys) {
+                key = all_keys[key_key];
+
+                var title = '';
+                var row_content = '';
+                if (key in frame) {
+                    row_content = frame[key].toString();
+                    if (row_content.length > 8)
+                        title = row_content;
+                }
+                else
+                    row_content = '';
+
+                table += '<td title="' + title + '">';
+                table += row_content;
+                table += '</td>';
+            }
+            table += '</tr>';
+        }
+
+        table += '</tbody></table>';
+        return table;
+    }
+
+    function get_all_keys_from_frames(thread) {
+        var all_keys = [];
+
+        for (var frame_key in thread) {
+            var frame = thread[frame_key];
+            var keys = Object.keys(frame);
+
+            for (var key in keys) {
+                if (all_keys.indexOf(keys[key]) === -1)
+                    all_keys.push(keys[key]);
+            }
+        }
+
+        /* order keys */
+        var desired_ordered_of_keys = ['function_name', 'file_name', 'address', 'build_id', 'build_id_offset'];
+
+        var all_ordered_keys = [];
+
+        for (var key_key in desired_ordered_of_keys) {
+            var in_key = desired_ordered_of_keys[key_key];
+            var key_index = all_keys.indexOf(in_key);
+            if (key_index !== -1) {
+                all_ordered_keys.push(in_key);
+                delete all_keys[key_index];
+            }
+        }
+
+        for(key_key in all_keys) {
+            all_ordered_keys.push(all_keys[key_key]);
+        }
+
+        return all_ordered_keys;
     }
 
     function update() {

--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -213,14 +213,28 @@ $(function() {
 
         var query_prio = cockpit.location.options['prio'] || "3";
         var prio_level = parseInt(query_prio, 10);
-        $("#journal-prio button").each(function() {
-            var num = parseInt($(this).attr("data-prio"), 10);
-            $(this).toggleClass('active', isNaN(prio_level) || num <= prio_level);
-        });
+
+        // Set selected item into priority dropdown menu
+        var all_prios = document.getElementById('prio-lists').childNodes;
+        var item;
+        for (var j = 0; j < all_prios.length; j++) {
+            if (all_prios[j].nodeName === 'LI') {
+                item = all_prios[j].childNodes[0];
+                if (item.getAttribute('data-prio') === query_prio) {
+                    $('#journal-prio').text(item.text);
+                    break;
+                }
+            }
+        }
 
         if (prio_level) {
             for (var i = 0; i <= prio_level; i++)
                 match.push('PRIORITY=' + i.toString());
+        }
+
+        // If item 'Only Problems' was selected, match only ABRT's problems
+        if (prio_level === 2) {
+            match.push('SYSLOG_IDENTIFIER=abrt-notification');
         }
 
         var options = cockpit.location.options;
@@ -318,14 +332,8 @@ $(function() {
             cockpit.location.go([ cursor ]);
     });
 
-    $('#journal-prio button').on("click", function() {
-        var options = cockpit.location.options;
-        var prio = $(this).attr('data-prio');
-        if (prio)
-            options.prio = prio;
-        else
-            delete options.prio;
-        cockpit.location.go([], options);
+    $('#journal-prio-menu a').on('click', function() {
+        cockpit.location.go([], $.extend(cockpit.location.options, { prio: $(this).attr('data-prio') }));
     });
 
     $('#journal-navigate-home').on("click", function() {

--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -417,6 +417,8 @@ $(function() {
         var pd = $('<div class="panel-group" id="accordion-markup">');
         var tab = $('<ul class="nav nav-tabs nav-tabs-pf">');
 
+        var d_btn =  $('<button class="btn btn-danger problem-btn btn-delete pficon pficon-delete">');
+
         ge_t.click(function() {
             switch_tab(ge_t, ge);
         });
@@ -427,6 +429,14 @@ $(function() {
 
         pd_t.click(function() {
             switch_tab(pd_t, pd);
+        });
+
+        d_btn.click(function() {
+            service.DeleteProblems([problem.path]);
+            displayable_problems = { };
+            find_problems().done(function() {
+                cockpit.location.go('/');
+            });
         });
 
         // write into general tab non-ABRT related items
@@ -444,6 +454,7 @@ $(function() {
         tab.html(ge_t);
         tab.append(pi_t);
         tab.append(pd_t);
+        tab.append(d_btn);
 
         var body = $('<th>');
         body.append(tab);

--- a/test/avocado/selenium-base.py
+++ b/test/avocado/selenium-base.py
@@ -62,13 +62,39 @@ class BasicTestSuite(SeleniumTest):
         self.wait_id("journal")
         self.wait_id("journal-current-day")
         self.wait_id("journal-prio")
-        self.click(self.wait_text('Errors', cond=clickable, element="button"))
+        self.click(self.wait_xpath(
+            "//span[@id='journal-prio' and contains(text(), '%s')]" % "Problems, Errors"))
+        self.wait_id("prio-lists")
+        self.click(self.wait_xpath(
+            "//a[@data-prio='2' and contains(text(), '%s')]" % "Only Problems"))
         self.wait_id("journal")
         self.wait_id("journal-current-day")
-        self.click(self.wait_text('Warnings', cond=clickable, element="button"))
+        self.click(self.wait_xpath(
+            "//span[@id='journal-prio' and contains(text(), '%s')]" % "Only Problems"))
+        self.wait_id("prio-lists")
+        self.click(self.wait_xpath(
+            "//a[@data-prio='3' and contains(text(), '%s')]" % "Problems, Errors"))
         self.wait_id("journal")
         self.wait_id("journal-current-day")
-        self.click(self.wait_text('Notices', cond=clickable, element="button"))
+        self.click(self.wait_xpath(
+            "//span[@id='journal-prio' and contains(text(), '%s')]" % "Problems, Errors"))
+        self.wait_id("prio-lists")
+        self.click(self.wait_xpath(
+            "//a[@data-prio='4' and contains(text(), '%s')]" % "Problems, Errors, Warnings"))
+        self.wait_id("journal")
+        self.wait_id("journal-current-day")
+        self.click(self.wait_xpath(
+            "//span[@id='journal-prio' and contains(text(), '%s')]" % "Problems, Errors, Warnings"))
+        self.wait_id("prio-lists")
+        self.click(self.wait_xpath(
+            "//a[@data-prio='5' and contains(text(), '%s')]" % "Problems, Errors, Warnings, Notices"))
+        self.wait_id("journal")
+        self.wait_id("journal-current-day")
+        self.click(self.wait_xpath(
+            "//span[@id='journal-prio' and contains(text(), '%s')]" % "Problems, Errors, Warnings, Notices"))
+        self.wait_id("prio-lists")
+        self.click(self.wait_xpath(
+            "//a[@data-prio='*' and contains(text(), '%s')]" % "Everything"))
         self.wait_id("journal")
         self.wait_id("journal-current-day")
         checkt = "ahojnotice"

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -303,5 +303,109 @@ s.send("PRIORITY=3\\nFOO=bar\\n")'
 
         b.wait_text("#journal-entry-message", "[no data]")
 
+    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-i386", "rhel-7-4")
+    @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1604", "rhel-atomic", "fedora-atomic")
+    def testAbrtSegv(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/system/logs")
+
+        m.execute("setenforce 0; ulimit -c unlimited; python -c 'import os; os.kill(os.getpid(), 11)' || true")
+
+        sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('crashed in posix_kill')"
+        b.wait_present(sel)
+        b.wait_visible(sel)
+        b.click(sel)
+
+        def wait_field(name, value):
+            row_sel = "#journal-entry-fields tr:contains('" + name + "')"
+            b.wait_present(row_sel + " td:nth-child(2):contains('" + value + "')")
+
+        wait_field("SYSLOG_IDENTIFIER", "abrt-notification")
+
+        b.click("li:contains(Problem info)")
+        wait_field("crash_function", "posix_kill")
+
+        b.click("li:contains(Problem details)")
+        sel = "#journal-entry-fields #accordion-markup .panel .panel-heading"
+        sel += " .panel-title .accordion-toggle:contains('core_backtrace')"
+        b.wait_present(sel)
+        b.wait_visible(sel)
+        b.click(sel)
+
+        sel = "#journal-entry #accordion-markup .panel .panel-collapse"
+        sel += " .panel-body:contains('signal: 11  executable: ')"
+        b.wait_present(sel)
+
+    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-i386", "rhel-7-4")
+    @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1604", "rhel-atomic", "fedora-atomic")
+    def testAbrtDelete(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/system/logs")
+
+        m.execute("setenforce 0; ulimit -c unlimited; echo 'sleep 42m &' > slp; chmod u+x slp")
+        m.execute("./slp; killall -s SIGSEGV sleep")
+
+        sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('crashed in __nanosleep()')"
+        b.wait_present(sel)
+        b.wait_visible(sel)
+        b.click(sel)
+
+        sel = "#journal-entry-fields .nav .btn-danger"
+        b.wait_present(sel)
+        b.wait_visible(sel)
+        b.click(sel)
+
+        b.wait_visible("#journal-box")
+        b.wait_in_text('#journal-box', "__nanosleep")
+
+        sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('crashed in __nanosleep()')"
+        b.click(sel)
+
+        b.wait_present('.cockpit-log-panel')
+        b.wait_visible('.cockpit-log-panel')
+
+        sel = "#journal-entry .panel #journal-entry-message:contains('crashed in __nanosleep()')"
+        b.wait_present(sel)
+
+    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-i386", "rhel-7-4")
+    @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1604", "rhel-atomic", "fedora-atomic")
+    def testAbrtReport(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/system/logs")
+
+        m.execute("setenforce 0; ulimit -c unlimited; echo 'sleep 42m &' > slp; chmod u+x slp")
+        m.execute("./slp; killall -s SIGSEGV sleep")
+
+        sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('crashed in __nanosleep()')"
+        b.wait_present(sel)
+        b.wait_visible(sel)
+        b.click(sel)
+
+        # Wait until loaded (when delete button is loaded, all is loaded)
+        sel = "#journal-entry-fields .nav .btn-danger"
+        b.wait_present(sel)
+        b.wait_visible(sel)
+
+        # If 'Reported' then skip test
+        sel = "#journal-entry-fields .nav .problem-btn:contains('Reported')"
+        if b.is_present(sel):
+            return
+
+        sel = "#journal-entry-fields .nav .btn-primary:contains('Report')"
+        b.wait_present(sel)
+        b.wait_visible(sel)
+        b.click(sel)
+
+        sel = "#journal-entry-fields .nav .problem-btn:contains('Reported')"
+        b.wait_present(sel)
+        b.wait_visible(sel)
+        self.assertTrue("/reports/bthash/" in b.attr(sel, 'href'))
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
This PR implements design 
https://github.com/cockpit-project/cockpit/wiki/Feature:-ABRT

This PR needs upstream Libreport (https://github.com/abrt/libreport), and newest ABRT. All of this will be in Fedora 26. However, if older ABRT or Libreport are installed or are not available at all no changes are visible for users.
If you want to test this PR now, you will need a few thinks:
abrt >= 2.8.0
libreport - must be build from upstream
satyr >= 0.22

It is also possible to use repository that I created in copr.
https://copr.fedorainfracloud.org/coprs/mmarusak/ABRT-for-cockpit-PR/

When everything installed you need to run:
service abrtd start
service abrt-ccpp stop
service abrt-journal-core start
ulimit -c unlimited
setenforce 0

All of these steps are only necessary because behaviour of Libreport is changing quite a bit from Fedora 26 onwards.

Then log in as root. (You need to be a sudo user to read problems. Otherwise none problems will be displayed.)