### PR TITLE
tools: Add temporary python2 build dependency

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -79,9 +79,9 @@ BuildRequires: pam-devel
 BuildRequires: autoconf automake
 %if 0%{?fedora} || 0%{?rhel} >= 8
 BuildRequires: /usr/bin/python3
-%else
-BuildRequires: /usr/bin/python2
 %endif
+# FIXME: tools/ is not completely ported to Python 3 yet
+BuildRequires: /usr/bin/python2
 BuildRequires: intltool
 %if %{defined build_dashboard}
 BuildRequires: libssh-devel >= %{libssh_version}

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -28,6 +28,7 @@ Build-Depends: debhelper (>= 9.20141010),
                docbook-xsl,
                glib-networking,
                openssh-client <!nocheck>,
+               python,
                python3,
 Standards-Version: 4.1.3
 Homepage: https://cockpit-project.org/


### PR DESCRIPTION
Several programs in tools/ are not yet ported to Python 3, so we need
the build dependency until that is completed and the build system
dynamically uses python 2 or 3 for all tools.