### PR TITLE
Image refresh for rhel-atomic

### DIFF
--- a/bots/images/rhel-atomic
+++ b/bots/images/rhel-atomic
@@ -1,1 +1,0 @@
-rhel-atomic-8f85268e90db15c5cad36dfb201c02c1d5291ce6.qcow2


### PR DESCRIPTION
Image creation for rhel-atomic in process on cockpit-tests-l7zcj.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-rhel-atomic-2017-05-30/