### PR TITLE
kubernetes: Fix use of SVG <use> tags in topology view

### DIFF
--- a/pkg/kubernetes/styles/topology.less
+++ b/pkg/kubernetes/styles/topology.less
@@ -58,22 +58,3 @@ kubernetes-topology-icon {
 .topology-actions {
     float: right;
 }
-
-.kube-topology g.ReplicationController text {
-    font-size: 24px;
-}
-
-.kube-topology g.Route text {
-    fill: #888;
-    font-size: 22px;
-}
-
-.kube-topology g.DeploymentConfig text {
-    font-family: FontAwesome;
-    fill: #888;
-    font-size: 22px;
-}
-
-.kube-topology g.Service text {
-    font-size: 22px;
-}

--- a/pkg/kubernetes/views/topology-page.html
+++ b/pkg/kubernetes/views/topology-page.html
@@ -62,28 +62,28 @@
 <svg class="kube-topology" hidden>
   <defs>
     <g class="Node" id="vertex-Node">
-      <circle r="15"></circle>
-      <text y="9">&#xe621;</text>
+      <circle r="15" fill="#fff" stroke="#aaa"></circle>
+      <text y="9" fill="#636363" font-family="PatternFlyIcons-webfont" font-size="18px" text-anchor="middle">&#xe621;</text>
     </g>
     <g class="Pod" id="vertex-Pod">
-      <circle r="15"></circle>
-      <text y="6" x="0.5">&#xf1b3;</text>
+      <circle r="15" fill="#fff" stroke="#aaa"></circle>
+      <text y="6" x="0.5" fill="#1186C1" font-family="FontAwesome" font-size="16px" text-anchor="middle">&#xf1b3;</text>
     </g>
     <g class="Service" id="vertex-Service">
-      <circle r="15"></circle>
-      <text y="10" x="-1">&#xe61e;</text>
+      <circle r="15" fill="#fff" stroke="#aaa"></circle>
+      <text y="10" x="-1" fill="#ff7f0e" font-family="PatternFlyIcons-webfont" font-size="20px" text-anchor="middle">&#xe61e;</text>
     </g>
     <g class="ReplicationController" id="vertex-ReplicationController">
-      <circle r="15"></circle>
-      <text y="9">&#xe624;</text>
+      <circle r="15" fill="#fff" stroke="#aaa"></circle>
+      <text y="9" fill="#9467bd" font-family="PatternFlyIcons-webfont" font-size="22px" text-anchor="middle">&#xe624;</text>
     </g>
     <g class="DeploymentConfig" id="vertex-DeploymentConfig">
-      <circle r="15"></circle>
-      <text y="8">&#xf013;</text>
+      <circle r="15" fill="#fff" stroke="#aaa"></circle>
+      <text y="8" fill="#888" font-family="FontAwesome" font-size="22px" text-anchor="middle">&#xf013;</text>
     </g>
     <g class="Route" id="vertex-Route">
-      <circle r="15"></circle>
-      <text y="9">&#xe625;</text>
+      <circle r="15" fill="#fff" stroke="#aaa"></circle>
+      <text y="9" fill="#888" font-family="PatternflyIcons-webfont" font-size="22px" text-anchor="middle">&#xe625;</text>
     </g>
   </defs>
 </svg>


### PR DESCRIPTION
The SVG &lt;use&gt; tag applies CSS differently depending on which browser
is in use. We need to include the actual fill, stroke and font
information in the SVG itself in order to reuse it via &lt;use&gt; tags.

In fact half the info (positioning) was already there, so this just
brings all the style related info into one place.