### PR TITLE
ws: Use language prefixed urls for cache busting

### DIFF
--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -606,6 +606,8 @@ cockpit_handler_default (CockpitWebServer *server,
 {
   CockpitWebService *service;
   const gchar *remainder = NULL;
+  gchar *lang = NULL;
+  gchar *lang_path = NULL;
   gboolean resource;
 
   path = cockpit_web_response_get_path (response);
@@ -622,8 +624,21 @@ cockpit_handler_default (CockpitWebServer *server,
   if (resource)
     {
       cockpit_web_response_skip_path (response);
-      remainder = cockpit_web_response_get_path (response);
 
+      lang = cockpit_web_server_parse_cookie (headers, "CockpitLang");
+      if (lang)
+        {
+          lang_path = g_strdup_printf ("/%s/", lang);
+          if (g_str_has_prefix (cockpit_web_response_get_path (response),
+                                lang_path))
+            {
+              cockpit_web_response_skip_path (response);
+            }
+          g_free (lang);
+          g_free (lang_path);
+        }
+
+      remainder = cockpit_web_response_get_path (response);
       if (!remainder)
         {
           cockpit_web_response_error (response, 404, NULL, NULL);

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -177,6 +177,32 @@ WantedBy=default.target
         self.assertEqual(b.text("#angular-context"), "Bereiten")
         self.assertEqual(b.text("#angular-interpolate"), u"'Marmalade' löschen!!!")
 
+        # Back to english
+        b.switch_to_top()
+        b.wait_visible("#navbar-dropdown")
+        b.click("#navbar-dropdown")
+        b.click(".display-language-menu a")
+        b.wait_popup('display-language')
+        b.set_val("#display-language select", "en-us")
+        b.click("#display-language-select-button")
+        b.expect_load()
+        b.wait_present("#content")
+        b.enter_page("/playground/translate")
+        self.assertEqual(b.text("#translate-html"), "Ready")
+
+        # Back to german
+        b.switch_to_top()
+        b.wait_visible("#navbar-dropdown")
+        b.click("#navbar-dropdown")
+        b.click(".display-language-menu a")
+        b.wait_popup('display-language')
+        b.set_val("#display-language select", "de-de")
+        b.click("#display-language-select-button")
+        b.expect_load()
+        b.wait_present("#content")
+        b.enter_page("/playground/translate")
+        self.assertEqual(b.text("#translate-html"), "Bereit")
+
         # Log out and check that login page is translated now
         b.logout()
         b.wait_visible('#password-group')


### PR DESCRIPTION
When users change languages we use window.location.reload(true) to have the browser refresh. However not all browsers include the Pragma: no-cache headers for subsequent resource
loads both in the page and in the iframes. So use urls prefixed by the language code that matches what is set in the CockpitLang cookie. This way each language will have it's own independent cache.

This only effects resource urls, not what is visible to the user.

This is an attempt to fix issues like https://github.com/cockpit-project/cockpit/issues/4784 and https://bugzilla.redhat.com/show_bug.cgi?id=965007.

The catch with this PR is that the language prefix must match your current cookie otherwise the page won't load. The alternative is to accept any language looking string as a prefix. We can't validate it because this happens in cockpit-ws and that might not have the same languages around as are available on the machine running the bridge. If we go with accepting any language looking string, it should probably override the cookie setting for that page. We would also need to decide if it should change the cookie as well or if we are ok the possible resulting mismatch.