### PR TITLE
bots: Add known issue for PCP crash on debian testing

### DIFF
--- a/bots/naughty/debian-testing/6108-pcp-pmfindprofile-crash
+++ b/bots/naughty/debian-testing/6108-pcp-pmfindprofile-crash
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+*
+  File "/build/cockpit/test/common/testlib.py", line *, in check_journal_messages
+*
+Error: /usr/*/cockpit-pcp: bridge was killed: 11


### PR DESCRIPTION
Another case of this known issue. 

Issue #6108 