### PR TITLE
test: Dump an HTML file when a test fails

### DIFF
--- a/test/common/phantom-driver.js
+++ b/test/common/phantom-driver.js
@@ -44,6 +44,7 @@
 
 var page = require('webpage').create();
 var sys = require('system');
+var fs = require('fs');
 var clearedStorage = false;
 var messages = "";
 var onCheckpoint;
@@ -184,6 +185,17 @@ var driver = {
         if (!file)
             file = "page.png";
         page.render(file);
+        sys.stderr.writeLine("Wrote " + file);
+        respond({ result: null });
+    },
+
+    dump: function(respond, file) {
+        if (!file)
+            file = "page.html";
+        var data = page.evaluate(function() {
+            return document.documentElement.outerHTML;
+	});
+        fs.write(file, data, 'w');
         sys.stderr.writeLine("Wrote " + file);
         respond({ result: null });
     },

--- a/test/common/phantom-driver.js
+++ b/test/common/phantom-driver.js
@@ -182,9 +182,9 @@ var driver = {
 
     show: function(respond, file) {
         if (!file)
-            file = "page.png"
+            file = "page.png";
         page.render(file);
-        sys.stderr.writeLine("Wrote " + file)
+        sys.stderr.writeLine("Wrote " + file);
         respond({ result: null });
     },
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -406,7 +406,7 @@ class Browser:
             self.enter_page(path.split("#")[0], host=host)
 
     def snapshot(self, title, label=None):
-        """Take a snapshot of the current screen and save it as a PNG.
+        """Take a snapshot of the current screen and save it as a PNG and HTML.
 
         Arguments:
             title: Used for the filename.
@@ -414,6 +414,9 @@ class Browser:
         if self.phantom and self.phantom.valid:
             filename = "{0}-{1}.png".format(label or self.label, title)
             self.phantom.show(filename)
+            attach(filename)
+            filename = "{0}-{1}.html".format(label or self.label, title)
+            self.phantom.dump(filename)
             attach(filename)
 
     def kill(self):


### PR DESCRIPTION
In addition to the PNG dump an HTML file when the test fails. This should help with diagnosing with certain test failures.

It is intentional that the iframe which we were in when the test fails is the one that is dumped.
