### PR TITLE
Image refresh for fedora-atomic

### DIFF
--- a/test/images/fedora-atomic
+++ b/test/images/fedora-atomic
@@ -1,1 +1,1 @@
-fedora-atomic-091de34851deb1fe5cfe9d9fdf7206c695179eb8.qcow2
+fedora-atomic-a312a6eeca9a9117f593f3bc92aea9286270319fba24a4aa29427d307ad8fa3a.qcow2


### PR DESCRIPTION
Image creation for fedora-atomic in process on cockpit-tests-hl9bn.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-atomic-2017-05-13/