### PR TITLE
subscriptions: Fix infinite hang for non-admin users

### DIFF
--- a/pkg/subscriptions/subscriptions-client.js
+++ b/pkg/subscriptions/subscriptions-client.js
@@ -105,7 +105,7 @@ function getSubscriptionDetails() {
     getDetailsRequested = false;
     gettingDetails = true;
     cockpit.spawn(['subscription-manager', 'list'],
-                  { directory: '/', superuser: "try", environ: ['LC_ALL=C'] })
+                  { directory: '/', superuser: "require", environ: ['LC_ALL=C'] })
         .done(function(output) {
             client.subscriptionStatus.products = parseMultipleSubscriptions(output);
         })
@@ -361,7 +361,7 @@ client.getSubscriptionStatus = function() {
      * 'subscription-manager status' will only return with exit code 0 if all is well (and subscriptions current)
      */
     cockpit.spawn(['subscription-manager', 'status'],
-                  { directory: '/', superuser: "try", environ: ['LC_ALL=C'], err: "out" })
+                  { directory: '/', superuser: "require", environ: ['LC_ALL=C'], err: "out" })
         .stream(function(text) {
             status_buffer += text;
         }).done(function(text) {

--- a/test/verify/check-subscriptions
+++ b/test/verify/check-subscriptions
@@ -250,5 +250,15 @@ class TestSubscriptions(MachineCase):
         # collapse again
         b.click(product_selector)
 
+        # now verify with an unprivileged user
+        if self.machine.image != "rhel-7-4":
+            b.logout()
+            self.machine.execute("useradd junior; echo junior:foobar | chpasswd")
+            self.login_and_go("/subscriptions", user="junior")
+            b.wait_present(".curtains-ct h1")
+            b.wait_in_text(".curtains-ct h1", "current user isn't allowed to access system subscription")
+            self.allow_authorize_journal_messages()
+
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
`subscription-manager list` and `status` fail with

    Error: this command requires root access to execute <unavailable>

for non-administrators. This causes the Subscriptions page to eternally
show the "Retrieving subscription status.." spinner.

Change the invocation to require superuser privileges (as other commands
on the page already do), to properly invoke the "current user isn't
allowed to access subscription status" curtain.

https://bugzilla.redhat.com/show_bug.cgi?id=1442540