### PR TITLE
bots: Add override for libvirt AppArmor denial for /proc/*/cmdline

### DIFF
--- a/bots/naughty/debian-testing/6690-apparmor-libvirt-cmdline
+++ b/bots/naughty/debian-testing/6690-apparmor-libvirt-cmdline
@@ -1,0 +1,1 @@
+Error: audit: type=1400 * apparmor="DENIED" operation="open" profile="libvirt-* name="/proc/*/cmdline" * comm="qemu-system-*" requested_mask="r" denied_mask="r"


### PR DESCRIPTION
See issue #6690
Downstream report: https://bugs.debian.org/878203

----

Example: http://209.132.184.41/logs/pull-8219-20171206-214646-d2e9e141-verify-debian-testing/log.html#2