### PR TITLE
bots: Widen pattern for known issue 7960

### DIFF
--- a/bots/naughty/ubuntu-stable/7960-ntp-apparmor-disconnected-path
+++ b/bots/naughty/ubuntu-stable/7960-ntp-apparmor-disconnected-path
@@ -1,1 +1,1 @@
-Error: audit: type=1400 * apparmor="DENIED" operation="sendmsg" info="Failed name lookup - disconnected path" error=-13 profile="/usr/sbin/ntpd" name="run/systemd/journal/dev-log" pid=* comm="ntpd" requested_mask="w" denied_mask="w"
+Error: audit: type=1400 * apparmor="DENIED" operation="sendmsg" info="Failed name lookup - disconnected path" error=-13 profile="/usr/sbin/ntpd" * pid=* comm="ntpd" requested_mask="w" denied_mask="w"


### PR DESCRIPTION
This AppArmor denial happens on other names too. Seen in the field:

    audit: type=1400 audit(1513335644.697:282): apparmor="DENIED"
    operation="connect" info="Failed name lookup - disconnected path"
    error=-13 profile="/usr/sbin/ntpd" name="var/lib/sss/pipes/nss"
    pid=8091 comm="ntpd" requested_mask="wr" denied_mask="wr" fsuid=110
    ouid=0


Example: https://fedorapeople.org/groups/cockpit/logs/pull-8276-20171215-104444-3a4b3e01-verify-ubuntu-stable/log.html#79