### PR TITLE
polyfills: Add more polyfills for IE11

### DIFF
--- a/pkg/lib/polyfills.js
+++ b/pkg/lib/polyfills.js
@@ -43,6 +43,22 @@ if (!String.prototype.endsWith) {
 	};
 }
 
+// for IE 11
+if (!String.prototype.includes) {
+    String.prototype.includes = function(search, start) {
+        'use strict';
+        if (typeof start !== 'number') {
+            start = 0;
+        }
+
+        if (start + search.length > this.length) {
+            return false;
+        } else {
+            return this.indexOf(search, start) !== -1;
+        }
+    };
+}
+
 if (!Array.prototype.findIndex) {
     Array.prototype.findIndex = function (predicate) {
         if (this === null) {
@@ -142,3 +158,75 @@ if (!Array.prototype.find) {
         }
     });
 }
+
+// for IE 11
+// https://tc39.github.io/ecma262/#sec-array.prototype.includes
+if (!Array.prototype.includes) {
+    Object.defineProperty(Array.prototype, 'includes', {
+        value: function(searchElement, fromIndex) {
+
+            if (this === null) {
+                throw new TypeError('"this" is null or not defined');
+            }
+
+            // 1. Let O be ? ToObject(this value).
+            var o = Object(this);
+
+            // 2. Let len be ? ToLength(? Get(O, "length")).
+            var len = o.length >>> 0;
+
+            // 3. If len is 0, return false.
+            if (len === 0) {
+                return false;
+            }
+
+            // 4. Let n be ? ToInteger(fromIndex).
+            //    (If fromIndex is undefined, this step produces the value 0.)
+            var n = fromIndex | 0;
+
+            // 5. If n ≥ 0, then
+            //  a. Let k be n.
+            // 6. Else n < 0,
+            //  a. Let k be len + n.
+            //  b. If k < 0, let k be 0.
+            var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+
+            function sameValueZero(x, y) {
+                return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
+            }
+
+            // 7. Repeat, while k < len
+            while (k < len) {
+                // a. Let elementK be the result of ? Get(O, ! ToString(k)).
+                // b. If SameValueZero(searchElement, elementK) is true, return true.
+                if (sameValueZero(o[k], searchElement)) {
+                    return true;
+                }
+                // c. Increase k by 1.
+                k++;
+            }
+
+            // 8. Return false
+            return false;
+        }
+    });
+}
+
+// for IE11
+// from:https://github.com/jserz/js_piece/blob/master/DOM/ChildNode/remove()/remove().md
+(function (arr) {
+    arr.forEach(function (item) {
+        if (item.hasOwnProperty('remove')) {
+            return;
+        }
+        Object.defineProperty(item, 'remove', {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: function remove() {
+                if (this.parentNode !== null)
+                    this.parentNode.removeChild(this);
+            }
+        });
+    });
+})([global.Element.prototype, global.CharacterData.prototype, global.DocumentType.prototype]);


### PR DESCRIPTION
Element.remove(), Array.includes(), String.includes()

Required by IE11.
Recently referenced from:
 - cockpit-components-dialog.jsx: Element.remove()
 - machines Create VM Dialog all remaining

Fixes: https://github.com/cockpit-project/cockpit/issues/9024