### PR TITLE
test: Fix race condition in testNodeNavigation

### DIFF
--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -773,6 +773,8 @@ class OpenshiftCommonTests(VolumeTests):
         b.click(".nodes-listing tbody[data-id='f1.cockpit.lan'] tr.listing-ct-panel a.machine-jump")
 
         b.switch_to_top()
+        # the troubleshoot button by itself shows/hides multiple times, wait for "Connecting.." to disappear first
+        b.wait_not_visible(".curtains-ct .spinner")
         b.wait_visible("#machine-troubleshoot")
         b.click('#machine-troubleshoot')
         b.wait_popup('troubleshoot-dialog')


### PR DESCRIPTION
The Troubleshoot button quickly appears and disappears while the
"Connecting to machine..." spinner is shown. Wait for that to go away
first before waiting for the Troubleshoot button. Fixes this race:

```
-> wait: ph_is_visible("#machine-troubleshoot")
<- {u'type': u'undefined'}
-> ph_click("#machine-troubleshoot",false)
<- {u'type': u'string', u'value': u'#machine-troubleshoot is not visible'}
Traceback (most recent call last):
  File "/home/martin/upstream/cockpit/test/verify/kubelib.py", line 793, in testNodeNavigation
    b.click('#machine-troubleshoot')
  File "/home/martin/upstream/cockpit/test/common/testlib.py", line 202, in click
    self.call_js_func('ph_click', selector, force)
  File "/home/martin/upstream/cockpit/test/common/testlib.py", line 187, in call_js_func
    return self.eval_js("%s(%s)" % (func, ','.join(map(jsquote, args))))
  File "/home/martin/upstream/cockpit/test/common/testlib.py", line 173, in eval_js
    self.raise_cdp_exception("eval_js", code, result["exceptionDetails"])
  File "/home/martin/upstream/cockpit/test/common/testlib.py", line 167, in raise_cdp_exception
    raise Error("%s(%s): %s" % (func, arg, msg))
Error: eval_js(ph_click("#machine-troubleshoot",false)): #machine-troubleshoot is not visible
```

Fixes #8364