### PR TITLE
DEBUG: testMachinesJsonVarMigration - ignore/don't merge

### DIFF
--- a/src/bridge/cockpitdbusmachines.c
+++ b/src/bridge/cockpitdbusmachines.c
@@ -176,7 +176,7 @@ migrate_var_config (void)
   /* TOCTOU, but if we really miss this, we'll migrate it the next time */
   if (!g_file_test (var_path, G_FILE_TEST_IS_REGULAR))
     {
-      g_debug ("%s does not exist, nothing to migrate", var_path);
+      g_info ("XXXXX %s does not exist, nothing to migrate", var_path);
       return;
     }
 
@@ -186,6 +186,8 @@ migrate_var_config (void)
       g_message ("failed to create %s, Cockpit will not work properly: %m", get_machines_json_dir ());
       return;
     }
+
+  g_message("XXXXX %s exists and created %s, attempting migration", var_path, get_machines_json_dir ());
 
   /* common case is to move it to 99-webui.json */
   gchar *etc_path = g_build_filename (get_machines_json_dir (), "99-webui.json", NULL);
@@ -300,6 +302,9 @@ cockpit_dbus_machines_startup (void)
   /* only attempt this in a privileged bridge, otherwise we get confusing failure messages */
   if (g_access ("/etc/cockpit", W_OK) >= 0)
     migrate_var_config ();
+  else
+    g_info("XXXXX /etc/cockpit is not writable, skipping migration; running as uid %u; file exists: %i",
+           getuid(), g_file_test("/etc/cockpit", G_FILE_TEST_EXISTS));
 
   /* watch for file changes and send D-Bus signal for it */
   machines_monitor_file = g_file_new_for_path (get_machines_json_dir ());

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -303,36 +303,51 @@ class TestDashboardSetup(MachineCase, DashBoardHelpers):
         b = self.browser
         m = self.machine
 
-        # create obsolete machines.json in /var
-        blue_conf = '{"blue": {"address": "1.2.3.4", "visible": true}}'
-        m.execute("echo '%s' > /var/lib/cockpit/machines.json" % blue_conf)
-        # prevent migration due to permission error; should not crash and keep/respect the old file
-        m.execute("""chattr +i /etc/cockpit/machines.d""")
-        self.login_and_go("/dashboard")
-        wait(lambda: m.execute("journalctl -b | grep 'migration.*machines.json.*failed'"))
-        self.wait_dashboard_addresses (b, [ "localhost", "1.2.3.4" ])
-        b.logout()
-        # should not have written anything and left the original file untouched
-        m.execute('chattr -i /etc/cockpit/machines.d && [ "$(ls /etc/cockpit/machines.d)" = "" ]')
-        self.assertEqual(m.execute("cat /var/lib/cockpit/machines.json").strip(), blue_conf)
-        self.allow_journal_messages(".*migration of /var/lib/cockpit/machines.json to /etc/cockpit/machines.d/99-webui.json failed:.*")
+        def goDashboardWithSuperuser():
+            # force spawning of privileged bridge
+            self.login_and_go("/playground/test", authorized=True)
+            b.wait_present(".super-channel .btn")
+            b.click(".super-channel .btn")
+            b.wait_in_text(".super-channel span", 'result:')
+            b.switch_to_top()
+            b.go("/dashboard")
+            b.enter_page("/dashboard")
 
-        # now machines.d/ is writable, should migrate
-        self.login_and_go("/dashboard")
-        wait(lambda: m.execute("test ! -e /var/lib/cockpit/machines.json && ls /etc/cockpit/machines.d/99-webui.json"))
-        self.wait_dashboard_addresses (b, [ "localhost", "1.2.3.4" ])
-        b.logout()
-        self.assertEqual(m.execute('cat /etc/cockpit/machines.d/99-webui.json').strip(), blue_conf)
+        try:
+            # create obsolete machines.json in /var
+            blue_conf = '{"blue": {"address": "10.111.113.2", "visible": true}}'
+            m.execute("echo '%s' > /var/lib/cockpit/machines.json" % blue_conf)
+            # prevent migration due to permission error; should not crash and keep/respect the old file
+            m.execute("""chattr +i /etc/cockpit/machines.d""")
+            goDashboardWithSuperuser()
+            self.wait_dashboard_addresses (b, [ "localhost", "10.111.113.2" ])
+            wait(lambda: m.execute("journalctl -b | grep 'migration.*machines.json.*failed'"))
+            b.logout()
+            # should not have written anything and left the original file untouched
+            m.execute('chattr -i /etc/cockpit/machines.d && [ "$(ls /etc/cockpit/machines.d)" = "" ]')
+            self.assertEqual(m.execute("cat /var/lib/cockpit/machines.json").strip(), blue_conf)
+            self.allow_journal_messages(".*migration of /var/lib/cockpit/machines.json to /etc/cockpit/machines.d/99-webui.json failed:.*")
 
-        # old /var file should not clobber existing 99-webui.json but move to 98-migrated.json and merge its data
-        green_conf = '{"green": {"address": "9.8.7.6", "visible": true}}'
-        m.execute("echo '%s' > /var/lib/cockpit/machines.json" % green_conf)
-        self.login_and_go("/dashboard")
-        wait(lambda: m.execute("test ! -e /var/lib/cockpit/machines.json && ls /etc/cockpit/machines.d/98-migrated.json"))
-        self.wait_dashboard_addresses (b, [ "localhost", "1.2.3.4", "9.8.7.6" ])
-        b.logout()
-        self.assertEqual(m.execute('cat /etc/cockpit/machines.d/99-webui.json').strip(), blue_conf)
-        self.assertEqual(m.execute('cat /etc/cockpit/machines.d/98-migrated.json').strip(), green_conf)
+            # now machines.d/ is writable, should migrate
+            goDashboardWithSuperuser()
+            self.wait_dashboard_addresses (b, [ "localhost", "10.111.113.2" ])
+            wait(lambda: m.execute("test ! -e /var/lib/cockpit/machines.json && ls /etc/cockpit/machines.d/99-webui.json"))
+            b.logout()
+            self.assertEqual(m.execute('cat /etc/cockpit/machines.d/99-webui.json').strip(), blue_conf)
+
+            # old /var file should not clobber existing 99-webui.json but move to 98-migrated.json and merge its data
+            green_conf = '{"green": {"address": "10.111.113.3", "visible": true}}'
+            m.execute("echo '%s' > /var/lib/cockpit/machines.json" % green_conf)
+            goDashboardWithSuperuser()
+            wait(lambda: m.execute("test ! -e /var/lib/cockpit/machines.json && ls /etc/cockpit/machines.d/98-migrated.json"))
+            self.wait_dashboard_addresses (b, [ "localhost", "10.111.113.2", "10.111.113.3" ])
+            b.logout()
+            self.assertEqual(m.execute('cat /etc/cockpit/machines.d/99-webui.json').strip(), blue_conf)
+            self.assertEqual(m.execute('cat /etc/cockpit/machines.d/98-migrated.json').strip(), green_conf)
+        except:
+            print(m.execute("ps aux | grep cockpit-bridge; ls -lR /etc/cockpit /var/lib/cockpit; grep -r .  /etc/cockpit /var/lib/cockpit"))
+            raise
+
         self.allow_journal_messages(
             '.* couldn\'t connect: .*',
             '.*refusing to connect to unknown host.*'


### PR DESCRIPTION
Add more verbiage and first wait for the machine to appear in the dashboard before waiting for the migration.

This is for debugging #7313. I only need the logs from a failed run from production as I can't reproduce this locally for the life of me.