### PR TITLE
Debian lvm fixes

### DIFF
--- a/bots/images/debian-testing
+++ b/bots/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-fc2416ba887fbdd97f91d575278282cbb0ddf15af6f09db734ca2f846fc6a7a6.qcow2
+debian-testing-6522ec67f4e558ad8ef273d802626f292f2448e41ec6cd5ceece25304845328c.qcow2

--- a/bots/images/scripts/debian.setup
+++ b/bots/images/scripts/debian.setup
@@ -72,7 +72,7 @@ case "$RELEASE" in
         # https://tracker.debian.org/pcp not currently in testing
         COCKPIT_DEPS="${COCKPIT_DEPS/libpcp3 /}"
         COCKPIT_DEPS="${COCKPIT_DEPS/pcp /}"
-        COCKPIT_DEPS="${COCKPIT_DEPS} libblockdev-mdraid2"
+        COCKPIT_DEPS="${COCKPIT_DEPS} libblockdev-mdraid2 udisks2-lvm2"
 
         # docker.io got removed from testing; use backports-version
         echo "deb http://deb.debian.org/debian jessie-backports main" >/etc/apt/sources.list.d/jessie-backports.list

--- a/bots/naughty/debian-testing/9036-apparmor-denied-libvirt-signal
+++ b/bots/naughty/debian-testing/9036-apparmor-denied-libvirt-signal
@@ -1,0 +1,1 @@
+Error: audit: type=1400 * apparmor="DENIED" operation="signal" profile="/usr/sbin/libvirtd" * requested_mask="send" denied_mask="send" signal=hup peer="unconfined"

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -23,7 +23,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
+@skipImage("UDisks doesn't have support for LVM", "debian-stable", "ubuntu-1604", "ubuntu-stable")
 class TestStorage(StorageCase):
     def testHiddenLuks(self):
         m = self.machine
@@ -128,6 +128,9 @@ class TestStorage(StorageCase):
                       "mount_point": mount_point_2 })
         self.content_row_wait_in_col(1, 1, "ext4 File System")
         self.wait_in_storaged_configuration(mount_point_2)
+
+        # we need to wait for mdadm --monitor to stop using the device before delete
+        m.execute("while fuser -s /dev/md127; do sleep 0.2; done", timeout=20)
 
         self.browser.click('.panel-heading:contains("RAID Device") button:contains("Delete")')
         self.confirm()

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -23,7 +23,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
+@skipImage("UDisks doesn't have support for LVM", "debian-stable", "ubuntu-1604", "ubuntu-stable")
 class TestStorage(StorageCase):
     def testLvm(self):
         m = self.machine

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -23,7 +23,7 @@ import parent
 from testlib import *
 from storagelib import *
 
-@skipImage("UDisks doesn't have support for LVM", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
+@skipImage("UDisks doesn't have support for LVM", "debian-stable", "ubuntu-1604", "ubuntu-stable")
 class TestStorage(StorageCase):
     def checkResize(self, fsys, can_shrink, can_grow, shrink_needs_unmount = None, grow_needs_unmount = None):
         m = self.machine


### PR DESCRIPTION
test: run lvm-related tests on debian-testing
    
We now have the udisks2-lvm2 package in debian-testing, so stop skipping the lvm-related tests for this image.

One of the newly-enabled test was failing on Debian, because of an attempt to delete a RAID device while it is still in use.  That appears to be related to mdadm --monitor being started after the device is created, and not settling down for a long time.

Wait for the the device to stop being used before attempting to delete it.

 - [ ] land PR #9006 