### PR TITLE
bots: Fix import of http.client

### DIFF
--- a/bots/learn-tests
+++ b/bots/learn-tests
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.


### PR DESCRIPTION
The learn-tests file was being run in the wrong version of
python. Lets change it to Python 3.x