### PR TITLE
test: Factor out package related things into new packagelib

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -20,34 +20,11 @@
 
 import parent
 from testlib import *
+from packagelib import PackageCase
 
 @skipImage("Image uses OSTree", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 @skipImage("PackageKit crashes, https://launchpad.net/bugs/1689820", "ubuntu-1604")
-class TestUpdates(MachineCase):
-    provision = {
-        "machine1": { "address": "10.111.113.2/20", "dns": "10.111.113.2" }
-    }
-
-    def setUp(self):
-        MachineCase.setUp(self)
-
-        self.isApt = "debian" in self.machine.image or "ubuntu" in self.machine.image
-
-        # disable all existing repositories to avoid hitting the network
-        if self.isApt:
-            self.machine.execute("rm -f /etc/apt/sources.list.d/*; echo > /etc/apt/sources.list; apt-get update")
-        else:
-            self.machine.execute("rm -f /etc/yum.repos.d/* /var/cache/yum/*")
-
-        # have PackageKit start from a clean slate
-        self.machine.execute("systemctl stop packagekit; rm -rf /var/cache/PackageKit")
-
-        # PackageKit refuses to operate when being offline (as on our test images); it's hard to fake
-        # NetworkManager's "is online" state, so disable it and let PackageKit fall back to the "unix"
-        # network stack; add a bogus default route to coerce it into being "online".
-        self.machine.execute("systemctl stop NetworkManager; ip route add default via 10.111.113.1 dev eth1")
-
-        self.updateInfo = {}
+class TestUpdates(PackageCase):
 
     def testBasic(self):
         # no security updates, no changelogs
@@ -529,142 +506,6 @@ class TestUpdates(MachineCase):
         b.wait_in_text("#state", "Loading available updates failed")
         b.wait_present("#app pre")
         b.wait_in_text("#app pre", "PackageKit is not installed")
-
-    #
-    # Helper functions for creating packages/repository
-    #
-
-    def createPackage(self, name, version, release, install=False, postinst=None, depends="", **updateinfo):
-        '''Create a dummy package in /tmp/repo on self.machine
-
-        If install is True, install the package. Otherwise, update the package
-        index in /tmp/repo.
-        '''
-        if self.isApt:
-            self.createDeb(name, version + '-' + release, depends, postinst, install)
-        else:
-            self.createRpm(name, version, release, depends, postinst, install)
-        if updateinfo:
-            self.updateInfo[(name, version, release)] = updateinfo
-
-    def createDeb(self, name, version, depends, postinst, install):
-        '''Create a dummy deb in /tmp/repo on self.machine
-
-        If install is True, install the package. Otherwise, update the package
-        index in /tmp/repo.
-        '''
-        deb = "/tmp/repo/{0}_{1}_all.deb".format(name, version)
-        if postinst:
-            postinstcode = "printf '#!/bin/sh\n{0}' > /tmp/b/DEBIAN/postinst; chmod 755 /tmp/b/DEBIAN/postinst".format(postinst)
-        else:
-            postinstcode = ''
-        cmd = '''mkdir -p /tmp/b/DEBIAN /tmp/repo
-                 printf "Package: {0}\nVersion: {1}\nPriority: optional\nSection: test\nMaintainer: foo\nDepends: {2}\nArchitecture: all\nDescription: dummy {0}\n" > /tmp/b/DEBIAN/control
-                 {4}
-                 touch /tmp/b/stamp-{0}-{1}
-                 dpkg -b /tmp/b {3}
-                 rm -r /tmp/b
-                 '''.format(name, version, depends, deb, postinstcode)
-        if install:
-            cmd += "dpkg -i " + deb
-        self.machine.execute(cmd)
-
-    def createRpm(self, name, version, release, requires, post, install):
-        '''Create a dummy rpm in /tmp/repo on self.machine
-
-        If install is True, install the package. Otherwise, update the package
-        index in /tmp/repo.
-        '''
-        if post:
-            postcode = '\n%%post\n' + post
-        else:
-            postcode = ''
-        if requires:
-            requires = "Requires: %s\n" % requires
-        cmd = '''printf 'Summary: dummy {0}\nName: {0}\nVersion: {1}\nRelease: {2}\nLicense: BSD\nBuildArch: noarch\n{3}
-%%install\ntouch $RPM_BUILD_ROOT/stamp-{0}-{1}-{2}\n
-%%description\nTest package.\n
-%%files\n/stamp-*\n
-{4}' > /tmp/spec
-                 rpmbuild -bb  /tmp/spec
-                 mkdir -p /tmp/repo
-                 cp ~/rpmbuild/RPMS/noarch/*.rpm /tmp/repo
-                 rm -rf ~/rpmbuild
-                 '''.format(name, version, release, requires, postcode)
-        if install:
-            cmd += "rpm -i /tmp/repo/{0}-{1}-{2}.*.rpm".format(name, version, release)
-        self.machine.execute(cmd)
-
-    def createAptChangelogs(self):
-        # apt metadata has no formal field for bugs/CVEs, they are parsed from the changelog
-        for ((pkg, ver, rel), info) in self.updateInfo.items():
-            changes = info.get("changes", "some changes")
-            if info.get("bugs"):
-                changes += " (Closes: {0})".format(", ".join(["#" + str(b) for b in info["bugs"]]))
-            if info.get("cves"):
-                changes += "\n  * " + ", ".join(info["cves"])
-
-            path = "/tmp/repo/changelogs/{0}/{1}/{1}_{2}-{3}".format(pkg[0], pkg, ver, rel)
-            contents = '''{0} ({1}-{2}) unstable; urgency=medium
-
-  * {3}
-
- -- Joe Developer <joe@example.com>  Wed, 31 May 2017 14:52:25 +0200
-'''.format(pkg, ver, rel, changes)
-            self.machine.execute("mkdir -p $(dirname {0}); echo '{1}' > {0}".format(path, contents))
-
-    def createYumUpdateInfo(self):
-        xml = '<?xml version="1.0" encoding="UTF-8"?>\n<updates>\n'
-        for ((pkg, ver, rel), info) in self.updateInfo.items():
-            refs = ""
-            for b in info.get("bugs", []):
-                refs += '      <reference href="https://bugs.example.com?bug={0}" id="{0}" type="bugzilla"/>\n'.format(b)
-            for c in info.get("cves", []):
-                refs += '      <reference href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={0}" id="{0}" type="cve"/>\n'.format(c)
-
-            xml += '''  <update from="test@example.com" status="stable" type="{severity}" version="2.0">
-    <id>UPDATE-{pkg}-{ver}-{rel}</id>
-    <title>{pkg} {ver}-{rel} update</title>
-    <issued date="2017-01-01 12:34:56"/>
-    <description>{desc}</description>
-    <references>
-{refs}
-    </references>
-    <pkglist>
-     <collection short="0815">
-        <package name="{pkg}" version="{ver}" release="{rel}" epoch="0" arch="noarch">
-          <filename>{pkg}-{ver}-{rel}.noarch.rpm</filename>
-        </package>
-      </collection>
-    </pkglist>
-  </update>
-'''.format(pkg=pkg, ver=ver, rel=rel, refs=refs,
-            desc=info.get("changes", ""), severity=info.get("severity", "bugfix"))
-
-        xml += '</updates>\n'
-        return xml
-
-    def enableRepo(self):
-        if self.isApt:
-            self.createAptChangelogs()
-            # HACK: on Debian jessie, apt has an error propagation bug that causes "Err file: Packages" for each absent
-            # compression format with file:// sources, which breaks PackageKit; work around by providing all formats
-            self.machine.execute('''echo 'deb [trusted=yes] file:///tmp/repo /' > /etc/apt/sources.list.d/test.list
-                                    cd /tmp/repo; apt-ftparchive packages . > Packages
-                                    gzip -c Packages > Packages.gz; bzip2 -c Packages > Packages.bz2; xz -c Packages > Packages.xz
-                                    O=$(apt-ftparchive -o APT::FTPArchive::Release::Origin=cockpittest release .); echo "$O" > Release
-                                    echo 'Changelogs: http://localhost:12345/changelogs/@CHANGEPATH@' >> Release
-                                    setsid python -m SimpleHTTPServer 12345 >/dev/null 2>&1 < /dev/null &
-                                    ''')
-            self.machine.wait_for_cockpit_running(port=12345)  # wait for changelog HTTP server to start up
-        else:
-            self.machine.execute('''printf '[updates]\nname=cockpittest\nbaseurl=file:///tmp/repo\nenabled=1\ngpgcheck=0\n' > /etc/yum.repos.d/cockpittest.repo
-                                    echo '{0}' > /tmp/updateinfo.xml
-                                    createrepo_c /tmp/repo
-                                    modifyrepo_c /tmp/updateinfo.xml /tmp/repo/repodata
-                                    $(which dnf 2>/dev/null|| which yum) clean all'''.format(self.createYumUpdateInfo()))
-
-
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+from testlib import *
+
+class PackageCase(MachineCase):
+    provision = {
+        "machine1": { "address": "10.111.113.2/20", "dns": "10.111.113.2" }
+    }
+
+    def setUp(self):
+        MachineCase.setUp(self)
+
+        self.isApt = "debian" in self.machine.image or "ubuntu" in self.machine.image
+
+        # disable all existing repositories to avoid hitting the network
+        if self.isApt:
+            self.machine.execute("rm -f /etc/apt/sources.list.d/*; echo > /etc/apt/sources.list; apt-get update")
+        else:
+            self.machine.execute("rm -f /etc/yum.repos.d/* /var/cache/yum/*")
+
+        # have PackageKit start from a clean slate
+        self.machine.execute("systemctl stop packagekit; rm -rf /var/cache/PackageKit")
+
+        # PackageKit refuses to operate when being offline (as on our test images); it's hard to fake
+        # NetworkManager's "is online" state, so disable it and let PackageKit fall back to the "unix"
+        # network stack; add a bogus default route to coerce it into being "online".
+        self.machine.execute("systemctl stop NetworkManager; ip route add default via 10.111.113.1 dev eth1")
+
+        self.updateInfo = {}
+
+    #
+    # Helper functions for creating packages/repository
+    #
+
+    def createPackage(self, name, version, release, install=False, postinst=None, depends="", **updateinfo):
+        '''Create a dummy package in /tmp/repo on self.machine
+
+        If install is True, install the package. Otherwise, update the package
+        index in /tmp/repo.
+        '''
+        if self.isApt:
+            self.createDeb(name, version + '-' + release, depends, postinst, install)
+        else:
+            self.createRpm(name, version, release, depends, postinst, install)
+        if updateinfo:
+            self.updateInfo[(name, version, release)] = updateinfo
+
+    def createDeb(self, name, version, depends, postinst, install):
+        '''Create a dummy deb in /tmp/repo on self.machine
+
+        If install is True, install the package. Otherwise, update the package
+        index in /tmp/repo.
+        '''
+        deb = "/tmp/repo/{0}_{1}_all.deb".format(name, version)
+        if postinst:
+            postinstcode = "printf '#!/bin/sh\n{0}' > /tmp/b/DEBIAN/postinst; chmod 755 /tmp/b/DEBIAN/postinst".format(postinst)
+        else:
+            postinstcode = ''
+        cmd = '''mkdir -p /tmp/b/DEBIAN /tmp/repo
+                 printf "Package: {0}\nVersion: {1}\nPriority: optional\nSection: test\nMaintainer: foo\nDepends: {2}\nArchitecture: all\nDescription: dummy {0}\n" > /tmp/b/DEBIAN/control
+                 {4}
+                 touch /tmp/b/stamp-{0}-{1}
+                 dpkg -b /tmp/b {3}
+                 rm -r /tmp/b
+                 '''.format(name, version, depends, deb, postinstcode)
+        if install:
+            cmd += "dpkg -i " + deb
+        self.machine.execute(cmd)
+
+    def createRpm(self, name, version, release, requires, post, install):
+        '''Create a dummy rpm in /tmp/repo on self.machine
+
+        If install is True, install the package. Otherwise, update the package
+        index in /tmp/repo.
+        '''
+        if post:
+            postcode = '\n%%post\n' + post
+        else:
+            postcode = ''
+        if requires:
+            requires = "Requires: %s\n" % requires
+        cmd = '''printf 'Summary: dummy {0}\nName: {0}\nVersion: {1}\nRelease: {2}\nLicense: BSD\nBuildArch: noarch\n{3}
+%%install\ntouch $RPM_BUILD_ROOT/stamp-{0}-{1}-{2}\n
+%%description\nTest package.\n
+%%files\n/stamp-*\n
+{4}' > /tmp/spec
+                 rpmbuild -bb  /tmp/spec
+                 mkdir -p /tmp/repo
+                 cp ~/rpmbuild/RPMS/noarch/*.rpm /tmp/repo
+                 rm -rf ~/rpmbuild
+                 '''.format(name, version, release, requires, postcode)
+        if install:
+            cmd += "rpm -i /tmp/repo/{0}-{1}-{2}.*.rpm".format(name, version, release)
+        self.machine.execute(cmd)
+
+    def createAptChangelogs(self):
+        # apt metadata has no formal field for bugs/CVEs, they are parsed from the changelog
+        for ((pkg, ver, rel), info) in self.updateInfo.items():
+            changes = info.get("changes", "some changes")
+            if info.get("bugs"):
+                changes += " (Closes: {0})".format(", ".join(["#" + str(b) for b in info["bugs"]]))
+            if info.get("cves"):
+                changes += "\n  * " + ", ".join(info["cves"])
+
+            path = "/tmp/repo/changelogs/{0}/{1}/{1}_{2}-{3}".format(pkg[0], pkg, ver, rel)
+            contents = '''{0} ({1}-{2}) unstable; urgency=medium
+
+  * {3}
+
+ -- Joe Developer <joe@example.com>  Wed, 31 May 2017 14:52:25 +0200
+'''.format(pkg, ver, rel, changes)
+            self.machine.execute("mkdir -p $(dirname {0}); echo '{1}' > {0}".format(path, contents))
+
+    def createYumUpdateInfo(self):
+        xml = '<?xml version="1.0" encoding="UTF-8"?>\n<updates>\n'
+        for ((pkg, ver, rel), info) in self.updateInfo.items():
+            refs = ""
+            for b in info.get("bugs", []):
+                refs += '      <reference href="https://bugs.example.com?bug={0}" id="{0}" type="bugzilla"/>\n'.format(b)
+            for c in info.get("cves", []):
+                refs += '      <reference href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={0}" id="{0}" type="cve"/>\n'.format(c)
+
+            xml += '''  <update from="test@example.com" status="stable" type="{severity}" version="2.0">
+    <id>UPDATE-{pkg}-{ver}-{rel}</id>
+    <title>{pkg} {ver}-{rel} update</title>
+    <issued date="2017-01-01 12:34:56"/>
+    <description>{desc}</description>
+    <references>
+{refs}
+    </references>
+    <pkglist>
+     <collection short="0815">
+        <package name="{pkg}" version="{ver}" release="{rel}" epoch="0" arch="noarch">
+          <filename>{pkg}-{ver}-{rel}.noarch.rpm</filename>
+        </package>
+      </collection>
+    </pkglist>
+  </update>
+'''.format(pkg=pkg, ver=ver, rel=rel, refs=refs,
+            desc=info.get("changes", ""), severity=info.get("severity", "bugfix"))
+
+        xml += '</updates>\n'
+        return xml
+
+    def enableRepo(self):
+        if self.isApt:
+            self.createAptChangelogs()
+            # HACK: on Debian jessie, apt has an error propagation bug that causes "Err file: Packages" for each absent
+            # compression format with file:// sources, which breaks PackageKit; work around by providing all formats
+            self.machine.execute('''echo 'deb [trusted=yes] file:///tmp/repo /' > /etc/apt/sources.list.d/test.list
+                                    cd /tmp/repo; apt-ftparchive packages . > Packages
+                                    gzip -c Packages > Packages.gz; bzip2 -c Packages > Packages.bz2; xz -c Packages > Packages.xz
+                                    O=$(apt-ftparchive -o APT::FTPArchive::Release::Origin=cockpittest release .); echo "$O" > Release
+                                    echo 'Changelogs: http://localhost:12345/changelogs/@CHANGEPATH@' >> Release
+                                    setsid python -m SimpleHTTPServer 12345 >/dev/null 2>&1 < /dev/null &
+                                    ''')
+            self.machine.wait_for_cockpit_running(port=12345)  # wait for changelog HTTP server to start up
+        else:
+            self.machine.execute('''printf '[updates]\nname=cockpittest\nbaseurl=file:///tmp/repo\nenabled=1\ngpgcheck=0\n' > /etc/yum.repos.d/cockpittest.repo
+                                    echo '{0}' > /tmp/updateinfo.xml
+                                    createrepo_c /tmp/repo
+                                    modifyrepo_c /tmp/updateinfo.xml /tmp/repo/repodata
+                                    $(which dnf 2>/dev/null|| which yum) clean all'''.format(self.createYumUpdateInfo()))


### PR DESCRIPTION
This splits out the "mock package" creation bits from PR #7076. This part is ready to go, prone to becoming conflict-y, and I also need it to cleanly write check-packagekit test cases for the "RHEL subscription" feature.