### PR TITLE
bots: Add registry IP to insecure-registry options for docker

### DIFF
--- a/bots/images/scripts/openshift.setup
+++ b/bots/images/scripts/openshift.setup
@@ -172,6 +172,7 @@ oc create -f /tmp/imagestream.json
 # Get registry address and configure docker for it
 address="$(oc get services docker-registry | tail -n1 | awk -v N=2 '{print $N}')"
 echo "$address     registry registry.cockpit.lan" >> /etc/hosts
+echo "INSECURE_REGISTRY='--insecure-registry registry:5000 --insecure-registry $address'" >> /etc/sysconfig/docker
 
 # Log in as another user
 printf "scruffy\r\nscruffy\r\n" | oc login


### PR DESCRIPTION
Openshift builds use the ip instead of the host name.

 * [x] image-refresh openshift