### PR TITLE
bots: Use cockpit's release-guide script instead of cockpituous'

### DIFF
--- a/bots/major-cockpit-release
+++ b/bots/major-cockpit-release
@@ -41,7 +41,7 @@ job release-dockerhub cockpituous/cockpit cockpit-project/cockpit
 job release-bodhi F27
 
 # Upload documentation
-job release-guide dist/guide cockpit-project/cockpit-project.github.io
+job bots/release-guide dist/guide cockpit-project/cockpit-project.github.io
 
 # Create and publish a Debian repository and Ubuntu PPA
 job release-dsc


### PR DESCRIPTION
release-guide was moved from cockpituous as it is very Cockpit specific.
It also adds the necessary `layout: guide` tag (see #7675) to index the
guide.

Fixes https://github.com/cockpit-project/cockpit-project.github.io/issues/98