### PR TITLE
bots: Re-drop systemtap-runtime-virtguest from rhel-7-5 image

### DIFF
--- a/bots/images/scripts/rhel.setup
+++ b/bots/images/scripts/rhel.setup
@@ -142,12 +142,12 @@ qemu-kvm \
 
 if [ "$IMAGE" = "rhel-7" ] || [ "$IMAGE" = "rhel-7-4" ]; then
     UDISKS="storaged storaged-lvm2 storaged-iscsi"
-    TEST_PACKAGES="$TEST_PACKAGES systemtap-runtime-virtguest"
 else
     UDISKS="udisks2 udisks2-lvm2 udisks2-iscsi"
 fi
 if [ "$IMAGE" = "rhel-7-5" ]; then
     COCKPIT_DEPS="$COCKPIT_DEPS kmod-kvdo vdo"
+    TEST_PACKAGES="${TEST_PACKAGES/systemtap-runtime-virtguest /}"
 fi
 if [ "$IMAGE" = "rhel-8" ]; then
     TEST_PACKAGES="${TEST_PACKAGES/yum-utils/dnf-utils}"


### PR DESCRIPTION
This package is not available in RHEL 7.5, but in 7.4 and 8. Commit
0465f523ea attempted to invert the logic, but did not remove it from the
initial `$TEST_PACKAGES` list. Thus it was added twice on 7.4.

As 7.5 is the special snowflake here, revert this part and blacklist it
explicitly there.

Fixes #8921 

 - [ ] image-refresh rhel-7-5