### PR TITLE
naughty: Close 8369: check-storage-mdraid causes kernel lockup on rhel-7-5

### DIFF
--- a/bots/naughty/rhel-7-5/8369-raid-kernel-lockup
+++ b/bots/naughty/rhel-7-5/8369-raid-kernel-lockup
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-storage-mdraid", line *, in testRaid
-    b.wait_not_in_text('#detail-sidebar', "DISK1")
-*
-Error: timeout

--- a/bots/naughty/rhel-7-5/8369-raid-kernel-lockup-2
+++ b/bots/naughty/rhel-7-5/8369-raid-kernel-lockup-2
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-storage-mdraid", line *, in testRaid
-    self.wait_states({ "QEMU QEMU HARDDISK (DISK4)": "In Sync" })
-*
-Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 26 days

check-storage-mdraid causes kernel lockup on rhel-7-5

Fixes #8369