### PR TITLE
machines: Add create vm dialog

### DIFF
--- a/pkg/lib/cockpit-components-select.jsx
+++ b/pkg/lib/cockpit-components-select.jsx
@@ -208,7 +208,6 @@
         );
     };
 
-
     SelectEntry.propTypes = {
         data: React.PropTypes.string.isRequired,
     };

--- a/pkg/machines/actions.es6
+++ b/pkg/machines/actions.es6
@@ -33,14 +33,18 @@ import { virt } from './provider.es6';
  * @param connectionName optional - if `undefined` then for all connections
  */
 export function getAllVms(connectionName) {
-    return virt('GET_ALL_VMS', {connectionName});
+    return virt('GET_ALL_VMS', { connectionName });
 }
 
 export function getVm(connectionName, lookupId) {
     return virt('GET_VM', {
         lookupId, // provider-specific (i.e. libvirt uses vm_name)
-        connectionName
+        connectionName,
     });
+}
+
+export function getOsInfoList() {
+    return virt('GET_OS_INFO_LIST');
 }
 
 export function shutdownVm(vm) {
@@ -65,6 +69,14 @@ export function startVm(vm) {
 
 export function deleteVm(vm, options) {
     return virt('DELETE_VM', { name: vm.name, id: vm.id, connectionName: vm.connectionName, options: options });
+}
+
+export function installVm(vm) {
+    return virt('INSTALL_VM', vm);
+}
+
+export function createVm(vmParams) {
+    return virt('CREATE_VM', vmParams);
 }
 
 export function vmDesktopConsole(vm, consoleDetail) {
@@ -122,30 +134,69 @@ export function delayPolling(action, timeout) {
 export function setProvider(provider) {
     return {
         type: 'SET_PROVIDER',
-        provider
+        provider,
     };
 }
 
 export function setRefreshInterval(refreshInterval) {
     return {
         type: 'SET_REFRESH_INTERVAL',
-        refreshInterval
+        refreshInterval,
     };
 }
 
 export function updateOrAddVm(props) {
     return {
         type: 'UPDATE_ADD_VM',
-        vm: props
+        vm: props,
     };
 }
 
 export function updateVm(props) {
     return {
         type: 'UPDATE_VM',
-        vm: props
+        vm: props,
     };
 }
+
+export function updateOsInfoList(osInfoList) {
+    return {
+        type: 'UPDATE_OS_INFO_LIST',
+        osInfoList,
+    };
+}
+
+export function vmCreateInProgress(vm) {
+    return {
+        type: 'VM_CREATE_IN_PROGRESS',
+        vm,
+    };
+}
+
+export function vmCreateCompleted(vm) {
+    return {
+        type: 'VM_CREATE_COMPLETED',
+        vm,
+    };
+}
+
+
+
+export function vmInstallInProgress(vm) {
+    return {
+        type: 'VM_INSTALL_IN_PROGRESS',
+        vm,
+    };
+}
+
+export function vmInstallCompleted(vm) {
+    return {
+        type: 'VM_INSTALL_COMPLETED',
+        vm,
+    };
+}
+
+
 
 export function vmActionFailed({ name, connectionName, message, detail, extraPayload }) {
     return {
@@ -156,7 +207,7 @@ export function vmActionFailed({ name, connectionName, message, detail, extraPay
             message,
             detail,
             extraPayload,
-        }
+        },
     };
 }
 
@@ -170,7 +221,7 @@ export function undefineVm(connectionName, name, transientOnly) {
         type: 'UNDEFINE_VM',
         name,
         connectionName,
-        transientOnly
+        transientOnly,
     };
 }
 
@@ -178,6 +229,6 @@ export function deleteUnlistedVMs(connectionName, vmNames) {
     return {
         type: 'DELETE_UNLISTED_VMS',
         vmNames,
-        connectionName
+        connectionName,
     };
 }

--- a/pkg/machines/app.jsx
+++ b/pkg/machines/app.jsx
@@ -21,13 +21,14 @@ import React from "react";
 import HostVmsList from "./hostvmslist.jsx";
 
 const App = ({ store }) => {
-    const { vms, config } = store.getState();
+    const { vms, config, osInfoList, ui } = store.getState();
     const dispatch = store.dispatch;
 
-    return (<HostVmsList vms={vms} config={config} dispatch={dispatch} />)
-}
+    // pass ui object
+    return (<HostVmsList vms={vms} config={config} osInfoList={osInfoList} ui={ui} dispatch={dispatch}/>);
+};
 App.propTypes = {
-    store: React.PropTypes.object.isRequired
-}
+    store: React.PropTypes.object.isRequired,
+};
 
 export default App;

--- a/pkg/machines/components/createVmDialog.jsx
+++ b/pkg/machines/components/createVmDialog.jsx
@@ -1,0 +1,440 @@
+/*jshint esversion: 6 */
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+import React, { PropTypes } from "react";
+import DialogPattern from 'cockpit-components-dialog.jsx';
+import Select from "cockpit-components-select.jsx";
+import FileAutoComplete from "../../lib/cockpit-components-file-autocomplete.jsx";
+import { createVm } from '../actions.es6';
+import {
+    digitFilter,
+    toFixedPrecision,
+    isEmpty,
+    convertToUnit,
+    timeoutedPromise,
+    units,
+} from "../helpers.es6";
+
+import {
+    NOT_SPECIFIED,
+    OTHER_OS_SHORT_ID,
+    DIVIDER_FAMILY,
+    prepareVendors,
+    getOSStringRepresentation,
+} from "./createVmDialogUtils.es6";
+
+import './createVmDialog.less';
+
+const _ = cockpit.gettext;
+
+const URL_SOURCE = 'url';
+const COCKPIT_FILESYSTEM_SOURCE = 'file';
+
+const WAIT_IF_SCRIPT_FAILS_WITH_ERROR = 3000; // 3s
+
+const MemorySelectRow = ({ label, id, value, initialUnit, onValueChange, onUnitChange }) => {
+    return (
+        <tr>
+            <td className="top">
+                <label className="control-label" htmlFor={id}>
+                    {label}
+                </label>
+            </td>
+            <td>
+                <div className="thirty-five-spaced-table">
+                    <span className="evenly-spaced-cell">
+                        <div className="evenly-spaced-table">
+                            <span className="evenly-spaced-cell">
+                                <input id={id} className="form-control"
+                                       type="number"
+                                       value={toFixedPrecision(value)}
+                                       onKeyPress={digitFilter}
+                                       step={1}
+                                       min={0}
+                                       onChange={onValueChange}/>
+                            </span>
+                            <span className="thirty-five-spaced-cell padding-left">
+                                <Select.Select id={id + "-unit-select"}
+                                               initial={initialUnit}
+                                               onChange={onUnitChange}>
+                                    <Select.SelectEntry data={units.MiB.name} key={units.MiB.name}>
+                                        {_("MiB")}
+                                    </Select.SelectEntry>
+                                    <Select.SelectEntry data={units.GiB.name} key={units.GiB.name}>
+                                        {_("GiB")}
+                                    </Select.SelectEntry>
+                                </Select.Select>
+                            </span>
+                        </div>
+                     </span>
+                </div>
+            </td>
+        </tr>
+    );
+};
+
+
+/* Create a virtual machine
+ * props:
+ *  - valuesChanged callback for changed values with the signature (key, value)
+ */
+class CreateVM extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            vendor: props.vmParams.vendor,
+            os: props.vmParams.os,
+            memorySize: convertToUnit(props.vmParams.memorySize, units.MiB, units.GiB), // tied to Unit
+            memorySizeUnit: units.GiB.name,
+            storageSize: props.vmParams.storageSize, // tied to Unit
+            storageSizeUnit: units.GiB.name,
+            sourceType: props.vmParams.sourceType,
+        };
+    }
+
+    onChangedEventValue(key, e) {
+        if (e && e.target && typeof(e.target.value) !== 'undefined') {
+            this.onChangedValue(key, e.target.value);
+        }
+    }
+
+    onChangedEventChecked(key, e) {
+        if (e && e.target && typeof(e.target.checked) === "boolean") {
+            this.onChangedValue(key, e.target.checked);
+        }
+    }
+
+    onChangedValue(key, value, valueParams) {
+        const notifyValuesChanged = (key, value) => {
+            if (this.props.valuesChanged) {
+                this.props.valuesChanged(key, value);
+            }
+        };
+
+        switch (key) {
+            case 'vendor': {
+                const os = this.props.vendorMap[value][0].shortId;
+                this.setState({
+                    [key]: value,
+                    os,
+                });
+                notifyValuesChanged('os', os);
+                break;
+            }
+            case 'os':
+                this.setState({ [key]: value });
+                break;
+            case 'source':
+                if (valueParams) {
+                    notifyValuesChanged('error', valueParams.error);
+                }
+                break;
+            case 'sourceType':
+                this.setState({ [key]: value });
+                notifyValuesChanged('source', null);
+                notifyValuesChanged('error', null);
+                break;
+            case 'memorySize':
+                this.setState({ [key]: value });
+                value = convertToUnit(value, this.state.memorySizeUnit, units.MiB);
+                break;
+            case 'storageSize':
+                this.setState({ [key]: value });
+                value = convertToUnit(value, this.state.storageSizeUnit, units.GiB);
+                break;
+            case 'memorySizeUnit':
+                this.setState({ [key]: value });
+                value = convertToUnit(this.state.memorySize, value, units.MiB);
+                key = 'memorySize';
+                break;
+            case 'storageSizeUnit':
+                this.setState({ [key]: value });
+                value = convertToUnit(this.state.storageSize, value, units.GiB);
+                key = 'storageSize';
+                break;
+            default:
+                break;
+        }
+
+        notifyValuesChanged(key, value);
+    }
+
+    render() {
+        const vendorSelectEntries = [];
+
+        if (this.props.familyMap[DIVIDER_FAMILY]) {
+            vendorSelectEntries.push((
+                <Select.SelectEntry data={NOT_SPECIFIED} key={NOT_SPECIFIED}>{_(NOT_SPECIFIED)}</Select.SelectEntry>));
+            vendorSelectEntries.push((<Select.SelectDivider/>));
+        }
+
+        this.props.familyList.forEach(({ family, vendors }) => {
+            if (family === DIVIDER_FAMILY) {
+                return;
+            }
+            vendorSelectEntries.push((<Select.SelectHeader>{family}</Select.SelectHeader>));
+
+            vendors.forEach((vendor) => {
+                vendorSelectEntries.push((
+                    <Select.SelectEntry data={vendor} key={vendor}>{vendor}</Select.SelectEntry>));
+            });
+        });
+
+        const osEntries = (
+            this.props.vendorMap[this.state.vendor]
+                .map(os => (<Select.SelectEntry data={os.shortId}
+                                                key={os.shortId}>{getOSStringRepresentation(os)}</Select.SelectEntry>))
+        );
+
+        let installationSource;
+        let installationSourceId;
+        switch (this.state.sourceType) {
+            case COCKPIT_FILESYSTEM_SOURCE:
+                installationSourceId="source-file";
+                installationSource = (
+                    <FileAutoComplete.FileAutoComplete id={installationSourceId}
+                                                       placeholder={_("Path to ISO file on host's file system")}
+                                                       onChange={this.onChangedValue.bind(this, 'source')}/>
+                );
+                break;
+            case URL_SOURCE:
+            default:
+                installationSourceId="source-url";
+                installationSource = (
+                    <input id={installationSourceId} className="form-control"
+                           type="text"
+                           minLength={1}
+                           placeholder={_("Remote URL")}
+                           value={this.props.vmParams.source}
+                           onChange={this.onChangedEventValue.bind(this, 'source')}/>
+                );
+                break;
+        }
+
+
+        return (
+            <div className="modal-body modal-dialog-body-table">
+                <table className="form-table-ct">
+                    <tr>
+                        <td className="top">
+                            <label className="control-label" htmlFor="vm-name">
+                                {_("Name")}
+                            </label>
+                        </td>
+                        <td>
+                            <input id="vm-name" className="form-control" type="text" minLength={1}
+                                   value={this.props.vmParams.vmName}
+                                   onChange={this.onChangedEventValue.bind(this, 'vmName')}/>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td className="top">
+                            <label className="control-label" htmlFor="source-type">
+                                {_("Installation Source Type")}
+                            </label>
+                        </td>
+                        <td>
+                            <Select.Select id="source-type"
+                                           initial={this.state.sourceType}
+                                           onChange={this.onChangedValue.bind(this, 'sourceType')}>
+                                <Select.SelectEntry data={COCKPIT_FILESYSTEM_SOURCE}
+                                                    key={COCKPIT_FILESYSTEM_SOURCE}>{_("Filesystem")}</Select.SelectEntry>
+                                <Select.SelectEntry data={URL_SOURCE} key={URL_SOURCE}>{_("URL")}</Select.SelectEntry>
+                            </Select.Select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td className="top">
+                            <label className="control-label" htmlFor={installationSourceId}>
+                                {_("Installation Source")}
+                            </label>
+                        </td>
+                        <td>
+                            {installationSource}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td className="top">
+                            <label className="control-label" htmlFor="vendor-select">
+                                {_("OS Vendor")}
+                            </label>
+                        </td>
+                        <td>
+                            <Select.Select id="vendor-select"
+                                           initial={this.state.vendor}
+                                           onChange={this.onChangedValue.bind(this, 'vendor')}>
+                                {vendorSelectEntries}
+                            </Select.Select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td className="top">
+                            <label className="control-label" htmlFor="vendor-select">
+                                {_("Operating System")}
+                            </label>
+                        </td>
+                        <td>
+                            <Select.StatelessSelect id="system-select"
+                                                    selected={this.state.os}
+                                                    onChange={this.onChangedValue.bind(this, 'os')}>
+                                {osEntries}
+                            </Select.StatelessSelect>
+                        </td>
+                    </tr>
+                    <MemorySelectRow label={_("Memory")}
+                                     id={"memory-size"}
+                                     value={this.state.memorySize}
+                                     initialUnit={this.state.memorySizeUnit}
+                                     onValueChange={this.onChangedEventValue.bind(this, 'memorySize')}
+                                     onUnitChange={this.onChangedValue.bind(this, 'memorySizeUnit')}/>
+                    <MemorySelectRow label={_("Storage Size")}
+                                     id={"storage-size"}
+                                     value={this.state.storageSize}
+                                     initialUnit={this.state.storageSizeUnit}
+                                     onValueChange={this.onChangedEventValue.bind(this, 'storageSize')}
+                                     onUnitChange={this.onChangedValue.bind(this, 'storageSizeUnit')}/>
+                    <tr>
+                        <td className="top">
+                            <label className="control-label" htmlFor="start-vm">
+                                {_("Immediately Start VM")}
+                            </label>
+                        </td>
+                        <td>
+                            <input id="start-vm" className="form-control dialog-checkbox" type="checkbox"
+                                   checked={this.props.vmParams.startVm}
+                                   onChange={this.onChangedEventChecked.bind(this, 'startVm')}/>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        );
+    }
+}
+
+CreateVM.propTypes = {
+    valuesChanged: PropTypes.func.isRequired,
+    vmParams: PropTypes.object.isRequired,
+    vendorMap: PropTypes.object.isRequired,
+    familyMap: PropTypes.object.isRequired,
+    familyList: PropTypes.array.isRequired,
+};
+
+function validateParams(vmParams) {
+    if (isEmpty(vmParams.vmName)) {
+        return _("Name should not be empty");
+    }
+
+    vmParams.vmName = vmParams.vmName.trim();
+    if (isEmpty(vmParams.vmName)) {
+        return _("Name should not consist of empty characters only");
+    }
+
+    if (vmParams.error) {
+        return vmParams.error;
+    }
+
+    vmParams.source = vmParams.source ? vmParams.source.trim() : null;
+    if (!isEmpty(vmParams.source)) {
+        switch (vmParams.sourceType) {
+            case COCKPIT_FILESYSTEM_SOURCE:
+                if (!vmParams.source.startsWith("/")) {
+                    return _("Invalid filename");
+                }
+                break;
+            case URL_SOURCE:
+            default:
+                if (!vmParams.source.startsWith("http") &&
+                    !vmParams.source.startsWith("ftp") &&
+                    !vmParams.source.startsWith("nfs")) {
+                    return _("Source should start with http, ftp or nfs protocol");
+                }
+                break;
+        }
+        if (vmParams.source === "/") {
+            vmParams.source = null;
+        }
+    }
+
+    if (isEmpty(vmParams.source)){
+      return _("Installation Source should not be empty");
+    }
+
+    if (vmParams.memorySize <= 0) {
+        return _("Memory should be positive number");
+    }
+
+    if (vmParams.storageSize < 0) {
+        return _("Storage Size should not be negative number");
+    }
+}
+
+export const createVmDialog = (dispatch, osInfoList) => {
+    const vmParams = {
+        'vmName': null,
+        "sourceType": COCKPIT_FILESYSTEM_SOURCE,
+        'source': null,
+        'vendor': NOT_SPECIFIED,
+        "os": OTHER_OS_SHORT_ID,
+        'memorySize': 1024, // MiB
+        'storageSize': 10, // GiB
+        'startVm': false,
+        'error': null,
+    };
+
+    const changeParams = (key, value) => {
+        vmParams[key] = value;
+    };
+
+    const vendors = prepareVendors(osInfoList);
+
+    const dialogBody = (
+        <CreateVM vmParams={vmParams}
+                  familyList={vendors.familyList}
+                  familyMap={vendors.familyMap}
+                  vendorMap={vendors.vendorMap}
+                  valuesChanged={changeParams}/>
+    );
+
+    const dialogProps = {
+        'title': _("Create New Virtual Machine"),
+        'body': dialogBody,
+    };
+
+    // also test modifying properties in subsequent render calls
+    const footerProps = {
+        'actions': [
+            {
+                'clicked': () => {
+                    const error = validateParams(vmParams);
+                    if (error) {
+                        return cockpit.defer().reject(error).promise;
+                    } else {
+                        return timeoutedPromise(dispatch(createVm(vmParams)), WAIT_IF_SCRIPT_FAILS_WITH_ERROR);
+                    }
+                },
+                'caption': _("Create"),
+                'style': 'primary',
+            },
+        ],
+    };
+
+    DialogPattern.show_modal_dialog(dialogProps, footerProps);
+};

