### PR TITLE
shell: Remove ability to drop privileges from top navbar

### DIFF
--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -30,16 +30,14 @@
                 </div>
               </li>
               <li class="credential-lock">
-                <a data-toggle="tooltip" data-placement="bottom" translate="title"
-                    title="Privileged tasks not available">
-                  <i class="fa fa-lock"></i>
-                  <span translate>Locked</span>
-                </a>
-                <a data-toggle="tooltip" data-placement="bottom" translate="title"
-                    title="Lock to prevent privileged tasks" class="credential-clear">
+                <span>
+                  <!-- Display nothing when unprivileged -->
+                </span>
+                <span data-toggle="tooltip" data-placement="bottom" translate="title"
+-                    title="Login has escalated admin privileges" class="navbar-text">
                   <i class="fa fa-unlock-alt"></i>
-                  <span translate>Unlocked</span>
-                </a>
+                  <span translate>Privileged</span>
+                </span>
               </li>
               <li id="navbar-oops" hidden>
                 <a><span class="oops-status" translatable="yes">Ooops!</span></a>

--- a/pkg/shell/privileges.js
+++ b/pkg/shell/privileges.js
@@ -22,17 +22,16 @@ var cockpit = require("cockpit");
 function Privileges() {
     var self = this;
     var locked = null;
-    var lock;
 
     function clicked(ev) {
         cockpit.drop_privileges(false);
         ev.preventDefault();
     }
 
-    function display(blink) {
+    function display() {
         var i, locks = document.querySelectorAll(".credential-lock");
         for (i = 0; i < locks.length; i++) {
-            lock = locks[i];
+            var lock = locks[i];
             if (locked !== true)
                 lock.classList.remove("credential-locked");
             else if (locked === true)
@@ -41,11 +40,6 @@ function Privileges() {
                 lock.classList.remove("credential-unlocked");
             else if (locked === false)
                 lock.classList.add("credential-unlocked");
-
-            if (lock.tagName == "LI" && blink)
-                lock.classList.add("credential-blink");
-            else
-                lock.classList.remove("credential-blink");
         }
 
         var clear = document.querySelectorAll(".credential-clear");
@@ -54,17 +48,15 @@ function Privileges() {
     }
 
     self.update = function update(hint) {
-        var blink = false;
         if (hint.credential == "password") {
             locked = false;
         } else if (hint.credential == "request") {
             if (locked === null)
                 locked = true;
-            blink = true;
         } else if (hint.credential == "none") {
             locked = null;
         }
-        display(blink);
+        display();
     };
 
     /* No op authorize command to poke about state */

--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -473,35 +473,6 @@ thead.credential-lock.credential-unlocked > *:last-child {
     display: table-row !important;
 }
 
-@-webkit-keyframes blink {
-    0% {
-        opacity: 0;
-    }
-    50% {
-        opacity: 0.5;
-    }
-    100% {
-        opacity: 1;
-    }
-}
-
-@keyframes blink {
-    0% {
-        opacity: 1;
-    }
-    50% {
-        opacity: 0.5;
-    }
-    100% {
-        opacity: 1;
-    }
-}
-
-.credential-blink {
-    -webkit-animation: blink 1.2s 1 linear;
-    animation: blink 1.2s 1 linear;
-}
-
 li.credential-lock {
     span { padding-left: 1em; }
 }

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -39,13 +39,12 @@ class TestReauthorize(MachineCase):
         b.wait_in_text(".cockpit-internal-reauthorize span", 'result:')
         self.assertEqual(b.text(".cockpit-internal-reauthorize span"), 'result: authorized')
 
-        # Deauthorize from the top bar
+        # Deauthorize user
         b.leave_page()
         b.click("#navbar-dropdown")
         b.click("#credentials-item")
-        b.wait_visible("a.credential-clear")
-        b.click("a.credential-clear")
-        b.wait_not_visible("a.credential-clear")
+        b.click("button.credential-clear")
+        b.wait_not_visible("button.credential-clear")
         b.click("#credentials-dialog [data-dismiss]")
 
         b.enter_page("/playground/test")


### PR DESCRIPTION
The UI does not respond to this event properly, and doing this
cleanly requires logging in again anyway. Lets not encourage
relying on this 'drop privileges' feature if it doesn't work
as expected.

The ability to start cockpit without escalating privileges remains
on the login screen.