### PR TITLE
bots: Add another naughty issue for pcp libraries crashing

### DIFF
--- a/bots/naughty/fedora-26/6108-pcp-pmfindprofile-crash-4
+++ b/bots/naughty/fedora-26/6108-pcp-pmfindprofile-crash-4
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+*
+  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
+*
+Error: /usr/*/cockpit-pcp: bridge was killed: 5


### PR DESCRIPTION
Error: /usr/libexec/cockpit-pcp: bridge was killed: 5