### PR TITLE
bots: Tighten image-trigger criteria

### DIFF
--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -47,6 +47,7 @@ import os
 import sys
 import tempfile
 import time
+import subprocess
 
 sys.dont_write_bytecode = True
 
@@ -89,6 +90,7 @@ def scan_for_prune():
     return tasks
 
 def scan(api, force, verbose):
+    subprocess.check_call([ "git", "fetch", "origin", "master" ])
     for (image, options) in REFRESH.items():
         perform = False
 
@@ -96,7 +98,7 @@ def scan(api, force, verbose):
             perform = image == force
         else:
             days = options.get("refresh-days", DAYS)
-            perform = task.stale(days, os.path.join("bots", "images", image))
+            perform = task.stale(days, os.path.join("bots", "images", image), "origin/master")
 
         if perform:
             text = "Image refresh for {0}".format(image)

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -308,7 +308,7 @@ def stale(days, pathspec, ref="HEAD"):
             sys.stderr.write("> " + output + "\n")
         return output
 
-    timestamp = execute("git", "log", "--max-count=1", "--pretty=format:%at", ref, "--", pathspec)
+    timestamp = execute("git", "log", "--max-count=1", "--pretty=format:%ct", ref, "--", pathspec)
     try:
         timestamp = int(timestamp)
     except ValueError:


### PR DESCRIPTION
Use commit date instead of author date. And make sure we are working off the latest master before checking dates.