### PR TITLE
naughty: Close 7977: ubuntu 17.10: hotplugging virtio disk fails

### DIFF
--- a/bots/naughty/ubuntu-stable/7977-libvirt-virtio-hotplug
+++ b/bots/naughty/ubuntu-stable/7977-libvirt-virtio-hotplug
@@ -1,4 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-machines", line *, in testDisks
-*
-CalledProcessError: Command 'virsh attach-disk subVmTest1 /var/lib/libvirt/images/image3.img vdc' returned non-zero exit status 1


### PR DESCRIPTION
Known issue which has not occurred in 21 days

ubuntu 17.10: hotplugging virtio disk fails

Fixes #7977