### PR TITLE
ovirt: Fix dynamically generated .vv file download in FF

### DIFF
--- a/pkg/ovirt/manifest.json.in
+++ b/pkg/ovirt/manifest.json.in
@@ -12,5 +12,5 @@
         "order": 60
      }
   },
-  "content-security-policy": "default-src 'self' blob:;img-src 'self' data:"
+  "content-security-policy": "default-src 'self' blob:;img-src 'self' data:;frame-src 'self' data:;"
 }


### PR DESCRIPTION
The content-security-policy is alligned with the one from pkg/machines
so download of dynamically generated .vv file for VM console opened in
external viewer via small iframe passes.