### PR TITLE
test: Remove one race condition

### DIFF
--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -42,7 +42,7 @@ class TestStorage(StorageCase):
 
         dev = m.execute("dd if=/dev/zero of=/disk1 bs=1M count=10 && losetup --show loop12 /disk1").strip()
 
-        b.wait(lambda: b.is_present("#others") and dev in b.text("#others"))
+        b.wait_present('tr:contains("%s")' % dev)
         b.click('tr:contains("%s")' % dev)
         b.wait_visible('#storage-detail')
 


### PR DESCRIPTION
The state of the DOM might change while the Python code runs, so we
rewrite the condition in JavaScript, which executes while the browser
event loop is stopped.