### PR TITLE
common: Don't assume that SIGUNUSED is always available

### DIFF
--- a/src/common/cockpitunixsignal.c
+++ b/src/common/cockpitunixsignal.c
@@ -92,7 +92,7 @@ struct signv {
   { "LOST",     SIGLOST },      /* 29 (arm,i386,m68k,ppc,sparc*) */
 #endif
   { "PWR",      SIGPWR },       /* 30 (arm,i386,m68k,ppc), 29 (alpha,sparc*), 19 (mips) */
-#ifndef _MIPS_ARCH
+#ifdef SIGUNUSED
   { "UNUSED",   SIGUNUSED },    /* 31 (arm,i386,m68k,ppc) */
 #endif
   { "SYS",      SIGSYS },       /* 31 (mips,alpha,sparc*) */


### PR DESCRIPTION
According to signal(7), SIGUNUSED is not guaranteed to be defined, and
indeed was dropped from glibc 2.25.90 (in Fedora Rawhide). Protect its
usage with an #ifdef to unbreak the build there.

On platforms where it's not defined there is no harm:
cockpit_strsignal() will then just use SIGSYS which is always defined
and an alias for SIGUNUSED.

Fixes #7142