### PR TITLE
test: The terminal test needs a DNS server

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -574,7 +574,9 @@ class MachineCase(unittest.TestCase):
             address = provision[key].get("address")
             if address is not None:
                 machine.set_address(address)
-                machine.set_dns(provision[key].get("dns"))
+            dns = provision[key].get("dns")
+            if address or dns:
+                machine.set_dns(dns)
             dhcp = provision[key].get("dhcp", False)
             if dhcp:
                 machine.dhcp_server()

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -22,6 +22,8 @@ import parent
 from testlib import *
 
 class TestTerminal(MachineCase):
+    provision = { "machine1": { "dns": "127.0.0.1" } }
+
     def testBasic(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
The terminal test needs a DNS server on certain operating systems
such as debian-stable in order not to timeout on printing the prompt.

This is likely a bug in debian-stable but affects far far more
than Cockpit.