### PR TITLE
bots: Download temporary images files to same filesystem

### DIFF
--- a/bots/image-download
+++ b/bots/image-download
@@ -132,7 +132,7 @@ def download(link, force, quiet, stores):
             sys.stderr.write(" > {0}\n".format(urlparse.urljoin(message, name)))
         break
 
-    (fd, temp) = tempfile.mkstemp(suffix=".partial", prefix=os.path.basename(dest), dir=DATA)
+    (fd, temp) = tempfile.mkstemp(suffix=".partial", prefix=os.path.basename(dest), dir=os.path.dirname(dest))
 
     # Adjust the command above that worked to make it visible and download real stuff
     cmd.remove("--head")


### PR DESCRIPTION
We should be downloading temporary image files to the same filesystem
as where they are going to be placed once done.