### PR TITLE
bots: Release to Fedora 28

### DIFF
--- a/bots/major-cockpit-release
+++ b/bots/major-cockpit-release
@@ -25,6 +25,7 @@ job release-srpm
 
 # Do fedora builds for the tag, using tarball
 job release-koji -k master
+job release-koji f28
 job release-koji f27
 
 # Upload release to github, using tarball
@@ -39,6 +40,7 @@ job release-dockerhub cockpituous/cockpit cockpit-project/cockpit
 
 # Push out a Bodhi update
 job release-bodhi F27
+job release-bodhi F28
 
 # Upload documentation
 job bots/release-guide dist/guide cockpit-project/cockpit-project.github.io


### PR DESCRIPTION
Fedora 28 has branched from Rawhide now, so we need to release there
explicitly.