### PR TITLE
test: Don't check journal for skipped tests

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -533,7 +533,7 @@ class MachineCase(unittest.TestCase):
         self.addCleanup(intercept)
 
     def tearDown(self):
-        if self.currentResult.wasSuccessful() and self.machine.address:
+        if self.currentResult.wasSuccessful() and len(self.currentResult.skipped) == 0 and self.machine.address:
             self.check_journal_messages()
         shutil.rmtree(self.tmpdir)
 


### PR DESCRIPTION
Otherwise we might end up with both a "ok" and "not ok" result for a
single test in the output, the "ok" from maybeIgnore and the "not ok"
from check_journal.