### PR TITLE
tools: Move cockpit-ssh from -dashboard to -bridge

### DIFF
--- a/bots/images/scripts/lib/atomic.install
+++ b/bots/images/scripts/lib/atomic.install
@@ -161,28 +161,19 @@ class AtomicCockpitInstaller:
             return None
 
     def update_container(self):
-        """ Install the latest cockpit-ws and cockpit-dashboard in our container"""
-        ws = None
-        dashboard = None
+        """ Install the latest cockpit RPMs in our container"""
+        rpm_args = []
         for package in self.rpms:
-            if 'cockpit-ws' in package:
-                ws = package
-            if 'cockpit-dashboard' in package:
-                dashboard = package
+            if 'cockpit-ws' in package or 'cockpit-dashboard' in package or 'cockpit-bridge' in package:
+                rpm_args.append("/host" + package)
 
-        if ws or dashboard:
+        if rpm_args:
             subprocess.check_call(["docker", "run", "--name", "build-cockpit",
                                    "-d", "--privileged", "-v", "/:/host",
                                    "cockpit/ws", "sleep", "1d"])
-            rpm_args = []
-            if ws:
-                rpm_args.append("/host" + ws)
-            if dashboard:
-                rpm_args.append("/host" + dashboard)
-
             if rpm_args:
                 rpm_args = ["docker", "exec", "build-cockpit",
-                            "rpm", "-U", "--force"] + rpm_args
+                            "rpm", "--freshen", "--verbose", "--force"] + rpm_args
                 if self.verbose:
                     print("updating cockpit-ws container")
                 subprocess.check_call(rpm_args)

--- a/containers/bastion/install.sh
+++ b/containers/bastion/install.sh
@@ -11,10 +11,8 @@ if [ -z "$OFFLINE" ]; then
     "$INSTALLER" install -y python3 openssl
 fi
 
-/container/scripts/install-rpms.sh cockpit-ws cockpit-dashboard
-
-# Remove unwanted packages
-rm -rf /usr/share/cockpit/dashboard/
+/container/scripts/install-rpms.sh cockpit-ws
+/container/scripts/install-rpms.sh --nodeps cockpit-bridge
 
 rm -rf /container/scripts
 rm -rf /container/rpms

--- a/containers/kubernetes/install.sh
+++ b/containers/kubernetes/install.sh
@@ -11,13 +11,13 @@ if [ -z "$OFFLINE" ]; then
 fi
 
 # Install packages without dependencies
-/container/scripts/install-rpms.sh cockpit-ws cockpit-dashboard
+/container/scripts/install-rpms.sh cockpit-ws
 /container/scripts/install-rpms.sh --nodeps cockpit-bridge
 /container/scripts/install-rpms.sh -a noarch --nodeps cockpit-system
 /container/scripts/install-rpms.sh --nodeps cockpit-kubernetes
 
 # Remove unwanted packages
-rm -rf /usr/share/cockpit/realmd/ /usr/share/cockpit/systemd/ /usr/share/cockpit/tuned/ /usr/share/cockpit/users/ /usr/share/cockpit/dashboard/
+rm -rf /usr/share/cockpit/realmd/ /usr/share/cockpit/systemd/ /usr/share/cockpit/tuned/ /usr/share/cockpit/users/
 
 # Remove unwanted cockpit-bridge binaries
 rm -rf /usr/bin/cockpit-bridge

--- a/containers/ws/install-package.sh
+++ b/containers/ws/install-package.sh
@@ -21,15 +21,15 @@ fi
 "$INSTALLER" install -y sed
 
 arch=`uname -p`
-rpm=$(ls /container/rpms/cockpit-ws-*$OSVER.*$arch.rpm /container/rpms/cockpit-dashboard-*$OSVER.*$arch.rpm || true)
+rpm=$(ls /container/rpms/cockpit-ws-*$OSVER.*$arch.rpm /container/rpms/cockpit-bridge-*$OSVER.*$arch.rpm || true)
 
 # If there are rpm files in the current directory we'll install those
 if [ -n "$rpm" ]; then
-    $INSTALLER -y install /container/rpms/cockpit-ws-*$OSVER.*$arch.rpm /container/rpms/cockpit-dashboard-*$OSVER.*$arch.rpm
+    $INSTALLER -y install /container/rpms/cockpit-ws-*$OSVER.*$arch.rpm /container/rpms/cockpit-bridge-*$OSVER.*$arch.rpm
 else
     ws=$(package_name "cockpit-ws")
