### PR TITLE
bots: Sync the journal before clearing out journal directory

### DIFF
--- a/bots/images/scripts/lib/containers.install
+++ b/bots/images/scripts/lib/containers.install
@@ -30,4 +30,6 @@ do
     rm -r "/var/tmp/containers/$NAME/rpms"
 done
 
+journalctl --flush || true
+journalctl --sync || killall systemd-journald || true
 rm -rf /var/log/journal/* || true

--- a/bots/images/scripts/lib/debian.install
+++ b/bots/images/scripts/lib/debian.install
@@ -86,5 +86,7 @@ if [ -n "$do_install" ]; then
 
     # firewall-cmd --add-service=cockpit --permanent
 
+    journalctl --flush
+    journalctl --sync || killall systemd-journald
     rm -rf /var/log/journal/*
 fi

--- a/bots/images/scripts/lib/fedora.install
+++ b/bots/images/scripts/lib/fedora.install
@@ -103,6 +103,9 @@ if [ -n "$do_install" ]; then
         firewall-cmd --add-service=cockpit --permanent
     fi
 
+    # Make sure we clean out the journal
+    journalctl --flush
+    journalctl --sync || killall systemd-journald
     rm -rf /var/log/journal/*
     rm -rf /var/lib/NetworkManager/dhclient-*.lease
 fi


### PR DESCRIPTION
Before testing we clear out the journal directory, so we can
see what journal messages are unique to the tests. However there
seem to be races with journald still writing to it, resulting
in messages like this in the logs:

    Journal file /var/log/journal/... corrupted, ignoring file.

Lets flush and sync the journal before clearing it.