### PR TITLE
ws: Install a sniplet in /etc/motd.d

### DIFF
--- a/src/ws/.gitignore
+++ b/src/ws/.gitignore
@@ -1,3 +1,4 @@
+/cockpit-motd.service
 /cockpit-ws
 /test-server
 /test-server-generated.c

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -162,16 +162,20 @@ remotectl_LDADD = \
 nodist_systemdunit_DATA += \
 	src/ws/cockpit.socket \
 	src/ws/cockpit.service \
+	src/ws/cockpit-motd.service \
 	$(NULL)
 
 firewalldir = $(prefix)/lib/firewalld/services
 firewall_DATA = src/ws/cockpit.xml
 
-issuedir = $(datadir)/$(PACKAGE)/issue/
-issue_DATA = \
-	src/ws/inactive.issue \
-	src/ws/active.issue \
-	$(NULL)
+motddir = $(datadir)/$(PACKAGE)/motd/
+dist_motd_DATA = src/ws/inactive.motd
+dist_motd_SCRIPTS = src/ws/update-motd
+
+# Automake: 'Variables using ... ‘sysconf’ ... are installed by install-exec.'
+install-exec-hook::
+	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/motd.d
+	$(LN_S) -nf /run/cockpit/motd $(DESTDIR)$(sysconfdir)/motd.d/cockpit
 
 tempconfdir = $(prefix)/lib/tmpfiles.d
 nodist_tempconf_DATA = src/ws/cockpit-tempfiles.conf
@@ -187,16 +191,17 @@ install-exec-hook::
 	test "$(COCKPIT_USER)" != "root" && chmod -f 4750 $(DESTDIR)$(libexecdir)/cockpit-session || true
 
 EXTRA_DIST += \
+	src/ws/cockpit-motd.service.in \
 	src/ws/cockpit.service.in \
 	src/ws/cockpit.socket.in \
 	$(firewall_DATA) \
-	$(issue_DATA) \
 	$(tempconf_in) \
 	$(NULL)
 
 CLEANFILES += \
 	src/ws/cockpit.socket \
 	src/ws/cockpit.service \
+	src/ws/cockpit-motd.service \
 	$(nodist_tempconf_DATA) \
 	$(NULL)
 

--- a/src/ws/active.issue
+++ b/src/ws/active.issue
@@ -1,2 +1,0 @@
-Admin Console: https://\4:9090/ or https://\6:9090/
-

--- a/src/ws/cockpit-motd.service.in
+++ b/src/ws/cockpit-motd.service.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=Cockpit motd updater service
+Documentation=man:cockpit-ws(8)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=-@datadir@/@PACKAGE@/motd/update-motd

--- a/src/ws/cockpit-tempfiles.conf.in
+++ b/src/ws/cockpit-tempfiles.conf.in
@@ -1,2 +1,2 @@
 d /run/cockpit 0755 - - -
-L+ /run/cockpit/issue - - - - @datadir@/@PACKAGE@/issue/inactive.issue
+L+ /run/cockpit/motd - - - - @datadir@/@PACKAGE@/motd/inactive.motd

--- a/src/ws/cockpit.socket.in
+++ b/src/ws/cockpit.socket.in
@@ -1,11 +1,13 @@
 [Unit]
 Description=Cockpit Web Service Socket
 Documentation=man:cockpit-ws(8)
+Wants=cockpit-motd.service
 
 [Socket]
 ListenStream=9090
-ExecStartPost=-/bin/ln -sf @datadir@/@PACKAGE@/issue/active.issue /run/cockpit/issue
-ExecStopPost=-/bin/ln -sf @datadir@/@PACKAGE@/issue/inactive.issue /run/cockpit/issue
+ExecStartPost=-@datadir@/@PACKAGE@/motd/update-motd
+ExecStartPost=-/bin/ln -snf active.motd /run/cockpit/motd
+ExecStopPost=-/bin/ln -snf @datadir@/@PACKAGE@/motd/inactive.motd /run/cockpit/motd
 
 [Install]
 WantedBy=sockets.target

--- a/src/ws/inactive.issue
+++ b/src/ws/inactive.issue
@@ -1,2 +1,0 @@
-Activate the web admin console with: systemctl enable --now cockpit.socket
-

--- a/src/ws/inactive.motd
+++ b/src/ws/inactive.motd
@@ -1,0 +1,2 @@
+Activate the web console with: systemctl enable --now cockpit.socket
+

--- a/src/ws/update-motd
+++ b/src/ws/update-motd
@@ -1,0 +1,24 @@
+#!/bin/sh -e
+
+# syntax: update-motd [port [hostname [ipaddr [protocol]]]]
+# each argument can be given as the empty string to use the default
+
+# port number from cmdline, then systemctl file, then 9090
+# take the last Listen line; this will be the user-specified one
+port=${1:-$(systemctl show --property Listen cockpit.socket |
+              sed -E '$!d;$s/.*[^0-9]([0-9]+).*/\1/;')}
+port=${port:-9090}
+
+# hostname from cmdline, then `hostname -f`
+hostname=${2:-$(hostname -f)}
+
+# ip addr from cmdline, then default route source addr
+ip=${3:-$(ip -o route get 255.0 2>/dev/null | sed -e 's/.*src \([^ ]*\) .*/\1/')}
+
+# protocol from cmdline, then https
+protocol=${4:-https}
+
+hostname_url="${protocol}://${hostname}:${port}/"
+ip_url="${ip:+ or ${protocol}://${ip}:${port}/}"
+
+printf 'Web console: %s%s\n\n' "${hostname_url}" "${ip_url}"  > /run/cockpit/active.motd

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -172,33 +172,32 @@ class TestConnection(MachineCase):
         m = self.machine
 
         if not m.image in ["rhel-7-5"]:
