### PR TITLE
bots: Add RHEL 7.5 nightly image

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -74,6 +74,12 @@ TRIGGERS = {
         "verify/rhel-7",
         "verify/rhel-atomic"  # builds in rhel-7
     ],
+    "rhel-7-4": [
+        "verify/rhel-7-4"
+    ],
+    "rhel-7-5": [
+        "verify/rhel-7-5"
+    ],
     "rhel-atomic": [
         "verify/rhel-atomic"
     ]
@@ -84,6 +90,7 @@ REDHAT_STORE = "https://cockpit-11.e2e.bos.redhat.com:8493"
 STORES = {
     "rhel-7": REDHAT_STORE,
     "rhel-7-4": REDHAT_STORE,
+    "rhel-7-5": REDHAT_STORE,
     "rhel-atomic": REDHAT_STORE,
     "windows-8": REDHAT_STORE
 }

--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -37,6 +37,7 @@ REFRESH = {
     "ipa": { "refresh-days": 120 },
     'rhel-7': { },
     'rhel-7-4': { },
+    'rhel-7-5': { },
     'rhel-atomic': { },
     'windows-8': { "refresh-days": 30 },
 }

--- a/bots/images/rhel-7-5
+++ b/bots/images/rhel-7-5
@@ -1,0 +1,1 @@
+rhel-7-5-1121d7fae3584b510f9afcaeef1cc4a7cb304e09de2bd23063f8f4b28c34e10f.qcow2

--- a/bots/images/scripts/rhel-7-5.bootstrap
+++ b/bots/images/scripts/rhel-7-5.bootstrap
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+BASE=$(dirname $0)
+#$BASE/virt-builder-fedora "$1" rhel-7.5 x86_64 ${SUBSCRIPTION_PATH:-~/.rhel}
+$BASE/virt-install-fedora "$1" x86_64 "http://download.eng.bos.redhat.com/nightly/latest-RHEL-7/compose/Server/x86_64/os/" ${SUBSCRIPTION_PATH:-~/.rhel}

--- a/bots/images/scripts/rhel-7-5.install
+++ b/bots/images/scripts/rhel-7-5.install
@@ -1,0 +1,1 @@
+rhel-7.install

--- a/bots/images/scripts/rhel-7-5.setup
+++ b/bots/images/scripts/rhel-7-5.setup
@@ -1,0 +1,1 @@
+rhel-7.setup

--- a/bots/images/scripts/rhel-7.setup
+++ b/bots/images/scripts/rhel-7.setup
@@ -43,11 +43,30 @@ set -x
 
 if [ ! -f "$SKIP_REPO_FLAG" ]; then
     # Configure repositories.
-    #
-    # if disabling the repos doesn't work, do without
-    yum -y --disablerepo=rhel-7-server-htb-rpms --disablerepo=rhel-sjis-for-rhel-7-server-rpms install yum-utils || yum -y install yum-utils
-    yum-config-manager --enable rhel-7-server-optional-rpms
-    yum-config-manager --enable rhel-7-server-extras-rpms
+
+    if [ "$IMAGE" = "rhel-7-5" ]; then
+cat <<EOF > /etc/yum.repos.d/nightly.repo
+[EXTRAS-7.5-LATEST]
+name=rhel-extras-compose
+baseurl=http://download.eng.bos.redhat.com/devel/candidate-trees/latest-EXTRAS-7-RHEL-7/compose/Server/x86_64/os
+enabled=1
+gpgcheck=0
+
+[RHEL-7.5-NIGHTLY]
+name=base-rhel
+baseurl=http://download.eng.bos.redhat.com/nightly/latest-RHEL-7/compose/Server/x86_64/os
+enabled=1
+gpgcheck=0
+EOF
+        # disable all default repos as they don't exist yet
+        sed -i 's/enabled = 1/enabled = 0/' /etc/yum.repos.d/redhat.repo
+        yum -y install yum-utils
+    else
+        # if disabling the repos doesn't work, do without
+        yum -y --disablerepo=rhel-7-server-htb-rpms --disablerepo=rhel-sjis-for-rhel-7-server-rpms install yum-utils || yum -y install yum-utils
+        yum-config-manager --enable rhel-7-server-optional-rpms
+        yum-config-manager --enable rhel-7-server-extras-rpms
+    fi
 
     # the following don't necessarily need to work
     yum-config-manager --disable rhel-sjis-for-rhel-7-server-rpms || true
@@ -82,9 +101,6 @@ realmd \
 selinux-policy-targeted \
 setroubleshoot-server \
 subscription-manager \
-storaged \
-storaged-lvm2 \
-storaged-iscsi \
 sos \
 tuned \
 "
