### PR TITLE
common: Strip parts of Content-Security-Policy before checking them

### DIFF
--- a/src/bridge/mock-resource/csp/cockpit/strip/manifest.json
+++ b/src/bridge/mock-resource/csp/cockpit/strip/manifest.json
@@ -1,0 +1,3 @@
+{
+    "content-security-policy": "img-src: 'self' data:; default-src 'self'"
+}

--- a/src/bridge/mock-resource/csp/cockpit/strip/test.html
+++ b/src/bridge/mock-resource/csp/cockpit/strip/test.html
@@ -1,0 +1,6 @@
+<html>
+<head>
+<title>Test</title>
+</head>
+<body>Test</body>
+</html>

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -1818,16 +1818,16 @@ cockpit_web_response_security_policy (const gchar *content_security_policy,
   if (content_security_policy)
     parts = g_strsplit (content_security_policy, ";", -1);
 
+  for (i = 0; parts && parts[i] != NULL; i++)
+    g_strstrip (parts[i]);
+
   if (!strv_have_prefix (parts, "default-src "))
     g_string_append_printf (result, "%s; ", default_src);
   if (!strv_have_prefix (parts, "connect-src "))
     g_string_append_printf (result, "%s; ", connect_src);
 
   for (i = 0; parts && parts[i] != NULL; i++)
-    {
-      g_strstrip (parts[i]);
-      g_string_append_printf (result, "%s; ", parts[i]);
-    }
+    g_string_append_printf (result, "%s; ", parts[i]);
 
   g_strfreev (parts);
 


### PR DESCRIPTION
Strip spaces in the manifest specified Content-Security-Policy so the
prefix matching that checks if the defaults need to be added isn't
thrown off by them.

Fixes #7005