### PR TITLE
Image refresh for ipa

### DIFF
--- a/test/images/ipa
+++ b/test/images/ipa
@@ -1,1 +1,1 @@
-ipa-97bf57dcbf2ef7f6a56caf5a3c77358ec9bcd01a.qcow2
+ipa-31dfa4a2a7cbd3013b8795da2450026503514be167dff70ba4eaeac0de02f483.qcow2


### PR DESCRIPTION
Image creation for ipa in process on cockpit-tests-ff1rg.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-ipa-2017-05-22/