### PR TITLE
test: Disable all third-party repos in semaphore

### DIFF
--- a/tools/semaphore-prepare
+++ b/tools/semaphore-prepare
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 change-phantomjs-version 2.1.1
+sudo rm /etc/apt/sources.list.d/*
 sudo apt-get update
 sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-login-dev libsystemd-journal-dev libkrb5-dev pcp pkg-config valgrind xmlto xsltproc pyflakes npm nodejs-legacy git libfontconfig1 dbus ssh libglib2.0-0-dbg glib-networking-dbg curl
 


### PR DESCRIPTION
Semaphore adds 21(!) third-party apt sources. This currently causes an
authentication failure for git as they added a PPA without adding the
corresponding public key. We don't need any packages from those
third-party sources, they only make stuff harder to reproduce locally
and package installation less reliable.

So disable all third-party sources in apt.

----

Setting 'bot' as this only affects semaphore. Setting 'priority' as currently all our semaphore runs fail due to this, let's fix testing ASAP.