### PR TITLE
machines: Redesign of inline notification on the Disks subtab

### DIFF
--- a/pkg/machines/components/inlineNotification.jsx
+++ b/pkg/machines/components/inlineNotification.jsx
@@ -1,0 +1,109 @@
+/*jshint esversion: 6 */
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from 'cockpit';
+import React, { PropTypes } from "react";
+
+const _ = cockpit.gettext;
+
+class InlineNotification extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            isDetail: false,
+        };
+
+        this.toggleDetail = this.toggleDetail.bind(this);
+    }
+
+    toggleDetail () {
+        this.setState({
+            isDetail: !this.state.isDetail,
+        });
+    }
+
+    render () {
+        const { notificationClass, iconClass, text, detail, textId, onDismiss } = this.props;
+
+        let detailButton = null;
+        if (detail) {
+            let detailButtonText = _("show more");
+            if (this.state.isDetail) {
+                detailButtonText = _("show less");
+            }
+
+            detailButton = (<a href='#' className='alert-link machines-more-button'
+                                     onClick={this.toggleDetail}>{detailButtonText}</a>);
+        }
+
+        const dismissableClass = this.props.onDismiss ? ' alert-dismissable' : '';
+        let closeButton = null;
+        if (this.props.onDismiss) {
+            // do not use "data-dismiss='alert'" to close the notification
+            closeButton = (
+                <button type='button' className='close' aria-hidden='true' onClick={onDismiss}>
+                    <span className='pficon pficon-close'/>
+                </button>
+            );
+        }
+
+        return (
+            <div className={notificationClass + dismissableClass}>
+                {closeButton}
+                <span className={iconClass}/>
+                <strong id={textId}>
+                    {text}
+                </strong>
+                {detailButton}
+                {this.state.isDetail && detail}
+            </div>
+        );
+    }
+}
+
+InlineNotification.propTypes = {
+    notificationClass: PropTypes.string, // classname for the notification type; see defaultProps
+    iconClass: PropTypes.string, // classname for the icon; see defaultProps
+    onDismiss: PropTypes.func, // callback to be called when 'close-button' is clicked. If undefined, then the buttun (means "cross") is not rendered.
+
+    text: PropTypes.string.isRequired, // main information to render
+    detail: PropTypes.string, // optional, more detailed information. If empty, the more/less button is not rendered.
+    textId: PropTypes.string, // optional, element id for the text
+};
+
+InlineNotification.defaultProps = {
+    notificationClass: 'alert alert-warning',
+    iconClass: 'pficon pficon-warning-triangle-o',
+};
+
+export const Alert = ({ onDismiss, text, textId, detail }) => {
+    return (
+        <InlineNotification onDismiss={onDismiss} text={text} textId={textId} detail={detail}
+                            notificationClass='alert alert-warning'
+                            iconClass='pficon pficon-warning-triangle-o' />
+    );
+};
+
+export const Info = ({ onDismiss, text, textId, detail }) => {
+    return (
+        <InlineNotification onDismiss={onDismiss} text={text} textId={textId} detail={detail}
+                            notificationClass='alert alert-info'
+                            iconClass='pficon pficon-info' />
+    );
+};

--- a/pkg/machines/components/vmLastMessage.jsx
+++ b/pkg/machines/components/vmLastMessage.jsx
@@ -17,55 +17,14 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
-import cockpit from 'cockpit';
 import React from "react";
 import { vmId } from '../helpers.es6';
 import { deleteVmMessage } from '../actions.es6';
+import { Alert } from './inlineNotification.jsx';
+
 import './vmLastMessage.css';
 
