### PR TITLE
storage: Install NFS packages on demand

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -123,6 +123,7 @@ SUBST_RULE = \
 	-e 's,[@]with_storaged_iscsi_sessions[@],$(with_storaged_iscsi_sessions),g' \
 	-e 's,[@]with_appstream_config_packages[@],$(with_appstream_config_packages),g' \
 	-e 's,[@]with_appstream_data_packages[@],$(with_appstream_data_packages),g' \
+	-e 's,[@]with_nfs_client_package[@],$(with_nfs_client_package),g' \
 	$< > $@.tmp && $(MV) $@.tmp $@ \
 	$(NULL)
 

--- a/configure.ac
+++ b/configure.ac
@@ -374,6 +374,13 @@ AC_ARG_WITH(appstream-data-packages,
             [with_appstream_data_packages='[[]]'])
 AC_SUBST(with_appstream_data_packages)
 
+AC_ARG_WITH(nfs-client-package,
+            AC_HELP_STRING([--with-nfs-client-package=JSON],
+                           [Package that is necessary for NFS clients, or 'false']),
+            [],
+            [with_nfs_client_package='false'])
+AC_SUBST(with_nfs_client_package)
+
 # Address sanitizer
 
 AC_MSG_CHECKING([for asan flags])

--- a/pkg/lib/cockpit-components-dialog.css
+++ b/pkg/lib/cockpit-components-dialog.css
@@ -1,0 +1,4 @@
+#cockpit_modal_dialog .modal-body {
+    max-height: calc(75vh - 10rem);
+    overflow: auto;
+}

--- a/pkg/lib/cockpit-components-dialog.jsx
+++ b/pkg/lib/cockpit-components-dialog.jsx
@@ -22,6 +22,7 @@ var React = require("react");
 var _ = cockpit.gettext;
 
 require("page.css");
