### PR TITLE
bots: Fix Machine.disconnect()

### DIFF
--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -347,10 +347,11 @@ class Machine:
                     raise
             self.ssh_master = None
         if self.ssh_process:
+            self.message("killing ssh master process", str(self.ssh_process.pid))
             self.ssh_process.stdin.close()
+            self.ssh_process.stdout.close()
             with Timeout(seconds=90, error_message="Timeout while waiting for ssh master to shut down"):
                 self.ssh_process.wait()
-            self.ssh_process.stdout.close()
             self.ssh_process = None
 
     def _check_ssh_master(self):


### PR DESCRIPTION
check-kdump often hangs in `self.machine.disconnect` as the ssh master
process is a zombie that just doesn't die. Close its stdout first, which
seems to help.

---

Example: https://fedorapeople.org/groups/cockpit/logs/pull-9264-20180610-190202-5e369c7e-verify-fedora-28/log.html#191

This seems to break most runs on fedora-28 on the infra. I could reproduce this once on my machine when running 3 tests in parallel and causing 100% CPU and a load > 5. While I don't fully understand *why* this works, it seems to help on my machine, so let's see what the bots say.