### PR TITLE
bots: Drop verifymachine5 image server

### DIFF
--- a/bots/image-download
+++ b/bots/image-download
@@ -34,7 +34,6 @@ CONFIG = "~/.config/image-stores"
 DEFAULT = [
     "http://cockpit-images.verify.svc.cluster.local",
     "https://images-cockpit.apps.ci.centos.org/",
-    "https://209.132.184.69:8493/",
     "https://209.132.184.41:8493/",
 ]
 

--- a/bots/image-upload
+++ b/bots/image-upload
@@ -22,7 +22,6 @@
 DEFAULT_UPLOAD = [
     "https://images-cockpit.apps.ci.centos.org/",
     "https://209.132.184.41:8493/",
-    "https://209.132.184.69:8493/",
 ]
 
 TOKEN = "~/.config/github-token"


### PR DESCRIPTION
With the primary image server being on CentOS CI now, having one backup
image server in fedorainfracloud is enough for now. Drop the second one
as that does not exist any more and causes curl to hang for a long time
when probing the latency.