### PR TITLE
realmd: Automatically set up Kerberos keytab for ws

### DIFF
--- a/doc/guide/sso.xml
+++ b/doc/guide/sso.xml
@@ -13,7 +13,6 @@
     <para>To authenticate users, the server that Cockpit is running on must be
       joined to a domain. This can usually be accomplished using the
       <ulink url="http://freedesktop.org/software/realmd/docs/realm.html"><code>realm join example.com</code></ulink>
-      
       command.</para>
 
     <para>The domain must be resolvable by DNS. For instance, the SRV records of the
@@ -26,7 +25,7 @@ _kerberos._udp.example.com has SRV record 0 100 88 dc.example.com
 
     <para>The server running Cockpit should have a fully qualified name that ends with
       the domain name.</para>
-  
+
     <para>There must be a valid Kerberos host key for the server in the <code>/etc/krb5.keytab</code>
       file. Alternatively, if you would like to use a different keytab, you can do so
       by placing it in <code>/etc/cockpit/krb5.keytab</code>. It may be necessary to
@@ -44,10 +43,21 @@ _kerberos._udp.example.com has SRV record 0 100 88 dc.example.com
       </varlistentry>
     </variablelist>
 
-    <para>The following command can be used to list the <code>/etc/krb5.keytab</code>:</para>
+    <para>When joining an IPA domain with Cockpit and the <code>ipa</code> command line tool is
+      available, both the service principal name and a <code>/etc/cockpit/krb5.keytab</code> get
+      created automatically, so that Kerberos based single sign on into Cockpit works out of the
+      box. If you want/need to do this by hand or in a script, the
+      corresponding commands with IPA are:</para>
 
 <programlisting>
-$ sudo klist -k
+$ sudo ipa service-add --ok-as-delegate=true --force HTTP/server.example.com@EXAMPLE.COM
+$ sudo ipa-getkeytab -p HTTP/server.example.com@EXAMPLE.COM -k /etc/cockpit/krb5.keytab
+</programlisting>
+
+    <para>The following command can be used to list the <code>/etc/cockpit/krb5.keytab</code>:</para>
+
+<programlisting>
+$ sudo klist -k /etc/cockpit/krb5.keytab
 </programlisting>
 
     <para>Lastly accounts from the domain must be resolvable to unix accounts on the server
@@ -60,7 +70,8 @@ user@example.com:*:381001109:381000513:User Name:/home/user:/bin/sh
 
     <para>If you wish to delegate your kerberos credentials to Cockpit, and allow Cockpit
       to then connect to other machines using those credentials, you should enable delegation
-      for the hosts running Cockpit, and in some cases the <code>HTTP</code> service as well.</para>
+      for the hosts running Cockpit, and in some cases the <code>HTTP</code> service as well.
+      When joining an IPA domain, this is enabled by default.</para>
 
   </section>
 

--- a/pkg/realmd/operation.js
+++ b/pkg/realmd/operation.js
@@ -11,6 +11,7 @@
 
     var SERVICE = "org.freedesktop.realmd.Service";
     var PROVIDER = "org.freedesktop.realmd.Provider";
+    var KERBEROS = "org.freedesktop.realmd.Kerberos";
     var KERBEROS_MEMBERSHIP = "org.freedesktop.realmd.KerberosMembership";
     var REALM = "org.freedesktop.realmd.Realm";
 
@@ -28,6 +29,7 @@
         var checking = null;
         var checked = null;
         var kerberos_membership = null;
