### PR TITLE
all: Use new 'post_hook' to set unit string on plots

### DIFF
--- a/pkg/docker/overview.js
+++ b/pkg/docker/overview.js
@@ -126,7 +126,9 @@
             else
                 axes.yaxis.options.max = null;
             axes.yaxis.options.min = 0;
-
+        };
+        mem_options.post_hook = function (flot) {
+            var axes = flot.getAxes();
             $("#containers-mem-unit").text(plot.bytes_tick_unit(axes.yaxis));
         };
 

--- a/pkg/lib/plot.js
+++ b/pkg/lib/plot.js
@@ -68,11 +68,15 @@ var C_ = cockpit.gettext;
  * Set the global flot options.  You need to refresh the plot
  * afterwards.
  *
- * In addition to the flot options, you can also set 'setup_hook'
+ * In addition to the flot options, you can also set the 'setup_hook'
  * field to a function.  This function will be called between
  * flot.setData() and flot.draw() and can be used to adjust the axes
  * limits, for example.  It is called with the flot object as its only
  * parameter.
+ *
+ * Setting the 'post_hook' to a function will call that function after
+ * each refresh of the plot.  This is used to decorate a plot with the
+ * unit strings, for example.
  *
  * - options = plot.get_options()
  *
@@ -169,6 +173,9 @@ plotter.plot = function plot(element, x_range_seconds, x_stop_seconds) {
 
         flot.setupGrid();
         flot.draw();
+
+        if (options.post_hook)
+            options.post_hook(flot);
     }
 
     var refresh_pending = false;
@@ -1071,6 +1078,8 @@ function setup_plot(graph_id, grid, data, user_options) {
                 user_options.setup_hook(plot);
             plot.setupGrid();
             plot.draw();
+            if (user_options.post_hook)
+                user_options.post_hook(plot);
         }
     }
 

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1431,15 +1431,18 @@ function render_active_connection(dev, with_link, hide_link_local) {
     return $('<span>').text(parts.join(", "));
 }
 
