### PR TITLE
bots: Remove unused imports from task code

### DIFF
--- a/bots/task/test-github
+++ b/bots/task/test-github
@@ -28,7 +28,6 @@ import os
 import signal
 import shutil
 import socket
-import subprocess
 import sys
 import tempfile
 import time

--- a/bots/task/test-task
+++ b/bots/task/test-task
@@ -29,7 +29,6 @@ import os
 import signal
 import shutil
 import socket
-import subprocess
 import sys
 import tempfile
 import time


### PR DESCRIPTION
We don't use the subprocess import in either of these places.