### PR TITLE
bots: Download fedora-26 image during tests-invoke

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -204,7 +204,9 @@ class PullTask(object):
         try:
             # Download all the additional images so that even older branches find them
             subprocess.check_call([ os.path.join(BOTS, "image-download"),
-                "candlepin", "fedora-stock", "fedora-23-stock", "ipa", "openshift", "selenium" ])
+                "candlepin", "fedora-stock", "fedora-23-stock", "fedora-26",
+                "ipa", "openshift", "selenium"
+            ])
 
         except subprocess.CalledProcessError:
             return "Downloading of additional images failed"


### PR DESCRIPTION
Lets download the fedora-26 image during tests-invoke. It's used
by tests like the networking tests to run a DHCP server. Doing
it during the tests results in slow downloads due to wasteful
parallel downloads.