### PR TITLE
bridge: Ignore network traffic on loopback

### DIFF
--- a/pkg/dashboard/list.js
+++ b/pkg/dashboard/list.js
@@ -96,8 +96,8 @@ var resource_monitors = [
               "network.interface.total.bytes"
           ],
           internal: [
-              "network.all.rx",
-              "network.all.tx"
+              "network.interface.rx",
+              "network.interface.tx"
           ],
           units: "bytes",
           'omit-instances': [ "lo" ],

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -480,7 +480,8 @@ PageServer.prototype = {
 
         var network_data = {
             direct: [ "network.interface.total.bytes" ],
-            internal: [ "network.all.tx", "network.all.rx" ],
+            internal: [ "network.interface.tx", "network.interface.rx" ],
+            "omit-instances": [ "lo" ],
             units: "bytes",
             derive: "rate"
         };

--- a/src/bridge/cockpitinternalmetrics.c
+++ b/src/bridge/cockpitinternalmetrics.c
@@ -520,6 +520,14 @@ cockpit_internal_metrics_finalize (GObject *object)
 
   g_free (self->instances);
   g_free (self->omit_instances);
+
+  for (int i = 0; i < self->n_metrics; i++)
+    {
+      MetricInfo *info = &self->metrics[i];
+      if (info->instances)
+        g_hash_table_unref (info->instances);
+    }
+
   g_free (self->metrics);
 
   G_OBJECT_CLASS (cockpit_internal_metrics_parent_class)->finalize (object);

--- a/src/bridge/cockpitinternalmetrics.c
+++ b/src/bridge/cockpitinternalmetrics.c
@@ -242,6 +242,15 @@ cockpit_internal_metrics_sample (CockpitSamples *samples,
 {
   CockpitInternalMetrics *self = COCKPIT_INTERNAL_METRICS (samples);
 
+  if (self->omit_instances)
+    {
+      for (int i = 0; self->omit_instances[i]; i++)
+        {
+          if (g_strcmp0 (instance, self->omit_instances[i]) == 0)
+            return;
+        }
+    }
+
   for (int i = 0; i < self->n_metrics; i++)
     {
       MetricInfo *info = &self->metrics[i];

--- a/src/bridge/cockpitinternalmetrics.c
+++ b/src/bridge/cockpitinternalmetrics.c
@@ -81,8 +81,8 @@ static MetricDescription metric_descriptions[] = {
   { "disk.all.read",    "bytes", "counter", FALSE, DISK_SAMPLER },
   { "disk.all.written", "bytes", "counter", FALSE, DISK_SAMPLER },
 
-  { "network.all.rx",       "bytes", "counter", FALSE, NETWORK_SAMPLER },
-  { "network.all.tx",       "bytes", "counter", FALSE, NETWORK_SAMPLER },
+  { "network.all.rx",       "bytes", "counter", FALSE, NETWORK_SAMPLER }, /* deprecated */
+  { "network.all.tx",       "bytes", "counter", FALSE, NETWORK_SAMPLER }, /* deprecated */
   { "network.interface.rx", "bytes", "counter", TRUE,  NETWORK_SAMPLER },
   { "network.interface.tx", "bytes", "counter", TRUE,  NETWORK_SAMPLER },
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -20,6 +20,7 @@
 
 import parent
 import time
+import subprocess
 from testlib import *
 
 def read_mem_info(machine):
@@ -33,6 +34,9 @@ def read_mem_info(machine):
     return info
 
 class TestMetrics(MachineCase):
+    provision = {
+        "0": { "forward": { "2000": 2000 } },
+    }
 
     def check_host_metrics(self):
         b = self.browser
@@ -121,15 +125,36 @@ class TestMetrics(MachineCase):
         b.wait_js_func("ph_flot_data_plateau", "#server_disk_io_graph", 100*1024, None, 5, "disk io");
         m.execute("kill %d" % disk_pid)
 
-        # Network.  Anything above 300 kb/s is good for now.
+        # Network traffic through loopback. Should be ignored.
         #
+        m.spawn("ping -w 5 -f -c 10000000 -s 50000  127.0.0.1", "load-net-lo.log")
+        try:
+            old_timeout = b.phantom.timeout
+            b.phantom.timeout = 10
+            try:
+                b.wait_js_func("ph_flot_data_plateau", "#server_network_traffic_graph", 300*1000, None, 5, "net io");
+            finally:
+                b.phantom.timeout = old_timeout
+            self.fail("Unexpected traffic graph for localhost")
+        except Error as ex:
+            if not ex.msg.startswith('timeout'):
+                raise
+
+        # Network traffic through Ethernet.  Anything above 300 kb/s is good for now.
+        #
+        m.execute("if type firewall-cmd >/dev/null 2>&1; then firewall-cmd --permanent --zone=public --add-port=2000/tcp && firewall-cmd --reload; fi")
+
         (eth_before, lo_before) = m.execute(r"grep -E 'eth0|ens5' /proc/net/dev | awk '{print $2 + $10}'; "
                                             r"grep '\blo:' /proc/net/dev | awk '{print $2 + $10}'").strip().split()
         time_before = time.time()
+
         # -q is necessary with netcat-openbsd, but does not exist with nmap-nc
         net_pid = m.spawn("nc `nc -h 2>&1| grep -q -- -q && echo '-q -1' || true` -l 2000 </dev/null >/dev/null", "load-net.log")
-        # client dies automatically once the server gets killed and the port closed
-        m.spawn("nc 172.27.0.15 2000 </dev/zero >/dev/null", "load-net-client.log")
+
+        # might take several attemps until server-side is listening
+        (host, port) = m.forward["2000"].split(":")
+        client = subprocess.Popen("for retry in `seq 10`; do nc {0} {1} </dev/zero >/dev/null; sleep 1; done".format(host, port), shell=True)
+
         try:
             b.wait_js_func("ph_flot_data_plateau", "#server_network_traffic_graph", 300*1000, None, 5, "net io");
         finally:
@@ -138,6 +163,9 @@ class TestMetrics(MachineCase):
                                               r"grep '\blo:' /proc/net/dev | awk '{print $2 + $10}'").strip().split()
             print("Measured {0:.1f}s of network traffic; eth0/ens5: {1} bytes, lo: {2} bytes".format(
                 time_after - time_before, int(eth_after) - int(eth_before), int(lo_after) - int(lo_before)))
+
+            client.terminate()
+            client.wait()
 
         m.execute("kill %d" % net_pid)
 


### PR DESCRIPTION
For most use cases loopback traffic is not very interesting, and even
misleading for server administration. It is also inconsistent with the 
graphs on "Networking" and "Dashboard", as these also ignore the lo
interface.

Move from the network.all.{tx,rx} internal metric towards the 
instantiated network.interface.{tx,rx} internal metric, as that can be
influenced with "omit-instances" and mirrors what the PCP metrics do
(network.interface.total.bytes also has per-interface instances). The 
per-interface measurements are done anyway, and the summation of the 
instances is not much extra overhead (and done for PCP too).

Drop the now unused network.all.{tx,rx} internal metrics.

Adjust check-metrics to move the netcat traffic to the Ethernet
interface by putting the sending side outside of the test VM. This
requires forwarding port 2000 and opening it in the firewall (where
applicable). Add another check that generates 5s of traffic on localhost
(via flood ping) and ensure that the networking graph does *not* exceed
300 kbps.

Fixes #7338