### PR TITLE
test: Use netcat instead of ssh in network load test

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -21,6 +21,7 @@
 import os
 
 import parent
+import time
 from testlib import *
 
 def read_mem_info(machine):
@@ -126,8 +127,19 @@ class TestMetrics(MachineCase):
         #
         identity = m._calc_identity()
         m.upload([ identity ], "/var/tmp")
+        (eth_before, lo_before) = m.execute(r"grep -E 'eth0|ens5' /proc/net/dev | awk '{print $2 + $10}'; "
+                                            r"grep '\blo:' /proc/net/dev | awk '{print $2 + $10}'").strip().split()
+        time_before = time.time()
         net_pid = m.spawn("ssh -o StrictHostKeyChecking=no -i /var/tmp/{1} {0} cat /dev/zero >/dev/null".format("172.27.0.15", os.path.basename(identity)), "load-net.log")
-        b.wait_js_func("ph_flot_data_plateau", "#server_network_traffic_graph", 300*1000, None, 5, "net io");
+        try:
+            b.wait_js_func("ph_flot_data_plateau", "#server_network_traffic_graph", 300*1000, None, 5, "net io");
+        finally:
+            time_after = time.time()
+            (eth_after, lo_after) = m.execute(r"grep -E 'eth0|ens5' /proc/net/dev | awk '{print $2 + $10}'; "
+                                              r"grep '\blo:' /proc/net/dev | awk '{print $2 + $10}'").strip().split()
+            print("Measured {0:.1f}s of network traffic; eth0/ens5: {1} bytes, lo: {2} bytes".format(
+                time_after - time_before, int(eth_after) - int(eth_before), int(lo_after) - int(lo_before)))
+
         m.execute("kill %d" % net_pid)
 
     @skipImage("No PCP available on Atomic", "fedora-atomic", "rhel-atomic", "continuous-atomic")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -18,8 +18,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-import os
-
 import parent
 import time
 from testlib import *
@@ -125,12 +123,13 @@ class TestMetrics(MachineCase):
 
         # Network.  Anything above 300 kb/s is good for now.
         #
-        identity = m._calc_identity()
-        m.upload([ identity ], "/var/tmp")
         (eth_before, lo_before) = m.execute(r"grep -E 'eth0|ens5' /proc/net/dev | awk '{print $2 + $10}'; "
                                             r"grep '\blo:' /proc/net/dev | awk '{print $2 + $10}'").strip().split()
         time_before = time.time()
-        net_pid = m.spawn("ssh -o StrictHostKeyChecking=no -i /var/tmp/{1} {0} cat /dev/zero >/dev/null".format("172.27.0.15", os.path.basename(identity)), "load-net.log")
+        # -q is necessary with netcat-openbsd, but does not exist with nmap-nc
+        net_pid = m.spawn("nc `nc -h 2>&1| grep -q -- -q && echo '-q -1' || true` -l 2000 </dev/null >/dev/null", "load-net.log")
+        # client dies automatically once the server gets killed and the port closed
+        m.spawn("nc 172.27.0.15 2000 </dev/zero >/dev/null", "load-net-client.log")
         try:
             b.wait_js_func("ph_flot_data_plateau", "#server_network_traffic_graph", 300*1000, None, 5, "net io");
         finally:


### PR DESCRIPTION
On some test VMs (notably rhel-atomic), launching ssh inside takes very
long and does not generate much traffic (possibly while the RNG is not
yet initialized). Use netcat instead of ssh to generate the network to
alleviate bottlenecks from encryption.

We need to support at least netcat-openbsd (on Debian/Ubuntu) and
nmap-nc, which differ in their default behaviour of EOF. The former
needs "-q -1" to continue listening, the latter does not support this
option; check nc's help to determine if it is supported.

Fixes #7318

Add debug information to check-metrics network load.