### PR TITLE
Webpack untangle

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -175,12 +175,10 @@ WEBPACK_PACKAGES = \
 
 V_WEBPACK = $(V_WEBPACK_$(V))
 V_WEBPACK_ = $(V_WEBPACK_$(AM_DEFAULT_VERBOSITY))
-V_WEBPACK_0 = @echo "  WEBPACK  $(@:dist/%/Makefile.deps=%)";
+V_WEBPACK_0 = @echo "  WEBPACK  $(@:dist/%/stamp=%)";
 
 WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(abspath $(srcdir)) BUILDDIR=$(builddir) \
 	       $(srcdir)/tools/missing $(srcdir)/tools/webpack-make
-
-WEBPACK_RULE = $(V_WEBPACK) $(WEBPACK_MAKE)
 
 WEBPACK_CONFIG = $(srcdir)/webpack.config.js
 WEBPACK_INPUTS =
@@ -188,18 +186,32 @@ WEBPACK_PO =
 WEBPACK_OUTPUTS =
 WEBPACK_INSTALL = $(WEBPACK_PACKAGES:%=dist/%/manifest.json)
 WEBPACK_DEPS = $(WEBPACK_PACKAGES:%=dist/%/Makefile.deps)
+WEBPACK_STAMPS = $(WEBPACK_PACKAGES:%=dist/%/stamp)
 WEBPACK_MANIFEST_IN = $(WEBPACK_PACKAGES:%=pkg/%/manifest.json.in)
 
-noinst_SCRIPTS += $(WEBPACK_DEPS) $(WEBPACK_INSTALL)
-CLEANFILES += $(WEBPACK_DEPS) $(WEBPACK_OUTPUTS)
-EXTRA_DIST += $(WEBPACK_DEPS) $(WEBPACK_MANIFEST_IN) webpack.config.js
+noinst_SCRIPTS += $(WEBPACK_STAMPS) $(WEBPACK_INSTALL)
+CLEANFILES += $(WEBPACK_STAMPS) $(WEBPACK_DEPS) $(WEBPACK_OUTPUTS)
+EXTRA_DIST += $(WEBPACK_STAMPS) $(WEBPACK_DEPS) $(WEBPACK_MANIFEST_IN) webpack.config.js
 
-# Run webpack if we don't have the include file or if its out of date
-# If we have distributed a copy in a tarball, copy that into place
-dist/%/Makefile.deps: $(WEBPACK_CONFIG)
-	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && if test $(srcdir)/dist/$*/Makefile.deps -nt $(WEBPACK_CONFIG); \
-	then cp -p $(srcdir)/dist/$*/Makefile.deps $@.tmp && $(MV) $@.tmp $@; \
-	else $(WEBPACK_MAKE) -d $@ $<; fi
+PRINT_COPY_MSG_0 = echo "  COPY    " $@ &&
+PRINT_COPY_MSG_ = $(PRINT_COPY_MSG_$(AM_DEFAULT_VERBOSITY))
+
+# Copy an original copy of each Makefile.deps from the srcdir, in case
+# of an out-of-tree build from a tarball.  This is needed because the
+# 'include' below won't find the file in srcdir.
+# This rule needs to have a successful exit, or make will become unhappy.
+dist/%/Makefile.deps:
+	$(AM_V_at)test "$(srcdir)" == "$(builddir)" -o ! $(srcdir)/$@ -nt $@ || ( \
+	  $(PRINT_COPY_MSG_$(V))$(MKDIR_P) $(dir $@) && \
+	  cp -p $(srcdir)/$@ $@.tmp && \
+	  mv $@.tmp $@)
+
+# This is the primary rule for running webpack
+dist/%/stamp: $(WEBPACK_CONFIG) $(srcdir)/tools/webpack-make
+	$(V_WEBPACK) $(MKDIR_P) dist/$* && \
+	  $(WEBPACK_MAKE) -d dist/$*/Makefile.deps $(WEBPACK_CONFIG) && \
+	  touch $@
+
 dist/%/manifest.json: pkg/%/manifest.json
 	$(COPY_RULE)
 

--- a/package.json
+++ b/package.json
@@ -79,8 +79,7 @@
     "strict-loader": "~1.1.0",
     "style-loader": "~0.13.1",
     "uglify-js": "~2.6.2",
