### PR TITLE
test: Fix cases where we race with tmp/run directory creation

### DIFF
--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -1001,8 +1001,11 @@ class VirtMachine(Machine):
     def _start_qemu(self, maintain=False, macaddr=None, wait_for_ip=True, memory_mb=None, cpus=None):
         self._cleanup()
 
-        if not os.path.exists(self.run_dir):
+        try:
             os.makedirs(self.run_dir, 0750)
+        except OSError, ex:
+            if ex.errno != errno.EEXIST:
+                raise
 
         image_to_use = self.image_file
         if not os.path.exists(self.image_file):


### PR DESCRIPTION
We're seeing this error in some tests. This is due to multiple
TEST_JOB's trying to create the directory at once.

```
OSError: [Errno 17] File exists: '/build/cockpit/test/common/../tmp/run'
```