### PR TITLE
machines: Fix memory/storage key filter

### DIFF
--- a/pkg/machines/helpers.es6
+++ b/pkg/machines/helpers.es6
@@ -151,13 +151,14 @@ export function logError(msg, ...params) {
 }
 
 export function digitFilter(event, allowDots = false) {
-    let doNotFilter = (allowDots && event.charCode === 46) || event.charCode >= 48 && event.charCode <= 57;
+    let accept = (allowDots && event.key === '.') || (event.key >= '0' && event.key <= '9') ||
+                 event.key === 'Backspace' || event.key === 'Delete' || event.key === 'Tab' ||
+                 event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'Home' || event.key === 'End';
 
-    if (!doNotFilter) {
+    if (!accept)
         event.preventDefault();
-    }
 
-    return doNotFilter;
+    return accept;
 }
 
 export function getTodayYearShifted(yearDifference) {

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -225,7 +225,10 @@ class Browser:
 
     def key_press(self, keys):
         for k in keys:
-            self.cdp.invoke("Input.dispatchKeyEvent", type="char", text=k)
+            if k.isalnum():
+                self.cdp.invoke("Input.dispatchKeyEvent", type="char", text=k, key=k)
+            else:
+                self.cdp.invoke("Input.dispatchKeyEvent", type="char", text=k)
 
     def wait_timeout(self, timeout):
         browser = self


### PR DESCRIPTION
Fix the key filter for the `MemorySelectRow` component to allow
navigation (cursor, home, end, tab) and edit (backspace, delete) keys.

Also stop using the non-standard and deprecated `charCode` (see
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/charCode)
and use the `key` event attribute instead.

Finally, rename the variable to something less ambiguous, as `filter`
can mean both "accept" and "reject".

Fixes #8678