### PR TITLE
WIP: tests: Introduce ph_document() indirection for current frame document

### DIFF
--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -5,10 +5,14 @@
  * for routine operations.
  */
 
+function ph_document() {
+    return document;
+}
+
 function ph_select(sel) {
     if (!window.Sizzle)
         throw "Sizzle was not properly loaded"
-    return window.Sizzle(sel);
+    return window.Sizzle(sel, ph_document());
 }
 
 function ph_only(els, sel)
@@ -52,7 +56,7 @@ function ph_set_val (sel, val)
     if (el.value === undefined)
         throw sel + " does not have a value";
     el.value = val;
-    var ev = document.createEvent("Event");
+    var ev = ph_document().createEvent("Event");
     ev.initEvent("change", true, false);
     el.dispatchEvent(ev);
 }
@@ -83,7 +87,7 @@ function ph_set_attr (sel, attr, val)
     else
         el.setAttribute(attr, val);
 
-    var ev = document.createEvent("Event");
+    var ev = ph_document().createEvent("Event");
     ev.initEvent("change", true, false);
     el.dispatchEvent(ev);
 }
@@ -100,7 +104,7 @@ function ph_click(sel, force) {
     if (!force && (el.offsetWidth <= 0 || el.offsetHeight <= 0))
         throw sel + " is not visible";
 
-    var ev = document.createEvent("MouseEvent");
+    var ev = ph_document().createEvent("MouseEvent");
     ev.initMouseEvent(
         "click",
         true /* bubble */, true /* cancelable */,
@@ -134,7 +138,7 @@ function ph_set_checked (sel, val)
         throw sel + " is not checkable";
     el.checked = val;
 
-    var ev = document.createEvent("Event");
+    var ev = ph_document().createEvent("Event");
     ev.initEvent("change", true, false);
     el.dispatchEvent(ev);
 }

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -36,7 +36,7 @@ class DashBoardHelpers:
     def wait_discovered_addresses(self, b, expected):
         b.wait_js_func(
             """(function(expected) {
-                var nodes = document.querySelectorAll('#dashboard_setup_server_dialog datalist option');
+                var nodes = ph_document().querySelectorAll('#dashboard_setup_server_dialog datalist option');
                 var actual = Array.prototype.map.call(nodes, function(e) {
                     return e.getAttribute("value");
                 });
@@ -46,7 +46,7 @@ class DashBoardHelpers:
     def wait_dashboard_addresses(self, b, expected):
         b.wait_js_func(
             """(function(expected) {
-                var nodes = document.querySelectorAll('#dashboard-hosts .list-group-item');
+                var nodes = ph_document().querySelectorAll('#dashboard-hosts .list-group-item');
                 var addresses = Array.prototype.map.call(nodes, function(e) {
                     return e.getAttribute("data-address");
                 });

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -482,8 +482,8 @@ class TestMachines(MachineCase):
         b.switch_to_frame("vm-subVmTest1-novnc-frame-container")
         # FIXME: the usual b.wait_present() does not  work here
         with b.wait_timeout(360):
-            b.wait(lambda: b.eval_js("document.documentElement.outerHTML.indexOf('noVNC_status_normal') >= 0"))
-        b.wait(lambda: b.eval_js("document.documentElement.outerHTML.indexOf('Connected (unencrypted) to: QEMU (subVmTest1)') >= 0"))
+            b.wait(lambda: b.eval_js("ph_document().documentElement.outerHTML.indexOf('noVNC_status_normal') >= 0"))
+        b.wait(lambda: b.eval_js("ph_document().documentElement.outerHTML.indexOf('Connected (unencrypted) to: QEMU (subVmTest1)') >= 0"))
 
     def testDelete(self):
         b = self.browser

--- a/test/verify/check-multi-os
+++ b/test/verify/check-multi-os
@@ -25,7 +25,7 @@ from testlib import *
 def wait_dashboard_addresses(b, expected):
     b.wait_js_func(
         """(function(expected) {
-            var nodes = document.querySelectorAll('#dashboard-hosts .list-group-item');
+            var nodes = ph_document().querySelectorAll('#dashboard-hosts .list-group-item');
             var addresses = Array.prototype.map.call(nodes, function(e) {
                 return e.getAttribute("data-address");
             });

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -1181,7 +1181,7 @@ class TestRegistry(MachineCase):
         b.click("a.pull-right")
         b.wait_present("modal-dialog")
         b.wait_val("#imagestream-modify-project-text", "marmalade")
-        b.wait_js_cond("document.activeElement == document.getElementById('imagestream-modify-name')")
+        b.wait_js_cond("ph_document().activeElement == ph_document().getElementById('imagestream-modify-name')")
         b.set_val("#imagestream-modify-name", "sometags")
         b.wait_present("#imagestream-modify-populate")
         b.click("#imagestream-modify-populate button")


### PR DESCRIPTION
With chromium we can't re-assign `document` to the current frame, it's
always the top-level document. Introduce a `ph_document()` test function
and change test-functions.js and our tests to use it.

For PhantomJS this just returns `document`, so no change in behaviour.

---

This is a prerequisite for PR #8069. I mostly file this PR to get a CI run and ensure that I don't break anything existing. Don't land this yet, this approach might not be the final one yet.