### PR TITLE
base1: Add longer simple-tap.js timeout

### DIFF
--- a/src/base1/simple-tap.js
+++ b/src/base1/simple-tap.js
@@ -13,7 +13,7 @@ var test = { };
     timeout = window.setTimeout(function() {
         console.log("test timed out, failed");
         console.log("phantom-tap-error");
-    }, 20000);
+    }, 60000);
 
     test.log = function log(message) {
         var output = document.getElementById("output");


### PR DESCRIPTION
From time to time this times out in Semaphore CI. Try making
the timeout longer, similar to the other timeouts during testing
which are 60 seconds.