### PR TITLE
oVirt: Fix spinner when installation dialog is canceled

### DIFF
--- a/pkg/ovirt/components/App.jsx
+++ b/pkg/ovirt/components/App.jsx
@@ -29,15 +29,35 @@ import { goToSubpage } from '../actions.es6';
 import hostToMaintenance from './HostToMaintenance.jsx';
 import HostStatus from './HostStatus.jsx';
 import { getHost } from "../selectors.es6";
+import CONFIG from '../config.es6';
 
 const _ = cockpit.gettext;
 
+const onReload = () => {
+    console.info('oVirt connection: page reload requested by user');
+    window.location.reload();
+};
+
 const LoginInProgress = ({ ovirtConfig }) => {
-    if (ovirtConfig && ovirtConfig.loginInProgress) {
+    if (!ovirtConfig) {
+        return null;
+    }
+
+    if (ovirtConfig.loginInProgress) {
         return (
             <p className='ovirt-login-in-progress'>
                 {_("oVirt login in progress") + '\xa0'}
                 <span className="spinner spinner-xs spinner-inline"></span>
+            </p>
+        );
+    }
+
+    if (!CONFIG.token) {
+        // i.e. after Cancel in Installation Dialog
+        return (
+            <p className='ovirt-login-in-progress'>
+                {_("No oVirt connection") + '\xa0'}
+                <a href="#" onClick={onReload}>{_("Reload")}</a>
             </p>
         );
     }

--- a/pkg/ovirt/components/InstallationDialog.jsx
+++ b/pkg/ovirt/components/InstallationDialog.jsx
@@ -89,9 +89,9 @@ const InstallationDialogBody = ({ values, onChange }) => {
             </table>
         </div>
     );
-}
+};
 
-function installationDialog() {
+function installationDialog({ onCancel }) {
     // TODO: check for root user (permission to write to configuration file)
 
     const values = {
@@ -103,14 +103,16 @@ function installationDialog() {
         { title: _("Connect to oVirt Engine"),
           body: <InstallationDialogBody values={values} onChange={() => dlg.render()}/>
         },
-        { actions: [
-            { caption: _("Register oVirt"),
-                style: 'primary',
-                clicked: () => {
-                    return configureOvirtUrl(values.oVirtUrl, values.oVirtPort);
-                }
-            }
-        ]
+        {
+            actions: [
+                {
+                    caption: _("Register oVirt"),
+                    style: 'primary',
+                    clicked: () => {
+                        return configureOvirtUrl(values.oVirtUrl, values.oVirtPort);
+                    }
+                }],
+            "cancel_clicked": () => onCancel && onCancel()
         });
 }
 

--- a/pkg/ovirt/configFuncs.es6
+++ b/pkg/ovirt/configFuncs.es6
@@ -46,13 +46,17 @@ export function readConfiguration ({ dispatch }) {
  * @param dispatch
  */
 function doReadConfiguration ({ dispatch }) {
+    const onCancel = () => {
+        dispatch(loginInProgress(false));
+    };
+
     // Configuration can be changed by admin after installation
     // and so is kept in separate file (out of manifest.json)
     return cockpit.file(OVIRT_CONF_FILE).read()
         .done((content) => {
             if (!content) {
                 console.info('Configuration file empty, post-installation setup follows to generate: ', OVIRT_CONF_FILE);
-                installationDialog();
+                installationDialog({ onCancel });
                 return;
             }
 
@@ -73,7 +77,7 @@ function doReadConfiguration ({ dispatch }) {
             return doLogin({ dispatch });
         }).fail( () => {
             console.info('Failed to read configuration, post-installation setup follows to generate: ', OVIRT_CONF_FILE);
-            installationDialog();
+            installationDialog({ onCancel });
         });
 }
 


### PR DESCRIPTION
When the user hits Cancel button in oVirt installation dialog (for FQDN and port),
proper message "No oVirt connection" is rendered. The user can Reload the page,
so the installation dialog is re-opened.

Fixes: https://github.com/cockpit-project/cockpit/issues/8515