### PR TITLE
tasks: Stop scanning cockpit-examples

### DIFF
--- a/.tasks
+++ b/.tasks
@@ -18,9 +18,6 @@ bots/tests-scan
 bots/tests-scan --repo cockpit-project/starter-kit \
                 -c cockpit/centos-7 \
                 -c cockpit/fedora-27
-bots/tests-scan --repo cockpit-project/cockpit-examples \
-                -c cockpit/centos-7 \
-                -c cockpit/fedora-27
 
 # When run automated, randomize to minimize stampeding herd
 if [ -t 0 ]; then


### PR DESCRIPTION
cockpit-examples is about to be mothballed as it got replaced with
starter-kit, the pinger test moving into cockpit proper, and a blog post
how to use Cockpit's test VMs with other test frameworks
(http://cockpit-project.org/blog/cockpit-custom-test-framework.html).