### PR TITLE
lib: Add missing Promise polyfill for IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "less-loader": "~4.0.6",
     "ng-cache-loader": "0.0.16",
     "po2json": "~0.4.1",
-    "promise": "~7.1.1",
     "raw-loader": "~0.5.1",
     "sizzle": "~2.1.0",
     "stdio": "~0.2.7",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "object-describer": "https://github.com/kubernetes-ui/object-describer.git#v1.0.4",
     "patternfly": "3.35.1",
     "patternfly-bootstrap-combobox": "1.1.7",
+    "promise": "8.0.1",
     "qunit-tap": "1.5.1",
     "qunitjs": "1.23.1",
     "react-lite": "0.15.39",

--- a/pkg/lib/polyfills.js
+++ b/pkg/lib/polyfills.js
@@ -23,6 +23,9 @@
  */
 
 // for IE 11
+require('promise/polyfill.js');
+
+// for IE 11
 if (!String.prototype.startsWith) {
     String.prototype.startsWith = function (searchString, position) {
         position = position || 0;

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -18,6 +18,7 @@
  */
 
 import cockpit from "cockpit";
+import '../lib/polyfills.js'; // once per application
 import React from "react";
 import moment from "moment";
 import { Tooltip } from "cockpit-components-tooltip.jsx";

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -18,6 +18,7 @@
  */
 
 import cockpit from "cockpit";
+import '../lib/polyfills.js'; // once per application
 import React from "react";
 import { Listing, ListingRow } from "cockpit-components-listing.jsx";
 

--- a/test/avocado/selenium-navigate.py
+++ b/test/avocado/selenium-navigate.py
@@ -24,6 +24,12 @@ class NavigateTestSuite(SeleniumTest):
         self.wait_frame("system")
         self.click(self.wait_id('system_information_systime_button', cond=clickable))
         self.wait_id('system_information_change_systime', cond=visible)
+
+        # Check hardware info page
+        self.click(self.wait_id('system_information_hardware_text', cond=clickable))
+        self.mainframe()
+        self.wait_frame("hwinfo")
+        self.wait_text('BIOS date')
         self.mainframe()
 
         # Now navigate to the logs

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -273,10 +273,6 @@ var extend = require("extend");
 var path = require("path");
 var fs = require("fs");
 
-/* For node 0.10.x we need this defined */
-if (typeof(global.Promise) == "undefined")
-    global.Promise = require('promise');
-
 /* These can be overridden, typically from the Makefile.am */
 var srcdir = process.env.SRCDIR || __dirname;
 var builddir = process.env.BUILDDIR || __dirname;


### PR DESCRIPTION
ES6 `Promise` is being used on the Hardware info, Software Updates, and
Machines pages. But this is undefined on Windows 8's IE, so add the
polyfill from our `promise` npm module.

Add a simple Selenium test which reproduces the crash (without this
fix).