### PR TITLE
WIP: Reduce parallel test jobs to 4 to see if that helps with flakes

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -40,7 +40,7 @@ DEVNULL = open("/dev/null", "r+")
 def main():
     parser = argparse.ArgumentParser(description='Run integration tests')
     parser.add_argument('-j', '--jobs', dest="jobs", type=int,
-            default=os.environ.get("TEST_JOBS", 1), help="Number of concurrent jobs")
+            default=4, help="Number of concurrent jobs")
     parser.add_argument('--rebase', help="Rebase onto the specific branch before testing")
     parser.add_argument('--remote', help="The Git remote to use (instead of 'origin')",
                         default="origin")


### PR DESCRIPTION
Don't land this, I just want to see if it makes any difference. ovirt, IPA, and kubevirt tests are almost impossible to get green right now, there is no apparent reason on the nodes, and locally they work just fine (but my machine isn't powerful enough to run 8 parallel tests).