### PR TITLE
kubernetes: object-describer dependency fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "jquery": "2.1.4",
     "jquery-flot": "0.8.3",
     "kubernetes-container-terminal": "1.0.3",
-    "org-kubernetes-object-describer": "https://github.com/kubernetes-ui/object-describer#v1.0.4",
+    "object-describer": "https://github.com/kubernetes-ui/object-describer.git#v1.0.4",
     "kubernetes-object-describer": "1.1.4",
     "kubernetes-topology-graph": "0.0.23",
     "moment": "2.10.6",

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -78,7 +78,7 @@ def module_license(moddir):
 
     # missing licenses
     mod = os.path.basename(moddir)
-    if mod == 'kubernetes-object-describer':
+    if mod == 'kubernetes-object-describer' or mod == 'object-describer':
         # upstream says "same as what we use for origin and origin-web-console which is Apache"
         # https://github.com/kubernetes-ui/object-describer/issues/31
         return 'Apache-2.0'
@@ -128,7 +128,7 @@ def module_copyright(moddir):
         pass
 
     # missing copyrights
-    if mod == 'kubernetes-object-describer':
+    if mod == 'kubernetes-object-describer' or mod == 'object-describer':
         # only committer is Jessica Forrester, working for Red Hat
         # https://github.com/kubernetes-ui/object-describer/issues/35
         copyrights.add(' (C) 2015-2017 Red Hat, Inc.')


### PR DESCRIPTION
It fixed npm declaration of object-describer dependency
(commit 3e12a1cd140ffbc26589ce093564075558817c4f) and adds necessary
changes to build-debian-copyright.

Fixes #7525.

@petervo please review