### PR TITLE
bots: Don't spam logs with image-download curl progress report

### DIFF
--- a/bots/image-download
+++ b/bots/image-download
@@ -142,7 +142,8 @@ def download(dest, force, quiet, stores):
 
     # Adjust the command above that worked to make it visible and download real stuff
     cmd.remove("--head")
-    if not quiet:
+    cmd.append("--show-error")
+    if not quiet and os.isatty(sys.stdout.fileno()):
         cmd.remove("--silent")
         cmd.insert(1, "--progress-bar")
     cmd.append("--remote-time")


### PR DESCRIPTION
When the output goes to a log file and a test has to download an image,
this results in a ~ 500 kB (!) output of the progress meter. This blows
up the logs, causes tests-policy GitHub errors (as that tries to put the
log output into a GitHub comment, which is limited to 64 KiB), and
confuses the log learning pattern matching.

Avoid this by only showing the progress bar when stdout is a terminal,
i. e. the command is being run interactively.

Also show errors during actual download by adding `--show-error`, which
are normally hidden with `--silent`.

---

Example: https://fedorapeople.org/groups/cockpit/logs/pull-8740-20180301-133333-f8bb64f9-verify-fedora-27/log.html#155