### PR TITLE
bots: Remove unused variables from make-cloud-init-iso

### DIFF
--- a/bots/machine/make-cloud-init-iso
+++ b/bots/machine/make-cloud-init-iso
@@ -20,9 +20,6 @@
 
 set -e
 
-out=$1
-arch=x86_64
-
 # create the cloud-init iso
 init_dir=$(mktemp -d)
 meta_data="$init_dir/meta-data"


### PR DESCRIPTION
Coverity is complaining about these.