### PR TITLE
tools: No stdin for tests run by 'make check'

### DIFF
--- a/tools/tap-driver
+++ b/tools/tap-driver
@@ -133,12 +133,14 @@ class Driver:
     def execute(self):
         try:
             proc = subprocess.Popen(self.argv, close_fds=True,
+                                    stdin=subprocess.PIPE,
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE)
         except OSError as ex:
             self.report_error("Couldn't run %s: %s" % (self.argv[0], str(ex)))
             return
 
+        proc.stdin.close()
         outf = proc.stdout.fileno()
         errf = proc.stderr.fileno()
         rset = [outf, errf]


### PR DESCRIPTION
We shouldn't depend on stdin, or see any side effects of stdin
being used by the test subprocess.