### PR TITLE
tools: Fix docker dependency

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -564,7 +564,7 @@ utility setroubleshoot to diagnose and resolve SELinux issues.
 Summary: Cockpit user interface for Docker containers
 Requires: %{name}-bridge >= %{required_base}
 Requires: %{name}-shell >= %{required_base}
-Requires: docker >= 1.3.0
+Requires: /usr/bin/docker
 Requires: python
 
 %description docker

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -85,7 +85,7 @@ Description: Cockpit deployment and developer guide
 Package: cockpit-docker
 Architecture: all
 Depends: ${misc:Depends},
-         docker.io (>= 1.3.0) | docker-engine (>= 1.3.0),
+         docker.io (>= 1.3.0) | docker-engine (>= 1.3.0) | docker-ce (>= 1.3.0),
          python3,
          cockpit-bridge (>= ${bridge:minversion}),
 Description: Cockpit user interface for Docker containers


### PR DESCRIPTION
There are several 'official' docker rpm packages docker, docker-engine, and docker-ce. We'll work
with any of them but since they have no common provides we have to depend on the binary otherwise people have trouble installing. This has the downside of us not being able to require a specific version but seems the best we can do for now.

Also adds docker-ce for the debian package