### PR TITLE
packagekit: Use shield icon for security updates

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -239,7 +239,7 @@ class UpdateItem extends React.Component {
         if (info.security) {
             security_info = (
                 <p>
-                    <span className="fa fa-bug security-label"> </span>
+                    <span className="fa fa-shield security-label">&nbsp;</span>
                     <span className="security-label-text">{ _("Security Update") + (info.cve_urls.length ? ": " : "") }</span>
                     { insertCommas(info.cve_urls.map(url => (
                         <a href={url} rel="noopener" referrerpolicy="no-referrer" target="_blank">


### PR DESCRIPTION
For consistency with other products that show errata/security issues.

Fixes #7745 

---

Now it looks like this:
![security-icon](https://user-images.githubusercontent.com/200109/30899246-6e9eb3da-a35f-11e7-95ed-1a633130ef61.png)

Note that I added an extra `&nbsp;`, as it looked rather crammed without (unlike with the bug icon).