### PR TITLE
test: Declare ubuntu-stable image

### DIFF
--- a/test/common/testinfra.py
+++ b/test/common/testinfra.py
@@ -82,6 +82,7 @@ DEFAULT_VERIFY = {
     'verify/rhel-7.4': [ ],
     'verify/rhel-atomic': BRANCHES,
     'verify/ubuntu-1604': [ 'master', 'rhel-7.4', 'rhel-7.3.5', 'rhel-7.3.4', 'rhel-7.3.3', 'rhel-7.3.2' ],
+    'verify/ubuntu-stable': [ ],
 }
 
 TESTING = "Testing in progress"


### PR DESCRIPTION
Declare the ubuntu-stable image which will soon be added.

-----

Now that Cockpit is in Ubuntu 17.04 and in backports down to 16.04 LTS, let's start testing on the latest Ubuntu release. Maybe at some point we want ubuntu-devel too (which should be fairly robust as it's gated through CI), but one step at a time.