### PR TITLE
test: Fix common test code for Python 3

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -31,7 +31,8 @@ def browser_path(headless=True):
         if g:
             return g[0]
 
-    p = subprocess.check_output("which chromium-browser || which chromium || which google-chrome || true", shell=True).strip()
+    p = subprocess.check_output("which chromium-browser || which chromium || which google-chrome || true",
+                                shell=True, universal_newlines=True).strip()
     if p:
         return p
 
@@ -96,6 +97,7 @@ class CDP:
         if not self._driver:
             self.start()
         self._driver.stdin.write(cmd + "\n")
+        self._driver.stdin.flush()
         line = self._driver.stdout.readline()
         if not line:
             self.kill()
@@ -206,6 +208,7 @@ class CDP:
                                         env=environ,
                                         stdout=subprocess.PIPE,
                                         stdin=subprocess.PIPE,
+                                        universal_newlines=True,
                                         close_fds=True)
         self.valid = True
 


### PR DESCRIPTION
- Fix some wrong bytes/string mixups which are hidden in Python 2.
- Add Python 3 variant for setting stdout to unbuffered.
- Avoid `input()`, as this is a bit unwieldy for bilingual code.
- Use `dict.items()`, as `.iteritems()` does not exist in Python 3, and
  the speed penalty for Python 2 is irrelevant for our small dicts.

With this I'm able to run some spot-check Cockpit tests and starter-kit tests as Python 3.