### PR TITLE
bots: Move RPM dependencies to Python 3

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -459,7 +459,7 @@ Recommends: device-mapper-multipath
 %endif
 %endif
 %endif
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?rhel} >= 8
 Requires: python3
 Requires: python3-dbus
 %else
@@ -657,7 +657,11 @@ Requires: %{name}-bridge >= %{required_base}
 Requires: %{name}-shell >= %{required_base}
 Requires: /usr/bin/docker
 Requires: /usr/lib/systemd/system/docker.service
+%if 0%{?fedora} || 0%{?rhel} >= 8
+Requires: python3
+%else
 Requires: python2
+%endif
 
 %description docker
 The Cockpit components for interacting with Docker and user interface.


### PR DESCRIPTION
We have python 3 on all supported Fedora releases and on RHEL 8 now, and
want to get rid of Python 2 in both.

https://bugzilla.redhat.com/show_bug.cgi?id=1561472