### PR TITLE
bots: Only mark the GitHub cache after success

### DIFF
--- a/bots/github/__init__.py
+++ b/bots/github/__init__.py
@@ -191,20 +191,20 @@ class GitHub(object):
 
     def post(self, resource, data, accept=[]):
         response = self.request("POST", resource, json.dumps(data), { "Content-Type": "application/json" })
-        self.cache.mark()
         status = response['status']
         if (status < 200 or status >= 300) and status not in accept:
             sys.stderr.write("{0}\n{1}\n".format(resource, response['data']))
             raise Exception("GitHub API problem: {0}".format(response['reason'] or status))
+        self.cache.mark()
         return json.loads(response['data'])
 
     def patch(self, resource, data, accept=[]):
         response = self.request("PATCH", resource, json.dumps(data), { "Content-Type": "application/json" })
-        self.cache.mark()
         status = response['status']
         if (status < 200 or status >= 300) and status not in accept:
             sys.stderr.write("{0}\n{1}\n".format(resource, response['data']))
             raise Exception("GitHub API problem: {0}".format(response['reason'] or status))
+        self.cache.mark()
         return json.loads(response['data'])
 
     def statuses(self, revision):


### PR DESCRIPTION
Marking the GitHub cache means that recent requests get revalidated
against GitHub. We normally do this when we've made a change to
GitHub. However we should wait until we get a success response
and not mark the cache in case of failure.