### PR TITLE
test: Add ubuntu-stable image

### DIFF
--- a/bots/image-scan
+++ b/bots/image-scan
@@ -58,6 +58,9 @@ DEFAULT_REFRESH = {
     "ubuntu-1604": {
         "triggers": [ "verify/ubuntu-1604" ]
     },
+    "ubuntu-stable": {
+        "triggers": [ "verify/ubuntu-stable" ]
+    },
     "openshift": {
         "triggers": [ "container/kubernetes",
                       "verify/fedora-25",

--- a/bots/images/scripts/debian.setup
+++ b/bots/images/scripts/debian.setup
@@ -77,19 +77,14 @@ case "$RELEASE" in
         # docker.io got removed from testing; use backports-version
         echo "deb http://deb.debian.org/debian jessie-backports main" >/etc/apt/sources.list.d/jessie-backports.list
         ;;
-
-    xenial)
-        TEST_PACKAGES="$TEST_PACKAGES systemd-coredump"
-
-        IPA_CLIENT_PACKAGES="$IPA_CLIENT_PACKAGES freeipa-client"
-        PBUILDER_OPTS='COMPONENTS="main universe"'
-        ;;
-
-    *)
-        echo "Error: Unknown Debian/Ubuntu release $RELEASE" >&2
-        exit 1
 esac
 
+if grep -q 'ID=ubuntu' /etc/os-release; then
+    TEST_PACKAGES="$TEST_PACKAGES systemd-coredump"
+
+    IPA_CLIENT_PACKAGES="$IPA_CLIENT_PACKAGES freeipa-client"
+    PBUILDER_OPTS='COMPONENTS="main universe"'
+fi
 
 useradd -m -U -c Administrator -G sudo -s /bin/bash admin
 echo admin:foobar | chpasswd

--- a/bots/images/scripts/debian.setup
+++ b/bots/images/scripts/debian.setup
@@ -77,6 +77,11 @@ case "$RELEASE" in
         # docker.io got removed from testing; use backports-version
         echo "deb http://deb.debian.org/debian jessie-backports main" >/etc/apt/sources.list.d/jessie-backports.list
         ;;
+
+    zesty)
+        # HACK: https://launchpad.net/bugs/1693154
+        mkdir /etc/krb5.conf.d/
+        ;;
 esac
 
 if grep -q 'ID=ubuntu' /etc/os-release; then
@@ -84,6 +89,10 @@ if grep -q 'ID=ubuntu' /etc/os-release; then
 
     IPA_CLIENT_PACKAGES="$IPA_CLIENT_PACKAGES freeipa-client"
     PBUILDER_OPTS='COMPONENTS="main universe"'
+
+    # We want to use/test NetworkManager instead of netplan/networkd for ethernets
+    mkdir -p /etc/NetworkManager/conf.d
+    touch /etc/NetworkManager/conf.d/10-globally-managed-devices.conf
 fi
 
 useradd -m -U -c Administrator -G sudo -s /bin/bash admin

