### PR TITLE
branding: Use normal automake variables for disting branding

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,6 @@ EXTRA_DIST = \
 	.bowerrc \
 	bower.json \
 	package.json \
-	src/branding \
 	README.md \
 	$(NULL)
 

--- a/src/branding/centos/Makefile.am
+++ b/src/branding/centos/Makefile.am
@@ -4,6 +4,8 @@ centosbranding_DATA = \
 	src/branding/centos/branding.css \
 	$(NULL)
 
+EXTRA_DIST += $(centosbranding_DATA)
+
 # Opportunistically use fedora-logos
 install-data-hook::
 	$(LN_S) -f /usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(centosbrandingdir)/logo.png

--- a/src/branding/debian/Makefile.am
+++ b/src/branding/debian/Makefile.am
@@ -2,7 +2,10 @@ debianbrandingdir = $(datadir)/cockpit/branding/debian
 
 debianbranding_DATA = \
 	src/branding/debian/branding.css \
+	src/branding/debian/favicon.ico \
 	$(NULL)
+
+EXTRA_DIST += $(debianbranding_DATA)
 
 # Opportunistically use debconf debian logos
 install-data-hook::

--- a/src/branding/default/Makefile.am
+++ b/src/branding/default/Makefile.am
@@ -1,11 +1,16 @@
 defaultbrandingdir = $(datadir)/cockpit/branding/default
 
 defaultbranding_DATA = \
-	src/branding/default/branding.css \
+	src/branding/default/apple-touch-icon.png \
 	src/branding/default/bg-login.jpg \
 	src/branding/default/bg-plain.jpg \
+	src/branding/default/branding.css \
 	src/branding/default/brand-large.png \
-	src/branding/default/logo.png \
-	src/branding/default/apple-touch-icon.png \
 	src/branding/default/favicon.ico \
+	src/branding/default/logo.png \
+	$(NULL)
+
+EXTRA_DIST += \
+	$(defaultbranding_DATA) \
+	src/branding/default/logo.svg \
 	$(NULL)

--- a/src/branding/fedora/Makefile.am
+++ b/src/branding/fedora/Makefile.am
@@ -4,6 +4,8 @@ fedorabranding_DATA = \
 	src/branding/fedora/branding.css \
 	$(NULL)
 
+EXTRA_DIST += $(fedorabranding_DATA)
+
 # Opportunistically use fedora-logos
 install-data-hook::
 	$(LN_S) -f /usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(fedorabrandingdir)/logo.png

--- a/src/branding/kubernetes/Makefile.am
+++ b/src/branding/kubernetes/Makefile.am
@@ -3,3 +3,5 @@ kubernetesbrandingdir = $(datadir)/cockpit/branding/kubernetes
 kubernetesbranding_DATA = \
 	src/branding/kubernetes/branding.css \
 	$(NULL)
+
+EXTRA_DIST += $(kubernetesbranding_DATA)

--- a/src/branding/registry/Makefile.am
+++ b/src/branding/registry/Makefile.am
@@ -3,3 +3,5 @@ registrybrandingdir = $(datadir)/cockpit/branding/registry
 registrybranding_DATA = \
 	src/branding/kubernetes/branding.css \
 	$(NULL)
+
+EXTRA_DIST += $(registrybranding_DATA)

--- a/src/branding/rhel/Makefile.am
+++ b/src/branding/rhel/Makefile.am
@@ -5,6 +5,8 @@ rhelbranding_DATA = \
 	src/branding/rhel/bg-login.jpg \
 	$(NULL)
 
+EXTRA_DIST += $(rhelbranding_DATA)
+
 # Opportunistically use redhat-logos ... yes they're called 'fedora'
 install-data-hook::
 	$(LN_S) -f /usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(rhelbrandingdir)/logo.png

--- a/src/branding/ubuntu/Makefile.am
+++ b/src/branding/ubuntu/Makefile.am
@@ -2,7 +2,10 @@ ubuntubrandingdir = $(datadir)/cockpit/branding/ubuntu
 
 ubuntubranding_DATA = \
 	src/branding/ubuntu/branding.css \
+	src/branding/ubuntu/favicon.ico \
 	$(NULL)
+
+EXTRA_DIST += $(ubuntubranding_DATA)
 
 # Opportunistically use plymouth ubuntu logo
 install-data-hook::


### PR DESCRIPTION
We were trying to avoid a bunch of duplicate lines, but this
lead to races during 'make distcheck' and intermittent failures
during continuous integration:

      -> cd: /tmp/am-dc-579//home/runner/cockpit/cockpit-139.x/_inst/share/cockpit/branding/kubernetes: No such file or directory
      ->  ( cd '/tmp/am-dc-579//home/runner/cockpit/cockpit-139.x/_inst/share/man/man5' && rm -f cockpit.conf.5 )
      -> make[1]: *** [uninstall-kubernetesbrandingDATA] Error 1
      -> make[1]: *** Waiting for unfinished jobs....
      ( cd '/tmp/am-dc-579//home/runner/cockpit/cockpit-139.x/_inst/share/man/man5' && rm -f cockpit.conf.5 )
     make[1]: *** [uninstall-kubernetesbrandingDATA] Error 1
     make[1]: *** Waiting for unfinished jobs....