### PR TITLE
bots: Trigger updating NPM packages more often

### DIFF
--- a/bots/npm-trigger
+++ b/bots/npm-trigger
@@ -19,7 +19,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 # Number of days between attempts to upgrade an NPM package
-DAYS = 7
+DAYS = 3
 
 import argparse
 import sys


### PR DESCRIPTION
This only does one package at a time, in order to reduce the
churn and load on humans who have to review and test the changes
especially for UI packages.

However since there are a lot of packages, trying one every three
days seems like a good compromise between churn, and detecting
important updates often enough.