### PR TITLE
Software Updates design improvements

### DIFF
--- a/pkg/packagekit/mock-updates.es6
+++ b/pkg/packagekit/mock-updates.es6
@@ -1,0 +1,72 @@
+/*jshint esversion: 6 */
+
+/*
+ * Mock "available updates" entries for interactively testing layout changes with large updates
+ * To use it, import it in updates.jsx:
+ *
+ *    import { injectMockUpdates } from "./mock-updates.es6";
+ *
+ * and call it in loadUpdates()'s Finished: Handler:
+ *
+ *      Finished: () => {
+ *          injectMockUpdates(updates);
+ *          let pkg_ids = Object.keys(updates);
+ */
+
+export function injectMockUpdates(updates) {
+    // two security updates
+    updates["security-one;2.3-4"] = {
+        name: "security-one",
+        version: "2.3-4",
+        bug_urls: [],
+        cve_urls: ["https://cve.example.com?name=CVE-2017-0815"],
+        security: true,
+        description: "This will wreck your data center!",
+    };
+    updates["security-two;1-2+sec1"] = {
+        name: "security-two",
+        version: "1-2+sec1",
+        bug_urls: [],
+        cve_urls: ["https://cve.example.com?name=CVE-2017-0042"],
+        security: true,
+        description: "Mostly Harmless",
+    };
+
+    // source with many binaries
+    for (let i = 1; i < 50; ++i) {
+        let name = `manypkgs${i}`;
+        updates[name + ";1-1"] = {
+            name: name,
+            version: "1-1",
+            bug_urls: [],
+            cve_urls: [],
+            security: false,
+            description: "Make everything better",
+        };
+    }
+
+    // long changelog
+    updates["verbose;1-1"] = {
+        name: "verbose",
+        version: "1-1",
+        bug_urls: [],
+        cve_urls: [],
+        security: false,
+        description: ("Some longish explanation of some boring technical change. " +
+            "This is total technobabble gibberish for layman users.\n\n").repeat(30)
+    };
+
+    // many bug fixes
+    var bugs = [];
+    for (let i = 10000; i < 10025; ++i)
+        bugs.push("http://bugzilla.example.com/" + i);
+    updates["buggy;1-1"] = {
+        name: "buggy",
+        version: "1-1",
+        bug_urls: bugs,
+        cve_urls: [],
+        security: false,
+        description: "This is FUBAR",
+    };
+}
+

--- a/pkg/packagekit/updates.css
+++ b/pkg/packagekit/updates.css
@@ -30,6 +30,77 @@ tr.security.listing-ct-item {
     border-bottom: 1px solid #e0e0e0;
 }
 
+
+/* Reformat table for narrow widths */
+@media screen and (max-width: 640px) {
+    .listing-ct {
+        /* counteract .container-fluid */
+        margin: 0 0 0 -20px;
+        width: 100vw;
+        overflow: hidden;
+    }
+    .listing-ct thead {
+        display: none;
+    }
+    .listing-ct-item {
+        display: block;
+        width: 100vw;
+    }
+    .listing-ct-item th,
+    .listing-ct-item td {
+        display: block;
+        width: 100%;
+        max-width: 100% !important;
+        padding: 10px 15px !important;
+    }
+    .listing-ct-item th + td,
+    .listing-ct-item td + td {
+        padding-top: 0 !important;
+    }
+}
+
+@media screen and (min-width: 641px) {
+    tr.listing-ct-item td.changelog {
+        width: 80ex;
+        white-space: pre-line;
+     }
+
+     .listing-ct-item td.narrow:nth-child(2) {
+         max-width: 25ex;
+    }
+}
+
+@media screen and (min-width: 641px) and (max-width: 1150px) {
+    .listing-ct-item th {
+        min-width: 30%;
+    }
+
+    /* This really should be .update-bugs or similar */
+    .listing-ct-item td.narrow:nth-child(3) {
+        min-width: 19ex;
+        width: 20ex;
+    }
+    /* Basically children of the above, but break before the odd bug links */
+    .listing-ct-item td.narrow:nth-child(3) a:nth-child(odd):before {
+        display: block;
+        content: '';
+    }
+}
+
+@media screen and (min-width: 1151px) {
+    /* This really should be .update-bugs or similar */
+    .listing-ct-item td.narrow:nth-child(3) {
+        min-width: 36ex;
+        width: 38ex;
+    }
+    /* Basically children of the above, but break before the odd bug links */
+    .listing-ct-item td.narrow:nth-child(3) a:nth-child(4n+5):before {
+        display: block;
+        content: '';
+    }
+}
+
+
 .security-label {
     color: darkred;
 }

