### PR TITLE
naughty: Close 7621: unrelated SELinux denial: NetworkManager cannot run arping

### DIFF
--- a/bots/naughty/rhel-7/7621-selinux-nm-arping
+++ b/bots/naughty/rhel-7/7621-selinux-nm-arping
@@ -1,1 +1,0 @@
-Error: *audit*avc:  denied  { execute } for * comm="NetworkManager" name="arping"


### PR DESCRIPTION
Known issue which has not occurred in 26 days

unrelated SELinux denial: NetworkManager cannot run arping

Fixes #7621