### PR TITLE
specify vagrant sync arguments to work around bad vagrant defaults

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure(2) do |config|
 
     config.vm.box = "fedora/26-cloud-base"
     config.vm.synced_folder ".", "/vagrant", disabled: true
-    config.vm.synced_folder "./dist", "/cockpit/dist", type: "rsync", create: true
+    config.vm.synced_folder "./dist", "/cockpit/dist", type: "rsync", create: true, rsync__args: ["--verbose", "--archive", "--delete", "-z"]
     config.vm.network "private_network", ip: "192.168.50.10"
     config.vm.network "forwarded_port", guest: 9090, host: 9090
     config.vm.hostname = "cockpit-devel"


### PR DESCRIPTION
Related vagrant issue: https://github.com/hashicorp/vagrant/issues/5471

(As Vagrant refuses to set good defaults that works properly on Linux, we need to set the rsync arguments ourselves.)