### PR TITLE
storage: Fix dialog tests for dropdown selection

### DIFF
--- a/pkg/lib/cockpit-components-select.jsx
+++ b/pkg/lib/cockpit-components-select.jsx
@@ -185,6 +185,8 @@
     class SelectEntry extends React.Component {
         render() {
             const value = (this.props.children !== undefined) ? this.props.children : textForUndefined;
+            // if value is not undefined then data-data is not rendered, tests changed accordingly
+            // TODO: better approach is via dataSets: https://github.com/facebook/react/issues/1259
             return (
                 <li data-value={value} data-data={this.props.data}>
                     <a>{value}</a>

--- a/pkg/storaged/dialogx.jsx
+++ b/pkg/storaged/dialogx.jsx
@@ -295,7 +295,7 @@ export const SelectOne = (tag, title, options, choices) => {
 
         render: (val, change) => {
             return (
-                <div data-field={tag} data-field-type="select">
+                <div data-field={tag}>
                     <StatelessSelect extraClass="form-control" selected={val} onChange={change}>
                         { choices.map(c => <SelectEntry data={c.value}>{c.title}</SelectEntry>) }
                     </StatelessSelect>

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -210,10 +210,12 @@ class StorageCase(MachineCase):
                 self.browser.set_val(sel + " input[type=text]", val.val)
         else:
             sel = self.dialog_field(field)
-            ftype = self.browser.attr(sel, "data-field-type")
-            if ftype == "select":
+            dropdown_sel = sel + ".dropdown"
+            if self.browser.is_present(dropdown_sel):
                 self.browser.click(sel + " button.dropdown-toggle")
-                self.browser.click(sel + " li[data-data=%s] a" % val)
+                item_sel = sel + ' li[value="%s"] a' % val
+                self.browser.wait_present(item_sel) # wait to expand
+                self.browser.click(item_sel)
             else:
                 self.browser.set_val(self.dialog_field(field), val)
 


### PR DESCRIPTION
This is part of #9263 split.

---

With move to React from react-lite, the html `data-*` attributes are
rendered differently, namely the second in a row is missing in the
rendered output breaking tests since the Dropdown selection seized
to work there.

With this patch, related CSS selectors are fixed.

In a follow-up, detasets can be used instead, see [1].

[1] https://github.com/facebook/react/issues/1259