### PR TITLE
Image refresh for ubuntu-1604

### DIFF
--- a/test/images/ubuntu-1604
+++ b/test/images/ubuntu-1604
@@ -1,1 +1,1 @@
-ubuntu-1604-406d9ca6d0f3e93dfed3a31504ba258ebd44bcfd.qcow2
+ubuntu-1604-1bdcdbcb140a94bf2950a5b1473815ec0db6b242.qcow2


### PR DESCRIPTION
Image creation for ubuntu-1604 in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-ubuntu-1604-2017-05-09/