### PR TITLE
docker: Correctly mark translatable strings

### DIFF
--- a/pkg/docker/containers-view.jsx
+++ b/pkg/docker/containers-view.jsx
@@ -332,10 +332,10 @@ var ImageSecurity = React.createClass({
         };
 
         if (info.successful === false) {
-            text = _('The scan from $time ($type) was not successful.');
+            text = _("The scan from $time ($type) was not successful.");
 
         } else if (info.vulnerabilities.length === 0) {
-            text = _('The scan from $time ($type) found no vulnerabilities.');
+            text = _("The scan from $time ($type) found no vulnerabilities.");
 
         } else {
             text = cockpit.ngettext('The scan from $time ($type) found one vulnerability:',
@@ -543,14 +543,14 @@ var ImageList = React.createClass({
         var tabs = [];
 
         tabs.push({
-            name: _('Details'),
+            name: _("Details"),
             renderer: ImageDetails,
             data: { image: image }
         });
 
         if (vulnerableInfo !== undefined) {
             tabs.push({
-                name: _('Security'),
+                name: _("Security"),
                 renderer: ImageSecurity,
                 data: {
                     image: image,

--- a/tools/static-code-tests
+++ b/tools/static-code-tests
@@ -8,7 +8,7 @@ if ! which pyflakes >/dev/null 2>&1; then
     exit 0
 fi
 
-echo "1..2"
+echo "1..3"
 
 cd "${srcdir:-.}"
 
@@ -33,3 +33,14 @@ if [ -n "$out" ]; then
     exit 1
 fi
 echo "ok 2 pyflakes"
+
+#
+# wrongly marked translatable strings
+#
+
+if out=$(find src/ pkg/ -name '*.js' -o -name '*.jsx' -o -name '*.es6' | xargs grep "_('"); then
+    echo 'ERROR: translatable strings must be marked with _("")'
+    echo "$out"
+    exit 1
+fi
+echo "ok 3 js-translatable-strings"


### PR DESCRIPTION
Our parser only finds _(""), not single quotes.