### PR TITLE
bots: Retry tests when flakey

### DIFF
--- a/bots/image-download
+++ b/bots/image-download
@@ -32,9 +32,9 @@
 
 CONFIG = "~/.config/image-stores"
 DEFAULT = [
+    "http://cockpit-images.verify.svc.cluster.local",
     "https://209.132.184.69:8493/",
     "https://209.132.184.41:8493/",
-    "http://cockpit-images.verify.svc.cluster.local",
     "https://fedorapeople.org/groups/cockpit/images/"
 ]
 

--- a/bots/learn/data.py
+++ b/bots/learn/data.py
@@ -38,7 +38,7 @@ def load(filename_or_fp, only=failures, limit=None, verbose=False):
         while True:
             try:
                 line = fp.readline().decode('utf-8')
-            except zlib.error as ex:
+            except (OSError, zlib.error) as ex:
                 sys.stderr.write("tests-data: {0}\n".format(str(ex)))
                 return
             if not line:

--- a/bots/task/github.py
+++ b/bots/task/github.py
@@ -161,7 +161,7 @@ class GitHub(object):
                 response = self.conn.getresponse()
                 break
             # This happens when GitHub disconnects in python3
-            except http.client.RemoteDisconnected:
+            except http.client.ConnectionResetError:
                 if connected:
                     raise
                 self.conn = None

