### PR TITLE
bots: Migrate image-refresh bot to new task structure

### DIFF
--- a/.tasks
+++ b/.tasks
@@ -13,10 +13,10 @@
 
 set -ex
 bots/tests-scan
-bots/image-scan
 
 # File issues for these tasks
 bots/po-trigger
+bots/image-trigger
 
 # Any tasks related to issues
 bots/issue-scan

--- a/bots/README.md
+++ b/bots/README.md
@@ -27,9 +27,9 @@ For debugging the images:
  * test/vm-run: Run a test machine image
 
 To check when images will automatically be refreshed by the bots
-use the image-scan tool:
+use the image-trigger tool:
 
-    $ bots/image-scan -vd
+    $ bots/image-trigger -vd
 
 ## Tests
 
@@ -45,7 +45,7 @@ A number of machines are watching our GitHub repository and are
 executing tests for pull requests as well as making new images.
 
 Most of this happens automatically, but you can influence their
-actions with the github-trigger utility in this directory.
+actions with the tests-trigger utility in this directory.
 
 ### Setup
 
@@ -60,17 +60,17 @@ encompass public_repo (or repo if you're accessing a private repo).
 ### Retrying a failed test
 
 If you want to run the "verify/fedora-24" testsuite again for pull
-request #1234, run github-trigger like so:
+request #1234, run tests-trigger like so:
 
-  $ bots/github-trigger 1234 verify/fedora-24
+    $ bots/tests-trigger 1234 verify/fedora-24
 
 ### Testing a pull request by a non-whitelisted user
 
 If you want to run all tests on pull request #1234 that has been
-opened by someone who is not in our white-list, run github-trigger
+opened by someone who is not in our white-list, run tests-trigger
 like so:
 
-  $ bots/github-trigger -f 1234
+    $ bots/github-trigger -f 1234
 
 Of course, you should make sure that the pull request is proper and
 doesn't execute evil code during tests.
@@ -81,28 +81,25 @@ Test images are refreshed automatically once per week, and even if the
 last refresh has failed, the machines wait one week before trying again.
 
 If you want the machines to refresh the fedora-24 image immediately,
-run github-trigger like so:
+run image-trigger like so:
 
-  $ bots/github-trigger --image fedora-24
+    $ bots/image-trigger fedora-24
 
 ### Creating new images for a pull request
 
 If as part of some new feature you need to change the content of some
 or all images, you can ask the machines to create those images.
 
-If you want to have a new fedora-24 image for pull request #1234, run
-github-trigger like so:
+If you want to have a new fedora-24 image for pull request #1234, add
+a bullet point to that pull request's description like so, and add the
+"bot" label to the pull request.
 
-  $ bots/github-trigger --image fedora-24 1234
+    * [ ] image-refresh fedora-24
 
 The machines will post comments to the pull request about their
 progress and at the end there will be links to commits with the new
 images.  You can then include these commits into the pull request in
 any way you like.
-
-NOTE: as part of this, the pull request will get the "bot" label and
-the machines will not automatically test pull requests with that
-label.  Thus, once the images are made, remove the "bot" label.
 
 If you are certain about the changes to the images, it is probably a
 good idea to make a dedicated pull request just for the images.  That

--- a/bots/github/__init__.py
+++ b/bots/github/__init__.py
@@ -297,8 +297,8 @@ class GitHub(object):
         return result
 
 class Checklist(object):
-    def __init__(self, body):
-        self.process(body)
+    def __init__(self, body=None):
+        self.process(body or "")
 
     def process(self, body, items={ }):
         self.items = { }

--- a/bots/github/__init__.py
+++ b/bots/github/__init__.py
@@ -40,8 +40,7 @@ __all__ = (
     'whitelist',
     'TESTING',
     'NO_TESTING',
-    'NOT_TESTED',
-    'ISSUE_TITLE_IMAGE_REFRESH'
+    'NOT_TESTED'
 )
 
 TESTING = "Testing in progress"

--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -63,7 +63,7 @@ TRIGGERS = {
         "verify/rhel-7",
         "verify/ubuntu-1604",
         "verify/debian-stable"
-    ]
+    ],
     "rhel-7": [
         "verify/rhel-7",
         "verify/rhel-atomic"  # builds in rhel-7
@@ -90,269 +90,50 @@ import time
 sys.dont_write_bytecode = True
 
 import github
-import sink
+import task
 
-HOSTNAME = socket.gethostname().split(".")[0]
 BOTS = os.path.abspath(os.path.dirname(__file__))
 BASE = os.path.normpath(os.path.join(BOTS, ".."))
 
-def main():
-    parser = argparse.ArgumentParser(description='Run image refresh')
-    parser.add_argument('--issue', dest='issue', action='store',
-            help='Act on an already created issue')
-    parser.add_argument('-o', "--offline", action='store_true',
-            help="Work offline, don''t fetch new data from origin for rebase")
-    parser.add_argument('--publish', dest='publish', default=os.environ.get("TEST_PUBLISH", ""),
-            action='store', help='Publish results centrally to a sink')
-    parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output')
-    parser.add_argument('image', help="The image to refresh")
-    opts = parser.parse_args()
+def run(image, verbose=False, **kwargs):
+    if not image:
+        raise RuntimeError("no image specified")
 
-    name = os.environ.get("TEST_NAME", "tests")
+    triggers = TRIGGERS.get(image, [ ])
+    store = STORES.get(image, None)
 
-    issue = None
-    api = None if opts.offline else github.GitHub()
-    if opts.issue and api:
-        issue = api.get("/issues/" + str(opts.issue))
+    # Cleanup any extraneous disk usage elsewhere
+    subprocess.check_call([ os.path.join(BASE, "test", "vm-reset") ])
 
-    triggers = TRIGGERS.get(opts.image, [ ])
-    store = STORES.get(opts.image, None)
+    # Setup network if necessary, any failures caught during testing
+    prep = os.path.join(BASE, "test", "vm-prep")
+    if os.path.exists(prep):
+        subprocess.call(["sudo", "-n", prep ])
 
-    try:
-        task = ImageTask(name, opts.image, triggers, issue, store)
-        ret = task.run(opts, api)
-    except RuntimeError, ex:
-        ret = str(ex)
+    cmd = [ os.path.join(BOTS, "image-create"), "--verbose", "--upload" ]
+    if store:
+        cmd += [ "--store", store ]
+    cmd += [ image ]
 
-    if ret:
-        sys.stderr.write("image-refresh: {0}\n".format(ret))
-        return 1
-    return 0
+    os.environ['VIRT_BUILDER_NO_CACHE'] = "yes"
+    ret = subprocess.call(cmd)
 
-class ImageTask(object):
-    def __init__(self, name, image, triggers, issue, store):
-        self.name = name
-        self.image = image
-        self.triggers = triggers or []
-        self.issue = issue
-        self.store = store or None
-        self.pull = None
-        self.sink = None
+    # When image creation fails, remove the link and make a pull
+    # request anyway, for extra attention
 
-    def description(self):
-        if self.issue:
-            return "{} (#{})".format(self.name, self.issue['number'])
-        else:
-            return self.name
+    if ret != 0:
+        os.unlink(os.path.join(BOTS, "images", image))
 
-    def start_publishing(self, host, api):
-        if self.pull:
-            identifier = self.name + "-" + self.pull['head']['sha']
-        else:
-            identifier = self.name + "-" + time.strftime("%Y-%m-%d")
+    branch = task.branch(image, "images: Update {0} image".format(image), **kwargs)
+    if branch:
+        pull = task.pull(branch, **kwargs)
 
-        requests = [ ]
-
-        body_text = ("Image creation for %s in process on %s.\nLog: :link"
-                     % (self.image, HOSTNAME))
-
-        # Update the body for an existing issue
-        if self.issue:
-            requests += [
-                # Get issue
-                { "method": "GET",
-                  "resource": api.qualify("issues/" + str(self.issue['number'])),
-                  "result": "issue"
-                },
-                # Update the issue
-                { "method": "POST",
-                    "resource": ":issue.url",
-                  "data": {
-                      "body": body_text,
-                      "labels": [ "bot", "image/" + self.image ]
-                  }
-                }
-            ]
-        else:
-            requests += [
-                # Create issue
-                { "method": "POST",
-                  "resource": api.qualify("issues"),
-                  "data": {
-                      "title": github.ISSUE_TITLE_IMAGE_REFRESH.format(self.image),
-                      "labels": [ "bot", "image/" + self.image ],
-                      "body": body_text
-                  },
-                  "result": "issue"
-                }
-            ]
-
-        # Make sure the body remains the same
-        watches = [{
-            "resource": api.qualify("issues?labels=bot,image/{0}&state=open".format(self.image)),
-            "result": [
-                {
-                  "body": body_text
-                }
-            ]
-        }]
-
-        status = {
-            "github": {
-                "token": api.token,
-                "requests": requests,
-                "watches": watches
-            },
-
-            "onaborted": {
-                "github": {
-                    "token": api.token,
-                    "requests": [
-                        # Post comment about failure
-                        { "method": "POST",
-                          "resource": ":issue.comments_url",
-                          "data": {
-                              "body": "Image creation aborted",
-                          }
-                        }
-                    ]
-                },
-            }
-        }
-        self.sink = sink.Sink(host, identifier, status)
-
-    def stop_publishing(self, api, ret, user, branch):
-        if ret is None:
-            message = "Image creation stopped to avoid conflict."
-        else:
-            if ret == 0:
-                if self.pull and branch:
-                    message = "Image creation done: https://github.com/{}/cockpit/commits/{}".format(user, branch)
-                else:
-                    message = "Image creation done."
-            else:
-                message = "Image creation failed."
-        if not branch:
-            message += "\nBranch creation failed."
-
-        requests = [
-            # Post comment
-            { "method": "POST",
-              "resource": ":issue.comments_url",
-              "data": {
-                  "body": message
-              }
-            }
-        ]
-
-        if not self.pull and branch:
-            requests += [
-                # Turn issue into pull request
-                { "method": "POST",
-                  "resource": api.qualify("pulls"),
-                  "data": {
-                      "issue": ":issue.number",
-                      "head": user + "::" + branch,
-                      "base": "master"
-                  },
-                  "result": "pull"
-                }
-            ]
-
-            for t in self.triggers:
-                requests += [
-                    # Trigger testing
-                    { "method": "POST",
-                      "resource": api.qualify("statuses/:pull.head.sha"),
-                      "data": {
-                          "state": "pending",
-                          "context": t,
-                          "description": github.NOT_TESTED
-                      }
-                    }
-                ]
-
-
-        self.sink.status['github']['requests'] = requests
-        self.sink.flush()
-
-    def run(self, opts, api):
-        if not api.token:
-            return "Need a github token to run image creation tasks"
-
-        if self.issue and 'pull_request' in self.issue:
-            self.pull = api.get(self.issue['pull_request']['url'])
-
-        if opts.publish:
-            self.start_publishing(opts.publish, api)
-
-        user = api.get("/user")['login']
-
-        test = os.path.join(BOTS, "..", "test")
-        os.environ["PATH"] = "{0}:{1}:{2}".format(os.environ.get("PATH"), BOTS, test)
-
-        # Cleanup any extraneous disk usage elsewhere
-        subprocess.check_call([ "vm-reset" ])
-
-        msg = "Creating image {0} on {1}...\n".format(self.image, HOSTNAME)
-        sys.stderr.write(msg)
-
-        if self.pull:
-            subprocess.check_call([ "git", "fetch", "origin", "pull/{}/head".format(self.pull['number']) ])
-            subprocess.check_call([ "git", "checkout", self.pull['head']['sha'] ])
-
-        # Setup network if necessary, any failures caught during testing
-        prep = os.path.join(BASE, "test", "vm-prep")
-        if os.path.exists(prep):
-            subprocess.call(["sudo", "-n", prep ])
-
-        cmd = [ "image-create", "--verbose", "--upload" ]
-        if self.store:
-            cmd += [ "--store", self.store ]
-        cmd += [ self.image ]
-
-        os.environ['VIRT_BUILDER_NO_CACHE'] = "yes"
-        ret = subprocess.call(cmd)
-
-        # Github wants the OAuth token as the username and git will
-        # happily echo that back out.  So we censor all output.
-
-        def run_censored(cmd):
-
-            def censored(text):
-                return text.replace(api.token, "CENSORED")
-
-            try:
-                output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-                print censored(output)
-                return True
-            except subprocess.CalledProcessError as e:
-                print censored(e.output)
-                print "Failed:", censored(' '.join(e.cmd))
-                return False
-
-        # Push the new image link to origin, but don't change any local refs
-
-        if self.pull:
-            branch = "refresh-" + self.image + "-" + self.pull['head']['sha']
-        else:
-            branch = "refresh-" + self.image + "-" + time.strftime("%Y-%m-%d")
-
-        url = "https://{0}@github.com/{1}/cockpit.git".format(api.token, user)
-
-        # When image creation fails, remove the link and make a pull
-        # request anyway, for extra attention
-
-        if ret != 0:
-            os.unlink(os.path.join(BOTS, "images", self.image))
-
-        have_branch = (run_censored([ "git", "checkout", "--detach" ]) and
-                       run_censored([ "git", "commit", "-a",
-                                      "-m", github.ISSUE_TITLE_IMAGE_REFRESH.format(self.image) ]) and
-                       run_censored([ "git", "push", url, "+HEAD:refs/heads/" + branch ]))
-
-        if self.sink:
-            self.stop_publishing(api, ret, user, branch if have_branch else None)
+        # Trigger this pull request
+        head = pull["head"]["sha"]
+        api = github.GitHub()
+        for trigger in triggers:
+            api.post("statuses/{0}".format(head), { "state": "pending", "context": trigger,
+                "description": github.NOT_TESTED })
 
 if __name__ == '__main__':
-    sys.exit(main())
+    task.main(function=run, title="Refresh image")

--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -124,7 +124,7 @@ def run(image, verbose=False, **kwargs):
     if ret != 0:
         os.unlink(os.path.join(BOTS, "images", image))
 
-    branch = task.branch(image, "images: Update {0} image".format(image), **kwargs)
+    branch = task.branch(image, "images: Update {0} image".format(image), pathspec="bots/images", **kwargs)
     if branch:
         pull = task.pull(branch, **kwargs)
 

--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -18,6 +18,68 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+TRIGGERS = {
+    "centos-7": [
+        "verify/centos-7"
+    ],
+    "continuous-atomic": [
+        "verify/continuous-atomic"
+    ],
+    "debian-testing": [
+        "verify/debian-testing"
+    ],
+    "debian-stable": [
+        "verify/debian-stable"
+    ],
+    "fedora-25": [
+        "verify/fedora-25",
+        "verify/fedora-atomic"
+    ],
+    "fedora-26": [
+        "verify/fedora-26"
+    ],
+    "fedora-atomic": [
+        "verify/fedora-atomic"
+    ],
+    "fedora-testing": [
+        "verify/fedora-testing"
+    ],
+    "fedora-i386": [
+        "verify/fedora-i386"
+    ],
+    "ubuntu-1604": [
+        "verify/ubuntu-1604"
+    ],
+    "ubuntu-stable": [
+        "verify/ubuntu-stable"
+    ],
+    "openshift": [
+        "container/kubernetes",
+        "verify/fedora-25",
+        "verify/rhel-7"
+    ],
+    "ipa": [
+        "verify/fedora-25",
+        "verify/rhel-7",
+        "verify/ubuntu-1604",
+        "verify/debian-stable"
+    ]
+    "rhel-7": [
+        "verify/rhel-7",
+        "verify/rhel-atomic"  # builds in rhel-7
+    ],
+    "rhel-atomic": [
+        "verify/rhel-atomic"
+    ]
+}
+
+REDHAT_STORE = "https://cockpit-11.e2e.bos.redhat.com:8493"
+
+STORES = {
+    "rhel-7": REDHAT_STORE,
+    "rhel-atomic": REDHAT_STORE
+}
+
 import argparse
 import os
 import subprocess
@@ -42,10 +104,6 @@ def main():
             help="Work offline, don''t fetch new data from origin for rebase")
     parser.add_argument('--publish', dest='publish', default=os.environ.get("TEST_PUBLISH", ""),
             action='store', help='Publish results centrally to a sink')
