### PR TITLE
storaged: Clarify and add tests for mdraid_name()

### DIFF
--- a/pkg/storaged/test-util.js
+++ b/pkg/storaged/test-util.js
@@ -56,4 +56,29 @@ QUnit.test("compare_versions", function() {
     }
 });
 
-QUnit.start();
+QUnit.test("mdraid_name_nohostnamed", function() {
+    var orig_hostnamed = utils.hostnamed;
+    utils.hostnamed = { StaticHostname: undefined };
+    assert.strictEqual(utils.mdraid_name({ "Name": "somehost:mydev" }), "mydev", "remote host name is skipped when hostnamed is not available");
+    utils.hostnamed = orig_hostnamed;
+});
+
+QUnit.test("mdraid_name_remote", function() {
+    var orig_hostnamed = utils.hostnamed;
+    utils.hostnamed = { StaticHostname: "sweethome" };
+    assert.strictEqual(utils.mdraid_name({ "Name": "somehost:mydev" }), "mydev (from somehost)", "expected name for remote host");
+    utils.hostnamed = orig_hostnamed;
+});
+
+QUnit.test("mdraid_name_local", function() {
+    var orig_hostnamed = utils.hostnamed;
+    utils.hostnamed = { StaticHostname: "sweethome" };
+    assert.strictEqual(utils.mdraid_name({ "Name": "sweethome:mydev" }), "mydev", "expected name for local host");
+    utils.hostnamed = orig_hostnamed;
+});
+
+/* Wait until the hostnamed dbus proxy is actually ready; otherwise the test
+ * finishes and kills the bridge before it can respond to the dbus channel open
+ * request for the hostnamed connection, which can cause hangs in
+ * ./test-server due to timing out that queued request. */
+utils.hostnamed.wait(QUnit.start);

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -53,7 +53,7 @@
         return a_ints.length - b_ints.length;
     };
 
-    var hostnamed = cockpit.dbus("org.freedesktop.hostname1").proxy();
+    utils.hostnamed = cockpit.dbus("org.freedesktop.hostname1").proxy();
 
     utils.array_find = function array_find(array, pred) {
         for (var i = 0; i < array.length; i++)
@@ -155,7 +155,10 @@
         if (parts.length != 2)
             return mdraid.Name;
 
-        if (parts[0] == hostnamed.StaticHostname)
+        /* if we call hostnamed too early, before the dbus.proxy() promise is fulfilled,
+         * it will not be valid yet; it's too inconvenient to make this
+         * function asynchronous, so just don't show the host name in this case */
+        if (utils.hostnamed.StaticHostname === undefined || parts[0] == utils.hostnamed.StaticHostname)
             return parts[1];
         else
             return cockpit.format(_("$name (from $host)"),


### PR DESCRIPTION
mdraid_name() is a synchronous function and it would be rather
inconvenient to make it asynchronous. If our (async) connection to
hostnamed is not established yet, or hostnamed is not available at all,
just skip the "(from hostname)" bit from the name, it's not terribly
important.

Add tests for all three cases (undefined, local, and remote host).

----

This is the reason for the `TESTS=dist/storaged/test-util.html` eternal hang in PR #6252. The new tests cause the test-server and spawned bridge  to actually wait for the dbus-json3 connection to hostnamed to finish properly, instead of shutting down the bridge too early and leaving the connection request pending.