### PR TITLE
unit-tests: Switch stdio to non-blocking after invoking Node.js

### DIFF
--- a/containers/unit-tests/Dockerfile
+++ b/containers/unit-tests/Dockerfile
@@ -24,6 +24,11 @@ RUN dpkg --add-architecture ${arch} && echo ${arch} > /arch && apt-get update &&
 RUN npm install -g n && n stable && \
     adduser --system --gecos "Builder" builder
 
+# HACK: Working around Node.js screwing around with stdio
+ENV NODE_PATH /usr/local/bin/nodejs
+RUN mv /usr/local/bin/node /usr/local/bin/nodejs
+ADD turd-polish /usr/local/bin/node
+
 USER builder
 
 VOLUME /source

--- a/containers/unit-tests/turd-polish
+++ b/containers/unit-tests/turd-polish
@@ -1,0 +1,41 @@
+#!/usr/bin/python2
+
+# Copyright (C) 2013 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+#
+# This is certified, A-grade, high quality turd polish. Node leaves
+# stdio file descriptors in non-blocking mode when exiting. This has
+# been reported, fixed, unfixed, ad nauseum.
+#
+# https://github.com/nodejs/node/issues/14752
+# https://github.com/nodejs/node/pull/17737
+# https://github.com/nodejs/node/pull/20592
+# https://github.com/nodejs/node/pull/21257
+#
+# It's starting to fester.
+#
+
+import fcntl
+import os
+import subprocess
+import sys
+
+assert "NODE_PATH" in os.environ
+proc = subprocess.Popen([ os.environ["NODE_PATH"] ] + sys.argv[1:])
+proc.wait()
+
+map(lambda fd: fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) &~ os.O_NONBLOCK), [0, 1, 2])
+sys.exit(proc.returncode)


### PR DESCRIPTION
Node leaves stdio file descriptors in non-blocking mode
when exiting. This has been reported, fixed, unfixed, ad nauseum.

https://github.com/nodejs/node/issues/14752
https://github.com/nodejs/node/pull/17737
https://github.com/nodejs/node/pull/20592
https://github.com/nodejs/node/pull/21257

Should this become a problem in more places, we could add such
a workaround elsewhere. But for now I'm limiting the ugliness to
the unit-tests container, where we see this cause a lot of failures.