### PR TITLE
naughty: Close 8709: rpm-ostreed: GetCachedUpdateRpmDiff gives wrong information

### DIFF
--- a/bots/naughty/continuous-atomic/8709-rpm-ostreed-broken-rpm-diff
+++ b/bots/naughty/continuous-atomic/8709-rpm-ostreed-broken-rpm-diff
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "check-ostree", line *, in testOstree
-    self.check_change_counts(b, "table.listing-ct tbody:nth-child(3)")
-  File "check-ostree", line *, in check_change_counts
-    "1 package")


### PR DESCRIPTION
Known issue which has not occurred in 22 days

rpm-ostreed: GetCachedUpdateRpmDiff gives wrong information

Fixes #8709