### PR TITLE
kdump: fix capitalization of kdump in sidebar

### DIFF
--- a/pkg/kdump/index.html
+++ b/pkg/kdump/index.html
@@ -20,7 +20,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title translatable="yes">Kernel dump configuration</title>
+    <title translatable="yes">Kernel Dump</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/pkg/kdump/manifest.json.in
+++ b/pkg/kdump/manifest.json.in
@@ -6,7 +6,7 @@
 
     "tools": {
         "index": {
-            "label": "Kernel dump configuration"
+            "label": "Kernel Dump"
         }
     }
 }


### PR DESCRIPTION
Unlike all the other items in the sidebar, kdump was using sentence
case, but according to Patternfly guidelines it should use Headline Case

Fixes issue #7024