### PR TITLE
build: Ship integration tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -378,6 +378,12 @@ dist-xz: distdir
 distcheck-hook::
 	$(srcdir)/tools/check-dist $(distdir)
 
+install-integration-tests::
+	$(MKDIR_P) $(DESTDIR)$(pkgdatadir)
+	( cd $(srcdir); git ls-tree HEAD --full-tree --name-only -r test || echo test ) | \
+		tar -C $(srcdir) -cf - -T - | tar -C $(DESTDIR)$(pkgdatadir) -xf -
+	rm -r $(DESTDIR)$(pkgdatadir)/test/tmp; ln -sf /var/tmp/cockpit $(DESTDIR)$(pkgdatadir)/test/tmp
+
 BOWER = $(srcdir)/bower_components
 
 include po/Makefile.am

--- a/containers/Makefile.am
+++ b/containers/Makefile.am
@@ -34,6 +34,19 @@ WS_DIR = $(srcdir)/containers/ws
 
 CLEANFILES += $(WS_DIR)/rpms
 
+# needed for installed integration tests
+ATOMIC_SETUP = \
+	$(WS_DIR)/atomic-install   \
+	$(WS_DIR)/atomic-run       \
+	$(WS_DIR)/atomic-uninstall \
+	$(NULL)
+
+EXTRA_DIST += $(ATOMIC_SETUP)
+
+install-integration-tests::
+	$(MKDIR_P) $(DESTDIR)/$(pkgdatadir)/containers/ws/
+	$(INSTALL_DATA) $(ATOMIC_SETUP) $(DESTDIR)/$(pkgdatadir)/containers/ws/
+
 ws-container:
 	rm -rf $(WS_DIR)/rpms && mkdir -p $(WS_DIR)/rpms
 	cd $(WS_DIR)/rpms && $(abs_srcdir)/tools/make-rpms

--- a/test/common/vmmanage.py
+++ b/test/common/vmmanage.py
@@ -122,7 +122,7 @@ def build_and_install(install_image, build_image, args):
     args.setdefault("containers", False)
     args.setdefault("address", None)
 
-    skips = [ ]
+    skips = ["cockpit-integration-tests"]
     if install_image:
         if "atomic" in install_image:
             skips.append("cockpit-kubernetes")

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -138,6 +138,7 @@ make -j4 check
 %install
 make install DESTDIR=%{buildroot}
 make install-tests DESTDIR=%{buildroot}
+make install-integration-tests DESTDIR=%{buildroot}
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/pam.d
 install -p -m 644 tools/cockpit.pam $RPM_BUILD_ROOT%{_sysconfdir}/pam.d/cockpit
 rm -f %{buildroot}/%{_libdir}/cockpit/*.so
@@ -441,6 +442,30 @@ These files are not required for running Cockpit.
 %{_unitdir}/cockpit.service.d
 %{_datadir}/%{name}/playground
 %{_prefix}/lib/cockpit-test-assets
+
+%package integration-tests
+Summary: Integration tests for Cockpit
+Requires: curl
+Requires: expect
+Requires: libvirt
+Requires: libvirt-client
+Requires: libvirt-daemon
+Requires: libvirt-python
+Requires: qemu-kvm
+Requires: npm
+Requires: python
+Requires: rsync
+Requires: xz
+Requires: openssh-clients
+Requires: fontconfig
+
+%description integration-tests
+This package contains Cockpit's integration tests for running in VMs.
+These are not required for running Cockpit.
+
+%files integration-tests
+%{_datadir}/%{name}/test
+%{_datadir}/%{name}/containers
 
 %package ws
 Summary: Cockpit Web Service


### PR DESCRIPTION
Add a new "make install-integration-tests" target to install our
integration tests. Some Atomic test images also need the ws container
install scripts, so ship them along.

Put them into a new cockpit-integration-tests RPM package. They don't
fit into "cockpit-tests" as that already contains the playground and
depends on -bridge and -ws, whereas -integration-tests depends on
libvirt, npm, and other packages which are not and should not be in our
test VMs.

Don't bother doing this for Debian, as autopkgtest runs the the tests
straight out of the source package.

---

This is a prerequisite for either implementation proposal of https://fedoraproject.org/wiki/Changes/InvokingTests ; I have a branch for the [package tests as RPMs](https://github.com/martinpitt/cockpit/commits/packaged-tests) proposal, and the Ansible alternative would mostly be the same tools/docker-verify script except that it wouldn't be shipped in an RPM.