### PR TITLE
rpmlint fixes for source rpm, run it during build

### DIFF
--- a/bots/images/scripts/lib/fedora.install
+++ b/bots/images/scripts/lib/fedora.install
@@ -62,10 +62,30 @@ if [ -n "$do_build" ]; then
     # we should still be protected against unexpected package
     # installations.
     echo "config_opts['rpmbuild_networking'] = True" >>/etc/mock/site-defaults.cfg
+    # don't destroy the mock after building, we want to run rpmlint
+    echo "config_opts['cleanup_on_success'] = False" >>/etc/mock/site-defaults.cfg
 
     rm -rf build-results
     srpm=$(/var/lib/testvm/make-srpm "$tar")
     LC_ALL=C.UTF-8 su builder -c "/usr/bin/mock --offline --no-clean --resultdir build-results $mock_opts --rebuild $srpm"
+
+    su builder -c "/usr/bin/mock --offline --shell" <<EOF
+if type rpmlint >/dev/null 2>&1; then
+    # blacklist "E: no-changelogname-tag" rpmlint error, expected due to our template cockpit.spec
+    mkdir -p ~/.config
+    echo 'addFilter("E: no-changelogname-tag")' > ~/.config/rpmlint
+    # we expect the srpm to be clean
+    echo
+    echo '====== rpmlint on srpm ====='
+    rpmlint /builddir/build/SRPMS/*.src.rpm
+    # this still has lots of errors, run it for information only
+    echo
+    echo '====== rpmlint binary rpms (advisory) ====='
+    rpmlint /builddir/build/RPMS/ || true
+else
+    echo '====== skipping rpmlint check, not installed ====='
+fi
+EOF
 fi
 
 # Install

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -278,6 +278,8 @@ cat kdump.list subscriptions.list sosreport.list networkmanager.list selinux.lis
 # -------------------------------------------------------------------------------
 # Sub-packages
 
+%define __lib lib
+
 %package bridge
 Summary: Cockpit bridge server-side component
 Requires: glib-networking
@@ -459,7 +461,7 @@ These files are not required for running Cockpit.
 %files tests
 %config(noreplace) %{_sysconfdir}/cockpit/cockpit.conf
 %{_datadir}/%{name}/playground
-%{_prefix}/lib/cockpit-test-assets
+%{_prefix}/%{__lib}/cockpit-test-assets
 
 %package integration-tests
 Summary: Integration tests for Cockpit
@@ -510,7 +512,7 @@ The Cockpit Web Service listens on the network, and authenticates users.
 %config(noreplace) %{_sysconfdir}/pam.d/cockpit
 %{_unitdir}/cockpit.service
 %{_unitdir}/cockpit.socket
-%{_prefix}/lib/firewalld/services/cockpit.xml
+%{_prefix}/%{__lib}/firewalld/services/cockpit.xml
 %{_sbindir}/remotectl
 %{_libdir}/security/pam_ssh_add.so
 %{_libexecdir}/cockpit-ws

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -119,13 +119,13 @@ machines.
 # generated and source file changes
 # Keep this in sync with tools/debian/rules.
 if [ -n "%{patches}" ]; then
-	git init
-	git config user.email "unused@example.com" && git config user.name "Unused"
-	git config core.autocrlf false && git config core.safecrlf false && git config gc.auto 0
-	git add -f . && git commit -a -q -m "Base" && git tag -a initial --message="initial"
-	git am --whitespace=nowarn %{patches}
-	touch -r $(git diff --name-only initial..HEAD) .git
-	rm -rf .git
+    git init
+    git config user.email "unused@example.com" && git config user.name "Unused"
+    git config core.autocrlf false && git config core.safecrlf false && git config gc.auto 0
+    git add -f . && git commit -a -q -m "Base" && git tag -a initial --message="initial"
+    git am --whitespace=nowarn %{patches}
+    touch -r $(git diff --name-only initial..HEAD) .git
+    rm -rf .git
 fi
 
 %build

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -356,7 +356,7 @@ Cockpit support for reading PCP metrics and loading PCP archives.
 
 %if %{defined build_dashboard}
 %package dashboard
-Summary: Cockpit SSH remoting and dashboard
+Summary: Cockpit remote servers and dashboard
 Requires: libssh >= %{libssh_version}
 Provides: %{name}-ssh = %{version}-%{release}
 # nothing depends on the dashboard, but we can't use it with older versions of the bridge
@@ -364,7 +364,8 @@ Conflicts: %{name}-bridge < 135
 Conflicts: %{name}-ws < 135
 
 %description dashboard
-Cockpit support for remoting to other servers, bastion hosts, and a basic dashboard
+Cockpit support for connecting to remote servers (through ssh),
+bastion hosts, and a basic dashboard.
 
 %files dashboard -f dashboard.list
 %{_libexecdir}/cockpit-ssh

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -356,7 +356,7 @@ Cockpit support for reading PCP metrics and loading PCP archives.
 %package dashboard
 Summary: Cockpit SSH remoting and dashboard
 Requires: libssh >= %{libssh_version}
-Provides: %{name}-ssh
+Provides: %{name}-ssh = %{version}-%{release}
 # nothing depends on the dashboard, but we can't use it with older versions of the bridge
 Conflicts: %{name}-bridge < 135
 Conflicts: %{name}-ws < 135
@@ -449,7 +449,7 @@ Summary: Tests for Cockpit
 Requires: %{name}-bridge >= 138
 Requires: %{name}-system >= 138
 Requires: openssh-clients
-Provides: %{name}-test-assets
+Provides: %{name}-test-assets = %{version}-%{release}
 Obsoletes: %{name}-test-assets < 132
 
 %description tests

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -70,9 +70,9 @@ Depends: ${misc:Depends},
          cockpit-ws (= ${binary:Version})
 Provides: cockpit-ssh
 Replaces: cockpit-system (<< 128), cockpit-ws (<< 128)
-Description: Cockpit SSH remoting and dashboard
- Cockpit support for remoting to other servers, bastion hosts, and
- a basic dashboard.
+Description: Cockpit remote servers and dashboard
+ Cockpit support for connecting to remote servers (through ssh)
+ bastion hosts, and a basic dashboard.
 
 Package: cockpit-doc
 Section: doc


### PR DESCRIPTION
This fixes the [rpmgrill errors](https://taskotron.fedoraproject.org/artifacts/all/241592c0-aa9e-11e7-8a28-525400817a8f/task_output/cockpit-152-1.fc27.log) for the source rpm. (Aside from the weird `invalid-url` which doesn't happen locally and looks like a flake).

The last commit runs rpmlint on Fedora 27 to enforce that our srpm stays clean. This depends on #7862 for the actual enforcement - the fixes are independent of that, of course.

 - [x] Put rpmlint into mock on Fedora 27 (#7862)