### PR TITLE
common: Fix double-free crash in cockpit_frame_read()

### DIFF
--- a/src/common/cockpitframe.c
+++ b/src/common/cockpitframe.c
@@ -189,8 +189,6 @@ cockpit_frame_read (int fd,
         }
       else if (res == 0)
         {
-          free (buf);
-
           /* No message parsed, but also no data received */
           if (size == 0 && buflen == 0)
             ret = 0;


### PR DESCRIPTION
When reaching EOF, i. e. read() returns 0, don't free the buffer. We
already do it in "out:".

Fixes #6239 

----
I ran `while test/verify/check-session TestSession.testBasic -stv; do sleep 3; done` on ubuntu-1604, and previously that would reliably reproduce it after a handful of runs. It has now survived > 30 runs.