### PR TITLE
test: Remove IPv6 support from cockpit1 bridged test network

### DIFF
--- a/test/common/network-cockpit.xml
+++ b/test/common/network-cockpit.xml
@@ -29,5 +29,4 @@
       <host mac='52:54:00:9e:00:FF' ip='10.111.112.115' name='ff.cockpit.lan' cockpit:test="unused"/>
     </dhcp>
   </ip>
-  <ip family="ipv6" address="fd00:111:112::1" prefix="64"/>
 </network>


### PR DESCRIPTION
On Fedora 26 and recent versions of libvirt, we start to see an error
like this:

    error: internal error: Check the host setup: enabling IPv6 forwarding with RA routes without accept_ra set to 2 is likely to cause routes loss. Interfaces to look at: enp3s0

Fixing this correctly requires changing the configuration of the
NIC in the machine running the tests:

    # echo 2 > /proc/sys/net/ipv6/conf/enp3s0/accept_ra

However, our tests don't use IPv6 (yet) and we're migrating away from
the cockpit1 bridge anyway in #6334. So lets just remove IPv6 support
from the cockpit1 network to make this problem go away.