### PR TITLE
bots: Fix log.html to show failed avocado/selenium tests properly

### DIFF
--- a/bots/task/log.html
+++ b/bots/task/log.html
@@ -135,7 +135,7 @@
         <script>
 
 var tap_range = /^([0-9]+)\.\.([0-9]+)$/m;
-var tap_result = /^(ok|not ok) ([0-9]+) (.*)\)(?: #? ?duration: ([0-9]+s))?(?: # SKIP .*)?$$/gm;
+var tap_result = /^(ok|not ok) ([0-9]+) (.*)(?: # duration: ([0-9]+s))?(?: # SKIP .*)?$$/gm;
 var tap_skipped = /^ok [0-9]+ ([^#].*\))(?: #? ?duration: ([^#]*))? # SKIP (.*$)/gm;
 var image_file = /([A-Za-z0-9\-\.]+)\.(png)$/gm;
 var journal_file = /(Journal extracted to )([A-Za-z0-9\-\.]+)\.(log)$/gm;
@@ -209,8 +209,6 @@ function extract(text) {
             } else if (m = tap_result.exec(segment)) {
                 entry.idx = m[2];
                 entry.id = m[2];
-                // our regex cuts this off
-                m[3] += ")";
                 entry.title = entry.id + ": " + m[3];
                 if (m[4])
                     entry.title += ", duration: " + m[4];

--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -76,9 +76,9 @@ def tap_output(machine):
             print(e)
         print("# TEST LOG END -------")
         if test_status == 'PASS':
-            print("ok %s %s %s" % (counter, test_name, test_time_string))
+            print("ok %s %s # %s" % (counter, test_name, test_time_string))
         else:
-            print("not ok %s %s %s" % (counter, test_name, test_time_string))
+            print("not ok %s %s # %s" % (counter, test_name, test_time_string))
         counter = counter + 1
     if len(json_info['tests']) != json_info['pass']:
         print("# %d TESTS FAILED duration: %ds" % (len(json_info['tests']) - json_info['pass'], json_info['time']))


### PR DESCRIPTION
This would just show all the tests as red if one of them failed.