### PR TITLE
packagekit: Show Red Hat security update classification and errata

### DIFF
--- a/pkg/packagekit/mock-updates.es6
+++ b/pkg/packagekit/mock-updates.es6
@@ -14,12 +14,14 @@
  */
 
 export function injectMockUpdates(updates) {
-    // two security updates
+    // some security updates
     updates["security-one;2.3-4"] = {
         name: "security-one",
         version: "2.3-4",
         bug_urls: [],
         cve_urls: ["https://cve.example.com?name=CVE-2014-123456", "https://cve.example.com?name=CVE-2017-9999"],
+        vendor_urls: ["https://access.redhat.com/security/updates/classification/#critical", "critical",
+                      "https://access.redhat.com/errata/RHSA-2000:0001", "https://access.redhat.com/errata/RHSA-2000:0002"],
         severity: 8,
         description: "This will wreck your data center!",
     };
@@ -28,8 +30,28 @@ export function injectMockUpdates(updates) {
         version: "1-2+sec1",
         bug_urls: [],
         cve_urls: ["https://cve.example.com?name=CVE-2014-54321"],
+        vendor_urls: ["https://access.redhat.com/security/updates/classification/#bogus", "bogus",
+                      "https://access.redhat.com/security/updates/classification/#low", "low"],
         severity: 8,
         description: "Mostly Harmless",
+    };
+    updates["security-three;5-2"] = {
+        name: "security-three",
+        version: "5-2",
+        bug_urls: [],
+        vendor_urls: ["https://access.redhat.com/security/updates/classification/#low", "low",
+                      "https://access.redhat.com/security/updates/classification/#important", "important"],
+        severity: 8,
+        description: "This update will make you sleep more peacefully.",
+    };
+    // no vendor URLs, default severity
+    updates["security-four;42"] = {
+        name: "security-four",
+        version: "42",
+        cve_urls: ["https://cve.example.com?name=CVE-2014-54321"],
+        vendor_urls: [],
+        severity: 8,
+        description: "Yet another weakness fixed.",
     };
 
     // source with many binaries

--- a/pkg/packagekit/updates.css
+++ b/pkg/packagekit/updates.css
@@ -18,6 +18,18 @@ tr.listing-ct-item td.type {
     white-space: nowrap;
 }
 
+.severity-critical {
+    color: #cc0000;
+}
+
+.severity-important {
+    color: #ec7a08;
+}
+
+.severity-low {
+    color: #8b8d8f;
+}
+
 tr.listing-ct-item td.changelog {
     max-width: 60vw;
     white-space: nowrap;

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -282,6 +282,17 @@ class UpdateItem extends React.Component {
             ));
         }
 
