### PR TITLE
Ensure we fail tests when a javascript exception happens

### DIFF
--- a/pkg/playground/exception.html
+++ b/pkg/playground/exception.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html ng-csp>
+<head>
+    <meta charset="utf-8">
+    <title>Javascript exceptions</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="../base1/patternfly.css" type="text/css" rel="stylesheet">
+    <script src="../base1/cockpit.js"></script>
+</head>
+<body hidden>
+    <div id="internal" class="container-fluid">
+        <h2>Exception</h2>
+
+        <p>Clicking this button should make a javascript exception happen.<p>
+
+        <button id="exception">Exception</button>
+    </div>
+    <script src="exception.js"></script>
+</body>
+</html>

--- a/pkg/playground/exception.js
+++ b/pkg/playground/exception.js
@@ -1,0 +1,13 @@
+/* An unhandled javascript exception */
+var button = document.getElementById("exception");
+button.addEventListener("click", function() {
+    var obj = { };
+    window.setTimeout(function() {
+        obj[0].value = 1;
+    }, 0);
+});
+
+var cockpit = require("cockpit");
+cockpit.transport.wait(function() {
+    document.body.removeAttribute("hidden");
+});

--- a/pkg/playground/manifest.json.in
+++ b/pkg/playground/manifest.json.in
@@ -15,6 +15,9 @@
         "translate": {
             "label": "Translating"
         },
+        "exception": {
+            "label": "Exceptions"
+        },
         "pkgs": {
             "label": "Packages"
         }

--- a/src/base1/test-http.js
+++ b/src/base1/test-http.js
@@ -31,6 +31,9 @@ QUnit.asyncTest("simple request", function() {
                     "cockpit": "122"
                 },
                 tools: {
+                    'exception': {
+                        'label': 'Exceptions'
+                    },
                     'patterns': {
                         label: "Design Patterns",
                         path: "jquery-patterns.html"

--- a/src/base1/test-stub.js
+++ b/src/base1/test-stub.js
@@ -70,6 +70,9 @@ QUnit.asyncTest("http", function() {
                     cockpit: "122"
                 },
                 tools: {
+                    'exception': {
+                        label: 'Exceptions'
+                    },
                     'patterns': {
                         label: "Design Patterns",
                         path: "jquery-patterns.html"

--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -21,6 +21,8 @@
 import parent
 from testlib import *
 
+import time
+
 class TestMenu(MachineCase):
     @enableAxe
     def testBasic(self):
@@ -49,6 +51,23 @@ class TestMenu(MachineCase):
             b.click("a[href='/system/#/memory']")
             b.enter_page("/system")
             b.wait_visible("#memory_status")
+
+        # Ensure that our tests pick up unhandled JS exceptions
+        b.switch_to_top()
+        b.click("a[href='/playground/exception']")
+        b.enter_page("/playground/exception")
+        b.wait_visible("button")
+        with self.assertRaisesRegex(RuntimeError, "TypeError:.*value.*undefined"):
+            b.click("button")
+            # Some round trips, one of which should update the deferred exception
+            for i in range(0, 5):
+                b.wait_visible("button")
+                time.sleep(2)
+
+        # UI should also show the crash
+        b.switch_to_top()
+        b.wait_present("#navbar-oops")
+        b.wait_visible("#navbar-oops")
 
 if __name__ == '__main__':
     test_main()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,6 +65,9 @@ var info = {
             "ovirt/ovirt.less",
         ],
 
+        "playground/exception": [
+            "playground/exception.js",
+        ],
         "playground/jquery-patterns": [
             "playground/jquery-patterns.js",
         ],
@@ -223,6 +226,7 @@ var info = {
 
         "packagekit/index.html",
 
+        "playground/exception.html",
         "playground/hammer.gif",
         "playground/jquery-patterns.html",
         "playground/metrics.html",


### PR DESCRIPTION
When PhantomJS was used we used to fail integration testing on every javascript exception. That is no longer the case with headless-chromium.

 * [x] #9639