### PR TITLE
build: add a rule to copy cockpit.js to dist/

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -203,6 +203,9 @@ dist/%/Makefile.deps: $(WEBPACK_CONFIG)
 dist/%/manifest.json: pkg/%/manifest.json
 	$(COPY_RULE)
 
+dist/base1/cockpit.js: src/base1/cockpit.js
+	$(COPY_RULE)
+
 -include $(WEBPACK_DEPS)
 
 distclean-local::


### PR DESCRIPTION
cockpit.js is automatically copied over to dist/ as a result of webpack
of each module, but if you modify cockpit.js on its own, it's not
copied.

Add a simple rule to do that.

Fixes #9424
Closes #9425