### PR TITLE
lib: Tolerate D-Bus disconnect after reloading systemd

### DIFF
--- a/pkg/playground/service.js
+++ b/pkg/playground/service.js
@@ -32,7 +32,7 @@
             $('#' + t).on('click', function () {
                 proxy[t]().
                     fail(function (error) {
-                        console.log(error);
+                        console.error("action", t, "failed:", JSON.stringify(error));
                     });
             });
         }


### PR DESCRIPTION
Some systemd versions disconnect too fast from the bus when calling
`Reload()`.  While this should be fixed, it does not actually break
operations, so ignore `NoReply` errors for this call.

See https://bugzilla.redhat.com/show_bug.cgi?id=1560549

Fix printing the error message in the playground. It is an objejct, so
just logging it previously just showed `<unavailable>`.