### PR TITLE
bots: Don't link to HTML logs for third-party tests

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -126,9 +126,6 @@ class PullTask(object):
                 }]
             },
             "revision": self.github_revision,
-            "link": "log.html",
-            "extras": [ "https://raw.githubusercontent.com/cockpit-project/cockpit/{0}/bots/task/log.html".format(self.github_revision) ],
-
             "onaborted": {
                 "github": {
                     "token": api.token,
@@ -147,6 +144,15 @@ class PullTask(object):
                 },
             }
         }
+
+        if self.context.startswith("cockpit/"):
+            # third-party project, link directly to text log
+            status["link"] = "log"
+        else:
+            # testing cockpit itself, use HTML log
+            status["link"] = "log.html"
+            status["extras"] = [ "https://raw.githubusercontent.com/cockpit-project/cockpit/{0}/bots/task/log.html".format(self.github_revision) ]
+
 
         # Include information about which base we're testing against
         if self.base:


### PR DESCRIPTION
Third-party projects have a test context like "cockpit/fedora-28", and
usually don't ship a log.html template. For these, directly link to the
plaintext log, to avoid getting broken log.html links. Also don't submit
a broken "log.html" extra link, as the third-party project's
`github_revision` is invalid for the cockpit repository.