### PR TITLE
tests: Fix check-menu on rhel-7-5

### DIFF
--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -43,11 +43,12 @@ class TestMenu(MachineCase):
 
         self.check_axe("Test-navigation")
 
-        # Check that we can use a link with a hash in it
-        b.switch_to_top()
-        b.click("a[href='/system/#/memory']")
-        b.enter_page("/system")
-        b.wait_visible("#memory_status")
+        # Check that we can use a link with a hash in it (fixed in Cockpit 170)
+        if m.image != 'rhel-7-5':
+            b.switch_to_top()
+            b.click("a[href='/system/#/memory']")
+            b.enter_page("/system")
+            b.wait_visible("#memory_status")
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Commit 0e507441a5ef392 introduced a new test which reproduces the
corresponding bug. This bug is present in RHEL 7.5 (Cockpit 154), so
blacklist it there.

Example: https://fedorapeople.org/groups/cockpit/logs/pull-9285-20180611-185151-fb2adce2-verify-rhel-7-5/log.html#151