### PR TITLE
bots: Fix linking of images into place for older branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ depcomp
 /bots/images/*.partial
 /bots/images/*.xz
 /test/images/*
+/test/verify/naughty-*/*
 /test/container-probe*
 /mock/
 *.min.html

--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -22,7 +22,6 @@ import errno
 import os
 import sys
 import glob
-import shutil
 import subprocess
 import tempfile
 
@@ -97,29 +96,7 @@ def main():
         sys.stderr.write("image-prepare: {0}\n".format(str(ex)))
         return 2
 
-    # The remaining images not yet prepared are symlinked from the bots/images
-    # directory into the test/images directory. This allows for other branches to
-    # run without modification, and allows tests to load images that they didn't
-    # install or need to install cockpit on (above).
-    link_remaining_images()
-
     return 0
-
-def link_remaining_images():
-    bots_images = os.path.join(BOTS, "images")
-    test_images = os.path.join(TEST, "images")
-    if not os.path.exists(test_images):
-        os.makedirs(test_images)
-    for image in os.listdir(bots_images):
-        if "." in image:
-            continue
-        if os.path.isdir(os.path.join(bots_images, image)):
-            continue
-        dest = os.path.join(test_images, image)
-        if not os.path.isfile(dest):
-            if os.path.lexists(dest):
-                os.unlink(dest)
-            os.symlink(os.path.join("..", "..", "bots", "images", image), dest)
 
 def upload_scripts(machine, args):
     machine.execute("rm -rf /var/lib/testvm")
@@ -129,18 +106,19 @@ def upload_scripts(machine, args):
 
 # Create the necessary layered image for the build/install
 def prepare_install_image(base_image):
-    if "/" in base_image:
-        image = os.path.abspath(base_image)
-    else:
+    if "/" not in base_image:
         base_image = os.path.join(BOTS, "images", base_image)
     test_images = os.path.join(TEST, "images")
-    install_image = os.path.join(test_images, os.path.basename(base_image))
     if not os.path.exists(test_images):
         os.makedirs(test_images)
+    install_image = os.path.join(test_images, os.path.basename(base_image))
+    base_image = os.path.realpath(base_image)
+    qcow2_image = "{0}.qcow2".format(install_image)
+    subprocess.check_call([ "qemu-img", "create", "-q", "-f", "qcow2",
+        "-o", "backing_file={0},backing_fmt=qcow2".format(base_image), qcow2_image ])
     if os.path.lexists(install_image):
         os.unlink(install_image)
-    subprocess.check_call([ "qemu-img", "create", "-q", "-f", "qcow2",
-        "-o", "backing_file={0},backing_fmt=qcow2".format(base_image), install_image ])
+    os.symlink(os.path.basename(qcow2_image), install_image)
     return install_image
 
 def run_install_script(machine, do_build, do_install, skips, arg, args):

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -20,8 +20,9 @@
 
 import argparse
 import os
-import subprocess
+import shutil
 import socket
+import subprocess
 import sys
 import time
 import traceback
@@ -201,6 +202,47 @@ class PullTask(object):
 
     def prepare(self, prefix, value, image, verbose=False):
         sys.stderr.write("Preparing image: building and installing Cockpit ...\n")
+
+        try:
+            # Download all the additional images so that even older branches find them
+            subprocess.check_call([ os.path.join(BOTS, "image-download"),
+                "candlepin", "fedora-stock", "fedora-23-stock", "ipa", "openshift", "selenium" ])
+
+        except subprocess.CalledProcessError:
+            return "Downloading of additional images failed"
+
+        # The images not yet prepared are symlinked from the bots/images
+        # directory into the test/images directory. This allows for other branches to
+        # run without modification, and allows tests to load images that they didn't
+        # install or need to install cockpit on (above).
+        bots_images = os.path.join(BOTS, "images")
+        test_images = os.path.join(BASE, "test", "images")
+        if not os.path.exists(test_images):
+            os.makedirs(test_images)
+        for name in os.listdir(bots_images):
+            if "." in name:
+                continue
+            target = os.path.join(bots_images, name)
+            if os.path.isdir(target):
+                continue
+            dest = os.path.join(test_images, name)
+            if not os.path.isfile(dest):
+                if os.path.lexists(dest):
+                    os.unlink(dest)
+                os.symlink(os.path.realpath(target), dest)
+
+        # Older branches require naughty files linked into specific places
+        # and do not use the image-pepare tooling
+        naughty_files = os.path.join(BOTS, "naughty")
+        for name in os.listdir(naughty_files):
+            dest = os.path.join(BASE, "test", "verify", "naughty-{0}".format(name))
+            if not os.path.islink(dest) and os.path.isdir(dest):
+                shutil.rmtree(dest)
+            elif os.path.lexists(dest):
+                os.unlink(dest)
+            os.symlink(os.path.join("..", "..", "bots", "naughty", name), dest)
+
+        # Now actually run the prepare tooling
         cmd = [ os.path.join(BOTS, "image-prepare") ]
         if prefix == "image" or prefix == "container":
             cmd += [ "--containers" ]
