### PR TITLE
test: Keep downloaded xz files when $TEST_DATA is in use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,8 +98,9 @@ depcomp
 /src/selinux/cockpit.pp
 /pkg/*/test-*.log
 /pkg/*/test-*.trs
-/test/images/*.*
-/test/images/*-checksum
+/test/images/*.qcow2
+/test/images/*.partial
+/test/images/*.xz
 /test/container-probe*
 /mock/
 *.min.html


### PR DESCRIPTION
When ```$TEST_DATA``` is in use, such as in the ```cockpit/tests``` containers, keep the ```.xz``` files around for downloaded images.

Further work in cockpituous will allow these files to be reshared between various testers via http, and possibly via bittorrent.