### PR TITLE
test: Fix static code tests

### DIFF
--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -19,7 +19,6 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
-import time
 
 import parent
 from testlib import *


### PR DESCRIPTION
The time import is not used, and Semaphore has started to
complain about this.