### PR TITLE
bots: Tell tests-scan about upcoming rhel-7-5 image

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -49,6 +49,7 @@ NPM_REPOS = {
 REDHAT_VERIFY = {
     "verify/rhel-7": [ 'master' ],
     "verify/rhel-7-4": [ 'master', 'rhel-7.4' ],
+    "verify/rhel-7-5": [ ],
     "verify/rhel-atomic": [ 'master' ],
     'selenium/explorer': [ 'master' ],
 }


### PR DESCRIPTION
We will soon add an image for RHEL 7.5 beta.

---

I will trigger only one test, as this is not really covered by CI.