-const _ = cockpit.gettext;
-
-class InlineNotification extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            isDetail: false,
-        };
-
-        this.toggleDetail = this.toggleDetail.bind(this);
-    }
-
-    toggleDetail () {
-        this.setState({
-            isDetail: !this.state.isDetail,
-        });
-    }
-
-    render () {
-        const { text, detail, textId, onDismiss } = this.props;
-
-        let detailButtonText = _("show more");
-        if (this.state.isDetail) {
-            detailButtonText = _("show less");
-        }
-        const detailButton = (<a href='#' className='alert-link machines-more-button' onClick={this.toggleDetail}>{detailButtonText}</a>);
-
-        // do not use "data-dismiss='alert'" to close the notification
-        return (
-            <div className='alert alert-warning alert-dismissable'>
-                <button type='button' className='close' aria-hidden='true' onClick={onDismiss}>
-                    <span className='pficon pficon-close'/>
-                </button>
-                <span className='pficon pficon-warning-triangle-o'/>
-                <strong id={textId}>
-                    {text}
-                </strong>
-                {detailButton}
-                {this.state.isDetail && detail}
-            </div>
-        );
-    }
-}
+React;
 
 const VmLastMessage = ({ vm, dispatch }) => {
     if (!vm.lastMessage) {
@@ -80,7 +39,7 @@ const VmLastMessage = ({ vm, dispatch }) => {
         dispatch(deleteVmMessage({ name: vm.name, connectionName: vm.connectionName }));
     };
 
-    return (<InlineNotification text={vm.lastMessage} textId={textId} detail={detail} onDismiss={onDismiss} />);
+    return (<Alert text={vm.lastMessage} textId={textId} detail={detail} onDismiss={onDismiss} />);
 };
 
 export default VmLastMessage;

--- a/pkg/machines/components/vmdiskstab.jsx
+++ b/pkg/machines/components/vmdiskstab.jsx
@@ -20,8 +20,9 @@
 import React, { PropTypes } from 'react';
 import cockpit from 'cockpit';
 import { Listing, ListingRow } from 'cockpit-components-listing.jsx';
-import { toGigaBytes } from './helpers.es6';
-import InfoRecord from './components/infoRecord.jsx';
+import { toGigaBytes } from '../helpers.es6';
+import InfoRecord from './infoRecord.jsx';
+import { Info } from './inlineNotification.jsx';
 
 const _ = cockpit.gettext;
 
@@ -96,28 +97,6 @@ const DiskBus = ({ disk, vmId }) => {
     );
 };
 
-const DiskStatsUnsupported = ({ vmId }) => {
-    return ( // no particular need to use the Listing component, but shares look&feel across other parts of Cockpit
-        <Listing columnTitles={[]}
-                 emptyCaption={
-                    <div id={`${vmId}-disksstats-unsupported`}>
-                        {_("Upgrade to a more recent version of libvirt to view disk statistics")}
-                    </div>}
-        />
-    );
-};
-
-const DiskStatsUnavailable = ({ vmId }) => {
-    return ( // no particular need to use the Listing component, but shares look&feel across other parts of Cockpit
-        <Listing columnTitles={[]}
-                 emptyCaption={
-                     <div id={`${vmId}-disksstats-unavailable`}>
-                         {_("Start the VM to see disk statistics.")}
-                     </div>}
-        />
-    );
-};
-
 class VmDisksTab extends React.Component {
     componentWillMount () {
         this.props.onUsageStartPolling();
@@ -179,17 +158,20 @@ class VmDisksTab extends React.Component {
         const actions = (provider.vmDisksActionsFactory instanceof Function) ?
             provider.vmDisksActionsFactory({vm}) : undefined; // listing-wide actions
 
-        let statsSupportComponent = null;
+        let notification = null;
         if (!areDiskStatsSupported) {
             if (vm.status === 'running') {
-                statsSupportComponent = (<DiskStatsUnsupported vmId={vmId} />);
+                notification = (<Info text={_("Upgrade to a more recent version of libvirt to view disk statistics")}
+                               textId={`${vmId}-disksstats-unsupported`} />);
             } else {
-                statsSupportComponent = (<DiskStatsUnavailable vmId={vmId} />);
+                notification = (<Info text={_("Start the VM to see disk statistics.")}
+                               textId={`${vmId}-disksstats-unavailable`} />);
             }
         }
 
         return (
             <div>
+                {notification}
                 <DiskTotal disks={vm.disks} vmId={vmId}/>
                 <Listing columnTitles={columnTitles} actions={actions}>
                     {Object.getOwnPropertyNames(vm.disks).sort().map(target => {
@@ -219,8 +201,6 @@ class VmDisksTab extends React.Component {
                         return (<ListingRow columns={columns}/>);
                     })}
                 </Listing>
-
-                {statsSupportComponent}
             </div>
         );
     }

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -24,7 +24,7 @@ import { shutdownVm, forceVmOff, forceRebootVm, rebootVm, startVm,
 import { rephraseUI, logDebug, toGigaBytes, toFixedPrecision, vmId } from "./helpers.es6";
 import DonutChart from "./c3charts.jsx";
 import { Listing, ListingRow } from "cockpit-components-listing.jsx";
-import VmDisksTab from './vmdiskstab.jsx';
+import VmDisksTab from './components/vmdiskstab.jsx';
 import VmNetworkTab from './vmnetworktab.jsx';
 import Consoles from './components/consoles.jsx';
 import { deleteDialog } from "./components/deleteDialog.jsx";


### PR DESCRIPTION
With this patch, the notifications (for old libvirt or a not-running VM)
are rendered using patternfly's inline notifications [1].

Generic components for their later reuse have been created.

[1] http://www.patternfly.org/pattern-library/communication/inline-notifications