### PR TITLE
Image refresh for centos-7

### DIFF
--- a/test/images/centos-7
+++ b/test/images/centos-7
@@ -1,1 +1,0 @@
-centos-7-f2fc14ebd13dd557dedd89c9a38ca8ef3af47589.qcow2


### PR DESCRIPTION
Image creation for centos-7 in process on cockpit-tests-v4dkw.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-centos-7-2017-05-13/