### PR TITLE
machines: fix for SPICE support detection

### DIFF
--- a/pkg/machines/scripts/create_machine.sh
+++ b/pkg/machines/scripts/create_machine.sh
@@ -26,8 +26,10 @@ spiceSupported(){
         *) QEMU=qemu-system-$ARCH;
     esac
 
-    printf '{"execute":"qmp_capabilities"}\n{"execute":"query-spice"}\n{"execute":"quit"}' | \
-        $QEMU --qmp stdio --nographic -nodefaults  | grep -q '"enabled":'
+    # if qemu-system-* is missing, SPICE is disabled by default
+    type -P $QEMU > /dev/null && \
+        printf '{"execute":"qmp_capabilities"}\n{"execute":"query-spice"}\n{"execute":"quit"}' | \
+            $QEMU --qmp stdio --nographic -nodefaults  | grep -q '"enabled":'
 }
 
 # prepare virt-install parameters


### PR DESCRIPTION
In create_machine.sh, the SPICE support is detected via querying qmp capabilities via qemu-system-*.

If qemu-system-${ARCH} is missing, the detection should fail gracefully and disable SPICE by default.
