### PR TITLE
test: Fedora 26 has branched start testing there

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2069,10 +2069,8 @@ function with_checkpoint(model, modify, options) {
     //
     // https://bugzilla.redhat.com/show_bug.cgi?id=1378393
     // https://bugzilla.redhat.com/show_bug.cgi?id=1398316
-    //
-    // These bugs are expected to be fixed in NM 1.6
 
-    if (options.hack_does_add_or_remove && !model.at_least_version("1.6")) {
+    if (options.hack_does_add_or_remove) {
         modify();
         return;
     }

--- a/test/README
+++ b/test/README
@@ -91,6 +91,7 @@ You can set these environment variables to configure the test suite:
                 "debian-testing"
                 "fedora-24"
                 "fedora-25"
+                "fedora-26"
                 "fedora-atomic"
                 "fedora-testing"
                 "rhel-7"

--- a/test/common/testinfra.py
+++ b/test/common/testinfra.py
@@ -66,7 +66,7 @@ DEFAULT_VERIFY = {
     'verify/fedora-24': [ ],
     'verify/fedora-25': [ 'master', 'pulls' ],
     'verify/fedora-i386': [ 'master', 'pulls' ],
-    'verify/fedora-26': [ ],
+    'verify/fedora-26': [ 'master', 'pulls' ],
     'verify/fedora-atomic': [ 'master', 'pulls' ],
     'verify/fedora-testing': [ ],
     'verify/rhel-7': [ 'master', 'pulls' ],
@@ -94,7 +94,12 @@ DEFAULT_IMAGE_REFRESH = {
     'fedora-25': {
         'triggers': [
             "verify/fedora-25",
-            "verify/fedora-atomic",  # builds in fedora-25
+            "verify/fedora-atomic", # builds in fedora-25
+        ]
+    },
+    'fedora-26': {
+        'triggers': [
+            "verify/fedora-26",
         ]
     },
     'fedora-atomic': {

--- a/test/images/fedora-26
+++ b/test/images/fedora-26
@@ -1,0 +1,1 @@
+fedora-26-5a477a0d02b6f5d450bdb7e3370be32092acc457.qcow2

--- a/test/images/scripts/fedora-26.bootstrap
+++ b/test/images/scripts/fedora-26.bootstrap
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 Red Hat Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA.
+
+BASE=$(dirname $0)
+# once it's released, we want to use http://dl.fedoraproject.org/pub/fedora/linux/releases/26/Server/x86_64/os
+$BASE/virt-install-fedora "$1" x86_64 "http://dl.fedoraproject.org/pub/fedora/linux/development/26/Server/x86_64/os/"

--- a/test/images/scripts/fedora-26.install
+++ b/test/images/scripts/fedora-26.install
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+set -e
+
+/var/lib/testvm/fedora.install "$@"

--- a/test/images/scripts/fedora-26.setup
+++ b/test/images/scripts/fedora-26.setup
@@ -43,8 +43,11 @@ virt-install \
 "
 
 # On the latest Fedora we mix things up a bit and install docker-latest
-# which Fedora and RHEL package as a more up to date version of docker
-COCKPIT_DEPS="$COCKPIT_DEPS docker-latest"
+# which Fedora and RHEL package as a more up to date version of docker.
+#
+# HACK- expect docker-latest conflicts with docker oin fedora-26 currently.
+#
+# COCKPIT_DEPS="$COCKPIT_DEPS docker-latest"
 
 # We also install the packages necessary to join a FreeIPA domain so
 # that we don't have to go to the network during a test run.

--- a/test/images/scripts/fedora-26.setup
+++ b/test/images/scripts/fedora-26.setup
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -ex
+
+# HACK - virt-resize might not be able to resize our xfs rootfs,
+# depending on how it was compiled and which plugins are installed,
+# and will just silently not do it.  So we do it here.
+#
+xfs_growfs /
+df -h /
+
+echo foobar | passwd --stdin root
+
+# We install all dependencies of the cockpit packages since we want
+# them to not spontaneously change from one test run to the next when
+# the distribution repository is updated.
+#
+COCKPIT_DEPS="\
+atomic \
+device-mapper-multipath \
+etcd \
+glib-networking \
+json-glib \
+kexec-tools \
+kubernetes \
+libssh \
+libvirt \
+libvirt-client \
+NetworkManager-team \
+pcp \
+pcp-libs \
+qemu \
+realmd \
+selinux-policy-targeted \
+setroubleshoot-server \
+sos \
+storaged \
+storaged-lvm2 \
+storaged-iscsi \
+subscription-manager \
+tuned \
+virt-install \
+"
+
+# On the latest Fedora we mix things up a bit and install docker-latest
+# which Fedora and RHEL package as a more up to date version of docker
+COCKPIT_DEPS="$COCKPIT_DEPS docker-latest"
+
+# We also install the packages necessary to join a FreeIPA domain so
+# that we don't have to go to the network during a test run.
+#
+IPA_CLIENT_PACKAGES="\
+freeipa-client \
+oddjob \
+oddjob-mkhomedir \
+sssd \
+"
+
+TEST_PACKAGES="\
+systemtap-runtime-virtguest \
+valgrind \
+gdb \
+targetcli \
+"
+
+rm -rf /etc/sysconfig/iptables
+
+maybe() { if type "$1" >/dev/null 2>&1; then "$@"; fi; }
+
+# For the D-Bus test server
+maybe firewall-cmd --permanent --add-port 8765/tcp
+
+echo 'NETWORKING=yes' > /etc/sysconfig/network
+
+useradd -c Administrator -G wheel admin
+echo foobar | passwd --stdin admin
+
+dnf $DNF_OPTS -y upgrade
+dnf $DNF_OPTS -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
+
+# Prepare for building
+dnf $DNF_OPTS -y install mock dnf-plugins-core rpm-build
+useradd -c Builder -G mock builder
+
+# HACK - mock --installdeps with yum is broken, it seems that it can't
+# run any package scriptlets.  Yum is deprecated anyway so we just use
+# dnf.  I wonder why dnf isn't the default anyway...
+#
+echo "config_opts['package_manager'] = 'dnf'" >>/etc/mock/site-defaults.cfg
+
+# HACK - Switch off gpgcheck while the repos and mirrors settle down
+sed -i -e 's/gpgcheck=1/gpgcheck=0/' /etc/mock/default.cfg
+
+srpm=$(/var/lib/testvm/make-srpm $TEST_SOURCE)
+su builder -c "/usr/bin/mock --verbose --installdeps $srpm"
+
+# HACK: docker falls over regularly, print its log if it does
+systemctl start docker || journalctl -u docker
+
+# Setup basics for building images
+docker build -t cockpit/base /var/tmp/cockpit-base
+
+# Configure kubernetes
+/var/lib/testvm/kubernetes.setup
+
+# docker images that we need for integration testing
+/var/lib/testvm/docker-images.setup
+
+# reduce image size
+dnf clean all
+/var/lib/testvm/zero-disk.setup
+
+ln -sf ../selinux/config /etc/sysconfig/selinux
+printf "SELINUX=enforcing\nSELINUXTYPE=targeted\n" > /etc/selinux/config
+
+touch /.autorelabel
+
+# Audit events to the journal
+rm -f '/etc/systemd/system/multi-user.target.wants/auditd.service'
+rm -rf /var/log/audit/

--- a/test/images/scripts/lib/kubernetes.setup
+++ b/test/images/scripts/lib/kubernetes.setup
@@ -32,6 +32,11 @@ openssl req -x509 -new -nodes -key ca.key -days 3072 -out ca.crt -subj '/CN=kube
 openssl genrsa -out server.key 2048
 openssl req -config openssl.conf -new -key server.key -out server.csr -subj '/CN=kubernetes'
 openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 3072 -extensions v3_req -extfile openssl.conf
+# make keys readable for "kube" group and thus for kube-apiserver.service on newer OSes
+if getent group kube >/dev/null; then
+    chgrp kube ca.key server.key
+    chmod 640 ca.key server.key
+fi
 
 echo -e '{"user":"admin"}\n{"user":"scruffy","readonly": true}' > /etc/kubernetes/authorization
 echo -e 'fubar,admin,10101\nscruffy,scruffy,10102' > /etc/kubernetes/passwd

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -135,7 +135,7 @@ class TestConnection(MachineCase):
         except subprocess.CalledProcessError, ex:
             m.message(ex.output)
             # Some operating systems fail SSL3 on the server side
-            if m.image in [ "debian-testing", "fedora-25", "fedora-i386", "fedora-testing" ]:
+            if m.image in [ "debian-testing", "fedora-25", "fedora-26", "fedora-i386", "fedora-testing" ]:
                 self.assertIn("ssl handshake failure", ex.output)
             else:
                 self.assertIn("wrong version number", ex.output)

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -35,6 +35,7 @@ from common.vmmanage import get_build_image
 #
 def can_manage(machine):
     return machine.image in [ "fedora-25",
+                              "fedora-26",
                               "fedora-testing",
                               "fedora-24",
                               "rhel-7",

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -53,8 +53,8 @@ def initially_loopbacked(machine):
     if machine.atomic_image:
         return False
 
-    # Debian and Ubuntu use the overlayfs driver by default.
-    if "debian" in machine.image or "ubuntu" in machine.image:
+    # Debian, Ubuntu, and Fedora 26 use the overlayfs driver by default.
+    if machine.image in [ "debian-8", "debian-testing", "ubuntu-1604", "fedora-26" ]:
         return False
 
     # The rest don't have space in the root volume group, or don't

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -113,7 +113,7 @@ def rhsmcertd_hack(m):
     m.execute("systemctl stop rhsmcertd || true")
 
 
-@skipImage("No OSTree available", "centos-7", "debian-8", "debian-testing", "fedora-24", "fedora-25", "fedora-testing", "fedora-i386", "rhel-7", "ubuntu-1604")
+@skipImage("No OSTree available", "centos-7", "debian-8", "debian-testing", "fedora-24", "fedora-25", "fedora-26", "fedora-testing", "fedora-i386", "rhel-7", "ubuntu-1604")
 class OstreeRestartCase(MachineCase):
 
     def setUp(self):
@@ -418,7 +418,7 @@ class OstreeRestartCase(MachineCase):
 
         self.allow_restart_journal_messages()
 
-@skipImage("No OSTree available", "centos-7", "debian-8", "debian-testing", "fedora-24", "fedora-25", "fedora-testing", "fedora-i386", "rhel-7", "ubuntu-1604")
+@skipImage("No OSTree available", "centos-7", "debian-8", "debian-testing", "fedora-24", "fedora-25", "fedora-26", "fedora-testing", "fedora-i386", "rhel-7", "ubuntu-1604")
 class OstreeCase(MachineCase):
 
     def testRemoteManagement(self):

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -48,7 +48,13 @@ class TestStorage(StorageCase):
 
         # Setup a iSCSI target with authentication for discovery and join
         #
+        # HACK - some versions of targetcli crash when TERM is not set
+        #        and stdout is not a tty.
+        #
+        #        https://bugzilla.redhat.com/show_bug.cgi?id=1441121
+
         m.execute("""
+                  export TERM=dumb
                   targetcli /backstores/ramdisk create test 50M
                   targetcli /iscsi set discovery_auth enable=1 userid=admin password=foobar
                   targetcli /iscsi create %(tgt)s

--- a/test/verify/check-subscriptions
+++ b/test/verify/check-subscriptions
@@ -58,7 +58,7 @@ for x in $(seq 1 200); do
 done
 """
 
-@skipImage("No subscriptions", "centos-7", "continuous-atomic", "debian-8", "debian-testing", "fedora-24", "fedora-25", "fedora-i386", "fedora-atomic", "fedora-testing", "ubuntu-1604")
+@skipImage("No subscriptions", "centos-7", "continuous-atomic", "debian-8", "debian-testing", "fedora-24", "fedora-25", "fedora-26", "fedora-i386", "fedora-atomic", "fedora-testing", "ubuntu-1604")
 class TestSubscriptions(MachineCase):
     additional_machines = {
         'candlepin': { 'machine': { 'image': 'candlepin' } }

--- a/test/verify/naughty-fedora-26/5143-bogus-partition-name
+++ b/test/verify/naughty-fedora-26/5143-bogus-partition-name
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-storage-partitions", line *, in testPartitions
+    self.confirm()

--- a/test/verify/naughty-fedora-26/5750-atomic-storage-reset-regressed
+++ b/test/verify/naughty-fedora-26/5750-atomic-storage-reset-regressed
@@ -1,0 +1,2 @@
+  File "./verify/check-docker-storage", line *, in testDevmapper
+    b.wait_not_present(".modal-dialog:contains(Add Additional Storage)")

--- a/test/verify/naughty-fedora-26/5754-atomic-vulnerabilityinfo-broken
+++ b/test/verify/naughty-fedora-26/5754-atomic-vulnerabilityinfo-broken
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "./verify/check-docker", line *, in testBasic
+    b.wait_present(row_selector + ' td span.pficon-warning-triangle-o')

--- a/test/verify/naughty-fedora-26/6108-pcp-pmfindprofile-crash
+++ b/test/verify/naughty-fedora-26/6108-pcp-pmfindprofile-crash
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+*
+  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
+*
+Error: /usr/*/cockpit-pcp: bridge was killed: 11

--- a/test/verify/naughty-fedora-26/6327-kube-apiserver-failure
+++ b/test/verify/naughty-fedora-26/6327-kube-apiserver-failure
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+*
+  File "/home/martin/upstream/cockpit/test/verify/kubelib.py", * in start_kubernetes
+*
+CalledProcessError: Command 'systemctl start etcd kube-apiserver kube-controller-manager kube-scheduler kube-proxy kubelet' returned non-zero exit status 1

--- a/test/verify/naughty-fedora-26/6331-lsblk-order-regression
+++ b/test/verify/naughty-fedora-26/6331-lsblk-order-regression
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-docker-storage", line *, in testDevmapper
+    b.wait_not_in_text("#storage-drives", "DISK1")

--- a/test/verify/naughty-fedora-26/6332-setroubleshoot-crashes
+++ b/test/verify/naughty-fedora-26/6332-setroubleshoot-crashes
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-setroubleshoot", line *, in testTroubleshootAlerts
+    b.wait_present(row_selector)


### PR DESCRIPTION
Now that Fedora 26 has branched, we won't be releasing into the
main Fedora 25 channels any longer.

We don't yet remove support for Fedora 24 because other pull
requests are coming that migrate Avocado and Selenium stuff
later.

Also remove a HACK that's supposedly fixed on Fedora 26.

 - [x] (pitti) investigate/fix multi-machine test regressions ("Internal error in login process"), due to [SELinux policy regression](https://bugzilla.redhat.com/show_bug.cgi?id=1381331); applied ugly hack
 - [x] (pitti) investigate/fix kubernetes failures, filed [Fedora bug report](https://bugzilla.redhat.com/show_bug.cgi?id=1441218), added known issue
 - [x] investigate/fix SELinux troubleshoot failures
 - [x] (mvo) fix timer creation (PR #6324)
 - [x] (mvo) known issue for [lsblk regression](https://bugzilla.redhat.com/show_bug.cgi?id=1441175)