### PR TITLE
naughty: Close 8112: {rhel,continuous}-atomic: tests sometimes fail with: Error was encountered while opening journal files: Input/output error

### DIFF
--- a/bots/naughty/continuous-atomic/8112-journal-file-error
+++ b/bots/naughty/continuous-atomic/8112-journal-file-error
@@ -1,1 +1,0 @@
-Error: Error was encountered while opening journal files:


### PR DESCRIPTION
Known issue which has not occurred in 22 days

{rhel,continuous}-atomic: tests sometimes fail with: Error was encountered while opening journal files: Input/output error

Fixes #8112