### PR TITLE
bots: Move tests-data into its own bot task

### DIFF
--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -28,6 +28,7 @@ NAMES = [
     "npm-update",
     "naughty-prune",
     "learn-tests",
+    "tests-data",
 ]
 
 KVM_TASKS = [

--- a/bots/learn-tests
+++ b/bots/learn-tests
@@ -24,6 +24,11 @@ SINCE_DAYS = 120
 # The name and version of the training data
 TRAINING_DATA = "tests-train-1.jsonl.gz"
 
+# The number of days in history to learn from. This is different from
+# the amount of  data we gather in tests-data, and can be adjusted
+# independently.
+SINCE = 21
+
 import gzip
 import os
 import subprocess
@@ -93,8 +98,16 @@ def loader(training_data, verbose, dry):
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
         inp = proc.stdout
 
+    since = time.strftime("%Y-%m-%d", time.gmtime(time.time() - (86400 * SINCE)))
+
+    def only(item):
+        if not learn.data.failures(item):
+            return False
+        date = item.get("date", "")
+        return date > since
+
     try:
-        items = list(learn.data.load(inp, only=learn.data.failures, verbose=verbose))
+        items = list(learn.data.load(inp, only=only, verbose=verbose))
     finally:
         if proc:
             proc.wait()

--- a/bots/learn-tests
+++ b/bots/learn-tests
@@ -18,9 +18,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-# The number of days of previous closed pull requests to learn from
-SINCE_DAYS = 120
-
 # The name and version of the training data
 TRAINING_DATA = "tests-train-1.jsonl.gz"
 
@@ -54,10 +51,7 @@ def run(training_data, verbose=False, dry=False, **kwargs):
         if not dry:
             subprocess.check_call([ os.path.join(BOTS, "image-download"), "--state", training_data ])
         training_data = os.path.join(DATA, training_data)
-    items = loader(training_data, verbose, dry)
-
-    if not dry:
-        subprocess.check_call(upload + [ training_data ])
+    items = loader(training_data, verbose)
 
     # Train for the second model
     path = train(items, verbose)
@@ -69,34 +63,19 @@ def run(training_data, verbose=False, dry=False, **kwargs):
 
 # Load jsonl style data into items, or if no file specified
 # then just run tests-data to retrieve live data
-def loader(training_data, verbose, dry):
+def loader(training_data, verbose):
     items = [ ]
 
     # The input file exists
     exists = training_data and os.path.exists(training_data)
 
     # Dry mode just read a file
-    if dry:
-        proc = None
-        if not exists:
-            raise RuntimeError("learn-tests: the input file doesn't exist: {0}".format(training_data))
-        inp = gzip.open(training_data, 'rb')
-        if verbose:
-            sys.stderr.write("Loading tests data\n")
-
-    # Launch the test-data command directly, and save the output
-    else:
-        cmd = [ os.path.join(BOTS, "tests-data"), "--since" ]
-        when = time.time() - 60 * 60 * 24 * SINCE_DAYS
-        cmd.append(time.strftime("%Y-%m-%d", time.gmtime(when)))
-        if exists:
-            cmd += [ "--seed", training_data ]
-        if verbose:
-            if exists:
-                sys.stderr.write("Loading existing tests data\n")
-            cmd.append("--verbose")
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        inp = proc.stdout
+    proc = None
+    if not exists:
+        raise RuntimeError("learn-tests: the input file doesn't exist: {0}".format(training_data))
+    inp = gzip.open(training_data, 'rb')
+    if verbose:
+        sys.stderr.write("Loading tests data\n")
 
     since = time.strftime("%Y-%m-%d", time.gmtime(time.time() - (86400 * SINCE)))
 

--- a/bots/learn-trigger
+++ b/bots/learn-trigger
@@ -29,6 +29,9 @@ sys.dont_write_bytecode = True
 
 import task
 
+# The name and version of the training data
+TRAINING_DATA = "tests-train-1.jsonl.gz"
+
 def main():
     parser = argparse.ArgumentParser(description='Ensure necessary issue learning from tests')
     parser.add_argument('-v', '--verbose', action="store_true", default=False,
@@ -39,7 +42,11 @@ def main():
     body = "Perform machine learning tasks such as retrieving new test logs and updating"
 
     since = time.time() - (DAYS * 86400)
-    issue = task.issue(title, body, "learn-tests", None, state="all", since=since)
+    items = [
+        "tests-data " + TRAINING_DATA,
+        "learn-tests " + TRAINING_DATA,
+    ]
+    issue = task.issue(title, body, items[1], items=items, state="all", since=since)
 
     if issue:
         sys.stderr.write("#{0}: learn-tests\n".format(issue["number"]))

--- a/bots/learn/cluster.py
+++ b/bots/learn/cluster.py
@@ -181,12 +181,12 @@ class Model():
 
         items = list(items)
 
-        if self.verbose:
-            sys.stderr.write("{0}: Items to train\n".format(len(items)))
-
         # Extract the features we want to use for clustering from the items
         self.extractor = extractor.Extractor()
         self.features = self.extractor.fit_transform(items)
+
+        if self.verbose:
+            sys.stderr.write("{0}: Items to train\n".format(len(self.features)))
 
         jobs = os.cpu_count() or -1
         start = time.perf_counter()

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -297,16 +297,20 @@ def stale(days, pathspec, ref="HEAD"):
 
     return timestamp < due
 
-def issue(title, body, name, context=None, state="open", since=None):
-    item = "{0} {1}".format(name, context or "").strip()
+def issue(title, body, item, context=None, items=[], state="open", since=None):
+    if context:
+        item = "{0} {1}".format(item, context).strip()
 
     for issue in api.issues(state=state, since=since):
         checklist = github.Checklist(issue["body"])
         if item in checklist.items:
             return issue
 
+    if not items:
+        items = [ item ]
     checklist = github.Checklist(body)
-    checklist.add(item)
+    for x in items:
+        checklist.add(x)
     data = {
         "title": title,
         "body": checklist.body,

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-import argparse
 import gzip
 import json
 import os
@@ -38,52 +37,45 @@ sys.dont_write_bytecode = True
 
 import task
 
+# The number of days of previous closed pull requests to learn from
+SINCE_DAYS = 120
+
 BOTS = os.path.abspath(os.path.dirname(__file__))
+DATA = os.path.join(os.environ.get("TEST_DATA", BOTS), "images")
 SEEDED = set()
 SINKS = { }
 
-def main():
-    parser = argparse.ArgumentParser(description="Pull out test data for pull requests")
-    parser.add_argument("--seed", action="store", help="Seed with existing data and update")
-    parser.add_argument("--since", help="Since a given ISO-8601 date")
-    parser.add_argument("-v", "--verbose", action="store_true", help="Show verbose progress")
-    opts = parser.parse_args()
-
-    # Parse the input date
-    since = opts.since
-    try:
-        if since is not None:
-            since = time.mktime(time.strptime(opts.since, "%Y-%m-%d"))
-    except ValueError:
-        sys.stderr.write("tests-data: invalid since date: {0}\n".format(since))
-        return 2
-
+def run(filename, verbose=False, dry=False, **kwargs):
+    since = time.time() - 60 * 60 * 24 * SINCE_DAYS
     pulls = Pulls(since)
 
     # Seed with our input data
-    if opts.seed:
-        (outfd, outname) = tempfile.mkstemp(prefix=os.path.basename(opts.seed), dir=os.path.dirname(opts.seed))
+    if filename:
+        if "/" not in filename and not os.path.exists(filename):
+            if not dry:
+                subprocess.check_call([ os.path.join(BOTS, "image-download"), "--state", filename ])
+            filename = os.path.join(DATA, filename)
+        (outfd, outname) = tempfile.mkstemp(prefix=os.path.basename(filename), dir=os.path.dirname(filename))
         os.close(outfd)
         output = gzip.open(outname, 'wb')
-        if os.path.exists(opts.seed):
-            with gzip.open(opts.seed, 'rb') as fp:
+        if os.path.exists(filename):
+            with gzip.open(filename, 'rb') as fp:
                 seed(since, fp, pulls, output)
     else:
-        output = outname = None
+        output = sys.stdout
+        outname = None
 
     def write(**kwargs):
         line = json.dumps(kwargs).encode('utf-8') + b"\n"
-        os.write(1, line)
-        if output:
-            output.write(line)
+        output.write(line)
 
     # Iterate through all revisions, pull requests on this branch
-    for (commit, merged, created, pull) in commits("master", pulls, since, opts.verbose):
+    for (commit, merged, created, pull) in commits("master", pulls, since, verbose):
         logged = False
-        if opts.verbose:
+        if verbose:
             sys.stderr.write("- {0}\n".format(commit))
         for (context, created, url, log) in logs(commit):
-            if opts.verbose:
+            if verbose:
                 sys.stderr.write("  - {0} {1}\n".format(created, context))
             for (status, name, body, tracker) in tap(log):
                 write(pull=pull, revision=commit, status=status,
@@ -105,7 +97,12 @@ def main():
     sys.stdout.flush()
     if output:
         output.close()
-        os.rename(outname, opts.seed)
+    if outname:
+        os.rename(outname, filename)
+
+    if not dry and outname and filename:
+        upload = [ os.path.join(BOTS, "image-upload"), "--state", filename ]
+        subprocess.check_call(upload)
 
 # An HTML parser that just pulls out all the <a href="...">
 # link hrefs in a given page of content. We also qualify these
@@ -278,7 +275,6 @@ def seed(since, fp, pulls, output):
                 item["tracker"] = qualify("issues/{0}".format(match.group(1)))
 
         line = json.dumps(item).encode('utf-8') + b"\n"
-        os.write(1, line)
         output.write(line)
 
 # Generate a list of (revision, merged, url) for the given branch
@@ -475,4 +471,4 @@ def qualify(path):
     return "https://api.github.com" + task.api.qualify(path)
 
 if __name__ == '__main__':
-    sys.exit(main())
+    task.main(function=run, title="Pull out test data for pull requests", verbose=True)


### PR DESCRIPTION
This allows us to separate it from the machine learning task, decouple, and more quickly iterate on the latter.

The intent is to be able to move the ML stuff into another project, containers, etc. And separate the cockpit specific parts (ie: tests-data, the part that pulls in data from our project).

 * [x] #9589 
 * [x] tests-data tests-train-1.jsonl.gz
 * [x] learn-tests tests-train-1.jsonl.gz