### PR TITLE
branding: Set content on :before

### DIFF
--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -20,7 +20,7 @@
               <i class="fa fa-bars" alt="Toggle navigation"></i>
             </button>
             <div class="navbar-brand">
-              <div id="index-brand"></div>
+              <div id="index-brand" class="hide-before"></div>
             </div>
           </div>
           <div class="collapse navbar-collapse navbar-collapse-1">

--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -35,6 +35,10 @@ html.index-page body {
     overflow: hidden;
 }
 
+.hide-before:before {
+    display: none;
+}
+
 .curtains-ct {
     top: auto;
     position: static;

--- a/src/branding/centos/branding.css
+++ b/src/branding/centos/branding.css
@@ -15,9 +15,12 @@ body.login-pf {
 #brand {
     font-size: 18pt;
     text-transform: uppercase;
+}
+
+#brand:before {
     content: "${NAME}";
 }
 
-#index-brand {
+#index-brand:before {
     content: "${NAME}";
 }

--- a/src/branding/debian/branding.css
+++ b/src/branding/debian/branding.css
@@ -15,9 +15,12 @@ body.login-pf {
 #brand {
     font-size: 18pt;
     text-transform: uppercase;
+}
+
+#brand:before {
     content: "${NAME}";
 }
 
-#index-brand {
+#index-brand:before {
     content: "${NAME}";
 }

--- a/src/branding/default/branding.css
+++ b/src/branding/default/branding.css
@@ -25,6 +25,9 @@ body.login-pf {
 }
 
 #index-brand {
-    content: "Cockpit";
     font-weight: bold;
+}
+
+#index-brand:before {
+    content: "Cockpit";
 }

--- a/src/branding/fedora/branding.css
+++ b/src/branding/fedora/branding.css
@@ -15,9 +15,12 @@ body.login-pf {
 #brand {
     font-size: 18pt;
     text-transform: uppercase;
+}
+
+#brand:before {
     content: "${NAME} <b>${VARIANT}</b>";
 }
 
-#index-brand {
+#index-brand:before {
     content: "${NAME} <b>${VARIANT}</b>";
 }

--- a/src/branding/kubernetes/branding.css
+++ b/src/branding/kubernetes/branding.css
@@ -15,10 +15,16 @@ body.login-pf {
 #brand {
     font-size: 18pt;
     text-transform: uppercase;
+}
+
+#brand:before {
     content: "${NAME}";
 }
 
 #index-brand {
-    content: "${NAME}";
     font-weight: bold;
+}
+
+#index-brand:before {
+    content: "${NAME}";
 }

--- a/src/branding/registry/branding.css
+++ b/src/branding/registry/branding.css
@@ -15,12 +15,18 @@ body.login-pf {
 #brand {
     font-size: 18pt;
     text-transform: uppercase;
+}
+
+#brand:before {
     content: "${NAME}";
 }
 
 #index-brand {
-    content: "${NAME}";
     font-weight: bold;
+}
+
+#index-brand:before {
+    content: "${NAME}";
 }
 
 .navbar-pf {

--- a/src/branding/rhel/branding.css
+++ b/src/branding/rhel/branding.css
@@ -21,10 +21,16 @@ body.login-pf {
 #brand {
     font-size: 18pt;
     text-transform: uppercase;
+}
+
+#brand:before {
     content: "${NAME}";
 }
 
 #index-brand {
-    content: "${NAME}";
     font-weight: bold;
+}
+
+#index-brand:before {
+    content: "${NAME}";
 }

--- a/src/branding/ubuntu/branding.css
+++ b/src/branding/ubuntu/branding.css
@@ -15,9 +15,16 @@ body.login-pf {
 #brand {
     font-size: 18pt;
     text-transform: uppercase;
+}
+
+#brand:before {
     content: "${PRETTY_NAME}";
 }
 
 #index-brand {
+    content: "${NAME}";
+}
+
+#index-brand:before {
     content: "${NAME}";
 }

--- a/src/ws/login.css
+++ b/src/ws/login.css
@@ -650,3 +650,7 @@ body {
         text-align: center;
     }
 }
+
+.hide-before:before {
+    display: none;
+}

--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -18,7 +18,7 @@
     <div class="container">
       <div class="row">
         <div class="col-sm-12">
-          <div id="brand">
+          <div id="brand" class="hide-before">
           </div><!--/#brand-->
         </div><!--/.col-*-->
 

--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -101,7 +101,8 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
     function brand(_id, def) {
         var style, elt = id(_id);
         if (elt)
-            style = window.getComputedStyle(elt);
+            style = window.getComputedStyle(elt, ":before");
+
         if (!style)
             return;
 
@@ -112,6 +113,8 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                 len > 2 && content[len - 1] === content[0])
                 content = content.substr(1, len - 2);
             elt.innerHTML = content || def;
+        } else {
+            elt.removeAttribute("class");
         }
     }
 

--- a/test/verify/check-multi-os
+++ b/test/verify/check-multi-os
@@ -239,7 +239,9 @@ class TestMultiOSDirect(MachineCase):
         b.switch_to_top()
 
         # Branding uses default because there is no os information
-        b.wait_in_text("#index-brand", "Cockpit")
+        b.wait_present("#index-brand")
+        b.wait_not_present("#index-brand.hide-before")
+
         b.wait_js_cond('window.location.pathname.indexOf("shell/index.html") > -1')
 
 if __name__ == '__main__':


### PR DESCRIPTION
Edge only supports content on :before and :after. Switch branding text to use :before.

:before is hidden because when content is found the javascript fills in variables and sets the text on the
actual element.

Only if there is no content found will :before be shown.

Fixes #8002