### PR TITLE
NFS client

### DIFF
--- a/pkg/apps/appstream.js
+++ b/pkg/apps/appstream.js
@@ -19,6 +19,7 @@
 
 var cockpit = require("cockpit");
 var python = require("python.jsx");
+var inotify_py = require("raw!inotify.py");
 var watch_appstream_py = require("raw!./watch-appstream.py");
 
 var metainfo_db = null;
@@ -32,7 +33,7 @@ function get_metainfo_db() {
         });
 
         var buf = "";
-        python.spawn(watch_appstream_py, [ ],
+        python.spawn([ inotify_py, watch_appstream_py ], [ ],
                      { environ: [ "LANGUAGE=" + (cockpit.language || "en") ]
                      })
             .stream(function (data) {

--- a/pkg/lib/inotify.py
+++ b/pkg/lib/inotify.py
@@ -1,0 +1,72 @@
+#
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import ctypes
+import struct
+import subprocess
+import traceback
+
+IN_CLOSE_WRITE = 0x00000008
+IN_MOVED_FROM  = 0x00000040
+IN_MOVED_TO    = 0x00000080
+IN_CREATE      = 0x00000100
+IN_DELETE      = 0x00000200
+IN_DELETE_SELF = 0x00000400
+IN_MOVE_SELF   = 0x00000800
+IN_IGNORED     = 0x00008000
+
+class Inotify:
+    def __init__(self):
+        self._libc = ctypes.CDLL(None, use_errno=True)
+        self._get_errno_func = ctypes.get_errno
+
+        self._libc.inotify_init.argtypes = []
+        self._libc.inotify_init.restype = ctypes.c_int
+        self._libc.inotify_add_watch.argtypes = [ctypes.c_int, ctypes.c_char_p,
+                                                 ctypes.c_uint32]
+        self._libc.inotify_add_watch.restype = ctypes.c_int
+        self._libc.inotify_rm_watch.argtypes = [ctypes.c_int, ctypes.c_int]
+        self._libc.inotify_rm_watch.restype = ctypes.c_int
+
+        self.fd = self._libc.inotify_init()
+
+    def add_watch(self, path, mask):
+        path = ctypes.create_string_buffer(path.encode(sys.getfilesystemencoding()))
+        wd = self._libc.inotify_add_watch(self.fd, path, mask)
+        if wd < 0:
+            sys.stderr.write("can't add watch for %s: %s\n" % (path, os.strerror(self._get_errno_func())))
+        return wd
+
+    def rem_watch(self, wd):
+        if self._libc.inotify_rm_watch(self.fd, wd) < 0:
+            sys.stderr.write("can't remove watch: %s\n" % (os.strerror(self._get_errno_func())))
+
+    def process(self, callback):
+        buf = os.read(self.fd, 4096)
+        pos = 0
+        while pos < len(buf):
+            (wd, mask, cookie, name_len) = struct.unpack('iIII', buf[pos:pos+16])
+            pos += 16
+            (name,) = struct.unpack('%ds' % name_len, buf[pos:pos + name_len])
+            pos += name_len
+            callback(wd, mask, name.decode().rstrip('\0'))
+
+    def run(self, callback):
+        while True:
+            self.process(callback)

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -25,6 +25,10 @@
 
     var utils = require('./utils');
 
+    var python = require("python.jsx");
+    var inotify_py = require("raw!inotify.py");
+    var nfs_mounts_py = require("raw!./nfs-mounts.py");
+
     /* STORAGED CLIENT
      */
 
@@ -409,6 +413,113 @@
     client.older_than = function older_than(version) {
         return utils.compare_versions(this.manager.Version, version) < 0;
     };
+
+    /* NFS mounts
+     */
+
+    function nfs_mounts() {
+        var self = {
+            entries: [ ],
+            fsys_sizes: { },
+
+            get_fsys_size: get_fsys_size,
+            entry_users: entry_users,
+
+            update_entry: update_entry,
+            add_entry: add_entry,
+            remove_entry: remove_entry,
+
+            mount_entry: mount_entry,
+            unmount_entry: unmount_entry,
+            stop_and_unmount_entry: stop_and_unmount_entry,
+            stop_and_remove_entry: stop_and_remove_entry
+        };
+
+        function spawn_nfs_mounts(args) {
+            return python.spawn([ inotify_py, nfs_mounts_py ], args, { superuser: "try", err: "message" });
+        }
+
+        var buf = "";
+        spawn_nfs_mounts([ "monitor" ])
+            .stream(function (output) {
+                var lines;
+
+                buf += output;
+                lines = buf.split("\n");
+                buf = lines[lines.length-1];
+                if (lines.length >= 2) {
+                    self.entries = JSON.parse(lines[lines.length-2]);
+                    self.fsys_sizes = { };
+                    $(self).triggerHandler('changed');
+                }
+            }).
+            fail(function (error) {
+                if (error != "closed") {
+                    console.warn(error);
+                }
+            });
+
+        function get_fsys_size(entry) {
+            var path = entry.fields[1];
+            if (self.fsys_sizes[path])
+                return self.fsys_sizes[path];
+
+            if (self.fsys_sizes[path] === false)
+                return null;
+
+            self.fsys_sizes[path] = false;
+            cockpit.spawn([ "stat", "-f", "-c", "[ %S, %f, %b ]", path ], { err: "message" })
+                .done(function (output) {
+                    var data = JSON.parse(output);
+                    self.fsys_sizes[path] = [ data[1]*data[0], data[2]*data[0] ];
+                    $(self).triggerHandler('changed');
+                })
+                .fail(function () {
+                    self.fsys_sizes[path] = [ 0, 0 ];
+                    $(self).triggerHandler('changed');
+                });
+
+            return null;
+        }
+
+        function update_entry(entry, new_fields) {
+            return spawn_nfs_mounts([ "update", JSON.stringify(entry), JSON.stringify(new_fields) ]);
+        }
+
+        function add_entry(fields) {
+            return spawn_nfs_mounts([ "add", JSON.stringify(fields) ]);
+        }
+
+        function remove_entry(entry) {
+            return spawn_nfs_mounts([ "remove", JSON.stringify(entry) ]);
+        }
+
+        function mount_entry(entry) {
+            return spawn_nfs_mounts([ "mount", JSON.stringify(entry) ]);
+        }
+
+        function unmount_entry(entry) {
+            return spawn_nfs_mounts([ "unmount", JSON.stringify(entry) ]);
+        }
+
+        function stop_and_unmount_entry(users, entry) {
+            var units = users.map(function (u) { return u.unit; });
+            return spawn_nfs_mounts([ "stop-and-unmount", JSON.stringify(units), JSON.stringify(entry) ]);
+        }
+
+        function stop_and_remove_entry(users, entry) {
+            var units = users.map(function (u) { return u.unit; });
+            return spawn_nfs_mounts([ "stop-and-remove", JSON.stringify(units), JSON.stringify(entry) ]);
+        }
+
+        function entry_users(entry) {
+            return spawn_nfs_mounts([ "users", JSON.stringify(entry) ]).then(JSON.parse);
+        }
+
+        return self;
+    }
+
+    client.nfs = nfs_mounts();
 
     function init_manager() {
         /* Storaged 2.6 and later uses the UDisks2 API names, but try the

--- a/pkg/storaged/dialog.js
+++ b/pkg/storaged/dialog.js
@@ -25,6 +25,7 @@
 
     var mustache = require("mustache");
     require("patterns");
+    require("cockpit-components-file-autocomplete.css");
 
     var _ = cockpit.gettext;
 
@@ -252,11 +253,71 @@
             input.toggle(event.target.checked);
         });
 
+        /* ComboBoxes
+         */
+
+        $dialog.on("click", ".combobox-container .caret", function(ev) {
+            $(this).parents(".input-group").toggleClass("open");
+        });
+
+        $dialog.on("click", ".combobox-container li a", function(ev) {
+            $(this).parents(".input-group").find("input").val($(this).text()).trigger("change");
+            $(this).parents(".input-group").removeClass("open");
+        });
+
+        function combobox_set_choices(name, choices) {
+            if (typeof choices == 'function') {
+                $.when(choices(get_field_values())).then(function (result) {
+                    if (result !== false)
+                        combobox_set_choices(name, result);
+                });
+                return;
+            }
+
+            var $f = $dialog.find('[data-field="' + name + '"]');
+            var $ul = $f.find('ul');
+            $ul.empty().append(choices.map(function (c) {
+                return $('<li>').append($('<a>').text(c));
+            }));
+            $f.find(".caret").toggle(choices.length > 0);
+        }
+
+        var combobox_some_dynamic = false;
+
+        $dialog.find(".combobox-container .caret").hide();
+        def.Fields.forEach(function (f) {
+            if (f.ComboBox) {
+                if (typeof f.Choices == 'function')
+                    combobox_some_dynamic = true;
+                combobox_set_choices(f.ComboBox, f.Choices);
+            }
+        });
+
+        var combobox_timeout;
+
+        function combobox_reset_dynamic_choices() {
+            if (!combobox_some_dynamic)
+                return;
+
+            if (combobox_timeout)
+                window.clearTimeout(combobox_timeout);
+            combobox_timeout = window.setTimeout(function () {
+                def.Fields.forEach(function (f) {
+                    if (f.ComboBox && typeof f.Choices == 'function') {
+                        combobox_set_choices(f.ComboBox, f.Choices);
+                    }
+                });
+            }, 500);
+        }
+
+        /* Main
+         */
+
         var invisible = { };
 
         function get_name(f) {
             return (f.TextInput || f.PassInput || f.SelectOne || f.SelectMany || f.SizeInput ||
-                    f.SizeSlider || f.CheckBox || f.Arrow || f.SelectRow || f.CheckBoxText);
+                    f.SizeSlider || f.CheckBox || f.Arrow || f.SelectRow || f.CheckBoxText || f.ComboBox);
         }
 
         function get_field_values() {
@@ -288,6 +349,8 @@
                         if ($(e).hasClass('highlight-ct'))
                             vals[n] = f.Rows[i].value;
                     });
+                } else if (f.ComboBox) {
+                    vals[n] = $f.find('input[type=text]').val();
                 } else if (f.Arrow) {
                     vals[n] = !$f.hasClass('collapsed');
                 } else if (f.CheckBoxText) {
@@ -372,6 +435,7 @@
 
         $dialog.on('change input', function (event) {
             update_visibility();
+            combobox_reset_dynamic_choices();
             var trigger = $(event.target).attr("data-field");
             if (trigger)
                 update_fields(trigger);
@@ -386,6 +450,16 @@
                 return err;
         }
 
+        function close() {
+            if (combobox_timeout)
+                window.clearTimeout(combobox_timeout);
+            $dialog.modal('hide');
+        }
+
+        $dialog.find('button[data-action="cancel"]').on('click', function () {
+            close();
+        });
+
         $dialog.find('button[data-action="apply"]').on('click', function () {
             var vals = get_validated_field_values();
             if (vals !== null) {
@@ -394,7 +468,7 @@
                     $dialog.dialog('wait', promise);
                     promise
                         .done(function (result) {
-                            $dialog.modal('hide');
+                            close();
                         })
                         .fail(function (err) {
                             if (def.Action.failure_filter)
@@ -408,7 +482,7 @@
                             }
                         });
                 } else {
-                    $dialog.modal('hide');
+                    close();
                 }
             }
         });

--- a/pkg/storaged/dialog.js
+++ b/pkg/storaged/dialog.js
@@ -61,6 +61,9 @@
                 f.Checked = (f.Value !== false);
         });
 
