### PR TITLE
Image refresh for debian-stable

### DIFF
--- a/test/images/debian-stable
+++ b/test/images/debian-stable
@@ -1,1 +1,1 @@
-debian-stable-ec55491d9655ba25e324b784c55e4a706eeff9fe.qcow2
+debian-stable-1fae94a017e08baa0ca6ce82165c929fb3419f1e.qcow2


### PR DESCRIPTION
Image creation for debian-stable in process on cockpit-11.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-stable-2017-05-02/