### PR TITLE
bots: Fix KeyError crash in tests-invoke

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -290,7 +290,10 @@ class PullTask(object):
         sink.status["message"] = message
         if "github" in sink.status:
             self.github_status_data["description"] = message
-        del sink.status["extras"]
+        try:
+            del sink.status["extras"]
+        except KeyError:
+            pass
         sink.flush()
 
         return ret


### PR DESCRIPTION
After commit cb29836c3c, third-party test runs don't have an `extras`
key in the sink status any more. Don't crash on trying to remove it.