### PR TITLE
packagekit: Redesign package update details list

### DIFF
--- a/pkg/packagekit/mock-updates.es6
+++ b/pkg/packagekit/mock-updates.es6
@@ -19,8 +19,8 @@ export function injectMockUpdates(updates) {
         name: "security-one",
         version: "2.3-4",
         bug_urls: [],
-        cve_urls: ["https://cve.example.com?name=CVE-2014-123456"],
-        security: true,
+        cve_urls: ["https://cve.example.com?name=CVE-2014-123456", "https://cve.example.com?name=CVE-2017-9999"],
+        severity: 8,
         description: "This will wreck your data center!",
     };
     updates["security-two;1-2+sec1"] = {
@@ -28,7 +28,7 @@ export function injectMockUpdates(updates) {
         version: "1-2+sec1",
         bug_urls: [],
         cve_urls: ["https://cve.example.com?name=CVE-2014-54321"],
-        security: true,
+        severity: 8,
         description: "Mostly Harmless",
     };
 
@@ -40,7 +40,7 @@ export function injectMockUpdates(updates) {
             version: "1-1",
             bug_urls: [],
             cve_urls: [],
-            security: false,
+            severity: 4,
             description: "Make everything better",
         };
     }
@@ -51,7 +51,7 @@ export function injectMockUpdates(updates) {
         version: "1-1",
         bug_urls: [],
         cve_urls: [],
-        security: false,
+        severity: 6,
         description: ("Some longish explanation of some boring technical change. " +
             "This is total technobabble gibberish for layman users.\n\n").repeat(30)
     };
@@ -65,7 +65,7 @@ export function injectMockUpdates(updates) {
         version: "1-1",
         bug_urls: bugs,
         cve_urls: [],
-        security: false,
+        severity: 6,
         description: "This is FUBAR",
     };
 }

--- a/pkg/packagekit/updates.css
+++ b/pkg/packagekit/updates.css
@@ -9,25 +9,30 @@ tr.listing-ct-item td:last-child {
     text-align: left;
 }
 
