### PR TITLE
ssh: Split out CockpitSshOptions into ssh code

### DIFF
--- a/src/common/cockpitconf.h
+++ b/src/common/cockpitconf.h
@@ -24,6 +24,8 @@
 
 G_BEGIN_DECLS
 
+#define COCKPIT_CONF_SSH_SECTION "Ssh-Login"
+
 const gchar *   cockpit_conf_string           (const gchar *section,
                                                const gchar *field);
 

--- a/src/ssh/Makefile-ssh.am
+++ b/src/ssh/Makefile-ssh.am
@@ -8,6 +8,8 @@ libcockpit_ssh_a_SOURCES = \
 	src/ws/cockpitauthoptions.c \
 	src/ws/cockpitauthprocess.h \
 	src/ws/cockpitauthprocess.c \
+	src/ssh/cockpitsshoptions.c \
+	src/ssh/cockpitsshoptions.h \
 	src/ssh/cockpitsshrelay.h \
 	src/ssh/cockpitsshrelay.c \
 	src/ssh/cockpitsshservice.h \
@@ -57,9 +59,14 @@ mock_sshd_CFLAGS = \
 	$(NULL)
 
 SSH_CHECKS = \
+	test-sshoptions \
 	test-sshtransport \
 	test-sshservice \
 	$(NULL)
+
+test_sshoptions_CFLAGS = $(cockpit_ssh_CFLAGS)
+test_sshoptions_SOURCES = src/ssh/test-sshoptions.c
+test_sshoptions_LDADD = libcockpit-ssh.a $(cockpit_ssh_LDADD)
 
 test_sshtransport_SOURCES = \
 	src/ssh/test-sshtransport.c \

--- a/src/ssh/cockpitsshoptions.c
+++ b/src/ssh/cockpitsshoptions.c
@@ -1,0 +1,152 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/cockpitconf.h"
+
+#include "cockpitsshoptions.h"
+
+static const gchar *default_knownhosts = PACKAGE_SYSCONF_DIR "/ssh/ssh_known_hosts";
+static const gchar *default_command = "cockpit-bridge";
+static const gchar *ignore_hosts_data = "*";
+static const gchar *hostkey_mismatch_data = "* invalid key";
+
+static gboolean
+has_environment_val (gchar **env,
+                     const gchar *name)
+{
+  const gchar *v = g_environ_getenv (env, name);
+  return v != NULL && v[0] != '\0';
+}
+
+static const gchar *
+get_environment_val (gchar **env,
+                     const gchar *name,
+                     const gchar *defawlt)
+{
+  if (has_environment_val (env, name))
+    return g_environ_getenv (env, name);
+  else
+    return defawlt;
+}
+
+static gchar **
+set_environment_val (gchar **env,
+                     const gchar *name,
+                     const gchar *val)
+{
+  return g_environ_setenv (env, name, val ? val : "", TRUE);
+}
+
+static gboolean
+get_environment_bool (gchar **env,
+                      const gchar *name,
+                      gboolean defawlt)
+{
+  const gchar *value = get_environment_val (env, name, NULL);
+
+  if (!value)
+    return defawlt;
+
+  return g_strcmp0 (value, "yes") == 0 ||
+         g_strcmp0 (value, "true") == 0 ||
+         g_strcmp0 (value, "1") == 0;
+}
+
+static gchar **
+set_environment_bool (gchar **env,
+                      const gchar *name,
+                      gboolean val)
+{
+  return g_environ_setenv (env, name, val ? "1" : "", TRUE);
+}
+
+static gboolean
+get_allow_unknown_hosts (gchar **env)
+{
+  const gchar *remote_peer = g_environ_getenv (env, "COCKPIT_REMOTE_PEER");
+
+  if (g_strcmp0 (remote_peer, "127.0.0.1") == 0 ||
+      g_strcmp0 (remote_peer, "::1") == 0 ||
+      cockpit_conf_bool (COCKPIT_CONF_SSH_SECTION, "allowUnknown", FALSE))
+    return TRUE;
+
+  return get_environment_bool (env, "COCKPIT_SSH_ALLOW_UNKNOWN", FALSE);
+}
+
+CockpitSshOptions *
+cockpit_ssh_options_from_env (gchar **env)
+{
+
+  CockpitSshOptions *options = g_new0 (CockpitSshOptions, 1);
+  options->knownhosts_data = get_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA",
+                                                 NULL);
+  if (g_strcmp0 (options->knownhosts_data, ignore_hosts_data) == 0)
+    options->ignore_hostkey = TRUE;
+
+  options->knownhosts_file = get_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE",
+                                                  default_knownhosts);
+  options->command = get_environment_val (env, "COCKPIT_SSH_BRIDGE_COMMAND", default_command);
+  options->supports_hostkey_prompt = get_environment_bool (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", FALSE);
+
+  if (options->knownhosts_data != NULL)
+    options->allow_unknown_hosts = TRUE;
+  else
+    options->allow_unknown_hosts = get_allow_unknown_hosts (env);
+
+  return options;
+}
+
+gchar **
+cockpit_ssh_options_to_env (CockpitSshOptions *options,
+                            gchar **env)
+{
+  const gchar *knownhosts_data;
+
+  env = set_environment_bool (env, "COCKPIT_SSH_ALLOW_UNKNOWN",
+                              options->allow_unknown_hosts);
+  env = set_environment_bool (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT",
+                              options->supports_hostkey_prompt);
+  env = set_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE",
+                             options->knownhosts_file);
+
+  if (options->ignore_hostkey)
+    knownhosts_data = ignore_hosts_data;
+  else if (options->knownhosts_data && options->knownhosts_data[0] == '\0')
+    knownhosts_data = hostkey_mismatch_data;
+  else
+    knownhosts_data = options->knownhosts_data;
+
+  env = set_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA",
+                             knownhosts_data);
+
+  /* Don't reset these vars unless we have values for them */
+  if (options->command)
+    {
+      env = set_environment_val (env, "COCKPIT_SSH_BRIDGE_COMMAND",
+                                 options->command);
+    }
+
+  return env;
+}
+
+const gchar *
+cockpit_get_default_knownhosts (void)
+{
+  return default_knownhosts;
+}

