### PR TITLE
Image refresh for debian-testing - DON'T MERGE (but keep open)

### DIFF
--- a/bots/images/debian-testing
+++ b/bots/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-ba2a6c738b0c177b0e7f77f750a8916aecb29c72604fdf3b1f63f17a3adb5cb3.qcow2
+debian-testing-48cebf045dcfd9308c30c176ddaf07a123c106288667b72556085d73d68de41e.qcow2


### PR DESCRIPTION
This collides with #7812. Keep this open to avoid cockpituous continuously open new ones.

Image refresh for debian-testing
 * [x] image-refresh debian-testing