### PR TITLE
naughty: Close 5671: Fedora 25: NetworkManager crash assertion devices/nm-device.c:9015

### DIFF
--- a/bots/naughty/fedora-25/5671-network-manager-crash-assertion
+++ b/bots/naughty/fedora-25/5671-network-manager-crash-assertion
@@ -1,1 +1,0 @@
-Error: org.freedesktop.NetworkManager: couldn't introspect*GDBus.Error:org.freedesktop.DBus.Error.NoReply: Message recipient disconnected from message bus without replying


### PR DESCRIPTION
Known issue which has not occurred in 172.0 days

Fedora 25: NetworkManager crash assertion devices/nm-device.c:9015

Fixes #5671