### PR TITLE
Image refresh for fedora-i386

### DIFF
--- a/test/images/fedora-i386
+++ b/test/images/fedora-i386
@@ -1,1 +1,1 @@
-fedora-i386-001a85d5557d0bfff3b44fc1738042df181c8698.qcow2
+fedora-i386-57be2d37e9d46de9653cac0aa3eeaff58f86e678.qcow2


### PR DESCRIPTION
Image creation for fedora-i386 in process on cockpit-9.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-i386-2017-04-11/