### PR TITLE
ws: Fix broken <polygon> tag in login screen

### DIFF
--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -453,7 +453,7 @@
                 </div>
               </td>
               <td class="shrink">
-                <input class="form-control size-text-ct" type='text'></input>
+                <input class="form-control size-text-ct" type='text'/>
               </td>
               <td class="shrink" translatable="yes">MiB</td>
             </tr>
@@ -470,7 +470,7 @@
                 </div>
               </td>
               <td class="shrink">
-                <input class="form-control size-text-ct" type='text'></input>
+                <input class="form-control size-text-ct" type='text'/>
               </td>
               <td  class="shrink" translatable="yes">shares</td>
             </tr>
@@ -624,7 +624,7 @@
                 </div>
               </td>
               <td class="shrink">
-                <input class="form-control size-text-ct" type='text'></input>
+                <input class="form-control size-text-ct" type='text'/>
               </td>
               <td class="shrink" translatable="yes">MiB</td>
             </tr>
@@ -641,7 +641,7 @@
                 </div>
               </td>
               <td class="shrink">
-                <input class="form-control size-text-ct" type='text'></input>
+                <input class="form-control size-text-ct" type='text'/>
               </td>
               <td  class="shrink" translatable="yes">shares</td>
             </tr>

--- a/pkg/kubernetes/views/nodes-page.html
+++ b/pkg/kubernetes/views/nodes-page.html
@@ -53,7 +53,7 @@
                 <i class="fa fa-fw" ng-if="!listing.enableActions"></i>
                 <div class="text-center" ng-if="listing.enableActions">
                     <input type="checkbox" ng-false-value="undefined"
-                        ng-model="listing.selected[link]"></input>
+                        ng-model="listing.selected[link]"/>
                 </div>
             </td>
             <th>{{item.metadata.name}}</th>

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -143,7 +143,7 @@
         </td>
         <td>
           <input id="network-vlan-settings-vlan-id-input" class="form-control" type="text"
-                 value="{{vlan_id}}"></input>
+                 value="{{vlan_id}}"/>
         </td>
       </tr>
       <tr>
@@ -152,7 +152,7 @@
         </td>
         <td>
           <input id="network-vlan-settings-interface-name-input" class="form-control" type="text"
-                 value="{{interface_name}}"></input>
+                 value="{{interface_name}}"/>
         </td>
       </tr>
     </table>
@@ -162,17 +162,17 @@
     <div>
       <label>
         <input id="network-mtu-settings-auto" {{^mtu}}checked="checked"{{/mtu}}
