### PR TITLE
Add firewall section to the networking page

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,6 +46,7 @@ Vagrant.configure(2) do |config|
             atomic \
             docker \
             etcd \
+            firewalld \
             git \
             kubernetes \
             NetworkManager \

--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -24,6 +24,7 @@ GUIDE_INCLUDES = \
 	doc/guide/authentication.xml \
 	doc/guide/embedding.xml \
 	doc/guide/feature-docker.xml \
+	doc/guide/feature-firewall.xml \
 	doc/guide/feature-journal.xml \
 	doc/guide/feature-kubernetes.xml \
 	doc/guide/feature-machines.xml \

--- a/doc/guide/cockpit-guide.xml
+++ b/doc/guide/cockpit-guide.xml
@@ -37,6 +37,7 @@
     <xi:include href="feature-journal.xml"/>
     <xi:include href="feature-docker.xml"/>
     <xi:include href="feature-networkmanager.xml"/>
+    <xi:include href="feature-firewall.xml"/>
     <xi:include href="feature-storaged.xml"/>
     <xi:include href="feature-users.xml"/>
     <xi:include href="feature-realmd.xml"/>

--- a/doc/guide/feature-firewall.xml
+++ b/doc/guide/feature-firewall.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
+	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
+<chapter id="feature-firewall">
+  <title>Firewall</title>
+
+  <para>Cockpit uses <ulink url="https://www.firewalld.org">firewalld</ulink> to
+    interact with the system's firewall. No firewall configuration UI will be
+    shown if firewalld is not installed.</para>
+
+  <para>Firewalld controls access to its APIs via PolicyKit. The user logged
+    into Cockpit needs to have the appropriate permissions to view or modify
+    the settings.</para>
+
+  <para>Cockpit can currently only show, add, and remove predefined firewalld
+    services in the default zone.</para>
+
+  <para>To perform similar tasks from the command line, use
+    <ulink url="https://www.firewalld.org/documentation/man-pages/firewall-cmd.html">firewalld-cmd</ulink>.
+    For example, to get the same list of allowed services that Cockpit
+    displays:</para>
+
+<programlisting>
+$ <command>sudo firewall-cmd --list-services</command>
+dhcpv6-client samba-client mdns ssh cockpit
+</programlisting>
+
+  <para>To enable an additional service, use:</para>
+<programlisting>
+$ <command>firewall-cmd --add-service pop3</command>
+success
+</programlisting>
+
+</chapter>