-function make_network_plot_setup_hook(unit) {
+function network_plot_setup_hook(pl) {
+    var axes = pl.getAxes();
+    if (axes.yaxis.datamax < 100000)
+        axes.yaxis.options.max = 100000;
+    else
+        axes.yaxis.options.max = null;
+    axes.yaxis.options.min = 0;
+}
+
+function make_network_plot_post_hook(unit) {
     return function (pl) {
         var axes = pl.getAxes();
-        if (axes.yaxis.datamax < 100000)
-            axes.yaxis.options.max = 100000;
-        else
-            axes.yaxis.options.max = null;
-        axes.yaxis.options.min = 0;
-
         $(unit).text(plot.bits_per_sec_tick_unit(axes.yaxis));
     };
 }
@@ -1609,7 +1612,8 @@ PageNetworking.prototype = {
         $.extend(rx_plot_options.grid,  { hoverable: true,
                                           autoHighlight: false
                                         });
-        rx_plot_options.setup_hook = make_network_plot_setup_hook("#networking-rx-unit");
+        rx_plot_options.setup_hook = network_plot_setup_hook;
+        rx_plot_options.post_hook = make_network_plot_post_hook("#networking-rx-unit");
         this.rx_plot = plot.plot($("#networking-rx-graph"), 300);
         this.rx_plot.set_options(rx_plot_options);
         this.rx_series = this.rx_plot.add_metrics_stacked_instances_series(rx_plot_data, { });
@@ -1630,7 +1634,8 @@ PageNetworking.prototype = {
         $.extend(tx_plot_options.grid,  { hoverable: true,
                                           autoHighlight: false
                                         });
-        tx_plot_options.setup_hook = make_network_plot_setup_hook("#networking-tx-unit");
+        tx_plot_options.setup_hook = network_plot_setup_hook;
+        tx_plot_options.post_hook = make_network_plot_post_hook("#networking-tx-unit");
         this.tx_plot = plot.plot($("#networking-tx-graph"), 300);
         this.tx_plot.set_options(tx_plot_options);
         this.tx_series = this.tx_plot.add_metrics_stacked_instances_series(tx_plot_data, { });
@@ -2170,7 +2175,8 @@ PageNetworkInterface.prototype = {
         $.extend(rx_plot_options.grid,  { hoverable: true,
                                           autoHighlight: false
                                         });
-        rx_plot_options.setup_hook = make_network_plot_setup_hook("#network-interface-rx-unit");
+        rx_plot_options.setup_hook = network_plot_setup_hook;
+        rx_plot_options.post_hook = make_network_plot_post_hook("#network-interface-rx-unit");
         this.rx_plot = plot.plot($("#network-interface-rx-graph"), 300);
         this.rx_plot.set_options(rx_plot_options);
         this.rx_series = this.rx_plot.add_metrics_stacked_instances_series(rx_plot_data, { });
@@ -2190,7 +2196,8 @@ PageNetworkInterface.prototype = {
         $.extend(tx_plot_options.grid,  { hoverable: true,
                                           autoHighlight: false
                                         });
-        tx_plot_options.setup_hook = make_network_plot_setup_hook("#network-interface-tx-unit");
+        tx_plot_options.setup_hook = network_plot_setup_hook;
+        tx_plot_options.post_hook = make_network_plot_post_hook("#network-interface-tx-unit");
         this.tx_plot = plot.plot($("#network-interface-tx-graph"), 300);
         this.tx_plot.set_options(tx_plot_options);
         this.tx_series = this.tx_plot.add_metrics_stacked_instances_series(tx_plot_data, { });

--- a/pkg/storaged/overview.js
+++ b/pkg/storaged/overview.js
@@ -589,15 +589,18 @@
 
         $(client).on('changed', render_jobs);
 
-        function make_plot_setup(unit) {
-            return function plot_setup(flot) {
-                var axes = flot.getAxes();
-                if (axes.yaxis.datamax < 100000)
-                    axes.yaxis.options.max = 100000;
-                else
-                    axes.yaxis.options.max = null;
-                axes.yaxis.options.min = 0;
+        function plot_setup(flot) {
+            var axes = flot.getAxes();
+            if (axes.yaxis.datamax < 100000)
+                axes.yaxis.options.max = 100000;
+            else
+                axes.yaxis.options.max = null;
+            axes.yaxis.options.min = 0;
+        }
 
+        function make_plot_post(unit) {
+            return function (flot) {
+                var axes = flot.getAxes();
                 $(unit).text(plot.bytes_per_sec_tick_unit(axes.yaxis));
             };
         }
@@ -622,7 +625,8 @@
         $.extend(read_plot_options.grid,  { hoverable: true,
                                             autoHighlight: false
                                           });
-        read_plot_options.setup_hook = make_plot_setup("#storage-reading-unit");
+        read_plot_options.setup_hook = plot_setup;
+        read_plot_options.post_hook = make_plot_post("#storage-reading-unit");
         var read_plot = plot.plot($("#storage-reading-graph"), 300);
         read_plot.set_options(read_plot_options);
         read_series = read_plot.add_metrics_stacked_instances_series(read_plot_data, { });
@@ -644,7 +648,8 @@
         $.extend(write_plot_options.grid,  { hoverable: true,
                                              autoHighlight: false
                                            });
-        write_plot_options.setup_hook = make_plot_setup("#storage-writing-unit");
+        write_plot_options.setup_hook = plot_setup;
+        write_plot_options.post_hook = make_plot_post("#storage-writing-unit");
         var write_plot = plot.plot($("#storage-writing-graph"), 300);
         write_plot.set_options(write_plot_options);
         write_series = write_plot.add_metrics_stacked_instances_series(write_plot_data, { });

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -468,7 +468,7 @@ PageServer.prototype = {
         $.extend(memory_options.yaxis, { ticks: plot.memory_ticks,
                                          tickFormatter: plot.format_bytes_tick_no_unit
                                        });
-        memory_options.setup_hook = function memory_setup_hook(pl) {
+        memory_options.post_hook = function memory_post_hook(pl) {
             var axes = pl.getAxes();
             $('#server_memory_unit').text(plot.bytes_tick_unit(axes.yaxis));
         };
@@ -497,7 +497,9 @@ PageServer.prototype = {
             else
                 axes.yaxis.options.max = null;
             axes.yaxis.options.min = 0;
-
+        };
+        network_options.post_hook = function network_post_hook(pl) {
+            var axes = pl.getAxes();
             $('#server_network_traffic_unit').text(plot.bits_per_sec_tick_unit(axes.yaxis));
         };
 
@@ -525,7 +527,9 @@ PageServer.prototype = {
             else
                 axes.yaxis.options.max = null;
             axes.yaxis.options.min = 0;
-
+        };
+        disk_options.post_hook = function disk_post_hook(pl) {
+            var axes = pl.getAxes();
             $('#server_disk_io_unit').text(plot.bytes_per_sec_tick_unit(axes.yaxis));
         };
 


### PR DESCRIPTION
The setup_hook is too early for this. We need the grid to be setup as
well to know the actual ranges of the axes.

Previously, we would show the unit string for the previous refresh of
a plot, which is almost always correct.  But when scrolling and
zooming around in archive data, it is easy to get the wrong unit
string.