### PR TITLE
bots: Add machine learning for test flakes and  failures

### DIFF
--- a/.tasks
+++ b/.tasks
@@ -29,6 +29,7 @@ if [ $chance -gt 9 ]; then
     bots/image-trigger
     bots/npm-trigger
     bots/naughty-trigger
+    bots/learn-trigger
 fi
 
 # Any tasks related to issues

--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -27,6 +27,7 @@ NAMES = [
     "koji-build",
     "npm-update",
     "naughty-prune",
+    "learn-tests",
 ]
 
 KVM_TASKS = [

--- a/bots/learn-tests
+++ b/bots/learn-tests
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Slavek Kabrda
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+# The number of days of previous closed pull requests to learn from
+SINCE_DAYS = 120
+
+# The name and version of the training data
+TRAINING_DATA = "tests-train-1.jsonl.gz"
+
+import gzip
+import json
+import os
+import random
+import subprocess
+import sys
+import time
+
+sys.dont_write_bytecode = True
+
+import task
+import task.learn1
+
+BOTS = os.path.dirname(os.path.realpath(__file__))
+DATA = os.path.join(os.environ.get("TEST_DATA", BOTS), "images")
+
+def run(training_data, verbose=False, dry=False, **kwargs):
+    upload = [ os.path.join(BOTS, "image-upload"), "--state" ]
+
+    # Default set of training data, retrieve it and use from DATA directory
+    if not training_data:
+        training_data = TRAINING_DATA
+        upload.append(TRAINING_DATA)
+    if "/" not in training_data and not os.path.exists(training_data):
+        if not dry:
+            subprocess.check_call([ os.path.join(BOTS, "image-download"), "--state", training_data ])
+        training_data = os.path.join(DATA, training_data)
+    items = loader(training_data, verbose, dry)
+
+    # If we're validating, only use some of the items
+    # for training and the rest for validation
+    if dry:
+        items, check = split(items, 0.6)
+
+    network = train(items, verbose)
+
+    # Write out the trained data
+    path = os.path.join(DATA, task.learn1.LEARN_DATA)
+    task.learn1.save(path + ".tmp", network)
+    os.rename(path + ".tmp", path)
+    upload.append(task.learn1.LEARN_DATA)
+
+    # Just print out the validation
+    if dry:
+        validate(check, network, verbose)
+
+    # Or do the upload if a real run
+    else:
+        subprocess.check_call(upload)
+
+# Load jsonl style data into items, or if no file specified
+# then just run tests-data to retrieve live data
+def loader(training_data, verbose, dry):
+    items = [ ]
+
+    # The input file exists
+    exists = training_data and os.path.exists(training_data)
+
+    # Dry mode just read a file
+    if dry:
+        proc = None
+        if not exists:
+            raise RuntimeError("tests-learn: the input file doesn't exist: {0}".format(training_data))
+        inp = gzip.open(training_data, 'rb')
+        if verbose:
+            sys.stderr.write("Loading tests data\n")
+
+    # Launch the test-data command directly, and save the output
+    else:
+        cmd = [ os.path.join(BOTS, "tests-data"), "--since" ]
+        when = time.time() - 60 * 60 * 24 * SINCE_DAYS
+        cmd.append(time.strftime("%Y-%m-%d", time.gmtime(when)))
+        if exists:
+            cmd += [ "--seed", training_data ]
+        if verbose:
+            if exists:
+                sys.stderr.write("Loading initial tests data\n")
+            cmd.append("--verbose")
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        inp = proc.stdout
+
+    try:
+        while True:
+            line = inp.readline()
+            if not line:
+                break
+            if "failure" in line:
+                item = json.loads(line)
+                if item['status'] == 'failure':
+                    items.append(item)
+    finally:
+        if proc:
+            proc.wait()
+            if proc.returncode != 0:
+                raise RuntimeError("tests-data command failed")
+        inp.close()
+
+    return items
+
+# Split items into two sets with probability factor
+# This is useful for validating the training where we
+# want to split the input data
+def split(items, factor):
+    a, b = [ ], [ ]
+    for item in items:
+        if random.random() < factor:
+            a.append(item)
+        else:
+            b.append(item)
+    return a, b
+
+def train(items, verbose):
+    tokenizer = task.learn1.Tokenizer1()
+    tokenizer.parse(items, verbose)
+
+    if verbose:
+        sys.stderr.write("Found {0} tokens, {1} contexts and {2} tests names\n".format(
+            len(tokenizer.tokens), len(tokenizer.contexts), len(tokenizer.tests)))
+
+    if verbose:
+        sys.stderr.write("Training neural network with dataset of {0} samples\n".format(len(items)))
+
+    network = task.learn1.NNWithScaler1(tokenizer)
+    network.train(items)
+
+    return network
+
+def validate(items, network, verbose):
+    # Statistics that get triggered when we have result data
+    successes = 0
+    false_negatives = 0
+    false_positives = 0
+    unsure = 0
+    total_count = 0
+
+    for i, item in enumerate(items):
+        pred_proba = network.predict_proba(item)
+        # we only assign 0 or 1 to pred if one of the probabilities is bigger than threshhold
+        pred = None
+        pred_text = "UNSURE "
+        if max(pred_proba) >= task.learn1.PREDICT_THRESHHOLD:
+            if int(pred_proba[1] >= pred_proba[0]) == 1:
+                pred_text = "FLAKE  "
+                pred = True
+            else:
+                pred_text = "NOT    "
+                pred = False
+
+        sys.stdout.write("{pred_text} {flake_proba:.6f} {p} {pull} {test} {context} {url}\n".format(
+            pred_text=pred_text,
+            flake_proba=pred_proba[1],
+            p=pred,
+            pull=item["pull"],
+            test=item["test"],
+            context=item["context"],
+            url=item.get("url", "")
+        ))
+
+        if "merged" in item:
+            if verbose:
+                sys.stderr.write('Predicted item {0} to be {1} => {2}\n'.format(
+                    i + 1,
+                    pred_text.strip(),
+                    'correct' if pred == item['merged'] else 'wrong'
+                ))
+            total_count += 1
+            if pred == item['merged']:
+                successes += 1
+            elif pred == True:
+                false_positives += 1
+            elif pred == False:
+                false_negatives += 1
+            else:
+                unsure += 1
+
+    # Statistics
+    if total_count:
+        sys.stderr.write('Successes: {0}:{1} ({2:.1%})\n'.format(successes,
+            total_count, float(successes) / float(total_count)))
+        sys.stderr.write('False positives: {0}\n'.format(false_positives))
+        sys.stderr.write('False negatives: {0}\n'.format(false_negatives))
+        sys.stderr.write('Unsure: {0}\n'.format(unsure))
+
+if __name__ == '__main__':
+    task.main(function=run, title="Learn from testing data", verbose=True)

--- a/bots/learn-trigger
+++ b/bots/learn-trigger
@@ -1,0 +1,50 @@
+#!/usr/bin/python2
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+# Number of days between learning attempts
+DAYS = 7
+
+import argparse
+import sys
+import time
+
+sys.dont_write_bytecode = True
+
+import task
+
+def main():
+    parser = argparse.ArgumentParser(description='Ensure necessary issue learning from tests')
+    parser.add_argument('-v', '--verbose', action="store_true", default=False,
+                        help="Print verbose information")
+    parser.parse_args()
+
+    title = "Update machine learning from test logs"
+    body = "Perform machine learning tasks such as retrieving new test logs and updating"
+
+    since = time.time() - (DAYS * 86400)
+    issue = task.issue(title, body, "learn-tests", None, state="all", since=since)
+
+    if issue:
+        sys.stderr.write("#{0}: learn-tests\n".format(issue["number"]))
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -91,6 +91,8 @@ def main(**kwargs):
         help="Act on an already created task issue")
     parser.add_argument("--publish", dest="publish", default=os.environ.get("TEST_PUBLISH", ""),
         action="store", help="Publish results centrally to a sink")
