### PR TITLE
naughty: Close 6432: Fedora: dockerd-current crashes with double-free

### DIFF
--- a/bots/naughty/fedora-26/6432-dockerd-current-double-free
+++ b/bots/naughty/fedora-26/6432-dockerd-current-double-free
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-docker", line *, in testBasic
-    b.wait_visible("#container-details-start")
-*
-Error: timeout

--- a/bots/naughty/fedora-26/6432-dockerd-current-double-free-2
+++ b/bots/naughty/fedora-26/6432-dockerd-current-double-free-2
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-docker", line *, in testBasic
-    b.wait_visible("#container-details")
-*
-Error: timeout

--- a/bots/naughty/rhel-7-4/6432-dockerd-current-double-free
+++ b/bots/naughty/rhel-7-4/6432-dockerd-current-double-free
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-docker", line *, in testBasic
-    b.wait_visible("#container-details-start")
-*
-Error: timeout

--- a/bots/naughty/rhel-7-4/6432-dockerd-current-double-free-2
+++ b/bots/naughty/rhel-7-4/6432-dockerd-current-double-free-2
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "./verify/check-docker", line *, in testBasic
-    b.wait_visible("#container-details")
-*
-Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 26.0 days

Fedora: dockerd-current crashes with double-free

Fixes #6432