### PR TITLE
naughty: Close 3326: Atomic: User cannot change port with selinux enabled

### DIFF
--- a/bots/naughty/fedora-atomic/3326-atomic-broken-semanage
+++ b/bots/naughty/fedora-atomic/3326-atomic-broken-semanage
@@ -1,1 +1,0 @@
-    m1.execute("! selinuxenabled || semanage port -a -t ssh_port_t -p tcp 2222")


### PR DESCRIPTION
Known issue which has not occurred in 193.0 days

Atomic: User cannot change port with selinux enabled

Fixes #3326