### PR TITLE
test: Build centos-7 from latest image

### DIFF
--- a/test/images/scripts/centos-7.bootstrap
+++ b/test/images/scripts/centos-7.bootstrap
@@ -1,4 +1,9 @@
 #! /bin/bash
 
 BASE=$(dirname $0)
-$BASE/virt-builder-fedora "$1" centos-7.3 x86_64
+# get the latest centos-7 virt-builder has to offer
+IMAGE_BASE=centos-7
+ARCH=x86_64
+CENTOS_LATEST=$(virt-builder -l | grep "$ARCH" | sort -r | grep -m 1 "$IMAGE_BASE" | cut -d" " -f1)
+
+$BASE/virt-builder-fedora "$1" "$CENTOS_LATEST" "$ARCH"


### PR DESCRIPTION
This way we don't miss an update but get it automatically when it's
available. We explicitly don't want to change the major version
automatically at this point.

```shell
[admin@localhost ~]$ CENTOS_LATEST=$(virt-builder -l | sort -r | grep -m 1 centos-7 | cut -d" " -f1)
[admin@localhost ~]$ echo "$CENTOS_LATEST"
centos-7.3
```