### PR TITLE
test: Declare fedora-i386 image

### DIFF
--- a/test/common/testinfra.py
+++ b/test/common/testinfra.py
@@ -65,6 +65,7 @@ DEFAULT_VERIFY = {
     'verify/debian-testing': [ 'master', 'pulls' ],
     'verify/fedora-24': [ ],
     'verify/fedora-25': [ 'master', 'pulls' ],
+    'verify/fedora-i386': [ ],
     'verify/fedora-26': [ ],
     'verify/fedora-atomic': [ 'master', 'pulls' ],
     'verify/fedora-testing': [ ],


### PR DESCRIPTION
We will soon add this to run integration tests on a 32 bit platform in
PR #6195. Make the image known to the test infrastructure, but don't
trigger it by default yet.

---

Using "bot" as this won't change any existing test, it's just a prerequisite for #6195 to land this.