+require("cockpit-components-dialog.css");
 
 /*
  * React template for a Cockpit dialog footer

--- a/pkg/lib/cockpit-components-dialog.jsx
+++ b/pkg/lib/cockpit-components-dialog.jsx
@@ -42,6 +42,7 @@ require("cockpit-components-dialog.css");
  *      - disabled optional, defaults to false
  *      - style defaults to 'default', other options: 'primary', 'danger'
  *  - static_error optional, always show this error
+ *  - idle_message optional, always show this message on the last row when idle
  *  - dialog_done optional, callback when dialog is finished (param true if success, false on cancel)
  */
 var DialogFooter = React.createClass({
@@ -159,6 +160,10 @@ var DialogFooter = React.createClass({
             wait_element = <div className="dialog-wait-ct pull-left">
                 <div className="spinner spinner-sm" />
                 <span>{ this.state.action_progress_message }</span>
+            </div>;
+        } else if (this.props.idle_message) {
+            wait_element = <div className="dialog-wait-ct pull-left">
+                { this.props.idle_message }
             </div>;
         }
 

--- a/pkg/lib/cockpit-components-install-dialog.css
+++ b/pkg/lib/cockpit-components-install-dialog.css
@@ -1,0 +1,38 @@
+.package-list-ct {
+    margin: 1em 0;
+    padding: 0;
+    max-width: 110rem;
+    text-align: left;
+    box-sizing: border-box;
+}
+
+.package-list-ct li {
+    text-align: left;
+    box-sizing: border-box;
+    width: 22rem;
+    padding: 0 1ex;
+    display: inline-block;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.scale-up-ct {
+    animation: dialogScaleUpCt 1s;
+}
+
+@keyframes dialogScaleUpCt {
+    0% {
+        opacity: 0;
+        max-height: 0;
+    }
+    25% {
+        opacity: 0;
+    }
+    50% {
+        max-height: 100vh;
+    }
+    100% {
+        opacity: 1;
+    }
+}

--- a/pkg/lib/cockpit-components-install-dialog.jsx
+++ b/pkg/lib/cockpit-components-install-dialog.jsx
@@ -1,0 +1,201 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+
+import { show_modal_dialog } from "cockpit-components-dialog.jsx";
+import * as PK from "packagekit.es6";
+
+import "cockpit-components-install-dialog.css";
+
+const _ = cockpit.gettext;
+
+// TODO - generalize this to arbitrary number of arguments (when needed)
+function format_to_array(fmt, arg) {
+    var index = fmt.indexOf("$0");
+    if (index >= 0)
+        return [ fmt.slice(0, index), arg, fmt.slice(index + 2) ];
+    else
+        return [ fmt ];
+}
+
+/* Calling install_dialog will open a dialog that lets the user
+ * install the given package.
+ *
+ * The install_dialog function returns a promise that is fulfilled when the dialog closes after
+ * a successful installation.  The promise is rejected when the user cancels the dialog.
+ *
+ * If the package is already installed before the dialog opens, we still go
+ * through all the motions and the dialog closes successfully without doing
+ * anything when the use hits "Install".
+ *
+ * You shouldn't call install_dialog unless you know that PackageKit is available.
+ * (If you do anyway, the resulting D-Bus errors will be shown to the user.)
+ */
+
+export function install_dialog(pkg) {
+    var data = null;
+    var error_message = null;
+    var progress_message = null;
+    var cancel = null;
+    var done = null;
+
+    var prom = new Promise((resolve, reject) => { done = f => { if (f) resolve(); else reject(); }; });
+
+    var dialog = null;
+    function update() {
+        let extra_details = null;
+        let remove_details = null;
+        let footer_message = null;
+
+        let missing_name = <strong>{pkg}</strong>;
+
+        if (data && data.extra_names.length > 0)
+            extra_details = (
+                <p className="scale-up-ct">
+                    {_("Additional packages:")}
+                    <ul className="package-list-ct">{data.extra_names.map(id => <li>{id}</li>)}</ul>
+                </p>
+            );
+
+        if (data && data.remove_names.length > 0)
+            remove_details = (
+                <p className="scale-up-ct">
+                    <span className="pficon pficon-warning-triangle-o" /> {_("Removals:")}
+                    <ul className="package-list">{data.remove_names.map(id => <li>{id}</li>)}</ul>
+                </p>
+            );
+
+        if (progress_message)
+            footer_message = (
+                <div>
+                    <div className="spinner spinner-sm" />
+                    <span>{ progress_message }</span>
+                </div>
+            );
+        else if (data && data.download_size) {
+            footer_message = (
+                <div>
+                    { format_to_array(_("Total size: $0"), <strong>{cockpit.format_bytes(data.download_size)}</strong>) }
+                </div>
+            );
+        }
+
+        let body = {
+            id: "dialog",
+            title: _("Install Software"),
+            body: (
+                <div className="modal-body">
+                    <p>{ format_to_array(_("$0 will be installed."), missing_name) }</p>
+                    { remove_details }
+                    { extra_details }
+                </div>
+            )
+        };
+
+        let footer = {
+            actions: [
+                { caption: _("Install"),
+                  style: "primary",
+                  clicked: install_missing,
+                  disabled: data == null
+                }
+            ],
+            static_error: error_message,
+            idle_message: footer_message,
+            dialog_done: f => { if (!f && cancel) cancel(); done(f); }
+        };
+
+        if (dialog) {
+            dialog.setProps(body);
+            dialog.setFooterProps(footer);
+        } else {
+            dialog = show_modal_dialog(body, footer);
+        }
+    }
+
+    function check_missing() {
+        PK.check_missing_packages([ pkg ],
+                                  p => {
+                                      cancel = p.cancel;
+                                      var pm = null;
+                                      if (p.waiting)
+                                          pm = _("Waiting for other software management operations to finish");
+                                      else
+                                          pm = _("Checking installed software");
+                                      if (pm != progress_message) {
+                                          progress_message = pm;
+                                          update();
+                                      }
+                                  })
+                .then(d => {
+                    if (d.unavailable_names.length > 0)
+                        error_message = cockpit.format(_("$0 is not available from any repository."),
+                                                       d.unavailable_names[0]);
+                    else
+                        data = d;
+                    progress_message = null;
+                    cancel = null;
+                    update();
+                })
+                .catch(e => {
+                    progress_message = null;
+                    cancel = null;
+                    error_message = e.toString();
+                    update();
+                });
+    }
+
+    function install_missing() {
+        // We need to return a Cockpit flavoured promise since we want
+        // to use progress notifications.
+        var dfd = cockpit.defer();
+
+        PK.install_missing_packages(data,
+                                    p => {
+                                        var text = null;
+                                        if (p.waiting) {
+                                            text = _("Waiting for other software management operations to finish");
+                                        } else if (p.package) {
+                                            var fmt;
+                                            if (p.info == PK.Enum.INFO_DOWNLOADING)
+                                                fmt = _("Downloading $0");
+                                            else if (p.info == PK.Enum.INFO_REMOVING)
+                                                fmt = _("Removing $0");
+                                            else
+                                                fmt = _("Installing $0");
+                                            text = format_to_array(fmt, <strong>{p.package}</strong>);
+                                        }
+                                        dfd.notify(text, p.cancel);
+                                    })
+                .then(() => {
+                    dfd.resolve();
+                })
+                .catch(error => {
+                    dfd.reject(error);
+                });
+
+        return dfd.promise;
+    }
+
+    update();
+    check_missing();
+    return prom;
+}

--- a/pkg/lib/packagekit.es6
+++ b/pkg/lib/packagekit.es6
@@ -87,6 +87,16 @@ export function call(objectPath, iface, method, args, opts) {
 }
 
 /**
+ * Figure out whether PackageKit is available
+ */
+export function detect() {
+    return call("/org/freedesktop/PackageKit", "org.freedesktop.DBus.Properties",
+                "Get", [ "org.freedesktop.PackageKit", "VersionMajor" ])
+            .then(() => true,
+                  () => false);
+}
+
+/**
  * Watch a running PackageKit transaction
  *
  * transactionPath (string): D-Bus object path of the PackageKit transaction

--- a/pkg/storaged/manifest.json.in
+++ b/pkg/storaged/manifest.json.in
@@ -14,5 +14,9 @@
 
     "hacks": {
         "with_storaged_iscsi_sessions": "@with_storaged_iscsi_sessions@"
+    },
+
+    "config": {
+        "nfs_client_package": @with_nfs_client_package@
     }
 }

--- a/pkg/storaged/nfs-panel.jsx
+++ b/pkg/storaged/nfs-panel.jsx
@@ -21,8 +21,9 @@ import cockpit from "cockpit";
 import React from "react";
 
 import { StorageButton, StorageUsageBar } from "./storage-controls.jsx";
-import { format_fsys_usage } from "./utils.js";
+import { format_fsys_usage, get_config } from "./utils.js";
 import { nfs_fstab_dialog } from "./nfs-details.jsx";
+import { OptionalPanel } from "./optional-panel.jsx";
 
 const _ = cockpit.gettext;
 
@@ -70,16 +71,29 @@ export class NFSPanel extends React.Component {
             nfs_fstab_dialog(client, null);
         }
 
+        var actions = (
+            <StorageButton kind="primary" onClick={add}>
+                <span className="fa fa-plus" />
+            </StorageButton>
+        );
+
+        var nfs_feature = {
+            is_enabled: () => client.features.nfs,
+            package: get_config("nfs_client_package", false),
+            enable: () => {
+                client.features.nfs = true;
+                client.nfs.start();
+            }
+        }
+
         return (
-            <div className="panel panel-default storage-mounts" id="nfs-mounts">
-                <div className="panel-heading">
-                    <span className="pull-right">
-                        <StorageButton kind="primary" onClick={add}>
-                            <span className="fa fa-plus" />
-                        </StorageButton>
-                    </span>
-                    <span>{_("NFS Mounts")}</span>
-                </div>
+            <OptionalPanel className="storage-mounts" id="nfs-mounts"
+                           client={client}
+                           title={_("NFS Mounts")}
+                           actions={actions}
+                           feature={nfs_feature}
+                           not_installed_text={_("NFS Support not installed")}
+                           install_title={_("Install NFS Support")}>
                 { mounts.length > 0
                     ? <table className="table table-hover">
                         <thead>
@@ -96,7 +110,7 @@ export class NFSPanel extends React.Component {
                     </table>
                     : <div className="empty-panel-text">{_("No NFS mounts set up")}</div>
                 }
-            </div>
+            </OptionalPanel>
         );
     }
 }

--- a/pkg/storaged/optional-panel.jsx
+++ b/pkg/storaged/optional-panel.jsx
@@ -1,0 +1,117 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+
+import { install_dialog } from "cockpit-components-install-dialog.jsx";
+import { StorageButton } from "./storage-controls.jsx";
+
+const _ = cockpit.gettext;
+
+/* OptionalPanel - a panel that is only visible when a certain feature
+                   has been detected.  It can also install missing packages
+                   to enable that feature.
+
+   Properties:
+
+   - client: The storage client
+   - title: Title of the panel
+   - actions: Buttons to show in the heading when the feature is enabled
+   - children: For the body of the panel when the feature is enabled
+
+   - feature: The feature object, see below.
+   - not_installed_text: The text to show in the panel body when the feature is not enabled.
+   - install_title: The text in the button that lets the user enable the feature at run time.
+
+   When the "feature" property is omitted (or false), the panel will always be shown.
+   Otherwise, the feature object determines what happens.  It has the following fields:
+
+   - is_enabled:  A function that should return whether the feature is enabled.  This
+                  function is called during rendering and thus needs to be fast and synchronous.
+
+   - package:     The name of tha package to install.  If omitted or false, the feature
+                  can not be enabled at run-time and the panel will be fully invisible
+                  if not already enabled.
+
+   - enable:      A function that is called once support for the feature has been
+                  successfully installed.  Subsequent calls to "is_enabled" should return true.
+*/
+
+export class OptionalPanel extends React.Component {
+    constructor() {
+        super();
+        this.state = { promise: null,
+                       error: null,
+                       progress: null,
+                       just_installed: false,
+        };
+    }
+
+    render() {
+        var self = this;
+        var { actions, className, id, title,
+              feature, not_installed_text, install_title } = this.props;
+
+        var feature_enabled = !feature || feature.is_enabled();
+        var required_package = feature && feature.package;
+
+        if (!feature_enabled && !(required_package && this.props.client.features.packagekit))
+            return null;
+
+        function install() {
+            install_dialog(required_package).then(() => {
+                feature.enable();
+                self.setState({ just_installed: "just-installed" });
+                window.setTimeout(() => { self.setState({ just_installed: "just-installed faded" }); },
+                                  4000);
+            });
+        }
+
+        var heading_right = null;
+        if (!feature_enabled) {
+            heading_right = <StorageButton kind="primary" onClick={install}>{install_title}</StorageButton>;
+        } else {
+            heading_right = (
+                <span>
+                    { this.state.just_installed
+                        ? <span className={this.state.just_installed}>{_("Support is installed.")}</span>
+                        : null
+                    }
+                    { actions }
+                </span>
+            );
+        }
+
+        return (
+            <div className={"panel panel-default " + className} id={id}>
+                <div className="panel-heading">
+                    <span className="pull-right">
+                        { heading_right }
+                    </span>
+                    <span>{title}</span>
+                </div>
+                { feature_enabled
+                    ? this.props.children
+                    : <div className="empty-panel-text">{not_installed_text}</div>
+                }
+            </div>
+        );
+    }
+}

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -626,3 +626,18 @@ td.storage-action {
 .modal-title {
     word-break: break-all;
 }
+
+.panel-heading .spinner-inline {
+    vertical-align: middle;
+    margin-left: 0.5ex;
+}
+
+.just-installed {
+    margin-right: 1em;
+}
+
+.faded {
+    transition: opacity 1s, visibility 1s;
+    opacity: 0;
+    visibility: hidden;
+}

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -677,5 +677,14 @@
                            ]);
     };
 
+    utils.get_config = function get_config(name, def) {
+        if (cockpit.manifests["storage"] && cockpit.manifests["storage"]["config"]) {
+            var val = cockpit.manifests["storage"]["config"][name];
+            return val !== undefined? val : def;
+        } else {
+            return def;
+        }
+    };
+
     module.exports = utils;
 }());

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -21,6 +21,7 @@
 import parent
 from testlib import *
 from storagelib import *
+from packagelib import *
 
 @skipImage("NetworkManager and NFS don't work together", "ubuntu-1604")
 class TestStorage(StorageCase):
@@ -199,6 +200,62 @@ class TestStorage(StorageCase):
         self.dialog_apply()
 
         b.wait_present("#detail-header button:contains(Mount)")
+
+@skipImage("NetworkManager and NFS don't work together", "ubuntu-1604")
+class TestStoragePackages(StorageCase, PackageCase):
+
+    def testNfsMissingPackages(self):
+        m = self.machine
+        b = self.browser
+
+        # Override configuration so that we don't have to remove the
+        # real package.
+
+        self.machine.write("/usr/share/cockpit/storaged/override.json",
+                           """{ "config": { "nfs_client_package": "fake-nfs-utils" } }""")
+
+        m.execute("mv /sbin/mount.nfs /sbin/mount.nfs.off")
+
+        self.login_and_go("/storage")
+
+        # The fake-nfs-utils package is not available yet
+
+        b.wait_present("button:contains('Install NFS Support')")
+        b.click("button:contains('Install NFS Support')")
+
+        self.dialog_wait_open()
+        b.wait_in_text("#dialog", "fake-nfs-utils is not available from any repository.")
+        self.dialog_cancel()
+        self.dialog_wait_close()
+
+        # Now make the package available
+
+        self.createPackage("dummy", "1.0", "1")
+        self.createPackage("fake-nfs-utils", "1.0", "1", depends="fake-libnfs")
+        self.createPackage("fake-libnfs", "1.0", "1")
+        self.enableRepo()
+
+        # HACK
+        #
+        # The first simulated install seems to silently not report
+        # anything on the Debian test images, for unknown reasons.  So
+        # we install a dummy package to warm up all parts of the
+        # machinery and distribute the fluids evenly.
+        #
+        if "debian" in m.image or "ubuntu" in m.image:
+            m.execute("pkcon refresh && pkcon install -y dummy")
+
+        b.reload()
+        b.enter_page("/storage")
+        b.wait_present("button:contains('Install NFS Support')")
+        b.click("button:contains('Install NFS Support')")
+        self.dialog_wait_open()
+        b.wait_in_text("#dialog", "fake-nfs-utils will be installed")
+        b.wait_in_text("#dialog", "fake-libnfs")
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        b.wait_present("#nfs-mounts button .fa-plus")
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -26,7 +26,7 @@ class PackageCase(MachineCase):
     }
 
     def setUp(self):
