### PR TITLE
Handle PackageKit restarts and fix check-apps race condition

### DIFF
--- a/pkg/lib/packagekit.es6
+++ b/pkg/lib/packagekit.es6
@@ -21,6 +21,8 @@
 
 import cockpit from "cockpit";
 
+const _ = cockpit.gettext;
+
 // see https://github.com/hughsie/PackageKit/blob/master/lib/packagekit-glib2/pk-enum.h
 export const Enum = {
     EXIT_SUCCESS: 1,
@@ -52,7 +54,14 @@ export const Enum = {
 
 export const transactionInterface = "org.freedesktop.PackageKit.Transaction";
 
-export const dbus_client = cockpit.dbus("org.freedesktop.PackageKit", { superuser: "try", "track": true });
+const dbus_client = cockpit.dbus("org.freedesktop.PackageKit", { superuser: "try", "track": true });
+
+/**
+ * Call a PackageKit method
+ */
+export function call(objectPath, iface, method, args, opts) {
+    return dbus_client.call(objectPath, iface, method, args, opts);
+}
 
 /**
  * Watch a running PackageKit transaction
@@ -64,6 +73,16 @@ export const dbus_client = cockpit.dbus("org.freedesktop.PackageKit", { superuse
 export function watchTransaction(transactionPath, signalHandlers, notifyHandler) {
     var subscriptions = [];
     var notifyReturn;
+
+    // Listen for PackageKit crashes while the transaction runs
+    function onClose(event, ex) {
+        console.warn("PackageKit went away during transaction", transactionPath, ":", JSON.stringify(ex));
+        if (signalHandlers.ErrorCode)
+            signalHandlers.ErrorCode("close", _("PackageKit crashed"));
+        if (signalHandlers.Finished)
+            signalHandlers.Finished(Enum.EXIT_FAILED);
+    }
+    dbus_client.addEventListener("close", onClose);
 
     if (signalHandlers) {
         Object.keys(signalHandlers).forEach(handler => subscriptions.push(
@@ -84,7 +103,10 @@ export function watchTransaction(transactionPath, signalHandlers, notifyHandler)
     // unsubscribe when transaction finished
     subscriptions.push(dbus_client.subscribe(
         { interface: transactionInterface, path: transactionPath, member: "Finished" },
-        () => subscriptions.map(s => s.remove()))
+        () => {
+            subscriptions.map(s => s.remove());
+            dbus_client.removeEventListener("close", onClose);
+        })
     );
 
     return notifyReturn;
@@ -116,7 +138,7 @@ export function watchTransaction(transactionPath, signalHandlers, notifyHandler)
  */
 export function transaction(method, arglist, signalHandlers, notifyHandler) {
     return new Promise((resolve, reject) => {
-        dbus_client.call("/org/freedesktop/PackageKit", "org.freedesktop.PackageKit", "CreateTransaction", [], {timeout: 5000})
+        call("/org/freedesktop/PackageKit", "org.freedesktop.PackageKit", "CreateTransaction", [], {timeout: 5000})
             .done(result => {
                 let transactionPath = result[0];
                 let watchPromise;
@@ -128,7 +150,7 @@ export function transaction(method, arglist, signalHandlers, notifyHandler) {
                 watchPromise
                 .done(() => {
                     if (method) {
-                        dbus_client.call(transactionPath, transactionInterface, method, arglist)
+                        call(transactionPath, transactionInterface, method, arglist)
                             .done(() => resolve(transactionPath))
                             .fail(reject);
                     } else {
@@ -169,7 +191,7 @@ export function cancellableTransaction(method, arglist, progress_cb, signalHandl
 
         function changed(props, transaction_path) {
             function cancel() {
-                dbus_client.call(transaction_path, transactionInterface, "Cancel", []);
+                call(transaction_path, transactionInterface, "Cancel", []);
                 cancelled = true;
             }
 

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -68,7 +68,7 @@ class TestApps(PackageCase):
 </components>
             """.format(body)})
         self.enableRepo()
-        self.machine.execute("pkcon refresh force")
+        self.machine.execute("systemctl stop packagekit && pkcon refresh force")
         self.machine.execute("pkcon -y install appstream-data-test")
 
     def testBasic(self):

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -375,6 +375,9 @@ class TestUpdates(PackageCase):
         b.wait_present(".container-fluid #history h2")
         assertHistory("#history ul", ["secdeclare", "secparse", "sevcritical"])
 
+        # stop PackageKit (e. g. idle timeout) to make sure the page survives that
+        m.execute("systemctl kill --signal=KILL packagekit.service")
+
         # new security versions are now installed
         m.execute("test -f /stamp-secdeclare-3-4.b1 && test -f /stamp-secparse-4-2 && test -f /stamp-sevcritical-5-2")
         # but the three others are untouched


### PR DESCRIPTION
See individual commit logs for details.

The check-apps race is somehow more apparent on Fedora-26, where it's just about impossible to get #8890 to green.

While investigating this, I noticed that our packagekit interface didn't handle PackageKit restarts at all. This should now be much more robust.