### PR TITLE
doc: Use https:// URLs

### DIFF
--- a/doc/guide/api-system.xml
+++ b/doc/guide/api-system.xml
@@ -41,7 +41,7 @@
           <listitem>
             <para><code>#?prio=5</code></para>
             <para>Filters the log to show entries below the specific priority, inclusive. These
-              <ulink url="http://en.wikipedia.org/wiki/Syslog#Severity_levels">priorities are syslog levels</ulink>.
+              <ulink url="https://en.wikipedia.org/wiki/Syslog#Severity_levels">priorities are syslog levels</ulink>.
               Specifying <code>*</code> as a priority will show all available entries. The default
               priority is <code>3</code>.</para>
           </listitem>

--- a/doc/guide/authentication.xml
+++ b/doc/guide/authentication.xml
@@ -22,7 +22,7 @@
       solution</link>.</para>
 
     <para>The web server can also be run from the <filename>cockpit/ws</filename> docker
-      container. If you are running cockpit on an <ulink url="http://www.projectatomic.io/">
+      container. If you are running cockpit on an <ulink url="https://www.projectatomic.io/">
       Atomic Host</ulink> this will be the default. In this setup, cockpit establishes an
       SSH connection from the container to the underlying host, meaning that it is up to
       your SSH server to grant access. To login with a local account, <filename>sshd

--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -128,7 +128,7 @@ client = cockpit.dbus(name, [options])
         <listitem><para>Set to <code>"require"</code> to talk to this service as root.
           The DBus service will see the DBus method calls and accesses as coming from root,
           rather than the logged in user. This is useful for talking to services that do not
-          correctly use <ulink url="http://www.freedesktop.org/software/polkit">polkit</ulink>
+          correctly use <ulink url="https://www.freedesktop.org/software/polkit">polkit</ulink>
           to authorize administrative users. If the currently logged in user is not
           permitted to become root (eg: via <code>pkexec</code>) then the <code>client</code> will
           immediately be <link linkend="cockpit-dbus-onclose">closed</link> with a
