### PR TITLE
test: Allow authorize messages in testNoPermission test

### DIFF
--- a/test/verify/check-shutdown-restart
+++ b/test/verify/check-shutdown-restart
@@ -37,6 +37,8 @@ class TestShutdownRestart(MachineCase):
         m = self.machine
         b = self.browser
 
+        self.allow_authorize_journal_messages()
+
         # Create a user without any role
         m.execute("useradd user -s /bin/bash -c 'User' || true")
         m.execute("echo user:foobar | chpasswd")


### PR DESCRIPTION
This test commonly fails with

    Unexpected journal message 'cannot reauthorize identity(s): unix-user:builder unix-user:admin'

which is legit as `check-shutdown-restart TestShutdownRestart.testNoPermission`
disables the admin powers from the test users.

----

Example: https://fedorapeople.org/groups/cockpit/logs/pull-7874-20171013-052323-e1446ce4-verify-ubuntu-stable/log.html#89