### PR TITLE
test: Fix grepping /proc/net/dev

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -144,7 +144,7 @@ class TestMetrics(MachineCase):
         #
         m.execute("if type firewall-cmd >/dev/null 2>&1; then firewall-cmd --permanent --zone=public --add-port=2000/tcp && firewall-cmd --reload; fi")
 
-        (eth_before, lo_before) = m.execute(r"grep -E 'eth0|ens5' /proc/net/dev | awk '{print $2 + $10}'; "
+        (eth_before, lo_before) = m.execute(r"grep -E '\beth0:|\bens5:' /proc/net/dev | awk '{print $2 + $10}'; "
                                             r"grep '\blo:' /proc/net/dev | awk '{print $2 + $10}'").strip().split()
         time_before = time.time()
 


### PR DESCRIPTION
Tighten the regexp for grepping the ethernet RX/TX states. It previously
also caught devices like "veth0716247", causing this failure:

    # testInternal (check_metrics.TestMetrics)
    #
    Traceback (most recent call last):
      File "/build/cockpit/bots/../test/verify/check-metrics", line 190, in testInternal
        self.check_host_metrics()
      File "/build/cockpit/bots/../test/verify/check-metrics", line 147, in check_host_metrics
        (eth_before, lo_before) = m.execute(r"grep -E 'eth0|ens5' /proc/net/dev | awk '{print $2 + $10}'; "
    ValueError: too many values to unpack