### PR TITLE
test: Recognize skipped tests and don't check journal

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -493,8 +493,8 @@ class MachineCase(unittest.TestCase):
         for success in self.currentResult.unexpectedSuccesses:
             if self == success:
                 return False
-        for success in self.currentResult.skipped:
-            if self == success:
+        for skipped in self.currentResult.skipped:
+            if self == skipped[0]:
                 return False
         return True
 


### PR DESCRIPTION
We shouldn't be checking the journal for skipped tests. The journal
is likely to have strange messages in it.

This is a regression from b772ad73975359b3b2ad1570cf40d90a788910bf