### PR TITLE
bots: Add labels to bot created pull requests

### DIFF
--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -359,7 +359,7 @@ def branch(context, message, pathspec=".", issue=None, **kwargs):
 
     return "{0}:{1}".format(user, branch)
 
-def pull(branch, body=None, issue=None, **kwargs):
+def pull(branch, body=None, issue=None, labels=['bot'], **kwargs):
     if "pull" in kwargs:
         return kwargs["pull"]
 
@@ -386,6 +386,9 @@ def pull(branch, body=None, issue=None, **kwargs):
             data["maintainer_can_modify"] = False
         pull = api.post("pulls", data)
 
+    # Update the pull request
+    label(pull, labels)
+
     # Update the issue if it is a dict
     if issue:
         try:
@@ -395,6 +398,13 @@ def pull(branch, body=None, issue=None, **kwargs):
             pass
 
     return pull
+
+def label(issue, labels=['bot']):
+    try:
+        resource = "issues/{0}/labels".format(issue["number"])
+    except TypeError:
+        resource = "issues/{0}/labels".format(issue)
+    return api.post(resource, labels)
 
 def comment(issue, comment):
     try:

--- a/bots/task/test-task
+++ b/bots/task/test-task
@@ -77,8 +77,13 @@ def mockServer():
             if self.path == "/repos/project/repo/pulls":
                 content_len = int(self.headers.getheader('content-length'))
                 data = json.loads(self.rfile.read(content_len))
+                data["number"] = 1234
                 self.replyJson(data)
             elif self.path == "/repos/project/repo/issues/1234/comments":
+                content_len = int(self.headers.getheader('content-length'))
+                data = json.loads(self.rfile.read(content_len))
+                self.replyJson(data)
+            elif self.path == "/repos/project/repo/issues/1234/labels":
                 content_len = int(self.headers.getheader('content-length'))
                 data = json.loads(self.rfile.read(content_len))
                 self.replyJson(data)
@@ -130,6 +135,10 @@ class TestTask(unittest.TestCase):
     def testComment(self):
         comment = task.comment(1234, "This is the comment")
         self.assertEqual(comment["body"], "This is the comment")
+
+    def testLabel(self):
+        label = task.label(1234, ['xxx'])
+        self.assertEqual(label, ['xxx'])
 
     def testPullBody(self):
         args = { "title": "Task title" }


### PR DESCRIPTION
By default add a 'bot' label to bot created pull requests. This
worked for issues turned into pull requests, but did not function
as expected for newly created pull requests.