### PR TITLE
tools: Install latest npm in semaphore-prepare

### DIFF
--- a/tools/semaphore-prepare
+++ b/tools/semaphore-prepare
@@ -2,4 +2,10 @@
 
 change-phantomjs-version 2.1.1
 sudo apt-get update
-sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-login-dev libsystemd-journal-dev libkrb5-dev pcp pkg-config valgrind xmlto xsltproc pyflakes npm nodejs-legacy git libfontconfig1 dbus ssh libglib2.0-0-dbg glib-networking-dbg
+sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-login-dev libsystemd-journal-dev libkrb5-dev pcp pkg-config valgrind xmlto xsltproc pyflakes npm nodejs-legacy git libfontconfig1 dbus ssh libglib2.0-0-dbg glib-networking-dbg curl
+
+# semaphore already has latest npm pre-installed, do that for local chroots
+if dpkg --compare-versions "$(npm --version)" lt "4"; then
+   sudo npm install -g n
+   sudo n stable
+fi


### PR DESCRIPTION
Semaphore's VMs already have that (so there this is a no-op), but Ubuntu
14.04's version is too old for Cockpit. This fixes running the semaphore
scripts in a local chroot.

---

"bot" as this only affects semaphore.