### PR TITLE
test: Update testing matrix

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -20,7 +20,7 @@
 
 BASELINE_PRIORITY = 10
 
-BRANCHES = [ 'master', 'rhel-7.4', 'rhel-7.3.1', 'rhel-7.3.2', 'rhel-7.3.3', 'rhel-7.3.4', 'rhel-7.3.5' ]
+BRANCHES = [ 'master', 'rhel-7.4', 'rhel-7.3.1', 'rhel-7.3.2', 'rhel-7.3.3', 'rhel-7.3.4', 'rhel-7.3.5', 'rhel-7.3.6' ]
 
 DEFAULT_VERIFY = {
     'avocado/fedora-24': BRANCHES,
@@ -34,17 +34,17 @@ DEFAULT_VERIFY = {
     'verify/debian-testing': BRANCHES,
     'verify/fedora-24': [ ],
     'verify/fedora-25': [ ],
-    'verify/fedora-i386': [ 'master', 'rhel-7.4', 'rhel-7.3.5' ],
+    'verify/fedora-i386': [ 'master', 'rhel-7.4', 'rhel-7.3.6', 'rhel-7.3.5' ],
     'verify/fedora-26': [ 'master' ],
     'verify/fedora-atomic': BRANCHES,
     'verify/fedora-testing': [ ],
-    'verify/ubuntu-1604': [ 'master', 'rhel-7.4', 'rhel-7.3.5', 'rhel-7.3.4', 'rhel-7.3.3', 'rhel-7.3.2' ],
+    'verify/ubuntu-1604': [ 'master', 'rhel-7.4', 'rhel-7.3.6', 'rhel-7.3.5', 'rhel-7.3.4', 'rhel-7.3.3', 'rhel-7.3.2' ],
     'verify/ubuntu-stable': [ 'master' ],
 }
 
 # Non-public images used for testing
 REDHAT_VERIFY = {
-    "verify/rhel-7": [ 'master', 'rhel-7.3.5', 'rhel-7.3.4', 'rhel-7.3.3', 'rhel-7.3.2' ],
+    "verify/rhel-7": [ 'master', 'rhel-7.3.6', 'rhel-7.3.5', 'rhel-7.3.4', 'rhel-7.3.3', 'rhel-7.3.2' ],
     "verify/rhel-7-4": [ 'master', 'rhel-7.4' ],
     "verify/rhel-atomic": [ 'master' ],
 }

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -31,14 +31,14 @@ DEFAULT_VERIFY = {
     'verify/centos-7': BRANCHES,
     'verify/continuous-atomic': [ ],
     'verify/debian-stable': [ 'master' ],
-    'verify/debian-testing': BRANCHES,
+    'verify/debian-testing': [ 'master' ],
     'verify/fedora-24': [ ],
     'verify/fedora-25': [ ],
     'verify/fedora-i386': [ 'master', 'rhel-7.4', 'rhel-7.3.6', 'rhel-7.3.5' ],
     'verify/fedora-26': [ 'master' ],
     'verify/fedora-atomic': BRANCHES,
     'verify/fedora-testing': [ ],
-    'verify/ubuntu-1604': [ 'master', 'rhel-7.4', 'rhel-7.3.6', 'rhel-7.3.5', 'rhel-7.3.4', 'rhel-7.3.3', 'rhel-7.3.2' ],
+    'verify/ubuntu-1604': [ 'master' ],
     'verify/ubuntu-stable': [ 'master' ],
 }
 


### PR DESCRIPTION
If we want to test Debian/Ubuntu on RHEL branches, we need to backport a bunch of test fixes. These increase patch file verbosity even though the test failures don't have any impact on users, since the branches aren't used to deliver on Debian/Ubuntu.

- Make the bots aware of the rhel-7.3.6 branch
- Don't test debian/ubuntu on rhel-* branches