### PR TITLE
doc: Update documentation for closing a spawned process channel

### DIFF
--- a/doc/guide/cockpit-spawn.xml
+++ b/doc/guide/cockpit-spawn.xml
@@ -237,8 +237,9 @@ process.input(data, [stream])
 <programlisting>
 process.close([problem])
 </programlisting>
-    <para>Close the process. If <code>problem</code> is specified it should be a
-      standard <link linkend="cockpit-problems">problem code</link> string. In this case the
+    <para>Close the process by closing its standard input and output. If <code>problem</code> is
+      specified it should be a standard
+      <link linkend="cockpit-problems">problem code</link> string. In this case the
       process will be terminated with a signal.</para>
   </refsection>
 </refentry>

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -793,6 +793,9 @@ If an "done" is sent to the bridge on this channel, then the socket and/or pipe
 input is shutdown. The channel will send an "done" when the output of the socket
 or pipe is done.
 
+If "spawn" is set and the channel is closed with a "problem" code, then the
+process will be sent a SIGTERM signal.
+
 Additionally, a "options" control message may be sent in this channel
 to change the "batch", "latency", and "window" options.
 


### PR DESCRIPTION
Clearly state how the spawned process channel is closed, and in
which cases a terminate signal is sent.

Fixes #7656