### PR TITLE
bots: Fix SOS report relabelto naughty directive

### DIFF
--- a/bots/naughty/fedora-25/6493-selinux-sosreport-relabelto
+++ b/bots/naughty/fedora-25/6493-selinux-sosreport-relabelto
@@ -1,1 +1,1 @@
-Error: audit: type=1400.*avc:  denied  { relabelto } for * comm="sosreport"
+Error: audit: type=1400*avc:  denied  { relabelto } for * comm="sosreport"


### PR DESCRIPTION
There was a typo here. We're using glob style matching.