### PR TITLE
packagekit: Put "More information..." link on its own line

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -258,7 +258,7 @@ class UpdateItem extends React.Component {
         if (!this.state.expanded && descLines.length > 7) {
             desc = (
                 <div onClick={ () => this.setState({expanded: true}) }>
-                    {descLines.slice(0, 6).join("\n")}
+                    {descLines.slice(0, 6).join("\n") + "\n"}
                     <a>{_("More information…")}</a>
                 </div>);
         } else {


### PR DESCRIPTION
If the previous changelog line is too short, the link previously got
appended right after it without any space. The design meant to put it on
a line of its own.