### PR TITLE
bots: Recognize failed items in the checklist

### DIFF
--- a/bots/github/__init__.py
+++ b/bots/github/__init__.py
@@ -331,8 +331,14 @@ class Checklist(object):
         check = item = None
         stripped = line.strip()
         if stripped[:6] in ["* [ ] ", "- [ ] ", "* [x] ", "- [x] "]:
-            item = stripped[6:].strip()
-            check = stripped[3] == "x"
+            status, unused, item = stripped[6:].strip().partition(": ")
+            if not item:
+                item = status
+                status = None
+            if status:
+                check = status
+            else:
+                check = stripped[3] == "x"
         return (item, check)
 
     def process(self, body, items={ }):

--- a/bots/github/test-checklist
+++ b/bots/github/test-checklist
@@ -38,6 +38,8 @@ class TestChecklist(unittest.TestCase):
         self.assertEqual(parse_line(" - [ ]  test two "), ("test two", False))
         self.assertEqual(parse_line(" - [x] test two "), ("test two", True))
         self.assertEqual(parse_line(" * [x] test two"), ("test two", True))
+        self.assertEqual(parse_line(" * [x] FAIL: test two"), ("test two", "FAIL"))
+        self.assertEqual(parse_line(" * [x] FAIL: test FAIL: two"), ("test FAIL: two", "FAIL"))
         self.assertEqual(parse_line(" * [x]test three"), (None, None))
 
     def testFormat(self):


### PR DESCRIPTION
When an item is marked as failed for a github task, make the
GitHub parser recognize it.