### PR TITLE
systemd: Fix hardware information page jump

### DIFF
--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -1475,7 +1475,7 @@ $("#link-disk").on("click", function() {
 });
 
 $("#system_information_hardware_text").on("click", function() {
-    cockpit.jump("/system/hwinfo");
+    cockpit.jump("/system/hwinfo", cockpit.transport.host);
     return false;
 });
 


### PR DESCRIPTION
Stay on the current machine instead of going back to the cockpit host.

Fixes #8681