### PR TITLE
test: Ignore SELinux denial of agetty execution by systemd

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -621,6 +621,9 @@ class MachineCase(unittest.TestCase):
         # SELinux and nfs-utils fighting: https://bugzilla.redhat.com/show_bug.cgi?id=1447854
         ".*type=1400 .*denied  { execute } for.*sm-notify.*init_t.*",
 
+        # SELinux prevents agetty from being executed by systemd: https://bugzilla.redhat.com/show_bug.cgi?id=1449569
+        ".*type=1400 .*denied  { execute } for.*agetty.*init_t.*",
+
         # apparmor loading
         "(audit: )?type=1400.*apparmor=\"STATUS\".*",
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1449569

---

This should fix [this test failure](https://fedorapeople.org/groups/cockpit/logs/pull-7160-20170705-071717-f4acd99e-verify-fedora-i386/log.html#53):
```
# testSocketPort (check_connection.TestConnection)
#
Unexpected journal message 'audit: type=1400 audit(1499239708.617:197): avc:  denied  { execute } for  pid=886 comm="(agetty)" name="agetty" dev="dm-0" ino=4299816 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=0'
Unexpected journal message 'audit: type=1400 audit(1499239708.614:199): avc:  denied  { execute } for  pid=887 comm="(agetty)" name="agetty" dev="dm-0" ino=4299816 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=0'
Journal extracted to TestConnection-testSocketPort-10.111.112.175-FAIL.log
not ok 53 testSocketPort (check_connection.TestConnection) duration: 15s
Traceback (most recent call last):
  File "/build/cockpit/test/common/testlib.py", line 555, in tearDown
    self.check_journal_messages()
  File "/build/cockpit/test/common/testlib.py", line 723, in check_journal_messages
    raise Error(first)
Error: audit: type=1400 audit(1499239708.617:197): avc:  denied  { execute } for  pid=886 comm="(agetty)" name="agetty" dev="dm-0" ino=4299816 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=0
```