### PR TITLE
Image refresh for rhel-7

### DIFF
--- a/test/images/rhel-7
+++ b/test/images/rhel-7
@@ -1,1 +1,0 @@
-rhel-7-25e0e381a3c2220ab26e82dab2b62484a9c4a2f2.qcow2


### PR DESCRIPTION
Image creation for rhel-7 in process on cockpit-tests-w69p3.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-rhel-7-2017-05-22/