### PR TITLE
kubernetes: Preserve expanded state of a virtual-machine row

### DIFF
--- a/pkg/kubernetes/scripts/virtual-machines/action-creators.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/action-creators.jsx
@@ -64,5 +64,15 @@ export function setPods(pods) {
     return {
         type: actionConstants.SET_PODS,
         payload: pods
-    }
+    };
+}
+
+export function vmExpanded({ vm, isExpanded }) {
+    return {
+        type: actionConstants.VM_EXPANDED,
+        payload: {
+            vm,
+            isExpanded
+        }
+    };
 }

--- a/pkg/kubernetes/scripts/virtual-machines/action-types.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/action-types.jsx
@@ -17,10 +17,10 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const SET_VMS = 'SET_VMS'
-export const SET_PVS = 'SET_PVS'
-export const SET_SETTINGS = 'SET_SETTINGS'
-export const SET_PODS = 'SET_PODS'
+export const SET_VMS = 'SET_VMS';
+export const SET_PVS = 'SET_PVS';
+export const SET_SETTINGS = 'SET_SETTINGS';
+export const SET_PODS = 'SET_PODS';
 
-export const VM_ACTION_FAILED = 'VM_ACTION_FAILED'
-export const REMOVE_VM_MESSAGE = 'REMOVE_VM_MESSAGE'
+export const VM_ACTION_FAILED = 'VM_ACTION_FAILED';
+export const REMOVE_VM_MESSAGE = 'REMOVE_VM_MESSAGE';

--- a/pkg/kubernetes/scripts/virtual-machines/action-types.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/action-types.jsx
@@ -24,3 +24,6 @@ export const SET_PODS = 'SET_PODS';
 
 export const VM_ACTION_FAILED = 'VM_ACTION_FAILED';
 export const REMOVE_VM_MESSAGE = 'REMOVE_VM_MESSAGE';
+
+export const VM_EXPANDED = 'VM_EXPANDED';
+

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx
@@ -19,32 +19,32 @@
 
 // @flow
 
-import React, { PropTypes } from 'react'
-import { connect } from 'react-redux'
-import { gettext as _ } from 'cockpit'
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { gettext as _ } from 'cockpit';
 
-import { Listing } from '../../../../lib/cockpit-components-listing.jsx'
-import VmsListingRow from './VmsListingRow.jsx'
+import { Listing } from '../../../../lib/cockpit-components-listing.jsx';
+import VmsListingRow from './VmsListingRow.jsx';
 import { getPod } from '../selectors.jsx';
 
 React;
 
 const VmsListing = ({ vms, pvs, pods, settings, vmsMessages }) => {
-    const isOpenshift = settings.flavor === 'openshift'
-    const namespaceLabel = isOpenshift ? _("Project") : _("Namespace")
+    const isOpenshift = settings.flavor === 'openshift';
+    const namespaceLabel = isOpenshift ? _("Project") : _("Namespace");
     const rows = vms.map(vm => (<VmsListingRow vm={vm}
                                                vmMessages={vmsMessages[vm.metadata.uid]}
                                                pod={getPod(vm, pods)}
                                                pvs={pvs}
-                                               key={vm.metadata.uid} />))
+                                               key={vm.metadata.uid} />));
     return (
         <Listing title={_("Virtual Machines")}
                  emptyCaption={_("No virtual machines")}
                  columnTitles={[_("Name"), namespaceLabel, _("Node"), _("State")]}>
             {rows}
         </Listing>
-    )
-}
+    );
+};
 
 VmsListing.propTypes = {
     vms: PropTypes.object.isRequired,
@@ -52,7 +52,7 @@ VmsListing.propTypes = {
     pods: PropTypes.object.isRequired,
     setting: PropTypes.object.isRequired,
     vmsMessages: PropTypes.object.isRequired,
-}
+};
 
 export default connect(
     ({ vms, pods, pvs, settings, vmsMessages }) => ({
@@ -62,4 +62,4 @@ export default connect(
         settings,
         vmsMessages,
     })
-)(VmsListing)
+)(VmsListing);

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx
@@ -21,6 +21,7 @@
 
 import React, { PropTypes } from 'react';
 import { gettext as _ } from 'cockpit';
+import { connect } from "react-redux";
 
 import { ListingRow } from '../../../../lib/cockpit-components-listing.jsx';
 import VmOverviewTab from './VmOverviewTabKubevirt.jsx';
@@ -29,11 +30,13 @@ import VmDisksTab from './VmDisksTabKubevirt.jsx';
 
 import type { Vm, VmMessages, PersistenVolumes, Pod } from '../types.jsx';
 import { NODE_LABEL, vmIdPrefx } from '../utils.jsx';
