### PR TITLE
test: Allow "Connection reset by peer" message in multi-machine troubleshooting

### DIFF
--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -868,6 +868,7 @@ class TestMultiMachine(MachineCase):
 
         self.allow_hostkey_messages()
         self.allow_journal_messages('.* couldn\'t connect: .*',
+                                    '.*: Connection reset by peer',
                                     '.* failed to retrieve resource: invalid-hostkey',
                                     '.* host key for server has changed to: .*',
                                     '.* spawning remote bridge failed .*',


### PR DESCRIPTION
Fixes:
```
testTroubleshooting (check_multi_machine.TestMultiMachine)

Unexpected journal message 'couldn't read from connection: Error receiving data: Connection reset by peer'
```

Example: https://fedorapeople.org/groups/cockpit/logs/pull-8365-20180105-091818-c2e8bc03-verify-rhel-7-5/log.html#16
 