### PR TITLE
test: Ignore journal message when docker restarts

### DIFF
--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -410,6 +410,9 @@ CMD ["/bin/sh"]
         b = self.browser
         m = self.machine
 
+        # This happens due to the Docker restart
+        self.allow_journal_messages('.*received truncated HTTP response.*')
+
         m.execute("systemctl start docker || systemctl start docker-latest")
 
         self.login_and_go("/docker")


### PR DESCRIPTION
During the docker restart test, we see a message like the the
following:

     http:///var/run/docker.sock/v1.12/events: received truncated HTTP response