### PR TITLE
kubernetes: Use more relaxed check pattern for group names

### DIFF
--- a/pkg/kubernetes/scripts/kube-client.js
+++ b/pkg/kubernetes/scripts/kube-client.js
@@ -1323,14 +1323,14 @@
                 if (meta) {
                     ex = null;
                     if (meta.name !== undefined) {
-                        var check_re = (resource.kind == "User") ? USER_NAME_RE : NAME_RE;
+                        var check_re = (resource.kind == "User" || resource.kind == "Group") ? USER_NAME_RE : NAME_RE;
                         if (!meta.name)
                             ex = new Error("The name cannot be empty");
                         else if (!check_re.test(meta.name))
                             if (check_re == NAME_RE) {
                                 ex = new Error("The name contains invalid characters. Only letters, numbers and dashes are allowed");
                             } else {
-                                ex = new Error("The name contains invalid characters. Only letters, numbers, spaces and the following symbols are allowed: , = @  . _ :");
+                                ex = new Error("The name contains invalid characters. Only letters, numbers, spaces and the following symbols are allowed: , = @  . _ - :");
                             }
                     }
                     if (ex) {

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -1040,6 +1040,7 @@ class RegistryTests(object):
         self.checkImageName(b, "aaa_", False)
         self.checkImageName(b, "aaa-", False)
         self.checkImageName(b, "aaa.", False)
+        self.checkImageName(b, "a_ a", False)
         self.checkImageName(b, "Aa_Bb_Cc", False)
         self.checkImageName(b, "aa_bb_cc", True)
         self.checkImageName(b, "aa-bb_cc.dd", True)
@@ -1072,14 +1073,14 @@ class RegistryTests(object):
         b.click("#add-group")
         b.wait_present("modal-dialog")
         b.wait_visible(".modal-body")
-        b.set_val("#group_name", "production")
+        b.set_val("#group_name", "Pro-Duction")
         b.click(".btn-primary")
         b.wait_not_present("modal-dialog")
         b.wait_present("tbody[data-id='marmalade']")
 
         #group page
-        b.click("tbody[data-id='production'] tr:first-child td:nth-of-type(2)")
-        b.wait_in_text(".content-filter h3", "production")
+        b.click("tbody[data-id='Pro-Duction'] tr:first-child td:nth-of-type(2)")
+        b.wait_in_text(".content-filter h3", "Pro-Duction")
 
         #add member
         b.click("a i.pficon-add-circle-o")
@@ -1112,12 +1113,12 @@ class RegistryTests(object):
         b.wait_not_present("modal-dialog")
 
         #delete user
-        b.wait_in_text(".content-filter h3", "production")
+        b.wait_in_text(".content-filter h3", "Pro-Duction")
         b.click(".content-filter .pficon-delete")
         b.wait_present("modal-dialog")
         b.click(".btn-primary")
         b.wait_not_present("modal-dialog")
-        b.wait_not_present("tbody[data-id='production']")
+        b.wait_not_present("tbody[data-id='Pro-Duction']")
 
     def testProjectUsers(self):
         o = self.openshift


### PR DESCRIPTION
Apply the regexp for user names to group names as well, so that upper case and other characters are allowed.

Also adjust the error message for invalid user names, dashes are already
allowed (and legit) in them.

https://bugzilla.redhat.com/show_bug.cgi?id=1582238