### PR TITLE
bots: Enable udisks2-{lvm2,iscsi} on rhel-8

### DIFF
--- a/bots/images/scripts/rhel.setup
+++ b/bots/images/scripts/rhel.setup
@@ -153,16 +153,13 @@ fi
 if [ "$IMAGE" = "rhel-8" ]; then
     TEST_PACKAGES="${TEST_PACKAGES/yum-utils/dnf-utils}"
     # some packages are still missing from RHEL 8
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1559810
-    UDISKS="${UDISKS/udisks2-lvm2 /}"
-    UDISKS="${UDISKS/udisks2-iscsi/}"
+    # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1567736
     COCKPIT_DEPS="${COCKPIT_DEPS/libvirt /}"
     COCKPIT_DEPS="${COCKPIT_DEPS/libvirt-client /}"
-    COCKPIT_DEPS="${COCKPIT_DEPS/atomic-openshift-clients /}"
-    TEST_PACKAGES="${TEST_PACKAGES/virt-install /}"
     TEST_PACKAGES="${TEST_PACKAGES/qemu-kvm /}"
-    # HACK: recommends are missing in repodata (https://bugzilla.redhat.com/show_bug.cgi?id=1559839)
-    COCKPIT_DEPS="$COCKPIT_DEPS cracklib-dicts libsss_sudo nmap-ncat"
+    TEST_PACKAGES="${TEST_PACKAGES/virt-install /}"
+    # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1567740
+    COCKPIT_DEPS="${COCKPIT_DEPS/atomic-openshift-clients /}"
 fi
 
 COCKPIT_DEPS="$COCKPIT_DEPS $UDISKS"

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -23,7 +23,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "rhel-8")
+@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
 class TestStorage(StorageCase):
     def testHiddenLuks(self):
         m = self.machine

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -22,7 +22,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for iSCSI", "debian-stable", "ubuntu-1604", "ubuntu-stable", "debian-testing", "centos-7", "rhel-8")
+@skipImage("UDisks doesn't have support for iSCSI", "debian-stable", "ubuntu-1604", "ubuntu-stable", "debian-testing", "centos-7")
 class TestStorage(StorageCase):
     def testISCSI(self):
         m = self.machine

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -23,7 +23,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "rhel-8")
+@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
 class TestStorage(StorageCase):
     def testLvm(self):
         m = self.machine

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -22,7 +22,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for multipath", "debian-stable", "ubuntu-1604", "ubuntu-stable", "rhel-8")
+@skipImage("UDisks doesn't have support for multipath", "debian-stable", "ubuntu-1604", "ubuntu-stable")
 @skipImage("No multipath on Debian", "debian-testing")
 class TestStorage(StorageCase):
     def testBasic(self):

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -23,7 +23,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "rhel-8")
+@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
 class TestStorage(StorageCase):
     def checkResize(self, fsys, can_shrink, can_grow, shrink_needs_unmount = None, grow_needs_unmount = None):
         m = self.machine


### PR DESCRIPTION
The packages are available now, #1559810 got fixed. Re-enable the
corresponding tests.

Recommends now also appear in repo data (#1559839), so drop the
corresponding hack from rhel.setup.

libvirt and an OpenShift client are still missing, add bugzilla
references to the hacks.


 - [ ] image-refresh rhel-8