### PR TITLE
kubernetes: Fix position of reset button in container terminal

### DIFF
--- a/pkg/kubernetes/styles/containers.less
+++ b/pkg/kubernetes/styles/containers.less
@@ -12,3 +12,8 @@
 .containers-listing .console-ct {
     min-height: 310px;
 }
+
+kubernetes-container-terminal .terminal-actions {
+    position: relative;
+    z-index: auto;
+}


### PR DESCRIPTION
The container terminal CSS needs to be overridden so it appears
in the right place as opposed to the use of the same component
in the Openshift Web Console.