### PR TITLE
Image refresh for debian-testing

### DIFF
--- a/bots/images/debian-testing
+++ b/bots/images/debian-testing
@@ -1,1 +1,0 @@
-debian-testing-a69fa907cfe752fb8e1846b78b928309b1755c152272cec2e575b0b80eef672f.qcow2


### PR DESCRIPTION
Image creation for debian-testing in process on cockpit-tests-l7zcj.
Log: http://fedorapeople.org/groups/cockpit/logs/refresh-debian-testing-2017-06-01/