### PR TITLE
Image refresh for debian-8

### DIFF
--- a/test/images/debian-8
+++ b/test/images/debian-8
@@ -1,1 +1,1 @@
-debian-8-fbf89ea1ec1dcbc64fa3cbe3c0af4409ea9936d2.qcow2
+debian-8-e2d6921cb7e6ffbf73fc6fc005a029984c2fd29c.qcow2


### PR DESCRIPTION
Image creation for debian-8 in process on cockpit-9.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-8-2017-04-12/