### PR TITLE
ws: Only set language on login

### DIFF
--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -476,7 +476,7 @@
      * As a convenience, common menu items can be setup by adding the
      * selector to be used to hook them up. The accepted selectors
      * are.
-     * oops_sel, logout_sel, language_sel, brand_sel, about_sel,
+     * oops_sel, logout_sel, brand_sel, about_sel,
      * user_sel, account_sel
      *
      * Emits "disconnect" and "expect_restart" signals, that should be
@@ -811,40 +811,6 @@
             });
         }
 
-        /* Display language dialog */
-        function setup_language(id) {
-            /*
-             * Note that we don't go ahead and load all the po files in order
-             * to produce this list. Perhaps we would include it somewhere in a
-             * separate automatically generated file. Need to see.
-             */
-            var manifest = cockpit.manifests["shell"] || { };
-            $(".display-language-menu").toggle(!!manifest.locales);
-            var language = document.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*\=\s*([^;]*).*$)|^.*$/, "$1");
-            if (!language)
-                language = "en-us";
-            $.each(manifest.locales || { }, function(code, name) {
-                var el = $("<option>").text(name).val(code);
-                if (code == language)
-                    el.attr("selected", "true");
-                $("#display-language-list").append(el);
-            });
-
-            $("#display-language-select-button").on("click", function(event) {
-                var code_to_select = $("#display-language-list").val();
-                var cookie = "CockpitLang=" + encodeURIComponent(code_to_select) +
-                             "; path=/; expires=Sun, 16 Jul 3567 06:23:41 GMT";
-                document.cookie = cookie;
-                window.localStorage.setItem("cockpit.lang", code_to_select);
-                window.location.reload(true);
-                return false;
-            });
-
-            $(id).on("shown.bs.modal", function() {
-                $("display-language-list").focus();
-            });
-        }
-
         /* About dialog */
         function setup_about(id) {
             $(cockpit.info).on("changed", function() {
@@ -876,9 +842,6 @@
 
         if (self.logout_sel)
             setup_logout(self.logout_sel);
-
-        if (self.language_sel)
-            setup_language(self.language_sel);
 
         var cal_title;
         if (self.brand_sel) {

--- a/pkg/shell/index-no-machines.js
+++ b/pkg/shell/index-no-machines.js
@@ -34,7 +34,6 @@
         brand_sel: "#index-brand",
         logout_sel: "#go-logout",
         oops_sel: "#navbar-oops",
-        language_sel: "#display-language",
         about_sel: "#about-version",
         default_title: default_title
     });

--- a/pkg/shell/index-stub.js
+++ b/pkg/shell/index-stub.js
@@ -37,7 +37,6 @@
         brand_sel: "#index-brand",
         logout_sel: "#go-logout",
         oops_sel: "#navbar-oops",
-        language_sel: "#display-language",
         about_sel: "#about-version",
         default_title: default_title,
         skip_brand_title: true

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -50,10 +50,6 @@
                   <span id="content-user-name"></span><b class="caret"></b>
                 </a>
                 <ul class="dropdown-menu">
-                  <li class="display-language-menu">
-                    <a data-toggle="modal" data-target="#display-language" translatable="yes">Display Language</a>
-                  </li>
-                  <li class="divider display-language-menu"></li>
                   <li>
                     <a data-toggle="modal" data-target="#about" translatable="yes">About Cockpit</a>
                   </li>
@@ -107,25 +103,6 @@
                 <div class="modal-content">
                 </div>
             </div>
-        </div>
-
-        <div class="modal" id="display-language" tabindex="-1" role="dialog" data-backdrop="static">
-          <div class="modal-dialog">
-            <div class="modal-content">
-              <div class="modal-header">
-                <h4 class="modal-title" translatable="yes">Display Language</h4>
-              </div>
-              <div class="modal-body">
-	        <p translatable="yes">Choose the language to be used in the application</p>
-                <select id="display-language-list" size="5" data-role="none">
-                </select>
-              </div>
-              <div class="modal-footer">
-                <button class="btn btn-default" data-dismiss="modal" translatable="yes">Cancel</button>
-                <button class="btn btn-primary" id="display-language-select-button" translatable="yes">Select</button>
-              </div>
-            </div>
-          </div>
         </div>
 
         <div class="modal" id="error-popup" tabindex="-1" role="dialog" data-backdrop="static">

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -44,7 +44,6 @@
         brand_sel: "#index-brand",
         logout_sel: "#go-logout",
         oops_sel: "#navbar-oops",
-        language_sel: "#display-language",
         about_sel: "#about-version",
         account_sel: "#go-account",
         user_sel: "#content-user-name",

--- a/pkg/shell/manifest.json.in
+++ b/pkg/shell/manifest.json.in
@@ -4,21 +4,6 @@
 	"cockpit": "134.x"
     },
 
-    "locales": {
-        "en-us": "English",
-        "ca-es": "Catalan",
-        "da-dk": "Dansk",
-        "de-de": "Deutsch",
-        "es-es": "Español",
-        "fr-fr": "Français",
-        "ja-ja": "日本語",
-        "pl-pl": "Polski",
-        "pt-br": "Portugueses",
-        "tr-tr": "Türkçe",
-        "uk-ua": "Українська",
-        "zh-cn": "中文"
-    },
-
     "bridges": [
         {
             "match": { "superuser": null },

--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -666,14 +666,6 @@ li.credential-lock > a:first-child {
     font-weight: bold;
 }
 
-#display-language-list {
-    width: 100%;
-}
-
-#display-language-list option {
-   padding: 10px;
-}
-
 iframe.container-frame {
     display: none;
     border: none;

--- a/pkg/shell/simple.html
+++ b/pkg/shell/simple.html
@@ -34,10 +34,6 @@
                   <span id="content-user-name"></span><b class="caret"></b>
                 </a>
                 <ul class="dropdown-menu">
-                  <li class="display-language-menu">
-                    <a data-toggle="modal" data-target="#display-language" translatable="yes">Display Language</a>
-                  </li>
-                  <li class="divider display-language-menu"></li>
                   <li>
                     <a data-toggle="modal" data-target="#about" translatable="yes">About Cockpit</a>
                   </li>
@@ -70,25 +66,6 @@
               </div>
               <div class="modal-footer">
                 <button class="btn btn-primary" data-dismiss="modal" translate>Close</button>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="modal" id="display-language" tabindex="-1" role="dialog" data-backdrop="static">
-          <div class="modal-dialog">
-            <div class="modal-content">
-              <div class="modal-header">
-                <h4 class="modal-title" translatable="yes">Display Language</h4>
-              </div>
-              <div class="modal-body">
-	        <p translatable="yes">Choose the language to be used in the application</p>
-                <select id="display-language-list" size="5" data-role="none">
-                </select>
-              </div>
-              <div class="modal-footer">
-                <button class="btn btn-default" data-dismiss="modal" translatable="yes">Cancel</button>
-                <button class="btn btn-primary" id="display-language-select-button" translatable="yes">Select</button>
               </div>
             </div>
           </div>

--- a/pkg/shell/stub.html
+++ b/pkg/shell/stub.html
@@ -38,10 +38,6 @@
                   <span id="content-user-name"></span><b class="caret"></b>
                 </a>
                 <ul class="dropdown-menu">
-                  <li class="display-language-menu">
-                    <a data-toggle="modal" data-target="#display-language" translatable="yes">Display Language</a>
-                  </li>
-                  <li class="divider display-language-menu"></li>
                   <li>
                     <a data-toggle="modal" data-target="#about" translatable="yes">About Cockpit</a>
                   </li>
@@ -88,25 +84,6 @@
                 <div class="modal-content">
                 </div>
             </div>
-        </div>
-
-        <div class="modal" id="display-language" tabindex="-1" role="dialog" data-backdrop="static">
-          <div class="modal-dialog">
-            <div class="modal-content">
-              <div class="modal-header">
-                <h4 class="modal-title" translatable="yes">Display Language</h4>
-              </div>
-              <div class="modal-body">
-	        <p translatable="yes">Choose the language to be used in the application</p>
-                <select id="display-language-list" size="5" data-role="none">
-                </select>
-              </div>
-              <div class="modal-footer">
-                <button class="btn btn-default" data-dismiss="modal" translatable="yes">Cancel</button>
-                <button class="btn btn-primary" id="display-language-select-button" translatable="yes">Select</button>
-              </div>
-            </div>
-          </div>
         </div>
 
         <div class="modal" id="error-popup" tabindex="-1" role="dialog" data-backdrop="static">

--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -55,7 +55,7 @@ typedef struct {
 typedef struct {
   const gchar *datadirs[8];
   const gchar *path;
-  const gchar *accept[8];
+  const gchar *lang;
   const gchar *expect;
   const gchar *headers[8];
   gboolean cacheable;
@@ -89,7 +89,6 @@ setup (TestCase *tc,
   JsonObject *options;
   JsonObject *headers;
   const gchar *control;
-  gchar *accept;
   GBytes *bytes;
   guint i;
 
@@ -97,6 +96,12 @@ setup (TestCase *tc,
 
   if (fixture->expect)
     cockpit_expect_warning (fixture->expect);
+
+  if (fixture->lang)
+    {
+      g_setenv ("LANG", fixture->lang, TRUE);
+      g_setenv ("LC_MESSAGES", fixture->lang, TRUE);
+    }
 
   if (fixture->datadirs[0])
     {
@@ -120,12 +125,6 @@ setup (TestCase *tc,
   json_object_set_string_member (options, "path", fixture->path);
 
   headers = json_object_new ();
-  if (fixture->accept[0])
-    {
-      accept = g_strjoinv (", ", (gchar **)fixture->accept);
-      json_object_set_string_member (headers, "Accept-Language", accept);
-      g_free (accept);
-    }
   if (!fixture->cacheable)
     json_object_set_string_member (headers, "Pragma", "no-cache");
   for (i = 0; i < G_N_ELEMENTS (fixture->headers); i += 2)
@@ -169,6 +168,8 @@ teardown (TestCase *tc,
   cockpit_packages_free (tc->packages);
 
   cockpit_bridge_data_dirs = NULL;
+  g_setenv ("LANG", "C", TRUE);
+  g_setenv ("LC_MESSAGES", "C", TRUE);
 }
 
 static const Fixture fixture_simple = {
@@ -221,7 +222,7 @@ test_forwarded (TestCase *tc,
 
 static const Fixture fixture_pig = {
   .path = "/another/test.html",
-  .accept = { "pig" },
+  .lang = "pig",
 };
 
 static void
@@ -245,7 +246,7 @@ test_localized_translated (TestCase *tc,
 
 static const Fixture fixture_unknown = {
   .path = "/another/test.html",
-  .accept = { "unknown" },
+  .lang = "unknown",
 };
 
 static void
@@ -269,7 +270,7 @@ test_localized_unknown (TestCase *tc,
 
 static const Fixture fixture_prefer_region = {
   .path = "/another/test.html",
-  .accept = { "pig-pen" },
+  .lang = "pig_PEN",
 };
 
 static void
@@ -293,7 +294,7 @@ test_localized_prefer_region (TestCase *tc,
 
 static const Fixture fixture_fallback = {
   .path = "/another/test.html",
-  .accept = { "pig-barn" },
+  .lang = "pig_BARN",
 };
 
 static void
@@ -617,8 +618,8 @@ test_list_bad_name (TestCase *tc,
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
   cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":"
-                                     "{\"X-Cockpit-Pkg-Checksum\":\"524d07b284cda92c86a908c67014ee882a80193b\",\"Content-Type\":\"application/json\",\"ETag\":\"\\\"$524d07b284cda92c86a908c67014ee882a80193b\\\"\"}}"
-                                 "{\".checksum\":\"524d07b284cda92c86a908c67014ee882a80193b\",\"ok\":{\".checksum\":\"524d07b284cda92c86a908c67014ee882a80193b\"}}", -1);
+                                     "{\"X-Cockpit-Pkg-Checksum\":\"524d07b284cda92c86a908c67014ee882a80193b-c\",\"Content-Type\":\"application/json\",\"ETag\":\"\\\"$524d07b284cda92c86a908c67014ee882a80193b-c\\\"\"}}"
+                                 "{\".checksum\":\"524d07b284cda92c86a908c67014ee882a80193b-c\",\"ok\":{\".checksum\":\"524d07b284cda92c86a908c67014ee882a80193b-c\"}}", -1);
   g_assert_cmpuint (count, ==, 2);
   g_bytes_unref (data);
 }
@@ -643,7 +644,7 @@ test_glob (TestCase *tc,
   message = mock_transport_pop_channel (tc->transport, "444");
   object = cockpit_json_parse_bytes (message, &error);
   g_assert_no_error (error);
-  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-Cockpit-Pkg-Checksum\":\"4f2a5a7bb5bf355776e1fc83831b1d846914182e\",\"Content-Type\":\"text/plain\"}}");
+  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-Cockpit-Pkg-Checksum\":\"4f2a5a7bb5bf355776e1fc83831b1d846914182e-c\",\"Content-Type\":\"text/plain\"}}");
   json_object_unref (object);
 
   message = mock_transport_pop_channel (tc->transport, "444");
@@ -909,15 +910,15 @@ test_reload_added (TestCase *tc,
   setup_reload_packages (datadir, "old");
   tc->packages = cockpit_packages_new ();
 
-  assert_manifest_checksum (tc, NULL,  "0e4445bda678eede7c520a0a0b87aae56e7570cf");
-  assert_manifest_checksum (tc, "old", "0e4445bda678eede7c520a0a0b87aae56e7570cf");
+  assert_manifest_checksum (tc, NULL,  "0e4445bda678eede7c520a0a0b87aae56e7570cf-c");
+  assert_manifest_checksum (tc, "old", "0e4445bda678eede7c520a0a0b87aae56e7570cf-c");
 
   setup_reload_packages (datadir, "new");
   cockpit_packages_reload (tc->packages);
 
-  assert_manifest_checksum (tc, NULL,  "0e4445bda678eede7c520a0a0b87aae56e7570cf");
-  assert_manifest_checksum (tc, "old", "0e4445bda678eede7c520a0a0b87aae56e7570cf");
-  assert_manifest_checksum (tc, "new", "516e9877b1255fa22f18c869e1715f39dd4b39ec");
+  assert_manifest_checksum (tc, NULL,  "0e4445bda678eede7c520a0a0b87aae56e7570cf-c");
+  assert_manifest_checksum (tc, "old", "0e4445bda678eede7c520a0a0b87aae56e7570cf-c");
+  assert_manifest_checksum (tc, "new", "516e9877b1255fa22f18c869e1715f39dd4b39ec-c");
 
   teardown_reload_packages (datadir);
 }
@@ -935,15 +936,15 @@ test_reload_removed (TestCase *tc,
   setup_reload_packages (datadir, "new");
   tc->packages = cockpit_packages_new ();
 
-  assert_manifest_checksum (tc, NULL,  "516e9877b1255fa22f18c869e1715f39dd4b39ec");
-  assert_manifest_checksum (tc, "old", "516e9877b1255fa22f18c869e1715f39dd4b39ec");
-  assert_manifest_checksum (tc, "new", "516e9877b1255fa22f18c869e1715f39dd4b39ec");
+  assert_manifest_checksum (tc, NULL,  "516e9877b1255fa22f18c869e1715f39dd4b39ec-c");
+  assert_manifest_checksum (tc, "old", "516e9877b1255fa22f18c869e1715f39dd4b39ec-c");
+  assert_manifest_checksum (tc, "new", "516e9877b1255fa22f18c869e1715f39dd4b39ec-c");
 
   setup_reload_packages (datadir, "old");
   cockpit_packages_reload (tc->packages);
 
-  assert_manifest_checksum (tc, NULL,  "516e9877b1255fa22f18c869e1715f39dd4b39ec");
-  assert_manifest_checksum (tc, "old", "516e9877b1255fa22f18c869e1715f39dd4b39ec");
+  assert_manifest_checksum (tc, NULL,  "516e9877b1255fa22f18c869e1715f39dd4b39ec-c");
+  assert_manifest_checksum (tc, "old", "516e9877b1255fa22f18c869e1715f39dd4b39ec-c");
   assert_manifest_checksum (tc, "new", NULL);
 
   teardown_reload_packages (datadir);
@@ -962,14 +963,14 @@ test_reload_updated (TestCase *tc,
   setup_reload_packages (datadir, "old");
   tc->packages = cockpit_packages_new ();
 
-  assert_manifest_checksum (tc, NULL,  "0e4445bda678eede7c520a0a0b87aae56e7570cf");
-  assert_manifest_checksum (tc, "old", "0e4445bda678eede7c520a0a0b87aae56e7570cf");
+  assert_manifest_checksum (tc, NULL,  "0e4445bda678eede7c520a0a0b87aae56e7570cf-c");
+  assert_manifest_checksum (tc, "old", "0e4445bda678eede7c520a0a0b87aae56e7570cf-c");
 
   setup_reload_packages (datadir, "updated");
   cockpit_packages_reload (tc->packages);
 
-  assert_manifest_checksum (tc, NULL,  "0e4445bda678eede7c520a0a0b87aae56e7570cf");
-  assert_manifest_checksum (tc, "old", "252178c3fba5843c8c3bb4ce7733b405741cedee");
+  assert_manifest_checksum (tc, NULL,  "0e4445bda678eede7c520a0a0b87aae56e7570cf-c");
+  assert_manifest_checksum (tc, "old", "252178c3fba5843c8c3bb4ce7733b405741cedee-c");
 
   teardown_reload_packages (datadir);
 }
@@ -993,7 +994,7 @@ test_csp_strip (TestCase *tc,
   g_assert_cmpstr (tc->problem, ==, NULL);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
-  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-Cockpit-Pkg-Checksum\":\"0c58347ff749c5918f7f311c109369c377dc2ba1\",\"Content-Type\":\"text/html\",\"Content-Security-Policy\":\"connect-src 'self' ws: wss:; img-src: 'self' data:; default-src 'self'\"}}<html>\x0A<head>\x0A<title>Test</title>\x0A</head>\x0A<body>Test</body>\x0A</html>\x0A", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-Cockpit-Pkg-Checksum\":\"0c58347ff749c5918f7f311c109369c377dc2ba1-c\",\"Content-Type\":\"text/html\",\"Content-Security-Policy\":\"connect-src 'self' ws: wss:; img-src: 'self' data:; default-src 'self'\"}}<html>\x0A<head>\x0A<title>Test</title>\x0A</head>\x0A<body>Test</body>\x0A</html>\x0A", -1);
   g_assert_cmpuint (count, ==, 2);
   g_bytes_unref (data);
 }

--- a/src/common/cockpitlocale.c
+++ b/src/common/cockpitlocale.c
@@ -64,6 +64,44 @@ cockpit_locale_from_language (const gchar *value,
   return result;
 }
 
+gchar *
+cockpit_language_from_locale (const gchar *value)
+{
+  gint len = -1;
+  const gchar *underscore;
+  const gchar *dot;
+  gchar *country = NULL;
+  gchar *lang = NULL;
+  gchar *result = NULL;
+
+  if (value == NULL || g_strcmp0 (value, "C") == 0)
+    return NULL;
+
+  dot = strchr (value, '.');
+  underscore = strchr (value, '_');
+
+  if (underscore)
+    {
+      if (dot && dot > underscore)
+        len = (dot - underscore) - 1;
+
+      country = g_ascii_strdown (underscore + 1, len);
+      lang = g_ascii_strdown (value, underscore - value);
+      result = g_strconcat (lang, "-", country, NULL);
+    }
+  else
+    {
+      if (dot)
+        len = (dot - value);
+
+      result = g_ascii_strdown (value, len);
+    }
+
+  g_free (country);
+  g_free (lang);
+  return result;
+}
+
 /* The most recently set language */
 static gchar previous[32] = { '\0' };
 

--- a/src/common/cockpitlocale.h
+++ b/src/common/cockpitlocale.h
@@ -28,6 +28,8 @@ gchar *               cockpit_locale_from_language       (const gchar *language,
                                                           const gchar *encoding,
                                                           gchar **shorter);
 
+gchar *               cockpit_language_from_locale       (const gchar *value);
+
 void                  cockpit_locale_set_language        (const gchar *language);
 
 G_END_DECLS

--- a/src/common/cockpittest.c
+++ b/src/common/cockpittest.c
@@ -217,6 +217,9 @@ cockpit_test_init (int *argc,
   g_setenv ("GIO_USE_VFS", "local", TRUE);
   g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
   g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
+  g_setenv ("LANG", "C", TRUE);
+  g_setenv ("LC_ALL", "C", TRUE);
+  g_setenv ("LC_MESSAGES", "C", TRUE);
 
   g_assert (g_snprintf (path, sizeof (path), "%s:%s", BUILDDIR, g_getenv ("PATH")) < sizeof (path));
   g_setenv ("PATH", path, TRUE);

--- a/src/common/test-locale.c
+++ b/src/common/test-locale.c
@@ -34,6 +34,7 @@ typedef struct {
 
 static FromFixture from_fixtures[] = {
   { "en", NULL, "en", "en" },
+  { "en", "UTF-8", "en.UTF-8", "en" },
   { "en-us", NULL, "en_US", "en" },
   { "en-us", "UTF-8", "en_US.UTF-8", "en" },
   { "zh-cn", NULL, "zh_CN", "zh" },
@@ -58,6 +59,18 @@ test_from_language (gconstpointer data)
   locale = cockpit_locale_from_language (fixture->language, fixture->encoding, NULL);
   g_assert_cmpstr (locale, ==, fixture->locale);
   g_free (locale);
+}
+
+static void
+test_to_language (gconstpointer data)
+{
+  const FromFixture *fixture = data;
+  gchar *lang;
+
+  lang = cockpit_language_from_locale (fixture->locale);
+  g_assert_cmpstr (lang, ==, fixture->language);
+
+  g_free (lang);
 }
 
 typedef struct {
@@ -170,6 +183,11 @@ main (int argc,
     {
       name = g_strdup_printf ("/locale/from-language/%s", from_fixtures[i].locale);
       g_test_add_data_func (name, from_fixtures + i, test_from_language);
+      g_free (name);
+      name = g_strdup_printf ("/locale/to-language/%s-%s",
+                              from_fixtures[i].locale,
+                              from_fixtures[i].language);
+      g_test_add_data_func (name, from_fixtures + i, test_to_language);
       g_free (name);
     }
 

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -29,6 +29,7 @@
 #include "common/cockpitconf.h"
 #include "common/cockpiterror.h"
 #include "common/cockpithex.h"
+#include "common/cockpitlocale.h"
 #include "common/cockpitlog.h"
 #include "common/cockpitjson.h"
 #include "common/cockpitmemory.h"
@@ -993,7 +994,8 @@ cockpit_session_create (CockpitAuth *self,
   const gchar *command;
   const gchar *section;
   const gchar *program_default;
-
+  gchar *lang = NULL;
+  gchar **languages = NULL;
   gchar **env = g_get_environ ();
 
   const gchar *argv[] = {
@@ -1045,6 +1047,19 @@ cockpit_session_create (CockpitAuth *self,
                               TRUE);
     }
 
+  lang = cockpit_web_server_parse_cookie (headers, "CockpitLang");
+  if (!lang)
+    {
+      languages = cockpit_web_server_parse_languages (headers, NULL);
+      lang = cockpit_locale_from_language (languages[0], "UTF-8", NULL);
+    }
+
+  if (lang)
+    {
+      env = g_environ_setenv (env, "LANG", lang, TRUE);
+      env = g_environ_setenv (env, "LC_MESSAGES", lang, TRUE);
+    }
+
   argv[0] = command;
   argv[1] = host ? host : "localhost";
 
@@ -1081,6 +1096,8 @@ cockpit_session_create (CockpitAuth *self,
   session->client_timeout = timeout_option ("response-timeout", section, cockpit_ws_auth_response_timeout);
 
 out:
+  g_free (lang);
+  g_strfreev (languages);
   g_strfreev (env);
   if (creds)
     cockpit_creds_unref (creds);

--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -472,12 +472,6 @@ cockpit_channel_response_create (CockpitWebService *service,
 }
 
 static gboolean
-is_resource_a_package_file (const gchar *path)
-{
-  return path && path[0] && strchr (path + 1, '/') != NULL;
-}
-
-static gboolean
 parse_host_and_etag (CockpitWebService *service,
                      GHashTable *headers,
                      const gchar *where,
@@ -485,15 +479,6 @@ parse_host_and_etag (CockpitWebService *service,
                      const gchar **host,
                      gchar **etag)
 {
-  gchar **languages = NULL;
-  gboolean translatable;
-  gchar *language;
-
-  /* Parse the language out of the CockpitLang cookie and set Accept-Language */
-  language = cockpit_web_server_parse_cookie (headers, "CockpitLang");
-  if (language)
-    g_hash_table_replace (headers, g_strdup ("Accept-Language"), language);
-
   if (!where)
     {
       *host = "localhost";
@@ -514,20 +499,7 @@ parse_host_and_etag (CockpitWebService *service,
   if (!*host)
     return FALSE;
 
-  /* Top level resources (like the /manifests) are not translatable */
-  translatable = is_resource_a_package_file (path);
-
-  /* The ETag contains the language setting */
-  if (translatable)
-    {
-      languages = cockpit_web_server_parse_languages (headers, "C");
-      *etag = g_strdup_printf ("\"%s-%s\"", where, languages[0]);
-      g_strfreev (languages);
-    }
-  else
-    {
-      *etag = g_strdup_printf ("\"%s\"", where);
-    }
+  *etag = g_strdup_printf ("\"%s\"", where);
 
   return TRUE;
 }

--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -78,6 +78,26 @@
               </div>
             </div>
 
+            <div id="language-group" class="form-group">
+              <label title="Language" for="server-field" class="col-sm-2 col-md-2 control-label" translate>Language</label>
+              <div class="col-sm-10 col-md-10 language-box">
+                <select id="language" class="form-control">
+                    <option value="en-us">English</option>
+                    <option value="ca-es">Catalan</option>
+                    <option value="da-dk">Dansk</option>
+                    <option value="de-de">Deutsch</option>
+                    <option value="es-es">Español</option>
+                    <option value="fr-fr">Français</option>
+                    <option value="ja-jp">日本語</option>
+                    <option value="pl-pl">Polski</option>
+                    <option value="pt-br">Portugueses</option>
+                    <option value="tr-tr">Türkçe</option>
+                    <option value="uk-ua">Українська</option>
+                    <option value="zh-cn">中文</option>
+                </select>
+              </div>
+            </div>
+
             <div class="form-group">
               <div class="col-md-3 col-sm-3 login-button-container">
                 <button class="btn btn-primary btn-lg col-xs-12" id="login-button">

--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -28,6 +28,21 @@
         return fmt.replace(fmt_re, function(m, x, y) { return args[x || y] || ""; });
     }
 
+    function select_language() {
+        var val = id("language").value;
+        if (!val)
+            val = "en-us";
+
+        var cookie = "CockpitLang=" + encodeURIComponent(val) +
+                     "; path=/; expires=Sun, 16 Jul 3567 06:23:41 GMT";
+        document.cookie = cookie;
+        window.localStorage.setItem("cockpit.lang", val);
+
+        if (!id("login-user-input").value)
+            window.location.reload(true);
+        return false;
+    }
+
     function gettext(key) {
         if (window.cockpit_po) {
             var translated = window.cockpit_po[key];
@@ -202,10 +217,12 @@
         id("option-group").setAttribute("data-state", show);
         if (show) {
             id("server-group").style.display = 'block';
+            id("language-group").style.display = 'block';
             id("option-caret").setAttribute("class", "caret caret-down");
             id("option-caret").setAttribute("className", "caret caret-down");
         } else {
             id("server-group").style.display = 'none';
+            id("language-group").style.display = 'none';
             id("option-caret").setAttribute("class", "caret caret-right");
             id("option-caret").setAttribute("className", "caret caret-right");
         }
@@ -217,6 +234,11 @@
         translate();
 
         setup_path_globals (window.location.pathname);
+
+        var language = document.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*\=\s*([^;]*).*$)|^.*$/, "$1");
+        if (language)
+            id("language").value = language;
+        id("language").addEventListener("change", select_language);
 
         // Setup title
         var title = environment.page.title;
@@ -460,8 +482,10 @@
 
         if (!connectable || in_conversation) {
             id("server-group").style.display = "none";
+            id("language-group").style.display = "none";
         } else {
             id("server-group").style.display = expanded ? "block" : "none";
+            id("language-group").style.display = expanded ? "block" : "none";
         }
 
 

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -1104,6 +1104,8 @@ static const char *env_names[] = {
   "G_SLICE",
   "PATH",
   "COCKPIT_REMOTE_PEER",
+  "LANG",
+  "LC_MESSAGES",
   NULL
 };
 

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -441,7 +441,7 @@ test_default (Test *test,
 }
 
 static const DefaultFixture fixture_resource_checksum = {
-  .path = "/cockpit/$060119c2a544d8e5becd0f74f9dcde146b8d99e3/test/sub/file.ext",
+  .path = "/cockpit/$060119c2a544d8e5becd0f74f9dcde146b8d99e3-c/test/sub/file.ext",
   .auth = "/cockpit",
   .expect = "HTTP/1.1 200*"
     "These are the contents of file.ext*"
@@ -501,7 +501,7 @@ static const DefaultFixture fixture_shell_path_package = {
   .org_path = "/path/system/host",
   .auth = "/cockpit",
   .expect = "HTTP/1.1 200*"
-      "<base href=\"/path/cockpit/$060119c2a544d8e5becd0f74f9dcde146b8d99e3/another/test.html\">*"
+      "<base href=\"/path/cockpit/$060119c2a544d8e5becd0f74f9dcde146b8d99e3-c/another/test.html\">*"
       "<title>In system dir</title>*"
 };
 
@@ -541,7 +541,7 @@ static const DefaultFixture fixture_machine_shell_index = {
   .auth = "/cockpit+=machine",
   .config = SRCDIR "/src/ws/mock-config/cockpit/cockpit.conf",
   .expect = "HTTP/1.1 200*"
-      "<base href=\"/cockpit+=machine/$060119c2a544d8e5becd0f74f9dcde146b8d99e3/second/test.html\">*"
+      "<base href=\"/cockpit+=machine/$060119c2a544d8e5becd0f74f9dcde146b8d99e3-c/second/test.html\">*"
       "<title>In system dir</title>*"
 };
 
@@ -559,7 +559,7 @@ static const DefaultFixture fixture_shell_package = {
   .path = "/system/host",
   .auth = "/cockpit",
   .expect = "HTTP/1.1 200*"
-      "<base href=\"/cockpit/$060119c2a544d8e5becd0f74f9dcde146b8d99e3/another/test.html\">*"
+      "<base href=\"/cockpit/$060119c2a544d8e5becd0f74f9dcde146b8d99e3-c/another/test.html\">*"
       "<title>In system dir</title>*"
 };
 

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -140,8 +140,7 @@ class TestApps(PackageCase):
 
         b.wait_present(".app-description:contains('DESCRIPTION:none')")
 
-        def set_lang(lang):
-            b.switch_to_top()
+        def legacy_switch(lang):
             b.click("#content-user-name")
             b.click(".display-language-menu a")
             b.wait_popup('display-language')
@@ -152,6 +151,26 @@ class TestApps(PackageCase):
             b.reload(ignore_cache=True)
             b.wait_present("#content")
             b.enter_page("/apps")
+
+        def login_switch(lang):
+            b.logout()
+            b.wait_present("#login")
+            b.wait_visible("#option-group")
+            b.click("#option-group span")
+            b.wait_visible("#language")
+            b.set_val("#language", lang)
+            b.expect_load()
+            b.login_and_go("/apps")
+            b.wait_present(".app-list")
+            b.wait_present(".app-list tr:contains('SUMMARY')")
+            b.click(".app-list tr:contains('SUMMARY')")
+
+        def set_lang(lang):
+            b.switch_to_top()
+            if b.is_present(".display-language-menu"):
+                legacy_switch(lang)
+            else:
+                login_switch(lang)
 
         set_lang("de-de")
         b.wait_present(".app-description:contains('DESCRIPTION:de')")

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -21,6 +21,34 @@
 import parent
 from testlib import *
 
+def legacy_switch(b, lang):
+    b.click("#content-user-name")
+    b.click(".display-language-menu a")
+    b.wait_popup('display-language')
+    b.set_val("#display-language select", lang)
+    b.click("#display-language-select-button")
+    b.expect_load()
+    # HACK: work around language switching in Chrome not working in current session (issue #8160)
+    b.reload(ignore_cache=True)
+    b.wait_present("#content")
+
+def login_switch(b, lang):
+    b.logout()
+    b.wait_present("#login")
+    b.wait_visible("#option-group")
+    b.click("#option-group span")
+    b.wait_visible("#language")
+    b.set_val("#language", lang)
+    b.expect_load()
+    b.login_and_go("/system")
+
+def set_lang(b):
+    b.switch_to_top()
+    if b.is_present(".display-language-menu"):
+        legacy_switch(b, "de-de")
+    else:
+        login_switch(b, "de-de")
+
 class TestPages(MachineCase):
     def testBasic(self):
         m = self.machine
@@ -124,16 +152,7 @@ WantedBy=default.target
             b.wait_present("#host-nav")
 
         # Lets try changing the language
-
-        b.click("#content-user-name")
-        b.click(".display-language-menu a")
-        b.wait_popup('display-language')
-        b.set_val("#display-language select", "de-de")
-        b.click("#display-language-select-button")
-        b.expect_load()
-        # HACK: work around language switching in Chrome not working in current session (issue #8160)
-        b.reload(ignore_cache=True)
-        b.wait_present("#content")
+        set_lang(b)
 
         # Check that the system page is translated
         b.go("/system")


### PR DESCRIPTION
Alternative to #7695. Launch the new session with a language. This allows the bridge to be translated
as well as fixes cache issues like #4784

Reopening as we need to figure out what to do about Oauth or kerberos authentication flows where users don't see the login form and thus are unable to select a language.