--- a/src/ssh/cockpitsshoptions.h
+++ b/src/ssh/cockpitsshoptions.h
@@ -17,22 +17,28 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COCKPIT_AUTH_OPTIONS_H__
-#define __COCKPIT_AUTH_OPTIONS_H__
+#ifndef __COCKPIT_SSH_OPTIONS_H__
+#define __COCKPIT_SSH_OPTIONS_H__
 
 #include <gio/gio.h>
 
 G_BEGIN_DECLS
 
 typedef struct {
-  const gchar *remote_peer;
-  const gchar *auth_type;
-} CockpitAuthOptions;
+  const gchar *knownhosts_data;
+  const gchar *knownhosts_file;
+  const gchar *command;
+  gboolean allow_unknown_hosts;
+  gboolean supports_hostkey_prompt;
+  gboolean ignore_hostkey;
+} CockpitSshOptions;
 
-CockpitAuthOptions * cockpit_auth_options_from_env  (gchar **env);
+CockpitSshOptions * cockpit_ssh_options_from_env   (gchar **env);
 
-gchar **             cockpit_auth_options_to_env    (CockpitAuthOptions *options,
-                                                     gchar **env);
+gchar **            cockpit_ssh_options_to_env     (CockpitSshOptions *options,
+                                                    gchar **env);
+
+const gchar *       cockpit_get_default_knownhosts  (void);
 
 G_END_DECLS
 

--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -33,6 +33,7 @@
 #include "ws/cockpitauthoptions.h"
 
 #include "cockpitsshrelay.h"
+#include "cockpitsshoptions.h"
 
 #include <libssh/libssh.h>
 #include <libssh/callbacks.h>
