### PR TITLE
po: Import Japanese translation updates from RHEL 7.5 branch

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -1,13 +1,14 @@
+# Ludek Janda <ljanda@redhat.com>, 2017. #zanata
 # cockpit <cockpituous@gmail.com>, 2017. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-07 10:17+0000\n"
+"POT-Creation-Date: 2017-11-13 07:09-0800\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2017-08-01 02:39-0400\n"
+"PO-Revision-Date: 2017-12-06 05:26-0500\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Japanese\n"
 "Language: ja\n"
@@ -22,19 +23,19 @@ msgstr " (OS と共有)"
 msgid " 1\"Do you want to delete the following Nodes?"
 msgstr " 1\" 次のノードを削除しますか?"
 
-#: pkg/storaged/others-panel.jsx:56
+#: pkg/storaged/overview.js:254
 msgid "$0 Block Device"
 msgstr "$0 ブロックデバイス"
 
-#: pkg/storaged/mdraid-details.jsx:192
+#: pkg/storaged/details.jsx:290
 msgid "$0 Chunk Size"
 msgstr "$0 チャンクサイズ"
 
-#: pkg/storaged/mdraid-details.jsx:190
+#: pkg/storaged/details.jsx:288
 msgid "$0 Disks"
 msgstr "$0 ディスク"
 
-#: pkg/storaged/content-views.jsx:302
+#: pkg/storaged/content-views.jsx:303
 msgctxt "storage-id-desc"
 msgid "$0 File System"
 msgstr "$0 ファイルシステム"
@@ -45,6 +46,8 @@ msgid ""
 "This may also effect other services as DNS resolution settings and the list "
 "of trusted CAs may change."
 msgstr ""
+"$0 ローカル認証情報を持つユーザーだけが、このマシンにログインできます。DNS 解決設定と、信頼される CA "
+"の一覧が変更する場合があるため、他のサービスにもこれが当てはまることもあります。"
 
 #: pkg/systemd/init.js:376 pkg/systemd/init.js:664
 msgid "$0 Template"
@@ -68,14 +71,14 @@ msgid "$0 byte"
 msgid_plural "$0 bytes"
 msgstr[0] "$0 バイト"
 
-#: pkg/lib/plot.js:897
+#: pkg/lib/plot.js:890
 msgid "$0 day"
 msgid_plural "$0 days"
 msgstr[0] "$0 日"
 
 #: src/base1/test-locale.js:64 src/base1/test-locale.js:65
 #: src/base1/test-locale.js:66 pkg/playground/translate.js:28
-#: pkg/playground/translate.js:31 pkg/storaged/mdraid-details.jsx:212
+#: pkg/playground/translate.js:31 pkg/storaged/details.jsx:301
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "$0 ディスクがありません"
@@ -88,7 +91,7 @@ msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "$0 ディスクがありません"
 
-#: src/ws/login.js:284 src/ws/login.js:610
+#: src/ws/login.js:281 src/ws/login.js:607
 msgid "$0 error"
 msgstr "$0 エラー"
 
@@ -100,7 +103,7 @@ msgstr "$0 がコード $1 で終了しました"
 msgid "$0 failed"
 msgstr "$0 が失敗しました"
 
-#: pkg/lib/plot.js:900
+#: pkg/lib/plot.js:893
 msgid "$0 hour"
 msgid_plural "$0 hours"
 msgstr[0] "$0 時間"
@@ -109,13 +112,13 @@ msgstr[0] "$0 時間"
 msgid ""
 "$0 is available for most operating systems. To install it, search for it in "
 "GNOME Software or run the following:"
-msgstr ""
+msgstr "$0 は、多数のオペレーティングシステムで利用できます。インストールするには、GNOME ソフトウェアで検索するか、以下を実行します:"
 
-#: pkg/storaged/content-views.jsx:253 pkg/storaged/content-views.jsx:463
-#: pkg/storaged/format-dialog.jsx:255 pkg/storaged/mdraid-details.jsx:270
-#: pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/details.jsx:93 pkg/storaged/details.jsx:153
+#: pkg/storaged/content-views.jsx:254 pkg/storaged/content-views.jsx:473
+#: pkg/storaged/format-dialog.jsx:117
 msgid "$0 is in active use"
-msgstr ""
+msgstr "$0 は、アクティブに使用されています。"
 
 #: pkg/ostree/client.js:484
 msgid "$0 key ID"
@@ -125,19 +128,19 @@ msgstr "$0 キー ID"
 msgid "$0 killed with signal $1"
 msgstr "$0 がシグナル $1 で終了しました"
 
-#: pkg/lib/plot.js:903
+#: pkg/lib/plot.js:896
 msgid "$0 minute"
 msgid_plural "$0 minutes"
 msgstr[0] "$0 分"
 
-#: pkg/lib/plot.js:891
+#: pkg/lib/plot.js:884
 msgid "$0 month"
 msgid_plural "$0 months"
 msgstr[0] "$0 ヶ月"
 
-#: pkg/packagekit/updates.jsx:272
+#: pkg/packagekit/updates.jsx:262
 msgid "$0 more…"
-msgstr ""
+msgstr "$0 を超えています…"
 
 #: pkg/selinux/setroubleshoot-view.jsx:410
 msgid "$0 occurrence"
@@ -160,18 +163,17 @@ msgstr "$0 パッケージ"
 msgid "$0 shares"
 msgstr "$0 シェア"
 
-#: pkg/packagekit/updates.jsx:191
-#, fuzzy
+#: pkg/packagekit/updates.jsx:179
 msgid "$0 update"
 msgid_plural "$0 updates"
-msgstr[0] "更新"
+msgstr[0] "$0 更新"
 
-#: pkg/lib/plot.js:894
+#: pkg/lib/plot.js:887
 msgid "$0 week"
 msgid_plural "$0 weeks"
 msgstr[0] "$0 週"
 
-#: pkg/lib/plot.js:888
+#: pkg/lib/plot.js:881
 msgid "$0 year"
 msgid_plural "$0 years"
 msgstr[0] "$0 年"
@@ -187,20 +189,15 @@ msgid "$0% Used"
 msgid_plural "$0% Used"
 msgstr[0] "$0% 使用済み"
 
-#: pkg/storaged/vgroup-details.jsx:116
+#: pkg/storaged/sidebar-views.jsx:300
 msgid "$0, $1 free"
 msgstr "$0, $1 空き"
 
-#: pkg/packagekit/updates.jsx:189
-msgid "$1 security fix"
-msgid_plural "$1 security fixes"
-msgstr[0] ""
-
-#: pkg/networkmanager/interfaces.js:2647
+#: pkg/networkmanager/interfaces.js:2640
 msgid "$mtu"
 msgstr "$mtu"
 
-#: pkg/storaged/utils.js:163
+#: pkg/storaged/utils.js:164
 msgid "$name (from $host)"
 msgstr "$name ($host)"
 
@@ -208,7 +205,7 @@ msgstr "$name ($host)"
 msgid "${hip}:${hport} -> $cport"
 msgstr "${hip}:${hport} -> $cport"
 
-#: pkg/storaged/utils.js:127
+#: pkg/storaged/utils.js:128
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
@@ -220,24 +217,24 @@ msgstr "'組織' を登録する必要があります。"
 msgid "'Organization' required when using activation keys."
 msgstr "アクティベーションキーを使用する場合は '組織' が必要です。"
 
-#: pkg/storaged/fsys-tab.jsx:164
+#: pkg/storaged/fsys-tab.jsx:185
 msgid "(default)"
 msgstr "(デフォルト)"
 
-#: pkg/storaged/crypto-tab.jsx:141
+#: pkg/storaged/crypto-tab.jsx:146
 msgid "(none)"
 msgstr "（なし）"
 
-#: pkg/packagekit/updates.jsx:193
+#: pkg/packagekit/updates.jsx:184
 msgid ", including $1 security fix"
 msgid_plural ", including $1 security fixes"
-msgstr[0] ""
+msgstr[0] "セキュリティー修正を $1 個含む"
 
 #: pkg/ostree/index.html:92
 msgid "- Add New Repository"
 msgstr "- 新規リポジトリーの追加"
 
-#: pkg/storaged/mdraids-panel.jsx:64
+#: pkg/storaged/overview.js:441
 msgid "1 MiB"
 msgstr "1 MiB"
 
@@ -245,25 +242,25 @@ msgstr "1 MiB"
 msgid "1 Minute"
 msgstr "1 分"
 
-#: pkg/dashboard/index.html:55 pkg/networkmanager/index.html:56
-#: pkg/networkmanager/index.html:543 pkg/systemd/index.html:191
-#: pkg/storaged/plot.jsx:85
+#: pkg/systemd/index.html:191 pkg/networkmanager/index.html:56
+#: pkg/networkmanager/index.html:543 pkg/dashboard/index.html:55
+#: pkg/storaged/index.html:310
 msgid "1 day"
 msgstr "1 日"
 
-#: pkg/dashboard/index.html:51 pkg/networkmanager/index.html:54
-#: pkg/networkmanager/index.html:541 pkg/systemd/index.html:187
-#: pkg/storaged/plot.jsx:79
+#: pkg/systemd/index.html:187 pkg/networkmanager/index.html:54
+#: pkg/networkmanager/index.html:541 pkg/dashboard/index.html:51
+#: pkg/storaged/index.html:308
 msgid "1 hour"
 msgstr "1 時間"
 
-#: pkg/systemd/host.js:1461
+#: pkg/systemd/host.js:1454
 msgid "1 min"
 msgstr "1 分"
 
-#: pkg/dashboard/index.html:57 pkg/networkmanager/index.html:57
-#: pkg/networkmanager/index.html:544 pkg/systemd/index.html:193
-#: pkg/storaged/plot.jsx:88
+#: pkg/systemd/index.html:193 pkg/networkmanager/index.html:57
+#: pkg/networkmanager/index.html:544 pkg/dashboard/index.html:57
+#: pkg/storaged/index.html:311
 msgid "1 week"
 msgstr "1 週間"
 
@@ -275,7 +272,7 @@ msgstr "10 日"
 msgid "11th"
 msgstr "11 日"
 
-#: pkg/storaged/mdraids-panel.jsx:62
+#: pkg/storaged/overview.js:439
 msgid "128 KiB"
 msgstr "128 KiB"
 
@@ -295,7 +292,7 @@ msgstr "14 日"
 msgid "15th"
 msgstr "15 日"
 
-#: pkg/storaged/mdraids-panel.jsx:59
+#: pkg/storaged/overview.js:436
 msgid "16 KiB"
 msgstr "16 KiB"
 
@@ -319,11 +316,11 @@ msgstr "19 日"
 msgid "1st"
 msgstr "1 日"
 
-#: pkg/storaged/mdraids-panel.jsx:65
+#: pkg/storaged/overview.js:442
 msgid "2 MiB"
 msgstr "2 MiB"
 
-#: pkg/systemd/host.js:1460
+#: pkg/systemd/host.js:1453
 msgid "2 min"
 msgstr "2 分"
 
@@ -375,7 +372,7 @@ msgstr "29 日"
 msgid "2nd"
 msgstr "2 日"
 
-#: pkg/systemd/host.js:1459
+#: pkg/systemd/host.js:1452
 msgid "3 min"
 msgstr "3 分"
 
@@ -387,7 +384,7 @@ msgstr "30 日"
 msgid "31st"
 msgstr "31 日"
 
-#: pkg/storaged/mdraids-panel.jsx:60
+#: pkg/storaged/overview.js:437
 msgid "32 KiB"
 msgstr "32 KiB"
 
@@ -395,11 +392,11 @@ msgstr "32 KiB"
 msgid "3rd"
 msgstr "3 日"
 
-#: pkg/storaged/mdraids-panel.jsx:57
+#: pkg/storaged/overview.js:434
 msgid "4 KiB"
 msgstr "4 KiB"
 
-#: pkg/systemd/host.js:1458
+#: pkg/systemd/host.js:1451
 msgid "4 min"
 msgstr "4 分"
 
@@ -415,17 +412,17 @@ msgstr "4 日"
 msgid "5 Minutes"
 msgstr "5 分"
 
-#: pkg/systemd/host.js:1457
+#: pkg/systemd/host.js:1450
 msgid "5 min"
 msgstr "5 分"
 
-#: pkg/dashboard/index.html:49 pkg/networkmanager/index.html:53
-#: pkg/networkmanager/index.html:540 pkg/systemd/index.html:185
-#: pkg/storaged/plot.jsx:76
+#: pkg/systemd/index.html:185 pkg/networkmanager/index.html:53
+#: pkg/networkmanager/index.html:540 pkg/dashboard/index.html:49
+#: pkg/storaged/index.html:307
 msgid "5 minutes"
 msgstr "5 分"
 
-#: pkg/storaged/mdraids-panel.jsx:63
+#: pkg/storaged/overview.js:440
 msgid "512 KiB"
 msgstr "512 KiB"
 
@@ -433,9 +430,9 @@ msgstr "512 KiB"
 msgid "5th"
 msgstr "5 日"
 
-#: pkg/dashboard/index.html:53 pkg/networkmanager/index.html:55
-#: pkg/networkmanager/index.html:542 pkg/systemd/index.html:189
-#: pkg/storaged/plot.jsx:82
+#: pkg/systemd/index.html:189 pkg/networkmanager/index.html:55
+#: pkg/networkmanager/index.html:542 pkg/dashboard/index.html:53
+#: pkg/storaged/index.html:309
 msgid "6 hours"
 msgstr "6 時間"
 
@@ -443,7 +440,7 @@ msgstr "6 時間"
 msgid "60 Minutes"
 msgstr "60 分"
 
-#: pkg/storaged/mdraids-panel.jsx:61
+#: pkg/storaged/overview.js:438
 msgid "64 KiB"
 msgstr "64 KiB"
 
@@ -455,15 +452,15 @@ msgstr "6 日"
 msgid "7th"
 msgstr "7 日"
 
-#: pkg/storaged/mdraids-panel.jsx:58
+#: pkg/storaged/overview.js:435
 msgid "8 KiB"
 msgstr "8 KiB"
 
-#: pkg/networkmanager/interfaces.js:1913
+#: pkg/networkmanager/interfaces.js:1908
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:1930
+#: pkg/networkmanager/interfaces.js:1925
 msgid "802.3ad LACP"
 msgstr "802.3ad LACP"
 
@@ -475,13 +472,33 @@ msgstr "8 日"
 msgid "9th"
 msgstr "9 日"
 
+#: pkg/storaged/utils.js:227
+msgid "<span>Encrypted $0</span>"
+msgstr "<span>暗号化された $0</span>"
+
+#: pkg/storaged/utils.js:219
+msgid "<span>Encrypted Logical Volume of $0</span>"
+msgstr "<span>暗号化された $0 の論理ボリューム</span>"
+
+#: pkg/storaged/utils.js:221
+msgid "<span>Encrypted Partition of $0</span>"
+msgstr "<span>暗号化された $0 のパーティション</span>†"
+
+#: pkg/storaged/utils.js:223
+msgid "<span>Logical Volume of $0</span>"
+msgstr "<span>$0 の論理ボリューム</span>"
+
+#: pkg/storaged/utils.js:225
+msgid "<span>Partition of $0</span>"
+msgstr "<span>$0 のパーティション</span>"
+
 #: pkg/lib/machine-not-supported.html:5
 msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr "Cockpit の互換バージョンが {{#strong}}{{host}}{{/strong}} にインストールされていません。"
 
-#: pkg/storaged/mdraid-details.jsx:118
+#: pkg/storaged/sidebar-views.jsx:142
 msgid "A spare disk needs to be added first before this disk can be removed."
 msgstr "このディスクを削除する前に、スペアディスクを追加する必要があります。"
 
@@ -489,15 +506,15 @@ msgstr "このディスクを削除する前に、スペアディスクを追加
 msgid "A user interface for GNU/Linux servers"
 msgstr "GNU/Linux サーバーのユーザーインターフェース"
 
-#: pkg/networkmanager/interfaces.js:1921
+#: pkg/networkmanager/interfaces.js:1916
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2676
+#: pkg/networkmanager/interfaces.js:2669
 msgid "ARP Monitoring"
 msgstr "ARP 監視"
 
-#: pkg/networkmanager/interfaces.js:1942
+#: pkg/networkmanager/interfaces.js:1937
 msgid "ARP Ping"
 msgstr "ARP Ping"
 
@@ -505,8 +522,8 @@ msgstr "ARP Ping"
 msgid "AWS Elastic Block Store"
 msgstr "AWS Elastic Block Store"
 
-#: pkg/shell/index.html:58 pkg/shell/index.html:84 pkg/shell/simple.html:42
-#: pkg/shell/simple.html:58 pkg/shell/stub.html:46 pkg/shell/stub.html:65
+#: pkg/shell/index.html:53 pkg/shell/index.html:95 pkg/shell/stub.html:41
+#: pkg/shell/stub.html:73 pkg/shell/simple.html:41 pkg/shell/simple.html:68
 msgid "About Cockpit"
 msgstr "Cockpit について"
 
@@ -514,8 +531,8 @@ msgstr "Cockpit について"
 msgid "Access"
 msgstr "アクセス"
 
-#: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pv-claim.html:9 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr "アクセスモード"
 
@@ -530,15 +547,15 @@ msgstr "アクセスは拒否されました"
 
 #: pkg/users/index.html:297
 msgid "Account Expiration"
-msgstr ""
+msgstr "アカウントの有効期限"
 
-#: pkg/shell/index.html:65
+#: pkg/shell/index.html:60
 msgid "Account Settings"
 msgstr "アカウント設定"
 
 #: pkg/users/index.html:61
 msgid "Account not available or cannot be edited."
-msgstr "アカウントが利用可能でないか、アカウントを編集できません。"
+msgstr "アカウントが利用できないか、アカウントを編集できません。"
 
 #: pkg/users/index.html:69
 msgid "Accounts"
@@ -549,16 +566,16 @@ msgctxt "page-title"
 msgid "Accounts"
 msgstr "アカウント"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:138
-#: pkg/ovirt/components/ClusterVms.jsx:175
+#: pkg/ovirt/components/ClusterVms.jsx:176
+#: pkg/ovirt/components/ClusterTemplates.jsx:129
 msgid "Action"
-msgstr ""
+msgstr "アクション"
 
-#: pkg/storaged/content-views.jsx:226
+#: pkg/storaged/content-views.jsx:227
 msgid "Activate"
 msgstr "有効化"
 
-#: pkg/storaged/jobs-panel.jsx:64
+#: pkg/storaged/jobs.js:147
 msgid "Activating $target"
 msgstr "$target のアクティベート"
 
@@ -566,15 +583,15 @@ msgstr "$target のアクティベート"
 msgid "Activation Key"
 msgstr "アクティベーションキー"
 
-#: pkg/networkmanager/interfaces.js:775 pkg/networkmanager/interfaces.js:1936
+#: pkg/networkmanager/interfaces.js:775 pkg/networkmanager/interfaces.js:1931
 msgid "Active"
 msgstr "動作中"
 
-#: pkg/networkmanager/interfaces.js:1910 pkg/networkmanager/interfaces.js:1927
+#: pkg/networkmanager/interfaces.js:1905 pkg/networkmanager/interfaces.js:1922
 msgid "Active Backup"
 msgstr "アクティブなバックアップ"
 
-#: pkg/shell/index.html:61 pkg/shell/stub.html:49 pkg/shell/active-pages.js:94
+#: pkg/shell/index.html:56 pkg/shell/active-pages.js:94
 msgid "Active Pages"
 msgstr "アクティブページ"
 
@@ -582,28 +599,27 @@ msgstr "アクティブページ"
 msgid "Actual"
 msgstr "実際"
 
-#: pkg/networkmanager/interfaces.js:1915
+#: pkg/networkmanager/interfaces.js:1910
 msgid "Adaptive load balancing"
 msgstr "適応ロードバランス"
 
-#: pkg/networkmanager/interfaces.js:1914
+#: pkg/networkmanager/interfaces.js:1909
 msgid "Adaptive transmit load balancing"
 msgstr "適応送信のロードバランス"
 
-#: pkg/kubernetes/views/add-user-dialog.html:27
+#: pkg/ostree/index.html:90 pkg/lib/machine-add.html:43
+#: pkg/shell/index.html:194 pkg/kubernetes/views/user-group-add.html:30
+#: pkg/kubernetes/views/add-member-role-dialog.html:61
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30
-#: pkg/kubernetes/views/add-member-role-dialog.html:61
-#: pkg/kubernetes/views/add-role-dialog.html:8 pkg/lib/machine-add.html:43
-#: pkg/ostree/index.html:90 pkg/shell/index.html:183
-#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/iscsi-panel.jsx:183
-#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/nfs-panel.jsx:175
-#: pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/add-user-dialog.html:27
+#: pkg/kubernetes/views/add-role-dialog.html:8
+#: pkg/storaged/sidebar-views.jsx:85 pkg/storaged/sidebar-views.jsx:249
+#: pkg/storaged/overview.js:634 pkg/storaged/overview.js:662
 msgid "Add"
 msgstr "追加する"
 
-#: pkg/networkmanager/interfaces.js:2992
+#: pkg/networkmanager/interfaces.js:2985
 msgid "Add $0"
 msgstr "$0 の追加"
 
@@ -627,7 +643,7 @@ msgstr "ブリッジの追加"
 msgid "Add Cluster Node"
 msgstr "クラスターノードの追加"
 
-#: pkg/storaged/mdraid-details.jsx:44 pkg/storaged/vgroup-details.jsx:48
+#: pkg/storaged/sidebar-views.jsx:68 pkg/storaged/sidebar-views.jsx:232
 msgid "Add Disks"
 msgstr "ディスクの追加"
 
@@ -644,10 +660,10 @@ msgid "Add Machine to Dashboard"
 msgstr "ダッシュボードへのマシンの追加"
 
 #: pkg/kubernetes/views/group-page.html:38
-#: pkg/kubernetes/views/group-panel.html:29
-#: pkg/kubernetes/views/project-body.html:108
 #: pkg/kubernetes/views/user-group-add.html:3
+#: pkg/kubernetes/views/project-body.html:108
 #: pkg/kubernetes/views/add-member-role-dialog.html:4
+#: pkg/kubernetes/views/group-panel.html:29
 msgid "Add Member"
 msgstr "メンバーの追加"
 
@@ -678,8 +694,8 @@ msgstr "ストレージの追加"
 msgid "Add Team"
 msgstr "チームの追加"
 
-#: pkg/kubernetes/views/add-user-dialog.html:3
 #: pkg/kubernetes/views/project-listing.html:83
+#: pkg/kubernetes/views/add-user-dialog.html:3
 msgid "Add User"
 msgstr "ユーザーの追加"
 
@@ -687,11 +703,11 @@ msgstr "ユーザーの追加"
 msgid "Add VLAN"
 msgstr "VLAN の追加"
 
-#: pkg/storaged/iscsi-panel.jsx:41
+#: pkg/storaged/overview.js:520
 msgid "Add iSCSI Portal"
 msgstr "iSCSI ポータルの追加"
 
-#: pkg/shell/index.html:174 pkg/users/index.html:462
+#: pkg/users/index.html:462 pkg/shell/index.html:185
 msgid "Add key"
 msgstr "鍵の追加"
 
@@ -703,7 +719,7 @@ msgstr "メンバーシップの追加"
 msgid "Add public key"
 msgstr "公開鍵の追加"
 
-#: pkg/networkmanager/interfaces.js:2991
+#: pkg/networkmanager/interfaces.js:2984
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
@@ -713,19 +729,15 @@ msgstr "<b>$0</b> を追加すると、サーバーへの接続が切断され�
 msgid "Adding key"
 msgstr "鍵の追加"
 
-#: pkg/storaged/jobs-panel.jsx:69
+#: pkg/storaged/jobs.js:152
 msgid "Adding physical volume to $target"
 msgstr "$target への物理ボリュームの追加"
 
-#: pkg/machines/vmnetworktab.jsx:88
-msgid "Additional"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2546
+#: pkg/networkmanager/interfaces.js:2539
 msgid "Additional DNS $val"
 msgstr "追加の DNS $val"
 
-#: pkg/networkmanager/interfaces.js:2549
+#: pkg/networkmanager/interfaces.js:2542
 msgid "Additional DNS Search Domains $val"
 msgstr "追加の DNS 検索ドメイン $val"
 
@@ -733,7 +745,7 @@ msgstr "追加の DNS 検索ドメイン $val"
 msgid "Additional Storage"
 msgstr "追加のストレージ"
 
-#: pkg/networkmanager/interfaces.js:2541
+#: pkg/networkmanager/interfaces.js:2534
 msgid "Additional address $val"
 msgstr "追加のアドレス $val"
 
@@ -741,27 +753,25 @@ msgstr "追加のアドレス $val"
 msgid "Additions"
 msgstr "追加"
 
-#: pkg/kubernetes/views/auth-form.html:29
+#: pkg/lib/machine-add.html:11 pkg/kubernetes/views/node-add.html:8
 #: pkg/kubernetes/views/dashboard-page.html:157
+#: pkg/kubernetes/views/auth-form.html:29
 #: pkg/kubernetes/views/details-page.html:174
-#: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
-#: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/kubernetes/views/nodes-page.html:43
+#: pkg/kubernetes/views/node-body.html:5 pkg/storaged/overview.js:629
 msgid "Address"
 msgstr "アドレス:"
 
-#: pkg/networkmanager/interfaces.js:2541
+#: pkg/networkmanager/interfaces.js:2534
 msgid "Address $val"
 msgstr "アドレス $val"
 
 #: pkg/machines/components/desktopConsole.jsx:154
-#: pkg/ovirt/components/VmOverviewColumn.jsx:73
-#, fuzzy
 msgid "Address:"
 msgstr "アドレス:"
 
 #: pkg/kubernetes/views/details-page.html:37
-#: pkg/networkmanager/interfaces.js:3185
+#: pkg/networkmanager/interfaces.js:3178
 msgid "Addresses"
 msgstr "アドレス"
 
@@ -798,7 +808,6 @@ msgid "After"
 msgstr "後"
 
 #: pkg/systemd/services.html:405 pkg/systemd/services.html:409
-#: pkg/systemd/init.js:970
 msgid "After system boot"
 msgstr "システムブート後"
 
@@ -832,16 +841,12 @@ msgstr "使用中のすべてのもの"
 msgid "All running"
 msgstr "実行中のすべてのもの"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:39
-msgid "All running virtual machines will be turned off."
-msgstr ""
-
 #: pkg/docker/index.html:540 pkg/docker/util.js:106
 msgid "Always"
 msgstr "常時"
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "アノテーション"
@@ -850,29 +855,29 @@ msgstr "アノテーション"
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr "匿名: 認証されていないすべてのユーザーがイメージをプルできます"
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:148
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:127
+#: pkg/apps/application-list.jsx:148
 msgid "Applications"
-msgstr ""
+msgstr "アプリケーション"
 
-#: pkg/networkmanager/index.html:620 pkg/networkmanager/index.html:644
-#: pkg/networkmanager/index.html:668 pkg/networkmanager/index.html:692
-#: pkg/networkmanager/index.html:716 pkg/networkmanager/index.html:740
-#: pkg/networkmanager/index.html:764 pkg/networkmanager/index.html:788
-#: pkg/networkmanager/index.html:812 pkg/ostree/index.html:39
-#: pkg/kdump/kdump-view.jsx:356 pkg/storaged/crypto-tab.jsx:81
-#: pkg/storaged/crypto-tab.jsx:110 pkg/storaged/fsys-tab.jsx:76
-#: pkg/storaged/fsys-tab.jsx:123 pkg/storaged/nfs-panel.jsx:175
+#: pkg/ostree/index.html:39 pkg/networkmanager/index.html:620
+#: pkg/networkmanager/index.html:644 pkg/networkmanager/index.html:668
+#: pkg/networkmanager/index.html:692 pkg/networkmanager/index.html:716
+#: pkg/networkmanager/index.html:740 pkg/networkmanager/index.html:764
+#: pkg/networkmanager/index.html:788 pkg/networkmanager/index.html:812
+#: pkg/kdump/kdump-view.jsx:356 pkg/storaged/fsys-tab.jsx:76
+#: pkg/storaged/fsys-tab.jsx:145 pkg/storaged/crypto-tab.jsx:81
+#: pkg/storaged/crypto-tab.jsx:115
 msgid "Apply"
 msgstr "適用"
 
 #: pkg/packagekit/autoupdates.jsx:293
 msgid "Apply all updates"
-msgstr ""
+msgstr "すべてのアップデートを適用します"
 
 #: pkg/packagekit/autoupdates.jsx:294
 msgid "Apply security updates"
-msgstr ""
+msgstr "セキュリティーアップデートを適用します"
 
 #: pkg/selinux/setroubleshoot-view.jsx:107
 msgid "Apply this solution"
@@ -883,13 +888,12 @@ msgid "Applying solution..."
 msgstr "ソリューションの適用中 ..."
 
 #: pkg/packagekit/updates.jsx:36
-#, fuzzy
 msgid "Applying updates"
-msgstr "ソリューションの適用中 ..."
+msgstr "アップデートの適用中 ..."
 
 #: pkg/packagekit/updates.jsx:38
 msgid "Applying updates failed"
-msgstr ""
+msgstr "アップデートの適用に失敗しました"
 
 #: node_modules/registry-image-widgets/views/image-config.html:16
 #: pkg/subscriptions/subscriptions-view.jsx:35
@@ -901,25 +905,28 @@ msgid "Are you sure you want to delete this image?"
 msgstr "このイメージを削除してもよろしいですか?"
 
 #: pkg/realmd/operation.js:105
-#, fuzzy
 msgid "Are you sure you want to leave the '$0' domain?"
-msgstr "このイメージを削除してもよろしいですか?"
+msgstr "'$0' ドメインを解除してもよろしいですか?"
 
 #: pkg/realmd/operation.js:103
-#, fuzzy
 msgid "Are you sure you want to leave this domain?"
-msgstr "このイメージを削除してもよろしいですか?"
+msgstr "このドメインを解除してもよろしいですか?"
+
+#: pkg/storaged/index.html:449
+msgctxt "storage"
+msgid "Assessment"
+msgstr "評価"
 
 #: pkg/systemd/index.html:91
 msgid "Asset Tag"
 msgstr "アセットタグ"
 
-#: pkg/storaged/mdraids-panel.jsx:78
+#: pkg/storaged/overview.js:455
 msgid "At least $0 disks are needed."
 msgstr "少なくとも $0 ディスクが必要です。"
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/sidebar-views.jsx:80 pkg/storaged/sidebar-views.jsx:244
+#: pkg/storaged/overview.js:503
 msgid "At least one disk is needed."
 msgstr "少なくとも 1 つのディスクが必要です。"
 
@@ -935,9 +942,9 @@ msgstr "監査ログ"
 msgid "Authenticating"
 msgstr "認証"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:68
-#: pkg/shell/index.html:151
+#: pkg/lib/machine-change-auth.html:32 pkg/shell/index.html:63
+#: pkg/shell/index.html:162 pkg/kubernetes/views/auth-form.html:85
+#: pkg/realmd/operation.html:35
 msgid "Authentication"
 msgstr "認証"
 
@@ -945,15 +952,15 @@ msgstr "認証"
 msgid "Authentication Failed"
 msgstr "認証に失敗しました"
 
-#: src/ws/login.js:590
+#: src/ws/login.js:587
 msgid "Authentication Failed: Server closed connection"
 msgstr "認証に失敗しました: サーバーの接続が切断されました"
 
-#: src/ws/login.js:600
+#: src/ws/login.js:597
 msgid "Authentication failed"
 msgstr "認証に失敗しました"
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/overview.js:650
 msgid "Authentication required"
 msgstr "認証が必要です"
 
@@ -967,28 +974,28 @@ msgstr "作成者"
 msgid "Authorized Public SSH Keys"
 msgstr "承認された公開 SSH 鍵"
 
-#: pkg/networkmanager/index.html:166 pkg/networkmanager/interfaces.js:1900
-#: pkg/networkmanager/interfaces.js:2649 pkg/networkmanager/interfaces.js:3193
-#: pkg/networkmanager/interfaces.js:3197 pkg/networkmanager/interfaces.js:3203
+#: pkg/networkmanager/index.html:166 pkg/networkmanager/interfaces.js:1895
+#: pkg/networkmanager/interfaces.js:2642 pkg/networkmanager/interfaces.js:3186
+#: pkg/networkmanager/interfaces.js:3190 pkg/networkmanager/interfaces.js:3196
 #: pkg/realmd/operation.js:285
 msgid "Automatic"
 msgstr "自動"
 
-#: pkg/networkmanager/interfaces.js:1901
+#: pkg/networkmanager/interfaces.js:1896
 msgid "Automatic (DHCP only)"
 msgstr "自動 (DHCP のみ)"
 
-#: pkg/networkmanager/interfaces.js:1891
+#: pkg/networkmanager/interfaces.js:1886
 msgid "Automatic (DHCP)"
 msgstr "自動 (DHCP)"
 
 #: pkg/packagekit/autoupdates.jsx:334
 msgid "Automatic Updates"
-msgstr ""
+msgstr "自動アップデート"
 
 #: pkg/ovirt/components/OVirtTab.jsx:79
 msgid "Automatically selected host"
-msgstr ""
+msgstr "自動的に選択されたホスト"
 
 #: pkg/systemd/index.html:398
 msgid "Automatically using NTP"
@@ -998,21 +1005,20 @@ msgstr "NTP を自動的に使用"
 msgid "Automatically using specific NTP servers"
 msgstr "特定の NTP サーバーを自動的に使用"
 
-#: pkg/machines/hostvmslist.jsx:309
+#: pkg/machines/hostvmslist.jsx:308
 msgid "Autostart:"
 msgstr "自動起動:"
 
-#: pkg/lib/machine-change-auth.html:66 pkg/ostree/index.html:255
-#: pkg/machines/hostvmslist.jsx:354 pkg/machines/hostvmslist.jsx:365
+#: pkg/ostree/index.html:255 pkg/lib/machine-change-auth.html:66
+#: pkg/machines/hostvmslist.jsx:353 pkg/machines/hostvmslist.jsx:364
 msgid "Available"
 msgstr "利用可能"
 
-#: pkg/packagekit/updates.jsx:836
-#, fuzzy
+#: pkg/packagekit/updates.jsx:822
 msgid "Available Updates"
-msgstr "利用可能"
+msgstr "利用可能なアップデート"
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/overview.js:624
 msgid "Available targets on $0"
 msgstr "$0 で利用可能なターゲット"
 
@@ -1036,36 +1042,41 @@ msgstr "passwd1 メカニズムに間違ったデータが渡されました"
 msgid "Balancer"
 msgstr "バランサー"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:137
+#: pkg/ovirt/components/ClusterTemplates.jsx:128
 msgid "Base Template"
-msgstr ""
+msgstr "ベーステンプレート"
 
-#: pkg/ovirt/components/ClusterVms.jsx:75
+#: pkg/ovirt/components/ClusterVms.jsx:74
 msgid "Base template"
-msgstr ""
+msgstr "ベーステンプレート"
 
 #: pkg/ovirt/components/OVirtTab.jsx:105 pkg/ovirt/components/OVirtTab.jsx:112
 msgid "Base template:"
-msgstr ""
+msgstr "ベーステンプレート:"
 
 #: pkg/ostree/index.html:68
 msgid "Begins with '-----BEGIN PGP PUBLIC KEY BLOCK-----'"
 msgstr "'-----BEGIN PGP PUBLIC KEY BLOCK-----' で始めます"
 
-#: pkg/storaged/block-details.jsx:34
-msgid "Block"
-msgstr ""
+#: pkg/storaged/index.html:559
+msgctxt "storage"
+msgid "Bitmap"
+msgstr "ビットマップ"
 
-#: pkg/storaged/content-views.jsx:606
+#: pkg/storaged/index.html:412
+msgid "Block Device"
+msgstr "ブロックデバイス"
+
+#: pkg/storaged/content-views.jsx:668
 msgid "Block device for filesystems"
 msgstr "ファイルシステム用ブロックデバイス"
 
-#: pkg/storaged/mdraid-details.jsx:102
+#: pkg/storaged/sidebar-views.jsx:126
 msgid "Blocked"
 msgstr "ブロック済み"
 
-#: pkg/networkmanager/interfaces.js:2405 pkg/networkmanager/interfaces.js:2417
-#: pkg/networkmanager/interfaces.js:2681
+#: pkg/networkmanager/interfaces.js:2398 pkg/networkmanager/interfaces.js:2410
+#: pkg/networkmanager/interfaces.js:2674
 msgid "Bond"
 msgstr "Bond"
 
