### PR TITLE
kubernetes: Go back to registry-image-widgets 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "qunitjs": "1.23.1",
     "react-lite-cockpit": "0.15.6",
     "redux": "3.5.2",
-    "registry-image-widgets": "0.0.7",
+    "registry-image-widgets": "git+https://github.com/petervo/registry-image-widgets.git#0.0.4-package",
     "requirejs": "2.1.16",
     "term.js-cockpit": "0.0.7"
   },

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -1039,7 +1039,7 @@ class TestRegistry(MachineCase):
 
         # .. and also on the image page
         b.go("#/images/marmalade/origin")
-        b.wait_in_text("body", "push an image to this image stream")
+        b.wait_in_text("body", "push to an image to this image stream")
         b.wait_in_text("body", "docker tag")
         b.wait_in_text("body", "docker push")
         b.wait_visible('.registry-imagestream-push')


### PR DESCRIPTION
This was changed in #6814 and broke kubernetes/registry layouts. We'll be properly integrating with the new version shortly but until then revert back to the old.