### PR TITLE
Image refresh for openshift

### DIFF
--- a/test/images/openshift
+++ b/test/images/openshift
@@ -1,1 +1,0 @@
-openshift-7b287ee1fabc7497f35ba8dbca54d715866eb27c.qcow2


### PR DESCRIPTION
Image creation for openshift in process on cockpit-tests-kx457.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-openshift-2017-05-11/