### PR TITLE
naughty: Close 8467: AppArmor denies operation="signal" to libvirtd

### DIFF
--- a/bots/naughty/debian-testing/8467-apparmor-libvirt-signal
+++ b/bots/naughty/debian-testing/8467-apparmor-libvirt-signal
@@ -1,1 +1,0 @@
-audit: type=1400 * apparmor="DENIED" operation="signal" profile="/usr/sbin/libvirtd" pid=* comm="libvirtd" requested_mask="send" denied_mask="send" signal=kill peer="unconfined"


### PR DESCRIPTION
Known issue which has not occurred in 25 days

AppArmor denies operation="signal" to libvirtd

Fixes #8467