### PR TITLE
bots: Drop obsolete unsetting of TEST_DATA

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -359,11 +359,6 @@ class PullTask(object):
 
 
         env = os.environ.copy()
-        # COMPAT: we can only use the cache for new enough branches which have the test/bots split;
-        # don't destroy the old test/images symlink farm
-        if "TEST_DATA" in env and subprocess.call(['git', 'ls-tree', '-d', 'HEAD:bots/images'],
-                                                  stdout=DEVNULL, stderr=DEVNULL) != 0:
-            del env["TEST_DATA"]
         env["PATH"] = "{0}:{1}:{2}".format(env.get("PATH", "/bin:/sbin"), BOTS, test)
 
         # Setup network if necessary, any failures caught during testing


### PR DESCRIPTION
This was introduced in commit 3a0980 and remedied in commit d9c14525a to
support the old rhel-7.4 branch. But that does not use the old
test/images any more since
https://github.com/cockpit-project/cockpit/commit/f2ca300c51 (and they
would not work any more anyway, as the images are long gone). Thus this
hack is obsolete now.

This makes the image cache actually being used for testing third-party
modules, where this particular way of checking for bots/images failed.