### PR TITLE
bots: Don't add test contexts to commits that have any

### DIFF
--- a/bots/github-trigger
+++ b/bots/github-trigger
@@ -7,20 +7,6 @@ sys.dont_write_bytecode = True
 
 import github
 
-OUR_CONTEXTS = [
-    "verify/",
-    "avocado/",
-    "container/",
-    "selenium/",
-    "koji/",
-]
-
-def known_context(context):
-    for prefix in OUR_CONTEXTS:
-        if context.startswith(prefix):
-            return True
-    return False
-
 def trigger_image(api, opts):
     title = github.ISSUE_TITLE_IMAGE_REFRESH.format(opts.image)
     if opts.pull:
@@ -53,7 +39,7 @@ def trigger_pull(api, opts):
         contexts = [ opts.context ]
         all = False
     else:
-        contexts = [ x for x in set(statuses.keys()) if known_context(x) ]
+        contexts = set(statuses.keys())
         all = True
 
     ret = 0

--- a/bots/github/__init__.py
+++ b/bots/github/__init__.py
@@ -47,6 +47,14 @@ TESTING = "Testing in progress"
 NOT_TESTED = "Not yet tested"
 NO_TESTING = "Manual testing required"
 
+OUR_CONTEXTS = [
+    "verify/",
+    "avocado/",
+    "container/",
+    "selenium/",
+    "koji/",
+]
+
 ISSUE_TITLE_IMAGE_REFRESH = "Image refresh for {0}"
 
 BOTS = os.path.join(os.path.dirname(__file__), "..")
@@ -83,6 +91,12 @@ def determine_github_base():
 
 # github base to use
 GITHUB_BASE = "https://api.github.com/repos/{0}/".format(os.environ.get("GITHUB_BASE", determine_github_base()))
+
+def known_context(context):
+    for prefix in OUR_CONTEXTS:
+        if context.startswith(prefix):
+            return True
+    return False
 
 def whitelist(filename=WHITELIST):
     # Try to load the whitelists
@@ -245,7 +259,7 @@ class GitHub(object):
             page += 1
             if "statuses" in data:
                 for status in data["statuses"]:
-                    if status["context"] not in result:
+                    if known_context(status["context"]) and status["context"] not in result:
                         result[status["context"]] = status
                 count = len(data["statuses"])
         return result

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -144,12 +144,6 @@ def prioritize(status, title, labels, priority, context):
     elif state in [ "pending" ]:
         update = None
 
-    # Don't start working on "bot" pull requests automatically.
-    # The bot triggers them explicitly.
-    elif "bot" in labels():
-        priority = None
-        update = None
-
     if priority > 0:
         if "priority" in labels():
             priority += 2
@@ -214,8 +208,9 @@ def scan_for_pull_tasks(api, update, human, policy):
         if ref:
             revision = ref["object"]["sha"]
             statuses = api.statuses(revision)
-            for context in branch_contexts[branch]:
-                status = statuses.get(context, { })
+            which = statuses.keys() or branch_contexts[branch]
+            for context in which:
+                status = statuses.get(context, None)
                 (priority, changes) = prioritize(status, "", lambda: [], 8, context)
                 if update_status(revision, context, status, changes):
                     results.append((priority, branch, revision, branch, context, None))
@@ -237,6 +232,9 @@ def scan_for_pull_tasks(api, update, human, policy):
                 pull["labels"] = result
             return pull["labels"]
 
+        # Do we have any statuses for this commit?
+        have = len(statuses.keys()) > 0
+
         for context in contexts:
             status = statuses.get(context, None)
             baseline = BASELINE_PRIORITY
@@ -245,9 +243,9 @@ def scan_for_pull_tasks(api, update, human, policy):
             # end up with a bunch of half tested pull requests
             baseline += 1.0 - (min(100000, float(number)) / 100000)
 
-            # Only create new status for those requested
+            # Only create new status for requests that have none
             if not status:
-                if context not in branch_contexts.get(base, []):
+                if have or context not in branch_contexts.get(base, []):
                     continue
                 status = { }
 


### PR DESCRIPTION
Once bots or anyone else adds a specific set of statuses to check
on a certain commit, we don't go around adding further status
contexts.

In order to accomplish this, only have GitHub code on our own statuses.