### PR TITLE
test: Add hack to work around buggy "mock --installdeps" for fedora-testing

### DIFF
--- a/test/images/fedora-testing
+++ b/test/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-bfe7fa533dbb71d1a7c19a01b0f9ebc39cd312b0.qcow2
+fedora-testing-902d7bcdbce3f5d8f16b7f9e78afeea42ed35185fa673e935d30cd080cc05a0b.qcow2

--- a/test/images/scripts/fedora-testing.install
+++ b/test/images/scripts/fedora-testing.install
@@ -1,1 +1,10 @@
-fedora-25.install
+#! /bin/bash
+
+set -e
+
+# HACK - We need to build with --no-bootstrap-chroot since that is how
+# we have initialized mock during setup.
+#
+# https://bugzilla.redhat.com/show_bug.cgi?id=1447627
+
+/var/lib/testvm/fedora.install --HACK-no-bootstrap-chroot "$@"

--- a/test/images/scripts/fedora-testing.setup
+++ b/test/images/scripts/fedora-testing.setup
@@ -83,17 +83,20 @@ dnf $DNF_OPTS -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
 dnf $DNF_OPTS -y install mock dnf-plugins-core rpm-build
 useradd -c Builder -G mock builder
 
-# HACK - mock --installdeps with yum is broken, it seems that it can't
-# run any package scriptlets.  Yum is deprecated anyway so we just use
-# dnf.  I wonder why dnf isn't the default anyway...
-#
-echo "config_opts['package_manager'] = 'dnf'" >>/etc/mock/site-defaults.cfg
-
 # Enable updates-testing in mock
 echo "config_opts['yum.conf'] += '[updates-testing]\nenabled=1'" >>/etc/mock/default.cfg
 
 srpm=$(/var/lib/testvm/make-srpm $TEST_SOURCE)
-su builder -c "/usr/bin/mock --verbose --installdeps $srpm"
+
+# HACK - mock --installdeps is broken, it seems that it forgets to
+# copy the source rpm to a location that dnf can actually access.  A
+# workaround is to pass "--no-bootstrap-chroot".
+#
+# When you remove this hack, also remove it in fedora-testing.install.
+#
+# https://bugzilla.redhat.com/show_bug.cgi?id=1447627
+
+su builder -c "/usr/bin/mock --no-bootstrap-chroot --verbose --installdeps \"$PWD/$srpm\""
 
 # HACK: docker fails without /etc/resolv.conf
 # https://bugzilla.redhat.com/show_bug.cgi?id=1448331


### PR DESCRIPTION
Commit b3b74f0c85f7 adds a workaround on Fedora 26 for a mock regression
<https://bugzilla.redhat.com/show_bug.cgi?id=1447627>.

This buggy mock has made it into Fedora 25 updates-testing now
(https://bodhi.fedoraproject.org/updates/FEDORA-2017-6b4200df6e) so
apply it there too.