-        MachineCase.setUp(self)
+        super(PackageCase, self).setUp()
 
         self.repo_dir = "/var/tmp/repo"
 

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -32,7 +32,7 @@ class StorageCase(MachineCase):
         if "atomic" in os.getenv("TEST_OS", ""):
             self.skipTest("No storage on Atomic")
 
-        MachineCase.setUp(self)
+        super(StorageCase, self).setUp()
         self.storagectl_cmd = self.machine.execute("for cmd in storagedctl storagectl udisksctl; do if which $cmd 2>/dev/null; then break; fi; done").strip()
 
         if "udisksctl" in self.storagectl_cmd:

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -150,6 +150,7 @@ exec 2>&1
     --with-selinux-config-type=etc_t \
     %{?rhel:--without-storaged-iscsi-sessions} \
     --with-appstream-data-packages='[ "appstream-data" ]' \
+    --with-nfs-client-package='"nfs-utils"' \
     %{!?build_dashboard:--disable-ssh}
 make -j4 %{?extra_flags} all
 

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -41,6 +41,7 @@ override_dh_auto_configure: debian/git-patches-applied
 		--with-networkmanager-needs-root=yes \
 		--with-cockpit-user=cockpit-ws \
 		--with-appstream-config-packages='[ "appstream" ]' \
+		--with-nfs-client-packages='"nfs-common"' \
 		--with-pamdir=/lib/$(DEB_HOST_MULTIARCH)/security \
 		--libexecdir=/usr/lib/cockpit $(CONFIG_OPTIONS)
 


### PR DESCRIPTION
### Testing

Currently, this just install the "nfs-utils" package.  So to test, remove "nfs-utils" first.

### Tasks

- [x] Make list of packages configurable
- [x] Say how many packages and how many bytes.
- [x] Test
- [x] Make sure everything is alright when PackageKit is not available
- [x] Implement mockups
- [x] Make sure this works as expected for non-root admins, and non-admins
- [x] Move "Checking installed software" into dialog

Demo for release notes: https://youtu.be/Gaioqm7sLEo