### PR TITLE
bots: Split out the image-prune command

### DIFF
--- a/bots/image-download
+++ b/bots/image-download
@@ -37,10 +37,7 @@ import stat
 import subprocess
 import sys
 import tempfile
-import time
 import urlparse
-
-from contextlib import contextmanager
 
 from task import github
 
@@ -48,8 +45,6 @@ BOTS = os.path.dirname(os.path.realpath(__file__))
 IMAGES = os.path.join(BOTS, "..", "bots", "images")
 DATA = os.path.join(os.environ.get("TEST_DATA", BOTS), "images")
 
-# threshold in G below which unreferenced qcow2 images will be pruned, even if they aren't old
-PRUNE_THRESHOLD_G = float(os.environ.get("PRUNE_THRESHOLD_G", 15))
 DEVNULL = open("/dev/null", "r+")
 
 def download(link, force, quiet, stores):
@@ -161,142 +156,6 @@ def download(link, force, quiet, stores):
     if not os.path.exists(image_file):
         os.symlink(os.path.abspath(dest), image_file)
 
-def enough_disk_space():
-    """Check if available disk space in our data store is sufficient
-    """
-    st = os.statvfs(DATA)
-    free = st.f_bavail * st.f_frsize / (1024*1024*1024)
-    return free >= PRUNE_THRESHOLD_G;
-
-def get_refs(open_pull_requests=True, offline=False):
-    """Return dictionary for available refs of the format {'rhel-7.4': 'ad50328990e44c22501bd5e454746d4b5e561b7c'}
-
-       Expects to be called from the top level of the git checkout
-       If offline is true, git show-ref is used instead of listing the remote
-    """
-    # get all remote heads and filter empty lines
-    # output of ls-remote has the format
-    #
-    # d864d3792db442e3de3d1811fa4bc371793a8f4f	refs/heads/master
-    # ad50328990e44c22501bd5e454746d4b5e561b7c	refs/heads/rhel-7.4
-
-    refs = { }
-
-    if open_pull_requests:
-        if offline:
-            raise Exception("Unable to consider open pull requests when in offline mode")
-        for p in github.GitHub().pulls():
-            refs["pull request #{} ({})".format(p["number"], p["title"])] = p["head"]["sha"]
-
-    git_cmd = "show-ref" if offline else "ls-remote"
-    ref_output = subprocess.check_output(["git", git_cmd]).splitlines()
-    # filter out the "refs/heads/" prefix and generate a dictionary
-    prefix = "refs/heads"
-    for ln in ref_output:
-        [ref, name] = ln.split()
-        if name.startswith(prefix):
-            refs[name[len(prefix):]] = ref
-
-    return refs
-
-def get_image_links(ref, git_path):
-    """Return all image links for the given git ref
-
-       Expects to be called from the top level of the git checkout
-    """
-    # get all the links we have first
-    # trailing slash on path is important
-    if not git_path.endswith("/"):
-        git_path = "{0}/".format(git_path)
-
-    try:
-        entries = subprocess.check_output(["git", "ls-tree",  "--name-only", ref, git_path]).splitlines()
-    except subprocess.CalledProcessError, e:
-        if e.returncode == 128:
-            sys.stderr.write("Skipping {0} due to tree error.\n".format(ref))
-            return []
-        raise
-    links = map(lambda entry: subprocess.check_output(["git", "show", "{0}:{1}".format(ref, entry)]), entries)
-    return [link for link in links if link.endswith(".qcow2")]
-
-@contextmanager
-def remember_cwd():
-    curdir = os.getcwd()
-    try:
-        yield
-    finally:
-        os.chdir(curdir)
-
-def get_image_names(quiet=False, open_pull_requests=True, offline=False):
-    """Return all image names used by all branches and optionally in open pull requests
-    """
-    images = set()
-    # iterate over visible refs (mostly branches)
-    # this hinges on being in the top level directory of the the git checkout
-    with remember_cwd():
-        os.chdir(os.path.join(BOTS, ".."))
-        refs = get_refs(open_pull_requests, offline)
-        # list images present in each branch / pull request
-        for name, ref in refs.items():
-            if not quiet:
-                sys.stderr.write("Considering images from {0} ({1})\n".format(name, ref))
-            # DEPRECATED old branches may still have images in test/images
-            for link in get_image_links(ref, "test/images"):
-                images.add(link)
-            for link in get_image_links(ref, "bots/images"):
-                images.add(link)
-
-    return images
-
-def prune_images(force, dryrun, quiet=False, open_pull_requests=True, offline=False):
-    """Prune images
-    """
-    now = time.time()
-
-    # everything we want to keep
-    targets = get_image_names(quiet, open_pull_requests, offline)
-
-    # what we have in the current checkout might already have been added by its branch, but check anyway
-    for filename in os.listdir(IMAGES):
-        path = os.path.join(IMAGES, filename)
-
-        # only consider original image entries as trustworthy sources and ignore non-links
-        if path.endswith(".qcow2") or path.endswith(".partial") or not os.path.islink(path):
-            continue
-
-        target = os.readlink(path)
-        if not os.path.isabs(target):
-            targets.add(os.path.join(IMAGES, target))
-            targets.add(os.path.join(DATA, target))
-        else:
-            targets.add(target)
-
-    expiry_threshold = now - IMAGE_EXPIRE * 86400
-    for filename in os.listdir(DATA):
-        path = os.path.join(DATA, filename)
-        if not force and (enough_disk_space() and os.lstat(path).st_mtime > expiry_threshold):
-            continue
-        if os.path.isfile(path) and (path.endswith(".xz") or path.endswith(".qcow2") or path.endswith(".partial")) and path not in targets:
-            if not quiet or dryrun:
-                sys.stderr.write("Pruning {0}\n".format(filename))
-            if not dryrun:
-                os.unlink(path)
-
-    # now prune broken links
-    for filename in os.listdir(IMAGES):
-        path = os.path.join(IMAGES, filename)
-
-        # don't prune original image entries and ignore non-links
-        if not path.endswith(".qcow2") or not os.path.islink(path):
-            continue
-
-        # if the link isn't valid, prune
-        if not os.path.isfile(path):
-            if not quiet or dryrun:
-                sys.stderr.write("Pruning link {0}\n".format(path))
-            if not dryrun:
-                os.unlink(path)
-
 def every_image():
     result = []
     for filename in os.listdir(IMAGES):
