### PR TITLE
bots: Fix the github-trigger script to avoid Semaphore

### DIFF
--- a/bots/github-trigger
+++ b/bots/github-trigger
@@ -7,6 +7,20 @@ sys.dont_write_bytecode = True
 
 import github
 
+OUR_CONTEXTS = [
+    "verify/",
+    "avocado/",
+    "container/",
+    "selenium/",
+    "koji/",
+]
+
+def known_context(context):
+    for prefix in OUR_CONTEXTS:
+        if context.startswith(prefix):
+            return True
+    return False
+
 def trigger_image(api, opts):
     title = github.ISSUE_TITLE_IMAGE_REFRESH.format(opts.image)
     if opts.pull:
@@ -39,7 +53,7 @@ def trigger_pull(api, opts):
         contexts = [ opts.context ]
         all = False
     else:
-        contexts = list(set(statuses.keys()))
+        contexts = [ x for x in set(statuses.keys()) if known_context(x) ]
         all = True
 
     ret = 0


### PR DESCRIPTION
Only trigger statuses with prefixes that we know about.