### PR TITLE
ovirt: Use event-driven refresh of oVirt data

### DIFF
--- a/pkg/ovirt/actions.es6
+++ b/pkg/ovirt/actions.es6
@@ -58,10 +58,28 @@ export function updateHost(host) {
     };
 }
 
+export function removeHost(id) {
+    return {
+        type: 'OVIRT_REMOVE_HOST',
+        payload: {
+            id,
+        }
+    };
+}
+
 export function updateVm(vm) {
     return {
         type: 'OVIRT_UPDATE_VM',
         payload: vm
+    };
+}
+
+export function removeVm(id) {
+    return {
+        type: 'OVIRT_REMOVE_VM',
+        payload: {
+            id,
+        }
     };
 }
 
@@ -72,6 +90,15 @@ export function updateTemplate(template) {
     };
 }
 
+export function removeTemplate(id) {
+    return {
+        type: 'OVIRT_REMOVE_TEMPLATE',
+        payload: {
+            id,
+        }
+    };
+}
+
 export function updateCluster(cluster) {
     return {
         type: 'OVIRT_UPDATE_CLUSTER',
@@ -79,38 +106,11 @@ export function updateCluster(cluster) {
     };
 }
 
-export function removeUnlistedHosts({allHostIds}) {
+export function removeCluster(id) {
     return {
-        type: 'OVIRT_REMOVE_UNLISTED_HOSTS',
+        type: 'OVIRT_REMOVE_CLUSTER',
         payload: {
-            allHostIds
-        }
-    };
-}
-
-export function removeUnlistedVms({allVmsIds}) {
-    return {
-        type: 'OVIRT_REMOVE_UNLISTED_VMS',
-        payload: {
-            allVmsIds
-        }
-    };
-}
-
-export function removeUnlistedTemplates({allTemplateIds}) {
-    return {
-        type: 'OVIRT_REMOVE_UNLISTED_TEMPLATES',
-        payload: {
-            allTemplateIds
-        }
-    };
-}
-
-export function removeUnlistedClusters({allClusterIds}) {
-    return {
-        type: 'OVIRT_REMOVE_UNLISTED_CLUSTERS',
-        payload: {
-            allClusterIds
+            id,
         }
     };
 }

--- a/pkg/ovirt/install.sh
+++ b/pkg/ovirt/install.sh
@@ -60,7 +60,7 @@ function generateProviderConfig() {
   # TODO: decrease polling interval if AuditLog-based updates proof to be working
   echo "{ \
       \"debug\": false, \
-      \"ovirt_polling_interval\": 60000, \
+      \"ovirt_polling_interval\": 5000, \
       \"cockpitPort\": 9090, \
       \"OVIRT_FQDN\": \"${ENGINE_FQDN}\", \
       \"OVIRT_PORT\": ${ENGINE_PORT}," \

--- a/pkg/ovirt/ovirtConverters.es6
+++ b/pkg/ovirt/ovirtConverters.es6
@@ -1,0 +1,146 @@
+/*jshint esversion: 6 */
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @param cluster - parsed oVirt resource
+ */
+export function clusterConverter(cluster) {
+    return {
+        id: cluster.id,
+        name: cluster.name,
+        // TODO: add more, if needed
+    };
+}
+
+export function hostConverter(host) {
+    return {
+        id: host.id,
+        name: host.name,
+        address: host.address,
+        clusterId: host.cluster ? host.cluster.id : undefined,
+        status: host.status,
+        memory: host.memory,
+        cpu: host.cpu ? {
+            name: host.cpu.name,
+            speed: host.cpu.speed,
+            topology: host.cpu.topology ? {
+                sockets: host.cpu.topology.sockets,
+                cores: host.cpu.topology.cores,
+                threads: host.cpu.topology.threads
+            } : undefined
+        } : undefined,
+        // summary
+        // vdsm version
+        // libvirt_version
+    };
+}
+
+export function templateConverter(template) {
+    return {
+        id: template.id,
+        name: template.name,
+        description: template.description,
+        cpu: {
+            architecture: template.cpu.architecture,
+            topology: {
+                sockets: template.cpu.topology.sockets,
+                cores: template.cpu.topology.cores,
+                threads: template.cpu.topology.threads
+            }
+        },
+        memory: template.memory,
+        creationTime: template.creation_time,
+
+        highAvailability: template.high_availability,
+        icons: {
+            largeId: template.large_icon ? template.large_icon.id : undefined,
+            smallId: template.small_icon ? template.small_icon.id : undefined,
+        },
+        os: {
+            type: template.os.type
+        },
+        stateless: template.stateless,
+        type: template.type, // server, desktop
+        version: {
+            name: template.version ? template.version.name : undefined,
+            number: template.version ? template.version.number : undefined,
+            baseTemplateId: template.version && template.version.base_template ? template.version.base_template.id : undefined,
+        },
+
+        // bios
+        // display
+        // migration
+        // memory_policy
+        // os.boot
+        // start_paused
+        // usb
+    };
+}
+
+export function vmConverter(vm) {
+    return {
+        id: vm.id,
+        name: vm.name,
+        state: mapOvirtStatusToLibvirtState(vm.status),
+        description: vm.description,
+        highAvailability: vm.high_availability,
+        icons: {
+            largeId: vm.large_icon && vm.large_icon.id || undefined,
+            smallId: vm.small_icon && vm.small_icon.id || undefined,
+        },
+        memory: vm.memory,
+        cpu: {
+            architecture: vm.cpu.architecture,
+            topology: {
+                sockets: vm.cpu.topology.sockets,
+                cores: vm.cpu.topology.cores,
+                threads: vm.cpu.topology.threads
+            }
+        },
+        origin: vm.origin,
+        os: {
+            type: vm.os.type
+        },
+        type: vm.type, // server, desktop
+        stateless: vm.stateless,
+        clusterId: vm.cluster.id,
+        templateId: vm.template.id,
+        hostId: vm.host ? vm.host.id : undefined,
+        fqdn: vm.fqdn,
+        startTime: vm.start_time, // in milliseconds since 1970/01/01
+    };
+}
+
+function mapOvirtStatusToLibvirtState(ovirtStatus) {
+    switch (ovirtStatus) {// TODO: finish - add additional states
+        case 'up': return 'running';
+        case 'down': return 'shut off';
+        default:
+            return ovirtStatus;
+    }
+}
+
+export function oVirtIconToInternal(ovirtIcon) {
+    return {
+        id: ovirtIcon.id,
+        type: ovirtIcon['media_type'],
+        data: ovirtIcon.data,
+    };
+}

--- a/pkg/ovirt/provider.es6
+++ b/pkg/ovirt/provider.es6
@@ -24,7 +24,8 @@ import { logDebug, logError, fileDownload } from '../machines/helpers.es6';
 import { readConfiguration } from './configFuncs.es6';
 import { CONSOLE_TYPE_ID_MAP } from './config.es6';
 import { ovirtApiGet, ovirtApiPost } from './ovirtApiAccess.es6';
-import { pollOvirt, forceNextOvirtPoll, oVirtIconToInternal } from './ovirt.es6';
+import { pollOvirt, forceNextOvirtPoll } from './ovirt.es6';
+import { oVirtIconToInternal } from './ovirtConverters.es6';
 
 import { updateIcon, downloadIcon, } from './actions.es6';
 import { getAllIcons, isVmManagedByOvirt } from './selectors.es6';

--- a/pkg/ovirt/reducers.es6
+++ b/pkg/ovirt/reducers.es6
@@ -22,6 +22,16 @@ import { logDebug } from '../machines/helpers.es6';
 // TODO: consider immutableJS
 // TODO: reducers share common code - generalize
 
+function removeResource(state, id) {
+    if (state[id]) {
+        const newState = Object.assign({}, state);
+        delete newState[id];
+        return newState;
+    }
+    return state;
+
+}
+
 function hostsReducer (state, action) {
     state = state || {}; // object of 'hostId: host'
 
@@ -33,13 +43,9 @@ function hostsReducer (state, action) {
             Object.assign(newState[action.payload.id], action.payload); // merge instead of replace, is it as expected?
             return newState;
         }
-        case 'OVIRT_REMOVE_UNLISTED_HOSTS':
+        case 'OVIRT_REMOVE_HOST':
         {
-            const newState = Object.assign({}, state);
-            const allHostIds = action.payload.allHostIds;
-            const toBeRemoved = Object.getOwnPropertyNames(newState).filter(hostId => (allHostIds.indexOf(hostId) < 0));
-            toBeRemoved.forEach(hostId => delete newState[hostId]);
-            return newState;
+            return removeResource(state, action.payload.id);
         }
         default:
             return state;
@@ -57,13 +63,9 @@ function clustersReducer (state, action) {
             Object.assign(newState[action.payload.id], action.payload); // merge instead of replace, is it as expected?
             return newState;
         }
-        case 'OVIRT_REMOVE_UNLISTED_CLUSTERS':
+        case 'OVIRT_REMOVE_CLUSTER':
         {
-            const newState = Object.assign({}, state);
-            const allIds = action.payload.allClusterIds;
-            const toBeRemoved = Object.getOwnPropertyNames(newState).filter(id => (allIds.indexOf(id) < 0));
-            toBeRemoved.forEach(id => delete newState[id]);
-            return newState;
+            return removeResource(state, action.payload.id);
         }
         default:
             return state;
@@ -116,13 +118,9 @@ function vmsReducer (state, action) {
             Object.assign(newState[action.payload.id], action.payload); // merge instead of replace, is it as expected?
             return newState;
         }
-        case 'OVIRT_REMOVE_UNLISTED_VMS':
+        case 'OVIRT_REMOVE_VM':
         {
-            const newState = Object.assign({}, state);
-            const allVmsIds = action.payload.allVmsIds;
-            const toBeRemoved = Object.getOwnPropertyNames(newState).filter(vmId => (allVmsIds.indexOf(vmId) < 0));
-            toBeRemoved.forEach(vmId => delete newState[vmId]);
-            return newState;
+            return removeResource(state, action.payload.id);
         }
         case 'VM_ACTION_FAILED': // this reducer seconds the implementation in cockpit:machines (see the 'vms' reducer there).
         { // If an action failed on a VM running on this host, the error will be recorded on two places - it's as expected.
@@ -157,13 +155,9 @@ function templatesReducer (state, action) {
             Object.assign(newState[action.payload.id], action.payload); // merge instead of replace, is it as expected?
             return newState;
         }
-        case 'OVIRT_REMOVE_UNLISTED_TEMPLATES':
+        case 'OVIRT_REMOVE_TEMPLATE':
         {
-            const newState = Object.assign({}, state);
-            const allTemplateIds = action.payload.allTemplateIds;
-            const toBeRemoved = Object.getOwnPropertyNames(newState).filter(id => (allTemplateIds.indexOf(id) < 0));
-            toBeRemoved.forEach(id => delete newState[id]);
-            return newState;
+            return removeResource(state, action.payload.id);
         }
         case 'VM_ACTION_FAILED': // this reducer seconds the implementation in cockpit:machines and the vmsReducer()
         {


### PR DESCRIPTION
With this patch, heavy polling to retrieve changes of oVirt-managed
resources via REST API is replaced by semi-event driven approach.

There is still polling involved but just for oVirt's `/api/events`
endpoint to periodically retrieve logged events within a configured
time-window.

These oVirt events were originally meant for audit purposes but it
seems they can be reused this way since they are comprehensive enough.

Events come with list of affected resources (like VM, cluster, host or template).
With this patch, targeted refresh of those resources is executed.

Reading of events is one of the "lighter" operations on the oVirt side,
so even oVirt-engine load is decreased with this change.

Based on the so far performed testing, there was found no gap in terms of
missing events.
If any found later, the oVirt side should be extended to generate
an adequate event. Means, the Cockpit side can stay untouched.

For follow-ups: Improve decision logic whether affected resource shall
be refreshed. This will farther reduce load but implementation requires
deeper analysis of event types since there is >1000 of them.

Fixes: https://github.com/cockpit-project/cockpit/issues/8028