### PR TITLE
image-customize improvements and bug fix, make testvm.py usable as executable test helper

### DIFF
--- a/bots/image-customize
+++ b/bots/image-customize
@@ -112,7 +112,7 @@ if args.commandlist or args.packagelist or args.scriptlist or args.uploadlist:
     if '/' not in args.image:
         subprocess.check_call(["image-download", args.image])
     machine = testvm.VirtMachine(maintain=True,
-        verbose=args.verbose, image=prepare_install_image(args.image), label="install")
+        verbose=args.verbose, image=prepare_install_image(args.image))
     machine.start()
     machine.wait_boot()
     try:

--- a/bots/image-customize
+++ b/bots/image-customize
@@ -43,20 +43,25 @@ parser.add_argument('-s', '--script', action='append', dest="scriptlist",
                                       default=[], help='Run selected script inside virtual machine')
 parser.add_argument('-u', '--upload', action='append', dest="uploadlist",
                     default=[], help='Upload file/dir to destination file/dir separated by ":" example: -u file.txt:/var/lib')
-parser.add_argument('image', help='The image to use')
+parser.add_argument('--base-image', help='Base image name, if "image" does not match a standard Cockpit VM image name')
+parser.add_argument('image', help='The image to use (destination name when using --base-image)')
 args = parser.parse_args()
 
+if not args.base_image:
+    args.base_image = os.path.basename(args.image)
+
 # Create the necessary layered image for the build/install
-def prepare_install_image(base_image):
+def prepare_install_image(base_image, install_image):
     if "/" not in base_image:
         base_image = os.path.join(BOTS, "images", base_image)
-    test_images = os.path.join(TEST, "images")
-    install_image = os.path.join(test_images, os.path.basename(base_image))
+    if "/" not in install_image:
+        install_image = os.path.join(os.path.join(TEST, "images"), os.path.basename(install_image))
 
-    # In vm-customize we don't force recreate immages
+    # In vm-customize we don't force recreate images
     if not os.path.exists(install_image):
-        if not os.path.exists(test_images):
-            os.makedirs(test_images)
+        install_image_dir = os.path.dirname(install_image)
+        if not os.path.exists(install_image_dir):
+            os.makedirs(install_image_dir)
         base_image = os.path.realpath(base_image)
         qcow2_image = "{0}.qcow2".format(install_image)
         subprocess.check_call([ "qemu-img", "create", "-q", "-f", "qcow2",
@@ -109,10 +114,10 @@ def install_packages(machine_instance, packagelist, install_command):
         machine_instance.execute(install_command + " " + ' '.join(allpackages), timeout=1800)
 
 if args.commandlist or args.packagelist or args.scriptlist or args.uploadlist:
-    if '/' not in args.image:
-        subprocess.check_call(["image-download", args.image])
+    if '/' not in args.base_image:
+        subprocess.check_call(["image-download", args.base_image])
     machine = testvm.VirtMachine(maintain=True,
-        verbose=args.verbose, image=prepare_install_image(args.image))
+        verbose=args.verbose, image=prepare_install_image(args.base_image, args.image))
     machine.start()
     machine.wait_boot()
     try:

--- a/bots/image-customize
+++ b/bots/image-customize
@@ -83,7 +83,7 @@ def run_script(machine_instance, scriptlist):
         if os.path.isfile(foo):
             pname = os.path.basename(foo)
             uploadpath = "/var/tmp/" + pname
-            machine_instance.upload([foo], uploadpath)
+            machine_instance.upload([os.path.abspath(foo)], uploadpath)
             machine_instance.execute("chmod a+x %s" % uploadpath)
             machine_instance.execute(uploadpath, timeout=1800)
         else:

--- a/test/verify/check-bots-api
+++ b/test/verify/check-bots-api
@@ -1,0 +1,74 @@
+#!/usr/bin/python2
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import subprocess
+import os
+import shutil
+import tempfile
+from glob import glob
+
+import parent
+from testlib import *
+import testvm
+
+@unittest.skipUnless("TEST_OS" in os.environ, "TEST_OS not set")
+class TestImageCustomize(unittest.TestCase):
+    def checkBoot(self, image):
+        with testvm.Timeout(seconds=300, error_message="Timed out waiting for image to run"):
+            network = testvm.VirtNetwork(0)
+            machine = testvm.VirtMachine(image=image, networking=network.host(), memory_mb=512)
+            machine.start()
+            machine.wait_boot()
+            out = machine.execute('cat /var/custom-test')
+            machine.stop()
+        self.assertEqual(out, "hello\n")
+
+    def testCustomDir(self):
+        dest = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, dest)
+
+        img = os.path.join(dest, os.environ["TEST_OS"])
+        with testvm.Timeout(seconds=300, error_message="Timed out waiting for image-customize"):
+            subprocess.check_call(["bots/image-customize", "--verbose", "--run-command",
+                                   "echo hello > /var/custom-test", img ])
+
+        self.assertTrue(os.path.exists(img))
+        self.checkBoot(img)
+
+    def testBaseImage(self):
+        img = "custom-" + os.environ["TEST_OS"]
+
+        def cleanup():
+            for f in glob("test/images/%s*" % img):
+                os.unlink(f)
+        self.addCleanup(cleanup)
+
+        with testvm.Timeout(seconds=300, error_message="Timed out waiting for image-customize"):
+            subprocess.check_call(["bots/image-customize", "--verbose", "--run-command",
+                                   "echo hello > /var/custom-test", "--base-image", os.environ["TEST_OS"], img ])
+
+        self.assertTrue(os.path.exists(os.path.join("test/images", img)))
+        # notice, not giving directory here - test/images/ should be the default
+        self.checkBoot(img)
+
+
+if __name__ == '__main__':
+    test_main()

