### PR TITLE
storage: Try to use a stable name for the VDO backing device

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -733,7 +733,7 @@
 
         function create(options) {
             var args = [ "create", "--name", options.name,
-                         "--device", utils.decode_filename(options.block.PreferredDevice) ];
+                         "--device", utils.stable_device_name(options.block) ];
             if (options.logical_size !== undefined)
                 args.push("--vdoLogicalSize", options.logical_size + "B");
             if (options.index_mem !== undefined)

--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -256,10 +256,10 @@
                       <div class="radio">
                         <label><input type="radio" name={{SelectOneOfMany}}
                                       {{#checked}}checked{{/checked}} value="{{value}}">
-                          {{#Label}}
-                          <span class="pull-right">{{.}}</span>
-                          {{/Label}}
                           <span>{{Title}}</span>
+                          {{#Label}}
+                          <span>{{.}}</span>
+                          {{/Label}}
                         </label>
                       </div>
                     </li>

--- a/pkg/storaged/vdos-panel.jsx
+++ b/pkg/storaged/vdos-panel.jsx
@@ -42,7 +42,9 @@ export class VDOsPanel extends React.Component {
                     break;
             }
 
-            var spaces = get_available_spaces(client).map(available_space_to_option);
+            var spaces = get_available_spaces(client).map(function (spc) {
+                return available_space_to_option(spc, true);
+            });
 
             dialog.open({ Title: _("Create VDO Device"),
                           Fields: [


### PR DESCRIPTION
Because of the way VDO works, the name of the device given to "vdo
create" needs to be stable across reboots.

This is unlike LVM2, for example, which will find its physical volumes
via the signature it writes to the volume itself.  Argueably VDO
should do the same, as no name can be truly stable.  But we can at
least try.