### PR TITLE
Image refresh for fedora-atomic

### DIFF
--- a/bots/images/fedora-atomic
+++ b/bots/images/fedora-atomic
@@ -1,1 +1,1 @@
-fedora-atomic-f3526b8f73fdb1f1e52fe77e152dfb0a77caa9abb5078d9f3e82268d226a2ca3.qcow2
+fedora-atomic-08381a3559f5e17f01d0a40f8a826fdcec543910db4b48feb5409e16bfc2d58e.qcow2

--- a/bots/images/scripts/lib/atomic.install
+++ b/bots/images/scripts/lib/atomic.install
@@ -222,7 +222,8 @@ class AtomicCockpitInstaller:
 
     def run(self):
         # Delete previous deployment if it's present
-        output = subprocess.check_output(["ostree", "admin", "status"])
+        # HACK: this command fails with a GPG validation error (https://bugzilla.redhat.com/show_bug.cgi?id=1571264)
+        output = subprocess.check_output(["ostree admin status || true"], shell=True)
         if output.count("origin refspec") != 1:
             subprocess.check_call(["ostree", "admin", "undeploy", "1"])
 


### PR DESCRIPTION
Image refresh for fedora-atomic
 * [x] image-refresh fedora-atomic
 * [x] land [gpgme regression fix](https://bodhi.fedoraproject.org/updates/FEDORA-2018-5b1642fbbb) in Fedora [Atomic](https://ftp-stud.hs-esslingen.de/pub/Mirrors/alt.fedoraproject.org/atomic/stable/)