### PR TITLE
tools: Update Debian autopkgtest

### DIFF
--- a/tools/debian/tests/avocado
+++ b/tools/debian/tests/avocado
@@ -1,18 +1,20 @@
 #!/bin/sh
-set -eu
+set -eux
 # Ubuntu still creates this legacy group by default, breaks useradd
-sudo delgroup --quiet --system admin || true
+delgroup --quiet --system admin || true
 
 # test expects this user and Fedora group "wheel"
 addgroup wheel
 useradd -m -U -c Administrator -G sudo,wheel -s /bin/bash admin
 echo admin:foobar | chpasswd
 
+# packaged phantomjs crashes with "QXcbConnection: Could not connect to display" otherwise
+export QT_QPA_PLATFORM=offscreen
+
 # avocado is not packaged, thus install through pip
 pip install avocado-framework
 
-# packaged phantomjs crashes with "QXcbConnection: Could not connect to display"
-npm install sizzle phantomjs-prebuilt
+npm install sizzle
 
 test/avocado/checklogin-raw.py
 test/avocado/checklogin-basic.py

--- a/tools/debian/tests/control
+++ b/tools/debian/tests/control
@@ -4,9 +4,11 @@ Depends: cockpit,
          python-pip,
          python-wheel,
          python-setuptools,
+         python-libvirt,
          npm,
          nodejs-legacy,
          libfontconfig1,
          curl,
+         phantomjs,
 # test changes PAM configs and creates admin users
 Restrictions: needs-root, allow-stderr, isolation-machine, breaks-testbed


### PR DESCRIPTION
Latest avocado now requires python-libvirt, add it as test dependency.

Use the packaged phantomjs instead of phantomjs-prebuilt as that is only
available for x86_64; this should make the tests work on other
architectures too. The Debian/Ubuntu phantomjs package is built with Qt
support, so run under $QT_QPA_PLATFORM=offscreen to work in a headless
test environment.

Drop stray "sudo" command. The test already runs as root, this was a
copy&paste leftover.

---

Yesterday's 141 release will not land in Ubuntu due to that, see http://people.canonical.com/~ubuntu-archive/proposed-migration/update_excuses.html#cockpit . The test crashes with `ImportError: No module named libvirt`.

Labelling "bot" as our CI doesn't cover autopkgtest. I verified this with a local autopkgtest run, and will now upload this patch to Debian too.