### PR TITLE
Image refresh for centos-7

### DIFF
--- a/test/images/centos-7
+++ b/test/images/centos-7
@@ -1,1 +1,1 @@
-centos-7-aa247acfc11b6d30d046b1ff5ecab1e3b9a7d63c.qcow2
+centos-7-af8db5080965d413da722b5ba082823413953114.qcow2


### PR DESCRIPTION
Image creation for centos-7 in process on cockpit-10.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-centos-7-2017-04-08/