### PR TITLE
bots: Checkout target bot before executing it

### DIFF
--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -119,6 +119,11 @@ def output_task(command, issue, verbose):
         return None
 
     context = context.strip()
+    checkout = "PRIORITY={priority:04d} "
+    cmd = "bots/{name} --issue='{issue}' {context}"
+
+    if "pull_request" in issue:
+        checkout += "bots/make-checkout --verbose pull/{issue}/head && "
 
     if verbose:
         return "issue-{issue} {name} {context}    {priority}".format(
@@ -130,11 +135,11 @@ def output_task(command, issue, verbose):
     else:
         if context:
             context = pipes.quote(context)
-        return "PRIORITY={priority:04d} bots/{name} --issue='{issue}' {context}".format(
+        return (checkout + cmd).format(
             issue=int(number),
             priority=PRIORITY,
             name=name,
-            context=context
+            context=context,
         )
 
 # Default scan behavior run for each task

--- a/bots/make-checkout
+++ b/bots/make-checkout
@@ -1,0 +1,74 @@
+#!/usr/bin/python2
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import os
+import subprocess
+import sys
+
+sys.dont_write_bytecode = True
+
+# Check out the given ref and if necessary overlay the bots
+# directory on top of it as expected on non-master branches
+
+BOTS = os.path.dirname(__file__)
+BASE = os.path.normpath(os.path.join(BOTS, ".."))
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch and checkout specific revision")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+    parser.add_argument("--base", nargs='?', help="Base branch that revision is for")
+    parser.add_argument("ref", help="The git ref to fetch")
+    parser.add_argument("revision", default="FETCH_HEAD", nargs='?',
+            help="Actual commit to check out, defaults to ref")
+
+    opts = parser.parse_args()
+
+    def execute(*args):
+        if opts.verbose:
+            sys.stderr.write("+ " + " ".join(args) + "\n")
+        try:
+            output = subprocess.check_output(args, cwd=BASE)
+        except subprocess.CalledProcessError as ex:
+            sys.exit(ex.returncode)
+        if opts.verbose and output:
+            sys.stderr.write("> " + output + "\n")
+        return output
+
+    execute("git", "fetch", "origin", opts.ref)
+    execute("git", "checkout", "--detach", opts.revision)
+
+    # COMPAT: If the bots directory doesn't exist in this branch, check it out from master
+    if opts.base and opts.base != "master":
+        sys.stderr.write("Checking out bots directory from master ...\n")
+        execute("git", "checkout", "--force", "origin/master", "--", "bots/")
+
+        # The machine code is special, copy it from master too
+        machine = os.path.join(BOTS, "machine")
+        for name in os.listdir(machine):
+            path = os.path.join(machine, name)
+            if os.path.islink(path):
+                os.unlink(path)
+                code = execute("git", "show", "origin/master:test/common/{0}".format(name))
+                with open(path, "w") as f:
+                    f.write(code)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -29,7 +29,6 @@ import traceback
 
 sys.dont_write_bytecode = True
 
-import task
 from task import github
 from task import sink
 
@@ -172,22 +171,6 @@ class PullTask(object):
             traceback.print_exc()
             return "Rebase failed"
 
-        try:
-            task.checkout(base=self.base)
-        except subprocess.CalledProcessError:
-            traceback.print_exc()
-            return "Rebase checkout of bots failed"
-
-        # If the bots directory changed during all of this, then respawn
-        if subprocess.call(["git", "diff", "--quiet", "--exit-code", "--staged", origin_base, "--", "bots/"]) == 1:
-            assert "TEST_INVOKE_RESPAWN" not in os.environ
-            os.environ["TEST_INVOKE_RESPAWN"] = "1"
-            sys.stderr.write("Rebase complete ... respawning\n")
-            if self.sink:
-                self.stop_publishing(None)
-            os.execv(__file__, sys.argv)
-            assert False, "not reached"
-
         return None
 
     def prepare(self, prefix, value, image, verbose=False):
@@ -300,29 +283,28 @@ class PullTask(object):
         return ret
 
     def run(self, opts):
-        if "TEST_INVOKE_RESPAWN" not in os.environ:
-            head = subprocess.check_output([ "git", "rev-parse", "HEAD" ]).strip()
-            if self.ref:
-                if not opts.offline:
-                    subprocess.check_call([ "git", "fetch", "origin", self.ref ])
-                if not self.revision:
-                    self.revision = subprocess.check_output([ "git", "rev-parse", "FETCH_HEAD" ]).strip()
-                # Force a checkout of the ref if not already checked out
-                if not head.lower().startswith(self.revision.lower()):
-                    subprocess.check_call([ "git", "checkout", "-f", self.revision ])
-
+        head = subprocess.check_output([ "git", "rev-parse", "HEAD" ]).strip()
+        if self.ref:
+            if not opts.offline:
+                subprocess.check_call([ "git", "fetch", "origin", self.ref ])
             if not self.revision:
-                self.revision = head
+                self.revision = subprocess.check_output([ "git", "rev-parse", "FETCH_HEAD" ]).strip()
+            # Force a checkout of the ref if not already checked out
+            if not head.lower().startswith(self.revision.lower()):
+                subprocess.check_call([ "git", "checkout", "-f", self.revision ])
 
-            # Retrieve information about our base branch and master (for bots/)
-            if self.base and not opts.offline:
-                subprocess.check_call([ "git", "fetch", "origin", self.base, "master" ])
+        if not self.revision:
+            self.revision = head
 
-            # Clean out the test directory
-            subprocess.check_call([ "git", "clean", "-d", "--force", "--quiet", "-x", "--", "test/" ])
+        # Retrieve information about our base branch and master (for bots/)
+        if self.base and not opts.offline:
+            subprocess.check_call([ "git", "fetch", "origin", self.base, "master" ])
 
-            os.environ["TEST_NAME"] = self.name
-            os.environ["TEST_REVISION"] = self.revision
+        # Clean out the test directory
+        subprocess.check_call([ "git", "clean", "-d", "--force", "--quiet", "-x", "--", "test/" ])
+
+        os.environ["TEST_NAME"] = self.name
+        os.environ["TEST_REVISION"] = self.revision
 
         # Split a value like verify/fedora-atomic
         (prefix, unused, value) = self.context.partition("/")
@@ -343,10 +325,8 @@ class PullTask(object):
 
         ret = None
 
-        # If a respawn then this is aleady done
-        if "TEST_INVOKE_RESPAWN" not in os.environ:
-            if self.base:
-                ret = self.rebase()
+        if self.base:
+            ret = self.rebase()
 
         test = os.path.join(BOTS, "..", "test")
 

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -123,15 +123,19 @@ def tests_invoke(priority, name, revision, ref, context, base=None, repo=None, c
     if not command:
         command = "bots/tests-invoke"
 
-    cmd = "PRIORITY={priority:04d} TEST_NAME='{name}-{current}' TEST_REVISION='{revision}' {command}"
+    checkout = "PRIORITY={priority:04d} bots/make-checkout --verbose"
+    cmd = "TEST_NAME='{name}-{current}' TEST_REVISION='{revision}' {command}"
     if base:
         cmd += " --rebase='{base}'"
+        checkout += " --base='{base}'"
 
     if repo:
         cmd = "GITHUB_BASE='{repo}' " + cmd
 
     cmd += " '{context}' '{ref}'"
-    return cmd.format(
+    checkout += " '{ref}' '{revision}' && "
+
+    return (checkout + cmd).format(
         priority=priority,
         name=pipes.quote(name),
         revision=pipes.quote(revision),
@@ -140,7 +144,7 @@ def tests_invoke(priority, name, revision, ref, context, base=None, repo=None, c
         context=pipes.quote(context),
         current=current,
         repo=repo,
-        command=command
+        command=command,
     )
 
 def prioritize(status, title, labels, priority, context):


### PR DESCRIPTION
In order to have bots better self-test themselves, checkout the
appropriate branch before having the bot start executing. We do
this with a new 'make-checkout' script.

This also removes the fragile respawning code in tests-invoke