### PR TITLE
bots: Add command to test PRs for npm dependencies

### DIFF
--- a/bots/image-naughty
+++ b/bots/image-naughty
@@ -40,7 +40,12 @@ def main():
     parser.add_argument('image', help="The image to check against")
     opts = parser.parse_args()
 
-    api = None if opts.offline else github.GitHub()
+    base = None
+    if os.environ.get("GITHUB_KNOWN_ISSUE_BASE"):
+        netloc = os.environ.get("GITHUB_API", "https://api.github.com")
+        base = "{0}/repos/{1}/".format(netloc, os.environ.get("GITHUB_KNOWN_ISSUE_BASE"))
+
+    api = None if opts.offline else github.GitHub(base=base)
     trace = sys.stdin.read()
     number = 0
 

--- a/bots/npm-repo-test-invoke
+++ b/bots/npm-repo-test-invoke
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import subprocess
+import argparse
+import socket
+import traceback
+
+sys.dont_write_bytecode = True
+
+from task import github
+from task import sink
+
+HOSTNAME = socket.gethostname().split(".")[0]
+BOTS = os.path.abspath(os.path.dirname(__file__))
+BASE = os.path.normpath(os.path.join(BOTS, ".."))
+
+def start_publishing(host, name, revision, context):
+        api = github.GitHub()
+        identifier = "-".join([
+            name.replace("/", "-"),
+            revision[0:8],
+            context.replace("/", "-")
+        ])
+
+        description = "{0} [{1}]".format(github.TESTING, HOSTNAME)
+
+        status = {
+            "github": {
+                "token": api.token,
+                "requests": [
+                    # Set status to pending
+                    { "method": "POST",
+                      "resource": api.qualify("statuses/" + revision),
+                      "data": {
+                            "state": "pending",
+                            "context": context,
+                            "description": description,
+                            "target_url": ":link"
+                        }
+                    }
+                ],
+                "watches": [{
+                    "resource": api.qualify("commits/" + revision + "/status"),
+                    "result": {
+                        "statuses": [
+                            {
+                                "context": context,
+                                "description": description,
+                                "target_url": ":link"
+                            }
+                        ]
+                    }
+                }]
+            },
+            "revision": revision,
+            "link": "log.html",
+            "extras": [ "https://raw.githubusercontent.com/cockpit-project/cockpit/master/bots/task/log.html" ],
+            "onaborted": {
+                "github": {
+                    "token": api.token,
+                    "requests": [
+                        # Set status to error
+                        { "method": "POST",
+                          "resource": api.qualify("statuses/" + revision),
+                          "data": {
+                              "state": "error",
+                              "context": context,
+                              "description": "NPM Install failed",
+                              "target_url": ":link"
+                          }
+                        }
+                    ]
+                }
+            }
+        }
+
+        return sink.Sink(host, identifier, status)
+
+def install(repo, revision, ref, name):
+    if ref:
+        subprocess.check_call([ "git", "fetch", "origin", ref ])
+        subprocess.check_output([ "git", "checkout", "origin/" + ref])
+
+    subprocess.check_output([ "npm", "install", "--save", "git+https://github.com/{0}#{1}".format(repo, revision)])
+
+    subprocess.check_output([ "git", "add", os.path.join(BASE, "package.json")])
+    subprocess.check_output(["git", "checkout", "--detach"])
+
+    # Commit the changes, if nothing to commit then there is nothing to test
+    try:
+        subprocess.check_output([ "git", "commit", "-m", "Testing {}".format(name)])
+    except subprocess.CalledProcessError:
+        return None
+
+    return subprocess.check_output([ "git", "rev-parse", "HEAD" ]).strip()
+
+def main():
+    parser = argparse.ArgumentParser(description='Run cockpit integration tests on a remote dependency')
+    parser.add_argument('-j', '--jobs', dest="jobs", type=int,
+            default=os.environ.get("TEST_JOBS", 1), help="Number of concurrent jobs")
+    parser.add_argument('--rebase', help="Rebase onto the specific branch before testing")
+    parser.add_argument('-o', "--offline", action='store_true',
+            help="Work offline, don''t fetch new data from origin for rebase")
+    parser.add_argument('--publish', dest='publish', default=os.environ.get("TEST_PUBLISH", ""),
+            action='store', help='Publish results centrally to a sink')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output')
+    parser.add_argument('context', help="The context or type of integration tests to run")
+    parser.add_argument('ref', nargs='?', help="The Git remote ref to pull")
+    opts = parser.parse_args()
+
+    git_base = github.determine_github_base()
+    repo = os.environ.get("GITHUB_BASE", git_base)
+    name = os.environ.get("TEST_NAME", "{0}-tests".format(repo))
+    revision = os.environ.get("TEST_REVISION")
+
+    if not revision:
+        sys.stderr.write("Npm install failed: missing revision\n")
+        sys.exit(1)
+
+    active_sink = None
+    if opts.publish:
+        active_sink = start_publishing(opts.publish, name, revision, opts.context)
+
+    try:
+        head = install(repo, revision, opts.ref, name)
+    except subprocess.CalledProcessError:
+        traceback.print_exc()
+        return 1
+
+    if not head:
+        sys.stderr.write("Cockpit is already at this version: Nothing to test")
+        return 1
+
+    if active_sink:
+        active_sink.flush(status={
+            "state": "pending",
+            "context": opts.context,
+            "description": "{0} [{1}]".format(github.TESTING, HOSTNAME),
+            "target_url": ":link"
+        })
+
+
+    del os.environ["TEST_REVISION"]
+
+    os.environ["TEST_REVISION"] = head
+    os.environ["GITHUB_REVISION"] = revision
+    os.environ["GITHUB_KNOWN_ISSUE_BASE"] = git_base
+    os.environ["TEST_NAME"] = name
+
+    args = list(sys.argv)
+    args[0] = os.path.join(BOTS, "tests-invoke")
+    os.execv(args[0], args)
+    assert False, "not reached"
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -54,9 +54,11 @@ def main():
 
     name = os.environ.get("TEST_NAME", "tests")
     revision = os.environ.get("TEST_REVISION")
