### PR TITLE
containers: Run unit-tests containers with volume's run script

### DIFF
--- a/containers/unit-tests/Dockerfile
+++ b/containers/unit-tests/Dockerfile
@@ -25,5 +25,6 @@ RUN npm install -g n && n stable && \
     adduser --system --gecos "Builder" builder
 
 USER builder
-ADD run.sh /
-CMD ["/run.sh"]
+
+VOLUME /source
+CMD ["/source/containers/unit-tests/run.sh"]


### PR DESCRIPTION
This makes it easy to test changes to it in PRs, as they become
self-validating. With copying the script into the container this would
always require a new container build, which then affects all other PRs
as well.

Also declare the /source volume as such.