### PR TITLE
bridge: Fix format string type mismatch on some architectures

### DIFF
--- a/src/bridge/cockpitfsread.c
+++ b/src/bridge/cockpitfsread.c
@@ -117,10 +117,10 @@ file_tag_from_stat (int res,
   // renames.
 
   if (res >= 0)
-    return g_strdup_printf ("1:%lu-%ld.%ld",
+    return g_strdup_printf ("1:%lu-%lld.%ld",
                             (unsigned long)buf->st_ino,
-                            buf->st_mtim.tv_sec,
-                            buf->st_mtim.tv_nsec);
+                            (long long int)buf->st_mtim.tv_sec,
+                            (long int)buf->st_mtim.tv_nsec);
   else if (err == ENOENT)
     return g_strdup ("-");
   else


### PR DESCRIPTION
On some architectures a time_t is "long long", not "long", and
compilation fails with

    src/bridge/cockpitfsread.c:120:38: error: format '%ld' expects
    argument of type 'long int', but argument 3 has type '__time_t
    {aka long long int}' [-Werror=format=]
       return g_strdup_printf ("1:%lu-%ld.%ld",

Explicitly cast the time_t to long long which is 64 bit safe.

At least on x32, struct timeval's tv_nsec is misdefined to be a long
long, although the specification says "long". Work around this
by explicitly casting to long, which is a no-op on most platforms and
safe on x32 as tv_nsec never exceeds 1 billion. This works around
<http://bugs.debian.org/861026>.