### PR TITLE
test: Fix race in check-reauthorize

### DIFF
--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -76,6 +76,10 @@ class TestReauthorize(MachineCase):
 
         b.enter_page("/playground/test")
 
+        # Twice to avoid races. This race is with cockpit-bridge --privileged exiting
+        b.click(".super-channel .btn")
+        b.wait_in_text(".super-channel span", 'result:')
+
         b.click(".super-channel .btn")
         b.wait_in_text(".super-channel span", 'result: access-denied')
 


### PR DESCRIPTION
This race is due to the fact that the UI doesn't wait to deauthorize.
And the deauthorize is still in progress while we are trying to
do a privileged operation.

So we see result: 'disconnected' instead of 'access-denied'