### PR TITLE
test: Add default timeout to Machine.execute()

### DIFF
--- a/bots/image-create
+++ b/bots/image-create
@@ -107,7 +107,8 @@ class MachineBuilder:
             self.machine.message("run setup script on guest")
 
             try:
-                self.machine.execute(script="/var/tmp/SETUP " + self.machine.image, environment=env, quiet=not self.machine.verbose)
+                self.machine.execute(script="/var/tmp/SETUP " + self.machine.image,
+                                     environment=env, quiet=not self.machine.verbose, timeout=120)
                 self.machine.execute(command="rm -f /var/tmp/SETUP")
                 self.machine.execute(command="rm -rf /root/.rhel")
 

--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -136,9 +136,10 @@ def run_install_script(machine, do_build, do_install, skips, arg, args):
                                                          " --install" if do_install else "",
                                                          " ".join(skip_args),
                                                          " '%s'" % arg if arg else "")
-    machine.execute(cmd)
+    machine.execute(cmd, timeout=1800)
+
     if install and args.containers:
-        machine.execute("/var/lib/testvm/containers.install")
+        machine.execute("/var/lib/testvm/containers.install", timeout=900)
 
 def build_and_install(build_image, build_results, skips, args):
     """Build and maybe install Cockpit into a test image"""


### PR DESCRIPTION
Wrap the `select()` loop and process `wait()` into a default two-minute
timeout, to avoid indefinitely hanging tests if the target VM crashes and
ssh hangs.

A lot of places call `execute()` inside a `Timeout` context manager
already, so update `Timeout` to be a no-op if an alarm handler is
already set. That way, the outer-most `Timeout` instance wins.

Fixes eternal test hangs on current rhel-7-5 image from
check-storage-mdraid.
  
 * [x] image-refresh fedora-27 (successful, just as a proof, won't commit)
  