### PR TITLE
Fix reset size

### DIFF
--- a/pkg/lib/cockpit-components-terminal.jsx
+++ b/pkg/lib/cockpit-components-terminal.jsx
@@ -50,8 +50,8 @@
 
         componentWillMount: function () {
             var term = new Term({
-                cols: this.state.cols || 80,
-                rows: this.state.rows || 25,
+                cols: this.props.cols || 80,
+                rows: this.props.rows || 25,
                 screenKeys: true
             });
 

--- a/pkg/lib/cockpit-components-terminal.jsx
+++ b/pkg/lib/cockpit-components-terminal.jsx
@@ -94,8 +94,15 @@
         },
 
         componentDidUpdate: function (prevProps) {
-            if (prevProps.channel !== this.props.channel)
+            if (prevProps.channel !== this.props.channel) {
                 this.connectChannel();
+                this.props.channel.control({
+                    window: {
+                        rows: this.state.rows,
+                        cols: this.state.cols
+                    }
+                });
+            }
         },
 
         render: function () {

--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -66,7 +66,6 @@
             var terminal;
             if (this.state.channel)
                 terminal = (<componentsTerminal.Terminal ref="terminal"
-                                                         fullscreen="true"
                                                          channel={this.state.channel}
                                                          onTitleChanged={this.onTitleChanged} />);
             else


### PR DESCRIPTION
Clicking on the reset button resulted in the terminal size being reset to 80x25, because we weren't resending the `TIOWINSZ` ioctl.

Also contains two only-slightly related commits. 

Fixes #7976