### PR TITLE
bots: Load issue title for task if issue specified

### DIFF
--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -242,6 +242,7 @@ def run(context, function, **kwargs):
         elif issue["title"].startswith("WIP:"):
             return "Issue is work in progress: {0}: {1}\n".format(number, issue["title"])
         kwargs["issue"] = issue
+        kwargs["title"] = issue["title"]
 
     publishing = begin(publish, name, context, issue=issue)
 


### PR DESCRIPTION
If an issue is specified, load the title for that issue as the tasks title. This helps fix the setting back of
the title from WIP to an appropriate title when the task completes.

It also helps match the intent that the task is about solving the issue itself.