### PR TITLE
WIP: machines: 'virsh event --loop' is not exited when libvirtd is down

### DIFF
--- a/pkg/machines/services.es6
+++ b/pkg/machines/services.es6
@@ -31,7 +31,7 @@ export function spawnProcess({ cmd, args = [], stdin, failHandler }) {
                 failHandler({exception, data});
                 return ;
             }
-            console.error(`spawn '${cmd}' process returned error: "${JSON.stringify(exception)}", data: "${JSON.stringify(data)}"`);
+            console.warn(`spawn '${cmd}' process returned error: "${JSON.stringify(exception)}", data: "${JSON.stringify(data)}"`);
         });
 }
 
@@ -41,7 +41,7 @@ export function spawnScript({ script }) {
 
     return spawn(cockpit.script(spawnArgs, [], { err: "message", environ: ['LC_ALL=C'] }))
         .fail((ex, data) =>
-            console.error(`spawn '${script}' script error: "${JSON.stringify(ex)}", data: "${JSON.stringify(data)}"`));
+            console.warn(`spawn '${script}' script error: "${JSON.stringify(ex)}", data: "${JSON.stringify(data)}"`));
 }
 
 function spawn(command) {

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -124,6 +124,7 @@ class TestMachines(MachineCase):
 
         # restart libvirtd
         m.execute("systemctl stop libvirtd")
+        # FIXME for debian-stable: stopping of libvirtd does not interrupt the 'virsh event --loop'
         b.wait_present("#app .blank-slate-pf")
         b.wait_visible("#app .blank-slate-pf")
         b.wait_in_text("#app .blank-slate-pf", "No VM is running")


### PR DESCRIPTION
Related to older libvirt versions like in recent debian-stable:
 the 'virsh event --loop' process is not exited when libvirtd is stopped.

WIP: the issue is so far just investigated, fix needs to be provided