### PR TITLE
systemd: Put [Install] section into foo.timer

### DIFF
--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -1269,16 +1269,18 @@ $(function() {
         var unit = "[Unit]\nDescription=";
         var service = "\n[Service]\nExecStart=";
         var timer = "\n[Timer]\n";
-        var service_file = unit + timer_unit.Description + service + timer_unit.Command + "\n[Install]\nWantedBy=default.target";
+        var install = "[Install]\nWantedBy=default.target\n";
+        var service_file = unit + timer_unit.Description + service + timer_unit.Command + "\n";
         var timer_file = " ";
         if (timer_unit.Calendar_or_Boot == "Boot") {
-            var boottimer = timer +"OnBootSec=" + timer_unit.boot_time + timer_unit.boot_time_unit;
+            var boottimer = timer +"OnBootSec=" + timer_unit.boot_time + timer_unit.boot_time_unit + "\n";
             timer_file = unit + timer_unit.Description + boottimer;
         }
         else if (timer_unit.Calendar_or_Boot == "Calendar") {
-            var calendartimer = timer + timer_unit.OnCalendar;
+            var calendartimer = timer + timer_unit.OnCalendar + "\n";
             timer_file = unit + timer_unit.Description + calendartimer;
         }
+        timer_file += install;
         // writing to file
         var service_path = "/etc/systemd/system/" + timer_unit.name + ".service";
         var file = cockpit.file(service_path, { superuser: 'try' });

--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -1269,7 +1269,7 @@ $(function() {
         var unit = "[Unit]\nDescription=";
         var service = "\n[Service]\nExecStart=";
         var timer = "\n[Timer]\n";
-        var install = "[Install]\nWantedBy=default.target\n";
+        var install = "[Install]\nWantedBy=timers.target\n";
         var service_file = unit + timer_unit.Description + service + timer_unit.Command + "\n";
         var timer_file = " ";
         if (timer_unit.Calendar_or_Boot == "Boot") {

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -470,7 +470,7 @@ WantedBy=default.target
         b.click("#timer-save-button")
         b.wait_popdown("timer-dialog")
         b.wait_present(svc_sel('boot_timer.timer'))
-        m.execute("systemctl enable boot_timer")
+        m.execute("systemctl enable boot_timer.timer")
         m.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")
         m.wait_reboot()
         m.start_cockpit()


### PR DESCRIPTION
and not into foo.service.  This allows us to enable and disable the
actual timer, and not the service that runs when the timer expires.

Also, avoid partial lines in the unit files.