### PR TITLE
kubernetes: Hide "docker push" commands for pull-only users on image stream

### DIFF
--- a/pkg/kubernetes/scripts/images.js
+++ b/pkg/kubernetes/scripts/images.js
@@ -28,6 +28,7 @@
     require('./date');
     require('./listing');
     require('./tags');
+    require('./policy');
 
     require('registry-image-widgets/dist/image-widgets.js');
 
@@ -131,11 +132,13 @@
         '$routeParams',
         'kubeSelect',
         'kubeLoader',
+        'KubeDiscoverSettings',
         'imageData',
         'imageActions',
         'ListingState',
         'projectData',
-        function($scope, $location, $routeParams, select, loader, data, actions, ListingState, projectData) {
+        'projectPolicy',
+        function($scope, $location, $routeParams, select, loader, discoverSettings, data, actions, ListingState, projectData, projectPolicy) {
             var target = $routeParams["target"] || "";
             var pos = target.indexOf(":");
 
@@ -219,6 +222,22 @@
 
                 return promise;
             };
+
+            function updateShowDockerPushCommands() {
+                discoverSettings().then(function(settings) {
+                    projectPolicy.subjectAccessReview(namespace, settings.currentUser, 'update', 'imagestreamimages')
+                       .then(function(allowed) {
+                            if (allowed != $scope.showDockerPushCommands) {
+                                $scope.showDockerPushCommands = allowed;
+                                $scope.$applyAsync();
+                            }
+                       });
+                });
+            }
+
+            // watch for project changes to update showDockerPushCommands, and initialize it
+            $scope.$on("$routeUpdate", updateShowDockerPushCommands);
+            updateShowDockerPushCommands();
         }
     ])
 

--- a/pkg/kubernetes/views/imagestream-page.html
+++ b/pkg/kubernetes/views/imagestream-page.html
@@ -18,7 +18,7 @@
         <registry-imagestream-body imagestream="stream" imagestream-modify="modifyImageStream"
             project-modify="modifyProject" project-sharing="sharedImages">
         </registry-imagestream-body>
-        <registry-imagestream-push settings="settings" imagestream="stream">
+        <registry-imagestream-push settings="settings" imagestream="stream" ng-show="showDockerPushCommands">
         </registry-imagestream-push>
     </div>
     <h3 translate>Images</h3>

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -974,8 +974,7 @@ class TestRegistry(MachineCase):
         # and neither the push command on the image page
         b.go("#/images/marmalade/origin")
         b.wait_in_text("body", "Images")
-        # FIXME: known to fail for now, needs fixing in registry-image-widgets
-        # b.wait_not_visible('.registry-imagestream-push')
+        b.wait_not_visible('.registry-imagestream-push')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Similarly to commit d3d9802aeb, hide the "docker push" commands for
users with only a pull role on the image stream page too.

https://bugzilla.redhat.com/show_bug.cgi?id=1373448