### PR TITLE
bots: Fix ResourceWarning in bot unit tests

### DIFF
--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -55,7 +55,6 @@ verbose = False
 
 BOTS = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
 BASE = os.path.normpath(os.path.join(BOTS, ".."))
-DEVNULL = open("/dev/null", "r+")
 
 #
 # The main function takes a list of tasks, each of wihch has the following

--- a/bots/task/test-github
+++ b/bots/task/test-github
@@ -88,6 +88,7 @@ def mockServer():
 
     child = os.fork()
     if child != 0:
+        httpd.server_close()
         return child
 
     # prctl(PR_SET_PDEATHSIG, SIGTERM)


### PR DESCRIPTION
This fixes a couple ResourceWarnings in the bot unit tests

    ResourceWarning: unclosed file <_io.TextIOWrapper name='/dev/null'
        mode='r+' encoding='UTF-8'>
    ResourceWarning: unclosed <socket.socket fd=3,
        family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM,
        proto=0, laddr=('127.0.0.8', 9898)>