### PR TITLE
bots: Download libssh during Atomic Host image creation

### DIFF
--- a/bots/images/scripts/continuous-atomic.setup
+++ b/bots/images/scripts/continuous-atomic.setup
@@ -47,6 +47,11 @@ echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" 
 ostree remote add --set=gpg-verify=false centos-atomic-continuous https://ci.centos.org/artifacts/sig-atomic/rdgo/centos-continuous/ostree/repo/
 rpm-ostree rebase centos-atomic-continuous:centos-atomic-host/7/x86_64/devel/continuous
 
+# Download the libssh RPM which we'll use for package overlay
+# The only way to do this is via a container
+. /etc/os-release
+docker run --rm --volume=/etc/yum.repos.d:/etc/yum.repos.d:z --volume=/root/rpms:/tmp/rpms:rw,z "$ID:$VERSION_ID" /bin/sh -cex "yum install -y findutils && yum install -y --downloadonly libssh && find /var -name '*.rpm' | while read rpm; do mv -v \$rpm /tmp/rpms; done"
+
 ostree checkout centos-atomic-continuous:centos-atomic-host/7/x86_64/devel/continuous /var/local-tree
 
 # reduce image size

--- a/bots/images/scripts/lib/atomic.setup
+++ b/bots/images/scripts/lib/atomic.setup
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-set -e
+set -ex
 
 # HACK: docker fails without /etc/resolv.conf
 # https://bugzilla.redhat.com/show_bug.cgi?id=1448331
@@ -52,6 +52,17 @@ if rpm-ostree upgrade --check; then
 else
     checkout=$(atomic host status --json | python -c 'import json; import sys; j = json.loads(sys.stdin.readline()); print [x for x in j["deployments"] if x["booted"]][0]["checksum"]')
 fi
+
+# Download the libssh RPM which we'll use for package overlay
+# The only way to do this is via a container
+. /etc/os-release
+REPO="updates"
+if [ "$ID" = "rhel" ]; then
+    subscription-manager repos --enable rhel-7-server-extras-rpms
+    REPO="rhel-7-server-extras-rpms"
+    ID="rhel7"
+fi
+docker run --rm --volume=/etc/yum.repos.d:/etc/yum.repos.d:z --volume=/root/rpms:/tmp/rpms:rw,z "$ID:$VERSION_ID" /bin/sh -cex "yum install -y findutils && yum install -y --downloadonly --enablerepo=$REPO libssh && find /var -name '*.rpm' | while read rpm; do mv -v \$rpm /tmp/rpms; done"
 
 # Checkout the just upgraded os branch since we'll use it every time
 # we build a new tree.


### PR DESCRIPTION
In order to test rpm-ostree package overlaying of the dashboard
the libssh RPM available. Lets download it while creating the
various atomic images.

There is no tooling on an Atomic Host to download images, so we
do it with a docker command using a matching container image.

 * [x] Works for fedora-atomic
 * [x] Works for rhel-atomic