### PR TITLE
bots: Load a small number of seed tracked known issues

### DIFF
--- a/bots/learn-tests
+++ b/bots/learn-tests
@@ -35,6 +35,7 @@ sys.dont_write_bytecode = True
 
 import task
 import learn.data
+import learn.extractor
 
 BOTS = os.path.dirname(os.path.realpath(__file__))
 DATA = os.path.join(os.environ.get("TEST_DATA", BOTS), "images")
@@ -96,15 +97,8 @@ def loader(training_data, verbose, dry):
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
         inp = proc.stdout
 
-    def failures_without_tracker(item):
-        return item.get("status") == "failure" and item.get("tracker") is None
-
-    # TODO: For now we avoid everything that already has a tracker
-    # otherwise this results in too much data for our simple use
-    # of the DBSCAN algorithm ... later we can preselect certain
-    # values that have a tracker ... or use BIRCH
     try:
-        items = list(learn.data.load(inp, only=failures_without_tracker, verbose=verbose))
+        items = list(learn.data.load(inp, only=learn.extractor.select, verbose=verbose))
     finally:
         if proc:
             proc.wait()

--- a/bots/learn/cluster.py
+++ b/bots/learn/cluster.py
@@ -20,7 +20,7 @@
 
 # WARNING: As you change this code increment this version number so
 # the machine learning model uses a new place to store the model
-VERSION = 4
+VERSION = 5
 
 # This attempts to cluster log items related to similarity and then
 # classify whether new test logs fit into those clusters. The clustering
@@ -56,6 +56,8 @@ from learn import extractor
 # The name and version of the learning data
 FILENAME = "tests-learn-{0}-{1}.model".format(VERSION, extractor.VERSION)
 
+# Note that we use pickle protocol=4 to get over size limits
+
 # Load a model from the given directory
 # Return None of the model doesn't exist
 def load(directory):
@@ -72,7 +74,7 @@ def save(directory, model):
     (outfd, outname) = tempfile.mkstemp(prefix=FILENAME, dir=directory)
     os.close(outfd)
     with gzip.open(outname, 'wb') as fp:
-        pickle.dump(model, fp)
+        pickle.dump(model, fp, protocol=4)
     os.rename(outname, path)
     return path
 

--- a/bots/learn/cluster.py
+++ b/bots/learn/cluster.py
@@ -42,6 +42,7 @@ import pickle
 import random
 import sys
 import time
+import tempfile
 
 import sklearn.cluster
 import sklearn.neighbors
@@ -68,9 +69,11 @@ def load(directory):
 # Write a model to the given directory
 def save(directory, model):
     path = os.path.join(directory, FILENAME)
-    with gzip.open(path + ".tmp", 'wb') as fp:
+    (outfd, outname) = tempfile.mkstemp(prefix=FILENAME, dir=directory)
+    os.close(outfd)
+    with gzip.open(outname, 'wb') as fp:
         pickle.dump(model, fp)
-    os.rename(path + ".tmp", path)
+    os.rename(outname, path)
     return path
 
 # A cluster of items with optional analysis of those items

--- a/bots/learn/data.py
+++ b/bots/learn/data.py
@@ -58,5 +58,7 @@ def load(filename_or_fp, only=failures, limit=None, verbose=False):
             if limit is not None and count == limit:
                 return
     finally:
+        if verbose and count > 0:
+            sys.stderr.write("{0}: Items loaded\n".format(count))
         if opened:
             fp.close()

--- a/bots/learn/learn1.py
+++ b/bots/learn/learn1.py
@@ -28,6 +28,7 @@ import pickle
 import operator
 import os
 import re
+import tempfile
 
 from sklearn.neural_network import MLPClassifier
 from sklearn.preprocessing import StandardScaler
@@ -45,9 +46,11 @@ def load(directory):
 
 def save(directory, model):
     path = os.path.join(directory, FILENAME)
-    with gzip.open(path + ".tmp", 'wb') as fp:
+    (outfd, outname) = tempfile.mkstemp(prefix=FILENAME, dir=directory)
+    os.close(outfd)
+    with gzip.open(outname, 'wb') as fp:
         pickle.dump(model, fp)
-    os.rename(path + ".tmp", path)
+    os.rename(outname, path)
     return path
 
 # -----------------------------------------------------------------------------

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -250,7 +250,7 @@ def seed(since, fp, pulls, output):
             SEEDED.add(seeded)
             seeded = None
 
-        if pull and item["merged"] not in [ True, False ]:
+        if pull and item.get("merged") not in [ True, False ]:
             item["merged"] = pulls.merged(pull)
 
         # Note that we've already retrieved this URL

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -26,6 +26,7 @@ import re
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.parse
 import urllib.request, urllib.error, urllib.parse
@@ -61,12 +62,14 @@ def main():
 
     # Seed with our input data
     if opts.seed:
-        output = gzip.open(opts.seed + ".tmp", 'wb')
+        (outfd, outname) = tempfile.mkstemp(prefix=os.path.basename(opts.seed), dir=os.path.dirname(opts.seed))
+        os.close(outfd)
+        output = gzip.open(outname, 'wb')
         if os.path.exists(opts.seed):
             with gzip.open(opts.seed, 'rb') as fp:
                 seed(since, fp, pulls, output)
     else:
-        output = None
+        output = outname = None
 
     def write(**kwargs):
         line = json.dumps(kwargs).encode('utf-8') + b"\n"
@@ -102,7 +105,7 @@ def main():
     sys.stdout.flush()
     if output:
         output.close()
-        os.rename(opts.seed + ".tmp", opts.seed)
+        os.rename(outname, opts.seed)
 
 # An HTML parser that just pulls out all the <a href="...">
 # link hrefs in a given page of content. We also qualify these

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -195,7 +195,7 @@ class PullTask(object):
         try:
             # Download some additional necessary state
             subprocess.check_call([ os.path.join(BOTS, "image-download"),
-                "--state", "tests-learn-2.nn", "tests-learn-4-1.model"
+                "--state", "tests-learn-2.nn", "tests-learn-5-1.model"
             ])
 
         except subprocess.CalledProcessError:

--- a/bots/tests-policy
+++ b/bots/tests-policy
@@ -176,15 +176,12 @@ def guessFlake(output, context):
         if result:
             cluster = model.clusters[result[0]]
             analysis = cluster.analyze()
-            merged = analysis["merged"][0]
-            print(repr(merged))
-            if merged[0] is None:
-                output += "\n# Flake unknown {0:.1f}% (clustering)\n".format(merged[1] * 100)
-            elif merged[0]:
-                output += "\n# Flake likely {0:.1f}% (clustering)\n".format(merged[1] * 100)
+            merged = analysis["merged"]
+            if merged > learn.cluster.FLAKE_THRESHOLD:
+                output += "\n# Flake likely: {0:.1f}% (clustering). Please file issue if this not a flake\n".format(merged)
                 flake = True
             else:
-                output += "\n# Flake unlikely {0:.1f}% (clustering)\n".format(merged[1] * 100)
+                output += "\n# Flake probability: {0:.3f} (clustering)\n".format(merged)
             if analysis["trackers"]:
                 tracker = analysis["trackers"][0]
                 output += "\n# Flake tracked {0} likelihood {1:.1f} (clustering)\n".format(tracker[0], tracker[1])


### PR DESCRIPTION
When doing machine learning, seed the clusters with a small number of known issues. This lets us see whether certain clusters are related to already known issues or not.

 * [x] learn-tests
 * [x] Examine if the tracked items showed up in the cluster attachments or not.