### PR TITLE
bots: Let npm-update try minor version updates too

### DIFF
--- a/bots/npm-update
+++ b/bots/npm-update
@@ -77,7 +77,7 @@ def run(package, verbose=False, **kwargs):
 
     # Add a tilde to all package.json dependencies
     before = data["dependencies"].copy()
-    data["dependencies"] = map_dict(before, lambda v: v[0].isalpha() and v or "~" + v)
+    data["dependencies"] = map_dict(before, lambda v: v[0].isalpha() and v or "^" + v)
     package_json(data)
 
     for package in packages:


### PR DESCRIPTION
By now, npm-update has exhausted available microversions of most of our
dependencies, as they moved on to newer minor or even major releases.

Minor version bumps are generally expected to stay backwards compatible,
and npm has used ^ instead of ~ for `--save` by default for 3½ years
now. So attempt to update to the latest minor release now.

 - [ ] generalize NPM copyright scanning (#8024)