### PR TITLE
users: Allow root account to be locked

### DIFF
--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -42,8 +42,7 @@ function update_accounts_privileged() {
             permission.user ? permission.user.name : '')
     );
     $(".accounts-privileged").find("input")
-        .attr('disabled', permission.allowed === false ||
-                          $('#account-user-name').text() === 'root');
+        .attr('disabled', permission.allowed === false);
 
     // enable fields for current account.
     $(".accounts-current-account").update_privileged(
@@ -57,6 +56,7 @@ function update_accounts_privileged() {
                                       _("Unable to delete root account"));
         $("#account-real-name-wrapper").update_privileged({allowed: false},
                                       _("Unable to rename root account"));
+        $("#account-real-name").prop('disabled', true);
     }
 }
 
@@ -927,7 +927,7 @@ PageAccount.prototype = {
             else
                 $('#account-last-login').text(this.lastLogin.toLocaleString());
 
-            if (typeof this.locked != 'undefined' && this.account["uid"] !== 0) {
+            if (typeof this.locked != 'undefined') {
                 $('#account-locked').prop('checked', this.locked);
                 $('#account-locked').prop('disabled', false);
             } else {

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -53,6 +53,27 @@ class TestAccounts(MachineCase):
         b.wait_visible("#accounts")
         b.wait_not_in_text('#accounts-list', "Anton Arbitrary")
 
+        # Check root user
+        b.go("#/root")
+        b.wait_present("#account")
+        b.wait_visible("#account")
+        b.wait_text("#account-user-name", "root")
+        # some operations are not allowed for root user
+        b.wait_present("#account-delete.disabled")
+        b.wait_present("#account-logout")
+        b.wait_attr("#account-logout", "disabled", "disabled")
+        b.wait_present("#account-real-name-wrapper.disabled")
+        b.wait_present("#account-locked:not(:checked)")
+        # root account should not be locked by default on our images
+        self.assertIn(m.execute("passwd -S root").split()[1], ["P", "PS"])
+        # now lock account
+        b.set_checked("#account-locked", True)
+        b.wait(lambda: m.execute("passwd -S root").split()[1] in ["L", "LK"])
+
+        # go back to accounts overview, check breadcrumb
+        b.click("#account .breadcrumb a")
+        b.wait_present("#accounts-create")
+
         # Create a user from the UI
         b.click('#accounts-create')
         b.wait_popup('accounts-create-dialog')


### PR DESCRIPTION
Commit b961df8825 introduced administering the root account, but
disabled (un)locking it. There is no good reason for that, as it can be
done on the command line, and is actually best practice after setting up
sudo users.

https://bugzilla.redhat.com/show_bug.cgi?id=1517484