### PR TITLE
Use the main react-lite instead of our fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "patternfly-bootstrap-combobox": "1.1.7",
     "qunit-tap": "1.5.1",
     "qunitjs": "1.23.1",
-    "react-lite-cockpit": "0.15.6",
+    "react-lite": "0.15.30",
     "redux": "3.5.2",
     "registry-image-widgets": "git+https://github.com/petervo/registry-image-widgets.git#0.0.4-package",
     "requirejs": "2.1.16",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -386,7 +386,7 @@ var aliases = {
     "angular-route": "angular-route/angular-route.js",
     "d3": "d3/d3.js",
     "moment": "moment/moment.js",
-    "react": "react-lite-cockpit/dist/react-lite.js",
+    "react": "react-lite/dist/react-lite.js",
     "term": "term.js-cockpit/src/term.js",
 };
 


### PR DESCRIPTION
Use the main react-lite code base instead of our fork. We don't
need either of the pull requests in our fork.

https://github.com/cockpit-project/react-lite