### PR TITLE
bots: Add fedora-28 image

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -44,6 +44,9 @@ TRIGGERS = {
         "verify/fedora-27",
         "verify/fedora-atomic",
     ],
+    "fedora-28": [
+        "verify/fedora-28",
+    ],
     "fedora-atomic": [
         "verify/fedora-atomic"
     ],

--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -28,6 +28,7 @@ REFRESH = {
     "debian-stable": { },
     "fedora-26": { },
     "fedora-27": { },
+    "fedora-28": { },
     "fedora-atomic": { },
     "fedora-testing": { },
     "fedora-i386": { },

--- a/bots/images/fedora-28
+++ b/bots/images/fedora-28
@@ -1,0 +1,1 @@
+fedora-28-624997c7f3ccd080cefbab1658bc5f4db231ccdbacaf12ea7942d8fb1225126b.qcow2

--- a/bots/images/scripts/fedora-28.bootstrap
+++ b/bots/images/scripts/fedora-28.bootstrap
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright (C) 2018 Red Hat Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA.
+
+BASE=$(dirname $0)
+$BASE/virt-install-fedora "$1" x86_64 "http://dl.fedoraproject.org/pub/fedora/linux/development/28/Server/x86_64/os/"
+# once Fedora 28 is released, switch to this:
+#$BASE/virt-install-fedora "$1" x86_64 "http://dl.fedoraproject.org/pub/fedora/linux/releases/28/Server/x86_64/os/"

--- a/bots/images/scripts/fedora-28.install
+++ b/bots/images/scripts/fedora-28.install
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+set -e
+/var/lib/testvm/fedora.install "$@"
+
+# HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1557913
+# this fails every test due to the SELinux violations (so naughty override
+# causes too much spamming) and causes long boot times due to holding up default.target
+systemctl disable pmcd.service

--- a/bots/images/scripts/fedora-28.setup
+++ b/bots/images/scripts/fedora-28.setup
@@ -1,0 +1,1 @@
+fedora.setup

--- a/bots/images/scripts/lib/fedora.install
+++ b/bots/images/scripts/lib/fedora.install
@@ -74,6 +74,7 @@ if [ -n "$do_build" ]; then
     LC_ALL=C.UTF-8 su builder -c "/usr/bin/mock --offline --no-clean --resultdir build-results $mock_opts --rebuild $srpm"
 
     su builder -c "/usr/bin/mock --offline --shell" <<EOF
+rm -rf /builddir/build
 if type rpmlint >/dev/null 2>&1; then
     # blacklist "E: no-changelogname-tag" rpmlint error, expected due to our template cockpit.spec
     mkdir -p ~/.config

--- a/bots/naughty/fedora-28/6493-selinux-sosreport-relabelto
+++ b/bots/naughty/fedora-28/6493-selinux-sosreport-relabelto
@@ -1,0 +1,1 @@
+Error: audit: type=1400*avc:  denied  { relabelto } for * comm="sosreport"

--- a/bots/naughty/fedora-28/7635-selinux-pmlogger
+++ b/bots/naughty/fedora-28/7635-selinux-pmlogger
@@ -1,0 +1,1 @@
+Error: audit: type=1400*avc:  denied  { sendto } for * path="/usr/bin/pmlogger"

--- a/bots/naughty/fedora-28/7635-selinux-pmlogger2
+++ b/bots/naughty/fedora-28/7635-selinux-pmlogger2
@@ -1,0 +1,1 @@
+Error: audit: type=1400*avc:  denied  { execute_no_trans } for * path="/usr/bin/pmlogger"

--- a/bots/naughty/fedora-28/7635-selinux-pmsignal
+++ b/bots/naughty/fedora-28/7635-selinux-pmsignal
@@ -1,0 +1,1 @@
+Error: audit: type=1400*avc:  denied  { signal } for * comm="pmsignal"

--- a/bots/naughty/fedora-28/7636-selinux-hostname
+++ b/bots/naughty/fedora-28/7636-selinux-hostname
@@ -1,0 +1,1 @@
+Error: audit: type=1400*avc:  denied  { map } for * comm="hostname"

--- a/bots/naughty/fedora-28/7636-selinux-logger
+++ b/bots/naughty/fedora-28/7636-selinux-logger
@@ -1,0 +1,1 @@
+Error: audit: type=1400*avc:  denied  { sendto } for * path="/run/systemd/journal/dev-log"

--- a/bots/naughty/fedora-28/7636-selinux-passwd
+++ b/bots/naughty/fedora-28/7636-selinux-passwd
@@ -1,0 +1,1 @@
+Error: audit: type=1400*avc:  denied  { map } for * comm="passwd"

--- a/bots/naughty/fedora-28/7636-selinux-pmie
+++ b/bots/naughty/fedora-28/7636-selinux-pmie
@@ -1,0 +1,1 @@
+Error: audit: type=1400*avc:  denied  { execute_no_trans } for * comm="pmie_check"

--- a/bots/naughty/fedora-28/8855-etcd-kubelet-failure
+++ b/bots/naughty/fedora-28/8855-etcd-kubelet-failure
@@ -1,0 +1,8 @@
+Traceback (most recent call last):
+  File "test/verify/check-kubernetes", line *
+    self.start_kubernetes()
+  File "test/verify/kubelib.py", line 79, in start_kubernetes
+    self.machine.execute("systemctl start etcd kube-apiserver kube-controller-manager kube-scheduler kube-proxy kubelet")
+*
+CalledProcessError: Command 'systemctl start etcd kube-apiserver kube-controller-manager kube-scheduler kube-proxy kubelet' returned non-zero exit status 1
+

--- a/bots/naughty/fedora-28/8869-selinux-dynamicuser
+++ b/bots/naughty/fedora-28/8869-selinux-dynamicuser
@@ -1,0 +1,2 @@
+Error: audit: type=1400 audit(*): avc:  denied  { * } for * comm="(imesyncd)" name=".pwd.lock"
+

--- a/bots/naughty/fedora-28/8871-selinux-rpcbind
+++ b/bots/naughty/fedora-28/8871-selinux-rpcbind
@@ -1,0 +1,1 @@
+Error: audit: type=1400 audit(*): avc:  denied  { name_bind } for * comm="rpcbind"

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -35,7 +35,7 @@ DEFAULT_VERIFY = {
     'verify/fedora-i386': BRANCHES,
     'verify/fedora-26': [ ],
     'verify/fedora-27': [ 'master' ],
-    'verify/fedora-28': [ ],
+    'verify/fedora-28': [ 'master' ],
     'verify/fedora-atomic': BRANCHES,
     'verify/fedora-testing': [ ],
     'verify/ubuntu-1604': [ 'master' ],

--- a/test/README
+++ b/test/README
@@ -68,6 +68,7 @@ You can set these environment variables to configure the test suite:
                 "debian-testing"
                 "fedora-26"
                 "fedora-27"
+                "fedora-28"
                 "fedora-atomic"
                 "fedora-testing"
                 "rhel-7"

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -784,6 +784,13 @@ class MachineCase(unittest.TestCase):
         messages = machine.journal_messages(syslog_ids, 5)
         if "TEST_AUDIT_NO_SELINUX" not in os.environ:
             messages += machine.audit_messages("14") # 14xx is selinux
+
+        # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1557913
+        # this fails tons of tests due to the SELinux violations (so naughty override causes too much spamming)
+        if self.image == 'fedora-28':
+            self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { dac_override }.*')
+            self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { module_request }.*')
+
         all_found = True
         first = None
         for m in messages:

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -37,6 +37,7 @@ from testlib import *
 def can_manage(machine):
     return machine.image in [ "fedora-26",
                               "fedora-27",
+                              "fedora-28",
                               "fedora-testing",
                               "rhel-7",
                               "rhel-7-4",
@@ -67,7 +68,7 @@ def initially_loopbacked(machine):
 
     # use the overlayfs or aufs driver by default on some distros
     if machine.image in [ "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable",
-                          "fedora-26", "fedora-testing", "fedora-27", "fedora-atomic",
+                          "fedora-26", "fedora-testing", "fedora-27", "fedora-28", "fedora-atomic",
                           "rhel-7", "rhel-7-4", "rhel-7-5" ]:
         return False
 

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -114,7 +114,7 @@ def rhsmcertd_hack(m):
     m.execute("systemctl stop rhsmcertd || true")
 
 
-@skipImage("No OSTree available", "centos-7", "debian-stable", "debian-testing", "fedora-26", "fedora-27", "fedora-testing", "fedora-i386", "rhel-7", "rhel-7-4", "rhel-7-5", "ubuntu-1604", "ubuntu-stable")
+@skipImage("No OSTree available", "centos-7", "debian-stable", "debian-testing", "fedora-26", "fedora-27", "fedora-28", "fedora-testing", "fedora-i386", "rhel-7", "rhel-7-4", "rhel-7-5", "ubuntu-1604", "ubuntu-stable")
 class OstreeRestartCase(MachineCase):
     provision = {
         "machine1": { "address": "10.111.113.2/20", "dns": "10.111.113.2" }
@@ -417,7 +417,7 @@ class OstreeRestartCase(MachineCase):
 
         self.allow_restart_journal_messages()
 
-@skipImage("No OSTree available", "centos-7", "debian-stable", "debian-testing", "fedora-26", "fedora-27", "fedora-testing", "fedora-i386", "rhel-7", "rhel-7-4", "rhel-7-5", "ubuntu-1604", "ubuntu-stable")
+@skipImage("No OSTree available", "centos-7", "debian-stable", "debian-testing", "fedora-26", "fedora-27", "fedora-28", "fedora-testing", "fedora-i386", "rhel-7", "rhel-7-4", "rhel-7-5", "ubuntu-1604", "ubuntu-stable")
 class OstreeCase(MachineCase):
     provision = {
         "machine1": { "address": "10.111.113.2/20", "dns": "10.111.113.2" }

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -656,7 +656,7 @@ class TestUpdates(PackageCase):
 
 
 @skipImage("Image uses OSTree", "continuous-atomic", "fedora-atomic", "rhel-atomic")
-@skipImage("No subscriptions", "centos-7", "debian-stable", "debian-testing", "fedora-26", "fedora-27", "fedora-i386", "fedora-testing", "ubuntu-1604", "ubuntu-stable")
+@skipImage("No subscriptions", "centos-7", "debian-stable", "debian-testing", "fedora-26", "fedora-27", "fedora-28", "fedora-i386", "fedora-testing", "ubuntu-1604", "ubuntu-stable")
 class TestUpdatesSubscriptions(PackageCase):
     provision = {
         "0": { "address": "10.111.113.2/20", "dns": "10.111.113.2" },

--- a/test/verify/check-subscriptions
+++ b/test/verify/check-subscriptions
@@ -78,7 +78,7 @@ print [ e['id'] for e in data if e['owner']['key'] == 'admin' and e['contractNum
 "
 """
 
-@skipImage("No subscriptions", "centos-7", "continuous-atomic", "debian-stable", "debian-testing", "fedora-26", "fedora-27", "fedora-i386", "fedora-atomic", "fedora-testing", "ubuntu-1604", "ubuntu-stable")
+@skipImage("No subscriptions", "centos-7", "continuous-atomic", "debian-stable", "debian-testing", "fedora-26", "fedora-27", "fedora-28", "fedora-i386", "fedora-atomic", "fedora-testing", "ubuntu-1604", "ubuntu-stable")
 class TestSubscriptions(MachineCase):
     provision = {
         "0": { "address": "10.111.113.1/20" },


### PR DESCRIPTION
Add workaround for pcp SELinux regression (issue #8847, downstream bug 
https://bugzilla.redhat.com/show_bug.cgi?id=1557913). This breaks
*every* test, thus a known issue/naughty override is too spammy and 
impractical. This also causes long boot times and check-services failure
due to pmcd.service holding up default.target. Remove and disable pmcd
in fedora-28.install, so that it's much easier to drop again and 
experiment with the unhacked original image.

Add naughty override for kubernetes failures (issue #8855, downstream
bugs https://bugzilla.redhat.com/show_bug.cgi?id=1557356 and 
https://bugzilla.redhat.com/show_bug.cgi?id=1558425)

Add naughty override for broken `DynamicUser=yes` due to SELinux policy
(issue #8869, https://bugzilla.redhat.com/show_bug.cgi?id=1559281).

Add naughty override for SELinux denying port binding to rpcbind
(issue #8871, https://bugzilla.redhat.com/show_bug.cgi?id=1559324).

Copy the fedora 27 naughty overrides which still seem relevant. Skip the 
PCP crashes for now, let's first see if they still actually happen with
pcp 4.x.

 * [x] image-refresh fedora-28
 - [x] rebuild with clevis+tang after #8832 
 - [x] copy naughty overrides from Fedora 27 which are still relevant
 - [x] investigate/report/naughty for broken kubernetes: [etcd failure](https://bugzilla.redhat.com/show_bug.cgi?id=1557356), [kubelet failure](https://bugzilla.redhat.com/show_bug.cgi?id=1558425)
 - [x] investigate `default.target` timeouts in check-services (fallout of pmcd.service)
 - [x] disable/quiesce pmcd issue more thoroughly, not through naughty override
 - [x] `test/verify/check-system-info TestSystemInfo.testTimeServers`: `avc:  denied  { create } for  pid=1553 comm="(imesyncd)" name=".pwd.lock"`
 - [x] `test/verify/check-docker TestDocker.testContainerProblems`
 - [x] avc:  denied  { name_bind } for  pid=1632 comm="rpcbind"] ([example](https://fedorapeople.org/groups/cockpit/logs/pull-8848-20180322-091414-70cb6b9e-verify-fedora-28/log.html#123))