### PR TITLE
apps: More robust collection parsing

### DIFF
--- a/pkg/apps/watch-appstream.py
+++ b/pkg/apps/watch-appstream.py
@@ -267,12 +267,15 @@ class MetainfoDB:
             info = { }
             origin = xml_root.attrib['origin']
             for xml_comp in xml_root.iter('component'):
-                comp = convert_collection_component(os.path.dirname(file), origin, xml_comp)
-                if comp is not None:
-                    if comp['id'] in info:
-                        pass # warning: duplicate id
-                    else:
-                        info[comp['id']] = comp
+                try:
+                    comp = convert_collection_component(os.path.dirname(file), origin, xml_comp)
+                    if comp is not None:
+                        if comp['id'] in info:
+                            pass # warning: duplicate id
+                        else:
+                            info[comp['id']] = comp
+                except KeyError:
+                    pass
             self.available_by_file[file] = info
         elif file in self.available_by_file:
             del self.available_by_file[file]

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -265,5 +265,34 @@ This <is <not XML.
         b.wait_present(".app-list-empty")
         reset()
 
+        # Error (launchable without type) in earlier entry, shouldn't affect the later entry
+        m.write("/usr/share/app-info/xmls/test.xml", """
+<components origin="test">
+  <component type="addon">
+    <extends>cockpit.desktop</extends>
+    <id>org.cockpit-project.test2</id>
+    <name>Name</name>
+    <summary>Summary</summary>
+    <description>
+        <p>Description 2</p>
+    </description>
+    <launchable>foo</launchable>
+    <pkgname>foo</pkgname>
+  </component>
+  <component type="addon">
+    <extends>cockpit.desktop</extends>
+    <id>org.cockpit-project.test</id>
+    <name>Name</name>
+    <summary>Summary 2</summary>
+    <description>
+        <p>Description</p>
+    </description>
+    <launchable type="cockpit-manifest">foo</launchable>
+    <pkgname>foo</pkgname>
+  </component>
+</components>""")
+        b.wait_not_present(".app-list-empty")
+        b.wait_present(".app-list tr:contains('Summary 2')")
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Any exception during parsing a XML collection file would ignore
everything from that file.  Let's just ignore the entry that caused
the exception.