### PR TITLE
test: Ensure docker is started before running sosrport

### DIFF
--- a/test/avocado/selenium-sosreport.py
+++ b/test/avocado/selenium-sosreport.py
@@ -18,6 +18,9 @@ class SosReportingTab(SeleniumTest):
     :avocado: enable
     """
     def test10SosReport(self):
+        # Docker must be running otherwise sosreport hangs
+        process.run("systemctl start docker", shell=True)
+
         self.login()
         self.wait_id("host-apps")
         self.click(self.wait_link('Diagnostic Report', cond=clickable))


### PR DESCRIPTION
Some docker versions hang when

docker stats --no-stream

is run and docker is not running