### PR TITLE
storage: Run vdo-monitor with Python 2 always

### DIFF
--- a/pkg/lib/python.jsx
+++ b/pkg/lib/python.jsx
@@ -22,12 +22,20 @@ import cockpit from "cockpit";
 // FIXME: eventually convert all images to python 3
 const pyinvoke = [ "sh", "-ec", "exec $(which python3 2>/dev/null || which python) $@", "--", "-" ];
 
-export function spawn (script_pieces, args, options) {
+function spawn_with_invoker (invoker, script_pieces, args, options) {
     var script;
     if (typeof script_pieces == "string")
         script = script_pieces;
     else
         script = script_pieces.join("\n");
 
-    return cockpit.spawn(pyinvoke.concat(args), options).input(script);
+    return cockpit.spawn(invoker.concat(args), options).input(script);
+}
+
+export function spawn (script_pieces, args, options) {
+    return spawn_with_invoker(pyinvoke, script_pieces, args, options);
+}
+
+export function spawn2 (script_pieces, args, options) {
+    return spawn_with_invoker([ "python2", "--", "-" ], script_pieces, args, options);
 }

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -641,7 +641,7 @@
 
         function start() {
             var buf = "";
-            python.spawn([ inotify_py, vdo_monitor_py ], [ ], { superuser: "try", err: "message" })
+            python.spawn2([ inotify_py, vdo_monitor_py ], [ ], { superuser: "try", err: "message" })
                 .stream(function (output) {
                     var lines;
 

--- a/pkg/storaged/vdo-details.jsx
+++ b/pkg/storaged/vdo-details.jsx
@@ -67,8 +67,8 @@ export class VDODetails extends React.Component {
         }
 
         if (path)
-            this.poll_process = python.spawn([ inotify_py, vdo_monitor_py ], [ path ],
-                                             { superuser: true })
+            this.poll_process = python.spawn2([ inotify_py, vdo_monitor_py ], [ path ],
+                                              { superuser: true })
                                       .stream((data) => {
                                           buf += data;
                                           var lines = buf.split("\n");


### PR DESCRIPTION
There is no Python 3 version of the vdomgmnt module.