### PR TITLE
kubernetes: add create vm dialog to VirtualMachines

### DIFF
--- a/pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx
@@ -26,6 +26,7 @@ import { gettext as _ } from 'cockpit';
 import { Listing } from '../../../../lib/cockpit-components-listing.jsx';
 import VmsListingRow from './VmsListingRow.jsx';
 import { getPod } from '../selectors.jsx';
+import CreateVmButton from './createVmButton.jsx';
 
 React;
 
@@ -37,9 +38,14 @@ const VmsListing = ({ vms, pvs, pods, settings, vmsMessages }) => {
                                                pod={getPod(vm, pods)}
                                                pvs={pvs}
                                                key={vm.metadata.uid} />));
+    let actions = [(
+        <CreateVmButton/>
+    )];
+
     return (
         <Listing title={_("Virtual Machines")}
                  emptyCaption={_("No virtual machines")}
+                 actions={actions}
                  columnTitles={[_("Name"), namespaceLabel, _("Node"), _("State")]}>
             {rows}
         </Listing>

--- a/pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+
+import React from 'react';
+import DialogPattern from 'cockpit-components-dialog.jsx';
+import CreateVmDialog from './createVmDialog.jsx'
+import { vmCreate } from '../kube-middleware.jsx';
+
+import { mouseClick } from '../utils.jsx'
+
+const _ = cockpit.gettext;
+
+class CreateVmButton extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.createVmDialog = this.createVmDialog.bind(this);
+    }
+
+    createVmDialog() {
+        let dialog = null;
+
+        const dialogProps = {
+            title: _("Create Virtual Machine"),
+            body: (
+                <CreateVmDialog ref={(d) => dialog = d}/>
+            ),
+        };
+
+        // also test modifying properties in subsequent render calls
+        const footerProps = {
+            actions: [
+                {
+                    clicked: () => {
+                        if (dialog) {
+                            const v = dialog.validate();
+                            dialog.showErrors(v.errors); // if no errors, then clear old errors
+                            if (v.success) {
+                                return vmCreate(v.result.resource);
+                            } else {
+                                return cockpit.reject(_("Resolve above errors to continue"));
+                            }
+                        }
+                    },
+                    caption: _("Create"),
+                    style: 'primary',
+                },
+            ],
+        };
+
+        DialogPattern.show_modal_dialog(dialogProps, footerProps);
+    }
+
+    render() {
+        return (
+            <a className="card-pf-link-with-icon pull-right" id="create-new-vm"
+               onClick={mouseClick(this.createVmDialog)}>
+                <span className="pficon pficon-add-circle-o"/>{_("Create")}
+            </a>
+        );
+    }
+}
+
+export default CreateVmButton;

