### PR TITLE
bots: Start releasing into Fedora 27

### DIFF
--- a/bots/major-cockpit-release
+++ b/bots/major-cockpit-release
@@ -25,7 +25,7 @@ job release-srpm
 
 # Do fedora builds for the tag, using tarball
 job release-koji -k master
-job release-koji f26
+job release-koji f27
 
 # Upload release to github, using tarball
 job release-github
@@ -38,7 +38,7 @@ job release-dockerhub cockpit-project/cockpit-container
 job release-dockerhub cockpituous/cockpit cockpit-project/cockpit
 
 # Push out a Bodhi update
-job release-bodhi F26
+job release-bodhi F27
 
 # Upload documentation
 job release-guide dist/guide cockpit-project/cockpit-project.github.io


### PR DESCRIPTION
Fedora 27 has branched and is in prerelease and/or beta mode.
We should start releasing Cockpit there.