### PR TITLE
bots: Temporarily upload public images to private store

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -126,6 +126,9 @@ def run(image, verbose=False, **kwargs):
     cmd = [ os.path.join(BOTS, "image-create"), "--verbose", "--upload" ]
     if store:
         cmd += [ "--store", store ]
+    else:
+        # HACK: use private store until public machines are back
+        cmd += [ "--store", REDHAT_STORE ]
     cmd += [ image ]
 
     os.environ['VIRT_BUILDER_NO_CACHE'] = "yes"


### PR DESCRIPTION
The publically accessible verifymachines{4,5} are down. Until they get
back up, upload non-RHEL images to the privage store as well, to unblock
image refreshes.

Fixes #8022