### PR TITLE
naughty: Close 5143: Fedora: storaged passes bogus partition names to libblockdev

### DIFF
--- a/bots/naughty/fedora-26/5143-bogus-partition-name
+++ b/bots/naughty/fedora-26/5143-bogus-partition-name
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-storage-partitions", line *, in testPartitions
-    self.confirm()


### PR DESCRIPTION
Known issue which has not occurred in 27 days

Fedora: storaged passes bogus partition names to libblockdev

Fixes #5143