### PR TITLE
networkmanager: Make sure slave panel visibility is always set

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2862,7 +2862,6 @@ PageNetworkInterface.prototype = {
             if (!con || (cs.type != "bond" && cs.type != "team" && cs.type != "bridge")) {
                 self.rx_series.add_instance(self.dev_name);
                 self.tx_series.add_instance(self.dev_name);
-                $('#network-interface-slaves').hide();
                 return;
             }
 
@@ -2997,6 +2996,7 @@ PageNetworkInterface.prototype = {
             update_network_privileged();
         }
 
+        $('#network-interface-slaves').hide();
         if (self.main_connection)
             update_connection_slaves(self.main_connection);
     }


### PR DESCRIPTION
The panel would be incorrectly left visible in certain cases, such as
with "unavailable" interfaces.