--- a/pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx
@@ -1,0 +1,242 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+import React from 'react';
+
+import './createVmDialog.less';
+import { preventDefault } from '../utils.jsx'
+
+const _ = cockpit.gettext;
+
+const MAX_IMPORT_FILE_SIZE_MIB = 50;
+const DROP_ZONE_ID = 'drop-zone';
+
+class CreateVmDialog extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            resource: '',
+            resourceError: null,
+            isDragging: false,
+            isOverDropZone: false,
+            dragOverElements: [],
+        };
+
+        this.onDragEnter = this.onDragEnter.bind(this);
+        this.onDragLeave = this.onDragLeave.bind(this);
+        this.onDrop = this.onDrop.bind(this);
+        this.onNewFile = this.onNewFile.bind(this);
+        this.onNewFileEvent = this.onNewFileEvent.bind(this);
+
+        this.onResourceChanged = this.onResourceChanged.bind(this);
+    }
+
+    onResourceChanged(e) {
+        if (e && e.target && typeof(e.target.value) !== 'undefined') {
+            this.setState({ resource: e.target.value });
+        }
+    }
+
+    componentDidMount() {
+        window.addEventListener('dragenter', this.onDragEnter);
+        window.addEventListener('dragleave', this.onDragLeave);
+        window.addEventListener('dragover', preventDefault);
+        window.addEventListener('drop', preventDefault);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('dragenter', this.onDragEnter);
+        window.removeEventListener('dragleave', this.onDragLeave);
+        window.removeEventListener('dragover', preventDefault);
+        window.removeEventListener('drop', preventDefault);
+    }
+
+    validate() {
+        let success = true;
+        let errors = {
+            resourceError: null,
+        };
+        let result = {
+            resource: null,
+        };
+
+        if (!this.state.resource) {
+            errors.resourceError = _("VM definition is required.");
+        } else {
+            try {
+                let res = JSON.parse(this.state.resource);
+                if (res === null || typeof res !== "object") {
+                    errors.resourceError = _("VM definition is not a valid JSON.");
+                } else if (res instanceof Array) {
+                    errors.resourceError = _("VM definition must be an object.");
+                } else {
+                    result.resource = res;
+                }
+            } catch (e) {
+                errors.resourceError = _("VM definition is not a valid JSON.");
+            }
+        }
+
+        for (const key in errors) {
+            if (errors[key]) {
+                success = false;
+                break;
+            }
+        }
+
+        return {
+            success,
+            errors,
+            result,
+        };
+    }
+
+    showErrors(errors) {
+        this.setState(errors);
+    }
+
+    onNewFile(file) {
+        if (file.size > MAX_IMPORT_FILE_SIZE_MIB * 1024 * 1024) {
+            this.setState({
+                resourceError: cockpit.format(_("Only files of size $0 MiB and less are supported"), MAX_IMPORT_FILE_SIZE_MIB),
+            });
+            return;
+        }
+        let reader = new FileReader();
+        reader.onload = (e) => this.setState({ resource: e.target.result });
+        reader.readAsText(file);
+    }
+
+    onNewFileEvent(e) {
+        if (e.target.files.length > 0) {
+            this.onNewFile(e.target.files[0]);
+        }
+    }
+
+    onDrop(e) {
+        e.preventDefault();
+        this.setState({ isDragging: false });
+        const dt = e.dataTransfer;
+        if (dt.items) {
+            for (let i = 0; i < dt.items.length; i++) {
+                if (dt.items[i].kind === "file") {
+                    this.onNewFile(dt.items[i].getAsFile());
+                    break;
+                }
+            }
+        } else {
+            if (dt.files.length > 0) {
+                this.onNewFile(dt.files[0].getAsFile());
+            }
+        }
+        this.setState({
+            isOverDropZone: false,
+            dragOverElements: [],
+        });
+    }
+
+    onDragEnter(e) {
+        console.log(e.target);
+        const elements = [...this.state.dragOverElements, e.target];
+        this.setState({
+            isDragging: elements.length > 0,
+            isOverDropZone: e.target.id === DROP_ZONE_ID || this.state.isOverDropZone,
+            dragOverElements: elements,
+        });
+    }
+
+    onDragLeave(e) {
+        const elements = this.state.dragOverElements.filter(elem => elem !== e.target);
+        this.setState({
+            isDragging: elements.length > 0,
+            isOverDropZone: e.target.id === DROP_ZONE_ID ? false : this.state.isOverDropZone,
+            dragOverElements: elements,
+        });
+    }
+
+    render() {
+        let formGroupClassNames = '';
+        let textAreaClassName = '';
+        let resourceErrorLabel = null;
+
+        let dropZoneOverlay = null;
+        let overDropZoneOverlay = null;
+
+        if (this.state.resourceError) {
+            formGroupClassNames += ' has-error';
+            resourceErrorLabel = (
+                <label className="help-block" id='resource-text-error'>{this.state.resourceError}</label>);
+        }
+
+        if (this.state.isDragging) {
+            formGroupClassNames += ' disable-events';
+            const dropHere = this.state.isOverDropZone ? (
+                <div>
+                    {_("Drop file here to upload.")}
+                </div>
+            ) : null;
+
+            dropZoneOverlay = (
+                <div className="overlay drop-overlay drop-area">
+                    {dropHere}
+                </div>
+            );
+        }
+
+        if (this.state.isOverDropZone) {
+            overDropZoneOverlay = (<div className="overlay drop-overlay drop-area-over"/>);
+            textAreaClassName = "text-area-opacity";
+        }
+
+        return (
+            <div className="modal-body modal-dialog-body-table">
+                <div className={"description"}>
+                    {_("Paste JSON Bellow, ")}
+                    <label htmlFor="file-input" className="unstyled-label">
+                        <a>
+                            {_("upload a JSON file")}
+                            <input id="file-input" type="file" className="hide"
+                                   accept=".json,.txt"
+                                   onChange={this.onNewFileEvent}/>
+                        </a>
+                    </label>
+                    {_(" or drag & drop.")}
+                </div>
+                <div id={DROP_ZONE_ID}
+                     onDrop={this.onDrop}>
+                    <div className={"form-group " + formGroupClassNames}>
+                        <div className="drop-container">
+                            {dropZoneOverlay}
+                            {overDropZoneOverlay}
+                            <textarea id="resource-text"
+                                      key="resource-text"
+                                      className={"form-control " + textAreaClassName}
+                                      value={this.state.resource}
+                                      onChange={this.onResourceChanged}/>
+                        </div>
+                        {resourceErrorLabel}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default CreateVmDialog;

--- a/pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.less
+++ b/pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.less
@@ -1,0 +1,58 @@
+#resource-text{
+    resize: none;
+    height: 50vh;
+    font-family: monospace;
+}
+
+.description{
+    padding: 0.5em 0 0.5em;
+}
+
+#resource-text-error {
+    padding-top: 1em;
+}
+
+.hide {
+    display: none;
+}
+
+.drop-area {
+    z-index: 11;
+    border: #0088ce dashed;
+}
+
+.drop-area-over {
+    z-index: 10;
+    background-color: #0088ce;
+    opacity: 0.25;
+}
+
+.drop-overlay {
+    height: 100%;
+}
+
+.overlay {
+    position: absolute;
+    width: 100%;
+    text-align: center;
+    align-content: center;
+    display:flex;
+    align-items: center; /* Vertical center alignment */
+    justify-content: center; /* Horizontal center alignment */
+}
+
+.disable-events {
+    pointer-events: none;
+}
+
+.drop-container {
+    position: relative;
+}
+
+.text-area-opacity {
+    opacity: 0.25;
+}
+
+.unstyled-label {
+    font-weight: normal;
+}

