### PR TITLE
bots: Move container tests to fedora-27

### DIFF
--- a/bots/images/scripts/lib/base/Dockerfile
+++ b/bots/images/scripts/lib/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:26
+FROM fedora:27
 
 ADD setup.sh /setup.sh
 

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -320,10 +320,8 @@ class PullTask(object):
         # Split a value like verify/fedora-atomic
         (prefix, unused, value) = self.context.partition("/")
 
-        if prefix in [ 'selenium', 'avocado' ]:
+        if prefix in [ 'selenium', 'avocado', 'container' ]:
             image = 'fedora-27'
-        elif prefix in [ 'container' ]:
-            image = 'fedora-26'
         else:
             image = value
         os.environ["TEST_OS"] = image

--- a/containers/bastion/Dockerfile
+++ b/containers/bastion/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:26
+FROM fedora:27
 
 ARG VERSION
 ARG INSTALLER

--- a/containers/kubernetes/Dockerfile
+++ b/containers/kubernetes/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:26
+FROM fedora:27
 
 ARG VERSION
 ARG INSTALLER

--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:26
+FROM fedora:27
 LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
 
 ARG VERSION


### PR DESCRIPTION
The tests use the cockpit/base container, so this requires refreshing the fedora-27 image.

 - [ ] image-refresh fedora-27