### PR TITLE
machines: Fix "Start VM" checkbox layout

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -315,7 +315,7 @@ class CreateVM extends React.Component {
                             </label>
                         </td>
                         <td>
-                            <input id="start-vm" className="form-control dialog-checkbox" type="checkbox"
+                            <input id="start-vm" type="checkbox"
                                    checked={this.props.vmParams.startVm}
                                    onChange={this.onChangedEventChecked.bind(this, 'startVm')} />
                         </td>

--- a/pkg/machines/components/create-vm-dialog/createVmDialog.less
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.less
@@ -39,11 +39,6 @@
     color: #888888;
 }
 
-.dialog-checkbox {
-    width: 26px;
-    margin: 0;
-}
-
 #vendor-select .dropdown-header,
 #vendor-select .divider {
     margin-top: 2ex;


### PR DESCRIPTION
Drop the two classes and the now unused `dialog-checkbox` CSS, to get
the default checkbox size and layout. Neither class is being used at
runtime or in tests.

Fixes #8916