### PR TITLE
naughty: Close 6332: Fedora: setroubleshootd API is broken:  AttributeError: module 'seobject' has no attribute 'boolean_desc'

### DIFF
--- a/bots/naughty/fedora-26/6332-setroubleshoot-crashes
+++ b/bots/naughty/fedora-26/6332-setroubleshoot-crashes
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-setroubleshoot", line *, in testTroubleshootAlerts
-    b.wait_present(row_selector)


### PR DESCRIPTION
Known issue which has not occurred in 23 days

Fedora: setroubleshootd API is broken:  AttributeError: module 'seobject' has no attribute 'boolean_desc'

Fixes #6332