### PR TITLE
ws: Clear cookie whenever we serve the login html

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -1556,3 +1556,17 @@ cockpit_auth_parse_application (const gchar *path,
   g_free (tmp);
   return val;
 }
+
+gchar *
+cockpit_auth_empty_cookie_value (const gchar *path)
+{
+  gchar *application = cockpit_auth_parse_application (path, NULL);
+  gchar *cookie = application_cookie_name (application);
+
+  gchar *cookie_line = g_strdup_printf ("%s=deleted; PATH=/", cookie);
+
+  g_free (application);
+  g_free (cookie);
+
+  return cookie_line;
+}

--- a/src/ws/cockpitauth.h
+++ b/src/ws/cockpitauth.h
@@ -94,6 +94,8 @@ gchar *         cockpit_auth_steal_authorization      (GHashTable *headers,
                                                        gchar **ret_type,
                                                        gchar **ret_conversation);
 
+gchar *         cockpit_auth_empty_cookie_value       (const gchar *path);
+
 G_END_DECLS
 
 #endif

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -589,6 +589,7 @@ handle_shell (CockpitHandlerData *data,
       shell_path = cockpit_conf_string ("WebService", "Shell");
       cockpit_channel_response_serve (service, headers, response, NULL,
                                       shell_path ? shell_path : cockpit_ws_shell_component);
+      cockpit_web_response_set_cache_type (response, COCKPIT_WEB_RESPONSE_NO_CACHE);
     }
   else
     {

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -520,6 +520,7 @@ static const DefaultFixture fixture_shell_path_login = {
   .org_path = "/path/system/host",
   .auth = NULL,
   .expect = "HTTP/1.1 200*"
+      "Set-Cookie: cockpit=deleted*"
       "<html>*"
       "<base href=\"/path/\">*"
       "login-button*"
@@ -599,6 +600,7 @@ static const DefaultFixture fixture_shell_login = {
   .path = "/system/host",
   .auth = NULL,
   .expect = "HTTP/1.1 200*"
+      "Set-Cookie: cockpit=deleted*"
       "<html>*"
       "<base href=\"/\">*"
       "login-button*"
@@ -652,6 +654,7 @@ static const DefaultFixture fixture_resource_login = {
   .path = "/cockpit/@localhost/yyy/zzz.html",
   .auth = NULL,
   .expect = "HTTP/1.1 200*"
+    "Set-Cookie: cockpit=deleted*"
     "<html>*"
     "login-button*"
 };
@@ -673,6 +676,17 @@ static const DefaultFixture fixture_host_static = {
     "Cache-Control: max-age=86400, private*"
     "#badge*"
     "url(\"logo.png\");*"
+};
+
+static const DefaultFixture fixture_host_login = {
+  .path = "/=host/system",
+  .auth = NULL,
+  .config = SRCDIR "/src/ws/mock-config/cockpit/cockpit.conf",
+  .expect = "HTTP/1.1 200*"
+      "Set-Cookie: machine-cockpit+host=deleted*"
+      "<html>*"
+      "<base href=\"/\">*"
+      "login-button*"
 };
 
 static const DefaultFixture fixture_host_static_no_auth = {
@@ -878,6 +892,8 @@ main (int argc,
   g_test_add ("/handlers/static/simple", Test, &fixture_static_simple,
               setup_default, test_default, teardown_default);
   g_test_add ("/handlers/static/host-static", Test, &fixture_host_static,
+              setup_default, test_default, teardown_default);
+  g_test_add ("/handlers/static/host-login", Test, &fixture_host_login,
               setup_default, test_default, teardown_default);
   g_test_add ("/handlers/static/host-static-no-auth", Test, &fixture_host_static_no_auth,
               setup_default, test_default, teardown_default);

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -531,6 +531,7 @@ static const DefaultFixture fixture_shell_index = {
   .auth = "/cockpit",
   .with_home = TRUE,
   .expect = "HTTP/1.1 200*"
+      "Cache-Control: no-cache, no-store*"
       "<base href=\"/cockpit/@localhost/another/test.html\">*"
       "<title>In home dir</title>*"
 };


### PR DESCRIPTION
When a user is logged in and they request a path that isn't for a specific file we serve the shell html. When they are not logged in we serve the login page.

Currently the shell html is served with a short cache that varies on cookie. However the cookie can invalidated by cockpit-ws, through an idleness or logout. If the user visits that page again without closing their browser. They will see the cached response (shell html) when really what they would expect is the login page.

This clears the cookie whenever we serve the login page. This work because on logout we force a page reload. 

However, if the cockpit-ws service is restarted or the user closes the only cockpit tab with out closing the browser they'll still get the shell html. The second commit stops caching any shell html to stop that from happening