### PR TITLE
ovirt: Hide Delete button for oVirt VMs

### DIFF
--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -104,7 +104,7 @@ const VmActions = ({ vm, config, dispatch, onStart, onReboot, onForceReboot, onS
     }
 
     let deleteAction = null;
-    if (state !== undefined && config.provider.canDelete && config.provider.canDelete(state)) {
+    if (state !== undefined && config.provider.canDelete && config.provider.canDelete(state, vm.id, config.providerState)) {
         deleteAction = (
             <button className="btn btn-danger" id={`${id}-delete`}
                     onClick={ mouseClick(() => deleteDialog(vm, dispatch)) }>

--- a/pkg/machines/libvirt.es6
+++ b/pkg/machines/libvirt.es6
@@ -106,7 +106,7 @@ LIBVIRT_PROVIDER = {
 
     canReset: (vmState) => vmState == 'running' || vmState == 'idle' || vmState == 'paused',
     canShutdown: (vmState) => LIBVIRT_PROVIDER.canReset(vmState),
-    canDelete: (vmState) => true,
+    canDelete: (vmState, vmId, providerState) => true,
     isRunning: (vmState) => LIBVIRT_PROVIDER.canReset(vmState),
     canRun: (vmState) => vmState == 'shut off',
     canConsole: (vmState) => vmState == 'running',

--- a/pkg/ovirt/provider.es6
+++ b/pkg/ovirt/provider.es6
@@ -36,9 +36,11 @@ import ConsoleClientResources from './components/ConsoleClientResources.jsx';
 import OVirtTab from './components/OVirtTab.jsx';
 
 const _ = cockpit.gettext;
+
+const OVIRT_PROVIDER = Object.create(LIBVIRT_PROVIDER); // inherit whatever is not implemented here
+
 const QEMU_SYSTEM = 'system'; // conforms connection name defined in parent's cockpit:machines/config.es6
 
-const OVIRT_PROVIDER = Object.create(LIBVIRT_PROVIDER);
 OVIRT_PROVIDER.name = 'oVirt';
 OVIRT_PROVIDER.ovirtApiMetadata = {
     passed: undefined, // check for oVirt API version
@@ -57,6 +59,10 @@ OVIRT_PROVIDER.vmTabRenderers = [
         component: OVirtTab,
     },
 ];
+
+// --- enable/disable actions in UI
+OVIRT_PROVIDER.canDelete = (vmState, vmId, providerState) =>
+    isVmManagedByOvirt(providerState, vmId) ? false : LIBVIRT_PROVIDER.canDelete(vmState, vmId);
 
 // --- verbs
 OVIRT_PROVIDER.init = function ({ dispatch }) {

--- a/pkg/ovirt/selectors.es6
+++ b/pkg/ovirt/selectors.es6
@@ -30,5 +30,5 @@ export function getCurrentHost (hosts) {
 }
 
 export function isVmManagedByOvirt (providerState, vmId) {
-    return providerState && !!providerState.vms[vmId];
+    return vmId && providerState && !!providerState.vms[vmId];
 }

--- a/test/verify/check-ovirt
+++ b/test/verify/check-ovirt
@@ -144,6 +144,8 @@ class TestOVirtMachines(MachineCase):
         b.wait_present("#vm-VM-vcpus")
         b.wait_in_text("#vm-VM-vcpus", "1")
 
+        b.wait_not_present("#vm-VM-delete") # oVirt-managed VM can not be deleted from Cockpit
+
         b.wait_present("#vm-VM-ovirt-description") # oVirt specific extension
         b.wait_present("#vm-VM-ovirt-suspendbutton") # oVirt specific extension
 


### PR DESCRIPTION
If a virtual machine is managed by oVirt, the Delete button
is not rendered among VM actions since such an action fits just
to oVirt Administration Portal better.

More detailed info in https://github.com/cockpit-project/cockpit/issues/7718.

Non-oVirt VMs are untouched.

Closes #7718