### PR TITLE
ws: Fix i18n of login page

### DIFF
--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -53,8 +53,8 @@
               </div>
               <div class="col-sm-2 col-md-2"></div>
               <div class="col-sm-10 col-md-10">
-                <label class="control-label">
-                    <input type="checkbox" class="form-control" id="authorized-input" translate>Reuse my password for privileged tasks</label>
+                <input type="checkbox" class="form-control" id="authorized-input">
+                <label for="authorized-input" class="control-label" translate>Reuse my password for privileged tasks</label>
               </div>
             </div>
 

--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -448,7 +448,7 @@
         id("user-group").style.display = in_conversation ? "none" : "block";
         id("password-group").style.display = in_conversation ? "none" : "block";
         id("conversation-group").style.display = in_conversation ? "block" : "none";
-        id("login-button-text").textContent = "Log In";
+        id("login-button-text").textContent = _("Log In");
         id("login-password-input").value = '';
 
         if (need_host()) {
@@ -474,7 +474,7 @@
     function show_login() {
         /* Show the login screen */
         id("server-name").textContent = document.title;
-        login_note("Log in with your server user account.");
+        login_note(_("Log in with your server user account."));
         id("login-user-input").addEventListener("keydown", function(e) {
             login_failure(null);
             if (e.which == 13)


### PR DESCRIPTION
There were three untranslatable strings:

- Wrap "Log in with your server user account." label and "Log In" button
  in `gettext()` calls.
- Don't put an `<input>` element into the translatable "Reuse my password
  for privileged tasks" label; as the value is not a plain string, this breaks the
   `gettext` call. Put the label separately, as for the other input lines.

https://bugzilla.redhat.com/show_bug.cgi?id=1541454