### PR TITLE
bots: Drop dangling network-cockpit.xml symlink

### DIFF
--- a/bots/machine/network-cockpit.xml
+++ b/bots/machine/network-cockpit.xml
@@ -1,1 +1,0 @@
-../../test/common/network-cockpit.xml


### PR DESCRIPTION
This unbreaks testing backbranches, which currently fail with

    fatal: Path 'test/common/network-cockpit.xml' exists on disk, but not in 'origin/master'.