### PR TITLE
test: Add logic to vm-run to run Windows and IE

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -276,3 +276,25 @@ And you can run cockpit-ws and cockpit-bridge under valgrind like this:
 
 Note that cockpit-session and cockpit-bridge will run from the installed
 prefix, rather than your build tree.
+
+# Running Internet Explorer to test Cockpit
+
+While running Firefox or Chrome on your Linux or Mac development machine
+may be easy, some people find it harder to test Internet Explorer. To
+use the following method you need access to the ```windows-8``` testing
+image. This image cannot be freely distributed for licensing reasons.
+
+Make sure you have the ```virt-viewer``` package installed on your Linux
+machine. And then run the following from the Cockpit checkout directory:
+
+    $ test/vm-run --network windows-8
+
+If the image is not yet downloaded, it'll take a while to download and
+you'll see progress on the command line. A screen will pop up and
+Windows will boot. Various command lines will show up once Windows has
+started. Ignore or minimize them, before starting Internet Explorer.
+
+Type the following into Internet Explorer's address bar to access Cockpit
+running on your development machine:
+
+     https://10.111.112.1:9090

--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -1023,17 +1023,16 @@ class VirtMachine(Machine):
 
     # start virsh console
     def qemu_console(self):
-        try:
-            self._start_qemu()
-            self.message("Started machine {0}".format(self.label))
-            if self.maintain:
-                message = "\nWARNING: Uncontrolled shutdown can lead to a corrupted image\n"
-            else:
-                message = "\nWARNING: All changes are discarded, the image file won't be changed\n"
-            message += self.diagnose() + "\nlogin: "
-            message = message.replace("\n", "\r\n")
+        self.message("Started machine {0}".format(self.label))
+        if self.maintain:
+            message = "\nWARNING: Uncontrolled shutdown can lead to a corrupted image\n"
+        else:
+            message = "\nWARNING: All changes are discarded, the image file won't be changed\n"
+        message += self.diagnose() + "\nlogin: "
+        message = message.replace("\n", "\r\n")
 
-            proc = subprocess.Popen("virsh -c qemu:///session console %s" % self._domain.ID(), shell=True)
+        try:
+            proc = subprocess.Popen("virsh -c qemu:///session console %s" % str(self._domain.ID()), shell=True)
 
             # Fill in information into /etc/issue about login access
             pid = 0
@@ -1057,8 +1056,28 @@ class VirtMachine(Machine):
                 # the domain may have already been freed (shutdown) while the console was running
                 self.message("libvirt error during shutdown: %s" % (le.get_error_message()))
 
-        except:
-            raise
+        except OSError, ex:
+            raise Failure("Failed to launch virsh command: {0}".format(ex.strerror))
+        finally:
+            self._cleanup()
+
+    def graphics_console(self):
+        self.message("Started machine {0}".format(self.label))
+        if self.maintain:
+            message = "\nWARNING: Uncontrolled shutdown can lead to a corrupted image\n"
+        else:
+            message = "\nWARNING: All changes are discarded, the image file won't be changed\n"
+        if "bridge" in self.networking:
+            message += "\nIn the machine a web browser can access Cockpit on parent host:\n\n"
+            message += "    https://10.111.112.1:9090\n"
+        message = message.replace("\n", "\r\n")
+
+        try:
+            proc = subprocess.Popen(["virt-viewer", str(self._domain.ID())])
+            sys.stderr.write(message)
+            proc.wait()
+        except OSError, ex:
+            raise Failure("Failed to launch virt-viewer command: {0}".format(ex.strerror))
         finally:
             self._cleanup()
 

--- a/test/vm-run
+++ b/test/vm-run
@@ -72,10 +72,15 @@ try:
         if subprocess.call(["ip", "address", "show", "dev", "cockpit1"], stdout=fp, stderr=fp) == 0:
             bridge = "cockpit1"
 
+    # Lets make sure Windows has enough memory to be productive
+    memory = args.memory
+    if "windows" in args.image and memory is None:
+        memory = 4096
+
     network = testvm.VirtNetwork(0, bridge=bridge)
 
     machine = testvm.VirtMachine(verbose=args.verbose, image=args.image, maintain=args.maintain,
-                                 networking=network.host(), memory_mb=args.memory, cpus=args.cpus)
+                                 networking=network.host(), memory_mb=memory, cpus=args.cpus)
 
     # Hack to make things easier for users who don't know about kubeconfig
     if args.image == 'openshift':
@@ -99,7 +104,16 @@ try:
             if ret != 0:
                 sys.exit(ret)
 
-    machine.qemu_console()
+    machine.start()
+
+    # Graphics console necessary
+    if "windows" in args.image:
+        machine.graphics_console()
+
+    # No graphics console necessary
+    else:
+        machine.qemu_console()
+
 except testvm.Failure, ex:
     print >> sys.stderr, "vm-run:", ex
     sys.exit(1)


### PR DESCRIPTION
This adds logic to test/vm-run to run Windows with a graphical
display on screen. It uses virt-viewer to accomplish this.

This allows our developers and designers to run an IE on
machines if they have access to the windows-8 image.

 * [x] #5477