### PR TITLE
docs: expand certmonger suggestion with DNS name

### DIFF
--- a/doc/guide/https.xml
+++ b/doc/guide/https.xml
@@ -68,8 +68,8 @@ $ sudo remotectl certificate
     be used to automatically prepare concatenated .cert file:</para>
 
     <programlisting>
-CERT_FILE=/etc/pki/tls/certs/${hostname).pem
-KEY_FILE=/etc/pki/tls/private/${hostname).key
+CERT_FILE=/etc/pki/tls/certs/$(hostname).pem
+KEY_FILE=/etc/pki/tls/private/$(hostname).key
 
 getcert request -f ${CERT_FILE} -k ${KEY_FILE} -C "sed -n w/etc/cockpit/ws-certs.d/50-from-certmonger.cert ${CERT_FILE} ${KEY_FILE}"
     </programlisting>

--- a/doc/guide/https.xml
+++ b/doc/guide/https.xml
@@ -71,7 +71,7 @@ $ sudo remotectl certificate
 CERT_FILE=/etc/pki/tls/certs/$(hostname).pem
 KEY_FILE=/etc/pki/tls/private/$(hostname).key
 
-getcert request -f ${CERT_FILE} -k ${KEY_FILE} -C "sed -n w/etc/cockpit/ws-certs.d/50-from-certmonger.cert ${CERT_FILE} ${KEY_FILE}"
+getcert request -f ${CERT_FILE} -k ${KEY_FILE} -D $(hostname --fqdn) -C "sed -n w/etc/cockpit/ws-certs.d/50-from-certmonger.cert ${CERT_FILE} ${KEY_FILE}"
     </programlisting>
   </section>
 

--- a/doc/man/cockpit-ws.xml
+++ b/doc/man/cockpit-ws.xml
@@ -85,6 +85,16 @@
 <programlisting>
 $ sudo remotectl certificate
 </programlisting>
+
+    <para>If using <literal>certmonger</literal> to manage certificates, following command can
+      be used to automatically prepare concatenated <literal>.cert</literal> file:</para>
+<programlisting>
+CERT_FILE=/etc/pki/tls/certs/$(hostname).pem
+KEY_FILE=/etc/pki/tls/private/$(hostname).key
+
+getcert request -f ${CERT_FILE} -k ${KEY_FILE} -D $(hostname --fqdn) -C "sed -n w/etc/cockpit/ws-certs.d/50-from-certmonger.cert ${CERT_FILE} ${KEY_FILE}"
+</programlisting>
+
   </refsect1>
 
   <refsect1 id="cockpit-ws-timeout">


### PR DESCRIPTION
Recently web browsers started paying more attention to subjectAltName. Modify suggested `certmonger` command to include -D switch.