### PR TITLE
bridge: Quiesce repeated /proc/diskstats messages

### DIFF
--- a/src/bridge/cockpitblocksamples.c
+++ b/src/bridge/cockpitblocksamples.c
@@ -32,10 +32,15 @@ cockpit_block_samples (CockpitSamples *samples)
   GError *error = NULL;
   gchar **lines = NULL;
   guint n;
+  static gboolean not_supported = FALSE;
+
+  if (not_supported)
+      goto out;
 
   if (!g_file_get_contents ("/proc/diskstats", &contents, &len, &error))
     {
       g_message ("error loading contents /proc/diskstats: %s", error->message);
+      not_supported = TRUE;
       goto out;
     }
 

--- a/src/bridge/cockpitdisksamples.c
+++ b/src/bridge/cockpitdisksamples.c
@@ -38,11 +38,16 @@ cockpit_disk_samples (CockpitSamples *samples)
   guint64 num_ops;
   gsize len;
   guint n;
+  static gboolean not_supported = FALSE;
+
+  if (not_supported)
+      goto out;
 
   if (!g_file_get_contents ("/proc/diskstats", &contents, &len, &error))
     {
-      g_message ("error loading contents /proc/vmstat: %s", error->message);
+      g_message ("error loading contents /proc/diskstats: %s", error->message);
       g_error_free (error);
+      not_supported = TRUE;
       goto out;
     }
 


### PR DESCRIPTION
If `/proc/diskstats` cannot be opened, remember this and exit
`cockpit_{block,disk}_samples()` immediately and quietly instead of
repeatedly complaining about the error.

Fixes #8630