### PR TITLE
bots: Adjust and centralize REDHAT_PING

### DIFF
--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -45,9 +45,6 @@ WINDOWS_TASKS = [
     "windows"
 ]
 
-# Server to tell us if we can create Red Hat images
-REDHAT_PING = "http://file.rdu.redhat.com"
-
 # Credentials for working on above contexts
 REDHAT_CREDS = "~/.rhel/login"
 
@@ -59,7 +56,7 @@ import urllib
 
 sys.dont_write_bytecode = True
 
-from task import github
+from task import github, REDHAT_PING
 
 BOTS = os.path.normpath(os.path.join(os.path.dirname(__file__)))
 BASE = os.path.normpath(os.path.join(BOTS, ".."))

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -44,7 +44,11 @@ __all__ = (
     "issue",
     "verbose",
     "stale",
+    "REDHAT_PING",
 )
+
+# Server to tell us if we can handle Red Hat images
+REDHAT_PING = "http://cockpit-11.e2e.bos.redhat.com"
 
 api = github.GitHub()
 verbose = False

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -54,9 +54,6 @@ REDHAT_VERIFY = {
     'selenium/explorer': [ 'master' ],
 }
 
-# Server to tell us if we can test Red Hat images
-REDHAT_PING = "http://cockpit-11.e2e.bos.redhat.com"
-
 # Host interfaces that tell us we're not in a namespaced network
 HOST_INTERFACES = [ "cockpit1", "docker0", "virbr0" ]
 
@@ -77,7 +74,7 @@ import urllib
 
 sys.dont_write_bytecode = True
 
-from task import github
+from task import github, REDHAT_PING
 
 def main():
     parser = argparse.ArgumentParser(description='Bot: scan and update status of pull requests on GitHub')


### PR DESCRIPTION
http://file.rdu.redhat.com just gives a 404, and we don't actually use
it for anything in Cockpit CI. Move `REDHAT_PING` out of
{tests,issue}-scan into the task library, and use cockpit-11 for both
as that's the actually important machine.