### PR TITLE
Image refresh for centos-7

### DIFF
--- a/bots/images/centos-7
+++ b/bots/images/centos-7
@@ -1,1 +1,0 @@
-centos-7-dbd063005151a02504cb565bedf0f42da0da0a8dd63aa1cd7a58a054e0e5fe3d.qcow2


### PR DESCRIPTION
Image creation for centos-7 in process on cockpit-7.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-centos-7-2017-05-29/