### PR TITLE
machines: Delete non-libvirt managed VM disks

### DIFF
--- a/pkg/machines/components/deleteDialog.jsx
+++ b/pkg/machines/components/deleteDialog.jsx
@@ -92,9 +92,16 @@ export function deleteDialog(vm, dispatch) {
             { caption: _("Delete"),
               style: 'danger',
               clicked: () => {
-                  let storage = [ ];
-                  values.disks.forEach(d => { if (d.checked) storage.push(d.target); });
-                  return dispatch(deleteVm(vm, { destroy: values.destroy, storage: storage }));
+                  let storage = [];
+                  values.disks.forEach(d => {
+                      if (d.checked) {
+                          storage.push(Object.assign({}, d));
+                      }
+                  });
+                  return dispatch(deleteVm(vm, {
+                      destroy: values.destroy,
+                      storage,
+                  }));
               }
             }
         ]


### PR DESCRIPTION
Within the `Delete VM` flow, even non-libvirt managed disk
file is removed if requested by user.

Prior this fix, removal of such a disk file failed and was
delegated for manual action.

Fixes: https://github.com/cockpit-project/cockpit/issues/8499