### PR TITLE
test: Use emulated QEMU for nested check-machines VMs

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -59,7 +59,7 @@ CONSOLE_XML="""
 """
 
 DOMAIN_XML="""
-<domain type='kvm'>
+<domain type='qemu'>
   <name>{name}</name>
   <vcpu>1</vcpu>
   <os>
@@ -178,6 +178,8 @@ class TestMachines(MachineCase):
 
         m.execute('[ "$(virsh domstate {0})" = running ] || '
                   '{{ virsh dominfo {0} >&2; cat /var/log/libvirt/qemu/{0}.log >&2; exit 1; }}'.format(name))
+
+        self.allow_journal_messages('.*denied.*search.*"qemu-system-x86".*dev="proc".*')
 
         return args
 


### PR DESCRIPTION
When nesting check-machines VMs use QEMU emulation to run them.
These are simple small VMs and we want them to be predictable.

Certain RHEL 7.x versions seem to have intermittent problems with
nested KVM on certain hardware. That means certain of our testing
cluster don't like nested virtualization, although it seems to
be totally solid elsewhere (like the Fedora Openstack).

In order to make the tests runnable everywhere, and avoid the
"paused" state, lets just use QEMU emulation for these internal
VMs.