### PR TITLE
bots: Add a match for PCP crash known issue

### DIFF
--- a/bots/naughty/fedora-25/6108-pcp-pmfindprofile-crash-2
+++ b/bots/naughty/fedora-25/6108-pcp-pmfindprofile-crash-2
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+*
+  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
+*
+Error: /usr/*/cockpit-pcp: bridge was killed: 6

--- a/bots/naughty/fedora-26/6108-pcp-pmfindprofile-crash-2
+++ b/bots/naughty/fedora-26/6108-pcp-pmfindprofile-crash-2
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+*
+  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
+*
+Error: /usr/*/cockpit-pcp: bridge was killed: 7


### PR DESCRIPTION
This is cockpit-pcp crashing due to broken PCP libraries ... again.

/usr/libexec/cockpit-pcp: bridge was killed: 7