### PR TITLE
dashboard: Reduce dependency to cockpit 138

### DIFF
--- a/pkg/dashboard/manifest.json.in
+++ b/pkg/dashboard/manifest.json.in
@@ -1,7 +1,7 @@
 {
     "version": "@VERSION@",
     "requires": {
-	"cockpit": "138.x"
+	"cockpit": "138"
     },
 
     "dashboard": {

--- a/pkg/ssh/manifest.json.in
+++ b/pkg/ssh/manifest.json.in
@@ -1,7 +1,7 @@
 {
     "version": "@VERSION@",
     "requires": {
-        "cockpit": "138.x"
+        "cockpit": "138"
     },
     "priority": 100,
     "bridges": [


### PR DESCRIPTION
The dashboard and ssh technically require 138 plus patches,
but downstream version 138 is already patched.

In Fedora we've had plenty of updates since then and we don't
want to run into this issue with each rebase.

- [ ] confirm this works downstream