### PR TITLE
bridge: Don't close dbus channels for unknown names

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -581,7 +581,11 @@ class OsUpdates extends React.Component {
 
     handleLoadError(ex) {
         console.error("loading available updates failed:", JSON.stringify(ex));
-        if (ex.problem === "not-found")
+        /* HACK: As of version 170, cockpit-bridge return a proper dbus error
+         * in "name", whereas older versions closed the channel with a
+         * "not-found" problem. Support both errors for now.
+         */
+        if (ex.problem === "not-found" || ex.name === "org.freedesktop.DBus.Error.ServiceUnknown")
             ex = _("PackageKit is not installed");
         this.state.errorMessages.push(ex.detail || ex.message || ex);
         this.setState({state: "loadError"});

--- a/src/base1/test-dbus.js
+++ b/src/base1/test-dbus.js
@@ -130,6 +130,40 @@ QUnit.asyncTest("owned messages", function() {
     acquire_name();
 });
 
+QUnit.asyncTest("call method on non-existent name", function() {
+    assert.expect(1);
+
+    var dbus = cockpit.dbus("com.example.nonexistent", { bus: "session" });
+    dbus.call("/foo", "com.example.nonexistent", "Foo", []).
+        then(function(reply) {
+           assert.ok(false, "should not return a reply");
+        }).
+        catch(function(error) {
+            assert.equal(error.name, "org.freedesktop.DBus.Error.ServiceUnknown");
+        }).
+        always(function() {
+            QUnit.start();
+        });
+});
+
+QUnit.asyncTest("should not be able to create proxy for non-existent name", function() {
+    assert.expect(1);
+
+    var dbus = cockpit.dbus("com.example.nonexistent", { bus: "session" });
+    var proxy = dbus.proxy("com.example.nonexistent", "/foo");
+
+    proxy.wait().
+        then(function(reply) {
+           assert.ok(false, "proxy should not become ready");
+        }).
+        catch(function (error) {
+           assert.equal(proxy.valid, false);
+        }).
+        always(function() {
+            QUnit.start();
+        });
+});
+
 QUnit.asyncTest("bad dbus address", function() {
     assert.expect(1);
 

--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -60,7 +60,6 @@ typedef struct {
   const gchar *default_name;
   guint default_watch;
   gboolean default_watched;
-  gboolean default_appeared;
 
   /* Call related */
   GCancellable *cancellable;
@@ -2676,12 +2675,6 @@ on_name_appeared (GDBusConnection *connection,
 
   g_object_ref (self);
 
-  if (!self->default_appeared)
-    {
-      self->default_appeared = TRUE;
-      send_ready (self);
-    }
-
   send_owned (self, name, name_owner);
 
   g_object_unref (self);
@@ -2699,8 +2692,6 @@ on_name_vanished (GDBusConnection *connection,
 
   if (!G_IS_DBUS_CONNECTION (connection) || g_dbus_connection_is_closed (connection))
     cockpit_channel_close (channel, "disconnected");
-  else if (!self->default_appeared)
-    cockpit_channel_close (channel, "not-found");
 }
 
 static CockpitDBusPeer *
@@ -2783,8 +2774,9 @@ process_connection (CockpitDBusJson *self,
       else
         {
           subscribe_and_cache (self);
-          send_ready (self);
         }
+
+      send_ready (self);
     }
 }
 

--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -2673,11 +2673,7 @@ on_name_appeared (GDBusConnection *connection,
 {
   CockpitDBusJson *self = COCKPIT_DBUS_JSON (user_data);
 
-  g_object_ref (self);
-
   send_owned (self, name, name_owner);
-
-  g_object_unref (self);
 }
 
 static void


### PR DESCRIPTION
Creating a dbus-json3 channel with a name that is not on the bus results
in the channel being closed immediately with a "not-found" error. That's
inconsistent behavior, because one can create such a client when the
name is available and the client continues to work when it disappears
and comes back.

Remove that restriction by not closing the channel on unknown names.
This is also how the similar function g_bus_watch_name() (which is used
in the bridge) works.