### PR TITLE
bots: Add issue-scan po-issue and po-refresh bots

### DIFF
--- a/.tasks
+++ b/.tasks
@@ -14,3 +14,9 @@
 set -ex
 bots/tests-scan
 bots/image-scan
+
+# File issues for these tasks
+bots/po-trigger
+
+# Any tasks related to issues
+bots/issue-scan

--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+PRIORITY = 10
+
+NAMES = [
+    "po-refresh",
+]
+
+import argparse
+import pipes
+import os
+import sys
+
+sys.dont_write_bytecode = True
+
+import github
+import sink
+
+BOTS = os.path.normpath(os.path.join(os.path.dirname(__file__)))
+BASE = os.path.normpath(os.path.join(BOTS, ".."))
+
+def main():
+    parser = argparse.ArgumentParser(description="Scan issues for tasks")
+    parser.add_argument("-v", "--human-readable", "--verbose", action="store_true", default=False,
+         dest="verbose", help="Print verbose information")
+    opts = parser.parse_args()
+
+    for result in scan(opts.verbose):
+        sys.stdout.write(result + "\n")
+    return 0
+
+# Map all checkable work items to fixtures
+def tasks_for_issues():
+    results = [ ]
+    for issue in github.GitHub().issues(state="open"):
+        if not issue["title"].strip().startswith("WIP"):
+            checklist = github.Checklist(issue["body"])
+            for item, checked in checklist.items.items():
+                if not checked:
+                    results.append((item, issue))
+    return results
+
+def output_task(command, issue, verbose):
+    name, unused, context = command.partition(" ")
+    if name not in NAMES:
+        return None
+    number = issue.get("number", None)
+    if number is None:
+        return None
+
+    context = context.strip()
+
+    if verbose:
+        return "issue-{issue} {name} {context}    {priority}".format(
+            issue=int(number),
+            priority=PRIORITY,
+            name=name,
+            context=context
+        )
+    else:
+        if context:
+            context = pipes.quote(context)
+        return "PRIORITY={priority:04d} bots/{name} --issue='{issue}' {context}".format(
+            issue=int(number),
+            priority=PRIORITY,
+            name=name,
+            context=context
+        )
+
+# Default scan behavior run for each task
+def scan(verbose):
+    global issues
+
+    results = [ ]
+
+    # Now go through each fixture
+    for (command, issue) in tasks_for_issues():
+        result = output_task(command, issue, verbose)
+        if result is not None:
+            results.append(result)
+
+    return results
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bots/po-refresh
+++ b/bots/po-refresh
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+import sys
+
+sys.dont_write_bytecode = True
+
+import task
+
+BOTS = os.path.abspath(os.path.dirname(__file__))
+BASE = os.path.normpath(os.path.join(BOTS, ".."))
+
+def run(context, verbose=False, **kwargs):
+    cwd = BASE
+
+    def output(*args):
+        if verbose:
+            sys.stderr.write("+ " + " ".join(args) + "\n")
+        return subprocess.check_output(args, cwd=cwd)
+    def execute(*args):
+        if verbose:
+            sys.stderr.write("+ " + " ".join(args) + "\n")
+        subprocess.check_call(args, cwd=cwd)
+
+    # Make a tree with source ... outputs working directory
+    cmd = [ "tools/make-source", "po/cockpit.pot" ]
+    if verbose:
+        sys.stderr.write("+ " + " ".join(cmd) + "\n")
+    line = subprocess.check_output(cmd, cwd=BASE)
+    cwd = os.path.abspath(line.strip())
+
+    # Do the various updates
+    cmd = [ "make", "upload-pot", "download-po" ]
+    if verbose:
+        sys.stderr.write("+ " + " ".join(args) + "\n")
+    subprocess.check_call(cmd, cwd=cwd)
+
+    # Create a pull request from these changes
+    branch = task.branch(context, "po: Update from Fedora Zanata", pathspec="po/", **kwargs)
+    if branch:
+        task.pull(branch, **kwargs)
+
+if __name__ == '__main__':
+    task.main(function=run, title="Update translations from Fedora Zanata")

