### PR TITLE
bots: Ignore zlib errors in tests training data

### DIFF
--- a/bots/learn/data.py
+++ b/bots/learn/data.py
@@ -21,6 +21,7 @@
 import gzip
 import json
 import sys
+import zlib
 
 def failures(item):
     return item.get("status") == "failure"
@@ -35,7 +36,11 @@ def load(filename_or_fp, only=failures, limit=None, verbose=False):
         fp = filename_or_fp
     try:
         while True:
-            line = fp.readline().decode('utf-8')
+            try:
+                line = fp.readline().decode('utf-8')
+            except zlib.error as ex:
+                sys.stderr.write("tests-data: {0}\n".format(str(ex)))
+                return
             if not line:
                 return
 

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -29,6 +29,7 @@ import sys
 import time
 import urllib.parse
 import urllib.request, urllib.error, urllib.parse
+import zlib
 
 import html.parser
 
@@ -228,7 +229,11 @@ def seed(since, fp, pulls, output):
     known = re.compile("# SKIP Known issue #([0-9]+)", re.IGNORECASE)
 
     while True:
-        line = fp.readline()
+        try:
+            line = fp.readline()
+        except zlib.error as ex:
+            sys.stderr.write("tests-data: {0}\n".format(str(ex)))
+            break
         if not line:
             break
         try:


### PR DESCRIPTION
During machine learning, we're getting into the situation where
truncated data results in a zlib.error. We should ignore such
errors and re-retrieve the missing data in the learn-data
job.

This change accomplishes that by printing out a warning when
we see such errors.

 * [x] learn-tests