### PR TITLE
bots: Allow seeding of tests-data with already collected data

### DIFF
--- a/bots/tests-data
+++ b/bots/tests-data
@@ -269,7 +269,10 @@ def included(pull):
     cwd = os.path.dirname(__file__)
     base = pull["base"]["ref"]
     if base not in FETCHED:
-        subprocess.check_call([ "git", "fetch", "-q", "--", "origin", base ], cwd=cwd)
+        try:
+            subprocess.check_call([ "git", "fetch", "-q", "--", "origin", base ], cwd=cwd)
+        except subprocess.CalledProcessError:
+            return None # error already printed by process
         FETCHED[base] = base
 
     # Look for git commits up until a year before the pull request

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -55,7 +55,7 @@ def main():
     for pull in task.api.pulls(state=opts.open and "open" or "closed", since=since):
         if opts.verbose:
             sys.stderr.write("pull-{0}\n".format(pull["number"]))
-        merged = included(pull, since)
+        merged = included(pull)
         for revision in revisions(pull):
             if opts.verbose:
                 sys.stderr.write("- {0}\n".format(revision))
@@ -257,7 +257,7 @@ def tap(content):
 
 # Check if a given pull request was included in its base
 # branch via merging or otherwise
-def included(pull, since):
+def included(pull):
     if pull.get("state") != "closed":
         return None
 

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -35,11 +35,13 @@ sys.dont_write_bytecode = True
 import task
 
 BOTS = os.path.abspath(os.path.dirname(__file__))
+SEEDED = { }
 FETCHED = { }
 SINKS = { }
 
 def main():
     parser = argparse.ArgumentParser(description="Pull out test data for pull requests")
+    parser.add_argument("--seed", action="store", help="Seed with existing data")
     parser.add_argument("--open", action="store_true", help="Pull data on open pull requests")
     parser.add_argument("--since", help="Since a given ISO-8601 date")
     parser.add_argument("-z", "--gzip", action="store_true", help="Compress input and output")
@@ -63,8 +65,14 @@ def main():
         sys.stdout.flush()
         sys.stdout = gzip.GzipFile(fileobj=sys.stdout, mode='wb')
 
+    # Seed with our input data
+    if opts.seed:
+        seed(opts.seed, opts.gzip, since)
+
     # Now start the process
     for pull in task.api.pulls(state=opts.open and "open" or "closed", since=since):
+        if pull["number"] in SEEDED:
+            continue
         if opts.verbose:
             sys.stderr.write("pull-{0}\n".format(pull["number"]))
         merged = included(pull)
@@ -128,6 +136,35 @@ def links(url):
     except urllib2.URLError:
         sys.stderr.write("{0}: {1}\n".format(url, ex))
     return result
+
+# Parses seed input data and passes it through to output
+# all the while preparing the fact that certain URLs have
+# already been seen
+def seed(filename, compress=False, since=None):
+    seeded = None
+    with (compress and gzip.open or open)(filename, 'rb') as fp:
+        while True:
+            line = fp.readline()
+            if not line:
+                break
+            try:
+                item = json.loads(line)
+            except ValueError, ex:
+                sys.stderr.write("{0}: {1}\n".format(filename, ex))
+                continue
+
+            # Once we see a new pull treat the old one as complete and seeded
+            # As a failsafe, just to make sure we didn't miss something
+            # wo don't treat the last pull request as completely seeded
+            pull = item.get("pull")
+            if pull != seeded:
+                SEEDED[pull] = True
+                seeded = pull
+
+            date = item.get("date")
+            if date and since < time.mktime(time.strptime(date, "%Y-%m-%dT%H:%M:%SZ")):
+                sys.stdout.write(line)
+                sys.stdout.flush()
 
 # Generates revisions for a given pull request. Each revision
 # is a simple string sha. The first one is the one that is at

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -19,6 +19,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
+import gzip
 import json
 import os
 import sys
@@ -41,17 +42,28 @@ def main():
     parser = argparse.ArgumentParser(description="Pull out test data for pull requests")
     parser.add_argument("--open", action="store_true", help="Pull data on open pull requests")
     parser.add_argument("--since", help="Since a given ISO-8601 date")
+    parser.add_argument("-z", "--gzip", action="store_true", help="Compress input and output")
     parser.add_argument("-v", "--verbose", action="store_true", help="Show verbose progress")
     opts = parser.parse_args()
 
+    # Parse the input date
     since = opts.since
     try:
         if since is not None:
             since = time.mktime(time.strptime(opts.since, "%Y-%m-%d"))
     except ValueError:
         sys.stderr.write("tests-data: invalid since date: {0}\n".format(since))
-        sys.exit(2)
+        return 2
 
+    # Compress the output if so
+    if opts.gzip:
+        if os.isatty(1):
+            sys.stderr.write("tests-data: refusing to compress to stdout")
+            return 2
+        sys.stdout.flush()
+        sys.stdout = gzip.GzipFile(fileobj=sys.stdout, mode='wb')
+
+    # Now start the process
     for pull in task.api.pulls(state=opts.open and "open" or "closed", since=since):
         if opts.verbose:
             sys.stderr.write("pull-{0}\n".format(pull["number"]))
@@ -75,11 +87,13 @@ def main():
                         "log": body
                     }))
                     sys.stdout.write("\n")
+                    sys.stdout.flush()
             # The next revisions for the pull request are not the ones
             # that got merged. Only the first one produced by revisions
             if merged:
                 merged = False
 
+    sys.stdout.flush()
 
 # An HTML parser that just pulls out all the <a href="...">
 # link hrefs in a given page of content. We also qualify these


### PR DESCRIPTION
Since one run of 30 days of test data is not enough to effectively train a neural network, we need to gather it more progressively.
    
Add a ```--seed``` argument to support this.
