### PR TITLE
bots: Don't test debian-8 on branches

### DIFF
--- a/bots/images/debian-8
+++ b/bots/images/debian-8
@@ -1,1 +1,0 @@
-debian-8-fbf89ea1ec1dcbc64fa3cbe3c0af4409ea9936d2.qcow2

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -33,7 +33,6 @@ DEFAULT_VERIFY = {
     'selenium/chrome': BRANCHES,
     'verify/centos-7': BRANCHES,
     'verify/continuous-atomic': [ ],
-    'verify/debian-8': [ 'rhel-7.4' ],
     'verify/debian-stable': [ 'master' ],
     'verify/debian-testing': BRANCHES,
     'verify/fedora-24': [ ],


### PR DESCRIPTION
This image no longer exists, and now that all the image prepare
logic is in bots/ we no longer have to pretend that it does.

This fixes 'verify/debian-8' with 'Preparation of testable image failed'
on pull request branches.