### PR TITLE
update storage tests, move debian-testing from storaged to udisks

### DIFF
--- a/test/images/debian-testing
+++ b/test/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-b70707f7707b80648eed8777df3c55bbc6cf5192.qcow2
+debian-testing-a2b7c8d3fe2b28510404a84a7bbb514376009285.qcow2

--- a/test/images/scripts/debian-testing.setup
+++ b/test/images/scripts/debian-testing.setup
@@ -24,10 +24,13 @@ network-manager \
 policykit-1 \
 realmd \
 selinux-basics \
-storaged \
-storaged-lvm2 \
 thin-provisioning-tools \
 xdg-utils \
+"
+
+# modern udisks (after re-merging storaged)
+COCKPIT_DEPS_EXPERIMENTAL="\
+udisks2 \
 "
 
 # We also install the packages necessary to join a FreeIPA domain so
@@ -41,14 +44,15 @@ packagekit \
 TEST_PACKAGES="\
 curl \
 gdb \
+mdadm \
 systemd-coredump \
 virtinst \
+xfsprogs \
 "
 
 useradd -m -U -c Administrator -G sudo -s /bin/bash admin
 echo admin:foobar | chpasswd
 
-# For storaged
 echo "deb http://deb.debian.org/debian experimental main" >/etc/apt/sources.list.d/experimental.list
 # FIXME: we need to enable jessie-backports until docker.io gets back into testing
 echo "deb http://deb.debian.org/debian jessie-backports main" >/etc/apt/sources.list.d/jessie-backports.list
@@ -56,6 +60,7 @@ apt-get -y update
 
 export DEBIAN_FRONTEND=noninteractive
 eatmydata apt-get -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
+eatmydata apt-get -y install -t experimental $COCKPIT_DEPS_EXPERIMENTAL
 
 # Prepare for building
 #

--- a/test/images/scripts/debian-testing.setup
+++ b/test/images/scripts/debian-testing.setup
@@ -88,7 +88,7 @@ systemctl restart docker || journalctl -u docker
 /var/lib/testvm/docker-images.setup
 
 # in case there are unnecessary packages
-apt-get -y autoremove || true
+eatmydata apt-get -y autoremove || true
 
 # reduce image size
 apt-get clean

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -23,7 +23,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for LVM", "debian-8", "ubuntu-1604")
+@skipImage("UDisks doesn't have support for LVM", "debian-8", "debian-testing", "ubuntu-1604")
 class TestStorage(StorageCase):
     def testHiddenLuks(self):
         m = self.machine

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -23,7 +23,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for LVM", "debian-8", "ubuntu-1604")
+@skipImage("UDisks doesn't have support for LVM", "debian-8", "debian-testing", "ubuntu-1604")
 class TestStorage(StorageCase):
     def testLvm(self):
         m = self.machine

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -151,13 +151,14 @@ class TestStorage(StorageCase):
         b.wait_text(info_field("Device"), "/dev/md/ARR")
 
         # Partitions also get symlinks in /dev/md/, so they should
-        # have names like "/dev/md/ARR1".  Existing storaged versions
-        # don't pick them up as the preferred device, however, so we
-        # will see "/dev/md127p1", for example.
-        #
-        # (https://github.com/storaged-project/storaged/issues/98)
-        #
-        part_prefix = dev + "p"
+        # have names like "/dev/md/ARR1".
+        if self.storaged_version >= [ 2, 6, 3]:
+            part_prefix = "/dev/md/ARR"
+        else:
+            # Older storaged versions don't pick them up as the preferred
+            # device, however, so we will see "/dev/md127p1", for example.
+            # (https://github.com/storaged-project/storaged/issues/98)
+            part_prefix = dev + "p"
 
         # Create partition table
         b.click('button:contains(Create partition table)')

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -45,8 +45,8 @@ class TestStorage(StorageCase):
         else:
             # We don't get to set the mountpoint with old UDisks so we
             # expect UDisks default.  (XXX - I think this is Ubuntu specific.)
-            mount_point_foo = "/media/admin/FILESYSTEM"
-            mount_point_bar = "/media/admin/FILESYSTEM"
+            mount_point_foo = self.mount_root + "/admin/FILESYSTEM"
+            mount_point_bar = self.mount_root + "/admin/FILESYSTEM"
 
         self.login_and_go("/storage")
 
