### PR TITLE
naughty: Close 7960: Ubuntu 17.10 regression: ntp.service causes AppArmor violation: Failed name lookup - disconnected path

### DIFF
--- a/bots/naughty/ubuntu-stable/7960-ntp-apparmor-disconnected-path
+++ b/bots/naughty/ubuntu-stable/7960-ntp-apparmor-disconnected-path
@@ -1,1 +1,0 @@
-Error: audit: type=1400 * apparmor="DENIED" operation="sendmsg" info="Failed name lookup - disconnected path" error=-13 profile="/usr/sbin/ntpd" * pid=* comm="ntpd" requested_mask="w" denied_mask="w"


### PR DESCRIPTION
Known issue which has not occurred in 25 days

Ubuntu 17.10 regression: ntp.service causes AppArmor violation: Failed name lookup - disconnected path

Fixes #7960