-    dashboard=$(package_name "cockpit-dashboard")
-    "$INSTALLER" -y install "$ws" "$dashboard"
+    bridge=$(package_name "cockpit-bridge")
+    "$INSTALLER" -y install "$ws" "$bridge"
 fi
 
 "$INSTALLER" clean all

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -150,8 +150,7 @@ exec 2>&1
     --with-selinux-config-type=etc_t \
     %{?rhel:--without-storaged-iscsi-sessions} \
     --with-appstream-data-packages='[ "appstream-data" ]' \
-    --with-nfs-client-package='"nfs-utils"' \
-    %{!?build_dashboard:--disable-ssh}
+    --with-nfs-client-package='"nfs-utils"'
 make -j4 %{?extra_flags} all
 
 %check
@@ -175,14 +174,20 @@ echo '{ "linguas": null }' > %{buildroot}%{_datadir}/cockpit/shell/override.json
 echo '%dir %{_datadir}/cockpit/base1' > base.list
 find %{buildroot}%{_datadir}/cockpit/base1 -type f >> base.list
 echo '%{_sysconfdir}/cockpit/machines.d' >> base.list
+# RHEL 7 needs to keep cockpit-ssh in dashboard for backwards compat
+%if 0%{?rhel} == 7 || 0%{?centos} == 7
+find %{buildroot}%{_datadir}/cockpit/ssh -type f >> dashboard.list
+echo '%{_libexecdir}/cockpit-ssh' >> dashboard.list
+%else
+find %{buildroot}%{_datadir}/cockpit/ssh -type f >> base.list
+echo '%{_libexecdir}/cockpit-ssh' >> base.list
+%endif
 
 %if %{defined build_dashboard}
 echo '%dir %{_datadir}/cockpit/dashboard' >> dashboard.list
 find %{buildroot}%{_datadir}/cockpit/dashboard -type f >> dashboard.list
-find %{buildroot}%{_datadir}/cockpit/ssh -type f >> dashboard.list
 %else
 rm -rf %{buildroot}/%{_datadir}/cockpit/dashboard
-rm -rf %{buildroot}/%{_datadir}/cockpit/ssh
 touch dashboard.list
 %endif
 
@@ -271,7 +276,7 @@ touch kubernetes.list
 
 # when not building basic packages, remove their files
 %if 0%{?build_basic} == 0
-for pkg in base1 branding motd kdump networkmanager realmd selinux shell sosreport static storaged systemd tuned users; do
+for pkg in base1 branding motd kdump networkmanager realmd selinux shell sosreport ssh static storaged systemd tuned users; do
     rm -r %{buildroot}/%{_datadir}/cockpit/$pkg
 done
 for data in applications doc locale man metainfo pixmaps; do
@@ -285,11 +290,12 @@ for libexec in cockpit-askpass cockpit-session cockpit-ws; do
 done
 rm -r %{buildroot}/%{_libdir}/security %{buildroot}/%{_sysconfdir}/pam.d %{buildroot}/%{_sysconfdir}/motd.d %{buildroot}/%{_sysconfdir}/issue.d
 rm %{buildroot}/usr/bin/cockpit-bridge %{buildroot}/usr/sbin/remotectl
+rm -f %{buildroot}%{_libexecdir}/cockpit-ssh
 %endif
 
 # when not building optional packages, remove their files
 %if 0%{?build_optional} == 0
-for pkg in apps dashboard docker kubernetes machines ostree ovirt packagekit pcp playground ssh; do
+for pkg in apps dashboard docker kubernetes machines ostree ovirt packagekit pcp playground; do
     rm -rf %{buildroot}/%{_datadir}/cockpit/$pkg
 done
 # files from -tests
