### PR TITLE
tools: Add conditional cockpit-packagekit dependency to our metapackage

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -112,6 +112,7 @@ Requires: %{name}-system = %{version}-%{release}
 Recommends: %{name}-dashboard = %{version}-%{release}
 Recommends: (%{name}-networkmanager = %{version}-%{release} if NetworkManager)
 Recommends: (%{name}-storaged = %{version}-%{release} if udisks2)
+Recommends: (%{name}-packagekit = %{version}-%{release} if PackageKit)
 %if 0%{?rhel} >= 8
 Recommends: subscription-manager-cockpit
 %endif


### PR DESCRIPTION
If PackageKit is already installed, make "cockpit" pull in
cockpit-packagekit as well. It becomes more and more important for
discovering apps (including Cockpit's own extensions), installing
packages on demand (such as nfs-utils or pcp), or showing available
updates and missing subscription.