+        if (def.Action && def.Action.Danger)
+            def.Action.DangerButton = true;
+
         function empty(obj) { return !obj || obj.length === 0; }
 
         def.HasBody = !empty(def.Fields) || !empty(def.Alerts) || !empty(def.Blocking);

--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -271,6 +271,109 @@
     </div>
   </script>
 
+  <script id="nfs-mounts-tmpl" type="x-template/mustache">
+    <div class="panel panel-default storage-mounts">
+      <div class="panel-heading">
+        <span class="pull-right">
+          {{#HasMounts}}
+          <button class="btn btn-default fa fa-check nfs-arm-button {{#armed}}active{{/armed}}"></button>
+          {{/HasMounts}}
+          <button class="btn btn-primary fa fa-plus" data-action="mount-add" ></button>
+        </span>
+        <span translatable="yes">NFS Mounts</span>
+      </div>
+      {{#HasMounts}}
+      <table class="table">
+        <thead>
+          <tr>
+            <th class="mount-name" translatable="yes">Server</th>
+            <th class="mount-point" translatable="yes">Mount Point</th>
+            {{#armed}}
+            <th class="mount-actions">&nbsp;</th>
+            {{/armed}}
+            {{^armed}}
+            <th class="mount-size-graph" translatable="yes">Size</th>
+            <th class="mount-size-number">&nbsp;</th>
+            {{/armed}}
+          </tr>
+        </thead>
+        <tbody>
+          {{#Mounts}}
+          <tr>
+            <td>
+              {{Server}} {{RemoteDir}}
+            </td>
+            <td>
+              {{MountPoint}}
+            </td>
+            {{#armed}}
+            <td class="text-right">
+              {{#IsMounted}}
+              <button translatable="yes" class="btn btn-default"
+                      data-action="mount-unmount" data-arg="{{action_arg}}">Unmount</button>
+              {{/IsMounted}}
+              {{^IsMounted}}
+              <button translatable="yes" class="btn btn-default"
+                      data-action="mount-mount" data-arg="{{action_arg}}">Mount</button>
+              {{/IsMounted}}
+              {{#CanEdit}}
+              <button class="btn btn-default pficon pficon-edit"
+                      data-action="mount-edit" data-arg="{{action_arg}}"></button>
+              <button class="btn btn-danger pficon pficon-delete"
+                      data-action="mount-remove" data-arg="{{action_arg}}"></button>
+              {{/CanEdit}}
+            </td>
+            {{/armed}}
+            {{^armed}}
+            {{#IsMounted}}
+            <td>
+              <div class="progress">
+                <div class="progress-bar {{#UsageCritical}}progress-bar-danger{{/UsageCritical}}"
+                     data-width="{{UsagePercent}}%">
+                </div>
+              </div>
+            </td>
+            <td class="usage-text">
+              {{UsageText}}
+            </td>
+            {{/IsMounted}}
+            {{^IsMounted}}
+            <td>
+              Not mounted
+            </td>
+            <td>
+            </td>
+            {{/IsMounted}}
+            {{/armed}}
+          </tr>
+          {{/Mounts}}
+        </tbody>
+      </table>
+      {{/HasMounts}}
+      {{^HasMounts}}
+      <div translatable="yes" class="empty-panel-text">No NFS mounts set up</div>
+      {{/HasMounts}}
+    </div>
+  </script>
+
+  <script id="nfs-users-tmpl" type="x-template/mustache">
+    <div>
+      <p>{{Description}}</p>
+      <div class="nfs-users-table">
+        <table>
+          <tbody>
+            {{#Users}}
+            <tr>
+              <td>{{unit}}</td>
+              <td>{{desc}}</td>
+            </tr>
+            {{/Users}}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </script>
+
   <script id="jobs-tmpl" type="x-template/mustache">
     {{#HasJobs}}
     <div class="panel panel-default">
@@ -335,6 +438,7 @@
       </div>
       <br/>
       <div id="mounts"></div>
+      <div id="nfs-mounts"></div>
       <div id="jobs"></div>
       <div class="panel panel-default cockpit-log-panel">
         <div class="panel-heading" translatable="yes">Storage Logs</div>
@@ -410,13 +514,14 @@
             </table>
             {{/HasMDRaidMembers}}
             {{/Blocking}}
+            {{{Body}}}
             <table class="form-table-ct">
               {{#Fields}}
               <tr>
                 {{#TextInput}}
                 <td class="top">{{Title}}</td>
                 <td>
-                  <input class="form-control" type="text" {{#Value}}value="{{.}}"{{/Value}} data-field={{.}}>
+                  <input class="form-control" {{#disabled}}disabled{{/disabled}} type="text" {{#Value}}value="{{.}}"{{/Value}} data-field={{.}}>
                 </td>
                 {{/TextInput}}
                 {{#PassInput}}
@@ -555,7 +660,7 @@
                 <td>
                   <div data-field={{.}} class="combobox-container">
                     <div class="input-group">
-                      <input autocomplete="false" class="combobox form-control" type="text" value={{Value}} />
+                      <input autocomplete="false" class="combobox form-control" type="text" {{#disabled}}disabled{{/disabled}} value={{Value}} />
                       <span class="form-control-feedback caret"></span>
                       <ul class="typeahead typeahead-long dropdown-menu">
                       </ul>
@@ -606,13 +711,22 @@
                 {{/MDRaidMembers}}
               </table>
               {{/HasMDRaidMembers}}
+              {{#HasUnits}}
+              <p translate>The filesystem is in use by system services or login sessions.<br>
+                Proceeding will stop these services and sessions.</p>
+              <table class="table table-bordered">
+                {{#Units}}
+                <tr><td><span class="pull-right">{{Name}}</span>{{Unit}}</td></tr>
+                {{/Units}}
+              </table>
+              {{/HasUnits}}
             </div>
             {{/Teardown}}
             {{#Action}}
             {{#Danger}}<div class="modal-footer-danger">{{.}}</div>{{/Danger}}
             <div class="spinner spinner-sm pull-left" hidden></div>
             <button class="btn btn-default" translatable="yes" data-action="cancel">Cancel</button>
-            <button class="btn {{#Danger}}btn-danger{{/Danger}}{{^Danger}}btn-primary{{/Danger}}"
+            <button class="btn {{#DangerButton}}btn-danger{{/DangerButton}}{{^DangerButton}}btn-primary{{/DangerButton}}"
                     data-action="apply">{{Title}}</button>
             {{/Action}}
             {{^Action}}

--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -550,6 +550,19 @@
                   </table>
                 </td>
                 {{/SelectRow}}
+                {{#ComboBox}}
+                <td class="top">{{Title}}</td>
+                <td>
+                  <div data-field={{.}} class="combobox-container">
+                    <div class="input-group">
+                      <input autocomplete="false" class="combobox form-control" type="text" value={{Value}} />
+                      <span class="form-control-feedback caret"></span>
+                      <ul class="typeahead typeahead-long dropdown-menu">
+                      </ul>
+                    </div>
+                  </div>
+                </td>
+                {{/ComboBox}}
                 {{#Arrow}}
                 <td colspan="2">
                   <div data-field={{.}} class="dialog-arrow {{^Value}}collapsed{{/Value}}">
@@ -598,12 +611,12 @@
             {{#Action}}
             {{#Danger}}<div class="modal-footer-danger">{{.}}</div>{{/Danger}}
             <div class="spinner spinner-sm pull-left" hidden></div>
-            <button class="btn btn-default" translatable="yes" data-dismiss="modal">Cancel</button>
+            <button class="btn btn-default" translatable="yes" data-action="cancel">Cancel</button>
             <button class="btn {{#Danger}}btn-danger{{/Danger}}{{^Danger}}btn-primary{{/Danger}}"
                     data-action="apply">{{Title}}</button>
             {{/Action}}
             {{^Action}}
-            <button class="btn btn-default" translatable="yes" data-dismiss="modal">Close</button>
+            <button class="btn btn-default" translatable="yes" data-action="cancel">Close</button>
             {{/Action}}
           </div>
         </div>

--- a/pkg/storaged/nfs-mounts.py
+++ b/pkg/storaged/nfs-mounts.py
@@ -1,0 +1,303 @@
+#! /usr/bin/python
+
+# nfs-mounts   --  Monitor and manage NFS mounts
+#
+# This is similar to how UDisks2 monitors and manages block device
+# mounts, but for NFS.  This might be moved into UDisks2, or not.
+
+# We monitor all NFS remotes listed in /etc/fstab and in /proc/self/mounts.
+# If a entry from mtab is also found in fstab, we report only the
+# fstab entry and mark it is "mounted".
+
+import select
+import re
+import sys
+import json
+import errno
+
+class Watcher:
+    def __init__(self, path):
+        self.inotify = Inotify()
+        self.path = path
+        self.setup()
+
+    def setup(self):
+        self.wd = self.inotify.add_watch(self.path, IN_CLOSE_WRITE)
+
+    def process(self, callback = None):
+        def event(wd, mask, name):
+            if callback:
+                callback()
+            if mask & IN_IGNORED:
+                self.setup()
+        self.inotify.process(event)
+
+def field_escape(str):
+    return str.replace("\\", "\\134").replace(" ", "\\040").replace("\t", "\\011")
+
+def field_unescape(str):
+    return re.sub("\\\\([0-7]{1,3})", lambda m: chr(int(m.group(1), 8)), str)
+
+def parse_tab(name):
+    entries = [ ]
+    for line in open(name, "r").read().split("\n"):
+        sline = line.strip()
+        if sline == "" or sline[0] == "#":
+            continue
+        fields = list(map(field_unescape, re.split("[ \t]+", sline)))
+        if len(fields) > 0 and ":" in fields[0]:
+            entries.append(fields)
+    return entries
+
+def index_tab(tab):
+    by_remote = { }
+    for t in tab:
+        if not t[0] in by_remote:
+            by_remote[t[0]] = [ ]
+        by_remote[t[0]].append(t)
+    return by_remote
+
+def modify_tab(name, modify):
+    lines = open(name, "r").read().split("\n")
+    if len(lines) > 0 and lines[len(lines)-1] == "":
+        del lines[len(lines)-1]
+
+    new_lines = [ ]
+    for line in lines:
+        sline = line.strip()
+        if sline == "" or sline[0] == "#":
+            new_lines.append(line)
+        else:
+            fields = list(map(field_unescape, re.split("[ \t]+", sline)))
+            if len(fields) > 0 and ":" in fields[0]:
+                new_fields = modify(fields)
+                if new_fields:
+                    if new_fields == fields:
+                        new_lines.append(line)
+                    else:
+                        new_lines.append(" ".join(map(field_escape, new_fields)))
+            else:
+                new_lines.append(line)
+    new_fields = modify(None)
+    if new_fields:
+        new_lines.append(" ".join(map(field_escape, new_fields)))
+
+    f = open(name + ".tmp", "w")
+    f.write("\n".join(new_lines) + "\n")
+    f.flush()
+    os.fsync(f.fileno())
+    f.close()
+    os.rename(name + ".tmp", name)
+
+fstab = [ ]
+fstab_by_remote = { }
+
+mtab = [ ]
+mtab_by_remote = { }
+
+def process_fstab():
+    global fstab, fstab_by_remote
+    fstab = parse_tab("/etc/fstab")
+    fstab_by_remote = index_tab(fstab)
+
+def process_mtab():
+    global mtab, mtab_by_remote
+    mtab = parse_tab("/proc/self/mounts")
+    mtab_by_remote = index_tab(mtab)
+
+def find_in_tab(tab_by_remote, fields):
+    for t in tab_by_remote.get(fields[0], [ ]):
+        if t[0] == fields[0] and t[1] == fields[1]:
+            return t
+    return None
+
+def report():
+    data = [ ]
+    for f in fstab:
+        m = find_in_tab(mtab_by_remote, f)
+        data.append({ "fstab": True, "fields": f, "mounted": m is not None })
+    for m in mtab:
+        if not find_in_tab(fstab_by_remote, m):
+            data.append({ "fstab": False, "fields": m, "mounted": True })
+    sys.stdout.write(json.dumps(data) + "\n")
+    sys.stdout.flush()
+
+def monitor():
+    process_mtab()
+    process_fstab()
+    report()
+    fstab_watcher = Watcher("/etc/fstab")
+    mtab_file = open("/proc/self/mounts", "r")
+    while True:
+        (r, w, x) = select.select([ fstab_watcher.inotify.fd ], [ ], [ mtab_file ])
+        if mtab_file in x:
+            process_mtab()
+            report()
+        if fstab_watcher.inotify.fd in r:
+            fstab_watcher.process()
+            process_fstab()
+            report()
+
+def mkdir_if_necessary(path):
+    if not os.path.exists(path):
+        os.makedirs(path)
+
+def rmdir_if_empty(path):
+    try:
+        os.rmdir(path)
+    except OSError as e:
+        if e.errno not in [ errno.ENOTEMPTY, errno.ENOTDIR, errno.ENOENT ]:
+            raise
+
+def update(entry, new_fields):
+    old_fields = entry["fields"]
+    if old_fields[1] != new_fields[1]:
+        mkdir_if_necessary(new_fields[1])
+    if entry["mounted"]:
+        if (new_fields[0] == old_fields[0]
+            and new_fields[1] == old_fields[1]
+            and new_fields[2] == old_fields[2]):
+            remount(new_fields)
+        else:
+            try:
+                unmount(entry)
+                if old_fields[1] != new_fields[1]:
+                    rmdir_if_empty(old_fields[1])
+            except subprocess.CalledProcessError:
+                pass
+            mount({ "fields": new_fields })
+    else:
+        if old_fields[1] != new_fields[1]:
+            rmdir_if_empty(old_fields[1])
+    modify_tab("/etc/fstab", lambda fields: new_fields if fields == old_fields else fields)
+
+def add(new_fields):
+    mkdir_if_necessary(new_fields[1])
+    mount({ "fields": new_fields })
+    modify_tab("/etc/fstab", lambda fields: new_fields if fields is None else fields)
+
+def remove(entry):
+    old_fields = entry["fields"]
+    if entry["mounted"]:
+        unmount(entry)
+    rmdir_if_empty(old_fields[1])
+    modify_tab("/etc/fstab", lambda fields: None if fields == old_fields else fields)
+
+def mount(entry):
+    fields = entry["fields"]
+    mkdir_if_necessary(fields[1])
+    subprocess.check_call([ "mount",
+                            "-t", fields[2],
+                            "-o", fields[3],
+                            fields[0],
+                            fields[1] ])
+
+def remount(fields):
+    subprocess.check_call([ "mount",
+                            "-o", "remount," + fields[3],
+                            fields[0],
+                            fields[1] ])
+
+def unmount(entry):
+    subprocess.check_call([ "umount", entry["fields"][1] ])
+
+def fuser(entry):
+
+    import dbus
+    bus = dbus.SystemBus()
+    systemd_manager = dbus.Interface(bus.get_object('org.freedesktop.systemd1', '/org/freedesktop/systemd1'),
+                                     dbus_interface='org.freedesktop.systemd1.Manager')
+
+    if not entry["mounted"]:
+        return [ ]
+
+    mount_point = entry["fields"][1]
+    results = { }
+
+    def check(path, pid):
+        t = os.readlink(path)
+        if t == mount_point or t.startswith(mount_point + "/"):
+            unit = systemd_manager.GetUnitByPID(int(pid))
+            if unit not in results:
+                unit_obj = bus.get_object('org.freedesktop.systemd1', unit)
+                desc = unit_obj.Get("org.freedesktop.systemd1.Unit", "Description",
+                                    dbus_interface="org.freedesktop.DBus.Properties")
+                id = unit_obj.Get("org.freedesktop.systemd1.Unit", "Id",
+                                  dbus_interface="org.freedesktop.DBus.Properties")
+                results[unit] = { "unit": id, "desc": desc }
+            return True
+        return False
+
+    def checkdir(path, pid):
+        for f in os.listdir(path):
+            if check(os.path.join(path, f), pid):
+                return True
+        return False
+
+    my_pid = os.getpid()
+
+    for p in os.listdir("/proc/"):
+        if not p.isdigit():
+            continue
+        if int(p) == my_pid:
+            continue
+        proc = "/proc/%s/" % p
+        try:
+            if check(proc + "exe", p): continue
+            if check(proc + "root", p): continue
+            if check(proc + "cwd", p): continue
+            if checkdir(proc + "fd", p): continue
+            if checkdir(proc + "map_files", p): continue
+        except OSError:
+            pass
+
+    return list(results.values())
+
+def users(entry):
+    data = fuser(entry)
+    sys.stdout.write(json.dumps(data) + "\n")
+    sys.stdout.flush()
+
+def stop_units(units):
+    import dbus
+    bus = dbus.SystemBus()
+    systemd_manager = dbus.Interface(bus.get_object('org.freedesktop.systemd1', '/org/freedesktop/systemd1'),
+                                     dbus_interface='org.freedesktop.systemd1.Manager')
+    for u in units:
+        systemd_manager.StopUnit(u, 'replace')
+
+def stop_and_unmount(units, entry):
+    stop_units(units)
+    unmount(entry)
+
+def stop_and_remove(units, entry):
+    stop_units(units)
+    remove(entry)
+
+def dispatch(argv):
+    if argv[1] == "monitor":
+        monitor()
+    elif argv[1] == "update":
+        update(json.loads(argv[2]), json.loads(argv[3]))
+    elif argv[1] == "add":
+        add(json.loads(argv[2]))
+    elif argv[1] == "remove":
+        remove(json.loads(argv[2]))
+    elif argv[1] == "mount":
+        mount(json.loads(argv[2]))
+    elif argv[1] == "unmount":
+        unmount(json.loads(argv[2]))
+    elif argv[1] == "stop-and-unmount":
+        stop_and_unmount(json.loads(argv[2]), json.loads(argv[3]))
+    elif argv[1] == "stop-and-remove":
+        stop_and_remove(json.loads(argv[2]), json.loads(argv[3]))
+    elif argv[1] == "users":
+        users(json.loads(argv[2]))
+
+try:
+    dispatch(sys.argv)
+except subprocess.CalledProcessError as e:
+    sys.exit(e.returncode)
+except Exception as e:
+    sys.stderr.write(str(e) + "\n")
+    sys.exit(1)

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -39,7 +39,7 @@
     text-overflow: ellipsis;
 }
 
-@media (min-width: 992px) {
+@media (max-width: 1200px) {
     .storage-mounts .mount-name {
         width: 25%;
     }
@@ -51,6 +51,9 @@
     }
     .storage-mounts .mount-size-number {
         width: 25%;
+    }
+    .storage-mounts .mount-actions {
+        width: 50%;
     }
 }
 
@@ -67,6 +70,13 @@
     .storage-mounts .mount-size-number {
         width: 15%;
     }
+    .storage-mounts .mount-actions {
+        width: 60%;
+    }
+}
+
+#nfs-mounts tr {
+    height: 42px;
 }
 
 @media (max-width: 1814px) {
@@ -563,6 +573,20 @@ a.disabled {
 
 td.storage-action {
     overflow: visible !important;
+}
+
+.nfs-users-table {
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.nfs-users-table table {
+    width: 100%;
+}
+
+.nfs-users-table td:nth-child(2) {
+    padding-left: 0.75em;
+    width: 80%;
 }
 
 /* Layout fix for tooltip arrows.

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -582,3 +582,7 @@ td.storage-action {
 .tooltip.bottom .tooltip-arrow {
     top: 1px;
 }
+
+.form-table-ct .combobox-container .input-group {
+    width: 100%;
+}

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -1,0 +1,169 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import parent
+from testlib import *
+from storagelib import *
+
+@skipImage("NetworkManager and NFS don't work together", "ubuntu-1604")
+class TestStorage(StorageCase):
+    def testNfsClient(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+        b.wait_in_text("#drives", "VirtIO")
+
+        m.execute("mkdir /home/foo /home/bar")
+        m.write("/etc/exports", "/home/foo 127.0.0.0/24(rw)\n/home/bar 127.0.0.0/24(rw)\n")
+        m.execute("systemctl restart nfs-server")
+
+        # Nothing there in the beginnging
+        b.wait_visible("#nfs-mounts .empty-panel-text")
+
+        # Add /home/foo
+        b.click("#nfs-mounts button[data-action=mount-add]")
+        self.dialog_wait_open()
+        self.dialog_set_val("server", "127.0.0.1")
+        self.dialog_set_combobox("remote", "/home/foo")
+        self.dialog_set_val("dir", "/mnt")
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        b.wait_present("#nfs-mounts td:contains(/home/foo)")
+        b.wait_present("#nfs-mounts td:contains(/mnt)")
+        b.wait_present("#nfs-mounts tr:contains(/mnt) .usage-text")
+        b.wait_text_not("#nfs-mounts tr:contains(/mnt) .usage-text", "")
+
+        # Add /home/bar
+        b.click("#nfs-mounts button[data-action=mount-add]")
+        self.dialog_wait_open()
+        self.dialog_set_val("server", "127.0.0.1")
+        self.dialog_set_combobox("remote", "/home/bar")
+        self.dialog_set_val("dir", "/mounts/bar")
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        b.wait_present("#nfs-mounts td:contains(/home/bar)")
+        b.wait_present("#nfs-mounts td:contains(/mounts/bar)")
+        b.wait_present("#nfs-mounts tr:contains(/mounts/bar) .usage-text")
+        b.wait_text_not("#nfs-mounts tr:contains(/mounts/bar) .usage-text", "")
+        m.execute("test -d /mounts/bar")
+
+        # Change mount point of /home/bar
+        b.click("#nfs-mounts .nfs-arm-button")
+        b.click("#nfs-mounts button[data-action=mount-edit][data-arg=1]")
+
+        self.dialog_wait_open()
+        self.dialog_set_val("dir", "/mounts/barbar")
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        b.wait_present("#nfs-mounts td:contains(/mounts/barbar)")
+        m.execute("! test -e /mounts/bar")
+        m.execute("test -d /mounts/barbar")
+
+        # Unmount and remount /home/foo
+        b.click("#nfs-mounts .nfs-arm-button")
+        b.click("#nfs-mounts button[data-action=mount-unmount][data-arg=0]")
+        b.wait_in_text("#nfs-mounts tr:contains(/home/foo)", "Not mounted")
+
+        b.click("#nfs-mounts .nfs-arm-button")
+        b.click("#nfs-mounts button[data-action=mount-mount][data-arg=0]")
+        b.wait_present("#nfs-mounts tr:contains(/mnt) .usage-text")
+        b.wait_text_not("#nfs-mounts tr:contains(/mnt) .usage-text", "")
+
+        # Remove /home/foo
+        b.click("#nfs-mounts .nfs-arm-button")
+        b.click("#nfs-mounts button[data-action=mount-remove][data-arg=0]")
+        b.wait_not_present("#nfs-mounts td:contains(/home/foo)")
+        m.execute("! test -e /mnt")
+
+    def testNfsListExports(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+        b.wait_in_text("#drives", "VirtIO")
+
+        m.execute("mkdir /home/foo /home/bar")
+        m.write("/etc/exports", "/home/foo 127.0.0.0/24(rw)\n/home/bar 127.0.0.0/24(rw)\n")
+        m.execute("systemctl restart nfs-server")
+
+        b.click("#nfs-mounts button[data-action=mount-add]")
+        self.dialog_wait_open()
+        self.dialog_set_val("server", "127.0.0.1")
+
+        def wait_for_exports():
+            def check():
+                choices = self.dialog_combobox_choices("remote")
+                return len(choices) == 2 and "/home/foo" in choices and "/home/bar" in choices
+            self.retry(None, check, None)
+
+        wait_for_exports()
+
+    def testNfsBusy(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+        b.wait_in_text("#drives", "VirtIO")
+
+        m.execute("mkdir /home/foo /home/bar")
+        m.write("/etc/exports", "/home/foo 127.0.0.0/24(rw)\n/home/bar 127.0.0.0/24(rw)\n")
+        m.execute("systemctl restart nfs-server")
+
+        # Nothing there in the beginnging
+        b.wait_visible("#nfs-mounts .empty-panel-text")
+
+        # Add /home/foo
+        b.click("#nfs-mounts button[data-action=mount-add]")
+        self.dialog_wait_open()
+        self.dialog_set_val("server", "127.0.0.1")
+        self.dialog_set_combobox("remote", "/home/foo")
+        self.dialog_set_val("dir", "/mounts/foo")
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        b.wait_present("#nfs-mounts td:contains(/home/foo)")
+        b.wait_present("#nfs-mounts td:contains(/mounts/foo)")
+        b.wait_present("#nfs-mounts tr:contains(/mounts/foo) .usage-text")
+        b.wait_text_not("#nfs-mounts tr:contains(/mounts/foo) .usage-text", "")
+
+        m.spawn("cd /mounts/foo; sleep infinity", "busy")
+        b.click("#nfs-mounts .nfs-arm-button")
+        b.click("#nfs-mounts button[data-action=mount-edit][data-arg=0]")
+
+        self.dialog_wait_open()
+        self.dialog_wait_alert("This NFS mount is in use")
+        self.dialog_cancel()
+        self.dialog_wait_close()
+
+        b.click("#nfs-mounts .nfs-arm-button")
+        b.click("#nfs-mounts button[data-action=mount-unmount][data-arg=0]")
+        self.dialog_wait_open()
+        b.wait_in_text("#dialog", "The filesystem is in use")
+        b.wait_in_text("#dialog", "of user root")
+        self.dialog_apply()
+
+        b.wait_in_text("#nfs-mounts tr:contains(/home/foo)", "Not mounted")
+
+if __name__ == '__main__':
+    test_main()

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -218,6 +218,10 @@ class StorageCase(MachineCase):
     def dialog_set_combobox(self, field, val):
         self.browser.set_val(self.dialog_field(field) + " input[type=text]", val)
 
+    def dialog_combobox_choices(self, field):
+        return self.browser.call_js_func("(function (sel) { return $(sel).find('li').get().map(function (elt) { return $(elt).text(); }) })",
+                                         self.dialog_field(field))
+
     def dialog_is_present(self, field, label):
         return self.browser.is_present('%s .checkbox:contains("%s") input' % (self.dialog_field(field), label))
 

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -215,6 +215,9 @@ class StorageCase(MachineCase):
                  }
             })""", self.dialog_field(field), val)
 
+    def dialog_set_combobox(self, field, val):
+        self.browser.set_val(self.dialog_field(field) + " input[type=text]", val)
+
     def dialog_is_present(self, field, label):
         return self.browser.is_present('%s .checkbox:contains("%s") input' % (self.dialog_field(field), label))
 
@@ -241,7 +244,7 @@ class StorageCase(MachineCase):
         self.browser.click('#dialog [data-action="apply"]')
 
     def dialog_cancel(self):
-        self.browser.click('#dialog [data-dismiss="modal"]')
+        self.browser.click('#dialog [data-action="cancel"]')
 
     def dialog_wait_close(self):
         self.browser.wait_not_present('#dialog')

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -446,6 +446,13 @@ Recommends: device-mapper-multipath
 %endif
 %endif
 %endif
+%if 0%{?fedora}
+Requires: python3
+Requires: python3-dbus
+%else
+Requires: python
+Requires: python-dbus
+%endif
 BuildArch: noarch
 
 %description storaged

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -130,6 +130,8 @@ Depends: ${misc:Depends},
          udisks2,
          udisks2 (<< 2.7) | libblockdev-mdraid2,
          cockpit-bridge (>= ${bridge:minversion}),
+         python3,
+         python3-dbus
 Description: Cockpit user interface for storage
  The Cockpit components for interacting with storage.
 


### PR DESCRIPTION
- [x] Also show mounts not in fstab
- [x] Create and remove mount point directories
- [x] Avoid flicker of arming machinery when list is rendered
- [x] Use showmount to help with/validate remote bits
- [x] Avoid quadratic complexity when preparing mount report
- [x] Show nice text when there are no nfs mounts
- [x] Tests
- [x] Use "mount -o remount" if only options change
- [x] Layout when armed
- [x] Don't let the user change server/remote/dir when mount is busy.
- [x] Refuse to remove busy mounts.
- [x] Reimplement lsof/fuser withing nfs-mounts.py
- [x] Let user kill all systemd units that keep a mount busy
- [x] Use python3 in preference to python2
- [x] Add nfs-server and python3-dbus to Debian/Ubuntu images
- [x] Make video for release notes
- [x] #7852 
- [x] #7812 
- [x] #7827 

Video: https://www.youtube.com/watch?v=PGCBda3Le9Y