### PR TITLE
test: Really avoid extra connections for additional network interfaces

### DIFF
--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -71,8 +71,8 @@ class NetworkCase(MachineCase):
         iface = self.get_iface(m, mac)
         wait(lambda: m.execute('nmcli device | grep %s | grep -v unavailable' % iface))
         if activate:
-            m.execute("nmcli con add type ethernet ifname %s" % iface)
-            m.execute("nmcli dev con %s" % iface)
+            m.execute("nmcli con add type ethernet ifname %s con-name %s" % (iface, iface))
+            m.execute("nmcli con up %s ifname %s" % (iface, iface))
         return iface
 
     def wait_for_iface(self, iface, active=True, state=None, prefix="10.111."):


### PR DESCRIPTION
If there are multiple connection settings for a given device, Cockpit
is supposed to pick up the "right" one.  But since this is a bit racy,
the tests try to avoid this situation by making sure that NM doesn't
create connections behind our back.

However, some versions of NetworkManager seem to fail to associate our
created connection with the device and will create another connection
upon "nmcli dev con".

We now avoid this by explicitly telling NM which connection to use
when activating a device.