@@ -1077,12 +1088,12 @@ msgstr "ボンド設定"
 msgid "Boot ID"
 msgstr "ブート ID"
 
-#: pkg/machines/hostvmslist.jsx:272
+#: pkg/machines/hostvmslist.jsx:271
 msgid "Boot Order:"
-msgstr ""
+msgstr "ブート順序:"
 
-#: pkg/networkmanager/interfaces.js:2411 pkg/networkmanager/interfaces.js:2423
-#: pkg/networkmanager/interfaces.js:2758
+#: pkg/networkmanager/interfaces.js:2404 pkg/networkmanager/interfaces.js:2416
+#: pkg/networkmanager/interfaces.js:2751
 msgid "Bridge"
 msgstr "ブリッジ"
 
@@ -1094,21 +1105,21 @@ msgstr "ブリッジポート設定"
 msgid "Bridge Settings"
 msgstr "ブリッジ設定"
 
-#: pkg/networkmanager/interfaces.js:2779
+#: pkg/networkmanager/interfaces.js:2772
 msgid "Bridge port"
 msgstr "ブリッジポート"
 
-#: pkg/networkmanager/interfaces.js:1912 pkg/networkmanager/interfaces.js:1929
+#: pkg/networkmanager/interfaces.js:1907 pkg/networkmanager/interfaces.js:1924
 msgid "Broadcast"
 msgstr "ブロードキャスト"
 
-#: pkg/networkmanager/interfaces.js:2694 pkg/networkmanager/interfaces.js:2728
+#: pkg/networkmanager/interfaces.js:2687 pkg/networkmanager/interfaces.js:2721
 msgid "Broken configuration"
 msgstr "破損した設定"
 
-#: pkg/packagekit/updates.jsx:341
+#: pkg/packagekit/updates.jsx:331
 msgid "Bugs"
-msgstr ""
+msgstr "バグ"
 
 #: node_modules/registry-image-widgets/views/image-body.html:18
 msgid "Built"
@@ -1118,26 +1129,21 @@ msgstr "ビルド"
 msgid "Bus"
 msgstr "バス"
 
-#: pkg/machines/libvirt.es6:254
-msgid "CHANGE NETWORK STATE action failed"
-msgstr ""
-
-#: pkg/dashboard/index.html:70 pkg/docker/index.html:263
-#: pkg/systemd/index.html:206 pkg/docker/containers-view.jsx:271
-#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
-#: pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/index.html:263 pkg/systemd/index.html:206
+#: pkg/dashboard/index.html:70 pkg/docker/containers-view.jsx:271
+#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/kubernetes/scripts/graphs.js:599
 msgid "CPU"
 msgstr "CPU"
 
-#: pkg/systemd/host.js:1355
+#: pkg/systemd/host.js:1348
 msgctxt "page-title"
 msgid "CPU Status"
 msgstr "CPU ステータス"
 
-#: pkg/machines/hostvmslist.jsx:301
-#, fuzzy
+#: pkg/machines/hostvmslist.jsx:300
 msgid "CPU Type:"
-msgstr "種類:"
+msgstr "CPU タイプ:"
 
 #: pkg/kubernetes/scripts/nodes.js:716
 msgid "CPU Utilization: $0%"
@@ -1151,11 +1157,11 @@ msgstr "CPU 優先度"
 msgid "CPU usage:"
 msgstr "CPU 使用率:"
 
-#: pkg/ovirt/provider.es6:211
+#: pkg/ovirt/provider.es6:202
 msgid "CREATE VM action failed"
-msgstr ""
+msgstr "CREATE VM アクションに失敗しました"
 
-#: pkg/systemd/index.html:257 pkg/systemd/host.js:1474
+#: pkg/systemd/index.html:257 pkg/systemd/host.js:1467
 msgid "Cached"
 msgstr "キャッシュ済み"
 
@@ -1163,74 +1169,68 @@ msgstr "キャッシュ済み"
 msgid "Can&rsquo;t connect to Docker"
 msgstr "Docker に接続できません"
 
-#: pkg/storaged/content-views.jsx:286
+#: pkg/storaged/content-views.jsx:287
 msgid "Can't delete while unlocked"
 msgstr "ロック解除されている間は削除できません"
 
-#: pkg/dashboard/list.js:199
-msgid "Can't load image"
-msgstr ""
-
-#: pkg/dashboard/index.html:173 pkg/docker/index.html:555
+#: pkg/ostree/index.html:164 pkg/users/index.html:221 pkg/users/index.html:285
+#: pkg/users/index.html:324 pkg/users/index.html:363 pkg/users/index.html:380
+#: pkg/users/index.html:404 pkg/users/index.html:461 pkg/docker/index.html:555
 #: pkg/docker/index.html:589 pkg/docker/index.html:651
 #: pkg/docker/index.html:703 pkg/docker/index.html:743
-#: pkg/kubernetes/views/add-user-dialog.html:26
-#: pkg/kubernetes/views/auth-form.html:128
-#: pkg/kubernetes/views/auth-rejected-cert.html:31
-#: pkg/kubernetes/views/deploy.html:61
-#: pkg/kubernetes/views/group-delete.html:20
-#: pkg/kubernetes/views/image-delete.html:7
-#: pkg/kubernetes/views/imagestream-delete.html:7
-#: pkg/kubernetes/views/imagestream-modify.html:96
-#: pkg/kubernetes/views/item-delete.html:10
-#: pkg/kubernetes/views/node-add.html:49
-#: pkg/kubernetes/views/node-delete.html:14
-#: pkg/kubernetes/views/project-delete.html:8
-#: pkg/kubernetes/views/project-modify.html:71
-#: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:202
-#: pkg/kubernetes/views/pvc-delete.html:14
-#: pkg/kubernetes/views/remove-role-dialog.html:7
-#: pkg/kubernetes/views/replicationcontroller-modify.html:16
-#: pkg/kubernetes/views/route-modify.html:16
-#: pkg/kubernetes/views/service-modify.html:24
-#: pkg/kubernetes/views/user-add-membership.html:48
-#: pkg/kubernetes/views/user-delete.html:24
-#: pkg/kubernetes/views/user-group-add.html:29
-#: pkg/kubernetes/views/user-group-remove.html:9
-#: pkg/kubernetes/views/user-modify.html:26
-#: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/kubernetes/views/add-group-dialog.html:18
-#: pkg/kubernetes/views/add-member-role-dialog.html:60
-#: pkg/kubernetes/views/add-role-dialog.html:7 pkg/lib/machine-add.html:42
-#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-sync-users.html:74 pkg/networkmanager/index.html:619
-#: pkg/networkmanager/index.html:643 pkg/networkmanager/index.html:667
-#: pkg/networkmanager/index.html:691 pkg/networkmanager/index.html:715
-#: pkg/networkmanager/index.html:739 pkg/networkmanager/index.html:763
-#: pkg/networkmanager/index.html:787 pkg/networkmanager/index.html:811
-#: pkg/ostree/index.html:164 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:124
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:329
+#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-sync-users.html:74
+#: pkg/lib/machine-change-port.html:40 pkg/lib/machine-add.html:42
+#: pkg/shell/index.html:135 pkg/shell/stub.html:113 pkg/shell/simple.html:100
 #: pkg/systemd/index.html:341 pkg/systemd/index.html:428
 #: pkg/systemd/index.html:480 pkg/systemd/index.html:496
-#: pkg/systemd/services.html:481 pkg/users/index.html:221
-#: pkg/users/index.html:285 pkg/users/index.html:324 pkg/users/index.html:363
-#: pkg/users/index.html:380 pkg/users/index.html:404 pkg/users/index.html:461
-#: pkg/apps/utils.jsx:90 pkg/lib/cockpit-components-dialog.jsx:138
-#: pkg/ovirt/components/ClusterTemplates.jsx:77
-#: pkg/ovirt/components/OVirtTab.jsx:68 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:216
-#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
-#: pkg/storaged/jobs-panel.jsx:119
+#: pkg/systemd/services.html:481 pkg/playground/translate.html:39
+#: pkg/networkmanager/index.html:619 pkg/networkmanager/index.html:643
+#: pkg/networkmanager/index.html:667 pkg/networkmanager/index.html:691
+#: pkg/networkmanager/index.html:715 pkg/networkmanager/index.html:739
+#: pkg/networkmanager/index.html:763 pkg/networkmanager/index.html:787
+#: pkg/networkmanager/index.html:811 pkg/dashboard/index.html:173
+#: pkg/kubernetes/views/pv-delete.html:10
+#: pkg/kubernetes/views/group-delete.html:20
+#: pkg/kubernetes/views/imagestream-delete.html:7
+#: pkg/kubernetes/views/user-group-add.html:29
+#: pkg/kubernetes/views/node-delete.html:14
+#: pkg/kubernetes/views/project-modify.html:71
+#: pkg/kubernetes/views/deploy.html:61
+#: pkg/kubernetes/views/add-group-dialog.html:18
+#: pkg/kubernetes/views/add-member-role-dialog.html:60
+#: pkg/kubernetes/views/node-add.html:49
+#: pkg/kubernetes/views/route-modify.html:16
+#: pkg/kubernetes/views/user-add-membership.html:48
+#: pkg/kubernetes/views/user-group-remove.html:9
+#: pkg/kubernetes/views/auth-form.html:128
+#: pkg/kubernetes/views/user-delete.html:24
+#: pkg/kubernetes/views/user-modify.html:26
+#: pkg/kubernetes/views/pv-modify.html:202
+#: pkg/kubernetes/views/auth-rejected-cert.html:31
+#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/kubernetes/views/service-modify.html:24
+#: pkg/kubernetes/views/project-delete.html:8
+#: pkg/kubernetes/views/pvc-delete.html:14
+#: pkg/kubernetes/views/item-delete.html:10
+#: pkg/kubernetes/views/add-user-dialog.html:26
+#: pkg/kubernetes/views/replicationcontroller-modify.html:16
+#: pkg/kubernetes/views/imagestream-modify.html:96
+#: pkg/kubernetes/views/remove-role-dialog.html:7
+#: pkg/kubernetes/views/add-role-dialog.html:7
+#: pkg/kubernetes/views/image-delete.html:7 pkg/realmd/operation.html:92
+#: pkg/storaged/index.html:287 pkg/storaged/index.html:853
+#: pkg/packagekit/updates.jsx:206 pkg/ovirt/components/VdsmView.jsx:97
+#: pkg/ovirt/components/VdsmView.jsx:111 pkg/ovirt/components/OVirtTab.jsx:68
+#: pkg/ovirt/components/ClusterTemplates.jsx:76 pkg/apps/utils.jsx:87
+#: pkg/lib/cockpit-components-dialog.jsx:138 pkg/sosreport/index.js:51
 msgid "Cancel"
 msgstr "取り消し"
 
-#: pkg/shell/indexes.js:404
+#: pkg/shell/indexes.js:332
 msgid "Cannot connect to an unknown machine"
 msgstr "不明なマシンには接続できません"
 
-#: src/ws/cockpitcertificate.c:481
+#: src/ws/cockpitcertificate.c:460
 msgid "Cannot decrypt PEM-encoded private key"
 msgstr "PEM で暗号化された秘密鍵を復号できません"
 
@@ -1246,13 +1246,19 @@ msgstr "このシステムでは realmd が利用できないため、ドメイ�
 msgid "Cannot schedule event in the past"
 msgstr "過去のイベントはスケジュールできません"
 
-#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
-#: pkg/machines/vmdiskstab.jsx:137
+#: pkg/kubernetes/views/pv-body.html:13 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pv-modify.html:44
+#: pkg/kubernetes/views/node-page.html:17 pkg/machines/vmdiskstab.jsx:137
 msgid "Capacity"
 msgstr "容量"
 
-#: pkg/networkmanager/interfaces.js:2480
+#: pkg/storaged/index.html:441 pkg/storaged/index.html:517
+#: pkg/storaged/index.html:550 pkg/storaged/index.html:595
+msgctxt "storage"
+msgid "Capacity"
+msgstr "容量"
+
+#: pkg/networkmanager/interfaces.js:2473
 msgid "Carrier"
 msgstr "キャリア"
 
@@ -1264,12 +1270,13 @@ msgstr "Ceph ファイルシステムマウント"
 msgid "Ceph Monitors"
 msgstr "Ceph モニター"
 
-#: pkg/docker/index.html:652 pkg/kubernetes/views/project-modify.html:74
+#: pkg/users/index.html:325 pkg/users/index.html:364 pkg/docker/index.html:652
+#: pkg/systemd/index.html:342 pkg/systemd/index.html:429
+#: pkg/kubernetes/views/project-modify.html:74
+#: pkg/kubernetes/views/route-modify.html:17
 #: pkg/kubernetes/views/pv-modify.html:204
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:342
-#: pkg/systemd/index.html:429 pkg/users/index.html:325 pkg/users/index.html:364
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/overview.js:712
 msgid "Change"
 msgstr "変更"
 
@@ -1277,7 +1284,7 @@ msgstr "変更"
 msgid "Change Host Name"
 msgstr "ホスト名の変更"
 
-#: pkg/shell/index.html:334
+#: pkg/shell/index.html:345
 msgid "Change Password"
 msgstr "パスワードの変更"
 
@@ -1301,7 +1308,7 @@ msgstr "システム時間の変更"
 msgid "Change User"
 msgstr "ユーザーの変更"
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/overview.js:704
 msgid "Change iSCSI Initiator Name"
 msgstr "iSCSI イニシエーター名の変更"
 
@@ -1321,17 +1328,17 @@ msgstr "リソース制限の変更"
 msgid "Change resources limits"
 msgstr "リソース制限の変更"
 
-#: pkg/networkmanager/interfaces.js:3031
+#: pkg/networkmanager/interfaces.js:3024
 msgid "Change the settings"
 msgstr "設定の変更"
 
-#: pkg/networkmanager/interfaces.js:3030
+#: pkg/networkmanager/interfaces.js:3023
 msgid ""
 "Changing the settings will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr "設定を変更すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
 
-#: pkg/ostree/index.html:210 pkg/packagekit/updates.jsx:207
+#: pkg/ostree/index.html:210 pkg/packagekit/updates.jsx:197
 msgid "Check for Updates"
 msgstr "更新の確認"
 
@@ -1339,17 +1346,17 @@ msgstr "更新の確認"
 msgid "Checking IP"
 msgstr "IP の確認"
 
-#: pkg/storaged/jobs-panel.jsx:59
+#: pkg/storaged/jobs.js:142
 msgid "Checking RAID Device $target"
 msgstr "RAID デバイス $target の確認"
 
-#: pkg/storaged/jobs-panel.jsx:60
+#: pkg/storaged/jobs.js:143
 msgid "Checking and Repairing RAID Device $target"
 msgstr "RAID デバイス $target の確認および修復"
 
 #: pkg/apps/application-list.jsx:124
 msgid "Checking for new applications"
-msgstr ""
+msgstr "新しいアプリケーションを探す"
 
 #: pkg/lib/machine-change-auth.html:71
 msgid "Checking for public keys"
@@ -1359,11 +1366,11 @@ msgstr "公開鍵の確認"
 msgid "Checking for updates"
 msgstr "更新の確認"
 
-#: pkg/shell/index.html:119 pkg/shell/simple.html:85 pkg/shell/stub.html:100
+#: pkg/shell/index.html:130 pkg/shell/stub.html:108 pkg/shell/simple.html:95
 msgid "Choose the language to be used in the application"
 msgstr "アプリケーションで使用する言語の選択"
 
-#: pkg/storaged/mdraids-panel.jsx:55
+#: pkg/storaged/overview.js:432
 msgid "Chunk Size"
 msgstr "チャンクサイズ"
 
@@ -1371,7 +1378,7 @@ msgstr "チャンクサイズ"
 msgid "Cinder"
 msgstr "Cinder"
 
-#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
+#: pkg/kubernetes/views/pv-panel.html:13 pkg/kubernetes/views/pv-page.html:16
 msgid "Claim"
 msgstr "クレーム"
 
@@ -1379,29 +1386,29 @@ msgstr "クレーム"
 msgid "Claim Name"
 msgstr "クレーム名"
 
-#: pkg/storaged/jobs-panel.jsx:51
+#: pkg/storaged/jobs.js:134
 msgid "Cleaning up for $target"
 msgstr "$target のクリーンアップ"
 
 #: pkg/machines/components/desktopConsole.jsx:40
 msgid ""
 "Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
-msgstr ""
+msgstr "\"リモートビューアーの起動\" をクリックすると、.vv ファイルをダウンロードし、$0 を起動します。"
 
 #: pkg/kubernetes/views/auth-form.html:88
 msgid "Client Certificate"
 msgstr "クライアント証明書"
 
-#: pkg/docker/index.html:724 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:830 pkg/shell/index.html:98
-#: pkg/shell/index.html:141 pkg/shell/index.html:345 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:334 pkg/systemd/index.html:287
-#: pkg/systemd/services.html:322 pkg/systemd/services.html:340
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:112 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:109
+#: pkg/users/index.html:45 pkg/docker/index.html:724
+#: pkg/lib/machine-invalid-hostkey.html:19
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-not-supported.html:8
+#: pkg/shell/index.html:109 pkg/shell/index.html:152 pkg/shell/index.html:356
+#: pkg/shell/stub.html:87 pkg/shell/stub.html:130 pkg/shell/simple.html:82
+#: pkg/systemd/index.html:287 pkg/systemd/services.html:322
+#: pkg/systemd/services.html:340 pkg/networkmanager/index.html:830
+#: pkg/storaged/index.html:641 pkg/storaged/index.html:858
+#: pkg/apps/utils.jsx:109 pkg/sosreport/index.js:45 pkg/sosreport/index.js:109
 msgid "Close"
 msgstr "閉じる"
 
@@ -1409,24 +1416,24 @@ msgstr "閉じる"
 msgid "Close Selected Pages"
 msgstr "選択されたページを閉じる"
 
-#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
-#: pkg/ovirt/components/App.jsx:78
+#: pkg/kubernetes/views/auth-form.html:5 pkg/ovirt/components/App.jsx:75
+#: pkg/ovirt/components/ClusterVms.jsx:174
 msgid "Cluster"
 msgstr "クラスター"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:130
+#: pkg/ovirt/components/ClusterTemplates.jsx:127
 msgid "Cluster Templates"
-msgstr ""
+msgstr "クラスターテンプレート"
 
-#: pkg/ovirt/components/ClusterVms.jsx:166
+#: pkg/ovirt/components/ClusterVms.jsx:173
 msgid "Cluster Virtual Machines"
-msgstr ""
+msgstr "クラスター仮想マシン"
 
 #: cockpit.desktop.in.h:1
 msgid "Cockpit"
 msgstr "Cockpit"
 
-#: src/ws/login.js:303
+#: src/ws/login.js:300
 msgid "Cockpit authentication is configured incorrectly."
 msgstr "Cockpit の認証が間違って設定されています。"
 
@@ -1442,14 +1449,14 @@ msgstr ""
 msgid "Cockpit could not contact the given host."
 msgstr "Cockpit は該当するホストに接続できませんでした。"
 
-#: pkg/shell/base_index.js:751
+#: pkg/shell/base_index.js:752
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
 "details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
 msgstr ""
 "Cockpit で予期しない内部エラーが発生しました。<br/><br/>ブラウザーで更新を押して Cockpit "
-"の再起動を試行できます。javascript コンソールにはこのエラーに関する詳細が含まれます (ほとんどのブラウザーでは <b>Ctrl-Shift-"
+"の再起動を試行できます。javascript コンソールに、このエラーに関する詳細が含まれます (ほとんどのブラウザーでは <b>Ctrl-Shift-"
 "J</b>)。"
 
 #: cockpit.appdata.xml.in.h:2
@@ -1464,13 +1471,17 @@ msgstr ""
 "ツールを区別せずに使用できます。Cockpit で起動されたサービスは端末で停止できます。同様に、端末でエラーが発生した場合は、そのエラーを "
 "Cockpit ジャーナルインターフェースで確認できます。"
 
-#: pkg/shell/index.html:87 pkg/shell/simple.html:61 pkg/shell/stub.html:68
+#: pkg/shell/index.html:98 pkg/shell/stub.html:76
 msgid "Cockpit is an interactive Linux server admin interface."
-msgstr "Cockpit は対話型 Linux サーバー管理インターフェースです。"
+msgstr "Cockpit は、対話型 Linux サーバー管理インターフェースです。"
+
+#: pkg/shell/simple.html:71
+msgid "Cockpit is an interactive Linux server admin interface. "
+msgstr "Cockpit は、対話型 Linux サーバー管理インターフェースです。"
 
 #: src/base1/cockpit.js:3960
 msgid "Cockpit is not compatible with the software on the system."
-msgstr "Cockpit にはシステム上のそのソフトウェアとの互換性がありません。"
+msgstr "Cockpit には、そのシステムのソフトウェアとの互換性がありません。"
 
 #: pkg/lib/machine-not-supported.html:2
 msgid "Cockpit is not installed"
@@ -1489,11 +1500,11 @@ msgid ""
 "after its buddies."
 msgstr ""
 "Cockpit "
-"は経験が少ないシステム管理者に最適です。これらのシステム管理者はストレージの管理、ジャーナルの検査、サービスの起動および停止などの単純なタスクを簡単に実行できるようになります。また、複数のサーバーを同時に監視および管理できます。これらのサーバーはクリックするだけで追加できます。追加後に、ご使用のマシンは他のマシンを管理するようになります。"
+"は、経験が少ないシステム管理者に最適です。これを使えば、ストレージの管理、ジャーナルの検査、サービスの起動および停止などの単純なタスクを簡単に実行できるようになります。また、複数のサーバーを同時に監視および管理できます。これらのサーバーはクリックするだけで追加できます。追加後に、ご使用のマシンは他のマシンを管理するようになります。"
 
-#: pkg/packagekit/updates.jsx:848
+#: pkg/packagekit/updates.jsx:834
 msgid "Cockpit itself will be updated."
-msgstr ""
+msgstr "Cockpit 自体がアップデートされます。"
 
 #: pkg/lib/machine-change-port.html:9
 msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
@@ -1513,7 +1524,7 @@ msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
-msgstr "Cockpit は {{#strong}}{{host}}{{/strong}} にログインできませんでした。"
+msgstr "Cockpit は、{{#strong}}{{host}}{{/strong}} にログインできませんでした。"
 
 #: pkg/lib/machine-auth-failed.html:6
 msgid ""
@@ -1521,8 +1532,8 @@ msgid ""
 "machine with cockpit you will need to enable one of the following "
 "authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
 msgstr ""
-"Cockpit は {{#strong}}{{host}}{{/strong}} にログインできませんでした。このマシンを Cockpit "
-"で使用するには、{{#strong}}{{host}}{{/strong}} 上の sshd 設定で次の認証方法のいずれかを有効にする必要があります。"
+"Cockpit は、{{#strong}}{{host}}{{/strong}} にログインできませんでした。このマシンを Cockpit "
+"で使用するには、{{#strong}}{{host}}{{/strong}} 上の sshd 設定で、次のいずれかの認証方法を有効にする必要があります。"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1530,11 +1541,11 @@ msgid ""
 "change your authentication credentials below. {{#can_sync}}You may prefer to "
 "{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
-"Cockpit は {{#strong}}{{host}}{{/strong}} "
-"にログインできませんでした。認証情報は以下で変更できます。{{#can_sync}}{{#sync_link}}アカウントとパスワードの同期{{/"
-"sync_link}}を実行できます。{{/can_sync}}"
+"Cockpit は、{{#strong}}{{host}}{{/strong}} "
+"にログインできませんでした。認証情報は以下で変更できます。{{#can_sync}}{{#sync_link}} アカウントとパスワードの同期 {{/"
+"sync_link}} を実行できます。{{/can_sync}}"
 
-#: pkg/dashboard/index.html:155 pkg/lib/machine-add.html:27
+#: pkg/lib/machine-add.html:27 pkg/dashboard/index.html:155
 msgid "Color"
 msgstr "色"
 
@@ -1562,7 +1573,7 @@ msgstr "コマンドは空にすることができません"
 msgid "Command:"
 msgstr "コマンド:"
 
-#: pkg/shell/index.html:283
+#: pkg/shell/index.html:294
 msgid "Comment"
 msgstr "コメント"
 
@@ -1579,11 +1590,11 @@ msgstr "イメージのコミット"
 msgid "Communication with tuned has failed"
 msgstr "tuned との通信に失敗しました"
 
-#: pkg/storaged/content-views.jsx:483
+#: pkg/storaged/content-views.jsx:493
 msgid "Compatible with all systems and devices (MBR)"
 msgstr "すべてのシステムおよびデバイスとの互換性あり (MBR)"
 
-#: pkg/storaged/content-views.jsx:484
+#: pkg/storaged/content-views.jsx:494
 msgid "Compatible with modern system and hard disks > 2TB (GPT)"
 msgstr "最新のシステムとの互換性があり、ハードディスクが 2TB よりも大きい (GPT)"
 
@@ -1601,17 +1612,17 @@ msgstr "コンピューター OU"
 
 #: pkg/systemd/init.js:640
 msgid "Condition $0=$1 was not met"
-msgstr ""
+msgstr "条件 $0=$1 を満たしていませんでした。"
 
 #: pkg/systemd/services.html:130
 msgid "Condition failed"
-msgstr ""
+msgstr "条件が満たされませんでした。"
 
 #: pkg/kubernetes/views/node-add.html:24
 msgid "Configuration"
 msgstr "設定"
 
-#: pkg/networkmanager/interfaces.js:2615
+#: pkg/networkmanager/interfaces.js:2608
 msgid "Configure"
 msgstr "設定"
 
@@ -1635,7 +1646,7 @@ msgstr "設定"
 msgid "Configuring IP"
 msgstr "IP の設定"
 
-#: pkg/shell/index.html:319 pkg/users/index.html:188
+#: pkg/users/index.html:188 pkg/shell/index.html:330
 msgid "Confirm"
 msgstr "確定します"
 
@@ -1644,33 +1655,32 @@ msgid "Confirm New Password"
 msgstr "新規パスワードの確認"
 
 #: pkg/machines/components/deleteDialog.jsx:92
-#, fuzzy
 msgid "Confirm deletion of $0"
-msgstr "$0 の削除を確定してください"
+msgstr "$0 の削除を確定"
 
 #: pkg/ovirt/components/OVirtTab.jsx:67
 msgid "Confirm migration"
-msgstr ""
+msgstr "移行の確定"
 
-#: pkg/storaged/format-dialog.jsx:303
+#: pkg/storaged/format-dialog.jsx:165
 msgid "Confirm passphrase"
 msgstr "パスフレーズの確認"
 
 #: pkg/ovirt/components/VdsmView.jsx:95
 msgid "Confirm reload:"
-msgstr ""
+msgstr "リロードの確認:"
 
 #: pkg/ovirt/components/VdsmView.jsx:108
 msgid "Confirm save:"
-msgstr ""
+msgstr "保存の確認:"
 
+#: pkg/lib/machine-unknown-hostkey.html:22
 #: pkg/kubernetes/views/auth-form.html:130
 #: pkg/kubernetes/views/auth-rejected-cert.html:33
-#: pkg/lib/machine-unknown-hostkey.html:22
 msgid "Connect"
 msgstr "接続"
 
-#: pkg/networkmanager/interfaces.js:2602
+#: pkg/networkmanager/interfaces.js:2595
 msgid "Connect automatically"
 msgstr "自動的に接続"
 
@@ -1680,19 +1690,19 @@ msgstr "接続先"
 
 #: pkg/ovirt/components/InstallationDialog.jsx:103
 msgid "Connect to oVirt Engine"
-msgstr ""
+msgstr "oVirt エンジンに接続"
 
 #: pkg/machines/components/desktopConsole.jsx:126
 msgid "Connect with Remote Viewer"
-msgstr ""
+msgstr "リモートビューアーに接続"
 
 #: pkg/machines/components/desktopConsole.jsx:189
 msgid "Connect with any $0 viewer application."
-msgstr ""
+msgstr "$0 ビューアーアプリケーションに接続します。"
 
 #: pkg/machines/components/desktopConsole.jsx:186
 msgid "Connect with any SPICE or VNC viewer application."
-msgstr ""
+msgstr "SPICE または VNC のビューアーアプリケーションに接続します。"
 
 #: pkg/lib/machine-add.html:39
 msgid ""
@@ -1711,15 +1721,15 @@ msgstr "OSTree への接続"
 msgid "Connecting to SETroubleshoot daemon..."
 msgstr "SETroubleshoot デーモンへの接続中 ..."
 
-#: pkg/shell/indexes.js:399
+#: pkg/shell/indexes.js:327
 msgid "Connecting to the machine"
 msgstr "マシンへの接続"
 
-#: pkg/kubernetes/index.html:104 pkg/kubernetes/registry.html:71
+#: pkg/kubernetes/index.html:101 pkg/kubernetes/registry.html:71
 msgid "Connecting..."
 msgstr "接続中..."
 
-#: pkg/machines/hostvmslist.jsx:504
+#: pkg/machines/hostvmslist.jsx:476
 msgid "Connection"
 msgstr "接続"
 
@@ -1737,15 +1747,15 @@ msgstr "接続設定"
 
 #: src/base1/cockpit.js:3952
 msgid "Connection has timed out."
-msgstr "接続がタイムアウトしました。"
+msgstr "接続がタイムアウトになりました。"
 
 #: pkg/networkmanager/index.html:842
 msgid "Connection will be lost"
 msgstr "接続が失われます"
 
-#: pkg/machines/hostvmslist.jsx:412
+#: pkg/machines/hostvmslist.jsx:410
 msgid "Console"
-msgstr ""
+msgstr "コンソール"
 
 #: pkg/docker/console.html:4 pkg/kubernetes/views/container-body.html:4
 #: pkg/kubernetes/views/container-page-inline.html:2
@@ -1786,10 +1796,10 @@ msgid "Container:"
 msgstr "コンテナー:"
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:280
-#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/kubernetes/views/pod-page.html:36
+#: pkg/kubernetes/views/containers-listing.html:5 pkg/kubernetes/index.html:52
 #: pkg/docker/containers-view.jsx:287
 msgid "Containers"
 msgstr "コンテナー"
@@ -1799,7 +1809,7 @@ msgctxt "page-title"
 msgid "Containers"
 msgstr "コンテナー"
 
-#: pkg/storaged/content-views.jsx:517
+#: pkg/storaged/content-views.jsx:527
 msgid "Content"
 msgstr "コンテンツ"
 
@@ -1826,11 +1836,11 @@ msgstr "{{host}} に接続できませんでした"
 msgid "Could not list services"
 msgstr "サービスを一覧表示できませんでした"
 
-#: src/ws/cockpitcertificate.c:529
+#: src/ws/cockpitcertificate.c:508
 msgid "Could not parse PEM-encoded certificate"
 msgstr "PEM でエンコードされた証明書を解析できませんでした"
 
-#: src/ws/cockpitcertificate.c:496
+#: src/ws/cockpitcertificate.c:475
 msgid "Could not parse PEM-encoded private key"
 msgstr "PEM で暗号化された秘密鍵を解析できませんでした"
 
@@ -1846,11 +1856,11 @@ msgstr "ユーザーグループを変更できませんでした"
 msgid "Couldn't change user password"
 msgstr "ユーザーパスワードを変更できませんでした"
 
-#: pkg/kubernetes/index.html:105 pkg/kubernetes/registry.html:72
+#: pkg/kubernetes/index.html:102 pkg/kubernetes/registry.html:72
 msgid "Couldn't connect to server"
 msgstr "サーバーに接続できませんでした"
 
-#: pkg/shell/indexes.js:402
+#: pkg/shell/indexes.js:330
 msgid "Couldn't connect to the machine"
 msgstr "マシンに接続できませんでした"
 
@@ -1859,7 +1869,7 @@ msgid "Couldn't create new users"
 msgstr "新規ユーザーを作成できませんでした"
 
 #: pkg/kubernetes/scripts/connection.js:512
-#: pkg/kubernetes/scripts/kube-client-cockpit.js:978
+#: pkg/kubernetes/scripts/kube-client-cockpit.js:972
 msgid "Couldn't find running API server"
 msgstr "実行中の API サーバーを見つけることができませんでした"
 
@@ -1898,16 +1908,16 @@ msgstr "クラッシュダンプの場所"
 msgid "Crash system"
 msgstr "クラッシュシステム"
 
-#: pkg/kubernetes/views/project-modify.html:72
-#: pkg/kubernetes/views/add-group-dialog.html:19 pkg/users/index.html:222
-#: pkg/ovirt/components/ClusterTemplates.jsx:78
-#: pkg/storaged/content-views.jsx:119 pkg/storaged/content-views.jsx:650
-#: pkg/storaged/lvol-tabs.jsx:132 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vgroups-panel.jsx:71
+#: pkg/users/index.html:222 pkg/kubernetes/views/project-modify.html:72
+#: pkg/kubernetes/views/add-group-dialog.html:19
+#: pkg/ovirt/components/ClusterTemplates.jsx:77 pkg/storaged/details.jsx:133
+#: pkg/storaged/lvol-tabs.jsx:132 pkg/storaged/content-views.jsx:120
+#: pkg/storaged/content-views.jsx:712 pkg/storaged/overview.js:461
+#: pkg/storaged/overview.js:508
 msgid "Create"
 msgstr "作成"
 
-#: pkg/storaged/content-views.jsx:596
+#: pkg/storaged/content-views.jsx:658
 msgid "Create Logical Volume"
 msgstr "論理ボリュームの作成"
 
@@ -1915,16 +1925,15 @@ msgstr "論理ボリュームの作成"
 msgid "Create New Account"
 msgstr "新規アカウントの作成"
 
-#: pkg/storaged/content-views.jsx:396
+#: pkg/storaged/content-views.jsx:398
 msgid "Create Partition"
 msgstr "パーティションの作成"
 
-#: pkg/storaged/mdraids-panel.jsx:38
+#: pkg/storaged/overview.js:415
 msgid "Create RAID Device"
 msgstr "RAID デバイスの作成"
 
 #: pkg/sosreport/index.html:36
-#, fuzzy
 msgid "Create Report"
 msgstr "レポートの作成"
 
@@ -1932,7 +1941,7 @@ msgstr "レポートの作成"
 msgid "Create Snapshot"
 msgstr "スナップショットの作成"
 
-#: pkg/storaged/content-views.jsx:103 pkg/storaged/content-views.jsx:130
+#: pkg/storaged/content-views.jsx:104 pkg/storaged/content-views.jsx:131
 msgid "Create Thin Volume"
 msgstr "シンボリュームの作成"
 
@@ -1944,11 +1953,11 @@ msgstr "タイマーの作成"
 msgid "Create Timers"
 msgstr "タイマーの作成"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:83
+#: pkg/ovirt/components/ClusterTemplates.jsx:82
 msgid "Create VM"
-msgstr ""
+msgstr "仮想マシンの作成"
 
-#: pkg/storaged/vgroups-panel.jsx:53
+#: pkg/storaged/overview.js:490
 msgid "Create Volume Group"
 msgstr "ボリュームグループの作成"
 
@@ -1964,32 +1973,33 @@ msgstr "空のイメージストリームの作成"
 msgid "Create image stream"
 msgstr "イメージストリームの作成"
 
-#: pkg/networkmanager/interfaces.js:3695 pkg/networkmanager/interfaces.js:3888
-#: pkg/networkmanager/interfaces.js:4127 pkg/networkmanager/interfaces.js:4333
+#: pkg/networkmanager/interfaces.js:3688 pkg/networkmanager/interfaces.js:3881
+#: pkg/networkmanager/interfaces.js:4120 pkg/networkmanager/interfaces.js:4326
 msgid "Create it"
 msgstr "作成"
 
-#: pkg/storaged/content-views.jsx:669
+#: pkg/storaged/content-views.jsx:731
 msgid "Create new Logical Volume"
 msgstr "新規論理ボリュームの作成"
 
-#: pkg/storaged/format-dialog.jsx:317
+#: pkg/storaged/format-dialog.jsx:202
 msgid "Create partition"
 msgstr "パーティションの作成"
 
-#: pkg/storaged/format-dialog.jsx:177
+#: pkg/storaged/format-dialog.jsx:39
 msgid "Create partition on $0"
 msgstr "$0 上でのパーティションの作成"
 
