### PR TITLE
system: Use "100%" for a fully loaded system, not ncpus*100%

### DIFF
--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -92,7 +92,8 @@
         <div class="row">
           <div class="col-sm-4">
             <div>
-              <span class="plot-unit" id="containers-cpu-unit">%</span><span class="plot-title" translatable="yes">Combined CPU usage</span>
+              <span class="plot-unit" id="containers-cpu-unit">%</span>
+              <span id="containers-cpu-graph-title" class="plot-title"></span>
             </div>
             <div id="containers-cpu-graph"></div>
           </div>

--- a/pkg/lib/machine-info.es6
+++ b/pkg/lib/machine-info.es6
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+
+var machine_info_promises = { };
+
+export function machine_info(address) {
+    var pr = machine_info_promises[address];
+    var dfd;
+    if (!pr) {
+        dfd = cockpit.defer();
+        machine_info_promises[address] = pr = dfd.promise();
+
+        cockpit.spawn(["cat", "/proc/meminfo", "/proc/cpuinfo"], { host: address }).
+            done(function(text) {
+                var info = { };
+                var match = text.match(/MemTotal:[^0-9]*([0-9]+) [kK]B/);
+                var total_kb = match && parseInt(match[1], 10);
+                if (total_kb)
+                    info.memory = total_kb*1024;
+
+                info.cpus = 0;
+                var re = new RegExp("^processor", "gm");
+                while (re.test(text))
+                    info.cpus += 1;
+                dfd.resolve(info);
+            }).
+            fail(function() {
+                dfd.reject();
+            });
+    }
+    return pr;
+}

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -153,6 +153,12 @@ a.disabled {
     color: #4daf4a;
 }
 
+#cpu_status_title {
+    padding: 20px 20px 0px 20px;
+    margin-bottom: -10px;
+    margin-left: 35px;
+}
+
 #cpu_status_graph,
 #memory_status_graph {
     height: 400px;

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -400,8 +400,6 @@ PageServer.prototype = {
                                      '/org/freedesktop/hostname1');
         self.kernel_hostname = null;
 
-        var series;
-
         /* CPU graph */
 
         var cpu_data = {
@@ -418,7 +416,7 @@ PageServer.prototype = {
                                     });
         self.cpu_plot = plot.plot($("#server_cpu_graph"), 300);
         self.cpu_plot.set_options(cpu_options);
-        series = self.cpu_plot.add_metrics_sum_series(cpu_data, { });
+        // This is added to the plot once we have the machine info, see below.
 
         /* Memory graph */
 
