### PR TITLE
packagekit: change string to not refer to Cockpit

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -948,9 +948,9 @@ class OsUpdates extends React.Component {
                           ? <div className="alert alert-warning">
                                 <span className="pficon pficon-warning-triangle-o"></span>
                                 <span>
-                                    <strong>{_("Cockpit itself will be updated.")}</strong>
+                                    <strong>{_("This web console will be updated.")}</strong>
                                     &nbsp;
-                                    {_("When you get disconnected, the updates will continue in the background. You can reconnect and resume watching the update progress.")}
+                                    {_("Your browser will disconnect, but this does not affect the update process. You can reconnect in a few moments to continue watching the progress.")}
                                 </span>
                             </div>
                           : null

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -537,7 +537,7 @@ class TestUpdates(PackageCase):
         b.wait_in_text("table.listing-ct", "cockpit-ws")
 
         b.wait_present("#app div.alert-warning")
-        b.wait_in_text("#app div.alert-warning", "Cockpit itself will be updated")
+        b.wait_in_text("#app div.alert-warning", "This web console will be updated.")
 
     def testPackageKitCrash(self):
         b = self.browser


### PR DESCRIPTION
Cockpit is the project name, and should not be visible in the UI.
Fixes issue #8737