### PR TITLE
bots: Create temporary lock directory if missing

### DIFF
--- a/bots/image-download
+++ b/bots/image-download
@@ -209,6 +209,8 @@ def committed_target(image):
 
 def wait_lock(target):
     lockfile = os.path.join(tempfile.gettempdir(), ".cockpit-test-resources", os.path.basename(target) + ".lock")
+    os.makedirs(os.path.dirname(lockfile), exist_ok=True)
+
     # we need to keep the lock fd open throughout the entire runtime, so remember it in a global-scoped variable
     wait_lock.f = open(lockfile, "w")
     for retry in range(360):


### PR DESCRIPTION
Fixes

    $ bots/image-download fedora-27
    image-download: [Errno 2] No such file or directory: '/tmp/.cockpit-test-resources/fedora-27-5[...].qcow2.lock'

Regression introduced in commit eaec9c114.