### PR TITLE
bots: Add ABRT packages to fedora-{25,i386,testing}

### DIFF
--- a/bots/images/scripts/fedora-25.setup
+++ b/bots/images/scripts/fedora-25.setup
@@ -70,6 +70,11 @@ gdb \
 targetcli \
 "
 
+ABRT_PACKAGES="\
+abrt-desktop \
+libreport-plugin-systemd-journal \
+"
+
 rm -rf /etc/sysconfig/iptables
 
 maybe() { if type "$1" >/dev/null 2>&1; then "$@"; fi; }
@@ -83,7 +88,7 @@ useradd -c Administrator -G wheel admin
 echo foobar | passwd --stdin admin
 
 dnf $DNF_OPTS -y upgrade
-dnf $DNF_OPTS -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
+dnf $DNF_OPTS -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES $ABRT_PACKAGES
 
 # Prepare for building
 dnf $DNF_OPTS -y install mock dnf-plugins-core rpm-build

--- a/bots/images/scripts/fedora-testing.setup
+++ b/bots/images/scripts/fedora-testing.setup
@@ -64,6 +64,11 @@ gdb \
 targetcli \
 "
 
+ABRT_PACKAGES="\
+abrt-desktop \
+libreport-plugin-systemd-journal \
+"
+
 rm -rf /etc/sysconfig/iptables
 
 maybe() { if type "$1" >/dev/null 2>&1; then "$@"; fi; }
@@ -78,7 +83,7 @@ echo foobar | passwd --stdin admin
 
 dnf config-manager --set-enabled updates-testing
 dnf $DNF_OPTS -y upgrade
-dnf $DNF_OPTS -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
+dnf $DNF_OPTS -y install $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES $ABRT_PACKAGES
 
 # Prepare for building
 dnf $DNF_OPTS -y install mock dnf-plugins-core rpm-build

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -303,7 +303,7 @@ s.send("PRIORITY=3\\nFOO=bar\\n")'
 
         b.wait_text("#journal-entry-message", "[no data]")
 
-    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-i386", "rhel-7-4")
+    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "rhel-7-4")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1604", "rhel-atomic", "fedora-atomic")
     def testAbrtSegv(self):
         b = self.browser
@@ -338,7 +338,7 @@ s.send("PRIORITY=3\\nFOO=bar\\n")'
         sel += " .panel-body:contains('signal: 11  executable: ')"
         b.wait_present(sel)
 
-    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-i386", "rhel-7-4")
+    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "rhel-7-4")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1604", "rhel-atomic", "fedora-atomic")
     def testAbrtDelete(self):
         b = self.browser
@@ -371,7 +371,7 @@ s.send("PRIORITY=3\\nFOO=bar\\n")'
         sel = "#journal-entry .panel #journal-entry-message:contains('crashed in __nanosleep()')"
         b.wait_present(sel)
 
-    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-i386", "rhel-7-4")
+    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "rhel-7-4")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1604", "rhel-atomic", "fedora-atomic")
     def testAbrtReport(self):
         b = self.browser


### PR DESCRIPTION
Commit f0ffc99 lets the ABRT tests run on all Fedoras (except for
fedora-i386), but commit f0ffc99e07 only added it to fedora-26. Add ABRT
to fedora-25 (aka -i386) and fedora -testing as well, and let the ABRT
tests run on fedora-i386 too.

 * [ ] FAIL: image-refresh fedora-25
- [ ] image-refresh fedora-i386
 * [ ] FAIL: image-refresh for fedora-testing