### PR TITLE
kdump: Internet Explorer doesn't support String.trimLeft()

### DIFF
--- a/pkg/kdump/config-client.es6
+++ b/pkg/kdump/config-client.es6
@@ -84,7 +84,7 @@ export class ConfigFile {
 
         this.settings = { };
         this._lines.forEach((line, index) => {
-            let trimmed = line.trimLeft();
+            let trimmed = line.trim();
             // if the line is empty or only a comment, skip
             if (trimmed.indexOf("#") === 0 || trimmed.length === 0)
                 return;

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -72,7 +72,7 @@ var KdumpTargetBody = React.createClass({
         var compressionPossible = (
             !this.props.settings ||
             !("core_collector" in this.props.settings) ||
-            (this.props.settings["core_collector"].value.trimLeft().indexOf("makedumpfile") === 0)
+            (this.props.settings["core_collector"].value.trim().indexOf("makedumpfile") === 0)
         );
         if (this.state.storeDest == "local") {
             var directory;


### PR DESCRIPTION
This is a non-standard function and not on a standards track
We should not use it.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft
