### PR TITLE
bots: Don't fail on existing persistent journal directory in debian.setup

### DIFF
--- a/bots/images/scripts/debian.setup
+++ b/bots/images/scripts/debian.setup
@@ -173,7 +173,7 @@ rm -f /var/cache/apt/*cache.bin
 # Final tweaks
 
 # Enable persistent journal
-mkdir /var/log/journal
+mkdir -p /var/log/journal
 
 # Allow root login with password
 sed -i 's/^[# ]*PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config

--- a/bots/images/ubuntu-stable
+++ b/bots/images/ubuntu-stable
@@ -1,1 +1,1 @@
-ubuntu-stable-cbfec5065b936bf422ff50f18d5631f6a7af814700b1d92b61940e485e6aca07.qcow2
+ubuntu-stable-423c6a04e53961292faf87e062b3bcff8f88e0d2b0fd32a749ae220ace804a67.qcow2


### PR DESCRIPTION
Apparently Ubuntu is now switching to persistent journal by default.

Fixes #8887

 * [x] image-refresh ubuntu-stable