### PR TITLE
bots: Fix broken apt sources on debian-stable

### DIFF
--- a/bots/images/debian-stable
+++ b/bots/images/debian-stable
@@ -1,1 +1,1 @@
-debian-stable-0be9971cdb1aed2e38e2cf13ec155e75776af647ff911514b6974df94c7b30ad.qcow2
+debian-stable-7cfcdddbbe3caf574cbd6578ef73ce5e118124ecd40e59960d5682ffe479df0d.qcow2

--- a/bots/images/scripts/debian.setup
+++ b/bots/images/scripts/debian.setup
@@ -61,7 +61,8 @@ case "$RELEASE" in
         COCKPIT_DEPS="${COCKPIT_DEPS/libpcp3 /}"
         COCKPIT_DEPS="${COCKPIT_DEPS/pcp /}"
 
-        echo 'deb http://security.debian.org/debian-security stable updates/main' >> /etc/apt/sources.list
+        echo >> /etc/apt/sources.list
+        echo 'deb http://security.debian.org/debian-security stable/updates main' >> /etc/apt/sources.list
 
         # docker.io is in backports only
         echo "deb http://deb.debian.org/debian jessie-backports main" >/etc/apt/sources.list.d/jessie-backports.list

--- a/bots/images/scripts/debian.setup
+++ b/bots/images/scripts/debian.setup
@@ -10,7 +10,6 @@ sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT/# GRUB_CMDLINE_LINUX_DEFAULT/' /etc/default
 # We install all dependencies of the cockpit packages since we want
 # them to not spontaneously change from one test run to the next when
 # the distribution repository is updated.
-# docker.io \
 #
 COCKPIT_DEPS="\
 cryptsetup \
@@ -76,11 +75,6 @@ case "$RELEASE" in
 
         # docker.io got removed from testing; use backports-version
         echo "deb http://deb.debian.org/debian jessie-backports main" >/etc/apt/sources.list.d/jessie-backports.list
-        ;;
-
-    zesty)
-        # HACK: https://launchpad.net/bugs/1693154
-        mkdir /etc/krb5.conf.d/
         ;;
 
     xenial)


### PR DESCRIPTION
The last line is not terminated with a newline, so the newly added line
for security updates both doesn't work and also breaks the
stable-updates apt source. It was also mis-formatted, the previous
"updates/main" ceased to work some time ago. Use the official syntax.
    
Fixes #8929 

 * [x] image-refresh debian-stable