### PR TITLE
Fix Python code for Python 3 syntax, some pyflakes errors

### DIFF
--- a/bots/image-create
+++ b/bots/image-create
@@ -60,7 +60,7 @@ class MachineBuilder:
         self.machine = machine
 
         try:
-            os.makedirs(TEMP, 0750)
+            os.makedirs(TEMP, 0o750)
         except OSError as ex:
             if ex.errno != errno.EEXIST:
                 raise
@@ -74,7 +74,7 @@ class MachineBuilder:
         assert not self.machine._domain
 
         if not os.path.exists(self.machine.run_dir):
-            os.makedirs(self.machine.run_dir, 0750)
+            os.makedirs(self.machine.run_dir, 0o750)
 
         bootstrap_script = os.path.join(BOTS, "images", "scripts", "%s.bootstrap" % (self.machine.image, ))
 
@@ -171,7 +171,7 @@ class MachineBuilder:
         images_dir = os.path.join(BOTS, "images")
 
         if not os.path.exists(data_dir):
-            os.makedirs(data_dir, 0750)
+            os.makedirs(data_dir, 0o750)
 
         if not os.path.exists(self.machine.image_file):
             raise testvm.Failure("Nothing to save.")

--- a/bots/image-create
+++ b/bots/image-create
@@ -61,7 +61,7 @@ class MachineBuilder:
 
         try:
             os.makedirs(TEMP, 0750)
-        except OSError, ex:
+        except OSError as ex:
             if ex.errno != errno.EEXIST:
                 raise
 
@@ -115,7 +115,7 @@ class MachineBuilder:
                     # update our local openshift kube config file to match the new image
                     self.machine.download("/root/.kube/config", "images/files/openshift.kubeconfig")
 
-            except subprocess.CalledProcessError, ex:
+            except subprocess.CalledProcessError as ex:
                 if args.sit:
                     sys.stderr.write(self.machine.diagnose())
                     raw_input ("Press RET to continue... ")
@@ -219,6 +219,6 @@ try:
             cmd += [ args.image ]
             subprocess.check_call(cmd)
 
-except testvm.Failure, ex:
+except testvm.Failure as ex:
     print >> sys.stderr, "image-create:", ex
     sys.exit(1)

--- a/bots/image-create
+++ b/bots/image-create
@@ -52,7 +52,7 @@ args = parser.parse_args()
 if args.image in ["candlepin", "continuous-atomic", "fedora-atomic", "ipa", "rhel-atomic", "selenium", "openshift", "openshift-node", "ovirt"]:
     if not args.no_build:
         if args.verbose:
-            print "Creating machine without build capabilities based on the image type"
+            print("Creating machine without build capabilities based on the image type")
         args.no_build = True
 
 class MachineBuilder:
@@ -209,10 +209,10 @@ try:
     builder = MachineBuilder(machine)
     builder.build()
     if not args.no_save:
-        print "Saving..."
+        print("Saving...")
         builder.save()
         if args.upload:
-            print "Uploading..."
+            print("Uploading...")
             cmd = [ os.path.join(BOTS, "image-upload") ]
             if args.store:
                 cmd += [ "--store", args.store ]
@@ -220,5 +220,5 @@ try:
             subprocess.check_call(cmd)
 
 except testvm.Failure as ex:
-    print >> sys.stderr, "image-create:", ex
+    sys.stderr.write("image-create: %s\n" % ex)
     sys.exit(1)

--- a/bots/image-customize
+++ b/bots/image-customize
@@ -82,7 +82,7 @@ def run_script(machine_instance, scriptlist):
             machine_instance.execute("chmod a+x %s" % uploadpath)
             machine_instance.execute(uploadpath)
         else:
-            print >> sys.stderr, "Bad path to script:", foo
+            sys.stderr.write("Bad path to script: %s\n" % foo)
 
 def upload_files(machine_instance, uploadfiles):
     """Upload files/directories inside image"""
@@ -104,7 +104,7 @@ def install_packages(machine_instance, packagelist, install_command):
         elif not re.search("/", foo):
             allpackages.append(foo)
         else:
-            print >> sys.stderr, "Bad package name or path:", foo
+            sys.stderr.write("Bad package name or path: %s\n" % foo)
     if allpackages:
         machine_instance.execute(install_command + " " + ' '.join(allpackages))
 

--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -75,7 +75,7 @@ def main():
             subprocess.check_call([ "image-download", base_image])
         if build_image and not os.path.exists(build_image):
             subprocess.check_call([ "image-download", build_image])
-    except OSError, ex:
+    except OSError as ex:
         if ex.errno != errno.ENOENT:
             raise
         sys.stderr.write("image-prepare: missing tools to download images\n")

--- a/bots/image-prune
+++ b/bots/image-prune
@@ -88,7 +88,7 @@ def get_image_links(ref, git_path):
 
     try:
         entries = subprocess.check_output(["git", "ls-tree",  "--name-only", ref, git_path]).splitlines()
-    except subprocess.CalledProcessError, e:
+    except subprocess.CalledProcessError as e:
         if e.returncode == 128:
             sys.stderr.write("Skipping {0} due to tree error.\n".format(ref))
             return []
@@ -197,7 +197,7 @@ def main():
 
     try:
         prune_images(args.force, args.dryrun, quiet=args.quiet, open_pull_requests=(not args.branches_only), offline=args.offline, checkout_only=args.checkout_only)
-    except RuntimeError, ex:
+    except RuntimeError as ex:
         sys.stderr.write("image-prune: {0}\n".format(str(ex)))
         return 1
 

--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -64,7 +64,7 @@ def main():
 
     try:
         results = scan(api, opts.image, opts.verbose)
-    except RuntimeError, ex:
+    except RuntimeError as ex:
         sys.stderr.write("image-trigger: " + str(ex) + "\n")
         return 1
 

--- a/bots/images/scripts/lib/atomic.install
+++ b/bots/images/scripts/lib/atomic.install
@@ -65,7 +65,7 @@ class AtomicCockpitInstaller:
 
     def setup_dirs(self):
         if self.verbose:
-            print "setting up new ostree repo"
+            print("setting up new ostree repo")
 
         try:
             shutil.rmtree(self.repo_location)
@@ -78,7 +78,7 @@ class AtomicCockpitInstaller:
 
         if not os.path.exists(self.checkout_location):
             if self.verbose:
