### PR TITLE
bots: Move fedora-testing to Fedora 28

### DIFF
--- a/bots/images/fedora-testing
+++ b/bots/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-9a0bd3c16fef06f588fcf6d90ef95a190a73caf7d34046d1ec8d127cd91aed3f.qcow2
+fedora-testing-28f369422e6c3bb4b851c521b71bd45cf5b36132425a96b5a5cfb528332030b4.qcow2

--- a/bots/images/scripts/fedora-testing.bootstrap
+++ b/bots/images/scripts/fedora-testing.bootstrap
@@ -1,1 +1,1 @@
-fedora-27.bootstrap
+fedora-28.bootstrap

--- a/bots/images/scripts/fedora-testing.install
+++ b/bots/images/scripts/fedora-testing.install
@@ -1,10 +1,1 @@
-#! /bin/bash
-
-set -e
-
-# HACK - We need to build with --no-bootstrap-chroot since that is how
-# we have initialized mock during setup.
-#
-# https://bugzilla.redhat.com/show_bug.cgi?id=1447627
-
-/var/lib/testvm/fedora.install --HACK-no-bootstrap-chroot "$@"
+fedora-28.install

--- a/bots/naughty/fedora-testing
+++ b/bots/naughty/fedora-testing
@@ -1,1 +1,1 @@
-fedora-27
+fedora-28

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -787,7 +787,7 @@ class MachineCase(unittest.TestCase):
         # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1557913
         # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1563143
         # these fail tons of tests due to the SELinux violations (so naughty override causes too much spamming)
-        if self.image == 'fedora-28' or self.image == 'fedora-atomic':
+        if self.image in ['fedora-28', 'fedora-atomic', 'fedora-testing']:
             self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { dac_override }.*')
             self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { module_request }.*')
             self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { getattr } for .* comm="which" path="/usr/sbin/setfiles".*')

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -121,7 +121,7 @@ class TestRealms(MachineCase):
         m.execute("! su -c klist admin")
         b.logout()
 
-        if m.image in ["fedora-28"]:
+        if m.image in ["fedora-28", "fedora-testing"]:
             # HACK: fix authselect/IPA regression (https://bugzilla.redhat.com/show_bug.cgi?id=1582111)
             self.machine.execute("authselect enable-feature with-sudo")
 
@@ -262,7 +262,7 @@ class TestRealms(MachineCase):
         m.execute("printf '[cockpit.lan]\\nfully-qualified-names = no\\n'  >> /etc/realmd.conf")
         m.execute("echo foobarfoo | realm join -vU admin cockpit.lan")
 
-        if m.image in ["fedora-28"]:
+        if m.image in ["fedora-28", "fedora-testing"]:
             # HACK: fix authselect/IPA regression (https://bugzilla.redhat.com/show_bug.cgi?id=1582111)
             self.machine.execute("authselect enable-feature with-sudo")
 


### PR DESCRIPTION
This is where the more interesting stuff happens now.

Replace fedora-testing.install with a symlink to fedora-28.install to
also pick up the pmcd hack from there.

 * [x] image-refresh fedora-testing
 * [x] naughty override for docker regression (#9285)