### PR TITLE
Image refresh for debian-8

### DIFF
--- a/test/images/debian-8
+++ b/test/images/debian-8
@@ -1,1 +1,1 @@
-debian-8-e11e243f88bb58c17d7a964cd9bc0a62a47ea0bb.qcow2
+debian-8-fbf89ea1ec1dcbc64fa3cbe3c0af4409ea9936d2.qcow2


### PR DESCRIPTION
Image creation for debian-8 in process on cockpit-11.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-8-2017-04-05/