### PR TITLE
storaged: Drop VDO async option

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -752,8 +752,6 @@
                 args.push("--deduplication", options.deduplication? "enabled" : "disabled");
             if (options.emulate_512 !== undefined)
                 args.push("--emulate512", options.emulate_512? "enabled" : "disabled");
-            if (options.asynchronous !== undefined)
-                args.push("--writePolicy", options.asynchronous? "async" : "sync");
             return cmd(args);
         }
 

--- a/pkg/storaged/vdos-panel.jsx
+++ b/pkg/storaged/vdos-panel.jsx
@@ -98,10 +98,6 @@ export class VDOsPanel extends React.Component {
                                 Title: _("Deduplication"),
                                 Value: true
                               },
-                              { CheckBox: "asynchronous",
-                                Title: _("Transfer data asynchronously"),
-                                Value: false,
-                              },
                               { CheckBox: "emulate_512",
                                 Title: _("Use 512 Byte emulation"),
                                 Value: false
@@ -124,7 +120,6 @@ export class VDOsPanel extends React.Component {
                                                             index_mem: vals.index_mem,
                                                             compression: vals.compression,
                                                             deduplication: vals.deduplication,
-                                                            asynchronous: vals.asynchronous,
                                                             emulate_512: vals.emulate_512
                                                         });
                                                     });


### PR DESCRIPTION
The current VDO version will auto detect the correct setting to use for
write policy (either sync or async).  Explicitly setting the option
disable the auto feature and set VDO to async mode, which may get
into an unsupported configuration later on.

As this is also an option that is quite hard to explain to users and we
don't/can't give them the information that they need to do an informed
decision, just remove the option completely and rely on automatic
detection.