### PR TITLE
WIP: base1: Fix race in test-machines

### DIFF
--- a/src/base1/test-machines.js
+++ b/src/base1/test-machines.js
@@ -143,7 +143,7 @@ function machinesUpdateTest(origJson, host, props, expectedJson)
             dbus.call("/machines", "cockpit.Machines", "Update", [ "99-webui.json", host, props ], { "type": "ssa{sv}" })
                 .done(function(reply) {
                     assert.deepEqual(reply, [], "no expected return value");
-                    cockpit.file(f, { syntax: JSON }).read().
+                    return cockpit.file(f, { syntax: JSON }).read().
                         done(function(content, tag) {
                             assert.deepEqual(content, expectedJson, "expected file content");
                         }).


### PR DESCRIPTION
The machinesUpdateTest function races due to the inner promise not
chaining up to the outer always() function. Fix it.