### PR TITLE
bots: Stop testing branches

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -249,22 +249,6 @@ def cockpit_tasks (api, update, policy):
                 branch_contexts[branch] = [ ]
             branch_contexts[branch].append(context)
 
-    branch_priority = BASELINE_PRIORITY - 3
-    for branch in branch_contexts:
-        ref = api.get("git/refs/heads/{0}".format(branch))
-        # if the branch doesn't exist but other branches begin with this name, GitHub returns a list
-        # we don't want to use such a list
-        # https://developer.github.com/v3/git/refs/
-        if ref and not isinstance(ref, list):
-            revision = ref["object"]["sha"]
-            statuses = api.statuses(revision)
-            which = list(statuses.keys()) or branch_contexts[branch]
-            for context in which:
-                status = statuses.get(context, { })
-                (priority, changes) = prioritize(status, "", lambda: [], branch_priority, context)
-                if not update or update_status(api, revision, context, status, changes):
-                    results.append((priority, branch, revision, branch, context, None))
-
     whitelist = github.whitelist()
     for pull in api.pulls():
         title = pull["title"]


### PR DESCRIPTION
When they have nothing else to do, this caused our bots to perpetually
run tests on master and rhel-7.4 branches (notably not rhel-7.5, which
we never added). Nobody looks at them, there is no expected change (both
the code and the test VMs stay the same), and the meaningful CI happens
on pull requests.  We never push directly to master, other than very rare
reverts of a recent PR that cased trouble; so this is just a waste of
resources.

Moreover, this breaks badly with new external repositories: If they
don't yet have tests, then the bots will be on a tight loop of "start
tests on master, fail on missing test/run, start over" - in this case
there is no place in GitHub to attach a result to, so these can never be
marked as "failed" properly.