### PR TITLE
test: Make vm-prep double check that cockpit1 doesn't exist

### DIFF
--- a/test/vm-prep
+++ b/test/vm-prep
@@ -56,6 +56,12 @@ prepare()
 		$VIRSH net-undefine $NETWORK_NAME
 	fi
 
+	# In case a network has leaked in from elsewhere
+	if ip address show dev $NETWORK_NAME >/dev/null 2>/dev/null; then
+		ip link set $NETWORK_NAME down || true
+		brctl delbr $NETWORK_NAME || true
+	fi
+
 	# HACK: NetworkManager races with dnsmasq-dhcp on bridge
 	# https://bugzilla.redhat.com/show_bug.cgi?id=1205081
 	cat > /etc/sysconfig/network-scripts/ifcfg-$NETWORK_NAME << EOF


### PR DESCRIPTION
When run in Kubernetes the Pod can outlast the Container and
so this network may have leaked in from elsewhere. Lets double
check and remove it using brctl.

Ported from cockpituous https://github.com/cockpit-project/cockpituous/pull/104