### PR TITLE
bots: Handle socket EPIPE errors when talking with GitHub

### DIFF
--- a/bots/task/github.py
+++ b/bots/task/github.py
@@ -183,6 +183,11 @@ class GitHub(object):
                 self.conn.request(method, self.qualify(resource), data, headers)
                 response = self.conn.getresponse()
                 break
+            # This happens when TLS is the source of a disconnection
+            except socket.error as ex:
+                if connected or ex.errno != errno.EPIPE:
+                    raise
+                self.conn = None
             # This happens when GitHub disconnects a keep-alive connection
             except httplib.BadStatusLine:
                 if connected:


### PR DESCRIPTION
These errors seem to popup on long keep-alive connections,
such as when retrieving data for machine learning from GitHub.

 * [x] learn-tests
 * [x] learn-tests