### PR TITLE
WIP: cockpit-tests-hjl9f: bots: Update fedora-i386 image to Fedora 26

### DIFF
--- a/bots/images/scripts/fedora-25.setup
+++ b/bots/images/scripts/fedora-25.setup
@@ -123,7 +123,7 @@ fi
 [ -z "$HAVE_KUBERNETES" ] || /var/lib/testvm/kubernetes.setup
 
 # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1341829
-# SELinux breaks coredumping on fedora-25
+# SELinux breaks coredumping on fedora-26
 printf '(allow init_t domain (process (rlimitinh)))\n' > domain.cil
 semodule -i domain.cil
 

--- a/bots/images/scripts/fedora-i386.bootstrap
+++ b/bots/images/scripts/fedora-i386.bootstrap
@@ -18,4 +18,4 @@
 # 02110-1301 USA.
 
 BASE=$(dirname $0)
-$BASE/virt-install-fedora "$1" i386 "http://dl.fedoraproject.org/pub/fedora/linux/releases/25/Server/i386/os"
+$BASE/virt-install-fedora "$1" i386 "http://dl.fedoraproject.org/pub/fedora/linux/releases/26/Server/i386/os"


### PR DESCRIPTION
The fedora-i386 image seems to be flaking on kdump tests
quite often. Before filing a known issue, lets start by updating
it to the next version of Fedora we're going to be testing on.

 * [ ] image-refresh fedora-i386