### PR TITLE
tools: Use parallel building in semaphore

### DIFF
--- a/tools/semaphore-run
+++ b/tools/semaphore-run
@@ -21,7 +21,7 @@ elif [ -n "$ARCH" ]; then
 fi
 
 ./autogen.sh --prefix=/usr --enable-strict --with-systemdunitdir=/tmp
-make V=1 all
+make -j2 V=1 all
 
 # only run distcheck on native arch
 if [ -z "$ARCH" ]; then


### PR DESCRIPTION
Make use of the two cores semaphore gives us to speed up the build.
Don't parallelize as aggressively as running the tests though, as some
builds (webpack etc.) take a lot of memory.

---

Tagging "bot" as this only affects semaphore.