### PR TITLE
machines: scroll noVNC into view

### DIFF
--- a/pkg/machines/components/vnc.jsx
+++ b/pkg/machines/components/vnc.jsx
@@ -24,34 +24,35 @@ import { vmId } from '../helpers.es6';
 
 const _ = cockpit.gettext;
 
-const Frame = ({ url, containerId }) => {
+const Frame = ({ url, novncContainerId }) => {
     return (
-        <iframe src={url} className='machines-console-frame-vnc' frameBorder='0' name={containerId} data-container-id={containerId}>
+        <iframe src={url} className='machines-console-frame-vnc' frameBorder='0' name={novncContainerId} data-container-id={novncContainerId}>
             {_("Your browser does not support iframes.")}
         </iframe>
     );
 };
 Frame.propTypes = {
     url: React.PropTypes.string.isRequired,
-    containerId: React.PropTypes.string.isRequired,
+    novncContainerId: React.PropTypes.string.isRequired,
 };
 
 const Vnc = ({ vm, consoleDetail }) => {
     if (!consoleDetail) {
         return null;
     }
-    const uniqueFrameContainerId = `${vmId(vm.name)}-novnc-frame-container`;
+    const vmIdPrefix = vmId(vm.name);
+    const novncContainerId = `${vmIdPrefix}-novnc-frame-container`;
 
     const encrypt = window.location.protocol === "https:";
     const port = consoleDetail.tlsPort || consoleDetail.port;
 
-    let params = `?host=${consoleDetail.address}&port=${port}&encrypt=${encrypt}&true_color=1&resize=true&containerId=${encodeURIComponent(uniqueFrameContainerId)}`;
+    let params = `?host=${consoleDetail.address}&port=${port}&encrypt=${encrypt}&true_color=1&resize=true&containerId=${encodeURIComponent(vmIdPrefix)}`;
     params = consoleDetail.password ? params += `&password=${consoleDetail.password}` : params;
 
     return (
-        <div id={uniqueFrameContainerId} className='machines-console-frame' style={{ height: '100px;' }}>
+        <div id={novncContainerId} className='machines-console-frame' style={{ height: '100px;' }}>
             <br />
-            <Frame url={`vnc.html${params}`} containerId={uniqueFrameContainerId} />
+            <Frame url={`vnc.html${params}`} novncContainerId={novncContainerId}/>
         </div>
     );
 };

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -427,6 +427,7 @@ const Vm = ({ vm, config, onStart, onShutdown, onForceoff, onReboot, onForceRebo
         : name;
 
     return (<ListingRow
+        rowId={`${vmId(vm.name)}`}
         columns={[
             {name: rowName, 'header': true},
             rephraseUI('connections', vm.connectionName),

--- a/pkg/machines/vnc.html
+++ b/pkg/machines/vnc.html
@@ -64,7 +64,6 @@
     <script>
         /* global window, $, Util, RFB, */
         "use strict";
-
         /*
             Unresolved issues when trying to bundle noVNC js files:
                 - sources are not UMD modules (so no "require()")
@@ -77,6 +76,23 @@
 
         var rfb;
         var resizeTimeout;
+
+        function ensureVisibility() {
+            setTimeout(function () {
+                var containerId = decodeURIComponent(WebUtil.getConfigVar("containerId", ""));
+                console.log("Scrolling VNC frame into view, containerId = ", containerId);
+
+                var toBeVisible = $("tr[data-row-id='" + containerId + "']", window.parent.document)[0];
+                var toBeVisibleRow = $("#" + containerId + "-row", window.parent.document)[0];
+
+                if (toBeVisible && toBeVisible.scrollIntoView) {
+                    toBeVisible.scrollIntoView(); // ensure maximal visibility of the VNC iframe + VM-controls
+                    toBeVisibleRow.scrollIntoView(); // ensure the VM's name is visible
+                } else {
+                    console.log('scrollIntoView() is not supported');
+                }
+            }, 50);
+        }
 
         function UIresize() {
             var containerId = decodeURIComponent(WebUtil.getConfigVar('containerId', ''));
@@ -91,10 +107,17 @@
             if (WebUtil.getConfigVar('resize', false)) {
                 var height = ($D('noVNC_canvas').height + 60)+ "px";
                 console.log('Resizing noVNC, height = ', height);
-                $("#" + containerId, window.parent.document)[0].style.height = height;
+
+                var novncContainerId = "#" + containerId + "-novnc-frame-container";
+                var novncContainer = $(novncContainerId, window.parent.document)[0];
+                novncContainer.style.height = height;
+
                 // no need to resize width - already 100%, potential scrollbar
+
+                ensureVisibility();
             }
         }
+
         function FBUComplete(rfb, fbu) {
             UIresize();
             rfb.set_onFBUComplete(function() { });


### PR DESCRIPTION
The noVNC frame and related components are scrolled into view when
Console subtab is opened.

Fixes: https://github.com/cockpit-project/cockpit/issues/6939