### PR TITLE
test: Give PackageKit update test more time on slow runners

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -341,7 +341,7 @@ class TestUpdates(MachineCase):
 
         # updating this package takes longer than a cockpit start and building the page
         self.createPackage("slow", "1", "1", install=True)
-        self.createPackage("slow", "1", "2",  postinst='sleep 10')
+        self.createPackage("slow", "1", "2",  postinst='sleep 20')
         self.enableRepo()
         m.execute("pkcon refresh")
 


### PR DESCRIPTION
`check-packagekit TestUpdates.testRunningUpdate()` sometimes fails
because after restarting cockpit the update is already done, i. e. the
restart took almost 10s. Double the time to reduce the race.

----

Example: https://fedorapeople.org/groups/cockpit/logs/pull-7323-20170719-045555-c9bccb8a-verify-fedora-i386/log.html#57