### PR TITLE
base1: use javascript-style locales for toLocaleString

### DIFF
--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -1474,13 +1474,13 @@ function factory() {
         else if (number % 1 === 0)
             return number.toString();
         else if (number > 0 && number <= 0.001)
-            return (0.001).toLocaleString(cockpit.language);
+            return (0.001).toLocaleString(cockpit.js_lang);
         else if (number < 0 && number >= -0.001)
-            return (-0.001).toLocaleString(cockpit.language);
+            return (-0.001).toLocaleString(cockpit.js_lang);
         else if (number > 999 || number < -999)
             return number.toFixed(0);
         else
-            return number.toLocaleString(cockpit.language, {
+            return number.toLocaleString(cockpit.js_lang, {
                 maximumSignificantDigits: 3,
                 minimumSignificantDigits: 3
             });
@@ -3845,6 +3845,7 @@ function factory() {
     var po_plural;
 
     cockpit.language = undefined;
+    cockpit.js_lang = undefined;
 
     cockpit.locale = function locale(po) {
         var lang = cockpit.language || "en";
@@ -3865,6 +3866,7 @@ function factory() {
         }
 
         cockpit.language = lang;
+        cockpit.js_lang = lang.replace('_', '-')
     };
 
     cockpit.translate = function translate(/* ... */) {

--- a/src/base1/test-format.js
+++ b/src/base1/test-format.js
@@ -44,24 +44,35 @@ QUnit.test("format_number", function () {
     ];
 
     var saved_language = cockpit.language;
+    var saved_js_lang = cockpit.js_lang;
     var i;
 
-    assert.expect(checks.length * 2);
+    assert.expect(checks.length * 3);
 
     cockpit.language = 'en';
+    cockpit.js_lang = 'en';
     for (i = 0; i < checks.length; i++) {
         assert.strictEqual(cockpit.format_number(checks[i][0]), checks[i][1],
                     "format_number@en(" + checks[i][0] + ") = " + checks[i][1]);
     }
 
     cockpit.language = 'de';
+    cockpit.js_lang = 'de';
     for (i = 0; i < checks.length; i++) {
         assert.strictEqual(cockpit.format_number(checks[i][0]), checks[i][2],
                     "format_number@de(" + checks[i][0] + ") = " + checks[i][2]);
     }
 
+    cockpit.language = 'pt_BR';
+    cockpit.js_lang = 'pt-br';
+    for (i = 0; i < checks.length; i++) {
+        assert.strictEqual(cockpit.format_number(checks[i][0]), checks[i][2],
+                    "format_number@pr_BR(" + checks[i][0] + ") = " + checks[i][2]);
+    }
+
   /* restore this as not to break the other tests */
   cockpit.language = saved_language;
+  cockpit.js_lang = saved_js_lang;
 });
 
 QUnit.test("format_bytes", function() {


### PR DESCRIPTION
For at least Brazilian Portuguese, we end up with cockpit.language set
to 'pt_BR', with an underscore.  Passing this to toLocaleString causes
an exception, because it wants to see it like 'pt-br'.

Other places in the code assume that cockpit.language is a POSIX style
locale, so we can't change it there.  Instead, add a new variable
cockpit.js_lang and set it to the version with the hyphen.

Fixes #9349