### PR TITLE
test: Widen allowed journal messages for PackageKit crash

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -377,7 +377,7 @@ class TestUpdates(MachineCase):
         b.wait_present("#app .container-fluid pre")
         self.assertEqual(b.text("#app .container-fluid pre"), "PackageKit crashed")
 
-        self.allow_journal_messages(".*org.freedesktop.PackageKit.Transaction .*Error.NoReply.*")
+        self.allow_journal_messages(".*org.freedesktop.PackageKit.*Error.NoReply.*")
 
     def testNoPackageKit(self):
         b = self.browser


### PR DESCRIPTION
When (intentionally) crashing PackageKit in TestUpdates.testPackageKitCrash()
we might not only get an error on the Transaction interface, but also on
the main interface:

    Error: org.freedesktop.PackageKit: couldn't introspect /4_dabbbccc:
       GDBus.Error:org.freedesktop.DBus.Error.NoReply:
       Message did not receive a reply (timeout by message bus)

So widen the pattern to allow both.

This was seen in https://fedorapeople.org/groups/cockpit/logs/pull-7117-20170711-165858-79485783-verify-centos-7/log.html