### PR TITLE
storage - NBDE playground 

### DIFF
--- a/pkg/lib/table.css
+++ b/pkg/lib/table.css
@@ -58,7 +58,8 @@
     padding-right: 15px;
 }
 
-.info-table-ct td {
+.info-table-ct > tr > td,
+.info-table-ct > tbody > tr > td {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -68,16 +69,19 @@
     line-height: 26px;
 }
 
-.info-table-ct td:first-child {
+.info-table-ct > tr > td:first-child,
+.info-table-ct > tbody > tr > td:first-child {
     text-align: right;
     color: #888888;
 }
 
-.info-table-ct td:not(:first-child) {
+.info-table-ct > tr > td:not(:first-child),
+.info-table-ct > tbody > tr > td:not(:first-child) {
     color: black;
 }
 
-.info-table-ct td button {
+.info-table-ct > tr > td button,
+.info-table-ct > tbody > tr > td button {
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/pkg/storaged/clevis-dialogs.jsx
+++ b/pkg/storaged/clevis-dialogs.jsx
@@ -1,0 +1,195 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import dialog from "./dialog";
+import React from "react";
+
+const _ = cockpit.gettext;
+
+// "React" is used implicitly by the <foo>...</foo> expansion but our
+// hinter doesn't know about that.
+React;
+
+export function add(client, block) {
+    dialog.open({ Title: _("Add network key"),
+                  Fields: [
+                      { TextInput: "url",
+                        Title: _("Key server address")
+                      },
+                      { PassInput: "passphrase",
+                        Title: _("Existing passphrase")
+                      }
+                  ],
+                  Action: {
+                      Title: _("Add"),
+                      action: function (vals) {
+                          return client.clevis_overlay.get_adv(vals.url).then(function (info) {
+                              add_adv(client, block, vals.url, info, vals.passphrase);
+                          });
+                      }
+                  }
+    });
+}
+
+function add_adv(client, block, url, info, passphrase) {
+    verify_adv(url, info,
+               _("Verify Key"),
+               null,
+               _("Trust Key"),
+               function () {
+                   return client.clevis_overlay.add(block, url, info.adv, passphrase);
+               });
+}
+
+function verify_adv( url, info, title, extra, action_title, action) {
+    var port_pos = url.lastIndexOf(":");
+    var host = (port_pos >= 0) ? url.substr(0, port_pos) : url;
+    var port = (port_pos >= 0) ? url.substr(port_pos + 1) : "";
+    var cmd = cockpit.format("ssh $0 tang-show-keys $1", host, port);
+
+    dialog.open({ Title: title,
+                  Fields: [ ],
+                  ReactBody:
+                  <div>
+                      { extra ? <p>{extra}</p> : null }
+                      <p>
+                          <span>{_("Manually verify the key on the server: ")}</span>
+                          <pre>{cmd}</pre>
+                      </p>
+                      <p>
+                          <span>{_("The output should match this text: ")}</span>
+                          <pre><samp>{info.sigkeys.join("\n")}</samp></pre>
+                      </p>
+                  </div>,
+                  Action: {
+                      Title: action_title,
+                      action: action
+                  }
+    });
+}
+
+export function remove(client, block, key) {
+    dialog.open({ Title: _("Please confirm network key removal"),
+                  Fields: [ ],
+                  ReactBody:
+                  <div>
+                      <p>{cockpit.format(_("The key of $0 will be removed."), key.url)}</p>
+                      <p>{_("Removing network keys might prevent unattended booting.")}</p>
+                  </div>,
+                  Action: {
+                      DangerButton: true,
+                      Title: _("Remove key"),
+                      action: function () {
+                          return client.clevis_overlay.remove(block, key);
+                      }
+                  }
+    });
+}
+
+export function check(client, block, key) {
+    // Cases:
+    // 0) server decrypts with key and advertises it -> say everything okay, do nothing
+    // 1) server doesn't decrypt with key anymore -> let people remove
+    // 2) server decrypts but doesn advertise anymore -> let people update
+    // 3) can't reach the server -> say that, do nothing
+
+    function key_is_okay() {
+        dialog.open({ Title: _("Key is okay"),
+                      Fields: [ ],
+                      ReactBody: <p>{_("This network key works fine right now and the encrypted data can be unlocked with it.")}</p>
+        });
+    }
+
+    function key_is_broken() {
+        dialog.open({ Title: _("Key does not work"),
+                      Fields: [ ],
+                      ReactBody:
+                      <div>
+                          <p>{_("This network key is not recognized anymore by the server. You might want to remove it.")}</p>
+                          <p>{_("Removing network keys might prevent unattended booting.")}</p>
+                      </div>,
+                      Action: {
+                          DangerButton: true,
+                          Title: _("Remove key"),
+                          action: function () {
+                              return client.clevis_overlay.remove(block, key);
+                          }
+                      }
+        });
+    }
+
+    function key_is_obsolete(info) {
+        function replace() {
+            return client.clevis_overlay.replace(block, key.slot, key.url, info.adv);
+        }
+
+        for (var i = 0; i < key.sigkeys.length; i++) {
+            if (info.sigkeys.indexOf(key.sigkeys[i]) >= 0) {
+                dialog.open({ Title: _("Key is obsolete"),
+                              Fields: [ ],
+                              ReactBody:
+                              <div>
+                                  <p>{_("This network key is obsolete. It is still functional but it should be replaced. A new key has been securely retrieved from the server.")}</p>
+                              </div>,
+                              Action: {
+                                  Title: _("Use new key"),
+                                  action: replace
+                              }
+                });
+                return;
+            }
+        }
+
+        verify_adv(key.url, info,
+                   _("Key is obsolete"),
+                   _("This network key is obsolete. It is still functional but it should be replaced. A new key has been retrieved from the server."),
+                   _("Trust new key"),
+                   replace);
+    }
+
+    function server_cant_be_reached() {
+        dialog.open({ Title: _("Server can't be reached"),
+                      Fields: [ ],
+                      ReactBody:
+                      <p>{cockpit.format(_("The key server at $0 can not be reached.  This network key can not unlock the encrypted data right now, but it might be able to when the server becomes reachable again."), key.url)}</p>,
+        });
+    }
+
+    client.clevis_overlay.get_adv(key.url)
+              .then(function (info) {
+                  client.clevis_overlay.check_key(block, key.slot)
+                        .then(function () {
+                            if (info.keys.indexOf(key.key) >= 0) {
+                                key_is_okay();
+                            } else {
+                                key_is_obsolete(info);
+                            }
+                        })
+                        .fail(function (error) {
+                            console.log(error);
+                            key_is_broken(key);
+                        });
+              })
+              .fail(function (error) {
+                  console.log(error);
+                  server_cant_be_reached();
+              });
+
+}

--- a/pkg/storaged/cockpit-clevis-tool.py
+++ b/pkg/storaged/cockpit-clevis-tool.py
@@ -1,0 +1,162 @@
+#! /usr/bin/python3
+
+# This is a huge hack, let's not bother to make it nice and efficient.
+
+import sys
+import os
+import json
+import subprocess
+import base64
+import hashlib
+import re
+
+import urllib.request
+
+def b64_decode(data):
+    # The data we get doesn't seem to have any padding, but the base64
+    # module requires it.  So we add it back.  Can't anyone agree on
+    # anything?  Not even base64?
+    return base64.urlsafe_b64decode(data + '=' * ((4 - len(data) % 4) % 4))
+
+def decode_clevis_slot(dev, slot):
+    out = subprocess.check_output([ "luksmeta", "load", "-d", dev, "-s", str(slot) ])
+    data = json.loads(b64_decode(out.decode().split(".")[0]))
+    if data['clevis']['pin'] == "tang":
+        return {
+            "slot": slot,
+            "type": "tang",
+            "url": data['clevis']['tang']['url'],
+            "key": data['kid'],
+            "sigkeys": list(map(compute_thp, filter(is_signing_key, data['clevis']['tang']['adv']['keys']))),
+        }
+
+def info(dev):
+    result = subprocess.run([ "luksmeta", "show", "-d", dev ], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    slots = [ ]
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        fields = re.split(b" +", line)
+        if fields[1] == b"active" and fields[2] == b"cb6e8904-81ff-40da-a84a-07ab9ab5715e":
+            info = decode_clevis_slot(dev, int(fields[0]))
+            if info:
+                slots.append(info)
+    return slots
+
+def infos():
+    res = { }
+    for dev in subprocess.check_output([ "lsblk", "-pln", "-o", "NAME" ]).splitlines():
+        i = info(dev)
+        if i:
+            res[dev.decode()] = i
+    return res
+
+def monitor():
+    mon = subprocess.Popen([ "stdbuf", "-o", "L", "udevadm", "monitor", "-u", "-s", "block"],
+                           bufsize=1, stdout=subprocess.PIPE)
+
+    old_infos = infos()
+    sys.stdout.write(json.dumps(old_infos) + "\n")
+    sys.stdout.flush()
+    while True:
+        line = mon.stdout.readline()
+        if b"UDEV" in line:
+            new_infos = infos()
+            if new_infos != old_infos:
+                sys.stdout.write(json.dumps(new_infos) + "\n")
+                sys.stdout.flush()
+                old_infos = new_infos
+
+def remove(dev, slot):
+    # XXX - require passphrase?  Not for security, but to avoid accidents.
+    # cryptsetup needs a terminal on stdin, even with -q or --key-file.
+    pty = os.openpty()
+    subprocess.check_call([ "cryptsetup", "luksKillSlot", "-q", dev, str(slot) ], stdin=pty[0])
+    subprocess.check_call([ "luksmeta", "wipe", "-d", dev, "-s", str(slot), "-f" ])
+
+REQUIRED_ATTRS = {
+    'RSA': ['kty', 'p', 'd', 'q', 'dp', 'dq', 'qi', 'oth'],
+    'EC':  ['kty', 'crv', 'x', 'y'],
+    'oct': ['kty', 'k'],
+}
+
+def compute_thp(jwk):
+    jwk = {k: v for k, v in jwk.items() if k in REQUIRED_ATTRS[jwk['kty']]}
+    jwk = json.dumps(jwk, sort_keys=True, separators=(',', ':'))
+    thp = hashlib.sha1(jwk.encode('utf8')).digest()
+    return base64.urlsafe_b64encode(thp).decode('utf8').rstrip('=')
+
+def is_signing_key(jwk):
+    use = jwk.get('use', None)
+    ops = jwk.get('key_ops', None)
+    if use is None and ops is None:
+        return True
+    if use == 'sig':
+        return True
+    if ops is not None and 'verify' in ops:
+        return True
+    return False
+
+def get_adv(url):
+    if not "://" in url:
+        url = "http://" + url
+    with urllib.request.urlopen(url + "/adv") as rsp:
+        adv_text = rsp.read()
+        adv = json.loads(adv_text.decode())
+        payload = json.loads(b64_decode(adv['payload']))
+        info = {
+            "adv": adv,
+            "sha1sum": hashlib.sha1(adv_text).hexdigest(),
+            "keys": list(map(compute_thp, payload['keys'])),
+            "sigkeys": list(map(compute_thp, filter(is_signing_key, payload['keys']))),
+        }
+        sys.stdout.write(json.dumps(info) + "\n")
+        sys.stdout.flush()
+
+def add(dev, url, adv, passphrase):
+    config = { "url": url, "adv": json.loads(adv) }
+    subprocess.run([ "clevis", "luks", "bind", "-f", "-k", "-", "-d", dev, "tang", json.dumps(config) ],
+                   check=True, input=passphrase.encode())
+
+def check_key(dev, slot):
+    jwe = subprocess.check_output([ "luksmeta", "load", "-d", dev, "-s", slot ])
+    subprocess.run([ "clevis", "decrypt" ],
+                   check = True, input = jwe, stdout=subprocess.PIPE).stdout
+
+def replace(dev, slot, url, adv):
+    jwe = subprocess.check_output([ "luksmeta", "load", "-d", dev, "-s", slot ])
+    passphrase = subprocess.run([ "clevis", "decrypt" ],
+                                check = True, input = jwe, stdout=subprocess.PIPE).stdout
+    if len(adv) > 0:
+        config = { "url": url, "adv": json.loads(adv) }
+    else:
+        config = { "url": url }
+    new_jwe = subprocess.run([ "clevis", "encrypt", "tang", json.dumps(config) ],
+                             check = True, input = passphrase, stdout=subprocess.PIPE).stdout
+    subprocess.run([ "luksmeta", "wipe", "-d", dev, "-s", slot, "-f" ])
+    subprocess.run([ "luksmeta", "save", "-d", dev, "-s", slot, "-u", "cb6e8904-81ff-40da-a84a-07ab9ab5715e" ],
+                   check = True, input = new_jwe)
+
+def unlock(dev):
+    # XXX - clevis-luks-unlock always exits 1, so we check whether the
+    # expected device exists afterwards.
+    clear_dev = b"luks-" + subprocess.check_output([ "cryptsetup", "luksUUID", dev ]).strip()
+    subprocess.run([ "clevis", "luks", "unlock", "-d", dev, "-n", clear_dev ])
+    sys.exit(0 if os.path.exists(b"/dev/mapper/" + clear_dev) else 1)
+
+if sys.argv[1] == "monitor":
+    monitor()
+elif sys.argv[1] == "remove":
+    remove(sys.argv[2], int(sys.argv[3]))
+elif sys.argv[1] == "get-adv":
+    get_adv(sys.argv[2])
+elif sys.argv[1] == "add":
+    add(sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
+elif sys.argv[1] == "check-key":
+    check_key(sys.argv[2], sys.argv[3])
+elif sys.argv[1] == "replace":
+    replace(sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
+elif sys.argv[1] == "unlock":
+    unlock(sys.argv[2])
+else:
+    raise RuntimeError("Nope")

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -171,6 +171,18 @@ function create_tabs(client, target, is_partition) {
     }
 
     function unlock() {
+        if (!client.features.clevis)
+            return unlock_with_passphrase();
+        else {
+            return client.clevis_overlay.unlock(block)
+                         .then(null,
+                               function () {
+                                   return unlock_with_passphrase();
+                               });
+        }
+    }
+
+    function unlock_with_passphrase() {
         var crypto = client.blocks_crypto[block.path];
         if (!crypto)
             return;

--- a/pkg/storaged/crypto-tab.jsx
+++ b/pkg/storaged/crypto-tab.jsx
@@ -32,11 +32,14 @@ var StorageButton = StorageControls.StorageButton;
 var StorageLink =   StorageControls.StorageLink;
 var FormatButton =  FormatDialog.FormatButton;
 
+var ClevisDialogs = require("./clevis-dialogs.jsx");
+
 var _ = cockpit.gettext;
 
 var CryptoTab = React.createClass({
     render: function () {
         var self = this;
+        var client = self.props.client;
         var block = self.props.block;
 
         function edit_config(modify) {
@@ -120,6 +123,33 @@ var CryptoTab = React.createClass({
             });
         }
 
+        function render_clevis_keys(keys) {
+            return (
+                <table className="network-keys-table">
+                    {
+                        keys.map(function (key) {
+                            return (
+                                <tr>
+                                    <td>{key.url}</td>
+                                    <td>
+                                        <StorageButton onClick={() => ClevisDialogs.remove(client, block, key)}>
+                                            Remove
+                                        </StorageButton>
+                                        <StorageButton onClick={() => ClevisDialogs.check(client, block, key)}>
+                                            Check
+                                        </StorageButton>
+                                    </td>
+                                </tr>
+                            );
+                        })
+                    }
+                    <tr>
+                        <td><StorageButton onClick={() => ClevisDialogs.add(client, block)}>Add</StorageButton></td>
+                    </tr>
+                </table>
+            );
+        }
+
         // See format-dialog.jsx above for why we don't offer editing
         // crypttab for the old UDisks2
 
@@ -139,7 +169,13 @@ var CryptoTab = React.createClass({
                       <tr>
                           <td>{_("Options")}</td>
                           <td><StorageLink onClick={edit_options}>{old_options || _("(none)")}</StorageLink></td>
-                    </tr> : null
+                      </tr> : null
+                    }
+                    { self.props.client.features.clevis ?
+                      <tr>
+                        <td>{_("Network keys")}</td>
+                        <td>{ render_clevis_keys(client.clevis_overlay.find_by_block(block) || [ ]) }</td>
+                      </tr> : null
                     }
                 </table>
             </div>

--- a/pkg/storaged/dialog.js
+++ b/pkg/storaged/dialog.js
@@ -67,7 +67,7 @@
 
         function empty(obj) { return !obj || obj.length === 0; }
 
-        def.HasBody = !empty(def.Fields) || !empty(def.Alerts) || !empty(def.Blocking);
+        def.HasBody = def.Body || !empty(def.Fields) || !empty(def.Alerts) || !empty(def.Blocking);
 
         function toggle_arrow(event) {
             /* jshint validthis:true */

--- a/pkg/storaged/dialog.js
+++ b/pkg/storaged/dialog.js
@@ -23,6 +23,7 @@
     var $ = require("jquery");
     var cockpit = require("cockpit");
 
+    var React = require("react");
     var mustache = require("mustache");
     var utils = require("./utils.js");
     require("patterns");
@@ -67,7 +68,7 @@
 
         function empty(obj) { return !obj || obj.length === 0; }
 
-        def.HasBody = def.Body || !empty(def.Fields) || !empty(def.Alerts) || !empty(def.Blocking);
+        def.HasBody = def.Body || def.ReactBody || !empty(def.Fields) || !empty(def.Alerts) || !empty(def.Blocking);
 
         function toggle_arrow(event) {
             /* jshint validthis:true */
@@ -96,6 +97,9 @@
         var $dialog = $(mustache.render(storage_dialog_tmpl, def));
         $('body').append($dialog);
         cur_dialog = $dialog;
+
+        if (def.ReactBody)
+            React.render(def.ReactBody, $dialog.find('.react-body')[0]);
 
         $dialog.on('hidden.bs.modal', function () {
             $dialog.remove();

--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -124,6 +124,10 @@
             {{/HasVDOs}}
             {{/Blocking}}
             {{{Body}}}
+            {{#ReactBody}}
+            <div class="react-body">
+            </div>
+            {{/ReactBody}}
             <table class="form-table-ct">
               {{#Fields}}
               <tr>

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -599,6 +599,11 @@ td.storage-action {
     width: 80%;
 }
 
+.network-keys-table td {
+    vertical-align: baseline;
+    padding-right: 10px;
+}
+
 .form-table-ct .combobox-container .input-group {
     width: 100%;
 }

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -123,5 +123,138 @@ class TestStorage(StorageCase):
         assert m.execute("grep -v ^# /etc/crypttab || true").strip() == ""
         assert m.execute("grep %s /etc/fstab || true" % mount_point_secret) == ""
 
+    def testClevis(self):
+        m = self.machine
+        b = self.browser
+
+        if m.execute("which clevis || true") == "":
+            self.skipTest("No clevis/tang here")
+
+        # We generate the keys and cache explicitly before starting
+        # the socket.  This allows us to control their names, which
+        # helps later on.
+
+        # HACK - tangd-udpate.service can't create /var/cache/tang.
+        #
+        #        https://github.com/latchset/tang/issues/24
+
+        m.execute("mkdir /var/cache/tang; chown -R tang:tang /var/cache/tang")
+
+        m.execute("rm -rf /var/db/tang/*")
+        m.execute("jose jwk gen -i '{\"alg\":\"ES512\"}' >/var/db/tang/sig1.jwk")
+        m.execute("jose jwk gen -i '{\"alg\":\"ECMR\"}' -o /var/db/tang/enc1.jwk")
+
+        # HACK - /var/cache/tang is automatically updated whenever
+        #        /var/db/tang changes, but also asynchronously in the
+        #        background, and it's not reliable either.
+        #
+        #        https://github.com/latchset/tang/issues/23
+
+        m.execute("systemctl reset-failed tangd-update; systemctl restart tangd-update")
+
+        m.execute("systemctl start tangd.socket")
+
+        self.login_and_go("/storage")
+
+        # Add a disk and format it with luks
+        m.add_disk("50M", serial="MYDISK")
+        b.wait_in_text("#drives", "MYDISK")
+        b.click('tr:contains("MYDISK")')
+        b.wait_visible("#storage-detail")
+
+        self.content_tab_action(1, 1, "Format")
+        self.dialog({ "type": "luks+ext4",
+                      "name": "ENCRYPTED",
+                      "passphrase": "vainu-reku-toma-rolle-kaja",
+                      "passphrase2": "vainu-reku-toma-rolle-kaja" })
+        self.content_row_wait_in_col(1, 1, "Encrypted data")
+        self.content_row_wait_in_col(2, 1, "ext4 File System")
+
+        # Set the flag and reload the page to make the Clevis stuff appear
+        #
+        b.eval_js('window.localStorage["clevis-feature"] = "on"')
+        b.reload()
+        b.enter_page("/storage")
+
+        # Lock the disk
+        #
+        self.content_head_action(1, "Lock")
+        b.wait_not_in_text("#detail-content", "ext4 File System")
+
+        # Add a key
+        #
+        self.content_tab_wait_in_info(1, 1, "Network keys", "")
+        self.content_tab_action(1, 1, "Add")
+        self.dialog_wait_open()
+        self.dialog_set_val("url", "127.0.0.1")
+        self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
+        self.dialog_apply()
+        b.wait_in_text("#dialog", "The output should match this text")
+        b.wait_in_text("#dialog", m.execute("jose jwk thp -i /var/db/tang/sig1.jwk").strip())
+
+        self.dialog_apply()
+        self.dialog_wait_close()
+        self.content_tab_wait_in_info(1, 1, "Network keys", "127.0.0.1")
+
+        # Unlock it.  This should succeed without prompting.
+        #
+        self.content_head_action(1, "Unlock")
+        self.content_row_wait_in_col(2, 1, "ext4 File System")
+
+        # Rotate the encryption key on the server, and rebind
+
+        m.execute("mv /var/db/tang/enc1.jwk /var/db/tang/.enc1.jwk")
+        m.execute("jose jwk gen -i '{\"alg\":\"ECMR\"}' >/var/db/tang/enc2.jwk")
+        m.execute("systemctl reset-failed tangd-update; systemctl restart tangd-update")
+
+        self.content_tab_action(1, 1, "Check")
+        self.dialog_wait_open()
+        b.wait_in_text("#dialog", "This network key is obsolete.")
+        b.wait_in_text("#dialog", "A new key has been securely retrieved from the server.")
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        # Remove obsolete key, disk should still unlock
+
+        m.execute("rm /var/db/tang/.enc1.jwk")
+        m.execute("systemctl restart tangd-update")
+        self.content_head_action(1, "Lock")
+        b.wait_not_in_text("#detail-content", "ext4 File System")
+        self.content_head_action(1, "Unlock")
+        self.content_row_wait_in_col(2, 1, "ext4 File System")
+
+        # Rotate both the encryption key and the signing key on the server, and rebind
+
+        m.execute("mv /var/db/tang/enc2.jwk /var/db/tang/.enc2.jwk")
+        m.execute("jose jwk gen -i '{\"alg\":\"ECMR\"}' >/var/db/tang/enc3.jwk")
+        m.execute("mv /var/db/tang/sig1.jwk /var/db/tang/.sig1.jwk")
+        m.execute("jose jwk gen -i '{\"alg\":\"ES512\"}' >/var/db/tang/sig2.jwk")
+        m.execute("systemctl reset-failed tangd-update; systemctl restart tangd-update")
+
+        self.content_tab_action(1, 1, "Check")
+        self.dialog_wait_open()
+        b.wait_in_text("#dialog", "This network key is obsolete.")
+        b.wait_in_text("#dialog", "The output should match this text")
+        b.wait_in_text("#dialog", m.execute("jose jwk thp -i /var/db/tang/sig2.jwk").strip())
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        # Remove the key on the server
+
+        m.execute("rm /var/db/tang/enc3.jwk")
+        m.execute("systemctl reset-failed tangd-update; systemctl restart tangd-update")
+        self.content_tab_action(1, 1, "Check")
+        self.dialog_wait_open()
+        b.wait_in_text("#dialog", "This network key is not recognized anymore by the server.")
+        self.dialog_cancel()
+        self.dialog_wait_close()
+
+        # Remove key on client
+
+        b.wait_in_text(self.content_tab_info_row(1, 1, "Network keys"), "127.0.0.1")
+        self.content_tab_action(1, 1, "Remove")
+        self.confirm()
+        b.wait_not_in_text(self.content_tab_info_row(1, 1, "Network keys"), "127.0.0.1")
+
 if __name__ == '__main__':
     test_main()

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -142,7 +142,7 @@ class StorageCase(MachineCase):
             row_item = row + " tr.listing-ct-item"
             tab_btn = row + " .listing-ct-head li:nth-child(%d) a" % tab_index
             tab = row + " .listing-ct-body:nth-child(%d)" % (tab_index + 1)
-            cell = tab + " table.info-table-ct tr:contains(%s) td:nth-child(2)" % title
+            cell = tab + " table.info-table-ct tr:contains(%s) > td:nth-child(2)" % title
 
             if not b.is_present(row + ".open"):
                 if not b.is_present(row_item):


### PR DESCRIPTION
The idea is that we add the necessary APIs to UDisks2 (and libblockdev), but this here is a quick and dirty skeleton that should inform the API design.

There is a hidden switch that needs to be explicitly flipped before this appears in the UI.  So I think we can actually consider merging and releasing this.

The hidden switch:  Type the following into the browser console and reload the storage page.
```
window.localStorage["clevis-feature"] = "on"
```

### Setting up tang

If you want to play with this, you need to set up a `tang` server.   This should work on Fedora 27:
```
# dnf install tang
# cat <<EOF >/etc/systemd/system/tangd.socket.d/port.conf 
[Socket]
ListenStream=
ListenStream=88
EOF
# systemctl enable --now tangd.socket
```

This puts the tangs server on port 88 instead of the default 80.  Any other port is fine as well.  (If port 80 is fine, you don't even need to put the file into with /etc/systemd.)

Then install the `clevis-luks` package on the system where you want to use this.

### Tasks

- [x] Add that hidden switch
- [x] Button for refreshing a key
- [x] Simple test to demonstrate feasibility
