### PR TITLE
system: Add initial hardware information page

### DIFF
--- a/pkg/lib/machine-info.es6
+++ b/pkg/lib/machine-info.es6
@@ -38,6 +38,10 @@ export function cpu_ram_info(address) {
                 if (total_kb)
                     info.memory = total_kb*1024;
 
+                match = text.match(new RegExp(/^model name\s*:\s*(.*)$/, "m"));
+                if (match)
+                    info.cpu_model = match[1];
+
                 info.cpus = 0;
                 var re = new RegExp("^processor", "gm");
                 while (re.test(text))

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -1474,6 +1474,11 @@ $("#link-disk").on("click", function() {
     return false;
 });
 
+$("#system_information_hardware_text").on("click", function() {
+    cockpit.jump("/system/hwinfo");
+    return false;
+});
+
 
 /*
  * INITIALIZATION AND NAVIGATION

--- a/pkg/systemd/hw-detect.es6
+++ b/pkg/systemd/hw-detect.es6
@@ -1,0 +1,74 @@
+/*jshint esversion: 6 */
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as machine_info from "machine-info.es6";
+
+// map an info.system key to a /sys/class/dmi/id/* attribute name
+const InfoDMIKey = {
+    version: "product_version",
+    name: "product_name",
+    type: "chassis_type_str",
+    bios_vendor: "bios_vendor",
+    bios_version: "bios_version",
+    bios_date: "bios_date",
+};
+
+function getDMI(info) {
+    return new Promise((resolve, reject) => {
+        machine_info.dmi_info()
+            .done(fields => {
+                Object.keys(InfoDMIKey).forEach(key => {
+                    info.system[key] = fields[InfoDMIKey[key]];
+                });
+                resolve();
+            })
+            .fail(reject);
+    });
+}
+
+export default function detect() {
+    let info = { system: { } };
+    var tasks = [];
+
+    tasks.push(new Promise((resolve, reject) => {
+        machine_info.cpu_ram_info()
+            .done(result => {
+                info.system.cpu_model = result.cpu_model;
+                info.system.nproc = result.cpus;
+                resolve();
+            });
+    }));
+
+    tasks.push(new Promise((resolve, reject) => {
+        getDMI(info)
+            .then(() => resolve())
+            .catch(error => {
+                // DMI only works on x86 machines; check devicetree (or what lshw does) on other arches
+                console.warn("Failed to get DMI information:", error.toString());
+                resolve();
+            });
+    }));
+
+    // return info after all task promises got done
+    return new Promise((resolve, reject) => {
+        Promise.all(tasks).then(() => resolve(info));
+    });
+}
+

--- a/pkg/systemd/hwinfo.css
+++ b/pkg/systemd/hwinfo.css
@@ -1,0 +1,12 @@
+@import "/table.css";
+
+/* show tbodys side by side on wide screens */
+@media screen and (min-width: 70rem) {
+  table.wide-split-table-ct {
+    width: 100%;
+  }
+  table.wide-split-table-ct tbody {
+    float: left;
+    width: 50%;
+  }
+}

--- a/pkg/systemd/hwinfo.html
+++ b/pkg/systemd/hwinfo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title translatable="yes">Hardware Information</title>
+    <meta charset="utf-8">
+    <link href="../base1/patternfly.css" type="text/css" rel="stylesheet">
+    <link href="system.css" type="text/css" rel="stylesheet">
+    <link href="hwinfo.css" type="text/css" rel="stylesheet">
+    <script src="../base1/cockpit.js"></script>
+    <script src="../*/po.js"></script>
+</head>
+<body>
+    <div id="hwinfo"></div>
+    <script src="hwinfo.js"></script>
+</body>
+</html>

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+
+import detect from "./hw-detect.es6";
+
+const _ = cockpit.gettext;
+
+const SystemInfo = ({ info }) => (
+    <table className="info-table-ct wide-split-table-ct">
+        <tbody>
+            <tr>
+                <th>{ _("Type") }</th>
+                <td>{ info.type }</td>
+            </tr>
+            <tr>
+                <th>{ _("Name") }</th>
+                <td>{ info.name }</td>
+            </tr>
+            <tr>
+                <th>{ _("Version") }</th>
+                <td>{ info.version }</td>
+            </tr>
+        </tbody>
+        <tbody>
+            <tr>
+                <th>{ _("BIOS") }</th>
+                <td>{ info.bios_vendor }</td>
+            </tr>
+            <tr>
+                <th>{ _("BIOS version") }</th>
+                <td>{ info.bios_version }</td>
+            </tr>
+            <tr>
+                <th>{ _("BIOS date") }</th>
+                <td>{ info.bios_date }</td>
+            </tr>
+            <tr>
+                <th>{ _("CPU") }</th>
+                <td>{ (info.nproc > 1) ? `${info.nproc}x ${info.cpu_model}` : info.cpu_model }</td>
+            </tr>
+        </tbody>
+    </table>
+);
+
+// FIXME: breadcrumb System link is broken
+const HardwareInfo = ({ info }) => (
+    <div className="page-ct container-fluid">
+        <ol className="breadcrumb">
+            <li><a onClick={ () => cockpit.jump("/system", cockpit.transport.host) }>{ _("System") }</a></li>
+            <li className="active">{ _("Hardware Information") }</li>
+        </ol>
+
+        <h2>{ _("System Information") }</h2>
+        <SystemInfo info={info.system}/>
+    </div>
+);
+
+document.addEventListener("DOMContentLoaded", () => {
+    document.title = cockpit.gettext(document.title);
+    detect().then(info => {
+        console.debug("hardware info collection data:", JSON.stringify(info));
+        React.render(<HardwareInfo info={info} />, document.getElementById("hwinfo"));
+    });
+});

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -85,7 +85,7 @@
             <table class="info-table-ct">
                 <tr>
                     <td translatable="yes">Hardware</td>
-                    <td id="system_information_hardware_text"></td>
+                    <td><a id="system_information_hardware_text"></a></td>
                 </tr>
                 <tr id="system-info-asset-row">
                     <td translatable="yes">Asset Tag</td>

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -334,5 +334,32 @@ class TestSystemInfo(MachineCase):
         # because of the reload
         self.allow_restart_journal_messages()
 
+    @skipImage("Introduced in Cockpit 161", "rhel-7-4")
+    def testHardwareInfo(self):
+        b = self.browser
+
+        self.login_and_go("/system")
+        b.wait_present('#system_information_hardware_text')
+        b.wait_visible('#system_information_hardware_text')
+        b.wait_in_text('#system_information_hardware_text', "QEMU")
+        b.click('#system_information_hardware_text')
+        b.enter_page("/system/hwinfo")
+
+        b.wait_present('#hwinfo .info-table-ct')
+        b.wait_in_text('#hwinfo .info-table-ct', "CPU")
+        # QEMU VM type
+        b.wait_in_text('#hwinfo .info-table-ct tbody:nth-of-type(1) tr:nth-of-type(1) td', "Other")
+        # Name
+        b.wait_in_text('#hwinfo .info-table-ct tbody:nth-of-type(1) tr:nth-of-type(2) td', "Standard PC")
+        # BIOS
+        b.wait_in_text('#hwinfo .info-table-ct tbody:nth-of-type(2) tr:nth-of-type(1) td', "SeaBIOS")
+        # BIOS date; just ensure it's from this century
+        b.wait_in_text('#hwinfo .info-table-ct tbody:nth-of-type(2) tr:nth-of-type(3) td', "/20")
+
+        # go back to system page
+        b.click('.breadcrumb a')
+        b.enter_page("/system")
+
+
 if __name__ == '__main__':
     test_main()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -137,6 +137,10 @@ var info = {
             "systemd/terminal.jsx",
             "systemd/terminal.css",
         ],
+        "systemd/hwinfo": [
+            "systemd/hwinfo.jsx",
+            "systemd/hwinfo.css",
+        ],
 
         "tuned/performance": [
             "tuned/dialog.js",
@@ -246,6 +250,7 @@ var info = {
         "systemd/logs.html",
         "systemd/services.html",
         "systemd/terminal.html",
+        "systemd/hwinfo.html",
 
         "users/index.html",
     ]


### PR DESCRIPTION
This can be reached through clicking on the "Hardware" name on the
System page.

Show global system properties for now, such as system type, name,
version, and BIOS information. Split the table into two horizontal parts
on wide enough screens.

This does not show any subsystem devices yet.

https://github.com/cockpit-project/cockpit/wiki/Feature:-Hardware-View

- [x] spread out table horizontally on wide screen as per design
- [x] add tests