### PR TITLE
Tighten up the default Content-Security-Policy

### DIFF
--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -91,8 +91,9 @@ $ cockpit-bridge --packages
             <ulink url="https://en.wikipedia.org/wiki/Content_Security_Policy">Content Security Policy</ulink>,
             which among other things does not allow inline styles or scripts. This can
             be overriden on a per-package basis, with this setting.</para>
-          <para>If the overriden content security policy does not contain a <code>default-src</code> or
-            <code>connect-src</code> these will be added to the policy from the manifest.</para>
+          <para>If the overriden content security policy does not contain a <code>default-src</code>,
+            <code>connect-src</code>, <code>base-uri</code>, <code>form-action</code>, <code>object-src</code>,
+            or <code>block-all-mixed-content</code> then these will be added to the policy from the manifest.</para>
         </listitem>
       </varlistentry>
       <varlistentry>

--- a/src/base1/test-http.js
+++ b/src/base1/test-http.js
@@ -166,7 +166,9 @@ QUnit.asyncTest("headers", function() {
                     "Header1": "booo",
                     "Header2": "yay value",
                     "Header3": "three",
-                    "Header4": "marmalade"
+                    "Header4": "marmalade",
+                    "Referrer-Policy": "no-referrer",
+                    "X-DNS-Prefetch-Control": "off",
             }, "got back headers");
         })
         .always(function() {
@@ -202,7 +204,9 @@ QUnit.asyncTest("connection headers", function() {
                     "Header1": "booo",
                     "Header2": "yay value",
                     "Header3": "three",
-                    "Header4": "marmalade"
+                    "Header4": "marmalade",
+                    "Referrer-Policy": "no-referrer",
+                    "X-DNS-Prefetch-Control": "off",
             }, "got back combined headers");
         })
         .always(function() {

--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -930,6 +930,9 @@ package_content (CockpitPackages *packages,
   const gchar *type;
   gchar *policy;
 
+  if (!self_origin)
+    self_origin = cockpit_web_response_get_origin (response);
+
   globbing = g_str_equal (name, "*");
   if (globbing)
     names = g_hash_table_get_keys (packages->listing);

--- a/src/bridge/test-httpstream.c
+++ b/src/bridge/test-httpstream.c
@@ -157,7 +157,7 @@ test_host_header (TestGeneral *tt,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_combine_output (tt->transport, "444", &count);
-  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{}}Da Da Da", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\"}}Da Da Da", -1);
   g_assert_cmpuint (count, ==, 2);
   g_bytes_unref (data);
 }
@@ -222,7 +222,7 @@ test_http_stream2 (TestGeneral *tt,
   object = mock_transport_pop_control (tt->transport);
   cockpit_assert_json_eq (object, "{\"command\":\"ready\",\"channel\":\"444\"}");
   object = mock_transport_pop_control (tt->transport);
-  cockpit_assert_json_eq (object, "{\"command\":\"response\",\"channel\":\"444\",\"status\":200,\"reason\":\"OK\",\"headers\":{}}");
+  cockpit_assert_json_eq (object, "{\"command\":\"response\",\"channel\":\"444\",\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\"}}");
 
   data = mock_transport_combine_output (tt->transport, "444", &count);
   cockpit_assert_bytes_eq (data, "Da Da Da", -1);
@@ -344,7 +344,7 @@ test_http_chunked (void)
   GBytes *data = NULL;
 
   const gchar *control;
-  gchar *expected = g_strdup_printf ("{\"status\":200,\"reason\":\"OK\",\"headers\":{}}%0*d", MAGIC_NUMBER, 0);
+  gchar *expected = g_strdup_printf ("{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\"}}%0*d", MAGIC_NUMBER, 0);
   guint count;
   guint port;
 
@@ -539,7 +539,7 @@ test_tls_basic (TestTls *test,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_combine_output (test->transport, "444", NULL);
-  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{}}Oh Marmalaade!", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\"}}Oh Marmalaade!", -1);
 
   g_bytes_unref (data);
 
@@ -701,7 +701,7 @@ test_tls_certificate (TestTls *test,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_combine_output (test->transport, "444", NULL);
-  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{}}Oh Marmalaade!", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\"}}Oh Marmalaade!", -1);
 
   g_bytes_unref (data);
 
