### PR TITLE
base1: Format number 0 correctly

### DIFF
--- a/doc/guide/cockpit-util.xml
+++ b/doc/guide/cockpit-util.xml
@@ -22,6 +22,9 @@ string = cockpit.format(template, [arg, ...])
 
     <para>In the second form, multiple <code>arg</code> arguments may be passed directly,
       and interpolated as as numeric fields in the <code>template</code>.</para>
+
+    <para>All falsy arguments except the numbers <code>0</code> and <code>0.0</code>are
+      replaced by an empty string.</para>
   </refsection>
 
   <refsection id="cockpit-format-bytes">

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -1442,7 +1442,20 @@ function factory() {
     cockpit.format = function format(fmt, args) {
         if (arguments.length != 2 || !is_object(args) || args === null)
             args = Array.prototype.slice.call(arguments, 1);
-        return fmt.replace(fmt_re, function(m, x, y) { return args[x || y] || ""; });
+
+        function replace(m, x, y) {
+            var value = args[x || y];
+
+            /* Special-case 0 (also catches 0.0). All other falsy values return
+             * the empty string.
+             */
+            if (value === 0)
+                return '0';
+
+            return value || '';
+        }
+
+        return fmt.replace(fmt_re, replace);
     };
 
     cockpit.format_number = function format_number(number) {

--- a/src/base1/test-format.js
+++ b/src/base1/test-format.js
@@ -13,6 +13,12 @@ QUnit.test("format", function() {
     assert.equal(cockpit.format("My $0 message with lots of things", "special"),
           "My special message with lots of things", "vararg one key");
     assert.equal(cockpit.format("Undefined $value", { }), "Undefined ", "missing value");
+
+    /* All falsy values except `0` should return the empty string */
+    assert.equal(cockpit.format("$0", 0), "0", "`0` as argument");
+    assert.equal(cockpit.format("$0", 0.0), "0", "`0.0` as argument");
+    assert.equal(cockpit.format("$0", false), "", "`false` as argument");
+    assert.equal(cockpit.format("$0", null), "", "`null` as argument");
 });
 
 QUnit.test("format_number", function () {


### PR DESCRIPTION
cockpit.format() returns the empty string for all falsy values, which is
surprising if one tries to format the number 0.

Add a special case for 0 and add documentation for that.