### PR TITLE
build: Fix cockpit-cache tarball layout

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -363,7 +363,7 @@ dist-hook::
 	[ ! -e $(distdir)/tools/cockpit.spec ] || $(srcdir)/tools/gen-spec-dependencies $(distdir)/tools/cockpit.spec
 
 DIST_TAR_MAIN = tar --format=posix -cf - "$(distdir)"
-DIST_TAR_CACHE = tar --format=posix -cf - --exclude='phantomjs*' --transform="s/^/$(distdir)/" \
+DIST_TAR_CACHE = tar --format=posix -cf - --exclude='phantomjs*' --transform="flags=r;s|^\./||" --transform="flags=r;s|^|$(distdir)/|" \
 	"$(srcdir)/node_modules" "$(srcdir)/package.json"
 
 DIST_ARCHIVES = \


### PR DESCRIPTION
Our recent release cache tarballs are competely broken:

```
$ tar tvf /tmp/cockpit-cache-157.tar.xz | grep 'cleancss.*->'
cockpit-157node_modules/html-minifier/node_modules/.bin/cleancss -> cockpit-157../clean-css/bin/cleancss
cockpit-157node_modules/.bin/cleancss -> cockpit-157../clean-css/bin/cleancss
```

tar's `--transform` option applies to symlink targets by default, which
breaks the links in node_modules/.bin/. Apply transformations to regular
files only.

Ensure a trailing slash after `$(distdir)`.

Also chop off `./` prefixes. While they are harmless, they look odd in
`tar tf` after prepending distdir.