### PR TITLE
test: Don't blacklist cockpit-stub from memory leak checks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -257,7 +257,7 @@ endif
 VALGRIND_ARGS = --trace-children=yes --quiet --error-exitcode=33 \
 	--suppressions=valgrind-suppressions --gen-suppressions=all \
 	--num-callers=16 --leak-check=yes --show-leak-kinds=definite \
-	--errors-for-leak-kinds=definite --trace-children-skip='*mock*,/bin*,/usr/bin/*,/usr/local/bin,*cockpit-stub'
+	--errors-for-leak-kinds=definite --trace-children-skip='*mock*,/bin*,/usr/bin/*,/usr/local/bin'
 VALGRIND_SUPPRESSIONS = \
 	tools/gcrypt.supp \
 	tools/glib.supp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -257,7 +257,7 @@ endif
 VALGRIND_ARGS = --trace-children=yes --quiet --error-exitcode=33 \
 	--suppressions=valgrind-suppressions --gen-suppressions=all \
 	--num-callers=16 --leak-check=yes --show-leak-kinds=definite \
-	--errors-for-leak-kinds=definite --trace-children-skip='*mock*,/bin*,/usr/bin/*,/usr/local/bin,*cockpit-bridge,*cockpit-stub'
+	--errors-for-leak-kinds=definite --trace-children-skip='*mock*,/bin*,/usr/bin/*,/usr/local/bin,*cockpit-stub'
 VALGRIND_SUPPRESSIONS = \
 	tools/gcrypt.supp \
 	tools/glib.supp \

--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -831,6 +831,7 @@ handle_package_checksum (CockpitWebServer *server,
 
   cockpit_web_response_content (response, out_headers, content, NULL);
   g_bytes_unref (content);
+  g_hash_table_unref (out_headers);
   return TRUE;
 }
 


### PR DESCRIPTION
Followup to #7748 to also memory-check `cockpit-stub`. Locally (on Fedora 27) this causes some errors, but let's see what the various CIs have to say.

Based on #7748, so land that first, or land only this and squash the first and third commit.