### PR TITLE
test: Fix race using docker page before its visible

### DIFF
--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -182,6 +182,7 @@ class TestDockerStorage(MachineCase):
         # Add a disk
 
         m.add_disk("100M", serial="DISK1")
+        b.wait_visible("#storage-drives")
         b.wait_in_text("#storage-drives", "DISK1")
 
         b.click("#storage-drives tr:contains(DISK1)")


### PR DESCRIPTION
The check-docker-storage page tries to use the docker
page before it is visible.