### PR TITLE
kubernetes: readme describes `bridge helper failed`

### DIFF
--- a/bots/README.md
+++ b/bots/README.md
@@ -25,6 +25,9 @@ For managing these images:
 For debugging the images:
 
  * test/vm-run: Run a test machine image
+ 
+In case of `qemu-system-x86_64: -netdev bridge,br=cockpit1,id=bridge0: bridge helper failed`
+error, please [allow][1] `qemu-bridge-helper` to access the bridge settings.
 
 To check when images will automatically be refreshed by the bots
 use the image-trigger tool:
@@ -106,3 +109,5 @@ good idea to make a dedicated pull request just for the images.  That
 pull request can then hopefully be merged to master faster.  If
 instead the images are created on the main feature pull request and
 sit there for a long time, they might cause annoying merge conflicts.
+
+[1]: https://blog.christophersmart.com/2016/08/31/configuring-qemu-bridge-helper-after-access-denied-by-acl-file-error/


### PR DESCRIPTION
When ` test/vm-run --network openshift` is executed on Fedora or CentOS,
it failes with following error:

libvirt.libvirtError: internal error: process exited while connecting to monitor:
2017-08-10T14:46:59.118700Z qemu-system-x86_64: -chardev pty,id=charserial0:
char device redirected to /dev/pts/4 (label charserial0)
access denied by acl file
2017-08-10T14:46:59.126574Z qemu-system-x86_64: -netdev bridge,br=cockpit1,id=bridge0:
bridge helper failed

which is not entirely self-explanatory. Link to a explanation and
workaround added.