### PR TITLE
bots: Use /var/tmp for placing sink attachments to upload

### DIFF
--- a/bots/sink/__init__.py
+++ b/bots/sink/__init__.py
@@ -34,7 +34,7 @@ BOTS = os.path.join(os.path.dirname(__file__), "..")
 
 class Sink(object):
     def __init__(self, host, identifier, status=None):
-        self.attachments = tempfile.mkdtemp(prefix="attachments.", dir=os.path.join(BOTS))
+        self.attachments = tempfile.mkdtemp(prefix="attachments.", dir="/var/tmp")
         self.status = status
 
         # Start a gzip and cat processes


### PR DESCRIPTION
This becomes a problem before rebasing because the sink starts logging
long before we have a chance to rebase and get the bots
directory all setup and in place.

Besides this is cleaner.