### PR TITLE
webpack: don't copy files into base1 and shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "strict-loader": "~1.1.0",
     "style-loader": "~0.13.1",
     "uglify-js": "~2.6.2",
-    "webpack": "~1.13.2"
+    "webpack": "~1.13.2",
+    "webpack-merge-and-include-globally": "~1.0.1"
   },
   "scripts": {
     "eslint": "eslint --ext .jsx --ext .es6 pkg/",

--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -6,8 +6,6 @@ nodist_base_DATA = \
 	dist/base1/patternfly.min.css.gz \
 	dist/base1/require.min.js.gz \
 	dist/base1/mustache.min.js.gz \
-	dist/base1/jquery.min.js.gz \
-	dist/base1/cockpit.min.js.gz \
 	$(NULL)
 base_DATA = \
 	dist/base1/manifest.json \
@@ -19,8 +17,6 @@ basedebug_DATA = \
 	dist/base1/patternfly.min.css.map \
 	dist/base1/mustache.min.js.map \
 	dist/base1/require.min.js.map \
-	dist/base1/jquery.min.js.map \
-	dist/base1/cockpit.min.js.map \
 	$(NULL)
 
 AM_TESTS_ENVIRONMENT = export G_DEBUG=fatal-criticals,fatal-warnings ; export XDG_CACHE_HOME=$$(mktemp -d) ; export XDG_RUNTIME_DIR=$$XDG_CACHE_HOME ;
@@ -35,16 +31,6 @@ dist/base1/require.js: src/base1/deprecated.js src/base1/require-config.js src/b
 	cat $(srcdir)/src/base1/deprecated.js $(srcdir)/src/base1/require-config.js $(srcdir)/node_modules/requirejs/require.js $(srcdir)/src/base1/require-loaders.js > $@.tmp && $(MV) $@.tmp $@
 dist/base1/require.min.js: dist/base1/require.js
 	$(MIN_JS_RULE)
-dist/base1/jquery.js:
-	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	cat $(srcdir)/node_modules/jquery/dist/jquery.js $(srcdir)/node_modules/bootstrap/dist/js/bootstrap.js $(srcdir)/node_modules/patternfly/dist/js/patternfly.js > $@.tmp && $(MV) $@.tmp $@
-dist/base1/jquery.min.js: dist/base1/jquery.js
-	$(MIN_JS_RULE)
-dist/base1/cockpit.js: src/base1/cockpit.js
-	$(JSHINT_RULE)
-	$(COPY_RULE)
-dist/base1/cockpit.min.js: dist/base1/cockpit.js
-	$(MIN_JS_RULE)
 dist/base1/mustache.js: src/base1/deprecated.js
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
 	cat $(srcdir)/src/base1/deprecated.js $(srcdir)/node_modules/mustache/mustache.js > $@.tmp && $(MV) $@.tmp $@
@@ -56,10 +42,6 @@ dist/base1/manifest.json: src/base1/manifest.json
 
 # All map files are built as side effects of minification
 dist/base1/require.min.js.map: dist/base1/require.min.js
-
-dist/base1/cockpit.min.js.map: dist/base1/cockpit.min.js
-
-dist/base1/jquery.min.js.map: dist/base1/jquery.min.js
 
 dist/base1/mustache.min.js.map: dist/base1/mustache.min.js
 
@@ -199,14 +181,8 @@ TESTS += $(base_TESTS)
 noinst_SCRIPTS += $(base_TESTS)
 
 EXTRA_DIST += \
-	dist/base1/cockpit.js \
 	dist/base1/cockpit.min.css \
 	dist/base1/cockpit.min.css.map \
-	dist/base1/cockpit.min.js \
-	dist/base1/cockpit.min.js.map \
-	dist/base1/jquery.js \
-	dist/base1/jquery.min.js \
-	dist/base1/jquery.min.js.map \
 	dist/base1/mustache.js \
 	dist/base1/mustache.min.js \
 	dist/base1/mustache.min.js.map \
@@ -237,20 +213,12 @@ EXTRA_DIST += \
 	$(NULL)
 
 CLEANFILES += \
-	dist/base1/cockpit.js \
 	dist/base1/cockpit.min.css \
 	dist/base1/cockpit.min.css.gz \
 	dist/base1/cockpit.min.css.map \
-	dist/base1/cockpit.min.js \
-	dist/base1/cockpit.min.js.gz \
-	dist/base1/cockpit.min.js.map \
 	dist/base1/fonts/fontawesome.woff \
 	dist/base1/fonts/glyphicons.woff \
 	dist/base1/fonts/patternfly.woff \
-	dist/base1/jquery.js \
-	dist/base1/jquery.min.js \
-	dist/base1/jquery.min.js.gz \
-	dist/base1/jquery.min.js.map \
 	dist/base1/manifest.json \
 	dist/base1/mustache.js \
 	dist/base1/mustache.min.js \

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -275,6 +275,7 @@ var webpack = require("webpack");
 var copy = require("copy-webpack-plugin");
 var html = require('html-webpack-plugin');
 var extract = require("extract-text-webpack-plugin");
+var MergeIntoSingleFilePlugin = require('webpack-merge-and-include-globally');
 var extend = require("extend");
 var path = require("path");
 var fs = require("fs");
@@ -343,6 +344,18 @@ var plugins = [
     }),
     new copy(info.files),
     new extract("[name].css"),
+    new MergeIntoSingleFilePlugin({
+        files: {
+            "base1/cockpit.js": [
+                srcdir + "/src/base1/cockpit.js"
+            ],
+            "base1/jquery.js": [
+                nodedir + "/jquery/dist/jquery.js",
+                nodedir + "/bootstrap/dist/js/bootstrap.js",
+                nodedir + "/patternfly/dist/js/patternfly.js"
+            ]
+        }
+    })
 ];
 
 var output = {
@@ -379,20 +392,6 @@ info.tests.forEach(function(test) {
         }));
     }
 });
-
-/* Just for the sake of tests, jquery.js and cockpit.js files */
-if (!section || section.indexOf("base1") === 0) {
-    files.push({
-        from: srcdir + path.sep + "src/base1/cockpit.js",
-        to: "base1/cockpit.js"
-    }, {
-        from: nodedir + path.sep + "jquery/dist/jquery.js",
-        to: "base1/jquery.js"
-    }, {
-        from: srcdir + path.sep + "po/po.js",
-        to: "shell/po.js"
-    });
-}
 
 var aliases = {
     "angular": "angular/angular.js",


### PR DESCRIPTION
This shouldn't ever have had any effect, because we're not copying
manifest.json files into these directories.

Also, the jquery.js we were copying is the vanilla upstream one, not the
one we supplement with bootstrap and patternfly in
src/base1/Makefile.am. This leads to errors when building first with a
Makefile and then with webpack.

**NOTE** marked as WIP. I'm not sure if this really doesn't affect any of the tests, yet.