### PR TITLE
WIP: machines: Add after-installation configuration file

### DIFF
--- a/doc/guide/feature-virtualmachines.xml
+++ b/doc/guide/feature-virtualmachines.xml
@@ -21,6 +21,70 @@
     </para>
     </section>
 
+    <section id="feature-virtualmachines-configuration">
+        <title>Optional configuration</title>
+        <para>
+            Defaults of the <emphasis>cockpit-machines</emphasis> plugin can be configured by
+            creating <filename>/etc/cockpit/virtual-machines.config</filename>.
+            The file is in JSON format and its content is merged to the plugin defaults.
+        </para>
+
+        <para>
+            Actual effective configuration is printed to browser's console log at the plugin's start-up in
+            <emphasis>debug</emphasis> (or <emphasis>verbose</emphasis>) scope.
+        </para>
+
+        <para>Options:</para>
+        <variablelist>
+            <varlistentry>
+                <term>DefaultRefreshInterval</term>
+                <listitem><para>Polling interval to read virtual machine's usage statistics. In milliseconds, default 10000.</para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>debug</term>
+                <listitem><para>Boolean value (true or false) to turn on/off verbose messages in browser's console log.</para></listitem>
+            </varlistentry>
+        </variablelist>
+
+        <para>Examples:</para>
+        <variablelist>
+            <varlistentry>
+                <term>Turn on debug messages in browser's console:</term>
+                <listitem>
+<programlisting>
+{"debug":true}
+</programlisting>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term>Default connections, refresh interval and verbose logging:</term>
+                <listitem>
+                    <para>
+<programlisting>
+{
+  "DefaultRefreshInterval":10000,
+  "Virsh": {
+    "connections": {
+      "system": {
+        "params":["-c","qemu:///system"]
+      },
+      "session":{
+        "params":["-c","qemu:///session"]
+      }
+    }
+  },
+  "debug":true
+}
+</programlisting>
+                    </para>
+                </listitem>
+            </varlistentry>
+
+        </variablelist>
+
+    </section>
+
     <section id="feature-virtualmachines-extending">
         <title>Extensions</title>
         <para>

--- a/pkg/machines/helpers.es6
+++ b/pkg/machines/helpers.es6
@@ -140,7 +140,7 @@ export function arrayEquals(arr1, arr2) {
 }
 
 export function logDebug(msg, ...params) {
-    if (VMS_CONFIG.isDev) {
+    if (VMS_CONFIG.debug) {
         console.log(msg, ...params);
     }
 }

--- a/pkg/machines/index.es6
+++ b/pkg/machines/index.es6
@@ -23,6 +23,7 @@ import store from './store.es6';
 import App from './app.jsx';
 import { initDataRetrieval } from './actions.es6';
 import { logDebug } from './helpers.es6';
+import { doReadConfiguration } from './config.es6';
 
 import Libvirt from './libvirt.es6';
 import { setVirtProvider } from './provider.es6';
@@ -40,14 +41,16 @@ function render() {
 export function appMain() {
     logDebug('index.es6: initial state: ' + JSON.stringify(store.getState()));
 
-    setVirtProvider(Libvirt);
+    doReadConfiguration().finally(() => {
+        setVirtProvider(Libvirt);
 
-    // re-render app every time the state changes
-    store.subscribe(render);
+        // re-render app every time the state changes
+        store.subscribe(render);
 
-    // do initial render
-    render();
+        // do initial render
+        render();
 
-    // initiate data retrieval
-    store.dispatch(initDataRetrieval());
+        // initiate data retrieval
+        store.dispatch(initDataRetrieval());
+    });
 }

--- a/pkg/ovirt/config.es6
+++ b/pkg/ovirt/config.es6
@@ -18,7 +18,7 @@
  */
 export const INSTALL_SH = '/usr/share/cockpit/ovirt/install.sh';
 
-export const OVIRT_CONF_FILE = '/etc/cockpit/machines-ovirt.config'; // relative URL for async download
+export const OVIRT_CONF_FILE = '/etc/cockpit/machines-ovirt.config';
 export const VDSM_CONF_FILE = '/etc/vdsm/vdsm.conf';
 export const PEM_FILE = '/etc/pki/vdsm/certs/cacert.pem';
 export const OVIRT_DEFAULT_PORT = 443;


### PR DESCRIPTION
Optional configuration can be provided by administrator
once the cockpit-machines package is installed.
    
Defaults or effective configuration is printed to log for review
or easy copy&paste setup.
    
The expected use-case is especially to configure Libvirt's
connection URI or turn on/off debug messages.
    
Location: `/etc/cockpit/virtual-machines.config`

Fixes: https://github.com/cockpit-project/cockpit/issues/7484

---
- [ ] Tests
