### PR TITLE
WIP containers: Add process listing to unit-tests container

### DIFF
--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -12,6 +12,10 @@ git clone /source /tmp/source
 [ ! -d /source/node_modules ] || cp -r /source/node_modules /tmp/source/
 cd /tmp/source
 
+# HACK: Debugging unit-tests container hanging in Semaphore
+( while true; do sleep 60; ps -xa; done ) &
+trap "kill %%" EXIT
+
 # cross-build flags
 ARCH=$(cat /arch)
 case $ARCH in

--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -13,7 +13,7 @@ git clone /source /tmp/source
 cd /tmp/source
 
 # HACK: Debugging unit-tests container hanging in Semaphore
-( while true; do sleep 60; ps -xa; done ) &
+( while true; do sleep 60; ps -xa; ps -fa; done ) &
 trap "kill %%" EXIT
 
 # cross-build flags

--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -189,7 +189,7 @@ class CDP:
 
         # wait for CDP to be up
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        for retry in range(300):
+        for retry in range(3000):
             try:
                 s.connect(('127.0.0.1', cdp_port))
                 break

--- a/tools/tap-driver
+++ b/tools/tap-driver
@@ -143,7 +143,10 @@ class Driver:
         errf = proc.stderr.fileno()
         rset = [outf, errf]
         while len(rset) > 0:
-            ret = select.select(rset, [], [], 10)
+            ret = select.select(rset, [], [], 60)
+            # HACK: Debugging hang in unit tests
+            if not ret[0] and not ret[1] and not ret[2]:
+                out("tap-driver: TIMEOUT in select {} {} {}\n".format(repr(rset), outf, errf), stream=sys.stderr, flush=True)
             if outf in ret[0]:
                 data = os.read(outf, 1024)
                 if data == "":


### PR DESCRIPTION
I'd like to debug issues related to teh unit-tests container
hanging in Semaphore for over an hour. To do that I want to see
the list of processes running in the container every 60 seconds.