### PR TITLE
users: Add more passwd expect cases

### DIFF
--- a/pkg/users/local.es6
+++ b/pkg/users/local.es6
@@ -68,7 +68,9 @@ function passwd_self(old_pass, new_pass) {
     ];
     var new_exps = [
         /.*New password: $/,
-        /.*Retype new password: $/
+        /.*Retype new password: $/,
+        /.*Enter new \w*\s?password: $/,
+        /.*Retype new \w*\s?password: $/
     ];
     var bad_exps = [
         /.*BAD PASSWORD:.*/


### PR DESCRIPTION
In some systems (like Ubuntu) the passwd command returns "Enter new UNIX password", instead of "New password", when changing user's password, because of this difference it was not possible to change the current user password using the cockpit interface.
The "UNIX" statement can also be "LDPA" or any other authentication provider and because of this I added a regex instead of fixed system name.