### PR TITLE
test: Fix race with systemd and check-services test

### DIFF
--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -118,10 +118,14 @@ OnCalendar=*:1/2
         b.wait_in_text(svc_sel('test.timer'), "Today")
         b.wait_in_text(svc_sel('test.timer'), "unknown")
         m.execute("systemctl stop test.timer")
+
         # Selects Services tab
         b.click('#services-filter :nth-child(2)')
         b.wait_present(svc_sel('test.service'))
         b.click(svc_sel("test.service"))
+        # systemd is often reloaded and above 'enable' takes effect
+        # Log line like: systemd[1]: Reloading.
+        m.execute("systemctl stop test.service")
         b.wait_visible('#service-valid')
         b.wait_in_text('#service-valid', "inactive")
         b.wait_action_btn(unit_action_btn, "Start")


### PR DESCRIPTION
When test.service is enabled and systemd reloads this causes
the test.service to be started. We see a log sequence like
this:

```
systemd[1]: Stopped Test Service.
systemd[1]: Reloading.
systemd[1]: tmp.mount: Cannot add dependency job, ignoring: Unit tmp.mount is masked.
systemd[1]: Started Test Timer.
systemd[1]: tmp.mount: Cannot add dependency job, ignoring: Unit tmp.mount is masked.
systemd[1]: Started Test Service.
sh[2598]: START
systemd[1]: Stopped Test Timer.
sh[2598]: WORKING
sh[2598]: WORKING
```

The 'Started Test Service' above happens before explictly
started because the service is enabled.