### PR TITLE
ssh: Use the cockpit.conf file directly for ignoring host keys

### DIFF
--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -19,6 +19,7 @@
 
 #include "config.h"
 
+#include "common/cockpitconf.h"
 #include "common/cockpithex.h"
 #include "common/cockpitjson.h"
 #include "common/cockpitmemory.h"
@@ -1144,6 +1145,7 @@ cockpit_ssh_connect (CockpitSshData *data,
                      const gchar *host_arg,
                      ssh_channel *out_channel)
 {
+  const gchar *ignore_hostkey;
   const gchar *problem;
 
   guint port = 22;
@@ -1184,7 +1186,12 @@ cockpit_ssh_connect (CockpitSshData *data,
 
   g_debug ("%s: connected", data->logname);
 
-  if (!data->ssh_options->ignore_hostkey)
+  /* This is a single host, for which we have been told to ignore the host key */
+  ignore_hostkey = cockpit_conf_string (SSH_SECTION, "host");
+  if (!ignore_hostkey)
+    ignore_hostkey = "127.0.0.2";
+
+  if (!g_str_equal (ignore_hostkey, host))
     {
       problem = verify_knownhost (data, host, port);
       if (problem != NULL)

--- a/src/ssh/cockpitsshtransport.c
+++ b/src/ssh/cockpitsshtransport.c
@@ -72,7 +72,6 @@ enum {
   PROP_HOST_KEY,
   PROP_HOST_FINGERPRINT,
   PROP_KNOWN_HOSTS,
-  PROP_IGNORE_KEY,
   PROP_PROMPT_HOSTKEY,
 };
 
@@ -104,7 +103,6 @@ struct _CockpitSshTransport {
   gchar *knownhosts_file;
   gchar *expected_hostkey;
   guint port;
-  gboolean ignore_hostkey;
   gboolean prompt_hostkey;
 
   /* Name used for logging */
@@ -388,7 +386,6 @@ cockpit_ssh_transport_start_process (CockpitSshTransport *self,
   ssh_options->supports_hostkey_prompt = self->prompt_hostkey;
   ssh_options->command = self->command;
   ssh_options->knownhosts_file = self->knownhosts_file;
-  ssh_options->ignore_hostkey = self->ignore_hostkey;
   ssh_options->knownhosts_data = self->expected_hostkey;
   options->auth_type = "bridge";
 
@@ -527,9 +524,6 @@ cockpit_ssh_transport_set_property (GObject *obj,
       break;
     case PROP_HOST_KEY:
       self->expected_hostkey = g_value_dup_string (value);
-      break;
-    case PROP_IGNORE_KEY:
-      self->ignore_hostkey = g_value_get_boolean (value);
       break;
     case PROP_PROMPT_HOSTKEY:
       self->prompt_hostkey = g_value_get_boolean (value);
@@ -692,10 +686,6 @@ cockpit_ssh_transport_class_init (CockpitSshTransportClass *klass)
   g_object_class_install_property (object_class, PROP_HOST_FINGERPRINT,
          g_param_spec_string ("host-fingerprint", NULL, NULL, NULL,
                               G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property (object_class, PROP_IGNORE_KEY,
-         g_param_spec_boolean ("ignore-key", NULL, NULL, FALSE,
-                               G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (object_class, PROP_PROMPT_HOSTKEY,
          g_param_spec_boolean ("prompt-hostkey", NULL, NULL, FALSE,

--- a/src/ssh/test-sshservice.c
+++ b/src/ssh/test-sshservice.c
@@ -508,7 +508,7 @@ test_unknown_host_key (TestCase *test,
 
   service = cockpit_ssh_service_new (COCKPIT_TRANSPORT (test->transport));
 
-  emit_string (test, NULL, "{\"command\": \"init\", \"version\": 1, \"host\": \"localhost\" }");
+  emit_string (test, NULL, "{\"command\": \"init\", \"version\": 1, \"host\": \"127.0.0.1\" }");
   emit_string (test, NULL, "{\"command\": \"open\","
                            " \"channel\": \"4\", \"payload\": \"echo\"}");
 

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -918,10 +918,7 @@ cockpit_auth_spawn_login_async (CockpitAuth *self,
       ssh_options->knownhosts_file = cockpit_ws_known_hosts;
 
       if (!host)
-        {
-          host = type_option (SSH_SECTION, "host", "127.0.0.1");
-          ssh_options->ignore_hostkey = TRUE;
-        }
+        host = type_option (SSH_SECTION, "host", "127.0.0.2");
       program_default = cockpit_ws_ssh_program;
       env = cockpit_ssh_options_to_env (ssh_options, env);
     }

--- a/src/ws/cockpitauthoptions.c
+++ b/src/ws/cockpitauthoptions.c
@@ -23,7 +23,6 @@
 
 static const gchar *default_knownhosts = PACKAGE_SYSCONF_DIR "/ssh/ssh_known_hosts";
 static const gchar *default_command = "cockpit-bridge";
-static const gchar *ignore_hosts_data = "*";
 static const gchar *hostkey_mismatch_data = "* invalid key";
 
 static gboolean
@@ -117,9 +116,6 @@ cockpit_ssh_options_from_env (gchar **env)
   CockpitSshOptions *options = g_new0 (CockpitSshOptions, 1);
   options->knownhosts_data = get_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA",
                                                  NULL);
-  if (g_strcmp0 (options->knownhosts_data, ignore_hosts_data) == 0)
-    options->ignore_hostkey = TRUE;
-
   options->knownhosts_file = get_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE",
                                                   default_knownhosts);
   options->command = get_environment_val (env, "COCKPIT_SSH_BRIDGE_COMMAND", default_command);
@@ -146,9 +142,7 @@ cockpit_ssh_options_to_env (CockpitSshOptions *options,
   env = set_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE",
                              options->knownhosts_file);
 
-  if (options->ignore_hostkey)
-    knownhosts_data = ignore_hosts_data;
-  else if (options->knownhosts_data && options->knownhosts_data[0] == '\0')
+  if (options->knownhosts_data && options->knownhosts_data[0] == '\0')
     knownhosts_data = hostkey_mismatch_data;
   else
     knownhosts_data = options->knownhosts_data;

--- a/src/ws/cockpitauthoptions.h
+++ b/src/ws/cockpitauthoptions.h
@@ -42,7 +42,6 @@ typedef struct {
   const gchar *command;
   gboolean allow_unknown_hosts;
   gboolean supports_hostkey_prompt;
-  gboolean ignore_hostkey;
 } CockpitSshOptions;
 
 CockpitSshOptions * cockpit_ssh_options_from_env   (gchar **env);

--- a/src/ws/test-authoptions.c
+++ b/src/ws/test-authoptions.c
@@ -67,24 +67,21 @@ test_ssh_options (void)
   g_assert_cmpstr (options->command, ==, "cockpit-bridge");
   g_assert_false (options->allow_unknown_hosts);
   g_assert_false (options->supports_hostkey_prompt);
-  g_assert_false (options->ignore_hostkey);
 
   options->knownhosts_data = "";
   options->knownhosts_file = "other-known";
   options->command = "other-command";
-  options->ignore_hostkey = TRUE;
 
   env = cockpit_ssh_options_to_env (options, NULL);
 
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN"), ==, "");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE"), ==, "other-known");
-  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA"), ==, "*");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA"), ==, "* invalid key");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_BRIDGE_COMMAND"), ==, "other-command");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT"), ==, "");
 
   options->allow_unknown_hosts = TRUE;
   options->supports_hostkey_prompt = TRUE;
-  options->ignore_hostkey = FALSE;
 
   g_strfreev (env);
   env = cockpit_ssh_options_to_env (options, NULL);
@@ -107,7 +104,6 @@ test_ssh_options (void)
   env = g_environ_setenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "", TRUE);
 
   options = cockpit_ssh_options_from_env (env);
-  g_assert_true (options->ignore_hostkey);
   g_assert_cmpstr (options->knownhosts_data, ==, "*");
   g_assert_false (options->supports_hostkey_prompt);
   g_assert_true (options->allow_unknown_hosts);
@@ -120,7 +116,6 @@ test_ssh_options (void)
   env = g_environ_setenv (NULL, "COCKPIT_SSH_KNOWN_HOSTS_DATA", "data", TRUE);
   env = g_environ_setenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "1", TRUE);
   options = cockpit_ssh_options_from_env (env);
-  g_assert_false (options->ignore_hostkey);
   g_assert_cmpstr (options->knownhosts_data, ==, "data");
   g_assert_true (options->supports_hostkey_prompt);
   g_assert_true (options->allow_unknown_hosts);
@@ -130,7 +125,6 @@ test_ssh_options (void)
   env = g_environ_setenv (NULL, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "key", TRUE);
   env = g_environ_setenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN", "key", TRUE);
   options = cockpit_ssh_options_from_env (env);
-  g_assert_false (options->ignore_hostkey);
   g_assert_null (options->knownhosts_data);
   g_assert_false (options->supports_hostkey_prompt);
   g_assert_false (options->allow_unknown_hosts);
@@ -139,7 +133,6 @@ test_ssh_options (void)
 
   env = g_environ_setenv (NULL, "COCKPIT_SSH_ALLOW_UNKNOWN", "yes", TRUE);
   options = cockpit_ssh_options_from_env (env);
-  g_assert_false (options->ignore_hostkey);
   g_assert_false (options->supports_hostkey_prompt);
   g_assert_true (options->allow_unknown_hosts);
   g_free (options);


### PR DESCRIPTION
The cockpit.conf file describes which host will be ignored for
host key verification. Just use that directly in cockpit-ssh
rather than passing options around.

@petervo Is it possible to make this work and move one more implementation details of ```cockpit-ssh``` out of ```cockpit-ws```