### PR TITLE
bridge: Don't clobber existing $HOME

### DIFF
--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -441,12 +441,12 @@ run_bridge (const gchar *interactive,
   else
     {
       g_setenv ("USER", pwd->pw_name, TRUE);
-      g_setenv ("HOME", pwd->pw_dir, TRUE);
+      g_setenv ("HOME", pwd->pw_dir, FALSE);
       g_setenv ("SHELL", pwd->pw_shell, TRUE);
     }
 
   /* Set a path if nothing is set */
-  g_setenv ("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", 0);
+  g_setenv ("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", FALSE);
 
   /*
    * The bridge always runs from within $XDG_RUNTIME_DIR


### PR DESCRIPTION
If $HOME is set, don't change it to what is set in /etc/passwd. General
Unix expectation is that $HOME trumps the dir in /etc/passwd.

This fixes test failures when building as a user which has an
inaccessible home dir set in /etc/passwd, such as in pbuilder.

Also fix the "overwrite" argument for the g_setenv() call for $PATH:
this is a boolean, so pass FALSE instead of 0 for clarity.

Fixes #6245