### PR TITLE
kubernetes: Fix Topology view layout

### DIFF
--- a/pkg/kubernetes/scripts/topology.js
+++ b/pkg/kubernetes/scripts/topology.js
@@ -171,7 +171,7 @@
             angular.extend($scope, actions);
 
             function resized() {
-                $scope.height = { height: (window.innerHeight - 55) + "px" };
+                $scope.height = { height: (window.innerHeight - 60) + "px" };
                 if (ready)
                     $scope.$digest();
             }

--- a/pkg/kubernetes/styles/app.less
+++ b/pkg/kubernetes/styles/app.less
@@ -55,11 +55,14 @@ path.line.highlight {
   margin-left: 110px;
   margin-right: 0px;
   min-height: 100%;
-  padding-bottom: 20px;
 }
 
 #content > .row {
     margin-right: 0px;
+}
+
+#content > *:last-child {
+    padding-bottom: 20px;
 }
 
 /* When panel is editable, then buttons are visible */

--- a/pkg/kubernetes/styles/topology.less
+++ b/pkg/kubernetes/styles/topology.less
@@ -1,5 +1,8 @@
 kubernetes-topology-graph {
     margin-right: 25%;
+    margin-top: 55px;
+    padding-bottom: 0px !important;
+    overflow: hidden;
 }
 
 .kube-pane {


### PR DESCRIPTION
The topology view went goes under the content-filter on the top
and had blank space on the bottom. Lets fix this the layout.