### PR TITLE
test: Merge and clean up kubevirt tests

### DIFF
--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -61,8 +61,6 @@ class TestOpenshift(MachineCase, OpenshiftCommonTests):
     def setUp(self):
         super(TestOpenshift, self).setUp()
 
-        print "======= done setUp"
-
         self.openshift = self.machines['openshift']
         self.openshift.upload(["verify/files/mock-app-openshift.json"], "/tmp")
         self.kubeconfig = os.path.join(self.tmpdir, "config")
@@ -87,6 +85,9 @@ class TestOpenshift(MachineCase, OpenshiftCommonTests):
         # Make sure we can write to kubeconfig
         m.execute("chown -R admin:admin /home/admin/.kube")
         self.login_and_go("/kubernetes")
+
+        # kubevirt not available, so should not show up in the menu
+        b.wait_not_present("#vms-menu-link")
 
         b.wait_present("#service-list")
         b.wait_in_text("#service-list", "docker-registry")
@@ -397,26 +398,7 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         wait(lambda: "Running" in o.execute("oc get pods | grep virt-controller"), delay=2) # is it deployed and up?
         wait(lambda: "No resources found" in o.execute("oc get vm 2>&1"), delay=2) # No VM created yet
 
-    def testKubevirtEnvironment(self):
-        self.bootstrapKubevirt()
-
-        o = self.openshift
-
-        o.execute("oc create -f /kubevirt/iscsi-demo-target.yaml") # disk for test VM
-        o.execute("oc create -f /kubevirt/vm.yaml") # let's create a VM
-        wait(lambda: "testvm" in o.execute("oc get vm"), delay=1)
-        wait(lambda: "virt-launcher-testvm" in o.execute("oc get pods"))
-        wait(lambda: "Running" in o.execute("oc get pods | grep virt-launcher-testvm"))
-
-    def testVirtualMachinesTabPresent(self):
-        self.bootstrapKubevirt()
-
-        b = self.browser
-        self.login_and_go("/kubernetes")
-        b.wait_present("#kubernetes-navigation")
-        self.assertTrue(b.is_present("#vms-menu-link"))
-
-    def testVirtualMachinesListed(self):
+    def testKubevirtMachinesList(self):
         self.bootstrapKubevirt()
 
         o = self.openshift
@@ -424,53 +406,28 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         o.execute("oc create -f /kubevirt/iscsi-demo-target.yaml")  # disk for test VM
         o.execute("oc create -f /kubevirt/vm.yaml")  # let's create a VM
         wait(lambda: "testvm" in o.execute("oc get vm"), msg='Deployment of virtual machine "testvm" failed.')
+        wait(lambda: "virt-launcher-testvm" in o.execute("oc get pods"))
+        wait(lambda: "Running" in o.execute("oc get pods | grep virt-launcher-testvm"))
 
         b = self.browser
         self.login_and_go("/kubernetes")
+        # kubevirt is available, so link should be present
         b.wait_present("#vms-menu-link")
         b.click("#vms-menu-link")
         b.wait_present("tr[data-row-id='vm-testvm']")
-        self.assertTrue(b.text("tr[data-row-id='vm-testvm'] th") == 'testvm')
+        self.assertEqual(b.text("tr[data-row-id='vm-testvm'] th"), "testvm")
 
-    def testVirtualMachineRowExpansion(self):
-        self.bootstrapKubevirt()
-
-        o = self.openshift
-        o.execute("oc create -f /kubevirt/iscsi-demo-target.yaml")  # disk for test VM
-        o.execute("oc create -f /kubevirt/vm.yaml")  # let's create a VM
-        wait(lambda: "testvm" in o.execute("oc get vm"), msg='Deployment of virtual machine "testvm" failed.')
-
-        b = self.browser
-        self.login_and_go("/kubernetes")
-        b.wait_present("#vms-menu-link")
-        b.click("#vms-menu-link")
-        b.wait_present("tr[data-row-id='vm-testvm']")
+        # expand row
         b.click("tr[data-row-id='vm-testvm']")
         b.wait_present("tr[data-row-id='vm-testvm'] + tr.listing-ct-panel")
-        self.assertTrue('Node' in b.text("tr[data-row-id='vm-testvm'] + tr.listing-ct-panel"))
+        b.wait_in_text("tr[data-row-id='vm-testvm'] + tr.listing-ct-panel", "Node")
 
-    def testVirtualMachineLinkToNode(self):
-        print 'start'
-        self.bootstrapKubevirt()
-        print 'kubevirt installed'
-
-        o = self.openshift
-        o.execute("oc create -f /kubevirt/iscsi-demo-target.yaml")  # disk for test VM
-        o.execute("oc create -f /kubevirt/vm.yaml")  # let's create a VM
-        wait(lambda: "testvm" in o.execute("oc get vm"), msg='Deployment of virtual machine "testvm" failed.')
-
-        b = self.browser
-        self.login_and_go("/kubernetes")
-        b.wait_present("#vms-menu-link")
-        b.click("#vms-menu-link")
-        b.wait_present("tr[data-row-id='vm-testvm']")
-        b.click("tr[data-row-id='vm-testvm']")
+        # link to node
         b.wait_present("tr[data-row-id='vm-testvm'] + tr.listing-ct-panel .vm-node")
-        node_not_assigned = '-'
         node_name = b.text("tr[data-row-id='vm-testvm'] + tr.listing-ct-panel .vm-node").strip()
-        if node_name != node_not_assigned:
-            b.click("tr[data-row-id='vm-testvm'] + tr.listing-ct-panel .vm-node a")
-            b.wait_js_cond('window.location.hash === "#/nodes/%s"' % (node_name,))
+        self.assertNotEqual(node_name, "-")  # `-` ==  unassigned
+        b.click("tr[data-row-id='vm-testvm'] + tr.listing-ct-panel .vm-node a")
+        b.wait_js_cond('window.location.hash === "#/nodes/%s"' % (node_name,))
 
 
 @skipImage("Kubernetes not packaged", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-i386")


### PR DESCRIPTION
 * The tests added in 2a7622d2 (add kubevirt VM list) have a high setup
   cost and don't modify VM state, so merge  them into one test case.
 * Remove some leftover debugging print statements.
 * Use more expressive assertion functions.
 * Remove the `if` condition whether the node is assigned; tests create
   a completely controlled environment and know that the node is
   assigned; avoids silently skipping parts of the test.
 * Check that the VM menu item is not present if kubevirt is not
   available.