--- a/bots/po-trigger
+++ b/bots/po-trigger
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+DAYS = 10
+
+import argparse
+import os
+import subprocess
+import sys
+
+sys.dont_write_bytecode = True
+
+import task
+
+def main():
+    parser = argparse.ArgumentParser(description="Ensure necessary issue exists for translations")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+    parser.add_argument("context", nargs="?")
+    opts = parser.parse_args()
+
+    task.verbose = opts.verbose
+    text = "Update translations from Fedora Zanata"
+
+    if opts.context or task.stale(DAYS, "po/*.po"):
+        issue = task.issue(text, text, "po-refresh")
+        sys.stderr.write("#{0}: po-refresh\n".format(issue["number"]))
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+# Shared GitHub code. When run as a script, we print out info about
+# our GitHub interacition.
+
+import argparse
+import os
+import random
+import socket
+import subprocess
+import sys
+import time
+import traceback
+
+sys.dont_write_bytecode = True
+
+import github
+import sink
+
+__all__ = (
+    "main",
+    "run",
+    "pull",
+    "issue",
+    "verbose",
+    "stale",
+)
+
+api = github.GitHub()
+verbose = False
+
+BOTS = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+BASE = os.path.normpath(os.path.join(BOTS, ".."))
+
+#
+# The main function takes a list of tasks, each of wihch has the following
+# fields, some of which have defaults:
+#
+#   title: The title for the task
+#   function: The function to call for the task
+#   options=[]: A list of string options to pass to the function argument
+#
+# The function for the task will be called with all the context for the task.
+# In addition it will be called with named arguments for all other task fields
+# and additional fields such as |verbose|. It should return a zero or None value
+# if successful, and a string or non-zero value if unsuccessful.
+#
+#   def run(context, verbose=False, **kwargs):
+#       if verbose:
+#           sys.stderr.write(image + "\n")
+#       return 0
+#
+# Call the task.main() as the entry point of your script in one of these ways:
+#
+#   # As a single task
+#   task.main(title="My title", function=run)
+#
+
+def main(**kwargs):
+    global verbose
+
+    task = kwargs.copy()
+
+    # Figure out a descriptoin for the --help
+    task["name"] = named(task)
+
+    parser = argparse.ArgumentParser(description=task.get("title", task["name"]))
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+    parser.add_argument("--issue", dest="issue", action="store",
+        help="Act on an already created task issue")
+    parser.add_argument("--publish", dest="publish", default=os.environ.get("TEST_PUBLISH", ""),
+        action="store", help="Publish results centrally to a sink")
+    parser.add_argument("context", nargs="?")
+
+    opts = parser.parse_args()
+    verbose = opts.verbose
+
+    ret = 0
+
+    if "verbose" not in task:
+        task["verbose"] = opts.verbose
+    task["issue"] = opts.issue
+    task["publish"] = opts.publish
+
+    ret = run(opts.context, **task)
+
+    if ret:
+        sys.stderr.write("{0}: {1}\n".format(task["name"], ret))
+
+    sys.exit(ret and 1 or 0)
+
+def named(task):
+    if "name" in task:
+        return task["name"]
+    else:
+        return os.path.basename(os.path.realpath(sys.argv[0]))
+
+def begin(publish, name, context, issue):
+    if not publish:
+        return None
+
+    hostname = socket.gethostname().split(".")[0]
+    current = time.strftime('%Y%m%d-%H%M%M')
+
+    # Update the body for an existing issue
+    if issue:
+        number = issue["number"]
+        identifier = "{0}-{1}-{2}".format(name, number, current)
+        title = issue["title"]
+        wip = "WIP: {0}: {1}".format(hostname, title)
+        requests = [ {
+            "method": "POST",
+            "resource": api.qualify("issues/{0}".format(number)),
+            "data": { "title": wip }
+        }, {
+            "method": "POST",
+            "resource": api.qualify("issues/{0}/comments".format(number)),
+            "data": { "body": "{0} in progress on {1}.\nLog: :link".format(name, hostname) }
+        } ]
+        watches = [ {
+            "resource": api.qualify("issues/{0}".format(number)),
+            "result": { "title": wip }
+        } ]
+        aborted = [ {
+            "method": "POST",
+            "resource": api.qualify("issues/{0}".format(number)),
+            "data": { "title": title }
+        }, {
+            "method": "POST",
+            "resource": api.qualify("issues/{0}/comments".format(number)),
+            "data": { "body": "Task aborted." }
+        } ]
+    else:
+        identifier = "{0}-{1}".format(name, current)
+        requests = [ ]
+        watches = [ ]
+        aborted = [ ]
+
+    status = {
+        "github": {
+            "token": api.token,
+            "requests": requests,
+            "watches": watches
+        },
+
+        "onaborted": {
+            "github": {
+                "token": api.token,
+                "requests": aborted
+            }
+        }
+    }
+
+    return sink.Sink(publish, identifier, status)
+
+def finish(publishing, ret, name, context, issue):
+    if not publishing:
+        return
+
+    if not ret:
+        comment = None
+    elif isinstance(ret, basestring):
+        comment = "{0}: :link".format(ret)
+    else:
+        comment = "Task failed: :link"
+
+    if issue:
+        body = None
+        if not ret:
+            item = "{0} {1}".format(name, context or "").strip()
+            checklist = github.Checklist(issue["body"])
+            checklist.check(item)
+            body = checklist.body
+
+        number = issue["number"]
+        title = issue["title"]
+        requests = [ {
+            "method": "POST",
+            "resource": api.qualify("issues/{0}".format(number)),
+            "data": { "title": title, "body": body }
+        } ]
+        if comment:
+            requests.append({
+                "method": "POST",
+                "resource": api.qualify("issues/{0}/comments".format(number)),
+                "data": { "body": comment }
+            })
+    else:
+        requests = [ ]
+
+    publishing.status['github']['requests'] = requests
+    publishing.status['github']['watches'] = None
+    publishing.status['github']['onaborted'] = None
+    publishing.flush()
+
+def run(context, function, **kwargs):
+    number = kwargs.get("issue", None)
+    publish = kwargs.get("publish", "")
+    name = kwargs["name"]
+
+    issue = None
+    if number:
+        issue = api.get("issues/{0}".format(number))
+        if not issue:
+            return "No such issue: {0}".format(number)
+        elif issue["title"].startswith("WIP:"):
+            return "Issue is work in progress: {0}: {1}\n".format(number, issue["title"])
+
+    publishing = begin(publish, name, context, issue=issue)
+
+    ret = "Task threw an exception"
+    try:
+        pull = None
+        if issue and "pull_request" in issue:
+           kwargs["pull"] = pull = api.get(issue["pull_request"]["url"])
+
+        # If this is a pull request then check it out
+        if pull:
+            execute("git", "fetch", "origin", "pull/{0}/head".format(pull["number"]))
+            execute("git", "checkout", "--detach", pull['head']['sha'])
+
+        ret = function(context, **kwargs)
+    except (RuntimeError, subprocess.CalledProcessError), ex:
+        ret = str(ex)
+    except:
+        traceback.print_exc(file=sys.stderr)
+    finally:
+        finish(publishing, ret, name, context, issue)
+    return ret or 0
+
+def stale(days, pathspec):
+    global verbose
+
+    def execute(*args):
+        if verbose:
+            sys.stderr.write("+ " + " ".join(args) + "\n")
+        output = subprocess.check_output(args, cwd=BASE)
+        if verbose:
+            sys.stderr.write("> " + output + "\n")
+        return output
+
+    timestamp = execute("git", "log", "--max-count=1", "--pretty=format:%at", pathspec)
+    try:
+        timestamp = int(timestamp)
+    except ValueError:
+        timestamp = 0
+
+    # We randomize when we think this should happen over a day
+    offset = days * 86400
+    due = time.time() - random.randint(offset - 43200, offset + 43200)
+
+    return timestamp < due
+
+def issue(title, body, name, context=None):
+    for issue in api.issues(state="open"):
+        if issue["title"].endswith(title):
+            return issue
+
+    item = "{0} {1}".format(name, context or "").strip()
+    checklist = github.Checklist(body)
+    checklist.add(item)
+
+    data = {
+        "title": title,
+        "body": checklist.body,
+        "labels": [ "bot" ]
+    }
+    return api.post("issues", data)
+
+def execute(*args):
+    global verbose
+    if verbose:
+        sys.stderr.write("+ " + " ".join(args) + "\n")
+
+    # Github wants the OAuth token as the username and git will
+    # happily echo that back out.  So we censor all output.
+    def censored(text):
+        return text.replace(api.token, "CENSORED")
+
+    try:
+        output = subprocess.check_output(args, cwd=BASE, stderr=subprocess.STDOUT)
+        sys.stderr.write(censored(output))
+    except subprocess.CalledProcessError, ex:
+        sys.stderr.write(censored(ex.output))
+        raise
+
+def branch(context, message, pathspec=".", issue=None, **kwargs):
+    current = time.strftime('%Y%m%d-%H%M%M')
+    name = named(kwargs)
+    branch = "{0} {1} {2}".format(name, context or "", current).strip()
+    branch = branch.replace(" ", "-").replace("--", "-")
+
+    user = api.get("/user")['login']
+    url = "https://{0}@github.com/{1}/cockpit".format(api.token, user)
+    clean = "https://github.com/{0}/cockpit".format(user)
+
+    # If there's nothing to add at that pathspec return None
+    try:
+        execute("git", "add", "--", pathspec)
+    except subprocess.CalledProcessError:
+        return None
+
+    execute("git", "checkout", "--detach")
+    execute("git", "commit", "-m", message)
+    execute("git", "push", url, "+HEAD:refs/heads/{0}".format(branch))
+
+    # Comment on the issue if present
+    if issue:
+        message = "{0} {1} done: {2}/commits/{3}".format(name, context or "", clean, branch)
+        try:
+            resource = "issues/{0}/comments".format(issue["number"])
+        except TypeError:
+            resource = "issues/{0}/comments".format(issue)
+        api.post(resource, { "body": message })
+
+    return "{0}:{1}".format(user, branch)
+
+def pull(branch, issue=None, **kwargs):
+    if "pull" in kwargs:
+        return kwargs["pull"]
+
+    data = {
+        "head": branch,
+        "base": "master",
+        "maintainer_can_modify": True
+    }
+    if issue:
+        try:
+            data["issue"] = issue["number"]
+        except TypeError:
+            data["issue"] = int(issue)
+    else:
+        data["title"] = kwargs["title"]
+    return api.post("pulls", data)

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -112,8 +112,8 @@ update-po: po/cockpit.pot
 		$(MSGMERGE) --output-file=$(srcdir)/po/$$lang.po $(srcdir)/po/$$lang.po $<; \
 	done
 
