### PR TITLE
test: Initial aXe integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ Test*.log
 cockpit-*.tar*
 Test*.png
 Test*.html
+Test*.json
 
 /pkg/networkmanager/override.json
 /pkg/storaged/override.json

--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -33,7 +33,9 @@ import tempfile
 import sys
 import time
 
-DEFAULT_IMAGE = os.environ.get("TEST_OS", "fedora-27")
+TEST_OS_DEFAULT = "fedora-27"
+
+DEFAULT_IMAGE = os.environ.get("TEST_OS", TEST_OS_DEFAULT)
 
 MEMORY_MB = 1024
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "term.js-cockpit": "0.0.10"
   },
   "devDependencies": {
+    "axe-core": "^2.6.1",
     "babel-core": "^6.26.0",
     "babel-eslint": "~7.1.1",
     "babel-loader": "^6.4.1",

--- a/test/common/axe.js
+++ b/test/common/axe.js
@@ -1,0 +1,1 @@
+../../node_modules/axe-core/axe.min.js

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -39,6 +39,7 @@ import json
 import tempfile
 import time
 import unittest
+import gzip
 
 import tap
 import testvm
@@ -57,6 +58,7 @@ __all__ = (
     'MachineCase',
     'skipImage',
     'skipPackage',
+    'enableAxe',
     'Error',
 
     'sit',
@@ -808,6 +810,61 @@ class MachineCase(unittest.TestCase):
             if log.startswith("error: uncaught"):
                 raise Error(log)
 
+    def check_axe(self, label=None, suffix=""):
+        """Run aXe check on the currently active frame
+
+        The report gets written into an attachment
+        "<label>-axe-{violations,incomplete}.json". If you specify a suffix, it
+        will be appended to the file name, which is useful if you call this
+        more than once within one test.
+        """
+        # only run this on the default OS test, that's enough
+        if os.getenv("TEST_OS") not in [None, testvm.TEST_OS_DEFAULT]:
+            return
+
+        report = self.browser.eval_js("axe.run()", no_trace=True)
+
+        # trim the report
+        def delkeys(dict, *keys):
+            for key in keys:
+                try:
+                    del dict[key]
+                except KeyError:
+                    pass
+        delkeys(report, "passes", "inapplicable", "timestamp")
+
+        for outcome in ["violations", "incomplete"]:
+            for test in report[outcome]:
+                delkeys(test, "tags", "help", "impact")
+
+                # failureSummary in nodes is highly repetitive and long, so summarize it on violation level
+                summaries = set()
+                for result in test["nodes"]:
+                    if "failureSummary" in result:
+                        summaries.add(result["failureSummary"])
+                    delkeys(result, "all", "any", "none", "impact", "failureSummary")
+
+                    # trim containing iframes from targets
+                    if result.get("target", []):
+                        result["target"] = result["target"][-1]
+
+                if summaries:
+                    test["failureSummaries"] = list(summaries)
+
+
+        # write the report
+        if suffix:
+            suffix = "-" + suffix
+        filename = "{0}{1}-axe.json.gz".format(label or self.label(), suffix)
+        with gzip.open(filename, "wb") as f:
+            f.write(json.dumps(report))
+        print("Wrote accessibility report to " + filename)
+        attach(filename)
+
+        # aXe triggers that *shrug*
+        self.allow_journal_messages("received invalid message without channel prefix")
+
+
     def snapshot(self, title, label=None):
         """Take a snapshot of the current screen and save it as a PNG.
 
@@ -859,6 +916,22 @@ def skipPackage(*args):
         if package in packages_env:
             return unittest.skip("{0} is excluded in $TEST_SKIP_PACKAGES".format(package))
     return lambda func: func
+
+def enableAxe(method):
+    """Enable aXe accessibility test code injection for this test case"""
+
+    # only run this on the default OS test, that's enough
+    if os.getenv("TEST_OS") not in [None, testvm.TEST_OS_DEFAULT]:
+        return method
+
+    def wrapper(*args):
+        with open(os.path.join(TEST_DIR, "common/axe.js")) as f:
+            script = f.read()
+        # first method argument is "self", a MachineCase instance
+        args[0].browser.cdp.invoke("Page.addScriptToEvaluateOnLoad", scriptSource=script, no_trace=True)
+        return method(*args)
+
+    return wrapper
 
 
 class TestResult(tap.TapResult):

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
 import os
-import sys
 
 import parent
 from testlib import *

--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -22,6 +22,7 @@ import parent
 from testlib import *
 
 class TestMenu(MachineCase):
+    @enableAxe
     def testBasic(self):
         b = self.browser
 
@@ -34,6 +35,8 @@ class TestMenu(MachineCase):
         b.wait_popup('about')
         b.click('#about button[data-dismiss="modal"]')
         b.wait_popdown("about")
+
+        self.check_axe("Test-navigation")
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -47,6 +47,7 @@ def ssh_reconnect(machine, timeout_sec=120):
 
 class TestSystemInfo(MachineCase):
 
+    @enableAxe
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -74,6 +75,8 @@ class TestSystemInfo(MachineCase):
         mid = m.execute("cat /etc/machine-id")
         b.wait_present('#system_machine_id')
         b.wait_text('#system_machine_id', mid)
+
+        self.check_axe()
 
         # Generate a new rsa key and change the config
         m.execute("ssh-keygen -f /etc/ssh/weirdname -t rsa -N ''")


### PR DESCRIPTION
Start running accessibility checks in our tests with
[aXe](https://www.axe-core.org). Add a `MachineCase.check_axe()` method
which generates an aXe report for the current frame and writes the JSON
reports into an attachment (names similar to screenshots and logs). This
gets heavily trimmed and gzipped to reduce the size from ~ 70 to 2 kB. 

Call this for the top-level navigation frame (in check-menu) and for the 
initial /system page (in check-system-info) for now. Once we get some
experience how to process, compare, and fix these, these calls will be
added to more tests.

To avoid injecting the axe check code into every test (which might skew
the results), introduce an `@enableAxe` decorator which does the 
injection. Every test that uses `check_axe()` must use that decorator.
Also, only do this on the default OS test for now (fedora-27 at the 
moment), as the results are going to be mostly identical between OSes
anyway.

Fixes #8641
------

~This is an initial PoC. I want to see if and how injecting the aXe helper affects the tests, and that attaching the two reports works as expected. However, the reports are currently much too large and verbose (roughly 40 kB each), and also rather hard to read. They need to be filtered to trim the information to what we need, similar to what the [CLI produces](https://i.imgur.com/HLc4x9u.png).~

 - [x] merge the two reports back into one
 - [x] trim reports
 - [x] add a decorator or similar to not impose the new inject on every test case
 - [x] fix attachments in CI