### PR TITLE
bots: Track latest RHEL Atomic Host and update to 7.4

### DIFF
--- a/bots/images/rhel-atomic
+++ b/bots/images/rhel-atomic
@@ -1,1 +1,1 @@
-rhel-atomic-ba8341c82a035445c9d0e030e4e2a380ba8d3d6cff03b3532b819ebf333f6c01.qcow2
+rhel-atomic-3bc2ce8fcfb8126f9794bdec5d89c38cbc30ba758dd017dbbeb495c10edb3f53.qcow2

--- a/bots/images/scripts/rhel-atomic.bootstrap
+++ b/bots/images/scripts/rhel-atomic.bootstrap
@@ -6,4 +6,4 @@ set -e
 url="http://cdn.stage.redhat.com/content/dist/rhel/atomic/7/7Server/x86_64/images/"
 
 BASE=$(dirname $0)
-$BASE/atomic.bootstrap "$1" "$url" "rhel-atomic-cloud-7.3.[0-9\.-]+.x86_64.qcow2"
+$BASE/atomic.bootstrap "$1" "$url" "rhel-atomic-cloud-[0-9\.-]+.x86_64.qcow2"

--- a/bots/naughty/rhel-atomic/7462-atomic-sosreport-hangs-forever
+++ b/bots/naughty/rhel-atomic/7462-atomic-sosreport-hangs-forever
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-sosreport", line *, in testBasic
+    b.wait_visible("#sos-download")
+*
+Error: timeout


### PR DESCRIPTION
We should track the latest RHEL Atomic Host and have the bots move between versions by themselves. We should avoid pinning rhel-atomic to a specific 7.x version.

This pull request updates the image to a 7.4 image, and changes it so that in the future it'll move to 7.5 and 7.6 by itself.

 * [x] Make sure #6556 works
 * [x] #7443 
