### PR TITLE
tools: Make phantomjs-prebuilt an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "CockpitDevelopmentDependencies",
   "description": "Cockpit isn't a Node package, these are devel time deps, not needed to build tarball either",
   "private": true,
+  "optionalDependencies": {
+    "phantomjs-prebuilt": "~2.1.14"
+  },
   "devDependencies": {
     "babel-core": "~5.8.38",
     "babel-loader": "~5.4.2",
@@ -26,7 +29,6 @@
     "less": "~2.6.0",
     "less-loader": "~2.2.3",
     "ng-cache-loader": "0.0.16",
-    "phantomjs-prebuilt": "~2.1.14",
     "po2json": "~0.4.1",
     "promise": "~7.1.1",
     "raw-loader": "~0.5.1",


### PR DESCRIPTION
Tests won't run if it fails, but we shouldn't require it for building.

Fixes #6428