### PR TITLE
bots: Reinstate image cache for master runs

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -373,7 +373,10 @@ class PullTask(object):
 
 
         env = os.environ.copy()
-        if "TEST_DATA" in env:
+        # COMPAT: we can only use the cache for new enough branches which have the test/bots split;
+        # don't destroy the old test/images symlink farm
+        if "TEST_DATA" in env and subprocess.call(['git', 'ls-tree', '-d', 'HEAD:bots/images'],
+                                                  stdout=DEVNULL, stderr=DEVNULL) != 0:
             del env["TEST_DATA"]
         env["PATH"] = "{0}:{1}:{2}".format(env.get("PATH", "/bin:/sbin"), BOTS, test)
 


### PR DESCRIPTION
Revert the unsetting of $TEST_DATA from commit 3a098012a if we run tests
on master. PR #6334 introduces image pulls into tests, which adds an
extra 20 minutes download time and is very susceptible to download
errors.

Only keep the unsetting for running tests for branches, as they still
use the old test/images/ system.