### PR TITLE
test: Disable pushState() throttling

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -183,8 +183,8 @@ class CDP:
             self._browser = subprocess.Popen(
                 argv + ["--disable-gpu", "--no-sandbox", "--disable-setuid-sandbox",
                     "--disable-namespace-sandbox", "--disable-seccomp-filter-sandbox",
-                    "--disable-sandbox-denial-logging", "--window-size=1280x1200",
-                    "--remote-debugging-port=%i" % cdp_port, "about:blank"],
+                    "--disable-sandbox-denial-logging", "--disable-pushstate-throttle",
+                    "--window-size=1280x1200", "--remote-debugging-port=%i" % cdp_port, "about:blank"],
                 env=environ, close_fds=True)
             if self.verbose:
                 sys.stderr.write("Started %s (pid %i) on port %i\n" % (exe, self._browser.pid, cdp_port))

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -733,6 +733,9 @@ class MachineCase(unittest.TestCase):
 
         # Various operating systems see this from time to time
         "Journal file.*truncated, ignoring file.",
+
+        # our core dump retrieval is not entirely reliable
+        "Failed to send coredump datagram:.*",
     ]
 
     def allow_journal_messages(self, *patterns):

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -19,7 +19,6 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import json
-import time
 
 import parent
 import atomiclib
@@ -159,11 +158,6 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
         b.wait_attr("#dashboard-hosts a.connected[data-address='10.111.113.2'] img", 'src', '../shell/images/server-small.png')
 
         # Test change user, not doing in edit to reuse machines
-        # HACK: This test triggers Chromium's window.history.pushState()
-        # throttling, so wait a bit to reset it
-        # Replace with --disable-pushstate-throttle once that exists
-        # https://bugs.chromium.org/p/chromium/issues/detail?id=769592
-        time.sleep(3)
 
         # Navigate to load iframe
         b.click("#dashboard-hosts .list-group-item[data-address='10.111.113.3']")


### PR DESCRIPTION
Chromium 67 finally fixes window.history.pushState() to not
[silently fail](https://bugs.chromium.org/p/chromium/issues/detail?id=794923)
any more. Disable the throttling and drop the sleep hack from commit
9db1e74a85a.

This should also fix some flakes in other tests, e. g.
`TestDashboardEditLimits` was also running into this.