### PR TITLE
test: Fix formatting of timeout messages

### DIFF
--- a/test/common/phantom-driver.js
+++ b/test/common/phantom-driver.js
@@ -373,7 +373,7 @@ function step() {
         if (responded)
             sys.stderr.writeLine("WARNING: " + line + " was true after timeout, add more checkpoints");
         else
-            respond({ error: "timeout" + messages.slice(currentCallMessageIndex).join('\n') });
+            respond({ error: "timeout\n" + messages.slice(currentCallMessageIndex).join('\n') });
     }, cmd.timeout || 60 * 1000);
 
     /* This function is called when functions want to respond */


### PR DESCRIPTION
Commit 89cde583c inadvertently changed the formatting of timeout
messages from

  Error: timeout
  blabla

to

  Error: timeoutblabla

as the previous messages string always got a `\n` prepended. Add  it
back. This will still cause an extra newline if there is no message, but
this is fairly harmless.

This unbreaks all our naughty patterns that involve timeouts.