### PR TITLE
bots: Hide done tests in human output of tests-scan again

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -98,7 +98,7 @@ def main():
 
 # Prepare a human readable output
 def tests_human(priority, name, revision, ref, context, base=None, repo=None, command=None):
-    if priority is None:
+    if not priority:
         return
     try:
         priority = int(priority)


### PR DESCRIPTION
Commit ae17417b64 changed the initial priority from `None` to 0 as
Python 3 does not allow comparisons between numbers and `None` any more.
Adjust `tests_human()` accordingly to avoid outputting a whole slew of
"priority 0" results which already ran.