### PR TITLE
machines: redesign VM error messages

### DIFF
--- a/pkg/machines/actions.es6
+++ b/pkg/machines/actions.es6
@@ -160,6 +160,11 @@ export function vmActionFailed({ name, connectionName, message, detail, extraPay
     };
 }
 
+export function deleteVmMessage({ name, connectionName }) {
+    // recently there's just the last error message kept so we can reuse the code
+    return vmActionFailed({ name, connectionName, message: null, detail: null, extraPayload: null });
+}
+
 export function undefineVm(connectionName, name, transientOnly) {
     return {
         type: 'UNDEFINE_VM',

--- a/pkg/machines/components/vmLastMessage.css
+++ b/pkg/machines/components/vmLastMessage.css
@@ -1,0 +1,3 @@
+.machines-more-button {
+    padding-left: 10px;
+}

--- a/pkg/machines/components/vmLastMessage.jsx
+++ b/pkg/machines/components/vmLastMessage.jsx
@@ -1,0 +1,86 @@
+/*jshint esversion: 6 */
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from 'cockpit';
+import React from "react";
+import { vmId } from '../helpers.es6';
+import { deleteVmMessage } from '../actions.es6';
+import './vmLastMessage.css';
+
+const _ = cockpit.gettext;
+
+class InlineNotification extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            isDetail: false,
+        };
+
+        this.toggleDetail = this.toggleDetail.bind(this);
+    }
+
+    toggleDetail () {
+        this.setState({
+            isDetail: !this.state.isDetail,
+        });
+    }
+
+    render () {
+        const { text, detail, textId, onDismiss } = this.props;
+
+        let detailButtonText = _("show more");
+        if (this.state.isDetail) {
+            detailButtonText = _("show less");
+        }
+        const detailButton = (<a href='#' className='alert-link machines-more-button' onClick={this.toggleDetail}>{detailButtonText}</a>);
+
+        // do not use "data-dismiss='alert'" to close the notification
+        return (
+            <div className='alert alert-warning alert-dismissable'>
+                <button type='button' className='close' aria-hidden='true' onClick={onDismiss}>
+                    <span className='pficon pficon-close'/>
+                </button>
+                <span className='pficon pficon-warning-triangle-o'/>
+                <strong id={textId}>
+                    {text}
+                </strong>
+                {detailButton}
+                {this.state.isDetail && detail}
+            </div>
+        );
+    }
+}
+
+const VmLastMessage = ({ vm, dispatch }) => {
+    if (!vm.lastMessage) {
+        return null;
+    }
+
+    const textId = `${vmId(vm.name)}-last-message`;
+    let detail = (vm.lastMessageDetail && vm.lastMessageDetail.exception) ? vm.lastMessageDetail.exception : null;
+    detail = detail && (<p>{detail}</p>);
+
+    const onDismiss = () => {
+        dispatch(deleteVmMessage({ name: vm.name, connectionName: vm.connectionName }));
+    };
+
+    return (<InlineNotification text={vm.lastMessage} textId={textId} detail={detail} onDismiss={onDismiss} />);
+};
+
+export default VmLastMessage;

--- a/pkg/machines/machines.less
+++ b/pkg/machines/machines.less
@@ -222,3 +222,7 @@
 .console-type-select {
     width: 19em !important;
 }
+
+.machines-status-alert {
+    padding-right: 5px;
+}

--- a/pkg/machines/reducers.es6
+++ b/pkg/machines/reducers.es6
@@ -152,7 +152,8 @@ function vms(state, action) {
             }
             const updatedVm = Object.assign(indexedVm.vmCopy, {
                 lastMessage: action.payload.message,
-                lastMessageDetail: action.payload.detail});
+                lastMessageDetail: action.payload.detail,
+            });
 
             return replaceVm({ state, updatedVm, index: indexedVm.index });
         }

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -330,6 +330,25 @@ class TestMachines(MachineCase):
         b.click("#vm-subVmTest2-forceOff")
         b.wait_in_text("#vm-subVmTest2-state", "shut off")
 
+        # test VM error messages
+        b.wait_visible("#vm-subVmTest2-run")
+        b.click("#vm-subVmTest2-run")
+        b.click("#vm-subVmTest2-run") # make use of slow processing - the button is still present; will cause error
+        b.wait_present("tr.listing-ct-item.listing-ct-nonavigate span span.pficon-warning-triangle-o.machines-status-alert") # triangle by status
+        b.wait_present("tr.listing-ct-panel div.listing-ct-body div.alert.alert-warning") # inline notification with error
+        b.wait_in_text("#vm-subVmTest2-last-message", "VM START action failed")
+
+        b.wait_present("a.alert-link.machines-more-button") # more/less button
+        b.wait_in_text("a.alert-link.machines-more-button", "show more")
+        b.click("a.alert-link.machines-more-button")
+        b.wait_present("tr.listing-ct-panel div.listing-ct-body div.alert.alert-warning > p")
+        b.wait_in_text("a.alert-link.machines-more-button", "show less")
+        b.wait_in_text("tr.listing-ct-panel div.listing-ct-body div.alert.alert-warning > p", "Domain is already active")
+
+        b.click("tr.listing-ct-panel div.listing-ct-body div.alert.alert-warning button") # close button
+        b.wait_not_present("tr.listing-ct-panel div.listing-ct-body div.alert.alert-warning") # inline notification is gone
+        b.wait_not_present("tr.listing-ct-item.listing-ct-nonavigate span span.pficon-warning-triangle-o.machines-status-alert") # triangle by status is gone
+
         # HACK: restarting libvirtd causes this completely unrelated SELinux issue
         self.allow_journal_messages('.*denied.*search.*"systemd-machine".*dev="proc".*')
 


### PR DESCRIPTION
Rendering of error message for a virtual machine has been improved.

The user can now
- dismiss the message
- show farther details by clicking on `more` button

Fixes: https://github.com/cockpit-project/cockpit/issues/7978