@@ -108,6 +124,16 @@ virt-install \
 cryptsetup \
 qemu-kvm \
 "
+
+# RHEL 7.5 renamed/dropped some packages
+if [ "$IMAGE" = "rhel-7-5" ]; then
+    UDISKS="udisks2 udisks2-lvm2 udisks2-iscsi"
+    TEST_PACKAGES="${TEST_PACKAGES/systemtap-runtime-virtguest /}"
+else
+    UDISKS="storaged storaged-lvm2 storaged-iscsi"
+fi
+
+COCKPIT_DEPS="$COCKPIT_DEPS $UDISKS"
 
 # The rhel-7.4 image has the cockpit packages from base preinstalled, to check for API breakages
 if [ "$IMAGE" = "rhel-7-4" ]; then
@@ -135,8 +161,8 @@ done
 [ -z "$error" ] || exit 1
 set -x
 
-# For debugging storaged crashes
-debuginfo-install -y storaged storaged-lvm2 storaged-iscsi
+# For debugging udisks/storaged crashes
+debuginfo-install -y $UDISKS
 
 # Prepare for building
 

--- a/bots/images/scripts/rhel-7.setup
+++ b/bots/images/scripts/rhel-7.setup
@@ -105,6 +105,7 @@ valgrind \
 gdb \
 yum-utils \
 virt-install \
+cryptsetup \
 qemu-kvm \
 "
 

--- a/bots/images/scripts/virt-install-fedora
+++ b/bots/images/scripts/virt-install-fedora
@@ -79,6 +79,7 @@ echo "$(cat $base/network-ifcfg-eth0)" > /etc/sysconfig/network-scripts/ifcfg-et
 echo "$(cat $base/network-ifcfg-eth1)" > /etc/sysconfig/network-scripts/ifcfg-eth1
 sed -i 's/GRUB_TIMEOUT.*/GRUB_TIMEOUT=0/; /GRUB_CMDLINE_LINUX=/ s/"$/ net.ifnames=0 biosdevname=0"/' /etc/default/grub
 grub2-mkconfig -o /boot/grub2/grub.cfg
+systemctl is-enabled sshd.socket || systemctl is-enabled sshd.service || systemctl enable sshd.socket
 %end
 EOF
 

--- a/bots/naughty/rhel-7-5/6359-glib-networking-change-cert
+++ b/bots/naughty/rhel-7-5/6359-glib-networking-change-cert
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-openshift", line *, in testReconnectChangeCert
+    b.wait_present("#service-list")
+*
+Error: timeout

--- a/bots/naughty/rhel-7-5/7891-selinux-denies-virtlogd-dbus
+++ b/bots/naughty/rhel-7-5/7891-selinux-denies-virtlogd-dbus
@@ -1,0 +1,1 @@
+Error: type=1400 * avc:  denied  { connectto } * comm="virtlogd" path="/run/dbus/system_bus_socket"

--- a/bots/naughty/rhel-7-5/7891-selinux-denies-virtlogd-dbus-2
+++ b/bots/naughty/rhel-7-5/7891-selinux-denies-virtlogd-dbus-2
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-machines", line *, in testBasic
+    wait(lambda: "Linux version" in self.machine.execute("cat {0}".format(args["logfile"])), delay=3)
+*
+Error: Condition did not become true.

--- a/bots/naughty/rhel-7-5/7904-semanage-policydb-version
+++ b/bots/naughty/rhel-7-5/7904-semanage-policydb-version
@@ -1,0 +1,4 @@
+ERROR: policydb version 31 does not match my version range 15-30
+ERROR: Unable to open policy //etc/selinux/targeted/policy/policy.31.
+*
+CalledProcessError: Command '! selinuxenabled || semanage *' returned non-zero exit status 1

--- a/bots/naughty/rhel-7-5/7904-semanage-policydb-version-2
+++ b/bots/naughty/rhel-7-5/7904-semanage-policydb-version-2
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-setroubleshoot", line *, in testTroubleshootAlerts
+    b.wait_in_text("body", "No SELinux alerts.")
+*
+Error: timeout

