### PR TITLE
Image refresh for ubuntu-1604

### DIFF
--- a/test/images/ubuntu-1604
+++ b/test/images/ubuntu-1604
@@ -1,1 +1,1 @@
-ubuntu-1604-7b7e139378f78a0a712ccaaebe094eabf9fbaec6.qcow2
+ubuntu-1604-1ef594b5e4c829dacfbc82138b1e890c0061c54d.qcow2


### PR DESCRIPTION
Image creation for ubuntu-1604 in process on cockpit-9.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-ubuntu-1604-2017-04-18/