### PR TITLE
bots: Use a more efficient way to get GitHub statuses

### DIFF
--- a/bots/github/__init__.py
+++ b/bots/github/__init__.py
@@ -212,14 +212,14 @@ class GitHub(object):
         page = 1
         count = 100
         while count == 100:
-            statuses = self.get("commits/{0}/statuses?page={1}&per_page={2}".format(revision, page, count))
+            data = self.get("commits/{0}/status?page={1}&per_page={2}".format(revision, page, count))
             count = 0
             page += 1
-            if statuses:
-                for status in statuses:
+            if "statuses" in data:
+                for status in data["statuses"]:
                     if status["context"] not in result:
                         result[status["context"]] = status
-                count = len(statuses)
+                count = len(data["statuses"])
         return result
 
     def pulls(self):


### PR DESCRIPTION
Looks like we were repetetively trying to retrieve information
about statuses in an inefficient manner. We just need the latest
status for each context.

https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref