### PR TITLE
bots: Fix race in pruning the GitHub cache

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,8 @@ nodist_noinst_SCRIPTS =
 dist_systemdunit_DATA   =
 nodist_systemdunit_DATA =
 
-TESTS =
+TESTS = \
+	tools/test-bots
 
 CLEANFILES = \
 	$(man_MANS) \

--- a/bots/github/cache.py
+++ b/bots/github/cache.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+# Shared GitHub code. When run as a script, we print out info about
+# our GitHub interacition.
+
+import json
+import os
+import stat
+import sys
+import tempfile
+import time
+import urllib
+
+__all__ = (
+    'Cache',
+)
+
+class Cache(object):
+    def __init__(self, directory):
+        self.directory = directory
+        if not os.path.exists(self.directory):
+            os.makedirs(self.directory)
+        self.prune()
+
+    def prune(self):
+        now = time.time()
+        for filename in os.listdir(self.directory):
+            path = os.path.join(self.directory, filename)
+            if os.path.isfile(path) and os.stat(path).st_mtime < now - 7 * 86400:
+                os.remove(path)
+
+    def read(self, resource):
+        path = os.path.join(self.directory, urllib.quote(resource, safe=''))
+        if not os.path.exists(path):
+            return None
+        with open(path, 'r') as fp:
+            try:
+                return json.load(fp)
+            except ValueError:
+                return None
+
+    def write(self, resource, contents):
+        path = os.path.join(self.directory, urllib.quote(resource, safe=''))
+        (fd, temp) = tempfile.mkstemp(dir=self.directory)
+        with os.fdopen(fd, 'w') as fp:
+            json.dump(contents, fp)
+        os.chmod(temp, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+        os.rename(temp, path)

--- a/bots/github/cache.py
+++ b/bots/github/cache.py
@@ -48,10 +48,13 @@ class Cache(object):
         if not os.path.exists(self.directory):
             return
         now = time.time()
-        for filename in os.listdir(self.directory):
-            path = os.path.join(self.directory, filename)
-            if os.path.isfile(path) and os.stat(path).st_mtime < now - 7 * 86400:
-                os.remove(path)
+        try:
+            for filename in os.listdir(self.directory):
+                path = os.path.join(self.directory, filename)
+                if os.path.isfile(path) and os.stat(path).st_mtime < now - 7 * 86400:
+                    os.remove(path)
+        except OSError:
+            pass
 
     # Read a resource from the cache or return None
     def read(self, resource):

--- a/bots/github/cache.py
+++ b/bots/github/cache.py
@@ -24,7 +24,6 @@
 import json
 import os
 import stat
-import sys
 import tempfile
 import time
 import urllib
@@ -34,33 +33,57 @@ __all__ = (
 )
 
 class Cache(object):
-    def __init__(self, directory):
+    def __init__(self, directory, lag=60):
         self.directory = directory
-        if not os.path.exists(self.directory):
-            os.makedirs(self.directory)
         self.prune()
 
+        # The lag tells us how long to assume cached data is "current"
+        self.lag = lag
+
+        # The mark tells us that stuff before this time is not "current"
+        self.marked = 0
+
+    # Prune old expired data from the cache directory
     def prune(self):
+        if not os.path.exists(self.directory):
+            return
         now = time.time()
         for filename in os.listdir(self.directory):
             path = os.path.join(self.directory, filename)
             if os.path.isfile(path) and os.stat(path).st_mtime < now - 7 * 86400:
                 os.remove(path)
 
+    # Read a resource from the cache or return None
     def read(self, resource):
         path = os.path.join(self.directory, urllib.quote(resource, safe=''))
-        if not os.path.exists(path):
-            return None
-        with open(path, 'r') as fp:
-            try:
+        try:
+            with open(path, 'r') as fp:
                 return json.load(fp)
-            except ValueError:
-                return None
+        except (IOError, ValueError):
+            return None
 
+    # Write a resource to the cache in an atomic way
     def write(self, resource, contents):
         path = os.path.join(self.directory, urllib.quote(resource, safe=''))
+        if not os.path.exists(self.directory):
+            os.makedirs(self.directory)
         (fd, temp) = tempfile.mkstemp(dir=self.directory)
         with os.fdopen(fd, 'w') as fp:
             json.dump(contents, fp)
         os.chmod(temp, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
         os.rename(temp, path)
+
+    # Tell the cache that stuff before this time is not "current"
+    def mark(self, mtime=None):
+        if not mtime:
+            mtime = time.time()
+        self.marked = mtime
+
+    # Check if a given resource in the cache is "current" or not
+    def current(self, resource):
+        path = os.path.join(self.directory, urllib.quote(resource, safe=''))
+        try:
+            mtime = os.path.getmtime(path)
+            return mtime > self.marked and mtime > (time.time() - self.lag)
+        except OSError:
+            return False

--- a/bots/github/test-cache
+++ b/bots/github/test-cache
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import tempfile
+import unittest
+
+import cache
+
+class TestCache(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.mkdtemp()
+
+    def tearDown(self):
+        for name in os.listdir(self.directory):
+            os.unlink(os.path.join(self.directory, name))
+        os.rmdir(self.directory)
+
+    def testReadWrite(self):
+        value = { "blah": 1 }
+
+        c = cache.Cache(self.directory)
+        result = c.read("pa+t\%h")
+        self.assertIsNone(result)
+
+        c.write("pa+t\%h", value)
+        result = c.read("pa+t\%h")
+        self.assertEqual(result, value)
+
+        other = "other"
+        c.write("pa+t\%h", other)
+        result = c.read("pa+t\%h")
+        self.assertEqual(result, other)
+
+        c.write("second", value)
+        result = c.read("pa+t\%h")
+        self.assertEqual(result, other)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bots/github/test-cache
+++ b/bots/github/test-cache
@@ -21,6 +21,7 @@
 import os
 import sys
 import tempfile
+import time
 import unittest
 
 import cache
@@ -53,6 +54,37 @@ class TestCache(unittest.TestCase):
         c.write("second", value)
         result = c.read("pa+t\%h")
         self.assertEqual(result, other)
+
+    def testCurrent(self):
+        c = cache.Cache(self.directory, lag=3)
+
+        c.write("resource2", { "value": 2 })
+        self.assertTrue(c.current("resource2"))
+
+        time.sleep(2)
+        self.assertTrue(c.current("resource2"))
+
+        time.sleep(2)
+        self.assertFalse(c.current("resource2"))
+
+    def testCurrentMark(self):
+        c = cache.Cache(self.directory, lag=3)
+
+        self.assertFalse(c.current("resource"))
+
+        c.write("resource", { "value": 1 })
+        self.assertTrue(c.current("resource"))
+
+        time.sleep(2)
+        self.assertTrue(c.current("resource"))
+
+        c.mark()
+        self.assertFalse(c.current("resource"))
+
+    def testCurrentZero(self):
+        c = cache.Cache(self.directory, lag=0)
+        c.write("resource", { "value": 1 })
+        self.assertFalse(c.current("resource"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/avocado/tap.py
+++ b/test/avocado/tap.py
@@ -1,0 +1,1 @@
+../../tools/tap.py

--- a/test/common/tap.py
+++ b/test/common/tap.py
@@ -1,0 +1,1 @@
+../../tools/tap.py

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -39,6 +39,7 @@ import tempfile
 import time
 import unittest
 
+import tap
 import testvm
 
 TEST_DIR = os.path.normpath(os.path.dirname(os.path.realpath(os.path.join(__file__, ".."))))
@@ -870,24 +871,10 @@ class Policy(object):
 
         return False
 
-class TapResult(unittest.TestResult):
+class TestResult(tap.TapResult):
     def __init__(self, stream, descriptions, verbosity):
-        self.offset = 0
         self.policy = None
-        super(TapResult, self).__init__(stream, descriptions, verbosity)
-
-    def ok(self, test):
-        data = "ok {0} {1} duration: {2}s\n".format(self.offset, str(test), int(time.time() - self.start_time))
-        sys.stdout.write(data)
-
-    def not_ok(self, test, err):
-        data = "not ok {0} {1} duration: {2}s\n".format(self.offset, str(test), int(time.time() - self.start_time))
-        if err:
-            data += self._exc_info_to_string(err, test)
-        sys.stdout.write(data)
-
-    def skip(self, test, reason):
-        sys.stdout.write("ok {0} {1} duration: {2}s # SKIP {3}\n".format(self.offset, str(test), int(time.time() - self.start_time), reason))
+        super(TestResult, self).__init__(verbosity)
 
     def maybeIgnore(self, test, err):
         string = self._exc_info_to_string(err, test)
@@ -904,45 +891,23 @@ class TapResult(unittest.TestResult):
                 raise RetryError("Retrying due to failure of test harness or framework")
         return False
 
-    def stop(self):
-        sys.stdout.write("Bail out!\n")
-        super(TapResult, self).stop()
-
-    def startTest(self, test):
-        self.start_time = time.time()
-        self.offset += 1
-        sys.stdout.write("# {0}\n# {1}\n#\n".format('-' * 70, str(test)))
-        super(TapResult, self).startTest(test)
-
-    def stopTest(self, test):
-        sys.stdout.write("\n")
-        super(TapResult, self).stopTest(test)
-
     def addError(self, test, err):
         if not self.maybeIgnore(test, err):
-            self.not_ok(test, err)
-            super(TapResult, self).addError(test, err)
+            super(TestResult, self).addError(test, err)
 
     def addFailure(self, test, err):
         if not self.maybeIgnore(test, err):
-            self.not_ok(test, err)
-            super(TapResult, self).addError(test, err)
+            super(TestResult, self).addError(test, err)
 
-    def addSuccess(self, test):
-        self.ok(test)
-        super(TapResult, self).addSuccess(test)
+    def startTest(self, test):
+        sys.stdout.write("# {0}\n# {1}\n#\n".format('-' * 70, str(test)))
+        sys.stdout.flush()
+        super(TestResult, self).startTest(test)
 
-    def addSkip(self, test, reason):
-        self.skip(test, reason)
-        super(TapResult, self).addSkip(test, reason)
-
-    def addExpectedFailure(self, test, err):
-        self.ok(test)
-        super(TapResult, self).addExpectedFailure(test, err)
-
-    def addUnexpectedSuccess(self, test):
-        self.not_ok(test, None)
-        super(TapResult, self).addUnexpectedSuccess(test)
+    def stopTest(self, test):
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+        super(TestResult, self).stopTest(test)
 
 class OutputBuffer(object):
     def __init__(self):
@@ -982,7 +947,7 @@ class OutputBuffer(object):
         return buffer
 
 class TapRunner(object):
-    resultclass = TapResult
+    resultclass = TestResult
 
     def __init__(self, verbosity=1, jobs=1, thorough=False):
         self.stream = unittest.runner._WritelnDecorator(sys.stderr)
@@ -991,7 +956,7 @@ class TapRunner(object):
         self.jobs = jobs
 
     def runOne(self, test, offset):
-        result = TapResult(self.stream, False, self.verbosity)
+        result = TestResult(self.stream, False, self.verbosity)
         result.offset = offset
         if not self.thorough:
             result.policy = Policy()
@@ -1008,9 +973,8 @@ class TapRunner(object):
             return result.wasSuccessful()
 
     def run(self, testable):
+        tap.TapResult.plan(testable)
         count = testable.countTestCases()
-        sys.stdout.write("1..{0}\n".format(count))
-        sys.stdout.flush()
 
         # For statistics
         start = time.time()

--- a/tools/Makefile-tools.am
+++ b/tools/Makefile-tools.am
@@ -22,4 +22,6 @@ coverage:
 	@echo "file://$(abs_top_builddir)/tools/coverage/index.html"
 endif
 
-TESTS += tools/static-code-tests
+TESTS += \
+	tools/static-code-tests \
+	tools/test-bots

--- a/tools/tap.py
+++ b/tools/tap.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2013 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import time
+import unittest
+
+class TapResult(unittest.TestResult):
+    def __init__(self, verbosity):
+        self.offset = 0
+        self.start_time = 0
+        super(TapResult, self).__init__(sys.stderr, False, verbosity)
+
+    @staticmethod
+    def plan(testable):
+        count = testable.countTestCases()
+        sys.stdout.write("1..{0}\n".format(count))
+        sys.stdout.flush()
+
+    def ok(self, test):
+        data = "ok {0} {1} duration: {2}s\n".format(self.offset,
+                str(test), int(time.time() - self.start_time))
+        sys.stdout.write(data)
+        sys.stdout.flush()
+
+    def not_ok(self, test, err):
+        data = "not ok {0} {1} duration: {2}s\n".format(self.offset,
+                str(test), int(time.time() - self.start_time))
+        if err:
+            data += self._exc_info_to_string(err, test)
+        sys.stdout.write(data)
+        sys.stdout.flush()
+
+    def skip(self, test, reason):
+        sys.stdout.write("ok {0} {1} duration: {2}s # SKIP {3}\n".format(self.offset,
+            str(test), int(time.time() - self.start_time), reason))
+        sys.stdout.flush()
+
+    def stop(self):
+        sys.stdout.write("Bail out!\n")
+        sys.stdout.flush()
+        super(TapResult, self).stop()
+
+    def startTest(self, test):
+        self.start_time = time.time()
+        self.offset += 1
+        super(TapResult, self).startTest(test)
+
+    def stopTest(self, test):
+        super(TapResult, self).stopTest(test)
+
+    def addError(self, test, err):
+        self.not_ok(test, err)
+        super(TapResult, self).addError(test, err)
+
+    def addFailure(self, test, err):
+        self.not_ok(test, err)
+        super(TapResult, self).addError(test, err)
+
+    def addSuccess(self, test):
+        self.ok(test)
+        super(TapResult, self).addSuccess(test)
+
+    def addSkip(self, test, reason):
+        self.skip(test, reason)
+        super(TapResult, self).addSkip(test, reason)
+
+    def addExpectedFailure(self, test, err):
+        self.ok(test)
+        super(TapResult, self).addExpectedFailure(test, err)
+
+    def addUnexpectedSuccess(self, test):
+        self.not_ok(test, None)
+        super(TapResult, self).addUnexpectedSuccess(test)
+
+class TapRunner(object):
+    resultclass = TapResult
+
+    def __init__(self, stream=None, descriptions=False, verbosity=1,
+                 failfast=False, resultclass=None):
+        self.verbosity = verbosity
+        self.failfast = failfast
+        if resultclass is not None:
+            self.resultclass = resultclass
+
+    def run(self, testable):
+        TapResult.plan(testable)
+        result = self.resultclass(self.verbosity)
+        result.failfast = self.failfast
+        startTestRun = getattr(result, 'startTestRun', None)
+        if startTestRun is not None:
+            startTestRun()
+        try:
+            testable(result)
+        finally:
+            stopTestRun = getattr(result, 'stopTestRun', None)
+            if stopTestRun is not None:
+                stopTestRun()
+        return result

--- a/tools/test-bots
+++ b/tools/test-bots
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import glob
+import imp
+import os
+import sys
+import unittest
+
+sys.dont_write_bytecode = True
+
+import tap
+
+BASE = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+
+def main():
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    for filename in glob.glob(os.path.join(BASE, "bots", "github", "test-*")):
+        name = os.path.basename(filename)
+        sys.path[0] = os.path.dirname(filename)
+        module = imp.load_source(name.replace("-", "_"), filename)
+        suite.addTest(loader.loadTestsFromModule(module))
+
+    runner = tap.TapRunner()
+    result = runner.run(suite)
+    if result.wasSuccessful():
+        return 0
+    return 1
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
When two bots end up pruning the GitHub cache at the same
time it can come to races on the os.remove() command.
    
Lets ignore these, and just have the pruning pick up next
time around.

 * [x] #6600 