### PR TITLE
ws: Fix regression in ./configure --with-branding

### DIFF
--- a/src/ws/cockpitbranding.c
+++ b/src/ws/cockpitbranding.c
@@ -64,6 +64,11 @@ cockpit_branding_calculate_static_roots (const gchar *os_id,
   if (is_local)
     add_system_dirs (dirs);
 
+#ifdef PACKAGE_BRAND
+  os_id = PACKAGE_BRAND;
+  os_variant_id = NULL;
+#endif
+
   if (os_id)
     {
       if (os_variant_id)


### PR DESCRIPTION
The ./configure option --with-branding no longer worked since
the commit 3a03ebe96a26db1ded577fd6e1d7c7bec0c00ece