### PR TITLE
machines: Added vCPU detail modal window

### DIFF
--- a/pkg/lib/cockpit-components-select.jsx
+++ b/pkg/lib/cockpit-components-select.jsx
@@ -155,6 +155,10 @@
                 this.props.onChange(data);
         }
 
+        componentWillReceiveProps(nextProps) {
+            this.setState({ currentData: nextProps.initial });
+        }
+
         render() {
             return (
                 <StatelessSelect onChange={this.onChange}

--- a/pkg/machines/actions.es6
+++ b/pkg/machines/actions.es6
@@ -115,6 +115,24 @@ export function enableLibvirt(enable, serviceName) {
     return virt('ENABLE_LIBVIRT', { enable, serviceName });
 }
 
+export function setVCPUSettings(vm, max, count, sockets, threads, cores) {
+    return virt('SET_VCPU_SETTINGS', {
+        id: vm.id,
+        name: vm.name,
+        connectionName: vm.connectionName,
+        max,
+        count,
+        sockets,
+        threads,
+        cores,
+        isRunning: vm.state == 'running'
+    });
+}
+
+export function getHypervisorMaxVCPU(connectionName) {
+    return virt('GET_HYPERVISOR_MAX_VCPU', { connectionName });
+}
+
 /**
  * Delay call of polling action.
  *
@@ -240,6 +258,16 @@ export function updateLibvirtState(state) {
     return {
         type: 'UPDATE_LIBVIRT_STATE',
         state,
+    };
+}
+
+export function setHypervisorMaxVCPU({ count, connectionName }) {
+    return {
+        type: 'SET_HYPERVISOR_MAX_VCPU',
+        payload: {
+            count,
+            connectionName,
+        }
     };
 }
 

--- a/pkg/machines/actions.es6
+++ b/pkg/machines/actions.es6
@@ -114,18 +114,6 @@ export function startLibvirt(serviceName) {
 export function enableLibvirt(enable, serviceName) {
     return virt('ENABLE_LIBVIRT', { enable, serviceName });
 }
-export function setVCPUSettings(vm, max, count, sockets, threads, cores) {
-    return virt('SET_VCPU_SETTINGS', {
-        name: vm.name,
-        connectionName: vm.connectionName,
-        max,
-        count,
-        sockets,
-        threads,
-        cores,
-        isRunning: vm.state == 'running'
-    });
-}
 
 export function setVCPUSettings(vm, max, count, sockets, threads, cores) {
     return virt('SET_VCPU_SETTINGS', {

--- a/pkg/machines/actions.es6
+++ b/pkg/machines/actions.es6
@@ -114,6 +114,18 @@ export function startLibvirt(serviceName) {
 export function enableLibvirt(enable, serviceName) {
     return virt('ENABLE_LIBVIRT', { enable, serviceName });
 }
+export function setVCPUSettings(vm, max, count, sockets, threads, cores) {
+    return virt('SET_VCPU_SETTINGS', {
+        name: vm.name,
+        connectionName: vm.connectionName,
+        max,
+        count,
+        sockets,
+        threads,
+        cores,
+        isRunning: vm.state == 'running'
+    });
+}
 
 export function setVCPUSettings(vm, max, count, sockets, threads, cores) {
     return virt('SET_VCPU_SETTINGS', {

--- a/pkg/machines/components/infoRecord.jsx
+++ b/pkg/machines/components/infoRecord.jsx
@@ -18,8 +18,9 @@
  */
 
 import React, { PropTypes } from "react";
+import { Tooltip } from "cockpit-components-tooltip.jsx";
 
-const InfoRecord = ({id, descr, value, descrClass, valueClass}) => {
+const InfoRecord = ({id, descr, value, descrClass, valueClass, tooltip}) => {
     return (<tr>
         <td className={descrClass || 'top'}>
             <label className='control-label'>
@@ -29,6 +30,9 @@ const InfoRecord = ({id, descr, value, descrClass, valueClass}) => {
         <td id={id} className={valueClass}>
             {value}
         </td>
+        {tooltip && (<td><Tooltip tip={tooltip} pos="top">
+            <span className="fa fa-lg fa-info-circle" />
+        </Tooltip></td>)}
     </tr>);
 };
 
@@ -41,6 +45,7 @@ InfoRecord.propTypes = {
         PropTypes.string,
         PropTypes.element
     ]).isRequired,
+    tooltip: PropTypes.string,
 }
 
 export default InfoRecord;

--- a/pkg/machines/components/vcpuModal.jsx
+++ b/pkg/machines/components/vcpuModal.jsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import cockpit from 'cockpit';
+
+import { show_modal_dialog } from 'cockpit-components-dialog.jsx';
+import SelectComponent from 'cockpit-components-select.jsx';
+import InfoRecord from './infoRecord.jsx';
+import { Alert } from './notification/inlineNotification.jsx';
+import { setVCPUSettings } from "../actions.es6";
+
+const _ = cockpit.gettext;
+
+const dividers = (num) => {
+    const divs = [1];
+
+    for (let i = 2; i < num; i++) {
+        if (num % i === 0) {
+            divs.push(i);
+        }
+    }
+
+    if (num > 1) {
+        divs.push(num);
+    }
+
+    return divs;
+}
+
+const clamp = (value, max, min) => {
+    return value < min || isNaN(value) ? min : (value > max ? max : value);
+}
+
+const Select = function ({ id, items, onChange, value }) {
+    return (<SelectComponent.Select id={id} initial={value} onChange={onChange}>
+        {items.map((t) => (
+            <SelectComponent.SelectEntry data={t}>{t}</SelectComponent.SelectEntry>
+        ))}
+    </SelectComponent.Select>);
+}
+
+class VCPUModalBody extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            sockets: props.cpu.topology.sockets || 1,
+            threads: props.cpu.topology.threads || 1,
+            cores: props.cpu.topology.cores || 1,
+            max: props.vcpus.max || 1,
+            count: parseInt(props.vcpus.count) || 1
+        };
+        this.onMaxChange = this.onMaxChange.bind(this);
+        this.onCountSelect = this.onCountSelect.bind(this);
+        this.onSocketChange = this.onSocketChange.bind(this);
+        this.onThreadsChange = this.onThreadsChange.bind(this);
+        this.onCoresChange = this.onCoresChange.bind(this);
+        props.onChange(this.state);
+    }
+
+    componentWillUpdate (nextProps, nextState) {
+        this.props.onChange(nextState);
+    }
+
+    onMaxChange (e) {
+        const maxHypervisor = parseInt(this.props.hypervisorMax);
+        let maxValue = parseInt(e.target.value);
+
+        // Check new value for limits
+        maxValue = clamp(maxValue, maxHypervisor, 1);
+
+        // Recalculate new values for sockets, cores and threads according to new max value
+        // Max value = Sockets * Cores * Threads
+        let state = { max: maxValue, sockets: this.state.sockets, cores: this.state.cores };
+
+        // If count of used VCPU greater then new max value, then change it to new max value
+        if (maxValue < this.state.count) {
+            state.count = maxValue;
+        }
+
+        // Recalculate sockets first, and get array of all divisors of new max values
+        let divs = dividers(state.max);
+
+        // If current sockets value is not in divisors array, then change it to max divisor
+        if (divs.indexOf(this.state.sockets) === -1 || (this.props.cpu.topology.sockets || 1) === this.state.sockets) {
+            state.sockets = divs[divs.length - 1];
+        }
+
+        // Get next divisors
+        divs = dividers(state.max / state.sockets);
+        if (divs.indexOf(this.state.cores) === -1) {
+            state.cores = divs[divs.length - 1];
+        }
+
+        // According to: Max value = Sockets * Cores * Threads. Threads = Max value / ( Sockets * Cores )
+        state.threads = state.max / (state.cores * state.sockets);
+        this.setState(state);
+    }
+
+    onCountSelect (e) {
+        let value = parseInt(e.target.value);
+        value = clamp(value, this.state.max, 1);
+        this.setState({ count: parseInt(value) });
+    }
+
+    onSocketChange (value) {
+        let state = { sockets: this.state.sockets, cores: this.state.cores };
+        state.sockets = parseInt(value);
+
+        // Get divisors of Max VCPU number divided by number of sockets
+        let divs = dividers(this.state.max / state.sockets);
+
+        // If current cores value is not in divisors array, then change it to max divisor
+        if (divs.indexOf(this.state.cores) === -1) {
+            state.cores = divs[divs.length - 1];
+        }
+
+        // Likewise: Max value = Sockets * Cores * Threads. Sockets = Max value / ( Threads * Cores )
+        state.threads = (this.state.max / (state.sockets * state.cores));
+        this.setState(state);
+    }
+
+    onThreadsChange (value) {
+        let state = { sockets: this.state.sockets, threads: this.state.threads };
+        state.threads = parseInt(value);
+        let divs = dividers(this.state.max / state.threads);
+
+        // If current sockets value is not in divisors array, then change it to max divisor
+        if (divs.indexOf(state.sockets) === -1) {
+            state.sockets = divs[divs.length - 1];
+        }
+
+        // Likewise: Max value = Sockets * Cores * Threads. Cores = Max value / ( Threads * Sockets )
+        state.cores = (this.state.max / (state.sockets * state.threads));
+
+        this.setState(state);
+    }
+
+    onCoresChange (value) {
+        let state = { sockets: this.state.sockets, threads: this.state.threads };
+        state.cores = parseInt(value);
+
+        let divs = dividers(this.state.max / state.cores);
+
+        // If current sockets value is not in divisors array, then change it to max divisor
+        if (divs.indexOf(state.sockets) === -1) {
+            state.sockets = divs[divs.length - 1];
+        }
+
+        // Likewise: Max value = Sockets * Cores * Threads. Threads = Max value / ( Cores * Sockets )
+        state.threads = (this.state.max / (state.sockets * state.cores));
+        this.setState(state);
+    }
+
+    render () {
+        let caution = null;
+
+        if (this.props.isRunning) {
+            caution = (
+                <tr>
+                    <td colSpan={2} className="machines-vcpu-caution">
+                        <Alert text={_("All changes will take effect only after stopping and starting the VM.")} />
+                    </td>
+                </tr>);
+        }
+
+        return (<div className="modal-body">
+            <table className="vcpu-detail-modal-table">
+                <tr>
+                    <td>
+                        <table className='form-table-ct'>
+                            <InfoRecord
+                                descr={_("vCPU Count")}
+                                tooltip={_("Fewer than the maximum number of virtual CPUs should be enabled.")}
+                                value={<input id="machines-vcpu-count-field" type="number" className="form-control" value={this.state.count} onChange={this.onCountSelect} />}
+                            />
+                            <InfoRecord
+                                descr={_("vCPU Maximum")}
+                                tooltip={cockpit.format(_("Maximum number of virtual CPUs allocated for the guest OS, which must be between 1 and $0"), this.props.hypervisorMax)}
+                                value={<input id="machines-vcpu-max-field" type="number" className="form-control" onChange={this.onMaxChange} value={this.state.max} />}
+                            />
+                        </table>
+                    </td>
+                    <td>
+                        <table className='form-table-ct vcpu-detail-modal-right'>
+                            <InfoRecord descr={_("Sockets")} tooltip={_("Preferred number of sockets to expose to the guest.")} value={
+                                <Select id='socketsSelect' value={this.state.sockets.toString()} onChange={this.onSocketChange} items={dividers(this.state.max).map((t) => t.toString())} />
+                            } />
+                            <InfoRecord descr={_("Cores per socket")} value={
+                                <Select id='coresSelect' value={this.state.cores.toString()} onChange={this.onCoresChange} items={dividers(this.state.max).map((t) => t.toString())} />
+                            } />
+                            <InfoRecord descr={_("Threads per cores")} value={
+                                <Select id='threadsSelect' value={this.state.threads.toString()} onChange={this.onThreadsChange} items={dividers(this.state.max).map((t) => t.toString())} />
+                            } />
+                        </table>
+                    </td>
+                </tr>
+                { caution }
+            </table>
+        </div>);
+    }
+}
+
+VCPUModalBody.propTypes = {
+    vcpus: React.PropTypes.object,
+    cpu: React.PropTypes.shape({
+        topology: React.PropTypes.object.isRequired
+    }).isRequired,
+    onChange: React.PropTypes.func.isRequired,
+    hypervisorMax: React.PropTypes.number
+};
+
+export default function ({ vm, dispatch, config }) {
+    let state = {};
+    const onStateChange = (st) => {
+        state = Object.assign({}, st);
+    }
+    return show_modal_dialog(
+        {
+            title: cockpit.format(_("$0 vCPU Details"), vm.name),
+            body: (<VCPUModalBody vcpus={vm.vcpus} cpu={vm.cpu} onChange={onStateChange} isRunning={vm.state == 'running'} hypervisorMax={config.hypervisorMaxVCPU[vm.connectionName]} />),
+            id: "machines-vcpu-modal-dialog"
+        },
+        { actions: [
+            {
+                caption: _("Apply"),
+                style: 'primary',
+                clicked: function () {
+                    return dispatch(setVCPUSettings(vm, state.max, state.count, state.sockets, state.threads, state.cores));
+                }
+            }
+        ]}
+    );
+}

