### PR TITLE
kubernetes: Fix incompatibility with certain Firefox versions

### DIFF
--- a/pkg/kubernetes/scripts/kube-client-cockpit.js
+++ b/pkg/kubernetes/scripts/kube-client-cockpit.js
@@ -484,11 +484,13 @@
                     channel.addEventListener("message", function(ev, data) {
                         if (base64)
                             data = "1" + window.btoa(data);
-                        var mev = document.createEvent('MessageEvent');
-                        if (!mev.initMessageEvent)
+                        var mev;
+                        if (window.MessageEvent) {
                             mev = new window.MessageEvent('message', { 'data': data });
-                        else
+                        } else {
+                            mev = document.createEvent('MessageEvent');
                             mev.initMessageEvent('message', false, false, data, null, null, window, null);
+                        }
                         ws.dispatchEvent(mev);
                     });
 
@@ -637,11 +639,13 @@
                     });
 
                     channel.addEventListener("message", function(ev, data) {
-                        var mev = document.createEvent('MessageEvent');
-                        if (!mev.initMessageEvent)
+                        var mev;
+                        if (window.MessageEvent) {
                             mev = new window.MessageEvent('message', { 'data': data });
-                        else
+                        } else {
+                            mev = document.createEvent('MessageEvent');
                             mev.initMessageEvent('message', false, false, data, null, null, window, null);
+                        }
                         ws.dispatchEvent(mev);
                     });
 


### PR DESCRIPTION
I get this error message when using Firefox 53 in the kubernetes
container view and open a shell:

MessageEvent.initMessageEvent can't be converted to a sequence.

I tried to substitute the last argument with null, undefined,
leave it out, all to no effect. This argument is not documented
here:

https://www.webplatform.org/docs/dom/MessageEvent/initMessageEvent/

In addition initMessageEvent is deprecated, so stop using
it when an alternative is available.