+    parser.add_argument("--dry", dest="dry", action="store_true",
+        help="Dry run to validate this task if supported")
     parser.add_argument("context", nargs="?")
 
     opts = parser.parse_args()
@@ -102,6 +104,7 @@ def main(**kwargs):
         task["verbose"] = opts.verbose
     task["issue"] = opts.issue
     task["publish"] = opts.publish
+    task["dry"] = opts.dry
 
     ret = run(opts.context, **task)
 

--- a/bots/task/learn1.py
+++ b/bots/task/learn1.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Slavek Kabrda
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import collections
+import gzip
+import pickle
+import operator
+import re
+import sys
+
+from sklearn.neural_network import MLPClassifier
+from sklearn.preprocessing import StandardScaler
+
+# The threshhold for predicting based on learned data
+PREDICT_THRESHHOLD = 0.70
+
+# The name and version of the learning data
+LEARN_DATA = "tests-learn-1.nn"
+
+def load(path):
+    with gzip.open(path, 'rb') as fp:
+        network = pickle.load(fp)
+    return network
+
+def save(path, network):
+    with gzip.open(path, 'wb') as fp:
+        pickle.dump(network, fp)
+
+
+# -----------------------------------------------------------------------------
+# The Neural Network
+
+class NNWithScaler1:
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+        self.network = MLPClassifier(hidden_layer_sizes=(500, 500))
+        self.scaler = StandardScaler()
+
+    def predict(self, item):
+        features, unused = self.digest(item)
+        X = self.scaler.transform([features])
+        return self.network.predict(X)[0]
+
+    def predict_proba(self, item):
+        features, unused = self.digest(item)
+        X = self.scaler.transform([features])
+        return self.network.predict_proba(X)[0]
+
+    def digest(self, item):
+        tokens = self.tokenizer.tokenize(item['log'])
+        features = []
+        # firstly output features for contexts
+        for context in self.tokenizer.contexts:
+            features.append(int(item['context'] == context))
+        # secondly output features for tests
+        for test in self.tokenizer.tests:
+            features.append(int(item['test'] == test))
+        # thirdly output features for tokens
+        for token in self.tokenizer.tokens:
+            features.append(tokens[token])
+        # When "merged" is none it's unknown, lets use -1 for that
+        result = item.get('merged')
+        if result:
+            result = 1
+        elif result is not None:
+            result = 0
+        return features, result
+
+    def train(self, items):
+        # For sanity checking
+        not_merged = 0
+        merged = 0
+
+        # Create the data set
+        X, y = [], []
+        for i, item in enumerate(items):
+            if item.get('status') != "failure":
+                continue
+            features, result = self.digest(item)
+            if result == 0:
+                not_merged += 1
+            elif result == 1:
+                merged += 1
+            else:
+                continue
+            X.append(features)
+            y.append(result)
+
+        # Some validation now
+        if merged + not_merged < 100:
+            raise RuntimeError("too few training data points: {0}".format(merged + not_merged))
+        if not_merged < 100:
+            raise RuntimeError("too little of training data represents non-flakes: {0}".format(not_merged))
+        if merged < 100:
+            raise RuntimeError("too little of training data represents flakes: {0}".format(merged))
+
+        # Actual neural network training
+        self.scaler.fit(X)
+        X = self.scaler.transform(X)
+        self.network.fit(X, y)
+
+# -----------------------------------------------------------------------------
+# The Tokenizer
+
+SPLIT_RE = re.compile(r'[\s]')
+
+TOKEN_REGEXES = {
+    'SpecialToken:Number': re.compile(r'^\d+(\.\d+)?$'),
+    'SpecialToken:Percent': re.compile(r'^\d+(\.\d+)?%$'),
+    'SpecialToken:Time': re.compile(r'\d\d:\d\d:\d\d'),
+    'SpecialToken:UUID': re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', re.I),
+    'SpecialToken:WSCerts': re.compile(r'^/etc/cockpit/ws-certs.d/0-self-signed.cert:[\w/\+]+$'),
+}
+
+class Tokenizer1:
+    top_tokens = 9000
+
+    def __init__(self):
+        self.tokens = collections.defaultdict(int)
+        self.contexts = set()
+        self.tests = set()
+
+    def tokenize(self, log):
+        def noise(line):
+            return line.startswith("Journal extracted") or \
+                line.startswith("Wrote ") or \
+                line.startswith("Warning: Permanently added") or \
+                line.startswith("not ok ") or \
+                line.startswith("# Flake") or \
+                line.startswith("# ---------------") or \
+                line.strip() == "#"
+
+        # Filter out noise lines
+        log = "\n".join(filter(lambda x: not noise(x), log.split('\n')))
+
+        result = [ ]
+
+        def unify_token(token):
+            if len(token) < 4:
+                return None
+            elif len(set(token)) == 1:
+                # omit stuf like "--------------------------"
+                return None
+            else:
+                for name, regex in TOKEN_REGEXES.items():
+                    if regex.match(token):
+                        return name
+            return token
+
+        split = SPLIT_RE.split(log)
+        for i in split:
+            unified = unify_token(i)
+            if unified is not None:
+                result.append(unified)
+
+        tokens = collections.defaultdict(int)
+        for token in result:
+            tokens[token] = tokens.get(token, 0) + 1
+        return tokens
+
+    def parse(self, items, verbose=False):
+        tokens = collections.defaultdict(int)
+        contexts = set()
+        tests = set()
+
+        for item in items:
+            for token, count in self.tokenize(item['log']).items():
+                tokens[token] = tokens.get(token, 0) + count
+            contexts.add(item['context'])
+            tests.add(item['test'])
+
+        # Get the top number of tokens
+        usetokens = []
+        for token, count in sorted(tokens.items(), key=operator.itemgetter(1), reverse=True):
+            usetokens.append(token)
+            if len(usetokens) == self.top_tokens:
+                break
+
+        self.tokens = usetokens
+        self.contexts = sorted(contexts)
+        self.tests = sorted(tests)

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -41,10 +41,9 @@ SINKS = { }
 
 def main():
     parser = argparse.ArgumentParser(description="Pull out test data for pull requests")