-#: pkg/storaged/content-views.jsx:512
+#: pkg/storaged/index.html:379 pkg/storaged/content-views.jsx:522
 msgid "Create partition table"
 msgstr "パーティションテーブルの作成"
 
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
-#: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:122
+#: pkg/kubernetes/views/replicationcontroller-body.html:7
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:122
 #: pkg/docker/containers-view.jsx:315 pkg/docker/containers-view.jsx:587
 msgid "Created"
 msgstr "作成済み"
@@ -1998,51 +2008,51 @@ msgstr "作成済み"
 msgid "Created:"
 msgstr "作成済み:"
 
-#: pkg/storaged/jobs-panel.jsx:58
+#: pkg/storaged/jobs.js:141
 msgid "Creating RAID Device $target"
 msgstr "RAID デバイス $target の作成"
 
-#: pkg/storaged/jobs-panel.jsx:46
+#: pkg/storaged/jobs.js:129
 msgid "Creating filesystem on $target"
 msgstr "$target 上でのファイルシステムの作成"
 
-#: pkg/storaged/jobs-panel.jsx:72
+#: pkg/storaged/jobs.js:155
 msgid "Creating logical volume $target"
 msgstr "論理ボリューム $target の作成"
 
-#: pkg/storaged/jobs-panel.jsx:50
+#: pkg/storaged/jobs.js:133
 msgid "Creating partition $target"
 msgstr "パーティション $target の作成"
 
-#: pkg/storaged/jobs-panel.jsx:66
+#: pkg/storaged/jobs.js:149
 msgid "Creating snapshot of $target"
 msgstr "$target のスナップショットの作成"
 
-#: pkg/networkmanager/interfaces.js:4332
+#: pkg/networkmanager/interfaces.js:4325
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr "この VLAN を作成すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
 
-#: pkg/networkmanager/interfaces.js:3694
+#: pkg/networkmanager/interfaces.js:3687
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr "このボンドを作成すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
 
-#: pkg/networkmanager/interfaces.js:4126
+#: pkg/networkmanager/interfaces.js:4119
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr "このブリッジを作成すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
 
-#: pkg/networkmanager/interfaces.js:3887
+#: pkg/networkmanager/interfaces.js:3880
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr "このチームを作成すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
 
-#: pkg/storaged/jobs-panel.jsx:67
+#: pkg/storaged/jobs.js:150
 msgid "Creating volume group $target"
 msgstr "ボリュームグループ $target の作成"
 
@@ -2054,11 +2064,11 @@ msgstr "現在の起動"
 msgid "Currently using:"
 msgstr "現在使用中:"
 
-#: pkg/storaged/format-dialog.jsx:69
+#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/format-dialog.jsx:184
 msgid "Custom"
 msgstr "Custom"
 
-#: pkg/storaged/format-dialog.jsx:250
+#: pkg/storaged/format-dialog.jsx:112
 msgid "Custom (Enter filesystem type)"
 msgstr "カスタム (ファイルシステムタイプの入力)"
 
@@ -2066,27 +2076,15 @@ msgstr "カスタム (ファイルシステムタイプの入力)"
 msgid "Custom URL"
 msgstr "カスタム URL"
 
-#: pkg/storaged/format-dialog.jsx:151
-msgid "Custom encryption options"
-msgstr ""
-
-#: pkg/storaged/nfs-panel.jsx:170
-msgid "Custom mount option"
-msgstr ""
-
-#: pkg/storaged/format-dialog.jsx:112
-msgid "Custom mount options"
-msgstr ""
-
-#: pkg/storaged/drive-details.jsx:50
+#: pkg/storaged/index.html:452
 msgid "DISK IS FAILING"
 msgstr "ディスクで障害が発生中"
 
-#: pkg/networkmanager/interfaces.js:3192
+#: pkg/networkmanager/interfaces.js:3185
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2546
+#: pkg/networkmanager/interfaces.js:2539
 msgid "DNS $val"
 msgstr "DNS $val"
 
@@ -2094,11 +2092,11 @@ msgstr "DNS $val"
 msgid "DNS Policy"
 msgstr "DNS ポリシー"
 
-#: pkg/networkmanager/interfaces.js:3196
+#: pkg/networkmanager/interfaces.js:3189
 msgid "DNS Search Domains"
 msgstr "DNS 検索ドメイン"
 
-#: pkg/networkmanager/interfaces.js:2549
+#: pkg/networkmanager/interfaces.js:2542
 msgid "DNS Search Domains $val"
 msgstr "DNS 検索ドメイン $val"
 
@@ -2110,7 +2108,7 @@ msgstr "ダッシュボード"
 msgid "Data Used"
 msgstr "使用済みデータ"
 
-#: pkg/storaged/content-views.jsx:224
+#: pkg/storaged/content-views.jsx:225
 msgid "Deactivate"
 msgstr "解除"
 
@@ -2118,15 +2116,15 @@ msgstr "解除"
 msgid "Deactivating"
 msgstr "非アクティブ化"
 
-#: pkg/storaged/jobs-panel.jsx:65
+#: pkg/storaged/jobs.js:148
 msgid "Deactivating $target"
 msgstr "$target の非アクティブ化"
 
-#: pkg/docker/index.html:350 pkg/docker/index.html:354
-#: pkg/ostree/index.html:253
+#: pkg/ostree/index.html:253 pkg/docker/index.html:350
+#: pkg/docker/index.html:354
 #: node_modules/registry-image-widgets/views/image-config.html:10
-#: pkg/storaged/format-dialog.jsx:68
 #: pkg/subscriptions/subscriptions-register.jsx:101
+#: pkg/storaged/fsys-tab.jsx:125 pkg/storaged/format-dialog.jsx:183
 msgid "Default"
 msgstr "デフォルト"
 
@@ -2134,29 +2132,28 @@ msgstr "デフォルト"
 msgid "Delay"
 msgstr "遅延"
 
+#: pkg/ostree/index.html:38 pkg/users/index.html:77 pkg/users/index.html:405
 #: pkg/docker/index.html:135 pkg/docker/index.html:239
-#: pkg/kubernetes/views/image-delete.html:8
+#: pkg/networkmanager/index.html:575 pkg/kubernetes/views/pv-delete.html:11
 #: pkg/kubernetes/views/imagestream-delete.html:8
-#: pkg/kubernetes/views/item-delete.html:11
 #: pkg/kubernetes/views/node-delete.html:15
-#: pkg/kubernetes/views/project-delete.html:9
-#: pkg/kubernetes/views/pv-delete.html:11
-#: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
-#: pkg/networkmanager/index.html:575 pkg/ostree/index.html:38
-#: pkg/users/index.html:77 pkg/users/index.html:405
-#: pkg/docker/containers-view.jsx:169 pkg/docker/containers-view.jsx:457
-#: pkg/docker/details.js:276 pkg/docker/image.js:141
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:96 pkg/machines/hostvmslist.jsx:112
-#: pkg/storaged/content-views.jsx:266 pkg/storaged/content-views.jsx:287
-#: pkg/storaged/mdraid-details.jsx:282 pkg/storaged/mdraid-details.jsx:300
-#: pkg/storaged/vgroup-details.jsx:215 pkg/storaged/vgroup-details.jsx:233
+#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/kubernetes/views/pvc-delete.html:15
+#: pkg/kubernetes/views/item-delete.html:11
+#: pkg/kubernetes/views/image-delete.html:8
+#: pkg/machines/components/deleteDialog.jsx:96 pkg/machines/hostvmslist.jsx:111
+#: pkg/docker/details.js:276 pkg/docker/containers-view.jsx:169
+#: pkg/docker/containers-view.jsx:457 pkg/docker/image.js:141
+#: pkg/kubernetes/scripts/volumes.js:218 pkg/storaged/details.jsx:105
+#: pkg/storaged/details.jsx:166 pkg/storaged/details.jsx:334
+#: pkg/storaged/details.jsx:383 pkg/storaged/content-views.jsx:267
+#: pkg/storaged/content-views.jsx:288
 msgid "Delete"
 msgstr "削除"
 
-#: pkg/docker/containers-view.jsx:456 pkg/networkmanager/interfaces.js:2330
-#: pkg/users/local.js:1104
+#: pkg/users/local.js:1104 pkg/docker/containers-view.jsx:456
+#: pkg/networkmanager/interfaces.js:2323
 msgid "Delete $0"
 msgstr "$0 の削除"
 
@@ -2190,7 +2187,7 @@ msgstr "選択項目の削除"
 
 #: pkg/machines/components/deleteDialog.jsx:59
 msgid "Delete associated storage files:"
-msgstr ""
+msgstr "関連するストレージファイルの削除:"
 
 #: pkg/kubernetes/views/imagestream-delete.html:3
 msgid "Delete image stream"
@@ -2200,11 +2197,11 @@ msgstr "イメージストリームの削除"
 msgid "Delete {{ item.kind }}"
 msgstr "{{ item.kind }} の削除"
 
-#: pkg/storaged/jobs-panel.jsx:49 pkg/storaged/jobs-panel.jsx:63
+#: pkg/storaged/jobs.js:132 pkg/storaged/jobs.js:146
 msgid "Deleting $target"
 msgstr "$target の削除中"
 
-#: pkg/networkmanager/interfaces.js:2329
+#: pkg/networkmanager/interfaces.js:2322
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2216,23 +2213,23 @@ msgid ""
 "automatically created again in some cases."
 msgstr "ポッドを削除すると、関連するすべてのコンテナーが終了します。ポッドは自動的に再び作成されることもあります。"
 
-#: pkg/storaged/mdraid-details.jsx:283
+#: pkg/storaged/details.jsx:106
 msgid "Deleting a RAID device will erase all data on it."
 msgstr "RAID デバイスを削除すると、そのデバイス上のすべてのデータが削除されます。"
 
-#: pkg/docker/containers-view.jsx:168 pkg/docker/details.js:275
+#: pkg/docker/details.js:275 pkg/docker/containers-view.jsx:168
 msgid "Deleting a container will erase all data in it."
 msgstr "コンテナーを削除すると、コンテナー内のすべてのデータが削除されます。"
 
-#: pkg/storaged/content-views.jsx:243
+#: pkg/storaged/content-views.jsx:244
 msgid "Deleting a logical volume will delete all data in it."
 msgstr "論理ボリュームを削除すると、論理ボリューム内のすべてのデータが削除されます。"
 
-#: pkg/storaged/content-views.jsx:246
+#: pkg/storaged/content-views.jsx:247
 msgid "Deleting a partition will delete all data in it."
 msgstr "パーティションを削除すると、パーティション内のすべてのデータが削除されます。"
 
-#: pkg/storaged/vgroup-details.jsx:214
+#: pkg/storaged/details.jsx:165
 msgid "Deleting a volume group will erase all data on it."
 msgstr "ボリュームグループを削除すると、ボリュームグループ上のすべてのデータが削除されます。"
 
@@ -2244,12 +2241,12 @@ msgid ""
 msgstr ""
 "イメージは、削除しても、多くの場合、後で必要なときに再びダウンロードできます。このイメージがリポジトリーにプッシュされたことがない場合は、イメージを再びダウンロードできません。"
 
-#: pkg/storaged/jobs-panel.jsx:68
+#: pkg/storaged/jobs.js:151
 msgid "Deleting volume group $target"
 msgstr "ボリュームグループ $target の削除"
 
-#: pkg/kubernetes/views/dashboard-page.html:131
 #: pkg/kubernetes/views/deploy.html:62
+#: pkg/kubernetes/views/dashboard-page.html:131
 msgid "Deploy"
 msgstr "デプロイ"
 
@@ -2271,25 +2268,25 @@ msgstr "デプロイメント設定"
 msgid "Deployment Configs"
 msgstr "デプロイメント設定"
 
+#: pkg/systemd/services.html:372 pkg/kubernetes/views/project-modify.html:40
 #: pkg/kubernetes/views/project-listing.html:15
 #: pkg/kubernetes/views/project-listing.html:54
-#: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:372
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:137
-#: pkg/ovirt/components/ClusterVms.jsx:75
-#: pkg/ovirt/components/ClusterVms.jsx:173 pkg/systemd/init.js:270
+#: pkg/ovirt/components/ClusterVms.jsx:74
+#: pkg/ovirt/components/ClusterVms.jsx:174
+#: pkg/ovirt/components/ClusterTemplates.jsx:128 pkg/systemd/init.js:270
 msgid "Description"
 msgstr "説明"
 
+#: pkg/ovirt/components/VmOverviewColumn.jsx:71
 #: pkg/ovirt/components/OVirtTab.jsx:143
-#: pkg/ovirt/components/VmOverviewColumn.jsx:72
 msgid "Description:"
-msgstr ""
+msgstr "詳細:"
 
-#: pkg/kubernetes/index.html:67 pkg/shell/index.html:251
+#: pkg/shell/index.html:262 pkg/kubernetes/index.html:64
+#: pkg/packagekit/updates.jsx:332 pkg/subscriptions/subscriptions-view.jsx:209
 #: pkg/docker/containers-view.jsx:258 pkg/docker/containers-view.jsx:406
 #: pkg/docker/containers-view.jsx:416 pkg/docker/containers-view.jsx:546
-#: pkg/packagekit/updates.jsx:342 pkg/subscriptions/subscriptions-view.jsx:209
 msgid "Details"
 msgstr "詳細"
 
@@ -2297,7 +2294,18 @@ msgstr "詳細"
 msgid "Device"
 msgstr "デバイス"
 
-#: pkg/storaged/content-views.jsx:511 pkg/storaged/format-dialog.jsx:396
+#: pkg/storaged/index.html:542
+msgctxt "storage"
+msgid "Device"
+msgstr "デバイス"
+
+#: pkg/storaged/index.html:465 pkg/storaged/index.html:471
+#: pkg/storaged/index.html:513
+msgctxt "storage"
+msgid "Device File"
+msgstr "デバイスファイル"
+
+#: pkg/storaged/content-views.jsx:521 pkg/storaged/format-dialog.jsx:279
 msgid "Device is read-only"
 msgstr "デバイスは読み取り専用です"
 
@@ -2327,11 +2335,11 @@ msgstr "無効化"
 msgid "Disable tuned"
 msgstr "tuned の無効化"
 
-#: pkg/networkmanager/interfaces.js:1895 pkg/systemd/init.js:303
+#: pkg/systemd/init.js:303 pkg/networkmanager/interfaces.js:1890
 msgid "Disabled"
 msgstr "無効"
 
-#: pkg/shell/simple.html:101 pkg/shell/indexes.js:154 pkg/shell/indexes.js:593
+#: pkg/shell/simple.html:111 pkg/shell/indexes.js:127 pkg/shell/indexes.js:507
 msgid "Disconnected"
 msgstr "切断されています"
 
@@ -2339,7 +2347,7 @@ msgstr "切断されています"
 msgid "Disk"
 msgstr "ディスク"
 
-#: pkg/dashboard/index.html:73 pkg/systemd/index.html:216
+#: pkg/systemd/index.html:216 pkg/dashboard/index.html:73
 msgid "Disk I/O"
 msgstr "ディスク I/O"
 
@@ -2347,18 +2355,18 @@ msgstr "ディスク I/O"
 msgid "Disk Utilization: $0%"
 msgstr "ディスク使用率: $0%˙"
 
-#: pkg/storaged/drive-details.jsx:51
+#: pkg/storaged/index.html:455
 msgid "Disk is OK"
 msgstr "ディスクは OK です"
 
-#: pkg/machines/hostvmslist.jsx:410 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/hostvmslist.jsx:409 pkg/storaged/sidebar-views.jsx:71
+#: pkg/storaged/sidebar-views.jsx:177 pkg/storaged/sidebar-views.jsx:235
+#: pkg/storaged/overview.js:449 pkg/storaged/overview.js:498
 msgid "Disks"
 msgstr "ディスク"
 
-#: pkg/shell/index.html:54 pkg/shell/index.html:116 pkg/shell/simple.html:38
-#: pkg/shell/simple.html:82 pkg/shell/stub.html:42 pkg/shell/stub.html:97
+#: pkg/shell/index.html:49 pkg/shell/index.html:127 pkg/shell/stub.html:37
+#: pkg/shell/stub.html:105 pkg/shell/simple.html:37 pkg/shell/simple.html:92
 msgid "Display Language"
 msgstr "言語の表示"
 
@@ -2443,11 +2451,10 @@ msgid "Domain Administrator Password"
 msgstr "ドメイン管理者パスワード"
 
 #: pkg/systemd/services.html:442 pkg/systemd/services.html:446
-#: pkg/systemd/init.js:1121
 msgid "Don't Repeat"
 msgstr "繰り返さないでください"
 
-#: pkg/storaged/content-views.jsx:476 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/content-views.jsx:486 pkg/storaged/format-dialog.jsx:138
 msgid "Don't overwrite existing data"
 msgstr "既存のデータを上書きしないでください"
 
@@ -2473,23 +2480,21 @@ msgstr "レポートのダウンロード"
 
 #: pkg/machines/components/desktopConsole.jsx:46
 msgid "Download the MSI from $0"
-msgstr ""
+msgstr "MSI を $0 からダウンロードします"
 
 #: pkg/packagekit/updates.jsx:62
-#, fuzzy
 msgid "Downloaded"
-msgstr "ダウンロード"
+msgstr "ダウンロードされました"
 
 #: pkg/packagekit/updates.jsx:54
-#, fuzzy
 msgid "Downloading"
-msgstr "ダウンロード"
+msgstr "ダウンロード中"
 
-#: pkg/docker/storage.jsx:160 pkg/storaged/drive-details.jsx:64
+#: pkg/storaged/index.html:409 pkg/docker/storage.jsx:160
 msgid "Drive"
 msgstr "ドライブ"
 
-#: pkg/storaged/drives-panel.jsx:97 pkg/storaged/drives-panel.jsx:99
+#: pkg/storaged/overview.js:192 pkg/storaged/overview.js:194
 msgctxt "storage"
 msgid "Drive"
 msgstr "ドライブ"
@@ -2498,7 +2503,7 @@ msgstr "ドライブ"
 msgid "Driver"
 msgstr "ドライバー"
 
-#: pkg/storaged/drives-panel.jsx:117
+#: pkg/storaged/index.html:164
 msgid "Drives"
 msgstr "ドライブ"
 
@@ -2510,7 +2515,7 @@ msgstr "重複するエイリアス"
 msgid "Duplicate port"
 msgstr "重複するポート"
 
-#: pkg/storaged/crypto-tab.jsx:135
+#: pkg/storaged/crypto-tab.jsx:140
 msgid "Edit"
 msgstr "編集"
 
@@ -2524,9 +2529,9 @@ msgstr "イメージストリームの編集"
 
 #: pkg/ovirt/components/VdsmView.jsx:125
 msgid "Edit the vdsm.conf"
-msgstr ""
+msgstr "vdsm.conf を編集します"
 
-#: pkg/storaged/jobs-panel.jsx:36
+#: pkg/storaged/jobs.js:119
 msgid "Ejecting $target"
 msgstr "$target の取り出し中"
 
@@ -2545,14 +2550,13 @@ msgstr "空"
 msgid "Empty Directory"
 msgstr "空のディレクトリー"
 
-#: pkg/storaged/jobs-panel.jsx:71
+#: pkg/storaged/jobs.js:154
 msgid "Emptying $target"
 msgstr "$target を空にしています"
 
-#: pkg/machines/hostvmslist.jsx:299
-#, fuzzy
+#: pkg/machines/hostvmslist.jsx:298
 msgid "Emulated Machine:"
-msgstr "仮想マシン"
+msgstr "エミュレートされたマシン:"
 
 #: pkg/systemd/init.js:535
 msgid "Enable"
@@ -2566,39 +2570,36 @@ msgstr "強制的に有効にする"
 msgid "Enabled"
 msgstr "有効"
 
-#: pkg/storaged/utils.js:248
-#, fuzzy
+#: pkg/storaged/storage-controls.jsx:214
 msgid "Encrypted $0"
-msgstr "暗号化されたデータ"
+msgstr "暗号化された $0"
 
-#: pkg/storaged/format-dialog.jsx:244
+#: pkg/storaged/format-dialog.jsx:106
 msgid "Encrypted EXT4 (LUKS)"
 msgstr "暗号化された EXT4 (LUKS)"
 
-#: pkg/storaged/utils.js:240
-#, fuzzy
+#: pkg/storaged/storage-controls.jsx:206
 msgid "Encrypted Logical Volume of $0"
-msgstr "<span>暗号化された $0 の論理ボリューム</span>"
+msgstr "暗号化された $0 の論理ボリューム"
 
-#: pkg/storaged/utils.js:242
-#, fuzzy
+#: pkg/storaged/storage-controls.jsx:208
 msgid "Encrypted Partition of $0"
-msgstr "<span>暗号化された $0 のパーティション</span>†"
+msgstr "暗号化された $0 のパーティション"
 
-#: pkg/storaged/format-dialog.jsx:243
+#: pkg/storaged/format-dialog.jsx:105
 msgid "Encrypted XFS (LUKS)"
 msgstr "暗号化された XFS (LUKS)"
 
-#: pkg/storaged/content-views.jsx:316
+#: pkg/storaged/content-views.jsx:317
 msgctxt "storage-id-desc"
 msgid "Encrypted data"
 msgstr "暗号化されたデータ"
 
-#: pkg/storaged/content-views.jsx:143
+#: pkg/storaged/content-views.jsx:144
 msgid "Encryption"
 msgstr "暗号化"
 
-#: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/format-dialog.jsx:139
+#: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/format-dialog.jsx:177
 msgid "Encryption Options"
 msgstr "暗号化オプション"
 
@@ -2610,8 +2611,8 @@ msgstr "エンドポイント"
 msgid "Endpoint Name"
 msgstr "エンドポイント名"
 
-#: pkg/kubernetes/views/service-page.html:14
 #: pkg/kubernetes/views/service-panel.html:9
+#: pkg/kubernetes/views/service-page.html:14
 msgid "Endpoints"
 msgstr "エンドポイント"
 
@@ -2627,9 +2628,9 @@ msgstr "ポリシーの適用:"
 msgid "Enter IP address or host name"
 msgstr "IP アドレスまたはホスト名の入力"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:76
+#: pkg/ovirt/components/ClusterTemplates.jsx:75
 msgid "Enter New VM name"
-msgstr ""
+msgstr "新規仮想マシン名を入力します"
 
 #: pkg/lib/machine-change-auth.html:57
 msgid ""
@@ -2650,7 +2651,7 @@ msgstr "Entrypoint"
 msgid "Environment"
 msgstr "環境"
 
-#: pkg/storaged/content-views.jsx:474 pkg/storaged/format-dialog.jsx:274
+#: pkg/storaged/content-views.jsx:484 pkg/storaged/format-dialog.jsx:136
 msgid "Erase"
 msgstr "削除"
 
@@ -2662,14 +2663,15 @@ msgstr "コンテナーの削除とストレージプールのリセット"
 msgid "Erase containers, reformat disks, and add them"
 msgstr "コンテナーの削除、ディスクの再フォーマット、およびそれらの追加"
 
-#: pkg/storaged/jobs-panel.jsx:45
+#: pkg/storaged/jobs.js:128
 msgid "Erasing $target"
 msgstr "$target の削除中"
 
-#: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:334 pkg/apps/utils.jsx:104
-#: pkg/storaged/devices.js:101 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:189 pkg/users/local.js:1381
+#: pkg/systemd/services.html:334 pkg/playground/translate.html:100
+#: pkg/playground/translate.html:105 pkg/apps/utils.jsx:101
+#: pkg/users/local.js:1381 pkg/storaged/details.jsx:199
+#: pkg/storaged/storage-controls.jsx:69 pkg/storaged/devices.js:118
+#: pkg/storaged/overview.js:694
 msgid "Error"
 msgstr "エラー"
 
@@ -2713,7 +2715,7 @@ msgstr "Ethernet MAC"
 msgid "Ethernet MTU"
 msgstr "Ethernet MTU"
 
-#: pkg/networkmanager/interfaces.js:1941
+#: pkg/networkmanager/interfaces.js:1936
 msgid "Ethtool"
 msgstr "Ethtool"
 
@@ -2737,17 +2739,17 @@ msgstr "期限切れの署名"
 msgid "Expose container ports"
 msgstr "コンテナーポートの公開"
 
-#: pkg/storaged/content-views.jsx:416 pkg/storaged/format-dialog.jsx:247
+#: pkg/storaged/content-views.jsx:418 pkg/storaged/format-dialog.jsx:109
 msgid "Extended Partition"
 msgstr "拡張パーティション"
 
-#: pkg/storaged/mdraid-details.jsx:98
+#: pkg/storaged/sidebar-views.jsx:122
 msgid "FAILED"
 msgstr "失敗"
 
 #: pkg/ovirt/components/InstallationDialog.jsx:49
 msgid "FQDN"
-msgstr ""
+msgstr "FQDN"
 
 #: pkg/ostree/index.html:258 pkg/networkmanager/interfaces.js:779
 msgid "Failed"
@@ -2757,7 +2759,7 @@ msgstr "失敗"
 msgid "Failed to add machine: $0"
 msgstr "マシンの追加に失敗しました: $0"
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:113 pkg/users/local.js:144
+#: pkg/users/local.js:113 pkg/users/local.js:144 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr "パスワードの変更に失敗しました"
 
@@ -2805,7 +2807,7 @@ msgstr "ファイバーチャネル"
 msgid "File"
 msgstr "File"
 
-#: pkg/storaged/content-views.jsx:141
+#: pkg/storaged/content-views.jsx:142
 msgid "Filesystem"
 msgstr "ファイルシステム"
 
@@ -2817,7 +2819,6 @@ msgstr "ファイルシステムのマウント"
 msgid "Filesystem Name"
 msgstr "ファイルシステム名"
 
-#: pkg/kubernetes/views/pv-modify.html:180
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -2825,20 +2826,26 @@ msgstr "ファイルシステム名"
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:180
 msgid "Filesystem Type"
 msgstr "ファイルシステムタイプ"
 
-#: pkg/storaged/format-dialog.jsx:289
+#: pkg/storaged/format-dialog.jsx:151
 msgid "Filesystem type"
 msgstr "ファイルシステムタイプ"
 
-#: pkg/storaged/fsys-panel.jsx:101
+#: pkg/storaged/index.html:223
 msgid "Filesystems"
 msgstr "ファイルシステム"
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:291
+#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:302
 msgid "Fingerprint"
 msgstr "フィンガープリント"
+
+#: pkg/storaged/index.html:424
+msgctxt "storage"
+msgid "Firmware Version"
+msgstr "ファームウェアバージョン"
 
 #: pkg/kubernetes/scripts/volumes.js:206
 msgid "Flex"
@@ -2854,60 +2861,60 @@ msgstr "Flocker データセット名"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:35
 msgid "Follows docker repo"
-msgstr ""
+msgstr "Docker リポジトリーに順守"
 
 #: pkg/users/index.html:121
 msgid "Force Change"
-msgstr ""
+msgstr "変更の強制"
 
 #: pkg/docker/util.js:506
 msgid "Force Delete"
 msgstr "削除の強制"
 
-#: pkg/machines/hostvmslist.jsx:66
+#: pkg/machines/hostvmslist.jsx:65
 msgid "Force Restart"
 msgstr "再起動の強制"
 
-#: pkg/machines/hostvmslist.jsx:80
+#: pkg/machines/hostvmslist.jsx:79
 msgid "Force Shut Down"
 msgstr "シャットダウンの強制"
 
 #: pkg/users/index.html:374
 msgid "Force password change"
-msgstr ""
+msgstr "パスワード変更の強制"
 
-#: pkg/storaged/content-views.jsx:492 pkg/storaged/format-dialog.jsx:317
-#: pkg/storaged/format-dialog.jsx:397
+#: pkg/storaged/content-views.jsx:502 pkg/storaged/format-dialog.jsx:202
+#: pkg/storaged/format-dialog.jsx:280
 msgid "Format"
 msgstr "フォーマット"
 
-#: pkg/storaged/format-dialog.jsx:179
+#: pkg/storaged/format-dialog.jsx:41
 msgid "Format $0"
 msgstr "$0 のフォーマット"
 
-#: pkg/storaged/content-views.jsx:470
+#: pkg/storaged/content-views.jsx:480
 msgid "Format Disk $0"
 msgstr "ディスク $0 のフォーマット"
 
-#: pkg/storaged/content-views.jsx:493
+#: pkg/storaged/content-views.jsx:503
 msgid "Formatting a disk will erase all data on it."
 msgstr "ディスクをフォーマットすると、ディスク上のすべてのデータが削除されます。"
 
-#: pkg/storaged/format-dialog.jsx:319
+#: pkg/storaged/format-dialog.jsx:204
 msgid "Formatting a storage device will erase all data on it."
 msgstr "ストレージデバイスをフォーマットすると、そのデバイス上のすべてのデータが削除されます。"
 
-#: pkg/networkmanager/interfaces.js:2751
+#: pkg/networkmanager/interfaces.js:2744
 msgid "Forward delay $forward_delay"
 msgstr "フォワード遅延 $forward_delay"
 
 #: pkg/systemd/index.html:265 pkg/docker/storage.jsx:300
-#: pkg/docker/storage.jsx:322 pkg/storaged/pvol-tabs.jsx:54
-#: pkg/systemd/host.js:1476
+#: pkg/docker/storage.jsx:322 pkg/systemd/host.js:1469
+#: pkg/storaged/pvol-tabs.jsx:48
 msgid "Free"
 msgstr "空き"
 
-#: pkg/storaged/content-views.jsx:402
+#: pkg/storaged/content-views.jsx:404
 msgid "Free Space"
 msgstr "空き領域"
 
@@ -2917,7 +2924,7 @@ msgstr "金曜日"
 
 #: node_modules/registry-image-widgets/views/image-listing.html:6
 msgid "From"
-msgstr ""
+msgstr "から"
 
 #: pkg/users/index.html:84 pkg/users/index.html:165
 msgid "Full Name"
@@ -2935,7 +2942,7 @@ msgstr "GCE 永続ディスク"
 msgid "Gateway:"
 msgstr "ゲートウェイ:"
 
-#: pkg/networkmanager/interfaces.js:2593 pkg/systemd/logs.js:411
+#: pkg/networkmanager/interfaces.js:2586
 msgid "General"
 msgstr "全般"
 
@@ -2963,13 +2970,13 @@ msgstr "GlusterFS"
 msgid "Go to"
 msgstr "移動"
 
-#: pkg/apps/application.jsx:108
+#: pkg/apps/application.jsx:93
 msgid "Go to Application"
-msgstr ""
+msgstr "アプリケーションへ移動"
 
-#: pkg/dashboard/index.html:46 pkg/networkmanager/index.html:51
-#: pkg/networkmanager/index.html:538 pkg/systemd/index.html:182
-#: pkg/storaged/plot.jsx:72
+#: pkg/systemd/index.html:182 pkg/networkmanager/index.html:51
+#: pkg/networkmanager/index.html:538 pkg/dashboard/index.html:46
+#: pkg/storaged/index.html:305
 msgid "Go to now"
 msgstr "今すぐ移動"
 
@@ -2980,7 +2987,7 @@ msgstr "優れた署名"
 #: pkg/kubernetes/views/project-body.html:3
 #: pkg/kubernetes/views/project-body.html:8
 msgid "Grant additional push or admin access to specific members below."
-msgstr "以下の特定のメンバーに追加のプッシュまたは管理アクセスを提供します。"
+msgstr "以下の特定のメンバーに、追加のプッシュまたは管理アクセスを提供します。"
 
 #: pkg/kubernetes/views/group-page.html:21
 #: pkg/kubernetes/views/group-panel.html:12
@@ -2996,20 +3003,20 @@ msgstr "グループまたはプロジェクト"
 msgid "Groups"
 msgstr "グループ"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:138
-#: pkg/ovirt/components/ClusterVms.jsx:174
+#: pkg/ovirt/components/ClusterVms.jsx:175
+#: pkg/ovirt/components/ClusterTemplates.jsx:129
 msgid "HA"
-msgstr ""
+msgstr "HA"
 
 #: pkg/ovirt/components/OVirtTab.jsx:127
 msgid "HA:"
-msgstr ""
+msgstr "HA:"
 
 #: pkg/networkmanager/index.html:292
 msgid "Hair Pin mode"
 msgstr "ヘアピンモード"
 
-#: pkg/networkmanager/interfaces.js:2777
+#: pkg/networkmanager/interfaces.js:2770
 msgid "Hairpin mode"
 msgstr "ヘアピンモード"
 
@@ -3017,7 +3024,7 @@ msgstr "ヘアピンモード"
 msgid "Hard Disk"
 msgstr "ハードディスク"
 
-#: pkg/storaged/drives-panel.jsx:85
+#: pkg/storaged/overview.js:180
 msgctxt "storage"
 msgid "Hard Disk"
 msgstr "ハードディスク"
@@ -3026,19 +3033,19 @@ msgstr "ハードディスク"
 msgid "Hardware"
 msgstr "ハードウェア"
 
-#: pkg/networkmanager/interfaces.js:2753
+#: pkg/networkmanager/interfaces.js:2746
 msgid "Hello time $hello_time"
 msgstr "Hello タイム $hello_time"
 
-#: pkg/kubernetes/views/details-page.html:73
+#: pkg/kubernetes/views/route-modify.html:8
 #: pkg/kubernetes/views/route-body.html:9
-#: pkg/kubernetes/views/route-modify.html:8 pkg/machines/vmdiskstab.jsx:56
-#: pkg/ovirt/components/App.jsx:75 pkg/ovirt/components/ClusterVms.jsx:57
-#: pkg/ovirt/components/ClusterVms.jsx:174
+#: pkg/kubernetes/views/details-page.html:73 pkg/machines/vmdiskstab.jsx:56
+#: pkg/ovirt/components/App.jsx:72 pkg/ovirt/components/ClusterVms.jsx:56
+#: pkg/ovirt/components/ClusterVms.jsx:175
 msgid "Host"
 msgstr "ホスト"
 
-#: pkg/dashboard/index.html:135 pkg/systemd/index.html:112
+#: pkg/systemd/index.html:112 pkg/dashboard/index.html:135
 msgid "Host Name"
 msgstr "ホスト名"
 
@@ -3050,28 +3057,24 @@ msgstr "ホストパス"
 msgid "Host key is incorrect"
 msgstr "ホスト鍵が正しくありません"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:78
-msgid "Host to Maintenance"
-msgstr ""
-
 #: pkg/systemd/services.html:458
 msgid "Hour : Minute"
 msgstr "時間: 分"
 
 #: pkg/systemd/init.js:1185 pkg/systemd/init.js:1214
 msgid "Hour needs to be a number between 0-23"
-msgstr "時間は 0〜23 の数字である必要があります"
+msgstr "時間は 0 - 23 の数字である必要があります"
 
 #: pkg/systemd/services.html:424
 msgid "Hours"
 msgstr "時"
 
-#: pkg/systemd/index.html:231 pkg/systemd/host.js:1387
+#: pkg/systemd/index.html:231 pkg/systemd/host.js:1380
 msgid "I/O Wait"
 msgstr "I/O 待機"
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr "IP"
 
@@ -3091,19 +3094,19 @@ msgstr "IP プレフィックスの長さ:"
 msgid "IP Settings"
 msgstr "IP 設定"
 
-#: pkg/networkmanager/interfaces.js:2802
+#: pkg/networkmanager/interfaces.js:2795
 msgid "IPv4"
 msgstr "IPv4"
 
-#: pkg/networkmanager/interfaces.js:3235
+#: pkg/networkmanager/interfaces.js:3228
 msgid "IPv4 Settings"
 msgstr "IPv4 のセッティング"
 
-#: pkg/networkmanager/interfaces.js:2803
+#: pkg/networkmanager/interfaces.js:2796
 msgid "IPv6"
 msgstr "IPv6"
 
-#: pkg/networkmanager/interfaces.js:3235
+#: pkg/networkmanager/interfaces.js:3228
 msgid "IPv6 Settings"
 msgstr "IPv6 のセッティング"
 
@@ -3116,7 +3119,7 @@ msgstr "ISCSI"
 msgid "Id"
 msgstr "ID"
 
-#: pkg/networkmanager/interfaces.js:2794
+#: pkg/networkmanager/interfaces.js:2787
 msgid "Id $id"
 msgstr "Id $id"
 
@@ -3134,13 +3137,13 @@ msgstr "識別子"
 msgid "Identities"
 msgstr "ID"
 
