### PR TITLE
kubernetes: Improve GCE support

### DIFF
--- a/pkg/kubernetes/standalone/src/cockpit-kube-auth/helpers/client.go
+++ b/pkg/kubernetes/standalone/src/cockpit-kube-auth/helpers/client.go
@@ -178,7 +178,7 @@ func (self *Client) confirmBasicAuth(creds *Credentials) error {
 		// Authorization header that is guarenteed to be invalid.
 		// This should return a 200 if the whole api is open or a 401 if the
 		// api is protected.
-		status, e = self.apiStatus("namespaces", "Basic")
+		status, e = self.apiStatus("namespaces", "Basic Og==")
 
 		// Some versions of kubernetes return 403 instead of 401
 		// when presented with bad basic auth data. In those cases


### PR DESCRIPTION
Make basic auth work with GCE 1.7.x

Allow tokens to be read from auth-provider sections of a user's kubeconfig file.