### PR TITLE
test: Print debugging info in check-metrics about memory

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -112,6 +112,7 @@ class TestMetrics(MachineCase):
         #
         meminfo = read_mem_info(m)
         mem_used = meminfo['MemTotal'] - meminfo['MemFree']
+        print "Measured Memory", mem_used
         b.wait_js_func("ph_flot_data_plateau", "#server_memory_graph", mem_used*0.95, mem_used*1.05, 15, "mem");
 
         # Disk.  Anything above 100 kiB/s is good for now.


### PR DESCRIPTION
This should help us debug problems with TestMetrics failing
when looking for memory data.