### PR TITLE
packagekit: update the severity colors to more a11y friendly ones

### DIFF
--- a/pkg/packagekit/updates.css
+++ b/pkg/packagekit/updates.css
@@ -19,7 +19,7 @@ tr.listing-ct-item td.type {
 }
 
 .severity-critical {
-    color: #cc0000;
+    color: #a30000;
 }
 
 .severity-important {
@@ -27,7 +27,7 @@ tr.listing-ct-item td.type {
 }
 
 .severity-low {
-    color: #8b8d8f;
+    color: #72767b;
 }
 
 tr.listing-ct-item td.changelog {


### PR DESCRIPTION
The guidelines from UXD was updated, since the old colors had some
some visibility issues for people with a certain color blindness.

Fixes issue #8629