### PR TITLE
bridge: Don't force output to utf-8 too early

### DIFF
--- a/src/common/cockpitunicode.c
+++ b/src/common/cockpitunicode.c
@@ -21,6 +21,27 @@
 
 #include "cockpitunicode.h"
 
+gboolean
+cockpit_unicode_has_incomplete_ending (GBytes *input)
+{
+  const gchar *data;
+  const gchar *end;
+  gsize length;
+
+  data = g_bytes_get_data (input, &length);
+  if (g_utf8_validate (data, length, &end))
+    return FALSE;
+
+  do
+    {
+      length -= (end - data) + 1;
+      data = end + 1;
+    }
+  while (!g_utf8_validate (data, length, &end));
+
+  return length == 0;
+}
+
 GBytes *
 cockpit_unicode_force_utf8 (GBytes *input)
 {

--- a/src/common/cockpitunicode.h
+++ b/src/common/cockpitunicode.h
@@ -26,6 +26,8 @@ G_BEGIN_DECLS
 
 GBytes *      cockpit_unicode_force_utf8    (GBytes *input);
 
+gboolean      cockpit_unicode_has_incomplete_ending (GBytes *input);
+
 G_END_DECLS
 
 #endif /* __COCKPIT_UNICODE_H__ */

--- a/src/common/test-unicode.c
+++ b/src/common/test-unicode.c
@@ -28,7 +28,24 @@
 typedef struct {
   const gchar *input;
   const gchar *output;
+  gboolean incomplete;
 } Fixture;
+
+static void
+test_incomplete_utf8 (gconstpointer data)
+{
+  const Fixture *fixture = data;
+  GBytes *input;
+  gboolean result;
+
+  g_assert (data != NULL);
+
+  input = g_bytes_new_static (fixture->input, strlen (fixture->input));
+  result = cockpit_unicode_has_incomplete_ending (input);
+  g_assert (result == fixture->incomplete);
+
+  g_bytes_unref (input);
+}
 
 static void
 test_force_utf8 (gconstpointer data)
@@ -56,11 +73,14 @@ test_force_utf8 (gconstpointer data)
 }
 
 static const Fixture fixtures[] = {
-  { "this is a ascii", NULL },
-  { "this is \303\244 utf8", NULL },
-  { "this is \303 invalid", "this is \357\277\275 invalid" },
-  { "this is invalid \303", "this is invalid \357\277\275" },
-  { "\303 this is \303 invalid \303", "\357\277\275 this is \357\277\275 invalid \357\277\275" },
+  { "this is a ascii", NULL, FALSE },
+  { "this is \303\244 utf8", NULL, FALSE },
+  { "this is \303 invalid", "this is \357\277\275 invalid", FALSE },
+  { "this is invalid \303", "this is invalid \357\277\275", TRUE },
+  { "\303 this is \303 invalid \303", "\357\277\275 this is \357\277\275 invalid \357\277\275", TRUE },
+  { "\303 this is \303 invalid \303\303", "\357\277\275 this is \357\277\275 invalid \357\277\275\357\277\275", TRUE },
+  { "\303 this is \303 invalid \303\303a", "\357\277\275 this is \357\277\275 invalid \357\277\275\357\277\275a", FALSE },
+  { "Marmalaade!""\xe2\x94\x80", NULL, FALSE },
 };
 
 int
@@ -69,6 +89,7 @@ main (int argc,
 {
   gchar *escaped;
   gchar *name;
+  gchar *name2;
   gint i;
 
   cockpit_test_init (&argc, &argv);
@@ -78,10 +99,13 @@ main (int argc,
       g_assert (fixtures[i].input != NULL);
       escaped = g_strcanon (g_strdup (fixtures[i].input), COCKPIT_TEST_CHARS, '_');
       name = g_strdup_printf ("/unicode/force-utf8/%s", escaped);
+      name2 = g_strdup_printf ("/unicode/incomplete-utf8/%s", escaped);
       g_free (escaped);
 
       g_test_add_data_func (name, fixtures + i, test_force_utf8);
+      g_test_add_data_func (name2, fixtures + i, test_incomplete_utf8);
       g_free (name);
+      g_free (name2);
     }
 
   return g_test_run ();


### PR DESCRIPTION
When we get a string that ends with a what looks like invalid utf-8 wait to see if more data comes in before forcing to to utf-8. Otherwise we end up splitting up multibyte characters.