### PR TITLE
shell: Make capitalization in the top right corner menu consistent

### DIFF
--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -64,7 +64,7 @@
                       id="credentials-item" translatable="yes">Authentication</a>
               </li>
               <li>
-                <a id="go-logout" translatable="yes">Log out</a>
+                <a id="go-logout" translatable="yes">Log Out</a>
               </li>
             </ul>
           </li>

--- a/pkg/shell/simple.html
+++ b/pkg/shell/simple.html
@@ -42,7 +42,7 @@
               </li>
               <li class="divider"></li>
               <li>
-                <a id="go-logout" translatable="yes">Log out</a>
+                <a id="go-logout" translatable="yes">Log Out</a>
               </li>
             </ul>
           </li>

--- a/pkg/shell/stub.html
+++ b/pkg/shell/stub.html
@@ -42,7 +42,7 @@
               </li>
               <li class="divider"></li>
               <li>
-                <a id="go-logout" translatable="yes">Log out</a>
+                <a id="go-logout" translatable="yes">Log Out</a>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
Fixes issue #7077