### PR TITLE
test: Fix waiting for cockpit/ws container (on Atomic)

### DIFF
--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -626,7 +626,7 @@ class Machine:
         else:
             return "wheel"
 
-    def start_cockpit(self, atomic_wait_for_host="localhost", tls=False):
+    def start_cockpit(self, atomic_wait_for_host=None, tls=False):
         """Start Cockpit.
 
         Cockpit is not running when the test virtual machine starts up, to
@@ -649,8 +649,7 @@ class Machine:
                 cmd += "/usr/bin/docker run -d --privileged --pid=host -v /:/host cockpit/ws /container/atomic-run --local-ssh --no-tls\n"
             with Timeout(seconds=90, error_message="Timeout while waiting for cockpit/ws to start"):
                 self.execute(script=cmd)
-            if atomic_wait_for_host:
-                self.wait_for_cockpit_running(atomic_wait_for_host)
+            self.wait_for_cockpit_running(atomic_wait_for_host or "localhost")
         elif tls:
             self.execute(script="""#!/bin/sh
             rm -f /etc/systemd/system/cockpit.service.d/notls.conf &&


### PR DESCRIPTION
Tests that started Cockpit through `login_and_go()` previously hung for
a minute when they did their first Cockpit request:

    Resource Error: Connection closed http://127.0.0.2:9591/playground/pkgs
    Restarting browser...

This was due to `login_and_go()` calling `start_cockpit()` with an
explicit `atomic_wait_for_host=None` argument, which sidestepped the
waiting for Cockpit to actually start up in the container. The first
request would then hang and hit the phantom timeout.

We don't actually need a mode where `start_cockpit()` does *not* wait
for the container, so just fix the default argument handling.