### PR TITLE
test: Fix stop_cockpit() to also stop the service

### DIFF
--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -702,7 +702,7 @@ class Machine:
             with Timeout(seconds=60, error_message="Timeout while waiting for cockpit/ws to stop"):
                 self.execute("docker kill `docker ps | grep cockpit/ws | awk '{print $1;}'`")
         else:
-            self.execute("systemctl stop cockpit.socket")
+            self.execute("systemctl stop cockpit.socket cockpit.service")
 
     def set_address(self, address, mac='52:54:01'):
         """Set IP address for the network interface with given mac prefix"""


### PR DESCRIPTION
This is being used in check-connection. Just stopping the socket does
not prove anything, as cockpit.service is running while the login page
is being served. This corresponds to shutting down the ws container on
Atomic.