### PR TITLE
test: Fix --trace option

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -95,7 +95,7 @@ class Browser:
             self.port = port
         self.default_user = "admin"
         self.label = label
-        self.cdp = cdp.CDP("C.utf8", headless)
+        self.cdp = cdp.CDP("C.utf8", headless, trace=opts.trace)
         self.password = "foobar"
 
     def title(self):


### PR DESCRIPTION
Commit 97ed5688e0fd7 split out the CDP class into a different file, but
forgot to actually pass the value of the `--trace` option to it.

---

As we don't cover this option on the CI machinery, I trigger just one test. This needs to be tested locally/manually to confirm. (I did, and it works)