### PR TITLE
Image refresh for fedora-i386

### DIFF
--- a/test/images/fedora-i386
+++ b/test/images/fedora-i386
@@ -1,1 +1,1 @@
-fedora-i386-1e34bf7fe194b90cbe122ea58db41164a52689c5.qcow2
+fedora-i386-0ab86be36e742ecff8326f0842b0fd87222e0bd7.qcow2


### PR DESCRIPTION
Image creation for fedora-i386 in process on cockpit-9.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-i386-2017-05-02/