-    parser.add_argument('--store', dest='store', action='store',
-            help='Alternate location to upload image to')
-    parser.add_argument('--triggers', dest='triggers', nargs='+',
-            action='store', help='Test contexts to trigger after creation')
     parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output')
     parser.add_argument('image', help="The image to refresh")
     opts = parser.parse_args()
@@ -57,8 +115,11 @@ def main():
     if opts.issue and api:
         issue = api.get("/issues/" + str(opts.issue))
 
+    triggers = TRIGGERS.get(opts.image, [ ])
+    store = STORES.get(opts.image, None)
+
     try:
-        task = ImageTask(name, opts.image, opts.triggers, issue, opts.store)
+        task = ImageTask(name, opts.image, triggers, issue, store)
         ret = task.run(opts, api)
     except RuntimeError, ex:
         ret = str(ex)

--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -18,9 +18,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-IMAGE_REFRESH = 7
+DAYS = 7
 
-DEFAULT_REFRESH = {
+REFRESH = {
     "centos-7": { },
     "continuous-atomic": { },
     "debian-testing": { },
@@ -33,17 +33,10 @@ DEFAULT_REFRESH = {
     "ubuntu-1604": { },
     "ubuntu-stable": { },
     "openshift": { "refresh-days": 30 },
-    "ipa": { "refresh-days": 120 }
-}
-
-
-REDHAT_REFRESH = {
+    "ipa": { "refresh-days": 120 },
     'rhel-7': { },
     'rhel-atomic': { }
 }
-
-# Server to tell us if we can create Red Hat images
-REDHAT_PING = "http://file.rdu.redhat.com"
 
 import argparse
 import os
@@ -57,20 +50,20 @@ import urllib
 sys.dont_write_bytecode = True
 
 import github
+import task
 
 def main():
-    parser = argparse.ArgumentParser(description='Bot: scan for images that need updating')
-    parser.add_argument('-d', '--dry', action="store_true", default=False,
-                        help='Don''t actually change anything on GitHub')
-    parser.add_argument('-v', '--human-readable', '--verbose', action="store_true", default=False,
+    parser = argparse.ArgumentParser(description='Ensure necessary issue exists for image refresh')
+    parser.add_argument('-v', '--verbose', action="store_true", default=False,
                         help="Print verbose information")
+    parser.add_argument("image", nargs="?")
     opts = parser.parse_args()
     api = github.GitHub()
 
     try:
-        results = scan(api, not opts.dry, opts.human_readable)
+        results = scan(api, opts.image, opts.verbose)
     except RuntimeError, ex:
-        sys.stderr.write("image-scan: " + str(ex) + "\n")
+        sys.stderr.write("image-trigger: " + str(ex) + "\n")
         return 1
 
     for result in results:
@@ -78,67 +71,6 @@ def main():
             sys.stdout.write(result + "\n")
 
     return 0
-
-# Prepare an image refresh command
-def image_refresh(priority, name, image, issue=None):
-    if priority <= 0:
-        return
-    cmd = "PRIORITY={priority:04d} TEST_NAME='{name}' bots/image-refresh"
-    if issue:
-        cmd += " --issue='{issue}'"
-    cmd += " '{image}'"
-    return cmd.format(**{
-        "priority": int(priority),
-        "name": pipes.quote(name),
-        "image": pipes.quote(image),
-        "issue": pipes.quote(str(issue)),
-    })
-
-def scan_image_wait_times(api, policy):
-    issues = api.get("issues?labels=bot&filter=all&state=all")
-
-    wait_times = { }
-    for image, config in policy.items():
-        wait_times[image] = 0
-        for issue in issues:
-            if issue['title'] == github.ISSUE_TITLE_IMAGE_REFRESH.format(image):
-                age = time.time() - time.mktime(time.strptime(issue['created_at'], "%Y-%m-%dT%H:%M:%SZ"))
-                refresh_days = config.get("refresh-days", IMAGE_REFRESH)
-                wait_time = refresh_days - (age / (24 * 60 * 60))
-                if wait_time > wait_times[image]:
-                    wait_times[image] = wait_time
-    return wait_times
-
-def scan_for_image_tasks(api, policy):
-    results = [ ]
-    requested = set()
-
-    # Trigger on explicit requests
-    def issue_requests_image_refresh(issue, comments, image):
-        request = "bot: " + github.ISSUE_TITLE_IMAGE_REFRESH.format(image)
-        in_process_prefix = "Image creation for {} in process".format(image)
-
-        needed = False
-        for body in [ issue['body'] ] + [ c['body'] for c in comments ]:
-            if body == request:
-                needed = True
-            if body.startswith(in_process_prefix):
-                needed = False
-        return needed
-
-    for issue in api.get("issues?labels=bot&state=open"):
-        comments = api.get(issue['comments_url'])
-        for image in policy:
-            if issue_requests_image_refresh(issue, comments, image):
-                requested.add(image)
-                results.append(image_refresh(BASELINE_PRIORITY, "refresh-" + image, image, issue['number']))
-
-    # Trigger based on how old the youngest issue is
-    for image, wait_time in scan_image_wait_times(api, policy).items():
-        if wait_time <= 0 and image not in requested:
-            results.append(image_refresh(BASELINE_PRIORITY, "refresh-" + image, image, None))
-
-    return results
 
 # Prepare an image prune command
 def scan_for_prune():
@@ -155,36 +87,22 @@ def scan_for_prune():
 
     return tasks
 
-def scan(api, update, verbose):
-    kvm = os.access("/dev/kvm", os.R_OK | os.W_OK)
-    if not kvm:
-        sys.stderr.write("tests-scan: No /dev/kvm access, not creating images here\n")
-        return []
+def scan(api, force, verbose):
+    for (image, options) in REFRESH.items():
+        perform = False
 
-    policy = DEFAULT_REFRESH
+        if force:
+            perform = image == force
+        else:
+            days = options.get("refresh-days", DAYS)
+            perform = task.stale(days, os.path.join("bots", "images", image))
 
-    # Check if we have access to Red Hat network and some subscription creds
-    try:
-        urllib.urlopen(REDHAT_PING).read()
-        if os.path.exists(os.path.expanduser("~/.rhel/login")):
-            policy.update(REDHAT_REFRESH)
-    except IOError:
-        pass
+        if perform:
+            text = "Image refresh for {0}".format(image)
+            issue = task.issue(text, text, "image-refresh", image)
+            sys.stderr.write("#{0}: image-refresh {1}\n".format(issue["number"], image))
 
-    task_entries = []
-
-    if verbose:
-        for image, wait_time in scan_image_wait_times(api, policy).items():
-            # Images with wait_time <= 0 are already included in the list
-            # of tasks above, so we don't need to list them here.
-            if wait_time > 0:
-                task_entries.append("{0:20}  {1:.1f} days".format(image, wait_time))
-    else:
-        task_entries += scan_for_image_tasks(api, policy)
-        task_entries += scan_for_prune()
-
-
-    return task_entries
+    return scan_for_prune()
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -18,78 +18,28 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-BASELINE_PRIORITY = 10
-
 IMAGE_REFRESH = 7
 
 DEFAULT_REFRESH = {
-    "centos-7": {
-        "triggers": [ "verify/centos-7" ]
-    },
-    "continuous-atomic": {
-        "triggers": [ "verify/continuous-atomic" ]
-    },
-    "debian-testing": {
-        "triggers": [ "verify/debian-testing" ]
-    },
-    "debian-stable": {
-        "triggers": [ "verify/debian-stable" ]
-    },
-    "fedora-25": {
-        "triggers": [
-            "verify/fedora-25",
-            "verify/fedora-atomic"
-        ]
-    },
-    "fedora-26": {
-        "triggers": [
-            "verify/fedora-26"
-        ]
-    },
-    "fedora-atomic": {
-        "triggers": [ "verify/fedora-atomic" ]
-    },
-    "fedora-testing": {
-        "triggers": [ "verify/fedora-testing" ]
-    },
-    "fedora-i386": {
-        "triggers": [ "verify/fedora-i386" ]
-    },
-    "ubuntu-1604": {
-        "triggers": [ "verify/ubuntu-1604" ]
-    },
-    "ubuntu-stable": {
-        "triggers": [ "verify/ubuntu-stable" ]
-    },
-    "openshift": {
-        "triggers": [ "container/kubernetes",
-                      "verify/fedora-25",
-                      "verify/rhel-7" ],
-        "refresh-days": 30
-    },
-    "ipa": {
-        "triggers": [ "verify/fedora-25",
-                      "verify/rhel-7",
-                      "verify/ubuntu-1604",
-                      "verify/debian-stable" ],
-        "refresh-days": 120
-    }
+    "centos-7": { },
+    "continuous-atomic": { },
+    "debian-testing": { },
+    "debian-stable": { },
+    "fedora-25": { },
+    "fedora-26": { },
+    "fedora-atomic": { },
+    "fedora-testing": { },
+    "fedora-i386": { },
+    "ubuntu-1604": { },
+    "ubuntu-stable": { },
+    "openshift": { "refresh-days": 30 },
+    "ipa": { "refresh-days": 120 }
 }
 
-REDHAT_STORE = "https://cockpit-11.e2e.bos.redhat.com:8493"
 
 REDHAT_REFRESH = {
-    'rhel-7': {
-        'triggers': [
-            "verify/rhel-7",
-            "verify/rhel-atomic"  # builds in rhel-7
-        ],
-        'store': REDHAT_STORE
-    },
-    'rhel-atomic': {
-        'triggers': [ "verify/rhel-atomic" ],
-        'store': REDHAT_STORE
-    }
+    'rhel-7': { },
+    'rhel-atomic': { }
 }
 
 # Server to tell us if we can create Red Hat images
@@ -130,23 +80,18 @@ def main():
     return 0
 
 # Prepare an image refresh command
-def image_refresh(priority, name, image, issue=None, triggers=[], store=None):
+def image_refresh(priority, name, image, issue=None):
     if priority <= 0:
         return
     cmd = "PRIORITY={priority:04d} TEST_NAME='{name}' bots/image-refresh"
     if issue:
         cmd += " --issue='{issue}'"
-    if store:
-        cmd += " --store='{store}'"
-    for trigger in triggers:
-        cmd += " --triggers='{0}'".format(pipes.quote(trigger))
     cmd += " '{image}'"
     return cmd.format(**{
         "priority": int(priority),
         "name": pipes.quote(name),
         "image": pipes.quote(image),
         "issue": pipes.quote(str(issue)),
-        "store": pipes.quote(str(store)),
     })
 
 def scan_image_wait_times(api, policy):
@@ -186,17 +131,12 @@ def scan_for_image_tasks(api, policy):
         for image in policy:
             if issue_requests_image_refresh(issue, comments, image):
                 requested.add(image)
-                store = policy.get(image, { }).get("store", None)
-                triggers = policy.get(image, { }).get("triggers", [ ])
-                results.append(image_refresh(BASELINE_PRIORITY, "refresh-" + image, image,
-                    issue['number'], triggers, store))
+                results.append(image_refresh(BASELINE_PRIORITY, "refresh-" + image, image, issue['number']))
 
     # Trigger based on how old the youngest issue is
     for image, wait_time in scan_image_wait_times(api, policy).items():
         if wait_time <= 0 and image not in requested:
-            store = policy.get(image, { }).get("store", None)
-            triggers = policy.get(image, { }).get("triggers", [ ])
-            results.append(image_refresh(BASELINE_PRIORITY, "refresh-" + image, image, None, triggers, store))
+            results.append(image_refresh(BASELINE_PRIORITY, "refresh-" + image, image, None))
 
     return results
 

--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -22,12 +22,29 @@ PRIORITY = 10
 
 NAMES = [
     "po-refresh",
+    "image-refresh",
 ]
+
+KVM_TASKS = [
+    "image-refresh"
+]
+
+REDHAT_TASKS = [
+    "rhel-7",
+    "rhel-atomic"
+]
+
+# Server to tell us if we can create Red Hat images
+REDHAT_PING = "http://file.rdu.redhat.com"
+
+# Credentials for working on above contexts
+REDHAT_CREDS = "~/.rhel/login"
 
 import argparse
 import pipes
 import os
 import sys
+import urllib
 
 sys.dont_write_bytecode = True
 
@@ -43,9 +60,30 @@ def main():
          dest="verbose", help="Print verbose information")
     opts = parser.parse_args()
 
+    kvm = os.access("/dev/kvm", os.R_OK | os.W_OK)
+    if not kvm:
+        sys.stderr.write("tests-scan: No /dev/kvm access, not creating images here\n")
+
+    try:
+        urllib.urlopen(REDHAT_PING).read()
+        redhat = os.path.exists(os.path.expanduser(REDHAT_CREDS))
+    except IOError:
+        redhat = False
+
     for result in scan(opts.verbose):
+        if not kvm and contains_any(result, KVM_TASKS):
+            continue
+        elif not redhat and contains_any(result, REDHAT_TASKS):
+            continue
         sys.stdout.write(result + "\n")
+
     return 0
+
+def contains_any(string, matches):
+    for match in matches:
+        if match in string:
+            return True
+    return False
 
 # Map all checkable work items to fixtures
 def tasks_for_issues():

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -169,7 +169,9 @@ def begin(publish, name, context, issue):
         }
     }
 
