### PR TITLE
Build OpenShift image for prerelease and test against it

### DIFF
--- a/bots/image-create
+++ b/bots/image-create
@@ -49,7 +49,7 @@ parser.add_argument('image', help='The image to create')
 args = parser.parse_args()
 
 # default to --no-build for some images
-if args.image in ["candlepin", "continuous-atomic", "fedora-atomic", "ipa", "rhel-atomic", "selenium", "openshift", "openshift-node", "ovirt"]:
+if args.image in ["candlepin", "continuous-atomic", "fedora-atomic", "ipa", "rhel-atomic", "selenium", "openshift", "openshift-prerelease", "openshift-node", "ovirt"]:
     if not args.no_build:
         if args.verbose:
             print("Creating machine without build capabilities based on the image type")

--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -35,6 +35,7 @@ REFRESH = {
     "ubuntu-1604": { },
     "ubuntu-stable": { },
     "openshift": { "refresh-days": 30 },
+    "openshift-prerelease": { "refresh-days": 30 },
     "ovirt": { "refresh-days": 120 },
     'rhel-7': { },
     'rhel-7-4': { },

--- a/bots/images/openshift-prerelease
+++ b/bots/images/openshift-prerelease
@@ -1,0 +1,1 @@
+openshift-prerelease-d856b21090a0c3a11a1d2d9c2c1f5c7ac1c6cdb336a221dfcc7ca5c05a53917e.qcow2

--- a/bots/images/scripts/openshift-prerelease.bootstrap
+++ b/bots/images/scripts/openshift-prerelease.bootstrap
@@ -1,0 +1,1 @@
+openshift.bootstrap

--- a/bots/images/scripts/openshift-prerelease.install
+++ b/bots/images/scripts/openshift-prerelease.install
@@ -1,0 +1,1 @@
+openshift.install

--- a/bots/images/scripts/openshift-prerelease.setup
+++ b/bots/images/scripts/openshift-prerelease.setup
@@ -1,0 +1,1 @@
+openshift.setup

--- a/bots/images/scripts/openshift.setup
+++ b/bots/images/scripts/openshift.setup
@@ -157,6 +157,24 @@ rm -r /tmp/registry
 cp /openshift.local.config/master/ca.crt /etc/pki/ca-trust/source/anchors/openshift-ca.crt
 update-ca-trust extract
 
+# HACK: Work around GnuTLS (client-side) or Go TLS (server-side) bug with
+# multiple O= RDNs; if it's in the "wrong" order, create a new admin
+# certificate that swaps it around
+# See https://github.com/openshift/origin/issues/18715
+if [ -n "$PRERELEASE" ] && openssl x509 -in /openshift.local.config/master/admin.crt -text | grep -q 'Subject:.*system:cluster-admins.*system:masters'; then
+    echo "Regenerating admin certificate to work around https://github.com/openshift/origin/issues/18715"
+    pushd /openshift.local.config/master/
+    mv admin.key admin.key.orig
+    mv admin.crt admin.crt.orig
+    mv admin.kubeconfig admin.kubeconfig.orig
+    openssl genrsa -out admin.key 2048
+    openssl req -new -nodes -key admin.key -out admin.csr -subj '/O=system:masters/O=system:cluster-admins/CN=system:admin'
+    openssl x509 -req -in admin.csr -CA ca.crt -CAkey ca.key -CAcreateserial -days 730 -out admin.crt
+    rm admin.csr
+    oc adm create-kubeconfig --certificate-authority=ca.crt --client-certificate=admin.crt --client-key=admin.key --master="https://10.111.112.101:8443" --kubeconfig=admin.kubeconfig
+    popd
+fi
+
 mkdir -p /root/.kube
 cp /openshift.local.config/master/admin.kubeconfig /root/.kube/config
 

--- a/bots/images/scripts/openshift.setup
+++ b/bots/images/scripts/openshift.setup
@@ -1,6 +1,10 @@
 #! /bin/bash
 
 set -eux
+PRERELEASE=
+if [ "${1%prerelease*}" != "$1" ]; then
+    PRERELEASE=1
+fi
 
 # Wait for x for many minutes
 function wait() {
@@ -71,7 +75,13 @@ systemctl start docker || journalctl -u docker
 
 # Can't use latest because release on older versions are done out of order
 RELEASES_JSON=$(curl -s https://api.github.com/repos/openshift/origin/releases)
-VERSION=$(echo "$RELEASES_JSON" | LC_ALL=C.UTF-8 python3 -c "import json, sys; obj=json.load(sys.stdin); releases = [x.get('tag_name', '') for x in obj if not x.get('prerelease')]; print(sorted (releases, reverse=True)[0])") || {
+if [ -n "$PRERELEASE" ]; then
+    comp=""
+else
+    comp="not"
+fi
+
+VERSION=$(echo "$RELEASES_JSON" | LC_ALL=C.UTF-8 python3 -c "import json, sys; obj=json.load(sys.stdin); releases = [x.get('tag_name', '') for x in obj if $comp x.get('prerelease')]; print(sorted (releases, reverse=True)[0])") || {
     echo "Failed to parse latest release:" >&2
     echo "$RELEASES_JSON" >&2
     echo "------------------------------------" >&2
@@ -184,7 +194,7 @@ echo '{"apiVersion":"v1","kind":"ImageStream","metadata": {"name":"busybox"},"sp
 oc create -f /tmp/imagestream.json
 
 # Get registry address and configure docker for it
-address="$(oc get services docker-registry | tail -n1 | awk -v N=2 '{print $N}')"
+address="$(oc get services docker-registry | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}')"
 echo "$address     registry registry.cockpit.lan" >> /etc/hosts
 echo "INSECURE_REGISTRY='--insecure-registry registry:5000 --insecure-registry $address'" >> /etc/sysconfig/docker
 
@@ -253,8 +263,8 @@ docker push registry:5000/pizzazz/monster
 oc config use-context default/10-111-112-101:8443/system:admin
 
 # Some roles for testing against
-printf '{"kind":"List","apiVersion":"v1","items":[{"kind":"RoleBinding","metadata":{"name":"registry-editor","namespace":"marmalade","resourceVersion":"1"},"userNames":["scruffy","amanda"],"groupNames":null,"subjects":[{"kind":"User","name":"scruffy"},{"kind":"User","name":"amanda"}],"roleRef":{"name":"registry-editor"}},{"kind":"RoleBinding","metadata":{"name":"registry-viewer","namespace":"marmalade","resourceVersion":"1"},"userNames":["scruffy","tom","amanda"],"groupNames":["sports"],"subjects":[{"kind":"User","name":"scruffy"},{"kind":"User","name":"tom"},{"kind":"User","name":"amanda"},{"kind":"Group","name":"sports"}],"roleRef":{"name":"registry-viewer"}}]}' | oc create -f -
-oc patch rolebinding/admin --namespace=marmalade -p '{"kind": "RoleBinding", "metadata":{"name":"admin","namespace":"marmalade"},"userNames":["scruffy"],"groupNames":null,"subjects":[{"kind":"User","name":"scruffys"}],"roleRef":{"name":"admin"}}'
+printf '{"kind":"List","apiVersion":"v1","items":[{"kind":"RoleBinding","apiVersion":"v1","metadata":{"name":"registry-editor","namespace":"marmalade","resourceVersion":"1"},"userNames":["scruffy","amanda"],"groupNames":null,"subjects":[{"kind":"User","name":"scruffy"},{"kind":"User","name":"amanda"}],"roleRef":{"name":"registry-editor"}},{"kind":"RoleBinding","apiVersion":"v1","metadata":{"name":"registry-viewer","namespace":"marmalade","resourceVersion":"1"},"userNames":["scruffy","tom","amanda"],"groupNames":["sports"],"subjects":[{"kind":"User","name":"scruffy"},{"kind":"User","name":"tom"},{"kind":"User","name":"amanda"},{"kind":"Group","name":"sports"}],"roleRef":{"name":"registry-viewer"}}]}' | oc create -f -
+oc patch rolebinding/admin --namespace=marmalade -p '{"kind": "RoleBinding", "metadata":{"name":"admin","namespace":"marmalade"},"userNames":["scruffy"],"groupNames":null,"subjects":[{"kind":"User","name":"scruffys"}],"roleRef":{"name":"admin"}}' || true
 
 # For testing the Cockpit OAuth client
 printf '{"kind":"OAuthClient","apiVersion":"v1","metadata":{"name":"cockpit-oauth-devel"},"respondWithChallenges":false,"secret":"secret","allowAnyScope":true,"redirectURIs":["http://localhost:9001"] }' | oc create -f -

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -483,6 +483,11 @@ class TestOpenshiftPrerelease(TestOpenshift):
         "openshift": { "image": "openshift-prerelease", "forward": { 30000: 30000, 8443: 8443 } }
     }
 
+    # https://github.com/cockpit-project/cockpit/issues/8744
+    @unittest.expectedFailure
+    def testVolumes(self):
+        super(TestOpenshiftPrerelease, self).testVolumes()
+
 
 @skipImage("Kubernetes not packaged", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-i386")
 @skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic")
@@ -520,6 +525,11 @@ class TestRegistryPrerelease(TestRegistry):
         "machine1": { "address": "10.111.113.1/20" },
         "openshift": { "image": "openshift-prerelease", "forward": { 30000: 30000, 8443: 8443 } }
     }
+
+    # https://github.com/cockpit-project/cockpit/issues/8745
+    @unittest.expectedFailure
+    def testImages(self):
+        super(TestRegistryPrerelease, self).testImages()
 
 
 if __name__ == '__main__':

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -477,6 +477,13 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         b.wait_js_cond('window.location.hash === "#/l/pods/kube-system/%s"' % (pod_name))
 
 
+class TestOpenshiftPrerelease(TestOpenshift):
+    provision = {
+        "machine1": { "address": "10.111.113.1/20" },
+        "openshift": { "image": "openshift-prerelease", "forward": { 30000: 30000, 8443: 8443 } }
+    }
+
+
 @skipImage("Kubernetes not packaged", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-i386")
 @skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 class TestRegistry(MachineCase, RegistryTests):
@@ -506,6 +513,13 @@ class TestRegistry(MachineCase, RegistryTests):
         wait_project(self.openshift, "marmalade")
 
         self.browser.wait_timeout(120)
+
+
+class TestRegistryPrerelease(TestRegistry):
+    provision = {
+        "machine1": { "address": "10.111.113.1/20" },
+        "openshift": { "image": "openshift-prerelease", "forward": { 30000: 30000, 8443: 8443 } }
+    }
 
 
 if __name__ == '__main__':

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -244,7 +244,7 @@ class VolumeTests(object):
         b.wait_not_present("modal-dialog input#modify-capacity")
         b.wait_in_text("modal-dialog span#modify-capacity", pv2_size)
 
-        if m.image == "openshift":
+        if "openshift" in m.image:
             b.set_val("modal-dialog #modify-path", "/not-tmp")
             b.click("modal-dialog .modal-footer button.btn-primary")
             b.wait_not_present("modal-dialog")

--- a/test/vm-run
+++ b/test/vm-run
@@ -86,7 +86,7 @@ try:
                                  networking=network.host(), memory_mb=memory, cpus=args.cpus)
 
     # Hack to make things easier for users who don't know about kubeconfig
-    if args.image == 'openshift':
+    if 'openshift' in args.image:
         kubeconfig = os.path.join(os.path.expanduser("~"), ".kube", "config")
         if not os.path.lexists(kubeconfig):
             d = os.path.dirname(kubeconfig)


### PR DESCRIPTION
This will allow us to adjust to API changes before a new major release, and thus have a chance to report bugs and release a new OpenShift with a working Cockpit.

This currently has a nasty workaround for a [GnuTLS bug](https://github.com/openshift/origin/issues/18715). So effectively Cockpit is not working with SSL cert authentication with current OpenShift 3.9. This is being investigated, and workaround unblocks running testing.

 - [x] fix concurrent image-downloads (PR #8741)
 - [x] fix image-download spam, breaking known issues (PR #8743)