### PR TITLE
test: Check privileged operations as FreeIPA admin

### DIFF
--- a/doc/guide/feature-realmd.xml
+++ b/doc/guide/feature-realmd.xml
@@ -24,4 +24,13 @@ $ <command>realm join example.com</command>
 Password for Administrator:
 </programlisting>
 
+<para>
+<ulink url="http://www.freedesktop.org/software/realmd/">realmd</ulink>
+sets up domain-qualified user names by default, i. e. login user names look like
+"<code>user@example.com</code>". For using unqualified names (just
+"<code>user</code>"), set the <code>fully-qualified-names</code> option in
+<ulink url="https://www.freedesktop.org/software/realmd/docs/realmd-conf.html">/etc/realmd.conf</ulink>
+before joining a domain.
+</para>
+
 </chapter>

--- a/pkg/lib/patterns.js
+++ b/pkg/lib/patterns.js
@@ -468,6 +468,7 @@
                   tooltip_element.attr('title', denied_message);
               tooltip_element.tooltip('fixTitle');
             }
+            $(this).attr('data-stable', 'yes');
         });
 
         return selector;

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -743,6 +743,8 @@ class MachineCase(unittest.TestCase):
                                     ".*Broken pipe.*",
                                     "g_dbus_connection_real_closed: Remote peer vanished with error: Underlying GIOStream returned 0 bytes on an async read \\(g-io-error-quark, 0\\). Exiting.",
                                     "connection unexpectedly closed by peer",
