### PR TITLE
Image refresh for debian-testing

### DIFF
--- a/test/images/debian-testing
+++ b/test/images/debian-testing
@@ -1,1 +1,0 @@
-debian-testing-4dd13cffa89c755091e40b1fedbd882b5dd70134.qcow2


### PR DESCRIPTION
Image creation for debian-testing in process on cockpit-tests-9clqx.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-testing-2017-05-04/