### PR TITLE
ws: Also strip query from original_path

### DIFF
--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -302,6 +302,7 @@ cockpit_web_server_default_handle_stream (CockpitWebServer *self,
   gboolean claimed = FALSE;
   GQuark detail;
   gchar *pos;
+  gchar *orig_pos;
   gchar bak;
 
   /* Yes, we happen to know that we can modify this string safely. */
@@ -311,6 +312,12 @@ cockpit_web_server_default_handle_stream (CockpitWebServer *self,
       *pos = '\0';
       pos++;
     }
+
+  /* We also have to strip original_path so that CockpitWebResponse
+     can rediscover url_root. */
+  orig_pos = strchr (original_path, '?');
+  if (orig_pos != NULL)
+    *orig_pos = '\0';
 
   /* TODO: Correct HTTP version for response */
   response = cockpit_web_response_new (io_stream, original_path, path, pos, headers);

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -497,6 +497,25 @@ class TestMultiMachine(MachineCase):
         self.checkDirectLogin('/cockpit-new/');
         self.allow_hostkey_messages()
 
+    @skipImage("cockpit-ws too old", "rhel-7-5")
+    def testUrlRootWithQuery(self):
+        b = self.browser
+        m = self.machine
+
+        m.execute('mkdir -p /etc/cockpit/ && echo "[WebService]\nUrlRoot = cockpit-new" > /etc/cockpit/cockpit.conf')
+        m.start_cockpit()
+
+        b.open("/cockpit-new/system?access_token=XXXX")
+        b.wait_visible("#login")
+        b.set_val("#login-user-input", "admin")
+        b.set_val("#login-password-input", "foobar")
+        b.set_checked("#authorized-input", True)
+        b.click('#login-button')
+        b.expect_load()
+        b.enter_page("/system")
+        b.switch_to_top()
+        b.wait_js_cond('window.location.pathname == "/cockpit-new/system"')
+
     def testExternalPage(self):
         b = self.browser
         m1 = self.machine


### PR DESCRIPTION
Otherwise the CockpitWebResponse will not rediscover the url_root when
a query is present.

This happens for example when logging in with OAuth.  In that case,
the URL contains "?access_token=XXX" and if CockpitWebResponse doesn't
rediscover the url_root, send_login_page will include the wrong <base>
directive in the login page.  This in turn means that login.js sends
the credentials to the wrong place.