### PR TITLE
naughty: Close 5998: Fedora: storaged asserts and crashes in handle_format()

### DIFF
--- a/bots/naughty/fedora-25/5998-storaged-handle-format-assert
+++ b/bots/naughty/fedora-25/5998-storaged-handle-format-assert
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-storage-format", line *, in testFormatTypes
-    check_type(*)
-*
-Message recipient disconnected from message bus without replying


### PR DESCRIPTION
Known issue which has not occurred in 59.0 days

Fedora: storaged asserts and crashes in handle_format()

Fixes #5998