### PR TITLE
ssh: Fix cockpit version dependency

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
+# manual comment added to force update in the patch system
 export PATH := $(PATH):$(abs_srcdir)/node_modules/.bin
 
 NULL =

--- a/pkg/ssh/manifest.json.in
+++ b/pkg/ssh/manifest.json.in
@@ -1,7 +1,7 @@
 {
     "version": "@VERSION@",
     "requires": {
-        "cockpit": "138.x"
+        "cockpit": "138"
     },
     "priority": 100,
     "bridges": [

--- a/tools/semaphore-prepare
+++ b/tools/semaphore-prepare
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 change-phantomjs-version 2.1.1
+sudo rm /etc/apt/sources.list.d/*
 sudo apt-get update
 sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-login-dev libsystemd-journal-dev libkrb5-dev pcp pkg-config valgrind xmlto xsltproc pyflakes npm nodejs-legacy git libfontconfig1 dbus ssh libglib2.0-0-dbg glib-networking-dbg


### PR DESCRIPTION
The ssh package requires cockpit 138, not 138.x, since it's a patched version of 138.