### PR TITLE
bots: Add naughty override for RHEL 7.5 RAID kernel lockup regression

### DIFF
--- a/bots/naughty/rhel-7-5/8369-raid-kernel-lockup
+++ b/bots/naughty/rhel-7-5/8369-raid-kernel-lockup
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-storage-mdraid", line *, in testRaid
+    b.wait_not_in_text('#detail-sidebar', "DISK1")
+*
+Error: timeout

--- a/bots/naughty/rhel-7-5/8369-raid-kernel-lockup-2
+++ b/bots/naughty/rhel-7-5/8369-raid-kernel-lockup-2
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-storage-mdraid", line *, in testRaid
+    self.wait_states({ "QEMU QEMU HARDDISK (DISK4)": "In Sync" })
+*
+Error: timeout


### PR DESCRIPTION
See issue #8369
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=1526283

---

- [x] fix eternal test hang (PR #8368), currently included in this PR