### PR TITLE
tools: Drop Debian package cockpit-pcp control record

### DIFF
--- a/tools/debian/adjust-for-release
+++ b/tools/debian/adjust-for-release
@@ -18,9 +18,12 @@ release="$1"
 debian_dir=$(dirname $(readlink -f "$0"))
 
 set -x
-# Remove PCP build dependencies while pcp is not in testing
+# Remove PCP build dependencies, binary package, and Suggests: while pcp is not in testing
 # (https://tracker.debian.org/pcp)
 case "$release" in
     unstable|testing|stable|stretch|buster)
-        sed -i '/libpcp.*-dev/d' $debian_dir/control ;;
+        sed -i '/libpcp.*-dev/d; /^Package: cockpit-pcp/,/^$/ d; /cockpit-pcp/d' $debian_dir/control
+        # also remove the files, otherwise --fail-missing breaks the build
+        sed -i 's/for m in /&pcp /' $debian_dir/rules
+        ;;
 esac

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -29,7 +29,7 @@ Build-Depends: debhelper (>= 9.20141010),
                glib-networking,
                openssh-client <!nocheck>,
                python,
-Standards-Version: 4.1.0
+Standards-Version: 4.1.1
 Homepage: http://cockpit-project.org/
 Vcs-Git: git://anonscm.debian.org/collab-maint/cockpit.git
 Vcs-Browser: https://anonscm.debian.org/cgit/collab-maint/cockpit.git


### PR DESCRIPTION
We haven't built cockpit-pcp for a while as pcp hasn't been in stable
and testing for a long time. But keeping the "Package:" binary record in
control confuses the Debian archive scripts as the package regularly
lands in binNEW (even through they are no actual new packages). This
causes unnecessary release delays and manual ftpmaster actions.

So drop the binary package record together with the build dependencies
when releasing cockpit.