### PR TITLE
autogen: check npm version

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -35,6 +35,12 @@ PKG_NAME="Cockpit"
 olddir=$(pwd)
 cd $srcdir
 
+npm_version=$(npm --version)
+if test ${npm_version%%.*} -lt 3; then
+  echo npm version greater than 3.0.0 required, but you have ${npm_version} installed
+  exit 1
+fi
+
 # Development dependencies: See node_modules/README
 npm prune
 npm install # see package.json


### PR DESCRIPTION
Make sure we have at least npm.  This will prevent others from wasting
time trying to chase down the dependencies problems reported by older
versions (such as the one found in Debian).