### PR TITLE
bots: Drop obsolete naughty override for #8100

### DIFF
--- a/bots/naughty/fedora-27/8100-selinux-modules.dep.bin
+++ b/bots/naughty/fedora-27/8100-selinux-modules.dep.bin
@@ -1,1 +1,0 @@
-Error: audit: type=1400*avc:  denied  { map } for * path="/usr/lib/modules*/modules.dep.bin"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1513399 got fixed in Fedora
27 and the update made it to the most recent image refresh.

Fixes #8100