@@ -314,23 +173,17 @@ def download_images(image_list, force, quiet, store):
 
 def main():
     parser = argparse.ArgumentParser(description='Download a virtual machine')
-    parser.add_argument("--force", action="store_true", help="Force unnecessary downloads, delete images even if they aren't old")
+    parser.add_argument("--force", action="store_true", help="Force unnecessary downloads")
     parser.add_argument("--store", action="append", help="Where to find images")
-    parser.add_argument("--prune", action="store_true", help="Remove unused images and links")
     parser.add_argument("--quiet", action="store_true", help="Make downloading quieter")
-    parser.add_argument("-d", "--dry-run-prune", dest="dryrun", action="store_true", help="Don't actually delete images and links")
-    parser.add_argument("-b", "--branches-only", dest="branches_only", action="store_true", help="Don't consider pull requests on GitHub, only look at branches")
-    parser.add_argument("-o", "--offline", dest="offline", action="store_true", help="Don't access external sources such as GitHub")
     parser.add_argument('image', nargs='*')
     args = parser.parse_args()
 
     # By default download all links
-    if not args.image and not args.prune:
+    if not args.image:
         args.image = every_image()
 
     try:
-        if args.prune:
-            prune_images(args.force, args.dryrun, quiet=args.quiet, open_pull_requests=(not args.branches_only), offline=args.offline)
         download_images(args.image, args.force, args.quiet, args.store)
     except RuntimeError, ex:
         sys.stderr.write("image-download: {0}\n".format(str(ex)))

