### PR TITLE
bots: Stop triggering fedora-27 on PRs, start triggering rhel-8

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -65,6 +65,7 @@ TRIGGERS = {
         "verify/rhel-7-5"
     ],
     "ipa": [
+        "verify/fedora-28",
         "verify/rhel-7",
         "verify/rhel-7-5",
         "verify/ubuntu-1604",

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -33,7 +33,7 @@ DEFAULT_VERIFY = {
     'verify/debian-stable': [ 'master' ],
     'verify/debian-testing': [ 'master' ],
     'verify/fedora-i386': BRANCHES,
-    'verify/fedora-27': [ 'master' ],
+    'verify/fedora-27': [ ],
     'verify/fedora-28': [ 'master' ],
     'verify/fedora-atomic': BRANCHES,
     'verify/fedora-testing': [ ],
@@ -45,7 +45,7 @@ DEFAULT_VERIFY = {
 REDHAT_VERIFY = {
     "verify/rhel-7": [ 'master' ],
     "verify/rhel-7-5": [ 'master', 'rhel-7.5' ],
-    "verify/rhel-8": [ ],
+    "verify/rhel-8": [ 'master' ],
     "verify/rhel-atomic": [ 'master' ],
     'selenium/explorer': [ 'master' ],
 }

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -202,6 +202,7 @@ class TestStorage(StorageCase):
         b.wait_present("#detail-header button:contains(Mount)")
 
 @skipImage("NetworkManager and NFS don't work together", "ubuntu-1604")
+@skipImage("https://bugzilla.redhat.com/show_bug.cgi?id=1559414", "rhel-8")
 class TestStoragePackages(StorageCase, PackageCase):
 
     def testNfsMissingPackages(self):


### PR DESCRIPTION
Fedora 28 is the current release,  we are not focussing on or releasing
to 27 any more. As such the weekly refreshes are sufficient, we don't
need to trigger fedora-27 on every PR any more.

rhel-8 is a major development target right now, so trigger that on every
PR instead.

 - [x] land and rebase to #9088