### PR TITLE
Fix size sliders after Patternfly update

### DIFF
--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -417,6 +417,7 @@ div.spinner {
 }
 
 .slider {
+    display: block;
     margin: 10px 10px;
     height: 5px;
     white-space: nowrap;

--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -535,6 +535,7 @@ li.credential-lock > a:first-child {
 }
 
 .slider {
+    display: block;
     margin: 10px 10px;
     height: 5px;
     white-space: nowrap;

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -258,6 +258,7 @@
  */
 
 .slider {
+    display: block;
     margin: 10px 10px;
     height: 5px;
     white-space: nowrap;


### PR DESCRIPTION
Patternfly 3.35.1 adds CSS for sliders, which collides with our slider
CSS.  This is a minimal fix.