### PR TITLE
Add tests for more Machines functionality and fix test bugs

### DIFF
--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -400,12 +400,13 @@ const Vm = ({ vm, config, onStart, onShutdown, onForceoff, onReboot, onForceRebo
               onUsageStartPolling, onUsageStopPolling, dispatch }) => {
     const stateIcon = (<StateIcon state={vm.state} config={config} valueId={`${vmId(vm.name)}-state`} />);
 
+    const usageTabName = (<div id={`${vmId(vm.name)}-usage`}>{_("Usage")}</div>);
     const disksTabName = (<div id={`${vmId(vm.name)}-disks`}>{_("Disks")}</div>);
     const consolesTabName = (<div id={`${vmId(vm.name)}-consoles`}>{_("Console")}</div>);
 
     let tabRenderers = [
         {name: _("Overview"), renderer: VmOverviewTab, data: {vm: vm, config: config }},
-        {name: _("Usage"), renderer: VmUsageTab, data: {vm, onUsageStartPolling, onUsageStopPolling}, presence: 'onlyActive' },
+        {name: usageTabName, renderer: VmUsageTab, data: {vm, onUsageStartPolling, onUsageStopPolling}, presence: 'onlyActive' },
         {name: disksTabName, renderer: VmDisksTab, data: {vm: vm, provider: config.provider}, presence: 'onlyActive' },
         {name: consolesTabName, renderer: GraphicsConsole, data: { vm, config, dispatch }}
     ];

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -54,7 +54,7 @@ class TestMachines(MachineCase):
         m.execute("virt-install --cpu host -r 128 --pxe --force --graphics {3},listen=127.0.0.1 --noautoconsole "
                   "--disk path={0},size=1,format=qcow2 --disk path={1},size=2,format=qcow2 "
                   "--boot hd,network "
-                  "-n {2} || true"
+                  "-n {2}"
                   .format(img1, img2, name, console))
 
         state = m.execute("virsh domstate {0}".format(name)).strip()

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -73,7 +73,7 @@ class TestMachines(MachineCase):
 
         b.click("tbody tr th") # click on the row header
         b.wait_present("#vm-subVmTest1-state")
-        b.wait_in_text("#vm-subVmTest1-state", "running") # running or paused
+        b.wait_in_text("#vm-subVmTest1-state", "running")
         b.wait_present("#vm-subVmTest1-vcpus")
         b.wait_in_text("#vm-subVmTest1-vcpus", "1")
 
@@ -83,10 +83,46 @@ class TestMachines(MachineCase):
         emulated_machine = b.eval_js("$('#vm-subVmTest1-emulatedmachine').text()")
         self.assertTrue(len(emulated_machine) > 0) # emulated machine varies across test machines
 
+        # switch to and check Usage
+        b.wait_present("#vm-subVmTest1-usage")
+        b.click("#vm-subVmTest1-usage")
+        b.wait_present("tbody.open .listing-ct-body td:nth-child(1) .usage-donut-caption")
+        b.wait_in_text("tbody.open .listing-ct-body td:nth-child(1) .usage-donut-caption", "128 MiB")
+        b.wait_present("#chart-donut-0 .donut-title-big-pf")
+        b.wait(lambda: float(b.text("#chart-donut-0 .donut-title-big-pf")) > 0.0)
+        b.wait_present("tbody.open .listing-ct-body td:nth-child(2) .usage-donut-caption")
+        b.wait_in_text("tbody.open .listing-ct-body td:nth-child(2) .usage-donut-caption", "1 vCPU")
+        # CPU usage cannot be nonzero with blank image, so just ensure it's a percentage
+        b.wait_present("#chart-donut-1 .donut-title-big-pf")
+        self.assertLessEqual(float(b.text("#chart-donut-1 .donut-title-big-pf")), 100.0)
+
+        # suspend/resume
+        m.execute("virsh suspend subVmTest1")
+        b.wait_in_text("#vm-subVmTest1-state", "paused")
+        # resume sometimes fails with "unable to execute QEMU command 'cont': Resetting the Virtual Machine is required"
+        m.execute('virsh resume subVmTest1 || { virsh destroy subVmTest1 && virsh start subVmTest1; }')
+        b.wait_in_text("#vm-subVmTest1-state", "running")
+
+        # shut off
         b.click("#vm-subVmTest1-off-caret")
         b.wait_visible("#vm-subVmTest1-forceOff")
         b.click("#vm-subVmTest1-forceOff")
         b.wait_in_text("#vm-subVmTest1-state", "shut off")
+
+        # usage should drop to zero
+        b.wait_in_text("#chart-donut-0 .donut-title-big-pf", "0.00")
+        b.wait_in_text("#chart-donut-1 .donut-title-big-pf", "0.0")
+
+        # start another one, should appear automatically
+        self.startVm("subVmTest2")
+        b.wait_present("#app .listing-ct tbody:nth-of-type(2) th")
+        b.wait_in_text("#app .listing-ct tbody:nth-of-type(2) th", "subVmTest2")
+        b.click("#app .listing-ct tbody:nth-of-type(2) th") # click on the row header
+        b.wait_present("#vm-subVmTest2-state")
+        b.wait_in_text("#vm-subVmTest2-state", "running")
+        b.wait_present("#vm-subVmTest2-vcpus")
+        b.wait_in_text("#vm-subVmTest2-vcpus", "1")
+        b.wait_in_text("#vm-subVmTest2-bootorder", "disk,network")
 
     def wait_for_disk_stats(self, name, target):
         b = self.browser

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -64,6 +64,7 @@ class TestMachines(MachineCase):
 
     def testBasic(self):
         b = self.browser
+        m = self.machine
 
         self.startVm("subVmTest1")
 
@@ -123,6 +124,33 @@ class TestMachines(MachineCase):
         b.wait_present("#vm-subVmTest2-vcpus")
         b.wait_in_text("#vm-subVmTest2-vcpus", "1")
         b.wait_in_text("#vm-subVmTest2-bootorder", "disk,network")
+
+        # restart libvirtd
+        m.execute("systemctl stop libvirtd")
+        b.wait_present("#app .blank-slate-pf")
+        b.wait_visible("#app .blank-slate-pf")
+        b.wait_in_text("#app .blank-slate-pf", "No VM is running")
+        m.execute("systemctl start libvirtd")
+        b.wait_present("#app .listing-ct tbody:nth-of-type(1) th")
+        b.wait_in_text("#app .listing-ct tbody:nth-of-type(1) th", "subVmTest1")
+        b.wait_present("#app .listing-ct tbody:nth-of-type(2) th")
+        b.wait_in_text("#app .listing-ct tbody:nth-of-type(2) th", "subVmTest2")
+        b.wait_present("#vm-subVmTest1-state")
+        b.wait_in_text("#vm-subVmTest1-state", "shut off")
+        b.wait_present("#vm-subVmTest2-state")
+        b.wait_in_text("#vm-subVmTest2-state", "running")
+
+        # stop second VM, event handling should still work
+        b.wait_present("#app .listing-ct tbody:nth-of-type(2) th")
+        b.wait_in_text("#app .listing-ct tbody:nth-of-type(2) th", "subVmTest2")
+        b.click("#app .listing-ct tbody:nth-of-type(2) th") # click on the row header
+        b.click("#vm-subVmTest2-off-caret")
+        b.wait_visible("#vm-subVmTest2-forceOff")
+        b.click("#vm-subVmTest2-forceOff")
+        b.wait_in_text("#vm-subVmTest2-state", "shut off")
+
+        # HACK: restarting libvirtd causes this completely unrelated SELinux issue
+        self.allow_journal_messages('.*denied.*search.*"systemd-machine".*dev="proc".*')
 
     def wait_for_disk_stats(self, name, target):
         b = self.browser


### PR DESCRIPTION
 * Add checks for restarting libvirt, Usage, and dynamically adding a VM (dynamically deleting one is already covered).
 * Drop the "|| true" in check-machine's startVm(). This isn't expected to fail, and if it does we want to 
know right there, not in some later part of the test.
 * Fix race condition in `startVm()`.

 - [x] ignore unrelated SELinux denial for systemd-machines
 - [x] handle `virsh resume` failures