### PR TITLE
containers/ws: Replace deprecated MAINTAINER with LABEL

### DIFF
--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:26
-MAINTAINER "Stef Walter" <stefw@redhat.com>
+LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
 
 ARG VERSION
 
@@ -10,9 +10,9 @@ RUN echo -e '[group_cockpit-cockpit-preview]\nname=Copr repo for cockpit-preview
 # Again see above ... we do our branching in shell script
 RUN /container/install-package.sh && /container/prep-container.sh
 
-LABEL INSTALL /usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-install
-LABEL UNINSTALL /usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-uninstall
-LABEL RUN /usr/bin/docker run -d --privileged --pid=host -v /:/host IMAGE /container/atomic-run --local-ssh
+LABEL INSTALL="/usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-install"
+LABEL UNINSTALL="/usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-uninstall"
+LABEL RUN="/usr/bin/docker run -d --privileged --pid=host -v /:/host IMAGE /container/atomic-run --local-ssh"
 
 # Look ma, no EXPOSE
 

--- a/containers/ws/Dockerfile.centos7
+++ b/containers/ws/Dockerfile.centos7
@@ -1,5 +1,5 @@
 FROM registry.centos.org/centos/centos
-MAINTAINER "Stef Walter" <stefw@redhat.com>
+LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
 
 ARG VERSION
 ARG INSTALLER="yum"
@@ -9,9 +9,9 @@ ADD . /container
 # Again see above ... we do our branching in shell script
 RUN /container/install-package.sh && /container/prep-container.sh
 
-LABEL INSTALL /usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-install
-LABEL UNINSTALL /usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-uninstall
-LABEL RUN /usr/bin/docker run -d --privileged --pid=host -v /:/host IMAGE /container/atomic-run --local-ssh
+LABEL INSTALL="/usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-install"
+LABEL UNINSTALL="/usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-uninstall"
+LABEL RUN="/usr/bin/docker run -d --privileged --pid=host -v /:/host IMAGE /container/atomic-run --local-ssh"
 
 # Look ma, no EXPOSE
 

--- a/containers/ws/Dockerfile.testing.centos7
+++ b/containers/ws/Dockerfile.testing.centos7
@@ -1,5 +1,5 @@
 FROM registry.centos.org/centos/centos
-MAINTAINER "Stef Walter" <stefw@redhat.com>
+LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
 
 ARG VERSION
 ARG INSTALLER="yum"
@@ -11,9 +11,9 @@ RUN echo -e "[cockpit_test]\nname=Cockpit Test\nbaseurl=http://cbs.centos.org/re
 # Again see above ... we do our branching in shell script
 RUN /container/install-package.sh && /container/prep-container.sh
 
-LABEL INSTALL /usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-install
-LABEL UNINSTALL /usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-uninstall
-LABEL RUN /usr/bin/docker run -d --privileged --pid=host -v /:/host IMAGE /container/atomic-run --local-ssh
+LABEL INSTALL="/usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-install"
+LABEL UNINSTALL="/usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-uninstall"
+LABEL RUN="/usr/bin/docker run -d --privileged --pid=host -v /:/host IMAGE /container/atomic-run --local-ssh"
 
 # Look ma, no EXPOSE
 


### PR DESCRIPTION
- Change the maintainer to our mailing list.
- Use the officially documented syntax with `="value"`
  (https://docs.docker.com/engine/reference/builder/#label).