### PR TITLE
test: Disable ALPN in vm-download

### DIFF
--- a/test/vm-download
+++ b/test/vm-download
@@ -103,13 +103,13 @@ def download(link, force, stores):
         source = urlparse.urljoin(store, name)
 
         try:
-            cmd = ["curl", "--head", "--silent",  "--resolve", resolve, "--fail", "--cacert", ca, ca_source]
+            cmd = ["curl", "--head", "--silent",  "--no-alpn", "--resolve", resolve, "--fail", "--cacert", ca, ca_source]
             subprocess.check_call(cmd, stdout=DEVNULL)
             break
         except subprocess.CalledProcessError:
             pass
         try:
-            cmd = ["curl", "--head", "--silent", "--fail", source]
+            cmd = ["curl", "--head", "--silent", "--no-alpn", "--fail", source]
             subprocess.check_call(cmd, stdout=DEVNULL)
             break
         except subprocess.CalledProcessError:


### PR DESCRIPTION
It causes excessive slowness and even connection resets/aborts with our
image stores, and is not at all security relevant.

Fixes #6571