### PR TITLE
naughty: Close 5010: Fedora, RHEL, CentOS: SELinux prevents password expiry reset from working

### DIFF
--- a/bots/naughty/centos-7/5010-selinux-cracklib
+++ b/bots/naughty/centos-7/5010-selinux-cracklib
@@ -1,1 +1,0 @@
-comm="cockpit-session" name="cracklib"

--- a/bots/naughty/centos-7/5010-selinux-password-expiry
+++ b/bots/naughty/centos-7/5010-selinux-password-expiry
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-login", line 181, in testExpired
-    b.wait_in_text("#conversation-prompt", "Retype")

--- a/bots/naughty/rhel-7/5010-selinux-cracklib
+++ b/bots/naughty/rhel-7/5010-selinux-cracklib
@@ -1,1 +1,0 @@
-comm="cockpit-session" name="cracklib"


### PR DESCRIPTION
Known issue which has not occurred in 196.0 days

Fedora, RHEL, CentOS: SELinux prevents password expiry reset from working

Fixes #5010