### PR TITLE
test: Retry test if failure involved "Operation canceled'

### DIFF
--- a/test/common/phantom-driver.js
+++ b/test/common/phantom-driver.js
@@ -424,10 +424,7 @@ page.onResourceError = function(ex) {
      * Certain resource errors seem to be noise caused by
      * cancelled loads, and racy state in phantomjs
      */
-    if (ex.errorString === "Operation cancelled" ||
-        ex.errorString === "Operation canceled") {
-        prefix = "Ignoring Resource Error: ";
-    } else if (ex.errorString.indexOf("Network access is disabled") !== -1) {
+    if (ex.errorString.indexOf("Network access is disabled") !== -1) {
         sys.stderr.writeLine("ERROR: fatal problem: " + ex.errorString);
         phantom.exit(1);
         process.exit(1);

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -861,6 +861,11 @@ class Policy(object):
         if "PhantomJS or driver broken" in trace:
             return True
 
+        # HACK: A race issue in phantomjs that happens randomly
+        # https://github.com/ariya/phantomjs/issues/12750
+        if "Resource Error: Operation canceled" in trace:
+            return True
+
         # HACK: Interacting with sshd during boot is not always predictable
         # We're using an implementation detail of the server as our "way in" for testing.
         # This often has to do with sshd being restarted for some reason


### PR DESCRIPTION
Every once in a while phantomjs complains about "Operation canceled" on
a resource. Often this is legit, such as unloading an <iframe> that has
not yet finished loading.

However this also just happens due to races in phantomjs, and we see
these as timeout failures. This is particularly true in tests that
test the login screen and reload the screen multiple times, both
failing, and logging in, logging out, rapidly etc.

Retrying these tests a limited number of times is appropriate, rather
than trying to fix the deep hole that is phantomjs.