### PR TITLE
bots: Use virtio network device instead of e1000

### DIFF
--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -1313,7 +1313,7 @@ class VirtMachine(Machine):
     def add_netiface(self, networking=None, vlan=0):
         if not networking:
             networking = VirtNetwork().interface()
-        cmd = "device_add e1000,mac={0}".format(networking["mac"])
+        cmd = "device_add virtio-net-pci,mac={0}".format(networking["mac"])
         if vlan == 0:
             self._qemu_monitor("netdev_add socket,mcast=230.0.0.1:{mcast},id={id}".format(mcast=networking["mcast"], id=networking["hostnet"]))
             cmd += ",netdev={id}".format(id=networking["hostnet"])


### PR DESCRIPTION
QEMU has supported virtio network devices for many years now. They are
much more performant and more friendly to cloud images which may not
have the e1000 driver. E. g. the current RHEL 8 nightly kernel doesn't
any more (https://bugzilla.redhat.com/show_bug.cgi?id=1559791)