+import { vmExpanded } from "../action-creators.jsx";
+import { getValueOrDefault } from "../utils.jsx";
 
 React;
 
-const VmsListingRow = ({ vm, vmMessages, pvs, pod }:
-                           { vm: Vm, vmMessages: VmMessages, pvs: PersistenVolumes, pod: Pod }) => {
+const VmsListingRow = ({ vm, vmMessages, pvs, pod, vmUi, onExpandChanged }:
+                           { vm: Vm, vmMessages: VmMessages, pvs: PersistenVolumes, pod: Pod, onExpandChanged: Function }) => {
     const node = (vm.metadata.labels && vm.metadata.labels[NODE_LABEL]) || '-';
     const phase = (vm.status && vm.status.phase) || _("n/a");
     const idPrefix = vmIdPrefx(vm);
@@ -52,17 +55,21 @@ const VmsListingRow = ({ vm, vmMessages, pvs, pod }:
         presence: 'onlyActive',
     };
 
+    const initiallyExpanded = getValueOrDefault(() => vmUi.isExpanded, false);
+
     return (
         <ListingRow
             rowId={idPrefix}
             columns={[
-                {name: vm.metadata.name, 'header': true},
+                { name: vm.metadata.name, 'header': true },
                 vm.metadata.namespace,
                 node,
                 phase // phases description https://github.com/kubevirt/kubevirt/blob/master/pkg/api/v1/types.go
             ]}
-            tabRenderers={[overviewTabRenderer, disksTabRenderer]}
-            listingActions={<VmActions vm={vm}/>}/>
+            tabRenderers={[ overviewTabRenderer, disksTabRenderer ]}
+            listingActions={<VmActions vm={vm}/>}
+            expandChanged={onExpandChanged(vm)}
+            initiallyExpanded={initiallyExpanded} />
     );
 };
 
@@ -71,6 +78,15 @@ VmsListingRow.propTypes = {
     vmMessages: PropTypes.object.isRequired,
     pvs: PropTypes.array.isRequired,
     pod: PropTypes.object.isRequired,
+    vmUi: PropTypes.object,
+    onExpandChanged: PropTypes.func.isRequired,
 };
 
-export default VmsListingRow;
+export default connect(
+    ({ ui }, { vm }) => ({
+        vmUi: ui[vm.metadata.uid]
+    }),
+    (dispatch) => ({
+        onExpandChanged: (vm) => (isExpanded) => dispatch(vmExpanded({ vm, isExpanded }))
+    })
+)(VmsListingRow);

--- a/pkg/kubernetes/scripts/virtual-machines/index.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/index.jsx
@@ -17,27 +17,27 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import 'regenerator-runtime/runtime' // required for library initialization
-import React from 'react'
-import { createStore } from 'redux'
-import { Provider } from 'react-redux'
+import 'regenerator-runtime/runtime'; // required for library initialization
+import React from 'react';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
 
-import { initMiddleware } from './kube-middleware.jsx'
-import reducers from './reducers.jsx'
-import * as actionCreators from './action-creators.jsx'
-import VmsListing from './components/VmsListing.jsx'
+import { initMiddleware } from './kube-middleware.jsx';
+import reducers from './reducers.jsx';
+import * as actionCreators from './action-creators.jsx';
+import VmsListing from './components/VmsListing.jsx';
 
 import '../../../machines/machines.less'; // once per component hierarchy
 
-let reduxStore
+let reduxStore;
 
 function initReduxStore() {
     const initialState = {
         vms: []
-    }
+    };
 
     const storeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__();
-    reduxStore = createStore(reducers, initialState, storeEnhancers)
+    reduxStore = createStore(reducers, initialState, storeEnhancers);
 }
 
 function addKubeLoaderListener ($scope, kubeLoader, kubeSelect) {
@@ -62,12 +62,12 @@ const VmsPlugin = () => (
     <Provider store={reduxStore} >
         <VmsListing />
     </Provider>
-)
+);
 
 function addScopeVarsToStore ($scope) {
     $scope.$watch(
         (scope => scope.settings),
-        (newSettings => reduxStore.dispatch(actionCreators.setSettings(newSettings))))
+        (newSettings => reduxStore.dispatch(actionCreators.setSettings(newSettings))));
 }
 
 /**
@@ -77,12 +77,12 @@ function addScopeVarsToStore ($scope) {
  * @param {kubeSelect} kubeSelect
  */
 function init($scope, kubeLoader, kubeSelect, kubeMethods) {
-    initReduxStore()
-    initMiddleware(kubeMethods)
-    addKubeLoaderListener($scope, kubeLoader, kubeSelect)
-    addScopeVarsToStore($scope)
-    const rootElement = document.querySelector('#kubernetes-virtual-machines-root')
-    React.render(<VmsPlugin />, rootElement)
+    initReduxStore();
+    initMiddleware(kubeMethods);
+    addKubeLoaderListener($scope, kubeLoader, kubeSelect);
+    addScopeVarsToStore($scope);
+    const rootElement = document.querySelector('#kubernetes-virtual-machines-root');
+    React.render(<VmsPlugin />, rootElement);
 }
 
 export { init };