-#: pkg/kubernetes/views/add-user-dialog.html:17
 #: pkg/kubernetes/views/project-listing.html:91
 #: pkg/kubernetes/views/user-modify.html:17
+#: pkg/kubernetes/views/add-user-dialog.html:17
 msgid "Identity"
 msgstr "ID"
 
-#: pkg/networkmanager/interfaces.js:1904 pkg/packagekit/updates.jsx:483
+#: pkg/packagekit/updates.jsx:473 pkg/networkmanager/interfaces.js:1899
 msgid "Ignore"
 msgstr "無視"
 
@@ -3180,23 +3183,22 @@ msgstr "イメージストリーム"
 msgid "Image commands"
 msgstr "イメージコマンド"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:41
+#: node_modules/registry-image-widgets/views/imagestream-body.html:39
 msgid "Image count"
 msgstr "イメージ数"
 
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:12
 msgid "Image stream"
-msgstr ""
+msgstr "イメージストリーム"
 
 #: pkg/docker/index.html:154
 msgid "Image:"
 msgstr "イメージ:"
 
 #: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/kubernetes/index.html:81 pkg/kubernetes/registry.html:49
-#: pkg/docker/containers-view.jsx:615
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:78
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:615
 msgid "Images"
 msgstr "イメージ"
 
@@ -3216,23 +3218,23 @@ msgstr "プロジェクト別イメージ"
 #: node_modules/registry-image-widgets/views/imagestream-body.html:15
 #: node_modules/registry-image-widgets/views/imagestream-body.html:16
 msgid "Images may be pulled by anonymous users"
-msgstr "イメージは匿名ユーザーがプルできます"
+msgstr "イメージは、匿名ユーザーがプルできます"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:20
 #: node_modules/registry-image-widgets/views/imagestream-body.html:21
 msgid "Images may be pulled by any authenticated user or group"
-msgstr "イメージは認証済みユーザーまたはグループがプルできます"
+msgstr "イメージは、認証済みユーザーまたはグループがプルできます"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:25
 #: node_modules/registry-image-widgets/views/imagestream-body.html:26
 msgid "Images may only be pulled by specific users or groups"
-msgstr "イメージは特定のユーザーまたはグループのみがプルできます"
+msgstr "イメージは、特定のユーザーまたはグループのみがプルできます"
 
 #: pkg/kubernetes/views/registry-dashboard-page.html:54
 msgid "Images pushed recently"
 msgstr "最近プッシュされたイメージ"
 
-#: pkg/storaged/mdraid-details.jsx:99
+#: pkg/storaged/sidebar-views.jsx:123
 msgid "In Sync"
 msgstr "同期"
 
@@ -3254,11 +3256,11 @@ msgid ""
 msgstr "ユーザーを同期するには、{{#strong}}{{host}}{{/strong}} にログインする必要があります。"
 
 #: pkg/networkmanager/interfaces.js:761 pkg/networkmanager/interfaces.js:1357
-#: pkg/networkmanager/interfaces.js:1364 pkg/networkmanager/interfaces.js:2496
+#: pkg/networkmanager/interfaces.js:1364 pkg/networkmanager/interfaces.js:2489
 msgid "Inactive"
 msgstr "停止"
 
-#: pkg/storaged/content-views.jsx:570
+#: pkg/storaged/content-views.jsx:615
 msgid "Inactive volume"
 msgstr "非アクティブなボリューム"
 
@@ -3270,46 +3272,45 @@ msgstr "正しくないホストキー"
 msgid "Information about the Docker storage pool is not available."
 msgstr "Docker ストレージプールに関する情報は利用できません。"
 
-#: pkg/packagekit/updates.jsx:442
+#: pkg/packagekit/updates.jsx:432
 msgid "Initializing..."
-msgstr ""
+msgstr "初期化中..."
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
+#: pkg/apps/application.jsx:97 pkg/apps/application-list.jsx:87
 msgid "Install"
-msgstr ""
+msgstr "インストール"
 
-#: pkg/packagekit/updates.jsx:819
+#: pkg/packagekit/updates.jsx:805
 msgid "Install All Updates"
-msgstr ""
+msgstr "すべてのアップデートをインストール"
 
-#: pkg/packagekit/updates.jsx:819 pkg/packagekit/updates.jsx:825
+#: pkg/packagekit/updates.jsx:811
 msgid "Install Security Updates"
-msgstr ""
+msgstr "セキュリティーアップデートのインストール"
 
 #: pkg/selinux/setroubleshoot-view.jsx:360
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
-msgstr "setroubleshoot-server をインストールして SELinux イベントをトラブルシュートします。"
+msgstr "setroubleshoot-server をインストールして、SELinux イベントをトラブルシュートします。"
 
 #: pkg/packagekit/updates.jsx:63
-#, fuzzy
 msgid "Installed"
-msgstr "インストールされた製品"
+msgstr "インストール済み"
 
 #: pkg/subscriptions/subscriptions-view.jsx:222
 msgid "Installed products"
 msgstr "インストールされた製品"
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
-#: pkg/packagekit/updates.jsx:55
+#: pkg/packagekit/updates.jsx:55 pkg/apps/application.jsx:55
+#: pkg/apps/application-list.jsx:47
 msgid "Installing"
-msgstr ""
+msgstr "インストール中"
 
 #: pkg/systemd/services.html:152
 msgid "Instantiate"
 msgstr "インスタンス化"
 
-#: pkg/kubernetes/views/pv-modify.html:169
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:169
 msgid "Interface"
 msgstr "インターフェース"
 
@@ -3317,7 +3318,7 @@ msgstr "インターフェース"
 msgid "Interfaces"
 msgstr "インターフェース"
 
-#: src/ws/login.js:582
+#: src/ws/login.js:579
 msgid "Internal Error: Invalid challenge header"
 msgstr "内部エラー: 無効なチャレンジヘッダー"
 
@@ -3337,11 +3338,11 @@ msgstr "無効なアドレス $0"
 msgid "Invalid credentials"
 msgstr "無効な資格情報"
 
-#: pkg/systemd/host.js:1265 pkg/systemd/shutdown.js:142
+#: pkg/systemd/host.js:1258 pkg/systemd/shutdown.js:142
 msgid "Invalid date format"
 msgstr "無効な日付形式"
 
-#: pkg/systemd/host.js:1261 pkg/systemd/shutdown.js:138
+#: pkg/systemd/host.js:1254 pkg/systemd/shutdown.js:138
 msgid "Invalid date format and invalid time format"
 msgstr "無効な日付形式と無効な時間形式"
 
@@ -3351,7 +3352,7 @@ msgstr "無効な日付形式。"
 
 #: pkg/users/local.js:1161
 msgid "Invalid expiration date"
-msgstr ""
+msgstr "無効な有効期限"
 
 #: pkg/lib/credentials.js:285
 msgid "Invalid file permissions"
@@ -3367,7 +3368,7 @@ msgstr "無効なメトリック $0"
 
 #: pkg/users/local.js:1234
 msgid "Invalid number of days"
-msgstr ""
+msgstr "無効な日数"
 
 #: pkg/systemd/init.js:1171
 msgid "Invalid number."
@@ -3385,7 +3386,7 @@ msgstr "無効なプレフィックス $0"
 msgid "Invalid prefix or netmask $0"
 msgstr "無効なプレフィックスまたはネットマスク $0"
 
-#: pkg/systemd/host.js:1263 pkg/systemd/shutdown.js:140
+#: pkg/systemd/host.js:1256 pkg/systemd/shutdown.js:140
 msgid "Invalid time format"
 msgstr "無効な時間形式"
 
@@ -3393,8 +3394,8 @@ msgstr "無効な時間形式"
 msgid "Invalid time zone"
 msgstr "無効なタイムゾーン"
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
-#: pkg/subscriptions/subscriptions-client.js:194
+#: pkg/subscriptions/subscriptions-client.js:194 pkg/storaged/overview.js:582
+#: pkg/storaged/overview.js:673
 msgid "Invalid username or password"
 msgstr "無効なユーザー名またはパスワード"
 
@@ -3402,7 +3403,7 @@ msgstr "無効なユーザー名またはパスワード"
 msgid "Is sshd running on a different port?"
 msgstr "sshd が別のポートで実行されていますか?"
 
-#: pkg/storaged/job-views.jsx:51 pkg/storaged/jobs-panel.jsx:168
+#: pkg/storaged/index.html:278
 msgid "Jobs"
 msgstr "ジョブ"
 
@@ -3451,14 +3452,13 @@ msgstr "Kerberos ベース SSO"
 msgid "Kerberos Ticket"
 msgstr "Kerberos チケット"
 
-#: pkg/systemd/index.html:235 pkg/systemd/host.js:1388
+#: pkg/systemd/index.html:235 pkg/systemd/host.js:1381
 msgid "Kernel"
 msgstr "カーネル"
 
 #: pkg/kdump/index.html:23
-#, fuzzy
 msgid "Kernel Dump"
-msgstr "カーネル"
+msgstr "カーネルダンプ"
 
 #: pkg/kubernetes/views/node-body.html:19
 msgid "Kernel Version"
@@ -3480,11 +3480,12 @@ msgstr "Kubernetes クラスター"
 msgid "LACP Key"
 msgstr "LACP キー"
 
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
-#: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
+#: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "ラベル"
@@ -3517,9 +3518,9 @@ msgstr "最後のトリガー"
 msgid "Last Updated"
 msgstr "最終更新日"
 
-#: pkg/packagekit/updates.jsx:211
+#: pkg/packagekit/updates.jsx:201
 msgid "Last checked: $0 ago"
-msgstr ""
+msgstr "最終確認: $0 前"
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
@@ -3528,7 +3529,7 @@ msgstr "最新バージョン"
 
 #: pkg/machines/components/desktopConsole.jsx:129
 msgid "Launch Remote Viewer"
-msgstr ""
+msgstr "リモートビューアーの起動"
 
 #: pkg/realmd/operation.js:102
 msgid "Leave"
@@ -3544,7 +3545,7 @@ msgid ""
 "you enter a different username, that user will always be used when "
 "connecting to this machine."
 msgstr ""
-"現在ログインしているユーザーとしてこのマシンに接続する場合は空白のままにします。異なるユーザー名を入力した場合は、このマシンへの接続時にそのユーザーが常に使用されます。"
+"現在ログインしているユーザーとしてこのマシンに接続する場合は空白のままにします。別のユーザー名を入力した場合は、このマシンへの接続時にそのユーザーが常に使用されます。"
 
 #: pkg/lib/machine-change-auth.html:23
 msgid ""
@@ -3553,8 +3554,10 @@ msgid ""
 "different username, that user will always be used connecting to this machine."
 ""
 msgstr ""
+"現在ログインしているユーザー {{#default_user}} ({{default_user}}){{/default_user}} "
+"としてこのマシンに接続する場合は空白のままにします。別のユーザー名を入力すると、このマシンへの接続時にそのユーザーが常に使用されます。"
 
-#: pkg/shell/index.html:92 pkg/shell/simple.html:66 pkg/shell/stub.html:73
+#: pkg/shell/index.html:103 pkg/shell/stub.html:81 pkg/shell/simple.html:76
 msgid "Licensed under:"
 msgstr "ライセンス保持者:"
 
@@ -3570,7 +3573,7 @@ msgstr "リンクの監視"
 msgid "Link down delay"
 msgstr "リンクダウンの遅延"
 
-#: pkg/networkmanager/interfaces.js:1892 pkg/networkmanager/interfaces.js:1902
+#: pkg/networkmanager/interfaces.js:1887 pkg/networkmanager/interfaces.js:1897
 msgid "Link local"
 msgstr "ローカルリンク"
 
@@ -3590,7 +3593,7 @@ msgstr "リンク"
 msgid "Links:"
 msgstr "リンク:"
 
-#: pkg/networkmanager/interfaces.js:1928
+#: pkg/networkmanager/interfaces.js:1923
 msgid "Load Balancing"
 msgstr "ロードバランシング"
 
@@ -3599,17 +3602,16 @@ msgid "Load earlier entries"
 msgstr "以前のエントリーのロード"
 
 #: pkg/packagekit/updates.jsx:39
-#, fuzzy
 msgid "Loading available updates failed"
-msgstr "利用可能な認証情報の使用"
+msgstr "利用可能なアップデートのロードに失敗しました"
 
 #: pkg/packagekit/updates.jsx:32
 msgid "Loading available updates, please wait..."
-msgstr ""
+msgstr "利用可能なアップデートをロード中です。しばらくお待ちください..."
 
 #: pkg/ovirt/components/VdsmView.jsx:36
 msgid "Loading data ..."
-msgstr ""
+msgstr "データのロード中..."
 
 #: pkg/kdump/kdump-view.jsx:370 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
 #: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
@@ -3628,15 +3630,11 @@ msgstr "ローカルディスク"
 msgid "Local Filesystem"
 msgstr "ローカルファイルシステム"
 
-#: pkg/storaged/nfs-panel.jsx:150
-msgid "Local Mount Point"
-msgstr ""
-
 #: pkg/kdump/kdump-view.jsx:174
 msgid "Location"
 msgstr "場所"
 
-#: pkg/storaged/content-views.jsx:208
+#: pkg/storaged/content-views.jsx:209
 msgid "Lock"
 msgstr "ロック"
 
@@ -3646,17 +3644,17 @@ msgstr "アカウントのロック"
 
 #: pkg/users/local.js:843 pkg/users/local.js:1143
 msgid "Lock account on $0"
-msgstr ""
+msgstr "$0 のアカウントをロック"
 
-#: pkg/shell/index.html:38
+#: pkg/shell/index.html:33
 msgid "Lock to prevent privileged tasks"
 msgstr "特権タスクを防ぐためにロック"
 
-#: pkg/shell/index.html:36
+#: pkg/shell/index.html:31
 msgid "Locked"
 msgstr "ロック"
 
-#: pkg/storaged/jobs-panel.jsx:38
+#: pkg/storaged/jobs.js:121
 msgid "Locking $target"
 msgstr "$target のロック中"
 
@@ -3664,12 +3662,11 @@ msgstr "$target のロック中"
 msgid "Log In"
 msgstr "ログイン"
 
-#: pkg/shell/index.html:72 pkg/shell/simple.html:46 pkg/shell/stub.html:53
-#, fuzzy
+#: pkg/shell/index.html:67 pkg/shell/stub.html:45 pkg/shell/simple.html:45
 msgid "Log Out"
 msgstr "ログアウト"
 
-#: pkg/shell/simple.html:108
+#: pkg/shell/simple.html:118
 msgid "Log in again"
 msgstr "再ログイン"
 
@@ -3693,30 +3690,29 @@ msgstr "ログメッセージ"
 msgid "Logged In"
 msgstr "すでにログインしています"
 
-#: pkg/kubernetes/views/pv-modify.html:158
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:158
 msgid "Logical Unit Number"
 msgstr "論理ユニット番号"
 
-#: pkg/storaged/utils.js:178
+#: pkg/storaged/utils.js:179
 msgid "Logical Volume"
 msgstr "論理ボリューム"
 
-#: pkg/storaged/utils.js:176
+#: pkg/storaged/utils.js:177
 msgid "Logical Volume (Snapshot)"
 msgstr "論理ボリューム (スナップショット)"
 
-#: pkg/storaged/utils.js:244
-#, fuzzy
+#: pkg/storaged/storage-controls.jsx:210
 msgid "Logical Volume of $0"
-msgstr "論理ボリューム"
+msgstr "$0 の論理ボリューム"
 
 #: pkg/subscriptions/subscriptions-register.jsx:140
 msgid "Login"
 msgstr "ログイン"
 
-#: src/ws/login.js:257
+#: src/ws/login.js:254
 msgid "Login Again"
 msgstr "再ログイン"
 
@@ -3736,12 +3732,12 @@ msgstr "ログインが失敗しました"
 msgid "Login/password or activation key required to register."
 msgstr "ログイン/パスワードまたはアクティベーションキーを登録する必要があります。"
 
-#: src/ws/login.js:258
+#: src/ws/login.js:255
 msgid "Logout Successful"
 msgstr "ログアウトが正常に行われました"
 
-#: pkg/kubernetes/views/container-page-inline.html:8
-#: pkg/kubernetes/views/container-panel.html:6 pkg/systemd/logs.html:68
+#: pkg/systemd/logs.html:68 pkg/kubernetes/views/container-page-inline.html:8
+#: pkg/kubernetes/views/container-panel.html:6
 msgid "Logs"
 msgstr "ログ"
 
@@ -3753,31 +3749,27 @@ msgstr "接続が失われました。再接続の試行中です"
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/vmnetworktab.jsx:69
-msgid "MAC Address"
-msgstr ""
-
 #: pkg/docker/index.html:185
 msgid "MAC Address:"
 msgstr "MAC アドレス:"
 
-#: pkg/ovirt/provider.es6:238
+#: pkg/ovirt/provider.es6:228
 msgid "MIGRATE action failed"
-msgstr ""
+msgstr "MIGRATE アクションに失敗しました"
 
-#: pkg/networkmanager/interfaces.js:1920
+#: pkg/networkmanager/interfaces.js:1915
 msgid "MII (Recommended)"
 msgstr "MII (推奨)"
 
-#: pkg/machines/vmnetworktab.jsx:90 pkg/networkmanager/interfaces.js:2651
+#: pkg/networkmanager/interfaces.js:2644
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4398
+#: pkg/networkmanager/interfaces.js:4391
 msgid "MTU must be a positive number"
 msgstr "MTU は正の数値である必要があります"
 
-#: pkg/kubernetes/views/node-body.html:15 pkg/systemd/index.html:95
+#: pkg/systemd/index.html:95 pkg/kubernetes/views/node-body.html:15
 msgid "Machine ID"
 msgstr "マシン ID"
 
@@ -3785,34 +3777,30 @@ msgstr "マシン ID"
 msgid "Machine SSH Key Fingerprints"
 msgstr "マシンSSH 鍵フィンガープリント"
 
-#: pkg/shell/indexes.js:293
+#: pkg/shell/index.html:81 pkg/shell/stub.html:59 pkg/shell/simple.html:56
+#: pkg/shell/indexes.js:264
 msgid "Machines"
 msgstr "マシン"
-
-#: pkg/machines/vmnetworktab.jsx:92
-msgid "Managed"
-msgstr ""
 
 #: pkg/kubernetes/scripts/dashboard.js:459
 msgid "Manifest"
 msgstr "マニフェスト"
 
-#: pkg/networkmanager/interfaces.js:1893 pkg/networkmanager/interfaces.js:1903
+#: pkg/networkmanager/interfaces.js:1888 pkg/networkmanager/interfaces.js:1898
 msgid "Manual"
 msgstr "手作業"
 
 #: pkg/machines/components/desktopConsole.jsx:194
-#, fuzzy
 msgid "Manual Connection"
-msgstr "接続"
+msgstr "手動接続"
 
 #: pkg/systemd/index.html:393 pkg/systemd/index.html:397
 msgid "Manually"
 msgstr "手動"
 
-#: pkg/storaged/jobs-panel.jsx:56
+#: pkg/storaged/jobs.js:139
 msgid "Marking $target as faulty"
-msgstr "$target を問題があるものとしてマークする"
+msgstr "$target を、問題があるものとしてマークする"
 
 #: pkg/systemd/init.js:540
 msgid "Mask"
@@ -3822,11 +3810,11 @@ msgstr "マスク"
 msgid "Mask Forcefully"
 msgstr "強制的にマスク"
 
-#: pkg/networkmanager/interfaces.js:2657
+#: pkg/networkmanager/interfaces.js:2650
 msgid "Master"
 msgstr "マスター"
 
-#: pkg/networkmanager/interfaces.js:2755
+#: pkg/networkmanager/interfaces.js:2748
 msgid "Maximum message age $max_age"
 msgstr "メッセージ最大期間 $max_age"
 
@@ -3838,17 +3826,18 @@ msgstr "普通"
 msgid "Member of"
 msgstr "メンバー"
 
-#: pkg/storaged/content-views.jsx:313
+#: pkg/storaged/content-views.jsx:314
 msgid "Member of RAID Device"
 msgstr "RAID デバイスのメンバー"
 
-#: pkg/storaged/content-views.jsx:309
+#: pkg/storaged/content-views.jsx:310
 msgid "Member of RAID Device $0"
 msgstr "RAID デバイス $0 のメンバー"
 
+#: pkg/networkmanager/index.html:315
 #: pkg/kubernetes/views/project-listing.html:16
 #: pkg/kubernetes/views/project-listing.html:55
-#: pkg/networkmanager/index.html:315 pkg/networkmanager/interfaces.js:2876
+#: pkg/networkmanager/interfaces.js:2869
 msgid "Members"
 msgstr "メンバー"
 
@@ -3859,16 +3848,16 @@ msgstr "メンバー"
 msgid "Membership"
 msgstr "メンバーシップ"
 
-#: pkg/dashboard/index.html:71 pkg/docker/index.html:264
-#: pkg/playground/translate.html:90 pkg/systemd/index.html:211
-#: pkg/docker/containers-view.jsx:271 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
-#: pkg/ovirt/components/ClusterTemplates.jsx:137
-#: pkg/ovirt/components/ClusterVms.jsx:173
+#: pkg/docker/index.html:264 pkg/systemd/index.html:211
+#: pkg/playground/translate.html:90 pkg/dashboard/index.html:71
+#: pkg/ovirt/components/ClusterVms.jsx:174
+#: pkg/ovirt/components/ClusterTemplates.jsx:128
+#: pkg/docker/containers-view.jsx:271 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830 pkg/kubernetes/scripts/graphs.js:604
 msgid "Memory"
 msgstr "メモリ"
 
-#: pkg/systemd/host.js:1440
+#: pkg/systemd/host.js:1433
 msgctxt "page-title"
 msgid "Memory"
 msgstr "メモリー"
@@ -3885,12 +3874,12 @@ msgstr "メモリー制限"
 msgid "Memory usage:"
 msgstr "メモリー使用状況:"
 
-#: pkg/machines/hostvmslist.jsx:290
+#: pkg/machines/hostvmslist.jsx:289
 msgid "Memory:"
 msgstr "メモリー:"
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr "メッセージ"
 
@@ -3898,8 +3887,8 @@ msgstr "メッセージ"
 msgid "Message to logged in users"
 msgstr "ログインしているユーザーへのメッセージ"
 
-#: pkg/kubernetes/views/image-page.html:29
 #: pkg/kubernetes/views/imagestream-page.html:30
+#: pkg/kubernetes/views/image-page.html:29
 #: node_modules/registry-image-widgets/views/image-panel.html:15
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:14
 msgid "Metadata"
@@ -3915,11 +3904,11 @@ msgstr "MiB"
 
 #: pkg/ovirt/components/OVirtTab.jsx:72
 msgid "Migrate To:"
-msgstr ""
+msgstr "移行先:"
 
 #: pkg/systemd/init.js:1191 pkg/systemd/init.js:1200 pkg/systemd/init.js:1209
 msgid "Minute needs to be a number between 0-59"
-msgstr "分は 0〜59 の数字である必要があります"
+msgstr "分は 0 - 59 の数字である必要があります"
 
 #: pkg/systemd/services.html:423
 msgid "Minutes"
@@ -3929,16 +3918,16 @@ msgstr "分"
 msgid "Mode"
 msgstr "モード"
 
-#: pkg/machines/vmnetworktab.jsx:68
-msgid "Model type"
-msgstr ""
+#: pkg/storaged/index.html:419
+msgctxt "storage"
+msgid "Model"
+msgstr "モデル"
 
 #: pkg/kubernetes/views/user-modify.html:27
 msgid "Modify"
 msgstr "修正"
 
-#: pkg/storaged/jobs-panel.jsx:39 pkg/storaged/jobs-panel.jsx:44
-#: pkg/storaged/jobs-panel.jsx:48
+#: pkg/storaged/jobs.js:122 pkg/storaged/jobs.js:127 pkg/storaged/jobs.js:131
 msgid "Modifying $target"
 msgstr "$target の変更"
 
@@ -3964,20 +3953,19 @@ msgstr "詳細表示"
 
 #: pkg/machines/components/desktopConsole.jsx:102
 #: pkg/machines/components/desktopConsole.jsx:110
-#, fuzzy
 msgid "More Information"
-msgstr "設定"
+msgstr "詳細情報"
 
 #: pkg/kdump/kdump-view.jsx:447
 msgid "More details"
 msgstr "詳細"
 
-#: pkg/packagekit/updates.jsx:285
+#: pkg/packagekit/updates.jsx:275
 msgid "More information…"
-msgstr ""
+msgstr "詳細情報…"
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:167
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-panel.jsx:277
+#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:188
+#: pkg/storaged/fsys-tab.jsx:217
 msgid "Mount"
 msgstr "マウント"
 
@@ -3985,150 +3973,129 @@ msgstr "マウント"
 msgid "Mount Location"
 msgstr "マウント場所"
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-panel.jsx:160
+#: pkg/storaged/fsys-tab.jsx:137 pkg/storaged/fsys-tab.jsx:199
+#: pkg/storaged/format-dialog.jsx:195
 msgid "Mount Options"
 msgstr "マウントオプション"
 
-#: pkg/storaged/format-dialog.jsx:74 pkg/storaged/fsys-panel.jsx:107
-#: pkg/storaged/fsys-tab.jsx:161 pkg/storaged/nfs-panel.jsx:345
+#: pkg/storaged/index.html:229 pkg/storaged/fsys-tab.jsx:130
+#: pkg/storaged/fsys-tab.jsx:182 pkg/storaged/format-dialog.jsx:189
 msgid "Mount Point"
 msgstr "マウントポイント"
-
-#: pkg/storaged/format-dialog.jsx:86 pkg/storaged/nfs-panel.jsx:162
-msgid "Mount at boot"
-msgstr ""
 
 #: pkg/docker/index.html:511
 msgid "Mount container volumes"
 msgstr "マウントコンテナーボリューム"
 
-#: pkg/storaged/format-dialog.jsx:84
-msgid "Mount options"
-msgstr ""
-
-#: pkg/storaged/format-dialog.jsx:81
-msgid "Mount point can not be empty"
-msgstr ""
-
-#: pkg/storaged/nfs-panel.jsx:154
-msgid "Mount point cannot be empty."
-msgstr ""
-
-#: pkg/storaged/nfs-panel.jsx:156
-msgid "Mount point must start with \"/\"."
-msgstr ""
-
-#: pkg/storaged/format-dialog.jsx:99 pkg/storaged/nfs-panel.jsx:166
-msgid "Mount read only"
-msgstr ""
-
-#: pkg/storaged/fsys-tab.jsx:191
+#: pkg/storaged/fsys-tab.jsx:212
 msgid "Mounted At"
 msgstr "マウント場所"
 
-#: pkg/storaged/format-dialog.jsx:66
+#: pkg/storaged/fsys-tab.jsx:123 pkg/storaged/format-dialog.jsx:181
 msgid "Mounting"
 msgstr "マウント"
 
-#: pkg/storaged/jobs-panel.jsx:42
+#: pkg/storaged/jobs.js:125
 msgid "Mounting $target"
 msgstr "$target のマウント"
+
+#: pkg/storaged/index.html:506
+msgctxt "storage"
+msgid "Multipathed Devices"
+msgstr "マルチパスデバイス"
 
 #: pkg/kubernetes/scripts/volumes.js:858
 msgid "NFS"
 msgstr "NFS"
 
-#: pkg/kubernetes/scripts/volumes.js:199 pkg/storaged/nfs-panel.jsx:125
+#: pkg/kubernetes/scripts/volumes.js:199
 msgid "NFS Mount"
 msgstr "NFS マウント"
 
-#: pkg/storaged/nfs-panel.jsx:338
-msgid "NFS Mounts"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1943
+#: pkg/networkmanager/interfaces.js:1938
 msgid "NSNA Ping"
 msgstr "NSNA Ping"
 
-#: pkg/storaged/format-dialog.jsx:246
+#: pkg/storaged/format-dialog.jsx:108
 msgid "NTFS - Compatible with most systems"
 msgstr "NTFS - 最新システムとの互換性あり"
 
-#: pkg/systemd/host.js:1321
+#: pkg/systemd/host.js:1314
 msgid "NTP Server"
 msgstr "NTP サーバー"
 
-#: pkg/docker/index.html:260 pkg/kubernetes/views/add-user-dialog.html:9
-#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/ostree/index.html:99 pkg/docker/index.html:260
+#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
+#: pkg/networkmanager/index.html:151 pkg/networkmanager/index.html:207
+#: pkg/networkmanager/index.html:306 pkg/networkmanager/index.html:406
+#: pkg/kubernetes/views/project-modify.html:16
+#: pkg/kubernetes/views/add-group-dialog.html:9
+#: pkg/kubernetes/views/volume-body.html:31
+#: pkg/kubernetes/views/node-add.html:16 pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/dashboard-page.html:156
 #: pkg/kubernetes/views/dashboard-page.html:198
+#: pkg/kubernetes/views/project-listing.html:14
+#: pkg/kubernetes/views/project-listing.html:53
+#: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/details-page.html:34
 #: pkg/kubernetes/views/details-page.html:70
 #: pkg/kubernetes/views/details-page.html:103
 #: pkg/kubernetes/views/details-page.html:137
 #: pkg/kubernetes/views/details-page.html:171
-#: pkg/kubernetes/views/imagestream-modify.html:10
-#: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
-#: pkg/kubernetes/views/project-listing.html:14
-#: pkg/kubernetes/views/project-listing.html:53
-#: pkg/kubernetes/views/project-listing.html:90
-#: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
-#: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
-#: pkg/kubernetes/views/volume-body.html:31
+#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/service-modify.html:9
+#: pkg/kubernetes/views/add-user-dialog.html:9
+#: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/volumes-page.html:19
 #: pkg/kubernetes/views/volumes-page.html:57
-#: pkg/kubernetes/views/add-group-dialog.html:9
-#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
-#: pkg/networkmanager/index.html:151 pkg/networkmanager/index.html:207
-#: pkg/networkmanager/index.html:306 pkg/networkmanager/index.html:406
-#: pkg/ostree/index.html:99
+#: pkg/kubernetes/views/nodes-page.html:41 pkg/storaged/index.html:228
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
+#: pkg/packagekit/updates.jsx:329 pkg/machines/hostvmslist.jsx:476
+#: pkg/ovirt/components/ClusterVms.jsx:174
+#: pkg/ovirt/components/ClusterTemplates.jsx:128
 #: pkg/docker/containers-view.jsx:271 pkg/docker/containers-view.jsx:587
-#: pkg/machines/hostvmslist.jsx:504
-#: pkg/ovirt/components/ClusterTemplates.jsx:137
-#: pkg/ovirt/components/ClusterVms.jsx:173 pkg/packagekit/updates.jsx:339
-#: pkg/storaged/content-views.jsx:106 pkg/storaged/content-views.jsx:599
-#: pkg/storaged/format-dialog.jsx:285 pkg/storaged/fsys-panel.jsx:106
-#: pkg/storaged/fsys-tab.jsx:71 pkg/storaged/fsys-tab.jsx:151
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
+#: pkg/storaged/fsys-tab.jsx:71 pkg/storaged/fsys-tab.jsx:172
+#: pkg/storaged/part-tab.jsx:37 pkg/storaged/details.jsx:127
 #: pkg/storaged/lvol-tabs.jsx:39 pkg/storaged/lvol-tabs.jsx:118
 #: pkg/storaged/lvol-tabs.jsx:155 pkg/storaged/lvol-tabs.jsx:192
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:37
-#: pkg/storaged/vgroup-details.jsx:180 pkg/storaged/vgroups-panel.jsx:56
+#: pkg/storaged/content-views.jsx:107 pkg/storaged/content-views.jsx:661
+#: pkg/storaged/format-dialog.jsx:147 pkg/storaged/overview.js:418
+#: pkg/storaged/overview.js:493 pkg/storaged/overview.js:629
+#: pkg/storaged/overview.js:707
 msgid "Name"
 msgstr "名前"
 
-#: pkg/storaged/utils.js:132
+#: pkg/storaged/utils.js:133
 msgid "Name cannot be empty."
-msgstr "名前は空にすることができません。"
+msgstr "名前は、空にすることができません。"
 
-#: pkg/storaged/utils.js:134
+#: pkg/storaged/utils.js:135
 msgid "Name cannot be longer than 127 characters."
-msgstr "名前は 127 文字を超えることができません。"
+msgstr "名前は、127 文字を超えることができません。"
 
-#: pkg/storaged/utils.js:138
+#: pkg/storaged/utils.js:139
 msgid "Name cannot contain the character '$0'."
-msgstr "名前には文字 '$0' を含めることができません。"
+msgstr "名前には、文字 '$0' を使用することができません。"
 
-#: pkg/storaged/utils.js:140
+#: pkg/storaged/utils.js:141
 msgid "Name cannot contain whitespace."
-msgstr "名前にはスペースを含めることができません。"
+msgstr "名前には、スペースを使用することができません。"
 
-#: pkg/kubernetes/views/containers-listing.html:14
-#: pkg/kubernetes/views/dashboard-page.html:160
+#: pkg/kubernetes/views/pod-body.html:5
 #: pkg/kubernetes/views/deploymentconfig-body.html:5
+#: pkg/kubernetes/views/pv-claim.html:6
+#: pkg/kubernetes/views/dashboard-page.html:160
+#: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
 #: pkg/kubernetes/views/details-page.html:139
 #: pkg/kubernetes/views/details-page.html:173
-#: pkg/kubernetes/views/pod-body.html:5 pkg/kubernetes/views/pv-claim.html:6
 #: pkg/kubernetes/views/replicationcontroller-body.html:5
-#: pkg/kubernetes/views/route-body.html:5
+#: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
 msgid "Namespace"
@@ -4138,11 +4105,11 @@ msgstr "名前空間"
 msgid "Namespace cannot be empty."
 msgstr "名前空間は空にすることができません。"
 
-#: pkg/systemd/host.js:1184
+#: pkg/systemd/host.js:1177
 msgid "Need at least one NTP server"
 msgstr "少なくとも 1 つの NTP サーバーが必要です"
 
-#: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
+#: pkg/playground/translate.html:95 pkg/dashboard/index.html:72
 #: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "ネットワーク"
@@ -4155,7 +4122,7 @@ msgstr "ネットワークトラフィック"
 msgid "Networking"
 msgstr "ネットワーキング"
 
-#: pkg/networkmanager/interfaces.js:1565 pkg/networkmanager/interfaces.js:2137
+#: pkg/networkmanager/interfaces.js:1562 pkg/networkmanager/interfaces.js:2132
 msgctxt "page-title"
 msgid "Networking"
 msgstr "ネットワーク"
@@ -4164,31 +4131,23 @@ msgstr "ネットワーク"
 msgid "Networking Logs"
 msgstr "ネットワークログ"
 
-#: pkg/machines/hostvmslist.jsx:411
-msgid "Networks"
-msgstr ""
-
 #: pkg/users/local.js:926
 msgid "Never"
 msgstr "しない"
 
 #: pkg/users/index.html:345 pkg/users/local.js:832
 msgid "Never expire password"
-msgstr ""
+msgstr "パスワードは失効しない"
 
 #: pkg/users/index.html:306 pkg/users/local.js:840
 msgid "Never lock account"
-msgstr ""
+msgstr "アカウントをロックしない"
 
 #: pkg/kubernetes/views/project-listing.html:46
 msgid "New Group"
 msgstr "新規グループ"
 
-#: pkg/storaged/nfs-panel.jsx:125
-msgid "New NFS Mount"
-msgstr ""
-
-#: pkg/shell/index.html:311 pkg/users/index.html:249
+#: pkg/users/index.html:249 pkg/shell/index.html:322
 msgid "New Password"
 msgstr "新規パスワード"
 
@@ -4201,7 +4160,7 @@ msgstr "新規プロジェクト"
 msgid "New image stream"
 msgstr "新規イメージストリーム"
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:121
+#: pkg/users/local.js:121 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr "新規パスワードは受け入れられませんでした"
 
@@ -4211,7 +4170,7 @@ msgstr "新規パスワードは受け入れられませんでした"
 msgid "New project"
 msgstr "新規プロジェクト"
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/overview.js:538
 msgid "Next"
 msgstr "次へ"
 
@@ -4219,13 +4178,13 @@ msgstr "次へ"
 msgid "Next Run"
 msgstr "次回の実行日時"
 
-#: pkg/systemd/index.html:243 pkg/systemd/host.js:1390
+#: pkg/systemd/index.html:243 pkg/systemd/host.js:1383
 msgid "Nice"
