### PR TITLE
bots: Drop check for legacy branches

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -50,20 +50,11 @@ REDHAT_VERIFY = {
     'selenium/explorer': [ 'master' ],
 }
 
-# Host interfaces that tell us we're not in a namespaced network
-HOST_INTERFACES = [ "cockpit1", "docker0", "virbr0" ]
-
-# Branches that need the bridged network to work
-LEGACY_BRANCHES = [
-    'rhel-7.4',
-]
-
 import argparse
 import os
 import json
 import pipes
 import random
-import subprocess
 import sys
 import time
 import urllib.request, urllib.parse, urllib.error
@@ -110,17 +101,6 @@ def default_policy():
         policy.update(REDHAT_VERIFY)
     except IOError:
         pass
-
-    # Check if we're in a namespaced network
-    null = open("/dev/null", "r+")
-    for interface in HOST_INTERFACES:
-        if subprocess.call([ "ip", "link", "show", interface ], stdout=null, stderr=null) == 0:
-            break
-
-    # In a namespaced network, remove legacy branches
-    else:
-        for context, branches in policy.items():
-            policy[context] = [branch for branch in branches if branch not in LEGACY_BRANCHES]
 
     return policy
 

--- a/test/verify/check-networking-bridge
+++ b/test/verify/check-networking-bridge
@@ -34,10 +34,9 @@ class TestNetworking(NetworkCase):
 
         self.login_and_go("/network")
 
-        # The second interface is connected to a different outside
-        # network than the first to avoid a cycle between the
-        # "cockpit1" bridge that all VMs are connected to, and the
-        # bridge we are creating here.
+        # The second interface is connected to a different outside network than
+        # the first to avoid a cycle between the bridge that all VMs are
+        # connected to, and the bridge we are creating here.
 
         iface1 = self.add_iface()
         iface2 = self.add_iface(vlan=1, activate=False)


### PR DESCRIPTION
We dropped the rhel-7-4 image and rhel-7.4 branch a while ago, and all
of our active branches use QEMU user networking. Drop the checks for
legacy branches and the cockpit1 bridge.

Note that test/vm-run still creates a cockpit1 bridge if `--network` is
given, and that continues to be an useful debugging tool. But we never
need that for running our tests.