### PR TITLE
packagekit: Ignore invalid bug URLs

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -240,8 +240,10 @@ class UpdateItem extends React.Component {
         var security_info = null;
 
         if (info.bug_urls && info.bug_urls.length) {
+            // HACK: bug_urls also contains titles, in a not-quite-predictable order; ignore them, only pick out
+            // http[s] URLs (https://bugs.freedesktop.org/show_bug.cgi?id=104552)
             // we assume a bug URL ends with a number; if not, show the complete URL
-            bugs = insertCommas(info.bug_urls.map(url => (
+            bugs = insertCommas(info.bug_urls.filter(url => url.match(/^https?:\/\//)).map(url => (
                 <a rel="noopener" referrerpolicy="no-referrer" target="_blank" href={url}>
                     {url.match(/[0-9]+$/) || url}
                 </a>)

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -163,9 +163,9 @@ rm -rf ~/rpmbuild
         for ((pkg, ver, rel), info) in self.updateInfo.items():
             refs = ""
             for b in info.get("bugs", []):
-                refs += '      <reference href="https://bugs.example.com?bug={0}" id="{0}" type="bugzilla"/>\n'.format(b)
+                refs += '      <reference href="https://bugs.example.com?bug={0}" id="{0}" title="Bug#{0} Description" type="bugzilla"/>\n'.format(b)
             for c in info.get("cves", []):
-                refs += '      <reference href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={0}" id="{0}" type="cve"/>\n'.format(c)
+                refs += '      <reference href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={0}" id="{0}" title="{0}" type="cve"/>\n'.format(c)
 
             xml += '''  <update from="test@example.com" status="stable" type="{severity}" version="2.0">
     <id>UPDATE-{pkg}-{ver}-{rel}</id>


### PR DESCRIPTION
On RHEL, PackageKit's `UpdateDetail` signal has `bugzilla_urls` entries
which are not URLs, but are bug titles for the previous or next list
entry. Filter entries which are actually displayable http:// or https://
URLs to fix that, and ignore the rest.

Add a `title` field to the yum updateinfo XML. This results in

```
Traceback (most recent call last):
  File "test/verify/check-packagekit", line 209, in testInfoSecurity
    self.assertEqual(b.text("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(2)"), "123, 456")
AssertionError: u'Bug#123 Description, Bug#456 Description, 123, 456' != '123, 456'
```

and thus reproduces the bug.

Fixes #8376