### PR TITLE
test: Avoid using jQuery in JS expressions

### DIFF
--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -196,7 +196,7 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
 
         # Test switching
         b.leave_page()
-        b.wait_js_cond('$("#machine-dropdown ul li").length == 3')
+        b.wait_js_cond('ph_select("#machine-dropdown ul li").length == 3')
 
         if m.image != "rhel-7-4":
             b.click("#host-nav-link")

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -34,26 +34,29 @@ class TestJournal(MachineCase):
         def inject_extras():
             b.eval_js("""
             ph_get_log_lines = function () {
-                var lines = [ ], i;
-                $('.cockpit-log-panel').children().each(function (i, e) {
-                    var $e = $(e);
-                    if ($e.is('.panel-heading')) {
-                        lines.push ($e.text());
+                var lines = [ ];
+                var panels = ph_find('.cockpit-log-panel').childNodes;
+                for (var i = 0; i < panels.length; ++i) {
+                    var e = panels[i];
+                    if (e.className === 'panel-heading') {
+                        lines.push (e.textContent);
                     } else {
-                        var msg = $e.find('.cockpit-log-message').text();
+                        var msg = e.querySelector('.cockpit-log-message');
+                        msg = msg ? msg.textContent : "";
                         var ident = '';
                         var count = '';
-                        if ($e.find('.cockpit-log-service-container').length > 0) {
-                            ident = $e.find('.cockpit-log-service-reduced').text();
+                        if (e.querySelectorAll('.cockpit-log-service-container').length > 0) {
+                            ident = e.querySelector('.cockpit-log-service-reduced').textContent;
                             // we need to slice the whitespace
-                            count = $e.find('.badge').text().slice(0, -1);
+                            count = e.querySelector('.badge').textContent.slice(0, -1);
                         } else {
-                            ident = $e.find('.cockpit-log-service').text();
+                            ident = e.querySelector('.cockpit-log-service');
+                            ident = ident ? ident.textContent : "";
                         }
                         lines.push ([ ident, msg, count ]);
                     }
-                });
-                var journal_start_text = $('.journal-start').text();
+                }
+                var journal_start_text = ph_find('.journal-start').textContent;
                 if (journal_start_text !== "")
                     lines.push(journal_start_text);
                 // console.log(JSON.stringify(lines));

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -227,7 +227,7 @@ class TestMachines(MachineCase):
         b.wait_in_text("#vm-subVmTest1-vcpus", "1")
 
         b.wait_in_text("#vm-subVmTest1-bootorder", "disk,network")
-        emulated_machine = b.eval_js("$('#vm-subVmTest1-emulatedmachine').text()")
+        emulated_machine = b.text("#vm-subVmTest1-emulatedmachine")
         self.assertTrue(len(emulated_machine) > 0) # emulated machine varies across test machines
 
         # switch to and check Usage

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -129,12 +129,8 @@ class TestMetrics(MachineCase):
         if m.image not in ["rhel-7-4"]:
             m.spawn("ping -w 5 -f -c 10000000 -s 50000  127.0.0.1", "load-net-lo.log")
             try:
-                old_timeout = b.phantom.timeout
-                b.phantom.timeout = 10
-                try:
+                with b.wait_timeout(10):
                     b.wait_js_func("ph_flot_data_plateau", "#server_network_traffic_graph", 300*1000, None, 5, "net io");
-                finally:
-                    b.phantom.timeout = old_timeout
                 self.fail("Unexpected traffic graph for localhost")
             except Error as ex:
                 if not ex.msg.startswith('timeout'):

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -100,7 +100,7 @@ class TestRealms(MachineCase):
         b.click("#system-info-domain a")
         b.wait_popup("realms-op")
         b.set_val(".realms-op-address", "NOPE")
-        b.wait_js_cond("$('.realms-op-address-error').attr('title') != ''")
+        b.wait_js_cond("ph_find('.realms-op-address-error').title != ''")
         b.click(".realms-op-cancel")
         b.wait_popdown("realms-op")
 
@@ -145,7 +145,7 @@ class TestRealms(MachineCase):
         b.click("#system-info-domain a")
         b.wait_popup("realms-op")
         b.set_val(".realms-op-address", "cockpit.lan")
-        b.wait_js_cond("$('.realms-op-address-error').attr('title') != ''")
+        b.wait_js_cond("ph_find('.realms-op-address-error').title != ''")
         b.set_val(".realms-op-admin", "admin")
         b.set_val(".realms-op-admin-password", "foobarfoo")
         b.click(".realms-op-apply")

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -37,12 +37,13 @@ class TestStorage(StorageCase):
     def wait_states(self, states):
         self.browser.wait_js_func("""(function(states) {
           var found = { };
-          $('#detail-sidebar tr').each(function (i, tr) {
-            var cell = $(tr).find('td:nth-child(2)');
-            var name = $(cell).find('a').text();
-            var state = $(cell).find('span.state').text();
+          var trs = ph_select('#detail-sidebar tr');
+          for (i = 0; i < trs.length; ++i) {
+            var cell = trs[i].querySelector('td:nth-child(2)');
+            var name = cell.querySelector('a').textContent;
+            var state = cell.querySelector('span.state').textContent;
             found[name] = state;
-          });
+          };
           for (s in states) {
             if (states[s] != found[s])
               return false;

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -66,7 +66,7 @@ class TestStorage(StorageCase):
 
         b.eval_js("""
           ph_texts = function (sel) {
-            return $(sel).map(function (i, e) { return $(e).text(); }).get();
+            return ph_select(sel).map(function (e) { return e.textContent });
           }""")
 
         # Add a disk

--- a/test/verify/check-storage-unused
+++ b/test/verify/check-storage-unused
@@ -54,7 +54,7 @@ mkpart logical ext2 24 48"""
 
         b.eval_js("""
           ph_texts = function (sel) {
-            return $(sel).map(function (i, e) { return $(e).text(); }).get();
+            return ph_select(sel).map(function(e) { return e.textContent });
           }""")
 
         # Keep opening the dialog until exactly /dev/sda6 and /dev/sdb

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -91,7 +91,7 @@ class NetworkCase(MachineCase):
             self.browser.wait_in_text(sel, text)
         except:
             print("Interface %s didn't show up." % iface)
-            print(self.browser.eval_js("$('#networking-interfaces').html()"))
+            print(self.browser.eval_js("ph_find('#networking-interfaces').outerHTML"))
             print(self.machine.execute("grep . /sys/class/net/*/address"))
             raise
 

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -209,17 +209,21 @@ class StorageCase(MachineCase):
     def dialog_set_expander(self, field, val):
         self.browser.call_js_func(
             """(function (sel, val) {
-                 if ($(sel).hasClass('collapsed') == val) {
-                    $(sel).click();
-                 }
+                 if ((ph_find(sel).className.indexOf('collapsed') >= 0) == val)
+                    ph_click(sel);
             })""", self.dialog_field(field), val)
 
     def dialog_set_combobox(self, field, val):
         self.browser.set_val(self.dialog_field(field) + " input[type=text]", val)
 
     def dialog_combobox_choices(self, field):
-        return self.browser.call_js_func("(function (sel) { return $(sel).find('li').get().map(function (elt) { return $(elt).text(); }) })",
-                                         self.dialog_field(field))
+        return self.browser.call_js_func("""(function (sel) {
+                                               var lis = ph_find(sel).querySelectorAll('li');
+                                               var result = [];
+                                               for (i = 0; i < lis.length; ++i)
+                                                 result.push(lis[i].textContent);
+                                               return result;
+                                             })""", self.dialog_field(field))
 
     def dialog_is_present(self, field, label):
         return self.browser.is_present('%s .checkbox:contains("%s") input' % (self.dialog_field(field), label))


### PR DESCRIPTION
We shouldn't rely on jQuery being present in eval_js(), as
phantom-lib.js says in its header. It doesn't work with chromium.

Note that this still leaves some jQuery in check-metrics; this cannot be
replaced with PhantomJS.

This also gets rid of an external usage of `phantom.timeout`.