### PR TITLE
bots: Add known issue for SELinux denying NetworkManager to run arping

### DIFF
--- a/bots/naughty/rhel-7/7621-selinux-nm-arping
+++ b/bots/naughty/rhel-7/7621-selinux-nm-arping
@@ -1,0 +1,1 @@
+Error: *audit*avc:  denied  { execute } for * comm="NetworkManager" name="arping"


### PR DESCRIPTION
See issue #7621 aka. https://bugzilla.redhat.com/show_bug.cgi?id=1488831

---

I have mostly seen this on the rhel-7.4 branch in PR #7604 so far, not on master. But I would like to land that in master, as 

 * both the images and the tests are the same
 * this is a race condition (e. g. [this run](https://fedorapeople.org/groups/cockpit/logs/pull-7604-20170906-093838-33595476-verify-rhel-7-4/log.html) happened to evade it), so it's likely to happen on master, too; and
 * on rhel-7.4 we should only backport what's in master.