--- a/pkg/machines/components/vm/vmUsageTab.jsx
+++ b/pkg/machines/components/vm/vmUsageTab.jsx
@@ -50,7 +50,7 @@ class VmUsageTab extends React.Component {
         let available = memTotal - rssMem; // in KiB
         available = available < 0 ? 0 : available;
 
-        const totalCpus = vm['vcpus'] > 0 ? vm['vcpus'] : 0;
+        const totalCpus = vm.vcpus && vm.vcpus.count > 0 ? vm.vcpus.count : 0;
         // 4 CPU system can have usage 400%, let's keep % between 0..100
         let cpuUsage = vm['cpuUsage'] / (totalCpus > 0 ? totalCpus : 1);
         cpuUsage = isNaN(cpuUsage) ? 0 : cpuUsage;

--- a/pkg/machines/components/vmOverviewTabLibvirt.jsx
+++ b/pkg/machines/components/vmOverviewTabLibvirt.jsx
@@ -39,10 +39,23 @@ const VmOverviewTabLibvirt = ({ vm, config, dispatch }) => {
     const idPrefix = vmId(vm.name);
     const message = (<VmLastMessage vm={vm} dispatch={dispatch} />);
 
+    const handleOpenModal = function () {
+        config.provider.openVCPUModal(
+            {
+                vm,
+                dispatch,
+                config,
+            },
+            config.providerState
+        );
+    };
+
+    const memoryLink = (<a id={`${vmId(vm.name)}-vcpus-count`} data-toggle="modal" data-target={`${vmId(vm.name)}-vcpu-modal`} onClick={handleOpenModal}>{vm.vcpus.count}</a>);
+
     let items = [
         { title: commonTitles.MEMORY, value: cockpit.format_bytes((vm.currentMemory ? vm.currentMemory : 0) * 1024), idPostfix: 'memory' },
         { title: _("Emulated Machine:"), value: vm.emulatedMachine, idPostfix: 'emulatedmachine' },
-        { title: commonTitles.CPUS, value: vm.vcpus, idPostfix: 'vcpus' },
+        { title: commonTitles.CPUS, value: memoryLink, idPostfix: 'vcpus' },
         { title: _("Boot Order:"), value: getBootOrder(vm), idPostfix: 'bootorder' },
         { title: _("CPU Type:"), value: vm.cpuModel, idPostfix: 'cputype' },
         { title: _("Autostart:"), value: rephraseUI('autostart', vm.autostart), idPostfix: 'autostart' },

--- a/pkg/machines/components/vmOverviewTabLibvirt.jsx
+++ b/pkg/machines/components/vmOverviewTabLibvirt.jsx
@@ -20,7 +20,6 @@ import cockpit from 'cockpit';
 import React, { PropTypes } from "react";
 
 import VmOverviewTab, { commonTitles } from './vmOverviewTab.jsx';
-import VCPUModal from './vcpuModal.jsx';
 import VmLastMessage from './vmLastMessage.jsx';
 
 import { rephraseUI, vmId } from "../helpers.es6";

--- a/pkg/machines/components/vmOverviewTabLibvirt.jsx
+++ b/pkg/machines/components/vmOverviewTabLibvirt.jsx
@@ -20,6 +20,7 @@ import cockpit from 'cockpit';
 import React, { PropTypes } from "react";
 
 import VmOverviewTab, { commonTitles } from './vmOverviewTab.jsx';
+import VCPUModal from './vcpuModal.jsx';
 import VmLastMessage from './vmLastMessage.jsx';
 
 import { rephraseUI, vmId } from "../helpers.es6";

--- a/pkg/machines/machines.less
+++ b/pkg/machines/machines.less
@@ -195,3 +195,58 @@
     margin-left: 3px;
 }
 
+.console-menu {
+    padding-bottom: 1em;
+}
+
+.console-actions-buttons {
+    margin-left: 5px;
+}
+
+.console-actions {
+    float: right;
+    position: relative;
+    top: -2em;
+}
+
+.console-type-select {
+    width: 19em !important;
+}
+
+.machines-status-alert {
+    padding-right: 5px;
+}
+
+.vcpu-detail-modal-table {
+    width: 100%;
+}
+
+.vcpu-detail-modal-table td {
+    width: 50%;
+}
+
+.vcpu-detail-modal-table tr td:first-child {
+    padding-top: 0.25em;
+    display: inherit;
+}
+
+table.vcpu-detail-modal-right td {
+    width: 25%;
+}
+
+table.vcpu-detail-modal-right input {
+    height: 25px;
+}
+
+table.vcpu-detail-modal-right .btn-group.bootstrap-select.dropdown {
+    width: 110px;
+}
+
+.vcpu-detail-modal-table tr td.machines-vcpu-caution:first-child {
+    width: 100%;
+    display: table-cell;
+}
+
+#machines-vcpu-modal-dialog div.modal-body {
+    overflow: visible;
+}

--- a/pkg/machines/reducers.es6
+++ b/pkg/machines/reducers.es6
@@ -43,6 +43,11 @@ function config(state, action) {
         newState.refreshInterval = action.refreshInterval;
         return newState;
     }
+    case 'SET_HYPERVISOR_MAX_VCPU': {
+        const newState = Object.assign({}, state);
+        newState.hypervisorMaxVCPU = Object.assign({}, newState.hypervisorMaxVCPU, { [action.payload.connectionName]: action.payload.count });
+        return newState;
+    }
     default:
         return state;
     }

