### PR TITLE
base1: Don't assume valid classList in all cases

### DIFF
--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -2391,7 +2391,7 @@ function factory() {
      */
 
     document.addEventListener("click", function(ev) {
-        if (in_array(ev.target.classList, 'disabled'))
+        if (ev.target.classList && in_array(ev.target.classList, 'disabled'))
           ev.stopPropagation();
     }, true);
 


### PR DESCRIPTION
Not all event targets seem to have one, such as the "document" itself.