### PR TITLE
bridge: Origin in Content-Security-Policy and Access-Control-Allow-Origin

### DIFF
--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -143,10 +143,16 @@ void         cockpit_web_response_set_cache_type         (CockpitWebResponse *se
 
 const gchar *  cockpit_web_response_get_url_root         (CockpitWebResponse *response);
 
+const gchar *  cockpit_web_response_get_protocol         (GIOStream *connection,
+                                                          GHashTable *headers);
+
 void           cockpit_web_response_template             (CockpitWebResponse *response,
                                                           const gchar *escaped,
                                                           const gchar **roots,
                                                           GHashTable *values);
+
+gchar *      cockpit_web_response_security_policy        (const gchar *content_security_policy,
+                                                          const gchar *self_origin);
 
 G_END_DECLS
 

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -156,9 +156,53 @@ test_resource_simple (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
+                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
+                           "Access-Control-Allow-Origin: http://localhost\r\n"
+                           "Transfer-Encoding: chunked\r\n"
+                           "Vary: Cookie\r\n"
+                           "\r\n"
+                           "52\r\n"
+                           "<html>\n"
+                           "<head>\n"
+                           "<title>In home dir</title>\n"
+                           "</head>\n"
+                           "<body>In home dir</body>\n"
+                           "</html>\n"
+                           "\r\n"
+                           "0\r\n\r\n", -1);
+  g_bytes_unref (bytes);
+  g_object_unref (response);
+}
+
+static void
+test_resource_simple_host (TestResourceCase *tc,
+                           gconstpointer data)
+{
+  CockpitWebResponse *response;
+  GError *error = NULL;
+  GBytes *bytes;
+  const gchar *url = "/@localhost/another/test.html";
+
+  g_hash_table_insert (tc->headers, g_strdup ("Host"), g_strdup ("my.host"));
+  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL);
+
+  cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.html");
+
+  while (cockpit_web_response_get_state (response) != COCKPIT_WEB_RESPONSE_SENT)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_output_stream_close (G_OUTPUT_STREAM (tc->output), NULL, &error);
+  g_assert_no_error (error);
+
+  bytes = g_memory_output_stream_steal_as_bytes (tc->output);
+  cockpit_assert_bytes_eq (bytes,
+                           "HTTP/1.1 200 OK\r\n"
+                           "Content-Security-Policy: default-src 'self' http://my.host; connect-src 'self' http://my.host ws: wss:\r\n"
+                           "Content-Type: text/html\r\n"
+                           "Cache-Control: no-cache, no-store\r\n"
+                           "Access-Control-Allow-Origin: http://my.host\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "Vary: Cookie\r\n"
                            "\r\n"
@@ -198,9 +242,10 @@ test_resource_language (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
+                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
+                           "Access-Control-Allow-Origin: http://localhost\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "Vary: Cookie\r\n"
                            "\r\n"
@@ -240,9 +285,10 @@ test_resource_cookie (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
+                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
+                           "Access-Control-Allow-Origin: http://localhost\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "Vary: Cookie\r\n"
                            "\r\n"
@@ -441,6 +487,7 @@ test_resource_checksum (TestResourceCase *tc,
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
                            "ETag: \"$060119c2a544d8e5becd0f74f9dcde146b8d99e3-c\"\r\n"
+                           "Access-Control-Allow-Origin: http://localhost\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "Cache-Control: max-age=31556926, public\r\n"
                            "\r\n"
@@ -583,6 +630,7 @@ test_resource_not_modified_new_language (TestResourceCase *tc,
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
                            "ETag: \"$060119c2a544d8e5becd0f74f9dcde146b8d99e3-de\"\r\n"
+                           "Access-Control-Allow-Origin: http://localhost\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "Cache-Control: max-age=31556926, public\r\n"
                            "\r\n"
@@ -626,6 +674,7 @@ test_resource_not_modified_cookie_language (TestResourceCase *tc,
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
                            "ETag: \"$060119c2a544d8e5becd0f74f9dcde146b8d99e3-fr\"\r\n"
+                           "Access-Control-Allow-Origin: http://localhost\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "Cache-Control: max-age=31556926, public\r\n"
                            "\r\n"
@@ -726,9 +775,10 @@ test_resource_language_suffix (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
+                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
+                           "Access-Control-Allow-Origin: http://localhost\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "Vary: Cookie\r\n"
                            "\r\n"
@@ -767,9 +817,10 @@ test_resource_language_fallback (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
+                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
+                           "Access-Control-Allow-Origin: http://localhost\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "Vary: Cookie\r\n"
                            "\r\n"
@@ -808,15 +859,17 @@ test_resource_gzip_encoding (TestResourceCase *tc,
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
                            "Content-Encoding: gzip\r\n"
-                           "Content-Type: text/plain\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
+                           "Access-Control-Allow-Origin: http://localhost\r\n"
+                           "Content-Type: text/plain\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "Vary: Cookie\r\n"
                            "\r\n"
                            "34\r\n"
                            "\x1F\x8B\x08\x08N1\x03U\x00\x03test-file.txt\x00sT(\xCEM\xCC\xC9Q(I-"
-                           ".QH\xCB\xCCI\xE5\x02\x00>PjG\x12\x00\x00\x00\x0D\x0A" "0\x0D\x0A\x0D\x0A",
-                           209);
+                           ".QH\xCB\xCCI\xE5\x02\x00>PjG\x12\x00\x00\x00\x0D\x0A"
+                           "0\x0D\x0A\x0D\x0A",
+                           256);
   g_bytes_unref (bytes);
   g_object_unref (response);
 }
@@ -844,9 +897,10 @@ test_resource_head (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self'; connect-src 'self' ws: wss:\r\n"
+                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws: wss:\r\n"
                            "Content-Type: text/html\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
+                           "Access-Control-Allow-Origin: http://localhost\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "Vary: Cookie\r\n"
                            "\r\n"
@@ -884,6 +938,8 @@ main (int argc,
 
   g_test_add ("/web-channel/resource/simple", TestResourceCase, NULL,
               setup_resource, test_resource_simple, teardown_resource);
+  g_test_add ("/web-channel/resource/simple_host", TestResourceCase, NULL,
+              setup_resource, test_resource_simple_host, teardown_resource);
   g_test_add ("/web-channel/resource/language", TestResourceCase, NULL,
               setup_resource, test_resource_language, teardown_resource);
   g_test_add ("/web-channel/resource/cookie", TestResourceCase, NULL,

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -170,6 +170,12 @@ class TestConnection(MachineCase):
         self.assertIn("s:/CN=localhost", output)
         self.assertIn("1 s:/OU=Intermediate", output)
 
+        # login handler: correct password
+        m.execute("curl -k -c cockpit.jar -s --head --header 'Authorization: Basic {}' https://{}:9090/cockpit/login".format(base64.b64encode("admin:foobar"), m.address))
+        headers = m.execute("curl -k --head -b cockpit.jar -s https://{}:9090/".format(m.address))
+        self.assertIn("default-src 'self' https://{}:9090; connect-src 'self' https://{}:9090 ws: wss".format(m.address, m.address), headers)
+        self.assertIn("Access-Control-Allow-Origin: https://{}:9090".format(m.address), headers)
+
         self.allow_journal_messages(
             ".*Peer failed to perform TLS handshake",
             ".*Error performing TLS handshake: Could not negotiate a supported cipher suite.")


### PR DESCRIPTION
In order to use <iframe> sandbox attribute and split various frames into
their own origin, we have to specify very cleary that these frames are
allowed to access the main origin server side.

This involves two things:

 * Further clarifying all the Content-Security-Policy headers
   to include our own Origin in addition to 'self'
 * Adding Access-Control-Allow-Origin headers with our own Origin