@@ -766,7 +766,7 @@ test_tls_authority_good (TestTls *test,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_combine_output (test->transport, "444", NULL);
-  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{}}Oh Marmalaade!", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\"}}Oh Marmalaade!", -1);
 
   g_bytes_unref (data);
 

--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -189,7 +189,7 @@ test_simple (TestCase *tc,
   g_assert_cmpstr (tc->problem, ==, NULL);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
-  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Cache-Control\":\"no-cache, no-store\"}}"
+  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"Cache-Control\":\"no-cache, no-store\"}}"
                            "These are the contents of file.ext\nOh marmalaaade\n", -1);
   g_assert_cmpuint (count, ==, 2);
   g_bytes_unref (data);
@@ -214,7 +214,7 @@ test_forwarded (TestCase *tc,
   g_assert_cmpstr (tc->problem, ==, NULL);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
-  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Content-Security-Policy\":\"default-src 'self' https://blah:9090; connect-src 'self' https://blah:9090 ws: wss:\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\",\"Access-Control-Allow-Origin\":\"https://blah:9090\"}}<html>\x0A<head>\x0A<title>In home dir</title>\x0A</head>\x0A<body>In home dir</body>\x0A</html>\x0A", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' https://blah:9090; connect-src 'self' https://blah:9090 wss://blah:9090; form-action 'self' https://blah:9090; base-uri 'self' https://blah:9090; object-src 'none'; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\",\"Access-Control-Allow-Origin\":\"https://blah:9090\"}}<html>\x0A<head>\x0A<title>In home dir</title>\x0A</head>\x0A<body>In home dir</body>\x0A</html>\x0A", -1);
   g_assert_cmpuint (count, ==, 2);
   g_bytes_unref (data);
 }
