### PR TITLE
naughty: Close 6690: debian-testing: apparmor denial: libvirt qemu cannot read `/proc/*/cmdline`

### DIFF
--- a/bots/naughty/debian-testing/6690-apparmor-libvirt-cmdline
+++ b/bots/naughty/debian-testing/6690-apparmor-libvirt-cmdline
@@ -1,1 +1,0 @@
-Error: audit: type=1400 * apparmor="DENIED" operation="open" profile="libvirt-* name="/proc/*/cmdline" * comm="qemu-system-*" requested_mask="r" denied_mask="r"


### PR DESCRIPTION
Known issue which has not occurred in 27 days

debian-testing: apparmor denial: libvirt qemu cannot read `/proc/*/cmdline`

Fixes #6690