### PR TITLE
Image refresh for fedora-atomic

### DIFF
--- a/bots/images/fedora-atomic
+++ b/bots/images/fedora-atomic
@@ -1,1 +1,0 @@
-fedora-atomic-b0cdcad9eab3701530423c0731c399970dc345e0cfbf475a3dfdc9f70ea76a82.qcow2


### PR DESCRIPTION
Image creation for fedora-atomic in process on cockpit-tests-svn8z.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-fedora-atomic-2017-05-30/