### PR TITLE
Image refresh for debian-testing

### DIFF
--- a/test/images/debian-testing
+++ b/test/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-098083aeac55eafa6b2d6398d7c13b1e1f81e4aa.qcow2
+debian-testing-833fe3022891964c9ab70261478a53f7f4cbba98.qcow2


### PR DESCRIPTION
Image creation for debian-testing in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-testing-2017-03-23/