### PR TITLE
test: Fix race in check-metrics

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -126,10 +126,9 @@ class TestMetrics(MachineCase):
         m.execute("kill %d" % disk_pid)
 
         # Network traffic through loopback. Should be ignored
-        m.spawn("ping -w 5 -f -c 10000000 -s 50000  127.0.0.1", "load-net-lo.log")
+        m.spawn("ping -f -c 10000000 -s 50000  127.0.0.1", "load-net-lo.log")
         try:
-            with b.wait_timeout(10):
-                b.wait_js_func("ph_flot_data_plateau", "#server_network_traffic_graph", 300*1000, None, 5, "net io");
+            b.wait_js_func("ph_flot_data_plateau", "#server_network_traffic_graph", 300*1000, None, 5, "net io");
             self.fail("Unexpected traffic graph for localhost")
         except Error as ex:
             if not ex.msg.startswith('timeout'):


### PR DESCRIPTION
We've seen races in check-metrics looking for network traffic
on heavily loaded nodes. Lets make this test more resilient.