### PR TITLE
machines: Send Non-Maskable interrupt feature added

### DIFF
--- a/pkg/machines/README.md
+++ b/pkg/machines/README.md
@@ -51,6 +51,7 @@ Your provider should have the following properties and methods:
         FORCEOFF_VM: function ({ name, id }) {},
         REBOOT_VM: function ({ name, id }) {},
         FORCEREBOOT_VM: function ({ name, id }) {},
+        SENDNMI_VM: function ({ name, id }) {},
         START_VM: function ({ name, id }) {},
         DELETE_VM: function ({ name, id, options }) {},
 
@@ -63,6 +64,7 @@ Your provider should have the following properties and methods:
         canReset: function (state) {return true;}, // return boolean
         canShutdown: function (state) {return true;},
         canDelete: function (state) {return true;},
+        canSendNMI: function (state) {return true;},
         isRunning: function (state) {return true;},
         canRun: function (state) {return true;},
 

--- a/pkg/machines/actions.es6
+++ b/pkg/machines/actions.es6
@@ -79,6 +79,10 @@ export function usageStopPolling(vm) {
     return virt('USAGE_STOP_POLLING', { name: vm.name, id: vm.id, connectionName: vm.connectionName });
 }
 
+export function sendNMI(vm) {
+    return virt('SENDNMI_VM', { name: vm.name, id: vm.id, connectionName: vm.connectionName });
+}
+
 /**
  * Delay call of polling action.
  *

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -20,7 +20,7 @@
 import cockpit from 'cockpit';
 import React, { PropTypes } from "react";
 import { shutdownVm, forceVmOff, forceRebootVm, rebootVm, startVm,
-         usageStartPolling, usageStopPolling } from "./actions.es6";
+         usageStartPolling, usageStopPolling, sendNMI } from "./actions.es6";
 import { rephraseUI, logDebug, toGigaBytes, toFixedPrecision, vmId } from "./helpers.es6";
 import DonutChart from "./c3charts.jsx";
 import { Listing, ListingRow } from "cockpit-components-listing.jsx";
@@ -50,7 +50,7 @@ const NoVm = () => {
     </div>);
 }
 
-const VmActions = ({ vm, config, dispatch, onStart, onReboot, onForceReboot, onShutdown, onForceoff }) => {
+const VmActions = ({ vm, config, dispatch, onStart, onReboot, onForceReboot, onShutdown, onForceoff, onSendNMI}) => {
     const id = vmId(vm.name);
     const state = vm.state;
 
@@ -71,17 +71,23 @@ const VmActions = ({ vm, config, dispatch, onStart, onReboot, onForceReboot, onS
 
     let shutdown = null;
     if (config.provider.canShutdown(state)) {
-        shutdown = DropdownButtons({
-            buttons: [{
-                title: _("Shut Down"),
-                action: onShutdown,
-                id: `${id}-off`
-            }, {
-                title: _("Force Shut Down"),
-                action: onForceoff,
-                id: `${id}-forceOff`
-            }]
-        });
+	let buttons = [{
+            title: _("Shut Down"),
+            action: onShutdown,
+            id: `${id}-off`
+        }, {
+            title: _("Force Shut Down"),
+            action: onForceoff,
+            id: `${id}-forceOff`
+        }];
+        if (config.provider.canSendNMI && config.provider.canSendNMI(state)) {
+            buttons.push({
+                title: _("Send Non-Maskable Interrupt"),
+                action: onSendNMI,
+                id: `${id}-sendNMI`
+            })
+        }
+        shutdown = DropdownButtons({ buttons: buttons });
     }
 
     let run = null;
@@ -124,6 +130,7 @@ VmActions.propTypes = {
     onForceReboot: PropTypes.func.isRequired,
     onShutdown: PropTypes.func.isRequired,
     onForceoff: PropTypes.func.isRequired,
+    onSendNMI: PropTypes.func.isRequired,
 }
 
 const IconElement = ({ onClick, className, title, state }) => {
@@ -397,7 +404,7 @@ VmUsageTab.propTypes = {
 /** One VM in the list (a row)
  */
 const Vm = ({ vm, config, onStart, onShutdown, onForceoff, onReboot, onForceReboot,
-              onUsageStartPolling, onUsageStopPolling, dispatch }) => {
+              onUsageStartPolling, onUsageStopPolling, onSendNMI, dispatch }) => {
     const stateIcon = (<StateIcon state={vm.state} config={config} valueId={`${vmId(vm.name)}-state`} />);
 
     const usageTabName = (<div id={`${vmId(vm.name)}-usage`}>{_("Usage")}</div>);
@@ -435,7 +442,7 @@ const Vm = ({ vm, config, onStart, onShutdown, onForceoff, onReboot, onForceRebo
             ]}
         tabRenderers={tabRenderers}
         listingActions={VmActions({vm, config, dispatch,
-            onStart, onReboot, onForceReboot, onShutdown, onForceoff})}/>);
+            onStart, onReboot, onForceReboot, onShutdown, onForceoff, onSendNMI})}/>);
 };
 Vm.propTypes = {
     vm: PropTypes.object.isRequired,
@@ -447,6 +454,7 @@ Vm.propTypes = {
     onForceReboot: PropTypes.func.isRequired,
     onUsageStartPolling: PropTypes.func.isRequired,
     onUsageStopPolling: PropTypes.func.isRequired,
+    onSendNMI: React.PropTypes.func.isRequired,
     dispatch: PropTypes.func.isRequired,
 };
 
@@ -476,6 +484,7 @@ const HostVmsList = ({ vms, config, dispatch }) => {
                         onForceoff={() => dispatch(forceVmOff(vm))}
                         onUsageStartPolling={() => dispatch(usageStartPolling(vm))}
                         onUsageStopPolling={() => dispatch(usageStopPolling(vm))}
+                        onSendNMI={() => dispatch(sendNMI(vm))}
                         dispatch={dispatch}
                     />);
             })}

