### PR TITLE
test: Use kubeconfig from openshift image even more

### DIFF
--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -146,7 +146,7 @@ class TestOpenshift(MachineCase, OpenshiftCommonTests):
 
         # Test the saved kube config file
         m.execute("rm /home/admin/.kube/config")
-        m.upload(["verify/files/openshift.kubeconfig"], "/home/admin/.kube/config")
+        m.upload([self.kubeconfig], "/home/admin/.kube/config")
         m.execute("chown -R admin:admin /home/admin/.kube")
 
         self.login_and_go("/kubernetes")


### PR DESCRIPTION
Follow-up to 7192243fbacf46e4ad527e424fe9496812f5dade

There is another place where we need to use the config
from the image instead of uploading the one from the source
tree.