### PR TITLE
bots: Decrease priority of issue related tasks slightly

### DIFF
--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-PRIORITY = 10
+PRIORITY = 9
 
 NAMES = [
     "example-task",


### PR DESCRIPTION
For tasks described as issues, we decrease their priority
slightly so that they compete with testing rather than
always override it.