### PR TITLE
bots: The Windows image is not public

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -191,7 +191,7 @@ class PullTask(object):
             # Download all the additional images so that even older branches find them
             subprocess.check_call([ os.path.join(BOTS, "image-download"),
                 "candlepin", "fedora-stock", "fedora-23-stock", "fedora-26",
-                "ipa", "openshift", "selenium", "windows-8"
+                "ipa", "openshift", "selenium"
             ])
 
         except subprocess.CalledProcessError:

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -26,7 +26,6 @@ DEFAULT_VERIFY = {
     'avocado/fedora-24': BRANCHES,
     'avocado/fedora-25': [ ],
     'container/kubernetes': BRANCHES,
-    'selenium/explorer': [ 'master' ],
     'selenium/firefox': BRANCHES,
     'selenium/chrome': BRANCHES,
     'verify/centos-7': BRANCHES,
@@ -48,6 +47,7 @@ REDHAT_VERIFY = {
     "verify/rhel-7": [ 'master', 'rhel-7.3.6', 'rhel-7.3.5', 'rhel-7.3.4', 'rhel-7.3.3', 'rhel-7.3.2' ],
     "verify/rhel-7-4": [ 'master', 'rhel-7.4' ],
     "verify/rhel-atomic": [ 'master' ],
+    'selenium/explorer': [ 'master' ],
 }
 
 # Server to tell us if we can test Red Hat images


### PR DESCRIPTION
The windows testing image cannot be publically loaded. So teach
the bots about that. They can check that they have access before
trying to use that image.