@@ -298,8 +304,6 @@ rm -r %{buildroot}/%{_prefix}/%{__lib}/cockpit-test-assets %{buildroot}/%{_sysco
 rm -r %{buildroot}/%{_libexecdir}/cockpit-pcp %{buildroot}/%{_localstatedir}/lib/pcp/
 # files from -kubernetes
 rm -f %{buildroot}/%{_libexecdir}/cockpit-kube-auth %{buildroot}/%{_libexecdir}/cockpit-kube-launch %{buildroot}/%{_libexecdir}/cockpit-stub
-# files from -dashboard
-rm -f %{buildroot}%{_libexecdir}/cockpit-ssh
 %endif
 
 sed -i "s|%{buildroot}||" *.list
@@ -366,6 +370,12 @@ machines.
 %package bridge
 Summary: Cockpit bridge server-side component
 Requires: glib-networking
+%if 0%{?rhel} != 7 && 0%{?centos} != 7
+Requires: libssh >= %{libssh_version}
+Provides: cockpit-ssh = %{version}-%{release}
+# cockpit-ssh moved from dashboard to bridge in 171
+Conflicts: cockpit-dashboard < 170.x
+%endif
 
 %description bridge
 The Cockpit bridge component installed server side and runs commands on the
@@ -699,10 +709,15 @@ Cockpit support for reading PCP metrics and loading PCP archives.
 %if %{defined build_dashboard}
 %package -n cockpit-dashboard
 Summary: Cockpit remote servers and dashboard
+%if 0%{?rhel} == 7 || 0%{?centos} == 7
 Requires: libssh >= %{libssh_version}
 Provides: cockpit-ssh = %{version}-%{release}
 # nothing depends on the dashboard, but we can't use it with older versions of the bridge
 Conflicts: cockpit-bridge < 135
+%else
+BuildArch: noarch
+Requires: cockpit-ssh >= 135
+%endif
 Conflicts: cockpit-ws < 135
 
 %description -n cockpit-dashboard
@@ -710,7 +725,6 @@ Cockpit support for connecting to remote servers (through ssh),
 bastion hosts, and a basic dashboard.
 
 %files -n cockpit-dashboard -f dashboard.list
-%{_libexecdir}/cockpit-ssh
 
 %endif
 

--- a/tools/debian/cockpit-bridge.install
+++ b/tools/debian/cockpit-bridge.install
@@ -1,5 +1,7 @@
 etc/cockpit/machines.d
 usr/bin/cockpit-bridge
 usr/lib/cockpit/cockpit-askpass
+usr/lib/cockpit/cockpit-ssh
 usr/share/cockpit/base1/
+usr/share/cockpit/ssh/
 usr/share/man/man1/cockpit-bridge.1

--- a/tools/debian/cockpit-dashboard.install
+++ b/tools/debian/cockpit-dashboard.install
@@ -1,3 +1,1 @@
-usr/lib/cockpit/cockpit-ssh
 usr/share/cockpit/dashboard/
-usr/share/cockpit/ssh/

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -59,16 +59,20 @@ Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
          glib-networking
+Provides: cockpit-ssh
+Breaks: cockpit-dashboard (<< 170.x)
+Replaces: cockpit-dashboard (<< 170.x)
 Description: Cockpit bridge server-side component
  The Cockpit bridge component installed server side and runs commands on
  the system on behalf of the web based user interface.
 
 Package: cockpit-dashboard
-Architecture: any
+Architecture: all
 Depends: ${misc:Depends},
          ${shlibs:Depends},
-         cockpit-ws (= ${binary:Version})
-Provides: cockpit-ssh
+         cockpit-bridge (>= 170.x),
+         cockpit-ws (>= ${source:Version}),
+         cockpit-ws (<< ${source:Version}.1~),
 Replaces: cockpit-system (<< 128), cockpit-ws (<< 128)
 Description: Cockpit remote servers and dashboard
  Cockpit support for connecting to remote servers (through ssh)


### PR DESCRIPTION
We are not yet ready to install cockpit-dashboard by default everywhere
just yet, because of the insufficient isolation of different server
iframes in the browser.

But we always want to provide the "connect to remote server"
functionality through the login page, bastion host containers, or direct
URLs (when integrating Cockpit into e. g. Foreman). So ship the 
cockpit-ssh bridge and the corresponding pkg/ssh/ manifest in
cockpit-bridge. This leaves cockpit-dashboard to ship only
pkg/dashboard, and thus it becomes an architecture independent package.

Adjust the package dependencies/conflicts accordingly. It is tempting to
bump the "requires/cockpit" in dashboard's manifest, but that would get 
in the way of downstream RHEL/CentOS packaging, so just put the version
number into the spec/control files directly.

Keep cockpit-ssh in dashboard on rhel/centos-7, though; otherwise we
can't test this with the rhel-7-5 image, and it also stays possible to
use upstream master's spec file to build RHEL/CentOS 7 packages.

Adjust the container build scripts, they need cockpit-ssh (but without
the actual dashboard bits).

 - [x] fix rhel-7-5 uninstallability
 - [x] fix uninstallability for fedora-atomic