### PR TITLE
test: Install glib debug symbols in semaphore, remove obsolete valgrind suppressions

### DIFF
--- a/tools/semaphore-prepare
+++ b/tools/semaphore-prepare
@@ -2,4 +2,4 @@
 
 change-phantomjs-version 2.1.1
 sudo apt-get update
-sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-login-dev libsystemd-journal-dev libkrb5-dev pcp pkg-config valgrind xmlto xsltproc pyflakes npm nodejs-legacy git libfontconfig1 dbus ssh
+sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-login-dev libsystemd-journal-dev libkrb5-dev pcp pkg-config valgrind xmlto xsltproc pyflakes npm nodejs-legacy git libfontconfig1 dbus ssh libglib2.0-0-dbg glib-networking-dbg

--- a/tools/semaphore-run
+++ b/tools/semaphore-run
@@ -12,7 +12,7 @@ if [ "$ARCH" = i386 ]; then
     # library -dev packages are not co-installable for multiple architectures,
     # so this can't go into the setup step
     DEVPKGS=$(grep -o '[^ ]*-dev' tools/semaphore-prepare | sed 's/$/:i386/')
-    sudo apt-get install -y --no-install-recommends gcc-multilib pkg-config:i386 glib-networking:i386 libc6-dbg:i386 $DEVPKGS
+    sudo apt-get install -y --no-install-recommends gcc-multilib pkg-config:i386 glib-networking:i386 glib-networking-dbg:i386 libc6-dbg:i386 libglib2.0-0-dbg:i386 $DEVPKGS
     export CFLAGS=-m32
     export LDFLAGS=-m32
 elif [ -n "$ARCH" ]; then

--- a/tools/travis.supp
+++ b/tools/travis.supp
@@ -1,38 +1,4 @@
 {
-   ubuntu_specific_dispatch
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:g_malloc
-   fun:g_slice_alloc
-   fun:g_slice_alloc0
-   obj:/lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0
-   fun:g_main_context_dispatch
-   obj:/lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0
-   fun:g_main_loop_run
-   obj:/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.4002.0
-   obj:/lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0
-   fun:start_thread
-   fun:clone
-}
-{
-   g_bus_get_sync__old
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:calloc
-   ...
-   fun:g_bus_get_sync
-   ...
-   fun:g_test_run
-}
-{
-   g_main_context_push_thread_default__old
-   Memcheck:Leak
-   match-leak-kinds: definite
-   ...
-   fun:g_main_context_push_thread_default
-}
-{
    ubuntu_leak_inside_of_address_sync_initable_new
    Memcheck:Leak
    match-leak-kinds: definite
@@ -44,21 +10,6 @@
    fun:g_initable_new
    fun:g_dbus_connection_new_for_address_sync
    fun:mock_service_thread
-   obj:/lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0
-   fun:start_thread
-   fun:clone
-}
-{
-   ubuntu_glib_thread_gio_leak
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:calloc
-   fun:g_malloc0
-   obj:/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.4002.0
-   obj:/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.4002.0
-   obj:/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.4002.0
-   obj:/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.4002.0
-   obj:/lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0
    obj:/lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0
    fun:start_thread
    fun:clone

--- a/tools/unknown.supp
+++ b/tools/unknown.supp
@@ -397,43 +397,6 @@
    fun:gcov_exit.part.5
 }
 {
-   ubuntu_12_04_unknown_leak_maybe_gdbus
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:calloc
-   fun:g_malloc0
-   obj:/lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0
-   fun:g_slice_alloc
-   fun:g_slice_alloc0
-   fun:g_type_create_instance
-   obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.4000.0
-   fun:g_object_new_valist
-   fun:g_object_new
-   obj:/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.4000.0
-   obj:/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.4000.0
-   obj:/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0.4000.0
-   obj:/lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0
-   obj:/lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0
-   fun:start_thread
-   fun:clone
-}
-{
-   ubuntu_12_04_i386_unknown_leak_maybe_gdbus
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:calloc
-   fun:g_malloc0
-   obj:/usr/lib/i386-linux-gnu/libgio-2.0.so.0.4002.0
-   obj:/usr/lib/i386-linux-gnu/libgio-2.0.so.0.4002.0
-   fun:g_initable_init
-   obj:/usr/lib/i386-linux-gnu/libgio-2.0.so.0.4002.0
-   obj:/usr/lib/i386-linux-gnu/libgio-2.0.so.0.4002.0
-   obj:/lib/i386-linux-gnu/libglib-2.0.so.0.4002.0
-   obj:/lib/i386-linux-gnu/libglib-2.0.so.0.4002.0
-   fun:start_thread
-   fun:clone
-}
-{
    gcov_exit
    Memcheck:Leak
    match-leak-kinds: definite


### PR DESCRIPTION
Some of our valgrind leak suppressions (like
"ubuntu_12_04_unknown_leak_maybe_gdbus" or ubuntu_glib_thread_gio_leak)
are very unspecific, and have a lot of "obj:" links which tend to vary
from time to time. Add the glib and glib-networking debug symbols to get
some more names into them.

Remove the brittle valgrind suppressions, as it seems with the debug
symbols these aren't actually necessary any more.

@mvollmer ran into a semaphore test failure today due to a mismatch on the above suppressions; a retry worked. Unfortunately the previous log is gone now. Let's robustify this.