### PR TITLE
kubernetes: Look at response status as well as code

### DIFF
--- a/pkg/kubernetes/scripts/kube-client.js
+++ b/pkg/kubernetes/scripts/kube-client.js
@@ -1230,9 +1230,12 @@
                             step();
                         }, function(response) {
                             var resp = response.data;
+                            var code = response.status;
+                            if (resp && resp.code)
+                                code = resp.code;
 
                             /* Ignore failures creating the namespace if it already exists */
-                            if (resource.kind == "Namespace" && resp && (resp.code === 409 || resp.code === 403)) {
+                            if (resource.kind == "Namespace" && (code === 409 || code === 403)) {
                                 debug("skipping namespace creation");
                                 step();
                             } else {


### PR DESCRIPTION
Some kubernetes endpoints aren't returning proper json responses for 403s. So look at the response status for codes as well.