### PR TITLE
tools: Don't run pyflakes on binary files

### DIFF
--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -9,7 +9,7 @@ cd "${srcdir:-.}"
 fail=0
 
 # we don't dist bots, so only check it when running in git
-[ -d bots ] &&  BOTS=$(grep -l '#!.*python' `find bots/ -type f ! -name '.*'` 2>/dev/null || true) || BOTS=
+[ -d bots ] &&  BOTS=$(grep -lI '#!.*python' `find bots/ -type f ! -name '.*'` 2>/dev/null || true) || BOTS=
 
 #
 # pyflakes


### PR DESCRIPTION
Currently, we are grepping all files in bots/ to see if they look like a
python script.  Unfortunately, we accept '#!.*python' anywhere in the
file as evidence of being python.

This has two problems.  First: grepping the full content of the image
files is slow.  Second: some of the images may match, which results in
pyflakes running against binary data (and failing).

Use `grep -I` which means "ignore binary files".

Closes #9410