@@ -439,7 +437,7 @@ PageServer.prototype = {
 
         self.memory_plot = plot.plot($("#server_memory_graph"), 300);
         self.memory_plot.set_options(memory_options);
-        series = self.memory_plot.add_metrics_sum_series(memory_data, { });
+        self.memory_plot.add_metrics_sum_series(memory_data, { });
 
         /* Network graph */
 
@@ -469,7 +467,7 @@ PageServer.prototype = {
 
         self.network_plot = plot.plot($("#server_network_traffic_graph"), 300);
         self.network_plot.set_options(network_options);
-        series = self.network_plot.add_metrics_sum_series(network_data, { });
+        self.network_plot.add_metrics_sum_series(network_data, { });
 
         /* Disk IO graph */
 
@@ -499,12 +497,15 @@ PageServer.prototype = {
 
         self.disk_plot = plot.plot($("#server_disk_io_graph"), 300);
         self.disk_plot.set_options(disk_options);
-        series = self.disk_plot.add_metrics_sum_series(disk_data, { });
+        self.disk_plot.add_metrics_sum_series(disk_data, { });
 
         machine_info().
             done(function (info) {
-                cpu_options.yaxis.max = info.cpus * 100;
-                self.cpu_plot.set_options(cpu_options);
+                $('#link-cpu').text(cockpit.format(cockpit.ngettext("of $0 CPU core", "of $0 CPU cores",
+                                                                    info.cpus),
+                                                   info.cpus));
+                cpu_data.factor = 0.1 / info.cpus; // millisec / sec -> percent
+                self.cpu_plot.add_metrics_sum_series(cpu_data, { });
                 memory_options.yaxis.max = info.memory;
                 self.memory_plot.set_options(memory_options);
             });
@@ -1319,15 +1320,17 @@ PageCpuStatus.prototype = {
     enter: function() {
         var self = this;
 
+        var n_cpus = 1;
+
         var options = {
             series: {shadowSize: 0,
                      lines: {lineWidth: 0, fill: true}
                     },
             yaxis: {min: 0,
-                    max: 100,
+                    max: n_cpus * 1000,
                     show: true,
                     ticks: 5,
-                    tickFormatter: function(v) { return (v / 10) + "%"; }},
+                    tickFormatter: function(v) { return (v / 10 / n_cpus) + "%"; }},
             xaxis: {show: true,
                     ticks: [[0.0*60, "5 min"],
                             [1.0*60, "4 min"],
@@ -1373,7 +1376,13 @@ PageCpuStatus.prototype = {
 
         machine_info().
             done(function (info) {
-                self.plot.set_yaxis_max(info.cpus * 1000);
+                // Setting n_cpus changes the tick labels, see tickFormatter above.
+                n_cpus = info.cpus;
+                self.plot.set_yaxis_max(n_cpus * 1000);
+                $("#cpu_status_title").text(cockpit.format(cockpit.ngettext("Usage of $0 CPU core",
+                                                                            "Usage of $0 CPU cores",
+                                                                            n_cpus),
+                                                           n_cpus));
             });
     },
 

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -19,6 +19,7 @@
 
 var $ = require("jquery");
 var cockpit = require("cockpit");
+var machine_info = require("machine-info.es6").machine_info;
 
 var Mustache = require("mustache");
 var plot = require("plot");
@@ -59,44 +60,6 @@ function update_shutdown_privileged() {
 function debug() {
     if (window.debugging == "all" || window.debugging == "system")
         console.debug.apply(console, arguments);
-}
-
-/* machine_info(address).done(function (info) { })
- *
- * Get information about the machine at ADDRESS.  The returned object
- * has these fields:
- *
- * memory  -  amount of physical memory
- */
-
-var machine_info_promises = { };
-
-function machine_info(address) {
-    var pr = machine_info_promises[address];
-    var dfd;
-    if (!pr) {
-        dfd = $.Deferred();
-        machine_info_promises[address] = pr = dfd.promise();
-
-        cockpit.spawn(["cat", "/proc/meminfo", "/proc/cpuinfo"]).
-            done(function(text) {
-                var info = { };
-                var match = text.match(/MemTotal:[^0-9]*([0-9]+) [kK]B/);
-                var total_kb = match && parseInt(match[1], 10);
-                if (total_kb)
-                    info.memory = total_kb*1024;
-
-                info.cpus = 0;
-                var re = new RegExp("^processor", "gm");
-                while (re.test(text))
-                    info.cpus += 1;
-                dfd.resolve(info);
-            }).
-            fail(function() {
-                dfd.reject();
-            });
-    }
-    return pr;
 }
 
 function ServerTime() {

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -203,7 +203,7 @@
                 </div>
             </div>
             <div>
-              <span class="plot-unit" id="server_cpu_unit">%</span><a id="link-cpu" translate>CPU</a>
+              <span class="plot-unit" id="server_cpu_unit">%</span><a id="link-cpu"></a>
             </div>
             <div id="server_cpu_graph" class="server-graph zoomable-plot"></div>
             <br/>
@@ -225,6 +225,7 @@
     </div>
 
     <div id="cpu_status" hidden>
+        <div id="cpu_status_title">Yo!</div>
         <ul class="server-graph-legend">
             <li class="cpu-io-wait">
                 <i class="fa fa-square"></i>


### PR DESCRIPTION
Cockpit used to treat one fully loaded core as "100% CPU", and if you
load two cores, you would get 200% CPU.  This is apparently not the
common thing to do.

Now Cockpit shows 100% CPU whn you load all cores.

Fixes #8373