### PR TITLE
kubernetes: React-related fixes

### DIFF
--- a/pkg/kubernetes/scripts/virtual-machines/components/VmDisksTabKubevirt.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmDisksTabKubevirt.jsx
@@ -115,7 +115,7 @@ const VmDisksTabKubevirt = ({ vm, pvs }: { vm: Vm, pvs: Array<PersistenVolume> }
 
 VmDisksTabKubevirt.propTypes = {
     vm: PropTypes.object.isRequired,
-    pvs: PropTypes.object.isRequired,
+    pvs: PropTypes.array.isRequired,
 };
 
 export default VmDisksTabKubevirt;

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmMessage.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmMessage.jsx
@@ -44,7 +44,7 @@ const VmMessage = ({ vm, vmMessages, onDismiss }: { vm: Vm, vmMessages: VmMessag
 
 VmMessage.propTypes = {
     vm: PropTypes.object.isRequired,
-    vmMessages: PropTypes.object.isRequired,
+    vmMessages: PropTypes.object,
     onDismiss: PropTypes.func.isRequired,
 };
 

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx
@@ -37,7 +37,7 @@ const VmsListing = ({ vms, pvs, pods, settings, vmsMessages }) => {
                                                pvs={pvs}
                                                key={vm.metadata.uid} />));
     let actions = [(
-        <CreateVmButton />
+        <CreateVmButton key='create-vm' />
     )];
 
     return (
@@ -51,9 +51,9 @@ const VmsListing = ({ vms, pvs, pods, settings, vmsMessages }) => {
 };
 
 VmsListing.propTypes = {
-    vms: PropTypes.object.isRequired,
-    pvs: PropTypes.object.isRequired,
-    pods: PropTypes.object.isRequired,
+    vms: PropTypes.array.isRequired,
+    pvs: PropTypes.array.isRequired,
+    pods: PropTypes.array.isRequired,
     vmsMessages: PropTypes.object.isRequired,
 };
 

--- a/pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx
+++ b/pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx
@@ -64,7 +64,7 @@ const VmsListingRow = ({ vm, vmMessages, pvs, pod, vmUi, onExpandChanged }:
                 phase // phases description https://github.com/kubevirt/kubevirt/blob/master/pkg/api/v1/types.go
             ]}
             tabRenderers={[ overviewTabRenderer, disksTabRenderer ]}
-            listingActions={<VmActions vm={vm} />}
+            listingActions={[ <VmActions vm={vm} /> ]}
             expandChanged={onExpandChanged(vm)}
             initiallyExpanded={initiallyExpanded} />
     );
@@ -72,7 +72,7 @@ const VmsListingRow = ({ vm, vmMessages, pvs, pod, vmUi, onExpandChanged }:
 
 VmsListingRow.propTypes = {
     vm: PropTypes.object.isRequired,
-    vmMessages: PropTypes.object.isRequired,
+    vmMessages: PropTypes.object,
     pvs: PropTypes.array.isRequired,
     pod: PropTypes.object.isRequired,
     vmUi: PropTypes.object,


### PR DESCRIPTION
Part of #9263 PR-split.

These propTypes changes will take effect with React, not related to react-lite.
The change was verified within #9263.
If something is missing, it can be "fixed" within real react-lite to React switch.