### PR TITLE
bots: Drop naughty overrides that got fixed in RHEL 7.4.2

### DIFF
--- a/bots/naughty/rhel-7-4/7710-broken-timers
+++ b/bots/naughty/rhel-7-4/7710-broken-timers
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-services", line *, in testCreateTimer
-    m.execute("while [ ! -f /tmp/hello ] ; do sleep 0.5; done")
-*
-RuntimeError: Timeout while waiting for boot timer to run

--- a/bots/naughty/rhel-7-4/7711-machine-nonstandard-ssh-port
+++ b/bots/naughty/rhel-7-4/7711-machine-nonstandard-ssh-port
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-multi-machine", line *, in testBasic
-    add_machine(b, m3_host)
-*
-Error: failed to call cockpit.Machines.Update():  Unexpected type 'int' in argument


### PR DESCRIPTION
138-10 fixes the broken timers and non-standard SSH ports, so now that
RHEL 7.4.2 is released we can drop the quirks.

Fixes #7710
Fixes #7711