### PR TITLE
bots: Fix typo of "master" instead of "origin/master"

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -179,7 +179,7 @@ class PullTask(object):
                     path = os.path.join(machine, name)
                     if os.path.islink(path):
                         os.unlink(path)
-                        code = subprocess.check_output([ "git", "show", "master:test/common/{0}".format(name) ])
+                        code = subprocess.check_output([ "git", "show", "origin/master:test/common/{0}".format(name) ])
                         with open(path, "w") as f:
                             f.write(code)
 


### PR DESCRIPTION
This causes a checkout from the wrong branch. This resulted in local
checkouts instead of checkouts on from the remote.