### PR TITLE
login: Login on Enter on reuse checkbox

### DIFF
--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -457,11 +457,15 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                 id("login-password-input").focus();
         }, false);
 
-        id("login-password-input").addEventListener("keydown", function(e) {
+        var do_login = function(e) {
             login_failure(null);
             if (e.which == 13)
                 call_login();
-        });
+        };
+
+        id("login-password-input").addEventListener("keydown", do_login);
+        id("authorized-input").addEventListener("keydown", do_login);
+
         show_form();
         id("login-user-input").focus();
         phantom_checkpoint();


### PR DESCRIPTION
Currently:
    Hitting Enter in the 'User name' field moves on to the Password field.
    Hitting Enter in the Password field attempts to log in.
    Hitting Enter with the 'Reuse my password' checkbox focused does nothing.

This change makes hitting Enter on the checkbox attempt to log in to
match the password field behavior and to keep keyboard users from
needing to Tab back to the password field or Tab forward to the Log In
button to continue.