### PR TITLE
package.json: Update patternfly to 3.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mustache": "2.3.0",
     "noVNC": "https://github.com/novnc/noVNC/archive/v0.6.2.tar.gz",
     "object-describer": "https://github.com/kubernetes-ui/object-describer.git#v1.0.4",
-    "patternfly": "3.27.7",
+    "patternfly": "3.35.1",
     "patternfly-bootstrap-combobox": "1.1.7",
     "qunit-tap": "1.5.1",
     "qunitjs": "1.23.1",

--- a/pkg/lib/variables.less
+++ b/pkg/lib/variables.less
@@ -1,5 +1,5 @@
 @import (less) "../../node_modules/bootstrap/less/variables.less";
-@import (less) "../../node_modules/patternfly/src/less/variables.less";
+@import (less) "../../node_modules/patternfly/dist/less/variables.less";
 
 @metadata-color: #888;
 


### PR DESCRIPTION
More recent versions stopped shipping the source dir through npm, so
pull in the less file from the dist/ dir instead.

----

This is primarily motivated by getting `pficon-security` and `pficon-enhancement` for the software updates page redesign (issue #8379), but also by not letting too much time pass between PF updates, so that the necessary changes don't become too big.

I went through all pages to check for visual oddities, and they work fine.