### PR TITLE
bots: Only include changed po files when updating translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,8 @@ depcomp
 /cockpit-ws
 /cockpit-ws.8
 /po/cockpit.pot
+/po/*.in
+/po/*.pot
 /src/selinux/tmp
 /src/selinux/cockpit.pp
 /pkg/*/test-*.log

--- a/bots/po-refresh
+++ b/bots/po-refresh
@@ -41,6 +41,16 @@ def run(context, verbose=False, **kwargs):
             sys.stderr.write("+ " + " ".join(args) + "\n")
         subprocess.check_call(args, cwd=cwd)
 
+    def changed(filename):
+        lines = output("git", "diff", "--", filename).split("\n")
+        msgstr = False
+        for line in lines:
+            if line.startswith("+msgstr ") and not line.endswith('""'):
+                if verbose:
+                    sys.stderr.write("{0}: {1}\n".format(filename, line[8:]))
+                msgstr = True
+        return msgstr
+
     # Make a tree with source ... outputs working directory
     cmd = [ "bots/make-source", "po/cockpit.pot" ]
     if verbose:
@@ -53,6 +63,16 @@ def run(context, verbose=False, **kwargs):
     if verbose:
         sys.stderr.write("+ " + " ".join(cmd) + "\n")
     subprocess.check_call(cmd, cwd=cwd)
+
+    # Here we have logic to only include files that actually
+    # changed translations, and reset all the remaining ones
+    files = output("git", "ls-files", "--modified", "po/")
+    for name in files.split("\n"):
+        if name.endswith(".po"):
+            if changed(name):
+                execute("git", "add", "--", name)
+            else:
+                execute("git", "checkout", "--", name)
 
     # Create a pull request from these changes
     branch = task.branch(context, "po: Update from Fedora Zanata", pathspec="po/", **kwargs)

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -346,7 +346,8 @@ def branch(context, message, pathspec=".", issue=None, **kwargs):
     url = "https://github.com/{0}/cockpit".format(user)
     clean = "https://github.com/{0}/cockpit".format(user)
 
-    execute("git", "add", "--", pathspec)
+    if pathspec is not None:
+        execute("git", "add", "--", pathspec)
     execute("git", "checkout", "--detach")
 
     # If there's nothing to add at that pathspec return None


### PR DESCRIPTION
We can check which files actually had valid changes when updating translations. This makes the diffs easier for people to cross check.