@@ -88,7 +88,7 @@ class TestStorage(StorageCase):
                                    values = { "mount_point": mount_point_bar })
             self.wait_in_storaged_configuration(mount_point_bar)
         else:
-            mount_point_bar = "/media/admin/filesystem"
+            mount_point_bar = self.mount_root + "/admin/filesystem"
 
         self.content_tab_action(1, 1, "Mount");
         self.content_tab_wait_in_info(1, 1, "Mounted At", mount_point_bar)
@@ -131,7 +131,7 @@ class TestStorage(StorageCase):
             self.wait_not_in_storaged_configuration(mount_point_bar)
 
             self.content_tab_action(1, 1, "Mount");
-            self.content_tab_wait_in_info(1, 1, "Mounted At", "/run/media/admin/filesystem")
+            self.content_tab_wait_in_info(1, 1, "Mounted At", self.mount_root + "/admin/filesystem")
 
             self.content_tab_action(1, 1, "Unmount");
             b.wait_not_present(self.content_tab_info_row(1, 1, "Mounted At"))

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -23,7 +23,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for LVM", "debian-8", "ubuntu-1604")
+@skipImage("UDisks doesn't have support for LVM", "debian-8", "debian-testing", "ubuntu-1604")
 class TestStorage(StorageCase):
     def testResize(self):
         m = self.machine

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -42,13 +42,15 @@ class TestStorage(StorageCase):
         b.wait_visible("#storage-detail")
         self.content_tab_wait_in_info(1, 2, "Name", "FSYS")
 
+        mountpoint = self.mount_root + "/admin/FSYS"
+
         self.content_tab_action(1, 2, "Mount")
-        self.content_tab_wait_in_info(1, 2, "Mounted At", "/run/media/admin/FSYS")
+        self.content_tab_wait_in_info(1, 2, "Mounted At", mountpoint)
 
         self.content_tab_info_action(1, 1, "Size")
         self.dialog({ "size": 400 })
 
-        size = int(m.execute("df -k --output=size /run/media/admin/FSYS | tail -1").strip())
+        size = int(m.execute("df -k --output=size %s | tail -1" % mountpoint).strip())
         assert (size > 300000)
 
         self.content_tab_info_action(1, 1, "Size")
@@ -56,9 +58,9 @@ class TestStorage(StorageCase):
 
         # Shrinking a filesystem will unmount it
         self.content_tab_action(1, 2, "Mount")
-        self.content_tab_wait_in_info(1, 2, "Mounted At", "/run/media/admin/FSYS")
+        self.content_tab_wait_in_info(1, 2, "Mounted At", mountpoint)
 
-        size = int(m.execute("df -k --output=size /run/media/admin/FSYS | tail -1").strip())
+        size = int(m.execute("df -k --output=size %s | tail -1" % mountpoint).strip())
         assert (size < 300000)
 
 if __name__ == '__main__':

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -220,6 +220,7 @@ class StorageCase(MachineCase):
 
     def dialog_wait_error(self, field, val):
         # XXX - allow for more than one error
+        self.browser.wait_present('#dialog .dialog-error')
         self.browser.wait_in_text('#dialog .dialog-error', val)
 
     def dialog_wait_not_visible(self, field):

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -43,6 +43,11 @@ class StorageCase(MachineCase):
 
         self.storaged_is_old_udisks = ("udisksctl" in self.storagectl_cmd and self.storaged_version < [2, 6, 0])
 
+        if self.machine.image in ["debian-8", "debian-testing", "ubuntu-1604" ]:
+            # Debian's udisks has a patch to use FHS /media directory
+            self.mount_root = "/media"
+        else:
+            self.mount_root = "/run/media"
 
     def inode(self, f):
         return self.machine.execute("stat -L '%s' -c %%i" % f)


### PR DESCRIPTION
It got replaced with udisks 2.6.4 (the rename/reunion). The -lvm2
component is not packaged yet due to some missing dependencies, so
disable the check-storage-lvm2 for debian-testing.

 - [x] update image
 - [x] fix missing `mkfs.*`
 - [x] fix `/run/media` on Debian/Ubuntu (it's `/media/` there)
 - [x] fix race condition in `check-storage-format TestStorage.testFormatTooSmall`
 - [x] fix check_storage_* tests