### PR TITLE
tools: Update Debian Vcs-* links for move to salsa

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -31,8 +31,8 @@ Build-Depends: debhelper (>= 9.20141010),
                python,
 Standards-Version: 4.1.3
 Homepage: http://cockpit-project.org/
-Vcs-Git: git://anonscm.debian.org/collab-maint/cockpit.git
-Vcs-Browser: https://anonscm.debian.org/cgit/collab-maint/cockpit.git
+Vcs-Git: https://salsa.debian.org/utopia-team/cockpit.git
+Vcs-Browser: https://salsa.debian.org/utopia-team/cockpit
 
 Package: cockpit
 Architecture: all


### PR DESCRIPTION
Alioth (git.debian.org) is being phased out in favor of GitLab
(salsa.debian.org) and the existing repository got moved.