### PR TITLE
examples: Change pinger to have a safe CSP and a test

### DIFF
--- a/examples/pinger/manifest.json
+++ b/examples/pinger/manifest.json
@@ -6,7 +6,5 @@
             "label": "Pinger",
             "path": "ping.html"
         }
-    },
-
-    "content-security-policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
+    }
 }

--- a/examples/pinger/ping.html
+++ b/examples/pinger/ping.html
@@ -5,7 +5,7 @@
     <script src="../base1/cockpit.js"></script>
 </head>
 <body>
-    <div class="container-fluid" style='max-width: 400px'>
+    <div class="container-fluid">
         <table class="form-table-ct">
             <tr>
                 <td><label class="control-label" for="address">Address</label></td>
@@ -13,45 +13,15 @@
             </tr>
             <tr>
                 <td><button class="btn btn-default btn-primary" id="ping">Ping</button></td>
-		<td><span id="result"></span></td>
+                <td><span id="result"></span></td>
             </tr>
         </table>
         <p>
-	    <pre id="output"></pre>
+            <pre id="output"></pre>
         </p>
     </div>
 
-    <script>
-        var address = document.getElementById("address");
-        var output = document.getElementById("output");
-        var result = document.getElementById("result");
-
-        document.getElementById("ping").addEventListener("click", ping_run);
-
-        function ping_run() {
-            var proc = cockpit.spawn(["ping", "-c", "4", address.value]);
-            proc.done(ping_success);
-            proc.stream(ping_output);
-            proc.fail(ping_fail);
-
-            result.innerHTML = "";
-            output.innerHTML = "";
-        }
-
-        function ping_success() {
-            result.style.color = "green";
-            result.innerHTML = "success";
-        }
-
-        function ping_fail() {
-            result.style.color = "red";
-            result.innerHTML = "fail";
-        }
-
-        function ping_output(data) {
-            output.append(document.createTextNode(data));
-        }
-    </script>
+    <script src="pinger.js"></script>
 </body>
 </html>
 

--- a/examples/pinger/pinger.js
+++ b/examples/pinger/pinger.js
@@ -1,0 +1,33 @@
+var address = document.getElementById("address");
+var output = document.getElementById("output");
+var result = document.getElementById("result");
+
+document.querySelector(".container-fluid").style["max-width"] = "500px";
+document.getElementById("ping").addEventListener("click", ping_run);
+
+function ping_run() {
+    var proc = cockpit.spawn(["ping", "-c", "4", address.value]);
+    proc.done(ping_success);
+    proc.stream(ping_output);
+    proc.fail(ping_fail);
+
+    result.innerHTML = "";
+    output.innerHTML = "";
+}
+
+function ping_success() {
+    result.style.color = "green";
+    result.innerHTML = "success";
+}
+
+function ping_fail() {
+    result.style.color = "red";
+    result.innerHTML = "fail";
+}
+
+function ping_output(data) {
+    output.append(document.createTextNode(data));
+}
+
+// Send a 'init' message.  This tells the tests that we are ready to go
+cockpit.transport.wait(function() { });

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+
+import os
+import sys
+
+import parent
+from testlib import *
+
+EXAMPLES_DIR = os.path.join(os.path.dirname(TEST_DIR), "examples")
+
+
+class TestPinger(MachineCase):
+    def setUp(self):
+        super(TestPinger, self).setUp()
+        self.machine.execute("mkdir -p ~admin/.local/share/cockpit")
+        self.machine.upload([os.path.join(EXAMPLES_DIR, "pinger")], "~admin/.local/share/cockpit/")
+
+    def testBasic(self):
+        b = self.browser
+
+        self.login_and_go("/pinger/ping")
+        b.wait_present("#address")
+        b.set_val("#address", "127.0.0.1")
+        b.click("button#ping")
+        b.wait_in_text("#result", "success")
+        b.wait_in_text("#output", "--- 127.0.0.1 ping statistics")
+
+
+if __name__ == '__main__':
+    test_main()


### PR DESCRIPTION
 - Split out the JavaScript bits of pinger into a separate .js file, and
   move the one `style=` assignment in HTML to JS. This avoids having to
   use `unsafe-inline` C-S-P.

 - Widen the maximal width to 500px. Otherwise the ping result cannot be
   shown completely.

 - Drop unnecessary `unsave-eval` C-S-P.

 - For `login_and_go("/pinger/ping")` to work, the pinger page needs to set
   `data-loaded`. This only happens at the first cockpit channel message,
   so call `cockpit.transport.wait()` to force that. Otherwise the first
   message only happens when pressing the "Ping" button.

 - Add a simple integration test to the new test/verify/check-examples.
   Over time, our other examples should be tested there as well.