### PR TITLE
bots: Drop Fedora 26 naughty override for kube api server failure

### DIFF
--- a/bots/naughty/fedora-26/6327-kube-apiserver-failure
+++ b/bots/naughty/fedora-26/6327-kube-apiserver-failure
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-*
-  File "/home/martin/upstream/cockpit/test/verify/kubelib.py", * in start_kubernetes
-*
-CalledProcessError: Command 'systemctl start etcd kube-apiserver kube-controller-manager kube-scheduler kube-proxy kubelet' returned non-zero exit status 1


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1441218 got fixed, and kube
tests succeed again on our recent fedora-26 image refresh.

Fixes #6327