### PR TITLE
Make cockpit-dashboard work with package layering

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -436,6 +436,8 @@ class Browser:
 
 
 class MachineCase(unittest.TestCase):
+    image = testvm.DEFAULT_IMAGE
+    runner = None
     machine = None
     machines = { }
     machine_class = None
@@ -451,9 +453,11 @@ class MachineCase(unittest.TestCase):
         (unused, sep, label) = self.id().partition(".")
         return label.replace(".", "-")
 
-    def new_machine(self, image=testvm.DEFAULT_IMAGE, forward={ }, **kwargs):
+    def new_machine(self, image=None, forward={ }, **kwargs):
         import testvm
         machine_class = self.machine_class
+        if image is None:
+            image = self.image
         if opts.address:
             if machine_class or forward:
                 raise unittest.SkipTest("Cannot run this test when specific machine address is specified")

--- a/test/verify/atomiclib.py
+++ b/test/verify/atomiclib.py
@@ -1,0 +1,10 @@
+def overlay_dashboard(m):
+    # If we can do package overlays on Atomic host, then try that here
+    # This tests the case that cockpit-dashboard is installable via
+    # package overlays on Atomic Host
+    # The libssh RPM was placed by the atomic setup scripts
+
+    if m.image in [ "fedora-atomic", "rhel-atomic", "continuous-atomic" ]:
+        m.execute("rm -rf /etc/yum.repos.d/* && rpm-ostree install /root/rpms/libssh-*.rpm /var/tmp/build-results/cockpit-dashboard-*.rpm")
+        m.spawn("sleep 2 && systemctl reboot", "reboot")
+        m.wait_reboot()

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -19,6 +19,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import json
+
 import parent
 from testlib import *
 
@@ -69,13 +70,29 @@ class DashBoardHelpers:
             b.click('#dashboard_setup_server_dialog .btn-primary')
         b.wait_popdown('dashboard_setup_server_dialog')
 
-@skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
+    def overlay_dashboard(self):
+        m = self.machine
+
+        # If we can do package overlays on Atomic host, then try that here
+        # This tests the case that cockpit-dashboard is installable via
+        # package overlays on Atomic Host
+        # The libssh RPM was placed by the atomic setup scripts
+
+        if m.image in [ "fedora-atomic", "rhel-atomic", "continuous-atomic" ]:
+            m.execute("rm -rf /etc/yum.repos.d/* && rpm-ostree install /root/rpms/libssh-*.rpm /var/tmp/build-results/cockpit-dashboard-*.rpm")
+            m.spawn("sleep 2 && systemctl reboot", "reboot")
+            m.wait_reboot()
+
 class TestBasicDashboard(MachineCase, DashBoardHelpers):
     provision = {
         'machine1': { "address": "10.111.113.1/20" },
         'machine2': { "address": "10.111.113.2/20" },
         'machine3': { "address": "10.111.113.3/20" }
     }
+
+    def setUp(self):
+        super(TestBasicDashboard, self).setUp()
+        self.overlay_dashboard()
 
     def testBasic(self):
         b = self.browser
@@ -144,7 +161,7 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
         self.machine_remove (b, "10.111.113.2")
         self.wait_dashboard_addresses (b, [ "localhost", "10.111.113.3" ])
         key = m.execute("grep '10.111.113.2' /etc/ssh/ssh_known_hosts && sed -i '/10.111.113.2/d' /etc/ssh/ssh_known_hosts")
-        m.execute("mkdir ~admin/.ssh && echo '{0}' > ~admin/.ssh/known_hosts && chown -R admin:admin ~admin/.ssh""".format(key))
+        m.execute("mkdir -p ~admin/.ssh && echo '{0}' > ~admin/.ssh/known_hosts && chown -R admin:admin ~admin/.ssh""".format(key))
         self.add_machine (b, "10.111.113.2", True)
         self.wait_dashboard_addresses (b, [ "localhost", "10.111.113.2", "10.111.113.3" ])
         # Should be connected, no error
@@ -203,13 +220,16 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
         self.allow_hostkey_messages()
         self.allow_journal_messages(".*server offered unsupported authentication methods: password public-key.*")
 
-@skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestDashboardSetup(MachineCase, DashBoardHelpers):
     provision = {
         'machine1': { "address": "10.111.113.1/20" },
         'machine2': { "address": "10.111.113.2/20" },
         'machine3': { "address": "10.111.113.3/20" }
     }
+
+    def setUp(self):
+        super(TestDashboardSetup, self).setUp()
+        self.overlay_dashboard()
 
     def testSetup(self):
         b = self.browser
@@ -299,6 +319,7 @@ class TestDashboardSetup(MachineCase, DashBoardHelpers):
         m2.execute("ps aux | grep cockpit-bridge | grep admin")
         self.allow_hostkey_messages()
 
