### PR TITLE
 networking: Add hack to kick new bonds etc to be fully awake

### DIFF
--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -159,6 +159,32 @@ class TestNetworking(NetworkCase):
         b.wait_popdown("network-bond-settings-dialog")
         b.wait_text("#network-interface-name", "tbond3000")
 
+    def testBondActive(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/network")
+
+        iface = self.add_iface()
+        self.wait_for_iface(iface)
+        ip = b.text("#networking-interfaces tr[data-interface='%s'] td:nth-child(2)" % iface)
+
+        # Put an active interface into a bond.  The bond should get the same IP as the active interface.
+
+        b.click("button:contains('Add Bond')")
+        b.wait_popup("network-bond-settings-dialog")
+        b.set_val("#network-bond-settings-dialog tr:contains('Name') input", "tbond")
+        b.set_checked("input[data-iface='%s']" % iface, True)
+        b.click("#network-bond-settings-dialog button:contains('Apply')")
+        b.wait_popdown("network-bond-settings-dialog")
+        b.wait_present("#networking-interfaces tr[data-interface='tbond']")
+
+        # Check that it has the interface enslaved and the right IP address
+        b.click("#networking-interfaces tr[data-interface='tbond'] td:first-child")
+        b.wait_visible("#network-interface")
+        b.wait_present("#network-interface-slaves tr[data-interface='%s']" % iface)
+        b.wait_in_text("#network-interface .panel:contains('tbond')", ip)
+
     @skipImage("Main interface can't be managed", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
     def testBondingMain(self):
         b = self.browser

--- a/test/verify/check-networking-bridge
+++ b/test/verify/check-networking-bridge
@@ -66,6 +66,32 @@ class TestNetworking(NetworkCase):
         b.wait_visible("#networking")
         b.wait_not_present("#networking-interfaces tr[data-interface='tbridge']")
 
+    def testBridgeActive(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/network")
+
+        iface = self.add_iface()
+        self.wait_for_iface(iface)
+        ip = b.text("#networking-interfaces tr[data-interface='%s'] td:nth-child(2)" % iface)
+
+        # Put an active interface into a bridge.  The bridge should
+        # get the same IP as the active interface.
+
+        b.click("button:contains('Add Bridge')")
+        b.wait_popup("network-bridge-settings-dialog")
+        b.set_val("#network-bridge-settings-dialog tr:contains('Name') input", "tbridge")
+        b.set_checked("input[data-iface='%s']" % iface, True)
+        b.click("#network-bridge-settings-dialog button:contains('Apply')")
+        b.wait_popdown("network-bridge-settings-dialog")
+        b.wait_present("#networking-interfaces tr[data-interface='tbridge']")
+
+        # Check that it has the interface enslaved and the right IP address
+        b.click("#networking-interfaces tr[data-interface='tbridge'] td:first-child")
+        b.wait_visible("#network-interface")
+        b.wait_present("#network-interface-slaves tr[data-interface='%s']" % iface)
+        b.wait_in_text("#network-interface .panel:contains('tbridge')", ip)
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-networking-team
+++ b/test/verify/check-networking-team
@@ -90,5 +90,33 @@ class TestNetworking(NetworkCase):
         self.allow_journal_messages(".*Connection reset by peer.*",
                                     "connection unexpectedly closed by peer")
 
+    @skipImage("No teams",  "continuous-atomic", "rhel-atomic", "ubuntu-1604", "ubuntu-stable")
+    def testTeamActive(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/network")
+
+        iface = self.add_iface()
+        self.wait_for_iface(iface)
+        ip = b.text("#networking-interfaces tr[data-interface='%s'] td:nth-child(2)" % iface)
+
+        # Put an active interface into a team.  The team should
+        # get the same IP as the active interface.
+
+        b.click("button:contains('Add Team')")
+        b.wait_popup("network-team-settings-dialog")
+        b.set_val("#network-team-settings-dialog tr:contains('Name') input", "tteam")
+        b.set_checked("input[data-iface='%s']" % iface, True)
+        b.click("#network-team-settings-dialog button:contains('Apply')")
+        b.wait_popdown("network-team-settings-dialog")
+        b.wait_present("#networking-interfaces tr[data-interface='tteam']")
+
+        # Check that it has the interface enslaved and the right IP address
+        b.click("#networking-interfaces tr[data-interface='tteam'] td:first-child")
+        b.wait_visible("#network-interface")
+        b.wait_present("#network-interface-slaves tr[data-interface='%s']" % iface)
+        b.wait_in_text("#network-interface .panel:contains('tteam')", ip)
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
This is expected to fix the failures uncovered by the new testBondActive test in #8736.  Those tests are included and extended here.
