### PR TITLE
bots: Handle GitHub.issues() since argument properly

### DIFF
--- a/bots/task/github.py
+++ b/bots/task/github.py
@@ -305,10 +305,10 @@ class GitHub(object):
                 # Check that the issues are past the expected date
                 if since:
                     closed = issue.get("closed_at", None)
-                    if closed and since > time.strptime(closed, "%Y-%m-%dT%H:%M:%SZ"):
+                    if closed and since > time.mktime(time.strptime(closed, "%Y-%m-%dT%H:%M:%SZ")):
                         continue
                     created = issue.get("created_at", None)
-                    if created and since > time.strptime(created, "%Y-%m-%dT%H:%M:%SZ"):
+                    if created and since > time.mktime(time.strptime(created, "%Y-%m-%dT%H:%M:%SZ")):
                         continue
 
                 result.append(issue)

--- a/bots/task/test-github
+++ b/bots/task/test-github
@@ -33,6 +33,7 @@ import sys
 import tempfile
 import time
 import unittest
+import urlparse
 
 BASE = os.path.dirname(__file__)
 DEVNULL = open("/dev/null", "r+")
@@ -63,20 +64,27 @@ def mockServer():
             self.replyData(json.dumps(value), headers=headers, status=status)
 
         def do_GET(self):
-            if self.path == "/count":
+            parsed = urlparse.urlparse(self.path)
+            if parsed.path == "/count":
                 self.replyJson(self.server.data["count"])
-            elif self.path == "/test/user":
+            elif parsed.path == "/issues":
+                self.replyJson([
+                    { "number": "5", "state": "open", "created_at": "2011-04-22T13:33:48Z" },
+                    { "number": "6", "state": "closed", "closed_at": "2011-04-21T13:33:48Z" },
+                    { "number": "7", "state": "open" }
+                ])
+            elif parsed.path == "/test/user":
                 if self.headers.getheader("If-None-Match") == "blah":
                     self.replyData("", status=304)
                 else:
                     self.replyJson({ "user": "blah" }, headers={ "ETag": "blah" })
-            elif self.path == "/test/user/modified":
+            elif parsed.path == "/test/user/modified":
                 if self.headers.getheader("If-Modified-Since") == "Thu, 05 Jul 2012 15:31:30 GMT":
                     self.replyData("", status=304)
                 else:
                     self.replyJson({ "user": "blah" }, headers={ "Last-Modified": "Thu, 05 Jul 2012 15:31:30 GMT" })
             else:
-                self.send_error(404, 'Mock Not Found: ' + self.path)
+                self.send_error(404, 'Mock Not Found: ' + parsed.path)
 
     httpd = BaseHTTPServer.HTTPServer(ADDRESS, Handler)
     httpd.data = data
@@ -133,6 +141,12 @@ class TestGitHub(unittest.TestCase):
             match = fnmatch.fnmatch(log, expect)
         if not match:
             self.fail("'{0}' did not match '{1}'".format(log, expect))
+
+    def testIssuesSince(self):
+        api = github.GitHub("http://127.0.0.8:9898/")
+        issues = api.issues(since=1499838499)
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0]["number"], "7")
 
 class TestWhitelist(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
We were parsing the created_at and closed_at attributes incorrectly
and this was resulting in matching older issues.