### PR TITLE
Fix tests in rhel-7.5 branch

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -651,6 +651,9 @@ class MachineCase(unittest.TestCase):
         # https://bugzilla.redhat.com/show_bug.cgi?id=1419263
         ".*type=1400 .*denied  { write } for.*firewalld.*__pycache__.*",
 
+        # HACK: affects *all* tests, impractical for a naughty (https://bugzilla.redhat.com/show_bug.cgi?id=1461893)
+        "type=1401 audit(.*): op=security_compute_av reason=bounds .* tclass=process.*",
+
         # https://bugzilla.redhat.com/show_bug.cgi?id=1242656
         "(audit: )?type=1400 .*denied.*comm=\"cockpit-ws\".*name=\"unix\".*dev=\"proc\".*",
         "(audit: )?type=1400 .*denied.*comm=\"ssh-transport-c\".*name=\"unix\".*dev=\"proc\".*",

--- a/test/common/testvm.py
+++ b/test/common/testvm.py
@@ -68,9 +68,15 @@ class Timeout:
         Specify machine to ensure that a machine's ssh operations are canceled when the timer expires.
     """
     def __init__(self, seconds=1, error_message='Timeout', machine=None):
+        if signal.getsignal(signal.SIGALRM) != signal.SIG_DFL:
+            # there is already a different Timeout active
+            self.seconds = None
+            return
+
         self.seconds = seconds
         self.error_message = error_message
         self.machine = machine
+
     def handle_timeout(self, signum, frame):
         if self.machine:
             if self.machine.ssh_process:
@@ -78,11 +84,16 @@ class Timeout:
             self.machine.disconnect()
 
         raise RuntimeError(self.error_message)
+
     def __enter__(self):
-        signal.signal(signal.SIGALRM, self.handle_timeout)
-        signal.alarm(self.seconds)
+        if self.seconds:
+            signal.signal(signal.SIGALRM, self.handle_timeout)
+            signal.alarm(self.seconds)
+
     def __exit__(self, type, value, traceback):
-        signal.alarm(0)
+        if self.seconds:
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, signal.SIG_DFL)
 
 class Failure(Exception):
     def __init__(self, msg):
@@ -363,7 +374,8 @@ class Machine:
         if not self._check_ssh_master():
             self._start_ssh_master()
 
-    def execute(self, command=None, script=None, input=None, environment={}, stdout=None, quiet=False, direct=False):
+    def execute(self, command=None, script=None, input=None, environment={},
+                stdout=None, quiet=False, direct=False, timeout=120):
         """Execute a shell command in the test machine and return its output.
 
         Either specify @command or @script
@@ -372,7 +384,8 @@ class Machine:
             command: The string to execute by /bin/sh.
             script: A multi-line script to execute in /bin/sh
             input: Input to send to the command
-            environment: Additional environmetn variables
+            environment: Additional environment variables
+            timeout: Applies if not already wrapped in a #Timeout context
         Returns:
             The command/script output as a string.
         """
@@ -428,41 +441,42 @@ class Machine:
             subprocess.call(cmd, stdout=stdout)
             return
 
-        output = ""
-        proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdin_fd = proc.stdin.fileno()
-        stdout_fd = proc.stdout.fileno()
-        stderr_fd = proc.stderr.fileno()
-        rset = [stdout_fd, stderr_fd]
-        wset = [stdin_fd]
-        while len(rset) > 0 or len(wset) > 0:
-            ret = select.select(rset, wset, [], 10)
-            for fd in ret[0]:
-                if fd == stdout_fd:
-                    data = os.read(fd, 1024)
-                    if data == "":
-                        rset.remove(stdout_fd)
-                        proc.stdout.close()
-                    else:
-                        if self.verbose:
-                            sys.stdout.write(data)
-                        output += data
-                elif fd == stderr_fd:
-                    data = os.read(fd, 1024)
-                    if data == "":
-                        rset.remove(stderr_fd)
-                        proc.stderr.close()
-                    elif not quiet or self.verbose:
-                        sys.stderr.write(data)
-            for fd in ret[1]:
-                if fd == stdin_fd:
-                    if input:
-                        num = os.write(fd, input)
-                        input = input[num:]
-                    if not input:
-                        wset.remove(stdin_fd)
-                        proc.stdin.close()
-        proc.wait()
+        with Timeout(seconds=timeout, error_message="Timed out on '%s'" % command, machine=self):
+            output = ""
+            proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdin_fd = proc.stdin.fileno()
+            stdout_fd = proc.stdout.fileno()
+            stderr_fd = proc.stderr.fileno()
+            rset = [stdout_fd, stderr_fd]
+            wset = [stdin_fd]
+            while len(rset) > 0 or len(wset) > 0:
+                ret = select.select(rset, wset, [], 10)
+                for fd in ret[0]:
+                    if fd == stdout_fd:
+                        data = os.read(fd, 1024)
+                        if data == "":
+                            rset.remove(stdout_fd)
+                            proc.stdout.close()
+                        else:
+                            if self.verbose:
+                                sys.stdout.write(data)
+                            output += data
+                    elif fd == stderr_fd:
+                        data = os.read(fd, 1024)
+                        if data == "":
+                            rset.remove(stderr_fd)
+                            proc.stderr.close()
+                        elif not quiet or self.verbose:
+                            sys.stderr.write(data)
+                for fd in ret[1]:
+                    if fd == stdin_fd:
+                        if input:
+                            num = os.write(fd, input)
+                            input = input[num:]
+                        if not input:
+                            wset.remove(stdin_fd)
+                            proc.stdin.close()
+            proc.wait()
 
         if proc.returncode != 0:
             raise subprocess.CalledProcessError(proc.returncode, command, output=output)

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -57,7 +57,9 @@ def initially_loopbacked(machine):
         return False
 
     # use the overlayfs or aufs driver by default on some distros
-    if machine.image in [ "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-26", "fedora-testing", "fedora-27", "fedora-atomic" ]:
+    if machine.image in [ "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable",
+                          "fedora-26", "fedora-testing", "fedora-27", "fedora-atomic",
+                          "rhel-7-5" ]:
         return False
 
     # The rest don't have space in the root volume group, or don't


### PR DESCRIPTION
Tests on current rhel-7.5 branch fail and hang. Backport a few fixes to keep them green again.

This also provides a guinea pig for validating the make-checkout and test-invoke changes (PR #8552, #8553, etc.)