### PR TITLE
bots: Drop obsolete semanage naughty override

### DIFF
--- a/bots/naughty/rhel-7-5/7904-semanage-policydb-version
+++ b/bots/naughty/rhel-7-5/7904-semanage-policydb-version
@@ -1,4 +1,0 @@
-ERROR: policydb version 31 does not match my version range 15-30
-ERROR: Unable to open policy //etc/selinux/targeted/policy/policy.31.
-*
-CalledProcessError: Command '! selinuxenabled || semanage *' returned non-zero exit status 1

--- a/bots/naughty/rhel-7-5/7904-semanage-policydb-version-2
+++ b/bots/naughty/rhel-7-5/7904-semanage-policydb-version-2
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-setroubleshoot", line *, in testTroubleshootAlerts
-    b.wait_in_text("body", "No SELinux alerts.")
-*
-Error: timeout


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1500888 got fixed in the
most recent RHEL 7.5 nightlies, so drop the known issue.

Fixes #7904