### PR TITLE
bots: Add debian-testing naughty override for systemd 238 regression

### DIFF
--- a/bots/images/debian-testing
+++ b/bots/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-9207163c6a01bd8d14bd00cd5a55f3b878a622aff44567c6a0fd4f8acacd1a9d.qcow2
+debian-testing-fc2416ba887fbdd97f91d575278282cbb0ddf15af6f09db734ca2f846fc6a7a6.qcow2

--- a/bots/naughty/debian-testing/8880-timedated-crash
+++ b/bots/naughty/debian-testing/8880-timedated-crash
@@ -1,0 +1,7 @@
+Traceback (most recent call last):
+  File "test/verify/check-system-info", line *, in testTime*
+    b.wait_popdown("system_information_change_systime")
+*
+Error: timeout
+*
+warning: Message recipient disconnected from message bus without replying

--- a/bots/naughty/debian-testing/8880-timedated-crash-2
+++ b/bots/naughty/debian-testing/8880-timedated-crash-2
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-journal", line *, in testBasic
+    m.execute("timedatectl set-ntp off; timedatectl set-time 2038-01-01")
+*
+CalledProcessError: Command 'timedatectl set-ntp off; timedatectl set-time 2038-01-01' returned non-zero exit status 1

--- a/bots/naughty/debian-testing/8880-timedated-crash-3
+++ b/bots/naughty/debian-testing/8880-timedated-crash-3
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-services", line *, in testCreateTimer
+    m.execute("timedatectl set-ntp off; timedatectl set-time '2020-01-01 15:30:00'")
+*
+CalledProcessError: Command 'timedatectl set-ntp off; timedatectl set-time '2020-01-01 15:30:00'' returned non-zero exit status 1


### PR DESCRIPTION
The timedated crash is the same as in RHEL 8 in PR #8874.

 * [x] image-refresh debian-testing