--- a/pkg/kubernetes/scripts/virtual-machines/index.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/index.jsx
@@ -64,8 +64,8 @@ function addKubeLoaderListener ($scope, kubeLoader, kubeSelect) {
 }
 
 const VmsPlugin = () => (
-    <Provider store={reduxStore} >
-        <VmsListing />
+    <Provider store={reduxStore}>
+        <VmsListing/>
     </Provider>
 );
 
@@ -80,11 +80,12 @@ function addScopeVarsToStore ($scope) {
  * @param {$rootScope.Scope} $scope 'VirtualMachinesCtrl' controller scope
  * @param {kubeLoader} kubeLoader
  * @param {kubeSelect} kubeSelect
+ * @param {kubeMethods} kubeMethods
  */
 function init($scope, kubeLoader, kubeSelect, kubeMethods) {
     initReduxStore();
     addKubeLoaderListener($scope, kubeLoader, kubeSelect);
-    initMiddleware(kubeMethods);
+    initMiddleware(kubeMethods, kubeLoader);
     addScopeVarsToStore($scope);
 
     const rootElement = document.querySelector('#kubernetes-virtual-machines-root');

--- a/pkg/kubernetes/scripts/virtual-machines/utils.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/utils.jsx
@@ -69,3 +69,9 @@ export function getValueOrDefault(accessor, defaultValue) {
     }
     return defaultValue;
 }
+
+export function preventDefault(e) {
+    e.preventDefault();
+    return false;
+}
+

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -32,6 +32,9 @@ from kubelib import *
 # prevent them from being run concurrently.  Both use a 'openshift'
 # machine, and we can only run a single one of those at the same time.
 
+base_dir = os.path.dirname(os.path.realpath(__file__))
+
+
 def wait_project(machine, project):
     i = 0
     found = True
@@ -475,6 +478,263 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         pod_name = b.text("#vm-testvm-pod > a").strip()
         b.click("#vm-testvm-pod > a")
         b.wait_js_cond('window.location.hash === "#/l/pods/kube-system/%s"' % (pod_name))
+
+    def testKubevirtMachinesCreate(self):
+        class TestCreateConfig:
+            VM_CONFIG_FILE = os.path.join(base_dir, "files/mock-kube-vm.json")
+            VM_CONFIG_FILE_VM_NAME = "testvm"
+            INVALID_FILE = os.path.join(base_dir, "/tmp/invalid-file.json")
+
+        class CreateVmRunner:
+            def __init__(self, test_obj):
+                self.browser = test_obj.browser
+                self.openshift = test_obj.openshift
+                self.assertEqual = test_obj.assertEqual
+
+            def tryCreate(self, dialog):
+                b = self.browser
+                name = dialog.name
+
+                dialog.open() \
+                    .fill() \
+                    .create()
+                row_selector = "tr[data-row-id='vm-{0}']".format(name)
+
+                b.wait_present(row_selector)
+                self.assertEqual(b.text("{0} th".format(row_selector)), name)
+                self.assertEqual(b.text("{0} td:nth-of-type(2)".format(row_selector)), dialog.getNamespace())
+
+                # expand row
+                b.click(row_selector)
+                b.wait_present("{0} + tr.listing-ct-panel".format(row_selector))
+                b.wait_in_text("{0} + tr.listing-ct-panel".format(row_selector), "Node")
+
+                return self
+
+            def deleteVm(self, dialog):
+                b = self.browser
+                self.openshift.execute("oc delete vm {0} --namespace={1}".format(dialog.name, dialog.getNamespace()))
+                b.wait_not_present("tr[data-row-id='vm-{0}']".format(dialog.name))
+
+                return self
+
+            def checkEnvIsEmpty(self):
+                b = self.browser
+                b.wait_present("thead tr td")
+                b.wait_in_text("thead tr td", "No virtual machines")
+                b.wait(lambda: "No resources found." in self.openshift.execute("oc get vms --all-namespaces 2>&1"))
+
+                return self
+
+        class VmDialog:
+            def __init__(self, test_obj, name, resource=None, namespace="All Projects", opts=None):
+                self.browser = test_obj.browser
+                self.machine = test_obj.machine
+                self.snapshot = test_obj.snapshot
+
+                self.name = name
+                self.resource = resource
+                self.namespace = namespace
+                self.opts = opts if opts else {}
+
+            def getNamespace(self):
+                return 'default' if self.namespace == "All Projects" else self.namespace
+
+            def open(self, preselect_namespace=True):
+                b = self.browser
+
+                if preselect_namespace:
+                    self._selectFromNamespaceDropdown(self.namespace)
+
+                b.wait_present("#create-new-vm")
+                b.click("#create-new-vm")
+                b.wait_present("#cockpit_modal_dialog")
+                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Create Virtual Machine")
+
+                return self
+
+            def fill(self):
+                if self.opts and 'filename' in self.opts:
+                    filename = self.opts['filename']
+                    self._setFile("#file-input", filename)
+                else:
+                    self._setVal("#resource-text", self.resource)
+
+                return self
+
+            def cancel(self):
+                b = self.browser
+                if b.is_present("#cockpit_modal_dialog"):
+                    b.click(".modal-footer button:contains(Cancel)")
+                    b.wait_not_present("#cockpit_modal_dialog")
+
+                return self
+
+            def create(self):
+                b = self.browser
+                b.click(".modal-footer button:contains(Create)")
+                b.wait_not_present("#cockpit_modal_dialog")
+
+                return self
+
+            def createAndExpectUiError(self, error_dict):
+                b = self.browser
+                b.click(".modal-footer button:contains(Create)")
+                b.wait_present(".modal-footer div.alert")
+                b.wait_in_text(".modal-footer div.alert", "Resolve above errors to continue")
+                for key, error in error_dict.items():
+                    b.wait_present(key)
+                    b.wait_in_text(key, error)
+
+                return self
+
+            def createAndExpectBackendError(self, error):
+                b = self.browser
+                b.click(".modal-footer button:contains(Create)")
+                b.wait_present(".modal-footer .spinner")
+                b.wait_not_present(".modal-footer .spinner")
+                b.wait_present(".modal-footer div.alert")
+                b.wait_in_text(".modal-footer div.alert", error)
+
+                return self
+
+            def _selectFromNamespaceDropdown(self, value):
+                b = self.browser
+                dropdown_selector = "filter-project div"
+                dropdown_button = "{0} button".format(dropdown_selector)
+                item_selector = "{0} ul li a:contains({1})".format(dropdown_selector, value)
+
+                b.wait_visible(dropdown_button)
+                b.click(dropdown_button)
+
+                b.wait_visible(item_selector)
+                b.click(item_selector)
+                b.wait_not_visible(item_selector)
+
+            def _setFile(self, id, filename):
+                b = self.browser
+                b.wait_present(id)
+                b.upload_file(id, filename)
+
+            def _setVal(self, selector, value, by_key_press=False):
+                b = self.browser
+                value = str(value)
+
+                b.wait_present(selector)
+                b.wait_visible(selector)
+                b.click(selector)
+                b.focus(selector)
+                b.set_val(selector, '')  # clear value
+                if by_key_press:
+                    b.key_press(value)
+                else:
+                    b.set_val(selector, value)
+                b.wait_val(selector, value)
+
+        self.bootstrapKubevirt()
+        runner = CreateVmRunner(self)
+
+        def getResource(name):
+            with open(TestCreateConfig.VM_CONFIG_FILE, 'r') as f:
+                return f.read().replace(TestCreateConfig.VM_CONFIG_FILE_VM_NAME, name)
+
+        def checkDialogUiErrorTest(dialog, error_dict):
+            dialog.open() \
+                .fill() \
+                .createAndExpectUiError(error_dict) \
+                .cancel()
+            runner.checkEnvIsEmpty()
+
+        def checkDialogBackendErrorTest(dialog, error):
+            dialog.open() \
+                .fill() \
+                .createAndExpectBackendError(error) \
+                .cancel()
+            runner.checkEnvIsEmpty()
+
+        def createTest(dialog):
+            runner.tryCreate(dialog) \
+                .deleteVm(dialog) \
+                .checkEnvIsEmpty()
+
+        def createDuplicateTest(dialog):
+            runner.tryCreate(dialog)
+            dialog.open() \
+                .fill() \
+                .createAndExpectBackendError("already exists") \
+                .cancel()
+            runner.deleteVm(dialog) \
+                .checkEnvIsEmpty()
+
+        b = self.browser
+        self.login_and_go("/kubernetes")
+
+        # kubevirt is available, so link should be present
+        b.wait_present("#vms-menu-link")
+        b.click("#vms-menu-link")
+        runner.checkEnvIsEmpty()
+
+        checkDialogUiErrorTest(
+            VmDialog(self, 'testvm1', ''),
+            {'#resource-text-error': "VM definition is required"}
+        )
+
+        checkDialogUiErrorTest(
+            VmDialog(self, 'testvm2', namespace='default',
+                                   opts={
+                                       'filename': TestCreateConfig.INVALID_FILE,
+                                   }),
+            {'#resource-text-error': "VM definition is required"}
+        )
+
+        checkDialogUiErrorTest(
+            VmDialog(self, 'testvm3', '{a": "b"}'),
+            {'#resource-text-error': "VM definition is not a valid JSON"}
+        )
+
+        checkDialogUiErrorTest(
+            VmDialog(self, 'testvm4', 'abcd '),
+            {'#resource-text-error': "VM definition is not a valid JSON"}
+        )
+
+        checkDialogUiErrorTest(
+            VmDialog(self, 'testvm5', 4145175),
+            {'#resource-text-error': "VM definition is not a valid JSON"}
+        )
+
+        checkDialogUiErrorTest(
+            VmDialog(self, 'testvm6', '[{}]'),
+            {'#resource-text-error': "VM definition must be an object."}
+        )
+
+        checkDialogBackendErrorTest(
+            VmDialog(self, 'testvm7', '{}'),
+            "Failure"
+        )
+
+        vm_name = 'testvm8'
+        createTest(VmDialog(self, vm_name, getResource(vm_name)))
+
+        vm_name = 'testvm9'
+        createTest(VmDialog(self, vm_name, getResource(vm_name), namespace='default'))
+
+        vm_name = 'testvm10'
+        createTest(VmDialog(self, vm_name, getResource(vm_name), namespace='kube-public'))
+
+        vm_name = 'testvm11'
+        createTest(VmDialog(self, vm_name, getResource(vm_name), namespace='kube-system'))
+
+        vm_name = 'testvm12'
+        createDuplicateTest(VmDialog(self, vm_name, getResource(vm_name)))
+
+        # test file input
+        vm_name = TestCreateConfig.VM_CONFIG_FILE_VM_NAME
+        createTest(
+            VmDialog(self, vm_name, namespace='kube-public',
+                                   opts={
+                                       'filename': TestCreateConfig.VM_CONFIG_FILE,
+                                   })
+        )
 
 
 class TestOpenshiftPrerelease(TestOpenshift):

--- a/test/verify/files/mock-kube-vm.json
+++ b/test/verify/files/mock-kube-vm.json
@@ -1,0 +1,69 @@
+{
+  "metadata": {
+    "name": "testvm"
+  },
+  "apiVersion": "kubevirt.io/v1alpha1",
+  "kind": "VirtualMachine",
+  "spec": {
+    "domain": {
+      "devices": {
+        "disks": [
+          {
+            "device": "disk",
+            "driver": {
+              "name": "qemu",
+              "type": "raw",
+              "cache": "none"
+            },
+            "snapshot": "external",
+            "source": {
+              "host": {
+                "name": "iscsi-demo-target.kube-system",
+                "port": "3260"
+              },
+              "name": "iqn.2017-01.io.kubevirt:sn.42/2",
+              "protocol": "iscsi"
+            },
+            "target": {
+              "dev": "vda"
+            },
+            "type": "network"
+          }
+        ],
+        "interfaces": [
+          {
+            "source": {
+              "network": "default"
+            },
+            "type": "network"
+          }
+        ],
+        "video": [
+          {
+            "type": "qxl"
+          }
+        ],
+        "graphics": [
+          {
+            "type": "spice"
+          }
+        ],
+        "consoles": [
+          {
+            "type": "pty"
+          }
+        ]
+      },
+      "memory": {
+        "unit": "MB",
+        "value": 64
+      },
+      "os": {
+        "type": {
+          "os": "hvm"
+        }
+      },
+      "type": "qemu"
+    }
+  }
+}


### PR DESCRIPTION
followup of kubernetes: Virtual machines side tab added https://github.com/cockpit-project/cockpit/pull/7830

#### Adds ability to create vms: 
- a simple functionality for now
- just copy kubevirt/cluster/vm.json (or any other vm definition) into the dialog


![kubevirt-create-vm](https://user-images.githubusercontent.com/3648838/35283453-9f80b38a-0058-11e8-9b7e-11182d038c6c.png)


#### Proper UI planned in the followup:
- there will be a switch between json and UI input
- if any value gets changed in the UI input option, then it will be modified in the json 
- vm will be created from the json
- this way it will be possible to create vm with attributes not available in the ui

todo:

- [x] basic implementation
- [x]  tests
- [x] add JSON colorization
- [x] add browse for JSON file
- [x] make textarea dropdown area for a file
- [x] empty state in textarea
- [x] update tests
- [ ] create video or series of screenshots

