### PR TITLE
bridge: Prevent writing more debug output to stdout

### DIFF
--- a/src/common/cockpitpipetransport.c
+++ b/src/common/cockpitpipetransport.c
@@ -62,6 +62,13 @@ enum {
     PROP_PIPE,
 };
 
+static void      cockpit_transport_read_from_pipe      (CockpitTransport *self,
+                                                        const gchar *logname,
+                                                        CockpitPipe *pipe,
+                                                        gboolean *closed,
+                                                        GByteArray *input,
+                                                        gboolean end_of_data);
+
 G_DEFINE_TYPE (CockpitPipeTransport, cockpit_pipe_transport, COCKPIT_TYPE_TRANSPORT);
 
 static void
@@ -325,7 +332,7 @@ cockpit_pipe_transport_get_pipe (CockpitPipeTransport *self)
  * Closed is pointer to a boolean value that may be updated
  * during the read and parse loop.
  */
-void
+static void
 cockpit_transport_read_from_pipe (CockpitTransport *self,
                                   const gchar *logname,
                                   CockpitPipe *pipe,

--- a/src/common/cockpitpipetransport.h
+++ b/src/common/cockpitpipetransport.h
@@ -46,12 +46,6 @@ CockpitTransport * cockpit_pipe_transport_new_fds    (const gchar *name,
 
 CockpitPipe *      cockpit_pipe_transport_get_pipe   (CockpitPipeTransport *self);
 
-void               cockpit_transport_read_from_pipe  (CockpitTransport *self,
-                                                      const gchar *logname,
-                                                      CockpitPipe *pipe,
-                                                      gboolean *closed,
-                                                      GByteArray *input,
-                                                      gboolean end_of_data);
 G_END_DECLS
 
 #endif /* __COCKPIT_PIPE_TRANSPORT_H__ */

--- a/src/ssh/ssh.c
+++ b/src/ssh/ssh.c
@@ -21,7 +21,6 @@
 
 #include <gio/gio.h>
 
-#include "common/cockpitpipetransport.h"
 #include "common/cockpitlog.h"
 #include "common/cockpittest.h"
 


### PR DESCRIPTION
Standard out is used for the Cockpit protocol, and some of the early debug statements were being sent there, leading to annoying feedback when debugging.

I've also put some other patches in this pull request, that are just simple code cleanup.