### PR TITLE
Revert "bots: Temporarily upload public images to private store"

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -126,9 +126,6 @@ def run(image, verbose=False, **kwargs):
     cmd = [ os.path.join(BOTS, "image-create"), "--verbose", "--upload" ]
     if store:
         cmd += [ "--store", store ]
-    else:
-        # HACK: use private store until public machines are back
-        cmd += [ "--store", REDHAT_STORE ]
     cmd += [ image ]
 
     os.environ['VIRT_BUILDER_NO_CACHE'] = "yes"


### PR DESCRIPTION
This reverts commit ab87336680d29af13b6415d565a7e223ddec4f42.

verifymachine{4,5} are back, and it's better to default to machines
which don't require the Red Hat VPN.