### PR TITLE
common: Port cockpitmemory to pure C and rename

### DIFF
--- a/src/bridge/askpass.c
+++ b/src/bridge/askpass.c
@@ -32,7 +32,7 @@ static void
 byte_array_clear_and_free (gpointer data)
 {
   GByteArray *buffer = data;
-  cockpit_secclear (buffer->data, buffer->len);
+  cockpit_memory_clear (buffer->data, buffer->len);
   g_byte_array_free (buffer, TRUE);
 }
 
@@ -271,7 +271,7 @@ main (int argc,
 
   /* Clear the password memory owned by JsonObject */
   if (response)
-    cockpit_secclear ((gchar *)response, -1);
+    cockpit_memory_clear ((gchar *)response, -1);
 
   if (request)
     json_object_unref (request);

--- a/src/common/cockpitmemory.c
+++ b/src/common/cockpitmemory.c
@@ -26,9 +26,9 @@
 int      cockpit_secmem_drain = 0;
 
 /**
- * cockpit_secclear:
+ * cockpit_memory_clear:
  *
- * The cockpit_secclear function overwrites LEN bytes of memory
+ * The cockpit_memory_clear function overwrites LEN bytes of memory
  * pointed to by DATA with non-sensitive values.  When LEN is -1, DATA
  * must be zero-terminated and all bytes until the zero are
  * overwritten.
@@ -40,10 +40,10 @@ int      cockpit_secmem_drain = 0;
  */
 
 void
-cockpit_secclear (gpointer data,
-                  gssize len)
+cockpit_memory_clear (void * data,
+                      ssize_t len)
 {
-  volatile gchar *vp;
+  volatile char *vp;
 
   if (!data)
     return;
@@ -56,7 +56,7 @@ cockpit_secclear (gpointer data,
   memset (data, 0xBB, len);
 
   /* Defeats others */
-  vp = (volatile gchar *)data;
+  vp = (volatile char *)data;
   while (len--)
     {
       cockpit_secmem_drain |= *vp;

--- a/src/common/cockpitmemory.h
+++ b/src/common/cockpitmemory.h
@@ -28,39 +28,6 @@ G_BEGIN_DECLS
 void     cockpit_secclear                (gpointer data,
                                           gssize length);
 
-#define DEFINE_CLEANUP_FUNCTION(Type, name, func) \
-  static inline void name (void *v) \
-  { \
-    func (*(Type*)v); \
-  }
-
-#define DEFINE_CLEANUP_FUNCTION0(Type, name, func) \
-  static inline void name (void *v) \
-  { \
-    if (*(Type*)v) \
-      func (*(Type*)v); \
-  }
-
-/* These functions shouldn't be invoked directly;
- * they are stubs that:
- * 1) Take a pointer to the location (typically itself a pointer).
- * 2) Provide %NULL-safety where it doesn't exist already (e.g. g_object_unref)
- */
-DEFINE_CLEANUP_FUNCTION0(GHashTable*, local_hashtable_unref, g_hash_table_unref)
-DEFINE_CLEANUP_FUNCTION0(GObject*, local_obj_unref, g_object_unref)
-DEFINE_CLEANUP_FUNCTION0(GVariant*, local_variant_unref, g_variant_unref)
-DEFINE_CLEANUP_FUNCTION0(GVariantIter*, local_variant_iter_free, g_variant_iter_free)
-
-DEFINE_CLEANUP_FUNCTION(char**, local_strfreev, g_strfreev)
-DEFINE_CLEANUP_FUNCTION(void*, local_free, g_free)
-
-#define cleanup_free __attribute__ ((cleanup(local_free)))
-#define cleanup_unref_object __attribute__ ((cleanup(local_obj_unref)))
-#define cleanup_unref_variant __attribute__ ((cleanup(local_variant_unref)))
-#define cleanup_free_variant_iter __attribute__ ((cleanup(local_variant_iter_free)))
-#define cleanup_unref_hashtable __attribute__ ((cleanup(local_hashtable_unref)))
-#define cleanup_strfreev __attribute__ ((cleanup(local_strfreev)))
-
 G_END_DECLS
 
 #endif /* __COCKPIT_MEMORY_H__ */

--- a/src/common/cockpitmemory.h
+++ b/src/common/cockpitmemory.h
@@ -20,14 +20,9 @@
 #ifndef __COCKPIT_MEMORY_H__
 #define __COCKPIT_MEMORY_H__
 
-#include <glib.h>
-#include <glib-object.h>
+#include <sys/types.h>
 
-G_BEGIN_DECLS
-
-void     cockpit_secclear                (gpointer data,
-                                          gssize length);
-
-G_END_DECLS
+void     cockpit_memory_clear            (void *data,
+                                          ssize_t length);
 
 #endif /* __COCKPIT_MEMORY_H__ */

--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -649,7 +649,7 @@ ssh_askpass (CockpitSshData *data,
     {
       g_message ("%s: the %s command failed: %s", data->logname, argv[0], error->message);
       g_error_free (error);
-      cockpit_secclear (password, -1);
+      cockpit_memory_clear (password, -1);
       g_free (password);
       password = NULL;
     }

--- a/src/ssh/cockpitsshtransport.c
+++ b/src/ssh/cockpitsshtransport.c
@@ -574,7 +574,7 @@ free_password (CockpitSshTransport *self)
   if (self->password)
     {
       data = (gpointer)g_bytes_get_data (self->password, &length);
-      cockpit_secclear (data, length);
+      cockpit_memory_clear (data, length);
       g_bytes_unref (self->password);
       self->password = NULL;
     }

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -121,7 +121,11 @@ sbin_PROGRAMS += remotectl
 
 libexec_PROGRAMS += cockpit-ws cockpit-session
 
-cockpit_session_SOURCES = src/ws/session.c
+cockpit_session_SOURCES = \
+	src/common/cockpitmemory.c \
+	src/common/cockpitmemory.h \
+	src/ws/session.c \
+	$(NULL)
 cockpit_session_LDADD = $(COCKPIT_SESSION_LIBS)
 
 cockpit_ws_SOURCES =					\

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -374,7 +374,7 @@ str_skip (gchar *v,
 static void
 clear_free_authorization (gpointer data)
 {
-  cockpit_secclear (data, strlen (data));
+  cockpit_memory_clear (data, strlen (data));
   g_free (data);
 }
 

--- a/src/ws/cockpitcertificate.c
+++ b/src/ws/cockpitcertificate.c
@@ -197,10 +197,10 @@ generate_temp_cert (const gchar *dir,
 
 out:
   g_free (cert_path);
-  cockpit_secclear (key_data, -1);
+  cockpit_memory_clear (key_data, -1);
   g_free (key_data);
   g_free (pem_data);
-  cockpit_secclear (cert_data, -1);
+  cockpit_memory_clear (cert_data, -1);
   g_free (cert_data);
   if (tmp_key)
     g_unlink (tmp_key);

--- a/src/ws/cockpitcreds.c
+++ b/src/ws/cockpitcreds.c
@@ -259,7 +259,7 @@ cockpit_creds_set_password (CockpitCreds *creds,
   if (creds->password)
     {
       data = (gpointer)g_bytes_get_data (creds->password, &length);
-      cockpit_secclear (data, length);
+      cockpit_memory_clear (data, length);
       creds->password = NULL;
     }
   if (password)

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -434,7 +434,7 @@ process_socket_authorize (CockpitWebService *self,
       if (password)
         {
           data = (gpointer)g_bytes_get_data (payload, &length);
-          cockpit_secclear (data, length);
+          cockpit_memory_clear (data, length);
           g_bytes_unref (password);
         }
     }

--- a/src/ws/reauthorize.c
+++ b/src/ws/reauthorize.c
@@ -17,6 +17,10 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
+
+#include "common/cockpitmemory.h"
+
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
@@ -141,32 +145,14 @@ hex_decode (const char *hex,
   return 0;
 }
 
-int _reauthorize_drain = 0;
-
 static void
 secfree (void *data,
          ssize_t len)
 {
-  volatile char *vp;
-
   if (!data)
     return;
 
-  if (len < 0)
-    len = strlen (data);
-
-  /* Defeats some optimizations */
-  memset (data, 0xAA, len);
-  memset (data, 0xBB, len);
-
-  /* Defeats others */
-  vp = (volatile char*)data;
-  while (len--)
-    {
-      _reauthorize_drain |= *vp;
-      *(vp++) = 0xAA;
-    }
-
+  cockpit_memory_clear (data, len);
   free (data);
 }
 

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -19,6 +19,8 @@
 
 #include "config.h"
 
+#include "common/cockpitmemory.h"
+
 #include <assert.h>
 #include <ctype.h>
 #include <err.h>
@@ -660,7 +662,7 @@ perform_basic (const char *rhost)
 
   if (input)
     {
-      memset (input, 0, strlen (input));
+      cockpit_memory_clear (input, strlen (input));
       free (input);
     }
 


### PR DESCRIPTION
This is so we can share the code in files that are using pure C.