### PR TITLE
Cleanup authorize and session related code

### DIFF
--- a/src/ws/cockpitcreds.c
+++ b/src/ws/cockpitcreds.c
@@ -113,7 +113,6 @@ out:
 
 /**
  * cockpit_creds_new:
- * @user: the user name the creds are for
  * @application: the application the creds are for
  * @...: multiple credentials, followed by NULL
  *
@@ -127,8 +126,7 @@ out:
  * Returns: (transfer full): the new set of credentials.
  */
 CockpitCreds *
-cockpit_creds_new (const gchar *user,
-                   const gchar *application,
+cockpit_creds_new (const gchar *application,
                    ...)
 {
   GBytes *password = NULL;
@@ -137,13 +135,10 @@ cockpit_creds_new (const gchar *user,
   const char *type;
   va_list va;
 
-  g_return_val_if_fail (user != NULL, NULL);
-  g_return_val_if_fail (!g_str_equal (user, ""), NULL);
   g_return_val_if_fail (application != NULL, NULL);
   g_return_val_if_fail (!g_str_equal (application, ""), NULL);
 
   creds = g_new0 (CockpitCreds, 1);
-  creds->user = g_strdup (user);
   creds->application = g_strdup (application);
   creds->login_data = NULL;
 
@@ -153,6 +148,8 @@ cockpit_creds_new (const gchar *user,
       type = va_arg (va, const char *);
       if (type == NULL)
         break;
+      else if (g_str_equal (type, COCKPIT_CRED_USER))
+        creds->user = g_strdup (va_arg (va, const char *));
       else if (g_str_equal (type, COCKPIT_CRED_PASSWORD))
         password = va_arg (va, GBytes *);
       else if (g_str_equal (type, COCKPIT_CRED_RHOST))
@@ -317,7 +314,6 @@ cockpit_creds_to_json (CockpitCreds *creds)
   JsonObject *login_data = NULL;
 
   object = json_object_new ();
-  json_object_set_string_member (object, "user", cockpit_creds_get_user (creds));
   json_object_set_string_member (object, "csrf-token", cockpit_creds_get_csrf_token (creds));
 
   login_data = cockpit_creds_get_login_data (creds);

--- a/src/ws/cockpitcreds.c
+++ b/src/ws/cockpitcreds.c
@@ -310,44 +310,6 @@ cockpit_creds_get_rhost (CockpitCreds *creds)
   return creds->rhost;
 }
 
-gboolean
-cockpit_creds_equal (gconstpointer v1,
-                     gconstpointer v2)
-{
-  const CockpitCreds *c1;
-  const CockpitCreds *c2;
-
-  if (v1 == v2)
-    return TRUE;
-  if (!v1 || !v2)
-    return FALSE;
-
-  c1 = v1;
-  c2 = v2;
-
-  return g_strcmp0 (c1->user, c2->user) == 0 &&
-         g_strcmp0 (c1->application, c2->application) == 0 &&
-         g_strcmp0 (c1->rhost, c2->rhost) == 0;
-}
-
-guint
-cockpit_creds_hash (gconstpointer v)
-{
-  const CockpitCreds *c = v;
-  guint hash = 0;
-  if (v)
-    {
-      c = v;
-      if (c->user)
-        hash ^= g_str_hash (c->user);
-      if (c->application)
-        hash ^= g_str_hash (c->application);
-      if (c->rhost)
-        hash ^= g_str_hash (c->rhost);
-    }
-  return hash;
-}
-
 JsonObject *
 cockpit_creds_to_json (CockpitCreds *creds)
 {

--- a/src/ws/cockpitcreds.h
+++ b/src/ws/cockpitcreds.h
@@ -61,11 +61,6 @@ const gchar *   cockpit_creds_get_rhost      (CockpitCreds *creds);
 
 const gchar *   cockpit_creds_get_csrf_token (CockpitCreds *creds);
 
-gboolean        cockpit_creds_equal          (gconstpointer v1,
-                                              gconstpointer v2);
-
-guint           cockpit_creds_hash           (gconstpointer v);
-
 const gchar *   cockpit_creds_get_application            (CockpitCreds *creds);
 
 JsonObject *    cockpit_creds_get_login_data             (CockpitCreds *creds);

--- a/src/ws/cockpitcreds.h
+++ b/src/ws/cockpitcreds.h
@@ -31,6 +31,7 @@ G_BEGIN_DECLS
 
 typedef struct _CockpitCreds       CockpitCreds;
 
+#define COCKPIT_CRED_USER         "user"
 #define COCKPIT_CRED_PASSWORD     "password"
 #define COCKPIT_CRED_RHOST        "rhost"
 #define COCKPIT_CRED_CSRF_TOKEN   "csrf-token"
@@ -40,8 +41,7 @@ typedef struct _CockpitCreds       CockpitCreds;
 
 GType           cockpit_creds_get_type       (void) G_GNUC_CONST;
 
-CockpitCreds *  cockpit_creds_new            (const gchar *user,
-                                              const gchar *application,
+CockpitCreds *  cockpit_creds_new            (const gchar *application,
                                               ...) G_GNUC_NULL_TERMINATED;
 
 CockpitCreds *  cockpit_creds_ref            (CockpitCreds *creds);

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -529,12 +529,12 @@ process_transport_authorize (CockpitWebService *self,
         }
     }
 
-  if (!self->sent_done)
+  if (cookie && !self->sent_done)
     {
       payload = cockpit_transport_build_control ("command", "authorize",
                                                  "cookie", cookie,
                                                  "response", response ? response : "",
-                                                 "host", host ? host : "localhost",
+                                                 "host", host,
                                                  NULL);
       cockpit_transport_send (transport, NULL, payload);
       g_bytes_unref (payload);

--- a/src/ws/mock-auth.c
+++ b/src/ws/mock-auth.c
@@ -133,8 +133,8 @@ mock_auth_login_finish (CockpitAuth *auth,
   nonce = cockpit_auth_nonce (auth);
 
   bytes = g_bytes_new_take (g_strdup (self->expect_password), strlen (self->expect_password));
-  creds = cockpit_creds_new (self->expect_user,
-                             g_object_get_data (G_OBJECT (result), "application"),
+  creds = cockpit_creds_new (g_object_get_data (G_OBJECT (result), "application"),
+                             COCKPIT_CRED_USER, self->expect_user,
                              COCKPIT_CRED_PASSWORD, bytes,
                              COCKPIT_CRED_RHOST, g_object_get_data (G_OBJECT (result), "remote"),
                              COCKPIT_CRED_CSRF_TOKEN, nonce,

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -98,7 +98,7 @@ setup_resource (TestResourceCase *tc,
 
   user = g_get_user_name ();
   password = g_bytes_new_take (g_strdup (PASSWORD), strlen (PASSWORD));
-  creds = cockpit_creds_new (user, "cockpit", COCKPIT_CRED_PASSWORD, password, NULL);
+  creds = cockpit_creds_new ("cockpit", COCKPIT_CRED_USER, user, COCKPIT_CRED_PASSWORD, password, NULL);
   g_bytes_unref (password);
 
   transport = cockpit_pipe_transport_new (tc->pipe);

--- a/src/ws/test-creds.c
+++ b/src/ws/test-creds.c
@@ -30,7 +30,10 @@ test_password (void)
   GBytes *password;
 
   password = g_bytes_new_take (g_strdup ("password"), 8);
-  creds = cockpit_creds_new ("user", "test", COCKPIT_CRED_PASSWORD, password, NULL);
+  creds = cockpit_creds_new ("test",
+                             COCKPIT_CRED_USER, "user",
+                             COCKPIT_CRED_PASSWORD, password,
+                             NULL);
   g_bytes_unref (password);
 
   g_assert (creds != NULL);
@@ -51,7 +54,7 @@ test_set_password (void)
   GBytes *two;
 
   password = g_bytes_new_take (g_strdup ("password"), 8);
-  creds = cockpit_creds_new ("user", "app", COCKPIT_CRED_PASSWORD, password, NULL);
+  creds = cockpit_creds_new ("app", COCKPIT_CRED_PASSWORD, password, NULL);
   g_bytes_unref (password);
 
   g_assert (creds != NULL);
@@ -86,12 +89,11 @@ test_poison (void)
   GBytes *out;
 
   password = g_bytes_new_take (g_strdup ("password"), 8);
-  creds = cockpit_creds_new ("user", "app", COCKPIT_CRED_PASSWORD, password, NULL);
+  creds = cockpit_creds_new ("app", COCKPIT_CRED_PASSWORD, password, NULL);
   g_bytes_unref (password);
 
   g_assert (creds != NULL);
 
-  g_assert_cmpstr ("user", ==, cockpit_creds_get_user (creds));
   g_assert_cmpstr ("password", ==, g_bytes_get_data (cockpit_creds_get_password (creds), NULL));
   g_assert_cmpstr ("app", ==, cockpit_creds_get_application (creds));
 
@@ -116,10 +118,9 @@ test_rhost (void)
 {
   CockpitCreds *creds;
 
-  creds = cockpit_creds_new ("user", "app", COCKPIT_CRED_RHOST, "remote", NULL);
+  creds = cockpit_creds_new ("app", COCKPIT_CRED_RHOST, "remote", NULL);
   g_assert (creds != NULL);
 
-  g_assert_cmpstr ("user", ==, cockpit_creds_get_user (creds));
   g_assert_cmpstr ("remote", ==, cockpit_creds_get_rhost (creds));
   g_assert_cmpstr ("app", ==, cockpit_creds_get_application (creds));
 
@@ -133,13 +134,12 @@ test_multiple (void)
   GBytes *password;
 
   password = g_bytes_new_take (g_strdup ("password"), 8);
-  creds = cockpit_creds_new ("user", "app",
+  creds = cockpit_creds_new ("app",
                              COCKPIT_CRED_PASSWORD, password,
                              COCKPIT_CRED_RHOST, "remote",
                              NULL);
   g_assert (creds != NULL);
 
-  g_assert_cmpstr ("user", ==, cockpit_creds_get_user (creds));
   g_assert_cmpstr ("remote", ==, cockpit_creds_get_rhost (creds));
   g_assert_cmpstr ("password", ==, g_bytes_get_data (cockpit_creds_get_password (creds), NULL));
   g_assert_cmpstr ("app", ==, cockpit_creds_get_application (creds));
@@ -162,20 +162,20 @@ test_login_data (void)
   CockpitCreds *creds4;
   CockpitCreds *creds5;
 
-  creds = cockpit_creds_new ("user", "app", NULL);
+  creds = cockpit_creds_new ("app", NULL);
 
   cockpit_expect_warning ("*received bad json data:*");
-  creds2 = cockpit_creds_new ("user", "app",
+  creds2 = cockpit_creds_new ("app",
                               COCKPIT_CRED_LOGIN_DATA, invalid, NULL);
 
-  creds3 = cockpit_creds_new ("user", "app",
+  creds3 = cockpit_creds_new ("app",
                               COCKPIT_CRED_LOGIN_DATA, no_data, NULL);
 
   cockpit_expect_warning ("*received bad login-data:*");
-  creds4 = cockpit_creds_new ("user", "app",
+  creds4 = cockpit_creds_new ("app",
                               COCKPIT_CRED_LOGIN_DATA, invalid_login, NULL);
 
-  creds5 = cockpit_creds_new ("user", "app",
+  creds5 = cockpit_creds_new ("app",
                               COCKPIT_CRED_LOGIN_DATA, valid, NULL);
 
   g_assert (creds != NULL);

--- a/src/ws/test-creds.c
+++ b/src/ws/test-creds.c
@@ -149,70 +149,6 @@ test_multiple (void)
 }
 
 static void
-test_hash (void)
-{
-  GBytes *pass1 = g_bytes_new_take (g_strdup ("pass1"), 5);
-  GBytes *pass2 = g_bytes_new_take (g_strdup ("pass2"), 5);
-
-  CockpitCreds *one = cockpit_creds_new ("user", "app", COCKPIT_CRED_PASSWORD, pass1, NULL);
-  CockpitCreds *rhost = cockpit_creds_new ("user", "app", COCKPIT_CRED_PASSWORD, pass1,
-                                           COCKPIT_CRED_RHOST, "meh", NULL);
-  CockpitCreds *app = cockpit_creds_new ("user", "app2", COCKPIT_CRED_PASSWORD, pass1, NULL);
-  CockpitCreds *copy = cockpit_creds_new ("user", "app", COCKPIT_CRED_PASSWORD, pass1, NULL);
-
-  g_bytes_unref (pass1);
-  g_bytes_unref (pass2);
-
-  g_assert_cmpuint (cockpit_creds_hash (one), !=, cockpit_creds_hash (rhost));
-  g_assert_cmpuint (cockpit_creds_hash (one), !=, cockpit_creds_hash (app));
-  g_assert_cmpuint (cockpit_creds_hash (one), ==, cockpit_creds_hash (one));
-  g_assert_cmpuint (cockpit_creds_hash (one), ==, cockpit_creds_hash (copy));
-
-  cockpit_creds_unref (one);
-  cockpit_creds_unref (rhost);
-  cockpit_creds_unref (copy);
-  cockpit_creds_unref (app);
-}
-
-static void
-test_equal (void)
-{
-  GBytes *pass1 = g_bytes_new_take (g_strdup ("pass1"), 5);
-  GBytes *pass2 = g_bytes_new_take (g_strdup ("pass2"), 5);
-
-  CockpitCreds *one = cockpit_creds_new ("user", "app", COCKPIT_CRED_PASSWORD, pass1, NULL);
-  CockpitCreds *rhost = cockpit_creds_new ("user", "app", COCKPIT_CRED_PASSWORD, pass1,
-                                           COCKPIT_CRED_RHOST, "meh", NULL);
-  CockpitCreds *app = cockpit_creds_new ("user", "app2", COCKPIT_CRED_PASSWORD, pass1, NULL);
-  CockpitCreds *scruffy = cockpit_creds_new ("scruffy", "app", COCKPIT_CRED_PASSWORD, pass1, NULL);
-  CockpitCreds *two = cockpit_creds_new ("user2", "app", COCKPIT_CRED_PASSWORD, pass2, NULL);
-  CockpitCreds *copy = cockpit_creds_new ("user", "app", COCKPIT_CRED_PASSWORD, pass1, NULL);
-
-  g_bytes_unref (pass1);
-  g_bytes_unref (pass2);
-
-  g_assert (!cockpit_creds_equal (one, two));
-  g_assert (cockpit_creds_equal (one, one));
-  g_assert (cockpit_creds_equal (one, copy));
-  g_assert (!cockpit_creds_equal (one, rhost));
-  g_assert (!cockpit_creds_equal (one, app));
-  g_assert (!cockpit_creds_equal (one, scruffy));
-  g_assert (!cockpit_creds_equal (rhost, scruffy));
-  g_assert (!cockpit_creds_equal (two, scruffy));
-  g_assert (!cockpit_creds_equal (two, NULL));
-  g_assert (!cockpit_creds_equal (NULL, two));
-  g_assert (cockpit_creds_equal (NULL, NULL));
-
-
-  cockpit_creds_unref (one);
-  cockpit_creds_unref (two);
-  cockpit_creds_unref (scruffy);
-  cockpit_creds_unref (rhost);
-  cockpit_creds_unref (copy);
-  cockpit_creds_unref (app);
-}
-
-static void
 test_login_data (void)
 {
   JsonObject *object;
@@ -272,8 +208,6 @@ main (int argc,
   g_test_add_func ("/creds/poison", test_poison);
   g_test_add_func ("/creds/rhost", test_rhost);
   g_test_add_func ("/creds/multiple", test_multiple);
-  g_test_add_func ("/creds/hash", test_hash);
-  g_test_add_func ("/creds/equal", test_equal);
   g_test_add_func ("/creds/login-data", test_login_data);
 
   return g_test_run ();

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -333,7 +333,7 @@ on_handle_stream_socket (CockpitWebServer *server,
                              "pid", pid,
                              NULL);
 
-      creds = cockpit_creds_new (g_get_user_name (), "test",
+      creds = cockpit_creds_new ("test",
                                  COCKPIT_CRED_CSRF_TOKEN, "myspecialtoken",
                                  NULL);
 

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -140,7 +140,8 @@ setup_mock_webserver (TestCase *test,
   test->auth = mock_auth_new (user, PASSWORD);
 
   password = g_bytes_new_take (g_strdup (PASSWORD), strlen (PASSWORD));
-  test->creds = cockpit_creds_new (user, "cockpit",
+  test->creds = cockpit_creds_new ("cockpit",
+                                   COCKPIT_CRED_USER, user,
                                    COCKPIT_CRED_PASSWORD, password,
                                    COCKPIT_CRED_CSRF_TOKEN, "my-csrf-token",
                                    NULL);

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -247,7 +247,7 @@ class TestKerberos(MachineCase):
                                        '--resolve', 'x0.cockpit.lan:9090:%s' % self.machine.address,
                                        'http://x0.cockpit.lan:9090/cockpit/login'])
         self.assertIn("HTTP/1.1 200 OK", output)
-        self.assertIn('"admin@cockpit.lan"', output)
+        self.assertIn('"csrf-token"', output)
 
         cookie = re.search("Set-Cookie: cockpit=([^ ;]+)", output).group(1)
         b.open("/system/terminal", cookie={ "name": "cockpit", "value": cookie, "domain": self.machine.address, "path": "/" })


### PR DESCRIPTION
Lots of cleanups to authorize and session related code. Brought over from my branch reworking the way authorize messages are sent into cockpit-session and cockpit-ssh.

 * [x] #6207 
 * [x] #6211 