### PR TITLE
7.4 backports: fix build in nspawn, bug fixes

### DIFF
--- a/pkg/lib/machines.js
+++ b/pkg/lib/machines.js
@@ -172,11 +172,16 @@
         }
 
         function update_saved_machine(host, values) {
-            // wrap values in variants for D-Bus call
+            // wrap values in variants for D-Bus call; at least values.port can
+            // be int or string, so stringify everything but the "visible" boolean
             var values_variant = {};
             for (var prop in values)
-                if (values[prop] !== null)
-                    values_variant[prop] = cockpit.variant(prop == "visible" ? 'b' : 's', values[prop]);
+                if (values[prop] !== null) {
+                    if (prop == "visible")
+                        values_variant[prop] = cockpit.variant('b', values[prop]);
+                    else
+                        values_variant[prop] = cockpit.variant('s', values[prop].toString());
+                }
 
             // FIXME: investigate re-using the proxy from Loader (runs in different frame/scope)
             var bridge = cockpit.dbus(null, { bus: "internal", "superuser": "try" });

--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -1269,16 +1269,18 @@ $(function() {
         var unit = "[Unit]\nDescription=";
         var service = "\n[Service]\nExecStart=";
         var timer = "\n[Timer]\n";
-        var service_file = unit + timer_unit.Description + service + timer_unit.Command + "\n[Install]\nWantedBy=default.target";
+        var install = "[Install]\nWantedBy=timers.target\n";
+        var service_file = unit + timer_unit.Description + service + timer_unit.Command + "\n";
         var timer_file = " ";
         if (timer_unit.Calendar_or_Boot == "Boot") {
-            var boottimer = timer +"OnBootSec=" + timer_unit.boot_time + timer_unit.boot_time_unit;
+            var boottimer = timer +"OnBootSec=" + timer_unit.boot_time + timer_unit.boot_time_unit + "\n";
             timer_file = unit + timer_unit.Description + boottimer;
         }
         else if (timer_unit.Calendar_or_Boot == "Calendar") {
-            var calendartimer = timer + timer_unit.OnCalendar;
+            var calendartimer = timer + timer_unit.OnCalendar + "\n";
             timer_file = unit + timer_unit.Description + calendartimer;
         }
+        timer_file += install;
         // writing to file
         var service_path = "/etc/systemd/system/" + timer_unit.name + ".service";
         var file = cockpit.file(service_path, { superuser: 'try' });

--- a/src/ws/remotectl-certificate.c
+++ b/src/ws/remotectl-certificate.c
@@ -115,7 +115,7 @@ set_cert_attributes (const gchar *path,
       g_message ("couldn't set certificate permissions: %s: %s", path, g_strerror (errno));
       goto out;
     }
-  if (chown (path, pwd->pw_uid, gr ? gr->gr_gid : 0) < 0)
+  if (chown (path, pwd->pw_uid, gr ? gr->gr_gid : -1) < 0)
     {
       g_message ("couldn't set certificate ownership: %s: %s", path, g_strerror (errno));
       goto out;

--- a/src/ws/test-remotectlcertificate.c
+++ b/src/ws/test-remotectlcertificate.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <grp.h>
 
 const gchar *config_dir = BUILDDIR "/test-configdir";
 
@@ -81,6 +82,7 @@ setup (TestCase *tc,
   const TestFixture *fix = data;
   const gchar *old_val = g_getenv ("XDG_CONFIG_DIRS");
   gint i;
+  struct group *gr = NULL;
 
   g_setenv ("XDG_CONFIG_DIRS", config_dir, TRUE);
   tc->cert_dir = g_build_filename (config_dir, "cockpit", "ws-certs.d", NULL);
@@ -91,8 +93,13 @@ setup (TestCase *tc,
   g_ptr_array_add (ptr, "certificate");
   g_ptr_array_add (ptr, "--user");
   g_ptr_array_add (ptr, (gchar *) g_get_user_name ());
-  g_ptr_array_add (ptr, "--group");
-  g_ptr_array_add (ptr, (gchar *) g_get_user_name ());
+
+  gr = getgrnam (g_get_user_name ());
+  if (gr != NULL)
+    {
+      g_ptr_array_add (ptr, "--group");
+      g_ptr_array_add (ptr, (gchar *) g_get_user_name ());
+    }
 
   for (i = 0; fix->files[i] != NULL; i++)
     g_ptr_array_add (ptr, (gchar *) fix->files[i]);

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -130,10 +130,12 @@ class TestMultiMachineAdd(MachineCase):
         b = self.browser
         m2 = self.machine2
         m3 = self.machine3
+        change_ssh_port(m3, 2222)
 
         self.login_and_go(None)
         add_machine(b, m2.address)
-        add_machine(b, m3.address)
+        m3_con = m3.address + ":2222"
+        add_machine(b, m3_con)
 
         # TODO: The concrete error message when killing the bridge and
         # session is not predictable.  So we just wait for any error
@@ -167,7 +169,7 @@ class TestMultiMachineAdd(MachineCase):
         b.click("#dashboard-hosts a[data-address='%s']" % m3.address)
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname != "/dashboard"')
-        b.enter_page("/system", host=m3.address)
+        b.enter_page("/system", host=m3_con)
         b.wait_text_not("#system_information_hostname_button", "")
         b.switch_to_top()
         b.go("/dashboard")

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -470,7 +470,7 @@ WantedBy=default.target
         b.click("#timer-save-button")
         b.wait_popdown("timer-dialog")
         b.wait_present(svc_sel('boot_timer.timer'))
-        m.execute("systemctl enable boot_timer")
+        m.execute("systemctl enable boot_timer.timer")
         m.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")
         m.wait_reboot()
         m.start_cockpit()


### PR DESCRIPTION
 * Fix building in nspawn (otherwise the [build fails](https://fedorapeople.org/groups/cockpit/logs/pull-7705-20170918-151111-dff84ca0-verify-rhel-7/log.html) on current images)
 * Fix non-standard ssh ports (https://bugzilla.redhat.com/show_bug.cgi?id=1478828)
 * Fix timers (https://bugzilla.redhat.com/show_bug.cgi?id=1478832)