### PR TITLE
sosreport: Increase max file size to 150M

### DIFF
--- a/pkg/sosreport/index.js
+++ b/pkg/sosreport/index.js
@@ -98,6 +98,7 @@
                         binary: "raw",
                         path: archive,
                         superuser: true,
+                        max_read_size: 150 * 1024 * 1024,
                         external: {
                             "content-disposition": 'attachment; filename="' + basename + '"',
                             "content-type": "application/x-xz, application/octet-stream"


### PR DESCRIPTION
The cockpit default is 16M and these reports can pretty easily exceed
that size.

"Fixes" the immediate issue that caused #8589 to be seen.

I didn't have a particular reason to pick 150 MB. It just seemed both large enough to be useful and small enough not to be harmful. Sizing recommendations are welcome.