### PR TITLE
Abrt reporting known problem

### DIFF
--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -444,7 +444,11 @@ $(function() {
                 });
                 proc.fail(function(ex) {
                     var message;
-                    if (ex.problem === 'access-denied') {
+                    // 70 is 'This problem has already been reported'
+                    if (ex.exit_status === 70) {
+                        window.location.reload();
+                        return;
+                    } else if (ex.problem === 'access-denied') {
                         message = _("Not authorized to upload-report");
                     } else if (ex.problem === "not-found") {
                         message = _("Reporter 'reporter-ureport' not found.");

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -370,6 +370,8 @@ s.send("PRIORITY=3\\nFOO=bar\\n")'
     @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-25", "fedora-i386", "fedora-testing", "rhel-7-4")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1604", "rhel-atomic", "fedora-atomic")
     def testAbrtReport(self):
+        # The testing server is located at verify/files/mock-faf-server.py
+        # Adjust Handler.known for for the expected succession of known/unknown problems
         b = self.browser
         m = self.machine
 
@@ -402,6 +404,30 @@ s.send("PRIORITY=3\\nFOO=bar\\n")'
         b.wait_present(sel)
         b.wait_visible(sel)
         self.assertIn("/reports/bthash/123deadbeef", b.attr(sel, 'href'))
+
+        # "Unreport" the problem to test reporting unknown problem
+        m.execute('find /var/spool/abrt -name "reported_to" | xargs rm')
+
+        b.reload()
+        b.enter_page("/system/logs")
+
+        sel = "#journal-entry-fields"
+        b.wait_present(sel)
+
+        self.allow_journal_messages('.*This problem has already been reported.')
+        self.allow_journal_messages('.*http://localhost:12345/reports/42/')
+        self.allow_journal_messages('.*https://bugzilla.example.com/show_bug.cgi\?id=123456')
+
+        sel = "#journal-entry-fields .nav .btn-primary:contains('Report')"
+        b.wait_present(sel)
+        b.wait_visible(sel)
+        b.click(sel)
+
+        sel = "#journal-entry-fields .nav .problem-btn:contains('Reported')"
+        b.wait_present(sel)
+        b.wait_visible(sel)
+        self.assertIn("/reports/bthash/123deadbeef", b.attr(sel, 'href'))
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/files/mock-faf-server.py
+++ b/test/verify/files/mock-faf-server.py
@@ -45,10 +45,11 @@ class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
                     'reporter': 'Bugzilla'
                 }
             ],
-            'result': False
+            'result': Handler.known.next()
         }
         json.dump(response, self.wfile, indent=2)
 
 PORT = 12345
+Handler.known = [True, False].__iter__()
 httpd = BaseHTTPServer.HTTPServer(("", PORT), Handler)
 httpd.serve_forever()


### PR DESCRIPTION
When I provided server for #7180 @martinpitt had some problems with it. It came out that when reporting known problem it is not working correctly in Cockpit.
Here I provide fix of this. The problem is that reporter-ureport returns code 70, which is not meant as error. I also provide test. Not really sure about the allow_journal_message part.