### PR TITLE
bots: Allow duration to be a directive in TAP output

### DIFF
--- a/bots/task/log.html
+++ b/bots/task/log.html
@@ -135,8 +135,8 @@
         <script>
 
 var tap_range = /^([0-9]+)\.\.([0-9]+)$/m;
-var tap_result = /^(ok|not ok) ([0-9]+) (.*)\)(?: duration: ([0-9]+s))?(?: # SKIP .*)?$$/gm;
-var tap_skipped = /^ok [0-9]+ ([^#].*\))(?: duration: ([^#]*))? # SKIP (.*$)/gm;
+var tap_result = /^(ok|not ok) ([0-9]+) (.*)\)(?: #? ?duration: ([0-9]+s))?(?: # SKIP .*)?$$/gm;
+var tap_skipped = /^ok [0-9]+ ([^#].*\))(?: #? ?duration: ([^#]*))? # SKIP (.*$)/gm;
 var image_file = /([A-Za-z0-9\-\.]+)\.(png)$/gm;
 var journal_file = /(Journal extracted to )([A-Za-z0-9\-\.]+)\.(log)$/gm;
 var test_header_start = "# ----------------------------------------------------------------------"


### PR DESCRIPTION
In the Test Anything Protocol directives such as SKIP or
duration should go after a '#' character. We should fix
log.html to support this