### PR TITLE
test: Print out core dumps that happened during testing

### DIFF
--- a/bots/naughty/debian-testing/6108-pcp-pmfindprofile-crash
+++ b/bots/naughty/debian-testing/6108-pcp-pmfindprofile-crash
@@ -1,5 +1,1 @@
-Traceback (most recent call last):
-*
-  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
-*
-Error: /usr/*/cockpit-pcp: bridge was killed: 11
+/usr/*/cockpit-pcp: bridge was killed:

--- a/bots/naughty/example/9876-example-traceback
+++ b/bots/naughty/example/9876-example-traceback
@@ -1,5 +1,1 @@
-Traceback (most recent call last):
-*
-  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
-*
-Error: /usr/*/cockpit-pcp: bridge was killed: 11
+/usr/*/cockpit-pcp: bridge was killed:

--- a/bots/naughty/fedora-27/6108-pcp-pmfindprofile-crash
+++ b/bots/naughty/fedora-27/6108-pcp-pmfindprofile-crash
@@ -1,5 +1,1 @@
-Traceback (most recent call last):
-*
-  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
-*
-Error: /usr/*/cockpit-pcp: bridge was killed: 11
+/usr/*/cockpit-pcp: bridge was killed:

--- a/bots/naughty/fedora-27/6108-pcp-pmfindprofile-crash-2
+++ b/bots/naughty/fedora-27/6108-pcp-pmfindprofile-crash-2
@@ -1,5 +1,1 @@
-Traceback (most recent call last):
-*
-  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
-*
-Error: /usr/*/cockpit-pcp: bridge was killed: 7
+/usr/*/cockpit-pcp: bridge was killed:

--- a/bots/naughty/fedora-27/6108-pcp-pmfindprofile-crash-3
+++ b/bots/naughty/fedora-27/6108-pcp-pmfindprofile-crash-3
@@ -1,5 +1,1 @@
-Traceback (most recent call last):
-*
-  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
-*
-Error: /usr/*/cockpit-pcp: bridge was killed: 6
+/usr/*/cockpit-pcp: bridge was killed:

--- a/bots/naughty/fedora-27/6108-pcp-pmfindprofile-crash-4
+++ b/bots/naughty/fedora-27/6108-pcp-pmfindprofile-crash-4
@@ -1,5 +1,1 @@
-Traceback (most recent call last):
-*
-  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
-*
-Error: /usr/*/cockpit-pcp: bridge was killed: 5
+/usr/*/cockpit-pcp: bridge was killed:

--- a/bots/naughty/fedora-28/6108-pcp-pmfindprofile-crash
+++ b/bots/naughty/fedora-28/6108-pcp-pmfindprofile-crash
@@ -1,5 +1,1 @@
-Traceback (most recent call last):
-*
-  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
-*
-Error: /usr/*/cockpit-pcp: bridge was killed: 11
+/usr/*/cockpit-pcp: bridge was killed:

--- a/bots/naughty/fedora-28/6108-pcp-pmfindprofile-crash-2
+++ b/bots/naughty/fedora-28/6108-pcp-pmfindprofile-crash-2
@@ -1,5 +1,1 @@
-Traceback (most recent call last):
-*
-  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
-*
-Error: /usr/*/cockpit-pcp: bridge was killed: 7
+/usr/*/cockpit-pcp: bridge was killed:

--- a/bots/naughty/fedora-28/6108-pcp-pmfindprofile-crash-3
+++ b/bots/naughty/fedora-28/6108-pcp-pmfindprofile-crash-3
@@ -1,5 +1,1 @@
-Traceback (most recent call last):
-*
-  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
-*
-Error: /usr/*/cockpit-pcp: bridge was killed: 6
+/usr/*/cockpit-pcp: bridge was killed:

--- a/bots/naughty/fedora-28/6108-pcp-pmfindprofile-crash-4
+++ b/bots/naughty/fedora-28/6108-pcp-pmfindprofile-crash-4
@@ -1,5 +1,1 @@
-Traceback (most recent call last):
-*
-  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
-*
-Error: /usr/*/cockpit-pcp: bridge was killed: 5
+/usr/*/cockpit-pcp: bridge was killed:

