### PR TITLE
bridge: Allow parameter substitution in when spawning peer bridges

### DIFF
--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -310,6 +310,43 @@ mypackage/test.min.js.gz
       </varlistentry>
     </variablelist>
 
+    <para>The <code>spawn</code> and <code>environ</code> values can be dynamically
+    taken from a matching open command values. When a value in either the <code>spawn</code>
+    or <code>environ</code> array contains a named variable wrapped in <code>${}</code>,
+    the variable will be replaced with the value contained in the matching open command.
+    Only named variables are supported and name can only contain letters, numbers and
+    the following symbols: <code>._-</code></para>
+
+    <para>For example a bridges section like:</para>
+<programlisting>
+{
+  "bridges": [
+    {
+      "match": { "payload": "example" },
+      "environ": [ "TAG=${tag}" ],
+      "spawn: [ "/example-bridge", "--tag", "${tag}" ],
+      "problem": "access-denied"
+    }
+  ]
+}
+</programlisting>
+
+    <para>when a open command is received with a payload of <code>example</code>
+        with <code>tag</code> value of <code>tag1</code>. The following
+        command will be spawned</para>
+
+    <programlisting>TAG=tag1 /example-bridge --tag tag1</programlisting>
+
+    <para>Processes that are reused so if another open command with a "tag" of
+        <code>tag1</code> is received. The open command will be passed to
+        existing process, rather than spawning a new one. However a open command
+        with an tag of <code>tag2</code> will spawn a new command:</para>
+
+    <programlisting>TAG=tag2 /example-bridge --tag tag2</programlisting>
+
+    <para>If you need to include <code>${}</code>, as an actual value in your arguments
+    you can escape it by prefixing it with a <code>\</code></para>
+
   </section>
 
   <section id="package-replace">

--- a/src/bridge/cockpitrouter.h
+++ b/src/bridge/cockpitrouter.h
@@ -46,7 +46,10 @@ void                cockpit_router_add_channel                     (CockpitRoute
                                                                     JsonObject *match,
                                                                     GType (* function) (void));
 
-CockpitPeer *       cockpit_router_add_bridge                      (CockpitRouter *self,
+void                cockpit_router_add_bridge                      (CockpitRouter *self,
+                                                                    JsonObject *config);
+
+void                cockpit_router_add_peer                        (CockpitRouter *self,
                                                                     JsonObject *match,
                                                                     CockpitPeer *peer);
 

--- a/src/common/cockpittemplate.c
+++ b/src/common/cockpittemplate.c
@@ -25,7 +25,7 @@
 
 #include <string.h>
 
-#define VARCHARS "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._"
+#define VARCHARS "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-"
 
 static gchar *
 find_variable (const gchar *start_marker,

--- a/src/common/test-template.c
+++ b/src/common/test-template.c
@@ -36,6 +36,7 @@ setup (TestCase *tc,
   tc->variables = g_hash_table_new (g_str_hash, g_str_equal);
   g_hash_table_insert (tc->variables, "Scruffy", "janitor");
   g_hash_table_insert (tc->variables, "oh", "marmalade");
+  g_hash_table_insert (tc->variables, "oh-dash", "dash-marmalade");
   g_hash_table_insert (tc->variables, "empty", "");
 }
 
@@ -73,6 +74,7 @@ static const Fixture expand_fixtures[] = {
   { "@@", "@@", "no-ending", "Test @@oh@@ su@@ffix", { "Test ", "marmalade", " su@@ffix", NULL } },
   { "@@", "@@", "extra-at-after", "Test @@oh@@ su@@ff@ix", { "Test ", "marmalade", " su@@ff@ix", NULL } },
   { "@@", "@@", "unknown", "Test @@unknown@@ suffix", { "Test ", "@@unknown@@", " suffix", NULL } },
+  { "@@", "@@", "dash", "Test @@oh-dash@@ suffix", { "Test ", "dash-marmalade", " suffix", NULL } },
   { "@@", "@@", "lots", "Oh @@oh@@ says Scruffy @@empty@@ the @@Scruffy@@",
       { "Oh ", "marmalade", " says Scruffy ", " the ", "janitor", NULL }
   },

--- a/src/common/test-template.c
+++ b/src/common/test-template.c
@@ -74,6 +74,7 @@ static const Fixture expand_fixtures[] = {
   { "@@", "@@", "no-ending", "Test @@oh@@ su@@ffix", { "Test ", "marmalade", " su@@ffix", NULL } },
   { "@@", "@@", "extra-at-after", "Test @@oh@@ su@@ff@ix", { "Test ", "marmalade", " su@@ff@ix", NULL } },
   { "@@", "@@", "unknown", "Test @@unknown@@ suffix", { "Test ", "@@unknown@@", " suffix", NULL } },
+  { "@@", "@@", "escaped", "Test \\@@oh@@ @@oh@@ suffix", { "Test ", "@@oh@@", " ", "marmalade", " suffix", NULL } },
   { "@@", "@@", "dash", "Test @@oh-dash@@ suffix", { "Test ", "dash-marmalade", " suffix", NULL } },
   { "@@", "@@", "lots", "Oh @@oh@@ says Scruffy @@empty@@ the @@Scruffy@@",
       { "Oh ", "marmalade", " says Scruffy ", " the ", "janitor", NULL }
@@ -82,6 +83,7 @@ static const Fixture expand_fixtures[] = {
   { "${", "}", "brackets-not-full", "Te$st ${oh} suffix", { "Te$st ", "marmalade", " suffix", NULL } },
   { "${", "}", "brackets-no-ending", "Test ${oh} su${ffix", { "Test ", "marmalade", " su${ffix", NULL } },
   { "${", "}", "brackets-unknown", "Test ${unknown} suffix", { "Test ", "${unknown}", " suffix", NULL } },
+  { "${", "}", "brackets-escaped", "Test \\${oh} ${oh} suffix", { "Test ", "${oh}", " ", "marmalade", " suffix", NULL } },
   { "${", "}", "brackets-lots", "Oh ${oh} says Scruffy ${empty} the ${Scruffy}",
       { "Oh ", "marmalade", " says Scruffy ", " the ", "janitor", NULL }
   },


### PR DESCRIPTION
Still a WIP since tests aren't done yet. But figured I'd post anyways to get some feedback since I deviated from what was initially discussed.

Basically instead of having any regex based parsing anywhere in the router or C code it would be better to leave that to a subcommand, which can be a really simple python (or dynamic language of your choice) script to transform the args however it thinks best and then exec a bridge.

So this just allows bridges to insert a full string from the open json command into either the spawn args or the env vars.

I think this reduces complexity and if preferable to having a regex based system we have to maintain anywhere. WDYT? if @stefwalter you agree I'll finish this up tommorrow otherwise i'll go back the regex version i was working on.