### PR TITLE
common: Add missing #include

### DIFF
--- a/src/common/test-transport.c
+++ b/src/common/test-transport.c
@@ -33,6 +33,7 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/uio.h>
 
 #define WAIT_UNTIL(cond) \
   G_STMT_START \


### PR DESCRIPTION
src/common/test-transport.c uses writev() but forgot to include uio.h.
This caused a build failure in Fedora rawhide.

Fixes #6840

----

I verified the failure and fix in a local rawhide mock. All other files that use `writev()` already include uio.h, this was the only one.