### PR TITLE
test: Increase Chromium window size

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -170,7 +170,7 @@ class CDP:
             self._browser = subprocess.Popen(
                 argv + ["--disable-gpu", "--no-sandbox", "--disable-setuid-sandbox",
                     "--disable-namespace-sandbox", "--disable-seccomp-filter-sandbox",
-                    "--disable-sandbox-denial-logging",
+                    "--disable-sandbox-denial-logging", "--window-size=1280x1200",
                     "--remote-debugging-port=%i" % cdp_port, "about:blank"],
                 env=environ, close_fds=True)
             if self.verbose:


### PR DESCRIPTION
The default 800x600 is a bit crammed and often cuts off interesting
details when looking at failures. Bump it to 1280x1200.