### PR TITLE
bots: Prepare images with Cockpit in bots/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ depcomp
 /bots/images/*.qcow2
 /bots/images/*.partial
 /bots/images/*.xz
+/test/images/*
 /test/container-probe*
 /mock/
 *.min.html

--- a/bots/image-create
+++ b/bots/image-create
@@ -186,9 +186,9 @@ class MachineBuilder:
         shutil.move(partial, data_file)
 
         # Update the images symlink
-        if os.path.islink(self.machine.image_base):
-            os.unlink(self.machine.image_base)
-        os.symlink(name, self.machine.image_base)
+        if os.path.islink(self.machine.image_file):
+            os.unlink(self.machine.image_file)
+        os.symlink(name, self.machine.image_file)
 
         # Handle alternate TEST_DATA
         image_file = os.path.join(images_dir, name)

--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -28,6 +28,7 @@ import tempfile
 
 BOTS = os.path.abspath(os.path.dirname(__file__))
 BASE = os.path.normpath(os.path.join(BOTS, ".."))
+TEST = os.path.join(BASE, "test")
 os.environ["PATH"] = "{0}:{1}".format(os.environ.get("PATH"), BOTS)
 
 # Borrow the VirtMachine implementation from the test/ directory
@@ -46,20 +47,27 @@ def main():
     parser.add_argument('-B', '--build-only', action='store_true', help='Only build and download results')
     parser.add_argument('-I', '--install-only', action='store_true', help='Only upload and install')
     parser.add_argument('-c', '--containers', action='store_true', help='Install container images')
-    parser.add_argument('--address', help='Address of already running machine')
+    parser.add_argument('--address', help='Address of already running machine, implies --install-only')
     parser.add_argument('image', nargs='?', default=testvm.DEFAULT_IMAGE, help='The image to use')
     args = parser.parse_args()
 
-    if args.build_only:
-        install_image = None
-    else:
-        install_image = args.image
+    # The basic operating system we're preparing on top of. Never written to
+    base_image = args.image
 
-    build_image = args.build_image
-    if args.install_only:
-        build_image = None
-    elif not build_image:
-        build_image = get_build_image(install_image or args.image)
+    # The image we're going to build in. This image is never written to
+    build_image = None
+    if not args.install_only:
+        build_image = get_build_image(args.build_image or base_image)
+
+    # Depending on the operating system ignore some things
+    skips = [ "cockpit-integration-tests" ]
+    if args.address:
+        skips.append("cockpit-tests")
+        args.install_only = True
+
+    if args.install_only and args.build_only:
+        sys.stderr.write("image-prepare: use of --install-only with --build-only is incompatible\n")
+        return 2
 
     # Default to putting build output in bots directory
     if "TEST_ATTACHMENTS" in os.environ:
@@ -67,35 +75,52 @@ def main():
     else:
         results = os.path.join(BOTS, "build-results")
 
+    # Make sure any images are downloaded
     try:
-        if build_image:
+        if not args.address and not os.path.exists(base_image):
+            subprocess.check_call([ "image-download", base_image])
+        if build_image and not os.path.exists(build_image):
             subprocess.check_call([ "image-download", build_image])
-        if install_image:
-            subprocess.check_call([ "image-download", install_image])
     except OSError, ex:
         if ex.errno != errno.ENOENT:
             raise
         sys.stderr.write("image-prepare: missing tools to download images\n")
     except subprocess.CalledProcessError as e:
-        print "unable to download all necessary images", e
+        sys.stderr.write("image-prepare: unable to download all necessary images\n")
         return 1
 
     try:
-        build_and_install(install_image, build_image, results, args={
-            "verbose": args.verbose,
-            "sit": args.sit,
-            "quick": args.quick,
-            "build_image": build_image,
-            "build_only": args.build_only,
-            "install_only": args.install_only,
-            "containers": args.containers,
-            "address": args.address,
-        })
-    except RuntimeError as ex:
+        if not args.install_only:
+            build_and_install(build_image, results, skips, args)
+        if not args.build_only and build_image != base_image:
+            only_install(base_image, results, skips, args, args.address)
+    except (RuntimeError, testvm.Failure) as ex:
         sys.stderr.write("image-prepare: {0}\n".format(str(ex)))
         return 2
 
+    # The remaining images not yet prepared are symlinked from the bots/images
+    # directory into the test/images directory. This allows for other branches to
+    # run without modification, and allows tests to load images that they didn't
+    # install or need to install cockpit on (above).
+    link_remaining_images()
+
     return 0
+
+def link_remaining_images():
+    bots_images = os.path.join(BOTS, "images")
+    test_images = os.path.join(TEST, "images")
+    if not os.path.exists(test_images):
+        os.makedirs(test_images)
+    for image in os.listdir(bots_images):
+        if "." in image:
+            continue
+        if os.path.isdir(os.path.join(bots_images, image)):
+            continue
+        dest = os.path.join(test_images, image)
+        if not os.path.isfile(dest):
+            if os.path.lexists(dest):
+                os.unlink(dest)
+            os.symlink(os.path.join("..", "..", "bots", "images", image), dest)
 
 def upload_scripts(machine, args):
     machine.execute("rm -rf /var/lib/testvm")
@@ -103,43 +128,61 @@ def upload_scripts(machine, args):
     machine.upload([ os.path.join(BOTS, "images", "scripts", "%s.install" % machine.image) ], "/var/tmp")
     machine.upload([ os.path.join(BASE, "containers") ], "/var/tmp")
 
+# Create the necessary layered image for the build/install
+def prepare_backing_file(machine, image):
+    if "/" in image:
+        image = os.path.abspath(image)
+    else:
+        image = os.path.join(BOTS, "images", image)
+    if os.path.lexists(machine.image_file):
+        os.unlink(machine.image_file)
+    images = os.path.dirname(machine.image_file)
+    if not os.path.exists(images):
+        os.makedirs(images)
+    subprocess.check_call([ "qemu-img", "create", "-q", "-f", "qcow2",
+        "-o", "backing_file={0},backing_fmt=qcow2".format(image), machine.image_file ])
+
 def run_install_script(machine, do_build, do_install, skips, arg, args):
     install = do_install
-    if args["containers"]:
+    if args.containers:
         do_install = False
 
-    skip_args = map(lambda skip: " --skip '%s'" % skip, skips or [])
+    skips = list(skips or [])
+    if "atomic" in machine.image:
+        skips.append("cockpit-kubernetes")
+    else:
+        skips.append("cockpit-ostree")
+
+    skip_args = map(lambda skip: " --skip '%s'" % skip, skips)
     cmd = "cd /var/tmp; ./%s.install%s%s%s%s%s%s" % (machine.image,
-                                                         " --verbose" if args["verbose"] else "",
-                                                         " --quick" if args["quick"] else "",
+                                                         " --verbose" if args.verbose else "",
+                                                         " --quick" if args.quick else "",
                                                          " --build" if do_build else "",
                                                          " --install" if do_install else "",
                                                          " ".join(skip_args),
                                                          " '%s'" % arg if arg else "")
     machine.execute(cmd)
-    if install and args["containers"]:
+    if install and args.containers:
         machine.execute("/var/lib/testvm/containers.install")
 
-def build_and_maybe_install(image, build_results, do_install=False, skips=None, args=None):
+def build_and_install(build_image, build_results, skips, args):
     """Build and maybe install Cockpit into a test image"""
-    machine = testvm.VirtMachine(verbose=args["verbose"], image=image, label="install")
-
-    # Remove any previous local override for the image
-    if os.path.exists(machine.image_file):
-        os.unlink(machine.image_file)
-
-    source = subprocess.check_output([ os.path.join(BASE, "tools", "make-source") ]).strip()
-    machine.start(maintain=do_install, memory_mb=4096, cpus=4)
+    machine = testvm.VirtMachine(verbose=args.verbose, image=build_image, label="install")
+    prepare_backing_file(machine, build_image)
+    machine.start(maintain=True, memory_mb=4096, cpus=4)
     completed = False
+
+    # While the machine is booting, make a tarball
+    source = subprocess.check_output([ os.path.join(BASE, "tools", "make-source") ]).strip()
 
     try:
         machine.wait_boot()
         upload_scripts(machine, args=args)
         machine.upload([ source ], "/var/tmp")
-        run_install_script(machine, True, do_install, skips, os.path.basename(source), args)
+        run_install_script(machine, True, True, skips, os.path.basename(source), args)
         completed = True
     finally:
-        if not completed and args["sit"]:
+        if not completed and args.sit:
             sys.stderr.write("ADDRESS: {0}\n".format(machine.address))
             raw_input ("Press RET to continue... ")
         try:
@@ -150,19 +193,14 @@ def build_and_maybe_install(image, build_results, do_install=False, skips=None, 
         finally:
             machine.stop()
 
-def only_install(image, build_results, skips=None, args=None, address=None):
+def only_install(image, build_results, skips, args, address):
     """Install Cockpit into a test image"""
-    verbose = args["verbose"]
     started = False
-    if args["address"]:
-        machine = testvm.Machine(address=args["address"], verbose=verbose, image=image, label="install")
+    if args.address:
+        machine = testvm.Machine(address=args.address, verbose=args.verbose, image=image, label="install")
     else:
-        machine = testvm.VirtMachine(verbose=verbose, image=image, label="install")
-
-        # Remove any previous local override for the image
-        if os.path.exists(machine.image_file):
-            os.unlink(machine.image_file)
-
+        machine = testvm.VirtMachine(verbose=args.verbose, image=image, label="install")
+        prepare_backing_file(machine, image)
         machine.start(maintain=True)
         started = True
     completed = False
@@ -175,7 +213,7 @@ def only_install(image, build_results, skips=None, args=None, address=None):
         run_install_script(machine, False, True, skips, None, args)
         completed = True
     finally:
-        if not completed and args["sit"]:
+        if not completed and args.sit:
             sys.stderr.write("ADDRESS: {0}\n".format(machine.address))
             raw_input ("Press RET to continue... ")
         if started:
@@ -184,55 +222,15 @@ def only_install(image, build_results, skips=None, args=None, address=None):
 # The Atomic variants can't build their own packages, so we build in
 # their non-Atomic siblings.  For example, fedora-atomic is built
 # in fedora-25
-def get_build_image (test_os):
-    build_os = test_os
-
+def get_build_image(image):
+    (test_os, unused) = os.path.splitext(os.path.basename(image))
     if test_os == "fedora-atomic":
-        build_os = "fedora-25"
+        image = "fedora-25"
     elif test_os == "rhel-atomic":
-        build_os = "rhel-7"
+        image = "rhel-7"
     elif test_os == "continuous-atomic":
-        build_os = "centos-7"
-    return build_os
-
-def build_and_install(install_image, build_image, build_results, args):
-    args.setdefault("verbose", False)
-    args.setdefault("sit", False)
-    args.setdefault("quick", False)
-    args.setdefault("build_image", build_image)
-    args.setdefault("build_only", False)
-    args.setdefault("install_only", False)
-    args.setdefault("containers", False)
-    args.setdefault("address", None)
-
-    skips = ["cockpit-integration-tests"]
-    if install_image:
-        if "atomic" in install_image:
-            skips.append("cockpit-kubernetes")
-        else:
-            skips.append("cockpit-ostree")
-    if args["address"]:
-        skips.append("cockpit-tests")
-
-    try:
-
-        if not args["address"] and build_image and build_image == install_image:
-            build_and_maybe_install(build_image, build_results, do_install=True, skips=skips, args=args)
-        else:
-            if build_image:
-                build_and_maybe_install(build_image, build_results, do_install=False, skips=skips, args=args)
-            if install_image:
-                only_install(install_image, build_results, skips, args=args)
-
-            # Atomics need a companion image for tests
-            if build_image and install_image and install_image in testvm.ATOMIC_IMAGES:
-                skips.append("cockpit-ostree")
-                only_install(build_image, build_results, skips, args=args)
-
-    except testvm.Failure, ex:
-        raise ("Unable to build and install cockpit package", ex)
-    return True
-
+        image = "centos-7"
+    return image
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -188,6 +188,33 @@ class PullTask(object):
 
         return None
 
+    def prepare(self, prefix, value, image, verbose=False):
+        sys.stderr.write("Preparing image: building and installing Cockpit ...\n")
+        cmd = [ os.path.join(BOTS, "image-prepare") ]
+        if prefix == "image" or prefix == "container":
+            cmd += [ "--containers" ]
+        if verbose:
+            cmd += [ "--verbose" ]
+
+        try:
+            # Do the basic prepare
+            subprocess.check_call(cmd + [ image ])
+
+            # For containers tests we install to openshift too
+            if value == "kubernetes":
+                subprocess.check_call(cmd + [ "--install-only", "openshift" ])
+
+        except subprocess.CalledProcessError:
+            return "Preparation of testable image failed"
+
+        try:
+            # Download all the additional images so that even branches find them
+            subprocess.check_call([ os.path.join(BOTS, "image-download"),
+                "candlepin", "fedora-stock", "ipa", "openshift", "selenium" ])
+
+        except subprocess.CalledProcessError:
+            return "Downloading of additional images failed"
+
     def stop_publishing(self, ret):
         sink = self.sink
         def mark_failed():
@@ -234,6 +261,9 @@ class PullTask(object):
         if self.base and not opts.offline:
             subprocess.check_call([ "git", "fetch", "origin", self.base ])
 
+        # Clean out the test directory
+        subprocess.check_call([ "git", "clean", "-d", "--force", "--quiet", "-x", "--", "test/" ])
+
         os.environ["TEST_NAME"] = self.name
         os.environ["TEST_REVISION"] = self.revision
 
@@ -241,11 +271,12 @@ class PullTask(object):
         (prefix, unused, value) = self.context.partition("/")
 
         if prefix in [ 'selenium' ]:
-            os.environ["TEST_OS"] = 'fedora-24'
+            image = 'fedora-24'
         elif prefix in [ 'container' ]:
-            os.environ["TEST_OS"] = 'fedora-25'
+            image = 'fedora-25'
         else:
-            os.environ["TEST_OS"] = value
+            image = value
+        os.environ["TEST_OS"] = image
 
         if opts.publish:
             self.start_publishing(opts.publish)
@@ -261,39 +292,48 @@ class PullTask(object):
             ret = self.rebase()
 
         test = os.path.join(BOTS, "..", "test")
-        os.environ["PATH"] = "{0}:{1}:{2}".format(os.environ.get("PATH"), BOTS, test)
 
         # Figure out what to do next
         if prefix == "verify":
             cmd = [ "timeout", "120m", os.path.join(test, "verify", "run-tests"),
-                    "--install", "--jobs", str(opts.jobs) ]
+                    "--jobs", str(opts.jobs) ]
         elif prefix == "avocado":
             cmd = [ "timeout", "60m", os.path.join(test, "avocado", "run-tests"),
-                    "--install", "--quick", "--tests" ]
+                    "--quick", "--tests" ]
         elif prefix == "koji":
             cmd = [ "timeout", "120m", os.path.join(test, "koji", "run-build") ]
         elif prefix == "selenium":
             if value not in ['firefox', 'chrome']:
                 ret = "Unknown browser for selenium test"
             cmd = [ "timeout", "60m", os.path.join(test, "avocado", "run-tests"),
-                    "--install", "--quick", "--selenium-tests", "--browser", value]
+                    "--quick", "--selenium-tests", "--browser", value]
         elif prefix == "image" or prefix == "container":
             cmd = [ "timeout", "90m", os.path.join(test, "containers", "run-tests"),
-                    "--install", "--container", value]
+                    "--container", value]
         else:
             ret = "Unknown context"
 
         if cmd and opts.verbose:
             cmd.append("--verbose")
 
+        env = os.environ.copy()
+        env["TEST_DATA"] = BOTS
+        env["PATH"] = "{0}:{1}:{2}".format(env.get("PATH", "/bin:/sbin"), BOTS, test)
+
         # Setup network if necessary, any failures caught during testing
         prep = os.path.join(BASE, "test", "vm-prep")
         if os.path.exists(prep):
-            subprocess.call(["sudo", "-n", prep ])
+            subprocess.call(["sudo", "-n", prep ], env=env)
 
-        # Actually run the tests
+        # Prepare the image to run
         if not ret:
-            ret = subprocess.call(cmd)
+            ret = self.prepare(prefix, value, image, opts.verbose)
+
+        # Actually run the tests. We modify the TEST_DATA environment
+        # variable when invoking them to make them look for images and
+        # such in the bots directory. In addition we have a nice path
+        if not ret:
+            ret = subprocess.call(cmd, env=env)
 
         # All done
         if self.sink:

--- a/test/README
+++ b/test/README
@@ -23,7 +23,7 @@ for more details and recommendations on ensuring it is enabled correctly.
 Before running the tests, ensure Cockpit has been built where the test suite
 expects to find it (do NOT run the build step as root):
 
-   $ ./test/verify/testsuite-prepare
+   $ ./bots/image-prepare
 
 To run the integration tests run the following (do NOT run the integration tests
 as root):
@@ -36,33 +36,25 @@ images to retrieve for different scenario tests).
 
 Alternatively you can run an individual test like this:
 
-    $ cd test
-    $ ./verify/testsuite-prepare
-    $ ./verify/check-session
+    $ ./bots/image-prepare
+    $ ./test/verify/check-session
 
 To see more verbose output from the test, use the --verbose and/or --trace flags:
 
-    $ ./verify/check-session --verbose --trace
+    $ ./test/verify/check-session --verbose --trace
 
 In addition if you specify `--sit`, then the test wail wait on failure and allow
 you to log into cockpit and/or the test instance and diagnose the issue. An address
 will be printed of the test instance.
 
-    $ ./verify/check-session --trace --sit
-
-In order to pick up local changes to Cockpit itself prior to running the tests,
-the `--install` option provides a convenient alternative to explicitly running
-`testsuite-prepare` as a separate step:
-
-    $ ./test/verify/run-tests --install
+    $ ./test/verify/check-session --trace --sit
 
 ## Details
 
 The verify test suite is the main test suite:
 
- * verify/testsuite-prepare: Prepare everything so that tests can run
- * verify/run-tests: Run all tests
- * verify/check-*: Run the selected tests
+ * test/verify/run-tests: Run all tests
+ * test/verify/check-*: Run the selected tests
 
 ## Test Configuration
 
@@ -151,12 +143,12 @@ A typical sequence of steps would thus be the following:
 
   $ bots/image-download
   $ test/vm-reset            # Start over
-  $ tools/make-rpms    # Create rpms
-  $ bots/image-install ...      # Install code to test
+  $ tools/make-rpms          # Create rpms
+  $ bots/image-install ...   # Install code to test
   $ test/verify/check-...    # Run some tests
 
   $ test/vm-reset            # Start over
-  $ bots/image-prepare ...      # Install code to test
+  $ bots/image-prepare ...   # Install code to test
   $ bots/verify/check-...    # Run some tests
 
 You can perform all of the above easily by doing `./testsuite-prepare`
@@ -167,13 +159,13 @@ Once you have a test machine image that contains the version of
 Cockpit that you want to test, you can run tests by picking a program
 and just executing it:
 
-  $ ./verify/check-connection
+  $ test/verify/check-connection
 
 Many of the verify tests can also be run against an already running
 machine. Although be aware that lots of the tests change state on
 the target machine.
 
-  $ ./verify/check-connection --machine=10.1.1.2
+  $ test/verify/check-connection --machine=10.1.1.2
 
 The test/containers/ tests use the same VMs as the above test/verify/ ones.
 But they don't have a separate "prepare" step/script; instead, the first time
@@ -188,7 +180,7 @@ will pause when a failure occurs so that you can log into the test
 machine and investigate the problem.
 
 You can log into a running test-machine using the ssh credentials in
-./test/common/identity as the user root.
+test/common/identity as the user root.
 
 You can also put calls to sit() into the tests themselves to stop them
 at strategic places.

--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -219,8 +219,6 @@ def main():
     parser.add_argument('-v', '--verbose', dest="verbosity", action='store_true',
                         help='Verbose output')
     parser.add_argument('-q', '--quick', action='store_true', help='Build faster')
-    parser.add_argument('--install', dest='install', action='store_true',
-                        help='Build and install Cockpit into test VMs')
     parser.add_argument("-b", "--browser", choices=['none', 'firefox', 'chrome'],
                     default='none',
                     help="selenium browser choice - in case of none, selenium isn't started")
@@ -233,17 +231,6 @@ def main():
     parser.add_argument('tests', nargs='*')
 
     opts = parser.parse_args()
-    if opts.install:
-        sys.stderr.write("Building and installing Cockpit ...\n")
-        subprocess.check_call([ "image-download", testvm.DEFAULT_IMAGE, "selenium" ])
-
-        cmd = [ "image-prepare" ]
-        if opts.verbosity:
-            cmd.append("--verbose")
-        if opts.quick:
-            cmd.append("--quick")
-        cmd.append(testvm.DEFAULT_IMAGE)
-        subprocess.check_call(cmd)
 
     regular_tests = [ "checklogin-basic.py", "checklogin-raw.py" ]
     browser_tests = [ "selenium-base.py", "selenium-storage.py", "selenium-docker.py", "selenium-sosreport.py" ]

--- a/test/containers/run-tests
+++ b/test/containers/run-tests
@@ -42,26 +42,6 @@ def check_valid(filename):
         return None
     return name.replace("-", "_")
 
-def install(opts):
-    sys.stderr.write("Building and installing Cockpit ...\n")
-    cmds = [
-        [ "image-download", testvm.DEFAULT_IMAGE ],
-        [ "image-prepare", "--containers", testvm.DEFAULT_IMAGE ],
-    ]
-
-    if opts.sit:
-        cmds[-1].append("--sit")
-
-    if opts.container == 'kubernetes':
-        cmds.append([ "image-download", 'openshift' ])
-        cmds.append([ "image-prepare", "--install-only", "--containers", "openshift" ])
-
-    if opts.sit:
-        cmds[-1].append("--sit")
-
-    for cmd in cmds:
-        subprocess.check_call(cmd)
-
 def run(opts):
     # Now actually load the tests, any modules that start with "check-*"
     loader = unittest.TestLoader()
@@ -80,16 +60,11 @@ def run(opts):
 
 def main():
     parser = testlib.arg_parser()
-    parser.add_argument('-i', '--install', dest="install", action='store_true',
-                        help='Install rpms')
     parser.add_argument('-c', '--container', dest="container", action='store',
                         help='container to test')
     opts = parser.parse_args()
     if not opts.container:
         opts.container = 'kubernetes'
-
-    if opts.install:
-        install(opts)
 
     if not os.path.isdir(os.path.abspath(os.path.join(testdir, "..", "containers", opts.container))):
         sys.stderr.write("Unable to run tests for unknown container {0}.\n".format(opts.container))

--- a/test/verify/run-tests
+++ b/test/verify/run-tests
@@ -28,17 +28,6 @@ def check_valid(filename):
         return None
     return name.replace("-", "_")
 
-def install(opts, image):
-    try:
-        sys.stderr.write("Building and installing Cockpit ...\n")
-        cmd = [ "image-prepare", image ]
-        subprocess.check_call(cmd)
-        return 0
-    except subprocess.CalledProcessError:
-        traceback.print_exc()
-        sys.stderr.write("Install failed\n")
-        return 1
-
 def run(opts):
     # Now actually load the tests, any modules that start with "check-*"
     loader = unittest.TestLoader()
@@ -57,8 +46,6 @@ def run(opts):
 def main():
     parser = testlib.arg_parser()
     parser.add_argument('--publish', action='store', help="Unused")
-    parser.add_argument('--install', dest='install', action='store_true',
-                        help='Build and install Cockpit into test VMs')
     parser.add_argument('image', action='store', nargs='?',
                         help='The operating system image to verify against')
     opts = parser.parse_args()
@@ -74,13 +61,7 @@ def main():
     testvm.DEFAULT_IMAGE = image
     os.environ["TEST_OS"] = image
 
-    ret = 0
-    if opts.install:
-        ret = install(opts, image)
-    if not ret:
-        ret = run(opts)
-
-    return ret
+    return run(opts)
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/test/vm-reset
+++ b/test/vm-reset
@@ -31,4 +31,4 @@ case ${1:-} in
 	;;
 esac
 
-rm -rf $BASE/tmp/run/* $BASE/tmp/run/.*??
+rm -rf $BASE/tmp/run/* $BASE/tmp/run/.*?? $BASE/images/*

--- a/test/vm-run
+++ b/test/vm-run
@@ -37,7 +37,16 @@ parser.add_argument('image', help='The image to run')
 args = parser.parse_args()
 
 try:
-    machine = testvm.VirtMachine(verbose=args.verbose, image=args.image)
+    image = args.image
+    if "/" in image:
+        image = os.path.abspath(image)
+    else:
+        image = os.path.join(TEST, "images", image)
+
+    # Be helpful and find image in bots/ if image-prepare hasn't been run
+    if not os.path.lexists(image):
+        image = os.path.join(BOTS, "images", image)
+    machine = testvm.VirtMachine(verbose=args.verbose, image=image)
 
     # Hack to make things easier for users who don't know about kubeconfig
     if args.image == 'openshift':
@@ -56,7 +65,7 @@ try:
             raise Exception("vm-run: please run: sudo test/vm-prep")
 
     # Check that image is downloaded
-    if not os.path.exists(machine.image_base):
+    if not os.path.exists(machine.image_file):
         try:
             ret = subprocess.call([ os.path.join(BOTS, "image-download"), args.image])
         except OSError, ex:


### PR DESCRIPTION
The test/ code no longer should have anything to do with preparing images for testing. The bots/ code and ```bots/image-prepare``` in particular will take care of this.

 * On master the code in ```test/``` for preparing images will be removed.
 * On branches the code in ```test/``` for preparing images will be unused.

No changes should be required to branches. Fingers crossed.

 * [x] #6673 
 * [x] #6676