### PR TITLE
ws: don't do DNS lookups on socket start

### DIFF
--- a/src/ws/cockpit-motd.service.in
+++ b/src/ws/cockpit-motd.service.in
@@ -2,7 +2,7 @@
 Description=Cockpit motd updater service
 Documentation=man:cockpit-ws(8)
 Wants=network-online.target
-After=network-online.target
+After=network-online.target cockpit.socket
 
 [Service]
 Type=oneshot

--- a/src/ws/cockpit.socket.in
+++ b/src/ws/cockpit.socket.in
@@ -5,7 +5,7 @@ Wants=cockpit-motd.service
 
 [Socket]
 ListenStream=9090
-ExecStartPost=-@datadir@/@PACKAGE@/motd/update-motd
+ExecStartPost=-@datadir@/@PACKAGE@/motd/update-motd '' localhost
 ExecStartPost=-/bin/ln -snf active.motd /run/cockpit/motd
 ExecStopPost=-/bin/ln -snf @datadir@/@PACKAGE@/motd/inactive.motd /run/cockpit/motd
 


### PR DESCRIPTION
Hardwire the hostname to 'localhost' when the motd-update script is run
from cockpit.socket.

In the case of the system starting up, the cockpit-motd service will
come by shortly to rewrite the file with the proper DNS name of the
host.  In the case that the system is already up, this will happen
almost immediately.

Add 'After=cockpit.socket' to the motd service to ensure that its
version of the update script always runs after the "localhost" version
in cockpit.socket.