### PR TITLE
ovirt: show FQDN of guest virtual machine

### DIFF
--- a/pkg/ovirt/components/VmOverviewColumn.jsx
+++ b/pkg/ovirt/components/VmOverviewColumn.jsx
@@ -69,6 +69,7 @@ const VmOverviewColumn = ({ vm, providerState }) => { // For reference, extend i
                 <div className='ovirt-provider-columns-one'>
                     <table className='form-table-ct'>
                         <VmProperty title={_("Description:")} value={clusterVm.description} id={`${idPrefix}-description`} />
+                        <VmProperty title={_("Address:")} value={clusterVm.fqdn} id={`${idPrefix}-fqdn`} />
                     </table>
                 </div>
                 <div className='ovirt-provider-columns-two'>

--- a/pkg/ovirt/ovirt.es6
+++ b/pkg/ovirt/ovirt.es6
@@ -189,6 +189,7 @@ function parseVms(deferred, data, dispatch) {
                 clusterId: vm.cluster.id,
                 templateId: vm.template.id,
                 hostId: vm.host ? vm.host.id : undefined,
+                fqdn: vm.fqdn,
             }));
         });
         dispatch(removeUnlistedVms({allVmsIds}));


### PR DESCRIPTION
If guest agent is installed in a virtual machine, oVirt can
retrieve machine's internal fqdn/ip.

Fixes: https://github.com/cockpit-project/cockpit/issues/7614