### PR TITLE
base1: Use javascript-style locales for toLocaleString

### DIFF
--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -1468,19 +1468,20 @@ function factory() {
          * non-localised conversions (and in both cases, show no
          * fractional part).
          */
+	var lang = cockpit.language === undefined ? undefined : cockpit.language.replace('_', '-');
 
         if (!number && number !== 0)
             return "";
         else if (number % 1 === 0)
             return number.toString();
         else if (number > 0 && number <= 0.001)
-            return (0.001).toLocaleString(cockpit.language);
+            return (0.001).toLocaleString(lang);
         else if (number < 0 && number >= -0.001)
-            return (-0.001).toLocaleString(cockpit.language);
+            return (-0.001).toLocaleString(lang);
         else if (number > 999 || number < -999)
             return number.toFixed(0);
         else
-            return number.toLocaleString(cockpit.language, {
+            return number.toLocaleString(lang, {
                 maximumSignificantDigits: 3,
                 minimumSignificantDigits: 3
             });

--- a/src/base1/test-format.js
+++ b/src/base1/test-format.js
@@ -46,7 +46,7 @@ QUnit.test("format_number", function () {
     var saved_language = cockpit.language;
     var i;
 
-    assert.expect(checks.length * 2);
+    assert.expect(checks.length * 3);
 
     cockpit.language = 'en';
     for (i = 0; i < checks.length; i++) {
@@ -58,6 +58,12 @@ QUnit.test("format_number", function () {
     for (i = 0; i < checks.length; i++) {
         assert.strictEqual(cockpit.format_number(checks[i][0]), checks[i][2],
                     "format_number@de(" + checks[i][0] + ") = " + checks[i][2]);
+    }
+
+    cockpit.language = 'pt_BR';
+    for (i = 0; i < checks.length; i++) {
+        assert.strictEqual(cockpit.format_number(checks[i][0]), checks[i][2],
+                    "format_number@pt_BR(" + checks[i][0] + ") = " + checks[i][2]);
     }
 
   /* restore this as not to break the other tests */


### PR DESCRIPTION
For at least Brazilian Portuguese, we end up with cockpit.language set
to 'pt_BR', with an underscore.  Passing this to toLocaleString causes
an exception, because it wants to see it like 'pt-br'.

Other places in the code assume that cockpit.language is a POSIX style
locale, so we can't change it there.  Instead, do the substitution
inside of format_number().

Fixes #9349
Closes #9413