### PR TITLE
machines: Split out usage stats polling

### DIFF
--- a/pkg/machines/actions.es6
+++ b/pkg/machines/actions.es6
@@ -116,60 +116,17 @@ export function setRefreshInterval(refreshInterval) {
     };
 }
 
-export function updateOrAddVm({ id, name, connectionName,
-    state,
-    osType,
-    fqdn,
-    uptime,
-    currentMemory,
-    rssMemory,
-    vcpus,
-    autostart,
-    actualTimeInMs,
-    cpuTime,
-    disks,
-    emulatedMachine,
-    cpuModel,
-    bootOrder,
-    displays,
-    }) {
-    const vm = {};
-
-    if (id !== undefined) vm.id = id;
-    if (name !== undefined) vm.name = name;
-    if (connectionName !== undefined) vm.connectionName = connectionName;
-    if (state !== undefined) vm.state = state;
-    if (osType !== undefined) vm.osType = osType;
-    if (currentMemory !== undefined) vm.currentMemory = currentMemory;
-    if (rssMemory !== undefined) vm.rssMemory = rssMemory;
-    if (vcpus !== undefined) vm.vcpus = vcpus;
-    if (fqdn !== undefined) vm.fqdn = fqdn;
-    if (uptime !== undefined) vm.uptime = uptime;
-    if (autostart !== undefined) vm.autostart = autostart;
-    if (disks !== undefined) vm.disks = disks;
-    if (emulatedMachine !== undefined) vm.emulatedMachine = emulatedMachine;
-    if (cpuModel !== undefined) vm.cpuModel = cpuModel;
-    if (bootOrder !== undefined) vm.bootOrder = bootOrder;
-    if (displays !== undefined) vm.displays = displays;
-
-    if (actualTimeInMs !== undefined) vm.actualTimeInMs = actualTimeInMs;
-    if (cpuTime !== undefined) vm.cpuTime = cpuTime;
-
+export function updateOrAddVm(props) {
     return {
         type: 'UPDATE_ADD_VM',
-        vm
+        vm: props
     };
 }
 
-export function updateVmDisksStats({ id, name, connectionName, disksStats }) {
+export function updateVm(props) {
     return {
-        type: 'UPDATE_VM_DISK_STATS',
-        payload: {
-            id,
-            name,
-            connectionName,
-            disksStats,
-        }
+        type: 'UPDATE_VM',
+        vm: props
     };
 }
 

--- a/pkg/machines/actions.es6
+++ b/pkg/machines/actions.es6
@@ -71,6 +71,14 @@ export function vmDesktopConsole(vm, consoleDetail) {
     return virt('CONSOLE_VM', { name: vm.name, id: vm.id, connectionName: vm.connectionName, consoleDetail });
 }
 
+export function usageStartPolling(vm) {
+    return virt('USAGE_START_POLLING', { name: vm.name, id: vm.id, connectionName: vm.connectionName });
+}
+
+export function usageStopPolling(vm) {
+    return virt('USAGE_STOP_POLLING', { name: vm.name, id: vm.id, connectionName: vm.connectionName });
+}
+
 /**
  * Delay call of polling action.
  *
@@ -83,6 +91,7 @@ export function vmDesktopConsole(vm, consoleDetail) {
  * and scheduled on later.
  *
  * @param action I.e. getAllVms()
+ * @param timeout Non-default timeout
  */
 export function delayPolling(action, timeout) {
     return (dispatch, getState) => {

--- a/pkg/machines/helpers.es6
+++ b/pkg/machines/helpers.es6
@@ -192,7 +192,7 @@ export function fileDownload ({ data, fileName = 'myFile.dat', mimeType = 'appli
     window.setTimeout(() => { // give phantomJS time ...
         logDebug('removing temporary A.HREF for filedownload');
         document.body.removeChild(a);
-    }, 500);
+    }, 5000);
     return true;
 }
 

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -19,7 +19,8 @@
  */
 import cockpit from 'cockpit';
 import React, { PropTypes } from "react";
-import { shutdownVm, forceVmOff, forceRebootVm, rebootVm, startVm } from "./actions.es6";
+import { shutdownVm, forceVmOff, forceRebootVm, rebootVm, startVm,
+         usageStartPolling, usageStopPolling } from "./actions.es6";
 import { rephraseUI, logDebug, toGigaBytes, toFixedPrecision, vmId } from "./helpers.es6";
 import DonutChart from "./c3charts.jsx";
 import { Listing, ListingRow } from "cockpit-components-listing.jsx";
@@ -314,75 +315,89 @@ VmOverviewTab.propTypes = {
     config: PropTypes.object.isRequired,
 }
 
-const VmUsageTab = ({ vm }) => {
-    const width = 220;
-    const height = 170;
-
-    const rssMem = vm["rssMemory"] ? vm["rssMemory"] : 0; // in KiB
-    const memTotal = vm["currentMemory"] ? vm["currentMemory"] : 0; // in KiB
-    let available = memTotal - rssMem; // in KiB
-    available = available < 0 ? 0 : available;
-
-    const totalCpus = vm['vcpus'] > 0 ? vm['vcpus'] : 0;
-    // 4 CPU system can have usage 400%, let's keep % between 0..100
-    let cpuUsage = vm['cpuUsage'] / (totalCpus > 0 ? totalCpus : 1);
-    cpuUsage = isNaN(cpuUsage) ? 0 : cpuUsage;
-    cpuUsage = toFixedPrecision(cpuUsage, 1);
-
-    logDebug(`VmUsageTab.render(): rssMem: ${rssMem} KiB, memTotal: ${memTotal} KiB, available: ${available} KiB, totalCpus: ${totalCpus}, cpuUsage: ${cpuUsage}`);
-
-    const memChartData = {
-        columns: [
-            [_("Used"), toGigaBytes(rssMem, 'KiB')],
-            [_("Available"), toGigaBytes(available, 'KiB')]
-        ],
-        groups: [
-            ["used", "available"]
-        ],
-        order: null
-    };
-
-    const cpuChartData = {
-        columns: [
-            [_("Used"), cpuUsage],
-            [_("Available"), 100.0 - cpuUsage]
-        ],
-        groups: [
-            ["used", "available"]
-        ],
-        order: null
-    };
-
-    const chartSize = {
-        width, // keep the .usage-donut-caption CSS in sync
-        height
+class VmUsageTab extends React.Component {
+    componentDidMount() {
+        this.props.onUsageStartPolling();
     }
 
-    return (<table>
-            <tr>
-                <td>
-                    <DonutChart data={memChartData} size={chartSize} width='8' tooltipText=' '
-                                primaryTitle={toGigaBytes(rssMem, 'KiB')} secondaryTitle='GB'
-                                caption={`used from ${cockpit.format_bytes(memTotal * 1024)} memory`}/>
-                </td>
+    componentWillUnmount() {
+        this.props.onUsageStopPolling();
+    }
 
-                <td>
-                    <DonutChart data={cpuChartData} size={chartSize} width='8' tooltipText=' '
-                                primaryTitle={cpuUsage} secondaryTitle='%'
-                                caption={`used from ${totalCpus} vCPUs`}/>
-                </td>
-            </tr>
-        </table>
+    render() {
+        const vm = this.props.vm;
+        const width = 220;
+        const height = 170;
 
-    );
-};
+        const rssMem = vm["rssMemory"] ? vm["rssMemory"] : 0; // in KiB
+        const memTotal = vm["currentMemory"] ? vm["currentMemory"] : 0; // in KiB
+        let available = memTotal - rssMem; // in KiB
+        available = available < 0 ? 0 : available;
+
+        const totalCpus = vm['vcpus'] > 0 ? vm['vcpus'] : 0;
+        // 4 CPU system can have usage 400%, let's keep % between 0..100
+        let cpuUsage = vm['cpuUsage'] / (totalCpus > 0 ? totalCpus : 1);
+        cpuUsage = isNaN(cpuUsage) ? 0 : cpuUsage;
+        cpuUsage = toFixedPrecision(cpuUsage, 1);
+
+        logDebug(`VmUsageTab.render(): rssMem: ${rssMem} KiB, memTotal: ${memTotal} KiB, available: ${available} KiB, totalCpus: ${totalCpus}, cpuUsage: ${cpuUsage}`);
+
+        const memChartData = {
+            columns: [
+                [_("Used"), toGigaBytes(rssMem, 'KiB')],
+                [_("Available"), toGigaBytes(available, 'KiB')]
+            ],
+            groups: [
+                ["used", "available"]
+            ],
+            order: null
+        };
+
+        const cpuChartData = {
+            columns: [
+                [_("Used"), cpuUsage],
+                [_("Available"), 100.0 - cpuUsage]
+            ],
+            groups: [
+                ["used", "available"]
+            ],
+            order: null
+        };
+
+        const chartSize = {
+            width, // keep the .usage-donut-caption CSS in sync
+            height
+        }
+
+        return (<table>
+                <tr>
+                    <td>
+                        <DonutChart data={memChartData} size={chartSize} width='8' tooltipText=' '
+                                    primaryTitle={toGigaBytes(rssMem, 'KiB')} secondaryTitle='GB'
+                                    caption={`used from ${cockpit.format_bytes(memTotal * 1024)} memory`}/>
+                    </td>
+
+                    <td>
+                        <DonutChart data={cpuChartData} size={chartSize} width='8' tooltipText=' '
+                                    primaryTitle={cpuUsage} secondaryTitle='%'
+                                    caption={`used from ${totalCpus} vCPUs`}/>
+                    </td>
+                </tr>
+            </table>
+
+        );
+    }
+}
 VmUsageTab.propTypes = {
-    vm: React.PropTypes.object.isRequired
+    vm: React.PropTypes.object.isRequired,
+    onUsageStartPolling: PropTypes.func.isRequired,
+    onUsageStopPolling: PropTypes.func.isRequired,
 };
 
 /** One VM in the list (a row)
  */
-const Vm = ({ vm, config, onStart, onShutdown, onForceoff, onReboot, onForceReboot, dispatch }) => {
+const Vm = ({ vm, config, onStart, onShutdown, onForceoff, onReboot, onForceReboot,
+              onUsageStartPolling, onUsageStopPolling, dispatch }) => {
     const stateIcon = (<StateIcon state={vm.state} config={config} valueId={`${vmId(vm.name)}-state`} />);
 
     const disksTabName = (<div id={`${vmId(vm.name)}-disks`}>{_("Disks")}</div>);
@@ -390,7 +405,7 @@ const Vm = ({ vm, config, onStart, onShutdown, onForceoff, onReboot, onForceRebo
 
     let tabRenderers = [
         {name: _("Overview"), renderer: VmOverviewTab, data: {vm: vm, config: config }},
-        {name: _("Usage"), renderer: VmUsageTab, data: {vm: vm}, presence: 'onlyActive' },
+        {name: _("Usage"), renderer: VmUsageTab, data: {vm, onUsageStartPolling, onUsageStopPolling}, presence: 'onlyActive' },
         {name: disksTabName, renderer: VmDisksTab, data: {vm: vm, provider: config.provider}, presence: 'onlyActive' },
         {name: consolesTabName, renderer: GraphicsConsole, data: { vm, config, dispatch }}
     ];
@@ -428,6 +443,8 @@ Vm.propTypes = {
     onForceoff: PropTypes.func.isRequired,
     onReboot: PropTypes.func.isRequired,
     onForceReboot: PropTypes.func.isRequired,
+    onUsageStartPolling: PropTypes.func.isRequired,
+    onUsageStopPolling: PropTypes.func.isRequired,
     dispatch: PropTypes.func.isRequired,
 };
 
@@ -455,6 +472,8 @@ const HostVmsList = ({ vms, config, dispatch }) => {
                         onForceReboot={() => dispatch(forceRebootVm(vm))}
                         onShutdown={() => dispatch(shutdownVm(vm))}
                         onForceoff={() => dispatch(forceVmOff(vm))}
+                        onUsageStartPolling={() => dispatch(usageStartPolling(vm))}
+                        onUsageStopPolling={() => dispatch(usageStopPolling(vm))}
                         dispatch={dispatch}
                     />);
             })}

--- a/pkg/machines/libvirt.es6
+++ b/pkg/machines/libvirt.es6
@@ -25,12 +25,12 @@ import cockpit from 'cockpit';
 import $ from 'jquery';
 
 import { updateOrAddVm,
+    updateVm,
     getVm,
     getAllVms,
     delayPolling,
     deleteUnlistedVMs,
     vmActionFailed,
-    updateVmDisksStats
 } from './actions.es6';
 
 import { spawnScript, spawnProcess } from './services.es6';
@@ -524,9 +524,9 @@ function parseDominfo(dispatch, connectionName, name, domInfo) {
     const autostart = getValueFromLine(lines, 'Autostart:');
 
     if (!LIBVIRT_PROVIDER.isRunning(state)) { // clean usage data
-        dispatch(updateOrAddVm({connectionName, name, state, autostart, actualTimeInMs: -1}));
+        dispatch(updateVm({connectionName, name, state, autostart, actualTimeInMs: -1}));
     } else {
-        dispatch(updateOrAddVm({connectionName, name, state, autostart}));
+        dispatch(updateVm({connectionName, name, state, autostart}));
     }
 
     return state;
@@ -538,7 +538,7 @@ function parseDommemstat(dispatch, connectionName, name, dommemstat) {
     let rssMemory = getValueFromLine(lines, 'rss'); // in KiB
 
     if (rssMemory) {
-        dispatch(updateOrAddVm({connectionName, name, rssMemory}));
+        dispatch(updateVm({connectionName, name, rssMemory}));
     }
 }
 
@@ -551,11 +551,10 @@ function parseDomstats(dispatch, connectionName, name, domstats) {
     // TODO: Add network usage statistics
 
     if (cpuTime) {
-        dispatch(updateOrAddVm({connectionName, name, actualTimeInMs, cpuTime}));
+        dispatch(updateVm({connectionName, name, actualTimeInMs, cpuTime}));
     }
 
-   dispatch(updateVmDisksStats({connectionName, name,
-       disksStats: parseDomstatsForDisks(lines)}));
+   dispatch(updateVm({connectionName, name, disksStats: parseDomstatsForDisks(lines)}));
 }
 
 function parseDomstatsForDisks(domstatsLines) {

--- a/pkg/machines/provider.es6
+++ b/pkg/machines/provider.es6
@@ -22,7 +22,7 @@ import cockpit from 'cockpit';
 import React from 'react';
 
 import { logDebug } from './helpers.es6';
-import { setProvider, delayPolling, getAllVms, deleteUnlistedVMs, updateOrAddVm } from './actions.es6';
+import { setProvider, delayPolling, getAllVms, deleteUnlistedVMs, updateVm, updateOrAddVm } from './actions.es6';
 
 import Store from './store.es6';
 import { Listing, ListingRow } from "cockpit-components-listing.jsx";
@@ -124,6 +124,7 @@ function exportedActionCreators () {
         virtMiddleware: virt,
         delayRefresh: () => delayPolling(getAllVms()),
         deleteUnlistedVMs: deleteUnlistedVMs,
+        updateVm: updateVm,
         updateOrAddVm: updateOrAddVm,
     };
 }

--- a/pkg/machines/reducers.es6
+++ b/pkg/machines/reducers.es6
@@ -214,10 +214,9 @@ function timeSampleUsageData(newVmRecord, previousVmRecord) {
             return;
         } else {
             logDebug(`timeSampleUsageData(): can't compute diff - missing previous record`);
+            newVmRecord.cpuUsage = 0;
         }
     }
-
-    newVmRecord.cpuUsage = 0;
 }
 
 export default combineReducers({

--- a/pkg/machines/reducers.es6
+++ b/pkg/machines/reducers.es6
@@ -145,28 +145,27 @@ function vms(state, action) {
                 return [...state, action.vm];
             }
 
-            let updatedVm;
-            if (action.vm['actualTimeInMs'] < 0) { // clear the usage data (i.e. VM went down)
-                logDebug(`Clearing usage data for vm '${action.vm.name}'`);
-                updatedVm = Object.assign({}, state[index], action.vm);
-                clearUsageData(updatedVm);
-            } else {
-                timeSampleUsageData(action.vm, state[index]);
-                updatedVm = Object.assign({}, state[index], action.vm);
-            }
-
+            const updatedVm = Object.assign({}, state[index], action.vm);
             return replaceVm({ state, updatedVm, index });
         }
-        case 'UPDATE_VM_DISK_STATS':
+        case 'UPDATE_VM':
         {
-            const indexedVm = findVmToUpdate(state, action.payload);
+            const indexedVm = findVmToUpdate(state, action.vm);
             if (!indexedVm) {
                 return state;
             }
 
-            // replace whole object, disk statistics are read at once
-            const updatedVm = Object.assign(indexedVm.vmCopy, {disksStats: action.payload.disksStats});
+            let updatedVm;
+            if (action.vm['actualTimeInMs'] < 0) { // clear the usage data (i.e. VM went down)
+                logDebug(`Clearing usage data for vm '${action.vm.name}'`);
+                updatedVm = Object.assign(indexedVm.vmCopy, action.vm);
+                clearUsageData(updatedVm);
+            } else {
+                timeSampleUsageData(action.vm, indexedVm.vmCopy);
+                updatedVm = Object.assign(indexedVm.vmCopy, action.vm);
+            }
 
+            // replace whole object
             return replaceVm({ state, updatedVm, index: indexedVm.index });
         }
         case 'VM_ACTION_FAILED': {

--- a/pkg/machines/selectors.es6
+++ b/pkg/machines/selectors.es6
@@ -27,3 +27,12 @@
 export function getRefreshInterval(state) {
     return state.config.refreshInterval;
 }
+
+export function usagePollingEnabled(state, name, connectionName) {
+    for (var i = 0; i < state.vms.length; i++) {
+        let vm = state.vms[i];
+        if (vm.connectionName === connectionName && vm.name === name)
+            return vm.usagePolling;
+    }
+    return false; // VM got undefined
+}


### PR DESCRIPTION
Polling is legitimate for the RAM/CPU usage, but it only needs to be
done for those VMs which have the "Usage" tab open. So move the "virsh
domstats" and "virsh dommemstat" into a usage{Start,Stop)Polling() API
and call these in VmUsageTab (it has presence: 'onlyActive' already).

Extend the delayPolling() API to accept a VM name to do a VM specific
polling loop, which can check if polling is enabled for that VM, and if
that VM still exists in the first place.

 - [x] fix CPU usage
 - [x] add new `updateVm()` to set polling flag to avoid race condition