### PR TITLE
packagekit: Render Markdown changelogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "qunitjs": "1.23.1",
     "react-lite": "0.15.39",
     "react-redux": "5.0.6",
+    "react-remarkable": "1.1.3",
     "redux": "3.7.2",
     "redux-saga": "0.16.0",
     "registry-image-widgets": "0.0.16",

--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-var cockpit = require("cockpit");
-var React = require("react");
+import cockpit from "cockpit";
+import React from "react";
 
 import OnOffSwitch from "cockpit-components-onoff.jsx";
 import Select from "cockpit-components-select.jsx";

--- a/pkg/packagekit/mock-updates.es6
+++ b/pkg/packagekit/mock-updates.es6
@@ -63,7 +63,8 @@ export function injectMockUpdates(updates) {
             bug_urls: [],
             cve_urls: [],
             severity: 4,
-            description: "Make everything better",
+            description: "Make [everything](http://everything.example.com) *better*\n\n * more packages\n * more `bugs`\n * more fun!",
+            markdown: true,
         };
     }
 

--- a/pkg/packagekit/updates.css
+++ b/pkg/packagekit/updates.css
@@ -38,9 +38,12 @@ tr.listing-ct-item td.changelog {
 }
 
 p.changelog {
-    white-space: pre-wrap;
     max-height: 20em;
     overflow: auto;
+}
+
+p.changelog div.changelog {
+    white-space: pre-wrap;
 }
 
 tr.security.listing-ct-item {

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -17,14 +17,14 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-var cockpit = require("cockpit");
-var React = require("react");
-var moment = require("moment");
-var Tooltip = require("cockpit-components-tooltip.jsx").Tooltip;
-var Markdown = require("react-remarkable");
-require("listing.less");
-
+import cockpit from "cockpit";
+import React from "react";
+import moment from "moment";
+import { Tooltip } from "cockpit-components-tooltip.jsx";
+import Markdown from "react-remarkable";
 import AutoUpdates from "./autoupdates.jsx";
+
+require("listing.less");
 
 const _ = cockpit.gettext;
 
@@ -624,7 +624,7 @@ class OsUpdates extends React.Component {
 
         dbus_pk.addEventListener("close", (event, ex) => {
             console.log("close:", event, ex);
-            var err;
+            let err;
             if (ex.problem == "not-found")
                 err = _("PackageKit is not installed")
             else
@@ -913,8 +913,8 @@ class OsUpdates extends React.Component {
                             </div>
                         </div>);
                 } else {
-                    var num_updates = Object.keys(this.state.updates).length;
-                    var num_security_updates = count_security_updates(this.state.updates);
+                    let num_updates = Object.keys(this.state.updates).length;
+                    let num_security_updates = count_security_updates(this.state.updates);
 
                     applyAll = (
                         <button className="btn btn-primary" onClick={ () => this.applyUpdates(false) }>

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -189,10 +189,10 @@ class TestUpdates(PackageCase):
 
         # just changelog
         self.createPackage("norefs-bin", "1", "1", install=True)
-        self.createPackage("norefs-bin", "2", "1", severity="enhancement", changes="Now 10% more unicorns")
+        self.createPackage("norefs-bin", "2", "1", severity="enhancement", changes="Now 10% *more* [unicorns](http://unicorn.example.com)")
         # binary from same source
         self.createPackage("norefs-doc", "1", "1", install=True)
-        self.createPackage("norefs-doc", "2", "1", severity="enhancement", changes="Now 10% more unicorns")
+        self.createPackage("norefs-doc", "2", "1", severity="enhancement", changes="Now 10% *more* [unicorns](http://unicorn.example.com)")
         # bug fixes
         self.createPackage("buggy", "2", "1", install=True)
         self.createPackage("buggy", "2", "2", changes="Fixit", bugs=[123, 456])
@@ -249,8 +249,15 @@ class TestUpdates(PackageCase):
         # buggy: bug refs, no security
         self.check_nth_update(4, "buggy", "2-2", "bug", 2, bugs=["123", "456"], desc_matches=["Fixit"])
         # norefs: just changelog, show both binary packages
-        self.check_nth_update(5, ["norefs-bin", "norefs-doc"], "2-1", self.enhancement_severity,
-                              desc_matches=["Now 10% more unicorns"])
+        sel = self.check_nth_update(5, ["norefs-bin", "norefs-doc"], "2-1", self.enhancement_severity,
+                                    desc_matches=["Now 10% more unicorns"])
+        # verify Markdown formatting in table cell
+        self.assertEqual(b.text(sel + " td.changelog em"), "more")  # *more*
+        self.assertEqual(b.attr(sel + " td.changelog a", "href"), "http://unicorn.example.com")
+        # verify Markdown formatting in details
+        self.assertEqual(b.text(sel + " .listing-ct-body em"), "more")  # *more*
+        self.assertEqual(b.attr(sel + " .listing-ct-body a:first-of-type", "href"), "http://unicorn.example.com")
+
         # install only security updates
         self.assertEqual(b.text("#app .container-fluid button.btn-default"), "Install Security Updates")
         b.click("#app .container-fluid button.btn-default")
@@ -432,9 +439,9 @@ class TestUpdates(PackageCase):
                               desc_matches=["fine07", "fine09"])
 
         # verbose changelog should be truncated
-        desc = b.text("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(4)").strip()
-        desc = desc.lstrip("* ")  # strip off Debian "* " prefix
-        self.assertEqual(desc, u"- Things change #00")
+        desc = b.text("#app .listing-ct tbody:nth-of-type(3) td:nth-of-type(4)")
+        self.assertIn("Things change #00", desc)
+        self.assertNotIn("#01", desc)
         # but complete in the details
         self.check_nth_update(3, "verbose", "1-2",
                               desc_matches=["Things change #00", "Things change #29"])


### PR DESCRIPTION
PackageKit's `UpdateDetail` signal [1] has both an `update_text` field which
is Markdown, and a `changelog` field which is the verbatim changelog.
If `update_text` is present, render that with react-remarkable [2];
otherwise, fall back to showing `changelog` in a pre-wrapped paragraph.

Rename `formatDescription()` to `removeHeading()` as that's all it's
supposed to do. 

[1] https://www.freedesktop.org/software/PackageKit/gtk-doc/Transaction.html#Transaction::UpdateDetail
[2] https://www.npmjs.com/package/react-remarkable

---
TODO:

 - [x] land software updates redesign (PR #8410)