### PR TITLE
naughty: Close 7575:  SELinux is preventing cockpit-session from using the 'dac_read_search' capabilities

### DIFF
--- a/bots/naughty/fedora-25/7575-selinux-dac_read_search
+++ b/bots/naughty/fedora-25/7575-selinux-dac_read_search
@@ -1,1 +1,0 @@
-Error: audit: type=1400*avc:  denied  { dac_read_search }


### PR DESCRIPTION
Known issue which has not occurred in 27 days

 SELinux is preventing cockpit-session from using the 'dac_read_search' capabilities

Fixes #7575