### PR TITLE
packagekit: Require appstream-data package

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -691,6 +691,7 @@ cluster. Installed on the Kubernetes master. This package is not yet complete.
 Summary: Cockpit user interface for packages
 Requires: %{name}-bridge >= %{required_base}
 Requires: PackageKit
+Requires: appstream-data
 
 %description packagekit
 The Cockpit components for installing OS updates and Cockpit add-ons,


### PR DESCRIPTION
So that we actually have the metadata for the list of installable
applications.