### PR TITLE
test: Fix attaching core dump to sink logs

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -749,7 +749,8 @@ class MachineCase(unittest.TestCase):
     def copy_cores(self, title, label=None):
         for name, m in self.machines.iteritems():
             if m.address:
-                dest = "%s-%s-%s.core" % (label or self.label(), m.address, title)
+                directory = "%s-%s-%s.core" % (label or self.label(), m.address, title)
+                dest = os.path.abspath(directory)
                 m.download_dir("/var/lib/systemd/coredump", dest)
                 try:
                     os.rmdir(dest)


### PR DESCRIPTION
The path resolution in download_dir would put the downloaded
cores in an unexpected location, resulting in the core dump
not being uploaded. So lets qualify the path properly.