### PR TITLE
test: Wait for browser longer

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -189,7 +189,7 @@ class CDP:
 
         # wait for CDP to be up
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        for retry in range(300):
+        for retry in range(3000):
             try:
                 s.connect(('127.0.0.1', cdp_port))
                 break


### PR DESCRIPTION
This can happen on loaded infrastructures. 30 seconds just isn't
enough time for the browser to come up reliably. Bump by factor
of ten.

This was seen in Semaphore CI:

    Traceback (most recent call last):
      File "./test/common/tap-cdp", line 70, in <module>
        cdp.invoke("Page.navigate", url=address + '/' + opts.test)
      File "/tmp/source/test/common/cdp.py", line 87, in invoke
        res = self.command(cmd)
      File "/tmp/source/test/common/cdp.py", line 97, in command
        self.start()
      File "/tmp/source/test/common/cdp.py", line 199, in start
        raise RuntimeError('timed out waiting for browser to start')
    RuntimeError: timed out waiting for browser to start