### PR TITLE
test: Fix vm-prep for running in a docker container

### DIFF
--- a/test/vm-prep
+++ b/test/vm-prep
@@ -42,7 +42,14 @@ silent()
 
 prepare()
 {
-	systemctl start libvirtd
+	if ! virsh list >/dev/null 2>&1; then
+		if systemctl status >/dev/null 2>&1; then
+			systemctl start libvirtd
+		else
+			libvirtd -d
+			virtlogd -d
+		fi
+	fi
 
 	if silent $VIRSH net-info $NETWORK_NAME; then
 		$VIRSH net-destroy $NETWORK_NAME || true
@@ -83,11 +90,11 @@ EOF
   done
 
     # We really want nested virtualization
-    if [ -d /sys/module/kvm_intel -a ! -f /etc/modprobe.d/kvm-intel.conf ]; then
+    if [ -d /sys/module/kvm_intel -a -d /etc/modprobe.d -a ! -f /etc/modprobe.d/kvm-intel.conf ]; then
         echo "options kvm-intel nested=1" > /etc/modprobe.d/kvm-intel.conf
         rmmod kvm-intel && modprobe kvm-intel || true
     fi
-    if [ -d /sys/module/kvm_amd -a ! -f /etc/modprobe.d/kvm-amd.conf ]; then
+    if [ -d /sys/module/kvm_amd -a -d /etc/modprobe.d -a ! -f /etc/modprobe.d/kvm-amd.conf ]; then
         echo "options kvm-amd nested=1" > /etc/modprobe.d/kvm-amd.conf
         rmmod kvm-amd && modprobe kvm-amd || true
     fi


### PR DESCRIPTION
We don't have systemd running in a docker container, so start libvirtd
and virtlogd directly in that case.

Refine the check for the modprobe.d configuration.

---
We don't run `vm-prep` anywhere in CI, so this needs to be tested manually. This is a fixed and refined version of @stefwalter 's [initial work](https://github.com/stefwalter/cockpit/tree/clean-staging-tests-oci), and I tested it in a clean fedora 25 docker container (no init) as well as on my host system (systemd as usual).