+    github_revision = os.environ.get("GITHUB_REVISION")
 
     try:
-        task = PullTask(name, revision, opts.ref, opts.context, opts.rebase)
+        task = PullTask(name, revision, opts.ref, opts.context, opts.rebase,
+                        github_revision=github_revision)
         ret = task.run(opts)
     except RuntimeError, ex:
         ret = str(ex)
@@ -67,21 +69,25 @@ def main():
     return 0
 
 class PullTask(object):
-    def __init__(self, name, revision, ref, context, base=None):
+    def __init__(self, name, revision, ref, context, base=None, github_revision=None):
         self.name = name
         self.revision = revision
         self.ref = ref
         self.context = context
         self.base = base
+        self.github_revision = github_revision
 
         self.sink = None
         self.github_status_data = None
 
     def start_publishing(self, host):
         api = github.GitHub()
+        if not self.github_revision:
+            self.github_revision = self.revision
+
         identifier = "-".join([
-            self.name,
-            self.revision[0:8],
+            self.name.replace("/", "-"),
+            self.github_revision[0:8],
             self.context.replace("/", "-")
         ])
 
@@ -100,12 +106,12 @@ class PullTask(object):
                 "requests": [
                     # Set status to pending
                     { "method": "POST",
-                      "resource": api.qualify("statuses/" + self.revision),
+                      "resource": api.qualify("statuses/" + self.github_revision),
                       "data": self.github_status_data
                     }
                 ],
                 "watches": [{
-                    "resource": api.qualify("commits/" + self.revision + "/status"),
+                    "resource": api.qualify("commits/" + self.github_revision + "/status"),
                     "result": {
                         "statuses": [
                             {
@@ -117,7 +123,7 @@ class PullTask(object):
                     }
                 }]
             },
-            "revision": self.revision,
+            "revision": self.github_revision,
             "link": "log.html",
             "extras": [ "https://raw.githubusercontent.com/cockpit-project/cockpit/master/bots/task/log.html" ],
 
@@ -127,7 +133,7 @@ class PullTask(object):
                     "requests": [
                         # Set status to error
                         { "method": "POST",
-                          "resource": api.qualify("statuses/" + self.revision),
+                          "resource": api.qualify("statuses/" + self.github_revision),
                           "data": {
                               "state": "error",
                               "context": self.context,
@@ -328,7 +334,7 @@ class PullTask(object):
             self.start_publishing(opts.publish)
             os.environ["TEST_ATTACHMENTS"] = self.sink.attachments
 
-        msg = "Testing {0} for {1} with {2} on {3}...\n".format(self.revision, self.name,
+        msg = "Testing {0} for {1} with {2} on {3}...\n".format(self.github_revision, self.name,
                                                                 self.context, HOSTNAME)
         sys.stderr.write(msg)
 

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -43,6 +43,10 @@ DEFAULT_VERIFY = {
     'verify/ubuntu-stable': [ 'master' ],
 }
 
+NPM_REPOS = {
+    'cockpit-project/registry-image-widgets': ['container/kubernetes', 'verify/fedora-26']
+}
+
 # Non-public images used for testing
 REDHAT_VERIFY = {
     "verify/rhel-7": [ 'master', 'rhel-7.3.6', 'rhel-7.3.5', 'rhel-7.3.4', 'rhel-7.3.3', 'rhel-7.3.2' ],
@@ -88,7 +92,7 @@ def main():
     return 0
 
 # Prepare a human readable output
-def tests_human(priority, name, revision, ref, context, base=None):
+def tests_human(priority, name, revision, ref, context, base=None, repo=None, command=None):
     if priority is None:
         return
     try:
@@ -103,7 +107,7 @@ def tests_human(priority, name, revision, ref, context, base=None):
     )
 
 # Prepare an test invocation command
-def tests_invoke(priority, name, revision, ref, context, base=None):
+def tests_invoke(priority, name, revision, ref, context, base=None, repo=None, command=None):
     try:
         priority = int(priority)
     except (ValueError, TypeError):
@@ -111,9 +115,16 @@ def tests_invoke(priority, name, revision, ref, context, base=None):
     if priority <= 0:
         return
     current = time.strftime('%Y%m%d-%H%M%M')
-    cmd = "PRIORITY={priority:04d} TEST_NAME='{name}-{current}' TEST_REVISION='{revision}' bots/tests-invoke"
+    if not command:
+        command = "bots/tests-invoke"
+
+    cmd = "PRIORITY={priority:04d} TEST_NAME='{name}-{current}' TEST_REVISION='{revision}' {command}"
     if base:
         cmd += " --rebase='{base}'"
+
+    if repo:
+        cmd = "GITHUB_BASE='{repo}' " + cmd
+
     cmd += " '{context}' '{ref}'"
     return cmd.format(
         priority=priority,
@@ -123,6 +134,8 @@ def tests_invoke(priority, name, revision, ref, context, base=None):
         ref=pipes.quote(ref),
         context=pipes.quote(context),
         current=current,
+        repo=repo,
+        command=command
     )
 
 def prioritize(status, title, labels, priority, context):
@@ -175,7 +188,60 @@ def dict_is_subset(full, check):
             return False
     return True
 
-def scan_for_pull_tasks(api, update, human, policy):
+def update_status(api, revision, context, last, changes):
+    if changes:
+        changes["context"] = context
+    if changes and not dict_is_subset(last, changes):
+        response = api.post("statuses/" + revision, changes, accept=[ 422 ]) # 422 Unprocessable Entity
+        errors = response.get("errors", None)
+        if not errors:
+            return True
+        for error in response.get("errors", []):
+            sys.stderr.write("{0}: {1}\n".format(revision, error.get('message', json.dumps(error))))
+            sys.stderr.write(json.dumps(changes))
+        return False
+    return True
+
+def external_tasks (update, policy):
+    results = []
+    whitelist = github.whitelist()
+
+    for repo, contexts in NPM_REPOS.items():
+        api = github.GitHub(base="https://api.github.com/repos/{}/".format(repo))
+
+        for pull in api.pulls():
+            title = pull["title"]
+            number = pull["number"]
+            revision = pull["head"]["sha"]
+            statuses = api.statuses(revision)
+            login = pull["head"]["user"]["login"]
+
+            have = len(statuses.keys()) > 0
+            for context in contexts:
+                status = statuses.get(context, None)
+
+                if not context in policy or (have and not status):
+                    continue
+
+                if not status:
+                    status = { }
+
+                baseline = BASELINE_PRIORITY
+
+                # For unmarked and untested status, user must be in whitelist
+                # Not this only applies to this specific commit. A new status
+                # will apply if the user pushes a new commit.
+                if login not in whitelist and status.get("description", github.NO_TESTING) == github.NO_TESTING:
+                    priority = github.NO_TESTING
+                    changes = { "description": github.NO_TESTING, "context": context, "state": "pending" }
+                else:
+                    (priority, changes) = prioritize(status, title, lambda: [], baseline, context)
+                if not update or update_status(api, revision, context, status, changes):
+                    results.append((priority, "%s-pull-%d" % (repo, number), revision, "master", context, None, repo, "bots/npm-repo-test-invoke"))
+
+    return results
+
+def cockpit_tasks (api, update, policy):
     contexts = policy
 
     results = []
@@ -185,20 +251,6 @@ def scan_for_pull_tasks(api, update, human, policy):
             if branch not in branch_contexts:
                 branch_contexts[branch] = [ ]
             branch_contexts[branch].append(context)
-
-    def update_status(revision, context, last, changes):
-        if changes:
-            changes["context"] = context
-        if update and changes and not dict_is_subset(last, changes):
-            response = api.post("statuses/" + revision, changes, accept=[ 422 ]) # 422 Unprocessable Entity
-            errors = response.get("errors", None)
-            if not errors:
-                return True
-            for error in response.get("errors", []):
-                sys.stderr.write("{0}: {1}\n".format(revision, error.get('message', json.dumps(error))))
-                sys.stderr.write(json.dumps(changes))
-            return False
-        return True
 
     branch_priority = BASELINE_PRIORITY - 3
     for branch in branch_contexts:
@@ -213,7 +265,7 @@ def scan_for_pull_tasks(api, update, human, policy):
             for context in which:
                 status = statuses.get(context, { })
                 (priority, changes) = prioritize(status, "", lambda: [], branch_priority, context)
-                if update_status(revision, context, status, changes):
+                if not update or update_status(api, revision, context, status, changes):
                     results.append((priority, branch, revision, branch, context, None))
 
     whitelist = github.whitelist()
@@ -258,8 +310,14 @@ def scan_for_pull_tasks(api, update, human, policy):
                 changes = { "description": github.NO_TESTING, "context": context, "state": "pending" }
             else:
                 (priority, changes) = prioritize(status, title, labels, baseline, context)
-            if update_status(revision, context, status, changes):
+            if not update or update_status(api, revision, context, status, changes):
                 results.append((priority, "pull-%d" % number, revision, "pull/%d/head" % number, context, base))
+
+    return results
+
+def scan_for_pull_tasks(api, update, human, policy):
+    results = cockpit_tasks(api, update, policy)
+    results.extend(external_tasks(update, policy))
 
     if human:
         func = lambda x: tests_human(*x)


### PR DESCRIPTION
Allows us to test PRs for npm dependencies before they get merged. Requires that the bot user has permissions on the remote npm repo as the github status results are written there.