### PR TITLE
test: Allow error message for deliberately crashed hostnamed

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -104,6 +104,8 @@ class TestConnection(MachineCase):
         cores = m.execute("find /var/lib/systemd/coredump -type f")
         self.assertNotEqual(cores, "")
 
+        self.allow_journal_messages(".*org.freedesktop.hostname1.*DBus.Error.NoReply.*")
+
     def testTls(self):
         m = self.machine
 


### PR DESCRIPTION
In `check-connection TestConnection.testBasic` we crash hostnamed to
verify core dumping. The bridge sometimes complains about not being able
to introspect hostnamed then.