--- a/bots/naughty/rhel-7/6108-pcp-pmfindprofile-crash
+++ b/bots/naughty/rhel-7/6108-pcp-pmfindprofile-crash
@@ -1,5 +1,1 @@
-Traceback (most recent call last):
-*
-  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
-*
-Error: /usr/*/cockpit-pcp: bridge was killed: 11
+/usr/*/cockpit-pcp: bridge was killed:

--- a/bots/naughty/rhel-x/6108-pcp-pmfindprofile-crash
+++ b/bots/naughty/rhel-x/6108-pcp-pmfindprofile-crash
@@ -1,5 +1,1 @@
-Traceback (most recent call last):
-*
-  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
-*
-Error: /usr/*/cockpit-pcp: bridge was killed: 11
+/usr/*/cockpit-pcp: bridge was killed:

--- a/bots/naughty/ubuntu-1604/6108-pcp-pmfindprofile-crash
+++ b/bots/naughty/ubuntu-1604/6108-pcp-pmfindprofile-crash
@@ -1,5 +1,1 @@
-Traceback (most recent call last):
-*
-  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
-*
-Error: /usr/*/cockpit-pcp: bridge was killed: 11
+/usr/*/cockpit-pcp: bridge was killed:

--- a/bots/naughty/ubuntu-1604/9487-nsupdate-assert
+++ b/bots/naughty/ubuntu-1604/9487-nsupdate-assert
@@ -1,0 +1,7 @@
+Process * (nsupdate) of user 0 dumped core.
+*
+Stack trace of thread*
+*__GI_raise*
+*__GI_abort*
+*isc_assertion_failed*
+*dns_name_clone*

--- a/bots/naughty/ubuntu-stable/6108-pcp-pmfindprofile-crash
+++ b/bots/naughty/ubuntu-stable/6108-pcp-pmfindprofile-crash
@@ -1,5 +1,1 @@
-Traceback (most recent call last):
-*
-  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
-*
-Error: /usr/*/cockpit-pcp: bridge was killed: 11
+/usr/*/cockpit-pcp: bridge was killed:

--- a/bots/naughty/ubuntu-stable/9486-libvirtd-crash-pci_get_strings
+++ b/bots/naughty/ubuntu-stable/9486-libvirtd-crash-pci_get_strings
@@ -1,0 +1,4 @@
+Process * (libvirtd) of user 0 dumped core.
+*
+Stack trace of thread*
+*pci_get_strings*

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -99,6 +99,7 @@ class TestConnection(MachineCase):
         cores = m.execute("find /var/lib/systemd/coredump -type f")
         self.assertNotEqual(cores, "")
 
+        self.allow_core_dumps = True
         self.allow_journal_messages(".*org.freedesktop.hostname1.*DBus.Error.NoReply.*")
 
     def testTls(self):

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -310,6 +310,7 @@ s.send(b"PRIORITY=3\\nFOO=bar\\n")'
     @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-i386", "rhel-7-5")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1604", "rhel-atomic", "fedora-atomic", "continuous-atomic", "rhel-x")
     def testAbrtSegv(self):
+        self.allow_core_dumps = True
         b = self.browser
         m = self.machine
 
@@ -345,6 +346,7 @@ s.send(b"PRIORITY=3\\nFOO=bar\\n")'
     @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-i386", "rhel-7-5")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1604", "rhel-atomic", "fedora-atomic", "continuous-atomic", "rhel-x")
     def testAbrtDelete(self):
+        self.allow_core_dumps = True
         b = self.browser
         m = self.machine
 
@@ -382,6 +384,7 @@ s.send(b"PRIORITY=3\\nFOO=bar\\n")'
     @skipImage("Newer version of ABRT required", "centos-7", "rhel-7", "fedora-i386", "rhel-7-5")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1604", "rhel-atomic", "fedora-atomic", "continuous-atomic", "rhel-x")
     def testAbrtReport(self):
+        self.allow_core_dumps = True
         # The testing server is located at verify/files/mock-faf-server.py
         # Adjust Handler.known for for the expected succession of known/unknown problems
         b = self.browser


### PR DESCRIPTION
Lets print out core dumps that happen during testing in the test log.

This helps with debugging, figuring out what happened. And also helps
the machine learning to figure out with more details about various
crashes.