### PR TITLE
Use HTML form instead of div for login screen.

### DIFF
--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -23,7 +23,7 @@
         </div><!--/.col-*-->
 
         <div id="login" class="col-sm-7 col-md-6 col-lg-5 login-area" style="visibility: hidden;">
-          <div role="form">
+          <form>
 
             <div id="error-group" class="alert alert-danger" hidden>
               <span id="login-error-message"></span>
@@ -86,7 +86,7 @@
                 </button>
               </div>
             </div>
-          </div>
+          </form>
         </div><!--/.col-*-->
 
         <div class="col-sm-5 col-md-6 col-lg-7 details" id="login-details">


### PR DESCRIPTION
This allows Firefox, the only browser I tested that did not offer to save the login credentials using `<div role="form">...</div>` to offer to save login credentials.

Addresses #6399