### PR TITLE
kubernetes: Handle url encoded selfLinks

### DIFF
--- a/pkg/kubernetes/scripts/kube-client.js
+++ b/pkg/kubernetes/scripts/kube-client.js
@@ -273,9 +273,6 @@
 
         /*
          * Combine into a path.
-         *
-         * Kubernetes names and namespaces are quite limited in their contents
-         * and do not need escaping to be used in a URI path.
          */
         var schema = SCHEMA[args[0]] || SCHEMA[""];
         var path = schema.api;
@@ -283,7 +280,8 @@
             path += "/namespaces/" + args[2];
         path += "/" + schema.type;
         if (args[1])
-            path += "/" + args[1];
+            path += "/" + encodeURIComponent(args[1]);
+
         return path;
     }
 
@@ -486,7 +484,7 @@
                 for (i = 0, len = drain.length; i < len; i++) {
                     resource = drain[i].object;
                     if (resource) {
-                        link = resourcePath([resource]);
+                        link = decodeURIComponent(resourcePath([resource]));
                         if (drain[i].type == "DELETED") {
                             delete objects[link];
                             removed[link] = resource;

--- a/pkg/kubernetes/scripts/test-kube-client.js
+++ b/pkg/kubernetes/scripts/test-kube-client.js
@@ -100,6 +100,56 @@ var FIXTURE_LARGE = require("./fixture-large");
         }
     ]);
 
+
+    kubeTest("loader load encoding", 2, FIXTURE_BASIC, [
+        "kubeLoader",
+        "kubeSelect",
+        "$q",
+        function(loader, select, $q) {
+            assert.equal(select().kind("Encoded").length, 0);
+
+            var defer = $q.defer();
+            var x = loader.listen(function() {
+                assert.equal(select().kind("Image").length, 1);
+                x.cancel();
+                defer.resolve();
+            });
+
+            loader.handle([{
+                "apiVersion": "v1",
+                "kind": "Image",
+                "metadata": {
+                    "name": "encoded:one",
+                    "resourceVersion": 10000,
+                    "uid": "11768037-ab8a-11e4-9a7c-100001001",
+                    "namespace": "default",
+                    "selfLink": "/oapi/v1/images/encoded%3Aone",
+                },
+            }, {
+                "apiVersion": "v1",
+                "kind": "Image",
+                "metadata": {
+                    "name": "encoded:one",
+                    "resourceVersion": 10000,
+                    "uid": "11768037-ab8a-11e4-9a7c-100001001",
+                    "namespace": "default",
+                },
+            }, {
+                "apiVersion": "v1",
+                "kind": "Image",
+                "metadata": {
+                    "name": "encoded:one",
+                    "resourceVersion": 10000,
+                    "uid": "11768037-ab8a-11e4-9a7c-100001001",
+                    "namespace": "default",
+                    "selfLink": "/oapi/v1/images/encoded:one",
+                },
+            }]);
+
+            return defer.promise;
+        }
+    ]);
+
     kubeTest("loader load fail", 3, FIXTURE_BASIC, [
         "kubeLoader",
         function(loader) {


### PR DESCRIPTION
Parts of a selfLink may be url encoded. We need links to match even when they were created without knowing the selfLink. Because not all versions of kube do this the same way url encode the name portion when building a resourcePath and url decode the path that is used as the key in the object.