-msgstr "Nice値"
+msgstr "Nice 値"
 
 #: pkg/docker/index.html:534 pkg/docker/index.html:538 pkg/docker/run.js:241
-#: pkg/docker/util.js:101 pkg/kubernetes/scripts/volumes.js:990
-#: pkg/networkmanager/interfaces.js:2484
+#: pkg/docker/util.js:101 pkg/networkmanager/interfaces.js:2477
+#: pkg/kubernetes/scripts/volumes.js:990
 msgid "No"
 msgstr "いいえ"
 
@@ -4237,29 +4196,25 @@ msgstr "遅延なし"
 msgid "No Deployments"
 msgstr "デプロイメントなし"
 
-#: pkg/storaged/format-dialog.jsx:249
+#: pkg/storaged/format-dialog.jsx:111
 msgid "No Filesystem"
 msgstr "ファイルシステムなし"
 
-#: pkg/storaged/content-views.jsx:676
+#: pkg/storaged/content-views.jsx:738
 msgid "No Logical Volumes"
 msgstr "論理ボリュームなし"
-
-#: pkg/storaged/nfs-panel.jsx:362
-msgid "No NFS mounts set up"
-msgstr ""
 
 #: pkg/ostree/app.js:107
 msgid "No OSTree deployments found"
 msgstr "OSTree デプロイメントが見つかりません"
 
-#: src/ws/cockpitcertificate.c:520
+#: src/ws/cockpitcertificate.c:499
 msgid "No PEM-encoded certificate found"
 msgstr "PEM でエンコードされた証明書が見つかりません"
 
-#: src/ws/cockpitcertificate.c:486
+#: src/ws/cockpitcertificate.c:465
 msgid "No PEM-encoded private key found"
-msgstr "PEM でエンコードされた秘密鍵が見つかりません"
+msgstr "PEM で暗号化された秘密鍵が見つかりません"
 
 #: pkg/kubernetes/views/pv-claim.html:39
 msgid "No Pods are using this claim"
@@ -4269,12 +4224,12 @@ msgstr "このクレームを使用しているポッドがありません"
 msgid "No SELinux alerts."
 msgstr "SELinux アラートがありません。"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:30
-#: pkg/ovirt/components/ClusterVms.jsx:36
+#: pkg/ovirt/components/ClusterVms.jsx:35
+#: pkg/ovirt/components/ClusterTemplates.jsx:29
 msgid "No VM found in oVirt."
-msgstr ""
+msgstr "oVirt で仮想マシンが見つかりませんでした。"
 
-#: pkg/machines/hostvmslist.jsx:48
+#: pkg/machines/hostvmslist.jsx:47
 msgid "No VM is running or defined on this host"
 msgstr "VM がこのホストで実行されていないか、定義されていません。"
 
@@ -4292,16 +4247,15 @@ msgstr "エイリアスが指定されていません"
 
 #: pkg/apps/application-list.jsx:134
 msgid "No applications installed or available"
-msgstr ""
+msgstr "アプリケーションがインストールされていないか、利用できません"
 
 #: pkg/sosreport/index.js:111
 msgid "No archive has been created."
 msgstr "アーカイブが作成されていません"
 
-#: pkg/machines/hostvmslist.jsx:266
-#, fuzzy
+#: pkg/machines/hostvmslist.jsx:265
 msgid "No boot device found"
-msgstr "ホストキーが見つかりません。"
+msgstr "ブートデバイスが見つかりません"
 
 #: pkg/networkmanager/interfaces.js:1359
 msgid "No carrier"
@@ -4327,30 +4281,26 @@ msgstr "コンテナーなし"
 msgid "No containers that match the current filter"
 msgstr "現在のフィルターに一致するコンテナーがありません"
 
-#: pkg/apps/application.jsx:79
-msgid "No description provided."
-msgstr ""
-
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vgroup-details.jsx:57 pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/sidebar-views.jsx:77 pkg/storaged/sidebar-views.jsx:241
+#: pkg/storaged/overview.js:451 pkg/storaged/overview.js:500
 msgid "No disks are available."
 msgstr "ディスクが利用できません。"
 
 #: pkg/machines/vmdiskstab.jsx:115
 msgid "No disks defined for this VM"
-msgstr "この VM に対してディスクが定義されていません"
+msgstr "この仮想マシンにはディスクが定義されていません"
 
-#: pkg/storaged/drives-panel.jsx:118
+#: pkg/storaged/index.html:191
 msgid "No drives attached"
 msgstr "ドライブが割り当てられていません"
 
-#: pkg/storaged/content-views.jsx:661
+#: pkg/storaged/content-views.jsx:723
 msgid "No free space"
 msgstr "空き領域なし"
 
 #: pkg/machines/components/graphicsConsole.jsx:32
 msgid "No graphics console is defined for this virtual machine."
-msgstr ""
+msgstr "この仮想マシンには、グラフィカルコンソールが定義されていません。"
 
 #: pkg/kubernetes/views/project-listing.html:74
 msgid "No groups are present."
@@ -4360,7 +4310,7 @@ msgstr "グループが存在しません。"
 msgid "No host keys found."
 msgstr "ホストキーが見つかりません。"
 
-#: pkg/storaged/iscsi-panel.jsx:288
+#: pkg/storaged/index.html:156
 msgid "No iSCSI targets set up"
 msgstr "iSCSI ターゲットが設定されていません"
 
@@ -4380,20 +4330,19 @@ msgstr "イメージがプッシュされていません"
 msgid "No images that match the current filter"
 msgstr "現在のフィルターに一致するイメージがありません"
 
-#: pkg/apps/utils.jsx:100
+#: pkg/apps/utils.jsx:97
 msgid "No installation package found for this application."
-msgstr ""
+msgstr "このアプリケーションのインストールパッケージが見つかりませんでした。"
 
 #: pkg/subscriptions/subscriptions-view.jsx:223
 msgid "No installed products on the system."
 msgstr "システムにインストールされた製品がありません。"
 
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:205
-#, fuzzy
+#: pkg/lib/cockpit-components-file-autocomplete.jsx:247
 msgid "No matching files found"
-msgstr "ホストキーが見つかりません。"
+msgstr "一致するファイルが見つかりませんでした。"
 
-#: pkg/storaged/drive-details.jsx:73
+#: pkg/storaged/index.html:444
 msgid "No media inserted"
 msgstr "メディアが挿入されていません"
 
@@ -4411,15 +4360,11 @@ msgid ""
 "No metadata file was selected. Please select a Kubernetes metadata file."
 msgstr "メタデータファイルが選択されていません。Kubernetes メタデータファイルを選択してください。"
 
-#: pkg/machines/vmnetworktab.jsx:32
-msgid "No network interfaces defined for this VM"
-msgstr ""
-
 #: pkg/kubernetes/views/dashboard-page.html:117
 msgid "No nodes in cluster"
 msgstr "クラスター内にノードがありません"
 
-#: pkg/storaged/content-views.jsx:487
+#: pkg/storaged/content-views.jsx:497
 msgid "No partitioning"
 msgstr "パーティションなし"
 
@@ -4463,7 +4408,7 @@ msgstr "現在のフィルターに一致する実行中のコンテナーがあ
 msgid "No signature avaliable"
 msgstr "署名が利用できません"
 
-#: pkg/storaged/mdraids-panel.jsx:126
+#: pkg/storaged/index.html:85
 msgid "No storage set up as RAID"
 msgstr "RAID として設定されたストレージがありません"
 
@@ -4473,11 +4418,11 @@ msgstr "このようなファイルまたはディレクトリーがありませ
 
 #: node_modules/registry-image-widgets/views/image-listing.html:73
 msgid "No tags are present."
-msgstr ""
+msgstr "タグが存在しません。"
 
 #: pkg/packagekit/updates.jsx:35
 msgid "No updates pending"
-msgstr ""
+msgstr "保留中の更新がありません"
 
 #: pkg/users/local.js:417
 msgid "No user name specified"
@@ -4487,7 +4432,7 @@ msgstr "ユーザー名が指定されていません"
 msgid "No users are present."
 msgstr "ユーザーが存在しません。"
 
-#: pkg/storaged/vgroups-panel.jsx:110
+#: pkg/storaged/index.html:118
 msgid "No volume groups created"
 msgstr "ボリュームグループが作成されていません"
 
@@ -4499,22 +4444,22 @@ msgstr "ボリュームが存在しません。"
 msgid "No volumes in use"
 msgstr "使用中のボリュームがありません"
 
+#: pkg/kubernetes/views/topology-page.html:38
+#: pkg/kubernetes/views/pod-body.html:18 pkg/kubernetes/views/node-panel.html:7
 #: pkg/kubernetes/views/containers-listing.html:15
 #: pkg/kubernetes/views/node-page.html:14
-#: pkg/kubernetes/views/node-panel.html:7 pkg/kubernetes/views/pod-body.html:18
-#: pkg/kubernetes/views/topology-page.html:38
 msgid "Node"
 msgstr "ノード"
 
 #: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:46
 msgid "Nodes"
 msgstr "ノード"
 
 #: pkg/kubernetes/views/topology-page.html:39
 msgid "Nodes are the machines that run your containers."
-msgstr "ノードはコンテナーを実行するマシンです。"
+msgstr "ノードは、コンテナーを実行するマシンです。"
 
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
@@ -4523,9 +4468,8 @@ msgstr "ノードはコンテナーを実行するマシンです。"
 msgid "None"
 msgstr "なし"
 
-#: pkg/kubernetes/views/details-page.html:53
-#: pkg/kubernetes/views/node-body.html:42 pkg/playground/translate.html:29
-#: pkg/kubernetes/scripts/nodes.js:319
+#: pkg/playground/translate.html:29 pkg/kubernetes/views/details-page.html:53
+#: pkg/kubernetes/views/node-body.html:42 pkg/kubernetes/scripts/nodes.js:319
 msgid "Not Ready"
 msgstr "準備ができていません"
 
@@ -4543,16 +4487,15 @@ msgstr "ホストの有効な値ではありません"
 
 #: pkg/docker/index.html:57
 msgid "Not authorized to access Docker on this system"
-msgstr "このシステム上の Docker にアクセスする権限がありません"
+msgstr "このシステムの Docker にアクセスする権限がありません"
 
 #: pkg/ostree/app.js:86
 msgid "Not authorized to update software on this system"
-msgstr "このシステム上のソフトウェアを更新する権限がありません"
+msgstr "このシステムのソフトウェアを更新する権限がありません"
 
 #: pkg/systemd/logs.js:452
-#, fuzzy
 msgid "Not authorized to upload-report"
-msgstr "このシステム上のソフトウェアを更新する権限がありません"
+msgstr "upload-report の権限がありません"
 
 #: pkg/networkmanager/interfaces.js:759
 msgid "Not available"
@@ -4567,19 +4510,15 @@ msgstr "接続していません"
 msgid "Not deployed"
 msgstr "デプロイされていません"
 
-#: pkg/docker/details.js:176 pkg/storaged/details.jsx:123
+#: pkg/docker/details.js:176 pkg/storaged/details.jsx:414
 msgid "Not found"
 msgstr "見つかりません"
-
-#: pkg/storaged/nfs-panel.jsx:297
-msgid "Not mounted"
-msgstr ""
 
 #: src/base1/cockpit.js:3938
 msgid "Not permitted to perform this action."
 msgstr "このアクションを実行する権限がありません。"
 
-#: pkg/storaged/mdraid-details.jsx:332
+#: pkg/storaged/details.jsx:318
 msgid "Not running"
 msgstr "実行中ではありません"
 
@@ -4589,20 +4528,19 @@ msgstr "同期されていません"
 
 #: node_modules/registry-image-widgets/views/image-listing.html:44
 msgid "Not yet synced"
-msgstr ""
+msgstr "同期されていません"
 
 #: pkg/systemd/services.html:316
 msgid "Note"
 msgstr "注記"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:50
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: pkg/kubernetes/views/node-body.html:13
-#: pkg/ovirt/components/ClusterTemplates.jsx:137
-#: pkg/ovirt/components/ClusterVms.jsx:173
+#: pkg/ovirt/components/ClusterVms.jsx:174
+#: pkg/ovirt/components/ClusterTemplates.jsx:128
 msgid "OS"
 msgstr "OS"
 
@@ -4612,7 +4550,7 @@ msgstr "OS $0 が見つかりません"
 
 #: pkg/ovirt/components/OVirtTab.jsx:145
 msgid "OS Type:"
-msgstr ""
+msgstr "OS タイプ:"
 
 #: pkg/kubernetes/views/nodes-page.html:19
 msgid "OS Versions"
@@ -4628,12 +4566,12 @@ msgstr "発生件数 $0"
 
 #: pkg/selinux/setroubleshoot-view.jsx:370
 msgid "Occurred between $0 and $1"
-msgstr "$0〜$1 の発生件数"
+msgstr "$0 - $1 の発生件数"
 
+#: pkg/shell/index.html:254 pkg/systemd/index.html:167
 #: pkg/playground/jquery-patterns.html:95
-#: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:243
-#: pkg/systemd/index.html:167 pkg/lib/patterns.js:244
-#: pkg/lib/cockpit-components-onoff.jsx:38
+#: pkg/playground/jquery-patterns.html:108 pkg/storaged/index.html:564
+#: pkg/lib/cockpit-components-onoff.jsx:38 pkg/lib/patterns.js:244
 msgid "Off"
 msgstr "オフ"
 
@@ -4641,18 +4579,18 @@ msgstr "オフ"
 msgid "Ok"
 msgstr "OK"
 
-#: pkg/shell/index.html:303 pkg/users/index.html:239
+#: pkg/users/index.html:239 pkg/shell/index.html:314
 msgid "Old Password"
 msgstr "古いパスワード"
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:78
+#: pkg/users/local.js:78 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
-msgstr "古いパスワードは受け入れられません"
+msgstr "古いパスワードは使用できません"
 
+#: pkg/shell/index.html:250 pkg/systemd/index.html:163
 #: pkg/playground/jquery-patterns.html:91
-#: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:239
-#: pkg/systemd/index.html:163 pkg/lib/patterns.js:244
-#: pkg/lib/cockpit-components-onoff.jsx:39
+#: pkg/playground/jquery-patterns.html:104 pkg/storaged/index.html:563
+#: pkg/lib/cockpit-components-onoff.jsx:39 pkg/lib/patterns.js:244
 msgid "On"
 msgstr "オン"
 
@@ -4679,18 +4617,18 @@ msgstr "ワンタイムパスワード"
 
 #: pkg/systemd/logs.html:58
 msgid "Only Problems"
-msgstr ""
+msgstr "問題のみ"
 
 #: pkg/systemd/init.js:1149
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr "アルファベット、数字、:、 _ 、.、@、- のみを使用できます。"
 
-#: pkg/shell/index.html:45 pkg/shell/simple.html:29 pkg/shell/stub.html:33
+#: pkg/shell/index.html:40 pkg/shell/stub.html:28 pkg/shell/simple.html:28
 msgid "Ooops!"
 msgstr "問題が発生しました"
 
-#: pkg/kubernetes/views/nodes-page.html:42 pkg/ostree/index.html:301
-#: pkg/systemd/index.html:99
+#: pkg/ostree/index.html:301 pkg/systemd/index.html:99
+#: pkg/kubernetes/views/nodes-page.html:42
 msgid "Operating System"
 msgstr "オペレーティングシステム"
 
@@ -4698,20 +4636,21 @@ msgstr "オペレーティングシステム"
 msgid "Operating System Updates"
 msgstr "オペレーティングシステムの更新"
 
-#: pkg/storaged/jobs-panel.jsx:80
+#: pkg/storaged/jobs.js:165
 msgid "Operation '$operation' on $target"
 msgstr "$target 上の操作 '$operation'"
 
-#: pkg/storaged/drives-panel.jsx:94
+#: pkg/storaged/overview.js:189
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr "光学ドライブ"
 
 #: pkg/ovirt/components/OVirtTab.jsx:152
 msgid "Optimized for:"
-msgstr ""
+msgstr "次に対して最適化:"
 
-#: pkg/kubernetes/views/volume-body.html:130 pkg/storaged/crypto-tab.jsx:140
+#: pkg/kubernetes/views/volume-body.html:130 pkg/storaged/crypto-tab.jsx:110
+#: pkg/storaged/crypto-tab.jsx:145
 msgid "Options"
 msgstr "オプション"
 
@@ -4723,12 +4662,12 @@ msgstr "部門"
 msgid "Origin"
 msgstr "生成"
 
-#: pkg/storaged/content-views.jsx:321
+#: pkg/storaged/content-views.jsx:322
 msgctxt "storage-id-desc"
 msgid "Other Data"
 msgstr "他のデータ"
 
-#: pkg/storaged/others-panel.jsx:67
+#: pkg/storaged/index.html:200
 msgid "Other Devices"
 msgstr "他のデバイス"
 
@@ -4736,12 +4675,12 @@ msgstr "他のデバイス"
 msgid "Other Options"
 msgstr "他のオプション"
 
-#: pkg/docker/index.html:290 pkg/kubernetes/index.html:43
-#: pkg/kubernetes/registry.html:43 pkg/machines/hostvmslist.jsx:415
+#: pkg/docker/index.html:290 pkg/kubernetes/index.html:40
+#: pkg/kubernetes/registry.html:43 pkg/machines/hostvmslist.jsx:413
 msgid "Overview"
 msgstr "概要"
 
-#: pkg/storaged/content-views.jsx:477 pkg/storaged/format-dialog.jsx:277
+#: pkg/storaged/content-views.jsx:487 pkg/storaged/format-dialog.jsx:139
 msgid "Overwrite existing data with zeros"
 msgstr "既存のデータをゼロで上書きする"
 
@@ -4749,24 +4688,22 @@ msgstr "既存のデータをゼロで上書きする"
 msgid "PD Name"
 msgstr "PD 名"
 
-#: pkg/packagekit/updates.jsx:488
+#: pkg/packagekit/updates.jsx:478
 msgid "Package information"
-msgstr ""
+msgstr "パッケージ情報"
 
-#: pkg/packagekit/updates.jsx:543
-#, fuzzy
+#: pkg/packagekit/updates.jsx:533
 msgid "PackageKit crashed"
-msgstr "パッケージ"
+msgstr "PackageKit がクラッシュしました"
 
-#: pkg/packagekit/updates.jsx:541 pkg/packagekit/updates.jsx:647
-#: pkg/packagekit/updates.jsx:721
-#, fuzzy
+#: pkg/packagekit/updates.jsx:531 pkg/packagekit/updates.jsx:637
+#: pkg/packagekit/updates.jsx:711
 msgid "PackageKit is not installed"
-msgstr "Cockpit はインストールされていません"
+msgstr "PackageKit はインストールされていません"
 
-#: pkg/packagekit/updates.jsx:745
+#: pkg/packagekit/updates.jsx:735
 msgid "PackageKit reported error code $0"
-msgstr ""
+msgstr "PackageKit が、エラーコード $0 を報告しました"
 
 #: pkg/ostree/index.html:266
 msgid "Packages"
@@ -4776,7 +4713,7 @@ msgstr "パッケージ"
 msgid "Parent"
 msgstr "親"
 
-#: pkg/networkmanager/interfaces.js:2793
+#: pkg/networkmanager/interfaces.js:2786
 msgid "Parent $parent"
 msgstr "親 $parent"
 
@@ -4785,48 +4722,48 @@ msgid "Part of "
 msgstr "一部"
 
 #: pkg/kubernetes/views/volume-body.html:8
-#: pkg/kubernetes/views/volume-body.html:18 pkg/storaged/content-views.jsx:137
+#: pkg/kubernetes/views/volume-body.html:18 pkg/storaged/content-views.jsx:138
 msgid "Partition"
 msgstr "パーティション"
 
-#: pkg/storaged/utils.js:246
-#, fuzzy
+#: pkg/storaged/storage-controls.jsx:212
 msgid "Partition of $0"
-msgstr "パーティション"
+msgstr "$0 のパーティション"
 
-#: pkg/storaged/content-views.jsx:481
+#: pkg/storaged/content-views.jsx:491
 msgid "Partitioning"
 msgstr "パーティション構成"
 
-#: pkg/networkmanager/interfaces.js:1935
+#: pkg/networkmanager/interfaces.js:1930
 msgid "Passive"
 msgstr "パッシブ"
 
-#: pkg/storaged/content-views.jsx:193 pkg/storaged/format-dialog.jsx:295
+#: pkg/storaged/content-views.jsx:194 pkg/storaged/format-dialog.jsx:157
 msgid "Passphrase"
 msgstr "パスフレーズ"
 
-#: pkg/storaged/format-dialog.jsx:298
+#: pkg/storaged/format-dialog.jsx:160
 msgid "Passphrase cannot be empty"
 msgstr "パスフレーズは空にすることができません"
 
-#: pkg/storaged/format-dialog.jsx:306
+#: pkg/storaged/format-dialog.jsx:168
 msgid "Passphrases do not match"
 msgstr "パスフレーズが一致しません"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
+#: pkg/users/index.html:117 pkg/users/index.html:177
 #: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:214 pkg/shell/index.html:253 pkg/shell/index.html:266
-#: pkg/users/index.html:117 pkg/users/index.html:177 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/lib/machine-auth-failed.html:8 pkg/shell/index.html:225
+#: pkg/shell/index.html:264 pkg/shell/index.html:277
+#: pkg/kubernetes/views/auth-form.html:105 src/ws/login.html:50
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
+#: pkg/storaged/overview.js:534 pkg/storaged/overview.js:657
 msgid "Password"
 msgstr "パスワード"
 
 #: pkg/users/index.html:336
 msgid "Password Expiration"
-msgstr ""
+msgstr "パスワードの有効期限"
 
 #: pkg/users/local.js:259
 msgid "Password is not acceptable"
@@ -4838,25 +4775,25 @@ msgstr "パスワードが弱すぎます"
 
 #: pkg/users/local.js:834
 msgid "Password must be changed"
-msgstr ""
+msgstr "パスワードを変更する必要があります"
 
 #: pkg/lib/credentials.js:289
 msgid "Password not accepted"
 msgstr "パスワードは受け入れられません"
 
-#: pkg/shell/index.html:157
+#: pkg/shell/index.html:168
 msgid ""
 "Password not usable for privileged tasks or to connect to other machines"
-msgstr "特権タスクの実行または他のマシンへの接続のためにパスワードを使用できません"
+msgstr "特権タスクの実行または他のマシンへの接続に、パスワードを使用できません"
 
 #: pkg/users/index.html:457
 msgid "Paste the contents of your public SSH key file here"
 msgstr "公開 SSH 鍵ファイルの内容をここに貼り付けます"
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr "パス"
 
@@ -4864,25 +4801,13 @@ msgstr "パス"
 msgid "Path cost"
 msgstr "パスコスト"
 
-#: pkg/networkmanager/interfaces.js:2775
+#: pkg/networkmanager/interfaces.js:2768
 msgid "Path cost $path_cost"
 msgstr "パスコスト $path_cost"
 
-#: pkg/storaged/nfs-panel.jsx:138
-msgid "Path on Server"
-msgstr ""
-
-#: pkg/storaged/nfs-panel.jsx:143
-msgid "Path on server cannot be empty."
-msgstr ""
-
-#: pkg/storaged/nfs-panel.jsx:145
-msgid "Path on server must start with \"/\"."
-msgstr ""
-
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:265
+#: pkg/lib/cockpit-components-file-autocomplete.jsx:232
 msgid "Path to file"
-msgstr ""
+msgstr "ファイルのパス"
 
 #: pkg/systemd/services.html:56
 msgid "Paths"
@@ -4896,11 +4821,11 @@ msgstr "保留中のボリュームクレーム"
 msgid "Performance Profile"
 msgstr "パフォーマンスプロファイル"
 
-#: pkg/networkmanager/interfaces.js:3507
+#: pkg/networkmanager/interfaces.js:3500
 msgid "Permanent"
 msgstr "永続"
 
-#: src/ws/login.js:606
+#: src/ws/login.js:603
 msgid "Permission denied"
 msgstr "パーミッションが拒否されました。"
 
@@ -4912,15 +4837,15 @@ msgstr "永続ボリューム"
 msgid "Phase"
 msgstr "フェーズ"
 
-#: pkg/storaged/content-views.jsx:146 pkg/storaged/content-views.jsx:311
+#: pkg/storaged/content-views.jsx:147 pkg/storaged/content-views.jsx:312
 msgid "Physical Volume"
 msgstr "物理ボリューム"
 
-#: pkg/storaged/vgroup-details.jsx:132
+#: pkg/storaged/sidebar-views.jsx:316
 msgid "Physical Volumes"
 msgstr "物理ボリューム"
 
-#: pkg/storaged/content-views.jsx:306
+#: pkg/storaged/content-views.jsx:307
 msgid "Physical volume of $0"
 msgstr "$0 の物理ボリューム"
 
@@ -4932,19 +4857,15 @@ msgstr "Ping 間隔"
 msgid "Ping Target"
 msgstr "Ping ターゲット"
 
-#: pkg/docker/containers-view.jsx:167 pkg/docker/details.js:274
-#: pkg/docker/image.js:139 pkg/storaged/content-views.jsx:260
-#: pkg/storaged/mdraid-details.jsx:277 pkg/storaged/vgroup-details.jsx:209
+#: pkg/docker/details.js:274 pkg/docker/containers-view.jsx:167
+#: pkg/docker/image.js:139 pkg/storaged/details.jsx:100
+#: pkg/storaged/details.jsx:160 pkg/storaged/content-views.jsx:261
 msgid "Please confirm deletion of $0"
 msgstr "$0 の削除を確定してください"
 
 #: pkg/docker/util.js:504
 msgid "Please confirm forced deletion of $0"
 msgstr "$0 の強制削除を確定してください"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:37
-msgid "Please confirm, the host shall be switched to maintenance mode."
-msgstr ""
 
 #: pkg/kubernetes/scripts/dashboard.js:440
 msgid "Please create another namespace for $0 \"$1\""
@@ -4982,7 +4903,7 @@ msgstr "有効なインターフェースを提供してください"
 msgid "Please provide a valid logical unit number"
 msgstr "有効な論理ユニット番号を提供してください"
 
-#: pkg/kubernetes/scripts/volumes.js:477 pkg/ostree/remotes.js:254
+#: pkg/ostree/remotes.js:254 pkg/kubernetes/scripts/volumes.js:477
 msgid "Please provide a valid name"
 msgstr "有効な名前を提供してください"
 
@@ -5009,18 +4930,18 @@ msgstr "有効なターゲットを提供してください"
 #: pkg/ovirt/components/InstallationDialog.jsx:85
 msgid ""
 "Please provide fully qualified domain name and port of the oVirt engine."
-msgstr ""
+msgstr "完全修飾ドメイン名と、oVirt エンジンのポートを提供してください。"
 
 #: pkg/ovirt/components/InstallationDialog.jsx:136
 msgid ""
 "Please provide valid oVirt engine fully qualified domain name (FQDN) and "
 "port (443 by default)"
-msgstr ""
+msgstr "有効な oVirt エンジンの完全修飾ドメイン名 (FQDN) と、ポート (デフォルトでは 443) を提供してください"
 
 #: pkg/ovirt/components/ConsoleClientResources.jsx:34
 msgid ""
 "Please refer to oVirt's $0 for more information about Remote Viewer setup."
-msgstr ""
+msgstr "リモートビューアーの設定の詳細は、oVirt の $0 を参照してください。"
 
 #: pkg/kubernetes/scripts/volumes.js:469
 msgid "Please select a valid access mode"
@@ -5036,11 +4957,11 @@ msgstr "有効なポリシーオプションを選択してください"
 
 #: pkg/users/local.js:1156
 msgid "Please specify an expiration date"
-msgstr ""
+msgstr "有効期限を指定してください"
 
 #: pkg/machines/components/graphicsConsole.jsx:41
 msgid "Please start the virtual machine to access its graphics console."
-msgstr ""
+msgstr "仮想マシンを起動して、グラフィックコンソールにアクセスしてください。"
 
 #: pkg/docker/search.js:150
 msgid "Please try another term"
@@ -5050,21 +4971,17 @@ msgstr "別の用語を試してください"
 msgid "Please type an address"
 msgstr "アドレスを入力してください"
 
-#: pkg/ovirt/components/ClusterVms.jsx:37
+#: pkg/ovirt/components/ClusterVms.jsx:36
 msgid "Please wait till VMs list is loaded from the server."
-msgstr ""
+msgstr "サーバーから仮想マシンの一覧がロードされるまでお待ちください。"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:31
+#: pkg/ovirt/components/ClusterTemplates.jsx:30
 msgid "Please wait till list of templates is loaded from the server."
-msgstr ""
+msgstr "テンプレートの一覧がサーバーからロードされるのをお待ちください。"
 
-#: pkg/machines/vmnetworktab.jsx:124
-msgid "Plug"
-msgstr ""
-
-#: pkg/kubernetes/views/containers-listing.html:12
-#: pkg/kubernetes/views/pod-page.html:12
 #: pkg/kubernetes/views/topology-page.html:14
+#: pkg/kubernetes/views/pod-page.html:12
+#: pkg/kubernetes/views/containers-listing.html:12
 msgid "Pod"
 msgstr "ポッド"
 
@@ -5086,11 +5003,11 @@ msgstr "ポッドがレプリケートされました"
 msgid "Pod Selector"
 msgstr "ポッドセレクター"
 
+#: pkg/kubernetes/views/pv-claim.html:37
 #: pkg/kubernetes/views/dashboard-page.html:18
 #: pkg/kubernetes/views/details-page.html:166
-#: pkg/kubernetes/views/pv-claim.html:37
-#: pkg/kubernetes/views/replicationcontroller-page.html:17
 #: pkg/kubernetes/views/replicationcontroller-panel.html:12
+#: pkg/kubernetes/views/replicationcontroller-page.html:17
 #: pkg/kubernetes/scripts/details.js:229
 msgid "Pods"
 msgstr "ポッド"
@@ -5101,7 +5018,7 @@ msgid ""
 "your application code."
 msgstr "ポッドには、ノードで一緒に実行される 1 つ以上のコンテナーが含まれます (アプリケーションコードを含む)"
 
-#: pkg/machines/vmdiskstab.jsx:54 pkg/storaged/content-views.jsx:129
+#: pkg/machines/vmdiskstab.jsx:54 pkg/storaged/content-views.jsx:130
 msgid "Pool"
 msgstr "プール"
 
@@ -5109,15 +5026,15 @@ msgstr "プール"
 msgid "Pool Name"
 msgstr "プール名"
 
-#: pkg/storaged/utils.js:172
+#: pkg/storaged/utils.js:173
 msgid "Pool for Thin Logical Volumes"
 msgstr "シン論理ボリューム用プール"
 
-#: pkg/storaged/content-views.jsx:551
+#: pkg/storaged/content-views.jsx:596
 msgid "Pool for Thin Volumes"
 msgstr "シンボリューム用プール"
 
-#: pkg/storaged/content-views.jsx:609
+#: pkg/storaged/content-views.jsx:671
 msgid "Pool for thinly provisioned volumes"
 msgstr "シンプロビジョニングされたボリューム用プール"
 
@@ -5126,21 +5043,16 @@ msgid "Populate"
 msgstr "入力"
 
 #: pkg/lib/machine-change-port.html:23 pkg/machines/vmdiskstab.jsx:57
-#: pkg/machines/vmnetworktab.jsx:62
-#: pkg/ovirt/components/InstallationDialog.jsx:67
-#: pkg/storaged/iscsi-panel.jsx:150
+#: pkg/ovirt/components/InstallationDialog.jsx:67 pkg/storaged/overview.js:629
 msgid "Port"
 msgstr "ポート"
 
-#: pkg/machines/vmnetworktab.jsx:93
-msgid "Portgroup"
-msgstr ""
-
-#: pkg/docker/index.html:496 pkg/kubernetes/views/container-body.html:12
-#: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:216
+#: pkg/docker/index.html:496 pkg/networkmanager/index.html:216
 #: pkg/networkmanager/index.html:415
+#: pkg/kubernetes/views/container-body.html:12
+#: pkg/kubernetes/views/service-body.html:13
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:317 pkg/networkmanager/interfaces.js:2876
+#: pkg/docker/containers-view.jsx:317 pkg/networkmanager/interfaces.js:2869
 msgid "Ports"
 msgstr "ポート"
 
@@ -5152,11 +5064,11 @@ msgstr "ポート:"
 msgid "Power Options"
 msgstr "電源オプション"
 
-#: pkg/networkmanager/interfaces.js:3182
+#: pkg/networkmanager/interfaces.js:3175
 msgid "Prefix length"
 msgstr "プレフィックス長"
 
-#: pkg/networkmanager/interfaces.js:3182
+#: pkg/networkmanager/interfaces.js:3175
 msgid "Prefix length or Netmask"
 msgstr "プレフィックス長またはネットマスク"
 
@@ -5166,9 +5078,9 @@ msgstr "準備中"
 
 #: pkg/ovirt/rephraseUI.es6:26
 msgid "Preparing for Maintenance"
-msgstr ""
+msgstr "メンテナンスの準備中"
 
-#: pkg/networkmanager/interfaces.js:3508
+#: pkg/networkmanager/interfaces.js:3501
 msgid "Preserve"
 msgstr "保存"
 
@@ -5186,14 +5098,14 @@ msgstr "プリティホスト名"
 
 #: pkg/networkmanager/index.html:349
 msgid "Primary"
-msgstr "プライマリ"
+msgstr "プライマリー"
 
 #: pkg/networkmanager/index.html:274 pkg/networkmanager/index.html:488
 #: pkg/networkmanager/index.html:506
 msgid "Priority"
 msgstr "優先度"
 
-#: pkg/networkmanager/interfaces.js:2749 pkg/networkmanager/interfaces.js:2773
+#: pkg/networkmanager/interfaces.js:2742 pkg/networkmanager/interfaces.js:2766
 msgid "Priority $priority"
 msgstr "優先度 $priority"
 
@@ -5201,29 +5113,21 @@ msgstr "優先度 $priority"
 msgid "Private: Allow only specific users or groups to pull images"
 msgstr "プライベート: 特定のユーザーまたはグループのみがイメージをプルすることを許可する"
 
-#: pkg/shell/index.html:33
+#: pkg/shell/index.html:28
 msgid "Privileged tasks not available"
 msgstr "特権タスクが利用できません"
 
-#: pkg/systemd/logs.js:413
-msgid "Problem details"
-msgstr ""
-
-#: pkg/systemd/logs.js:412
-msgid "Problem info"
-msgstr ""
-
 #: pkg/systemd/logs.html:57
 msgid "Problems, Errors"
-msgstr ""
+msgstr "問題、エラー"
 
 #: pkg/systemd/logs.html:56
 msgid "Problems, Errors, Warnings"
-msgstr ""
+msgstr "問題、エラー、警告"
 
 #: pkg/systemd/logs.html:55
 msgid "Problems, Errors, Warnings, Notices"
-msgstr ""
+msgstr "問題、エラー、警告、注記"
 
 #: pkg/subscriptions/subscriptions-view.jsx:33
 msgid "Product ID"
@@ -5233,19 +5137,19 @@ msgstr "製品 ID"
 msgid "Product name"
 msgstr "製品名"
 
-#: pkg/kubernetes/views/containers-listing.html:13
-#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/pod-body.html:4
 #: pkg/kubernetes/views/deploymentconfig-body.html:4
+#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
 #: pkg/kubernetes/views/details-page.html:138
 #: pkg/kubernetes/views/details-page.html:172
-#: pkg/kubernetes/views/imagestream-modify.html:21
-#: pkg/kubernetes/views/pod-body.html:4
 #: pkg/kubernetes/views/replicationcontroller-body.html:4
-#: pkg/kubernetes/views/route-body.html:4
+#: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/service-body.html:4
+#: pkg/kubernetes/views/imagestream-modify.html:21
 #: pkg/kubernetes/views/volumes-page.html:58
 msgid "Project"
 msgstr "プロジェクト"
@@ -5266,7 +5170,7 @@ msgstr "プロジェクトアクセスポリシーにより、認証されたユ
 msgid "Project access policy only allows specific members to access images."
 msgstr "プロジェクトアクセスポリシーにより、特定のメンバーのみがイメージにアクセスできます。"
 
-#: pkg/shell/index.html:88 pkg/shell/simple.html:62 pkg/shell/stub.html:69
+#: pkg/shell/index.html:99 pkg/shell/stub.html:77 pkg/shell/simple.html:72
 msgid "Project website"
 msgstr "プロジェクト Web サイト"
 
