### PR TITLE
naughty: Close 6331: Fedora: lsblk -sl has unexpected output ordering 

### DIFF
--- a/bots/naughty/fedora-26/6331-lsblk-order-regression
+++ b/bots/naughty/fedora-26/6331-lsblk-order-regression
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-docker-storage", line *, in testDevmapper
-    b.wait_not_in_text("#storage-drives", "DISK1")


### PR DESCRIPTION
Known issue which has not occurred in 7.0 days

Fedora: lsblk -sl has unexpected output ordering 

Fixes #6331