### PR TITLE
Fix tests to work with current master bots/ and images

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -378,12 +378,6 @@ dist-xz: distdir
 distcheck-hook::
 	$(srcdir)/tools/check-dist $(distdir)
 
-install-integration-tests::
-	$(MKDIR_P) $(DESTDIR)$(pkgdatadir)
-	( cd $(srcdir); git ls-tree HEAD --full-tree --name-only -r test || echo test ) | \
-		tar -C $(srcdir) -cf - -T - | tar -C $(DESTDIR)$(pkgdatadir) -xf -
-	rm -r $(DESTDIR)$(pkgdatadir)/test/tmp; ln -sf /var/tmp/cockpit $(DESTDIR)$(pkgdatadir)/test/tmp
-
 include po/Makefile.am
 include pkg/Makefile.am
 include src/base1/Makefile.am

--- a/containers/Makefile.am
+++ b/containers/Makefile.am
@@ -34,19 +34,6 @@ WS_DIR = $(srcdir)/containers/ws
 
 CLEANFILES += $(WS_DIR)/rpms
 
-# needed for installed integration tests
-ATOMIC_SETUP = \
-	$(WS_DIR)/atomic-install   \
-	$(WS_DIR)/atomic-run       \
-	$(WS_DIR)/atomic-uninstall \
-	$(NULL)
-
-EXTRA_DIST += $(ATOMIC_SETUP)
-
-install-integration-tests::
-	$(MKDIR_P) $(DESTDIR)/$(pkgdatadir)/containers/ws/
-	$(INSTALL_PROGRAM) $(ATOMIC_SETUP) $(DESTDIR)/$(pkgdatadir)/containers/ws/
-
 ws-container:
 	rm -rf $(WS_DIR)/rpms && mkdir -p $(WS_DIR)/rpms
 	cd $(WS_DIR)/rpms && $(abs_srcdir)/tools/make-rpms

--- a/test/containers/check-kubernetes-openshift
+++ b/test/containers/check-kubernetes-openshift
@@ -85,7 +85,7 @@ class OCMachine(VirtMachine):
 
         # TODO: For now we only support cluster admins
         # This sometimes fails if openshift is still modifying the clusterpolicybinding
-        cmd = "oadm policy add-cluster-role-to-user cluster-admin admin"
+        cmd = "oc adm policy add-cluster-role-to-user cluster-admin admin"
         try:
             self.execute(cmd)
         except:

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -1042,9 +1042,9 @@ class TestRegistry(MachineCase):
         m = self.machine
 
         # create push and pull user and login as pushuser
-        o.execute("oadm policy add-role-to-user registry-viewer pulluser -n marmalade")
-        o.execute("oadm policy add-role-to-user registry-editor pushuser -n marmalade")
-        o.execute("oadm policy add-role-to-user registry-viewer pushuser -n pizzazz")
+        o.execute("oc adm policy add-role-to-user registry-viewer pulluser -n marmalade")
+        o.execute("oc adm policy add-role-to-user registry-editor pushuser -n marmalade")
+        o.execute("oc adm policy add-role-to-user registry-viewer pushuser -n pizzazz")
         tmpfile = os.path.join(self.tmpdir, "kubeconfig")
         o.execute('printf "pushuser\r\na\r\n" | oc login')
         o.download("/root/.kube/config", tmpfile)

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -146,7 +146,6 @@ make -j4 check
 %install
 make install DESTDIR=%{buildroot}
 make install-tests DESTDIR=%{buildroot}
-make install-integration-tests DESTDIR=%{buildroot}
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/pam.d
 install -p -m 644 tools/cockpit.pam $RPM_BUILD_ROOT%{_sysconfdir}/pam.d/cockpit
 rm -f %{buildroot}/%{_libdir}/cockpit/*.so
@@ -505,34 +504,6 @@ These files are not required for running Cockpit.
 %config(noreplace) %{_sysconfdir}/cockpit/cockpit.conf
 %{_datadir}/%{name}/playground
 %{_prefix}/%{__lib}/cockpit-test-assets
-
-%package integration-tests
-Summary: Integration tests for Cockpit
-Requires: curl
-Requires: expect
-Requires: libvirt
-Requires: libvirt-client
-Requires: libvirt-daemon
-%if 0%{?rhel}%{?centos} == 0 || 0%{?rhel} >= 8 || 0%{?centos} >= 8
-Requires: python2-libvirt
-%else
-Requires: libvirt-python
-%endif
-Requires: qemu-kvm
-Requires: npm
-Requires: python2
-Requires: rsync
-Requires: xz
-Requires: openssh-clients
-Requires: fontconfig
-
-%description integration-tests
-This package contains Cockpit's integration tests for running in VMs.
-These are not required for running Cockpit.
-
-%files integration-tests
-%{_datadir}/%{name}/test
-%{_datadir}/%{name}/containers
 
 %package ws
 Summary: Cockpit Web Service


### PR DESCRIPTION
See individual commit logs. This adjusts the tests to work with current openshift image and bots/ and also gets rid of some upstream <-> downstream diff of the .spec file.