### PR TITLE
ws: Install a /etc/issue.d/cockpit link

### DIFF
--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -176,6 +176,8 @@ dist_motd_SCRIPTS = src/ws/update-motd
 install-exec-hook::
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/motd.d
 	$(LN_S) -nf /run/cockpit/motd $(DESTDIR)$(sysconfdir)/motd.d/cockpit
+	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/issue.d
+	$(LN_S) -nf /run/cockpit/motd $(DESTDIR)$(sysconfdir)/issue.d/cockpit
 
 tempconfdir = $(prefix)/lib/tmpfiles.d
 nodist_tempconf_DATA = src/ws/cockpit-tempfiles.conf

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -172,12 +172,14 @@ class TestConnection(MachineCase):
         m = self.machine
 
         if not m.image in ["rhel-7-5"]:
+            self.assertIn("systemctl", m.execute("cat /etc/issue.d/cockpit"))
             self.assertIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
             self.assertNotIn("9090", m.execute("cat /etc/motd.d/cockpit"))
         m.start_cockpit()
 
         if not m.image in ["rhel-7-5"]:
             self.assertNotIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
+            self.assertIn("9090", m.execute("cat /etc/issue.d/cockpit"))
             self.assertIn("9090", m.execute("cat /etc/motd.d/cockpit"))
 
         m.execute("systemctl stop cockpit.socket")
@@ -188,6 +190,7 @@ class TestConnection(MachineCase):
 
         # cockpit-ws from base package
         if not m.image in ["rhel-7-5"]:
+            self.assertIn("systemctl", m.execute("cat /etc/issue.d/cockpit"))
             self.assertIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
             self.assertNotIn("9090", m.execute("cat /etc/motd.d/cockpit"))
             self.assertNotIn("443", m.execute("cat /etc/motd.d/cockpit"))
@@ -197,6 +200,7 @@ class TestConnection(MachineCase):
         if not m.image in ["rhel-7-5"]:
             self.assertNotIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
             self.assertNotIn("9090", m.execute("cat /etc/motd.d/cockpit"))
+            self.assertIn("443", m.execute("cat /etc/issue.d/cockpit"))
             self.assertIn("443", m.execute("cat /etc/motd.d/cockpit"))
 
         output = m.execute('curl -k https://localhost 2>&1 || true')

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -493,6 +493,7 @@ The Cockpit Web Service listens on the network, and authenticates users.
 %doc %{_mandir}/man8/pam_ssh_add.8.gz
 %config(noreplace) %{_sysconfdir}/%{name}/ws-certs.d
 %config(noreplace) %{_sysconfdir}/pam.d/cockpit
+%config %{_sysconfdir}/issue.d/cockpit
 %config %{_sysconfdir}/motd.d/cockpit
 %{_datadir}/%{name}/motd/update-motd
 %{_datadir}/%{name}/motd/inactive.motd

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -1,4 +1,5 @@
 etc/cockpit/ws-certs.d
+etc/issue.d/cockpit
 etc/motd.d/cockpit
 etc/pam.d/cockpit
 lib/systemd/system/cockpit.service


### PR DESCRIPTION
Display our motd message also at the virtual console by way of linking
it to /etc/issue.d/cockpit.

This requires v2.32 of util-linux to be installed.  If an earlier
version is installed, then the file in issue.d will simply be ignored.

Tweak the tests to make sure the file is properly installed.