### PR TITLE
base1: Fix race in test-machines.js

### DIFF
--- a/src/base1/test-machines.js
+++ b/src/base1/test-machines.js
@@ -141,7 +141,7 @@ function machinesUpdateTest(origJson, host, props, expectedJson)
     cockpit.file(f).replace(origJson).
         done(function(tag) {
             dbus.call("/machines", "cockpit.Machines", "Update", [ "99-webui.json", host, props ], { "type": "ssa{sv}" })
-                .done(function(reply) {
+                .then(function(reply) {
                     assert.deepEqual(reply, [], "no expected return value");
                     return cockpit.file(f, { syntax: JSON }).read().
                         done(function(content, tag) {


### PR DESCRIPTION
We need to use promise.then() when we want to chain promises
together, rather than promise.done()