--- a/pkg/kubernetes/scripts/virtual-machines/index.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/index.jsx
@@ -26,12 +26,17 @@ import { initMiddleware } from './kube-middleware.jsx';
 import reducers from './reducers.jsx';
 import * as actionCreators from './action-creators.jsx';
 import VmsListing from './components/VmsListing.jsx';
+import { logDebug } from './utils.jsx';
 
 import '../../../machines/machines.less'; // once per component hierarchy
 
 let reduxStore;
-
 function initReduxStore() {
+    if (reduxStore) {
+        logDebug('initReduxStore(): store already initialized, skipping. ', reduxStore);
+        return;
+    }
+    logDebug('initReduxStore(): initializing empty store');
     const initialState = {
         vms: []
     };
@@ -42,7 +47,7 @@ function initReduxStore() {
 
 function addKubeLoaderListener ($scope, kubeLoader, kubeSelect) {
     // register load callback( callback, until )
-    kubeLoader.listen(function() {
+    kubeLoader.listen(() => {
         const vms = kubeSelect().kind('VirtualMachine')
         const persistentVolumes = kubeSelect().kind('PersistentVolume')
         const pods = kubeSelect().kind('Pod');
@@ -78,9 +83,10 @@ function addScopeVarsToStore ($scope) {
  */
 function init($scope, kubeLoader, kubeSelect, kubeMethods) {
     initReduxStore();
-    initMiddleware(kubeMethods);
     addKubeLoaderListener($scope, kubeLoader, kubeSelect);
+    initMiddleware(kubeMethods);
     addScopeVarsToStore($scope);
+
     const rootElement = document.querySelector('#kubernetes-virtual-machines-root');
     React.render(<VmsPlugin />, rootElement);
 }

--- a/pkg/kubernetes/scripts/virtual-machines/reducers.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/reducers.jsx
@@ -23,14 +23,14 @@ import * as actionTypes from './action-types.jsx'
 
 const createReducer = (initialState, actionHandlerMap) => (state = initialState, action) => {
     if (actionHandlerMap[action.type]) {
-        return actionHandlerMap[action.type](state, action)
+        return actionHandlerMap[action.type](state, action);
     }
-    return state
-}
+    return state;
+};
 
 const vmsReducer = createReducer([], {
     [actionTypes.SET_VMS]: (state = [], { payload }) => payload ? payload : []
-})
+});
 
 const pvsReducer = createReducer([], {
     [actionTypes.SET_PVS]: (state = [], { payload }) => payload ? payload : []
@@ -42,7 +42,7 @@ const podsReducer = createReducer([], {
 
 const settingsReducer = createReducer([], {
     [actionTypes.SET_SETTINGS]: (state = [], { payload }) => payload ? payload : {}
-})
+});
 
 const vmsMessagesReducer = createReducer({}, {
     [actionTypes.VM_ACTION_FAILED]: (state = {}, { payload: { vm, message, detail } }) => {
@@ -63,7 +63,7 @@ const vmsMessagesReducer = createReducer({}, {
       delete newState[vm.metadata.uid];
       return newState;
     },
-})
+});
 
 const rootReducer = combineReducers({
     vms: vmsReducer, // VirtualMachines from API
@@ -71,6 +71,6 @@ const rootReducer = combineReducers({
     pods: podsReducer, // Pods from API
     settings: settingsReducer,
     vmsMessages: vmsMessagesReducer,
-})
+});
 
-export default rootReducer
+export default rootReducer;

--- a/pkg/kubernetes/scripts/virtual-machines/reducers.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/reducers.jsx
@@ -28,22 +28,40 @@ const createReducer = (initialState, actionHandlerMap) => (state = initialState,
     return state;
 };
 
+/**
+ * state = [
+ *  { ... } : Vm
+ * ]
+ */
 const vmsReducer = createReducer([], {
     [actionTypes.SET_VMS]: (state = [], { payload }) => payload ? payload : []
 });
 
 const pvsReducer = createReducer([], {
     [actionTypes.SET_PVS]: (state = [], { payload }) => payload ? payload : []
-})
+});
 
 const podsReducer = createReducer([], {
     [actionTypes.SET_PODS]: (state = [], { payload }) => payload ? payload : []
 })
 
+/**
+ * state = [
+ *   {...}
+ * ]
+ */
 const settingsReducer = createReducer([], {
     [actionTypes.SET_SETTINGS]: (state = [], { payload }) => payload ? payload : {}
 });
 
+/**
+ * state = {
+ *  vmUID: {
+ *      message,
+ *      detail
+ *    }
+ * }
+ */
 const vmsMessagesReducer = createReducer({}, {
     [actionTypes.VM_ACTION_FAILED]: (state = {}, { payload: { vm, message, detail } }) => {
       const newState = Object.assign({}, state);
@@ -65,12 +83,26 @@ const vmsMessagesReducer = createReducer({}, {
     },
 });
 
+/**
+ * state = {
+ *  vmUID: {
+ *      isExpanded: boolean
+ *    }
+ * }
+ */
+const uiReducer = createReducer({}, {
+    [actionTypes.VM_EXPANDED]: (state = {}, { payload: { vm, isExpanded }}) => {
+        return Object.assign({}, state, { [vm.metadata.uid]: { isExpanded } });
+    }
+});
+
 const rootReducer = combineReducers({
     vms: vmsReducer, // VirtualMachines from API
     pvs: pvsReducer, // PersistenVolumes from API
     pods: podsReducer, // Pods from API
-    settings: settingsReducer,
-    vmsMessages: vmsMessagesReducer,
+    settings: settingsReducer, // settings gathered at run-time
+    vmsMessages: vmsMessagesReducer, // messages related to a VM
+    ui: uiReducer, // various UI-state descriptions (i.e. to restore UI after back-button)
 });
 
 export default rootReducer;

--- a/pkg/lib/cockpit-components-listing.jsx
+++ b/pkg/lib/cockpit-components-listing.jsx
@@ -45,6 +45,7 @@ require('./listing.less');
  * selectChanged optional: callback will be used when the "selected" state changes
  * selected optional: true if the item is selected, can't be true if row has navigation or expansion
  * initiallyExpanded optional: the entry will be initially rendered as expanded, but then behaves normally
+ * expandChanged optional: callback will be used if the row is either expanded or collapsed passing single `isExpanded` boolean argument
  */
 var ListingRow = React.createClass({
     propTypes: {
@@ -57,6 +58,7 @@ var ListingRow = React.createClass({
         selectChanged: React.PropTypes.func,
         selected: React.PropTypes.bool,
         initiallyExpanded: React.PropTypes.bool,
+        expandChanged: React.PropTypes.func,
         initiallyActiveTab: React.PropTypes.bool,
     },
     getDefaultProps: function () {
@@ -108,6 +110,8 @@ var ListingRow = React.createClass({
         }
 
         this.setState( { loadedTabs: loadedTabs });
+
+        this.props.expandChanged && this.props.expandChanged(willBeExpanded);
 
         e.stopPropagation();
         e.preventDefault();

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -443,8 +443,7 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         # return back to the virtual-machines
         b.wait_present("#vms-menu-link") # left-side menu
         b.click("#vms-menu-link")
-        b.wait_present("tr[data-row-id='vm-testvm']")
-        b.click("tr[data-row-id='vm-testvm']") # expand
+        b.wait_present("tr[data-row-id='vm-testvm']") # the row is already expanded if saving of UI state works
 
         # delete VM
         b.wait_present("#vm-testvm-delete")
@@ -469,8 +468,7 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
 
         # link to pod
         b.click("#vms-menu-link")
-        b.wait_present("tr[data-row-id='vm-testvm']")
-        b.click("tr[data-row-id='vm-testvm']")  # expand row
+        b.wait_present("tr[data-row-id='vm-testvm']") # the row is already expanded if saving of UI state works
         b.wait_present("#vm-testvm-pod")
         wait(lambda: b.text("#vm-testvm-pod > a").strip() != "")
         b.wait_in_text("#vm-testvm-pod", "virt-launcher-testvm---") # Example: virt-launcher-testvm-----rx59t


### PR DESCRIPTION
In the `Virtual Machines` view, the listing row keeps to be expanded even
when the user hits `back button` to return from another Cockpit's
view (like navigating to `Pods` view and coming back).

With this PR, the redux store is kept among various navigation steps through
cockpit making it a good place to store UI-state related data, so the view
can be fully restored once the `Virtual Machines` view is re-entered.