### PR TITLE
bots: Fix image-customize for `$TEST_DATA` and absent images

### DIFF
--- a/bots/image-customize
+++ b/bots/image-customize
@@ -108,10 +108,11 @@ def install_packages(machine_instance, packagelist, install_command):
     if allpackages:
         machine_instance.execute(install_command + " " + ' '.join(allpackages))
 
-current_image = args.image
 if args.commandlist or args.packagelist or args.scriptlist or args.uploadlist:
+    if '/' not in args.image:
+        subprocess.check_call(["image-download", args.image])
     machine = testvm.VirtMachine(maintain=True,
-        verbose=args.verbose, image=prepare_install_image(current_image), label="install")
+        verbose=args.verbose, image=prepare_install_image(args.image), label="install")
     machine.start()
     machine.wait_boot()
     try:


### PR DESCRIPTION
In this case it currently fails like this:

```
$ bots/image-customize -v -i bash fedora-27
qemu-img: [..]/test/images/fedora-27.qcow2: Could not open '[..]/bots/images/fedora-27-e49f[..].qcow2':
No such file or directory
```

Fix this by calling `image-download` first, which will either download
missing images or create the symlink to the actual image in
`$TEST_DATA`.

---

image-customize is not being used anywhere in cockpit our cockpituous, so this needs to be tested manually. I did that with a command like the above, and also on a custom image (specified with full path). Thus I only trigger one test.