+    @skipImage("No migration on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
     def testMachinesJsonVarMigration(self):
         b = self.browser
         m = self.machine
@@ -315,6 +336,7 @@ class TestDashboardSetup(MachineCase, DashBoardHelpers):
 
         # create obsolete machines.json in /var
         blue_conf = '{"blue": {"address": "10.111.113.2", "visible": true}}'
+        m.execute("mkdir -p /var/lib/cockpit")
         m.execute("echo '%s' > /var/lib/cockpit/machines.json" % blue_conf)
         # prevent migration due to permission error; should not crash and keep/respect the old file
         m.execute("""chattr +i /etc/cockpit/machines.d""")

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -21,7 +21,9 @@
 import json
 
 import parent
+import atomiclib
 from testlib import *
+
 
 class DashBoardHelpers:
     def check_discovered_addresses(self, b, addresses):
@@ -70,19 +72,6 @@ class DashBoardHelpers:
             b.click('#dashboard_setup_server_dialog .btn-primary')
         b.wait_popdown('dashboard_setup_server_dialog')
 
-    def overlay_dashboard(self):
-        m = self.machine
-
-        # If we can do package overlays on Atomic host, then try that here
-        # This tests the case that cockpit-dashboard is installable via
-        # package overlays on Atomic Host
-        # The libssh RPM was placed by the atomic setup scripts
-
-        if m.image in [ "fedora-atomic", "rhel-atomic", "continuous-atomic" ]:
-            m.execute("rm -rf /etc/yum.repos.d/* && rpm-ostree install /root/rpms/libssh-*.rpm /var/tmp/build-results/cockpit-dashboard-*.rpm")
-            m.spawn("sleep 2 && systemctl reboot", "reboot")
-            m.wait_reboot()
-
 class TestBasicDashboard(MachineCase, DashBoardHelpers):
     provision = {
         'machine1': { "address": "10.111.113.1/20" },
@@ -92,7 +81,7 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
 
     def setUp(self):
         super(TestBasicDashboard, self).setUp()
-        self.overlay_dashboard()
+        atomiclib.overlay_dashboard(self.machine)
 
     def testBasic(self):
         b = self.browser
@@ -229,7 +218,7 @@ class TestDashboardSetup(MachineCase, DashBoardHelpers):
 
     def setUp(self):
         super(TestDashboardSetup, self).setUp()
-        self.overlay_dashboard()
+        atomiclib.overlay_dashboard(self.machine)
 
     def testSetup(self):
         b = self.browser
@@ -371,8 +360,11 @@ class TestDashboardSetup(MachineCase, DashBoardHelpers):
             '.*refusing to connect to unknown host.*'
         )
 
-@skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestDashboardEditLimits(MachineCase, DashBoardHelpers):
+    def setUp(self):
+        super(TestDashboardEditLimits, self).setUp()
+        atomiclib.overlay_dashboard(self.machine)
+
     def testEdit(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -22,6 +22,7 @@ import subprocess
 import re
 import time
 
+import atomiclib
 import parent
 from testlib import *
 
@@ -115,7 +116,6 @@ def change_ssh_port(machine, address, port=None, timeout_sec=120):
         time.sleep(0.5)
     raise error
 
-@skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestMultiMachineAdd(MachineCase):
     provision = {
         "machine1": { "address": "10.111.113.1/20" },
@@ -129,6 +129,7 @@ class TestMultiMachineAdd(MachineCase):
         self.machine2.execute("hostnamectl set-hostname machine2")
         self.machine3 = self.machines['machine3']
         self.machine3.execute("hostnamectl set-hostname machine3")
+        atomiclib.overlay_dashboard(self.machine)
 
     def testBasic(self):
         b = self.browser
@@ -196,7 +197,6 @@ class TestMultiMachineAdd(MachineCase):
                                     ".*: bridge program failed: Child process exited with code .*")
 
 
-@skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestMultiMachine(MachineCase):
     provision = {
         "machine1": { "address": "10.111.113.1/20" },
@@ -208,6 +208,7 @@ class TestMultiMachine(MachineCase):
         MachineCase.setUp(self)
         self.machine2 = self.machines['machine2']
         self.machine2.execute("hostnamectl set-hostname machine2")
+        atomiclib.overlay_dashboard(self.machine)
 
     def checkDirectLogin(self, root='/'):
         b = self.browser
@@ -256,11 +257,15 @@ class TestMultiMachine(MachineCase):
         else:
             m2_dashboard_name = "machine2"
 
-        b.click("a[href='/dashboard']")
-        b.enter_page("/dashboard")
-        b.wait_present("a[data-address='localhost']")
-        b.wait_in_text("a[data-address='localhost']", m2_dashboard_name)
-        b.wait_not_present("a[data-address='10.111.113.2']")
+        # Dashboard is not installed on secondary atomic machines
+        if not m2.atomic_image:
+            b.click("a[href='/dashboard']")
+            b.enter_page("/dashboard")
+            b.wait_present("a[data-address='localhost']")
+            b.wait_in_text("a[data-address='localhost']", m2_dashboard_name)
+            b.wait_not_present("a[data-address='10.111.113.2']")
+        else:
+            b.wait_not_present("a[href='/dashboard']")
         b.logout()
 
         # Falls back to legacy /var/lib/cockpit/known_hosts
@@ -417,11 +422,15 @@ class TestMultiMachine(MachineCase):
         b.wait_in_text('#system_information_hostname_button', "machine2")
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname == "{0}=10.111.113.2/system"'.format(root))
-        b.click("a[href='/dashboard']")
-        b.enter_page("/dashboard")
-        b.wait_present("a[data-address='localhost']")
-        b.wait_in_text("a[data-address='localhost']", m2_dashboard_name)
-        b.wait_not_present("a[data-address='10.111.113.2']")
+
+        if not m2.atomic_image:
+            b.click("a[href='/dashboard']")
+            b.enter_page("/dashboard")
+            b.wait_present("a[data-address='localhost']")
+            b.wait_in_text("a[data-address='localhost']", m2_dashboard_name)
+            b.wait_not_present("a[data-address='10.111.113.2']")
+        else:
+            b.wait_not_present("a[href='/dashboard']")
 
         # Might happen when we switch away.
         self.allow_hostkey_messages()

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -19,6 +19,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent
+import atomiclib
 from testlib import *
 
 import subprocess
@@ -55,7 +56,6 @@ KEY_IDS_MD5 = [
     "256 b5:80:1b:f5:98:89:2a:39:f3:78:b3:64:5c:64:33:17 /home/admin/.ssh/id_ed25519 (ED25519)"
 ]
 
-@skipImage("No cockpit-ssh on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestMultiMachineKeyAuth(MachineCase):
     provision = {
         "machine1": { "address": "10.111.113.1/20" },
@@ -92,6 +92,7 @@ class TestMultiMachineKeyAuth(MachineCase):
 
     def setUp(self):
         MachineCase.setUp(self)
+        atomiclib.overlay_dashboard(self.machine)
         self.machine2 = self.machines['machine2']
 
         # Add user
@@ -129,8 +130,9 @@ class TestMultiMachineKeyAuth(MachineCase):
             b.wait_js_cond('loaded === true');
             self.check_keys(["2048 93:40:9e:67:82:78:a8:99:89:39:d5:ba:e0:50:70:e1 id_rsa (RSA)"],
                             ["2048 SHA256:SRvBhCmkCEVnJ6ascVH0AoVEbS3nPbowZkNevJnXtgw id_rsa (RSA)"])
-        # Check our keys were loaded.
-        self.check_keys(KEY_IDS_MD5, KEY_IDS)
+        else:
+            # Check our keys were loaded.
+            self.check_keys(KEY_IDS_MD5, KEY_IDS)
 
         # Add machine
         b.switch_to_top()
@@ -220,10 +222,6 @@ class TestMultiMachineKeyAuth(MachineCase):
                                     "Error executing command as another user: Not authorized",
                                     "This incident has been reported.",
                                     "sudo: a password is required")
-
-        # No dashboard on Atomic Host
-        if m1.image in [ "continuous-atomic", "fedora-atomic", "rhel-atomic" ]:
-            return
 
         # We expect this iframe to be active
         b.switch_to_top()

--- a/test/verify/check-multi-os
+++ b/test/verify/check-multi-os
@@ -19,6 +19,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent
+import atomiclib
 from testlib import *
 
 def wait_dashboard_addresses(b, expected):
@@ -60,6 +61,10 @@ class TestMultiOS(MachineCase):
         "0": { "address": "10.111.113.1/20" },
         "fedora-stock": { "address": "10.111.113.5/20", "image": "fedora-stock" }
     }
+
+    def setUp(self):
+        super(TestMultiOS, self).setUp()
+        atomiclib.overlay_dashboard(self.machine)
 
     def check_spawn(self, b, address):
         result = b.call_js_func("""(function(address) {
@@ -178,7 +183,6 @@ class TestMultiOS(MachineCase):
         self.allow_journal_messages("usermod: user 'postfix' does not exist")
         self.allow_journal_messages(".*pam_authenticate failed: Authentication failure")
 
-    @skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
     def testFedora22(self):
         try:
             self.checkStock()
@@ -193,7 +197,10 @@ class TestMultiOSDirect(MachineCase):
         "fedora-23-stock": { "address": "10.111.113.5/20", "image": "fedora-23-stock" }
     }
 
-    @skipImage("No dashboard on Atomic", "continuous-atomic", "fedora-atomic", "rhel-atomic")
+    def setUp(self):
+        super(TestMultiOSDirect, self).setUp()
+        atomiclib.overlay_dashboard(self.machine)
+
     def testFedora23Direct(self):
         b = self.browser
 


### PR DESCRIPTION
Users should be able to install cockpit-dashboard using RPM OSTree package layering.

 * [x] Test this with real koji builds
 * [x] projectatomic/rpm-ostree#780
 * [x] #7443
 * [x] #7444 
 * [x] New Atomic Host images
 * [x] Integration tests