--- a/pkg/machines/libvirt.es6
+++ b/pkg/machines/libvirt.es6
@@ -110,6 +110,7 @@ LIBVIRT_PROVIDER = {
     isRunning: (vmState) => LIBVIRT_PROVIDER.canReset(vmState),
     canRun: (vmState) => vmState == 'shut off',
     canConsole: (vmState) => vmState == 'running',
+    canSendNMI: (vmState) => LIBVIRT_PROVIDER.canReset(vmState),
 
     /**
      * Read VM properties of a single VM (virsh)
@@ -266,6 +267,15 @@ LIBVIRT_PROVIDER = {
             });
         };
     },
+
+    SENDNMI_VM ({ name, connectionName }) {
+        logDebug(`${this.name}.SENDNMI_VM(${name}):`);
+        return dispatch => spawnVirsh({connectionName,
+            method: 'SENDNMI_VM',
+            failHandler: buildFailHandler({ dispatch, name, connectionName, message: _("VM SEND Non-Maskable Interrrupt action failed")}),
+            args: ['inject-nmi', name]
+        });
+    }
 };
 
 function canLoggedUserConnectSession (connectionName, loggedUser) {

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -20,6 +20,7 @@
 
 import parent
 from testlib import *
+
 import os
 import sys
 
@@ -243,7 +244,20 @@ class TestMachines(MachineCase):
         b.wait_in_text("#vm-subVmTest1-state", "running")
 
         if args["logfile"] is not None:
-            wait(lambda: "Linux version" in self.machine.execute("cat {0}".format(args["logfile"])))
+            wait(lambda: "Linux version" in self.machine.execute("cat {0}".format(args["logfile"])), delay=3)
+
+        # Wait for the system to completely start
+        if args["logfile"] is not None:
+            wait(lambda: "login as 'cirros' user." in self.machine.execute("cat {0}".format(args["logfile"])), delay=3)
+
+        # Send Non-Maskable Interrupt (no change in VM state is expected)
+        b.click("#vm-subVmTest1-off-caret")
+        b.wait_visible("#vm-subVmTest1-sendNMI")
+        b.click("#vm-subVmTest1-sendNMI")
+        b.wait_not_visible("#vm-subVmTest1-sendNMI")
+
+        if args["logfile"] is not None:
+            b.wait(lambda: "NMI received" in self.machine.execute("cat {0}".format(args["logfile"])))
 
         # shut off
         b.click("#vm-subVmTest1-off-caret")
@@ -251,7 +265,7 @@ class TestMachines(MachineCase):
         b.click("#vm-subVmTest1-forceOff")
         b.wait_in_text("#vm-subVmTest1-state", "shut off")
 
-        # usage should drop to zero
+        # continue shut off validation - usage should drop to zero
         b.wait_in_text("#chart-donut-0 .donut-title-big-pf", "0.00")
         b.wait_in_text("#chart-donut-1 .donut-title-big-pf", "0.0")
 


### PR DESCRIPTION
This feature adds the ability to send a Non-Maskable interrupt
to a non responsive VM.

A new button is added to the host vms list for that.
By clicking on that button, the guest OS recieves a NMI and might get into panic mode
and a vmcore file may be created, which will help understanding what is the problem with
that VM.

(Please note that this depends on how the VM's kerenl is configured - is guest OS intalled?,
is kdump enabled? and is kerenl configured to get into panic mode while recieving a NMI?
otherwise nmi will be ignored or no vmcore will be created after vm crashed)

https://bugzilla.redhat.com/show_bug.cgi?id=1297037

Blocked on: 
 * [x] #7117 
 * [x] @mlibra Fixing bug in getVirtProvider that tests have found, where actions are not propogated.