-tr.listing-ct-item th {
-    vertical-align: top;
-}
-
-tr.listing-ct-item td {
-    vertical-align: top;
-}
-
-tr.listing-ct-item td.narrow {
+tr.listing-ct-item td.version {
     max-width: 18ex;
     word-wrap: break-word;
 }
 
+tr.listing-ct-item td.type {
+    white-space: nowrap;
+}
+
 tr.listing-ct-item td.changelog {
+    max-width: 60vw;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+p.changelog {
     white-space: pre-wrap;
+    max-height: 20em;
+    overflow: auto;
 }
 
 tr.security.listing-ct-item {
-    background-color: #fbf0f0;
+    background-color: #fbf0f0 !important;  /* keep red background when expanded */
     border-top: 1px solid #e0e0e0;
     border-bottom: 1px solid #e0e0e0;
 }
@@ -61,58 +66,10 @@ tr.security.listing-ct-item {
     }
 }
 
-@media screen and (min-width: 641px) {
-    tr.listing-ct-item td.changelog {
-        width: 80ex;
-        white-space: pre-line;
-     }
-
-     .listing-ct-item td.narrow:nth-child(2) {
-         max-width: 25ex;
-    }
-}
-
 @media screen and (min-width: 641px) and (max-width: 1150px) {
     .listing-ct-item th {
         min-width: 30%;
     }
-
-    /* This really should be .update-bugs or similar */
-    .listing-ct-item td.narrow:nth-child(3) {
-        min-width: 19ex;
-        width: 20ex;
-    }
-    /* Basically children of the above, but break before the odd bug links */
-    .listing-ct-item td.narrow:nth-child(3) a:nth-child(odd):before {
-        display: block;
-        content: '';
-    }
-}
-
-@media screen and (min-width: 1151px) {
-    /* This really should be .update-bugs or similar */
-    .listing-ct-item td.narrow:nth-child(3) {
-        min-width: 36ex;
-        width: 38ex;
-    }
-    /* Basically children of the above, but break before the odd bug links */
-    .listing-ct-item td.narrow:nth-child(3) a:nth-child(4n+5):before {
-        display: block;
-        content: '';
-    }
-}
-
-.info-expander {
-    display: block;
-}
-
-.security-label {
-    color: darkred;
-}
-
-.security-label-text {
-    color: darkred;
-    font-weight: 600;
 }
 
 /* don't let the install progress bar get too wide */

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -247,10 +247,8 @@ class UpdateItem extends React.Component {
         var security_info = null;
 
         if (info.bug_urls && info.bug_urls.length) {
-            // HACK: bug_urls also contains titles, in a not-quite-predictable order; ignore them, only pick out
-            // http[s] URLs (https://bugs.freedesktop.org/show_bug.cgi?id=104552)
             // we assume a bug URL ends with a number; if not, show the complete URL
-            bugs = insertCommas(info.bug_urls.filter(url => url.match(/^https?:\/\//)).map(url => (
+            bugs = insertCommas(info.bug_urls.map(url => (
                 <a rel="noopener" referrerpolicy="no-referrer" target="_blank" href={url}>
                     {url.match(/[0-9]+$/) || url}
                 </a>)
@@ -578,12 +576,15 @@ class OsUpdates extends React.Component {
                                update_text, changelog /* state, issued, updated */) => {
                     let u = this.state.updates[packageId];
                     u.vendor_urls = vendor_urls;
-                    u.bug_urls = deduplicate(bug_urls);
-                    u.description = this.formatDescription(update_text || changelog);
-                    // HACK: on yum, cve_urls also contains non-URLs; ignore them, only pick out
-                    // http[s] URLs (https://bugs.freedesktop.org/show_bug.cgi?id=104552)
+                    // HACK: bug_urls and cve_urls also contain titles, in a not-quite-predictable order; ignore them,
+                    // only pick out http[s] URLs (https://bugs.freedesktop.org/show_bug.cgi?id=104552)
+                    if (bug_urls)
+                        bug_urls = bug_urls.filter(url => url.match(/^https?:\/\//));
                     if (cve_urls)
                         cve_urls = cve_urls.filter(url => url.match(/^https?:\/\//));
+
+                    u.description = this.formatDescription(update_text || changelog);
+                    u.bug_urls = deduplicate(bug_urls);
                     // many backends don't support proper severities; parse CVEs from description as a fallback
                     u.cve_urls = deduplicate(cve_urls && cve_urls.length > 0 ? cve_urls : parseCVEs(u.description));
                     if (u.cve_urls && u.cve_urls.length > 0)

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -43,13 +43,21 @@ class TestUpdates(PackageCase):
         # Disable Subscription Manager for these tests; subscriptions are tested in a separate class
         self.machine.execute("[ ! -f /usr/libexec/rhsmd ] || mv /usr/libexec/rhsmd /usr/libexec/rhsmd.disabled")
 
-    def check_nth_update(self, index, pkgname, version, bugs=None, security=False, desc_matches=[], cves=[]):
+        # only the yum backend properly recognizes "enhancement" severity; apt
+        # does not have that metadata and PackageKit-dnf does not parse it
+        if self.backend == "yum":
+            self.enhancement_severity = "enhancement"
+        else:
+            self.enhancement_severity = "bug"
+
+    def check_nth_update(self, index, pkgname, version, severity="bug", num_issues=None, desc_matches=[], cves=[], bugs=[]):
         """Check the contents of the package update table row at index
 
         None properties will not be tested.
         """
         b = self.browser
         row = "#app .listing-ct tbody:nth-of-type(%i) " % index
+        severity_to_icon = { "bug": "fa-bug", "enhancement": "pficon-enhancement", "security": "pficon-security" }
 
         if isinstance(pkgname, list):
             for idx, pkg in enumerate(pkgname, 1):
@@ -57,19 +65,23 @@ class TestUpdates(PackageCase):
         else:
             self.assertEqual(b.text(row +"th span"), pkgname)
             self.assertEqual(b.text(row + "th .tooltip-inner"), "dummy " + pkgname)
-        self.assertEqual(b.text(row + "td:nth-of-type(1)"), version)
-        if bugs is not None:
-            self.assertEqual(b.text(row + "td:nth-of-type(2)"), bugs)
-        if security:
-            self.assertEqual(b.text(row + "td:nth-of-type(3) span.security-label-text"),
-                             cves and "Security Update: " or "Security Update")
-        else:
-            self.assertFalse(b.is_present(row + "td:nth-of-type(3) span.security-label-text"))
-        description = b.text(row + "td:nth-of-type(3)")
-        for m in desc_matches:
-            self.assertIn(m, description)
-        for c in cves:
-            self.assertIn(m, description)
+        self.assertEqual(b.text(row + "td:nth-of-type(2)"), version)
+        # verify type
+        self.assertTrue(b.is_present(row + "td:nth-of-type(3) span." + severity_to_icon[severity]))
+        self.assertEqual(b.text(row + "td:nth-of-type(3)").strip(),
+                         num_issues is not None and str(num_issues) or "")
+
+        # should not be expanded by default
+        self.assertFalse(b.is_present(row + ".listing-ct-body"))
+        # expand
+        b.click(row + "td.listing-ct-toggle")
+        b.wait_present(row + ".listing-ct-body")
+        b.wait_in_text(row + ".listing-ct-body", "Packages:")
+        desc = b.text(row + ".listing-ct-body")
+
+        # details should contain all description bits, CVEs and bug numbers
+        for m in desc_matches +  cves + bugs:
+            self.assertIn(m, desc)
 
     def testBasic(self):
         # no security updates, no changelogs
@@ -110,8 +122,8 @@ class TestUpdates(PackageCase):
 
         b.wait_present("table.listing-ct")
         b.wait_in_text("table.listing-ct", "vanilla")
-        self.check_nth_update(1, "chocolate", "2.0-2", bugs="")
-        self.check_nth_update(2, "vanilla", "1.0-2", bugs="")
+        self.check_nth_update(1, "chocolate", "2.0-2")
+        self.check_nth_update(2, "vanilla", "1.0-2")
 
         # old versions are still installed
         m.execute("test -f /stamp-vanilla-1.0-1 && test -f /stamp-chocolate-2.0-1")
@@ -203,16 +215,17 @@ class TestUpdates(PackageCase):
         b.wait_in_text("table.listing-ct", "secparse")
 
         # security updates should get sorted on top and then alphabetically, so start with "secdeclare"
-        self.check_nth_update(1, "secdeclare", "3-4.b1", bugs="", security=True,
+        self.check_nth_update(1, "secdeclare", "3-4.b1", "security", 1,
                               desc_matches=["Will crash your data center"], cves=["CVE-2014-123456"])
         # secparse should also be considered a security update as the changelog mentions CVEs
-        self.check_nth_update(2, "secparse", "4-2", bugs="", security=True,
-                              desc_matches=["Fix CVE-2014-54321 and CVE-2017-9999."], cves=["CVE-2014-123456"])
+        self.check_nth_update(2, "secparse", "4-2", "security", 2,
+                              desc_matches=["Fix CVE-2014-54321 and CVE-2017-9999."],
+                              cves=["CVE-2014-54321", "CVE-2017-9999"])
         # buggy: bug refs, no security
-        self.check_nth_update(3, "buggy", "2-2", bugs="123, 456", desc_matches=["Fixit"])
+        self.check_nth_update(3, "buggy", "2-2", "bug", 2, bugs=["123", "456"], desc_matches=["Fixit"])
         # norefs: just changelog, show both binary packages
-        self.check_nth_update(4, ["norefs-bin", "norefs-doc"], "2-1", bugs="", desc_matches=["Now 10% more unicorns"])
-
+        self.check_nth_update(4, ["norefs-bin", "norefs-doc"], "2-1", self.enhancement_severity,
+                              desc_matches=["Now 10% more unicorns"])
         # install only security updates
         self.assertEqual(b.text("#app .container-fluid button.btn-default"), "Install Security Updates")
         b.click("#app .container-fluid button.btn-default")
@@ -345,7 +358,7 @@ class TestUpdates(PackageCase):
             b.wait_in_text("table.listing-ct", "secnocve")
 
             # secnocve should be displayed properly
-            self.check_nth_update(2, "secnocve", "1-2", bugs="", security=True, desc_matches=["Fix leak"])
+            self.check_nth_update(2, "secnocve", "1-2", "security", desc_matches=["Fix leak"])
 
     @skipImage("Ubuntu 16.04 PackageKit does not support changelogs", "ubuntu-1604")
     def testInfoTruncation(self):
@@ -353,12 +366,12 @@ class TestUpdates(PackageCase):
         m = self.machine
 
         # update with not too many binary packages
-        for i in range(8):
+        for i in range(4):
             self.createPackage("coarse{:02}".format(i), "1", "1", install=True)
             self.createPackage("coarse{:02}".format(i), "1", "2", changes="make it greener")
 
         # update with lots of binary packages
-        for i in range(25):
+        for i in range(10):
             self.createPackage("fine{:02}".format(i), "1", "1", install=True)
             self.createPackage("fine{:02}".format(i), "1", "2", changes="make it better")
 
@@ -369,66 +382,38 @@ class TestUpdates(PackageCase):
         self.createPackage("verbose", "1", "1", install=True)
         self.createPackage("verbose", "1", "2", changes=long_changelog)
 
-        # update with lots of packages and long changelog
-        for i in range(20):
-            self.createPackage("wide-n-tall{:02}".format(i), "3", "1", install=True)
-            self.createPackage("wide-n-tall{:02}".format(i), "3", "2", changes=long_changelog)
-
         self.enableRepo()
 
         m.start_cockpit()
         b.login_and_go("/updates")
 
         b.wait_present("table.listing-ct")
-        b.wait_in_text("table.listing-ct", "Things change #05")
+        b.wait_in_text("table.listing-ct", "Things change")
 
         # "coarse" package list should be complete
         t = b.text("#app .listing-ct tbody:nth-of-type(1) th")
         self.assertIn("coarse00", t)
-        self.assertIn("coarse07", t)
-        self.assertNotIn("more", t)
+        self.assertIn("coarse03", t)
+        self.assertNotIn(u"…", t)
 
         # "fine" package list should be truncated
         t = b.text("#app .listing-ct tbody:nth-of-type(2) th")
         self.assertIn("fine00", t)
-        self.assertIn("fine10", t)
-        self.assertNotIn("fine20", t)
-        b.wait_present("#app .listing-ct tbody:nth-of-type(2) th a")
-        b.wait_in_text("#app .listing-ct tbody:nth-of-type(2) th a", "10 more")
+        self.assertIn("fine03", t)
+        self.assertNotIn("fine09", t)
+        self.assertIn(u"…", t)
+        # but complete in the details
+        self.check_nth_update(2, ["fine00", "fine01", "fine02", "fine03"], "1-2",
+                              desc_matches=["fine07", "fine09"])
 
         # verbose changelog should be truncated
-        t = b.text("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(3)")
-        self.assertIn("Things change #00", t)
-        self.assertIn("Things change #04", t)
-        self.assertNotIn("Things change #07", t)
-        self.assertNotIn("Things change #20", t)
-        b.wait_present("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(3) a")
-        b.wait_in_text("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(3) a", "More information")
-
-        # wide-n-tall package list and changelog should both be truncated
-        t = b.text("#app .listing-ct tbody:nth-of-type(4) td:nth-of-type(3)")
-        self.assertIn("Things change #04", t)
-        self.assertNotIn("Things change #07", t)
-        b.wait_present("#app .listing-ct tbody:nth-of-type(4) th a")
-        b.wait_in_text("#app .listing-ct tbody:nth-of-type(4) th a", "5 more")
-        b.wait_present("#app .listing-ct tbody:nth-of-type(4) td:nth-of-type(3) a")
-        b.wait_in_text("#app .listing-ct tbody:nth-of-type(4) td:nth-of-type(3) a", "More information")
-
-        # expand fine package list by clicking on the "more" link
-        b.click("#app .listing-ct tbody:nth-of-type(2) th a")
-        b.wait_in_text("#app .listing-ct tbody:nth-of-type(2) th", "fine24")
-        b.wait_not_present("#app .listing-ct tbody:nth-of-type(2) th a")
-
-        # expand verbose changelog by clicking on he truncated text
-        b.click("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(3) div")
-        b.wait_in_text("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(3)", "Things change #29")
-        b.wait_not_present("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(3) a")
-
-        # clicking on package list should also expand changelog
-        b.click("#app .listing-ct tbody:nth-of-type(4) th a")
-        b.wait_in_text("#app .listing-ct tbody:nth-of-type(4) th", "wide-n-tall19")
-        b.wait_in_text("#app .listing-ct tbody:nth-of-type(4) td:nth-of-type(3)", "Things change #29")
-        b.wait_not_present("#app .listing-ct tbody:nth-of-type(4) td:nth-of-type(3) a")
+        desc = b.text("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(4)").strip()
+        desc = desc.lstrip("* ")  # strip off Debian "* " prefix
+        self.assertEqual(desc, u"- Things change #00")
+        # but complete in the details
+        self.check_nth_update(3, "verbose", "1-2",
+                              desc_matches=["Things change #00", "Things change #29"])
+        # seems we can't verify that the description has a scrollbar
 
     def testUpdateError(self):
         b = self.browser


### PR DESCRIPTION
Implement most parts of new design [1] to make the update list more
consistent with other products such as Satellite or Composer.
    
[1] https://raw.githubusercontent.com/cockpit-project/cockpit-design/master/software-updates/software-updates-security-levels.png
    
Fixes #8379

Blockers:
 - [x] Refactor check-packagekit tests (PR #8408)
 - [x] Update PatternFly (PR #8403)
 - [x] Fix duplicated/invalid CVE URLs on RHEL (#8409)
 - [x] expander icons are not centered