### PR TITLE
packagekit: Ignore invalid CVE URLs

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -575,6 +575,10 @@ class OsUpdates extends React.Component {
                     u.vendor_urls = vendor_urls;
                     u.bug_urls = deduplicate(bug_urls);
                     u.description = this.formatDescription(update_text || changelog);
+                    // HACK: on yum, cve_urls also contains non-URLs; ignore them, only pick out
+                    // http[s] URLs (https://bugs.freedesktop.org/show_bug.cgi?id=104552)
+                    if (cve_urls)
+                        cve_urls = cve_urls.filter(url => url.match(/^https?:\/\//));
                     // many backends don"t support this; parse CVEs from description as a fallback
                     u.cve_urls = deduplicate(cve_urls && cve_urls.length > 0 ? cve_urls : parseCVEs(u.description));
                     if (u.cve_urls && u.cve_urls.length > 0)


### PR DESCRIPTION
Similar to commit b3b5b6866822, ignore non-URLs in PackageKit's
`cve_urls` field of the `UpdateDetail` signal. On yum, they get
redundant non-URL entries such as

```
$ pkcon get-update-detail [...]
 [...]
 CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-123456, CVE-2014-123456
```

which leads to links such as http://127.0.0.1/cockpit/.../updates/CVE-...

See PackageKit bug <https://bugs.freedesktop.org/show_bug.cgi?id=104552>.

----

screenshot from `check-packagekit TestUpdates.testInfoSecurity`:

![bad-cve-url](https://user-images.githubusercontent.com/200109/34849659-6f8ae6e8-f723-11e7-91b0-d0833f7965ab.png)

(notice the duplication and the bad link)

The current tests don't catch this duplication, but the new tests for the redesign (issue #8379) do that; this is how I found out about it. So I propose to verify the non-duplication there already, the PR for the redesign will land shortly (it's just blocked by three of my current PRs).