### PR TITLE
bots: Make checklist parsing more flexible

### DIFF
--- a/bots/task/github.py
+++ b/bots/task/github.py
@@ -330,7 +330,7 @@ class Checklist(object):
     def parse_line(line):
         check = item = None
         stripped = line.strip()
-        if stripped[:6] in ["* [ ] ", "- [ ] ", "* [x] ", "- [x] "]:
+        if stripped[:6] in ["* [ ] ", "- [ ] ", "* [x] ", "- [x] ", "* [X] ", "- [X] "]:
             status, unused, item = stripped[6:].strip().partition(": ")
             if not item:
                 item = status
@@ -338,7 +338,7 @@ class Checklist(object):
             if status:
                 check = status
             else:
-                check = stripped[3] == "x"
+                check = stripped[3] in ["x", "X"]
         return (item, check)
 
     def process(self, body, items={ }):

--- a/bots/task/test-checklist
+++ b/bots/task/test-checklist
@@ -41,6 +41,11 @@ class TestChecklist(unittest.TestCase):
         self.assertEqual(parse_line(" * [x] FAIL: test two"), ("test two", "FAIL"))
         self.assertEqual(parse_line(" * [x] FAIL: test FAIL: two"), ("test FAIL: two", "FAIL"))
         self.assertEqual(parse_line(" * [x]test three"), (None, None))
+        self.assertEqual(parse_line(" - [X] test two "), ("test two", True))
+        self.assertEqual(parse_line(" * [X] test four"), ("test four", True))
+        self.assertEqual(parse_line(" * [X] FAIL: test four"), ("test four", "FAIL"))
+        self.assertEqual(parse_line(" * [X] FAIL: test FAIL: four"), ("test FAIL: four", "FAIL"))
+        self.assertEqual(parse_line(" * [X]test five"), (None, None))
 
     def testFormat(self):
         format_line = github.Checklist.format_line
@@ -49,17 +54,18 @@ class TestChecklist(unittest.TestCase):
         self.assertEqual(format_line("blah", "FAIL"), " * [ ] FAIL: blah")
 
     def testProcess(self):
-        body = "This is a description\n- [ ] item1\n * [x] Item two\n\nMore lines"
+        body = "This is a description\n- [ ] item1\n * [x] Item two\n * [X] Item three\n\nMore lines"
         checklist = github.Checklist(body)
         self.assertEqual(checklist.body, body)
-        self.assertEqual(checklist.items, { "item1": False, "Item two": True })
+        self.assertEqual(checklist.items, { "item1": False, "Item two": True, "Item three": True })
 
     def testCheck(self):
-        body = "This is a description\n- [ ] item1\n * [x] Item two\n\nMore lines"
+        body = "This is a description\n- [ ] item1\n * [x] Item two\n * [X] Item three\n\nMore lines"
         checklist = github.Checklist(body)
         checklist.check("item1", True)
-        self.assertEqual(checklist.body, "This is a description\n * [x] item1\n * [x] Item two\n\nMore lines")
-        self.assertEqual(checklist.items, { "item1": True, "Item two": True })
+        checklist.check("Item three", False)
+        self.assertEqual(checklist.body, "This is a description\n * [x] item1\n * [x] Item two\n * [ ] Item three\n\nMore lines")
+        self.assertEqual(checklist.items, { "item1": True, "Item two": True, "Item three": False })
 
     def testDisable(self):
         body = "This is a description\n- [ ] item1\n * [x] Item two\n\nMore lines"


### PR DESCRIPTION
GitHub interprets [x] as well as [X] as checked items in lists.
Let the bots code reflect that and add more tests.

Sample:

- [x] checked with `x`
- [X] checked with `X`

Follow-up to #7034 
