### PR TITLE
test: Add testNetworking.testBondActive

### DIFF
--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -159,6 +159,32 @@ class TestNetworking(NetworkCase):
         b.wait_popdown("network-bond-settings-dialog")
         b.wait_text("#network-interface-name", "tbond3000")
 
+    def testBondActive(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/network")
+
+        iface = self.add_iface()
+        self.wait_for_iface(iface)
+        ip = b.text("#networking-interfaces tr[data-interface='%s'] td:nth-child(2)" % iface)
+
+        # Put an active interface into a bond.  The bond should get the same IP as the active interface.
+
+        b.click("button:contains('Add Bond')")
+        b.wait_popup("network-bond-settings-dialog")
+        b.set_val("#network-bond-settings-dialog tr:contains('Name') input", "tbond")
+        b.set_checked("input[data-iface='%s']" % iface, True)
+        b.click("#network-bond-settings-dialog button:contains('Apply')")
+        b.wait_popdown("network-bond-settings-dialog")
+        b.wait_present("#networking-interfaces tr[data-interface='tbond']")
+
+        # Check that it has the interface enslaved and the right IP address
+        b.click("#networking-interfaces tr[data-interface='tbond'] td:first-child")
+        b.wait_visible("#network-interface")
+        b.wait_present("#network-interface-slaves tr[data-interface='%s']" % iface)
+        b.wait_in_text("#network-interface .panel:contains('tbond')", ip)
+
     @skipImage("Main interface can't be managed", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
     def testBondingMain(self):
         b = self.browser


### PR DESCRIPTION
NetworkManager 1.10 has a regression here, so let's test this
explicitly.

testBondingMain also hits the regression, but because the active
interface has "manual" ipv4 settings, and Cockpit copies those to the
bond, the bond ends up looking okay although it doesn't really work.

testBond also hits the regression, but because it has one inactive
interface, the bond ends up being functional (with just one slave).

Fixes #8735