### PR TITLE
tools: Update debian/adjust-for-release for buster

### DIFF
--- a/bots/images/debian-testing
+++ b/bots/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-f06febc0c062a29db8a2e1dbf055e8911f22e1a2177c3d8f7c820a828f4e34fd.qcow2
+debian-testing-8f13ebed649eecb27a3dd5a5adba4abb455a0bb26f8c1389b31ef42c6600a50f.qcow2

--- a/bots/images/scripts/debian-testing.bootstrap
+++ b/bots/images/scripts/debian-testing.bootstrap
@@ -1,2 +1,4 @@
 #! /bin/sh -ex
-exec $(dirname $0)/lib/debian.bootstrap "$1" "$2" debian-8 "deb http://deb.debian.org/debian testing main"
+ARCH=x86_64
+DEBIAN_LATEST=$(virt-builder -l  | grep "$ARCH" | sort -r | grep -m1 '^debian-' | cut -d' ' -f1)
+exec $(dirname $0)/lib/debian.bootstrap "$1" "$2" "$DEBIAN_LATEST" "deb http://deb.debian.org/debian testing main"

--- a/tools/debian/adjust-for-release
+++ b/tools/debian/adjust-for-release
@@ -20,6 +20,7 @@ debian_dir=$(dirname $(readlink -f "$0"))
 set -x
 # Remove PCP build dependencies while pcp is not in testing
 # (https://tracker.debian.org/pcp)
-if [ "$release" = unstable ] || [ "$release" = testing ] || [ "$release" = stretch ]; then
-    sed -i '/libpcp.*-dev/d' $debian_dir/control
-fi
+case "$release" in
+    unstable|testing|stable|stretch|buster)
+        sed -i '/libpcp.*-dev/d' $debian_dir/control ;;
+esac


### PR DESCRIPTION
Fix debian-testing image builds (#7231). Also, build debian-testing from latest debian virt-builder image (Debian 9 right now) instead from debian-8. Please see commit logs for details.