### PR TITLE
bots: Stop testing each pull request on Fedora 25

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -37,7 +37,7 @@ DEFAULT_VERIFY = {
     'verify/debian-stable': [ 'master' ],
     'verify/debian-testing': BRANCHES,
     'verify/fedora-24': [ ],
-    'verify/fedora-25': BRANCHES,
+    'verify/fedora-25': [ ],
     'verify/fedora-i386': [ 'master', 'rhel-7.4', 'rhel-7.3.5' ],
     'verify/fedora-26': [ 'master' ],
     'verify/fedora-atomic': BRANCHES,


### PR DESCRIPTION
We no longer test pull requests on Fedora 25. We are not aiming
to release Cockpit on Fedora 25. If we do at any point do a
maintenance release there, we should create a new branch in
this repository and enable fedora-25 testing on that branch.