### PR TITLE
Be explicit about using Python 2.x

### DIFF
--- a/bots/example-task
+++ b/bots/example-task
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/github-info
+++ b/bots/github-info
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/image-create
+++ b/bots/image-create
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # This file is part of Cockpit.
 #
 # Copyright (C) 2015 Red Hat, Inc.

--- a/bots/image-customize
+++ b/bots/image-customize
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # This file is part of Cockpit.
 #
 # Copyright (C) 2015 Red Hat, Inc.

--- a/bots/image-download
+++ b/bots/image-download
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/image-naughty
+++ b/bots/image-naughty
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # This file is part of Cockpit.
 #
 # Copyright (C) 2015 Red Hat, Inc.

--- a/bots/image-prune
+++ b/bots/image-prune
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/image-upload
+++ b/bots/image-upload
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 
 # The default settings here should match one of the default
 # download stores. These are usually cockpit/images instances

--- a/bots/images/scripts/lib/atomic.install
+++ b/bots/images/scripts/lib/atomic.install
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/koji-build
+++ b/bots/koji-build
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/naughty-prune
+++ b/bots/naughty-prune
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/naughty-trigger
+++ b/bots/naughty-trigger
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/npm-repo-test-invoke
+++ b/bots/npm-repo-test-invoke
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # This file is part of Cockpit.
 #
 # Copyright (C) 2017 Red Hat, Inc.

--- a/bots/npm-trigger
+++ b/bots/npm-trigger
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/npm-update
+++ b/bots/npm-update
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/po-refresh
+++ b/bots/po-refresh
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/po-trigger
+++ b/bots/po-trigger
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/cache.py
+++ b/bots/task/cache.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/github.py
+++ b/bots/task/github.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/sink.py
+++ b/bots/task/sink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/test-cache
+++ b/bots/task/test-cache
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/test-checklist
+++ b/bots/task/test-checklist
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/test-github
+++ b/bots/task/test-github
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/test-task
+++ b/bots/task/test-task
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/tests-trigger
+++ b/bots/tests-trigger
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 
 import argparse
 import sys

--- a/pkg/docker/cockpit-atomic-storage
+++ b/pkg/docker/cockpit-atomic-storage
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python2
 
 # This utility fills in the gaps between the Atomic image storage API
 # and the Cockpit UI.  Specifically, it replicates some bits of

--- a/test/avocado/checkexample-foo.py
+++ b/test/avocado/checkexample-foo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/avocado/checklogin-basic.py
+++ b/test/avocado/checklogin-basic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/avocado/checklogin-raw.py
+++ b/test/avocado/checklogin-raw.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/avocado/checkrealms-basic.py
+++ b/test/avocado/checkrealms-basic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/avocado/scheduler.py
+++ b/test/avocado/scheduler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 from nrun import *
 

--- a/test/avocado/selenium-base.py
+++ b/test/avocado/selenium-base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # we need to be able to find and import seleniumlib, so add this directory
 import os

--- a/test/avocado/selenium-docker.py
+++ b/test/avocado/selenium-docker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # we need to be able to find and import seleniumlib, so add this directory
 import os

--- a/test/avocado/selenium-navigate.py
+++ b/test/avocado/selenium-navigate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # we need to be able to find and import seleniumlib, so add this directory
 import os

--- a/test/avocado/selenium-sosreport.py
+++ b/test/avocado/selenium-sosreport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # we need to be able to find and import seleniumlib, so add this directory
 import os

--- a/test/avocado/selenium-storage.py
+++ b/test/avocado/selenium-storage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # we need to be able to find and import seleniumlib, so add this directory
 import os

