### PR TITLE
test: Clean up ws kerberos setup

### DIFF
--- a/pkg/realmd/README.md
+++ b/pkg/realmd/README.md
@@ -12,8 +12,7 @@ To contribute to this component, run a test domain which ends
 up being rather easy. Install the stuff in ```test/README``` near the
 top. And then do the following:
 
-    $ sudo bots/image-prep
-    $ bots/image-run --network ipa
+    $ test/vm-run --network ipa
 
 That runs an IPA domain. Now in another terminal do the following:
 
@@ -36,10 +35,6 @@ above.
 
     $ kinit admin@COCKPIT.LAN
     Password for admin@COCKPIT.LAN:
-
-**BUG:** IPA sometimes fails to start up correctly on system boot. You may
-have to log into the IPA server and run `systemctl start ipa`.
-[ipa bug](https://bugzilla.redhat.com/show_bug.cgi?id=1071356)
 
 ## Setting up Single Sign on
 
@@ -65,13 +60,8 @@ the computer running Cockpit.
 
     $ sudo -s
     # kinit admin@COCKPIT.LAN
-    # curl -s --negotiate -u : https://f0.cockpit.lan/ipa/json \
-            --header 'Referer: https://f0.cockpit.lan/ipa' \
-            --header "Content-Type: application/json" \
-            --header "Accept: application/json" \
-            --data '{"params": [["HTTP/my-server.cockpit.lan@COCKPIT.LAN"], {"raw": false, "all": false, "version": "2.101", "force": true, "no_members": false, "ipakrbokasdelegate": true}], "method": "service_add", "id": 0}'
-    # ipa-getkeytab -q -s f0.cockpit.lan -p HTTP/my-server.cockpit.lan \
-            -k /etc/krb5.keytab
+    # ipa service-add --ok-as-delegate=true --force HTTP/my-server.cockpit.lan@COCKPIT.LAN
+    # ipa-getkeytab -q -s f0.cockpit.lan -p HTTP/my-server.cockpit.lan -k /etc/krb5.keytab
 
 Now when you go to your cockpit instance you should be able to log in without
 authenticating. Make sure to use the full hostname that you set above, the one

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -156,7 +156,7 @@ class TestRealms(MachineCase):
 
 JOIN_SCRIPT = """
 set -ex
-# HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1071356#c11
+# Wait until zones from LDAP get loaded
 for x in $(seq 1 20); do
     if nslookup -type=SRV _ldap._tcp.cockpit.lan; then
         break
@@ -176,13 +176,7 @@ fi
 echo '%(password)s' | KRB5_TRACE=/dev/stderr kinit -f admin@COCKPIT.LAN
 
 # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1144292
-curl --insecure -s --negotiate -u : https://f0.cockpit.lan/ipa/json --header 'Referer: https://f0.cockpit.lan/ipa' --header "Content-Type: application/json" --header "Accept: application/json" --data '{"params": [["HTTP/x0.cockpit.lan@COCKPIT.LAN"], {"raw": false, "all": false, "version": "2.101", "force": true, "no_members": false, "ipakrbokasdelegate": true}], "method": "service_add", "id": 0}'
-
-# HACK: https://bugs.freedesktop.org/show_bug.cgi?id=98479
-if ! grep -q 'services.*nss' /etc/sssd/sssd.conf; then
-    sed -i 's/^services = sudo, ssh$/services = sudo, ssh, nss, pam/' /etc/sssd/sssd.conf
-    systemctl restart sssd
-fi
+LC_ALL=C.UTF-8 ipa service-add --ok-as-delegate=true --force HTTP/x0.cockpit.lan@COCKPIT.LAN
 
 # HACK: This needs to work, but may take a minute
 for x in $(seq 1 60); do


### PR DESCRIPTION
 * Use "ipa service-add" instead of a raw long curl REST API call to add
   an SPN for cockpit-ws HTTP. This is available on all currently
   supported OSes in freeipa-client.

 * Drop hacks and documentation for #98479 and #1071356, they got fixed
   a long time ago.

 * Replace "HACK" marker for #1071356 with an explanation comment, as
   this is apparently working as intended.

 * Adjust the instructions how to run our IPA VM.