### PR TITLE
test: Wait for volume groups panel to appear before looking into it

### DIFF
--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -47,6 +47,7 @@ class TestStorage(StorageCase):
 
         # Create a volume group out of two disks
         m.execute("vgcreate TEST1 %s %s" % (dev_1, dev_2))
+        b.wait_present("#vgroups")
         b.wait_in_text("#vgroups", "TEST1")
         b.click('tr:contains("TEST1")')
         b.wait_visible("#storage-detail")

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -42,6 +42,7 @@ class TestStorage(StorageCase):
 
         m.execute("vgcreate TEST /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1")
         m.execute("lvcreate TEST -n vol -L 200m")
+        b.wait_present("#vgroups")
         b.wait_in_text("#vgroups", "TEST")
         b.click('#vgroups tr:contains("TEST")')
         b.wait_visible("#storage-detail")

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -40,6 +40,7 @@ class TestStorage(StorageCase):
         m.add_disk("10G", serial="DISK1")
         b.wait_in_text("#drives", "DISK1")
         m.execute("vgcreate vdo_vgroup /dev/sda && lvcreate -n lvol -L 5G vdo_vgroup")
+        b.wait_present("#vgroups")
         b.wait_in_text("#vgroups", "vdo_vgroup")
 
         # Create VDO


### PR DESCRIPTION
This shouldn't be necessary since the page is supposed to come up with all optional features fully enabled or disabled.  Still, I have seen tests fail that might be explained by this race...

So my plan is to put this in to rule out a race during page construction, and if we still see failures where '#vgroups' doesn't show up as expected, we know it's something else.