### PR TITLE
build: Fix `make uninstall` race with find

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -214,10 +214,10 @@ install-data-local:: $(WEBPACK_DEBUG)
 	$(MKDIR_P) $(DESTDIR)$(debugdir)$(pkgdatadir)
 	tar -cf - $^ | tar -C $(DESTDIR)$(debugdir)$(pkgdatadir) --strip-components=1 -xvf -
 uninstall-local::
-	find $(DESTDIR)$(pkgdatadir) -type f -delete
-	find $(DESTDIR)$(pkgdatadir) -type d -empty -delete
-	find $(DESTDIR)$(debugdir)$(pkgdatadir) -type f -delete
-	find $(DESTDIR)$(debugdir)$(pkgdatadir) -type d -empty -delete
+	find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type f -delete
+	find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete
+	find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type f -delete
+	find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete
 dist-hook:: $(WEBPACK_INPUTS) $(WEBPACK_OUTPUTS) $(WEBPACK_PO)
 	tar -cf - $^ | tar -C $(distdir) -xf -
 


### PR DESCRIPTION
The generic `find` cleanup of `pkgdatadir` has a race condition with
explicit `*_DATA` file lists. When `make uninstall` runs with `-j`
(parallel tasks), this sequence often happens:

```
find /tmp/source/cockpit-168.x/_inst/share/cockpit -type f -delete
 ( cd '/tmp/source/cockpit-168.x/_inst/share/cockpit/machines' && rm -f base.css )
find: cannot delete '/tmp/source/cockpit-168.x/_inst/share/cockpit/machines/base.css': No such file or directory
Makefile:8634: recipe for target 'uninstall-local' failed
```

Fortunately `find` has an `-ignore_readdir_race` option to quiesce
exactly this situation, use it.