### PR TITLE
ssh: Use a standard x-conversation prompt for host-key

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -120,5 +120,4 @@ The following environment variables are used to set options for the ```cockpit-s
  * **COCKPIT_SSH_KNOWN_HOSTS_FILE** Path to knownhost files. Defaults to ```PACKAGE_SYSCONF_DIR/ssh/ssh_known_hosts```
  * **COCKPIT_SSH_KNOWN_HOSTS_DATA** Known host data to validate against or '*' to skip validation```
  * **COCKPIT_SSH_BRIDGE_COMMAND** Command to launch after a ssh connection is established. Defaults to ```cockpit-bridge``` if not provided.
- * **COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT** Set to ```1``` if caller supports prompting users for unknown host keys.
  * **KRB5CCNAME** Kerberos credentials cache name. Not set when no active kerberos session is active.

--- a/pkg/ssh/manifest.json.in
+++ b/pkg/ssh/manifest.json.in
@@ -8,7 +8,6 @@
         {
             "match": { "session": "private", "user": null, "host": null },
             "environ": [ "COCKPIT_SSH_ALLOW_UNKNOWN=true",
-                         "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize",
                          "COCKPIT_PRIVATE_${channel}=${channel}" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${user}@${host}" ],
             "timeout": 30,
@@ -17,7 +16,6 @@
         {
             "match": { "session": "private", "host": null },
             "environ": [ "COCKPIT_SSH_ALLOW_UNKNOWN=true",
-                         "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize",
                          "COCKPIT_PRIVATE_${channel}=${channel}" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${user}@${host}" ],
             "timeout": 30,
@@ -25,16 +23,14 @@
         },
         {
             "match": { "user": null, "host": null },
-            "environ": [ "COCKPIT_SSH_ALLOW_UNKNOWN=true",
-                         "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize" ],
+            "environ": [ "COCKPIT_SSH_ALLOW_UNKNOWN=true" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${user}@${host}" ],
             "timeout": 30,
             "problem": "not-supported"
         },
         {
             "match": { "host": null },
-            "environ": [ "COCKPIT_SSH_ALLOW_UNKNOWN=true",
-                         "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize" ],
+            "environ": [ "COCKPIT_SSH_ALLOW_UNKNOWN=true" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${host}" ],
             "timeout": 30,
             "problem": "not-supported"

--- a/src/common/cockpitauthorize.c
+++ b/src/common/cockpitauthorize.c
@@ -457,7 +457,8 @@ out:
 }
 
 char *
-cockpit_authorize_parse_x_conversation (const char *challenge)
+cockpit_authorize_parse_x_conversation (const char *challenge,
+                                        char **conversation)
 {
   unsigned char *buf = NULL;
   int x_conversation;
@@ -478,7 +479,7 @@ cockpit_authorize_parse_x_conversation (const char *challenge)
       return NULL;
     }
 
-  challenge = cockpit_authorize_subject (challenge, NULL);
+  challenge = cockpit_authorize_subject (challenge, conversation);
   if (!challenge)
     return NULL;
 

--- a/src/common/cockpitauthorize.h
+++ b/src/common/cockpitauthorize.h
@@ -45,7 +45,8 @@ void *        cockpit_authorize_parse_negotiate           (const char *challenge
 char *        cockpit_authorize_build_negotiate           (const void *input,
                                                            size_t length);
 
-char *        cockpit_authorize_parse_x_conversation      (const char *challenge);
+char *        cockpit_authorize_parse_x_conversation      (const char *challenge,
+                                                           char **conversation);
 
 char *        cockpit_authorize_build_x_conversation      (const char *prompt,
                                                            char **conversation);

--- a/src/common/test-authorize.c
+++ b/src/common/test-authorize.c
@@ -332,7 +332,7 @@ test_parse_x_conversation (void *data)
   if (fix->ret == NULL)
     expect_message = "invalid";
 
-  result = cockpit_authorize_parse_x_conversation (fix->input);
+  result = cockpit_authorize_parse_x_conversation (fix->input, NULL);
   if (fix->errn != 0)
     assert_num_eq (errno, fix->errn);
   if (fix->ret)

--- a/src/ssh/cockpitsshoptions.c
+++ b/src/ssh/cockpitsshoptions.c
@@ -24,7 +24,6 @@
 static const gchar *default_knownhosts = PACKAGE_SYSCONF_DIR "/ssh/ssh_known_hosts";
 static const gchar *default_command = "cockpit-bridge";
 static const gchar *ignore_hosts_data = "*";
-static const gchar *authorize_knownhosts_data = "authorize";
 static const gchar *hostkey_mismatch_data = "* invalid key";
 
 static gboolean
@@ -100,13 +99,9 @@ cockpit_ssh_options_from_env (gchar **env)
   if (g_strcmp0 (options->knownhosts_data, ignore_hosts_data) == 0)
     options->ignore_hostkey = TRUE;
 
-  if (g_strcmp0 (options->knownhosts_data, authorize_knownhosts_data) == 0)
-    options->knownhosts_authorize = TRUE;
-
   options->knownhosts_file = get_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE",
                                                   default_knownhosts);
   options->command = get_environment_val (env, "COCKPIT_SSH_BRIDGE_COMMAND", default_command);
-  options->supports_hostkey_prompt = get_environment_bool (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", FALSE);
   options->auth_type = get_environment_val (env, "COCKPIT_AUTH_MESSAGE_TYPE", NULL);
   options->remote_peer = get_environment_val (env, "COCKPIT_REMOTE_PEER", "localhost");
 
@@ -126,8 +121,6 @@ cockpit_ssh_options_to_env (CockpitSshOptions *options,
 
   env = set_environment_bool (env, "COCKPIT_SSH_ALLOW_UNKNOWN",
                               options->allow_unknown_hosts);
-  env = set_environment_bool (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT",
-                              options->supports_hostkey_prompt);
   env = set_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE",
                              options->knownhosts_file);
   env = set_environment_val (env, "COCKPIT_REMOTE_PEER",
@@ -144,8 +137,6 @@ cockpit_ssh_options_to_env (CockpitSshOptions *options,
 
   if (options->ignore_hostkey)
     knownhosts_data = ignore_hosts_data;
-  else if (options->knownhosts_authorize)
-    knownhosts_data = authorize_knownhosts_data;
   else if (options->knownhosts_data && options->knownhosts_data[0] == '\0')
     knownhosts_data = hostkey_mismatch_data;
   else

--- a/src/ssh/cockpitsshoptions.h
+++ b/src/ssh/cockpitsshoptions.h
@@ -31,9 +31,7 @@ typedef struct {
   const gchar *remote_peer;
   const gchar *auth_type;
   gboolean allow_unknown_hosts;
-  gboolean supports_hostkey_prompt;
   gboolean ignore_hostkey;
-  gboolean knownhosts_authorize;
 } CockpitSshOptions;
 
 CockpitSshOptions * cockpit_ssh_options_from_env   (gchar **env);

--- a/src/ssh/test-sshoptions.c
+++ b/src/ssh/test-sshoptions.c
@@ -40,9 +40,7 @@ test_ssh_options (void)
   g_assert_cmpstr (options->knownhosts_file, ==, PACKAGE_SYSCONF_DIR "/ssh/ssh_known_hosts");
   g_assert_cmpstr (options->command, ==, "cockpit-bridge");
   g_assert_false (options->allow_unknown_hosts);
-  g_assert_false (options->supports_hostkey_prompt);
   g_assert_false (options->ignore_hostkey);
-  g_assert_false (options->knownhosts_authorize);
 
   options->knownhosts_data = "";
   options->knownhosts_file = "other-known";
@@ -57,12 +55,10 @@ test_ssh_options (void)
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE"), ==, "other-known");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA"), ==, "*");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_BRIDGE_COMMAND"), ==, "other-command");
-  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT"), ==, "");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_REMOTE_PEER"), ==, "other");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_AUTH_MESSAGE_TYPE"), ==, "test");
 
   options->allow_unknown_hosts = TRUE;
-  options->supports_hostkey_prompt = TRUE;
   options->ignore_hostkey = FALSE;
   options->auth_type = NULL;
 
@@ -71,7 +67,6 @@ test_ssh_options (void)
   g_assert_null (options->auth_type);
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA"), ==, "* invalid key");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN"), ==, "1");
-  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT"), ==, "1");
 
   options->knownhosts_data = "key";
   g_strfreev (env);
@@ -85,48 +80,37 @@ test_ssh_options (void)
   env = g_environ_setenv (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE", "other-known", TRUE);
   env = g_environ_setenv (env, "COCKPIT_SSH_BRIDGE_COMMAND", "other-command", TRUE);
   env = g_environ_setenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN", "", TRUE);
-  env = g_environ_setenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "", TRUE);
 
   options = cockpit_ssh_options_from_env (env);
   g_assert_true (options->ignore_hostkey);
   g_assert_cmpstr (options->knownhosts_data, ==, "*");
-  g_assert_false (options->supports_hostkey_prompt);
   g_assert_true (options->allow_unknown_hosts);
   g_assert_cmpstr (options->knownhosts_file, ==, "other-known");
   g_assert_cmpstr (options->command, ==, "other-command");
-  g_assert_false (options->knownhosts_authorize);
 
   g_free (options);
   g_strfreev (env);
 
   env = g_environ_setenv (NULL, "COCKPIT_SSH_KNOWN_HOSTS_DATA", "data", TRUE);
-  env = g_environ_setenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "1", TRUE);
   options = cockpit_ssh_options_from_env (env);
   g_assert_false (options->ignore_hostkey);
   g_assert_cmpstr (options->knownhosts_data, ==, "data");
-  g_assert_true (options->supports_hostkey_prompt);
   g_assert_true (options->allow_unknown_hosts);
-  g_assert_false (options->knownhosts_authorize);
   g_free (options);
   g_strfreev (env);
 
   env = g_environ_setenv (NULL, "COCKPIT_SSH_KNOWN_HOSTS_DATA", "authorize", TRUE);
-  env = g_environ_setenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "key", TRUE);
   env = g_environ_setenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN", "key", TRUE);
   options = cockpit_ssh_options_from_env (env);
   g_assert_false (options->ignore_hostkey);
