### PR TITLE
naughty: Close 8942: SELinux doesn't allow "systemctl start tangd.socket"

### DIFF
--- a/bots/naughty/fedora-26/8942-selinux-tangd-socket
+++ b/bots/naughty/fedora-26/8942-selinux-tangd-socket
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-storage-luks", line *, in testClevis
-    m.execute("systemctl start tangd.socket")


### PR DESCRIPTION
Known issue which has not occurred in 26 days

SELinux doesn't allow "systemctl start tangd.socket"

Fixes #8942