### PR TITLE
backport: 7.4-extras branch

### DIFF
--- a/pkg/dashboard/manifest.json.in
+++ b/pkg/dashboard/manifest.json.in
@@ -1,7 +1,7 @@
 {
     "version": "@VERSION@",
     "requires": {
-	"cockpit": "138.x"
+	"cockpit": "138"
     },
 
     "dashboard": {

--- a/pkg/ssh/manifest.json.in
+++ b/pkg/ssh/manifest.json.in
@@ -1,7 +1,7 @@
 {
     "version": "@VERSION@",
     "requires": {
-        "cockpit": "138.x"
+        "cockpit": "138"
     },
     "priority": 100,
     "bridges": [

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -626,6 +626,10 @@ class MachineCase(unittest.TestCase):
         'Error was encountered while opening journal files:.*',
         'Failed to get data: Cannot assign requested address',
 
+        # HACK https://bugzilla.redhat.com/show_bug.cgi?id=1461893
+        # selinux errors while logging in via ssh
+        'type=1401 audit(.*): op=security_compute_av reason=bounds .* tclass=process perms=transition.*',
+
         # Various operating systems see this from time to time
         "Journal file.*truncated, ignoring file.",
     ]


### PR DESCRIPTION
Two commits we need downstream:

- ssh hookup channel callbacks
- dashboard/ssh dependencies

The dependencies need to be changed, because the necessary patches beyond 138 are included in the downstream 138 release.