--- a/test/verify/check-bots-api
+++ b/test/verify/check-bots-api
@@ -69,6 +69,22 @@ class TestImageCustomize(unittest.TestCase):
         # notice, not giving directory here - test/images/ should be the default
         self.checkBoot(img)
 
+    def testScriptRelativePath(self):
+        dest = tempfile.mkdtemp(dir=".")
+        self.addCleanup(shutil.rmtree, dest)
+
+        script = os.path.join(dest, "setup.sh")
+        with open(script, "w") as f:
+            f.write("#!/bin/sh -eu\necho hello > /var/custom-test\n")
+
+        img = os.path.join(dest, os.environ["TEST_OS"])
+        with testvm.Timeout(seconds=300, error_message="Timed out waiting for image-customize"):
+            subprocess.check_call(["bots/image-customize", "--verbose", "--script", script, img])
+
+        self.assertTrue(os.path.exists(img))
+        self.checkBoot(img)
+
+
 @unittest.skipUnless("TEST_OS" in os.environ, "TEST_OS not set")
 class TestBotsVM(unittest.TestCase):
     def testBasic(self):

--- a/test/verify/check-bots-api
+++ b/test/verify/check-bots-api
@@ -69,6 +69,40 @@ class TestImageCustomize(unittest.TestCase):
         # notice, not giving directory here - test/images/ should be the default
         self.checkBoot(img)
 
+@unittest.skipUnless("TEST_OS" in os.environ, "TEST_OS not set")
+class TestBotsVM(unittest.TestCase):
+    def testBasic(self):
+        dest = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, dest)
+        img = os.path.join(dest, os.environ["TEST_OS"])
+        with testvm.Timeout(seconds=300, error_message="Timed out waiting for image-customize"):
+            subprocess.check_call(["bots/image-customize", "--verbose", "--run-command",
+                                   "echo hello > /var/custom-test", img ])
+
+        # boot it and wait for RUNNING marker, parse out ssh and cockpit addresses
+        with testvm.Timeout(seconds=300, error_message="Timed out waiting for testvm.py to boot VM"):
+            vm = subprocess.Popen(["bots/machine/testvm.py", img],
+                                  stdout=subprocess.PIPE, universal_newlines=True)
+            # first line should be the SSH command
+            ssh_command = vm.stdout.readline().split()
+            # second line is the redirected cockpit address
+            cockpit_address = vm.stdout.readline()
+            # third should be the "I am ready" flag
+            running = vm.stdout.readline()
+
+        self.assertEqual(running, "RUNNING\n")
+        self.assertTrue(cockpit_address.startswith("http://127.0.0.2:9"), cockpit_address)
+        # test SSH command and that we have the expected flag file
+        self.assertEqual(ssh_command[0], "ssh")
+        with testvm.Timeout(seconds=30, error_message="Timed out waiting for ssh command"):
+            out = subprocess.check_output(ssh_command + ["cat", "/var/custom-test"])
+        self.assertEqual(out, "hello\n")
+
+        # should cleanly stop on SIGTERM
+        vm.terminate()
+        with testvm.Timeout(seconds=60, error_message="Timed out waiting for script to terminate"):
+            self.assertEqual(vm.wait(), 0)
+
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
See individual commit logs. The testvm.py part will get rid of https://github.com/cockpit-project/cockpit-examples/blob/master/test/vm-run, so external tests that are not written in Python don't need a copy of this and we have this code under test coverage.