### PR TITLE
test: Drop Fedora 25 known issue for udisks poll crash

### DIFF
--- a/test/verify/naughty-fedora-25/6119-storaged-udisksd-poll-with-variant
+++ b/test/verify/naughty-fedora-25/6119-storaged-udisksd-poll-with-variant
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-storage-lvm2", line *, in testLvm
-    "DISK2": True }})
-*
-Message recipient disconnected from message bus without replying


### PR DESCRIPTION
The fix from storaged 2.6.3 got backported to Fedora 25 now
(htttps://bugzilla.redhat.com/show_bug.cgi?id=1432743) so let's ensure
that this stays fixed.

Fixes #6119

----
I'm only triggering a subset of the tests for efficiency.