### PR TITLE
test: Fix invalid clicks and races in check-accounts tests

### DIFF
--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -990,7 +990,8 @@ PageAccount.prototype = {
             return;
 
         var proc;
-        if ($(ev.target).prop('checked')) {
+        var checked = $(ev.target).prop('checked');
+        if (checked) {
             proc = cockpit.spawn(["/usr/sbin/usermod", this.account["name"], "-G", id, "-a"],
                                  { "superuser": "require", err: "message" });
         } else {
@@ -998,7 +999,12 @@ PageAccount.prototype = {
                                  { "superuser": "require", err: "message" });
         }
 
-        proc.then(function() {
+        proc.then(function(data) {
+            if(!data && checked)
+                data = "Added " + self.account["name"] + " to group " + name;
+            else if (!data && !checked)
+                data = "Removed " + self.account["name"] + " from group " + name;
+            console.log(data);
             self.roles_changed = true;
             self.update();
         }, show_unexpected_error);

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -98,18 +98,20 @@ class TestAccounts(MachineCase):
         b.set_val('#accounts-create-real-name', "Jussi Junior")
         b.set_val('#accounts-create-pw1', good_password)
         b.set_val('#accounts-create-pw2', good_password)
-        b.set_val('#accounts-create-locked', "yes")
+        b.set_checked('#accounts-create-locked', True)
         b.click('#accounts-create-create')
         b.wait_popdown('accounts-create-dialog')
         b.wait_in_text('#accounts-list', "Jussi Junior")
 
         admin_role_sel = 'input[data-name="%s"]' % m.get_admin_group()
+        b.wait(lambda: "jussi" in m.execute("grep jussi /etc/passwd"))
+        b.wait(lambda: "jussi" not in m.execute("grep %s /etc/group" % m.get_admin_group()))
 
         # Unlock it and make it an admin
         b.go("#/jussi")
         b.wait_visible("#account")
         b.wait_text("#account-user-name", "jussi")
-        b.set_val('#accounts-create-locked', "no")
+        b.set_checked('#account-locked', False)
         b.wait_present(admin_role_sel + ":not(:checked)")
         b.set_checked(admin_role_sel, True)
         b.wait_present(admin_role_sel + ":checked")


### PR DESCRIPTION
The check-accounts tests was clicking invalid checkboxes to unlock accounts (the one in the dialog instead of on the page) and not waiting appropriately for users to be created everywhere.
