### PR TITLE
ovirt: remove [PROJECT_ROOT]/machines-ovirt.config

### DIFF
--- a/machines-ovirt.config
+++ b/machines-ovirt.config
@@ -1,7 +1,0 @@
-{
-    "debug": true,
-    "OVIRT_BASE_URL": "https://engine.local/ovirt-engine",
-    "CONSOLE_CLIENT_RESOURCES_URL": "https://www.ovirt.org/documentation/admin-guide/virt/console-client-resources/",
-    "ovirt_polling_interval": 5000,
-    "cockpitPort": 9090
-}


### PR DESCRIPTION
Committed by mistake within 9d0d268.

This file is meant to be generated by pkg/ovirt/install.sh and
further adjusted by admin.