### PR TITLE
ovirt: match Cockpit host to oVirt host by IP

### DIFF
--- a/pkg/ovirt/actions.es6
+++ b/pkg/ovirt/actions.es6
@@ -147,3 +147,12 @@ export function setHostname(hostname) {
         }
     };
 }
+
+export function setHostIPs(ips) {
+    return {
+        type: 'OVIRT_SET_HOST_IPS',
+        payload: {
+            ips,
+        }
+    };
+}

--- a/pkg/ovirt/reducers.es6
+++ b/pkg/ovirt/reducers.es6
@@ -101,6 +101,10 @@ function configReducer (state, action) {
     {
         return Object.assign({}, state, { hostname: action.payload.hostname });
     }
+    case 'OVIRT_SET_HOST_IPS':
+    {
+        return Object.assign({}, state, { hostIPs: action.payload.ips });
+    }
     default:
         return state;
     }

--- a/pkg/ovirt/selectors.es6
+++ b/pkg/ovirt/selectors.es6
@@ -34,9 +34,14 @@ export function getHost(hosts, ovirtConfig) {
     const hostAddress = getHostAddress();
     let hostId = Object.getOwnPropertyNames(hosts).find(hostId => hosts[hostId].address === hostAddress);
 
-    // match by system's hostname as fallback
+    // try to match by system's hostname
     if (!hostId && ovirtConfig && ovirtConfig.hostname) {
         hostId = Object.getOwnPropertyNames(hosts).find(hostId => hosts[hostId].address === ovirtConfig.hostname);
+    }
+
+    // try to match one of host IPs to oVirt host.address
+    if (!hostId && ovirtConfig && ovirtConfig.hostIPs) {
+        hostId = Object.getOwnPropertyNames(hosts).find(hostId => ovirtConfig.hostIPs.includes(hosts[hostId].address));
     }
 
     return hostId && hosts[hostId];


### PR DESCRIPTION
With this patch, cockpit host is matched to oVirt host by one of
it's IP addresses (output of `hostname -I`).

Added to existing matching by:
- hostname from browser URL
- FQDN of the Cockpit machine (`hostname -f`)

Fixes: https://github.com/cockpit-project/cockpit/issues/8768