-upload-pot:
-	zanata-cli push --includes cockpit.pot --project-config "$(srcdir)/po/zanata.xml" \
+upload-pot: po/cockpit.pot
+	zanata-cli -B push --includes cockpit.pot --project-config "$(srcdir)/po/zanata.xml" \
 		-s "$(builddir)/po"
 
 upload-translations:
@@ -123,6 +123,7 @@ upload-translations:
 download-po:
 	zanata-cli -B pull --includes=cockpit.pot --project-config "$(srcdir)/po/zanata.xml" \
 		--min-doc-percent 1 -s "$(builddir)/po" -t "$(srcdir)/po"
+	sh -c 'cd $(srcdir)/po; ls *.po' | sed 's/\.po//g' | sort > $(srcdir)/po/LINGUAS
 
 CLEANFILES += \
 	$(MO_FILES) \

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -390,6 +390,12 @@ install-exec-hook::
 	mkdir -p $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/machines.d
 	chmod 755 $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/machines.d
 
-prepare-po::
-	$(INTLTOOL_EXTRACT) -l --type=gettext/xml $(srcdir)/$(appdata_in)
-	$(INTLTOOL_EXTRACT) -l --type=gettext/ini $(srcdir)/$(desktop_in)
+prepare-po-appdata: $(appdata_in)
+	cp $< .
+	$(INTLTOOL_EXTRACT) -l --type=gettext/xml $(notdir $(appdata_in))
+
+prepare-po-desktop: $(desktop_in)
+	cp $< .
+	$(INTLTOOL_EXTRACT) -l --type=gettext/ini $(notdir $(desktop_in))
+
+prepare-po:: prepare-po-appdata prepare-po-desktop

