### PR TITLE
common: Allow parsing the conversation out

### DIFF
--- a/src/common/cockpitauthorize.c
+++ b/src/common/cockpitauthorize.c
@@ -457,7 +457,8 @@ out:
 }
 
 char *
-cockpit_authorize_parse_x_conversation (const char *challenge)
+cockpit_authorize_parse_x_conversation (const char *challenge,
+                                        char **conversation)
 {
   unsigned char *buf = NULL;
   int x_conversation;
@@ -478,7 +479,7 @@ cockpit_authorize_parse_x_conversation (const char *challenge)
       return NULL;
     }
 
-  challenge = cockpit_authorize_subject (challenge, NULL);
+  challenge = cockpit_authorize_subject (challenge, conversation);
   if (!challenge)
     return NULL;
 

--- a/src/common/cockpitauthorize.h
+++ b/src/common/cockpitauthorize.h
@@ -45,7 +45,8 @@ void *        cockpit_authorize_parse_negotiate           (const char *challenge
 char *        cockpit_authorize_build_negotiate           (const void *input,
                                                            size_t length);
 
-char *        cockpit_authorize_parse_x_conversation      (const char *challenge);
+char *        cockpit_authorize_parse_x_conversation      (const char *challenge,
+                                                           char **conversation);
 
 char *        cockpit_authorize_build_x_conversation      (const char *prompt,
                                                            char **conversation);

--- a/src/common/test-authorize.c
+++ b/src/common/test-authorize.c
@@ -332,7 +332,7 @@ test_parse_x_conversation (void *data)
   if (fix->ret == NULL)
     expect_message = "invalid";
 
-  result = cockpit_authorize_parse_x_conversation (fix->input);
+  result = cockpit_authorize_parse_x_conversation (fix->input, NULL);
   if (fix->errn != 0)
     assert_num_eq (errno, fix->errn);
   if (fix->ret)

--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -376,7 +376,7 @@ prompt_with_authorize (CockpitSshData *data,
     }
   else if (!g_str_equal (response, ""))
     {
-      result = cockpit_authorize_parse_x_conversation (response);
+      result = cockpit_authorize_parse_x_conversation (response, NULL);
       if (!result)
         g_message ("received unexpected \"authorize\" control message \"response\"");
     }

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -453,7 +453,7 @@ pam_conv_func (int num_msg,
             }
 
           authorization = read_authorize_response (msg[i]->msg);
-          prompt_resp = cockpit_authorize_parse_x_conversation (authorization);
+          prompt_resp = cockpit_authorize_parse_x_conversation (authorization, NULL);
 
           debug ("got prompt response");
           if (prompt_resp)


### PR DESCRIPTION
Allow parsing the conversation identifier out in the
cockpit_authorize_parse_x_conversation() function.