### PR TITLE
machines: Use iframe download workaround on all browsers

### DIFF
--- a/pkg/machines/helpers.es6
+++ b/pkg/machines/helpers.es6
@@ -247,10 +247,6 @@ export function toFixedPrecision(value, precision) {
     return result;
 }
 
-function isFirefox() {
-    return window.navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-}
-
 /**
  * Download given content as a file in the browser
  *
@@ -270,12 +266,13 @@ export function fileDownload({ data, fileName = 'myFile.dat', mimeType = 'applic
     a.href = `data:${mimeType},${encodeURIComponent(data)}`;
     document.body.appendChild(a); // if not used further then at least within integration tests
 
-    // Workaround since I can't get CSP working on newer Firefox versions for this
-    if (!isFirefox() && 'download' in a) { // html5 A[download]
+    // Workaround since I can't get CSP working for this
+    /*
+    if ('download' in a) { // html5 A[download]
         logDebug('fileDownload() is using A.HREF');
         a.setAttribute('download', fileName);
         a.click();
-    } else { // do iframe dataURL download (old ch+FF):
+    } else */ { // do iframe dataURL download
         logDebug('fileDownload() is using IFRAME');
         const f = document.createElement('iframe');
         f.width = '1';


### PR DESCRIPTION
Chromium 65 refuses to download the generated .vv file as well now:

```
CDP: {"source":"other","level":"error","text":"Refused to frame '' because it violates the following Content Security Policy directive: \"default-src 'self' http://127.0.0.2:9091\". Note that 'frame-src' was not explicitly set, so 'default-src' is used as a fallback.\n","timestamp":1527156936689.5,"url":"http://127.0.0.2:9091/cockpit/$0021b50df7588e9af173d46d5eda7bdac26be09b97f000fec7a55dda9228c356/machines/machines.js","lineNumber":6126}
CDP: executionContextDestroyed 11
```

And after that one just gets a blank page with a sad face. Use the
workaround of wrapping this in a dynamic iframe on all browsers now.

 - [ ] drop `@expectedFailure` marking once PR #9283 lands