### PR TITLE
sosreport: Remove unnecessary module private scope

### DIFF
--- a/pkg/sosreport/index.js
+++ b/pkg/sosreport/index.js
@@ -17,9 +17,6 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
-
     var cockpit = require("cockpit");
     var $ = require("jquery");
 
@@ -169,4 +166,3 @@
     }
 
     init();
-}());


### PR DESCRIPTION
When webpack bundles javascript, it puts each loaded module in
its own private scope. So we don't need these in our individual
javascript files once they've been migrated to webpack.