### PR TITLE
ovirt: fix ovirt-cockpit SSO detection

### DIFF
--- a/pkg/ovirt/configFuncs.es6
+++ b/pkg/ovirt/configFuncs.es6
@@ -64,7 +64,7 @@ export function readConfiguration ({ dispatch }) {
 
 function storeSsoUri (location) {
     const accessTokenStart = location.href.lastIndexOf('access_token=');
-    if (accessTokenStart) { // valid only if ovirt-cockpit-sso is involved
+    if (accessTokenStart >= 0) { // valid only if ovirt-cockpit-sso is involved
         const ssoUri = location.href.substr(0, accessTokenStart + 'access_token='.length);
         logDebug('storeSsoUri(): ', ssoUri);
         window.sessionStorage.setItem('OVIRT_PROVIDER_SSO_URI', ssoUri);


### PR DESCRIPTION
If oVirt->Cockpit SSO is involved, redirection URL is stored for the
case of expired access token.

This patch provides fix for bug in non-SSO flow detection.