### PR TITLE
tools: More general workaround for our %post SELinux hack

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -359,7 +359,7 @@ Cockpit support for remoting to other servers, bastion hosts, and a basic dashbo
 %post dashboard
 # HACK: Until policy changes make it downstream
 echo "Applying workaround for broken SELinux policy: https://bugzilla.redhat.com/show_bug.cgi?id=1381331" >&2
-test -f %{_bindir}/chcon && chcon -t cockpit_ws_exec_t %{_libexecdir}/cockpit-ssh
+chcon -t cockpit_ws_exec_t %{_libexecdir}/cockpit-ssh || true
 %if 0%{?fedora} > 0 && 0%{?fedora} >= 26
 if type semodule >/dev/null 2>&1; then
     tmp=$(mktemp -d)


### PR DESCRIPTION
This isn't a complete feature fix as found in #6556. But certain
operating systems (eg: Atomic) have chcon but it cannot be run
correctly or cannot be run during %post. So make this %post section
recover from failures better.