### PR TITLE
kubernetes: Render VM's pod name

### DIFF
--- a/pkg/kubernetes/scripts/virtual-machines/action-creators.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/action-creators.jsx
@@ -59,3 +59,10 @@ export function removeVmMessage({ vm }) {
       }
     };
 }
+
+export function setPods(pods) {
+    return {
+        type: actionConstants.SET_PODS,
+        payload: pods
+    }
+}

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx
@@ -23,7 +23,7 @@ import { gettext as _ } from 'cockpit';
 
 import VmOverviewTab, { commonTitles } from '../../../../machines/components/vmOverviewTab.jsx';
 
-import type { Vm, VmMessages } from '../types.jsx';
+import type { Vm, VmMessages, Pod } from '../types.jsx';
 import { getPairs, NODE_LABEL, vmIdPrefx, getValueOrDefault } from '../utils.jsx';
 
 import VmMessage from './VmMessage.jsx';
@@ -61,21 +61,29 @@ function getMemory(vm: Vm) {
     return _("Not Available");
 }
 
-const VmOverviewTabKubevirt = ({ vm, vmMessages }: { vm: Vm, vmMessages: VmMessages }) => {
+const PodLink = ({ pod }) => {
+    if (!pod || !pod.metadata.namespace || !pod.metadata.name) {
+        return null;
+    }
+
+    return (<a href={`#/l/pods/${pod.metadata.namespace}/${pod.metadata.name}`}>{pod.metadata.name}</a>);
+};
+
+const VmOverviewTabKubevirt = ({ vm, vmMessages, pod }: { vm: Vm, vmMessages: VmMessages, pod: Pod }) => {
     const idPrefix = vmIdPrefx(vm);
 
     const message = (<VmMessage vmMessages={vmMessages} vm={vm}/>);
 
     const nodeName = getNodeName(vm);
     const nodeLink = nodeName ? (<a href={`#/nodes/${nodeName}`}>{nodeName}</a>) : '-';
-
-    console.log('VmOverviewTabKubevirt: vm = ', vm);
+    const podLink = (<PodLink pod={pod}/>);
 
     const items = [
         {title: commonTitles.MEMORY, value: getMemory(vm), idPostfix: 'memory'},
         {title: _("Node:"), value: nodeLink, idPostfix: 'node'},
         {title: commonTitles.CPUS, value: _(getValueOrDefault(() => vm.spec.domain.cpu.cores, 1)), idPostfix: 'vcpus'},
         {title: _("Labels:"), value: getLabels(vm), idPostfix: 'labels'},
+        {title: _("Pod:"), value: podLink, idPostfix: 'pod'},
     ];
     return (<VmOverviewTab message={message}
                            idPrefix={idPrefix}

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx
@@ -25,13 +25,18 @@ import { gettext as _ } from 'cockpit'
 
 import { Listing } from '../../../../lib/cockpit-components-listing.jsx'
 import VmsListingRow from './VmsListingRow.jsx'
+import { getPod } from '../selectors.jsx';
 
 React;
 
-const VmsListing = ({ vms, pvs, settings, vmsMessages }) => {
+const VmsListing = ({ vms, pvs, pods, settings, vmsMessages }) => {
     const isOpenshift = settings.flavor === 'openshift'
     const namespaceLabel = isOpenshift ? _("Project") : _("Namespace")
-    const rows = vms.map(vm => (<VmsListingRow vm={vm} vmMessages={vmsMessages[vm.metadata.uid]} pvs={pvs} key={vm.metadata.uid} />))
+    const rows = vms.map(vm => (<VmsListingRow vm={vm}
+                                               vmMessages={vmsMessages[vm.metadata.uid]}
+                                               pod={getPod(vm, pods)}
+                                               pvs={pvs}
+                                               key={vm.metadata.uid} />))
     return (
         <Listing title={_("Virtual Machines")}
                  emptyCaption={_("No virtual machines")}
@@ -44,13 +49,17 @@ const VmsListing = ({ vms, pvs, settings, vmsMessages }) => {
 VmsListing.propTypes = {
     vms: PropTypes.object.isRequired,
     pvs: PropTypes.object.isRequired,
+    pods: PropTypes.object.isRequired,
     setting: PropTypes.object.isRequired,
     vmsMessages: PropTypes.object.isRequired,
 }
 
-export default connect(({ vms, pvs, settings, vmsMessages }) => ({
-    vms, // VirtualMachines
-    pvs, // PersistentVolumes
-    settings,
-    vmsMessages,
-}))(VmsListing)
+export default connect(
+    ({ vms, pods, pvs, settings, vmsMessages }) => ({
+        vms, // VirtualMachines
+        pods,
+        pvs, // PersistentVolumes
+        settings,
+        vmsMessages,
+    })
+)(VmsListing)

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx
@@ -27,19 +27,21 @@ import VmOverviewTab from './VmOverviewTabKubevirt.jsx';
 import VmActions from './VmActions.jsx';
 import VmDisksTab from './VmDisksTabKubevirt.jsx';
 
-import type { Vm, VmMessages, PersistenVolumes } from '../types.jsx';
+import type { Vm, VmMessages, PersistenVolumes, Pod } from '../types.jsx';
 import { NODE_LABEL, vmIdPrefx } from '../utils.jsx';
 
 React;
 
-const VmsListingRow = ({ vm, vmMessages, pvs }: { vm: Vm, vmMessages: VmMessages, pvs: PersistenVolumes }) => {
+const VmsListingRow = ({ vm, vmMessages, pvs, pod }:
+                           { vm: Vm, vmMessages: VmMessages, pvs: PersistenVolumes, pod: Pod }) => {
     const node = (vm.metadata.labels && vm.metadata.labels[NODE_LABEL]) || '-';
     const phase = (vm.status && vm.status.phase) || _("n/a");
-    const idPrefix = vmIdPrefx(vm)
+    const idPrefix = vmIdPrefx(vm);
+
     const overviewTabRenderer = {
        name: _("Overview"),
         renderer: VmOverviewTab,
-        data: { vm, vmMessages },
+        data: { vm, vmMessages, pod },
         presence: 'always',
     };
 
@@ -48,7 +50,7 @@ const VmsListingRow = ({ vm, vmMessages, pvs }: { vm: Vm, vmMessages: VmMessages
         renderer: VmDisksTab,
         data: { vm, pvs },
         presence: 'onlyActive',
-    }
+    };
 
     return (
         <ListingRow
@@ -68,6 +70,7 @@ VmsListingRow.propTypes = {
     vm: PropTypes.object.isRequired,
     vmMessages: PropTypes.object.isRequired,
     pvs: PropTypes.array.isRequired,
+    pod: PropTypes.object.isRequired,
 };
 
 export default VmsListingRow;

--- a/pkg/kubernetes/scripts/virtual-machines/index.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/index.jsx
@@ -45,14 +45,17 @@ function addKubeLoaderListener ($scope, kubeLoader, kubeSelect) {
     kubeLoader.listen(function() {
         const vms = kubeSelect().kind('VirtualMachine')
         const persistentVolumes = kubeSelect().kind('PersistentVolume')
+        const pods = kubeSelect().kind('Pod');
 
         reduxStore.dispatch(actionCreators.setVms(Object.values(vms)))
         reduxStore.dispatch(actionCreators.setPVs(Object.values(persistentVolumes)))
+        reduxStore.dispatch(actionCreators.setPods(Object.values(pods)))
     }, $scope);
 
     // enable watching( watched-entity-type, until )
     kubeLoader.watch('VirtualMachine', $scope);
     kubeLoader.watch('PersistentVolume', $scope);
+    kubeLoader.watch('Pod', $scope);
 }
 
 const VmsPlugin = () => (

--- a/pkg/kubernetes/scripts/virtual-machines/reducers.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/reducers.jsx
@@ -36,6 +36,10 @@ const pvsReducer = createReducer([], {
     [actionTypes.SET_PVS]: (state = [], { payload }) => payload ? payload : []
 })
 
+const podsReducer = createReducer([], {
+    [actionTypes.SET_PODS]: (state = [], { payload }) => payload ? payload : []
+})
+
 const settingsReducer = createReducer([], {
     [actionTypes.SET_SETTINGS]: (state = [], { payload }) => payload ? payload : {}
 })
@@ -64,6 +68,7 @@ const vmsMessagesReducer = createReducer({}, {
 const rootReducer = combineReducers({
     vms: vmsReducer, // VirtualMachines from API
     pvs: pvsReducer, // PersistenVolumes from API
+    pods: podsReducer, // Pods from API
     settings: settingsReducer,
     vmsMessages: vmsMessagesReducer,
 })

--- a/pkg/kubernetes/scripts/virtual-machines/selectors.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/selectors.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of Cockpit.
  *
- * Copyright (C) 2017 Red Hat, Inc.
+ * Copyright (C) 2018 Red Hat, Inc.
  *
  * Cockpit is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by
@@ -17,10 +17,20 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const SET_VMS = 'SET_VMS'
-export const SET_PVS = 'SET_PVS'
-export const SET_SETTINGS = 'SET_SETTINGS'
-export const SET_PODS = 'SET_PODS'
+import { getValueOrDefault, VM_UID_LABEL } from "./utils.jsx";
 
-export const VM_ACTION_FAILED = 'VM_ACTION_FAILED'
-export const REMOVE_VM_MESSAGE = 'REMOVE_VM_MESSAGE'
+/**
+ * Returns pod corresponding to the given vm.
+ */
+export function getPod(vm, pods) {
+    if (!pods) {
+        return null;
+    }
+
+    const vmId = vm.metadata.uid;
+    if (!vmId) {
+        return null;
+    }
+
+    return pods.find(pod => getValueOrDefault(() => pod.metadata.labels[VM_UID_LABEL], null) === vmId);
+}

--- a/pkg/kubernetes/scripts/virtual-machines/types.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/types.jsx
@@ -19,6 +19,9 @@
 
 // @flow
 
+export type Labels = {[string]: string};
+export type Annotations = Object;
+
 export type Vm = {
     apiVersion: string,
     kind: 'VirtualMachine',
@@ -26,7 +29,7 @@ export type Vm = {
         clusterName: string,
         creationTimestamp: string,
         generation: number,
-        labels: {[string]: string},
+        labels: Labels,
         name: string,
         namespace: string,
         resourceVersion: string,
@@ -75,8 +78,8 @@ export type PersistenVolume = {
         "uid": string,
         "resourceVersion": string,
         "creationTimestamp": string,
-        "labels": {[string]: string},
-        "annotations": Object,
+        "labels": Labels,
+        "annotations": Annotations,
     },
     "spec": {
         "capacity": {
@@ -105,3 +108,29 @@ export type PersistenVolume = {
 }
 
 export type PersistenVolumes = Array<PersistenVolume>;
+
+export type PodMetadata = {
+    "name": string,
+    "generateName": ?string,
+    "namespace": string,
+    "selfLink": string,
+    "uid": string,
+    "resourceVersion": string,
+    "creationTimestamp": string,
+    "labels": Labels,
+    "annotations": Annotations
+};
+
+export type PodSpec = Object; // TODO: define when needed
+
+export type Pod = {
+    "kind": "Pod",
+    "apiVersion": string,
+    "metadata": PodMetadata,
+    "spec": PodSpec,
+    "status": ?{
+        "phase": ?string
+    }
+};
+
+export type Pods = Array<Pod>;

--- a/pkg/kubernetes/scripts/virtual-machines/utils.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/utils.jsx
@@ -18,6 +18,7 @@
  */
 
 export const NODE_LABEL = 'kubevirt.io/nodeName';
+export const VM_UID_LABEL = 'kubevirt.io/vmUID';
 
 /**
  * @return {Array<{key: *, value: *}>} all own enumerable key-value pairs

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -424,6 +424,7 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         b.wait_present("#vm-testvm-memory")
         b.wait_in_text("#vm-testvm-memory", "64M")
         b.wait_in_text("#vm-testvm-labels", "kubevirt.io/nodeName=f1.cockpit.lan")
+        b.wait_present("#vm-testvm-pod")
 
         # switch to the Disks subtab
         b.wait_present("#vm-testvm-disks-tab")
@@ -465,6 +466,17 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         node_name = b.text("#vm-testvm-node > a").strip()
         b.click("#vm-testvm-node > a") # jump to "node" detail
         b.wait_js_cond('window.location.hash === "#/nodes/%s"' % (node_name,))
+
+        # link to pod
+        b.click("#vms-menu-link")
+        b.wait_present("tr[data-row-id='vm-testvm']")
+        b.click("tr[data-row-id='vm-testvm']")  # expand row
+        b.wait_present("#vm-testvm-pod")
+        wait(lambda: b.text("#vm-testvm-pod > a").strip() != "")
+        b.wait_in_text("#vm-testvm-pod", "virt-launcher-testvm---") # Example: virt-launcher-testvm-----rx59t
+        pod_name = b.text("#vm-testvm-pod > a").strip()
+        b.click("#vm-testvm-pod > a")
+        b.wait_js_cond('window.location.hash === "#/l/pods/kube-system/%s"' % (pod_name))
 
 
 @skipImage("Kubernetes not packaged", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-i386")


### PR DESCRIPTION
The `pod name` is rendered for a virtual machine
in kubernetes/virtual-machines.

The name is a link navigating to pod's detail page.

---
Depends on: ~~https://github.com/cockpit-project/cockpit/pull/8492~~