### PR TITLE
test: Don't count retried tests as failures

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1052,7 +1052,7 @@ class TapRunner(object):
         # Write the output
         sys.stdout.write(output)
 
-        if "# SKIP " in output:
+        if "# SKIP " in output or "# RETRY" in output:
             failed = 0
 
         # Whether we should retry the test or not


### PR DESCRIPTION
Reset the test's failure flag when encountering a network or
infrastructure hiccup (such as failing to boot a machine) and a test is
retried. This should not contribute to the overall test failure count.

This fixes failing tests if some tests got retried, but otherwise all
succeeded.

Fixes #8585