### PR TITLE
bots: Add naughty override for AppArmor signal denial for libvirtd

### DIFF
--- a/bots/naughty/debian-testing/8467-apparmor-libvirt-signal
+++ b/bots/naughty/debian-testing/8467-apparmor-libvirt-signal
@@ -1,0 +1,1 @@
+audit: type=1400 * apparmor="DENIED" operation="signal" profile="/usr/sbin/libvirtd" pid=* comm="libvirtd" requested_mask="send" denied_mask="send" signal=kill peer="unconfined"


### PR DESCRIPTION
See known issue #8467
Downstream report: https://bugs.debian.org/887977