--- a/pkg/machines/components/createVmDialog.less
+++ b/pkg/machines/components/createVmDialog.less
@@ -1,0 +1,59 @@
+.bootstrap-select:not([class*=col-]):not([class*=form-control]):not(.input-group-btn) {
+    width: 100%;
+    padding-bottom: 1px;
+}
+
+.input-group {
+    width: 100%;
+}
+
+.evenly-spaced-table {
+    display: table;
+    width: 100%;
+}
+
+.thirty-five-spaced-table {
+    display: table;
+    width: 35%;
+}
+
+.evenly-spaced-cell {
+    display: table-cell;
+    vertical-align: middle;
+    text-align: center;
+}
+
+.thirty-five-spaced-cell {
+    display: table-cell;
+    vertical-align: middle;
+    text-align: center;
+    width: 35%;
+    max-width: 35%;
+}
+
+.padding-left {
+    padding-left: 0.5em;
+}
+
+.td-child {
+    color: #888888;
+}
+
+.dialog-checkbox {
+    width: 26px;
+    margin: 0;
+}
+
+#vendor-select .dropdown-header,
+#vendor-select .divider {
+    margin-top: 2ex;
+}
+
+/* Make the max-height based on the screen hight - offset from the top */
+#vendor-select .dropdown-menu {
+    max-height: ~"calc(90vh - 50px - 8em)";
+}
+
+#system-select .dropdown-menu {
+    max-height: ~"calc(90vh - 50px - 10em)";
+}

