### PR TITLE
test: Rebuild RHEL Atomic image with predictable names

### DIFF
--- a/test/images/rhel-atomic
+++ b/test/images/rhel-atomic
@@ -1,1 +1,1 @@
-rhel-atomic-ed6e1448e75468d3b4070e7a7418170149ecd0ec.qcow2
+rhel-atomic-293005d165d5fa506ae6edd31c41bf197385f160.qcow2


### PR DESCRIPTION
This is a followup from #6403 which forgot to rebuild the
rhel-atomic image.