### PR TITLE
tools: Re-enable building of cockpit-pcp on Debian unstable/testing

### DIFF
--- a/bots/images/debian-testing
+++ b/bots/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-cbf52282aed6b0b6de640b7bdedcb8d011fa95d0f5f1ae844b0ff7b14024cd79.qcow2
+debian-testing-bd9c8c907b3dc5e69c753ed935740372009dbb79efa5886f8280f7ce0ca4fc84.qcow2

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -175,7 +175,7 @@ class TestMetrics(MachineCase):
         m.execute("kill %d" % net_pid)
 
     @skipImage("No PCP available on Atomic", "fedora-atomic", "rhel-atomic", "continuous-atomic")
-    @skipImage("No PCP available on Debian 9/testing/unstable", "debian-stable", "debian-testing")
+    @skipImage("No PCP available on Debian 9/testing/unstable", "debian-stable")
     def testPcp(self):
         m = self.machine
 

--- a/tools/debian/adjust-for-release
+++ b/tools/debian/adjust-for-release
@@ -18,10 +18,10 @@ release="$1"
 debian_dir=$(dirname $(readlink -f "$0"))
 
 set -x
-# Remove PCP build dependencies, binary package, and Suggests: while pcp is not in testing
+# Remove PCP build dependencies, binary package, and Suggests: while pcp is not in stable
 # (https://tracker.debian.org/pcp)
 case "$release" in
-    unstable|testing|stable|stretch|buster)
+    stable|stretch)
         sed -i '/libpcp.*-dev/d; /^Package: cockpit-pcp/,/^$/ d; /cockpit-pcp/d' $debian_dir/control
         # also remove the files, otherwise --fail-missing breaks the build
         sed -i 's/for m in /&pcp /' $debian_dir/rules


### PR DESCRIPTION
pcp has been back in testing for two months
(https://tracker.debian.org/pkg/pcp), so put it back on our
debian-testing image and build the cockpit-pcp package there again.

 * [x] land #9043 to add back pcp to debian-testing image
 * [x] Fix image-refresh for debian-testing (#9149)

Rebuild image with this PR to get pcp into pbuilder:
 * [x] image-refresh debian-testing