### PR TITLE
bots: Drop release-debian from major-cockpit-release

### DIFF
--- a/bots/major-cockpit-release
+++ b/bots/major-cockpit-release
@@ -46,4 +46,3 @@ job bots/release-guide dist/guide cockpit-project/cockpit-project.github.io
 # Create and publish a Debian repository and Ubuntu PPA
 job release-dsc
 job release-ubuntu-ppa
-job release-debian fedorapeople.org:/project/cockpit/debian jessie unstable


### PR DESCRIPTION
Cockpituous' release-debian script currently pushes packages to a custom
repository which is not being advertised any more (since cockpit is now
in Debian proper), and also to jessie which is EOL soon and not getting
tested in CI any more.

Automating proper Debian downstream releases needs to be reworked and
rethought.