### PR TITLE
WIP: Networkmanager zones

### DIFF
--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -177,6 +177,19 @@
     </div>
   </script>
 
+  <script id="network-zone-settings-template" type="x-template/mustache">
+    <table class="form-table-ct">
+      <tr>
+        <td>
+          <label class="control-label" translatable="yes">Zone</label>
+        </td>
+        <td id="network-zone-settings-zone-select">
+          {{! the rather complex dropdown-select will be created dynamically via jquery }}
+        </td>
+      </tr>
+    </table>
+  </script>
+
   <script id="network-mac-settings-template" type="x-template/mustache">
     <table class="form-table-ct">
       <tr>
@@ -786,6 +799,30 @@
           </div>
           <button class="btn btn-default" translatable="yes" id="network-mtu-settings-cancel">Cancel</button>
           <button class="btn btn-primary" translatable="yes" id="network-mtu-settings-apply">Apply</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal" id="network-zone-settings-dialog"
+       tabindex="-1" role="dialog"
+       data-backdrop="static">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h4 class="modal-title" translatable="yes">Firewall Zone</h4>
+        </div>
+        <div class="modal-body">
+          <div id="network-zone-settings-body">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <div class="alert alert-danger dialog-error" id="network-zone-settings-error">
+            <i class="fa fa-exclamation-triangle"></i>
+            <span></span>
+          </div>
+          <button class="btn btn-default" translatable="yes" id="network-zone-settings-cancel">Cancel</button>
+          <button class="btn btn-primary" translatable="yes" id="network-zone-settings-apply">Apply</button>
         </div>
       </div>
     </div>

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -95,6 +95,7 @@
           <tr>
             <th translatable="yes">Name</th>
             <th translatable="yes">IP Address</th>
+            <th translatable="yes">Zone</th>
             <th translatable="yes" class="networking-speed">Sending</th>
             <th translatable="yes" class="networking-speed">Receiving</th>
           </tr>
@@ -113,6 +114,7 @@
           <tr>
             <th translatable="yes">Name</th>
             <th translatable="yes">IP Address</th>
+            <th translatable="yes">Zone</th>
             <th translatable="yes" class="networking-speed">Sending</th>
             <th translatable="yes" class="networking-speed">Receiving</th>
           </tr>

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1666,8 +1666,8 @@ PageNetworking.prototype = {
                 var tx = samples[1][0];
                 var row = $('#networking-interfaces tr[data-sample-id="' + encodeURIComponent(iface) + '"]');
                 if (rx !== undefined && tx !== undefined && row.length > 0) {
-                    row.find('td:nth-child(3)').text(cockpit.format_bits_per_sec(tx * 8));
-                    row.find('td:nth-child(4)').text(cockpit.format_bits_per_sec(rx * 8));
+                    row.find('td:nth-child(4)').text(cockpit.format_bits_per_sec(tx * 8));
+                    row.find('td:nth-child(5)').text(cockpit.format_bits_per_sec(rx * 8));
                 }
             }
         }
