### PR TITLE
test: Adjust for changed PCP 4.x API

### DIFF
--- a/src/bridge/mock-pmda.c
+++ b/src/bridge/mock-pmda.c
@@ -74,12 +74,19 @@ static int64_t counter64 = INT64_MAX - 100;
 static int
 mock_fetchCallBack(pmdaMetric *mdesc, unsigned int inst, pmAtomValue *atom)
 {
+#if PM_VERSION_CURRENT >= PM_VERSION(4,0,0)
+  if (pmID_cluster(mdesc->m_desc.pmid) != 0)
+    return PM_ERR_PMID;
+
+  switch (pmID_item(mdesc->m_desc.pmid)) {
+#else
   __pmID_int		*idp = (__pmID_int *)&(mdesc->m_desc.pmid);
 
   if (idp->cluster != 0)
     return PM_ERR_PMID;
 
   switch (idp->item) {
+#endif
   case 0:
     if (inst != PM_IN_NULL)
       return PM_ERR_INST;

--- a/src/bridge/test-pcp.c
+++ b/src/bridge/test-pcp.c
@@ -46,8 +46,13 @@ init_mock_pmda (void)
       exit (0);
     }
 
+#if PM_VERSION_CURRENT >= PM_VERSION(4,0,0)
+  g_assert (pmSpecLocalPMDA ("clear") == NULL);
+  g_assert (pmSpecLocalPMDA ("add,333,./mock-pmda.so,mock_init") == NULL);
+#else
   g_assert (__pmLocalPMDA (PM_LOCAL_CLEAR, 0, NULL, NULL) >= 0);
   g_assert (__pmLocalPMDA (PM_LOCAL_ADD, 333, "./mock-pmda.so", "mock_init") >= 0);
+#endif
 
   void *handle = dlopen ("./mock-pmda.so", RTLD_NOW);
   g_assert (handle != NULL);


### PR DESCRIPTION
PCP 4.0 dropped some internal APIs and replaced them with official
functions:

 * The `__pmID_int` bit field got replaced with `pmID_*(pmID)`
   accessors.
 * `__pmLocalPMDA()` and the `PM_LOCAL_*` constants got replaced with a
   string specification with `pmSpecLocalPMDA()`.

These don't exist yet in 3.x, so use a macro version test for the two
code paths for the time being.

Fixes #8674