### PR TITLE
ws: Setup default cockpit.issue to display cockpit status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,8 @@ depcomp
 /src/ws/cockpit.appdata.xml
 /src/ws/cockpit.desktop
 /src/ws/cockpit.service
+/src/ws/cockpit.socket
+/src/ws/cockpit-tempfiles.conf
 src/common/cockpitassets.c
 src/common/cockpitassets.h
 /po/.intltool-merge-cache

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,7 @@ SUFFIXES = \
 	.map .map.gz \
 	.mo .po \
 	.service .service.in \
+	.socket .socket.in \
 	.svg .svg.gz \
 	.woff .woff.gz \
 	.1 .8 .5 \
@@ -103,6 +104,7 @@ SUBST_RULE = \
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && sed \
 	-e 's,[@]datadir[@],$(datadir),g' \
 	-e 's,[@]libexecdir[@],$(libexecdir),g' \
+	-e 's,[@]sysconfdir[@],$(sysconfdir),g' \
 	-e 's,[@]libdir[@],$(libdir),g' \
 	-e 's,[@]includedir[@],$(includedir),g' \
 	-e 's,[@]bindir[@],$(bindir),g' \
@@ -133,6 +135,8 @@ SUBST_RULE = \
 .map.map.gz:
 	$(GZ_RULE)
 .service.in.service:
+	$(SUBST_RULE)
+.socket.in.socket:
 	$(SUBST_RULE)
 .svg.svg.gz:
 	$(GZ_RULE)

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -159,11 +159,26 @@ remotectl_LDADD = \
 	$(COCKPIT_LIBS) \
 	$(NULL)
 
-dist_systemdunit_DATA += src/ws/cockpit.socket
-nodist_systemdunit_DATA += src/ws/cockpit.service
+nodist_systemdunit_DATA += \
+	src/ws/cockpit.socket \
+	src/ws/cockpit.service \
+	$(NULL)
 
 firewalldir = $(prefix)/lib/firewalld/services
 firewall_DATA = src/ws/cockpit.xml
+
+issuedir = $(datadir)/$(PACKAGE)/issue/
+issue_DATA = \
+	src/ws/inactive.issue \
+	src/ws/active.issue \
+	$(NULL)
+
+tempconfdir = $(prefix)/lib/tmpfiles.d
+nodist_tempconf_DATA = src/ws/cockpit-tempfiles.conf
+tempconf_in = src/ws/cockpit-tempfiles.conf.in
+
+$(nodist_tempconf_DATA): $(tempconf_in)
+	$(SUBST_RULE)
 
 # If running cockpit-ws as a non-standard user, we also set up
 # cockpit-session to be setuid root, but only runnable by cockpit-session
@@ -173,11 +188,16 @@ install-exec-hook::
 
 EXTRA_DIST += \
 	src/ws/cockpit.service.in \
+	src/ws/cockpit.socket.in \
 	$(firewall_DATA) \
+	$(issue_DATA) \
+	$(tempconf_in) \
 	$(NULL)
 
 CLEANFILES += \
+	src/ws/cockpit.socket \
 	src/ws/cockpit.service \
+	$(nodist_tempconf_DATA) \
 	$(NULL)
 
 appdatadir = $(datadir)/metainfo

--- a/src/ws/active.issue
+++ b/src/ws/active.issue
@@ -1,0 +1,2 @@
+Admin Console: https://\4:9090/ or https://\6:9090/
+

--- a/src/ws/cockpit-tempfiles.conf.in
+++ b/src/ws/cockpit-tempfiles.conf.in
@@ -1,0 +1,2 @@
+d /run/cockpit 0755 - - -
+L+ /run/cockpit/issue - - - - @datadir@/@PACKAGE@/issue/inactive.issue

--- a/src/ws/cockpit.socket
+++ b/src/ws/cockpit.socket
@@ -1,9 +1,0 @@
-[Unit]
-Description=Cockpit Web Service Socket
-Documentation=man:cockpit-ws(8)
-
-[Socket]
-ListenStream=9090
-
-[Install]
-WantedBy=sockets.target

--- a/src/ws/cockpit.socket.in
+++ b/src/ws/cockpit.socket.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=Cockpit Web Service Socket
+Documentation=man:cockpit-ws(8)
+
+[Socket]
+ListenStream=9090
+ExecStartPost=-/bin/ln -sf @datadir@/@PACKAGE@/issue/active.issue /run/cockpit/issue
+ExecStopPost=-/bin/ln -sf @datadir@/@PACKAGE@/issue/inactive.issue /run/cockpit/issue
+
+[Install]
+WantedBy=sockets.target

