### PR TITLE
bots: Drop distro version from avocado/fedora integration test

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -36,7 +36,7 @@ TRIGGERS = {
         "selenium/explorer",
         "selenium/chrome",
         "selenium/firefox",
-        "avocado/fedora-25"
+        "avocado/fedora",
     ],
     "fedora-26": [
         "verify/fedora-26",
@@ -45,7 +45,7 @@ TRIGGERS = {
     ],
     "fedora-27": [
         "verify/fedora-27",
-        "verify/fedora-atomic"
+        "verify/fedora-atomic",
     ],
     "fedora-atomic": [
         "verify/fedora-atomic"

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -23,7 +23,7 @@ BASELINE_PRIORITY = 10
 BRANCHES = [ 'master', 'rhel-7.4' ]
 
 DEFAULT_VERIFY = {
-    'avocado/fedora-25': BRANCHES,
+    'avocado/fedora': BRANCHES,
     'container/kubernetes': BRANCHES,
     'selenium/firefox': BRANCHES,
     'selenium/chrome': BRANCHES,


### PR DESCRIPTION
There is no reason to include the Fedora release number in the test
name, as we just have one. It will soon be moved to Fedora 27, too.