### PR TITLE
test: further improvements to Martins recent PMDA interface fixes

### DIFF
--- a/src/bridge/mock-pmda.c
+++ b/src/bridge/mock-pmda.c
@@ -16,8 +16,13 @@
  */
 
 #include <pcp/pmapi.h>
-#include <pcp/impl.h>
 #include <pcp/pmda.h>
+
+#if PM_VERSION_CURRENT < PM_VERSION(4,0,0)
+#include <pcp/impl.h>
+#define pmID_cluster(pmid) pmid_cluster(pmid)
+#define pmID_item(pmid) pmid_item(pmid)
+#endif
 
 static pmdaInstid inst_values[] = {
     { 1, "red" }, { 2, "green" }, { 3, "blue" }
@@ -74,19 +79,10 @@ static int64_t counter64 = INT64_MAX - 100;
 static int
 mock_fetchCallBack(pmdaMetric *mdesc, unsigned int inst, pmAtomValue *atom)
 {
-#if PM_VERSION_CURRENT >= PM_VERSION(4,0,0)
   if (pmID_cluster(mdesc->m_desc.pmid) != 0)
     return PM_ERR_PMID;
 
   switch (pmID_item(mdesc->m_desc.pmid)) {
-#else
-  __pmID_int		*idp = (__pmID_int *)&(mdesc->m_desc.pmid);
-
-  if (idp->cluster != 0)
-    return PM_ERR_PMID;
-
-  switch (idp->item) {
-#endif
   case 0:
     if (inst != PM_IN_NULL)
       return PM_ERR_INST;

--- a/src/bridge/test-pcp.c
+++ b/src/bridge/test-pcp.c
@@ -35,6 +35,11 @@
 #include <pcp/pmapi.h>
 #include <pcp/impl.h>
 
+#if PM_VERSION_CURRENT < PM_VERSION(4,0,0)
+#include <pcp/impl.h>
+#define pmSpecLocalPMDA(command) __pmSpecLocalPMDA(command)
+#endif
+
 void (*mock_pmda_control) (const char *cmd, ...);
 
 static void
@@ -46,13 +51,8 @@ init_mock_pmda (void)
       exit (0);
     }
 
-#if PM_VERSION_CURRENT >= PM_VERSION(4,0,0)
   g_assert (pmSpecLocalPMDA ("clear") == NULL);
   g_assert (pmSpecLocalPMDA ("add,333,./mock-pmda.so,mock_init") == NULL);
-#else
-  g_assert (__pmLocalPMDA (PM_LOCAL_CLEAR, 0, NULL, NULL) >= 0);
-  g_assert (__pmLocalPMDA (PM_LOCAL_ADD, 333, "./mock-pmda.so", "mock_init") >= 0);
-#endif
 
   void *handle = dlopen ("./mock-pmda.so", RTLD_NOW);
   g_assert (handle != NULL);


### PR DESCRIPTION
Cleanup the PCP PMDA mock-pmda code to only use the now-official
interfaces for some PCP functionality, and use compat macros to
emulate the now-official interfaces in older versions.

This will make it easier to identify and remove the compat code
in years to come, including the removal of <pcp/impl.h> - now an
empty header file since PCP v4.