### PR TITLE
test: Fix the bots and test directory pyflakes

### DIFF
--- a/bots/task/github.py
+++ b/bots/task/github.py
@@ -25,9 +25,7 @@ import errno
 import http.client
 import json
 import os
-import re
 import socket
-import subprocess
 import sys
 import time
 import urllib.parse

--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -29,6 +29,7 @@ sys.dont_write_bytecode = True
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 from verify import parent
+parent # pyflakes
 
 import testvm
 

--- a/test/containers/check-bastion
+++ b/test/containers/check-bastion
@@ -26,6 +26,8 @@ test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(test_dir)
 
 from verify import parent
+parent # pyflakes
+
 from testlib import *
 from testvm import VirtMachine
 

--- a/test/containers/check-kubernetes
+++ b/test/containers/check-kubernetes
@@ -25,6 +25,8 @@ test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(test_dir)
 
 from verify import parent
+parent # pyflakes
+
 from testlib import *
 from testvm import VirtMachine
 from verify import kubelib

--- a/test/containers/check-kubernetes-openshift
+++ b/test/containers/check-kubernetes-openshift
@@ -27,7 +27,10 @@ base_dir = os.path.dirname(os.path.realpath(__file__))
 test_dir = os.path.dirname(base_dir)
 sys.path.append(test_dir)
 
-from verify import parent, kubelib
+from verify import parent
+parent # pyflakes
+
+from verify import kubelib
 from testlib import *
 from testvm import VirtMachine
 

--- a/test/containers/run-tests
+++ b/test/containers/run-tests
@@ -28,7 +28,10 @@ sys.dont_write_bytecode = True
 base_dir = os.path.dirname(os.path.realpath(__file__))
 testdir = os.path.dirname(base_dir)
 sys.path.append(testdir)
+
 from verify import parent
+parent # pyflakes
+
 from common import testlib
 
 def check_valid(filename):


### PR DESCRIPTION
These are flakes that show up when you run tools/test-static-code
in on master.

    bots/task/github.py:28: 're' imported but unused
    bots/task/github.py:30: 'subprocess' imported but unused
    test/avocado/run-tests:31: 'verify.parent' imported but unused
    test/containers/run-tests:31: 'verify.parent' imported but unused
    test/containers/check-bastion:28: 'verify.parent' imported but unused
    test/containers/check-kubernetes:27: 'verify.parent' imported but unused
    test/containers/check-kubernetes-openshift:30: 'verify.parent' imported but unused