+        var kerberos = null;
 
         /* If in an operation first time cancel is clicked, cancel operation */
         $(".realms-op-cancel").on("click", function() {
@@ -161,11 +163,14 @@
 
                         realm = null;
                         kerberos_membership = null;
+                        kerberos = null;
 
                         dfd.reject(new Error(message));
                     } else {
                         kerberos_membership = realmd.proxy(KERBEROS_MEMBERSHIP, path);
                         $(kerberos_membership).on("changed", update);
+
+                        kerberos = realmd.proxy(KERBEROS, path);
 
                         realm = realmd.proxy(REALM, path);
                         $(realm).on("changed", update);
@@ -320,6 +325,71 @@
             return creds;
         }
 
+        // Request and install a kerberos keytab for cockpit-ws (with IPA)
+        // This is opportunistic: Some realms might not use IPA, or an unsupported auth mechanism
+        function install_ws_keytab() {
+            // skip this on remote ssh hosts, only set up ws hosts
+            if (cockpit.transport.host !== "localhost")
+                return cockpit.resolve();
+
+            if (auth !== "password/administrator") {
+                console.log("Installing kerberos keytab not supported for auth mode", auth);
+                return cockpit.resolve();
+            }
+
+            var user = $(".realms-op-admin").val();
+            var password = $(".realms-op-admin-password").val();
+
+            // ipa-getkeytab needs root to create the file
+            var script = 'set -eu; [ $(id -u) = 0 ] || exit 0; ';
+            // not an IPA setup? cannot handle this
+            script += 'type ipa >/dev/null 2>&1 || exit 0; ';
+
+            // IPA operations require auth; read password from stdin to avoid quoting issues
+            // if kinit fails, we can't handle this setup, exit cleanly
+            script += 'kinit ' + user + '@' + kerberos.RealmName + ' || exit 0; ';
+
+            // create a kerberos Service Principal Name for cockpit-ws, unless already present
+            script += 'service="HTTP/$(hostname -f)@' + kerberos.RealmName + '"; ' +
+                      'ipa service-show "$service" || ipa service-add --ok-as-delegate=true --force "$service"; ';
+
+            // add cockpit-ws key, unless already present
+            script += 'mkdir -p /etc/cockpit; ';
+            script += 'klist -k /etc/cockpit/krb5.keytab | grep -qF "$service" || ' +
+                      'ipa-getkeytab -p HTTP/$(hostname -f) -k /etc/cockpit/krb5.keytab; ';
+
+            // use a temporary keytab to avoid interfering with the system one
+            var proc = cockpit.script(script, [], { superuser: "require", err: "message",
+                                                    environ: ["KRB5CCNAME=/run/cockpit/keytab-setup"] });
+            proc.input(password);
+            return proc;
+        }
+
+        // Remove SPN from cockpit-ws keytab
+        function cleanup_ws_keytab() {
+            // skip this on remote ssh hosts, only set up ws hosts
+            if (cockpit.transport.host !== "localhost")
+                return cockpit.resolve();
+
+            var dfd = cockpit.defer();
+
+            kerberos = realmd.proxy(KERBEROS, realm.path);
+            kerberos.wait()
+                .done(function() {
+                    cockpit.script('[ ! -e /etc/cockpit/krb5.keytab ] || ipa-rmkeytab -k /etc/cockpit/krb5.keytab -p ' +
+                                   '"HTTP/$(hostname -f)@' + kerberos.RealmName + '"',
+                                   [], { superuser: "require", err: "message" })
+                        .done(dfd.resolve)
+                        .fail(function(ex) {
+                            console.log("Failed to clean up SPN from /etc/cockpit/krb5.keytab:", JSON.stringify(ex));
+                            dfd.resolve();
+                        });
+                })
+                .fail(dfd.resolve); // no Kerberos domain? nevermind then
+
+            return dfd.promise();
+        }
+
         var unique = 1;
 
         function perform() {
@@ -351,14 +421,14 @@
                         if (computer_ou)
                             options["computer-ou"] = cockpit.variant('s', computer_ou);
                         if (kerberos_membership.valid) {
-                            call = kerberos_membership.call("Join", [ credentials(), options ]);
+                            call = kerberos_membership.call("Join", [ credentials(), options ]).then(install_ws_keytab);
                         } else {
                             busy(null);
                             $(".realms-op-message").empty().text(_("Joining this domain is not supported"));
                             $(".realms-op-error").show();
                         }
                     } else if (mode == 'leave') {
-                        call = realm.Deconfigure(options);
+                        call = cleanup_ws_keytab().then(function() { realm.Deconfigure(options); });
                     }
 
                     if (!call) {
@@ -372,7 +442,7 @@
                             if (ex.name == "org.freedesktop.realmd.Error.Cancelled") {
                                 $(dialog).modal("hide");
                             } else {
-                                console.log("Failed to join domain: " + realm.Name + ": " + ex);
+                                console.log("Failed to " + mode + " domain: " + realm.Name + ": " + ex);
                                 $(".realms-op-message").empty().text(ex + " ");
                                 $(".realms-op-error").show();
                                 if (diagnostics) {

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -161,7 +161,6 @@ class TestNetworking(NetworkCase):
 
     def testBondActive(self):
         b = self.browser
-        m = self.machine
 
         self.login_and_go("/network")
 

--- a/test/verify/check-networking-bridge
+++ b/test/verify/check-networking-bridge
@@ -68,7 +68,6 @@ class TestNetworking(NetworkCase):
 
     def testBridgeActive(self):
         b = self.browser
-        m = self.machine
 
         self.login_and_go("/network")
 

--- a/test/verify/check-networking-team
+++ b/test/verify/check-networking-team
@@ -93,7 +93,6 @@ class TestNetworking(NetworkCase):
     @skipImage("No teams",  "continuous-atomic", "rhel-atomic", "ubuntu-1604", "ubuntu-stable")
     def testTeamActive(self):
         b = self.browser
-        m = self.machine
 
         self.login_and_go("/network")
 

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -22,6 +22,34 @@ import parent
 from testlib import *
 
 import re
+import subprocess
+
+WAIT_KRB_SCRIPT = """
+# HACK: This needs to work, but may take a minute
+for x in $(seq 1 60); do
+    if getent passwd admin@cockpit.lan; then
+        break
+    fi
+    if systemctl --quiet is-failed sssd.service; then
+        systemctl status --lines=100 sssd.service >&2
+        exit 1
+    fi
+    sleep $x
+done
+
+# This directory should be owned by the domain user
+getent passwd admin@cockpit.lan
+chown -R admin@cockpit.lan /home/admin
+
+# HACK: This needs to work but may take a minute
+for x in $(seq 1 60); do
+    if ssh -oStrictHostKeyChecking=no -oBatchMode=yes -l admin@cockpit.lan x0.cockpit.lan true; then
+        break
+    fi
+    sleep $x
+done
+"""
+
 
 @skipImage("No realmd available", "continuous-atomic", "fedora-atomic", "rhel-atomic")
 @skipImage("No freeipa available", "debian-stable", "debian-testing")
@@ -67,6 +95,31 @@ class TestRealms(MachineCase):
             # Check that this has worked
             wait_number_domains(1)
 
+        # should not have any leftover tickets from the joining
+        m.execute("! klist")
+        m.execute("! su -c klist admin")
+
+        # validate Kerberos setup for ws; requires FreeIPA with the "ipa" tool
+        if m.image not in ["rhel-7-5", "ubuntu-1604", "ubuntu-stable"]:
+            m.execute("echo foobarfoo | kinit -f admin@COCKPIT.LAN")
+            m.execute(script=WAIT_KRB_SCRIPT, timeout=300)
+
+            # should have added SPN to ws keytab
+            output = m.execute(['klist', '-k', '/etc/cockpit/krb5.keytab'])
+            self.assertIn('HTTP/x0.cockpit.lan@COCKPIT.LAN', output)
+
+            # kerberos login should work
+            output = m.execute(['curl', '-s', '--negotiate', '--delegation', 'always', '-u', ':', "-D", "-",
+                                'http://x0.cockpit.lan:9090/cockpit/login'])
+            self.assertIn("HTTP/1.1 200 OK", output)
+            self.assertIn('"csrf-token"', output)
+        elif m.image != "rhel-7-5":  # on 7.5 with older ws curl succeeds
+            # curl negotiation should fail without a proper ws keytab; this provides a hint
+            # when FreeIPA becomes new enough on the images above to start working
+            self.assertRaisesRegexp(subprocess.CalledProcessError, "returned non-zero exit status 6", m.execute,
+                    ['curl', '-s', '--negotiate', '--delegation', 'always', '-u:', '-D-',
+                     'http://x0.cockpit.lan:9090/cockpit/login'])
+
         # Leave the domain
         b.click("#system-info-domain a")
         b.wait_popup("realms-op")
@@ -75,6 +128,9 @@ class TestRealms(MachineCase):
         b.click(".realms-op-apply")
         b.wait_popdown("realms-op")
         wait_number_domains(0)
+
+        # should have cleaned up ws keytab
+        m.execute("! klist -k /etc/cockpit/krb5.keytab | grep COCKPIT.LAN")
 
         # Send a wrong password
         b.click("#system-info-domain a")
@@ -167,30 +223,6 @@ else
     curl --insecure -s --negotiate -u : https://f0.cockpit.lan/ipa/json --header 'Referer: https://f0.cockpit.lan/ipa' --header "Content-Type: application/json" --header "Accept: application/json" --data '{"params": [["HTTP/x0.cockpit.lan@COCKPIT.LAN"], {"raw": false, "all": false, "version": "2.101", "force": true, "no_members": false, "ipakrbokasdelegate": true}], "method": "service_add", "id": 0}'
 fi
 ipa-getkeytab -p HTTP/x0.cockpit.lan -k %(keytab)s
-
-# HACK: This needs to work, but may take a minute
-for x in $(seq 1 60); do
-    if getent passwd admin@cockpit.lan; then
-        break
-    fi
-    if systemctl --quiet is-failed sssd.service; then
-        systemctl status --lines=100 sssd.service >&2
-        exit 1
-    fi
-    sleep $x
-done
-
-# This directory should be owned by the domain user
-getent passwd admin@cockpit.lan
-chown -R admin@cockpit.lan /home/admin
-
-# HACK: This needs to work but may take a minute
-for x in $(seq 1 60); do
-    if ssh -oStrictHostKeyChecking=no -oBatchMode=yes -l admin@cockpit.lan x0.cockpit.lan true; then
-        break
-    fi
-    sleep $x
-done
 """
 
 # This is here because our test framework can't run ipa VM's twice
@@ -210,6 +242,7 @@ class TestKerberos(MachineCase):
             # no nss-myhostname there
             self.machine.execute("echo '10.111.113.1 x0.cockpit.lan' >> /etc/hosts")
         self.machine.execute(script=JOIN_SCRIPT % args, timeout=1800)
+        self.machine.execute(script=WAIT_KRB_SCRIPT, timeout=300)
 
     def testNegotiate(self):
         self.allow_authorize_journal_messages()

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -21,7 +21,6 @@
 import parent
 from testlib import *
 
-import os
 import re
 
 @skipImage("No realmd available", "continuous-atomic", "fedora-atomic", "rhel-atomic")


### PR DESCRIPTION
When joining an IPA domain and the `ipa` tool is available (in package
freeipa-client), set up Kerberos authentication for Cockpit's webserver:

 * HTTP clients like curl or web browsers use the HTTP/hostname Service
   Principal Name (SPN), so create it on demand for the host that runs
   cockpit-ws.

 * Request a keytab for ws, unless a key for that SPN already exists.

This makes kerberos single-sign on work out of the box in the common
case of IPA with an admin user/password.

On leaving the domain, remove the corresponding SPNs from the ws keytab.

TODO:
 - [x] land cleanups (PR #8949)
 - [x] land more cleanups (PR #8959)
 - [x] documentation (add ipa commands for manual operation)
 - [x] refine/clean up tests
 - [x] do this only on a host where ws is running, not on remote ssh ones
 - [x] ipa-rmkeytab on leaving domain (?)
 - [x] Fix [ubuntu-1604](https://fedorapeople.org/groups/cockpit/logs/pull-8956-20180409-150000-7141be9c-verify-ubuntu-1604/log.html#214) test failure (same on ubuntu-stable)
 - [x] Fix  [centos-7 failure](https://fedorapeople.org/groups/cockpit/logs/pull-8956-20180409-160000-7141be9c-verify-centos-7/log.html#214)
 - [x] Use temporary keytab (`$KRB5CCNAME`) during setup
 - [x] Fix [rhel-7-4 failure](https://fedorapeople.org/groups/cockpit/logs/pull-8956-20180410-151313-60bbb7e9-verify-rhel-7-4/log.html#214)
 - [x] check/fix behaviour as non-admin