### PR TITLE
Debian packaging updates

### DIFF
--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+adduser --system --group --home / --no-create-home cockpit-ws
+
+if ! dpkg-statoverride --list /usr/lib/cockpit/cockpit-session >/dev/null; then
+    dpkg-statoverride --update --add root cockpit-ws 4750 /usr/lib/cockpit/cockpit-session
+fi
+
 #DEBHELPER#
 
 # restart cockpit.service on package upgrades, if it's already running

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -43,11 +43,11 @@ Depends: ${misc:Depends},
          cockpit-ws (>= ${source:Version}),
          cockpit-ws (<< ${source:Version}.1~),
          cockpit-system (= ${binary:Version}),
-Recommends: cockpit-docker (= ${binary:Version}),
-            cockpit-storaged (= ${binary:Version}),
+Recommends: cockpit-storaged (= ${binary:Version}),
             cockpit-networkmanager (= ${binary:Version})
 Suggests: cockpit-doc (= ${binary:Version}),
           cockpit-pcp (>= ${source:Version}),
+          cockpit-docker (= ${binary:Version}),
           xdg-utils,
 Description: User interface for Linux servers
  Cockpit runs in a browser and can manage your network of GNU/Linux

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -157,7 +157,8 @@ Package: cockpit-ws
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
-         glib-networking
+         glib-networking,
+         adduser,
 Description: Cockpit Web Service
  The Cockpit Web Service listens on the network, and authenticates
  users.

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -39,6 +39,7 @@ override_dh_clean:
 override_dh_auto_configure: debian/git-patches-applied
 	dh_auto_configure -- \
 		--with-networkmanager-needs-root=yes \
+		--with-cockpit-user=cockpit-ws \
 		--with-pamdir=/lib/$(DEB_HOST_MULTIARCH)/security \
 		--libexecdir=/usr/lib/cockpit $(CONFIG_OPTIONS)
 
@@ -56,9 +57,6 @@ override_dh_systemd_start:
 override_dh_install:
 	dh_install --list-missing -Xusr/src/debug
 	make install-tests DESTDIR=debian/cockpit-tests
-
-override_dh_fixperms:
-	dh_fixperms -Xcockpit-session
 
 override_dh_gencontrol:
 	dh_gencontrol -- -Vbridge:minversion="$(shell tools/min-base-version)"

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -9,7 +9,7 @@ ifneq ($(shell dpkg -s libpcp3-dev >/dev/null 2>&1 && echo yes),yes)
 endif
 
 %:
-	dh $@ --with=systemd
+	dh $@ --with=systemd,autoreconf
 
 # Apply patches using git in order to support binary patches. Note that
 # we also reset mtimes since patches should be "complete" and include both

--- a/tools/debian/tests/avocado
+++ b/tools/debian/tests/avocado
@@ -1,5 +1,8 @@
 #!/bin/sh
 set -eu
+# Ubuntu still creates this legacy group by default, breaks useradd
+sudo delgroup --quiet --system admin || true
+
 # test expects this user and Fedora group "wheel"
 addgroup wheel
 useradd -m -U -c Administrator -G sudo,wheel -s /bin/bash admin


### PR DESCRIPTION
Cockpit was synced to Ubuntu now, and its [autopkgtest fails](http://autopkgtest.ubuntu.com/packages/c/cockpit). When I wrote it, I only tested this on Debian. Now fixed and tested on both.

cockpit-ws still ran as root, unlike wit the RPMs where it runs as unprivileged system user. Privilege reduction is rather important for security, so bring that in line with cockpit.spec.

The third commit lowers the cockpit-docker Recommends: for the "cockpit" metapackage. Right now, a failing `apt-get install cockpit` (due to failing installation of docker.io) gives a bad first impression, even though it's not really cockpit's fault. But [docker.io](https://tracker.debian.org/pkg/docker.io) has 8 (!) release-critical bugs in unstable  and hasn't been in Debian testing for a fair while. On Ubuntu, docker.io is much less popular than in the Fedora/RH world (LXC/lxd is preferred there), and docker has a fair share of dependencies. So "Suggests:" sounds more appropriate to me, packaging UIs will offer it as extending functionality, but I don't see much reason to always install it by default everywhere.