### PR TITLE
Typo: Add a missing installation step in the vagrant setup.

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -56,17 +56,12 @@ the Cockpit integration tests locally.
 It is recommended to use a Vagrant virtual machine to develop Cockpit.
 
 Most of Cockpit is written in javascript. Almost all of this code is found
-in the packages in the `pkg/` subdirectory of the Cockpit git checkout.
+in the packages in the pkg/ subdirectory of the Cockpit git checkout.
 
 To use Vagrant to develop Cockpit, run in its top level git checkout.
 In some cases you may need to use `sudo` with vagrant commands:
 
     $ vagrant up
-
-It might complain for a missing `/dist` directory in the Cockpit sources.
-Run it to automatically prepare the sources for compilation.
-
-    $ ./autogen.sh
 
 Now you can edit files in the `pkg/` subdirectory of the Cockpit sources.
 Use the `webpack` command to build those sources. The changes should

--- a/HACKING.md
+++ b/HACKING.md
@@ -56,12 +56,17 @@ the Cockpit integration tests locally.
 It is recommended to use a Vagrant virtual machine to develop Cockpit.
 
 Most of Cockpit is written in javascript. Almost all of this code is found
-in the packages in the pkg/ subdirectory of the Cockpit git checkout.
+in the packages in the `pkg/` subdirectory of the Cockpit git checkout.
 
 To use Vagrant to develop Cockpit, run in its top level git checkout.
 In some cases you may need to use `sudo` with vagrant commands:
 
     $ vagrant up
+
+It might complain for a missing `/dist` directory in the Cockpit sources.
+Run it to automatically prepare the sources for compilation.
+
+    $ ./autogen.sh
 
 Now you can edit files in the `pkg/` subdirectory of the Cockpit sources.
 Use the `webpack` command to build those sources. The changes should

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure(2) do |config|
 
     config.vm.box = "fedora/25-cloud-base"
     config.vm.synced_folder ".", "/vagrant", disabled: true
-    config.vm.synced_folder "./dist", "/cockpit/dist", type: "rsync"
+    config.vm.synced_folder "./dist", "/cockpit/dist", type: "rsync", create: true
     config.vm.network "private_network", ip: "192.168.50.10"
     config.vm.network "forwarded_port", guest: 9090, host: 9090
     config.vm.hostname = "cockpit-devel"


### PR DESCRIPTION
While using a vagrant virtual machine to setup cockpit, on trying to bring the machine up, it complains about a missing /dist subdirectory.
On running, 
    $ ./autogen.sh
the directory is created preparing the sources for compilation.

Please review the same. Thanks.