### PR TITLE
test: Remove dead code branch

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -122,8 +122,6 @@ WantedBy=default.target
             else:
                 b.wait_not_present(".area-ct-body.single-nav")
             b.wait_present("#host-nav")
-        elif "fedora-atomic" in m.image:
-            b.wait_not_visible("#content-navbar")
 
         # Lets try changing the language
 


### PR DESCRIPTION
The navigation rework PR #7482 left a dead `elif:` branch in
check-pages [1], remove it.

https://github.com/cockpit-project/cockpit/pull/7482/files#diff-038717f13e5f02881f8023bca6241c49R117

----

Stupid tiny thing, but it was one of the outstanding comments in #7482, so let's clean it up to avoid confusion.