### PR TITLE
ovirt: Filter cluster VMs/Templates on cluster

### DIFF
--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -372,7 +372,7 @@ class VmUsageTab extends React.Component {
         const chartSize = {
             width, // keep the .usage-donut-caption CSS in sync
             height
-        }
+        };
 
         return (<table>
                 <tr>
@@ -463,7 +463,7 @@ Vm.propTypes = {
 /**
  * List of all VMs defined on this host
  */
-const HostVmsList = ({ vms, config, dispatch }) => {
+const HostVmsList = ({ vms, config, dispatch, actions }) => {
     if (vms.length === 0) {
         return (<div className='container-fluid'>
             <NoVm />
@@ -472,8 +472,13 @@ const HostVmsList = ({ vms, config, dispatch }) => {
 
     const sortFunction = (vmA, vmB) => vmA.name.localeCompare(vmB.name);
 
+    let allActions = []; // like createVmAction
+    if (actions) {
+        allActions = allActions.concat(actions);
+    }
+
     return (<div className='container-fluid'>
-        <Listing title={_("Virtual Machines")} columnTitles={[_("Name"), _("Connection"), _("State")]}>
+        <Listing title={_("Virtual Machines")} columnTitles={[_("Name"), _("Connection"), _("State")]} actions={allActions}>
             {vms
                 .sort(sortFunction)
                 .map(vm => {

--- a/pkg/ovirt/actions.es6
+++ b/pkg/ovirt/actions.es6
@@ -47,6 +47,10 @@ export function createVmFromTemplate ({ templateName, clusterName, vm }) {
     return virt('CREATE_VM_FROM_TEMPLATE', { templateName, clusterName, vm });
 }
 
+export function switchHostToMaintenance ({ hostId }) {
+    return virt('HOST_TO_MAINTENANCE', { hostId });
+}
+
 export function updateHost(host) {
     return {
         type: 'OVIRT_UPDATE_HOST',
@@ -132,6 +136,16 @@ export function goToSubpage (target) {
         type: 'OVIRT_GOTO_SUBPAGE',
         payload: {
             target,
+        },
+    };
+}
+
+export function setHostname(hostname) {
+    return {
+        type: 'OVIRT_SET_HOSTNAME',
+        payload: {
+            hostname,
         }
     };
 }
+

--- a/pkg/ovirt/components/App.jsx
+++ b/pkg/ovirt/components/App.jsx
@@ -28,7 +28,7 @@ import VdsmView from './VdsmView.jsx';
 import { goToSubpage } from '../actions.es6';
 import hostToMaintenance from './HostToMaintenance.jsx';
 import HostStatus from './HostStatus.jsx';
-import { getHost } from "../helpers.es6";
+import { getHost } from "../selectors.es6";
 
 const _ = cockpit.gettext;
 

--- a/pkg/ovirt/components/App.jsx
+++ b/pkg/ovirt/components/App.jsx
@@ -26,6 +26,9 @@ import ClusterTemplates from './ClusterTemplates.jsx';
 import VdsmView from './VdsmView.jsx';
 
 import { goToSubpage } from '../actions.es6';
+import hostToMaintenance from './HostToMaintenance.jsx';
+import HostStatus from './HostStatus.jsx';
+import { getHost } from "../helpers.es6";
 
 const _ = cockpit.gettext;
 
@@ -85,12 +88,15 @@ const TopMenu = ({ ovirtConfig, router, dispatch }) => {
     );
 };
 
-const HostVmsListDecorated = ({ vms, config, dispatch }) => {
+const HostVmsListDecorated = ({ vms, config, dispatch, host }) => {
+    const actions = host && [hostToMaintenance({ dispatch, host })];
     return (
         <div className='container-fluid'>
+            <HostStatus host={host}/>
             <HostVmsList vms={vms}
                          config={config}
-                         dispatch={dispatch} />
+                         dispatch={dispatch}
+                         actions={actions} />
         </div>
     );
 };
@@ -100,13 +106,16 @@ const App = ({ store }) => {
     const dispatch = store.dispatch;
     const { vms, config } = state;
 
-    let ovirtConfig, router;
+    let ovirtConfig, hosts, router;
     if (config.providerState) {
         ovirtConfig = config.providerState.ovirtConfig;
+        hosts = config.providerState.hosts;
         router = config.providerState.router;
     }
 
+    const host = getHost(hosts, ovirtConfig); // oVirt record for current host
     const route = router && router.route;
+
     let component = null;
     switch (route) {
         case 'clustervms':
@@ -120,7 +129,7 @@ const App = ({ store }) => {
             break;
         default:
             component = (
-                <HostVmsListDecorated vms={vms} config={config} dispatch={dispatch} />);
+                <HostVmsListDecorated vms={vms} config={config} dispatch={dispatch} host={host} />);
     }
 
     return (

--- a/pkg/ovirt/components/ClusterVms.jsx
+++ b/pkg/ovirt/components/ClusterVms.jsx
@@ -25,7 +25,7 @@ import CONFIG from '../config.es6';
 import { Listing, ListingRow } from "cockpit-components-listing.jsx";
 import { StateIcon, DropdownButtons } from "../../machines/hostvmslist.jsx";
 
-import { toGigaBytes, valueOrDefault, isSameHostAddress, getHostAddress } from '../helpers.es6';
+import { toGigaBytes, valueOrDefault, isSameHostAddress, getHost } from '../helpers.es6';
 import { startVm, goToSubpage } from '../actions.es6';
 import rephraseUI from '../rephraseUI.es6';
 
@@ -135,10 +135,9 @@ const VmLastMessage = ({ vm }) => {
 
 const Vm = ({ vm, hosts, templates, clusters, config, dispatch }) => {
     const stateIcon = (<StateIcon state={vm.state} config={config}/>);
-
-    const hostAddress = getHostAddress();
-    const hostId = Object.getOwnPropertyNames(hosts).find(hostId => hosts[hostId].address === hostAddress);
-    const hostName = hostId && hosts[hostId] ? hosts[hostId].name : undefined;
+    const ovirtConfig = config.providerState && config.providerState.ovirtConfig;
+    const currentHost = getHost(hosts, ovirtConfig);
+    const hostName = currentHost && currentHost.name;
 
     return (<ListingRow // TODO: icons?
         columns={[

--- a/pkg/ovirt/components/HostStatus.css
+++ b/pkg/ovirt/components/HostStatus.css
@@ -1,0 +1,15 @@
+.ovirt-host-status-wrapper {
+    width: 100%;
+    text-align: right;
+}
+
+.ovirt-host-status {
+    /*float: right;*/
+    display: inline-flex;
+}
+
+.ovirt-host-status-label {
+    text-align: right;
+    color: #888888;
+    font-weight: 600;
+}

--- a/pkg/ovirt/components/HostStatus.jsx
+++ b/pkg/ovirt/components/HostStatus.jsx
@@ -1,0 +1,47 @@
+/*jshint esversion: 6 */
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from "react";
+import cockpit from 'cockpit';
+
+import rephraseUI from '../rephraseUI.es6';
+
+import './HostStatus.css';
+
+React;
+const _ = cockpit.gettext;
+
+const HostStatus = ({ host }) => {
+    if (!host) {
+        return null;
+    }
+
+    return (
+        <div className='container-fluid ovirt-host-status-wrapper'>
+            <div className='ovirt-host-status'>
+                <div className='ovirt-host-status-label'>
+                    {_("oVirt Host State:")}
+                </div>
+                &nbsp;
+                {rephraseUI('hostStatus', host.status)}
+            </div>
+        </div>);
+};
+
+export default HostStatus;

--- a/pkg/ovirt/components/HostToMaintenance.css
+++ b/pkg/ovirt/components/HostToMaintenance.css
@@ -1,0 +1,3 @@
+.ovirt-action-padding {
+    padding-right: 5px;
+}

--- a/pkg/ovirt/components/HostToMaintenance.jsx
+++ b/pkg/ovirt/components/HostToMaintenance.jsx
@@ -1,0 +1,84 @@
+/*jshint esversion: 6 */
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from "react";
+import cockpit from 'cockpit';
+
+import './HostToMaintenance.css';
+
+import DialogPattern from 'cockpit-components-dialog.jsx';
+import { switchHostToMaintenance } from '../actions.es6';
+
+const _ = cockpit.gettext;
+
+React;
+
+const hostToMaintenanceDialog = (dispatch, host) => {
+    const hostId = host && host.id;
+
+    const body = (
+        <div className="modal-body">
+            {_("Please confirm, the host shall be switched to maintenance mode.")}
+            <br />
+            {_("All running virtual machines will be turned off.")}
+        </div>
+    );
+    const dialogProps = {
+        'title': _("Switch Host to Maintenance"),
+        body,
+    };
+
+    let footerProps = {
+        'actions': [
+            { 'clicked': () => { return dispatch(switchHostToMaintenance({ hostId })); },
+                'caption': _("OK"),
+                'style': 'primary',
+            },
+        ],
+    };
+
+    DialogPattern.show_modal_dialog(dialogProps, footerProps);
+};
+
+const showHostToMaintenanceDialog = (dispatch, hosts) => {
+    return (event) => {
+        if (!event || event.button !== 0) {
+            return;
+        }
+        hostToMaintenanceDialog(dispatch, hosts);
+    }
+};
+
+const hostToMaintenance = ({ dispatch, host }) => {
+    if (!host) {
+        return null;
+    }
+
+    // TODO: "pficon-maintenance" seems to be added to patternfly since 3.26 release - change once this gets to cockpit
+    return (
+        <a className='card-pf-link-with-icon pull-right' id='ovirt-host-to-maintenance'
+           onClick={showHostToMaintenanceDialog(dispatch, host)}>
+            <div className='ovirt-action-padding'>
+                <span className='pficon pficon-close'/>{_("Host to Maintenance")}
+            </div>
+        </a>
+    )
+};
+
+export default hostToMaintenance;

--- a/pkg/ovirt/helpers.es6
+++ b/pkg/ovirt/helpers.es6
@@ -24,23 +24,6 @@ export function getHostAddress() {
     return localAddress;
 }
 
-export function getHost(hosts, ovirtConfig) {
-    if (!hosts) {
-        return undefined;
-    }
-
-    // match by browser URL first
-    const hostAddress = getHostAddress();
-    let hostId = Object.getOwnPropertyNames(hosts).find(hostId => hosts[hostId].address === hostAddress);
-
-    // match by system's hostname as fallback
-    if (!hostId && ovirtConfig && ovirtConfig.hostname) {
-         hostId = Object.getOwnPropertyNames(hosts).find(hostId => hosts[hostId].address === ovirtConfig.hostname);
-    }
-
-    return hostId && hosts[hostId];
-}
-
 export function isSameHostAddress(hostAddress) {
     return getHostAddress() === hostAddress;
 }

--- a/pkg/ovirt/helpers.es6
+++ b/pkg/ovirt/helpers.es6
@@ -24,6 +24,23 @@ export function getHostAddress() {
     return localAddress;
 }
 
+export function getHost(hosts, ovirtConfig) {
+    if (!hosts) {
+        return undefined;
+    }
+
+    // match by browser URL first
+    const hostAddress = getHostAddress();
+    let hostId = Object.getOwnPropertyNames(hosts).find(hostId => hosts[hostId].address === hostAddress);
+
+    // match by system's hostname as fallback
+    if (!hostId && ovirtConfig && ovirtConfig.hostname) {
+         hostId = Object.getOwnPropertyNames(hosts).find(hostId => hosts[hostId].address === ovirtConfig.hostname);
+    }
+
+    return hostId && hosts[hostId];
+}
+
 export function isSameHostAddress(hostAddress) {
     return getHostAddress() === hostAddress;
 }
@@ -59,4 +76,3 @@ export function valueOrDefault(value, def) {
 export function isNumeric(value) {
     return /^\d+$/.test(value);
 }
-

--- a/pkg/ovirt/ovirtApiAccess.es6
+++ b/pkg/ovirt/ovirtApiAccess.es6
@@ -65,7 +65,7 @@ export function ovirtApiGet (resource, custHeaders, failHandler) {
 
     return getHttpClient().get(url, null, headers)
         .fail(function (exception, error) {
-            console.info(`HTTP GET failed: ${JSON.stringify(error)}, ${JSON.stringify(exception)}`);
+            console.info(`HTTP GET failed: ${JSON.stringify(error)}, ${JSON.stringify(exception)}, url: `, url);
             handleOvirtError({ error, exception, failHandler });
         });
 }
@@ -79,13 +79,14 @@ export function ovirtApiPost (resource, body, failHandler) {
         'Authorization': 'Bearer ' + CONFIG.token,
     };
 
+    const url = `/ovirt-engine/api/${resource}`;
     return getHttpClient().request({
         method: 'POST',
-        path: `/ovirt-engine/api/${resource}`,
+        path: url,
         headers,
         body,
     }).fail(function (exception, error) {
-        console.info(`HTTP POST failed: ${JSON.stringify(error)}`);
+        console.info(`HTTP POST failed: ${JSON.stringify(error)}`, url);
         handleOvirtError({error, exception, failHandler});
     });
 }

--- a/pkg/ovirt/ovirtApiAccess.es6
+++ b/pkg/ovirt/ovirtApiAccess.es6
@@ -85,7 +85,7 @@ export function ovirtApiPost (resource, body, failHandler) {
         headers,
         body,
     }).fail(function (exception, error) {
-        logError(`HTTP POST failed: ${JSON.stringify(error)}`);
+        console.info(`HTTP POST failed: ${JSON.stringify(error)}`);
         handleOvirtError({error, exception, failHandler});
     });
 }

--- a/pkg/ovirt/reducers.es6
+++ b/pkg/ovirt/reducers.es6
@@ -96,6 +96,10 @@ function configReducer (state, action) {
         {
             return Object.assign({}, state, { loginInProgress: action.payload.loginInProgress });
         }
+        case 'OVIRT_SET_HOSTNAME':
+        {
+            return Object.assign({}, state, { hostname: action.payload.hostname });
+        }
         default:
             return state;
     }

--- a/pkg/ovirt/selectors.es6
+++ b/pkg/ovirt/selectors.es6
@@ -17,18 +17,76 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
+import cockpit from 'cockpit';
+
 import { getHostAddress } from './helpers.es6';
+import { logDebug, logError } from '../machines/helpers.es6';
 
 export function getAllIcons (state) {
     return state.config && state.config.providerState ? state.config.providerState.icons : {};
 }
 
-export function getCurrentHost (hosts) {
-    const currentHostAddress = getHostAddress();
-    const hostId = Object.getOwnPropertyNames(hosts).filter(hostId => currentHostAddress === hosts[hostId].address);
-    return hostId ? hosts[hostId] : undefined;
+export function getHost(hosts, ovirtConfig) {
+    if (!hosts) {
+        return null;
+    }
+
+    // match by browser URL first
+    const hostAddress = getHostAddress();
+    let hostId = Object.getOwnPropertyNames(hosts).find(hostId => hosts[hostId].address === hostAddress);
+
+    // match by system's hostname as fallback
+    if (!hostId && ovirtConfig && ovirtConfig.hostname) {
+        hostId = Object.getOwnPropertyNames(hosts).find(hostId => hosts[hostId].address === ovirtConfig.hostname);
+    }
+
+    return hostId && hosts[hostId];
+}
+
+export function getCurrentClusterFromState(state) {
+    return getCurrentCluster(state.config.providerState.hosts, state.config.providerState.clusters, state.config.providerState.ovirtConfig);
+}
+
+export function getCurrentCluster (hosts, clusters, ovirtConfig) {
+    const currentHost = getHost(hosts, ovirtConfig);
+    if (!currentHost || !clusters || !currentHost.clusterId) {
+        return null;
+    }
+
+    return clusters[currentHost.clusterId];
 }
 
 export function isVmManagedByOvirt (providerState, vmId) {
     return vmId && providerState && !!providerState.vms[vmId];
+}
+
+function _waitForCurrentCluster(deferred, getState, counter) {
+    if (counter <= 0) {
+        logError('waitForCurrentCluster(): timeout reached, list of hosts and/or clusters has not yet finished');
+        deferred.reject();
+    }
+
+    logDebug('Sleeping in _waitForCurrentCluster(), ', counter);
+    window.setTimeout(() => {
+        const currentCluster = getCurrentClusterFromState(getState());
+        if (currentCluster) {
+            deferred.resolve(currentCluster);
+        } else {
+            _waitForCurrentCluster(deferred, getState, counter - 1);
+        }
+    }, 250);
+}
+
+export function waitForCurrentCluster(getState) {
+    let currentCluster = getCurrentClusterFromState(getState());
+    if (currentCluster) {
+        return cockpit.resolve(currentCluster);
+    }
+
+    const deferred = cockpit.defer();
+    logDebug('Waiting for list of clusters and hosts to be loaded');
+
+    _waitForCurrentCluster(deferred, getState, 20);
+
+    return deferred.promise;
 }

--- a/pkg/ovirt/store.es6
+++ b/pkg/ovirt/store.es6
@@ -17,37 +17,18 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-import store from './store.es6';
-import { getAllVms } from '../machines/actions.es6';
+import store from '../machines/store.es6';
 import { logDebug } from '../machines/helpers.es6';
 
-import Provider from './provider.es6';
-import App from './components/App.jsx';
-import { setVirtProvider } from '../machines/provider.es6';
-
-function render() {
-    React.render(
-        React.createElement(App, {store: store}),
-        document.getElementById('app')
-    );
+export function waitForReducerSubtreeInit(delayedFunc) {
+    const state = store.getState();
+    if (state && state.config && state.config.providerState && state.config.providerState.ovirtConfig) {
+        delayedFunc();
+    } else {
+        logDebug('waitForReducerSubtreeInit(): subtree not yet initialized, waiting ...');
+        window.setTimeout(() => waitForReducerSubtreeInit(delayedFunc), 500);
+    }
 }
 
-/**
- * Start the application.
- */
-export function appMain() {
-    console.log("loading ovirt package");
-    logDebug('index.es6: initial state: ' + JSON.stringify(store.getState()));
-
-    setVirtProvider(Provider);
-
-    // re-render app every time the state changes
-    store.subscribe(render);
-
-    // do initial render
-    render();
-
-    // initiate data retrieval
-    store.dispatch(getAllVms());
-}
+// Let pkg/machines build the Redux store and extend it at runtime.
+export default store;

--- a/test/verify/check-ovirt
+++ b/test/verify/check-ovirt
@@ -178,21 +178,20 @@ class TestOVirtMachines(MachineCase):
 
         # switch to cluster view and check expected cluster content
         b.click("#ovirt-topnav-clustervms")
-        b.wait_in_text("body", "Cluster Virtual Machines")
+        b.wait_in_text("body", "Virtual Machines of Default cluster")
         b.wait_in_text("tr.listing-ct-item > th", "VM") # name
-        b.wait_in_text("tr.listing-ct-item > td:nth-child(4)", "Default") # cluster
-        b.wait_in_text("tr.listing-ct-item > td:nth-child(5)", "Blank") # template
-        b.wait_in_text("tr.listing-ct-item > td:nth-child(6)", "1 GiB") # memory
-        b.wait_in_text("tr.listing-ct-item > td:nth-child(8)", "other") # OS
-        b.wait_in_text("tr.listing-ct-item > td:nth-child(9)", "no") # HA
+        b.wait_in_text("tr.listing-ct-item > td:nth-child(4)", "Blank") # template
+        b.wait_in_text("tr.listing-ct-item > td:nth-child(5)", "1 GiB") # memory
+        b.wait_in_text("tr.listing-ct-item > td:nth-child(7)", "other") # OS
+        b.wait_in_text("tr.listing-ct-item > td:nth-child(8)", "no") # HA
         with b.wait_timeout(180):
-            b.wait_in_text("tr.listing-ct-item > td:nth-child(13)", "shut off") # state
+            b.wait_in_text("tr.listing-ct-item > td:nth-child(12)", "shut off") # state
 
         b.click("button.dropdown-toggle") # caret for 'Run|Run Here'
         b.wait_visible("a:contains('Run Here')")
         b.click("a:contains('Run Here')") # start the VM on this host
         with b.wait_timeout(180):
-            b.wait_in_text("tr.listing-ct-item > td:nth-child(11)", "host") # Host of name 'host'
+            b.wait_in_text("tr.listing-ct-item > td:nth-child(10)", "host") # Host of name 'host'
 
         # switch back to VM list and check
         b.click("#ovirt-topnav-hostvms")
@@ -206,7 +205,7 @@ class TestOVirtMachines(MachineCase):
 
         # switch to Templates
         b.click("#ovirt-topnav-clustertemplates")
-        b.wait_in_text("body", "Cluster Templates")
+        b.wait_in_text("body", "Templates of Default cluster")
         b.wait_in_text("tr.listing-ct-item > th", "Blank") # name
         b.wait_in_text("tr.listing-ct-item > td:nth-child(4)", "Blank") # Base Template
         b.wait_in_text("tr.listing-ct-item > td:nth-child(5)", "Blank template") # Description
@@ -232,7 +231,7 @@ class TestOVirtMachines(MachineCase):
 
         # check the just created VM
         b.click("#ovirt-topnav-clustervms")
-        b.wait_in_text("body", "Cluster Virtual Machines")
+        b.wait_in_text("body", "Virtual Machines of Default cluster")
         with b.wait_timeout(180):
             b.wait_present("table > tbody:nth-child(4) > tr.listing-ct-item > th") # at least two VMs are listed
         b.wait_in_text("table > tbody:nth-child(4) > tr.listing-ct-item > th", "myVMFromBlankTemplate") # check 'name' of the second one

--- a/test/verify/check-ovirt
+++ b/test/verify/check-ovirt
@@ -65,6 +65,11 @@ class TestOVirtMachines(MachineCase):
         self.ovirt = self.machines['ovirt']
         m = self.machine
 
+        m.execute("hostname ovirt.cockpit.lan") # used as fallback when resolving based on browser's URL is not matching, see ovirt/helpers.es6:getHost()
+
+        self.engine_url = "https://{0}/ovirt-engine/".format(self.ovirt.forward['443']) # from phantomJS
+        print("Engine URL: {0}".format(self.engine_url))
+
         # Wait for the web service to be accessible
         args = { "api": "curl -s -k -u admin@internal:engine -H Content-type:application/xml", "addr": OVIRT_ADDR }
         m.execute(script=WAIT_SCRIPT % args)
@@ -241,6 +246,36 @@ class TestOVirtMachines(MachineCase):
         b.wait_present("button:contains('OK')")
         b.click("button:contains('OK')")  # Limitation of this test env: In fact self.machine is updated and not the VDSM, see hack_for_missing_vdsm().
         b.wait(lambda: TEST_VDSM_CONF_CONTENT in self.machine.execute("cat {0}".format(VDSM_CONF_FILE)))
+
+        # sit(self.machines)
+
+    def testHostToMaintenance(self):
+        b = self.browser
+
+        # By-passing the ovirt-authentication cycle of redirects by retrieving oVirt SSO token independently
+        # and navigating directly to the last step of auth procedure by passing the '#token=' URL param
+        self.login_and_go("/machines#token={0}".format(self.access_token))
+        b.wait_present(".main-app-div")
+        b.wait_in_text("body", "Virtual Machines")
+
+        b.wait_in_text("tbody tr th", "VM") # row with a vitual machine
+        b.wait_present("#ovirt-host-to-maintenance")
+        b.click("#ovirt-host-to-maintenance")
+
+        b.wait_present("#cockpit_modal_dialog")
+        b.wait_present("#cockpit_modal_dialog div:contains(Switch Host to Maintenance)")
+        b.click("#cockpit_modal_dialog button:contains(OK)")
+
+        # Since the test environment has just a single host, the action can not succeed on oVirt side - there is no
+        # remaining host to migrate the VM to or reassign SPM. In addition, the test environment is based on faqemu (fake qemu).
+        # Building of full-featured test environment seems to be not worth of the effort recently since we are not
+        # testing the oVirt itself but pkg/ovirt and it's connection to oVirt API.
+        #
+        # For this reason the test checks just for rendered error which is produced by oVirt API to verify proper action
+        # calling and processing on pkg/ovirt side.
+        b.wait_in_text(".modal-footer", "The following Hosts have running VMs and cannot be switched to maintenance mode: host.Please ensure that the following Clusters have at least one Host in UP state: Default.")
+        b.click("#cockpit_modal_dialog button:contains(Cancel)")
+        b.wait_not_present("#cockpit_modal_dialog")
 
         # sit(self.machines)
 


### PR DESCRIPTION
Cluster virtual machines and templates are retrieved and
rendered for current cluster only.

A host machine can be member of at most one cluster at a time.

Closes #7671

 - [x] Requires #7663 - Host to Maintenance to avoid merge conflicts, functionality is unrelated otherwise