### PR TITLE
machines: Replace state polling with event handling

### DIFF
--- a/pkg/machines/actions.es6
+++ b/pkg/machines/actions.es6
@@ -151,6 +151,15 @@ export function vmActionFailed({ name, connectionName, message, detail}) {
     };
 }
 
+export function undefineVm(connectionName, name, transientOnly) {
+    return {
+        type: 'UNDEFINE_VM',
+        name,
+        connectionName,
+        transientOnly
+    };
+}
+
 export function deleteUnlistedVMs(connectionName, vmNames) {
     return {
         type: 'DELETE_UNLISTED_VMS',

--- a/pkg/machines/libvirt.es6
+++ b/pkg/machines/libvirt.es6
@@ -29,6 +29,7 @@ import { updateOrAddVm,
     getVm,
     getAllVms,
     delayPolling,
+    undefineVm,
     deleteUnlistedVMs,
     vmActionFailed,
 } from './actions.es6';
@@ -139,7 +140,10 @@ LIBVIRT_PROVIDER = {
     GET_ALL_VMS ({ connectionName }) {
         logDebug(`${this.name}.GET_ALL_VMS(connectionName='${connectionName}'):`);
         if (connectionName) {
-            return dispatch => doGetAllVms(dispatch, connectionName);
+            return dispatch => {
+                startEventMonitor(dispatch, connectionName);
+                doGetAllVms(dispatch, connectionName);
+            };
         }
 
         return dispatch => { // for all connections
@@ -151,10 +155,7 @@ LIBVIRT_PROVIDER = {
                         connectionName => canLoggedUserConnectSession(connectionName, loggedUser))
                     .map(connectionName => dispatch(getAllVms(connectionName)));
 
-                return cockpit.all(promises)
-                    .then(() => { // keep polling AFTER all VM details have been read (avoid overlap)
-                        dispatch(delayPolling(getAllVms()));
-                    });
+                return cockpit.all(promises);
             });
         };
     },
@@ -619,6 +620,92 @@ function doUsagePolling (name, connectionName) {
                     parseDomstats(dispatch, connectionName, name, domstats);
             }).then(() => dispatch(delayPolling(doUsagePolling(name, connectionName), null, name, connectionName)));
     };
+}
+
+function handleEvent(dispatch, connectionName, line) {
+    // example lines, some with detail, one without:
+    // event 'reboot' for domain sid-lxde
+    // event 'lifecycle' for domain sid-lxde: Shutdown Finished
+    // event 'device-removed' for domain green: virtio-disk2
+    const eventRe = /event '([a-z-]+)' .* domain ([^:]+)(?:: (.*))?$/;
+
+    var match = eventRe.exec(line);
+    if (!match) {
+        console.warn("Unable to parse event, ignoring:", line);
+        return;
+    }
+    var [event_, name, info] = match.slice(1);
+
+    logDebug(`handleEvent(${connectionName}): domain ${name}: got event ${event_}; details: ${info}`);
+
+    // types and details: https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainEventID
+    switch (event_) {
+        case 'lifecycle':
+            let type = info.split(' ')[0];
+            switch (type) {
+                case 'Undefined':
+                    dispatch(undefineVm(connectionName, name));
+                    break;
+
+                case 'Defined':
+                case 'Started':
+                    dispatch(getVm(connectionName, name));
+                    break;
+
+                case 'Stopped':
+                    dispatch(updateVm({connectionName, name, state: 'shut off', actualTimeInMs: -1}));
+                    // transient VMs don't have a separate Undefined event, so remove them on stop
+                    dispatch(undefineVm(connectionName, name, true));
+                    break;
+
+                case 'Suspended':
+                    dispatch(updateVm({connectionName, name, state: 'paused'}));
+                    break;
+
+                case 'Resumed':
+                    dispatch(updateVm({connectionName, name, state: 'running'}));
+                    break;
+
+                default:
+                    logDebug(`Unhandled lifecycle event type ${type} in event: ${line}`);
+            }
+            break;
+
+        case 'metadata-change':
+        case 'device-added':
+        case 'device-removed':
+        case 'disk-change':
+        case 'tray-change':
+        case 'control-error':
+            // these (can) change what we display, so re-read the state
+            dispatch(getVm(connectionName, name));
+            break;
+
+        default:
+            logDebug(`handleEvent ${connectionName} ${name}: ignoring event ${line}`);
+    }
+}
+
+function startEventMonitor(dispatch, connectionName) {
+    var output_buf = '';
+
+    // set up event monitor for that connection; force PTY as otherwise the buffering
+    // will not show every line immediately
+    cockpit.spawn(['virsh'].concat(VMS_CONFIG.Virsh.connections[connectionName].params).concat(['-r', 'event', '--all', '--loop']), {'err': 'message', 'pty': true})
+        .stream(data => {
+            // buffer and line-split the output, there is no guarantee that we always get whole lines
+            output_buf += data;
+            let lines = output_buf.split('\n');
+            while (lines.length > 1)
+                handleEvent(dispatch, connectionName, lines.shift().trim());
+            output_buf = lines[0];
+        })
+        .fail(ex => {
+            // this usually happens if libvirtd gets stopped or isn't running; retry connecting every 10s
+            console.log("virsh event failed:", ex);
+            dispatch(deleteUnlistedVMs(connectionName, []));
+            dispatch(delayPolling(getAllVms(connectionName)));
+        });
 }
 
 export default LIBVIRT_PROVIDER;

