### PR TITLE
machines: Change default font for SerialConsole

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Cockpit isn't a Node package, these are devel time deps, not needed to build tarball either",
   "private": true,
   "dependencies": {
-    "@patternfly/react-console": "1.1.1",
+    "@patternfly/react-console": "1.2.0",
     "angular": "1.3.20",
     "angular-bootstrap-npm": "0.13.4",
     "angular-gettext": "2.3.11",

--- a/pkg/machines/components/serialConsole.jsx
+++ b/pkg/machines/components/serialConsole.jsx
@@ -23,6 +23,11 @@ import { SerialConsole } from '@patternfly/react-console';
 
 const _ = cockpit.gettext;
 
+const XTERM_FONT_FAMILY = 'Menlo, Monaco, Consolas, monospace';
+const XTERM_FONT_SIZE = 12;
+const XTERM_COLS = 90;
+const XTERM_ROWS = 30;
+
 class SerialConsoleCockpit extends React.Component {
     constructor (props) {
         super(props);
@@ -116,8 +121,10 @@ class SerialConsoleCockpit extends React.Component {
     render () {
         return (
             <SerialConsole id={this.props.vmName} ref='serialconsole'
-                rows={30}
-                cols={90}
+                rows={XTERM_ROWS}
+                cols={XTERM_COLS}
+                fontFamily={XTERM_FONT_FAMILY}
+                fontSize={XTERM_FONT_SIZE}
                 status={this.getStatus()}
                 onConnect={this.onConnect}
                 onDisconnect={this.onDisconnect}


### PR DESCRIPTION
Font for `<SerialConsole>` component changed to
  `Menlo, Monaco, Consolas, monospace`, size `12`
to be unified with the rest of Cockpit.

---

Depends on: https://github.com/patternfly/patternfly-react/pull/356