### PR TITLE
users: Add another admin group for weldr

### DIFF
--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -708,7 +708,8 @@ PageAccount.prototype = {
         var role_groups = {
             "wheel":   _("Server Administrator"),
             "sudo":    _("Server Administrator"),
-            "docker":  _("Container Administrator")
+            "docker":  _("Container Administrator"),
+            "weldr":   _("Image Builder")
         };
 
         function parse_groups(content) {


### PR DESCRIPTION
This group allows users to attach to the lorax-composer socket.
In the UI we can add people to this group.