### PR TITLE
Clean up various PhantomJS hacks

### DIFF
--- a/bots/task/test-policy
+++ b/bots/task/test-policy
@@ -71,32 +71,6 @@ Journal extracted to TestMultiMachine-testFrameNavigation-fedora-i386-127.0.0.2-
 Journal extracted to TestMultiMachine-testFrameNavigation-fedora-i386-127.0.0.2-2502-FAIL.log
 """
 
-PHANTOMJS_CRASH = """
-# ----------------------------------------------------------------------
-# testFrameNavigation (check_multi_machine.TestMultiMachine)
-#
-Resource Error: Operation canceled http://127.0.0.2:9391/cockpit/@10.111.113.2/playground/test.html#/
-Resource Error: Operation canceled http://127.0.0.2:9391/cockpit/@10.111.113.2/playground/test.html#/
-not ok 110 testFrameNavigation (check_multi_machine.TestMultiMachine)
-Traceback (most recent call last):
-  File "test/verify/check-multi-machine", line 202, in tearDown
-    MachineCase.tearDown(self)
-Error: blah
-"""
-
-PHANTOMJS_RETRY = """
-# ----------------------------------------------------------------------
-# testFrameNavigation (check_multi_machine.TestMultiMachine)
-#
-Resource Error: Operation canceled http://127.0.0.2:9391/cockpit/@10.111.113.2/playground/test.html#/
-Resource Error: Operation canceled http://127.0.0.2:9391/cockpit/@10.111.113.2/playground/test.html#/
-# RETRY due to failure of test harness or framework
-Traceback (most recent call last):
-  File "test/verify/check-multi-machine", line 202, in tearDown
-    MachineCase.tearDown(self)
-Error: blah
-"""
-
 class TestPolicy(unittest.TestCase):
     def testNaughtyNumber(self):
         script = os.path.join(BOTS, "image-naughty")
@@ -118,13 +92,6 @@ class TestPolicy(unittest.TestCase):
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
         (output, unused) = proc.communicate(PCP_CRASH)
         self.assertEqual(output, PCP_KNOWN)
-
-    def testRetryIssue(self):
-        script = os.path.join(BOTS, "tests-policy")
-        cmd = [ script, "--offline", "verify/example" ]
-        proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
-        (output, unused) = proc.communicate(PHANTOMJS_CRASH)
-        self.assertEqual(output, PHANTOMJS_RETRY)
 
 
 if __name__ == '__main__':

--- a/bots/tests-policy
+++ b/bots/tests-policy
@@ -184,18 +184,6 @@ def checkRetry(trace):
 
     trace = normalize_traceback(trace)
 
-    # HACK: An issue in phantomjs and QtWebkit
-    # http://stackoverflow.com/questions/35337304/qnetworkreply-network-access-is-disabled-in-qwebview
-    # https://github.com/owncloud/client/issues/3600
-    # https://github.com/ariya/phantomjs/issues/14789
-    if "PhantomJS or driver broken" in trace:
-        return True
-
-    # HACK: A race issue in phantomjs that happens randomly
-    # https://github.com/ariya/phantomjs/issues/12750
-    if "Resource Error: Operation canceled" in trace:
-        return True
-
     # HACK: Interacting with sshd during boot is not always predictable
     # We're using an implementation detail of the server as our "way in" for testing.
     # This often has to do with sshd being restarted for some reason

--- a/pkg/kubernetes/scripts/containers.js
+++ b/pkg/kubernetes/scripts/containers.js
@@ -28,8 +28,6 @@
 
     require('kubernetes-container-terminal/dist/container-terminal.js');
 
-    var phantom_checkpoint = phantom_checkpoint || function () { };
-
     angular.module('kubernetes.containers', [
         'ngRoute',
         'ui.cockpit',
@@ -289,8 +287,6 @@
                             pre.append(span);
                             if (at_bottom)
                                 pre[0].scrollTop = pre[0].scrollHeight;
-
-                            phantom_checkpoint();
                         }
 
                         ws = socket(url);

--- a/pkg/machines/helpers.es6
+++ b/pkg/machines/helpers.es6
@@ -213,7 +213,7 @@ export function fileDownload ({ data, fileName = 'myFile.dat', mimeType = 'appli
         window.setTimeout(() => document.body.removeChild(f), 333);
     }
 
-    window.setTimeout(() => { // give phantomJS time ...
+    window.setTimeout(() => { // give test browser some time ...
         logDebug('removing temporary A.HREF for filedownload');
         document.body.removeChild(a);
     }, 5000);

--- a/pkg/machines/reducers.es6
+++ b/pkg/machines/reducers.es6
@@ -45,29 +45,6 @@ if (!Array.prototype.findIndex) {
     };
 }
 
-// --- compatibility hack for PhantomJS
-if (typeof Object.assign != 'function') {
-    Object.assign = function (target) {
-        'use strict';
-        if (target === null) {
-            throw new TypeError('Cannot convert undefined or null to object');
-        }
-
-        target = Object(target);
-        for (var index = 1; index < arguments.length; index++) {
-            var source = arguments[index];
-            if (source !== null) {
-                for (var key in source) {
-                    if (Object.prototype.hasOwnProperty.call(source, key)) {
-                        target[key] = source[key];
-                    }
-                }
-            }
-        }
-        return target;
-    };
-}
-
 // --- helpers -------------------
 function getFirstIndexOfVm(state, field, value, connectionName) {
     return state.findIndex(e => {

--- a/pkg/ostree/app.js
+++ b/pkg/ostree/app.js
@@ -16,8 +16,6 @@
     var _ = cockpit.gettext;
     cockpit.translate();
 
-    var phantom_checkpoint = phantom_checkpoint || function () { };
-
     function track_id(item) {
         if (!item)
             return;
@@ -75,7 +73,6 @@
                 function set_curtains(curtains) {
                     $scope.$applyAsync(function() {
                         $scope.curtains = curtains;
-                        phantom_checkpoint();
                     });
                 }
 
@@ -156,14 +153,6 @@
             function($scope) {
                 $scope.os = null;
                 $scope.track_id = track_id;
-
-                /*
-                 * phantom_checkpoint for tests
-                 * on digest
-                 */
-                $scope.$watch(function() {
-                    phantom_checkpoint();
-                });
 
                 $scope.displayOS = function(os) {
                     $scope.os = os;

--- a/pkg/ovirt/components/ClusterVms.jsx
+++ b/pkg/ovirt/components/ClusterVms.jsx
@@ -187,51 +187,6 @@ const ClusterVms = ({ dispatch, config }) => {
     </div>);
 };
 
-// --- hack for phantomJS:
-// https://tc39.github.io/ecma262/#sec-array.prototype.find
-if (!Array.prototype.find) {
-    Object.defineProperty(Array.prototype, 'find', {
-        value: function(predicate) {
-            // 1. Let O be ? ToObject(this value).
-            if (this == null) {
-                throw new TypeError('"this" is null or not defined');
-            }
-
-            var o = Object(this);
-
-            // 2. Let len be ? ToLength(? Get(O, "length")).
-            var len = o.length >>> 0;
-
-            // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-            if (typeof predicate !== 'function') {
-                throw new TypeError('predicate must be a function');
-            }
-
-            // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
-            var thisArg = arguments[1];
-
-            // 5. Let k be 0.
-            var k = 0;
-
-            // 6. Repeat, while k < len
-            while (k < len) {
-                // a. Let Pk be ! ToString(k).
-                // b. Let kValue be ? Get(O, Pk).
-                // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-                // d. If testResult is true, return kValue.
-                var kValue = o[k];
-                if (predicate.call(thisArg, kValue, k, o)) {
-                    return kValue;
-                }
-                // e. Increase k by 1.
-                k++;
-            }
-
-            // 7. Return undefined.
-            return undefined;
-        }
-    });
-}
 // ------------
 
 export { VmLastMessage, VmDescription, VmMemory, VmCpu, VmOS, VmHA, VmStateless };

--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -279,10 +279,7 @@ export default class AutoUpdates extends React.Component {
         var autoConfig;
 
         if (backend.enabled) {
-            // Array.from(Array(24).keys()) or [...Array(24).keys()] is not understood by PhantomJS
-            let hours = [];
-            for (let i = 0; i < 24; ++i)
-                hours.push(i);
+            let hours = Array.from(Array(24).keys());
 
             autoConfig = (
                 <table className="auto-conf">

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -17,8 +17,6 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-var phantom_checkpoint = phantom_checkpoint || function () { };
-
 (function() {
     "use strict";
 
@@ -339,7 +337,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             frame.setAttribute('data-loaded', '1');
 
             perform_track(child);
-            phantom_checkpoint();
 
             index.navigate();
             return source;
@@ -509,7 +506,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             if (!a.host || window.location.host === a.host) {
                 self.jump(a.getAttribute('href'));
                 ev.preventDefault();
-                phantom_checkpoint();
             }
         });
 
@@ -517,7 +513,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             var old_onerror = window.onerror;
             window.onerror = function cockpit_error_handler(msg, url, line) {
                 self.show_oops();
-                phantom_checkpoint();
                 if (old_onerror)
                     return old_onerror(msg, url, line);
                 return false;
@@ -849,7 +844,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
 
             $(id).on("shown.bs.modal", function() {
                 $("display-language-list").focus();
-                phantom_checkpoint();
             });
         }
 
@@ -857,7 +851,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
         function setup_about(id) {
             $(cockpit.info).on("changed", function() {
                 $(id).text(cockpit.info.version);
-                phantom_checkpoint();
             });
         }
 

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -509,15 +509,13 @@
             }
         });
 
-        if (window.navigator.userAgent.indexOf("PhantomJS") == -1) {
-            var old_onerror = window.onerror;
-            window.onerror = function cockpit_error_handler(msg, url, line) {
-                self.show_oops();
-                if (old_onerror)
-                    return old_onerror(msg, url, line);
-                return false;
-            };
-        }
+        var old_onerror = window.onerror;
+        window.onerror = function cockpit_error_handler(msg, url, line) {
+            self.show_oops();
+            if (old_onerror)
+                return old_onerror(msg, url, line);
+            return false;
+        };
 
         /*
          * Navigation is driven by state objects, which are used with pushState()

--- a/pkg/shell/index-no-machines.js
+++ b/pkg/shell/index-no-machines.js
@@ -17,8 +17,6 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-var phantom_checkpoint = phantom_checkpoint || function () { };
-
 (function() {
     "use strict";
 

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -17,8 +17,6 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-var phantom_checkpoint = phantom_checkpoint || function () { };
-
 (function() {
     "use strict";
 
@@ -155,7 +153,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             $(".curtains-ct p").text(cockpit.message(watchdog_problem));
             $(".curtains-ct").show();
             $("#navbar-dropdown").addClass("disabled");
-            phantom_checkpoint();
         }
 
         /* Handles navigation */
@@ -468,8 +465,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                 label = item ? item.label : "";
                 update_title(label, machine);
             }
-
-            phantom_checkpoint();
         }
 
         function update_machines() {
@@ -594,7 +589,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             $(".curtains-ct p").text(cockpit.message(watchdog_problem));
             $(".curtains-ct").show();
             $("#navbar-dropdown").addClass("disabled");
-            phantom_checkpoint();
         }
 
         index.ready();
@@ -664,8 +658,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             item = compiled.items[state.component];
             label = item ? item.label : "";
             update_title(label);
-
-            phantom_checkpoint();
         }
 
         cockpit.transport.wait(function() {

--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -396,7 +396,6 @@ html.index-page body {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        display: -webkit-flex; /* Fallback for PhantomJS */
         display: flex;
         align-items: center;
         text-decoration: none;

--- a/pkg/shell/switcher.less
+++ b/pkg/shell/switcher.less
@@ -177,7 +177,6 @@
         -webkit-flex: auto;
         flex: auto;
         position: relative;
-        width: 100%; // Hack for PhantomJS
 
         /* Position as absolute to make things work on old Chrome versions,
            mainly to make tests pass */

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -360,9 +360,4 @@ a.disabled {
     padding: 0px;
     margin: 0px;
     white-space: pre-wrap;
-    max-height: 300px;
-}
-
-#motd.phantom {
-    overflow: hidden;
 }

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -629,9 +629,6 @@ PageServer.prototype = {
     },
 
     show: function() {
-        /* HACK: Overflow: auto on motd pre element causes a phantomjs crash */
-        $('#motd').toggleClass("phantom", window.navigator.userAgent.indexOf("PhantomJS") > -1);
-
         this.cpu_plot.start_walking();
         this.memory_plot.start_walking();
         this.disk_plot.start_walking();

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -76,7 +76,7 @@
           <span class="pficon pficon-close"></span>
         </button>
         <span class="pficon pficon-info"></span>
-        <pre id="motd" class="phantom"></pre>
+        <pre id="motd"></pre>
       </div>
     </div>
 

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -26,8 +26,6 @@ try {
 
 var mock = mock || { };
 
-var phantom_checkpoint = phantom_checkpoint || function () { };
-
 (function() {
 "use strict";
 
@@ -549,7 +547,6 @@ function Transport() {
         else
             process_message(channel, payload);
 
-        phantom_checkpoint();
         return true;
     };
 

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -4524,17 +4524,13 @@ function factory() {
             window.parent.postMessage("\n{ \"command\": \"oops\" }", transport_origin);
     };
 
-    var old_onerror;
-
-    if (window.navigator.userAgent.indexOf("PhantomJS") == -1) {
-        old_onerror = window.onerror;
-        window.onerror = function(msg, url, line) {
-            cockpit.oops();
-            if (old_onerror)
-                return old_onerror(msg, url, line);
-            return false;
-        };
-    }
+    var old_onerror = window.onerror;
+    window.onerror = function(msg, url, line) {
+        cockpit.oops();
+        if (old_onerror)
+            return old_onerror(msg, url, line);
+        return false;
+    };
 
     return cockpit;
 } /* scope end */

--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -1,7 +1,5 @@
 /* global XMLHttpRequest */
 
-var phantom_checkpoint = phantom_checkpoint || function () { };
-
 (function(console) {
     var url_root;
     window.localStorage.removeItem('url-root');
@@ -471,7 +469,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
 
         show_form();
         id("login-user-input").focus();
-        phantom_checkpoint();
     }
 
     function show_converse(prompt_data) {
@@ -513,7 +510,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
         id("conversation-input").addEventListener("keydown", key_down);
         id("login-button").addEventListener("click", call_converse);
         show_form(true);
-        phantom_checkpoint();
     }
 
     function utf8(str) {
@@ -610,7 +606,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
                 fatal(format(_("$0 error"), xhr.status));
             }
             id("login-button").removeAttribute('disabled');
-            phantom_checkpoint();
         };
         xhr.send();
     }
@@ -662,7 +657,6 @@ var phantom_checkpoint = phantom_checkpoint || function () { };
             } else {
                 login_reload (embeded_url);
             }
-            phantom_checkpoint();
         };
         xhr.send();
     }

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -223,8 +223,6 @@ class Browser:
 
     def key_press(self, keys):
         for k in keys:
-            if k == 'Return':
-                k = '\r'  # FIXME: PhantomJS backwards compat
             self.cdp.invoke("Input.dispatchKeyEvent", type="char", text=k)
 
     def wait_timeout(self, timeout):

--- a/test/verify/check-active-pages
+++ b/test/verify/check-active-pages
@@ -71,8 +71,7 @@ class TestActivePages(MachineCase):
         b.wait_text_not(line_sel(1), line_text(""))
 
         # run the sleep command
-        key_presses = list("sleep 999999") + [ "Return" ];
-        b.key_press( key_presses )
+        b.key_press("sleep 999999\r")
 
         # wait for it to be present in ps
         wait(lambda: m.execute("ps ax | grep 'sleep 99.*999'"))

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -356,22 +356,22 @@ CMD ["/bin/sh"]
 
         # Wait for the container to wake up
         try:
-            b.key_press( [ 'Return', 'Return', 'Return' ] )
+            b.key_press("\r\r\r")
             b.wait_in_text("#container-terminal", "#")
         except Error as ex:
             if not ex.msg.startswith('timeout'):
                 raise
 
-        b.key_press( [ 'c', 'l', 'e', 'a', 'r', 'Return' ] )
+        b.key_press("clear\r")
         b.wait_in_text("#container-terminal", "#")
 
         b.focus('#container-terminal .console-ct .terminal')
-        b.key_press( [ 'e', 'n', 'v', 'Return' ] )
+        b.key_press("env\r")
         b.wait_in_text("#container-terminal", "zero=GGG")
         b.wait_in_text("#container-terminal", "SECOND=marmalade")
 
         b.focus('#container-terminal .console-ct .terminal')
-        b.key_press( [ 'l', 's', ' ', '/', 'b', 'l', 'a', 'h', '/', 'Return' ] )
+        b.key_press("ls /blah/\r")
         b.wait_in_text("#container-terminal", "dripping.txt")
 
         self.allow_journal_messages('.*denied.*name_connect.*docker.*')

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -701,8 +701,7 @@ class TestAutoUpdates(PackageCase):
             return
 
         def wait_pending():
-            # the controls get disabled while applying the config changes is in progress; wait for both transitions, to
-            # get Phantom checkpoints while the setConfig() promise is running
+            # the controls get disabled while applying the config changes is in progress; wait for both transitions
             b.wait_present("#automatic .disabled")
             b.wait_not_present("#automatic .disabled")
 

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -294,7 +294,7 @@ class TestKerberos(MachineCase):
         wait_prompt(b, 1)
 
         # run kinit and see if got forwarded the kerberos ticket into the session
-        b.key_press(list("klist") + [ "Return" ])
+        b.key_press("klist\r")
         wait_prompt(b, 2)
         text = b.text(line_sel(2)).replace(u"\xa0", " ").strip()
         self.assertIn("Ticket cache", text)

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -52,10 +52,10 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
         b.wait_js_func("(function (sel) { return ph_text(sel).trim() != ''})", line_sel(n))
 
         # clear any messages (for example, instructions about sudo) and wait for prompt
-        b.key_press( [ 'c', 'l', 'e', 'a', 'r' ] )
+        b.key_press("clear")
         b.wait_js_cond("ph_text('.terminal').indexOf('clear') >= 0")
         # now wait for clear to take effect
-        b.key_press( [ 'Return' ] )
+        b.key_press("\r")
         b.wait_js_cond("ph_text('.terminal').indexOf('clear') < 0")
         # now we should get a clean prompt
         wait_line(n, "$")
@@ -71,13 +71,12 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
             self.assertIn("~]$", prompt)
 
         # Run some commands
-        b.key_press( [ 'w', 'h', 'o', 'a', 'm', 'i', 'Return' ] )
+        b.key_press("whoami\r")
         wait_line(n + 1, "admin")
 
         wait_line(n + 2, prompt)
 
-        b.key_press([ 'e', 'c', 'h', 'o', ' ',  '-', 'e', ' ',
-                      '"', '1', '\\', 'u', '0', '0', '4', '1', '"', 'Return' ])
+        b.key_press('echo -e "1\\u0041"\r')
         wait_line(n + 3, '1A')
 
         # The '@' sign is in the default prompt

--- a/test/verify/files/embed-cockpit.html
+++ b/test/verify/files/embed-cockpit.html
@@ -143,7 +143,6 @@
         </div><!-- /row -->
     </div><!-- /container -->
     <script>
-        var phantom_checkpoint = phantom_checkpoint || function () { };
         var frames = { };
 
         function click(ev) {
@@ -163,7 +162,6 @@
                 document.getElementById("embed-here").appendChild(frame);
                 frame.addEventListener("load", function(ev) {
                     ev.target.setAttribute("loaded", "1");
-                    phantom_checkpoint();
                 });
             }
 

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -324,7 +324,7 @@ class KubernetesCommonTests(VolumeTests):
         b.wait_visible("tbody.open .listing-ct-panel div.terminal")
         b.wait_in_text("tbody.open .listing-ct-panel div.terminal", "#")
         b.focus('tbody.open .listing-ct-panel .terminal')
-        b.key_press( [ 'w', 'h', 'o', 'a', 'm', 'i', 'Return' ] )
+        b.key_press("whoami\r")
         b.wait_in_text("tbody.open .listing-ct-panel div.terminal", "root")
 
     def testDelete(self):


### PR DESCRIPTION
Now that the port to Chromium has landed, clean up the PhantomJS hacks that are only related to the integration tests (unit tests still need to be ported).