@@ -5276,7 +5180,7 @@ msgstr "プロジェクト:"
 
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:88
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:85
 #: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr "プロジェクト"
@@ -5299,19 +5203,15 @@ msgstr "プロトコル"
 
 #: pkg/subscriptions/subscriptions-register.jsx:125
 msgid "Proxy"
-msgstr "プロキシ"
+msgstr "プロキシー"
 
 #: pkg/kubernetes/views/node-body.html:25
 msgid "Proxy Version"
 msgstr "プロキシーバージョン"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:252
+#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:263
 msgid "Public Key"
 msgstr "公開鍵"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:39
-msgid "Public pulling repo"
-msgstr ""
 
 #: pkg/kubernetes/views/registry-dashboard-page.html:152
 msgid "Pull an image:"
@@ -5325,7 +5225,7 @@ msgstr "プル対象"
 msgid "Pull specific tags from another image repository"
 msgstr "別のイメージリポジトリーから特定のタグをプルします"
 
-#: pkg/storaged/content-views.jsx:604
+#: pkg/storaged/content-views.jsx:666
 msgid "Purpose"
 msgstr "目的"
 
@@ -5333,92 +5233,97 @@ msgstr "目的"
 msgid "Push an image:"
 msgstr "イメージのプッシュ:"
 
-#: pkg/kubernetes/views/pv-modify.html:147
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:147
 msgid "Qualified Name"
 msgstr "修飾名"
 
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/details.jsx:283
 msgid "RAID ($0)"
 msgstr "RAID ($0)"
 
-#: pkg/storaged/mdraid-details.jsx:179
+#: pkg/storaged/details.jsx:277
 msgid "RAID 0"
 msgstr "RAID 0"
 
-#: pkg/storaged/mdraids-panel.jsx:46
+#: pkg/storaged/overview.js:423
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (ストライプ)"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/details.jsx:278
 msgid "RAID 1"
 msgstr "RAID 1"
 
-#: pkg/storaged/mdraids-panel.jsx:47
+#: pkg/storaged/overview.js:424
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (ミラー)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/details.jsx:282
 msgid "RAID 10"
 msgstr "RAID 10"
 
-#: pkg/storaged/mdraids-panel.jsx:51
+#: pkg/storaged/overview.js:428
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RAID 10 (ミラーのストライプ)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/details.jsx:279
 msgid "RAID 4"
 msgstr "RAID 4"
 
-#: pkg/storaged/mdraids-panel.jsx:48
+#: pkg/storaged/overview.js:425
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (専用パリティー)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/details.jsx:280
 msgid "RAID 5"
 msgstr "RAID 5"
 
-#: pkg/storaged/mdraids-panel.jsx:49
+#: pkg/storaged/overview.js:426
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (分散パリティー)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/details.jsx:281
 msgid "RAID 6"
 msgstr "RAID 6"
 
-#: pkg/storaged/mdraids-panel.jsx:50
+#: pkg/storaged/overview.js:427
 msgid "RAID 6 (Double Distributed Parity)"
 msgstr "RAID 6 (ダブル分散パリティー)"
 
-#: pkg/storaged/pvol-tabs.jsx:74
+#: pkg/storaged/index.html:535 pkg/storaged/pvol-tabs.jsx:68
 msgid "RAID Device"
 msgstr "RAID デバイス"
 
-#: pkg/storaged/mdraid-details.jsx:306 pkg/storaged/utils.js:222
+#: pkg/storaged/utils.js:240 pkg/storaged/storage-controls.jsx:172
 msgid "RAID Device $0"
 msgstr "RAID デバイス $0"
 
-#: pkg/storaged/mdraids-panel.jsx:125
+#: pkg/storaged/index.html:63
 msgid "RAID Devices"
 msgstr "RAID デバイス"
 
-#: pkg/storaged/mdraids-panel.jsx:44
+#: pkg/storaged/overview.js:421
 msgid "RAID Level"
 msgstr "RAID レベル"
 
-#: pkg/storaged/content-views.jsx:149
+#: pkg/storaged/index.html:554
+msgctxt "storage"
+msgid "RAID Level"
+msgstr "RAID レベル"
+
+#: pkg/storaged/content-views.jsx:150
 msgid "RAID Member"
 msgstr "RAID メンバー"
 
-#: pkg/ovirt/provider.es6:144
+#: pkg/ovirt/provider.es6:137
 msgid "REBOOT action failed"
-msgstr ""
+msgstr "REBOOT アクションに失敗しました"
 
 #: pkg/kubernetes/scripts/volumes.js:200
 msgid "Rados Block Device"
 msgstr "Rados ブロックデバイス"
 
-#: pkg/networkmanager/interfaces.js:3509
+#: pkg/networkmanager/interfaces.js:3502
 msgid "Random"
 msgstr "ランダム"
 
@@ -5426,7 +5331,6 @@ msgstr "ランダム"
 msgid "Raw to a device"
 msgstr "デバイスに対する Raw"
 
-#: pkg/kubernetes/views/pv-modify.html:194
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -5438,6 +5342,7 @@ msgstr "デバイスに対する Raw"
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:194
 msgid "Read Only"
 msgstr "読み込み専用"
 
@@ -5461,7 +5366,7 @@ msgstr "読み取り専用"
 msgid "ReadWrite"
 msgstr "読み書き"
 
-#: pkg/storaged/plot.jsx:265
+#: pkg/storaged/index.html:325
 msgid "Reading"
 msgstr "読み取り中"
 
@@ -5473,9 +5378,9 @@ msgstr "読み取り中 ..."
 msgid "Readonly"
 msgstr "読み取り専用"
 
+#: pkg/playground/translate.html:19 pkg/playground/translate.html:179
 #: pkg/kubernetes/views/details-page.html:52
-#: pkg/kubernetes/views/node-body.html:41 pkg/playground/translate.html:19
-#: pkg/playground/translate.html:179 pkg/kubernetes/scripts/nodes.js:324
+#: pkg/kubernetes/views/node-body.html:41 pkg/kubernetes/scripts/nodes.js:324
 msgid "Ready"
 msgstr "準備ができています"
 
@@ -5488,13 +5393,13 @@ msgstr "準備ができています"
 msgid "Real Host Name"
 msgstr "実際のホスト名"
 
-#: pkg/systemd/host.js:857
+#: pkg/systemd/host.js:850
 msgid ""
 "Real host name can only contain lower-case characters, digits, dashes, and "
 "periods (with populated subdomains)"
 msgstr "実際のホスト名には小文字、数字、ダッシュ、およびピリオドのみを含めることができます (入力されたサブドメインを含む)。"
 
-#: pkg/systemd/host.js:858
+#: pkg/systemd/host.js:851
 msgid "Real host name must be 64 characters or less"
 msgstr "実際のホスト名は 64 文字以下である必要があります"
 
@@ -5506,7 +5411,7 @@ msgstr "理由"
 msgid "Rebase and Reboot"
 msgstr "リベースおよび再起動"
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:81 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242
 msgid "Reboot"
 msgstr "再起動"
 
@@ -5536,17 +5441,17 @@ msgstr "最近開いたファイル"
 msgid "Reclaim Policy"
 msgstr "リクレームポリシー"
 
-#: pkg/kubernetes/index.html:108 pkg/kubernetes/registry.html:75
-#: pkg/ostree/index.html:423 pkg/shell/index.html:406 pkg/shell/simple.html:138
-#: pkg/shell/stub.html:180
+#: pkg/ostree/index.html:423 pkg/shell/index.html:377 pkg/shell/stub.html:151
+#: pkg/shell/simple.html:131 pkg/kubernetes/index.html:105
+#: pkg/kubernetes/registry.html:75
 msgid "Reconnect"
 msgstr "再接続"
 
-#: pkg/storaged/mdraid-details.jsx:100
+#: pkg/storaged/sidebar-views.jsx:124
 msgid "Recovering"
 msgstr "復旧"
 
-#: pkg/storaged/jobs-panel.jsx:61
+#: pkg/storaged/jobs.js:144
 msgid "Recovering RAID Device $target"
 msgstr "RAID デバイス $target の復旧"
 
@@ -5560,17 +5465,17 @@ msgstr "ディスクの再フォーマットおよび追加"
 
 #: pkg/packagekit/updates.jsx:34
 msgid "Refreshing package information"
-msgstr ""
+msgstr "パッケージ情報の更新中"
 
-#: src/ws/login.js:596
+#: src/ws/login.js:593
 msgid "Refusing to connect. Host is unknown"
 msgstr "接続を拒否しています。ホストが不明です"
 
-#: src/ws/login.js:598
+#: src/ws/login.js:595
 msgid "Refusing to connect. Hostkey does not match"
 msgstr "接続を拒否しています。ホストキーが一致しません"
 
-#: src/ws/login.js:594
+#: src/ws/login.js:591
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "接続を拒否しています。ホストキーが不明です"
 
@@ -5589,7 +5494,7 @@ msgstr "永続ボリュームの登録"
 
 #: pkg/ovirt/components/InstallationDialog.jsx:107
 msgid "Register oVirt"
-msgstr ""
+msgstr "oVirt の登録"
 
 #: pkg/subscriptions/main.js:74
 msgid "Register system"
@@ -5597,11 +5502,11 @@ msgstr "システムの登録"
 
 #: pkg/ovirt/components/InstallationDialog.jsx:127
 msgid "Registering oVirt to Cockpit"
-msgstr ""
+msgstr "oVirt を Cockpit に登録中"
 
-#: pkg/packagekit/updates.jsx:901
+#: pkg/packagekit/updates.jsx:887
 msgid "Register…"
-msgstr ""
+msgstr "登録中…"
 
 #: pkg/ostree/index.html:305
 msgid "Released"
@@ -5627,7 +5532,7 @@ msgstr "リモートレジストリーは安全ではありません"
 msgid "Remote;Administration;"
 msgstr "リモート;管理;"
 
-#: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
+#: pkg/storaged/overview.js:185 pkg/storaged/overview.js:187
 msgctxt "storage"
 msgid "Removable Drive"
 msgstr "リムーバブルドライブ"
@@ -5637,14 +5542,14 @@ msgid "Removals"
 msgstr "削除"
 
 #: pkg/kubernetes/views/group-delete.html:21
-#: pkg/kubernetes/views/remove-role-dialog.html:8
-#: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
+#: pkg/kubernetes/views/user-delete.html:25
+#: pkg/kubernetes/views/remove-role-dialog.html:8 pkg/apps/application.jsx:94
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr "削除"
 
-#: pkg/networkmanager/interfaces.js:2945
+#: pkg/networkmanager/interfaces.js:2938
 msgid "Remove $0"
 msgstr "$0 の削除"
 
@@ -5672,26 +5577,25 @@ msgstr "イメージタグの削除"
 msgid "Remove membership"
 msgstr "メンバーシップの削除"
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
-msgstr ""
+msgstr "削除中"
 
-#: pkg/storaged/jobs-panel.jsx:57
+#: pkg/storaged/jobs.js:140
 msgid "Removing $target from RAID Device"
 msgstr "$target を RAID デバイスから削除"
 
-#: pkg/networkmanager/interfaces.js:2944
+#: pkg/networkmanager/interfaces.js:2937
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr "<b>$0</b> を削除すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
 
-#: pkg/storaged/jobs-panel.jsx:70
+#: pkg/storaged/jobs.js:153
 msgid "Removing physical volume from $target"
 msgstr "$target  から物理ボリュームを削除"
 
-#: pkg/storaged/lvol-tabs.jsx:44 pkg/storaged/vgroup-details.jsx:186
-#: pkg/storaged/vgroup-details.jsx:232
+#: pkg/storaged/details.jsx:382 pkg/storaged/lvol-tabs.jsx:44
 msgid "Rename"
 msgstr "名前変更"
 
@@ -5699,11 +5603,11 @@ msgstr "名前変更"
 msgid "Rename Logical Volume"
 msgstr "論理ボリュームの名前変更"
 
-#: pkg/storaged/vgroup-details.jsx:177
+#: pkg/storaged/details.jsx:124
 msgid "Rename Volume Group"
 msgstr "ボリュームグループの名前変更"
 
-#: pkg/storaged/jobs-panel.jsx:73
+#: pkg/storaged/jobs.js:156
 msgid "Renaming $target"
 msgstr "$target の名前変更"
 
@@ -5734,9 +5638,9 @@ msgstr "毎年繰り返す"
 msgid "Replicas"
 msgstr "レプリカ"
 
-#: pkg/kubernetes/views/replicationcontroller-page.html:14
-#: pkg/kubernetes/views/replicationcontroller-panel.html:10
 #: pkg/kubernetes/views/topology-page.html:22
+#: pkg/kubernetes/views/replicationcontroller-panel.html:10
+#: pkg/kubernetes/views/replicationcontroller-page.html:14
 msgid "Replication Controller"
 msgstr "レプリケーションコントローラー"
 
@@ -5751,21 +5655,13 @@ msgid ""
 "and remove pods when necessary."
 msgstr "レプリケーションコントローラーにより、テンプレートからポッドのインスタンスが動的に作成され、必要に応じてポッドが削除されます。"
 
-#: pkg/systemd/logs.js:437
-msgid "Report"
-msgstr ""
-
-#: pkg/systemd/logs.js:430
-msgid "Reported"
-msgstr ""
-
 #: pkg/systemd/logs.js:454
 msgid "Reporter 'reporter-ureport' not found."
-msgstr ""
+msgstr "レポーターの 'reporter-ureport' が見つかりませんでした。"
 
 #: pkg/systemd/logs.js:456
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
-msgstr ""
+msgstr "レポートは成功しませんでした。次を試してください: `reporter-ureport -d"
 
 #: pkg/docker/index.html:677
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:7
@@ -5786,11 +5682,11 @@ msgstr "要求"
 
 #: pkg/users/local.js:1220
 msgid "Require password change every $0 days"
-msgstr ""
+msgstr "パスワードを $0 日ごとに変更する"
 
 #: pkg/users/local.js:836
 msgid "Require password change on $0"
-msgstr ""
+msgstr "$0 でパスワードを変更する"
 
 #: pkg/kubernetes/views/auth-form.html:54
 msgid "Requires Authentication"
@@ -5800,8 +5696,8 @@ msgstr "認証が必要"
 msgid "Reserved memory"
 msgstr "予約済みメモリー"
 
-#: pkg/docker/index.html:294 pkg/users/index.html:381
-#: pkg/systemd/terminal.jsx:80
+#: pkg/users/index.html:381 pkg/docker/index.html:294
+#: pkg/systemd/terminal.jsx:81
 msgid "Reset"
 msgstr "リセット"
 
@@ -5827,14 +5723,14 @@ msgstr "ファイルシステムのサイズ変更"
 msgid "Resize Logical Volume"
 msgstr "論理ボリュームのサイズ変更"
 
-#: pkg/storaged/jobs-panel.jsx:74
+#: pkg/storaged/jobs.js:157
 msgid "Resizing $target"
 msgstr "$target のサイズ変更"
 
 #: pkg/docker/index.html:134 pkg/systemd/index.html:136
-#: pkg/systemd/index.html:143 pkg/docker/containers-view.jsx:239
-#: pkg/machines/hostvmslist.jsx:62 pkg/systemd/init.js:515
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/systemd/index.html:143 pkg/machines/hostvmslist.jsx:61
+#: pkg/docker/containers-view.jsx:239 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:515
 msgid "Restart"
 msgstr "再起動"
 
@@ -5842,10 +5738,9 @@ msgstr "再起動"
 msgid "Restart Count"
 msgstr "再起動回数"
 
-#: pkg/packagekit/updates.jsx:485
-#, fuzzy
+#: pkg/packagekit/updates.jsx:475
 msgid "Restart Now"
-msgstr "再起動"
+msgstr "すぐに再起動"
 
 #: pkg/docker/index.html:529 pkg/kubernetes/views/pod-body.html:10
 msgid "Restart Policy"
@@ -5855,15 +5750,13 @@ msgstr "再起動ポリシー"
 msgid "Restart Policy:"
 msgstr "再起動ポリシー:"
 
-#: pkg/packagekit/updates.jsx:480
-#, fuzzy
+#: pkg/packagekit/updates.jsx:470
 msgid "Restart Recommended"
-msgstr "推奨"
+msgstr "再起動が推奨されます"
 
-#: pkg/packagekit/updates.jsx:885
-#, fuzzy
+#: pkg/packagekit/updates.jsx:871
 msgid "Restarting"
-msgstr "再起動"
+msgstr "再起動中"
 
 #: pkg/networkmanager/index.html:39
 msgid "Restoring connection"
@@ -5881,10 +5774,10 @@ msgstr "再試行回数:"
 msgid "Retrieving subscription status..."
 msgstr "サブスクリプションステータスを再取得中 ..."
 
-#: pkg/shell/index.html:161
+#: pkg/shell/index.html:172
 msgid ""
 "Reuse my password for privileged tasks and to connect to other machines"
-msgstr "特権タスクの実行または他のマシンへの接続のためにパスワードを再使用します"
+msgstr "特権タスクの実行または他のマシンへの接続に、パスワードを再使用します"
 
 #: pkg/kubernetes/views/volume-body.html:26
 msgid "Revision"
@@ -5894,8 +5787,8 @@ msgstr "リビジョン"
 msgid "Role"
 msgstr "役職"
 
-#: pkg/kubernetes/views/project-body.html:21
-#: pkg/kubernetes/views/add-member-role-dialog.html:39 pkg/users/index.html:92
+#: pkg/users/index.html:92 pkg/kubernetes/views/project-body.html:21
+#: pkg/kubernetes/views/add-member-role-dialog.html:39
 msgid "Roles"
 msgstr "ロール"
 
@@ -5903,7 +5796,7 @@ msgstr "ロール"
 msgid "Roll Back and Reboot"
 msgstr "ロールバックおよび再起動"
 
-#: pkg/networkmanager/interfaces.js:1909 pkg/networkmanager/interfaces.js:1926
+#: pkg/networkmanager/interfaces.js:1904 pkg/networkmanager/interfaces.js:1921
 msgid "Round Robin"
 msgstr "ラウンドロビン"
 
@@ -5913,19 +5806,19 @@ msgid "Route"
 msgstr "ルート"
 
 #: pkg/kubernetes/views/details-page.html:65
-#: pkg/kubernetes/scripts/details.js:218 pkg/networkmanager/interfaces.js:3201
+#: pkg/networkmanager/interfaces.js:3194 pkg/kubernetes/scripts/details.js:218
 msgid "Routes"
 msgstr "ルート"
 
 #: pkg/docker/index.html:237 pkg/docker/index.html:556
-#: pkg/systemd/services.html:400 pkg/machines/hostvmslist.jsx:97
-#: pkg/ovirt/components/ClusterVms.jsx:84
+#: pkg/systemd/services.html:400 pkg/machines/hostvmslist.jsx:96
+#: pkg/ovirt/components/ClusterVms.jsx:83
 msgid "Run"
 msgstr "実行"
 
-#: pkg/ovirt/components/ClusterVms.jsx:89
+#: pkg/ovirt/components/ClusterVms.jsx:88
 msgid "Run Here"
-msgstr ""
+msgstr "ここから実行"
 
 #: pkg/docker/index.html:418
 msgid "Run Image"
@@ -5939,13 +5832,9 @@ msgstr "次で実行"
 msgid "Runner"
 msgstr "ランナー"
 
-#: pkg/ostree/index.html:251 pkg/storaged/mdraid-details.jsx:332
+#: pkg/ostree/index.html:251 pkg/storaged/details.jsx:318
 msgid "Running"
 msgstr "実行中"
-
-#: pkg/ovirt/components/VmOverviewColumn.jsx:74
-msgid "Running Since:"
-msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:345
 msgid "SELinux Access Control Errors"
@@ -5971,34 +5860,33 @@ msgstr "SELinux はシステムで無効です"
 msgid "SELinux system status is unknown."
 msgstr "SELinux システムステータスが不明です。"
 
-#: pkg/ovirt/provider.es6:96 pkg/ovirt/provider.es6:120
+#: pkg/ovirt/provider.es6:89 pkg/ovirt/provider.es6:113
 msgid "SHUTDOWN action failed"
-msgstr ""
+msgstr "SHUTDOWN アクションに失敗しました"
 
-#: pkg/storaged/jobs-panel.jsx:35
+#: pkg/storaged/jobs.js:118
 msgid "SMART self-test of $target"
 msgstr "$target の SMART 自己テスト"
 
 #: pkg/machines/components/desktopConsole.jsx:188
 msgid "SPICE"
-msgstr ""
+msgstr "SPICE"
 
 #: pkg/machines/components/desktopConsole.jsx:157
-#, fuzzy
 msgid "SPICE Address:"
-msgstr "IP アドレス:"
+msgstr "SPICE アドレス:"
 
 #: pkg/machines/components/desktopConsole.jsx:163
 msgid "SPICE Port:"
-msgstr ""
+msgstr "SPICE ポート:"
 
 #: pkg/machines/components/desktopConsole.jsx:166
 msgid "SPICE TLS Port:"
-msgstr ""
+msgstr "SPICE TLS ポート:"
 
-#: pkg/ovirt/provider.es6:180
+#: pkg/ovirt/provider.es6:173
 msgid "START action failed"
-msgstr ""
+msgstr "START アクションに失敗しました"
 
 #: pkg/networkmanager/index.html:242
 msgid "STP Forward delay"
@@ -6016,9 +5904,9 @@ msgstr "STP メッセージ最大期間"
 msgid "STP Priority"
 msgstr "STP 優先度"
 
-#: pkg/ovirt/provider.es6:258
+#: pkg/ovirt/provider.es6:248
 msgid "SUSPEND action failed"
-msgstr ""
+msgstr "SUSPEND アクションに失敗しました"
 
 #: pkg/systemd/services.html:199
 msgid "Saturday"
@@ -6041,7 +5929,6 @@ msgid "Scheduling Disabled"
 msgstr "スケジューリングの無効化"
 
 #: pkg/systemd/services.html:418 pkg/systemd/services.html:422
-#: pkg/systemd/init.js:971
 msgid "Seconds"
 msgstr "秒"
 
@@ -6067,7 +5954,7 @@ msgstr "シークレットボリューム"
 msgid "Secure Shell Keys"
 msgstr "セキュアシェルキー"
 
-#: pkg/storaged/jobs-panel.jsx:52
+#: pkg/storaged/jobs.js:135
 msgid "Securely erasing $target"
 msgstr "$target を安全に削除"
 
@@ -6075,12 +5962,11 @@ msgstr "$target を安全に削除"
 msgid "Security"
 msgstr "Security"
 
-#: pkg/packagekit/updates.jsx:255
-#, fuzzy
+#: pkg/packagekit/updates.jsx:245
 msgid "Security Update"
-msgstr "Security"
+msgstr "セキュリティー更新"
 
-#: pkg/shell/index.html:125 pkg/shell/simple.html:91 pkg/shell/stub.html:106
+#: pkg/shell/index.html:136 pkg/shell/stub.html:114 pkg/shell/simple.html:101
 msgid "Select"
 msgstr "選択"
 
@@ -6098,9 +5984,9 @@ msgid ""
 "{{#strong}}{{host}}{{/strong}}"
 msgstr "{{#strong}}{{host}}{{/strong}} と同期するユーザーを選択します"
 
-#: pkg/machines/hostvmslist.jsx:86
+#: pkg/machines/hostvmslist.jsx:85
 msgid "Send Non-Maskable Interrupt"
-msgstr ""
+msgstr "マスク不可割り込みを送信します"
 
 #: pkg/networkmanager/index.html:70 pkg/networkmanager/index.html:98
 #: pkg/networkmanager/index.html:116 pkg/networkmanager/index.html:557
@@ -6108,14 +5994,18 @@ msgstr ""
 msgid "Sending"
 msgstr "送信:"
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-panel.jsx:344
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/storaged/index.html:430
+msgctxt "storage"
+msgid "Serial Number"
+msgstr "シリアル番号"
+
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/kdump/kdump-view.jsx:127 pkg/subscriptions/subscriptions-register.jsx:64
 msgid "Server"
 msgstr "サーバー"
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-panel.jsx:129
+#: pkg/storaged/overview.js:523
 msgid "Server Address"
 msgstr "サーバーアドレス"
 
@@ -6123,13 +6013,9 @@ msgstr "サーバーアドレス"
 msgid "Server Administrator"
 msgstr "サーバー管理者"
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/overview.js:526
 msgid "Server address cannot be empty."
 msgstr "サーバーアドレスは空にできません。"
-
-#: pkg/storaged/nfs-panel.jsx:133
-msgid "Server cannot be empty."
-msgstr ""
 
 #: src/base1/cockpit.js:3958
 msgid "Server has closed the connection."
@@ -6139,9 +6025,9 @@ msgstr "サーバーの接続が終了しました。"
 msgid "Servers"
 msgstr "サーバー"
 
-#: pkg/kubernetes/views/service-page.html:12
-#: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30
+#: pkg/kubernetes/views/service-panel.html:8
+#: pkg/kubernetes/views/service-page.html:12
 msgid "Service"
 msgstr "サービス"
 
@@ -6177,9 +6063,10 @@ msgstr "サービスが停止中です"
 msgid "Service name"
 msgstr "サービス名"
 
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:289
 #: pkg/kubernetes/views/dashboard-page.html:134
-#: pkg/kubernetes/views/details-page.html:29 pkg/systemd/services.html:4
-#: pkg/systemd/services.html:289 pkg/kubernetes/scripts/details.js:215
+#: pkg/kubernetes/views/details-page.html:29
+#: pkg/kubernetes/scripts/details.js:215
 msgid "Services"
 msgstr "サービス"
 
@@ -6187,7 +6074,7 @@ msgstr "サービス"
 msgid ""
 "Services group pods and provide a common DNS name and an optional, load-"
 "balanced IP address to access them."
-msgstr "サービスはポッドをグループ化し、ポッドにアクセスするために共通の DNS 名とオプションのロードバランス IP アドレスを提供します。"
+msgstr "サービスはポッドをグループ化し、ポッドにアクセスするための共通の DNS 名と、任意のロードバランス IP アドレスを提供します。"
 
 #: pkg/machines/helpers.es6:104
 msgid "Session"
@@ -6197,11 +6084,11 @@ msgstr "セッション"
 msgid "Session Affinity"
 msgstr "セッションアフィニティー"
 
-#: pkg/dashboard/index.html:174 pkg/users/index.html:286
+#: pkg/users/index.html:286 pkg/dashboard/index.html:174
 msgid "Set"
 msgstr "セット"
 
-#: pkg/systemd/host.js:612
+#: pkg/systemd/host.js:608
 msgid "Set Host name"
 msgstr "ホスト名の設定"
 
@@ -6222,9 +6109,8 @@ msgid "Set to"
 msgstr "設定値"
 
 #: pkg/packagekit/updates.jsx:65
-#, fuzzy
 msgid "Set up"
-msgstr "設定値"
+msgstr "設定"
 
 #: pkg/selinux/setroubleshoot-view.jsx:282
 msgid ""
@@ -6232,24 +6118,22 @@ msgid ""
 msgstr "設定が設定された状態と異なるため、次回起動時に元の状態に戻ります。"
 
 #: pkg/packagekit/updates.jsx:57
-#, fuzzy
 msgid "Setting up"
-msgstr "IP 設定"
+msgstr "設定中"
 
-#: pkg/storaged/jobs-panel.jsx:47
+#: pkg/storaged/jobs.js:130
 msgid "Setting up loop device $target"
 msgstr "ループデバイス $target の設定"
 
 #: pkg/systemd/logs.html:47
-#, fuzzy
 msgid "Severity"
-msgstr "Security"
+msgstr "重大度"
 
 #: pkg/kubernetes/views/volume-body.html:139
 msgid "Share Name"
 msgstr "共有名"
 
-#: pkg/networkmanager/interfaces.js:1894
+#: pkg/networkmanager/interfaces.js:1889
 msgid "Shared"
 msgstr "共有"
 
@@ -6287,8 +6171,8 @@ msgid "Show all Pods"
 msgstr "すべてのポッドの表示"
 
 #: pkg/kubernetes/views/group-page.html:14
-#: pkg/kubernetes/views/project-page.html:23
 #: pkg/kubernetes/views/user-page.html:16
+#: pkg/kubernetes/views/project-page.html:23
 msgid "Show all Projects"
 msgstr "すべてのプロジェクトの表示"
 
@@ -6320,7 +6204,7 @@ msgstr "すべてのイメージの表示"
 msgid "Show fingerprints"
 msgstr "フィンガープリントの表示"
 
-#: pkg/systemd/index.html:146 pkg/machines/hostvmslist.jsx:76
+#: pkg/systemd/index.html:146 pkg/machines/hostvmslist.jsx:75
 #: pkg/systemd/shutdown.js:93 pkg/systemd/shutdown.js:94
 msgid "Shut Down"
 msgstr "シャットダウン"
@@ -6341,28 +6225,28 @@ msgstr "以降"
 msgid "Since $0"
 msgstr "$0 以降"
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:587
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:644
-#: pkg/storaged/format-dialog.jsx:266 pkg/storaged/fsys-panel.jsx:108
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/storaged/index.html:230
+#: pkg/docker/containers-view.jsx:587 pkg/storaged/part-tab.jsx:41
 #: pkg/storaged/lvol-tabs.jsx:70 pkg/storaged/lvol-tabs.jsx:122
 #: pkg/storaged/lvol-tabs.jsx:161 pkg/storaged/lvol-tabs.jsx:198
-#: pkg/storaged/nfs-panel.jsx:352 pkg/storaged/part-tab.jsx:41
+#: pkg/storaged/content-views.jsx:112 pkg/storaged/content-views.jsx:706
+#: pkg/storaged/format-dialog.jsx:128
 msgid "Size"
 msgstr "Size"
 
-#: pkg/storaged/dialog.js:406
+#: pkg/storaged/dialog.js:322
 msgid "Size cannot be negative"
 msgstr "サイズはマイナスにすることができません"
 
-#: pkg/storaged/dialog.js:404
+#: pkg/storaged/dialog.js:320
 msgid "Size cannot be zero"
 msgstr "サイズはゼロにすることができません"
 
-#: pkg/storaged/dialog.js:408
+#: pkg/storaged/dialog.js:324
 msgid "Size is too large"
 msgstr "サイズが大きすぎます"
 
-#: pkg/storaged/dialog.js:402
+#: pkg/storaged/dialog.js:318
 msgid "Size must be a number"
 msgstr "サイズは数値である必要があります"
 
@@ -6375,7 +6259,7 @@ msgstr "証明書検証の省略"
 msgid "Sockets"
 msgstr "ソケット"
 
-#: pkg/ostree/index.html:23 pkg/packagekit/index.html:23
+#: pkg/packagekit/index.html:23 pkg/ostree/index.html:23
 msgid "Software Updates"
 msgstr "ソフトウェア更新"
 
@@ -6383,7 +6267,7 @@ msgstr "ソフトウェア更新"
 msgid "Solid-State Disk"
 msgstr "ソリッドステートディスク"
 
-#: pkg/storaged/drives-panel.jsx:87
+#: pkg/storaged/overview.js:182
 msgctxt "storage"
 msgid "Solid-State Disk"
 msgstr "ソリッドステートディスク"
@@ -6403,13 +6287,13 @@ msgstr "ソリューション"
 #: pkg/packagekit/updates.jsx:33
 msgid ""
 "Some other program is currently using the package manager, please wait..."
-msgstr ""
+msgstr "別のプログラムがパッケージマネージャーを使用中です。しばらくお待ちください..."
 
 #: pkg/kubernetes/scripts/volumes.js:906
 msgid "Sorry, I don't know how to modify this volume"
-msgstr "申し訳ありませんが、このボリュームを変更する方法がわかりません"
+msgstr "このボリュームを変更する方法がわかりません"
 
-#: pkg/machines/vmdiskstab.jsx:141 pkg/machines/vmnetworktab.jsx:71
+#: pkg/machines/vmdiskstab.jsx:141
 msgid "Source"
 msgstr "ソース"
 
@@ -6417,7 +6301,7 @@ msgstr "ソース"
 msgid "Source URL"
 msgstr "ソース URL"
 
-#: pkg/networkmanager/interfaces.js:2747
+#: pkg/networkmanager/interfaces.js:2740
 msgid "Spanning Tree Protocol"
 msgstr "スパニング ツリープロトコル"
 
@@ -6425,7 +6309,7 @@ msgstr "スパニング ツリープロトコル"
 msgid "Spanning Tree Protocol (STP)"
 msgstr "スパニング ツリープロトコル (STP)"
 
-#: pkg/storaged/mdraid-details.jsx:100
+#: pkg/storaged/sidebar-views.jsx:124
 msgid "Spare"
 msgstr "スペア"
 
@@ -6433,13 +6317,13 @@ msgstr "スペア"
 msgid "Specific Time"
 msgstr "特定の時間"
 
-#: pkg/networkmanager/interfaces.js:3510
+#: pkg/networkmanager/interfaces.js:3503
 msgid "Stable"
 msgstr "安定"
 
 #: pkg/docker/index.html:132 pkg/docker/containers-view.jsx:236
-#: pkg/storaged/mdraid-details.jsx:296 pkg/storaged/swap-tab.jsx:76
-#: pkg/systemd/init.js:513
+#: pkg/systemd/init.js:513 pkg/storaged/details.jsx:330
+#: pkg/storaged/swap-tab.jsx:76
 msgid "Start"
 msgstr "開始日"
 
@@ -6451,15 +6335,15 @@ msgstr "Docker の起動"
 msgid "Start Multipath"
 msgstr "マルチパスの開始"
 
-#: pkg/storaged/mdraid-details.jsx:298
+#: pkg/storaged/details.jsx:332
 msgid "Start Scrubbing"
 msgstr "Scrubbing の起動"
 
-#: pkg/storaged/jobs-panel.jsx:55
+#: pkg/storaged/jobs.js:138
 msgid "Starting RAID Device $target"
 msgstr "RAID デバイス $target の起動"
 
-#: pkg/storaged/jobs-panel.jsx:40
+#: pkg/storaged/jobs.js:123
 msgid "Starting swapspace $target"
 msgstr "スワップ領域 $target の起動"
 
@@ -6469,37 +6353,42 @@ msgstr "開始"
 
 #: pkg/kubernetes/views/container-body.html:16
 #: pkg/kubernetes/views/details-page.html:38
-#: pkg/kubernetes/views/details-page.html:175
-#: pkg/docker/containers-view.jsx:125 pkg/docker/containers-view.jsx:271
-#: pkg/machines/hostvmslist.jsx:504 pkg/machines/vmnetworktab.jsx:120
-#: pkg/ovirt/components/ClusterVms.jsx:176 pkg/systemd/init.js:275
+#: pkg/kubernetes/views/details-page.html:175 pkg/machines/hostvmslist.jsx:476
+#: pkg/ovirt/components/ClusterVms.jsx:177 pkg/docker/containers-view.jsx:125
+#: pkg/docker/containers-view.jsx:271 pkg/systemd/init.js:275
 msgid "State"
 msgstr "状態"
+
+#: pkg/storaged/index.html:570
+msgctxt "storage"
+msgid "State"
+msgstr "ステート"
 
 #: pkg/docker/index.html:165
 msgid "State:"
 msgstr "状態:"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:138
-#: pkg/ovirt/components/ClusterVms.jsx:174
+#: pkg/ovirt/components/ClusterVms.jsx:175
+#: pkg/ovirt/components/ClusterTemplates.jsx:129
 msgid "Stateless"
-msgstr ""
+msgstr "ステートレス"
 
 #: pkg/ovirt/components/OVirtTab.jsx:151
 msgid "Stateless:"
-msgstr ""
+msgstr "ステートレス:"
 
 #: pkg/systemd/init.js:304
 msgid "Static"
 msgstr "静的"
 
+#: pkg/ostree/index.html:288 pkg/kubernetes/views/pv-body.html:24
+#: pkg/kubernetes/views/pvc-body.html:13 pkg/kubernetes/views/pv-claim.html:29
 #: pkg/kubernetes/views/containers-listing.html:16
+#: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
-#: pkg/kubernetes/views/volumes-page.html:21 pkg/ostree/index.html:288
-#: pkg/networkmanager/interfaces.js:2503
 #: pkg/subscriptions/subscriptions-view.jsx:36
+#: pkg/networkmanager/interfaces.js:2496
 msgid "Status"
 msgstr "状態"
 
