### PR TITLE
Image refresh for debian-stable

### DIFF
--- a/bots/images/debian-stable
+++ b/bots/images/debian-stable
@@ -1,1 +1,1 @@
-debian-stable-a90402c582a94cbd8d2c6fc4eb3f5cd0290c21f9ef525ead45d8c3c376f0b60b.qcow2
+debian-stable-d0e5531071b0bc00e46cdb2d66f7d1d43a402205bd0361726f4c4074af09083d.qcow2


### PR DESCRIPTION
Image creation for debian-stable in process on cockpit-tests-svn8z.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-stable-2017-05-31/