### PR TITLE
common: Don't use unsupported SIGSTKFLT on alpha and sparc

### DIFF
--- a/src/common/cockpitunixsignal.c
+++ b/src/common/cockpitunixsignal.c
@@ -67,7 +67,7 @@ struct signv {
   { "PIPE",     SIGPIPE },      /* 13 */
   { "ALRM",     SIGALRM },      /* 14 */
   { "TERM",     SIGTERM },      /* 15 */
-#ifndef _MIPS_ARCH
+#ifdef SIGSTKFLT
   { "STKFLT",   SIGSTKFLT },    /* 16 (arm,i386,m68k,ppc) */
 #endif
   { "CHLD",     SIGCHLD },      /* 17 (arm,i386,m68k,ppc), 20 (alpha,sparc*), 18 (mips) */


### PR DESCRIPTION
Currently, cockpit fails to build from source on alpha and sparc* in Debian as SIGSTKFLT is not defined on these architectures:

```bash
gcc -DHAVE_CONFIG_H -I.  -I. -I./src -I. -I./src -DSRCDIR=\"/<<PKGBUILDDIR>>\" -DBUILDDIR=\"/<<PKGBUILDDIR>>\" -DDATADIR=\"/usr/share\" -DPACKAGE_LIBEXEC_DIR=\""/usr/lib/cockpit"\" -DPACKAGE_SYSCONF_DIR=\""/etc"\" -DPACKAGE_BIN_DIR=\""/usr/bin"\" -DPACKAGE_LOCALSTATE_DIR=\""/var/lib/cockpit"\" -DPACKAGE_LIB_DIR=\""/usr/lib/sparc64-linux-gnu"\" -D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT  -Wdate-time -D_FORTIFY_SOURCE=2 -DG_LOG_DOMAIN=\"cockpit-protocol\" -pthread -I/usr/include/gio-unix-2.0/ -I/usr/include/glib-2.0 -I/usr/lib/sparc64-linux-gnu/glib-2.0/include -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_34 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_34 -pthread -I/usr/include/json-glib-1.0 -I/usr/include/glib-2.0 -I/usr/lib/sparc64-linux-gnu/glib-2.0/include   -Wall           -Werror=strict-prototypes -Werror=missing-prototypes           -Werror=implicit-function-declaration           -Werror=pointer-arith -Werror=init-self           -Werror=format=2           -Werror=return-type           -Werror=missing-include-dirs -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -g -c -o src/common/libcockpit_common_a-cockpitunixsignal.o `test -f 'src/common/cockpitunixsignal.c' || echo './'`src/common/cockpitunixsignal.c
src/common/cockpitunixsignal.c:71:17: error: 'SIGSTKFLT' undeclared here (not in a function); did you mean 'SIGSTKSZ'?
   { "STKFLT",   SIGSTKFLT },    /* 16 (arm,i386,m68k,ppc) */
                 ^~~~~~~~~
                 SIGSTKSZ
make[2]: *** [Makefile:4770: src/common/libcockpit_common_a-cockpitunixsignal.o] Error 1
make[2]: Leaving directory '/<<PKGBUILDDIR>>'
make[1]: *** [Makefile:2886: all] Error 2
make[1]: Leaving directory '/<<PKGBUILDDIR>>'
dh_auto_build: make -j1 returned exit code 2
make: *** [debian/rules:12: build-arch] Error 2
```

See: https://buildd.debian.org/status/fetch.php?pkg=cockpit&arch=sparc64&ver=162-1&stamp=1519233181&raw=0

Hence, disable it on these architectures, too. Also, use the more common ```__mips__``` for MIPS targets.