### PR TITLE
Image refresh for fedora-i386

### DIFF
--- a/test/images/fedora-i386
+++ b/test/images/fedora-i386
@@ -1,1 +1,1 @@
-fedora-i386-3b53d88c0b3891ba39b07e11fa770cf5d6104885.qcow2
+fedora-i386-4e2deaf67b61a1bf4f3cf78e430d25b91fb58a2a.qcow2


### PR DESCRIPTION
Image creation for fedora-i386 in process on cockpit-10.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-i386-2017-03-28/