### PR TITLE
Port cockpithex code away from GLib

### DIFF
--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -129,7 +129,7 @@ test_hash_LDADD = $(libcockpit_common_a_LIBS)
 
 test_hex_CFLAGS = $(libcockpit_common_a_CFLAGS)
 test_hex_SOURCES = src/common/test-hex.c
-test_hex_LDADD = $(libcockpit_common_a_LIBS)
+test_hex_LDADD = libretest.a $(libcockpit_common_a_LIBS)
 
 test_json_CFLAGS = $(libcockpit_common_a_CFLAGS)
 test_json_SOURCES = src/common/test-json.c

--- a/src/common/cockpithex.c
+++ b/src/common/cockpithex.c
@@ -21,22 +21,25 @@
 
 #include "cockpithex.h"
 
+#include <stdlib.h>
 #include <string.h>
 
 static const char HEX[] = "0123456789abcdef";
 
-gchar *
-cockpit_hex_encode (gconstpointer data,
-                    gssize length)
+char *
+cockpit_hex_encode (const void * data,
+                    ssize_t length)
 {
-  const guchar *in = data;
-  gchar *out;
-  gsize i;
+  const unsigned char *in = data;
+  char *out;
+  size_t i;
 
   if (length < 0)
     length = strlen (data);
 
-  out = g_malloc (length * 2 + 1);
+  out = malloc (length * 2 + 1);
+  if (!out)
+    return NULL;
   for (i = 0; i < length; i++)
     {
       out[i * 2] = HEX[in[i] >> 4];
@@ -46,28 +49,31 @@ cockpit_hex_encode (gconstpointer data,
   return out;
 }
 
-gpointer
-cockpit_hex_decode (const gchar *hex,
-                    gsize *length)
+void *
+cockpit_hex_decode (const char *hex,
+                    ssize_t hexlen,
+                    size_t *length)
 {
-  const gchar *hpos;
-  const gchar *lpos;
-  gsize len;
-  gchar *out;
-  gint i;
+  const char *hpos;
+  const char *lpos;
+  char *out;
+  int i;
 
-  len = strlen (hex);
-  if (len % 2 != 0)
+  if (hexlen < 0)
+    hexlen = strlen (hex);
+  if (hexlen % 2 != 0)
     return NULL;
 
-  out = g_malloc (len * 2 + 1);
-  for (i = 0; i < len / 2; i++)
+  out = malloc (hexlen * 2 + 1);
+  if (!out)
+    return NULL;
+  for (i = 0; i < hexlen / 2; i++)
     {
       hpos = strchr (HEX, hex[i * 2]);
       lpos = strchr (HEX, hex[i * 2 + 1]);
       if (hpos == NULL || lpos == NULL)
         {
-          g_free (out);
+          free (out);
           return NULL;
         }
       out[i] = ((hpos - HEX) << 4) | ((lpos - HEX) & 0xf);

--- a/src/common/cockpithex.h
+++ b/src/common/cockpithex.h
@@ -20,16 +20,13 @@
 #ifndef __COCKPIT_HEX_H__
 #define __COCKPIT_HEX_H__
 
-#include <glib.h>
+#include <sys/types.h>
 
-G_BEGIN_DECLS
+char *          cockpit_hex_encode            (const void *data,
+                                               ssize_t length);
 
-gchar *          cockpit_hex_encode            (gconstpointer data,
-                                                gssize length);
-
-gpointer         cockpit_hex_decode            (const gchar *hex,
-                                                gsize *length);
-
-G_END_DECLS
+void *          cockpit_hex_decode            (const char *hex,
+                                               ssize_t hexlen,
+                                               size_t *length);
 
 #endif

--- a/src/common/test-hex.c
+++ b/src/common/test-hex.c
@@ -21,51 +21,62 @@
 
 #include "cockpithex.h"
 
-#include "cockpittest.h"
+#include "retest/retest.h"
 
-#include <glib.h>
+#include <stdlib.h>
 
 static void
 test_decode_success (void)
 {
-  gpointer decoded;
-  gsize length;
+  void * decoded;
+  size_t length;
 
-  decoded = cockpit_hex_decode ("6d61726d616c616465", &length);
-  g_assert_cmpstr (decoded, ==, "marmalade");
-  g_assert_cmpuint (length, ==, 9);
-  g_free (decoded);
+  decoded = cockpit_hex_decode ("6d61726d616c616465", -1, &length);
+  assert_str_cmp (decoded, ==, "marmalade");
+  assert_num_cmp (length, ==, 9);
+  free (decoded);
+}
+
+static void
+test_decode_part (void)
+{
+  void * decoded;
+  size_t length;
+
+  decoded = cockpit_hex_decode ("6d61726d616c616465", 8, &length);
+  assert_str_cmp (decoded, ==, "marm");
+  assert_num_cmp (length, ==, 4);
+  free (decoded);
 }
 
 static void
 test_decode_no_length (void)
 {
-  gpointer decoded;
+  void *decoded;
 
-  decoded = cockpit_hex_decode ("6d61726d616c616465", NULL);
-  g_assert_cmpstr (decoded, ==, "marmalade");
-  g_free (decoded);
+  decoded = cockpit_hex_decode ("6d61726d616c616465", -1, NULL);
+  assert_str_cmp (decoded, ==, "marmalade");
+  free (decoded);
 }
 
 static void
 test_decode_fail (void)
 {
-  gpointer decoded;
-  gsize length;
+  void *decoded;
+  size_t length;
 
-  decoded = cockpit_hex_decode ("abcdefghijklmn", &length);
-  g_assert (decoded == NULL);
+  decoded = cockpit_hex_decode ("abcdefghijklmn", -1, &length);
+  assert (decoded == NULL);
 }
 
 int
 main (int argc,
       char *argv[])
 {
-  cockpit_test_init (&argc, &argv);
+  re_test (test_decode_success, "/hex/decode-success");
+  re_test (test_decode_part, "/hex/decode-part");
+  re_test (test_decode_no_length, "/hex/decode-no-length");
+  re_test (test_decode_fail, "/hex/decode-fail");
 
-  g_test_add_func ("/hex/decode-success", test_decode_success);
-  g_test_add_func ("/hex/decode-no-length", test_decode_no_length);
-  g_test_add_func ("/hex/decode-fail", test_decode_fail);
-
-  return g_test_run ();
+  return re_test_run (argc, argv);
 }

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -124,6 +124,8 @@ libexec_PROGRAMS += cockpit-ws cockpit-session
 cockpit_session_SOURCES = \
 	src/common/cockpitmemory.c \
 	src/common/cockpitmemory.h \
+	src/common/cockpithex.c \
+	src/common/cockpithex.h \
 	src/ws/session.c \
 	$(NULL)
 cockpit_session_LDADD = $(COCKPIT_SESSION_LIBS)

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -553,7 +553,7 @@ build_gssapi_output_header (JsonObject *results)
   /* We've received indication from the bridge that GSSAPI is supported */
   gssapi_available = 1;
 
-  data = cockpit_hex_decode (output, &length);
+  data = cockpit_hex_decode (output, -1, &length);
   if (!data)
     {
       g_warning ("received invalid gssapi-output field");

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -19,6 +19,7 @@
 
 #include "config.h"
 
+#include "common/cockpithex.h"
 #include "common/cockpitmemory.h"
 
 #include <assert.h>
@@ -153,19 +154,16 @@ write_auth_hex (const char *field,
                 const unsigned char *src,
                 size_t len)
 {
-  static const char hex[] = "0123456789abcdef";
-  size_t i;
+  char *encoded;
 
   debug ("writing %s", field);
   fprintf (authf, "%s \"%s\": \"", auth_delimiter, field);
-  for (i = 0; i < len; i++)
-    {
-      unsigned char byte = src[i];
-      fputc_unlocked (hex[byte >> 4], authf);
-      fputc_unlocked (hex[byte & 0xf], authf);
-    }
+
+  encoded = cockpit_hex_encode (src, len);
+  fputs_unlocked (encoded, authf);
   fputc_unlocked ('\"', authf);
   auth_delimiter = ",";
+  free (encoded);
 }
 
 static void


### PR DESCRIPTION
This is so it can be reused from places that don't use Glib.
This removes code duplication.