### PR TITLE
users: Don't rely on constructor name

### DIFF
--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -92,7 +92,7 @@ function passwd_self(old_pass, new_pass) {
             dfd.resolve();
         })
         .fail(function(ex) {
-            if (ex.constructor.name == "ProcessError")
+            if (ex.exit_status)
                 ex = new Error(failure);
             dfd.reject(ex);
         })
@@ -136,7 +136,7 @@ function passwd_change(user, new_pass) {
             dfd.resolve();
         })
         .fail(function(ex, response) {
-            if (ex.constructor.name == "ProcessError") {
+            if (ex.exit_status) {
                 console.log(ex);
                 if (response)
                     ex = new Error(response);


### PR DESCRIPTION
This changes when minified so we shouldn't rely on it