### PR TITLE
bots: Fix typo in tests-invoke that always checked out bots

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -167,10 +167,11 @@ class PullTask(object):
             return "Rebase failed"
 
         # If the bots directory doesn't exist in this branch, check it out from master
-        ret = subprocess.call([ "git", "ls-tree" "-d", "HEAD:bots/"], stdout=DEVNULL, stderr=DEVNULL)
+        ret = subprocess.call([ "git", "ls-tree", "-d", "HEAD:bots/"], stdout=DEVNULL)
         if ret == 0:
             return None
         try:
+            sys.stderr.write("Checking out bots directory from master ...\n")
             subprocess.check_call([ "git", "checkout", "--force", "origin/master", "--", "bots/" ])
             self.respawn = True
         except:


### PR DESCRIPTION
The bots directory was always being checked out from master even
for pull requests that changed it. This was due to a typo in
the command line.