### PR TITLE
bots: Add known issue for ubuntu-stable libvirt AppArmor denial

### DIFF
--- a/bots/naughty/ubuntu-stable/8016-apparmor-denied-libvirt-max_segments
+++ b/bots/naughty/ubuntu-stable/8016-apparmor-denied-libvirt-max_segments
@@ -1,0 +1,1 @@
+Error: audit: type=1400 * apparmor="DENIED" operation="open" profile="libvirt* name="*/queue/max_segments" * requested_mask="r" denied_mask="r"


### PR DESCRIPTION
This does not actually break anything, but triggers an unexpected
message.

Known issue #8016
Downstream report: https://launchpad.net/bugs/1729626