### PR TITLE
test: Fix KeyError if screenshot is not available

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -467,10 +467,14 @@ class Browser:
         if self.cdp and self.cdp.valid:
             filename = "{0}-{1}.png".format(label or self.label, title)
             ret = self.cdp.invoke("Page.captureScreenshot", no_trace=True)
-            with open(filename, 'wb') as f:
-                f.write(base64.standard_b64decode(ret["data"]))
-            attach(filename)
-            print("Wrote screenshot to " + filename)
+            if "data" in ret:
+                with open(filename, 'wb') as f:
+                    f.write(base64.standard_b64decode(ret["data"]))
+                attach(filename)
+                print("Wrote screenshot to " + filename)
+            else:
+                print("Screenshot not available")
+
             filename = "{0}-{1}.html".format(label or self.label, title)
             html = self.cdp.invoke("Runtime.evaluate", expression="document.documentElement.outerHTML",
                                    no_trace=True)["result"]["value"]


### PR DESCRIPTION
This fixes followup exceptions on test failures like:
```
Error: [...]

not ok [...]
Traceback (most recent call last):
  File "/build/cockpit/test/common/testlib.py", line 660, in intercept
    self.snapshot("FAIL")
  File "/build/cockpit/test/common/testlib.py", line 819, in snapshot
    self.browser.snapshot(title, label)
  File "/build/cockpit/test/common/testlib.py", line 470, in snapshot
    f.write(base64.standard_b64decode(ret["data"]))
KeyError: 'data'
```