### PR TITLE
Image refresh for centos-7

### DIFF
--- a/bots/images/centos-7
+++ b/bots/images/centos-7
@@ -1,1 +1,1 @@
-centos-7-dbd063005151a02504cb565bedf0f42da0da0a8dd63aa1cd7a58a054e0e5fe3d.qcow2
+centos-7-900ba1f01bdbdf09aadeca3c5207da88e8fb4f672ceb75664853756b3f55ea2c.qcow2


### PR DESCRIPTION
Image creation for centos-7 in process on cockpit-tests-sk6m2.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-centos-7-2017-05-30/