--- a/pkg/ovirt/components/ClusterTemplates.jsx
+++ b/pkg/ovirt/components/ClusterTemplates.jsx
@@ -104,7 +104,7 @@ const Template = ({ template, templates, cluster, dispatch }) => {
             template.version.baseTemplateId ? (templates[template.version.baseTemplateId].name) : null,
             <VmDescription descr={template.description} />,
             <VmMemory mem={template.memory} />,
-            <VmCpu cpu={template.cpu} />,
+            <VmCpu vm={template} />,
             <VmOS os={template.os} />,
             <VmHA highAvailability={template.highAvailability} />,
             <VmStateless stateless={template.stateless} />,

--- a/pkg/ovirt/components/ClusterVms.jsx
+++ b/pkg/ovirt/components/ClusterVms.jsx
@@ -24,6 +24,7 @@ import CONFIG from '../config.es6';
 import { Listing, ListingRow } from "cockpit-components-listing.jsx";
 import StateIcon from "../../machines/components/vm/stateIcon.jsx";
 import DropdownButtons from "../../machines/components/dropdownButtons.jsx";
+import VCPUModal from './vcpuModal.jsx';
 
 import { toGigaBytes, valueOrDefault, isSameHostAddress } from '../helpers.es6';
 import { startVm, goToSubpage } from '../actions.es6';
@@ -40,10 +41,18 @@ const VmOS = ({ os }) => (<div>{os.type}</div>);
 const VmStateless = ({ stateless }) => (<div>{rephraseUI('stateless', stateless)}</div>);
 const VmDescription = ({ descr }) => (<span>{descr}</span>); // cropping is not needed, the text wraps
 
-const VmCpu = ({ cpu }) => { // TODO: render CPU architecture and topology?
-    const vCpus = valueOrDefault(cpu.topology.sockets, 1) * valueOrDefault(cpu.topology.cores, 1) * valueOrDefault(cpu.topology.threads, 1);
-    const tooltip = `${_("sockets")}: ${cpu.topology.sockets}\n${_("cores")}: ${cpu.topology.cores}\n${_("threads")}: ${cpu.topology.threads}`;
-    return (<span title={tooltip} data-toggle='tooltip' data-placement='left'>{vCpus}</span>);
+const VmCpu = ({ vm, dispatch }) => {
+    const vCpus = valueOrDefault(vm.cpu.topology.sockets, 1) * valueOrDefault(vm.cpu.topology.cores, 1) * valueOrDefault(vm.cpu.topology.threads, 1);
+    const tooltip = `${_("sockets")}: ${vm.cpu.topology.sockets}\n${_("cores")}: ${vm.cpu.topology.cores}\n${_("threads")}: ${vm.cpu.topology.threads}`;
+
+    const handleOpenModal = function () {
+        VCPUModal({
+            vm,
+            dispatch
+        });
+    };
+
+    return (<a title={tooltip} id={`cluster-${vm.name}-cpus`} data-toggle='tooltip' data-placement='left' onClick={handleOpenModal}>{vCpus}</a>);
 };
 
 const VmHost = ({ id, hosts, dispatch }) => {
@@ -139,7 +148,7 @@ const Vm = ({ vm, hosts, templates, config, dispatch }) => {
             <VmDescription descr={vm.description} />,
             <VmTemplate id={vm.templateId} templates={templates} />,
             <VmMemory mem={vm.memory} />,
-            <VmCpu cpu={vm.cpu} />,
+            <VmCpu vm={vm} dispatch={dispatch} />,
             <VmOS os={vm.os} />,
             <VmHA highAvailability={vm.highAvailability} />,
             <VmStateless stateless={vm.stateless} />,

--- a/pkg/ovirt/components/vcpuModal.jsx
+++ b/pkg/ovirt/components/vcpuModal.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import cockpit from 'cockpit';
+
+import { show_modal_dialog } from 'cockpit-components-dialog.jsx';
+import { setVCPUSettings } from "../../machines/actions.es6";
+import InfoRecord from '../../machines/components/infoRecord.jsx';
+
+const _ = cockpit.gettext;
+
+class VCPUModalBody extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            sockets: props.cpu.topology.sockets || 1,
+            threads: props.cpu.topology.threads || 1,
+            cores: props.cpu.topology.cores || 1,
+            count: (props.cpu.topology.sockets * props.cpu.topology.cores * props.cpu.topology.threads) || 1
+        }
+
+        this.handleChange = this.handleChange.bind(this);
+        props.onChange(this.state);
+    }
+
+    componentWillUpdate (nextProps, nextState) {
+        this.props.onChange(nextState);
+    }
+
+    handleChange (paramName) {
+        return (e) => {
+            let value = parseInt(e.target.value);
+            if (!value) {
+                value = 1;
+            }
+
+            let state = { sockets: this.state.sockets, threads: this.state.threads, cores: this.state.cores };
+            state[paramName] = value;
+            // Get values of topology and calculate product of multiplying
+            state.count = Object.values(state).reduce((accumulator, currentValue) => accumulator * currentValue, 1);
+
+            this.setState(state);
+        }
+    }
+
+    render () {
+        return (<div className="modal-body">
+            <table className="vcpu-detail-modal-table">
+                <tr>
+                    <td>
+                        <table className='form-table-ct'>
+                            <InfoRecord
+                                descr={_("vCPU Count")}
+                                tooltip={_("Number of virtual CPUs that gonna be used.")}
+                                value={<input id="machines-vcpu-count-field" type="number" className="form-control" value={this.state.count} disabled />}
+                            />
+                        </table>
+                    </td>
+                    <td>
+                        <table className='form-table-ct vcpu-detail-modal-right'>
+                            <InfoRecord descr={_("Sockets")} tooltip={_("Preferred number of sockets to expose to the guest.")} value={
+                                <input id='socketsInput' value={this.state.sockets.toString()} onChange={this.handleChange("sockets")} disabled={this.props.isRunning} />
+                            } />
+                            <InfoRecord descr={_("Cores per socket")} value={
+                                <input id='coresInput' value={this.state.cores.toString()} onChange={this.handleChange("cores")} disabled={this.props.isRunning} />
+                            } />
+                            <InfoRecord descr={_("Threads per cores")} value={
+                                <input id='threadsInput' value={this.state.threads.toString()} onChange={this.handleChange("threads")} disabled={this.props.isRunning} />
+                            } />
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </div>);
+    }
+}
+
+VCPUModalBody.propTypes = {
+    cpu: React.PropTypes.shape({
+        topology: React.PropTypes.object.isRequired
+    }).isRequired,
+    onChange: React.PropTypes.func.isRequired,
+};
+
+export default function ({ vm, dispatch }) {
+    let state = {};
+    const onStateChange = (st) => {
+        state = Object.assign({}, st);
+    }
+
+    return show_modal_dialog(
+        {
+            title: cockpit.format(_("$0 vCPU Details"), vm.name),
+            body: (<VCPUModalBody cpu={vm.cpu} onChange={onStateChange} isRunning={vm.state == 'running'} />),
+            id: "machines-vcpu-modal-dialog"
+        },
+        { actions: [
+            {
+                caption: _("Apply"),
+                style: 'primary',
+                clicked: function () {
+                    return dispatch(setVCPUSettings(vm, null, null, state.sockets, state.threads, state.cores));
+                }
+            }
+        ]}
+    );
+}

--- a/pkg/ovirt/ovirtApiAccess.es6
+++ b/pkg/ovirt/ovirtApiAccess.es6
@@ -91,6 +91,28 @@ export function ovirtApiPost (resource, body, failHandler) {
             });
 }
 
