### PR TITLE
test: Show VM log and state on failed startup

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -35,7 +35,6 @@ def readFile(name):
 # rmmod kvm-intel && modprobe kvm-intel || true
 
 @skipImage("Atomic cannot run virtual machines", "fedora-atomic", "rhel-atomic", "continuous-atomic")
-@skipImage("Debian Stable creates paused machines", "debian-stable")
 class TestMachines(MachineCase):
     def startVm(self, name, console='spice'):
         m = self.machine

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -56,10 +56,8 @@ class TestMachines(MachineCase):
                   "-n {2} || true"
                   .format(img1, img2, name, console))
 
-        state = m.execute("virsh domstate {0}".format(name)).strip()
-        # debug info: machine state
-        m.message("state: '{0}'".format(state))
-        self.assertIn(state, ["running"])
+        m.execute('[ "$(virsh domstate {0})" = running ] || '
+                  '{{ virsh dominfo {0} >&2; cat /var/log/libvirt/qemu/{0}.log >&2; exit 1; }}'.format(name))
 
     def testBasic(self):
         b = self.browser


### PR DESCRIPTION
If the VM inside the test VM fails to start up, show the complete dominfo and the log file. This should make it much easier to identify KVM or other problems on the host.

The second commit re-enables `check-machines` on debian-stable. The "paused VM" has nothing to do with the VM OS but with /dev/kvm on the testing host.