### PR TITLE
doc: Document internationalization in Cockpit

### DIFF
--- a/doc/guide/cockpit-locale.xml
+++ b/doc/guide/cockpit-locale.xml
@@ -91,7 +91,7 @@ cockpit.translate(element, ...)
 cockpit.translate(selection)
 </programlisting>
 
-    <para>The document will be scanned for translatable tags and they will be translated according
+    <para>The document will be scanned for <code>translate</code> tags and they will be translated according
       to the strings in loaded locale data. One or more <code>element</code> arguments may be specified.
       These are DOM elements for specific parts of the document to be translated. If no <code>element</code>
       is specified then the entire document is translated.</para>

--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -1,0 +1,83 @@
+
+Cockpit Internationalization
+============================
+
+All human-visible strings on Cockpit's web pages should be translatable. This
+document describes the entire internationalization process, which uses [GNU gettext](https://www.gnu.org/software/gettext/) and related tools as much as possible.
+
+Marking strings
+---------------
+Strings that are visible to humans and which should be translated must be
+marked as such on Cockpit pages, in one of two ways:
+
+ * If the string appears in a HTML source, it must be enclosed in a tag with
+   the `translate="yes"` attribute (some code also still has the deprecated
+   `translatable="yes"`). Example:
+
+   ```html
+   <span translate="yes">Image</span>
+   ```
+
+ * If the string appears in JavaScript source, it must use the
+   [cockpit.gettext()](http://cockpit-project.org/guide/latest/cockpit-locale.html#cockpit-locale-gettext)
+   or a related function, commonly called through an alias `_()`, with double-quoted
+   strings so that `xgettext` can recognize it. Example:
+
+   ```js
+   const _ = cockpit.gettext;
+
+   var translated = _("Time");
+
+   // in a JSX block:
+   <tr>
+     <th>{ _("Image") }</th>
+   </tr>
+   ```
+   For strings that involve numbers you need to use
+   [cockpit.ngettext()](http://cockpit-project.org/guide/latest/cockpit-locale.html#cockpit-locale-ngettext)
+   instead:
+
+   ```js
+   var translated = cockpit.ngettext("This thing", "The things", numberOfThings);
+   ```
+
+   The [cockpit.format()](http://cockpit-project.org/guide/latest/cockpit-util.html#cockpit-format)
+   function is useful for parameterized strings where the order of parameters
+   might change between languages.
+
+Translation process
+-------------------
+
+ * Translatable strings from HTML, JavaScript (as above) and C files get
+   extracted with various invocations of
+   [xgettext](https://linux.die.net/man/1/xgettext), see
+   [po/Makefile.am](https://github.com/cockpit-project/cockpit/blob/master/po/Makefile.am).
+   Running `make po/cockpit.pot` will generate a standard PO template.
+
+ * With `make -C po upload-pot` the PO template gets uploaded to the
+   [Zanata translation platform](https://fedora.zanata.org/iteration/view/cockpit/master)
+   where everybody can contribute translations to various languages.
+
+ *  With `make -C po download-po` Zanata's translations are downloaded to
+    `po/XX.po`. This is done by
+   [bots/po-refresh](https://github.com/cockpit-project/cockpit/blob/master/bots/po-refresh)
+   which is invoked regularly by
+   [bots/po-trigger](https://github.com/cockpit-project/cockpit/blob/master/bots/po-trigger).
+
+ * Translations can also be done using any other tool or platform and be
+   submitted via pull requests that update the `po/XX.po` files. In this case
+   they should then also be uploaded to Zanata again with
+   `make -C po upload-translations`.
+
+Using translations at runtime
+-----------------------------
+HTML and JavaScript don't directly support gettext po and mo files. The
+translations from po files are converted to a JavaScript function by
+[po/po2json](https://github.com/cockpit-project/cockpit/blob/master/po/po2json)
+which inserts the actual translations into the
+[po.empty.js template](https://github.com/cockpit-project/cockpit/blob/master/po/po.empty.js).
+The resulting files are written to `dist/<page>/po.XX.js` from where they
+can be imported by the page and used by `cockpit.gettext()`.
+
+HTML pages which use `translate="yes"` tags need to call
+[cockpit.translate()](http://cockpit-project.org/guide/latest/cockpit-locale.html#cockpit-locale-translate) which will iterate over all such tags and replace their content with the result of calling `cockpit.gettext()` on their original content.


### PR DESCRIPTION
This is useful for external projects which want to integrate with Cockpit, or get included (such as welder).

@mvollmer, I think you were most recently involved with this. Can you please have a look? The one thing I'm not yet clear about is how and where the po files get split into per-page js files. I see the generic `po.%.js: %.po` rule in po/Makefile.am, but not where and how these get filtered for the currently processed page.