### PR TITLE
test: Fix parsing of test names in avocado tests

### DIFF
--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -69,8 +69,7 @@ def tap_output(machine):
     counter = 1
     for t in json_info['tests']:
         test_status = t['status']
-        name_search = re.search("([^/]+):(.*)$", t['test'])
-        test_name = "%s (%s)" % (name_search.group(1), name_search.group(2))
+        test_name = os.path.basename(t['test'])
         test_log = t['logfile']
         test_time_string = "duration: %ds" % t['time']
         print "# ----------------------------------------------------------------------"


### PR DESCRIPTION
The parsing of test names would fail when running Avocado tests
with a specific test argument, and certain failures, such as
invalid syntax in the test.