### PR TITLE
naughty: Close 8389: SSH sessions are in a private "mnt" namespace

### DIFF
--- a/bots/naughty/debian-testing/8389-crippled-ssh-sessions
+++ b/bots/naughty/debian-testing/8389-crippled-ssh-sessions
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "./test/verify/check-storage-mounting", line *, in testMounting
-    b.wait_not_in_text("#storage_mounts", mount_point_bar)

--- a/bots/naughty/debian-testing/8389-crippled-ssh-sessions-2
+++ b/bots/naughty/debian-testing/8389-crippled-ssh-sessions-2
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-storage-used", line *, in testUsed
-    self.content_tab_wait_in_info(2, 1, "Mounted At", "/mnt")


### PR DESCRIPTION
Known issue which has not occurred in 25 days

SSH sessions are in a private "mnt" namespace

Fixes #8389