### PR TITLE
test: Mark debian-testing as having loopbacked docker storage

### DIFF
--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -54,7 +54,7 @@ def initially_loopbacked(machine):
         return False
 
     # use the overlayfs driver by default on some distros
-    if machine.image in [ "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-26" ]:
+    if machine.image in [ "debian-stable", "ubuntu-1604", "ubuntu-stable", "fedora-26" ]:
         return False
 
     # The rest don't have space in the root volume group, or don't


### PR DESCRIPTION
The current debian-testing image has a loopbacked docker storage
you can see this by doing:

    # systemctl start docker
    # losetup