### PR TITLE
Image refresh for debian-testing

### DIFF
--- a/bots/images/debian-testing
+++ b/bots/images/debian-testing
@@ -1,1 +1,0 @@
-debian-testing-d052686efd86c9dc35b74ba58402884f616994c9.qcow2


### PR DESCRIPTION
Image creation for debian-testing in process on cockpit-tests-4hkfv.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-testing-2017-05-30/