### PR TITLE
users: Prevent account details from showing spontaneously

### DIFF
--- a/pkg/users/index.html
+++ b/pkg/users/index.html
@@ -54,6 +54,8 @@
     </div>
   </div>
 
+  <div id="account-page">
+
   <div id="account-failure" class="curtains-ct blank-slate-pf" hidden>
     <div class="blank-slate-pf-icon">
       <i class="fa fa-exclamation-circle"></i>
@@ -149,6 +151,8 @@
       <div class="list-group" id="account-authorized-keys-list">
       </div>
     </div>
+  </div>
+
   </div>
 
   <div class="modal" id="accounts-create-dialog"

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -594,7 +594,7 @@ function PageAccountsCreate() {
 
 PageAccount.prototype = {
     _init: function(user) {
-        this.id = "account";
+        this.id = "account-page";
         this.section_id = "accounts";
         this.roles = [];
         this.role_template = $("#role-entry-tmpl").html();


### PR DESCRIPTION
The "#account" page would show itself whenever its "update" method is
called, which might happen at any time even when the user has
navigated away from that page.

Rather than making sure that "update" is never called at the wrong
moment, we wrap the page into a new div that encompasses both
"#account" and "#account-failure", and navigating shows/hides that
div.

Fixes #8476
Closes #....