-    "webpack": "~1.13.2",
-    "webpack-merge-and-include-globally": "~1.0.1"
+    "webpack": "~1.13.2"
   },
   "scripts": {
     "eslint": "eslint --ext .jsx --ext .es6 pkg/",

--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -6,6 +6,8 @@ nodist_base_DATA = \
 	dist/base1/patternfly.min.css.gz \
 	dist/base1/require.min.js.gz \
 	dist/base1/mustache.min.js.gz \
+	dist/base1/jquery.min.js.gz \
+	dist/base1/cockpit.min.js.gz \
 	$(NULL)
 base_DATA = \
 	dist/base1/manifest.json \
@@ -17,6 +19,8 @@ basedebug_DATA = \
 	dist/base1/patternfly.min.css.map \
 	dist/base1/mustache.min.js.map \
 	dist/base1/require.min.js.map \
+	dist/base1/jquery.min.js.map \
+	dist/base1/cockpit.min.js.map \
 	$(NULL)
 
 AM_TESTS_ENVIRONMENT = export G_DEBUG=fatal-criticals,fatal-warnings ; export XDG_CACHE_HOME=$$(mktemp -d) ; export XDG_RUNTIME_DIR=$$XDG_CACHE_HOME ;
@@ -31,6 +35,16 @@ dist/base1/require.js: src/base1/deprecated.js src/base1/require-config.js src/b
 	cat $(srcdir)/src/base1/deprecated.js $(srcdir)/src/base1/require-config.js $(srcdir)/node_modules/requirejs/require.js $(srcdir)/src/base1/require-loaders.js > $@.tmp && $(MV) $@.tmp $@
 dist/base1/require.min.js: dist/base1/require.js
 	$(MIN_JS_RULE)
+dist/base1/jquery.js:
+	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
+	cat $(srcdir)/node_modules/jquery/dist/jquery.js $(srcdir)/node_modules/bootstrap/dist/js/bootstrap.js $(srcdir)/node_modules/patternfly/dist/js/patternfly.js > $@.tmp && $(MV) $@.tmp $@
+dist/base1/jquery.min.js: dist/base1/jquery.js
+	$(MIN_JS_RULE)
+dist/base1/cockpit.js: src/base1/cockpit.js
+	$(JSHINT_RULE)
+	$(COPY_RULE)
+dist/base1/cockpit.min.js: dist/base1/cockpit.js
+	$(MIN_JS_RULE)
 dist/base1/mustache.js: src/base1/deprecated.js
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
 	cat $(srcdir)/src/base1/deprecated.js $(srcdir)/node_modules/mustache/mustache.js > $@.tmp && $(MV) $@.tmp $@
@@ -42,6 +56,10 @@ dist/base1/manifest.json: src/base1/manifest.json
 
 # All map files are built as side effects of minification
 dist/base1/require.min.js.map: dist/base1/require.min.js
+
+dist/base1/cockpit.min.js.map: dist/base1/cockpit.min.js
+
+dist/base1/jquery.min.js.map: dist/base1/jquery.min.js
 
 dist/base1/mustache.min.js.map: dist/base1/mustache.min.js
 
@@ -181,8 +199,14 @@ TESTS += $(base_TESTS)
 noinst_SCRIPTS += $(base_TESTS)
 
 EXTRA_DIST += \
+	dist/base1/cockpit.js \
 	dist/base1/cockpit.min.css \
 	dist/base1/cockpit.min.css.map \
+	dist/base1/cockpit.min.js \
+	dist/base1/cockpit.min.js.map \
+	dist/base1/jquery.js \
+	dist/base1/jquery.min.js \
+	dist/base1/jquery.min.js.map \
 	dist/base1/mustache.js \
 	dist/base1/mustache.min.js \
 	dist/base1/mustache.min.js.map \
@@ -213,12 +237,20 @@ EXTRA_DIST += \
 	$(NULL)
 
 CLEANFILES += \
+	dist/base1/cockpit.js \
 	dist/base1/cockpit.min.css \
 	dist/base1/cockpit.min.css.gz \
 	dist/base1/cockpit.min.css.map \
+	dist/base1/cockpit.min.js \
+	dist/base1/cockpit.min.js.gz \
+	dist/base1/cockpit.min.js.map \
 	dist/base1/fonts/fontawesome.woff \
 	dist/base1/fonts/glyphicons.woff \
 	dist/base1/fonts/patternfly.woff \
+	dist/base1/jquery.js \
+	dist/base1/jquery.min.js \
+	dist/base1/jquery.min.js.gz \
+	dist/base1/jquery.min.js.map \
 	dist/base1/manifest.json \
 	dist/base1/mustache.js \
 	dist/base1/mustache.min.js \

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -88,6 +88,7 @@ function generateDeps(makefile, stats) {
     var debugs = { };
 
     var pkgdir = path.dirname(makefile);
+    var stampfile = pkgdir + '/stamp';
 
     stats.compilation.modules.forEach(function(module) {
         var parts = module.identifier().split("!");
@@ -193,12 +194,11 @@ function generateDeps(makefile, stats) {
     lines.push("\t$(MSGGREP) " + filters.join(" ") + " $< > $@.tmp && mv $@.tmp $@");
     lines.push("");
 
-    lines.push(makefile + ": $(WEBPACK_CONFIG) $(" + prefix + "_INPUTS)");
-    lines.push("\t$(WEBPACK_RULE) -d " + makefile + " $(WEBPACK_CONFIG)");
+    lines.push(stampfile + ": $(" + prefix + "_INPUTS)");
     lines.push("");
 
     outputs.forEach(function(name) {
-        lines.push(name + ": " + makefile);
+        lines.push(name + ": " + stampfile);
         lines.push("")
     });
 
@@ -215,14 +215,10 @@ function generateDeps(makefile, stats) {
     lines.push("TESTS += $(" + prefix + "_TESTS)");
     lines.push("");
 
-    lines.push(prefix + ": " + makefile + " $(" + prefix + "_OUTPUTS) $(" + prefix + "_INSTALL)");
-    lines.push("\t@true");
+    lines.push(prefix + ": " + stampfile);
     lines.push("clean-" + prefix + ": ");
-    lines.push("\trm -rf $(" + prefix + "_OUTPUTS) $(" + prefix + "_INSTALL) " + makefile);
-    lines.push("all-local:: " + prefix);
-    lines.push("\t@true");
+    lines.push("\trm -rf $(" + prefix + "_OUTPUTS) $(" + prefix + "_INSTALL) " + stampfile);
     lines.push("clean-local:: clean-" + prefix);
-    lines.push("\t@true");
 
     data = lines.join("\n") + "\n";
     fs.writeFileSync(makefile, data);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -277,7 +277,6 @@ var webpack = require("webpack");
 var copy = require("copy-webpack-plugin");
 var html = require('html-webpack-plugin');
 var extract = require("extract-text-webpack-plugin");
-var MergeIntoSingleFilePlugin = require('webpack-merge-and-include-globally');
 var extend = require("extend");
 var path = require("path");
 var fs = require("fs");
@@ -346,18 +345,6 @@ var plugins = [
     }),
     new copy(info.files),
     new extract("[name].css"),
-    new MergeIntoSingleFilePlugin({
-        files: {
-            "base1/cockpit.js": [
-                srcdir + "/src/base1/cockpit.js"
-            ],
-            "base1/jquery.js": [
-                nodedir + "/jquery/dist/jquery.js",
-                nodedir + "/bootstrap/dist/js/bootstrap.js",
-                nodedir + "/patternfly/dist/js/patternfly.js"
-            ]
-        }
-    })
 ];
 
 var output = {
@@ -394,6 +381,20 @@ info.tests.forEach(function(test) {
         }));
     }
 });
+
+/* Just for the sake of tests, jquery.js and cockpit.js files */
+if (!section || section.indexOf("base1") === 0) {
+    files.push({
+        from: srcdir + path.sep + "src/base1/cockpit.js",
+        to: "base1/cockpit.js"
+    }, {
+        from: nodedir + path.sep + "jquery/dist/jquery.js",
+        to: "base1/jquery.js"
+    }, {
+        from: srcdir + path.sep + "po/po.js",
+        to: "shell/po.js"
+    });
+}
 
 var aliases = {
     "angular": "angular/angular.js",


### PR DESCRIPTION
The main improvement here is that typing 'make clean' will no longer
invoke webpack.  This was being caused by the 'include' directives for
the Makefile.deps forcing the corresponding rule to run immedately,
which involved running webpack to generate the dependencies.  Instead,
we have a separate stamp file, which is depended on as a normal build
target.

We move to a more traditional approach, as used by automake for C
compilation: during the first run, the files are absent, and that's OK
because the target will be built anyway.  The files are then produced
merely as a side effect of the compilation process, and are not depended
on by anything in the Makefile.

There is one special exception for the case of doing out-of-tree builds
of tarballs.  In this case, we want to make sure the Makefile.deps get
copied out of the srcdir into the builddir (because Makefile includes
don't search the VPATH).

This patch also removes redundant rules from Makefile.deps, depending
entirely on the new implicit rule in Makefile.am for webpack runs.  This
removes the inconsistency of seeing 'GEN dist/x/Makefile.deps' the first
time and then 'WEBPACK x' on future runs: it's always 'WEBPACK x' now.

It's now also possible to modify webpack.config.js and type 'make apps',
and only build the one directory.

The webpack builds now also depend on tools/webpack-make, so changing
this script will correctly re-run the build.

[[this branch also reverts the changes from #8266]]