--- a/pkg/machines/components/createVmDialogUtils.es6
+++ b/pkg/machines/components/createVmDialogUtils.es6
@@ -1,0 +1,233 @@
+/*jshint esversion: 6 */
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+    getTodayYearShifted,
+} from "../helpers.es6";
+
+export const OTHER_OS = "Other OS";
+export const OTHER_OS_SHORT_ID = "other-os";
+export const NOT_SPECIFIED = "Unspecified";
+export const DIVIDER_FAMILY = "Divider";
+
+const LINUX = 'linux';
+const WINDOWS = 'windows';
+const BSD = 'bsd';
+
+const IGNORE_VENDORS = ['ALTLinux', 'Mandriva', 'GNOME Project'];
+
+const ACCEPT_RELEASE_DATES_AFTER = getTodayYearShifted(-3);
+const ACCEPT_EOL_DATES_AFTER = getTodayYearShifted(-1);
+
+
+export function getOSStringRepresentation(os) {
+    let appendix = '';
+
+    if (os.version && !os.name.includes(os.version)) {
+        appendix += os.version;
+    }
+    if (os.codename) {
+        appendix += (appendix ? ' ' : '') + os.codename;
+    }
+    if (appendix) {
+        appendix = ` (${appendix})`;
+    }
+
+    return `${os.name}${appendix}`;
+}
+
+export function prepareVendors(osInfoList) {
+    const familyMap = {};
+    const vendorMap = {};
+
+    osInfoList = [...osInfoList];
+    osInfoList.push({
+        'shortId': OTHER_OS_SHORT_ID,
+        'name': OTHER_OS,
+        'version': null,
+        'family': DIVIDER_FAMILY,
+        'vendor': NOT_SPECIFIED,
+    });
+
+    osInfoList.forEach(os => {
+        os.sort_family = os.family;
+        os.sort_vendor = os.vendor;
+
+        if (os.version) {
+            os.version = os.version.trim();
+        }
+
+        correctSpecialCases(os);
+
+        // filter old linux distros
+        if (os.sort_family === LINUX &&
+            (IGNORE_VENDORS.includes(os.sort_vendor) || filterReleaseEolDates(os))) {
+            return;
+        }
+
+        if (!familyMap[os.sort_family]) {
+            familyMap[os.sort_family] = {};
+        }
+
+        if (!(vendorMap[os.sort_vendor] instanceof Array)) {
+            vendorMap[os.sort_vendor] = [];
+            familyMap[os.sort_family][os.sort_vendor] = null;
+        }
+        vendorMap[os.sort_vendor].push(os);
+
+    });
+
+    Object.keys(vendorMap)
+        .forEach(vendor => {
+            // distro sort
+            vendorMap[vendor] = vendorMap[vendor].sort((a, b) => {
+                if (!a.sortByVersionOnly) {
+                    const result = compareDates(a.releaseDate, b.releaseDate, true); // sort by release date
+                    if (result) {
+                        return result;
+                    }
+                }
+
+                return (b.version + "").localeCompare(a.version, undefined, { // then sort by version
+                    numeric: true,
+                    sensitivity: 'base',
+                });
+            });
+        });
+
+
+    const familyList = Object.keys(familyMap)
+        .sort((a, b) => {
+            // families sort
+            return customVendorSort(a, b) || a.localeCompare(b);
+        }).map(family => {
+            // vendor sort
+            const vendorMap = familyMap[family];
+            const vendors = Object.keys(vendorMap).sort(window.localeCompare);
+            return {family, vendors};
+        });
+
+    return {familyList, familyMap, vendorMap};
+}
+
+function filterReleaseEolDates(os) {
+    return !(!os.releaseDate && !os.eolDate) && // presume rolling release
+        compareDates(ACCEPT_RELEASE_DATES_AFTER, os.releaseDate) < 0 && // if release/eol dates less than accepted dates
+        compareDates(ACCEPT_EOL_DATES_AFTER, os.eolDate) < 0; // empty date is also less than accepted date
+}
+
+function compareDates(a, b, emptyFirst = false) {
+    if (!a) {
+        if (!b) {
+            return 0;
+        }
+        return emptyFirst ? -1 : 1;
+    }
+    if (!b) {
+        return emptyFirst ? 1 : -1;
+    }
+
+    return new Date(b).getTime() - new Date(a).getTime();
+}
+
+function customVendorSort(a, b) {
+    if (a === LINUX) {
+        return -1;
+    }
+    if (b === LINUX) {
+        return 1;
+    }
+    if (a === WINDOWS) {
+        return -1;
+    }
+    if (b === WINDOWS) {
+        return 1;
+    }
+    return 0;
+}
+
+function correctSpecialCases(os) {
+    // windows
+    if (os.sort_family.toLowerCase().startsWith('win') || os.sort_family.toLowerCase() === 'msdos') {
+        os.sort_family = WINDOWS;
+    }
+
+    if (os.sort_vendor.toLowerCase().startsWith('microsoft')) {
+        os.sort_vendor = 'Microsoft Corporation';
+    }
+
+    if (os.shortId === 'win8') {
+        os.releaseDate = '2012-08-01';
+    }
+
+    if (os.shortId === 'win8.1') {
+        os.releaseDate = '2014-04-08';
+    }
+
+    if (os.shortId === 'msdos6.22') {
+        os.releaseDate = '1994-06-01';
+    }
+
+    // linux
+    if (os.shortId.toLowerCase().includes('centos7')) {
+        os.eolDate = '2024-06-30';
+    }
+
+    if (os.sort_vendor.toLowerCase() === 'centos' || os.sort_vendor.toLowerCase() === 'suse') {
+        os.sortByVersionOnly = true;
+    }
+
+    // bsd
+    if (os.sort_family.toLowerCase().includes(BSD)) {
+        os.sort_family = BSD;
+    }
+
+    if (os.shortId === 'freebsd2.2.9') {
+        os.releaseDate = '2006-04-01'; // april fools prank
+    }
+
+    if (os.shortId === 'openbsd4.2') {
+        os.releaseDate = '2007-11-01';
+    }
+
+    if (os.shortId === 'openbsd4.3') {
+        os.releaseDate = '2008-05-01';
+    }
+
+    if (os.shortId === 'openbsd4.4') {
+        os.releaseDate = '2008-11-01';
+    }
+
+    if (os.shortId === 'openbsd4.5') {
+        os.releaseDate = '2009-05-01';
+    }
+
+    if (os.shortId === 'openbsd4.8') {
+        os.releaseDate = '2010-11-01';
+    }
+
+    if (os.shortId === 'openbsd4.9') {
+        os.releaseDate = '2011-05-01';
+    }
+
+    if (os.shortId === 'openbsd5.0') {
+        os.releaseDate = '2011-11-01';
+    }
+}

--- a/pkg/machines/components/vmdiskstab.jsx
+++ b/pkg/machines/components/vmdiskstab.jsx
@@ -20,7 +20,7 @@
 import React, { PropTypes } from 'react';
 import cockpit from 'cockpit';
 import { Listing, ListingRow } from 'cockpit-components-listing.jsx';
-import { toGigaBytes } from '../helpers.es6';
+import { convertToUnit, units, toReadableNumber } from '../helpers.es6';
 import InfoRecord from './infoRecord.jsx';
 import { Info } from './inlineNotification.jsx';
 
@@ -68,7 +68,7 @@ const StorageUnit = ({ value, id }) => {
 
     return (
         <div id={id}>
-            {toGigaBytes(value, 'B')}&nbsp;{_("GB")}
+            {toReadableNumber(convertToUnit(value, units.B, units.GiB))}&nbsp;{_("GiB")}
         </div>
     );
 };

