### PR TITLE
test: Fix pyflakes errors

### DIFF
--- a/test/common/tap-cdp
+++ b/test/common/tap-cdp
@@ -24,7 +24,6 @@ import cdp
 import re
 import subprocess
 import sys
-import time
 
 tap_line_re = re.compile(r'^(ok [0-9]+|not ok [0-9]+|bail out!|[0-9]+\.\.[0-9]+|# )', re.IGNORECASE)
 

--- a/test/containers/check-bastion
+++ b/test/containers/check-bastion
@@ -26,11 +26,11 @@ base_dir = os.path.dirname(os.path.realpath(__file__))
 test_dir = os.path.abspath(os.path.join(base_dir, ".."))
 
 try:
-    import testlib
+    from common.testlib import *
 except:
     sys.path.append(test_dir)
+    from common.testlib import *
 
-from common.testlib import *
 from common.testvm import VirtMachine
 
 AUTH_KEY = os.path.join(test_dir, "containers/files/enc_rsa")


### PR DESCRIPTION
On current Fedora 27:

    test/common/tap-cdp:27: 'time' imported but unused
    test/containers/check-bastion:29: 'testlib' imported but unused
    not ok 2 pyflakes bots test