--- a/pkg/lib/cockpit-components-tooltip.jsx
+++ b/pkg/lib/cockpit-components-tooltip.jsx
@@ -42,10 +42,10 @@ var Tooltip = React.createClass({
     getInitialState: function () {
         return { open: false, pos: "top" };
     },
-    onMouseover: function () {
+    onMouseEnter: function () {
         this.setState({ open: true });
     },
-    onMouseout: function () {
+    onMouseLeave: function () {
         this.setState({ open: false });
     },
     render: function () {
@@ -143,8 +143,8 @@ var Tooltip = React.createClass({
         return (
             <div className={ "tooltip-ct-outer " + self.props.className || '' }>
                 <div className="tooltip-ct-inner"
-                     onMouseover={this.onMouseover}
-                     onMouseout={this.onMouseout}>
+                     onMouseEnter={this.onMouseEnter}
+                     onMouseLeave={this.onMouseLeave}>
                     {self.props.children}
                 </div>
                 <div ref={fixDOMElements} className={classes} style={{ top: 0, left: -10000 }}>

--- a/pkg/lib/cockpit-components-tooltip.jsx
+++ b/pkg/lib/cockpit-components-tooltip.jsx
@@ -33,6 +33,9 @@ require('./tooltip.css');
  *
  * Whenever the mouse hovers over the children of a Tooltip,
  * the text (or arbitrary element) in the "tip" property is shown.
+ *
+ * If "className" prop is given, its contents is added to the classes of the
+ * outermost element of the tooltip.
  */
 
 var Tooltip = React.createClass({
@@ -138,7 +141,7 @@ var Tooltip = React.createClass({
             classes += " in";
 
         return (
-            <div className="tooltip-ct-outer">
+            <div className={ "tooltip-ct-outer " + self.props.className || '' }>
                 <div className="tooltip-ct-inner"
                      onMouseover={this.onMouseover}
                      onMouseout={this.onMouseout}>

--- a/pkg/networkmanager/firewall-client.es6
+++ b/pkg/networkmanager/firewall-client.es6
@@ -1,0 +1,195 @@
+/* jshint esversion: 6 */
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+import service from 'service';
+
+var firewall = {
+    installed: true,
+    enabled: false,
+    readonly: true,
+    services: {},
+    enabledServices: new Set()
+};
+
+cockpit.event_target(firewall);
+
+const firewalld_service = service.proxy('firewalld');
+const firewalld_dbus = cockpit.dbus('org.fedoraproject.FirewallD1');
+
+firewalld_service.addEventListener('changed', () => {
+    let installed = !!firewalld_service.exists;
+
+    if (firewall.installed == installed)
+        return;
+
+    firewall.installed = installed;
+    firewall.dispatchEvent('changed');
+});
+
+function fetchServiceInfos(services) {
+    var promises = cockpit.all(services.map(service => {
+        if (firewall.services[service])
+            return firewall.services[service];
+
+        return firewalld_dbus.call('/org/fedoraproject/FirewallD1',
+                                   'org.fedoraproject.FirewallD1',
+                                   'getServiceSettings', [service])
+                .then(reply => {
+                    const [ , name, description, ports ] = reply[0];
+
+                    let info = {
+                        id: service,
+                        name: name,
+                        description: description,
+                        ports: ports.map(p => ({ port: p[0], protocol: p[1] }))
+                    };
+
+                    firewall.services[service] = info;
+                    return info;
+                });
+    }));
+
+    /*
+     * Work around `cockpit.all()` returning results in individual arguments -
+     * that's just confusing and doesn't work with ES6 style functions.
+     */
+    return promises.then(function () {
+        return Array.prototype.slice.call(arguments);
+    });
+}
+
+firewalld_dbus.addEventListener('owner', (event, owner) => {
+    firewall.enabled = !!owner;
+
+    firewall.services = {};
+    firewall.enabledServices = new Set();
+
+    if (!firewall.enabled) {
+        firewall.dispatchEvent('changed');
+        return;
+    }
+
+    firewalld_dbus.call('/org/fedoraproject/FirewallD1',
+                        'org.fedoraproject.FirewallD1.zone',
+                        'getServices', [''])
+            .then(reply => fetchServiceInfos(reply[0]))
+            .then(services => services.map(s => firewall.enabledServices.add(s.id)))
+            .then(() => firewall.dispatchEvent('changed'))
+            .catch(error => console.warn(error));
+});
+
+firewalld_dbus.subscribe({
+    interface: 'org.fedoraproject.FirewallD1.zone',
+    path: '/org/fedoraproject/FirewallD1',
+    member: 'ServiceAdded'
+}, (path, iface, signal, args) => {
+    const service = args[1];
+
+    fetchServiceInfos([service])
+            .then(info => {
+                firewall.enabledServices.add(info[0].id);
+                firewall.dispatchEvent('changed');
+            })
+            .catch(error => console.warn(error));
+});
+
+firewalld_dbus.subscribe({
+    interface: 'org.fedoraproject.FirewallD1.zone',
+    path: '/org/fedoraproject/FirewallD1',
+    member: 'ServiceRemoved'
+}, (path, iface, signal, args) => {
+    const service = args[1];
+
+    firewall.enabledServices.delete(service);
+    firewall.dispatchEvent('changed');
+});
+
+cockpit.spawn(['sh', '-c', 'pkcheck --action-id org.fedoraproject.FirewallD1.all --process $$ --allow-user-interaction 2>&1'])
+        .done(() => {
+            firewall.readonly = false;
+            firewall.dispatchEvent('changed');
+        });
+
+firewall.enable = () => cockpit.all(firewalld_service.enable(), firewalld_service.start());
+
+firewall.disable = () => cockpit.all(firewalld_service.stop(), firewalld_service.disable());
+
+firewall.getAvailableServices = () => {
+    return firewalld_dbus.call('/org/fedoraproject/FirewallD1',
+                               'org.fedoraproject.FirewallD1',
+                               'listServices', [])
+            .then(reply => fetchServiceInfos(reply[0]))
+            .catch(error => console.warn(error));
+};
+
+function getDefaultZonePath() {
+    return firewalld_dbus.call('/org/fedoraproject/FirewallD1',
+                               'org.fedoraproject.FirewallD1',
+                               'getDefaultZone', [])
+            .then(reply => firewalld_dbus.call('/org/fedoraproject/FirewallD1/config',
+                                               'org.fedoraproject.FirewallD1.config',
+                                               'getZoneByName', [reply[0]]))
+            .then(reply => reply[0]);
+}
+
+/*
+ * Remove a service from the default zone (i.e., close its ports).
+ *
+ * Returns a promise that resolves when the service is removed.
+ */
+firewall.removeService = (service) => {
+    return firewalld_dbus.call('/org/fedoraproject/FirewallD1',
+                               'org.fedoraproject.FirewallD1.zone',
+                               'removeService', ['', service])
+            .then(reply => getDefaultZonePath())
+            .then(path => firewalld_dbus.call(path, 'org.fedoraproject.FirewallD1.config.zone',
+                                              'removeService', [service]));
+};
+
+/*
+ * Add a predefined firewalld service to the default zone (i.e., open its
+ * ports).
+ *
+ * Returns a promise that resolves when the service is added.
+ */
+firewall.addService = (service) => {
+    return firewalld_dbus.call('/org/fedoraproject/FirewallD1',
+                               'org.fedoraproject.FirewallD1.zone',
+                               'addService', ['', service, 0])
+            .then(reply => getDefaultZonePath())
+            .then(path => firewalld_dbus.call(path, 'org.fedoraproject.FirewallD1.config.zone',
+                                              'addService', [service]));
+};
+
+/*
+ * Like addService(), but adds multiple predefined firewalld services at once
+ * to the default zone.
+ *
+ * Returns a promise that resolves when all services are added.
+ */
+firewall.addServices = (services) => {
+    return cockpit.all(services.map(s => firewall.addService(s)))
+            .then(function () {
+                return Array.prototype.slice.call(arguments);
+            });
+};
+
+export default firewall;

--- a/pkg/networkmanager/firewall.html
+++ b/pkg/networkmanager/firewall.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<!--
+This file is part of Cockpit.
+
+Copyright (C) 2017 Red Hat, Inc.
+
+Cockpit is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+Cockpit is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+-->
+<html>
+  <head>
+    <title translate>Firewall</title>
+    <meta charset="utf-8">
+
+    <link href="../base1/patternfly.css" type="text/css" rel="stylesheet">
+    <link href="firewall.css" type="text/css" rel="stylesheet">
+
+    <script src="../base1/cockpit.js"></script>
+    <script src="../*/po.js"></script>
+    <script src="firewall.js"></script>
+  </head>
+
+  <body>
+      <div id="firewall"></div>
+  </body>
+</html>

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -1,0 +1,342 @@
+/* jshint esversion: 6 */
+
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+import firewall from "./firewall-client.es6";
+import { Listing, ListingRow } from "cockpit-components-listing.jsx";
+import { OnOffSwitch } from "cockpit-components-onoff.jsx";
+import { show_modal_dialog } from "cockpit-components-dialog.jsx";
+import { Tooltip } from "cockpit-components-tooltip.jsx";
+
+import "table.css";
+import "./networking.css";
+
+const _ = cockpit.gettext;
+
+function EmptyState(props) {
+    return (
+        <div className="curtains-ct blank-slate-pf">
+            {props.icon && <div className={"blank-slate-pf-icon " + props.icon} />}
+            <h1>{props.title}</h1>
+            {props.children}
+        </div>
+    );
+}
+
+function ServiceRow(props) {
+    if (!props.service.name)
+        return <ListingRow key={props.service.id} columns={["", "", ""]} />
+
+    var tcp = props.service.ports.filter(p => p.protocol.toUpperCase() == 'TCP');
+    var udp = props.service.ports.filter(p => p.protocol.toUpperCase() == 'UDP');
+
+    function onRemoveService(event) {
+        if (event.button !== 0)
+            return;
+
+        props.onRemoveService(props.service.id);
+        event.stopPropagation();
+    }
+
+    var deleteButton;
+    if (props.readonly) {
+        deleteButton = (
+            <Tooltip className="pull-right" tip={_("You are not authorized to modify the firewall.")}>
+                <button className="btn btn-danger pficon pficon-delete" disabled />
+            </Tooltip>
+        );
+    } else {
+        deleteButton = <button className="btn btn-danger pficon pficon-delete" onClick={onRemoveService}/>;
+    }
+
+    var columns = [
+        { name: props.service.name, header: true },
+        <div>
+            { tcp.map(p => p.port).join(', ') }
+        </div>,
+        <div>
+            { udp.map(p => p.port).join(', ') }
+        </div>,
+        deleteButton
+    ];
+
+    var tabs = [
+        { name: _("Details"), renderer: () => <p>{props.service.description}</p> }
+    ];
+
+    return <ListingRow key={props.service.id}
+                       rowId={props.service.id}
+                       columns={columns}
+                       tabRenderers={tabs}/>;
+}
+
+class SearchInput extends React.Component {
+    constructor() {
+        super();
+
+        this.onValueChanged = this.onValueChanged.bind(this);
+    }
+
+    onValueChanged(event) {
+        if (this.timer)
+            window.clearTimeout(this.timer);
+
+        this.timer = window.setTimeout(() => {
+            this.props.onChange(event.target.value);
+            this.timer = null;
+        }, 300);
+    }
+
+    render() {
+        return <input id={this.props.id}
+                      className={this.props.className}
+                      onChange={this.onValueChanged} />
+    }
+}
+
+class AddServicesDialogBody extends React.Component {
+    constructor() {
+        super();
+
+        this.state = {
+            services: null,
+            selected: new Set(),
+            filter: ""
+        };
+
+        this.onFilterChanged = this.onFilterChanged.bind(this);
+        this.onToggleService = this.onToggleService.bind(this);
+    }
+
+    componentDidMount() {
+        firewall.getAvailableServices()
+                .then(services => this.setState({ services: services }));
+    }
+
+    onFilterChanged(value) {
+        this.setState({ filter: value.toLowerCase() });
+    }
+
+    onToggleService(event) {
+        var service = event.target.id;
+        var enabled = event.target.checked;
+
+        this.setState(oldState => {
+            let selected = new Set(oldState.selected);
+
+            if (enabled)
+                selected.add(service)
+            else
+                selected.delete(service);
+
+            this.props.selectionChanged(selected);
+
+            return {
+                selected: selected
+            };
+        });
+    }
+
+    render() {
+        if (!this.state.services) {
+            return (
+                <div className="modal-body">
+                    <div className="spinner spinner-lg" />
+                </div>
+            );
+        }
+
+        var services;
+        if (this.state.filter)
+            services = this.state.services.filter(s => s.name.toLowerCase().indexOf(this.state.filter) > -1);
+        else
+            services = this.state.services;
+
+        return (
+            <div id="add-services-dialog" className="modal-body">
+                <table className="form-table-ct">
+                    <tr>
+                        <td>
+                            <label htmlFor="filter-services-input" className="control-label">
+                                {_("Filter Services")}
+                            </label>
+                        </td>
+                        <td>
+                            <SearchInput id="filter-services-input"
+                                         className="form-control"
+                                         onChange={this.onFilterChanged} />
+                        </td>
+                    </tr>
+                </table>
+                <ul className="list-group dialog-list-ct">
+                    {
+                        services.map(s => (
+                            <li className="list-group-item">
+                                <label>
+                                    <input id={s.id}
+                                           type="checkbox"
+                                           checked={this.state.selected.has(s.id)}
+                                           onClick={this.onToggleService} />
+                                    &nbsp;
+                                    <span>{s.name}</span>
+                                </label>
+                            </li>
+                        ))
+                    }
+                </ul>
+            </div>
+        );
+    }
+}
+
+export class Firewall extends React.Component {
+    constructor() {
+        super();
+
+        this.state = {
+            firewall,
+            pendingTarget: null /* `null` for not pending */
+        };
+
+        this.onFirewallChanged = this.onFirewallChanged.bind(this);
+        this.onSwitchChanged = this.onSwitchChanged.bind(this);
+        this.onAddServices = this.onAddServices.bind(this);
+        this.onRemoveService = this.onRemoveService.bind(this);
+    }
+
+    onFirewallChanged() {
+        this.setState((prevState) => {
+            if (prevState.pendingTarget === firewall.enabled)
+                return { firewall, pendingTarget: null };
+
+            return { firewall }
+        });
+    }
+
+    onSwitchChanged(value) {
+        this.setState({ pendingTarget: value });
+
+        if (value)
+            firewall.enable();
+        else
+            firewall.disable();
+    }
+
+    onAddServices() {
+        var services = [...this.state.firewall.services].map(id => this.state.firewall.services[id]);
+        services.sort((a, b) => a.name.localeCompare(b.name));
+
+        var selected = new Set();
+
+        show_modal_dialog(
+            {
+                title: _("Add Services"),
+                body: <AddServicesDialogBody selectionChanged={s => { selected = [...s] }} />
+            },
+            {
+                cancel_caption: _("Cancel"),
+                actions: [
+                    {
+                        caption: _("Add Services"),
+                        style: 'primary',
+                        clicked: () => firewall.addServices(selected)
+                    }
+                ]
+            });
+    }
+
+    onRemoveService(service) {
+        firewall.removeService(service);
+    }
+
+    componentDidMount() {
+        firewall.addEventListener("changed", this.onFirewallChanged);
+    }
+
+    componentWillUnmount() {
+        firewall.removeEventListener("changed", this.onFirewallChanged);
+    }
+
+    render() {
+        function go_up(event) {
+            if (!event || event.button !== 0)
+                return;
+
+            cockpit.jump("/network", cockpit.transport.host);
+        }
+
+        if (!this.state.firewall.installed) {
+            return (
+                <EmptyState title={_("Firewall is not available")} icon="fa fa-exclamation-circle">
+                    <p>{cockpit.format(_("Please install the {0} package"), "firewalld")}</p>
+                </EmptyState>
+            );
+        }
+
+        var addServiceAction;
+        if (this.state.firewall.readonly) {
+            addServiceAction = (
+                <Tooltip className="pull-right" tip={_("You are not authorized to modify the firewall.")}>
+                    <button className="btn btn-primary" disabled> {_("Add Services…")} </button>
+                </Tooltip>
+            );
+        } else {
+            addServiceAction = <button className="btn btn-primary pull-right" onClick={this.onAddServices}>{_("Add Services…")}</button>;
+        }
+
+        var services = [...this.state.firewall.enabledServices].map(id => this.state.firewall.services[id]);
+        services.sort((a, b) => a.name.localeCompare(b.name));
+
+        var enabled = this.state.pendingTarget !== null ? this.state.pendingTarget : this.state.firewall.enabled;
+
+        return (
+            <div className="container-fluid page-ct">
+                <ol className="breadcrumb">
+                    <li><a onClick={go_up}>{_("Networking")}</a></li>
+                    <li className="active">{_("Firewall")}</li>
+                </ol>
+                <h1>
+                    {_("Firewall")}
+                    <OnOffSwitch state={enabled}
+                                 enabled={this.state.pendingTarget === null}
+                                 onChange={this.onSwitchChanged} />
+                </h1>
+                <Listing title={_("Allowed Services")}
+                         columnTitles={[ _("Service"), _("TCP"), _("UDP"), "" ]}
+                         emptyCaption={_("No open ports")}
+                         actions={addServiceAction}>
+                    {
+                        services.map(s => <ServiceRow service={s}
+                                                      readonly={this.state.firewall.readonly}
+                                                      onRemoveService={this.onRemoveService} />)
+                    }
+                </Listing>
+            </div>
+        );
+    }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    document.title = cockpit.gettext(document.title);
+
+    React.render(<Firewall />, document.getElementById("firewall"));
+});

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -79,6 +79,25 @@
       </div>
     </div>
     <br/>
+    <div class="panel panel-default" id="networking-firewall" hidden>
+      <div class="panel-heading">
+        <a id="networking-firewall-link" translatable="yes">Firewall</a>
+        <div class="pull-right">
+          <div class="btn-group btn-onoff-ct" id="networking-firewall-switch" data-toggle="buttons">
+              <label class="btn active">
+                <input type="radio" name="firewall" />
+                <span translatable="yes">On</span>
+              </label>
+              <label class="btn">
+                <input type="radio" name="firewall" />
+                <span translatable="yes">Off</span>
+              </label>
+          </div>
+        </div>
+      </div>
+      <div id="networking-firewall-summary" class="panel-body">
+      </div>
+    </div>
     <div class="panel panel-default"
          id="networking-interfaces">
       <div class="panel-heading">

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -191,3 +191,39 @@ span.inverted-switchbox {
     margin-top: 6px;
     margin-right: 20px;
 }
+
+h1 .btn-onoff-ct {
+    margin-left: 1.5em;
+    vertical-align: text-bottom;
+}
+
+#networking-firewall-summary:hover {
+    cursor: pointer;
+    background-color: #def3ff;
+}
+
+/* set min-height to the same as max-height, so that the list doesn't shrink
+ * when filtering */
+#add-services-dialog .dialog-list-ct {
+    min-height: 230px;
+}
+
+#add-services-dialog .form-table-ct {
+    margin-bottom: 0.5em;
+}
+
+#add-services-dialog .list-group-item {
+    padding: 0;
+}
+
+#add-services-dialog .list-group-item label {
+    padding: 10px 15px;
+    margin: 0;
+    width: 100%;
+    cursor: pointer;
+}
+
+#add-services-dialog .list-group-item input[type="checkbox"] {
+    margin: 0;
+    vertical-align: middle;
+}

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -149,7 +149,7 @@ class TestNetworking(NetworkCase):
 
         b.click("#networking-interfaces tr[data-interface='tbond'] td:first-child")
         b.wait_visible("#network-interface")
-        b.click(".panel-heading .btn:contains('On')")
+        b.click("#network-interface .panel-heading .btn:contains('On')")
         b.wait_in_text("tr:contains('Status')", "Configuring")
 
         b.click("tr:contains('Bond') a")

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -1,0 +1,118 @@
+#!/usr/bin/python2
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import parent
+from testlib import *
+import time
+
+
+def wait_unit_state(machine, unit, state):
+
+    def active_state(unit):
+        # HACK: don't use `systemctl is-active` here because of
+        #   https://bugzilla.redhat.com/show_bug.cgi?id=1073481
+        # Also, use `systemctl --value` once that exists everywhere
+        line = machine.execute("systemctl show -p ActiveState {}".format(unit))
+        return line.strip().split("=")[1]
+
+    wait(lambda: active_state(unit) == state, delay=0.2)
+
+
+@skipImage("firewalld not installed", "rhel-7-5", "centos-7", "fedora-atomic", "rhel-atomic", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1604")
+class TestFirewall(MachineCase):
+
+    def testNetworkingPage(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/network")
+        b.wait_visible("#networking-firewall")
+
+        m.execute("systemctl stop firewalld")
+        b.wait_in_text("#networking-firewall-switch label.active", "Off")
+        m.execute("systemctl start firewalld")
+        b.wait_in_text("#networking-firewall-switch label.active", "On")
+
+        # to toggle the switch, click on the non-active label, where the slider is
+        b.click("#networking-firewall-switch label:not(.active)")
+        b.wait_present("#networking-firewall-switch label.active:not(.disabled)")
+        b.wait_in_text("#networking-firewall-switch label.active", "Off")
+        wait_unit_state(m, "firewalld", "inactive")
+        b.wait_in_text("#networking-firewall-summary", "0 Active Rules")
+
+        b.click("#networking-firewall-switch label:not(.active)")
+        b.wait_present("#networking-firewall-switch label.active:not(.disabled)")
+        b.wait_in_text("#networking-firewall-switch label.active", "On")
+        wait_unit_state(m, "firewalld", "active")
+
+        active_rules = m.execute("firewall-cmd --list-services").split()
+        b.wait_in_text("#networking-firewall-summary", "{} Active Rule".format(len(active_rules)))
+
+        b.click("#networking-firewall-link")
+        b.enter_page("/network/firewall")
+
+        b.click(".breadcrumb li:first a")
+        b.enter_page("/network")
+
+
+    def testFirewallPage(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/network/firewall")
+        m.execute("systemctl start firewalld")
+
+        # ensure that pop3 is not enabled (shouldn't be on any of our images),
+        # so that we can use it for testing
+        b.wait_not_present("tr[data-row-id='pop3']")
+
+        m.execute("firewall-cmd --add-service=pop3")
+        b.wait_present("tr[data-row-id='pop3']")
+
+        # all services should be shown after the one we added above is
+        # visible, so do a basic sanity check now
+        active_rules = m.execute("firewall-cmd --list-services").split()
+        b.call_js_func("ph_count_check", "tr.listing-ct-item", len(active_rules))
+
+        b.click("tr[data-row-id='pop3'] .listing-ct-toggle")
+        b.wait_in_text("tbody.open tr.listing-ct-panel", "Post Office Protocol")
+
+        b.click("tr[data-row-id='pop3'] .btn.pficon-delete")
+        b.wait_not_present("tr[data-row-id='pop3']")
+        self.assertNotIn('pop3', m.execute("firewall-cmd --list-services").split())
+
+
+    def testAddServices(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/network/firewall")
+
+        # click on the "Add Services…" button
+        b.wait_present("caption button.btn-primary:enabled")
+        b.click("caption button.btn-primary")
+        b.wait_present("#cockpit_modal_dialog li input#pop3")
+        b.click("#cockpit_modal_dialog li input#pop3")
+        b.click("#cockpit_modal_dialog .btn-primary")
+        b.wait_present("tr[data-row-id='pop3']")
+
+
+if __name__ == '__main__':
+    test_main()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,6 +51,10 @@ var info = {
             "networkmanager/utils.js"
         ],
 
+        "networkmanager/firewall": [
+            "networkmanager/firewall.jsx"
+        ],
+
         "ostree/ostree": [
             "ostree/app.js",
             "ostree/ostree.less",
@@ -206,6 +210,8 @@ var info = {
         "machines/vnc.css",
 
         "networkmanager/index.html",
+        "networkmanager/firewall.html",
+        "networkmanager/manifest.json",
 
         "ostree/index.html",
 


### PR DESCRIPTION
First look at a what a firewall module might look like.

It operates on firewalld's default zone and there are no plans to expose zones, as they don't seem to be used very often on servers.

The delete buttons don't work yet, but the UI updates itself when adding and removing services from the default zone with one of:
```
sudo firewallctl zone '' remove service ssh
sudo firewallctl zone '' add service ssh
``` 

![firewall](https://user-images.githubusercontent.com/1221707/32411073-f94cb802-c1d1-11e7-80aa-d9d0226b5243.png)

This will implement the minimal version of the design and iterate in later pull requests.

- [x] show the firewall section on the default page when firewalld is installed
- [x] show the list of services that are currently active
- [x] allow to remove a service
- [x] allow to add one of firewalld's predefined services
- [x] tests
- [x] add doc/guide page
- [ ] feature video for release notes