### PR TITLE
lib: Fix duplicate RegExp with different flags

### DIFF
--- a/pkg/lib/machine-info.es6
+++ b/pkg/lib/machine-info.es6
@@ -38,12 +38,12 @@ export function cpu_ram_info(address) {
                 if (total_kb)
                     info.memory = total_kb*1024;
 
-                match = text.match(new RegExp(/^model name\s*:\s*(.*)$/, "m"));
+                match = text.match(/^model name\s*:\s*(.*)$/m);
                 if (match)
                     info.cpu_model = match[1];
 
                 info.cpus = 0;
-                var re = new RegExp("^processor", "gm");
+                var re = /^processor/gm;
                 while (re.test(text))
                     info.cpus += 1;
                 dfd.resolve(info);


### PR DESCRIPTION
Consistently use the `/regexp/` syntax for clarity, and avoid wrapping a
regular expression into another. The latter might lead to

    Page error: TypeError: Cannot supply flags when constructing one RegExp from another.

Consistently use the `/regexp/` syntax for clarity.