### PR TITLE
tools/cockpit.spec: Adjust storaged/udisks2 dependency

### DIFF
--- a/bots/images/scripts/lib/fedora.install
+++ b/bots/images/scripts/lib/fedora.install
@@ -12,7 +12,8 @@ fi
 
 do_build=
 do_install=
-mock_opts=""
+# we build RHEL 7.x in a CentOS mock, thus we can't parse os-release in the .spec
+mock_opts="--define='os_version_id $(. /etc/os-release; echo $VERSION_ID)'"
 args=$(getopt -o "vqs:" -l "verbose,quick,skip:,build,install,rhel,HACK-no-bootstrap-chroot" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
Adjust the target OS specific dependencies of cockpit-storaged:

 * RHEL 7.4 and current CentOS 7 ship storaged and do not support
   Recommends:.
 * RHEL = 7.5 will only ship udisks2, which does (rightfully) not
   provide storaged. Still no support for Recommends:.
 * RHEL 8 will only ship udisks2, but does support Recommends:
 * Fedora 27 also moved to udisks2, earlier versions have storaged. All
   supported Fedora releases support Recommends:.

Standard RPM macros do not allow us to differentiate between RHEL 7.4
and 7.5 (%rhel == 7), so check /etc/os-release for that. This works for
"real-life" builds, but not for building on our test images as these use
a CentOS 7 mock chroot for all RHEL builds. Thus do the os-release
parsing in fedora.install and pass on the value as define.

The udisks2 modules for lvm2 and iscsi are not yet available on RHEL
7.5, so skip these dependencies for now.