### PR TITLE
naughty: Close 8117: centos/rhel 7:  SELinux prevents dhclient from name_bind on ephemeral port

### DIFF
--- a/bots/naughty/centos-7/8117-selinux-dhclient-bind
+++ b/bots/naughty/centos-7/8117-selinux-dhclient-bind
@@ -1,2 +1,0 @@
-Error: type=1400 audit.*: avc:  denied  { name_bind } for .* comm="dhclient"
-

--- a/bots/naughty/rhel-7-4/8117-selinux-dhclient-bind
+++ b/bots/naughty/rhel-7-4/8117-selinux-dhclient-bind
@@ -1,2 +1,0 @@
-Error: type=1400 audit.*: avc:  denied  { name_bind } for .* comm="dhclient"
-

--- a/bots/naughty/rhel-7/8117-selinux-dhclient-bind
+++ b/bots/naughty/rhel-7/8117-selinux-dhclient-bind
@@ -1,2 +1,0 @@
-Error: type=1400 audit.*: avc:  denied  { name_bind } for .* comm="dhclient"
-


### PR DESCRIPTION
Known issue which has not occurred in 24 days

centos/rhel 7:  SELinux prevents dhclient from name_bind on ephemeral port

Fixes #8117