### PR TITLE
Makefile: Fix race in 'make uninstall' target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -214,7 +214,7 @@ install-data-local:: $(WEBPACK_DEBUG)
 	$(MKDIR_P) $(DESTDIR)$(debugdir)$(pkgdatadir)
 	tar -cf - $^ | tar -C $(DESTDIR)$(debugdir)$(pkgdatadir) --strip-components=1 -xvf -
 uninstall-local::
-	find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type f -delete
+	find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type f -exec rm -f {} \;
 	find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete
 	find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type f -delete
 	find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete

--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -13,11 +13,6 @@ playground_DATA = \
 dist/playground/extra.de.po: pkg/playground/extra.de.po
 	$(COPY_RULE)
 
-machinesdir = $(pkgdatadir)/machines
-machines_DATA = \
-	dist/machines/base.css \
-	$(NULL)
-
 dist/machines/base.css: node_modules/noVNC/include/base.css
 	$(COPY_RULE)
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -206,6 +206,7 @@ var info = {
         "kubernetes/index.html",
         "kubernetes/registry.html",
 
+        "machines/base.css",
         "machines/index.html",
         "machines/vnc.html",
         "machines/vnc.css",


### PR DESCRIPTION
The find command in uninstall-local races with other parts of
the Makefile that install and remove stuff in $(pkgdir) explictly.