### PR TITLE
tools: Fix broken dist paths with out of tree builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -170,7 +170,7 @@ V_WEBPACK = $(V_WEBPACK_$(V))
 V_WEBPACK_ = $(V_WEBPACK_$(AM_DEFAULT_VERBOSITY))
 V_WEBPACK_0 = @echo "  WEBPACK  $(@:dist/%/Makefile.deps=%)";
 
-WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(srcdir) BUILDDIR=$(builddir) \
+WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(abspath $(srcdir)) BUILDDIR=$(builddir) \
 	       $(srcdir)/tools/missing $(srcdir)/tools/webpack-make
 
 WEBPACK_RULE = $(V_WEBPACK) $(WEBPACK_MAKE)

--- a/autogen.sh
+++ b/autogen.sh
@@ -81,6 +81,11 @@ if [ -z "${NOREDIRECTMAKEFILE:-}" ]; then
     if [ ! -e $srcdir/dist ]; then
         ln -s $olddir/dist $srcdir/dist
     fi
+    # support out-of-tree builds, where "make dist" needs the source files with sane paths
+    if [ ! -e $olddir/pkg ] && [ ! -e $olddir/node_modules ]; then
+        ln -s "$srcdir/pkg" "$olddir/pkg"
+        ln -s "$srcdir/node_modules" "$olddir/node_modules"
+    fi
 fi
 
 echo

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -268,11 +268,12 @@ function maybePushInput(inputs, po_locations, input) {
     if (stats.mtime > latest)
         latest = stats.mtime;
 
-    // Qualify the input file and add it
-    input = path.relative(cwd, input);
+    // Strip builddir and srcdir absolute paths from input file and add it
+    if (input.indexOf(cwd) === 0)
+        input = input.substr(cwd.length+1);
     if (srcdir && input.indexOf(srcdir) === 0) {
         po_location = input.substr(srcdir.length+1);
-        input = "$(srcdir)" + input.substr(srcdir.length);
+        input = input.substr(srcdir.length+1);
     } else {
         po_location = input;
     }


### PR DESCRIPTION
Running `make dist` in an out-of-tree build that is not underneath
srcdir previously resulted in a broken tarball, containing pkg/* and
node_modules/* under a path to the srcdir.

E. g., diffing file lists between an in-tree and out-of-tree dist
tarball looked like this:

    -cockpit-154.x/pkg/lib/journal.js
    +cockpit-154.x/upstream/cockpit/pkg/lib/journal.js

Avoid this by putting pkg and node_modules symlinks into the build dir
and chopping off absolute build dir prefixes in webpack-make, instead of
creating path prefixes to the srcdir.

Change the invocation of webpack-make to always pass a canonical
absolute $SRCDIR, so that maybePushInput() does not have to handle
different cases of absolute vs. relative srcdir.