### PR TITLE
base: make cockpit.jump() behave as documented

### DIFF
--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -2626,6 +2626,13 @@ function factory() {
             path = "/" + path.map(encodeURIComponent).join("/").replace("%40", "@").replace("%3D", "=").replace(/%2B/g, "+");
         else
             path = "" + path;
+
+        /* When host is not given (undefined), use current transport's host. If
+         * it is null, use localhost.
+         */
+        if (host === undefined)
+            host = cockpit.transport.host;
+
         var options = { command: "jump", location: path, host: host };
         cockpit.transport.inject("\n" + JSON.stringify(options));
     };


### PR DESCRIPTION
The documentation says that if "host is not specified, then the
component on the same host as the caller will be displayed". However,
cockpit.jump() returned to localhost when `host` was not given, which is
the same behavior as is documented for passing `null`.

Differentiate between passing `null` and not passing `host` at all. In
the latter case, set the host to the current host.