### PR TITLE
bots: Make sure to add 'Manual testing required' when scanning

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -254,7 +254,7 @@ def scan_for_pull_tasks(api, update, human, policy):
             # will apply if the user pushes a new commit.
             if login not in whitelist and status.get("description", github.NO_TESTING) == github.NO_TESTING:
                 priority = github.NO_TESTING
-                changes = None
+                changes = { "description": github.NO_TESTING, "context": context, "state": "pending" }
             else:
                 (priority, changes) = prioritize(status, title, labels, baseline, context)
             if update_status(revision, context, status, changes):


### PR DESCRIPTION
When scanning pull requests, make sure to add 'Manual testing
required' statuses for folks not on the whitelist.