--- a/bots/naughty/rhel-7-5/7916-sssd-crash
+++ b/bots/naughty/rhel-7-5/7916-sssd-crash
@@ -1,0 +1,6 @@
+* sssd.service*
+   Active: failed (Result: core-dump) *
+*
+* #0  * (memberof.so)
+*
+  File "test/verify/check-realms", line *, in testNegotiate

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -49,7 +49,7 @@ NPM_REPOS = {
 REDHAT_VERIFY = {
     "verify/rhel-7": [ 'master' ],
     "verify/rhel-7-4": [ 'master', 'rhel-7.4' ],
-    "verify/rhel-7-5": [ ],
+    "verify/rhel-7-5": [ 'master', 'rhel-7.5' ],
     "verify/rhel-atomic": [ 'master' ],
     'selenium/explorer': [ 'master' ],
 }

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -41,6 +41,7 @@ def can_manage(machine):
                               "fedora-testing",
                               "rhel-7",
                               "rhel-7-4",
+                              "rhel-7-5",
                               "centos-7",
                               "rhel-atomic",
                               "fedora-atomic",

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -295,7 +295,7 @@ s.send("PRIORITY=3\\nFOO=bar\\n")'
 
         b.wait_text("#journal-entry-message", "[no data]")
 
-    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-25", "fedora-i386", "fedora-testing", "rhel-7-4")
+    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-25", "fedora-i386", "fedora-testing", "rhel-7-4", "rhel-7-5")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1604", "rhel-atomic", "fedora-atomic", "continuous-atomic")
     def testAbrtSegv(self):
         b = self.browser
@@ -330,7 +330,7 @@ s.send("PRIORITY=3\\nFOO=bar\\n")'
         sel += " .panel-body:contains('signal: 11  executable: ')"
         b.wait_present(sel)
 
-    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-25", "fedora-i386", "fedora-testing", "rhel-7-4")
+    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-25", "fedora-i386", "fedora-testing", "rhel-7-4", "rhel-7-5")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1604", "rhel-atomic", "fedora-atomic", "continuous-atomic")
     def testAbrtDelete(self):
         b = self.browser
@@ -366,7 +366,7 @@ s.send("PRIORITY=3\\nFOO=bar\\n")'
         b.wait_not_present("#journal-entry-fields .nav")
 
 
-    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-25", "fedora-i386", "fedora-testing", "rhel-7-4")
+    @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-25", "fedora-i386", "fedora-testing", "rhel-7-4", "rhel-7-5")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1604", "rhel-atomic", "fedora-atomic", "continuous-atomic")
     def testAbrtReport(self):
         # The testing server is located at verify/files/mock-faf-server.py

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -114,7 +114,7 @@ def rhsmcertd_hack(m):
     m.execute("systemctl stop rhsmcertd || true")
 
 
