### PR TITLE
naughty: Close 5378: Fedora 25: Storaged (udisksd) crashes with unknown backtrace

### DIFF
--- a/bots/naughty/fedora-25/5378-storaged-udisksd-crash
+++ b/bots/naughty/fedora-25/5378-storaged-udisksd-crash
@@ -1,6 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-storage-lvm2", line 113, in testLvm
-    "DISK2": True }})
-*
-Error: timeout
-Message recipient disconnected from message bus without replying


### PR DESCRIPTION
Known issue which has not occurred in 231.0 days

Fedora 25: Storaged (udisksd) crashes with unknown backtrace

Fixes #5378