### PR TITLE
systemd: Use cockpit.localStorage instead of window

### DIFF
--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -237,7 +237,7 @@ PageServer.prototype = {
         cockpit.file("/etc/motd").watch(function (content) {
             if (content)
                 content = $.trim(content);
-            if (content && content != window.localStorage.getItem('dismissed-motd')) {
+            if (content && content != cockpit.localStorage.getItem('dismissed-motd')) {
                 $('#motd').text(content);
                 $('#motd-box').show();
             } else {
@@ -248,7 +248,7 @@ PageServer.prototype = {
         });
 
         $('#motd-box button.close').click(function () {
-            window.localStorage.setItem('dismissed-motd', $('#motd').text());
+            cockpit.localStorage.setItem('dismissed-motd', $('#motd').text());
             $('#motd-box').hide();
         });
 


### PR DESCRIPTION
Allows storage keys to be prefixed.