### PR TITLE
test: Disable parallel job execution for container/kubernetes

### DIFF
--- a/test/containers/run-tests
+++ b/test/containers/run-tests
@@ -55,6 +55,12 @@ def run(opts):
     return testlib.test_main(options=opts, suite=suite)
 
 def main():
+    # HACK: Full chromium under Xvfb is very brittle; disable default parallelism
+    try:
+        del os.environ["TEST_JOBS"]
+    except KeyError:
+        pass
+
     parser = testlib.arg_parser()
     parser.add_argument('-c', '--container', dest="container", action='store',
                         help='container to test')


### PR DESCRIPTION
Apparently running full chromium under xvfb is rather brittle (see
commit 9a6fce4e2eebd), and it's currently way too hard to get the
container/kubernetes test to pass.  Disable the default parallelism
through `$TEST_JOBS` for the time being until headless chrome has a
solution for <https://bugs.chromium.org/p/chromium/issues/detail?id=757181>.

----

Note: This is supposed to help with weird failures like https://fedorapeople.org/groups/cockpit/logs/pull-8280-20171216-124242-1e1fca54-container-kubernetes/log.html#19 . I'm not actually sure if that is because Xvfb actually crashes (`chrome_browser_main_extra_parts_x11.cc(62)] X IO error received (X server probably went away)`) or if that's just a side effect of killing chromium and xvfb out of order in test/common/xvfb-wrapper after a  "regular" test failure. My suspicion is that it's the latter.

But either way, we need to do something about the container/kubernetes test. I'll use this PR to see if that helps in any way.