### PR TITLE
bots: Stop releasing into Fedora 27

### DIFF
--- a/bots/major-cockpit-release
+++ b/bots/major-cockpit-release
@@ -26,7 +26,6 @@ job release-srpm
 # Do fedora builds for the tag, using tarball
 job release-koji -k master
 job release-koji f28
-job release-koji f27
 
 # Upload release to github, using tarball
 job release-github
@@ -39,7 +38,6 @@ job release-dockerhub cockpit-project/cockpit-container
 job release-dockerhub cockpituous/cockpit cockpit-project/cockpit
 
 # Push out a Bodhi update
-job release-bodhi F27
 job release-bodhi F28
 
 # Upload documentation


### PR DESCRIPTION
Fedora 28 is released now.