### PR TITLE
lib: Fix remote hosts with nonstandard port

### DIFF
--- a/pkg/lib/machines.js
+++ b/pkg/lib/machines.js
@@ -172,11 +172,16 @@
         }
 
         function update_saved_machine(host, values) {
-            // wrap values in variants for D-Bus call
+            // wrap values in variants for D-Bus call; at least values.port can
+            // be int or string, so stringify everything but the "visible" boolean
             var values_variant = {};
             for (var prop in values)
-                if (values[prop] !== null)
-                    values_variant[prop] = cockpit.variant(prop == "visible" ? 'b' : 's', values[prop]);
+                if (values[prop] !== null) {
+                    if (prop == "visible")
+                        values_variant[prop] = cockpit.variant('b', values[prop]);
+                    else
+                        values_variant[prop] = cockpit.variant('s', values[prop].toString());
+                }
 
             // FIXME: investigate re-using the proxy from Loader (runs in different frame/scope)
             var bridge = cockpit.dbus(null, { bus: "internal", "superuser": "try" });

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -130,10 +130,12 @@ class TestMultiMachineAdd(MachineCase):
         b = self.browser
         m2 = self.machine2
         m3 = self.machine3
+        change_ssh_port(m3, 2222)
 
         self.login_and_go(None)
         add_machine(b, m2.address)
-        add_machine(b, m3.address)
+        m3_con = m3.address + ":2222"
+        add_machine(b, m3_con)
 
         # TODO: The concrete error message when killing the bridge and
         # session is not predictable.  So we just wait for any error
@@ -167,7 +169,7 @@ class TestMultiMachineAdd(MachineCase):
         b.click("#dashboard-hosts a[data-address='%s']" % m3.address)
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname != "/dashboard"')
-        b.enter_page("/system", host=m3.address)
+        b.enter_page("/system", host=m3_con)
         b.wait_text_not("#system_information_hostname_button", "")
         b.switch_to_top()
         b.go("/dashboard")


### PR DESCRIPTION
The connection properties' "port" field  is an integer, so mark it as
such when building the GVariant wrapper in `update_saved_machine()`.

Fixes #6291