-                print "cloning current branch"
+                print("cloning current branch")
 
             subprocess.check_call(["ostree", "checkout", self.branch,
                                    self.checkout_location])
@@ -89,7 +89,7 @@ class AtomicCockpitInstaller:
 
     def switch_to_local_tree(self):
         if self.verbose:
-            print "install new ostree commit"
+            print("install new ostree commit")
 
         # Not an error if this fails
         subprocess.call(["ostree", "remote", "delete", "local"])
@@ -119,7 +119,7 @@ class AtomicCockpitInstaller:
 
     def commit_to_repo(self):
         if self.verbose:
-            print "commit package changes to our repo"
+            print("commit package changes to our repo")
 
         # move etc back to /usr/etc
         subprocess.check_call(["mv", os.path.join(self.checkout_location, "etc"),
@@ -191,7 +191,7 @@ class AtomicCockpitInstaller:
                 rpm_args = ["docker", "exec", "build-cockpit",
                             "rpm", "-U", "--force"] + rpm_args
                 if self.verbose:
-                    print "updating cockpit-ws container"
+                    print("updating cockpit-ws container")
                 subprocess.check_call(rpm_args)
 
                 # if we update the RPMs, also update the scripts, to keep them in sync
@@ -212,14 +212,14 @@ class AtomicCockpitInstaller:
         packages = subprocess.check_output("rpm -qa | grep cockpit", shell=True)
 
         if self.verbose:
-            print "installed packages: {0}".format(packages)
+            print("installed packages: {0}".format(packages))
 
         installed_packages = packages.strip().split("\n")
         return installed_packages
 
     def clean_network(self):
         if self.verbose:
-            print "clean network configuration:"
+            print("clean network configuration:")
         subprocess.check_call(["rm", "-rf", "/var/lib/NetworkManager"])
         subprocess.check_call(["rm", "-rf", "/var/lib/dhcp"])
 
@@ -238,20 +238,20 @@ class AtomicCockpitInstaller:
         for p in self.packages_force_install:
             if not p in packages_to_install:
                 if self.verbose:
-                    print "adding package %s (forced)" % (p)
+                    print("adding package %s (forced)" % (p))
                 packages_to_install.append(p)
 
         packages_to_install = filter(lambda p: any(os.path.split(p)[1].startswith(base) for base in packages_to_install), self.rpms)
 
         if self.verbose:
-            print "packages to install:"
-            print packages_to_install
+            print("packages to install:")
+            print(packages_to_install)
 
         if self.external_packages:
             names = self.external_packages.keys()
             if self.verbose:
-                print "external packages to install:"
-                print names
+                print("external packages to install:")
+                print(names)
 
             downloader = urllib.URLopener()
             for name, url in self.external_packages.items():
@@ -282,7 +282,7 @@ parser.add_argument('--skip', action='append', default=[], help='Packes to skip 
 args = parser.parse_args()
 
 if args.build:
-    print >> sys.stderr, "Can't build on Atomic"
+    sys.stderr.write("Can't build on Atomic\n")
     sys.exit(1)
 
 if args.install:

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -273,7 +273,7 @@ def run(context, function, **kwargs):
     except (AssertionError, KeyboardInterrupt):
         raise
     except:
-        traceback.print_exc(file=sys.stderr)
+        sys.stderr.write(traceback.print_exc())
     finally:
         finish(publishing, ret, name, context, issue)
     return ret or 0

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -268,7 +268,7 @@ def run(context, function, **kwargs):
             execute("git", "checkout", "--detach", pull['head']['sha'])
 
         ret = function(context, **kwargs)
-    except (RuntimeError, subprocess.CalledProcessError), ex:
+    except (RuntimeError, subprocess.CalledProcessError) as ex:
         ret = str(ex)
     except (AssertionError, KeyboardInterrupt):
         raise

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -155,7 +155,7 @@ def links(url):
     except urllib2.HTTPError, ex:
         if ex.code != 404:
             raise
-    except urllib2.URLError:
+    except urllib2.URLError as ex:
         sys.stderr.write("{0}: {1}\n".format(url, ex))
     return result
 
@@ -275,7 +275,7 @@ def logs(revision):
             except urllib2.HTTPError, ex:
                 if ex.code != 404:
                     raise
-            except urllib2.URLError:
+            except urllib2.URLError as ex:
                 sys.stderr.write("{0}: {1}\n".format(target, ex))
 
 # Generate (status, body) for each Test Anything Protocol test

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -152,7 +152,7 @@ def links(url):
     parser = HrefParser(url, result)
     try:
         parser.feed(retrieve(url))
-    except urllib2.HTTPError, ex:
+    except urllib2.HTTPError as ex:
         if ex.code != 404:
             raise
     except urllib2.URLError as ex:
@@ -170,7 +170,7 @@ def seed(since, fp, output):
             break
         try:
             item = json.loads(line)
-        except ValueError, ex:
+        except ValueError as ex:
             sys.stderr.write("tests-data: {1}\n".format(str(ex)))
             continue
 
@@ -239,12 +239,12 @@ def revisions(pull):
             target = urlparse.urljoin(link, "status")
             try:
                 data = json.loads(retrieve(target))
-            except ValueError, ex:
+            except ValueError as ex:
                 sys.stderr.write("{0}: {1}\n".format(target, ex))
-            except urllib2.HTTPError, ex:
+            except urllib2.HTTPError as ex:
                 if ex.code != 404:
                     raise
-            except urllib2.URLError, ex:
+            except urllib2.URLError as ex:
                 sys.stderr.write("{0}: {1}\n".format(target, ex))
                 pass
             else:
@@ -272,7 +272,7 @@ def logs(revision):
                 target = target[:-5]
             try:
                 yield (status["context"], status["created_at"], target, retrieve(target))
-            except urllib2.HTTPError, ex:
+            except urllib2.HTTPError as ex:
                 if ex.code != 404:
                     raise
             except urllib2.URLError as ex:

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -60,7 +60,7 @@ def main():
         task = PullTask(name, revision, opts.ref, opts.context, opts.rebase,
                         github_revision=github_revision)
         ret = task.run(opts)
-    except RuntimeError, ex:
+    except RuntimeError as ex:
         ret = str(ex)
 
     if ret:
@@ -242,7 +242,7 @@ class PullTask(object):
         # COMPAT: Create a legacy tmp/run directory to prevent races during testing
         try:
             os.makedirs(os.path.join(BASE, "test", "tmp", "run"))
-        except OSError, ex:
+        except OSError as ex:
             if ex.errno != errno.EEXIST:
                 raise
 

--- a/bots/tests-policy
+++ b/bots/tests-policy
@@ -96,7 +96,7 @@ def main():
         sys.stdout.write(output)
         return 0
 
-    except RuntimeError, ex:
+    except RuntimeError as ex:
         sys.stderr.write("{0}: {1}\n".format(script, ex))
         return 1
 

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -87,7 +87,7 @@ def main():
 
     try:
         results = scan(api, not opts.dry, opts.human_readable)
-    except RuntimeError, ex:
+    except RuntimeError as ex:
         sys.stderr.write("tests-scan: " + str(ex) + "\n")
         return 1
 

--- a/test/avocado/cockpit.py
+++ b/test/avocado/cockpit.py
@@ -189,7 +189,7 @@ class Cockpit():
                     found = True
                     break
             if not found:
-                print "Unexpected journal message '%s'" % m
+                print("Unexpected journal message '%s'" % m)
                 all_found = False
                 if not first:
                     first = m

--- a/test/avocado/libdisc.py
+++ b/test/avocado/libdisc.py
@@ -52,7 +52,7 @@ class Disc():
         process.run("iscsiadm -m discovery -t sendtargets -p %s" % self.ip, shell = True)
         process.run("iscsiadm -m node --targetname=%s.%s:%s --login" % (self.prefix, self.domain, targetsuffix), shell = True)
         tmp = process.run("iscsiadm -m node" , shell = True)
-        print tmp.stdout
+        print(tmp.stdout)
         tmp = process.run("sleep 5; iscsiadm -m session -P 3 | tail -1" , shell = True)
         tmp1 = re.search('Attached scsi disk\s+([a-z]*)\s+', tmp.stdout)
         return "/dev/%s" % str(tmp1.group(1))

--- a/test/avocado/libnetwork.py
+++ b/test/avocado/libnetwork.py
@@ -32,13 +32,13 @@ class Network():
         self.interfaces=[]
         process.run("modprobe veth", shell=True)
         if self.brname and self.checkifbridgeexist():
-            print "adding bridge " + self.brname
+            print("adding bridge " + self.brname)
             self.createbridge()
 
     def clear(self):
         self.deleteallinterfaces()
         if self.brname and not self.checkifbridgeexist():
-            print "deleting bridge " + self.brname
+            print("deleting bridge " + self.brname)
             self.delbridge()
 
     def checkifbridgeexist(self):

--- a/test/avocado/libnetwork.py
+++ b/test/avocado/libnetwork.py
@@ -59,7 +59,7 @@ class Network():
 
     def addiface(self, ifname, bridge=True):
         if ifname in self.interfaces:
-            raise("Unable to add network interface %s (already exit)" % ifname)
+            raise RuntimeError("Unable to add network interface %s (already exists)")
         process.run("ip link add name %sbr type veth peer name %s" % (ifname, ifname), shell=True)
         process.run("ip link set dev %sbr up" % ifname, shell=True)
         process.run("ip link set dev %s up" % ifname, shell=True)
@@ -83,7 +83,7 @@ class Network():
             process.run("ip link del dev %sbr type veth" % ifname, shell=True)
             self.interfaces.remove(ifname)
         else:
-            raise ("Unable to remove interface %s (does not exist)" % ifname)
+            raise RuntimeError("Unable to remove interface %s (does not exist)")
 
     def deleteallinterfaces(self):
         for interface in self.interfaces:

--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -55,35 +55,35 @@ def tap_output(machine):
     try:
         json_info = json.loads(machine.execute(command="cat " + os.path.join(avocado_results_dir, "latest/results.json"), quiet=True))
     except Exception as e:
-        print "ERROR: Unable to fetch JSON from remote machine:", os.path.join(avocado_results_dir, "latest/results.json")
-        print e
+        print("ERROR: Unable to fetch JSON from remote machine: " + os.path.join(avocado_results_dir, "latest/results.json"))
+        print(e)
         return None
-    print "\nTAP output -------------------------"
-    print "1..%s" % len(json_info['tests'])
+    print("\nTAP output -------------------------")
+    print("1..%s" % len(json_info['tests']))
     counter = 1
     for t in json_info['tests']:
         test_status = t['status']
         test_name = os.path.basename(t['test'])
         test_log = t['logfile']
         test_time_string = "duration: %ds" % t['time']
-        print "# ----------------------------------------------------------------------"
-        print "# %s %s" % (test_name, test_time_string)
-        print "#"
+        print("# ----------------------------------------------------------------------")
+        print("# %s %s" % (test_name, test_time_string))
+        print("#")
         try:
-            print machine.execute(command="cat " + test_log, quiet=True)
+            print(machine.execute(command="cat " + test_log, quiet=True))
         except Exception as e:
-            print "ERROR: Unable to fetch testlog from remote machine:", test_log
-            print e
-        print "# TEST LOG END -------"
+            print("ERROR: Unable to fetch testlog from remote machine: " + test_log)
+            print(e)
+        print("# TEST LOG END -------")
         if test_status == 'PASS':
-            print "ok %s %s %s" % (counter, test_name, test_time_string)
+            print("ok %s %s %s" % (counter, test_name, test_time_string))
         else:
-            print "not ok %s %s %s" % (counter, test_name, test_time_string)
+            print("not ok %s %s %s" % (counter, test_name, test_time_string))
         counter = counter + 1
     if len(json_info['tests']) != json_info['pass']:
-        print "# %d TESTS FAILED duration: %ds" % (len(json_info['tests']) - json_info['pass'], json_info['time'])
+        print("# %d TESTS FAILED duration: %ds" % (len(json_info['tests']) - json_info['pass'], json_info['time']))
     else:
-        print "# TESTS PASSED duration: %ds" %  json_info['time']
+        print("# TESTS PASSED duration: %ds" %  json_info['time'])
 
 def run_avocado_tests(machine, avocado_tests, print_failed=True, env=[]):
     """ Execute avocado on the machine with the passed environment variables and run
@@ -121,9 +121,9 @@ def run_avocado_tests(machine, avocado_tests, print_failed=True, env=[]):
                         if test_name.startswith(machine_test_dir + '/'):
                             test_name = test_name[(len(machine_test_dir) + 1):]
                         fail_reason = t['fail_reason']
-                        print "[" + test_status + "] " + test_name + " (" + fail_reason + ")"
+                        print("[" + test_status + "] " + test_name + " (" + fail_reason + ")")
             except:
-                print "Unable to show avocado test result summary"
+                print("Unable to show avocado test result summary")
         return_state = False
     tap_output(machine)
     return return_state
@@ -217,7 +217,7 @@ def run_avocado(avocado_tests, verbose, browser, download_logs, sit):
             copy_avocado_logs(machine, "PASSED")
 
         if not success and sit:
-            print >> sys.stderr, machine.diagnose()
+            sys.stderr.write(machine.diagnose() + "\n")
             raw_input ("Press RET to continue... ")
 
         return success

--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -21,12 +21,7 @@
 import argparse
 import json
 import os
-import shutil
 import sys
-import subprocess
-import glob
-import re
-import time
 
 # we use symlinked files
 # the directory structure breaks on the second run with .pyc files
@@ -35,7 +30,6 @@ sys.dont_write_bytecode = True
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.append(os.path.abspath(os.path.dirname(os.path.realpath(__file__))))
 
-from common import testlib
 from common import testvm
 
 machine_test_dir = "/tmp/avocado_tests"

--- a/test/avocado/timeoutlib.py
+++ b/test/avocado/timeoutlib.py
@@ -158,7 +158,7 @@ if __name__ == '__main__':
 
     except Exception as e:
         import sys, traceback
-        print >> sys.stderr, traceback.format_exc()
+        sys.stderr.write(traceback.format_exc())
         assert False, 'Unexpected exception raised: %s' % repr(e)
 
 
@@ -185,7 +185,7 @@ if __name__ == '__main__':
 
     except Exception as e:
         import sys, traceback
-        print >> sys.stderr, traceback.format_exc()
+        sys.stderr.write(traceback.format_exc())
         assert False, 'Unexpected exception raised: %s' % repr(e)
 
     # And react only to a set of exceptions
@@ -204,7 +204,7 @@ if __name__ == '__main__':
 
     except Exception as e:
         import sys, traceback
-        print >> sys.stderr, traceback.format_exc()
+        sys.stderr.write(traceback.format_exc())
         assert False, 'Unexpected exception raised: %s' % repr(e)
 
     # Use inverted result of wrapped fn
@@ -242,5 +242,5 @@ if __name__ == '__main__':
 
     except Exception as e:
         import sys, traceback
-        print >> sys.stderr, traceback.format_exc()
+        sys.stderr.write(traceback.format_exc())
         assert False, 'Unexpected exception raised: %s' % repr(e)

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -346,8 +346,7 @@ class Browser:
                         self.click("#machine-reconnect", True)
                         self.wait_not_visible(".curtains-ct")
                         continue
-                exc_info = sys.exc_info()
-                raise exc_info[0], exc_info[1], exc_info[2]
+                raise
 
         self.switch_to_frame(frame)
         self.wait_present("body")

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -339,7 +339,7 @@ class Browser:
                 self.wait_not_visible(".curtains-ct")
                 self.wait_visible("iframe.container-frame[name='%s']" % frame)
                 break
-            except Error, ex:
+            except Error as ex:
                 if reconnect and ex.msg.startswith('timeout'):
                     reconnect = False
                     if self.is_present("#machine-reconnect"):
@@ -530,7 +530,7 @@ class MachineCase(unittest.TestCase):
         for retry in range(0, max_retry_hard_limit):
             try:
                 super(MachineCase, self).run(result)
-            except RetryError, ex:
+            except RetryError as ex:
                 assert retry < max_retry_hard_limit
                 sys.stderr.write("{0}\n".format(ex))
                 sleep(retry * 10)
@@ -808,7 +808,7 @@ class MachineCase(unittest.TestCase):
                 m.download_dir("/var/lib/systemd/coredump", dest)
                 try:
                     os.rmdir(dest)
-                except OSError, ex:
+                except OSError as ex:
                     if ex.errno == errno.ENOTEMPTY:
                         print "Core dumps downloaded to %s" % (dest)
                         attach(dest)
@@ -1081,7 +1081,7 @@ class TapRunner(object):
         try:
             proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
             (output, error) = proc.communicate(output)
-        except OSError, ex:
+        except OSError as ex:
             if ex.errno != errno.ENOENT:
                 sys.stderr.write("Couldn't check known issue: {0}\n".format(str(ex)))
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -127,7 +127,7 @@ class Browser:
 
         tries = 0
         while not tryopen(tries >= 20):
-            print "Restarting browser..."
+            print("Restarting browser...")
             sleep(0.1)
             tries = tries + 1
 
@@ -568,7 +568,7 @@ class MachineCase(unittest.TestCase):
             if not self.machine:
                 self.machine = machine
             if opts.trace:
-                print "Starting {0} {1}".format(key, machine.label)
+                print("Starting {0} {1}".format(key, machine.label))
             machine.start()
 
         def sitter():
@@ -768,7 +768,7 @@ class MachineCase(unittest.TestCase):
                     found = True
                     break
             if not found:
-                print "Unexpected journal message '%s'" % m
+                print("Unexpected journal message '%s'" % m)
                 all_found = False
                 if not first:
                     first = m
@@ -797,7 +797,7 @@ class MachineCase(unittest.TestCase):
                 log = "%s-%s-%s.log" % (label or self.label(), m.label, title)
                 with open(log, "w") as fp:
                     m.execute("journalctl", stdout=fp)
-                    print "Journal extracted to %s" % (log)
+                    print("Journal extracted to %s" % (log))
                     attach(log)
 
     def copy_cores(self, title, label=None):
@@ -810,7 +810,7 @@ class MachineCase(unittest.TestCase):
                     os.rmdir(dest)
                 except OSError as ex:
                     if ex.errno == errno.ENOTEMPTY:
-                        print "Core dumps downloaded to %s" % (dest)
+                        print("Core dumps downloaded to %s" % (dest))
                         attach(dest)
 
 some_failed = False
@@ -835,7 +835,7 @@ class Phantom:
         if not self._driver:
             self.start()
         if opts.trace:
-            print "-> {0}({1})".format(name, repr(args)[1:-2])
+            print("-> {0}({1})".format(name, repr(args)[1:-2]))
         line = json.dumps({
             "cmd": name,
             "args": args,
@@ -849,15 +849,15 @@ class Phantom:
         try:
             res = json.loads(line)
         except:
-            print line.strip()
+            print(line.strip())
             raise
         if 'error' in res:
             if opts.trace:
-                print "<- raise", res['error']
+                print("<- raise", res['error'])
             raise Error(res['error'])
         if 'result' in res:
             if opts.trace:
-                print "<-", repr(res['result'])
+                print("<-", repr(res['result']))
             return res['result']
         raise Error("unexpected: " + line.strip())
 
@@ -959,7 +959,7 @@ class TapRunner(object):
             return False
         except:
             sys.stderr.write("Unexpected exception while running {0}\n".format(test))
-            traceback.print_exc(file=sys.stderr)
+            sys.stderr.write(traceback.print_exc())
             return False
         else:
             result.printErrors()

--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -970,7 +970,7 @@ class VirtMachine(Machine):
 
         try:
             os.makedirs(self.run_dir, 0750)
-        except OSError, ex:
+        except OSError as ex:
             if ex.errno != errno.EEXIST:
                 raise
 
@@ -1021,7 +1021,7 @@ class VirtMachine(Machine):
         try:
             # print >> sys.stderr, test_domain_desc
             self._domain = self.virt_connection.createXML(test_domain_desc, libvirt.VIR_DOMAIN_START_AUTODESTROY)
-        except libvirt.libvirtError, le:
+        except libvirt.libvirtError as le:
             if 'already exists with uuid' in le.message:
                 raise RepeatableFailure("libvirt domain already exists: " + le.message)
             else:
@@ -1058,11 +1058,11 @@ class VirtMachine(Machine):
                     self.shutdown()
                 else:
                     self.kill()
-            except libvirt.libvirtError, le:
+            except libvirt.libvirtError as le:
                 # the domain may have already been freed (shutdown) while the console was running
                 self.message("libvirt error during shutdown: %s" % (le.get_error_message()))
 
-        except OSError, ex:
+        except OSError as ex:
             raise Failure("Failed to launch virsh command: {0}".format(ex.strerror))
         finally:
             self._cleanup()
@@ -1082,7 +1082,7 @@ class VirtMachine(Machine):
             proc = subprocess.Popen(["virt-viewer", str(self._domain.ID())])
             sys.stderr.write(message)
             proc.wait()
-        except OSError, ex:
+        except OSError as ex:
             raise Failure("Failed to launch virt-viewer command: {0}".format(ex.strerror))
         finally:
             self._cleanup()
@@ -1095,7 +1095,7 @@ class VirtMachine(Machine):
         if not os.path.exists(image_file):
             try:
                 subprocess.check_call([ "image-download", image_file ])
-            except OSError, ex:
+            except OSError as ex:
                 if ex.errno != errno.ENOENT:
                     raise
         return image_file
@@ -1192,7 +1192,7 @@ class VirtMachine(Machine):
                     with stdchannel_redirected(sys.stderr, os.devnull):
                         if not self._domain.isActive():
                             break
-                except libvirt.libvirtError, le:
+                except libvirt.libvirtError as le:
                     if 'no domain' in le.message or 'not found' in le.message:
                         break
                     raise
@@ -1202,7 +1202,7 @@ class VirtMachine(Machine):
             try:
                 with stdchannel_redirected(sys.stderr, os.devnull):
                     self._domain.destroyFlags(libvirt.VIR_DOMAIN_DESTROY_DEFAULT)
-            except libvirt.libvirtError, le:
+            except libvirt.libvirtError as le:
                 if 'not found' not in str(le):
                     raise
         self._cleanup(quick=True)
@@ -1223,7 +1223,7 @@ class VirtMachine(Machine):
 
         try:
             os.makedirs(self.run_dir, 0750)
-        except OSError, ex:
+        except OSError as ex:
             if ex.errno != errno.EEXIST:
                 raise
 

--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -586,7 +586,7 @@ class Machine:
 
     def _calc_identity(self):
         identity = os.path.join(LOCAL_DIR, "identity")
-        os.chmod(identity, 0600)
+        os.chmod(identity, 0o600)
         return identity
 
     def journal_messages(self, syslog_ids, log_level):
@@ -823,7 +823,7 @@ class VirtNetwork:
     def _lock(self, start, step=1, force=False):
         resources = os.path.join(tempfile.gettempdir(), ".cockpit-test-resources")
         if not os.path.exists(resources):
-            os.mkdir(resources, 0755)
+            os.mkdir(resources, 0o755)
         for port in range(start, start + (100 * step), step):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -969,7 +969,7 @@ class VirtMachine(Machine):
         self._cleanup()
 
         try:
-            os.makedirs(self.run_dir, 0750)
+            os.makedirs(self.run_dir, 0o750)
         except OSError as ex:
             if ex.errno != errno.EEXIST:
                 raise
@@ -1222,7 +1222,7 @@ class VirtMachine(Machine):
         index = len(self._disks)
 
         try:
-            os.makedirs(self.run_dir, 0750)
+            os.makedirs(self.run_dir, 0o750)
         except OSError as ex:
             if ex.errno != errno.EEXIST:
                 raise

--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -169,7 +169,7 @@ class Machine:
         """Prints args if in verbose mode"""
         if not self.verbose:
             return
-        print " ".join(args)
+        print(" ".join(args))
 
     def start(self):
         """Overridden by machine classes to start the machine"""
@@ -1001,8 +1001,8 @@ class VirtMachine(Machine):
             keys["type"] = "kvm"
             keys["cpu"] = TEST_KVM_XML.format(**keys)
         else:
-            print >> sys.stderr, "WARNING: Starting virtual machine with emulation due to missing KVM"
-            print >> sys.stderr, "WARNING: Machine will run about 10-20 times slower"
+            sys.stderr.write("WARNING: Starting virtual machine with emulation due to missing KVM\n")
+            sys.stderr.write("WARNING: Machine will run about 10-20 times slower\n")
 
         keys.update(self.networking)
         keys["name"] = "{image}-{control}".format(**keys)
@@ -1165,7 +1165,7 @@ class VirtMachine(Machine):
                 os.unlink(self._transient_image)
         except:
             (type, value, traceback) = sys.exc_info()
-            print >> sys.stderr, "WARNING: Cleanup failed:", str(value)
+            sys.stderr.write("WARNING: Cleanup failed:%s\n" % value)
 
     def kill(self):
         # stop system immediately, with potential data loss

--- a/test/containers/check-kubernetes
+++ b/test/containers/check-kubernetes
@@ -213,13 +213,13 @@ class KubernetesCase(KubernetesContainerCase, kubelib.KubernetesCommonTests):
 
     def check_logs(self, b):
         if not self.supports_websocket:
-            print "No websocket support on kubernetes yet"
+            print("No websocket support on kubernetes yet")
         else:
             super(KubernetesCase, self).check_logs(b)
 
     def check_shell(self, b):
         if not self.supports_websocket:
-            print "No websocket support on kubernetes yet"
+            print("No websocket support on kubernetes yet")
         else:
             super(KubernetesCase, self).check_shell(b)
 

--- a/test/containers/check-kubernetes
+++ b/test/containers/check-kubernetes
@@ -94,7 +94,6 @@ class TestKubernetesLogin(KubernetesContainerCase):
         self.browser.wait_visible('#login-button')
 
     def check_login(self, mode):
-        m = self.machine
         b = self.browser
 
         if self.get_bad_auth_code(port=6443) == "403":
@@ -120,7 +119,7 @@ class TestKubernetesLogin(KubernetesContainerCase):
         b.wait_visible('#login-button')
 
         self.login("admin", "fubar")
-        with b.wait_timeout(10) as r:
+        with b.wait_timeout(10):
             b.expect_load()
         b.wait_present("#content")
         b.wait_text('#content-user-name', 'admin')

--- a/test/containers/run-tests
+++ b/test/containers/run-tests
@@ -16,14 +16,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-import argparse
-import os
 import sys
 import glob
 import imp
 import os
 import string
-import subprocess
 import unittest
 
 sys.dont_write_bytecode = True
@@ -33,7 +30,6 @@ testdir = os.path.abspath(os.path.join(base_dir, ".."))
 sys.path.append(testdir)
 
 from common import testlib
-from common import testvm
 
 def check_valid(filename):
     name = os.path.basename(filename)

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -358,7 +358,7 @@ CMD ["/bin/sh"]
         try:
             b.key_press( [ 'Return', 'Return', 'Return' ] )
             b.wait_in_text("#container-terminal", "#")
-        except Error, ex:
+        except Error as ex:
             if not ex.msg.startswith('timeout'):
                 raise
 

--- a/test/verify/check-example
+++ b/test/verify/check-example
@@ -38,9 +38,9 @@ class TestSimple(unittest.TestCase):
         for i in range(0, 10):
             time.sleep(0.100)
             if i % 2:
-                print >> sys.stderr, ">1", i
+                sys.stderr.write(">1%i\n" % i)
             else:
-                print ">2", i
+                print(">2", i)
         self.assertTrue(True)
 
     def testTwo(self):

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -320,7 +320,7 @@ class TestMachines(MachineCase):
         try:
             with b.wait_timeout(10):
                 b.wait_present("#vm-{0}-disks-{1}-used".format(name, target)) # wait for disk statistics to show up
-        except Error, ex:
+        except Error as ex:
             if not ex.msg.startswith('timeout'):
                 exc_info = sys.exc_info()
                 raise exc_info[0], exc_info[1], exc_info[2]

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -22,7 +22,6 @@ import parent
 from testlib import *
 
 import os
-import sys
 
 def readFile(name):
     content = ''
@@ -322,8 +321,7 @@ class TestMachines(MachineCase):
                 b.wait_present("#vm-{0}-disks-{1}-used".format(name, target)) # wait for disk statistics to show up
         except Error as ex:
             if not ex.msg.startswith('timeout'):
-                exc_info = sys.exc_info()
-                raise exc_info[0], exc_info[1], exc_info[2]
+                raise
             # stats did not show up, check if user message showed up
             print("Libvirt version does not support disk statistics")
             b.wait_present("#vm-{0}-disksstats-unsupported".format(name))

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -325,7 +325,7 @@ class TestMachines(MachineCase):
                 exc_info = sys.exc_info()
                 raise exc_info[0], exc_info[1], exc_info[2]
             # stats did not show up, check if user message showed up
-            print "Libvirt version does not support disk statistics"
+            print("Libvirt version does not support disk statistics")
             b.wait_present("#vm-{0}-disksstats-unsupported".format(name))
 
     def testDisks(self):
@@ -391,7 +391,7 @@ class TestMachines(MachineCase):
 
         # Test remove disk
         m.execute("virsh detach-disk subVmTest1 vdc")
-        print "Restarting vm-subVmTest1, might take a while"
+        print("Restarting vm-subVmTest1, might take a while")
         b.click("#vm-subVmTest1-reboot-caret")
         b.wait_visible("#vm-subVmTest1-forceReboot")
         b.click("#vm-subVmTest1-forceReboot")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -105,7 +105,7 @@ class TestMetrics(MachineCase):
         m.execute("kill %d" % cpu_pid)
         cpu_percentage = float(m.execute("/var/lib/testvm/measure-cpu stop '%s'" % cpu_start))
 
-        print "Measured CPU", cpu_percentage
+        print("Measured CPU", cpu_percentage)
         self.assertTrue(b.call_js_func("ph_flot_data_plateau", "#server_cpu_graph",
                                        cpu_percentage*0.50, cpu_percentage*1.50, 15, "cpu"));
 
@@ -115,7 +115,7 @@ class TestMetrics(MachineCase):
         #
         meminfo = read_mem_info(m)
         mem_used = meminfo['MemTotal'] - meminfo['MemFree']
-        print "Measured Memory", mem_used
+        print("Measured Memory", mem_used)
         b.wait_js_func("ph_flot_data_plateau", "#server_memory_graph", mem_used*0.95, mem_used*1.05, 15, "mem");
 
         # Disk.  Anything above 100 kiB/s is good for now.
@@ -171,8 +171,8 @@ class TestMetrics(MachineCase):
             time_after = time.time()
             (eth_after, lo_after) = m.execute(r"grep -E '" + iface + r"' /proc/net/dev | awk '{print $2 + $10}'; "
                                               r"grep '\blo:' /proc/net/dev | awk '{print $2 + $10}'").strip().split()
-            print("Measured {0:.1f}s of network traffic; {3}: {1} bytes, lo: {2} bytes".format(
-                time_after - time_before, int(eth_after) - int(eth_before), int(lo_after) - int(lo_before), iface))
+            print(("Measured {0:.1f}s of network traffic; {3}: {1} bytes, lo: {2} bytes".format(
+                time_after - time_before, int(eth_after) - int(eth_before), int(lo_after) - int(lo_before), iface)))
 
             client.terminate()
             client.wait()

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -111,7 +111,7 @@ def change_ssh_port(machine, address, port=None, timeout_sec=120):
         try:
             machine.execute("true", quiet=True)
             return
-        except Exception, e:
+        except Exception as e:
             error = e
         time.sleep(0.5)
     raise error

--- a/test/verify/check-multi-os
+++ b/test/verify/check-multi-os
@@ -186,7 +186,7 @@ class TestMultiOS(MachineCase):
     def testFedora22(self):
         try:
             self.checkStock()
-        except Error, e:
+        except Error as e:
             # Old versions of Cockpit in Fedora 22 have a race which throws an exception
             if e.msg != "Error: TypeError: null is not an object (evaluating 'o.client.lookup')":
                 raise

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -41,7 +41,7 @@ def wait_project(machine, project):
             output = machine.execute("oc get projects")
             if project not in output:
                 if not found:
-                    print >> sys.stderr, output
+                    sys.stderr.write(output)
                 found = True
                 raise Exception(output)
             break

--- a/test/verify/check-ovirt
+++ b/test/verify/check-ovirt
@@ -68,7 +68,7 @@ class TestOVirtMachines(MachineCase):
         m.execute("hostname ovirt.cockpit.lan") # used as fallback when resolving based on browser's URL is not matching, see ovirt/helpers.es6:getHost()
 
         self.engine_url = "https://{0}/ovirt-engine/".format(self.ovirt.forward['443']) # from phantomJS
-        print("Engine URL: {0}".format(self.engine_url))
+        print(("Engine URL: {0}".format(self.engine_url)))
 
         # Wait for the web service to be accessible
         args = { "api": "curl -s -k -u admin@internal:engine -H Content-type:application/xml", "addr": OVIRT_ADDR }
@@ -93,7 +93,7 @@ class TestOVirtMachines(MachineCase):
         cmd = "{0} https://{1}/ovirt-engine/api/datacenters/{2} | xmllint --xpath \"string(/data_center/status)\" -".format(curl, OVIRT_ADDR, dc_id)
         status = m.execute(cmd)
         if status != "up":
-            print("Data Center status: {0}, waiting for automatic reactivation".format(status))
+            print(("Data Center status: {0}, waiting for automatic reactivation".format(status)))
             wait(lambda: "up" in m.execute(cmd), delay=10)
 
     def enforce_cockpit_ovirt(self):
@@ -116,10 +116,10 @@ class TestOVirtMachines(MachineCase):
     def get_ovirt_token(self):
         m = self.machine
         response = m.execute("curl --insecure -H 'Accept: application/json' --data 'grant_type=password&scope=ovirt-app-api&username={0}&password={1}' https://{2}:{3}/ovirt-engine/sso/oauth/token".format(OVIRT_USER, OVIRT_PWD, ENGINE_FQDN, ENGINE_PORT))
-        print response
+        print(response)
         data = json.loads(response)
         token = data['access_token']
-        print("oVirt token retrieved: {0}".format(token))
+        print(("oVirt token retrieved: {0}".format(token)))
         return token
 
     def hack_for_missing_vdsm(self):

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -75,7 +75,7 @@ class TestStorage(StorageCase):
                 try:
                     self.browser.wait_in_text(info_field("State"), "Not running")
                     break
-                except Error, ex:
+                except Error as ex:
                     if not ex.msg.startswith('timeout'):
                         raise
                     self.browser.wait_present(".modal-dialog")

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -30,8 +30,8 @@ def info_field(name):
 class TestStorage(StorageCase):
     def tearDown(self):
         # HACK - for debugging https://github.com/cockpit-project/cockpit/issues/2924
-        print self.machine.execute("parted -s /dev/md127 print || true")
-        print self.machine.execute("lsblk || true")
+        print(self.machine.execute("parted -s /dev/md127 print || true"))
+        print(self.machine.execute("lsblk || true"))
         MachineCase.tearDown(self)
 
     def wait_states(self, states):

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -38,7 +38,7 @@ def ssh_reconnect(machine, timeout_sec=120):
         try:
             machine.execute("true", quiet=True)
             return
-        except Exception, e:
+        except Exception as e:
             error = e
         time.sleep(0.5)
 

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -31,7 +31,7 @@ class TestTerminal(MachineCase):
 
         # Make sure we get what we expect
         m.write("/tmp/bashrc-extra", """
-PS1="\u@\h \W]\$ "
+PS1="\\u@\\h \\W]\$ "
 PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"'
 """)
         m.execute("cat /tmp/bashrc-extra >>/home/admin/.bashrc")

--- a/test/verify/files/measure-cpu
+++ b/test/verify/files/measure-cpu
@@ -29,8 +29,8 @@ def cpu_stat():
             return int(l.split()[1])
 
 if sys.argv[1] == "start":
-    print repr((monotonic_time(), cpu_stat()))
+    print(repr((monotonic_time(), cpu_stat())))
 elif sys.argv[1] == "stop":
     (start_time, start_stat) = eval(sys.argv[2])
     hz = os.sysconf('SC_CLK_TCK')
-    print (cpu_stat() - start_stat) / (monotonic_time() - start_time) / hz * 100
+    print((cpu_stat() - start_stat) / (monotonic_time() - start_time) / hz * 100)

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -35,7 +35,7 @@ class NetworkCase(MachineCase):
         failures_allowed = 3
         while True:
             try:
-                print m.execute("nmcli con show")
+                print(m.execute("nmcli con show"))
                 m.execute("""nmcli -f UUID,DEVICE connection show | awk '$2 == "--" { print $1 }' | xargs -r nmcli con del""")
                 break
             except subprocess.CalledProcessError:
@@ -58,7 +58,7 @@ class NetworkCase(MachineCase):
             path = m.execute("grep -li '%s' /sys/class/net/*/address" % mac)
             return path.split("/")[-2]
         iface = wait(getit).strip()
-        print "%s -> %s" % (mac, iface)
+        print("%s -> %s" % (mac, iface))
         return iface
 
     def add_iface(self, mac=None, vlan=0, activate=True):
@@ -90,9 +90,9 @@ class NetworkCase(MachineCase):
             self.browser.wait_visible(sel)
             self.browser.wait_in_text(sel, text)
         except:
-            print "Interface %s didn't show up." % iface
-            print self.browser.eval_js("$('#networking-interfaces').html()")
-            print self.machine.execute("grep . /sys/class/net/*/address")
+            print("Interface %s didn't show up." % iface)
+            print(self.browser.eval_js("$('#networking-interfaces').html()"))
+            print(self.machine.execute("grep . /sys/class/net/*/address"))
             raise
 
     def iface_con_id(self, iface):

--- a/test/verify/run-tests
+++ b/test/verify/run-tests
@@ -6,7 +6,6 @@ import os
 import string
 import subprocess
 import sys
-import traceback
 import unittest
 
 import parent

--- a/test/vm-run
+++ b/test/vm-run
@@ -102,7 +102,7 @@ try:
     if not os.path.exists(machine.image_file):
         try:
             ret = subprocess.call([ os.path.join(BOTS, "image-download"), args.image])
-        except OSError, ex:
+        except OSError as ex:
             if ex.errno != errno.ENOENT:
                 raise
         else:
@@ -119,6 +119,6 @@ try:
     else:
         machine.qemu_console()
 
-except testvm.Failure, ex:
+except testvm.Failure as ex:
     print >> sys.stderr, "vm-run:", ex
     sys.exit(1)

--- a/test/vm-run
+++ b/test/vm-run
@@ -120,5 +120,5 @@ try:
         machine.qemu_console()
 
 except testvm.Failure as ex:
-    print >> sys.stderr, "vm-run:", ex
+    sys.stderr.write("vm-run: %s\n" % ex)
     sys.exit(1)

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -151,6 +151,6 @@ License: %s''' % (module, '\n'.join(sorted(copyrights)), license))
 
 for l in template.splitlines():
     if '#NPM' in l:
-        print u'\n\n'.join(paragraphs).encode('UTF-8'),
+        print('\n\n'.join(paragraphs).encode('UTF-8'))
     else:
         print(l)

--- a/tools/tap-driver
+++ b/tools/tap-driver
@@ -135,7 +135,7 @@ class Driver:
             proc = subprocess.Popen(self.argv, close_fds=True,
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE)
-        except OSError, ex:
+        except OSError as ex:
             self.report_error("Couldn't run %s: %s" % (self.argv[0], str(ex)))
             return
 

--- a/tools/tap-driver
+++ b/tools/tap-driver
@@ -62,7 +62,7 @@ def terminal_width():
         return w
     except IOError, (errno, strerror):
         if errno != 25: # ENOTTY
-            print >> sys.stderr, errno, strerror, sys.exc_info()
+            sys.stderr.write("%i %s %s\n" % (errno, strerror, sys.exc_info()))
         return sys.maxint;
 
 class Driver:

--- a/tools/tap-gtester
+++ b/tools/tap-gtester
@@ -86,22 +86,22 @@ class GTestCompiler(NullCompiler):
            elif cmd == "result":
                if self.test_name:
                    if data == "OK":
-                       print "ok %d %s" % (self.test_num, self.test_name)
+                       print("ok %d %s" % (self.test_num, self.test_name))
                    if data == "FAIL":
-                       print "not ok %d %s", (self.test_num, self.test_name)
+                       print("not ok %d %s", (self.test_num, self.test_name))
                self.test_name = None
            elif cmd == "skipping":
                if "/subprocess" not in data:
-                   print "ok %d # skip -- %s" % (self.test_num, data)
+                   print("ok %d # skip -- %s" % (self.test_num, data))
                self.test_name = None
            elif data:
-               print "# %s: %s" % (cmd, data)
+               print("# %s: %s" % (cmd, data))
            else:
-               print "# %s" % cmd
+               print("# %s" % cmd)
         elif line.startswith("(MSG: "):
-            print "# %s" % line[6:-1]
+            print("# %s" % line[6:-1])
         elif line:
-            print "# %s" % line
+            print("# %s" % line)
         sys.stdout.flush()
 
     def run(self, proc, output=""):
@@ -116,10 +116,10 @@ class GTestCompiler(NullCompiler):
             if line.startswith("/"):
                 self.test_remaining.append(line.strip())
         if not self.test_remaining:
-            print "Bail out! No tests found in GTest: %s" % self.command[0]
+            print("Bail out! No tests found in GTest: %s" % self.command[0])
             return 0
 
-        print "1..%d" % len(self.test_remaining)
+        print("1..%d" % len(self.test_remaining))
 
         # First try to run all the tests in a batch
         proc = subprocess.Popen(self.command + ["--verbose" ], close_fds=True, stdout=subprocess.PIPE)
@@ -128,13 +128,13 @@ class GTestCompiler(NullCompiler):
             return 0
 
         if result < 0:
-            print >> sys.stderr, "%s terminated with %s" % (self.command[0], strsignal(-result))
+            sys.stderr.write("%s terminated with %s\n" % (self.command[0], strsignal(-result)))
 
         # Now pick up any stragglers due to failures
         while True:
             # Assume that the last test failed
             if self.test_name:
-                print "not ok %d %s" % (self.test_num, self.test_name)
+                print("not ok %d %s" % (self.test_num, self.test_name))
                 self.test_name = None
 
             # Run any tests which didn't get run
@@ -165,7 +165,7 @@ def main(argv):
     format = args.format
     cmd = args.command
     if not cmd:
-        print >> sys.stderr, "tap-gtester: specify a command to run"
+        sys.stderr.write("tap-gtester: specify a command to run\n")
         return 2
     if cmd[0] == '--':
         cmd.pop(0)


### PR DESCRIPTION
Running `tools/test-static-code` on current Fedora with pyflakes 1.6.0 gives tons of errors that aren't yet spotted by the old version in semaphore. Many of them are because it now defaults to Python 3 syntax, but as at some point we want to move to Python 3 this PR moves to a syntax which works with both 2 and 3. But this also found some actual code bugs.

Note: This does not yet fix *all* pyflakes errors, as the remaining few are a bit more intrusive. Let's do away with the majority first, with this trivial and half-automated conversion (2to3). Also, this is not at all sufficient to make the code Python 3 compatible, just the syntax.