-    parser.add_argument("--seed", action="store", help="Seed with existing data")
+    parser.add_argument("--seed", action="store", help="Seed with existing data and update")
     parser.add_argument("--open", action="store_true", help="Pull data on open pull requests")
     parser.add_argument("--since", help="Since a given ISO-8601 date")
-    parser.add_argument("-z", "--gzip", action="store_true", help="Compress input and output")
     parser.add_argument("-v", "--verbose", action="store_true", help="Show verbose progress")
     opts = parser.parse_args()
 
@@ -57,17 +56,14 @@ def main():
         sys.stderr.write("tests-data: invalid since date: {0}\n".format(since))
         return 2
 
-    # Compress the output if so
-    if opts.gzip:
-        if os.isatty(1):
-            sys.stderr.write("tests-data: refusing to compress to stdout")
-            return 2
-        sys.stdout.flush()
-        sys.stdout = gzip.GzipFile(fileobj=sys.stdout, mode='wb')
-
     # Seed with our input data
     if opts.seed:
-        seed(opts.seed, opts.gzip, since)
+        output = gzip.open(opts.seed + ".tmp", 'wb')
+        if os.path.exists(opts.seed):
+            with gzip.open(opts.seed, 'rb') as fp:
+                seed(since, fp, output)
+    else:
+        output = None
 
     # Now start the process
     for pull in task.api.pulls(state=opts.open and "open" or "closed", since=since):
