### PR TITLE
Image refresh for centos-7

### DIFF
--- a/test/images/centos-7
+++ b/test/images/centos-7
@@ -1,1 +1,1 @@
-centos-7-f3460572647daa7cd779c5b6a3cd7a63829c83ab.qcow2
+centos-7-82e0afd494926fffb8fa883585bde2e964b439e1.qcow2


### PR DESCRIPTION
Image creation for centos-7 in process on cockpit-8.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-centos-7-2017-04-22/