### PR TITLE
test: Allow restart messages in testNoAdminGroup()

### DIFF
--- a/test/verify/check-shutdown-restart
+++ b/test/verify/check-shutdown-restart
@@ -39,6 +39,7 @@ class TestShutdownRestart(MachineCase):
         b = self.browser
 
         self.allow_authorize_journal_messages()
+        self.allow_restart_journal_messages()
 
         # Create a user without any role
         m.execute("useradd user -s /bin/bash -c 'User' || true")


### PR DESCRIPTION
This often fails like this:
```
Unexpected journal message 'PolicyKit daemon disconnected from the bus.'
Unexpected journal message 'We are no longer a registered authentication agent.'
Traceback (most recent call last):
  File "/build/cockpit/test/common/testlib.py", line 665, in tearDown
    self.check_journal_messages()
  File "/build/cockpit/test/common/testlib.py", line 822, in check_journal_messages
    raise Error(first)
Error: PolicyKit daemon disconnected from the bus.
```

The test reboots the machine, so allow corresponding messages.