### PR TITLE
tools: Adjust Debian smoke test for downstream RHEL

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -155,6 +155,10 @@ class TestConnection(MachineCase):
             ".*Peer failed to perform TLS handshake",
             ".*Error performing TLS handshake: Could not negotiate a supported cipher suite.")
 
+        # check the Debian smoke test
+        m.upload([ "../tools/debian/tests/smoke" ], "/tmp")
+        m.execute("/tmp/smoke")
+
     def testConfigOrigins(self):
         m = self.machine
         m.execute('mkdir -p /etc/cockpit/ && echo "[WebService]\nOrigins = http://other-origin:9090 http://localhost:9090" > /etc/cockpit/cockpit.conf')

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -153,6 +153,7 @@ class TestConnection(MachineCase):
 
         self.allow_journal_messages(
             ".*Peer failed to perform TLS handshake",
+            ".*invalid base64 data in Basic header",
             ".*Error performing TLS handshake: Could not negotiate a supported cipher suite.")
 
         # check the Debian smoke test

--- a/tools/debian/tests/smoke
+++ b/tools/debian/tests/smoke
@@ -13,7 +13,7 @@ OUT=$(cockpit-bridge --packages)
 echo "$OUT"
 check_out "^base1: /usr/share/cockpit/base1"
 check_out "^system:"
-check_out "^dashboard:"
+check_out "^users:"
 
 echo " * socket unit is set up correctly, login page available"
 OUT=$(curl --silent --insecure https://localhost:9090)


### PR DESCRIPTION
Dashboard is not included in the RHEL packages, so check for the "users"
page instead.