### PR TITLE
kubernetes: Allow role names that contain colons

### DIFF
--- a/pkg/kubernetes/scripts/kube-client.js
+++ b/pkg/kubernetes/scripts/kube-client.js
@@ -67,7 +67,7 @@
     ]);
 
     var NAME_RE = /^[a-z0-9]([-a-z0-9_.]*[a-z0-9])?$/;
-    var USER_NAME_RE = /^[a-zA-Z0-9_.]([-a-zA-Z0-9 ,=@._]*[a-zA-Z0-9._])?$/;
+    var USER_NAME_RE = /^[a-zA-Z0-9_.]([-a-zA-Z0-9 ,=@._:]*[a-zA-Z0-9._:])?$/;
 
     /* Timeout for non-GET requests */
     var REQ_TIMEOUT = "120s";
@@ -1330,7 +1330,7 @@
                             if (check_re == NAME_RE) {
                                 ex = new Error("The name contains invalid characters. Only letters, numbers and dashes are allowed");
                             } else {
-                                ex = new Error("The name contains invalid characters. Only letters, numbers, spaces and the following symbols are allowed: , = @  . _");
+                                ex = new Error("The name contains invalid characters. Only letters, numbers, spaces and the following symbols are allowed: , = @  . _ :");
                             }
                     }
                     if (ex) {

--- a/pkg/kubernetes/scripts/projects.js
+++ b/pkg/kubernetes/scripts/projects.js
@@ -879,7 +879,7 @@
         'fields',
         function($q, $scope, projectData, projectPolicy, kselect, fields) {
             var selectMember = 'Select Member';
-            var NAME_RE = /^[a-z0-9_.]([-a-z0-9@._]*[a-z0-9._])?$/;
+            var NAME_RE = /^[a-z0-9_.]([-a-z0-9@._:]*[a-z0-9._:])?$/;
             var selectRole = 'Select Role';
             $scope.selected = {
                 member: selectMember,

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -1281,9 +1281,25 @@ class RegistryTests(object):
         testlib.wait(lambda: 'foo@bar.com' in o.execute("oc get rolebinding -n testprojectuserproj"), delay=5)
         self.assertNotIn('foo ^ bar', o.execute("oc get rolebinding -n testprojectuserproj"))
 
-        # it appears on the "All projects" page too
+        # service accounts should be accepted
+        b.wait_present("a i.pficon-add-circle-o")
+        b.click("a i.pficon-add-circle-o")
+        b.wait_present("modal-dialog")
+        b.wait_visible("#add_member_name")
+        b.set_val("#add_member_name", "system:janitor:default")
+        b.wait_visible("#add_role")
+        b.click("#add_role button")
+        b.wait_visible("#add_role .dropdown-menu")
+        b.click("#add_role a[value='Admin']")
+        b.click(".btn-primary")
+        b.wait_not_present("modal-dialog")
+        b.wait_present("tbody[data-id='system:janitor:default']")
+        testlib.wait(lambda: 'system:janitor:default' in o.execute("oc get rolebinding -n testprojectuserproj"), delay=5)
+
+        # they appear on the "All projects" page too
         b.go("#/projects/")
         b.wait_present("tbody[data-id='foo@bar.com']")
+        b.wait_present("tbody[data-id='system:janitor:default']")
 
         # try to add user with invalid name from "All projects" page
         b.click("#add-user")


### PR DESCRIPTION
This allows adding service accounts like
`system:serviceaccount:myproj:default`.

https://bugzilla.redhat.com/show_bug.cgi?id=1569348