### PR TITLE
shell: Center the "Disconnected" curtain in the content area

### DIFF
--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -37,6 +37,7 @@ html.index-page body {
 
 .curtains-ct {
     top: auto;
+    position: static;
 }
 
 #dashboard-add {


### PR DESCRIPTION
Fixes #7106