### PR TITLE
test: Ignore DBus disconnect messages when restarting

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -756,6 +756,7 @@ class MachineCase(unittest.TestCase):
                                     'localhost: dropping message while waiting for child to exit',
                                     '.*: GDBus.Error:org.freedesktop.PolicyKit1.Error.Failed: .*',
                                     '.*g_dbus_connection_call_finish_internal.*G_IS_DBUS_CONNECTION.*',
+                                    '.*Message recipient disconnected from message bus without replying.*',
                                     )
 
     def allow_authorize_journal_messages(self):


### PR DESCRIPTION
When restarting the system, we can ignore DBus message disconnect
requests.