+export function ovirtApiPut (resource, body, failHandler) {
+    logDebug(`ovirtApiPut(): resource: ${resource}, body: ${body}`);
+
+    const headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/xml',
+        'Authorization': 'Bearer ' + CONFIG.token,
+    };
+
+    const url = `/ovirt-engine/api/${resource}`;
+    return getHttpClient().request({
+        method: 'PUT',
+        path: url,
+        headers,
+        body,
+    })
+            .fail(function (exception, error) {
+                console.info(`HTTP PUT failed: ${JSON.stringify(error)}`, url);
+                handleOvirtError({ error, exception, failHandler });
+            });
+}
+
 export function handleOvirtError ({ error, exception, failHandler }) {
     if (!error) {
         logError(`oVirt operation failed but no error received`);

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -539,8 +539,132 @@ class TestMachines(MachineCase):
 
         b.wait_in_text("#vm-subVmTest1-network-2-state span", "up")
 
+<<<<<<< HEAD
     # HACK: broken with Chromium > 63, see https://github.com/cockpit-project/cockpit/pull/9229
     @unittest.skip("Broken with current chromium, see PR #9229")
+=======
+    def testVCPU(self):
+        b = self.browser
+        m = self.machine
+
+        self.startVm("subVmTest1")
+
+        self.login_and_go("/machines")
+        b.wait_in_text("body", "Virtual Machines")
+        b.wait_present("tbody tr th")
+        b.wait_in_text("tbody tr th", "subVmTest1")
+        b.click("tbody tr th") # click on the row header
+
+        b.wait_present("#vm-subVmTest1-state")
+        b.wait_in_text("#vm-subVmTest1-state", "running")
+
+        b.wait_present("#vm-subVmTest1-vcpus-count") # wait for the tab
+        b.click("#vm-subVmTest1-vcpus-count") # open VCPU modal detail window
+
+        b.wait_present(".vcpu-detail-modal-table")
+        b.is_present(".machines-vcpu-caution")
+
+        # Test basic vCPU properties
+        b.wait_val("#machines-vcpu-count-field", "1")
+        b.wait_val("#machines-vcpu-max-field", "1")
+
+        # Set new values
+        b.set_val("#machines-vcpu-max-field", "4")
+        b.set_val("#machines-vcpu-count-field", "3")
+
+        # Set new socket value
+        b.wait_present("#socketsSelect li[data-value=2] a")
+        b.click("#socketsSelect button");
+        b.click("#socketsSelect li[data-value=2] a")
+        b.wait_in_text("#socketsSelect button", "2")
+        b.wait_in_text("#coresSelect button", "1")
+        b.wait_in_text("#threadsSelect button", "2")
+
+        # Save
+        b.click(".apply")
+        b.wait_not_present("#cockpit_modal_dialog")
+
+        # Shut off VM for applying changes after save
+        b.click("#vm-subVmTest1-off-caret")
+        b.wait_visible("#vm-subVmTest1-forceOff")
+        b.click("#vm-subVmTest1-forceOff")
+        b.wait_in_text("#vm-subVmTest1-state", "shut off")
+
+        # Check changes
+        b.wait_visible("#vm-subVmTest1-vcpus-count")
+        b.wait_in_text("#vm-subVmTest1-vcpus-count", "3")
+
+        # Check after boot
+        # Run VM
+        b.click("#vm-subVmTest1-run")
+        b.wait_in_text("#vm-subVmTest1-state", "running")
+
+        # Check VCPU count
+        b.wait_visible("#vm-subVmTest1-vcpus-count")
+        b.wait_in_text("#vm-subVmTest1-vcpus-count", "3")
+
+        # Open dialog window
+        b.click("#vm-subVmTest1-vcpus-count")
+        b.wait_present(".vcpu-detail-modal-table")
+
+        # Check basic values
+        b.wait_val("#machines-vcpu-count-field", "3")
+        b.wait_val("#machines-vcpu-max-field", "4")
+
+        # Check sockets, cores and threads
+        b.wait_in_text("#socketsSelect button", "2")
+        b.wait_in_text("#coresSelect button", "1")
+        b.wait_in_text("#threadsSelect button", "2")
+
+        b.click(".cancel")
+        b.wait_not_present("#cockpit_modal_dialog")
+
+        # Shut off VM
+        b.click("#vm-subVmTest1-off-caret")
+        b.wait_visible("#vm-subVmTest1-forceOff")
+        b.click("#vm-subVmTest1-forceOff")
+        b.wait_in_text("#vm-subVmTest1-state", "shut off")
+
+        # Open dialog
+        b.wait_present("#vm-subVmTest1-vcpus-count")
+        b.click("#vm-subVmTest1-vcpus-count")
+
+        b.wait_present(".vcpu-detail-modal-table")
+
+        b.set_val("#machines-vcpu-count-field", "2")
+
+        # Set new socket value
+        b.wait_present("#coresSelect li[data-value=2] a")
+        b.click("#coresSelect button");
+        b.click("#coresSelect li[data-value=2] a")
+        b.wait_in_text("#coresSelect button", "2")
+        b.wait_in_text("#socketsSelect button", "2")
+        b.wait_in_text("#threadsSelect button", "1")
+
+        # Save
+        b.click(".apply")
+        b.wait_not_present("#cockpit_modal_dialog")
+
+        b.wait(lambda: m.execute("virsh dumpxml subVmTest1 | xmllint --xpath '/domain/cpu/topology[@sockets=\"2\"][@threads=\"1\"][@cores=\"2\"]' -"))
+
+        # Open dialog
+        b.wait_present("#vm-subVmTest1-vcpus-count")
+        b.click("#vm-subVmTest1-vcpus-count")
+
+        b.wait_present(".vcpu-detail-modal-table")
+        b.wait_not_present(".machines-vcpu-caution")
+
+        # Set new socket value
+        b.wait_in_text("#coresSelect button", "2")
+        b.wait_in_text("#socketsSelect button", "2")
+        b.wait_in_text("#threadsSelect button", "1")
+
+        b.wait_in_text("#vm-subVmTest1-vcpus-count", "2")
+
+        # Check value of sockets, threads and cores from VM dumpxml
+        m.execute("virsh dumpxml subVmTest1 | xmllint --xpath '/domain/cpu/topology[@sockets=\"2\"][@threads=\"1\"][@cores=\"2\"]' -")
+
+>>>>>>> machines: Add vCPU detail modal window
     def testExternalConsole(self):
         b = self.browser
 

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -539,10 +539,6 @@ class TestMachines(MachineCase):
 
         b.wait_in_text("#vm-subVmTest1-network-2-state span", "up")
 
-<<<<<<< HEAD
-    # HACK: broken with Chromium > 63, see https://github.com/cockpit-project/cockpit/pull/9229
-    @unittest.skip("Broken with current chromium, see PR #9229")
-=======
     def testVCPU(self):
         b = self.browser
         m = self.machine
@@ -664,7 +660,8 @@ class TestMachines(MachineCase):
         # Check value of sockets, threads and cores from VM dumpxml
         m.execute("virsh dumpxml subVmTest1 | xmllint --xpath '/domain/cpu/topology[@sockets=\"2\"][@threads=\"1\"][@cores=\"2\"]' -")
 
->>>>>>> machines: Add vCPU detail modal window
+    # HACK: broken with Chromium > 63, see https://github.com/cockpit-project/cockpit/pull/9229
+    @unittest.skip("Broken with current chromium, see PR #9229")
     def testExternalConsole(self):
         b = self.browser
 

--- a/test/verify/check-ovirt
+++ b/test/verify/check-ovirt
@@ -297,5 +297,54 @@ class TestOVirtMachines(MachineCase):
 
         # sit(self.machines)
 
+    def testVCPU(self):
+        b = self.browser
+
+        self.login_and_go("/machines#token={0}".format(self.access_token))
+        b.wait_present(".main-app-div")
+        b.wait_in_text("body", "Virtual Machines")
+
+        b.wait_present("tbody tr th")
+        b.wait_in_text("tbody tr th", "VM")
+        b.click("tbody tr th") # click on the row header
+
+        b.wait_present("#vm-VM-state")
+        b.wait_in_text("#vm-VM-state", "running")
+
+        b.click("#vm-VM-off-caret")
+        b.wait_visible("#vm-VM-forceOff")
+        b.click("#vm-VM-forceOff")
+        b.wait_present("thead tr td")
+        b.wait_in_text("thead tr td", "No VM is running")
+
+        # Go to Cluster tab
+        b.click("#ovirt-topnav-clustervms")
+        b.wait_in_text("body", "Virtual Machines of Default cluster")
+        b.wait_present("tr.listing-ct-item > th")
+        b.wait_in_text("tr.listing-ct-item > th", "VM") # name
+        with b.wait_timeout(180):
+            b.wait_in_text("tr.listing-ct-item > td:nth-child(12)", "shut off") # state
+
+        b.wait_in_text("#cluster-VM-cpus", "1")
+        b.click("#cluster-VM-cpus") # open VCPU modal detail window
+
+        b.wait_present(".vcpu-detail-modal-table")
+        b.is_present(".machines-vcpu-caution")
+
+        # Set new socket value
+        b.set_val("#socketsInput", "2")
+        b.set_val("#coresInput", "1")
+        b.set_val("#threadsInput", "2")
+
+        b.wait_val("#machines-vcpu-count-field", "4")
+
+        # Save
+        b.click(".apply")
+        b.wait_not_present("#cockpit_modal_dialog")
+
+        # Check changes
+        b.wait_visible("#cluster-VM-cpus")
+        b.wait_in_text("#cluster-VM-cpus", "4")
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
At request of @mareklibra, I added detail modal for vCPU. It getting data from `vcpu` and `cpu` (topology) tags. @petervo, @mareklibra  please review.
Pressing vCPUs count will open modal window:
![pic1](https://user-images.githubusercontent.com/3332176/31496932-94111cde-af5d-11e7-84a5-4471ef0e7bcd.png)
If `topology` tag doesn't exist than values of `threads`, `sockets` and `cores` will be `N/A`
![pic2](https://user-images.githubusercontent.com/3332176/31501799-8964ab8a-af6b-11e7-8908-7c3c0db456ce.png)


