### PR TITLE
ovirt: Clean up install.sh

### DIFF
--- a/pkg/ovirt/install.sh
+++ b/pkg/ovirt/install.sh
@@ -21,19 +21,20 @@
 
 ENGINE_FQDN=$1
 ENGINE_PORT=$2
-COCKPIT_DIR=${3:-/usr/share/cockpit}  # TODO: get it dynamically via 'rpm -q cockpit-shell --fileprovide' or 'dpkg -L'
+
 ETC_COCKPIT_DIR='/etc/cockpit'
-VIRSH_CONNECTION_URI=$4 # optional
+
+VIRSH_CONNECTION_URI=$3 # optional
 VIRSH_CONNECTION_NAME='remote' # used if VIRSH_CONNECTION_URI is set
 
 EXIT_PARAMS=1 # wrong command parameters
 EXIT_NO_ACCESS_MACHINES_OVIRT_CONFIG=3 # can't write to /etc/cockpit/machines-ovirt.config, try as root
 
 function usage() {
-  echo Usage: $0 '[ENGINE_FQDN] [ENGINE_PORT] [[COCKPIT_INSTLLATION_DIR]] [[VIRSH_CONNECTION_URI]]'
+  echo Usage: $0 '[ENGINE_FQDN] [ENGINE_PORT] [[VIRSH_CONNECTION_URI]]'
   echo Example: $0 engine.mydomain.com 443
-  echo Example: $0 engine.mydomain.com 443 /usr/share/cockpit
-  echo Example: $0 engine.mydomain.com 443 /usr/share/cockpit qemu:///system
+  echo Example: $0 engine.mydomain.com 443
+  echo Example: $0 engine.mydomain.com 443 qemu:///system
 }
 
 function checkParams() {

--- a/test/verify/check-ovirt
+++ b/test/verify/check-ovirt
@@ -36,7 +36,6 @@ VIRSH_CONNECTION_URI = "qemu+tcp://10.111.113.5/system"
 OVIRT_USER = "admin@internal"
 OVIRT_PWD = "engine"
 CA_PEM_FILE = '/etc/pki/vdsm/certs/cacert.pem'
-COCKPIT_DIR = '/usr/share/cockpit'
 VDSM_CONF_FILE = '/etc/vdsm/vdsm.conf'
 
 WAIT_SCRIPT = """
@@ -103,8 +102,10 @@ class TestOVirtMachines(MachineCase):
         # In case of passing this initialization step via UI, a series of redirects (oVirt verification and authentication) would follow.
         # The installation dialog calls 'ovirt/install.sh' script, so this simplification is acceptable for the test.
         m = self.machine
-        m.execute("bash /usr/share/cockpit/ovirt/install.sh {0} {1} {2} {3}".format(ENGINE_FQDN, ENGINE_PORT, COCKPIT_DIR, VIRSH_CONNECTION_URI))
-        m.execute("sed -i 's/false/true/' /etc/cockpit/machines-ovirt.config") # turn on debug messages
+
+        m.execute("bash /usr/share/cockpit/ovirt/install.sh {0} {1} {2}".format(ENGINE_FQDN, ENGINE_PORT, VIRSH_CONNECTION_URI))
+        # m.execute("sed -i 's/false/true/' /etc/cockpit/machines-ovirt.config") # turn on debug messages
+
         self.access_token = self.get_ovirt_token()
 
     def get_ovirt_token(self):


### PR DESCRIPTION
The `install.sh` script no more relies on cockpit-ovirt installation
directory, so the `COCKPIT_DIR` variable is removed.

Closes #7905