### PR TITLE
tools: Lower docker.io to a Recommends: for Debian cockpit-docker packages

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -85,9 +85,9 @@ Description: Cockpit deployment and developer guide
 Package: cockpit-docker
 Architecture: all
 Depends: ${misc:Depends},
-         docker.io (>= 1.3.0) | docker-engine (>= 1.3.0) | docker-ce (>= 1.3.0),
          python3,
          cockpit-bridge (>= ${bridge:minversion}),
+Recommends: docker.io (>= 1.3.0) | docker-engine (>= 1.3.0) | docker-ce (>= 1.3.0),
 Description: Cockpit user interface for Docker containers
  The Cockpit components for interacting with Docker and user interface.
 


### PR DESCRIPTION
In Debian, docker.io is rather hopeless right now and neither available
in stable nor in testing. Lower cockpit-docker's docker.io dependency to
a Recommends: to unblock it from testing migration and backportability;
it gracefully handles the case when docker.io is not installed.

Debian users can still install the package from jessie-backports (as we
do on our test images) or directly from upstream.