### PR TITLE
test: Drop SHA1 from our mock KDC config

### DIFF
--- a/src/ws/mock-kdc.conf.in
+++ b/src/ws/mock-kdc.conf.in
@@ -13,6 +13,6 @@
   key_stash_file = @dir@/key_stash
   acl_file = @dir@/kadm5.acl
   admin_keytab = @dir@/kadm5.keytab
-  supported_enctypes = aes256-cts:normal aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal camellia256-cts:normal camellia128-cts:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
+  supported_enctypes = aes256-cts:normal aes128-cts:normal arcfour-hmac:normal camellia256-cts:normal camellia128-cts:normal des-cbc-md5:normal des-cbc-crc:normal
   database_name = @dir@/database
  }


### PR DESCRIPTION
This only affects tests, but helps with auditing for remaining SHA1
usage.

See issue #5940