--- a/bots/task/log.html
+++ b/bots/task/log.html
@@ -180,7 +180,7 @@ function extract(text) {
 
         // delete retried segments
         for (s = 0; s < segments.length; s += 1) {
-            if (segments[s].indexOf("Retrying due to failure of test harness or framework") == -1)
+            if (segments[s].indexOf("# RETRY") == -1)
                 continue;
             segments.splice(s, 1);
             s -= 1;

--- a/bots/task/log.html
+++ b/bots/task/log.html
@@ -178,15 +178,6 @@ function extract(text) {
         var segments = text.split(test_header_start);
         $('#test-info').text(text.slice(0, text.indexOf('\n')));
 
-        // delete retried segments
-        for (s = 0; s < segments.length; s += 1) {
-            if (segments[s].indexOf("# RETRY") == -1)
-                continue;
-            segments.splice(s, 1);
-            s -= 1;
-            retries += 1;
-        }
-
         var test_links = {};
         segments.forEach(function (segment, segmentIndex) {
             tap_range.lastIndex = 0;
@@ -223,6 +214,9 @@ function extract(text) {
                     } else {
                         passed += 1;
                     }
+		} else if (segment.indexOf("# RETRY") !== -1) {
+                    retries += 1;
+                    entry.passed = false;
                 } else {
                     entry.passed = false;
                     failed += 1;
@@ -280,7 +274,7 @@ function extract(text) {
                                                                 skipped: skipped,
                                                                 retries: retries,
                                                                 total: total,
-                                                                left: total - passed - failed - skipped
+                                                                left: total - passed - failed - skipped - retries
                                                               })
                            );
         $('#testing-progress').html(Mustache.render(progress_template,

--- a/bots/task/sink.py
+++ b/bots/task/sink.py
@@ -39,7 +39,10 @@ class Sink(object):
         self.status = status
 
         # Start a gzip and cat processes
-        self.ssh = subprocess.Popen([ "ssh", host, "--", "python", "sink", identifier ], stdin=subprocess.PIPE)
+        self.ssh = subprocess.Popen([
+            "ssh", "-o", "ServerAliveInterval=30", host, "--",
+            "python", "sink", identifier
+        ], stdin=subprocess.PIPE)
 
         # Send the status line
         self.ssh.stdin.write(json.dumps(status).encode('utf-8') + b"\n")

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -387,6 +387,11 @@ def logs(revision):
         count = 0
         for status in data.get("statuses", [ ]):
             count += 1
+            # Make sure to not consider "state": "success" as a success
+            # here because individual tests may have failed, or been retried.
+            #
+            # Always only consider tests individually to have run or failed
+            # not entire test suite statuses
             if status["state"] in [ "pending" ]:
                 continue
             target = status["target_url"]

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -231,7 +231,7 @@ def seed(since, fp, pulls, output):
     while True:
         try:
             line = fp.readline()
-        except zlib.error as ex:
+        except (OSError, zlib.error) as ex:
             sys.stderr.write("tests-data: {0}\n".format(str(ex)))
             break
         if not line:

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -239,7 +239,7 @@ def seed(since, fp, pulls, output):
         try:
             item = json.loads(line.decode('utf-8'))
         except ValueError as ex:
-            sys.stderr.write("tests-data: {1}\n".format(str(ex)))
+            sys.stderr.write("tests-data: {0}\n".format(str(ex)))
             continue
 
         # Once we see a new pull treat the old one as complete and seeded

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -127,7 +127,7 @@ class PullTask(object):
             },
             "revision": self.github_revision,
             "link": "log.html",
-            "extras": [ "https://raw.githubusercontent.com/cockpit-project/cockpit/master/bots/task/log.html" ],
+            "extras": [ "https://raw.githubusercontent.com/cockpit-project/cockpit/{0}/bots/task/log.html".format(self.github_revision) ],
 
             "onaborted": {
                 "github": {

--- a/bots/tests-policy
+++ b/bots/tests-policy
@@ -91,7 +91,7 @@ def main():
 
         # Otherwise we filter the output and write it back
         if number:
-            output = filterSkip(output, "Known issue #{0}".format(number))
+            output = filterSkip(output, "# SKIP Known issue #{0}".format(number))
         elif checkRetry(output):
             output = filterRetry(output, "# RETRY due to failure of test harness or framework")
         else:
@@ -113,16 +113,16 @@ def filterSkip(output, skip):
     lines = output.split("\n")
     for i, line in enumerate(lines):
         if line.startswith("not ok "):
-            lines[i] = line[4:] + " # SKIP " + skip
+            lines[i] = line[4:] + " " + skip
     return "\n".join(lines)
 
-# Update TAP output failure and put a skip message
+# Update TAP output failure and put a retry message
 # in the appropriate place
-def filterRetry(output, prefix):
+def filterRetry(output, retry):
     lines = output.split("\n")
     for i, line in enumerate(lines):
-        if line.startswith("not ok ") or line.startswith("ok "):
-            lines[i] = prefix
+        if line.startswith("not ok "):
+            lines[i] = line + " " + retry
     return "\n".join(lines)
 
 # Figure out the name from a failed test
@@ -170,6 +170,7 @@ def guessFlake(output, context):
                 output += "\n# Flake probability: {0:.1f}% (neural network)\n".format(pred_proba[1] * 100)
 
     # The new model
+    flake = False
     if model:
         result = model.predict([ item ])[0]
         if result:
@@ -181,12 +182,15 @@ def guessFlake(output, context):
                 output += "\n# Flake unknown {0:.1f}% (clustering)\n".format(merged[1] * 100)
             elif merged[0]:
                 output += "\n# Flake likely {0:.1f}% (clustering)\n".format(merged[1] * 100)
+                flake = True
             else:
                 output += "\n# Flake unlikely {0:.1f}% (clustering)\n".format(merged[1] * 100)
             if analysis["trackers"]:
                 tracker = analysis["trackers"][0]
                 output += "\n# Flake tracked {0} likelihood {1:.1f} (clustering)\n".format(tracker[0], tracker[1])
 
+    if flake:
+        output = filterRetry(output, "# RETRY due to flakiness")
     return output
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Lets retry tests when they are seen as flaky by the clustering logic.
    
This adjusts the TAP output from the tests somewhat for retried tests
so that these still get registered as failures for the clustering logic
but don't apply to the success or failure of the entire test suite.

 * [x] learn-tests
 * [x] Look through the log output