-@skipImage("No OSTree available", "centos-7", "debian-stable", "debian-testing", "fedora-25", "fedora-26", "fedora-27", "fedora-testing", "fedora-i386", "rhel-7", "rhel-7-4", "ubuntu-1604", "ubuntu-stable")
+@skipImage("No OSTree available", "centos-7", "debian-stable", "debian-testing", "fedora-25", "fedora-26", "fedora-27", "fedora-testing", "fedora-i386", "rhel-7", "rhel-7-4", "rhel-7-5", "ubuntu-1604", "ubuntu-stable")
 class OstreeRestartCase(MachineCase):
     provision = {
         "machine1": { "address": "10.111.113.2/20", "dns": "10.111.113.2" }
@@ -415,7 +415,7 @@ class OstreeRestartCase(MachineCase):
 
         self.allow_restart_journal_messages()
 
-@skipImage("No OSTree available", "centos-7", "debian-stable", "debian-testing", "fedora-25", "fedora-26", "fedora-27", "fedora-testing", "fedora-i386", "rhel-7", "rhel-7-4", "ubuntu-1604", "ubuntu-stable")
+@skipImage("No OSTree available", "centos-7", "debian-stable", "debian-testing", "fedora-25", "fedora-26", "fedora-27", "fedora-testing", "fedora-i386", "rhel-7", "rhel-7-4", "rhel-7-5", "ubuntu-1604", "ubuntu-stable")
 class OstreeCase(MachineCase):
     provision = {
         "machine1": { "address": "10.111.113.2/20", "dns": "10.111.113.2" }

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -656,7 +656,7 @@ class TestAutoUpdates(PackageCase):
             self.backend = "apt"
         elif self.machine.image.startswith("fedora"):
             self.backend = "dnf"
-        elif self.machine.image in ["centos-7", "rhel-7", "rhel-7-4"]:
+        elif self.machine.image in ["centos-7", "rhel-7", "rhel-7-4", "rhel-7-5"]:
             self.backend = "yum"
         else:
             raise NotImplementedError("unknown image " + self.machine.image)

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -550,7 +550,7 @@ class TestUpdatesSubscriptions(PackageCase):
         self.candlepin.execute("systemctl start tomcat")
 
         # remove all existing products (RHEL server), as we can't control them
-        m.execute("rm /etc/pki/product-default/*.pem /etc/pki/product/*.pem")
+        m.execute("rm -f /etc/pki/product-default/*.pem /etc/pki/product/*.pem")
 
         # download product info from the candlepin machine and install it
         product_file = os.path.join(self.tmpdir, "88888.pem")

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -73,7 +73,7 @@ class TestStorage(StorageCase):
         check_type("xfs")
         check_type("ext4")
         check_type("vfat")
-        if not m.image in [ "rhel-7", "rhel-7-4", "centos-7" ]:
+        if not m.image in [ "rhel-7", "rhel-7-4", "rhel-7-5", "centos-7" ]:
             check_type("ntfs")
 
 if __name__ == '__main__':

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -24,6 +24,8 @@ from testlib import *
 from storagelib import *
 
 @skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
+# HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1503100
+@skipImage("udisks2-lvm2 missing in RHEL 7.5", "rhel-7-5")
 class TestStorage(StorageCase):
     def testHiddenLuks(self):
         m = self.machine

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -31,7 +31,7 @@ class TestStorage(StorageCase):
         b.wait_timeout(120)
 
         # rhel-7 is missing the iSCSI session API
-        if m.image in ["rhel-7", "rhel-7-4"]:
+        if m.image in ["rhel-7", "rhel-7-4", "rhel-7-5"]:
             self.login_and_go("/storage")
             # The optional parts of the UI have been configured
             # properly before the page is shown, so we can now

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -24,6 +24,8 @@ from testlib import *
 from storagelib import *
 
 @skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
+# HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1503100
+@skipImage("udisks2-lvm2 missing in RHEL 7.5", "rhel-7-5")
 class TestStorage(StorageCase):
     def testLvm(self):
         m = self.machine

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -24,6 +24,8 @@ from storagelib import *
 
 @skipImage("UDisks doesn't have support for multipath", "debian-stable", "ubuntu-1604", "ubuntu-stable")
 @skipImage("No multipath on Debian", "debian-testing")
+# HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1503100
+@skipImage("udisks2-lvm2 missing in RHEL 7.5", "rhel-7-5")
 class TestStorage(StorageCase):
     def testBasic(self):
         m = self.machine

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -24,6 +24,8 @@ from testlib import *
 from storagelib import *
 
 @skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
+# HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1503100
+@skipImage("udisks2-lvm2 missing in RHEL 7.5", "rhel-7-5")
 class TestStorage(StorageCase):
     def testResize(self):
         m = self.machine

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -252,7 +252,7 @@ class TestSystemInfo(MachineCase):
         self.assertIn("Mon Jun  4 06:34:", m.execute("date"))
         self.assertIn("EEST 2018\n", m.execute("date"))
 
-    @skipImage("No NTP servers config", "centos-7", "continuous-atomic", "rhel-7", "rhel-7-4", "rhel-atomic")
+    @skipImage("No NTP servers config", "centos-7", "continuous-atomic", "rhel-7", "rhel-7-4", "rhel-7-5", "rhel-atomic")
     def testTimeServers(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
Build from the latest nightly compose, what will eventually become RHEL
7.5.  This uses all built cockpit packages for the time being, until 7.5 
gets released. At that point we will pre-install the cockpit packages
from base (like on rhel-7-4) and rhel-7 will switch over to 7.5.

Similar to what commit 9620ff41 did for RHEL 7.4 while it was beta,
disable all default redhat repositories (as they don't exist yet) and 
add the nightly ones in rhel-7.setup, when building the rhel-7-5 image.

Add some test package special cases to rhel-7.setup, as storaged was 
replaced by udisks2 and there does not seem to be a replacement for 
systemtap-runtime-virtguest.

---

This also needs some adjustment to virt-install-fedora to enable sshd (separate commit), and adjusting cockpit-storaged's dependencies (PR #7886).

 - [x] upload rhel-7-5 image
 - [x] debug why building on infra [fails](http://fedorapeople.org/groups/cockpit/logs/image-refresh-7887-20171016-090707/) - fixed with container rebuild (libvirt regression fix)
 - [x] adjust cockpit-storaged's dependencies (PR #7886)
 - [x] wait for udisks2 to ship missing modules in RHEL 7.5; disable the tests for the time being 
 - [x] fix PackageKit tests (they assume that there is at least one RHEL product installed)
 - [x] disable ABRT tests, apparently ABRT packages on RHEL 7.5 are still not recent enough
 - [x] naughty override for new SELinux violations in Machines tests (#7891)
 - [x] copy the glib-networking naughty override
 - [x] investigate `check-storage-multipath` regression (needs LVM)
 - [x] investigate `check-storage-used` regression (cryptsetup not installed)
 - [x] handle SELinux regression [policydb version 31 does not match my version range 15-30
](https://bugzilla.redhat.com/show_bug.cgi?id=1500888) in `check-multi-machine`, `check-connection`, `check-setroubleshoot`
 - [x] make check-realms fail usefully (PR #7915)
 - [x] add naughty override for sssd.service crash (#7916)