--- a/tools/make-source
+++ b/tools/make-source
@@ -18,18 +18,14 @@
 
 set -eu
 
-if [ $# != 0 ]; then
-	echo "usage: make-source" >&2
+if [ $# -gt 1 ]; then
+	echo "usage: make-source [target]" >&2
     exit 2
 fi
 
-base=$(cd $(dirname $0); pwd -P)
-
-cd $base/..
-
-dump_dist_gzip() {
-    make -C "$1" -s dump-dist-gzip
-}
+TARGET=${1:-dist-gzip}
+BASE=$(cd $(dirname $(dirname $0)); pwd -P)
+cd $BASE
 
 # Configure the source for making a tarball in a temporary directory, unless
 # the source has already been configured
@@ -46,5 +42,11 @@ else
     builddir=.
 fi
 
-make -j8 -C $builddir --silent dist-gzip 1>&2
-make -C "$builddir" --silent dump-dist-gzip
+make -j8 -C "$builddir" --silent $TARGET 1>&2
+
+# Output the gzip name if requested
+if [ "$TARGET" = "dist-gzip" ]; then
+    make -C "$builddir" --silent dump-dist-gzip
+else
+    echo "$builddir"
+fi


### PR DESCRIPTION
The issue-scan bot scans all issues labeled 'bot' for outstanding checklist items that it can tackle. It ignores any issue that is marked with WIP.
    
The po-issue bot files issues for updating the po/*.po from Fedora Zanata.
    
The po-refresh bot actually does an update from Fedora Zanata and uses shared task infrastructure code.

 * [x] #6845 