### PR TITLE
examples: Fix failed pings in pinger

### DIFF
--- a/examples/pinger/ping.html
+++ b/examples/pinger/ping.html
@@ -45,8 +45,8 @@
         }
 
         function ping_fail() {
-            status.css("color", "red");
-            status.text("fail");
+            result.css("color", "red");
+            result.text("fail");
         }
 
         function ping_output(data) {


### PR DESCRIPTION
For failures, ping oopses with `status.css is not a function`. Indeed
it's not, touch the `result` field instead like for the success case.