### PR TITLE
users: Notify that a login/logout is necessary to get role changes

### DIFF
--- a/pkg/users/index.html
+++ b/pkg/users/index.html
@@ -480,6 +480,12 @@
       </label>
     </div>
     {{/roles}}
+    {{#changed}}
+    <div class="alert alert-info">
+      <span class="pficon pficon-info"></span>
+      <span translatable>The user must log out and log back in to fully change roles.</span>
+    </div>
+    {{/changed}}
   </script>
 
 </body>

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -114,6 +114,9 @@ class TestAccounts(MachineCase):
         b.set_checked(admin_role_sel, True)
         b.wait_present(admin_role_sel + ":checked")
         b.wait(lambda: "jussi" in m.execute("grep %s /etc/group" % m.get_admin_group()))
+        # An alert which shows up once we've changed things
+        if m.image != 'rhel-7-5':
+            b.wait_present("#account-roles .alert-info")
         b.set_checked(admin_role_sel, False)
         b.wait_present(admin_role_sel + ":not(:checked)")
         b.wait(lambda: "jussi" not in m.execute("grep %s /etc/group" % m.get_admin_group()))


### PR DESCRIPTION
The Roles checkboxes add and remove users from key groups which give
them access to do certain things.

However these changes do not fully apply until a user has logged out and
logged back in. This is true both outside of Cockpit in a terminal and
inside of Cockpit.

There is an exception: One can run 'newgrp' to start a shell with updated
groups. However, this does not 'fully apply' the group changes and the
notification is still correct despite this exception.