### PR TITLE
test: Wait for resources in phantom-driver

### DIFF
--- a/test/common/phantom-driver.js
+++ b/test/common/phantom-driver.js
@@ -80,14 +80,17 @@ function inject_basics(loading) {
      */
     var injected = page.evaluate(function(canary, loading) {
         if (loading) {
+            /* A load is not complete until all resources are done */
+	    if (document.readyState !== "complete") {
+                document.addEventListener("readystatechange", function() {
+                    console.log("-*-CHECKPOINT-*-");
+                });
+		return null;
+            }
             if (typeof loading !== "string")
                 loading = window.location.href;
-            if (window.location.href !== loading || document.readyState === "loading") {
-                document.onreadystatechange = function() {
-                    console.log("-*-CHECKPOINT-*-");
-                };
+            if (window.location.href !== loading)
                 return null;
-            }
         }
         return canary in window;
     }, canary, loading || false);


### PR DESCRIPTION
When using phantomjs it seems that often we move to fast and
induce races in its network access code. Lets make things more
predictable by waiting for all resources on the page to load.

In addition this has the benefit of producing debuggable output
for all resources, or troubleshooting cases where an expected
resource just hung.

 - [x] #7061