### PR TITLE
webpack.config.js: Add react-redux alias

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -402,6 +402,7 @@ var aliases = {
     "react": "react-lite/dist/react-lite.js",
     "react-dom": "react-lite/dist/react-lite.js",
     "term": "term.js-cockpit/src/term.js",
+    "react-redux": "react-redux/dist/react-redux.js"
 };
 
 /* HACK: To get around redux warning about reminimizing code */


### PR DESCRIPTION
Pre-built non-minified dist version is used.
This fixes Cockpit build using `nvm 8` (tested with `nvm v8.9.4` and `npm v6.0.1`).

Prior this change, the `react-redux` was fully built from sources causing failure
with missing `hoist-non-react-statics` npm dependency which was downloaded to `react-redux/node_modules`.