--- a/bots/image-prune
+++ b/bots/image-prune
@@ -1,0 +1,210 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2013 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+# Days after which images expire if not in use
+IMAGE_EXPIRE = 14
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+
+from contextlib import contextmanager
+
+from task import github
+
+BOTS = os.path.dirname(os.path.realpath(__file__))
+IMAGES = os.path.join(BOTS, "..", "bots", "images")
+DATA = os.path.join(os.environ.get("TEST_DATA", BOTS), "images")
+
+# threshold in G below which unreferenced qcow2 images will be pruned, even if they aren't old
+PRUNE_THRESHOLD_G = float(os.environ.get("PRUNE_THRESHOLD_G", 15))
+
+def enough_disk_space():
+    """Check if available disk space in our data store is sufficient
+    """
+    st = os.statvfs(DATA)
+    free = st.f_bavail * st.f_frsize / (1024*1024*1024)
+    return free >= PRUNE_THRESHOLD_G;
+
+def get_refs(open_pull_requests=True, offline=False):
+    """Return dictionary for available refs of the format {'rhel-7.4': 'ad50328990e44c22501bd5e454746d4b5e561b7c'}
+
+       Expects to be called from the top level of the git checkout
+       If offline is true, git show-ref is used instead of listing the remote
+    """
+    # get all remote heads and filter empty lines
+    # output of ls-remote has the format
+    #
+    # d864d3792db442e3de3d1811fa4bc371793a8f4f	refs/heads/master
+    # ad50328990e44c22501bd5e454746d4b5e561b7c	refs/heads/rhel-7.4
+
+    refs = { }
+
+    if open_pull_requests:
+        if offline:
+            raise Exception("Unable to consider open pull requests when in offline mode")
+        for p in github.GitHub().pulls():
+            refs["pull request #{} ({})".format(p["number"], p["title"])] = p["head"]["sha"]
+
+    git_cmd = "show-ref" if offline else "ls-remote"
+    ref_output = subprocess.check_output(["git", git_cmd]).splitlines()
+    # filter out the "refs/heads/" prefix and generate a dictionary
+    prefix = "refs/heads"
+    for ln in ref_output:
+        [ref, name] = ln.split()
+        if name.startswith(prefix):
+            refs[name[len(prefix):]] = ref
+
+    return refs
+
+def get_image_links(ref, git_path):
+    """Return all image links for the given git ref
+
+       Expects to be called from the top level of the git checkout
+    """
+    # get all the links we have first
+    # trailing slash on path is important
+    if not git_path.endswith("/"):
+        git_path = "{0}/".format(git_path)
+
+    try:
+        entries = subprocess.check_output(["git", "ls-tree",  "--name-only", ref, git_path]).splitlines()
+    except subprocess.CalledProcessError, e:
+        if e.returncode == 128:
+            sys.stderr.write("Skipping {0} due to tree error.\n".format(ref))
+            return []
+        raise
+    links = map(lambda entry: subprocess.check_output(["git", "show", "{0}:{1}".format(ref, entry)]), entries)
+    return [link for link in links if link.endswith(".qcow2")]
+
+@contextmanager
+def remember_cwd():
+    curdir = os.getcwd()
+    try:
+        yield
+    finally:
+        os.chdir(curdir)
+
+def get_image_names(quiet=False, open_pull_requests=True, offline=False):
+    """Return all image names used by all branches and optionally in open pull requests
+    """
+    images = set()
+    # iterate over visible refs (mostly branches)
+    # this hinges on being in the top level directory of the the git checkout
+    with remember_cwd():
+        os.chdir(os.path.join(BOTS, ".."))
+        refs = get_refs(open_pull_requests, offline)
+        # list images present in each branch / pull request
+        for name, ref in refs.items():
+            if not quiet:
+                sys.stderr.write("Considering images from {0} ({1})\n".format(name, ref))
+            # DEPRECATED old branches may still have images in test/images
+            for link in get_image_links(ref, "test/images"):
+                images.add(link)
+            for link in get_image_links(ref, "bots/images"):
+                images.add(link)
+
+    return images
+
+def prune_images(force, dryrun, quiet=False, open_pull_requests=True, offline=False):
+    """Prune images
+    """
+    now = time.time()
+
+    # everything we want to keep
+    targets = get_image_names(quiet, open_pull_requests, offline)
+
+    # what we have in the current checkout might already have been added by its branch, but check anyway
+    for filename in os.listdir(IMAGES):
+        path = os.path.join(IMAGES, filename)
+
+        # only consider original image entries as trustworthy sources and ignore non-links
+        if path.endswith(".qcow2") or path.endswith(".partial") or not os.path.islink(path):
+            continue
+
+        target = os.readlink(path)
+        if not os.path.isabs(target):
+            targets.add(os.path.join(IMAGES, target))
+            targets.add(os.path.join(DATA, target))
+        else:
+            targets.add(target)
+
+    expiry_threshold = now - IMAGE_EXPIRE * 86400
+    for filename in os.listdir(DATA):
+        path = os.path.join(DATA, filename)
+        if not force and (enough_disk_space() and os.lstat(path).st_mtime > expiry_threshold):
+            continue
+        if os.path.isfile(path) and (path.endswith(".xz") or path.endswith(".qcow2") or path.endswith(".partial")) and path not in targets:
+            if not quiet or dryrun:
+                sys.stderr.write("Pruning {0}\n".format(filename))
+            if not dryrun:
+                os.unlink(path)
+
+    # now prune broken links
+    for filename in os.listdir(IMAGES):
+        path = os.path.join(IMAGES, filename)
+
+        # don't prune original image entries and ignore non-links
+        if not path.endswith(".qcow2") or not os.path.islink(path):
+            continue
+
+        # if the link isn't valid, prune
+        if not os.path.isfile(path):
+            if not quiet or dryrun:
+                sys.stderr.write("Pruning link {0}\n".format(path))
+            if not dryrun:
+                os.unlink(path)
+
+def every_image():
+    result = []
+    for filename in os.listdir(IMAGES):
+        link = os.path.join(IMAGES, filename)
+        if os.path.islink(link):
+            result.append(filename)
+    return result
+
+def download_images(image_list, force, quiet, store):
+    for image in image_list:
+        link = os.path.join(IMAGES, image)
+        if not os.path.islink(link):
+            raise RuntimeError("image link does not exist: " + image)
+        download(link, force, quiet, store)
+
+def main():
+    parser = argparse.ArgumentParser(description='Prune downloaded images')
+    parser.add_argument("--force", action="store_true", help="Delete images even if they aren't old")
+    parser.add_argument("--quiet", action="store_true", help="Make downloading quieter")
+    parser.add_argument("-d", "--dry-run-prune", dest="dryrun", action="store_true", help="Don't actually delete images and links")
+    parser.add_argument("-b", "--branches-only", dest="branches_only", action="store_true", help="Don't consider pull requests on GitHub, only look at branches")
+    parser.add_argument("-o", "--offline", dest="offline", action="store_true", help="Don't access external sources such as GitHub")
+    args = parser.parse_args()
+
+    try:
+        prune_images(args.force, args.dryrun, quiet=args.quiet, open_pull_requests=(not args.branches_only), offline=args.offline)
+    except RuntimeError, ex:
+        sys.stderr.write("image-prune: {0}\n".format(str(ex)))
+        return 1
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -85,7 +85,7 @@ def scan_for_prune():
     except OSError:
         mtime = 0
     if mtime < time.time() - 3600:
-        tasks.append("PRIORITY=0000 touch {0} && bots/image-download --prune".format(stamp))
+        tasks.append("PRIORITY=0000 touch {0} && bots/image-prune".format(stamp))
 
     return tasks
 


### PR DESCRIPTION
Most of the code in image-download is pruning stuff. This really
should be in its own file. This starts to make the download code
more approachable.