### PR TITLE
machines: unify disk's row height

### DIFF
--- a/pkg/machines/machines.less
+++ b/pkg/machines/machines.less
@@ -37,10 +37,14 @@
 .machines-disks-source-descr {
     color: #888888;
     text-align: right;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
 }
 
 .machines-disks-source-value {
     text-align: left !important;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
 }
 
 .machines-disks-alias {


### PR DESCRIPTION
for both empty and non-empty `Source` column.

Fixes: https://github.com/cockpit-project/cockpit/issues/8003