### PR TITLE
bots: Improve unattended downloads

### DIFF
--- a/bots/image-download
+++ b/bots/image-download
@@ -191,13 +191,16 @@ def download_images(image_list, force, quiet, state, store):
     if not os.path.exists(DATA):
         os.makedirs(DATA)
 
-    # A default set of images are all links in git
+    # A default set of images are all links in git.  These links have
+    # no directory part.  Other links might exist, such as the
+    # auxiliary links created by committed_target above, and we ignore
+    # them.
     if not image_list:
         image_list = []
         if not state:
             for filename in os.listdir(IMAGES):
                 link = os.path.join(IMAGES, filename)
-                if os.path.islink(link):
+                if os.path.islink(link) and os.path.dirname(os.readlink(link)) == "":
                     image_list.append(filename)
 
     for image in image_list:

--- a/bots/image-download
+++ b/bots/image-download
@@ -203,14 +203,21 @@ def download_images(image_list, force, quiet, state, store):
                 if os.path.islink(link) and os.path.dirname(os.readlink(link)) == "":
                     image_list.append(filename)
 
-    for image in image_list:
-        if state:
-            target = state_target(image)
-        else:
-            target = committed_target(image)
-        if force or state or not os.path.exists(target):
-            download(target, force, quiet, store)
+    success = True
 
+    for image in image_list:
+        try:
+            if state:
+                target = state_target(image)
+            else:
+                target = committed_target(image)
+            if force or state or not os.path.exists(target):
+                download(target, force, quiet, store)
+        except Exception as ex:
+            success = False
+            sys.stderr.write("image-download: {0}\n".format(str(ex)))
+
+    return success
 
 def main():
     parser = argparse.ArgumentParser(description='Download a bot state or images')
@@ -221,10 +228,7 @@ def main():
     parser.add_argument('image', nargs='*')
     args = parser.parse_args()
 
-    try:
-        download_images(args.image, args.force, args.quiet, args.state, args.store)
-    except RuntimeError, ex:
-        sys.stderr.write("image-download: {0}\n".format(str(ex)))
+    if not download_images(args.image, args.force, args.quiet, args.state, args.store):
         return 1
 
     return 0

--- a/bots/image-download
+++ b/bots/image-download
@@ -181,8 +181,8 @@ def committed_target(image):
     # The image file in the images directory, may be same as dest
     image_file = os.path.join(IMAGES, os.readlink(link))
 
-    # Double check that symlink in place
-    if not os.path.exists(image_file):
+    # Double check that symlink in place but never make a cycle.
+    if not os.path.exists(image_file) and os.path.abspath(dest) != os.path.abspath(image_file):
         os.symlink(os.path.abspath(dest), image_file)
 
     return dest


### PR DESCRIPTION
I want to batch my image downloads for times when I have good bandwidth, and these changes should allow me to fire off "./bots/image-download" and walk away.
