### PR TITLE
storage: Break long dialog titles

### DIFF
--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -615,3 +615,10 @@ td.storage-action {
 .form-table-ct .combobox-container .input-group {
     width: 100%;
 }
+
+/* Prevent long names from sticking out of dialog titles
+ */
+
+.modal-title {
+    word-break: break-all;
+}


### PR DESCRIPTION
So that they don't stick out into the background.

Fixes: #979