### PR TITLE
bots: Install tuned on debian-testing and ubuntu-stable images

### DIFF
--- a/bots/images/debian-testing
+++ b/bots/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-d945207a7d88eaede473d6a7386bf6f65bec09e9bbd03255ad7c81e6ac1e218a.qcow2
+debian-testing-cbf52282aed6b0b6de640b7bdedcb8d011fa95d0f5f1ae844b0ff7b14024cd79.qcow2

--- a/bots/images/scripts/debian.setup
+++ b/bots/images/scripts/debian.setup
@@ -31,6 +31,7 @@ python3-dbus \
 realmd \
 selinux-basics \
 thin-provisioning-tools \
+tuned \
 xdg-utils \
 udisks2 \
 udisks2-lvm2 \
@@ -64,6 +65,7 @@ case "$RELEASE" in
         COCKPIT_DEPS="${COCKPIT_DEPS/pcp /}"
         COCKPIT_DEPS="${COCKPIT_DEPS/libblockdev-mdraid2 /}"
         COCKPIT_DEPS="${COCKPIT_DEPS/udisks2-lvm2 /}"
+        COCKPIT_DEPS="${COCKPIT_DEPS/tuned /}"
 
         echo >> /etc/apt/sources.list
         echo 'deb http://security.debian.org/debian-security stable/updates main' >> /etc/apt/sources.list
@@ -81,6 +83,7 @@ case "$RELEASE" in
         # these packages are not in Ubuntu 16.04
         COCKPIT_DEPS="${COCKPIT_DEPS/libblockdev-mdraid2 /}"
         COCKPIT_DEPS="${COCKPIT_DEPS/udisks2-lvm2 /}"
+        COCKPIT_DEPS="${COCKPIT_DEPS/tuned /}"
 
         # NFS and NetworkManager don't work together
         TEST_PACKAGES="${TEST_PACKAGES/nfs-server /}"

--- a/bots/images/scripts/lib/debian.install
+++ b/bots/images/scripts/lib/debian.install
@@ -81,6 +81,9 @@ if [ -n "$do_install" ]; then
     # after start_cockpit().
     systemctl disable cockpit.socket
 
+    # HACK: tuned breaks QEMU (https://launchpad.net/bugs/1774000)
+    systemctl disable tuned.service 2>/dev/null || true
+
     # firewall-cmd --add-service=cockpit --permanent
 
     rm -rf /var/log/journal/*

--- a/bots/images/ubuntu-stable
+++ b/bots/images/ubuntu-stable
@@ -1,1 +1,1 @@
-ubuntu-stable-76eacf4be6c04f46baefd530061022b76b7a09e08e3a3ce7713b3f554d2a38ca.qcow2
+ubuntu-stable-cdd0bb08c4733e35810e34ba8e90638a5eead1ef97af6eac190b8015987268c8.qcow2

--- a/test/verify/check-tuned
+++ b/test/verify/check-tuned
@@ -21,7 +21,7 @@
 import parent
 from testlib import *
 
-@skipImage("No tuned packaged", "debian-stable", "debian-testing", "fedora-atomic", "ubuntu-1604", "ubuntu-stable")
+@skipImage("No tuned packaged", "debian-stable", "fedora-atomic", "ubuntu-1604")
 @skipImage("tuned currently uninstallable (bz#1537205)", "rhel-8")
 class TestTuned(MachineCase):
     def testBasic(self):


### PR DESCRIPTION
Enable check-tuned on these images.

 * [x] image-refresh debian-testing
 * [x] image-refresh ubuntu-stable