### PR TITLE
bots: Adjust for Fedora Atomic now being version 28

### DIFF
--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -199,11 +199,11 @@ def only_install(image, build_results, skips, args, address):
 
 # The Atomic variants can't build their own packages, so we build in
 # their non-Atomic siblings.  For example, fedora-atomic is built
-# in fedora-27
+# in fedora-28
 def get_build_image(image):
     (test_os, unused) = os.path.splitext(os.path.basename(image))
     if test_os == "fedora-atomic":
-        image = "fedora-27"
+        image = "fedora-28"
     elif test_os == "rhel-atomic":
         image = "rhel-7"
     elif test_os == "continuous-atomic":

--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -42,10 +42,10 @@ TRIGGERS = {
     ],
     "fedora-27": [
         "verify/fedora-27",
-        "verify/fedora-atomic",
     ],
     "fedora-28": [
         "verify/fedora-28",
+        "verify/fedora-atomic",
     ],
     "fedora-atomic": [
         "verify/fedora-atomic"

--- a/bots/images/fedora-atomic
+++ b/bots/images/fedora-atomic
@@ -1,1 +1,1 @@
-fedora-atomic-f3526b8f73fdb1f1e52fe77e152dfb0a77caa9abb5078d9f3e82268d226a2ca3.qcow2
+fedora-atomic-05c8a9c54fb545cbecf70cda9f1618f618be3fbe7165b244d3d329954a64783b.qcow2

--- a/bots/images/scripts/fedora-atomic.bootstrap
+++ b/bots/images/scripts/fedora-atomic.bootstrap
@@ -8,6 +8,6 @@ url="https://download.fedoraproject.org/pub/alt/atomic/stable/"
 BASE=$(dirname $0)
 
 # The Fedora URLs have the version twice in the name. for example:
-# https://dl.fedoraproject.org/pub/alt/atomic/stable/Fedora-Atomic-25-20160921.0/CloudImages/x86_64/images/Fedora-Cloud-Base-25-20160921.0.x86_64.qcow2
+# https://dl.fedoraproject.org/pub/alt/atomic/stable/Fedora-Atomic-28-20180425.0/AtomicHost/x86_64/images/Fedora-AtomicHost-28-20180425.0.x86_64.qcow2
 $BASE/atomic.bootstrap "$1" "$url" \
-    "Fedora-Atomic-[-0-9\.]+" "CloudImages" "x86_64" "images" "Fedora-Atomic-[-0-9\.]+.x86_64.qcow2"
+    "Fedora-Atomic-[-0-9\.]+" "AtomicHost" "x86_64" "images" "Fedora-AtomicHost-[-0-9\.]+.x86_64.qcow2"

--- a/bots/images/scripts/fedora-atomic.install
+++ b/bots/images/scripts/fedora-atomic.install
@@ -4,3 +4,7 @@
 set -e
 
 /var/lib/testvm/atomic.install --verbose --skip cockpit-kdump "$@"
+
+# HACK: https://github.com/projectatomic/rpm-ostree/issues/1360
+# rpm-ostree upgrade --check otherwise fails
+mkdir -p /var/cache/rpm-ostree

--- a/bots/images/scripts/lib/atomic.install
+++ b/bots/images/scripts/lib/atomic.install
@@ -93,7 +93,7 @@ class AtomicCockpitInstaller:
         subprocess.call(["ostree", "remote", "delete", "local"])
 
         subprocess.check_call(["ostree", "remote", "add", "local",
-                               "file:///{}".format(self.repo_location),
+                               "file://{}".format(self.repo_location),
                                "--no-gpg-verify"])
 
         # HACK: https://github.com/candlepin/subscription-manager/issues/1404

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -42,11 +42,11 @@ def can_manage(machine):
 
 # The Atomic variants can't build their own packages, so we build in
 # their non-Atomic siblings.  For example, fedora-atomic is built
-# in fedora-26
+# in fedora-28
 def get_build_image(test_os):
     build_os = test_os
     if test_os == "fedora-atomic":
-        build_os = "fedora-27"
+        build_os = "fedora-28"
     elif test_os == "rhel-atomic":
         build_os = "rhel-7"
     elif test_os == "continuous-atomic":

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -326,15 +326,30 @@ class OstreeRestartCase(MachineCase):
         m.start_cockpit()
         b.reload()
         b.login_and_go("/updates")
-
-        # After reboot upgrade but no rollback target
         b.wait_present('table.listing-ct')
         b.wait_present('table.listing-ct tbody')
-        b.wait_present('table.listing-ct tbody:nth-child(3) i.fa-circle')
-        b.wait_in_text("table.listing-ct tbody:nth-child(3) div.listing-ct-actions button", "Update")
-        b.wait_present('table.listing-ct tbody:nth-child(4) i.fa-check-circle-o')
+
+        if m.image in ["fedora-atomic"]:
+            # newer rpm-ostree flips back and forth between the two latest releases with rollback
+            b.wait_present('table.listing-ct tbody:nth-child(3) i.fa-check-circle-o')
+            b.wait_text('table.listing-ct tbody:nth-child(3) div.listing-ct-head h3', name + " cockpit-base.1")
+            b.wait_in_text("table.listing-ct tbody:nth-child(3) div.listing-ct-head", "Running")
+
+            b.wait_present('table.listing-ct tbody:nth-child(4) i.fa-circle')
+            b.wait_text('table.listing-ct tbody:nth-child(4) div.listing-ct-head h3', name + " cockpit-base.2")
+            b.wait_present("table.listing-ct tbody:nth-child(4) div.listing-ct-head button")
+            b.wait_in_text("table.listing-ct tbody:nth-child(4) div.listing-ct-head button", "Roll Back")
+        else:
+            # older rpm-ostree doesn't "roll back" forwards to the current release, it appears as regular update
+            b.wait_present('table.listing-ct tbody:nth-child(3) i.fa-circle')
+            b.wait_text('table.listing-ct tbody:nth-child(3) div.listing-ct-head h3', name + " cockpit-base.2")
+            b.wait_in_text("table.listing-ct tbody:nth-child(3) div.listing-ct-actions button", "Update")
+
+            b.wait_present('table.listing-ct tbody:nth-child(4) i.fa-check-circle-o')
+            b.wait_text('table.listing-ct tbody:nth-child(4) div.listing-ct-head h3', name + " cockpit-base.1")
+            b.wait_not_present("button:contains('Roll Back')");
+
         b.wait_not_present('table.listing-ct tbody:nth-child(5)')
-        b.wait_not_present("button:contains('Roll Back')");
 
         self.allow_restart_journal_messages()
 


### PR DESCRIPTION
 * [x] Publish f28/cockpit container: https://pagure.io/releng/issue/7483
 * [x] image-refresh fedora-atomic
 * [x] adjust ostree tests for new rollback behaviour