### PR TITLE
bots: don't guess github base

### DIFF
--- a/bots/npm-repo-test-invoke
+++ b/bots/npm-repo-test-invoke
@@ -126,8 +126,7 @@ def main():
     parser.add_argument('ref', nargs='?', help="The Git remote ref to pull")
     opts = parser.parse_args()
 
-    git_base = github.determine_github_base()
-    repo = os.environ.get("GITHUB_BASE", git_base)
+    repo = os.environ.get("GITHUB_BASE", "cockpit-project/cockpit")
     name = os.environ.get("TEST_NAME", "{0}-tests".format(repo))
     revision = os.environ.get("TEST_REVISION")
 
@@ -162,7 +161,7 @@ def main():
 
     os.environ["TEST_REVISION"] = head
     os.environ["GITHUB_REVISION"] = revision
-    os.environ["GITHUB_KNOWN_ISSUE_BASE"] = git_base
+    os.environ["GITHUB_KNOWN_ISSUE_BASE"] = "cockpit-project/cockpit"
     os.environ["TEST_NAME"] = name
 
     args = list(sys.argv)

--- a/bots/task/github.py
+++ b/bots/task/github.py
@@ -63,32 +63,6 @@ TOKEN = "~/.config/github-token"
 WHITELIST = os.path.join(BASE, "bots", "whitelist")
 WHITELIST_LOCAL = "~/.config/github-whitelist"
 
-def determine_github_base():
-    # pick a base
-    try:
-        # see where we get master from, e.g. origin
-        get_remote_command = ["git", "config", "--local", "--get", "branch.master.remote"]
-        remote = subprocess.Popen(get_remote_command, stdout=subprocess.PIPE, cwd=BASE, universal_newlines=True).communicate()[0].strip()
-        # see if we have a git checkout - it can be in https or ssh format
-        formats = [
-            re.compile("""https:\/\/github\.com\/(.*)\.git"""),
-            re.compile("""git@github.com:(.*)\.git""")
-            ]
-        remote_output = subprocess.Popen(
-                ["git", "ls-remote", "--get-url", remote],
-                stdout=subprocess.PIPE, cwd=BASE, universal_newlines=True
-            ).communicate()[0].strip()
-        for f in formats:
-            m = f.match(remote_output)
-            if m:
-                return list(m.groups())[0]
-    except subprocess.CalledProcessError:
-        sys.stderr.write("Unable to get git repo information, using defaults\n")
-
-    # if we still don't have something, default to cockpit-project/cockpit
-    return "cockpit-project/cockpit"
-
-
 def known_context(context):
     for prefix in OUR_CONTEXTS:
         if context.startswith(prefix):
@@ -135,7 +109,7 @@ class GitHub(object):
     def __init__(self, base=None, cacher=None):
         if base is None:
             netloc = os.environ.get("GITHUB_API", "https://api.github.com")
-            base = "{0}/repos/{1}/".format(netloc, os.environ.get("GITHUB_BASE", determine_github_base()))
+            base = "{0}/repos/{1}/".format(netloc, os.environ.get("GITHUB_BASE", "cockpit-project/cockpit"))
         self.url = urllib.parse.urlparse(base)
         self.conn = None
         self.token = None


### PR DESCRIPTION
Guessing the github project by looking at git remotes break when
multiple remotes are set up: we could try triggering on a project that
we didn't mean to trigger on. For example, running bots/test-trigger
from a feature branch doesn't work.

Remove the magic and use "cockpit-project/cockpit" as a default (which
we do anyway if we're not in a git checkout). This is all in cockpit's
repository, there's no need to pretend this is generic. There's still
GITHUB_BASE which can be used to override it.