### PR TITLE
bots: Fix the image-trigger script

### DIFF
--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -36,7 +36,7 @@ REFRESH = {
     "ipa": { "refresh-days": 120 },
     'rhel-7': { },
     'rhel-7-4': { },
-    'rhel-atomic': { }
+    'rhel-atomic': { },
     'windows-8': { "refresh-days": 30 },
 }
 


### PR DESCRIPTION
This script has a regression caused in
14623f17f78a4a9e70f77b0aa280cb560541aeb9 where it completely
fails to run.