### PR TITLE
ovirt: use synchronous calls for API calls

### DIFF
--- a/pkg/ovirt/provider.es6
+++ b/pkg/ovirt/provider.es6
@@ -81,7 +81,7 @@ OVIRT_PROVIDER.SHUTDOWN_VM = function (payload) {
         forceNextOvirtPoll();
         return ovirtApiPost(
             `vms/${id}/shutdown`,
-            '<action />',
+            '<action><async>false</async></action>',
             buildFailHandler({
                 dispatch,
                 name: vmName,
@@ -105,7 +105,7 @@ OVIRT_PROVIDER.FORCEOFF_VM = function (payload) {
         forceNextOvirtPoll();
         return ovirtApiPost(
             `vms/${id}/stop`,
-            '<action />',
+            '<action><async>false</async></action>',
             buildFailHandler({
                 dispatch,
                 name: vmName,
@@ -129,7 +129,7 @@ OVIRT_PROVIDER.REBOOT_VM = function (payload) {
         forceNextOvirtPoll();
         return ovirtApiPost(
             `vms/${id}/reboot`,
-            '<action />',
+            '<action><async>false</async></action>',
             buildFailHandler({
                 dispatch,
                 name: vmName,
@@ -157,8 +157,8 @@ OVIRT_PROVIDER.START_VM = function (payload) {
     const hostName = payload.hostName; // optional
 
     const actionXml = hostName ?
-        `<action><vm><placement_policy><hosts><host><name>${hostName}</name></host></hosts></placement_policy></vm></action>`
-        : '<action />';
+        `<action><async>false</async><vm><placement_policy><hosts><host><name>${hostName}</name></host></hosts></placement_policy></vm></action>`
+        : '<action><async>false</async></action>';
 
     return (dispatch) => {
         forceNextOvirtPoll();
@@ -192,17 +192,20 @@ OVIRT_PROVIDER.CREATE_VM_FROM_TEMPLATE = function (payload) {
     const cluster =  `<cluster><name>${clusterName}</name></cluster>`;
     const action = `<vm>${name}${cluster}${template}</vm>`;
 
-    return (dispatch) => ovirtApiPost(
-        `vms`,
-        action,
-        buildFailHandler({
-            dispatch,
-            name: vm.name,
-            connectionName: QEMU_SYSTEM,
-            msg: _("CREATE VM action failed"),
-            extraPayload: { templateName },
-        })
-    );
+    return (dispatch) => {
+        forceNextOvirtPoll();
+        return ovirtApiPost(
+            `vms`,
+            action,
+            buildFailHandler({
+                dispatch,
+                name: vm.name,
+                connectionName: QEMU_SYSTEM,
+                msg: _("CREATE VM action failed"),
+                extraPayload: {templateName},
+            })
+        );
+    };
 };
 
 OVIRT_PROVIDER.MIGRATE_VM = function ({ vmId, vmName, hostId }) {
@@ -213,7 +216,7 @@ OVIRT_PROVIDER.MIGRATE_VM = function ({ vmId, vmName, hostId }) {
     }
 
     const action = hostId ?
-        `<action><host id="${hostId}"/></action>` :
+        `<action><async>false</async><host id="${hostId}"/></action>` :
         '<action/>';
 
     return (dispatch) => {


### PR DESCRIPTION
If possible, oVirt actions are called synchronously
from oVirt engine perspective.

It means, oVirt API HTTP call does not respond sooner
than the action is finished.
Please note, there is no full guarantee for that - bugs or
irregularities on oVirt side are still possible.

To avoid confusion - the client side (browser with cockpit-ovirt) is
still not blocked, the HTTP call is still performed asynchronously
thanks to Promises.

This change improves user experience in case of failures.

Closes #7672