--- a/src/ws/inactive.issue
+++ b/src/ws/inactive.issue
@@ -1,0 +1,2 @@
+Activate the web admin console with: systemctl enable --now cockpit.socket
+

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -164,14 +164,38 @@ class TestConnection(MachineCase):
 
         self.allow_journal_messages('peer did not close io when expected')
 
-    @skipImage("Atomic changes ports differently", "fedora-atomic", "rhel-atomic", "continuous-atomic")
-    def testSocketPort(self):
+    @skipImage("Atomic doesn't use socket", "fedora-atomic", "rhel-atomic", "continuous-atomic")
+    def testSocket(self):
         m = self.machine
+
+        if not m.image in ["rhel-7-4", "rhel-7-5"]:
+            self.assertIn("systemctl", m.execute("cat /run/cockpit/issue"))
+            self.assertNotIn("9090", m.execute("cat /run/cockpit/issue"))
+        m.start_cockpit()
+
+        if not m.image in ["rhel-7-4", "rhel-7-5"]:
+            self.assertNotIn("systemctl", m.execute("cat /run/cockpit/issue"))
+            self.assertIn("9090", m.execute("cat /run/cockpit/issue"))
+
+        m.execute("systemctl stop cockpit.socket")
 
         # Change port according to documentation: http://cockpit-project.org/guide/latest/listen.html
         m.execute('! selinuxenabled || semanage port -m -t websm_port_t -p tcp 443')
-        m.execute('mkdir -p /etc/systemd/system/cockpit.socket.d/ && printf "[Socket]\nListenStream=\nListenStream=443" > /etc/systemd/system/cockpit.socket.d/listen.conf')
+        m.execute("echo 'custom activemessage' > /etc/cockpit/active.issue")
+        m.execute('mkdir -p /etc/systemd/system/cockpit.socket.d/ && printf "[Socket]\nListenStream=\nListenStream=443\nExecStartPost=-/bin/ln -sf /etc/cockpit/active.issue /run/cockpit/issue" > /etc/systemd/system/cockpit.socket.d/listen.conf')
+
+        # cockpit-ws from base package
+        if not m.image in ["rhel-7-4", "rhel-7-5"]:
+            self.assertIn("systemctl", m.execute("cat /run/cockpit/issue"))
+            self.assertNotIn("9090", m.execute("cat /run/cockpit/issue"))
+            self.assertNotIn("custom activemessage", m.execute("cat /run/cockpit/issue"))
         m.start_cockpit(tls=True)
+
+        # cockpit-ws from base package
+        if not m.image in ["rhel-7-4", "rhel-7-5"]:
+            self.assertNotIn("systemctl", m.execute("cat /run/cockpit/issue"))
+            self.assertNotIn("9090", m.execute("cat /run/cockpit/issue"))
+            self.assertIn("custom activemessage", m.execute("cat /run/cockpit/issue"))
 
         output = m.execute('curl -k https://localhost 2>&1 || true')
         self.assertIn('Loading...', output)

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -560,9 +560,12 @@ The Cockpit Web Service listens on the network, and authenticates users.
 %doc %{_mandir}/man8/pam_ssh_add.8.gz
 %config(noreplace) %{_sysconfdir}/%{name}/ws-certs.d
 %config(noreplace) %{_sysconfdir}/pam.d/cockpit
+%{_datadir}/%{name}/issue/active.issue
+%{_datadir}/%{name}/issue/inactive.issue
 %{_unitdir}/cockpit.service
 %{_unitdir}/cockpit.socket
 %{_prefix}/%{__lib}/firewalld/services/cockpit.xml
+%{_prefix}/%{__lib}/tmpfiles.d/cockpit-tempfiles.conf
 %{_sbindir}/remotectl
 %{_libdir}/security/pam_ssh_add.so
 %{_libexecdir}/cockpit-ws

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -3,11 +3,13 @@ etc/pam.d/cockpit
 lib/systemd/system/cockpit.service
 lib/systemd/system/cockpit.socket
 lib/*/security/pam_ssh_add.so
+usr/lib/tmpfiles.d/cockpit-tempfiles.conf
 usr/lib/cockpit/cockpit-session
 usr/lib/cockpit/cockpit-ws
 usr/lib/firewalld/services/cockpit.xml
 usr/sbin/remotectl
 usr/share/cockpit/branding/
+usr/share/cockpit/issue/
 usr/share/cockpit/static/
 usr/share/locale/
 usr/share/man/man5/cockpit.conf.5


### PR DESCRIPTION
Upstream agetty has gotten support for loading additional messages from /etc/issue.d/. Setup a
cockpit.issue file that alters it's contents based on the status of the cockpit.socket.

This way distros that choose to can add a link from a file in /etc/issue.d/ to /etc/cockpit/cockpit.issue
and display the appropriate message to users.