### PR TITLE
kubernetes: Disable editing of volume host paths

### DIFF
--- a/pkg/kubernetes/views/pv-modify.html
+++ b/pkg/kubernetes/views/pv-modify.html
@@ -128,7 +128,8 @@
                 </td>
                 <td>
                     <input id="modify-path" class="form-control" type="text"
-                        ng-model="fields.path">
+                        ng-if="!item" ng-model="fields.path">
+                    <span id="modify-path" ng-if="item">{{ fields.path }}</span>
                 </td>
             </tr>
             <tr ng-if="hasField('target')">

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -483,11 +483,6 @@ class TestOpenshiftPrerelease(TestOpenshift):
         "openshift": { "image": "openshift-prerelease", "forward": { 30000: 30000, 8443: 8443 } }
     }
 
-    # https://github.com/cockpit-project/cockpit/issues/8744
-    @unittest.expectedFailure
-    def testVolumes(self):
-        super(TestOpenshiftPrerelease, self).testVolumes()
-
 
 @skipImage("Kubernetes not packaged", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-i386")
 @skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic")

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -243,15 +243,11 @@ class VolumeTests(object):
         b.wait_in_text("modal-dialog span#modify-name", "pv2")
         b.wait_not_present("modal-dialog input#modify-capacity")
         b.wait_in_text("modal-dialog span#modify-capacity", pv2_size)
+        b.wait_not_present("modal-dialog input#modify-path")
+        b.wait_in_text("modal-dialog span#modify-path", "/tmp")
 
-        if "openshift" in m.image:
-            b.set_val("modal-dialog #modify-path", "/not-tmp")
-            b.click("modal-dialog .modal-footer button.btn-primary")
-            b.wait_not_present("modal-dialog")
-            b.wait_in_text(".listing-ct-inline", "/not-tmp")
-        else:
-            b.click("modal-dialog button.btn-default")
-            b.wait_not_present("modal-dialog")
+        b.click("modal-dialog button.btn-default")
+        b.wait_not_present("modal-dialog")
 
         b.click("a.hidden-xs")
         b.wait_present(".pv-listing tbody[data-id='fc-volume']")


### PR DESCRIPTION
Starting with Kubernetes 1.9 and OpenShift 3.9, the host path of
persistent volumes is immutable. Change the volume edit dialog to show
it as a read-only value, similar to what it does for type, name, and
capacity already.

Note that this is a small regression for running against earlier
OpenShift versions. There the volume has to be removed and recreated
again to change the path. The API does not tell us whether it's
modifiable, so we can't easily make the field editable conditionally.

Remove the special case from the corresponding test and always make sure
that the path is read-only in "edit" mode.

Fixes #8744