### PR TITLE
bots: Avoid concurrent downloads of the same image

### DIFF
--- a/bots/image-download
+++ b/bots/image-download
@@ -49,6 +49,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import fcntl
 import urllib.parse
 
 BOTS = os.path.dirname(os.path.realpath(__file__))
@@ -205,6 +206,21 @@ def committed_target(image):
 
     return dest
 
+def wait_lock(target):
+    lockfile = os.path.join(tempfile.gettempdir(), ".cockpit-test-resources", os.path.basename(target) + ".lock")
+    # we need to keep the lock fd open throughout the entire runtime, so remember it in a global-scoped variable
+    wait_lock.f = open(lockfile, "w")
+    for retry in range(360):
+        try:
+            fcntl.flock(wait_lock.f, fcntl.LOCK_NB | fcntl.LOCK_EX)
+            return
+        except BlockingIOError as e:
+            if retry == 0:
+                print("Waiting for concurrent image-download of %s..." % os.path.basename(target))
+            time.sleep(10)
+    else:
+        raise TimeoutError("timed out waiting for concurrent downloads of %s\n" % target)
+
 def download_images(image_list, force, quiet, state, store):
     if not os.path.exists(DATA):
         os.makedirs(DATA)
@@ -229,6 +245,10 @@ def download_images(image_list, force, quiet, state, store):
                 target = state_target(image)
             else:
                 target = committed_target(image)
+
+            # don't download the same thing multiple times in parallel
+            wait_lock(target)
+
             if force or state or not os.path.exists(target):
                 download(target, force, quiet, store)
         except Exception as ex:


### PR DESCRIPTION
Use per-image-name locking in image-download to avoid multiple parallel
tests downloading the same image. All but the first instance will then
just wait and immediately succeed without downloading again.

This avoids tests trying to download ovirt or openshift-prerelease
images multiple times at once, which makes them very prone to fail.

This is a more general approach than the static hardcoded (and outdated)
list of downloads in tests-invoke.

---

I originally pushed this patch to PR #8740, but this might take longer to land. Let's land this fix in the meantime, and see if it helps with the ovirt tests.