### PR TITLE
bots: Add low priority prune image task

### DIFF
--- a/bots/image-scan
+++ b/bots/image-scan
@@ -97,6 +97,7 @@ import os
 import json
 import pipes
 import sys
+import tempfile
 import time
 import urllib
 
@@ -196,6 +197,21 @@ def scan_for_image_tasks(api, policy):
 
     return results
 
+# Prepare an image prune command
+def scan_for_prune():
+    tasks = [ ]
+    stamp = os.path.join(tempfile.gettempdir(), "cockpit-image-prune.stamp")
+
+    # Don't prune more than once per hour
+    try:
+        mtime = os.stat(stamp).st_mtime
+    except OSError:
+        mtime = 0
+    if mtime < time.time() - 3600:
+        tasks.append("PRIORITY=0000 touch {0} && bots/image-download --prune".format(stamp))
+
+    return tasks
+
 def scan(api, update, verbose):
     kvm = os.access("/dev/kvm", os.R_OK | os.W_OK)
     if not kvm:
@@ -212,6 +228,7 @@ def scan(api, update, verbose):
         pass
 
     task_entries = scan_for_image_tasks(api, policy)
+    task_entries += scan_for_prune()
 
     if verbose:
         for image, wait_time in scan_image_wait_times(api, policy).items():


### PR DESCRIPTION
This is a task that gets run as low priority after all other
tasks have completed. In addition we should aim not to run
it over and over again, so we have a simple stap that prevents
that.