### PR TITLE
bots: Always use bots/ from master for invoking tests

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -166,9 +166,9 @@ class PullTask(object):
             traceback.print_exc()
             return "Rebase failed"
 
-        # COMPAT: If the bots directory doesn't exist in this branch, check it out from master
+        # Always use bots/ and test images from master
         try:
-            if subprocess.call([ "git", "ls-tree", "-d", "HEAD:bots/"], stdout=DEVNULL) != 0:
+            if self.base and self.base != "master":
                 sys.stderr.write("Checking out bots directory from master ...\n")
                 subprocess.check_call([ "git", "checkout", "--force", "origin/master", "--", "bots/" ])
 


### PR DESCRIPTION
Some newer branches like rhel-7.3.6 and rhel-7.4-extras have an existing
bots/ directory. We must still use master's bots/ for those, to keep
up with image refreshes and infrastructure fixes.

Fixes #7255 