--- a/pkg/packagekit/updates.css
+++ b/pkg/packagekit/updates.css
@@ -169,7 +169,7 @@ tr.security.listing-ct-item {
 .flow-list {
     margin: 1em 1em 3em;
     padding: 0;
-    max-width: 66rem;
+    max-width: 110rem;
     text-align: left;
     box-sizing: border-box;
 }

--- a/pkg/packagekit/updates.css
+++ b/pkg/packagekit/updates.css
@@ -24,8 +24,10 @@ tr.listing-ct-item td.changelog {
     white-space: pre-wrap;
 }
 
-tr.security {
+tr.security.listing-ct-item {
     background-color: #fbf0f0;
+    border-top: 1px solid #e0e0e0;
+    border-bottom: 1px solid #e0e0e0;
 }
 
 .security-label {

--- a/pkg/packagekit/updates.css
+++ b/pkg/packagekit/updates.css
@@ -100,6 +100,9 @@ tr.security.listing-ct-item {
     }
 }
 
+.info-expander {
+    display: block;
+}
 
 .security-label {
     color: darkred;

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -117,7 +117,9 @@ function deduplicate(list) {
     return result;
 }
 
-function commaJoin(list) {
+// Insert comma strings in between elements of the list. Unlike list.join(",")
+// this does not stringify the elements, which we need to keep as JSX objects.
+function insertCommas(list) {
     return list.reduce((prev, cur) => [prev, ", ", cur])
 }
 
@@ -197,7 +199,7 @@ function UpdateItem(props) {
 
     if (info.bug_urls && info.bug_urls.length) {
         // we assume a bug URL ends with a number; if not, show the complete URL
-        bugs = commaJoin(info.bug_urls.map(u => <a rel="noopener" referrerpolicy="no-referrer" target="_blank" href={u} >{u.match(/[0-9]+$/) || u}</a>));
+        bugs = insertCommas(info.bug_urls.map(u => <a rel="noopener" referrerpolicy="no-referrer" target="_blank" href={u} >{u.match(/[0-9]+$/) || u}</a>));
     }
 
     if (info.security) {
@@ -205,7 +207,7 @@ function UpdateItem(props) {
             <p>
                 <span className="fa fa-bug security-label"> </span>
                 <span className="security-label-text">{ _("Security Update") + (info.cve_urls.length ? ": " : "") }</span>
-                { commaJoin(info.cve_urls.map(u => <a href={u} rel="noopener" referrerpolicy="no-referrer" target="_blank">{u.match(/[^/=]+$/)}</a>)) }
+                { insertCommas(info.cve_urls.map(u => <a href={u} rel="noopener" referrerpolicy="no-referrer" target="_blank">{u.match(/[^/=]+$/)}</a>)) }
             </p>
         );
     }
@@ -213,7 +215,7 @@ function UpdateItem(props) {
     return (
         <tbody>
             <tr className={ "listing-ct-item" + (info.security ? " security" : "") }>
-                <th>{ commaJoin(props.pkgNames.map(n => (<Tooltip tip={packageSummaries[n]}><span>{n}</span></Tooltip>))) }</th>
+                <th>{ insertCommas(props.pkgNames.map(n => (<Tooltip tip={packageSummaries[n]}><span>{n}</span></Tooltip>))) }</th>
                 <td className="narrow">{info.version}</td>
                 <td className="narrow">{bugs}</td>
                 <td className="changelog">{security_info}{info.description}</td>

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -227,7 +227,6 @@ class TestUpdates(MachineCase):
         # history on restart page should show the two security updates
         b.wait_present(".expander-title span")
         b.click(".expander-title span")
-        b.wait_present("ul")
         assertHistory("ul", ["secdeclare", "secparse"])
 
         # ignore restarting

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import parent
 from testlib import *
 
 @skipImage("Image uses OSTree", "continuous-atomic", "fedora-atomic", "rhel-atomic")
@@ -215,9 +216,9 @@ class TestUpdates(MachineCase):
         b.wait_present("#app .container-fluid h1")
         b.wait_in_text("#app .container-fluid h1", "Restart Recommended")
 
-        def assertHistory(parent, updates):
-            selector = parent + " .tooltip-ct-outer:nth-child({0}) li"
-            b.wait_present(parent)
+        def assertHistory(path, updates):
+            selector = path + " .tooltip-ct-outer:nth-child({0}) li"
+            b.wait_present(path)
             b.wait_present(selector.format(len(updates)))
             for index, pkg in enumerate(updates, start=1):
                 self.assertEqual(b.text(selector.format(index)), pkg)

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -155,7 +155,7 @@ class TestUpdates(MachineCase):
         # security fix with proper CVE list and severity
         self.createPackage("secdeclare", "3", "4.a1", install=True)
         self.createPackage("secdeclare", "3", "4.b1", severity="security",
-                           changes="stop kittens from dying", cves=['CVE-2016-0001'])
+                           changes="Will crash your data center", cves=['CVE-2016-0001'])
         # security fix with parsing from changes
         self.createPackage("secparse", "4", "1", install=True)
         self.createPackage("secparse", "4", "2", changes="Fix CVE-2017-0001 and CVE-2017-0002.")
@@ -180,7 +180,7 @@ class TestUpdates(MachineCase):
         self.assertEqual(b.text("#app .listing-ct tbody:nth-of-type(1) td:nth-of-type(3) span.security-label-text"),
                          "Security Update: ")
         desc = b.text("#app .listing-ct tbody:nth-of-type(1) td:nth-of-type(3)")
-        self.assertIn("stop kittens from dying", desc)
+        self.assertIn("Will crash your data center", desc)
         self.assertIn("CVE-2016-0001", desc)
 
         # secparse should also be considered a security update as the changelog mentions CVEs
@@ -297,6 +297,88 @@ class TestUpdates(MachineCase):
         assertHistory("ul", ["buggy", "norefs-bin", "norefs-doc"])
 
         self.allow_restart_journal_messages()
+
+    def testInfoTruncation(self):
+        b = self.browser
+        m = self.machine
+
+        # update with not too many binary packages
+        for i in range(8):
+            self.createPackage("coarse{:02}".format(i), "1", "1", install=True)
+            self.createPackage("coarse{:02}".format(i), "1", "2", changes="make it greener")
+
+        # update with lots of binary packages
+        for i in range(25):
+            self.createPackage("fine{:02}".format(i), "1", "1", install=True)
+            self.createPackage("fine{:02}".format(i), "1", "2", changes="make it better")
+
+        # update with long changelog
+        long_changelog = ""
+        for i in range(30):
+            long_changelog += " - Things change #{:02}\n".format(i)
+        self.createPackage("verbose", "1", "1", install=True)
+        self.createPackage("verbose", "1", "2", changes=long_changelog)
+
+        # update with lots of packages and long changelog
+        for i in range(20):
+            self.createPackage("wide-n-tall{:02}".format(i), "3", "1", install=True)
+            self.createPackage("wide-n-tall{:02}".format(i), "3", "2", changes=long_changelog)
+
+        self.enableRepo()
+
+        m.start_cockpit()
+        b.login_and_go("/updates")
+
+        b.wait_present("table.listing-ct")
+        b.wait_in_text("table.listing-ct", "Things change #05")
+
+        # "coarse" package list should be complete
+        t = b.text("#app .listing-ct tbody:nth-of-type(1) th")
+        self.assertIn("coarse00", t)
+        self.assertIn("coarse07", t)
+        self.assertNotIn("more", t)
+
+        # "fine" package list should be truncated
+        t = b.text("#app .listing-ct tbody:nth-of-type(2) th")
+        self.assertIn("fine00", t)
+        self.assertIn("fine10", t)
+        self.assertNotIn("fine20", t)
+        b.wait_present("#app .listing-ct tbody:nth-of-type(2) th a")
+        b.wait_in_text("#app .listing-ct tbody:nth-of-type(2) th a", "10 more")
+
+        # verbose changelog should be truncated
+        t = b.text("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(3)")
+        self.assertIn("Things change #00", t)
+        self.assertIn("Things change #04", t)
+        self.assertNotIn("Things change #07", t)
+        self.assertNotIn("Things change #20", t)
+        b.wait_present("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(3) a")
+        b.wait_in_text("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(3) a", "More information")
+
+        # wide-n-tall package list and changelog should both be truncated
+        t = b.text("#app .listing-ct tbody:nth-of-type(4) td:nth-of-type(3)")
+        self.assertIn("Things change #04", t)
+        self.assertNotIn("Things change #07", t)
+        b.wait_present("#app .listing-ct tbody:nth-of-type(4) th a")
+        b.wait_in_text("#app .listing-ct tbody:nth-of-type(4) th a", "5 more")
+        b.wait_present("#app .listing-ct tbody:nth-of-type(4) td:nth-of-type(3) a")
+        b.wait_in_text("#app .listing-ct tbody:nth-of-type(4) td:nth-of-type(3) a", "More information")
+
+        # expand fine package list by clicking on the "more" link
+        b.click("#app .listing-ct tbody:nth-of-type(2) th a")
+        b.wait_in_text("#app .listing-ct tbody:nth-of-type(2) th", "fine24")
+        b.wait_not_present("#app .listing-ct tbody:nth-of-type(2) th a")
+
+        # expand verbose changelog by clicking on he truncated text
+        b.click("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(3) div")
+        b.wait_in_text("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(3)", "Things change #29")
+        b.wait_not_present("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(3) a")
+
+        # clicking on package list should also expand changelog
+        b.click("#app .listing-ct tbody:nth-of-type(4) th a")
+        b.wait_in_text("#app .listing-ct tbody:nth-of-type(4) th", "wide-n-tall19")
+        b.wait_in_text("#app .listing-ct tbody:nth-of-type(4) td:nth-of-type(3)", "Things change #29")
+        b.wait_not_present("#app .listing-ct tbody:nth-of-type(4) td:nth-of-type(3) a")
 
     def testUpdateError(self):
         b = self.browser


### PR DESCRIPTION
 * Distinguishable row border color for security updates (#7170)
 * Improve widths of available updates columns (#7171 first part)
 * Truncate long package lists/changelogs, with expander (#7171, second part)

See the issues above for screenshots.