### PR TITLE
test: Don't use asynchronous signals to interrupt a wait

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -240,17 +240,12 @@ class Browser:
         return r
 
     def wait(self, predicate):
-        def alarm_handler(signum, frame):
-            raise Error('timed out waiting for predicate to become true')
-
-        signal.signal(signal.SIGALRM, alarm_handler)
-        orig_handler = signal.alarm(self.cdp.timeout)
-        while True:
+        for _ in range(self.cdp.timeout * 5):
             val = predicate()
             if val:
-                signal.alarm(0)
-                signal.signal(signal.SIGALRM, orig_handler)
                 return val
+            time.sleep(0.2)
+        raise Error('timed out waiting for predicate to become true')
 
     def wait_js_cond(self, cond):
         result = self.cdp.invoke("Runtime.evaluate",


### PR DESCRIPTION
The handler might interrupt things at unexpected times, such as in the
middle of a CDP call, which knocks the protocol out of synch.  A
subsequent CDP call to create a snapshot would see the reply for the
previous command, not its own.