### PR TITLE
kubernetes: Avoid creating links in /etc

### DIFF
--- a/containers/kubernetes/install.sh
+++ b/containers/kubernetes/install.sh
@@ -29,11 +29,20 @@ rm -rf /container/rpms
 # Openshift will change the user
 # but it will be part of gid 0
 # so make the files we need group writable
+
+# We replace os-release with
+# kubernetes or openshift specific text
+chmod 775 /container
+ln -sf /container/os-release /etc/os-release
+
+# We link in a customized config file
+# We may also need to generate certificates
 rm -rf /etc/cockpit/
 mkdir -p /etc/cockpit/
-chmod 775 /etc
 chmod 775 /etc/cockpit
-chmod 775 /etc/os-release
+
+# The index html is changed for the registry
+# We also add override.json files to both these locations
 chmod 775 /usr/share/cockpit/shell
 chmod 775 /usr/share/cockpit/kubernetes
 

--- a/pkg/kubernetes/standalone/src/cockpit-kube-launch/main.go
+++ b/pkg/kubernetes/standalone/src/cockpit-kube-launch/main.go
@@ -158,7 +158,7 @@ func main() {
 	override := path.Join(*confDir, fmt.Sprintf("%s-override.json", name))
 	brand := path.Join(*confDir, fmt.Sprintf("%s-brand", name))
 	linkFiles(override, "/usr/share/cockpit/shell/override.json")
-	linkFiles(brand, "/etc/os-release")
+	linkFiles(brand, "/container/os-release")
 
 	if isRegistry {
 		registry_override := path.Join(*confDir, "registry-dashboard-override.json")


### PR DESCRIPTION
Gotten reports of /etc not being writable in some environments so setup a link in advance so we don't need to change anything there.