### PR TITLE
test: Wait for deletion icon before clicking on it

### DIFF
--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -1174,6 +1174,7 @@ class RegistryTests(object):
         b.wait_not_present("modal-dialog")
 
         #delete project member X
+        b.wait_present("tbody[data-id='testprojectuserproj'] tr td:last-child a i.pficon-close")
         b.click("tbody[data-id='testprojectuserproj'] tr td:last-child a i.pficon-close")
         b.wait_present("modal-dialog")
         b.wait_visible(".modal-body")


### PR DESCRIPTION
This fixes a common race condition in `testProjectUsers()`.

---
Example log: https://fedorapeople.org/groups/cockpit/logs/pull-8282-20171217-113333-53d182fe-container-kubernetes/log.html#22