### PR TITLE
Image refresh for ipa

### DIFF
--- a/bots/images/ipa
+++ b/bots/images/ipa
@@ -1,1 +1,0 @@
-ipa-97bf57dcbf2ef7f6a56caf5a3c77358ec9bcd01a.qcow2


### PR DESCRIPTION
Image creation for ipa in process on verifymachine4.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-ipa-2017-05-23/