### PR TITLE
Revert "test: Build as root for debian-unstable"

### DIFF
--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -23,7 +23,7 @@ basedebug_DATA = \
 	dist/base1/cockpit.min.js.map \
 	$(NULL)
 
-AM_TESTS_ENVIRONMENT = export G_DEBUG=fatal-criticals,fatal-warnings ; export XDG_CACHE_HOME=$$(mktemp -d) ;
+AM_TESTS_ENVIRONMENT = export G_DEBUG=fatal-criticals,fatal-warnings ; export XDG_CACHE_HOME=$$(mktemp -d) ; export XDG_RUNTIME_DIR=$$XDG_CACHE_HOME ;
 
 dist/base1/cockpit.min.css: src/base1/cockpit.css
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \

--- a/test/images/scripts/lib/debian.install
+++ b/test/images/scripts/lib/debian.install
@@ -63,6 +63,13 @@ if [ -n "$do_build" ]; then
     echo BUILDUSERID=0      >>~/.pbuilderrc
     echo BUILDUSERNAME=root >>~/.pbuilderrc
 
+    # pbuilder < 0.228.6 has broken /dev/pts/ptmx permissions; affects Ubuntu < 17.04
+    # see https://bugs.debian.org/841935
+    if ! grep -q ptmxmode /usr/lib/pbuilder/pbuilder-modules; then
+        echo "Fixing /dev/pts/ptmx mode in pbuilder"
+        sed -i '/mount -t devpts none/ s/$/,ptmxmode=666,newinstance/' /usr/lib/pbuilder/pbuilder-modules
+    fi
+
     pbuilder build --buildresult "$resultdir" \
                    --logfile "$resultdir/build.log" \
                    cockpit_${upstream_ver}-1.dsc >$stdout_dest

--- a/test/images/scripts/lib/debian.install
+++ b/test/images/scripts/lib/debian.install
@@ -56,12 +56,7 @@ if [ -n "$do_build" ]; then
     )
 
     # Some unit tests want a real network interface
-    echo USENETWORK=yes     >>~/.pbuilderrc
-
-    # Pbuilder doesn't seem to give enough rights to its default
-    # build user (anymore) to run the unit tests
-    echo BUILDUSERID=0      >>~/.pbuilderrc
-    echo BUILDUSERNAME=root >>~/.pbuilderrc
+    echo USENETWORK=yes >>~/.pbuilderrc
 
     # pbuilder < 0.228.6 has broken /dev/pts/ptmx permissions; affects Ubuntu < 17.04
     # see https://bugs.debian.org/841935

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -8,9 +8,6 @@ ifneq ($(shell dpkg -s libpcp3-dev >/dev/null 2>&1 && echo yes),yes)
 	CONFIG_OPTIONS = --disable-pcp
 endif
 
-# pbuilder's user has home dir /nonexistent, but our tests want to have working $XDG dirs
-export HOME=$(CURDIR)/debian/tmp/home
-
 %:
 	dh $@ --with=systemd
 


### PR DESCRIPTION
This reverts commit 57f8fe075671985d17b6a1be5ffb032dd722a062.

This is a significant difference compared to how we build in
cockpituous' release-debian script, and has hidden issues during CI that
broke at least two releases.

Debian packages *must* be able to build as non-root user. If that does
not work with some test, let's fix that, as it's going to fail later on
in PPAs or Debian proper anyway. However, other than issue #6245 this
works fine.

This also runs tests with a temporary `$XDG_RUNTIME_DIR` as determined in PR #6251.

---
@mvollmer, @dperpeet  , you were wondering about that this morning/during standup. This is a better way to reproduce the release failure than the [semaphore hack](https://github.com/cockpit-project/cockpit/pull/6246#issuecomment-290645196).

Blocked as this requires fixing the actual issue #6245 first, via #6246 or other means. I'll just trigger one test to demonstrate that it fails similarly than the cockpituous release.

- [x] verify that test fails without #6245 fix
- [x] fix checks in pbuilder due to inaccessible home dir (#6245)
- [x] fix test failures due to inaccessible `XDG_RUNTIME_DIR`
- [x] fix "forkpty failed" warning in ubuntu-1604 unit tests