### PR TITLE
ws: consider ID_LIKE from os-release for branding

### DIFF
--- a/src/ws/cockpitbranding.c
+++ b/src/ws/cockpitbranding.c
@@ -54,6 +54,7 @@ add_system_dirs (GPtrArray *dirs)
 gchar **
 cockpit_branding_calculate_static_roots (const gchar *os_id,
                                          const gchar *os_variant_id,
+                                         const gchar *os_id_like,
                                          gboolean is_local)
 {
   GPtrArray *dirs;
@@ -69,6 +70,17 @@ cockpit_branding_calculate_static_roots (const gchar *os_id,
       if (os_variant_id)
           g_ptr_array_add (dirs, g_strdup_printf (DATADIR "/cockpit/branding/%s-%s", os_id, os_variant_id));
       g_ptr_array_add (dirs, g_strdup_printf (DATADIR "/cockpit/branding/%s", os_id));
+    }
+
+  if (os_id_like)
+    {
+      gchar **ids;
+
+      ids = g_strsplit_set (os_id_like, " ", -1);
+      for (gint i = 0; ids[i]; i += 1)
+        g_ptr_array_add (dirs, g_strdup_printf (DATADIR "/cockpit/branding/%s", ids[i]));
+
+      g_strfreev (ids);
     }
 
   if (!is_local)
@@ -134,13 +146,14 @@ on_init_ready (GObject *object,
         {
           roots = cockpit_branding_calculate_static_roots (g_hash_table_lookup (os_release, "ID"),
                                                            g_hash_table_lookup (os_release, "VARIANT_ID"),
+                                                           g_hash_table_lookup (os_release, "ID_LIKE"),
                                                            FALSE);
           g_object_set_data_full (G_OBJECT (transport), "os-release", os_release,
                                   (GDestroyNotify) g_hash_table_unref);
         }
       else
         {
-          roots = cockpit_branding_calculate_static_roots (NULL, NULL, FALSE);
+          roots = cockpit_branding_calculate_static_roots (NULL, NULL, NULL, FALSE);
         }
 
       g_object_set_data_full (G_OBJECT (transport), "static-roots", roots,

--- a/src/ws/cockpitbranding.h
+++ b/src/ws/cockpitbranding.h
@@ -26,6 +26,7 @@ G_BEGIN_DECLS
 
 gchar **        cockpit_branding_calculate_static_roots     (const gchar *os_id,
                                                              const gchar *os_variant_id,
+                                                             const gchar *os_id_like,
                                                              gboolean is_local);
 
 void            cockpit_branding_serve                      (CockpitWebService *service,

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -285,7 +285,7 @@ build_environment (GHashTable *os_release)
    * the corresponding information is not a leak.
    */
   static const gchar *release_fields[] = {
-    "NAME", "ID", "PRETTY_NAME", "VARIANT", "VARIANT_ID", "CPE_NAME",
+    "NAME", "ID", "PRETTY_NAME", "VARIANT", "VARIANT_ID", "CPE_NAME", "ID_LIKE"
   };
 
   static const gchar *prefix = "\n    <script>\nvar environment = ";

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -72,19 +72,22 @@ setup_static_roots (GHashTable *os_release)
   gchar **roots;
   const gchar *os_variant_id;
   const gchar *os_id;
+  const gchar *os_id_like;
 
   if (os_release)
     {
       os_id = g_hash_table_lookup (os_release, "ID");
       os_variant_id = g_hash_table_lookup (os_release, "VARIANT_ID");
+      os_id_like = g_hash_table_lookup (os_release, "ID_LIKE");
     }
   else
     {
       os_id = NULL;
       os_variant_id = NULL;
+      os_id_like = NULL;
     }
 
-  roots = cockpit_branding_calculate_static_roots (os_id, os_variant_id, TRUE);
+  roots = cockpit_branding_calculate_static_roots (os_id, os_variant_id, os_id_like, TRUE);
 
   /* Load the fail template */
   g_resources_register (cockpitassets_get_resource ());


### PR DESCRIPTION
os-release lets an operating system specify "other OS identifiers it
itself is a derivative of" in the ID_LIKE key. Include those when
deciding which branding to show, before falling back on the default
cockpit branding.