### PR TITLE
bridge: Fix warnings noted by American Fuzzy Lop GCC

### DIFF
--- a/src/bridge/cockpitchannel.c
+++ b/src/bridge/cockpitchannel.c
@@ -1403,8 +1403,8 @@ cockpit_channel_parse_stream (CockpitChannel *self)
 {
   CockpitConnectable *connectable;
   GSocketConnectable *address;
-  gboolean local;
-  gchar *name;
+  gboolean local = FALSE;
+  gchar *name = NULL;
 
   address = parse_address (self, &name, &local);
   if (!address)


### PR DESCRIPTION
This fixes warnings that show up when building with afl-gcc.
They're not actually serious warnings, but lets quieten them down
anyway.