### PR TITLE
logs, accessibility: first pass at log a11y-ification

### DIFF
--- a/pkg/lib/cockpit-components-logs-panel.jsx
+++ b/pkg/lib/cockpit-components-logs-panel.jsx
@@ -45,8 +45,8 @@ class JournalOutput {
         }
 
         return (
-            <div className="cockpit-logline">
-                <div className="cockpit-log-warning">
+            <div className="cockpit-logline" role="row">
+                <div className="cockpit-log-warning" role="cell">
                     { warning
                         ? <i className="fa fa-exclamation-triangle" />
                         : null
@@ -56,15 +56,15 @@ class JournalOutput {
                         : null
                     }
                 </div>
-                <div className="cockpit-log-time">{time}</div>
-                <span className="cockpit-log-message">{message}</span>
+                <div className="cockpit-log-time" role="cell">{time}</div>
+                <span className="cockpit-log-message" role="cell">{message}</span>
                 {
                     count > 1
-                        ? <div className="cockpit-log-service-container">
-                            <div className="cockpit-log-service-reduced">{ident}</div>
-                            <span className="badge">{count}&#160;<i className="fa fa-caret-right" /></span>
+                        ? <div className="cockpit-log-service-container" role="cell">
+                            <div className="cockpit-log-service-reduced" role="cell">{ident}</div>
+                            <span className="badge" role="cell">{count}&#160;<i className="fa fa-caret-right" /></span>
                         </div>
-                        : <div className="cockpit-log-service">{ident}</div>
+                        : <div className="cockpit-log-service" role="cell">{ident}</div>
                 }
             </div>
         );
@@ -76,9 +76,9 @@ class JournalOutput {
 
     render_reboot_separator() {
         return (
-            <div className="cockpit-logline">
-                <div className="cockpit-log-warning" />
-                <span className="cockpit-log-message cockpit-logmsg-reboot">{_("Reboot")}</span>
+            <div className="cockpit-logline" role="row">
+                <div className="cockpit-log-warning" role="cell" />
+                <span className="cockpit-log-message cockpit-logmsg-reboot" role="cell">{_("Reboot")}</span>
             </div>
         );
     }
@@ -124,9 +124,9 @@ export class LogsPanel extends React.Component {
 
     render() {
         return (
-            <div className="panel panel-default cockpit-log-panel">
+            <div className="panel panel-default cockpit-log-panel" role="table">
                 <div className="panel-heading">{this.props.title}</div>
-                <div className="panel-body">
+                <div className="panel-body" role="rowgroup">
                     { this.state.logs }
                 </div>
             </div>

--- a/pkg/lib/journal_line.mustache
+++ b/pkg/lib/journal_line.mustache
@@ -1,19 +1,19 @@
-<div class="cockpit-logline" data-cursor="{{cursor}}">
-  <div class="cockpit-log-warning">{{#warning}}
+<div class="cockpit-logline" data-cursor="{{cursor}}" role="row">
+  <div class="cockpit-log-warning" role="cell">{{#warning}}
     <i class="fa fa-exclamation-triangle"></i>
   {{/warning}}{{#problem}}
     <i class="fa fa-times-circle-o"></i>
   {{/problem}}
   </div>
-  <div class="cockpit-log-time">{{time}}</div>
-  <span class="cockpit-log-message">{{message}}</span>
+  <div class="cockpit-log-time" role="cell">{{time}}</div>
+  <span class="cockpit-log-message" role="cell">{{message}}</span>
   {{! if we have count (repeated messages), show service name and badge - otherwise just the service }}
   {{#count}}
-  <div class="cockpit-log-service-container">
+  <div class="cockpit-log-service-container" role="cell">
     <div class="cockpit-log-service-reduced">{{service}}</div>
     <span class="badge">{{count}}&#160;<i class="fa fa-caret-right"></i></span>
   </div>
   {{/count}}{{^count}}
-  <div class="cockpit-log-service">{{service}}</div>
+  <div class="cockpit-log-service" role="cell">{{service}}</div>
   {{/count}}
 </div>

--- a/pkg/lib/journal_reboot.mustache
+++ b/pkg/lib/journal_reboot.mustache
@@ -1,5 +1,5 @@
-<div class="cockpit-logline">
+<div class="cockpit-logline" role="row">
   {{! placeholders for correct message alignment }}
-  <div class="cockpit-log-warning"></div>
-  <span class="cockpit-log-message cockpit-logmsg-reboot">{{message}}</span>
+  <div class="cockpit-log-warning" role="cell"></div>
+  <span class="cockpit-log-message cockpit-logmsg-reboot" role="cell">{{message}}</span>
 </div>

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -140,9 +140,10 @@
         </tbody>
       </table>
     </div>
-    <div class="panel panel-default cockpit-log-panel">
-      <div class="panel-heading" translatable="yes">Networking Logs</div>
-      <div class="panel-body" id="networking-log"></div>
+    <div class="panel panel-default cockpit-log-panel" role="table"
+     aria-labelledby="networking-log-header">
+      <div class="panel-heading" translatable="yes" id="networking-log-header">Networking Logs</div>
+      <div class="panel-body" id="networking-log" role="rowgroup"></div>
     </div>
   </div>
 

--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -95,8 +95,8 @@ $(function() {
 
     /* Not public API */
     function journalbox(outer, start, match, day_box) {
-        var box = $('<div class="panel panel-default cockpit-log-panel">');
-        var start_box = $('<div class="journal-start">');
+        var box = $('<div class="panel panel-default cockpit-log-panel" role="table">');
+        var start_box = $('<div class="journal-start" role="rowgroup">');
 
         outer.empty().append(box, start_box);
 

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -312,9 +312,9 @@
 
     <div id="service-valid">
       <div id="service-unit"></div>
-      <div class="panel panel-default cockpit-log-panel" id="service-log-box">
-        <div class="panel-heading" translatable="yes">Service Logs</div>
-        <div class="panel-body" id="service-log"></div>
+      <div class="panel panel-default cockpit-log-panel" id="service-log-box" role="table" aria-describedby="service-log-box-heading">
+        <div class="panel-heading" id="service-log-box-heading" translatable="yes">Service Logs</div>
+        <div class="panel-body" id="service-log" role="rowgroup"></div>
       </div>
     </div>
 


### PR DESCRIPTION
Add roles to make what is otherwise tabular data into fake tables for accessibility improvements.

Based on: https://www.w3.org/TR/wai-aria-practices-1.1/examples/table/table.html

Fixes #9310.