### PR TITLE
ostree: Use ReloadConfig when available

### DIFF
--- a/pkg/ostree/remotes.js
+++ b/pkg/ostree/remotes.js
@@ -46,18 +46,20 @@ angular.module('ostree.remotes', [
         }
 
         function listBranches(remote) {
-            return cockpit.spawn(["ostree", "remote", "refs", remote],
-                                 { "superuser" : "try", "err" : "message"}).
-                then(function(data) {
-                    var d = [];
-                    angular.forEach(data.trim().split(/\r\n|\r|\n/), function (v, k) {
-                        var parts = v.split(":");
-                        if (parts.length > 1)
-                            d.push(parts.slice(1).join(":"));
-                        else
-                            d.push(v);
+            return client.reload().then(function () {
+                return cockpit.spawn(["ostree", "remote", "refs", remote],
+                                     { "superuser" : "try", "err" : "message"}).
+                    then(function(data) {
+                        var d = [];
+                        angular.forEach(data.trim().split(/\r\n|\r|\n/), function (v, k) {
+                            var parts = v.split(":");
+                            if (parts.length > 1)
+                                d.push(parts.slice(1).join(":"));
+                            else
+                                d.push(v);
+                        });
+                        return d.sort();
                     });
-                    return d.sort();
                 });
         }
 


### PR DESCRIPTION
rpm-ostree recently added a ReloadConfig method that syncs the loaded remote configs with what is on disk.
When available use it before calling methods that pull from remotes and before listing branches.