### PR TITLE
bots: Track latest Fedora Atomic Host and update to 26

### DIFF
--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -198,11 +198,11 @@ def only_install(image, build_results, skips, args, address):
 
 # The Atomic variants can't build their own packages, so we build in
 # their non-Atomic siblings.  For example, fedora-atomic is built
-# in fedora-25
+# in fedora-26
 def get_build_image(image):
     (test_os, unused) = os.path.splitext(os.path.basename(image))
     if test_os == "fedora-atomic":
-        image = "fedora-25"
+        image = "fedora-26"
     elif test_os == "rhel-atomic":
         image = "rhel-7"
     elif test_os == "continuous-atomic":

--- a/bots/images/fedora-atomic
+++ b/bots/images/fedora-atomic
@@ -1,1 +1,1 @@
-fedora-atomic-9331ebf6f6f6b4ba217f26ef04afd39fc25fc37e648a3d80a3df51ed7b99a27d.qcow2
+fedora-atomic-48a5f6bac377e657e084b2e02160c1f285e2735da6800fa8e2a07b18dab72b41.qcow2

--- a/bots/images/scripts/atomic.bootstrap
+++ b/bots/images/scripts/atomic.bootstrap
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-set -e
+set -ex
 
 out=$1
 base=$2
@@ -56,12 +56,12 @@ else
     fi
 fi
 
-# Make the image be at least 8 Gig.  During boot, docker-storage-setup
+# Make the image be at least 12 Gig.  During boot, docker-storage-setup
 # will grow the partitions etc as appropriate, and atomic.setup will
 # explicitly grow the docker pool.
 
 vsize=$(qemu-img info "$out" --output=json | python -c 'import json, sys; print json.load(sys.stdin)["virtual-size"]')
 
-if [ "$vsize" -lt 8589934592 ]; then
-    qemu-img resize "$out" 8589934592
+if [ "$vsize" -lt 12884901888 ]; then
+    qemu-img resize "$out" 12884901888
 fi

--- a/bots/images/scripts/fedora-atomic.bootstrap
+++ b/bots/images/scripts/fedora-atomic.bootstrap
@@ -10,4 +10,4 @@ BASE=$(dirname $0)
 # The Fedora URLs have the version twice in the name. for example:
 # https://dl.fedoraproject.org/pub/alt/atomic/stable/Fedora-Atomic-25-20160921.0/CloudImages/x86_64/images/Fedora-Cloud-Base-25-20160921.0.x86_64.qcow2
 $BASE/atomic.bootstrap "$1" "$url" \
-    "Fedora-Atomic-25-[0-9\.]+" "CloudImages" "x86_64" "images" "Fedora-Atomic-25-[0-9\.]+.x86_64.qcow2"
+    "Fedora-Atomic-[-0-9\.]+" "CloudImages" "x86_64" "images" "Fedora-Atomic-[-0-9\.]+.x86_64.qcow2"

--- a/bots/images/scripts/fedora-atomic.install
+++ b/bots/images/scripts/fedora-atomic.install
@@ -3,4 +3,4 @@
 
 set -e
 
-/var/lib/testvm/atomic.install --skip cockpit-kdump "$@"
+/var/lib/testvm/atomic.install --verbose --skip cockpit-kdump "$@"

--- a/bots/images/scripts/lib/atomic.setup
+++ b/bots/images/scripts/lib/atomic.setup
@@ -31,7 +31,11 @@ systemctl daemon-reload
 # HACK: docker falls over regularly, print its log if it does
 systemctl start docker || journalctl -u docker
 lvresize atomicos/root        -l+50%FREE -r
-lvresize atomicos/docker-pool -l+100%FREE
+if lvs atomicos/docker-pool 2>/dev/null; then
+    lvresize atomicos/docker-pool -l+100%FREE
+else
+    lvresize atomicos/docker-root-lv -l+100%FREE
+fi
 
 # we need cockpit/ws as well
 docker pull cockpit/ws

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -132,8 +132,7 @@ class TestDockerStorageMapper(MachineCase):
 
         if can_manage(m):
             # Allow docker-storage-setup to be happy with our very small disks
-            m.write("/etc/sysconfig/docker-storage-setup",
-                    'MIN_DATA_SIZE=80M\n')
+            m.execute("echo 'MIN_DATA_SIZE=80M\n' >> /etc/sysconfig/docker-storage-setup")
 
         def check_loopback(val):
             # We pass the output through logger to diagnose flakey issues

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -72,11 +72,11 @@ def initially_without_vgroup(machine):
 
 # The Atomic variants can't build their own packages, so we build in
 # their non-Atomic siblings.  For example, fedora-atomic is built
-# in fedora-25
+# in fedora-26
 def get_build_image(test_os):
     build_os = test_os
     if test_os == "fedora-atomic":
-        build_os = "fedora-25"
+        build_os = "fedora-26"
     elif test_os == "rhel-atomic":
         build_os = "rhel-7"
     elif test_os == "continuous-atomic":

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -56,7 +56,7 @@ def initially_loopbacked(machine):
         return False
 
     # use the overlayfs driver by default on some distros
-    if machine.image in [ "debian-stable", "ubuntu-1604", "ubuntu-stable", "fedora-26" ]:
+    if machine.image in [ "debian-stable", "ubuntu-1604", "ubuntu-stable", "fedora-26", "fedora-atomic" ]:
         return False
 
     # The rest don't have space in the root volume group, or don't

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -51,6 +51,7 @@ def ensure_remote_http_port (m, remote="local"):
         m.execute(["ostree", "remote", "delete", remote])
         m.execute(["ostree", "remote", "add", remote,
                    "http://127.0.0.1:12345", "--no-gpg-verify"])
+        m.execute("printf '\nmin-free-space-percent=0\n' >> /var/local-repo/config")
         try:
             m.execute(["rpm-ostree reload"])
         except subprocess.CalledProcessError:

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -488,9 +488,11 @@ class OstreeCase(MachineCase):
         b.wait_present("#change-branch")
         b.wait_in_text("#change-branch", branch)
         # But can't list
+        b.click("#change-branch")
         b.wait_present("table.listing-ct tbody:nth-child(2) ul.dropdown-menu")
         b.wait_present("table.listing-ct tbody:nth-child(2) ul.dropdown-menu div.alert")
-        b.wait_in_text("table.listing-ct tbody:nth-child(2) ul.dropdown-menu div.alert", "Connection refused")
+        # Actual error message changes between versions
+        b.wait_present("table.listing-ct tbody:nth-child(2) ul.dropdown-menu div.alert span.pficon-warning-triangle-o")
 
         # Config created
         self.assertEqual(m.execute("cat /etc/ostree/remotes.d/zremote-test1.conf").strip(),


### PR DESCRIPTION
We should track the latest Fedora Atomic Host and move between versions by themselves.
    
As you can see there are some fixes needed at present when that happens. Over time we should work to make this more dynamic and select a build image based on what the atomic image can tell us about itself.

This pull request updates the image to a 26 image, and changes it so that in the future it'll move to 27 and 28 by itself.

 * [x] Make sure #6556 works
 * [x] #7443 
