### PR TITLE
kubernetes: Fix topology regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "jquery": "2.1.4",
     "jquery-flot": "0.8.3",
     "kubernetes-container-terminal": "1.0.3",
+    "org-kubernetes-object-describer": "https://github.com/kubernetes-ui/object-describer#v1.0.4",
     "kubernetes-object-describer": "1.1.4",
     "kubernetes-topology-graph": "0.0.23",
     "moment": "2.10.6",

--- a/pkg/kubernetes/scripts/details.js
+++ b/pkg/kubernetes/scripts/details.js
@@ -21,6 +21,7 @@
     "use strict";
 
     var angular = require('angular');
+    require('object-describer/dist/object-describer.js');
     require('kubernetes-object-describer/dist/object-describer.js');
     require('angular-dialog.js');
 

--- a/pkg/kubernetes/scripts/main.js
+++ b/pkg/kubernetes/scripts/main.js
@@ -26,6 +26,7 @@
     require('angular-gettext/dist/angular-gettext.js');
     require('angular-bootstrap-npm/dist/angular-bootstrap.js');
     require('kubernetes-container-terminal/dist/container-terminal.js');
+    require('object-describer/dist/object-describer.js');
     require('kubernetes-object-describer/dist/object-describer.js');
 
     /* The kubernetes client */

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -639,6 +639,38 @@ class KubernetesCommonTests(VolumeTests):
         # Assert that at least one link between Service and Pod has loaded
         b.wait_present("svg line.ServicePod")
 
+        # Make sure that details display works
+        b.wait_present("svg g.Node")
+        b.wait_js_func(
+            """(function() {
+                var el = window.Sizzle("svg g.Node");
+                var i;
+                for (i = 0; i < el.length; i++) {
+                    var x = el[i].getAttribute("cx");
+                    var y = el[i].getAttribute("cy");
+                    if (x && y) {
+                        var ev = document.createEvent("MouseEvent");
+                        ev.initMouseEvent(
+                            "mousedown",
+                            true /* bubble */, true /* cancelable */,
+                            window, null,
+                            0, 0, 0, 0, /* coordinates */
+                            false, false, false, false, /* modifier keys */
+                            0 /*left*/, null);
+
+                        /* Now dispatch the event */
+                        el[i].dispatchEvent(ev);
+                        return true;
+                    }
+                }
+
+            })""", "true")
+
+        b.wait_present("div.sidebar-pf-right")
+        b.wait_present("div.sidebar-pf-right kubernetes-object-describer")
+        b.wait_in_text("div.sidebar-pf-right kubernetes-object-describer", "127.0.0.1")
+        b.wait_in_text("div.sidebar-pf-right kubernetes-object-describer h3:first", "Node")
+
 class OpenshiftCommonTests(VolumeTests):
 
     def testBasic(self):


### PR DESCRIPTION
The version of kubernetes-object-describer in npm is broken. It is missing the actual kubernetesUI code.
Bring that repo in separately and make sure we are loading it.

Adds test to prevent regressing again.