### PR TITLE
bots: PCP SIGSEGV applies to RHEL 7.4 too

### DIFF
--- a/bots/naughty/rhel-7-4/6108-pcp-pmfindprofile-crash
+++ b/bots/naughty/rhel-7-4/6108-pcp-pmfindprofile-crash
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+*
+  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
+*
+Error: /usr/*/cockpit-pcp: bridge was killed: 11

--- a/bots/naughty/rhel-7/6108-pcp-pmfindprofile-crash
+++ b/bots/naughty/rhel-7/6108-pcp-pmfindprofile-crash
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+*
+  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
+*
+Error: /usr/*/cockpit-pcp: bridge was killed: 11


### PR DESCRIPTION
Copy the naughty override from Fedora.

Example: https://fedorapeople.org/groups/cockpit/logs/pull-8069-20171214-162121-6dea9ac0-verify-rhel-7-4/log.html#141