### PR TITLE
test: Drop override for kubernetes broken selfLink

### DIFF
--- a/test/verify/naughty-centos-7/6059-kubernetes-broken-selfLink
+++ b/test/verify/naughty-centos-7/6059-kubernetes-broken-selfLink
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "kubelib.py", line *, in testNodes
-    b.wait_not_present("modal-dialog")
-*
-the server could not find the requested resource

--- a/test/verify/naughty-centos-7/6059-kubernetes-broken-selfLink-2
+++ b/test/verify/naughty-centos-7/6059-kubernetes-broken-selfLink-2
@@ -1,4 +1,0 @@
-Traceback (most recent call last):
-  File "kubelib.py", line *, in testVolumes
-    b.wait_present(".pv-listing")*
-the server could not find the requested resource

--- a/test/verify/naughty-rhel-7/6059-kubernetes-broken-selfLink
+++ b/test/verify/naughty-rhel-7/6059-kubernetes-broken-selfLink
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "kubelib.py", line *, in testNodes
-    b.wait_not_present("modal-dialog")
-*
-the server could not find the requested resource

--- a/test/verify/naughty-rhel-7/6059-kubernetes-broken-selfLink-2
+++ b/test/verify/naughty-rhel-7/6059-kubernetes-broken-selfLink-2
@@ -1,4 +1,0 @@
-Traceback (most recent call last):
-  File "kubelib.py", line *, in testVolumes
-    b.wait_present(".pv-listing")*
-the server could not find the requested resource


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1430427 got fixed recently in RHEL-7/Centos-7,
so kubernetes should have working selfLinks again.

Fixes #6059

---

- [x] Let's first verify that the tests agree, I'll drop WIP if/once they are green.