### PR TITLE
bots: Remove erroneous exit in release-guide

### DIFF
--- a/bots/release-guide
+++ b/bots/release-guide
@@ -125,7 +125,6 @@ layout: guide\
 
 commit()
 (
-exit 2
     trace "Pushing changes to guide"
     git -C $WORKDIR/repo push origin master
     rm -rf $WORKDIR


### PR DESCRIPTION
The release guide script had a debugging aid which was introduced
during 76cfd05f492e475b11476aab1bc823af50690245. Lets remove it
and actually upload the changes.