### PR TITLE
Software Updates: Cancel button, design updates

### DIFF
--- a/pkg/packagekit/updates.css
+++ b/pkg/packagekit/updates.css
@@ -38,8 +38,9 @@ tr.security {
 }
 
 /* don't let the install progress bar get too wide */
-.progress {
+.progress-main-view {
     max-width: 60rem;
+    margin: 10ex auto 0;
 }
 
 /* stolen from pkg/systemd/host.css */

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -110,16 +110,17 @@ function HeaderBar(props) {
     }
 
     var lastChecked;
-    if (props.timeSinceRefresh) {
-        lastChecked = (
-            <span style={{paddingRight: "3ex"}}>
-                {cockpit.format(_("Last checked: $0 ago"), moment.duration(props.timeSinceRefresh * 1000).humanize())}
-            </span>
-        );
-    }
     var refreshButton;
-    if (props.state == "uptodate" || props.state == "available")
+    if (props.state == "uptodate" || props.state == "available") {
         refreshButton = <button className="btn btn-default" onClick={() => props.onRefresh()} >Check for updates</button>;
+        if (props.timeSinceRefresh) {
+            lastChecked = (
+                <span style={{paddingRight: "3ex"}}>
+                    {cockpit.format(_("Last checked: $0 ago"), moment.duration(props.timeSinceRefresh * 1000).humanize())}
+                </span>
+            );
+        }
+    }
 
     return (
         <div className="content-header-extra">

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -29,6 +29,7 @@ const _ = cockpit.gettext;
 const STATE_HEADINGS = {
     "loading": _("Loading available updates, please wait..."),
     "locked": _("Some other program is currently using the package manager, please wait..."),
+    "refreshing": _("Refreshing package information"),
     "uptodate": _("No updates pending"),
     "applying": _("Applying updates"),
     "updateError": _("Applying updates failed"),
@@ -311,7 +312,7 @@ class OsUpdates extends React.Component {
                 err = _("PackageKit is not installed")
             else
                 err = _("PackageKit crashed");
-            if (this.state.state == "loading") {
+            if (this.state.state == "loading" || this.state.state == "refreshing") {
                 this.handleLoadError(err);
             } else if (this.state.state == "applying") {
                 this.state.errorMessages.push(err);
@@ -486,6 +487,7 @@ class OsUpdates extends React.Component {
     renderContent() {
         switch (this.state.state) {
             case "loading":
+            case "refreshing":
             case "locked":
                 if (this.state.loadPercent)
                     return (
@@ -556,7 +558,7 @@ class OsUpdates extends React.Component {
     }
 
     handleRefresh() {
-        this.setState({state: "loading", loadPercent: null});
+        this.setState({state: "refreshing", loadPercent: null});
         pkTransaction()
             .done(transProxy =>  {
                 transProxy.addEventListener("ErrorCode", (event, code, details) => this.handleLoadError(details));

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -112,7 +112,7 @@ function HeaderBar(props) {
     var lastChecked;
     var refreshButton;
     if (props.state == "uptodate" || props.state == "available") {
-        refreshButton = <button className="btn btn-default" onClick={() => props.onRefresh()} >Check for updates</button>;
+        refreshButton = <button className="btn btn-default" onClick={() => props.onRefresh()} >{_("Check for updates")}</button>;
         if (props.timeSinceRefresh) {
             lastChecked = (
                 <span style={ {paddingRight: "3ex"} }>

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -51,7 +51,7 @@ const PK_STATUS_STRINGS = {
     8: _("Downloading"),
     9: _("Installing"),
     10: _("Updating"),
-    11: _("Cleaning up"),
+    11: _("Setting up"),
     14: _("Verifying"),
 }
 
@@ -517,7 +517,7 @@ class OsUpdates extends React.Component {
                     <div>
                         <table width="100%">
                             <tr>
-                                <td><h2>{_("Available Packages")}</h2></td>
+                                <td><h2>{_("Available Updates")}</h2></td>
                                 <td className="text-right">
                                     { this.state.haveSecurity
                                       ? <button className="btn btn-default"

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -115,7 +115,7 @@ function HeaderBar(props) {
         refreshButton = <button className="btn btn-default" onClick={() => props.onRefresh()} >Check for updates</button>;
         if (props.timeSinceRefresh) {
             lastChecked = (
-                <span style={{paddingRight: "3ex"}}>
+                <span style={ {paddingRight: "3ex"} }>
                     {cockpit.format(_("Last checked: $0 ago"), moment.duration(props.timeSinceRefresh * 1000).humanize())}
                 </span>
             );
@@ -248,14 +248,14 @@ class ApplyUpdates extends React.Component {
         if (this.state.percentage !== null)
             progressBar = (
                 <div className="progress progress-label-top-right">
-                    <div className="progress-bar" role="progressbar" style={{width: this.state.percentage + "%"}}>
+                    <div className="progress-bar" role="progressbar" style={ {width: this.state.percentage + "%"} }>
                         {this.state.timeRemaining !== null ? <span>{moment.duration(this.state.timeRemaining * 1000).humanize()}</span> : null}
                     </div>
                 </div>
             );
 
         return (
-            <div>
+            <div className="progress-main-view">
                 <div className="progress-description">
                     <div className="spinner spinner-xs spinner-inline"></div>
                     {action}
@@ -492,13 +492,14 @@ class OsUpdates extends React.Component {
             case "locked":
                 if (this.state.loadPercent)
                     return (
-                        <div className="progress">
-                          <div className="progress-bar" role="progressbar"
-                               style={{width: this.state.loadPercent + "%"}}>
-                          </div>
-                      </div>)
+                        <div className="progress-main-view">
+                            <div className="progress">
+                                <div className="progress-bar" role="progressbar" style={ {width: this.state.loadPercent + "%"} }></div>
+                            </div>
+                        </div>
+                    );
                 else
-                    return <div className="spinner spinner-lg" />;
+                    return <div className="spinner spinner-lg progress-main-view" />;
 
             case "available":
                 return (

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -103,9 +103,13 @@ class TestUpdates(MachineCase):
         b.wait_in_text("#state", "Applying updates")
         b.wait_present("#app div.progress-bar")
 
-        # no refresh button or "last checked"
-        b.wait_present(".content-header-extra td.text-right")
-        self.assertEqual(b.text(".content-header-extra td.text-right").strip(), "")
+        # no refresh button or "last checked", but Cancel button
+        b.wait_present(".content-header-extra td.text-right button")
+        self.assertFalse(b.is_present(".content-header-extra td.text-right span"))
+        b.wait_in_text(".content-header-extra td button", "Cancel")
+
+        # Cancel button should eventually get disabled
+        b.wait_present(".content-header-extra td button:disabled")
 
         # should have succeeded
         b.wait_in_text("#state", "No updates pending")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -71,6 +71,9 @@ class TestUpdates(MachineCase):
         b.wait_in_text(".content-header-extra td button", "Check for updates")
         b.click(".content-header-extra td button")
 
+        b.wait_present(".content-header-extra td.text-right span")
+        self.assertEqual(b.text(".content-header-extra td.text-right span"), "Last checked: a few seconds ago")
+
         b.wait_present(".container-fluid h2")
         b.wait_in_text(".container-fluid h2", "Available Packages")
         self.assertEqual(b.text("#state"), "2 updates")
@@ -100,8 +103,15 @@ class TestUpdates(MachineCase):
         b.wait_in_text("#state", "Applying updates")
         b.wait_present("#app div.progress-bar")
 
+        # no refresh button or "last checked"
+        b.wait_present(".content-header-extra td.text-right")
+        self.assertEqual(b.text(".content-header-extra td.text-right").strip(), "")
+
         # should have succeeded
         b.wait_in_text("#state", "No updates pending")
+        b.wait_present(".content-header-extra td.text-right span")
+        b.wait_in_text(".content-header-extra td.text-right span", "Last checked:")
+
         # empty state visible in main area
         b.wait_present(".container-fluid div.blank-slate-pf")
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -75,7 +75,7 @@ class TestUpdates(MachineCase):
         self.assertEqual(b.text(".content-header-extra td.text-right span"), "Last checked: a few seconds ago")
 
         b.wait_present(".container-fluid h2")
-        b.wait_in_text(".container-fluid h2", "Available Packages")
+        b.wait_in_text(".container-fluid h2", "Available Updates")
         self.assertEqual(b.text("#state"), "2 updates")
 
         b.wait_present("table.listing-ct")
@@ -150,7 +150,7 @@ class TestUpdates(MachineCase):
         m.start_cockpit()
         b.login_and_go("/updates")
         b.wait_present(".container-fluid h2")
-        b.wait_in_text(".container-fluid h2", "Available Packages")
+        b.wait_in_text(".container-fluid h2", "Available Updates")
         self.assertEqual(b.text("#state"), "5 updates, including 2 security fixes")
 
         b.wait_present("table.listing-ct")
@@ -197,7 +197,7 @@ class TestUpdates(MachineCase):
 
         # should have succeeded; 3 non-security updates left
         b.wait_in_text("#state", "3 updates")
-        b.wait_in_text(".container-fluid h2", "Available Packages")
+        b.wait_in_text(".container-fluid h2", "Available Updates")
         b.wait_in_text("table.listing-ct", "norefs-doc")
         self.assertIn("buggy", b.text("table.listing-ct"))
         self.assertNotIn("secdeclare", b.text("table.listing-ct"))
@@ -239,7 +239,7 @@ class TestUpdates(MachineCase):
         m.start_cockpit()
         b.login_and_go("/updates")
         b.wait_present(".container-fluid h2")
-        b.wait_in_text(".container-fluid h2", "Available Packages")
+        b.wait_in_text(".container-fluid h2", "Available Updates")
         self.assertEqual(b.text("#state"), "1 update")
 
         b.wait_present("#app .container-fluid button")
@@ -295,7 +295,7 @@ class TestUpdates(MachineCase):
         b.click(".content-header-extra td button")
 
         b.wait_present(".container-fluid h2")
-        b.wait_in_text(".container-fluid h2", "Available Packages")
+        b.wait_in_text(".container-fluid h2", "Available Updates")
         self.assertEqual(b.text("#state"), "2 updates")
 
         b.wait_present("table.listing-ct")


### PR DESCRIPTION
@garrett worked on some [design updates](https://github.com/cockpit-project/cockpit-design/compare/4aa9713...8ff91cc#commitcomment-22546155) for "Software Updates". This adds a "Cancel" button to applying updates (while it's still safe), fixes the display of "Last checked:", centers and adds spacing to progress bars, and introduces a new state for "Refreshing package information" as that looks quite different and takes much longer than merely loading the list of available updates.

I did not yet move the "refresh packages" progress bar into the header bar as we don't have the "Automatic Updates" configuration bit yet -- thus the main area would be completely empty.