-            self.assertIn("systemctl", m.execute("cat /run/cockpit/issue"))
-            self.assertNotIn("9090", m.execute("cat /run/cockpit/issue"))
+            self.assertIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
+            self.assertNotIn("9090", m.execute("cat /etc/motd.d/cockpit"))
         m.start_cockpit()
 
         if not m.image in ["rhel-7-5"]:
-            self.assertNotIn("systemctl", m.execute("cat /run/cockpit/issue"))
-            self.assertIn("9090", m.execute("cat /run/cockpit/issue"))
+            self.assertNotIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
+            self.assertIn("9090", m.execute("cat /etc/motd.d/cockpit"))
 
         m.execute("systemctl stop cockpit.socket")
 
         # Change port according to documentation: https://cockpit-project.org/guide/latest/listen.html
         m.execute('! selinuxenabled || semanage port -m -t websm_port_t -p tcp 443')
-        m.execute("echo 'custom activemessage' > /etc/cockpit/active.issue")
-        m.execute('mkdir -p /etc/systemd/system/cockpit.socket.d/ && printf "[Socket]\nListenStream=\nListenStream=443\nExecStartPost=-/bin/ln -sf /etc/cockpit/active.issue /run/cockpit/issue" > /etc/systemd/system/cockpit.socket.d/listen.conf')
+        m.execute('mkdir -p /etc/systemd/system/cockpit.socket.d/ && printf "[Socket]\nListenStream=\nListenStream=443" > /etc/systemd/system/cockpit.socket.d/listen.conf')
 
         # cockpit-ws from base package
         if not m.image in ["rhel-7-5"]:
-            self.assertIn("systemctl", m.execute("cat /run/cockpit/issue"))
-            self.assertNotIn("9090", m.execute("cat /run/cockpit/issue"))
-            self.assertNotIn("custom activemessage", m.execute("cat /run/cockpit/issue"))
+            self.assertIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
+            self.assertNotIn("9090", m.execute("cat /etc/motd.d/cockpit"))
+            self.assertNotIn("443", m.execute("cat /etc/motd.d/cockpit"))
         m.start_cockpit(tls=True)
 
         # cockpit-ws from base package
         if not m.image in ["rhel-7-5"]:
-            self.assertNotIn("systemctl", m.execute("cat /run/cockpit/issue"))
-            self.assertNotIn("9090", m.execute("cat /run/cockpit/issue"))
-            self.assertIn("custom activemessage", m.execute("cat /run/cockpit/issue"))
+            self.assertNotIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
+            self.assertNotIn("9090", m.execute("cat /etc/motd.d/cockpit"))
+            self.assertIn("443", m.execute("cat /etc/motd.d/cockpit"))
 
         output = m.execute('curl -k https://localhost 2>&1 || true')
         self.assertIn('Loading...', output)

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -493,9 +493,11 @@ The Cockpit Web Service listens on the network, and authenticates users.
 %doc %{_mandir}/man8/pam_ssh_add.8.gz
 %config(noreplace) %{_sysconfdir}/%{name}/ws-certs.d
 %config(noreplace) %{_sysconfdir}/pam.d/cockpit
-%{_datadir}/%{name}/issue/active.issue
-%{_datadir}/%{name}/issue/inactive.issue
+%config %{_sysconfdir}/motd.d/cockpit
+%{_datadir}/%{name}/motd/update-motd
+%{_datadir}/%{name}/motd/inactive.motd
 %{_unitdir}/cockpit.service
+%{_unitdir}/cockpit-motd.service
 %{_unitdir}/cockpit.socket
 %{_prefix}/%{__lib}/firewalld/services/cockpit.xml
 %{_prefix}/%{__lib}/tmpfiles.d/cockpit-tempfiles.conf

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -1,6 +1,8 @@
 etc/cockpit/ws-certs.d
+etc/motd.d/cockpit
 etc/pam.d/cockpit
 lib/systemd/system/cockpit.service
+lib/systemd/system/cockpit-motd.service
 lib/systemd/system/cockpit.socket
 lib/*/security/pam_ssh_add.so
 usr/lib/tmpfiles.d/cockpit-tempfiles.conf
@@ -9,7 +11,7 @@ usr/lib/cockpit/cockpit-ws
 usr/lib/firewalld/services/cockpit.xml
 usr/sbin/remotectl
 usr/share/cockpit/branding/
-usr/share/cockpit/issue/
+usr/share/cockpit/motd/
 usr/share/cockpit/static/
 usr/share/locale/
 usr/share/man/man5/cockpit.conf.5


### PR DESCRIPTION
In the case that cockpit is not running, provide advice on how to start
it.  If it is running, show the URL at which cockpit is accessed.

For now, we just use the fully-qualified hostname (if it is set).  In
the future, we can perform some more interesting heuristics to determine
a better name or IP address to show.

Closes #9129