### PR TITLE
test: Close ssh's stdout properly

### DIFF
--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -346,6 +346,7 @@ class Machine:
             self.ssh_process.stdin.close()
             with Timeout(seconds=90, error_message="Timeout while waiting for ssh master to shut down"):
                 self.ssh_process.wait()
+            self.ssh_process.stdout.close()
             self.ssh_process = None
 
     def _check_ssh_master(self):


### PR DESCRIPTION
This avoids a warning when running the tests with Python 3:

    bots/machine/testvm.py:348: ResourceWarning: unclosed file <_io.BufferedReader name=13>
      self.ssh_process = None