### PR TITLE
test: Add environment variable to disable check for unexpected SELinux messages

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -776,7 +776,8 @@ class MachineCase(unittest.TestCase):
         machine = machine or self.machine
         syslog_ids = [ "cockpit-ws", "cockpit-bridge" ]
         messages = machine.journal_messages(syslog_ids, 5)
-        messages += machine.audit_messages("14") # 14xx is selinux
+        if "TEST_AUDIT_NO_SELINUX" not in os.environ:
+            messages += machine.audit_messages("14") # 14xx is selinux
         all_found = True
         first = None
         for m in messages:


### PR DESCRIPTION
Unexpected SELinux messages often get in the way for testing external
modules and also older downstream versions on newer images, so provide a
knob to skip this part.