### PR TITLE
bots: Fix the example-task script

### DIFF
--- a/bots/example-task
+++ b/bots/example-task
@@ -37,7 +37,7 @@ BASE = os.path.normpath(os.path.join(BOTS, ".."))
 def run(argument, verbose=False, **kwargs):
     try:
         int(argument)
-    except ValueError:
+    except (TypeError, ValueError):
         return "Failed to parse argument"
 
     sys.stdout.write("Example message to log\n")


### PR DESCRIPTION
This script would fail with an exception when run without arguments.