### PR TITLE
packagekit: Show most recent update

### DIFF
--- a/pkg/packagekit/updates.css
+++ b/pkg/packagekit/updates.css
@@ -58,12 +58,59 @@ tr.security {
     margin-top: 5em;
 }
 
+/* fixed width to avoid jumpy text between expanded/collapsed */
+.expander-caret {
+    width: 2ex;
+}
+
+.expander-title {
+    margin-bottom: 2em;
+    display: flex;
+    align-items: center;
+}
+
+.expander-title hr {
+    flex: auto;
+}
+
+.expander-title span {
+    padding: 1ex;
+    flex: none;
+}
+
 /* http://www.patternfly.org/pattern-library/communication/empty-state/ has a
  * gray background which we don't want here */
 
 .blank-slate-pf {
     background: inherit;
     border: none;
+}
+
+.flow-list-blank-slate {
+    padding-top: 8em;
+    margin: 0 auto;
+    max-width: 69rem;
+    text-align: center;
+}
+
+.flow-list {
+    margin: 1em 1em 3em;
+    padding: 0;
+    max-width: 66rem;
+    text-align: left;
+    box-sizing: border-box;
+}
+
+.flow-list li {
+    text-align: left;
+    box-sizing: border-box;
+    width: 22rem;
+    padding: 0 1ex;
+    display: inline-block;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-weight: 600;
 }
 
 /* Layout fix for tooltip arrows.

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -507,7 +507,7 @@ class OsUpdates extends React.Component {
                         this.loadUpdates();
                     } else {
                         // normally we get FAILED here with ErrorCodes; handle unexpected errors to allow for some debugging
-                        if (exit != PK_EXIT_ENUM_FAILED)
+                        if (exit !== PK_EXIT_ENUM_FAILED)
                             this.state.errorMessages.push(cockpit.format(_("PackageKit reported error code $0"), exit));
                         this.setState({state: "updateError"});
                     }

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -77,6 +77,7 @@ class TestUpdates(MachineCase):
         b.wait_present(".content-header-extra td.text-right span")
         self.assertEqual(b.text(".content-header-extra td.text-right span"), "Last checked: a few seconds ago")
 
+        # no Update History yet, should be unique
         b.wait_present(".container-fluid h2")
         b.wait_in_text(".container-fluid h2", "Available Updates")
         self.assertEqual(b.text("#state"), "2 updates")
@@ -162,6 +163,7 @@ class TestUpdates(MachineCase):
 
         m.start_cockpit()
         b.login_and_go("/updates")
+        # no Update History yet, should be unique
         b.wait_present(".container-fluid h2")
         b.wait_in_text(".container-fluid h2", "Available Updates")
         self.assertEqual(b.text("#state"), "5 updates, including 2 security fixes")
@@ -208,20 +210,42 @@ class TestUpdates(MachineCase):
         b.wait_in_text("#state", "Applying updates")
         b.wait_present("#app div.progress-bar")
 
-        # should have succeeded and show restart page; cancel
+        # should have succeeded and show restart page
         b.wait_present("#app .container-fluid h1")
         b.wait_in_text("#app .container-fluid h1", "Restart Recommended")
+
+        def assertHistory(parent, updates):
+            selector = parent + " .tooltip-ct-outer:nth-child({0}) li"
+            b.wait_present(parent)
+            b.wait_present(selector.format(len(updates)))
+            for index, pkg in enumerate(updates, start=1):
+                self.assertEqual(b.text(selector.format(index)), pkg)
+            # make sure we don't have any extra ones
+            self.assertFalse(b.is_present(selector.format(len(updates) + 1)))
+
+        # history on restart page should show the two security updates
+        b.wait_present(".expander-title span")
+        b.click(".expander-title span")
+        b.wait_present("ul")
+        assertHistory("ul", ["secdeclare", "secparse"])
+
+        # ignore restarting
         b.wait_present("#app .container-fluid button.btn-default")
         b.click("#app .container-fluid button.btn-default")
 
         # should have succeeded; 3 non-security updates left
         b.wait_present("#state")
         b.wait_in_text("#state", "3 updates")
-        b.wait_in_text(".container-fluid h2", "Available Updates")
+        b.wait_present(".container-fluid #available h2")
+        b.wait_in_text(".container-fluid #available h2", "Available Updates")
         b.wait_in_text("table.listing-ct", "norefs-doc")
         self.assertIn("buggy", b.text("table.listing-ct"))
         self.assertNotIn("secdeclare", b.text("table.listing-ct"))
         self.assertNotIn("secparse", b.text("table.listing-ct"))
+
+        # history should show the security updates
+        b.wait_present(".container-fluid #history h2")
+        assertHistory("#history ul", ["secdeclare", "secparse"])
 
         # new security versions are now installed
         m.execute("test -f /stamp-secdeclare-3-4.b1 && test -f /stamp-secparse-4-2")
@@ -243,6 +267,11 @@ class TestUpdates(MachineCase):
         # new versions are now installed
         m.execute("test -f /stamp-norefs-bin-2-1 && test -f /stamp-norefs-doc-2-1")
 
+        # history on restart page should show the three non-security updates
+        b.wait_present(".expander-title span")
+        b.click(".expander-title span")
+        assertHistory("ul", ["buggy", "norefs-bin", "norefs-doc"])
+
         # do the reboot; this will disconnect the web UI
         m.reset_reboot_flag()
         b.click("#app .container-fluid button.btn-primary")
@@ -262,6 +291,9 @@ class TestUpdates(MachineCase):
         b.wait_in_text("#state", "No updates pending")
         # empty state visible in main area
         b.wait_present(".container-fluid div.blank-slate-pf")
+
+        # history on "up to date" page should show the recent update
+        assertHistory("ul", ["buggy", "norefs-bin", "norefs-doc"])
 
         self.allow_restart_journal_messages()
 
@@ -343,8 +375,8 @@ class TestUpdates(MachineCase):
         b.wait_in_text(".content-header-extra td button", "Check for updates")
         b.click(".content-header-extra td button")
 
-        b.wait_present(".container-fluid h2")
-        b.wait_in_text(".container-fluid h2", "Available Updates")
+        b.wait_present(".container-fluid #available h2")
+        b.wait_in_text(".container-fluid #available h2", "Available Updates")
         self.assertEqual(b.text("#state"), "2 updates")
 
         b.wait_present("table.listing-ct")


### PR DESCRIPTION
Show a list of binary packages from the most recent update on all pages,
to help people to see which services to verify.

Fixes #7063 

---

This is an initial early PR to see how the new functionality and tests behave across our OS landscape.

- [x] @garrett: See if flow-list can be centered without centering the individual rows
- [x] Add "Package information" expander on "Restart required" page (right now the history is just shown right away)
- [x] Investigate/fix `TypeError: undefined is not a function (evaluating 't.GetOldTransactions(0)')` - fixed by #7175

Postponed to new PR:
- [ ] Add "Upgrade Log" to "Applying" page (entirely new widget)