### PR TITLE
test: Remove libvirt VirtEvent handling from test code

### DIFF
--- a/bots/image-create
+++ b/bots/image-create
@@ -132,8 +132,7 @@ class MachineBuilder:
         self.machine.start()
         self.machine.reset_reboot_flag()
         try:
-            # it could be that selinux relabeling needs a reboot
-            self.machine.wait_boot(wait_for_running_timeout=120, allow_one_reboot=True)
+            self.machine.wait_boot(wait_for_running_timeout=120)
         finally:
             self.machine.stop(timeout_sec=120)
 

--- a/bots/image-create
+++ b/bots/image-create
@@ -89,7 +89,7 @@ class MachineBuilder:
         """Prepare a test image further by running some commands in it."""
         self.machine.start()
         try:
-            self.machine.wait_boot(wait_for_running_timeout=120)
+            self.machine.wait_boot(timeout_sec=120)
             self.machine.upload([ os.path.join(BOTS, "images", "scripts", "lib") ], "/var/lib/testvm")
             self.machine.upload([script], "/var/tmp/SETUP")
             if source:
@@ -130,9 +130,8 @@ class MachineBuilder:
         This also takes care of any selinux relabeling setup triggered
         Don't wait for an ip address during start, since the system might reboot"""
         self.machine.start()
-        self.machine.reset_reboot_flag()
         try:
-            self.machine.wait_boot(wait_for_running_timeout=120)
+            self.machine.wait_boot(timeout_sec=120)
         finally:
             self.machine.stop(timeout_sec=120)
 

