### PR TITLE
lib: Don't let file-autocomplete CSS leak into combobox

### DIFF
--- a/pkg/lib/cockpit-components-file-autocomplete.css
+++ b/pkg/lib/cockpit-components-file-autocomplete.css
@@ -1,38 +1,38 @@
-.combobox-container input {
+.file-autocomplete-ct input {
     padding-right: 24px;
 }
 
-.combobox-container ul {
+.file-autocomplete-ct ul {
     max-height: 250px;
 }
 
-.combobox-container .alert {
+.file-autocomplete-ct .alert {
     margin: 0;
     border: none;
     padding: 0 24px 0 6px;
 }
 
-.combobox-container .error input {
+.file-autocomplete-ct .error input {
     border-color: red;
 }
 
-.combobox-container .error input {
+.file-autocomplete-ct .error input {
     border-color: red;
 }
 
-.combobox-container .error ul {
+.file-autocomplete-ct .error ul {
     border-color: red;
     padding: 0;
 }
 
-.combobox-container span.spinner,
-.combobox-container span.caret {
+.file-autocomplete-ct span.spinner,
+.file-autocomplete-ct span.caret {
     position: absolute;
     top: 7px;
     z-index: 9;
 }
 
-.combobox-container span.caret {
+.file-autocomplete-ct span.caret {
     width: 1.5em;
     height: 1.5em;
     cursor: pointer;

--- a/pkg/lib/cockpit-components-file-autocomplete.jsx
+++ b/pkg/lib/cockpit-components-file-autocomplete.jsx
@@ -285,7 +285,7 @@ var FileAutoComplete = React.createClass({
         }
 
         return (
-            <div className="combobox-container" id={this.props.id}>
+            <div className="combobox-container file-autocomplete-ct" id={this.props.id}>
                 <div className={classes}>
                     <input ref="input" autocomplete="false" placeholder={placeholder} className="combobox form-control" type="text" onChange={this.delayedOnChange} value={this.state.value} onBlur={this.onBlur} />
                     <span onClick={this.showAllOptions} className={controlClasses}></span>


### PR DESCRIPTION
The CSS breaks the regular Patternfly combobox layout.