### PR TITLE
packagekit: Show Log of update actions

### DIFF
--- a/pkg/packagekit/updates.css
+++ b/pkg/packagekit/updates.css
@@ -113,6 +113,28 @@ tr.security {
     font-weight: 600;
 }
 
+.update-log {
+    padding-top: 8em;
+    margin: 0 auto;
+    max-width: 69rem;
+    text-align: center;
+}
+
+.update-log-content {
+    margin: 0 10ex;
+    height: 13em;
+    overflow-y: auto;
+}
+
+.update-log th {
+    text-align: left;
+    padding-right: 3ex;
+}
+
+.update-log td {
+    text-align: left;
+}
+
 /* Layout fix for tooltip arrows.
  *
  * Sometimes when there are non-integer coordinates involved

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -56,6 +56,14 @@ const PK_STATUS_STRINGS = {
     14: _("Verifying"),
 }
 
+const PK_STATUS_LOG_STRINGS = {
+    8: _("Downloaded"),
+    9: _("Installed"),
+    10: _("Updated"),
+    11: _("Set up"),
+    14: _("Verified"),
+}
+
 const transactionInterface = "org.freedesktop.PackageKit.Transaction";
 
 var dbus_pk = cockpit.dbus("org.freedesktop.PackageKit", { superuser: "try", "track": true });
@@ -125,6 +133,11 @@ class Expander extends React.Component {
     constructor() {
         super();
         this.state = {expanded: false};
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (this.props.onExpand && !prevState.expanded && this.state.expanded)
+            this.props.onExpand();
     }
 
     render() {
@@ -301,7 +314,9 @@ function UpdateHistory(props) {
 class ApplyUpdates extends React.Component {
     constructor() {
         super();
-        this.state = { percentage: 0, timeRemaining: null, curStatus: null, curPackage: null };
+        // actions is a chronological list of { status: PK_STATUS_*, package: "name version" } events
+        // that happen during applying updates
+        this.state = { percentage: 0, timeRemaining: null, actions: [] };
     }
 
     componentDidMount() {
@@ -319,39 +334,74 @@ class ApplyUpdates extends React.Component {
                         if ("RemainingTime" in reply[0])
                             remain = reply[0].RemainingTime.v;
                         // info: see PK_STATUS_* at https://github.com/hughsie/PackageKit/blob/master/lib/packagekit-glib2/pk-enum.h
-                        this.setState({ curPackage: pfields[0] + " " + pfields[1],
-                                        curStatus: info,
+                        let newActions = this.state.actions.slice();
+                        newActions.push({ status: info, package: pfields[0] + " " + pfields[1] });
+
+                        let log = document.getElementById("update-log");
+                        let atBottom = false;
+                        if (log) {
+                            if (log.scrollHeight - log.clientHeight <= log.scrollTop + 2)
+                                atBottom = true;
+                        }
+
+                        this.setState({ actions: newActions,
                                         percentage: percent <= 100 ? percent : 0,
                                         timeRemaining: remain > 0 ? remain : null
                         });
+
+                        // scroll update log to the bottom, if it already is (almost) at the bottom
+                        if (log && atBottom)
+                            log.scrollTop = log.scrollHeight;
                     });
             },
         });
     }
 
     render() {
-        var action;
+        var actionHTML, logRows;
 
-        if (this.state.curPackage)
-            action = (
+        if (this.state.actions.length > 0) {
+            let lastAction = this.state.actions[this.state.actions.length - 1];
+            actionHTML = (
                 <span>
-                    <strong>{ PK_STATUS_STRINGS[this.state.curStatus || PK_STATUS_ENUM_UPDATE] || PK_STATUS_STRINGS[PK_STATUS_ENUM_UPDATE] }</strong>
-                    &nbsp;{this.state.curPackage}
-                </span>
-            );
-        else
-            action = _("Initializing...");
+                    <strong>{ PK_STATUS_STRINGS[lastAction.status] || PK_STATUS_STRINGS[PK_STATUS_ENUM_UPDATE] }</strong>
+                    &nbsp;{lastAction.package}
+                </span>);
+            logRows = this.state.actions.slice(0, -1).map(action => (
+                <tr>
+                    <th>{PK_STATUS_LOG_STRINGS[action.status] || PK_STATUS_LOG_STRINGS[PK_STATUS_ENUM_UPDATE]}</th>
+                    <td>{action.package}</td>
+                </tr>));
+        } else {
+            actionHTML = _("Initializing...");
+        }
 
         return (
-            <div className="progress-main-view">
-                <div className="progress-description">
-                    <div className="spinner spinner-xs spinner-inline"></div>
-                    {action}
-                </div>
-                <div className="progress progress-label-top-right">
-                    <div className="progress-bar" role="progressbar" style={ {width: this.state.percentage + "%"} }>
-                        { this.state.timeRemaining !== null ? <span>{moment.duration(this.state.timeRemaining * 1000).humanize()}</span> : null }
+            <div>
+                <div className="progress-main-view">
+                    <div className="progress-description">
+                        <div className="spinner spinner-xs spinner-inline"></div>
+                        {actionHTML}
                     </div>
+                    <div className="progress progress-label-top-right">
+                        <div className="progress-bar" role="progressbar" style={ {width: this.state.percentage + "%"} }>
+                            { this.state.timeRemaining !== null ? <span>{moment.duration(this.state.timeRemaining * 1000).humanize()}</span> : null }
+                        </div>
+                    </div>
+                </div>
+
+                <div className="update-log">
+                    <Expander title={_("Update Log")} onExpand={() => {
+                        // always scroll down on expansion
+                        let log = document.getElementById("update-log");
+                        log.scrollTop = log.scrollHeight;
+                    }}>
+                        <div id="update-log" className="update-log-content">
+                            <table>
+                                {logRows}
+                            </table>
+                        </div>
+                    </Expander>
                 </div>
             </div>
         );

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -65,9 +65,11 @@ class TestUpdates(MachineCase):
         # empty state visible in main area
         b.wait_present(".container-fluid div.blank-slate-pf")
 
-        # create two updates
+        install_lockfile = "/tmp/finish-pk"
+        # create two updates; force installing chocolate before vanilla
         self.createPackage("vanilla", "1.0", "1", install=True)
-        self.createPackage("vanilla", "1.0", "2")
+        self.createPackage("vanilla", "1.0", "2", depends="chocolate",
+                           postinst="while [ ! -e {0} ]; do sleep 1; done; rm -f {0}".format(install_lockfile))
         self.createPackage("chocolate", "2.0", "1", install=True)
         self.createPackage("chocolate", "2.0", "2")
         self.enableRepo()
@@ -117,7 +119,20 @@ class TestUpdates(MachineCase):
         # Cancel button should eventually get disabled
         b.wait_present(".content-header-extra td button:disabled")
 
-        # should have succeeded and show restart page; cancel
+        # update log only exists in the expander, collapsed by default
+        self.assertFalse(b.is_present("#update-log"))
+        # expand it
+        b.wait_present(".expander-title span")
+        b.click(".expander-title span")
+        b.wait_present("#update-log")
+        b.wait_visible("#update-log")
+        # should eventually show chocolate when vanilla starts installing
+        b.wait_in_text("#update-log", "chocolate")
+
+        # finish the package installation
+        m.execute("touch {0}".format(install_lockfile))
+
+        # update should succeed and show restart page; cancel
         b.wait_present("#app .container-fluid h1")
         b.wait_in_text("#app .container-fluid h1", "Restart Recommended")
         b.wait_present("#app .container-fluid button.btn-primary")
@@ -438,20 +453,20 @@ class TestUpdates(MachineCase):
     # Helper functions for creating packages/repository
     #
 
-    def createPackage(self, name, version, release, install=False, postinst=None, **updateinfo):
+    def createPackage(self, name, version, release, install=False, postinst=None, depends="", **updateinfo):
         '''Create a dummy package in /tmp/repo on self.machine
 
         If install is True, install the package. Otherwise, update the package
         index in /tmp/repo.
         '''
         if self.isApt:
-            self.createDeb(name, version + '-' + release, postinst, install)
+            self.createDeb(name, version + '-' + release, depends, postinst, install)
         else:
-            self.createRpm(name, version, release, postinst, install)
+            self.createRpm(name, version, release, depends, postinst, install)
         if updateinfo:
             self.updateInfo[(name, version, release)] = updateinfo
 
-    def createDeb(self, name, version, postinst, install):
+    def createDeb(self, name, version, depends, postinst, install):
         '''Create a dummy deb in /tmp/repo on self.machine
 
         If install is True, install the package. Otherwise, update the package
@@ -463,17 +478,17 @@ class TestUpdates(MachineCase):
         else:
             postinstcode = ''
         cmd = '''mkdir -p /tmp/b/DEBIAN /tmp/repo
-                 printf "Package: {0}\nVersion: {1}\nPriority: optional\nSection: test\nMaintainer: foo\nArchitecture: all\nDescription: dummy {0}\n" > /tmp/b/DEBIAN/control
-                 {3}
+                 printf "Package: {0}\nVersion: {1}\nPriority: optional\nSection: test\nMaintainer: foo\nDepends: {2}\nArchitecture: all\nDescription: dummy {0}\n" > /tmp/b/DEBIAN/control
+                 {4}
                  touch /tmp/b/stamp-{0}-{1}
-                 dpkg -b /tmp/b {2}
+                 dpkg -b /tmp/b {3}
                  rm -r /tmp/b
-                 '''.format(name, version, deb, postinstcode)
+                 '''.format(name, version, depends, deb, postinstcode)
         if install:
             cmd += "dpkg -i " + deb
         self.machine.execute(cmd)
 
-    def createRpm(self, name, version, release, post, install):
+    def createRpm(self, name, version, release, requires, post, install):
         '''Create a dummy rpm in /tmp/repo on self.machine
 
         If install is True, install the package. Otherwise, update the package
@@ -483,16 +498,18 @@ class TestUpdates(MachineCase):
             postcode = '\n%%post\n' + post
         else:
             postcode = ''
-        cmd = '''printf 'Summary: dummy {0}\nName: {0}\nVersion: {1}\nRelease: {2}\nLicense: BSD\nBuildArch: noarch\n
+        if requires:
+            requires = "Requires: %s\n" % requires
+        cmd = '''printf 'Summary: dummy {0}\nName: {0}\nVersion: {1}\nRelease: {2}\nLicense: BSD\nBuildArch: noarch\n{3}
 %%install\ntouch $RPM_BUILD_ROOT/stamp-{0}-{1}-{2}\n
 %%description\nTest package.\n
 %%files\n/stamp-*\n
-{3}' > /tmp/spec
+{4}' > /tmp/spec
                  rpmbuild -bb  /tmp/spec
                  mkdir -p /tmp/repo
                  cp ~/rpmbuild/RPMS/noarch/*.rpm /tmp/repo
                  rm -rf ~/rpmbuild
-                 '''.format(name, version, release, postcode)
+                 '''.format(name, version, release, requires, postcode)
         if install:
             cmd += "rpm -i /tmp/repo/{0}-{1}-{2}.*.rpm".format(name, version, release)
         self.machine.execute(cmd)


### PR DESCRIPTION
In ApplyUpdates, remember all reported PackageKit actions instead of
just the last one, and display them in a log view in an expander below
the progress bar.

Automatically keep the update log scrolled to the bottom as long as it
is (almost) at the bottom already, so that without human interference it
always shows the latest information. Also scroll to the bottom when the
Expander gets opened; add a new `onExpand()` callback for this purpose.
    
Check this in TestUpdates.testBasic(). For that the test needs to
enforce an ordering on package updates, so add dependencies to the
generated test packages.
