### PR TITLE
test: Tell the verify machines that test/debian-stable exists

### DIFF
--- a/test/common/testinfra.py
+++ b/test/common/testinfra.py
@@ -62,6 +62,7 @@ DEFAULT_VERIFY = {
     'verify/centos-7': [ 'master', 'pulls' ],
     'verify/continuous-atomic': [ 'master' ],
     'verify/debian-8': [ 'master', 'pulls', ],
+    'verify/debian-stable': [ ],
     'verify/debian-testing': [ 'master', 'pulls' ],
     'verify/fedora-24': [ ],
     'verify/fedora-25': [ 'master', 'pulls' ],


### PR DESCRIPTION
In PR #6407 we will rename debian-8 to debian-stable. In order to start
(manual) testing there, add it to DEFAULT_VERIFY.