### PR TITLE
bots: Add tests for whitelist and don't auto read it

### DIFF
--- a/bots/github-trigger
+++ b/bots/github-trigger
@@ -43,7 +43,7 @@ def trigger_pull(api, opts):
     # triggering is manual, so don't prevent triggering a user that isn't on the whitelist
     # but issue a warning in case of an oversight
     login = pull["head"]["user"]["login"]
-    if not opts.allow and not login in api.whitelist:
+    if not opts.allow and not login in github.whitelist():
         sys.stderr.write("Pull request author '{0}' isn't whitelisted. Override with --allow.\n".format(login))
         return 1
 

--- a/bots/github/test-github
+++ b/bots/github/test-github
@@ -117,5 +117,30 @@ class TestGitHub(unittest.TestCase):
         count = api.get("/count")
         self.assertEqual(count, 1)
 
+class TestWhitelist(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp)
+
+    def testLoad(self):
+        filename = os.path.join(self.temp, "whitelist")
+        with open(filename, "w") as f:
+            f.write("   one   \n   two\nthree\n\n")
+        whitelist = github.whitelist(filename)
+        self.assertEqual(set(github.whitelist(filename)), set(["one", "two", "three"]))
+        self.assertNotIn("four", whitelist)
+        self.assertNotIn("", whitelist)
+
+    def testDefault(self):
+        whitelist = github.whitelist()
+        self.assertTrue(len(whitelist) > 0)
+
+    def testNotPresent(self):
+        filename = os.path.join(self.temp, "whitelist")
+        whitelist = github.whitelist(filename)
+        self.assertEqual(len(whitelist), 0)
+
 if __name__ == '__main__':
     unittest.main()

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -198,6 +198,7 @@ def scan_for_pull_tasks(api, update, policy):
                 if update_status(revision, context, status, changes):
                     results.append(tests_invoke(priority, branch, revision, branch, context))
 
+    whitelist = github.whitelist()
     for pull in api.pulls():
         title = pull["title"]
         number = pull["number"]
@@ -224,7 +225,7 @@ def scan_for_pull_tasks(api, update, policy):
             # For unmarked and untested status, user must be in whitelist
             # Not this only applies to this specific commit. A new status
             # will apply if the user pushes a new commit.
-            if login not in api.whitelist:
+            if login not in whitelist:
                 if status.get("description", github.NO_TESTING) == github.NO_TESTING:
                     baseline = 0
 


### PR DESCRIPTION
There's no need to automatically read the github whitelist.
In addition we should have tests for loading and parsing it.