-    return sink.Sink(publish, identifier, status)
+    publishing = sink.Sink(publish, identifier, status)
+    sys.stderr.write("Running {0} {1} on {2}".format(name, context or "", hostname))
+    return publishing
 
 def finish(publishing, ret, name, context, issue):
     if not publishing:
@@ -240,6 +242,8 @@ def run(context, function, **kwargs):
         ret = function(context, **kwargs)
     except (RuntimeError, subprocess.CalledProcessError), ex:
         ret = str(ex)
+    except KeyboardInterrupt:
+        raise
     except:
         traceback.print_exc(file=sys.stderr)
     finally:

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -185,19 +185,18 @@ def finish(publishing, ret, name, context, issue):
         comment = "Task failed: :link"
 
     if issue:
-        body = None
-        if not ret:
-            item = "{0} {1}".format(name, context or "").strip()
-            checklist = github.Checklist(issue["body"])
-            checklist.check(item)
-            body = checklist.body
+        # Note that we check whether pass or fail ... this is because
+        # the task is considered "done" until a human comes through and
+        # triggers it again by unchecking the box.
+        item = "{0} {1}".format(name, context or "").strip()
+        checklist = github.Checklist(issue["body"])
+        checklist.check(item)
 
         number = issue["number"]
-        title = issue["title"]
         requests = [ {
             "method": "POST",
             "resource": api.qualify("issues/{0}".format(number)),
-            "data": { "title": title, "body": body }
+            "data": { "title": issue["title"], "body": checklist.body }
         } ]
         if comment:
             requests.append({

--- a/bots/tests-trigger
+++ b/bots/tests-trigger
@@ -7,18 +7,6 @@ sys.dont_write_bytecode = True
 
 import github
 
-def trigger_image(api, opts):
-    title = github.ISSUE_TITLE_IMAGE_REFRESH.format(opts.image)
-    if opts.pull:
-        # Add a comment to the pull request with the right text and set the right label
-        issue = api.get("issues/" + opts.pull)
-        api.post("issues/" + opts.pull + "/comments", { "body": "bot: " + title })
-        api.patch("issues/" + opts.pull, { "labels": issue['labels'] + [ "bot", "image/" + opts.image ] })
-    else:
-        # Make a new issue with the right content.
-        api.post("issues", { "title": title, "labels": [ "bot", "image/" + opts.image ], "body": "bot: " + title })
-    return 0
-
 def trigger_pull(api, opts):
     pull = api.get("pulls/" + opts.pull)
 
@@ -74,20 +62,12 @@ def main():
                         help='Force setting the status even if the program logic thinks it shouldn''t be done')
     parser.add_argument('-a', '--allow', action='store_true', dest='allow',
                         help="Allow triggering for users that aren't whitelisted")
-    parser.add_argument('--image', help='Trigger a image refresh instead of a testsuite run')
-    parser.add_argument('pull', nargs='?', help='The pull request to trigger')
+    parser.add_argument('pull', help='The pull request to trigger')
     parser.add_argument('context', nargs='?', help='The github task context to trigger')
     opts = parser.parse_args()
 
     api = github.GitHub()
-
-    if opts.image:
-        return trigger_image(api, opts)
-    elif opts.pull and not opts.image:
-        return trigger_pull(api, opts)
-    else:
-        sys.stderr.write("Please specify either --image or a pull request.\n")
-        return 1
+    return trigger_pull(api, opts)
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
The new image-refresh bot is now driven off of checklists in either issues or pull requests.

Depends on:
 * [x] #6735