### PR TITLE
Image refresh for ubuntu-1604

### DIFF
--- a/test/images/ubuntu-1604
+++ b/test/images/ubuntu-1604
@@ -1,1 +1,1 @@
-ubuntu-1604-cb6967c46dd19e84c537bf3318e783f9e2bfbc47.qcow2
+ubuntu-1604-7b7e139378f78a0a712ccaaebe094eabf9fbaec6.qcow2


### PR DESCRIPTION
Image creation for ubuntu-1604 in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-ubuntu-1604-2017-04-11/