### PR TITLE
ws: Disconnect correct signal

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -196,7 +196,7 @@ cockpit_session_unref (gpointer data)
     {
       if (session->control_sig)
         g_signal_handler_disconnect (session->transport, session->control_sig);
-      if (session->control_sig)
+      if (session->close_sig)
         g_signal_handler_disconnect (session->transport, session->close_sig);
       g_object_unref (session->transport);
     }


### PR DESCRIPTION
Copy/paste error, suggested by Coverity.