### PR TITLE
src: localise numbers

### DIFF
--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -1446,10 +1446,14 @@ function factory() {
     };
 
     cockpit.format_number = function format_number(number) {
-        /* TODO: Make the decimal separator translatable */
-
         /* We show 3 digits of precison but avoid scientific notation.
          * We also show integers without digits after the comma.
+         *
+         * We want to localise the decimal place, but we never want to
+         * show thousands separators (to avoid ambiguity).  For this
+         * reason, for integers and large enough numbers, we use
+         * non-localised conversions (and in both cases, show no
+         * fractional part).
          */
 
         if (!number && number !== 0)
@@ -1457,13 +1461,16 @@ function factory() {
         else if (number % 1 === 0)
             return number.toString();
         else if (number > 0 && number <= 0.001)
-            return "0.001";
+            return (0.001).toLocaleString(cockpit.language);
         else if (number < 0 && number >= -0.001)
-            return "-0.001";
+            return (-0.001).toLocaleString(cockpit.language);
         else if (number > 999 || number < -999)
             return number.toFixed(0);
         else
-            return number.toPrecision(3);
+            return number.toLocaleString(cockpit.language, {
+                maximumSignificantDigits: 3,
+                minimumSignificantDigits: 3
+            });
     };
 
     function format_units(number, suffixes, factor, separate) {

--- a/src/base1/test-format.js
+++ b/src/base1/test-format.js
@@ -17,31 +17,45 @@ QUnit.test("format", function() {
 
 QUnit.test("format_number", function () {
     var checks = [
-        [ 23.4, "23.4" ],
-        [ 23.46, "23.5" ],
-        [ 23.44, "23.4" ],
+        [ 23.4, "23.4", "23,4" ],
+        [ 23.46, "23.5", "23,5" ],
+        [ 23.44, "23.4", "23,4" ],
 
-        [ -23.4, "-23.4" ],
-        [ -23.46, "-23.5" ],
-        [ -23.44, "-23.4" ],
+        [ -23.4, "-23.4", "-23,4" ],
+        [ -23.46, "-23.5", "-23,5" ],
+        [ -23.44, "-23.4", "-23,4" ],
 
-        [ 0, "0" ],
-        [ 0.001, "0.001" ],
-        [ -0.001, "-0.001" ],
+        [ 0, "0", "0" ],
+        [ 0.001, "0.001" , "0,001"],
+        [ -0.001, "-0.001", "-0,001" ],
 
-        [ 123.0, "123" ],
-        [ 123.01, "123" ],
-        [ -123.0, "-123" ],
-        [ -123.01, "-123" ],
-        [ null, "" ],
-        [ undefined, "" ],
+        [ 123.0, "123", "123" ],
+        [ 123.01, "123", "123" ],
+        [ -123.0, "-123", "-123" ],
+        [ -123.01, "-123", "-123" ],
+        [ null, "", "" ],
+        [ undefined, "", "" ],
     ];
 
-    assert.expect(checks.length);
-    for (var i = 0; i < checks.length; i++) {
+    var saved_language = cockpit.language;
+    var i;
+
+    assert.expect(checks.length * 2);
+
+    cockpit.language = 'en';
+    for (i = 0; i < checks.length; i++) {
         assert.strictEqual(cockpit.format_number(checks[i][0]), checks[i][1],
-                    "format_number(" + checks[i][0] + ") = " + checks[i][1]);
+                    "format_number@en(" + checks[i][0] + ") = " + checks[i][1]);
     }
+
+    cockpit.language = 'de';
+    for (i = 0; i < checks.length; i++) {
+        assert.strictEqual(cockpit.format_number(checks[i][0]), checks[i][2],
+                    "format_number@de(" + checks[i][0] + ") = " + checks[i][2]);
+    }
+
+  /* restore this as not to break the other tests */
+  cockpit.language = saved_language;
 });
 
 QUnit.test("format_bytes", function() {


### PR DESCRIPTION
Various cockpit modules format numbers through cockpit.format_number().
For some time, it's been a TODO there to enable i18n on number
formatting (to use the correct grouping and decimals separator).

We can do that by way of .toLocaleString(), with the correct options.

MDN says that the 'options' parameter is not supported on at least some
versions of mobile browsers, so we might have a minor regression there,
but this is not a huge issue, and nicer than having more complicated
code.

Closes #8445