### PR TITLE
test: Fix timeout handling

### DIFF
--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -103,7 +103,7 @@ def run_avocado_tests(machine, avocado_tests, print_failed=True, env=[]):
                  ]
 
     try:
-        machine.execute(" ".join(cmd_parts))
+        machine.execute(" ".join(cmd_parts), timeout=3600)
     except:
         if print_failed:
             # try to get the list of failed tests

--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -93,6 +93,7 @@ class Timeout:
     def __exit__(self, type, value, traceback):
         if self.seconds:
             signal.alarm(0)
+            signal.signal(signal.SIGALRM, signal.SIG_DFL)
 
 class Failure(Exception):
     def __init__(self, msg):

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -105,7 +105,7 @@ def generate_new_commit(m, pkg_to_remove):
 
     commit_args = [REPO_LOCATION, branch.strip(), CHECKOUT_LOCATION, KEY_ID]
     command = "ostree commit -s cockpit-tree2 --repo {0} -b {1} --add-metadata-string version=cockpit-base.2 --tree=dir={2} --gpg-sign={3} --gpg-homedir=/root/"
-    m.execute(command.format(*commit_args))
+    m.execute(command.format(*commit_args), timeout=600)
     m.execute(["ostree", "summary", "--repo={}".format(REPO_LOCATION), "-u"])
 
 def rhsmcertd_hack(m):

--- a/test/verify/check-ovirt
+++ b/test/verify/check-ovirt
@@ -72,7 +72,7 @@ class TestOVirtMachines(MachineCase):
 
         # Wait for the web service to be accessible
         args = { "api": "curl -s -k -u admin@internal:engine -H Content-type:application/xml", "addr": OVIRT_ADDR }
-        m.execute(script=WAIT_SCRIPT % args)
+        m.execute(script=WAIT_SCRIPT % args, timeout=1000)
 
         # Run the prepared VM
         vmid = m.execute("%(api)s https://%(addr)s/ovirt-engine/api/vms/ | xmllint --xpath \"string(/vms/vm[name=\'VM\']/@id)\" -" % args)

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -225,7 +225,7 @@ class TestKerberos(MachineCase):
         if "ubuntu" in self.machine.image:
             # no nss-myhostname there
             self.machine.execute("echo '10.111.113.1 x0.cockpit.lan' >> /etc/hosts")
-        self.machine.execute(script=JOIN_SCRIPT % args)
+        self.machine.execute(script=JOIN_SCRIPT % args, timeout=1800)
 
     def tearDown(self):
         if 'KRB5CCNAME' in os.environ:

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -147,7 +147,7 @@ class VolumeTests(object):
 
         b.wait_present(".pv-listing tbody[data-id='pv1']")
 
-        m.execute("kubectl delete namespace another")
+        m.execute("kubectl delete namespace another", timeout=600)
         b.wait_not_present(".pvc-listing")
 
     def testVolumes(self):


### PR DESCRIPTION
Fix `Timeout` to reset `SIGALRM` to `SIG_DFL` when leaving, so that at
the next time the query whether an alarm is already set will actually
work. This previously broke all but the first timeout, causing infinite
hangs.