### PR TITLE
Image refresh for ubuntu-stable

### DIFF
--- a/bots/images/ubuntu-stable
+++ b/bots/images/ubuntu-stable
@@ -1,1 +1,1 @@
-ubuntu-stable-4717d0c2ecef387c11a12343984d9667f1ecfdc2ca1704e47d5ca24e8f5559fa.qcow2
+ubuntu-stable-3a5dd273642090e8cdc59def4dc841e7cddad3e6ba7234d8f9ed359f7c4ef519.qcow2


### PR DESCRIPTION
Image creation for ubuntu-stable in process on cockpit-tests-z1cxm.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-ubuntu-stable-2017-05-31/