### PR TITLE
bridge: Forward kill messages

### DIFF
--- a/src/bridge/cockpitrouter.c
+++ b/src/bridge/cockpitrouter.c
@@ -834,7 +834,6 @@ on_transport_control (CockpitTransport *transport,
   else if (g_str_equal (command, "kill"))
     {
       process_kill (self, options);
-      return TRUE;
     }
   else if (g_str_equal (command, "close"))
     {


### PR DESCRIPTION
We need to forward kill messages to all peers. Each bridge can then decide what to kill.

This came up when working on machine disconnection. Separating it out as we probably need to backport it.