### PR TITLE
Fixes for task bots: Respect whitelist, Handle failure better, Tests

### DIFF
--- a/bots/example-task
+++ b/bots/example-task
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+# To use this example add a line to an issue with the "bot" label
+#
+#  * [ ] example-bot 20
+#
+
+import argparse
+import os
+import sys
+import time
+
+sys.dont_write_bytecode = True
+
+import task
+
+BOTS = os.path.abspath(os.path.dirname(__file__))
+BASE = os.path.normpath(os.path.join(BOTS, ".."))
+
+def run(argument, verbose=False, **kwargs):
+    try:
+        seconds = int(argument)
+    except ValueError:
+        return "Failed to parse argument"
+
+    sys.stdout.write("Example message to log\n")
+    time.sleep(20)
+
+if __name__ == '__main__':
+    task.main(function=run, title="Example bot task")

--- a/bots/github/test-checklist
+++ b/bots/github/test-checklist
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import imp
+import os
+import sys
+import unittest
+
+BASE = os.path.dirname(__file__)
+github = imp.load_source("github", os.path.join(BASE, "__init__.py"))
+
+class TestChecklist(unittest.TestCase):
+    def testParse(self):
+        parse_line = github.Checklist.parse_line
+        self.assertEqual(parse_line("blah"), (None, None))
+        self.assertEqual(parse_line(""), (None, None))
+        self.assertEqual(parse_line(""), (None, None))
+        self.assertEqual(parse_line("* [ ] test two"), ("test two", False))
+        self.assertEqual(parse_line("- [ ] test two"), ("test two", False))
+        self.assertEqual(parse_line(" * [ ]  test two "), ("test two", False))
+        self.assertEqual(parse_line(" - [ ]  test two "), ("test two", False))
+        self.assertEqual(parse_line(" - [x] test two "), ("test two", True))
+        self.assertEqual(parse_line(" * [x] test two"), ("test two", True))
+        self.assertEqual(parse_line(" * [x]test three"), (None, None))
+
+    def testFormat(self):
+        format_line = github.Checklist.format_line
+        self.assertEqual(format_line("blah", True), " * [x] blah")
+        self.assertEqual(format_line("blah", False), " * [ ] blah")
+        self.assertEqual(format_line("blah", "FAIL"), " * [ ] FAIL: blah")
+
+    def testProcess(self):
+        body = "This is a description\n- [ ] item1\n * [x] Item two\n\nMore lines"
+        checklist = github.Checklist(body)
+        self.assertEqual(checklist.body, body)
+        self.assertEqual(checklist.items, { "item1": False, "Item two": True })
+
+    def testCheck(self):
+        body = "This is a description\n- [ ] item1\n * [x] Item two\n\nMore lines"
+        checklist = github.Checklist(body)
+        checklist.check("item1", True)
+        self.assertEqual(checklist.body, "This is a description\n * [x] item1\n * [x] Item two\n\nMore lines")
+        self.assertEqual(checklist.items, { "item1": True, "Item two": True })
+
+    def testDisable(self):
+        body = "This is a description\n- [ ] item1\n * [x] Item two\n\nMore lines"
+        checklist = github.Checklist(body)
+        checklist.check("item1", "Status")
+        self.assertEqual(checklist.body, "This is a description\n * [ ] Status: item1\n * [x] Item two\n\nMore lines")
+        self.assertEqual(checklist.items, { "item1": "Status", "Item two": True })
+
+    def testAdd(self):
+        body = "This is a description\n- [ ] item1\n * [x] Item two\n\nMore lines"
+        checklist = github.Checklist(body)
+        checklist.add("Item three")
+        self.assertEqual(checklist.body, "This is a description\n- [ ] item1\n * [x] Item two\n\nMore lines\n * [ ] Item three")
+        self.assertEqual(checklist.items, { "item1": False, "Item two": True, "Item three": False })
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -117,12 +117,8 @@ def run(image, verbose=False, **kwargs):
 
     os.environ['VIRT_BUILDER_NO_CACHE'] = "yes"
     ret = subprocess.call(cmd)
