### PR TITLE
bots: Make image-naughty script not fail when GitHub flakes

### DIFF
--- a/bots/image-naughty
+++ b/bots/image-naughty
@@ -46,7 +46,7 @@ def main():
         if trace:
             number = check_known_issue(api, trace, opts.image)
     except RuntimeError, ex:
-        sys.stderr.write("image-naughty: {0}\n".format(ret))
+        sys.stderr.write("image-naughty: {0}\n".format(ex))
         return 1
 
     if number:

--- a/bots/image-naughty
+++ b/bots/image-naughty
@@ -23,7 +23,9 @@ import datetime
 import fnmatch
 import re
 import os
+import socket
 import sys
+import traceback
 
 sys.dont_write_bytecode = True
 
@@ -50,7 +52,11 @@ def main():
         return 1
 
     if number:
-        post_github(api, number, trace, opts.image)
+        try:
+            post_github(api, number, trace, opts.image)
+        except socket.error:
+            traceback.print_exc()
+            sys.stderr.write("image-naughty: posting update to GitHub failed\n")
         sys.stdout.write("{0}\n".format(number))
     return 0;
 


### PR DESCRIPTION
If connecting to GitHub and posting an update about a known issue disconnects for some reason, we should keep moving on, and have the test skip the known issue. Lets print out, the failure but not cause the test to fail.
