### PR TITLE
test: Switch default image to Fedora 27

### DIFF
--- a/test/README
+++ b/test/README
@@ -61,11 +61,12 @@ You can set these environment variables to configure the test suite:
                 "debian-testing"
                 "fedora-25"
                 "fedora-26"
+                "fedora-27"
                 "fedora-atomic"
                 "fedora-testing"
                 "rhel-7"
                 "ubuntu-1604"
-             "fedora-26" is the default (testvm.py)
+             "fedora-27" is the default (testvm.py)
 
   TEST_DATA  Where to find and store test machine images.  The
              default is the same directory that this README file is in.

--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -32,7 +32,7 @@ import tempfile
 import sys
 import time
 
-DEFAULT_IMAGE = os.environ.get("TEST_OS", "fedora-26")
+DEFAULT_IMAGE = os.environ.get("TEST_OS", "fedora-27")
 
 MEMORY_MB = 1024
 


### PR DESCRIPTION
Fedora 27 is released now.

---

This would ordinarily not require a full green test run, but this is my guinea pig to exercise the new cockpit/tests container that  got updated to Fedora 26 (https://github.com/cockpit-project/cockpituous/pull/156) and uses a bigger and shared /dev/shm (https://github.com/cockpit-project/cockpituous/pull/157).