### PR TITLE
apps: Revert unnecessary Promise wrapping

### DIFF
--- a/pkg/apps/packagekit.es6
+++ b/pkg/apps/packagekit.es6
@@ -52,9 +52,7 @@ function resolve(method, filter, name, progress_cb) {
 }
 
 function reload_bridge_packages() {
-    return new Promise((resolve, reject) =>
-        cockpit.dbus(null, { bus: "internal" }).call("/packages", "cockpit.Packages", "Reload", [ ]).then(resolve, reject)
-    );
+    return cockpit.dbus(null, { bus: "internal" }).call("/packages", "cockpit.Packages", "Reload", [ ]);
 }
 
 function install(name, progress_cb) {


### PR DESCRIPTION
Commit 717c6e9fd70 wrapped a `cockpit.promise` into a JS `Promise`, but
this isn't actually necessary. They are compatible enough for chaining
to work.