### PR TITLE
test: Support installing existing packages in testsuite-prepare

### DIFF
--- a/test/README
+++ b/test/README
@@ -25,6 +25,15 @@ expects to find it (do NOT run the build step as root):
 
    $ ./test/verify/testsuite-prepare
 
+If you want to test already existing cockpit rpm or deb packages (and
+potentially others like docker), put them into test/tmp/build-results/ and
+run
+
+   $ ./test/verify/testsuite-prepare --nobuild
+
+instead. --nobuild will avoid building cockpit from the git tree and installing
+most npm/bower modules.
+
 To run the integration tests run the following (do NOT run the integration tests
 as root):
 

--- a/test/verify/testsuite-prepare
+++ b/test/verify/testsuite-prepare
@@ -21,6 +21,7 @@ import os
 import sys
 import glob
 import shutil
+import subprocess
 
 import parent
 from common import testinfra
@@ -34,19 +35,36 @@ if __name__ == "__main__":
         )
     parser.add_argument('-v', '--verbose', action='store_true', help='Display verbose progress details')
     parser.add_argument('-n', '--noinstall', action='store_true', help='Do not install cockpit to base image')
+    parser.add_argument('--nobuild', action='store_true',
+                        help='Do not build packages, just install test/tmp/build-results/* (rpm or deb)')
     parser.add_argument('-f', '--force', action='store_true', help='Force update of images')
     parser.add_argument('image', nargs='?', default=testinfra.DEFAULT_IMAGE, help='The image to use')
     args = parser.parse_args()
 
     test_os = args.image
-    build_os = vmmanage.get_build_image(test_os)
 
     os.system(os.path.join(testinfra.TEST_DIR,"vm-reset"))
-    try:
-        vmimages.download_images([build_os], args.force, [])
-    except Exception as e:
-        print "unable to download all necessary images", e
-        sys.exit(1)
+
+    if args.nobuild:
+        build_os = None
+
+        # Ensure that we have phantomjs for running our tests
+        root_dir = os.path.dirname(os.path.abspath(testinfra.TEST_DIR))
+        if not os.path.exists(os.path.join(root_dir, 'node_modules', 'phantomjs-prebuilt')):
+            try:
+                subprocess.check_call(['npm', 'install', 'sizzle', 'phantomjs-prebuilt'])
+            except subprocess.CalledProcessError as e:
+                sys.stderr.write(str(e) + '\n')
+                sys.exit(1)
+
+    else:
+        build_os = vmmanage.get_build_image(test_os)
+
+        try:
+            vmimages.download_images([build_os], args.force, [])
+        except Exception as e:
+            print "unable to download all necessary images", e
+            sys.exit(1)
 
     retvalue=0
     if args.noinstall:


### PR DESCRIPTION
Add a --nobuild option to testsuite-prepare which will avoid building
cockpit from the git tree and installing +most npm/bower modules, and
just install all test/tmp/build-results/*.{rpm,deb} packages into the
test VM.

This makes it possible to use our existing test machinery for validating
new distro packages in CI (as we want to test *those* RPMs then, not
locally built ones).

It also makes it much easier to test e. g. a new storaged package from a
clean tree with something like

    mkdir -p test/tmp/build-results
    (cd test/tmp/build-results; koji download-build --arch=noarch --arch=x86_64 cockpit-135-1.fc25)
    cp /some/where/additional*.rpm test/tmp/build-results/
    test/verify/testsuite-prepare --nobuild && test/verify/check-...

---
This came up recently in a discussion with @vpodzime for testing the fix for issue #6119, and we noticed that it was unnecessarily hard to run cockpit's tests from a clean tree for this use case (you need to install build deps, wait for the build, etc.)

This is also a prerequisite for using the tests in a  framework like https://fedoraproject.org/wiki/Changes/InvokingTests as there we already have a set of cockpit RPMs ("test subject") and *don't* want to build local ones.