### PR TITLE
lib: Fix race when changing machine data

### DIFF
--- a/pkg/lib/machines.js
+++ b/pkg/lib/machines.js
@@ -175,23 +175,18 @@
             // wrap values in variants for D-Bus call; at least values.port can
             // be int or string, so stringify everything but the "visible" boolean
             var values_variant = {};
-            for (var prop in values)
+            for (var prop in values) {
                 if (values[prop] !== null) {
                     if (prop == "visible")
                         values_variant[prop] = cockpit.variant('b', values[prop]);
                     else
                         values_variant[prop] = cockpit.variant('s', values[prop].toString());
                 }
+            }
 
             // FIXME: investigate re-using the proxy from Loader (runs in different frame/scope)
             var bridge = cockpit.dbus(null, { bus: "internal", "superuser": "try" });
             var mod = bridge.call("/machines", "cockpit.Machines", "Update", [ "99-webui.json", host, values_variant ])
-                .done(function() {
-                    var prop, over = { };
-                    for (prop in values)
-                        over[prop] = null;
-                    self.overlay(host, over);
-                })
                 .fail(function(error) {
                     console.error("failed to call cockpit.Machines.Update(): ", error);
                 });
@@ -402,9 +397,6 @@
 
         /* Have we loaded from cockpit session */
         var session_loaded = false;
-
-        /* File we are watching */
-        var file;
 
         /* echo channels to each machine */
         var channels = { };
@@ -685,10 +677,6 @@
             $(machines).off("changed", updated);
             $(machines).off("removed", removed);
             machines = null;
-
-            if (file)
-                file.close();
-            file = null;
 
             window.removeEventListener("storage", process_session_machines);
             var hosts = Object.keys(channels);

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -203,29 +203,15 @@ class TestMultiMachineKeyAuth(MachineCase):
         b.click("#troubleshoot-dialog .btn-primary")
         b.wait_popdown('troubleshoot-dialog')
         b.enter_page("/system", host="10.111.113.2")
+        b.switch_to_top()
+
+        # We expect this iframe without the custom user to be active
         b.wait_not_present("iframe.container-frame[name='cockpit1:user@10.111.113.2/system']")
+        b.wait_present("iframe.container-frame[name='cockpit1:10.111.113.2/system']")
 
         # Change user
         authorize_user(m2, "user")
-
-        self.allow_restart_journal_messages()
-        self.allow_hostkey_messages()
-        # Might happen when killing the bridge.
-        self.allow_journal_messages("localhost: dropping message while waiting for child to exit",
-                                    "Received message for unknown channel: .*",
-                                    ".*: error reading from ssh",
-                                    ".*: bridge program failed: Child process exited with code .*",
-                                    # Since there is not password,
-                                    # reauthorize doesn't work on m2
-                                    "received authorize command for wrong user: user",
-                                    ".*: user admin reauthorization failed",
-                                    "Error executing command as another user: Not authorized",
-                                    "This incident has been reported.",
-                                    "sudo: a password is required")
-
-        # We expect this iframe to be active
-        b.switch_to_top()
-        b.wait_present("iframe.container-frame[name='cockpit1:10.111.113.2/system']")
+        m2.execute("rm /home/admin/.ssh/authorized_keys")
 
         b.go("/dashboard")
         b.enter_page("/dashboard")
@@ -249,6 +235,20 @@ class TestMultiMachineKeyAuth(MachineCase):
         b.click("#dashboard-hosts .list-group-item[data-address='10.111.113.2']")
         b.enter_page("/system", host="user@10.111.113.2")
 
+        self.allow_restart_journal_messages()
+        self.allow_hostkey_messages()
+        # Might happen when killing the bridge.
+        self.allow_journal_messages("localhost: dropping message while waiting for child to exit",
+                                    "Received message for unknown channel: .*",
+                                    ".*: error reading from ssh",
+                                    ".*: bridge program failed: Child process exited with code .*",
+                                    # Since there is not password,
+                                    # reauthorize doesn't work on m2
+                                    "received authorize command for wrong user: user",
+                                    ".*: user admin reauthorization failed",
+                                    "Error executing command as another user: Not authorized",
+                                    "This incident has been reported.",
+                                    "sudo: a password is required")
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Previously if the Loader frame dbus property change callback fired before the dbus change callback and before the session storage change callback in Machines frame the changes would get overwritten by the old values. We don't really need to reset overlay values anymore so just remove that part. #