### PR TITLE
ws: Update AppStream metadata to current format

### DIFF
--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -180,7 +180,7 @@ CLEANFILES += \
 	src/ws/cockpit.service \
 	$(NULL)
 
-appdatadir = $(datadir)/appdata
+appdatadir = $(datadir)/metainfo
 nodist_appdata_DATA = src/ws/cockpit.appdata.xml
 appdata_in = src/ws/cockpit.appdata.xml.in
 

--- a/src/ws/cockpit.appdata.xml.in
+++ b/src/ws/cockpit.appdata.xml.in
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Richard Hughes <richard@hughsie.com> -->
-<application>
-  <id type="desktop">cockpit.desktop</id>
+<component type="desktop-application">
+  <id>cockpit.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LGPL-2.0+</project_license>
+  <name>Cockpit</name>
+  <_summary>User interface for Linux servers</_summary>
   <description>
     <_p>
       Cockpit is a server manager that makes it easy to administer your Linux
@@ -26,12 +28,22 @@
     <!-- FIXME: we need some 16:9 screenshots of the latest code; also putting
                 them on http://cockpit-project.org/ would be best to control
                 them in the future -->
-    <screenshot type="default">http://cockpit-project.org/screenshots/cockpit-overview.png</screenshot>
-    <screenshot>http://cockpit-project.org/screenshots/cockpit-services.png</screenshot>
-    <screenshot>http://cockpit-project.org/screenshots/cockpit-journal.png</screenshot>
-    <screenshot>http://cockpit-project.org/screenshots/cockpit-network.png</screenshot>
-    <screenshot>http://cockpit-project.org/screenshots/cockpit-storage.png</screenshot>
+    <screenshot type="default">
+        <image>http://cockpit-project.org/screenshots/cockpit-overview.png</image>
+    </screenshot>
+    <screenshot>
+        <image>http://cockpit-project.org/screenshots/cockpit-services.png</image>
+    </screenshot>
+    <screenshot>
+        <image>http://cockpit-project.org/screenshots/cockpit-journal.png</image>
+    </screenshot>
+    <screenshot>
+        <image>http://cockpit-project.org/screenshots/cockpit-network.png</image>
+    </screenshot>
+    <screenshot>
+        <image>http://cockpit-project.org/screenshots/cockpit-storage.png</image>
+    </screenshot>
   </screenshots>
   <url type="homepage">http://cockpit-project.org/</url>
-  <updatecontact>anilsson_at_redhat.com</updatecontact>
-</application>
+  <update_contact>anilsson_at_redhat.com</update_contact>
+</component>

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -106,7 +106,7 @@ machines.
 %{_docdir}/%{name}/COPYING
 %{_docdir}/%{name}/README.md
 %dir %{_datadir}/%{name}
-%{_datadir}/appdata/cockpit.appdata.xml
+%{_datadir}/metainfo/cockpit.appdata.xml
 %{_datadir}/applications/cockpit.desktop
 %{_datadir}/pixmaps/cockpit.png
 %doc %{_mandir}/man1/cockpit.1.gz

--- a/tools/debian/cockpit.install
+++ b/tools/debian/cockpit.install
@@ -1,4 +1,4 @@
-usr/share/appdata/cockpit.appdata.xml
+usr/share/metainfo/cockpit.appdata.xml
 usr/share/applications/cockpit.desktop
 usr/share/pixmaps/cockpit.png
 usr/share/man/man1/cockpit.1


### PR DESCRIPTION
Adjust XML to current format
<https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html>
and move to /usr/share/metainfo/.