### PR TITLE
bots: Declare fedora-28 image

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -35,6 +35,7 @@ DEFAULT_VERIFY = {
     'verify/fedora-i386': BRANCHES,
     'verify/fedora-26': [ ],
     'verify/fedora-27': [ 'master' ],
+    'verify/fedora-28': [ ],
     'verify/fedora-atomic': BRANCHES,
     'verify/fedora-testing': [ ],
     'verify/ubuntu-1604': [ 'master' ],


### PR DESCRIPTION
Fedora 28 has branched off rawhide, and we will soon start testing
Cockpit on  Fedora 28. Make the image known to the bots.