### PR TITLE
system: Add PCI devices to hardware information

### DIFF
--- a/pkg/lib/cockpit-components-listing.jsx
+++ b/pkg/lib/cockpit-components-listing.jsx
@@ -273,6 +273,8 @@ var ListingRow = React.createClass({
  * - fullWidth optional: set width to 100% of parent, defaults to true
  * - emptyCaption header caption to show if list is empty, defaults to "No entries"
  * - columnTitles: array of column titles, as strings
+ * - columnTitleClick: optional callback for clicking on column title (for sorting)
+ *                     receives the column index as argument
  * - actions: additional listing-wide actions (displayed next to the list's title)
  */
 var Listing = React.createClass({
@@ -281,6 +283,7 @@ var Listing = React.createClass({
         fullWidth: React.PropTypes.bool,
         emptyCaption: React.PropTypes.string.isRequired,
         columnTitles: React.PropTypes.arrayOf(React.PropTypes.string),
+        columnTitleClick: React.PropTypes.func,
         actions: React.PropTypes.arrayOf(React.PropTypes.node)
     },
     getDefaultProps: function () {
@@ -291,6 +294,7 @@ var Listing = React.createClass({
         };
     },
     render: function() {
+        var self = this;
         var bodyClasses = ["listing", "listing-ct"];
         if (this.props.fullWidth)
             bodyClasses.push("listing-ct-wide");
@@ -319,7 +323,12 @@ var Listing = React.createClass({
             headerRow = (
                 <tr>
                     <th className="listing-ct-toggle"></th>
-                    { this.props.columnTitles.map(function (title) { return <th>{title}</th>; }) }
+                    { this.props.columnTitles.map(function (title, index) {
+                        var clickHandler = null;
+                        if (self.props.columnTitleClick)
+                            clickHandler = function() { self.props.columnTitleClick(index) };
+                        return <th onClick={clickHandler}>{title}</th>;
+                    }) }
                 </tr>
             );
         } else {

--- a/pkg/systemd/hwinfo.css
+++ b/pkg/systemd/hwinfo.css
@@ -10,3 +10,12 @@
     width: 50%;
   }
 }
+
+/* disable right justified last column */
+table.listing-ct thead th:last-child {
+    text-align: left;
+}
+
+tr.listing-ct-item td:last-child {
+    text-align: left;
+}

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -19,6 +19,7 @@
 
 import cockpit from "cockpit";
 import React from "react";
+import { Listing, ListingRow } from "cockpit-components-listing.jsx";
 
 import detect from "./hw-detect.es6";
 
@@ -61,17 +62,43 @@ const SystemInfo = ({ info }) => (
     </table>
 );
 
-const HardwareInfo = ({ info }) => (
-    <div className="page-ct container-fluid">
-        <ol className="breadcrumb">
-            <li><a onClick={ () => cockpit.jump("/system", cockpit.transport.host) }>{ _("System") }</a></li>
-            <li className="active">{ _("Hardware Information") }</li>
-        </ol>
+class HardwareInfo extends React.Component {
+    constructor(props) {
+        super(props);
+        this.sortColumnFields = [ "cls", "model", "vendor", "slot" ];
+        this.state = { sortBy: "cls" };
+    }
 
-        <h2>{ _("System Information") }</h2>
-        <SystemInfo info={info.system}/>
-    </div>
-);
+    render() {
+        let pci = null;
+
+        if (this.props.info.pci.length > 0) {
+            let sortedPci = this.props.info.pci.concat();
+            sortedPci.sort((a, b) => a[this.state.sortBy].localeCompare(b[this.state.sortBy]));
+
+            pci = (
+                <Listing title={ _("PCI") } columnTitles={ [ _("Class"), _("Model"), _("Vendor"), _("Slot") ] }
+                         columnTitleClick={ index => this.setState({ sortBy: this.sortColumnFields[index] }) } >
+                    { sortedPci.map(dev => <ListingRow columns={[ dev.cls, dev.model, dev.vendor, dev.slot ]} />) }
+                </Listing>
+            );
+        }
+
+        return (
+            <div className="page-ct container-fluid">
+                <ol className="breadcrumb">
+                    <li><a onClick={ () => cockpit.jump("/system", cockpit.transport.host) }>{ _("System") }</a></li>
+                    <li className="active">{ _("Hardware Information") }</li>
+                </ol>
+
+                <h2>{ _("System Information") }</h2>
+                <SystemInfo info={this.props.info.system}/>
+
+                { pci }
+            </div>
+        );
+    }
+}
 
 document.addEventListener("DOMContentLoaded", () => {
     document.title = cockpit.gettext(document.title);

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -345,6 +345,7 @@ class TestSystemInfo(MachineCase):
         b.click('#system_information_hardware_text')
         b.enter_page("/system/hwinfo")
 
+        # system info
         b.wait_present('#hwinfo .info-table-ct')
         b.wait_in_text('#hwinfo .info-table-ct', "CPU")
         # QEMU VM type
@@ -355,6 +356,21 @@ class TestSystemInfo(MachineCase):
         b.wait_in_text('#hwinfo .info-table-ct tbody:nth-of-type(2) tr:nth-of-type(1) td', "SeaBIOS")
         # BIOS date; just ensure it's from this century
         b.wait_in_text('#hwinfo .info-table-ct tbody:nth-of-type(2) tr:nth-of-type(3) td', "/20")
+
+        # PCI
+        b.wait_present('#hwinfo .listing-ct caption')
+        b.wait_in_text('#hwinfo .listing-ct caption', "PCI")
+        b.wait_in_text('#hwinfo .listing-ct', "0000:00:00.0")
+
+        # sorted by device class by default; this makes some assumptions about QEMU devices
+        b.wait_in_text('#hwinfo .listing-ct tbody:first-of-type td:nth-of-type(2)', "Bridge")
+        b.wait_in_text('#hwinfo .listing-ct tbody:last-of-type td:nth-of-type(2)', "Unclassified")
+
+        # sort by model
+        b.click('#hwinfo .listing-ct thead th:nth-of-type(3)')
+        b.wait_in_text('#hwinfo .listing-ct tbody:first-of-type td:nth-of-type(3)', "440FX")
+        b.wait_in_text('#hwinfo .listing-ct tbody:last-of-type td:nth-of-type(3)', "Virtio SCSI")
+        b.wait_not_in_text('#hwinfo .listing-ct tbody:last-of-type td:nth-of-type(2)', "Unclassified")
 
         # go back to system page
         b.click('.breadcrumb a')


### PR DESCRIPTION
Get them from udev's database dump. This is available on any non-ancient
Linux system and does not require privileges or new dependencies. This
also contains information about USB and SCSI devices, so these can be
added in the future without any extra calls.

Sort the table by device class by default, which appears to be the most
common view. Add click handlers to columns to change the sorting order,
in case someone wants a topological (by slot) or per-vendor list.