### PR TITLE
build: Obsolete old cockpit-networkmanager packages

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -412,6 +412,7 @@ Provides: %{name}-tuned = %{version}-%{release}
 Provides: %{name}-users = %{version}-%{release}
 %if 0%{?rhel}
 Provides: %{name}-networkmanager = %{version}-%{release}
+Obsoletes: %{name}-networkmanager < 135
 Requires: NetworkManager
 Provides: %{name}-kdump = %{version}-%{release}
 Requires: kexec-tools


### PR DESCRIPTION
In some cases these were built indepdendently on centos-7, but
they are part of cockpit-system.

Issue #6365 

I'm not quite sure where the individual cockpit-networkmanager packages came from.