### PR TITLE
Terminal selection and focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "redux": "3.7.2",
     "registry-image-widgets": "0.0.13",
     "requirejs": "2.1.22",
-    "term.js-cockpit": "0.0.8"
+    "term.js-cockpit": "0.0.10"
   },
   "optionalDependencies": {
     "phantomjs-prebuilt": "~2.1.14"

--- a/pkg/docker/docker.js
+++ b/pkg/docker/docker.js
@@ -148,8 +148,6 @@
         /* Shows and hides the cursor */
         self.typeable = function typeable(yes) {
             term.cursorHidden = !yes;
-            if (yes)
-                term.showCursor();
             term.refresh(term.y, term.y);
             enable_input = yes;
         };

--- a/pkg/lib/console.css
+++ b/pkg/lib/console.css
@@ -7,7 +7,7 @@
     margin-bottom: 0;
     font-size: 10px;
     text-align: center;
-    line-height: 1;
+    line-height: normal;
 }
 
 @media (min-width: 568px) {

--- a/pkg/lib/console.css
+++ b/pkg/lib/console.css
@@ -38,7 +38,22 @@
     padding: 10px;
 }
 
-.console-ct .terminal-cursor {
-    color: #000;
-    background: #f0f0f0;
+.terminal .terminal-cursor {
+    border: 1px solid #f0f0f0;
+}
+
+.terminal:focus .terminal-cursor {
+    border: none;
+    animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+    from {
+        color: #000;
+        background: #f0f0f0;
+    }
+    50% {
+        color: #f0f0f0;
+        background: #000;
+    }
 }


### PR DESCRIPTION
Fix terminal selection issues. The problem is that term.js blinks the cursor by constantly removing and inserting a span, which clears the selection of the cursor line. Blink the cursor with a css animation instead. This makes copy and paste (also in curses applications) with the right-click menu at least possible.

Also fix the line-height to make selections look better.

Depends on term.js-cockpit 0.0.9:
- [x] https://github.com/cockpit-project/term.js/pull/2
- [x] https://github.com/cockpit-project/term.js/pull/4