--- a/test/avocado/seleniumlib.py
+++ b/test/avocado/seleniumlib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 """ SETUP tasks
 
 # workaround for RHEL7

--- a/test/avocado/timeoutlib.py
+++ b/test/avocado/timeoutlib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/containers/check-kubernetes
+++ b/test/containers/check-kubernetes
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/containers/check-kubernetes-openshift
+++ b/test/containers/check-kubernetes-openshift
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/containers/run-tests
+++ b/test/containers/run-tests
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # This file is part of Cockpit.
 #
 # Copyright (C) 2016 Red Hat, Inc.

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-active-pages
+++ b/test/verify/check-active-pages
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-embed
+++ b/test/verify/check-embed
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-example
+++ b/test/verify/check-example
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-keys
+++ b/test/verify/check-keys
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-kubernetes
+++ b/test/verify/check-kubernetes
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-multi-os
+++ b/test/verify/check-multi-os
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-networking-basic
+++ b/test/verify/check-networking-basic
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-networking-bridge
+++ b/test/verify/check-networking-bridge
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-networking-checkpoints
+++ b/test/verify/check-networking-checkpoints
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-networking-mac
+++ b/test/verify/check-networking-mac
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-networking-mtu
+++ b/test/verify/check-networking-mtu
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-networking-other
+++ b/test/verify/check-networking-other
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-networking-settings
+++ b/test/verify/check-networking-settings
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-networking-team
+++ b/test/verify/check-networking-team
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-networking-unmanaged
+++ b/test/verify/check-networking-unmanaged
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-networking-vlan
+++ b/test/verify/check-networking-vlan
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-ovirt
+++ b/test/verify/check-ovirt
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-packages
+++ b/test/verify/check-packages
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-roles
+++ b/test/verify/check-roles
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-shutdown-restart
+++ b/test/verify/check-shutdown-restart
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-ignored
+++ b/test/verify/check-storage-ignored
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-msdos
+++ b/test/verify/check-storage-msdos
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-raid1
+++ b/test/verify/check-storage-raid1
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-unused
+++ b/test/verify/check-storage-unused
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-subscriptions
+++ b/test/verify/check-subscriptions
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/check-tuned
+++ b/test/verify/check-tuned
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/files/measure-cpu
+++ b/test/verify/files/measure-cpu
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python2
 
 import sys
 import os

--- a/test/verify/files/mock-faf-server.py
+++ b/test/verify/files/mock-faf-server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # export uReport_URL="http://localhost:12345"
 
 import cgi

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/verify/run-tests
+++ b/test/verify/run-tests
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 
 import glob
 import imp

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/test/vm-run
+++ b/test/vm-run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # This file is part of Cockpit.
 #
 # Copyright (C) 2013 Red Hat, Inc.

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # generate debian/copyright from debian/copyright.template and node_modules
 # Author: Martin Pitt <mpitt@debian.org>
 #

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -51,7 +51,7 @@ BuildRequires: pkgconfig(polkit-agent-1) >= 0.105
 BuildRequires: pam-devel
 
 BuildRequires: autoconf automake
-BuildRequires: /usr/bin/python
+BuildRequires: /usr/bin/python2
 BuildRequires: intltool
 %if %{defined build_dashboard}
 BuildRequires: libssh-devel >= %{libssh_version}
@@ -468,7 +468,7 @@ Requires: libvirt-daemon
 Requires: libvirt-python
 Requires: qemu-kvm
 Requires: npm
-Requires: python
+Requires: python2
 Requires: rsync
 Requires: xz
 Requires: openssh-clients
@@ -615,7 +615,7 @@ Summary: Cockpit user interface for Docker containers
 Requires: %{name}-bridge >= %{required_base}
 Requires: %{name}-shell >= %{required_base}
 Requires: /usr/bin/docker
-Requires: python
+Requires: python2
 
 %description docker
 The Cockpit components for interacting with Docker and user interface.

--- a/tools/gen-spec-dependencies
+++ b/tools/gen-spec-dependencies
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Compute dependencies of our cockpit-<module> packages to to -bridge/-shell,
 # by replacing %{required_base} with the requires["cockpit"] version from
 # pkg/<module>/manifest.json.in (this is done by tools/min-base-version).

--- a/tools/min-base-version
+++ b/tools/min-base-version
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Compute the maximum required "cockpit" version from all pkg/*/manifest.json
 # for computing rpm/deb package dependencies. This is a bit stricter than
 # absolutely required, as only some subpackages might require a newer cockpit

--- a/tools/python.supp
+++ b/tools/python.supp
@@ -1,0 +1,9 @@
+{
+   Py_Main
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_allocate_lock
+   ...
+   fun:Py_InitializeEx
+   fun:Py_Main
+}

--- a/tools/python.supp
+++ b/tools/python.supp
@@ -1,9 +1,0 @@
-{
-   Py_Main
-   Memcheck:Leak
-   fun:malloc
-   fun:PyThread_allocate_lock
-   ...
-   fun:Py_InitializeEx
-   fun:Py_Main
-}

--- a/tools/tap-driver
+++ b/tools/tap-driver
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # Copyright (C) 2013 Red Hat, Inc.
 #

--- a/tools/tap-gtester
+++ b/tools/tap-gtester
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # Copyright (C) 2014 Red Hat, Inc.
 #

--- a/tools/test-bots
+++ b/tools/test-bots
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/tools/test-bots
+++ b/tools/test-bots
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.


### PR DESCRIPTION
We'd like to migrate to Python 3.x for our tests and scripts. But
that's a lot of work.

But distributions would like us to be explicit about the version
of python that our tests and scripts use. See:

https://taskotron.fedoraproject.org/artifacts/all/ec52504e-9e9f-11e7-86b2-525400817a8f/task_output/output.log

and

https://fedoraproject.org/wiki/Packaging:Python#Dependencies