### PR TITLE
networking: Hide actions and show notification if NM is not running

### DIFF
--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -40,7 +40,19 @@
   </div>
 
   <div id="networking" class="container-fluid page-ct" hidden>
-    <div class="row">
+    <div id="networking-nm-crashed" class="alert alert-danger" hidden>
+      <button class="btn btn-default pull-right" type="submit" translatable="yes">Start Service</button>
+        <span class="pficon pficon-error-circle-o"></span>
+        <strong translatable="yes">NetworkManager is not running.</strong> <a href="#" class="alert-link">Troubleshoot…</a>
+    </div>
+
+    <div id="networking-nm-disabled" class="alert alert-info" hidden>
+      <button class="btn btn-default pull-right" type="submit" translatable="yes">Enable Service</button>
+      <span class="pficon pficon-info"></span>
+      <strong translatable="yes">Network devices and graphs require NetworkManager.</strong>
+    </div>
+
+    <div id="networking-graphs" class="row">
       <div id="networking-graph-toolbar" class="zoom-controls standard-zoom-controls">
         <div class="dropdown">
           <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">

--- a/test/verify/check-networking-basic
+++ b/test/verify/check-networking-basic
@@ -85,5 +85,74 @@ class TestNetworking(NetworkCase):
 
         wait(lambda: "yes" in m.execute("nmcli -f ipv4.ignore-auto-dns connection show '%s'" % con_id))
 
+    @skipImage("cockpit-system too old", "rhel-7-5")
+    def testNoService(self):
+        b = self.browser
+        m = self.machine
+
+        def assert_running():
+            b.wait_not_visible("#networking-nm-crashed")
+            b.wait_not_visible("#networking-nm-disabled")
+            b.wait_visible("#networking-graphs")
+            b.wait_visible("#networking-interfaces")
+            b.wait_present("#networking-interfaces tr[data-interface='eth1']")
+
+        def assert_stopped(enabled):
+            # should hide graphs and actions and show the appropriate notification
+            b.wait_not_visible("#networking-graphs")
+            b.wait_not_visible("#networking-interfaces")
+            if enabled:
+                b.wait_visible("#networking-nm-crashed")
+                b.wait_not_visible("#networking-nm-disabled")
+            else:
+                b.wait_not_visible("#networking-nm-crashed")
+                b.wait_visible("#networking-nm-disabled")
+
+        self.login_and_go("/network")
+        assert_running()
+
+        # Disable NM D-Bus activation; it auto-starts at unpredictable times from background actions,
+        # which makes it impossible/meaningless to write a test; copy the full unit file, Alias= cannot
+        # be reliably disabled with drop-ins
+        m.execute("""systemctl cat NetworkManager.service | sed '/Alias=/d' > /etc/systemd/system/NetworkManager.service
+rm -f --verbose /etc/systemd/system/dbus-org.freedesktop.NetworkManager.service
+systemctl daemon-reload""")
+
+        # stop/start NM on CLI, page should notice
+        m.execute("systemctl stop NetworkManager")
+        assert_stopped(True)
+        m.execute("systemctl start NetworkManager")
+        assert_running()
+
+        # stop NM, test inline start button
+        m.execute("systemctl stop NetworkManager")
+        assert_stopped(True)
+        b.click("#networking-nm-crashed button")
+        assert_running()
+
+        # stop NM, test troubleshoot button
+        m.execute("systemctl stop NetworkManager")
+        assert_stopped(True)
+        b.click("#networking-nm-crashed a")
+        b.enter_page("/system/services")
+        b.wait_present("#service-unit")
+        b.wait_in_text("#service-unit", "NetworkManager.service")
+        b.wait_present("button[data-action='StartUnit']")
+        b.click("button[data-action='StartUnit']")
+        b.wait_in_text("#service-unit", "(running)")
+        # networking page should notice start from Services page
+        b.go("/network")
+        b.enter_page("/network")
+        assert_running()
+
+        # stop and disable NM, enablement info notification
+        m.execute("systemctl stop NetworkManager; systemctl disable NetworkManager")
+        assert_stopped(False)
+        b.click("#networking-nm-disabled button")
+        assert_running()
+        wait(lambda: m.execute("systemctl is-enabled NetworkManager"))
+
+        self.allow_journal_messages(".*org.freedesktop.NetworkManager.*")
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
If NetworkManager is not running or is not even installed, the graphs
don't work and clicking any action button like "Add Bond" causes the 
page to crash.

Track "owner" notifications on the D-Bus client to get notified when NM
(dis)appears from the bus.

  * If NM is enabled, then show an error notification, as this is an
    unexpected situation (NM crashed?). Offer a Troubleshoot link to the 
    Services page, and a "quick-fix" button to start NM. 

  * If NM is disabled, just show an info notification, as chances are 
    that the machine uses something else to manage the network. Offer a
    button to enable and start NM, for the "first-time setup" use case.

Some OSes (like Fedora) configure NetworkManager to do D-Bus activation.
As there is pretty much always some background noise with pinging NM, 
this interferes with the test at unpredictable times, thus disable D-Bus
activation for this test.

https://bugzilla.redhat.com/show_bug.cgi?id=1551615

 - [x] Update status after D-Bus service (dis)appears or when page shows
 - [x] Design review
 - [x] Update verbiage for the "disabled" case
 - [x] Tests