### PR TITLE
test: Adjust expected messages in check-apps

### DIFF
--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -110,7 +110,7 @@ class TestApps(PackageCase):
 
         # Switching to a language might produce these messages, which seem to be harmless.
         self.allow_journal_messages("invalid or unusable locale.*",
-                                    "Error receiving data: Connection reset by peer")
+                                    "Error .* data: Connection reset by peer")
 
         # Reset everything
         m.execute("rm -rf /usr/share/metainfo /usr/share/app-info /var/cache/app-info")


### PR DESCRIPTION
The test sometimes fails with

    Unexpected journal message 'Error sending data: Connection reset by peer'

So allow messages about both sending and receiving.