### PR TITLE
packagekit: Fix overflow in changelog table column

### DIFF
--- a/pkg/packagekit/mock-updates.es6
+++ b/pkg/packagekit/mock-updates.es6
@@ -79,6 +79,17 @@ export function injectMockUpdates(updates) {
             "This is total technobabble gibberish for layman users.\n\n").repeat(30)
     };
 
+    updates["verbose-md;1-1"] = {
+        name: "verbose-md",
+        version: "1-1",
+        bug_urls: [],
+        cve_urls: [],
+        severity: 6,
+        description: ("Some longish explanation of some *boring* technical change. " +
+            "This is total technobabble gibberish for layman users.\n\n").repeat(30),
+        markdown: true,
+    };
+
     // many bug fixes
     var bugs = [];
     for (let i = 10000; i < 10025; ++i)

--- a/pkg/packagekit/updates.less
+++ b/pkg/packagekit/updates.less
@@ -14,8 +14,9 @@ tr.listing-ct-item {
     td.type {
         white-space: nowrap;
     }
-    td.changelog {
+    td.changelog, td.changelog p {
         max-width: 60vw;
+        margin-bottom: 0;  // counter-act <Markdown>
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
The changelog cell contains a `<Markdown>` element which always gets
rendered as a `<p>`. This doesn't inherit the `<td>`'s ellipsis/overflow
properties, so adjust CSS to apply these to the paragraph.

Fixes #8963