### PR TITLE
Image refresh for centos-7

### DIFF
--- a/test/images/centos-7
+++ b/test/images/centos-7
@@ -1,1 +1,1 @@
-centos-7-f2fc14ebd13dd557dedd89c9a38ca8ef3af47589.qcow2
+centos-7-dbd063005151a02504cb565bedf0f42da0da0a8dd63aa1cd7a58a054e0e5fe3d.qcow2


### PR DESCRIPTION
Image creation for centos-7 in process on cockpit-tests-jstv4.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-centos-7-2017-05-22/