### PR TITLE
ws: Allow auth commands to set credentials that can be used for future challenges

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -320,6 +320,19 @@ Example authorize challenge and response messages:
         "response": "crypt1:$6$r0oetn2039ntoen..."
     }
 
+Authorize messages are used during authentication by authentication
+commands (ei: cockpit-session, cockpit-ssh) to obtain the users credentials
+from cockpit-ws. An authentication command can send a authorize message
+with a response but no cookie. For example
+
+    {
+        "command": "authorize",
+        "response": "Basic ..."
+    }
+
+In that case cockpit-ws will store the response and use it in a reply
+to a subsequent challenge.
+
 For credential cache authorization, the following fields are defined:
 
  * "credential": Empty or "password"

--- a/src/ws/mock-auth-command.c
+++ b/src/ws/mock-auth-command.c
@@ -95,7 +95,7 @@ static void
 write_message (const char *message)
 {
   if (cockpit_frame_write (STDOUT_FILENO, (unsigned char *)message, strlen (message)) < 0)
-    err (EX, "coludn't write init message");
+    err (EX, "coludn't write message");
 }
 
 static void
@@ -130,6 +130,22 @@ main (int argc,
   if (strcmp (data, "") == 0)
     {
       write_init_message ("\"problem\":\"authentication-failed\"");
+    }
+  if (strcmp (data, "no-cookie") == 0)
+    {
+      write_message ("\n{\"command\":\"authorize\",\"response\": \"user me\"}");
+      free (message);
+      write_authorize_challenge ("*");
+      message = read_authorize_response ();
+      if (!data || strcmp (message, "user me") != 0)
+        {
+          write_init_message ("\"problem\": \"authentication-failed\"");
+        }
+      else
+        {
+          write_init_message ("\"user\": \"me\"");
+          success = 1;
+        }
     }
   else if (strcmp (data, "failslow") == 0)
     {
@@ -301,6 +317,7 @@ main (int argc,
     }
 
 out:
+  free (message);
   if (success)
     {
       if (launch_bridge)

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -679,6 +679,12 @@ static const ErrorFixture fixture_ssh_auth_with_error = {
   .header = "testsshscheme with-error",
 };
 
+static const SuccessFixture fixture_no_cookie = {
+  .warning = NULL,
+  .data = NULL,
+  .header = "testscheme no-cookie"
+};
+
 static const SuccessFixture fixture_no_data = {
   .warning = NULL,
   .data = NULL,
@@ -1177,6 +1183,8 @@ main (int argc,
   g_test_add ("/auth/bad-coversation", Test, &fixture_bad_conversation,
               setup_normal, test_custom_fail, teardown_normal);
   g_test_add ("/auth/custom-success", Test, &fixture_no_data,
+              setup_normal, test_custom_success, teardown_normal);
+  g_test_add ("/auth/custom-no-cookie-success", Test, &fixture_no_cookie,
               setup_normal, test_custom_success, teardown_normal);
   g_test_add ("/auth/custom-data-then-success", Test, &fixture_data_then_success,
               setup_normal, test_custom_success, teardown_normal);


### PR DESCRIPTION
@stefwalter. Any thoughts on this.

This makes having small commands written in dynamic languages much easier. It becomes a simple lookup creds, send the ```set-credentials``` authorize command up to cockpit-ws and the exec cockpit-ssh.

WDYT?