### PR TITLE
bots: Only test older branches if we have a host network

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -56,11 +56,20 @@ REDHAT_VERIFY = {
 # Server to tell us if we can test Red Hat images
 REDHAT_PING = "http://cockpit-11.e2e.bos.redhat.com"
 
+# Host interfaces that tell us we're not in a namespaced network
+HOST_INTERFACES = [ "cockpit1", "docker0", "virbr0" ]
+
+# Branches that need the bridged network to work
+LEGACY_BRANCHES = [
+    'rhel-7.4',
+]
+
 import argparse
 import os
 import json
 import pipes
 import random
+import subprocess
 import sys
 import time
 import urllib
@@ -339,6 +348,17 @@ def scan(api, update, human):
         policy.update(REDHAT_VERIFY)
     except IOError:
         pass
+
+    # Check if we're in a namespaced network
+    null = open("/dev/null", "r+")
+    for interface in HOST_INTERFACES:
+        if subprocess.call([ "ip", "link", "show", interface ], stdout=null, stderr=null) == 0:
+            break
+
+    # In a namespaced network, remove legacy branches
+    else:
+        for context, branches in policy.items():
+            policy[context] = filter(lambda branch: branch not in LEGACY_BRANCHES, branches)
 
     return scan_for_pull_tasks(api, update, human, policy)
 

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -20,7 +20,7 @@
 
 BASELINE_PRIORITY = 10
 
-BRANCHES = [ 'master', 'rhel-7.4', 'rhel-7.3.1', 'rhel-7.3.2', 'rhel-7.3.3', 'rhel-7.3.4', 'rhel-7.3.5', 'rhel-7.3.6' ]
+BRANCHES = [ 'master', 'rhel-7.4' ]
 
 DEFAULT_VERIFY = {
     'avocado/fedora-25': BRANCHES,
@@ -32,7 +32,7 @@ DEFAULT_VERIFY = {
     'verify/debian-stable': [ 'master' ],
     'verify/debian-testing': [ 'master' ],
     'verify/fedora-25': [ ],
-    'verify/fedora-i386': [ 'master', 'rhel-7.4', 'rhel-7.3.6', 'rhel-7.3.5' ],
+    'verify/fedora-i386': BRANCHES,
     'verify/fedora-26': [ 'master' ],
     'verify/fedora-27': [ ],
     'verify/fedora-atomic': BRANCHES,
@@ -47,7 +47,7 @@ NPM_REPOS = {
 
 # Non-public images used for testing
 REDHAT_VERIFY = {
-    "verify/rhel-7": [ 'master', 'rhel-7.3.6', 'rhel-7.3.5', 'rhel-7.3.4', 'rhel-7.3.3', 'rhel-7.3.2' ],
+    "verify/rhel-7": [ 'master' ],
     "verify/rhel-7-4": [ 'master', 'rhel-7.4' ],
     "verify/rhel-atomic": [ 'master' ],
     'selenium/explorer': [ 'master' ],


### PR DESCRIPTION
The older rhel-7.4 and rhel-7.3.x branches require a full host
network in order to run tests. Because these branches use a
bridged VM network rather than an isolated QEMU socket network.

Since some of the bots are starting to run without a host network,
check that we have a host network before including those branches
for testing.