### PR TITLE
packagekit: Automatically refresh if PackageKit has no local data

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -57,6 +57,9 @@ class TestUpdates(MachineCase):
         # no repositories at all, thus no updates
         b.wait_present(".content-header-extra td button")
         b.wait_in_text("#state", "No updates pending")
+        b.wait_present(".content-header-extra td.text-right span")
+        # PK starts from a blank state, thus should force refresh and set the "time since" to 0
+        self.assertEqual(b.text(".content-header-extra td.text-right span"), "Last checked: a few seconds ago")
         # empty state visible in main area
         b.wait_present(".container-fluid div.blank-slate-pf")
 


### PR DESCRIPTION
The very first time when PackageKit gets used it has no cached package
information, and GetTimeSinceAction(REFRESH_CACHE) == -1 (aka. "large
unsigned number"). Force a refresh in this case to get a proper progress
bar and the "Refreshing.." state, instead of letting PK silently do that
in the background and just show an indefinite spinner for several minutes.

For that, separate the "time since action" check from the GetUpdates()
call, and do that in a new initialLoadOrRefresh() function.

Also fix the displaying of "Last checked:": Update the state after
calling RefreshCache(), and also show it if the number of seconds is 0.

----

This change is on top of #7026, so that needs to land first.

 - [x] land #7026 

@andreasn, @garrett: This fixes the first major issue from yesterday's user testing.