### PR TITLE
test: Fix more pyflakes failures

### DIFF
--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -218,7 +218,11 @@ def run_avocado(avocado_tests, verbose, browser, download_logs, sit):
 
         if not success and sit:
             sys.stderr.write(machine.diagnose() + "\n")
-            raw_input ("Press RET to continue... ")
+            try:
+                input = raw_input
+            except NameError:
+                pass
+            input ("Press RET to continue... ")
 
         return success
     finally:

--- a/test/containers/check-kubernetes
+++ b/test/containers/check-kubernetes
@@ -23,11 +23,7 @@ import sys
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
 test_dir = os.path.abspath(os.path.join(base_dir, ".."))
-
-try:
-    import testlib
-except:
-    sys.path.append(test_dir)
+sys.path.append(test_dir)
 
 from common.testlib import *
 from common.testvm import VirtMachine

--- a/test/containers/check-kubernetes-openshift
+++ b/test/containers/check-kubernetes-openshift
@@ -25,11 +25,7 @@ import time
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
 test_dir = os.path.abspath(os.path.join(base_dir, ".."))
-
-try:
-    import testlib
-except:
-    sys.path.append(test_dir)
+sys.path.append(test_dir)
 
 from common.testlib import *
 from common.testvm import VirtMachine


### PR DESCRIPTION
    test/avocado/run-tests:221: undefined name 'raw_input'
    test/containers/check-kubernetes-openshift:30: 'testlib' imported but unused
    test/containers/check-kubernetes:28: 'testlib' imported but unused