### PR TITLE
Image refresh for ubuntu-1604

### DIFF
--- a/bots/images/ubuntu-1604
+++ b/bots/images/ubuntu-1604
@@ -1,1 +1,0 @@
-ubuntu-1604-1bdcdbcb140a94bf2950a5b1473815ec0db6b242.qcow2


### PR DESCRIPTION
Image creation for ubuntu-1604 in process on cockpit-tests-sk6m2.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-ubuntu-1604-2017-05-29/