### PR TITLE
test: Run with temporary $XDG_CACHE_HOME

### DIFF
--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -23,7 +23,7 @@ basedebug_DATA = \
 	dist/base1/cockpit.min.js.map \
 	$(NULL)
 
-AM_TESTS_ENVIRONMENT = export G_DEBUG=fatal-criticals,fatal-warnings ;
+AM_TESTS_ENVIRONMENT = export G_DEBUG=fatal-criticals,fatal-warnings ; export XDG_CACHE_HOME=$$(mktemp -d) ;
 
 dist/base1/cockpit.min.css: src/base1/cockpit.css
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \


### PR DESCRIPTION
Avoid clobbering the real user's home directory with cache files from
the unit tests. This also avoids (fatal) warnings about "couldn't create
runtime dir:" if the user's home directory does not exist (like e. g. in
pbuilder).

Note: We cannot use a temporary $HOME because cockpit-bridge
overwrites it with the value from /etc/passwd; see #6246 for details.

Fixes #6245