### PR TITLE
sosreport: Fix capitalization in sidebar and button

### DIFF
--- a/pkg/sosreport/index.html
+++ b/pkg/sosreport/index.html
@@ -34,7 +34,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
       <p translatable="yes">This tool will collect system configuration and diagnostic information from this system for use with diagnosing problems with the system.</p>
       <p translatable="yes">The collected information will be stored locally on the system.</p>
       <button translatable="yes" class="btn btn-primary"
-              data-toggle="modal" data-target="#sos">Create report</button>
+              data-toggle="modal" data-target="#sos">Create Report</button>
     </div>
 
     <div class="modal" id="sos" tabindex="-1" role="dialog" data-backdrop="static">

--- a/pkg/sosreport/manifest.json.in
+++ b/pkg/sosreport/manifest.json.in
@@ -6,7 +6,7 @@
 
     "tools": {
         "index": {
-            "label": "Diagnostic reports"
+            "label": "Diagnostic Reports"
         }
     }
 }


### PR DESCRIPTION
Diagnostic Reports in the sidebar was using sentence case
The Create Report button was also using sentence case
In both of these cases it should use headline case, according to Patternfly

Fixes issues #7023 and #7027