### PR TITLE
machines: Remove status icons in VMs list

### DIFF
--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -169,8 +169,6 @@ export const StateIcon = ({ state, config, valueId }) => {
         return (
             <span title={stateMap[state].title} data-toggle='tooltip' data-placement='left'>
                 <span id={valueId}>{rephraseUI('vmStates', state)}</span>
-                &nbsp;
-                <i className={stateMap[state].className} />
             </span>);
     }
     return (<small>{state}</small>);


### PR DESCRIPTION
Made simple removing of status icons in machines.
![screenshot from 2017-08-31 16-18-59](https://user-images.githubusercontent.com/3332176/29928194-a25b258e-8e68-11e7-96f2-06bf15d9f41d.png)
