### PR TITLE
naughty: Close 9117: NetworkManager 1.12 does not recognize rolled back checkpoints any more

### DIFF
--- a/bots/naughty/rhel-8/9117-nm-checkpoint-rollback
+++ b/bots/naughty/rhel-8/9117-nm-checkpoint-rollback
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-networking-checkpoints", line *, in testCheckpoint*
-    b.wait_visible("#confirm-breaking-change-popup")
-*
-Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 27 days

NetworkManager 1.12 does not recognize rolled back checkpoints any more

Fixes #9117