@@ -611,7 +611,7 @@ invocation.done(function(args, options) { ... })
 invocation.fail(function(exception) { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="http://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
+      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
       It sets up a handler to be called when the DBus method call fails.</para>
 
     <para>The <code>exception</code> object passed to the handler can have the
@@ -643,7 +643,7 @@ invocation.fail(function(exception) { ... })
 invocation.always(function() { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="http://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
+      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
       It sets up a handler to be called when the DBus method call finishes whether successfully,
       or fails.</para>
   </refsection>
@@ -725,11 +725,11 @@ watch = client.watch({ "path_namespace": path_namespace, "interface": interface 
       show up before that method call reply is received, or signal event is triggered.
       It should be possible to rely on this guarantee, unless the DBus service in question
       behaves incorrectly. Internally these watches work well with code that implements the
-      <ulink url="http://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-objectmanager">ObjectManager</ulink>
+      <ulink url="https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-objectmanager">ObjectManager</ulink>
       portion of the DBus specification. If no ObjectManager implementation is available, the
       watch falls back to using DBus
-      <ulink url="http://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-introspectable">Introspection</ulink> along with the usual
-      <ulink url="http://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-properties">PropertiesChanged</ulink> signal. If the DBus service implements none of these, or implements them in an
+      <ulink url="https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-introspectable">Introspection</ulink> along with the usual
+      <ulink url="https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-properties">PropertiesChanged</ulink> signal. If the DBus service implements none of these, or implements them in an
       inconsistent manner, then this function will provide inconsistent or unexpected
       results.</para>
 
@@ -785,7 +785,7 @@ watch.done(function() { ... })
 watch.fail(function() { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="http://api.jquery.com/category/deferred-object/">jQuery promise</ulink>
+      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink>
       method. It sets up a handler to be called if the watch fails to populate its initial
       properties and interfaces. Note that a watch will only fail if the DBus client
       closes or is somehow disconnected. It does not fail in the case of missing
@@ -798,7 +798,7 @@ watch.fail(function() { ... })
 watch.always(function() { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="http://api.jquery.com/category/deferred-object/">jQuery promise</ulink>
+      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink>
       method. It sets up a handler to be called when the watch has populated its initial
       properties and interfaces or has failed to do so.</para>
   </refsection>

--- a/doc/guide/cockpit-http.xml
+++ b/doc/guide/cockpit-http.xml
@@ -136,7 +136,7 @@ request.done(function(data) { ... })
 request.fail(function(exception[, data]) { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="http://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
+      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
       It sets up a handler to be called when the request fails, or returns an error code.</para>
 
     <para>The <code>exception</code> object passed to the handler can have the
@@ -176,7 +176,7 @@ request.fail(function(exception[, data]) { ... })
 request.always(function() { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="http://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
+      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
       It sets up a handler to be called when the process completes, whether it exits successfully,
       fails, terminates, or exits with a failure.</para>
   </refsection>

--- a/doc/guide/cockpit-metrics.xml
+++ b/doc/guide/cockpit-metrics.xml
@@ -53,7 +53,7 @@ metrics = cockpit.metrics(interval, options, cache)
           to <code>"internal"</code> to retrieve internal metrics read
           by the bridge. If set to <code>"direct"</code> or
           <code>"pmcd"</code> then data will be retrieved from <ulink
-          url="http://pcp.io">PCP</ulink>if it is available. The
+          url="https://pcp.io">PCP</ulink>if it is available. The
           default is <code>"internal"</code>.</para></listitem>
       </varlistentry>
       <varlistentry>

--- a/doc/guide/cockpit-spawn.xml
+++ b/doc/guide/cockpit-spawn.xml
@@ -154,7 +154,7 @@ process.done(function(data[, message]) { ... })
 process.fail(function(exception[, data]) { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="http://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
+      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
       It sets up a handler to be called when the process fails, terminates or exits.</para>
 
     <para>The <code>exception</code> object passed to the handler can have the
@@ -195,7 +195,7 @@ process.fail(function(exception[, data]) { ... })
 process.always(function() { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="http://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
+      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
       It sets up a handler to be called when the process completes, whether it exits successfully,
       fails, terminates, or exits with a failure.</para>
   </refsection>

--- a/doc/guide/embedding.xml
+++ b/doc/guide/embedding.xml
@@ -95,7 +95,7 @@ GET: https://server.example.com:9090/ping
 </programlisting>
 
     <para>The <code>/ping</code> request allows
-      <ulink url="http://en.wikipedia.org/wiki/Cross-origin_resource_sharing">Cross Origin Resource Sharing</ulink>
+      <ulink url="https://en.wikipedia.org/wiki/Cross-origin_resource_sharing">Cross Origin Resource Sharing</ulink>
       headers and as such can be performed from Javascript code with any origin. The request can also be
       made via plain HTTP without SSL. It is by design that no further information is present in the
       response.</para>

--- a/doc/guide/feature-journal.xml
+++ b/doc/guide/feature-journal.xml
@@ -8,7 +8,7 @@
     services, storage, networking etc.</para>
 
   <para>Cockpit accesses Journal data via the
-    <ulink url="http://www.freedesktop.org/software/systemd/man/journalctl.html"><code>journalctl</code></ulink>
+    <ulink url="https://www.freedesktop.org/software/systemd/man/journalctl.html"><code>journalctl</code></ulink>
     command. Similar tasks can be performed at the command line:</para>
 
 <programlisting>

--- a/doc/guide/feature-kubernetes.xml
+++ b/doc/guide/feature-kubernetes.xml
@@ -5,12 +5,12 @@
   <title>Kubernetes</title>
 
   <para>Cockpit has a dashboard that interacts with a
-    <ulink url="http://kubernetes.io/">Kubernetes cluster</ulink> or an
+    <ulink url="https://kubernetes.io/">Kubernetes cluster</ulink> or an
     <ulink url="https://enterprise.openshift.com/">Openshift v3 cluster</ulink>. This
     functionality is in the Cockpit <emphasis>kubernetes</emphasis> package.</para>
 
   <para>The dashboard can either be deployed on kubernetes as a
-    <ulink url="http://kubernetes.io/docs/user-guide/pods/">container in a pod</ulink> or used
+    <ulink url="https://kubernetes.io/docs/user-guide/pods/">container in a pod</ulink> or used
     via a normal authenticated Cockpit session. Cockpit communicates with Kubernetes via its
     REST API.</para>
 

--- a/doc/guide/feature-pcp.xml
+++ b/doc/guide/feature-pcp.xml
@@ -5,15 +5,15 @@
   <title>PCP</title>
 
   <para>If available, Cockpit uses the
-    <ulink url="http://www.pcp.io/">Performance Co-Pilot</ulink> framework to
+    <ulink url="https://pcp.io/">Performance Co-Pilot</ulink> framework to
     gather metrics data about the system. This data is used to display graphs.
     Cockpit can use the PCP logging feature to display archived data about the
     system from a different point in time. If PCP is not available, then Cockpit
     gathers the metrics data itself, but archival features are not available.</para>
 
   <para>To see similar metrics data from the command line, you can use tools like
-    <ulink url="http://www.pcp.io/books/PCP_UAG/html/LE38515-PARENT.html#LE91266-PARENT"><code>pmstat</code></ulink>
-    or <ulink url="http://www.pcp.io/books/PCP_UAG/html/LE60452-PARENT.html"><code>pminfo</code></ulink>:</para>
+    <ulink url="https://pcp.io/books/PCP_UAG/html/LE38515-PARENT.html#LE91266-PARENT"><code>pmstat</code></ulink>
+    or <ulink url="https://pcp.io/books/PCP_UAG/html/LE60452-PARENT.html"><code>pminfo</code></ulink>:</para>
 
 <programlisting>
 $ <command>pmstat</command>

--- a/doc/guide/feature-realmd.xml
+++ b/doc/guide/feature-realmd.xml
@@ -5,7 +5,7 @@
   <title>realmd</title>
 
   <para>If available on the system, Cockpit uses
-    <ulink url="http://www.freedesktop.org/software/realmd/">realmd</ulink>
+    <ulink url="https://www.freedesktop.org/software/realmd/">realmd</ulink>
     and the DBus APIs it provides to configure the system's Active Directory
     or IPA domain membership.</para>
 
@@ -17,7 +17,7 @@
     the same permissions as they do from the command line.</para>
 
   <para>To perform similar tasks from the command line, use the
-    <ulink url="http://www.freedesktop.org/software/realmd/docs/realm.html">realm</ulink> command:</para>
+    <ulink url="https://www.freedesktop.org/software/realmd/docs/realm.html">realm</ulink> command:</para>
 
 <programlisting>
 $ <command>realm join example.com</command>

--- a/doc/guide/feature-subscription.xml
+++ b/doc/guide/feature-subscription.xml
@@ -5,7 +5,7 @@
   <title>Subscription Manager</title>
 
   <para>Cockpit can use
-    <ulink url="http://www.candlepinproject.org/">Subscription Manager</ulink> to join the
+    <ulink url="https://www.candlepinproject.org/">Subscription Manager</ulink> to join the
     attach the machine to a subscription, if the operating system (such as RHEL) requires this. This
     functionality is in the Cockpit <emphasis>subscriptions</emphasis> package.</para>
 
@@ -14,7 +14,7 @@
     to root in order to access subscription information or make changes.</para>
 
   <para>To perform similar tasks from the command line, use the
-    <ulink url="http://linux.die.net/man/8/subscription-manager"><code>subscription-manager</code></ulink>
+    <ulink url="https://linux.die.net/man/8/subscription-manager"><code>subscription-manager</code></ulink>
     tool:</para>
 
 <programlisting>

--- a/doc/guide/feature-systemd.xml
+++ b/doc/guide/feature-systemd.xml
@@ -5,7 +5,7 @@
   <title>systemd</title>
 
   <para>Cockpit uses
-    <ulink url="http://www.freedesktop.org/wiki/Software/systemd/">systemd</ulink>
+    <ulink url="https://www.freedesktop.org/wiki/Software/systemd/">systemd</ulink>
     and the DBus APIs it provides to configure and monitor core aspects of the system.
     Use of alternate system APIs are not currently implemented.</para>
 
@@ -15,7 +15,7 @@
 
   <para>Cockpit retrieves information about the host and changes the hostname via the
     <code>hostnamed</code> daemon. To perform similar tasks from the command line use the
-    <ulink url="http://www.freedesktop.org/software/systemd/man/hostnamectl.html"><code>hostnamectl</code></ulink>
+    <ulink url="https://www.freedesktop.org/software/systemd/man/hostnamectl.html"><code>hostnamectl</code></ulink>
     command:</para>
 
 <programlisting>
@@ -34,7 +34,7 @@ $ <command>hostnamectl</command>
 
   <para>Cockpit configures the system time and time zone via the <code>timedated</code> daemon.
     To perform similar tasks from the command line use the
-    <ulink url="http://www.freedesktop.org/software/systemd/man/timedatectl.html"><code>timedatectl</code></ulink>
+    <ulink url="https://www.freedesktop.org/software/systemd/man/timedatectl.html"><code>timedatectl</code></ulink>
     command:</para>
 
 <programlisting>
@@ -56,7 +56,7 @@ Africa/Algiers
     behave inconsistently with regards to time synchronization.</para>
 
   <para>Cockpit restarts or powers down the machine by using the
-    <ulink url="http://www.freedesktop.org/software/systemd/man/shutdown.html"><code>shutdown</code></ulink>
+    <ulink url="https://www.freedesktop.org/software/systemd/man/shutdown.html"><code>shutdown</code></ulink>
     command. To perform similar tasks from the command line, run it directly:</para>
 
 <programlisting>
@@ -66,7 +66,7 @@ Shutdown scheduled for Sa 2015-09-26 15:49:40 CEST, use 'shutdown -c' to cancel.
 
   <para>Cockpit manages system services and sockets via systemd. To perform similar tasks from the
     command line use the
-    <ulink url="http://www.freedesktop.org/software/systemd/man/systemctl.html"><code>systemctl</code></ulink>
+    <ulink url="https://www.freedesktop.org/software/systemd/man/systemctl.html"><code>systemctl</code></ulink>
     command:</para>
 
 <programlisting>

--- a/doc/guide/feature-virtualmachines.xml
+++ b/doc/guide/feature-virtualmachines.xml
@@ -8,7 +8,7 @@
         These can be accessed from menu via <emphasis>Virtual Machines</emphasis></para>
 
     <para>Primary datasource is <ulink url="https://www.qemu.org/">QEMU</ulink> / <ulink url="https://libvirt.org/">Libvirt</ulink>,
-        access to Libvirtd is wrapped by the <ulink url="http://libvirt.org/virshcmdref.html">virsh</ulink> tool.</para>
+        access to Libvirtd is wrapped by the <ulink url="https://libvirt.org/virshcmdref.html">virsh</ulink> tool.</para>
 
     <section id="feature-virtualmachines-nestedvirtualization">
     <title>Nested Virtualization</title>

--- a/doc/guide/https.xml
+++ b/doc/guide/https.xml
@@ -92,7 +92,7 @@ Environment=G_TLS_GNUTLS_PRIORITY=NORMAL:%COMPAT
 </programlisting>
 
     <para>The environment variable value is a
-      <ulink url="http://gnutls.org/manual/html_node/Priority-Strings.html#Priority-Strings">GnuTLS priority string</ulink>.</para>
+      <ulink url="https://gnutls.org/manual/html_node/Priority-Strings.html#Priority-Strings">GnuTLS priority string</ulink>.</para>
 
   </section>
 

--- a/doc/guide/listen.xml
+++ b/doc/guide/listen.xml
@@ -26,7 +26,7 @@
     <title>Cockpit systemd Socket</title>
 
     <para>On servers with
-      <ulink url="http://www.freedesktop.org/wiki/Software/systemd/"><code>systemd</code></ulink>
+      <ulink url="https://www.freedesktop.org/wiki/Software/systemd/"><code>systemd</code></ulink>
       Cockpit starts on demand via socket activation. To change its port and/or address
       you should place the following content in the
       <code>/etc/systemd/system/cockpit.socket.d/listen.conf</code> file. Create the file
@@ -70,7 +70,7 @@ $ sudo systemctl restart cockpit.socket
   <section id="listen-selinux">
     <title>SELinux Port</title>
 
-    <para>If <ulink url="http://selinuxproject.org/page/Main_Page">SELinux</ulink> is
+    <para>If <ulink url="https://selinuxproject.org/page/Main_Page">SELinux</ulink> is
       protecting your server, then you will need to tell it to allow Cockpit to listen
       on the new port. Run the following command to do so. The last argument specifies
       the desired TCP port.</para>

--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -26,7 +26,7 @@
       along with dash, underscore, dot, and comma. No spaces are allowed.</para>
 
     <para>Cockpit uses the data directories from the
-      <ulink url="http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html">XDG Base Directory
+      <ulink url="https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html">XDG Base Directory
         Specification</ulink>
       to locate packages. The <code>$XDG_DATA_DIRS</code> represents a colon separate list of system data
       directories, and <code>$XDG_DATA_HOME</code> is a user specific data directory. If the environment

--- a/doc/guide/privileges.xml
+++ b/doc/guide/privileges.xml
@@ -9,8 +9,8 @@
     the console.</para>
 
   <para>In some cases Cockpit will try to escalate the privileges of the user
-    using <ulink url="http://www.freedesktop.org/wiki/Software/polkit/">Policy Kit</ulink>
-    or <ulink url="http://www.sudo.ws/">sudo</ulink>. If the user is able to escalate
+    using <ulink url="https://www.freedesktop.org/wiki/Software/polkit/">Policy Kit</ulink>
+    or <ulink url="https://www.sudo.ws/">sudo</ulink>. If the user is able to escalate
     privileges from the command line, then Cockpit will use that same capability to
     perform certain privileged tasks.</para>
 
@@ -42,9 +42,9 @@ $ pkexec cockpit-bridge
   <section id="privileges-polkit">
     <title>Customizing Polkit Privileges</title>
 
-    <para>Services like <ulink url="http://www.freedesktop.org/wiki/Software/systemd/">systemd</ulink>
+    <para>Services like <ulink url="https://www.freedesktop.org/wiki/Software/systemd/">systemd</ulink>
       and <ulink url="https://wiki.gnome.org/Projects/NetworkManager">NetworkManager</ulink> use
-      <ulink url="http://www.freedesktop.org/wiki/Software/polkit/">Polkit</ulink> to
+      <ulink url="https://www.freedesktop.org/wiki/Software/polkit/">Polkit</ulink> to
       validate and escalate privileges. It is possible to customize these rules with files
       in <filename>/etc/polkit-1/rules.d</filename>.</para>
 

--- a/doc/guide/sso.xml
+++ b/doc/guide/sso.xml
@@ -12,7 +12,7 @@
 
     <para>To authenticate users, the server that Cockpit is running on must be
       joined to a domain. This can usually be accomplished using the
-      <ulink url="http://freedesktop.org/software/realmd/docs/realm.html"><code>realm join example.com</code></ulink>
+      <ulink url="https://freedesktop.org/software/realmd/docs/realm.html"><code>realm join example.com</code></ulink>
       command.</para>
 
     <para>The domain must be resolvable by DNS. For instance, the SRV records of the

--- a/doc/guide/startup.xml
+++ b/doc/guide/startup.xml
@@ -6,7 +6,7 @@
 
   <para>Cockpit's <code>cockpit-ws</code> component is what the browser connects to
     and it typically starts on demand via
-    <ulink url="http://www.freedesktop.org/wiki/Software/systemd/"><code>systemd</code></ulink>
+    <ulink url="https://www.freedesktop.org/wiki/Software/systemd/"><code>systemd</code></ulink>
     socket activation.</para>
 
   <para>The actual <code>cockpit.service</code> and <code>cockpit-ws</code> process will start on


### PR DESCRIPTION
Except for cockpit-project.org, which does not have a valid SSL
certificate yet.