### PR TITLE
bots: Add Cockpit release script

### DIFF
--- a/bots/major-cockpit-release
+++ b/bots/major-cockpit-release
@@ -1,0 +1,49 @@
+# This is a script run to release Cockpit
+#
+# This script is run in the cockpit/release container
+# https://github.com/cockpit-project/cockpituous/tree/master/release
+#
+# Anything that start with 'job' may run in a way that it SIGSTOP's
+# itself when preliminary preparition and then gets a SIGCONT in
+# order to complete its work
+
+# Initial variables which help the scripts share
+RELEASE_SPEC=tools/cockpit.spec
+RELEASE_CONTROL=tools/debian/control
+RELEASE_SRPM=$PWD/_release/srpm
+RELEASE_DSC=$PWD/_release/dsc
+RELEASE_SOURCE=$PWD/_release/source
+
+# Fedora needs this crap. It's like packages are made
+# by cobblers not automated systems.
+cat ~/.fedora-password | kinit cockpit@FEDORAPROJECT.ORG
+
+# Build the source tarball patches and srpm
+job release-source
+job release-srpm
+
+
+# Do fedora builds for the tag, using tarball
+job release-koji -k master
+job release-koji f26
+
+# Upload release to github, using tarball
+job release-github
+
+# Push to COPR builds
+job release-copr @cockpit/cockpit-preview
+
+# Update the Github repo that Docker Hub is tracking
+job release-dockerhub cockpit-project/cockpit-container
+job release-dockerhub cockpituous/cockpit cockpit-project/cockpit
+
+# Push out a Bodhi update
+job release-bodhi F26
+
+# Upload documentation
+job release-guide dist/guide cockpit-project/cockpit-project.github.io
+
+# Create and publish a Debian repository and Ubuntu PPA
+job release-dsc
+job release-ubuntu-ppa
+job release-debian fedorapeople.org:/project/cockpit/debian jessie unstable


### PR DESCRIPTION
Move the Cockpit release script into the main cockpit repository.
This has everything to do with Cockpit itself, and less to do
with the tools embedded in that container.