### PR TITLE
tools: Properly munge the patternfly font paths

### DIFF
--- a/tools/patternfly.sed
+++ b/tools/patternfly.sed
@@ -1,8 +1,8 @@
-s/src: url(.*eot[^']*');$//
+s/src: url(.*eot[^'"]*['"]);$//
 s/src: url.*glyphicons-halflings-regular.woff.*/src: url('fonts\/glyphicons.woff') format('woff');/
 s/src: url.*fontawesome-webfont.woff.*/src: url('fonts\/fontawesome.woff?v=4.2.0') format('woff');/
 s/src: url.*PatternFlyIcons-webfont.woff.*/src: url('fonts\/patternfly.woff') format('woff');/
-s/src: url.*OpenSans-\([^']*\).woff.*/src: url('..\/..\/static\/fonts\/OpenSans-\1.woff') format('woff');/
+s/src:.*url.*OpenSans-\([^'"]*\).woff.*/src: url('..\/..\/static\/fonts\/OpenSans-\1.woff') format('woff');/
 s/url('..\/img\//url('images\//
 s/url("..\/img\//url("images\//
 

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -4,7 +4,7 @@ set -eu
 
 echo "1..5"
 
-distdir=$(pwd)
+builddir=$(pwd)
 cd "${srcdir:-.}"
 fail=0
 
@@ -85,8 +85,8 @@ fi
 # Bad paths or modifications in patternfly for fonts
 #
 
-if grep -R "\.\./fonts/OpenSans\|fonts/.*eot\|truetype" $distdir/dist/*/*.css >&2; then
-    echo "ERROR: invalid patternfly fonts paths found"
+if grep "\.\./fonts/OpenSans\|fonts/.*eot\|truetype" dist/*/*.css $builddir/dist/*/*.css >&2; then
+    echo "ERROR: invalid patternfly fonts paths found" >&2
     echo "not ok 5 patternfly-font-paths"
     fail=1
 else

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -2,8 +2,9 @@
 # run static code checks like pyflakes and pep8
 set -eu
 
-echo "1..4"
+echo "1..5"
 
+distdir=$(pwd)
 cd "${srcdir:-.}"
 fail=0
 
@@ -78,6 +79,18 @@ if [ $safe == "no" ]; then
    fail=1
 else
     echo "ok 4 unsafe-security-policy"
+fi
+
+#
+# Bad paths or modifications in patternfly for fonts
+#
+
+if grep -R "\.\./fonts/OpenSans\|fonts/.*eot\|truetype" $distdir/dist/*/*.css >&2; then
+    echo "ERROR: invalid patternfly fonts paths found"
+    echo "not ok 5 patternfly-font-paths"
+    fail=1
+else
+    echo "ok 5 patternfly-font-paths"
 fi
 
 exit $fail


### PR DESCRIPTION
The OpenSans fonts are in our static directory and used on the
login page. These are not part of a package. In addition we don't
ship any other font formats but woff.

The patternfly.sed script munges patternfly for our use cases,
however it wasn't working with the new patternfly.

Update the script and add tests.