### PR TITLE
storage: Change busy NFS unmount button to headline case

### DIFF
--- a/pkg/storaged/nfs-panel.jsx
+++ b/pkg/storaged/nfs-panel.jsx
@@ -237,7 +237,7 @@ export class NFSPanel extends React.Component {
                         nfs_busy_dialog(client,
                                         _("Unable to unmount filesystem"),
                                         entry, error,
-                                        _("Stop and unmount"),
+                                        _("Stop and Unmount"),
                                         function (users) {
                                             return client.nfs.stop_and_unmount_entry(users, entry);
                                         });

--- a/po/ca.po
+++ b/po/ca.po
@@ -6947,7 +6947,7 @@ msgid "Stop and remove"
 msgstr "Atura i treu"
 
 #: pkg/storaged/nfs-panel.jsx:240
-msgid "Stop and unmount"
+msgid "Stop and Unmount"
 msgstr "Atura i desmunta"
 
 #: node_modules/registry-image-widgets/views/image-config.html:14

--- a/po/pl.po
+++ b/po/pl.po
@@ -7044,7 +7044,7 @@ msgid "Stop and remove"
 msgstr "Zatrzymaj i usuń"
 
 #: pkg/storaged/nfs-panel.jsx:240
-msgid "Stop and unmount"
+msgid "Stop and Unmount"
 msgstr "Zatrzymaj i odmontuj"
 
 #: node_modules/registry-image-widgets/views/image-config.html:14

--- a/po/uk.po
+++ b/po/uk.po
@@ -7061,7 +7061,7 @@ msgid "Stop and remove"
 msgstr "Зупинити і вилучити"
 
 #: pkg/storaged/nfs-panel.jsx:240
-msgid "Stop and unmount"
+msgid "Stop and Unmount"
 msgstr "Зупинити і демонтувати"
 
 #: node_modules/registry-image-widgets/views/image-config.html:14


### PR DESCRIPTION
The button for stopping and unmounting in the busy NFS dialog
was using sentence case, but patternfly recommends headline case
So change this button to that.

https://www.patternfly.org/styles/terminology-and-wording/