### PR TITLE
semaphore: Write build output carefully to stdout

### DIFF
--- a/tools/careful-cat.c
+++ b/tools/careful-cat.c
@@ -1,0 +1,61 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+
+/* Carefully cat stdin to stdout.
+ *
+ * This uses small writes and handles EAGAIN from write by waiting a
+ * bit and trying again.
+ *
+ * This program is used in Travis to work around this bug:
+ *
+ *    https://github.com/travis-ci/travis-ci/issues/4704
+ */
+
+void
+main (void)
+{
+  char buffer[1024], *ptr;
+  int n, m;
+
+  while (1)
+    {
+      n = read (0, buffer, sizeof(buffer));
+      if (n == 0)
+        break;
+
+      if (n < 0)
+        {
+          perror("read");
+          exit (1);
+        }
+
+      ptr = buffer;
+      while (n > 0)
+        {
+          m = write (1, ptr, n);
+          if (m == 0)
+            {
+              fprintf(stderr, "write: closed\n");
+              exit (1);
+            }
+
+          if (m < 0)
+            {
+              int err = errno;
+              perror("write");
+              if (err != EAGAIN)
+                exit (1);
+              sleep(1);
+            }
+          else
+            {
+              n -= m;
+              ptr += m;
+            }
+        }
+    }
+
+  exit (0);
+}

--- a/tools/semaphore-run
+++ b/tools/semaphore-run
@@ -20,14 +20,13 @@ elif [ -n "$ARCH" ]; then
     exit 1
 fi
 
+gcc ./tools/careful-cat.c -o careful-cat
 ./autogen.sh --prefix=/usr --enable-strict --with-systemdunitdir=/tmp
 make -j2 V=1 all
 
 # only run distcheck on native arch
 if [ -z "$ARCH" ]; then
-    make -j8 distcheck
-    make -j8 check-memory
+    make -j8 distcheck check-memory 2>&1 | ./careful-cat
 elif [ "$ARCH" = i386 ]; then
-    linux32 make -j8 check
-    linux32 make -j8 check-memory
+    linux32 make -j8 check check-memory 2>&1 | ./careful-cat
 fi


### PR DESCRIPTION
Stdout/stderr are connected to something that fails big/fast writes
with EAGAIN sometimes.  To defend against this, we pass our output
through careful-cat, which handles EAGAIN.

This brings back work done for Travis:

    commit 9edc68797f48efb4f67c763a1e344729eaadab75
    Author: Marius Vollmer <mvollmer@redhat.com>
    Date:   Mon Aug 24 13:35:04 2015 +0300

    Related #2611

The specific lines in the output logs that this addresses are:

    /bin/bash: line 2: echo: write error: Resource temporarily unavailable
    /bin/bash: line 10: echo: write error: Resource temporarily unavailable
    /bin/bash: line 10: echo: write error: Resource temporarily unavailable
    tar: write error