@@ -222,6 +222,7 @@ test_forwarded (TestCase *tc,
 static const Fixture fixture_pig = {
   .path = "/another/test.html",
   .accept = { "pig" },
+  .headers = { "Host", "blah:9090" },
 };
 
 static void
@@ -238,7 +239,7 @@ test_localized_translated (TestCase *tc,
   g_assert_cmpstr (tc->problem, ==, NULL);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
-  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Content-Security-Policy\":\"default-src 'self'; connect-src 'self' ws: wss:\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}<html>\n<head>\n<title>Inlay omehay irday</title>\n</head>\n<body>Inlay omehay irday</body>\n</html>\n", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' http://blah:9090; connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}<html>\n<head>\n<title>Inlay omehay irday</title>\n</head>\n<body>Inlay omehay irday</body>\n</html>\n", -1);
   g_assert_cmpuint (count, ==, 2);
   g_bytes_unref (data);
 }
@@ -246,6 +247,7 @@ test_localized_translated (TestCase *tc,
 static const Fixture fixture_unknown = {
   .path = "/another/test.html",
   .accept = { "unknown" },
+  .headers = { "Host", "blah:9090" },
 };
 
 static void
@@ -262,7 +264,7 @@ test_localized_unknown (TestCase *tc,
   g_assert_cmpstr (tc->problem, ==, NULL);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
-  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Content-Security-Policy\":\"default-src 'self'; connect-src 'self' ws: wss:\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}<html>\n<head>\n<title>In home dir</title>\n</head>\n<body>In home dir</body>\n</html>\n", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' http://blah:9090; connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}<html>\n<head>\n<title>In home dir</title>\n</head>\n<body>In home dir</body>\n</html>\n", -1);
   g_assert_cmpuint (count, ==, 2);
   g_bytes_unref (data);
 }
@@ -270,6 +272,7 @@ test_localized_unknown (TestCase *tc,
 static const Fixture fixture_prefer_region = {
   .path = "/another/test.html",
   .accept = { "pig-pen" },
+  .headers = { "Host", "blah:9090" },
 };
 
 static void
@@ -286,7 +289,7 @@ test_localized_prefer_region (TestCase *tc,
   g_assert_cmpstr (tc->problem, ==, NULL);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
-  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Content-Security-Policy\":\"default-src 'self'; connect-src 'self' ws: wss:\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}<html>\n<head>\n<title>Inway omeha irda</title>\n</head>\n<body>Inway omeha irda</body>\n</html>\n", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' http://blah:9090; connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}<html>\n<head>\n<title>Inway omeha irda</title>\n</head>\n<body>Inway omeha irda</body>\n</html>\n", -1);
   g_assert_cmpuint (count, ==, 2);
   g_bytes_unref (data);
 }
@@ -294,6 +297,7 @@ test_localized_prefer_region (TestCase *tc,
 static const Fixture fixture_fallback = {
   .path = "/another/test.html",
   .accept = { "pig-barn" },
+  .headers = { "Host", "blah:9090" },
 };
 
 static void
@@ -310,7 +314,7 @@ test_localized_fallback (TestCase *tc,
   g_assert_cmpstr (tc->problem, ==, NULL);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
-  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Content-Security-Policy\":\"default-src 'self'; connect-src 'self' ws: wss:\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}<html>\n<head>\n<title>Inlay omehay irday</title>\n</head>\n<body>Inlay omehay irday</body>\n</html>\n", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' http://blah:9090; connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}<html>\n<head>\n<title>Inlay omehay irday</title>\n</head>\n<body>Inlay omehay irday</body>\n</html>\n", -1);
   g_assert_cmpuint (count, ==, 2);
   g_bytes_unref (data);
 }
@@ -333,7 +337,7 @@ test_incompatible_version (TestCase *tc,
   g_assert_cmpstr (tc->problem, ==, NULL);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
-  cockpit_assert_bytes_eq (data, "{\"status\":503,\"reason\":\"This package requires Cockpit version 999.5 or later\",\"headers\":{\"Content-Type\":\"text/html; charset=utf8\"}}<html><head><title>This package requires Cockpit version 999.5 or later</title></head><body>This package requires Cockpit version 999.5 or later</body></html>\n", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":503,\"reason\":\"This package requires Cockpit version 999.5 or later\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"Content-Type\":\"text/html; charset=utf8\"}}<html><head><title>This package requires Cockpit version 999.5 or later</title></head><body>This package requires Cockpit version 999.5 or later</body></html>\n", -1);
   g_bytes_unref (data);
 }
 
@@ -355,7 +359,7 @@ test_incompatible_requires (TestCase *tc,
   g_assert_cmpstr (tc->problem, ==, NULL);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
-  cockpit_assert_bytes_eq (data, "{\"status\":503,\"reason\":\"This package is not compatible with this version of Cockpit\",\"headers\":{\"Content-Type\":\"text/html; charset=utf8\"}}<html><head><title>This package is not compatible with this version of Cockpit</title></head><body>This package is not compatible with this version of Cockpit</body></html>\n", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":503,\"reason\":\"This package is not compatible with this version of Cockpit\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"Content-Type\":\"text/html; charset=utf8\"}}<html><head><title>This package is not compatible with this version of Cockpit</title></head><body>This package is not compatible with this version of Cockpit</body></html>\n", -1);
   g_bytes_unref (data);
 }
 
@@ -389,7 +393,7 @@ test_large (TestCase *tc,
 
   /* Should not have been sent as one block */
   g_assert_cmpuint (count, ==, 8);
-  prefix = "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Cache-Control\":\"no-cache, no-store\"}}";
+  prefix = "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"Cache-Control\":\"no-cache, no-store\"}}";
   g_assert_cmpuint (g_bytes_get_size (data), >, strlen (prefix));
   g_assert (strncmp (g_bytes_get_data (data, NULL), prefix, strlen (prefix)) == 0);
   sub = g_bytes_new_from_bytes (data, strlen (prefix), g_bytes_get_size (data) - strlen (prefix));
@@ -422,7 +426,7 @@ test_listing (TestCase *tc,
   object = cockpit_json_parse_bytes (message, &error);
   g_assert_no_error (error);
   cockpit_assert_json_eq (object,
-                          "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Cache-Control\":\"no-cache, no-store\",\"Content-Type\":\"application/json\"}}");
+                          "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"Cache-Control\":\"no-cache, no-store\",\"Content-Type\":\"application/json\"}}");
   json_object_unref (object);
 
   message = mock_transport_pop_channel (tc->transport, "444");
@@ -479,7 +483,7 @@ test_not_found (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_pop_channel (tc->transport, "444");
-  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
 }
 
 static const Fixture fixture_unknown_package = {
@@ -498,7 +502,7 @@ test_unknown_package (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_pop_channel (tc->transport, "444");
-  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
 }
 
 static const Fixture fixture_no_path = {
@@ -517,7 +521,7 @@ test_no_path (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_pop_channel (tc->transport, "444");
-  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
 }
 
 static const Fixture fixture_bad_path = {
@@ -536,7 +540,7 @@ test_bad_path (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_pop_channel (tc->transport, "444");
-  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
 }
 
 static const Fixture fixture_no_package = {
@@ -555,7 +559,7 @@ test_no_package (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_pop_channel (tc->transport, "444");
-  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
 }
 
 static const Fixture fixture_bad_package = {
@@ -576,7 +580,7 @@ test_bad_package (TestCase *tc,
     g_main_context_iteration (NULL, TRUE);
 
   data = mock_transport_pop_channel (tc->transport, "444");
-  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":404,\"reason\":\"Not Found\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"Content-Type\":\"text/html; charset=utf8\"}}", -1);
 }
 
 static void
@@ -617,7 +621,8 @@ test_list_bad_name (TestCase *tc,
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
   cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":"
-                                     "{\"X-Cockpit-Pkg-Checksum\":\"524d07b284cda92c86a908c67014ee882a80193b\",\"Content-Type\":\"application/json\",\"ETag\":\"\\\"$524d07b284cda92c86a908c67014ee882a80193b\\\"\"}}"
+                                     "{\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\","
+                                     "\"X-Cockpit-Pkg-Checksum\":\"524d07b284cda92c86a908c67014ee882a80193b\",\"Content-Type\":\"application/json\",\"ETag\":\"\\\"$524d07b284cda92c86a908c67014ee882a80193b\\\"\"}}"
                                  "{\".checksum\":\"524d07b284cda92c86a908c67014ee882a80193b\",\"ok\":{\".checksum\":\"524d07b284cda92c86a908c67014ee882a80193b\"}}", -1);
   g_assert_cmpuint (count, ==, 2);
   g_bytes_unref (data);
@@ -643,7 +648,7 @@ test_glob (TestCase *tc,
   message = mock_transport_pop_channel (tc->transport, "444");
   object = cockpit_json_parse_bytes (message, &error);
   g_assert_no_error (error);
-  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-Cockpit-Pkg-Checksum\":\"4f2a5a7bb5bf355776e1fc83831b1d846914182e\",\"Content-Type\":\"text/plain\"}}");
+  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"X-Cockpit-Pkg-Checksum\":\"4f2a5a7bb5bf355776e1fc83831b1d846914182e\",\"Referrer-Policy\":\"no-referrer\",\"Content-Type\":\"text/plain\"}}");
   json_object_unref (object);
 
   message = mock_transport_pop_channel (tc->transport, "444");
@@ -977,6 +982,7 @@ test_reload_updated (TestCase *tc,
 static const Fixture fixture_csp_strip = {
   .path = "/strip/test.html",
   .datadirs = { SRCDIR "/src/bridge/mock-resource/csp", NULL },
+  .headers = { "Host", "blah:9090" },
 };
 
 static void
@@ -993,7 +999,7 @@ test_csp_strip (TestCase *tc,
   g_assert_cmpstr (tc->problem, ==, NULL);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
-  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-Cockpit-Pkg-Checksum\":\"0c58347ff749c5918f7f311c109369c377dc2ba1\",\"Content-Type\":\"text/html\",\"Content-Security-Policy\":\"connect-src 'self' ws: wss:; img-src: 'self' data:; default-src 'self'\"}}<html>\x0A<head>\x0A<title>Test</title>\x0A</head>\x0A<body>Test</body>\x0A</html>\x0A", -1);
+  cockpit_assert_bytes_eq (data, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"X-DNS-Prefetch-Control\":\"off\",\"X-Cockpit-Pkg-Checksum\":\"0c58347ff749c5918f7f311c109369c377dc2ba1\",\"Content-Type\":\"text/html\",\"Referrer-Policy\":\"no-referrer\",\"Content-Security-Policy\":\"connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; block-all-mixed-content; img-src: 'self' http://blah:9090 data:; default-src 'self' http://blah:9090\"}}<html>\x0A<head>\x0A<title>Test</title>\x0A</head>\x0A<body>Test</body>\x0A</html>\x0A", -1);
   g_assert_cmpuint (count, ==, 2);
   g_bytes_unref (data);
 }

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -143,6 +143,8 @@ void         cockpit_web_response_set_cache_type         (CockpitWebResponse *se
 
 const gchar *  cockpit_web_response_get_url_root         (CockpitWebResponse *response);
 
+const gchar *  cockpit_web_response_get_origin           (CockpitWebResponse *response);
+
 const gchar *  cockpit_web_response_get_protocol         (GIOStream *connection,
                                                           GHashTable *headers);
 

--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -134,7 +134,8 @@ test_return_content (TestCase *tc,
   g_bytes_unref (content);
 
   resp = output_as_string (tc);
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nthe content");
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Length: 11\r\n"
+                   "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\nthe content");
 }
 
 static void
@@ -154,7 +155,7 @@ test_return_content_headers (TestCase *tc,
   g_hash_table_destroy (headers);
 
   resp = output_as_string (tc);
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nMy-header: my-value\r\nContent-Length: 11\r\n\r\nthe content");
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nMy-header: my-value\r\nContent-Length: 11\r\nX-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\nthe content");
 }
 
 
@@ -173,6 +174,8 @@ test_return_error (TestCase *tc,
     "HTTP/1.1 500 Reason here: booyah\r\n"
     "Content-Type: text/html; charset=utf8\r\n"
     "Transfer-Encoding: chunked\r\n"
+    "X-DNS-Prefetch-Control: off\r\n"
+    "Referrer-Policy: no-referrer\r\n"
     "\r\n"
     "13\r\n<html><head><title>\r\n"
     "13\r\nReason here: booyah\r\n"
@@ -357,7 +360,7 @@ test_template (TestCase *tc,
   cockpit_web_response_template (tc->response, NULL, roots, data);
 
   resp = output_as_string (tc);
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Type: text/css\r\nTransfer-Encoding: chunked\r\n\r\n17\r\n#brand {\n    content: \"\r\n4\r\ntest\r\n4\r\n <b>\r\n5\r\nVALUE\r\n9\r\n</b>\";\n}\n\r\n0\r\n\r\n");
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Type: text/css\r\nTransfer-Encoding: chunked\r\nX-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\n17\r\n#brand {\n    content: \"\r\n4\r\ntest\r\n4\r\n <b>\r\n5\r\nVALUE\r\n9\r\n</b>\";\n}\n\r\n0\r\n\r\n");
   g_hash_table_unref (data);
 }
 
@@ -451,7 +454,8 @@ test_content_encoding (TestCase *tc,
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_SENT);
 
   g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Encoding: blah\r\n"
-                   "Content-Length: 50\r\nTransfer-Encoding: chunked\r\n\r\n"
+                   "Content-Length: 50\r\nTransfer-Encoding: chunked\r\n"
+                   "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\n"
                    "26\r\nCockpit is perfect for new sysadmins, \r\n0\r\n\r\n");
 }
 
@@ -483,7 +487,8 @@ test_stream (TestCase *tc,
   resp = output_as_string (tc);
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_SENT);
 
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nthe content");
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Length: 11\r\n"
+                   "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\nthe content");
 }
 
 static void
@@ -516,7 +521,8 @@ test_head (TestCase *tc,
   resp = output_as_string (tc);
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_SENT);
 
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Length: 19\r\n\r\n");
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Length: 19\r\n"
+                   "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\n");
 }
 
 static void
@@ -555,7 +561,8 @@ test_chunked_transfer_encoding (TestCase *tc,
   resp = output_as_string (tc);
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_SENT);
 
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n"
+                   "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\n"
                    "26\r\nCockpit is perfect for new sysadmins, \r\n"
                    "4d\r\nallowing them to easily perform simple tasks such as storage administration, \r\n"
                    "37\r\ninspecting journals and starting and stopping services.\r\n0\r\n\r\n");
@@ -600,7 +607,8 @@ test_chunked_zero_length (TestCase *tc,
   resp = output_as_string (tc);
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_SENT);
 
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n"
+                   "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\n"
                    "26\r\nCockpit is perfect for new sysadmins, \r\n"
                    "37\r\ninspecting journals and starting and stopping services.\r\n0\r\n\r\n");
 }
