### PR TITLE
naughty: Close 8903: system 238 regression: logind sessions stuck in "closing" state after daemon-reload

### DIFF
--- a/bots/naughty/rhel-8/8903-systemd-session-stuck-in-closing
+++ b/bots/naughty/rhel-8/8903-systemd-session-stuck-in-closing
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-session", line *, in testBasic
-    wait_session(False)
-*
-Error: Condition did not become true.


### PR DESCRIPTION
Known issue which has not occurred in 25 days

system 238 regression: logind sessions stuck in "closing" state after daemon-reload

Fixes #8903