### PR TITLE
ws: Add localhost SubjectAltName to sscg created SSL certificates

### DIFF
--- a/src/ws/cockpitcertificate.c
+++ b/src/ws/cockpitcertificate.c
@@ -220,6 +220,8 @@ sscg_make_dummy_cert (const gchar *key_file,
     "--ca-file", ca_file,
     "--hostname", cn,
     "--organization", org,
+    "--subject-alt-name", "localhost",
+    "--subject-alt-name", "IP:127.0.0.1/255.255.255.255",
     NULL
   };
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -92,7 +92,7 @@ Requires: %{name}-system = %{version}-%{release}
 Recommends: %{name}-dashboard = %{version}-%{release}
 Recommends: %{name}-networkmanager = %{version}-%{release}
 Recommends: %{name}-storaged = %{version}-%{release}
-Recommends: sscg >= 2.0.4
+Recommends: sscg >= 2.3
 %ifarch x86_64 %{arm} aarch64 ppc64le i686 s390x
 Recommends: %{name}-docker = %{version}-%{release}
 %endif


### PR DESCRIPTION
Similar to commit bf5f1bfac5a37, but when sscg is being used. This
already puts the real host name into SAN, but it's plausible that the
certificate is being used on another host. For symmetry, allow localhost
and 127.0.0.1 too.