### PR TITLE
tools: Fix libvirt Python dependency for Fedora < 27

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -513,7 +513,7 @@ Requires: expect
 Requires: libvirt
 Requires: libvirt-client
 Requires: libvirt-daemon
-%if 0%{?rhel}%{?centos} == 0 || 0%{?rhel} >= 8 || 0%{?centos} >= 8
+%if 0%{?rhel} >= 8 || 0%{?centos} >= 8 || 0%{?fedora} >= 27
 Requires: python2-libvirt
 %else
 Requires: libvirt-python


### PR DESCRIPTION
The package was renamed in Fedora 27, but remains libvirt-python in
earlier versions.

The original check was introduced in https://github.com/cockpit-project/cockpit/pull/7831

Maybe I'm missing something? Not sure why building cockpit on older Fedoras works right now... 