### PR TITLE
common: Use cockpit.conf for fatal criticals

### DIFF
--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -130,6 +130,19 @@ ProtocolHeader = X-Forwarded-Proto
     </variablelist>
   </refsect1>
 
+  <refsect1 id="cockpit-conf-log">
+    <title>Log</title>
+    <variablelist>
+      <varlistentry>
+        <term><option>Fatal</option></term>
+        <listitem>
+          <para>The kind of log messages in the bridge to treat as fatal. Separate multiple values
+            with spaces. Relevant values are: <code>criticals</code> and <code>warnings</code>.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+
   <refsect1 id="cockpit-conf-oauth">
     <title>OAuth</title>
     <para>Cockpit can be configured to support the <ulink url="https://tools.ietf.org/html/rfc6749#section-4.2">

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -382,9 +382,9 @@ testassetsdir = $(prefix)/lib/cockpit-test-assets
 testserviceddir = $(systemdunitdir)/cockpit.service.d
 
 install-tests::
-	$(MKDIR_P) $(DESTDIR)$(testassetsdir) $(DESTDIR)$(testserviceddir)
+	$(MKDIR_P) $(DESTDIR)$(testassetsdir) $(DESTDIR)$(testserviceddir) $(DESTDIR)/etc/cockpit
 	$(INSTALL_DATA) mock-pam-conv-mod.so $(DESTDIR)$(testassetsdir)
-	$(INSTALL_DATA) $(srcdir)/src/ws/fatal.conf $(DESTDIR)$(testserviceddir)
+	$(INSTALL_DATA) $(srcdir)/src/ws/fatal.conf $(DESTDIR)/etc/cockpit/cockpit.conf
 
 install-exec-hook::
 	mkdir -p $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/machines.d

--- a/src/ws/fatal.conf
+++ b/src/ws/fatal.conf
@@ -1,2 +1,2 @@
-[Service]
-Environment=G_DEBUG=fatal-criticals
+[Log]
+Fatal = criticals

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -450,7 +450,7 @@ This package contains tests and files used while testing Cockpit.
 These files are not required for running Cockpit.
 
 %files tests
-%{_unitdir}/cockpit.service.d
+%config(noreplace) %{_sysconfdir}/cockpit/cockpit.conf
 %{_datadir}/%{name}/playground
 %{_prefix}/lib/cockpit-test-assets
 


### PR DESCRIPTION
The way that our testing uses environment variables to setup
fatal criticals during testing doesn't work for the privileged
bridge or other bridges. Both pkexec and sudo clean out the
environment.

So lets use cockpit.conf to configure this consistently across
all cockpit processes.