### PR TITLE
test: Fix expect_load() races

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -118,13 +118,8 @@ class Browser:
         if cookie:
             self.cdp.invoke("Network.setCookie", **cookie)
         self.switch_to_top()
-        if opts.trace:
-            print("-> open " + href)
-        # Page.navigate() already waits for the page to load, but not for loadEventFired; set up waiting for that
-        # first to avoid a race: calling expect_load() after Page.navigate() might miss the event
-        self.cdp.command("pr = expectLoad(%i); client.Page.navigate({ url: '%s' }).then(() => pr)" % (self.cdp.timeout * 1000, href))
-        if opts.trace:
-            print("<- open " + href + " done")
+        self.cdp.invoke("Page.navigate", url=href)
+        self.expect_load()
 
     def reload(self, ignore_cache=False):
         self.switch_to_top()


### PR DESCRIPTION
PR #8606 fixed the "CDP command, then expect_load" race for
`Browser.open()`, as that was the most prominent (and only observed)
failure. However, in principle this affects every other scenario as
well, e. g. clicking a Log In button or navigation menu entry, whose
page load could then happen before calling `expect_load()`.

Generalize the approach by setting up the `Page.loadEventFired()`
promise before every CDP command, except for `expectLoad()` itself, and
then make the latter just wait on that promise.

----

~This is WIP for now, as this might cause some fallout from tests which use expect_load() wrongly. But let's fix these, as I believe the general approach of this is better than the status quo.~ However, if someone has an idea how to make the code less ugly, I'm all ears!

 - [x] PR #8606