### PR TITLE
bots: Add logging to GitHub accesses

### DIFF
--- a/bots/github/__init__.py
+++ b/bots/github/__init__.py
@@ -26,8 +26,10 @@ import httplib
 import json
 import os
 import re
+import socket
 import subprocess
 import sys
+import time
 import urlparse
 
 import cache
@@ -104,6 +106,17 @@ def whitelist(filename=WHITELIST):
     # Remove duplicate entries
     return set(whitelist)
 
+class Logger(object):
+    def __init__(self, directory):
+        hostname = socket.gethostname().split(".")[0]
+        month = time.strftime("%Y%m")
+        self.path = os.path.join(directory, "{0}-{1}.log".format(hostname, month))
+
+    # Yes, we open the file each time
+    def write(self, value):
+        with open(self.path, 'a') as f:
+            f.write(value)
+
 class GitHub(object):
     def __init__(self, base=GITHUB_BASE, cacher=None):
         self.url = urlparse.urlparse(base)
@@ -126,6 +139,10 @@ class GitHub(object):
             directory = os.path.join(os.environ.get("TEST_DATA", BOTS), "github")
             cacher = cache.Cache(directory)
         self.cache = cacher
+
+        # Create a log for debugging our GitHub access
+        self.log = Logger(self.cache.directory)
+        self.log.write("")
 
     def qualify(self, resource):
         return urlparse.urljoin(self.url.path, resource)
@@ -157,6 +174,13 @@ class GitHub(object):
         heads = { }
         for (header, value) in response.getheaders():
             heads[header.lower()] = value
+        self.log.write('{0} - - [{1}] "{2} {3} HTTP/1.1" {4} -\n'.format(
+            self.url.netloc,
+            time.asctime(),
+            method,
+            resource,
+            response.status
+        ))
         return {
             "status": response.status,
             "reason": response.reason,

--- a/bots/github/cache.py
+++ b/bots/github/cache.py
@@ -35,7 +35,7 @@ __all__ = (
 class Cache(object):
     def __init__(self, directory, lag=None):
         self.directory = directory
-        self.prune()
+        self.pruned = False
 
         # Default to zero lag when command on command line
         if lag is None:
@@ -82,6 +82,9 @@ class Cache(object):
             json.dump(contents, fp)
         os.chmod(temp, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
         os.rename(temp, path)
+        if not self.pruned:
+            self.pruned = True
+            self.prune()
 
     # Tell the cache that stuff before this time is not "current"
     def mark(self, mtime=None):

--- a/bots/github/test-github
+++ b/bots/github/test-github
@@ -21,12 +21,14 @@
 ADDRESS = ("127.0.0.8", 9898)
 
 import ctypes
+import fnmatch
 import httplib
 import imp
 import json
 import os
 import signal
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
@@ -116,6 +118,22 @@ class TestGitHub(unittest.TestCase):
 
         count = api.get("/count")
         self.assertEqual(count, 1)
+
+    def testLog(self):
+        api = github.GitHub("http://127.0.0.8:9898", cacher=cache.Cache(self.temp))
+
+        api.get("/test/user")
+        api.get("/test/user")
+
+        expect = '127.0.0.8:9898 - - * "GET /test/user HTTP/1.1" 200 -\n' + \
+                 '127.0.0.8:9898 - - * "GET /test/user HTTP/1.1" 304 -\n'
+        hostname = socket.gethostname().split(".")[0]
+        month = time.strftime("%Y%m")
+        with open(os.path.join(self.temp, "{0}-{1}.log".format(hostname, month))) as f:
+            log = f.read()
+            match = fnmatch.fnmatch(log, expect)
+        if not match:
+            self.fail("'{0}' did not match '{1}'".format(log, expect))
 
 class TestWhitelist(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This allows us to start to diagnose when and where we have
exccessive access, how to deal with it, and whether we should
think about a different GitHub access approach.