### PR TITLE
bridge: Add the option for the host field to be expanded

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -153,6 +153,35 @@ open in the "fence" group, any channels opened after that point will be
 blocked and wait until all channels in the "fence" group are closed before
 resuming.
 
+**Host values**
+
+Because the host parameter is how cockpit maps url requests to the correct bridge,
+cockpit may need to additional information to route the message correctly.
+For example you want to connect to a container ```my-container``` running
+on "my.host".
+
+To allow this the host parameter can encode a key/value pair that will
+be expanded in the open command json. The format is host+key+value. For example
+
+    {
+        "command": "open",
+        "channel": "a4",
+        "payload": "stream",
+        "host": "my.host+container+my-container"
+    }
+
+will be expanded to
+
+    {
+        "command": "open",
+        "channel": "a4",
+        "payload": "stream",
+        "host": "my.host",
+        "host-container": "my-container",
+        "host": "my.host"
+    }
+
+
 Command: close
 --------------
 

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -2462,6 +2462,7 @@ function factory() {
             /* Undo unnecessary encoding of these */
             href = href.replace("%40", "@");
             href = href.replace("%3D", "=");
+            href = href.replace(/%2B/g, "+");
 
             var i, opt, value, query = [];
             function push_option(v) {
@@ -2584,7 +2585,7 @@ function factory() {
 
     cockpit.jump = function jump(path, host) {
         if (is_array(path))
-            path = "/" + path.map(encodeURIComponent).join("/").replace("%40", "@").replace("%3D", "=");
+            path = "/" + path.map(encodeURIComponent).join("/").replace("%40", "@").replace("%3D", "=").replace(/%2B/g, "+");
         else
             path = "" + path;
         var options = { command: "jump", location: path, host: host };


### PR DESCRIPTION
This introduces ! as a separator to allow us to include an additional key/value parameter along with the host parameter.

If present the key/value pair is added to the json open command. This allows us to use those additional parameters to route incoming requests for available in alternate bridges correctly.