### PR TITLE
Image refresh for fedora-testing - fixed in PR #8297, close after that

### DIFF
--- a/bots/images/fedora-testing
+++ b/bots/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-9550057fa4ee4057b956ad5720dc4ecac73647087a4bb2139afaa7d3d7e10f80.qcow2
+fedora-testing-fa794631f79cece1eebca09f9b414bb24accae9086b3f41442ec4cee239bc683.qcow2


### PR DESCRIPTION
Image refresh for fedora-testing
 * [x] image-refresh fedora-testing