### PR TITLE
build: rename `cockpit-ovirt` to `cockpit-machines-ovirt` package

### DIFF
--- a/doc/guide/feature-virtualmachines.xml
+++ b/doc/guide/feature-virtualmachines.xml
@@ -29,12 +29,12 @@
             of providers (i.e. <link linkend="feature-ovirtvirtualmachines">oVirt Virtual Machines</link>).
         </para>
         <para>
-            Both <emphasis>cockpit-ovirt</emphasis> and <emphasis>cockpit-machines</emphasis> RPM packages can be
+            Both <emphasis>cockpit-machines-ovirt</emphasis> and <emphasis>cockpit-machines</emphasis> RPM packages can be
             installed together but only one of them can be loaded at a time depending on the <emphasis>priority</emphasis>
             attribute set in <emphasis>manifest.json</emphasis> files.
         </para>
         <para>
-            By default, <emphasis>cockpit-ovirt</emphasis> takes precedence over <emphasis>cockpit-machines</emphasis>.
+            By default, <emphasis>cockpit-machines-ovirt</emphasis> takes precedence over <emphasis>cockpit-machines</emphasis>.
         </para>
 
     </section>

--- a/pkg/ovirt/install.sh
+++ b/pkg/ovirt/install.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# Installation script of the cockpit-machines-ovirt-provider.
-# Required to be called after RPM installation and before Cockpit Machines cockpit-machines-ovirt-provider is accessed.
+# Installation script of the cockpit-machines-ovirt.
+# Required to be called after RPM installation and before Cockpit Machines cockpit-machines-ovirt is accessed.
 #
 # Main task: update configuration files for Engine URL
 # Reason: Engine URL can't be determined from VDSM host automatically, so it must be provided by the user.
 #
 # What it does:
-#      update cockpit-ovirt runtime configuration (to assemble oVirt REST API URL)
+#      update cockpit-machines-ovirt runtime configuration (to assemble oVirt REST API URL)
 #
 # How to run:
 #      either manually after rpm installations as root:

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -141,7 +141,7 @@ class TestMachines(MachineCase):
     def setUp(self):
         MachineCase.setUp(self)
 
-        # enforce use of cockpit-machines instead of cockpit-ovirt
+        # enforce use of cockpit-machines instead of cockpit-machines-ovirt
         m = self.machine
         m.execute("sed -i 's/\"priority\".*$/\"priority\": 100,/' {0}".format("/usr/share/cockpit/machines/manifest.json"))
         m.execute("[ ! -e {0} ] || sed -i 's/\"priority\".*$/\"priority\": 0,/' {0}".format("/usr/share/cockpit/ovirt/manifest.json"))

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -391,6 +391,8 @@ class OstreeRestartCase(MachineCase):
         b.wait_in_text("table.listing-ct tbody:nth-child(3) div.packages", "contains the same packages as your currently booted")
 
         # Apply update
+        b.wait_present("table.listing-ct tbody:nth-child(3) div.listing-ct-actions button") # wait to be rendered
+        b.wait_not_present("table.listing-ct tbody:nth-child(3) div.listing-ct-actions button.disabled") # and enabled
         b.click("table.listing-ct tbody:nth-child(3) div.listing-ct-actions button")
         b.wait_present("table.listing-ct tbody:nth-child(3) div.ostree-progress")
         b.wait_not_present('table.listing-ct tbody:nth-child(3) div.listing-ct-error')

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -157,7 +157,7 @@ class OstreeRestartCase(MachineCase):
         rhsmcertd_hack(m)
 
         cockpit_shell = m.execute("rpm -qa | grep cockpit-ostree").strip()
-        cockpit_machines = m.execute("rpm -qa | grep cockpit-machines").strip()
+        cockpit_machines = m.execute("rpm -qa | grep cockpit-machines | grep -v cockpit-machines-ovirt").strip()
 
         self.login_and_go("/updates")
         b.enter_page("/updates")

--- a/test/verify/check-ovirt
+++ b/test/verify/check-ovirt
@@ -97,7 +97,7 @@ class TestOVirtMachines(MachineCase):
             wait(lambda: "up" in m.execute(cmd), delay=10)
 
     def enforce_cockpit_ovirt(self):
-        # enforce use of cockpit-ovirt instead of cockpit-machines
+        # enforce use of cockpit-machines-ovirt instead of cockpit-machines
         m = self.machine
         m.execute("sed -i 's/\"priority\".*$/\"priority\": 0,/' {0}".format("/usr/share/cockpit/machines/manifest.json"))
         m.execute("sed -i 's/\"priority\".*$/\"priority\": 100,/' {0}".format("/usr/share/cockpit/ovirt/manifest.json"))

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -337,17 +337,21 @@ The Cockpit components for managing virtual machines.
 
 %files machines -f machines.list
 
-%package ovirt
+%package machines-ovirt
 Summary: Cockpit user interface for oVirt virtual machines
 Requires: %{name}-bridge >= %{required_base}
 Requires: %{name}-system >= %{required_base}
 Requires: libvirt
 Requires: libvirt-client
+# package of old name "cockpit-ovirt" was shipped on fedora only
+%if 0%{?fedora} >= 25
+Obsoletes: %{name}-ovirt < 161
+%endif
 
-%description ovirt
+%description machines-ovirt
 The Cockpit components for managing oVirt virtual machines.
 
-%files ovirt -f ovirt.list
+%files machines-ovirt -f ovirt.list
 
 %package ostree
 Summary: Cockpit user interface for rpm-ostree

--- a/tools/gen-spec-dependencies
+++ b/tools/gen-spec-dependencies
@@ -40,6 +40,8 @@ for line in fileinput.input(sys.argv[1], inplace=True):
         assert curpkg, "spec file uses %{required_base} outside of %package stanza"
         # lazily determine this -- some packages don't use %{required_base} and some multiple times
         if not pkg_base_dep:
+            if "machines-ovirt" == curpkg:
+                curpkg = "ovirt"
             pkg_base_dep = subprocess.check_output([min_base_version_path, curpkg], universal_newlines=True).strip()
             sys.stderr.write('base dependency of %s: %s\n' % (curpkg, pkg_base_dep))
         line = line.replace("%{required_base}", pkg_base_dep)


### PR DESCRIPTION
Due to potential naming collision with [1], it's good to rename
the `cockpit-ovirt` rpm package to unique `cockpit-machines-ovirt`
before its first listing in official distribution channels.

Referenced by: https://bugzilla.redhat.com/show_bug.cgi?id=1515796

[1] https://gerrit.ovirt.org/#/admin/projects/cockpit-ovirt