### PR TITLE
Image refresh for debian-testing

### DIFF
--- a/test/images/debian-testing
+++ b/test/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-8dd7a8ba1d848ca9380e7ff1f57184349db075bb.qcow2
+debian-testing-6125b4ff8fffcfc58ef0c6a9eb017c19b3929956.qcow2


### PR DESCRIPTION
Image creation for debian-testing in process on cockpit-9.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-testing-2017-04-27/