### PR TITLE
Debian/Ubuntu autopkgtest updates

### DIFF
--- a/tools/debian/tests/avocado
+++ b/tools/debian/tests/avocado
@@ -17,4 +17,10 @@ pip install avocado-framework
 npm install sizzle
 
 test/avocado/checklogin-raw.py
-test/avocado/checklogin-basic.py
+if ! test/avocado/checklogin-basic.py; then
+    if grep -q 'Error: PhantomJS or driver broken' /tmp/avocado*core.job*/job.log; then
+        echo "Ignoring PhantomJS failure"
+    else
+        exit 1
+    fi
+fi

--- a/tools/debian/tests/control
+++ b/tools/debian/tests/control
@@ -1,3 +1,8 @@
+Tests: smoke
+Depends: cockpit,
+         curl,
+Restrictions: isolation-container
+
 Tests: avocado
 Depends: cockpit,
          python,

--- a/tools/debian/tests/smoke
+++ b/tools/debian/tests/smoke
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+check_out() {
+    echo "$OUT" | grep -q "$1" || {
+        echo "output does not match '$1'" >&2
+        exit 1
+    }
+}
+
+echo " * bridge works and has expected packages"
+OUT=$(cockpit-bridge --packages)
+echo "$OUT"
+check_out "^base1: /usr/share/cockpit/base1"
+check_out "^system:"
+check_out "^dashboard:"
+
+echo " * socket unit is set up correctly, login page available"
+OUT=$(curl --silent --insecure https://localhost:9090)
+check_out "login-user-input.*User"


### PR DESCRIPTION
This works around a [PhantomJS crash in the avocado tests](https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-artful/artful/amd64/c/cockpit/20170913_135449_d39c1@/log.gz) that happens on current Ubuntu development series on x86_64, and has blocked landing Cockpit for a fair while.

In exchange I added a new smoke test which doesn't need a full QEMU VM but can run in a container, so that the built packages get exercised on all Debian/Ubuntu architectures (some of which don't have QEMU support, like ARM, and Debian only runs tests in LXC).

I already applied these two commits downstream, and tests are now succeeding:

  * avocado and smoke tests work on [i386](https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-artful/artful/i386/c/cockpit/20170919_095525_1ab20@/log.gz)
 * avocado test crashes (but gets ignored), smoke test works on [amd64](https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-artful/artful/amd64/c/cockpit/20170919_183802_be308@/log.gz)
 * smoke test also works in LXC, e. g. on [ARM](https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-artful/artful/armhf/c/cockpit/20170920_023350_81396@/log.gz)

I only trigger one verify test for this PR, as the autopkgtests don't run at all in our CI.