### PR TITLE
naughty: Close 5662: CentOS 7: NetworkManager crash assertion devices/nm-device.c:8954

### DIFF
--- a/bots/naughty/centos-7/5662-networkmanager-assertion-devices
+++ b/bots/naughty/centos-7/5662-networkmanager-assertion-devices
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-networking", line *, in testBasic
-    b.wait_popdown("network-ip-settings-dialog")
-*
-connection ens6 cannot change the UUID from


### PR DESCRIPTION
Known issue which has not occurred in 166.0 days

CentOS 7: NetworkManager crash assertion devices/nm-device.c:8954

Fixes #5662