### PR TITLE
packagekit: Always recommend rebooting after applying updates

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -222,7 +222,7 @@ function UpdatesList(props) {
 class ApplyUpdates extends React.Component {
     constructor() {
         super();
-        this.state = {percentage: null, timeRemaining: null, curStatus: null, curPackage: null};
+        this.state = {percentage: 0, timeRemaining: null, curStatus: null, curPackage: null};
     }
 
     componentDidMount() {
@@ -233,7 +233,7 @@ class ApplyUpdates extends React.Component {
             // info: see PK_STATUS_* at https://github.com/hughsie/PackageKit/blob/master/lib/packagekit-glib2/pk-enum.h
             this.setState({curPackage: pfields[0] + " " + pfields[1],
                            curStatus: info,
-                           percentage: transProxy.Percentage <= 100 ? transProxy.Percentage : null,
+                           percentage: transProxy.Percentage <= 100 ? transProxy.Percentage : 0,
                            timeRemaining: transProxy.RemainingTime > 0 ? transProxy.RemainingTime : null});
         });
     }
@@ -251,23 +251,17 @@ class ApplyUpdates extends React.Component {
         else
             action = _("Initializing...");
 
-        var progressBar;
-        if (this.state.percentage !== null)
-            progressBar = (
-                <div className="progress progress-label-top-right">
-                    <div className="progress-bar" role="progressbar" style={ {width: this.state.percentage + "%"} }>
-                        {this.state.timeRemaining !== null ? <span>{moment.duration(this.state.timeRemaining * 1000).humanize()}</span> : null}
-                    </div>
-                </div>
-            );
-
         return (
             <div className="progress-main-view">
                 <div className="progress-description">
                     <div className="spinner spinner-xs spinner-inline"></div>
                     {action}
                 </div>
-                {progressBar}
+                <div className="progress progress-label-top-right">
+                    <div className="progress-bar" role="progressbar" style={ {width: this.state.percentage + "%"} }>
+                        {this.state.timeRemaining !== null ? <span>{moment.duration(this.state.timeRemaining * 1000).humanize()}</span> : null}
+                    </div>
+                </div>
             </div>
         );
     }

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -263,6 +263,8 @@ class TestUpdates(MachineCase):
         # empty state visible in main area
         b.wait_present(".container-fluid div.blank-slate-pf")
 
+        self.allow_restart_journal_messages()
+
     def testUpdateError(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -114,7 +114,17 @@ class TestUpdates(MachineCase):
         # Cancel button should eventually get disabled
         b.wait_present(".content-header-extra td button:disabled")
 
-        # should have succeeded
+        # should have succeeded and show restart page; cancel
+        b.wait_present("#app .container-fluid h1")
+        b.wait_in_text("#app .container-fluid h1", "Restart Recommended")
+        b.wait_present("#app .container-fluid button.btn-primary")
+        self.assertEqual(b.text("#app .container-fluid button.btn-primary"), "Restart Now")
+        b.wait_present("#app .container-fluid button.btn-default")
+        self.assertEqual(b.text("#app .container-fluid button.btn-default"), "Ignore")
+        b.click("#app .container-fluid button.btn-default")
+
+        # should go back to updates overview, nothing pending any more
+        b.wait_present("#state")
         b.wait_in_text("#state", "No updates pending")
         b.wait_present(".content-header-extra td.text-right span")
         b.wait_in_text(".content-header-extra td.text-right span", "Last checked:")
@@ -198,7 +208,14 @@ class TestUpdates(MachineCase):
         b.wait_in_text("#state", "Applying updates")
         b.wait_present("#app div.progress-bar")
 
+        # should have succeeded and show restart page; cancel
+        b.wait_present("#app .container-fluid h1")
+        b.wait_in_text("#app .container-fluid h1", "Restart Recommended")
+        b.wait_present("#app .container-fluid button.btn-default")
+        b.click("#app .container-fluid button.btn-default")
+
         # should have succeeded; 3 non-security updates left
+        b.wait_present("#state")
         b.wait_in_text("#state", "3 updates")
         b.wait_in_text(".container-fluid h2", "Available Updates")
         b.wait_in_text("table.listing-ct", "norefs-doc")
@@ -218,13 +235,33 @@ class TestUpdates(MachineCase):
         b.wait_in_text("#state", "Applying updates")
         b.wait_present("#app div.progress-bar")
 
-        # should have succeeded
-        b.wait_in_text("#state", "No updates pending")
-        # empty state visible in main area
-        b.wait_present(".container-fluid div.blank-slate-pf")
+        # should have succeeded and show restart
+        b.wait_present("#app .container-fluid h1")
+        b.wait_in_text("#app .container-fluid h1", "Restart Recommended")
+        b.wait_present("#app .container-fluid button.btn-default")
 
         # new versions are now installed
         m.execute("test -f /stamp-norefs-bin-2-1 && test -f /stamp-norefs-doc-2-1")
+
+        # do the reboot; this will disconnect the web UI
+        m.reset_reboot_flag()
+        b.click("#app .container-fluid button.btn-primary")
+        b.switch_to_top()
+        b.wait_present(".curtains-ct")
+        b.wait_visible(".curtains-ct")
+        b.wait_in_text(".curtains-ct h1", "Disconnected")
+
+        # ensure that rebooting actually worked
+        m.wait_reboot()
+        m.start_cockpit()
+        b.reload()
+        b.login_and_go("/updates")
+
+        # no further updates
+        b.wait_present("#state")
+        b.wait_in_text("#state", "No updates pending")
+        # empty state visible in main area
+        b.wait_present(".container-fluid div.blank-slate-pf")
 
     def testUpdateError(self):
         b = self.browser
@@ -287,7 +324,12 @@ class TestUpdates(MachineCase):
         b.wait_in_text("#state", "Applying updates")
         b.wait_present("#app div.progress-bar")
 
-        # should have succeeded
+        # should have succeeded and show restart page; cancel
+        b.wait_present("#app .container-fluid h1")
+        b.wait_in_text("#app .container-fluid h1", "Restart Recommended")
+        b.wait_present("#app .container-fluid button.btn-default")
+        b.click("#app .container-fluid button.btn-default")
+        b.wait_present("#state")
         b.wait_in_text("#state", "No updates pending")
 
         # now pretend that there is a newer cockpit-ws available, warn about disconnect


### PR DESCRIPTION
We currently don't have a reliable way of determining whether updates
need a reboot to fully take effect:

 * PackageKit's API for this is only implemented for Debian-based OSes
   (based on the /run/reboot-required flag), and is only reliable on
   Ubuntu.

 * RHEL/Fedora based OSes don't even restart services on package
   updates, so special-casing the kernel would be a very unsafe
   heuristics.

 * tracer on RHEL/Fedora is not installed by default and can take
   unacceptably long (observed 90 seconds).

During user testing this was one of the top uncertainties, so for now
err on the safe side and always recommend to reboot after applying
updates. This can be refined later (particularly on Ubuntu).

Fixes #7065

 - [x] don't show reboot recommendation after Cancel