### PR TITLE
machines: Enable Redux DevTools Extension

### DIFF
--- a/pkg/machines/store.es6
+++ b/pkg/machines/store.es6
@@ -16,14 +16,12 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
-import { applyMiddleware, createStore } from 'redux/dist/redux';
+
+import { createStore, applyMiddleware, compose } from 'redux';
 import reducer from './reducers.es6';
 import { thunk } from './middlewares.es6';
 
-const createStoreWithMiddleware = applyMiddleware(
-    thunk
-)(createStore);
-
-const store = createStoreWithMiddleware(reducer);
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const store = createStore(reducer, /* preloadedState, */ composeEnhancers(applyMiddleware(thunk)));
 
 export default store;


### PR DESCRIPTION
With Redux DevTools enabled, content of the Redux store can be
debugged more easily.

More info: https://github.com/zalmoxisus/redux-devtools-extension