@@ -77,13 +73,14 @@ def main():
             sys.stderr.write("pull-{0}\n".format(pull["number"]))
         merged = included(pull)
         for revision in revisions(pull):
+            logged = False
             if opts.verbose:
                 sys.stderr.write("- {0}\n".format(revision))
             for (context, created, url, log) in logs(revision):
                 if opts.verbose:
                     sys.stderr.write("  - {0} {1}\n".format(created, context))
                 for (status, name, body) in tap(log):
-                    sys.stdout.write(json.dumps({
+                    line = json.dumps({
                         "pull": pull["number"],
                         "revision": revision,
                         "status": status,
@@ -93,15 +90,40 @@ def main():
                         "test": name,
                         "url": url,
                         "log": body
-                    }))
-                    sys.stdout.write("\n")
+                    }) + "\n"
+                    sys.stdout.write(line)
                     sys.stdout.flush()
+                    if output:
+                        output.write(line)
+                    logged = True
+
             # The next revisions for the pull request are not the ones
             # that got merged. Only the first one produced by revisions
             if merged:
                 merged = False
 
+            # Nothing found for this revision
+            if not logged:
+                line = json.dumps({
+                    "pull": pull["number"],
+                    "revision": revision,
+                    "status": "unknown",
+                    "context": context,
+                    "date": None,
+                    "merged": merged,
+                    "test": None,
+                    "url": None,
+                    "log": None
+                }) + "\n"
+                sys.stdout.write(line)
+                sys.stdout.flush()
+                if output:
+                    output.write(line)
+
     sys.stdout.flush()
+    if output:
+        output.close()
+        os.rename(opts.seed + ".tmp", opts.seed)
 
 # An HTML parser that just pulls out all the <a href="...">
 # link hrefs in a given page of content. We also qualify these
@@ -140,31 +162,31 @@ def links(url):
 # Parses seed input data and passes it through to output
 # all the while preparing the fact that certain URLs have
 # already been seen
-def seed(filename, compress=False, since=None):
+def seed(since, fp, output):
     seeded = None
-    with (compress and gzip.open or open)(filename, 'rb') as fp:
-        while True:
-            line = fp.readline()
-            if not line:
-                break
-            try:
-                item = json.loads(line)
-            except ValueError, ex:
-                sys.stderr.write("{0}: {1}\n".format(filename, ex))
-                continue
+    while True:
+        line = fp.readline()
+        if not line:
+            break
+        try:
+            item = json.loads(line)
+        except ValueError, ex:
+            sys.stderr.write("tests-data: {1}\n".format(str(ex)))
+            continue
 
