### PR TITLE
lib: Don't fix tooltip size too early

### DIFF
--- a/pkg/lib/cockpit-components-tooltip.jsx
+++ b/pkg/lib/cockpit-components-tooltip.jsx
@@ -87,7 +87,7 @@ var Tooltip = React.createClass({
                 return;
 
             // Stop resizing
-            if (!tip.style.width || !tip.style.height) {
+            if ((!tip.style.width || !tip.style.height) && tip.offsetWidth > 0) {
                 tip.style.width = tip.offsetWidth + "px";
                 tip.style.height = tip.offsetHeight + "px";
             }


### PR DESCRIPTION
If a tooltip is inserted into an invisible element (such as the
document body that is invisible while a page is initializing), it wont
be layouted at all and report size 0x0.  We shouldn't fix it to that
size but wait until it has a real size.