### PR TITLE
Include cerbot certificate concatenation example

### DIFF
--- a/doc/guide/https.xml
+++ b/doc/guide/https.xml
@@ -63,12 +63,22 @@ MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCyOJ5garOYw0sm
 $ sudo remotectl certificate
 </programlisting>
 
-    <para>If using <code>certmonger</code> to manage certificates, following command can
-    be used to automatically prepare concatenated .cert file:</para>
+    <para>If using <code>certbot</code> to manage certificates, the following command
+    can be used to automatically prepare concatenated .cert file:</para>
 
     <programlisting>
-CERT_FILE=/etc/pki/tls/certs/${hostname).pem
-KEY_FILE=/etc/pki/tls/private/${hostname).key
+CERT_FILE=/etc/letsencrypt/live/${hostname}/fullchain.pem
+KEY_FILE=/etc/letsencrypt/live/${hostname}/privkey.pem
+
+getcert request -f ${CERT_FILE} -k ${KEY_FILE} -C "sed -n w/etc/cockpit/ws-certs.d/50-from-certbot.cert ${CERT_FILE} ${KEY_FILE}"
+    </programlisting>
+
+    <para>If using <code>certmonger</code> to manage certificates, the following command
+    can be used to automatically prepare concatenated .cert file:</para>
+
+    <programlisting>
+CERT_FILE=/etc/pki/tls/certs/${hostname}.pem
+KEY_FILE=/etc/pki/tls/private/${hostname}.key
 
 getcert request -f ${CERT_FILE} -k ${KEY_FILE} -C "sed -n w/etc/cockpit/ws-certs.d/50-from-certmonger.cert ${CERT_FILE} ${KEY_FILE}"
     </programlisting>


### PR DESCRIPTION
Seeing [how popular Let’s Encrypt has become](https://trends.builtwith.com/ssl/root-authority), I thought this additional example would be useful to many.

Should there be info about regenerating the concatenated certificate every night with a cronjob? …