### PR TITLE
test: Clean up Chromium injected files

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -19,25 +19,23 @@ def browser_path(headless=True):
     """Return path to CDP browser.
 
     Support the following locations:
-     - "chromium-browser" in $PATH (distro package)
      - /usr/lib*/chromium-browser/headless_shell (chromium-headless RPM), if
        headless is true
+     - "chromium-browser" in $PATH (distro package)
      - node_modules/chromium/lib/chromium/chrome-linux/chrome (npm install chromium)
 
     Exit with an error if none is found.
     """
+    if headless:
+        g = glob.glob("/usr/lib*/chromium-browser/headless_shell")
+        if g:
+            return g[0]
     try:
         return subprocess.check_output(["which", "chromium-browser"]).strip()
     except subprocess.CalledProcessError:
-        if headless:
-            g = glob.glob("/usr/lib*/chromium-browser/headless_shell")
-            if g:
-                return g[0]
-
         p = os.path.join(os.path.dirname(TEST_DIR), "node_modules/chromium/lib/chromium/chrome-linux/chrome")
         if os.access(p, os.X_OK):
             return p
-
         raise
 
 

--- a/test/common/tap-cdp
+++ b/test/common/tap-cdp
@@ -62,7 +62,7 @@ server = subprocess.Popen(opts.server,
 
 address = server.stdout.readline()
 
-cdp = cdp.CDP("C.utf8", inject_helpers=False)
+cdp = cdp.CDP("C.utf8")
 cdp.invoke("Page.navigate", url=address + '/' + opts.test)
 
 success = True

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -93,7 +93,9 @@ class Browser:
             self.port = port
         self.default_user = "admin"
         self.label = label
-        self.cdp = cdp.CDP("C.utf8", headless, verbose=opts.trace, trace=opts.trace)
+        path = os.path.dirname(__file__)
+        self.cdp = cdp.CDP("C.utf8", headless, verbose=opts.trace, trace=opts.trace,
+                           inject_helpers=[os.path.join(path, "test-functions.js"), os.path.join(path, "sizzle.js")])
         self.password = "foobar"
 
     def title(self):


### PR DESCRIPTION
Stop hardcoding the injected files in the `CDP` class, to make it more
general and reusable. Instead pass the injected files as a list, and
move the ones relevant for the integration tests into the integration
tests' `Browser` class.

 - [x] land #8405 and resolve conflicts