### PR TITLE
test: Remove STP and forward_delay from our bridge

### DIFF
--- a/test/common/network-cockpit.xml
+++ b/test/common/network-cockpit.xml
@@ -6,7 +6,7 @@
       <port start='1024' end='65535'/>
     </nat>
   </forward>
-  <bridge name='cockpit1' stp='on' delay='0' />
+  <bridge name='cockpit1' />
   <domain name='cockpit.lan'/>
   <ip address='10.111.112.1' netmask='255.255.240.0'>
     <dhcp xmlns:cockpit="urn:cockpit-project.org:cockpit">

--- a/test/vm-prep
+++ b/test/vm-prep
@@ -63,9 +63,14 @@ DEVICE=$NETWORK_NAME
 NM_CONTROLLED=no
 EOF
 
+    # HACK: In case of read-only /sys avoid libvirt writing there
+    mount -o bind /mnt /sys/devices/virtual/net/
+
     $VIRSH net-define $BASE/common/network-cockpit.xml
-	$VIRSH net-autostart $NETWORK_NAME
-	$VIRSH net-start $NETWORK_NAME
+    $VIRSH net-autostart $NETWORK_NAME
+    $VIRSH net-start $NETWORK_NAME
+
+    umount /sys/devices/virtual/net
 
 	if [ ! -u $QEMU_BRIDGE_HELPER ]; then
 		chmod -v u+s $QEMU_BRIDGE_HELPER


### PR DESCRIPTION
When used in a container, these are problematic to setup.