### PR TITLE
ws: Fix assertion when translations are missing

### DIFF
--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -395,7 +395,7 @@ send_login_html (CockpitWebResponse *response,
           g_message ("%s", error->message);
           g_clear_error (&error);
         }
-      else
+      else if (po_bytes)
         {
           filter3 = cockpit_web_inject_new (marker, po_bytes, 1);
           g_bytes_unref (po_bytes);


### PR DESCRIPTION
When the translations are missing, cockpit-ws fails to start.
The browser gets 'Connection Refused' due to this failure:

    cockpit-ws[22669]: cockpit_web_inject_new: assertion 'inject != NULL' failed