### PR TITLE
naughty: Close 5754: Fedora, RHEL, Atomic: atomic scan VulnerabilityInfo DBus API is broken

### DIFF
--- a/bots/naughty/continuous-atomic/5754-atomic-vulnerabilityinfo-broken
+++ b/bots/naughty/continuous-atomic/5754-atomic-vulnerabilityinfo-broken
@@ -1,1 +1,0 @@
-../naughty-fedora-25/5754-atomic-vulnerabilityinfo-broken

--- a/bots/naughty/fedora-24/5754-atomic-vulnerabilityinfo-broken
+++ b/bots/naughty/fedora-24/5754-atomic-vulnerabilityinfo-broken
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-docker", line *, in testBasic
-    b.wait_present(row_selector + ' td span.pficon-warning-triangle-o')

--- a/bots/naughty/fedora-25/5754-atomic-vulnerabilityinfo-broken
+++ b/bots/naughty/fedora-25/5754-atomic-vulnerabilityinfo-broken
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-docker", line *, in testBasic
-    b.wait_present(row_selector + ' td span.pficon-warning-triangle-o')

--- a/bots/naughty/fedora-26/5754-atomic-vulnerabilityinfo-broken
+++ b/bots/naughty/fedora-26/5754-atomic-vulnerabilityinfo-broken
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-docker", line *, in testBasic
-    b.wait_present(row_selector + ' td span.pficon-warning-triangle-o')

--- a/bots/naughty/rhel-7/5754-atomic-vulnerabilityinfo-broken
+++ b/bots/naughty/rhel-7/5754-atomic-vulnerabilityinfo-broken
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-docker", line *, in testBasic
-    b.wait_present(row_selector + ' td span.pficon-warning-triangle-o')


### PR DESCRIPTION
Known issue which has not occurred in 46.0 days

Fedora, RHEL, Atomic: atomic scan VulnerabilityInfo DBus API is broken

Fixes #5754