### PR TITLE
test: Fix verbose dumping of execute output

### DIFF
--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -460,17 +460,16 @@ class Machine:
                             rset.remove(stdout_fd)
                             proc.stdout.close()
                         else:
-                            data = data.decode('utf-8', 'replace')
                             if self.verbose:
-                                sys.stdout.write(data)
-                            output += data
+                                sys.stdout.write(data.decode('utf-8', 'ignore'))
+                            output += data.decode('utf-8', 'replace')
                     elif fd == stderr_fd:
                         data = os.read(fd, 1024)
                         if not data:
                             rset.remove(stderr_fd)
                             proc.stderr.close()
                         elif not quiet or self.verbose:
-                            sys.stderr.write(data.decode('utf-8', 'replace'))
+                            sys.stderr.write(data.decode('utf-8', 'ignore'))
                 for fd in ret[1]:
                     if fd == stdin_fd:
                         if input:


### PR DESCRIPTION
We have a problem when running check-connection with the -t
argument, due to dumping of non-ascii characters to output

    File "test/verify/check-connection", line 158, in testConfigOrigins
      output = m.execute('curl -s -f -N -H "Connection: Upg...
    File "/data/src/cockpit/test/common/testvm.py", line 464, in execute
      sys.stdout.write(data)
    UnicodeEncodeError: 'ascii' codec can't encode character u'\ufffd'