### PR TITLE
bots: Ignore failure when posting known issue to GitHub fails

### DIFF
--- a/bots/task/github.py
+++ b/bots/task/github.py
@@ -188,7 +188,7 @@ class GitHub(object):
             return json.loads(cached['data'] or "null")
         elif response['status'] < 200 or response['status'] >= 300:
             sys.stderr.write("{0}\n{1}\n".format(resource, response['data']))
-            raise Exception("GitHub API problem: {0}".format(response['reason'] or response['status']))
+            raise RuntimeError("GitHub API problem: {0}".format(response['reason'] or response['status']))
         else:
             self.cache.write(qualified, response)
             return json.loads(response['data'] or "null")
@@ -198,7 +198,7 @@ class GitHub(object):
         status = response['status']
         if (status < 200 or status >= 300) and status not in accept:
             sys.stderr.write("{0}\n{1}\n".format(resource, response['data']))
-            raise Exception("GitHub API problem: {0}".format(response['reason'] or status))
+            raise RuntimeError("GitHub API problem: {0}".format(response['reason'] or status))
         self.cache.mark()
         return json.loads(response['data'])
 
@@ -207,7 +207,7 @@ class GitHub(object):
         status = response['status']
         if (status < 200 or status >= 300) and status not in accept:
             sys.stderr.write("{0}\n{1}\n".format(resource, response['data']))
-            raise Exception("GitHub API problem: {0}".format(response['reason'] or status))
+            raise RuntimeError("GitHub API problem: {0}".format(response['reason'] or status))
         self.cache.mark()
         return json.loads(response['data'])
 

--- a/bots/tests-policy
+++ b/bots/tests-policy
@@ -69,7 +69,7 @@ def main():
         if number and api and api.available:
             try:
                 post_github(api, number, output, image)
-            except socket.error:
+            except (socket.error, RuntimeError):
                 traceback.print_exc()
                 sys.stderr.write("{0}: posting update to GitHub failed\n".format(script))
                 # Fall through


### PR DESCRIPTION
When posting a known issue to GitHub logging fails, still treat
as a known issue and allow the tests-policy script to succeed.