### PR TITLE
test: Enable firewall tests on the atomics

### DIFF
--- a/bots/images/scripts/lib/atomic.install
+++ b/bots/images/scripts/lib/atomic.install
@@ -260,6 +260,13 @@ class AtomicCockpitInstaller:
                           os.path.split(x)[-1].startswith("cockpit-machines")]
         self.install_packages(no_deps, deps=False, replace=True)
 
+        # If firewalld is installed, we need to poke a hole for cockpit, so
+        # that we can run firewall tests on it (change firewall-cmd to
+        # --add-service=cockpit once all supported atomics ship with the
+        # service file)
+        if subprocess.call(["systemctl", "enable", "--now", "firewalld"]) == 0:
+            subprocess.call(["firewall-cmd", "--permanent", "--add-port=9090/tcp"])
+
         self.commit_to_repo()
         self.switch_to_local_tree()
         self.update_container()

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -34,7 +34,6 @@ def wait_unit_state(machine, unit, state):
     wait(lambda: active_state(unit) == state, delay=0.2)
 
 
-@skipImage("firewalld not installed", "fedora-atomic", "rhel-atomic", "continuous-atomic")
 @skipImage("enabling firewall got fixed in PR #10511", "rhel-7-6-distropkg")
 class TestFirewall(MachineCase):
 


### PR DESCRIPTION
Depends on

- [ ] ~#9125 (these are the first images on which firewalld is disabled by default, which is broken)~