### PR TITLE
machines: Create and Attach disk to a virtual machine

### DIFF
--- a/pkg/machines/actions.es6
+++ b/pkg/machines/actions.es6
@@ -51,6 +51,14 @@ export function getOsInfoList() {
     return virt('GET_OS_INFO_LIST');
 }
 
+export function getStoragePools(connectionName) {
+    return virt('GET_STORAGE_POOLS', { connectionName });
+}
+
+export function getStorageVolumes(connectionName, poolName) {
+    return virt('GET_STORAGE_VOLUMES', { connectionName, poolName });
+}
+
 export function shutdownVm(vm) {
     return virt('SHUTDOWN_VM', { name: vm.name, id: vm.id, connectionName: vm.connectionName });
 }
@@ -130,7 +138,15 @@ export function setVCPUSettings(vm, max, count, sockets, threads, cores) {
 }
 
 export function getHypervisorMaxVCPU(connectionName) {
-    return virt('GET_HYPERVISOR_MAX_VCPU', { connectionName });
+    return virt('GET_HYPERVISOR_MAX_VCPU', {connectionName});
+}
+
+export function volumeCreateAndAttach({ connectionName, poolName, volumeName, size, format, target, permanent, hotplug, vmName }) {
+    return virt('CREATE_AND_ATTACH_VOLUME', { connectionName, poolName, volumeName, size, format, target, permanent, hotplug, vmName });
+}
+
+export function attachDisk({ connectionName, diskFileName, target, permanent, hotplug, vmName }) {
+    return virt('ATTACH_DISK', { connectionName, diskFileName, target, permanent, hotplug, vmName });
 }
 
 /**
@@ -190,6 +206,27 @@ export function updateVm(props) {
     return {
         type: 'UPDATE_VM',
         vm: props,
+    };
+}
+
+export function updateStoragePools({ connectionName, pools }) {
+    return {
+        type: 'UPDATE_STORAGE_POOLS',
+        payload: {
+            connectionName,
+            pools,
+        }
+    };
+}
+
+export function updateStorageVolumes({ connectionName, poolName, volumes }) {
+    return {
+        type: 'UPDATE_STORAGE_VOLUMES',
+        payload: {
+            connectionName,
+            poolName,
+            volumes,
+        },
     };
 }
 

--- a/pkg/machines/app.jsx
+++ b/pkg/machines/app.jsx
@@ -22,7 +22,7 @@ import LibvirtSlate from "./components/libvirtSlate.jsx"
 import { createVmAction } from "./components/create-vm-dialog/createVmDialog.jsx";
 
 const App = ({ store }) => {
-    const { vms, config, systemInfo, ui } = store.getState();
+    const { vms, config, storagePools, systemInfo, ui } = store.getState();
     const dispatch = store.dispatch;
 
     if (systemInfo.libvirtService.activeState !== 'running') {
@@ -33,6 +33,7 @@ const App = ({ store }) => {
     return (<HostVmsList vms={vms}
         config={config}
         ui={ui}
+        storagePools={storagePools}
         dispatch={dispatch}
         actions={createVmAction({ dispatch, systemInfo })} />);
 };

--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -24,8 +24,6 @@ import Select from "cockpit-components-select.jsx";
 import FileAutoComplete from "cockpit-components-file-autocomplete.jsx";
 import { createVm, addErrorNotification } from '../../actions.es6';
 import {
-    digitFilter,
-    toFixedPrecision,
     isEmpty,
     convertToUnit,
     timeoutedPromise,
@@ -40,6 +38,7 @@ import {
     prepareVendors,
     getOSStringRepresentation,
 } from "./createVmDialogUtils.es6";
+import MemorySelectRow from '../memorySelectRow.jsx';
 
 import './createVmDialog.less';
 import VMS_CONFIG from '../../config.es6';
@@ -48,47 +47,6 @@ const _ = cockpit.gettext;
 
 const URL_SOURCE = 'url';
 const COCKPIT_FILESYSTEM_SOURCE = 'file';
-
-const MemorySelectRow = ({ label, id, value, initialUnit, onValueChange, onUnitChange }) => {
-    return (
-        <tr>
-            <td className="top">
-                <label className="control-label" htmlFor={id}>
-                    {label}
-                </label>
-            </td>
-            <td>
-                <div className="thirty-five-spaced-table">
-                    <span className="evenly-spaced-cell">
-                        <div className="evenly-spaced-table">
-                            <span className="evenly-spaced-cell">
-                                <input id={id} className="form-control"
-                                       type="number"
-                                       value={toFixedPrecision(value)}
-                                       onKeyPress={digitFilter}
-                                       step={1}
-                                       min={0}
-                                       onChange={onValueChange} />
-                            </span>
-                            <span className="thirty-five-spaced-cell padding-left">
-                                <Select.Select id={id + "-unit-select"}
-                                               initial={initialUnit}
-                                               onChange={onUnitChange}>
-                                    <Select.SelectEntry data={units.MiB.name} key={units.MiB.name}>
-                                        {_("MiB")}
-                                    </Select.SelectEntry>
-                                    <Select.SelectEntry data={units.GiB.name} key={units.GiB.name}>
-                                        {_("GiB")}
-                                    </Select.SelectEntry>
-                                </Select.Select>
-                            </span>
-                        </div>
-                    </span>
-                </div>
-            </td>
-        </tr>
-    );
-};
 
 /* Create a virtual machine
  * props:

--- a/pkg/machines/components/diskAdd.css
+++ b/pkg/machines/components/diskAdd.css
@@ -1,0 +1,66 @@
+.dialog-field {
+    display: inline-flex;
+    padding: 0px;
+}
+
+.dialog-field > label {
+    white-space: nowrap;
+    color: #888888;
+    float: right;
+    width: 100%;
+    text-align: right;
+}
+
+.dialog-field .form-control {
+    margin-left: 5px !important;
+}
+
+.modal-body .add-disk-dialog {
+    height: 16em;
+    padding-bottom: 0px !important;
+}
+
+.add-disk-body {
+    margin-top: 1em;
+}
+
+.add-disk-body .row {
+    padding-bottom: 0.5em;
+}
+
+.add-disk-body .row:first-child {
+    padding-bottom: 2em;
+    padding-top: 1em;
+}
+
+.add-disk-body .row:last-child {
+    padding-top: 1em;
+}
+
+.add-disk-size {
+    width: 5em;
+    margin-right: 5px;
+    text-align: right;
+}
+
+.add-disk-target > label {
+    width: auto;
+    padding-left: 2em;
+}
+
+.add-disk-file-format > label {
+    width: auto;
+    padding-left: 2em;
+}
+
+.add-disk-attach-perm {
+    padding-left: 5px;
+}
+
+.add-disk-attach-perm > label {
+    margin-left: 5px;
+    text-align: left;
+    color: #363636;
+}
+
+.add-disk-attach-perm > input[type=checkbox] { }

--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -1,0 +1,445 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import cockpit from 'cockpit';
+
+import DialogPattern from 'cockpit-components-dialog.jsx';
+import Select from "cockpit-components-select.jsx";
+
+import { mouseClick, units, convertToUnit, digitFilter, toFixedPrecision } from '../helpers.es6';
+import { volumeCreateAndAttach, attachDisk, getVm, getStoragePools } from '../actions.es6';
+
+import './diskAdd.css';
+
+const _ = cockpit.gettext;
+
+const CREATE_NEW = 'create-new';
+const USE_EXISTING = 'use-existing';
+
+function getAvailableTargets(vm) {
+    const existingTargets = Object.getOwnPropertyNames(vm.disks);
+    const targets = [];
+    let i = 0;
+    while (i < 26 && targets.length < 5) {
+        const target = `vd${String.fromCharCode(97 + i)}`;
+        if (!existingTargets.includes(target)) {
+            targets.push(target);
+        }
+        i++;
+    }
+    return targets;
+}
+
+const SelectExistingVolume = ({ idPrefix, dialogValues, onValueChanged, vmStoragePools, vmDisks }) => {
+    const vmStoragePool = vmStoragePools[dialogValues.storagePoolName];
+
+    const usedDiskPaths = Object.getOwnPropertyNames(vmDisks)
+            .filter(target => vmDisks[target].source && vmDisks[target].source.file)
+            .map(target => vmDisks[target].source.file);
+
+    const filteredVolumes = vmStoragePool.filter(volume => !usedDiskPaths.includes(volume.path));
+
+    let initiallySelected;
+    let content;
+    if (filteredVolumes.length > 0) {
+        content = filteredVolumes.map(volume => {
+            return (
+                <Select.SelectEntry data={volume.name} key={volume.name}>
+                    {volume.name}
+                </Select.SelectEntry>
+            );
+        });
+        initiallySelected = dialogValues.existingVolumeName;
+    } else {
+        content = (
+            <Select.SelectEntry data="empty" key="empty-list">
+                <i>{_("The pool is empty")}</i>
+            </Select.SelectEntry>
+        );
+        initiallySelected = "empty";
+    }
+
+    return (
+        <div className="row">
+            <div className="col-sm-1 dialog-field">
+                <label htmlFor={`${idPrefix}-select-volume`}>
+                    {_("Volume: ")}
+                </label>
+            </div>
+            <div className="col-sm-11 dialog-field">
+                <Select.Select id={`${idPrefix}-select-volume`}
+                               onChange={value => onValueChanged('existingVolumeName', value)}
+                               initial={initiallySelected}
+                               enabled={filteredVolumes.length > 0}
+                               extraClass='form-control'>
+                    {content}
+                </Select.Select>
+            </div>
+        </div>
+    );
+};
+
+const PermanentChange = ({ idPrefix, onValueChanged, dialogValues, provider, vm }) => {
+    // By default for a running VM, the disk is attached until shut down only. Enable permanent change of the domain.xml
+    if (!provider.isRunning(vm.state)) {
+        return null;
+    }
+
+    return (
+        <div className="row">
+            <div className="col-sm-1 dialog-field" />
+
+            <div className="col-sm-11 dialog-field add-disk-attach-perm">
+                <input id={`${idPrefix}-permanent`}
+                       type="checkbox"
+                       checked={dialogValues.permanent}
+                       onChange={e => onValueChanged('permanent', e.target.checked)} />
+                <label>
+                    {_("Attach permanently")}
+                </label>
+            </div>
+        </div>
+    );
+};
+
+const VolumeName = ({ idPrefix, dialogValues, onValueChanged }) => {
+    return (
+        <div className="row">
+            <div className="col-sm-1 dialog-field">
+                <label htmlFor={`${idPrefix}-name`}>
+                    {_("Name: ")}
+                </label>
+            </div>
+            <div className="col-sm-11 dialog-field">
+                <input id={`${idPrefix}-name`}
+                       className="form-control"
+                       type="text"
+                       minLength={1}
+                       placeholder={_("New Volume Name")}
+                       value={dialogValues.volumeName}
+                       onChange={e => onValueChanged('volumeName', e.target.value)} />
+
+            </div>
+        </div>
+    );
+};
+
+const VolumeDetails = ({ idPrefix, onValueChanged, dialogValues }) => {
+    return (
+        <div className="row">
+            <div className="col-sm-1 dialog-field">
+                <label htmlFor={`${idPrefix}-size`}>
+                    {_("Size: ")}
+                </label>
+            </div>
+            <div className="col-sm-3 dialog-field">
+                <input id={`${idPrefix}-size`}
+                       className="form-control add-disk-size"
+                       type="number"
+                       value={toFixedPrecision(dialogValues.size)}
+                       onKeyPress={digitFilter}
+                       step={1}
+                       min={0}
+                       onChange={e => onValueChanged('size', e.target.value)} />
+
+                <Select.Select id={`${idPrefix}-unit`}
+                               initial={dialogValues.unit}
+                               onChange={value => onValueChanged('unit', value)}>
+                    <Select.SelectEntry data={units.MiB.name} key={units.MiB.name}>
+                        {_("MiB")}
+                    </Select.SelectEntry>
+                    <Select.SelectEntry data={units.GiB.name} key={units.GiB.name}>
+                        {_("GiB")}
+                    </Select.SelectEntry>
+                </Select.Select>
+            </div>
+
+            <div className="col-sm-4 dialog-field add-disk-file-format">
+                <label htmlFor={`${idPrefix}-fileformat`}>
+                    {_("Format: ")}
+                </label>
+                <Select.Select id={`${idPrefix}-diskfileformat`}
+                               onChange={value => onValueChanged('diskFileFormat', value)}
+                               initial={dialogValues.diskFileFormat}
+                               extraClass='form-control'>
+                    <Select.SelectEntry data='qcow2' key='qcow2'>
+                        {_("qcow2")}
+                    </Select.SelectEntry>
+                    <Select.SelectEntry data='raw' key='raw'>
+                        {_("raw")}
+                    </Select.SelectEntry>
+                </Select.Select>
+            </div>
+
+            <div className="col-sm-4" />
+        </div>
+    );
+};
+
+const PoolAndTargetRow = ({ idPrefix, onValueChanged, dialogValues, vmStoragePools }) => {
+    return (
+        <div className="row">
+            <div className="col-sm-1 dialog-field">
+                <label htmlFor={`${idPrefix}-select-pool`}>
+                    {_("Pool: ")}
+                </label>
+            </div>
+            <div className="col-sm-5 dialog-field">
+                <Select.Select id={`${idPrefix}-select-pool`}
+                               onChange={value => onValueChanged('storagePoolName', value)}
+                               initial={dialogValues.storagePoolName}
+                               extraClass="form-control">
+                    {Object.getOwnPropertyNames(vmStoragePools)
+                            .sort((a, b) => a.localeCompare(b))
+                            .map(poolName => {
+                                return (
+                                    <Select.SelectEntry data={poolName} key={poolName}>
+                                        {poolName}
+                                    </Select.SelectEntry>
+                                );
+                            })}
+                </Select.Select>
+            </div>
+
+            <div className="col-sm-6 dialog-field add-disk-target">
+                <label htmlFor={`${idPrefix}-target`}>
+                    {_("Target: ")}
+                </label>
+                <Select.Select id={`${idPrefix}-target`}
+                               onChange={value => onValueChanged('target', value)}
+                               initial={dialogValues.target}
+                               extraClass="form-control">
+                    {dialogValues.availableTargets.map(target => {
+                        return (
+                            <Select.SelectEntry data={target} key={target}>
+                                {target}
+                            </Select.SelectEntry>
+                        );
+                    })}
+                </Select.Select>
+            </div>
+        </div>
+    );
+};
+
+const CreateNewDisk = ({ idPrefix, onValueChanged, dialogValues, vmStoragePools, provider, vm }) => {
+    return (
+        <div className='container-fluid add-disk-body'>
+            <PoolAndTargetRow idPrefix={idPrefix}
+                              dialogValues={dialogValues}
+                              onValueChanged={onValueChanged}
+                              vmStoragePools={vmStoragePools} />
+
+            <VolumeName idPrefix={idPrefix} dialogValues={dialogValues} onValueChanged={onValueChanged} />
+            <VolumeDetails idPrefix={idPrefix} dialogValues={dialogValues} onValueChanged={onValueChanged} />
+            <PermanentChange idPrefix={idPrefix} dialogValues={dialogValues} onValueChanged={onValueChanged} provider={provider} vm={vm} />
+        </div>
+    );
+};
+
+const UseExistingDisk = ({ idPrefix, onValueChanged, dialogValues, vmStoragePools, provider, vm }) => {
+    return (
+        <div className='container-fluid add-disk-body'>
+            <PoolAndTargetRow idPrefix={idPrefix}
+                              dialogValues={dialogValues}
+                              onValueChanged={onValueChanged}
+                              vmStoragePools={vmStoragePools} />
+
+            <SelectExistingVolume idPrefix={idPrefix} dialogValues={dialogValues} onValueChanged={onValueChanged} vmStoragePools={vmStoragePools} vmDisks={vm.disks} />
+            <PermanentChange idPrefix={idPrefix} dialogValues={dialogValues} onValueChanged={onValueChanged} provider={provider} vm={vm} />
+        </div>
+    );
+};
+
+class AddDisk extends React.Component {
+    constructor(props) {
+        super(props);
+        const { vm, storagePools, provider } = this.props;
+
+        const availableTargets = getAvailableTargets(vm);
+        this.state = {
+            storagePoolName: storagePools && storagePools[vm.connectionName] && Object.getOwnPropertyNames(storagePools[vm.connectionName])[0],
+            mode: CREATE_NEW,
+            volumeName: undefined,
+            existingVolumeName: undefined,
+            size: 1,
+            unit: units.GiB.name,
+            diskFileFormat: 'qcow2',
+            target: availableTargets[0],
+            permanent: !provider.isRunning(vm.state), // default true for a down VM; for a running domain, the disk is attached tentatively only
+            hotplug: provider.isRunning(vm.state), // must be kept false for a down VM; the value is not being changed by user
+
+            availableTargets, // for optimization
+        };
+        this.props.onStateChanged(this.state);
+
+        this.onValueChanged = this.onValueChanged.bind(this);
+        this.getDefaultVolumeName = this.getDefaultVolumeName.bind(this);
+    }
+
+    getDefaultVolumeName(poolName) {
+        const { storagePools, vm } = this.props;
+        const vmStoragePools = storagePools[vm.connectionName];
+        return vmStoragePools && vmStoragePools[poolName] && vmStoragePools[poolName][0] && vmStoragePools[poolName][0].name;
+    }
+
+    onValueChanged(key, value) {
+        const stateDelta = { [key]: value };
+
+        if (key === 'storagePoolName' && this.state.mode === USE_EXISTING) { // user changed pool
+            stateDelta.existingVolumeName = this.getDefaultVolumeName(value);
+        }
+
+        this.setState(stateDelta);
+        this.props.onStateChanged(stateDelta);
+    }
+
+    render() {
+        const { vm, storagePools, provider } = this.props;
+        const idPrefix = `${this.props.idPrefix}-adddisk`;
+        const vmStoragePools = storagePools[vm.connectionName];
+
+        return (
+            <div className='modal-body add-disk-dialog'>
+                <ul className="nav nav-tabs nav-tabs-pf">
+                    <li key='one' className={this.state.mode === CREATE_NEW && "active"}>
+                        <a href="#" onClick={() => this.onValueChanged('mode', CREATE_NEW)}>{_("Create New")}</a>
+                    </li>
+                    <li key='two' className={this.state.mode === USE_EXISTING && "active"}>
+                        <a href="#" onClick={() => this.onValueChanged('mode', USE_EXISTING)}>{_("Use Existing")}</a>
+                    </li>
+                </ul>
+                {this.state.mode === CREATE_NEW && (
+                    <CreateNewDisk idPrefix={`${idPrefix}-new`}
+                                   onValueChanged={this.onValueChanged}
+                                   dialogValues={this.state}
+                                   vmStoragePools={vmStoragePools}
+                                   provider={provider}
+                                   vm={vm} />
+                )}
+                {this.state.mode === USE_EXISTING && (
+                    <UseExistingDisk idPrefix={`${idPrefix}-existing`}
+                                     onValueChanged={this.onValueChanged}
+                                     dialogValues={this.state}
+                                     vmStoragePools={vmStoragePools}
+                                     provider={provider}
+                                     vm={vm} />
+                )}
+            </div>
+        );
+    }
+}
+
+function getDiskFileName(storagePools, vm, poolName, volumeName) {
+    const vmStoragePools = storagePools[vm.connectionName];
+    let volume;
+    if (vmStoragePools && vmStoragePools[poolName] && vmStoragePools[poolName]) {
+        volume = vmStoragePools[poolName].find(volume => volume.name === volumeName);
+    }
+    return volume && volume.path;
+}
+
+const addDiskDialog = (dispatch, provider, idPrefix, vm, storagePools) => {
+    let dialogObj;
+    let dialogState = {};
+    const onStateChanged = stateDelta => { Object.assign(dialogState, stateDelta); };
+
+    const dialogProps = {
+        'title': _("Add Disk"),
+        'body': <AddDisk idPrefix={idPrefix} vm={vm} storagePools={storagePools} onStateChanged={onStateChanged} provider={provider} />,
+    };
+
+    const dialogError = text => {
+        footerProps['static_error'] = text;
+        dialogObj.setFooterProps(footerProps);
+        return cockpit.defer().reject().promise;
+    };
+
+    const onAddClicked = () => {
+        dialogError(null); // remove any old error
+
+        if (dialogState.mode === CREATE_NEW) {
+            // validate
+            if (!dialogState.volumeName) {
+                return dialogError(_("Please enter new volume name"));
+            }
+            if (!(dialogState.size > 0)) { // must be positive number
+                return dialogError(_("Please enter new volume size"));
+            }
+
+            // create new disk
+            return dispatch(volumeCreateAndAttach({ connectionName: vm.connectionName,
+                                                    poolName: dialogState.storagePoolName,
+                                                    volumeName: dialogState.volumeName,
+                                                    size: convertToUnit(dialogState.size, dialogState.unit, 'MiB'),
+                                                    format: dialogState.diskFileFormat,
+                                                    target: dialogState.target,
+                                                    permanent: dialogState.permanent,
+                                                    hotplug: dialogState.hotplug,
+                                                    vmName: vm.name }))
+                    .fail(exc => dialogError(_("Disk failed to be created with following error: ") + exc.message))
+                    .then(() => { // force reload of VM data, events are not reliable (i.e. for a down VM)
+                        return dispatch(getVm(vm.connectionName, vm.name));
+                    });
+        }
+
+        // use existing volume
+        return dispatch(attachDisk({ connectionName: vm.connectionName,
+                                     diskFileName: getDiskFileName(storagePools, vm, dialogState.storagePoolName, dialogState.existingVolumeName),
+                                     target: dialogState.target,
+                                     permanent: dialogState.permanent,
+                                     hotplug: dialogState.hotplug,
+                                     vmName: vm.name }))
+                .fail(exc => dialogError(_("Disk failed to be attached with following error: ") + exc.message))
+                .then(() => { // force reload of VM data, events are not reliable (i.e. for a down VM)
+                    return dispatch(getVm(vm.connectionName, vm.name));
+                });
+    };
+
+    const footerProps = {
+        'actions': [
+            {
+                'clicked': onAddClicked,
+                'caption': _("Add Disk"),
+                'style': 'primary',
+            },
+        ],
+    };
+
+    // Refresh storage volume list before displaying the dialog.
+    // There are recently no Libvirt events for storage volumes and polling is ugly.
+    // https://bugzilla.redhat.com/show_bug.cgi?id=1578836
+    dispatch(getStoragePools(vm.connectionName))
+            .then(() => {
+                dialogObj = DialogPattern.show_modal_dialog(dialogProps, footerProps)
+            });
+};
+
+const AddDiskAction = ({ dispatch, provider, idPrefix, vm, storagePools }) => {
+    return (
+        <button type="button"
+                className="btn btn-primary pull-right"
+                id={`${idPrefix}-adddisk`}
+                onClick={mouseClick(() => addDiskDialog(dispatch, provider, idPrefix, vm, storagePools))}>
+            {_("Add Disk")}
+        </button>
+    );
+};
+
+export default AddDiskAction;

--- a/pkg/machines/components/memorySelectRow.jsx
+++ b/pkg/machines/components/memorySelectRow.jsx
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import cockpit from 'cockpit';
+
+import Select from "cockpit-components-select.jsx";
+
+import { digitFilter, toFixedPrecision, units } from "../helpers.es6";
+
+const _ = cockpit.gettext;
+
+const MemorySelectRow = ({ label, id, value, initialUnit, onValueChange, onUnitChange }) => {
+    return (
+        <tr>
+            <td className="top">
+                <label className="control-label" htmlFor={id}>
+                    {label}
+                </label>
+            </td>
+            <td>
+                <div className="thirty-five-spaced-table">
+                    <span className="evenly-spaced-cell">
+                        <div className="evenly-spaced-table">
+                            <span className="evenly-spaced-cell">
+                                <input id={id} className="form-control"
+                                       type="number"
+                                       value={toFixedPrecision(value)}
+                                       onKeyPress={digitFilter}
+                                       step={1}
+                                       min={0}
+                                       onChange={onValueChange} />
+                            </span>
+                            <span className="thirty-five-spaced-cell padding-left">
+                                <Select.Select id={id + "-unit-select"}
+                                               initial={initialUnit}
+                                               onChange={onUnitChange}>
+                                    <Select.SelectEntry data={units.MiB.name} key={units.MiB.name}>
+                                        {_("MiB")}
+                                    </Select.SelectEntry>
+                                    <Select.SelectEntry data={units.GiB.name} key={units.GiB.name}>
+                                        {_("GiB")}
+                                    </Select.SelectEntry>
+                                </Select.Select>
+                            </span>
+                        </div>
+                    </span>
+                </div>
+            </td>
+        </tr>
+    );
+};
+
+export default MemorySelectRow;

--- a/pkg/machines/components/vm/vm.jsx
+++ b/pkg/machines/components/vm/vm.jsx
@@ -36,7 +36,7 @@ const _ = cockpit.gettext;
 
 /** One VM in the list (a row)
  */
