### PR TITLE
ovirt: fix failed action reducer for a non-oVirt VM

### DIFF
--- a/pkg/ovirt/reducers.es6
+++ b/pkg/ovirt/reducers.es6
@@ -128,7 +128,7 @@ function vmsReducer (state, action) {
             // So far, the VM is identified by "name" only
             // See the templatesReducer() as well.
             const vmId =  Object.getOwnPropertyNames(state).filter(vmId => state[vmId].name === action.payload.name);
-            if (!vmId) {
+            if (!vmId || vmId.length === 0) {
                 return state;
             }
 


### PR DESCRIPTION
This patch fixes incorrect storing of failed action message for
non-Ovirt a VM within cockpit-ovirt reducer.