### PR TITLE
bots: Fix path to openshift.kubeconfig in image-create

### DIFF
--- a/bots/image-create
+++ b/bots/image-create
@@ -104,7 +104,7 @@ class MachineBuilder:
 
                 if self.machine.image == 'openshift':
                     # update our local openshift kube config file to match the new image
-                    self.machine.download("/root/.kube/config", "verify/files/openshift.kubeconfig")
+                    self.machine.download("/root/.kube/config", "../test/verify/files/openshift.kubeconfig")
 
             except subprocess.CalledProcessError, ex:
                 if args.sit:


### PR DESCRIPTION
This is to fix the following problem:

    /build/cockpit/bots/machine/../verify/files/openshift.kubeconfig: No such file or directory
image-create: setup failed with code 1