### PR TITLE
bots: Drop temporary testImages known issue again

### DIFF
--- a/bots/naughty/centos-7/7452-testImages-new-openshift
+++ b/bots/naughty/centos-7/7452-testImages-new-openshift
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "/build/cockpit/bots/../test/verify/check-openshift", line *, in testImages
-    b.click("tbody[data-id='marmalade/busybee:0.x'] tr td.listing-ct-toggle")
-*
-Error: tbody[data-id='marmalade/busybee:0.x'] tr td.listing-ct-toggle not found

--- a/bots/naughty/fedora-26/7452-testImages-new-openshift
+++ b/bots/naughty/fedora-26/7452-testImages-new-openshift
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "/build/cockpit/bots/../test/verify/check-openshift", line *, in testImages
-    b.click("tbody[data-id='marmalade/busybee:0.x'] tr td.listing-ct-toggle")
-*
-Error: tbody[data-id='marmalade/busybee:0.x'] tr td.listing-ct-toggle not found

--- a/bots/naughty/rhel-7-4/7452-testImages-new-openshift
+++ b/bots/naughty/rhel-7-4/7452-testImages-new-openshift
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "/build/cockpit/bots/../test/verify/check-openshift", line *, in testImages
-    b.click("tbody[data-id='marmalade/busybee:0.x'] tr td.listing-ct-toggle")
-*
-Error: tbody[data-id='marmalade/busybee:0.x'] tr td.listing-ct-toggle not found

--- a/bots/naughty/rhel-7/7452-testImages-new-openshift
+++ b/bots/naughty/rhel-7/7452-testImages-new-openshift
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "/build/cockpit/bots/../test/verify/check-openshift", line *, in testImages
-    b.click("tbody[data-id='marmalade/busybee:0.x'] tr td.listing-ct-toggle")
-*
-Error: tbody[data-id='marmalade/busybee:0.x'] tr td.listing-ct-toggle not found


### PR DESCRIPTION
It got fixed in PR #7401 which landed now.

Fixes #7452