### PR TITLE
kubernetes: Support X-Forwarded-Proto for kubernetes

### DIFF
--- a/containers/kubernetes/cockpit.conf.tmpl
+++ b/containers/kubernetes/cockpit.conf.tmpl
@@ -1,5 +1,6 @@
 [WebService]
 LoginTo = false
+ProtocolHeader = X-Forwarded-Proto
 {{ if .origins }}
 Origins = {{.origins}}
 {{end}}
@@ -9,7 +10,6 @@ Shell = /shell/simple.html
 {{else}}
 Shell = /shell/stub.html
 {{if .is_openshift }}
-ProtocolHeader = X-Forwarded-Proto
 LoginTitle = Openshift Cockpit
 {{else}}
 LoginTitle = Kubernetes Cockpit


### PR DESCRIPTION
Previously we only set it for openshift. Some, though not all, kubernetes ingress implementations set this header correctly.