### PR TITLE
Fix `cockpit.all`

### DIFF
--- a/pkg/docker/atomic.js
+++ b/pkg/docker/atomic.js
@@ -64,11 +64,11 @@ function updateVulnerableInfo() {
                     return cockpit.file(infos[id].json_file, { syntax: JSON }).read();
                 });
 
-                cockpit.all(promises).done(function () {
+                cockpit.all(promises).done(function (infos) {
                     var detailedInfos = {};
 
-                    for (var i = 0; i < arguments.length; i++)
-                        detailedInfos[ids[i]] = sanitizeVulnerableInfo(ids[i], arguments[i]);
+                    for (var i = 0; i < infos.length; i++)
+                        detailedInfos[ids[i]] = sanitizeVulnerableInfo(ids[i], infos[i]);
 
                     atomic.dispatchEvent("vulnerableInfoChanged", detailedInfos);
                 });

--- a/pkg/networkmanager/firewall-client.es6
+++ b/pkg/networkmanager/firewall-client.es6
@@ -45,7 +45,7 @@ firewalld_service.addEventListener('changed', () => {
 });
 
 function fetchServiceInfos(services) {
-    var promises = cockpit.all(services.map(service => {
+    return cockpit.all(services.map(service => {
         if (firewall.services[service])
             return firewall.services[service];
 
@@ -66,14 +66,6 @@ function fetchServiceInfos(services) {
                     return info;
                 });
     }));
-
-    /*
-     * Work around `cockpit.all()` returning results in individual arguments -
-     * that's just confusing and doesn't work with ES6 style functions.
-     */
-    return promises.then(function () {
-        return Array.prototype.slice.call(arguments);
-    });
 }
 
 firewalld_dbus.addEventListener('owner', (event, owner) => {

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -551,7 +551,7 @@ class OsUpdates extends React.Component {
                         transactionPath, "org.freedesktop.DBus.Properties", "Get", [PK.transactionInterface, "Role"], {timeout: 5000}));
 
                     cockpit.all(promises)
-                            .done(roles => {
+                            .done((roles) => {
                                 // any transaction with UPDATE_PACKAGES role?
                                 for (let idx = 0; idx < roles.length; ++idx) {
                                     if (roles[idx].v === PK.Enum.ROLE_UPDATE_PACKAGES) {

--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -123,6 +123,7 @@ base_QUNIT_TESTS = \
 	dist/base1/test-user.html \
 	dist/base1/test-machines.html \
 	dist/base1/test-permissions.html \
+	dist/base1/test-promise.html \
 	dist/base1/test-series.html \
 	dist/base1/test-cache.html \
 	dist/base1/test-websocket.html \

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -1402,23 +1402,34 @@ function factory() {
         var deferred = cockpit.defer();
         var counter = 0;
         var results = [];
+        var as_varargs = false;
 
-        if (!is_array (promises))
+        if (!is_array (promises)) {
             promises = Array.prototype.slice.call(arguments);
+            as_varargs = true;
+        }
 
         promises.forEach(function(promise, key) {
             counter++;
             cockpit.when(promise).then(function(value) {
                 results[key] = value;
-                if (!(--counter))
-                    deferred.resolve.apply(deferred, results);
+                if (!(--counter)) {
+                    if (as_varargs)
+                        deferred.resolve.apply(deferred, results);
+                    else
+                        deferred.resolve.call(deferred, results);
+                }
             }, function(/* ... */) {
                 deferred.reject.apply(deferred, arguments);
             });
         });
 
-        if (counter === 0)
-            deferred.resolve.apply(deferred, results);
+        if (counter === 0) {
+            if (as_varargs)
+                deferred.resolve.apply(deferred, results);
+            else
+                deferred.resolve.call(deferred, results);
+        }
         return deferred.promise;
     };
 

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -1403,7 +1403,7 @@ function factory() {
         var counter = 0;
         var results = [];
 
-        if (arguments.length != 1 && !is_array (promises))
+        if (!is_array (promises))
             promises = Array.prototype.slice.call(arguments);
 
         promises.forEach(function(promise, key) {

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -1418,7 +1418,7 @@ function factory() {
         });
 
         if (counter === 0)
-            deferred.resolve(results);
+            deferred.resolve.apply(deferred, results);
         return deferred.promise;
     };
 

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -1299,7 +1299,7 @@ function factory() {
             then = values[0] && values[0].then;
         if (is_function(then)) {
             state.status = -1;
-            then.call(values, function(/* ... */) {
+            then.call(values[0], function(/* ... */) {
                 if (done)
                     return;
                 done = true;

--- a/src/base1/test-promise.js
+++ b/src/base1/test-promise.js
@@ -3,7 +3,7 @@
 /* jshint esnext: true */   /* for Promise object */
 
 QUnit.test("cockpit.all with 0 promises", function (assert) {
-    assert.expect(2);
+    assert.expect(3);
 
     var done = assert.async(2);
 
@@ -13,7 +13,8 @@ QUnit.test("cockpit.all with 0 promises", function (assert) {
     });
 
     cockpit.all([]).then(function () {
-        assert.equal(arguments.length, 0, "array");
+        assert.equal(arguments.length, 1, "1 argument");
+        assert.ok(Array.isArray(arguments[0]), "array");
         done();
     });
 });
@@ -31,7 +32,7 @@ QUnit.test("cockpit.all with 1 promise", function (assert) {
 
     p = Promise.resolve(1);
     cockpit.all([p]).then(function (r) {
-        assert.equal(r, 1);
+        assert.strictEqual(r[0], 1);
         done();
     });
 });
@@ -44,10 +45,34 @@ QUnit.test("cockpit.all with ES6 promises", function (assert) {
     var es6 = Promise.resolve('es6');
     var cpt = cockpit.defer().resolve('cockpit').promise();
 
-    cockpit.all([es6, cpt]).then(function (r1, r2) {
+    cockpit.all(es6, cpt).then(function (r1, r2) {
         assert.equal(r1, 'es6', 'es6');
         assert.equal(r2, 'cockpit', 'cockpit');
 
+        done();
+    });
+});
+
+QUnit.test("cockpit.all varargs vs array", function (assert) {
+    assert.expect(7);
+
+    var done = assert.async(2);
+
+    var p1 = Promise.resolve(1);
+    var p2 = Promise.resolve(2);
+
+    cockpit.all([p1, p2]).then(function (r) {
+        assert.ok(Array.isArray(r), 'returns array');
+        assert.equal(r.length, 2, 'of length 2');
+        assert.equal(r[0], 1, 'result 1');
+        assert.equal(r[1], 2, 'result 2');
+        done();
+    });
+
+    cockpit.all(p1, p2).then(function (r1, r2) {
+        assert.equal(arguments.length, 2, 'returns results as arguments');
+        assert.equal(r1, 1, 'result 1');
+        assert.equal(r2, 2, 'result 2');
         done();
     });
 });

--- a/src/base1/test-promise.js
+++ b/src/base1/test-promise.js
@@ -1,0 +1,19 @@
+/* global $, cockpit, QUnit, unescape, escape */
+
+QUnit.test("cockpit.all with 0 promises", function (assert) {
+    assert.expect(2);
+
+    var done = assert.async(2);
+
+    cockpit.all().then(function () {
+        assert.equal(arguments.length, 0, "varargs");
+        done();
+    });
+
+    cockpit.all([]).then(function () {
+        assert.equal(arguments.length, 0, "array");
+        QUnit.start();
+    });
+});
+
+QUnit.start();

--- a/src/base1/test-promise.js
+++ b/src/base1/test-promise.js
@@ -18,6 +18,24 @@ QUnit.test("cockpit.all with 0 promises", function (assert) {
     });
 });
 
+QUnit.test("cockpit.all with 1 promise", function (assert) {
+    assert.expect(2);
+
+    var done = assert.async(2);
+
+    var p = Promise.resolve(1);
+    cockpit.all(p).then(function (r) {
+        assert.equal(r, 1);
+        done();
+    });
+
+    p = Promise.resolve(1);
+    cockpit.all([p]).then(function (r) {
+        assert.equal(r, 1);
+        done();
+    });
+});
+
 QUnit.test("cockpit.all with ES6 promises", function (assert) {
     assert.expect(2);
 

--- a/src/base1/test-promise.js
+++ b/src/base1/test-promise.js
@@ -1,5 +1,7 @@
 /* global $, cockpit, QUnit, unescape, escape */
 
+/* jshint esnext: true */   /* for Promise object */
+
 QUnit.test("cockpit.all with 0 promises", function (assert) {
     assert.expect(2);
 
@@ -12,7 +14,23 @@ QUnit.test("cockpit.all with 0 promises", function (assert) {
 
     cockpit.all([]).then(function () {
         assert.equal(arguments.length, 0, "array");
-        QUnit.start();
+        done();
+    });
+});
+
+QUnit.test("cockpit.all with ES6 promises", function (assert) {
+    assert.expect(2);
+
+    var done = assert.async(1);
+
+    var es6 = Promise.resolve('es6');
+    var cpt = cockpit.defer().resolve('cockpit').promise();
+
+    cockpit.all([es6, cpt]).then(function (r1, r2) {
+        assert.equal(r1, 'es6', 'es6');
+        assert.equal(r2, 'cockpit', 'cockpit');
+
+        done();
     });
 });
 


### PR DESCRIPTION
Make `cockpit.all` internally consistent and more compatible with ES6 Promises.

This technically contains API breaks, but we've never publicly documented this call and as such I'd say it's private. None of the external projects in the (very useful!) list on #8505 use `cockpit.all`. I've fixed all sites in cockpit itself where I saw problems. Mostly the results aren't even used, but let's see what the tests say.