### PR TITLE
test: Add another expected restart journal message

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -663,6 +663,7 @@ class MachineCase(unittest.TestCase):
                                     ".*Broken pipe.*",
                                     "g_dbus_connection_real_closed: Remote peer vanished with error: Underlying GIOStream returned 0 bytes on an async read \\(g-io-error-quark, 0\\). Exiting.",
                                     "connection unexpectedly closed by peer",
+                                    "peer did not close io when expected",
                                     # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1141137
                                     "localhost: bridge program failed: Child process killed by signal 9",
                                     "request timed out, closing",


### PR DESCRIPTION
Observed in `check-connection TestConnection.testBasic`:

    > transport closed: terminated
    Unexpected journal message 'peer did not close io when expected'

Seen in https://fedorapeople.org/groups/cockpit/logs/pull-6334-20170712-051919-6439792f-verify-debian-testing/log.html#46