### PR TITLE
base1: Check root bridge instead of group membership in `permission()`

### DIFF
--- a/src/base1/test-permissions.js
+++ b/src/base1/test-permissions.js
@@ -25,9 +25,12 @@ var limited_user = {
 QUnit.module("Permission tests", {
     setup: function() {
         this.old_dbus = cockpit.dbus;
+        this.old_is_superuser = cockpit._is_superuser;
+        cockpit._is_superuser = false;
     },
     teardown: function() {
         cockpit.dbus = this.old_dbus;
+        cockpit._is_superuser = this.old_is_superuser;
     }
 });
 
@@ -58,7 +61,14 @@ QUnit.test("group-permissions", function() {
     assert.equal(p4.allowed, true, "no group match but root, allowed");
 });
 
-// Start tests after we have a user object
-cockpit.user().done(function (user) {
-    QUnit.start();
+QUnit.test("admin-permissions", function() {
+    assert.expect(2);
+
+    var p1 = cockpit.permission({ user: priv_user, _is_superuser: false, admin: true });
+    assert.equal(p1.allowed, false, "no superuser, admin not allowed");
+
+    var p2 = cockpit.permission({ user: priv_user, _is_superuser: true, admin: true });
+    assert.equal(p2.allowed, true, "superuser, admin allowed");
 });
+
+QUnit.start();

--- a/test/verify/check-shutdown-restart
+++ b/test/verify/check-shutdown-restart
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import time
+
 import parent
 from testlib import *
 
@@ -32,7 +34,7 @@ class TestShutdownRestart(MachineCase):
         self.machine.execute("hostnamectl set-hostname machine1")
         self.machines['machine2'].execute("hostnamectl set-hostname machine2")
 
-    def testNoPermission(self):
+    def testNoAdminGroup(self):
         m = self.machine
         b = self.browser
 
@@ -55,6 +57,30 @@ class TestShutdownRestart(MachineCase):
         b.wait_present("#shutdown-group button.btn-danger.disabled")
         b.wait_present("#shutdown-group button.btn-default.disabled")
         b.wait_not_present("#shutdown-group button:not(.disabled)")
+
+        b.logout()
+
+        if m.image != "rhel-7-5":
+            # now give user direct sudo access
+            m.execute("echo 'user ALL=(ALL) ALL' > /etc/sudoers.d/user")
+            self.login_and_go("/system", user="user")
+
+            # it takes a while for the permission check to finish, it is always enabled at first
+            time.sleep(2)
+
+            # shutdown button should be enabled and working
+            b.click("#shutdown-group button.btn-danger")
+            b.wait_popup("shutdown-dialog")
+            b.wait_in_text("#shutdown-dialog .btn-danger", 'Restart')
+            b.click("#shutdown-dialog .dropdown button")
+            b.click("a:contains('No Delay')")
+            b.click("#shutdown-dialog .btn-danger")
+            b.switch_to_top()
+
+            b.wait_visible(".curtains-ct")
+            b.wait_in_text(".curtains-ct h1", "Disconnected")
+
+            m.wait_reboot()
 
     def testBasic(self):
         m = self.machine


### PR DESCRIPTION
Previously, `cockpit.permission({ admin: true })` checked whether the
user was in the `wheel` (Fedora/RHEL) or `sudo` (Debian/Ubuntu) groups.
But this is insufficient: Other operating systems or customized systems
might use other groups, or have user instead of group based sudo rules.
For example: With FreeIPA, sudo access is given through the
`admins@domain.name` group, causing all `cockpit.permission()` guarded
functionality to be disabled.

Instead, check if we have a running superuser bridge by testing if we
can create a `null` channel with `superuser`.

Add coverage of `admin: true` to the unit test; it wasn't covered
before, and it's the only mode that we actually use in production.
Also simplify the test a bit: It's not necessary to wait on the real
`cockpit.user()`, as the function gets mock data passed in through the
(undocumented) `user` and `_is_superuser` properties.

https://bugzilla.redhat.com/show_bug.cgi?id=1574630