### PR TITLE
package.json: Move to Babel 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     "phantomjs-prebuilt": "~2.1.14"
   },
   "devDependencies": {
-    "babel-core": "~5.8.38",
-    "babel-loader": "~5.4.2",
+    "babel-core": "^6.26.0",
     "babel-eslint": "~7.1.1",
+    "babel-loader": "^6.4.1",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
     "clean-css": "~3.4.20",
     "copy-webpack-plugin": "~3.0.1",
     "css-loader": "~0.23.1",
@@ -65,5 +67,11 @@
     "style-loader": "~0.13.1",
     "uglify-js": "~2.6.2",
     "webpack": "~1.13.2"
+  },
+  "babel": {
+    "presets": [
+      "react",
+      "es2015"
+    ]
   }
 }


### PR DESCRIPTION
Babel 6.x moves transformations for various ECMAScript features and
standards into separate packages and allows us to more flexibly
configure which language features we need. For now, just use ES2015 and
React, like we had before with Babel 5.x.

--- 
This will soon become relevant for merging Welder, which uses post-ES2015 features such as object spreads and class properties. I'm trying to port the code away from those, but even if we do I think there's no harm in moving into this direction. Once we are there, we can even move further to the recommended [env preset](https://babeljs.io/docs/plugins/preset-env/) to avoid adding transformations for browsers which already support the features we need.