-
-    # When image creation fails, remove the link and make a pull
-    # request anyway, for extra attention
-
-    if ret != 0:
-        os.unlink(os.path.join(BOTS, "images", image))
+    if ret:
+        return ret
 
     branch = task.branch(image, "images: Update {0} image".format(image), pathspec="bots/images", **kwargs)
     if branch:

--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -21,6 +21,7 @@
 PRIORITY = 10
 
 NAMES = [
+    "example-task",
     "po-refresh",
     "image-refresh",
 ]

--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -89,12 +89,17 @@ def contains_any(string, matches):
 # Map all checkable work items to fixtures
 def tasks_for_issues():
     results = [ ]
+    whitelist = github.whitelist()
     for issue in github.GitHub().issues(state="open"):
-        if not issue["title"].strip().startswith("WIP"):
-            checklist = github.Checklist(issue["body"])
-            for item, checked in checklist.items.items():
-                if not checked:
-                    results.append((item, issue))
+        if issue["title"].strip().startswith("WIP"):
+            continue
+        login = issue.get("user", { }).get("login", { })
+        if login not in whitelist:
+            continue
+        checklist = github.Checklist(issue["body"])
+        for item, checked in checklist.items.items():
+            if not checked:
+                results.append((item, issue))
     return results
 
 def output_task(command, issue, verbose):

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -170,7 +170,7 @@ def begin(publish, name, context, issue):
     }
 
     publishing = sink.Sink(publish, identifier, status)
-    sys.stderr.write("Running {0} {1} on {2}".format(name, context or "", hostname))
+    sys.stderr.write("Running {0} {1} on {2}\n".format(name, context or "", hostname))
     return publishing
 
 def finish(publishing, ret, name, context, issue):

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -170,7 +170,11 @@ def begin(publish, name, context, issue):
     }
 
     publishing = sink.Sink(publish, identifier, status)
-    sys.stderr.write("Running {0} {1} on {2}\n".format(name, context or "", hostname))
+    sys.stdout.write("# Task: {0} {1}\n# Host: {2}\n\n".format(name, context or "", hostname))
+
+    # For statistics
+    publishing.start = time.time()
+
     return publishing
 
 def finish(publishing, ret, name, context, issue):
@@ -179,10 +183,16 @@ def finish(publishing, ret, name, context, issue):
 
     if not ret:
         comment = None
+        result = "Completed"
     elif isinstance(ret, basestring):
         comment = "{0}: :link".format(ret)
+        result = ret
     else:
         comment = "Task failed: :link"
+        result = "Failed"
+
+    duration = int(time.time() - publishing.start)
+    sys.stdout.write("\n# Result: {0}\n# Duration: {1}s\n".format(result, duration))
 
     if issue:
         # Note that we check whether pass or fail ... this is because

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -200,7 +200,7 @@ def finish(publishing, ret, name, context, issue):
         # triggers it again by unchecking the box.
         item = "{0} {1}".format(name, context or "").strip()
         checklist = github.Checklist(issue["body"])
-        checklist.check(item)
+        checklist.check(item, ret and "FAIL" or True)
 
         number = issue["number"]
         requests = [ {


### PR DESCRIPTION
1. Only process task issues from people on the whitelist
    
For the time being only issues created by people on the whitelist are allowed to be processed. We may get more fine grained about this in the future, but this is a good place to start.

2. Disable tasks that failed
    
When running a task in a checklist, and it fails, disable that item in the checklist by prefixing it with a "FAIL:" prefix. The actual failure reason will be included below. The goal here is for a human to have to change the item in the checklist before any bot will examine it again.

3. Updates to messages and output

4. An example task for the bots

Testing the example bot:

 * [x] example-task 30