-            # Once we see a new pull treat the old one as complete and seeded
-            # As a failsafe, just to make sure we didn't miss something
-            # wo don't treat the last pull request as completely seeded
-            pull = item.get("pull")
-            if pull != seeded:
-                SEEDED[pull] = True
-                seeded = pull
+        # Once we see a new pull treat the old one as complete and seeded
+        # As a failsafe, just to make sure we didn't miss something
+        # wo don't treat the last pull request as completely seeded
+        pull = item.get("pull")
+        if pull != seeded:
+            SEEDED[pull] = True
+            seeded = pull
 
-            date = item.get("date")
-            if date and since < time.mktime(time.strptime(date, "%Y-%m-%dT%H:%M:%SZ")):
-                sys.stdout.write(line)
-                sys.stdout.flush()
+        date = item.get("date")
+        if date and since < time.mktime(time.strptime(date, "%Y-%m-%dT%H:%M:%SZ")):
+            sys.stdout.write(line)
+            sys.stdout.flush()
+            output.write(line)
 
 # Generates revisions for a given pull request. Each revision
 # is a simple string sha. The first one is the one that is at

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -200,6 +200,11 @@ class PullTask(object):
                 "ipa", "openshift", "selenium"
             ])
 
+            # Download some additional necessary state
+            subprocess.check_call([ os.path.join(BOTS, "image-download"),
+                "--state", "tests-learn-1.nn"
+            ])
+
         except subprocess.CalledProcessError:
             return "Downloading of additional images failed"
 

--- a/bots/tests-policy
+++ b/bots/tests-policy
@@ -25,13 +25,21 @@ import re
 import os
 import socket
 import sys
+import time
 import traceback
 
 sys.dont_write_bytecode = True
 
 from task import github
 
-BOTS = os.path.join(os.path.dirname(__file__))
+try:
+    import task.learn1
+    WITH_LEARNING = True
+except ImportError:
+    WITH_LEARNING = False
+
+BOTS = os.path.dirname(os.path.realpath(__file__))
+DATA = os.path.join(os.environ.get("TEST_DATA", BOTS), "images")
 
 def main():
     script = os.path.basename(__file__)
@@ -82,6 +90,8 @@ def main():
             output = filterSkip(output, "Known issue #{0}".format(number))
         elif checkRetry(output):
             output = filterRetry(output, "# RETRY due to failure of test harness or framework")
+        else:
+            output = guessFlake(output, context)
 
         sys.stdout.write(output)
         return 0
@@ -110,6 +120,55 @@ def filterRetry(output, prefix):
         if line.startswith("not ok ") or line.startswith("ok "):
             lines[i] = prefix
     return "\n".join(lines)
+
+# Figure out the name from a failed test
+def parseName(output):
+    for line in output.split("\n"):
+        if line.startswith("not ok "):
+            line = line[7:]
+            while line[0].isspace() or line[0].isdigit():
+                line = line[1:]
+            (name, delim, directive) = line.partition("#")
+            (name, delim, directive) = name.partition("duration")
+            name = name.strip()
+            return name
+    return ""
+
+# -----------------------------------------------------------------------------
+# Flakiness Checks
+
+def guessFlake(output, context):
+    if not WITH_LEARNING:
+        return output
+
+    path = os.path.join(DATA, task.learn1.LEARN_DATA)
+    if not os.path.exists(path):
+        return output
+
+    # The pickled neural network
+    network = task.learn1.load(path)
+
+    # Build up an item just like in tests-data
+    item = {
+        "pull": None,
+        "revision": os.environ.get("TEST_REVISION"),
+        "status": "failure",
+        "context": context,
+        "date": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "merged": None,
+        "test": parseName(output),
+        "url": None,
+        "log": output
+    }
+
+    pred_proba = network.predict_proba(item)
+    if max(pred_proba) >= 0.5:
+        if int(pred_proba[1] >= pred_proba[0]) == 1:
+            output += "\n# Flake probability: {0:.1f}%\n".format(pred_proba[1] * 100)
+    # TODO: Remove this line
+    output += "\n# Flake debug: " + repr(pred_proba)
+
+    return output
 
 # -----------------------------------------------------------------------------
 # Retry policy


### PR DESCRIPTION
Goal is to start putting numbers under each test failure whether we think this is a flake or not.

 * [x] #7403 
 * [x] #7808 
 * [x] https://github.com/cockpit-project/cockpituous/pull/152
 * [x] tests-learn script
 * [x] tests-policy script

