### PR TITLE
docker: Display volumes and env vars in running containers

### DIFF
--- a/pkg/docker/details.js
+++ b/pkg/docker/details.js
@@ -57,6 +57,17 @@
             $('#container-details-stop').on('click', $.proxy(this, "stop_container"));
             $('#container-details-restart').on('click', $.proxy(this, "restart_container"));
             $('#container-details-delete').on('click', $.proxy(this, "delete_container"));
+            $('#container-details-inspect-row').on('click', function() {
+                    $(this).toggleClass('active');
+                    var kiddo = $(this).find("i");
+                    if ($(this).hasClass('active')){
+                        kiddo.removeClass('fa-expand');
+                        kiddo.addClass('fa-compress');
+                    } else {
+                        kiddo.removeClass('fa-compress');
+                        kiddo.addClass('fa-expand');
+                    }
+            });
 
             self.memory_limit = new util.MemorySlider($("#container-resources-dialog .memory-slider"),
                                                       10*1024*1024, 2*1024*1024*1024);
@@ -168,6 +179,7 @@
             $('#container-details-ports-row').hide();
             $('#container-details-links-row').hide();
             $('#container-details-resource-row').hide();
+            $('#container-details-inspect').text("");
 
             var info = this.client.containers[this.container_id];
             util.docker_debug("container-details", this.container_id, info);
@@ -215,6 +227,8 @@
 
             $('#container-details-ports-row').toggle(port_bindings.length > 0);
             $('#container-details-ports').html(util.multi_line(port_bindings));
+
+            $('#container-details-inspect').text(JSON.stringify(info, null, 4));
 
             this.update_links(info);
 

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -628,3 +628,36 @@ table.drive-list td:nth-child(2) img {
     padding-left: 20px;
     padding-right: 20px;
 }
+
+pre {
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
+    white-space: -pre-wrap;
+    white-space: -o-pre-wrap;
+    word-wrap: break-word;
+}
+
+.docker-inspect {
+    height: 44px;
+    width: 15em;
+    position: relative;
+    transition: height 0.5s, width 0.5s;
+    -webkit-transition: height 0.5s, width 0.5s;
+    overflow: hidden;
+    top: 15px;
+}
+
+.docker-inspect:hover {
+    cursor: pointer;
+}
+
+.docker-inspect.active {
+    width: 100%;
+    height: 100%;
+}
+
+.placeholder {
+    width: 100%;
+    overflow: hidden;
+    visibility: hidden;
+}

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -226,6 +226,16 @@
           </tr>
         </table>
         <div id="container-terminal" hidden></div>
+        <div class="panel panel-default placeholder"></div>
+        <div id="container-details-inspect-row" class="panel panel-default docker-inspect">
+            <div class="panel-heading">
+                <i class="fa fa-expand fa-lg" aria-hidden="true"></i>
+                <span>Docker inspect</span>
+            </div>
+            <div class="panel-body">
+                <pre id="container-details-inspect"></pre>
+            </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Hi,
this is a new feature that I taught may be interesting.
As I went home I played with containers and some info that I needed Cockpit does not provided. So I thought I could propose including that info into container details. But then I realized that there is sooo many other details that could be displayed, it would be really cramped to include everything what somebody needs. So my thought was to display whole docker-inspect for those, who sometimes seek for some special info.

I've recorded a quick demo how this works: https://youtu.be/sWfrr7AvRWQ

Disclaimer:
This is my thought, if it is something that Cockpit does not want feel free to close this PR:) Also design was created by me and I am no designer. And finally - this was just quick coding while sitting in a train, some changes will probably be needed (and test of course).