### PR TITLE
kubernetes: Fix regression in sidebar layout

### DIFF
--- a/pkg/kubernetes/styles/sidebar.less
+++ b/pkg/kubernetes/styles/sidebar.less
@@ -58,7 +58,7 @@
     .nav-sidebar {
         width: unit(@sidebar-width-md, px);
         a {
-            padding: 5px 8px !important;
+            padding: 7px 8px 5px 8px !important;
             height: 40px !important;
             width: unit(@sidebar-width-md, px) !important;
             i {
@@ -68,6 +68,8 @@
             span {
                 display: inline !important;
                 font-size: 12px;
+		margin-left: 4px;
+		margin-top: 2px;
             }
         }
     }


### PR DESCRIPTION
With the new Patternfly in 09189397042c9f6fcc6db5024aa3282cc5cb16e7
the layout for the kubernetes sidebar broke. This should fix
the padding.