### PR TITLE
tools: Prefer recent debhelper over obsolete dh-systemd

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Cockpit <cockpit@cockpit-project.org>
 Build-Depends: debhelper (>= 9.20141010),
-               dh-systemd,
+               debhelper (>= 9.20160709) | dh-systemd,
                dpkg-dev (>= 1.17.14),
                dh-autoreconf,
                autoconf,

--- a/tools/debian/source/lintian-overrides
+++ b/tools/debian/source/lintian-overrides
@@ -6,3 +6,6 @@ cockpit source: source-is-missing dist/*.js*
 cockpit source: source-is-missing pkg/kubernetes/scripts/test-images.js line length*
 # pkg/machines/include is symlink to node_components/noVNC/include and content is meant as downloadable resource at runtime
 cockpit source: source-is-missing pkg/machines/include/*
+# We prefer a newer debhelper which merged dh-systemd
+cockpit source: missing-build-dependency-for-dh_-command dh_systemd_start => dh-systemd
+cockpit source: missing-build-dependency-for-dh-addon systemd => dh-systemd


### PR DESCRIPTION
dh-systemd got absorbed into debhelper a while ago, and lintian now
starts to complain about the obsolete package:

    E: cockpit source: build-depends-on-obsolete-package build-depends: dh-systemd => use debhelper (>= 9.20160709)

Prefer a newer debhelper and don't install dh-systemd then, but keep it
as alternative build dependency for backportability to older
Debian/Ubuntu releases.

This will fix the image rebuild in PR #7800.