### PR TITLE
naughty: Close 5340: Debian: Docker fails to run due to new systemd cgroup layout

### DIFF
--- a/bots/naughty/debian-stable/5340-oci-systemd-cgroup-layout
+++ b/bots/naughty/debian-stable/5340-oci-systemd-cgroup-layout
@@ -1,2 +1,0 @@
-Error: timeout
-rpc error: code = 2 desc = "oci runtime error: could not synchronise with container process: no subsystem for mount"

--- a/bots/naughty/debian-testing/5340-oci-systemd-cgroup-layout
+++ b/bots/naughty/debian-testing/5340-oci-systemd-cgroup-layout
@@ -1,2 +1,0 @@
-Error: timeout
-rpc error: code = 2 desc = "oci runtime error: could not synchronise with container process: no subsystem for mount"


### PR DESCRIPTION
Known issue which has not occurred in 231.0 days

Debian: Docker fails to run due to new systemd cgroup layout

Fixes #5340