### PR TITLE
package.json: Update jQuery to current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bootstrap-datepicker": "1.7.1",
     "c3": "0.4.18",
     "d3": "3.5.17",
-    "jquery": "2.2.4",
+    "jquery": "3.3.1",
     "jquery-flot": "0.8.3",
     "kubernetes-container-terminal": "1.0.3",
     "kubernetes-object-describer": "1.1.4",

--- a/pkg/lib/patterns.js
+++ b/pkg/lib/patterns.js
@@ -230,7 +230,7 @@
         /* During testing, no Cockpit dependency */
         var _ = cockpit.gettext || function(x) { return x; };
 
-        sel = sel.find(".btn-onoff-ct").andSelf().filter(".btn-onoff-ct");
+        sel = sel.find(".btn-onoff-ct").addBack().filter(".btn-onoff-ct");
         sel.each(function(x, el) {
             var self = $(el)
                 .attr("data-toggle", "buttons")

--- a/pkg/shell/credentials.js
+++ b/pkg/shell/credentials.js
@@ -271,7 +271,7 @@
                         if (!(id in rows)) {
                             row = rows[id] = body.clone();
                             row.attr("data-id", id)
-                                .show()
+                                .removeAttr("hidden")
                                 .onoff();
                             table.append(row);
                         }


### PR DESCRIPTION
This fixes several marked outstanding vulnerabilities, They do not actually affect Cockpit (see below), but one of these days one will, so let's not fall behind too much.

---
This is just an initial CI run to see what breaks.

This is formally an API break. Conceptually we should never have made this a public API, but here we are.. To actually land this, we need to do several things:

 - [x] Review jQuery upstream changelog and [upgrade guide](https://jquery.com/upgrade-guide/3.0/) for things to watch out. I went through all breaking changes, and verified that the ones *not* mentioned below don't affect us:
   - https://jquery.com/upgrade-guide/3.0/#breaking-change-removeattr-no-longer-sets-properties-to-false : used a lot, needs UI testing (but tests should cover most of this)
   - https://jquery.com/upgrade-guide/3.0/#breaking-change-return-values-on-empty-sets-are-undefined : I went through all usages and they are not collections, so this should be okay
   - https://jquery.com/upgrade-guide/3.0/#breaking-change-return-values-on-empty-sets-are-undefined :our tests ought to catch this, but watch out in manual testing
   -  https://jquery.com/upgrade-guide/3.0/#breaking-change-width-height-css-quot-width-quot-and-css-quot-height-quot-can-return-non-integer-values : could cause visual-only UI changes
   - https://jquery.com/upgrade-guide/3.0/#breaking-change-show-hide-and-toggle-methods-now-respect-more-stylesheet-changes - one instance got caught by tests, but watch out in manual testing
   - https://jquery.com/upgrade-guide/3.0/#breaking-change-on-quot-ready-quot-fn-removed - used once in pkg/shell/indexes.js, verify multiple machines (although tests cover this)
 - [X] Fix removed `andSelf()`
 - [x] Fix display of SSH keys in authentication menu dialog (spotted by check-keys)

 - [x] Research which external Cockpit modules use the bundled jQuery and test/update/port them away if necessary. Particularly in Fedora/Red Hat, but also check GitHub.
   - [X] welder-web: Uses its own jquery
   - [X] [subscription-manager](https://github.com/candlepin/subscription-manager/tree/master/cockpit/src): doesn't use jquery at all
   - [x] https://github.com/dpmramesh/cockpit-gluster : uses cockpit's jquery, but looks safe; filed https://github.com/dpmramesh/cockpit-gluster/issues/2
   - [x] https://github.com/kubevirt/cockpit-demo : does not use jquery
   - [x] https://github.com/cmucc/cockpit-libvirt : uses cockpit's jquery, but just a prototype and usage looks ok; filed https://github.com/cmucc/cockpit-libvirt/issues/1
   - [x] https://github.com/RedHatQE/rhsm-cockpit-qe : does not use jquery
   - [x] https://github.com/garrett/cockpit-mockweb : just docs
   - [x] https://github.com/mvollmer/cockpit-app-freeipa : uses its own jquery
   - [x] https://github.com/abbra/cockpit-app-samba-ad : uses its own jquery
   - [x] https://github.com/mvollmer/cockpit-apps-bin : bundles cockpit's jquery, but looks safe; filed https://github.com/mvollmer/cockpit-apps-bin/issues/1
   - [x] https://github.com/oVirt/cockpit-machines-ovirt-provider : obsolete, in cockpit proper now
   - [x] https://github.com/NethServer/nethserver-cockpit : uses cockpit-bundled jquery in tests only; project disabled issues, so *shrug* 
   - [x] https://github.com/cockpit-project/starter-kit : does not use jquery
   - [x] https://github.com/abrt/cockpit-abrt : uses cockpit-bundled jquery and hide/show, could be affected; filed https://github.com/abrt/cockpit-abrt/issues/10 - *update*: just a PoC project, obsolete, landed in cockpit proper
   - [x] https://github.com/hellcatz/zcash-cli-cockpit: uses cockpit-bundled jquery, unsure if affected; filed https://github.com/hellcatz/zcash-cli-cockpit/issues/2
   - [ ] https://github.com/fleet-commander/fc-admin: uses cockpit-bundled jquery; filed https://github.com/fleet-commander/fc-admin/issues/165

 - [x] Update our documentation and examples (PR #8504)
 - [x] Announce on [mailing list](https://lists.fedorahosted.org/archives/list/cockpit-devel@lists.fedorahosted.org/thread/TDBKI4372I4ZPGQFCZB377DX2QG2YDDY/)
 - [X] Evaluate impact of the above CVEs and check whether anything needs to be fixed in back branches.
  * [CVE-2015-9251](https://nvd.nist.gov/vuln/detail/CVE-2015-9251): Doesn't affect shipped product; only pkg/lib/machines.js and bots/task/log.html use `.ajax()` but with a `dataType` option. But might be good to update jQuery in  bots/task/log.html.
  * [CVE-2016-10707](https://nvd.nist.gov/vuln/detail/CVE-2016-10707): This was introduced after 2.2.x, our current version still does the `.toLowerCase()`. Thus does not affect us.
 - [x] Manually test all the pages to ensure event handlers etc. work correctly; our tests might not catch all issues here.