### PR TITLE
bots: Add missing images for branches

### DIFF
--- a/bots/images/debian-8
+++ b/bots/images/debian-8
@@ -1,0 +1,1 @@
+debian-8-fbf89ea1ec1dcbc64fa3cbe3c0af4409ea9936d2.qcow2


### PR DESCRIPTION
All the images are loaded from ```bots/images``` now. So it needs to
contain all of the images that the branches refer to, including
```debian-8```. This reflects what's in ```bots/tests-scan```