### PR TITLE
tools: Add virt-install recommendation to cockpit-machines

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -346,9 +346,15 @@ Requires: %{name}-bridge >= %{required_base}
 Requires: %{name}-system >= %{required_base}
 Requires: libvirt
 Requires: libvirt-client
+# Optional components (for f24 we use soft deps)
+%if 0%{?fedora} >= 24 || 0%{?rhel} >= 8
+Recommends: virt-install
+%endif
 
 %description machines
 The Cockpit components for managing virtual machines.
+
+If "virt-install" is installed, you can also create new virtual machines.
 
 %files machines -f machines.list
 

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -29,7 +29,7 @@ Build-Depends: debhelper (>= 9.20141010),
                glib-networking,
                openssh-client <!nocheck>,
                python,
-Standards-Version: 4.1.1
+Standards-Version: 4.1.3
 Homepage: http://cockpit-project.org/
 Vcs-Git: git://anonscm.debian.org/collab-maint/cockpit.git
 Vcs-Browser: https://anonscm.debian.org/cgit/collab-maint/cockpit.git

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -97,8 +97,12 @@ Architecture: all
 Depends: ${misc:Depends},
          libvirt-daemon-system,
          libosinfo-bin
+Recommends: virtinst
 Description: Cockpit user interface for virtual machines
  The Cockpit components for managing virtual machines.
+ .
+ If the "virtinst" package is installed, you can also create new virtual
+ machines.
 
 Package: cockpit-networkmanager
 Architecture: all


### PR DESCRIPTION
This is being used for creating new VMs.
    
https://bugzilla.redhat.com/show_bug.cgi?id=1557039

Also slip in a Standards-Version bump for Debian.