### PR TITLE
system, mobile: drop extra padding in system info table

### DIFF
--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -622,10 +622,34 @@ li.credential-lock > a:first-child {
   }
 }
 
+@media (max-width: 991px) {
+  #server .info-table-ct-container {
+      padding: 0 0 20px;
+      overflow: hidden;
+
+      th,
+      td:first-child {
+          padding-left: 0;
+      }
+
+      td:last-child {
+          max-width: 50vw;
+      }
+  }
+}
+
 @media (max-width: 480px) {
-  /* server overview dashboard */
-  #server .info-table-ct-container td button {
-      max-width: 200px;
+  #server .info-table-ct-container {
+
+      td {
+          overflow: auto;
+          word-wrap: break-word;
+
+          /* server overview dashboard */
+          button {
+              max-width: 200px;
+          }
+      }
   }
 }
 


### PR DESCRIPTION
This change should fix the system information table rendering oddly on mobile in issue #8464 by removing a bit of extra padding. 