### PR TITLE
Image refresh for debian-testing

### DIFF
--- a/test/images/debian-testing
+++ b/test/images/debian-testing
@@ -1,1 +1,0 @@
-debian-testing-d052686efd86c9dc35b74ba58402884f616994c9.qcow2


### PR DESCRIPTION
Image creation for debian-testing in process on cockpit-tests-2qfs5.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-testing-2017-05-13/