### PR TITLE
terminal: prevent page from closing when terminal has focus

### DIFF
--- a/pkg/lib/cockpit-components-terminal.jsx
+++ b/pkg/lib/cockpit-components-terminal.jsx
@@ -107,7 +107,11 @@
 
         render: function () {
             // ensure react never reuses this div by keying it with the terminal widget
-            return <div ref="terminal" className="console-ct" key={this.state.terminal} />;
+            return <div ref="terminal"
+                        key={this.state.terminal}
+                        className="console-ct"
+                        onFocusIn={this.onFocusIn}
+                        onFocusOut={this.onFocusOut} />;
         },
 
         componentWillUnmount: function () {
@@ -162,6 +166,24 @@
                 rows: Math.floor((node.parentElement.clientHeight - padding) / rect.height),
                 cols: Math.floor((node.parentElement.clientWidth - padding) / rect.width)
             });
+        },
+
+        onBeforeUnload: function (event) {
+            // Firefox requires this when the page is in an iframe
+            event.preventDefault();
+
+            // see "an almost cross-browser solution" at
+            // https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload
+            event.returnValue = '';
+            return '';
+        },
+
+        onFocusIn: function () {
+            window.addEventListener('beforeunload', this.onBeforeUnload);
+        },
+
+        onFocusOut: function () {
+            window.removeEventListener('beforeunload', this.onBeforeUnload);
         }
     });
 


### PR DESCRIPTION
Use the 'beforeunload' event to trigger a "are you sure you want to
close this page" alert when the terminal has focus. This is a kludge for
people who use Ctrl+W a lot in terminals and often accidentally close
their browser tab because of it.

Keep the string empty to avoid pulling in cockpit for translations.
Modern browsers ignore the string and show their own message.

This implements one of the suggested fixes in #7956.