### PR TITLE
Run 32 bit test on semaphore

### DIFF
--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -342,7 +342,7 @@ CLEANFILES += \
 # for this.
 #
 mock-pmda.so: src/bridge/mock-pmda.c
-	$(AM_V_CCLD) $(CC) -fPIC -shared \
+	$(AM_V_CCLD) $(CC) $(CFLAGS) -fPIC -shared \
 		-DSRCDIR=\"$(abs_srcdir)\" \
 		-o mock-pmda.so $(srcdir)/src/bridge/mock-pmda.c -lpcp_pmda -lpcp
 

--- a/src/bridge/mock-pmda.c
+++ b/src/bridge/mock-pmda.c
@@ -122,6 +122,8 @@ mock_fetchCallBack(pmdaMetric *mdesc, unsigned int inst, pmAtomValue *atom)
   return 0;
 }
 
+void mock_control (const char *cmd, ...);
+
 void
 mock_control (const char *cmd, ...)
 {
@@ -171,8 +173,10 @@ mock_control (const char *cmd, ...)
   va_end(ap);
 }
 
+void mock_init (pmdaInterface *dp);
+
 void
-mock_init(pmdaInterface *dp)
+mock_init (pmdaInterface *dp)
 {
   pmdaDSO(dp, PMDA_INTERFACE_2, "mock-pmda", NULL);
 

--- a/tools/semaphore-prepare
+++ b/tools/semaphore-prepare
@@ -2,4 +2,4 @@
 
 change-phantomjs-version 2.1.1
 sudo apt-get update
-sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libgirepository1.0-dev libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-login-dev libsystemd-journal-dev libkrb5-dev pcp pkg-config valgrind xmlto xsltproc pyflakes npm nodejs-legacy git libfontconfig1 dbus ssh
+sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-login-dev libsystemd-journal-dev libkrb5-dev pcp pkg-config valgrind xmlto xsltproc pyflakes npm nodejs-legacy git libfontconfig1 dbus ssh

--- a/tools/semaphore-run
+++ b/tools/semaphore-run
@@ -1,8 +1,33 @@
 #!/bin/bash
 
-set -ex
+set -eux
+
+ARCH=${1:-}
+
+if [ "$ARCH" = i386 ]; then
+    # help apt to figure out replacing GI dependencies (we don't need them
+    # anyway, but a lot of stuff is pre-installed in semaphore)
+    sudo apt-get purge --auto-remove -y python3-gi gir1.2-glib-2.0
+
+    # library -dev packages are not co-installable for multiple architectures,
+    # so this can't go into the setup step
+    DEVPKGS=$(grep -o '[^ ]*-dev' tools/semaphore-prepare | sed 's/$/:i386/')
+    sudo apt-get install -y --no-install-recommends gcc-multilib pkg-config:i386 glib-networking:i386 libc6-dbg:i386 $DEVPKGS
+    export CFLAGS=-m32
+    export LDFLAGS=-m32
+elif [ -n "$ARCH" ]; then
+    echo "Unknown architecture '$ARCH'" >&2
+    exit 1
+fi
 
 ./autogen.sh --prefix=/usr --enable-strict --with-systemdunitdir=/tmp
 make V=1 all
-make -j8 distcheck
-make -j8 check-memory
+
+# only run distcheck on native arch
+if [ -z "$ARCH" ]; then
+    make -j8 distcheck
+    make -j8 check-memory
+elif [ "$ARCH" = i386 ]; then
+    linux32 make -j8 check
+    linux32 make -j8 check-memory
+fi

--- a/tools/unknown.supp
+++ b/tools/unknown.supp
@@ -418,6 +418,22 @@
    fun:clone
 }
 {
+   ubuntu_12_04_i386_unknown_leak_maybe_gdbus
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   fun:g_malloc0
+   obj:/usr/lib/i386-linux-gnu/libgio-2.0.so.0.4002.0
+   obj:/usr/lib/i386-linux-gnu/libgio-2.0.so.0.4002.0
+   fun:g_initable_init
+   obj:/usr/lib/i386-linux-gnu/libgio-2.0.so.0.4002.0
+   obj:/usr/lib/i386-linux-gnu/libgio-2.0.so.0.4002.0
+   obj:/lib/i386-linux-gnu/libglib-2.0.so.0.4002.0
+   obj:/lib/i386-linux-gnu/libglib-2.0.so.0.4002.0
+   fun:start_thread
+   fun:clone
+}
+{
    gcov_exit
    Memcheck:Leak
    match-leak-kinds: definite


### PR DESCRIPTION
I just added a third job "#3 - gcc 32 bit" to semaphore which will  run `tools/semaphore-run i386`. This PR fills that with life and do a 32 bit build/make check.

"bot" as this only affects semaphore.

I will now work on adding an i386 image and integration test (see [Trello card](https://trello.com/c/y9wrQjg1/375-epic-unit-and-integration-tests-on-a-non-x86-architecture)), after which this will be somewhat redundant. But this is easier to set up, gave me some initial insight/fix for cross-building (we might want to run ppc64 or s390x in semaphore for big-endian coverage), and won't need additional resources on our Cockpit test runners.