### PR TITLE
machines: Dropdown buttons for actions are deduplicated

### DIFF
--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -159,15 +159,15 @@ StateIcon.propTypes = {
  * @constructor
  */
 export const DropdownButtons = ({ buttons }) => {
-    const buttonsHtml = buttons.map(
-        button => {
+    const buttonsHtml = buttons
+        .filter(button => buttons[0].id === undefined || buttons[0].id !== button.id)
+        .map(button => {
             return (<li className='presentation'>
                 <a role='menuitem' onClick={button.action} id={button.id}>
                     {button.title}
                 </a>
             </li>)
-        }
-    );
+        });
 
     const caretId = buttons[0]['id'] ? `${buttons[0]['id']}-caret` : undefined;
     return (<div className='btn-group'>


### PR DESCRIPTION
cockpi-machines: With this patch, the dropdown buttons list only unique buttons.

The default action (the only one visble when collapsed) is not
repeated in the list when the carret is clicked.

Before:
![01_before](https://cloud.githubusercontent.com/assets/17194943/26144771/68e5080a-3aea-11e7-99f6-3039b0129d51.png)

With the patch:
![02_after](https://cloud.githubusercontent.com/assets/17194943/26144772/68f49d56-3aea-11e7-8af7-ec7551ea3e49.png)
