### PR TITLE
Move semaphore test into a container

### DIFF
--- a/containers/Makefile.am
+++ b/containers/Makefile.am
@@ -55,3 +55,17 @@ ws-container:
 ws-container-shell:
 	sudo docker run -ti --rm --publish=9001:9090 \
 		cockpit/ws /bin/bash
+
+UNIT_TESTS_DIR = $(srcdir)/containers/unit-tests
+
+unit-tests-container:
+	sudo docker build -t cockpit/unit-tests $(UNIT_TESTS_DIR)
+	sudo docker tag  cockpit/unit-tests:latest docker.io/cockpit/unit-tests:latest
+	sudo docker build --build-arg arch=i386 -t cockpit/unit-tests:i386 containers/unit-tests/
+	sudo docker tag  cockpit/unit-tests:i386 docker.io/cockpit/unit-tests:i386
+
+unit-tests-container-run:
+	sudo docker run -ti --rm -v $(abs_srcdir):/source:ro cockpit/unit-tests
+
+unit-tests-container-shell:
+	sudo docker run -ti --rm -v $(abs_srcdir):/source:ro cockpit/unit-tests /bin/bash

--- a/containers/unit-tests/Dockerfile
+++ b/containers/unit-tests/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:16.04
+
+ARG arch=amd64
+
+# dependencies which must be installed for the target architecture
+# we must do cross-builds on i386 as phantomjs is not available for i386
+ARG _crossdeps="libglib2.0-dev libgudev-1.0-dev libjson-glib-dev libkeyutils-dev liblvm2-dev libnm-glib-dev \
+    libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev \
+    libssh-dev libsystemd-dev libkrb5-dev \
+    glib-networking glib-networking-dbg libc6-dbg libglib2.0-0-dbg pkg-config"
+
+RUN dpkg --add-architecture ${arch} && echo ${arch} > /arch && apt-get update && \
+    apt-get install -y --no-install-recommends build-essential gcc-multilib clang \
+      autoconf automake gdb gtk-doc-tools intltool libjavascript-minifier-xs-perl libjson-perl valgrind \
+      xmlto xsltproc pyflakes npm nodejs-legacy git libfontconfig1 dbus ssh curl \
+      $(for p in ${_crossdeps}; do echo $p:${arch}; done) && \
+    apt-get clean
+
+# use latest npm/node
+# add system user to avoid same UIDs as host's source volume
+RUN npm install -g n && n stable && \
+    adduser --system --gecos "Builder" builder
+
+USER builder
+ADD run.sh /
+CMD ["/run.sh"]

--- a/containers/unit-tests/README.md
+++ b/containers/unit-tests/README.md
@@ -1,0 +1,47 @@
+# Cockpit unit test container
+
+This container has all build dependencies and toolchains (GCC and clang) that
+we want to exercise Cockpit with, mostly for `make distcheck` and `make
+check-memory`. This container gets run in semaphore, but can be easily run
+locally too.
+
+It assumes that the Cockpit source git checkout is available in `/source`. It
+will not modify that directory or take uncommitted changes into account, but it
+will re-use an already existing `node_modules/` directory.
+
+## Building
+
+In a built cockpit tree you can run
+
+    $ make unit-tests-container
+
+which will build the `cockpit/unit-tests` and `cockpit/unit-tests:i386`
+containers.
+
+## Running tests
+
+Tests in that container for the default configuration get started with
+
+    $ make unit-tests-container-run
+
+or equivalently with
+
+    $ sudo docker run -ti --volume `pwd`:/source:ro cockpit/unit-tests
+
+You can pass `--env=CC=clang` to build with Clang instead of gcc, or run
+`cockpit/unit-tests:i386` to run on a 32 bit architecture.
+
+## Debugging tests
+
+For interactive debugging, run a shell in the container:
+
+    $ make unit-tests-container-shell
+
+or start the container with `bash` as the entry point. `./run.sh` will start
+the builds and test run, then you can investigate in the build tree at
+`/tmp/source/`.
+
+## More Info
+
+ * [Cockpit Project](https://cockpit-project.org)
+ * [Cockpit Development](https://github.com/cockpit-project/cockpit)

--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -o pipefail
+set -eux
+
+# copy host's source tree to avoid changing that, and make sure we have a clean tree
+if [ ! -e /source/.git ]; then
+    echo "This container must be run with --volume <host cockpit source checkout>:/source:ro" >&2
+    exit 1
+fi
+git clone /source /tmp/source
+[ ! -d /source/node_modules ] || cp -r /source/node_modules /tmp/source/
+cd /tmp/source
+
+# cross-build flags
+ARCH=$(cat /arch)
+case $ARCH in
+    amd64) ;;
+    i386)
+        export CFLAGS=-m32
+        export LDFLAGS=-m32
+        ;;
+    *)
+        echo "Unknown architecture '$ARCH'" >&2
+        exit 1
+esac
+
+${CC:-gcc} ./tools/careful-cat.c -o careful-cat
+./autogen.sh --prefix=/usr --enable-strict --with-systemdunitdir=/tmp
+make -j2 V=1 all
+
+# only run distcheck on main arch
+if [ "$ARCH" = amd64 ]; then
+    make -j8 distcheck 2>&1 | ./careful-cat
+else
+    make -j8 check 2>&1 | ./careful-cat
+fi
+
+make -j8 check-memory 2>&1 | ./careful-cat || {
+    ./careful-cat test-suite.log
+    exit 1
+}

