### PR TITLE
machines: Allow Up/Down arrows in number inputs

### DIFF
--- a/pkg/machines/helpers.es6
+++ b/pkg/machines/helpers.es6
@@ -153,7 +153,9 @@ export function logError(msg, ...params) {
 export function digitFilter(event, allowDots = false) {
     let accept = (allowDots && event.key === '.') || (event.key >= '0' && event.key <= '9') ||
                  event.key === 'Backspace' || event.key === 'Delete' || event.key === 'Tab' ||
-                 event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'Home' || event.key === 'End';
+                 event.key === 'ArrowLeft' || event.key === 'ArrowRight' ||
+                 event.key === 'ArrowUp' || event.key === 'ArrowDown' ||
+                 event.key === 'Home' || event.key === 'End';
 
     if (!accept)
         event.preventDefault();


### PR DESCRIPTION
On Firefox, the memory and storage size number inputs didn't handle
ArrowUp and ArrowDown keys to increase and decrease their values. Fix
this by also passing these keys through in the filter function.

This doesn't happen on Chrome, which seems to circumvent the key press
event completely for some control keys.