### PR TITLE
systemd: Inform about not met conditions

### DIFF
--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -633,6 +633,14 @@ $(function() {
                 template_description = cockpit.format(_("This unit is an instance of the $0 template."), link);
             }
 
+            var conditions = cur_unit.Conditions;
+            var not_met_conditions = [];
+            for (var i = 0; i < conditions.length; i++) {
+                if (conditions[i][4] < 0) {
+                    not_met_conditions.push(cockpit.format(_("Condition $0=$1 was not met"), conditions[i][0], conditions[i][3]));
+                }
+            }
+
             var text = mustache.render(unit_template,
                                        {
                                            Unit: cur_unit,
@@ -643,6 +651,7 @@ $(function() {
                                            TemplateDescription: template_description,
                                            UnitButton: unit_action_btn,
                                            FileButton: file_action_btn,
+                                           NotMetConditions: not_met_conditions,
                                        });
             $('#service-unit').html(text);
             $('#service-unit-action').on('click', "[data-action]", unit_action);

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -122,6 +122,23 @@
             {{/TemplateDescription}}
           </table>
         </div>
+        {{#NotMetConditions.length}}
+        <div class="list-group-item cond-fail">
+          <table>
+            <tr>
+              <td>
+                <span translate>Condition failed</span>
+                <ul>
+                {{#NotMetConditions}}
+                  <li>{{.}}</li>
+                {{/NotMetConditions}}
+               </ul>
+             </td>
+             <td></td>
+            </tr>
+          </table>
+        </div>
+        {{/NotMetConditions.length}}
       </div>
     </div>
   </script>

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -481,5 +481,64 @@ WantedBy=default.target
 
         self.allow_restart_journal_messages()
 
+    @skipImage("Not available with Cockpit 138", "rhel-7-4")
+    def testConditions(self):
+        m = self.machine
+        b = self.browser
+        m.write("/etc/systemd/system/condtest.service",
+"""
+[Unit]
+Description=Test Service
+ConditionDirectoryNotEmpty=/var/tmp/empty
+
+[Service]
+ExecStart=/bin/sh -c "while true; do sleep 5; done"
+
+[Install]
+WantedBy=multi-user.target
+""")
+
+        m.execute("mkdir -p /var/tmp/empty")
+        m.execute("rm -rf /var/tmp/empty/*")
+
+        # After writing files out tell systemd about them
+        m.execute("systemctl daemon-reload")
+        self.machine.execute("systemctl start multi-user.target")
+
+        # This does not work for not enabled services. See:
+        # https://github.com/systemd/systemd/issues/2234
+        self.machine.execute("systemctl enable condtest")
+
+        self.login_and_go("/system/services")
+
+        def svc_sel(service):
+            return 'tr[data-goto-unit="%s"]' % service
+
+        unit_action_btn = '#service-valid .list-group-item:nth-child(1) .btn-group'
+
+        # Selects Services tab
+        b.click('#services-filter :nth-child(2)')
+        b.wait_present(svc_sel('condtest.service'))
+        b.click(svc_sel("condtest.service"))
+        b.wait_visible('#service-valid')
+        b.wait_in_text('#service-valid', "inactive")
+        b.wait_action_btn(unit_action_btn, "Start")
+        b.click_action_btn(unit_action_btn)
+
+        b.wait_present("#service-unit div.cond-fail")
+        b.wait_in_text("#service-unit div.cond-fail", "ConditionDirectoryNotEmpty")
+
+        # If the condition succeeds the message disappears
+        m.execute("touch /var/tmp/empty/non-empty")
+
+        b.wait_visible('#service-valid')
+        b.wait_in_text('#service-valid', "inactive")
+        b.wait_action_btn(unit_action_btn, "Start")
+        b.click_action_btn(unit_action_btn)
+        b.wait_in_text('#service-valid', "active")
+
+        b.wait_not_present("#service-unit div.cond-fail")
+
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Hi cockpit folks!

Today I played with services a little bit. I was keen to use Cockpit for it.
When starting abrt-vmcore I felt like something is broken.
Little did I realize that some conditions can fail and service won't be
started. Now in Cockpit this can be very confusing, since clicking
`start` button does not seem to do anything.

After this patch failed conditions are listed.

How to reproduce:
1) Make sure that /var/crash is empty
2) Try to start abrt-vmcore service (Harvest vmcores for ABRT)

Result:
Nothing happens

Expected result:
Either service is started or I am informed why the service could not be started

This is the view if all conditions are met:
![all_met](https://user-images.githubusercontent.com/12330670/28957357-d1aec6e2-78f1-11e7-8ca4-db55f6aa575d.png)
This is the view if some conditions are not met:
![one_not_met](https://user-images.githubusercontent.com/12330670/28957358-d1b15650-78f1-11e7-8962-f196a93a9681.png)

Note 1: I am not sure what is your take on this. I was just really confused when I tried to start the mentioned service and it was doing nothing. Then I looked into `service abrt-vmcore status` and quickly realized what I was forgetting.

Note 2: Documentations says, that all conditions must be met and `and` operator is used. I think that short-circuit evaluation is used so never more than one condition will be mentioned. But I might be wrong, so I did it as I was excepting more conditions not to be met. (I tried it with more conditions failing, and only the last one was visible both in cockpit and service tool).

Note 3: I am not a UX guy, so if you do not like the design, send me some mockups and I gladly make it that way.

Note 4: No tests yet. I do not want to spent to much time on it (I did it while eating my breakfast today), if you say you do not want it.

