### PR TITLE
bots: Rename RHEL 7.4 image to rhel-7-4

### DIFF
--- a/bots/README.md
+++ b/bots/README.md
@@ -12,6 +12,9 @@ will be updated as they are.
 In order to test Cockpit it is staged into an operating system
 image. These images are tracked in the ```bots/images``` directory.
 
+These well known image names are expected to contain no ```.```
+characters and have no file name extension.
+
 For managing these images:
 
  * image-download: Download test images

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -49,7 +49,7 @@ DEFAULT_VERIFY = {
 # Non-public images used for testing
 REDHAT_VERIFY = {
     "verify/rhel-7": [ "master", "pulls" ],
-    "verify/rhel-7.4": [ ],
+    "verify/rhel-7-4": [ ],
     "verify/rhel-atomic": [ "master", "pulls" ],
 }
 


### PR DESCRIPTION
Files in the "images" directories without extensions are meant to
be the well known image names. Whereas files with extensions
are meant to be actual data or specific instances of images.