### PR TITLE
networkmanager: Hide panel when there's nothing to be shown

### DIFF
--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -582,7 +582,7 @@
         </table>
       </div>
     </div>
-    <div class="panel panel-default" id="network-interface-slaves">
+    <div class="panel panel-default" id="network-interface-slaves" hidden>
       <table class="table table-hover">
         <thead>
           <tr>


### PR DESCRIPTION
Hiding and Showing the slaves chart is already managed on javascript, but when the interface is unavailable the panel will be shown only with the headers.
![capture](https://user-images.githubusercontent.com/3775353/27497537-8045356a-5831-11e7-8cb5-6da5a5738e58.PNG)
(I took this screenshot from the wlan interface from a Raspberry Pi with the wifi radio off)
In this case is better to hide the panel.