### PR TITLE
debian: Ensure unit tests have a working $HOME

### DIFF
--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -8,6 +8,9 @@ ifneq ($(shell dpkg -s libpcp3-dev >/dev/null 2>&1 && echo yes),yes)
 	CONFIG_OPTIONS = --disable-pcp
 endif
 
+# pbuilder's user has home dir /nonexistent, but our tests want to have working $XDG dirs
+export HOME=$(CURDIR)/debian/tmp/home
+
 %:
 	dh $@ --with=systemd
 


### PR DESCRIPTION
pbuilder's user has home dir "/nonexistent" in /etc/passwd (so commit
8acf23b9 does not help), so the build fails with lots of

    WARNING: cockpit-bridge: couldn't create runtime dir: /nonexistent/.cache: Permission denied

This could arguably be downgraded to a message as it's not an internal
Cockpit inconsistency, but doing that then results in subsequent
warnings like

    WARNING: cockpit-bridge: couldn't create temporary socket file: No such file or directory

It makes more sense to run the tests with an actually working $HOME
directory, so set one in debian/rules.

----
I tested this successfully in our release container (locally) with the `pbuilder build` command that we use in production, and the build succeeds now.