### PR TITLE
Image refresh for openshift

### DIFF
--- a/bots/images/openshift
+++ b/bots/images/openshift
@@ -1,1 +1,0 @@
-openshift-7b287ee1fabc7497f35ba8dbca54d715866eb27c.qcow2


### PR DESCRIPTION
Image creation for openshift in process on cockpit-tests-9dnvx.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-openshift-2017-06-01/