### PR TITLE
test: Drop unnecessary m.image special cases

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -95,18 +95,10 @@ class TestConnection(MachineCase):
         if m.image in [ "debian-stable" ]:
             return
 
-        # Lets crash a process and see if we get a proper backtrace in the logs
+        # Lets crash a systemd-crontrolled process and see if we get a proper backtrace in the logs
         # This helps with debugging failures in the tests elsewhere
-        if m.image in ["debian-testing", "ubuntu-1604"]:
-            binary = "cron"
-            m.execute("systemctl start cron")
-        elif m.image in ["fedora-atomic"]:
-            binary = "agetty"
-        else:
-            binary = "crond"
-            m.execute("systemctl start crond")
-        m.execute("kill -SEGV $(pgrep {0})".format(binary))
-        wait(lambda: m.execute("journalctl -b | grep 'Process.*{0}.*of user.*dumped core.'".format(binary)))
+        m.execute("systemctl start systemd-hostnamed; pkill -e -SEGV systemd-hostnam")
+        wait(lambda: m.execute("journalctl -b | grep 'Process.*systemd-hostnam.*of user.*dumped core.'"))
 
         # Make sure the core dumps exist in the directory, so we can download them
         cores = m.execute("find /var/lib/systemd/coredump -type f")

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -46,8 +46,7 @@ class TestNetworking(NetworkCase):
 
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
-        if "ubuntu" not in m.image and "debian" not in m.image:
-            m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbond")
+        m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbond")
 
         # Check that the members are displayed and both On
         b.click("#networking-interfaces tr[data-interface='tbond'] td:first-child")

--- a/test/verify/check-networking-team
+++ b/test/verify/check-networking-team
@@ -54,8 +54,7 @@ class TestNetworking(NetworkCase):
 
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
-        if "ubuntu" not in m.image and "debian" not in m.image:
-            m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tteam")
+        m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tteam")
 
         # Check that the members are displayed
         b.click("#networking-interfaces tr[data-interface='tteam'] td:first-child")


### PR DESCRIPTION
This makes our testing more comparable and avoids having to change
special cases when adding/changing images.

 * check-connection: Crash systemd-hostnamed everywhere instead of a different
   process on each OS.
 * check-networking-{bond,team}: Drop redundant image check, the command
   already checks if sysconfig is being used on the system.