### PR TITLE
dashboard: Fix cockpit version dependency

### DIFF
--- a/pkg/dashboard/manifest.json.in
+++ b/pkg/dashboard/manifest.json.in
@@ -1,7 +1,7 @@
 {
     "version": "@VERSION@",
     "requires": {
-	"cockpit": "138.x"
+        "cockpit": "138"
     },
 
     "dashboard": {


### PR DESCRIPTION
The dashboard requires cockpit 138, not 138.x.