### PR TITLE
tools: Don't build ovirt on Debian/Ubuntu

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -132,7 +132,7 @@ class TestMachines(MachineCase):
         # enforce use of cockpit-machines instead of cockpit-ovirt
         m = self.machine
         m.execute("sed -i 's/\"priority\".*$/\"priority\": 100,/' {0}".format("/usr/share/cockpit/machines/manifest.json"))
-        m.execute("sed -i 's/\"priority\".*$/\"priority\": 0,/' {0}".format("/usr/share/cockpit/ovirt/manifest.json"))
+        m.execute("[ ! -e {0} ] || sed -i 's/\"priority\".*$/\"priority\": 0,/' {0}".format("/usr/share/cockpit/ovirt/manifest.json"))
 
     def startVm(self, name, graphics='spice'):
         m = self.machine

--- a/tools/debian/cockpit-ovirt.install
+++ b/tools/debian/cockpit-ovirt.install
@@ -1,1 +1,0 @@
-usr/share/cockpit/ovirt/

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -99,13 +99,6 @@ Depends: ${misc:Depends},
 Description: Cockpit user interface for virtual machines
  The Cockpit components for managing virtual machines.
 
-Package: cockpit-ovirt
-Architecture: all
-Depends: ${misc:Depends},
-         libvirt-daemon-system
-Description: Cockpit user interface for oVirt virtual machines
- The Cockpit components for managing virtual machines running on an oVirt host..
-
 Package: cockpit-networkmanager
 Architecture: all
 Depends: ${misc:Depends},

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -59,7 +59,7 @@ override_dh_install:
 	dpkg-vendor --derives-from ubuntu || rm -r debian/tmp/usr/share/cockpit/branding/ubuntu
 
 	# unpackaged modules
-	for m in kdump kubernetes ostree selinux sosreport subscriptions; do rm -r debian/tmp/usr/share/cockpit/$$m; done
+	for m in kdump kubernetes ostree selinux sosreport subscriptions ovirt; do rm -r debian/tmp/usr/share/cockpit/$$m; done
 	# part of kubernetes
 	rm -f debian/tmp/usr/lib/cockpit/cockpit-stub
 


### PR DESCRIPTION
oVirt is not available in the Debian/Ubuntu world right now, so don't
build cockpit-ovirt there. (It was already disabled downstream).

`check-ovirt` skips the test there either, and we should not ship
untested code.

Adjust check-machines to only adjust the ovirt manifest priority if it
actually exists.