### PR TITLE
bots: Decrease memory allocated for install VMs

### DIFF
--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -145,7 +145,7 @@ def build_and_install(build_image, build_results, skips, args):
     """Build and maybe install Cockpit into a test image"""
     build_image = prepare_install_image(build_image)
     machine = testvm.VirtMachine(verbose=args.verbose, image=build_image,
-            memory_mb=4096, cpus=4, maintain=True, networking=networking)
+            memory_mb=2048, cpus=4, maintain=True, networking=networking)
     completed = False
 
     # While the machine is booting, make a tarball


### PR DESCRIPTION
4 gigabytes is a bit much for standard developer laptops.