### PR TITLE
ssh: Remove the COCKPIT_AUTH_MESSAGE_TYPE variable

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -112,7 +112,6 @@ Environment Variables
 The following environment variables are set by cockpit-ws when spawning an auth process
 
  * **COCKPIT_REMOTE_PEER** Set to the ip address of the connecting user.
- * **COCKPIT_AUTH_MESSAGE_TYPE** A string representing the type of message that will be sent on the authentication fd. When the message is passed durning login, this will be set to the value of the auth scheme that was included in the Authorization http header.
 
 The following environment variables are used to set options for the ```cockpit-ssh``` process.
 

--- a/src/ssh/cockpitsshoptions.c
+++ b/src/ssh/cockpitsshoptions.c
@@ -107,7 +107,6 @@ cockpit_ssh_options_from_env (gchar **env)
                                                   default_knownhosts);
   options->command = get_environment_val (env, "COCKPIT_SSH_BRIDGE_COMMAND", default_command);
   options->supports_hostkey_prompt = get_environment_bool (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT", FALSE);
-  options->auth_type = get_environment_val (env, "COCKPIT_AUTH_MESSAGE_TYPE", NULL);
   options->remote_peer = get_environment_val (env, "COCKPIT_REMOTE_PEER", "localhost");
 
   if (options->knownhosts_data != NULL)
@@ -132,15 +131,6 @@ cockpit_ssh_options_to_env (CockpitSshOptions *options,
                              options->knownhosts_file);
   env = set_environment_val (env, "COCKPIT_REMOTE_PEER",
                              options->remote_peer);
-  if (options->auth_type)
-    {
-      env = g_environ_setenv (env, "COCKPIT_AUTH_MESSAGE_TYPE",
-                              options->auth_type, TRUE);
-    }
-  else
-    {
-      env = g_environ_unsetenv (env, "COCKPIT_AUTH_MESSAGE_TYPE");
-    }
 
   if (options->ignore_hostkey)
     knownhosts_data = ignore_hosts_data;

--- a/src/ssh/cockpitsshoptions.h
+++ b/src/ssh/cockpitsshoptions.h
@@ -29,7 +29,6 @@ typedef struct {
   const gchar *knownhosts_file;
   const gchar *command;
   const gchar *remote_peer;
-  const gchar *auth_type;
   gboolean allow_unknown_hosts;
   gboolean supports_hostkey_prompt;
   gboolean ignore_hostkey;

--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -2055,8 +2055,7 @@ cockpit_ssh_relay_start (CockpitSshRelay *self,
   };
 
   self->ssh_data->outfd = outfd;
-  self->ssh_data->initial_auth_data = challenge_for_auth_data (self->ssh_data->ssh_options->auth_type,
-                                                               outfd,
+  self->ssh_data->initial_auth_data = challenge_for_auth_data ("*", outfd,
                                                                &self->ssh_data->auth_type);
 
   problem = cockpit_ssh_connect (self->ssh_data, self->connection_string, &self->channel);

--- a/src/ssh/test-sshoptions.c
+++ b/src/ssh/test-sshoptions.c
@@ -35,7 +35,6 @@ test_ssh_options (void)
 
   options = cockpit_ssh_options_from_env (env);
   g_assert_null (options->knownhosts_data);
-  g_assert_null (options->auth_type);
   g_assert_cmpstr (options->remote_peer, ==, "localhost");
   g_assert_cmpstr (options->knownhosts_file, ==, PACKAGE_SYSCONF_DIR "/ssh/ssh_known_hosts");
   g_assert_cmpstr (options->command, ==, "cockpit-bridge");
@@ -48,7 +47,6 @@ test_ssh_options (void)
   options->knownhosts_file = "other-known";
   options->command = "other-command";
   options->ignore_hostkey = TRUE;
-  options->auth_type = "test";
   options->remote_peer = "other";
 
   env = cockpit_ssh_options_to_env (options, NULL);
@@ -59,16 +57,13 @@ test_ssh_options (void)
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_BRIDGE_COMMAND"), ==, "other-command");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT"), ==, "");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_REMOTE_PEER"), ==, "other");
-  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_AUTH_MESSAGE_TYPE"), ==, "test");
 
   options->allow_unknown_hosts = TRUE;
   options->supports_hostkey_prompt = TRUE;
   options->ignore_hostkey = FALSE;
-  options->auth_type = NULL;
 
   g_strfreev (env);
   env = cockpit_ssh_options_to_env (options, NULL);
-  g_assert_null (options->auth_type);
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA"), ==, "* invalid key");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_ALLOW_UNKNOWN"), ==, "1");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT"), ==, "1");


### PR DESCRIPTION
This isn't used anywhere. If a session program wants "authorize"
data ... it should "authorize" with a "challenge" of "*"