### PR TITLE
packagekit: Fix crash on security updates without CVE URLs

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -135,6 +135,8 @@ function deduplicate(list) {
 // Insert comma strings in between elements of the list. Unlike list.join(",")
 // this does not stringify the elements, which we need to keep as JSX objects.
 function insertCommas(list) {
+    if (list.length <= 1)
+        return list;
     return list.reduce((prev, cur) => [prev, ", ", cur])
 }
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -330,6 +330,31 @@ class TestUpdates(PackageCase):
         # should only have one button (only security updates)
         self.assertEqual(b.text("#app .container-fluid button"), "Install Security Updates")
 
+        # security fix without CVE URLs
+        # PackageKit's dnf backend does not recognize this (https://bugs.freedesktop.org/show_bug.cgi?id=101070)
+        # and PackageKit's deb backend does not know about severity at all, so only test this on RPM
+        if self.backend == "yum":
+            self.createPackage("secnocve", "1", "1", install=True)
+            self.createPackage("secnocve", "1", "2", severity="security", changes="Fix leak")
+            self.enableRepo()
+            # check for updates
+            b.wait_in_text(".content-header-extra td button", "Check for Updates")
+            b.click(".content-header-extra td button")
+            b.wait_present("#available h2")
+            b.wait_in_text("#available h2", "Available Updates")
+            b.wait_in_text("#state", "2")
+
+            b.wait_present("table.listing-ct")
+            b.wait_in_text("table.listing-ct", "secnocve")
+
+            # secnocve should be displayed properly
+            self.assertEqual(b.text("#app .listing-ct tbody:nth-of-type(2) th span"), "secnocve")
+            self.assertEqual(b.text("#app .listing-ct tbody:nth-of-type(2) td:nth-of-type(1)"), "1-2")
+            self.assertEqual(b.text("#app .listing-ct tbody:nth-of-type(2) td:nth-of-type(2)"), "")
+            self.assertEqual(b.text("#app .listing-ct tbody:nth-of-type(2) td:nth-of-type(3) span.security-label-text"),
+                             "Security Update")
+            self.assertIn("Fix leak", b.text("#app .listing-ct tbody:nth-of-type(2) td:nth-of-type(3)"))
+
     @skipImage("Ubuntu 16.04 PackageKit does not support changelogs", "ubuntu-1604")
     def testInfoTruncation(self):
         b = self.browser
@@ -671,16 +696,6 @@ class TestAutoUpdates(PackageCase):
 
         # Disable Subscription Manager for these tests; subscriptions are tested in a separate class
         self.machine.execute("[ ! -f /usr/libexec/rhsmd ] || mv /usr/libexec/rhsmd /usr/libexec/rhsmd.disabled")
-
-        # expected backend; hardcode this on image names to check the auto-detection
-        if self.machine.image.startswith("debian") or self.machine.image.startswith("ubuntu"):
-            self.backend = "apt"
-        elif self.machine.image.startswith("fedora"):
-            self.backend = "dnf"
-        elif self.machine.image in ["centos-7", "rhel-7", "rhel-7-4", "rhel-7-5"]:
-            self.backend = "yum"
-        else:
-            raise NotImplementedError("unknown image " + self.machine.image)
 
         # not implemented for yum and apt yet, only dnf
         self.supported_backend = self.backend in ["dnf"]

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -28,10 +28,18 @@ class PackageCase(MachineCase):
     def setUp(self):
         MachineCase.setUp(self)
 
-        self.isApt = "debian" in self.machine.image or "ubuntu" in self.machine.image
+        # expected backend; hardcode this on image names to check the auto-detection
+        if self.machine.image.startswith("debian") or self.machine.image.startswith("ubuntu"):
+            self.backend = "apt"
+        elif self.machine.image.startswith("fedora"):
+            self.backend = "dnf"
+        elif self.machine.image in ["centos-7", "rhel-7", "rhel-7-4", "rhel-7-5"]:
+            self.backend = "yum"
+        else:
+            raise NotImplementedError("unknown image " + self.machine.image)
 
         # disable all existing repositories to avoid hitting the network
-        if self.isApt:
+        if self.backend == "apt":
             self.machine.execute("rm -f /etc/apt/sources.list.d/*; echo > /etc/apt/sources.list; apt-get update")
         else:
             self.machine.execute("rm -f /etc/yum.repos.d/* /var/cache/yum/*")
@@ -56,7 +64,7 @@ class PackageCase(MachineCase):
         If install is True, install the package. Otherwise, update the package
         index in /tmp/repo.
         '''
-        if self.isApt:
+        if self.backend == "apt":
             self.createDeb(name, version + '-' + release, depends, postinst, install, content)
         else:
             self.createRpm(name, version, release, depends, postinst, install, content)
@@ -190,7 +198,7 @@ rm -rf ~/rpmbuild
         return xml
 
     def enableRepo(self):
-        if self.isApt:
+        if self.backend == "apt":
             self.createAptChangelogs()
             # HACK: on Debian jessie, apt has an error propagation bug that causes "Err file: Packages" for each absent
             # compression format with file:// sources, which breaks PackageKit; work around by providing all formats


### PR DESCRIPTION
If an update is marked as type "security" but has no CVE URLs,
`insertCommas()` is called on an empty list. This does not work with the
`.reduce()` function and it crashes with

    TypeError: reduce of empty array with no initial value

Fix this by checking for an empty list in `insertCommas()`.

Reproduce this in a test case with `severity="security"` and no CVE
URLs. This only works on yum, as PackageKit's apt backend does not
support severities, and the dnf backend yields wrong values
(https://bugs.freedesktop.org/show_bug.cgi?id=101070). For that, move
the backend detection from `TestAutoUpdates` to the parent `PackageCase`
class.

Fixes #8375