@@ -217,14 +259,6 @@ class PullTask(object):
 
         except subprocess.CalledProcessError:
             return "Preparation of testable image failed"
-
-        try:
-            # Download all the additional images so that even branches find them
-            subprocess.check_call([ os.path.join(BOTS, "image-download"),
-                "candlepin", "fedora-stock", "ipa", "openshift", "selenium" ])
-
-        except subprocess.CalledProcessError:
-            return "Downloading of additional images failed"
 
     def stop_publishing(self, ret):
         sink = self.sink
@@ -331,7 +365,8 @@ class PullTask(object):
             cmd.append("--verbose")
 
         env = os.environ.copy()
-        env["TEST_DATA"] = BOTS
+        if "TEST_DATA" in env:
+            del env["TEST_DATA"]
         env["PATH"] = "{0}:{1}:{2}".format(env.get("PATH", "/bin:/sbin"), BOTS, test)
 
         # Setup network if necessary, any failures caught during testing
@@ -343,9 +378,7 @@ class PullTask(object):
         if not ret:
             ret = self.prepare(prefix, value, image, opts.verbose)
 
-        # Actually run the tests. We modify the TEST_DATA environment
-        # variable when invoking them to make them look for images and
-        # such in the bots directory. In addition we have a nice path
+        # Actually run the tests
         if not ret:
             ret = subprocess.call(cmd, env=env)
 

--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -1105,9 +1105,9 @@ class VirtMachine(Machine):
             self._cleanup()
 
     def start(self, maintain=False, macaddr=None, memory_mb=None, cpus=None, wait_for_ip=True):
-        if self.fetch:
+        if self.fetch and not os.path.exists(self.image_file):
             try:
-                subprocess.check_call([ "image-download", self.image ])
+                subprocess.check_call([ "image-download", self.image_file ])
             except OSError, ex:
                 if ex.errno != errno.ENOENT:
                     raise

--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -901,6 +901,8 @@ class VirtMachine(Machine):
             self.image_file = image = os.path.abspath(image)
         else:
             self.image_file = os.path.join(LOCAL_DIR, "..", "images", image)
+            if not os.path.lexists(self.image_file):
+                self.image_file = os.path.join(LOCAL_DIR, "..", "..", "bots", "images", image)
         (image, extension) = os.path.splitext(os.path.basename(image))
 
         Machine.__init__(self, image=image, **args)

--- a/test/vm-run
+++ b/test/vm-run
@@ -37,16 +37,7 @@ parser.add_argument('image', help='The image to run')
 args = parser.parse_args()
 
 try:
-    image = args.image
-    if "/" in image:
-        image = os.path.abspath(image)
-    else:
-        image = os.path.join(TEST, "images", image)
-
-    # Be helpful and find image in bots/ if image-prepare hasn't been run
-    if not os.path.lexists(image):
-        image = os.path.join(BOTS, "images", image)
-    machine = testvm.VirtMachine(verbose=args.verbose, image=image)
+    machine = testvm.VirtMachine(verbose=args.verbose, image=args.image)
 
     # Hack to make things easier for users who don't know about kubeconfig
     if args.image == 'openshift':


### PR DESCRIPTION
For older branches that we don't want to modify, the images need
to treat them correctly. So we create them all as such, even the
ones that we prepared.

In addition the targets for the symlinks need to be files, and
we need to unset TEST_DATA so that the files are no longer