### PR TITLE
test: Don't complain if downloaded directory is empty

### DIFF
--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -494,7 +494,8 @@ class Machine:
         try:
             subprocess.check_call(cmd)
             target = os.path.join(dest, os.path.basename(source))
-            subprocess.check_call([ "find", target, "-type", "f", "-exec", "chmod", "0644", "{}", ";" ])
+            if os.path.exists(target):
+                subprocess.check_call([ "find", target, "-type", "f", "-exec", "chmod", "0644", "{}", ";" ])
         except:
             self.message("Error while downloading directory '{0}'".format(source))
 


### PR DESCRIPTION
We run 'find' on downloaded directories to make the files accessible.
But when they're empty and the scp is a no-op, we shouldn't complain.