### PR TITLE
bots: Kill the SSH master process explicitly after testing

### DIFF
--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -349,6 +349,7 @@ class Machine:
         if self.ssh_process:
             self.message("killing ssh master process", str(self.ssh_process.pid))
             self.ssh_process.stdin.close()
+            self.ssh_process.terminate()
             self.ssh_process.stdout.close()
             with Timeout(seconds=90, error_message="Timeout while waiting for ssh master to shut down"):
                 self.ssh_process.wait()


### PR DESCRIPTION
This is so we don't wait for hanging processes to timeout.
We see this from time to time in test flakes.