### PR TITLE
test: Fix verbose dumping of execute output harder

### DIFF
--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -462,7 +462,7 @@ class Machine:
                             proc.stdout.close()
                         else:
                             if self.verbose:
-                                sys.stdout.write(data.decode('utf-8', 'ignore'))
+                                os.write(sys.stdout.fileno(), data)
                             output += data.decode('utf-8', 'replace')
                     elif fd == stderr_fd:
                         data = os.read(fd, 1024)
@@ -470,7 +470,7 @@ class Machine:
                             rset.remove(stderr_fd)
                             proc.stderr.close()
                         elif not quiet or self.verbose:
-                            sys.stderr.write(data.decode('utf-8', 'ignore'))
+                            os.write(sys.stderr.fileno(), data)
                 for fd in ret[1]:
                     if fd == stdin_fd:
                         if input:


### PR DESCRIPTION
Commit 1105141a improved this, but not enough yet:
`test/verify/check-system-info TestSystemInfo.testBasic -tv` still fails
with

```
+ journalctl 2>&1 -o cat -p 5 SYSLOG_IDENTIFIER=cockpit-ws SYSLOG_IDENTIFIER=cockpit-bridge || true
Traceback (most recent call last):
  File "/build/cockpit/bots/../test/verify/check-system-info", line 188, in testBasic
    self.check_journal_messages()
  File "/build/cockpit/test/common/testlib.py", line 780, in check_journal_messages
    messages = machine.journal_messages(syslog_ids, 5)
  File "/build/cockpit/bots/machine/testvm.py", line 625, in journal_messages
    messages = self.execute(cmd).splitlines()
  File "/build/cockpit/bots/machine/testvm.py", line 465, in execute
    sys.stdout.write(data.decode('utf-8', 'ignore'))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u201c' in position 58: ordinal not in range(128)
```

The previous approach of writing an unicode string to sys.stdout still
fails if `sys.stdout.encoding` is not set, and it seems wrong to change
it inside testvm.py. So move to completely ignoring the encoding layers
and just write the raw bytes to stdout/stderr.