### PR TITLE
kubernetes: add pod metrics to virtual machines

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "object-describer": "https://github.com/kubernetes-ui/object-describer.git#v1.0.4",
     "patternfly": "3.35.1",
     "patternfly-bootstrap-combobox": "1.1.7",
+    "patternfly-react": "1.19.1",
     "promise": "8.0.1",
     "qunit-tap": "1.5.1",
     "qunitjs": "1.23.1",

--- a/pkg/kubernetes/scripts/virtual-machines.js
+++ b/pkg/kubernetes/scripts/virtual-machines.js
@@ -72,8 +72,9 @@
         'kubeLoader',
         'kubeSelect',
         'kubeMethods',
-        function($scope, loader, select, methods) {
-            vmsReact.init($scope, loader, select, methods);
+        'KubeRequest',
+        function($scope, loader, select, methods, request) {
+            vmsReact.init($scope, loader, select, methods, request);
         }]
     );
 

--- a/pkg/kubernetes/scripts/virtual-machines/action-creators.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/action-creators.jsx
@@ -67,6 +67,13 @@ export function setPods(pods) {
     };
 }
 
+export function setNodeMetrics(metrics) {
+    return {
+        type: actionConstants.SET_NODE_METRICS,
+        payload: metrics,
+    };
+}
+
 export function vmExpanded({ vm, isExpanded }) {
     return {
         type: actionConstants.VM_EXPANDED,

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx
@@ -62,20 +62,17 @@ const CPUChart = ({ id, podMetrics }) => {
             <DonutChart
                 size={{ width: 150, height: 150 }}
                 data={{
-                    columns: [["Used", used], ["Free", available]],
+                    columns: [[_("Used"), used], [_("Free"), available]],
                     order: null,
                     colors: {
                         "Used": color,
                         "Free": "#BBBBBB",
                     },
                 }}
-                title={{ primary: used + unit, secondary: "Used" }}
+                title={{ primary: used + unit, secondary: _("Used") }}
                 tooltip={{
-                    contents: (data) => {
-                        return `${data[0].value}${unit}&nbsp;${data[0].name}`;
-                    },
+                    contents: (data) => `${data[0].value}${unit}&nbsp;${data[0].name}`
                 }}
-
                 donut={{ width: 9, label: { show: false } }}
             />
         </div>

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx
@@ -1,0 +1,149 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// @flow
+import React, { PropTypes } from 'react';
+import { DonutChart } from 'patternfly-react'
+import cockpit, { gettext as _ } from 'cockpit';
+
+import './VmMetricsTab.less';
+
+const MetricColumn = ({ type, children, className }) => {
+    return (
+        <div className={`col-sm-4 ${className || ''}`}>
+            <div className="container metric">
+                {children}
+            </div>
+            <div className="text-center">{type}</div>
+        </div>
+    );
+};
+
+const MetricColumnContent = ({ id, title, smallTitle }) => {
+    return (
+        <div id={id} className="centered">
+            <span id={`${id}-title`} className="block donut-title-big-pf">
+                {title}
+            </span>
+            <div className="container small-text-layout">
+                <span id={`${id}-small-title`} className="donut-title-small-pf small-text">
+                    {smallTitle}
+                </span>
+            </div>
+        </div>
+    );
+};
+
+const CPUChart = ({ id, podMetrics }) => {
+    const used = podMetrics.cpu && podMetrics.cpu.usageNanoCores ? Math.round((podMetrics.cpu.usageNanoCores / 1000000000) * 100) : 0;
+    const available = 100 - used;
+    const unit = "%";
+    const index = [90, 80, 70, -1].findIndex((v) => used > v);
+    const color = ["#CE0000", "#EC7A08", "#F9D67A", "#D4F0FA"][index];
+
+    return (
+        <div className="centered" id={id}>
+            <DonutChart
+                size={{ width: 150, height: 150 }}
+                data={{
+                    columns: [["Used", used], ["Free", available]],
+                    order: null,
+                    colors: {
+                        "Used": color,
+                        "Free": "#BBBBBB",
+                    },
+                }}
+                title={{ primary: used + unit, secondary: "Used" }}
+                tooltip={{
+                    contents: (data) => {
+                        return `${data[0].value}${unit}&nbsp;${data[0].name}`;
+                    },
+                }}
+
+                donut={{ width: 9, label: { show: false } }}
+            />
+        </div>
+    );
+};
+
+const CpuColumn = ({ podMetrics }) => {
+    return (
+        <MetricColumn type={_("CPU")}>
+            <CPUChart id="cpu-metric" podMetrics={podMetrics} />
+        </MetricColumn>
+    );
+};
+
+const MemoryColumn = ({ podMetrics }) => {
+    const usage = cockpit.format_bytes(podMetrics.memory.usageBytes);
+    return (
+        <MetricColumn type={_("Memory")}>
+            <MetricColumnContent id="memory-metric" title={usage} />
+        </MetricColumn>
+    );
+};
+
+const NetworkColumn = ({ podMetrics }) => {
+    const received = cockpit.format_bytes_per_sec(podMetrics.network.rxBytes);
+    const transmitted = cockpit.format_bytes_per_sec(podMetrics.network.txBytes);
+    const title = (
+        <div>
+            <div className="inline-block" id="download-metric">
+                <div className="next-to-left fa fa-arrow-down" />
+                {received}
+            </div>
+            <div className="inline-block" id="upload-metric">
+                <div className="next-clear fa fa-arrow-up" />
+                {transmitted}
+            </div>
+        </div>
+    );
+    return (
+        <MetricColumn type={_("Network")} className="no-padding-left">
+            <MetricColumnContent id="network-metric" title={title} />
+        </MetricColumn>
+    );
+};
+
+const PodMetrics = ({ podMetrics }) => {
+    return (
+        <div className="row">
+            <CpuColumn podMetrics={podMetrics} />
+            <MemoryColumn podMetrics={podMetrics} />
+            <NetworkColumn podMetrics={podMetrics} />
+        </div>
+    );
+};
+
+const VmMetricsTab = ({podMetrics}) => {
+    const content = podMetrics ? (<PodMetrics podMetrics={podMetrics} />)
+        : _("Usage metrics are available after the pod starts");
+
+    return (
+        <div id="usage-metrics">
+            {content}
+        </div>
+    );
+};
+
+VmMetricsTab.propTypes = {
+    podMetrics: PropTypes.object.isRequired,
+};
+
+export default VmMetricsTab;

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.less
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.less
@@ -1,0 +1,50 @@
+.centered {
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.container {
+    text-align: center;
+    align-content: center;
+    display:flex;
+    align-items: center; /* Vertical center alignment */
+    justify-content: center; /* Horizontal center alignment */
+    width: initial;
+}
+
+.metric {
+    height: 150px;
+}
+
+.small-text-layout {
+    height: 12px;
+}
+
+.small-text {
+    position: absolute;
+    margin-top: -8px;
+}
+
+span.block {
+    display:block;
+}
+
+.fa-arrow-up {
+    color: #4d5258; /* pf-black-700 */
+    padding-right: 0.5em;
+    padding-left: 0.5em;
+}
+
+.fa-arrow-down {
+    color: #4d5258; /* pf-black-700 */
+    padding-right: 0.5em;
+    padding-left: 0.5em;
+}
+
+.no-padding-left {
+    padding-left: 0;
+}
+
+.inline-block {
+    display: inline-block;
+}

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx
@@ -24,13 +24,10 @@ import { gettext as _ } from 'cockpit';
 import VmOverviewTab, { commonTitles } from '../../../../machines/components/vmOverviewTab.jsx';
 
 import type { Vm, VmMessages, Pod } from '../types.jsx';
-import { getPairs, NODE_LABEL, vmIdPrefx, getValueOrDefault } from '../utils.jsx';
+import { getPairs, vmIdPrefx, getValueOrDefault } from '../utils.jsx';
+import { getNodeName } from '../selectors.jsx';
 
 import VmMessage from './VmMessage.jsx';
-
-function getNodeName(vm: Vm) {
-    return (vm.metadata.labels && vm.metadata.labels[NODE_LABEL]) || null
-}
 
 const getLabels = (vm: Vm) => {
     let labels = null;
@@ -83,6 +80,7 @@ const VmOverviewTabKubevirt = ({ vm, vmMessages, pod }: { vm: Vm, vmMessages: Vm
         {title: _("Labels:"), value: getLabels(vm), idPostfix: 'labels'},
         {title: _("Pod:"), value: podLink, idPostfix: 'pod'},
     ];
+
     return (<VmOverviewTab message={message}
                            idPrefix={idPrefix}
                            items={items} />);

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx
@@ -25,17 +25,26 @@ import { gettext as _ } from 'cockpit';
 
 import { Listing } from '../../../../lib/cockpit-components-listing.jsx';
 import VmsListingRow from './VmsListingRow.jsx';
-import { getPod } from '../selectors.jsx';
+import { getPod, getPodMetrics } from '../selectors.jsx';
 import CreateVmButton from './createVmButton.jsx';
 
-const VmsListing = ({ vms, pvs, pods, settings, vmsMessages }) => {
+const VmsListing = ({ vms, pvs, pods, settings, vmsMessages, nodeMetrics }) => {
     const isOpenshift = settings.flavor === 'openshift';
     const namespaceLabel = isOpenshift ? _("Project") : _("Namespace");
-    const rows = vms.map(vm => (<VmsListingRow vm={vm}
-                                               vmMessages={vmsMessages[vm.metadata.uid]}
-                                               pod={getPod(vm, pods)}
-                                               pvs={pvs}
-                                               key={vm.metadata.uid} />));
+
+    const rows = vms.map(vm => {
+        const pod = getPod(vm, pods);
+
+        return (
+            <VmsListingRow vm={vm}
+                vmMessages={vmsMessages[vm.metadata.uid]}
+                pod={pod}
+                podMetrics={getPodMetrics(pod, nodeMetrics)}
+                pvs={pvs}
+                key={vm.metadata.uid} />
+        );
+    });
+
     let actions = [(
         <CreateVmButton key='create-vm' />
     )];
@@ -55,14 +64,16 @@ VmsListing.propTypes = {
     pvs: PropTypes.array.isRequired,
     pods: PropTypes.array.isRequired,
     vmsMessages: PropTypes.object.isRequired,
+    nodeMetrics: PropTypes.object.isRequired,
 };
 
 export default connect(
-    ({ vms, pods, pvs, settings, vmsMessages }) => ({
+    ({ vms, pods, pvs, settings, vmsMessages, nodeMetrics }) => ({
         vms, // VirtualMachines
         pods,
         pvs, // PersistentVolumes
         settings,
         vmsMessages,
+        nodeMetrics,
     })
 )(VmsListing);

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx
@@ -26,22 +26,30 @@ import { connect } from "react-redux";
 import { ListingRow } from '../../../../lib/cockpit-components-listing.jsx';
 import VmOverviewTab from './VmOverviewTabKubevirt.jsx';
 import VmActions from './VmActions.jsx';
+import VmMetricsTab from './VmMetricsTab.jsx';
 import VmDisksTab from './VmDisksTabKubevirt.jsx';
 
 import type { Vm, VmMessages, PersistenVolumes, Pod } from '../types.jsx';
 import { NODE_LABEL, vmIdPrefx, getValueOrDefault } from '../utils.jsx';
 import { vmExpanded } from "../action-creators.jsx";
 
-const VmsListingRow = ({ vm, vmMessages, pvs, pod, vmUi, onExpandChanged }:
+const VmsListingRow = ({ vm, vmMessages, pvs, pod, podMetrics, vmUi, onExpandChanged }:
                            { vm: Vm, vmMessages: VmMessages, pvs: PersistenVolumes, pod: Pod, onExpandChanged: Function }) => {
     const node = (vm.metadata.labels && vm.metadata.labels[NODE_LABEL]) || '-';
     const phase = (vm.status && vm.status.phase) || _("n/a");
     const idPrefix = vmIdPrefx(vm);
 
     const overviewTabRenderer = {
-        name: _("Overview"),
+        name: (<div id={`${idPrefix}-overview-tab`}>{_("Overview")}</div>),
         renderer: VmOverviewTab,
         data: { vm, vmMessages, pod },
+        presence: 'always',
+    };
+
+    const metricsTabRenderer = {
+        name: (<div id={`${idPrefix}-usage-tab`}>{_("Usage")}</div>),
+        renderer: VmMetricsTab,
+        data: { podMetrics },
         presence: 'always',
     };
 
@@ -63,7 +71,7 @@ const VmsListingRow = ({ vm, vmMessages, pvs, pod, vmUi, onExpandChanged }:
                 node,
                 phase // phases description https://github.com/kubevirt/kubevirt/blob/master/pkg/api/v1/types.go
             ]}
-            tabRenderers={[ overviewTabRenderer, disksTabRenderer ]}
+            tabRenderers={[ overviewTabRenderer, metricsTabRenderer, disksTabRenderer ]}
             listingActions={[ <VmActions vm={vm} /> ]}
             expandChanged={onExpandChanged(vm)}
             initiallyExpanded={initiallyExpanded} />

--- a/pkg/kubernetes/scripts/virtual-machines/config.es6
+++ b/pkg/kubernetes/scripts/virtual-machines/config.es6
@@ -1,7 +1,7 @@
 /*
  * This file is part of Cockpit.
  *
- * Copyright (C) 2017 Red Hat, Inc.
+ * Copyright (C) 2018 Red Hat, Inc.
  *
  * Cockpit is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by
@@ -17,13 +17,11 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const SET_VMS = 'SET_VMS';
-export const SET_PVS = 'SET_PVS';
-export const SET_SETTINGS = 'SET_SETTINGS';
-export const SET_PODS = 'SET_PODS';
-export const SET_NODE_METRICS = 'SET_NODE_METRICS';
+/**
+ * Application-wide constants
+ */
+const CONFIG = {
+    MetricsRefreshInterval: 5000, // in ms
+};
 
-export const VM_ACTION_FAILED = 'VM_ACTION_FAILED';
-export const REMOVE_VM_MESSAGE = 'REMOVE_VM_MESSAGE';
-
-export const VM_EXPANDED = 'VM_EXPANDED';
+export default CONFIG;

--- a/pkg/kubernetes/scripts/virtual-machines/index.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/index.jsx
@@ -27,6 +27,7 @@ import reducers from './reducers.jsx';
 import * as actionCreators from './action-creators.jsx';
 import VmsListing from './components/VmsListing.jsx';
 import { logDebug } from './utils.jsx';
+import { watchMetrics, cleanupMetricsWatch } from "./watch-metrics.es6";
 
 import '../../../machines/machines.less'; // once per component hierarchy
 
@@ -81,12 +82,16 @@ function addScopeVarsToStore ($scope) {
  * @param {kubeLoader} kubeLoader
  * @param {kubeSelect} kubeSelect
  * @param {kubeMethods} kubeMethods
+ * @param {KubeRequest} KubeRequest
  */
-function init($scope, kubeLoader, kubeSelect, kubeMethods) {
+function init($scope, kubeLoader, kubeSelect, kubeMethods, KubeRequest) {
     initReduxStore();
     addKubeLoaderListener($scope, kubeLoader, kubeSelect);
-    initMiddleware(kubeMethods, kubeLoader);
+    initMiddleware(kubeMethods, kubeLoader, KubeRequest);
     addScopeVarsToStore($scope);
+
+    watchMetrics(reduxStore);
+    $scope.$on("$destroy", () => cleanupMetricsWatch());
 
     const rootElement = document.querySelector('#kubernetes-virtual-machines-root');
     React.render(<VmsPlugin />, rootElement);

--- a/pkg/kubernetes/scripts/virtual-machines/kube-middleware.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/kube-middleware.jsx
@@ -21,10 +21,12 @@ import cockpit from 'cockpit';
 
 let kubeMethods = null;
 let kubeLoader = null;
+let KubeRequest = null;
 
-export function initMiddleware(_kubeMethods, _kubeLoader) {
+export function initMiddleware(_kubeMethods, _kubeLoader, _KubeRequest) {
     kubeMethods = _kubeMethods;
     kubeLoader = _kubeLoader;
+    KubeRequest = _KubeRequest;
 }
 
 function vmCreate(resource) {
@@ -49,4 +51,10 @@ async function vmDelete({ vm }) {
     return kubeMethods.delete(selfLink); // no value is returned (empty promise). An exception is thrown in case of failure
 }
 
-export { vmDelete, vmCreate };
+async function fetchStatSummary(nodeName) {
+    const path = "/api/v1/nodes/" + encodeURIComponent(nodeName) + "/proxy/stats/summary/";
+
+    return KubeRequest("GET", path);
+}
+
+export { vmDelete, vmCreate, fetchStatSummary };

--- a/pkg/kubernetes/scripts/virtual-machines/reducers.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/reducers.jsx
@@ -96,12 +96,19 @@ const uiReducer = createReducer({}, {
     }
 });
 
+const nodeMetricsReducer = createReducer({}, {
+    [actionTypes.SET_NODE_METRICS]: (state = {}, { payload }) => {
+        return payload.node ? Object.assign({}, state, { [payload.node.nodeName]: payload }) : state;
+    },
+});
+
 const rootReducer = combineReducers({
     vms: vmsReducer, // VirtualMachines from API
     pvs: pvsReducer, // PersistenVolumes from API
     pods: podsReducer, // Pods from API
     settings: settingsReducer, // settings gathered at run-time
     vmsMessages: vmsMessagesReducer, // messages related to a VM
+    nodeMetrics: nodeMetricsReducer, // metrics of all VM's nodes
     ui: uiReducer, // various UI-state descriptions (i.e. to restore UI after back-button)
 });
 

--- a/pkg/kubernetes/scripts/virtual-machines/selectors.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/selectors.jsx
@@ -17,7 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getValueOrDefault, VM_UID_LABEL, VM_CREATED_BY_LABEL } from "./utils.jsx";
+import { getValueOrDefault, VM_UID_LABEL, VM_CREATED_BY_LABEL, NODE_LABEL } from './utils.jsx';
+import type { Vm } from './types.jsx';
 
 /**
  * Returns pod corresponding to the given vm.
@@ -34,4 +35,25 @@ export function getPod(vm, pods) {
 
     return pods.find(pod => getValueOrDefault(() => (pod.metadata.annotations[VM_CREATED_BY_LABEL] /* kubevirt >= 0.5 */ ||
                                                      pod.metadata.labels[VM_UID_LABEL]), null) === vmId);
+}
+
+/**
+ * Returns pod metrics corresponding to the given vm.
+ */
+export function getPodMetrics(pod, nodeMetrics) {
+    const node = getValueOrDefault(() => nodeMetrics[pod.spec.nodeName], null);
+    if (!node) {
+        return null;
+    }
+
+    const podUid = pod.metadata.uid;
+    if (!podUid) {
+        return null;
+    }
+
+    return node.pods.find(pod => pod.podRef.uid === podUid);
+}
+
+export function getNodeName(vm: Vm) {
+    return getValueOrDefault(() => vm.metadata.labels[NODE_LABEL], null);
 }

--- a/pkg/kubernetes/scripts/virtual-machines/watch-metrics.es6
+++ b/pkg/kubernetes/scripts/virtual-machines/watch-metrics.es6
@@ -1,0 +1,92 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { getNodeName } from './selectors.jsx';
+import { fetchStatSummary } from './kube-middleware.jsx';
+import { setNodeMetrics } from "./action-creators.jsx";
+
+import CONFIG from './config.es6';
+
+let metrics = {
+    timeout: null,
+    unSubscribe: null,
+    watchedNodes: {},
+};
+
+function watchMetricsContinuously(fetchNode, timeout) {
+    metrics.timeout = window.setTimeout(async () => {
+        metrics.timeout = null;
+        for (let node of Object.keys(metrics.watchedNodes)) {
+            await fetchNode(node);
+        }
+        watchMetricsContinuously(fetchNode);
+    }, timeout == null ? CONFIG.MetricsRefreshInterval : timeout);
+}
+
+export function watchMetrics(store) {
+    if (metrics.timeout) {
+        cleanupMetricsWatch();
+    }
+
+    const fetchNode = async (node) => {
+        const result = await fetchStatSummary(node).catch((ex) => console.warn(ex));
+        return store.dispatch(setNodeMetrics(result.data));
+    };
+
+    metrics.unSubscribe = store.subscribe(function() {
+        const state = store.getState();
+        const nodes = {};
+        let refresh = false;
+
+        Object.keys(state.ui).forEach(metadata_uid => {
+            const vmUiState = state.ui[metadata_uid];
+            if (vmUiState.isExpanded) {
+                const vm = state.vms.find(vm => vm.metadata.uid === metadata_uid);
+                const node = getNodeName(vm);
+                if (node) {
+                    if (!metrics.watchedNodes[node] && !nodes[node]) {
+                        refresh = true
+                    }
+                    nodes[node] = node;
+                }
+            }
+        });
+
+        metrics.watchedNodes = nodes;
+
+        if (refresh && metrics.timeout) {
+            window.clearTimeout(metrics.timeout);
+            watchMetricsContinuously(fetchNode, 0);
+        }
+    });
+
+    watchMetricsContinuously(fetchNode, 0);
+}
+
+export function cleanupMetricsWatch() {
+    if (metrics.unSubscribe) {
+        metrics.unSubscribe();
+    }
+
+    window.clearTimeout(metrics.timeout);
+
+    metrics.timeout = null;
+    metrics.unSubscribe = null;
+    metrics.watchedNodes = {};
+}

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -403,8 +403,8 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         o.execute("oc adm policy add-scc-to-user privileged -n kube-system -z kubevirt-admin")
         o.execute("oc adm policy add-scc-to-user privileged -n kube-system -z default")
 
-        wait(lambda: "Running" in o.execute("oc get pods | grep virt-controller"), delay=2) # is it deployed and up?
-        wait(lambda: "No resources found." in o.execute("oc get vm 2>&1"), delay=2) # No VM created/started yet
+        wait(lambda: "Running" in o.execute("oc get pods | grep virt-controller"), delay=2, tries=150) # is it deployed and up?
+        wait(lambda: "No resources found." in o.execute("oc get vm 2>&1"), delay=2, tries=150) # No VM created/started yet
 
     def testUndeployKubevirt(self):
         # The kubevirt is deployed by default in the openshift image.
@@ -444,9 +444,10 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
 
         # The "fedoravm" VirtualMachine is created from OfflineVirtualMachine
         o.execute("oc patch offlinevirtualmachine fedoravm --type=merge -p '{\"spec\":{\"running\": true}}'")  # let's start the VM
-        wait(lambda: "fedoravm" in o.execute("oc get vm"), msg='Start of the "fedoravm" virtual machine failed.')
-        wait(lambda: "virt-launcher-fedoravm" in o.execute("oc get pods"))
-        wait(lambda: "Running" in o.execute("oc get pods | grep virt-launcher-fedoravm")) # Example: virt-launcher-fedoravm-----rx59t
+        print("starting vm, might take a while")
+        wait(lambda: "fedoravm" in o.execute("oc get vm"), msg='Start of the "fedoravm" virtual machine failed.', delay=2)
+        wait(lambda: "virt-launcher-fedoravm" in o.execute("oc get pods"), delay=2)
+        wait(lambda: "Running" in o.execute("oc get pods | grep virt-launcher-fedoravm"), delay=2, tries=150) # Example: virt-launcher-fedoravm-----rx59t
 
         b = self.browser
         self.login_and_go("/kubernetes")
@@ -480,8 +481,8 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
             return m.group(1) if m else None
 
         wait(lambda: get_units_value("#memory-metric-title") > 0)
-        self.assertTrue(get_units_value("#download-metric", True) >= 0)
-        self.assertTrue(get_units_value("#upload-metric", True) >= 0)
+        self.assertGreaterEqual(get_units_value("#download-metric", True), 0)
+        self.assertGreaterEqual(get_units_value("#upload-metric", True), 0)
 
         # switch to the Disks subtab
         b.wait_present("#vm-fedoravm-disks-tab")
@@ -504,16 +505,18 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         # return back to the virtual-machines
         b.wait_present("#vms-menu-link") # left-side menu
         b.click("#vms-menu-link")
-        b.wait_present("tr[data-row-id='vm-fedoravm']") # the row is already expanded if saving of UI state works
 
         # delete the VM (not the OVM), the VM pod should be recreated automatically
+        wait(lambda: "virt-launcher-fedoravm" in o.execute("oc get pods | grep Running"), delay=2, tries=150)
+        b.wait_present("tr[data-row-id='vm-fedoravm']") # the row is already expanded if saving of UI state works
         b.wait_present("#vm-fedoravm-delete")
-        wait(lambda: "virt-launcher-fedoravm" in o.execute("oc get pods | grep Running"))
         b.click("#vm-fedoravm-delete")
-        b.wait_present("#kubernetes-virtual-machines-root tr > td:contains(No virtual machines)")
+        print("restarting vm, might take a while")
+        with self.browser.wait_timeout(300):
+            b.wait_present("#kubernetes-virtual-machines-root tr > td:contains(No virtual machines)")
+            # Since the VM is created from OVM, it will be automatically restarted (spec.running: true)
+            b.wait_present("tr[data-row-id='vm-fedoravm']")
 
-        # Since the VM is created from OVM, it will be automatically restarted (spec.running: true)
-        b.wait_present("tr[data-row-id='vm-fedoravm']")
         if not b.is_present("#vm-fedoravm-usage-tab"):  # if not expanded
             b.click("tr[data-row-id='vm-fedoravm']")  # expand row
 
@@ -527,7 +530,7 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         self.assertFalse(b.is_present("#network-metric"))
         b.click("#vm-fedoravm-overview-tab")
         b.click("tr[data-row-id='vm-fedoravm']")  # hide row
-        wait(lambda: "Running" in o.execute("oc get pods | grep virt-launcher-fedoravm"))
+        wait(lambda: "Running" in o.execute("oc get pods | grep virt-launcher-fedoravm"), delay=2, tries=150)
 
         # link to node
         b.wait_present("tr[data-row-id='vm-fedoravm']") # the just-started VM is listed
@@ -542,8 +545,7 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         # link to pod
         b.click("#vms-menu-link")
         b.wait_present("tr[data-row-id='vm-fedoravm']") # the row is already expanded if saving of UI state works
-        b.wait_present("#vm-fedoravm-pod")
-        wait(lambda: b.text("#vm-fedoravm-pod > a").strip() != "")
+        wait(lambda: b.is_present("#vm-fedoravm-pod > a") and b.text("#vm-fedoravm-pod > a").strip() != "")
         b.wait_in_text("#vm-fedoravm-pod", "virt-launcher-fedoravm")
         pod_name = b.text("#vm-fedoravm-pod > a").strip()
         b.click("#vm-fedoravm-pod > a")
@@ -570,7 +572,9 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
                     .create()
                 row_selector = "tr[data-row-id='vm-{0}']".format(name)
 
-                b.wait_present(row_selector)
+                print("creating vm, might take a while")
+                with self.browser.wait_timeout(300):
+                    b.wait_present(row_selector)
                 self.assertEqual(b.text("{0} th".format(row_selector)), name)
                 self.assertEqual(b.text("{0} td:nth-of-type(2)".format(row_selector)), dialog.getNamespace())
 
@@ -642,6 +646,8 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
 
             def create(self):
                 b = self.browser
+                # wait for a file to load into the text area
+                b.wait(lambda: b.val("#resource-text"))
                 b.click(".modal-footer button:contains(Create)")
                 b.wait_not_present("#cockpit_modal_dialog")
 

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -25,6 +25,7 @@ import os
 import unittest
 import time
 import sys
+import re
 
 from kubelib import *
 
@@ -464,6 +465,24 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         b.wait_in_text("#vm-fedoravm-labels", "kubevirt.io/nodeName=f1.cockpit.lan")
         b.wait_present("#vm-fedoravm-pod")
 
+        # switch to the Usage subtab
+        b.wait_present("#vm-fedoravm-usage-tab")
+        b.click("#vm-fedoravm-usage-tab")
+        b.wait_present("#cpu-metric div svg")  # cannot check cpu component because it is an external dependency
+        b.wait_present("#memory-metric")
+        b.wait_present("#network-metric")
+
+        def get_units_value(selector, per_second=False):
+            units_regex = "([0-9]+\.?[0-9]*) .?i?B"
+            if per_second:
+                units_regex += "/s"
+            m = re.match(units_regex, b.text(selector))
+            return m.group(1) if m else None
+
+        wait(lambda: get_units_value("#memory-metric-title") > 0)
+        self.assertTrue(get_units_value("#download-metric", True) >= 0)
+        self.assertTrue(get_units_value("#upload-metric", True) >= 0)
+
         # switch to the Disks subtab
         b.wait_present("#vm-fedoravm-disks-tab")
         b.click("#vm-fedoravm-disks-tab")
@@ -495,6 +514,19 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
 
         # Since the VM is created from OVM, it will be automatically restarted (spec.running: true)
         b.wait_present("tr[data-row-id='vm-fedoravm']")
+        if not b.is_present("#vm-fedoravm-usage-tab"):  # if not expanded
+            b.click("tr[data-row-id='vm-fedoravm']")  # expand row
+
+        # check usage still not present because vm is not running yet)
+        b.wait_present("#vm-fedoravm-usage-tab")
+        b.click("#vm-fedoravm-usage-tab")
+        b.wait_present("#usage-metrics")
+        b.wait_in_text("#usage-metrics", "Usage metrics are available after the pod starts")
+        self.assertFalse(b.is_present("#cpu-metric"))
+        self.assertFalse(b.is_present("#memory-metric"))
+        self.assertFalse(b.is_present("#network-metric"))
+        b.click("#vm-fedoravm-overview-tab")
+        b.click("tr[data-row-id='vm-fedoravm']")  # hide row
         wait(lambda: "Running" in o.execute("oc get pods | grep virt-launcher-fedoravm"))
 
         # link to node


### PR DESCRIPTION
adds metrics of a pod where the vm is running
- cpu (donut chart from patternfly-react)
- memory
- network

storage usage of the vm is omitted now because it is hard to measure

