### PR TITLE
ws: Use well known location for keytab when present

### DIFF
--- a/doc/guide/sso.xml
+++ b/doc/guide/sso.xml
@@ -28,8 +28,10 @@ _kerberos._udp.example.com has SRV record 0 100 88 dc.example.com
       the domain name.</para>
   
     <para>There must be a valid Kerberos host key for the server in the <code>/etc/krb5.keytab</code>
-      file. It may be necessary to create a kerberos service principal and update the keytab if it
-      is not present. Depending on your domain type different service names are required:</para>
+      file. Alternatively, if you would like to use a different keytab, you can do so
+      by placing it in <code>/etc/cockpit/krb5.keytab</code>. It may be necessary to
+      create a kerberos service principal and update the keytab if it is not present.
+      Depending on your domain type different service names are required:</para>
 
     <variablelist>
       <varlistentry>

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -62,6 +62,7 @@
 #define DEBUG_SESSION 0
 #define EX 127
 #define DEFAULT_PATH "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+#define COCKPIT_KTAB PACKAGE_SYSCONF_DIR "/cockpit/krb5.keytab"
 
 static struct passwd *pwd;
 static struct passwd pwd_buf;
@@ -739,6 +740,12 @@ perform_gssapi (const char *rhost,
   int res;
 
   res = PAM_AUTH_ERR;
+
+  if (!getenv ("COCKPIT_TEST_KEEP_KTAB") &&
+      access (COCKPIT_KTAB, F_OK) == 0)
+    {
+      setenv ("KRB5_KTNAME", COCKPIT_KTAB, 1);
+    }
 
   debug ("reading kerberos auth from cockpit-ws");
   input.value = cockpit_authorize_parse_negotiate (authorization, &input.length);

--- a/src/ws/test-kerberos.c
+++ b/src/ws/test-kerberos.c
@@ -278,6 +278,8 @@ test_authenticate (TestCase *test,
   GError *error = NULL;
 
   g_setenv ("COCKPIT_TEST_KEEP_PATH", "1", TRUE);
+  g_setenv ("COCKPIT_TEST_KEEP_KTAB", "1", TRUE);
+
   if (!mock_kdc_available)
     {
       cockpit_test_skip ("mock kdc not available to test against");

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -178,7 +178,6 @@ echo '%(password)s' | KRB5_TRACE=/dev/stderr kinit -f admin@COCKPIT.LAN
 
 # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1144292
 curl --insecure -s --negotiate -u : https://f0.cockpit.lan/ipa/json --header 'Referer: https://f0.cockpit.lan/ipa' --header "Content-Type: application/json" --header "Accept: application/json" --data '{"params": [["HTTP/x0.cockpit.lan@COCKPIT.LAN"], {"raw": false, "all": false, "version": "2.101", "force": true, "no_members": false, "ipakrbokasdelegate": true}], "method": "service_add", "id": 0}'
-ipa-getkeytab -q -s f0.cockpit.lan -p HTTP/x0.cockpit.lan -k /etc/krb5.keytab
 
 # HACK: https://bugs.freedesktop.org/show_bug.cgi?id=98479
 if ! grep -q 'services.*nss' /etc/sssd/sssd.conf; then
@@ -259,6 +258,20 @@ class TestKerberos(MachineCase):
         self.configure_kerberos()
         self.machine.restart_cockpit()
 
+        self.machine.execute("mkdir -p /etc/cockpit")
+        keytab = "/etc/cockpit/krb5.keytab"
+        # These only support the default keytab location
+        if self.machine.image in ["rhel-7-4", "rhel-7-5"]:
+            keytab = "/etc/krb5.keytab"
+
+        # Pull keytab
+        self.machine.execute(["ipa-getkeytab","-q","-s","f0.cockpit.lan",
+                              "-p","HTTP/x0.cockpit.lan","-k",keytab])
+
+        if self.machine.image not in ["rhel-7-4", "rhel-7-5"]:
+            self.machine.execute("chmod 600 /etc/cockpit/krb5.keytab")
+
+
         output = self.machine.execute(['/usr/bin/curl', '-s', '--negotiate', '--delegation', 'always', '-u', ':', "-D", "-",
                                        '--resolve', 'x0.cockpit.lan:9090:10.111.113.1',
                                        'http://x0.cockpit.lan:9090/cockpit/login'])
@@ -331,6 +344,24 @@ class TestKerberos(MachineCase):
 
         # Make sure we connected via SSH
         self.assertIn("admin@cockpit.lan", self.machine.execute("ps -xa | grep sshd"))
+        b.kill()
+
+        if self.machine.image not in ["rhel-7-4", "rhel-7-5"]:
+            # Remove cockpit keytab
+            self.machine.execute("mv /etc/cockpit/krb5.keytab /etc/cockpit/bk.keytab")
+            output = self.machine.execute(['/usr/bin/curl', '-s', '--negotiate', '--delegation', 'always', '-u', ':', "-D", "-",
+                                           '--resolve', 'x0.cockpit.lan:9090:10.111.113.1',
+                                           'http://x0.cockpit.lan:9090/cockpit/login'])
+            self.assertIn("HTTP/1.1 401", output)
+
+            # Pull http into default keytab
+            self.machine.execute('printf "rkt /etc/cockpit/bk.keytab\nwkt /etc/krb5.keytab\nq" | ktutil')
+            output = self.machine.execute(['/usr/bin/curl', '-s', '--negotiate', '--delegation', 'always', '-u', ':', "-D", "-",
+                                           '--resolve', 'x0.cockpit.lan:9090:10.111.113.1',
+                                           'http://x0.cockpit.lan:9090/cockpit/login'])
+            self.assertIn("HTTP/1.1 200 OK", output)
+            self.assertIn('"csrf-token"', output)
+        self.allow_restart_journal_messages()
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
When /etc/cockpit/krb5.keytab is present use it instead of the system default keytab.

Allows users to symlink in alternate keytabs. Such as /etc/httpd/conf/ipa.keytab.

Replaces #3434