### PR TITLE
bots: Drop naughty override for #6359 on fedora-27

### DIFF
--- a/bots/naughty/fedora-27/6359-glib-networking-change-cert
+++ b/bots/naughty/fedora-27/6359-glib-networking-change-cert
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-openshift", line *, in testReconnectChangeCert
-    b.wait_present("#service-list")
-*
-Error: timeout


### PR DESCRIPTION
glib-networking's handling of certificates got fixed a few months ago
(https://bugzilla.gnome.org/show_bug.cgi?id=781578). Fedora 27 has this
glib-networking version, so drop the known issue there.