### PR TITLE
Image refresh for debian-8

### DIFF
--- a/test/images/debian-8
+++ b/test/images/debian-8
@@ -1,1 +1,1 @@
-debian-8-d8df1a69d1725ad05ef063802cac3ff947f9c80f.qcow2
+debian-8-a1256fd073f45b2f76c58cc257f7b62fe5157502.qcow2


### PR DESCRIPTION
Image creation for debian-8 in process on cockpit-10.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-8-2017-04-26/