### PR TITLE
Image refresh for fedora-26

### DIFF
--- a/test/images/fedora-26
+++ b/test/images/fedora-26
@@ -1,1 +1,1 @@
-fedora-26-5a477a0d02b6f5d450bdb7e3370be32092acc457.qcow2
+fedora-26-c6aee1b1ab6b33c9c4d6153c715889df3caa9627.qcow2

--- a/test/images/scripts/fedora-26.setup
+++ b/test/images/scripts/fedora-26.setup
@@ -57,6 +57,7 @@ freeipa-client \
 oddjob \
 oddjob-mkhomedir \
 sssd \
+libsss_sudo \
 "
 
 TEST_PACKAGES="\


### PR DESCRIPTION
Image creation for fedora-26 in process on cockpit-10.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-26-2017-04-20/