### PR TITLE
bots: add libvirt-dbus package in fedora images

### DIFF
--- a/bots/images/scripts/fedora.setup
+++ b/bots/images/scripts/fedora.setup
@@ -42,6 +42,7 @@ kexec-tools \
 libssh \
 libvirt \
 libvirt-client \
+libvirt-dbus \
 NetworkManager-team \
 openssl \
 PackageKit \


### PR DESCRIPTION
libvirt-dbus package will be needed for cockpit machines.
For now the package is available only for fedora > 27 thus
only this script will be updated.

 - [ ] image-refresh fedora-27
 - [ ] image-refresh fedora-28
 - [ ] image-refresh fedora-i386
 - [ ] land fedora-testing fix (PR #9267)