### PR TITLE
tools: Fix clobbering of $DH_OPTIONS for Ubuntu 16.04 builds

### DIFF
--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -11,7 +11,7 @@ endif
 # PackageKit crashes on update information on Ubuntu 16.04, which makes
 # "Software Updates" useless (LP: #1689820)
 ifneq ($(shell grep xenial /etc/os-release),)
-	export DH_OPTIONS = -Ncockpit-packagekit
+	export DH_OPTIONS += -Ncockpit-packagekit
 endif
 
 %:


### PR DESCRIPTION
When building for xenial (Ubuntu 16.04 LTS), don't clobber the
previously set `$DH_OPTIONS` from above. This fixes the build failure in
xenial-backports.

Regression introduced in commit 45c2edbf93a.

---

See arch links in https://launchpad.net/ubuntu/+source/cockpit/145-1~ubuntu16.04.1 for the failed build logs. I verified the failuire and fix locally in a xenial schroot.