### PR TITLE
Test fixes

### DIFF
--- a/test/avocado/selenium-sosreport.py
+++ b/test/avocado/selenium-sosreport.py
@@ -20,7 +20,7 @@ class SosReportingTab(SeleniumTest):
     def test10SosReport(self):
         self.login()
         self.wait_id("sidebar")
-        self.click(self.wait_link('Diagnostic report', cond=clickable))
+        self.click(self.wait_link('Diagnostic Report', cond=clickable))
         self.wait_frame("sosreport")
         self.wait_text("This tool will collect system configuration and diagnostic")
         self.click(self.wait_xpath('//button[@data-target="#sos"]', cond=clickable))

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -268,7 +268,8 @@ class TestMachines(MachineCase):
             b.wait_present("iframe.machines-console-frame-vnc")
             b.switch_to_frame("vm-subVmTest1-novnc-frame-container")
             # FIXME: the usual b.wait_present() does not  work here
-            b.wait(lambda: b.eval_js("document.documentElement.outerHTML.indexOf('noVNC_status_normal') >= 0"))
+            with b.wait_timeout(360):
+                b.wait(lambda: b.eval_js("document.documentElement.outerHTML.indexOf('noVNC_status_normal') >= 0"))
             b.wait(lambda: b.eval_js("document.documentElement.outerHTML.indexOf('Connected (unencrypted) to: QEMU (subVmTest1)') >= 0"))
         else:
             print "WARNING: Test VM creation failed, virt-install finished in 'paused' state. Skipping the 'testInlineConsole' scenario"


### PR DESCRIPTION
The avocado tests are now broken due to the label change (brown paperbag), and I noticed a race in the VM tests in PR #6950 . Setting "priority" for the former.