### PR TITLE
test: Add logger to diagnose flakiness of check-docker-storage

### DIFF
--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -124,10 +124,11 @@ class TestDockerStorage(MachineCase):
                     'MIN_DATA_SIZE=80M\n')
 
         def check_loopback(val):
+            # We pass the output through logger to diagnose flakey issues
             if val:
-                m.execute("losetup -l -O BACK-FILE | grep -q /var/lib/docker")
+                m.execute("losetup -l -O BACK-FILE | logger -s 2>&1 | grep -q /var/lib/docker")
             else:
-                m.execute("! (losetup -l -O BACK-FILE | grep -q /var/lib/docker)")
+                m.execute("! (losetup -l -O BACK-FILE | logger -s 2>&1 | grep -q /var/lib/docker)")
 
         def check_atomic_vgroup(val):
             if val:


### PR DESCRIPTION
Sometimes losetup seems to produce unexpected output. Lets diagnose
this by adding logger so we can see the output in the journal.