### PR TITLE
bots: Add naughty for another sssd crash

### DIFF
--- a/bots/naughty/ubuntu-1604/6422-nsupdate-crash-sssd-3
+++ b/bots/naughty/ubuntu-1604/6422-nsupdate-crash-sssd-3
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "./verify/check-realms", line *, in testNegotiate
+    self.configure_kerberos()
+*
+CalledProcessError: Command '<script>' returned non-zero exit status 1

--- a/bots/naughty/ubuntu-stable/6422-nsupdate-crash-sssd-3
+++ b/bots/naughty/ubuntu-stable/6422-nsupdate-crash-sssd-3
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "./verify/check-realms", line *, in testNegotiate
+    self.configure_kerberos()
+*
+CalledProcessError: Command '<script>' returned non-zero exit status 1


### PR DESCRIPTION
Another instance of https://bugzilla.redhat.com/show_bug.cgi?id=1447268

../../../lib/dns/name.c:1002: REQUIRE((((source) != ((void *)0)) && (((const isc__magic_t *)(source))->magic == ((('D') << 24 | ('N') << 16 | ('S') << 8 | ('n')))))) failed, back trace

But this time the error code is 1

https://fedorapeople.org/groups/cockpit/logs/pull-7647-20170914-064242-98099d31-verify-ubuntu-1604/TestKerberos-testNegotiate-ubuntu-1604-127.0.0.2-2901-FAIL.log