### PR TITLE
machines: Start usage polling for the 'Disks' subtab

### DIFF
--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -381,7 +381,7 @@ const Vm = ({ vm, config, hostDevices, onStart, onShutdown, onForceoff, onReboot
     let tabRenderers = [
         {name: _("Overview"), renderer: VmOverviewTab, data: {vm, config, dispatch }},
         {name: usageTabName, renderer: VmUsageTab, data: {vm, onUsageStartPolling, onUsageStopPolling}, presence: 'onlyActive' },
-        {name: disksTabName, renderer: VmDisksTab, data: {vm, provider: config.provider}, presence: 'onlyActive' },
+        {name: disksTabName, renderer: VmDisksTab, data: {vm, provider: config.provider, onUsageStartPolling, onUsageStopPolling}, presence: 'onlyActive' },
         {name: networkTabName, renderer: VmNetworkTab, data: { vm, dispatch, hostDevices }},
         {name: consolesTabName, renderer: Consoles, data: { vm, config, dispatch }},
     ];


### PR DESCRIPTION
Usage statistics polling is started even if the `Disks` subtab is entered.
This is required to read `domstats`.

The user is newly informed about the need to start the VM to read
its disk stats.

Fixes: https://github.com/cockpit-project/cockpit/issues/8393