### PR TITLE
test: Fix test-dbus to work without a system bus

### DIFF
--- a/src/base1/test-dbus.js
+++ b/src/base1/test-dbus.js
@@ -705,10 +705,10 @@ QUnit.asyncTest("internal dbus bus none with address", function() {
 QUnit.asyncTest("separate dbus connections for channel groups", function() {
     assert.expect(4);
 
-    var channel1 = cockpit.channel({ payload: 'dbus-json3', group: 'foo' });
-    var channel2 = cockpit.channel({ payload: 'dbus-json3', group: 'bar' });
-    var channel3 = cockpit.channel({ payload: 'dbus-json3', group: 'foo' });
-    var channel4 = cockpit.channel({ payload: 'dbus-json3', group: 'baz' });
+    var channel1 = cockpit.channel({ payload: 'dbus-json3', group: 'foo', bus: 'session' });
+    var channel2 = cockpit.channel({ payload: 'dbus-json3', group: 'bar', bus: 'session' });
+    var channel3 = cockpit.channel({ payload: 'dbus-json3', group: 'foo', bus: 'session' });
+    var channel4 = cockpit.channel({ payload: 'dbus-json3', group: 'baz', bus: 'session' });
 
     cockpit.all([
         channel1.wait(), channel2.wait(), channel3.wait(), channel4.wait()


### PR DESCRIPTION
The last test in `TESTS=dist/base1/test-dbus` hangs eternally if there
is no system D-Bus running:

```
PASS: dist/base1/test-dbus.html 187 - receive writable fd: fd received and not writable
cockpit-bridge-Message: 1:58: Could not connect: No such file or directory
cockpit-bridge-Message: 1:60: (null)
cockpit-bridge-Message: 1:59: Could not connect: No such file or directory
cockpit-bridge-Message: 1:61: Could not connect: No such file or directory
Could not connect: No such file or directory
(null)
Could not connect: No such file or directory
Could not connect: No such file or directory
```

This happens when running tests in mock or in a docker container.

Use the session bus to avoid this and make fewer assumptions about the
host system.