@@ -636,7 +644,8 @@ test_web_filter_simple (TestCase *tc,
   resp = output_as_string (tc);
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_SENT);
 
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n"
+                   "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\n"
                    "c\r\n<html><head>\r\n"
                    "d\r\n<meta inject>\r\n"
                    "26\r\n<title>The Title</title></head></html>\r\n"
@@ -686,7 +695,8 @@ test_web_filter_multiple (TestCase *tc,
   resp = output_as_string (tc);
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_SENT);
 
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n"
+                   "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\n"
                    "6\r\n<html>\r\n"
                    "1\r\n \r\n"
                    "6\r\n<head>\r\n"
@@ -750,7 +760,8 @@ test_web_filter_split (TestCase *tc,
   resp = output_as_string (tc);
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_SENT);
 
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n"
+                   "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\n"
                    "1\r\n<\r\n"
                    "2\r\nht\r\n"
                    "4\r\nml><\r\n"
@@ -804,7 +815,8 @@ test_web_filter_shift (TestCase *tc,
   resp = output_as_string (tc);
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_SENT);
 
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n"
+                   "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\n"
                    "4\r\nfoof\r\n"
                    "4\r\noofn\r\n"
                    "8\r\ninjected\r\n"
@@ -849,7 +861,8 @@ test_web_filter_shift_three (TestCase *tc,
   resp = output_as_string (tc);
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_SENT);
 
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n"
+                   "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\n"
                    "4\r\nfoof\r\n"
                    "1\r\no\r\n"
                    "2\r\nof\r\n"
