### PR TITLE
tools: Ignore pre-installed nvm binaries and modules

### DIFF
--- a/tools/semaphore-prepare
+++ b/tools/semaphore-prepare
@@ -5,7 +5,6 @@ sudo rm /etc/apt/sources.list.d/*
 sudo apt-get update
 sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-login-dev libsystemd-journal-dev libkrb5-dev pcp pkg-config valgrind xmlto xsltproc pyflakes npm nodejs-legacy git libfontconfig1 dbus ssh libglib2.0-0-dbg glib-networking-dbg curl
 
-# semaphore already has latest npm pre-installed, do that for local chroots
 if dpkg --compare-versions "$(npm --version)" lt "4"; then
    sudo npm install -g n
    sudo n stable

--- a/tools/semaphore-run
+++ b/tools/semaphore-run
@@ -3,6 +3,12 @@
 set -o pipefail
 set -eux
 
+# on semaphore the old npm in ~/.nvm is preferred over /usr/local, where "g stable" ends up
+# also, it has pre-installed a lot of random modules which interfere with our own packages.json
+if hostname | grep -q ^semaphore && [ -d ~/.nvm ] ; then
+    mv ~/.nvm ~/.nvm.disabled
+fi
+
 ARCH=${1:-}
 
 if [ "$ARCH" = i386 ]; then


### PR DESCRIPTION
On semaphore, our semaphore-prepare script actually already installs the
latest version via `g stable`, but it does not get used as
~/.bash_profile sets a `$PATH` that prefers the user-local version in
~/.nvm. This dir also has a ton of modules already pre-installed, which
is both breaking our build (like in #7870) and also potentially hides
missing dependencies in our package.json. So disable it.
    
Drop the comment in semaphore-prepare as it's not actually true.
