### PR TITLE
bots: Add known issue for more pcp crashes

### DIFF
--- a/bots/naughty/fedora-25/6108-pcp-pmfindprofile-crash-3
+++ b/bots/naughty/fedora-25/6108-pcp-pmfindprofile-crash-3
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+*
+  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
+*
+Error: /usr/*/cockpit-pcp: bridge was killed: 7


### PR DESCRIPTION
Seen here: https://github.com/cockpit-project/cockpit/pull/7377
```
Traceback (most recent call last):
  File "/build/cockpit/test/common/testlib.py", line 598, in tearDown
    self.check_journal_messages()
  File "/build/cockpit/test/common/testlib.py", line 769, in check_journal_messages
    raise Error(first)
Error: /usr/libexec/cockpit-pcp: bridge was killed: 7
```