--- a/pkg/machines/libvirt.es6
+++ b/pkg/machines/libvirt.es6
@@ -522,11 +522,12 @@ function parseDominfo(dispatch, connectionName, name, domInfo) {
     const lines = parseLines(domInfo);
     const state = getValueFromLine(lines, 'State:');
     const autostart = getValueFromLine(lines, 'Autostart:');
+    const persistent = getValueFromLine(lines, 'Persistent:') == 'yes';
 
     if (!LIBVIRT_PROVIDER.isRunning(state)) { // clean usage data
-        dispatch(updateVm({connectionName, name, state, autostart, actualTimeInMs: -1}));
+        dispatch(updateVm({connectionName, name, state, autostart, persistent, actualTimeInMs: -1}));
     } else {
-        dispatch(updateVm({connectionName, name, state, autostart}));
+        dispatch(updateVm({connectionName, name, state, persistent, autostart}));
     }
 
     return state;

--- a/pkg/machines/provider.es6
+++ b/pkg/machines/provider.es6
@@ -22,7 +22,7 @@ import cockpit from 'cockpit';
 import React from 'react';
 
 import { logDebug } from './helpers.es6';
-import { setProvider, delayPolling, getAllVms, deleteUnlistedVMs, updateVm, updateOrAddVm } from './actions.es6';
+import { setProvider, delayPolling, getAllVms, undefineVm, deleteUnlistedVMs, updateVm, updateOrAddVm } from './actions.es6';
 
 import Store from './store.es6';
 import { Listing, ListingRow } from "cockpit-components-listing.jsx";
@@ -123,6 +123,7 @@ function exportedActionCreators () {
     return {
         virtMiddleware: virt,
         delayRefresh: () => delayPolling(getAllVms()),
+        undefineVm: undefineVm,
         deleteUnlistedVMs: deleteUnlistedVMs,
         updateVm: updateVm,
         updateOrAddVm: updateOrAddVm,

--- a/pkg/machines/reducers.es6
+++ b/pkg/machines/reducers.es6
@@ -179,6 +179,12 @@ function vms(state, action) {
 
             return replaceVm({ state, updatedVm, index: indexedVm.index });
         }
+        case 'UNDEFINE_VM':
+        {
+            return state
+                .filter(vm => (action.connectionName !== vm.connectionName || action.name != vm.name ||
+                               (action.transientOnly && vm.persistent)));
+        }
         case 'DELETE_UNLISTED_VMS':
         {
             return state


### PR DESCRIPTION
Use "virsh event" instead of polling the enumeration and state of machines.

 - [x] land #7131
 - [x] line buffering
 - [x] fix test/verify/check-machines TestMachines.testDisks -stv
 - [x] land #7154 for covering additional features in tests
 - [x] handle paused/unpaused events