@@ -1221,7 +1222,7 @@ cockpit_ssh_connect (CockpitSshData *data,
   g_debug ("%s: connected", data->logname);
 
   /* This is a single host, for which we have been told to ignore the host key */
-  ignore_hostkey = cockpit_conf_string (SSH_SECTION, "host");
+  ignore_hostkey = cockpit_conf_string (COCKPIT_CONF_SSH_SECTION, "host");
   if (!ignore_hostkey)
     ignore_hostkey = "127.0.0.1";
 

--- a/src/ssh/cockpitsshtransport.c
+++ b/src/ssh/cockpitsshtransport.c
@@ -26,6 +26,7 @@
 #define G_LOG_DOMAIN "cockpit-protocol"
 
 #include "cockpitsshtransport.h"
+#include "cockpitsshoptions.h"
 
 #include "common/cockpitauthorize.h"
 #include "common/cockpitconf.h"
@@ -490,13 +491,13 @@ cockpit_ssh_transport_constructed (GObject *object)
   g_return_if_fail (self->host != NULL);
 
   /* How long to wait for the auth process to send some data */
-  pipe_timeout = cockpit_conf_guint (SSH_SECTION, "timeout",
+  pipe_timeout = cockpit_conf_guint (COCKPIT_CONF_SSH_SECTION, "timeout",
                                      cockpit_ssh_process_timeout, 1, 999);
   /* How long to wait for a response from the client to a auth prompt */
-  idle_timeout = cockpit_conf_guint (SSH_SECTION, "response-timeout",
+  idle_timeout = cockpit_conf_guint (COCKPIT_CONF_SSH_SECTION, "response-timeout",
                                      cockpit_ssh_response_timeout, 1, 999);
   /* The wanted authfd for this command, default is 3 */
-  wanted_fd = cockpit_conf_guint (SSH_SECTION, "authFD", 3, 1024, 3);
+  wanted_fd = cockpit_conf_guint (COCKPIT_CONF_SSH_SECTION, "authFD", 3, 1024, 3);
 
   self->auth_process = g_object_new (COCKPIT_TYPE_AUTH_PROCESS,
                                    "pipe-timeout", pipe_timeout,

--- a/src/ssh/test-sshoptions.c
+++ b/src/ssh/test-sshoptions.c
@@ -1,0 +1,156 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "common/cockpitconf.h"
+#include "common/cockpittest.h"
+
+#include "cockpitsshoptions.h"
+
+/* Mock override these from other files */
+extern const gchar *cockpit_config_file;
+
+static void
+test_ssh_options (void)
+{
+  gchar **env = NULL;
+  CockpitSshOptions *options = NULL;
+
+  options = cockpit_ssh_options_from_env (env);
+  g_assert_null (options->knownhosts_data);
+  g_assert_cmpstr (options->knownhosts_file, ==, PACKAGE_SYSCONF_DIR "/ssh/ssh_known_hosts");
+  g_assert_cmpstr (options->command, ==, "cockpit-bridge");
+  g_assert_false (options->allow_unknown_hosts);
+  g_assert_false (options->supports_hostkey_prompt);
+  g_assert_false (options->ignore_hostkey);
+
+  options->knownhosts_data = "";
+  options->knownhosts_file = "other-known";
+  options->command = "other-command";
+  options->ignore_hostkey = TRUE;
+
+  env = cockpit_ssh_options_to_env (options, NULL);
+
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN"), ==, "");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE"), ==, "other-known");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA"), ==, "*");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_BRIDGE_COMMAND"), ==, "other-command");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT"), ==, "");
+
+  options->allow_unknown_hosts = TRUE;
+  options->supports_hostkey_prompt = TRUE;
+  options->ignore_hostkey = FALSE;
+
+  g_strfreev (env);
+  env = cockpit_ssh_options_to_env (options, NULL);
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA"), ==, "* invalid key");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN"), ==, "1");
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT"), ==, "1");
+
+  options->knownhosts_data = "key";
+  g_strfreev (env);
+  env = cockpit_ssh_options_to_env (options, NULL);
+  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA"), ==, "key");
+  g_strfreev (env);
+  g_free (options);
+
+  /* Start with a clean env */
+  env = g_environ_setenv (NULL, "COCKPIT_SSH_KNOWN_HOSTS_DATA", "*", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE", "other-known", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_BRIDGE_COMMAND", "other-command", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN", "", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "", TRUE);
+
+  options = cockpit_ssh_options_from_env (env);
+  g_assert_true (options->ignore_hostkey);
+  g_assert_cmpstr (options->knownhosts_data, ==, "*");
+  g_assert_false (options->supports_hostkey_prompt);
+  g_assert_true (options->allow_unknown_hosts);
+  g_assert_cmpstr (options->knownhosts_file, ==, "other-known");
+  g_assert_cmpstr (options->command, ==, "other-command");
+
+  g_free (options);
+  g_strfreev (env);
+
+  env = g_environ_setenv (NULL, "COCKPIT_SSH_KNOWN_HOSTS_DATA", "data", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "1", TRUE);
+  options = cockpit_ssh_options_from_env (env);
+  g_assert_false (options->ignore_hostkey);
+  g_assert_cmpstr (options->knownhosts_data, ==, "data");
+  g_assert_true (options->supports_hostkey_prompt);
+  g_assert_true (options->allow_unknown_hosts);
+  g_free (options);
+  g_strfreev (env);
+
+  env = g_environ_setenv (NULL, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "key", TRUE);
+  env = g_environ_setenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN", "key", TRUE);
+  options = cockpit_ssh_options_from_env (env);
+  g_assert_false (options->ignore_hostkey);
+  g_assert_null (options->knownhosts_data);
+  g_assert_false (options->supports_hostkey_prompt);
+  g_assert_false (options->allow_unknown_hosts);
+  g_free (options);
+  g_strfreev (env);
+
+  env = g_environ_setenv (NULL, "COCKPIT_SSH_ALLOW_UNKNOWN", "yes", TRUE);
+  options = cockpit_ssh_options_from_env (env);
+  g_assert_false (options->ignore_hostkey);
+  g_assert_false (options->supports_hostkey_prompt);
+  g_assert_true (options->allow_unknown_hosts);
+  g_free (options);
+  g_strfreev (env);
+
+  env = g_environ_setenv (NULL, "COCKPIT_REMOTE_PEER", "127.0.0.1", TRUE);
+  options = cockpit_ssh_options_from_env (env);
+  g_assert_true (options->allow_unknown_hosts);
+  g_free (options);
+  g_strfreev (env);
+
+  env = g_environ_setenv (NULL, "COCKPIT_REMOTE_PEER", "::1", TRUE);
+  options = cockpit_ssh_options_from_env (env);
+  g_assert_true (options->allow_unknown_hosts);
+  g_free (options);
+  g_strfreev (env);
+}
+
+static void
+test_ssh_options_alt_conf (void)
+{
+  CockpitSshOptions *options = NULL;
+
+  cockpit_config_file = SRCDIR "/src/ws/mock-config/cockpit/cockpit-alt.conf";
+  cockpit_conf_cleanup ();
+
+  options = cockpit_ssh_options_from_env (NULL);
+  g_assert_true (options->allow_unknown_hosts);
+  g_free (options);
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+  cockpit_test_init (&argc, &argv);
+
+  g_test_add_func ("/ssh-options/basic", test_ssh_options);
+  g_test_add_func ("/ssh-options/alt-conf", test_ssh_options_alt_conf);
+
+  return g_test_run ();
+}

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -829,11 +829,11 @@ cockpit_auth_spawn_login_async (CockpitAuth *self,
     }
 
   if (host)
