### PR TITLE
containers: Add chromium to unit-tests container

### DIFF
--- a/containers/unit-tests/Dockerfile
+++ b/containers/unit-tests/Dockerfile
@@ -12,7 +12,7 @@ ARG _crossdeps="libglib2.0-dev libgudev-1.0-dev libjson-glib-dev libkeyutils-dev
 RUN dpkg --add-architecture ${arch} && echo ${arch} > /arch && apt-get update && \
     apt-get install -y --no-install-recommends build-essential gcc-multilib clang python3 \
       autoconf automake gdb gtk-doc-tools intltool libjavascript-minifier-xs-perl libjson-perl valgrind \
-      xmlto xsltproc pyflakes npm nodejs-legacy git libfontconfig1 dbus ssh curl \
+      xmlto xsltproc pyflakes npm nodejs-legacy git libfontconfig1 dbus ssh curl chromium-browser \
       $(for p in ${_crossdeps}; do echo $p:${arch}; done) && \
     apt-get clean
 


### PR DESCRIPTION
In PR #8314 we will port the unit tests from PhantomJS to Chromium.

---

I built and [published](https://hub.docker.com/r/cockpit/unit-tests/tags/) new 32/64 bit containers with this change and ran them locally to ensure that they still work (merely adding chromium should be harmless, but there are also some new package versions through updates).