@@ -883,7 +896,8 @@ test_web_filter_passthrough (TestCase *tc,
   resp = output_as_string (tc);
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_SENT);
 
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n"
+                   "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\n"
                    "32\r\n<html><head><title>The Title</title></head></html>\r\n"
                    "0\r\n\r\n");
 }
@@ -917,7 +931,8 @@ test_abort (TestCase *tc,
 
   resp = output_as_string (tc);
 
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\n");
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Length: 11\r\n"
+                   "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\n");
 }
 
 static const TestFixture fixture_connection_close = {
@@ -941,7 +956,8 @@ test_connection_close (TestCase *tc,
   g_bytes_unref (content);
 
   resp = output_as_string (tc);
-  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Length: 11\r\nConnection: close\r\n\r\nthe content");
+  g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Length: 11\r\nConnection: close\r\n"
+                   "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\nthe content");
 }
 
 typedef struct {

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -351,6 +351,7 @@ send_login_html (CockpitWebResponse *response,
   GBytes *url_bytes = NULL;
   CockpitWebFilter *filter2 = NULL;
   const gchar *url_root = NULL;
+  gchar *content_security_policy = NULL;
   gchar *cookie_line = NULL;
   gchar *base;
 
@@ -418,13 +419,13 @@ send_login_html (CockpitWebResponse *response,
     {
       /* The login Content-Security-Policy allows the page to have inline <script> and <style> tags. */
       cookie_line = cockpit_auth_empty_cookie_value (path);
+      content_security_policy = cockpit_web_response_security_policy ("default-src 'self' 'unsafe-inline'",
+                                                                      cockpit_web_response_get_origin (response));
+
       cockpit_web_response_headers (response, 200, "OK", -1,
-                                    "Content-Type",
-                                    "text/html",
-                                    "Content-Security-Policy",
-                                    "default-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:",
-                                    "Set-Cookie",
-                                    cookie_line,
+                                    "Content-Type", "text/html",
+                                    "Content-Security-Policy", content_security_policy,
+                                    "Set-Cookie", cookie_line,
                                     NULL);
       if (cockpit_web_response_queue (response, bytes))
         cockpit_web_response_complete (response);
@@ -433,6 +434,7 @@ send_login_html (CockpitWebResponse *response,
     }
 
   g_free (cookie_line);
+  g_free (content_security_policy);
   g_strfreev (languages);
 }
 

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -177,7 +177,8 @@ test_resource_simple (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws: wss:\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
+                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; block-all-mixed-content\r\n"
                            "Content-Type: text/html\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
                            "Access-Control-Allow-Origin: http://localhost\r\n"
@@ -220,7 +221,8 @@ test_resource_simple_host (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self' http://my.host; connect-src 'self' http://my.host ws: wss:\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
+                           "Content-Security-Policy: default-src 'self' http://my.host; connect-src 'self' http://my.host ws://my.host; form-action 'self' http://my.host; base-uri 'self' http://my.host; object-src 'none'; block-all-mixed-content\r\n"
                            "Content-Type: text/html\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
                            "Access-Control-Allow-Origin: http://my.host\r\n"
@@ -263,7 +265,8 @@ test_resource_language (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws: wss:\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
+                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; block-all-mixed-content\r\n"
                            "Content-Type: text/html\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
                            "Access-Control-Allow-Origin: http://localhost\r\n"
@@ -306,7 +309,8 @@ test_resource_cookie (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws: wss:\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
+                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; block-all-mixed-content\r\n"
                            "Content-Type: text/html\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
                            "Access-Control-Allow-Origin: http://localhost\r\n"
@@ -350,6 +354,7 @@ test_resource_not_found (TestResourceCase *tc,
                            "HTTP/1.1 404 Not Found\r\n"
                            "Content-Type: text/html; charset=utf8\r\n"
                            "Transfer-Encoding: chunked\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
                            "\r\n13\r\n"
                            "<html><head><title>\r\n9\r\n"
                            "Not Found\r\n15\r\n"
@@ -385,6 +390,7 @@ test_resource_no_path (TestResourceCase *tc,
                            "HTTP/1.1 404 Not Found\r\n"
                            "Content-Type: text/html; charset=utf8\r\n"
                            "Transfer-Encoding: chunked\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
                            "\r\n13\r\n"
                            "<html><head><title>\r\n9\r\n"
                            "Not Found\r\n15\r\n"
@@ -429,6 +435,7 @@ test_resource_failure (TestResourceCase *tc,
                            "HTTP/1.1 500 Internal Server Error\r\n"
                            "Content-Type: text/html; charset=utf8\r\n"
                            "Transfer-Encoding: chunked\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
                            "\r\n13\r\n"
                            "<html><head><title>\r\n15\r\n"
                            "Internal Server Error\r\n15\r\n"
@@ -504,6 +511,7 @@ test_resource_checksum (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
                            "ETag: \"$060119c2a544d8e5becd0f74f9dcde146b8d99e3-c\"\r\n"
                            "Access-Control-Allow-Origin: http://localhost\r\n"
                            "Transfer-Encoding: chunked\r\n"
@@ -545,6 +553,7 @@ test_resource_not_modified (TestResourceCase *tc,
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 304 Not Modified\r\n"
                            "ETag: \"$060119c2a544d8e5becd0f74f9dcde146b8d99e3-c\"\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
                            "\r\n", -1);
   g_bytes_unref (bytes);
   g_object_unref (response);
@@ -578,6 +587,7 @@ test_resource_not_modified_new_language (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
                            "ETag: \"$060119c2a544d8e5becd0f74f9dcde146b8d99e3-de\"\r\n"
                            "Access-Control-Allow-Origin: http://localhost\r\n"
                            "Transfer-Encoding: chunked\r\n"
@@ -622,6 +632,7 @@ test_resource_not_modified_cookie_language (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
                            "ETag: \"$060119c2a544d8e5becd0f74f9dcde146b8d99e3-fr\"\r\n"
                            "Access-Control-Allow-Origin: http://localhost\r\n"
                            "Transfer-Encoding: chunked\r\n"
@@ -659,6 +670,7 @@ test_resource_no_checksum (TestResourceCase *tc,
                            "HTTP/1.1 404 Not Found\r\n"
                            "Content-Type: text/html; charset=utf8\r\n"
                            "Transfer-Encoding: chunked\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
                            "\r\n13\r\n"
                            "<html><head><title>\r\n9\r\n"
                            "Not Found\r\n15\r\n"
@@ -693,6 +705,7 @@ test_resource_bad_checksum (TestResourceCase *tc,
                            "HTTP/1.1 404 Not Found\r\n"
                            "Content-Type: text/html; charset=utf8\r\n"
                            "Transfer-Encoding: chunked\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
                            "\r\n13\r\n"
                            "<html><head><title>\r\n9\r\n"
                            "Not Found\r\n15\r\n"
@@ -724,7 +737,8 @@ test_resource_language_suffix (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws: wss:\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
+                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; block-all-mixed-content\r\n"
                            "Content-Type: text/html\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
                            "Access-Control-Allow-Origin: http://localhost\r\n"
@@ -766,7 +780,8 @@ test_resource_language_fallback (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws: wss:\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
+                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; block-all-mixed-content\r\n"
                            "Content-Type: text/html\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
                            "Access-Control-Allow-Origin: http://localhost\r\n"
@@ -807,6 +822,7 @@ test_resource_gzip_encoding (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
                            "Content-Encoding: gzip\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
                            "Access-Control-Allow-Origin: http://localhost\r\n"
@@ -818,7 +834,7 @@ test_resource_gzip_encoding (TestResourceCase *tc,
                            "\x1F\x8B\x08\x08N1\x03U\x00\x03test-file.txt\x00sT(\xCEM\xCC\xC9Q(I-"
                            ".QH\xCB\xCCI\xE5\x02\x00>PjG\x12\x00\x00\x00\x0D\x0A"
                            "0\x0D\x0A\x0D\x0A",
-                           256);
+                           315);
   g_bytes_unref (bytes);
   g_object_unref (response);
 }
@@ -846,7 +862,8 @@ test_resource_head (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
-                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws: wss:\r\n"
+                           "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
+                           "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; block-all-mixed-content\r\n"
                            "Content-Type: text/html\r\n"
                            "Cache-Control: no-cache, no-store\r\n"
                            "Access-Control-Allow-Origin: http://localhost\r\n"

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -144,7 +144,10 @@ class TestConnection(MachineCase):
         # login handler: correct password
         m.execute("curl -k -c cockpit.jar -s --head --header 'Authorization: Basic {}' https://127.0.0.1:9090/cockpit/login".format(base64.b64encode("admin:foobar"), ))
         headers = m.execute("curl -k --head -b cockpit.jar -s https://127.0.0.1:9090/")
-        self.assertIn("default-src 'self' https://127.0.0.1:9090; connect-src 'self' https://127.0.0.1:9090 ws: wss", headers)
+        if m.image in ["rhel-7-4"]:
+            self.assertIn("default-src 'self' https://127.0.0.1:9090; connect-src 'self' https://127.0.0.1:9090 ws: wss", headers)
+        else:
+            self.assertIn("default-src 'self' https://127.0.0.1:9090; connect-src 'self' https://127.0.0.1:9090 wss://127.0.0.1:9090", headers)
         self.assertIn("Access-Control-Allow-Origin: https://127.0.0.1:9090", headers)
 
         self.allow_journal_messages(


### PR DESCRIPTION
In order to not accidentally leak information off the host, we need to have a tighter default Content-Security-Policy.
    
 * Set the form-action, base-uri fields to 'self'
 * Fill in the actual proper orrigin for ws and wss in connect-src
 * Set the object-src to 'none'
 * Set block-all-mixed-content
    
We also set several headers to avoid prefetching and leaking of information. These are:
  * X-DNS-Prefetch-Control
  * Referrer-Policy