@@ -1726,6 +1726,7 @@ PageNetworking.prototype = {
                 return;
 
             var dev = iface.Device;
+	    var zone = iface.Device.ActiveConnection.Connection.Settings.connection.zone;
             var show_traffic = (dev && (dev.State == 100 || dev.State == 10) && dev.Carrier === true);
 
             self.rx_series.add_instance(iface.Name);
@@ -1737,6 +1738,7 @@ PageNetworking.prototype = {
                                    }).
                          append($('<td>').text(iface.Name),
                                 $('<td>').html(render_active_connection(dev, false, true)),
+				$('<td>').text(zone_text(zone)),
                                 (show_traffic?
                                  [ $('<td>').text(""), $('<td>').text("") ] :
                                  $('<td colspan="2">').text(device_state_text(dev))));

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1726,7 +1726,13 @@ PageNetworking.prototype = {
                 return;
 
             var dev = iface.Device;
-	    var zone = iface.Device.ActiveConnection.Connection.Settings.connection.zone;
+	    var zone = null;
+	    if (dev &&
+		dev.ActiveConnection &&
+		dev.ActiveConnection.Connection &&
+		dev.ActiveConnection.Connection.Settings &&
+		dev.ActiveConnection.Connection.Settings.connection)
+		zone = dev.ActiveConnection.Connection.Settings.connection.zone;
             var show_traffic = (dev && (dev.State == 100 || dev.State == 10) && dev.Carrier === true);
 
             self.rx_series.add_instance(iface.Name);
@@ -2617,12 +2623,7 @@ PageNetworkInterface.prototype = {
 
             function render_zone_row() {
                 var rows = [ ];
-
-                function add_row(fmt, args) {
-                    rows.push(cockpit.format(fmt, args));
-                }
-
-		add_row(zone_text(settings.connection.zone), settings.connection.zone);
+		rows.push(zone_text(settings.connection.zone));
                 return render_settings_row(_("Zone"), rows, configure_zone_settings);
             }
 

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1727,12 +1727,10 @@ PageNetworking.prototype = {
 
             var dev = iface.Device;
 	    var zone = null;
-	    if (dev &&
-		dev.ActiveConnection &&
-		dev.ActiveConnection.Connection &&
-		dev.ActiveConnection.Connection.Settings &&
-		dev.ActiveConnection.Connection.Settings.connection)
-		zone = dev.ActiveConnection.Connection.Settings.connection.zone;
+	    if (iface.MainConnection &&
+		iface.MainConnection.Settings &&
+		iface.MainConnection.Settings.connection)
+		zone = iface.MainConnection.Settings.connection.zone;
             var show_traffic = (dev && (dev.State == 100 || dev.State == 10) && dev.Carrier === true);
 
             self.rx_series.add_instance(iface.Name);

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2275,7 +2275,7 @@ PageNetworkInterface.prototype = {
         this.dev = null;
     },
 
-    show_dialog: function(dialog, id) {
+    show_dialog: function(dialog, id, options) {
         var self = this;
         var con = self.main_connection;
         var dev = self.dev;
@@ -2297,7 +2297,8 @@ PageNetworkInterface.prototype = {
         dialog.connection = self.main_connection;
         dialog.ghost_settings = self.ghost_settings;
         dialog.apply_settings = settings_applier(self.model, self.dev, con);
-        dialog.done = reactivate_connection;
+        if (!options || !options.dont_reactivate_connection)
+            dialog.done = reactivate_connection;
         $(id).modal('show');
     },
 
@@ -2598,7 +2599,8 @@ PageNetworkInterface.prototype = {
             }
 
             function configure_zone_settings() {
-                self.show_dialog(PageNetworkZoneSettings, '#network-zone-settings-dialog');
+                self.show_dialog(PageNetworkZoneSettings, '#network-zone-settings-dialog',
+                                 { dont_reactivate_connection: true });
             }
 
             function render_autoconnect_row() {

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -105,7 +105,7 @@ class TestNetworking(NetworkCase):
         m.execute("nmcli dev dis %s" % iface2)
 
         b.wait_in_text("tr[data-interface='%s'] td:nth-child(2)" % iface1, "10.42.")
-        b.wait_text("tr[data-interface='%s'] td:nth-child(3)" % iface2, "Inactive")
+        b.wait_text("tr[data-interface='%s'] td:nth-child(4)" % iface2, "Inactive")
 
         b.click("button:contains('Add Bond')")
         b.wait_popup("network-bond-settings-dialog")

--- a/test/verify/check-networking-zone
+++ b/test/verify/check-networking-zone
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2013 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import parent
+from testlib import *
+from netlib import *
+
+class TestNetworking(NetworkCase):
+    def testZone(self):
+        b = self.browser
+        m = self.machine
+
+        # HACK - https://bugzilla.redhat.com/show_bug.cgi?id=1452017
+        self.allow_journal_messages("org\\.fedoraproject\\.FirewallD1: couldn't get all properties of org\\.fedoraproject\\.FirewallD1\\.zone at /org/fedoraproject/FirewallD1: GDBus\\.Error:org\\.freedesktop\\.DBus\\.Python\\.dbus\\.exceptions\\.DBusException: org\\.freedesktop\\.DBus\\.Error\\.UnknownInterface: FirewallD does not implement org\\.fedoraproject\\.FirewallD1\\.zone")
+
+        self.login_and_go("/network")
+
+        iface = self.add_iface()
+        self.wait_for_iface(iface)
+
+        b.click("#networking-interfaces tr[data-interface='%s']" % iface)
+        b.wait_visible("#network-interface")
+
+        b.click("tr:contains('Zone') a")
+        b.wait_popup("network-zone-settings-dialog")
+        b.wait_present("li[value=trusted] a")
+        b.click("li[value=trusted] a", True)
+        b.click("#network-zone-settings-apply")
+        b.wait_popdown("network-mtu-settings-dialog")
+        b.wait_in_text("#network-interface-settings tr:contains('Zone')", "trusted")
+
+if __name__ == '__main__':
+    test_main()


### PR DESCRIPTION
This adds firewall zones to the networkmanager plugin.

Patch 1 adds the zone setting to the connection settings page and adds a dialog to be able to change the zone setting. The available firewall zones are only gathered in the dialog from firewalld.

Patch 2 adds the zone setting to the interfaces list in the main page.