### PR TITLE
naughty: Close 4980: RHEL: SELinux prevents NetworkManager from removing resolv.conf

### DIFF
--- a/bots/naughty/rhel-7/4980-selinux-networkmanager-resolv-conf
+++ b/bots/naughty/rhel-7/4980-selinux-networkmanager-resolv-conf
@@ -1,1 +1,0 @@
-scontext=system_u:system_r:NetworkManager_t:s0 tcontext=unconfined_u:object_r:etc_t:s0 tclass=file


### PR DESCRIPTION
Known issue which has not occurred in 26 days

RHEL: SELinux prevents NetworkManager from removing resolv.conf

Fixes #4980