### PR TITLE
naughty: Close 8272: Kernel 4.14 on Fedora breaks core dumping for processes in namespaces

### DIFF
--- a/bots/naughty/fedora-26/8272-selinux-systemd-unit-coredumping
+++ b/bots/naughty/fedora-26/8272-selinux-systemd-unit-coredumping
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "/build/cockpit/bots/../test/verify/check-connection", line *, in testBasic
-    wait(lambda: m.execute("journalctl -b | grep 'Process.*systemd-hostnam.*of user.*dumped core.'"))
-*
-CalledProcessError: Command 'journalctl -b | grep 'Process.*systemd-hostnam.*of user.*dumped core.'' returned non-zero exit status 1

--- a/bots/naughty/fedora-27/8272-selinux-systemd-unit-coredumping
+++ b/bots/naughty/fedora-27/8272-selinux-systemd-unit-coredumping
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "/build/cockpit/bots/../test/verify/check-connection", line *, in testBasic
-    wait(lambda: m.execute("journalctl -b | grep 'Process.*systemd-hostnam.*of user.*dumped core.'"))
-*
-CalledProcessError: Command 'journalctl -b | grep 'Process.*systemd-hostnam.*of user.*dumped core.'' returned non-zero exit status 1


### PR DESCRIPTION
Known issue which has not occurred in 22 days

Kernel 4.14 on Fedora breaks core dumping for processes in namespaces

Fixes #8272