### PR TITLE
bots: Move default test image to fedora-28

### DIFF
--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -33,7 +33,7 @@ import tempfile
 import sys
 import time
 
-TEST_OS_DEFAULT = "fedora-27"
+TEST_OS_DEFAULT = "fedora-28"
 
 DEFAULT_IMAGE = os.environ.get("TEST_OS", TEST_OS_DEFAULT)
 

--- a/test/README
+++ b/test/README
@@ -73,7 +73,7 @@ You can set these environment variables to configure the test suite:
                 "fedora-testing"
                 "rhel-7"
                 "ubuntu-1604"
-             "fedora-27" is the default (testvm.py)
+             "fedora-28" is the default (testvm.py)
 
   TEST_DATA  Where to find and store test machine images.  The
              default is the same directory that this README file is in.


### PR DESCRIPTION
It is released now and our primary Fedora target.