@@ -6516,22 +6405,14 @@ msgid "Sticky"
 msgstr "スティッキー"
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:234
-#: pkg/storaged/mdraid-details.jsx:297 pkg/storaged/swap-tab.jsx:75
-#: pkg/systemd/init.js:514
+#: pkg/systemd/init.js:514 pkg/storaged/details.jsx:331
+#: pkg/storaged/swap-tab.jsx:75
 msgid "Stop"
 msgstr "停止"
 
-#: pkg/storaged/mdraid-details.jsx:299
+#: pkg/storaged/details.jsx:333
 msgid "Stop Scrubbing"
 msgstr "Scrubbing の停止"
-
-#: pkg/storaged/nfs-panel.jsx:259
-msgid "Stop and remove"
-msgstr ""
-
-#: pkg/storaged/nfs-panel.jsx:240
-msgid "Stop and unmount"
-msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-config.html:14
 msgid "Stop with"
@@ -6541,20 +6422,24 @@ msgstr "停止"
 msgid "Stopped"
 msgstr "停止中"
 
-#: pkg/storaged/jobs-panel.jsx:54
+#: pkg/storaged/jobs.js:137
 msgid "Stopping RAID Device $target"
 msgstr "RAID デバイス $target の停止"
 
-#: pkg/storaged/jobs-panel.jsx:41
+#: pkg/storaged/jobs.js:124
 msgid "Stopping swapspace $target"
 msgstr "スワップ領域 $target の停止"
 
 #: pkg/docker/index.html:281 pkg/storaged/index.html:23
-#: pkg/storaged/details.jsx:129
+#: pkg/storaged/index.html:607
 msgid "Storage"
 msgstr "ストレージ"
 
-#: pkg/storaged/logs-panel.jsx:37
+#: pkg/storaged/index.html:621
+msgid "Storage Log"
+msgstr "ストレージログ"
+
+#: pkg/storaged/index.html:340
 msgid "Storage Logs"
 msgstr "ストレージログ"
 
@@ -6566,7 +6451,7 @@ msgstr "ストレージプール"
 msgid "Store Performance Data"
 msgstr "パフォーマンスデータの保存"
 
-#: pkg/storaged/format-dialog.jsx:311
+#: pkg/storaged/format-dialog.jsx:173
 msgid "Store passphrase"
 msgstr "パスフレーズの保存"
 
@@ -6574,7 +6459,7 @@ msgstr "パスフレーズの保存"
 msgid "Stored Passphrase"
 msgstr "保存されたパスフレーズ"
 
-#: pkg/storaged/crypto-tab.jsx:134
+#: pkg/storaged/crypto-tab.jsx:139
 msgid "Stored passphrase"
 msgstr "保存されたパスフレーズ"
 
@@ -6596,62 +6481,50 @@ msgstr "日曜日"
 
 #: pkg/ovirt/components/VmActions.jsx:42
 msgid "Suspend"
-msgstr ""
+msgstr "一時停止"
 
-#: pkg/storaged/content-views.jsx:151
+#: pkg/storaged/content-views.jsx:152
 msgid "Swap"
 msgstr "スワップ"
 
-#: pkg/storaged/content-views.jsx:319
+#: pkg/storaged/content-views.jsx:320
 msgctxt "storage-id-desc"
 msgid "Swap Space"
 msgstr "スワップ領域"
 
-#: pkg/systemd/index.html:253 pkg/systemd/host.js:1473
+#: pkg/systemd/index.html:253 pkg/systemd/host.js:1466
 msgid "Swap Used"
 msgstr "使用済みスワップ"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:43
-msgid "Switch Host to Maintenance"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2387 pkg/networkmanager/interfaces.js:2929
+#: pkg/networkmanager/interfaces.js:2380 pkg/networkmanager/interfaces.js:2922
 msgid "Switch off $0"
 msgstr "$0 をオフにする"
 
-#: pkg/networkmanager/interfaces.js:2362 pkg/networkmanager/interfaces.js:2917
+#: pkg/networkmanager/interfaces.js:2355 pkg/networkmanager/interfaces.js:2910
 msgid "Switch on $0"
 msgstr "$0 をオンにする"
 
 #: pkg/machines/components/graphicsConsole.jsx:60
 msgid "Switch to Desktop Viewer"
-msgstr ""
+msgstr "デスクトップビューアーに切り替える"
 
 #: pkg/machines/components/graphicsConsole.jsx:70
 msgid "Switch to In-Browser Viewer"
-msgstr ""
+msgstr "ブラウザー内ビューアーに切り替えます。"
 
-#: pkg/ovirt/provider.es6:369
-msgid "Switching host to maintenance mode failed. Received error: "
-msgstr ""
-
-#: pkg/ovirt/provider.es6:363
-msgid "Switching host to maintenance mode in progress ..."
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2386
+#: pkg/networkmanager/interfaces.js:2379
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
 msgstr "<b>$0</b> をオフにすると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
 
-#: pkg/networkmanager/interfaces.js:2928
+#: pkg/networkmanager/interfaces.js:2921
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
-msgstr "<b>$0</b> をオフにすると、サーバーへの接続が切断され、管理 UI が利用できなくなります。1"
+msgstr "<b>$0</b> をオフにすると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
 
-#: pkg/networkmanager/interfaces.js:2361 pkg/networkmanager/interfaces.js:2916
+#: pkg/networkmanager/interfaces.js:2354 pkg/networkmanager/interfaces.js:2909
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6665,7 +6538,7 @@ msgstr "リモートイメージリポジトリーからすべてのタグを同
 msgid "Synchronize"
 msgstr "同期"
 
-#: pkg/dashboard/index.html:172 pkg/lib/machine-sync-users.html:4
+#: pkg/lib/machine-sync-users.html:4 pkg/dashboard/index.html:172
 msgid "Synchronize users"
 msgstr "ユーザーの同期"
 
@@ -6677,7 +6550,7 @@ msgstr "同期済み"
 msgid "Synchronized with {{Server}}"
 msgstr "{{Server}} と同期済み"
 
-#: pkg/storaged/jobs-panel.jsx:62
+#: pkg/storaged/jobs.js:145
 msgid "Synchronizing RAID Device $target"
 msgstr "RAID デバイス $target の同期"
 
@@ -6693,9 +6566,9 @@ msgstr "システムサービス"
 msgid "System Time"
 msgstr "システム時間"
 
-#: pkg/packagekit/updates.jsx:914
+#: pkg/packagekit/updates.jsx:900
 msgid "System is up to date"
-msgstr ""
+msgstr "システムは最新の状態です"
 
 #: pkg/docker/index.html:320 pkg/docker/index.html:324
 msgid "TCP"
@@ -6712,14 +6585,13 @@ msgstr "タグ"
 
 #: pkg/kubernetes/views/imagestream-modify.html:76
 #: node_modules/registry-image-widgets/views/image-body.html:29
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
+#: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: pkg/docker/containers-view.jsx:312
 msgid "Tags"
 msgstr "タグ"
 
 #: pkg/kubernetes/views/pv-modify.html:136 pkg/machines/vmdiskstab.jsx:134
-#: pkg/machines/vmnetworktab.jsx:70
 msgid "Target"
 msgstr "ターゲット"
 
@@ -6731,18 +6603,18 @@ msgstr "ターゲットポータル"
 msgid "Target World Wide Names"
 msgstr "ターゲットワールドワイド名"
 
-#: pkg/systemd/services.html:52 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:52 pkg/storaged/overview.js:628
 msgid "Targets"
 msgstr "ターゲット"
 
-#: pkg/networkmanager/interfaces.js:2407 pkg/networkmanager/interfaces.js:2419
-#: pkg/networkmanager/interfaces.js:2704
+#: pkg/networkmanager/interfaces.js:2400 pkg/networkmanager/interfaces.js:2412
+#: pkg/networkmanager/interfaces.js:2697
 msgid "Team"
 msgstr "チーム"
 
-#: pkg/networkmanager/interfaces.js:2732
+#: pkg/networkmanager/interfaces.js:2725
 msgid "Team Port"
-msgstr "Team ポート"
+msgstr "チームポート"
 
 #: pkg/networkmanager/index.html:680
 msgid "Team Port Settings"
@@ -6753,20 +6625,16 @@ msgid "Team Settings"
 msgstr "チーム設定"
 
 #: pkg/kubernetes/views/deploymentconfig-page.html:15
+#: pkg/kubernetes/views/replicationcontroller-panel.html:14
 #: pkg/kubernetes/views/deploymentconfig-panel.html:10
 #: pkg/kubernetes/views/replicationcontroller-page.html:20
-#: pkg/kubernetes/views/replicationcontroller-panel.html:14
-#: pkg/ovirt/components/ClusterVms.jsx:173
+#: pkg/ovirt/components/ClusterVms.jsx:174
 msgid "Template"
 msgstr "テンプレート"
 
-#: pkg/ovirt/components/App.jsx:81
+#: pkg/ovirt/components/App.jsx:78
 msgid "Templates"
-msgstr ""
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:132
-msgid "Templates of $0 cluster"
-msgstr ""
+msgstr "テンプレート"
 
 #: pkg/systemd/terminal.html:4
 msgid "Terminal"
@@ -6782,7 +6650,7 @@ msgstr "設定のテスト"
 
 #: pkg/kdump/kdump-view.jsx:480
 msgid "Test is only available while the kdump service is running."
-msgstr "テストは kdump サービスが実行中の間だけ利用可能です。"
+msgstr "テストは、kdump サービスが実行中の間だけ利用できます。"
 
 #: pkg/kdump/kdump-view.jsx:300
 msgid "Test kdump settings"
@@ -6794,68 +6662,67 @@ msgstr "接続のテスト"
 
 #: pkg/storaged/index.html:40
 msgid "The \"storaged\" API is not available on this system."
-msgstr "\"storaged\" API はこのシステムでは利用できません。"
+msgstr "\"storaged\" API は、このシステムでは利用できません。"
 
 #: pkg/docker/storage.jsx:496
 msgid "The Docker storage pool cannot be managed on this system."
-msgstr "Docker ストレージプールはこのシステムで管理できません。"
+msgstr "Docker ストレージプールは、このシステムで管理できません。"
 
 #: pkg/lib/machine-dialogs.js:385
 msgid "The IP address or host name cannot contain whitespace."
-msgstr "IP アドレスまたはホスト名にはスペースを含めることができません。"
+msgstr "IP アドレスまたはホスト名には、スペースを含めることができません。"
 
-#: pkg/storaged/mdraid-details.jsx:218
+#: pkg/storaged/index.html:530
 msgid "The RAID Array is in a degraded state"
 msgstr "RAID アレイは劣化状態にあります"
 
-#: pkg/storaged/mdraid-details.jsx:148
-#, fuzzy
+#: pkg/storaged/sidebar-views.jsx:172
 msgid "The RAID device must be running in order to add spare disks."
-msgstr "スペアディスクを追加する場合は、MDRAID デバイスが実行中である必要があります。"
+msgstr "スペアディスクを追加する場合は、RAID デバイスが実行中である必要があります。"
 
-#: pkg/storaged/mdraid-details.jsx:114
+#: pkg/storaged/sidebar-views.jsx:138
 msgid "The RAID device must be running in order to remove disks."
 msgstr "ディスクを取り外す場合は、RAID デバイスが実行中である必要があります。"
 
-#: pkg/machines/hostvmslist.jsx:160
+#: pkg/machines/hostvmslist.jsx:159
 msgid "The VM crashed."
 msgstr "VM がクラッシュしました。"
 
-#: pkg/machines/hostvmslist.jsx:159
+#: pkg/machines/hostvmslist.jsx:158
 msgid "The VM is down."
 msgstr "VM がダウンしています。"
 
-#: pkg/machines/hostvmslist.jsx:158
+#: pkg/machines/hostvmslist.jsx:157
 msgid "The VM is going down."
 msgstr "VM がダウンします。"
 
-#: pkg/machines/hostvmslist.jsx:156
+#: pkg/machines/hostvmslist.jsx:155
 msgid "The VM is idle."
 msgstr "VM がアイドル状態です。"
 
-#: pkg/machines/hostvmslist.jsx:162
+#: pkg/machines/hostvmslist.jsx:161
 msgid "The VM is in process of dying (shut down or crash is not completed)."
 msgstr "VM が終了中の状態です (シャットダウンまたはクラッシュが完了していません)。"
 
-#: pkg/machines/hostvmslist.jsx:157
+#: pkg/machines/hostvmslist.jsx:156
 msgid "The VM is paused."
 msgstr "VM が一時停止しています。"
 
 #: pkg/machines/components/deleteDialog.jsx:53
 msgid "The VM is running and will be forced off before deletion."
-msgstr ""
+msgstr "仮想マシンが稼動しているため、削除前に強制的に電源がオフになります。"
 
-#: pkg/machines/hostvmslist.jsx:155
+#: pkg/machines/hostvmslist.jsx:154
 msgid "The VM is running."
 msgstr "VM が実行中です。"
 
-#: pkg/machines/hostvmslist.jsx:163
+#: pkg/machines/hostvmslist.jsx:162
 msgid "The VM is suspended by guest power management."
 msgstr "VM はゲストの電源管理によって一時停止されています。"
 
 #: pkg/users/local.js:1259
 msgid "The account '$0' will be forced to change their password on next login"
-msgstr ""
+msgstr "アカウント '$0' が次回ログインする際に、パスワードの変更が求められます"
 
 #: pkg/kubernetes/scripts/nodes.js:403
 msgid "The address contains invalid characters"
@@ -6869,7 +6736,7 @@ msgstr "ホスト {{#strong}}{{host}}{{/strong}} の認証を確立できませ�
 
 #: pkg/sosreport/index.html:35
 msgid "The collected information will be stored locally on the system."
-msgstr "収集された情報はシステムにローカルで保存されます。"
+msgstr "収集した情報は、システムのローカルに保存されます。"
 
 #: pkg/selinux/setroubleshoot-view.jsx:280
 msgid "The configured state is unknown, it might change on the next boot."
@@ -6881,32 +6748,26 @@ msgstr "コンテナー '{{ target }}' が存在しません。"
 
 #: pkg/subscriptions/subscriptions-view.jsx:192
 msgid "The current user isn't allowed to access system subscription status."
-msgstr "現在のユーザーにはシステムサブスクリプションステータスへのアクセスが許可されていません。"
+msgstr "現在のユーザーには、システムサブスクリプションステータスへのアクセスが許可されていません。"
 
 #: pkg/kubernetes/views/deploymentconfig-page.html:25
 msgid "The deployment config '{{ target }}' does not exist."
 msgstr "デプロイメント設定 '{{ target }}' が存在しません。"
 
-#: pkg/storaged/index.html:316
-msgid ""
-"The filesystem is in use by system services or login sessions.               "
-" Proceeding will stop these services and sessions."
-msgstr ""
-
-#: pkg/packagekit/updates.jsx:357
+#: pkg/packagekit/updates.jsx:347
 msgid "The following packages were recently updated:"
-msgstr ""
+msgstr "以下のパッケージは最近更新されました:"
 
-#: pkg/packagekit/updates.jsx:356
+#: pkg/packagekit/updates.jsx:346
 msgid "The following packages were updated $0:"
-msgstr ""
+msgstr "以下のパッケージが更新されました $0:"
 
 #: pkg/sosreport/index.html:51
 msgid ""
 "The generated archive contains data considered sensitive and its content "
 "should be reviewed by the originating organization before being passed to "
 "any third party."
-msgstr "生成されたアーカイブには、機密データと見なされるデータが含まれます。その内容はサードパーティーに渡す前に元の組織が確認する必要があります。"
+msgstr "生成されたアーカイブには、機密データと見なされるデータが含まれます。サードパーティーに渡す前に、所属先の組織に確認してください。"
 
 #: pkg/kubernetes/views/group-page.html:47
 msgid "The group '{{ groupName }}' does not exist."
@@ -6919,21 +6780,21 @@ msgid ""
 "is trying to attack your connection to this machine."
 msgstr ""
 "{{#strong}}{{host}}{{/strong}} "
-"の鍵が、以前に使用された鍵と一致しません。このマシンが最近置き換えられたものでない限り、誰かがこのマシンへの接続を攻撃しようとしている可能性があります。"
+"の鍵が、以前に使用された鍵と一致しません。このマシンを最近取り換えた場合を除いて、誰かがこのマシンへの接続を攻撃しようとしている可能性があります。"
 
 #: pkg/users/authorized-keys.js:119
 msgid "The key you provided was not valid."
 msgstr "提供した鍵が有効ではありません。"
 
-#: pkg/storaged/mdraid-details.jsx:120
+#: pkg/storaged/sidebar-views.jsx:144
 msgid "The last disk of a RAID device cannot be removed."
-msgstr "RAID デバイスの最後のディスクは取り外すことができません。"
+msgstr "RAID デバイスの最後のディスクは、取り外すことができません。"
 
-#: pkg/storaged/vgroup-details.jsx:94
+#: pkg/storaged/sidebar-views.jsx:278
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "ボリュームグループの最後の物理ボリュームは削除できません。"
 
-#: pkg/shell/indexes.js:396
+#: pkg/shell/indexes.js:324
 msgid "The machine is restarting"
 msgstr "マシンが再起動中です"
 
@@ -6987,29 +6848,29 @@ msgstr "ルート '{{ target }}' が存在しません。"
 
 #: pkg/docker/containers-view.jsx:338
 msgid "The scan from $time ($type) found no vulnerabilities."
-msgstr ""
+msgstr "$time ($type) のスキャンでは、脆弱性は見つかりませんでした。"
 
 #: pkg/docker/containers-view.jsx:335
 msgid "The scan from $time ($type) was not successful."
-msgstr ""
+msgstr "$time ($type) のスキャンは成功しませんでした。"
 
 #: pkg/kubernetes/scripts/dashboard.js:386
 msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr "選択されたファイルは有効な Kubernetes アプリケーションマニフェストではありません。"
+msgstr "選択されたファイルは、有効な Kubernetes アプリケーションマニフェストではありません。"
 
-#: src/ws/login.js:588
+#: src/ws/login.js:585
 msgid ""
 "The server refused to authenticate '$0' using password authentication, and "
 "no other supported authentication methods are available."
-msgstr "サーバーはパスワード認証を使用した '$0' の認証を拒否しました。サポートされた他の認証方法は利用できません。"
+msgstr "サーバーは、パスワード認証を使用した '$0' の認証を拒否しました。その他に利用できる、サポートされている認証方法はありません。"
 
 #: src/base1/cockpit.js:3942
 msgid "The server refused to authenticate using any supported methods."
-msgstr "サーバーはサポートされた方法を使用した認証を拒否しました。"
+msgstr "サーバーは、サポートされた方法を使用した認証を拒否しました。"
 
 #: pkg/kubernetes/views/auth-rejected-cert.html:2
 msgid "The server uses a certificate signed by an unknown authority."
-msgstr "サーバーは不明な認証局によって署名された証明書を使用します。"
+msgstr "サーバーは、不明な認証局が署名した証明書を使用します。"
 
 #: pkg/kubernetes/views/service-page.html:19
 msgid "The service '{{ target }}' does not exist."
@@ -7019,7 +6880,7 @@ msgstr "サービス '{{ target }}' は存在しません。"
 msgid ""
 "The storage pool will be reset to optimize its layout.  All containers will "
 "be erased."
-msgstr "ストレージプールはそのレイアウトを最適化するためにリセットされます。すべてのコンテナーは削除されます。"
+msgstr "ストレージプールは、そのレイアウトを最適化するためにリセットされます。すべてのコンテナーは削除されます。"
 
 #: pkg/kubernetes/views/user-page.html:29
 msgid "The user '{{ userName }}' does not exist."
@@ -7027,36 +6888,35 @@ msgstr "ユーザー '{{ userName }}' は存在しません。"
 
 #: pkg/systemd/init.js:837
 msgid "The user <b>$0</b> does not have permissions for creating timers"
-msgstr "ユーザー <b>$0</b> はタイマーを作成するパーミッションを持っていません"
+msgstr "ユーザー <b>$0</b> は、タイマーを作成するパーミッションを持っていません"
 
 #: pkg/dashboard/list.js:209
 msgid "The user <b>$0</b> is not permitted to manage servers"
-msgstr "ユーザー <b>$0</b> はサーバーを管理することを許可されていません"
+msgstr "ユーザー <b>$0</b> は、サーバーを管理することを許可されていません"
 
-#: pkg/storaged/storage-controls.jsx:65
+#: pkg/storaged/permissions.js:60 pkg/storaged/storage-controls.jsx:79
 msgid "The user <b>$0</b> is not permitted to manage storage"
-msgstr "ユーザー <b>$0</b> はストレージを管理することを許可されていません"
+msgstr "ユーザー <b>$0</b> は、ストレージを管理することを許可されていません"
 
 #: pkg/users/local.js:41
 msgid "The user <b>$0</b> is not permitted to modify accounts"
-msgstr "ユーザー <b>$0</b> はアカウントを変更することを許可されていません"
+msgstr "ユーザー <b>$0</b> は、アカウントを変更することを許可されていません"
 
 #: pkg/systemd/host.js:46
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
-msgstr "ユーザー <b>$0</b> はホスト名を変更することを許可されていません"
+msgstr "ユーザー <b>$0</b> は、ホスト名を変更することを許可されていません"
 
-#: pkg/networkmanager/interfaces.js:1456
+#: pkg/networkmanager/interfaces.js:1453
 msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr "ユーザー <b>$0</b> はネットワーク設定を変更することを許可されていません"
+msgstr "ユーザー <b>$0</b> は、ネットワーク設定を変更することを許可されていません"
 
 #: pkg/realmd/operation.js:450
 msgid "The user <b>$0</b> is not permitted to modify realms"
-msgstr "ユーザー <b>$0</b> はレルムを変更することを許可されていません"
+msgstr "ユーザー <b>$0</b> は、レルムを変更することを許可されていません"
 
 #: pkg/systemd/host.js:54
-#, fuzzy
 msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
-msgstr "ユーザー <b>$0</b> はサーバーを管理することを許可されていません"
+msgstr "ユーザー <b>$0</b> は、このサーバーをシャットダウンまたは再起動することを許可されていません"
 
 #: pkg/users/local.js:518
 msgid ""
@@ -7064,7 +6924,7 @@ msgid ""
 "underscores."
 msgstr "ユーザー名は a〜z の文字、数字、ドット、ダッシュ、およびアンダースコアだけで構成されます。"
 
-#: src/ws/login.js:127
+#: src/ws/login.js:124
 msgid ""
 "The web browser configuration prevents Cockpit from running (inaccessible "
 "$0)"
@@ -7084,20 +6944,15 @@ msgstr "システムに複数のパスを持つデバイスがありますが、
 msgid "There are no authorized public keys for this account."
 msgstr "このアカウントに承認された公開鍵がありません。"
 
-#: pkg/storaged/vgroup-details.jsx:100
-#, fuzzy
+#: pkg/storaged/sidebar-views.jsx:284
 msgid ""
 "There is not enough free space elsewhere to remove this physical volume. At "
 "least $0 more free space is needed."
 msgstr "この物理ボリュームを削除するのに十分な空き領域がありません。少なくとも $0 の空き領域が必要です。"
 
-#: pkg/storaged/utils.js:174
+#: pkg/storaged/utils.js:175
 msgid "Thin Logical Volume"
 msgstr "シン論理ボリューム"
-
-#: pkg/storaged/nfs-panel.jsx:126
-msgid "This NFS mount is in use and only its options can be changed."
-msgstr ""
 
 #: pkg/kubernetes/views/pvc-delete.html:8
 msgid ""
@@ -7108,46 +6963,52 @@ msgstr "このクレームは使用中です。クレームを削除すると、
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
-msgstr "この日はすべての月で存在しません。<br> タイマーは 31 日がある月でのみ実行されます。"
+msgstr "この日は、すべての月に存在するわけではありません。<br>この タイマーは、31 日がある月でのみ実行されます。"
 
 #: pkg/ostree/index.html:327
 msgid ""
 "This deployment contains the same packages as your currently booted system"
 msgstr "このデプロイメントには、現在起動されているシステムと同じパッケージが含まれています"
 
-#: pkg/networkmanager/interfaces.js:2514
+#: pkg/networkmanager/interfaces.js:2507
 msgid "This device cannot be managed here."
 msgstr "このデバイスはここで管理できません。"
 
-#: pkg/storaged/index.html:289
+#: pkg/storaged/index.html:822
 msgid ""
 "This device has filesystems that are currently in use.                "
 "Proceeding will unmount all filesystems on it."
 msgstr ""
+"このデバイスには、現在使用中のファイルシステムがあります。                "
+"続行すると、このデバイスのファイルシステムをすべてアンマウントします。"
 
-#: pkg/storaged/index.html:110
+#: pkg/storaged/index.html:672
 msgid "This device is currently used for RAID devices."
-msgstr ""
+msgstr "このデバイスは、現在 RAID デバイスに使用されています。"
 
-#: pkg/storaged/index.html:307
+#: pkg/storaged/index.html:840
 msgid ""
 "This device is currently used for RAID devices.                Proceeding "
 "will remove it from its RAID devices."
 msgstr ""
+"このデバイスは、現在 RAID デバイスに使用されています。                続行すると、RAID "
+"デバイスからこのデバイスが削除されます。"
 
-#: pkg/storaged/index.html:102
+#: pkg/storaged/index.html:664
 msgid "This device is currently used for volume groups."
-msgstr ""
+msgstr "このデバイスは、現在ボリュームグループに使用されています。"
 
-#: pkg/storaged/index.html:298
+#: pkg/storaged/index.html:831
 msgid ""
 "This device is currently used for volume groups.                Proceeding "
 "will remove it from its volume groups."
 msgstr ""
+"このデバイスは現在ボリュームグループに使用されています。                "
+"続行すると、そのボリュームグループからこのデバイスが削除されます。"
 
-#: pkg/storaged/mdraid-details.jsx:116
+#: pkg/storaged/sidebar-views.jsx:140
 msgid "This disk cannot be removed while the device is recovering."
-msgstr "このディスクは、デバイスが復旧中に取り外すことができません。"
+msgstr "このディスクは、デバイスの復旧中に取り外すことができません。"
 
 #: pkg/systemd/init.js:1144 pkg/systemd/init.js:1156 pkg/systemd/init.js:1163
 msgid "This field cannot be empty."
@@ -7159,7 +7020,7 @@ msgstr "このイメージは存在しません。"
 
 #: pkg/storaged/lvol-tabs.jsx:96
 msgid "This logical volume cannot be made smaller."
-msgstr "この論理ボリュームは小さくすることができません。"
+msgstr "この論理ボリュームは、小さくすることができません。"
 
 #: pkg/lib/machine-dialogs.js:363
 msgid "This machine has already been added."
@@ -7173,20 +7034,20 @@ msgstr "これにはしばらく時間がかかることがあります"
 msgid ""
 "This option is for single node testing only – local storage will not work in "
 "a multi-node cluster"
-msgstr "このオプションは単一ノードのテストにのみ使用できます – ローカルストレージはマルチノードクラスターで動作しません"
+msgstr "このオプションは、単一ノードのテストにのみ使用できます。ローカルストレージは、マルチノードクラスターで動作しません"
 
 #: src/bridge/cockpitpackages.c:506
 msgid "This package is not compatible with this version of Cockpit"
-msgstr "このパッケージには Cockpit のこのバージョンとの互換性がありません"
+msgstr "このパッケージには、Cockpit のこのバージョンとの互換性がありません"
 
 #: src/bridge/cockpitpackages.c:495
 #, c-format
 msgid "This package requires Cockpit version %s or later"
-msgstr "このパッケージには Cockpit バージョン %s 以降が必要です"
+msgstr "このパッケージには、Cockpit バージョン %s 以降が必要です"
 
-#: pkg/packagekit/updates.jsx:896
+#: pkg/packagekit/updates.jsx:882
 msgid "This system is not registered"
-msgstr ""
+msgstr "このシステムは登録されていません"
 
 #: pkg/tuned/dialog.js:102
 msgid "This system is using a custom profile"
@@ -7200,7 +7061,7 @@ msgstr "このシステムは推奨プロファイルを使用しています"
 msgid ""
 "This tool will collect system configuration and diagnostic information from "
 "this system for use with diagnosing problems with the system."
-msgstr "このツールは、システムの問題の診断で使用するためにシステムからシステム設定と診断情報を収集します。"
+msgstr "このツールは、システムの問題を診断するのに使用する、システム設定と診断情報をシステムから収集します。"
 
 #: pkg/systemd/init.js:633
 msgid "This unit is an instance of the $0 template."
@@ -7222,7 +7083,7 @@ msgstr "cockpit-ws のこのバージョンでは、別のユーザーまたは�
 
 #: pkg/ovirt/components/OVirtTab.jsx:133
 msgid "This virtual machine is not managed by oVirt"
-msgstr ""
+msgstr "この仮想マシンは、oVirt で管理されていません"
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
@@ -7232,13 +7093,13 @@ msgid ""
 msgstr ""
 "このボリュームは {{ item.item.spec.claimRef.namespace }} / {{ item.item.spec."
 "claimRef.name }} "
-"によってクレームされました。このボリュームを削除すると、そのクレームが破損して、依存するすべてのポッドで問題が発生することがあります。"
+"によってクレームされました。このボリュームを削除するとそのクレームが破損し、依存するすべてのポッドで問題が発生することがあります。"
 
 #: pkg/kubernetes/views/pv-claim.html:23
 msgid "This volume has not been claimed"
 msgstr "このボリュームはクレームされていません"
 
-#: src/ws/login.js:132
+#: src/ws/login.js:129
 msgid "This web browser is too old to run Cockpit (missing $0)"
 msgstr "この Web ブラウザーは古いため Cockpit を実行できません ($0 が不明)"
 
@@ -7249,11 +7110,11 @@ msgid ""
 "process may take a while."
 msgstr ""
 "このため、kdump 設定は、カーネル (つまり、システム) "
-"をクラッシュすることによりテストされます。設定に応じて、再起動が自動的に行われず、処理にしばらく時間がかかることがあります。"
+"をクラッシュしてテストします。設定に応じて、再起動が自動的に行われず、処理にしばらく時間がかかることがあります。"
 
 #: pkg/kdump/kdump-view.jsx:516
 msgid "This will test the kdump configuration by crashing the kernel."
-msgstr "このため、kdump 設定はカーネルをクラッシュすることによりテストされます。"
+msgstr "このため、kdump 設定は、カーネルをクラッシュしてテストします。"
 
 #: pkg/systemd/services.html:197
 msgid "Thursday"
@@ -7267,17 +7128,19 @@ msgstr "タイムゾーン"
 msgid "Timers"
 msgstr "タイマー"
 
-#: pkg/shell/index.html:327
+#: pkg/shell/index.html:338
 msgid ""
 "Tip: Make your key password match your login password to automatically "
 "authenticate against other systems."
-msgstr "ヒント: 他のシステムに対して自動的に認証する場合は、鍵のパスワードをログインパスワードに一致させます。"
+msgstr "ヒント: 他のシステムで自動的に認証されるようにするには、鍵のパスワードをログインパスワードに一致させます。"
 
-#: pkg/packagekit/updates.jsx:897
+#: pkg/packagekit/updates.jsx:883
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
 msgstr ""
+"ソフトウェアアップデートを取得するには、このシステムを Red Hat に登録する必要があります。登録には、Red Hat "
+"カスタマーポータルまたはローカルのサブスクリプションサーバーを使用します。"
 
 #: node_modules/registry-image-widgets/views/image-pull.html:4
 msgid "To pull this image:"
@@ -7285,7 +7148,7 @@ msgstr "このイメージをプルする:"
 
 #: node_modules/registry-image-widgets/views/imagestream-push.html:4
 msgid "To push an image to this image stream:"
-msgstr ""
+msgstr "このイメージストリームにイメージをプッシュするには:"
 
 #: pkg/lib/machine-change-port.html:11
 msgid ""
@@ -7297,15 +7160,15 @@ msgstr "別のポートを試すには、cockpit-ws を新しいバージョン�
 msgid "Token"
 msgstr "トークン"
 
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:151
+#: pkg/lib/cockpit-components-file-autocomplete.jsx:133
 msgid "Too many files found"
-msgstr ""
+msgstr "見つかったファイルが多すぎます"
 
 #: src/base1/cockpit.js:3964
 msgid "Too much data"
 msgstr "データが多すぎます"
 
-#: pkg/kubernetes/index.html:61
+#: pkg/kubernetes/index.html:58
 msgid "Topology"
 msgstr "トポロジー"
 
@@ -7321,14 +7184,14 @@ msgstr "ツリー"
 msgid "Triggers"
 msgstr "トリガー"
 
-#: pkg/kubernetes/index.html:109 pkg/shell/index.html:407
-#: pkg/shell/simple.html:139 pkg/shell/stub.html:181
+#: pkg/shell/index.html:378 pkg/shell/stub.html:152
+#: pkg/kubernetes/index.html:106
 msgid "Troubleshoot"
 msgstr "トラブルシュート"
 
 #: pkg/kubernetes/views/auth-rejected-cert.html:21
 msgid "Trust this certificate for this connection"
-msgstr "この接続に対してこの証明書を信頼します"
+msgstr "この接続に対して、この証明書を信頼します"
 
 #: src/ws/login.html:111
 msgid "Try Again"
@@ -7338,7 +7201,7 @@ msgstr "再試行します"
 msgid "Try again"
 msgstr "再試行します"
 
-#: pkg/shell/simple.html:107
+#: pkg/shell/simple.html:117
 msgid "Try to reconnect"
 msgstr "再接続を試行します"
 
@@ -7366,11 +7229,11 @@ msgstr "Tuned が実行中ではありません"
 msgid "Tuned is off"
 msgstr "Tuned がオフです"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
+#: pkg/shell/index.html:298 pkg/kubernetes/views/deploy.html:9
+#: pkg/kubernetes/views/pv-modify.html:10
 #: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:287
-#: pkg/machines/vmnetworktab.jsx:67 pkg/storaged/format-dialog.jsx:281
-#: pkg/storaged/part-tab.jsx:49 pkg/storaged/unrecognized-tab.jsx:44
+#: pkg/kubernetes/views/volumes-page.html:20 pkg/storaged/part-tab.jsx:49
+#: pkg/storaged/unrecognized-tab.jsx:44 pkg/storaged/format-dialog.jsx:143
 msgid "Type"
 msgstr "タイプ"
 
@@ -7399,6 +7262,11 @@ msgstr "URL"
 msgid "UUID"
 msgstr "UUID"
 
+#: pkg/storaged/index.html:546 pkg/storaged/index.html:591
+msgctxt "storage"
+msgid "UUID"
+msgstr "UUID"
+
 #: pkg/kdump/kdump-view.jsx:288
 msgid "Unable to apply settings: $0"
 msgstr "設定を適用できません: $0"
@@ -7415,7 +7283,7 @@ msgstr "OSTree と通信できません"
 msgid "Unable to connect"
 msgstr "接続できません"
 
-#: src/ws/login.js:592
+#: src/ws/login.js:589
 msgid "Unable to connect to that address"
 msgstr "そのアドレスに接続できません"
 
@@ -7436,7 +7304,7 @@ msgstr "アラート詳細を取得できません"
 msgid "Unable to get alert: $0"
 msgstr "アラートを取得できません: $0"
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/overview.js:591
 msgid "Unable to reach server"
 msgstr "サーバーに到達できません"
 
@@ -7444,17 +7312,13 @@ msgstr "サーバーに到達できません"
 msgid "Unable to read the Kubernetes application manifest. Code $0."
 msgstr "Kubernetes アプリケーションマニフェストを読み取ることができません。コード $0。"
 
-#: pkg/storaged/nfs-panel.jsx:257
-msgid "Unable to remove mount"
-msgstr ""
-
 #: pkg/users/local.js:59
 msgid "Unable to rename root account"
 msgstr "root アカウントの名前を変更できません"
 
 #: node_modules/registry-image-widgets/views/image-listing.html:41
 msgid "Unable to resolve"
-msgstr ""
+msgstr "解決できません"
 
 #: pkg/selinux/setroubleshoot-client.js:172
 msgid "Unable to run fix: %0"
@@ -7464,56 +7328,52 @@ msgstr "修正を実行できません: %0"
 msgid "Unable to start setroubleshootd"
 msgstr "setroubleshootd を起動できません"
 