--- a/pkg/machines/libvirtUtils.es6
+++ b/pkg/machines/libvirtUtils.es6
@@ -1,0 +1,80 @@
+/*jshint esversion: 6 */
+
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+function prepareParams(objectData, valueTransformer) {
+    let result = '';
+    let startLine = true;
+    Object.keys(objectData).forEach((key) => {
+        const options = valueTransformer(objectData[key]);
+
+        Object.keys(options).forEach((optionKey) => {
+            const option = options[optionKey];
+            if (option) {
+                result += (startLine) ? `${optionKey}=${option}` : `,${optionKey}=${option}`;
+                if (startLine) {
+                    startLine = false;
+                }
+            }
+        });
+        result += '\n';
+        startLine = true;
+    });
+
+    return result;
+}
+
+export function prepareDisplaysParam(displays) {
+    return prepareParams(displays, display => {
+        return {
+            type: display.type,
+            listen: display.address,
+            port: display.port,
+            tlsport: display.tlsPort,
+        };
+    });
+}
+
+export function prepareDisksParam(disks) {
+    const isVolume = (disk) => disk.source.volume && disk.source.pool;
+    const getVolume = (disk) => isVolume(disk) ? `${disk.source.pool}/${disk.source.volume}` : null;
+    const getPath = (disk) => isVolume(disk) ? null : disk.source.file;
+
+    return prepareParams(disks, disk => {
+        return {
+            path: getPath(disk),
+            vol: getVolume(disk),
+            device: disk.device,
+            boot_order: disk.bootOrder,
+            bus: disk.bus,
+            removable: disk.removable,
+            readonly: disk.readonly ? 'on' : 'off',
+            shareable: disk.shareable ? 'on' : 'off',
+            cache: disk.driver.cache,
+            discard: disk.driver.discard,
+            driver_name: disk.driver.name,
+            driver_type: disk.driver.type,
+            io: disk.driver.io,
+            error_policy: disk.driver.errorPolicy,
+            startup_policy: disk.source.startupPolicy,
+            // format: libvirt's format auto-detection
+        };
+    });
+}

--- a/pkg/machines/scripts/create_machine.sh
+++ b/pkg/machines/scripts/create_machine.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+
+set -u -o noglob
+VM_NAME="$1"
+SOURCE="$2"
+OS="$3"
+MEMORY_SIZE="$4" # in MiB
+STORAGE_SIZE="$5" # in GiB
+START_VM="$6"
+
+endIfFailed(){
+	if [ $1 -ne 0 ]; then
+	    rm -f "$XMLS_FILE"
+        exit $1
+    fi
+}
+
+# prepare virt-install parameters
+COMPARISON=$(awk 'BEGIN{ print "'$STORAGE_SIZE'"<=0 }')
+if [ "$COMPARISON" -eq 1 ]; then
+    # default to no disk if size 0
+    DISK_OPTIONS="none"
+else
+    DISK_OPTIONS="size=$STORAGE_SIZE,format=qcow2"
+fi
+
+GRAPHICS_PARAM="--graphics spice,listen=127.0.0.1 --graphics vnc,listen=127.0.0.1"
+
+if [ "$OS" = "other-os" -o  -z "$OS" ]; then
+    OS="auto"
+fi
+
+FIRST_1_SOURCE="`echo "$SOURCE" | cut -c 1`"
+FIRST_3_SOURCE="`echo "$SOURCE" | cut -c -3`"
+FIRST_4_SOURCE="`echo "$SOURCE" | cut -c -4`"
+
+if [ "$START_VM" = "true" -a "$FIRST_1_SOURCE" = "/" -a ! -f "$SOURCE" ]; then
+    echo "$SOURCE does not exist or is not a file" 1>&2
+    exit 1
+fi
+
+if [ "$START_VM" = "true" -a \( "$FIRST_1_SOURCE" = "/" -o "$FIRST_4_SOURCE" = "http" -o "$FIRST_3_SOURCE" = "ftp" -o "$FIRST_3_SOURCE" = "nfs" \) ]; then
+    LOCATION_PARAM="--cdrom $SOURCE"
+else
+    # prevents creating duplicate cdroms if start vm is false
+    # or if no source received
+    LOCATION_PARAM=""
+fi
+
+
+XMLS_FILE="`mktemp`"
+
+if [ "$START_VM" = "true" ]; then
+    STARTUP_PARAMS="--wait -1 --noautoconsole --noreboot"
+    HAS_INSTALL_PHASE="false"
+else
+    # 2 = last phase only
+    STARTUP_PARAMS="--print-xml"
+    HAS_INSTALL_PHASE="true"
+fi
+
+virt-install \
+    --name "$VM_NAME" \
+    --os-variant "$OS" \
+    --memory "$MEMORY_SIZE" \
+    --quiet \
+    --disk  "$DISK_OPTIONS" \
+    $STARTUP_PARAMS \
+    $LOCATION_PARAM \
+    $GRAPHICS_PARAM \
+> "$XMLS_FILE"
+
+endIfFailed $?
+
+# add metadata to domain
+
+if [ "$START_VM" = "true" ]; then
+    virsh -q dumpxml "$VM_NAME" > "$XMLS_FILE"
+fi
+
+# LAST STEP ONLY - virt-install can output 1 or 2 steps
+DOMAIN_MATCHES=`grep -n '</domain>' "$XMLS_FILE"`
+LAST_STEP=`echo "$DOMAIN_MATCHES" | wc -l`
+CURRENT_STEP=1
+START_LINE=1
+
+# go through all domains (line numbers) and increment steps
+echo "$DOMAIN_MATCHES"  |  sed 's/[^0-9]//g' | while read -r FINISH_LINE ; do
+        QUIT_LINE="`expr $FINISH_LINE + 1`"
+        # define only last step
+        if [ "$CURRENT_STEP" = "$LAST_STEP" ]; then
+            sed -n -i "$START_LINE"','"$FINISH_LINE"'p;'"$QUIT_LINE"'q' "$XMLS_FILE"
+            METADATA_LINE=`grep -n '</metadata>' "$XMLS_FILE" | sed 's/[^0-9]//g'`
+
+            METADATA='    <cockpit_machines:data xmlns:cockpit_machines="https://github.com/cockpit-project/cockpit/tree/master/pkg/machines"> \
+      <cockpit_machines:has_install_phase>'"$HAS_INSTALL_PHASE"'</cockpit_machines:has_install_phase> \
+      <cockpit_machines:install_source>'"$SOURCE"'</cockpit_machines:install_source> \
+      <cockpit_machines:os_variant>'"$OS"'</cockpit_machines:os_variant> \
+    </cockpit_machines:data>'
+
+            if [ -z "$METADATA_LINE"  ]; then
+                METADATA_LINE="`cat "$XMLS_FILE" | wc -l`"
+                METADATA='\ \ <metadata> \
+'"$METADATA"' \
+  </metadata>'
+            fi
+
+            #inject metadata, and define
+            sed "$METADATA_LINE""i $METADATA" "$XMLS_FILE" | virsh -q define /dev/stdin
+            endIfFailed $?
+        else
+            START_LINE="$QUIT_LINE"
+            CURRENT_STEP="`expr $CURRENT_STEP + 1`"
+        fi
+done
+
+rm -f "$XMLS_FILE"

--- a/pkg/machines/scripts/get_os_list.sh
+++ b/pkg/machines/scripts/get_os_list.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# sed strips spaces at the end, the beginning and spaces around '|'
+osinfo-query os --fields=short-id,name,version,family,vendor,release-date,eol-date,codename | tail -n +3 | sed -e 's/\s*|\s*/|/g; s/^\s*//g; s/\s*$//g'

