### PR TITLE
ssh: Only connect to unknown hosts on private connections

### DIFF
--- a/pkg/ssh/manifest.json.in
+++ b/pkg/ssh/manifest.json.in
@@ -25,16 +25,14 @@
         },
         {
             "match": { "user": null, "host": null },
-            "environ": [ "COCKPIT_SSH_ALLOW_UNKNOWN=true",
-                         "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize" ],
+            "environ": [ "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${user}@${host}" ],
             "timeout": 30,
             "problem": "not-supported"
         },
         {
             "match": { "host": null },
-            "environ": [ "COCKPIT_SSH_ALLOW_UNKNOWN=true",
-                         "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize" ],
+            "environ": [ "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${host}" ],
             "timeout": 30,
             "problem": "not-supported"


### PR DESCRIPTION
Only allow connecting to unknown hosts on private connections.