### PR TITLE
bridge: Add "timeout" option to CockpitPeer

### DIFF
--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -336,7 +336,12 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                 if (control.command === "init") {
                     if (source)
                         unregister(source);
-                    source = register(child);
+                    if (control.problem) {
+                        console.warn("child frame failed to init: " + control.problem);
+                        source = null;
+                    } else {
+                        source = register(child);
+                    }
                     if (source) {
                         var reply = $.extend({ }, cockpit.transport.options,
                             { command: "init", "host": source.default_host, "channel-seed": source.channel_seed }

--- a/src/bridge/cockpitpeer.h
+++ b/src/bridge/cockpitpeer.h
@@ -52,6 +52,8 @@ gboolean            cockpit_peer_handle                          (CockpitPeer *p
                                                                   JsonObject *options,
                                                                   GBytes *data);
 
+void                cockpit_peer_reset                           (CockpitPeer *peer);
+
 G_END_DECLS
 
 #endif /* __COCKPIT_PEER_H__ */

--- a/src/bridge/mock-bridge.c
+++ b/src/bridge/mock-bridge.c
@@ -41,6 +41,7 @@
 static gboolean opt_lower;
 static gboolean opt_upper;
 static gboolean opt_show_count;
+static gboolean opt_problem;
 
 static GHashTable *channels;
 
@@ -257,6 +258,12 @@ send_init_command (CockpitTransport *transport)
   json_object_set_string_member (object, "command", "init");
   json_object_set_int_member (object, "version", 1);
 
+  if (opt_problem)
+    {
+      json_object_set_string_member (object, "problem", "canna-do-it");
+      json_object_set_string_member (object, "another-field", "extra");
+    }
+
   bytes = cockpit_json_write_bytes (object);
   json_object_unref (object);
 
@@ -290,6 +297,7 @@ main (int argc,
     { "lower", 0, 0, G_OPTION_ARG_NONE, &opt_lower, "Lower case channel type", NULL },
     { "count", 0, 0, G_OPTION_ARG_NONE, &opt_show_count, "Show open channels count in ready messages", NULL },
     { "upper", 0, 0, G_OPTION_ARG_NONE, &opt_upper, "Upper case channel type", NULL },
+    { "problem", 0, 0, G_OPTION_ARG_NONE, &opt_problem, "Set a problem in \"init\" message", NULL },
     { NULL }
   };
 


### PR DESCRIPTION
This is a step towards having the ```cockpit-bridge``` be able to directly route to ```cockpit-ssh``` instances.