### PR TITLE
tools: Build cockpit-packagekit on ubuntu-1604

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -36,7 +36,6 @@ done
 """
 
 @skipImage("Image uses OSTree", "continuous-atomic", "fedora-atomic", "rhel-atomic")
-@skipImage("PackageKit crashes, https://launchpad.net/bugs/1689820", "ubuntu-1604")
 class TestUpdates(PackageCase):
     def setUp(self):
         PackageCase.setUp(self)
@@ -149,6 +148,7 @@ class TestUpdates(PackageCase):
         # new versions are now installed
         m.execute("test -f /stamp-vanilla-1.0-2 && test -f /stamp-chocolate-2.0-2")
 
+    @skipImage("Ubuntu 16.04 PackageKit does not support changelogs", "ubuntu-1604")
     def testInfoSecurity(self):
         b = self.browser
         m = self.machine
@@ -307,6 +307,7 @@ class TestUpdates(PackageCase):
 
         self.allow_restart_journal_messages()
 
+    @skipImage("Ubuntu 16.04 PackageKit does not support changelogs", "ubuntu-1604")
     def testInfoTruncation(self):
         b = self.browser
         m = self.machine

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -8,12 +8,6 @@ ifneq ($(shell dpkg -s libpcp3-dev >/dev/null 2>&1 && echo yes),yes)
 	CONFIG_OPTIONS = --disable-pcp
 endif
 
-# PackageKit crashes on update information on Ubuntu 16.04, which makes
-# "Software Updates" useless (LP: #1689820)
-ifneq ($(shell grep xenial /etc/os-release),)
-	export DH_OPTIONS += -Ncockpit-packagekit
-endif
-
 %:
 	dh $@ --with=systemd,autoreconf
 


### PR DESCRIPTION
Now that PackageKit stopped crashing in Ubuntu 16.04
(https://launchpad.net/bugs/1689820), enable the package there. However,
that version is not able to read changelogs from apt yet, so still skip
the two corresponding tests.

Fixes #7465