### PR TITLE
bots: Fix use of qualify command in tests-invoke

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -99,7 +99,7 @@ class PullTask(object):
                     }
                 ],
                 "watches": [{
-                    "resource": github.qualify("commits/" + self.revision + "/status"),
+                    "resource": api.qualify("commits/" + self.revision + "/status"),
                     "result": {
                         "statuses": [
                             {


### PR DESCRIPTION
This is a typo that's causing the tests to fail.