### PR TITLE
SSCG should be an optional dep of cockpit-ws

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -99,7 +99,6 @@ Requires: %{name}-system = %{version}-%{release}
 Recommends: %{name}-dashboard = %{version}-%{release}
 Recommends: (%{name}-networkmanager = %{version}-%{release} if NetworkManager)
 Recommends: (%{name}-storaged = %{version}-%{release} if udisks2)
-Recommends: sscg >= 2.3
 %if 0%{?rhel} >= 8
 Recommends: subscription-manager-cockpit
 %endif
@@ -536,6 +535,9 @@ Summary: Cockpit Web Service
 Requires: glib-networking
 Requires: openssl
 Requires: glib2 >= 2.37.4
+%if 0%{?fedora} >= 24 || 0%{?rhel} >= 8
+Recommends: sscg >= 2.3
+%endif
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd


### PR DESCRIPTION
Currently, SSCG is only pulled in if the 'cockpit' metapackage is
installed. However, it should be installed wherever the
cockpit-ws package is, since it is used to generate the initial
TLS certificate.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>