### PR TITLE
test: Don't use Browser.wait for non-browser conditions

### DIFF
--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -90,10 +90,10 @@ class TestAccounts(MachineCase):
         b.wait_present(admin_role_sel + ":not(:checked)")
         b.set_checked(admin_role_sel, True)
         b.wait_present(admin_role_sel + ":checked")
-        b.wait(lambda: "jussi" in m.execute("grep %s /etc/group" % m.get_admin_group()))
+        wait(lambda: "jussi" in m.execute("grep %s /etc/group" % m.get_admin_group()))
         b.set_checked(admin_role_sel, False)
         b.wait_present(admin_role_sel + ":not(:checked)")
-        b.wait(lambda: "jussi" not in m.execute("grep %s /etc/group" % m.get_admin_group()))
+        wait(lambda: "jussi" not in m.execute("grep %s /etc/group" % m.get_admin_group()))
         m.execute("/usr/sbin/usermod jussi -G %s -a" % m.get_admin_group())
         b.wait_present(admin_role_sel + ":checked")
 

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -265,7 +265,7 @@ class TestMachines(MachineCase):
         b.wait_not_visible("#vm-subVmTest1-sendNMI")
 
         if args["logfile"] is not None:
-            b.wait(lambda: "NMI received" in self.machine.execute("cat {0}".format(args["logfile"])))
+            wait(lambda: "NMI received" in self.machine.execute("cat {0}".format(args["logfile"])))
 
         # shut off
         b.click("#vm-subVmTest1-off-caret")

--- a/test/verify/check-ovirt
+++ b/test/verify/check-ovirt
@@ -260,7 +260,7 @@ class TestOVirtMachines(MachineCase):
         b.click("button:contains('Save')")
         b.wait_present("button:contains('OK')")
         b.click("button:contains('OK')")  # Limitation of this test env: In fact self.machine is updated and not the VDSM, see hack_for_missing_vdsm().
-        b.wait(lambda: TEST_VDSM_CONF_CONTENT in self.machine.execute("cat {0}".format(VDSM_CONF_FILE)))
+        wait(lambda: TEST_VDSM_CONF_CONTENT in self.machine.execute("cat {0}".format(VDSM_CONF_FILE)))
 
         # sit(self.machines)
 


### PR DESCRIPTION
Browser.wait processes events in the browser until the condition is
true.  If there aren't any events, the predicate isn't evaluated and
we might get stuck.

This is highly theoretical since the browser does get enough events
from the metric channels that drive the plots on the system page, for
example.  But it's good to be theoretically correct, of course.