### PR TITLE
tests: Fail early and verbosely if sssd.service crashes

### DIFF
--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -161,6 +161,10 @@ for x in $(seq 1 20); do
     if nslookup -type=SRV _ldap._tcp.cockpit.lan; then
         break
     else
+        if systemctl --quiet is-failed sssd.service; then
+            systemctl status --lines=100 sssd.service >&2
+            exit 1
+        fi
         sleep $x
     fi
 done
@@ -186,6 +190,10 @@ fi
 for x in $(seq 1 60); do
     if getent passwd admin@cockpit.lan; then
         break
+    fi
+    if systemctl --quiet is-failed sssd.service; then
+        systemctl status --lines=100 sssd.service >&2
+        exit 1
     fi
     sleep $x
 done


### PR DESCRIPTION
If sssd.service fails, we previously just ran the polling loop until the
end (20 mins) and then the log did not show any root cause. With that,
the test fails much faster and allows us to write naughty overrides
against the real failure.