-  g_assert_false (options->supports_hostkey_prompt);
   g_assert_true (options->allow_unknown_hosts);
-  g_assert_true (options->knownhosts_authorize);
   g_free (options);
   g_strfreev (env);
 
   env = g_environ_setenv (NULL, "COCKPIT_SSH_ALLOW_UNKNOWN", "yes", TRUE);
   options = cockpit_ssh_options_from_env (env);
   g_assert_false (options->ignore_hostkey);
-  g_assert_false (options->supports_hostkey_prompt);
   g_assert_true (options->allow_unknown_hosts);
-  g_assert_false (options->knownhosts_authorize);
   g_free (options);
   g_strfreev (env);
 

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -120,8 +120,6 @@ main (int argc,
 
   g_setenv ("G_TLS_GNUTLS_PRIORITY", "SECURE128:%LATEST_RECORD_VERSION:-VERS-SSL3.0:-VERS-TLS1.0", FALSE);
 
-  g_setenv ("COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", "1", TRUE);
-
   g_type_init ();
 
   memset (&data, 0, sizeof (data));

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -453,7 +453,7 @@ pam_conv_func (int num_msg,
             }
 
           authorization = read_authorize_response (msg[i]->msg);
-          prompt_resp = cockpit_authorize_parse_x_conversation (authorization);
+          prompt_resp = cockpit_authorize_parse_x_conversation (authorization, NULL);
 
           debug ("got prompt response");
           if (prompt_resp)


### PR DESCRIPTION
When a channel has a host-key specified, use a standard "authorize"
"x-conversation" prompt to prompt for it. We answer such prompts
in CockpitPeer if the channel had the appropriate override.