### PR TITLE
Remove jshint leftovers

### DIFF
--- a/pkg/apps/packagekit.es6
+++ b/pkg/apps/packagekit.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/apps/utils.jsx
+++ b/pkg/apps/utils.jsx
@@ -23,10 +23,6 @@ import { show_modal_dialog } from "cockpit-components-dialog.jsx";
 
 const _ = cockpit.gettext;
 
-// Explicitly use React so that jshint doesn't complain.  The conversion to js inserts
-// references to React that jshint doesn't seem to see.
-React;
-
 export function left_click(fun) {
     return function (event) {
         if (!event || event.button !== 0)

--- a/pkg/kdump/config-client.es6
+++ b/pkg/kdump/config-client.es6
@@ -17,8 +17,6 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-  /* jshint esversion:6 */
-
 import cockpit from 'cockpit';
 
 /* Parse an ini-style config file

--- a/pkg/kdump/kdump-client.es6
+++ b/pkg/kdump/kdump-client.es6
@@ -17,8 +17,6 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
- /* jshint esversion:6 */
-
 import cockpit from 'cockpit';
 var _ = cockpit.gettext;
 import {proxy as serviceProxy} from 'service';

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx
@@ -31,8 +31,6 @@ import { vmActionFailed } from '../action-creators.jsx';
 // import DropdownButtons from '../../../../machines/components/dropdownButtons.jsx';
 import { mouseClick } from '../utils.jsx';
 
-React;
-
 const VmActions = ({ vm, onFailure }: { vm: Vm, onFailure: Function }) => {
     const id = vmIdPrefx(vm);
 

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmDisksTabKubevirt.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmDisksTabKubevirt.jsx
@@ -26,7 +26,6 @@ import type { Vm, PersistenVolume } from '../types.jsx';
 import { vmIdPrefx, getValueOrDefault } from '../utils.jsx';
 import VmDisksTab from '../../../../machines/components/vmDisksTab.jsx';
 
-React;
 const _ = cockpit.gettext;
 /**
  * Finds matching PersistentVolume for the given VM disk.

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmMessage.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmMessage.jsx
@@ -27,8 +27,6 @@ import { Alert } from '../../../../machines/components/notification/inlineNotifi
 
 import { removeVmMessage } from '../action-creators.jsx';
 
-React;
-
 const VmMessage = (({ vm, vmMessages, onDismiss }: { vm: Vm, vmMessages: VmMessages, onDismiss: Function }) => {
   if (!vmMessages) {
     return null;

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx
@@ -28,8 +28,6 @@ import { getPairs, NODE_LABEL, vmIdPrefx, getValueOrDefault } from '../utils.jsx
 
 import VmMessage from './VmMessage.jsx';
 
-React;
-
 function getNodeName(vm: Vm) {
     return (vm.metadata.labels && vm.metadata.labels[NODE_LABEL]) || null
 }

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx
@@ -28,8 +28,6 @@ import VmsListingRow from './VmsListingRow.jsx';
 import { getPod } from '../selectors.jsx';
 import CreateVmButton from './createVmButton.jsx';
 
-React;
-
 const VmsListing = ({ vms, pvs, pods, settings, vmsMessages }) => {
     const isOpenshift = settings.flavor === 'openshift';
     const namespaceLabel = isOpenshift ? _("Project") : _("Namespace");

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx
@@ -33,8 +33,6 @@ import { NODE_LABEL, vmIdPrefx } from '../utils.jsx';
 import { vmExpanded } from "../action-creators.jsx";
 import { getValueOrDefault } from "../utils.jsx";
 
-React;
-
 const VmsListingRow = ({ vm, vmMessages, pvs, pod, vmUi, onExpandChanged }:
                            { vm: Vm, vmMessages: VmMessages, pvs: PersistenVolumes, pod: Pod, onExpandChanged: Function }) => {
     const node = (vm.metadata.labels && vm.metadata.labels[NODE_LABEL]) || '-';

--- a/pkg/lib/machine-info.es6
+++ b/pkg/lib/machine-info.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/lib/packagekit.es6
+++ b/pkg/lib/packagekit.es6
@@ -1,5 +1,3 @@
-/*jshint esversion: 6 */
-
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/actions.es6
+++ b/pkg/machines/actions.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/app.jsx
+++ b/pkg/machines/app.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/c3charts.jsx
+++ b/pkg/machines/c3charts.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/consoles.jsx
+++ b/pkg/machines/components/consoles.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/create-vm-dialog/createVmDialogUtils.es6
+++ b/pkg/machines/components/create-vm-dialog/createVmDialogUtils.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/create-vm-dialog/uiState.es6
+++ b/pkg/machines/components/create-vm-dialog/uiState.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/deleteDialog.jsx
+++ b/pkg/machines/components/deleteDialog.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/deleteDialog.jsx
+++ b/pkg/machines/components/deleteDialog.jsx
@@ -26,10 +26,6 @@ import './deleteDialog.css';
 
 const _ = cockpit.gettext;
 
-// Explicitly use React so that jshint doesn't complain.  The conversion to js inserts
-// references to React that jshint doesn't seem to see.
-React;
-
 const DeleteDialogBody = ({ values, onChange }) => {
     function disk_row(disk) {
         return (

--- a/pkg/machines/components/desktopConsole.jsx
+++ b/pkg/machines/components/desktopConsole.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/dropdownButtons.jsx
+++ b/pkg/machines/components/dropdownButtons.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/dropdownButtons.jsx
+++ b/pkg/machines/components/dropdownButtons.jsx
@@ -20,8 +20,6 @@ import React, { PropTypes } from "react";
 import { mouseClick } from '../helpers.es6';
 import './dropdownButtons.css';
 
-React;
-
 /**
  * Render group of buttons as a dropdown
  *

--- a/pkg/machines/components/infoRecord.jsx
+++ b/pkg/machines/components/infoRecord.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/infoRecord.jsx
+++ b/pkg/machines/components/infoRecord.jsx
@@ -19,8 +19,6 @@
 
 import React, { PropTypes } from "react";
 
-React;
-
 const InfoRecord = ({id, descr, value, descrClass, valueClass}) => {
     return (<tr>
         <td className={descrClass || 'top'}>

--- a/pkg/machines/components/libvirtSlate.jsx
+++ b/pkg/machines/components/libvirtSlate.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/notification/inlineNotification.jsx
+++ b/pkg/machines/components/notification/inlineNotification.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/notification/notificationArea.jsx
+++ b/pkg/machines/components/notification/notificationArea.jsx
@@ -20,8 +20,6 @@
 import React, { PropTypes } from "react";
 import { Notification, NotificationMessage } from "./notification.jsx";
 
-React;
-
 const NotificationArea = ({ notifications, onDismiss, id }) => {
     if (!notifications || notifications.length === 0) {
         return null;

--- a/pkg/machines/components/serialConsole.jsx
+++ b/pkg/machines/components/serialConsole.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/vm/dummyVm.jsx
+++ b/pkg/machines/components/vm/dummyVm.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/vm/dummyVm.jsx
+++ b/pkg/machines/components/vm/dummyVm.jsx
@@ -25,8 +25,6 @@ import {
 import StateIcon from './stateIcon.jsx';
 import { ListingRow } from "cockpit-components-listing.jsx";
 
-React;
-
 /** One Ui Dummy VM in the list (a row)
  */
 const DummyVm = ({ vm }) => {

--- a/pkg/machines/components/vm/stateIcon.jsx
+++ b/pkg/machines/components/vm/stateIcon.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/vm/stateIcon.jsx
+++ b/pkg/machines/components/vm/stateIcon.jsx
@@ -24,8 +24,6 @@ import {
 
 const _ = cockpit.gettext;
 
-React;
-
 const StateIcon = ({ state, config, valueId, extra }) => {
     if (state === undefined) {
         return (<div/>);

--- a/pkg/machines/components/vm/vm.jsx
+++ b/pkg/machines/components/vm/vm.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/vm/vm.jsx
+++ b/pkg/machines/components/vm/vm.jsx
@@ -34,8 +34,6 @@ import { ListingRow } from "cockpit-components-listing.jsx";
 
 const _ = cockpit.gettext;
 
-React;
-
 /** One VM in the list (a row)
  */
 const Vm = ({ vm, config, hostDevices, onStart, onInstall, onShutdown, onForceoff, onReboot, onForceReboot,

--- a/pkg/machines/components/vm/vmActions.jsx
+++ b/pkg/machines/components/vm/vmActions.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/vm/vmActions.jsx
+++ b/pkg/machines/components/vm/vmActions.jsx
@@ -29,8 +29,6 @@ import DropdownButtons from '../dropdownButtons.jsx';
 
 const _ = cockpit.gettext;
 
-React;
-
 const VmActions = ({ vm, config, dispatch, onStart, onInstall, onReboot, onForceReboot, onShutdown, onForceoff, onSendNMI }) => {
     const id = vmId(vm.name);
     const state = vm.state;

--- a/pkg/machines/components/vm/vmUsageTab.jsx
+++ b/pkg/machines/components/vm/vmUsageTab.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/vmDiskSourceCell.jsx
+++ b/pkg/machines/components/vmDiskSourceCell.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/vmDiskSourceCell.jsx
+++ b/pkg/machines/components/vmDiskSourceCell.jsx
@@ -21,7 +21,6 @@ import cockpit from 'cockpit';
 
 import InfoRecord from './infoRecord.jsx';
 
-React;
 const _ = cockpit.gettext;
 
 const DiskSourceCell = ({ diskSource, idPrefix }) => {

--- a/pkg/machines/components/vmDisksTab.jsx
+++ b/pkg/machines/components/vmDisksTab.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/vmDisksTab.jsx
+++ b/pkg/machines/components/vmDisksTab.jsx
@@ -22,7 +22,6 @@ import { Listing, ListingRow } from 'cockpit-components-listing.jsx';
 import { Info } from './notification/inlineNotification.jsx';
 import { convertToUnit, toReadableNumber, units } from "../helpers.es6";
 
-React;
 const _ = cockpit.gettext;
 
 const DiskTotal = ({ disks, idPrefix }) => {

--- a/pkg/machines/components/vmDisksTabLibvirt.jsx
+++ b/pkg/machines/components/vmDisksTabLibvirt.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/vmDisksTabLibvirt.jsx
+++ b/pkg/machines/components/vmDisksTabLibvirt.jsx
@@ -23,7 +23,6 @@ import { vmId } from '../helpers.es6';
 import VmDisksTab from './vmDisksTab.jsx';
 import DiskSourceCell from './vmDiskSourceCell.jsx';
 
-React;
 const _ = cockpit.gettext;
 
 class VmDisksTabLibvirt extends React.Component {

--- a/pkg/machines/components/vmLastMessage.jsx
+++ b/pkg/machines/components/vmLastMessage.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/vmLastMessage.jsx
+++ b/pkg/machines/components/vmLastMessage.jsx
@@ -21,8 +21,6 @@ import { vmId } from '../helpers.es6';
 import { deleteVmMessage } from '../actions.es6';
 import { Alert } from './notification/inlineNotification.jsx';
 
-React;
-
 const VmLastMessage = ({ vm, dispatch }) => {
     if (!vm.lastMessage) {
         return null;

--- a/pkg/machines/components/vmOverviewTab.jsx
+++ b/pkg/machines/components/vmOverviewTab.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/vmOverviewTab.jsx
+++ b/pkg/machines/components/vmOverviewTab.jsx
@@ -21,8 +21,6 @@ import React, { PropTypes } from "react";
 
 const _ = cockpit.gettext;
 
-React;
-
 const Items = ({ items, idPrefix, divider, colClass }) => {
     if (!items) {
         return null;

--- a/pkg/machines/components/vmOverviewTabLibvirt.jsx
+++ b/pkg/machines/components/vmOverviewTabLibvirt.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/components/vmOverviewTabLibvirt.jsx
+++ b/pkg/machines/components/vmOverviewTabLibvirt.jsx
@@ -26,8 +26,6 @@ import { rephraseUI, vmId } from "../helpers.es6";
 
 const _ = cockpit.gettext;
 
-React;
-
 function getBootOrder(vm) {
     let bootOrder = _("No boot device found");
     if (vm.bootOrder && vm.bootOrder.devices && vm.bootOrder.devices.length > 0) {

--- a/pkg/machines/components/vnc.jsx
+++ b/pkg/machines/components/vnc.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/config.es6
+++ b/pkg/machines/config.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/helpers.es6
+++ b/pkg/machines/helpers.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/index.es6
+++ b/pkg/machines/index.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/libvirt.es6
+++ b/pkg/machines/libvirt.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/libvirtUtils.es6
+++ b/pkg/machines/libvirtUtils.es6
@@ -1,5 +1,3 @@
-/*jshint esversion: 6 */
-
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/middlewares.es6
+++ b/pkg/machines/middlewares.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/provider.es6
+++ b/pkg/machines/provider.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/reducers.es6
+++ b/pkg/machines/reducers.es6
@@ -1,4 +1,3 @@
-    /*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/services.es6
+++ b/pkg/machines/services.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/store.es6
+++ b/pkg/machines/store.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/machines/vmnetworktab.jsx
+++ b/pkg/machines/vmnetworktab.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/actions.es6
+++ b/pkg/ovirt/actions.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/components/App.jsx
+++ b/pkg/ovirt/components/App.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/components/ClusterTemplates.jsx
+++ b/pkg/ovirt/components/ClusterTemplates.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/components/ClusterTemplates.jsx
+++ b/pkg/ovirt/components/ClusterTemplates.jsx
@@ -29,7 +29,6 @@ import { logDebug } from '../../machines/helpers.es6';
 const NoTemplate = () => (<div>{_("No VM found in oVirt.")}</div>);
 const NoTemplateUnitialized = () => (<div>{_("Please wait till list of templates is loaded from the server.")}</div>);
 
-React;
 const _ = cockpit.gettext;
 
 class CreateVmFromTemplate extends React.Component {

--- a/pkg/ovirt/components/ClusterVms.jsx
+++ b/pkg/ovirt/components/ClusterVms.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/components/ClusterVms.jsx
+++ b/pkg/ovirt/components/ClusterVms.jsx
@@ -30,7 +30,6 @@ import { startVm, goToSubpage } from '../actions.es6';
 import rephraseUI from '../rephraseUI.es6';
 import { getCurrentCluster, getHost } from '../selectors.es6';
 
-React;
 const _ = cockpit.gettext;
 
 const NoVm = () => (<div>{_("No VM found in oVirt.")}</div>);

--- a/pkg/ovirt/components/ConfirmButtons.jsx
+++ b/pkg/ovirt/components/ConfirmButtons.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/components/ConfirmButtons.jsx
+++ b/pkg/ovirt/components/ConfirmButtons.jsx
@@ -18,8 +18,6 @@
  */
 import React from "react";
 
-React;
-
 // TODO: replace this by Cockpit's modal dialog
 const ConfirmButtons = ({ confirmText, dismissText, onYes, onNo }) => {
     return (

--- a/pkg/ovirt/components/ConsoleClientResources.jsx
+++ b/pkg/ovirt/components/ConsoleClientResources.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/components/ConsoleClientResources.jsx
+++ b/pkg/ovirt/components/ConsoleClientResources.jsx
@@ -21,7 +21,6 @@ import React from "react";
 
 import CONFIG from '../config.es6';
 
-React;
 const _ = cockpit.gettext;
 
 const ConsoleClientResources = ({ vm, providerState }) => {

--- a/pkg/ovirt/components/HostStatus.jsx
+++ b/pkg/ovirt/components/HostStatus.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/components/HostStatus.jsx
+++ b/pkg/ovirt/components/HostStatus.jsx
@@ -23,7 +23,6 @@ import rephraseUI from '../rephraseUI.es6';
 
 import './HostStatus.css';
 
-React;
 const _ = cockpit.gettext;
 
 const HostStatus = ({ host }) => {

--- a/pkg/ovirt/components/HostToMaintenance.jsx
+++ b/pkg/ovirt/components/HostToMaintenance.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/components/HostToMaintenance.jsx
+++ b/pkg/ovirt/components/HostToMaintenance.jsx
@@ -26,8 +26,6 @@ import { switchHostToMaintenance } from '../actions.es6';
 
 const _ = cockpit.gettext;
 
-React;
-
 const hostToMaintenanceDialog = (dispatch, host) => {
     const hostId = host && host.id;
 

--- a/pkg/ovirt/components/InstallationDialog.jsx
+++ b/pkg/ovirt/components/InstallationDialog.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/components/InstallationDialog.jsx
+++ b/pkg/ovirt/components/InstallationDialog.jsx
@@ -31,8 +31,6 @@ import './InstallationDialog.css';
 
 const _ = cockpit.gettext;
 
-React;
-
 const INSTALL_SH_ERRORS = {
     '1': _("oVirt Provider installation script failed due to missing arguments."),
     '3': _("oVirt Provider installation script failed: Can't write to /etc/cockpit/machines-ovirt.config, try as root."),

--- a/pkg/ovirt/components/OVirtTab.jsx
+++ b/pkg/ovirt/components/OVirtTab.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/components/OVirtTab.jsx
+++ b/pkg/ovirt/components/OVirtTab.jsx
@@ -27,7 +27,6 @@ import ConfirmButtons from './ConfirmButtons.jsx';
 import VmProperty from '../../machines/components/infoRecord.jsx';
 import rephraseUI from '../rephraseUI.es6';
 
-React;
 const _ = cockpit.gettext;
 
 import './OVirtTab.css';

--- a/pkg/ovirt/components/VdsmView.jsx
+++ b/pkg/ovirt/components/VdsmView.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/components/VdsmView.jsx
+++ b/pkg/ovirt/components/VdsmView.jsx
@@ -24,7 +24,6 @@ import './VdsmView.css';
 import { VDSM_CONF_FILE } from '../config.es6';
 import { logDebug, logError } from '../../machines/helpers.es6';
 
-React;
 const _ = cockpit.gettext;
 
 class VdsmConf extends React.Component { // TODO: needs design

--- a/pkg/ovirt/components/VmActions.jsx
+++ b/pkg/ovirt/components/VmActions.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/components/VmActions.jsx
+++ b/pkg/ovirt/components/VmActions.jsx
@@ -22,7 +22,6 @@ import React from "react";
 import { suspendVm } from '../actions.es6';
 import { vmId } from '../../machines/helpers.es6';
 
-React;
 const _ = cockpit.gettext;
 
 const VmActions = ({ vm, providerState, dispatch }) => {

--- a/pkg/ovirt/components/VmOverviewColumn.jsx
+++ b/pkg/ovirt/components/VmOverviewColumn.jsx
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/components/VmOverviewColumn.jsx
+++ b/pkg/ovirt/components/VmOverviewColumn.jsx
@@ -21,7 +21,6 @@ import React from "react";
 
 import { formatDateTime } from '../helpers.es6';
 
-React;
 const _ = cockpit.gettext;
 
 import './VmOverviewColumn.css';

--- a/pkg/ovirt/config.es6
+++ b/pkg/ovirt/config.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/configFuncs.es6
+++ b/pkg/ovirt/configFuncs.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/helpers.es6
+++ b/pkg/ovirt/helpers.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/index.es6
+++ b/pkg/ovirt/index.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/ovirt.es6
+++ b/pkg/ovirt/ovirt.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/ovirtApiAccess.es6
+++ b/pkg/ovirt/ovirtApiAccess.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/ovirtConverters.es6
+++ b/pkg/ovirt/ovirtConverters.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/provider.es6
+++ b/pkg/ovirt/provider.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/reducers.es6
+++ b/pkg/ovirt/reducers.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/rephraseUI.es6
+++ b/pkg/ovirt/rephraseUI.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/selectors.es6
+++ b/pkg/ovirt/selectors.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/ovirt/store.es6
+++ b/pkg/ovirt/store.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *

--- a/pkg/packagekit/mock-updates.es6
+++ b/pkg/packagekit/mock-updates.es6
@@ -1,5 +1,3 @@
-/*jshint esversion: 6 */
-
 /*
  * Mock "available updates" entries for interactively testing layout changes with large updates
  * To use it, import it in updates.jsx:

--- a/pkg/storaged/clevis-dialogs.jsx
+++ b/pkg/storaged/clevis-dialogs.jsx
@@ -18,7 +18,7 @@
  */
 
 import cockpit from "cockpit";
-import React from "react"; React;
+import React from "react";
 
 import { dialog_open, TextInput, PassInput } from "./dialogx.jsx";
 

--- a/pkg/storaged/dialogx.jsx
+++ b/pkg/storaged/dialogx.jsx
@@ -124,7 +124,7 @@
 import cockpit from "cockpit";
 const _ = cockpit.gettext;
 
-import React from "react"; React;
+import React from "react";
 
 import { show_modal_dialog } from "cockpit-components-dialog.jsx";
 

--- a/pkg/systemd/hw-detect.es6
+++ b/pkg/systemd/hw-detect.es6
@@ -1,4 +1,3 @@
-/*jshint esversion: 6 */
 /*
  * This file is part of Cockpit.
  *


### PR DESCRIPTION
Since `eslint` replaced `jshint` for `.jsx` and `.es6` files [1], explicit use of `React` or setting of jshint version
is no more needed.

[1] https://github.com/cockpit-project/cockpit/pull/9000