### PR TITLE
apps: Prefer installed metadata over repository metadata

### DIFF
--- a/pkg/apps/watch-appstream.py
+++ b/pkg/apps/watch-appstream.py
@@ -296,8 +296,8 @@ class MetainfoDB:
                 if not comp['id'] in comps:
                     comps[comp['id']] = comp;
                 else:
-                    z = comps[comp['id']].copy()
-                    z.update(comp)
+                    z = comp.copy()
+                    z.update(comps[comp['id']])
                     comps[comp['id']] = z;
 
         data = {


### PR DESCRIPTION
Usually these two are the same, but if they differ and the package is
installed, it's confusing to show something that doesn't apply to the
installed version.

Also, repository metadata might not have an icon while the installed
metadata has, and with this change, we see that icon.