### PR TITLE
shell: Fix shell exceptions on Internet Explorer

### DIFF
--- a/pkg/lib/machines.js
+++ b/pkg/lib/machines.js
@@ -51,7 +51,7 @@
 
         function storage(ev) {
             if (ev.key === key && ev.storageArea === window.sessionStorage)
-                refresh(JSON.parse(ev.newValue));
+                refresh(JSON.parse(ev.newValue || "null"));
         }
 
         window.addEventListener("storage", storage);


### PR DESCRIPTION
Simply clicking from one screen to another in Internet Explorer
results in exceptions and Ooops being displayed. This is due
to differences in behavior on what is acessible and which
properties are available on certain events.