--- a/bots/images/scripts/candlepin.setup
+++ b/bots/images/scripts/candlepin.setup
@@ -40,8 +40,6 @@ yum clean all
 rm -rf /var/log/journal/*
 echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" > /etc/sysctl.d/50-coredump.conf
 
-touch /.autorelabel
-
 # Audit events to the journal
 rm -f '/etc/systemd/system/multi-user.target.wants/auditd.service'
 rm -rf /var/log/audit/

--- a/bots/images/scripts/fedora-24.setup
+++ b/bots/images/scripts/fedora-24.setup
@@ -135,8 +135,6 @@ printf "SELINUX=enforcing\nSELINUXTYPE=targeted\n" > /etc/selinux/config
 # Prevent SSH from hanging for a long time when no external network access
 echo 'UseDNS no' >> /etc/ssh/sshd_config
 
-touch /.autorelabel
-
 # Audit events to the journal
 rm -f '/etc/systemd/system/multi-user.target.wants/auditd.service'
 rm -rf /var/log/audit/

--- a/bots/images/scripts/fedora-25.setup
+++ b/bots/images/scripts/fedora-25.setup
@@ -134,8 +134,6 @@ printf "SELINUX=enforcing\nSELINUXTYPE=targeted\n" > /etc/selinux/config
 # Prevent SSH from hanging for a long time when no external network access
 echo 'UseDNS no' >> /etc/ssh/sshd_config
 
-touch /.autorelabel
-
 # Audit events to the journal
 rm -f '/etc/systemd/system/multi-user.target.wants/auditd.service'
 rm -rf /var/log/audit/

--- a/bots/images/scripts/fedora-26.setup
+++ b/bots/images/scripts/fedora-26.setup
@@ -137,8 +137,6 @@ printf "SELINUX=enforcing\nSELINUXTYPE=targeted\n" > /etc/selinux/config
 # Prevent SSH from hanging for a long time when no external network access
 echo 'UseDNS no' >> /etc/ssh/sshd_config
 
-touch /.autorelabel
-
 # Audit events to the journal
 rm -f '/etc/systemd/system/multi-user.target.wants/auditd.service'
 rm -rf /var/log/audit/

--- a/bots/images/scripts/fedora-testing.setup
+++ b/bots/images/scripts/fedora-testing.setup
@@ -129,8 +129,6 @@ printf "SELINUX=enforcing\nSELINUXTYPE=targeted\n" > /etc/selinux/config
 # Prevent SSH from hanging for a long time when no external network access
 echo 'UseDNS no' >> /etc/ssh/sshd_config
 
-touch /.autorelabel
-
 # Audit events to the journal
 rm -f '/etc/systemd/system/multi-user.target.wants/auditd.service'
 rm -rf /var/log/audit/

--- a/bots/images/scripts/rhel-7-4.setup
+++ b/bots/images/scripts/rhel-7-4.setup
@@ -209,8 +209,6 @@ echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" 
 # Prevent SSH from hanging for a long time when no external network access
 echo 'UseDNS no' >> /etc/ssh/sshd_config
 
-touch /.autorelabel
-
 # Audit events to the journal
 rm -f '/etc/systemd/system/multi-user.target.wants/auditd.service'
 rm -rf /var/log/audit/

--- a/bots/images/scripts/rhel-7.setup
+++ b/bots/images/scripts/rhel-7.setup
@@ -203,8 +203,6 @@ echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" 
 # Prevent SSH from hanging for a long time when no external network access
 echo 'UseDNS no' >> /etc/ssh/sshd_config
 
-touch /.autorelabel
-
 # Audit events to the journal
 rm -f '/etc/systemd/system/multi-user.target.wants/auditd.service'
 rm -rf /var/log/audit/

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -42,7 +42,6 @@ class TestKdump(MachineCase):
 
     def rebootMachine(self):
         # Now reboot things
-        self.machine.reset_reboot_flag()
         self.machine.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")
         self.machine.wait_reboot()
         self.machine.start_cockpit()
@@ -127,7 +126,7 @@ class TestKdump(MachineCase):
         self.browser.wait_visible("div.curtains-ct")
         self.browser.wait_in_text("div.curtains-ct h1", "Disconnected")
         self.machine.disconnect()
-        self.machine.wait_boot(wait_for_running_timeout=300)
+        self.machine.wait_boot(timeout_sec=300)
         #self.browser.click("#machine-reconnect")
         #self.browser.expect_load()
         #self.browser.wait_visible("#login")

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -277,7 +277,6 @@ class OstreeRestartCase(MachineCase):
         m.start_cockpit()
         b.reload()
         b.login_and_go("/updates")
-        m.reset_reboot_flag()
 
         # After reboot, check commit
         b.wait_present('table.listing-ct')
@@ -326,7 +325,6 @@ class OstreeRestartCase(MachineCase):
         m.start_cockpit()
         b.reload()
         b.login_and_go("/updates")
-        m.reset_reboot_flag()
 
         # After reboot upgrade but no rollback target
         b.wait_present('table.listing-ct')
@@ -405,7 +403,6 @@ class OstreeRestartCase(MachineCase):
         m.start_cockpit()
         b.reload()
         b.login_and_go("/updates")
-        m.reset_reboot_flag()
 
         # After reboot, check commit
         b.wait_present('table.listing-ct')

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -274,7 +274,6 @@ class TestUpdates(MachineCase):
         assertHistory("ul", ["buggy", "norefs-bin", "norefs-doc"])
 
         # do the reboot; this will disconnect the web UI
-        m.reset_reboot_flag()
         b.click("#app .container-fluid button.btn-primary")
         b.switch_to_top()
         b.wait_present(".curtains-ct")

--- a/test/verify/check-shutdown-restart
+++ b/test/verify/check-shutdown-restart
@@ -64,7 +64,6 @@ class TestShutdownRestart(MachineCase):
         self.login_and_go("/system")
 
         # Reboot
-        m.reset_reboot_flag()
         b.click("#shutdown-group button.btn-danger")
         b.wait_popup("shutdown-dialog")
         b.wait_in_text("#shutdown-dialog .btn-danger", 'Restart')
@@ -107,7 +106,6 @@ class TestShutdownRestart(MachineCase):
             b2.wait_text("#system_information_hostname_button", "machine1")
 
             # Check auto reconnect on restart
-            m.reset_reboot_flag()
             b2.click("#shutdown-group button.btn-danger")
             b2.wait_popup("shutdown-dialog")
             b2.wait_in_text("#shutdown-dialog .btn-danger", 'Restart')


### PR DESCRIPTION
This is error prone code and seems to result in locking problems like this:
    
    python: ../nptl/pthread_mutex_lock.c:81: __pthread_mutex_lock: Assertion `mutex->__data.__owner == 0' failed.
    
We simply use the kernel boot_id to tell us about when an operating system has rebooted. This is not libvirt specific.

 * [x] #7336