--- a/bots/images/scripts/ubuntu-stable.bootstrap
+++ b/bots/images/scripts/ubuntu-stable.bootstrap
@@ -1,0 +1,20 @@
+#! /bin/sh -ex
+
+# determine latest stable release (see https://launchpad.net/+apidoc)
+# in most cases the current series is devel, except for right after a stable release
+rel=$(curl --silent https://api.launchpad.net/devel/ubuntu/current_series_link | sed 's/^"//; s/"$//')
+if ! curl --silent "$rel" | grep -q '"supported": true'; then
+    # not supported, go back
+    rel=$(curl --silent "$rel/previous_series_link" | sed 's/^"//; s/"$//')
+
+     if ! curl --silent "$rel" | grep -q '"supported": true'; then
+         echo "ERROR: neither of the last two releases are supported!?" >&2
+         exit 1
+    fi
+fi
+# release name is the last part of the URL
+rel=${rel##*/}
+
+exec $(dirname $0)/lib/debian.bootstrap "$1" "$2" ubuntu-16.04 "deb http://archive.ubuntu.com/ubuntu $rel main universe
+deb http://archive.ubuntu.com/ubuntu ${rel}-updates main universe
+deb http://security.ubuntu.com/ubuntu ${rel}-security main universe"

--- a/bots/images/scripts/ubuntu-stable.install
+++ b/bots/images/scripts/ubuntu-stable.install
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+set -e
+
+/var/lib/testvm/debian.install "$@"

--- a/bots/images/scripts/ubuntu-stable.setup
+++ b/bots/images/scripts/ubuntu-stable.setup
@@ -1,0 +1,1 @@
+debian.setup

--- a/bots/images/ubuntu-stable
+++ b/bots/images/ubuntu-stable
@@ -1,0 +1,1 @@
+ubuntu-stable-4717d0c2ecef387c11a12343984d9667f1ecfdc2ca1704e47d5ca24e8f5559fa.qcow2

--- a/bots/naughty/ubuntu-stable/5256-parted-clobbers-extended-partitions
+++ b/bots/naughty/ubuntu-stable/5256-parted-clobbers-extended-partitions
@@ -1,0 +1,1 @@
+self.content_row_wait_in_col(3, 1, "xfs File System")

--- a/bots/naughty/ubuntu-stable/5295-apparmor-denied-ntpd
+++ b/bots/naughty/ubuntu-stable/5295-apparmor-denied-ntpd
@@ -1,0 +1,1 @@
+apparmor="DENIED" operation="open" profile="/usr/sbin/ntpd"

--- a/bots/naughty/ubuntu-stable/6108-pcp-pmfindprofile-crash
+++ b/bots/naughty/ubuntu-stable/6108-pcp-pmfindprofile-crash
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+*
+  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
+*
+Error: /usr/*/cockpit-pcp: bridge was killed: 11

--- a/bots/naughty/ubuntu-stable/6422-nsupdate-crash-sssd
+++ b/bots/naughty/ubuntu-stable/6422-nsupdate-crash-sssd
@@ -1,0 +1,4 @@
+Traceback (most recent call last):
+  File "./check-realms", line *, in testNegotiate
+    self.assertIn("HTTP/1.1 200 OK", output)
+AssertionError: 'HTTP/1.1 200 OK' not found in 'HTTP/1.1 401 Authentication required*

--- a/bots/naughty/ubuntu-stable/6422-nsupdate-crash-sssd-2
+++ b/bots/naughty/ubuntu-stable/6422-nsupdate-crash-sssd-2
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "./verify/check-realms", line *, in testNegotiate
+    self.configure_kerberos()
+*
+CalledProcessError: Command '<script>' returned non-zero exit status 2

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -43,7 +43,7 @@ DEFAULT_VERIFY = {
     'verify/fedora-atomic': BRANCHES,
     'verify/fedora-testing': [ ],
     'verify/ubuntu-1604': [ 'master', 'rhel-7.4', 'rhel-7.3.5', 'rhel-7.3.4', 'rhel-7.3.3', 'rhel-7.3.2' ],
-    'verify/ubuntu-stable': [ ],
+    'verify/ubuntu-stable': [ 'master' ],
 }
 
 # Non-public images used for testing

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -129,7 +129,7 @@ class TestConnection(MachineCase):
         except subprocess.CalledProcessError, ex:
             m.message(ex.output)
             # Some operating systems fail SSL3 on the server side
-            if m.image in [ "debian-testing", "fedora-25", "fedora-26", "fedora-i386", "fedora-testing" ]:
+            if m.image in [ "debian-testing", "fedora-25", "fedora-26", "fedora-i386", "fedora-testing", "ubuntu-stable" ]:
                 self.assertIn("ssl handshake failure", ex.output)
             else:
                 self.assertIn("wrong version number", ex.output)

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -320,7 +320,7 @@ CMD ["/bin/sh"]
         b.wait_present("#select-mounted-volumes form:eq(0)")
         b.set_val("#select-mounted-volumes form:eq(0) input:eq(0)", "/blah")
         b.set_val("#select-mounted-volumes form:eq(0) input:eq(1)", "/mnt")
-        if m.image not in [ "debian-stable", "debian-testing", "ubuntu-1604" ]:
+        if m.image not in [ "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable" ]:
             m.execute("chcon --dereference -HRt svirt_sandbox_file_t /mnt")
         m.execute("touch /mnt/dripping.txt")
 
@@ -530,7 +530,7 @@ CMD ["/bin/sh"]
         # This should be updated
         b.wait_in_text("#container-details-cpu-row", "1024 shares")
 
-@skipImage("Skip on systems without atomic and ones with missing deps", "centos-7", "debian-stable", "debian-testing", "ubuntu-1604", "rhel-atomic", "fedora-atomic", "fedora-i386")
+@skipImage("Skip on systems without atomic and ones with missing deps", "centos-7", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "rhel-atomic", "fedora-atomic", "fedora-i386")
 class TestAtomicScan(MachineCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -53,7 +53,7 @@ def initially_loopbacked(machine):
         return False
 
     # Debian, Ubuntu, and Fedora 26 use the overlayfs driver by default.
-    if machine.image in [ "debian-stable", "debian-testing", "ubuntu-1604", "fedora-26" ]:
+    if machine.image in [ "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-26" ]:
         return False
 
     # The rest don't have space in the root volume group, or don't

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -21,7 +21,7 @@
 import parent
 from testlib import *
 
-@skipImage("kexec-tools not installed", "continuous-atomic", "fedora-24", "fedora-atomic", "centos-7", "debian-stable", "debian-testing", "ubuntu-1604")
+@skipImage("kexec-tools not installed", "continuous-atomic", "fedora-24", "fedora-atomic", "centos-7", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
 class TestKdump(MachineCase):
     def rreplace(self, s, old, new, count):
         li = s.rsplit(old, count)

--- a/test/verify/check-kubernetes
+++ b/test/verify/check-kubernetes
@@ -24,7 +24,7 @@ import unittest
 from testlib import *
 import kubelib
 
-@skipImage("No kubernetes packaged", "debian-stable", "debian-testing", "ubuntu-1604", "fedora-i386")
+@skipImage("No kubernetes packaged", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-i386")
 @skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestKubernetes(kubelib.KubernetesCase, kubelib.KubernetesCommonTests):
 
@@ -37,7 +37,7 @@ class TestKubernetes(kubelib.KubernetesCase, kubelib.KubernetesCommonTests):
         m.upload(["verify/files/mock-k8s-tiny-app.json"], "/tmp")
         self.wait_api_server()
 
-@skipImage("No kubernetes packaged", "debian-stable", "debian-testing", "ubuntu-1604", "fedora-i386")
+@skipImage("No kubernetes packaged", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-i386")
 @skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestConnection(kubelib.KubernetesCase):
     def testConnect(self):
@@ -224,7 +224,7 @@ class TestConnection(kubelib.KubernetesCase):
                                     "connection unexpectedly closed by peer",
                                     ".*: Error sending data: Broken pipe.*")
 
-@skipImage("No kubernetes packaged", "debian-stable", "debian-testing", "ubuntu-1604", "fedora-i386")
+@skipImage("No kubernetes packaged", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-i386")
 @unittest.skipIf(True, "Nulecule deploys temporarily removed.")
 class TestNulecule(kubelib.KubernetesCase):
     def setUp(self):

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -154,7 +154,7 @@ class TestNetworking(NetworkCase):
         b.wait_popdown("network-bond-settings-dialog")
         b.wait_text("#network-interface-name", "tbond3000")
 
-    @skipImage("Main interface can't be managed", "debian-stable", "debian-testing", "ubuntu-1604")
+    @skipImage("Main interface can't be managed", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
     def testBondingMain(self):
         b = self.browser
         m = self.machine
@@ -186,7 +186,7 @@ class TestNetworking(NetworkCase):
         b.wait_present("#networking-interfaces tr[data-interface='%s']" % iface)
         b.wait_in_text("#networking-interfaces tr[data-interface='%s']" % iface, m.address)
 
-    @skipImage("Main interface can't be managed", "debian-stable", "debian-testing", "ubuntu-1604")
+    @skipImage("Main interface can't be managed", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
     def testBondingMainSlowly(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networking-checkpoints
+++ b/test/verify/check-networking-checkpoints
@@ -22,7 +22,7 @@ import parent
 from testlib import *
 from netlib import *
 
-@skipImage("No network checkpoint support", "centos-7", "continuous-atomic", "debian-stable", "fedora-24", "fedora-atomic", "rhel-atomic", "ubuntu-1604")
+@skipImage("No network checkpoint support", "centos-7", "continuous-atomic", "debian-stable", "fedora-24", "fedora-atomic", "rhel-atomic", "ubuntu-1604", "ubuntu-stable")
 class TestNetworking(NetworkCase):
     def testCheckpoint(self):
         b = self.browser
@@ -30,7 +30,7 @@ class TestNetworking(NetworkCase):
 
         iface = self.get_iface(m, m.macaddr)
 
-        if m.image in [ "debian-testing", "debian-stable", "ubuntu-1604" ]:
+        if m.image in [ "debian-testing", "debian-stable", "ubuntu-1604", "ubuntu-stable" ]:
             m.execute("sed -i -e 's/managed=false/managed=true/' /etc/NetworkManager/NetworkManager.conf")
             m.execute("systemctl restart NetworkManager")
             # HACK - https://bugzilla.redhat.com/show_bug.cgi?id=1400525
@@ -46,7 +46,7 @@ class TestNetworking(NetworkCase):
         b.wait_visible("#confirm-breaking-change-popup")
         b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
 
-        if m.image not in [ "debian-testing", "debian-stable", "ubuntu-1604" ]:
+        if m.image not in [ "debian-testing", "debian-stable", "ubuntu-1604", "ubuntu-stable" ]:
             # Change IP
             b.click("tr:contains('IPv4') a")
             b.wait_popup("network-ip-settings-dialog")
@@ -59,7 +59,7 @@ class TestNetworking(NetworkCase):
             b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
 
 
-    @skipImage("Main interface settings are read-only", "debian-stable", "debian-testing", "ubuntu-1604")
+    @skipImage("Main interface settings are read-only", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
     def testCheckpointSlowRollback(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networking-other
+++ b/test/verify/check-networking-other
@@ -23,7 +23,7 @@ from testlib import *
 from netlib import *
 
 class TestNetworking(NetworkCase):
-    @skipImage("No 'tun' support", "centos-7", "debian-stable", "rhel-atomic", "ubuntu-1604")
+    @skipImage("No 'tun' support", "centos-7", "debian-stable", "rhel-atomic", "ubuntu-1604", "ubuntu-stable")
     def testOther(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networking-team
+++ b/test/verify/check-networking-team
@@ -30,7 +30,7 @@ class TestNetworking(NetworkCase):
         self.login_and_go("/network")
 
         can_add_teams = m.image not in [ "continuous-atomic", "rhel-atomic",
-                                         "debian-stable", "ubuntu-1604" ]
+                                         "debian-stable", "ubuntu-1604", "ubuntu-stable" ]
 
         b.wait_attr("#networking-add-team", "data-test-stable", "yes")
         if not can_add_teams:

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -51,7 +51,7 @@ def wait_project(machine, project):
             i = i + 1
             time.sleep(2)
 
-@skipImage("Kubernetes not packaged", "debian-stable", "debian-testing", "ubuntu-1604", "fedora-i386")
+@skipImage("Kubernetes not packaged", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-i386")
 @skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestOpenshift(MachineCase, OpenshiftCommonTests):
     additional_machines = {
@@ -379,7 +379,7 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         b.wait_present("#service-list")
 
 
-@skipImage("Kubernetes not packaged", "debian-stable", "debian-testing", "ubuntu-1604", "fedora-i386")
+@skipImage("Kubernetes not packaged", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-i386")
 @skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestRegistry(MachineCase):
     additional_machines = {

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -112,7 +112,7 @@ def rhsmcertd_hack(m):
     m.execute("systemctl stop rhsmcertd || true")
 
 
-@skipImage("No OSTree available", "centos-7", "debian-stable", "debian-testing", "fedora-24", "fedora-25", "fedora-26", "fedora-testing", "fedora-i386", "rhel-7", "ubuntu-1604")
+@skipImage("No OSTree available", "centos-7", "debian-stable", "debian-testing", "fedora-24", "fedora-25", "fedora-26", "fedora-testing", "fedora-i386", "rhel-7", "ubuntu-1604", "ubuntu-stable")
 class OstreeRestartCase(MachineCase):
 
     def setUp(self):
@@ -417,7 +417,7 @@ class OstreeRestartCase(MachineCase):
 
         self.allow_restart_journal_messages()
 
-@skipImage("No OSTree available", "centos-7", "debian-stable", "debian-testing", "fedora-24", "fedora-25", "fedora-26", "fedora-testing", "fedora-i386", "rhel-7", "ubuntu-1604")
+@skipImage("No OSTree available", "centos-7", "debian-stable", "debian-testing", "fedora-24", "fedora-25", "fedora-26", "fedora-testing", "fedora-i386", "rhel-7", "ubuntu-1604", "ubuntu-stable")
 class OstreeCase(MachineCase):
 
     def testRemoteManagement(self):

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -43,7 +43,7 @@ WantedBy=default.target
         # On Debian and Ubuntu we have to generate the other locales :S
         if m.image in ["debian-stable", "debian-testing" ]:
             m.execute("echo 'de_DE.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen && update-locale")
-        elif m.image in [ "ubuntu-1604" ]:
+        elif m.image in [ "ubuntu-1604", "ubuntu-stable" ]:
             m.execute("locale-gen de_DE && locale-gen de_DE.UTF-8 && update-locale")
 
         # On Atomic no locales other than en_US are supported on the host itself

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -182,6 +182,7 @@ done
 
 if ! echo '%(password)s' | realm join -U admin cockpit.lan; then
     journalctl -u realmd.service
+    exit 1
 fi
 
 echo '%(password)s' | kinit -f admin@COCKPIT.LAN

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -53,7 +53,7 @@ mv -f ~/.ssh/authorized_keys.test-avc ~/.ssh/authorized_keys
 
 @skipImage("DBus API of setroubleshoot too old", "centos-7")
 class TestSelinux(MachineCase):
-    @skipImage("No setroubleshoot", "continuous-atomic", "debian-stable", "debian-testing", "fedora-atomic", "rhel-atomic", "ubuntu-1604")
+    @skipImage("No setroubleshoot", "continuous-atomic", "debian-stable", "debian-testing", "fedora-atomic", "rhel-atomic", "ubuntu-1604", "ubuntu-stable")
     def testTroubleshootAlerts(self):
         b = self.browser
 
@@ -144,7 +144,7 @@ class TestSelinux(MachineCase):
 
         #b.wait_in_text("body", "No SELinux alerts.")
 
-    @skipImage("No cockpit-selinux", "debian-stable", "debian-testing", "continuous-atomic", "fedora-atomic", "ubuntu-1604")
+    @skipImage("No cockpit-selinux", "debian-stable", "debian-testing", "continuous-atomic", "fedora-atomic", "ubuntu-1604", "ubuntu-stable")
     def testEnforcingToggle(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -23,7 +23,7 @@ from testlib import *
 
 import subprocess
 
-@skipImage("No sosreport", "continuous-atomic", "debian-stable", "debian-testing", "ubuntu-1604")
+@skipImage("No sosreport", "continuous-atomic", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
 class TestSOS(MachineCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -23,7 +23,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604")
+@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
 class TestStorage(StorageCase):
     def testHiddenLuks(self):
         m = self.machine

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -23,7 +23,7 @@ from testlib import *
 from storagelib import *
 
 @skipImage("storaged-iscsi not packaged", "centos-7", "debian-testing")
-@skipImage("UDisks doesn't have support for iSCSI", "debian-stable", "ubuntu-1604")
+@skipImage("UDisks doesn't have support for iSCSI", "debian-stable", "ubuntu-1604", "ubuntu-stable")
 class TestStorage(StorageCase):
     def testISCSI(self):
         m = self.machine

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -23,7 +23,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604")
+@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
 class TestStorage(StorageCase):
     def testLvm(self):
         m = self.machine

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -22,7 +22,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for multipath", "debian-stable", "ubuntu-1604")
+@skipImage("UDisks doesn't have support for multipath", "debian-stable", "ubuntu-1604", "ubuntu-stable")
 @skipImage("No multipath on Debian", "debian-testing")
 class TestStorage(StorageCase):
     def testBasic(self):

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -23,7 +23,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604")
+@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
 class TestStorage(StorageCase):
     def testResize(self):
         m = self.machine

--- a/test/verify/check-subscriptions
+++ b/test/verify/check-subscriptions
@@ -78,7 +78,7 @@ print [ e['id'] for e in data if e['owner']['key'] == 'admin' and e['contractNum
 "
 """
 
-@skipImage("No subscriptions", "centos-7", "continuous-atomic", "debian-stable", "debian-testing", "fedora-24", "fedora-25", "fedora-26", "fedora-i386", "fedora-atomic", "fedora-testing", "ubuntu-1604")
+@skipImage("No subscriptions", "centos-7", "continuous-atomic", "debian-stable", "debian-testing", "fedora-24", "fedora-25", "fedora-26", "fedora-i386", "fedora-atomic", "fedora-testing", "ubuntu-1604", "ubuntu-stable")
 class TestSubscriptions(MachineCase):
     additional_machines = {
         'candlepin': { 'machine': { 'image': 'candlepin' } }

--- a/test/verify/check-tuned
+++ b/test/verify/check-tuned
@@ -21,7 +21,7 @@
 import parent
 from testlib import *
 
-@skipImage("No tuned packaged", "debian-stable", "debian-testing", "fedora-atomic", "ubuntu-1604")
+@skipImage("No tuned packaged", "debian-stable", "debian-testing", "fedora-atomic", "ubuntu-1604", "ubuntu-stable")
 class TestTuned(MachineCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -43,7 +43,7 @@ class StorageCase(MachineCase):
 
         self.storaged_is_old_udisks = ("udisksctl" in self.storagectl_cmd and self.storaged_version < [2, 6, 0])
 
-        if self.machine.image in ["debian-stable", "debian-testing", "ubuntu-1604" ]:
+        if "debian" in self.machine.image or "ubuntu" in self.machine.image:
             # Debian's udisks has a patch to use FHS /media directory
             self.mount_root = "/media"
         else:


### PR DESCRIPTION
Now that Cockpit is in Ubuntu 17.04 and in backports down to 16.04 LTS, let's start testing on the latest Ubuntu release.
    
This also includes some generalizations of debian.setup Ubuntu specifics for all releases. They don't change the ubuntu-1604 image.

This is an initial version without copying the quirks, and without adding the `if m.image...` type special cases yet. I want to work on the latter a bit still (some can be dropped entirely), I just want to get an initial run first.

 - [x] copy/adjust ubuntu-1604 special cases as necessary
 - [x] drop some test special cases (PR #6574)
 - [x] fix `Connection 'eth1' is not available` check-networking-* failures
 - [x] add naughty overrides
 - [x] fix `check-storage-mounting` timeout
 - [x] investigate `check-storage-msdos` failure - sda5 gets created and is in udisks, but does not show up even after page reload  - issue 5256, copied naughty from debian-testing
 - [x] rebuild image to fix `check-machines TestMachines.testBasic` [apparmor violation](https://launchpad.net/bugs/1680384)
 - [x] investigate/work around [`check-realms` failures](https://bugs.launchpad.net/ubuntu/+source/freeipa/+bug/1693154)
 - [x] fix `test/verify/check-connection TestConnection.testTls`
 - [x] ~~sometimes tests fail with `org.freedesktop.DBus.Error.LimitsExceeded` - specific to ubuntu-stable or general flake? - independent, Lars works on that~~