### PR TITLE
bridge: Use SHA256 for package checksums

### DIFF
--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -131,8 +131,6 @@ struct _CockpitPackage {
  * It is also *not* a security sensitive use case. The hashes are never shared
  * or compared between different users, only the same user (with same credentials)
  * on different machines.
- *
- * So we use the fastest, good ol' SHA1.
  */
 
 static gboolean   package_walk_directory   (GChecksum *own_checksum,
@@ -222,7 +220,7 @@ package_walk_file (GChecksum *own_checksum,
   if (own_checksum && bundle_checksum)
     {
       bytes = g_mapped_file_get_bytes (mapped);
-      string = g_compute_checksum_for_bytes (G_CHECKSUM_SHA1, bytes);
+      string = g_compute_checksum_for_bytes (G_CHECKSUM_SHA256, bytes);
       g_bytes_unref (bytes);
 
       /*
@@ -612,7 +610,7 @@ maybe_add_package (GHashTable *listing,
     paths = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 
   if (bundle_checksum)
-    own_checksum = g_checksum_new (G_CHECKSUM_SHA1);
+    own_checksum = g_checksum_new (G_CHECKSUM_SHA256);
 
   if (bundle_checksum || paths)
     {
@@ -731,7 +729,7 @@ build_packages (CockpitPackages *packages)
   g_free (packages->bundle_checksum);
   packages->bundle_checksum = NULL;
 
-  checksum = g_checksum_new (G_CHECKSUM_SHA1);
+  checksum = g_checksum_new (G_CHECKSUM_SHA256);
   if (build_package_listing (packages->listing, checksum, old_listing))
     {
       packages->bundle_checksum = g_strdup (g_checksum_get_string (checksum));

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -45,8 +45,9 @@
 
 /*
  * To recalculate the checksums found in this file, do something like:
- * $ XDG_DATA_DIRS=$PWD/src/bridge/mock-resource/system/ XDG_DATA_HOME=/nonexistant cockpit-bridge --packages
+ * $ XDG_DATA_DIRS=$PWD/src/bridge/mock-resource/system/ XDG_DATA_HOME=/nonexistant ./cockpit-bridge --packages
  */
+#define CHECKSUM "$6d675909f0b33b83a48e67e29cea9797012ded09394546634b9cd967bbe3fbf5"
 
 #define PASSWORD "this is the password"
 
@@ -499,7 +500,7 @@ test_resource_checksum (TestResourceCase *tc,
 
   response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL);
   cockpit_channel_response_serve (tc->service, tc->headers, response,
-                                "$060119c2a544d8e5becd0f74f9dcde146b8d99e3",
+                                CHECKSUM,
                                 "/test/sub/file.ext");
 
   while (cockpit_web_response_get_state (response) != COCKPIT_WEB_RESPONSE_SENT)
@@ -512,7 +513,7 @@ test_resource_checksum (TestResourceCase *tc,
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
                            "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
-                           "ETag: \"$060119c2a544d8e5becd0f74f9dcde146b8d99e3-c\"\r\n"
+                           "ETag: \"" CHECKSUM "-c\"\r\n"
                            "Access-Control-Allow-Origin: http://localhost\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "Cache-Control: max-age=31556926, public\r\n"
@@ -536,11 +537,11 @@ test_resource_not_modified (TestResourceCase *tc,
   request_checksum (tc);
 
   g_hash_table_insert (tc->headers, g_strdup ("If-None-Match"),
-                       g_strdup ("\"$060119c2a544d8e5becd0f74f9dcde146b8d99e3-c\""));
+                       g_strdup ("\"" CHECKSUM "-c\""));
 
   response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, tc->headers);
   cockpit_channel_response_serve (tc->service, tc->headers, response,
-                                "$060119c2a544d8e5becd0f74f9dcde146b8d99e3",
+                                CHECKSUM,
                                 "/test/sub/file.ext");
 
   while (cockpit_web_response_get_state (response) != COCKPIT_WEB_RESPONSE_SENT)
@@ -552,7 +553,7 @@ test_resource_not_modified (TestResourceCase *tc,
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 304 Not Modified\r\n"
-                           "ETag: \"$060119c2a544d8e5becd0f74f9dcde146b8d99e3-c\"\r\n"
+                           "ETag: \"" CHECKSUM "-c\"\r\n"
                            "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
                            "\r\n", -1);
   g_bytes_unref (bytes);
@@ -570,12 +571,12 @@ test_resource_not_modified_new_language (TestResourceCase *tc,
   request_checksum (tc);
 
   g_hash_table_insert (tc->headers, g_strdup ("If-None-Match"),
-                       g_strdup ("\"$060119c2a544d8e5becd0f74f9dcde146b8d99e3-c\""));
+                       g_strdup ("\"" CHECKSUM "-c\""));
   g_hash_table_insert (tc->headers, g_strdup ("Accept-Language"), g_strdup ("de"));
 
   response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, tc->headers);
   cockpit_channel_response_serve (tc->service, tc->headers, response,
-                                "$060119c2a544d8e5becd0f74f9dcde146b8d99e3",
+                                CHECKSUM,
                                 "/test/sub/file.ext");
 
   while (cockpit_web_response_get_state (response) != COCKPIT_WEB_RESPONSE_SENT)
@@ -588,7 +589,7 @@ test_resource_not_modified_new_language (TestResourceCase *tc,
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
                            "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
-                           "ETag: \"$060119c2a544d8e5becd0f74f9dcde146b8d99e3-de\"\r\n"
+                           "ETag: \"" CHECKSUM "-de\"\r\n"
                            "Access-Control-Allow-Origin: http://localhost\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "Cache-Control: max-age=31556926, public\r\n"
@@ -613,14 +614,14 @@ test_resource_not_modified_cookie_language (TestResourceCase *tc,
   request_checksum (tc);
 
   g_hash_table_insert (tc->headers, g_strdup ("If-None-Match"),
-                       g_strdup ("\"$060119c2a544d8e5becd0f74f9dcde146b8d99e3-c\""));
+                       g_strdup ("\"" CHECKSUM "-c\""));
 
   cookie = g_strdup_printf ("%s; CockpitLang=fr", (gchar *)g_hash_table_lookup (tc->headers, "Cookie"));
   g_hash_table_insert (tc->headers, g_strdup ("Cookie"), cookie);
 
   response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, tc->headers);
   cockpit_channel_response_serve (tc->service, tc->headers, response,
-                                "$060119c2a544d8e5becd0f74f9dcde146b8d99e3",
+                                CHECKSUM,
                                 "/test/sub/file.ext");
 
   while (cockpit_web_response_get_state (response) != COCKPIT_WEB_RESPONSE_SENT)
@@ -633,7 +634,7 @@ test_resource_not_modified_cookie_language (TestResourceCase *tc,
   cockpit_assert_bytes_eq (bytes,
                            "HTTP/1.1 200 OK\r\n"
                            "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
-                           "ETag: \"$060119c2a544d8e5becd0f74f9dcde146b8d99e3-fr\"\r\n"
+                           "ETag: \"" CHECKSUM "-fr\"\r\n"
                            "Access-Control-Allow-Origin: http://localhost\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "Cache-Control: max-age=31556926, public\r\n"

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -40,8 +40,9 @@
 
 /*
  * To recalculate the checksums found in this file, do something like:
- * $ XDG_DATA_DIRS=$PWD/src/bridge/mock-resource/system/ XDG_DATA_HOME=/nonexistant cockpit-bridge --packages
+ * $ XDG_DATA_DIRS=$PWD/src/bridge/mock-resource/system/ XDG_DATA_HOME=/nonexistant ./cockpit-bridge --packages
  */
+#define CHECKSUM "$6d675909f0b33b83a48e67e29cea9797012ded09394546634b9cd967bbe3fbf5"
 
 /* Mock override this from cockpitconf.c */
 extern const gchar *cockpit_config_file;
@@ -441,7 +442,7 @@ test_default (Test *test,
 }
 
 static const DefaultFixture fixture_resource_checksum = {
-  .path = "/cockpit/$060119c2a544d8e5becd0f74f9dcde146b8d99e3/test/sub/file.ext",
+  .path = "/cockpit/" CHECKSUM "/test/sub/file.ext",
   .auth = "/cockpit",
   .expect = "HTTP/1.1 200*"
     "These are the contents of file.ext*"
@@ -501,7 +502,7 @@ static const DefaultFixture fixture_shell_path_package = {
   .org_path = "/path/system/host",
   .auth = "/cockpit",
   .expect = "HTTP/1.1 200*"
-      "<base href=\"/path/cockpit/$060119c2a544d8e5becd0f74f9dcde146b8d99e3/another/test.html\">*"
+      "<base href=\"/path/cockpit/" CHECKSUM "/another/test.html\">*"
       "<title>In system dir</title>*"
 };
 
@@ -541,7 +542,7 @@ static const DefaultFixture fixture_machine_shell_index = {
   .auth = "/cockpit+=machine",
   .config = SRCDIR "/src/ws/mock-config/cockpit/cockpit.conf",
   .expect = "HTTP/1.1 200*"
-      "<base href=\"/cockpit+=machine/$060119c2a544d8e5becd0f74f9dcde146b8d99e3/second/test.html\">*"
+      "<base href=\"/cockpit+=machine/" CHECKSUM "/second/test.html\">*"
       "<title>In system dir</title>*"
 };
 
@@ -559,7 +560,7 @@ static const DefaultFixture fixture_shell_package = {
   .path = "/system/host",
   .auth = "/cockpit",
   .expect = "HTTP/1.1 200*"
-      "<base href=\"/cockpit/$060119c2a544d8e5becd0f74f9dcde146b8d99e3/another/test.html\">*"
+      "<base href=\"/cockpit/" CHECKSUM "/another/test.html\">*"
       "<title>In system dir</title>*"
 };
 


### PR DESCRIPTION
SHA1 got [broken](https://shattered.it/) a while ago. Our package
checksums are not security sensitive, but for the sake of easier
auditing, change them to SHA256.

Avoid the repeated inline checksums in tests and factorize them into
constants. Also update the command how to recompute them to use the
bridge from the build tree instead of the system.

See issue #5940