-const Vm = ({ vm, config, hostDevices, onStart, onInstall, onShutdown, onForceoff, onReboot, onForceReboot,
+const Vm = ({ vm, config, hostDevices, storagePools, onStart, onInstall, onShutdown, onForceoff, onReboot, onForceReboot,
               onUsageStartPolling, onUsageStopPolling, onSendNMI, dispatch }) => {
     const stateAlert = vm.lastMessage && (<span className='pficon-warning-triangle-o machines-status-alert' />);
     const stateIcon = (<StateIcon state={vm.state} config={config} valueId={`${vmId(vm.name)}-state`} extra={stateAlert} />);
@@ -49,7 +49,7 @@ const Vm = ({ vm, config, hostDevices, onStart, onInstall, onShutdown, onForceof
     let tabRenderers = [
         {name: _("Overview"), renderer: VmOverviewTab, data: { vm, config, dispatch }},
         {name: usageTabName, renderer: VmUsageTab, data: { vm, onUsageStartPolling, onUsageStopPolling }, presence: 'onlyActive'},
-        {name: disksTabName, renderer: VmDisksTab, data: { vm, onUsageStartPolling, onUsageStopPolling }, presence: 'onlyActive'},
+        {name: disksTabName, renderer: VmDisksTab, data: { vm, config, storagePools, onUsageStartPolling, onUsageStopPolling, dispatch }, presence: 'onlyActive'},
         {name: networkTabName, renderer: VmNetworkTab, data: { vm, dispatch, hostDevices }},
         {name: consolesTabName, renderer: Consoles, data: { vm, config, dispatch }},
     ];
@@ -104,6 +104,7 @@ const Vm = ({ vm, config, hostDevices, onStart, onInstall, onShutdown, onForceof
 Vm.propTypes = {
     vm: PropTypes.object.isRequired,
     config: PropTypes.object.isRequired,
+    storagePools: PropTypes.object.isRequired,
     hostDevices: PropTypes.object.isRequired,
     onStart: PropTypes.func.isRequired,
     onShutdown: PropTypes.func.isRequired,

--- a/pkg/machines/components/vmDisksTab.jsx
+++ b/pkg/machines/components/vmDisksTab.jsx
@@ -24,17 +24,6 @@ import { convertToUnit, toReadableNumber, units } from "../helpers.es6";
 
 const _ = cockpit.gettext;
 
-const DiskTotal = ({ disks, idPrefix }) => {
-    return (
-        <span className='machines-disks-total'>
-            {_("Count:")}&nbsp;
-            <span id={`${idPrefix}-total-value`} className='machines-disks-total-value'>
-                {disks.length}
-            </span>
-        </span>
-    );
-};
-
 const StorageUnit = ({ value, id }) => {
     if (!value) {
         return null;
@@ -63,7 +52,7 @@ const VmDiskCell = ({ value, id }) => {
     );
 };
 
-const VmDisksTab = ({ idPrefix, disks, renderCapacity, notificationText }) => {
+const VmDisksTab = ({ idPrefix, disks, actions, renderCapacity, notificationText }) => {
     if (!disks || disks.length === 0) {
         return (<div>{_("No disks defined for this VM")}</div>);
     }
@@ -93,8 +82,7 @@ const VmDisksTab = ({ idPrefix, disks, renderCapacity, notificationText }) => {
     return (
         <div>
             {notification}
-            <DiskTotal disks={disks} idPrefix={idPrefix} />
-            <Listing columnTitles={columnTitles}>
+            <Listing columnTitles={columnTitles} actions={actions}>
                 {disks.map(disk => {
                     const idPrefixRow = `${idPrefix}-${disk.target || disk.device}`;
                     const columns = [
@@ -125,6 +113,7 @@ const VmDisksTab = ({ idPrefix, disks, renderCapacity, notificationText }) => {
 
 VmDisksTab.propTypes = {
     idPrefix: PropTypes.string.isRequired,
+    actions: PropTypes.arrayOf(React.PropTypes.node),
     disks: PropTypes.array.isRequired,
     renderCapacity: PropTypes.bool,
     notificationText: PropTypes.string,

--- a/pkg/machines/components/vmDisksTab.jsx
+++ b/pkg/machines/components/vmDisksTab.jsx
@@ -53,36 +53,36 @@ const VmDiskCell = ({ value, id }) => {
 };
 
 const VmDisksTab = ({ idPrefix, disks, actions, renderCapacity, notificationText }) => {
-    if (!disks || disks.length === 0) {
-        return (<div>{_("No disks defined for this VM")}</div>);
-    }
-
-    const renderCapacityUsed = !!disks.find(disk => (!!disk.used));
-    const renderReadOnly = !!disks.find(disk => (typeof disk.readonly !== "undefined"));
-
-    const columnTitles = [_("Device"), _("Target")];
-    if (renderCapacity) {
-        if (renderCapacityUsed) {
-            columnTitles.push(_("Used"));
-        }
-        columnTitles.push(_("Capacity"));
-    }
-    columnTitles.push(_("Bus"));
-    if (renderReadOnly) {
-        columnTitles.push(_("Readonly"));
-    }
-    columnTitles.push(_("Source"));
-
     let notification = null;
-    if (notificationText) {
-        notification = (<Info text={notificationText}
-                              textId={`${idPrefix}-notification`} />);
+    const columnTitles = [_("Device"), _("Target")];
+    let renderCapacityUsed, renderReadOnly;
+
+    if (disks && disks.length > 0) {
+        renderCapacityUsed = !!disks.find(disk => (!!disk.used));
+        renderReadOnly = !!disks.find(disk => (typeof disk.readonly !== "undefined"));
+
+        if (renderCapacity) {
+            if (renderCapacityUsed) {
+                columnTitles.push(_("Used"));
+            }
+            columnTitles.push(_("Capacity"));
+        }
+        columnTitles.push(_("Bus"));
+        if (renderReadOnly) {
+            columnTitles.push(_("Readonly"));
+        }
+        columnTitles.push(_("Source"));
+
+        if (notificationText) {
+            notification = (<Info text={notificationText}
+                                  textId={`${idPrefix}-notification`} />);
+        }
     }
 
     return (
         <div>
             {notification}
-            <Listing columnTitles={columnTitles} actions={actions}>
+            <Listing columnTitles={columnTitles} actions={actions} emptyCaption={_("No disks defined for this VM")}>
                 {disks.map(disk => {
                     const idPrefixRow = `${idPrefix}-${disk.target || disk.device}`;
                     const columns = [

--- a/pkg/machines/components/vmDisksTabLibvirt.jsx
+++ b/pkg/machines/components/vmDisksTabLibvirt.jsx
@@ -20,6 +20,7 @@ import React, { PropTypes } from 'react';
 import cockpit from 'cockpit';
 
 import { vmId } from '../helpers.es6';
+import AddDiskAction from './diskAdd.jsx';
 import VmDisksTab from './vmDisksTab.jsx';
 import DiskSourceCell from './vmDiskSourceCell.jsx';
 
@@ -87,7 +88,7 @@ class VmDisksTabLibvirt extends React.Component {
     }
 
     render() {
-        const { vm } = this.props;
+        const { vm, dispatch, config, storagePools } = this.props;
 
         const idPrefix = `${vmId(vm.name)}-disks`;
         const areDiskStatsSupported = this.getDiskStatsSupport(vm);
@@ -100,6 +101,7 @@ class VmDisksTabLibvirt extends React.Component {
 
         return (
             <VmDisksTab idPrefix={idPrefix}
+                actions={[<AddDiskAction dispatch={dispatch} provider={config.provider} idPrefix={idPrefix} vm={vm} storagePools={storagePools} />]}
                 disks={disks}
                 renderCapacity={areDiskStatsSupported}
                 notificationText={this.getNotification(vm, areDiskStatsSupported)} />
@@ -109,6 +111,7 @@ class VmDisksTabLibvirt extends React.Component {
 
 VmDisksTabLibvirt.propTypes = {
     vm: PropTypes.object.isRequired,
+    dispatch: PropTypes.func.isRequired,
 
     onUsageStartPolling: PropTypes.func.isRequired,
     onUsageStopPolling: PropTypes.func.isRequired,

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -72,7 +72,7 @@ class HostVmsList extends React.Component {
     }
 
     render() {
-        const { vms, config, ui, dispatch, actions } = this.props;
+        const { vms, config, ui, storagePools, dispatch, actions } = this.props;
         const combinedVms = [...vms, ...this.asDummVms(vms, ui.vms)];
 
         const sortFunction = (vmA, vmB) => vmA.name.localeCompare(vmB.name);
@@ -101,6 +101,7 @@ class HostVmsList extends React.Component {
                             return (
                                 <Vm vm={vm} config={config}
                                     hostDevices={this.deviceProxies}
+                                    storagePools={storagePools}
                                     onStart={() => dispatch(startVm(vm))}
                                     onInstall={() => dispatch(installVm(vm))}
                                     onReboot={() => dispatch(rebootVm(vm))}
@@ -123,6 +124,7 @@ HostVmsList.propTypes = {
     vms: PropTypes.array.isRequired,
     config: PropTypes.object.isRequired,
     ui: PropTypes.object.isRequired,
+    storagePools: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
 };
 

--- a/pkg/machines/reducers.es6
+++ b/pkg/machines/reducers.es6
@@ -177,6 +177,46 @@ function systemInfo(state, action) {
     }
 }
 
+function storagePools(state, action) {
+    state = state || { };
+    /* Example:
+    state = { "connectionNameA": {
+            "poolNameA": [
+                {name, path},
+                {name, path},
+            ],
+            "poolNameB": []
+            },
+            "connectionNameB": {}
+       }
+    */
+    switch (action.type) {
+    case 'UPDATE_STORAGE_POOLS': {
+        const { connectionName, pools } = action.payload;
+
+        const newState = Object.assign({}, state);
+        newState[connectionName] = {};
+
+        // Array of strings (pool names)
+        pools.forEach(poolName => {
+            newState[connectionName][poolName] = []; // will be filled by UPDATE_STORAGE_VOLUMES
+        });
+
+        return newState;
+    }
+    case 'UPDATE_STORAGE_VOLUMES': {
+        const { connectionName, poolName, volumes } = action.payload;
+
+        const newState = Object.assign({}, state);
+        newState[connectionName] = Object.assign({}, newState[connectionName]);
+        newState[connectionName][poolName] = volumes;
+        return newState;
+    }
+    default: // by default all reducers should return initial state on unknown actions
+        return state;
+    }
+}
+
 function ui(state, action) {
     // transient properties
     state = state || {
@@ -267,5 +307,6 @@ export default combineReducers({
     }),
     vms,
     systemInfo,
+    storagePools,
     ui,
 });

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -447,9 +447,6 @@ class TestMachines(MachineCase):
         b.click("#vm-subVmTest1-disks") # open the "Disks" subtab
 
         # Test basic disk properties
-        b.wait_present("#vm-subVmTest1-disks-total-value") # wait for the "Count" value
-        b.wait_in_text("#vm-subVmTest1-disks-total-value", "2")
-
         b.wait_in_text("#vm-subVmTest1-disks-hda-target", "hda")
         b.wait_in_text("#vm-subVmTest1-disks-hdb-target", "hdb")
 
@@ -470,13 +467,14 @@ class TestMachines(MachineCase):
 
             b.wait_in_text("#vm-subVmTest1-disks-hdb-capacity", "1")
 
-        # Test add disk
+        # Test add disk by external action
         m.execute("qemu-img create -f raw /var/lib/libvirt/images/image3.img 128M")
         m.execute("virsh attach-disk subVmTest1 /var/lib/libvirt/images/image3.img vdc") # attach to the virtio bus instead of ide
 
-        b.wait_in_text("#vm-subVmTest1-disks-total-value", "3")
         b.wait_in_text("#vm-subVmTest1-disks-hda-target", "hda")
         b.wait_in_text("#vm-subVmTest1-disks-hdb-target", "hdb")
+        b.wait_present("#vm-subVmTest1-disks-hdb-used")
+        b.wait_present("#vm-subVmTest1-disks-vdc-target")
         b.wait_in_text("#vm-subVmTest1-disks-vdc-target", "vdc")
 
         b.wait_in_text("#vm-subVmTest1-disks-hda-bus", "ide")
@@ -486,21 +484,146 @@ class TestMachines(MachineCase):
         b.wait_in_text("#vm-subVmTest1-disks-vdc-source", "/var/lib/libvirt/images/image3.img")
 
         self.wait_for_disk_stats("subVmTest1", "vdc")
-        if b.is_present("#vm-subVmTest1-disks-hda-used"):
+        if b.is_present("#vm-subVmTest1-disks-vdc-used"):
             b.wait_in_text("#vm-subVmTest1-disks-vdc-used", "0.00")
             b.wait_in_text("#vm-subVmTest1-disks-vdc-capacity", "0.13") # 128 MB
 
-        # Test remove disk
+        # Test remove disk - by external action
         m.execute("virsh detach-disk subVmTest1 vdc")
         print("Restarting vm-subVmTest1, might take a while")
         b.click("#vm-subVmTest1-reboot-caret")
         b.wait_visible("#vm-subVmTest1-forceReboot")
         b.click("#vm-subVmTest1-forceReboot")
 
-        b.wait_in_text("#vm-subVmTest1-disks-total-value", "2")
-
+        b.wait_not_present("#vm-subVmTest1-disks-vdc-target")
         b.wait_in_text("#vm-subVmTest1-disks-hda-target", "hda")
         b.wait_in_text("#vm-subVmTest1-disks-hdb-target", "hdb")
+
+     # Test Add Disk via dialog
+    def testAddDisk(self):
+        b = self.browser
+        m = self.machine
+
+        # prepare libvirt storage pools
+        m.execute("mkdir /mnt/vm_one ; mkdir /mnt/vm_two ; mkdir /mnt/vm_tmp ; chmod a+rwx /mnt/vm_one /mnt/vm_two /mnt/vm_tmp")
+        m.execute("virsh pool-create-as default_tmp --type dir --target /mnt/vm_tmp")
+        m.execute("virsh pool-create-as myPoolOne --type dir --target /mnt/vm_one")
+        m.execute("virsh pool-create-as myPoolTwo --type dir --target /mnt/vm_two")
+
+        m.execute("virsh vol-create-as myPoolTwo mydiskofpooltwo --capacity 1G --format qcow2")
+        m.execute("virsh vol-create-as myPoolTwo mydiskofpooltwo_permanent --capacity 1G --format qcow2")
+        wait(lambda: "mydiskofpooltwo_permanent" in m.execute("virsh vol-list myPoolTwo"))
+
+        self.startVm("subVmTest1")
+
+        self.login_and_go("/machines")
+        b.wait_in_text("body", "Virtual Machines")
+        b.wait_present("tbody tr th")
+        b.wait_in_text("tbody tr th", "subVmTest1")
+
+        b.click("tbody tr th") # click on the row header
+        b.wait_present("#vm-subVmTest1-state")
+        b.wait_in_text("#vm-subVmTest1-state", "running")
+
+        b.wait_present("#vm-subVmTest1-disks") # wait for the tab
+        b.click("#vm-subVmTest1-disks") # open the "Disks" subtab
+
+        b.wait_present("#vm-subVmTest1-disks-adddisk") # button
+        b.click("#vm-subVmTest1-disks-adddisk")
+        b.wait_present(".add-disk-dialog ul li a:contains(Create New)") # subtab title in the modal dialog
+        b.wait_present("#vm-subVmTest1-disks-adddisk-new-select-pool")
+
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-select-pool", "myPoolOne")
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-target", "vde")
+        self._setVal("#vm-subVmTest1-disks-adddisk-new-name", "mydiskofpoolone")
+        self._setVal("#vm-subVmTest1-disks-adddisk-new-size", 2048)
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-select-pool", "myPoolOne")
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-unit", "MiB")
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-diskfileformat", "raw") # verify content of the dropdown box
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-diskfileformat", "qcow2") # and switch it back
+        # keep "Attach permanently" un-checked (by default)
+        b.wait_in_text("#vm-subVmTest1-state", "running") # re-check
+        b.click(".modal-footer button:contains(Add Disk)")
+        b.wait_not_present("#cockpit_modal_dialog")
+        b.wait_present("#vm-subVmTest1-disks-vde-target") # verify after modal dialog close
+        b.wait_in_text("#vm-subVmTest1-disks-vde-target", "vde")
+        b.wait_in_text("#vm-subVmTest1-disks-vde-bus", "virtio")
+        b.wait_in_text("#vm-subVmTest1-disks-vde-device", "disk")
+        b.wait_in_text("#vm-subVmTest1-disks-vde-source", "/mnt/vm_one/mydiskofpoolone") # should be gone after shut down
+
+        b.click("#vm-subVmTest1-disks-adddisk")
+        b.wait_present("#vm-subVmTest1-disks-adddisk-new-permanent")
+        b.wait_present("#vm-subVmTest1-disks-adddisk-new-name")
+        b.click("#vm-subVmTest1-disks-adddisk-new-permanent")
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-select-pool", "myPoolOne")
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-target", "vda")
+        self._setVal("#vm-subVmTest1-disks-adddisk-new-name", "mydiskofpoolone_permanent")
+        self._setVal("#vm-subVmTest1-disks-adddisk-new-size", 2) # keep GiB and qcow2 format
+        b.click(".modal-footer button:contains(Add Disk)")
+        b.wait_not_present("#cockpit_modal_dialog")
+        b.wait_present("#vm-subVmTest1-disks-vda-target") # verify after modal dialog close
+        b.wait_in_text("#vm-subVmTest1-disks-vda-target", "vda")
+        b.wait_in_text("#vm-subVmTest1-disks-vda-bus", "virtio")
+        b.wait_in_text("#vm-subVmTest1-disks-vda-device", "disk")
+        b.wait_in_text("#vm-subVmTest1-disks-vda-source", "/mnt/vm_one/mydiskofpoolone_permanent") # should survive the shut down
+
+        b.click("#vm-subVmTest1-disks-adddisk")
+        b.wait_present(".add-disk-dialog ul li a:contains(Use Existing)") # dialog subtab title
+        b.click(".add-disk-dialog ul li a:contains(Use Existing)")
+        b.wait_present("#vm-subVmTest1-disks-adddisk-existing-select-pool")
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-existing-select-pool", "myPoolOne")
+        b.wait_present("#vm-subVmTest1-disks-adddisk-existing-select-volume button.disabled span i:contains(The pool is empty)") # since both disks are already attached
+        b.click(".modal-footer button:contains(Cancel)")
+        b.wait_not_present("#cockpit_modal_dialog")
+
+        b.click("#vm-subVmTest1-disks-adddisk")
+        b.wait_present(".add-disk-dialog ul li a:contains(Use Existing)") # dialog subtab title
+        b.click(".add-disk-dialog ul li a:contains(Use Existing)")
+        b.wait_present("#vm-subVmTest1-disks-adddisk-existing-select-volume")
+        b.wait_present("#vm-subVmTest1-disks-adddisk-existing-permanent")
+        b.click("#vm-subVmTest1-disks-adddisk-existing-permanent")
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-existing-select-pool", "myPoolTwo")
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-existing-select-volume", "mydiskofpooltwo_permanent")
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-existing-target", "vdd")
+        b.click(".modal-footer button:contains(Add Disk)")
+        b.wait_not_present("#cockpit_modal_dialog")
+        b.wait_present("#vm-subVmTest1-disks-vdd-target") # verify after modal dialog close
+        b.wait_in_text("#vm-subVmTest1-disks-vdd-target", "vdd")
+        b.wait_in_text("#vm-subVmTest1-disks-vdd-bus", "virtio")
+        b.wait_in_text("#vm-subVmTest1-disks-vdd-device", "disk")
+        b.wait_in_text("#vm-subVmTest1-disks-vdd-source", "/mnt/vm_two/mydiskofpooltwo_permanent")
+
+        b.click("#vm-subVmTest1-disks-adddisk")
+        b.wait_present(".add-disk-dialog ul li a:contains(Use Existing)") # dialog subtab title
+        b.click(".add-disk-dialog ul li a:contains(Use Existing)")
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-existing-select-pool", "myPoolTwo")
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-existing-select-volume", "mydiskofpooltwo")
+        self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-existing-target", "vdb")
+        b.click(".modal-footer button:contains(Add Disk)")
+        b.wait_not_present("#cockpit_modal_dialog")
+        b.wait_present("#vm-subVmTest1-disks-vdb-target") # verify after modal dialog close
+        b.wait_in_text("#vm-subVmTest1-disks-vdb-target", "vdb")
+        b.wait_in_text("#vm-subVmTest1-disks-vdb-bus", "virtio")
+        b.wait_in_text("#vm-subVmTest1-disks-vdb-device", "disk")
+        b.wait_in_text("#vm-subVmTest1-disks-vdb-source", "/mnt/vm_two/mydiskofpooltwo")
+
+        # shut off
+        b.click("#vm-subVmTest1-off-caret")
+        b.wait_visible("#vm-subVmTest1-forceOff")
+        b.click("#vm-subVmTest1-forceOff")
+        b.wait_in_text("#vm-subVmTest1-state", "shut off")
+
+        # check if the just added non-permanent disks are gone
+        b.wait_not_present("#vm-subVmTest1-disks-vdb-target")
+        b.wait_not_present("#vm-subVmTest1-disks-vde-target")
+        b.wait_present("#vm-subVmTest1-disks-vda-target")
+        b.wait_present("#vm-subVmTest1-disks-vdd-target")
+
+    def _selectFromDropdown(self, selector, value):
+        selectFromDropdown(self.browser, selector, value)
+
+    def _setVal(self, selector, value):
+        setValToElement(self.browser, selector, value)
 
     def testNetworks(self):
         b = self.browser
@@ -1183,16 +1306,7 @@ class TestMachines(MachineCase):
             return self
 
         def _selectFromDropdown(self, selector, value):
-            b = self.browser
-            button_text_selector = "{0} button span:nth-of-type(1)".format(selector)
-
-            b.wait_visible(selector)
-            if not b.text(button_text_selector) == value:
-                item_selector = "{0} ul li[data-value*='{1}'] a".format(selector, value)
-                b.click(selector)
-                b.wait_visible(item_selector)
-                b.click(item_selector)
-            b.wait_in_text(button_text_selector, value)
+            selectFromDropdown(self.browser, selector, value)
 
         def _setFileAutocompleteVal(self, selector, location):
             b = self.browser
@@ -1215,16 +1329,7 @@ class TestMachines(MachineCase):
             b.wait_val(selector + " input", location)
 
         def _setVal(self, selector, value):
-            b = self.browser
-            value = str(value)
-
-            b.wait_present(selector)
-            b.wait_visible(selector)
-            b.click(selector)
-            b.focus(selector)
-            b.set_val(selector, '')  # clear value
-            b.key_press(value)
-            b.wait_val(selector, value)
+            setValToElement(self.browser, selector, value)
 
     class CreateVmRunner:
         def __init__(self, test_obj):
@@ -1292,11 +1397,8 @@ class TestMachines(MachineCase):
             b.wait_present("#vm-{0}-disks".format(name))  # wait for the tab
             b.click("#vm-{0}-disks".format(name))  # open the "Disks" subtab
 
-            # Test number of disks and disk creation
+            # Test disk creation
             if dialog.storage_size > 0:
-                b.wait_present("#vm-{0}-disks-total-value".format(name))
-                b.wait_in_text("#vm-{0}-disks-total-value".format(name), 2 if dialog.start_vm else 1)  # CD-ROM
-
                 if b.is_present("#vm-{0}-disks-vda-target".format(name)):
                     b.wait_in_text("#vm-{0}-disks-vda-target".format(name), "vda")
                 else:
@@ -1381,6 +1483,28 @@ class TestMachines(MachineCase):
 
             return self
 
+
+def selectFromDropdown(b, selector, value):
+    button_text_selector = "{0} button span:nth-of-type(1)".format(selector)
+
+    b.wait_visible(selector)
+    if not b.text(button_text_selector) == value:
+        item_selector = "{0} ul li[data-value*='{1}'] a".format(selector, value)
+        b.click(selector)
+        b.wait_visible(item_selector)
+        b.click(item_selector)
+        b.wait_in_text(button_text_selector, value)
+
+def setValToElement(b, selector, value):
+    value = str(value)
+
+    b.wait_present(selector)
+    b.wait_visible(selector)
+    b.click(selector)
+    b.focus(selector)
+    b.set_val(selector, '')  # clear value
+    b.key_press(value)
+    b.wait_val(selector, value)
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -492,8 +492,6 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         # switch to the Disks subtab
         b.wait_present("#vm-fedoravm-disks-tab")
         b.click("#vm-fedoravm-disks-tab")
-        b.wait_present("#vm-fedoravm-disks-total-value") # wait for the "Count" value
-        b.wait_in_text("#vm-fedoravm-disks-total-value", "2")
         b.wait_present("#vm-fedoravm-disks-disk0-device") # check disk properties
         b.wait_present("#vm-fedoravm-disks-disk1-device")
         b.wait_in_text("#vm-fedoravm-disks-disk0-device", "disk0")

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -403,7 +403,7 @@ var aliases = {
     "moment": "moment/moment.js",
     "react": "react-lite/dist/react-lite.js",
     "react-dom": "react-lite/dist/react-lite.js",
-    "term": "term.js-cockpit/src/term.js",
+    "term": "term.js-cockpit/src/term.js"
 };
 
 /* HACK: To get around redux warning about reminimizing code */


### PR DESCRIPTION
Fixes: https://github.com/cockpit-project/cockpit/issues/9081

The Disks subtab is provided for new `Add Disk` action.
Within a dialog, the user can create a new virtual disk or select
existing one to be attached to a virtual machine.
    
If the virtual machine is running, there's check-box to make the
disk attachment permanent (means, it will stay attached even after the VM gets down).
    
The "Count" field showing the total count of attached disks is removed from the tab,
seems not providing sufficient value to the users.
    
Based on Libvirt storage pools.
Recently only the `directory` pool type is supported.

---
- [x] pool and volumes refresh (`virsh pool-event` seems to be unreliable)
- [x] attach unique volumes only 
- [x] tests
- [x] UX review
- [ ] video walk-through

