### PR TITLE
tools: Put back udisks module dependencies on RHEL 7.5

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -406,11 +406,8 @@ Requires: device-mapper-multipath
 %else
 %if 0%{?rhel} == 7
 Requires: udisks2 >= 2.6
-# FIXME: udisks2 modules not yet available on 7.5
-%if "%{os_version_id}" != "7.5"
 Requires: udisks2-lvm2 >= 2.6
 Requires: udisks2-iscsi >= 2.6
-%endif
 Requires: device-mapper-multipath
 %else
 %if 0%{?fedora} >= 27 || 0%{?rhel} >= 8


### PR DESCRIPTION
These are available now, so put back the dependencies to keep feature
parity with 7.4.
 
 - [x] land new rhel-7-5 image (PR #8332)