### PR TITLE
machines: Don't swallow promise failures

### DIFF
--- a/pkg/machines/libvirt.es6
+++ b/pkg/machines/libvirt.es6
@@ -265,7 +265,7 @@ function spawnVirsh({connectionName, method, failHandler, args}) {
         cmd: 'virsh',
         args: VMS_CONFIG.Virsh.connections[connectionName].params.concat(args),
         failHandler,
-    }).catch((ex, data, output) => {
+    }).fail((ex, data, output) => {
         const msg = `${method}() exception: '${ex}', data: '${data}', output: '${output}'`;
         if (failHandler) {
             logDebug(msg);

--- a/pkg/machines/provider.es6
+++ b/pkg/machines/provider.es6
@@ -111,15 +111,17 @@ function getVirtProvider (store) {
  * Lazily initializes the virt provider and dispatches given method on it.
  */
 export function virt(method, action) {
-    return (dispatch, getState) => getVirtProvider({dispatch, getState}).then(provider => {
+    return (dispatch, getState) => getVirtProvider({dispatch, getState}).fail(err => {
+        console.error('could not detect any virt provider');
+    }).then(provider => {
         if (method in provider) {
             logDebug(`Calling ${provider.name}.${method}`, action);
             return dispatch(provider[method](action));
         } else {
-            console.warn(`method: '${method}' is not supported by provider: '${provider.name}'`);
+            var msg = `method: '${method}' is not supported by provider: '${provider.name}'`;
+            console.warn(msg);
+            return cockpit.reject(msg);
         }
-    }).catch(err => {
-        console.error('could not detect any virt provider');
     });
 }
 


### PR DESCRIPTION
This makes it possible to use the promises returned by the asynchronous
actions.

This uses 'fail' instead of 'catch'.  Also, intercept the getProvider
errors only and not errors from the actual action as well.