--- a/pkg/machines/scripts/install_machine.sh
+++ b/pkg/machines/scripts/install_machine.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+
+set -u -o noglob
+
+VM_NAME="$1"
+SOURCE="$2"
+OS="$3"
+MEMORY_SIZE="$4" # in Mib
+VCPUS="$5"
+DISKS="$6"
+DISPLAYS="$7"
+
+# prepare virt-install parameters
+
+createOptions(){
+    CREATE_OPTIONS_RESULT=""
+	while IFS= read -r PARAM
+    do
+       if [ -n "$PARAM" ]; then
+           CREATE_OPTIONS_RESULT="${CREATE_OPTIONS_RESULT} $2 $PARAM"
+       fi
+    done << EOF
+    $1
+EOF
+}
+
+if [ -z "$OS" ]; then
+    OS="auto"
+fi
+
+if [ -z "$DISKS" ]; then
+    DISKS_PARAM="--disk none"
+else
+    createOptions "$DISKS" "--disk"
+    DISKS_PARAM="$CREATE_OPTIONS_RESULT"
+fi
+
+if [ -z "$DISPLAYS" ]; then
+    GRAPHICS_PARAM="--graphics none"
+else
+    createOptions "$DISPLAYS" "--graphics"
+    GRAPHICS_PARAM="$CREATE_OPTIONS_RESULT"
+fi
+
+FIRST_1_SOURCE="`echo "$SOURCE" | cut -c 1`"
+FIRST_3_SOURCE="`echo "$SOURCE" | cut -c -3`"
+FIRST_4_SOURCE="`echo "$SOURCE" | cut -c -4`"
+
+if [ "$FIRST_1_SOURCE" = "/" -a ! -f "$SOURCE" ]; then
+    echo "$SOURCE does not exist or is not a file" 1>&2
+    exit 1
+fi
+
+if [ "$FIRST_1_SOURCE" = "/" -o "$FIRST_4_SOURCE" = "http" -o "$FIRST_3_SOURCE" = "ftp" -o "$FIRST_3_SOURCE" = "nfs" ]; then
+    LOCATION_PARAM="--cdrom $SOURCE"
+else
+    LOCATION_PARAM=""
+fi
+
+# backup
+DOMAIN_FILE="`mktemp`"
+
+virsh -q destroy "$VM_NAME" 2>/dev/null
+virsh -q dumpxml "$VM_NAME" > "$DOMAIN_FILE"
+virsh -q undefine "$VM_NAME" --managed-save
+
+virt-install \
+    --name "$VM_NAME" \
+    --os-variant "$OS" \
+    --memory "$MEMORY_SIZE" \
+    --vcpus "$VCPUS" \
+    --quiet \
+    --wait -1 \
+    --noautoconsole \
+    --noreboot \
+    $DISKS_PARAM \
+    $LOCATION_PARAM \
+    $GRAPHICS_PARAM
+EXIT_STATUS=$?
+
+if [ "$EXIT_STATUS" -eq 0 ]; then
+    # set metadata
+    virsh -q dumpxml "$VM_NAME" > "$DOMAIN_FILE"
+    METADATA_LINE=`grep -n '</metadata>' "$DOMAIN_FILE" | sed 's/[^0-9]//g'`
+    METADATA='    <cockpit_machines:data xmlns:cockpit_machines="https://github.com/cockpit-project/cockpit/tree/master/pkg/machines"> \
+      <cockpit_machines:has_install_phase>false</cockpit_machines:has_install_phase> \
+      <cockpit_machines:install_source>'"$SOURCE"'</cockpit_machines:install_source> \
+      <cockpit_machines:os_variant>'"$OS"'</cockpit_machines:os_variant> \
+    </cockpit_machines:data>'
+
+    if [ -z "$METADATA_LINE"  ]; then
+        METADATA_LINE="`cat "$DOMAIN_FILE" | wc -l`"
+        METADATA='\ \ <metadata> \
+'"$METADATA"' \
+  </metadata>'
+    fi
+
+    #inject metadata, and define
+    sed "$METADATA_LINE""i $METADATA" "$DOMAIN_FILE" | virsh -q define /dev/stdin
+    rm -f "$DOMAIN_FILE"
+else
+    # return back if failed
+    if virsh list --all | awk  '{print $2}' | grep -q --line-regexp --fixed-strings "$VM_NAME"; then
+        # undefine if the domain was created but still failed
+        virsh -q undefine "$VM_NAME" --managed-save
+    fi
+    virsh -q define "$DOMAIN_FILE"
+    rm -f "$DOMAIN_FILE"
+    exit 1
+fi

--- a/pkg/ovirt/components/App.jsx
+++ b/pkg/ovirt/components/App.jsx
@@ -36,7 +36,8 @@ const LoginInProgress = ({ ovirtConfig }) => {
     if (ovirtConfig && ovirtConfig.loginInProgress) {
         return (
             <p className='ovirt-login-in-progress'>
-                {_("oVirt login in progress")} <span className="spinner spinner-xs spinner-inline"></span>
+                {_("oVirt login in progress") + '\xa0'}
+                <span className="spinner spinner-xs spinner-inline"></span>
             </p>
         );
     }
@@ -88,15 +89,17 @@ const TopMenu = ({ ovirtConfig, router, dispatch }) => {
     );
 };
 
