### PR TITLE
machines: clean up comment

### DIFF
--- a/pkg/machines/libvirt.es6
+++ b/pkg/machines/libvirt.es6
@@ -136,7 +136,7 @@ LIBVIRT_PROVIDER = {
      * Initialize the provider.
      * Arguments are used for reference only, they are actually not needed for this Libvirt provider.
      *
-     * @param providerContext - see `getProviderContext()` in provider.es6
+     * @param providerContext - contains context details, like the dispatch function, see provider.es6
      * @returns {boolean} - true, if initialization succeeded; or Promise
      */
     init(providerContext) {


### PR DESCRIPTION
Some people claim, comments should be avoided in the code since they are never updated along further changes. And they would be right this time.

In machines/libvirt.es6, description of the LIBVIRT_PROVIDER.init()
function is fixed after former refactoring.