### PR TITLE
shell: Allow hash in manifest.json item paths

### DIFF
--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -923,6 +923,15 @@
                         item.path = info.path.replace(/\.html$/, "");
                     else
                         item.path = name + "/" + prop;
+
+                    /* Split out any hash in the path */
+                    var pos = item.path.indexOf("#");
+                    if (pos !== -1) {
+                        item.hash = item.path.substr(pos + 1);
+                        item.path = item.path.substr(0, pos);
+                    }
+
+                    /* Fix component for compatibility and normalize it */
                     if (item.path.indexOf("/") === -1)
                         item.path = name + "/" + item.path;
                     if (item.path.slice(-6) == "/index")

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -269,7 +269,7 @@
                 listItem = $("<li class='list-group-item'>")
                     .toggleClass("active", active)
                     .append($("<a>")
-                        .attr("href", index.href({ host: machine.address, component: component.path }))
+                        .attr("href", index.href({ host: machine.address, component: component.path, hash: component.hash }))
                         .append($("<span>").text(component.label)));
 
                 if (active)

--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -25,6 +25,11 @@ class TestMenu(MachineCase):
     @enableAxe
     def testBasic(self):
         b = self.browser
+        m = self.machine
+
+        # Add a link with a hash in it to test that this works
+        m.execute("mkdir -p /usr/local/share/cockpit/systemd && cp -rp /usr/share/cockpit/systemd/* /usr/local/share/cockpit/systemd")
+        m.execute("""sed -i '/"menu"/a "memory": { "label": "Memory", "path": "#/memory" },' /usr/local/share/cockpit/systemd/manifest.json""")
 
         self.login_and_go("/system")
 
@@ -37,6 +42,12 @@ class TestMenu(MachineCase):
         b.wait_popdown("about")
 
         self.check_axe("Test-navigation")
+
+        # Check that we can use a link with a hash in it
+        b.switch_to_top()
+        b.click("a[href='/system/#/memory']")
+        b.enter_page("/system")
+        b.wait_visible("#memory_status")
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
This allows a link in the sidebar to correctly link to a subpage
or particular section of a components.