-               type="radio" name="mtu-mode"></input>
+               type="radio" name="mtu-mode"/>
         <span translatable="yes">Automatic</span>
       </label>
     </div>
     <div>
       <label>
         <input id="network-mtu-settings-custom"  {{#mtu}}checked="checked"{{/mtu}}
-               type="radio" name="mtu-mode"></input>
+               type="radio" name="mtu-mode"/>
         <span translatable="yes">Set to</span>
         <input id="network-mtu-settings-input"
-               class="form-control" type="text" value="{{mtu}}"></input>
+               class="form-control" type="text" value="{{mtu}}"/>
       </label>
     </div>
   </script>
@@ -186,7 +186,7 @@
         <td>
           <div class="input-group">
             <input id="network-mac-settings-input" class="form-control" type="text"
-                   value="{{assigned_mac_address}}"></input>
+                   value="{{assigned_mac_address}}"/>
             <div class="input-group-btn dropdown">
               <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                 <span class="fa fa-caret-down"></span>
@@ -208,7 +208,7 @@
         </td>
         <td>
           <input id="network-bridge-settings-name-input" class="form-control" type="text"
-                 value="{{bridge_name}}"></input>
+                 value="{{bridge_name}}"/>
         </td>
       </tr>
       <tr>
@@ -225,7 +225,7 @@
         </td>
         <td>
           <input id="network-bridge-settings-stp-enabled-input" type="checkbox"
-                 {{#stp_checked}}checked{{/stp_checked}}></input>
+                 {{#stp_checked}}checked{{/stp_checked}}/>
         </td>
       </tr>
       <tr>
@@ -234,7 +234,7 @@
         </td>
         <td>
           <input id="network-bridge-settings-stp-priority-input" class="form-control" type="text"
-                 value="{{stp_priority}}"></input>
+                 value="{{stp_priority}}"/>
         </td>
       </tr>
       <tr>
@@ -243,7 +243,7 @@
         </td>
         <td>
           <input id="network-bridge-settings-stp-forward-delay-input" class="form-control" type="text"
-                 value="{{stp_forward_delay}}"></input>
+                 value="{{stp_forward_delay}}"/>
         </td>
       </tr>
       <tr>
@@ -252,7 +252,7 @@
         </td>
         <td>
           <input id="network-bridge-settings-stp-hello-time-input" class="form-control" type="text"
-                 value="{{stp_hello_time}}"></input>
+                 value="{{stp_hello_time}}"/>
         </td>
       </tr>
       <tr>
@@ -261,7 +261,7 @@
         </td>
         <td>
           <input id="network-bridge-settings-stp-max-age-input" class="form-control" type="text"
-                 value="{{stp_max_age}}"></input>
+                 value="{{stp_max_age}}"/>
         </td>
       </tr>
     </table>
@@ -275,7 +275,7 @@
         </td>
         <td>
           <input id="network-bridge-port-settings-priority-input" class="form-control network-number-field" type="text"
-                 value="{{priority}}"></input>
+                 value="{{priority}}"/>
         </td>
       </tr>
       <tr>
@@ -284,7 +284,7 @@
         </td>
         <td>
           <input id="network-bridge-port-settings-path-cost-input" class="form-control network-number-field" type="text"
-                 value="{{path_cost}}"></input>
+                 value="{{path_cost}}"/>
         </td>
       </tr>
       <tr>
@@ -293,7 +293,7 @@
         </td>
         <td>
           <input id="network-bridge-settings-hairpin-mode-input" type="checkbox"
-                 {{#hairpin_mode_checked}}checked{{/hairpin_mode_checked}}></input>
+                 {{#hairpin_mode_checked}}checked{{/hairpin_mode_checked}}/>
         </td>
       </tr>
     </table>
@@ -307,7 +307,7 @@
         </td>
         <td>
           <input id="network-bond-settings-interface-name-input" class="form-control"
-                 value="{{interface_name}}"></input>
+                 value="{{interface_name}}"/>
         </td>
       </tr>
       <tr>
@@ -325,7 +325,7 @@
         <td>
           <div class="input-group">
             <input id="network-bond-settings-mac-input" class="form-control" type="text"
-                   value="{{assigned_mac_address}}"></input>
+                   value="{{assigned_mac_address}}"/>
             <div class="input-group-btn dropdown">
               <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                 <span class="fa fa-caret-down"></span>
@@ -366,7 +366,7 @@
         </td>
         <td>
           <input id="network-bond-settings-monitoring-interval-input" class="form-control network-number-field"
-                 type="text" maxlength="4" value="{{monitoring_interval}}"></input>
+                 type="text" maxlength="4" value="{{monitoring_interval}}"/>
         </td>
       </tr>
       <tr>
@@ -375,7 +375,7 @@
         </td>
         <td>
           <input id="network-bond-settings-monitoring-targets-input" class="form-control"
-                 type="text" value="{{monitoring_targets}}"></input>
+                 type="text" value="{{monitoring_targets}}"/>
         </td>
       </tr>
       <tr>
@@ -384,7 +384,7 @@
         </td>
         <td>
           <input id="network-bond-settings-link-up-delay-input" class="form-control network-number-field"
-                 type="text" maxlength="4" value="{{link_up_delay}}"></input>
+                 type="text" maxlength="4" value="{{link_up_delay}}"/>
         </td>
       </tr>
       <tr>
@@ -393,7 +393,7 @@
         </td>
         <td>
           <input id="network-bond-settings-link-down-delay-input" class="form-control network-number-field"
-                 type="text" maxlength="4" value="{{link_down_delay}}"></input>
+                 type="text" maxlength="4" value="{{link_down_delay}}"/>
         </td>
       </tr>
     </table>
@@ -407,7 +407,7 @@
         </td>
         <td>
           <input id="network-team-settings-interface-name-input" class="form-control"
-                 value="{{interface_name}}"></input>
+                 value="{{interface_name}}"/>
         </td>
       </tr>
       <tr>
@@ -448,7 +448,7 @@
         </td>
         <td>
           <input id="network-team-settings-ping-interval-input" class="form-control network-number-field"
-                 type="text" maxlength="4" value="{{config.link_watch.interval}}"></input>
+                 type="text" maxlength="4" value="{{config.link_watch.interval}}"/>
         </td>
       </tr>
       <tr>
@@ -457,7 +457,7 @@
         </td>
         <td>
           <input id="network-team-settings-ping-target-input" class="form-control"
-                 type="text" value="{{config.link_watch.target_host}}"></input>
+                 type="text" value="{{config.link_watch.target_host}}"/>
         </td>
       </tr>
       <tr>
@@ -466,7 +466,7 @@
         </td>
         <td>
           <input id="network-team-settings-link-up-delay-input" class="form-control network-number-field"
-                 type="text" maxlength="4" value="{{config.link_watch.delay_up}}"></input>
+                 type="text" maxlength="4" value="{{config.link_watch.delay_up}}"/>
         </td>
       </tr>
       <tr>
@@ -475,7 +475,7 @@
         </td>
         <td>
           <input id="network-team-settings-link-down-delay-input" class="form-control network-number-field"
-                 type="text" maxlength="4" value="{{config.link_watch.delay_down}}"></input>
+                 type="text" maxlength="4" value="{{config.link_watch.delay_down}}"/>
         </td>
       </tr>
     </table>
@@ -489,7 +489,7 @@
         </td>
         <td>
           <input id="network-team-port-settings-ab-prio-input" class="form-control network-number-field" type="text"
-                 value="{{prio}}"></input>
+                 value="{{prio}}"/>
         </td>
       </tr>
       <tr>
@@ -498,7 +498,7 @@
         </td>
         <td>
           <input id="network-team-port-settings-ab-sticky-input" type="checkbox"
-                 {{#sticky}}checked{{/sticky}}></input>
+                 {{#sticky}}checked{{/sticky}}/>
         </td>
       </tr>
       <tr>
@@ -507,7 +507,7 @@
         </td>
         <td>
           <input id="network-team-port-settings-lacp-prio-input" class="form-control network-number-field" type="text"
-                 value="{{lacp_prio}}"></input>
+                 value="{{lacp_prio}}"/>
         </td>
       </tr>
       <tr>
@@ -516,7 +516,7 @@
         </td>
         <td>
           <input id="network-team-port-settings-lacp-key-input" class="form-control network-number-field" type="text"
-                 value="{{lacp_key}}"></input>
+                 value="{{lacp_key}}"/>
         </td>
       </tr>
     </table>

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -222,7 +222,7 @@
                                             </dt>
                                             <dd>
                                                 <input class="form-control credential-password"
-                                                        value="" type="password"></input>
+                                                        value="" type="password"/>
                                             </dd>
                                             <dt></dt>
                                             <dd>
@@ -258,21 +258,21 @@
                                             </dt>
                                             <dd>
                                                 <input class="form-control credential-old"
-                                                    value="" type="password"></input>
+                                                    value="" type="password"/>
                                             </dd>
                                             <dt>
                                                 <label translatable="yes">New Password</label>
                                             </dt>
                                             <dd>
                                                 <input class="form-control credential-new"
-                                                    value="" type="password"></input>
+                                                    value="" type="password"/>
                                             </dd>
                                             <dt>
                                                 <label translatable="yes">Confirm</label>
                                             </dt>
                                             <dd>
                                                 <input class="form-control credential-two"
-                                                    value="" type="password"></input>
+                                                    value="" type="password"/>
                                             </dd>
                                             <dt>
                                                 <a tabindex="0" role="button" data-toggle="popover"

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -131,7 +131,7 @@
       <div class="panel-heading">{{Description}}</div>
       <div class="list-group">
         <div class="list-group-item">
-          <input></input>
+          <input/>
           <button translatable="yes">Instantiate</button>
         </div>
       </div>

--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -61,8 +61,8 @@
               <div class="col-sm-5 col-md-5">
                 <i id="option-caret" class="caret caret-right" aria-hidden="true">
                     <svg height="16" width="16" viewBox="0 0 16 16">
-                        <polygon fill="#ffffff" points="4,0 4,14 12,7"/>
-                        <polygon>
+                        <polygon fill="#ffffff" points="4,0 4,14 12,7">
+                        </polygon>
                     </svg>
                 </i>
                 <span translate>Other Options</span>


### PR DESCRIPTION
This &lt;polygon&gt; tag in the login screen is broken, and Internet Explorer complains.

In addition, the <input> tag closes itself
    
Internet Explorer complains when we use invalid &lt;input&gt;&lt;/input&gt; tags in HTML. The <input> tag is meant to close itself, much like an &lt;img&gt; tag.

