### PR TITLE
systemd: Don't infer package update severity if we don't know

### DIFF
--- a/pkg/lib/packagekit.es6
+++ b/pkg/lib/packagekit.es6
@@ -28,6 +28,7 @@ export const Enum = {
     EXIT_CANCELLED: 3,
     ROLE_REFRESH_CACHE: 13,
     ROLE_UPDATE_PACKAGES: 22,
+    INFO_UNKNOWN: -1,
     INFO_LOW: 3,
     INFO_ENHANCEMENT: 4,
     INFO_NORMAL: 5,

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -403,13 +403,16 @@ PageServer.prototype = {
             // show highest severity level
             var severity = infos[infos.length - 1];
             var text;
-            self.os_updates_icon.className = packagekit.getSeverityIcon(severity);
+            self.os_updates_icon.className = packagekit.getSeverityIcon(
+                severity > packagekit.Enum.INFO_UNKNOWN ? severity : packagekit.Enum.INFO_NORMAL);
             if (severity == packagekit.Enum.INFO_SECURITY)
                 text = _("Security Updates Available");
             else if (severity >= packagekit.Enum.INFO_NORMAL)
                 text = _("Bug Fix Updates Available");
-            else
+            else if (severity >= packagekit.Enum.INFO_LOW)
                 text = _("Enhancement Updates Available");
+            else
+                text = _("Updates Available");
 
             set_page_link("#system_information_updates_text", "updates", text);
         }
@@ -428,9 +431,9 @@ PageServer.prototype = {
                 },
                 {
                     Package: function (info) {
-                        // HACK: dnf backend yields wrong severity (https://bugs.freedesktop.org/show_bug.cgi?id=101070)
+                        // dnf backend yields wrong severity (https://bugs.freedesktop.org/show_bug.cgi?id=101070)
                         if (info < packagekit.Enum.INFO_LOW || info > packagekit.Enum.INFO_SECURITY)
-                            info = packagekit.Enum.INFO_NORMAL;
+                            info = packagekit.Enum.INFO_UNKNOWN;
                         self.os_updates[info] = (self.os_updates[info] || 0) + 1;
                     }
                 })

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -157,7 +157,11 @@ class TestUpdates(PackageCase):
             b.go("/system")
             b.enter_page("/system")
             self.wait_checking_updates()
-            b.wait_text("#system_information_updates_text", "Bug Fix Updates Available")
+            # PackageKit's dnf backend misparses severities (https://bugs.freedesktop.org/show_bug.cgi?id=101070)
+            if self.backend == "dnf":
+                b.wait_text("#system_information_updates_text", "Updates Available")
+            else:
+                b.wait_text("#system_information_updates_text", "Bug Fix Updates Available")
             self.assertIn("fa-bug", b.attr("#system_information_updates_icon", "class"))
             # should be a link, click on it to go to /updates
             b.click("#system_information_updates_text a")
@@ -312,11 +316,18 @@ class TestUpdates(PackageCase):
             b.go("/system")
             b.enter_page("/system")
             self.wait_checking_updates()
-            # PackageKit's dnf backend mis-parses severity (https://bugs.freedesktop.org/show_bug.cgi?id=101070)
-            # and PackageKit's deb backend does not know about severity at all, so only test this on RPM
-            if self.backend == 'yum':
+            if self.backend == 'dnf':
+                # PackageKit's dnf backend mis-parses severity (https://bugs.freedesktop.org/show_bug.cgi?id=101070)
+                b.wait_text("#system_information_updates_text", "Updates Available")
+                self.assertIn("bug", b.attr("#system_information_updates_icon", "class"))
+            elif self.backend == 'apt':
+                # PackageKit's deb backend always reports "normal"
+                b.wait_text("#system_information_updates_text", "Bug Fix Updates Available")
+                self.assertIn("bug", b.attr("#system_information_updates_icon", "class"))
+            else:
                 b.wait_text("#system_information_updates_text", "Security Updates Available")
                 self.assertIn("security", b.attr("#system_information_updates_icon", "class"))
+
             # should be a link, click on it to go to back to /updates
             b.click("#system_information_updates_text a")
             b.enter_page("/updates")


### PR DESCRIPTION
With dnf and apt we don't (currently) get a valid package update
severity. In these cases, stop showing "bug fix" for them, and just show
"Updates available" without further qualification. Do keep the bug icon
for them though.

Follow-up for PR #8822