### PR TITLE
bots: Fetch latest origin/master in test-invoke

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -315,9 +315,9 @@ class PullTask(object):
             if not self.revision:
                 self.revision = head
 
-            # Retrieve information about our base branch
+            # Retrieve information about our base branch and master (for bots/)
             if self.base and not opts.offline:
-                subprocess.check_call([ "git", "fetch", "origin", self.base ])
+                subprocess.check_call([ "git", "fetch", "origin", self.base, "master" ])
 
             # Clean out the test directory
             subprocess.check_call([ "git", "clean", "-d", "--force", "--quiet", "-x", "--", "test/" ])


### PR DESCRIPTION
When testing a backports branch we check out master's bots/ directory on
top of it. Make sure we got the latest version.

@stefwalter: This is completely untested and just a theory so far for what happens in https://github.com/cockpit-project/cockpit/pull/7236#issuecomment-315109135 . Sorry, need to run now, but this might be a plausible explanation?