### PR TITLE
Adding undocumented option to cockpit.file()

### DIFF
--- a/doc/guide/cockpit-file.xml
+++ b/doc/guide/cockpit-file.xml
@@ -17,6 +17,8 @@ file = cockpit.file(path,
                     { syntax: syntax_object,
                       binary: boolean,
                       max_read_size: int,
+                      superuser: string,
+                      host: string
                     })
 
 promise = file.read()
@@ -65,6 +67,9 @@ cockpit.file("/path/to/file").read()
     <para>It is not an error when the file does not exist. In this case, the
       <code>done()</code> callback will be called with a <code>null</code>
       value for <code>content</code> and <code>tag</code> is <code>"-"</code>.</para>
+      <para>The <code>superuser</code> and <code>host</code> options can be used the same way
+      as described in the <link linkend="cockpit-channels-channel">cockpit.channel()</link>
+      to provide a different access level to the file.</para>
     <para>You can use the <code>max_read_size</code> option to limit
       the amount of data that is read.  If the file is larger than the
       given limit, no data is read and the channel is closed with


### PR DESCRIPTION
As discussed here https://github.com/cockpit-project/cockpit-project.github.io/pull/70 it's also possible to use "superuser" and "host" option on cockpit.file but it was not documented in the Cockpit Guide