-const HostVmsListDecorated = ({ vms, config, dispatch, host }) => {
+const HostVmsListDecorated = ({ vms, config, osInfoList, ui, dispatch, host }) => {
     const actions = host && [hostToMaintenance({ dispatch, host })];
     return (
         <div className='container-fluid'>
             <HostStatus host={host}/>
             <HostVmsList vms={vms}
                          config={config}
+                         osInfoList={osInfoList}
+                         ui={ui}
                          dispatch={dispatch}
-                         actions={actions} />
+                         actions={actions}/>
         </div>
     );
 };
@@ -104,7 +107,7 @@ const HostVmsListDecorated = ({ vms, config, dispatch, host }) => {
 const App = ({ store }) => {
     const state = store.getState();
     const dispatch = store.dispatch;
-    const { vms, config } = state;
+    const { vms, config, osInfoList, ui }  = state;
 
     let ovirtConfig, hosts, router;
     if (config.providerState) {
@@ -129,7 +132,7 @@ const App = ({ store }) => {
             break;
         default:
             component = (
-                <HostVmsListDecorated vms={vms} config={config} dispatch={dispatch} host={host} />);
+                <HostVmsListDecorated vms={vms} config={config} osInfoList={osInfoList} ui={ui} dispatch={dispatch} host={host} />);
     }
 
     return (
@@ -141,6 +144,6 @@ const App = ({ store }) => {
 };
 App.propTypes = {
     store: React.PropTypes.object.isRequired
-}
+};
 
 export default App;

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -22,6 +22,7 @@ import parent
 from testlib import *
 
 import os
+import functools
 
 def readFile(name):
     content = ''
@@ -140,24 +141,30 @@ class TestMachines(MachineCase):
 
     def setUp(self):
         MachineCase.setUp(self)
+        self.startLibvirt()
 
         # enforce use of cockpit-machines instead of cockpit-machines-ovirt
         m = self.machine
         m.execute("sed -i 's/\"priority\".*$/\"priority\": 100,/' {0}".format("/usr/share/cockpit/machines/manifest.json"))
         m.execute("[ ! -e {0} ] || sed -i 's/\"priority\".*$/\"priority\": 0,/' {0}".format("/usr/share/cockpit/ovirt/manifest.json"))
 
+        self.allow_journal_messages('.*type=1400.*')
+
+    def startLibvirt(self):
+        m = self.machine
+        # Ensure everything has started correctly
+        m.execute("systemctl start libvirtd")
+        print(m.execute("date"))
+        # Wait until we can get a list of domains
+        wait(lambda: m.execute("virsh list"))
+        # Wait for the network 'default' to become active
+        wait(lambda: m.execute(command="virsh net-info default | grep Active"))
+
     def startVm(self, name, graphics='spice', ptyconsole=False):
         m = self.machine
 
         image_file = m.pull("cirros")
         m.add_disk(serial="NESTED", path=image_file, type="qcow2")
-
-        # Ensure everything has started correctly
-        m.execute("systemctl start libvirtd")
-        # Wait until we can get a list of domains
-        wait(lambda: m.execute("virsh list"))
-        # Wait for the network 'default' to become active
-        wait(lambda: m.execute(command="virsh net-info default | grep Active"))
         # Wait for the disk to be added
         wait(lambda: m.execute("ls -l /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_NESTED"))
 
@@ -218,6 +225,7 @@ class TestMachines(MachineCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
+        b.wait_present("tbody tr th")
         b.wait_in_text("tbody tr th", "subVmTest1")
 
         b.click("tbody tr th") # click on the row header
@@ -237,6 +245,7 @@ class TestMachines(MachineCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
+        b.wait_present("tbody tr th")
         b.wait_in_text("tbody tr th", "subVmTest1")
 
         b.click("tbody tr th") # click on the row header
@@ -308,9 +317,8 @@ class TestMachines(MachineCase):
 
         # restart libvirtd
         m.execute("systemctl stop libvirtd")
-        b.wait_present("#app .blank-slate-pf")
-        b.wait_visible("#app .blank-slate-pf")
-        b.wait_in_text("#app .blank-slate-pf", "No VM is running")
+        b.wait_present("thead tr td")
+        b.wait_in_text("thead tr td", "No VM is running")
         m.execute("systemctl start libvirtd")
         b.wait_present("#app .listing-ct tbody:nth-of-type(1) th")
         b.wait_in_text("#app .listing-ct tbody:nth-of-type(1) th", "subVmTest1")
@@ -372,6 +380,7 @@ class TestMachines(MachineCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
+        b.wait_present("tbody tr th")
         b.wait_in_text("tbody tr th", "subVmTest1")
 
         b.click("tbody tr th") # click on the row header
@@ -445,6 +454,7 @@ class TestMachines(MachineCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
+        b.wait_present("tbody tr th")
         b.wait_in_text("tbody tr th", "subVmTest1")
 
         b.click("tbody tr th") # click on the row header
@@ -463,7 +473,7 @@ class TestMachines(MachineCase):
 
         # Test add network
         m.execute("virsh attach-interface --domain subVmTest1 --type network --source default --model virtio --mac 52:54:00:4b:73:5f --config --live")
-        
+
         b.wait_present("#vm-subVmTest1-network-2-type")
         b.wait_in_text("#vm-subVmTest1-network-2-type", "network")
         b.wait_in_text("#vm-subVmTest1-network-2-source", "default")
@@ -480,6 +490,7 @@ class TestMachines(MachineCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
+        b.wait_present("tbody tr th")
         b.wait_in_text("tbody tr th", "subVmTest1")
 
         b.click("tbody tr th") # click on the row header
@@ -506,6 +517,7 @@ class TestMachines(MachineCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
+        b.wait_present("tbody tr th")
         b.wait_in_text("tbody tr th", "subVmTest1")
 
         b.click("tbody tr th") # click on the row header
@@ -534,6 +546,7 @@ class TestMachines(MachineCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
+        b.wait_present("tbody tr th")
         b.wait_in_text("tbody tr th", name)
 
         m.execute("test -f {0}".format(img2))
@@ -562,6 +575,7 @@ class TestMachines(MachineCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
+        b.wait_present("tbody tr th")
         b.wait_in_text("tbody tr th", name)
 
         b.click("tbody tr th") # click on the row header
@@ -600,6 +614,551 @@ class TestMachines(MachineCase):
             b.wait_present("div.terminal > div:contains(Connected)")
 
         # sit(self.machines)
+
+    def testCreate(self):
+        """
+        this test will print many expected error messages
+        """
+
+        runner = TestMachines.CreateVmRunner(self)
+        config = TestMachines.TestCreateConfig
+
+        self.login_and_go("/machines")
+        self.browser.wait_in_text("body", "Virtual Machines")
+
+        def checkVendorsLoadedInUi(dialog):
+            dialog.open()
+            has_vendor = dialog.hasVendor()
+            dialog.cancel()
+            return has_vendor
+
+        def cancelDialogTest(dialog):
+            dialog.open() \
+                .fill() \
+                .cancel(True)
+            runner.assertScriptFinished() \
+                .checkEnvIsEmpty()
+
+        def checkFilteredOsTest(dialog):
+            dialog.open() \
+                .checkOsOrVendorFiltered() \
+                .cancel(True)
+            runner.assertScriptFinished() \
+                .checkEnvIsEmpty()
+
+        def checkDialogErrorTest(dialog, error, ui_validation=True):
+            dialog.open() \
+                .fill() \
+                .createAndExpectError(error, ui_validation) \
+                .cancel(ui_validation)
+            runner.assertScriptFinished() \
+                .checkEnvIsEmpty()
+
+        def createTest(dialog):
+            runner.tryCreate(dialog) \
+                .assertScriptFinished() \
+                .deleteVm(dialog) \
+                .checkEnvIsEmpty()
+
+        def installWithErrorTest(dialog):
+            runner.tryInstallWithError(dialog) \
+                .assertScriptFinished() \
+                .deleteVm(dialog) \
+                .checkEnvIsEmpty()
+
+        # wait for os and vendors to load.
+        runner.assertOsInfoQueryFinished()
+        rhDialog = TestMachines.VmDialog(self, "loadVendors", os_vendor=config.REDHAT_VENDOR)
+        with self.browser.wait_timeout(10):
+            self.browser.wait(functools.partial(checkVendorsLoadedInUi, rhDialog))
+
+        runner.checkEnvIsEmpty()
+
+        # test just the DIALOG CREATION and cancel
+        print("    *\n    * validation errors and ui info/warn messages expected:\n    * ")
+        cancelDialogTest(TestMachines.VmDialog(self, "subVmTestCreate1", is_filesystem_location=True,
+                                               location=config.NOVELL_MOCKUP_ISO_PATH,
+                                               memory_size=1, memory_size_unit='MiB',
+                                               storage_size=12500, storage_size_unit='GiB',
+                                               os_vendor=config.UNSPECIFIED_VENDOR,
+                                               os_name=config.OTHER_OS,
+                                               start_vm=True))
+        cancelDialogTest(TestMachines.VmDialog(self, "subVmTestCreate2", is_filesystem_location=False,
+                                               location=config.VALID_URL,
+                                               memory_size=12654, memory_size_unit='GiB',
+                                               storage_size=0, storage_size_unit='MiB',
+                                               os_vendor=config.NOVELL_VENDOR,
+                                               os_name=config.NOVELL_NETWARE_4,
+                                               start_vm=False))
+
+        # check if older os are filtered
+        checkFilteredOsTest(TestMachines.VmDialog(self, "subVmTestCreate3", os_vendor=config.REDHAT_VENDOR,
+                                                  os_name=config.REDHAT_RHEL_4_7_FILTERED_OS))
+
+        checkFilteredOsTest(TestMachines.VmDialog(self, "subVmTestCreate4", os_vendor=config.MANDRIVA_FILTERED_VENDOR,
+                                                  os_name=config.MANDRIVA_2011_FILTERED_OS))
+
+        checkFilteredOsTest(TestMachines.VmDialog(self, "subVmTestCreate5", os_vendor=config.MAGEIA_VENDOR,
+                                                  os_name=config.MAGEIA_3_FILTERED_OS))
+
+        # try to CREATE WITH DIALOG ERROR
+
+        # name
+        checkDialogErrorTest(TestMachines.VmDialog(self, ""), "Name")
+
+        # location
+        checkDialogErrorTest(TestMachines.VmDialog(self, "subVmTestCreate7", is_filesystem_location=False,
+                                                   location="invalid/url",
+                                                   os_vendor=config.NOVELL_VENDOR,
+                                                   os_name=config.NOVELL_NETWARE_4), "Source")
+
+        # memory
+        checkDialogErrorTest(TestMachines.VmDialog(self, "subVmTestCreate8", location=config.NOVELL_MOCKUP_ISO_PATH,
+                                                   memory_size=100, memory_size_unit='GiB',
+                                                   storage_size=100, storage_size_unit='MiB',
+                                                   os_vendor=config.NOVELL_VENDOR,
+                                                   os_name=config.NOVELL_NETWARE_6,
+                                                   start_vm=True), "memory", ui_validation=False)
+
+        # disk
+        checkDialogErrorTest(TestMachines.VmDialog(self, "subVmTestCreate9", location=config.NOVELL_MOCKUP_ISO_PATH,
+                                                   storage_size=10000, storage_size_unit='GiB',
+                                                   os_vendor=config.NOVELL_VENDOR,
+                                                   os_name=config.NOVELL_NETWARE_6,
+                                                   start_vm=True), "space", ui_validation=False)
+
+        # start vm
+        checkDialogErrorTest(TestMachines.VmDialog(self, "subVmTestCreate10",
+                                                   os_vendor=config.NOVELL_VENDOR,
+                                                   os_name=config.NOVELL_NETWARE_6, start_vm=True),
+                             "Installation Source should not be empty", ui_validation=True)
+
+        # try to CREATE few machines
+        createTest(TestMachines.VmDialog(self, "subVmTestCreate11", is_filesystem_location=False,
+                                         location=config.VALID_URL,
+                                         storage_size=1,
+                                         os_vendor=config.MICROSOFT_VENDOR,
+                                         os_name=config.MICROSOFT_VISTA))
+
+        createTest(TestMachines.VmDialog(self, "subVmTestCreate12", is_filesystem_location=False,
+                                         location=config.VALID_URL,
+                                         memory_size=256, memory_size_unit='MiB',
+                                         storage_size=100, storage_size_unit='MiB',
+                                         os_vendor=config.MICROSOFT_VENDOR,
+                                         os_name=config.MICROSOFT_XP_OS,
+                                         start_vm=False))
+
+        createTest(TestMachines.VmDialog(self, "subVmTestCreate13", is_filesystem_location=False,
+                                         location=config.VALID_URL,
+                                         memory_size=900, memory_size_unit='GiB',
+                                         storage_size=100, storage_size_unit='MiB',
+                                         os_vendor=config.APPLE_VENDOR,
+                                         os_name=config.MACOS_X_TIGER,
+                                         start_vm=False))
+
+        createTest(TestMachines.VmDialog(self, "subVmTestCreate14", is_filesystem_location=True,
+                                         location=config.NOVELL_MOCKUP_ISO_PATH,
+                                         memory_size=256, memory_size_unit='MiB',
+                                         storage_size=0, storage_size_unit='MiB',
+                                         os_vendor=config.APPLE_VENDOR,
+                                         os_name=config.MACOS_X_TIGER,
+                                         start_vm=False))
+        # try to INSTALL WITH ERROR
+        installWithErrorTest(TestMachines.VmDialog(self, "subVmTestCreate15", is_filesystem_location=True,
+                                                   location=config.NOVELL_MOCKUP_ISO_PATH,
+                                                   memory_size=900, memory_size_unit='GiB',
+                                                   storage_size=10, storage_size_unit='MiB',
+                                                   os_vendor=config.APPLE_VENDOR,
+                                                   os_name=config.MACOS_X_LEOPARD))
+
+        # TODO: add use cases with start_vm=True and check that vm started
+        # - for install when creating vm
+        # - for create vm and then install
+        # see https://github.com/cockpit-project/cockpit/issues/8385
+
+        # console for try INSTALL
+        self.allow_journal_messages('.*connection.*')
+        self.allow_journal_messages('.*Connection.*')
+        self.allow_journal_messages('.*session closed.*')
+
+        runner.destroy()
+
+    class TestCreateConfig:
+        VALID_URL = 'http://mirror.i3d.net/pub/centos/7/os/x86_64/'
+        NOVELL_MOCKUP_ISO_PATH = '/tmp/novell.iso'
+        NOT_EXISTENT_PATH = '/tmp/not-existent.iso'
+
+        UNSPECIFIED_VENDOR = 'Unspecified'
+        OTHER_OS = 'Other OS'
+
+        NOVELL_VENDOR = 'Novell'
+        NOVELL_NETWARE_4 = 'Novell Netware 4'
+        NOVELL_NETWARE_5 = 'Novell Netware 5'
+        NOVELL_NETWARE_6 = 'Novell Netware 6'
+
+        OPENBSD_VENDOR = 'OpenBSD Project'
+        OPENBSD_5_4 = 'OpenBSD 5.4'
+
+        MICROSOFT_VENDOR = 'Microsoft Corporation'
+        MICROSOFT_MILLENNIUM_OS = 'Microsoft Windows Millennium Edition'
+        MICROSOFT_XP_OS = 'Microsoft Windows XP'
+        MICROSOFT_VISTA = 'Microsoft Windows Vista'
+        MICROSOFT_10_OS = 'Microsoft Windows 10'
+
+        APPLE_VENDOR = 'Apple Inc.'
+        MACOS_X_TIGER = 'MacOS X Tiger'
+        MACOS_X_LEOPARD = 'MacOS X Leopard'
+
+        # LINUX can be filtered if 3 years old
+        REDHAT_VENDOR = 'Red Hat, Inc'
+        REDHAT_RHEL_4_7_FILTERED_OS = 'Red Hat Enterprise Linux 4.9'
+
+        MANDRIVA_FILTERED_VENDOR = 'Mandriva'
+        MANDRIVA_2011_FILTERED_OS = 'Mandriva Linux 2011'
+
+        MAGEIA_VENDOR = 'Mageia'
+        MAGEIA_3_FILTERED_OS = 'Mageia 3'
+
+    class VmDialog:
+        def __init__(self, env, name, is_filesystem_location=True, location='',
+                     memory_size=1, memory_size_unit='GiB',
+                     storage_size=1, storage_size_unit='GiB',
+                     os_vendor=None,
+                     os_name=None,
+                     start_vm=False):
+
+            if not is_filesystem_location and start_vm:
+                raise Exception("cannot start vm because url specified (no connection available in this test)")
+
+            self.browser = env.browser
+            self.machine = env.machine
+
+            self.name = name
+            self.is_filesystem_location = is_filesystem_location
+            self.location = location
+            self.memory_size = memory_size
+            self.memory_size_unit = memory_size_unit
+            self.storage_size = storage_size
+            self.storage_size_unit = storage_size_unit
+            self.os_vendor = os_vendor if os_vendor else TestMachines.TestCreateConfig.UNSPECIFIED_VENDOR
+            self.os_name = os_name if os_name else TestMachines.TestCreateConfig.OTHER_OS
+            self.start_vm = start_vm
+
+        def getMemoryText(self):
+            return "{0} {1}".format(self.memory_size, self.memory_size_unit)
+
+        def open(self):
+            b = self.browser
+
+            b.wait_present("#create-new-vm")
+            b.click("#create-new-vm")
+            b.wait_present("#cockpit_modal_dialog")
+            b.wait_in_text(".modal-dialog .modal-header .modal-title", "Create New Virtual Machine")
+
+            if self.os_name != TestMachines.TestCreateConfig.OTHER_OS and self.os_vendor != TestMachines.TestCreateConfig.UNSPECIFIED_VENDOR:
+                # check if there is os and vendor present in osinfo-query because it can be filtered out in the UI
+                query_result = '{0}|{1}'.format(self.os_name, self.os_vendor)
+                # throws exception if grep fails
+                self.machine.execute(
+                    "osinfo-query os --fields=name,vendor | tail -n +3 | sed -e 's/\s*|\s*/|/g; s/^\s*//g; s/\s*$//g' | grep '{0}'".format(
+                        query_result))
+
+            return self
+
+        def hasVendor(self):
+            b = self.browser
+
+            vendor_selector = "#vendor-select button span:nth-of-type(1)"
+            vendor_item_selector = "#vendor-select ul li[data-value*='{0}'] a".format(self.os_vendor)
+
+            b.wait_visible(vendor_selector)
+            b.click(vendor_selector)
+
+            has_vendor = True
+            try:
+                with b.wait_timeout(1):
+                    b.wait_present(vendor_item_selector)
+            except Exception:
+                has_vendor = False
+
+            b.click(vendor_selector)  # close
+            return has_vendor
+
+        def checkOsOrVendorFiltered(self):
+            b = self.browser
+
+            vendor_selector = "#vendor-select button span:nth-of-type(1)"
+            vendor_item_selector = "#vendor-select ul li[data-value*='{0}'] a".format(self.os_vendor)
+
+            b.wait_visible(vendor_selector)
+            if not b.text(vendor_selector) == self.os_vendor:
+                b.click(vendor_selector)
+                try:
+                    with b.wait_timeout(1):
+                        b.wait_present(vendor_item_selector)
+                        b.wait_visible(vendor_item_selector)
+                        b.click(vendor_item_selector)
+                except Exception:
+                    # vendor not found which is ok
+                    b.click(vendor_selector)  # close
+                    return self
+            b.wait_in_text(vendor_selector, self.os_vendor)
+            # vendor successfully found
+
+            system_selector = "#system-select button span:nth-of-type(1)"
+            system_item_selector = "#system-select ul li[data-value*='{0}'] a".format(self.os_name)
+
+            b.wait_visible(system_selector)
+            b.click(system_selector)
+            try:
+                with b.wait_timeout(1):
+                    b.wait_present(system_item_selector)
+                    b.wait_visible(system_item_selector)
+                # os found which is not ok
+                raise AssertionError("{0} was not filtered".format(self.os_name))
+            except AssertionError as e:
+                raise
+            except Exception:
+                # os not found which is ok
+                b.click(system_selector)  # close
+                return self
+
+        def fill(self):
+            b = self.browser
+            self._setVal("#vm-name", self.name)
+
+            expected_source_type = 'Filesystem' if self.is_filesystem_location else 'URL'
+            self._selectFromDropdown("#source-type", expected_source_type)
+            if self.is_filesystem_location:
+                self._setFileAutocompleteVal("#source-file", self.location)
+            else:
+                self._setVal("#source-url", self.location)
+
+            self._selectFromDropdown("#vendor-select", self.os_vendor)
+            self._selectFromDropdown("#system-select", self.os_name)
+
+            self._setVal("#memory-size", self.memory_size)
+            self._selectFromDropdown("#memory-size-unit-select", self.memory_size_unit)
+
+            self._setVal("#storage-size", self.storage_size)
+            self._selectFromDropdown("#storage-size-unit-select", self.storage_size_unit)
+
+            b.wait_visible("#start-vm")
+            b.set_checked("#start-vm", self.start_vm)
+
+            return self
+
+        def cancel(self, force=False):
+            b = self.browser
+            if b.is_present("#cockpit_modal_dialog"):
+                b.click(".modal-footer button:contains(Cancel)")
+                b.wait_not_present("#cockpit_modal_dialog")
+            elif force:
+                raise Exception("There is no dialog to cancel")
+            return self
+
+        def create(self):
+            b = self.browser
+            b.click(".modal-footer button:contains(Create)")
+            b.wait_not_present("#cockpit_modal_dialog")
+            return self
+
+        def createAndExpectError(self, error, ui_validation):
+            b = self.browser
+            b.click(".modal-footer button:contains(Create)")
+            if ui_validation:
+                b.wait_present(".modal-footer div.alert")
+                b.wait_in_text(".modal-footer div.alert", error)
+            else:
+                b.wait_present(".modal-footer .spinner")
+                b.wait_not_present(".modal-footer .spinner")
+                try:
+                    # dialog can complete within next 3 seconds if error not found
+                    with b.wait_timeout(5):
+                        b.wait_present(".modal-footer div.alert")
+                        b.wait_in_text(".modal-footer div.alert", error)
+                except Exception as x:
+                    # raise dialog did not complete and there was no error
+                    # also CPU must be supported to detect errors
+                    # FIXME: "CPU is incompatible with host CPU" check should not be needed; happens only on fedora i386
+                    # see https://github.com/cockpit-project/cockpit/issues/8385
+                    if b.is_present("#cockpit_modal_dialog") and \
+                                    "CPU is incompatible with host CPU" not in b.text(".modal-footer div.alert") and \
+                                    "unsupported configuration: CPU mode" not in b.text(".modal-footer div.alert"):
+                        raise x
+            return self
+
+        def _selectFromDropdown(self, selector, value):
+            b = self.browser
+            button_text_selector = "{0} button span:nth-of-type(1)".format(selector)
+
+            b.wait_visible(selector)
+            if not b.text(button_text_selector) == value:
+                item_selector = "{0} ul li[data-value*='{1}'] a".format(selector, value)
+                b.click(selector)
+                b.wait_visible(item_selector)
+                b.click(item_selector)
+            b.wait_in_text(button_text_selector, value)
+
+        def _setFileAutocompleteVal(self, selector, location):
+            b = self.browser
+            caret_selector = "{0} span.caret".format(selector)
+            spinner_selector = "{0} .spinner".format(selector)
+            file_item_selector_template = "{0} ul li a:contains({1})"
+
+            b.wait_present(selector)
+            b.wait_visible(selector)
+
+            for path_part in location.split('/')[1:]:
+                b.wait_not_present(spinner_selector)
+                file_item_selector = file_item_selector_template.format(selector, path_part)
+                if not b.is_present(file_item_selector) or not b.is_visible(file_item_selector):
+                    b.click(caret_selector)
+                b.wait_visible(file_item_selector)
+                b.click(file_item_selector)
+
+            b.wait_not_present(spinner_selector)
+            b.wait_val(selector + " input", location)
+
+        def _setVal(self, selector, value):
+            b = self.browser
+            value = str(value)
+
+            b.wait_present(selector)
+            b.wait_visible(selector)
+            b.click(selector)
+            b.focus(selector)
+            b.set_val(selector, '')  # clear value
+            b.key_press(value)
+            b.wait_val(selector, value)
+
+    class CreateVmRunner:
+        def __init__(self, env):
+            self.browser = env.browser
+            self.machine = env.machine
+
+            self.machine.execute("touch {0}".format(TestMachines.TestCreateConfig.NOVELL_MOCKUP_ISO_PATH))
+
+        def destroy(self):
+            self.machine.execute("rm -f {0}".format(TestMachines.TestCreateConfig.NOVELL_MOCKUP_ISO_PATH))
+
+        def tryCreate(self, dialog):
+            b = self.browser
+            name = dialog.name
+
+            dialog.open() \
+                .fill() \
+                .create()
+
+            # successfully created
+            b.wait_present("#vm-{0}-row".format(name))
+            b.wait_in_text("#vm-{0}-row".format(name), name)
+            b.wait_present("#vm-{0}-state".format(name))
+            b.wait_in_text("#vm-{0}-state".format(name), "running" if dialog.start_vm else "shut off")
+
+            # wait for vm with console tab to open
+            if dialog.start_vm:
+                b.expect_load_frame("vm-{0}-novnc-frame-container".format(name))
+            else:
+                b.wait_present(
+                    ".listing-ct-body div:contains(Please start the virtual machine to access its console.)")
+
+            # check memory
+            b.wait_present("#vm-{0}-usage".format(name))
+            b.click("#vm-{0}-usage".format(name))
+            b.wait_present("tbody.open .listing-ct-body td:nth-child(1) .usage-donut-caption")
+            b.wait_in_text("tbody.open .listing-ct-body td:nth-child(1) .usage-donut-caption", dialog.getMemoryText())
+
+            # check disks
+            b.wait_present("#vm-{0}-disks".format(name))  # wait for the tab
+            b.click("#vm-{0}-disks".format(name))  # open the "Disks" subtab
+
+            # Test number of disks and disk creation
+            if dialog.storage_size > 0:
+                b.wait_present("#vm-{0}-disks-total-value".format(name))
+                b.wait_in_text("#vm-{0}-disks-total-value".format(name), 2 if dialog.start_vm else 1)  # CD-ROM
+
+                if b.is_present("#vm-{0}-disks-vda-target".format(name)):
+                    b.wait_in_text("#vm-{0}-disks-vda-target".format(name), "vda")
+                else:
+                    b.wait_in_text("#vm-{0}-disks-hda-target".format(name), "hda")
+
+            else:
+                b.wait_in_text("tbody tr td div.listing-ct-body", "No disks defined")
+
+            return self
+
+        def tryInstallWithError(self, dialog):
+            b = self.browser
+            dialog.start_vm = False
+            name = dialog.name
+
+            dialog.open() \
+                .fill() \
+                .create()
+
+            b.wait_present("#vm-{0}-install".format(name))
+            # should fail because of memory error
+            b.click("#vm-{0}-install".format(name))
+            # install script redefines vm
+            b.wait_not_present("#app .listing-ct tbody:nth-of-type(1) th")
+            # install
+            b.wait_present("#app .listing-ct tbody:nth-of-type(1) th")
+            b.wait_in_text("#app .listing-ct tbody:nth-of-type(1) th", name)
+            b.wait_present("#app .listing-ct tbody:nth-of-type(1) tr td span span.pficon-warning-triangle-o")
+            # depends on timeout
+            if not b.is_present(".listing-ct-panel .listing-ct-head"):
+                # automatic selection of console timed out and listing is closed
+                b.click("#app .listing-ct tbody:nth-of-type(1) th")
+
+            b.wait_present("#vm-{0}-install".format(name))
+            b.click("#app .listing-ct tbody:nth-of-type(1) .listing-ct-panel .listing-ct-head a:contains(Overview)")
+            b.wait_present("#vm-{0}-last-message".format(name))
+            b.wait_in_text("#vm-{0}-last-message".format(name), "INSTALL VM action failed")
+            b.click("#app .listing-ct tbody:nth-of-type(1) a:contains(show more)")
+
+            return self
+
+        def deleteVm(self, dialog):
+            b = self.browser
+            vm_delete_button = "#vm-{0}-delete".format(dialog.name)
+
+            b.wait_present(vm_delete_button)
+            b.click(vm_delete_button)
+            b.wait_present("#cockpit_modal_dialog")
+            b.click("#cockpit_modal_dialog button:contains(Delete)")
+            b.wait_not_present("#cockpit_modal_dialog")
+            b.wait_not_present("vm-{0}-row".format(dialog.name))
+
+            return self
+
+        def _commandNotRunning(self, command):
+            try:
+                self.machine.execute("pgrep -fc {0}".format(command))
+                return False
+            except Exception as e:
+                return hasattr(e, 'returncode') and e.returncode == 1
+
+        def assertScriptFinished(self):
+            with self.browser.wait_timeout(20):
+                self.browser.wait(functools.partial(self._commandNotRunning, "virt-install"))
+
+            return self
+
+        def assertOsInfoQueryFinished(self):
+            with self.browser.wait_timeout(10):
+                self.browser.wait(functools.partial(self._commandNotRunning, "osinfo-query"))
+            return self
+
+        def checkEnvIsEmpty(self):
+            b = self.browser
+            b.wait_present("thead tr td")
+            b.wait_in_text("thead tr td", "No VM is running")
+            # wait for the vm and disks to be deleted
+            b.wait(lambda: self.machine.execute("virsh list --all | wc -l") == '3\n')
+            b.wait(lambda: self.machine.execute("ls /home/admin/.local/share/libvirt/images/ 2>/dev/null | wc -l") == '0\n')
+
+            return self
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-ovirt
+++ b/test/verify/check-ovirt
@@ -83,6 +83,8 @@ class TestOVirtMachines(MachineCase):
         self.hack_for_missing_vdsm()
         self.pass_install_dialog()
 
+        self.allow_journal_messages('.*type=1400.*')
+
     def wait_for_dc(self):
         # wait for DC to get up
         m = self.machine
@@ -143,6 +145,7 @@ class TestOVirtMachines(MachineCase):
         b.wait_present(".main-app-div")
         b.wait_in_text("body", "Virtual Machines")
 
+        b.wait_present("tbody tr th")
         b.wait_in_text("tbody tr th", "VM")
         b.click("tbody tr th") # click on the row header
         b.wait_present("#vm-VM-state")
@@ -174,7 +177,8 @@ class TestOVirtMachines(MachineCase):
         b.click("#vm-VM-off-caret")
         b.wait_visible("#vm-VM-forceOff")
         b.click("#vm-VM-forceOff")
-        b.wait_in_text("body", "No VM is running or defined on this host")
+        b.wait_present("thead tr td")
+        b.wait_in_text("thead tr td", "No VM is running")
 
         # switch to cluster view and check expected cluster content
         b.click("#ovirt-topnav-clustervms")
@@ -273,6 +277,7 @@ class TestOVirtMachines(MachineCase):
         b.wait_present(".main-app-div")
         b.wait_in_text("body", "Virtual Machines")
 
+        b.wait_present("tbody tr th")
         b.wait_in_text("tbody tr th", "VM") # row with a vitual machine
         b.wait_present("#ovirt-host-to-maintenance")
         b.click("#ovirt-host-to-maintenance")


### PR DESCRIPTION
Hello, I overtook #7138 
creating vm works now but it was not tested properly yet

there are few changes in the proposed UI
- no memory slider unless somebody knows how to detect maximum memory
- operating system and version are changed to vendor and operating system because of osinfo-query 
- composition of the Ui is a bit changed mainly because it was not possible to fit vendor and os next to each other (too long names)

also I had to extend Select in pkg/lib/cockpit-components-select.jsx because it does not have any way to select items programmatically. Please let me know if I should refactor it or just use my StatelessSelect 

todo:
- [x] open created vm in vmList
- [x] add remote url/server's filesystem options
- [x] create vm bar is hidden when no vms are present
- [x] better input validation
- [x] error localization
- [x] optimize shell scripts
- [x] refactor toMega/Kilo/GigaByte helpers
- [x] sorting
- [x] add console
- [x] start-immediatelly flow
- [x] postpone install flow [needs refactoring and correctness check]
- [x] fix double cd-rom creation
- [x] add install fail handler (possibly create as well)
- [x] add live cd checkbox
- [x] pass through number of cpus and consoles
- [x] testing (for disks test only size and format until disks dialog is implemented)
- [x] install (hide on click)