+        var errata = null;
+        if (info.vendor_urls) {
+            errata = insertCommas(info.vendor_urls.filter(url => url.indexOf("/errata/") > 0).map(url => (
+                <a href={url} rel="noopener" referrerpolicy="no-referrer" target="_blank">
+                    {url.match(/[^/=]+$/)}
+                </a>)
+            ));
+            if (!errata.length)
+                errata = null; // simpler testing below
+        }
+
         var type;
         var secSeverity;
         if (info.severity === PK_INFO_ENUM_SECURITY) {
@@ -337,6 +348,8 @@ class UpdateItem extends React.Component {
                                 { cves ? <dd>{cves}</dd> : null }
                                 { secSeverity ? <dt>{_("Severity:")}</dt> : null }
                                 { secSeverity ? <dd className="severity">{secSeverity}</dd> : null }
+                                { errata ? <dt>{_("Errata:")}</dt> : null }
+                                { errata ? <dd>{errata}</dd> : null }
                                 { bugs ? <dt>{_("Bugs:")}</dt> : null }
                                 { bugs ? <dd>{bugs}</dd> : null }
                             </dl>

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -83,6 +83,8 @@ class TestUpdates(PackageCase):
         for m in desc_matches +  cves + bugs:
             self.assertIn(m, desc)
 
+        return row
+
     def testBasic(self):
         # no security updates, no changelogs
         b = self.browser
@@ -197,10 +199,13 @@ class TestUpdates(PackageCase):
         # security fix with proper CVE list and severity
         self.createPackage("secdeclare", "3", "4.a1", install=True)
         self.createPackage("secdeclare", "3", "4.b1", severity="security",
-                           changes="Will crash your data center", cves=['CVE-2014-123456'])
+                           changes="Will crash your data center", cves=["CVE-2014-123456"])
         # security fix with parsing from changes
         self.createPackage("secparse", "4", "1", install=True)
         self.createPackage("secparse", "4", "2", changes="Fix CVE-2014-54321 and CVE-2017-9999.")
+        # security fix with RHEL severity
+        self.createPackage("sevcritical", "5", "1", install=True)
+        self.createPackage("sevcritical", "5", "2", cves=["CVE-2014-54321"], securitySeverity="critical", changes="More broken stuff")
 
         self.enableRepo()
         m.execute("pkcon refresh")
@@ -209,10 +214,10 @@ class TestUpdates(PackageCase):
         b.login_and_go("/updates")
         b.wait_present("#available h2")
         b.wait_in_text("#available h2", "Available Updates")
-        self.assertEqual(b.text("#state"), "5 updates, including 2 security fixes")
+        self.assertEqual(b.text("#state"), "6 updates, including 3 security fixes")
 
         b.wait_present("table.listing-ct")
-        b.wait_in_text("table.listing-ct", "secparse")
+        b.wait_in_text("table.listing-ct", "sevcritical")
 
         # security updates should get sorted on top and then alphabetically, so start with "secdeclare"
         self.check_nth_update(1, "secdeclare", "3-4.b1", "security", 1,
@@ -221,10 +226,21 @@ class TestUpdates(PackageCase):
         self.check_nth_update(2, "secparse", "4-2", "security", 2,
                               desc_matches=["Fix CVE-2014-54321 and CVE-2017-9999."],
                               cves=["CVE-2014-54321", "CVE-2017-9999"])
+        sel = self.check_nth_update(3, "sevcritical", "5-2", "security", 1,
+                                    desc_matches=["More broken stuff"])
+        if self.backend == 'yum':
+            # sevcritical has a severity
+            self.assertIn("Severity:", b.text(sel + " .listing-ct-body"))
+            self.assertIn("critical", b.text(sel + " .listing-ct-body"))
+            # icon has critical class
+            self.assertIn("severity-critical", b.attr(sel + " td:nth-of-type(3) span.pficon", "class"))
+            # details has link to severity definition
+            self.assertIn("access.redhat.com", b.attr(sel + " .listing-ct-body dd.severity a:first-of-type", "href"))
+
         # buggy: bug refs, no security
-        self.check_nth_update(3, "buggy", "2-2", "bug", 2, bugs=["123", "456"], desc_matches=["Fixit"])
+        self.check_nth_update(4, "buggy", "2-2", "bug", 2, bugs=["123", "456"], desc_matches=["Fixit"])
         # norefs: just changelog, show both binary packages
-        self.check_nth_update(4, ["norefs-bin", "norefs-doc"], "2-1", self.enhancement_severity,
+        self.check_nth_update(5, ["norefs-bin", "norefs-doc"], "2-1", self.enhancement_severity,
                               desc_matches=["Now 10% more unicorns"])
         # install only security updates
         self.assertEqual(b.text("#app .container-fluid button.btn-default"), "Install Security Updates")
@@ -246,10 +262,10 @@ class TestUpdates(PackageCase):
             # make sure we don't have any extra ones
             self.assertFalse(b.is_present(selector.format(len(updates) + 1)))
 
-        # history on restart page should show the two security updates
+        # history on restart page should show the three security updates
         b.wait_present(".expander-title span")
         b.click(".expander-title span")
-        assertHistory("ul", ["secdeclare", "secparse"])
+        assertHistory("ul", ["secdeclare", "secparse", "sevcritical"])
 
         # ignore restarting
         b.wait_present("#app .container-fluid button.btn-default")
@@ -267,10 +283,10 @@ class TestUpdates(PackageCase):
 
         # history should show the security updates
         b.wait_present(".container-fluid #history h2")
-        assertHistory("#history ul", ["secdeclare", "secparse"])
+        assertHistory("#history ul", ["secdeclare", "secparse", "sevcritical"])
 
         # new security versions are now installed
-        m.execute("test -f /stamp-secdeclare-3-4.b1 && test -f /stamp-secparse-4-2")
+        m.execute("test -f /stamp-secdeclare-3-4.b1 && test -f /stamp-secparse-4-2 && test -f /stamp-sevcritical-5-2")
         # but the three others are untouched
         m.execute("test -f /stamp-buggy-2-1 && test -f /stamp-norefs-bin-1-1 && test -f /stamp-norefs-doc-1-1")
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -242,7 +242,7 @@ class TestUpdates(PackageCase):
             b.wait_present(path)
             b.wait_present(selector.format(len(updates)))
             for index, pkg in enumerate(updates, start=1):
-                self.assertEqual(b.text(selector.format(index)), pkg)
+                b.wait_in_text(selector.format(index), pkg)
             # make sure we don't have any extra ones
             self.assertFalse(b.is_present(selector.format(len(updates) + 1)))
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -203,9 +203,10 @@ class TestUpdates(PackageCase):
         # security fix with parsing from changes
         self.createPackage("secparse", "4", "1", install=True)
         self.createPackage("secparse", "4", "2", changes="Fix CVE-2014-54321 and CVE-2017-9999.")
-        # security fix with RHEL severity
+        # security fix with RHEL severity and errata
         self.createPackage("sevcritical", "5", "1", install=True)
-        self.createPackage("sevcritical", "5", "2", cves=["CVE-2014-54321"], securitySeverity="critical", changes="More broken stuff")
+        self.createPackage("sevcritical", "5", "2", cves=["CVE-2014-54321"], securitySeverity="critical",
+                           errata=["RHSA-2000:0001", "RHSA-2000:0002"], changes="More broken stuff")
 
         self.enableRepo()
         m.execute("pkcon refresh")
@@ -220,18 +221,26 @@ class TestUpdates(PackageCase):
         b.wait_in_text("table.listing-ct", "sevcritical")
 
         # security updates should get sorted on top and then alphabetically, so start with "secdeclare"
-        self.check_nth_update(1, "secdeclare", "3-4.b1", "security", 1,
-                              desc_matches=["Will crash your data center"], cves=["CVE-2014-123456"])
+        sel = self.check_nth_update(1, "secdeclare", "3-4.b1", "security", 1,
+                                    desc_matches=["Will crash your data center"], cves=["CVE-2014-123456"])
+        # should not have erratum label in details
+        self.assertNotIn("Errat", b.text(sel))
+
         # secparse should also be considered a security update as the changelog mentions CVEs
         self.check_nth_update(2, "secparse", "4-2", "security", 2,
                               desc_matches=["Fix CVE-2014-54321 and CVE-2017-9999."],
                               cves=["CVE-2014-54321", "CVE-2017-9999"])
         sel = self.check_nth_update(3, "sevcritical", "5-2", "security", 1,
                                     desc_matches=["More broken stuff"])
+
         if self.backend == 'yum':
-            # sevcritical has a severity
-            self.assertIn("Severity:", b.text(sel + " .listing-ct-body"))
-            self.assertIn("critical", b.text(sel + " .listing-ct-body"))
+            # sevcritical has a severity and errata
+            details = b.text(sel + " .listing-ct-body")
+            self.assertIn("Severity:", details)
+            self.assertIn("critical", details)
+            self.assertIn("Errata:", details)
+            self.assertIn("RHSA-2000:0001", details)
+            self.assertIn("RHSA-2000:0002", details)
             # icon has critical class
             self.assertIn("severity-critical", b.attr(sel + " td:nth-of-type(3) span.pficon", "class"))
             # details has link to severity definition

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -174,6 +174,8 @@ rm -rf ~/rpmbuild
                 refs += '      <reference href="https://bugs.example.com?bug={0}" id="{0}" title="Bug#{0} Description" type="bugzilla"/>\n'.format(b)
             for c in info.get("cves", []):
                 refs += '      <reference href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={0}" id="{0}" title="{0}" type="cve"/>\n'.format(c)
+            if info.get("securitySeverity"):
+                refs += '      <reference href="https://access.redhat.com/security/updates/classification/#{0}" id="" title="" type="other"/>\n'.format(info["securitySeverity"])
 
             xml += '''  <update from="test@example.com" status="stable" type="{severity}" version="2.0">
     <id>UPDATE-{pkg}-{ver}-{rel}</id>

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -176,6 +176,8 @@ rm -rf ~/rpmbuild
                 refs += '      <reference href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={0}" id="{0}" title="{0}" type="cve"/>\n'.format(c)
             if info.get("securitySeverity"):
                 refs += '      <reference href="https://access.redhat.com/security/updates/classification/#{0}" id="" title="" type="other"/>\n'.format(info["securitySeverity"])
+            for e in info.get("errata", []):
+                refs += '      <reference href="https://access.redhat.com/errata/{0}" id="{0}" title="{0}" type="self"/>\n'.format(e)
 
             xml += '''  <update from="test@example.com" status="stable" type="{severity}" version="2.0">
     <id>UPDATE-{pkg}-{ver}-{rel}</id>


### PR DESCRIPTION
See individual commit logs, this implements the other part of #8379.

---

TODO:
 - [x] Land first part of redesign (PR #8410)
 - [x] implement showing errata