### PR TITLE
eslint: Ignore JSX attribute indention

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,8 @@
             {
                 "ObjectExpression": "first",
                 "CallExpression": {"arguments": "first"},
-                "MemberExpression": 2
+                "MemberExpression": 2,
+                "ignoredNodes": [ "JSXAttribute" ]
             }],
         "react/jsx-indent-props": "off",
         "react/jsx-indent": "off",

--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -69,7 +69,7 @@ class ApplicationRow extends React.Component {
                         {comp.summary}
                         <div className="alert alert-danger alert-dismissable">
                             <button className="close"
-                                onClick={left_click(() => { this.setState({ error: null }) })}>
+                                    onClick={left_click(() => { this.setState({ error: null }) })}>
                                 <span className="pficon pficon-close"/>
                             </button>
                             <span className="pficon pficon-error-circle-o"/>

--- a/pkg/apps/utils.jsx
+++ b/pkg/apps/utils.jsx
@@ -81,8 +81,8 @@ export const ProgressBar = ({ title, data }) => {
 export const CancelButton = ({ data }) => {
     return (
         <button className="btn btn-default"
-            disabled={!data.cancel}
-            onClick={left_click(data.cancel)}>
+                disabled={!data.cancel}
+                onClick={left_click(data.cancel)}>
             {_("Cancel")}
         </button>
     );

--- a/pkg/docker/containers-view.jsx
+++ b/pkg/docker/containers-view.jsx
@@ -102,11 +102,11 @@ var ContainerHeader = React.createClass({
                     <Select.SelectEntry data='running'>{_("Images and running containers")}</Select.SelectEntry>
                 </Select.Select>
                 <input type="text"
-                    id="containers-filter"
-                    ref="filterTextInput"
-                    className="form-control"
-                    placeholder={_("Type to filter…")}
-                    onChange={this.handleFilterTextChange} />
+                       id="containers-filter"
+                       ref="filterTextInput"
+                       className="form-control"
+                       placeholder={_("Type to filter…")}
+                       onChange={this.handleFilterTextChange} />
             </div>
         );
     }
@@ -310,11 +310,11 @@ var ContainerList = React.createClass({
 
             var actions = [
                 <button className="btn btn-danger btn-delete pficon pficon-delete"
-                    onClick={ this.deleteContainer.bind(this, container) } />,
+                        onClick={ this.deleteContainer.bind(this, container) } />,
                 <button className="btn btn-default"
-                    disabled={isRunning}
-                    data-container-id={container.Id}
-                    data-toggle="modal" data-target="#container-commit-dialog">
+                        disabled={isRunning}
+                        data-container-id={container.Id}
+                        data-toggle="modal" data-target="#container-commit-dialog">
                     {_("Commit")}
                 </button>,
                 <Dropdown actions={startStopActions} />
@@ -339,10 +339,10 @@ var ContainerList = React.createClass({
             }
 
             return <Listing.ListingRow key={container.Id}
-                columns={columns}
-                tabRenderers={tabs}
-                navigateToItem={ this.navigateToContainer.bind(this, container) }
-                listingActions={actions}/>;
+                                       columns={columns}
+                                       tabRenderers={tabs}
+                                       navigateToItem={ this.navigateToContainer.bind(this, container) }
+                                       listingActions={actions}/>;
         }, this);
 
         var columnTitles = [_("Name"), _("Image"), _("Command"), _("CPU"), _("Memory"), _("State")];
@@ -638,15 +638,15 @@ var ImageList = React.createClass({
 
         var actions = [
             <button className="btn btn-danger btn-delete pficon pficon-delete"
-                onClick={ this.deleteImage.bind(this, image) } />
+                    onClick={ this.deleteImage.bind(this, image) } />
         ];
 
         return <Listing.ListingRow key={image.Id}
-            rowId={image.Id}
-            columns={columns}
-            tabRenderers={tabs}
-            navigateToItem={ this.navigateToImage.bind(this, image) }
-            listingActions={actions}/>;
+                                   rowId={image.Id}
+                                   columns={columns}
+                                   tabRenderers={tabs}
+                                   navigateToItem={ this.navigateToImage.bind(this, image) }
+                                   listingActions={actions}/>;
     },
 
     render: function () {

--- a/pkg/docker/storage.jsx
+++ b/pkg/docker/storage.jsx
@@ -171,7 +171,7 @@
                 drive_rows.push(
                     <tr onClick={self.toggleDrive.bind(self, drive)}>
                         <td><input type="checkbox"
-                            checked={self.driveChecked(drive)}/>
+                                   checked={self.driveChecked(drive)}/>
                         </td>
                         <td><img role="presentation" src="images/drive-harddisk-symbolic.svg"/></td>
                         <td>
@@ -202,8 +202,8 @@
                     </div>
                     <div className="drives-panel-footer">
                         <button className="btn btn-primary"
-                            disabled={ !button_enabled }
-                            onClick={ self.onButtonClicked }>{_("Add Storage")}</button>
+                                disabled={ !button_enabled }
+                                onClick={ self.onButtonClicked }>{_("Add Storage")}</button>
                     </div>
                 </div>
             );

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -87,9 +87,9 @@ var KdumpTargetBody = React.createClass({
                     </td>
                     <td>
                         <input id="kdump-settings-local-directory" className="form-control" type="text"
-                            placeholder="/var/crash" value={directory}
-                            data-stored={directory}
-                            onChange={this.changeValue.bind(this, "path")}/>
+                               placeholder="/var/crash" value={directory}
+                               data-stored={directory}
+                               onChange={this.changeValue.bind(this, "path")}/>
                     </td>
                 </tr>
             );
@@ -107,8 +107,8 @@ var KdumpTargetBody = React.createClass({
                     <td>
                         <label>
                             <input id="kdump-settings-nfs-mount" className="form-control" type="text"
-                                placeholder="penguin.example.com:/export/cores" value={nfs}
-                                onChange={this.changeValue.bind(this, "nfs")}/>
+                                   placeholder="penguin.example.com:/export/cores" value={nfs}
+                                   onChange={this.changeValue.bind(this, "nfs")}/>
                         </label>
                     </td>
                 </tr>
@@ -130,8 +130,8 @@ var KdumpTargetBody = React.createClass({
                     <td>
                         <label>
                             <input id="kdump-settings-ssh-server" className="form-control" type="text"
-                                placeholder="user@server.com" value={ssh}
-                                onChange={this.changeValue.bind(this, "ssh")}/>
+                                   placeholder="user@server.com" value={ssh}
+                                   onChange={this.changeValue.bind(this, "ssh")}/>
                         </label>
                     </td>
                 </tr>),
@@ -144,8 +144,8 @@ var KdumpTargetBody = React.createClass({
                     <td>
                         <label>
                             <input id="kdump-settings-ssh-server" className="form-control" type="text"
-                                placeholder="/root/.ssh/kdump_id_rsa" value={sshkey}
-                                onChange={this.changeValue.bind(this, "sshkey")}/>
+                                   placeholder="/root/.ssh/kdump_id_rsa" value={sshkey}
+                                   onChange={this.changeValue.bind(this, "sshkey")}/>
                         </label>
                     </td>
                 </tr>),
@@ -176,7 +176,7 @@ var KdumpTargetBody = React.createClass({
                         </td>
                         <td>
                             <Select.Select key='location' onChange={this.changeLocation}
-                                id="kdump-settings-location" initial={storageDest}>
+                                           id="kdump-settings-location" initial={storageDest}>
                                 <Select.SelectEntry data='local' key='local'>{targetDescription.local}</Select.SelectEntry>
                                 <Select.SelectEntry data='other' key='other'>{targetDescription.other}</Select.SelectEntry>
                             </Select.Select>
@@ -193,8 +193,8 @@ var KdumpTargetBody = React.createClass({
                             <div className="checkbox">
                                 <label>
                                     <input id="kdump-settings-compression" type="checkbox" checked={this.props.compressionEnabled}
-                                        onChange={this.handleCompressionClick.bind(this)}
-                                        enabled={compressionPossible}/>
+                                           onChange={this.handleCompressionClick.bind(this)}
+                                           enabled={compressionPossible}/>
                                     {_("Compress crash dumps to save space")}
                                 </label>
                             </div>

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmDisksTabKubevirt.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmDisksTabKubevirt.jsx
@@ -91,8 +91,8 @@ const VmDisksTabKubevirt = ({ vm, pvs }: { vm: Vm, pvs: Array<PersistenVolume> }
 
     return (
         <VmDisksTab idPrefix={idPrefix}
-            disks={disks}
-            renderCapacity={true}/>
+                    disks={disks}
+                    renderCapacity={true}/>
     );
 };
 

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx
@@ -84,8 +84,8 @@ const VmOverviewTabKubevirt = ({ vm, vmMessages, pod }: { vm: Vm, vmMessages: Vm
         {title: _("Pod:"), value: podLink, idPostfix: 'pod'},
     ];
     return (<VmOverviewTab message={message}
-        idPrefix={idPrefix}
-        items={items} />);
+                           idPrefix={idPrefix}
+                           items={items} />);
 };
 
 export default VmOverviewTabKubevirt;

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx
@@ -32,19 +32,19 @@ const VmsListing = ({ vms, pvs, pods, settings, vmsMessages }) => {
     const isOpenshift = settings.flavor === 'openshift';
     const namespaceLabel = isOpenshift ? _("Project") : _("Namespace");
     const rows = vms.map(vm => (<VmsListingRow vm={vm}
-        vmMessages={vmsMessages[vm.metadata.uid]}
-        pod={getPod(vm, pods)}
-        pvs={pvs}
-        key={vm.metadata.uid} />));
+                                               vmMessages={vmsMessages[vm.metadata.uid]}
+                                               pod={getPod(vm, pods)}
+                                               pvs={pvs}
+                                               key={vm.metadata.uid} />));
     let actions = [(
         <CreateVmButton/>
     )];
 
     return (
         <Listing title={_("Virtual Machines")}
-            emptyCaption={_("No virtual machines")}
-            actions={actions}
-            columnTitles={[_("Name"), namespaceLabel, _("Node"), _("State")]}>
+                 emptyCaption={_("No virtual machines")}
+                 actions={actions}
+                 columnTitles={[_("Name"), namespaceLabel, _("Node"), _("State")]}>
             {rows}
         </Listing>
     );

--- a/pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx
@@ -213,23 +213,23 @@ class CreateVmDialog extends React.Component {
                         <a>
                             {_("upload a JSON file")}
                             <input id="file-input" type="file" className="hide"
-                                accept=".json,.txt"
-                                onChange={this.onNewFileEvent}/>
+                                   accept=".json,.txt"
+                                   onChange={this.onNewFileEvent}/>
                         </a>
                     </label>
                     {_(" or drag & drop.")}
                 </div>
                 <div id={DROP_ZONE_ID}
-                    onDrop={this.onDrop}>
+                     onDrop={this.onDrop}>
                     <div className={"form-group " + formGroupClassNames}>
                         <div className="drop-container">
                             {dropZoneOverlay}
                             {overDropZoneOverlay}
                             <textarea id="resource-text"
-                                key="resource-text"
-                                className={"form-control " + textAreaClassName}
-                                value={this.state.resource}
-                                onChange={this.onResourceChanged}/>
+                                      key="resource-text"
+                                      className={"form-control " + textAreaClassName}
+                                      value={this.state.resource}
+                                      onChange={this.onResourceChanged}/>
                         </div>
                         {resourceErrorLabel}
                     </div>

--- a/pkg/lib/cockpit-components-select.jsx
+++ b/pkg/lib/cockpit-components-select.jsx
@@ -158,10 +158,10 @@
         render() {
             return (
                 <StatelessSelect onChange={this.onChange}
-                    selected={this.state.currentData}
-                    id={this.props.id}
-                    enabled={this.props.enabled}
-                    extraClass={this.props.extraClass}>
+                                 selected={this.state.currentData}
+                                 id={this.props.id}
+                                 enabled={this.props.enabled}
+                                 extraClass={this.props.extraClass}>
                     {this.props.children}
                 </StatelessSelect>
             );

--- a/pkg/lib/cockpit-components-terminal.jsx
+++ b/pkg/lib/cockpit-components-terminal.jsx
@@ -108,10 +108,10 @@
         render: function () {
             // ensure react never reuses this div by keying it with the terminal widget
             return <div ref="terminal"
-                key={this.state.terminal}
-                className="console-ct"
-                onFocusIn={this.onFocusIn}
-                onFocusOut={this.onFocusOut} />;
+                        key={this.state.terminal}
+                        className="console-ct"
+                        onFocusIn={this.onFocusIn}
+                        onFocusOut={this.onFocusOut} />;
         },
 
         componentWillUnmount: function () {

--- a/pkg/lib/cockpit-components-tooltip.jsx
+++ b/pkg/lib/cockpit-components-tooltip.jsx
@@ -140,8 +140,8 @@ var Tooltip = React.createClass({
         return (
             <div className="tooltip-ct-outer">
                 <div className="tooltip-ct-inner"
-                    onMouseover={this.onMouseover}
-                    onMouseout={this.onMouseout}>
+                     onMouseover={this.onMouseover}
+                     onMouseout={this.onMouseout}>
                     {self.props.children}
                 </div>
                 <div ref={fixDOMElements} className={classes} style={{ top: 0, left: -10000 }}>

--- a/pkg/machines/components/consoles.jsx
+++ b/pkg/machines/components/consoles.jsx
@@ -76,9 +76,9 @@ const ConsoleSelector = ({ onChange, selected, isSerialConsole, vm }) => {
                 </td>
                 <td>
                     <Select.StatelessSelect id="console-type-select"
-                        selected={selected}
-                        onChange={onChange}
-                        extraClass='console-type-select'>
+                                            selected={selected}
+                                            onChange={onChange}
+                                            extraClass='console-type-select'>
                         {entries}
                     </Select.StatelessSelect>
                 </td>

--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -63,17 +63,17 @@ const MemorySelectRow = ({ label, id, value, initialUnit, onValueChange, onUnitC
                         <div className="evenly-spaced-table">
                             <span className="evenly-spaced-cell">
                                 <input id={id} className="form-control"
-                                    type="number"
-                                    value={toFixedPrecision(value)}
-                                    onKeyPress={digitFilter}
-                                    step={1}
-                                    min={0}
-                                    onChange={onValueChange}/>
+                                       type="number"
+                                       value={toFixedPrecision(value)}
+                                       onKeyPress={digitFilter}
+                                       step={1}
+                                       min={0}
+                                       onChange={onValueChange}/>
                             </span>
                             <span className="thirty-five-spaced-cell padding-left">
                                 <Select.Select id={id + "-unit-select"}
-                                    initial={initialUnit}
-                                    onChange={onUnitChange}>
+                                               initial={initialUnit}
+                                               onChange={onUnitChange}>
                                     <Select.SelectEntry data={units.MiB.name} key={units.MiB.name}>
                                         {_("MiB")}
                                     </Select.SelectEntry>
@@ -238,8 +238,8 @@ class CreateVM extends React.Component {
                         </td>
                         <td>
                             <input id="vm-name" className="form-control" type="text" minLength={1}
-                                value={this.props.vmParams.vmName}
-                                onChange={this.onChangedEventValue.bind(this, 'vmName')}/>
+                                   value={this.props.vmParams.vmName}
+                                   onChange={this.onChangedEventValue.bind(this, 'vmName')}/>
                         </td>
                     </tr>
                     <tr>
@@ -250,10 +250,10 @@ class CreateVM extends React.Component {
                         </td>
                         <td>
                             <Select.Select id="source-type"
-                                initial={this.state.sourceType}
-                                onChange={this.onChangedValue.bind(this, 'sourceType')}>
+                                           initial={this.state.sourceType}
+                                           onChange={this.onChangedValue.bind(this, 'sourceType')}>
                                 <Select.SelectEntry data={COCKPIT_FILESYSTEM_SOURCE}
-                                    key={COCKPIT_FILESYSTEM_SOURCE}>{_("Filesystem")}</Select.SelectEntry>
+                                                    key={COCKPIT_FILESYSTEM_SOURCE}>{_("Filesystem")}</Select.SelectEntry>
                                 <Select.SelectEntry data={URL_SOURCE} key={URL_SOURCE}>{_("URL")}</Select.SelectEntry>
                             </Select.Select>
                         </td>
@@ -276,8 +276,8 @@ class CreateVM extends React.Component {
                         </td>
                         <td>
                             <Select.Select id="vendor-select"
-                                initial={this.state.vendor}
-                                onChange={this.onChangedValue.bind(this, 'vendor')}>
+                                           initial={this.state.vendor}
+                                           onChange={this.onChangedValue.bind(this, 'vendor')}>
                                 {vendorSelectEntries}
                             </Select.Select>
                         </td>
@@ -290,24 +290,24 @@ class CreateVM extends React.Component {
                         </td>
                         <td>
                             <Select.StatelessSelect id="system-select"
-                                selected={this.state.os}
-                                onChange={this.onChangedValue.bind(this, 'os')}>
+                                                    selected={this.state.os}
+                                                    onChange={this.onChangedValue.bind(this, 'os')}>
                                 {osEntries}
                             </Select.StatelessSelect>
                         </td>
                     </tr>
                     <MemorySelectRow label={_("Memory")}
-                        id={"memory-size"}
-                        value={this.state.memorySize}
-                        initialUnit={this.state.memorySizeUnit}
-                        onValueChange={this.onChangedEventValue.bind(this, 'memorySize')}
-                        onUnitChange={this.onChangedValue.bind(this, 'memorySizeUnit')}/>
+                                     id={"memory-size"}
+                                     value={this.state.memorySize}
+                                     initialUnit={this.state.memorySizeUnit}
+                                     onValueChange={this.onChangedEventValue.bind(this, 'memorySize')}
+                                     onUnitChange={this.onChangedValue.bind(this, 'memorySizeUnit')}/>
                     <MemorySelectRow label={_("Storage Size")}
-                        id={"storage-size"}
-                        value={this.state.storageSize}
-                        initialUnit={this.state.storageSizeUnit}
-                        onValueChange={this.onChangedEventValue.bind(this, 'storageSize')}
-                        onUnitChange={this.onChangedValue.bind(this, 'storageSizeUnit')}/>
+                                     id={"storage-size"}
+                                     value={this.state.storageSize}
+                                     initialUnit={this.state.storageSizeUnit}
+                                     onValueChange={this.onChangedEventValue.bind(this, 'storageSize')}
+                                     onUnitChange={this.onChangedValue.bind(this, 'storageSizeUnit')}/>
                     <tr>
                         <td className="top">
                             <label className="control-label" htmlFor="start-vm">
@@ -316,8 +316,8 @@ class CreateVM extends React.Component {
                         </td>
                         <td>
                             <input id="start-vm" className="form-control dialog-checkbox" type="checkbox"
-                                checked={this.props.vmParams.startVm}
-                                onChange={this.onChangedEventChecked.bind(this, 'startVm')}/>
+                                   checked={this.props.vmParams.startVm}
+                                   onChange={this.onChangedEventChecked.bind(this, 'startVm')}/>
                         </td>
                     </tr>
                 </table>
@@ -404,10 +404,10 @@ export const createVmDialog = (dispatch, osInfoList) => {
 
     const dialogBody = (
         <CreateVM vmParams={vmParams}
-            familyList={vendors.familyList}
-            familyMap={vendors.familyMap}
-            vendorMap={vendors.vendorMap}
-            valuesChanged={changeParams}/>
+                  familyList={vendors.familyList}
+                  familyMap={vendors.familyMap}
+                  vendorMap={vendors.vendorMap}
+                  valuesChanged={changeParams}/>
     );
 
     const dialogProps = {

--- a/pkg/machines/components/deleteDialog.jsx
+++ b/pkg/machines/components/deleteDialog.jsx
@@ -32,10 +32,10 @@ const DeleteDialogBody = ({ values, onChange }) => {
             <tr>
                 <td>
                     <input type="checkbox" checked={disk.checked}
-                        onChange={(event) => {
-                            disk.checked = event.target.checked;
-                            onChange();
-                        }}/>
+                           onChange={(event) => {
+                               disk.checked = event.target.checked;
+                               onChange();
+                           }}/>
                 </td>
                 <td>{disk.file}</td>
                 <td>{disk.target}</td>

--- a/pkg/machines/components/libvirtSlate.jsx
+++ b/pkg/machines/components/libvirtSlate.jsx
@@ -103,10 +103,10 @@ class LibvirtSlate extends React.Component {
                 <div className="checkbox">
                     <label>
                         <input type="checkbox"
-                            id="enable-libvirt"
-                            disabled={!name}
-                            checked={this.state.libvirtEnabled}
-                            onChange={this.onLibvirtEnabledChanged}/>
+                               id="enable-libvirt"
+                               disabled={!name}
+                               checked={this.state.libvirtEnabled}
+                               onChange={this.onLibvirtEnabledChanged}/>
                         {_("Automatically start libvirt on boot")}
                     </label>
                 </div>
@@ -114,14 +114,14 @@ class LibvirtSlate extends React.Component {
             action = (
                 <div className="blank-slate-pf-main-action">
                     <button className="btn btn-default btn-lg"
-                        id="troubleshoot"
-                        onClick={mouseClick(this.goToServicePage)}>
+                            id="troubleshoot"
+                            onClick={mouseClick(this.goToServicePage)}>
                         {_("Troubleshoot")}
                     </button>
                     <button className="btn btn-primary btn-lg"
-                        id="start-libvirt"
-                        disabled={!name}
-                        onClick={mouseClick(this.startService)}>
+                            id="start-libvirt"
+                            disabled={!name}
+                            onClick={mouseClick(this.startService)}>
                         {_("Start libvirt")}
                     </button>
                 </div>

--- a/pkg/machines/components/notification/inlineNotification.jsx
+++ b/pkg/machines/components/notification/inlineNotification.jsx
@@ -76,8 +76,8 @@ InlineNotification.propTypes = {
 export const Alert = ({ onDismiss, text, textId, detail }) => {
     return (
         <Notification onDismiss={onDismiss}
-            notificationClass='alert alert-warning'
-            iconClass='pficon pficon-warning-triangle-o'>
+                      notificationClass='alert alert-warning'
+                      iconClass='pficon pficon-warning-triangle-o'>
             <InlineNotification text={text} textId={textId} detail={detail} />
         </Notification>
 
@@ -87,8 +87,8 @@ export const Alert = ({ onDismiss, text, textId, detail }) => {
 export const Info = ({ onDismiss, text, textId, detail }) => {
     return (
         <Notification onDismiss={onDismiss}
-            notificationClass='alert alert-info'
-            iconClass='pficon pficon-info'>
+                      notificationClass='alert alert-info'
+                      iconClass='pficon pficon-info'>
             <InlineNotification text={text} textId={textId} detail={detail} />
         </Notification>
     );

--- a/pkg/machines/components/notification/notificationArea.jsx
+++ b/pkg/machines/components/notification/notificationArea.jsx
@@ -31,9 +31,9 @@ const NotificationArea = ({ notifications, onDismiss, id }) => {
         const icon = isError ? 'pficon-error-circle-o' : 'pficon pficon-info';
 
         return (<Notification onDismiss={onDismiss ? onDismiss.bind(onDismiss, notification.id) : null}
-            id={`${id}-notification-${notification.id}`}
-            notificationClass={'alert ' + clazz}
-            iconClass={'pficon ' + icon}>
+                              id={`${id}-notification-${notification.id}`}
+                              notificationClass={'alert ' + clazz}
+                              iconClass={'pficon ' + icon}>
             <NotificationMessage description={notification.description} message={notification.message}/>
         </Notification>);
     });

--- a/pkg/machines/components/serialConsole.jsx
+++ b/pkg/machines/components/serialConsole.jsx
@@ -104,13 +104,13 @@ class SerialConsole extends React.Component {
             <div className="console-ct-container">
                 <div className="console-actions">
                     <button ref="disconnectButton" id={`${vmName}-serialconsole-disconnect`}
-                        className={`btn btn-default console-actions-buttons ${disconnectDisabled}`}
-                        onClick={this.onDisconnectClick}>
+                            className={`btn btn-default console-actions-buttons ${disconnectDisabled}`}
+                            onClick={this.onDisconnectClick}>
                         {_("Disconnect")}
                     </button>
 
                     <button ref="resetButton" id={`${vmName}-serialconsole-reconnect`}
-                        className="btn btn-default console-actions-buttons" onClick={this.onResetClick}>
+                            className="btn btn-default console-actions-buttons" onClick={this.onResetClick}>
                         {_("Reconnect")}
                     </button>
                 </div>

--- a/pkg/machines/components/vm/vmActions.jsx
+++ b/pkg/machines/components/vm/vmActions.jsx
@@ -94,7 +94,7 @@ const VmActions = ({ vm, config, dispatch, onStart, onInstall, onReboot, onForce
     if (state !== undefined && config.provider.canDelete && config.provider.canDelete(state, vm.id, config.providerState)) {
         deleteAction = (
             <button className="btn btn-danger" id={`${id}-delete`}
-                onClick={mouseClick(() => deleteDialog(vm, dispatch))}>
+                    onClick={mouseClick(() => deleteDialog(vm, dispatch))}>
                 {_("Delete")}
             </button>
         );

--- a/pkg/machines/components/vmDiskSourceCell.jsx
+++ b/pkg/machines/components/vmDiskSourceCell.jsx
@@ -27,7 +27,7 @@ const DiskSourceCell = ({ diskSource, idPrefix }) => {
     const addOptional = (chunks, value, descr) => {
         if (value) {
             chunks.push(<InfoRecord descrClass='machines-disks-source-descr' descr={descr}
-                valueClass='machines-disks-source-value' value={value}/>);
+                                    valueClass='machines-disks-source-value' value={value}/>);
         }
     };
 

--- a/pkg/machines/components/vmDisksTab.jsx
+++ b/pkg/machines/components/vmDisksTab.jsx
@@ -87,7 +87,7 @@ const VmDisksTab = ({ idPrefix, disks, renderCapacity, notificationText }) => {
     let notification = null;
     if (notificationText) {
         notification = (<Info text={notificationText}
-            textId={`${idPrefix}-notification`}/>);
+                              textId={`${idPrefix}-notification`}/>);
     }
 
     return (

--- a/pkg/machines/components/vmOverviewTab.jsx
+++ b/pkg/machines/components/vmOverviewTab.jsx
@@ -62,7 +62,7 @@ const VmOverviewTab = ({ message, idPrefix, items, extraItems }) => {
             <Items items={items} idPrefix={idPrefix} divider={extraItems ? 6 : 12}/>
             {extraItems && extraItems.map(col =>
                 (<Items items={col} idPrefix={idPrefix} divider='3'
-                    colClass='col-lg-12 col-md-12 col-sm-12 col-xs-12'/>))}
+                        colClass='col-lg-12 col-md-12 col-sm-12 col-xs-12'/>))}
         </div>);
 };
 

--- a/pkg/machines/components/vmOverviewTabLibvirt.jsx
+++ b/pkg/machines/components/vmOverviewTabLibvirt.jsx
@@ -49,9 +49,9 @@ const VmOverviewTabLibvirt = ({ vm, config, dispatch }) => {
     ];
 
     return (<VmOverviewTab message={message}
-        idPrefix={idPrefix}
-        items={items}
-        extraItems={config.provider.vmOverviewExtra && config.provider.vmOverviewExtra(vm, config.providerState)}/>);
+                           idPrefix={idPrefix}
+                           items={items}
+                           extraItems={config.provider.vmOverviewExtra && config.provider.vmOverviewExtra(vm, config.providerState)}/>);
 };
 
 VmOverviewTabLibvirt.propTypes = {

--- a/pkg/ovirt/components/App.jsx
+++ b/pkg/ovirt/components/App.jsx
@@ -96,21 +96,21 @@ const TopMenu = ({ ovirtConfig, router, dispatch }) => {
     return (
         <nav className='content-extra-header'>
             <a className={'top-menu-link' + selected('hostvms')} href='#'
-                id='ovirt-topnav-hostvms'
-                aria-current={selected_aria('hostvms')}
-                onClick={() => onNavigate('hostvms')}>{_("Host")}</a>
+               id='ovirt-topnav-hostvms'
+               aria-current={selected_aria('hostvms')}
+               onClick={() => onNavigate('hostvms')}>{_("Host")}</a>
             <a className={'top-menu-link' + selected('clustervms')} href='#'
-                id='ovirt-topnav-clustervms'
-                aria-current={selected_aria('clustervms')}
-                onClick={() => onNavigate('clustervms')}>{_("Cluster")}</a>
+               id='ovirt-topnav-clustervms'
+               aria-current={selected_aria('clustervms')}
+               onClick={() => onNavigate('clustervms')}>{_("Cluster")}</a>
             <a className={'top-menu-link' + selected('clustertemplates')} href='#'
-                id='ovirt-topnav-clustertemplates'
-                aria-current={selected_aria('clustertemplates')}
-                onClick={() => onNavigate('clustertemplates')}>{_("Templates")}</a>
+               id='ovirt-topnav-clustertemplates'
+               aria-current={selected_aria('clustertemplates')}
+               onClick={() => onNavigate('clustertemplates')}>{_("Templates")}</a>
             <a className={'top-menu-link' + selected('vdsm')} href='#'
-                id='ovirt-topnav-vdsm'
-                aria-current={selected_aria('vdsm')}
-                onClick={() => onNavigate('vdsm')}>{_("VDSM")}</a>
+               id='ovirt-topnav-vdsm'
+               aria-current={selected_aria('vdsm')}
+               onClick={() => onNavigate('vdsm')}>{_("VDSM")}</a>
 
             <LoginInProgress ovirtConfig={ovirtConfig}/>
         </nav>
@@ -128,11 +128,11 @@ const HostVmsListDecorated = ({ vms, config, systemInfo, ui, dispatch, host }) =
         <div className='container-fluid'>
             <HostStatus host={host}/>
             <HostVmsList vms={vms}
-                config={config}
-                systemInfo={systemInfo}
-                ui={ui}
-                dispatch={dispatch}
-                actions={actions}/>
+                         config={config}
+                         systemInfo={systemInfo}
+                         ui={ui}
+                         dispatch={dispatch}
+                         actions={actions}/>
         </div>
     );
 };

--- a/pkg/ovirt/components/HostToMaintenance.jsx
+++ b/pkg/ovirt/components/HostToMaintenance.jsx
@@ -70,7 +70,7 @@ const hostToMaintenance = ({ dispatch, host }) => {
     // TODO: "pficon-maintenance" seems to be added to patternfly since 3.26 release - change once this gets to cockpit
     return (
         <a className='card-pf-link-with-icon pull-right' id='ovirt-host-to-maintenance'
-            onClick={showHostToMaintenanceDialog(dispatch, host)}>
+           onClick={showHostToMaintenanceDialog(dispatch, host)}>
             <div className='ovirt-action-padding'>
                 <span className='pficon pficon-close'/>{_("Host to Maintenance")}
             </div>

--- a/pkg/ovirt/components/InstallationDialog.jsx
+++ b/pkg/ovirt/components/InstallationDialog.jsx
@@ -48,13 +48,13 @@ const InstallationDialogBody = ({ values, onChange }) => {
                     </td>
                     <td>
                         <input id='ovirt-provider-install-dialog-engine-fqdn'
-                            className='form-control'
-                            type='text'
-                            placeholder='engine.mydomain.com'
-                            onChange={(event) => {
-                                values.oVirtUrl = event.target.value;
-                                onChange();
-                            }}
+                               className='form-control'
+                               type='text'
+                               placeholder='engine.mydomain.com'
+                               onChange={(event) => {
+                                   values.oVirtUrl = event.target.value;
+                                   onChange();
+                               }}
                         />
                     </td>
                 </tr>
@@ -66,13 +66,13 @@ const InstallationDialogBody = ({ values, onChange }) => {
                     </td>
                     <td>
                         <input id='ovirt-provider-install-dialog-engine-fqdn'
-                            className='form-control'
-                            type='text'
-                            placeholder={OVIRT_DEFAULT_PORT}
-                            onChange={(event) => {
-                                values.oVirtPort = isNumeric(event.target.value) ? event.target.value : values.oVirtPort;
-                                onChange();
-                            }}
+                               className='form-control'
+                               type='text'
+                               placeholder={OVIRT_DEFAULT_PORT}
+                               onChange={(event) => {
+                                   values.oVirtPort = isNumeric(event.target.value) ? event.target.value : values.oVirtPort;
+                                   onChange();
+                               }}
                         />
                     </td>
                 </tr>

--- a/pkg/ovirt/components/OVirtTab.jsx
+++ b/pkg/ovirt/components/OVirtTab.jsx
@@ -63,9 +63,9 @@ class MigrateTo extends React.Component {
                 <td>
                     {this.state.confirmAction
                         ? (<ConfirmButtons confirmText={_("Confirm migration")}
-                            dismissText={_("Cancel")}
-                            onYes={onActionConfirmed}
-                            onNo={onActionCanceled}/>)
+                                         dismissText={_("Cancel")}
+                                         onYes={onActionConfirmed}
+                                         onNo={onActionCanceled}/>)
                         : (<button className="btn btn-default btn-danger" onClick={onAction} id={`${idPrefix}-migratetobutton`}>
                             {_("Migrate To:")}
                         </button>)
@@ -101,17 +101,17 @@ const VmTemplate = ({ clusterVm, templates, id }) => {
     if (!template) {
         return (
             <VmProperty descr={_("Base template:")}
-                value='' />
+                        value='' />
         );
     }
 
     const version = template.version;
     return (
         <VmProperty descr={_("Base template:")}
-            value={version.name
-                ? (`${version.name} (${template.name})`)
-                : template.name}
-            id={id}
+                    value={version.name
+                        ? (`${version.name} (${template.name})`)
+                        : template.name}
+                    id={id}
         />
     );
 };

--- a/pkg/ovirt/components/VmActions.jsx
+++ b/pkg/ovirt/components/VmActions.jsx
@@ -36,7 +36,7 @@ const VmActions = ({ vm, providerState, dispatch }) => {
     return (
         <div className='btn-group'>
             <button className='btn btn-default' id={`${idPrefix}-suspendbutton`}
-                onClick={() => dispatch(suspendVm({ id: clusterVm.id, name: clusterVm.name, connectionName: vm.connectionName }))}>
+                    onClick={() => dispatch(suspendVm({ id: clusterVm.id, name: clusterVm.name, connectionName: vm.connectionName }))}>
                 {_("Suspend")}
             </button>
         </div>

--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -286,7 +286,7 @@ export default class AutoUpdates extends React.Component {
                     <tr>
                         <td>
                             <Select.Select id="auto-update-type" enabled={!this.state.pending} initial={backend.type}
-                                onChange={ t => this.handleChange(null, t, null, null) }>
+                                           onChange={ t => this.handleChange(null, t, null, null) }>
                                 <Select.SelectEntry data="all">{_("Apply all updates")}</Select.SelectEntry>
                                 <Select.SelectEntry data="security">{_("Apply security updates")}</Select.SelectEntry>
                             </Select.Select>
@@ -294,7 +294,7 @@ export default class AutoUpdates extends React.Component {
 
                         <td>
                             <Select.Select id="auto-update-day" enabled={!this.state.pending} initial={backend.day}
-                                onChange={ d => this.handleChange(null, null, d, null) }>
+                                           onChange={ d => this.handleChange(null, null, d, null) }>
                                 <Select.SelectEntry data="">{_("every day")}</Select.SelectEntry>
                                 <Select.SelectEntry data="mon">{_("on Mondays")}</Select.SelectEntry>
                                 <Select.SelectEntry data="tue">{_("on Tuesdays")}</Select.SelectEntry>
@@ -310,7 +310,7 @@ export default class AutoUpdates extends React.Component {
 
                         <td>
                             <Select.Select id="auto-update-time" enabled={!this.state.pending} initial={backend.time}
-                                onChange={ t => this.handleChange(null, null, null, t) }>
+                                           onChange={ t => this.handleChange(null, null, null, t) }>
                                 { hours.map(h => <Select.SelectEntry data={h + ":00"}>{('0' + h).slice(-2) + ":00"}</Select.SelectEntry>)}
                             </Select.Select>
                         </td>
@@ -330,7 +330,7 @@ export default class AutoUpdates extends React.Component {
                     <tr>
                         <td><h2>{_("Automatic Updates")}</h2></td>
                         <td><OnOffSwitch.OnOffSwitch state={onOffState} enabled={!this.state.pending}
-                            onChange={e => this.handleChange(e, null, null, null) } /></td>
+                                                     onChange={e => this.handleChange(e, null, null, null) } /></td>
                     </tr>
                 </table>
 

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -953,10 +953,10 @@ class OsUpdates extends React.Component {
         return (
             <div>
                 <HeaderBar state={this.state.state} updates={this.state.updates}
-                    timeSinceRefresh={this.state.timeSinceRefresh} onRefresh={this.handleRefresh}
-                    unregistered={this.state.unregistered}
-                    allowCancel={this.state.allowCancel}
-                    onCancel={ () => PK.call(this.state.applyTransaction, PK.transactionInterface, "Cancel", []) } />
+                           timeSinceRefresh={this.state.timeSinceRefresh} onRefresh={this.handleRefresh}
+                           unregistered={this.state.unregistered}
+                           allowCancel={this.state.allowCancel}
+                           onCancel={ () => PK.call(this.state.applyTransaction, PK.transactionInterface, "Cancel", []) } />
                 <div className="container-fluid">
                     {this.renderContent()}
                 </div>

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -103,7 +103,7 @@ var SELinuxEventDetails = React.createClass({
                 fixit = (
                     <div className="setroubleshoot-listing-action">
                         <button className="btn btn-default"
-                            onClick={ self.runFix.bind(self, itmIdx) }
+                                onClick={ self.runFix.bind(self, itmIdx) }
                         >{ _("Apply this solution") }
                         </button>
                     </div>
@@ -425,8 +425,8 @@ var SETroubleshootPage = React.createClass({
 
         troubleshooting = (
             <cockpitListing.Listing
-                title={ title }
-                emptyCaption={ emptyCaption }
+                    title={ title }
+                    emptyCaption={ emptyCaption }
             >
                 {entries}
             </cockpitListing.Listing>

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -356,7 +356,7 @@ function append_row(client, rows, level, key, name, desc, tabs, job_object) {
     if (job_object)
         last_column = (
             <span className="spinner spinner-sm spinner-inline"
-                style={{visibility: client.path_jobs[job_object] ? "visible" : "hidden"}}>
+                  style={{visibility: client.path_jobs[job_object] ? "visible" : "hidden"}}>
             </span>);
     if (tabs.row_action) {
         if (last_column) {
@@ -375,9 +375,9 @@ function append_row(client, rows, level, key, name, desc, tabs, job_object) {
     ];
     rows.push(
         <CockpitListing.ListingRow key={key}
-            columns={cols}
-            tabRenderers={tabs.renderers}
-            listingActions={tabs.actions}/>
+                                   columns={cols}
+                                   tabRenderers={tabs.renderers}
+                                   listingActions={tabs.actions}/>
     );
 }
 
@@ -534,7 +534,7 @@ function block_content(client, block, allow_partitions) {
 
     return (
         <CockpitListing.Listing title={_("Content")}
-            actions={format_disk_btn}>
+                                actions={format_disk_btn}>
             { block_rows(client, block) }
         </CockpitListing.Listing>
     );
@@ -682,7 +682,7 @@ var VGroup = React.createClass({
         var new_volume_link = (
             <div className="pull-right">
                 <StorageLink onClick={create_logical_volume}
-                    excuse={excuse}>
+                             excuse={excuse}>
                     <span className="pficon pficon-add-circle-o"></span>
                     {" "}
                     {_("Create new Logical Volume")}
@@ -691,8 +691,8 @@ var VGroup = React.createClass({
 
         return (
             <CockpitListing.Listing title="Logical Volumes"
-                actions={new_volume_link}
-                emptyCaption={_("No Logical Volumes")}>
+                                    actions={new_volume_link}
+                                    emptyCaption={_("No Logical Volumes")}>
                 { vgroup_rows(self.props.client, vgroup) }
             </CockpitListing.Listing>
         );

--- a/pkg/storaged/dialogx.jsx
+++ b/pkg/storaged/dialogx.jsx
@@ -195,10 +195,10 @@ export const dialog_open = (def) => {
             id: "dialog",
             title: def.Title,
             body: <Body body={def.Body}
-                fields={fields}
-                values={values}
-                errors={errors}
-                onChange={() => update(null)}/>
+                        fields={fields}
+                        values={values}
+                        errors={errors}
+                        onChange={() => update(null)}/>
         };
     }
 
@@ -252,8 +252,8 @@ export const TextInput = (tag, title, options) => {
 
         render: (val, change) =>
             <input data-field={tag}
-                className="form-control" type="text" value={val}
-                onChange={event => change(event.target.value)}/>
+                   className="form-control" type="text" value={val}
+                   onChange={event => change(event.target.value)}/>
     }
 }
 
@@ -266,7 +266,7 @@ export const PassInput = (tag, title, options) => {
 
         render: (val, change) =>
             <input data-field={tag}
-                className="form-control" type="password" value={val}
-                onChange={event => change(event.target.value)}/>
+                   className="form-control" type="password" value={val}
+                   onChange={event => change(event.target.value)}/>
     }
 }

--- a/pkg/storaged/drives-panel.jsx
+++ b/pkg/storaged/drives-panel.jsx
@@ -101,12 +101,12 @@ export class DrivesPanel extends React.Component {
 
             return (
                 <OverviewSidePanelRow client={client}
-                    name={name}
-                    detail={desc}
-                    stats={io}
-                    highlight={dev == props.highlight}
-                    go={() => cockpit.location.go([ dev ])}
-                    job_path={path}/>
+                                      name={name}
+                                      detail={desc}
+                                      stats={io}
+                                      highlight={dev == props.highlight}
+                                      go={() => cockpit.location.go([ dev ])}
+                                      job_path={path}/>
             );
         }
 
@@ -115,8 +115,8 @@ export class DrivesPanel extends React.Component {
 
         return (
             <OverviewSidePanel id="drives"
-                title={_("Drives")}
-                empty_text={_("No drives attached")}>
+                               title={_("Drives")}
+                               empty_text={_("No drives attached")}>
                 { drives }
             </OverviewSidePanel>
         );

--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -398,7 +398,7 @@ var FormatButton = React.createClass({
     render: function () {
         return (
             <StorageControls.StorageButton onClick={this.onClick}
-                excuse={this.props.block.ReadOnly ? _("Device is read-only") : null}>
+                                           excuse={this.props.block.ReadOnly ? _("Device is read-only") : null}>
                 {_("Format")}
             </StorageControls.StorageButton>
         );

--- a/pkg/storaged/iscsi-panel.jsx
+++ b/pkg/storaged/iscsi-panel.jsx
@@ -252,11 +252,11 @@ export class IscsiPanel extends React.Component {
 
             return (
                 <OverviewSidePanelRow client={client}
-                    kind="array"
-                    name={session.data["target_name"] || ""}
-                    detail={session.data["persistent_address"] + ":" +
+                                      kind="array"
+                                      name={session.data["target_name"] || ""}
+                                      detail={session.data["persistent_address"] + ":" +
                                               session.data["persistent_port"]}
-                    actions={actions}/>
+                                      actions={actions}/>
             );
         }
 
@@ -285,10 +285,10 @@ export class IscsiPanel extends React.Component {
 
         return (
             <OverviewSidePanel id="iscsi-sessions"
-                title={_("iSCSI Targets")}
-                empty_text={_("No iSCSI targets set up")}
-                hover={false}
-                actions={actions}>
+                               title={_("iSCSI Targets")}
+                               empty_text={_("No iSCSI targets set up")}
+                               hover={false}
+                               actions={actions}>
                 { sessions }
             </OverviewSidePanel>
         );

--- a/pkg/storaged/mdraid-details.jsx
+++ b/pkg/storaged/mdraid-details.jsx
@@ -358,8 +358,8 @@ export class MDRaidDetails extends React.Component {
         var content = <Content.Block client={this.props.client} block={block}/>;
 
         return <StdDetailsLayout client={this.props.client} alert={degraded_message}
-            header={ header }
-            sidebar={ sidebar }
-            content={ content }/>;
+                                 header={ header }
+                                 sidebar={ sidebar }
+                                 content={ content }/>;
     }
 }

--- a/pkg/storaged/mdraids-panel.jsx
+++ b/pkg/storaged/mdraids-panel.jsx
@@ -104,11 +104,11 @@ export class MDRaidsPanel extends React.Component {
 
             return (
                 <OverviewSidePanelRow client={client}
-                    kind="array"
-                    name={mdraid_name(mdraid)}
-                    detail={fmt_size(mdraid.Size)}
-                    go={() => cockpit.location.go([ "mdraid", mdraid.UUID ])}
-                    job_path={path}/>
+                                      kind="array"
+                                      name={mdraid_name(mdraid)}
+                                      detail={fmt_size(mdraid.Size)}
+                                      go={() => cockpit.location.go([ "mdraid", mdraid.UUID ])}
+                                      job_path={path}/>
             );
         }
 
@@ -123,9 +123,9 @@ export class MDRaidsPanel extends React.Component {
 
         return (
             <OverviewSidePanel id="mdraids"
-                title={_("RAID Devices")}
-                empty_text={_("No storage set up as RAID")}
-                actions={actions}>
+                               title={_("RAID Devices")}
+                               empty_text={_("No storage set up as RAID")}
+                               actions={actions}>
                 { mdraids }
             </OverviewSidePanel>
         );

--- a/pkg/storaged/others-panel.jsx
+++ b/pkg/storaged/others-panel.jsx
@@ -51,12 +51,12 @@ export class OthersPanel extends React.Component {
 
             return (
                 <OverviewSidePanelRow client={client}
-                    kind={false}
-                    testkey={dev}
-                    name={name}
-                    detail={cockpit.format(_("$0 Block Device"), fmt_size(block.Size))}
-                    go={() => cockpit.location.go([ dev ])}
-                    job_path={path}/>
+                                      kind={false}
+                                      testkey={dev}
+                                      name={name}
+                                      detail={cockpit.format(_("$0 Block Device"), fmt_size(block.Size))}
+                                      go={() => cockpit.location.go([ dev ])}
+                                      job_path={path}/>
             );
         }
 
@@ -67,7 +67,7 @@ export class OthersPanel extends React.Component {
         if (others.length > 0)
             return (
                 <OverviewSidePanel id="others"
-                    title={_("Other Devices")}>
+                                   title={_("Other Devices")}>
                     { others }
                 </OverviewSidePanel>
             );

--- a/pkg/storaged/plot.jsx
+++ b/pkg/storaged/plot.jsx
@@ -258,14 +258,14 @@ export class StoragePlots extends React.Component {
         return (
             <div className={Object.keys(this.state.classes).join(" ")}>
                 <ZoomControls ref={setup_controls}
-                    onClassesChanged={(cls) => this.setState({ classes: cls })}/>
+                              onClassesChanged={(cls) => this.setState({ classes: cls })}/>
                 <div className="row">
                     <StoragePlot devs={devs} onHover={this.props.onHover}
-                        onPlotCreated={new_plot}
-                        title={_("Reading")} data={read_plot_data}/>
+                                 onPlotCreated={new_plot}
+                                 title={_("Reading")} data={read_plot_data}/>
                     <StoragePlot devs={devs} onHover={this.props.onHover}
-                        onPlotCreated={new_plot}
-                        title={_("Writing")} data={write_plot_data}/>
+                                 onPlotCreated={new_plot}
+                                 title={_("Writing")} data={write_plot_data}/>
                 </div>
             </div>
         );

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -103,13 +103,13 @@ var StorageButton = React.createClass({
 
         return (
             <StorageControl excuse={this.props.excuse}
-                content={(excuse) => (
-                    <button id={this.props.id}
-                        onClick={checked(this.props.onClick)}
-                        className={classes + (excuse ? " disabled" : "")}>
-                        {this.props.children}
-                    </button>
-                )}/>
+                            content={(excuse) => (
+                                <button id={this.props.id}
+                                            onClick={checked(this.props.onClick)}
+                                            className={classes + (excuse ? " disabled" : "")}>
+                                    {this.props.children}
+                                </button>
+                            )}/>
         );
     }
 });
@@ -118,14 +118,14 @@ var StorageLink = React.createClass({
     render: function () {
         return (
             <StorageControl excuse={this.props.excuse}
-                content={(excuse) => (
-                    <a onClick={checked(this.props.onClick)}
-                        role="link"
-                        tabIndex="0"
-                        className={excuse ? " disabled" : ""}>
-                        {this.props.children}
-                    </a>
-                )}/>
+                            content={(excuse) => (
+                                <a onClick={checked(this.props.onClick)}
+                                       role="link"
+                                       tabIndex="0"
+                                       className={excuse ? " disabled" : ""}>
+                                    {this.props.children}
+                                </a>
+                            )}/>
         );
     }
 });
@@ -199,13 +199,13 @@ class StorageOnOff extends React.Component {
 
         return (
             <StorageControl excuse={this.props.excuse}
-                content={(excuse) => (
-                    <OnOffSwitch state={this.state.promise
-                        ? this.state.promise_goal_state
-                        : this.props.state}
-                    enabled={!excuse && !this.state.promise}
-                    onChange={onChange}/>
-                )}/>
+                            content={(excuse) => (
+                                <OnOffSwitch state={this.state.promise
+                                    ? this.state.promise_goal_state
+                                    : this.props.state}
+                                                 enabled={!excuse && !this.state.promise}
+                                                 onChange={onChange}/>
+                            )}/>
         );
     }
 }
@@ -216,31 +216,31 @@ class StorageMultiAction extends React.Component {
 
         return (
             <StorageControl excuse={this.props.excuse}
-                content={(excuse) => {
-                    var btn_classes = "btn btn-default";
-                    if (excuse)
-                        btn_classes += " disabled";
-                    return (
-                        <div className="btn-group">
-                            <button className={btn_classes} onClick={checked(dflt.action)}>
-                                {dflt.title}
-                            </button>
-                            <button className={btn_classes + " dropdown-toggle"}
-                                data-toggle="dropdown">
-                                <span className="caret"></span>
-                            </button>
-                            <ul className="dropdown-menu action-dropdown-menu" role="menu">
-                                { this.props.actions.map((act) => (
-                                    <li className="presentation">
-                                        <a role="menuitem" tabIndex="0" onClick={checked(act.action)}>
-                                            {act.title}
-                                        </a>
-                                    </li>))
-                                }
-                            </ul>
-                        </div>
-                    );
-                }}/>
+                            content={(excuse) => {
+                                var btn_classes = "btn btn-default";
+                                if (excuse)
+                                    btn_classes += " disabled";
+                                return (
+                                    <div className="btn-group">
+                                        <button className={btn_classes} onClick={checked(dflt.action)}>
+                                            {dflt.title}
+                                        </button>
+                                        <button className={btn_classes + " dropdown-toggle"}
+                                                    data-toggle="dropdown">
+                                            <span className="caret"></span>
+                                        </button>
+                                        <ul className="dropdown-menu action-dropdown-menu" role="menu">
+                                            { this.props.actions.map((act) => (
+                                                <li className="presentation">
+                                                    <a role="menuitem" tabIndex="0" onClick={checked(act.action)}>
+                                                        {act.title}
+                                                    </a>
+                                                </li>))
+                                            }
+                                        </ul>
+                                    </div>
+                                );
+                            }}/>
         );
     }
 }

--- a/pkg/storaged/vdo-details.jsx
+++ b/pkg/storaged/vdo-details.jsx
@@ -304,13 +304,13 @@ export class VDODetails extends React.Component {
                         <tr>
                             <td>{_("Compression")}</td>
                             <td><StorageOnOff state={vdo.compression}
-                                onChange={() => vdo.set_compression(!vdo.compression)}/>
+                                              onChange={() => vdo.set_compression(!vdo.compression)}/>
                             </td>
                         </tr>
                         <tr>
                             <td>{_("Deduplication")}</td>
                             <td><StorageOnOff state={vdo.deduplication}
-                                onChange={() => vdo.set_deduplication(!vdo.deduplication)}/>
+                                              onChange={() => vdo.set_deduplication(!vdo.deduplication)}/>
                             </td>
                         </tr>
                     </table>
@@ -321,8 +321,8 @@ export class VDODetails extends React.Component {
         var content = <Content.Block client={client} block={block} allow_partitions={false}/>;
 
         return <StdDetailsLayout client={this.props.client}
-            alert={alert}
-            header={header}
-            content={content}/>;
+                                 alert={alert}
+                                 header={header}
+                                 content={content}/>;
     }
 }

--- a/pkg/storaged/vdos-panel.jsx
+++ b/pkg/storaged/vdos-panel.jsx
@@ -137,11 +137,11 @@ export class VDOsPanel extends React.Component {
             var block = client.slashdevs_block[vdo.dev];
             return (
                 <OverviewSidePanelRow client={client}
-                    kind="array"
-                    name={vdo.name}
-                    detail={fmt_size(vdo.logical_size)}
-                    go={() => cockpit.location.go([ "vdo", vdo.name ])}
-                    job_path={block && block.path}/>
+                                      kind="array"
+                                      name={vdo.name}
+                                      detail={fmt_size(vdo.logical_size)}
+                                      go={() => cockpit.location.go([ "vdo", vdo.name ])}
+                                      job_path={block && block.path}/>
             );
         }
 
@@ -155,9 +155,9 @@ export class VDOsPanel extends React.Component {
 
         return (
             <OverviewSidePanel id="vdos"
-                title={_("VDO Devices")}
-                empty_text={_("No storage set up as VDO")}
-                actions={actions}>
+                               title={_("VDO Devices")}
+                               empty_text={_("No storage set up as VDO")}
+                               actions={actions}>
                 { vdos }
             </OverviewSidePanel>
         );

--- a/pkg/storaged/vgroup-details.jsx
+++ b/pkg/storaged/vgroup-details.jsx
@@ -258,8 +258,8 @@ export class VGroupDetails extends React.Component {
         var content = <Content.VGroup client={this.props.client} vgroup={vgroup}/>;
 
         return <StdDetailsLayout client={this.props.client}
-            header={ header }
-            sidebar={ sidebar }
-            content={ content }/>;
+                                 header={ header }
+                                 sidebar={ sidebar }
+                                 content={ content }/>;
     }
 }

--- a/pkg/storaged/vgroups-panel.jsx
+++ b/pkg/storaged/vgroups-panel.jsx
@@ -88,11 +88,11 @@ export class VGroupsPanel extends React.Component {
 
             return (
                 <OverviewSidePanelRow client={client}
-                    kind="array"
-                    name={vgroup.Name}
-                    detail={fmt_size(vgroup.Size)}
-                    go={() => cockpit.location.go([ "vg", vgroup.Name ])}
-                    job_path={path}/>
+                                      kind="array"
+                                      name={vgroup.Name}
+                                      detail={fmt_size(vgroup.Size)}
+                                      go={() => cockpit.location.go([ "vg", vgroup.Name ])}
+                                      job_path={path}/>
             );
         }
 
@@ -107,9 +107,9 @@ export class VGroupsPanel extends React.Component {
 
         return (
             <OverviewSidePanel id="vgroups"
-                title={_("Volume Groups")}
-                empty_text={_("No volume groups created")}
-                actions={actions}>
+                               title={_("Volume Groups")}
+                               empty_text={_("No volume groups created")}
+                               actions={actions}>
                 { vgroups }
             </OverviewSidePanel>
         );

--- a/pkg/subscriptions/subscriptions-register.jsx
+++ b/pkg/subscriptions/subscriptions-register.jsx
@@ -65,8 +65,8 @@ var PatternDialogBody = React.createClass({
                                 </label>
                             </td>
                             <td><input className="form-control" id="subscription-proxy-server" type="text"
-                                placeholder="hostname:port" value={this.props.proxyServer}
-                                onChange={this.props.onChange.bind(this, 'proxyServer')}/>
+                                       placeholder="hostname:port" value={this.props.proxyServer}
+                                       onChange={this.props.onChange.bind(this, 'proxyServer')}/>
                             </td>
                         </tr>
 
@@ -77,8 +77,8 @@ var PatternDialogBody = React.createClass({
                                 </label>
                             </td>
                             <td><input className="form-control" id="subscription-proxy-user" type="text"
-                                value={this.props.proxyUser}
-                                onChange={this.props.onChange.bind(this, 'proxyUser')}/>
+                                       value={this.props.proxyUser}
+                                       onChange={this.props.onChange.bind(this, 'proxyUser')}/>
                             </td>
                         </tr>
 
@@ -89,8 +89,8 @@ var PatternDialogBody = React.createClass({
                                 </label>
                             </td>
                             <td><input className="form-control" id="subscription-proxy-password" type="password"
-                                value={this.props.proxyPassword}
-                                onChange={this.props.onChange.bind(this, 'proxyPassword')}/>
+                                       value={this.props.proxyPassword}
+                                       onChange={this.props.onChange.bind(this, 'proxyPassword')}/>
                             </td>
                         </tr>
                     </tbody>
@@ -112,7 +112,7 @@ var PatternDialogBody = React.createClass({
                         </td>
                         <td>
                             <Select.Select key='urlSource' onChange={ this.props.onChange.bind(this, 'url') }
-                                id="subscription-register-url" initial="default">
+                                           id="subscription-register-url" initial="default">
                                 <Select.SelectEntry data='default' key='default'>{ urlEntries['default'] }</Select.SelectEntry>
                                 <Select.SelectEntry data='custom' key='custom'>{ urlEntries['custom'] }</Select.SelectEntry>
                             </Select.Select>
@@ -128,7 +128,7 @@ var PatternDialogBody = React.createClass({
                         <td>
                             <label>
                                 <input id="subscription-proxy-use" type="checkbox" checked={this.props.proxy}
-                                    onChange={ this.props.onChange.bind(this, 'proxy') }/>
+                                       onChange={ this.props.onChange.bind(this, 'proxy') }/>
                                 {_("Use proxy server")}
                             </label>
                             {proxy}
@@ -142,8 +142,8 @@ var PatternDialogBody = React.createClass({
                         </td>
                         <td>
                             <input id="subscription-register-username" className="form-control" type="text"
-                                value={this.props.user}
-                                onChange={this.props.onChange.bind(this, 'user')}/>
+                                   value={this.props.user}
+                                   onChange={this.props.onChange.bind(this, 'user')}/>
                         </td>
                     </tr>
                     <tr>
@@ -154,8 +154,8 @@ var PatternDialogBody = React.createClass({
                         </td>
                         <td>
                             <input id="subscription-register-password" className="form-control" type="password"
-                                value={this.props.password}
-                                onChange={this.props.onChange.bind(this, 'password')}/>
+                                   value={this.props.password}
+                                   onChange={this.props.onChange.bind(this, 'password')}/>
                         </td>
                     </tr>
                     <tr>
@@ -166,8 +166,8 @@ var PatternDialogBody = React.createClass({
                         </td>
                         <td>
                             <input id="subscription-register-key" className="form-control" type="text"
-                                placeholder="key_one,key_two" value={this.props.activationKeys}
-                                onChange={this.props.onChange.bind(this, 'activationKeys')}/>
+                                   placeholder="key_one,key_two" value={this.props.activationKeys}
+                                   onChange={this.props.onChange.bind(this, 'activationKeys')}/>
                         </td>
                     </tr>
                     <tr>
@@ -178,8 +178,8 @@ var PatternDialogBody = React.createClass({
                         </td>
                         <td>
                             <input id="subscription-register-org" className="form-control" type="text"
-                                value={this.props.org}
-                                onChange={this.props.onChange.bind(this, 'org')}/>
+                                   value={this.props.org}
+                                   onChange={this.props.onChange.bind(this, 'org')}/>
                         </td>
                     </tr>
                 </table>

--- a/pkg/subscriptions/subscriptions-view.jsx
+++ b/pkg/subscriptions/subscriptions-view.jsx
@@ -140,12 +140,12 @@ var SubscriptionStatus = React.createClass({
         if (this.props.status == 'Unknown') {
             label = <label>{ _("Status: System isn't registered") }</label>;
             action = (<button className="btn btn-primary"
-                onClick={this.handleRegisterSystem}>{_("Register")}</button>
+                              onClick={this.handleRegisterSystem}>{_("Register")}</button>
             );
         } else {
             label = <label>{ cockpit.format(_("Status: $0"), this.props.status) }</label>;
             action = (<button className="btn btn-primary" disabled={isUnregistering}
-                onClick={this.handleUnregisterSystem}>{_("Unregister")}</button>
+                              onClick={this.handleUnregisterSystem}>{_("Unregister")}</button>
             );
             if (isUnregistering) {
                 note = (

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -79,7 +79,7 @@ class HardwareInfo extends React.Component {
 
             pci = (
                 <Listing title={ _("PCI") } columnTitles={ [ _("Class"), _("Model"), _("Vendor"), _("Slot") ] }
-                    columnTitleClick={ index => this.setState({ sortBy: this.sortColumnFields[index] }) } >
+                         columnTitleClick={ index => this.setState({ sortBy: this.sortColumnFields[index] }) } >
                     { sortedPci.map(dev => <ListingRow columns={[ dev.cls, dev.model, dev.vendor, dev.slot ]} />) }
                 </Listing>
             );


### PR DESCRIPTION
This aspect really was a change for the worse.
Revert the JSX attribute indentation of commit a6f180eb37 and tell
eslint to ignore them. There currently does not seem to be a mode to
enforce vertically aligned attributes.