### PR TITLE
test: revert redirecting the cdp driver's stderr

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -192,7 +192,6 @@ class CDP:
         self._driver = subprocess.Popen(["%s/cdp-driver.js" % path, str(cdp_port)],
                                         env=environ,
                                         stdout=subprocess.PIPE,
-                                        stderr=subprocess.PIPE,
                                         stdin=subprocess.PIPE,
                                         close_fds=True)
         self.valid = True


### PR DESCRIPTION
In 97ed5688, the cdp handling was moved into a separate file. It also
started redirecting the driver's stderr (without a mention in the commit
message). Revert this change so that the stderr is visible in test
output.