### PR TITLE
Image refresh for fedora-26

### DIFF
--- a/test/images/fedora-26
+++ b/test/images/fedora-26
@@ -1,1 +1,0 @@
-fedora-26-c6aee1b1ab6b33c9c4d6153c715889df3caa9627.qcow2


### PR DESCRIPTION
Image creation for fedora-26 in process on cockpit-10.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-26-2017-04-27/