### PR TITLE
packagekit: Don't call loadHistory from render

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -729,6 +729,7 @@ class OsUpdates extends React.Component {
 
                                            if (exit === PK.Enum.EXIT_SUCCESS) {
                                                this.setState({ state: "updateSuccess", loadPercent: null });
+                                               this.loadHistory();
                                            } else if (exit === PK.Enum.EXIT_CANCELLED) {
                                                this.setState({ state: "loading", loadPercent: null });
                                                this.loadUpdates();
@@ -880,7 +881,6 @@ class OsUpdates extends React.Component {
             return <ApplyUpdates transaction={this.state.applyTransaction} />
 
         case "updateSuccess":
-            this.loadHistory();
             return <AskRestart onRestart={this.handleRestart} onIgnore={this.loadUpdates} history={this.state.history} />;
 
         case "restart":


### PR DESCRIPTION
This causes infinite loops since loadHistory sets the state, which
causes render to run again, etc.

Fixes #9114