### PR TITLE
test: Enable translations testing on RHEL

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -119,9 +119,6 @@ WantedBy=default.target
             b.wait_not_visible("#content-navbar")
 
         # Lets try changing the language
-        # Translations are not ready for RHEL yet
-        if "rhel" in m.image:
-            return
 
         b.click("#content-user-name")
         b.click(".display-language-menu a")


### PR DESCRIPTION
Translations should be tested on RHEL.

Found while trying to reproduce language-switching bug https://bugzilla.redhat.com/show_bug.cgi?id=1484691
