### PR TITLE
test: Fix vm-run --network

### DIFF
--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -1045,13 +1045,13 @@ class VirtMachine(Machine):
                 raise
 
     # start virsh console
-    def qemu_console(self):
+    def qemu_console(self, extra_message=""):
         self.message("Started machine {0}".format(self.label))
         if self.maintain:
             message = "\nWARNING: Uncontrolled shutdown can lead to a corrupted image\n"
         else:
             message = "\nWARNING: All changes are discarded, the image file won't be changed\n"
-        message += self.diagnose() + "\nlogin: "
+        message += self.diagnose() + extra_message + "\nlogin: "
         message = message.replace("\n", "\r\n")
 
         try:

--- a/test/vm-run
+++ b/test/vm-run
@@ -27,9 +27,10 @@ import testvm
 
 NETWORK_SCRIPT="""
     set -ex
-	/bin/virsh net-destroy cockpit1 || true
-	/bin/virsh net-undefine cockpit1 || true
+    /bin/virsh net-destroy cockpit1 || true
+    /bin/virsh net-undefine cockpit1 || true
     /bin/virsh net-define /dev/stdin <<EOF
+
 <network ipv6='yes'>
   <name>cockpit1</name>
   <uuid>f3605fa4-0763-41ea-8143-49da3bf73263</uuid>
@@ -48,8 +49,19 @@ NETWORK_SCRIPT="""
   <ip family="ipv6" address="fd00:111:112::1" prefix="64"/>
 </network>
 EOF
-	/bin/virsh net-autostart cockpit1
-	/bin/virsh net-start cockpit1
+
+    if [ ! -u /usr/libexec/qemu-bridge-helper ]; then
+        chmod -v u+s /usr/libexec/qemu-bridge-helper
+    fi
+
+    for qemu_config in /etc/qemu-kvm/bridge.conf /etc/qemu/bridge.conf; do
+       if [ -e "$qemu_config" ] && ! grep -qF cockpit1 "$qemu_config"; then
+          echo "allow cockpit1" >> "$qemu_config"
+       fi
+    done
+
+    /bin/virsh net-autostart cockpit1
+    /bin/virsh net-start cockpit1
 """
 
 parser = argparse.ArgumentParser(description='Run a test machine')

--- a/test/vm-run
+++ b/test/vm-run
@@ -21,6 +21,7 @@ import errno
 import os
 import subprocess
 import sys
+import re
 
 from verify import parent
 import testvm
@@ -121,13 +122,21 @@ try:
 
     machine.start()
 
+    # for a bridged network, up its interface with DHCP and show it in the console message
+    message = ""
+    if args.network and bridge:
+        machine.execute("nmcli connection modify 'System eth1' ipv4.method auto && nmcli connection up 'System eth1'")
+        output = machine.execute("ip -4 a show dev eth1")
+        ip = re.search("inet ([^/]+)", output).group(1)
+        message = "\nBRIDGE IP FROM HOST\n  %s\n" % ip
+
     # Graphics console necessary
     if "windows" in args.image:
         machine.graphics_console()
 
     # No graphics console necessary
     else:
-        machine.qemu_console()
+        machine.qemu_console(message)
 
 except testvm.Failure as ex:
     sys.stderr.write("vm-run: %s\n" % ex)


### PR DESCRIPTION
In order to use qemu-bridge-helper as an unprivileged user with
the cockpit1 network we have to configure things. We used to do
this in the vm-prep script, so move this logic to vm-run now that
it's housed there.