### PR TITLE
ssh: increase timeout in test-sshbridge

### DIFF
--- a/src/ssh/test-sshbridge.c
+++ b/src/ssh/test-sshbridge.c
@@ -33,7 +33,7 @@
 #include <sys/prctl.h>
 #include <sys/socket.h>
 
-#define TIMEOUT 30
+#define TIMEOUT 120
 
 #define WAIT_UNTIL(cond) \
   G_STMT_START \


### PR DESCRIPTION
Running the /ssh-bridge/echo-large test locally with a CPU quota of 10%
sometimes hits the current timeout of 30s.  This testcase is
periodically failing on semaphore, for probably the same reason.
Increase to 120.

Closes #9426