### PR TITLE
bots: Drop docker resolv.conf hack from Fedora images

### DIFF
--- a/bots/images/scripts/fedora.setup
+++ b/bots/images/scripts/fedora.setup
@@ -156,12 +156,6 @@ srpm=$(/var/lib/testvm/make-srpm $TEST_SOURCE)
 su builder -c "/usr/bin/mock --no-bootstrap-chroot --verbose --installdeps \"$PWD/$srpm\""
 su builder -c "/usr/bin/mock --install --verbose rpmlint"
 
-# HACK: docker fails without /etc/resolv.conf
-# https://bugzilla.redhat.com/show_bug.cgi?id=1448331
-mkdir -p /etc/systemd/system/docker.service.d
-printf "[Service]\nExecStartPre=/bin/sh -c 'echo -n >> /etc/resolv.conf'\n" > /etc/systemd/system/docker.service.d/resolv.conf
-systemctl daemon-reload
-
 # HACK: docker falls over regularly, print its log if it does
 systemctl start docker || journalctl -u docker
 


### PR DESCRIPTION
Follow-up to commit 1df3363747f4.

 - [ ] image-refresh fedora-26
 - [ ] image-refresh fedora-27
 - [ ] image-refresh fedora-28
 - [ ] image-refresh fedora-i386
 - [ ] image-refresh fedora-testing