### PR TITLE
Image refresh for centos-7

### DIFF
--- a/test/images/centos-7
+++ b/test/images/centos-7
@@ -1,1 +1,1 @@
-centos-7-bfda26be2b19ddcb6ddca79387ad27e8ea21fdd0.qcow2
+centos-7-8a1eb1db82d6fab312416e63dfa26b9b065d22dc.qcow2


### PR DESCRIPTION
Image creation for centos-7 in process on cockpit-11.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-centos-7-2017-03-25/