--- a/tools/careful-cat.c
+++ b/tools/careful-cat.c
@@ -13,7 +13,7 @@
  *    https://github.com/travis-ci/travis-ci/issues/4704
  */
 
-void
+int
 main (void)
 {
   char buffer[1024], *ptr;
@@ -28,7 +28,7 @@ main (void)
       if (n < 0)
         {
           perror("read");
-          exit (1);
+          return 1;
         }
 
       ptr = buffer;
@@ -38,7 +38,7 @@ main (void)
           if (m == 0)
             {
               fprintf(stderr, "write: closed\n");
-              exit (1);
+              return 1;
             }
 
           if (m < 0)
@@ -46,7 +46,7 @@ main (void)
               int err = errno;
               perror("write");
               if (err != EAGAIN)
-                exit (1);
+                return 1;
               sleep(1);
             }
           else
@@ -57,5 +57,5 @@ main (void)
         }
     }
 
-  exit (0);
+  return 0;
 }

--- a/tools/semaphore-prepare
+++ b/tools/semaphore-prepare
@@ -1,12 +1,1 @@
-#!/bin/bash
-
-change-phantomjs-version 2.1.1
-sudo rm /etc/apt/sources.list.d/*
-sudo apt-get update
-sudo apt-get -y --no-install-recommends install autoconf automake gdb glib-networking gtk-doc-tools intltool libglib2.0-dev libgudev-1.0-dev libjavascript-minifier-xs-perl libjson-glib-dev libjson-perl libkeyutils-dev liblvm2-dev libnm-glib-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libssh-dev libsystemd-daemon-dev libsystemd-login-dev libsystemd-journal-dev libkrb5-dev pcp pkg-config valgrind xmlto xsltproc pyflakes npm nodejs-legacy git libfontconfig1 dbus ssh libglib2.0-0-dbg glib-networking-dbg curl
-
-# semaphore already has latest npm pre-installed, do that for local chroots
-if dpkg --compare-versions "$(npm --version)" lt "4"; then
-   sudo npm install -g n
-   sudo n stable
-fi
+/bin/true

--- a/tools/semaphore-run
+++ b/tools/semaphore-run
@@ -1,33 +1,14 @@
-#!/bin/bash
+#!/bin/sh -ex
 
-set -o pipefail
-set -eux
+# semaphore has a hacked phantomjs-prebuilt cached which points to /usr/local/bin/phantomjs
+[ -x node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs ] || rm -rf node_modules/phantomjs-prebuilt
 
-ARCH=${1:-}
-
-if [ "$ARCH" = i386 ]; then
-    # help apt to figure out replacing GI dependencies (we don't need them
-    # anyway, but a lot of stuff is pre-installed in semaphore)
-    sudo apt-get purge --auto-remove -y python3-gi gir1.2-glib-2.0
-
-    # library -dev packages are not co-installable for multiple architectures,
-    # so this can't go into the setup step
-    DEVPKGS=$(grep -o '[^ ]*-dev' tools/semaphore-prepare | sed 's/$/:i386/')
-    sudo apt-get install -y --no-install-recommends gcc-multilib pkg-config:i386 glib-networking:i386 glib-networking-dbg:i386 libc6-dbg:i386 libglib2.0-0-dbg:i386 $DEVPKGS
-    export CFLAGS=-m32
-    export LDFLAGS=-m32
-elif [ -n "$ARCH" ]; then
-    echo "Unknown architecture '$ARCH'" >&2
-    exit 1
-fi
-
-gcc ./tools/careful-cat.c -o careful-cat
-./autogen.sh --prefix=/usr --enable-strict --with-systemdunitdir=/tmp
-make -j2 V=1 all
-
-# only run distcheck on native arch
-if [ -z "$ARCH" ]; then
-    make -j8 distcheck check-memory 2>&1 | ./careful-cat
-elif [ "$ARCH" = i386 ]; then
-    linux32 make -j8 check check-memory 2>&1 | ./careful-cat
+# temporary shim, remove once landed on master and semaphore config got updated
+if [ "$1" = i386 ]; then
+    sudo docker run --volume `pwd`:/source:ro cockpit/unit-tests:i386
+elif [ "${CC#clang}" != "$CC" ]; then
+    sudo docker run --env=CC=clang --volume `pwd`:/source:ro cockpit/unit-tests
+else
+    # standard arch/compiler
+    sudo docker run --volume `pwd`:/source:ro cockpit/unit-tests
 fi


### PR DESCRIPTION
The semaphore CI are pre-populated with tons of arbitrary npm modules in
~/.nvm, which even hides an explicit `g stable`.  This breaks `npm install`
in e. g. #7870 and also also potentially hides missing dependencies in
our package.json. This environment is also hard to reproduce locally,
and fairly old already (there is no newer image than 14.04 available,
which we don't even support in Cockpit).

Thus drop running the tests directly in the semaphore VM, and move to
clean Ubuntu 16.04 based docker containers instead. These can easily be
reproduced locally and save setup time as we don't need the expensive
apt-get install on every run.

Replace tools/semaphore-prepare with containers/unit-tests/Dockerfile,
move tools/semaphore-run to containers/unit-tests/run.sh. The latter now 
does not need to uninstall/reinstall i386 packages any more. Also, use 
`$CC` instead of `gcc` for building careful-cat, and run distcheck and 
check-memory in separate make invocations so that they are easier to
spot in the log.

Keep the two semaphore scripts as shims until this PR lands on master
and the semaphore config gets updated.

Integrate this into containers/Makefile.am and add appropriate
documentation.

Fixes #7954

 - [x] fix unit tests without system d-bus (#7952)