### PR TITLE
gitignore: Ignore test HTML dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,7 @@ po*.js.gz
 Test*.log
 cockpit-*.tar*
 Test*.png
+Test*.html
 
 /pkg/networkmanager/override.json
 /pkg/storaged/override.json


### PR DESCRIPTION
Since commit 05e83720bd failed tests leave a HTML dump behind.