### PR TITLE
test: Fix race waiting for container terminal

### DIFF
--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -339,6 +339,15 @@ CMD ["/bin/sh"]
         b.wait_present("#container-terminal .console-ct .terminal")
 
         b.focus('#container-terminal .console-ct .terminal')
+
+        # Wait for the container to wake up
+        try:
+            b.key_press( [ 'Return', 'Return', 'Return' ] )
+            b.wait_in_text("#container-terminal", "#")
+        except Error, ex:
+            if not ex.msg.startswith('timeout'):
+                raise
+
         b.key_press( [ 'c', 'l', 'e', 'a', 'r', 'Return' ] )
         b.wait_in_text("#container-terminal", "#")
 


### PR DESCRIPTION
It seems like on Debian we run into a race where our keystrokes
are not processed by the container. Likely because they arrive
before the container processes have started up.