+                                    "cockpit-session: .*timed out.*",
+                                    "ignoring failure from session process:.*",
                                     "peer did not close io when expected",
                                     "request timed out, closing",
                                     "PolicyKit daemon disconnected from the bus.",

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -760,6 +760,7 @@ class MachineCase(unittest.TestCase):
 
     def allow_authorize_journal_messages(self):
         self.allow_journal_messages("cannot reauthorize identity.*:.*unix-user:admin.*",
+                                    "cannot reauthorize identity\(s\).*:.*unix-user:.*",
                                     ".*: pam_authenticate failed: Authentication failure",
                                     ".*is not in the sudoers file.  This incident will be reported.",
                                     ".*: a password is required",

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -25,6 +25,7 @@ import re
 import subprocess
 
 WAIT_KRB_SCRIPT = """
+set -ex
 # HACK: This needs to work, but may take a minute
 for x in $(seq 1 60); do
     if getent passwd admin@cockpit.lan; then

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -165,6 +165,8 @@ class TestRealms(MachineCase):
         b.click(".realms-op-cancel")
         b.wait_popdown("realms-op")
 
+        self.allow_restart_journal_messages()
+
     def testNotSupported(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -60,9 +60,29 @@ class TestRealms(MachineCase):
         "ipa": { "image": "ipa", "memory_mb": 2048 }
     }
 
+    def addSudoRule(self):
+        '''Allow "admins" IPA group members to run sudo'''
+
+        # HACK: https://pagure.io/freeipa/issue/7538
+        # This is an "unbreak my setup" step and ought to happen by default.
+        # Do that on the IPA server instead of the client:
+        #  - This avoids interfering too much with the client and test
+        #  - It is a more realistic scenario anyway (admins configuring everything
+        #    before clients join)
+        #  - It avoids long propagation delays
+        #  - It also works for Ubuntu clients that don't have the `ipa` CLI tool
+
+        ipa_machine = self.machines['ipa']
+        # need to wait for IPA to start up
+        ipa_machine.execute("while ! echo foobarfoo | kinit -f admin; do sleep 5; done", timeout=300)
+        ipa_machine.execute('export LC_ALL=C.UTF-8 && while ! ipa user-find >/dev/null; do sleep 5; done', timeout=300)
+        ipa_machine.execute('export LC_ALL=C.UTF-8 && ipa sudorule-add --hostcat=all --cmdcat=all All && ipa sudorule-add-user --groups=admins All')
+
     def testIpa(self):
         m = self.machine
         b = self.browser
+
+        self.addSudoRule()
 
         m.execute("hostnamectl set-hostname x0.cockpit.lan")
         self.login_and_go("/system")
@@ -99,9 +119,11 @@ class TestRealms(MachineCase):
         # should not have any leftover tickets from the joining
         m.execute("! klist")
         m.execute("! su -c klist admin")
+        b.logout()
 
-        # validate Kerberos setup for ws; requires FreeIPA with the "ipa" tool
+        # the following requires the "ipa" tool and fixed "admin" permission check (PR #9127)
         if m.image not in ["rhel-7-5", "ubuntu-1604"]:
+            # validate Kerberos setup for ws
             m.execute("echo foobarfoo | kinit -f admin@COCKPIT.LAN")
             m.execute(script=WAIT_KRB_SCRIPT, timeout=300)
 
@@ -114,6 +136,28 @@ class TestRealms(MachineCase):
                                 'http://x0.cockpit.lan:9090/cockpit/login'])
             self.assertIn("HTTP/1.1 200 OK", output)
             self.assertIn('"csrf-token"', output)
+
+            # wait until IPA user works
+            m.execute('while ! su - -c "echo foobarfoo | sudo -S true" admin@cockpit.lan; do sleep 5; done',
+                      timeout=300)
+
+            # log in as IPA admin and check that we can do privileged operations
+            orig_password = b.password
+            b.password = 'foobarfoo'
+
+            # Joining a domain with realmd enables `use_fully_qualified_names` by default; this is inconsistent with
+            # ipa-client-install (https://bugzilla.redhat.com/show_bug.cgi?id=1575538)
+            self.login_and_go('/system/services#/systemd-tmpfiles-clean.timer', user='admin@cockpit.lan')
+            b.wait_present('#service-unit')
+            b.wait_in_text('#service-unit', "waiting")
+            b.wait_present('#service-unit-action button[data-action="StopUnit"]')
+            b.click('#service-unit-action button[data-action="StopUnit"]')
+            b.wait_in_text('#service-unit', "dead")
+            b.logout()
+            b.password = orig_password
+
+            self.allow_authorize_journal_messages()
+
         elif m.image != "rhel-7-5":  # on 7.5 with older ws curl succeeds
             # curl negotiation should fail without a proper ws keytab; this provides a hint
             # when FreeIPA becomes new enough on the images above to start working
@@ -122,6 +166,9 @@ class TestRealms(MachineCase):
                      'http://x0.cockpit.lan:9090/cockpit/login'])
 
         # Leave the domain
+        b.login_and_go("/system")
+        b.wait_present("#system-info-domain a")
+        b.wait_in_text("#system-info-domain a", "cockpit.lan")
         b.click("#system-info-domain a")
         b.wait_popup("realms-op")
         b.wait_visible(".realms-op-leave-only-row")
@@ -167,6 +214,64 @@ class TestRealms(MachineCase):
         b.wait_popdown("realms-op")
 
         self.allow_restart_journal_messages()
+
+    @skipImage("Requires fixed admin permission check (PR #9127)", "rhel-7-5")
+    def testIpaUnqualifiedUsers(self):
+        m = self.machine
+        b = self.browser
+
+        self.addSudoRule()
+
+        m.execute("hostnamectl set-hostname x0.cockpit.lan")
+
+        # Wait for DNS to work as expected.
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1071356#c11
+        wait(lambda: m.execute("nslookup -type=SRV _ldap._tcp.cockpit.lan"))
+
+        # delete the local admin user, going to use the IPA one instead
+        m.execute("userdel --remove admin" )
+
+        # Tell realmd to not enable domain-qualified logins
+        # (https://bugzilla.redhat.com/show_bug.cgi?id=1575538)
+        m.execute("printf '[cockpit.lan]\\nfully-qualified-names = no\\n'  >> /etc/realmd.conf")
+        m.execute("echo foobarfoo | realm join -U admin cockpit.lan")
+
+        # wait until IPA user works
+        m.execute('while ! su - -c "echo foobarfoo | sudo -S true" admin; do sleep 5; done',
+                  timeout=300)
+
+        # login should now work with the IPA admin user
+        b.password = 'foobarfoo'
+        self.login_and_go("/system")
+        b.wait_present("#system-info-domain a")
+        b.wait_in_text("#system-info-domain a", "cockpit.lan")
+
+        # should be able to run admin operations
+        b.go('/system/services#/systemd-tmpfiles-clean.timer')
+        b.enter_page('/system/services')
+        b.wait_present('#service-unit')
+        b.wait_in_text('#service-unit', "waiting")
+        b.wait_present('#service-unit-action button[data-action="StopUnit"]')
+        b.click('#service-unit-action button[data-action="StopUnit"]')
+        b.wait_in_text('#service-unit', "dead")
+
+        b.go('/system')
+        b.enter_page('/system')
+        # it takes a while for the permission check to finish, it is always enabled at first
+        b.wait_present('#shutdown-group button.btn-danger[data-stable=yes]')
+        # shutdown button should be enabled and working
+        b.click("#shutdown-group button.btn-danger")
+        b.wait_popup("shutdown-dialog")
+        b.wait_in_text("#shutdown-dialog .btn-danger", 'Restart')
+        b.click("#shutdown-dialog .dropdown button")
+        b.click("a:contains('No Delay')")
+        b.click("#shutdown-dialog .btn-danger")
+        b.switch_to_top()
+        b.wait_visible(".curtains-ct")
+        b.wait_in_text(".curtains-ct h1", "Disconnected")
+        m.wait_reboot()
+
+        self.allow_authorize_journal_messages()
 
     def testNotSupported(self):
         m = self.machine


### PR DESCRIPTION
When using FreeIPA, admins are often/usually centrally managed as well.
Add a test case that does privileged operations (stopping a systemd
service) as FreeIPA-mananged central "admin" user.

There are two cases here, which we both check:

 * realmd enables `use_fully_qualified_names` by default, i. e.  they
   always have to be specified as "user@domain.name".  Note that this
   contradicts a direct `ipa-client-install` that keeps that option off 
   by default, see <https://bugzilla.redhat.com/show_bug.cgi?id=1575538>.

   This now gets covered in the existing `testIpa()` check. Also
   document it on the realmd feature page, as it's not immediately
   obvious. Depending on how the discussion goes on the above bug, we
   might also introduce an UI for this option at some point.

 * When using `ipa-client-install` directly it defaults to
   `use_fully_qualified_names` being off, i. e. IPA users are just
   written as "user". The same can be achieved with pre-configuring
   realmd. Cover this in a new `testIpaUnqualifiedUsers()` check.

In both cases a sudo rule for the `admins` IPA group needs to be added;
this should happen by default (https://pagure.io/freeipa/issue/7538)

----

TODO:
 - [x] Land #9127 to obsolete the `wheel` group requirement ~and remove the hack~ (that part is done)
 - [X] File [upstream bug](https://pagure.io/freeipa/issue/7538) for configuring sudo rule by default
 - [x] add user documentation for the qualified user names option
 - [x] fix [unexpected session timeout message](https://fedorapeople.org/groups/cockpit/logs/pull-9123-20180508-094848-8a1c7c21-verify-rhel-7-5/log.html#170)