### PR TITLE
test: Fix testAbrtDelete() to verify actually intended behaviour

### DIFF
--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -363,8 +363,9 @@ s.send("PRIORITY=3\\nFOO=bar\\n")'
 
         b.wait_present("#journal-entry-id")
         b.wait_in_text("#journal-entry-id", "python")
+        # details view should hide log view
         b.wait_present('.cockpit-log-panel')
-        b.wait_visible('.cockpit-log-panel')
+        b.wait_not_visible('.cockpit-log-panel')
         b.wait_present("#journal-entry-message:contains('crashed in posix_kill')")
         b.wait_not_present("#journal-entry-fields .nav")
 


### PR DESCRIPTION
When clicking on an ABRT report in the journal log list and getting to
the details view of the report, the log list view (`.cockpit-log-panel`)
gets hidden. Actually assert that instead of the opposite.

This race condition happens to work (most of the time) with PhantomJS,
but when running with chromium this gets spotted as a failure.

Fixes #8153