### PR TITLE
packagekit: Don't show enumeration and heading in updates overview

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -146,6 +146,21 @@ function insertCommas(list) {
     return list.reduce((prev, cur) => [prev, ", ", cur])
 }
 
+// Fedora changelogs are a wild mix of enumerations or not, headings, etc.
+// Remove that formatting to avoid an untidy updates overview list
+function cleanupChangelogLine(text) {
+    if (!text)
+        return text;
+
+    // enumerations
+    text = text.replace(/^[-* ]*/, "");
+
+    // headings
+    text = text.replace(/^=+\s+/, "").replace(/=+\s*$/, "");
+
+    return text.trim();
+}
+
 class Expander extends React.Component {
     constructor() {
         super();
@@ -335,6 +350,7 @@ class UpdateItem extends React.Component {
         var descriptionFirstLine = (info.description || "").trim();
         if (descriptionFirstLine.indexOf("\n") >= 0)
             descriptionFirstLine = descriptionFirstLine.slice(0, descriptionFirstLine.indexOf("\n"));
+        descriptionFirstLine = cleanupChangelogLine(descriptionFirstLine);
         var description;
         if (info.markdown) {
             descriptionFirstLine = <Markdown source={descriptionFirstLine} />;

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -195,7 +195,7 @@ class TestUpdates(PackageCase):
         self.createPackage("norefs-doc", "2", "1", severity="enhancement", changes="Now 10% *more* [unicorns](http://unicorn.example.com)")
         # bug fixes
         self.createPackage("buggy", "2", "1", install=True)
-        self.createPackage("buggy", "2", "2", changes="Fixit", bugs=[123, 456])
+        self.createPackage("buggy", "2", "2", changes="* Fixit", bugs=[123, 456])
         # security fix with proper CVE list and severity
         self.createPackage("secdeclare", "3", "4.a1", install=True)
         self.createPackage("secdeclare", "3", "4.b1", severity="security",
@@ -247,7 +247,12 @@ class TestUpdates(PackageCase):
             self.assertIn("access.redhat.com", b.attr(sel + " .listing-ct-body dd.severity a:first-of-type", "href"))
 
         # buggy: bug refs, no security
-        self.check_nth_update(4, "buggy", "2-2", "bug", 2, bugs=["123", "456"], desc_matches=["Fixit"])
+        sel = self.check_nth_update(4, "buggy", "2-2", "bug", 2, bugs=["123", "456"], desc_matches=["Fixit"])
+        # should filter out enumeration in overview
+        ch = b.eval_js('document.querySelector("%s").innerHTML' % (sel + " td.changelog"))
+        self.assertNotIn("<li>", ch)
+        self.assertNotIn("*", ch)
+
         # norefs: just changelog, show both binary packages
         sel = self.check_nth_update(5, ["norefs-bin", "norefs-doc"], "2-1", self.enhancement_severity,
                                     desc_matches=["Now 10% more unicorns"])


### PR DESCRIPTION
Fedora changelogs are a wild mix of enumerations or not, headings, etc.
Filter out enumerations and headings from the first changelog line
that gets displayed in the table, but keep formatting in the details
expander.

Fixes #8644