### PR TITLE
test: Remove blanket audit filter from check-{machines,ovirt}

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -148,8 +148,6 @@ class TestMachines(MachineCase):
         m.execute("sed -i 's/\"priority\".*$/\"priority\": 100,/' {0}".format("/usr/share/cockpit/machines/manifest.json"))
         m.execute("[ ! -e {0} ] || sed -i 's/\"priority\".*$/\"priority\": 0,/' {0}".format("/usr/share/cockpit/ovirt/manifest.json"))
 
-        self.allow_journal_messages('.*type=1400.*')
-
     def startLibvirt(self):
         m = self.machine
         # Ensure everything has started correctly

--- a/test/verify/check-ovirt
+++ b/test/verify/check-ovirt
@@ -83,8 +83,6 @@ class TestOVirtMachines(MachineCase):
         self.hack_for_missing_vdsm()
         self.pass_install_dialog()
 
-        self.allow_journal_messages('.*type=1400.*')
-
     def wait_for_dc(self):
         # wait for DC to get up
         m = self.machine


### PR DESCRIPTION
This is most likely a missed debugging leftover from commit e788a1868.
This stopped the tracking of at least known issue #6901. Right now there
are no other AppArmor violations, but we want to know if new ones
appear.

Fixes #8753