### PR TITLE
test: Use mock FAF server for ABRT report test

### DIFF
--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -377,6 +377,11 @@ s.send("PRIORITY=3\\nFOO=bar\\n")'
         b = self.browser
         m = self.machine
 
+        # start mock FAF server
+        m.upload(["verify/files/mock-faf-server.py"], "/tmp/")
+        m.execute("setsid python /tmp/mock-faf-server.py >/tmp/mock-faf.log 2>&1 &")
+        m.execute("echo 'URL=http://localhost:12345' >> /etc/libreport/plugins/ureport.conf")
+
         self.login_and_go("/system/logs")
 
         m.execute("setenforce 0; ulimit -c unlimited; echo 'sleep 42m &' > slp; chmod u+x slp")
@@ -392,11 +397,6 @@ s.send("PRIORITY=3\\nFOO=bar\\n")'
         b.wait_present(sel)
         b.wait_visible(sel)
 
-        # If 'Reported' then skip test
-        sel = "#journal-entry-fields .nav .problem-btn:contains('Reported')"
-        if b.is_present(sel):
-            return
-
         sel = "#journal-entry-fields .nav .btn-primary:contains('Report')"
         b.wait_present(sel)
         b.wait_visible(sel)
@@ -405,7 +405,7 @@ s.send("PRIORITY=3\\nFOO=bar\\n")'
         sel = "#journal-entry-fields .nav .problem-btn:contains('Reported')"
         b.wait_present(sel)
         b.wait_visible(sel)
-        self.assertTrue("/reports/bthash/" in b.attr(sel, 'href'))
+        self.assertIn("/reports/bthash/123deadbeef", b.attr(sel, 'href'))
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/files/mock-faf-server.py
+++ b/test/verify/files/mock-faf-server.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+# export uReport_URL="http://localhost:12345"
+
+import cgi
+import json
+import BaseHTTPServer
+
+class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
+    def do_POST(self):
+        form = cgi.FieldStorage(
+            fp=self.rfile,
+            headers=self.headers,
+            environ={
+                'REQUEST_METHOD': 'POST',
+                'CONTENT_TYPE': self.headers['Content-Type'],
+            }
+        )
+
+        self.send_response(202)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Connection', 'close')
+        self.end_headers()
+
+        json_str = form['file'].file.read()
+        try:
+            # just check that it's a JSON
+            json.loads(json_str)
+        except ValueError:
+            sys.stderr.write('Received invalid JSON data:\n{0}\n'.format(json_str))
+            return
+
+        response = {
+            'bthash': '123deadbeef',
+            'message': 'http://localhost:12345/reports/42/\nhttps://bugzilla.example.com/show_bug.cgi?id=123456',
+            'reported_to': [
+                {
+                    'type': 'url',
+                    'value': 'http://localhost:12345/reports/42/',
+                    'reporter': 'ABRT Server'
+                },
+                {
+                    'type': 'url',
+                    'value': 'https://bugzilla.example.com/show_bug.cgi?id=123456',
+                    'reporter': 'Bugzilla'
+                }
+            ],
+            'result': False
+        }
+        json.dump(response, self.wfile, indent=2)
+
+PORT = 12345
+httpd = BaseHTTPServer.HTTPServer(("", PORT), Handler)
+httpd.serve_forever()


### PR DESCRIPTION
Stop sending our synthetic crash to the real Fedora FAF server. It is
just garbage there, requires networking, and isn't flexible enough for
simulating different scenarios.

Thanks to Matej Marusak for providing the mock server!

CC @marusak 