### PR TITLE
tools: In TAP format, make the duration a directive

### DIFF
--- a/tools/tap.py
+++ b/tools/tap.py
@@ -34,13 +34,13 @@ class TapResult(unittest.TestResult):
         sys.stdout.flush()
 
     def ok(self, test):
-        data = "ok {0} {1} duration: {2}s\n".format(self.offset,
+        data = "ok {0} {1} # duration: {2}s\n".format(self.offset,
                 str(test), int(time.time() - self.start_time))
         sys.stdout.write(data)
         sys.stdout.flush()
 
     def not_ok(self, test, err):
-        data = "not ok {0} {1} duration: {2}s\n".format(self.offset,
+        data = "not ok {0} {1} # duration: {2}s\n".format(self.offset,
                 str(test), int(time.time() - self.start_time))
         if err:
             data = self._exc_info_to_string(err, test) + "\n" + data
@@ -48,7 +48,7 @@ class TapResult(unittest.TestResult):
         sys.stdout.flush()
 
     def skip(self, test, reason):
-        sys.stdout.write("ok {0} {1} duration: {2}s # SKIP {3}\n".format(self.offset,
+        sys.stdout.write("ok {0} {1} # duration: {2}s # SKIP {3}\n".format(self.offset,
             str(test), int(time.time() - self.start_time), reason))
         sys.stdout.flush()
 


### PR DESCRIPTION
In the Test Anything Protocol directives such as SKIP or
duration should go after a '#' character.

 * [x] #7361