### PR TITLE
naughty: Close 7509: Fedora: SELinux prevents arping from 'write' accesses on the fifo_file

### DIFF
--- a/bots/naughty/fedora-26/7509-selinux-kdump-arping
+++ b/bots/naughty/fedora-26/7509-selinux-kdump-arping
@@ -1,1 +1,0 @@
-Error: audit: type=1400*avc:  denied  { write } for * comm="arping"


### PR DESCRIPTION
Known issue which has not occurred in 21 days

Fedora: SELinux prevents arping from 'write' accesses on the fifo_file

Fixes #7509