### PR TITLE
Revert "build: Ship integration tests"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -385,12 +385,6 @@ dist-xz: distdir
 distcheck-hook::
 	$(srcdir)/tools/check-dist $(distdir)
 
-install-integration-tests::
-	$(MKDIR_P) $(DESTDIR)$(pkgdatadir)
-	( cd $(srcdir); git ls-tree HEAD --full-tree --name-only -r test || echo test ) | \
-		tar -C $(srcdir) -cf - -T - | tar -C $(DESTDIR)$(pkgdatadir) -xf -
-	rm -r $(DESTDIR)$(pkgdatadir)/test/tmp; ln -sf /var/tmp/cockpit $(DESTDIR)$(pkgdatadir)/test/tmp
-
 include po/Makefile.am
 include pkg/Makefile.am
 include src/base1/Makefile.am

--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -57,7 +57,7 @@ def main():
         build_image = get_build_image(args.build_image or base_image)
 
     # Depending on the operating system ignore some things
-    skips = [ "cockpit-integration-tests" ]
+    skips = []
     if args.address:
         skips.append("cockpit-tests")
         args.install_only = True

--- a/containers/Makefile.am
+++ b/containers/Makefile.am
@@ -34,19 +34,6 @@ WS_DIR = $(srcdir)/containers/ws
 
 CLEANFILES += $(WS_DIR)/rpms
 
-# needed for installed integration tests
-ATOMIC_SETUP = \
-	$(WS_DIR)/atomic-install   \
-	$(WS_DIR)/atomic-run       \
-	$(WS_DIR)/atomic-uninstall \
-	$(NULL)
-
-EXTRA_DIST += $(ATOMIC_SETUP)
-
-install-integration-tests::
-	$(MKDIR_P) $(DESTDIR)/$(pkgdatadir)/containers/ws/
-	$(INSTALL_PROGRAM) $(ATOMIC_SETUP) $(DESTDIR)/$(pkgdatadir)/containers/ws/
-
 ws-container:
 	rm -rf $(WS_DIR)/rpms && mkdir -p $(WS_DIR)/rpms
 	cd $(WS_DIR)/rpms && $(abs_srcdir)/tools/make-rpms

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -152,7 +152,6 @@ make -j4 check
 %install
 make install DESTDIR=%{buildroot}
 make install-tests DESTDIR=%{buildroot}
-make install-integration-tests DESTDIR=%{buildroot}
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/pam.d
 install -p -m 644 tools/cockpit.pam $RPM_BUILD_ROOT%{_sysconfdir}/pam.d/cockpit
 rm -f %{buildroot}/%{_libdir}/cockpit/*.so
@@ -505,34 +504,6 @@ These files are not required for running Cockpit.
 %config(noreplace) %{_sysconfdir}/cockpit/cockpit.conf
 %{_datadir}/%{name}/playground
 %{_prefix}/%{__lib}/cockpit-test-assets
-
-%package integration-tests
-Summary: Integration tests for Cockpit
-Requires: curl
-Requires: expect
-Requires: libvirt
-Requires: libvirt-client
-Requires: libvirt-daemon
-%if 0%{?rhel} >= 8 || 0%{?centos} >= 8 || 0%{?fedora} >= 27
-Requires: python2-libvirt
-%else
-Requires: libvirt-python
-%endif
-Requires: qemu-kvm
-Requires: npm
-Requires: python2
-Requires: rsync
-Requires: xz
-Requires: openssh-clients
-Requires: fontconfig
-
-%description integration-tests
-This package contains Cockpit's integration tests for running in VMs.
-These are not required for running Cockpit.
-
-%files integration-tests
-%{_datadir}/%{name}/test
-%{_datadir}/%{name}/containers
 
 %package ws
 Summary: Cockpit Web Service


### PR DESCRIPTION
This was an experiment for an early version of
https://fedoraproject.org/wiki/Changes/InvokingTests which proposed that
tests must be packaged. Now tests are shipped in dist-git and can run
them out of the source tree, so there is no reason to ship them as RPM
any more.

It also wouldn't really work as running the tests now requires the
scripts in bots/. As this RPM has never been used and doesn't get
tested, drop it.

This reverts commit a4d18dc8d51727576a1fe8d313bc7028b12b6e83.