### PR TITLE
packagekit: Handle unregistered Red Hat systems

### DIFF
--- a/pkg/packagekit/updates.css
+++ b/pkg/packagekit/updates.css
@@ -162,6 +162,13 @@ tr.security.listing-ct-item {
     border: none;
 }
 
+/* standard blank-slate-pf does not limit width of paragraph, which looks ugly */
+.blank-slate-pf p {
+    max-width: 50rem;
+    margin: 0 auto;
+    text-align: center;
+}
+
 .flow-list-blank-slate {
     padding-top: 8em;
     margin: 0 auto;

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -18,13 +18,31 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import os
+
 import parent
 from testlib import *
 from packagelib import PackageCase
 
+WAIT_SCRIPT = """
+set -ex
+for x in $(seq 1 200); do
+    if curl --insecure -s https://%(addr)s:8443/candlepin; then
+        break
+    else
+        sleep 1
+    fi
+done
+"""
+
 @skipImage("Image uses OSTree", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 @skipImage("PackageKit crashes, https://launchpad.net/bugs/1689820", "ubuntu-1604")
 class TestUpdates(PackageCase):
+    def setUp(self):
+        PackageCase.setUp(self)
+
+        # Disable Subscription Manager for these tests; subscriptions are tested in a separate class
+        self.machine.execute("[ ! -f /usr/libexec/rhsmd ] || mv /usr/libexec/rhsmd /usr/libexec/rhsmd.disabled")
 
     def testBasic(self):
         # no security updates, no changelogs
@@ -506,6 +524,119 @@ class TestUpdates(PackageCase):
         b.wait_in_text("#state", "Loading available updates failed")
         b.wait_present("#app pre")
         b.wait_in_text("#app pre", "PackageKit is not installed")
+
+
+@skipImage("Image uses OSTree", "continuous-atomic", "fedora-atomic", "rhel-atomic")
+@skipImage("No subscriptions", "centos-7", "debian-stable", "debian-testing", "fedora-24", "fedora-25", "fedora-26", "fedora-i386", "fedora-testing", "ubuntu-1604", "ubuntu-stable")
+class TestUpdatesSubscriptions(PackageCase):
+    provision = {
+        "0": { "address": "10.111.113.2/20", "dns": "10.111.113.2" },
+        "candlepin": { "image": "candlepin", "address": "10.111.113.5/20" }
+    }
+
+    def register(self):
+        # this fails with "Unable to find available subscriptions for all your installed products", but works anyway
+        self.machine.execute("subscription-manager register --insecure --serverurl https://10.111.113.5:8443/candlepin --org=admin --activationkey=awesome_os_pool || true")
+        self.machine.execute("subscription-manager attach --auto")
+
+    def setUp(self):
+        PackageCase.setUp(self)
+        self.candlepin = self.machines['candlepin']
+        m = self.machine
+
+        # wait for candlepin to be active and verify
+        self.candlepin.execute("systemctl start tomcat")
+
+        # remove all existing products (RHEL server), as we can't control them
+        m.execute("rm /etc/pki/product-default/*.pem /etc/pki/product/*.pem")
+
+        # download product info from the candlepin machine and install it
+        product_file = os.path.join(self.tmpdir, "88888.pem")
+        self.candlepin.download("/root/candlepin/generated_certs/88888.pem", product_file)
+
+        # # upload product info to the test machine
+        m.upload([product_file], "/etc/pki/product")
+
+        # make sure that rhsm skips certificate checks for the server
+        m.execute("sed -i -e 's/insecure = 0/insecure = 1/g' /etc/rhsm/rhsm.conf")
+
+        # Wait for the web service to be accessible
+        m.execute(script=WAIT_SCRIPT % { "addr": "10.111.113.5" })
+
+    def testNoUpdates(self):
+        m = self.machine
+        b = self.browser
+
+        # fresh machine, no updates available; by default our rhel-* images are not registered
+        m.start_cockpit()
+        b.login_and_go("/updates")
+
+        # empty state visible in main area
+        b.wait_present(".container-fluid div.blank-slate-pf button")
+        b.wait_in_text(".container-fluid div.blank-slate-pf", "This system is not registered")
+        # hides the header bar
+        self.assertFalse(b.is_present(".content-header-extra"))
+
+        # use the button to switch to Subscriptions
+        b.click(".container-fluid div.blank-slate-pf button")
+        b.switch_to_top()
+        b.wait_js_cond('window.location.pathname === "/subscriptions"')
+
+        # after registration it should show the usual "system is up to date", through the "status changed" signal
+        self.register()
+        b.go("/updates")
+        b.enter_page("/updates")
+        b.wait_present(".content-header-extra td button")
+        b.wait_present("#state")
+        b.wait_in_text("#state", "No updates pending")
+        b.wait_present(".container-fluid div.blank-slate-pf")
+        b.wait_in_text(".container-fluid div.blank-slate-pf", "up to date")
+
+    def testAvailableUpdates(self):
+        m = self.machine
+        b = self.browser
+
+        # one available update
+        self.createPackage("vanilla", "1.0", "1", install=True)
+        self.createPackage("vanilla", "1.0", "2")
+        self.enableRepo()
+
+        # by default our rhel-* images are not registered; should show available update and unregistered warning, but no
+        # other action buttons
+        m.start_cockpit()
+        b.login_and_go("/updates")
+
+        b.wait_present(".alert-warning")
+        b.wait_in_text(".alert-warning", "subscribe")
+        b.wait_present("table.listing-ct")
+        b.wait_in_text("table.listing-ct", "vanilla")
+        # should show header bar
+        b.wait_present("#state")
+        self.assertEqual(b.text("#state"), "1 update")
+        b.wait_present(".content-header-extra")
+        self.assertEqual(b.text(".content-header-extra td.text-right span"), "Last checked: a few seconds ago")
+        # should be unique; no other action buttons
+        b.wait_present("button")
+        b.wait_in_text("button", "Registration")
+
+        # use the button to switch to Subscriptions
+        b.click("button")
+        b.switch_to_top()
+        b.wait_js_cond('window.location.pathname === "/subscriptions"')
+
+        # after registration it should show the usual "system is up to date"
+        self.register()
+        b.go("/updates")
+        b.enter_page("/updates")
+        b.wait_not_present(".alert-warning")
+        # h2 should now be unique, no update history yet, no warning any more
+        b.wait_present(".container-fluid h2")
+        b.wait_in_text(".container-fluid h2", "Available Updates")
+        # has action buttons
+        b.wait_present(".content-header-extra td button")
+        b.wait_present("#app .container-fluid button")
+        self.assertEqual(b.text("#app .container-fluid button"), "Install all updates")
+
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Do a status D-Bus call to subscription-manager. If that succeeds and the
status is not registered (expired, warning, or registration-required),
adjust the status views:

 * If there are no updates available, replace the "system is up to date"
   page with a "This system is not registered" warning. That system
   really is not okay as the big check mark previously indicated.

 * If there are updates available, they can usually not be installed any
   more with an expired subscription. Continue to show the updates, but
   disable the update action buttons and show a warning at the top.

In both cases, provide a button to directly go to the Subscriptions
page.

Add tests using the candlepin image and it's "88888" product for which
tests can control the subscription.

Fixes #7194 

----

There are still two minor [design questions](https://github.com/cockpit-project/cockpit/issues/7194#issuecomment-319338062) for @garrett  compared to the specified design in #7194 , but I'd like to give this an initial spin on CI and collect some review.

 - [ ] add an `<a>` to access.redhat.com or not?
 - [ ] confirm changed string in warning box