### PR TITLE
containers: Remove login options from kubernetes container

### DIFF
--- a/containers/kubernetes/cockpit.conf.tmpl
+++ b/containers/kubernetes/cockpit.conf.tmpl
@@ -1,4 +1,5 @@
 [WebService]
+LoginTo = false
 {{ if .origins }}
 Origins = {{.origins}}
 {{end}}

--- a/test/containers/check-kubernetes
+++ b/test/containers/check-kubernetes
@@ -142,6 +142,7 @@ class TestKubernetesLogin(KubernetesContainerCase):
         # Try to login, no api var
         b.open("/")
         b.wait_visible("#login")
+        b.wait_not_visible("#option-group")
         b.wait_text("#server-name", "Kubernetes Cockpit")
         self.login("admin", "fubar")
         b.wait_in_text("#login-fatal-message", "No kubernetes")


### PR DESCRIPTION
This is never used in the kubernetes use case.

Really we should remove the password checkbox and change the login text. But that would require either cockpit-ws changes or having the containers ship their own login html and js. But at least this is a good first step.