### PR TITLE
bots: Fix error in tests-data using unassigned variable

### DIFF
--- a/bots/tests-data
+++ b/bots/tests-data
@@ -411,6 +411,7 @@ def logs(revision):
 # body: full log of the test
 # tracker: url tracking the failure, or None
 def tap(content):
+    name = status = tracker = None
     prefix = None
     body = [ ]
     blocks = False


### PR DESCRIPTION
The variable tracker has not been assigned:

    File "/build/cockpit/bots/tests-data", line 77, in main
      for (status, name, body, tracker) in tap(log):
    File "/build/cockpit/bots/tests-data", line 449, in tap
      yield (status, name, "\n".join(body), tracker)
    UnboundLocalError: local variable 'tracker' referenced before assignment
  
 * [ ] learn-tests