### PR TITLE
docker: gui: fix memory limit slider doesn't activate

### DIFF
--- a/pkg/docker/util.js
+++ b/pkg/docker/util.js
@@ -360,7 +360,7 @@
             if (data !== undefined)
                 $(slider).prop("value", (Math.log(data) - minv) / scale);
             $(slider)
-                .attr("disabled", data === undefined)
+                .attr("disabled", !check.checked)
                 .trigger("change");
             updating = false;
         }


### PR DESCRIPTION
Slider should not be disabled if data is undefined. Instead checkbox
value should be checked.

fixes: https://github.com/cockpit-project/cockpit/issues/8634

Signed-off-by: Katerina Koukiou <kkoukiou@redhat.com>