-#: pkg/storaged/nfs-panel.jsx:238
-msgid "Unable to unmount filesystem"
-msgstr ""
-
 #: pkg/playground/translate.html:34 pkg/playground/translate.html:39
 #: pkg/kubernetes/scripts/charts.js:112
 msgid "Unavailable"
 msgstr "利用できません"
 
 #: pkg/docker/index.html:718 pkg/networkmanager/index.html:824
-#: pkg/shell/base_index.js:750 pkg/users/local.js:1390
+#: pkg/users/local.js:1390 pkg/shell/base_index.js:751
 msgid "Unexpected error"
 msgstr "予期しないエラー"
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
-#: node_modules/registry-image-widgets/views/image-body.html:16
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
+#: node_modules/registry-image-widgets/views/image-body.html:16
+#: pkg/networkmanager/interfaces.js:531 pkg/networkmanager/interfaces.js:1005
+#: pkg/networkmanager/interfaces.js:2420 pkg/networkmanager/interfaces.js:2422
 #: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
 #: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/networkmanager/interfaces.js:531 pkg/networkmanager/interfaces.js:1005
-#: pkg/networkmanager/interfaces.js:2427 pkg/networkmanager/interfaces.js:2429
 #: pkg/storaged/fsys-tab.jsx:62 pkg/storaged/swap-tab.jsx:56
 msgid "Unknown"
 msgstr "不明"
 
-#: pkg/networkmanager/interfaces.js:2413 pkg/networkmanager/interfaces.js:2425
+#: pkg/networkmanager/interfaces.js:2406 pkg/networkmanager/interfaces.js:2418
 msgid "Unknown \"$0\""
 msgstr "不明な \"$0\""
 
-#: pkg/storaged/mdraid-details.jsx:103
+#: pkg/storaged/sidebar-views.jsx:127
 msgid "Unknown ($0)"
 msgstr "不明な ($0)"
 
-#: pkg/apps/application.jsx:98
+#: pkg/apps/application.jsx:83
 msgid "Unknown Application"
-msgstr ""
+msgstr "不明なアプリケーション"
 
 #: pkg/lib/machine-unknown-hostkey.html:2
 msgid "Unknown Host Key"
 msgstr "不明なホストキー"
 
-#: pkg/networkmanager/interfaces.js:2530
+#: pkg/networkmanager/interfaces.js:2523
 msgid "Unknown configuration"
 msgstr "不明な設定"
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/overview.js:587
 msgid "Unknown host name"
 msgstr "不明なホスト名"
 
@@ -7521,28 +7381,20 @@ msgstr "不明なホスト名"
 msgid "Unless Stopped"
 msgstr "停止されていない場合"
 
-#: pkg/storaged/content-views.jsx:190 pkg/storaged/content-views.jsx:197
-#: pkg/storaged/content-views.jsx:210
+#: pkg/storaged/content-views.jsx:191 pkg/storaged/content-views.jsx:198
+#: pkg/storaged/content-views.jsx:211
 msgid "Unlock"
 msgstr "ロック解除"
 
-#: pkg/shell/index.html:223 pkg/shell/index.html:275
+#: pkg/shell/index.html:234 pkg/shell/index.html:286
 msgid "Unlock Key"
 msgstr "ロック解除キー"
 
-#: pkg/storaged/format-dialog.jsx:141
-msgid "Unlock at boot"
-msgstr ""
-
-#: pkg/storaged/format-dialog.jsx:146
-msgid "Unlock read only"
-msgstr ""
-
-#: pkg/shell/index.html:41
+#: pkg/shell/index.html:36
 msgid "Unlocked"
 msgstr "ロック解除済み"
 
-#: pkg/storaged/jobs-panel.jsx:37
+#: pkg/storaged/jobs.js:120
 msgid "Unlocking $target"
 msgstr "$target をロック解除中"
 
@@ -7554,11 +7406,11 @@ msgstr "未管理のインターフェース"
 msgid "Unmask"
 msgstr "マスク解除"
 
-#: pkg/storaged/fsys-tab.jsx:195 pkg/storaged/nfs-panel.jsx:276
+#: pkg/storaged/fsys-tab.jsx:216
 msgid "Unmount"
 msgstr "アンマウント"
 
-#: pkg/storaged/jobs-panel.jsx:43
+#: pkg/storaged/jobs.js:126
 msgid "Unmounting $target"
 msgstr "$target のアンマウント中"
 
@@ -7566,15 +7418,11 @@ msgstr "$target のアンマウント中"
 msgid "Unnamed"
 msgstr "名前なし"
 
-#: pkg/machines/vmnetworktab.jsx:124
-msgid "Unplug"
-msgstr ""
-
-#: pkg/storaged/content-views.jsx:153
+#: pkg/storaged/content-views.jsx:154
 msgid "Unrecognized Data"
 msgstr "認識されないデータ"
 
-#: pkg/storaged/content-views.jsx:324
+#: pkg/storaged/content-views.jsx:325
 msgctxt "storage-id-desc"
 msgid "Unrecognized Data"
 msgstr "認識されないデータ"
@@ -7583,9 +7431,9 @@ msgstr "認識されないデータ"
 msgid "Unregister"
 msgstr "登録解除"
 
-#: pkg/packagekit/updates.jsx:798
+#: pkg/packagekit/updates.jsx:788
 msgid "Unregistered System"
-msgstr ""
+msgstr "未登録のシステム"
 
 #: pkg/subscriptions/subscriptions-view.jsx:154
 msgid "Unregistering system..."
@@ -7593,14 +7441,14 @@ msgstr "システムの登録解除中 ..."
 
 #: node_modules/registry-image-widgets/views/image-listing.html:46
 msgid "Unresolved"
-msgstr ""
+msgstr "解決されません"
 
 #: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
 #: src/bridge/cockpitdbussetup.c:625
 msgid "Unsupported setup mechanism"
 msgstr "サポートされないセットアップメカニズム"
 
-#: pkg/storaged/content-views.jsx:570
+#: pkg/storaged/content-views.jsx:615
 msgid "Unsupported volume"
 msgstr "サポートされないボリューム"
 
@@ -7616,36 +7464,33 @@ msgstr "$StartedAt から稼働中"
 msgid "Update"
 msgstr "更新"
 
-#: pkg/packagekit/updates.jsx:860
-#, fuzzy
+#: pkg/packagekit/updates.jsx:846
 msgid "Update History"
-msgstr "更新"
+msgstr "履歴の更新"
 
-#: pkg/packagekit/updates.jsx:460
-#, fuzzy
+#: pkg/packagekit/updates.jsx:450
 msgid "Update Log"
-msgstr "更新"
+msgstr "ログの更新"
 
 #: pkg/ostree/index.html:233
 msgid "Update and Reboot"
 msgstr "更新および再起動"
 
 #: pkg/packagekit/updates.jsx:64
-#, fuzzy
 msgid "Updated"
-msgstr "更新"
+msgstr "更新済み"
 
-#: pkg/packagekit/updates.jsx:481
+#: pkg/packagekit/updates.jsx:471
 msgid "Updated packages may require a restart to take effect."
-msgstr ""
+msgstr "パッケージの更新を反映するには、再起動が必要になる場合があります。"
 
 #: pkg/ostree/index.html:317 pkg/ostree/index.html:343
 msgid "Updates"
 msgstr "更新"
 
-#: pkg/packagekit/updates.jsx:802
+#: pkg/packagekit/updates.jsx:792
 msgid "Updates are disabled."
-msgstr ""
+msgstr "更新が無効です。"
 
 #: pkg/ostree/index.html:262 pkg/packagekit/updates.jsx:56
 #: pkg/subscriptions/subscriptions-view.jsx:187
@@ -7658,9 +7503,9 @@ msgstr "$0 の更新中 ..."
 
 #: pkg/machines/vmdiskstab.jsx:107
 msgid "Upgrade to a more recent version of libvirt to view disk statistics"
-msgstr "ディスクの統計情報を表示するには libvirt の新しいバージョンにアップグレードしてください"
+msgstr "ディスクの統計情報を表示するには、libvirt を新しいバージョンにアップグレードしてください"
 
-#: pkg/machines/hostvmslist.jsx:409 pkg/storaged/unrecognized-tab.jsx:40
+#: pkg/machines/hostvmslist.jsx:408 pkg/storaged/unrecognized-tab.jsx:40
 msgid "Usage"
 msgstr "使用法"
 
@@ -7668,9 +7513,9 @@ msgstr "使用法"
 msgid "Use proxy server"
 msgstr "プロキシーサーバーの使用"
 
-#: pkg/shell/index.html:170
+#: pkg/shell/index.html:181
 msgid "Use the following keys to authenticate against other systems"
-msgstr "他のシステムに対して認証する場合は次の鍵を使用します"
+msgstr "他のシステムに対して認証する場合は、次の鍵を使用します"
 
 #: pkg/kdump/kdump-view.jsx:162
 msgid "Use the setting in /etc/kdump.conf"
@@ -7680,11 +7525,11 @@ msgstr "/etc/kdump.conf の設定を使用します"
 msgid "Use trusted GPG key"
 msgstr "信頼済み GPG 鍵の使用"
 
-#: pkg/systemd/index.html:261 pkg/docker/storage.jsx:315
+#: pkg/systemd/index.html:261 pkg/machines/hostvmslist.jsx:352
+#: pkg/machines/hostvmslist.jsx:363 pkg/machines/vmdiskstab.jsx:136
+#: pkg/docker/storage.jsx:315 pkg/systemd/host.js:1468
 #: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
-#: pkg/machines/hostvmslist.jsx:353 pkg/machines/hostvmslist.jsx:364
-#: pkg/machines/vmdiskstab.jsx:136 pkg/storaged/fsys-tab.jsx:204
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1475
+#: pkg/storaged/fsys-tab.jsx:225 pkg/storaged/swap-tab.jsx:82
 msgid "Used"
 msgstr "Used"
 
@@ -7692,18 +7537,19 @@ msgstr "Used"
 msgid "Used by Containers"
 msgstr "コンテナーにより使用済み"
 
-#: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
+#: pkg/systemd/index.html:239 pkg/playground/translate.html:85
+#: pkg/playground/translate.html:105 pkg/dashboard/index.html:142
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
-#: pkg/playground/translate.html:105 pkg/systemd/index.html:239
-#: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1389
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/auth-form.html:61
+#: pkg/kubernetes/views/user-panel.html:9
+#: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1382
 msgid "User"
 msgstr "ユーザー"
 
-#: pkg/realmd/operation.html:48 pkg/users/index.html:88
-#: pkg/users/index.html:171
+#: pkg/users/index.html:88 pkg/users/index.html:171
+#: pkg/realmd/operation.html:48
 msgid "User Name"
 msgstr "ユーザー名"
 
@@ -7713,14 +7559,14 @@ msgstr "ユーザーパスワード"
 
 #: cockpit.appdata.xml.in.h:1
 msgid "User interface for Linux servers"
-msgstr ""
+msgstr "Linux サーバーのユーザーインターフェース"
 
 #: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "ユーザー名"
 
-#: src/ws/login.js:398
+#: src/ws/login.js:395
 msgid "User name cannot be empty"
 msgstr "ユーザー名は空にできません"
 
@@ -7728,8 +7574,8 @@ msgstr "ユーザー名は空にできません"
 msgid "User or Group"
 msgstr "ユーザーまたはグループ"
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/overview.js:530
+#: pkg/storaged/overview.js:653
 msgid "Username"
 msgstr "ユーザー名"
 
@@ -7741,20 +7587,20 @@ msgstr "ユーザー"
 msgid "Using available credentials"
 msgstr "利用可能な認証情報の使用"
 
-#: pkg/ovirt/components/App.jsx:84
+#: pkg/ovirt/components/App.jsx:81
 msgid "VDSM"
-msgstr ""
+msgstr "VDSM"
 
 #: pkg/ovirt/components/VdsmView.jsx:128
 msgid "VDSM Service Management"
-msgstr ""
+msgstr "VDSM サービス管理"
 
-#: pkg/storaged/format-dialog.jsx:245
+#: pkg/storaged/format-dialog.jsx:107
 msgid "VFAT - Compatible with all systems and devices"
 msgstr "VFAT - すべてのシステムおよびデバイスとの互換性あり"
 
-#: pkg/networkmanager/interfaces.js:2409 pkg/networkmanager/interfaces.js:2421
-#: pkg/networkmanager/interfaces.js:2796
+#: pkg/networkmanager/interfaces.js:2402 pkg/networkmanager/interfaces.js:2414
+#: pkg/networkmanager/interfaces.js:2789
 msgid "VLAN"
 msgstr "VLAN"
 
@@ -7766,51 +7612,49 @@ msgstr "VLAN Id"
 msgid "VLAN Settings"
 msgstr "VLAN 設定"
 
-#: pkg/machines/libvirt.es6:186
+#: pkg/machines/libvirt.es6:177
 msgid "VM FORCE OFF action failed"
 msgstr "VM FORCE OFF アクションに失敗しました"
 
-#: pkg/machines/libvirt.es6:204
+#: pkg/machines/libvirt.es6:195
 msgid "VM FORCE REBOOT action failed"
 msgstr "VM FORCE REBOOT アクションに失敗しました"
 
-#: pkg/machines/libvirt.es6:195
+#: pkg/machines/libvirt.es6:186
 msgid "VM REBOOT action failed"
 msgstr "VM REBOOT アクションに失敗しました"
 
-#: pkg/machines/libvirt.es6:297
+#: pkg/machines/libvirt.es6:275
 msgid "VM SEND Non-Maskable Interrrupt action failed"
-msgstr ""
+msgstr "VM SEND マスク不可な割り込みアクションに失敗しました"
 
-#: pkg/machines/libvirt.es6:177
+#: pkg/machines/libvirt.es6:168
 msgid "VM SHUT DOWN action failed"
 msgstr "VM SHUT DOWN アクションに失敗しました"
 
-#: pkg/machines/libvirt.es6:213
+#: pkg/machines/libvirt.es6:204
 msgid "VM START action failed"
 msgstr "VM START アクションに失敗しました"
 
-#: pkg/ovirt/components/VmOverviewColumn.jsx:55
+#: pkg/ovirt/components/VmOverviewColumn.jsx:54
 msgid "VM icon"
-msgstr ""
+msgstr "VM アイコン"
 
 #: pkg/machines/components/desktopConsole.jsx:188
 msgid "VNC"
-msgstr ""
+msgstr "VNC"
 
 #: pkg/machines/components/desktopConsole.jsx:160
-#, fuzzy
 msgid "VNC Address:"
-msgstr "MAC アドレス:"
+msgstr "VNC アドレス:"
 
 #: pkg/machines/components/desktopConsole.jsx:169
-#, fuzzy
 msgid "VNC Port:"
-msgstr "ポート:"
+msgstr "VNC ポート:"
 
 #: pkg/machines/components/desktopConsole.jsx:172
 msgid "VNC TLS Port:"
-msgstr ""
+msgstr "VNC TLS ポート:"
 
 #: src/ws/login.html:101
 msgid "Validating authentication token"
@@ -7822,59 +7666,51 @@ msgstr "鍵の検証"
 
 #: pkg/packagekit/updates.jsx:66
 msgid "Verified"
-msgstr ""
+msgstr "検証済み"
 
 #: pkg/packagekit/updates.jsx:58
 msgid "Verifying"
-msgstr ""
+msgstr "検証中"
 
-#: pkg/ostree/index.html:303 pkg/shell/index.html:90 pkg/shell/simple.html:64
-#: pkg/shell/stub.html:71 pkg/systemd/index.html:108
-#: pkg/ovirt/components/ClusterTemplates.jsx:137
-#: pkg/ovirt/components/ClusterVms.jsx:75 pkg/packagekit/updates.jsx:340
+#: pkg/ostree/index.html:303 pkg/shell/index.html:101 pkg/shell/stub.html:79
+#: pkg/shell/simple.html:74 pkg/systemd/index.html:108
+#: pkg/packagekit/updates.jsx:330 pkg/ovirt/components/ClusterVms.jsx:74
+#: pkg/ovirt/components/ClusterTemplates.jsx:128
 #: pkg/subscriptions/subscriptions-view.jsx:34
 msgid "Version"
 msgstr "バージョン"
 
-#: pkg/ovirt/components/ClusterVms.jsx:75
+#: pkg/ovirt/components/ClusterVms.jsx:74
 msgid "Version num"
-msgstr ""
+msgstr "バージョン番号"
 
-#: pkg/storaged/jobs-panel.jsx:53
+#: pkg/storaged/jobs.js:136
 msgid "Very securely erasing $target"
 msgstr "$target を非常に安全に削除"
 
-#: pkg/packagekit/updates.jsx:808
+#: pkg/packagekit/updates.jsx:798
 msgid "View Registration Details"
-msgstr ""
+msgstr "登録の詳細を表示"
 
-#: pkg/machines/hostvmslist.jsx:504
+#: pkg/machines/hostvmslist.jsx:476
 msgid "Virtual Machines"
 msgstr "仮想マシン"
 
-#: pkg/ovirt/components/ClusterVms.jsx:168
-msgid "Virtual Machines of $0 cluster"
-msgstr ""
-
-#: pkg/machines/vmnetworktab.jsx:91
-msgid "Virtualport"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
-#: pkg/kubernetes/views/pvc-body.html:6 pkg/machines/vmdiskstab.jsx:55
-#: pkg/storaged/content-views.jsx:132
+#: pkg/kubernetes/views/pvc-body.html:6 pkg/kubernetes/views/pv-panel.html:10
+#: pkg/kubernetes/views/pv-page.html:13 pkg/machines/vmdiskstab.jsx:55
+#: pkg/storaged/content-views.jsx:133
 msgid "Volume"
 msgstr "音量"
 
-#: pkg/storaged/pvol-tabs.jsx:44
+#: pkg/storaged/index.html:584 pkg/storaged/pvol-tabs.jsx:44
 msgid "Volume Group"
 msgstr "ボリュームグループ"
 
-#: pkg/storaged/utils.js:228 pkg/storaged/vgroup-details.jsx:239
+#: pkg/storaged/utils.js:246 pkg/storaged/storage-controls.jsx:180
 msgid "Volume Group $0"
 msgstr "ボリュームグループ $0"
 
-#: pkg/storaged/vgroups-panel.jsx:109
+#: pkg/storaged/index.html:96
 msgid "Volume Groups"
 msgstr "ボリュームグループ"
 
@@ -7883,17 +7719,17 @@ msgstr "ボリュームグループ"
 msgid "Volume ID"
 msgstr "ボリューム ID"
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr "ボリューム名"
 
-#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
+#: pkg/kubernetes/views/volume-body.html:1 pkg/kubernetes/views/pvc-body.html:2
 msgid "Volume Type"
 msgstr "ボリュームタイプ"
 
 #: pkg/docker/index.html:507 pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:74
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:71
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "ボリューム"
@@ -7907,9 +7743,9 @@ msgstr "待機中"
 msgid "Waiting for details..."
 msgstr "詳細を待機中 ..."
 
-#: pkg/apps/utils.jsx:66
+#: pkg/apps/utils.jsx:63
 msgid "Waiting for other programs to finish using the package manager..."
-msgstr ""
+msgstr "パッケージマネージャーを使用して、その他のプログラムを終了するのを待機中..."
 
 #: pkg/kubernetes/views/pv-modify.html:24
 msgid "Warning:"
@@ -7927,25 +7763,30 @@ msgstr "週"
 msgid "Welcome to the Image Registry"
 msgstr "イメージレジストリーへようこそ"
 
-#: pkg/kubernetes/views/volumes-page.html:61 pkg/ostree/index.html:282
+#: pkg/ostree/index.html:282 pkg/kubernetes/views/volumes-page.html:61
 msgid "When"
 msgstr "日付"
 
-#: pkg/packagekit/updates.jsx:850
+#: pkg/packagekit/updates.jsx:836
 msgid ""
 "When you get disconnected, the updates will continue in the background. You "
 "can reconnect and resume watching the update progress."
-msgstr ""
+msgstr "切断すると、更新は背景で継続します。再接続すると、更新の進捗確認を再開できます。"
 
 #: pkg/docker/index.html:478
 msgid "With terminal"
 msgstr "端末の使用"
 
-#: pkg/storaged/mdraid-details.jsx:101
+#: pkg/storaged/index.html:436
+msgctxt "storage"
+msgid "World Wide Name"
+msgstr "ワールドワイド名"
+
+#: pkg/storaged/sidebar-views.jsx:125
 msgid "Write-mostly"
 msgstr "Write-mostly"
 
-#: pkg/storaged/plot.jsx:268
+#: pkg/storaged/index.html:331
 msgid "Writing"
 msgstr "書き込み"
 
@@ -7953,19 +7794,19 @@ msgstr "書き込み"
 msgid "Writing objects"
 msgstr "オブジェクトの書き込み"
 
-#: src/ws/login.js:602
+#: src/ws/login.js:599
 msgid "Wrong user name or password"
 msgstr "ユーザー名またはパスワードが間違っています"
 
-#: pkg/storaged/format-dialog.jsx:241
+#: pkg/storaged/format-dialog.jsx:103
 msgid "XFS - Red Hat Enterprise Linux 7 default"
 msgstr "XFS - Red Hat Enterprise Linux 7 のデフォルト値"
 
-#: pkg/networkmanager/interfaces.js:1911
+#: pkg/networkmanager/interfaces.js:1906
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/kubernetes/scripts/volumes.js:988 pkg/networkmanager/interfaces.js:2483
+#: pkg/networkmanager/interfaces.js:2476 pkg/kubernetes/scripts/volumes.js:988
 msgid "Yes"
 msgstr "はい"
 
@@ -7980,7 +7821,7 @@ msgstr ""
 #: pkg/dashboard/list.js:395
 msgid ""
 "You are currently connected directly to this server. You cannot delete it."
-msgstr "現在このサーバーに直接接続されています。削除できません。"
+msgstr "現在、このサーバーに直接接続されています。削除できません。"
 
 #: pkg/kubernetes/views/auth-rejected-cert.html:3
 msgid ""
@@ -8007,13 +7848,13 @@ msgstr "このアカウントに承認された公開鍵を表示するパーミ
 msgid "You don't have permission to manage the Docker storage pool."
 msgstr "Docker ストレージプールを管理するパーミッションがありません。"
 
-#: pkg/packagekit/updates.jsx:804
+#: pkg/packagekit/updates.jsx:794
 msgid "You need to re-subscribe this system."
-msgstr ""
+msgstr "再度、このシステムをサブスクライブする必要があります。"
 
 #: pkg/machines/components/vnc.jsx:30
 msgid "Your browser does not support iframes."
-msgstr ""
+msgstr "ブラウザーが、iframe をサポートしません。"
 
 #: pkg/kubernetes/views/registry-dashboard-page.html:112
 msgid ""
@@ -8021,11 +7862,11 @@ msgid ""
 "from the command line."
 msgstr "ログイン資格情報は、コマンドラインから docker レジストリーを使用するアクセスを提供しません。"
 
-#: pkg/packagekit/updates.jsx:886
+#: pkg/packagekit/updates.jsx:872
 msgid ""
 "Your server will close the connection soon. You can reconnect after it has "
 "restarted."
-msgstr ""
+msgstr "サーバーがまもなく接続を閉じます。再起動したら再接続できます。"
 
 #: src/base1/cockpit.js:3934
 msgid "Your session has been terminated."
@@ -8057,49 +7898,40 @@ msgstr "alias"
 
 #: pkg/packagekit/autoupdates.jsx:321
 msgid "and restart the machine automatically."
-msgstr ""
+msgstr "自動的にマシンを再起動します。"
 
 #: pkg/ostree/index.html:186 pkg/packagekit/autoupdates.jsx:312
 msgid "at"
 msgstr "時間: "
 
-#: pkg/machines/helpers.es6:129
-msgid "bridge"
-msgstr ""
-
-#: pkg/storaged/utils.js:87
+#: pkg/storaged/utils.js:88
 msgctxt "format-bytes"
 msgid "bytes"
 msgstr "バイト"
 
 #: pkg/machines/helpers.es6:118
 msgid "cdrom"
-msgstr ""
+msgstr "cdrom"
 
 #: pkg/ovirt/rephraseUI.es6:36
 msgid "connecting"
-msgstr ""
+msgstr "接続中"
 
-#: pkg/ovirt/components/ClusterVms.jsx:46
+#: pkg/ovirt/components/ClusterVms.jsx:45
 msgid "cores"
-msgstr ""
+msgstr "コア"
 
 #: pkg/machines/helpers.es6:112
 msgid "crashed"
 msgstr "クラッシュ"
 
 #: pkg/machines/helpers.es6:123
-#, fuzzy
 msgid "custom"
-msgstr "Custom"
+msgstr "カスタム"
 
 #: pkg/docker/util.js:122
 msgid "default"
 msgstr "default"
-
-#: pkg/machines/helpers.es6:127
-msgid "direct"
-msgstr ""
 
 #: pkg/machines/helpers.es6:99 pkg/ovirt/components/OVirtTab.jsx:122
 msgid "disabled"
@@ -8107,11 +7939,11 @@ msgstr "無効"
 
 #: pkg/machines/helpers.es6:117 pkg/machines/helpers.es6:120
 msgid "disk"
-msgstr ""
+msgstr "ディスク"
 
-#: pkg/machines/helpers.es6:144 pkg/ovirt/rephraseUI.es6:28
+#: pkg/ovirt/rephraseUI.es6:28
 msgid "down"
-msgstr ""
+msgstr "下へ"
 
 #: pkg/machines/helpers.es6:113
 msgid "dying"
@@ -8131,33 +7963,25 @@ msgstr "有効"
 
 #: pkg/ovirt/rephraseUI.es6:29
 msgid "error"
-msgstr ""
-
-#: pkg/machines/helpers.es6:131
-msgid "ethernet"
-msgstr ""
+msgstr "エラー"
 
 #: pkg/packagekit/autoupdates.jsx:301
 msgid "every day"
-msgstr ""
+msgstr "毎日"
 
-#: pkg/storaged/format-dialog.jsx:242
+#: pkg/storaged/format-dialog.jsx:104
 msgid "ext4 - Red Hat Enterprise Linux 6 default"
 msgstr "ext4 - Red Hat Enterprise Linux 6 のデフォルト値"
 
-#: pkg/systemd/host.js:731
+#: pkg/systemd/host.js:724
 msgid "failed to list ssh host keys: $0"
 msgstr "ssh ホスト鍵の一覧表示に失敗しました: $0"
 
 #: pkg/machines/helpers.es6:124
 msgid "host"
-msgstr ""
+msgstr "ホスト"
 
-#: pkg/machines/helpers.es6:132
-msgid "hostdev"
-msgstr ""
-
-#: pkg/storaged/iscsi-panel.jsx:287
+#: pkg/storaged/index.html:133
 msgid "iSCSI Targets"
 msgstr "iSCSI ターゲット"
 
@@ -8167,15 +7991,15 @@ msgstr "アイドル"
 
 #: pkg/ovirt/rephraseUI.es6:30
 msgid "initializing"
-msgstr ""
+msgstr "初期化中"
 
 #: pkg/ovirt/rephraseUI.es6:31
 msgid "installation failed"
-msgstr ""
+msgstr "インストールに失敗しました"
 
 #: pkg/ovirt/rephraseUI.es6:39
 msgid "installing OS"
-msgstr ""
+msgstr "OS のインストール中"
 
 #: pkg/kdump/kdump-view.jsx:379
 msgid "invalid: multiple targets defined"
@@ -8187,7 +8011,7 @@ msgstr "kdump ステータス"
 
 #: pkg/ovirt/rephraseUI.es6:40
 msgid "kdumping"
-msgstr ""
+msgstr "kdump 中"
 
 #: pkg/docker/run.js:526
 msgid "key"
@@ -8199,98 +8023,90 @@ msgstr "$0 (ローカル)"
 
 #: pkg/ovirt/rephraseUI.es6:32
 msgid "maintenance"
-msgstr ""
+msgstr "メンテナンス"
 
-#: pkg/machines/helpers.es6:133
-msgid "mcast"
-msgstr ""
-
-#: pkg/machines/helpers.es6:119 pkg/machines/helpers.es6:128
-#, fuzzy
+#: pkg/machines/helpers.es6:119
 msgid "network"
 msgstr "ネットワーク"
 
-#: pkg/kubernetes/views/route-body.html:14 pkg/machines/helpers.es6:140
-#: pkg/machines/vmdiskstab.jsx:174 pkg/ovirt/components/ClusterVms.jsx:38
-#: pkg/ovirt/rephraseUI.es6:44
+#: pkg/kubernetes/views/route-body.html:14 pkg/machines/vmdiskstab.jsx:174
+#: pkg/ovirt/components/ClusterVms.jsx:37 pkg/ovirt/rephraseUI.es6:44
 msgid "no"
 msgstr "いいえ"
 
 #: pkg/ovirt/rephraseUI.es6:33
 msgid "non operational"
-msgstr ""
+msgstr "稼動していません"
 
 #: pkg/ovirt/rephraseUI.es6:34
 msgid "non responsive"
-msgstr ""
+msgstr "応答しません"
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:104
 msgid "none"
 msgstr "なし"
 
-#: pkg/ovirt/provider.es6:58
+#: pkg/ovirt/provider.es6:55
 msgid "oVirt"
-msgstr ""
-
-#: pkg/ovirt/components/HostStatus.jsx:39
-msgid "oVirt Host State:"
-msgstr ""
+msgstr "oVirt"
 
 #: pkg/ovirt/components/InstallationDialog.jsx:38
 msgid "oVirt Provider installation script failed due to missing arguments."
-msgstr ""
+msgstr "引数がないため、oVirt プロバイダーのインストールスクリプトに失敗しました。"
 
 #: pkg/ovirt/components/InstallationDialog.jsx:39
 msgid ""
 "oVirt Provider installation script failed: Can't write to /etc/cockpit/"
 "machines-ovirt.config, try as root."
 msgstr ""
+"oVirt プロバイダーのインストールスクリプトに失敗しました。/etc/cockpit/machines-ovirt.config "
+"に書き込めません。root で試行してください。"
 
 #: pkg/ovirt/components/InstallationDialog.jsx:161
 msgid "oVirt installation script failed with following output: "
-msgstr ""
+msgstr "oVirt インストールスクリプトが失敗し、次が出力されます: "
 
-#: pkg/ovirt/components/App.jsx:39
+#: pkg/ovirt/components/App.jsx:36
 msgid "oVirt login in progress"
-msgstr ""
+msgstr "oVirt ログインの処理中"
 
 #: pkg/packagekit/autoupdates.jsx:306
 msgid "on Fridays"
-msgstr ""
+msgstr "毎週金曜日"
 
 #: pkg/packagekit/autoupdates.jsx:302
 msgid "on Mondays"
-msgstr ""
+msgstr "毎週月曜日"
 
 #: pkg/packagekit/autoupdates.jsx:307
 msgid "on Saturdays"
-msgstr ""
+msgstr "毎週土曜日"
 
 #: pkg/packagekit/autoupdates.jsx:308
 msgid "on Sundays"
-msgstr ""
+msgstr "毎週日曜日"
 
 #: pkg/packagekit/autoupdates.jsx:305
 msgid "on Thursdays"
-msgstr ""
+msgstr "毎週木曜日"
 
 #: pkg/packagekit/autoupdates.jsx:303
 msgid "on Tuesdays"
-msgstr ""
+msgstr "毎週火曜日"
 
 #: pkg/packagekit/autoupdates.jsx:304
 msgid "on Wednesdays"
-msgstr ""
+msgstr "毎週水曜日"
 
-#: pkg/machines/libvirt.es6:512
+#: pkg/machines/libvirt.es6:433
 msgid "other"
-msgstr ""
+msgstr "その他"
 
 #: pkg/machines/helpers.es6:109
 msgid "paused"
@@ -8298,7 +8114,7 @@ msgstr "一時停止"
 
 #: pkg/ovirt/rephraseUI.es6:35
 msgid "pending approval"
-msgstr ""
+msgstr "保留中の承認"
 
 #: pkg/kubernetes/views/dashboard-page.html:83
 msgid "pending volume claims"
@@ -8306,7 +8122,7 @@ msgstr "保留中のボリュームクレーム"
 
 #: pkg/ovirt/rephraseUI.es6:37
 msgid "reboot"
-msgstr ""
+msgstr "再起動"
 
 #: pkg/tuned/change-profile.jsx:52
 msgid "recommended"
@@ -8324,10 +8140,6 @@ msgstr "名前、名前空間、または説明別の検索"
 msgid "select container"
 msgstr "コンテナーの選択"
 
-#: pkg/machines/helpers.es6:134
-msgid "server"
-msgstr ""
-
 #: pkg/docker/index.html:475 pkg/docker/index.html:646
 msgid "shares"
 msgstr "共有"
@@ -8340,9 +8152,9 @@ msgstr "シャットオフ"
 msgid "shutdown"
 msgstr "shutdown"
 
-#: pkg/ovirt/components/ClusterVms.jsx:46
+#: pkg/ovirt/components/ClusterVms.jsx:45
 msgid "sockets"
-msgstr ""
+msgstr "ソケット"
 
 #: pkg/selinux/setroubleshoot-view.jsx:118
 msgid "solution details"
@@ -8356,9 +8168,9 @@ msgstr "ssh 鍵"
 msgid "suspended (PM)"
 msgstr "一時停止中 (PM)"
 
-#: pkg/ovirt/components/ClusterVms.jsx:46
+#: pkg/ovirt/components/ClusterVms.jsx:45
 msgid "threads"
-msgstr ""
+msgstr "スレッド"
 
 #: pkg/docker/run.js:473
 msgid "to host path"
@@ -8368,13 +8180,9 @@ msgstr "ホストパスに対して"
 msgid "to host port"
 msgstr "ホストポートに対して"
 
-#: pkg/machines/helpers.es6:135
-msgid "udp"
-msgstr ""
-
 #: pkg/ovirt/rephraseUI.es6:38
 msgid "unassigned"
-msgstr ""
+msgstr "未割り当て"
 
 #: pkg/lib/cockpit-components-select.jsx:30
 msgid "undefined"
@@ -8385,7 +8193,7 @@ msgstr "未定義"
 msgid "unknown"
 msgstr "不明"
 
-#: pkg/storaged/jobs-panel.jsx:92
+#: pkg/storaged/jobs.js:179
 msgid "unknown target"
 msgstr "不明なターゲット"
 
@@ -8393,20 +8201,16 @@ msgstr "不明なターゲット"
 msgid "unpartitioned space on $0"
 msgstr "$0 の未パーティション領域"
 
-#: pkg/machines/helpers.es6:143 pkg/ovirt/rephraseUI.es6:27
+#: pkg/ovirt/rephraseUI.es6:27
 msgid "up"
-msgstr ""
+msgstr "上へ"
 
-#: pkg/machines/helpers.es6:130
-msgid "user"
-msgstr ""
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:137
-#: pkg/ovirt/components/ClusterVms.jsx:173
+#: pkg/ovirt/components/ClusterVms.jsx:174
+#: pkg/ovirt/components/ClusterTemplates.jsx:128
 msgid "vCPUs"
-msgstr ""
+msgstr "vCPU"
 
-#: pkg/machines/hostvmslist.jsx:292
+#: pkg/machines/hostvmslist.jsx:291
 msgid "vCPUs:"
 msgstr "vCPU:"
 
@@ -8414,13 +8218,8 @@ msgstr "vCPU:"
 msgid "value"
 msgstr "value"
 
-#: pkg/machines/helpers.es6:136
-msgid "vhostuser"
-msgstr ""
-
-#: pkg/kubernetes/views/route-body.html:13 pkg/machines/helpers.es6:139
-#: pkg/machines/vmdiskstab.jsx:174 pkg/ovirt/components/ClusterVms.jsx:38
-#: pkg/ovirt/rephraseUI.es6:43
+#: pkg/kubernetes/views/route-body.html:13 pkg/machines/vmdiskstab.jsx:174
+#: pkg/ovirt/components/ClusterVms.jsx:37 pkg/ovirt/rephraseUI.es6:43
 msgid "yes"
 msgstr "はい"
 
@@ -8431,3 +8230,4 @@ msgid ""
 msgstr ""
 "{{ condition.message }}。タイムスタンプ: {{ condition.lastTransitionTime }} エラー数: {{ "
 "condition.generation }}"
+


### PR DESCRIPTION
Import the "iteration=rhel-7.5" Japanese translations from Zanata so
that they trickle into the master branch.

https://bugzilla.redhat.com/show_bug.cgi?id=1512923