### PR TITLE
users: fix string to be about password instead of account expiry

### DIFF
--- a/pkg/users/index.html
+++ b/pkg/users/index.html
@@ -342,7 +342,7 @@
                 <td>
                   <label>
                     <input type="radio" id="password-expiration-never" name="mode" value="never"/>
-                    <span translate>Never lock account</span>
+                    <span translate>Never expire password</span>
                   </label>
                 </td>
               </tr>


### PR DESCRIPTION
The string incorrectly referred to account expiration, should be
password expiration.

Fixes #7895