-    section = SSH_SECTION;
+    section = COCKPIT_CONF_SSH_SECTION;
   else if (self->login_loopback && g_strcmp0 (type, "basic") == 0)
-    section = SSH_SECTION;
+    section = COCKPIT_CONF_SSH_SECTION;
   else if (g_strcmp0 (action, ACTION_SSH) == 0)
-    section = SSH_SECTION;
+    section = COCKPIT_CONF_SSH_SECTION;
   else
     section = type;
 
@@ -856,12 +856,12 @@ cockpit_auth_spawn_login_async (CockpitAuth *self,
     authorized = "";
   ad->authorize_password = (strstr (authorized, "password") != NULL);
 
-  if (g_strcmp0 (section, SSH_SECTION) == 0)
+  if (g_strcmp0 (section, COCKPIT_CONF_SSH_SECTION) == 0)
     {
       ad->is_ssh = TRUE;
 
       if (!host)
-        host = type_option (SSH_SECTION, "host", "127.0.0.1");
+        host = type_option (COCKPIT_CONF_SSH_SECTION, "host", "127.0.0.1");
 
       program_default = cockpit_ws_ssh_program;
     }

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -79,9 +79,6 @@ static guint sig__idling = 0;
 /* Tristate tracking whether gssapi works properly */
 static gint gssapi_available = -1;
 
-/* Used by test to overide known hosts */
-const gchar *cockpit_ws_known_hosts = NULL;
-
 G_DEFINE_TYPE (CockpitAuth, cockpit_auth, G_TYPE_OBJECT)
 
 typedef struct {
@@ -780,7 +777,6 @@ cockpit_auth_spawn_login_async (CockpitAuth *self,
   GSimpleAsyncResult *result;
   AuthData *ad = NULL;
   CockpitAuthOptions *options = NULL;
-  CockpitSshOptions *ssh_options = NULL;
   GBytes *authorization = NULL;
 
   gchar *type = NULL;
@@ -864,15 +860,10 @@ cockpit_auth_spawn_login_async (CockpitAuth *self,
     {
       ad->is_ssh = TRUE;
 
-      ssh_options = g_new0 (CockpitSshOptions, 1);
-      ssh_options->supports_hostkey_prompt = TRUE;
-      ssh_options->knownhosts_file = cockpit_ws_known_hosts;
-
       if (!host)
         host = type_option (SSH_SECTION, "host", "127.0.0.1");
 
       program_default = cockpit_ws_ssh_program;
-      env = cockpit_ssh_options_to_env (ssh_options, env);
     }
   else
     {
@@ -910,7 +901,6 @@ out:
   g_free (application);
   g_strfreev (env);
   g_free (options);
-  g_free (ssh_options);
 
   if (ad)
     auth_data_unref (ad);

--- a/src/ws/cockpitws.h
+++ b/src/ws/cockpitws.h
@@ -30,7 +30,6 @@ G_BEGIN_DECLS
 extern const gchar *cockpit_ws_session_program;
 extern const gchar *cockpit_ws_ssh_program;
 extern const gchar *cockpit_ws_bridge_program;
-extern const gchar *cockpit_ws_known_hosts;
 extern const gchar *cockpit_ws_default_host_header;
 extern gint cockpit_ws_specific_ssh_port;
 extern guint cockpit_ws_ping_interval;

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -120,6 +120,8 @@ main (int argc,
 
   g_setenv ("G_TLS_GNUTLS_PRIORITY", "SECURE128:%LATEST_RECORD_VERSION:-VERS-SSL3.0:-VERS-TLS1.0", FALSE);
 
+  g_setenv ("COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "1", TRUE);
+
   g_type_init ();
 
   memset (&data, 0, sizeof (data));

--- a/src/ws/test-authoptions.c
+++ b/src/ws/test-authoptions.c
@@ -55,131 +55,13 @@ test_auth_options (void)
   g_strfreev (env);
 }
 
-static void
-test_ssh_options (void)
-{
-  gchar **env = NULL;
-  CockpitSshOptions *options = NULL;
-
-  options = cockpit_ssh_options_from_env (env);
-  g_assert_null (options->knownhosts_data);
-  g_assert_cmpstr (options->knownhosts_file, ==, PACKAGE_SYSCONF_DIR "/ssh/ssh_known_hosts");
-  g_assert_cmpstr (options->command, ==, "cockpit-bridge");
-  g_assert_false (options->allow_unknown_hosts);
-  g_assert_false (options->supports_hostkey_prompt);
-  g_assert_false (options->ignore_hostkey);
-
-  options->knownhosts_data = "";
-  options->knownhosts_file = "other-known";
-  options->command = "other-command";
-  options->ignore_hostkey = TRUE;
-
-  env = cockpit_ssh_options_to_env (options, NULL);
-
-  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN"), ==, "");
-  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE"), ==, "other-known");
-  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA"), ==, "*");
-  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_BRIDGE_COMMAND"), ==, "other-command");
-  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT"), ==, "");
-
-  options->allow_unknown_hosts = TRUE;
-  options->supports_hostkey_prompt = TRUE;
-  options->ignore_hostkey = FALSE;
-
-  g_strfreev (env);
-  env = cockpit_ssh_options_to_env (options, NULL);
-  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA"), ==, "* invalid key");
-  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN"), ==, "1");
-  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT"), ==, "1");
-
-  options->knownhosts_data = "key";
-  g_strfreev (env);
-  env = cockpit_ssh_options_to_env (options, NULL);
-  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA"), ==, "key");
-  g_strfreev (env);
-  g_free (options);
-
-  /* Start with a clean env */
-  env = g_environ_setenv (NULL, "COCKPIT_SSH_KNOWN_HOSTS_DATA", "*", TRUE);
-  env = g_environ_setenv (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE", "other-known", TRUE);
-  env = g_environ_setenv (env, "COCKPIT_SSH_BRIDGE_COMMAND", "other-command", TRUE);
-  env = g_environ_setenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN", "", TRUE);
-  env = g_environ_setenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "", TRUE);
-
-  options = cockpit_ssh_options_from_env (env);
-  g_assert_true (options->ignore_hostkey);
-  g_assert_cmpstr (options->knownhosts_data, ==, "*");
-  g_assert_false (options->supports_hostkey_prompt);
-  g_assert_true (options->allow_unknown_hosts);
-  g_assert_cmpstr (options->knownhosts_file, ==, "other-known");
-  g_assert_cmpstr (options->command, ==, "other-command");
-
-  g_free (options);
-  g_strfreev (env);
-
-  env = g_environ_setenv (NULL, "COCKPIT_SSH_KNOWN_HOSTS_DATA", "data", TRUE);
-  env = g_environ_setenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "1", TRUE);
-  options = cockpit_ssh_options_from_env (env);
-  g_assert_false (options->ignore_hostkey);
-  g_assert_cmpstr (options->knownhosts_data, ==, "data");
-  g_assert_true (options->supports_hostkey_prompt);
-  g_assert_true (options->allow_unknown_hosts);
-  g_free (options);
-  g_strfreev (env);
-
-  env = g_environ_setenv (NULL, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "key", TRUE);
-  env = g_environ_setenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN", "key", TRUE);
-  options = cockpit_ssh_options_from_env (env);
-  g_assert_false (options->ignore_hostkey);
-  g_assert_null (options->knownhosts_data);
-  g_assert_false (options->supports_hostkey_prompt);
-  g_assert_false (options->allow_unknown_hosts);
-  g_free (options);
-  g_strfreev (env);
-
-  env = g_environ_setenv (NULL, "COCKPIT_SSH_ALLOW_UNKNOWN", "yes", TRUE);
-  options = cockpit_ssh_options_from_env (env);
-  g_assert_false (options->ignore_hostkey);
-  g_assert_false (options->supports_hostkey_prompt);
-  g_assert_true (options->allow_unknown_hosts);
-  g_free (options);
-  g_strfreev (env);
-
-  env = g_environ_setenv (NULL, "COCKPIT_REMOTE_PEER", "127.0.0.1", TRUE);
-  options = cockpit_ssh_options_from_env (env);
-  g_assert_true (options->allow_unknown_hosts);
-  g_free (options);
-  g_strfreev (env);
-
-  env = g_environ_setenv (NULL, "COCKPIT_REMOTE_PEER", "::1", TRUE);
-  options = cockpit_ssh_options_from_env (env);
-  g_assert_true (options->allow_unknown_hosts);
-  g_free (options);
-  g_strfreev (env);
-}
-
-static void
-test_ssh_options_alt_conf (void)
-{
-  CockpitSshOptions *options = NULL;
-
-  cockpit_config_file = SRCDIR "/src/ws/mock-config/cockpit/cockpit-alt.conf";
-  cockpit_conf_cleanup ();
-
-  options = cockpit_ssh_options_from_env (NULL);
-  g_assert_true (options->allow_unknown_hosts);
-  g_free (options);
-}
-
 int
 main (int argc,
       char *argv[])
 {
   cockpit_test_init (&argc, &argv);
 
-  g_test_add_func ("/auth-options/auth-options", test_auth_options);
-  g_test_add_func ("/auth-options/ssh-options", test_ssh_options);
-  g_test_add_func ("/auth-options/ssh-options-alt-conf", test_ssh_options_alt_conf);
+  g_test_add_func ("/auth-options/basic", test_auth_options);
 
   return g_test_run ();
 }

--- a/src/ws/test-authssh.c
+++ b/src/ws/test-authssh.c
@@ -410,8 +410,8 @@ main (int argc,
       char *argv[])
 {
   cockpit_ws_ssh_program = BUILDDIR "/cockpit-ssh";
-  cockpit_ws_known_hosts = SRCDIR "/src/ssh/mock_known_hosts";
 
+  g_setenv ("COCKPIT_SSH_KNOWN_HOSTS_FILE", SRCDIR "/src/ssh/mock_known_hosts", TRUE);
   g_setenv ("COCKPIT_SSH_BRIDGE_COMMAND", BUILDDIR "/cockpit-bridge", TRUE);
 
   cockpit_test_init (&argc, &argv);


### PR DESCRIPTION
This allows us to have less code in cockpit-ws, and moves it to where it's actually used.
